### PR TITLE
Feature persistence: hole/boss/combine, patterns, surfaces, face-edits

### DIFF
--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -188,6 +188,22 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 
 ## Session log
 
+- **2026-06-02:** **Feature persistence — more codecs (branch `feature-codecs`).** Added
+  recipe codecs (with round-trip tests) for: **hole/boss** (placed on a face by key) +
+  **combine** (bodies by index); **patterns** rectangular/circular/sketch-driven + **mirror**
+  (source features recorded as program indices, re-bound on restore); **boundary-patch**
+  and **ruled-surface** (sketch-based, like extrude); the six direct **face-edits**
+  (split/move-face/face-offset/delete-face/replace-face/thicken, uniform via a faceEditor
+  interface). Split the feature codecs into per-family files (serialize_*.go) to stay
+  under the size limit. With extrude + dress-up (already merged), ~20 feature kinds now
+  round-trip; uncoded kinds still error on save (no silent loss).
+  **Blocked on model integration (not serialization):** user **work features**
+  (WorkPlane/Axis/Point/UCS) and **revolve** — work features are standalone types not
+  stored on the PartComponentDefinition, so there is nothing persistent to serialize until
+  they are wired into the part (and revolve references a WorkAxis with no persistent home).
+  **Deferred (geometry-data serialization):** freeform sub-D cage, mesh, non-parametric
+  base (raw B-rep bodies). **Scattered numeric edits remaining:** trim-by-plane, surface
+  offset, mid-surface, stitch, sculpt, core-cavity.
 - **2026-06-02:** **Feature persistence — dress-up family + reference keys.** Added
   codecs for **fillet, chamfer, shell, draft, thread** to `model/feature/serialize.go`.
   These reference body edges/faces by **reference key**; the keys are lineage-derived

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -73,6 +73,10 @@ func (f *faceEditFeature) Recompute(in Input) (Output, error) {
 	return resolveFacesThenDefer(in, f.faceKeys, f.kind)
 }
 
+// FaceKeys returns the reference keys of the faces this direct edit acts on. It lets
+// the recipe serialize every face-edit feature uniformly (they share this shape).
+func (f *faceEditFeature) FaceKeys() [][]byte { return f.faceKeys }
+
 // SplitFeature, MoveFaceFeature, FaceOffsetFeature, DeleteFaceFeature,
 // ReplaceFaceFeature and ThickenFeature are the deferred direct edits (phase C).
 type (

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -37,6 +37,9 @@ type FeatureData struct {
 	CircPattern   *CircPatternData         `yaml:"circularPattern,omitempty"`
 	SketchPattern *SketchDrivenPatternData `yaml:"sketchDrivenPattern,omitempty"`
 	Mirror        *MirrorData              `yaml:"mirror,omitempty"`
+
+	BoundaryPatch *BoundaryPatchData `yaml:"boundaryPatch,omitempty"`
+	RuledSurface  *RuledSurfaceData  `yaml:"ruledSurface,omitempty"`
 }
 
 // EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
@@ -162,6 +165,18 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.Mirror = &MirrorData{Source: src, Plane: encodeKey(f.def.MirrorPlaneKey)}
+	case *BoundaryPatchFeature:
+		bp, err := serializeBoundaryPatch(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.BoundaryPatch = bp
+	case *RuledSurfaceFeature:
+		rs, err := serializeRuledSurface(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.RuledSurface = rs
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -262,6 +277,10 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSketchPattern(fs, fd.SketchPattern, restored)
 	case "mirror":
 		return restoreMirror(fs, fd.Mirror, restored)
+	case "boundary-patch":
+		return restoreBoundaryPatch(fs, fd.BoundaryPatch, sk)
+	case "ruled-surface":
+		return restoreRuledSurface(fs, fd.RuledSurface, sk)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -29,6 +29,9 @@ type FeatureData struct {
 	Shell      *FaceDressData `yaml:"shell,omitempty"`
 	Draft      *FaceDressData `yaml:"draft,omitempty"`
 	Thread     *ThreadData    `yaml:"thread,omitempty"`
+	Hole       *HoleData      `yaml:"hole,omitempty"`
+	Boss       *BossData      `yaml:"boss,omitempty"`
+	Combine    *CombineData   `yaml:"combine,omitempty"`
 }
 
 // EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
@@ -105,6 +108,20 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer) (FeatureData, error) {
 		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle)}
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation}
+	case *HoleFeature:
+		h, err := serializeHole(f.def)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Hole = h
+	case *BossFeature:
+		fd.Boss = &BossData{Face: encodeKey(f.def.PlacementFaceKey), Diameter: evalFloat(f.def.Diameter), Height: evalFloat(f.def.Height)}
+	case *CombineFeature:
+		op, err := operationName(f.def.Operation)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Combine = &CombineData{Target: f.def.TargetIndex, Tool: f.def.ToolIndex, Operation: op}
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -193,6 +210,12 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer) (*PartFeat
 			return nil, err
 		}
 		return du.AddThread(key, fd.Thread.Designation), nil
