### PR TITLE
Model browser: tree↔viewport selection sync, sketch auto-naming, context menus

### DIFF
--- a/app/browser.go
+++ b/app/browser.go
@@ -2,7 +2,11 @@
 
 package app
 
-import "github.com/Oblikovati/oblikovati/model/compdef"
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/model/compdef"
+)
 
 // The browser tree reflects the active document's structure — parameters, sketches,
 // and the feature history — read directly from the model each frame (no parallel
@@ -14,7 +18,7 @@ import "github.com/Oblikovati/oblikovati/model/compdef"
 // clicking "XY Plane" selects the plane to sketch on).
 type BrowserNode struct {
 	Label    string
-	Kind     string // "document" | "origin" | "workplane" | "parameters" | "parameter" | "sketches" | "sketch" | "feature"
+	Kind     string // "document" | "origin" | "workplane" | "parameters" | "parameter" | "bodies" | "body" | "sketches" | "sketch" | "feature"
 	Select   Selectable
 	Children []BrowserNode
 }
@@ -46,7 +50,9 @@ func BuildBrowser(s *Session) BrowserNode {
 	return root
 }
 
-// addPartBranches adds the origin, parameters, sketches and features of a part.
+// addPartBranches adds the origin, parameters, solid bodies, sketches and features of a
+// part. Sketch/feature/body nodes are selectable so clicking one syncs the 3D view (and
+// a viewport pick lights up the matching node).
 func addPartBranches(root *BrowserNode, part *compdef.PartComponentDefinition) {
 	origin := root.child("Origin", "origin")
 	for _, wp := range part.OriginPlanes() {
@@ -56,13 +62,29 @@ func addPartBranches(root *BrowserNode, part *compdef.PartComponentDefinition) {
 	for _, p := range part.Parameters().All() {
 		params.child(p.Name(), "parameter")
 	}
+	addBodyBranch(root, part)
 	sketches := root.child("Sketches", "sketches")
 	for i := 0; i < part.Sketches().Count(); i++ {
-		sketches.child(part.Sketches().Item(i).Name(), "sketch")
+		sk := part.Sketches().Item(i)
+		sketches.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
 	}
 	features := part.Features()
 	for i := 0; i < features.Count(); i++ {
 		f := features.Item(i)
-		root.child(f.Name(), "feature")
+		root.selectableChild(f.Name(), "feature", FeatureHandle{Feature: f})
+	}
+}
+
+// addBodyBranch adds the "Solid Bodies" folder. Bodies carry no name, so they are
+// numbered Solid1, Solid2, … in body order (Inventor's convention). The folder is
+// omitted when the part has produced no bodies yet.
+func addBodyBranch(root *BrowserNode, part *compdef.PartComponentDefinition) {
+	bodies := part.SurfaceBodies().All()
+	if len(bodies) == 0 {
+		return
+	}
+	folder := root.child("Solid Bodies", "bodies")
+	for i, b := range bodies {
+		folder.selectableChild(fmt.Sprintf("Solid%d", i+1), "body", BodyHandle{Body: b})
 	}
 }

--- a/app/browser_actions.go
+++ b/app/browser_actions.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// Session actions invoked from the model browser's right-click menu. Each mutates the
+// active part and (when the change affects geometry) recomputes it, then clears the
+// selection — the deleted/edited node no longer exists at its old identity. They are
+// the undo-friendly seam between the menu (app/browser_menu.go) and the model.
+
+// EditSketch opens an existing sketch for editing (the menu's "Edit Sketch"). It errors
+// when a sketch is already being edited, since Inventor forbids nesting sketch edits.
+func (s *Session) EditSketch(sk *sketch.Sketch) error {
+	if sk == nil {
+		return errors.New("app: EditSketch with nil sketch")
+	}
+	if s.activeSketch != nil {
+		return errors.New("app: already editing a sketch (finish it first)")
+	}
+	s.EnterSketch(sk)
+	return nil
+}
+
+// DeleteSketch removes a sketch from the active part. If it is the one being edited the
+// environment is exited first so the editor never points at a freed sketch.
+func (s *Session) DeleteSketch(sk *sketch.Sketch) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if sk == nil {
+		return errors.New("app: DeleteSketch with nil sketch")
+	}
+	if s.activeSketch == sk {
+		s.ExitSketch()
+	}
+	if !part.Sketches().Remove(sk.ID()) {
+		return errors.New("app: DeleteSketch: sketch not in active part")
+	}
+	s.selection.Clear()
+	part.Recompute()
+	return nil
+}
+
+// DeleteFeature removes a feature from the active part's history and recomputes so
+// downstream geometry reflects its absence.
+func (s *Session) DeleteFeature(f *feature.PartFeature) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if f == nil {
+		return errors.New("app: DeleteFeature with nil feature")
+	}
+	if !part.Features().Remove(f.ID()) {
+		return errors.New("app: DeleteFeature: feature not in active part")
+	}
+	s.selection.Clear()
+	part.Recompute()
+	return nil
+}
+
+// ToggleFeatureSuppressed flips a feature's explicit suppression and recomputes, so the
+// part rebuilds with or without that feature's contribution.
+func (s *Session) ToggleFeatureSuppressed(f *feature.PartFeature) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if f == nil {
+		return errors.New("app: ToggleFeatureSuppressed with nil feature")
+	}
+	f.SetSuppressed(!f.Suppressed())
+	part.Recompute()
+	return nil
+}

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// The model browser's right-click menu. Inventor shows a different set of commands per
+// node type; BrowserMenu returns that set as plain data so the head (head/ui) renders it
+// without knowing the model — each item carries the closure that performs the action.
+
+// BrowserMenuItem is one entry in a node's context menu. A disabled item is shown greyed.
+// Invoke performs the action against the session; a nil Invoke is a non-actionable label.
+type BrowserMenuItem struct {
+	Label   string
+	Enabled bool
+	Invoke  func(*Session) error
+}
+
+// BrowserMenu returns the context-menu entries for a node, keyed on its Kind. Folder and
+// other non-actionable nodes return nil (no menu). The entries close over the node's
+// concrete handle, so a wrong handle/kind pairing safely yields no menu.
+func BrowserMenu(n BrowserNode) []BrowserMenuItem {
+	switch n.Kind {
+	case "sketch":
+		return sketchMenu(n.Select)
+	case "feature":
+		return featureMenu(n.Select)
+	case "workplane":
+		return workPlaneMenu(n.Select)
+	default:
+		return nil
+	}
+}
+
+// sketchMenu offers Edit Sketch, a Visibility toggle, and Delete.
+func sketchMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(SketchHandle)
+	if !ok {
+		return nil
+	}
+	return []BrowserMenuItem{
+		{Label: "Edit Sketch", Enabled: true, Invoke: func(s *Session) error { return s.EditSketch(h.Sketch) }},
+		{Label: "Visibility", Enabled: true, Invoke: func(*Session) error {
+			h.Sketch.SetVisible(!h.Sketch.Visible())
+			return nil
+		}},
+		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteSketch(h.Sketch) }},
+	}
+}
+
+// featureMenu offers a Suppress/Unsuppress toggle (label reflects current state) and Delete.
+func featureMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(FeatureHandle)
+	if !ok {
+		return nil
+	}
+	suppressLabel := "Suppress"
+	if h.Feature.Suppressed() {
+		suppressLabel = "Unsuppress"
+	}
+	return []BrowserMenuItem{
+		{Label: suppressLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleFeatureSuppressed(h.Feature) }},
+		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteFeature(h.Feature) }},
+	}
+}
+
+// workPlaneMenu offers New Sketch on the plane (the model has no plane-visibility flag yet).
+func workPlaneMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(WorkPlaneHandle)
+	if !ok {
+		return nil
+	}
+	return []BrowserMenuItem{
+		{Label: "New Sketch", Enabled: true, Invoke: func(s *Session) error {
+			_, err := s.CreateSketch(h.Plane.Plane())
+			return err
+		}},
+	}
+}

