### PR TITLE
feat(ribbon): SVG icon buttons and add-in-contributed commands

### DIFF
--- a/addin/router/commands.go
+++ b/addin/router/commands.go
@@ -5,6 +5,7 @@ package router
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/Oblikovati/api/wire"
 
@@ -19,10 +20,32 @@ func listCommands(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 		out[i] = wire.CommandInfo{
 			ID: c.ID(), DisplayName: c.DisplayName(), Tab: c.Tab(),
 			Category: c.Category(), Alias: c.Alias(), Tooltip: c.Tooltip(),
+			Icon: c.Icon(), ButtonStyle: c.ButtonStyle(),
 			Enabled: c.IsEnabled(s),
 		}
 	}
 	return json.Marshal(wire.ListCommandsResult{Commands: out})
+}
+
+// createCommand registers a ribbon button on behalf of an add-in (wire commands.create
+// / Inventor's ButtonDefinition). The command runs no host logic — clicking it fires a
+// command.ended event the add-in handles in its Notify entry point — so the host stays
+// agnostic to the add-in's action. It errors on a missing id/displayName or a duplicate id.
+func createCommand(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.CreateCommandArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if in.ID == "" || in.DisplayName == "" {
+		return nil, fmt.Errorf("commands.create: id and displayName are required, got id=%q displayName=%q", in.ID, in.DisplayName)
+	}
+	cmd := app.NewCommand(in.ID, in.DisplayName, in.Category, func(*app.Session) error { return nil }).
+		WithTab(in.Tab).WithAlias(in.Alias).WithTooltip(in.Tooltip).
+		WithIcon(in.Icon).WithButtonStyle(in.ButtonStyle)
+	if err := s.Commands().Add(cmd); err != nil {
+		return nil, err
+	}
+	return ok()
 }
 
 // executeCommand runs the command with the given id (the same path a ribbon click

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -35,6 +35,7 @@ func New(ops *opregistry.Registry) *Router {
 	r := &Router{ops: ops, handlers: map[string]handlerFunc{}}
 	r.handlers[wire.MethodCommandsList] = listCommands
 	r.handlers[wire.MethodCommandsExecute] = executeCommand
+	r.handlers[wire.MethodCommandsCreate] = createCommand
 	r.handlers[wire.MethodDocumentsList] = listDocuments
 	r.handlers[wire.MethodDocumentsCreate] = createDocument
 	r.handlers[wire.MethodDocumentsActivate] = activateDocument

--- a/addin/router/router_test.go
+++ b/addin/router/router_test.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Oblikovati/api/types"
 	"github.com/Oblikovati/api/wire"
 
 	"github.com/Oblikovati/oblikovati/addin/opregistry"
 	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/event"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/doc"
@@ -85,9 +87,62 @@ func TestCommandsListAndExecute(t *testing.T) {
 	if len(res.Commands) == 0 {
 		t.Fatal("commands.list returned none")
 	}
+	// The icon + button-style metadata must survive the wire round-trip so add-ins
+	// can render the host's ribbon styling.
+	var extrude *wire.CommandInfo
+	for i := range res.Commands {
+		if res.Commands[i].ID == "Create.Extrude" {
+			extrude = &res.Commands[i]
+		}
+	}
+	if extrude == nil {
+		t.Fatal("commands.list omitted Create.Extrude")
+	}
+	if extrude.Icon != "extrude" || extrude.ButtonStyle != types.LargeIconButton {
+		t.Errorf("Extrude wire info = (%q, %s), want (\"extrude\", %s)",
+			extrude.Icon, extrude.ButtonStyle, types.LargeIconButton)
+	}
 	call(t, r, s, "commands.execute", `{"id":"test.noop"}`, nil)
 	if _, err := r.Handle(s, "commands.execute", []byte(`{"id":"does.not.exist"}`)); err == nil {
 		t.Fatal("expected error executing unknown command")
+	}
+}
+
+// TestCommandsCreateAddsRibbonButtonAndNotifiesOnExecute proves the add-in UI
+// extension contract: commands.create registers a button that appears in the ribbon,
+// and executing it (a click) fires a command.ended event — the signal forwarded to an
+// add-in so it can run the button's action. A duplicate id is rejected.
+func TestCommandsCreateAddsRibbonButtonAndNotifiesOnExecute(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "commands.create",
+		`{"id":"AddIn.Ping","displayName":"Ping","tab":"AddInTab","category":"Demo","icon":"extrude","buttonStyle":2}`, nil)
+
+	// The add-in's button is now on the ribbon, styled as requested.
+	panel, ok := app.BuildRibbon(s).Panel("Demo")
+	if !ok || len(panel.Buttons) != 1 {
+		t.Fatalf("Demo panel = %+v ok=%v, want one add-in button", panel, ok)
+	}
+	if b := panel.Buttons[0].Command; b.DisplayName() != "Ping" || b.Icon() != "extrude" || b.ButtonStyle() != app.LargeIconButton {
+		t.Errorf("button = (%q,%q,%s), want (Ping,extrude,large-icon)", b.DisplayName(), b.Icon(), b.ButtonStyle())
+	}
+
+	// Clicking it fires command.ended so a listening add-in can react.
+	var ended string
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.CommandEnded) event.Outcome {
+		ended = e.ID
+		return event.Continue()
+	})
+	call(t, r, s, "commands.execute", `{"id":"AddIn.Ping"}`, nil)
+	if ended != "AddIn.Ping" {
+		t.Errorf("command.ended id = %q, want AddIn.Ping", ended)
+	}
+
+	// A duplicate id and a missing displayName are both rejected.
+	if _, err := r.Handle(s, "commands.create", []byte(`{"id":"AddIn.Ping","displayName":"Dup"}`)); err == nil {
+		t.Error("duplicate commands.create accepted")
+	}
+	if _, err := r.Handle(s, "commands.create", []byte(`{"id":"AddIn.NoName"}`)); err == nil {
+		t.Error("commands.create without displayName accepted")
 	}
 }
 

--- a/app/command.go
+++ b/app/command.go
@@ -2,7 +2,23 @@
 
 package app
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Oblikovati/api/types"
+)
+
+// ButtonStyle is how a command renders in the ribbon (text, small icon, large icon).
+// The type and its values are defined once in the Apache-2.0 contract
+// ([types.ButtonStyle]); this alias keeps the app.ButtonStyle / app.LargeIconButton
+// spelling local to the implementation (ADR-0018).
+type ButtonStyle = types.ButtonStyle
+
+const (
+	TextOnlyButton  = types.TextOnlyButton
+	SmallIconButton = types.SmallIconButton
+	LargeIconButton = types.LargeIconButton
+)
 
 // ControlKind is the UI control a command presents as — Inventor's ControlDefinition
 // kinds. The ribbon (ImGui) renders the right widget per kind; the logic is identical.
@@ -30,6 +46,8 @@ type CommandDefinition struct {
 	kind        ControlKind
 	alias       string // typed command alias (e.g. "E" → Extrude), Inventor-style
 	tooltip     string
+	iconKey     string      // icon asset key (e.g. "extrude"); empty ⇒ no icon
+	buttonStyle ButtonStyle // ribbon render style; zero value ⇒ text-only
 	enabled     func(*Session) bool
 	run         func(*Session) error
 }