+	case "hole":
+		return restoreHole(fs, fd.Hole)
+	case "boss":
+		return restoreBoss(fs, fd.Boss)
+	case "combine":
+		return restoreCombine(fs, fd.Combine)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -39,6 +39,7 @@ type FeatureData struct {
 
 	BoundaryPatch *BoundaryPatchData `yaml:"boundaryPatch,omitempty"`
 	RuledSurface  *RuledSurfaceData  `yaml:"ruledSurface,omitempty"`
+	FaceEdit      *FaceEditData      `yaml:"faceEdit,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -143,6 +144,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.RuledSurface = rs
+	case faceEditor:
+		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -226,6 +229,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreBoundaryPatch(fs, fd.BoundaryPatch, sk)
 	case "ruled-surface":
 		return restoreRuledSurface(fs, fd.RuledSurface, sk)
+	case "split", "move-face", "face-offset", "delete-face", "replace-face", "thicken":
+		return restoreFaceEdit(fs, fd.Kind, fd.FaceEdit)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -32,6 +32,11 @@ type FeatureData struct {
 	Hole       *HoleData      `yaml:"hole,omitempty"`
 	Boss       *BossData      `yaml:"boss,omitempty"`
 	Combine    *CombineData   `yaml:"combine,omitempty"`
+
+	RectPattern   *RectPatternData         `yaml:"rectangularPattern,omitempty"`
+	CircPattern   *CircPatternData         `yaml:"circularPattern,omitempty"`
+	SketchPattern *SketchDrivenPatternData `yaml:"sketchDrivenPattern,omitempty"`
+	Mirror        *MirrorData              `yaml:"mirror,omitempty"`
 }
 
 // EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
@@ -77,10 +82,11 @@ type SketchIndexer interface {
 // MarshalRecipe projects the feature program into its serializable form, in history
 // order, erroring on any feature kind without a codec (no silent loss).
 func (fs *PartFeatures) MarshalRecipe(sk SketchIndexer) ([]FeatureData, error) {
+	idx := fs.indexByID()
 	out := make([]FeatureData, 0, fs.Count())
 	for i := 0; i < fs.Count(); i++ {
 		pf := fs.Item(i)
-		fd, err := serializeFeature(pf, sk)
+		fd, err := serializeFeature(pf, sk, idx)
 		if err != nil {
 			return nil, fmt.Errorf("feature %d (%s): %w", i, pf.Kind(), err)
 		}
@@ -89,7 +95,17 @@ func (fs *PartFeatures) MarshalRecipe(sk SketchIndexer) ([]FeatureData, error) {
 	return out, nil
 }
 
-func serializeFeature(pf *PartFeature, sk SketchIndexer) (FeatureData, error) {
+// indexByID maps each feature's stable id to its position, so a pattern can record
+// which earlier features it replicates as program indices (ids are not persisted).
+func (fs *PartFeatures) indexByID() map[ID]int {
+	m := make(map[ID]int, fs.Count())
+	for i := 0; i < fs.Count(); i++ {
+		m[fs.Item(i).ID()] = i
+	}
+	return m
+}
+
+func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (FeatureData, error) {
 	fd := FeatureData{Kind: pf.Kind(), Name: pf.name, Suppressed: pf.suppress}
 	switch f := pf.feature.(type) {
 	case *ExtrudeFeature:
@@ -122,6 +138,30 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer) (FeatureData, error) {
 			return FeatureData{}, err
 		}
 		fd.Combine = &CombineData{Target: f.def.TargetIndex, Tool: f.def.ToolIndex, Operation: op}
+	case *RectangularPatternFeature:
+		src, err := sourceIndices(f.def.SourceFeatures, idx)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.RectPattern = &RectPatternData{Source: src, CountX: evalInt(f.def.CountX), CountY: evalInt(f.def.CountY)}
+	case *CircularPatternFeature:
+		src, err := sourceIndices(f.def.SourceFeatures, idx)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.CircPattern = &CircPatternData{Source: src, Count: evalInt(f.def.Count), Angle: evalFloat(f.def.Angle)}
+	case *SketchDrivenPatternFeature:
+		src, err := sourceIndices(f.def.SourceFeatures, idx)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SketchPattern = &SketchDrivenPatternData{Source: src, PointCount: evalInt(f.def.PointCount)}
+	case *MirrorFeature:
+		src, err := sourceIndices(f.def.SourceFeatures, idx)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Mirror = &MirrorData{Source: src, Plane: encodeKey(f.def.MirrorPlaneKey)}
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -149,30 +189,28 @@ func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, e
 	}, nil
 }
 
-// ApplyRecipe rebuilds the feature program from its serialized form, in order. The
-// caller recomputes afterward to regenerate geometry.
+// ApplyRecipe rebuilds the feature program from its serialized form, in order. It
+// tracks the features restored so far so a pattern/mirror can resolve the earlier
+// features it replicates (recorded as program indices). The caller recomputes
+// afterward to regenerate geometry.
 func (fs *PartFeatures) ApplyRecipe(data []FeatureData, sk SketchIndexer) error {
+	restored := make([]*PartFeature, 0, len(data))
 	for i, fd := range data {
-		if err := restoreFeature(fs, fd, sk); err != nil {
+		pf, err := buildFeature(fs, fd, sk, restored)
+		if err != nil {
 			return fmt.Errorf("feature %d (%s): %w", i, fd.Kind, err)
 		}
+		applyFeatureState(pf, fd)
+		restored = append(restored, pf)
 	}
-	return nil
-}
-
-func restoreFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer) error {
-	pf, err := buildFeature(fs, fd, sk)
-	if err != nil {
-		return err
-	}
-	applyFeatureState(pf, fd)
 	return nil
 }
 
 // buildFeature reconstructs one feature from its payload, erroring on an unknown kind
 // or a missing payload (no silent loss). Dress-up edge/face keys re-bind to the
-// regenerated topology on the next recompute (kernel topo FindEdgeByKey/FindFaceByKey).
-func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer) (*PartFeature, error) {
+// regenerated topology on the next recompute (kernel topo FindEdgeByKey/FindFaceByKey);
+// patterns resolve their source features from restored (the features built so far).
+func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored []*PartFeature) (*PartFeature, error) {
 	du := NewDressUpFeatures(fs)
 	switch fd.Kind {
 	case "extrude":
@@ -216,6 +254,14 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer) (*PartFeat
 		return restoreBoss(fs, fd.Boss)
 	case "combine":
 		return restoreCombine(fs, fd.Combine)
+	case "rectangular-pattern":
+		return restoreRectPattern(fs, fd.RectPattern, restored)
+	case "circular-pattern":
+		return restoreCircPattern(fs, fd.CircPattern, restored)
+	case "sketch-driven-pattern":
+		return restoreSketchPattern(fs, fd.SketchPattern, restored)
+	case "mirror":
+		return restoreMirror(fs, fd.Mirror, restored)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}
@@ -317,6 +363,16 @@ func evalFloat(fn func() float64) float64 {
 }
 
 func constFloat(v float64) func() float64 { return func() float64 { return v } }
+
+// evalInt / constInt are the integer counterparts for pattern counts.
+func evalInt(fn func() int) int {
+	if fn == nil {
+		return 0
+	}
+	return fn()
+}
+
+func constInt(v int) func() int { return func() int { return v } }
 
 // applyFeatureState restores the per-feature engine state (name, suppression).
 func applyFeatureState(pf *PartFeature, fd FeatureData) {

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -3,7 +3,6 @@
 package feature
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
@@ -40,39 +39,6 @@ type FeatureData struct {
 
 	BoundaryPatch *BoundaryPatchData `yaml:"boundaryPatch,omitempty"`
 	RuledSurface  *RuledSurfaceData  `yaml:"ruledSurface,omitempty"`
-}
-
-// EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
-// picked edges as reference keys plus the scalar value. The keys are base64 because
-// they are opaque lineage-derived bytes — the one non-text field (ADR-0020); they
-// re-bind to the regenerated edges after recompute (kernel topo FindEdgeByKey).
-type EdgeDressData struct {
-	Edges []string `yaml:"edges"`
-	Value float64  `yaml:"value"`
-}
-
-// FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked
-// faces as reference keys plus the scalar value.
-type FaceDressData struct {
-	Faces []string `yaml:"faces"`
-	Value float64  `yaml:"value"`
-}
-
-// ThreadData tags a single cylindrical face (reference key) with a thread designation.
-type ThreadData struct {
-	Face        string `yaml:"face"`
-	Designation string `yaml:"designation"`
-}
-
-// ExtrudeData is an extrude's recipe: which sketch profile, the boolean operation, and
-// the distance extent. The distance is the evaluated growth (a fixed value on reopen;
-// parametric distance expressions arrive with the dimension-driven extent API).
-type ExtrudeData struct {
-	Sketch    int     `yaml:"sketch"`
-	Profile   int     `yaml:"profile"`
-	Operation string  `yaml:"operation"`
-	Distance  float64 `yaml:"distance"`
-	Taper     float64 `yaml:"taper,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -183,27 +149,6 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 	return fd, nil
 }
 
