### PR TITLE
Sketch editor: driving dimensions, finished-sketch picking, usable extrude, ribbon layout

### DIFF
--- a/app/extrude_session.go
+++ b/app/extrude_session.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "github.com/Oblikovati/oblikovati/model/param"
+
+// Session bridge for the Extrude tool's UI: the head reads/sets the distance in the
+// document's display unit (e.g. mm) without touching database units or the tool's
+// internals, and asks whether a profile has been picked so it can prompt vs. highlight.
+
+// ActiveExtrude returns the running Extrude tool, or nil when the active tool is not an
+// extrude (or there is none).
+func (s *Session) ActiveExtrude() *ExtrudeTool {
+	if s.tool == nil {
+		return nil
+	}
+	ext, _ := s.tool.tool.(*ExtrudeTool)
+	return ext
+}
+
+// ExtrudeDistanceDisplay returns the active extrude tool's distance in the document's
+// length unit (the value an input field shows), or 0 when no extrude is active.
+func (s *Session) ExtrudeDistanceDisplay() float64 {
+	ext := s.ActiveExtrude()
+	if ext == nil {
+		return 0
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(ext.Distance(), param.Length))
+}
+
+// SetExtrudeDistanceDisplay sets the active extrude tool's distance from a value given in
+// the document's length unit (e.g. 25 mm), converting to database units. A no-op when no
+// extrude is active.
+func (s *Session) SetExtrudeDistanceDisplay(value float64) {
+	if ext := s.ActiveExtrude(); ext != nil {
+		ext.SetDistance(s.DocumentUnits().FromPreferred(value, param.Length).Value)
+	}
+}
+
+// LengthUnitName returns the document's preferred length-unit name (e.g. "mm"), to label
+// the distance field.
+func (s *Session) LengthUnitName() string {
+	return s.DocumentUnits().PreferredName(param.Length)
+}

--- a/app/extrude_session_test.go
+++ b/app/extrude_session_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+func TestActiveExtrudeNilWhenNoExtrudeTool(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if s.ActiveExtrude() != nil {
+		t.Error("ActiveExtrude should be nil with no tool")
+	}
+	s.StartTool(NewLineTool())
+	if s.ActiveExtrude() != nil {
+		t.Error("ActiveExtrude should be nil when a non-extrude tool is active")
+	}
+}
+
+func TestExtrudeDistanceDisplayRoundTripsThroughDocUnit(t *testing.T) {
+	s, _ := topDownPickerOverSquare(t)
+	s.StartTool(NewExtrudeTool())
+	// The document length unit defaults to mm; the model database unit is cm. Setting
+	// 50 mm must store 5 (cm) on the tool and read back as 50 mm.
+	s.SetExtrudeDistanceDisplay(50)
+	if got := s.ActiveExtrude().Distance(); got < 4.999 || got > 5.001 {
+		t.Errorf("distance stored = %v db units, want ~5 (cm) for 50 mm", got)
+	}
+	if got := s.ExtrudeDistanceDisplay(); got < 49.99 || got > 50.01 {
+		t.Errorf("distance display = %v, want ~50 mm", got)
+	}
+}
+
+func TestExtrudeDialogPathBuildsSolid(t *testing.T) {
+	s, _ := topDownPickerOverSquare(t) // 2×2 square at origin, top-down camera
+	s.StartTool(NewExtrudeTool())
+	s.Click(200, 200) // pick the profile (center pixel)
+	ext := s.ActiveExtrude()
+	if _, picked := ext.PickedProfile(); !picked {
+		t.Fatal("clicking inside the square should pick its profile")
+	}
+	s.SetExtrudeDistanceDisplay(40) // 40 mm via the dialog path
+	if !ext.CanCommit() {
+		t.Fatal("profile + distance should make the extrude committable")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("extrude via the dialog path: %v", err)
+	}
+	if !ext.AddedFeature().Health().OK() {
+		t.Errorf("extruded feature unhealthy: %s", ext.AddedFeature().Health().Reason)
+	}
+}

