### PR TITLE
Inventor-style origin coordinate system + work-feature & revolve persistence

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,3 +49,12 @@ issues:
     # Tests may be longer and print freely.
     - path: _test\.go
       linters: [funlen, gocyclo, forbidigo, dupl]
+    # The recipe codecs (ADR-0020 document persistence) are exhaustive, one-case-per
+    # -kind dispatch switches — serializing/restoring every entity/constraint/feature
+    # kind — so their statement count is inherent to the dispatch, not a smell.
+    - path: serialize.*\.go
+      linters: [funlen, gocyclo]
+    # The recipe DTOs deliberately echo their package (SketchData, FeatureData) for
+    # readable cross-package use; the stutter is intentional, descriptive naming.
+    - text: "stutters"
+      linters: [revive]

--- a/app/create_sketch_tool.go
+++ b/app/create_sketch_tool.go
@@ -5,7 +5,7 @@ package app
 import (
 	"errors"
 
-	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
 )
 
 // CreateSketchTool is Inventor's "Create 2D Sketch" interaction: after the command
@@ -14,7 +14,7 @@ import (
 // the instant it is clicked (auto-commit). It restricts the selection filter to work
 // planes while active, so only valid sketch hosts highlight/pick.
 type CreateSketchTool struct {
-	plane      *compdef.WorkPlane
+	plane      *feature.WorkPlane
 	prevFilter *SelectionFilter
 }
 

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
-	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/scene"
 )
 