-func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, error) {
-	if def.Extent.Type != DistanceExtent {
-		return nil, fmt.Errorf("only distance extents are serializable (got extent type %d)", def.Extent.Type)
-	}
-	idx, ok := sk.IndexOf(def.Sketch)
-	if !ok {
-		return nil, fmt.Errorf("extrude references a sketch that is not in the part")
-	}
-	op, err := operationName(def.Operation)
-	if err != nil {
-		return nil, err
-	}
-	return &ExtrudeData{
-		Sketch:    idx,
-		Profile:   def.ProfileIndex,
-		Operation: op,
-		Distance:  def.Extent.distance(),
-		Taper:     def.Taper,
-	}, nil
-}
-
 // ApplyRecipe rebuilds the feature program from its serialized form, in order. It
 // tracks the features restored so far so a pattern/mirror can resolve the earlier
 // features it replicates (recorded as program indices). The caller recomputes
@@ -285,103 +230,6 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}
 }
-
-// requireExtrude restores an extrude, erroring on a missing payload.
-func requireExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
-	if ed == nil {
-		return nil, fmt.Errorf("extrude feature is missing its payload")
-	}
-	return restoreExtrude(fs, ed, sk)
-}
-
-// dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups.
-type dressInputs struct {
-	keys  [][]byte
-	value float64
-}
-
-func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
-	if d == nil {
-		return dressInputs{}, fmt.Errorf("%s feature is missing its payload", kind)
-	}
-	keys, err := decodeKeys(d.Edges)
-	if err != nil {
-		return dressInputs{}, err
-	}
-	return dressInputs{keys: keys, value: d.Value}, nil
-}
-
-func requireFaceDress(d *FaceDressData, kind string) (dressInputs, error) {
-	if d == nil {
-		return dressInputs{}, fmt.Errorf("%s feature is missing its payload", kind)
-	}
-	keys, err := decodeKeys(d.Faces)
-	if err != nil {
-		return dressInputs{}, err
-	}
-	return dressInputs{keys: keys, value: d.Value}, nil
-}
-
-func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
-	skt, ok := sk.At(ed.Sketch)
-	if !ok {
-		return nil, fmt.Errorf("extrude references sketch index %d, which does not exist", ed.Sketch)
-	}
-	op, err := parseOperation(ed.Operation)
-	if err != nil {
-		return nil, err
-	}
-	dist := ed.Distance
-	pf := NewExtrudeFeatures(fs).AddByDistanceExtent(skt, ed.Profile, op, func() float64 { return dist })
-	if ed.Taper != 0 {
-		pf.feature.(*ExtrudeFeature).def.Taper = ed.Taper
-	}
-	return pf, nil
-}
-
-// encodeKeys / decodeKeys base64-encode reference keys (opaque lineage bytes) so they
-// stay valid text in the YAML document (ADR-0020); they re-bind after recompute.
-func encodeKeys(keys [][]byte) []string {
-	out := make([]string, len(keys))
-	for i, k := range keys {
-		out[i] = encodeKey(k)
-	}
-	return out
-}
-
-func decodeKeys(encoded []string) ([][]byte, error) {
-	out := make([][]byte, len(encoded))
-	for i, e := range encoded {
-		k, err := decodeKey(e)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = k
-	}
-	return out, nil
-}
-
-func encodeKey(k []byte) string { return base64.StdEncoding.EncodeToString(k) }
-
-func decodeKey(s string) ([]byte, error) {
-	k, err := base64.StdEncoding.DecodeString(s)
-	if err != nil {
-		return nil, fmt.Errorf("reference key %q is not valid base64: %w", s, err)
-	}
-	return k, nil
-}
-
-// evalFloat reads a dress-up's scalar (a closure, typically a parameter); a nil closure
-// reads as 0. constFloat is its inverse for restore — a fixed value (parametric
-// dress-up values arrive with the dimension-driven API, like extrude distance).
-func evalFloat(fn func() float64) float64 {
-	if fn == nil {
-		return 0
-	}
-	return fn()
-}
-
-func constFloat(v float64) func() float64 { return func() float64 { return v } }
 
 // evalInt / constInt are the integer counterparts for pattern counts.
 func evalInt(fn func() int) int {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// This file holds the YAML codecs for the dress-up family (fillet/chamfer/shell/draft/
+// thread) and the reference-key + scalar helpers shared across feature codecs. Edge and
+// face reference keys are opaque lineage bytes, so they are base64-encoded (ADR-0020)
+// and re-bind to the regenerated topology after recompute.
+
+// EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
+// picked edges as reference keys plus the scalar value.
+type EdgeDressData struct {
+	Edges []string `yaml:"edges"`
+	Value float64  `yaml:"value"`
+}
+
+// FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked
+// faces as reference keys plus the scalar value.
+type FaceDressData struct {
+	Faces []string `yaml:"faces"`
+	Value float64  `yaml:"value"`
+}
+
+// ThreadData tags a single cylindrical face (reference key) with a thread designation.
+type ThreadData struct {
+	Face        string `yaml:"face"`
+	Designation string `yaml:"designation"`
+}
+
+// dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups.
+type dressInputs struct {
+	keys  [][]byte
+	value float64
+}
+
+func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
+	if d == nil {
+		return dressInputs{}, fmt.Errorf("%s feature is missing its payload", kind)
+	}
+	keys, err := decodeKeys(d.Edges)
+	if err != nil {
+		return dressInputs{}, err
+	}
+	return dressInputs{keys: keys, value: d.Value}, nil
+}
+
+func requireFaceDress(d *FaceDressData, kind string) (dressInputs, error) {
+	if d == nil {
+		return dressInputs{}, fmt.Errorf("%s feature is missing its payload", kind)
+	}
+	keys, err := decodeKeys(d.Faces)
+	if err != nil {
+		return dressInputs{}, err
+	}
+	return dressInputs{keys: keys, value: d.Value}, nil
+}
+
+// encodeKeys / decodeKeys base64-encode reference keys (opaque lineage bytes) so they
+// stay valid text in the YAML document (ADR-0020); they re-bind after recompute.
+func encodeKeys(keys [][]byte) []string {
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = encodeKey(k)
+	}
+	return out
+}
+
+func decodeKeys(encoded []string) ([][]byte, error) {
+	out := make([][]byte, len(encoded))
+	for i, e := range encoded {
+		k, err := decodeKey(e)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = k
+	}
+	return out, nil
+}
+
+func encodeKey(k []byte) string { return base64.StdEncoding.EncodeToString(k) }
+
+func decodeKey(s string) ([]byte, error) {
+	k, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("reference key %q is not valid base64: %w", s, err)
+	}
+	return k, nil
+}
+
+// evalFloat reads a feature's scalar (a closure, typically a parameter); a nil closure
+// reads as 0. constFloat is its inverse for restore — a fixed value (parametric values
+// arrive with the dimension-driven API, like extrude distance).
+func evalFloat(fn func() float64) float64 {
+	if fn == nil {
+		return 0
+	}
+	return fn()
+}
+
+func constFloat(v float64) func() float64 { return func() float64 { return v } }

