### PR TITLE
feat(head): run on macOS/MoltenVK and ship a signed universal .app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,9 +141,38 @@ jobs:
           name: head-windows
           path: dist/*.zip
 
-  # GUI head — macOS, Intel (macos-15-intel) + Apple Silicon (macos-14). Unsigned;
-  # MoltenVK + the Vulkan loader are bundled.
-  head-macos:
+  # macOS signing is gated on repo secrets. A no-Gatekeeper-workaround download must be
+  # Developer-ID signed + notarized, so without those credentials we skip the whole
+  # macOS release rather than publish something Gatekeeper would block (forks and
+  # unconfigured repos still build every other target). Secrets cannot be read in job
+  # `if:` directly, so this job surfaces their presence as an output the macOS jobs gate
+  # on. Requires the caller to pass `secrets: inherit`.
+  macos-preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+    steps:
+      - id: check
+        env:
+          CERT: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          CERT_PW: ${{ secrets.MACOS_CERT_PASSWORD }}
+          AC_APPLE_ID: ${{ secrets.MACOS_AC_APPLE_ID }}
+          AC_PASSWORD: ${{ secrets.MACOS_AC_PASSWORD }}
+          AC_TEAM_ID: ${{ secrets.MACOS_AC_TEAM_ID }}
+        run: |
+          if [ -n "$CERT" ] && [ -n "$CERT_PW" ] && [ -n "$AC_APPLE_ID" ] && [ -n "$AC_PASSWORD" ] && [ -n "$AC_TEAM_ID" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::macOS signing secrets not configured — skipping the macOS release."
+          fi
+
+  # GUI head — macOS per-arch build (Intel + Apple Silicon). Each runner natively builds
+  # the cgo/Vulkan head and stages its binary plus the dylibs it bundles (loader, GLFW,
+  # MoltenVK) for the universal merge in head-macos.
+  head-macos-build:
+    needs: macos-preflight
+    if: needs.macos-preflight.outputs.enabled == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -172,9 +201,66 @@ jobs:
           VER='${{ inputs.version }}'
           LD="-s -w -X ${CORE}/build.Version=${VER} -X ${CORE}/build.Commit=$(git rev-parse --short HEAD) -X ${CORE}/build.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           CGO_ENABLED=1 go build -ldflags "$LD" -o "$GITHUB_WORKSPACE/dist/oblikovati-head" ./cmd/oblikovati-head
-      - name: Package tarball
-        run: scripts/package-macos.sh dist/oblikovati-head '${{ inputs.version }}' '${{ matrix.arch }}' dist
+      - name: Stage binary + dylibs
+        run: scripts/macos-stage.sh dist/oblikovati-head "stage-${{ matrix.arch }}"
       - uses: actions/upload-artifact@v4
         with:
-          name: head-macos-${{ matrix.arch }}
-          path: dist/*.tar.gz
+          name: head-macos-stage-${{ matrix.arch }}
+          path: stage-${{ matrix.arch }}
+
+  # GUI head — macOS universal bundle: lipo both arches into one Oblikovati.app, then
+  # codesign (Developer ID + hardened runtime) + notarize + staple, so a downloaded build
+  # runs on a clean Mac with no Vulkan SDK, no env setup, and no Gatekeeper prompt.
+  head-macos:
+    needs: [macos-preflight, head-macos-build]
+    if: needs.macos-preflight.outputs.enabled == 'true'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: head-macos-stage-*
+          path: stage
+      - name: Lipo universal binary + dylibs
+        run: |
+          set -euo pipefail
+          mkdir -p uni/bin uni/fw
+          amd_bin="$(find stage -path '*amd64*' -name oblikovati-head -type f | head -1)"
+          arm_bin="$(find stage -path '*arm64*' -name oblikovati-head -type f | head -1)"
+          lipo -create "$amd_bin" "$arm_bin" -output uni/bin/oblikovati-head
+          arm_fw="$(dirname "$(find stage -path '*arm64*' -name libvulkan.1.dylib -type f | head -1)")"
+          amd_fw="$(dirname "$(find stage -path '*amd64*' -name libvulkan.1.dylib -type f | head -1)")"
+          for f in "$arm_fw"/*.dylib; do
+            b="$(basename "$f")"
+            lipo -create "$amd_fw/$b" "$arm_fw/$b" -output "uni/fw/$b"
+          done
+      - name: Assemble .app
+        run: scripts/package-macos.sh uni/bin/oblikovati-head uni/fw '${{ inputs.version }}' dist
+      - name: Import Developer ID certificate
+        env:
+          CERT: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          CERT_PW: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KC="$RUNNER_TEMP/signing.keychain-db"
+          KCPW="$(uuidgen)"
+          security create-keychain -p "$KCPW" "$KC"
+          security set-keychain-settings -lut 21600 "$KC"
+          security unlock-keychain -p "$KCPW" "$KC"
+          echo "$CERT" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PW" -t cert -f pkcs12 -k "$KC" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -k "$KCPW" "$KC" >/dev/null
+          security list-keychains -d user -s "$KC" $(security list-keychains -d user | tr -d '"')
+          IDENT="$(security find-identity -v -p codesigning "$KC" | awk -F'"' '/Developer ID Application/{print $2; exit}')"
+          [ -n "$IDENT" ] || { echo "no Developer ID Application identity found in the imported certificate"; exit 1; }
+          echo "DEVELOPER_ID_APP=$IDENT" >> "$GITHUB_ENV"
+      - name: Sign, notarize, staple
+        env:
+          AC_APPLE_ID: ${{ secrets.MACOS_AC_APPLE_ID }}
+          AC_PASSWORD: ${{ secrets.MACOS_AC_PASSWORD }}
+          AC_TEAM_ID: ${{ secrets.MACOS_AC_TEAM_ID }}
+        run: scripts/macos-sign.sh dist/Oblikovati.app '${{ inputs.version }}' dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: head-macos
+          path: dist/*.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,9 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.guard.outputs.version }}
+    # macOS signing/notarization reads MACOS_* repo secrets; without inherit the
+    # reusable workflow can't see them and skips the macOS release.
+    secrets: inherit
 
   publish:
     needs: [guard, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.version.outputs.version }}
+    # macOS signing/notarization reads MACOS_* repo secrets; without inherit the
+    # reusable workflow can't see them and skips the macOS release.
+    secrets: inherit
 
   publish:
     needs: [version, build]

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ prereleases under the rolling `nightly` tag.
   loader is bundled; your GPU's Vulkan driver is used from the system.
 - **Windows** — download and unzip `*-windows-amd64.zip`, run `oblikovati-head.exe`
   (the GLFW + runtime DLLs are bundled; `vulkan-1.dll` comes from your GPU driver).
-- **macOS** — download `*-darwin-<arch>.tar.gz`, extract, run `./oblikovati/oblikovati-head`.
-  Vulkan runs over **MoltenVK** (bundled). Builds are **unsigned** (no Apple cert
-  yet), so the first launch needs **right-click → Open** to clear Gatekeeper.
+- **macOS** — download `Oblikovati-*-macos-universal.zip`, unzip, and double-click
+  **`Oblikovati.app`** (one universal build for Intel + Apple Silicon). Vulkan runs over
+  **MoltenVK**, bundled inside the app; it is codesigned + notarized, so it launches with
+  no Gatekeeper prompt and needs no Vulkan SDK or setup.
 
 **CLI (`oblikovati-cli`)** — a single static binary for your OS/arch; download, make
 it executable, and run. `oblikovati-cli version` prints the build metadata.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,9 +7,9 @@ Two channels, both automated by GitHub Actions:
 | **Nightly** | daily cron + manual `workflow_dispatch`, on `develop` | `.github/workflows/nightly.yml` | rolling `nightly` **prerelease** (skipped if no new commits) |
 | **Stable** | push to `release` (merge a PR `develop` → `release`) | `.github/workflows/release.yml` | GitHub release tagged `vMAJOR.MINOR.<timestamp>` |
 
-Both build the **GUI head + CLI** for Windows, Linux (AppImage), and macOS (Intel +
-Apple Silicon, **unsigned** — right-click → Open the first time). Add-ins are **not**
-shipped; they are maintained by external vendors.
+Both build the **GUI head + CLI** for Windows, Linux (AppImage), and macOS (one
+**universal `.app`**, codesigned + notarized — see [macOS signing](#macos-signing--notarization)).
+Add-ins are **not** shipped; they are maintained by external vendors.
 
 ## Versioning — `MAJOR.MINOR.PATCH`
 
@@ -45,6 +45,32 @@ PATCH is never edited by hand — it is the build timestamp.
 The `release` branch is the stable channel (one-time setup: `git branch release &&
 git push -u origin release`).
 
+## macOS signing & notarization
+
+The macOS head ships as a single **universal `Oblikovati.app`** (Intel + Apple Silicon
+lipo'd together) that is Developer-ID **codesigned, notarized, and stapled**, so a
+downloaded build runs on a clean Mac with **no Vulkan SDK, no environment setup, and no
+Gatekeeper prompt**. MoltenVK + the Vulkan loader + GLFW are bundled in
+`Contents/Frameworks` (found via `@rpath`); the app points the loader at the bundled
+MoltenVK ICD in-process at startup (`head/internal/native/icd_darwin.go`).
+
+This requires an Apple Developer account. Add these **repository secrets** (Settings →
+Secrets and variables → Actions). When any is missing, the macOS release is **skipped**
+(the rest of the build still publishes):
+
+| Secret | What it is |
+|--------|------------|
+| `MACOS_CERT_P12_BASE64` | base64 of the **Developer ID Application** certificate exported as `.p12` (`base64 -i cert.p12 \| pbcopy`) |
+| `MACOS_CERT_PASSWORD` | password set when exporting the `.p12` |
+| `MACOS_AC_APPLE_ID` | Apple ID email used for notarization |
+| `MACOS_AC_PASSWORD` | an **app-specific password** for that Apple ID (appleid.apple.com → Sign-In and Security) |
+| `MACOS_AC_TEAM_ID` | the 10-character Apple Developer **Team ID** |
+
+The signing identity is derived automatically from the imported certificate. The
+build/sign/notarize flow lives in `scripts/package-macos.sh` + `scripts/macos-sign.sh`
+and the `head-macos*` jobs in `build.yml`. Notarization adds a few minutes (Apple-side
+scan); `notarytool --wait` blocks the job on the verdict.
+
 ## Local builds
 
 `make build` / `make build-all` (in `source/`) stamp `build.Version` from `VERSION`
@@ -57,7 +83,8 @@ version via `VERSION=… make build`.
   Windows mingw DLLs) is built in `scripts/package-*.sh` and the `build` workflow; it
   needs a few CI iterations to harden across platforms. The CLI path is cgo-free and
   reliable.
-- macOS builds are **unsigned** (no Apple Developer cert yet) — Gatekeeper will warn.
+- macOS builds are codesigned + notarized when the `MACOS_*` secrets are set (see
+  [macOS signing](#macos-signing--notarization)); otherwise the macOS release is skipped.
 - Linux/Windows **arm64 head** is deferred (no standard arm CI runner); the CLI ships
   for arm64 on all OSes.
 - `source/.goreleaser.yaml` is superseded by this pipeline (kept only for local

--- a/architecture/decisions/ADR-0017-release-pipeline.md
+++ b/architecture/decisions/ADR-0017-release-pipeline.md
@@ -59,7 +59,9 @@ channels driven by the branch model rather than hand-cut tags.
 - Per-OS head packaging may need occasional CI tuning (AppImage Vulkan bundling,
   macOS dylib relocation, Windows DLLs); the CLI path is cgo-free and reliable, and
   the workflow ships it independently of head packaging.
-- macOS builds are **unsigned** (Gatekeeper right-click → Open); Linux/Windows
-  **arm64 head** is deferred (no standard arm runner) while the CLI ships all arches.
+- macOS packaging was later reworked by [ADR-0019](ADR-0019-macos-moltenvk-support.md):
+  the head now ships as one **signed + notarized universal `.app`** (not an unsigned
+  tarball), gated on `MACOS_*` secrets. Linux/Windows **arm64 head** is deferred (no
+  standard arm runner) while the CLI ships all arches.
 - CI (`ci.yml`) runs on `main` + `develop` and PRs; the release workflows are
   separate. ADR-0015's `make`/lint/test foundation is unchanged.

--- a/architecture/decisions/ADR-0019-macos-moltenvk-support.md
+++ b/architecture/decisions/ADR-0019-macos-moltenvk-support.md
@@ -1,0 +1,96 @@
+# ADR-0019 — macOS support: MoltenVK runtime fixes + signed universal .app
+
+**Status:** accepted (2026-06) · **Updates:** [ADR-0017](ADR-0017-release-pipeline.md)
+(macOS artifact: unsigned tarball → signed universal `.app`). **Builds on:**
+[ADR-0005](ADR-0005-vulkan13-renderer.md) (Vulkan 1.3), [ADR-0008](ADR-0008-cgo-boundary.md)
+(cgo edge). Operational guide: [`RELEASING.md`](../../RELEASING.md).
+
+## Context
+
+The head (Vulkan 1.3 + GLFW + Dear ImGui) was developed and CI-tested on Linux/X11,
+where Vulkan is a system facility. The first run on a Mac host showed the head did not
+start **at all** on macOS, and the existing macOS release (ADR-0017: an unsigned tarball
+with a `DYLD_*`-setting launcher) could never give a clean-Mac, no-workaround download.
+macOS differs from Linux/Windows in four ways that each broke a different stage:
+
+1. **No system Vulkan.** Vulkan reaches the GPU only through **MoltenVK** (Vulkan→Metal),
+   a *portability* driver that ships with the app, not the OS.
+2. **The Vulkan loader hides portability drivers** unless the instance explicitly opts in.
+3. **Cocoa requires the main thread** for all window/event calls.
+4. **Gatekeeper blocks downloaded code** that is not Developer-ID signed *and* notarized,
+   and the **hardened runtime** notarization requires **strips `DYLD_*`** on exec.
+
+## Decision
+
+Make the head run on MoltenVK and ship it as a self-contained, notarized app. All
+runtime changes are guarded so Linux/Windows behavior is unchanged.
+
+### Runtime (head)
+
+1. **Opt into portability enumeration** in `vkCreateInstance`: add
+   `VK_KHR_portability_enumeration` + the `ENUMERATE_PORTABILITY_BIT_KHR` flag. Without
+   it the loader reports *"Found no drivers!"* and `vkCreateInstance` fails with
+   `VK_ERROR_INCOMPATIBLE_DRIVER` — MoltenVK is a portability device the loader will not
+   enumerate unless asked.
+2. **Enable `VK_KHR_portability_subset`** on the device when the GPU advertises it —
+   mandatory for a portability device, else device creation is a validation error
+   (`VUID-VkDeviceCreateInfo-pProperties-04451`).
+3. **Pin the main OS thread** (`runtime.LockOSThread` in `native`'s package `init`), so
+   GLFW init/window/poll run on the main thread Cocoa demands. Inert on other platforms.
+4. **Point the loader at the bundled MoltenVK ICD in-process** at startup
+   (`head/internal/native/icd_darwin.go` sets `VK_ICD_FILENAMES` before `vkCreateInstance`).
+   In-process `setenv` is honored by the loader (cgo syncs Go env → libc) and, unlike a
+   launcher's `DYLD_*`, **survives the hardened runtime**. Guarded: it does nothing
+   unless the bundled manifest exists and no override is already set, so `go run`/tests/
+   Linux are unaffected.
+
+Extensions 1–2 are added only when the loader/device advertises them (queried at runtime),
+so the same source is correct on every platform.
+
+### Distribution (CI)
+
+Replace the unsigned tarball + `DYLD_*` launcher with a **single universal
+`Oblikovati.app`**, Developer-ID **codesigned + notarized + stapled**:
+
+- **Bundle** the loader + MoltenVK + GLFW in `Contents/Frameworks`; the binary finds
+  them via a baked-in **`@rpath`** (`@executable_path/../Frameworks`), not `DYLD_*`.
+- **GLFW finds the loader itself** via its Cocoa bundle search (the app is a real
+  `.app` with `libvulkan.1.dylib` in `Frameworks`), so no `DYLD_LIBRARY_PATH`.
+- **One Team ID for everything.** The hardened runtime's *library validation* requires
+  every loaded dylib to share the main binary's Team ID, so CI signs the binary and all
+  bundled dylibs with the same Developer ID — which removes the need for the insecure
+  `disable-library-validation` entitlement.
+- **Universal**: each arch (Intel + Apple Silicon) is built natively (the cgo head can't
+  cross-compile, per ADR-0008/0017) and `lipo`'d into one `.app`.
+- **Gated on secrets**: the whole macOS release is **skipped** (not failed) when the
+  `MACOS_*` signing secrets are absent, so forks/unconfigured repos still build the rest.
+
+Files: `head/internal/native/{icd_darwin.go,mainthread.go,app.cpp}`,
+`scripts/{package-macos.sh,macos-stage.sh,macos-sign.sh}`, and the `macos-preflight` /
+`head-macos-build` / `head-macos` jobs in `build.yml` (`release.yml` + `nightly.yml`
+pass `secrets: inherit`).
+
+## Why (alternatives rejected)
+
+- **Why a `.app` + in-process `setenv`, not the `DYLD_*` launcher (ADR-0017)?** The
+  launcher is fundamentally incompatible with notarization: the hardened runtime strips
+  `DYLD_*`, so a notarized launcher build could not find its libraries. The `.app` +
+  `@rpath` + in-process ICD path is the only design that is both self-contained and
+  notarizable. Verified end-to-end on a clean environment before wiring CI.
+- **Why bundle the loader, not link MoltenVK directly?** Keeping the loader keeps one
+  code path with Linux/Windows and preserves the option of validation layers in dev;
+  the portability requirement is a *loader* behavior we now satisfy correctly anyway.
+- **Why notarize, not just sign?** Developer-ID signing alone still trips Gatekeeper on
+  downloaded apps (macOS 10.15+); notarization + stapling is what removes the prompt.
+
+## Consequences
+
+- **ADR-0017's macOS artifact is updated**: unsigned per-arch tarball → one signed,
+  notarized universal `.app`; `RELEASING.md` lists the required `MACOS_*` repo secrets.
+- **macOS dev still needs setup** (brew GLFW/loader/MoltenVK + a `go.work`); the bundle
+  machinery is release-only — see `DEVELOPMENT.md` / the dev notes.
+- One **benign validation message remains** (`UNASSIGNED-non-acquired-swapchain-image-used`
+  at startup) in the shared swapchain loop, not MoltenVK-specific; tracked as a
+  low-priority follow-up.
+- First notarization may surface an entitlement need (Metal/MoltenVK); entitlements are
+  intentionally minimal and a one-line addition in `macos-sign.sh` if required.

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -8,6 +8,16 @@
 #include "imgui_internal.h" // DockBuilder* for the default dock layout
 #include "backends/imgui_impl_glfw.h"
 #include <cstring>
+#include <cstdio>
+#include <vector>
+
+// obk_glfw_error surfaces GLFW init/window failures (otherwise obk_head_create just
+// returns null and the Go side reports a generic "step 1" with no cause — on macOS the
+// usual cause is calling GLFW off the main thread, see runtime.LockOSThread in the
+// head commands).
+static void obk_glfw_error(int code, const char* desc) {
+    fprintf(stderr, "[head] GLFW error %d: %s\n", code, desc ? desc : "(null)");
+}
 
 // obk_find_memory_type: shared with viewport.cpp (declared in head.h).
 uint32_t obk_find_memory_type(VkPhysicalDevice phys, uint32_t type_bits,
@@ -27,16 +37,48 @@ namespace {
 
 bool ok(VkResult r) { return r == VK_SUCCESS; }
 
+// instance_has_ext reports whether the loader advertises an instance extension, so we
+// only opt into portability on platforms (macOS/MoltenVK) that actually expose it.
+bool instance_has_ext(const char* name) {
+    uint32_t n = 0;
+    vkEnumerateInstanceExtensionProperties(nullptr, &n, nullptr);
+    std::vector<VkExtensionProperties> props(n);
+    vkEnumerateInstanceExtensionProperties(nullptr, &n, props.data());
+    for (const auto& p : props)
+        if (strcmp(p.extensionName, name) == 0) return true;
+    return false;
+}
+
+// device_has_ext reports whether a physical device advertises a device extension.
+bool device_has_ext(VkPhysicalDevice dev, const char* name) {
+    uint32_t n = 0;
+    vkEnumerateDeviceExtensionProperties(dev, nullptr, &n, nullptr);
+    std::vector<VkExtensionProperties> props(n);
+    vkEnumerateDeviceExtensionProperties(dev, nullptr, &n, props.data());
+    for (const auto& p : props)
+        if (strcmp(p.extensionName, name) == 0) return true;
+    return false;
+}
+
 bool create_instance(HeadContext* c, const char** exts, uint32_t n) {
     VkApplicationInfo app{};
     app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     app.pApplicationName = "Oblikovati";
     app.apiVersion = VK_API_VERSION_1_3;
+    std::vector<const char*> enabled(exts, exts + n);
     VkInstanceCreateInfo ci{};
     ci.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    // Portability drivers (MoltenVK on macOS) are hidden from the loader unless the
+    // instance opts in, otherwise vkCreateInstance fails with INCOMPATIBLE_DRIVER
+    // ("Found no drivers!"). The guard keeps this a no-op on Linux/Windows, where the
+    // extension is absent.
+    if (instance_has_ext(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        enabled.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        ci.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    }
     ci.pApplicationInfo = &app;
-    ci.enabledExtensionCount = n;
-    ci.ppEnabledExtensionNames = exts;
+    ci.enabledExtensionCount = (uint32_t)enabled.size();
+    ci.ppEnabledExtensionNames = enabled.data();
     return ok(vkCreateInstance(&ci, c->allocator, &c->instance));
 }
 
@@ -51,13 +93,19 @@ bool create_device(HeadContext* c) {
     q.queueFamilyIndex = c->queueFamily;
     q.queueCount = 1;
     q.pQueuePriorities = &prio;
-    const char* dev_ext[] = {"VK_KHR_swapchain"};
+    std::vector<const char*> dev_ext = {"VK_KHR_swapchain"};
+    // A portability-subset device (MoltenVK) MUST enable VK_KHR_portability_subset when
+    // it advertises it, or device creation is a validation error
+    // (VUID-VkDeviceCreateInfo-pProperties-04451). String literal, not the *_EXTENSION_NAME
+    // macro, which is gated behind VK_ENABLE_BETA_EXTENSIONS.
+    if (device_has_ext(c->physical, "VK_KHR_portability_subset"))
+        dev_ext.push_back("VK_KHR_portability_subset");
     VkDeviceCreateInfo ci{};
     ci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
     ci.queueCreateInfoCount = 1;
     ci.pQueueCreateInfos = &q;
-    ci.enabledExtensionCount = 1;
-    ci.ppEnabledExtensionNames = dev_ext;
+    ci.enabledExtensionCount = (uint32_t)dev_ext.size();
+    ci.ppEnabledExtensionNames = dev_ext.data();
     if (!ok(vkCreateDevice(c->physical, &ci, c->allocator, &c->device))) return false;
     vkGetDeviceQueue(c->device, c->queueFamily, 0, &c->queue);
     return true;
@@ -153,17 +201,21 @@ void frame_present(HeadContext* c) {
 extern "C" {
 
 void* obk_head_create(int width, int height, const char* title) {
-    if (!glfwInit()) return nullptr;
-    if (!glfwVulkanSupported()) { glfwTerminate(); return nullptr; }
+    glfwSetErrorCallback(obk_glfw_error);
+    if (!glfwInit()) { fprintf(stderr, "[head] glfwInit failed\n"); return nullptr; }
+    if (!glfwVulkanSupported()) {
+        fprintf(stderr, "[head] glfwVulkanSupported=false (GLFW cannot find the Vulkan loader)\n");
+        glfwTerminate(); return nullptr;
+    }
     HeadContext* c = new HeadContext();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     c->window = glfwCreateWindow(width, height, title, nullptr, nullptr);
-    if (!c->window) { delete c; glfwTerminate(); return nullptr; }
+    if (!c->window) { fprintf(stderr, "[head] glfwCreateWindow failed\n"); delete c; glfwTerminate(); return nullptr; }
     uint32_t n = 0;
     const char** exts = glfwGetRequiredInstanceExtensions(&n);
-    if (!create_instance(c, exts, n) || !create_device(c) || !create_descriptor_pool(c)) {
-        delete c; return nullptr;
-    }
+    if (!create_instance(c, exts, n)) { fprintf(stderr, "[head] vkCreateInstance failed\n"); delete c; return nullptr; }
+    if (!create_device(c)) { fprintf(stderr, "[head] device selection/creation failed (no Vulkan physical device?)\n"); delete c; return nullptr; }
+    if (!create_descriptor_pool(c)) { fprintf(stderr, "[head] descriptor pool creation failed\n"); delete c; return nullptr; }
     VkSurfaceKHR surface = VK_NULL_HANDLE;
     if (!ok(glfwCreateWindowSurface(c->instance, c->window, c->allocator, &surface))) {
         delete c; return nullptr;

--- a/head/internal/native/icd_darwin.go
+++ b/head/internal/native/icd_darwin.go
@@ -1,0 +1,42 @@
+//go:build darwin && cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package native
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// init points the Vulkan loader at the MoltenVK ICD bundled inside our .app, so a
+// downloaded release runs on a clean Mac with no Vulkan SDK and no environment setup.
+//
+// macOS has no system Vulkan: the loader only finds a driver via VK_ICD_FILENAMES or
+// system search paths that a release must not depend on. We ship MoltenVK in the
+// bundle and set the variable here, in-process, BEFORE any vkCreateInstance — unlike a
+// launcher's DYLD_* vars, an in-process setenv survives the hardened runtime that
+// notarization requires (cgo keeps Go's os.Setenv in sync with libc getenv, which the
+// loader reads). GLFW finds the loader itself via the bundle's Frameworks dir, so no
+// DYLD_LIBRARY_PATH is needed.
+//
+// Guards keep this inert outside the bundle: an explicit override (developer machines)
+// or a missing bundled manifest (plain `go run`, tests) leaves the environment alone.
+func init() {
+	if os.Getenv("VK_ICD_FILENAMES") != "" || os.Getenv("VK_DRIVER_FILES") != "" {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	// Bundle layout: Oblikovati.app/Contents/MacOS/<exe> with the manifest one level up
+	// under Resources (see scripts/package-macos.sh).
+	icd := filepath.Join(filepath.Dir(exe), "..", "Resources", "vulkan", "icd.d", "MoltenVK_icd.json")
+	if _, err := os.Stat(icd); err != nil {
+		return
+	}
+	// Ignore the error: a failure here just falls back to the loader's default search,
+	// which is exactly the behavior we have without this shim.
+	_ = os.Setenv("VK_ICD_FILENAMES", icd)
+}

--- a/head/internal/native/mainthread.go
+++ b/head/internal/native/mainthread.go
@@ -1,0 +1,15 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package native
+
+import "runtime"
+
+// GLFW and the underlying window system require that init, window creation, and event
+// polling all happen on the main OS thread — on macOS/Cocoa, calling them off the main
+// thread aborts the process. Package init() runs on the startup (main) thread before
+// main(), so locking here pins the main goroutine to that thread for the whole process
+// and every head binary that imports this package (headsmoke, oblikovati-head) inherits
+// the guarantee without repeating it.
+func init() { runtime.LockOSThread() }

--- a/scripts/macos-sign.sh
+++ b/scripts/macos-sign.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Codesign, notarize, and staple the Oblikovati .app so a downloaded release launches
+# on a clean Mac with no Gatekeeper prompt (the last piece of "no workarounds").
+#
+# Why each step:
+#   - Sign inside-out (dylibs, then the bundle) with one Developer ID, under the
+#     HARDENED RUNTIME (--options runtime). Notarization REQUIRES hardened runtime; and
+#     because every dylib shares the binary's Team ID, hardened-runtime library
+#     validation passes without the insecure disable-library-validation entitlement.
+#   - Notarize: Apple scans the signed app and records its ticket. WITHOUT this, a
+#     downloaded (quarantined) app is blocked even when correctly signed.
+#   - Staple: attach the ticket to the .app so it verifies offline / first launch.
+#
+#   Usage: scripts/macos-sign.sh <app> <version> <out-dir>
+# Env (provided by CI from repo secrets). When ANY is missing the macOS release is
+# skipped (exit 0) rather than failing the pipeline — forks and unconfigured repos can
+# still build everything else:
+#   DEVELOPER_ID_APP  codesign identity, e.g. "Developer ID Application: Foo (TEAMID)"
+#   AC_APPLE_ID       Apple ID email for notarytool
+#   AC_PASSWORD       app-specific password for that Apple ID
+#   AC_TEAM_ID        Apple Developer Team ID
+set -euo pipefail
+
+app="$1"
+version="$2"
+out="${3:-dist}"
+mkdir -p "$out"
+out="$(cd "$out" && pwd)"
+
+# A signed+notarized bundle is the only way to ship a no-workaround Mac download, so
+# without credentials we skip the whole macOS release instead of publishing something
+# Gatekeeper would block.
+for v in DEVELOPER_ID_APP AC_APPLE_ID AC_PASSWORD AC_TEAM_ID; do
+	if [ -z "${!v:-}" ]; then
+		echo "macos-sign: \$$v not set — Apple credentials not configured; skipping macOS signing + notarization."
+		exit 0
+	fi
+done
+
+sign() { codesign --force --options runtime --timestamp --sign "$DEVELOPER_ID_APP" "$@"; }
+
+# Nested code first, then the bundle (which signs Contents/MacOS/oblikovati-head and
+# seals the bundle). --timestamp contacts Apple's TSA, required for notarization.
+sign "$app/Contents/Frameworks/"*.dylib
+sign "$app"
+codesign --verify --deep --strict --verbose=2 "$app"
+
+# Notarize the zipped bundle and wait for Apple's verdict (non-zero exit fails the job).
+zip="$out/Oblikovati-$version-macos-universal.zip"
+ditto -c -k --keepParent "$app" "$zip"
+xcrun notarytool submit "$zip" \
+	--apple-id "$AC_APPLE_ID" --password "$AC_PASSWORD" --team-id "$AC_TEAM_ID" --wait
+
+# Staple the ticket into the .app, then re-zip so the published artifact carries it.
+xcrun stapler staple "$app"
+xcrun stapler validate "$app"
+rm -f "$zip"
+ditto -c -k --keepParent "$app" "$zip"
+echo "signed + notarized + stapled: $zip"

--- a/scripts/macos-stage.sh
+++ b/scripts/macos-stage.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Stage one architecture's macOS head build for the universal-bundle assembly.
+#
+# The universal .app is lipo'd from both runners' outputs, so each runner uploads its
+# binary plus the exact dylibs it links against (Vulkan loader + GLFW) and MoltenVK
+# (dlopened by the loader, not a link-time dep). Symlinks are dereferenced and copied
+# under canonical names so the two arches' files line up by name for `lipo -create`.
+#
+#   Usage: scripts/macos-stage.sh <head-binary> <out-staging-dir>
+# Requires: brew with glfw, vulkan-loader, molten-vk.
+set -euo pipefail
+
+bin="$1"
+out="$2"
+mkdir -p "$out/bin" "$out/frameworks"
+
+cp "$bin" "$out/bin/oblikovati-head"
+
+# -L dereferences the brew version symlinks (libvulkan.1.dylib -> libvulkan.1.4.350.dylib)
+# so the staged file keeps the canonical name the binary links against.
+cp -L "$(brew --prefix vulkan-loader)/lib/libvulkan.1.dylib" "$out/frameworks/"
+cp -L "$(brew --prefix molten-vk)/lib/libMoltenVK.dylib" "$out/frameworks/"
+cp -L "$(brew --prefix glfw)"/lib/libglfw.3.dylib "$out/frameworks/"
+
+echo "staged $(uname -m) head + dylibs in $out"
+ls -1 "$out/frameworks"

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,56 +1,83 @@
 #!/usr/bin/env bash
-# Package the Oblikovati GUI head for macOS (UNSIGNED — no Apple cert yet, so users
-# right-click → Open the first time to clear Gatekeeper).
+# Assemble the Oblikovati GUI head into a self-contained macOS .app bundle.
 #
-# macOS has no native Vulkan, so we bundle the Vulkan loader + MoltenVK (Vulkan over
-# Metal) and a launcher that points the loader at them. Homebrew-linked dylibs carry
-# absolute install names, so we rewrite the head's references to @rpath and ship the
-# libs alongside it.
+# macOS has no system Vulkan, so the bundle ships its own loader + MoltenVK (Vulkan
+# over Metal) + GLFW. The result runs on a clean Mac with NO Vulkan SDK and NO
+# environment setup:
+#   - the binary finds its dylibs via a baked-in @rpath (@executable_path/../Frameworks),
+#     not DYLD_* (which the hardened runtime that notarization requires would strip);
+#   - GLFW finds the loader itself via the bundle's Frameworks dir (Cocoa bundle search);
+#   - the app points the loader at the bundled MoltenVK ICD in-process at startup
+#     (head/internal/native/icd_darwin.go), so no launcher and no env var are needed.
 #
-#   Usage: scripts/package-macos.sh <head-binary> <version> <arch> <out-dir>
-# Requires: brew packages glfw, vulkan-loader, molten-vk; install_name_tool (Xcode CLT).
+# This script only assembles + relinks the bundle; codesigning + notarization is a
+# separate step (scripts/macos-sign.sh) so an unsigned bundle is still locally runnable.
+#
+#   Usage: scripts/package-macos.sh <head-binary> <frameworks-dir> <version> <out-dir>
+#     <head-binary>     the oblikovati-head executable (single-arch or universal)
+#     <frameworks-dir>  dir holding libvulkan.1.dylib, libMoltenVK.dylib, libglfw.*.dylib
+#                       (matching arch(es) of <head-binary>)
+#     <version>         release version string
+#     <out-dir>         where Oblikovati.app is written
+# Requires: install_name_tool, otool (Xcode Command Line Tools).
 set -euo pipefail
 
 bin="$1"
-version="$2"
-arch="$3"
+frameworks="$2"
+version="$3"
 out="${4:-dist}"
 mkdir -p "$out"
 out="$(cd "$out" && pwd)"
 
-stage="$(mktemp -d)/oblikovati"
-mkdir -p "$stage/bin" "$stage/lib" "$stage/share/vulkan/icd.d"
-cp "$bin" "$stage/bin/oblikovati-head"
+app="$out/Oblikovati.app"
+rm -rf "$app"
+macos="$app/Contents/MacOS"
+fw="$app/Contents/Frameworks"
+icddir="$app/Contents/Resources/vulkan/icd.d"
+mkdir -p "$macos" "$fw" "$icddir"
 
-brewp="$(brew --prefix)"
-# Bundle the Vulkan loader, MoltenVK, and GLFW dylibs.
-cp "$brewp"/lib/libvulkan.1*.dylib "$stage/lib/" 2>/dev/null || cp "$brewp"/lib/libvulkan*.dylib "$stage/lib/"
-cp "$(brew --prefix molten-vk)/lib/libMoltenVK.dylib" "$stage/lib/"
-cp "$(brew --prefix glfw)"/lib/libglfw*.dylib "$stage/lib/" 2>/dev/null || true
+cp "$bin" "$macos/oblikovati-head"
+chmod +x "$macos/oblikovati-head"
+cp "$frameworks"/*.dylib "$fw/"
 
-# ICD manifest pointing the loader at the bundled MoltenVK (path relative to the json).
-cat >"$stage/share/vulkan/icd.d/MoltenVK_icd.json" <<'EOF'
-{ "file_format_version": "1.0.0", "ICD": { "library_path": "../../../lib/libMoltenVK.dylib", "api_version": "1.2.0" } }
+# Info.plist — CFBundleExecutable wires the launch; the identifier + versions are what
+# notarization and Gatekeeper record. NSHighResolutionCapable gives a crisp viewport.
+cat >"$app/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key><string>oblikovati-head</string>
+	<key>CFBundleIdentifier</key><string>com.oblikovati.head</string>
+	<key>CFBundleName</key><string>Oblikovati</string>
+	<key>CFBundleDisplayName</key><string>Oblikovati</string>
+	<key>CFBundlePackageType</key><string>APPL</string>
+	<key>CFBundleShortVersionString</key><string>${version}</string>
+	<key>CFBundleVersion</key><string>${version}</string>
+	<key>LSMinimumSystemVersion</key><string>11.0</string>
+	<key>NSHighResolutionCapable</key><true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key><true/>
+</dict>
+</plist>
 EOF
 
-# Rewrite the head's absolute brew dylib references to @rpath and add an rpath to lib/.
-fix_ref() {
-	local dep; dep="$(otool -L "$stage/bin/oblikovati-head" | awk '/'"$1"'/{print $1; exit}')"
-	[ -n "$dep" ] && install_name_tool -change "$dep" "@rpath/$(basename "$dep")" "$stage/bin/oblikovati-head" || true
-}
-fix_ref libvulkan
-fix_ref libglfw
-install_name_tool -add_rpath "@loader_path/../lib" "$stage/bin/oblikovati-head" 2>/dev/null || true
-
-# Launcher: point the loader at the bundled ICD, then exec the head.
-cat >"$stage/oblikovati-head" <<'EOF'
-#!/usr/bin/env bash
-here="$(cd "$(dirname "$0")" && pwd)"
-export VK_ICD_FILENAMES="$here/share/vulkan/icd.d/MoltenVK_icd.json"
-export DYLD_LIBRARY_PATH="$here/lib:${DYLD_LIBRARY_PATH:-}"
-exec "$here/bin/oblikovati-head" "$@"
+# ICD manifest the in-process shim points the loader at. library_path is relative to the
+# json: Resources/vulkan/icd.d/ -> ../../../Frameworks/libMoltenVK.dylib.
+cat >"$icddir/MoltenVK_icd.json" <<'EOF'
+{ "file_format_version": "1.0.0", "ICD": { "library_path": "../../../Frameworks/libMoltenVK.dylib", "api_version": "1.2.0" } }
 EOF
-chmod +x "$stage/oblikovati-head"
 
-tar -C "$(dirname "$stage")" -czf "$out/oblikovati-head-$version-darwin-$arch.tar.gz" oblikovati
-echo "built $out/oblikovati-head-$version-darwin-$arch.tar.gz"
+# Relink for the bundle: give every bundled dylib an @rpath id, repoint the binary's
+# linked deps that we bundle to @rpath, and add the Frameworks rpath. MoltenVK is not a
+# link-time dep of the binary (the loader dlopens it via the ICD), so it needs only an id.
+for f in "$fw"/*.dylib; do
+	install_name_tool -id "@rpath/$(basename "$f")" "$f"
+done
+for dep in $(otool -L "$macos/oblikovati-head" | awk 'NR>1{print $1}'); do
+	base="$(basename "$dep")"
+	[ -f "$fw/$base" ] && install_name_tool -change "$dep" "@rpath/$base" "$macos/oblikovati-head"
+done
+otool -l "$macos/oblikovati-head" | grep -q "@executable_path/../Frameworks" \
+	|| install_name_tool -add_rpath "@executable_path/../Frameworks" "$macos/oblikovati-head"
+
+echo "assembled $app"


### PR DESCRIPTION
## Summary

The head never started on macOS, and the release couldn't produce a no-workaround Mac download. This fixes both. Validated end-to-end on a clean environment on real hardware (Intel Mac); see ADR-0019 for the full rationale.

### Runtime (all guarded — no effect on Linux/Windows)
- **Instance**: opt into `VK_KHR_portability_enumeration` (+ `ENUMERATE_PORTABILITY` flag) so the loader enumerates MoltenVK — otherwise `vkCreateInstance` fails `VK_ERROR_INCOMPATIBLE_DRIVER` (*"Found no drivers!"*).
- **Device**: enable `VK_KHR_portability_subset` when advertised (else validation `VUID-VkDeviceCreateInfo-pProperties-04451`).
- **Main-thread pin** for GLFW/Cocoa (`runtime.LockOSThread` in `native` init).
- **In-process ICD path** (`icd_darwin.go`) — points the loader at the bundled MoltenVK at startup; survives the hardened runtime, unlike a `DYLD_*` launcher.
- Surface GLFW/Vulkan init failures instead of a silent `null`.

### Distribution
Replace the unsigned tarball + `DYLD_*` launcher with one **notarizable universal `Oblikovati.app`**: loader + MoltenVK + GLFW bundled in `Frameworks` via `@rpath`, GLFW finds the loader via Cocoa bundle search, every dylib signed with one Team ID (no `disable-library-validation`). CI `lipo`s Intel+ARM, codesigns (Developer ID, hardened runtime), notarizes, and staples. **The macOS release is skipped when the `MACOS_*` secrets are absent.**

### Docs
ADR-0019 (+ cross-link from ADR-0017), `RELEASING.md` signing secrets, `README.md` install steps.

## Action required before the first signed Mac build
Add these repo secrets (Settings → Secrets and variables → Actions): `MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `MACOS_AC_APPLE_ID`, `MACOS_AC_PASSWORD`, `MACOS_AC_TEAM_ID`.

## Known follow-up
One benign startup validation message (`UNASSIGNED-non-acquired-swapchain-image-used`) remains in the shared swapchain loop — not MoltenVK-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)