@@ -20,7 +20,7 @@ import (
 type RayPicker struct {
 	camera scene.Camera
 	bodies func() []*topo.Body
-	planes func() []*compdef.WorkPlane
+	planes func() []*feature.WorkPlane
 }
 
 // NewRayPicker builds a picker over a camera and a provider of the current scene
@@ -31,7 +31,7 @@ func NewRayPicker(camera scene.Camera, bodies func() []*topo.Body) *RayPicker {
 
 // WithPlanes adds a provider of selectable work planes (the part's origin planes), so
 // the picker can resolve a click on a datum plane in empty space.
-func (p *RayPicker) WithPlanes(planes func() []*compdef.WorkPlane) *RayPicker {
+func (p *RayPicker) WithPlanes(planes func() []*feature.WorkPlane) *RayPicker {
 	p.planes = planes
 	return p
 }
@@ -73,11 +73,11 @@ func (p *RayPicker) nearestFace(origin math.Point3, dir math.Vector3) (*topo.Fac
 
 // nearestPlane returns the closest origin work plane whose display square the ray
 // crosses, and the ray parameter (or nil/Inf if none).
-func (p *RayPicker) nearestPlane(origin math.Point3, dir math.Vector3) (*compdef.WorkPlane, float64) {
+func (p *RayPicker) nearestPlane(origin math.Point3, dir math.Vector3) (*feature.WorkPlane, float64) {
 	if p.planes == nil {
 		return nil, stdmath.Inf(1)
 	}
-	var hit *compdef.WorkPlane
+	var hit *feature.WorkPlane
 	best := stdmath.Inf(1)
 	for _, wp := range p.planes() {
 		if t, ok := rayWorkPlane(origin, dir, wp); ok && t < best {
@@ -104,7 +104,7 @@ func facePick(face *topo.Face, body *topo.Body, filter *SelectionFilter) (Select
 
 // rayWorkPlane intersects a ray with a work plane and reports the forward parameter
 // when the hit lies within the plane's finite display square.
-func rayWorkPlane(origin math.Point3, dir math.Vector3, wp *compdef.WorkPlane) (float64, bool) {
+func rayWorkPlane(origin math.Point3, dir math.Vector3, wp *feature.WorkPlane) (float64, bool) {
 	plane := wp.Plane()
 	n := plane.Normal().AsVector()
 	denom := dir.Dot(n)

--- a/app/selection.go
+++ b/app/selection.go
@@ -4,7 +4,6 @@ package app
 
 import (
 	"github.com/Oblikovati/oblikovati/kernel/topo"
-	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
@@ -63,7 +62,7 @@ type SketchEntityHandle struct{ Entity sketch.Entity }
 func (SketchEntityHandle) SelectionKind() SelectionKind { return SelectSketchEntity }
 
 // WorkPlaneHandle wraps a picked origin/work plane (selected to host a new sketch).
-type WorkPlaneHandle struct{ Plane *compdef.WorkPlane }
+type WorkPlaneHandle struct{ Plane *feature.WorkPlane }
 
 func (WorkPlaneHandle) SelectionKind() SelectionKind { return SelectWorkPlane }
 

--- a/app/sketch_env.go
+++ b/app/sketch_env.go
@@ -5,7 +5,7 @@ package app
 import (
 	"errors"
 
-	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
 
@@ -49,7 +49,7 @@ func (s *Session) CreateSketchOnSelectedPlane() (*sketch.Sketch, error) {
 }
 
 // SelectedWorkPlane returns the first selected work plane, or nil.
-func (s *Session) SelectedWorkPlane() *compdef.WorkPlane {
+func (s *Session) SelectedWorkPlane() *feature.WorkPlane {
 	for _, it := range s.selection.Items() {
 		if h, ok := it.(WorkPlaneHandle); ok {
 			return h.Plane

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -111,7 +111,7 @@ func seedPart(s *app.Session) {
 	// staying bound to this seeded part.
 	s.SetPicker(app.NewRayPicker(s.Camera(),
 		func() []*topo.Body { return activeBodies(s) }).
-		WithPlanes(func() []*compdef.WorkPlane { return activeOriginPlanes(s) }))
+		WithPlanes(func() []*feature.WorkPlane { return activeOriginPlanes(s) }))
 
 	// Frame the box (centered ~(2,1.5,2.5)) from a three-quarter view.
 	cam := s.Camera()
@@ -132,7 +132,7 @@ func activeBodies(s *app.Session) []*topo.Body {
 
 // activeOriginPlanes returns the active part's origin work planes (nil if none), so
 // the picker can hit-test the current document's planes.
-func activeOriginPlanes(s *app.Session) []*compdef.WorkPlane {
+func activeOriginPlanes(s *app.Session) []*feature.WorkPlane {
 	if p, err := modelaccess.ActivePart(s); err == nil {
 		return p.OriginPlanes()
 	}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
@@ -338,7 +339,7 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		// ignore user input; otherwise apply navigation then resolve clicks/hover so the
 		// picker hit-tests against the current view.
 		placing := isPlacingTool(s)
-		var hovered *compdef.WorkPlane
+		var hovered *feature.WorkPlane
 		cam := s.Camera()
 		cam.Width, cam.Height = pw, ph
 		if s.CameraAnimating() {
@@ -414,7 +415,7 @@ func handleViewportClick(s *app.Session) {
 // hoveredPlane returns the origin work plane under the cursor (the front-most hit), or
 // nil — used to highlight the plane the user is about to pick. Only meaningful while
 // the viewport is hovered and not editing a sketch.
-func hoveredPlane(s *app.Session) *compdef.WorkPlane {
+func hoveredPlane(s *app.Session) *feature.WorkPlane {
 	if !native.IsItemHovered() || s.InSketch() {
 		return nil
 	}

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -7,6 +7,7 @@ package ui
 import (
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
@@ -15,7 +16,7 @@ import (
 // host. The selected plane is highlighted; the plane under the cursor is shown in the
 // hover color (the focus the user is about to pick). Shown outside the sketch
 // environment.
-func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *compdef.WorkPlane) []renderer.DrawItem {
+func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *feature.WorkPlane) []renderer.DrawItem {
 	if part == nil {
 		return nil
 	}
@@ -27,7 +28,7 @@ func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *com
 }
 
 // planeColor chooses a plane's draw color: selected wins, then hovered, then faint.
-func planeColor(wp, selected, hovered *compdef.WorkPlane) [4]float32 {
+func planeColor(wp, selected, hovered *feature.WorkPlane) [4]float32 {
 	switch wp {
 	case selected:
 		return selectedPlaneColor
@@ -46,7 +47,7 @@ var (
 
 // planeBorder builds the border-and-diagonals line item of a work plane's display
 // square, mapped from the plane's 2D frame into model space.
-func planeBorder(wp *compdef.WorkPlane, color [4]float32) renderer.DrawItem {
+func planeBorder(wp *feature.WorkPlane, color [4]float32) renderer.DrawItem {
 	pl := wp.Plane()
 	s := wp.DisplaySize()
 	corners2D := []math.Point2{math.P2(-s, -s), math.P2(s, -s), math.P2(s, s), math.P2(-s, s)}

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -188,6 +188,22 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 
 ## Session log
 
+- **2026-06-02:** **Inventor-style origin coordinate system + work-feature persistence
+  (branch `work-features`).** Modelled construction geometry like Inventor (verified
+  against `Oblikovati.Contracts.CSharp`): a part owns one `feature.WorkGeometry` holding
+  the static origin coordinate system — center point, X/Y/Z axes, XY/XZ/YZ planes — as
+  grounded `IsCoordinateSystemElement` members with well-known `WorkRef` keys, plus the
+  user work planes/axes/points. Work features are now defined **relative to references**
+  (origin well-known keys; user features by collection position), resolved at recompute,
+  replacing the opaque eval closures with typed serializable definitions. Unified on one
+  `WorkPlane` type (dropped `compdef.WorkPlane`; migrated ~13 app/head sites); the part
+  recomputes its work geometry before the feature program. Persistence: a `workFeatures`
+  recipe section serializes user features in creation order (origin regenerated);
+  **revolve** serializes its axis as a `WorkRef` and re-binds it on restore. Verified:
+  a work plane offset off the origin XY re-resolves to z=5 after reopen; a revolve's axis
+  re-binds to `origin/axis/z`. Full suite + `head` green. Out of scope (error loudly until
+  coded): face/edge/sketch-referenced work features, sweep/loft/coil/rib, mesh, freeform
+  cage, non-parametric base.
 - **2026-06-02:** **Feature persistence — more codecs (branch `feature-codecs`).** Added
   recipe codecs (with round-trip tests) for: **hole/boss** (placed on a face by key) +
   **combine** (bodies by index); **patterns** rectangular/circular/sketch-driven + **mirror**

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -27,8 +27,8 @@ type PartComponentDefinition struct {
 	sketches *sketch.Sketches
 	features *feature.PartFeatures
 	keys     *identity.KeyManager
-	origin   []*WorkPlane         // the three origin datum planes (XY/XZ/YZ)
-	units    param.UnitsOfMeasure // document display units (length/angle/…)
+	work     *feature.WorkGeometry // origin coordinate frame + user work planes/axes/points
+	units    param.UnitsOfMeasure  // document display units (length/angle/…)
 	version  uint64
 	eop      int // end-of-part feature index; endOfPartAtEnd ⇒ full program
 }
@@ -44,7 +44,7 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		sketches: sketch.NewSketches(),
 		features: feature.NewPartFeatures(params, keys),
 		keys:     keys,
-		origin:   newOriginPlanes(),
+		work:     feature.NewWorkGeometry(),
 		units:    param.DefaultUnitsOfMeasure(),
 		eop:      endOfPartAtEnd,
 	}
@@ -71,6 +71,7 @@ func (d *PartComponentDefinition) Features() *feature.PartFeatures { return d.fe
 // SurfaceBodies, advancing the geometry version. This is the part-level
 // orchestration that turns the feature history into the evaluated result.
 func (d *PartComponentDefinition) Recompute() {
+	d.work.Recompute()
 	d.features.Recompute()
 	d.bodies = topo.NewSurfaceBodies()
 	for _, b := range d.features.Result() {

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -28,11 +28,12 @@ var _ doc.RecipeContent = (*PartComponentDefinition)(nil)
 // parameters. Sketches and features join it in later phases. The realized B-rep is
 // never stored — ApplyRecipe recomputes it.
 type partRecipe struct {
-	Units      map[string]string     `yaml:"units,omitempty"`
-	EndOfPart  *int                  `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
-	Parameters []parameterRecipe     `yaml:"parameters,omitempty"`
-	Sketches   []sketch.SketchData   `yaml:"sketches,omitempty"`
-	Features   []feature.FeatureData `yaml:"features,omitempty"`
+	Units        map[string]string         `yaml:"units,omitempty"`
+	EndOfPart    *int                      `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
+	Parameters   []parameterRecipe         `yaml:"parameters,omitempty"`
+	WorkFeatures []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
+	Sketches     []sketch.SketchData       `yaml:"sketches,omitempty"`
+	Features     []feature.FeatureData     `yaml:"features,omitempty"`
 }
 
 // sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
@@ -81,11 +82,16 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compdef: marshal features: %w", err)
 	}
+	work, err := feature.MarshalWork(d.work)
+	if err != nil {
+		return nil, fmt.Errorf("compdef: marshal work features: %w", err)
+	}
 	r := partRecipe{
-		Units:      d.unitsRecipe(),
-		Parameters: d.parametersRecipe(),
-		Sketches:   sketches,
-		Features:   features,
+		Units:        d.unitsRecipe(),
+		Parameters:   d.parametersRecipe(),
+		WorkFeatures: work,
+		Sketches:     sketches,
+		Features:     features,
 	}
 	if d.eop != endOfPartAtEnd {
 		eop := d.eop
@@ -106,10 +112,13 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 	if err := d.applyParameters(r.Parameters); err != nil {
 		return err
 	}
+	if err := feature.ApplyWork(d.work, r.WorkFeatures); err != nil {
+		return fmt.Errorf("compdef: restore work features: %w", err)
+	}
 	if err := d.sketches.ApplyRecipe(r.Sketches); err != nil {
 		return fmt.Errorf("compdef: restore sketches: %w", err)
 	}
-	if err := d.features.ApplyRecipe(r.Features, sketchIndex{d.sketches}); err != nil {
+	if err := d.features.ApplyRecipe(r.Features, sketchIndex{d.sketches}, d.work); err != nil {
 		return fmt.Errorf("compdef: restore features: %w", err)
 	}
 	if r.EndOfPart != nil {

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -187,6 +187,51 @@ func featureByKind(fs *feature.PartFeatures, kind string) (*feature.PartFeature,
 	return nil, false
 }
 
+func TestWorkFeaturesSurviveRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	// A user work plane offset 5 above the origin XY plane (references the origin).
+	def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 5 })
+
+	reopened := reopenThroughStore(t, d)
+	if got := reopened.WorkPlanes().Count(); got != 4 {
+		t.Fatalf("work plane count after reopen = %d, want 4 (3 origin + 1 user)", got)
+	}
+	// The origin frame is regenerated (grounded coordinate-system elements).
+	if !reopened.WorkPlanes().Item(0).IsCoordinateSystemElement() {
+		t.Error("origin plane lost its coordinate-system flag after reopen")
+	}
+	user := reopened.WorkPlanes().Item(3)
+	if user.IsCoordinateSystemElement() {
+		t.Error("restored user plane should not be a coordinate-system element")
+	}
+	if !user.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), 1e-9) {
+		t.Errorf("restored work plane origin = %v, want (0,0,5) — its ref to the origin XY plane must re-resolve", user.Plane().Origin())
+	}
+}
+
+func TestRevolveAxisRebindsAfterReopen(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	rectangle(sk, 4, 3)
+	zAxis := def.WorkAxes().Item(2) // the origin Z axis
+	feature.NewRevolveFeatures(def.Features()).
+		Add(sk, 0, zAxis, func() float64 { return 0 }, ops.NewBody)
+
+	reopened := reopenThroughStore(t, d)
+	rev, ok := featureByKind(reopened.Features(), "revolve")
+	if !ok {
+		t.Fatal("revolve feature missing after reopen")
+	}
+	axis := rev.Definition().(*feature.RevolveFeature).Definition().Axis
+	if axis == nil || axis.Key() != feature.OriginZAxis {
+		t.Errorf("revolve axis after reopen = %v, want origin Z axis — it must re-bind by WorkRef", axis)
+	}
+}
+
 func TestLengthUnitSurvivesRoundTrip(t *testing.T) {
 	ws := doc.NewWorkspace(nil)
 	d, _ := compdef.AddPart(ws, "Part1", true)

--- a/model/compdef/workplane.go
+++ b/model/compdef/workplane.go
@@ -2,55 +2,36 @@
 
 package compdef
 
-import "github.com/Oblikovati/oblikovati/model/sketch"
+import "github.com/Oblikovati/oblikovati/model/feature"
 
-// WorkPlane is a part datum plane — one of the three origin planes (XY/XZ/YZ) or, in
-// future, a user-created work plane. It hosts sketches and is selectable in the browser
-// and the 3D view. DisplaySize is the half-extent at which the (infinite) plane is
-// drawn and hit-tested as a finite square so it can be picked in the viewport.
-type WorkPlane struct {
-	name        string
-	plane       sketch.Plane
-	displaySize float64
-}
+// The part's datum geometry — the origin coordinate system (XY/XZ/YZ planes, X/Y/Z
+// axes, center point) plus user-created work planes/axes/points — lives in one
+// [feature.WorkGeometry], matching how Inventor structures a ComponentDefinition's
+// WorkPlanes/WorkAxes/WorkPoints collections (the origin elements are grounded
+// coordinate-system members). The part delegates to it.
 
-// newWorkPlane constructs a named datum plane with a display half-extent.
-func newWorkPlane(name string, plane sketch.Plane, displaySize float64) *WorkPlane {
-	return &WorkPlane{name: name, plane: plane, displaySize: displaySize}
-}
+// WorkGeometry returns the part's construction-geometry frame.
+func (d *PartComponentDefinition) WorkGeometry() *feature.WorkGeometry { return d.work }
 
-// Name returns the plane's display name (e.g. "XY Plane").
-func (w *WorkPlane) Name() string { return w.name }
-
-// Plane returns the underlying sketch plane (origin + in-plane axes), the host a new
-// sketch is created on.
-func (w *WorkPlane) Plane() sketch.Plane { return w.plane }
-
-// DisplaySize is the half-edge length of the square the plane is drawn/picked as.
-func (w *WorkPlane) DisplaySize() float64 { return w.displaySize }
-
-// defaultOriginPlaneSize is the half-extent the origin planes display at.
-const defaultOriginPlaneSize = 5.0
-
-// newOriginPlanes builds the three standard origin work planes of a fresh part.
-func newOriginPlanes() []*WorkPlane {
-	return []*WorkPlane{
-		newWorkPlane("XY Plane", sketch.XYPlane(), defaultOriginPlaneSize),
-		newWorkPlane("XZ Plane", sketch.XZPlane(), defaultOriginPlaneSize),
-		newWorkPlane("YZ Plane", sketch.YZPlane(), defaultOriginPlaneSize),
-	}
+// WorkPlanes/WorkAxes/WorkPoints/UserCoordinateSystems expose the datum collections.
+func (d *PartComponentDefinition) WorkPlanes() *feature.WorkPlanes { return d.work.WorkPlanes() }
+func (d *PartComponentDefinition) WorkAxes() *feature.WorkAxes     { return d.work.WorkAxes() }
+func (d *PartComponentDefinition) WorkPoints() *feature.WorkPoints { return d.work.WorkPoints() }
+func (d *PartComponentDefinition) UserCoordinateSystems() *feature.UserCoordinateSystems {
+	return d.work.UserCoordinateSystems()
 }
 
 // OriginPlanes returns the part's origin datum planes (XY/XZ/YZ), the Origin folder's
 // contents in the browser and the default sketch hosts.
-func (d *PartComponentDefinition) OriginPlanes() []*WorkPlane {
-	return append([]*WorkPlane(nil), d.origin...)
+func (d *PartComponentDefinition) OriginPlanes() []*feature.WorkPlane {
+	return d.work.OriginPlanes()
 }
 
-// WorkPlaneByName returns the origin plane with the given name, or false.
-func (d *PartComponentDefinition) WorkPlaneByName(name string) (*WorkPlane, bool) {
-	for _, w := range d.origin {
-		if w.name == name {
+// WorkPlaneByName returns the work plane with the given name (e.g. "XY Plane"), or false.
+func (d *PartComponentDefinition) WorkPlaneByName(name string) (*feature.WorkPlane, bool) {
+	planes := d.work.WorkPlanes()
+	for i := 0; i < planes.Count(); i++ {
+		if w := planes.Item(i); w.Name() == name {
 			return w, true
 		}
 	}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -40,6 +40,7 @@ type FeatureData struct {
 	BoundaryPatch *BoundaryPatchData `yaml:"boundaryPatch,omitempty"`
 	RuledSurface  *RuledSurfaceData  `yaml:"ruledSurface,omitempty"`
 	FaceEdit      *FaceEditData      `yaml:"faceEdit,omitempty"`
+	Revolve       *RevolveData       `yaml:"revolve,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -144,6 +145,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.RuledSurface = rs
+	case *RevolveFeature:
+		rv, err := serializeRevolve(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Revolve = rv
 	case faceEditor:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	default:
@@ -156,10 +163,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 // tracks the features restored so far so a pattern/mirror can resolve the earlier
 // features it replicates (recorded as program indices). The caller recomputes
 // afterward to regenerate geometry.
-func (fs *PartFeatures) ApplyRecipe(data []FeatureData, sk SketchIndexer) error {
+func (fs *PartFeatures) ApplyRecipe(data []FeatureData, sk SketchIndexer, work *WorkGeometry) error {
 	restored := make([]*PartFeature, 0, len(data))
 	for i, fd := range data {
-		pf, err := buildFeature(fs, fd, sk, restored)
+		pf, err := buildFeature(fs, fd, sk, restored, work)
 		if err != nil {
 			return fmt.Errorf("feature %d (%s): %w", i, fd.Kind, err)
 		}
@@ -173,7 +180,7 @@ func (fs *PartFeatures) ApplyRecipe(data []FeatureData, sk SketchIndexer) error 
 // or a missing payload (no silent loss). Dress-up edge/face keys re-bind to the
 // regenerated topology on the next recompute (kernel topo FindEdgeByKey/FindFaceByKey);
 // patterns resolve their source features from restored (the features built so far).
-func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored []*PartFeature) (*PartFeature, error) {
+func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored []*PartFeature, work *WorkGeometry) (*PartFeature, error) {
 	du := NewDressUpFeatures(fs)
 	switch fd.Kind {
 	case "extrude":
@@ -231,6 +238,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreRuledSurface(fs, fd.RuledSurface, sk)
 	case "split", "move-face", "face-offset", "delete-face", "replace-face", "thicken":
 		return restoreFaceEdit(fs, fd.Kind, fd.FaceEdit)
+	case "revolve":
+		return restoreRevolve(fs, fd.Revolve, sk, work)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -38,7 +38,7 @@ func TestExtrudeFeatureRoundTrip(t *testing.T) {
 	}
 
 	fresh := NewPartFeatures(nil, nil)
-	if err := fresh.ApplyRecipe(data, oneSketch{sk}); err != nil {
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
 		t.Fatalf("ApplyRecipe: %v", err)
 	}
 	if fresh.Count() != 1 || fresh.Item(0).Kind() != "extrude" {
@@ -67,7 +67,7 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 		t.Fatalf("MarshalRecipe: %v", err)
 	}
 	fresh := NewPartFeatures(nil, nil)
-	if err := fresh.ApplyRecipe(data, oneSketch{}); err != nil {
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
 		t.Fatalf("ApplyRecipe: %v", err)
 	}
 	if fresh.Count() != 5 {
@@ -99,7 +99,7 @@ func TestSolidFeaturesRoundTrip(t *testing.T) {
 		t.Fatalf("MarshalRecipe: %v", err)
 	}
 	fresh := NewPartFeatures(nil, nil)
-	if err := fresh.ApplyRecipe(data, oneSketch{}); err != nil {
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
 		t.Fatalf("ApplyRecipe: %v", err)
 	}
 	if fresh.Count() != 3 {
@@ -135,7 +135,7 @@ func TestPatternFeaturesRebindSourceByIndex(t *testing.T) {
 		t.Fatalf("MarshalRecipe: %v", err)
 	}
 	fresh := NewPartFeatures(nil, nil)
-	if err := fresh.ApplyRecipe(data, oneSketch{sk}); err != nil {
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
 		t.Fatalf("ApplyRecipe: %v", err)
 	}
 	if fresh.Count() != 3 {
@@ -171,7 +171,7 @@ func TestSurfaceFeaturesRoundTrip(t *testing.T) {
 		t.Fatalf("MarshalRecipe: %v", err)
 	}
 	fresh := NewPartFeatures(nil, nil)
-	if err := fresh.ApplyRecipe(data, oneSketch{sk}); err != nil {
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
 		t.Fatalf("ApplyRecipe: %v", err)
 	}
 	if fresh.Count() != 2 {
@@ -203,7 +203,7 @@ func TestFaceEditFeaturesRoundTrip(t *testing.T) {
 		t.Fatalf("MarshalRecipe: %v", err)
 	}
 	fresh := NewPartFeatures(nil, nil)
-	if err := fresh.ApplyRecipe(data, oneSketch{}); err != nil {
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
 		t.Fatalf("ApplyRecipe: %v", err)
 	}
 

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// This file serializes a part's USER work features (planes/axes/points) into the
+// recipe. The origin coordinate system is regenerated, never serialized — only its
+// stable references are recorded. User features are stored in global creation order so
+// a feature that references an earlier one restores after it; their definitions name
+// the geometry they are built on by WorkRef (origin well-known keys, or earlier user
+// features by position), which re-resolve on recompute.
+
+// WorkFeatureData is the recipe form of one user work feature: which collection it
+// belongs to, its definition kind, the references it is built on, and any parameter.
+type WorkFeatureData struct {
+	Collection string    `yaml:"collection"` // plane | axis | point
+	Kind       string    `yaml:"kind"`
+	Refs       []string  `yaml:"refs,omitempty"`
+	Offset     float64   `yaml:"offset,omitempty"`   // plane-offset
+	Position   []float64 `yaml:"position,omitempty"` // point position [x,y,z]
+}
+
+// MarshalWork projects the user work features into the recipe, in creation order.
+func MarshalWork(g *WorkGeometry) ([]WorkFeatureData, error) {
+	out := make([]WorkFeatureData, 0, len(g.userSeq))
+	for i, e := range g.userSeq {
+		d, err := serializeWorkFeature(g, e)
+		if err != nil {
+			return nil, fmt.Errorf("work feature %d (%s): %w", i, e.collection, err)
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+func serializeWorkFeature(g *WorkGeometry, e userEntry) (WorkFeatureData, error) {
+	switch e.collection {
+	case "plane":
+		return serializePlaneDef(g.planes.Item(e.index).def)
+	case "axis":
+		return serializeAxisDef(g.axes.Item(e.index).def)
+	case "point":
+		return serializePointDef(g.points.Item(e.index).def)
+	default:
+		return WorkFeatureData{}, fmt.Errorf("unknown work collection %q", e.collection)
+	}
+}
+
+func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
+	d := WorkFeatureData{Collection: "plane", Kind: def.kindName(), Refs: refStrings(def.refs())}
+	switch v := def.(type) {
+	case offsetPlaneDef:
+		d.Offset = v.offset()
+	case threePointPlaneDef:
+		// references only
+	default:
+		return WorkFeatureData{}, fmt.Errorf("no codec for work plane definition %q", def.kindName())
+	}
+	return d, nil
+}
+
+func serializeAxisDef(def axisDefinition) (WorkFeatureData, error) {
+	switch def.(type) {
+	case twoPointsAxisDef, planeIntersectionAxisDef:
+		return WorkFeatureData{Collection: "axis", Kind: def.kindName(), Refs: refStrings(def.refs())}, nil
+	default:
+		return WorkFeatureData{}, fmt.Errorf("no codec for work axis definition %q", def.kindName())
+	}
+}
+
+func serializePointDef(def pointDefinition) (WorkFeatureData, error) {
+	d := WorkFeatureData{Collection: "point", Kind: def.kindName(), Refs: refStrings(def.refs())}
+	switch v := def.(type) {
+	case positionPointDef:
+		p := v.at()
+		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+	case planeAxisPointDef:
+		// references only
+	default:
+		return WorkFeatureData{}, fmt.Errorf("no codec for work point definition %q", def.kindName())
+	}
+	return d, nil
+}
+
+// ApplyWork rebuilds the user work features onto g (which already holds the origin
+// frame), in order, resolving each one's references as it goes.
+func ApplyWork(g *WorkGeometry, data []WorkFeatureData) error {
+	for i, d := range data {
+		if err := restoreWorkFeature(g, d); err != nil {
+			return fmt.Errorf("work feature %d (%s/%s): %w", i, d.Collection, d.Kind, err)
+		}
+	}
+	return nil
+}
+
+func restoreWorkFeature(g *WorkGeometry, d WorkFeatureData) error {
+	switch d.Collection + "/" + d.Kind {
+	case "plane/plane-offset":
+		base, err := workRefAt(d.Refs, 0)
+		if err != nil {
+			return err
+		}
+		off := d.Offset
+		g.WorkPlanes().AddByPlaneAndOffset(base, func() float64 { return off })
+	case "plane/three-points":
+		r, err := workRefs(d.Refs, 3)
+		if err != nil {
+			return err
+		}
+		g.WorkPlanes().AddByThreePoints(r[0], r[1], r[2])
+	case "axis/two-points":
+		r, err := workRefs(d.Refs, 2)
+		if err != nil {
+			return err
+		}
+		g.WorkAxes().AddByTwoPoints(r[0], r[1])
+	case "axis/plane-intersection":
+		r, err := workRefs(d.Refs, 2)
+		if err != nil {
+			return err
+		}
+		g.WorkAxes().AddByPlaneIntersection(r[0], r[1])
+	case "point/position":
+		if len(d.Position) != 3 {
+			return fmt.Errorf("position point needs 3 coordinates, got %d", len(d.Position))
+		}
+		pos := math.P3(d.Position[0], d.Position[1], d.Position[2])
+		g.WorkPoints().AddByPosition(func() math.Point3 { return pos })
+	case "point/plane-axis-intersection":
+		r, err := workRefs(d.Refs, 2)
+		if err != nil {
+			return err
+		}
+		g.WorkPoints().AddByPlaneAndAxisIntersection(r[0], r[1])
+	default:
+		return fmt.Errorf("no restore codec for work feature %s/%s", d.Collection, d.Kind)
+	}
+	return nil
+}
+
+// RevolveData is a revolve's recipe: the sketch profile, the revolution axis (a
+// WorkRef, typically an origin axis or a user work axis), the swept angle, and the
+// boolean operation. Generation is still deferred, but the definition round-trips.
+type RevolveData struct {
+	Sketch    int     `yaml:"sketch"`
+	Profile   int     `yaml:"profile"`
+	Axis      string  `yaml:"axis"`
+	Angle     float64 `yaml:"angle,omitempty"` // 0 ⇒ full revolution
+	Operation string  `yaml:"operation"`
+}
+
+func serializeRevolve(def *RevolveDefinition, sk SketchIndexer) (*RevolveData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("revolve references a sketch that is not in the part")
+	}
+	if def.Axis == nil {
+		return nil, fmt.Errorf("revolve has no axis")
+	}
+	op, err := operationName(def.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return &RevolveData{
+		Sketch:    idx,
+		Profile:   def.ProfileIndex,
+		Axis:      string(def.Axis.Key()),
+		Angle:     evalFloat(def.Angle),
+		Operation: op,
+	}, nil
+}
+
+func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *WorkGeometry) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("revolve feature is missing its payload")
+	}
+	skt, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("revolve references sketch index %d, which does not exist", d.Sketch)
+	}
+	if work == nil {
+		return nil, fmt.Errorf("revolve needs the part's work geometry to resolve its axis")
+	}
+	axis, err := work.axis(WorkRef(d.Axis))
+	if err != nil {
+		return nil, fmt.Errorf("revolve axis: %w", err)
+	}
+	op, err := parseOperation(d.Operation)
+	if err != nil {
+		return nil, err
+	}
+	angle := d.Angle
+	return NewRevolveFeatures(fs).Add(skt, d.Profile, axis, func() float64 { return angle }, op), nil
+}
+
+// refStrings renders work references as their string form for YAML.
+func refStrings(refs []WorkRef) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]string, len(refs))
+	for i, r := range refs {
+		out[i] = string(r)
+	}
+	return out
+}
+
+// workRefs requires exactly n references; workRefAt fetches one by position.
+func workRefs(refs []string, n int) ([]WorkRef, error) {
+	if len(refs) != n {
+		return nil, fmt.Errorf("expected %d references, got %d", n, len(refs))
+	}
+	out := make([]WorkRef, n)
+	for i, r := range refs {
+		out[i] = WorkRef(r)
+	}
+	return out, nil
+}
+
+func workRefAt(refs []string, i int) (WorkRef, error) {
+	if i >= len(refs) {
+		return "", fmt.Errorf("missing reference %d (have %d)", i, len(refs))
+	}
+	return WorkRef(refs[i]), nil
+}

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -10,25 +10,85 @@ import (
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
 
-// WorkAxis is a parametric datum line: an origin and a unit direction.
-type WorkAxis struct {
-	id       ID
-	name     string
-	evaluate func() (math.Point3, math.UnitVector3, error)
-	origin   math.Point3
-	dir      math.UnitVector3
-	health   health.Health
+// axisDefinition computes a work axis (origin + unit direction) from its references.
+type axisDefinition interface {
+	kindName() string
+	refs() []WorkRef
+	eval(r workResolver) (math.Point3, math.UnitVector3, error)
 }
 
-func (w *WorkAxis) ID() ID                      { return w.id }
-func (w *WorkAxis) Name() string                { return w.name }
-func (w *WorkAxis) Health() health.Health       { return w.health }
-func (w *WorkAxis) Origin() math.Point3         { return w.origin }
-func (w *WorkAxis) Direction() math.UnitVector3 { return w.dir }
+// fixedAxisDef is a grounded axis (an origin axis): fixed geometry, no references.
+type fixedAxisDef struct {
+	origin math.Point3
+	dir    math.UnitVector3
+}
 
-// Recompute re-derives the axis, going sick on a degenerate definition.
-func (w *WorkAxis) Recompute() {
-	o, d, err := w.evaluate()
+func (d fixedAxisDef) kindName() string { return "fixed" }
+func (d fixedAxisDef) refs() []WorkRef  { return nil }
+func (d fixedAxisDef) eval(workResolver) (math.Point3, math.UnitVector3, error) {
+	return d.origin, d.dir, nil
+}
+
+// twoPointsAxisDef is the axis through two referenced points.
+type twoPointsAxisDef struct{ a, b WorkRef }
+
+func (d twoPointsAxisDef) kindName() string { return "two-points" }
+func (d twoPointsAxisDef) refs() []WorkRef  { return []WorkRef{d.a, d.b} }
+func (d twoPointsAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	a, err := r.point(d.a)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	b, err := r.point(d.b)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	dir, err := math.UnitVector3FromVector(a.VectorTo(b))
+	return a, dir, err
+}
+
+// planeIntersectionAxisDef is the axis where two referenced planes meet.
+type planeIntersectionAxisDef struct{ p1, p2 WorkRef }
+
+func (d planeIntersectionAxisDef) kindName() string { return "plane-intersection" }
+func (d planeIntersectionAxisDef) refs() []WorkRef  { return []WorkRef{d.p1, d.p2} }
+func (d planeIntersectionAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	p1, err := r.plane(d.p1)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	p2, err := r.plane(d.p2)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	return planeIntersectionLine(p1, p2)
+}
+
+// WorkAxis is a datum line: an origin and a unit direction.
+type WorkAxis struct {
+	id               ID
+	key              WorkRef
+	name             string
+	def              axisDefinition
+	origin           math.Point3
+	dir              math.UnitVector3
+	health           health.Health
+	coordinateSystem bool
+	grounded         bool
+}
+
+func (w *WorkAxis) ID() ID                          { return w.id }
+func (w *WorkAxis) Key() WorkRef                    { return w.key }
+func (w *WorkAxis) Name() string                    { return w.name }
+func (w *WorkAxis) Health() health.Health           { return w.health }
+func (w *WorkAxis) Origin() math.Point3             { return w.origin }
+func (w *WorkAxis) Direction() math.UnitVector3     { return w.dir }
+func (w *WorkAxis) IsCoordinateSystemElement() bool { return w.coordinateSystem }
+func (w *WorkAxis) Grounded() bool                  { return w.grounded }
+
+// recompute re-derives the axis, going sick on a degenerate definition.
+func (w *WorkAxis) recompute(r workResolver) {
+	o, d, err := w.def.eval(r)
 	if err != nil {
 		w.health = health.Sicken("work axis: " + err.Error())
 		return
@@ -36,35 +96,46 @@ func (w *WorkAxis) Recompute() {
 	w.origin, w.dir, w.health = o, d, health.Healthy
 }
 
-// WorkAxes is the collection of datum axes.
+// WorkAxes is the part's collection of datum axes (origin first, then user).
 type WorkAxes struct {
+	g     *WorkGeometry
 	items []*WorkAxis
 	byID  map[ID]*WorkAxis
+	byKey map[WorkRef]*WorkAxis
 }
 
-// NewWorkAxes returns an empty collection.
-func NewWorkAxes() *WorkAxes { return &WorkAxes{byID: map[ID]*WorkAxis{}} }
+func newWorkAxes(g *WorkGeometry) *WorkAxes {
+	return &WorkAxes{g: g, byID: map[ID]*WorkAxis{}, byKey: map[WorkRef]*WorkAxis{}}
+}
 
-// AddByTwoPoints creates an axis through two (parametric) points.
-func (c *WorkAxes) AddByTwoPoints(a, b func() math.Point3) *WorkAxis {
-	eval := func() (math.Point3, math.UnitVector3, error) {
-		d, err := math.UnitVector3FromVector(a().VectorTo(b()))
-		return a(), d, err
+func (c *WorkAxes) addOrigin(key WorkRef, name string, origin math.Point3, dir math.UnitVector3) *WorkAxis {
+	w := &WorkAxis{
+		id: nextID(), key: key, name: name, def: fixedAxisDef{origin: origin, dir: dir},
+		coordinateSystem: true, grounded: true,
 	}
-	return c.add(eval)
+	return c.track(w)
 }
 
-// AddByPlaneIntersection creates the axis where two planes meet.
-func (c *WorkAxes) AddByPlaneIntersection(p1, p2 sketch.Plane) *WorkAxis {
-	eval := func() (math.Point3, math.UnitVector3, error) { return planeIntersectionLine(p1, p2) }
-	return c.add(eval)
+// AddByTwoPoints creates a user axis through two referenced points.
+func (c *WorkAxes) AddByTwoPoints(a, b WorkRef) *WorkAxis {
+	return c.addUser(twoPointsAxisDef{a: a, b: b})
 }
 
-func (c *WorkAxes) add(eval func() (math.Point3, math.UnitVector3, error)) *WorkAxis {
-	w := &WorkAxis{id: nextID(), name: "WorkAxis", evaluate: eval}
-	w.Recompute()
+// AddByPlaneIntersection creates the axis where two referenced planes meet.
+func (c *WorkAxes) AddByPlaneIntersection(p1, p2 WorkRef) *WorkAxis {
+	return c.addUser(planeIntersectionAxisDef{p1: p1, p2: p2})
+}
+
+func (c *WorkAxes) addUser(def axisDefinition) *WorkAxis {
+	w := &WorkAxis{id: nextID(), key: userRef("axis", len(c.items)), name: "WorkAxis", def: def}
+	return c.track(w)
+}
+
+func (c *WorkAxes) track(w *WorkAxis) *WorkAxis {
+	w.recompute(c.g)
 	c.items = append(c.items, w)
 	c.byID[w.id] = w
+	c.byKey[w.key] = w
 	return w
 }
 
@@ -72,23 +143,76 @@ func (c *WorkAxes) add(eval func() (math.Point3, math.UnitVector3, error)) *Work
 func (c *WorkAxes) Count() int           { return len(c.items) }
 func (c *WorkAxes) Item(i int) *WorkAxis { return c.items[i] }
 
-// WorkPoint is a parametric datum point.
-type WorkPoint struct {
-	id       ID
-	name     string
-	evaluate func() (math.Point3, error)
-	point    math.Point3
-	health   health.Health
+// pointDefinition computes a work point's position from its references.
+type pointDefinition interface {
+	kindName() string
+	refs() []WorkRef
+	eval(r workResolver) (math.Point3, error)
 }
 
-func (w *WorkPoint) ID() ID                { return w.id }
-func (w *WorkPoint) Name() string          { return w.name }
-func (w *WorkPoint) Health() health.Health { return w.health }
-func (w *WorkPoint) Point() math.Point3    { return w.point }
+// fixedPointDef is a grounded point (the origin center): fixed geometry, no references.
+type fixedPointDef struct{ point math.Point3 }
 
-// Recompute re-derives the point.
-func (w *WorkPoint) Recompute() {
-	p, err := w.evaluate()
+func (d fixedPointDef) kindName() string                       { return "fixed" }
+func (d fixedPointDef) refs() []WorkRef                        { return nil }
+func (d fixedPointDef) eval(workResolver) (math.Point3, error) { return d.point, nil }
+
+// positionPointDef is a point at a (parametric) absolute position.
+type positionPointDef struct{ at func() math.Point3 }
+
+func (d positionPointDef) kindName() string                       { return "position" }
+func (d positionPointDef) refs() []WorkRef                        { return nil }
+func (d positionPointDef) eval(workResolver) (math.Point3, error) { return d.at(), nil }
+
+// planeAxisPointDef is the point where a referenced axis pierces a referenced plane.
+type planeAxisPointDef struct {
+	plane WorkRef
+	axis  WorkRef
+}
+
+func (d planeAxisPointDef) kindName() string { return "plane-axis-intersection" }
+func (d planeAxisPointDef) refs() []WorkRef  { return []WorkRef{d.plane, d.axis} }
+func (d planeAxisPointDef) eval(r workResolver) (math.Point3, error) {
+	plane, err := r.plane(d.plane)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	axis, err := r.axis(d.axis)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	n := plane.Normal().AsVector()
+	denom := axis.dir.AsVector().Dot(n)
+	if math.IsNearZero(denom, math.DefaultTolerance) {
+		return math.Point3{}, errors.New("axis is parallel to the plane")
+	}
+	t := axis.origin.VectorTo(plane.Origin()).Dot(n) / denom
+	return axis.origin.TranslateBy(axis.dir.AsVector().Scale(t)), nil
+}
+
+// WorkPoint is a datum point.
+type WorkPoint struct {
+	id               ID
+	key              WorkRef
+	name             string
+	def              pointDefinition
+	point            math.Point3
+	health           health.Health
+	coordinateSystem bool
+	grounded         bool
+}
+
+func (w *WorkPoint) ID() ID                          { return w.id }
+func (w *WorkPoint) Key() WorkRef                    { return w.key }
+func (w *WorkPoint) Name() string                    { return w.name }
+func (w *WorkPoint) Health() health.Health           { return w.health }
+func (w *WorkPoint) Point() math.Point3              { return w.point }
+func (w *WorkPoint) IsCoordinateSystemElement() bool { return w.coordinateSystem }
+func (w *WorkPoint) Grounded() bool                  { return w.grounded }
+
+// recompute re-derives the point.
+func (w *WorkPoint) recompute(r workResolver) {
+	p, err := w.def.eval(r)
 	if err != nil {
 		w.health = health.Sicken("work point: " + err.Error())
 		return
@@ -96,39 +220,47 @@ func (w *WorkPoint) Recompute() {
 	w.point, w.health = p, health.Healthy
 }
 
-// WorkPoints is the collection of datum points.
+// WorkPoints is the part's collection of datum points (origin first, then user).
 type WorkPoints struct {
+	g     *WorkGeometry
 	items []*WorkPoint
 	byID  map[ID]*WorkPoint
+	byKey map[WorkRef]*WorkPoint
 }
 
-// NewWorkPoints returns an empty collection.
-func NewWorkPoints() *WorkPoints { return &WorkPoints{byID: map[ID]*WorkPoint{}} }
-
-// AddByPoint creates a datum point at a (parametric) position.
-func (c *WorkPoints) AddByPoint(at func() math.Point3) *WorkPoint {
-	return c.add(func() (math.Point3, error) { return at(), nil })
+func newWorkPoints(g *WorkGeometry) *WorkPoints {
+	return &WorkPoints{g: g, byID: map[ID]*WorkPoint{}, byKey: map[WorkRef]*WorkPoint{}}
 }
 
-// AddByPlaneAndAxisIntersection creates the point where an axis pierces a plane.
-func (c *WorkPoints) AddByPlaneAndAxisIntersection(plane sketch.Plane, axis *WorkAxis) *WorkPoint {
-	eval := func() (math.Point3, error) {
-		n := plane.Normal().AsVector()
-		denom := axis.dir.AsVector().Dot(n)
-		if math.IsNearZero(denom, math.DefaultTolerance) {
-			return math.Point3{}, errors.New("axis is parallel to the plane")
-		}
-		t := axis.origin.VectorTo(plane.Origin()).Dot(n) / denom
-		return axis.origin.TranslateBy(axis.dir.AsVector().Scale(t)), nil
+func (c *WorkPoints) addOrigin(key WorkRef, name string, at math.Point3) *WorkPoint {
+	w := &WorkPoint{
+		id: nextID(), key: key, name: name, def: fixedPointDef{point: at},
+		coordinateSystem: true, grounded: true,
 	}
-	return c.add(eval)
+	return c.track(w)
 }
 
-func (c *WorkPoints) add(eval func() (math.Point3, error)) *WorkPoint {
-	w := &WorkPoint{id: nextID(), name: "WorkPoint", evaluate: eval}
-	w.Recompute()
+// AddByPosition creates a user point at a (parametric) absolute position.
+func (c *WorkPoints) AddByPosition(at func() math.Point3) *WorkPoint {
+	return c.addUser(positionPointDef{at: at})
+}
+
+// AddByPlaneAndAxisIntersection creates the point where a referenced axis pierces a
+// referenced plane.
+func (c *WorkPoints) AddByPlaneAndAxisIntersection(plane, axis WorkRef) *WorkPoint {
+	return c.addUser(planeAxisPointDef{plane: plane, axis: axis})
+}
+
+func (c *WorkPoints) addUser(def pointDefinition) *WorkPoint {
+	w := &WorkPoint{id: nextID(), key: userRef("point", len(c.items)), name: "WorkPoint", def: def}
+	return c.track(w)
+}
+
+func (c *WorkPoints) track(w *WorkPoint) *WorkPoint {
+	w.recompute(c.g)
 	c.items = append(c.items, w)
 	c.byID[w.id] = w
+	c.byKey[w.key] = w
 	return w
 }
 
@@ -136,8 +268,8 @@ func (c *WorkPoints) add(eval func() (math.Point3, error)) *WorkPoint {
 func (c *WorkPoints) Count() int            { return len(c.items) }
 func (c *WorkPoints) Item(i int) *WorkPoint { return c.items[i] }
 
-// planeIntersectionLine returns a point on, and the direction of, the line where
-// two planes meet (error if they are parallel).
+// planeIntersectionLine returns a point on, and the direction of, the line where two
+// planes meet (error if they are parallel).
 func planeIntersectionLine(p1, p2 sketch.Plane) (math.Point3, math.UnitVector3, error) {
 	n1, n2 := p1.Normal().AsVector(), p2.Normal().AsVector()
 	cross := n1.Cross(n2)

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -108,12 +108,12 @@ func newWorkAxes(g *WorkGeometry) *WorkAxes {
 	return &WorkAxes{g: g, byID: map[ID]*WorkAxis{}, byKey: map[WorkRef]*WorkAxis{}}
 }
 
-func (c *WorkAxes) addOrigin(key WorkRef, name string, origin math.Point3, dir math.UnitVector3) *WorkAxis {
+func (c *WorkAxes) addOrigin(key WorkRef, name string, origin math.Point3, dir math.UnitVector3) {
 	w := &WorkAxis{
 		id: nextID(), key: key, name: name, def: fixedAxisDef{origin: origin, dir: dir},
 		coordinateSystem: true, grounded: true,
 	}
-	return c.track(w)
+	c.track(w)
 }
 
 // AddByTwoPoints creates a user axis through two referenced points.
@@ -133,12 +133,11 @@ func (c *WorkAxes) addUser(def axisDefinition) *WorkAxis {
 	return w
 }
 
-func (c *WorkAxes) track(w *WorkAxis) *WorkAxis {
+func (c *WorkAxes) track(w *WorkAxis) {
 	w.recompute(c.g)
 	c.items = append(c.items, w)
 	c.byID[w.id] = w
 	c.byKey[w.key] = w
-	return w
 }
 
 // Count/Item index the collection.
@@ -234,12 +233,12 @@ func newWorkPoints(g *WorkGeometry) *WorkPoints {
 	return &WorkPoints{g: g, byID: map[ID]*WorkPoint{}, byKey: map[WorkRef]*WorkPoint{}}
 }
 
-func (c *WorkPoints) addOrigin(key WorkRef, name string, at math.Point3) *WorkPoint {
+func (c *WorkPoints) addOrigin(key WorkRef, name string, at math.Point3) {
 	w := &WorkPoint{
 		id: nextID(), key: key, name: name, def: fixedPointDef{point: at},
 		coordinateSystem: true, grounded: true,
 	}
-	return c.track(w)
+	c.track(w)
 }
 
 // AddByPosition creates a user point at a (parametric) absolute position.
@@ -260,12 +259,11 @@ func (c *WorkPoints) addUser(def pointDefinition) *WorkPoint {
 	return w
 }
 
-func (c *WorkPoints) track(w *WorkPoint) *WorkPoint {
+func (c *WorkPoints) track(w *WorkPoint) {
 	w.recompute(c.g)
 	c.items = append(c.items, w)
 	c.byID[w.id] = w
 	c.byKey[w.key] = w
-	return w
 }
 
 // Count/Item index the collection.

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -128,7 +128,9 @@ func (c *WorkAxes) AddByPlaneIntersection(p1, p2 WorkRef) *WorkAxis {
 
 func (c *WorkAxes) addUser(def axisDefinition) *WorkAxis {
 	w := &WorkAxis{id: nextID(), key: userRef("axis", len(c.items)), name: "WorkAxis", def: def}
-	return c.track(w)
+	c.track(w)
+	c.g.recordUser("axis", len(c.items)-1)
+	return w
 }
 
 func (c *WorkAxes) track(w *WorkAxis) *WorkAxis {
@@ -253,7 +255,9 @@ func (c *WorkPoints) AddByPlaneAndAxisIntersection(plane, axis WorkRef) *WorkPoi
 
 func (c *WorkPoints) addUser(def pointDefinition) *WorkPoint {
 	w := &WorkPoint{id: nextID(), key: userRef("point", len(c.items)), name: "WorkPoint", def: def}
-	return c.track(w)
+	c.track(w)
+	c.g.recordUser("point", len(c.items)-1)
+	return w
 }
 
 func (c *WorkPoints) track(w *WorkPoint) *WorkPoint {

--- a/model/feature/work_features_test.go
+++ b/model/feature/work_features_test.go
@@ -12,11 +12,39 @@ import (
 
 const wtol = 1e-9
 
+func TestOriginCoordinateFrame(t *testing.T) {
+	g := NewWorkGeometry()
+	if g.WorkPoints().Count() != 1 || g.WorkAxes().Count() != 3 || g.WorkPlanes().Count() != 3 {
+		t.Fatalf("origin frame counts pts=%d axes=%d planes=%d, want 1/3/3",
+			g.WorkPoints().Count(), g.WorkAxes().Count(), g.WorkPlanes().Count())
+	}
+	// Every origin element is a grounded coordinate-system element.
+	for i := 0; i < g.WorkPlanes().Count(); i++ {
+		p := g.WorkPlanes().Item(i)
+		if !p.IsCoordinateSystemElement() || !p.Grounded() {
+			t.Errorf("origin plane %q not a grounded coordinate-system element", p.Name())
+		}
+	}
+	// Well-known origin references resolve to the absolute frame.
+	xy, err := g.plane(OriginXYPlane)
+	if err != nil || !xy.Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("origin XY plane normal = %v err=%v, want +Z", xy.Normal(), err)
+	}
+	c, err := g.point(OriginCenter)
+	if err != nil || !c.IsEqualTo(math.P3(0, 0, 0), wtol) {
+		t.Errorf("origin center = %v err=%v, want (0,0,0)", c, err)
+	}
+	x, err := g.axis(OriginXAxis)
+	if err != nil || !x.Direction().AsVector().IsEqualTo(math.V3(1, 0, 0), wtol) {
+		t.Errorf("origin X axis dir = %v err=%v, want +X", x.Direction(), err)
+	}
+}
+
 func TestOffsetWorkPlaneMovesWithParameter(t *testing.T) {
 	ps := param.NewParameters()
 	off, _ := ps.AddUserParameter("gap", "5 cm")
-	planes := NewWorkPlanes()
-	wp := planes.AddByPlaneAndOffset(sketch.XYPlane(), func() float64 { return off.ModelValue() })
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return off.ModelValue() })
 
 	// XY plane offset 5 along +Z → origin at z=5.
 	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) {
@@ -25,65 +53,45 @@ func TestOffsetWorkPlaneMovesWithParameter(t *testing.T) {
 	if !wp.Health().OK() {
 		t.Error("offset plane should be healthy")
 	}
+	if wp.IsCoordinateSystemElement() {
+		t.Error("a user work plane is not a coordinate-system element")
+	}
 	// Drive the parameter: the datum moves on recompute.
 	if err := off.SetExpression("12 cm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	wp.Recompute()
+	g.Recompute()
 	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 12), wtol) {
 		t.Errorf("after param change, plane origin = %v, want (0,0,12)", wp.Plane().Origin())
 	}
 }
 
-func TestWorkPlaneServesAsSketchPlane(t *testing.T) {
-	planes := NewWorkPlanes()
-	wp := planes.AddByPlaneAndOffset(sketch.XYPlane(), func() float64 { return 3 })
-	// The datum plane is directly usable as a sketch host.
-	s := sketch.NewSketches().Add(wp.Plane())
-	got := s.ToModel(math.P2(1, 2)) // sketch (1,2) on the z=3 plane → (1,2,3)
-	if !got.IsEqualTo(math.P3(1, 2, 3), wtol) {
-		t.Errorf("sketch on work plane mapped to %v, want (1,2,3)", got)
-	}
-}
-
 func TestThreePointWorkPlaneAndDegenerate(t *testing.T) {
-	planes := NewWorkPlanes()
-	wp := planes.AddByThreePoints(
-		func() math.Point3 { return math.P3(0, 0, 0) },
-		func() math.Point3 { return math.P3(1, 0, 0) },
-		func() math.Point3 { return math.P3(0, 1, 0) },
-	)
+	g := NewWorkGeometry()
+	a := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 0) })
+	b := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 0, 0) })
+	c := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 0) })
+	wp := g.WorkPlanes().AddByThreePoints(a.Key(), b.Key(), c.Key())
 	if !wp.Health().OK() || !wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
 		t.Errorf("three-point plane normal = %v, want (0,0,1)", wp.Plane().Normal())
 	}
 	// Collinear points are degenerate → sick, not garbage.
-	bad := planes.AddByThreePoints(
-		func() math.Point3 { return math.P3(0, 0, 0) },
-		func() math.Point3 { return math.P3(1, 0, 0) },
-		func() math.Point3 { return math.P3(2, 0, 0) },
-	)
+	d := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(2, 0, 0) })
+	bad := g.WorkPlanes().AddByThreePoints(a.Key(), b.Key(), d.Key())
 	if bad.Health().OK() {
 		t.Error("collinear three-point plane should be sick")
-	}
-	if planes.Count() != 2 || planes.Item(0) != wp {
-		t.Error("work plane collection tracking wrong")
-	}
-	if _, ok := planes.ByID(wp.ID()); !ok {
-		t.Error("ByID failed")
 	}
 }
 
 func TestWorkAxisByTwoPointsAndPlaneIntersection(t *testing.T) {
-	axes := NewWorkAxes()
-	ax := axes.AddByTwoPoints(
-		func() math.Point3 { return math.P3(0, 0, 0) },
-		func() math.Point3 { return math.P3(0, 0, 4) },
-	)
+	g := NewWorkGeometry()
+	top := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 4) })
+	ax := g.WorkAxes().AddByTwoPoints(OriginCenter, top.Key())
 	if !ax.Direction().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
 		t.Errorf("axis dir = %v, want +Z", ax.Direction())
 	}
 	// XY plane ∩ XZ plane = the X axis.
-	inter := axes.AddByPlaneIntersection(sketch.XYPlane(), sketch.XZPlane())
+	inter := g.WorkAxes().AddByPlaneIntersection(OriginXYPlane, OriginXZPlane)
 	if !inter.Health().OK() {
 		t.Fatalf("plane-intersection axis sick: %+v", inter.Health())
 	}
@@ -91,44 +99,52 @@ func TestWorkAxisByTwoPointsAndPlaneIntersection(t *testing.T) {
 		t.Errorf("XY∩XZ axis dir = %v, want parallel to X", inter.Direction())
 	}
 	// Parallel planes do not intersect → sick.
-	top := axes.AddByPlaneIntersection(sketch.XYPlane(), offsetXY(10))
-	if top.Health().OK() {
+	off := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 10 })
+	par := g.WorkAxes().AddByPlaneIntersection(OriginXYPlane, off.Key())
+	if par.Health().OK() {
 		t.Error("parallel planes should yield a sick axis")
-	}
-	if axes.Count() != 3 || axes.Item(0) != ax {
-		t.Error("axis collection tracking wrong")
 	}
 }
 
-func TestWorkPointAndUCS(t *testing.T) {
-	pts := NewWorkPoints()
-	wp := pts.AddByPoint(func() math.Point3 { return math.P3(2, 3, 4) })
+func TestWorkPointPiercesPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(2, 3, 4) })
 	if !wp.Point().IsEqualTo(math.P3(2, 3, 4), wtol) || !wp.Health().OK() {
 		t.Errorf("work point = %v", wp.Point())
 	}
-	// Z axis through origin pierces the z=5 plane at (0,0,5).
-	axes := NewWorkAxes()
-	zAxis := axes.AddByTwoPoints(func() math.Point3 { return math.P3(0, 0, 0) }, func() math.Point3 { return math.P3(0, 0, 1) })
-	pierce := pts.AddByPlaneAndAxisIntersection(offsetXY(5), zAxis)
+	// The Z origin axis pierces the z=5 plane at (0,0,5).
+	off := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 5 })
+	pierce := g.WorkPoints().AddByPlaneAndAxisIntersection(off.Key(), OriginZAxis)
 	if !pierce.Point().IsEqualTo(math.P3(0, 0, 5), 1e-6) {
 		t.Errorf("pierce point = %v, want (0,0,5)", pierce.Point())
 	}
-	// An axis parallel to the plane never pierces it → sick.
-	xAxis := axes.AddByTwoPoints(func() math.Point3 { return math.P3(0, 0, 0) }, func() math.Point3 { return math.P3(1, 0, 0) })
-	if pts.AddByPlaneAndAxisIntersection(offsetXY(5), xAxis).Health().OK() {
+	// The X axis is parallel to the z=5 plane → never pierces → sick.
+	bad := g.WorkPoints().AddByPlaneAndAxisIntersection(off.Key(), OriginXAxis)
+	if bad.Health().OK() {
 		t.Error("axis parallel to plane should give a sick point")
 	}
-	if pts.Count() != 3 {
-		t.Errorf("point collection count = %d, want 3", pts.Count())
-	}
+}
 
-	ucs := NewUserCoordinateSystems()
-	frame := ucs.AddByPlane(offsetXY(5))
-	if !frame.Origin().IsEqualTo(math.P3(0, 0, 5), wtol) || !frame.ZAxis().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
-		t.Errorf("UCS frame wrong: origin=%v z=%v", frame.Origin(), frame.ZAxis())
+func TestWorkFeatureNamesAndKeys(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	wp.SetName("Datum1")
+	if wp.Name() != "Datum1" || wp.Key() != WorkRef("plane/3") {
+		t.Errorf("work plane name/key = %q/%q, want Datum1/plane/3", wp.Name(), wp.Key())
 	}
-	if !frame.XYPlane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) || ucs.Count() != 1 || ucs.Item(0) != frame {
-		t.Error("UCS plane / collection wrong")
+	// The origin center is point 0, so the first user point is point/1.
+	up := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 1, 1) })
+	if up.Key() != WorkRef("point/1") {
+		t.Errorf("first user point key = %q, want point/1", up.Key())
+	}
+}
+
+func TestUserCoordinateSystem(t *testing.T) {
+	ucs := NewUserCoordinateSystems().AddByPlane(offsetXY(5))
+	ucs.SetName("Frame")
+	if ucs.Name() != "Frame" || !ucs.Origin().IsEqualTo(math.P3(0, 0, 5), wtol) ||
+		!ucs.ZAxis().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("UCS frame wrong: origin=%v z=%v", ucs.Origin(), ucs.ZAxis())
 	}
 }
 
@@ -140,32 +156,3 @@ func offsetXY(z float64) sketch.Plane {
 
 func mustX() math.UnitVector3 { u, _ := math.NewUnitVector3(1, 0, 0); return u }
 func mustY() math.UnitVector3 { u, _ := math.NewUnitVector3(0, 1, 0); return u }
-
-func TestWorkFeatureAccessors(t *testing.T) {
-	planes := NewWorkPlanes()
-	wp := planes.AddByPlaneAndOffset(sketch.XYPlane(), func() float64 { return 1 })
-	wp.SetName("Datum1")
-	if wp.Name() != "Datum1" {
-		t.Error("work plane SetName/Name wrong")
-	}
-
-	axes := NewWorkAxes()
-	ax := axes.AddByTwoPoints(func() math.Point3 { return math.P3(0, 0, 0) }, func() math.Point3 { return math.P3(1, 0, 0) })
-	if ax.ID() == 0 || ax.Name() != "WorkAxis" || !ax.Origin().IsEqualTo(math.P3(0, 0, 0), wtol) || axes.Item(0) != ax {
-		t.Error("work axis accessors wrong")
-	}
-
-	pts := NewWorkPoints()
-	p := pts.AddByPoint(func() math.Point3 { return math.P3(1, 1, 1) })
-	if p.ID() == 0 || p.Name() != "WorkPoint" {
-		t.Error("work point accessors wrong")
-	}
-
-	ucs := NewUserCoordinateSystems().AddByPlane(sketch.XYPlane())
-	ucs.SetName("Frame")
-	if ucs.ID() == 0 || ucs.Name() != "Frame" ||
-		!ucs.XAxis().AsVector().IsEqualTo(math.V3(1, 0, 0), wtol) ||
-		!ucs.YAxis().AsVector().IsEqualTo(math.V3(0, 1, 0), wtol) {
-		t.Error("UCS accessors wrong")
-	}
-}

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -46,10 +46,24 @@ type workResolver interface {
 // the single owner so references between work features (and from revolve) resolve in
 // one place. A part component definition holds exactly one.
 type WorkGeometry struct {
-	planes *WorkPlanes
-	axes   *WorkAxes
-	points *WorkPoints
-	ucs    *UserCoordinateSystems
+	planes  *WorkPlanes
+	axes    *WorkAxes
+	points  *WorkPoints
+	ucs     *UserCoordinateSystems
+	userSeq []userEntry // user work features in global creation order (for serialization)
+}
+
+// userEntry records a user work feature's collection and index in global creation
+// order, so serialization replays them in dependency order — a work feature may
+// reference an earlier one (e.g. a point on a user plane).
+type userEntry struct {
+	collection string
+	index      int
+}
+
+// recordUser appends a freshly added user work feature to the creation-order log.
+func (g *WorkGeometry) recordUser(collection string, index int) {
+	g.userSeq = append(g.userSeq, userEntry{collection: collection, index: index})
 }
 
 // NewWorkGeometry builds the frame pre-populated with the grounded origin coordinate

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// WorkRef is a stable, serializable reference to a work feature or origin element —
+// the way work features (and revolve) name the geometry they are built on, mirroring
+// Inventor's reference model (every work feature is defined relative to references,
+// not absolute coordinates). Origin elements have well-known refs; user work features
+// are referenced by their position in their collection ("plane/2", "axis/0"), which is
+// deterministic because they are recreated in creation order on recompute/reopen — the
+// same index-as-stable-ref scheme sketches and patterns already use.
+type WorkRef string
+
+// Well-known origin references — the static coordinate system every part document has
+// from creation (Inventor's "Origin" folder): a center point, the X/Y/Z axes, and the
+// XY/XZ/YZ planes. They are grounded coordinate-system elements.
+const (
+	OriginCenter  WorkRef = "origin/point/center"
+	OriginXAxis   WorkRef = "origin/axis/x"
+	OriginYAxis   WorkRef = "origin/axis/y"
+	OriginZAxis   WorkRef = "origin/axis/z"
+	OriginXYPlane WorkRef = "origin/plane/xy"
+	OriginXZPlane WorkRef = "origin/plane/xz"
+	OriginYZPlane WorkRef = "origin/plane/yz"
+)
+
+// workResolver resolves a WorkRef to its current geometry. [WorkGeometry] implements
+// it; work-feature definitions resolve their references through it at recompute.
+type workResolver interface {
+	plane(WorkRef) (sketch.Plane, error)
+	axis(WorkRef) (*WorkAxis, error)
+	point(WorkRef) (math.Point3, error)
+}
+
+// WorkGeometry is a part's construction-geometry frame: the static origin coordinate
+// system plus the user-created work planes, axes, points and coordinate systems. It is
+// the single owner so references between work features (and from revolve) resolve in
+// one place. A part component definition holds exactly one.
+type WorkGeometry struct {
+	planes *WorkPlanes
+	axes   *WorkAxes
+	points *WorkPoints
+	ucs    *UserCoordinateSystems
+}
+
+// NewWorkGeometry builds the frame pre-populated with the grounded origin coordinate
+// system (center point, X/Y/Z axes, XY/XZ/YZ planes) — the absolute document reference
+// frame every other work feature is built relative to.
+func NewWorkGeometry() *WorkGeometry {
+	g := &WorkGeometry{}
+	g.planes = newWorkPlanes(g)
+	g.axes = newWorkAxes(g)
+	g.points = newWorkPoints(g)
+	g.ucs = NewUserCoordinateSystems()
+	g.seedOrigin()
+	return g
+}
+
+// WorkPlanes/WorkAxes/WorkPoints/UserCoordinateSystems expose the collections (origin
+// elements first, then user features).
+func (g *WorkGeometry) WorkPlanes() *WorkPlanes                       { return g.planes }
+func (g *WorkGeometry) WorkAxes() *WorkAxes                           { return g.axes }
+func (g *WorkGeometry) WorkPoints() *WorkPoints                       { return g.points }
+func (g *WorkGeometry) UserCoordinateSystems() *UserCoordinateSystems { return g.ucs }
+
+// OriginPlanes returns the three origin coordinate-system planes (XY/XZ/YZ) — the
+// browser's Origin folder and the default sketch hosts.
+func (g *WorkGeometry) OriginPlanes() []*WorkPlane {
+	out := make([]*WorkPlane, 0, 3)
+	for i := 0; i < g.planes.Count(); i++ {
+		if p := g.planes.Item(i); p.coordinateSystem {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Recompute re-derives every work feature in order (origin first, grounded; then user
+// features, which may reference earlier ones).
+func (g *WorkGeometry) Recompute() {
+	for i := 0; i < g.points.Count(); i++ {
+		g.points.Item(i).recompute(g)
+	}
+	for i := 0; i < g.axes.Count(); i++ {
+		g.axes.Item(i).recompute(g)
+	}
+	for i := 0; i < g.planes.Count(); i++ {
+		g.planes.Item(i).recompute(g)
+	}
+}
+
+// seedOrigin creates the grounded origin coordinate-system elements with their
+// well-known refs. Their geometry is fixed (the document's absolute frame).
+func (g *WorkGeometry) seedOrigin() {
+	center := math.P3(0, 0, 0)
+	g.points.addOrigin(OriginCenter, "Center Point", center)
+	g.axes.addOrigin(OriginXAxis, "X Axis", center, mustUnit(1, 0, 0))
+	g.axes.addOrigin(OriginYAxis, "Y Axis", center, mustUnit(0, 1, 0))
+	g.axes.addOrigin(OriginZAxis, "Z Axis", center, mustUnit(0, 0, 1))
+	g.planes.addOrigin(OriginXYPlane, "XY Plane", sketch.XYPlane())
+	g.planes.addOrigin(OriginXZPlane, "XZ Plane", sketch.XZPlane())
+	g.planes.addOrigin(OriginYZPlane, "YZ Plane", sketch.YZPlane())
+}
+
+// plane/axis/point implement workResolver, resolving a ref to its current geometry.
+func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
+	if i, ok := userIndex(ref, "plane"); ok {
+		if i < 0 || i >= g.planes.Count() {
+			return sketch.Plane{}, fmt.Errorf("work geometry: no work plane %q", ref)
+		}
+		return g.planes.Item(i).Plane(), nil
+	}
+	w, ok := g.planes.byKey[ref]
+	if !ok {
+		return sketch.Plane{}, fmt.Errorf("work geometry: unknown plane reference %q", ref)
+	}
+	return w.Plane(), nil
+}
+
+func (g *WorkGeometry) axis(ref WorkRef) (*WorkAxis, error) {
+	if i, ok := userIndex(ref, "axis"); ok {
+		if i < 0 || i >= g.axes.Count() {
+			return nil, fmt.Errorf("work geometry: no work axis %q", ref)
+		}
+		return g.axes.Item(i), nil
+	}
+	w, ok := g.axes.byKey[ref]
+	if !ok {
+		return nil, fmt.Errorf("work geometry: unknown axis reference %q", ref)
+	}
+	return w, nil
+}
+
+func (g *WorkGeometry) point(ref WorkRef) (math.Point3, error) {
+	if i, ok := userIndex(ref, "point"); ok {
+		if i < 0 || i >= g.points.Count() {
+			return math.Point3{}, fmt.Errorf("work geometry: no work point %q", ref)
+		}
+		return g.points.Item(i).Point(), nil
+	}
+	w, ok := g.points.byKey[ref]
+	if !ok {
+		return math.Point3{}, fmt.Errorf("work geometry: unknown point reference %q", ref)
+	}
+	return w.Point(), nil
+}
+
+// userIndex parses a "<collection>/<i>" user-feature reference into its index.
+func userIndex(ref WorkRef, collection string) (int, bool) {
+	prefix := collection + "/"
+	s := string(ref)
+	if !strings.HasPrefix(s, prefix) {
+		return 0, false
+	}
+	i, err := strconv.Atoi(strings.TrimPrefix(s, prefix))
+	if err != nil {
+		return 0, false
+	}
+	return i, true
+}
+
+// userRef builds the stable reference for the i-th user feature in a collection.
+func userRef(collection string, i int) WorkRef {
+	return WorkRef(collection + "/" + strconv.Itoa(i))
+}
+
+func mustUnit(x, y, z float64) math.UnitVector3 {
+	u, _ := math.NewUnitVector3(x, y, z)
+	return u
+}

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -147,13 +147,16 @@ func (c *WorkPlanes) AddByThreePoints(a, b, cc WorkRef) *WorkPlane {
 	return c.addUser("WorkPlane", threePointPlaneDef{a: a, b: b, c: cc})
 }
 
-// addUser adds a user datum plane, keying it by its position so references stay stable.
+// addUser adds a user datum plane, keying it by its position so references stay stable,
+// and records it in the part's global creation order.
 func (c *WorkPlanes) addUser(name string, def planeDefinition) *WorkPlane {
 	w := &WorkPlane{
 		id: nextID(), key: userRef("plane", len(c.items)), name: name, def: def,
 		displaySize: defaultOriginPlaneSize,
 	}
-	return c.track(w)
+	c.track(w)
+	c.g.recordUser("plane", len(c.items)-1)
+	return w
 }
 
 func (c *WorkPlanes) track(w *WorkPlane) *WorkPlane {

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -8,34 +8,105 @@ import (
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
 
-// Work features are parametric construction geometry — datum planes, axes and
-// points defined by relationships (offset, three-point, intersection…) that
-// recompute when their driving inputs change and are valid feature/sketch inputs
-// wherever no model face exists yet (modeling/01). Each holds an evaluate closure
-// capturing its definition; Recompute re-derives the geometry and sets health.
+// Work features are parametric construction geometry — datum planes, axes and points
+// defined by relationships to other geometry (Inventor's model: every work feature is
+// built relative to references, resolved at recompute). Each holds a typed, serializable
+// [planeDefinition]/etc. (not an opaque closure) so it round-trips. The origin elements
+// are grounded coordinate-system members with fixed geometry; user features reference
+// the origin or earlier features by [WorkRef].
 
-// WorkPlane is a parametric datum plane.
-type WorkPlane struct {
-	id       ID
-	name     string
-	evaluate func() (sketch.Plane, error)
-	plane    sketch.Plane
-	health   health.Health
+// defaultOriginPlaneSize is the half-extent the origin planes display at.
+const defaultOriginPlaneSize = 5.0
+
+// planeDefinition computes a work plane from its references. Concrete kinds capture the
+// references + parameters; eval resolves the references through the work resolver.
+type planeDefinition interface {
+	kindName() string
+	refs() []WorkRef
+	eval(r workResolver) (sketch.Plane, error)
 }
 
-// ID/Name identify the datum; Health reports its last recompute state.
+// fixedPlaneDef is a grounded plane (an origin plane): fixed geometry, no references.
+type fixedPlaneDef struct{ plane sketch.Plane }
+
+func (d fixedPlaneDef) kindName() string                        { return "fixed" }
+func (d fixedPlaneDef) refs() []WorkRef                         { return nil }
+func (d fixedPlaneDef) eval(workResolver) (sketch.Plane, error) { return d.plane, nil }
+
+// offsetPlaneDef is a plane parallel to a base plane, offset along its normal by a
+// (parametric) distance — Inventor's PlaneAndOffset definition.
+type offsetPlaneDef struct {
+	base   WorkRef
+	offset func() float64
+}
+
+func (d offsetPlaneDef) kindName() string { return "plane-offset" }
+func (d offsetPlaneDef) refs() []WorkRef  { return []WorkRef{d.base} }
+func (d offsetPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	base, err := r.plane(d.base)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	origin := base.Origin().TranslateBy(base.Normal().AsVector().Scale(d.offset()))
+	return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+}
+
+// threePointPlaneDef builds a plane through three referenced points.
+type threePointPlaneDef struct{ a, b, c WorkRef }
+
+func (d threePointPlaneDef) kindName() string { return "three-points" }
+func (d threePointPlaneDef) refs() []WorkRef  { return []WorkRef{d.a, d.b, d.c} }
+func (d threePointPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	a, err := r.point(d.a)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	b, err := r.point(d.b)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	c, err := r.point(d.c)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeThroughPoints(a, b, c)
+}
+
+// WorkPlane is a datum plane — an origin coordinate-system plane or a user work plane.
+type WorkPlane struct {
+	id               ID
+	key              WorkRef
+	name             string
+	def              planeDefinition
+	plane            sketch.Plane
+	health           health.Health
+	displaySize      float64
+	coordinateSystem bool
+	grounded         bool
+}
+
+// ID/Key/Name identify the datum; Health reports its last recompute state.
 func (w *WorkPlane) ID() ID                { return w.id }
+func (w *WorkPlane) Key() WorkRef          { return w.key }
 func (w *WorkPlane) Name() string          { return w.name }
 func (w *WorkPlane) SetName(n string)      { w.name = n }
 func (w *WorkPlane) Health() health.Health { return w.health }
 
-// Plane returns the current datum plane, also usable directly as a sketch plane.
+// Plane returns the current datum plane, also usable directly as a sketch host.
 func (w *WorkPlane) Plane() sketch.Plane { return w.plane }
 
-// Recompute re-derives the plane from its definition, going sick on failure (e.g.
+// DisplaySize is the half-edge length of the square the plane is drawn/picked as.
+func (w *WorkPlane) DisplaySize() float64 { return w.displaySize }
+
+// IsCoordinateSystemElement reports whether this is one of the origin frame's planes;
+// Grounded reports whether its geometry is fixed (the absolute document frame).
+func (w *WorkPlane) IsCoordinateSystemElement() bool { return w.coordinateSystem }
+func (w *WorkPlane) Grounded() bool                  { return w.grounded }
+
+// recompute re-derives the plane from its definition, going sick on failure (e.g.
 // degenerate three points) rather than producing garbage.
-func (w *WorkPlane) Recompute() {
-	p, err := w.evaluate()
+func (w *WorkPlane) recompute(r workResolver) {
+	p, err := w.def.eval(r)
 	if err != nil {
 		w.health = health.Sicken("work plane: " + err.Error())
 		return
@@ -43,44 +114,57 @@ func (w *WorkPlane) Recompute() {
 	w.plane, w.health = p, health.Healthy
 }
 
-// WorkPlanes is the collection of datum planes and their relationship constructors.
+// WorkPlanes is the part's collection of datum planes (origin first, then user). It
+// holds its owning [WorkGeometry] so Add* can resolve references at creation.
 type WorkPlanes struct {
+	g     *WorkGeometry
 	items []*WorkPlane
 	byID  map[ID]*WorkPlane
+	byKey map[WorkRef]*WorkPlane
 }
 
-// NewWorkPlanes returns an empty collection.
-func NewWorkPlanes() *WorkPlanes { return &WorkPlanes{byID: map[ID]*WorkPlane{}} }
+func newWorkPlanes(g *WorkGeometry) *WorkPlanes {
+	return &WorkPlanes{g: g, byID: map[ID]*WorkPlane{}, byKey: map[WorkRef]*WorkPlane{}}
+}
 
-// AddByPlaneAndOffset creates a plane parallel to base, offset along its normal by
-// the value the offset closure returns (typically a parameter), so the datum moves
-// when that parameter changes.
-func (c *WorkPlanes) AddByPlaneAndOffset(base sketch.Plane, offset func() float64) *WorkPlane {
-	eval := func() (sketch.Plane, error) {
-		origin := base.Origin().TranslateBy(base.Normal().AsVector().Scale(offset()))
-		return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+// addOrigin adds a grounded coordinate-system plane with a well-known reference.
+func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) *WorkPlane {
+	w := &WorkPlane{
+		id: nextID(), key: key, name: name, def: fixedPlaneDef{plane: plane},
+		displaySize: defaultOriginPlaneSize, coordinateSystem: true, grounded: true,
 	}
-	return c.add("WorkPlane", eval)
+	return c.track(w)
 }
 
-// AddByThreePoints creates a plane through three (parametric) points, with its X
-// axis toward the second point.
-func (c *WorkPlanes) AddByThreePoints(a, b, cc func() math.Point3) *WorkPlane {
-	eval := func() (sketch.Plane, error) {
-		return planeThroughPoints(a(), b(), cc())
+// AddByPlaneAndOffset creates a user plane parallel to base, offset by the value the
+// closure returns (typically a parameter), so the datum moves when that param changes.
+func (c *WorkPlanes) AddByPlaneAndOffset(base WorkRef, offset func() float64) *WorkPlane {
+	return c.addUser("WorkPlane", offsetPlaneDef{base: base, offset: offset})
+}
+
+// AddByThreePoints creates a user plane through three referenced points.
+func (c *WorkPlanes) AddByThreePoints(a, b, cc WorkRef) *WorkPlane {
+	return c.addUser("WorkPlane", threePointPlaneDef{a: a, b: b, c: cc})
+}
+
+// addUser adds a user datum plane, keying it by its position so references stay stable.
+func (c *WorkPlanes) addUser(name string, def planeDefinition) *WorkPlane {
+	w := &WorkPlane{
+		id: nextID(), key: userRef("plane", len(c.items)), name: name, def: def,
+		displaySize: defaultOriginPlaneSize,
 	}
-	return c.add("WorkPlane", eval)
+	return c.track(w)
 }
 
-func (c *WorkPlanes) add(name string, eval func() (sketch.Plane, error)) *WorkPlane {
-	w := &WorkPlane{id: nextID(), name: name, evaluate: eval}
-	w.Recompute()
+func (c *WorkPlanes) track(w *WorkPlane) *WorkPlane {
+	w.recompute(c.g)
 	c.items = append(c.items, w)
 	c.byID[w.id] = w
+	c.byKey[w.key] = w
 	return w
 }
 
-// Count/Item index the collection; ByID looks up.
+// Count/Item index the collection; ByID/ByKey look up.
 func (c *WorkPlanes) Count() int            { return len(c.items) }
 func (c *WorkPlanes) Item(i int) *WorkPlane { return c.items[i] }
 func (c *WorkPlanes) ByID(id ID) (*WorkPlane, bool) {

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -128,12 +128,12 @@ func newWorkPlanes(g *WorkGeometry) *WorkPlanes {
 }
 
 // addOrigin adds a grounded coordinate-system plane with a well-known reference.
-func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) *WorkPlane {
+func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) {
 	w := &WorkPlane{
 		id: nextID(), key: key, name: name, def: fixedPlaneDef{plane: plane},
 		displaySize: defaultOriginPlaneSize, coordinateSystem: true, grounded: true,
 	}
-	return c.track(w)
+	c.track(w)
 }
 
 // AddByPlaneAndOffset creates a user plane parallel to base, offset by the value the
@@ -159,12 +159,11 @@ func (c *WorkPlanes) addUser(name string, def planeDefinition) *WorkPlane {
 	return w
 }
 
-func (c *WorkPlanes) track(w *WorkPlane) *WorkPlane {
+func (c *WorkPlanes) track(w *WorkPlane) {
 	w.recompute(c.g)
 	c.items = append(c.items, w)
 	c.byID[w.id] = w
 	c.byKey[w.key] = w
-	return w
 }
 
 // Count/Item index the collection; ByID/ByKey look up.


### PR DESCRIPTION
Models construction geometry the way Inventor does (verified against the `Oblikovati.Contracts.CSharp` API reference), then persists it — unblocking work-feature and revolve round-tripping.

## Phase 1 — origin coordinate system + work model (foundation)
- A part owns one `feature.WorkGeometry`: the **static origin coordinate system** (center point, X/Y/Z axes, XY/XZ/YZ planes) as **grounded `IsCoordinateSystemElement`** members with well-known `WorkRef` keys, plus the user work planes/axes/points and UCS collections.
- Work features are defined **relative to references** (`WorkRef`) — origin well-known keys, user features by collection position — resolved at recompute, replacing the opaque eval closures with **typed serializable definitions**.
- Unified on one `WorkPlane` type (dropped `compdef.WorkPlane`); migrated the ~13 app/head sites. The part recomputes its work geometry before the feature program.

## Phase 2 — persistence + revolve
- A `workFeatures` recipe section serializes **user** work features in global creation order (origin is regenerated, never serialized); each names the geometry it is built on by `WorkRef` and re-resolves on recompute.
- **Revolve** serializes its axis as a `WorkRef` and re-binds it through the part's work geometry on restore (generation stays deferred).

## Verification
A user work plane offset off the origin XY re-resolves to z=5 after reopen; a revolve's axis re-binds to `origin/axis/z`. `go vet` clean; full core suite **0 failures**; `head` builds + tests pass.

## Out of scope (error loudly until coded)
Face/edge/sketch-referenced work features, sweep/loft/coil/rib, mesh, freeform cage, non-parametric base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)