--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// ExtrudeData is an extrude's recipe: which sketch profile, the boolean operation, and
+// the distance extent. The distance is the evaluated growth (a fixed value on reopen;
+// parametric distance expressions arrive with the dimension-driven extent API).
+type ExtrudeData struct {
+	Sketch    int     `yaml:"sketch"`
+	Profile   int     `yaml:"profile"`
+	Operation string  `yaml:"operation"`
+	Distance  float64 `yaml:"distance"`
+	Taper     float64 `yaml:"taper,omitempty"`
+}
+
+func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, error) {
+	if def.Extent.Type != DistanceExtent {
+		return nil, fmt.Errorf("only distance extents are serializable (got extent type %d)", def.Extent.Type)
+	}
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("extrude references a sketch that is not in the part")
+	}
+	op, err := operationName(def.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return &ExtrudeData{
+		Sketch:    idx,
+		Profile:   def.ProfileIndex,
+		Operation: op,
+		Distance:  def.Extent.distance(),
+		Taper:     def.Taper,
+	}, nil
+}
+
+// requireExtrude restores an extrude, erroring on a missing payload.
+func requireExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
+	if ed == nil {
+		return nil, fmt.Errorf("extrude feature is missing its payload")
+	}
+	return restoreExtrude(fs, ed, sk)
+}
+
+func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
+	skt, ok := sk.At(ed.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("extrude references sketch index %d, which does not exist", ed.Sketch)
+	}
+	op, err := parseOperation(ed.Operation)
+	if err != nil {
+		return nil, err
+	}
+	dist := ed.Distance
+	pf := NewExtrudeFeatures(fs).AddByDistanceExtent(skt, ed.Profile, op, func() float64 { return dist })
+	if ed.Taper != 0 {
+		pf.feature.(*ExtrudeFeature).def.Taper = ed.Taper
+	}
+	return pf, nil
+}

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// This file holds the YAML codec for the direct face-edit features — split, move-face,
+// face-offset, delete-face, replace-face and thicken. They share one shape (a set of
+// picked faces by reference key), so they serialize uniformly via the faceEditor
+// interface and restore by kind. The keys re-bind to the regenerated faces on recompute.
+
+// FaceEditData is a direct face edit: the picked faces as reference keys.
+type FaceEditData struct {
+	Faces []string `yaml:"faces"`
+}
+
+// faceEditor is satisfied by every direct face-edit feature (they embed faceEditFeature),
+// exposing the picked face keys for serialization.
+type faceEditor interface {
+	Feature
+	FaceKeys() [][]byte
+}
+
+// restoreFaceEdit rebuilds a direct face edit of the given kind from its face keys.
+func restoreFaceEdit(fs *PartFeatures, kind string, d *FaceEditData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("%s feature is missing its payload", kind)
+	}
+	keys, err := decodeKeys(d.Faces)
+	if err != nil {
+		return nil, err
+	}
+	m := NewModifyFeatures(fs)
+	switch kind {
+	case "split":
+		return m.AddSplit(keys), nil
+	case "move-face":
+		return m.AddMoveFace(keys), nil
+	case "face-offset":
+		return m.AddFaceOffset(keys), nil
+	case "delete-face":
+		return m.AddDeleteFace(keys), nil
+	case "replace-face":
+		return m.AddReplaceFace(keys), nil
+	case "thicken":
+		return m.AddThicken(keys), nil
+	default:
+		return nil, fmt.Errorf("unknown face-edit kind %q", kind)
+	}
+}

