### PR TITLE
Document persistence: open/save flow + git-friendly YAML recipe (ADR-0020)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -426,6 +426,10 @@ go.work.sum
 
 experiments/
 
+# Generated document thumbnails (ADR-0020): a .obk is a committed YAML text file;
+# its thumbnail is regenerable cache written beside it on save and never committed.
+*.obk.thumb.*
+
 # Add-in *sources* are tracked; only shared-library build outputs are ignored.
 # The host loads built libs from addins/ at runtime, and `go build -buildmode=
 # c-shared` also emits a header beside the .so/.dll output, so keep them out.

--- a/addin/router/documents.go
+++ b/addin/router/documents.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Oblikovati/api/wire"
 
@@ -47,9 +46,9 @@ func createDocument(s *app.Session, args json.RawMessage) (json.RawMessage, erro
 	if in.Name == "" {
 		return nil, errors.New("documents.create: name is required")
 	}
-	t, err := parseDocumentType(in.Type)
+	t, err := doc.ParseDocumentType(in.Type)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("documents.create: %w", err)
 	}
 	d, err := newDocumentOfType(s, t, in.Name)
 	if err != nil {
@@ -82,20 +81,4 @@ func newDocumentOfType(s *app.Session, t doc.DocumentType, name string) (*doc.Do
 		return compdef.AddPart(s.Workspace(), name, true)
 	}
 	return s.Workspace().Add(t, name, true)
-}
-
-// parseDocumentType maps a type name to the DocumentType discriminator.
-func parseDocumentType(name string) (doc.DocumentType, error) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "part":
-		return doc.Part, nil
-	case "assembly":
-		return doc.Assembly, nil
-	case "drawing":
-		return doc.Drawing, nil
-	case "presentation":
-		return doc.Presentation, nil
-	default:
-		return doc.Unknown, fmt.Errorf("documents.create: unknown type %q (want part|assembly|drawing|presentation)", name)
-	}
 }

--- a/app/session.go
+++ b/app/session.go
@@ -3,7 +3,9 @@
 package app
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Oblikovati/oblikovati/event"
 	"github.com/Oblikovati/oblikovati/model/doc"
@@ -33,10 +35,21 @@ type Session struct {
 	grid            *GridSettings
 }
 
-// NewSession creates an empty in-memory session.
-func NewSession() *Session {
+// NewSession creates an empty in-memory session with no persistence store. Its
+// documents live only in memory — Save/Open return "no store configured" — which
+// is what the unit tests and headless synthetic sessions want. The windowed head
+// and the CLI inject a real store via [NewSessionWithStore].
+func NewSession() *Session { return newSession(nil) }
+
+// NewSessionWithStore creates a session whose workspace persists through store, so
+// File ▸ Open/Save and the CLI fixture commands read and write real .obk packages
+// on disk. Pass a persistence.PackageStore from the binary (the app package depends
+// only on the doc.Store interface, never on persistence — the DI rule).
+func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
+
+func newSession(store doc.Store) *Session {
 	return &Session{
-		workspace: doc.NewWorkspace(nil),
+		workspace: doc.NewWorkspace(store),
 		commands:  NewCommandManager(),
 		bus:       event.NewBus(),
 		selection: NewSelection(),
@@ -116,4 +129,47 @@ func (s *Session) Invoke(alias string) error {
 		return fmt.Errorf("app: no command for alias %q", alias)
 	}
 	return s.Execute(c.id)
+}
+
+// ErrNoActiveDoc is returned by the save verbs when there is no active document to
+// act on (an empty session).
+var ErrNoActiveDoc = errors.New("app: no active document to save")
+
+// ErrNeedsPath is returned by [Session.SaveActiveDocument] when the active document
+// has never been saved — its name is not yet an .obk path (a freshly created
+// "PartN"). File ▸ Save catches this and falls back to Save As to prompt for a
+// destination.
+var ErrNeedsPath = errors.New("app: document has no file path yet; use Save As")
+
+// OpenDocument loads the package at path into the workspace and makes it the active,
+// visible document. It is the core of File ▸ Open and the CLI open command.
+//
+//	d, err := session.OpenDocument("/models/bracket.obk")
+func (s *Session) OpenDocument(path string) (*doc.Document, error) {
+	return s.workspace.Open(path, true)
+}
+
+// SaveActiveDocument writes the active document back to its existing .obk path. A
+// document that was never saved has no path yet — we detect this by the absence of
+// the [doc.PackageExtension] suffix, since new documents are minted with bare names
+// like "Part1" — and return [ErrNeedsPath] so the UI can prompt via Save As.
+func (s *Session) SaveActiveDocument() error {
+	d := s.workspace.ActiveDocument()
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	if !strings.HasSuffix(d.FullFileName(), doc.PackageExtension) {
+		return ErrNeedsPath
+	}
+	return s.workspace.Save(d)
+}
+
+// SaveActiveDocumentAs writes the active document to path, which becomes its new
+// identity. It is the core of File ▸ Save As and the CLI save-as command.
+func (s *Session) SaveActiveDocumentAs(path string) error {
+	d := s.workspace.ActiveDocument()
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	return s.workspace.SaveAs(d, path)
 }

--- a/app/session_persistence_test.go
+++ b/app/session_persistence_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/persistence"
+)
+
+// storeBackedSession wires a real .obk PackageStore into a session rooted at dir, so
+// these tests exercise the genuine save→reopen path (CONVENTIONS.md M03: persistence
+// PBIs assert a real round-trip, not a fake).
+func storeBackedSession() *app.Session {
+	return app.NewSessionWithStore(persistence.NewPackageStore())
+}
+
+func TestSaveActiveDocumentAsThenReopen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bracket.obk")
+
+	s := storeBackedSession()
+	if _, err := compdef.AddPart(s.Workspace(), "Part1", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if err := s.SaveActiveDocumentAs(path); err != nil {
+		t.Fatalf("SaveActiveDocumentAs(%q): %v", path, err)
+	}
+
+	// A fresh session must reopen the package with identical identity.
+	reopened, err := storeBackedSession().OpenDocument(path)
+	if err != nil {
+		t.Fatalf("OpenDocument(%q): %v", path, err)
+	}
+	if got := reopened.DocumentType(); got != doc.Part {
+		t.Errorf("reopened type = %v, want %v", got, doc.Part)
+	}
+	if got := reopened.DisplayName(); got != "bracket" {
+		t.Errorf("reopened display name = %q, want %q", got, "bracket")
+	}
+}
+
+func TestSaveActiveDocumentNeedsPathBeforeFirstSaveAs(t *testing.T) {
+	s := storeBackedSession()
+	if _, err := compdef.AddPart(s.Workspace(), "Part1", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	// "Part1" has no .obk extension, so File ▸ Save must defer to Save As.
+	if err := s.SaveActiveDocument(); !errors.Is(err, app.ErrNeedsPath) {
+		t.Fatalf("SaveActiveDocument() = %v, want ErrNeedsPath", err)
+	}
+}
+
+func TestSaveActiveDocumentSucceedsAfterSaveAs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plate.obk")
+	s := storeBackedSession()
+	if _, err := compdef.AddPart(s.Workspace(), "Part1", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if err := s.SaveActiveDocumentAs(path); err != nil {
+		t.Fatalf("SaveActiveDocumentAs: %v", err)
+	}
+	// The document now carries a real .obk path, so a plain Save writes through.
+	if err := s.SaveActiveDocument(); err != nil {
+		t.Errorf("SaveActiveDocument() after Save As = %v, want nil", err)
+	}
+}
+
+func TestSaveActiveDocumentNoActiveDocument(t *testing.T) {
+	if err := storeBackedSession().SaveActiveDocument(); !errors.Is(err, app.ErrNoActiveDoc) {
+		t.Fatalf("SaveActiveDocument() with no doc = %v, want ErrNoActiveDoc", err)
+	}
+}

--- a/architecture/decisions/ADR-0020-yaml-git-friendly-document-format.md
+++ b/architecture/decisions/ADR-0020-yaml-git-friendly-document-format.md
@@ -1,0 +1,82 @@
+# ADR-0020 — Documents are a single git-friendly YAML file (not a binary ZIP package)
+
+**Status:** accepted (user decision, 2026-06-02) · **Amends:**
+[ADR-0006](ADR-0006-no-com-object-model.md) / core/05 (the on-disk format was
+specified as a ZIP package of binary streams; it is now one text file).
+
+## Context
+
+The `.obk` document format (architecture core/05) was a **ZIP archive** of named
+binary streams (`persistence/io.go` `marshalZip`/`readZip`; manifest `manifest.json`,
+model streams `model/*.bin`). A ZIP is opaque to version control: git stores the whole
+archive as one binary blob, so diffs, blame, and three-way merges are impossible. Users
+want to keep documents **in git** and review changes to a model the way they review
+code.
+
+At the same time, real document content must finally persist: a reopened part must
+restore its **recipe** (parameters, sketches, the ordered feature program), since this
+is a history-based modeler and the realized B-rep is regenerable cache
+(see the recipe-persistence work that depends on this ADR).
+
+## Decision
+
+A document is a **single YAML text file** (`.obk`), not a ZIP package. The file holds
+**only the recipe** — text, no binary blobs:
+
+```yaml
+schemaVersion: 2
+documentType: part
+displayName: bracket
+model:                      # the recipe (parameters / sketches / features)
+  parameters:
+    - {name: width, kind: user, expression: 4 cm}
+  sketches: [ ... ]
+  features: [ ... ]
+data: {}                    # add-in / attribute text sections (UTF-8; base64 only if a
+                            # stream is genuinely non-text — the rare exception)
+```
+
+Rules:
+
+1. **One text file per document.** Replaces the ZIP container. Git diffs/merges a
+   document line-by-line. Atomic save (write-temp-then-rename) is unchanged.
+2. **Recipe only; no binary in the committed file.** Realized geometry (bodies) is never
+   persisted — reopen restores the recipe and runs `Recompute()`.
+3. **Vector references use SVG.** Where a document references vector graphics, the
+   reference is SVG (text), never a raster/binary blob — so it stays diffable.
+4. **Thumbnails are generated, not committed.** A thumbnail may be generated next to the
+   document on save, but it is **always git-ignored** (a sidecar, never inside the YAML).
+   It is pure cache, regenerable on demand.
+5. **No silent data loss.** Any sketch entity, constraint, or feature kind without a
+   serialization codec makes **Save fail loudly** (naming the offending kind), rather
+   than dropping data quietly.
+
+## Why YAML, and the first third-party dependency
+
+YAML (over JSON) for human-authored-adjacent diffs: comments, block scalars, and
+compact flow style keep a model readable and a change reviewable. We use
+**`gopkg.in/yaml.v3`** (Apache-2.0, GPL-compatible). This is the **first external
+dependency of the GPL core module** (previously only the sibling Apache `/api`). Per
+the dependency rule (CLAUDE.md) it is wrapped behind a thin, project-owned interface
+(`persistence/yamlcodec`) so exactly one package imports the library and a future
+swap stays local.
+
+## Consequences
+
+- **`persistence` swaps its container backend** (ZIP → YAML) while keeping the logical
+  document model (manifest fields + named sections) and the atomic-save invariant.
+  `schemaVersion` bumps **1 → 2**; legacy ZIP `.obk` files are rejected with a clear
+  message (pre-release: the only existing `.obk` files are regenerable test fixtures, so
+  no ZIP→YAML migration is written).
+- **The opaque exception:** reference-key contexts (topological naming) are serialized
+  opaque bytes; they are carried as a single base64 string field, justified here as the
+  one non-diffable value, because correct geometry rebinding after recompute requires it.
+- A repo `.gitignore` rule excludes generated thumbnails.
+- `cat foo.obk` is now a readable, reviewable document.
+
+## Shape
+
+```
+bracket.obk            # one YAML text file = one document (committed)
+bracket.obk.thumb.*    # generated thumbnail (git-ignored, regenerable)
+```

--- a/cmd/oblikovati-cli/cli_test.go
+++ b/cmd/oblikovati-cli/cli_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runCLI invokes the dispatcher with args, capturing user-facing output. It is the
+// seam the table tests drive — no process, no os.Exit.
+func runCLI(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	err := run(args, &out)
+	return out.String(), err
+}
+
+func TestNewWritesPackageThatInfoReports(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bracket.obk")
+
+	out, err := runCLI(t, "new", "part", path)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if !strings.Contains(out, "created part") {
+		t.Errorf("new output = %q, want it to mention 'created part'", out)
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("expected %s on disk: %v", path, statErr)
+	}
+
+	info, err := runCLI(t, "info", path)
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if !strings.Contains(info, "type: part") || !strings.Contains(info, "name: bracket") {
+		t.Errorf("info output = %q, want type: part and name: bracket", info)
+	}
+}
+
+func TestNewAppendsPackageExtension(t *testing.T) {
+	stem := filepath.Join(t.TempDir(), "noext")
+	if _, err := runCLI(t, "new", "assembly", stem); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := os.Stat(stem + ".obk"); err != nil {
+		t.Fatalf("expected %s.obk on disk: %v", stem, err)
+	}
+}
+
+func TestInfoJSONIsParseable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plate.obk")
+	if _, err := runCLI(t, "new", "part", path); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	// --json must work in either position relative to the path.
+	out, err := runCLI(t, "info", path, "--json")
+	if err != nil {
+		t.Fatalf("info --json: %v", err)
+	}
+	var report manifestReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("info --json emitted invalid JSON %q: %v", out, err)
+	}
+	if report.Type != "part" || report.Name != "plate" || report.SchemaVersion != 2 {
+		t.Errorf("report = %+v, want {2 part plate}", report)
+	}
+}
+
+func TestSaveAsCopiesPackage(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.obk")
+	dst := filepath.Join(dir, "dst.obk")
+	if _, err := runCLI(t, "new", "drawing", src); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if _, err := runCLI(t, "save-as", src, dst); err != nil {
+		t.Fatalf("save-as: %v", err)
+	}
+	out, err := runCLI(t, "info", dst)
+	if err != nil {
+		t.Fatalf("info dst: %v", err)
+	}
+	if !strings.Contains(out, "type: drawing") || !strings.Contains(out, "name: dst") {
+		t.Errorf("copied package info = %q, want type: drawing and name: dst", out)
+	}
+}
+
+func TestOpenReportsIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "p.obk")
+	if _, err := runCLI(t, "new", "part", path); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	out, err := runCLI(t, "open", path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !strings.Contains(out, "opened part") {
+		t.Errorf("open output = %q, want 'opened part'", out)
+	}
+}
+
+func TestUsageErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no command", nil},
+		{"unknown command", []string{"frobnicate"}},
+		{"unknown type", []string{"new", "bogus", "/tmp/x.obk"}},
+		{"new missing path", []string{"new", "part"}},
+		{"info missing path", []string{"info"}},
+		{"save-as one arg", []string{"save-as", "/tmp/a.obk"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := runCLI(t, tc.args...); err == nil {
+				t.Errorf("run(%v) = nil error, want a usage error", tc.args)
+			}
+		})
+	}
+}

--- a/cmd/oblikovati-cli/cmd_inspect.go
+++ b/cmd/oblikovati-cli/cmd_inspect.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/persistence"
+)
+
+// cmdOpen loads the package at path through the real open flow (the store-backed
+// workspace) and reports the reconstructed document's identity — proving the file
+// round-trips into a live document, which is what an e2e open test asserts.
+func cmdOpen(args []string, out io.Writer) error {
+	if len(args) != 1 {
+		return fmt.Errorf("open: expected <path>, got %d arg(s)", len(args))
+	}
+	path := args[0]
+	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	d, err := ws.Open(path, true)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	fmt.Fprintf(out, "opened %s %q from %s\n", d.DocumentType(), d.DisplayName(), path)
+	return nil
+}
+
+// manifestReport is the JSON shape printed by `info --json`, so e2e tests can parse a
+// fixture's identity without scraping plain text.
+type manifestReport struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Type          string `json:"type"`
+	Name          string `json:"name"`
+}
+
+// cmdInfo reads the package manifest at path and prints its identity — schema
+// version, document kind, display name — without reconstructing a full document.
+func cmdInfo(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("info", flag.ContinueOnError)
+	fs.SetOutput(out)
+	asJSON := fs.Bool("json", false, "print the manifest as a JSON object")
+	// Reorder so the --json flag may sit before OR after the path; Go's flag package
+	// otherwise stops at the first positional argument.
+	flags, operands := partitionFlags(args)
+	if err := fs.Parse(flags); err != nil {
+		return err
+	}
+	if len(operands) != 1 {
+		return fmt.Errorf("info: expected <path>, got %d arg(s)", len(operands))
+	}
+	report, err := readManifest(operands[0])
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		return json.NewEncoder(out).Encode(report)
+	}
+	fmt.Fprintf(out, "schema version: %d\ntype: %s\nname: %s\n",
+		report.SchemaVersion, report.Type, report.Name)
+	return nil
+}
+
+// partitionFlags splits args into dash-prefixed flags and bare operands, so a
+// subcommand can accept its flag in any position. It assumes flags are booleans (no
+// separate value token), which holds for every oblikovati-cli flag today.
+func partitionFlags(args []string) (flags, operands []string) {
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			flags = append(flags, a)
+			continue
+		}
+		operands = append(operands, a)
+	}
+	return flags, operands
+}
+
+// readManifest opens the package and projects its manifest into a manifestReport,
+// translating the persisted DocumentType code into its stable name.
+func readManifest(path string) (manifestReport, error) {
+	pkg, err := persistence.OpenPackage(path)
+	if err != nil {
+		return manifestReport{}, fmt.Errorf("info: %w", err)
+	}
+	m, err := pkg.Manifest()
+	if err != nil {
+		return manifestReport{}, fmt.Errorf("info: %w", err)
+	}
+	return manifestReport{
+		SchemaVersion: m.SchemaVersion,
+		Type:          doc.DocumentType(m.DocumentType).String(),
+		Name:          m.DisplayName,
+	}, nil
+}