--- a/app/extrude_session_test.go
+++ b/app/extrude_session_test.go
@@ -16,7 +16,7 @@ func TestActiveExtrudeNilWhenNoExtrudeTool(t *testing.T) {
 }
 
 func TestExtrudeDistanceDisplayRoundTripsThroughDocUnit(t *testing.T) {
-	s, _ := topDownPickerOverSquare(t)
+	s := topDownPickerOverSquare(t)
 	s.StartTool(NewExtrudeTool())
 	// The document length unit defaults to mm; the model database unit is cm. Setting
 	// 50 mm must store 5 (cm) on the tool and read back as 50 mm.
@@ -30,7 +30,7 @@ func TestExtrudeDistanceDisplayRoundTripsThroughDocUnit(t *testing.T) {
 }
 
 func TestExtrudeDialogPathBuildsSolid(t *testing.T) {
-	s, _ := topDownPickerOverSquare(t) // 2×2 square at origin, top-down camera
+	s := topDownPickerOverSquare(t) // 2×2 square at origin, top-down camera
 	s.StartTool(NewExtrudeTool())
 	s.Click(200, 200) // pick the profile (center pixel)
 	ext := s.ActiveExtrude()

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -46,6 +46,18 @@ func (t *ExtrudeTool) Pick(_ *Session, sel Selectable) {
 // would set).
 func (t *ExtrudeTool) SetDistance(d float64) { t.distance = d }
 
+// Distance returns the current extrusion distance (database units).
+func (t *ExtrudeTool) Distance() float64 { return t.distance }
+
+// PickedProfile returns the profile the user clicked (and true), or false when none has
+// been picked yet — so the UI can highlight the selected profile and prompt otherwise.
+func (t *ExtrudeTool) PickedProfile() (ProfileHandle, bool) {
+	if t.profile == nil {
+		return ProfileHandle{}, false
+	}
+	return *t.profile, true
+}
+
 // SetOperation chooses join/cut/intersect/new-body.
 func (t *ExtrudeTool) SetOperation(op ops.PartFeatureOperation) { t.operation = op }
 

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/scene"
 )
 
@@ -18,9 +19,10 @@ import (
 // [Picker], so a test "clicks on" a modeled solid or a datum plane — screen coordinate
 // → ray → face/plane — with no GPU.
 type RayPicker struct {
-	camera scene.Camera
-	bodies func() []*topo.Body
-	planes func() []*feature.WorkPlane
+	camera   scene.Camera
+	bodies   func() []*topo.Body
+	planes   func() []*feature.WorkPlane
+	sketches func() []*sketch.Sketch
 }
 
 // NewRayPicker builds a picker over a camera and a provider of the current scene
@@ -36,26 +38,106 @@ func (p *RayPicker) WithPlanes(planes func() []*feature.WorkPlane) *RayPicker {
 	return p
 }
 
+// WithSketches adds a provider of the part's (visible) sketches, so the picker can
+// resolve a click inside a sketch profile region — what an extrude/revolve consumes.
+func (p *RayPicker) WithSketches(sketches func() []*sketch.Sketch) *RayPicker {
+	p.sketches = sketches
+	return p
+}
+
 // SetCamera updates the view used for picking.
 func (p *RayPicker) SetCamera(c scene.Camera) { p.camera = c }
 
 // Pick returns the nearest selectable under the pixel honoring the filter: a face hit
-// (or its owning body) when a solid is in front, otherwise the nearest origin work
-// plane whose finite display square the ray crosses.
+// (or its owning body) when a solid is in front, a sketch profile region the ray lands
+// in, or the nearest origin work plane whose finite display square the ray crosses —
+// whichever the filter accepts and is closest. Ties favor faces, then planes, then
+// profiles (the append order), so a solid in front wins over the sketch on its face.
 func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, bool) {
 	origin, dir := p.camera.RayThrough(x, y)
-	face, body, faceT := p.nearestFace(origin, dir)
-	plane, planeT := p.nearestPlane(origin, dir)
-	faceSel, faceOK := facePick(face, body, filter)
-	planeOK := plane != nil && filter.Accepts(SelectWorkPlane)
-	switch {
-	case faceOK && (!planeOK || faceT <= planeT):
-		return faceSel, true
-	case planeOK:
-		return WorkPlaneHandle{Plane: plane}, true
-	default:
+	var cands []pickCandidate
+	if face, body, t := p.nearestFace(origin, dir); face != nil {
+		if sel, ok := facePick(face, body, filter); ok {
+			cands = append(cands, pickCandidate{t, sel})
+		}
+	}
+	if plane, t := p.nearestPlane(origin, dir); plane != nil && filter.Accepts(SelectWorkPlane) {
+		cands = append(cands, pickCandidate{t, WorkPlaneHandle{Plane: plane}})
+	}
+	if sel, t, ok := p.nearestProfile(origin, dir, filter); ok {
+		cands = append(cands, pickCandidate{t, sel})
+	}
+	return nearestCandidate(cands)
+}
+
+// pickCandidate is one ray hit: its forward parameter and the selectable it resolves to.
+type pickCandidate struct {
+	t   float64
+	sel Selectable
+}
+
+// nearestCandidate returns the candidate with the smallest ray parameter (the first one
+// on ties, preserving the face→plane→profile precedence), or false when there are none.
+func nearestCandidate(cands []pickCandidate) (Selectable, bool) {
+	best, bestT := -1, stdmath.Inf(1)
+	for i, c := range cands {
+		if c.t < bestT {
+			best, bestT = i, c.t
+		}
+	}
+	if best < 0 {
 		return nil, false
 	}
+	return cands[best].sel, true
+}
+
+// nearestProfile returns the closest sketch profile region the ray lands inside (mapped
+// through each visible sketch's plane), and the ray parameter — when the filter accepts
+// profiles. ok is false when no sketches are provided, profiles aren't accepted, or the
+// ray misses every region.
+func (p *RayPicker) nearestProfile(origin math.Point3, dir math.Vector3, filter *SelectionFilter) (Selectable, float64, bool) {
+	if p.sketches == nil || !filter.Accepts(SelectProfile) {
+		return nil, stdmath.Inf(1), false
+	}
+	var hit Selectable
+	best := stdmath.Inf(1)
+	for _, sk := range p.sketches() {
+		t, uv, ok := rayPlanePoint(origin, dir, sk.Plane())
+		if !ok || t >= best {
+			continue
+		}
+		if idx, found := profileAt(sk, uv); found {
+			best, hit = t, ProfileHandle{Sketch: sk, ProfileIndex: idx}
+		}
+	}
+	return hit, best, hit != nil
+}
+
+// profileAt returns the index of the first profile in sk whose region contains the
+// sketch-plane point uv, or false when uv is outside every profile.
+func profileAt(sk *sketch.Sketch, uv math.Point2) (int, bool) {
+	profiles := sk.Profiles()
+	for i := 0; i < profiles.Count(); i++ {
+		if profiles.Item(i).Contains(uv) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// rayPlanePoint intersects a ray with an (infinite) sketch plane, returning the forward
+// ray parameter and the hit point in sketch (2D) coordinates.
+func rayPlanePoint(origin math.Point3, dir math.Vector3, plane sketch.Plane) (float64, math.Point2, bool) {
+	n := plane.Normal().AsVector()
+	denom := dir.Dot(n)
+	if math.IsNearZero(denom, math.DefaultTolerance) {
+		return 0, math.Point2{}, false
+	}
+	t := origin.VectorTo(plane.Origin()).Dot(n) / denom
+	if t <= 0 {
+		return 0, math.Point2{}, false
+	}
+	return t, plane.ToSketch(origin.TranslateBy(dir.Scale(t))), true
 }
 
 // nearestFace returns the closest ray-hit face, its body, and the ray parameter.

--- a/app/raypicker_profile_test.go
+++ b/app/raypicker_profile_test.go
@@ -10,23 +10,22 @@ import (
 	"github.com/Oblikovati/oblikovati/scene"
 )
 
-// topDownPickerOverSquare returns a RayPicker looking straight down the XY sketch with
-// its 2×2 square, plus the sketch — so a center-pixel click ray lands inside the profile.
-func topDownPickerOverSquare(t *testing.T) (*Session, *RayPicker) {
+// topDownPickerOverSquare returns a session whose picker looks straight down the XY
+// sketch with its 2×2 square — so a center-pixel click ray lands inside the profile.
+func topDownPickerOverSquare(t *testing.T) *Session {
 	t.Helper()
 	s, profile := newPartWithSquare(t, 2)
 	cam := scene.NewCamera(400, 400)
 	cam.Eye = math.P3(1, 1, 20) // above the square's center (1,1)
 	cam.Target = math.P3(1, 1, 0)
 	cam.Up = math.V3(0, 1, 0)
-	picker := NewRayPicker(cam, partBodies(s)).
-		WithSketches(func() []*sketch.Sketch { return []*sketch.Sketch{profile.Sketch} })
-	s.SetPicker(picker)
-	return s, picker
+	s.SetPicker(NewRayPicker(cam, partBodies(s)).
+		WithSketches(func() []*sketch.Sketch { return []*sketch.Sketch{profile.Sketch} }))
+	return s
 }
 
 func TestRayPickerSelectsSketchProfile(t *testing.T) {
-	s, _ := topDownPickerOverSquare(t)
+	s := topDownPickerOverSquare(t)
 	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
 	s.Click(200, 200) // center pixel → inside the square
 	if s.Selection().Count() != 1 {
@@ -39,7 +38,7 @@ func TestRayPickerSelectsSketchProfile(t *testing.T) {
 }
 
 func TestRayPickerMissesOutsideProfile(t *testing.T) {
-	s, _ := topDownPickerOverSquare(t)
+	s := topDownPickerOverSquare(t)
 	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
 	s.Click(10, 10) // a corner pixel, well outside the 2×2 square
 	if s.Selection().Count() != 0 {
@@ -48,7 +47,7 @@ func TestRayPickerMissesOutsideProfile(t *testing.T) {
 }
 
 func TestExtrudeFromPickedProfile(t *testing.T) {
-	s, _ := topDownPickerOverSquare(t)
+	s := topDownPickerOverSquare(t)
 	ext := NewExtrudeTool()
 	s.StartTool(ext) // sets the filter to SelectProfile
 	s.Click(200, 200)

--- a/app/raypicker_profile_test.go
+++ b/app/raypicker_profile_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// topDownPickerOverSquare returns a RayPicker looking straight down the XY sketch with
+// its 2×2 square, plus the sketch — so a center-pixel click ray lands inside the profile.
+func topDownPickerOverSquare(t *testing.T) (*Session, *RayPicker) {
+	t.Helper()
+	s, profile := newPartWithSquare(t, 2)
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(1, 1, 20) // above the square's center (1,1)
+	cam.Target = math.P3(1, 1, 0)
+	cam.Up = math.V3(0, 1, 0)
+	picker := NewRayPicker(cam, partBodies(s)).
+		WithSketches(func() []*sketch.Sketch { return []*sketch.Sketch{profile.Sketch} })
+	s.SetPicker(picker)
+	return s, picker
+}
+
+func TestRayPickerSelectsSketchProfile(t *testing.T) {
+	s, _ := topDownPickerOverSquare(t)
+	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+	s.Click(200, 200) // center pixel → inside the square
+	if s.Selection().Count() != 1 {
+		t.Fatalf("profile pick selected %d, want 1", s.Selection().Count())
+	}
+	ph, ok := s.Selection().First().(ProfileHandle)
+	if !ok || ph.ProfileIndex != 0 {
+		t.Fatalf("selected %T (index %d), want ProfileHandle index 0", s.Selection().First(), ph.ProfileIndex)
+	}
+}
+
+func TestRayPickerMissesOutsideProfile(t *testing.T) {
+	s, _ := topDownPickerOverSquare(t)
+	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+	s.Click(10, 10) // a corner pixel, well outside the 2×2 square
+	if s.Selection().Count() != 0 {
+		t.Errorf("clicking outside the profile selected %d, want 0", s.Selection().Count())
+	}
+}
+
+func TestExtrudeFromPickedProfile(t *testing.T) {
+	s, _ := topDownPickerOverSquare(t)
+	ext := NewExtrudeTool()
+	s.StartTool(ext) // sets the filter to SelectProfile
+	s.Click(200, 200)
+	ext.SetDistance(5)
+	if !ext.CanCommit() {
+		t.Fatal("clicking inside the square should have picked the profile for extrude")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("extrude from picked profile: %v", err)
+	}
+	if !ext.AddedFeature().Health().OK() {
+		t.Errorf("extruded feature unhealthy: %s", ext.AddedFeature().Health().Reason)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -30,6 +30,7 @@ type Session struct {
 	camTween        cameraTween
 	sketchReturnCam scene.Camera
 	activeSketch    *sketch.Sketch
+	pendingDim      *sketch.DimensionConstraint
 	overlays        []renderer.DrawItem
 	addins          *AddInManager
 	grid            *GridSettings
@@ -91,6 +92,7 @@ func (s *Session) ExitSketch() {
 	if s.activeSketch != nil {
 		s.activeSketch.ExitEdit()
 		s.activeSketch = nil
+		s.pendingDim = nil // no dangling edit box after leaving the sketch
 		s.animateCameraTo(s.sketchReturnCam, sketchViewTweenSeconds)
 	}
 }

--- a/app/sketch_constraints.go
+++ b/app/sketch_constraints.go
@@ -296,29 +296,32 @@ func applyDimension(s *Session, ents []sketch.Entity) error {
 	if s.activeSketch == nil {
 		return errors.New("no active sketch")
 	}
-	dims := s.activeSketch.DimensionConstraints()
-	units := s.DocumentUnits()
-	var created *sketch.DimensionConstraint
-	var err error
-	switch {
-	case len(filterCircles(ents)) >= 1:
-		c := filterCircles(ents)[0]
-		created, err = dims.AddRadius(c, lengthExpr(units, c.Radius))
-	case len(filterLines(ents)) >= 2:
-		l := filterLines(ents)
-		created, err = dims.AddAngle(l[0], l[1], angleExpr(units, lineAngle(l[0], l[1])))
-	default:
-		a, b, ok := pointPairFrom(ents)
-		if !ok {
-			return errNeed("dimension", "points, a line, a circle, or two lines")
-		}
-		created, err = dims.AddDistance(a, b, lengthExpr(units, a.Position().DistanceTo(b.Position())))
-	}
+	created, err := addDimensionFor(s.activeSketch.DimensionConstraints(), s.DocumentUnits(), ents)
 	if err != nil {
 		return err
 	}
 	s.pendingDim = created
 	return s.afterConstraint()
+}
+
+// addDimensionFor creates the dimension implied by the picked entities — a circle's
+// radius, the angle between two lines, or a distance between two points (or a line's
+// length) — at the current measured value in the document's units.
+func addDimensionFor(dims *sketch.DimensionConstraints, units param.UnitsOfMeasure, ents []sketch.Entity) (*sketch.DimensionConstraint, error) {
+	switch {
+	case len(filterCircles(ents)) >= 1:
+		c := filterCircles(ents)[0]
+		return dims.AddRadius(c, lengthExpr(units, c.Radius))
+	case len(filterLines(ents)) >= 2:
+		l := filterLines(ents)
+		return dims.AddAngle(l[0], l[1], angleExpr(units, lineAngle(l[0], l[1])))
+	default:
+		a, b, ok := pointPairFrom(ents)
+		if !ok {
+			return nil, errNeed("dimension", "points, a line, a circle, or two lines")
+		}
+		return dims.AddDistance(a, b, lengthExpr(units, a.Position().DistanceTo(b.Position())))
+	}
 }
 
 // lengthExpr formats a database-unit length as a parseable expression in the document's

--- a/app/sketch_constraints.go
+++ b/app/sketch_constraints.go
@@ -289,33 +289,35 @@ func applyFix(s *Session, ents []sketch.Entity) error {
 
 // applyDimension adds the dimension implied by the picked entities: a circle's radius,
 // the angle between two lines, or a distance between two points (or a line's length),
-// created at the current measured value in the document's units.
+// created at the current measured value in the document's units. The new dimension is
+// held as the session's pending dimension so the UI can immediately prompt for a value
+// to drive the geometry (Inventor's edit-on-place flow).
 func applyDimension(s *Session, ents []sketch.Entity) error {
 	if s.activeSketch == nil {
 		return errors.New("no active sketch")
 	}
 	dims := s.activeSketch.DimensionConstraints()
 	units := s.DocumentUnits()
+	var created *sketch.DimensionConstraint
+	var err error
 	switch {
 	case len(filterCircles(ents)) >= 1:
 		c := filterCircles(ents)[0]
-		if _, err := dims.AddRadius(c, lengthExpr(units, c.Radius)); err != nil {
-			return err
-		}
+		created, err = dims.AddRadius(c, lengthExpr(units, c.Radius))
 	case len(filterLines(ents)) >= 2:
 		l := filterLines(ents)
-		if _, err := dims.AddAngle(l[0], l[1], angleExpr(units, lineAngle(l[0], l[1]))); err != nil {
-			return err
-		}
+		created, err = dims.AddAngle(l[0], l[1], angleExpr(units, lineAngle(l[0], l[1])))
 	default:
 		a, b, ok := pointPairFrom(ents)
 		if !ok {
 			return errNeed("dimension", "points, a line, a circle, or two lines")
 		}
-		if _, err := dims.AddDistance(a, b, lengthExpr(units, a.Position().DistanceTo(b.Position()))); err != nil {
-			return err
-		}
+		created, err = dims.AddDistance(a, b, lengthExpr(units, a.Position().DistanceTo(b.Position())))
 	}
+	if err != nil {
+		return err
+	}
+	s.pendingDim = created
 	return s.afterConstraint()
 }
 

--- a/app/sketch_dimension_edit.go
+++ b/app/sketch_dimension_edit.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// Editing a dimension's value — Inventor's edit-on-place flow. When the Dimension tool
+// places a dimension it is held as the session's "pending" dimension; the UI shows an
+// edit box pre-filled with its current expression, and committing a value drives the
+// geometry through the parameter DAG + solver. Double-clicking an existing dimension
+// re-opens the same edit by making it pending again.
+
+// PendingDimension returns the dimension awaiting a typed value (just placed or being
+// re-edited), or nil. The head shows an edit popup while this is non-nil.
+func (s *Session) PendingDimension() *sketch.DimensionConstraint { return s.pendingDim }
+
+// PendingDimensionExpression returns the current expression text to pre-fill the edit
+// box (e.g. "25 mm"), or "" when no dimension is pending.
+func (s *Session) PendingDimensionExpression() string {
+	if s.pendingDim == nil {
+		return ""
+	}
+	return s.pendingDim.Parameter().Expression()
+}
+
+// BeginEditDimension re-opens a placed dimension for editing (the double-click path).
+func (s *Session) BeginEditDimension(d *sketch.DimensionConstraint) {
+	s.pendingDim = d
+}
+
+// CommitPendingDimension sets the pending dimension's value from a parseable expression
+// (e.g. "30 mm", "width/2", "45 deg") and re-solves, so the geometry moves to satisfy
+// it. It errors (and leaves the dimension pending) when there is none pending or the
+// expression is invalid, so the UI can keep the edit box open to correct it.
+func (s *Session) CommitPendingDimension(expression string) error {
+	if s.pendingDim == nil {
+		return errors.New("app: no dimension is being edited")
+	}
+	if err := s.pendingDim.Parameter().SetExpression(expression); err != nil {
+		return err
+	}
+	s.pendingDim = nil
+	if s.activeSketch != nil {
+		s.activeSketch.Solve()
+	}
+	return nil
+}
+
+// CancelPendingDimension dismisses the edit box, keeping the dimension at its current
+// (measured) value — Inventor accepts the placed dimension when you cancel the edit.
+func (s *Session) CancelPendingDimension() { s.pendingDim = nil }

--- a/app/sketch_dimension_edit_test.go
+++ b/app/sketch_dimension_edit_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// placeDistanceDim drives the Dimension tool over two points and returns the sketch.
+func placeDistanceDim(t *testing.T, s *Session, sk *sketch.Sketch, a, b math.Point2) {
+	t.Helper()
+	s.StartTool(newDimensionTool())
+	s.feedPick(SketchEntityHandle{Entity: sk.Points().Add(a)})
+	s.feedPick(SketchEntityHandle{Entity: sk.Points().Add(b)})
+}
+
+func TestPlacingDimensionMakesItPending(t *testing.T) {
+	s, sk := sketchSession(t)
+	placeDistanceDim(t, s, sk, math.P2(0, 0), math.P2(3, 0))
+	if s.PendingDimension() == nil {
+		t.Fatal("placing a dimension should leave it pending for value entry")
+	}
+	if got := s.PendingDimensionExpression(); got == "" {
+		t.Errorf("pending expression = %q, want the measured value pre-filled", got)
+	}
+}
+
+func TestCommitPendingDimensionDrivesGeometry(t *testing.T) {
+	s, sk := sketchSession(t)
+	a := sk.Points().Add(math.P2(0, 0))
+	b := sk.Points().Add(math.P2(3, 0)) // 3 cm apart
+	s.StartTool(newDimensionTool())
+	s.feedPick(SketchEntityHandle{Entity: a})
+	s.feedPick(SketchEntityHandle{Entity: b})
+	if err := s.CommitPendingDimension("50 mm"); err != nil {
+		t.Fatalf("CommitPendingDimension: %v", err)
+	}
+	if s.PendingDimension() != nil {
+		t.Error("committing should clear the pending dimension")
+	}
+	// 50 mm = 5 cm: the solver should drive the points to 5 db-units (cm) apart.
+	if d := a.Position().DistanceTo(b.Position()); d < 4.99 || d > 5.01 {
+		t.Errorf("after committing 50 mm the points are %v cm apart, want ~5", d)
+	}
+}
+
+func TestCommitInvalidExpressionKeepsPending(t *testing.T) {
+	s, sk := sketchSession(t)
+	placeDistanceDim(t, s, sk, math.P2(0, 0), math.P2(3, 0))
+	if err := s.CommitPendingDimension("not a number ++"); err == nil {
+		t.Fatal("an invalid expression should error")
+	}
+	if s.PendingDimension() == nil {
+		t.Error("an invalid expression should keep the dimension pending so the box stays open")
+	}
+}
+
+func TestCancelPendingDimensionKeepsMeasuredValue(t *testing.T) {
+	s, sk := sketchSession(t)
+	placeDistanceDim(t, s, sk, math.P2(0, 0), math.P2(3, 0))
+	s.CancelPendingDimension()
+	if s.PendingDimension() != nil {
+		t.Error("cancel should dismiss the edit box")
+	}
+	if sk.DimensionConstraints().Count() != 1 {
+		t.Error("cancel should keep the placed dimension at its measured value")
+	}
+}
+
+func TestFinishSketchClearsPendingDimension(t *testing.T) {
+	s, sk := sketchSession(t)
+	placeDistanceDim(t, s, sk, math.P2(0, 0), math.P2(3, 0))
+	if err := s.FinishSketch(); err != nil {
+		t.Fatalf("FinishSketch: %v", err)
+	}
+	if s.PendingDimension() != nil {
+		t.Error("leaving the sketch should clear any pending dimension edit")
+	}
+}
+
+func TestBeginEditDimensionReopens(t *testing.T) {
+	s, sk := sketchSession(t)
+	placeDistanceDim(t, s, sk, math.P2(0, 0), math.P2(3, 0))
+	d := sk.DimensionConstraints().Item(0)
+	s.CancelPendingDimension()
+	s.BeginEditDimension(d)
+	if s.PendingDimension() != d {
+		t.Error("BeginEditDimension should re-open the given dimension for editing")
+	}
+}

--- a/app/sketch_dimension_view.go
+++ b/app/sketch_dimension_view.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/param"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// SketchDimensions turns the active sketch's dimensional constraints into render-ready
+// views — line segments and a value label, all in sketch-plane (2D) coordinates so the
+// head maps them to model space through the sketch plane and projects the label anchor
+// to the screen. Returns nil when no sketch is being edited. This keeps all dimension
+// geometry/formatting logic here (unit-testable, headless) and the head a dumb renderer.
+func (s *Session) SketchDimensions() []DimensionView {
+	if s.activeSketch == nil {
+		return nil
+	}
+	units := s.DocumentUnits()
+	var out []DimensionView
+	for _, d := range s.activeSketch.DimensionConstraints().All() {
+		if v, ok := dimensionView(d, units); ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// DimensionView is one dimension ready to draw: its lines (sketch-plane point pairs),
+// the value label and the plane-space point to anchor the label text at, plus the
+// dimension itself so the head can re-open it for editing on a double-click.
+type DimensionView struct {
+	Dim      *sketch.DimensionConstraint
+	Segments [][2]math.Point2
+	Label    string
+	LabelAt  math.Point2
+	Driven   bool
+}
+
+const (
+	// radiusPrefix/diameterPrefix tag radial dimensions in the (ASCII default font)
+	// label; the leader geometry (radial vs across-circle) also distinguishes them.
+	radiusPrefix   = "R"
+	diameterPrefix = "D"
+	// dimGapFactor offsets the dimension line off the geometry as a fraction of the
+	// measured size; dimMinGap (db units, cm) keeps tiny dimensions legible.
+	dimGapFactor = 0.15
+	dimMinGap    = 0.5
+	// angleArcSegments samples the angle dimension's arc.
+	angleArcSegments = 16
+)
+
+// dimensionView builds the view for one dimension, or false for an unhandled shape.
+func dimensionView(d *sketch.DimensionConstraint, units param.UnitsOfMeasure) (DimensionView, bool) {
+	refs := d.Refs()
+	switch d.Kind() {
+	case sketch.DistanceDim:
+		a, b := asPoint(refs, 0), asPoint(refs, 1)
+		if a == nil || b == nil {
+			return DimensionView{}, false
+		}
+		return distanceView(d, a.Position(), b.Position(), lengthExpr(units, d.Measured())), true
+	case sketch.RadiusDim:
+		return circleView(d, refs, radiusPrefix+lengthExpr(units, d.Measured()), false)
+	case sketch.DiameterDim:
+		return circleView(d, refs, diameterPrefix+lengthExpr(units, d.Measured()), true)
+	case sketch.AngleDim:
+		return angleView(d, refs, angleExpr(units, d.Measured()))
+	case sketch.ArcLengthDim:
+		return arcLengthView(d, refs, lengthExpr(units, d.Measured()))
+	}
+	return DimensionView{}, false
+}
+
+// distanceView offsets the dimension line off the measured segment by a perpendicular
+// gap, with a witness line back to each measured point, and labels it at the midpoint.
+func distanceView(d *sketch.DimensionConstraint, a, b math.Point2, label string) DimensionView {
+	dir := normalize(a.VectorTo(b))
+	off := math.V2(-dir.Y, dir.X).Scale(dimGap(a.DistanceTo(b)))
+	a2, b2 := a.TranslateBy(off), b.TranslateBy(off)
+	segs := [][2]math.Point2{{a, a2}, {b, b2}, {a2, b2}}
+	return DimensionView{Dim: d, Segments: segs, Label: label, LabelAt: a2.Midpoint(b2), Driven: d.Driven()}
+}
+
+// circleView draws a radial leader (radius) or an across-the-circle line (diameter),
+// extended past the rim by the gap, with the label at the outer end.
+func circleView(d *sketch.DimensionConstraint, refs []sketch.Entity, label string, diameter bool) (DimensionView, bool) {
+	c, ok := refs[0].(*sketch.Circle)
+	if !ok {
+		return DimensionView{}, false
+	}
+	center, r := c.Center.Position(), c.Radius
+	dir := math.V2(stdmath.Sqrt2/2, stdmath.Sqrt2/2) // 45° leader
+	out := center.TranslateBy(dir.Scale(r + dimGap(r)))
+	near := center
+	if diameter {
+		near = center.TranslateBy(dir.Scale(-r))
+	}
+	segs := [][2]math.Point2{{near, out}}
+	return DimensionView{Dim: d, Segments: segs, Label: label, LabelAt: out, Driven: d.Driven()}, true
+}
+
+// angleView draws an arc between the two lines about their intersection, labeled at the
+// arc midpoint. False when the lines are parallel (no vertex).
+func angleView(d *sketch.DimensionConstraint, refs []sketch.Entity, label string) (DimensionView, bool) {
+	l1, l2 := asLine(refs, 0), asLine(refs, 1)
+	if l1 == nil || l2 == nil {
+		return DimensionView{}, false
+	}
+	v, ok := lineIntersection(l1, l2)
+	if !ok {
+		return DimensionView{}, false
+	}
+	startA := angleAwayFrom(v, l1)
+	endA := startA + shortDelta(startA, angleAwayFrom(v, l2))
+	// Size the arc by the shorter line's far-end span (its near end may sit on the
+	// vertex, which would otherwise collapse the radius to the minimum gap).
+	r := dimGap(stdmath.Min(v.DistanceTo(farthestEnd(v, l1)), v.DistanceTo(farthestEnd(v, l2))))
+	segs := arcSegments(v, r, startA, endA)
+	labelAt := v.TranslateBy(dirVec((startA + endA) / 2).Scale(r))
+	return DimensionView{Dim: d, Segments: segs, Label: label, LabelAt: labelAt, Driven: d.Driven()}, true
+}
+
+// arcLengthView puts a short leader at the arc's midpoint, labeled with the length.
+func arcLengthView(d *sketch.DimensionConstraint, refs []sketch.Entity, label string) (DimensionView, bool) {
+	a, ok := refs[0].(*sketch.Arc)
+	if !ok {
+		return DimensionView{}, false
+	}
+	c, r := a.Center.Position(), a.Radius()
+	mid := arcMidAngle(a)
+	on := c.TranslateBy(dirVec(mid).Scale(r))
+	out := c.TranslateBy(dirVec(mid).Scale(r + dimGap(r)))
+	return DimensionView{Dim: d, Segments: [][2]math.Point2{{on, out}}, Label: label, LabelAt: out, Driven: d.Driven()}, true
+}
+
+// asPoint/asLine fetch a typed ref or nil (defensive against unexpected ref shapes).
+func asPoint(refs []sketch.Entity, i int) *sketch.Point {
+	if i >= len(refs) {
+		return nil
+	}
+	p, _ := refs[i].(*sketch.Point)
+	return p
+}
+
+func asLine(refs []sketch.Entity, i int) *sketch.Line {
+	if i >= len(refs) {
+		return nil
+	}
+	l, _ := refs[i].(*sketch.Line)
+	return l
+}
+
+// normalize returns the unit vector of v, or +X for a (near-)zero vector.
+func normalize(v math.Vector2) math.Vector2 {
+	l := v.Length()
+	if l < math.DefaultTolerance {
+		return math.V2(1, 0)
+	}
+	return v.Scale(1 / l)
+}
+
+// dimGap is the dimension-line offset for a measured size (a fraction, floored).
+func dimGap(size math.Scalar) math.Scalar {
+	if g := size * dimGapFactor; g > dimMinGap {
+		return g
+	}
+	return dimMinGap
+}
+
+// dirVec is the unit vector at angle a (radians).
+func dirVec(a float64) math.Vector2 { return math.V2(stdmath.Cos(a), stdmath.Sin(a)) }
+
+// angleAwayFrom is the angle of the direction from the vertex toward the line's far
+// endpoint — so the angle arc opens between the two lines, not away from them.
+func angleAwayFrom(vertex math.Point2, l *sketch.Line) float64 {
+	d := vertex.VectorTo(farthestEnd(vertex, l))
+	return stdmath.Atan2(d.Y, d.X)
+}
+
+// farthestEnd returns the line endpoint farther from the vertex.
+func farthestEnd(vertex math.Point2, l *sketch.Line) math.Point2 {
+	a, b := l.A.Position(), l.B.Position()
+	if vertex.DistanceTo(a) > vertex.DistanceTo(b) {
+		return a
+	}
+	return b
+}
+
+// lineIntersection returns the intersection of the two infinite lines, false if parallel.
+func lineIntersection(l1, l2 *sketch.Line) (math.Point2, bool) {
+	p, r := l1.A.Position(), l1.A.Position().VectorTo(l1.B.Position())
+	q, s := l2.A.Position(), l2.A.Position().VectorTo(l2.B.Position())
+	rxs := r.Cross(s)
+	if stdmath.Abs(rxs) < math.DefaultTolerance {
+		return math.Point2{}, false
+	}
+	t := p.VectorTo(q).Cross(s) / rxs
+	return p.TranslateBy(r.Scale(t)), true
+}
+
+// shortDelta returns the signed angle (in (-π,π]) to rotate from a1 to a2.
+func shortDelta(a1, a2 float64) float64 {
+	d := stdmath.Mod(a2-a1, 2*stdmath.Pi)
+	if d <= -stdmath.Pi {
+		d += 2 * stdmath.Pi
+	}
+	if d > stdmath.Pi {
+		d -= 2 * stdmath.Pi
+	}
+	return d
+}
+
+// arcSegments samples an arc from a0 to a1 about center at radius r into line segments.
+func arcSegments(center math.Point2, r, a0, a1 float64) [][2]math.Point2 {
+	prev := center.TranslateBy(dirVec(a0).Scale(r))
+	segs := make([][2]math.Point2, 0, angleArcSegments)
+	for i := 1; i <= angleArcSegments; i++ {
+		a := a0 + (a1-a0)*float64(i)/float64(angleArcSegments)
+		cur := center.TranslateBy(dirVec(a).Scale(r))
+		segs = append(segs, [2]math.Point2{prev, cur})
+		prev = cur
+	}
+	return segs
+}
+
+// arcMidAngle returns the angle (about the center) of the arc's midpoint, respecting
+// sweep direction.
+func arcMidAngle(a *sketch.Arc) float64 {
+	c := a.Center.Position()
+	sa := stdmath.Atan2(a.Start.Position().Y-c.Y, a.Start.Position().X-c.X)
+	ea := stdmath.Atan2(a.End.Position().Y-c.Y, a.End.Position().X-c.X)
+	if a.CounterClockwise && ea < sa {
+		ea += 2 * stdmath.Pi
+	}
+	if !a.CounterClockwise && ea > sa {
+		ea -= 2 * stdmath.Pi
+	}
+	return (sa + ea) / 2
+}

--- a/app/sketch_dimension_view_test.go
+++ b/app/sketch_dimension_view_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+func TestSketchDimensionsNilOutsideSketch(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if got := s.SketchDimensions(); got != nil {
+		t.Errorf("SketchDimensions outside a sketch = %v, want nil", got)
+	}
+}
+
+func TestDistanceDimensionView(t *testing.T) {
+	s, sk := sketchSession(t)
+	a := sk.Points().Add(math.P2(0, 0))
+	b := sk.Points().Add(math.P2(3, 0)) // 3 cm = 30 mm
+	if _, err := sk.DimensionConstraints().AddDistance(a, b, "30 mm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+	views := s.SketchDimensions()
+	if len(views) != 1 {
+		t.Fatalf("got %d dimension views, want 1", len(views))
+	}
+	v := views[0]
+	if !strings.Contains(v.Label, "30") {
+		t.Errorf("distance label = %q, want it to show 30 mm", v.Label)
+	}
+	if len(v.Segments) != 3 { // two witness lines + the dimension line
+		t.Errorf("distance dimension has %d segments, want 3", len(v.Segments))
+	}
+}
+
+func TestRadiusAndDiameterViewsDiffer(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(math.P2(0, 0), 2)
+	if _, err := sk.DimensionConstraints().AddRadius(c, "20 mm"); err != nil {
+		t.Fatalf("AddRadius: %v", err)
+	}
+	views := s.SketchDimensions()
+	if len(views) != 1 || !strings.HasPrefix(views[0].Label, radiusPrefix) {
+		t.Fatalf("radius view = %+v, want one labeled with %q", views, radiusPrefix)
+	}
+	// A radius leader is one segment; the diameter line spans the circle (still one
+	// segment) but is labeled differently — verify the prefix distinguishes them.
+	if _, err := sk.DimensionConstraints().AddDiameter(c, "40 mm"); err != nil {
+		t.Fatalf("AddDiameter: %v", err)
+	}
+	views = s.SketchDimensions()
+	var sawDiameter bool
+	for _, v := range views {
+		if strings.HasPrefix(v.Label, diameterPrefix) {
+			sawDiameter = true
+		}
+	}
+	if !sawDiameter {
+		t.Errorf("expected a diameter-prefixed (%q) label among %d views", diameterPrefix, len(views))
+	}
+}
+
+func TestAngleDimensionViewHasArc(t *testing.T) {
+	s, sk := sketchSession(t)
+	l1 := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	l2 := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 4))
+	if _, err := sk.DimensionConstraints().AddAngle(l1, l2, "90 deg"); err != nil {
+		t.Fatalf("AddAngle: %v", err)
+	}
+	views := s.SketchDimensions()
+	if len(views) != 1 {
+		t.Fatalf("got %d angle views, want 1", len(views))
+	}
+	if len(views[0].Segments) != angleArcSegments {
+		t.Errorf("angle arc has %d segments, want %d", len(views[0].Segments), angleArcSegments)
+	}
+	if !strings.Contains(views[0].Label, "deg") {
+		t.Errorf("angle label = %q, want degrees", views[0].Label)
+	}
+}
+
+func TestParallelLinesAngleViewSkipped(t *testing.T) {
+	s, sk := sketchSession(t)
+	l1 := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	l2 := sk.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(4, 1)) // parallel: no vertex
+	if _, err := sk.DimensionConstraints().AddAngle(l1, l2, "0 deg"); err != nil {
+		t.Fatalf("AddAngle: %v", err)
+	}
+	if got := s.SketchDimensions(); len(got) != 0 {
+		t.Errorf("parallel-line angle should be skipped (no vertex), got %d views", len(got))
+	}
+}

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -111,7 +111,8 @@ func seedPart(s *app.Session) {
 	// staying bound to this seeded part.
 	s.SetPicker(app.NewRayPicker(s.Camera(),
 		func() []*topo.Body { return activeBodies(s) }).
-		WithPlanes(func() []*feature.WorkPlane { return activeOriginPlanes(s) }))
+		WithPlanes(func() []*feature.WorkPlane { return activeOriginPlanes(s) }).
+		WithSketches(func() []*sketch.Sketch { return activeSketches(s) }))
 
 	// Frame the box (centered ~(2,1.5,2.5)) from a three-quarter view.
 	cam := s.Camera()
@@ -137,6 +138,22 @@ func activeOriginPlanes(s *app.Session) []*feature.WorkPlane {
 		return p.OriginPlanes()
 	}
 	return nil
+}
+
+// activeSketches returns the active part's visible sketches (nil if none), so the picker
+// can resolve a click inside a finished sketch's profile region (for extrude/revolve).
+func activeSketches(s *app.Session) []*sketch.Sketch {
+	p, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil
+	}
+	var out []*sketch.Sketch
+	for i := 0; i < p.Sketches().Count(); i++ {
+		if sk := p.Sketches().Item(i); sk.Visible() {
+			out = append(out, sk)
+		}
+	}
+	return out
 }
 
 // rectangle adds a closed w×h rectangle (one profile) at the sketch origin.

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -19,6 +19,10 @@ int  obk_ig_button(const char* label);
 void obk_ig_same_line(void);
 void obk_ig_separator(void);
 void obk_ig_separator_text(const char* s);
+void obk_ig_begin_group(void);
+void obk_ig_end_group(void);
+void obk_ig_separator_vertical(void);
+int  obk_ig_mouse_double_clicked(int button);
 int  obk_ig_begin_tab_bar(const char* id);
 int  obk_ig_begin_tab_item_ex(const char* label, int setSelected);
 int  obk_ig_selectable(const char* label, int selected);
@@ -120,6 +124,15 @@ func Button(label string) bool {
 
 func SameLine()  { C.obk_ig_same_line() }
 func Separator() { C.obk_ig_separator() }
+
+// BeginGroup / EndGroup bracket a layout group: everything between them is treated as
+// one item for SameLine, so a ribbon panel (button row + title) can sit beside the next.
+func BeginGroup() { C.obk_ig_begin_group() }
+func EndGroup()   { C.obk_ig_end_group() }
+
+// SeparatorVertical draws a vertical divider line, for separating horizontally-laid
+// ribbon panels.
+func SeparatorVertical() { C.obk_ig_separator_vertical() }
 
 // InputFloat draws a float field; returns true (and writes *v) when edited.
 func InputFloat(label string, v *float32) bool {
@@ -275,6 +288,10 @@ func MouseDown(button int) bool { return C.obk_ig_mouse_down(C.int(button)) != 0
 // IsItemClicked reports whether the last item was clicked with the given button this
 // frame (used to place sketch geometry by clicking in the viewport).
 func IsItemClicked(button int) bool { return C.obk_ig_is_item_clicked(C.int(button)) != 0 }
+
+// IsMouseDoubleClicked reports a double-click of the given button this frame (used to
+// re-open a dimension for editing).
+func IsMouseDoubleClicked(button int) bool { return C.obk_ig_mouse_double_clicked(C.int(button)) != 0 }
 
 // ItemRectMin returns the screen-space top-left of the last item (the viewport image),
 // so a mouse position can be converted to a pixel local to the viewport.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -4,6 +4,7 @@
 // Go-described tree in C++ — is what lets Go own the UI composition. Add wrappers as
 // the chrome grows; resist putting logic here.
 #include "imgui.h"
+#include "imgui_internal.h" // SeparatorEx (vertical ribbon-panel divider)
 
 extern "C" {
 
@@ -22,6 +23,15 @@ int  obk_ig_button(const char* label)        { return ImGui::Button(label) ? 1 :
 void obk_ig_same_line(void)                  { ImGui::SameLine(); }
 void obk_ig_separator(void)                  { ImGui::Separator(); }
 void obk_ig_separator_text(const char* s)    { ImGui::SeparatorText(s); }
+// begin_group/end_group bracket a layout group so a whole ribbon panel (its button
+// row + title) lays out as one item and panels can sit SameLine side-by-side.
+void obk_ig_begin_group(void)                { ImGui::BeginGroup(); }
+void obk_ig_end_group(void)                  { ImGui::EndGroup(); }
+// separator_vertical draws a vertical divider between two horizontally-laid panels.
+void obk_ig_separator_vertical(void)         { ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical); }
+// mouse_double_clicked reports a double-click of the given button this frame (used to
+// re-open a dimension for editing).
+int  obk_ig_mouse_double_clicked(int button) { return ImGui::IsMouseDoubleClicked(button) ? 1 : 0; }
 
 int  obk_ig_begin_tab_bar(const char* id)    { return ImGui::BeginTabBar(id) ? 1 : 0; }
 void obk_ig_end_tab_bar(void)                { ImGui::EndTabBar(); }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -43,6 +43,8 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	}
 	drawBrowser(s)
 	drawViewportPanel(win, s)
+	drawDimensionPopup(s)
+	drawExtrudeDialog(s)
 	drawStatusBar(s)
 	drawPreferencesWindow(s)
 	drawFileDialog(s)
@@ -165,10 +167,8 @@ func drawRibbon(s *app.Session) string {
 	if native.Begin("Ribbon") && native.BeginTabBar("##ribbon-tabs") {
 		for _, tab := range app.BuildRibbon(s).Tabs {
 			if native.BeginTabItemSelected(tab.Name, tab.Name == force) {
-				for _, panel := range tab.Panels {
-					if id := drawPanel(panel); id != "" {
-						activated = id
-					}
+				if id := drawTabPanels(tab.Panels); id != "" {
+					activated = id
 				}
 				native.EndTabItem()
 			}
@@ -176,6 +176,24 @@ func drawRibbon(s *app.Session) string {
 		native.EndTabBar()
 	}
 	native.End()
+	return activated
+}
+
+// drawTabPanels lays the tab's panels out horizontally — each panel is a layout group
+// (button row + title) and panels sit SameLine with a vertical divider between them, so
+// no panel is pushed off-screen the way a vertical stack hid the Sketch tab's Exit panel.
+func drawTabPanels(panels []app.RibbonPanel) string {
+	var activated string
+	for i, panel := range panels {
+		if i > 0 {
+			native.SameLine()
+			native.SeparatorVertical()
+			native.SameLine()
+		}
+		if id := drawPanel(panel); id != "" {
+			activated = id
+		}
+	}
 	return activated
 }
 
@@ -193,14 +211,32 @@ func contextualTab(s *app.Session) string {
 	return "3D Model"
 }
 
-// drawPanel renders one ribbon panel — a titled separator and a row of command buttons.
-// Returns the id of a clicked command, or "".
+// ribbonMaxRows caps how many button rows a panel uses (Inventor stacks small buttons a
+// few rows deep); the column count grows to fit, keeping each panel narrow so panels sit
+// side-by-side without running off the ribbon.
+const ribbonMaxRows = 3
+
+// panelCols returns how many columns to wrap a panel's n buttons into, bounded so the
+// panel is at most ribbonMaxRows tall.
+func panelCols(n int) int {
+	if n <= ribbonMaxRows {
+		return 1
+	}
+	return (n + ribbonMaxRows - 1) / ribbonMaxRows
+}
+
+// drawPanel renders one ribbon panel as a self-contained layout group: a compact grid of
+// command buttons with the panel title beneath them (Inventor's panel layout), so the
+// whole panel is one narrow, horizontally-placeable unit. The title uses plain Text (not
+// SeparatorText, which would stretch the group to the full window width and hide every
+// panel to its right). Returns the id of a clicked command, or "".
 func drawPanel(panel app.RibbonPanel) string {
 	var activated string
-	native.SeparatorText(panel.Name)
+	cols := panelCols(len(panel.Buttons))
+	native.BeginGroup()
 	for i, btn := range panel.Buttons {
-		if i > 0 {
-			native.SameLine()
+		if i > 0 && i%cols != 0 {
+			native.SameLine() // continue the current row; a new row starts at each multiple of cols
 		}
 		native.BeginDisabled(!btn.Enabled)
 		if native.Button(btn.Command.DisplayName()) {
@@ -209,6 +245,8 @@ func drawPanel(panel app.RibbonPanel) string {
 		native.EndDisabled()
 		native.SetItemTooltip(btn.Command.Tooltip())
 	}
+	native.Text(panel.Name) // panel title under its buttons
+	native.EndGroup()
 	return activated
 }
 
@@ -355,23 +393,30 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		}
 
 		list := renderer.BuildDrawList(activeBodies(s), cam, ops.DefaultQuality())
+		var dims []app.DimensionView
+		var sketchPlane sketch.Plane
 		if s.InSketch() {
-			plane := s.ActiveSketch().Plane()
+			sketchPlane = s.ActiveSketch().Plane()
 			if g := s.Grid(); g.Visible {
-				list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery), list.Items...)
+				list.Items = append(gridOverlay(sketchPlane, g.SpacingModel(), g.MajorEvery), list.Items...)
 			}
 			list.Items = append(list.Items, sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s))...)
-			if item, ok := pointsOverlay(plane, s.ActiveSketch(), pointMarkerPixels*cam.WorldPerPixel()); ok {
+			dims = s.SketchDimensions()
+			list.Items = append(list.Items, dimensionLines(sketchPlane, dims)...)
+			if item, ok := pointsOverlay(sketchPlane, s.ActiveSketch(), pointMarkerPixels*cam.WorldPerPixel()); ok {
 				list.Items = append(list.Items, item)
 			}
 			if item, ok := toolPreview(s); ok {
 				list.Items = append(list.Items, item)
 			}
-			if item, ok := snapMarker(s, plane, cam.WorldPerPixel()); ok {
+			if item, ok := snapMarker(s, sketchPlane, cam.WorldPerPixel()); ok {
 				list.Items = append(list.Items, item)
 			}
 		} else {
 			list.Items = append(list.Items, planesOverlay(activePart(s), s.SelectedWorkPlane(), hovered)...)
+			list.Items = append(list.Items, partSketchOverlays(s)...)
+			list.Items = append(list.Items, extrudeProfileHighlight(s)...)
+			list.Items = append(list.Items, activeToolPreviewItems(s)...)
 		}
 		m := viewport.Flatten(list)
 		mvp := renderer.ViewProjection(cam, viewportNear, viewportFar)
@@ -381,6 +426,11 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		if tex := win.ViewportTexture(); tex != 0 {
 			native.SetCursorPos(cx, cy) // draw the image back over the invisible button
 			native.Image(tex, float32(pw), float32(ph))
+		}
+		if s.InSketch() && len(dims) > 0 {
+			if d := drawDimensionLabels(cx, cy, cam, sketchPlane, dims); d != nil {
+				s.BeginEditDimension(d) // double-clicked a dimension's value
+			}
 		}
 	}
 	native.End()

--- a/head/ui/dimension_overlay.go
+++ b/head/ui/dimension_overlay.go
@@ -1,0 +1,145 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"bytes"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/renderer"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// Dimension display: the lines (extension/dimension/arc leaders) are 3D line items in
+// the viewport draw list — like the grid and sketch geometry — while the value text is
+// 2D, drawn over the rendered image at the label anchor's projected pixel. Double-
+// clicking a label re-opens the dimension's value editor (drawDimensionPopup). The
+// geometry + labels come pre-computed from app.Session.SketchDimensions (headless).
+
+var (
+	// dimensionColor is the green used for driving dimension lines (Inventor-like);
+	// drivenColor marks reference (driven) dimensions distinctly.
+	dimensionColor       = [4]float32{0.45, 0.85, 0.5, 1}
+	dimensionDrivenColor = [4]float32{0.55, 0.7, 0.95, 1}
+)
+
+// dimensionLines accumulates every dimension's segments (mapped plane→model through the
+// sketch plane) into colored line items, driving and driven dimensions kept apart.
+func dimensionLines(plane sketch.Plane, views []app.DimensionView) []renderer.DrawItem {
+	driving, driven := &segAccum{}, &segAccum{}
+	for _, v := range views {
+		acc := driving
+		if v.Driven {
+			acc = driven
+		}
+		for _, s := range v.Segments {
+			acc.seg(plane, s[0], s[1])
+		}
+	}
+	var items []renderer.DrawItem
+	items = appendGrid(items, driving, dimensionColor)
+	items = appendGrid(items, driven, dimensionDrivenColor)
+	return items
+}
+
+// drawDimensionLabels overlays each dimension's value text at its projected anchor (the
+// image has already been drawn at window-local cx,cy). Returns the dimension whose label
+// was double-clicked this frame, or nil — the caller re-opens it for editing.
+func drawDimensionLabels(cx, cy float32, cam scene.Camera, plane sketch.Plane, views []app.DimensionView) *sketch.DimensionConstraint {
+	mx, my := native.MousePos()
+	ox, oy := native.ItemRectMin()
+	dbl := native.IsMouseDoubleClicked(native.MouseLeft)
+	var hit *sketch.DimensionConstraint
+	for _, v := range views {
+		sx, sy, ok := renderer.Project(cam, viewportNear, viewportFar, plane.ToModel(v.LabelAt))
+		if !ok {
+			continue
+		}
+		native.SetCursorPos(cx+float32(sx), cy+float32(sy))
+		native.Text(v.Label)
+		if dbl && labelHit(mx-ox, my-oy, float32(sx), float32(sy)) {
+			hit = v.Dim
+		}
+	}
+	return hit
+}
+
+// labelHit reports whether the (viewport-local) cursor is within a label's rough text
+// box anchored at (lblX, lblY) — the double-click target for editing a dimension.
+func labelHit(curX, curY, lblX, lblY float32) bool {
+	dx, dy := curX-lblX, curY-lblY
+	return dx >= -4 && dx <= 64 && dy >= -2 && dy <= 18
+}
+
+// dimEdit holds the edit box's text buffer (owned across frames so ImGui edits it in
+// place) and the dimension it is currently seeded for (to re-seed when a new edit opens).
+var dimEdit = struct {
+	buf        []byte
+	dim        *sketch.DimensionConstraint
+	posX, posY float32 // where to place the box (the cursor when it opened)
+	place      bool    // set the position this frame (only on the opening frame)
+}{buf: make([]byte, 64)}
+
+// dimPopupCursorOffset nudges the edit box off the cursor so it does not cover the
+// dimension being placed.
+const dimPopupCursorOffset = 14
+
+// drawDimensionPopup shows the value editor while a dimension is pending. It opens at the
+// cursor (where the dimension was placed / double-clicked) and is then freely movable. OK
+// commits the typed expression (driving the geometry through the solver); an invalid
+// expression keeps the dimension pending so the box stays open. Cancel accepts the
+// measured value.
+func drawDimensionPopup(s *app.Session) {
+	d := s.PendingDimension()
+	if d == nil {
+		dimEdit.dim = nil
+		return
+	}
+	if d != dimEdit.dim { // a new edit opened — seed the buffer + remember the cursor
+		seedEditBuf(s.PendingDimensionExpression())
+		dimEdit.dim = d
+		mx, my := native.MousePos()
+		dimEdit.posX, dimEdit.posY = mx+dimPopupCursorOffset, my+dimPopupCursorOffset
+		dimEdit.place = true
+	}
+	if dimEdit.place { // position once at the cursor, then let the user drag it
+		native.SetNextWindowPos(dimEdit.posX, dimEdit.posY)
+		dimEdit.place = false
+	}
+	native.SetNextWindowSize(260, 96)
+	if native.Begin("Edit Dimension") {
+		native.Text("Value")
+		native.InputText("##dim-value", dimEdit.buf)
+		if native.Button("OK") {
+			_ = s.CommitPendingDimension(editBufText()) // keeps box open on parse error
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelPendingDimension()
+		}
+	}
+	native.End()
+}
+
+// seedEditBuf copies expr into the edit buffer, NUL-terminated and zero-padded.
+func seedEditBuf(expr string) {
+	for i := range dimEdit.buf {
+		dimEdit.buf[i] = 0
+	}
+	n := copy(dimEdit.buf, expr)
+	if n >= len(dimEdit.buf) {
+		dimEdit.buf[len(dimEdit.buf)-1] = 0
+	}
+}
+
+// editBufText returns the NUL-terminated edit-buffer contents as a Go string.
+func editBufText() string {
+	if i := bytes.IndexByte(dimEdit.buf, 0); i >= 0 {
+		return string(dimEdit.buf[:i])
+	}
+	return string(dimEdit.buf)
+}

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -1,0 +1,96 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// The Extrude flow in the head: while the Extrude tool runs, a small dialog lets the
+// user type a distance and OK/Cancel, and the picked profile is highlighted in the
+// viewport (with a live prism preview once a distance is set). Without this the tool
+// could capture a profile but never set a distance, so OK stayed disabled and extrude
+// looked broken. The distance is in the document's length unit (e.g. mm).
+
+// extrudeUI holds the dialog's distance field across frames and whether the dialog was
+// open last frame (so it seeds the field once when the tool opens).
+var extrudeUI = struct {
+	distance float32
+	open     bool
+}{distance: 10}
+
+// drawExtrudeDialog shows the distance editor while the Extrude tool is active and keeps
+// the tool's distance in sync with the field each frame; OK commits, Cancel aborts.
+func drawExtrudeDialog(s *app.Session) {
+	ext := s.ActiveExtrude()
+	if ext == nil {
+		extrudeUI.open = false
+		return
+	}
+	if !extrudeUI.open { // tool just opened — seed the field from its current distance
+		if d := s.ExtrudeDistanceDisplay(); d > 0 {
+			extrudeUI.distance = float32(d)
+		}
+		extrudeUI.open = true
+	}
+	native.SetNextWindowSize(280, 132)
+	if native.Begin("Extrude") {
+		_, picked := ext.PickedProfile()
+		if !picked {
+			native.Text("Click a sketch profile to extrude")
+		}
+		native.Text("Distance (" + s.LengthUnitName() + ")")
+		native.InputFloat("##extrude-distance", &extrudeUI.distance)
+		s.SetExtrudeDistanceDisplay(float64(extrudeUI.distance)) // keep the tool in sync
+		native.BeginDisabled(!ext.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK() // a failed commit (e.g. open profile) keeps the tool open
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}
+
+// extrudeProfileHighlight outlines the profile picked for extrude (and its holes) in the
+// selection color, so the user sees what they clicked. Returns nil when no extrude tool
+// is active or no profile is picked yet.
+func extrudeProfileHighlight(s *app.Session) []renderer.DrawItem {
+	ext := s.ActiveExtrude()
+	if ext == nil {
+		return nil
+	}
+	ph, ok := ext.PickedProfile()
+	if !ok || ph.ProfileIndex >= ph.Sketch.Profiles().Count() {
+		return nil
+	}
+	prof := ph.Sketch.Profiles().Item(ph.ProfileIndex)
+	acc := &segAccum{}
+	acc.polyline(ph.Sketch.Plane(), prof.OuterLoop().Polygon(), true)
+	for _, hole := range prof.InnerLoops() {
+		acc.polyline(ph.Sketch.Plane(), hole.Polygon(), true)
+	}
+	return appendGrid(nil, acc, sketchSelectedColor)
+}
+
+// activeToolPreviewItems returns the active tool's transient preview (the Extrude prism
+// wireframe), drawn in the 3D view outside the sketch environment. Nil when the tool has
+// no preview or nothing to show yet.
+func activeToolPreviewItems(s *app.Session) []renderer.DrawItem {
+	ti := s.ActiveTool()
+	if ti == nil {
+		return nil
+	}
+	pv, ok := ti.Tool().(app.Previewable)
+	if !ok {
+		return nil
+	}
+	return pv.Preview(s)
+}

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -7,10 +7,31 @@ package ui
 import (
 	stdmath "math"
 
+	"github.com/Oblikovati/oblikovati/app"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
+
+// partSketchOverlays renders the active part's finished, visible sketches in the 3D
+// view (the one being edited is drawn by the in-sketch overlay instead), so a sketch
+// stays visible after Finish Sketch and its profile can be clicked to extrude. Returns
+// nil when there is no active part.
+func partSketchOverlays(s *app.Session) []renderer.DrawItem {
+	part := activePart(s)
+	if part == nil {
+		return nil
+	}
+	var items []renderer.DrawItem
+	for i := 0; i < part.Sketches().Count(); i++ {
+		sk := part.Sketches().Item(i)
+		if !sk.Visible() || sk.IsEditing() {
+			continue
+		}
+		items = append(items, sketchOverlay(sk, nil, nil)...)
+	}
+	return items
+}
 
 // sketchOverlay turns the active sketch's geometry into wireframe line items drawn in
 // the viewport, so the user sees what they draw in the sketch environment. Curves are

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -188,6 +188,59 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 
 ## Session log
 
+- **2026-06-02:** **Usable Extrude in the head: distance dialog + profile-pick feedback
+  (M05 UI, user direction).** Even with finished sketches now pickable, the head had no
+  way to *complete* an extrude — picking a profile stored it on the tool with no highlight,
+  and there was no distance field, so OK stayed disabled (distance 0) and extrude looked
+  like "can't select." Added: `ExtrudeTool.PickedProfile`/`Distance` getters + Session
+  bridges (`ActiveExtrude`, `ExtrudeDistanceDisplay`/`SetExtrudeDistanceDisplay` converting
+  the document length unit ↔ database units, `LengthUnitName`); a head **Extrude dialog**
+  (distance field in doc units + OK/Cancel, syncing the tool each frame) and a viewport
+  **profile highlight** of the picked region (outer + holes) plus the live prism **preview**
+  (the tool's Previewable wireframe, now drawn outside the sketch env). Verified headlessly:
+  click a profile → set 40 mm via the dialog path → OK → a healthy solid; the mm↔cm
+  round-trip is unit-tested. Core suite + vet + fmt green; head builds, `make smoke` 5
+  frames zero validation errors, `head/ui` in-window tests pass. (Known lim: a circle drawn
+  *inside* a rectangle is one region with a hole — the inner disk isn't independently
+  selectable yet; multi-region overlapping profiles are a model-level follow-up.)
+- **2026-06-02:** **Finished sketches stay visible and are pickable for extrude (M05 UI,
+  user direction).** After Finish Sketch the sketch vanished from the 3D view and could
+  not be selected, so extrude was unreachable. Two gaps: the sketch overlay only rendered
+  *inside* the sketch editor, and `RayPicker` only hit-tested faces/work-planes (never
+  profiles — the end-to-end extrude test used a stub picker). Now (1) the head renders the
+  active part's finished, visible sketches in the 3D view (`partSketchOverlays`, skipping
+  the one being edited); (2) `RayPicker.WithSketches` lets the picker resolve a click
+  inside a sketch **profile region** to a `ProfileHandle` — it ray-casts each visible
+  sketch's plane, maps the hit to 2D, and tests the new `sketch.Profile.Contains` (inside
+  the outer loop, outside any hole); nearest-candidate selection keeps a solid in front
+  winning over the sketch on its face, and profiles are only picked when the filter admits
+  them (the Extrude tool sets `SelectProfile`). Verified end-to-end headlessly: a top-down
+  click inside a square picks its profile and extrudes to a healthy solid; clicks outside
+  miss; an open profile contains nothing. Core suite + vet + fmt green; head builds, `make
+  smoke` 5 frames zero validation errors, `head/ui` in-window tests pass.
+- **2026-06-02:** **Sketch editor: dimension constraints made real in the UI + ribbon
+  panels laid out horizontally (M05 UI, user direction).** Two gaps closed toward a
+  feature-complete sketch editor. (1) **Ribbon layout** — panels were stacking
+  *vertically*, pushing the contextual Sketch tab's "Exit" panel (Finish Sketch) off
+  screen; new `BeginGroup`/`EndGroup`/`SeparatorVertical` native bindings + a rewritten
+  `drawRibbon`/`drawPanel` now lay each panel out as a horizontal group (button row +
+  title) with vertical dividers, so every panel (incl. Exit/Finish Sketch) is visible.
+  (2) **Dimensions** — the Dimension tool placed a driving dimension at the *measured*
+  value with no way to set it and no on-screen display. Now the just-placed dimension is
+  held as the session's **pending** dimension (`Session.PendingDimension`/
+  `CommitPendingDimension`/`CancelPendingDimension`/`BeginEditDimension`); the head shows
+  an **edit popup** pre-filled with the value, and committing an expression (e.g. "50 mm",
+  "width/2") **drives the geometry** through the parameter DAG + solver. Dimensions now
+  **render in the viewport**: `Session.SketchDimensions()` emits render-ready
+  `DimensionView`s (witness/dimension lines, radial/diameter leaders, angle arcs, arc-
+  length leaders + a value label) computed headlessly in sketch-plane coords; the head
+  draws the lines as 3D line items and the value text at the label anchor projected to
+  screen via the new pure `renderer.Project`. **Double-clicking** a dimension's label
+  re-opens its editor. App-layer logic fully unit-tested (pending/commit/cancel + a view
+  per kind + parallel-line angle skip); `renderer.Project` tested (center/upper-half/
+  behind-camera). `CGO_ENABLED=0 go test ./...` + vet + race green; head builds, `make
+  smoke` renders 5 frames with zero Vulkan validation errors and `head/ui` in-window
+  tests pass.
 - **2026-06-02:** **Inventor-style origin coordinate system + work-feature persistence
   (branch `work-features`).** Modelled construction geometry like Inventor (verified
   against `Oblikovati.Contracts.CSharp`): a part owns one `feature.WorkGeometry` holding

--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -63,6 +63,21 @@ func (p *Profile) InnerLoops() []Loop {
 // IsClosed reports whether the profile encloses a region (its outer loop is closed).
 func (p *Profile) IsClosed() bool { return p.outer.closed }
 
+// Contains reports whether the sketch-plane point q lies in the profile's region: inside
+// the (closed) outer loop and outside every inner-loop hole. Used to hit-test a click on
+// a profile so it can be picked for extrude/revolve. An open profile contains nothing.
+func (p *Profile) Contains(q math.Point2) bool {
+	if !p.outer.closed || !pointInPolygon(q, p.outer.polygon) {
+		return false
+	}
+	for _, h := range p.inner {
+		if pointInPolygon(q, h.polygon) {
+			return false
+		}
+	}
+	return true
+}
+
 // Profiles is the set of profiles detected in a sketch.
 type Profiles struct {
 	items []*Profile

--- a/model/sketch/profile_test.go
+++ b/model/sketch/profile_test.go
@@ -36,6 +36,36 @@ func TestRectangleYieldsOneClosedProfile(t *testing.T) {
 	}
 }
 
+func TestProfileContainsPointInsideOutsideAndInHole(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	addRectangle(s, 0, 0, 10, 10)                   // outer
+	s.Circles().AddByCenterRadius(math.P2(5, 5), 2) // hole at the center
+	p := s.Profiles().Item(0)
+	if !p.Contains(math.P2(1, 1)) {
+		t.Error("a point inside the rectangle (clear of the hole) should be contained")
+	}
+	if p.Contains(math.P2(5, 5)) {
+		t.Error("the hole center is in an inner loop and must NOT be contained")
+	}
+	if p.Contains(math.P2(20, 20)) {
+		t.Error("a point outside the outer loop must not be contained")
+	}
+}
+
+func TestOpenProfileContainsNothing(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(4, 0))
+	c := s.Points().Add(math.P2(4, 3))
+	s.Lines().Add(a, b)
+	s.Lines().Add(b, c) // an open chain — no enclosed region
+	for i := 0; i < s.Profiles().Count(); i++ {
+		if s.Profiles().Item(i).Contains(math.P2(2, 1)) {
+			t.Error("an open profile should contain no point")
+		}
+	}
+}
+
 func TestNestedLoopsClassifyInnerAndOuter(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	addRectangle(s, 0, 0, 10, 10)                   // outer

--- a/renderer/transform.go
+++ b/renderer/transform.go
@@ -22,6 +22,25 @@ func ViewProjection(cam scene.Camera, near, far float64) [16]float32 {
 	return mul4(projection(cam, near, far), view(cam))
 }
 
+// Project maps a world point to viewport pixel coordinates (origin top-left, x right,
+// y down), using the same view·projection the viewport uploads — so an overlay drawn at
+// (x, y) sits exactly over the 3D point (e.g. a dimension's value label over its anchor).
+// ok is false when the point is at or behind the camera (clip w ≤ 0, not on screen).
+func Project(cam scene.Camera, near, far float64, p math.Point3) (x, y float64, ok bool) {
+	vp := ViewProjection(cam, near, far)
+	v := [4]float64{p.X, p.Y, p.Z, 1}
+	var clip [4]float64
+	for r := 0; r < 4; r++ {
+		clip[r] = float64(vp[0*4+r])*v[0] + float64(vp[1*4+r])*v[1] +
+			float64(vp[2*4+r])*v[2] + float64(vp[3*4+r])*v[3]
+	}
+	if clip[3] <= 0 {
+		return 0, 0, false
+	}
+	ndcX, ndcY := clip[0]/clip[3], clip[1]/clip[3] // Vulkan clip y already points down
+	return (ndcX*0.5 + 0.5) * float64(cam.Width), (ndcY*0.5 + 0.5) * float64(cam.Height), true
+}
+
 // view is the right-handed world→eye transform (camera looks down its local −Z),
 // column-major.
 func view(cam scene.Camera) [16]float32 {

--- a/renderer/transform_test.go
+++ b/renderer/transform_test.go
@@ -100,3 +100,29 @@ func TestProjectionTranslationInvariance(t *testing.T) {
 		}
 	}
 }
+
+func TestProjectTargetIsScreenCenter(t *testing.T) {
+	cam := testCamera() // 800×600, looking at the origin
+	x, y, ok := Project(cam, 0.1, 1000, math.P3(0, 0, 0))
+	if !ok {
+		t.Fatal("the target is in front of the camera, want ok")
+	}
+	if stdmath.Abs(x-400) > 1e-3 || stdmath.Abs(y-300) > 1e-3 {
+		t.Errorf("target projected to pixel (%g, %g), want screen center (400, 300)", x, y)
+	}
+}
+
+func TestProjectPlacesWorldUpInUpperHalf(t *testing.T) {
+	cam := testCamera()
+	_, y, ok := Project(cam, 0.1, 1000, math.P3(0, 1, 0)) // above the target
+	if !ok || y >= 300 {
+		t.Errorf("world +Y projected to pixel y=%g (ok=%v), want upper half (< 300)", y, ok)
+	}
+}
+
+func TestProjectBehindCameraNotOk(t *testing.T) {
+	cam := testCamera() // eye at z=10 looking toward −z
+	if _, _, ok := Project(cam, 0.1, 1000, math.P3(0, 0, 20)); ok {
+		t.Error("a point behind the camera should report ok=false")
+	}
+}


### PR DESCRIPTION
## What

Makes the sketch editor usable end to end in the head: **draw a sketch → dimension it → finish it → extrude its profile.**

### Dimensions (driving)
- Placing a dimension now opens an edit box (at the cursor) pre-filled with the measured value; committing an expression (`50 mm`, `width/2`, `45 deg`) **drives the geometry** through the parameter DAG + solver. Double-clicking a dimension re-opens it.
- Dimensions **render in the viewport** — `Session.SketchDimensions` emits render-ready views (witness/dimension lines, radial/diameter leaders, angle arcs, arc-length leaders + value label), computed headlessly; the head draws lines as 3D items and value text via the new pure `renderer.Project`.

### Finished sketches are visible & selectable
- The head renders the active part's finished, visible sketches, and `RayPicker.WithSketches` resolves a click inside a profile region to a `ProfileHandle` (new `sketch.Profile.Contains`). Nearest-candidate selection keeps a solid in front winning over the sketch on its face; profiles are picked only when the filter admits them.

### Usable Extrude in the head
- A distance dialog (document units, OK/Cancel) + a picked-profile highlight + the live prism preview, via new `ExtrudeTool` getters and `Session` bridges that convert the document length unit ↔ database units. Previously extrude could capture a profile but never set a distance, so OK stayed disabled.

### Ribbon layout
- Ribbon panels were stacking vertically (`SeparatorText` inside a group stretched it to full window width), hiding every panel after the first — including the Sketch tab's Finish/Exit panel. Panels now lay out **horizontally** as compact button grids with dividers, via new `BeginGroup`/`EndGroup`/`SeparatorVertical` native bindings.

## Why

The sketch editor had the model-level pieces (M06) but the head couldn't complete the basic workflow: no way to set a dimension value, finished sketches were invisible and unpickable, extrude had no distance input, and ribbon panels (incl. the exit button) were hidden. This closes those gaps toward a feature-complete sketch editor.

## Testing
- `CGO_ENABLED=0 go build/vet ./...` clean; core suite race-tested green (`app`, `model/sketch`, `renderer`), incl. new tests for `Profile.Contains`, profile picking, the dimension edit/view model, `renderer.Project`, and the extrude distance round-trip.
- Head builds; `make smoke` renders 5 frames with **zero Vulkan validation errors**; `head/ui` in-window tests pass.

## Known limitation
A circle drawn *inside* a rectangle is one region with a hole (the inner disk isn't independently selectable yet); multi-region overlapping profiles are a model-level follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)