--- a/model/feature/serialize_pattern.go
+++ b/model/feature/serialize_pattern.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// This file holds the YAML codecs for pattern features (rectangular/circular/
+// sketch-driven) and mirror. These replicate earlier features, recorded as program
+// indices (feature ids are session-local, never persisted) and resolved back to the
+// restored features on open. Mirror also references a mirror plane by reference key.
+
+// RectPatternData replicates source features in a 2D grid.
+type RectPatternData struct {
+	Source []int `yaml:"source"`
+	CountX int   `yaml:"countX"`
+	CountY int   `yaml:"countY"`
+}
+
+// CircPatternData replicates source features around an axis.
+type CircPatternData struct {
+	Source []int   `yaml:"source"`
+	Count  int     `yaml:"count"`
+	Angle  float64 `yaml:"angle"`
+}
+
+// SketchDrivenPatternData places one occurrence of the source per sketch point.
+type SketchDrivenPatternData struct {
+	Source     []int `yaml:"source"`
+	PointCount int   `yaml:"pointCount"`
+}
+
+// MirrorData reflects source features across a plane (a reference key).
+type MirrorData struct {
+	Source []int  `yaml:"source"`
+	Plane  string `yaml:"plane"`
+}
+
+func restoreRectPattern(fs *PartFeatures, d *RectPatternData, restored []*PartFeature) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("rectangular-pattern feature is missing its payload")
+	}
+	src, err := resolveSources(d.Source, restored)
+	if err != nil {
+		return nil, err
+	}
+	NewPatternFeatures(fs).AddRectangular(src, constInt(d.CountX), constInt(d.CountY))
+	return lastFeature(fs), nil
+}
+
+func restoreCircPattern(fs *PartFeatures, d *CircPatternData, restored []*PartFeature) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("circular-pattern feature is missing its payload")
+	}
+	src, err := resolveSources(d.Source, restored)
+	if err != nil {
+		return nil, err
+	}
+	NewPatternFeatures(fs).AddCircular(src, constInt(d.Count), constFloat(d.Angle))
+	return lastFeature(fs), nil
+}
+
+func restoreSketchPattern(fs *PartFeatures, d *SketchDrivenPatternData, restored []*PartFeature) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sketch-driven-pattern feature is missing its payload")
+	}
+	src, err := resolveSources(d.Source, restored)
+	if err != nil {
+		return nil, err
+	}
+	NewPatternFeatures(fs).AddSketchDriven(src, constInt(d.PointCount))
+	return lastFeature(fs), nil
+}
+
+func restoreMirror(fs *PartFeatures, d *MirrorData, restored []*PartFeature) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("mirror feature is missing its payload")
+	}
+	src, err := resolveSources(d.Source, restored)
+	if err != nil {
+		return nil, err
+	}
+	key, err := decodeKey(d.Plane)
+	if err != nil {
+		return nil, err
+	}
+	NewPatternFeatures(fs).AddMirror(src, key)
+	return lastFeature(fs), nil
+}
+
+// sourceIndices maps a pattern's source feature ids to their program positions for
+// serialization, erroring if a source is not part of the program.
+func sourceIndices(ids []ID, idx map[ID]int) ([]int, error) {
+	out := make([]int, len(ids))
+	for i, id := range ids {
+		pos, ok := idx[id]
+		if !ok {
+			return nil, fmt.Errorf("pattern source feature id %d is not in the program", id)
+		}
+		out[i] = pos
+	}
+	return out, nil
+}
+
+// resolveSources maps program positions back to the restored features' ids, erroring
+// on an out-of-range index (a source must precede the pattern that consumes it).
+func resolveSources(indices []int, restored []*PartFeature) ([]ID, error) {
+	out := make([]ID, len(indices))
+	for i, pos := range indices {
+		if pos < 0 || pos >= len(restored) {
+			return nil, fmt.Errorf("pattern source index %d is out of range (%d features restored so far)", pos, len(restored))
+		}
+		out[i] = restored[pos].ID()
+	}
+	return out, nil
+}
+
+// lastFeature returns the most recently added feature — the pattern Add methods return
+// the concrete feature, not the engine's PartFeature wrapper, so restore reads it back.
+func lastFeature(fs *PartFeatures) *PartFeature { return fs.Item(fs.Count() - 1) }