--- a/cmd/oblikovati-cli/cmd_new.go
+++ b/cmd/oblikovati-cli/cmd_new.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/persistence"
+)
+
+// cmdNew creates a document of the named kind and saves it as an .obk package at
+// path, the core fixture-generation command:
+//
+//	oblikovati-cli new part fixtures/bracket.obk
+func cmdNew(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("new", flag.ContinueOnError)
+	fs.SetOutput(out)
+	seed := fs.Bool("seed", false, "add a sketch + user parameter to a part (in-memory only; not persisted until M07)")
+	flags, operands := partitionFlags(args)
+	if err := fs.Parse(flags); err != nil {
+		return err
+	}
+	if len(operands) != 2 {
+		return fmt.Errorf("new: expected <type> <path>, got %d arg(s); see `oblikovati-cli help`", len(operands))
+	}
+	t, err := doc.ParseDocumentType(operands[0])
+	if err != nil {
+		return fmt.Errorf("new: %w", err)
+	}
+	path := withPackageExt(operands[1])
+	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	d, err := createDocument(ws, t, path, *seed, out)
+	if err != nil {
+		return err
+	}
+	if err := ws.Save(d); err != nil {
+		return fmt.Errorf("new: save %q: %w", path, err)
+	}
+	fmt.Fprintf(out, "created %s %q at %s\n", t, d.DisplayName(), path)
+	return nil
+}
+
+// createDocument adds a document of kind t to ws. A part is realized with a component
+// definition (so --seed has somewhere to write); other kinds use the default content
+// and ignore --seed.
+func createDocument(ws *doc.Workspace, t doc.DocumentType, path string, seed bool, out io.Writer) (*doc.Document, error) {
+	if t != doc.Part {
+		if seed {
+			fmt.Fprintln(out, "note: --seed applies only to parts; ignored")
+		}
+		d, err := ws.Add(t, path, true)
+		if err != nil {
+			return nil, fmt.Errorf("new: %w", err)
+		}
+		return d, nil
+	}
+	d, err := compdef.AddPart(ws, path, true)
+	if err != nil {
+		return nil, fmt.Errorf("new: %w", err)
+	}
+	if seed {
+		seedPart(d, out)
+	}
+	return d, nil
+}
+
+// seedPart populates a part with a user parameter and a sketch so a fixture is not a
+// bare shell. NOTE: model streams are not yet persisted (only the manifest is — see
+// persistence/store.go), so this content round-trips through save→reopen: the recipe
+// (parameter + sketch + extrude) is recomputed into the same solid on open (ADR-0020).
+func seedPart(d *doc.Document, out io.Writer) {
+	def, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return
+	}
+	_, _ = def.Parameters().AddUserParameter("width", "4 cm")
+	sk := def.Sketches().Add(sketch.XYPlane())
+	seedRectangle(sk, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+	fmt.Fprintln(out, "note: --seed builds a 4×3×5 extruded block (parameter + sketch + extrude); it round-trips through save/open")
+}
+
+// seedRectangle adds a closed w×h rectangle from four corner-sharing points.
+func seedRectangle(sk *sketch.Sketch, w, h float64) {
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(w, 0))
+	c2 := sk.Points().Add(math.P2(w, h))
+	c3 := sk.Points().Add(math.P2(0, h))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}
+
+// withPackageExt returns path with the [doc.PackageExtension] suffix, appending it
+// when absent so generated fixtures share one predictable extension. A path that
+// already ends in .obk is returned unchanged.
+func withPackageExt(path string) string {
+	if strings.EqualFold(filepath.Ext(path), doc.PackageExtension) {
+		return path
+	}
+	return path + doc.PackageExtension
+}

--- a/cmd/oblikovati-cli/cmd_saveas.go
+++ b/cmd/oblikovati-cli/cmd_saveas.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/persistence"
+)
+
+// cmdSaveAs opens src and re-saves it under dst, exercising the open→save-as
+// round-trip (the rename/copy path) end to end:
+//
+//	oblikovati-cli save-as fixtures/bracket.obk fixtures/copy.obk
+func cmdSaveAs(args []string, out io.Writer) error {
+	if len(args) != 2 {
+		return fmt.Errorf("save-as: expected <src> <dst>, got %d arg(s)", len(args))
+	}
+	src, dst := args[0], withPackageExt(args[1])
+	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	d, err := ws.Open(src, true)
+	if err != nil {
+		return fmt.Errorf("save-as: open %q: %w", src, err)
+	}
+	if err := ws.SaveAs(d, dst); err != nil {
+		return fmt.Errorf("save-as: %w", err)
+	}
+	fmt.Fprintf(out, "saved %q as %s\n", d.DisplayName(), dst)
+	return nil
+}

--- a/cmd/oblikovati-cli/main.go
+++ b/cmd/oblikovati-cli/main.go
@@ -1,23 +1,61 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Command oblikovati-cli is the headless entry point — batch processing,
-// translation, and thumbnail export. It links no native code, so it builds and
-// runs with CGO_ENABLED=0 (architecture/ADR-0008).
+// Command oblikovati-cli is the headless entry point — it creates, inspects, and
+// re-saves .obk document packages without a window. It links no native code, so it
+// builds and runs with CGO_ENABLED=0 (architecture/ADR-0008). Its primary job today
+// is generating .obk test-case fixtures for end-to-end tests:
+//
+//	oblikovati-cli new part fixtures/bracket.obk
+//	oblikovati-cli info fixtures/bracket.obk
+//	oblikovati-cli save-as fixtures/bracket.obk fixtures/copy.obk
 package main
 
 import (
-	"log/slog"
+	"fmt"
+	"io"
 	"os"
-
-	"github.com/Oblikovati/oblikovati/build"
 )
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-	log.Info("oblikovati-cli",
-		"version", build.Version,
-		"commit", build.Commit,
-		"date", build.Date,
-		"debug", build.Debug,
-	)
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }
+
+// run dispatches argv (without the program name) to a subcommand, writing
+// user-facing output to out. It returns a non-nil error on bad usage or IO failure;
+// main turns that into a non-zero exit. Keeping the dispatch pure (no os.Exit, an
+// injected writer) is what makes the subcommands table-testable.
+func run(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("oblikovati-cli: no command\n%s", usage)
+	}
+	switch args[0] {
+	case "new":
+		return cmdNew(args[1:], out)
+	case "open":
+		return cmdOpen(args[1:], out)
+	case "info":
+		return cmdInfo(args[1:], out)
+	case "save-as":
+		return cmdSaveAs(args[1:], out)
+	case "version":
+		return cmdVersion(out)
+	case "help", "-h", "--help":
+		fmt.Fprintln(out, usage)
+		return nil
+	default:
+		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|version)", args[0])
+	}
+}
+
+// usage is the one-screen command summary printed on `help` or a usage error.
+const usage = `oblikovati-cli — headless .obk document tool
+
+usage:
+  oblikovati-cli new <part|assembly|drawing|presentation> <path> [--seed]
+  oblikovati-cli open <path>
+  oblikovati-cli info <path> [--json]
+  oblikovati-cli save-as <src> <dst>
+  oblikovati-cli version`

--- a/cmd/oblikovati-cli/version.go
+++ b/cmd/oblikovati-cli/version.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Oblikovati/oblikovati/build"
+)
+
+// cmdVersion prints the build identity as plain text (CLAUDE.md: plain text for
+// user-facing CLI output, JSON only for debugging logs).
+func cmdVersion(out io.Writer) error {
+	fmt.Fprintf(out, "oblikovati-cli %s (commit %s, built %s)\n",
+		build.Version, build.Commit, build.Date)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/Oblikovati/oblikovati
 
 go 1.22
 
-require github.com/Oblikovati/api v0.0.0
+require (
+	github.com/Oblikovati/api v0.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 // github.com/Oblikovati/api is the Apache-2.0 contract, now a sibling repo
 // (../Oblikovati.API). It is resolved for local development via the go.work

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/persistence"
 )
 
 func main() {
@@ -72,7 +73,10 @@ func run(session *app.Session, maxFrames int) error {
 // content: the ribbon lists sketch/create tools, and the browser shows a part with a
 // parameter and a sketch. Clicking Extrude starts the interactive tool.
 func newDemoSession() *app.Session {
-	s := app.NewSession()
+	// A real .obk store so File ▸ Open/Save/Save As hit disk (the headless tests use the
+	// nil-store NewSession). The head injects the concrete store; app depends only on the
+	// doc.Store interface.
+	s := app.NewSessionWithStore(persistence.NewPackageStore())
 	registerCommands(s)
 	seedPart(s)
 	return s

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -32,6 +32,7 @@ void obk_ig_bullet_text(const char* s);
 void obk_ig_set_item_tooltip(const char* s);
 int  obk_ig_input_float(const char* label, float* v);
 int  obk_ig_input_int(const char* label, int* v);
+int  obk_ig_input_text(const char* label, char* buf, int buf_size);
 int  obk_ig_checkbox(const char* label, int* v);
 void obk_ig_begin_disabled(int disabled);
 void obk_ig_end_disabled(void);
@@ -132,6 +133,19 @@ func InputInt(label string, v *int32) bool {
 	c, free := cstr(label)
 	defer free()
 	return C.obk_ig_input_int(c, (*C.int)(v)) != 0
+}
+
+// InputText draws a single-line text field bound to buf, a fixed byte buffer the
+// caller owns across frames; ImGui edits it in place (NUL-terminated, up to
+// len(buf)-1 bytes) and returns true on the frame the text changed. The head's
+// file-path modal is the only string input on the chrome today.
+func InputText(label string, buf []byte) bool {
+	if len(buf) == 0 {
+		return false
+	}
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_input_text(c, (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))) != 0
 }
 
 // Checkbox draws a checkbox; returns true (and writes *v) when toggled.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -49,6 +49,7 @@ void obk_ig_set_item_tooltip(const char* s)  { ImGui::SetItemTooltip("%s", s); }
 // changed this frame and writes the new value back through the pointer.
 int  obk_ig_input_float(const char* label, float* v) { return ImGui::InputFloat(label, v) ? 1 : 0; }
 int  obk_ig_input_int(const char* label, int* v)     { return ImGui::InputInt(label, v) ? 1 : 0; }
+int  obk_ig_input_text(const char* label, char* buf, int buf_size) { return ImGui::InputText(label, buf, (size_t)buf_size) ? 1 : 0; }
 int  obk_ig_checkbox(const char* label, int* v) {
     bool b = (*v != 0);
     bool changed = ImGui::Checkbox(label, &b);

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -44,6 +44,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawViewportPanel(win, s)
 	drawStatusBar(s)
 	drawPreferencesWindow(s)
+	drawFileDialog(s)
 	return activated
 }
 
@@ -99,7 +100,15 @@ func drawMenuBar(s *app.Session) string {
 		if native.MenuItem("New Part") {
 			createNewPart(s)
 		}
-		native.MenuItem("Open")
+		if native.MenuItem("Open") {
+			fileModal.openFor(dialogOpen)
+		}
+		if native.MenuItem("Save") {
+			saveActive(s)
+		}
+		if native.MenuItem("Save As") {
+			fileModal.openFor(dialogSaveAs)
+		}
 		native.EndMenu()
 	}
 	if native.BeginMenu("Edit") {

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "bytes"
+
+// fileDialogMode is which file operation the path modal will perform on confirm. The
+// zero value (dialogClosed) means the modal is not showing.
+type fileDialogMode int
+
+const (
+	dialogClosed fileDialogMode = iota
+	dialogOpen                  // File ▸ Open
+	dialogSaveAs                // File ▸ Save As
+)
+
+// pathBufferLen bounds the path the user can type. ImGui edits the buffer in place,
+// so it is a fixed array, not a growable slice; 512 covers any realistic file path.
+const pathBufferLen = 512
+
+// fileDialog is the head's path-entry modal state: which operation is pending and the
+// path being typed. It is deliberately free of any native/cgo dependency so the
+// open→type→confirm/cancel transitions are unit-testable; the draw method that renders
+// it lives in the cgo file file_dialog_draw.go (the navigate.go split, ADR-0014).
+type fileDialog struct {
+	mode fileDialogMode
+	path [pathBufferLen]byte
+}
+
+// fileAction is what a confirmed dialog asks the chrome to perform. Kind ==
+// dialogClosed means "nothing this frame" (a cancel, or OK on an empty path).
+type fileAction struct {
+	Kind fileDialogMode
+	Path string
+}
+
+// openFor arms the dialog for mode with an empty path. Calling it again re-arms the
+// dialog (e.g. switching from Open to Save As) and clears any prior text.
+func (d *fileDialog) openFor(mode fileDialogMode) {
+	d.mode = mode
+	d.path = [pathBufferLen]byte{}
+}
+
+// isOpen reports whether the modal should render this frame.
+func (d *fileDialog) isOpen() bool { return d.mode != dialogClosed }
+
+// title is the window heading for the current mode.
+func (d *fileDialog) title() string {
+	if d.mode == dialogSaveAs {
+		return "Save As"
+	}
+	return "Open"
+}
+
+// text returns the NUL-trimmed path the user has typed into the buffer.
+func (d *fileDialog) text() string {
+	if i := bytes.IndexByte(d.path[:], 0); i >= 0 {
+		return string(d.path[:i])
+	}
+	return string(d.path[:])
+}
+
+// confirm dismisses the dialog and returns the action for its mode and typed path. A
+// blank path yields a dialogClosed action so the caller never acts on "".
+func (d *fileDialog) confirm() fileAction {
+	path := d.text()
+	mode := d.mode
+	d.cancel()
+	if path == "" {
+		return fileAction{Kind: dialogClosed}
+	}
+	return fileAction{Kind: mode, Path: path}
+}
+
+// cancel dismisses the dialog without an action and clears the typed path.
+func (d *fileDialog) cancel() {
+	d.mode = dialogClosed
+	d.path = [pathBufferLen]byte{}
+}

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -1,0 +1,69 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// fileModal is the chrome's single path-entry dialog (UI state, not model state, so it
+// lives here in the head). File-menu items arm it; drawFileDialog renders it.
+var fileModal fileDialog
+
+// drawFileDialog renders the path modal when armed and applies a confirmed Open/Save As
+// to the session. DrawChrome calls it once per frame. Failures go to stderr — the head
+// has no message box yet (a fast-follow when the notification surface lands).
+func drawFileDialog(s *app.Session) {
+	if !fileModal.isOpen() {
+		return
+	}
+	var act fileAction
+	if native.Begin(fileModal.title()) {
+		native.Text("File path:")
+		native.InputText("##file-path", fileModal.path[:])
+		if native.Button("OK") {
+			act = fileModal.confirm()
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			fileModal.cancel()
+		}
+	}
+	native.End()
+	applyFileAction(s, act)
+}
+
+// applyFileAction performs the confirmed file operation. A successful Save As becomes
+// the document's path, so a later File ▸ Save writes straight through.
+func applyFileAction(s *app.Session, act fileAction) {
+	switch act.Kind {
+	case dialogOpen:
+		if _, err := s.OpenDocument(act.Path); err != nil {
+			fmt.Fprintf(os.Stderr, "open %q: %v\n", act.Path, err)
+		}
+	case dialogSaveAs:
+		if err := s.SaveActiveDocumentAs(act.Path); err != nil {
+			fmt.Fprintf(os.Stderr, "save as %q: %v\n", act.Path, err)
+		}
+	}
+}
+
+// saveActive saves the active document in place, falling back to the Save As modal when
+// it has never been saved (a freshly created "PartN" has no path yet — app.ErrNeedsPath).
+func saveActive(s *app.Session) {
+	err := s.SaveActiveDocument()
+	if errors.Is(err, app.ErrNeedsPath) {
+		fileModal.openFor(dialogSaveAs)
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "save: %v\n", err)
+	}
+}

--- a/head/ui/file_dialog_test.go
+++ b/head/ui/file_dialog_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// typePath simulates the user typing into the modal's in-place buffer — what
+// native.InputText writes each frame — so these tests exercise the state machine
+// without the cgo draw path.
+func (d *fileDialog) typePath(s string) {
+	d.path = [pathBufferLen]byte{}
+	copy(d.path[:], s)
+}
+
+func TestFileDialogConfirmReturnsActionForMode(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogSaveAs)
+	if !d.isOpen() || d.title() != "Save As" {
+		t.Fatalf("openFor(SaveAs): isOpen=%v title=%q", d.isOpen(), d.title())
+	}
+	d.typePath("/models/part.obk")
+	act := d.confirm()
+	if act.Kind != dialogSaveAs || act.Path != "/models/part.obk" {
+		t.Errorf("confirm() = %+v, want SaveAs /models/part.obk", act)
+	}
+	if d.isOpen() {
+		t.Error("dialog should be closed after confirm")
+	}
+}
+
+func TestFileDialogCancelYieldsNoAction(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogOpen)
+	d.typePath("/x.obk")
+	d.cancel()
+	if d.isOpen() {
+		t.Error("cancel should close the dialog")
+	}
+	if d.text() != "" {
+		t.Errorf("cancel should clear the path, got %q", d.text())
+	}
+}
+
+func TestFileDialogConfirmEmptyPathIsNoAction(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogOpen)
+	if act := d.confirm(); act.Kind != dialogClosed {
+		t.Errorf("confirm with empty path = %+v, want dialogClosed", act)
+	}
+}
+
+func TestFileDialogOpenForReArmsAndClears(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogOpen)
+	d.typePath("stale")
+	d.openFor(dialogSaveAs)
+	if d.title() != "Save As" {
+		t.Errorf("title after re-arm = %q, want Save As", d.title())
+	}
+	if d.text() != "" {
+		t.Errorf("re-arm should clear the prior path, got %q", d.text())
+	}
+}
+
+func TestFileDialogTitleDefaultsToOpen(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogOpen)
+	if d.title() != "Open" {
+		t.Errorf("title() = %q, want Open", d.title())
+	}
+}

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -188,6 +188,82 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 
 ## Session log
 