--- a/app/browser_menu_test.go
+++ b/app/browser_menu_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// extrudedBoxPart builds a part with one sketch profile extruded into one solid, so the
+// browser has a sketch node, a feature node and a Solid Bodies folder to exercise.
+func extrudedBoxPart(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(-2, -2))
+	c1 := sk.Points().Add(math.P2(2, -2))
+	c2 := sk.Points().Add(math.P2(2, 2))
+	c3 := sk.Points().Add(math.P2(-2, 2))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+	return s, def
+}
+
+// findNode returns the first descendant (depth-first) with the given kind, or fails.
+func findNode(t *testing.T, n BrowserNode, kind string) BrowserNode {
+	t.Helper()
+	if got, ok := searchNode(n, kind); ok {
+		return got
+	}
+	t.Fatalf("no browser node of kind %q under %q", kind, n.Label)
+	return BrowserNode{}
+}
+
+func searchNode(n BrowserNode, kind string) (BrowserNode, bool) {
+	for _, c := range n.Children {
+		if c.Kind == kind {
+			return c, true
+		}
+		if got, ok := searchNode(c, kind); ok {
+			return got, true
+		}
+	}
+	return BrowserNode{}, false
+}
+
+func TestBuildBrowserMakesSketchFeatureBodySelectable(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	root := BuildBrowser(s)
+
+	if _, ok := findNode(t, root, "sketch").Select.(SketchHandle); !ok {
+		t.Error("sketch node is not selectable with a SketchHandle")
+	}
+	if _, ok := findNode(t, root, "feature").Select.(FeatureHandle); !ok {
+		t.Error("feature node is not selectable with a FeatureHandle")
+	}
+	body := findNode(t, root, "body")
+	if _, ok := body.Select.(BodyHandle); !ok {
+		t.Errorf("body node is not selectable with a BodyHandle (label %q)", body.Label)
+	}
+	if body.Label != "Solid1" {
+		t.Errorf("first body label = %q, want Solid1", body.Label)
+	}
+}
+
+func TestBrowserMenuByKind(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	root := BuildBrowser(s)
+
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "sketch"))); !equalStrings(labels, []string{"Edit Sketch", "Visibility", "Delete"}) {
+		t.Errorf("sketch menu = %v", labels)
+	}
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "feature"))); !equalStrings(labels, []string{"Suppress", "Delete"}) {
+		t.Errorf("feature menu = %v", labels)
+	}
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "workplane"))); !equalStrings(labels, []string{"New Sketch"}) {
+		t.Errorf("workplane menu = %v", labels)
+	}
+	if m := BrowserMenu(findNode(t, root, "parameters")); m != nil {
+		t.Errorf("parameters folder should have no menu, got %v", menuLabels(m))
+	}
+}
+
+func TestBrowserMenuDeleteSketchRemovesIt(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	node := findNode(t, BuildBrowser(s), "sketch")
+	del := menuItem(t, BrowserMenu(node), "Delete")
+	if err := del.Invoke(s); err != nil {
+		t.Fatalf("Delete sketch: %v", err)
+	}
+	if def.Sketches().Count() != 0 {
+		t.Errorf("sketch count after Delete = %d, want 0", def.Sketches().Count())
+	}
+}
+
+func TestBrowserMenuDeleteFeatureRemovesAndRecomputes(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	node := findNode(t, BuildBrowser(s), "feature")
+	del := menuItem(t, BrowserMenu(node), "Delete")
+	if err := del.Invoke(s); err != nil {
+		t.Fatalf("Delete feature: %v", err)
+	}
+	if def.Features().Count() != 0 {
+		t.Errorf("feature count after Delete = %d, want 0", def.Features().Count())
+	}
+	if len(def.SurfaceBodies().All()) != 0 {
+		t.Errorf("body remains after deleting its only feature: %d bodies", len(def.SurfaceBodies().All()))
+	}
+}
+
+func TestBrowserMenuSuppressTogglesLabel(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	node := findNode(t, BuildBrowser(s), "feature")
+	if err := menuItem(t, BrowserMenu(node), "Suppress").Invoke(s); err != nil {
+		t.Fatalf("Suppress: %v", err)
+	}
+	// Rebuild: the same feature node should now offer Unsuppress.
+	node = findNode(t, BuildBrowser(s), "feature")
+	if _, ok := findMenuItem(BrowserMenu(node), "Unsuppress"); !ok {
+		t.Errorf("after Suppress, menu = %v, want an Unsuppress entry", menuLabels(BrowserMenu(node)))
+	}
+}
+
+func TestBrowserMenuEditSketchEntersIt(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	node := findNode(t, BuildBrowser(s), "sketch")
+	if err := menuItem(t, BrowserMenu(node), "Edit Sketch").Invoke(s); err != nil {
+		t.Fatalf("Edit Sketch: %v", err)
+	}
+	if s.ActiveSketch() != def.Sketches().Item(0) {
+		t.Error("Edit Sketch did not enter the sketch")
+	}
+}
+
+func menuLabels(items []BrowserMenuItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.Label
+	}
+	return out
+}
+
+func findMenuItem(items []BrowserMenuItem, label string) (BrowserMenuItem, bool) {
+	for _, it := range items {
+		if it.Label == label {
+			return it, true
+		}
+	}
+	return BrowserMenuItem{}, false
+}
+
+func menuItem(t *testing.T, items []BrowserMenuItem, label string) BrowserMenuItem {
+	t.Helper()
+	if it, ok := findMenuItem(items, label); ok {
+		return it
+	}
+	t.Fatalf("menu has no %q item; labels = %v", label, menuLabels(items))
+	return BrowserMenuItem{}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -176,7 +176,7 @@ func facePick(face *topo.Face, body *topo.Body, filter *SelectionFilter) (Select
 	case face == nil:
 		return nil, false
 	case filter.Accepts(SelectFace):
-		return FaceHandle{Face: face}, true
+		return FaceHandle{Face: face, Body: body}, true
 	case filter.Accepts(SelectBody):
 		return BodyHandle{Body: body}, true
 	default:

--- a/app/selection.go
+++ b/app/selection.go
@@ -21,6 +21,7 @@ const (
 	SelectProfile
 	SelectSketchEntity
 	SelectWorkPlane
+	SelectSketch
 )
 
 // Selectable is anything the selection set can hold. Concrete handles wrap the
@@ -30,9 +31,13 @@ type Selectable interface {
 	SelectionKind() SelectionKind
 }
 
-// FaceHandle / EdgeHandle / VertexHandle / BodyHandle wrap picked topology.
+// FaceHandle / EdgeHandle / VertexHandle / BodyHandle wrap picked topology. FaceHandle
+// also carries the owning Body so a face pick can light up that body's browser node.
 type (
-	FaceHandle   struct{ Face *topo.Face }
+	FaceHandle struct {
+		Face *topo.Face
+		Body *topo.Body
+	}
 	EdgeHandle   struct{ Edge *topo.Edge }
 	VertexHandle struct{ Vertex *topo.Vertex }
 	BodyHandle   struct{ Body *topo.Body }
@@ -60,6 +65,12 @@ func (ProfileHandle) SelectionKind() SelectionKind { return SelectProfile }
 type SketchEntityHandle struct{ Entity sketch.Entity }
 
 func (SketchEntityHandle) SelectionKind() SelectionKind { return SelectSketchEntity }
+
+// SketchHandle wraps a whole sketch (selected in the browser), as opposed to one of its
+// entities — the input for Edit Sketch and for highlighting the sketch in the view.
+type SketchHandle struct{ Sketch *sketch.Sketch }
+
+func (SketchHandle) SelectionKind() SelectionKind { return SelectSketch }
 
 // WorkPlaneHandle wraps a picked origin/work plane (selected to host a new sketch).
 type WorkPlaneHandle struct{ Plane *feature.WorkPlane }

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -34,6 +34,9 @@ int  obk_ig_tree_node(const char* label);
 void obk_ig_tree_pop(void);
 void obk_ig_bullet_text(const char* s);
 void obk_ig_set_item_tooltip(const char* s);
+int  obk_ig_begin_popup_context_item(const char* id);
+void obk_ig_end_popup(void);
+void obk_ig_set_scroll_here_y(void);
 int  obk_ig_input_float(const char* label, float* v);
 int  obk_ig_input_int(const char* label, int* v);
 int  obk_ig_input_text(const char* label, char* buf, int buf_size);
@@ -246,6 +249,22 @@ func SetItemTooltip(s string) {
 	defer free()
 	C.obk_ig_set_item_tooltip(c)
 }
+
+// BeginPopupContextItem opens (on a right-click of the item just drawn) and begins a
+// context-menu popup identified by id, returning true while it is open — fill it with
+// MenuItem rows, then call EndPopup only when this returned true.
+func BeginPopupContextItem(id string) bool {
+	c, free := cstr(id)
+	defer free()
+	return C.obk_ig_begin_popup_context_item(c) != 0
+}
+
+// EndPopup closes a popup begun by BeginPopupContextItem (call only when it returned true).
+func EndPopup() { C.obk_ig_end_popup() }
+
+// SetScrollHereY scrolls the current window to center the most recently drawn item — used
+// to reveal the browser node that just synced to the active selection.
+func SetScrollHereY() { C.obk_ig_set_scroll_here_y() }
 
 // BeginDisabled / EndDisabled gray out and disable the widgets between them.
 func BeginDisabled(disabled bool) {

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -55,6 +55,14 @@ void obk_ig_tree_pop(void)                   { ImGui::TreePop(); }
 void obk_ig_bullet_text(const char* s)       { ImGui::BulletText("%s", s); }
 void obk_ig_set_item_tooltip(const char* s)  { ImGui::SetItemTooltip("%s", s); }
 
+// begin_popup_context_item opens (on right-click of the just-drawn item) and begins a
+// context-menu popup keyed by id; returns 1 while the popup is open so the caller fills
+// it with menu_items, then calls end_popup. set_scroll_here_y scrolls the current window
+// so the last item is centered — used to reveal the browser node synced to the selection.
+int  obk_ig_begin_popup_context_item(const char* id) { return ImGui::BeginPopupContextItem(id) ? 1 : 0; }
+void obk_ig_end_popup(void)                  { ImGui::EndPopup(); }
+void obk_ig_set_scroll_here_y(void)          { ImGui::SetScrollHereY(0.5f); }
+
 // Preference widgets: a float/int field and a checkbox. Each returns 1 when the value
 // changed this frame and writes the new value back through the pointer.
 int  obk_ig_input_float(const char* label, float* v) { return ImGui::InputFloat(label, v) ? 1 : 0; }

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -1,0 +1,95 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The model browser tree (Inventor's browser): each frame it reads app.BuildBrowser and
+// draws it with Dear ImGui. Selecting a node syncs the 3D view (and a viewport pick syncs
+// the tree back, since both set the same Session selection); right-clicking a node opens
+// its app.BrowserMenu; when the selection changes the matching node is scrolled into view.
+
+// browserSelectionSync remembers the selection from the previous frame so the tree scrolls
+// to the synced node only when the selection actually changed — scrolling every frame
+// would fight the user's own scrolling.
+type browserSelectionSync struct{ last app.Selectable }
+
+var browserSync browserSelectionSync
+
+// drawBrowser renders the model browser tree from the active document, then records the
+// selection so the next frame can detect a change for scroll-sync.
+func drawBrowser(s *app.Session) {
+	if native.Begin("Model") {
+		drawNode(s, app.BuildBrowser(s))
+		browserSync.last = s.Selection().First()
+	}
+	native.End()
+}
+
+// drawNode renders a browser node and its children: a selectable node as a clickable,
+// highlightable row; a branch as a collapsible tree node; a plain leaf as a bullet row.
+func drawNode(s *app.Session, n app.BrowserNode) {
+	switch {
+	case n.Select != nil:
+		drawSelectableNode(s, n)
+	case len(n.Children) == 0:
+		native.BulletText(n.Label)
+	default:
+		drawBranchNode(s, n)
+	}
+}
+
+// drawSelectableNode draws a clickable row that selects the node, offers its context menu,
+// and scrolls itself into view when it is the node the selection just changed to.
+func drawSelectableNode(s *app.Session, n app.BrowserNode) {
+	current := s.Selection().First()
+	if native.Selectable(n.Label, current == n.Select) {
+		s.SelectBrowserNode(n)
+	}
+	drawNodeMenu(s, n)
+	if current != nil && n.Select == current && current != browserSync.last {
+		native.SetScrollHereY()
+	}
+}
+
+// drawBranchNode draws a collapsible folder and recurses into its children when open. A
+// branch may still carry a context menu (e.g. a work-plane row that owns children later).
+func drawBranchNode(s *app.Session, n app.BrowserNode) {
+	open := native.TreeNode(n.Label)
+	drawNodeMenu(s, n)
+	if !open {
+		return
+	}
+	for _, child := range n.Children {
+		drawNode(s, child)
+	}
+	native.TreePop()
+}
+
+// drawNodeMenu opens the node's right-click context menu (if it has any entries) and runs
+// the action behind a clicked item. Nodes whose kind has no menu draw nothing.
+func drawNodeMenu(s *app.Session, n app.BrowserNode) {
+	items := app.BrowserMenu(n)
+	if len(items) == 0 {
+		return
+	}
+	if !native.BeginPopupContextItem("##menu-" + n.Kind + "/" + n.Label) {
+		return
+	}
+	for _, it := range items {
+		if native.MenuItem(it.Label) && it.Invoke != nil {
+			if err := it.Invoke(s); err != nil {
+				fmt.Fprintf(os.Stderr, "browser %q: %v\n", it.Label, err)
+			}
+		}
+	}
+	native.EndPopup()
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -328,36 +328,6 @@ func drawDocumentTabs(s *app.Session) {
 	}
 }
 
-// drawBrowser renders the model browser tree from the active document.
-func drawBrowser(s *app.Session) {
-	if native.Begin("Model") {
-		drawNode(s, app.BuildBrowser(s))
-	}
-	native.End()
-}
-
-// drawNode renders a browser node and its children: a selectable node (e.g. a work
-// plane) as a clickable, highlightable row that selects it; a branch as a tree node;
-// a plain leaf as a bullet row.
-func drawNode(s *app.Session, n app.BrowserNode) {
-	if n.Select != nil {
-		if native.Selectable(n.Label, s.Selection().First() == n.Select) {
-			s.SelectBrowserNode(n)
-		}
-		return
-	}
-	if len(n.Children) == 0 {
-		native.BulletText(n.Label)
-		return
-	}
-	if native.TreeNode(n.Label) {
-		for _, child := range n.Children {
-			drawNode(s, child)
-		}
-		native.TreePop()
-	}
-}
-
 // drawViewportPanel renders the active part's geometry through the Vulkan viewport and
 // shows the result as an image filling the panel. An invisible drag button under the
 // image captures mouse navigation (orbit/pan/zoom) and updates the session camera, so
@@ -392,7 +362,11 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 			hovered = hoveredPlane(s)
 		}
 
-		list := renderer.BuildDrawList(activeBodies(s), cam, ops.DefaultQuality())
+		bodies := activeBodies(s)
+		list := renderer.BuildDrawList(bodies, cam, ops.DefaultQuality())
+		// Paint the selected body cyan so a browser/viewport pick reads in the 3D view
+		// (a no-op in sketch mode, where the selection is sketch entities, not bodies).
+		list = highlightSelection(list, s.Selection().First(), bodies)
 		var dims []app.DimensionView
 		var sketchPlane sketch.Plane
 		if s.InSketch() {

--- a/head/ui/highlight.go
+++ b/head/ui/highlight.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// Viewport highlight of the active selection. A draw item is tagged with its body's
+// ObjectID (renderer.BuildDrawList); recoloring the items whose id belongs to the
+// selection paints the selected body cyan, so a browser pick lights up the 3D view (and
+// a viewport pick, which sets the same selection, lights up the same body). Work-plane
+// and sketch highlight are handled by their own overlays (planesOverlay / sketchOverlay).
+
+// selectionHighlight is the cyan used for a selected body, matching the selected-plane
+// color so selection reads consistently across the view.
+var selectionHighlight = [4]float32{0.3, 0.85, 1, 1}
+
+// highlightSelection recolors the draw items belonging to the selected body/bodies. It
+// returns the (in-place mutated) list for call-site convenience; the list is rebuilt
+// each frame so the mutation is not observable across frames.
+func highlightSelection(list renderer.DrawList, sel app.Selectable, partBodies []*topo.Body) renderer.DrawList {
+	ids := bodyHighlightIDs(sel, partBodies)
+	if len(ids) == 0 {
+		return list
+	}
+	return recolorByObjectID(list, ids, selectionHighlight)
+}
+
+// bodyHighlightIDs returns the set of body ObjectIDs to highlight for a selection: the
+// picked body itself, the body owning a picked face, or — since features do not yet map
+// to the faces they created — every body of the part when a feature is selected.
+func bodyHighlightIDs(sel app.Selectable, partBodies []*topo.Body) map[uint64]bool {
+	switch h := sel.(type) {
+	case app.BodyHandle:
+		return singleID(h.Body)
+	case app.FaceHandle:
+		return singleID(h.Body)
+	case app.FeatureHandle:
+		ids := make(map[uint64]bool, len(partBodies))
+		for _, b := range partBodies {
+			ids[b.ID()] = true
+		}
+		return ids
+	default:
+		return nil
+	}
+}
+
+// singleID is the one-element id set for a body, or empty when the body is nil.
+func singleID(b *topo.Body) map[uint64]bool {
+	if b == nil {
+		return nil
+	}
+	return map[uint64]bool{b.ID(): true}
+}
+
+// recolorByObjectID paints every draw item whose ObjectID is in ids the given color.
+func recolorByObjectID(list renderer.DrawList, ids map[uint64]bool, color [4]float32) renderer.DrawList {
+	for i := range list.Items {
+		if ids[list.Items[i].ObjectID] {
+			list.Items[i].Color = color
+		}
+	}
+	return list
+}

--- a/head/ui/highlight_test.go
+++ b/head/ui/highlight_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// tinyBody builds the smallest valid body so its ObjectID can be matched in a draw list.
+func tinyBody() *topo.Body {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("t", "body", 0)))
+	v := bld.AddVertex(math.P3(0, 0, 0), topo.NewLineage(topo.Tok("t", "vertex", 0)))
+	e := bld.AddEdge(geom.NewLineSegment(math.P3(0, 0, 0), math.P3(1, 0, 0)), v, v, topo.NewLineage(topo.Tok("t", "edge", 0)))
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, topo.NewLineage(topo.Tok("t", "face", 0)), topo.OuterLoop(topo.Fwd(e)))
+	return bld.Build()
+}
+
+func TestHighlightSelectionRecolorsOnlyTheSelectedBody(t *testing.T) {
+	b := tinyBody()
+	other := uint64(b.ID() + 1)
+	base := [4]float32{0.5, 0.5, 0.5, 1}
+	list := renderer.DrawList{Items: []renderer.DrawItem{
+		{ObjectID: b.ID(), Color: base},
+		{ObjectID: other, Color: base},
+	}}
+
+	got := highlightSelection(list, app.BodyHandle{Body: b}, nil)
+
+	if got.Items[0].Color != selectionHighlight {
+		t.Errorf("selected body item not highlighted: %v", got.Items[0].Color)
+	}
+	if got.Items[1].Color != base {
+		t.Errorf("unselected body item was recolored: %v", got.Items[1].Color)
+	}
+}
+
+func TestHighlightSelectionNoSelectionLeavesColors(t *testing.T) {
+	base := [4]float32{0.5, 0.5, 0.5, 1}
+	list := renderer.DrawList{Items: []renderer.DrawItem{{ObjectID: 7, Color: base}}}
+	if got := highlightSelection(list, nil, nil); got.Items[0].Color != base {
+		t.Errorf("nil selection recolored an item: %v", got.Items[0].Color)
+	}
+}
+
+func TestBodyHighlightIDsForFeatureCoversWholePart(t *testing.T) {
+	b := tinyBody()
+	f := app.FeatureHandle{} // a feature selection highlights every part body
+	ids := bodyHighlightIDs(f, []*topo.Body{b})
+	if !ids[b.ID()] || len(ids) != 1 {
+		t.Errorf("feature selection should highlight all part bodies, got %v", ids)
+	}
+}

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -22,15 +22,34 @@ func partSketchOverlays(s *app.Session) []renderer.DrawItem {
 	if part == nil {
 		return nil
 	}
+	selected := selectedSketch(s)
 	var items []renderer.DrawItem
 	for i := 0; i < part.Sketches().Count(); i++ {
 		sk := part.Sketches().Item(i)
 		if !sk.Visible() || sk.IsEditing() {
 			continue
 		}
-		items = append(items, sketchOverlay(sk, nil, nil)...)
+		items = append(items, sketchOverlay(sk, allEntitiesWhenSelected(sk, selected), nil)...)
 	}
 	return items
+}
+
+// selectedSketch returns the whole sketch selected in the browser, or nil — the input for
+// highlighting a finished sketch in the 3D view.
+func selectedSketch(s *app.Session) *sketch.Sketch {
+	if h, ok := s.Selection().First().(app.SketchHandle); ok {
+		return h.Sketch
+	}
+	return nil
+}
+
+// allEntitiesWhenSelected returns a predicate that marks every entity of sk as selected
+// when sk is the chosen sketch (so its curves draw cyan), or nil to draw it amber.
+func allEntitiesWhenSelected(sk, selected *sketch.Sketch) func(sketch.Entity) bool {
+	if sk != selected {
+		return nil
+	}
+	return func(sketch.Entity) bool { return true }
 }
 
 // sketchOverlay turns the active sketch's geometry into wireframe line items drawn in

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -43,6 +43,27 @@ func (fs *PartFeatures) Add(f Feature, deps ...ID) *PartFeature {
 	return pf
 }
 
+// Remove deletes the feature with the given id from the program, reporting whether it
+// was found. The tail from the removed position is marked dirty so the next Recompute
+// rebuilds the body state without it (the clean prefix before it is still reused).
+func (fs *PartFeatures) Remove(id ID) bool {
+	if _, ok := fs.byID[id]; !ok {
+		return false
+	}
+	delete(fs.byID, id)
+	for i, pf := range fs.items {
+		if pf.id != id {
+			continue
+		}
+		fs.items = append(fs.items[:i], fs.items[i+1:]...)
+		for _, tail := range fs.items[i:] {
+			tail.dirty = true
+		}
+		break
+	}
+	return true
+}
+
 // Count returns the number of features; Item returns the i-th in history order.
 func (fs *PartFeatures) Count() int              { return len(fs.items) }
 func (fs *PartFeatures) Item(i int) *PartFeature { return fs.items[i] }
@@ -74,7 +95,11 @@ func (fs *PartFeatures) Recompute() {
 	end := fs.effectiveEnd()
 	start := fs.earliestDirty(end)
 	if start < 0 {
-		return // nothing dirty within the evaluated range
+		// Nothing dirty: the result is the cached body state at the cutoff. Re-deriving
+		// it (rather than leaving fs.result untouched) keeps the result correct after a
+		// Remove that shortened the program — the deleted tail no longer contributes.
+		fs.result = fs.prefixBodies(end)
+		return
 	}
 	bodies := fs.prefixBodies(start)
 	sick := fs.sickBefore(start)

--- a/model/feature/engine_test.go
+++ b/model/feature/engine_test.go
@@ -124,3 +124,37 @@ func TestLookupAndRename(t *testing.T) {
 		t.Error("ByID failed after rename")
 	}
 }
+
+func TestRemoveFeatureDropsItAndRebuilds(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	a := fs.Add(body())
+	b := fs.Add(body())
+	fs.Recompute()
+	if len(fs.Result()) != 2 {
+		t.Fatalf("precondition: result has %d bodies, want 2", len(fs.Result()))
+	}
+	if !fs.Remove(a.ID()) {
+		t.Fatal("Remove reported the feature missing")
+	}
+	if fs.Count() != 1 || fs.Item(0) != b {
+		t.Errorf("after Remove: count=%d, item0==b: %v", fs.Count(), fs.Item(0) == b)
+	}
+	if _, ok := fs.ByID(a.ID()); ok {
+		t.Error("ByID still finds the removed feature")
+	}
+	fs.Recompute()
+	if len(fs.Result()) != 1 {
+		t.Errorf("after Remove+Recompute: result has %d bodies, want 1", len(fs.Result()))
+	}
+}
+
+func TestRemoveFeatureMissingIsNoop(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	fs.Add(body())
+	if fs.Remove(99999) {
+		t.Error("Remove of an absent id reported success")
+	}
+	if fs.Count() != 1 {
+		t.Errorf("Remove of an absent id changed the count to %d", fs.Count())
+	}
+}

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -3,6 +3,7 @@
 package sketch
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/Oblikovati/oblikovati/math"
@@ -180,6 +181,7 @@ func (s *Sketch) ToSketch(p math.Point3) math.Point2 { return s.plane.ToSketch(p
 type Sketches struct {
 	items []*Sketch
 	byID  map[ID]*Sketch
+	seq   int // running counter behind the Sketch1, Sketch2, … auto-names
 }
 
 // NewSketches returns an empty collection.
@@ -187,9 +189,32 @@ func NewSketches() *Sketches {
 	return &Sketches{byID: map[ID]*Sketch{}}
 }
 
-// Add creates a planar sketch on plane and adds it to the collection.
+// Add creates a planar sketch on plane and adds it to the collection, giving it the
+// next free auto-name (Sketch1, Sketch2, …) like Inventor.
 func (c *Sketches) Add(plane Plane) *Sketch {
-	return c.AddNamed("", plane)
+	return c.AddNamed(c.nextSketchName(), plane)
+}
+
+// nextSketchName mints the first unused Sketch{N} name, advancing the counter past
+// names already taken (so a restored "Sketch3" doesn't collide with a later Add).
+func (c *Sketches) nextSketchName() string {
+	for {
+		c.seq++
+		name := fmt.Sprintf("Sketch%d", c.seq)
+		if !c.nameTaken(name) {
+			return name
+		}
+	}
+}
+
+// nameTaken reports whether a sketch in the collection already uses name.
+func (c *Sketches) nameTaken(name string) bool {
+	for _, s := range c.items {
+		if s.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // AddNamed creates a named planar sketch on plane.
@@ -211,4 +236,20 @@ func (c *Sketches) Item(i int) *Sketch { return c.items[i] }
 func (c *Sketches) ByID(id ID) (*Sketch, bool) {
 	s, ok := c.byID[id]
 	return s, ok
+}
+
+// Remove deletes the sketch with the given id, reporting whether it was found. The
+// auto-name counter is not rewound — Inventor does not reuse a deleted sketch's number.
+func (c *Sketches) Remove(id ID) bool {
+	if _, ok := c.byID[id]; !ok {
+		return false
+	}
+	delete(c.byID, id)
+	for i, s := range c.items {
+		if s.id == id {
+			c.items = append(c.items[:i], c.items[i+1:]...)
+			break
+		}
+	}
+	return true
 }

--- a/model/sketch/sketch_test.go
+++ b/model/sketch/sketch_test.go
@@ -110,3 +110,39 @@ func TestSketchIDsAreUnique(t *testing.T) {
 		t.Error("sketches share an id")
 	}
 }
+
+func TestAddAutoNamesSequentially(t *testing.T) {
+	c := NewSketches()
+	if got := c.Add(XYPlane()).Name(); got != "Sketch1" {
+		t.Errorf("first Add name = %q, want Sketch1", got)
+	}
+	if got := c.Add(XYPlane()).Name(); got != "Sketch2" {
+		t.Errorf("second Add name = %q, want Sketch2", got)
+	}
+}
+
+func TestAddSkipsNameTakenByAddNamed(t *testing.T) {
+	c := NewSketches()
+	c.AddNamed("Sketch1", XYPlane()) // a restored sketch already holds Sketch1
+	if got := c.Add(XYPlane()).Name(); got != "Sketch2" {
+		t.Errorf("Add after explicit Sketch1 = %q, want Sketch2 (no collision)", got)
+	}
+}
+
+func TestRemoveSketch(t *testing.T) {
+	c := NewSketches()
+	a := c.Add(XYPlane())
+	b := c.Add(XZPlane())
+	if !c.Remove(a.ID()) {
+		t.Fatal("Remove reported the sketch missing")
+	}
+	if c.Count() != 1 || c.Item(0) != b {
+		t.Errorf("after Remove: count=%d, item0==b: %v", c.Count(), c.Item(0) == b)
+	}
+	if _, ok := c.ByID(a.ID()); ok {
+		t.Error("ByID still finds the removed sketch")
+	}
+	if c.Remove(a.ID()) {
+		t.Error("second Remove of the same id reported success")
+	}
+}


### PR DESCRIPTION
## What & why

The model browser felt disconnected from the 3D view. This brings three Inventor-standard behaviors:

### 1. Tree ↔ viewport selection sync
- Sketch and feature nodes are now selectable, plus a new **Solid Bodies** folder (`Solid1`, `Solid2`, …).
- Selecting a node highlights its geometry in the viewport (bodies repaint cyan; work planes / sketch curves via the existing overlays).
- A viewport pick sets the same `Session` selection, so the matching node highlights and **scrolls into view**. A picked face carries its owning body so it maps back to that body's node.

### 2. Sketch auto-naming
New sketches are named `Sketch1`, `Sketch2`, … (next free name, skipping taken ones) instead of an unnamed bullet.

### 3. Right-click context menus (per node type)
- sketch → **Edit Sketch / Visibility / Delete**
- feature → **Suppress|Unsuppress / Delete**
- work plane → **New Sketch**

Delete/Suppress recompute the part. Adds `Remove` to the `Sketches` and `PartFeatures` collections and fixes `Recompute` to keep the result correct after the program shortens. New ImGui popup/scroll bindings in `head/internal/native`. **No public `/api` surface** — internal app/model/head only.

## Tests
- `go test ./...` (root) and head `./ui/...` + `./internal/native/...` green.
- New coverage: auto-naming, removal+recompute, selectable tree, menu-per-kind + delete/suppress/edit effects, highlight recolor.
- `gofmt`/`go vet` clean; SPDX headers present.

## Scope / follow-ups
- Origin **axes/points** aren't drawn in the viewport yet — nothing to highlight; deferred.
- Per-feature *face* highlighting needs feature→face topological mapping (doesn't exist); a feature selection highlights the whole part body as an approximation.
- Sketch display names are **not persisted** (`SketchData` has no `Name`) — a rename is lost on reload; flagged for the persistence roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)