--- a/model/feature/serialize_solid.go
+++ b/model/feature/serialize_solid.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// This file holds the YAML codecs for the placed/boolean solid features: holes,
+// bosses (both placed on a face by reference key, like the dress-up family) and
+// combine (a boolean between two running bodies by index). Keys re-bind to the
+// regenerated topology after recompute; body indices address the running state.
+
+// HoleData is a hole's recipe: the placement face (reference key), diameter/depth,
+// the hole geometry type, and optional tap data.
+type HoleData struct {
+	Face        string  `yaml:"face"`
+	Diameter    float64 `yaml:"diameter"`
+	Depth       float64 `yaml:"depth"`
+	Type        string  `yaml:"type"`
+	Tapped      bool    `yaml:"tapped,omitempty"`
+	Designation string  `yaml:"designation,omitempty"`
+}
+
+// BossData is a boss's recipe: a raised cylinder on a placement face.
+type BossData struct {
+	Face     string  `yaml:"face"`
+	Diameter float64 `yaml:"diameter"`
+	Height   float64 `yaml:"height"`
+}
+
+// CombineData booleans two running bodies (by index) under an operation.
+type CombineData struct {
+	Target    int    `yaml:"target"`
+	Tool      int    `yaml:"tool"`
+	Operation string `yaml:"operation"`
+}
+
+func serializeHole(def *HoleDefinition) (*HoleData, error) {
+	kind, err := holeTypeName(def.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &HoleData{
+		Face:        encodeKey(def.PlacementFaceKey),
+		Diameter:    evalFloat(def.Diameter),
+		Depth:       evalFloat(def.Depth),
+		Type:        kind,
+		Tapped:      def.Tap.Tapped,
+		Designation: def.Tap.Designation,
+	}, nil
+}
+
+func restoreHole(fs *PartFeatures, h *HoleData) (*PartFeature, error) {
+	if h == nil {
+		return nil, fmt.Errorf("hole feature is missing its payload")
+	}
+	key, err := decodeKey(h.Face)
+	if err != nil {
+		return nil, err
+	}
+	holeType, err := parseHoleType(h.Type)
+	if err != nil {
+		return nil, err
+	}
+	holes := NewHoleFeatures(fs)
+	var pf *PartFeature
+	if h.Tapped {
+		pf = holes.AddTapped(key, constFloat(h.Diameter), constFloat(h.Depth), h.Designation)
+	} else {
+		pf = holes.AddDrilled(key, constFloat(h.Diameter), constFloat(h.Depth))
+	}
+	pf.feature.(*HoleFeature).def.Type = holeType
+	return pf, nil
+}
+
+func restoreBoss(fs *PartFeatures, b *BossData) (*PartFeature, error) {
+	if b == nil {
+		return nil, fmt.Errorf("boss feature is missing its payload")
+	}
+	key, err := decodeKey(b.Face)
+	if err != nil {
+		return nil, err
+	}
+	return NewBossFeatures(fs).Add(key, constFloat(b.Diameter), constFloat(b.Height)), nil
+}
+
+func restoreCombine(fs *PartFeatures, c *CombineData) (*PartFeature, error) {
+	if c == nil {
+		return nil, fmt.Errorf("combine feature is missing its payload")
+	}
+	op, err := parseOperation(c.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return NewModifyFeatures(fs).AddCombine(c.Target, c.Tool, op), nil
+}
+
+// holeTypeName / parseHoleType map the hole geometry type to/from a stable name.
+func holeTypeName(t HoleType) (string, error) {
+	switch t {
+	case DrilledHole:
+		return "drilled", nil
+	case CounterboreHole:
+		return "counterbore", nil
+	case CountersinkHole:
+		return "countersink", nil
+	default:
+		return "", fmt.Errorf("unknown hole type %d", t)
+	}
+}
+
+func parseHoleType(name string) (HoleType, error) {
+	switch name {
+	case "drilled":
+		return DrilledHole, nil
+	case "counterbore":
+		return CounterboreHole, nil
+	case "countersink":
+		return CountersinkHole, nil
+	default:
+		return 0, fmt.Errorf("unknown hole type %q (want drilled|counterbore|countersink)", name)
+	}
+}

--- a/model/feature/serialize_surface.go
+++ b/model/feature/serialize_surface.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// This file holds the YAML codecs for the sketch-based surface features — boundary
+// patch (fills closed sketch loops) and ruled surface (sweeps a profile's edges by a
+// distance). Like extrude, they reference their input sketch by index via the
+// SketchIndexer.
+
+// BoundaryPatchData is a boundary patch's recipe: the closed sketch loops it fills.
+type BoundaryPatchData struct {
+	Loops []PatchLoopData `yaml:"loops"`
+}
+
+// PatchLoopData is one boundary loop: a sketch profile and its continuity condition.
+type PatchLoopData struct {
+	Sketch    int    `yaml:"sketch"`
+	Profile   int    `yaml:"profile"`
+	Condition string `yaml:"condition"`
+}
+
+// RuledSurfaceData is a ruled surface's recipe: a profile swept by straight rulings.
+type RuledSurfaceData struct {
+	Sketch   int     `yaml:"sketch"`
+	Profile  int     `yaml:"profile"`
+	Type     string  `yaml:"type"`
+	Distance float64 `yaml:"distance"`
+}
+
+func serializeBoundaryPatch(def *BoundaryPatchDefinition, sk SketchIndexer) (*BoundaryPatchData, error) {
+	if def.Loops == nil || def.Loops.Count() == 0 {
+		return nil, fmt.Errorf("boundary patch has no loops")
+	}
+	out := &BoundaryPatchData{Loops: make([]PatchLoopData, def.Loops.Count())}
+	for i := 0; i < def.Loops.Count(); i++ {
+		loop := def.Loops.Item(i)
+		idx, ok := sk.IndexOf(loop.Sketch)
+		if !ok {
+			return nil, fmt.Errorf("boundary patch loop %d references a sketch not in the part", i)
+		}
+		cond, err := patchConditionName(loop.Condition)
+		if err != nil {
+			return nil, err
+		}
+		out.Loops[i] = PatchLoopData{Sketch: idx, Profile: loop.ProfileIndex, Condition: cond}
+	}
+	return out, nil
+}
+
+func restoreBoundaryPatch(fs *PartFeatures, d *BoundaryPatchData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil || len(d.Loops) == 0 {
+		return nil, fmt.Errorf("boundary-patch feature is missing its loops")
+	}
+	first, err := resolvePatchLoop(d.Loops[0], sk)
+	if err != nil {
+		return nil, err
+	}
+	pf := NewBoundaryPatchFeatures(fs).Add(first.skt, first.profile, first.cond)
+	// Additional loops (outer + holes) append to the same patch definition.
+	for i := 1; i < len(d.Loops); i++ {
+		more, err := resolvePatchLoop(d.Loops[i], sk)
+		if err != nil {
+			return nil, err
+		}
+		pf.feature.(*BoundaryPatchFeature).def.Loops.Add(more.skt, more.profile, more.cond)
+	}
+	return pf, nil
+}
+
+// patchLoopInputs is the resolved (sketch, profile, condition) of one loop.
+type patchLoopInputs struct {
+	skt     *sketch.Sketch
+	profile int
+	cond    PatchCondition
+}
+
+// resolvePatchLoop resolves a serialized loop's sketch index and continuity name.
+func resolvePatchLoop(loop PatchLoopData, sk SketchIndexer) (patchLoopInputs, error) {
+	skt, ok := sk.At(loop.Sketch)
+	if !ok {
+		return patchLoopInputs{}, fmt.Errorf("boundary patch references sketch index %d, which does not exist", loop.Sketch)
+	}
+	cond, err := parsePatchCondition(loop.Condition)
+	if err != nil {
+		return patchLoopInputs{}, err
+	}
+	return patchLoopInputs{skt: skt, profile: loop.Profile, cond: cond}, nil
+}
+
+func serializeRuledSurface(def *RuledSurfaceDefinition, sk SketchIndexer) (*RuledSurfaceData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("ruled surface references a sketch not in the part")
+	}
+	kind, err := ruledTypeName(def.Type)
+	if err != nil {
+		return nil, err
+	}
+	return &RuledSurfaceData{Sketch: idx, Profile: def.ProfileIndex, Type: kind, Distance: evalFloat(def.Distance)}, nil
+}
+
+func restoreRuledSurface(fs *PartFeatures, d *RuledSurfaceData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("ruled-surface feature is missing its payload")
+	}
+	skt, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("ruled surface references sketch index %d, which does not exist", d.Sketch)
+	}
+	kind, err := parseRuledType(d.Type)
+	if err != nil {
+		return nil, err
+	}
+	return NewRuledSurfaceFeatures(fs).AddByDistance(skt, d.Profile, kind, constFloat(d.Distance)), nil
+}
+
+// patchConditionName / parsePatchCondition map the continuity condition to/from a name.
+func patchConditionName(c PatchCondition) (string, error) {
+	switch c {
+	case PatchFree:
+		return "free", nil
+	case PatchTangent:
+		return "tangent", nil
+	case PatchCurvature:
+		return "curvature", nil
+	default:
+		return "", fmt.Errorf("unknown patch condition %d", c)
+	}
+}
+
+func parsePatchCondition(name string) (PatchCondition, error) {
+	switch name {
+	case "free":
+		return PatchFree, nil
+	case "tangent":
+		return PatchTangent, nil
+	case "curvature":
+		return PatchCurvature, nil
+	default:
+		return 0, fmt.Errorf("unknown patch condition %q (want free|tangent|curvature)", name)
+	}
+}
+
+// ruledTypeName / parseRuledType map the ruled-surface direction type to/from a name.
+func ruledTypeName(t RuledSurfaceType) (string, error) {
+	switch t {
+	case RuledNormal:
+		return "normal", nil
+	case RuledTangent:
+		return "tangent", nil
+	case RuledPerpendicular:
+		return "perpendicular", nil
+	default:
+		return "", fmt.Errorf("unknown ruled surface type %d", t)
+	}
+}
+
+func parseRuledType(name string) (RuledSurfaceType, error) {
+	switch name {
+	case "normal":
+		return RuledNormal, nil
+	case "tangent":
+		return RuledTangent, nil
+	case "perpendicular":
+		return RuledPerpendicular, nil
+	default:
+		return 0, fmt.Errorf("unknown ruled surface type %q (want normal|tangent|perpendicular)", name)
+	}
+}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -188,6 +188,41 @@ func TestSurfaceFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestFaceEditFeaturesRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	m := NewModifyFeatures(fs)
+	m.AddSplit([][]byte{[]byte("f-split")})
+	m.AddMoveFace([][]byte{[]byte("f-move")})
+	m.AddFaceOffset([][]byte{[]byte("f-off")})
+	m.AddDeleteFace([][]byte{[]byte("f-del")})
+	m.AddReplaceFace([][]byte{[]byte("f-rep")})
+	m.AddThicken([][]byte{[]byte("f-thick")})
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	want := []string{"split", "move-face", "face-offset", "delete-face", "replace-face", "thicken"}
+	if fresh.Count() != len(want) {
+		t.Fatalf("feature count = %d, want %d", fresh.Count(), len(want))
+	}
+	for i, kind := range want {
+		if got := fresh.Item(i).Kind(); got != kind {
+			t.Errorf("feature %d kind = %q, want %q", i, got, kind)
+		}
+	}
+	// The split's face key must survive byte-for-byte.
+	split := fresh.Item(0).Definition().(faceEditor)
+	if len(split.FaceKeys()) != 1 || string(split.FaceKeys()[0]) != "f-split" {
+		t.Errorf("split face keys = %v, want [f-split]", split.FaceKeys())
+	}
+}
+
 func TestUncodedFeatureErrorsRatherThanDrops(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	fs.Add(fakeFeature{})

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -123,6 +123,43 @@ func TestSolidFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPatternFeaturesRebindSourceByIndex(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	src := NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	NewPatternFeatures(fs).AddRectangular([]ID{src.ID()}, func() int { return 3 }, func() int { return 2 })
+	NewPatternFeatures(fs).AddMirror([]ID{src.ID()}, []byte("plane-key"))
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 3 {
+		t.Fatalf("feature count = %d, want 3 (extrude + rect pattern + mirror)", fresh.Count())
+	}
+
+	// The pattern's source must re-bind to the RESTORED extrude's id, not the old one.
+	wantSource := fresh.Item(0).ID()
+	rect := fresh.Item(1).Definition().(*RectangularPatternFeature).Definition()
+	if len(rect.SourceFeatures) != 1 || rect.SourceFeatures[0] != wantSource {
+		t.Errorf("rect pattern source = %v, want [%d]", rect.SourceFeatures, wantSource)
+	}
+	if rect.CountX() != 3 || rect.CountY() != 2 {
+		t.Errorf("rect counts = %dx%d, want 3x2", rect.CountX(), rect.CountY())
+	}
+	mirror := fresh.Item(2).Definition().(*MirrorFeature).Definition()
+	if len(mirror.SourceFeatures) != 1 || mirror.SourceFeatures[0] != wantSource {
+		t.Errorf("mirror source = %v, want [%d]", mirror.SourceFeatures, wantSource)
+	}
+	if string(mirror.MirrorPlaneKey) != "plane-key" {
+		t.Errorf("mirror plane key = %q, want plane-key", mirror.MirrorPlaneKey)
+	}
+}
+
 func TestUncodedFeatureErrorsRatherThanDrops(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	fs.Add(fakeFeature{})

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -160,6 +160,34 @@ func TestPatternFeaturesRebindSourceByIndex(t *testing.T) {
 	}
 }
 
+func TestSurfaceFeaturesRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewBoundaryPatchFeatures(fs).Add(sk, 0, PatchFree)
+	NewRuledSurfaceFeatures(fs).AddByDistance(sk, 0, RuledNormal, func() float64 { return 2 })
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 2 {
+		t.Fatalf("feature count = %d, want 2", fresh.Count())
+	}
+
+	bp := fresh.Item(0).Definition().(*BoundaryPatchFeature).Definition()
+	if bp.Loops.Count() != 1 || bp.Loops.Item(0).ProfileIndex != 0 || bp.Loops.Item(0).Condition != PatchFree {
+		t.Errorf("boundary patch loop = %+v, want one free loop on profile 0", bp.Loops.Item(0))
+	}
+	rs := fresh.Item(1).Definition().(*RuledSurfaceFeature).Definition()
+	if rs.Type != RuledNormal || rs.Distance() != 2 {
+		t.Errorf("ruled surface = type %v dist %v, want normal 2", rs.Type, rs.Distance())
+	}
+}
+
 func TestUncodedFeatureErrorsRatherThanDrops(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	fs.Add(fakeFeature{})

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -88,6 +88,41 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSolidFeaturesRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewHoleFeatures(fs).AddTapped([]byte("face-1"), func() float64 { return 6 }, func() float64 { return 10 }, "M6x1")
+	NewBossFeatures(fs).Add([]byte("face-2"), func() float64 { return 8 }, func() float64 { return 4 })
+	NewModifyFeatures(fs).AddCombine(0, 1, ops.Cut)
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 3 {
+		t.Fatalf("feature count = %d, want 3", fresh.Count())
+	}
+
+	hole := fresh.Item(0).Definition().(*HoleFeature).Definition()
+	if string(hole.PlacementFaceKey) != "face-1" || hole.Diameter() != 6 || hole.Depth() != 10 {
+		t.Errorf("hole = face %q d %v depth %v, want face-1 6 10", hole.PlacementFaceKey, hole.Diameter(), hole.Depth())
+	}
+	if !hole.Tap.Tapped || hole.Tap.Designation != "M6x1" {
+		t.Errorf("hole tap = %+v, want tapped M6x1", hole.Tap)
+	}
+	boss := fresh.Item(1).Definition().(*BossFeature).Definition()
+	if string(boss.PlacementFaceKey) != "face-2" || boss.Height() != 4 {
+		t.Errorf("boss = face %q height %v, want face-2 4", boss.PlacementFaceKey, boss.Height())
+	}
+	combine := fresh.Item(2).Definition().(*CombineFeature).Definition()
+	if combine.TargetIndex != 0 || combine.ToolIndex != 1 || combine.Operation != ops.Cut {
+		t.Errorf("combine = %+v, want target 0 tool 1 Cut", combine)
+	}
+}
+
 func TestUncodedFeatureErrorsRatherThanDrops(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	fs.Add(fakeFeature{})


### PR DESCRIPTION
Extends the document recipe (ADR-0020) with codecs for more feature kinds, each with a round-trip test. Builds on the merged document-persistence work (extrude + dress-up).

## Now round-tripping
- **hole / boss** (placed on a face by reference key) + **combine** (bodies by index)
- **patterns**: rectangular / circular / sketch-driven + **mirror** — source features recorded as program indices and re-bound on restore
- **boundary-patch** + **ruled-surface** (sketch-based, like extrude)
- the six direct **face-edits** (split/move-face/face-offset/delete-face/replace-face/thicken), uniform via a faceEditor interface

Reference keys re-bind to the regenerated topology after recompute. Uncoded feature kinds still error on save (no silent loss). Also split the feature codecs into per-family files to stay under the size limit.

## Verification
`go vet` clean; full core suite **0 failures**; `head/ui` cgo tests pass; each commit builds independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)