### PR TITLE
UI ThemeManager: themable shell with Light/Dark + custom themes

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -49,6 +49,8 @@ func New(ops *opregistry.Registry) *Router {
 	r.handlers[wire.MethodSketchRectangle] = sketchRectangle
 	r.handlers[wire.MethodFeaturesList] = r.listFeatureKinds
 	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
+	r.handlers[wire.MethodThemeActive] = themeActive
+	r.handlers[wire.MethodThemeList] = themeList
 	return r
 }
 

--- a/addin/router/router_test.go
+++ b/addin/router/router_test.go
@@ -246,6 +246,44 @@ func TestModelSelectionEmpty(t *testing.T) {
 	}
 }
 
+func TestThemeActiveServesEveryColor(t *testing.T) {
+	r, s := seededSession(t)
+	var view wire.ThemeView
+	call(t, r, s, "theme.active", "{}", &view)
+	if view.Name != "Dark" || view.Kind != "dark" {
+		t.Fatalf("theme.active = (%q,%q), want (Dark,dark)", view.Name, view.Kind)
+	}
+	// An add-in reads colors by token string; every token must be present so its UI can
+	// look them all up without a missing-key check.
+	for _, tok := range types.AllThemeTokens() {
+		hex, ok := view.Colors[string(tok)]
+		if !ok || len(hex) != 9 || hex[0] != '#' {
+			t.Errorf("theme.active color %q = %q, want a \"#RRGGBBAA\" value", tok, hex)
+		}
+	}
+}
+
+func TestThemeListFlagsActive(t *testing.T) {
+	r, s := seededSession(t)
+	if err := s.DuplicateTheme("Dark", "My Dark"); err != nil { // becomes active
+		t.Fatalf("DuplicateTheme: %v", err)
+	}
+	var list wire.ListThemesResult
+	call(t, r, s, "theme.list", "{}", &list)
+	if len(list.Themes) != 3 { // Dark, Light, My Dark
+		t.Fatalf("theme.list = %d themes, want 3", len(list.Themes))
+	}
+	var active string
+	for _, th := range list.Themes {
+		if th.Active {
+			active = th.Name
+		}
+	}
+	if active != "My Dark" {
+		t.Errorf("active theme in list = %q, want \"My Dark\"", active)
+	}
+}
+
 func TestParametersNoActiveDocument(t *testing.T) {
 	r := New(opregistry.Default())
 	s := app.NewSession() // empty workspace

--- a/addin/router/theme.go
+++ b/addin/router/theme.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// themeActive returns the host's active theme — name, kind, and every semantic color as
+// hex — so an add-in can paint its own panels to match the host (wire.MethodThemeActive).
+func themeActive(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	active := s.Themes().Active()
+	colors := make(map[string]string, len(types.AllThemeTokens()))
+	for _, tok := range types.AllThemeTokens() {
+		colors[string(tok)] = active.Color(tok).Hex()
+	}
+	return json.Marshal(wire.ThemeView{
+		Name:   active.Name(),
+		Kind:   string(active.Kind()),
+		Colors: colors,
+	})
+}
+
+// themeList returns a summary of every available theme (built-in and custom), flagging
+// the active one (wire.MethodThemeList).
+func themeList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	lib := s.Themes()
+	activeName := lib.ActiveName()
+	themes := lib.Themes()
+	out := make([]wire.ThemeSummary, len(themes))
+	for i, t := range themes {
+		out[i] = wire.ThemeSummary{
+			Name:   t.Name(),
+			Kind:   string(t.Kind()),
+			Active: t.Name() == activeName,
+		}
+	}
+	return json.Marshal(wire.ListThemesResult{Themes: out})
+}

--- a/app/appearance.go
+++ b/app/appearance.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"github.com/Oblikovati/api/contract"
+
+	"github.com/Oblikovati/oblikovati/theme"
+)
+
+// Themes returns the session's UI theme library (built-ins plus the user's customs with
+// an active selection). On first use, before any store is attached, it holds only the
+// shipped Dark/Light built-ins — the windowed head/CLI call [Session.LoadThemes] to fold
+// in the user's saved customs. Unit sessions therefore see a deterministic built-in-only
+// library with no disk access.
+func (s *Session) Themes() *theme.Library {
+	if s.themes == nil {
+		s.themes = theme.NewLibrary(nil, "Dark")
+	}
+	return s.themes
+}
+
+// Theme returns the active theme as the public read-only contract (what the wire router
+// serves and add-ins read).
+func (s *Session) Theme() contract.Theme { return s.Themes().Active() }
+
+// ThemeRevision is the active library's change counter; the head compares it across
+// frames to decide whether to re-apply the theme to Dear ImGui (live preview).
+func (s *Session) ThemeRevision() uint64 { return s.Themes().Revision() }
+
+// LoadThemes attaches a persistence store and replaces the in-memory library with one
+// built from the user's saved customs and selected theme. The binary (head/CLI) calls
+// this once at startup with an OS-backed store; a load error (one corrupt file) is
+// returned but the good themes still load. The store is retained so later edits persist.
+func (s *Session) LoadThemes(store *theme.Store) error {
+	customs, active, err := store.Load()
+	s.themes = theme.NewLibrary(customs, active)
+	s.themeStore = store
+	return err
+}
+
+// SetActiveTheme selects a theme by name and persists the choice (when a store is
+// attached). Selecting an unknown name is a no-op.
+func (s *Session) SetActiveTheme(name string) error {
+	s.Themes().SetActive(name)
+	return s.persistActive()
+}
+
+// DuplicateTheme creates a custom full-snapshot copy of base under newName, makes it
+// active, and persists both the new theme file and the selection. It surfaces the
+// library's name/uniqueness error.
+func (s *Session) DuplicateTheme(base, newName string) error {
+	dup, err := s.Themes().Duplicate(base, newName)
+	if err != nil {
+		return err
+	}
+	if err := s.persistTheme(dup); err != nil {
+		return err
+	}
+	return s.persistActive()
+}
+
+// DeleteTheme removes a custom theme (reselecting Dark if it was active) and deletes its
+// file. It surfaces the library's "not found / built-in" error.
+func (s *Session) DeleteTheme(name string) error {
+	if err := s.Themes().Remove(name); err != nil {
+		return err
+	}
+	if s.themeStore != nil {
+		if err := s.themeStore.RemoveTheme(name); err != nil {
+			return err
+		}
+	}
+	return s.persistActive()
+}
+
+// SaveActiveTheme writes the active theme's current colors to disk (the editor's Save
+// after recoloring). It is a no-op for a built-in or when no store is attached.
+func (s *Session) SaveActiveTheme() error {
+	active := s.Themes().Active()
+	if !active.Kind().Editable() {
+		return nil
+	}
+	return s.persistTheme(active)
+}
+
+// persistTheme writes one custom theme when a store is attached (else a no-op).
+func (s *Session) persistTheme(t *theme.Theme) error {
+	if s.themeStore == nil {
+		return nil
+	}
+	return s.themeStore.SaveTheme(t)
+}
+
+// persistActive writes the selected-theme preference when a store is attached.
+func (s *Session) persistActive() error {
+	if s.themeStore == nil {
+		return nil
+	}
+	return s.themeStore.SaveActive(s.Themes().ActiveName())
+}

--- a/app/session.go
+++ b/app/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
 	"github.com/Oblikovati/oblikovati/scene"
+	"github.com/Oblikovati/oblikovati/theme"
 )
 
 // Session is the running application state and the seam tests drive synthetically.
@@ -34,6 +35,8 @@ type Session struct {
 	overlays        []renderer.DrawItem
 	addins          *AddInManager
 	grid            *GridSettings
+	themes          *theme.Library
+	themeStore      *theme.Store
 }
 
 // NewSession creates an empty in-memory session with no persistence store. Its

--- a/architecture/decisions/ADR-0021-ui-theming-semantic-tokens.md
+++ b/architecture/decisions/ADR-0021-ui-theming-semantic-tokens.md
@@ -1,0 +1,63 @@
+# ADR-0021 — UI theming via semantic tokens (head applies, core owns state)
+
+**Status:** accepted (user decision, 2026-06-02) · **Relates to:**
+[ADR-0004](ADR-0004-ui-imgui.md) (Dear ImGui head), [ADR-0018](ADR-0018-apache-api-contract-module.md)
+(API contract split), [ADR-0020](ADR-0020-yaml-git-friendly-document-format.md) (YAML files).
+
+## Context
+
+The UI had no theming. Colors were hardcoded as package-level vars scattered across
+`head/ui/*.go` (icon tint, grid/plane/sketch/dimension/selection/preview colors), the
+window background was a literal `EndFrame(0.12, 0.13, 0.16)`, and the Dear ImGui chrome
+used its default style untouched. There was no preference persistence to disk at all.
+
+We want a ThemeManager that styles the whole shell — window, menus, icons, viewport 2D
+overlays, and 3D gizmos — ships a Light and a Dark built-in, lets a user duplicate one
+into an editable custom theme with a color picker, updates the UI **live** while editing,
+and stores custom themes per user. Theming does **not** cover 3D body appearance, which
+the future material/appearance subsystem owns.
+
+## Decision
+
+1. **Semantic tokens, not raw ImGui slots.** A curated ~33-token vocabulary
+   (`api/types.ThemeToken`, grouped Chrome / Viewport 2D / Gizmos 3D / Icons) is the
+   user-facing palette. One token may drive several Dear ImGui color slots (e.g. the
+   accent feeds the active tab, checkmark, slider grab, and selection). This keeps the
+   editor small and themes coherent, versus exposing ~55 `ImGuiCol_` slots.
+
+2. **Exposed on the public API (ADR-0018 two-part work).** The token enum + `Rgba` value
+   type live in `api/types`; a read-only `Theme` interface in `api/contract`;
+   `theme.active` / `theme.list` methods + DTOs in `api/wire`; a typed group in
+   `api/client`. So an add-in can read the host's active theme and match it.
+
+3. **The core owns theme state; the head applies it.** Because the wire router
+   (`addin/router`, GPL app module) cannot import `/head`, the active theme lives on the
+   `*app.Session` (a `theme.Library`, alongside `GridSettings`). The head reads it to
+   style Dear ImGui and the overlays; the router reads it to serve `theme.*`. The pure-Go
+   `theme/` package (palette, defaults, library, IO) has no cgo/ImGui dependency and is
+   fully headless-tested.
+
+4. **Full-snapshot custom themes.** Duplicating a built-in copies every token value into
+   the custom theme; it is self-contained (no base inheritance to resolve) and keeps its
+   look even if a built-in's defaults later change.
+
+5. **YAML files in the user config dir.** Customs persist as readable YAML under
+   `os.UserConfigDir()/oblikovati/themes/*.yaml`, the selected theme under
+   `.../preferences.yaml`, through the existing `persistence/yamlcodec` seam (ADR-0020),
+   behind a `theme.FileSystem` interface (in-memory fake in tests).
+
+6. **Live apply via a revision counter.** `theme.Library` bumps a monotonic revision on
+   any select/edit/add/remove. `head/ui` re-pushes the chrome colors into Dear ImGui's
+   persistent style (set once per change, not per widget) and refreshes the overlay/icon
+   color vars and the viewport clear color only when the revision changes — so a theme
+   switch or a color-picker drag restyles the whole UI on the next frame.
+
+## Consequences
+
+- New work touching UI color must add a token (in `api/types`, with a default in both
+  built-in palettes — guarded by `TestDefaultsComplete`) rather than a hardcoded color.
+- The head maps tokens → ImGui slots by **name** (`native.SetStyleColor("WindowBg", …)`),
+  so the binding survives `ImGuiCol_` enum reordering between Dear ImGui versions.
+- Themes are presentation-only and per-user; they are not part of a document and never
+  travel in a `.obk` file.
+- Add-in theme access is read-only for now; an add-in cannot define or mutate host themes.

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/persistence"
+	"github.com/Oblikovati/oblikovati/theme"
 )
 
 func main() {
@@ -64,7 +65,7 @@ func run(session *app.Session, maxFrames int) error {
 			}
 		}
 		addins.drain()