@@ -54,6 +72,18 @@ func (c *CommandDefinition) WithKind(k ControlKind) *CommandDefinition { c.kind 
 // WithTooltip sets the hover tooltip.
 func (c *CommandDefinition) WithTooltip(t string) *CommandDefinition { c.tooltip = t; return c }
 
+// WithIcon sets the command's icon asset key (resolved by the head to an SVG glyph).
+// Pair it with WithButtonStyle to make the ribbon show the icon; a key with the
+// text-only style is ignored by the renderer.
+func (c *CommandDefinition) WithIcon(key string) *CommandDefinition { c.iconKey = key; return c }
+
+// WithButtonStyle sets how the command renders in the ribbon (text/small-icon/
+// large-icon). Inventor's large buttons head a panel; small ones fill dense grids.
+func (c *CommandDefinition) WithButtonStyle(s ButtonStyle) *CommandDefinition {
+	c.buttonStyle = s
+	return c
+}
+
 // WithEnable sets the enable predicate (nil ⇒ always enabled).
 func (c *CommandDefinition) WithEnable(p func(*Session) bool) *CommandDefinition {
 	c.enabled = p
@@ -61,13 +91,15 @@ func (c *CommandDefinition) WithEnable(p func(*Session) bool) *CommandDefinition
 }
 
 // ID/DisplayName/Tab/Category/Kind/Alias/Tooltip are the command's metadata.
-func (c *CommandDefinition) ID() string          { return c.id }
-func (c *CommandDefinition) DisplayName() string { return c.displayName }
-func (c *CommandDefinition) Tab() string         { return c.tab }
-func (c *CommandDefinition) Category() string    { return c.category }
-func (c *CommandDefinition) Kind() ControlKind   { return c.kind }
-func (c *CommandDefinition) Alias() string       { return c.alias }
-func (c *CommandDefinition) Tooltip() string     { return c.tooltip }
+func (c *CommandDefinition) ID() string               { return c.id }
+func (c *CommandDefinition) DisplayName() string      { return c.displayName }
+func (c *CommandDefinition) Tab() string              { return c.tab }
+func (c *CommandDefinition) Category() string         { return c.category }
+func (c *CommandDefinition) Kind() ControlKind        { return c.kind }
+func (c *CommandDefinition) Alias() string            { return c.alias }
+func (c *CommandDefinition) Tooltip() string          { return c.tooltip }
+func (c *CommandDefinition) Icon() string             { return c.iconKey }
+func (c *CommandDefinition) ButtonStyle() ButtonStyle { return c.buttonStyle }
 
 // IsEnabled reports whether the command may run in the given session (predicate true
 // or absent).

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -2,6 +2,8 @@
 
 package app
 
+import "strings"
+
 // RegisterStandardCommands wires Inventor's standard ribbon for a session: the 3D Model
 // tab (Create 2D Sketch, Extrude), the contextual Sketch tab (the full geometry-tool
 // Create panel + Finish Sketch), and the View tab (Zoom All, Home). Sketch geometry
@@ -39,11 +41,13 @@ func modelTabCommands() []*CommandDefinition {
 			s.StartTool(NewCreateSketchTool())
 			return nil
 		}).WithTab("3D Model").WithAlias("S").WithEnable(canCreateSketch).
+			WithIcon("create-sketch").WithButtonStyle(LargeIconButton).
 			WithTooltip("Create 2D Sketch — pick a work plane or planar face to sketch on."),
 		NewCommand("Create.Extrude", "Extrude", "Create", func(s *Session) error {
 			s.StartTool(NewExtrudeTool())
 			return nil
 		}).WithTab("3D Model").WithAlias("E").WithEnable(notInSketch).
+			WithIcon("extrude").WithButtonStyle(LargeIconButton).
 			WithTooltip("Extrude — add depth to a sketch profile to create or modify a solid."),
 	}
 }
@@ -57,10 +61,12 @@ func sketchTabCommands() []*CommandDefinition {
 		s.StartTool(newDimensionTool())
 		return nil
 	}).WithTab("Sketch").WithAlias("D").WithEnable(inSketch).
+		WithIcon("dimension").WithButtonStyle(SmallIconButton).
 		WithTooltip("Dimension — then pick points/a line/a circle/two lines to dimension."))
 	return append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
 		return s.FinishSketch()
 	}).WithTab("Sketch").WithEnable(inSketch).
+		WithIcon("finish-sketch").WithButtonStyle(LargeIconButton).
 		WithTooltip("Finish Sketch — leave the sketch environment and update the part."))
 }
 
@@ -85,7 +91,8 @@ func createCommands() []*CommandDefinition {
 		cmds[i] = NewCommand(c.id, c.name, "Create", func(s *Session) error {
 			s.StartTool(start())
 			return nil
-		}).WithTab("Sketch").WithAlias(c.alias).WithEnable(inSketch).WithTooltip(c.tip)
+		}).WithTab("Sketch").WithAlias(c.alias).WithEnable(inSketch).WithTooltip(c.tip).
+			WithIcon(strings.ToLower(c.name)).WithButtonStyle(SmallIconButton)
 	}
 	return cmds
 }
@@ -99,7 +106,8 @@ func constrainCommands() []*CommandDefinition {
 		cmds[i] = NewCommand(d.id, d.name, "Constrain", func(s *Session) error {
 			s.StartTool(newTool())
 			return nil
-		}).WithTab("Sketch").WithEnable(inSketch).WithTooltip(d.tooltip)
+		}).WithTab("Sketch").WithEnable(inSketch).WithTooltip(d.tooltip).
+			WithIcon(strings.ToLower(d.name)).WithButtonStyle(SmallIconButton)
 	}
 	return cmds
 }
@@ -110,11 +118,13 @@ func viewTabCommands() []*CommandDefinition {
 		NewCommand("View.ZoomAll", "Zoom All", "Navigate", func(s *Session) error {
 			s.FitView()
 			return nil
-		}).WithTab("View").WithTooltip("Zoom All — fit the entire model in the viewport."),
+		}).WithTab("View").WithIcon("zoom-all").WithButtonStyle(LargeIconButton).
+			WithTooltip("Zoom All — fit the entire model in the viewport."),
 		NewCommand("View.Home", "Home", "Navigate", func(s *Session) error {
 			s.HomeView()
 			return nil
-		}).WithTab("View").WithTooltip("Home View — the default isometric view, framed to fit."),
+		}).WithTab("View").WithIcon("home").WithButtonStyle(LargeIconButton).
+			WithTooltip("Home View — the default isometric view, framed to fit."),
 	}
 }
 

--- a/app/commands_standard_test.go
+++ b/app/commands_standard_test.go
@@ -31,6 +31,36 @@ func TestStandardRibbonHasSketchCreatePanel(t *testing.T) {
 	}
 }
 