+- **2026-06-02:** **Feature persistence — dress-up family + reference keys.** Added
+  codecs for **fillet, chamfer, shell, draft, thread** to `model/feature/serialize.go`.
+  These reference body edges/faces by **reference key**; the keys are lineage-derived
+  bytes (`topo …ReferenceKey()`), so they serialize as base64 and **re-bind to the
+  regenerated topology after recompute** via `body.FindEdgeByKey`/`FindFaceByKey` — no
+  KeyManager context blob is needed (the earlier plan over-scoped this). Verified:
+  extrude → pick a real edge → fillet → save → reopen → recompute → the fillet's edge
+  key **re-binds** (health Warning = resolved, not Sick). Dress-up values
+  (radius/distance/thickness/angle) persist as evaluated scalars like the extrude
+  distance. No-silent-loss still errors on the remaining uncoded feature kinds (holes,
+  patterns, work features, surfaces, mesh, …). Full suite + `go vet` green.
+- **2026-06-02:** **Feature persistence — extrude (Phase 4 of the YAML recipe).** The
+  feature program now serializes into the recipe via `model/feature/serialize.go`: a
+  per-kind codec (switch) + a `SketchIndexer` seam so features re-bind their input
+  sketch by index. **Extrude** is fully coded (sketch+profile+operation+distance extent
+  +taper); on open the program is rebuilt and `Recompute()` regenerates the solid.
+  Verified end-to-end: part → rectangle sketch → extrude → save → reopen → **identical
+  body** (same range box, 1 body). `compdef.partRecipe.Features` wires it in; `cli new
+  part --seed` now emits a real 4×3×5 block that round-trips. No-silent-loss:
+  `MarshalRecipe` errors on any feature kind without a codec. **Remaining (follow-on,
+  incremental):** codecs for the other ~24 feature kinds (dress-up, holes, patterns,
+  work features, surfaces, …); the dress-up family additionally needs reference-key
+  context persistence (`identity.SaveContextToArray` + `KeyToString`) so edge/face
+  picks rebind after recompute — the machinery is scoped but lands with those codecs.
+  Also captured a model gap: distance extents serialize the evaluated value (parametric
+  distance expressions need the dimension-driven extent API). Full suite + race green.
+- **2026-06-02:** **Sketch persistence (Phase 3 of the YAML recipe).** Sketches now
+  round-trip in the `.obk` recipe: `model/sketch/serialize.go` + `serialize_restore.go`
+  capture the host plane, every constrainable point, all curve entities (line/circle/
+  arc/ellipse/spline + standalone points), and **all** geometric (~17 kinds) and
+  dimensional (distance/radius/diameter/angle/arc-length) constraints. Points are
+  recorded once and referenced by id, so a **shared corner stays one point** — a
+  rectangle reopens as 4 points / 4 lines / 1 closed profile, not 8 points. Added
+  point-accepting `Add` cores to the entity collections and a `refs []Entity` to
+  `DimensionConstraint` (a dimension now records what it measures). No-silent-loss:
+  `MarshalRecipe` errors on blocks / any uncoded entity/constraint kind. Wired into
+  `compdef` `partRecipe.Sketches`. Verified: a part with a constrained sketch survives
+  save→YAML→open through the real store; `cli new part --seed` now persists its sketch.
+  Full suite + `go vet` green. **Remaining:** Phase 4 — the feature program + reference
+  keys (the geometry-producing features), still dropped on save until then.
+- **2026-06-02:** **Git-friendly YAML document format + parameter persistence (user
+  direction; ADR-0020).** Replaced the ZIP `.obk` container with a **single YAML text
+  file** per document so models live in git with line-level diffs. New
+  `persistence/yamlcodec` is the sole importer of `gopkg.in/yaml.v3` (the GPL core's
+  first third-party dep, wrapped per CLAUDE.md) and owns the on-disk shape: manifest at
+  top level, recipe as a **native nested node** (not an escaped blob), binary data
+  sections base64. `persistence` reworked (io/package/manifest/migration/compaction);
+  schema bumped **1→2**; legacy ZIP `.obk` rejected with a clear message (no migration —
+  only fixtures existed). **Recipe round-trip:** a new `doc.RecipeContent` seam + a
+  content-factory registry (`doc.RegisterContentFactory`, populated by `compdef.init`)
+  lets the store reconstruct a live part on open; `compdef/serialize.go` persists/restores
+  **parameters** (creation order, incl. dependent expressions), **display units**, and
+  the **end-of-part** marker, then `Recompute()`s. Proven: `cli new part p.obk --seed`
+  → `cat` shows readable YAML → `save-as` reopens and re-emits the `width` param + units
+  identically. `go vet` + full core suite green. **KNOWN GAP (next):** sketches (Phase 3)
+  and the feature program + reference keys (Phase 4) are NOT yet in the recipe, so a
+  part's geometry is currently dropped on save — strict no-silent-loss guard lands with
+  those phases.
+- **2026-06-02:** **Document open/save flow wired through the CLI and UI head (user
+  direction, e2e fixtures).** The M03 model lifecycle (`Workspace.Open/Save/SaveAs`,
+  `persistence.PackageStore`) existed but nothing drove it — `app.NewSession` passed a
+  nil store, so Save/Open always errored. Added `app.NewSessionWithStore(doc.Store)` (app
+  still depends only on the interface; the binaries inject `persistence.PackageStore`) and
+  thin Session verbs `OpenDocument` / `SaveActiveDocument` (returns `ErrNeedsPath` when the
+  doc has no `.obk` path yet) / `SaveActiveDocumentAs`. New **`oblikovati-cli`** fixture
+  generator: `new <type> <path> [--seed]`, `open`, `info [--json]`, `save-as`, `version`,
+  sharing one `doc.ParseDocumentType` with the add-in router (de-duped). The head's File
+  menu gained working **Open / Save / Save As** via a pure-Go `fileDialog` state machine
+  (unit-tested) + one new cgo `native.InputText` binding; `newDemoSession` now injects a
+  real store. Fixed a latent wart: `doc.Restore` made every persisted name an explicit
+  override, freezing a *derived* name across Save As — now a derived name stays derived and
+  follows the file (regression test in `persistence/store_test.go`). **Known limit:**
+  `PackageStore.Save` still persists only the manifest (type + name), so `--seed` content
+  and model streams do not round-trip until stream persistence (M07+); `.obk` fixtures are
+  type+name-bearing shells today. `go vet` + race suite green (golangci-lint not run — not
+  installed locally).
 - **2026-06-01:** **Coincident point-to-curve / midpoint (M05 UI, user direction).** Bug:
   coincident only worked end-to-end (point-to-point) — picking a point and a line/midpoint
   added nothing, because the model only had point-to-point coincident and the tool only

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/param"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
+)
+
+// init registers the real part content with the document layer so opening a part
+// document reconstructs a live PartComponentDefinition (with its recipe machinery),
+// not the identity-only stub (see doc.RegisterContentFactory).
+func init() {
+	doc.RegisterContentFactory(doc.Part, func() doc.Content { return NewPartComponentDefinition() })
+}
+
+// var assertion: a part definition is recipe-bearing content (doc.RecipeContent), so
+// the store persists and restores its model on save/open.
+var _ doc.RecipeContent = (*PartComponentDefinition)(nil)
+
+// partRecipe is the YAML shape of a part's persisted recipe (ADR-0020). It is the
+// document's restorable state: display units, the end-of-part marker, and the
+// parameters. Sketches and features join it in later phases. The realized B-rep is
+// never stored — ApplyRecipe recomputes it.
+type partRecipe struct {
+	Units      map[string]string     `yaml:"units,omitempty"`
+	EndOfPart  *int                  `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
+	Parameters []parameterRecipe     `yaml:"parameters,omitempty"`
+	Sketches   []sketch.SketchData   `yaml:"sketches,omitempty"`
+	Features   []feature.FeatureData `yaml:"features,omitempty"`
+}
+
+// sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
+// can record and re-bind their input sketch by index.
+type sketchIndex struct{ sketches *sketch.Sketches }
+
+func (si sketchIndex) IndexOf(s *sketch.Sketch) (int, bool) {
+	for i := 0; i < si.sketches.Count(); i++ {
+		if si.sketches.Item(i) == s {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (si sketchIndex) At(i int) (*sketch.Sketch, bool) {
+	if i < 0 || i >= si.sketches.Count() {
+		return nil, false
+	}
+	return si.sketches.Item(i), true
+}
+
+// parameterRecipe is one parameter: an editable parameter carries an Expression; a
+// read-only parameter (reference/derived) carries a measured Value + Unit.
+type parameterRecipe struct {
+	Name       string  `yaml:"name"`
+	Kind       string  `yaml:"kind"`
+	Expression string  `yaml:"expression,omitempty"`
+	Value      float64 `yaml:"value,omitempty"`
+	Unit       string  `yaml:"unit,omitempty"`
+}
+
+// unitCategories are the display-unit categories a document persists, in a stable
+// order. The values are stable enum ids; the names come from param.Unit.String().
+var unitCategories = []param.Unit{
+	param.Length, param.Angle, param.Area, param.Volume, param.Mass, param.Time,
+}
+
+// MarshalRecipe renders the part's recipe as YAML bytes (doc.RecipeContent).
+func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
+	sketches, err := d.sketches.MarshalRecipe()
+	if err != nil {
+		return nil, fmt.Errorf("compdef: marshal sketches: %w", err)
+	}
+	features, err := d.features.MarshalRecipe(sketchIndex{d.sketches})
+	if err != nil {
+		return nil, fmt.Errorf("compdef: marshal features: %w", err)
+	}
+	r := partRecipe{
+		Units:      d.unitsRecipe(),
+		Parameters: d.parametersRecipe(),
+		Sketches:   sketches,
+		Features:   features,
+	}
+	if d.eop != endOfPartAtEnd {
+		eop := d.eop
+		r.EndOfPart = &eop
+	}
+	return yamlcodec.Marshal(r)
+}
+
+// ApplyRecipe restores the part from recipe YAML and recomputes (doc.RecipeContent).
+func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
+	var r partRecipe
+	if err := yamlcodec.Unmarshal(model, &r); err != nil {
+		return fmt.Errorf("compdef: parse part recipe: %w", err)
+	}
+	if err := d.applyUnits(r.Units); err != nil {
+		return err
+	}
+	if err := d.applyParameters(r.Parameters); err != nil {
+		return err
+	}
+	if err := d.sketches.ApplyRecipe(r.Sketches); err != nil {
+		return fmt.Errorf("compdef: restore sketches: %w", err)
+	}
+	if err := d.features.ApplyRecipe(r.Features, sketchIndex{d.sketches}); err != nil {
+		return fmt.Errorf("compdef: restore features: %w", err)
+	}
+	if r.EndOfPart != nil {
+		d.SetEndOfPart(*r.EndOfPart)
+	}
+	d.Recompute()
+	return nil
+}
+
+// unitsRecipe captures the preferred display-unit name for each category.
+func (d *PartComponentDefinition) unitsRecipe() map[string]string {
+	out := make(map[string]string, len(unitCategories))
+	for _, cat := range unitCategories {
+		out[cat.String()] = d.units.PreferredName(cat)
+	}
+	return out
+}
+
+// applyUnits restores the preferred display unit for each named category. An unknown
+// category name or an invalid unit is a corrupt-recipe error (no silent loss).
+func (d *PartComponentDefinition) applyUnits(units map[string]string) error {
+	for name, unitName := range units {
+		cat, ok := unitCategoryByName(name)
+		if !ok {
+			return fmt.Errorf("compdef: unknown unit category %q in recipe", name)
+		}
+		if err := d.units.SetPreferred(cat, unitName); err != nil {
+			return fmt.Errorf("compdef: restore units: %w", err)
+		}
+	}
+	return nil
+}
+
+// parametersRecipe captures every parameter in creation order (a valid order to
+// re-add: an expression can only reference parameters created before it).
+func (d *PartComponentDefinition) parametersRecipe() []parameterRecipe {
+	all := d.params.All()
+	if len(all) == 0 {
+		return nil
+	}
+	out := make([]parameterRecipe, 0, len(all))
+	for _, p := range all {
+		pr := parameterRecipe{Name: p.Name(), Kind: p.Kind().String()}
+		if p.Kind().Editable() {
+			pr.Expression = p.Expression()
+		} else {
+			pr.Value, pr.Unit = p.Value().Value, p.Value().Unit.String()
+		}
+		out = append(out, pr)
+	}
+	return out
+}
+
+// applyParameters re-adds each parameter in recipe order. A parse error (bad
+// expression, duplicate name, unknown kind/unit) aborts the load rather than dropping
+// the parameter silently.
+func (d *PartComponentDefinition) applyParameters(params []parameterRecipe) error {
+	for _, pr := range params {
+		if err := d.addParameter(pr); err != nil {
+			return fmt.Errorf("compdef: restore parameter %q: %w", pr.Name, err)
+		}
+	}
+	return nil
+}
+
+// addParameter re-creates one parameter from its recipe entry.
+func (d *PartComponentDefinition) addParameter(pr parameterRecipe) error {
+	switch pr.Kind {
+	case param.UserParam.String():
+		_, err := d.params.AddUserParameter(pr.Name, pr.Expression)
+		return err
+	case param.ModelParam.String():
+		_, err := d.params.AddModelParameter(pr.Name, pr.Expression)
+		return err
+	case param.TableParam.String():
+		_, err := d.params.AddTableParameter(pr.Name, pr.Expression)
+		return err
+	case param.ReferenceParam.String():
+		return d.addReadOnlyParameter(pr, d.params.AddReferenceParameter)
+	case param.DerivedParam.String():
+		return d.addReadOnlyParameter(pr, d.params.AddDerivedParameter)
+	default:
+		return fmt.Errorf("unknown parameter kind %q (want user|model|table|reference|derived)", pr.Kind)
+	}
+}
+
+// addReadOnlyParameter rebuilds a read-only parameter's measured quantity from its
+// value + unit and adds it through the given collection method.
+func (d *PartComponentDefinition) addReadOnlyParameter(pr parameterRecipe, add func(string, param.Quantity) (*param.Parameter, error)) error {
+	unit, ok := unitCategoryByName(pr.Unit)
+	if !ok {
+		return fmt.Errorf("unknown unit %q", pr.Unit)
+	}
+	_, err := add(pr.Name, param.Q(pr.Value, unit))
+	return err
+}
+
+// unitCategoryByName maps a category name (param.Unit.String()) back to its Unit.
+func unitCategoryByName(name string) (param.Unit, bool) {
+	for _, cat := range unitCategories {
+		if cat.String() == name {
+			return cat, true
+		}
+	}
+	return 0, false
+}

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/health"
+	"github.com/Oblikovati/oblikovati/model/param"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/persistence"
+)
+
+// reopenThroughStore saves ws's active document to a temp .obk and reopens it in a
+// fresh, store-backed workspace — the real save→YAML→open path.
+func reopenThroughStore(t *testing.T, d *doc.Document) *compdef.PartComponentDefinition {
+	t.Helper()
+	store := persistence.NewPackageStore()
+	path := filepath.Join(t.TempDir(), "part.obk")
+	saveWS := doc.NewWorkspace(store)
+	// Re-register d under the store-backed workspace identity, then save.
+	saved, err := compdef.AddPart(saveWS, path, true)
+	if err != nil {
+		t.Fatalf("AddPart(save): %v", err)
+	}
+	// Copy the recipe across by marshaling the source and applying onto the saved doc.
+	src := d.Content().(*compdef.PartComponentDefinition)
+	model, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if err := saved.Content().(*compdef.PartComponentDefinition).ApplyRecipe(model); err != nil {
+		t.Fatalf("ApplyRecipe(seed): %v", err)
+	}
+	if err := saveWS.Save(saved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	def, ok := reopened.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		t.Fatalf("reopened content is %T, want *PartComponentDefinition", reopened.Content())
+	}
+	return def
+}
+
+func TestParametersSurviveRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, err := compdef.AddPart(ws, "Part1", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := d.Content().(*compdef.PartComponentDefinition)
+	if _, err := def.Parameters().AddUserParameter("width", "4 cm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	if _, err := def.Parameters().AddUserParameter("height", "width / 2"); err != nil {
+		t.Fatalf("AddUserParameter(height): %v", err)
+	}
+
+	reopened := reopenThroughStore(t, d)
+
+	width, ok := reopened.Parameters().ByName("width")
+	if !ok || width.Expression() != "4 cm" {
+		t.Errorf("width after reopen = %v ok=%v, want expression 4 cm", width, ok)
+	}
+	// A dependent expression must survive too (proves creation-order restore is valid).
+	height, ok := reopened.Parameters().ByName("height")
+	if !ok || height.Expression() != "width / 2" {
+		t.Errorf("height after reopen = %v ok=%v, want expression 'width / 2'", height, ok)
+	}
+	if got := reopened.Parameters().Count(); got != 2 {
+		t.Errorf("parameter count after reopen = %d, want 2", got)
+	}
+}
+
+func TestSketchGeometrySurvivesRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	// A closed rectangle from four corner-sharing lines.
+	c0 := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	c1 := sk.Lines().AddByTwoPoints(math.P2(4, 0), math.P2(4, 3))
+	sk.GeometricConstraints().AddPerpendicular(c0, c1)
+
+	reopened := reopenThroughStore(t, d)
+	if got := reopened.Sketches().Count(); got != 1 {
+		t.Fatalf("sketch count after reopen = %d, want 1", got)
+	}
+	rs := reopened.Sketches().Item(0)
+	if got := rs.Lines().Count(); got != 2 {
+		t.Errorf("line count after reopen = %d, want 2", got)
+	}
+	if got := rs.GeometricConstraints().Count(); got != 1 {
+		t.Errorf("constraint count after reopen = %d, want 1", got)
+	}
+}
+
+func TestExtrudedSolidSurvivesRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	rectangle(sk, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+	before := def.RangeBox()
+	if len(def.SurfaceBodies().All()) != 1 {
+		t.Fatalf("expected 1 body before save, got %d", len(def.SurfaceBodies().All()))
+	}
+
+	reopened := reopenThroughStore(t, d)
+	bodies := reopened.SurfaceBodies().All()
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 body after reopen+recompute, got %d (the extrude must regenerate)", len(bodies))
+	}
+	after := reopened.RangeBox()
+	if !after.Min.IsEqualTo(before.Min, 1e-6) || !after.Max.IsEqualTo(before.Max, 1e-6) {
+		t.Errorf("range box after reopen = [%v..%v], want [%v..%v]",
+			after.Min, after.Max, before.Min, before.Max)
+	}
+}
+
+// rectangle adds a closed w×h rectangle (one profile) at the sketch origin, with the
+// corners as shared points so the loop is structurally closed (a shared point IS a
+// coincidence) — the same way the head's rectangle tool builds it.
+func rectangle(s *sketch.Sketch, w, h float64) {
+	c0 := s.Points().Add(math.P2(0, 0))
+	c1 := s.Points().Add(math.P2(w, 0))
+	c2 := s.Points().Add(math.P2(w, h))
+	c3 := s.Points().Add(math.P2(0, h))
+	s.Lines().Add(c0, c1)
+	s.Lines().Add(c1, c2)
+	s.Lines().Add(c2, c3)
+	s.Lines().Add(c3, c0)
+}
+
+func TestFilletEdgeKeyRebindsAfterReopen(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	rectangle(sk, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+
+	// Pick a real edge off the extruded body and fillet it by reference key.
+	edgeKey := def.SurfaceBodies().All()[0].Edges()[0].ReferenceKey()
+	fillet := feature.NewDressUpFeatures(def.Features()).
+		AddFillet([][]byte{edgeKey}, func() float64 { return 0.2 })
+	def.Recompute()
+	if fillet.Health().Status != health.Warning {
+		t.Fatalf("fillet health before save = %v, want Warning (edge resolved, geometry deferred)", fillet.Health().Status)
+	}
+
+	reopened := reopenThroughStore(t, d)
+	// The reopened extrude regenerates the body with the same lineage, so the fillet's
+	// edge key must re-bind — proving reference keys survive save→reopen.
+	got, ok := featureByKind(reopened.Features(), "fillet")
+	if !ok {
+		t.Fatal("fillet feature missing after reopen")
+	}
+	if got.Health().Status != health.Warning {
+		t.Errorf("fillet health after reopen = %v, want Warning (edge key must re-bind, not be lost/Sick)", got.Health().Status)
+	}
+}
+
+// featureByKind returns the first feature of the given kind.
+func featureByKind(fs *feature.PartFeatures, kind string) (*feature.PartFeature, bool) {
+	for i := 0; i < fs.Count(); i++ {
+		if fs.Item(i).Kind() == kind {
+			return fs.Item(i), true
+		}
+	}
+	return nil, false
+}
+
+func TestLengthUnitSurvivesRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	if err := def.SetLengthUnit("in"); err != nil {
+		t.Fatalf("SetLengthUnit: %v", err)
+	}
+
+	reopened := reopenThroughStore(t, d)
+	if got := reopened.Units().PreferredName(param.Length); got != "in" {
+		t.Errorf("length unit after reopen = %q, want in", got)
+	}
+}

--- a/model/doc/content.go
+++ b/model/doc/content.go
@@ -17,6 +17,35 @@ type Content interface {
 	DocumentType() DocumentType
 }
 
+// RecipeContent is the optional interface real content implements to persist and
+// restore its modeling recipe (parameters, sketches, features) as opaque YAML bytes.
+// The store serializes the recipe for content that implements it and restores it on
+// open; a bare stub (which implements only [Content]) round-trips identity alone.
+// The recipe schema is owned by the content's own package (e.g. model/compdef), not
+// by doc or persistence — keeping the format layer content-agnostic (ADR-0020).
+type RecipeContent interface {
+	Content
+	// MarshalRecipe renders the content's recipe as YAML bytes.
+	MarshalRecipe() ([]byte, error)
+	// ApplyRecipe restores the content from recipe YAML bytes (and recomputes).
+	ApplyRecipe(model []byte) error
+}
+
+// contentFactories holds the constructor for each document kind's REAL content,
+// registered by the owning package's init (e.g. model/compdef). It is the seam that
+// lets [Restore] rebuild live content — with its recipe machinery — without doc
+// importing the heavy model packages (which would cycle). Writes happen at init
+// (single-threaded); reads happen later.
+var contentFactories = map[DocumentType]func() Content{}
+
+// RegisterContentFactory installs the constructor for a kind's real content. Call it
+// from an init() in the package that owns the content type, so any binary that imports
+// that package gets live content on open. Without a registered factory, [newContent]
+// falls back to the identity-only stub.
+func RegisterContentFactory(t DocumentType, factory func() Content) {
+	contentFactories[t] = factory
+}
+
 // PartComponentDefinition is the stub for a part's modeling content: sketches,
 // features and the resulting B-rep body (M07). Modernizes COM
 // PartComponentDefinition.

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -95,7 +95,14 @@ func (d *Document) DisplayName() string {
 	if d.displayName != "" {
 		return d.displayName
 	}
-	base := filepath.Base(d.fullDocumentName)
+	return derivedDisplayName(d.fullDocumentName)
+}
+
+// derivedDisplayName is the human name implied by a full document name — its base
+// without directory or extension — used as the fallback when no explicit override
+// is set, and by [Restore] to tell a persisted derived name from a custom one.
+func derivedDisplayName(fullDocumentName string) string {
+	base := filepath.Base(fullDocumentName)
 	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 

--- a/model/doc/document_type_parse.go
+++ b/model/doc/document_type_parse.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseDocumentType maps a kind name to its [DocumentType]. It is the inverse of
+// [DocumentType.String] and the single shared parser for the in-process drivers
+// (the add-in router's documents.create and the oblikovati-cli fixture commands),
+// so the name↔kind table lives in exactly one place. The match is case-insensitive
+// and trims surrounding whitespace.
+//
+//	t, err := doc.ParseDocumentType("Part") // t == doc.Part
+func ParseDocumentType(name string) (DocumentType, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "part":
+		return Part, nil
+	case "assembly":
+		return Assembly, nil
+	case "drawing":
+		return Drawing, nil
+	case "presentation":
+		return Presentation, nil
+	default:
+		return Unknown, fmt.Errorf("doc: unknown document type %q (want part|assembly|drawing|presentation)", name)
+	}
+}

--- a/model/doc/store.go
+++ b/model/doc/store.go
@@ -23,10 +23,15 @@ type Store interface {
 	Exists(fullDocumentName string) bool
 }
 
-// newContent builds the empty content stub for a document kind. Save/Load and the
-// create-from-template path use it so a kind always pairs with matching content.
-// The concrete content types fill in from M07/M11/M14/M16.
+// newContent builds the content object for a document kind. It prefers a real content
+// factory registered by the owning package (e.g. model/compdef via
+// [RegisterContentFactory]) so Load reconstructs live, recipe-bearing content; absent a
+// factory it returns the identity-only stub. Save/Load and the create-from-template
+// path use it so a kind always pairs with matching content.
 func newContent(t DocumentType) (Content, error) {
+	if factory, ok := contentFactories[t]; ok {
+		return factory(), nil
+	}
 	switch t {
 	case Part:
 		return &PartComponentDefinition{}, nil
@@ -51,6 +56,12 @@ func Restore(t DocumentType, fullDocumentName, displayName string) (*Document, e
 		return nil, err
 	}
 	d := newDocument(t, fullDocumentName, content, true)
-	d.displayName = displayName
+	// Only carry an explicit override when the persisted name diverges from what the
+	// file path implies. A derived name must stay derived so it follows the file
+	// across Save As — otherwise reopening would freeze the old base name (e.g.
+	// `save-as a.obk b.obk` would reopen still calling the document "a").
+	if displayName != "" && displayName != derivedDisplayName(fullDocumentName) {
+		d.displayName = displayName
+	}
 	return d, nil
 }

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// This file serializes the ordered feature program into the git-friendly YAML recipe
+// (ADR-0020) and rebuilds it on open, then the part recompute regenerates geometry.
+// Features reference sketches by index (resolved through a [SketchIndexer]); features
+// that reference realized topology (dress-up edges/faces by reference key) get their
+// codecs — and the key-context persistence — as those kinds are added. Any feature
+// kind without a codec makes Save error rather than drop the feature silently.
+
+// FeatureData is the serializable form of one history feature. Exactly one payload
+// pointer is set, matching Kind.
+type FeatureData struct {
+	Kind       string         `yaml:"kind"`
+	Name       string         `yaml:"name,omitempty"`
+	Suppressed bool           `yaml:"suppressed,omitempty"`
+	Extrude    *ExtrudeData   `yaml:"extrude,omitempty"`
+	Fillet     *EdgeDressData `yaml:"fillet,omitempty"`
+	Chamfer    *EdgeDressData `yaml:"chamfer,omitempty"`
+	Shell      *FaceDressData `yaml:"shell,omitempty"`
+	Draft      *FaceDressData `yaml:"draft,omitempty"`
+	Thread     *ThreadData    `yaml:"thread,omitempty"`
+}
+
+// EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
+// picked edges as reference keys plus the scalar value. The keys are base64 because
+// they are opaque lineage-derived bytes — the one non-text field (ADR-0020); they
+// re-bind to the regenerated edges after recompute (kernel topo FindEdgeByKey).
+type EdgeDressData struct {
+	Edges []string `yaml:"edges"`
+	Value float64  `yaml:"value"`
+}
+
+// FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked
+// faces as reference keys plus the scalar value.
+type FaceDressData struct {
+	Faces []string `yaml:"faces"`
+	Value float64  `yaml:"value"`
+}
+
+// ThreadData tags a single cylindrical face (reference key) with a thread designation.
+type ThreadData struct {
+	Face        string `yaml:"face"`
+	Designation string `yaml:"designation"`
+}
+
+// ExtrudeData is an extrude's recipe: which sketch profile, the boolean operation, and
+// the distance extent. The distance is the evaluated growth (a fixed value on reopen;
+// parametric distance expressions arrive with the dimension-driven extent API).
+type ExtrudeData struct {
+	Sketch    int     `yaml:"sketch"`
+	Profile   int     `yaml:"profile"`
+	Operation string  `yaml:"operation"`
+	Distance  float64 `yaml:"distance"`
+	Taper     float64 `yaml:"taper,omitempty"`
+}
+
+// SketchIndexer maps between a sketch pointer and its index in the part, so a feature
+// can record which sketch it consumes (marshal) and re-bind it (restore).
+type SketchIndexer interface {
+	IndexOf(*sketch.Sketch) (int, bool)
+	At(int) (*sketch.Sketch, bool)
+}
+
+// MarshalRecipe projects the feature program into its serializable form, in history
+// order, erroring on any feature kind without a codec (no silent loss).
+func (fs *PartFeatures) MarshalRecipe(sk SketchIndexer) ([]FeatureData, error) {
+	out := make([]FeatureData, 0, fs.Count())
+	for i := 0; i < fs.Count(); i++ {
+		pf := fs.Item(i)
+		fd, err := serializeFeature(pf, sk)
+		if err != nil {
+			return nil, fmt.Errorf("feature %d (%s): %w", i, pf.Kind(), err)
+		}
+		out = append(out, fd)
+	}
+	return out, nil
+}
+
+func serializeFeature(pf *PartFeature, sk SketchIndexer) (FeatureData, error) {
+	fd := FeatureData{Kind: pf.Kind(), Name: pf.name, Suppressed: pf.suppress}
+	switch f := pf.feature.(type) {
+	case *ExtrudeFeature:
+		ed, err := serializeExtrude(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Extrude = ed
+	case *FilletFeature:
+		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius)}
+	case *ChamferFeature:
+		fd.Chamfer = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Distance)}
+	case *ShellFeature:
+		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness)}
+	case *FaceDraftFeature:
+		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle)}
+	case *ThreadFeature:
+		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation}
+	default:
+		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
+	}
+	return fd, nil
+}
+
+func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, error) {
+	if def.Extent.Type != DistanceExtent {
+		return nil, fmt.Errorf("only distance extents are serializable (got extent type %d)", def.Extent.Type)
+	}
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("extrude references a sketch that is not in the part")
+	}
+	op, err := operationName(def.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return &ExtrudeData{
+		Sketch:    idx,
+		Profile:   def.ProfileIndex,
+		Operation: op,
+		Distance:  def.Extent.distance(),
+		Taper:     def.Taper,
+	}, nil
+}
+
+// ApplyRecipe rebuilds the feature program from its serialized form, in order. The
+// caller recomputes afterward to regenerate geometry.
+func (fs *PartFeatures) ApplyRecipe(data []FeatureData, sk SketchIndexer) error {
+	for i, fd := range data {
+		if err := restoreFeature(fs, fd, sk); err != nil {
+			return fmt.Errorf("feature %d (%s): %w", i, fd.Kind, err)
+		}
+	}
+	return nil
+}
+
+func restoreFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer) error {
+	pf, err := buildFeature(fs, fd, sk)
+	if err != nil {
+		return err
+	}
+	applyFeatureState(pf, fd)
+	return nil
+}
+
+// buildFeature reconstructs one feature from its payload, erroring on an unknown kind
+// or a missing payload (no silent loss). Dress-up edge/face keys re-bind to the
+// regenerated topology on the next recompute (kernel topo FindEdgeByKey/FindFaceByKey).
+func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer) (*PartFeature, error) {
+	du := NewDressUpFeatures(fs)
+	switch fd.Kind {
+	case "extrude":
+		return requireExtrude(fs, fd.Extrude, sk)
+	case "fillet":
+		d, err := requireEdgeDress(fd.Fillet, "fillet")
+		if err != nil {
+			return nil, err
+		}
+		return du.AddFillet(d.keys, constFloat(d.value)), nil
+	case "chamfer":
+		d, err := requireEdgeDress(fd.Chamfer, "chamfer")
+		if err != nil {
+			return nil, err
+		}
+		return du.AddChamfer(d.keys, constFloat(d.value)), nil
+	case "shell":
+		d, err := requireFaceDress(fd.Shell, "shell")
+		if err != nil {
+			return nil, err
+		}
+		return du.AddShell(d.keys, constFloat(d.value)), nil
+	case "draft":
+		d, err := requireFaceDress(fd.Draft, "draft")
+		if err != nil {
+			return nil, err
+		}
+		return du.AddDraft(d.keys, constFloat(d.value)), nil
+	case "thread":
+		if fd.Thread == nil {
+			return nil, fmt.Errorf("thread feature is missing its payload")
+		}
+		key, err := decodeKey(fd.Thread.Face)
+		if err != nil {
+			return nil, err
+		}
+		return du.AddThread(key, fd.Thread.Designation), nil
+	default:
+		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
+	}
+}
+
+// requireExtrude restores an extrude, erroring on a missing payload.
+func requireExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
+	if ed == nil {
+		return nil, fmt.Errorf("extrude feature is missing its payload")
+	}
+	return restoreExtrude(fs, ed, sk)
+}
+
+// dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups.
+type dressInputs struct {
+	keys  [][]byte
+	value float64
+}
+
+func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
+	if d == nil {
+		return dressInputs{}, fmt.Errorf("%s feature is missing its payload", kind)
+	}
+	keys, err := decodeKeys(d.Edges)
+	if err != nil {
+		return dressInputs{}, err
+	}
+	return dressInputs{keys: keys, value: d.Value}, nil
+}
+
+func requireFaceDress(d *FaceDressData, kind string) (dressInputs, error) {
+	if d == nil {
+		return dressInputs{}, fmt.Errorf("%s feature is missing its payload", kind)
+	}
+	keys, err := decodeKeys(d.Faces)
+	if err != nil {
+		return dressInputs{}, err
+	}
+	return dressInputs{keys: keys, value: d.Value}, nil
+}
+
+func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
+	skt, ok := sk.At(ed.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("extrude references sketch index %d, which does not exist", ed.Sketch)
+	}
+	op, err := parseOperation(ed.Operation)
+	if err != nil {
+		return nil, err
+	}
+	dist := ed.Distance
+	pf := NewExtrudeFeatures(fs).AddByDistanceExtent(skt, ed.Profile, op, func() float64 { return dist })
+	if ed.Taper != 0 {
+		pf.feature.(*ExtrudeFeature).def.Taper = ed.Taper
+	}
+	return pf, nil
+}
+
+// encodeKeys / decodeKeys base64-encode reference keys (opaque lineage bytes) so they
+// stay valid text in the YAML document (ADR-0020); they re-bind after recompute.
+func encodeKeys(keys [][]byte) []string {
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = encodeKey(k)
+	}
+	return out
+}
+
+func decodeKeys(encoded []string) ([][]byte, error) {
+	out := make([][]byte, len(encoded))
+	for i, e := range encoded {
+		k, err := decodeKey(e)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = k
+	}
+	return out, nil
+}
+
+func encodeKey(k []byte) string { return base64.StdEncoding.EncodeToString(k) }
+
+func decodeKey(s string) ([]byte, error) {
+	k, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("reference key %q is not valid base64: %w", s, err)
+	}
+	return k, nil
+}
+
+// evalFloat reads a dress-up's scalar (a closure, typically a parameter); a nil closure
+// reads as 0. constFloat is its inverse for restore — a fixed value (parametric
+// dress-up values arrive with the dimension-driven API, like extrude distance).
+func evalFloat(fn func() float64) float64 {
+	if fn == nil {
+		return 0
+	}
+	return fn()
+}
+
+func constFloat(v float64) func() float64 { return func() float64 { return v } }
+
+// applyFeatureState restores the per-feature engine state (name, suppression).
+func applyFeatureState(pf *PartFeature, fd FeatureData) {
+	if fd.Name != "" {
+		pf.SetName(fd.Name)
+	}
+	if fd.Suppressed {
+		pf.SetSuppressed(true)
+	}
+}
+
+// operationName / parseOperation map the boolean operation to/from a stable name.
+func operationName(op ops.PartFeatureOperation) (string, error) {
+	switch op {
+	case ops.Join:
+		return "join", nil
+	case ops.Cut:
+		return "cut", nil
+	case ops.Intersect:
+		return "intersect", nil
+	case ops.NewBody:
+		return "newBody", nil
+	default:
+		return "", fmt.Errorf("unknown feature operation %d", op)
+	}
+}
+
+func parseOperation(name string) (ops.PartFeatureOperation, error) {
+	switch name {
+	case "join":
+		return ops.Join, nil
+	case "cut":
+		return ops.Cut, nil
+	case "intersect":
+		return ops.Intersect, nil
+	case "newBody":
+		return ops.NewBody, nil
+	default:
+		return 0, fmt.Errorf("unknown feature operation %q (want join|cut|intersect|newBody)", name)
+	}
+}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// oneSketch is a SketchIndexer over a single sketch at index 0 — enough to round-trip
+// a feature program that consumes one sketch.
+type oneSketch struct{ s *sketch.Sketch }
+
+func (o oneSketch) IndexOf(s *sketch.Sketch) (int, bool) { return 0, s == o.s }
+func (o oneSketch) At(i int) (*sketch.Sketch, bool) {
+	if i == 0 {
+		return o.s, true
+	}
+	return nil, false
+}
+
+func TestExtrudeFeatureRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if len(data) != 1 || data[0].Kind != "extrude" || data[0].Extrude == nil {
+		t.Fatalf("marshaled = %+v, want one extrude with payload", data)
+	}
+	if data[0].Extrude.Distance != 5 {
+		t.Errorf("distance = %v, want 5", data[0].Extrude.Distance)
+	}
+
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "extrude" {
+		t.Errorf("restored program = %d features, want one extrude", fresh.Count())
+	}
+}
+
+// fakeFeature is a feature kind with no codec, used to prove Save errors rather than
+// dropping it.
+type fakeFeature struct{}
+
+func (fakeFeature) Kind() string                    { return "fake" }
+func (fakeFeature) Recompute(Input) (Output, error) { return Output{}, nil }
+
+func TestDressUpFeaturesRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	du := NewDressUpFeatures(fs)
+	du.AddFillet([][]byte{[]byte("edge-a"), []byte("edge-b")}, func() float64 { return 0.5 })
+	du.AddChamfer([][]byte{[]byte("edge-c")}, func() float64 { return 0.3 })
+	du.AddShell([][]byte{[]byte("face-a")}, func() float64 { return 2 })
+	du.AddDraft([][]byte{[]byte("face-b")}, func() float64 { return 0.1 })
+	du.AddThread([]byte("face-c"), "M6x1")
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 5 {
+		t.Fatalf("feature count after round trip = %d, want 5", fresh.Count())
+	}
+
+	// The fillet's edge keys and radius must survive byte-for-byte / value-for-value.
+	fillet := fresh.Item(0).Definition().(*FilletFeature).Definition()
+	if len(fillet.EdgeKeys) != 2 || string(fillet.EdgeKeys[0]) != "edge-a" || string(fillet.EdgeKeys[1]) != "edge-b" {
+		t.Errorf("fillet edge keys = %v, want [edge-a edge-b]", fillet.EdgeKeys)
+	}
+	if fillet.Radius() != 0.5 {
+		t.Errorf("fillet radius = %v, want 0.5", fillet.Radius())
+	}
+	thread := fresh.Item(4).Definition().(*ThreadFeature).Definition()
+	if string(thread.FaceKey) != "face-c" || thread.Designation != "M6x1" {
+		t.Errorf("thread = key %q designation %q, want face-c M6x1", thread.FaceKey, thread.Designation)
+	}
+}
+
+func TestUncodedFeatureErrorsRatherThanDrops(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	fs.Add(fakeFeature{})
+	if _, err := fs.MarshalRecipe(oneSketch{}); err == nil {
+		t.Error("MarshalRecipe silently accepted a feature with no codec; it must error")
+	}
+}

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -57,7 +57,13 @@ type DimensionConstraint struct {
 	limits  ConstraintLimits
 	measure func() float64
 	vars    []*math.Scalar
+	refs    []Entity // the dimensioned geometry (points/lines/arcs), for editing + serialization
 }
+
+// Refs returns the geometry the dimension measures (points for a distance, the line
+// pair for an angle, the circle for a radius, …). It is what serialization records so
+// the dimension can be rebound on open.
+func (d *DimensionConstraint) Refs() []Entity { return d.refs }
 
 // Kind returns the dimension kind.
 func (d *DimensionConstraint) Kind() DimKind { return d.kind }
@@ -126,17 +132,17 @@ func (dc *DimensionConstraints) Item(i int) *DimensionConstraint { return dc.ite
 func (dc *DimensionConstraints) AddDistance(a, b *Point, expression string) (*DimensionConstraint, error) {
 	measure := func() float64 { return a.Position().DistanceTo(b.Position()) }
 	vars := []*math.Scalar{&a.X, &a.Y, &b.X, &b.Y}
-	return dc.create(DistanceDim, expression, measure, vars)
+	return dc.create(DistanceDim, expression, []Entity{a, b}, measure, vars)
 }
 
 // AddRadius dimensions a circle's radius.
 func (dc *DimensionConstraints) AddRadius(c *Circle, expression string) (*DimensionConstraint, error) {
-	return dc.create(RadiusDim, expression, func() float64 { return c.Radius }, []*math.Scalar{&c.Radius})
+	return dc.create(RadiusDim, expression, []Entity{c}, func() float64 { return c.Radius }, []*math.Scalar{&c.Radius})
 }
 
 // AddDiameter dimensions a circle's diameter.
 func (dc *DimensionConstraints) AddDiameter(c *Circle, expression string) (*DimensionConstraint, error) {
-	return dc.create(DiameterDim, expression, func() float64 { return 2 * c.Radius }, []*math.Scalar{&c.Radius})
+	return dc.create(DiameterDim, expression, []Entity{c}, func() float64 { return 2 * c.Radius }, []*math.Scalar{&c.Radius})
 }
 
 // AddAngle dimensions the angle (radians, in [0,π]) between two lines.
@@ -146,23 +152,24 @@ func (dc *DimensionConstraints) AddAngle(l1, l2 *Line, expression string) (*Dime
 		d2x, d2y := lineDir(l2)
 		return stdmath.Atan2(stdmath.Abs(d1x*d2y-d1y*d2x), d1x*d2x+d1y*d2y)
 	}
-	return dc.create(AngleDim, expression, measure, lineVars(l1, l2))
+	return dc.create(AngleDim, expression, []Entity{l1, l2}, measure, lineVars(l1, l2))
 }
 
 // AddArcLength dimensions an arc's length (radius × swept angle).
 func (dc *DimensionConstraints) AddArcLength(a *Arc, expression string) (*DimensionConstraint, error) {
 	measure := func() float64 { return a.Radius() * arcSweep(a) }
 	vars := []*math.Scalar{&a.Center.X, &a.Center.Y, &a.Start.X, &a.Start.Y, &a.End.X, &a.End.Y}
-	return dc.create(ArcLengthDim, expression, measure, vars)
+	return dc.create(ArcLengthDim, expression, []Entity{a}, measure, vars)
 }
 
-// create builds a driving dimension backed by a fresh model parameter.
-func (dc *DimensionConstraints) create(kind DimKind, expression string, measure func() float64, vars []*math.Scalar) (*DimensionConstraint, error) {
+// create builds a driving dimension backed by a fresh model parameter. refs records
+// the dimensioned geometry for editing and serialization.
+func (dc *DimensionConstraints) create(kind DimKind, expression string, refs []Entity, measure func() float64, vars []*math.Scalar) (*DimensionConstraint, error) {
 	p, err := dc.params.AddModelParameter(dc.nextName(), expression)
 	if err != nil {
 		return nil, fmt.Errorf("sketch: dimension parameter: %w", err)
 	}
-	d := &DimensionConstraint{constraintBase: newConstraint(), kind: kind, param: p, measure: measure, vars: vars}
+	d := &DimensionConstraint{constraintBase: newConstraint(), kind: kind, param: p, measure: measure, vars: vars, refs: refs}
 	dc.items = append(dc.items, d)
 	return d, nil
 }

--- a/model/sketch/entity_collections.go
+++ b/model/sketch/entity_collections.go
@@ -40,7 +40,14 @@ type Circles struct {
 
 // AddByCenterRadius creates a circle from a new center point and a radius.
 func (c *Circles) AddByCenterRadius(center math.Point2, radius math.Scalar) *Circle {
-	circ := &Circle{entityBase: newEntity(), Center: c.s.newPoint(center), Radius: radius}
+	return c.Add(c.s.newPoint(center), radius)
+}
+
+// Add creates a circle around an existing center point; sharing the center with
+// another entity makes them concentric structurally. Used by restore to rebuild a
+// circle that shares points with other geometry.
+func (c *Circles) Add(center *Point, radius math.Scalar) *Circle {
+	circ := &Circle{entityBase: newEntity(), Center: center, Radius: radius}
 	c.s.add(circ)
 	c.items = append(c.items, circ)
 	return circ
@@ -58,11 +65,17 @@ type Arcs struct {
 
 // AddByCenterStartEnd creates an arc from a center and two endpoints.
 func (c *Arcs) AddByCenterStartEnd(center, start, end math.Point2, ccw bool) *Arc {
+	return c.Add(c.s.newPoint(center), c.s.newPoint(start), c.s.newPoint(end), ccw)
+}
+
+// Add creates an arc from existing center/start/end points; sharing endpoints with
+// other entities makes them coincident structurally. Used by restore.
+func (c *Arcs) Add(center, start, end *Point, ccw bool) *Arc {
 	a := &Arc{
 		entityBase:       newEntity(),
-		Center:           c.s.newPoint(center),
-		Start:            c.s.newPoint(start),
-		End:              c.s.newPoint(end),
+		Center:           center,
+		Start:            start,
+		End:              end,
 		CounterClockwise: ccw,
 	}
 	c.s.add(a)
@@ -82,9 +95,14 @@ type Ellipses struct {
 
 // Add creates an ellipse from a center, major-axis direction, and the two radii.
 func (c *Ellipses) Add(center math.Point2, majorAxis math.Vector2, majorR, minorR math.Scalar) *Ellipse {
+	return c.AddWithCenter(c.s.newPoint(center), majorAxis, majorR, minorR)
+}
+
+// AddWithCenter creates an ellipse around an existing center point. Used by restore.
+func (c *Ellipses) AddWithCenter(center *Point, majorAxis math.Vector2, majorR, minorR math.Scalar) *Ellipse {
 	e := &Ellipse{
 		entityBase:  newEntity(),
-		Center:      c.s.newPoint(center),
+		Center:      center,
 		MajorAxis:   majorAxis,
 		MajorRadius: majorR,
 		MinorRadius: minorR,
@@ -119,6 +137,12 @@ func (c *Splines) add(pts []math.Point2, closed, fit bool) *Spline {
 	for i, p := range pts {
 		points[i] = c.s.newPoint(p)
 	}
+	return c.AddWithPoints(points, closed, fit)
+}
+
+// AddWithPoints creates a spline through existing points. Used by restore to rebuild
+// a spline that may share endpoints with adjacent geometry.
+func (c *Splines) AddWithPoints(points []*Point, closed, fit bool) *Spline {
 	sp := &Spline{entityBase: newEntity(), Points: points, Closed: closed, fit: fit}
 	c.s.add(sp)
 	c.items = append(c.items, sp)

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// This file defines the git-friendly YAML projection of a sketch (ADR-0020) and the
+// marshal half of the round trip; serialize_restore.go rebuilds a live sketch from it.
+// A sketch is captured as its host plane, its constrainable points (the solver's
+// variables), its curve entities (referencing points by id), and its geometric and
+// dimensional constraints (referencing points/curves by id). Shared points — a corner
+// where two lines meet *is* a coincidence — are preserved because every point is
+// recorded once and referenced by id.
+
+// SketchData is the serializable form of one sketch.
+type SketchData struct {
+	Plane       PlaneData        `yaml:"plane"`
+	Points      []PointData      `yaml:"points,omitempty"`
+	Entities    []EntityData     `yaml:"entities,omitempty"`
+	Constraints []ConstraintData `yaml:"constraints,omitempty"`
+	Dimensions  []DimensionData  `yaml:"dimensions,omitempty"`
+}
+
+// PlaneData is a sketch plane as an origin and two in-plane axes (model space).
+type PlaneData struct {
+	Origin [3]float64 `yaml:"origin"`
+	XAxis  [3]float64 `yaml:"xAxis"`
+	YAxis  [3]float64 `yaml:"yAxis"`
+}
+
+// PointData is one constrainable point. Standalone marks a SketchPoint (a point that
+// is itself an entity), distinct from a curve's owned endpoint/center.
+type PointData struct {
+	ID         int     `yaml:"id"`
+	X          float64 `yaml:"x"`
+	Y          float64 `yaml:"y"`
+	Standalone bool    `yaml:"standalone,omitempty"`
+}
+
+// EntityData is one curve entity. Points lists the curve's defining point ids in a
+// kind-specific order (line: A,B; circle: center; arc: center,start,end; ellipse:
+// center; spline: all). Unused fields stay zero/omitted per kind.
+type EntityData struct {
+	ID           int       `yaml:"id"`
+	Kind         string    `yaml:"kind"`
+	Points       []int     `yaml:"points,omitempty"`
+	Radius       float64   `yaml:"radius,omitempty"`
+	CCW          bool      `yaml:"ccw,omitempty"`
+	MajorAxis    []float64 `yaml:"majorAxis,omitempty"` // ellipse only: [x, y]
+	MajorRadius  float64   `yaml:"majorRadius,omitempty"`
+	MinorRadius  float64   `yaml:"minorRadius,omitempty"`
+	Closed       bool      `yaml:"closed,omitempty"`
+	Fit          bool      `yaml:"fit,omitempty"`
+	Construction bool      `yaml:"construction,omitempty"`
+}
+
+// ConstraintData is one geometric constraint: its kind plus operand ids split into
+// Points (point operands) and Curves (line/circular/smooth entity operands), in the
+// order the constraint's factory expects.
+type ConstraintData struct {
+	Kind   string `yaml:"kind"`
+	Points []int  `yaml:"points,omitempty"`
+	Curves []int  `yaml:"curves,omitempty"`
+}
+
+// DimensionData is one dimensional constraint: its kind, operand ids, the value
+// expression, and driving/limit state.
+type DimensionData struct {
+	Kind       string      `yaml:"kind"`
+	Points     []int       `yaml:"points,omitempty"`
+	Curves     []int       `yaml:"curves,omitempty"`
+	Expression string      `yaml:"expression"`
+	Driven     bool        `yaml:"driven,omitempty"`
+	Limits     *LimitsData `yaml:"limits,omitempty"`
+}
+
+// LimitsData carries a dimension's drive limits when enabled.
+type LimitsData struct {
+	Min float64 `yaml:"min"`
+	Max float64 `yaml:"max"`
+}
+
+// MarshalRecipe projects every sketch into its serializable form, in order. It errors
+// (rather than dropping data) on any geometry it cannot yet serialize, e.g. blocks.
+func (sc *Sketches) MarshalRecipe() ([]SketchData, error) {
+	out := make([]SketchData, 0, sc.Count())
+	for i := 0; i < sc.Count(); i++ {
+		sd, err := serializeSketch(sc.Item(i))
+		if err != nil {
+			return nil, fmt.Errorf("sketch %d: %w", i, err)
+		}
+		out = append(out, sd)
+	}
+	return out, nil
+}
+
+func serializeSketch(s *Sketch) (SketchData, error) {
+	if len(s.blocks.defs) > 0 || len(s.blocks.instances) > 0 {
+		return SketchData{}, fmt.Errorf("block serialization is not yet supported (%d defs, %d instances)", len(s.blocks.defs), len(s.blocks.instances))
+	}
+	sd := SketchData{Plane: serializePlane(s.plane)}
+	standalone := standalonePointIDs(s)
+	for _, p := range s.pts {
+		sd.Points = append(sd.Points, PointData{ID: int(p.id), X: float64(p.X), Y: float64(p.Y), Standalone: standalone[p.id]})
+	}
+	for _, e := range s.ents {
+		if _, isPoint := e.(*Point); isPoint {
+			continue // standalone points are captured in Points, not Entities
+		}
+		ed, err := serializeEntity(e)
+		if err != nil {
+			return SketchData{}, err
+		}
+		sd.Entities = append(sd.Entities, ed)
+	}
+	for _, c := range s.geomCons.All() {
+		cd, err := serializeConstraint(c)
+		if err != nil {
+			return SketchData{}, err
+		}
+		sd.Constraints = append(sd.Constraints, cd)
+	}
+	for _, d := range s.dimCons.items {
+		dd, err := serializeDimension(d)
+		if err != nil {
+			return SketchData{}, err
+		}
+		sd.Dimensions = append(sd.Dimensions, dd)
+	}
+	return sd, nil
+}
+
+// standalonePointIDs is the set of point ids that are standalone SketchPoints.
+func standalonePointIDs(s *Sketch) map[ID]bool {
+	out := make(map[ID]bool, len(s.points.items))
+	for _, p := range s.points.items {
+		out[p.id] = true
+	}
+	return out
+}
+
+func serializePlane(p Plane) PlaneData {
+	o, x, y := p.origin, p.xAxis, p.yAxis
+	return PlaneData{
+		Origin: [3]float64{float64(o.X), float64(o.Y), float64(o.Z)},
+		XAxis:  [3]float64{float64(x.X()), float64(x.Y()), float64(x.Z())},
+		YAxis:  [3]float64{float64(y.X()), float64(y.Y()), float64(y.Z())},
+	}
+}
+
+func serializeEntity(e Entity) (EntityData, error) {
+	switch v := e.(type) {
+	case *Line:
+		return EntityData{ID: int(v.id), Kind: "line", Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction}, nil
+	case *Circle:
+		return EntityData{ID: int(v.id), Kind: "circle", Points: []int{int(v.Center.id)}, Radius: float64(v.Radius), Construction: v.construction}, nil
+	case *Arc:
+		return EntityData{ID: int(v.id), Kind: "arc", Points: []int{int(v.Center.id), int(v.Start.id), int(v.End.id)}, CCW: v.CounterClockwise, Construction: v.construction}, nil
+	case *Ellipse:
+		return EntityData{ID: int(v.id), Kind: "ellipse", Points: []int{int(v.Center.id)}, MajorAxis: []float64{float64(v.MajorAxis.X), float64(v.MajorAxis.Y)}, MajorRadius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius), Construction: v.construction}, nil
+	case *Spline:
+		return EntityData{ID: int(v.id), Kind: "spline", Points: pointIDsOf(v.Points), Closed: v.Closed, Fit: v.fit, Construction: v.construction}, nil
+	default:
+		return EntityData{}, fmt.Errorf("cannot serialize entity of type %T (no codec)", e)
+	}
+}
+
+func serializeConstraint(c Constraint) (ConstraintData, error) {
+	switch v := c.(type) {
+	case *CoincidentConstraint:
+		return ConstraintData{Kind: "coincident", Points: []int{int(v.A.id), int(v.B.id)}}, nil
+	case *HorizontalConstraint:
+		return ConstraintData{Kind: "horizontal", Points: []int{int(v.A.id), int(v.B.id)}}, nil
+	case *VerticalConstraint:
+		return ConstraintData{Kind: "vertical", Points: []int{int(v.A.id), int(v.B.id)}}, nil
+	case *PointOnLineConstraint:
+		return ConstraintData{Kind: "pointOnLine", Points: []int{int(v.P.id)}, Curves: []int{int(v.L.id)}}, nil
+	case *MidpointConstraint:
+		return ConstraintData{Kind: "midpoint", Points: []int{int(v.P.id)}, Curves: []int{int(v.L.id)}}, nil
+	case *PointOnCircleConstraint:
+		return ConstraintData{Kind: "pointOnCircle", Points: []int{int(v.P.id)}, Curves: []int{int(v.C.EntityID())}}, nil
+	case *ParallelConstraint:
+		return ConstraintData{Kind: "parallel", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
+	case *PerpendicularConstraint:
+		return ConstraintData{Kind: "perpendicular", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
+	case *CollinearConstraint:
+		return ConstraintData{Kind: "collinear", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
+	case *EqualLengthConstraint:
+		return ConstraintData{Kind: "equalLength", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
+	case *ConcentricConstraint:
+		return ConstraintData{Kind: "concentric", Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
+	case *EqualRadiusConstraint:
+		return ConstraintData{Kind: "equalRadius", Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
+	case *CircularTangentConstraint:
+		return ConstraintData{Kind: "circularTangent", Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
+	case *TangentConstraint:
+		return ConstraintData{Kind: "tangent", Curves: []int{int(v.L.id), int(v.C.EntityID())}}, nil
+	case *SymmetryConstraint:
+		return ConstraintData{Kind: "symmetry", Points: []int{int(v.A.id), int(v.B.id)}, Curves: []int{int(v.About.id)}}, nil
+	case *FixConstraint:
+		return ConstraintData{Kind: "fix", Points: []int{int(v.P.id)}}, nil
+	case *SmoothConstraint:
+		return ConstraintData{Kind: "smooth", Points: []int{int(v.P1.id), int(v.P2.id)}, Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
+	default:
+		return ConstraintData{}, fmt.Errorf("cannot serialize constraint of type %T (no codec)", c)
+	}
+}
+
+func serializeDimension(d *DimensionConstraint) (DimensionData, error) {
+	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven}
+	if d.limits.Enabled {
+		dd.Limits = &LimitsData{Min: d.limits.Min, Max: d.limits.Max}
+	}
+	kind, err := dimKindName(d.kind)
+	if err != nil {
+		return DimensionData{}, err
+	}
+	dd.Kind = kind
+	// Split the dimensioned geometry into point and curve operands by kind.
+	switch d.kind {
+	case DistanceDim:
+		dd.Points = entityIDsOf(d.refs)
+	default:
+		dd.Curves = entityIDsOf(d.refs)
+	}
+	return dd, nil
+}
+
+func dimKindName(k DimKind) (string, error) {
+	switch k {
+	case DistanceDim:
+		return "distance", nil
+	case AngleDim:
+		return "angle", nil
+	case RadiusDim:
+		return "radius", nil
+	case DiameterDim:
+		return "diameter", nil
+	case ArcLengthDim:
+		return "arcLength", nil
+	default:
+		return "", fmt.Errorf("cannot serialize dimension of kind %d (no codec)", k)
+	}
+}
+
+// pointIDsOf returns the ids of a list of points.
+func pointIDsOf(pts []*Point) []int {
+	out := make([]int, len(pts))
+	for i, p := range pts {
+		out[i] = int(p.id)
+	}
+	return out
+}
+
+// entityIDsOf returns the ids of a list of entities.
+func entityIDsOf(ents []Entity) []int {
+	out := make([]int, len(ents))
+	for i, e := range ents {
+		out[i] = int(e.EntityID())
+	}
+	return out
+}
+
+// vector3 builds a math.Vector3 from a serialized triple.
+func vector3(v [3]float64) math.Vector3 { return math.V3(v[0], v[1], v[2]) }

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// ApplyRecipe rebuilds the sketches from their serialized form, in order. It is the
+// inverse of [Sketches.MarshalRecipe]: points are recreated first (preserving shared
+// identity, so a corner shared by two lines is one point again), then curve entities
+// referencing them, then geometric and dimensional constraints. Any operand that does
+// not resolve, or any unknown kind, is an error — a recipe never restores partially.
+func (sc *Sketches) ApplyRecipe(data []SketchData) error {
+	for i, sd := range data {
+		if err := restoreSketch(sc, sd); err != nil {
+			return fmt.Errorf("sketch %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func restoreSketch(sc *Sketches, sd SketchData) error {
+	plane, err := restorePlane(sd.Plane)
+	if err != nil {
+		return err
+	}
+	r := &sketchRestorer{
+		s:         sc.Add(plane),
+		pointMap:  make(map[int]*Point, len(sd.Points)),
+		entityMap: make(map[int]Entity, len(sd.Entities)),
+	}
+	r.restorePoints(sd.Points)
+	if err := r.restoreEntities(sd.Entities); err != nil {
+		return err
+	}
+	if err := r.restoreConstraints(sd.Constraints); err != nil {
+		return err
+	}
+	return r.restoreDimensions(sd.Dimensions)
+}
+
+// sketchRestorer carries the id→object maps while rebuilding one sketch.
+type sketchRestorer struct {
+	s         *Sketch
+	pointMap  map[int]*Point
+	entityMap map[int]Entity
+}
+
+func (r *sketchRestorer) restorePoints(points []PointData) {
+	for _, pd := range points {
+		pos := math.P2(pd.X, pd.Y)
+		if pd.Standalone {
+			r.pointMap[pd.ID] = r.s.points.Add(pos)
+			continue
+		}
+		r.pointMap[pd.ID] = r.s.newPoint(pos)
+	}
+}
+
+func (r *sketchRestorer) restoreEntities(entities []EntityData) error {
+	for _, ed := range entities {
+		e, err := r.restoreEntity(ed)
+		if err != nil {
+			return err
+		}
+		e.(interface{ SetConstruction(bool) }).SetConstruction(ed.Construction)
+		r.entityMap[ed.ID] = e
+	}
+	return nil
+}
+
+func (r *sketchRestorer) restoreEntity(ed EntityData) (Entity, error) {
+	switch ed.Kind {
+	case "line":
+		p, err := r.points(ed.Points, 2)
+		if err != nil {
+			return nil, err
+		}
+		return r.s.lines.Add(p[0], p[1]), nil
+	case "circle":
+		p, err := r.points(ed.Points, 1)
+		if err != nil {
+			return nil, err
+		}
+		return r.s.circles.Add(p[0], math.Scalar(ed.Radius)), nil
+	case "arc":
+		p, err := r.points(ed.Points, 3)
+		if err != nil {
+			return nil, err
+		}
+		return r.s.arcs.Add(p[0], p[1], p[2], ed.CCW), nil
+	case "ellipse":
+		p, err := r.points(ed.Points, 1)
+		if err != nil {
+			return nil, err
+		}
+		if len(ed.MajorAxis) != 2 {
+			return nil, fmt.Errorf("ellipse needs a 2-component majorAxis, got %d", len(ed.MajorAxis))
+		}
+		axis := math.V2(ed.MajorAxis[0], ed.MajorAxis[1])
+		return r.s.ellipses.AddWithCenter(p[0], axis, math.Scalar(ed.MajorRadius), math.Scalar(ed.MinorRadius)), nil
+	case "spline":
+		p, err := r.points(ed.Points, len(ed.Points))
+		if err != nil {
+			return nil, err
+		}
+		return r.s.splines.AddWithPoints(p, ed.Closed, ed.Fit), nil
+	default:
+		return nil, fmt.Errorf("unknown entity kind %q", ed.Kind)
+	}
+}
+
+func (r *sketchRestorer) restoreConstraints(constraints []ConstraintData) error {
+	for _, cd := range constraints {
+		if err := r.restoreConstraint(cd); err != nil {
+			return fmt.Errorf("constraint %q: %w", cd.Kind, err)
+		}
+	}
+	return nil
+}
+
+func (r *sketchRestorer) restoreConstraint(cd ConstraintData) error {
+	g := r.s.geomCons
+	switch cd.Kind {
+	case "coincident":
+		return r.twoPoints(cd, func(a, b *Point) { g.AddCoincident(a, b) })
+	case "horizontal":
+		return r.twoPoints(cd, func(a, b *Point) { g.AddHorizontal(a, b) })
+	case "vertical":
+		return r.twoPoints(cd, func(a, b *Point) { g.AddVertical(a, b) })
+	case "parallel":
+		return r.twoLines(cd, func(a, b *Line) { g.AddParallel(a, b) })
+	case "perpendicular":
+		return r.twoLines(cd, func(a, b *Line) { g.AddPerpendicular(a, b) })
+	case "collinear":
+		return r.twoLines(cd, func(a, b *Line) { g.AddCollinear(a, b) })
+	case "equalLength":
+		return r.twoLines(cd, func(a, b *Line) { g.AddEqualLength(a, b) })
+	case "concentric":
+		return r.twoCurves(cd, func(a, b CircularCurve) { g.AddConcentric(a, b) })
+	case "equalRadius":
+		return r.twoCurves(cd, func(a, b CircularCurve) { g.AddEqualRadius(a, b) })
+	case "circularTangent":
+		return r.twoCurves(cd, func(a, b CircularCurve) { g.AddCircularTangent(a, b) })
+	case "pointOnLine":
+		return r.pointAndLine(cd, func(p *Point, l *Line) { g.AddPointOnLine(p, l) })
+	case "midpoint":
+		return r.pointAndLine(cd, func(p *Point, l *Line) { g.AddMidpoint(p, l) })
+	case "pointOnCircle":
+		p, err := r.point(cd.Points, 0)
+		if err != nil {
+			return err
+		}
+		c, err := r.curve(cd.Curves, 0)
+		if err != nil {
+			return err
+		}
+		g.AddPointOnCircle(p, c)
+		return nil
+	case "tangent":
+		l, err := r.line(cd.Curves, 0)
+		if err != nil {
+			return err
+		}
+		c, err := r.curve(cd.Curves, 1)
+		if err != nil {
+			return err
+		}
+		g.AddTangent(l, c)
+		return nil
+	case "symmetry":
+		a, err := r.point(cd.Points, 0)
+		if err != nil {
+			return err
+		}
+		b, err := r.point(cd.Points, 1)
+		if err != nil {
+			return err
+		}
+		about, err := r.line(cd.Curves, 0)
+		if err != nil {
+			return err
+		}
+		g.AddSymmetry(a, b, about)
+		return nil
+	case "fix":
+		p, err := r.point(cd.Points, 0)
+		if err != nil {
+			return err
+		}
+		g.AddFix(p)
+		return nil
+	case "smooth":
+		c1, err := r.smooth(cd.Curves, 0)
+		if err != nil {
+			return err
+		}
+		c2, err := r.smooth(cd.Curves, 1)
+		if err != nil {
+			return err
+		}
+		p1, err := r.point(cd.Points, 0)
+		if err != nil {
+			return err
+		}
+		p2, err := r.point(cd.Points, 1)
+		if err != nil {
+			return err
+		}
+		g.AddSmooth(c1, c2, p1, p2)
+		return nil
+	default:
+		return fmt.Errorf("unknown constraint kind %q", cd.Kind)
+	}
+}
+
+func (r *sketchRestorer) restoreDimensions(dims []DimensionData) error {
+	for _, dd := range dims {
+		d, err := r.restoreDimension(dd)
+		if err != nil {
+			return fmt.Errorf("dimension %q: %w", dd.Kind, err)
+		}
+		if dd.Driven {
+			d.SetDriven(true)
+		}
+		if dd.Limits != nil {
+			d.SetLimits(dd.Limits.Min, dd.Limits.Max)
+		}
+	}
+	return nil
+}
+
+func (r *sketchRestorer) restoreDimension(dd DimensionData) (*DimensionConstraint, error) {
+	dc := r.s.dimCons
+	switch dd.Kind {
+	case "distance":
+		a, err := r.point(dd.Points, 0)
+		if err != nil {
+			return nil, err
+		}
+		b, err := r.point(dd.Points, 1)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddDistance(a, b, dd.Expression)
+	case "radius":
+		c, err := r.circle(dd.Curves, 0)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddRadius(c, dd.Expression)
+	case "diameter":
+		c, err := r.circle(dd.Curves, 0)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddDiameter(c, dd.Expression)
+	case "angle":
+		l1, err := r.line(dd.Curves, 0)
+		if err != nil {
+			return nil, err
+		}
+		l2, err := r.line(dd.Curves, 1)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddAngle(l1, l2, dd.Expression)
+	case "arcLength":
+		a, err := r.arc(dd.Curves, 0)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddArcLength(a, dd.Expression)
+	default:
+		return nil, fmt.Errorf("unknown dimension kind %q", dd.Kind)
+	}
+}
+
+// --- operand resolution -------------------------------------------------------------
+
+// twoPoints/twoLines/twoCurves/pointAndLine resolve the common operand shapes and
+// invoke the constraint factory, keeping restoreConstraint flat.
+func (r *sketchRestorer) twoPoints(cd ConstraintData, add func(a, b *Point)) error {
+	p, err := r.points(cd.Points, 2)
+	if err != nil {
+		return err
+	}
+	add(p[0], p[1])
+	return nil
+}
+
+func (r *sketchRestorer) twoLines(cd ConstraintData, add func(a, b *Line)) error {
+	a, err := r.line(cd.Curves, 0)
+	if err != nil {
+		return err
+	}
+	b, err := r.line(cd.Curves, 1)
+	if err != nil {
+		return err
+	}
+	add(a, b)
+	return nil
+}
+
+func (r *sketchRestorer) twoCurves(cd ConstraintData, add func(a, b CircularCurve)) error {
+	a, err := r.curve(cd.Curves, 0)
+	if err != nil {
+		return err
+	}
+	b, err := r.curve(cd.Curves, 1)
+	if err != nil {
+		return err
+	}
+	add(a, b)
+	return nil
+}
+
+func (r *sketchRestorer) pointAndLine(cd ConstraintData, add func(p *Point, l *Line)) error {
+	p, err := r.point(cd.Points, 0)
+	if err != nil {
+		return err
+	}
+	l, err := r.line(cd.Curves, 0)
+	if err != nil {
+		return err
+	}
+	add(p, l)
+	return nil
+}
+
+// points resolves exactly n point operands.
+func (r *sketchRestorer) points(ids []int, n int) ([]*Point, error) {
+	if len(ids) != n {
+		return nil, fmt.Errorf("expected %d point operands, got %d", n, len(ids))
+	}
+	out := make([]*Point, n)
+	for i := range ids {
+		p, err := r.point(ids, i)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = p
+	}
+	return out, nil
+}
+
+func (r *sketchRestorer) point(ids []int, i int) (*Point, error) {
+	id, err := at(ids, i, "point")
+	if err != nil {
+		return nil, err
+	}
+	p, ok := r.pointMap[id]
+	if !ok {
+		return nil, fmt.Errorf("unresolved point id %d", id)
+	}
+	return p, nil
+}
+
+func (r *sketchRestorer) entity(ids []int, i int) (Entity, error) {
+	id, err := at(ids, i, "entity")
+	if err != nil {
+		return nil, err
+	}
+	e, ok := r.entityMap[id]
+	if !ok {
+		return nil, fmt.Errorf("unresolved entity id %d", id)
+	}
+	return e, nil
+}
+
+func (r *sketchRestorer) line(ids []int, i int) (*Line, error) {
+	e, err := r.entity(ids, i)
+	if err != nil {
+		return nil, err
+	}
+	l, ok := e.(*Line)
+	if !ok {
+		return nil, fmt.Errorf("entity %d is %T, want a line", ids[i], e)
+	}
+	return l, nil
+}
+
+func (r *sketchRestorer) circle(ids []int, i int) (*Circle, error) {
+	e, err := r.entity(ids, i)
+	if err != nil {
+		return nil, err
+	}
+	c, ok := e.(*Circle)
+	if !ok {
+		return nil, fmt.Errorf("entity %d is %T, want a circle", ids[i], e)
+	}
+	return c, nil
+}
+
+func (r *sketchRestorer) arc(ids []int, i int) (*Arc, error) {
+	e, err := r.entity(ids, i)
+	if err != nil {
+		return nil, err
+	}
+	a, ok := e.(*Arc)
+	if !ok {
+		return nil, fmt.Errorf("entity %d is %T, want an arc", ids[i], e)
+	}
+	return a, nil
+}
+
+func (r *sketchRestorer) curve(ids []int, i int) (CircularCurve, error) {
+	e, err := r.entity(ids, i)
+	if err != nil {
+		return nil, err
+	}
+	c, ok := e.(CircularCurve)
+	if !ok {
+		return nil, fmt.Errorf("entity %d is %T, want a circular curve", ids[i], e)
+	}
+	return c, nil
+}
+
+func (r *sketchRestorer) smooth(ids []int, i int) (SmoothCurve, error) {
+	e, err := r.entity(ids, i)
+	if err != nil {
+		return nil, err
+	}
+	c, ok := e.(SmoothCurve)
+	if !ok {
+		return nil, fmt.Errorf("entity %d is %T, want a smooth curve", ids[i], e)
+	}
+	return c, nil
+}
+
+// at returns ids[i] or a descriptive error when the operand is missing.
+func at(ids []int, i int, what string) (int, error) {
+	if i >= len(ids) {
+		return 0, fmt.Errorf("missing %s operand %d (have %d)", what, i, len(ids))
+	}
+	return ids[i], nil
+}
+
+// restorePlane rebuilds a sketch plane from its serialized origin and axes.
+func restorePlane(pd PlaneData) (Plane, error) {
+	x, err := math.UnitVector3FromVector(vector3(pd.XAxis))
+	if err != nil {
+		return Plane{}, fmt.Errorf("plane x-axis: %w", err)
+	}
+	y, err := math.UnitVector3FromVector(vector3(pd.YAxis))
+	if err != nil {
+		return Plane{}, fmt.Errorf("plane y-axis: %w", err)
+	}
+	return NewPlane(math.P3(pd.Origin[0], pd.Origin[1], pd.Origin[2]), x, y)
+}

--- a/model/sketch/serialize_test.go
+++ b/model/sketch/serialize_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// roundTrip serializes sc and rebuilds it in a fresh collection, returning the
+// reopened first sketch — the real save→restore path the part recipe uses.
+func roundTrip(t *testing.T, sc *Sketches) *Sketch {
+	t.Helper()
+	data, err := sc.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewSketches()
+	if err := fresh.ApplyRecipe(data); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != sc.Count() {
+		t.Fatalf("sketch count after round trip = %d, want %d", fresh.Count(), sc.Count())
+	}
+	return fresh.Item(0)
+}
+
+// TestRectangleSharedPointsSurvive proves that a rectangle built from four lines
+// sharing corner points round-trips as four lines and four points (not eight), i.e.
+// the structural coincidence at each corner is preserved.
+func TestRectangleSharedPointsSurvive(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	// Four corners as shared points.
+	p00 := s.newPoint(math.P2(0, 0))
+	p40 := s.newPoint(math.P2(4, 0))
+	p43 := s.newPoint(math.P2(4, 3))
+	p03 := s.newPoint(math.P2(0, 3))
+	s.lines.Add(p00, p40)
+	s.lines.Add(p40, p43)
+	s.lines.Add(p43, p03)
+	s.lines.Add(p03, p00)
+
+	out := roundTrip(t, sc)
+	if got := out.Lines().Count(); got != 4 {
+		t.Errorf("line count = %d, want 4", got)
+	}
+	if got := len(out.AllPoints()); got != 4 {
+		t.Errorf("point count = %d, want 4 (shared corners must not be duplicated)", got)
+	}
+	// The four lines must still form a closed loop: each corner point is shared by
+	// exactly two lines, so a single closed profile is detected.
+	if got := out.Profiles().Count(); got != 1 {
+		t.Errorf("profile count = %d, want 1 closed loop", got)
+	}
+}
+
+// TestEntityKindsSurvive round-trips one of every curve entity and checks counts +
+// key geometry.
+func TestEntityKindsSurvive(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	s.Circles().AddByCenterRadius(math.P2(5, 5), 2)
+	s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1, 0), math.P2(0, 1), true)
+	s.Ellipses().Add(math.P2(2, 2), math.V2(1, 0), 3, 1)
+	s.Splines().AddByPoints([]math.Point2{math.P2(0, 0), math.P2(1, 1), math.P2(2, 0)}, false)
+	s.Points().Add(math.P2(9, 9))
+
+	out := roundTrip(t, sc)
+	if out.Lines().Count() != 1 || out.Circles().Count() != 1 || out.Arcs().Count() != 1 ||
+		out.Ellipses().Count() != 1 || out.Splines().Count() != 1 || out.Points().Count() != 1 {
+		t.Errorf("entity counts after round trip: lines=%d circles=%d arcs=%d ellipses=%d splines=%d points=%d, want all 1",
+			out.Lines().Count(), out.Circles().Count(), out.Arcs().Count(), out.Ellipses().Count(), out.Splines().Count(), out.Points().Count())
+	}
+	if got := out.Circles().Item(0).Radius; got != 2 {
+		t.Errorf("circle radius = %v, want 2", got)
+	}
+}
+
+// TestConstraintsSurvive round-trips a representative geometric constraint and a
+// dimensional constraint and checks they are rebuilt.
+func TestConstraintsSurvive(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	l1 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	l2 := s.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(4, 1))
+	s.GeometricConstraints().AddParallel(l1, l2)
+	s.GeometricConstraints().AddCoincident(l1.A, l2.A)
+	if _, err := s.DimensionConstraints().AddDistance(l1.A, l1.B, "40 mm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+
+	out := roundTrip(t, sc)
+	if got := out.GeometricConstraints().Count(); got != 2 {
+		t.Errorf("geometric constraint count = %d, want 2", got)
+	}
+	if got := out.DimensionConstraints().Count(); got != 1 {
+		t.Errorf("dimension count = %d, want 1", got)
+	}
+	dim := out.DimensionConstraints().Item(0)
+	if dim.Kind() != DistanceDim || dim.Parameter().Expression() != "40 mm" {
+		t.Errorf("restored dimension = kind %v expr %q, want distance 40 mm", dim.Kind(), dim.Parameter().Expression())
+	}
+}
+
+// TestPlaneSurvives round-trips a non-origin plane.
+func TestPlaneSurvives(t *testing.T) {
+	sc := NewSketches()
+	sc.Add(XZPlane())
+	out := roundTrip(t, sc)
+	got := out.Plane()
+	want := XZPlane()
+	if !got.Normal().AsVector().IsEqualTo(want.Normal().AsVector(), 1e-9) {
+		t.Errorf("plane normal = %v, want %v", got.Normal(), want.Normal())
+	}
+}
+
+// TestBlocksErrorRatherThanDropSilently guards the no-silent-loss rule for an as-yet
+// unsupported feature.
+func TestBlocksErrorRatherThanDropSilently(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	def := s.Blocks().DefineBlock("b")
+	s.Blocks().Insert(def, math.Identity3())
+	if _, err := sc.MarshalRecipe(); err == nil {
+		t.Error("MarshalRecipe silently accepted a sketch with blocks; it must error")
+	}
+}

--- a/persistence/dataio_test.go
+++ b/persistence/dataio_test.go
@@ -55,7 +55,7 @@ func TestCompactionDropsCacheLosslessly(t *testing.T) {
 		"cache/tessellation":   bytes.Repeat([]byte{0xaa}, 4096),
 		"cache/preview":        bytes.Repeat([]byte{0xbb}, 1024),
 	})
-	before, _ := p.marshalZip()
+	before, _ := p.marshal()
 
 	reclaimed := Compact(p)
 	if reclaimed != 4096+1024 {
@@ -68,7 +68,7 @@ func TestCompactionDropsCacheLosslessly(t *testing.T) {
 		t.Error("recipe stream lost during compaction")
 	}
 
-	after, _ := p.marshalZip()
+	after, _ := p.marshal()
 	if len(after) >= len(before) {
 		t.Errorf("compacted archive (%d B) not smaller than original (%d B)", len(after), len(before))
 	}

--- a/persistence/doc.go
+++ b/persistence/doc.go
@@ -1,24 +1,26 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package persistence is the on-disk document format: a portable ZIP package
-// (".obk") of named binary streams, replacing COM's OLE structured storage with
-// something cross-platform and tool-inspectable (architecture core/05).
+// Package persistence is the on-disk document format: a single **git-friendly YAML
+// text file** (".obk") per document, replacing COM's OLE structured storage with
+// something cross-platform, tool-inspectable, and version-controllable (ADR-0020,
+// architecture core/05). The earlier ZIP-of-binary-streams container is gone — a
+// document is now one text file git can diff and merge.
 //
-// A [Package] is an ordered set of named streams (e.g. "manifest.json",
-// "model/parameters.bin", "thumbnail.png") plus typed manifest access. It is read
-// with [OpenPackage] and written with [Package.Save], which is atomic
-// (write-temp-then-rename) so an interrupted save never corrupts the prior file.
-// On open, [OpenPackage] runs the [Migrate] pipeline so older-schema packages are
-// upgraded to the current version.
+// A [Package] is the in-memory document model: the manifest identity (schema
+// version, document kind, display name), the model recipe section, and named text
+// data sections (DataIO / attributes). It is read with [OpenPackage] and written
+// with [Package.Save], which is atomic (write-temp-then-rename) so an interrupted
+// save never corrupts the prior file. On open, [OpenPackage] runs the [Migrate]
+// pipeline so older-schema documents are upgraded to the current version.
 //
-// [PackageStore] adapts a Package directory into the [doc.Store] seam the document
-// workspace depends on (M03-F02): documents save and reopen as real files on disk.
-// [DataIO] is the arbitrary-stream read/write surface used by add-ins and the
+// [PackageStore] adapts a Package into the [doc.Store] seam the document workspace
+// depends on (M03-F02): documents save and reopen as real files on disk. [DataIO]
+// is the arbitrary text-section read/write surface used by add-ins and the
 // attribute layer (M03-F06).
 //
-// Scope note: streams here are opaque byte blobs. The typed, columnar Codec[T]
-// serialization keyed by stable TypeID (core/05) arrives once there is real model
-// data to serialize — the feature program and sketches land from M07. Until then
-// the recipe a document carries is just its manifest identity, which is exactly
-// what round-trips today.
+// Recipe-only, no binaries (ADR-0020): the file holds the regenerable recipe
+// (parameters, sketches, features) as text; realized geometry is recomputed on
+// open, vector references are SVG, and thumbnails are generated git-ignored
+// sidecars. The one opaque exception is the reference-key context (topological
+// naming), carried as a base64 string because correct rebinding requires it.
 package persistence

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -3,23 +3,23 @@
 package persistence
 
 import (
-	"archive/zip"
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
 )
 
-// OpenPackage reads the ZIP package at path into memory and runs the migration
+// OpenPackage reads the YAML document at path into memory and runs the migration
 // pipeline so the result is at [CurrentSchemaVersion]. It does not hold the file
-// open — the package is fully buffered, which is what makes save atomic.
+// open — the document is fully buffered, which is what makes save atomic. A legacy
+// ZIP package is rejected with a clear message (ADR-0020).
 func OpenPackage(path string) (*Package, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("persistence: open %q: %w", path, err)
 	}
-	p, err := readZip(raw)
+	p, err := decode(raw)
 	if err != nil {
 		return nil, fmt.Errorf("persistence: read %q: %w", path, err)
 	}
@@ -29,62 +29,50 @@ func OpenPackage(path string) (*Package, error) {
 	return p, nil
 }
 
-// Save writes the package to path atomically: it serializes the whole archive in
+// Save writes the package to path atomically: it serializes the whole document in
 // memory, writes it to a sibling temp file, fsyncs, then renames over path. An
 // interruption before the rename leaves any prior file at path untouched
-// (architecture core/05: replaces COM compaction-on-save with a simpler invariant).
+// (architecture core/05).
 func (p *Package) Save(path string) error {
-	data, err := p.marshalZip()
+	data, err := p.marshal()
 	if err != nil {
 		return fmt.Errorf("persistence: marshal %q: %w", path, err)
 	}
 	return atomicWriteFile(path, data)
 }
 
-// marshalZip renders the package as a deflate-compressed ZIP archive with streams
-// in deterministic order (see streamNames) for stable output.
-func (p *Package) marshalZip() ([]byte, error) {
-	var buf bytes.Buffer
-	zw := zip.NewWriter(&buf)
-	for _, name := range p.streamNames() {
-		w, err := zw.Create(name)
-		if err != nil {
-			return nil, err
-		}
-		if _, err := w.Write(p.streams[name]); err != nil {
-			return nil, err
-		}
-	}
-	if err := zw.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+// marshal renders the package as a single YAML document (manifest + recipe + data
+// sections). Map keys are emitted in sorted order by the YAML library, so output is
+// stable for clean git diffs.
+func (p *Package) marshal() ([]byte, error) {
+	return yamlcodec.MarshalDocument(yamlcodec.Document{
+		SchemaVersion: p.manifest.SchemaVersion,
+		DocumentType:  p.manifest.DocumentType,
+		DisplayName:   p.manifest.DisplayName,
+		Model:         p.model,
+		Data:          p.streams,
+	})
 }
 
-// readZip rebuilds a package from ZIP bytes, preserving entry order.
-func readZip(raw []byte) (*Package, error) {
-	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+// decode rebuilds a package from a document's YAML bytes.
+func decode(raw []byte) (*Package, error) {
+	doc, err := yamlcodec.UnmarshalDocument(raw)
 	if err != nil {
 		return nil, err
 	}
 	p := NewPackage()
-	for _, entry := range zr.File {
-		data, err := readZipEntry(entry)
-		if err != nil {
-			return nil, err
+	if doc.SchemaVersion != 0 || doc.DocumentType != 0 || doc.DisplayName != "" {
+		p.manifest = Manifest{
+			SchemaVersion: doc.SchemaVersion,
+			DocumentType:  doc.DocumentType,
+			DisplayName:   doc.DisplayName,
 		}
-		p.WriteStream(entry.Name, data)
+	}
+	p.model = doc.Model
+	for name, data := range doc.Data {
+		p.WriteStream(name, data)
 	}
 	return p, nil
-}
-
-func readZipEntry(entry *zip.File) ([]byte, error) {
-	rc, err := entry.Open()
-	if err != nil {
-		return nil, err
-	}
-	defer rc.Close()
-	return io.ReadAll(rc)
 }
 
 // atomicWriteFile writes data to path via a sibling temp file and a rename, so the

--- a/persistence/io_test.go
+++ b/persistence/io_test.go
@@ -17,14 +17,27 @@ func TestOpenMissingFileErrors(t *testing.T) {
 	}
 }
 
-func TestOpenCorruptArchiveErrors(t *testing.T) {
+func TestOpenNonDocumentYAMLErrors(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "corrupt.obk")
-	if err := os.WriteFile(path, []byte("this is not a zip archive"), 0o644); err != nil {
+	// A bare scalar is valid YAML but not a document mapping — must be rejected.
+	if err := os.WriteFile(path, []byte("this is not a document"), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	if _, err := OpenPackage(path); err == nil {
-		t.Error("OpenPackage of a non-zip file returned no error")
+		t.Error("OpenPackage of a non-document YAML file returned no error")
+	}
+}
+
+func TestOpenLegacyZipRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "legacy-zip.obk")
+	// "PK\x03\x04" is the ZIP local-file-header magic — a pre-ADR-0020 package.
+	if err := os.WriteFile(path, []byte("PK\x03\x04rest-of-a-zip"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := OpenPackage(path); err == nil {
+		t.Error("OpenPackage accepted a legacy ZIP .obk; it should reject pre-YAML packages")
 	}
 }
 
@@ -39,13 +52,14 @@ func TestSaveToMissingDirectoryErrors(t *testing.T) {
 	}
 }
 
-func TestBadManifestJSONErrors(t *testing.T) {
-	p := NewPackage()
-	p.WriteStream(manifestStream, []byte("{ not valid json"))
-	if _, err := p.Manifest(); err == nil {
-		t.Error("Manifest accepted invalid JSON")
+func TestOpenMalformedYAMLErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.obk")
+	// Unbalanced brackets — not parseable as YAML at all.
+	if err := os.WriteFile(path, []byte("schemaVersion: 2\nmodel: [unclosed"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
 	}
-	if err := Migrate(p); err == nil {
-		t.Error("Migrate accepted a package with an invalid manifest")
+	if _, err := OpenPackage(path); err == nil {
+		t.Error("OpenPackage accepted malformed YAML")
 	}
 }

--- a/persistence/manifest.go
+++ b/persistence/manifest.go
@@ -2,40 +2,20 @@
 
 package persistence
 
-import (
-	"encoding/json"
-	"fmt"
-)
+// CurrentSchemaVersion is the document schema version written by this build. Bump it
+// whenever the on-disk layout changes and add a [Migration] from the prior version so
+// old files keep opening (architecture core/05). v2 is the YAML single-file format
+// (ADR-0020); v1 and earlier were the ZIP-package format and are not migrated (the
+// only pre-v2 files were regenerable fixtures).
+const CurrentSchemaVersion = 2
 
-// CurrentSchemaVersion is the package schema version written by this build. Bump
-// it whenever the on-disk layout changes and add a [Migration] from the prior
-// version so old files keep opening (architecture core/05).
-const CurrentSchemaVersion = 1
-
-// manifestStream is the well-known stream holding the package manifest.
-const manifestStream = "manifest.json"
-
-// Manifest is the package header: schema version (for migration), the root
-// document kind, the display name, and an optional thumbnail stream reference. It
-// is the JSON document at [manifestStream] and is the only part of the package the
-// store needs to reconstruct a document's identity today.
+// Manifest is the document's identity header: schema version (for migration), the
+// root document kind, and the display name. On disk these are the top-level fields of
+// the YAML document (see persistence/yamlcodec); in memory the [Package] holds it as
+// a value. It is the only part of the document the store needs to reconstruct a
+// document's identity.
 type Manifest struct {
-	SchemaVersion int    `json:"schemaVersion"`
-	DocumentType  uint32 `json:"documentType"`
-	DisplayName   string `json:"displayName"`
-	Thumbnail     string `json:"thumbnail,omitempty"`
-}
-
-// encode renders the manifest as indented JSON so the package stays diff-friendly.
-func (m Manifest) encode() ([]byte, error) {
-	return json.MarshalIndent(m, "", "  ")
-}
-
-// decodeManifest parses a manifest stream.
-func decodeManifest(data []byte) (Manifest, error) {
-	var m Manifest
-	if err := json.Unmarshal(data, &m); err != nil {
-		return Manifest{}, fmt.Errorf("persistence: invalid manifest: %w", err)
-	}
-	return m, nil
+	SchemaVersion int
+	DocumentType  uint32
+	DisplayName   string
 }

--- a/persistence/migration.go
+++ b/persistence/migration.go
@@ -7,22 +7,20 @@ import (
 	"fmt"
 )
 
-// Migration upgrades a package one schema version forward, in place. It is keyed
-// in [migrations] by the version it upgrades FROM.
+// Migration upgrades a document one schema version forward, in place. It is keyed in
+// [migrations] by the version it upgrades FROM.
 type Migration func(*Package) error
 
-// migrations maps a from-version to the step that brings a package to the next
-// version. Register a new entry whenever [CurrentSchemaVersion] is bumped; never
-// remove old ones — they are the only path forward for files in the wild.
-var migrations = map[int]Migration{
-	0: migrateV0toV1,
-}
+// migrations maps a from-version to the step that brings a document to the next
+// version. It is empty at the v2 (YAML) baseline: the pre-v2 ZIP format is not
+// migrated (ADR-0020). Register a step here whenever [CurrentSchemaVersion] is bumped
+// past 2; never remove one — it is the only path forward for files in the wild.
+var migrations = map[int]Migration{}
 
-// Migrate upgrades a document package to [CurrentSchemaVersion], applying each
-// registered step in order and stamping the new version into the manifest. A
-// package with no manifest (an arbitrary DataIO container) is left untouched. A
-// package from a newer build than this one is rejected rather than silently
-// downgraded.
+// Migrate upgrades a document to [CurrentSchemaVersion], applying each registered step
+// in order and stamping the new version into the manifest. A document with no manifest
+// (an arbitrary DataIO container) is left untouched. A document from a newer build than
+// this one is rejected rather than silently downgraded.
 func Migrate(p *Package) error {
 	m, err := p.Manifest()
 	if errors.Is(err, errNoManifest) {
@@ -32,12 +30,12 @@ func Migrate(p *Package) error {
 		return err
 	}
 	if m.SchemaVersion > CurrentSchemaVersion {
-		return fmt.Errorf("persistence: package schema v%d is newer than supported v%d", m.SchemaVersion, CurrentSchemaVersion)
+		return fmt.Errorf("persistence: document schema v%d is newer than supported v%d", m.SchemaVersion, CurrentSchemaVersion)
 	}
 	for v := m.SchemaVersion; v < CurrentSchemaVersion; v++ {
 		step, ok := migrations[v]
 		if !ok {
-			return fmt.Errorf("persistence: no migration from schema v%d", v)
+			return fmt.Errorf("persistence: no migration from schema v%d (pre-v2 ZIP packages are unsupported, ADR-0020)", v)
 		}
 		if err := step(p); err != nil {
 			return fmt.Errorf("persistence: migrating from v%d: %w", v, err)
@@ -45,15 +43,4 @@ func Migrate(p *Package) error {
 	}
 	m.SchemaVersion = CurrentSchemaVersion
 	return p.SetManifest(m)
-}
-
-// migrateV0toV1 renames the v0 parameter stream to its v1 name. v0 packages stored
-// parameters under "model/params.bin"; v1 standardized on "model/parameters.bin".
-// The bytes are carried over unchanged, so no data is lost.
-func migrateV0toV1(p *Package) error {
-	if data, ok := p.ReadStream("model/params.bin"); ok {
-		p.WriteStream("model/parameters.bin", data)
-		p.DeleteStream("model/params.bin")
-	}
-	return nil
 }

--- a/persistence/migration_test.go
+++ b/persistence/migration_test.go
@@ -3,39 +3,29 @@
 package persistence
 
 import (
-	"bytes"
 	"path/filepath"
 	"testing"
 )
 
-func TestOlderVersionFileOpensAndMigrates(t *testing.T) {
+func TestCurrentVersionFileNeedsNoMigration(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "legacy.obk")
+	path := filepath.Join(dir, "current.obk")
 
-	// Hand-build a v0 package: old parameter stream name, schema version 0.
-	legacy := NewPackage()
-	if err := legacy.SetManifest(Manifest{SchemaVersion: 0, DocumentType: 1, DisplayName: "Legacy"}); err != nil {
+	saved := NewPackage()
+	if err := saved.SetManifest(Manifest{SchemaVersion: CurrentSchemaVersion, DocumentType: 1, DisplayName: "Bracket"}); err != nil {
 		t.Fatalf("SetManifest: %v", err)
 	}
-	legacy.WriteStream("model/params.bin", []byte("param-bytes"))
-	if err := legacy.Save(path); err != nil {
+	if err := saved.Save(path); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 
-	upgraded, err := OpenPackage(path) // OpenPackage migrates
+	reopened, err := OpenPackage(path) // OpenPackage runs Migrate (a no-op at the current version)
 	if err != nil {
 		t.Fatalf("OpenPackage: %v", err)
 	}
-	m, _ := upgraded.Manifest()
-	if m.SchemaVersion != CurrentSchemaVersion {
-		t.Errorf("schema after migrate = %d, want %d", m.SchemaVersion, CurrentSchemaVersion)
-	}
-	if _, ok := upgraded.ReadStream("model/params.bin"); ok {
-		t.Error("legacy stream name still present after migration")
-	}
-	got, ok := upgraded.ReadStream("model/parameters.bin")
-	if !ok || !bytes.Equal(got, []byte("param-bytes")) {
-		t.Errorf("migrated stream = %q ok=%v, want carried-over bytes (no data loss)", got, ok)
+	m, _ := reopened.Manifest()
+	if m.SchemaVersion != CurrentSchemaVersion || m.DisplayName != "Bracket" {
+		t.Errorf("reopened manifest = %+v, want v%d Bracket", m, CurrentSchemaVersion)
 	}
 }
 

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -2,29 +2,29 @@
 
 package persistence
 
-import (
-	"errors"
-	"sort"
-)
+import "errors"
 
-// errNoManifest reports a package with no manifest stream — not a valid document
-// package (though still a valid container of arbitrary streams, e.g. for DataIO).
+// errNoManifest reports a document with no manifest — not a valid document file
+// (though still a valid container of arbitrary data sections, e.g. for DataIO).
 var errNoManifest = errors.New("persistence: package has no manifest")
 
-// StreamStat is the size/name of one stream. It modernizes COM's tagSTATSTG, kept
-// to the two fields callers actually use here.
+// StreamStat is the size/name of one data section. It modernizes COM's tagSTATSTG,
+// kept to the two fields callers actually use here.
 type StreamStat struct {
 	Name string
 	Size int64
 }
 
-// Package is an in-memory document container: an ordered set of named byte
-// streams. Order is preserved so saved archives are stable (manifest first), which
-// keeps diffs readable. Stream bytes are copied in and out so a Package never
-// shares backing arrays with its callers.
+// Package is an in-memory document: its manifest identity, the recipe section (the
+// model, as opaque YAML bytes owned by model/compdef), and an ordered set of named
+// binary data sections (DataIO / attribute scratch). On disk it is one YAML text
+// file (ADR-0020). Stream bytes are copied in and out so a Package never shares
+// backing arrays with its callers.
 type Package struct {
-	streams map[string][]byte
-	order   []string
+	manifest Manifest          // identity; the zero value means "no manifest"
+	model    []byte            // recipe YAML bytes; nil ⇒ no model
+	streams  map[string][]byte // named binary data sections
+	order    []string          // data-section insertion order, for stable enumeration
 }
 
 // NewPackage returns an empty package.
@@ -32,7 +32,7 @@ func NewPackage() *Package {
 	return &Package{streams: map[string][]byte{}}
 }
 
-// WriteStream stores data under name, replacing any existing stream of that name.
+// WriteStream stores data under name, replacing any existing section of that name.
 // The bytes are copied; later mutations by the caller do not affect the package.
 func (p *Package) WriteStream(name string, data []byte) {
 	if _, exists := p.streams[name]; !exists {
@@ -43,7 +43,7 @@ func (p *Package) WriteStream(name string, data []byte) {
 	p.streams[name] = clone
 }
 
-// ReadStream returns a copy of the named stream's bytes, or false if absent.
+// ReadStream returns a copy of the named section's bytes, or false if absent.
 func (p *Package) ReadStream(name string) ([]byte, bool) {
 	data, ok := p.streams[name]
 	if !ok {
@@ -54,7 +54,7 @@ func (p *Package) ReadStream(name string) ([]byte, bool) {
 	return clone, true
 }
 
-// DeleteStream removes a stream, reporting whether it existed.
+// DeleteStream removes a data section, reporting whether it existed.
 func (p *Package) DeleteStream(name string) bool {
 	if _, ok := p.streams[name]; !ok {
 		return false
@@ -69,7 +69,7 @@ func (p *Package) DeleteStream(name string) bool {
 	return true
 }
 
-// Streams returns a stat for every stream, in write order.
+// Streams returns a stat for every data section, in write order.
 func (p *Package) Streams() []StreamStat {
 	stats := make([]StreamStat, 0, len(p.order))
 	for _, name := range p.order {
@@ -78,7 +78,7 @@ func (p *Package) Streams() []StreamStat {
 	return stats
 }
 
-// Stat returns the stat of one stream, or false if absent.
+// Stat returns the stat of one data section, or false if absent.
 func (p *Package) Stat(name string) (StreamStat, bool) {
 	data, ok := p.streams[name]
 	if !ok {
@@ -87,40 +87,34 @@ func (p *Package) Stat(name string) (StreamStat, bool) {
 	return StreamStat{Name: name, Size: int64(len(data))}, true
 }
 
-// Manifest decodes the package manifest, or returns errNoManifest if absent.
+// Manifest returns the document's manifest, or errNoManifest if none has been set
+// (a manifest-less data container).
 func (p *Package) Manifest() (Manifest, error) {
-	data, ok := p.ReadStream(manifestStream)
-	if !ok {
+	if p.manifest == (Manifest{}) {
 		return Manifest{}, errNoManifest
 	}
-	return decodeManifest(data)
+	return p.manifest, nil
 }
 
-// SetManifest encodes m into the manifest stream.
+// SetManifest records the document's identity.
 func (p *Package) SetManifest(m Manifest) error {
-	data, err := m.encode()
-	if err != nil {
-		return err
-	}
-	p.WriteStream(manifestStream, data)
+	p.manifest = m
 	return nil
 }
 
-// streamNames returns the stream names in a deterministic order (manifest first,
-// then the rest sorted) for stable archive output regardless of write order.
-func (p *Package) streamNames() []string {
-	rest := make([]string, 0, len(p.order))
-	hasManifest := false
-	for _, n := range p.order {
-		if n == manifestStream {
-			hasManifest = true
-			continue
-		}
-		rest = append(rest, n)
+// ModelYAML returns a copy of the recipe section's YAML bytes, or false if the
+// document has no model. The recipe schema is owned by model/compdef; persistence
+// treats it as opaque bytes embedded natively in the file (ADR-0020).
+func (p *Package) ModelYAML() ([]byte, bool) {
+	if len(p.model) == 0 {
+		return nil, false
 	}
-	sort.Strings(rest)
-	if hasManifest {
-		return append([]string{manifestStream}, rest...)
-	}
-	return rest
+	out := make([]byte, len(p.model))
+	copy(out, p.model)
+	return out, true
+}
+
+// SetModelYAML stores the recipe section's YAML bytes (copied).
+func (p *Package) SetModelYAML(b []byte) {
+	p.model = append([]byte(nil), b...)
 }

--- a/persistence/package_test.go
+++ b/persistence/package_test.go
@@ -101,7 +101,7 @@ func TestInterruptedSaveLeavesPriorFileIntact(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "p.obk")
 
-	v1, err := packageWith(map[string][]byte{"s": []byte("v1")}).marshalZip()
+	v1, err := packageWith(map[string][]byte{"s": []byte("v1")}).marshal()
 	if err != nil {
 		t.Fatalf("marshal v1: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestInterruptedSaveLeavesPriorFileIntact(t *testing.T) {
 	}
 
 	// Stage v2 but never commit — the "crash" happens between stage and rename.
-	v2, _ := packageWith(map[string][]byte{"s": []byte("v2")}).marshalZip()
+	v2, _ := packageWith(map[string][]byte{"s": []byte("v2")}).marshal()
 	tmp, err := stage(path, v2)
 	if err != nil {
 		t.Fatalf("stage v2: %v", err)

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -23,8 +23,9 @@ func NewPackageStore() *PackageStore {
 
 var _ doc.Store = (*PackageStore)(nil)
 
-// Save writes the document's manifest into a fresh package and saves it atomically
-// at the document's file name.
+// Save writes the document's manifest and — when its content carries a recipe — the
+// model recipe into a fresh package, and saves it atomically at the document's file
+// name. The realized geometry is never written; it is recomputed on open (ADR-0020).
 func (s *PackageStore) Save(d *doc.Document) error {
 	pkg := NewPackage()
 	manifest := Manifest{
@@ -34,6 +35,13 @@ func (s *PackageStore) Save(d *doc.Document) error {
 	}
 	if err := pkg.SetManifest(manifest); err != nil {
 		return err
+	}
+	if rc, ok := d.Content().(doc.RecipeContent); ok {
+		model, err := rc.MarshalRecipe()
+		if err != nil {
+			return fmt.Errorf("persistence: save %q: marshal recipe: %w", d.FullFileName(), err)
+		}
+		pkg.SetModelYAML(model)
 	}
 	return pkg.Save(d.FullFileName())
 }
@@ -49,7 +57,20 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	if err != nil {
 		return nil, fmt.Errorf("persistence: load %q: %w", fullDocumentName, err)
 	}
-	return doc.Restore(doc.DocumentType(manifest.DocumentType), fullDocumentName, manifest.DisplayName)
+	d, err := doc.Restore(doc.DocumentType(manifest.DocumentType), fullDocumentName, manifest.DisplayName)
+	if err != nil {
+		return nil, err
+	}
+	if model, ok := pkg.ModelYAML(); ok {
+		rc, ok := d.Content().(doc.RecipeContent)
+		if !ok {
+			return nil, fmt.Errorf("persistence: load %q: file has a model recipe but %v content cannot restore it (is its package imported?)", fullDocumentName, d.DocumentType())
+		}
+		if err := rc.ApplyRecipe(model); err != nil {
+			return nil, fmt.Errorf("persistence: load %q: %w", fullDocumentName, err)
+		}
+	}
+	return d, nil
 }
 
 // Exists reports whether a package file is present at fullDocumentName.

--- a/persistence/store_test.go
+++ b/persistence/store_test.go
@@ -54,6 +54,42 @@ func TestPackageStoreExists(t *testing.T) {
 	}
 }
 
+// TestDerivedDisplayNameFollowsSaveAs guards the Restore refinement: a document
+// saved with a name derived from its file (no explicit override) must, after
+// save-as to a new path, reopen under the NEW base name — not the stale original.
+func TestDerivedDisplayNameFollowsSaveAs(t *testing.T) {
+	dir := t.TempDir()
+	store := NewPackageStore()
+	src := filepath.Join(dir, "original.obk")
+	dst := filepath.Join(dir, "renamed.obk")
+
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, src, true) // derived name "original", no override
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	editing := doc.NewWorkspace(store)
+	reopened, err := editing.Open(src, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := editing.SaveAs(reopened, dst); err != nil {
+		t.Fatalf("SaveAs: %v", err)
+	}
+
+	final, err := doc.NewWorkspace(store).Open(dst, true)
+	if err != nil {
+		t.Fatalf("Open renamed: %v", err)
+	}
+	if got := final.DisplayName(); got != "renamed" {
+		t.Errorf("display name after save-as = %q, want %q (derived names must follow the file)", got, "renamed")
+	}
+}
+
 func TestPackageStoreLoadRejectsNonPackage(t *testing.T) {
 	dir := t.TempDir()
 	bogus := filepath.Join(dir, "bogus.obk")

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package yamlcodec is the project's single point of contact with the YAML library
+// (gopkg.in/yaml.v3). Per the dependency rule (CLAUDE.md) and ADR-0020, only this
+// package imports yaml — everything else marshals through these functions, so a
+// future library swap stays local.
+//
+// It also owns the on-disk .obk document shape: one readable YAML file whose manifest
+// fields sit at the top level and whose recipe is a NATIVE nested node (not a quoted
+// blob), so a model diffs line-by-line in git. Binary data sections (add-in/attribute
+// scratch — the rare non-recipe payload) are base64-encoded, the one concession to
+// non-text data (ADR-0020).
+package yamlcodec
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Marshal renders v as YAML bytes.
+func Marshal(v any) ([]byte, error) { return yaml.Marshal(v) }
+
+// Unmarshal parses YAML bytes into v.
+func Unmarshal(data []byte, v any) error { return yaml.Unmarshal(data, v) }
+
+// Document is the decoded form of a .obk file: identity, the recipe section (raw YAML
+// bytes, embedded natively on disk for readability), and named binary data sections.
+// Model is nil when the document carries no recipe (e.g. a manifest-only stub or a
+// pure DataIO container).
+type Document struct {
+	SchemaVersion int
+	DocumentType  uint32
+	DisplayName   string
+	Model         []byte
+	Data          map[string][]byte
+}
+
+// onDisk is the YAML projection of a Document: manifest at top level, recipe as a
+// native node, data sections base64-encoded. omitempty keeps a minimal file readable.
+type onDisk struct {
+	SchemaVersion int               `yaml:"schemaVersion,omitempty"`
+	DocumentType  uint32            `yaml:"documentType,omitempty"`
+	DisplayName   string            `yaml:"displayName,omitempty"`
+	Model         yaml.Node         `yaml:"model,omitempty"`
+	Data          map[string]string `yaml:"data,omitempty"`
+}
+
+// MarshalDocument renders d as the on-disk YAML file. The recipe bytes are parsed and
+// embedded as a native node so the model is real nested YAML, not an escaped string.
+func MarshalDocument(d Document) ([]byte, error) {
+	od := onDisk{
+		SchemaVersion: d.SchemaVersion,
+		DocumentType:  d.DocumentType,
+		DisplayName:   d.DisplayName,
+	}
+	if len(d.Model) > 0 {
+		node, err := modelNode(d.Model)
+		if err != nil {
+			return nil, err
+		}
+		od.Model = *node
+	}
+	if len(d.Data) > 0 {
+		od.Data = make(map[string]string, len(d.Data))
+		for name, raw := range d.Data {
+			od.Data[name] = base64.StdEncoding.EncodeToString(raw)
+		}
+	}
+	return yaml.Marshal(od)
+}
+
+// UnmarshalDocument decodes a .obk file's bytes. It rejects a legacy ZIP package with
+// a clear message (ADR-0020: the format is now YAML) and surfaces base64/YAML errors.
+func UnmarshalDocument(raw []byte) (Document, error) {
+	if isZip(raw) {
+		return Document{}, errors.New("yamlcodec: this looks like a legacy ZIP .obk; the document format is now a YAML text file (ADR-0020) and old ZIP packages are not supported")
+	}
+	var od onDisk
+	if err := yaml.Unmarshal(raw, &od); err != nil {
+		return Document{}, fmt.Errorf("yamlcodec: parse document: %w", err)
+	}
+	d := Document{
+		SchemaVersion: od.SchemaVersion,
+		DocumentType:  od.DocumentType,
+		DisplayName:   od.DisplayName,
+	}
+	if od.Model.Kind != 0 {
+		b, err := yaml.Marshal(&od.Model)
+		if err != nil {
+			return Document{}, fmt.Errorf("yamlcodec: extract model: %w", err)
+		}
+		d.Model = b
+	}
+	if len(od.Data) > 0 {
+		d.Data = make(map[string][]byte, len(od.Data))
+		for name, enc := range od.Data {
+			b, err := base64.StdEncoding.DecodeString(enc)
+			if err != nil {
+				return Document{}, fmt.Errorf("yamlcodec: data section %q is not valid base64: %w", name, err)
+			}
+			d.Data[name] = b
+		}
+	}
+	return d, nil
+}
+
+// modelNode parses recipe YAML bytes into the mapping node to embed under `model:`.
+// yaml.Unmarshal yields a document node wrapping the real content; we splice in that
+// content root so the embedded model is not double-wrapped.
+func modelNode(modelYAML []byte) (*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(modelYAML, &doc); err != nil {
+		return nil, fmt.Errorf("yamlcodec: embed model: %w", err)
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		return doc.Content[0], nil
+	}
+	return &doc, nil
+}
+
+// isZip reports whether raw begins with the local-file-header magic of a ZIP archive
+// ("PK\x03\x04") — i.e. a pre-ADR-0020 package.
+func isZip(raw []byte) bool {
+	return len(raw) >= 4 && raw[0] == 'P' && raw[1] == 'K' && raw[2] == 0x03 && raw[3] == 0x04
+}

--- a/persistence/yamlcodec/yamlcodec_test.go
+++ b/persistence/yamlcodec/yamlcodec_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package yamlcodec
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDocumentRoundTrip(t *testing.T) {
+	in := Document{
+		SchemaVersion: 2,
+		DocumentType:  1,
+		DisplayName:   "bracket",
+		Model:         []byte("parameters:\n  - {name: width, expression: 4 cm}\n"),
+		Data:          map[string][]byte{"addins/acme/state.bin": {0xde, 0xad, 0xbe, 0xef, 0x00}},
+	}
+	raw, err := MarshalDocument(in)
+	if err != nil {
+		t.Fatalf("MarshalDocument: %v", err)
+	}
+	out, err := UnmarshalDocument(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalDocument: %v", err)
+	}
+	if out.SchemaVersion != 2 || out.DocumentType != 1 || out.DisplayName != "bracket" {
+		t.Errorf("identity round trip = %+v, want v2 part bracket", out)
+	}
+	if !bytes.Equal(out.Data["addins/acme/state.bin"], in.Data["addins/acme/state.bin"]) {
+		t.Errorf("binary data section not byte-identical: %v", out.Data)
+	}
+	// The model must come back parseable to the same content.
+	if !strings.Contains(string(out.Model), "width") || !strings.Contains(string(out.Model), "4 cm") {
+		t.Errorf("model lost on round trip: %q", out.Model)
+	}
+}
+
+func TestModelEmbeddedNatively(t *testing.T) {
+	raw, err := MarshalDocument(Document{
+		SchemaVersion: 2, DocumentType: 1, DisplayName: "p",
+		Model: []byte("parameters:\n  - {name: width, expression: 4 cm}\n"),
+	})
+	if err != nil {
+		t.Fatalf("MarshalDocument: %v", err)
+	}
+	text := string(raw)
+	// Native nesting: the model is real YAML under `model:`, not a quoted/escaped blob.
+	if !strings.Contains(text, "model:") || !strings.Contains(text, "parameters:") {
+		t.Errorf("model not embedded as native YAML:\n%s", text)
+	}
+	if strings.Contains(text, "\\n") {
+		t.Errorf("model appears escaped as a string, not embedded:\n%s", text)
+	}
+}
+
+func TestLegacyZipRejected(t *testing.T) {
+	if _, err := UnmarshalDocument([]byte("PK\x03\x04and the rest")); err == nil {
+		t.Error("UnmarshalDocument accepted ZIP magic; legacy packages must be rejected")
+	}
+}
+
+func TestNonDocumentScalarRejected(t *testing.T) {
+	if _, err := UnmarshalDocument([]byte("just a scalar string")); err == nil {
+		t.Error("UnmarshalDocument accepted a bare scalar as a document")
+	}
+}
+
+func TestEmptyModelOmitted(t *testing.T) {
+	raw, err := MarshalDocument(Document{SchemaVersion: 2, DocumentType: 1, DisplayName: "p"})
+	if err != nil {
+		t.Fatalf("MarshalDocument: %v", err)
+	}
+	if strings.Contains(string(raw), "model:") {
+		t.Errorf("empty model should be omitted, got:\n%s", raw)
+	}
+}


### PR DESCRIPTION
Makes documents openable, saveable, and **round-trippable**: a reopened `.obk` restores the part's modelling state (parameters, sketches, extruded solids, dress-up features) instead of being an empty type+name shell. The on-disk format is now a single **git-friendly YAML text file** (ADR-0020), not a binary ZIP.

## Commits
- **feat(doc):** document open/save flow for the CLI and UI head — Session store injection + `OpenDocument`/`SaveActiveDocument(As)`; headless `oblikovati-cli` (new/open/info/save-as); head File menu Open/Save/Save As via a path modal + a native `InputText` binding.
- **feat(persistence):** single-file YAML format (ADR-0020) — replaces the ZIP container; `persistence/yamlcodec` wraps `gopkg.in/yaml.v3` (the core's first third-party dep); schema v2; legacy ZIP rejected; recipe-only on disk.
- **feat(model):** persist the part recipe — parameters (creation order), units, end-of-part; sketches (plane, shared points, all entities + geometric/dimensional constraints); features (extrude + fillet/chamfer/shell/draft/thread). Dress-up reference keys re-bind to regenerated topology after recompute. No silent data loss: serialization errors on any uncoded kind.

## Verification
`go vet ./...` clean; full core suite **0 failures**; `head/ui` cgo tests pass; each commit builds independently.

## Notes
- First third-party dependency in the GPL core (`gopkg.in/yaml.v3`, Apache-2.0).
- Remaining feature kinds (holes/boss, patterns, work features, surfaces, mesh) are not yet coded and **error loudly on save** until their codecs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)