-		win.EndFrame(0.12, 0.13, 0.16)
+		win.EndFrame(ui.WindowClearColor()) // themed swapchain background (ADR-0021)
 	}
 	return nil
 }
@@ -79,7 +80,23 @@ func newDemoSession() *app.Session {
 	s := app.NewSessionWithStore(persistence.NewPackageStore())
 	registerCommands(s)
 	seedPart(s)
+	loadThemes(s)
 	return s
+}
+
+// loadThemes folds the user's saved custom themes and selected theme into the session
+// from the OS config dir, so the chrome opens in the theme last used. A locate/load error
+// is non-fatal — the built-in Dark/Light are always available — so a bad theme file never
+// blocks startup; it is reported to stderr.
+func loadThemes(s *app.Session) {
+	root, err := theme.DefaultRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "themes: %v\n", err)
+		return
+	}
+	if err := s.LoadThemes(theme.NewStore(root, theme.OSFileSystem{})); err != nil {
+		fmt.Fprintf(os.Stderr, "themes: %v\n", err)
+	}
 }
 
 func registerCommands(s *app.Session) {

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -60,6 +60,17 @@ void obk_ig_get_cursor_pos(float* x, float* y);
 void obk_ig_set_cursor_pos(float x, float y);
 void obk_ig_set_next_window_pos(float x, float y);
 void obk_ig_set_next_window_size(float w, float h);
+void obk_ig_set_next_window_size_first_use(float w, float h);
+
+// Theming verbs (ADR-0021). set_style_color overwrites one persistent ImGuiStyle color,
+// addressed by its ImGui name (e.g. "WindowBg", "Button") so Go never hardcodes the
+// enum index (which shifts between ImGui versions); an unknown name is ignored.
+// color_edit4 is the swatch+picker editing a 4-float RGBA in place (1 on change).
+// begin_combo/end_combo bracket the theme selector dropdown.
+void obk_ig_set_style_color(const char* name, float r, float g, float b, float a);
+int  obk_ig_color_edit4(const char* label, float* rgba);
+int  obk_ig_begin_combo(const char* label, const char* preview);
+void obk_ig_end_combo(void);
 
 unsigned int obk_ig_dockspace_over_main(void);
 void obk_ig_dock_default_layout(unsigned int dockId, const char* ribbon, const char* model, const char* viewport, const char* status);
@@ -173,6 +184,38 @@ func Checkbox(label string, v *bool) bool {
 	*v = cv != 0
 	return changed
 }
+
+// SetStyleColor overwrites one Dear ImGui style color, addressed by its ImGui name
+// (e.g. "WindowBg", "Button", "TabSelected"). ImGui's style is persistent global state,
+// so the theme apply layer calls this once per token when the theme changes — not every
+// frame. An unrecognized name is a no-op. See head/ui theme apply (ADR-0021).
+func SetStyleColor(name string, c [4]float32) {
+	cn, free := cstr(name)
+	defer free()
+	C.obk_ig_set_style_color(cn, C.float(c[0]), C.float(c[1]), C.float(c[2]), C.float(c[3]))
+}
+
+// ColorEdit4 draws a color swatch that opens a picker, editing the RGBA in place and
+// returning true on the frame the color changed — the per-token control in the
+// Appearance editor.
+func ColorEdit4(label string, c *[4]float32) bool {
+	cl, free := cstr(label)
+	defer free()
+	return C.obk_ig_color_edit4(cl, (*C.float)(unsafe.Pointer(&c[0]))) != 0
+}
+
+// BeginCombo / EndCombo bracket a dropdown showing preview as the closed value; when
+// BeginCombo returns true the popup is open, so draw the Selectable options and pair it
+// with EndCombo. Used by the theme selector.
+func BeginCombo(label, preview string) bool {
+	cl, free := cstr(label)
+	defer free()
+	cp, free2 := cstr(preview)
+	defer free2()
+	return C.obk_ig_begin_combo(cl, cp) != 0
+}
+
+func EndCombo() { C.obk_ig_end_combo() }
 
 // SeparatorText draws a labeled horizontal separator (used as panel titles).
 func SeparatorText(s string) {
@@ -359,6 +402,12 @@ func SetCursorPos(x, y float32) { C.obk_ig_set_cursor_pos(C.float(x), C.float(y)
 // in-window tests to put the viewport panel at a known rect so injected input lands on it.
 func SetNextWindowPos(x, y float32)  { C.obk_ig_set_next_window_pos(C.float(x), C.float(y)) }
 func SetNextWindowSize(w, h float32) { C.obk_ig_set_next_window_size(C.float(w), C.float(h)) }
+
+// SetNextWindowSizeOnce sets the next window's size only the first time it is shown
+// (ImGuiCond_FirstUseEver), so it gives a sensible default the user can still resize.
+func SetNextWindowSizeOnce(w, h float32) {
+	C.obk_ig_set_next_window_size_first_use(C.float(w), C.float(h))
+}
 
 // DockSpaceOverMain hosts a full-window dockspace each frame and returns its stable id.
 // Call it once per frame before the panels; the panels then dock into it.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -3,6 +3,7 @@
 // each frame (ADR-0004/0009). Keeping the binding here — rather than rendering a
 // Go-described tree in C++ — is what lets Go own the UI composition. Add wrappers as
 // the chrome grows; resist putting logic here.
+#include <cstring> // strcmp (theme color-name lookup)
 #include "imgui.h"
 #include "imgui_internal.h" // SeparatorEx (vertical ribbon-panel divider)
 
@@ -16,6 +17,9 @@ int  obk_ig_menu_item(const char* label)     { return ImGui::MenuItem(label) ? 1
 
 void obk_ig_set_next_window_pos(float x, float y)  { ImGui::SetNextWindowPos(ImVec2(x, y)); }
 void obk_ig_set_next_window_size(float w, float h) { ImGui::SetNextWindowSize(ImVec2(w, h)); }
+void obk_ig_set_next_window_size_first_use(float w, float h) {
+    ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_FirstUseEver);
+}
 int  obk_ig_begin(const char* name)          { return ImGui::Begin(name) ? 1 : 0; }
 void obk_ig_end(void)                        { ImGui::End(); }
 void obk_ig_text(const char* s)              { ImGui::TextUnformatted(s); }
@@ -77,6 +81,52 @@ int  obk_ig_checkbox(const char* label, int* v) {
 
 void obk_ig_begin_disabled(int disabled)     { ImGui::BeginDisabled(disabled != 0); }
 void obk_ig_end_disabled(void)               { ImGui::EndDisabled(); }
+
+// --- Theming (ADR-0021) -----------------------------------------------------------
+// obk_col_index maps an ImGui color NAME to its ImGuiCol_ enum so the Go side never
+// hardcodes the numeric index (it shifts between ImGui versions). Only the slots the
+// theme drives are listed; an unknown name returns -1 (ignored). Several names may share
+// a token on the Go side (e.g. an accent token sets TabSelected, CheckMark, SliderGrab).
+static int obk_col_index(const char* name) {
+    struct { const char* n; int c; } table[] = {
+        {"Text", ImGuiCol_Text}, {"TextDisabled", ImGuiCol_TextDisabled},
+        {"WindowBg", ImGuiCol_WindowBg}, {"ChildBg", ImGuiCol_ChildBg},
+        {"PopupBg", ImGuiCol_PopupBg}, {"Border", ImGuiCol_Border},
+        {"FrameBg", ImGuiCol_FrameBg}, {"FrameBgHovered", ImGuiCol_FrameBgHovered},
+        {"FrameBgActive", ImGuiCol_FrameBgActive}, {"TitleBg", ImGuiCol_TitleBg},
+        {"TitleBgActive", ImGuiCol_TitleBgActive}, {"TitleBgCollapsed", ImGuiCol_TitleBgCollapsed},
+        {"MenuBarBg", ImGuiCol_MenuBarBg}, {"ScrollbarBg", ImGuiCol_ScrollbarBg},
+        {"ScrollbarGrab", ImGuiCol_ScrollbarGrab}, {"ScrollbarGrabHovered", ImGuiCol_ScrollbarGrabHovered},
+        {"ScrollbarGrabActive", ImGuiCol_ScrollbarGrabActive}, {"CheckMark", ImGuiCol_CheckMark},
+        {"SliderGrab", ImGuiCol_SliderGrab}, {"SliderGrabActive", ImGuiCol_SliderGrabActive},
+        {"Button", ImGuiCol_Button}, {"ButtonHovered", ImGuiCol_ButtonHovered},
+        {"ButtonActive", ImGuiCol_ButtonActive}, {"Header", ImGuiCol_Header},
+        {"HeaderHovered", ImGuiCol_HeaderHovered}, {"HeaderActive", ImGuiCol_HeaderActive},
+        {"Separator", ImGuiCol_Separator}, {"SeparatorHovered", ImGuiCol_SeparatorHovered},
+        {"SeparatorActive", ImGuiCol_SeparatorActive}, {"Tab", ImGuiCol_Tab},
+        {"TabHovered", ImGuiCol_TabHovered}, {"TabSelected", ImGuiCol_TabSelected},
+        {"TabDimmed", ImGuiCol_TabDimmed}, {"TabDimmedSelected", ImGuiCol_TabDimmedSelected},
+        {"TextSelectedBg", ImGuiCol_TextSelectedBg},
+    };
+    for (auto& e : table) {
+        if (strcmp(e.n, name) == 0) return e.c;
+    }
+    return -1;
+}
+
+void obk_ig_set_style_color(const char* name, float r, float g, float b, float a) {
+    int idx = obk_col_index(name);
+    if (idx < 0) return;
+    ImGui::GetStyle().Colors[idx] = ImVec4(r, g, b, a);
+}
+
+int  obk_ig_color_edit4(const char* label, float* rgba) {
+    return ImGui::ColorEdit4(label, rgba) ? 1 : 0;
+}
+int  obk_ig_begin_combo(const char* label, const char* preview) {
+    return ImGui::BeginCombo(label, preview) ? 1 : 0;
+}
+void obk_ig_end_combo(void)                  { ImGui::EndCombo(); }
 
 // want_capture_mouse reports whether ImGui consumed the pointer this frame, so the Go
 // loop knows when NOT to forward a click to the 3D viewport (picking).

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -53,6 +53,10 @@ struct Viewport {
     VkDescriptorSet texture = VK_NULL_HANDLE; // ImGui sampled-image set
 
     GpuBuffer       vbuf, ibuf;
+
+    // Background the 3D pass clears to (themed; ADR-0021). Defaults reproduce the
+    // pre-theming look so an un-themed build is unchanged.
+    float           clearR = 0.10f, clearG = 0.11f, clearB = 0.13f;
 };
 
 namespace {
@@ -384,7 +388,7 @@ void obk_viewport_render(void* h, int w, int hh, const float* mvp, int lit_unuse
     vkBeginCommandBuffer(v->cmd, &bi);
 
     VkClearValue clears[2];
-    clears[0].color = {{0.10f, 0.11f, 0.13f, 1.0f}};
+    clears[0].color = {{v->clearR, v->clearG, v->clearB, 1.0f}};
     clears[1].depthStencil = {1.0f, 0};
     VkRenderPassBeginInfo rp{};
     rp.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -434,6 +438,16 @@ void obk_viewport_render(void* h, int w, int hh, const float* mvp, int lit_unuse
     vkResetFences(c->device, 1, &v->fence);
     vkQueueSubmit(c->queue, 1, &submit, v->fence);
     vkWaitForFences(c->device, 1, &v->fence, VK_TRUE, UINT64_MAX);
+}
+
+// obk_viewport_set_clear sets the 3D pass background (themed). Takes effect on the next
+// render; a no-op before the viewport is initialized.
+void obk_viewport_set_clear(void* h, float r, float g, float b) {
+    HeadContext* c = (HeadContext*)h;
+    if (!c->viewport) return;
+    c->viewport->clearR = r;
+    c->viewport->clearG = g;
+    c->viewport->clearB = b;
 }
 
 // obk_viewport_texture returns the ImGui texture handle for the rendered color image

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -11,6 +11,7 @@ void     obk_viewport_init(void* h, const uint32_t* vert, int vlen, const uint32
 void     obk_viewport_render(void* h, int w, int hh, const float* mvp, int lit_unused,
                              const float* triV, int triVC, const uint32_t* triIdx, int triIC,
                              const float* lineV, int lineVC, const uint32_t* lineIdx, int lineIC);
+void     obk_viewport_set_clear(void* h, float r, float g, float b);
 uint64_t obk_viewport_texture(void* h);
 
 void obk_ig_image(unsigned long long tex, float w, float h);
@@ -39,6 +40,12 @@ func (win *Window) RenderViewport(w, h int, mvp []float32,
 		(*C.float)(unsafe.Pointer(&mvp[0])), 0,
 		floatPtr(triVerts), C.int(triVCount), uint32Ptr(triIdx), C.int(len(triIdx)),
 		floatPtr(lineVerts), C.int(lineVCount), uint32Ptr(lineIdx), C.int(len(lineIdx)))
+}
+
+// SetViewportClear sets the 3D pass background color (themed); it takes effect on the
+// next RenderViewport.
+func (w *Window) SetViewportClear(r, g, b float32) {
+	C.obk_viewport_set_clear(w.handle, C.float(r), C.float(g), C.float(b))
 }
 
 // ViewportTexture returns the ImGui texture handle for the last rendered frame.

--- a/head/ui/appearance_tab.go
+++ b/head/ui/appearance_tab.go
@@ -1,0 +1,130 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"bytes"
+
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/theme"
+)
+
+// themeNameBuf backs the "new theme name" field across frames (ImGui edits it in place);
+// themeStatus shows the last action's error, or "" when fine.
+var (
+	themeNameBuf [64]byte
+	themeStatus  string
+)
+
+// drawAppearanceTab is the Preferences ▸ Appearance pane: pick a theme, duplicate the
+// active one into an editable custom, and recolor its tokens with a live preview (every
+// edit bumps the theme revision, so the whole UI restyles next frame). Built-in themes
+// are read-only; the user duplicates to customize (ADR-0021).
+func drawAppearanceTab(s *app.Session) {
+	drawThemeSelector(s)
+	drawThemeActions(s)
+	native.Separator()
+	drawColorRows(s)
+}
+
+// drawThemeSelector renders the theme dropdown; choosing an entry activates it (and
+// persists the choice).
+func drawThemeSelector(s *app.Session) {
+	lib := s.Themes()
+	if !native.BeginCombo("Theme", lib.ActiveName()) {
+		return
+	}
+	for _, t := range lib.Themes() {
+		if native.Selectable(t.Name(), t.Name() == lib.ActiveName()) {
+			themeStatus = errText(s.SetActiveTheme(t.Name()))
+		}
+	}
+	native.EndCombo()
+}
+
+// drawThemeActions renders the duplicate field/button plus Save/Delete for a custom
+// active theme. Save writes the active theme's current colors to disk; Delete removes it.
+func drawThemeActions(s *app.Session) {
+	native.InputText("New name", themeNameBuf[:])
+	native.SameLine()
+	if native.Button("Duplicate") {
+		duplicateActiveTheme(s)
+	}
+	if active := s.Themes().Active(); active.Kind().Editable() {
+		native.SameLine()
+		if native.Button("Save") {
+			themeStatus = errText(s.SaveActiveTheme())
+		}
+		native.SameLine()
+		if native.Button("Delete") {
+			themeStatus = errText(s.DeleteTheme(active.Name()))
+		}
+	}
+	if themeStatus != "" {
+		native.Text(themeStatus)
+	}
+}
+
+// duplicateActiveTheme copies the active theme into a new custom under the typed name,
+// reporting the library's name/uniqueness error in the status line.
+func duplicateActiveTheme(s *app.Session) {
+	name := bufString(themeNameBuf[:])
+	themeStatus = errText(s.DuplicateTheme(s.Themes().ActiveName(), name))
+	if themeStatus == "" {
+		clearBuf(themeNameBuf[:]) // consumed the typed name
+	}
+}
+
+// drawColorRows lists every token as a color swatch, grouped by area, disabled (read-only)
+// for a built-in theme. Editing a swatch recolors the active custom theme live.
+func drawColorRows(s *app.Session) {
+	active := s.Themes().Active()
+	native.BeginDisabled(!active.Kind().Editable())
+	var group theme.Group
+	for _, tok := range types.AllThemeTokens() {
+		info := theme.InfoFor(tok)
+		if info.Group != group {
+			group = info.Group
+			native.SeparatorText(string(group))
+		}
+		drawColorRow(s, active, tok, info.Label)
+	}
+	native.EndDisabled()
+}
+
+// drawColorRow draws one token's swatch+picker; on change it recolors the active theme.
+// The label carries a hidden "##token" suffix so each row has a stable, unique ImGui id.
+func drawColorRow(s *app.Session, active *theme.Theme, tok types.ThemeToken, label string) {
+	c := active.Color(tok).Array()
+	if native.ColorEdit4(label+"##"+string(tok), &c) {
+		s.Themes().EditActiveColor(tok, types.Rgba{R: c[0], G: c[1], B: c[2], A: c[3]})
+	}
+}
+
+// errText renders an action error for the status line ("" on success).
+func errText(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+// bufString reads the NUL-terminated text ImGui wrote into an InputText buffer.
+func bufString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+// clearBuf zeroes an InputText buffer (so the field empties after a successful action).
+func clearBuf(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -33,6 +33,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	if icons == nil {
 		icons = newIconCache(win) // lazily bind the icon cache to this window
 	}
+	applyThemeIfChanged(win, s) // restyle ImGui + overlays when the theme changed (live preview)
 	handleKeyboard(s)
 	activated := drawMenuBar(s)
 	dockID := native.DockSpaceOverMain()
@@ -568,9 +569,6 @@ func toolPreview(s *app.Session) (renderer.DrawItem, bool) {
 	acc.polyline(s.ActiveSketch().Plane(), pts, closed)
 	return renderer.DrawItem{Primitive: renderer.Lines, Positions: acc.pos, Indices: acc.idx, Color: previewColor}, true
 }
-
-// previewColor is the bright rubber-band color for in-progress sketch geometry.
-var previewColor = [4]float32{0.95, 0.95, 1, 1}
 
 const (
 	viewportNear = 0.1

--- a/head/ui/dimension_overlay.go
+++ b/head/ui/dimension_overlay.go
@@ -20,13 +20,6 @@ import (
 // clicking a label re-opens the dimension's value editor (drawDimensionPopup). The
 // geometry + labels come pre-computed from app.Session.SketchDimensions (headless).
 
-var (
-	// dimensionColor is the green used for driving dimension lines (Inventor-like);
-	// drivenColor marks reference (driven) dimensions distinctly.
-	dimensionColor       = [4]float32{0.45, 0.85, 0.5, 1}
-	dimensionDrivenColor = [4]float32{0.55, 0.7, 0.95, 1}
-)
-
 // dimensionLines accumulates every dimension's segments (mapped plane→model through the
 // sketch plane) into colored line items, driving and driven dimensions kept apart.
 func dimensionLines(plane sketch.Plane, views []app.DimensionView) []renderer.DrawItem {

--- a/head/ui/grid_overlay.go
+++ b/head/ui/grid_overlay.go
@@ -59,9 +59,3 @@ func appendGrid(items []renderer.DrawItem, acc *segAccum, color [4]float32) []re
 		Primitive: renderer.Lines, Positions: acc.pos, Indices: acc.idx, Color: color,
 	})
 }
-
-var (
-	gridMinorColor = [4]float32{0.27, 0.29, 0.33, 1}
-	gridMajorColor = [4]float32{0.4, 0.43, 0.48, 1}
-	gridAxisColor  = [4]float32{0.55, 0.6, 0.68, 1}
-)

--- a/head/ui/highlight.go
+++ b/head/ui/highlight.go
@@ -14,10 +14,6 @@ import (
 // a viewport pick, which sets the same selection, lights up the same body). Work-plane
 // and sketch highlight are handled by their own overlays (planesOverlay / sketchOverlay).
 
-// selectionHighlight is the cyan used for a selected body, matching the selected-plane
-// color so selection reads consistently across the view.
-var selectionHighlight = [4]float32{0.3, 0.85, 1, 1}
-
 // highlightSelection recolors the draw items belonging to the selected body/bodies. It
 // returns the (in-place mutated) list for call-site convenience; the list is rebuilt
 // each frame so the mutation is not observable across frames.

--- a/head/ui/icon_cache.go
+++ b/head/ui/icon_cache.go
@@ -9,10 +9,9 @@ import (
 	"github.com/Oblikovati/oblikovati/head/internal/native"
 )
 
-// iconTint is the color every ribbon glyph is drawn with. The icons are rasterized as
-// white alpha masks, so this single tint recolors all of them — the hook a future
-// theme manager sets. Default: a light gray that reads on the dark chrome.
-var iconTint = [4]float32{0.85, 0.87, 0.90, 1}
+// iconTint (the color every ribbon glyph is drawn with) is now theme-driven and lives in
+// theme_apply.go: icons are rasterized as white alpha masks, so that single tint recolors
+// all of them when the theme changes (ADR-0021).
 
 // Rasterization sizes per button style. Small icons fill the dense sketch tool grids;
 // large icons head a panel (Inventor's two button sizes).

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -39,12 +39,6 @@ func planeColor(wp, selected, hovered *feature.WorkPlane) [4]float32 {
 	}
 }
 
-var (
-	faintPlaneColor    = [4]float32{0.45, 0.5, 0.6, 1}
-	hoverPlaneColor    = [4]float32{1, 0.7, 0.2, 1}
-	selectedPlaneColor = [4]float32{0.3, 0.85, 1, 1}
-)
-
 // planeBorder builds the border-and-diagonals line item of a work plane's display
 // square, mapped from the plane's 2D frame into model space.
 func planeBorder(wp *feature.WorkPlane, color [4]float32) renderer.DrawItem {

--- a/head/ui/preferences_window.go
+++ b/head/ui/preferences_window.go
@@ -13,20 +13,34 @@ import (
 // not model state, so it lives here in the head.
 var showPreferences bool
 
-// drawPreferencesWindow renders the Preferences window when open: the sketch-grid
-// spacing (in the document's units), visibility, and major-line interval. Edits write
-// straight back to the session's settings, so the grid updates next frame.
+// drawPreferencesWindow renders the Preferences window when open, as tabs: Sketch Grid
+// (spacing in the document's units, visibility, major-line interval) and Appearance (the
+// theme picker + editor). Edits write straight back to the session, so the grid and theme
+// update next frame.
 func drawPreferencesWindow(s *app.Session) {
 	if !showPreferences {
 		return
 	}
-	if native.Begin("Preferences") {
-		native.SeparatorText("Sketch Grid")
-		editGridSpacing(s)
-		editGridVisibility(s)
-		editGridMajor(s)
+	native.SetNextWindowSizeOnce(640, 480) // sensible default; the user can still resize
+	if native.Begin("Preferences") && native.BeginTabBar("##prefs-tabs") {
+		if native.BeginTabItem("Sketch Grid") {
+			drawGridTab(s)
+			native.EndTabItem()
+		}
+		if native.BeginTabItem("Theme") {
+			drawAppearanceTab(s)
+			native.EndTabItem()
+		}
+		native.EndTabBar()
 	}
 	native.End()
+}
+
+// drawGridTab renders the sketch-grid preference fields.
+func drawGridTab(s *app.Session) {
+	editGridSpacing(s)
+	editGridVisibility(s)
+	editGridMajor(s)
 }
 
 // editGridSpacing draws the spacing field labeled with the document's length unit.

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -84,16 +84,6 @@ func sketchOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool, candida
 	return items
 }
 
-var (
-	// sketchColor is the amber wireframe used for sketch geometry (Inventor-like).
-	sketchColor = [4]float32{1, 0.78, 0.2, 1}
-	// sketchSelectedColor highlights selected / picked sketch entities (cyan).
-	sketchSelectedColor = [4]float32{0.3, 0.9, 1, 1}
-	// sketchCandidateColor highlights the valid hover target for the active constraint
-	// tool (green), so the user sees which geometry is selectable.
-	sketchCandidateColor = [4]float32{0.4, 1, 0.45, 1}
-)
-
 // sketchSegments is the polyline resolution for sampling sketch curves.
 const sketchSegments = 64
 

--- a/head/ui/snap_glyph.go
+++ b/head/ui/snap_glyph.go
@@ -22,13 +22,8 @@ const (
 	triBaseDrop      = 0.5       // sin(30°)
 )
 
-var (
-	// snapGlyphColor is the bright marker drawn under the cursor at a snap point.
-	snapGlyphColor = [4]float32{1, 1, 1, 1}
-	// pointMarkerColor marks placed sketch points so a 1px point is visible; it matches
-	// the sketch wireframe amber so points read as part of the geometry.
-	pointMarkerColor = sketchColor
-)
+// snapGlyphColor (the cursor snap marker) and pointMarkerColor (placed sketch points,
+// matching the sketch wireframe) are theme-driven and declared in theme_apply.go.
 
 // snapGlyph builds the snap marker at the snapped point: a square for an endpoint, a
 // triangle for a line midpoint, a cross for an on-curve (edge) snap. hWorld is the

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -1,0 +1,124 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/api/contract"
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/theme"
+)
+
+// Theme-driven colors for the viewport overlays and ribbon icons. They live here in one
+// place (rather than scattered across the overlay files) because they all share one
+// owner: the active theme. They are seeded from the Dark built-in so they hold correct
+// values before the first applyThemeIfChanged and in any headless head test, then
+// overwritten from the active theme whenever it changes (ADR-0021). The overlay files
+// read these vars by name exactly as before.
+var (
+	gridMinorColor, gridMajorColor, gridAxisColor          [4]float32
+	sketchColor, sketchSelectedColor, sketchCandidateColor [4]float32
+	previewColor                                           [4]float32 // rubber-band preview
+	dimensionColor, dimensionDrivenColor                   [4]float32
+	snapGlyphColor, pointMarkerColor                       [4]float32
+	faintPlaneColor, hoverPlaneColor, selectedPlaneColor   [4]float32
+	selectionHighlight                                     [4]float32 // picked-body highlight
+	iconTint                                               [4]float32 // ribbon glyph tint
+	windowClearColor                                       [3]float32 // swapchain (chrome) clear
+)
+
+func init() { refreshThemeColors(theme.DefaultDark()) }
+
+// appliedThemeRevision is the library revision last pushed into Dear ImGui and the color
+// vars, so applyThemeIfChanged is a cheap no-op on the frames the theme has not changed.
+var appliedThemeRevision uint64
+
+// applyThemeIfChanged re-styles the UI from the active theme when it has changed since
+// the last frame — pushing the chrome colors into Dear ImGui's persistent style (set
+// once per change, not per widget), refreshing the overlay/icon color vars, and updating
+// the 3D viewport's clear color. Called at the top of DrawChrome; this is the live-preview
+// hook (a theme switch or a color edit bumps the library revision).
+func applyThemeIfChanged(win *native.Window, s *app.Session) {
+	rev := s.ThemeRevision()
+	if rev == appliedThemeRevision {
+		return
+	}
+	appliedThemeRevision = rev
+	active := s.Theme()
+	applyChromeStyle(active)
+	refreshThemeColors(active)
+	vp := active.Color(types.TokenViewportBg)
+	win.SetViewportClear(vp.R, vp.G, vp.B)
+}
+
+// refreshThemeColors copies the active theme's overlay/icon colors into the package vars
+// the overlay builders read each frame.
+func refreshThemeColors(t contract.Theme) {
+	arr := func(tok types.ThemeToken) [4]float32 { return t.Color(tok).Array() }
+	gridMinorColor = arr(types.TokenGridMinor)
+	gridMajorColor = arr(types.TokenGridMajor)
+	gridAxisColor = arr(types.TokenGridAxis)
+	sketchColor = arr(types.TokenSketchGeometry)
+	sketchSelectedColor = arr(types.TokenSketchSelected)
+	sketchCandidateColor = arr(types.TokenSketchCandidate)
+	previewColor = arr(types.TokenSketchPreview)
+	dimensionColor = arr(types.TokenDimensionDriving)
+	dimensionDrivenColor = arr(types.TokenDimensionDriven)
+	snapGlyphColor = arr(types.TokenSnapGlyph)
+	pointMarkerColor = sketchColor // placed points match the sketch wireframe
+	faintPlaneColor = arr(types.TokenPlaneFaint)
+	hoverPlaneColor = arr(types.TokenPlaneHover)
+	selectedPlaneColor = arr(types.TokenPlaneSelected)
+	selectionHighlight = arr(types.TokenSelectionHighlight)
+	iconTint = arr(types.TokenIconTint)
+	c := t.Color(types.TokenChromeWindowBg)
+	windowClearColor = [3]float32{c.R, c.G, c.B}
+}
+
+// WindowClearColor is the themed background the frame loop clears the swapchain to (the
+// area behind/around the docked panels). The main loop passes it to Window.EndFrame.
+func WindowClearColor() (r, g, b float32) {
+	return windowClearColor[0], windowClearColor[1], windowClearColor[2]
+}
+
+// chromeBinding maps each chrome token to the Dear ImGui color slots it drives, by name
+// (native.SetStyleColor resolves the name to the version-specific enum). One token may
+// feed several slots, which is how a small palette styles the whole shell — e.g. the
+// accent paints the active tab, checkmark, slider grab, and selection. Each ImGui slot
+// appears under exactly one token, so apply order does not matter.
+var chromeBinding = map[types.ThemeToken][]string{
+	types.TokenChromeWindowBg:      {"WindowBg"},
+	types.TokenChromePanelBg:       {"ChildBg"},
+	types.TokenChromePopupBg:       {"PopupBg"},
+	types.TokenChromeMenuBarBg:     {"MenuBarBg"},
+	types.TokenChromeHeaderBg:      {"TitleBg", "TitleBgCollapsed", "Header"},
+	types.TokenChromeText:          {"Text"},
+	types.TokenChromeTextDisabled:  {"TextDisabled"},
+	types.TokenChromeBorder:        {"Border", "Separator"},
+	types.TokenChromeControlBg:     {"FrameBg"},
+	types.TokenChromeControlHover:  {"FrameBgHovered", "SeparatorHovered"},
+	types.TokenChromeControlActive: {"FrameBgActive"},
+	types.TokenChromeButton:        {"Button", "Tab", "TabDimmed"},
+	types.TokenChromeButtonHover:   {"ButtonHovered"},
+	types.TokenChromeButtonActive:  {"ButtonActive", "TabDimmedSelected"},
+	types.TokenChromeAccent: {
+		"TitleBgActive", "TabSelected", "TabHovered", "CheckMark",
+		"SliderGrab", "SliderGrabActive", "HeaderHovered", "HeaderActive",
+		"SeparatorActive", "ScrollbarGrabActive", "TextSelectedBg",
+	},
+	types.TokenChromeScrollbar: {"ScrollbarBg", "ScrollbarGrab", "ScrollbarGrabHovered"},
+}
+
+// applyChromeStyle pushes every chrome token's color into the ImGui slots it binds to.
+func applyChromeStyle(t contract.Theme) {
+	for tok, slots := range chromeBinding {
+		c := t.Color(tok).Array()
+		for _, slot := range slots {
+			native.SetStyleColor(slot, c)
+		}
+	}
+}

--- a/head/ui/theme_apply_test.go
+++ b/head/ui/theme_apply_test.go
@@ -1,0 +1,53 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/theme"
+)
+
+// TestChromeBindingSlotsUnique guards the apply contract that each Dear ImGui color slot
+// is driven by exactly one token — overlap would make the last-applied token silently win
+// and the result order-dependent.
+func TestChromeBindingSlotsUnique(t *testing.T) {
+	seen := map[string]types.ThemeToken{}
+	for tok, slots := range chromeBinding {
+		for _, slot := range slots {
+			if other, dup := seen[slot]; dup {
+				t.Errorf("ImGui slot %q bound by both %q and %q", slot, other, tok)
+			}
+			seen[slot] = tok
+		}
+	}
+}
+
+// TestRefreshThemeColorsReadsActiveTheme proves the overlay color vars are sourced from
+// the active theme, not frozen at their seeded Dark values: switching to Light must change
+// the sketch-geometry color.
+func TestRefreshThemeColorsReadsActiveTheme(t *testing.T) {
+	refreshThemeColors(theme.DefaultDark())
+	dark := sketchColor
+	refreshThemeColors(theme.DefaultLight())
+	if sketchColor == dark {
+		t.Errorf("sketchColor unchanged after switching Dark->Light (%v); not reading the theme", sketchColor)
+	}
+	// pointMarkerColor must track sketchColor (placed points match the wireframe).
+	if pointMarkerColor != sketchColor {
+		t.Errorf("pointMarkerColor %v != sketchColor %v", pointMarkerColor, sketchColor)
+	}
+	refreshThemeColors(theme.DefaultDark()) // restore the package default for other tests
+}
+
+func TestBufString(t *testing.T) {
+	buf := make([]byte, 16)
+	copy(buf, "My Dark\x00garbage")
+	if got := bufString(buf); got != "My Dark" {
+		t.Errorf("bufString = %q, want \"My Dark\"", got)
+	}
+}

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-066-theme-contract.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-066-theme-contract.md
@@ -1,0 +1,39 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-066
+title: Theme public contract (api)
+status: done
+estimate: S
+---
+
+# PBI-066 — Theme public contract (api)
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Define the Apache-2.0 public surface for UI themes, once, in `Oblikovati.API`.
+
+## Scope / work
+
+- `api/types`: `Rgba` (0..1 RGBA with `ParseHex`/`Hex`/`Array`), `ThemeToken` string
+  enum (Chrome / Viewport 2D / Gizmos 3D / Icons) + `AllThemeTokens()`, `ThemeKind`.
+- `api/contract`: `Theme` interface (`Name`, `Kind`, `Color`).
+- `api/wire`: `ThemeView`, `ThemeSummary`, `ListThemesResult`, `MethodThemeActive`,
+  `MethodThemeList`.
+- `api/client`: typed `Theme` group (`Active`, `List`).
+
+## API contracts
+
+- `types.ThemeToken`, `types.Rgba`, `types.ThemeKind`, `contract.Theme`, `wire.ThemeView`,
+  `client.Theme`.
+
+## Acceptance criteria
+
+- `go build ./...` + tests green in the api module; hex parse round-trips; token list has
+  no duplicates.
+
+## Depends on
+
+ADR-0018, ADR-0021.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-067-core-theme-package.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-067-core-theme-package.md
@@ -1,0 +1,41 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-067
+title: Core theme package — palette, defaults, library
+status: done
+estimate: M
+---
+
+# PBI-067 — Core theme package: palette, defaults, library
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Implement the GPL theme model: palettes, the built-in Dark/Light themes, and the library
+with an active selection and a live-apply revision counter.
+
+## Scope / work
+
+- `theme/token.go`: type aliases + editor metadata (`TokenInfo`, `Group`, `InfoFor`).
+- `theme/palette.go`: `Palette` (full snapshot), `Color`/`Clone`/`Hex`/`NewPalette`.
+- `theme/defaults.go`: `DefaultDark` (reproduces the pre-theming hardcoded colors) /
+  `DefaultLight` / `Builtins`.
+- `theme/theme.go`: `Theme` satisfying `contract.Theme`; read-only built-ins; `Duplicate`.
+- `theme/library.go`: built-ins + customs, active selection, monotonic `Revision`,
+  `SetActive` / `Duplicate` / `Remove` / `EditActiveColor`.
+
+## API contracts
+
+- Implements `contract.Theme` (compile-time asserted).
+
+## Acceptance criteria
+
+- Both built-ins define every token (`TestDefaultsComplete`); built-ins are immutable;
+  duplicate is an independent snapshot; select/edit bump the revision; unknown active name
+  falls back to Dark.
+
+## Depends on
+
+PBI-066.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-068-theme-persistence.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-068-theme-persistence.md
@@ -1,0 +1,38 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-068
+title: Custom theme persistence (user config dir)
+status: done
+estimate: S
+---
+
+# PBI-068 — Custom theme persistence (user config dir)
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Load and save custom themes and the selected-theme preference under the per-user config
+directory, as readable YAML.
+
+## Scope / work
+
+- `theme/store.go`: `Store` over a `FileSystem` seam; `Load` (customs + active),
+  `SaveTheme`, `RemoveTheme`, `SaveActive`; `DefaultRoot` via `os.UserConfigDir`; YAML via
+  `persistence/yamlcodec`.
+- `theme/os_fs.go`: `OSFileSystem` (creates dirs on write; tolerant of a missing dir/file).
+
+## API contracts
+
+- None (internal); reuses `persistence/yamlcodec`.
+
+## Acceptance criteria
+
+- Save→Load round-trips a custom theme's name/kind/colors; first run (no dir) loads empty;
+  built-ins are refused for saving; theme files are human-readable YAML. Tested with an
+  in-memory fake FS (no real disk IO).
+
+## Depends on
+
+PBI-067, ADR-0020.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-069-session-router.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-069-session-router.md
@@ -1,0 +1,37 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-069
+title: Session hooks & router theme.* methods
+status: done
+estimate: S
+---
+
+# PBI-069 — Session hooks & router theme.* methods
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Hang the theme library off the session and serve the read-only theme methods over the
+wire router.
+
+## Scope / work
+
+- `app/appearance.go`: `Session.Themes` / `Theme` / `ThemeRevision` / `LoadThemes` /
+  `SetActiveTheme` / `DuplicateTheme` / `DeleteTheme` / `SaveActiveTheme` (persist via the
+  attached store; built-in-only & deterministic without one).
+- `addin/router/theme.go`: `themeActive` / `themeList`; registered in `router.go`.
+
+## API contracts
+
+- Serves `wire.MethodThemeActive`, `wire.MethodThemeList`.
+
+## Acceptance criteria
+
+- `theme.active` returns the active theme with a hex value for every token; `theme.list`
+  flags the active theme; a duplicated custom appears and becomes active.
+
+## Depends on
+
+PBI-067, PBI-068.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-070-native-style-verbs.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-070-native-style-verbs.md
@@ -1,0 +1,36 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-070
+title: Native ImGui style/picker/combo verbs
+status: done
+estimate: S
+---
+
+# PBI-070 — Native ImGui style/picker/combo verbs
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Add the Dear ImGui verbs theming needs to the native seam.
+
+## Scope / work
+
+- `head/internal/native` (C++ `imgui_wrap.cpp` + Go `imgui.go`):
+  `SetStyleColor(name, rgba)` mapping an ImGui color **name** → enum (version-robust),
+  `ColorEdit4`, `BeginCombo` / `EndCombo`.
+- `head/internal/native/viewport.{cpp,go}`: `SetViewportClear` (themed 3D pass clear).
+
+## API contracts
+
+- None (internal native binding).
+
+## Acceptance criteria
+
+- Head builds with cgo; `SetStyleColor` with an unknown name is a no-op; existing in-window
+  tests stay green.
+
+## Depends on
+
+ADR-0004.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-071-theme-apply-layer.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-071-theme-apply-layer.md
@@ -1,0 +1,40 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-071
+title: Head apply layer & themed overlays
+status: done
+estimate: M
+---
+
+# PBI-071 — Head apply layer & themed overlays
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Drive the whole shell's colors from the active theme, live.
+
+## Scope / work
+
+- `head/ui/theme_apply.go`: centralizes the overlay/icon color vars (seeded from Dark);
+  `chromeBinding` (token → ImGui slot names); `applyThemeIfChanged` (re-push style +
+  refresh vars + viewport clear when the revision changes); `WindowClearColor`.
+- Remove the hardcoded color vars from `grid_overlay.go`, `sketch_overlay.go`,
+  `plane_overlay.go`, `dimension_overlay.go`, `highlight.go`, `snap_glyph.go`,
+  `chrome.go`, `icon_cache.go`.
+- `chrome.go` calls `applyThemeIfChanged`; `main.go` clears to `WindowClearColor`.
+
+## API contracts
+
+- None (head-internal).
+
+## Acceptance criteria
+
+- Default look unchanged from before theming; switching Dark↔Light recolors chrome,
+  overlays, gizmos, icons, and both clears next frame. Each ImGui slot is bound by exactly
+  one token; overlay vars read the active theme (unit-tested without a window).
+
+## Depends on
+
+PBI-069, PBI-070.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-072-appearance-tab.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/PBI-072-appearance-tab.md
@@ -1,0 +1,38 @@
+---
+milestone: M05
+feature: F06
+pbi: PBI-072
+title: Preferences Appearance tab
+status: done
+estimate: S
+---
+
+# PBI-072 — Preferences Appearance tab
+
+**Milestone:** M05 · **Feature:** F06 UI Theming & Appearance
+
+## Goal
+
+Give the user a Preferences ▸ Appearance pane to pick, create, and recolor themes with a
+live preview.
+
+## Scope / work
+
+- `head/ui/preferences_window.go`: tabbed window (Sketch Grid + Appearance).
+- `head/ui/appearance_tab.go`: theme selector combo; duplicate-to-custom (named); per-token
+  `ColorEdit4` grouped by area, disabled for built-ins; Save / Delete for customs; status
+  line for action errors.
+
+## API contracts
+
+- None (head-internal; drives `Session` theme methods).
+
+## Acceptance criteria
+
+- Selecting a theme restyles immediately; duplicating a built-in creates an editable custom
+  and activates it; editing a swatch updates the UI live; Save persists; reopening the app
+  restores the custom theme and selection.
+
+## Depends on
+
+PBI-071.

--- a/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/_feature.md
+++ b/implementation-plan/M05-ui-commands-addins/F06-theming-appearance/_feature.md
@@ -1,0 +1,61 @@
+---
+milestone: M05
+feature: F06
+name: UI Theming & Appearance
+status: in-progress
+---
+
+# M05 · F06 — UI Theming & Appearance
+
+A ThemeManager that styles the whole application shell — window, menus, ribbon icons,
+viewport 2D overlays, and 3D gizmos — from a curated set of semantic color tokens. Ships
+a Light and a Dark built-in; the user can duplicate one into an editable custom theme and
+recolor any token with a color picker, with the UI updating live. Custom themes persist
+per user as YAML. Excludes 3D body appearance (the future material/appearance subsystem).
+
+See [ADR-0021](../../../architecture/decisions/ADR-0021-ui-theming-semantic-tokens.md).
+
+## In scope
+
+- Semantic token palette (`api/types.ThemeToken`) grouped Chrome / Viewport 2D / Gizmos
+  3D / Icons; `Rgba` value type; built-in Dark + Light palettes.
+- Read-only public surface: `contract.Theme`, `theme.active` / `theme.list` wire methods,
+  typed `client.Theme` group.
+- Core `theme/` package: palette, library with active selection + revision counter,
+  YAML persistence to the user config dir behind a filesystem seam.
+- `Session` integration; `addin/router` `theme.*` handlers.
+- Head apply layer: token → Dear ImGui slot binding (by name), overlay/icon color
+  refresh, themed viewport + swapchain clear; native `SetStyleColor` / `ColorEdit4` /
+  `BeginCombo` verbs.
+- Preferences ▸ Appearance tab: theme selector, duplicate, per-token color picker with
+  live preview, save, delete.
+
+## Out of scope
+
+- 3D body/material appearance (later subsystem).
+- Add-in-authored or add-in-mutated themes (read-only access only).
+- Font/spacing/sizing theming (colors only for v1).
+
+## Key API contracts delivered
+
+- `types.ThemeToken`, `types.Rgba`, `types.ThemeKind`
+- `contract.Theme`
+- `wire.ThemeView`, `wire.ThemeSummary`, `wire.ListThemesResult`,
+  `MethodThemeActive`, `MethodThemeList`
+- `client.Theme`
+
+## Depends on
+
+F02 (command framework), F03 (ribbon/browser/docking chrome), ADR-0018, ADR-0020.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-066](PBI-066-theme-contract.md) | Theme public contract (api) |
+| [PBI-067](PBI-067-core-theme-package.md) | Core theme package: palette, defaults, library |
+| [PBI-068](PBI-068-theme-persistence.md) | Custom theme persistence (user config dir) |
+| [PBI-069](PBI-069-session-router.md) | Session hooks & router theme.* methods |
+| [PBI-070](PBI-070-native-style-verbs.md) | Native ImGui style/picker/combo verbs |
+| [PBI-071](PBI-071-theme-apply-layer.md) | Head apply layer & themed overlays |
+| [PBI-072](PBI-072-appearance-tab.md) | Preferences Appearance tab |

--- a/theme/defaults.go
+++ b/theme/defaults.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/api/types"
+)
+
+// DefaultDark is the shipped dark theme. Its viewport/overlay/icon colors reproduce the
+// values the head hardcoded before theming (so the default look is unchanged); the
+// chrome colors are a coherent dark Dear ImGui palette. Built fresh on each call so the
+// library holds an independent copy.
+func DefaultDark() *Theme { return New("Dark", KindDark, mustPalette(darkHex)) }
+
+// DefaultLight is the shipped light theme — the same token set tuned for a light shell.
+func DefaultLight() *Theme { return New("Light", KindLight, mustPalette(lightHex)) }
+
+// Builtins returns the two shipped themes, dark first (the out-of-the-box default).
+func Builtins() []*Theme { return []*Theme{DefaultDark(), DefaultLight()} }
+
+// darkHex reproduces the pre-theming hardcoded overlay/icon colors (head/ui) and pairs
+// them with a dark chrome palette. See ADR-0021 for the token meanings.
+var darkHex = map[string]string{
+	// Chrome
+	string(types.TokenChromeWindowBg):      "#1e2127ff",
+	string(types.TokenChromePanelBg):       "#262a31ff",
+	string(types.TokenChromePopupBg):       "#1a1c22ff",
+	string(types.TokenChromeMenuBarBg):     "#15171cff",
+	string(types.TokenChromeHeaderBg):      "#2a2f38ff",
+	string(types.TokenChromeText):          "#d9dce1ff",
+	string(types.TokenChromeTextDisabled):  "#6b7280ff",
+	string(types.TokenChromeBorder):        "#3a3f49ff",
+	string(types.TokenChromeControlBg):     "#262a31ff",
+	string(types.TokenChromeControlHover):  "#2f343cff",
+	string(types.TokenChromeControlActive): "#3a414bff",
+	string(types.TokenChromeButton):        "#2a2f38ff",
+	string(types.TokenChromeButtonHover):   "#353b45ff",
+	string(types.TokenChromeButtonActive):  "#454d59ff",
+	string(types.TokenChromeAccent):        "#3fb6ffff",
+	string(types.TokenChromeScrollbar):     "#3a3f49ff",
+	// Viewport 2D (pre-theming head values)
+	string(types.TokenViewportBg):       "#1a1c21ff", // viewport.cpp clear {0.10,0.11,0.13}
+	string(types.TokenGridMinor):        "#454a54ff", // grid_overlay.go gridMinorColor
+	string(types.TokenGridMajor):        "#666e7aff", // grid_overlay.go gridMajorColor
+	string(types.TokenGridAxis):         "#8c99adff", // grid_overlay.go gridAxisColor
+	string(types.TokenSketchGeometry):   "#ffc733ff", // sketch_overlay.go sketchColor
+	string(types.TokenSketchSelected):   "#4de6ffff", // sketch_overlay.go sketchSelectedColor
+	string(types.TokenSketchCandidate):  "#66ff73ff", // sketch_overlay.go sketchCandidateColor
+	string(types.TokenSketchPreview):    "#f2f2ffff", // chrome.go previewColor
+	string(types.TokenDimensionDriving): "#73d980ff", // dimension_overlay.go dimensionColor
+	string(types.TokenDimensionDriven):  "#8cb3f2ff", // dimension_overlay.go dimensionDrivenColor
+	string(types.TokenSnapGlyph):        "#ffffffff", // snap_glyph.go snapGlyphColor
+	// Gizmos 3D (pre-theming head values)
+	string(types.TokenPlaneFaint):         "#738099ff", // plane_overlay.go faintPlaneColor
+	string(types.TokenPlaneHover):         "#ffb333ff", // plane_overlay.go hoverPlaneColor
+	string(types.TokenPlaneSelected):      "#4dd9ffff", // plane_overlay.go selectedPlaneColor
+	string(types.TokenSelectionHighlight): "#4dd9ffff", // highlight.go selectionHighlight
+	// Icons (pre-theming head values)
+	string(types.TokenIconTint):     "#d9dee6ff", // icon_cache.go iconTint
+	string(types.TokenIconDisabled): "#6b7280ff",
+}
+
+// lightHex is a light-shell palette over the same token set.
+var lightHex = map[string]string{
+	// Chrome
+	string(types.TokenChromeWindowBg):      "#f3f4f6ff",
+	string(types.TokenChromePanelBg):       "#ffffffff",
+	string(types.TokenChromePopupBg):       "#ffffffff",
+	string(types.TokenChromeMenuBarBg):     "#e6e8ebff",
+	string(types.TokenChromeHeaderBg):      "#dfe3e8ff",
+	string(types.TokenChromeText):          "#1c1f24ff",
+	string(types.TokenChromeTextDisabled):  "#9aa0a8ff",
+	string(types.TokenChromeBorder):        "#c7ccd3ff",
+	string(types.TokenChromeControlBg):     "#ffffffff",
+	string(types.TokenChromeControlHover):  "#eceef1ff",
+	string(types.TokenChromeControlActive): "#dde1e6ff",
+	string(types.TokenChromeButton):        "#e6e8ebff",
+	string(types.TokenChromeButtonHover):   "#dde1e6ff",
+	string(types.TokenChromeButtonActive):  "#cfd4daff",
+	string(types.TokenChromeAccent):        "#1f7fd6ff",
+	string(types.TokenChromeScrollbar):     "#c7ccd3ff",
+	// Viewport 2D
+	string(types.TokenViewportBg):       "#e8eaedff",
+	string(types.TokenGridMinor):        "#c2c7cfff",
+	string(types.TokenGridMajor):        "#a8aeb8ff",
+	string(types.TokenGridAxis):         "#7f8794ff",
+	string(types.TokenSketchGeometry):   "#c77f00ff",
+	string(types.TokenSketchSelected):   "#0a84c7ff",
+	string(types.TokenSketchCandidate):  "#1faa3aff",
+	string(types.TokenSketchPreview):    "#5a5a99ff",
+	string(types.TokenDimensionDriving): "#2f9e45ff",
+	string(types.TokenDimensionDriven):  "#3f66c7ff",
+	string(types.TokenSnapGlyph):        "#1c1f24ff",
+	// Gizmos 3D
+	string(types.TokenPlaneFaint):         "#8c99adff",
+	string(types.TokenPlaneHover):         "#d98a00ff",
+	string(types.TokenPlaneSelected):      "#0a84c7ff",
+	string(types.TokenSelectionHighlight): "#0a84c7ff",
+	// Icons
+	string(types.TokenIconTint):     "#3a3f49ff",
+	string(types.TokenIconDisabled): "#aeb4bdff",
+}
+
+// mustPalette builds a palette from a built-in hex map, panicking with the offending
+// color if a literal is malformed — these maps are authored constants, so a bad value
+// is a programming error caught by [TestDefaultsComplete], not a runtime condition.
+func mustPalette(hex map[string]string) Palette {
+	p, err := NewPalette(hex)
+	if err != nil {
+		panic(fmt.Sprintf("theme: malformed built-in palette: %v", err))
+	}
+	return p
+}

--- a/theme/library.go
+++ b/theme/library.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import "fmt"
+
+// Library is the set of themes available in a session: the two built-ins followed by the
+// user's customs, with one active selection. A monotonic revision counter is bumped on
+// every change that affects the rendered look (select, edit, add, remove) so the head can
+// cheaply detect "theme changed since I last applied it" and restyle on the next frame —
+// the hook behind live preview (ADR-0021).
+type Library struct {
+	themes   []*Theme // built-ins first (Dark, Light), then customs in load order
+	active   string   // name of the active theme
+	revision uint64
+}
+
+// NewLibrary builds a library from the loaded customs and the persisted active-theme
+// name. The built-ins are always present and first; an unknown or empty active name
+// falls back to Dark, so a corrupt preference never leaves the UI unstyled.
+func NewLibrary(customs []*Theme, active string) *Library {
+	lib := &Library{themes: Builtins(), active: active, revision: 1}
+	for _, c := range customs {
+		lib.themes = append(lib.themes, c)
+	}
+	if _, ok := lib.find(active); !ok {
+		lib.active = "Dark"
+	}
+	return lib
+}
+
+// Themes returns every theme in display order (built-ins then customs). Callers must not
+// mutate the slice.
+func (l *Library) Themes() []*Theme { return l.themes }
+
+// Customs returns just the user themes — what [Store.Save] persists.
+func (l *Library) Customs() []*Theme {
+	var out []*Theme
+	for _, t := range l.themes {
+		if t.Kind() == KindCustom {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// Active returns the active theme (never nil; the constructor guarantees a valid active).
+func (l *Library) Active() *Theme {
+	t, _ := l.find(l.active)
+	return t
+}
+
+// ActiveName returns the active theme's name (the value [Store] persists).
+func (l *Library) ActiveName() string { return l.active }
+
+// Revision returns the change counter; compare it to a previously-seen value to decide
+// whether to re-apply the theme.
+func (l *Library) Revision() uint64 { return l.revision }
+
+// SetActive switches the active theme by name, bumping the revision. It is a no-op
+// (no bump) for an unknown name or the already-active one.
+func (l *Library) SetActive(name string) {
+	if name == l.active {
+		return
+	}
+	if _, ok := l.find(name); !ok {
+		return
+	}
+	l.active = name
+	l.revision++
+}
+
+// Duplicate creates a custom full-snapshot copy of base under newName, adds it, makes it
+// active, and bumps the revision. It errors on an unknown base or a name already in use.
+func (l *Library) Duplicate(base, newName string) (*Theme, error) {
+	src, ok := l.find(base)
+	if !ok {
+		return nil, fmt.Errorf("theme: duplicate base %q not found", base)
+	}
+	if _, taken := l.find(newName); taken || newName == "" {
+		return nil, fmt.Errorf("theme: name %q is empty or already in use", newName)
+	}
+	dup := src.Duplicate(newName)
+	l.themes = append(l.themes, dup)
+	l.active = newName
+	l.revision++
+	return dup, nil
+}
+
+// Remove deletes a custom theme by name, bumping the revision. It errors when the name is
+// unknown or names a built-in (built-ins cannot be removed). Removing the active theme
+// reselects Dark.
+func (l *Library) Remove(name string) error {
+	t, ok := l.find(name)
+	if !ok {
+		return fmt.Errorf("theme: remove %q not found", name)
+	}
+	if t.Kind() != KindCustom {
+		return fmt.Errorf("theme: built-in %q cannot be removed", name)
+	}
+	l.themes = without(l.themes, name)
+	if l.active == name {
+		l.active = "Dark"
+	}
+	l.revision++
+	return nil
+}
+
+// EditActiveColor recolors one token of the active theme and bumps the revision (the
+// live-preview path). It is a no-op when the active theme is a built-in (read-only).
+func (l *Library) EditActiveColor(token Token, c Rgba) {
+	a := l.Active()
+	if !a.Kind().Editable() {
+		return
+	}
+	a.SetColor(token, c)
+	l.revision++
+}
+
+// find returns the named theme and whether it exists.
+func (l *Library) find(name string) (*Theme, bool) {
+	for _, t := range l.themes {
+		if t.Name() == name {
+			return t, true
+		}
+	}
+	return nil, false
+}
+
+// without returns themes with the named one removed (order preserved).
+func without(themes []*Theme, name string) []*Theme {
+	out := themes[:0:0]
+	for _, t := range themes {
+		if t.Name() != name {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/theme/os_fs.go
+++ b/theme/os_fs.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// OSFileSystem is the production [FileSystem]: real files under the user config dir.
+type OSFileSystem struct{}
+
+// ReadDir returns the base names of the files in dir. A missing directory (first run)
+// yields no names and no error, per the [FileSystem] contract.
+func (OSFileSystem) ReadDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// ReadFile reads a file's contents.
+func (OSFileSystem) ReadFile(path string) ([]byte, error) { return os.ReadFile(path) }
+
+// WriteFile writes data to path, creating parent directories as needed (0o755 dirs,
+// 0o644 file) so the first save into a fresh config dir succeeds.
+func (OSFileSystem) WriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Remove deletes a file; a missing file is not an error (idempotent delete).
+func (OSFileSystem) Remove(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/theme/palette.go
+++ b/theme/palette.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import "github.com/Oblikovati/api/types"
+
+// Palette is a full-snapshot color map: every theme stores a color for every token, so
+// there is no inheritance to resolve at read time (the user chose self-contained custom
+// themes — ADR-0021). Build one with [NewPalette] from a token→hex map.
+type Palette map[Token]Rgba
+
+// fallbackColor is returned for a token a palette is missing — a conspicuous magenta, so
+// an incomplete palette is visible on screen rather than silently black. A complete
+// palette (the built-ins, and any custom copied from one) never hits this.
+var fallbackColor = Rgba{R: 1, G: 0, B: 1, A: 1}
+
+// Color returns the token's color, or [fallbackColor] if the palette omits it.
+func (p Palette) Color(t Token) Rgba {
+	if c, ok := p[t]; ok {
+		return c
+	}
+	return fallbackColor
+}
+
+// Clone returns an independent copy, so editing a custom theme never mutates the
+// built-in palette it was copied from.
+func (p Palette) Clone() Palette {
+	out := make(Palette, len(p))
+	for t, c := range p {
+		out[t] = c
+	}
+	return out
+}
+
+// Hex renders the palette as the token→"#RRGGBBAA" map used in theme files and on the
+// wire ([github.com/Oblikovati/api/wire.ThemeView]).
+func (p Palette) Hex() map[string]string {
+	out := make(map[string]string, len(p))
+	for t, c := range p {
+		out[string(t)] = c.Hex()
+	}
+	return out
+}
+
+// NewPalette builds a palette from a token→hex map (a loaded theme file). It errors,
+// naming the offending token, on any malformed hex; missing tokens are tolerated here
+// and resolved to [fallbackColor] at read time, so a partial file still loads.
+func NewPalette(hex map[string]string) (Palette, error) {
+	out := make(Palette, len(hex))
+	for k, v := range hex {
+		c, err := types.ParseHex(v)
+		if err != nil {
+			return nil, err
+		}
+		out[Token(k)] = c
+	}
+	return out, nil
+}

--- a/theme/store.go
+++ b/theme/store.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
+)
+
+// FileSystem is the thin filesystem seam the [Store] depends on, so theme IO is testable
+// with an in-memory fake and never touches a real disk in unit tests (CLAUDE.md). The
+// real implementation is [OSFileSystem]. ReadDir must return an empty slice and nil error
+// for a directory that does not exist yet (first run), so Load needs no special-casing.
+type FileSystem interface {
+	ReadDir(dir string) ([]string, error)     // base names of the directory's files
+	ReadFile(path string) ([]byte, error)     // file contents
+	WriteFile(path string, data []byte) error // create/overwrite, making parent dirs
+	Remove(path string) error                 // delete a file
+}
+
+// Store loads and saves custom themes and the active-theme preference under a root
+// directory (the app's per-user config dir). Built-in themes are never persisted; only
+// the user's customs and which theme is selected.
+type Store struct {
+	root string
+	fs   FileSystem
+}
+
+// NewStore builds a store rooted at dir, backed by fs.
+func NewStore(dir string, fs FileSystem) *Store { return &Store{root: dir, fs: fs} }
+
+// DefaultRoot is the per-user config directory the app stores themes under
+// (e.g. ~/.config/oblikovati on Linux, %AppData%\oblikovati on Windows). It defers to
+// os.UserConfigDir so the location is the OS-native one.
+func DefaultRoot() (string, error) {
+	cfg, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("theme: locate user config dir: %w", err)
+	}
+	return filepath.Join(cfg, "oblikovati"), nil
+}
+
+// themeFile is the on-disk YAML shape of one custom theme: a name and the full color
+// snapshot as "#RRGGBBAA" hex. Kind is always custom (built-ins are not saved), so it is
+// not stored.
+type themeFile struct {
+	Name   string            `yaml:"name"`
+	Colors map[string]string `yaml:"colors"`
+}
+
+// prefsFile is the tiny preferences document holding the selected theme's name.
+type prefsFile struct {
+	ActiveTheme string `yaml:"activeTheme"`
+}
+
+// Load reads the active-theme preference and every custom theme file. A missing config
+// dir (first run) yields no customs and an empty active name — [NewLibrary] then falls
+// back to the Dark default. A single malformed theme file is skipped (its error is
+// returned alongside the good ones) rather than aborting the whole load.
+func (s *Store) Load() (customs []*Theme, active string, err error) {
+	active = s.loadActive()
+	names, derr := s.fs.ReadDir(s.themesDir())
+	if derr != nil {
+		return nil, active, fmt.Errorf("theme: read themes dir %q: %w", s.themesDir(), derr)
+	}
+	sort.Strings(names) // deterministic load order
+	for _, name := range names {
+		if !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		t, lerr := s.loadTheme(filepath.Join(s.themesDir(), name))
+		if lerr != nil {
+			err = lerr // remember the last bad file but keep loading the good ones
+			continue
+		}
+		customs = append(customs, t)
+	}
+	return customs, active, err
+}
+
+// SaveTheme writes one custom theme to its file. It errors (rather than silently
+// skipping) when asked to persist a built-in, which has no business on disk.
+func (s *Store) SaveTheme(t *Theme) error {
+	if t.Kind() != KindCustom {
+		return fmt.Errorf("theme: refusing to save built-in %q", t.Name())
+	}
+	data, err := yamlcodec.Marshal(themeFile{Name: t.Name(), Colors: t.Palette().Hex()})
+	if err != nil {
+		return fmt.Errorf("theme: marshal %q: %w", t.Name(), err)
+	}
+	return s.fs.WriteFile(s.themePath(t.Name()), data)
+}
+
+// RemoveTheme deletes a custom theme's file.
+func (s *Store) RemoveTheme(name string) error {
+	return s.fs.Remove(s.themePath(name))
+}
+
+// SaveActive persists the selected theme's name to the preferences file.
+func (s *Store) SaveActive(name string) error {
+	data, err := yamlcodec.Marshal(prefsFile{ActiveTheme: name})
+	if err != nil {
+		return fmt.Errorf("theme: marshal preferences: %w", err)
+	}
+	return s.fs.WriteFile(s.prefsPath(), data)
+}
+
+// loadActive reads the active-theme name, returning "" when the preferences file is
+// absent or unreadable (the library then defaults to Dark).
+func (s *Store) loadActive() string {
+	data, err := s.fs.ReadFile(s.prefsPath())
+	if err != nil {
+		return ""
+	}
+	var p prefsFile
+	if yamlcodec.Unmarshal(data, &p) != nil {
+		return ""
+	}
+	return p.ActiveTheme
+}
+
+// loadTheme decodes one custom theme file into a Theme, naming the file on any error.
+func (s *Store) loadTheme(path string) (*Theme, error) {
+	data, err := s.fs.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("theme: read %q: %w", path, err)
+	}
+	var tf themeFile
+	if err := yamlcodec.Unmarshal(data, &tf); err != nil {
+		return nil, fmt.Errorf("theme: parse %q: %w", path, err)
+	}
+	if tf.Name == "" {
+		return nil, fmt.Errorf("theme: %q has no name", path)
+	}
+	palette, err := NewPalette(tf.Colors)
+	if err != nil {
+		return nil, fmt.Errorf("theme: %q: %w", path, err)
+	}
+	return New(tf.Name, KindCustom, palette), nil
+}
+
+func (s *Store) themesDir() string { return filepath.Join(s.root, "themes") }
+func (s *Store) prefsPath() string { return filepath.Join(s.root, "preferences.yaml") }
+func (s *Store) themePath(n string) string {
+	return filepath.Join(s.themesDir(), slug(n)+".yaml")
+}
+
+// slug turns a theme name into a safe file base: lower-case, non-alphanumerics collapsed
+// to '-'. The on-disk name is cosmetic — the authoritative name is the file's `name`
+// field — so a slug collision only risks one custom overwriting another, which the
+// unique-name rule in [Library.Duplicate] already prevents at the source.
+func slug(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "theme"
+	}
+	return out
+}

--- a/theme/store_test.go
+++ b/theme/store_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+)
+
+// fakeFS is an in-memory FileSystem for store tests — no real disk IO, so the tests are
+// fast and isolated (CLAUDE.md: mock filesystem with a named fake).
+type fakeFS struct {
+	files map[string][]byte
+}
+
+func newFakeFS() *fakeFS { return &fakeFS{files: map[string][]byte{}} }
+
+func (f *fakeFS) ReadDir(dir string) ([]string, error) {
+	var names []string
+	for path := range f.files {
+		if filepath.Dir(path) == dir {
+			names = append(names, filepath.Base(path))
+		}
+	}
+	return names, nil
+}
+
+func (f *fakeFS) ReadFile(path string) ([]byte, error) {
+	data, ok := f.files[path]
+	if !ok {
+		return nil, &notFoundError{path}
+	}
+	return data, nil
+}
+
+func (f *fakeFS) WriteFile(path string, data []byte) error {
+	f.files[path] = data
+	return nil
+}
+
+func (f *fakeFS) Remove(path string) error {
+	delete(f.files, path)
+	return nil
+}
+
+type notFoundError struct{ path string }
+
+func (e *notFoundError) Error() string { return "not found: " + e.path }
+
+func TestStoreSaveLoadRoundTrip(t *testing.T) {
+	fs := newFakeFS()
+	store := NewStore("/cfg/oblikovati", fs)
+
+	lib := NewLibrary(nil, "Dark")
+	custom, _ := lib.Duplicate("Dark", "My Dark")
+	lib.EditActiveColor(types.TokenChromeAccent, mustParse(t, "#ff7a45ff"))
+
+	if err := store.SaveTheme(custom); err != nil {
+		t.Fatalf("SaveTheme: %v", err)
+	}
+	if err := store.SaveActive(lib.ActiveName()); err != nil {
+		t.Fatalf("SaveActive: %v", err)
+	}
+
+	customs, active, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if active != "My Dark" {
+		t.Errorf("active = %q, want \"My Dark\"", active)
+	}
+	if len(customs) != 1 {
+		t.Fatalf("loaded %d customs, want 1", len(customs))
+	}
+	got := customs[0]
+	if got.Name() != "My Dark" || got.Kind() != KindCustom {
+		t.Errorf("loaded theme = (%q,%q), want (\"My Dark\",custom)", got.Name(), got.Kind())
+	}
+	if got.Color(types.TokenChromeAccent) != mustParse(t, "#ff7a45ff") {
+		t.Errorf("accent not round-tripped: got %v", got.Color(types.TokenChromeAccent).Hex())
+	}
+}
+
+func TestStoreRefusesToSaveBuiltin(t *testing.T) {
+	store := NewStore("/cfg/oblikovati", newFakeFS())
+	if err := store.SaveTheme(DefaultDark()); err == nil {
+		t.Error("SaveTheme(built-in) should fail")
+	}
+}
+
+func TestStoreLoadEmptyOnFirstRun(t *testing.T) {
+	store := NewStore("/cfg/oblikovati", newFakeFS())
+	customs, active, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load on empty store: %v", err)
+	}
+	if len(customs) != 0 || active != "" {
+		t.Errorf("empty store: customs=%d active=%q, want 0 and \"\"", len(customs), active)
+	}
+}
+
+func TestStoreRemoveTheme(t *testing.T) {
+	fs := newFakeFS()
+	store := NewStore("/cfg/oblikovati", fs)
+	lib := NewLibrary(nil, "Dark")
+	custom, _ := lib.Duplicate("Dark", "Temp")
+	_ = store.SaveTheme(custom)
+
+	if err := store.RemoveTheme("Temp"); err != nil {
+		t.Fatalf("RemoveTheme: %v", err)
+	}
+	customs, _, _ := store.Load()
+	if len(customs) != 0 {
+		t.Errorf("after remove, loaded %d customs, want 0", len(customs))
+	}
+}
+
+func TestStoreThemeFileIsReadableYAML(t *testing.T) {
+	fs := newFakeFS()
+	store := NewStore("/cfg/oblikovati", fs)
+	custom, _ := NewLibrary(nil, "Dark").Duplicate("Dark", "My Dark")
+	_ = store.SaveTheme(custom)
+	for path, data := range fs.files {
+		if strings.HasSuffix(path, ".yaml") {
+			if !strings.Contains(string(data), "name: My Dark") {
+				t.Errorf("theme file %q not human-readable YAML:\n%s", path, data)
+			}
+		}
+	}
+}
+
+func mustParse(t *testing.T, hex string) Rgba {
+	t.Helper()
+	c, err := types.ParseHex(hex)
+	if err != nil {
+		t.Fatalf("ParseHex(%q): %v", hex, err)
+	}
+	return c
+}

--- a/theme/theme.go
+++ b/theme/theme.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import "github.com/Oblikovati/api/contract"
+
+// Theme is one named UI color theme: a display name, a kind (light/dark/custom), and a
+// full-snapshot [Palette]. It is the GPL implementation of [contract.Theme].
+type Theme struct {
+	name    string
+	kind    Kind
+	palette Palette
+}
+
+// compile-time proof that the implementation satisfies the public contract (ADR-0018).
+var _ contract.Theme = (*Theme)(nil)
+
+// New builds a theme from a name, kind, and palette. The palette is cloned so later
+// edits to one theme never leak into another that shared the map.
+func New(name string, kind Kind, palette Palette) *Theme {
+	return &Theme{name: name, kind: kind, palette: palette.Clone()}
+}
+
+// Name is the display label, unique within a [Library].
+func (t *Theme) Name() string { return t.name }
+
+// Kind classifies the theme as a built-in (light/dark) or a user copy (custom).
+func (t *Theme) Kind() Kind { return t.kind }
+
+// Color returns the color bound to token, or the palette fallback if absent.
+func (t *Theme) Color(token Token) Rgba { return t.palette.Color(token) }
+
+// Palette returns the theme's color map (the editor reads it to populate color rows;
+// callers must not mutate it — use [Theme.SetColor]).
+func (t *Theme) Palette() Palette { return t.palette }
+
+// SetColor recolors one token. It is a no-op on a built-in (light/dark), which is
+// read-only by contract; only custom themes are editable (see [types.ThemeKind.Editable]).
+func (t *Theme) SetColor(token Token, c Rgba) {
+	if !t.kind.Editable() {
+		return
+	}
+	t.palette[token] = c
+}
+
+// Duplicate returns an independent custom copy under newName — a full snapshot of this
+// theme's colors (the user chose self-contained customs, ADR-0021), so the copy keeps
+// its look even if a built-in's defaults later change.
+func (t *Theme) Duplicate(newName string) *Theme {
+	return &Theme{name: newName, kind: KindCustom, palette: t.palette.Clone()}
+}

--- a/theme/theme_test.go
+++ b/theme/theme_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package theme
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+)
+
+// TestDefaultsComplete guards the contract that a built-in defines every token — the
+// head reads colors without nil checks, so a missing token would render the magenta
+// fallback. Catches a token added to api/types without a default color.
+func TestDefaultsComplete(t *testing.T) {
+	for _, th := range Builtins() {
+		for _, tok := range types.AllThemeTokens() {
+			if _, ok := th.Palette()[tok]; !ok {
+				t.Errorf("%s theme missing token %q", th.Name(), tok)
+			}
+		}
+	}
+}
+
+func TestBuiltinsAreReadOnly(t *testing.T) {
+	dark := DefaultDark()
+	before := dark.Color(types.TokenChromeAccent)
+	dark.SetColor(types.TokenChromeAccent, Rgba{R: 1}) // no-op on a built-in
+	if dark.Color(types.TokenChromeAccent) != before {
+		t.Error("SetColor mutated a built-in dark theme; built-ins must be read-only")
+	}
+}
+
+func TestDuplicateIsIndependentSnapshot(t *testing.T) {
+	dark := DefaultDark()
+	custom := dark.Duplicate("My Dark")
+	if custom.Kind() != KindCustom {
+		t.Fatalf("Duplicate kind = %q, want custom", custom.Kind())
+	}
+	custom.SetColor(types.TokenChromeAccent, Rgba{R: 1, A: 1})
+	if dark.Color(types.TokenChromeAccent) == custom.Color(types.TokenChromeAccent) {
+		t.Error("editing the custom copy leaked into the source built-in")
+	}
+}
+
+func TestLibrarySetActiveBumpsRevision(t *testing.T) {
+	lib := NewLibrary(nil, "Dark")
+	r0 := lib.Revision()
+	lib.SetActive("Light")
+	if lib.Active().Name() != "Light" {
+		t.Fatalf("Active = %q, want Light", lib.Active().Name())
+	}
+	if lib.Revision() <= r0 {
+		t.Errorf("revision did not advance on SetActive (%d -> %d)", r0, lib.Revision())
+	}
+	// Re-selecting the same theme must NOT bump (no visible change).
+	r1 := lib.Revision()
+	lib.SetActive("Light")
+	if lib.Revision() != r1 {
+		t.Errorf("revision advanced on no-op SetActive (%d -> %d)", r1, lib.Revision())
+	}
+}
+
+func TestLibraryUnknownActiveFallsBackToDark(t *testing.T) {
+	lib := NewLibrary(nil, "Nonexistent")
+	if lib.Active().Name() != "Dark" {
+		t.Errorf("Active = %q, want Dark fallback", lib.Active().Name())
+	}
+}
+
+func TestLibraryDuplicateAndEdit(t *testing.T) {
+	lib := NewLibrary(nil, "Dark")
+	dup, err := lib.Duplicate("Dark", "My Dark")
+	if err != nil {
+		t.Fatalf("Duplicate: %v", err)
+	}
+	if lib.Active() != dup {
+		t.Error("Duplicate did not activate the new custom theme")
+	}
+	r := lib.Revision()
+	lib.EditActiveColor(types.TokenChromeAccent, Rgba{R: 1, A: 1})
+	if lib.Revision() <= r {
+		t.Error("EditActiveColor did not bump the revision")
+	}
+	if dup.Color(types.TokenChromeAccent) != (Rgba{R: 1, A: 1}) {
+		t.Error("EditActiveColor did not recolor the active custom theme")
+	}
+}
+
+func TestLibraryDuplicateRejectsDuplicateName(t *testing.T) {
+	lib := NewLibrary(nil, "Dark")
+	if _, err := lib.Duplicate("Dark", "Light"); err == nil {
+		t.Error("Duplicate to an existing name should fail")
+	}
+}
+
+func TestLibraryRemoveCustomReselectsDark(t *testing.T) {
+	lib := NewLibrary(nil, "Dark")
+	_, _ = lib.Duplicate("Dark", "My Dark") // becomes active
+	if err := lib.Remove("My Dark"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if lib.Active().Name() != "Dark" {
+		t.Errorf("after removing active custom, Active = %q, want Dark", lib.Active().Name())
+	}
+	if err := lib.Remove("Dark"); err == nil {
+		t.Error("removing a built-in should fail")
+	}
+}

--- a/theme/token.go
+++ b/theme/token.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package theme owns the application UI's color themes: the semantic-token palette the
+// shell styles itself from, the shipped Light and Dark built-ins, the in-memory library
+// of built-ins plus user customs with an active selection, and load/save of customs to
+// the user config directory. It is the GPL implementation of the Apache-2.0
+// [github.com/Oblikovati/api/contract.Theme] contract (ADR-0021).
+//
+// Themes cover the application shell only — window, menus, viewport 2D overlays, and 3D
+// gizmos. 3D body appearance belongs to the (future) material/appearance subsystem.
+//
+// This package is pure data + IO with no cgo or ImGui dependency, so it is fully
+// headless-testable; the head (head/ui) maps tokens onto Dear ImGui colors and the
+// renderer's overlay colors.
+package theme
+
+import "github.com/Oblikovati/api/types"
+
+// Token, Rgba, and Kind alias the canonical Apache-2.0 definitions so callers program
+// against the theme package without importing api/types directly (the rest of this
+// module follows the same aliasing rule as model/param — ADR-0018).
+type (
+	Token = types.ThemeToken
+	Rgba  = types.Rgba
+	Kind  = types.ThemeKind
+)
+
+const (
+	KindLight  = types.ThemeLight
+	KindDark   = types.ThemeDark
+	KindCustom = types.ThemeCustom
+)
+
+// Group is the editor heading a token is shown under — the four areas a theme styles.
+type Group string
+
+const (
+	GroupChrome   Group = "Chrome"
+	GroupViewport Group = "Viewport 2D"
+	GroupGizmos   Group = "Gizmos 3D"
+	GroupIcons    Group = "Icons"
+)
+
+// TokenInfo is the editor metadata for one token: a human label and the group it shows
+// under. The token's color lives in the [Palette], not here.
+type TokenInfo struct {
+	Token Token
+	Label string
+	Group Group
+}
+
+// tokenInfos is the display table for every token, in [types.AllThemeTokens] order. The
+// editor iterates it to lay out grouped color rows; a missing entry falls back to the
+// token's raw string (see [InfoFor]), so a new token is never invisible.
+var tokenInfos = map[Token]TokenInfo{
+	types.TokenChromeWindowBg:      {types.TokenChromeWindowBg, "Window background", GroupChrome},
+	types.TokenChromePanelBg:       {types.TokenChromePanelBg, "Panel background", GroupChrome},
+	types.TokenChromePopupBg:       {types.TokenChromePopupBg, "Popup background", GroupChrome},
+	types.TokenChromeMenuBarBg:     {types.TokenChromeMenuBarBg, "Menu bar", GroupChrome},
+	types.TokenChromeHeaderBg:      {types.TokenChromeHeaderBg, "Header / title", GroupChrome},
+	types.TokenChromeText:          {types.TokenChromeText, "Text", GroupChrome},
+	types.TokenChromeTextDisabled:  {types.TokenChromeTextDisabled, "Text (disabled)", GroupChrome},
+	types.TokenChromeBorder:        {types.TokenChromeBorder, "Border", GroupChrome},
+	types.TokenChromeControlBg:     {types.TokenChromeControlBg, "Control background", GroupChrome},
+	types.TokenChromeControlHover:  {types.TokenChromeControlHover, "Control (hover)", GroupChrome},
+	types.TokenChromeControlActive: {types.TokenChromeControlActive, "Control (active)", GroupChrome},
+	types.TokenChromeButton:        {types.TokenChromeButton, "Button", GroupChrome},
+	types.TokenChromeButtonHover:   {types.TokenChromeButtonHover, "Button (hover)", GroupChrome},
+	types.TokenChromeButtonActive:  {types.TokenChromeButtonActive, "Button (active)", GroupChrome},
+	types.TokenChromeAccent:        {types.TokenChromeAccent, "Accent", GroupChrome},
+	types.TokenChromeScrollbar:     {types.TokenChromeScrollbar, "Scrollbar", GroupChrome},
+	types.TokenViewportBg:          {types.TokenViewportBg, "Background", GroupViewport},
+	types.TokenGridMinor:           {types.TokenGridMinor, "Grid (minor)", GroupViewport},
+	types.TokenGridMajor:           {types.TokenGridMajor, "Grid (major)", GroupViewport},
+	types.TokenGridAxis:            {types.TokenGridAxis, "Grid (axis)", GroupViewport},
+	types.TokenSketchGeometry:      {types.TokenSketchGeometry, "Sketch geometry", GroupViewport},
+	types.TokenSketchSelected:      {types.TokenSketchSelected, "Sketch (selected)", GroupViewport},
+	types.TokenSketchCandidate:     {types.TokenSketchCandidate, "Sketch (candidate)", GroupViewport},
+	types.TokenSketchPreview:       {types.TokenSketchPreview, "Sketch preview", GroupViewport},
+	types.TokenDimensionDriving:    {types.TokenDimensionDriving, "Dimension (driving)", GroupViewport},
+	types.TokenDimensionDriven:     {types.TokenDimensionDriven, "Dimension (driven)", GroupViewport},
+	types.TokenSnapGlyph:           {types.TokenSnapGlyph, "Snap glyph", GroupViewport},
+	types.TokenPlaneFaint:          {types.TokenPlaneFaint, "Work plane", GroupGizmos},
+	types.TokenPlaneHover:          {types.TokenPlaneHover, "Work plane (hover)", GroupGizmos},
+	types.TokenPlaneSelected:       {types.TokenPlaneSelected, "Work plane (selected)", GroupGizmos},
+	types.TokenSelectionHighlight:  {types.TokenSelectionHighlight, "Selection highlight", GroupGizmos},
+	types.TokenIconTint:            {types.TokenIconTint, "Icon tint", GroupIcons},
+	types.TokenIconDisabled:        {types.TokenIconDisabled, "Icon (disabled)", GroupIcons},
+}
+
+// InfoFor returns the editor metadata for a token, falling back to a self-labeled entry
+// in the Chrome group for any token without an explicit row (so the editor stays robust
+// to a token added without a label).
+func InfoFor(t Token) TokenInfo {
+	if info, ok := tokenInfos[t]; ok {
+		return info
+	}
+	return TokenInfo{Token: t, Label: string(t), Group: GroupChrome}
+}


### PR DESCRIPTION
## What

Adds a **ThemeManager** that styles the whole application shell — window, menus, ribbon icons, viewport 2D overlays, and 3D gizmos — from a curated set of semantic color tokens. Ships **Light** and **Dark** built-ins; the user can duplicate one into an editable custom theme and recolor any token with a color picker, with the UI updating **live**. Custom themes persist per user as YAML. Excludes 3D body appearance (the future material/appearance subsystem).

Pairs with the contract PR (Oblikovati.API#2, already merged).

### Core (GPL)
- New `theme/` package: semantic-token `Palette`, `DefaultDark` (reproduces the head's previously hardcoded colors — default look unchanged) / `DefaultLight`, `Library` with an active selection and a monotonic revision counter, and YAML persistence to the user config dir behind a `FileSystem` seam.
- `Session` owns the library (like `GridSettings`) so the wire router can serve it without depending on `/head`.
- `addin/router` `theme.active` / `theme.list`.

### Head (cgo)
- Native verbs: `SetStyleColor` (maps an ImGui color **name** → enum, so the binding survives ImGui version bumps), `ColorEdit4`, `BeginCombo`, `SetViewportClear`.
- `theme_apply.go` centralizes the formerly-scattered overlay/icon color vars + the token→ImGui-slot binding, and re-styles only when the theme revision changes.
- Preferences gains a **Theme** tab (selector, duplicate, per-token picker with live preview, save/delete); the window opens at 640×480.

### Docs
- ADR-0021; M05 / F06-theming-appearance feature + PBI-066…072.

## Why

Theming was absent: colors were hardcoded across `head/ui` and the chrome used ImGui defaults. This makes the shell themable and personalizable, exposes the active theme on the public API so add-in panels can match the host, and keeps theme state in the core so the wire router can serve it.

## Tests

`go test ./...` green across the core and head: palette completeness, built-in immutability, library revision/duplicate/remove, fake-FS persistence round-trip, router `theme.active`/`theme.list`, binding-slot uniqueness, theme-driven overlay refresh; head in-window (offscreen-Vulkan) tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)