+// TestIconCommandsCarryIconAndStyle guards that every command rendered with an icon
+// style also names an icon asset (so the ribbon never asks the head for an empty key)
+// and that a known large/small command keeps its expected style.
+func TestIconCommandsCarryIconAndStyle(t *testing.T) {
+	s := registeredSession(t)
+	for _, c := range s.Commands().All() {
+		if c.ButtonStyle().ShowsIcon() && c.Icon() == "" {
+			t.Errorf("command %q has icon style %s but no icon key", c.ID(), c.ButtonStyle())
+		}
+	}
+	want := map[string]struct {
+		icon  string
+		style ButtonStyle
+	}{
+		"Create.Extrude": {"extrude", LargeIconButton},
+		"Sketch.Line":    {"line", SmallIconButton},
+		"Sketch.Finish":  {"finish-sketch", LargeIconButton},
+	}
+	for id, w := range want {
+		c, ok := s.Commands().ByID(id)
+		if !ok {
+			t.Fatalf("command %q not registered", id)
+		}
+		if c.Icon() != w.icon || c.ButtonStyle() != w.style {
+			t.Errorf("command %q = (%q, %s), want (%q, %s)",
+				id, c.Icon(), c.ButtonStyle(), w.icon, w.style)
+		}
+	}
+}
+
 func TestModelTabHasCreate2DSketch(t *testing.T) {
 	s := registeredSession(t)
 	r := BuildRibbon(s)

--- a/head/go.mod
+++ b/head/go.mod
@@ -7,9 +7,19 @@ module github.com/Oblikovati/oblikovati/head
 
 go 1.22
 
-require github.com/Oblikovati/oblikovati v0.0.0
+require (
+	github.com/Oblikovati/oblikovati v0.0.0
+	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
+	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
+)
 
-require github.com/Oblikovati/api v0.0.0 // indirect
+require (
+	github.com/Oblikovati/api v0.0.0 // indirect
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
+	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 // The core stays a relative replace: head is a submodule of this same repo, so
 // `../` is the repo root regardless of where the repo is checked out. The

--- a/head/go.sum
+++ b/head/go.sum
@@ -1,0 +1,15 @@
+github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c h1:km8GpoQut05eY3GiYWEedbTT0qnSxrCjsVbb7yKY1KE=
+github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c/go.mod h1:cNQ3dwVJtS5Hmnjxy6AgTPd0Inb3pW05ftPSX7NZO7Q=
+github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef h1:Ch6Q+AZUxDBCVqdkI8FSpFyZDtCVBc2VmejdNrm5rRQ=
+github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef/go.mod h1:nXTWP6+gD5+LUJ8krVhhoeHjvHTutPxMYl5SvkcnJNE=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
+golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/head/icon/assets/arc.svg
+++ b/head/icon/assets/arc.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 18 A 10 10 0 0 1 20 18"/><circle cx="4" cy="18" r="1.6" fill="#000" stroke="none"/><circle cx="20" cy="18" r="1.6" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/circle.svg
+++ b/head/icon/assets/circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/></svg>

--- a/head/icon/assets/coincident.svg
+++ b/head/icon/assets/coincident.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="12" r="5"/><circle cx="14" cy="12" r="2.6" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/collinear.svg
+++ b/head/icon/assets/collinear.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="10" y2="12"/><line x1="14" y1="12" x2="21" y2="12"/><circle cx="12" cy="12" r="1.2" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/concentric.svg
+++ b/head/icon/assets/concentric.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3.5"/></svg>

--- a/head/icon/assets/create-sketch.svg
+++ b/head/icon/assets/create-sketch.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="1"/><path d="M8 16 L14 10 L16 12 L10 18 Z" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/dimension.svg
+++ b/head/icon/assets/dimension.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 8 V18 M19 8 V18"/><path d="M5 13 H19"/><path d="M7 11 L5 13 L7 15 M17 11 L19 13 L17 15"/></svg>

--- a/head/icon/assets/ellipse.svg
+++ b/head/icon/assets/ellipse.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="12" rx="9" ry="6"/></svg>

--- a/head/icon/assets/equal.svg
+++ b/head/icon/assets/equal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="9" x2="19" y2="9"/><line x1="5" y1="15" x2="19" y2="15"/></svg>

--- a/head/icon/assets/extrude.svg
+++ b/head/icon/assets/extrude.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="13" width="11" height="7"/><path d="M12 10 L12 3 M9 6 L12 3 L15 6"/></svg>

--- a/head/icon/assets/finish-sketch.svg
+++ b/head/icon/assets/finish-sketch.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13 L9 18 L20 6"/></svg>

--- a/head/icon/assets/fix.svg
+++ b/head/icon/assets/fix.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="11" width="12" height="9" rx="1"/><path d="M9 11 V8 A3 3 0 0 1 15 8 V11"/></svg>

--- a/head/icon/assets/home.svg
+++ b/head/icon/assets/home.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11 L12 3 L21 11"/><path d="M5 10 V20 H19 V10"/><rect x="10" y="14" width="4" height="6" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/horizontal.svg
+++ b/head/icon/assets/horizontal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="12" x2="20" y2="12"/><circle cx="4" cy="12" r="1.6" fill="#000" stroke="none"/><circle cx="20" cy="12" r="1.6" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/line.svg
+++ b/head/icon/assets/line.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="19" x2="19" y2="5"/><circle cx="5" cy="19" r="1.6" fill="#000" stroke="none"/><circle cx="19" cy="5" r="1.6" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/parallel.svg
+++ b/head/icon/assets/parallel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="20" x2="14" y2="4"/><line x1="12" y1="20" x2="20" y2="4"/></svg>

--- a/head/icon/assets/perpendicular.svg
+++ b/head/icon/assets/perpendicular.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 4 V19 H20"/><path d="M5 14 H10 V19"/></svg>

--- a/head/icon/assets/point.svg
+++ b/head/icon/assets/point.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="2.5" fill="#000" stroke="none"/><path d="M12 4 V8 M12 16 V20 M4 12 H8 M16 12 H20"/></svg>

--- a/head/icon/assets/polygon.svg
+++ b/head/icon/assets/polygon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12,3 20,7.5 20,16.5 12,21 4,16.5 4,7.5"/></svg>

--- a/head/icon/assets/rectangle.svg
+++ b/head/icon/assets/rectangle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="6" width="16" height="12"/></svg>

--- a/head/icon/assets/spline.svg
+++ b/head/icon/assets/spline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16 C 7 6, 11 6, 14 12 S 20 18, 21 8"/></svg>

--- a/head/icon/assets/symmetric.svg
+++ b/head/icon/assets/symmetric.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="3" x2="12" y2="21"/><path d="M8 8 L4 12 L8 16"/><path d="M16 8 L20 12 L16 16"/></svg>

--- a/head/icon/assets/tangent.svg
+++ b/head/icon/assets/tangent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="15" r="6"/><line x1="3" y1="9" x2="21" y2="9"/></svg>

--- a/head/icon/assets/vertical.svg
+++ b/head/icon/assets/vertical.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="4" x2="12" y2="20"/><circle cx="12" cy="4" r="1.6" fill="#000" stroke="none"/><circle cx="12" cy="20" r="1.6" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/zoom-all.svg
+++ b/head/icon/assets/zoom-all.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8 V4 H8 M16 4 H20 V8 M20 16 V20 H16 M8 20 H4 V16"/></svg>

--- a/head/icon/raster.go
+++ b/head/icon/raster.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package icon turns the embedded ribbon SVG glyphs into tintable RGBA bitmaps the
+// head can upload as ImGui textures. It is the ONLY importer of the third-party SVG
+// rasterizer (oksvg/rasterx), so the rest of the head depends on this thin seam
+// rather than the library (CLAUDE.md: wrap third-party libs behind our own interface).
+//
+// Glyphs are rasterized as a MONOCHROME alpha mask: the coverage the SVG produces
+// becomes the alpha channel and RGB is forced to white, so a theme can tint the icon
+// at draw time (ImGui's ImageButton tint color) without re-rasterizing it.
+package icon
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+
+	"github.com/srwiley/oksvg"
+	"github.com/srwiley/rasterx"
+)
+
+// Rasterize renders svg into a px×px tintable RGBA glyph (RGB=white, A=coverage).
+//
+//	img, err := icon.Rasterize(svgBytes, 32) // 32px large-button glyph
+func Rasterize(svg []byte, px int) (*image.RGBA, error) {
+	if px <= 0 {
+		return nil, fmt.Errorf("icon: rasterize px must be > 0, got %d", px)
+	}
+	parsed, err := oksvg.ReadIconStream(bytes.NewReader(svg))
+	if err != nil {
+		return nil, fmt.Errorf("icon: parse SVG (%d bytes): %w", len(svg), err)
+	}
+	parsed.SetTarget(0, 0, float64(px), float64(px))
+	img := image.NewRGBA(image.Rect(0, 0, px, px))
+	scanner := rasterx.NewScannerGV(px, px, img, img.Bounds())
+	parsed.Draw(rasterx.NewDasher(px, px, scanner), 1.0)
+	return whiteWithCoverageAlpha(img), nil
+}
+
+// whiteWithCoverageAlpha rewrites every pixel to straight-alpha white (RGB=255),
+// keeping the coverage the rasterizer wrote into the alpha channel. ImGui blends with
+// straight (non-premultiplied) src-alpha and multiplies by the per-vertex tint, so a
+// white mask tints cleanly to any theme color: result = tint × (white, coverage).
+// Go's image.RGBA is alpha-premultiplied, but for an opaque fill the alpha already
+// equals coverage regardless of the SVG's fill color, so only RGB needs forcing.
+func whiteWithCoverageAlpha(img *image.RGBA) *image.RGBA {
+	for i := 0; i < len(img.Pix); i += 4 {
+		img.Pix[i] = 255
+		img.Pix[i+1] = 255
+		img.Pix[i+2] = 255
+	}
+	return img
+}

--- a/head/icon/raster_test.go
+++ b/head/icon/raster_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package icon
+
+import "testing"
+
+// tinySVG is a filled square covering the whole viewBox, so a correct rasterization
+// leaves every pixel fully covered.
+const tinySVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect x="0" y="0" width="10" height="10" fill="#000"/></svg>`
+
+func TestRasterizeProducesTintableMask(t *testing.T) {
+	img, err := Rasterize([]byte(tinySVG), 16)
+	if err != nil {
+		t.Fatalf("Rasterize: %v", err)
+	}
+	if b := img.Bounds(); b.Dx() != 16 || b.Dy() != 16 {
+		t.Fatalf("size = %dx%d, want 16x16", b.Dx(), b.Dy())
+	}
+	// A fully covered pixel must be opaque white (RGB forced to 255, alpha = coverage).
+	off := img.PixOffset(8, 8)
+	px := img.Pix[off : off+4]
+	if px[0] != 255 || px[1] != 255 || px[2] != 255 {
+		t.Errorf("center RGB = %v, want forced white [255 255 255]", px[:3])
+	}
+	if px[3] == 0 {
+		t.Error("center alpha = 0, want coverage > 0")
+	}
+}
+
+func TestRasterizeRejectsNonPositivePx(t *testing.T) {
+	if _, err := Rasterize([]byte(tinySVG), 0); err == nil {
+		t.Error("Rasterize(px=0) returned nil error, want failure")
+	}
+}
+
+func TestRasterizeRejectsBadSVG(t *testing.T) {
+	// Malformed XML (unbalanced angle brackets) must fail the tokenizer; oksvg
+	// tolerates non-SVG plain text, so a stricter input is needed to prove errors
+	// propagate.
+	if _, err := Rasterize([]byte("<svg><<<"), 16); err == nil {
+		t.Error("Rasterize(malformed XML) returned nil error, want parse failure")
+	}
+}
+
+func TestSVGLookup(t *testing.T) {
+	if _, ok := SVG("extrude"); !ok {
+		t.Error(`SVG("extrude") not found, want bundled`)
+	}
+	if _, ok := SVG("does-not-exist"); ok {
+		t.Error(`SVG("does-not-exist") found, want false`)
+	}
+}
+
+// TestEveryBundledIconRasterizes guards that all shipped glyphs are valid SVG the
+// rasterizer accepts (a malformed asset would otherwise only surface at runtime as a
+// silently-missing icon).
+func TestEveryBundledIconRasterizes(t *testing.T) {
+	keys := Keys()
+	if len(keys) == 0 {
+		t.Fatal("no icons bundled")
+	}
+	for _, key := range keys {
+		svg, ok := SVG(key)
+		if !ok {
+			t.Errorf("Keys() listed %q but SVG() did not find it", key)
+			continue
+		}
+		if _, err := Rasterize(svg, 32); err != nil {
+			t.Errorf("Rasterize(%q): %v", key, err)
+		}
+	}
+}

--- a/head/icon/registry.go
+++ b/head/icon/registry.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package icon
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// assetsFS embeds the ribbon glyph set. Each file is "<key>.svg"; the key is what a
+// command's WithIcon names (e.g. "extrude" → assets/extrude.svg).
+//
+//go:embed assets/*.svg
+var assetsFS embed.FS
+
+// SVG returns the embedded SVG bytes for an icon key, or false if no such asset is
+// bundled (the caller then falls back to a text button, never a blank icon).
+func SVG(key string) ([]byte, bool) {
+	b, err := assetsFS.ReadFile("assets/" + key + ".svg")
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}
+
+// Keys returns every bundled icon key (filename without the .svg extension), so a test
+// can rasterize the whole set and a tool can list what is available.
+func Keys() []string {
+	entries, err := fs.ReadDir(assetsFS, "assets")
+	if err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		keys = append(keys, name[:len(name)-len(".svg")])
+	}
+	return keys
+}

--- a/head/internal/addinhost/loader_test.go
+++ b/head/internal/addinhost/loader_test.go
@@ -21,21 +21,21 @@ import (
 // build never reaches the network, and GOWORK=off so the fixture builds against its
 // own go.mod — it is a separate module standing in for an external add-in, and the
 // repo's go.work workspace (which does not `use` it) must not capture it.
-func buildFixture(t *testing.T) string {
+func buildFixture(t *testing.T, dirName string) string {
 	t.Helper()
 	ext := ".so"
 	if runtime.GOOS == "darwin" {
 		ext = ".dylib"
 	}
-	out := filepath.Join(t.TempDir(), "echofixture"+ext)
+	out := filepath.Join(t.TempDir(), dirName+ext)
 	_, thisFile, _, _ := runtime.Caller(0)
-	src := filepath.Join(filepath.Dir(thisFile), "testdata", "echoaddin")
+	src := filepath.Join(filepath.Dir(thisFile), "testdata", dirName)
 
 	cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, ".")
 	cmd.Dir = src
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=1", "GOTOOLCHAIN=local", "GOWORK=off")
 	if combined, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build fixture add-in: %v\n%s", err, combined)
+		t.Fatalf("build fixture add-in %q: %v\n%s", dirName, err, combined)
 	}
 	return out
 }
@@ -44,7 +44,7 @@ func buildFixture(t *testing.T) string {
 // activate it, and confirm its add-in->host->add-in echo round-trips through the
 // Dispatcher. Activate blocks on the host-call, so we drain concurrently.
 func TestLoadDirRoundTripsHostCall(t *testing.T) {
-	so := buildFixture(t)
+	so := buildFixture(t, "echoaddin")
 	dir := filepath.Dir(so)
 
 	d := dispatch.New(8)

--- a/head/internal/addinhost/testdata/uiaddin/go.mod
+++ b/head/internal/addinhost/testdata/uiaddin/go.mod
@@ -1,0 +1,7 @@
+// Isolated module for the UI-extension test fixture: a c-shared add-in built by the
+// addinhost integration test. It stands in for an external add-in that adds a ribbon
+// button over the host API and acts when the button is clicked. Under testdata/ so
+// normal `go build ./...` ignores it; its own go.mod keeps the build self-contained.
+module uifixture
+
+go 1.22

--- a/head/internal/addinhost/testdata/uiaddin/main.go
+++ b/head/internal/addinhost/testdata/uiaddin/main.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// uifixture is a c-shared add-in for the addinhost UI-extension test. It demonstrates
+// the Inventor-style flow end to end over the C ABI: on Activate it registers a ribbon
+// BUTTON through the host API (commands.create); when the user clicks that button the
+// host fires a command.ended event, delivered to ObkAddInNotify, where the add-in runs
+// its action — here, creating a document through the host API (documents.create).
+//
+// The action runs on its OWN goroutine: ObkAddInNotify is invoked on the host's
+// session goroutine, and a host call made synchronously from there would block on the
+// dispatcher that very goroutine drives (a deadlock). Real add-ins relay events
+// asynchronously for the same reason.
+package main
+
+/*
+#include <stdlib.h>
+#include <stdint.h>
+
+#define OBK_OK 0
+#define OBK_ERR 1
+
+typedef int  (*HostCall)(const char* method, const uint8_t* req, int reqLen, uint8_t** resp, int* respLen);
+typedef void (*HostFree)(uint8_t* p);
+
+static int  call_host(HostCall c, const char* m, const uint8_t* req, int n, uint8_t** resp, int* rl) { return c(m, req, n, resp, rl); }
+static void call_free(HostFree f, uint8_t* p) { f(p); }
+*/
+import "C"
+
+import (
+	"encoding/json"
+	"sync"
+	"unsafe"
+)
+
+// buttonID is the command this add-in registers and listens for.
+const buttonID = "AddIn.Ping"
+
+var (
+	idStr  = C.CString("com.oblikovati.ui-fixture")
+	manStr = C.CString(`{"id":"com.oblikovati.ui-fixture","displayName":"UI Fixture","version":"0.0.0","capabilities":["ui"]}`)
+
+	mu       sync.Mutex
+	hostCall C.HostCall
+	hostFree C.HostFree
+)
+
+//export ObkAddInId
+func ObkAddInId() *C.char { return idStr }
+
+//export ObkAddInManifest
+func ObkAddInManifest() *C.char { return manStr }
+
+//export ObkAddInActivate
+func ObkAddInActivate(call C.HostCall, free C.HostFree) C.int {
+	mu.Lock()
+	hostCall, hostFree = call, free
+	mu.Unlock()
+	// Extend the UI: register a large-icon ribbon button (Inventor's ButtonDefinition).
+	req, _ := json.Marshal(map[string]any{
+		"id":          buttonID,
+		"displayName": "Ping",
+		"tab":         "AddInTab",
+		"category":    "Demo",
+		"icon":        "extrude",
+		"buttonStyle": 2, // LargeIconButton
+	})
+	if _, ok := callHost("commands.create", req); !ok {
+		return C.OBK_ERR
+	}
+	return C.OBK_OK
+}
+
+//export ObkAddInDeactivate
+func ObkAddInDeactivate() C.int { return C.OBK_OK }
+
+// hostEvent is the subset of the host's serialized event this add-in reacts to.
+type hostEvent struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+//export ObkAddInNotify
+func ObkAddInNotify(ev *C.uint8_t, n C.int) C.int {
+	var e hostEvent
+	if err := json.Unmarshal(C.GoBytes(unsafe.Pointer(ev), n), &e); err != nil {
+		return C.OBK_OK // ignore events we cannot parse
+	}
+	if e.Type == "command.ended" && e.Command == buttonID {
+		go runButtonAction() // off the session goroutine — see the package comment
+	}
+	return C.OBK_OK
+}
+
+// runButtonAction is the button's behavior: create a part document through the host
+// API, proving an add-in can drive the model in response to its own button click.
+func runButtonAction() {
+	req, _ := json.Marshal(map[string]any{"type": "part", "name": "FromAddIn"})
+	callHost("documents.create", req)
+}
+
+// callHost invokes a host method with a JSON request, returning the JSON reply and
+// whether the call succeeded; it releases the host-owned reply buffer.
+func callHost(method string, req []byte) ([]byte, bool) {
+	mu.Lock()
+	call, free := hostCall, hostFree
+	mu.Unlock()
+	if call == nil {
+		return nil, false
+	}
+	cMethod := C.CString(method)
+	defer C.free(unsafe.Pointer(cMethod))
+
+	var reqPtr *C.uint8_t
+	if len(req) > 0 {
+		reqPtr = (*C.uint8_t)(unsafe.Pointer(&req[0]))
+	}
+	var resp *C.uint8_t
+	var respLen C.int
+	rc := C.call_host(call, cMethod, reqPtr, C.int(len(req)), &resp, &respLen)
+	if resp == nil {
+		return nil, rc == C.OBK_OK
+	}
+	out := C.GoBytes(unsafe.Pointer(resp), respLen)
+	C.call_free(free, resp)
+	return out, rc == C.OBK_OK
+}
+
+//export ObkFree
+func ObkFree(p *C.uint8_t) { C.free(unsafe.Pointer(p)) }
+
+func main() {}

--- a/head/internal/addinhost/uiaddin_test.go
+++ b/head/internal/addinhost/uiaddin_test.go
@@ -1,0 +1,112 @@
+//go:build linux || darwin
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addinhost
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Oblikovati/oblikovati/addin/dispatch"
+	"github.com/Oblikovati/oblikovati/addin/events"
+	"github.com/Oblikovati/oblikovati/addin/opregistry"
+	"github.com/Oblikovati/oblikovati/addin/router"
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// TestAddInExtendsRibbonAndActsOnClick is the end-to-end proof of add-in UI
+// extension over the API. A real c-shared add-in (testdata/uiaddin), wired through the
+// exact production glue (SetHost→router, events.Subscribe→Notify, a drained
+// Dispatcher), (1) registers a ribbon button on Activate via commands.create, then
+// (2) when that button is "clicked" (session.Execute), reacts to the forwarded
+// command.ended event by creating a document through the host API — Inventor's
+// ButtonDefinition + OnExecute, across the two-Go-runtime boundary.
+func TestAddInExtendsRibbonAndActsOnClick(t *testing.T) {
+	so := buildFixture(t, "uiaddin")
+
+	s := app.NewSession()
+	d := dispatch.New(8)
+	defer d.Close()
+	rtr := router.New(opregistry.Default())
+	SetHost(d, func(method string, req []byte) ([]byte, error) {
+		return rtr.Handle(s, method, req)
+	}, 2*time.Second)
+
+	libs, err := LoadDir(filepath.Dir(so))
+	if err != nil || len(libs) != 1 {
+		t.Fatalf("LoadDir: libs=%d err=%v", len(libs), err)
+	}
+	addin := libs[0]
+	defer addin.Close()
+
+	// Forward session events to the add-in over the C ABI (the production wiring).
+	subs := events.Subscribe(s, func(ev []byte) { _ = addin.Notify(ev) })
+	defer func() {
+		for _, sub := range subs {
+			sub.Cancel()
+		}
+	}()
+
+	// Activate blocks on the add-in's commands.create host call, so drain concurrently.
+	activated := make(chan error, 1)
+	go func() { activated <- addin.Activate(s) }()
+	if err := drainUntil(t, d, activated); err != nil {
+		t.Fatalf("Activate (the add-in's commands.create host call): %v", err)
+	}
+
+	// (1) The UI is extended: the add-in's button is on the ribbon, styled as asked.
+	panel, ok := app.BuildRibbon(s).Panel("Demo")
+	if !ok || len(panel.Buttons) != 1 || panel.Buttons[0].Command.ID() != "AddIn.Ping" {
+		t.Fatalf("add-in did not add its ribbon button: panel=%+v ok=%v", panel, ok)
+	}
+
+	// (2) "Click" the button. Execute fires command.ended → the add-in's Notify → it
+	// queues a documents.create host call we drain until the new document appears.
+	if err := s.Execute("AddIn.Ping"); err != nil {
+		t.Fatalf("execute add-in command: %v", err)
+	}
+	if !drainUntilDocument(t, d, s, "FromAddIn") {
+		t.Fatal("add-in did not create its document in response to the button click")
+	}
+}
+
+// drainUntil drains d on this goroutine until done yields (returning its value) or a
+// deadline passes. Draining here keeps all model access on one goroutine.
+func drainUntil(t *testing.T, d *dispatch.Dispatcher, done <-chan error) error {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		d.Drain(0)
+		select {
+		case err := <-done:
+			return err
+		case <-deadline:
+			t.Fatal("timed out draining the dispatcher")
+			return nil
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+// drainUntilDocument drains d until a document named name is open, or a deadline passes.
+func drainUntilDocument(t *testing.T, d *dispatch.Dispatcher, s *app.Session, name string) bool {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		d.Drain(0)
+		for _, doc := range s.Workspace().Documents() {
+			if doc.DisplayName() == name {
+				return true
+			}
+		}
+		select {
+		case <-deadline:
+			return false
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -112,11 +112,14 @@ bool create_device(HeadContext* c) {
 }
 
 bool create_descriptor_pool(HeadContext* c) {
-    VkDescriptorPoolSize sizes[] = {{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 64}};
+    // Combined-image-sampler sets are shared by the font atlas, the offscreen viewport
+    // image, and one per cached ribbon icon (texture.cpp). The icon set alone is ~25
+    // and grows with the command set, so size generously to avoid AddTexture failing.
+    VkDescriptorPoolSize sizes[] = {{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 256}};
     VkDescriptorPoolCreateInfo ci{};
     ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
     ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-    ci.maxSets = 64;
+    ci.maxSets = 256;
     ci.poolSizeCount = 1;
     ci.pPoolSizes = sizes;
     return ok(vkCreateDescriptorPool(c->device, &ci, c->allocator, &c->descriptorPool));
@@ -354,6 +357,7 @@ void obk_head_destroy(void* h) {
     if (!c) return;
     vkDeviceWaitIdle(c->device);
     obk_viewport_destroy(c);
+    obk_icons_destroy(c); // frees icon textures before the Vulkan backend shuts down
     ImGui_ImplVulkan_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();

--- a/head/internal/native/head.h
+++ b/head/internal/native/head.h
@@ -8,7 +8,8 @@
 #include <GLFW/glfw3.h>
 #include <vulkan/vulkan.h>
 
-struct Viewport; // defined in viewport.cpp
+struct Viewport;     // defined in viewport.cpp
+struct IconTextures; // ribbon-icon texture cache, defined in texture.cpp
 
 struct HeadContext {
     GLFWwindow*              window = nullptr;
@@ -23,6 +24,7 @@ struct HeadContext {
     uint32_t                 minImageCount = 2;
     bool                     swapChainRebuild = false;
     Viewport*                viewport = nullptr; // 3D scene render target (lazy)
+    IconTextures*            icons = nullptr;    // ribbon-icon texture cache (lazy)
 };
 
 // Pick a memory type index satisfying type_bits and props, or UINT32_MAX. Shared by
@@ -33,3 +35,7 @@ uint32_t obk_find_memory_type(VkPhysicalDevice phys, uint32_t type_bits,
 // obk_viewport_destroy frees the viewport target/pipelines; defined in viewport.cpp
 // (C linkage) and called from app.cpp on teardown.
 extern "C" void obk_viewport_destroy(HeadContext* c);
+
+// obk_icons_destroy frees the ribbon-icon texture cache (images + sampler); defined in
+// texture.cpp (C linkage) and called from app.cpp on teardown.
+extern "C" void obk_icons_destroy(HeadContext* c);

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -129,6 +129,15 @@ void obk_ig_set_cursor_pos(float x, float y)  { ImGui::SetCursorPos(ImVec2(x, y)
 void obk_ig_image(unsigned long long tex, float w, float h) {
     ImGui::Image((ImTextureID)tex, ImVec2(w, h));
 }
+// image_button draws a clickable icon (a ribbon button) tinted by (r,g,b,a) so a theme
+// recolors the monochrome glyph without re-rasterizing it; the str_id keeps each
+// button's ImGui id distinct. Returns 1 if clicked this frame.
+int obk_ig_image_button(const char* id, unsigned long long tex, float w, float h,
+                        float r, float g, float b, float a) {
+    return ImGui::ImageButton(id, (ImTextureID)tex, ImVec2(w, h),
+                              ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                              ImVec4(r, g, b, a)) ? 1 : 0;
+}
 void obk_ig_content_region_avail(float* w, float* h) {
     ImVec2 a = ImGui::GetContentRegionAvail();
     *w = a.x;

--- a/head/internal/native/texture.cpp
+++ b/head/internal/native/texture.cpp
@@ -1,0 +1,252 @@
+// Ribbon-icon textures: upload a CPU-side RGBA bitmap (rasterized from an SVG glyph by
+// the pure-Go head/icon package) into a device-local Vulkan image and hand it to Dear
+// ImGui as a sampled texture, the same way viewport.cpp exposes the 3D color image.
+// Unlike the viewport (a render target), these are static uploads, so the path is a
+// staging-buffer copy with layout transitions rather than a render pass.
+//
+// Textures are cached by the Go side (head/ui) and created once per (icon, size), so
+// this code optimizes for clarity over batching. Each created texture's image/memory/
+// view is tracked so it can be freed on teardown via the returned descriptor set.
+#include "head.h"
+#include <cstring>
+#include <unordered_map>
+
+namespace {
+
+struct IconTexture {
+    VkImage         image = VK_NULL_HANDLE;
+    VkDeviceMemory  memory = VK_NULL_HANDLE;
+    VkImageView     view = VK_NULL_HANDLE;
+};
+
+constexpr VkFormat kIconFormat = VK_FORMAT_R8G8B8A8_UNORM;
+
+// transition records an image layout barrier covering the whole color image — enough
+// for the two transitions a static upload needs (UNDEFINED→TRANSFER_DST→SHADER_READ).
+void transition(VkCommandBuffer cmd, VkImage image, VkImageLayout from, VkImageLayout to,
+                VkAccessFlags srcAccess, VkAccessFlags dstAccess,
+                VkPipelineStageFlags srcStage, VkPipelineStageFlags dstStage) {
+    VkImageMemoryBarrier b{};
+    b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    b.oldLayout = from;
+    b.newLayout = to;
+    b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    b.image = image;
+    b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    b.srcAccessMask = srcAccess;
+    b.dstAccessMask = dstAccess;
+    vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &b);
+}
+
+} // namespace
+
+// IconTextures owns the resources shared by every icon texture (a sampler plus a
+// transient command pool/fence for the upload submits) and the per-texture registry
+// keyed by the ImGui descriptor set that identifies the texture to Go.
+struct IconTextures {
+    VkSampler       sampler = VK_NULL_HANDLE;
+    VkCommandPool   cmdPool = VK_NULL_HANDLE;
+    VkFence         fence = VK_NULL_HANDLE;
+    std::unordered_map<VkDescriptorSet, IconTexture> registry;
+};
+
+namespace {
+
+// ensure_icons lazily builds the shared sampler/command pool/fence on first upload.
+IconTextures* ensure_icons(HeadContext* c) {
+    if (c->icons) return c->icons;
+    IconTextures* it = new IconTextures();
+
+    VkSamplerCreateInfo si{};
+    si.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    si.magFilter = si.minFilter = VK_FILTER_LINEAR;
+    si.addressModeU = si.addressModeV = si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    vkCreateSampler(c->device, &si, nullptr, &it->sampler);
+
+    VkCommandPoolCreateInfo cp{};
+    cp.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    cp.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    cp.queueFamilyIndex = c->queueFamily;
+    vkCreateCommandPool(c->device, &cp, nullptr, &it->cmdPool);
+
+    VkFenceCreateInfo fi{};
+    fi.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    vkCreateFence(c->device, &fi, nullptr, &it->fence);
+
+    c->icons = it;
+    return it;
+}
+
+// make_staging creates a host-visible buffer holding the RGBA pixels to copy.
+bool make_staging(HeadContext* c, VkDeviceSize bytes, const void* src, VkBuffer* buf,
+                  VkDeviceMemory* mem) {
+    VkBufferCreateInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bi.size = bytes;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    if (vkCreateBuffer(c->device, &bi, nullptr, buf) != VK_SUCCESS) return false;
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(c->device, *buf, &req);
+    VkMemoryAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    ai.allocationSize = req.size;
+    ai.memoryTypeIndex = obk_find_memory_type(c->physical, req.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (vkAllocateMemory(c->device, &ai, nullptr, mem) != VK_SUCCESS) return false;
+    vkBindBufferMemory(c->device, *buf, *mem, 0);
+    void* mapped = nullptr;
+    vkMapMemory(c->device, *mem, 0, bytes, 0, &mapped);
+    std::memcpy(mapped, src, (size_t)bytes);
+    vkUnmapMemory(c->device, *mem);
+    return true;
+}
+
+// make_device_image creates the sampled device-local image the icon lives in.
+bool make_device_image(HeadContext* c, int w, int h, IconTexture* tex) {
+    VkImageCreateInfo ii{};
+    ii.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    ii.imageType = VK_IMAGE_TYPE_2D;
+    ii.format = kIconFormat;
+    ii.extent = {(uint32_t)w, (uint32_t)h, 1};
+    ii.mipLevels = 1;
+    ii.arrayLayers = 1;
+    ii.samples = VK_SAMPLE_COUNT_1_BIT;
+    ii.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ii.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    ii.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    if (vkCreateImage(c->device, &ii, nullptr, &tex->image) != VK_SUCCESS) return false;
+    VkMemoryRequirements req;
+    vkGetImageMemoryRequirements(c->device, tex->image, &req);
+    VkMemoryAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    ai.allocationSize = req.size;
+    ai.memoryTypeIndex = obk_find_memory_type(c->physical, req.memoryTypeBits,
+                                              VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (vkAllocateMemory(c->device, &ai, nullptr, &tex->memory) != VK_SUCCESS) return false;
+    vkBindImageMemory(c->device, tex->image, tex->memory, 0);
+    VkImageViewCreateInfo vi{};
+    vi.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    vi.image = tex->image;
+    vi.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    vi.format = kIconFormat;
+    vi.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    return vkCreateImageView(c->device, &vi, nullptr, &tex->view) == VK_SUCCESS;
+}
+
+} // namespace
+
+extern "C" {
+
+// obk_create_texture uploads w×h RGBA8 pixels and returns the ImGui texture handle (a
+// VkDescriptorSet) for drawing with obk_ig_image / obk_ig_image_button, or 0 on failure.
+uint64_t obk_create_texture(void* h, const unsigned char* rgba, int w, int hh) {
+    HeadContext* c = (HeadContext*)h;
+    if (!c || !rgba || w <= 0 || hh <= 0) return 0;
+    IconTextures* it = ensure_icons(c);
+
+    VkDeviceSize bytes = (VkDeviceSize)w * hh * 4;
+    VkBuffer staging = VK_NULL_HANDLE;
+    VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+    IconTexture tex{};
+    bool okBuf = make_staging(c, bytes, rgba, &staging, &stagingMem);
+    bool okImg = okBuf && make_device_image(c, w, hh, &tex);
+    if (!okImg) {
+        if (staging) vkDestroyBuffer(c->device, staging, nullptr);
+        if (stagingMem) vkFreeMemory(c->device, stagingMem, nullptr);
+        if (tex.view) vkDestroyImageView(c->device, tex.view, nullptr);
+        if (tex.image) vkDestroyImage(c->device, tex.image, nullptr);
+        if (tex.memory) vkFreeMemory(c->device, tex.memory, nullptr);
+        return 0;
+    }
+
+    VkCommandBufferAllocateInfo ca{};
+    ca.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    ca.commandPool = it->cmdPool;
+    ca.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    ca.commandBufferCount = 1;
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    vkAllocateCommandBuffers(c->device, &ca, &cmd);
+
+    VkCommandBufferBeginInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd, &bi);
+
+    transition(cmd, tex.image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+               0, VK_ACCESS_TRANSFER_WRITE_BIT,
+               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {(uint32_t)w, (uint32_t)hh, 1};
+    vkCmdCopyBufferToImage(cmd, staging, tex.image,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    transition(cmd, tex.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+               VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+               VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+
+    vkEndCommandBuffer(cmd);
+
+    VkSubmitInfo submit{};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &cmd;
+    vkResetFences(c->device, 1, &it->fence);
+    vkQueueSubmit(c->queue, 1, &submit, it->fence);
+    vkWaitForFences(c->device, 1, &it->fence, VK_TRUE, UINT64_MAX);
+    vkFreeCommandBuffers(c->device, it->cmdPool, 1, &cmd);
+    vkDestroyBuffer(c->device, staging, nullptr);
+    vkFreeMemory(c->device, stagingMem, nullptr);
+
+    VkDescriptorSet set = ImGui_ImplVulkan_AddTexture(it->sampler, tex.view,
+                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    if (set == VK_NULL_HANDLE) {
+        vkDestroyImageView(c->device, tex.view, nullptr);
+        vkDestroyImage(c->device, tex.image, nullptr);
+        vkFreeMemory(c->device, tex.memory, nullptr);
+        return 0;
+    }
+    it->registry[set] = tex;
+    return (uint64_t)set;
+}
+
+// obk_destroy_texture frees one icon texture by its handle (idempotent on an unknown
+// or zero handle), removing it from ImGui and releasing its image/memory/view.
+void obk_destroy_texture(void* h, uint64_t handle) {
+    HeadContext* c = (HeadContext*)h;
+    if (!c || !c->icons || handle == 0) return;
+    VkDescriptorSet set = (VkDescriptorSet)handle;
+    auto found = c->icons->registry.find(set);
+    if (found == c->icons->registry.end()) return;
+    vkDeviceWaitIdle(c->device);
+    ImGui_ImplVulkan_RemoveTexture(set);
+    IconTexture& tex = found->second;
+    vkDestroyImageView(c->device, tex.view, nullptr);
+    vkDestroyImage(c->device, tex.image, nullptr);
+    vkFreeMemory(c->device, tex.memory, nullptr);
+    c->icons->registry.erase(found);
+}
+
+// obk_icons_destroy tears the whole cache down on shutdown (see head.h / app.cpp).
+void obk_icons_destroy(HeadContext* c) {
+    IconTextures* it = c->icons;
+    if (!it) return;
+    vkDeviceWaitIdle(c->device);
+    for (auto& kv : it->registry) {
+        ImGui_ImplVulkan_RemoveTexture(kv.first);
+        vkDestroyImageView(c->device, kv.second.view, nullptr);
+        vkDestroyImage(c->device, kv.second.image, nullptr);
+        vkFreeMemory(c->device, kv.second.memory, nullptr);
+    }
+    vkDestroyFence(c->device, it->fence, nullptr);
+    vkDestroyCommandPool(c->device, it->cmdPool, nullptr);
+    vkDestroySampler(c->device, it->sampler, nullptr);
+    delete it;
+    c->icons = nullptr;
+}
+
+} // extern "C"

--- a/head/internal/native/texture.go
+++ b/head/internal/native/texture.go
@@ -1,0 +1,45 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package native
+
+/*
+#include <stdint.h>
+
+uint64_t obk_create_texture(void* h, const unsigned char* rgba, int w, int hh);
+void     obk_destroy_texture(void* h, uint64_t tex);
+
+int obk_ig_image_button(const char* id, unsigned long long tex, float w, float h,
+                        float r, float g, float b, float a);
+*/
+import "C"
+
+import "unsafe"
+
+// CreateTexture uploads a width×height RGBA8 bitmap (row-major, 4 bytes/pixel) into a
+// device-local Vulkan image and returns its ImGui texture handle for ImageButton/Image,
+// or 0 on failure (e.g. a bad size or a full descriptor pool). The pixels are copied,
+// so the caller may reuse rgba afterwards. Pair every success with DestroyTexture.
+func (w *Window) CreateTexture(rgba []byte, width, height int) uint64 {
+	if len(rgba) < width*height*4 || width <= 0 || height <= 0 {
+		return 0
+	}
+	return uint64(C.obk_create_texture(w.handle,
+		(*C.uchar)(unsafe.Pointer(&rgba[0])), C.int(width), C.int(height)))
+}
+
+// DestroyTexture frees a texture created by CreateTexture (no-op on a zero handle).
+func (w *Window) DestroyTexture(tex uint64) {
+	C.obk_destroy_texture(w.handle, C.uint64_t(tex))
+}
+
+// ImageButton draws a clickable icon of size w×h for the texture, tinted by the RGBA
+// color so the same monochrome glyph recolors per theme. id must be unique per button
+// (use the command id). Returns true on the frame it is clicked.
+func ImageButton(id string, tex uint64, w, h float32, tint [4]float32) bool {
+	c, free := cstr(id)
+	defer free()
+	return C.obk_ig_image_button(c, C.ulonglong(tex), C.float(w), C.float(h),
+		C.float(tint[0]), C.float(tint[1]), C.float(tint[2]), C.float(tint[3])) != 0
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -30,6 +30,9 @@ import (
 // function stays free of side effects on the model. The window is needed to render the
 // 3D viewport into its offscreen target.
 func DrawChrome(win *native.Window, s *app.Session) string {
+	if icons == nil {
+		icons = newIconCache(win) // lazily bind the icon cache to this window
+	}
 	handleKeyboard(s)
 	activated := drawMenuBar(s)
 	dockID := native.DockSpaceOverMain()
@@ -238,16 +241,71 @@ func drawPanel(panel app.RibbonPanel) string {
 		if i > 0 && i%cols != 0 {
 			native.SameLine() // continue the current row; a new row starts at each multiple of cols
 		}
-		native.BeginDisabled(!btn.Enabled)
-		if native.Button(btn.Command.DisplayName()) {
-			activated = btn.Command.ID()
+		if id := drawRibbonButton(btn); id != "" {
+			activated = id
 		}
-		native.EndDisabled()
-		native.SetItemTooltip(btn.Command.Tooltip())
 	}
 	native.Text(panel.Name) // panel title under its buttons
 	native.EndGroup()
 	return activated
+}
+
+// drawRibbonButton renders one command in its configured style (text, small icon, or
+// large icon), greyed when its predicate is false, with the command tooltip on hover.
+// It returns the command id when clicked this frame, else "".
+func drawRibbonButton(btn app.RibbonButton) string {
+	native.BeginDisabled(!btn.Enabled)
+	clicked := drawButtonControl(btn)
+	native.EndDisabled()
+	if clicked {
+		return btn.Command.ID()
+	}
+	return ""
+}
+
+// drawButtonControl draws the command's clickable control and its tooltip, returning
+// whether it was clicked. An icon-style command falls back to a labeled text button
+// when its glyph texture is unavailable (missing asset or upload failure), so a missing
+// icon never hides the command.
+func drawButtonControl(btn app.RibbonButton) bool {
+	if px, ok := iconSizeFor(btn.Command.ButtonStyle()); ok {
+		if tex, ok := icons.texture(btn.Command.Icon(), px); ok {
+			return drawIconButton(btn, tex, float32(px))
+		}
+	}
+	clicked := native.Button(btn.Command.DisplayName())
+	native.SetItemTooltip(btn.Command.Tooltip())
+	return clicked
+}
+
+// iconSizeFor returns the rasterization size for an icon button style, or false for a
+// text-only command.
+func iconSizeFor(s app.ButtonStyle) (int, bool) {
+	switch s {
+	case app.SmallIconButton:
+		return smallIconPx, true
+	case app.LargeIconButton:
+		return largeIconPx, true
+	default:
+		return 0, false
+	}
+}
+
+// drawIconButton renders an icon button: small ones are icon-only (dense tool grids),
+// large ones place the name as a caption beneath the icon (Inventor's large button).
+// The icon is the click target either way.
+func drawIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
+	if btn.Command.ButtonStyle() != app.LargeIconButton {
+		clicked := native.ImageButton(btn.Command.ID(), tex, px, px, iconTint)
+		native.SetItemTooltip(btn.Command.Tooltip())
+		return clicked
+	}
+	native.BeginGroup()
+	clicked := native.ImageButton(btn.Command.ID(), tex, px, px, iconTint)
+	native.SetItemTooltip(btn.Command.Tooltip())
+	native.Text(btn.Command.DisplayName())
+	native.EndGroup()
+	return clicked
 }
 
 // prevFramedDoc tracks which document the camera was last framed to, so switching

--- a/head/ui/icon_cache.go
+++ b/head/ui/icon_cache.go
@@ -1,0 +1,74 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/head/icon"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// iconTint is the color every ribbon glyph is drawn with. The icons are rasterized as
+// white alpha masks, so this single tint recolors all of them — the hook a future
+// theme manager sets. Default: a light gray that reads on the dark chrome.
+var iconTint = [4]float32{0.85, 0.87, 0.90, 1}
+
+// Rasterization sizes per button style. Small icons fill the dense sketch tool grids;
+// large icons head a panel (Inventor's two button sizes).
+const (
+	smallIconPx = 18
+	largeIconPx = 32
+)
+
+// icons is the chrome's icon texture cache, lazily created from the window on the first
+// DrawChrome (package-global to match the chrome's other per-window state).
+var icons *iconCache
+
+// iconCache rasterizes embedded SVG glyphs and uploads them as ImGui textures, caching
+// by (key, px) so each glyph is rasterized and uploaded exactly once for the window's
+// lifetime. The native side frees the GPU textures on window teardown.
+type iconCache struct {
+	win *native.Window
+	tex map[iconKey]uint64
+}
+
+type iconKey struct {
+	name string
+	px   int
+}
+
+func newIconCache(win *native.Window) *iconCache {
+	return &iconCache{win: win, tex: map[iconKey]uint64{}}
+}
+
+// texture returns the ImGui texture handle for an icon at the given pixel size,
+// rasterizing and uploading it on first use. It returns (0,false) when the key has no
+// bundled asset or rasterization/upload fails, so the caller falls back to text. A
+// failed lookup is cached (as 0) too, so a missing glyph is not retried every frame.
+func (c *iconCache) texture(name string, px int) (uint64, bool) {
+	if name == "" || px <= 0 {
+		return 0, false
+	}
+	k := iconKey{name, px}
+	if t, ok := c.tex[k]; ok {
+		return t, t != 0
+	}
+	t := c.upload(name, px)
+	c.tex[k] = t
+	return t, t != 0
+}
+
+// upload rasterizes the named glyph to px×px and hands the RGBA to the GPU, returning 0
+// if the asset is missing or either step fails.
+func (c *iconCache) upload(name string, px int) uint64 {
+	svg, ok := icon.SVG(name)
+	if !ok {
+		return 0
+	}
+	img, err := icon.Rasterize(svg, px)
+	if err != nil {
+		return 0
+	}
+	return c.win.CreateTexture(img.Pix, px, px)
+}

--- a/head/ui/icon_inwindow_test.go
+++ b/head/ui/icon_inwindow_test.go
@@ -1,0 +1,44 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// TestInWindowRibbonUploadsIconTextures drives the real chrome for a few frames and
+// asserts the 3D Model tab's large-icon command (Extrude) was rasterized from its SVG
+// and uploaded as a live ImGui/Vulkan texture — exercising the whole SVG→RGBA→GPU path
+// on real hardware, not just the pure-Go rasterizer. Skips when no display/Vulkan is
+// available (e.g. CI without a GPU).
+func TestInWindowRibbonUploadsIconTextures(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false // rebuild the default layout for this fresh window/context
+	icons = nil         // rebind the icon cache to this fresh window
+
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	for i := 0; i < 3; i++ { // settle the dock/tab layout, then draw the ribbon's icons
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	if icons == nil {
+		t.Fatal("DrawChrome did not initialize the icon cache")
+	}
+	tex, ok := icons.tex[iconKey{name: "extrude", px: largeIconPx}]
+	if !ok {
+		t.Fatal("ribbon never uploaded the Extrude large-icon texture (was the 3D Model tab drawn?)")
+	}
+	if tex == 0 {
+		t.Error("Extrude icon texture handle is 0 — SVG rasterization or the Vulkan upload failed")
+	}
+}

--- a/head/ui/inwindow_test.go
+++ b/head/ui/inwindow_test.go
@@ -60,6 +60,7 @@ func TestInWindowDockedViewportIsInteractive(t *testing.T) {
 	win := newViewportWindow(t)
 	defer win.Destroy()
 	dockLaidOut = false // rebuild the default layout for this fresh window/context
+	icons = nil         // rebind the icon cache to this fresh window (it holds GPU handles)
 	s := framedSession()
 
 	frame := func() {


### PR DESCRIPTION
## What

Two related ribbon improvements (the GPL implementation of the contract merged in Oblikovati.API#1):

### Inventor-style icon buttons
- New pure-Go **`head/icon`** package rasterizes embedded **SVG** glyphs to tintable RGBA alpha masks (via `oksvg`/`rasterx`) — the only importer of the library, wrapped behind our own `Rasterize`/`SVG`.
- New **`head/internal/native/texture.*`** uploads CPU RGBA → device-local Vulkan image → ImGui texture, plus an `ImageButton` with a tint color.
- **`head/ui`** caches textures per `(key, size)` and renders each command as text / small-icon / large-icon, falling back to text when a glyph is missing. Glyphs are monochrome and tinted at draw time, so a future theme manager recolors them with no re-rasterization.
- Standard commands tagged with icon keys + styles; the router reports `Icon` + `ButtonStyle` over the wire.

### Add-in UI extension
- **`commands.create`** registers an add-in's ribbon button. It runs no host logic — clicking it fires `command.ended`, which the existing event forwarding delivers to the add-in's `Notify` (Inventor's `ButtonDefinition` + `OnExecute`). The production head already loads add-ins, forwards events, and drains their host calls, so the loop is complete.
- A real **c-shared test add-in** (`testdata/uiaddin`) proves the end-to-end flow: it adds a ribbon button on `Activate` and creates a document when the button is "clicked".

## Why

The ribbon was text-only and add-ins could not contribute UI. This brings it in line with Inventor's small/large icon buttons and opens the ribbon to add-ins over the public API.

## Tests

`go test ./...` across the core and `head` modules, including:
- pure-Go icon rasterization (every bundled glyph) and the `commands.create` router flow;
- a real-GPU in-window test asserting an SVG glyph uploads to a live Vulkan/ImGui texture;
- the end-to-end c-shared add-in test (button registered → click → document created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)