### PR TITLE
Materials & Appearances subsystem (PBR appearances, physical materials)

### DIFF
--- a/addin/router/material.go
+++ b/addin/router/material.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/material"
+)
+
+// appearanceInfo marshals a model appearance into its wire DTO.
+func appearanceInfo(a *material.Appearance) wire.AppearanceInfo {
+	return wire.AppearanceInfo{
+		ID: a.ID(), DisplayName: a.DisplayName(), Source: string(a.Source()),
+		Albedo: a.Albedo().Hex(), Metallic: a.Metallic(), Roughness: a.Roughness(),
+		Emissive: a.Emissive().Hex(), Opacity: a.Opacity(),
+	}
+}
+
+// materialInfo marshals a model material into its wire DTO.
+func materialInfo(m *material.Material) wire.MaterialInfo {
+	return wire.MaterialInfo{
+		ID: m.ID(), DisplayName: m.DisplayName(), Source: string(m.Source()),
+		Density: m.Density(), Mechanical: m.Mechanical(), Thermal: m.Thermal(),
+		Electrical: m.Electrical(), AppearanceID: m.AppearanceID(),
+	}
+}
+
+func listAppearances(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	apprs := s.Materials().Appearances()
+	out := make([]wire.AppearanceInfo, len(apprs))
+	for i, a := range apprs {
+		out[i] = appearanceInfo(a)
+	}
+	return json.Marshal(wire.ListAppearancesResult{Appearances: out})
+}
+
+func listMaterials(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	mats := s.Materials().Materials()
+	out := make([]wire.MaterialInfo, len(mats))
+	for i, m := range mats {
+		out[i] = materialInfo(m)
+	}
+	return json.Marshal(wire.ListMaterialsResult{Materials: out})
+}
+
+func getAppearance(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AssetRefArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	a, ok := s.Materials().Appearance(in.ID)
+	if !ok {
+		return nil, fmt.Errorf("appearances.get: unknown appearance %q", in.ID)
+	}
+	return json.Marshal(appearanceInfo(a))
+}
+
+func getMaterial(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AssetRefArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	m, ok := s.Materials().Material(in.ID)
+	if !ok {
+		return nil, fmt.Errorf("materials.get: unknown material %q", in.ID)
+	}
+	return json.Marshal(materialInfo(m))
+}
+
+func createAppearance(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.DuplicateAssetArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	a, err := s.DuplicateAppearance(in.BaseID, in.Name)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(appearanceInfo(a))
+}
+
+func createMaterial(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.DuplicateAssetArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	m, err := s.DuplicateMaterial(in.BaseID, in.Name)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(materialInfo(m))
+}
+
+func updateAppearance(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AppearanceInfo
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	albedo, err := material.ParseColor(in.Albedo)
+	if err != nil {
+		return nil, fmt.Errorf("appearances.update: albedo: %w", err)
+	}
+	emissive, err := material.ParseColor(in.Emissive)
+	if err != nil {
+		return nil, fmt.Errorf("appearances.update: emissive: %w", err)
+	}
+	s.UpdateAppearance(in.ID, material.AppearanceSpec{
+		DisplayName: in.DisplayName, Albedo: albedo, Metallic: in.Metallic,
+		Roughness: in.Roughness, Emissive: emissive, Opacity: in.Opacity,
+	})
+	a, ok := s.Materials().Appearance(in.ID)
+	if !ok {
+		return nil, fmt.Errorf("appearances.update: unknown appearance %q", in.ID)
+	}
+	return json.Marshal(appearanceInfo(a))
+}
+
+func updateMaterial(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.MaterialInfo
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	s.UpdateMaterial(in.ID, material.MaterialSpec{
+		DisplayName: in.DisplayName, Density: in.Density, Mechanical: in.Mechanical,
+		Thermal: in.Thermal, Electrical: in.Electrical, AppearanceID: in.AppearanceID,
+	})
+	m, ok := s.Materials().Material(in.ID)
+	if !ok {
+		return nil, fmt.Errorf("materials.update: unknown material %q", in.ID)
+	}
+	return json.Marshal(materialInfo(m))
+}
+
+func assignMaterial(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AssignMaterialArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if err := s.AssignMaterial(in.BodyKey, in.MaterialID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func assignAppearance(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AssignAppearanceArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if err := s.AssignAppearance(in.Scope, in.Key, in.AppearanceID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func physicalProperties(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	props, ok := s.PhysicalProperties()
+	if !ok {
+		return nil, fmt.Errorf("model.physicalProperties: no active part")
+	}
+	return json.Marshal(props)
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -33,6 +33,14 @@ type Router struct {
 // New builds a router whose feature operations come from ops.
 func New(ops *opregistry.Registry) *Router {
 	r := &Router{ops: ops, handlers: map[string]handlerFunc{}}
+	r.registerStandardHandlers()
+	r.registerMaterialHandlers()
+	return r
+}
+
+// registerStandardHandlers wires the command/document/parameter/model/sketch/feature/theme
+// methods.
+func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodCommandsList] = listCommands
 	r.handlers[wire.MethodCommandsExecute] = executeCommand
 	r.handlers[wire.MethodCommandsCreate] = createCommand
@@ -51,6 +59,11 @@ func New(ops *opregistry.Registry) *Router {
 	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
 	r.handlers[wire.MethodThemeActive] = themeActive
 	r.handlers[wire.MethodThemeList] = themeList
+}
+
+// registerMaterialHandlers wires the appearance/material/assignment/physical-properties
+// methods (M19 / ADR-0022).
+func (r *Router) registerMaterialHandlers() {
 	r.handlers[wire.MethodAppearancesList] = listAppearances
 	r.handlers[wire.MethodAppearancesGet] = getAppearance
 	r.handlers[wire.MethodAppearancesCreate] = createAppearance
@@ -62,7 +75,6 @@ func New(ops *opregistry.Registry) *Router {
 	r.handlers[wire.MethodModelAssignMaterial] = assignMaterial
 	r.handlers[wire.MethodModelAssignAppearance] = assignAppearance
 	r.handlers[wire.MethodModelPhysicalProperties] = physicalProperties
-	return r
 }
 
 // Handle dispatches method with its JSON args (empty args become {}), returning the

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -51,6 +51,17 @@ func New(ops *opregistry.Registry) *Router {
 	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
 	r.handlers[wire.MethodThemeActive] = themeActive
 	r.handlers[wire.MethodThemeList] = themeList
+	r.handlers[wire.MethodAppearancesList] = listAppearances
+	r.handlers[wire.MethodAppearancesGet] = getAppearance
+	r.handlers[wire.MethodAppearancesCreate] = createAppearance
+	r.handlers[wire.MethodAppearancesUpdate] = updateAppearance
+	r.handlers[wire.MethodMaterialsList] = listMaterials
+	r.handlers[wire.MethodMaterialsGet] = getMaterial
+	r.handlers[wire.MethodMaterialsCreate] = createMaterial
+	r.handlers[wire.MethodMaterialsUpdate] = updateMaterial
+	r.handlers[wire.MethodModelAssignMaterial] = assignMaterial
+	r.handlers[wire.MethodModelAssignAppearance] = assignAppearance
+	r.handlers[wire.MethodModelPhysicalProperties] = physicalProperties
 	return r
 }
 

--- a/addin/router/router_test.go
+++ b/addin/router/router_test.go
@@ -284,6 +284,65 @@ func TestThemeListFlagsActive(t *testing.T) {
 	}
 }
 
+func TestAppearancesAndMaterialsListAndCreate(t *testing.T) {
+	r, s := seededSession(t)
+	var apprs wire.ListAppearancesResult
+	call(t, r, s, "appearances.list", "{}", &apprs)
+	if len(apprs.Appearances) == 0 {
+		t.Fatal("appearances.list returned none")
+	}
+	var mats wire.ListMaterialsResult
+	call(t, r, s, "materials.list", "{}", &mats)
+	if len(mats.Materials) == 0 {
+		t.Fatal("materials.list returned none")
+	}
+	// Duplicate a built-in into a project-scoped editable material.
+	var made wire.MaterialInfo
+	call(t, r, s, "materials.create", `{"baseId":"steel","name":"Shop Steel"}`, &made)
+	if made.Source != "project" || made.Density == 0 {
+		t.Fatalf("created material = %+v, want a project copy with density", made)
+	}
+	// Edit its appearance's albedo and read it back.
+	var appr wire.AppearanceInfo
+	call(t, r, s, "appearances.create", `{"baseId":"steel","name":"Shop Steel Look"}`, &appr)
+	appr.Albedo = "#ff8800ff"
+	var updated wire.AppearanceInfo
+	call(t, r, s, "appearances.update", mustJSON(t, appr), &updated)
+	if updated.Albedo != "#ff8800ff" {
+		t.Errorf("updated albedo = %q, want #ff8800ff", updated.Albedo)
+	}
+}
+
+func TestAssignMaterialAndPhysicalProperties(t *testing.T) {
+	r, s := seededSession(t)
+	// Build a solid so there is volume to weigh.
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"5 cm"}}`, nil)
+	call(t, r, s, "model.assignMaterial", `{"materialId":"steel"}`, nil)
+
+	var props struct {
+		Mass    float64 `json:"mass"`
+		Volume  float64 `json:"volume"`
+		Density float64 `json:"density"`
+	}
+	call(t, r, s, "model.physicalProperties", "{}", &props)
+	if props.Volume <= 0 || props.Mass <= 0 {
+		t.Fatalf("physical properties = %+v, want positive volume and mass", props)
+	}
+	// Steel density is 7.85 g/cm³, so mass ≈ density × volume.
+	if got := props.Mass / props.Volume; got < 7.8 || got > 7.9 {
+		t.Errorf("mass/volume = %v, want ≈7.85 (steel density)", got)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
 func TestParametersNoActiveDocument(t *testing.T) {
 	r := New(opregistry.Default())
 	s := app.NewSession() // empty workspace

--- a/app/material_ops.go
+++ b/app/material_ops.go
@@ -96,27 +96,49 @@ func (s *Session) PhysicalProperties() (types.PhysicalProperties, bool) {
 	if err != nil {
 		return types.PhysicalProperties{}, false
 	}
+	return s.sumBodyProperties(part), true
+}
+
+// massAccum accumulates volume/area/mass and the volume-weighted centroid numerator across
+// a part's bodies.
+type massAccum struct {
+	volume, area, mass float64
+	cx, cy, cz         float64
+}
+
+// sumBodyProperties sums the per-body geometry properties (each body weighted by its
+// effective material's density) into the part's physical properties.
+func (s *Session) sumBodyProperties(part *compdef.PartComponentDefinition) types.PhysicalProperties {
 	look := material.MergedLookup{Embedded: part.Assets(), Catalog: s.Materials()}
 	assign := part.Assignments()
-	var volume, area, mass float64
-	var cx, cy, cz float64
+	var a massAccum
 	for _, b := range part.SurfaceBodies().All() {
 		gp := ops.BodyGeometryProperties(b, ops.DefaultQuality())
 		density := 0.0
 		if m, ok := assign.EffectiveMaterial(look, material.RefKey(b.ReferenceKey())); ok {
 			density = m.Density()
 		}
-		volume += gp.Volume
-		area += gp.Area
-		mass += density * gp.Volume
-		cx += float64(gp.Centroid.X) * gp.Volume
-		cy += float64(gp.Centroid.Y) * gp.Volume
-		cz += float64(gp.Centroid.Z) * gp.Volume
+		a.add(gp, density)
 	}
-	props := types.PhysicalProperties{Mass: mass, Volume: volume, Area: area}
-	if volume > 0 {
-		props.Density = mass / volume
-		props.Centroid = [3]float64{cx / volume, cy / volume, cz / volume}
+	return a.result()
+}
+
+// add folds one body's geometry properties (at the given density) into the accumulator.
+func (a *massAccum) add(gp ops.GeometryProperties, density float64) {
+	a.volume += gp.Volume
+	a.area += gp.Area
+	a.mass += density * gp.Volume
+	a.cx += float64(gp.Centroid.X) * gp.Volume
+	a.cy += float64(gp.Centroid.Y) * gp.Volume
+	a.cz += float64(gp.Centroid.Z) * gp.Volume
+}
+
+// result finalizes the accumulator, dividing the centroid numerator by total volume.
+func (a *massAccum) result() types.PhysicalProperties {
+	props := types.PhysicalProperties{Mass: a.mass, Volume: a.volume, Area: a.area}
+	if a.volume > 0 {
+		props.Density = a.mass / a.volume
+		props.Centroid = [3]float64{a.cx / a.volume, a.cy / a.volume, a.cz / a.volume}
 	}
-	return props, true
+	return props
 }

--- a/app/material_ops.go
+++ b/app/material_ops.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/material"
+)
+
+// AppearanceScope names where an appearance override applies (the wire "scope" values).
+const (
+	ScopePart = "part"
+	ScopeBody = "body"
+	ScopeFace = "face"
+)
+
+// AssignMaterial sets the material for a body (bodyKey hex) or the part default (empty
+// bodyKey), embedding a portable copy of the material and its appearance in the document
+// so the assignment survives a round-trip even without the project library.
+func (s *Session) AssignMaterial(bodyKey, materialID string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if _, ok := s.Materials().Material(materialID); !ok {
+		return fmt.Errorf("app: unknown material %q", materialID)
+	}
+	s.embedMaterial(part, materialID)
+	if bodyKey == "" {
+		part.Assignments().SetPartMaterial(materialID)
+	} else {
+		part.Assignments().SetBodyMaterial(bodyKey, materialID)
+	}
+	part.MarkChanged()
+	return nil
+}
+
+// AssignAppearance overrides the appearance at part/body/face scope, embedding a portable
+// copy of the appearance in the document.
+func (s *Session) AssignAppearance(scope, key, appearanceID string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if _, ok := s.Materials().Appearance(appearanceID); !ok {
+		return fmt.Errorf("app: unknown appearance %q", appearanceID)
+	}
+	s.embedAppearance(part, appearanceID)
+	switch scope {
+	case ScopePart:
+		part.Assignments().SetPartAppearance(appearanceID)
+	case ScopeBody:
+		part.Assignments().SetBodyAppearance(key, appearanceID)
+	case ScopeFace:
+		part.Assignments().SetFaceAppearance(key, appearanceID)
+	default:
+		return fmt.Errorf("app: unknown appearance scope %q", scope)
+	}
+	part.MarkChanged()
+	return nil
+}
+
+// embedAppearance copies a non-built-in appearance into the document's asset set, so the
+// .obk carries its own copy (built-ins are reproducible and not embedded).
+func (s *Session) embedAppearance(part *compdef.PartComponentDefinition, id string) {
+	a, ok := s.Materials().Appearance(id)
+	if !ok || a.Source() == material.SourceBuiltin {
+		return
+	}
+	part.Assets().PutAppearance(material.NewAppearance(a.ID(), material.SourceDocument, a.Spec()))
+}
+
+// embedMaterial copies a non-built-in material (and its appearance) into the document.
+func (s *Session) embedMaterial(part *compdef.PartComponentDefinition, id string) {
+	m, ok := s.Materials().Material(id)
+	if !ok {
+		return
+	}
+	s.embedAppearance(part, m.AppearanceID())
+	if m.Source() == material.SourceBuiltin {
+		return
+	}
+	part.Assets().PutMaterial(material.NewMaterial(m.ID(), material.SourceDocument, m.Spec()))
+}
+
+// PhysicalProperties computes the active part's mass/volume/area/centroid, summed over its
+// bodies, each body using its effective material's density. It returns false when there is
+// no active part.
+func (s *Session) PhysicalProperties() (types.PhysicalProperties, bool) {
+	part, err := activePart(s)
+	if err != nil {
+		return types.PhysicalProperties{}, false
+	}
+	look := material.MergedLookup{Embedded: part.Assets(), Catalog: s.Materials()}
+	assign := part.Assignments()
+	var volume, area, mass float64
+	var cx, cy, cz float64
+	for _, b := range part.SurfaceBodies().All() {
+		gp := ops.BodyGeometryProperties(b, ops.DefaultQuality())
+		density := 0.0
+		if m, ok := assign.EffectiveMaterial(look, material.RefKey(b.ReferenceKey())); ok {
+			density = m.Density()
+		}
+		volume += gp.Volume
+		area += gp.Area
+		mass += density * gp.Volume
+		cx += float64(gp.Centroid.X) * gp.Volume
+		cy += float64(gp.Centroid.Y) * gp.Volume
+		cz += float64(gp.Centroid.Z) * gp.Volume
+	}
+	props := types.PhysicalProperties{Mass: mass, Volume: volume, Area: area}
+	if volume > 0 {
+		props.Density = mass / volume
+		props.Centroid = [3]float64{cx / volume, cy / volume, cz / volume}
+	}
+	return props, true
+}

--- a/app/materials.go
+++ b/app/materials.go
@@ -19,6 +19,55 @@ func (s *Session) Materials() *material.Library {
 	return s.materials
 }
 
+// LoadProjectMaterials attaches a project asset store and folds its shared appearances and
+// materials into the library. The head calls this with an OS-backed store rooted at the
+// active project's design-data directory; later customizations persist back through it.
+func (s *Session) LoadProjectMaterials(store *material.Store) error {
+	s.materialStore = store
+	return store.Load(s.Materials())
+}
+
+// DuplicateAppearance creates a project-scoped editable copy of an appearance and persists
+// the project library.
+func (s *Session) DuplicateAppearance(baseID, name string) (*material.Appearance, error) {
+	a, err := s.Materials().DuplicateAppearance(baseID, name, material.SourceProject)
+	if err != nil {
+		return nil, err
+	}
+	s.saveProjectMaterials()
+	return a, nil
+}
+
+// DuplicateMaterial creates a project-scoped editable copy of a material.
+func (s *Session) DuplicateMaterial(baseID, name string) (*material.Material, error) {
+	m, err := s.Materials().DuplicateMaterial(baseID, name, material.SourceProject)
+	if err != nil {
+		return nil, err
+	}
+	s.saveProjectMaterials()
+	return m, nil
+}
+
+// UpdateAppearance / UpdateMaterial edit an asset's spec (a no-op for built-ins) and
+// persist the project library.
+func (s *Session) UpdateAppearance(id string, spec material.AppearanceSpec) {
+	s.Materials().EditAppearance(id, spec)
+	s.saveProjectMaterials()
+}
+
+func (s *Session) UpdateMaterial(id string, spec material.MaterialSpec) {
+	s.Materials().EditMaterial(id, spec)
+	s.saveProjectMaterials()
+}
+
+// saveProjectMaterials writes the project library when a store is attached (else a no-op,
+// e.g. in headless tests).
+func (s *Session) saveProjectMaterials() {
+	if s.materialStore != nil {
+		_ = s.materialStore.Save(s.Materials())
+	}
+}
+
 // SurfaceLookup returns the per-body PBR resolver for the active part: it maps each body
 // to its effective appearance (via the part's assignment store and the material library)
 // and converts that to a [renderer.Surface]. It returns nil when there is no active part,

--- a/app/materials.go
+++ b/app/materials.go
@@ -28,10 +28,10 @@ func (s *Session) SurfaceLookup() renderer.SurfaceLookup {
 	if err != nil {
 		return nil
 	}
-	lib := s.Materials()
+	look := material.MergedLookup{Embedded: part.Assets(), Catalog: s.Materials()}
 	assign := part.Assignments()
 	return func(b *topo.Body) renderer.Surface {
-		appr := assign.EffectiveAppearance(lib, material.RefKey(b.ReferenceKey()), "")
+		appr := assign.EffectiveAppearance(look, material.RefKey(b.ReferenceKey()), "")
 		return appearanceSurface(appr)
 	}
 }

--- a/app/materials.go
+++ b/app/materials.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/model/material"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// Materials returns the session's appearance/material library (built-ins on first use;
+// the project library and document-embedded assets fold in as those land). It is shared
+// by every open document of the session, the way the project asset library is shared
+// across a project's documents (ADR-0022).
+func (s *Session) Materials() *material.Library {
+	if s.materials == nil {
+		s.materials = material.NewLibrary()
+	}
+	return s.materials
+}
+
+// SurfaceLookup returns the per-body PBR resolver for the active part: it maps each body
+// to its effective appearance (via the part's assignment store and the material library)
+// and converts that to a [renderer.Surface]. It returns nil when there is no active part,
+// so the renderer falls back to the neutral default.
+func (s *Session) SurfaceLookup() renderer.SurfaceLookup {
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	lib := s.Materials()
+	assign := part.Assignments()
+	return func(b *topo.Body) renderer.Surface {
+		appr := assign.EffectiveAppearance(lib, material.RefKey(b.ReferenceKey()), "")
+		return appearanceSurface(appr)
+	}
+}
+
+// appearanceSurface converts a model appearance into the renderer's PBR surface value.
+func appearanceSurface(a *material.Appearance) renderer.Surface {
+	em := a.Emissive()
+	return renderer.Surface{
+		Albedo:    a.Albedo().Array(),
+		Metallic:  a.Metallic(),
+		Roughness: a.Roughness(),
+		Emissive:  [3]float32{em.R, em.G, em.B},
+		Opacity:   a.Opacity(),
+	}
+}

--- a/app/materials_test.go
+++ b/app/materials_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/model/compdef"
+)
+
+func TestMaterialsLibrarySeeded(t *testing.T) {
+	s := NewSession()
+	if len(s.Materials().Materials()) == 0 || len(s.Materials().Appearances()) == 0 {
+		t.Fatal("session material library is empty; built-ins should be seeded")
+	}
+}
+
+func TestSurfaceLookupNilWithoutActivePart(t *testing.T) {
+	s := NewSession()
+	if s.SurfaceLookup() != nil {
+		t.Error("SurfaceLookup should be nil with no active part (renderer uses its default)")
+	}
+}
+
+func TestSurfaceLookupResolvesAssignedAppearance(t *testing.T) {
+	s := NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "p.obk", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if s.SurfaceLookup() == nil {
+		t.Fatal("SurfaceLookup nil with an active part")
+	}
+	// The mapping from a library appearance to a renderer surface must carry the PBR
+	// fields (the steel built-in is metallic).
+	steel, _ := s.Materials().Appearance("steel")
+	surf := appearanceSurface(steel)
+	if surf.Albedo != steel.Albedo().Array() || surf.Metallic != steel.Metallic() {
+		t.Errorf("appearanceSurface lost PBR fields: %+v", surf)
+	}
+}

--- a/app/render.go
+++ b/app/render.go
@@ -33,7 +33,7 @@ func (s *Session) Overlays() []renderer.DrawItem {
 // RenderFrame builds the frame draw list — the active part's bodies, the persistent
 // overlays, and the active tool's transient preview — and submits it to the backend.
 func (s *Session) RenderFrame(backend renderer.Backend) {
-	list := renderer.BuildDrawList(s.sceneBodies(), s.camera, ops.DefaultQuality())
+	list := renderer.BuildDrawList(s.sceneBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup())
 	list.Items = append(list.Items, s.overlays...)
 	if s.tool != nil {
 		if p, ok := s.tool.tool.(Previewable); ok {

--- a/app/session.go
+++ b/app/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Oblikovati/oblikovati/event"
 	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/material"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
 	"github.com/Oblikovati/oblikovati/scene"
@@ -37,6 +38,7 @@ type Session struct {
 	grid            *GridSettings
 	themes          *theme.Library
 	themeStore      *theme.Store
+	materials       *material.Library
 }
 
 // NewSession creates an empty in-memory session with no persistence store. Its

--- a/app/session.go
+++ b/app/session.go
@@ -39,6 +39,7 @@ type Session struct {
 	themes          *theme.Library
 	themeStore      *theme.Store
 	materials       *material.Library
+	materialStore   *material.Store
 }
 
 // NewSession creates an empty in-memory session with no persistence store. Its

--- a/architecture/decisions/ADR-0022-materials-appearances.md
+++ b/architecture/decisions/ADR-0022-materials-appearances.md
@@ -1,0 +1,64 @@
+# ADR-0022 — Materials & Appearances (typed assets, project-scoped, PBR)
+
+**Status:** accepted (user decision, 2026-06-02) · **Relates to:**
+[ADR-0005](ADR-0005-vulkan13-renderer.md) (renderer), [ADR-0014](ADR-0014-renderer-testability.md)
+(pure draw list), [ADR-0018](ADR-0018-apache-api-contract-module.md) (API split),
+[ADR-0020](ADR-0020-yaml-git-friendly-document-format.md) (YAML documents),
+[ADR-0021](ADR-0021-ui-theming-semantic-tokens.md) (reuses Rgba / the color picker).
+
+## Context
+
+Every body rendered with one hardcoded `renderer.defaultSurfaceColor` ("the neutral
+material used until materials land"), bodies carried no physical properties, and there was
+no way to author or assign look/material data. We want two linked subsystems: **Appearance**
+(what the renderer shows) and **Material** (real-world physical properties), assignable to
+bodies, with custom assets shared across a project's documents.
+
+Inventor models these as generic **Asset** objects (a bag of typed `AssetValue`s); a
+`MaterialAsset` references an appearance asset and a physical-properties asset; assets live
+in project-scoped `AssetLibraries`; `AppearanceSourceTypeEnum` defines an override
+precedence chain.
+
+## Decision
+
+1. **Typed structs, not a generic AssetValue bag.** `Appearance` (metallic-roughness PBR:
+   albedo, metallic, roughness, emissive, opacity) and `Material` (density + Mechanical /
+   Thermal / Electrical groups, referencing an appearance by id) are concrete typed Go
+   structs in `model/material`, consistent with `model/param`/`model/sketch` and CLAUDE.md's
+   "explicit types, no Dict". Inventor's names and the appearance-source precedence are kept.
+
+2. **Solid PBR values now; no texture maps.** First milestone carries scalar/color PBR
+   through `renderer.DrawItem`; the basic shader uses albedo and the rest feeds a future GGX
+   upgrade. Image-texture maps are deferred (they need binary document sections + UVs).
+
+3. **Three scope tiers, resolved document → project → built-in.** A shipped read-only
+   catalog (built-ins), the active project's shared library (`DesignProject.Locations.
+   DesignData`, `appearances.yaml`/`materials.yaml`), and per-document **embedded copies** of
+   the non-built-in assets a document uses (so an `.obk` is self-contained). `MergedLookup`
+   resolves embedded assets over the session catalog.
+
+4. **Assignment by persistent reference key.** Assignments live on `PartComponentDefinition`
+   keyed by `topo` `ReferenceKey` (stable across `Recompute`, unlike body id), with the
+   precedence `face override → body appearance → body material → part material → part default
+   → neutral default`.
+
+5. **Public API (ADR-0018).** `types` (AssetSource, property groups, PhysicalProperties,
+   reusing `Rgba`), `contract` (Appearance/Material), `wire` (appearances.* / materials.* /
+   model.assign* / model.physicalProperties), `client` groups; served by `addin/router`.
+
+6. **Renderer stays pure.** `BuildDrawList` takes a `SurfaceLookup` resolver built in the app
+   from the active part's assignments + library; `renderer` never imports `model`.
+
+7. **Mass properties from geometry.** A new `ops.BodyGeometryProperties` computes
+   volume/area/centroid via the divergence-theorem signed-tetrahedron sum (oriented outward
+   from per-vertex normals); mass = density × volume.
+
+## Consequences
+
+- New UI color/material data is added as typed fields + assets, not hardcoded colors.
+- A document embeds the assets it uses, so it renders correctly without its project library;
+  the project library is the shared catalog and the source of cross-document reuse.
+- Body/face-level appearance overrides are modeled and resolved now; **face-level override
+  rendering** (splitting a body mesh per face) and **image textures** are follow-on work.
+- Live edit/assign updates the viewport next frame (the resolver reads the library each
+  frame), matching the theming live-update model.

--- a/architecture/decisions/ADR-0022-materials-appearances.md
+++ b/architecture/decisions/ADR-0022-materials-appearances.md
@@ -43,8 +43,9 @@ precedence chain.
    → neutral default`.
 
 5. **Public API (ADR-0018).** `types` (AssetSource, property groups, PhysicalProperties,
-   reusing `Rgba`), `contract` (Appearance/Material), `wire` (appearances.* / materials.* /
-   model.assign* / model.physicalProperties), `client` groups; served by `addin/router`.
+   reusing `Rgba`), `contract` (Appearance/Material), `wire` (`appearances.*`, `materials.*`,
+   `model.assignMaterial`, `model.assignAppearance`, `model.physicalProperties`), `client`
+   groups; served by `addin/router`.
 
 6. **Renderer stays pure.** `BuildDrawList` takes a `SurfaceLookup` resolver built in the app
    from the active part's assignments + library; `renderer` never imports `model`.

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -38,6 +38,7 @@ int  obk_ig_begin_popup_context_item(const char* id);
 void obk_ig_end_popup(void);
 void obk_ig_set_scroll_here_y(void);
 int  obk_ig_input_float(const char* label, float* v);
+int  obk_ig_input_double(const char* label, double* v);
 int  obk_ig_input_int(const char* label, int* v);
 int  obk_ig_input_text(const char* label, char* buf, int buf_size);
 int  obk_ig_checkbox(const char* label, int* v);
@@ -153,6 +154,14 @@ func InputFloat(label string, v *float32) bool {
 	c, free := cstr(label)
 	defer free()
 	return C.obk_ig_input_float(c, (*C.float)(v)) != 0
+}
+
+// InputDouble draws a float64 field; returns true (and writes *v) when edited. Used by the
+// material editors, where values (e.g. resistivity ~1e15) exceed float32 precision.
+func InputDouble(label string, v *float64) bool {
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_input_double(c, (*C.double)(v)) != 0
 }
 
 // InputInt draws an integer field; returns true (and writes *v) when edited.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -70,6 +70,7 @@ void obk_ig_set_scroll_here_y(void)          { ImGui::SetScrollHereY(0.5f); }
 // Preference widgets: a float/int field and a checkbox. Each returns 1 when the value
 // changed this frame and writes the new value back through the pointer.
 int  obk_ig_input_float(const char* label, float* v) { return ImGui::InputFloat(label, v) ? 1 : 0; }
+int  obk_ig_input_double(const char* label, double* v) { return ImGui::InputDouble(label, v) ? 1 : 0; }
 int  obk_ig_input_int(const char* label, int* v)     { return ImGui::InputInt(label, v) ? 1 : 0; }
 int  obk_ig_input_text(const char* label, char* buf, int buf_size) { return ImGui::InputText(label, buf, (size_t)buf_size) ? 1 : 0; }
 int  obk_ig_checkbox(const char* label, int* v) {

--- a/head/ui/appearance_editor.go
+++ b/head/ui/appearance_editor.go
@@ -1,0 +1,91 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/material"
+)
+
+// drawAppearanceTabContent renders the appearance selector, actions, and PBR editor inside
+// the Materials window (distinct from the theme Appearance tab in appearance_tab.go).
+func drawAppearanceTabContent(s *app.Session) {
+	lib := s.Materials()
+	if _, ok := lib.Appearance(selectedAppearance); !ok && len(lib.Appearances()) > 0 {
+		selectedAppearance = lib.Appearances()[0].ID()
+	}
+	drawAppearanceSelector(s)
+	a, ok := lib.Appearance(selectedAppearance)
+	if !ok {
+		return
+	}
+	drawAppearanceActions(s, a)
+	native.Separator()
+	editAppearancePBR(s, a)
+}
+
+// drawAppearanceSelector renders the appearance dropdown.
+func drawAppearanceSelector(s *app.Session) {
+	current := selectedAppearance
+	if a, ok := s.Materials().Appearance(selectedAppearance); ok {
+		current = a.DisplayName()
+	}
+	if !native.BeginCombo("Appearance", current) {
+		return
+	}
+	for _, a := range s.Materials().Appearances() {
+		if native.Selectable(a.DisplayName(), a.ID() == selectedAppearance) {
+			selectedAppearance = a.ID()
+		}
+	}
+	native.EndCombo()
+}
+
+// drawAppearanceActions renders duplicate + assign-to-part for the selected appearance.
+func drawAppearanceActions(s *app.Session, a *material.Appearance) {
+	native.InputText("Copy name", apprNameBuf[:])
+	native.SameLine()
+	if native.Button("Duplicate##appr") {
+		if dup, err := s.DuplicateAppearance(a.ID(), bufString(apprNameBuf[:])); err == nil {
+			selectedAppearance = dup.ID()
+			clearBuf(apprNameBuf[:])
+		}
+	}
+	if native.Button("Assign to part") {
+		_ = s.AssignAppearance(app.ScopePart, "", a.ID())
+	}
+}
+
+// editAppearancePBR renders the metallic-roughness controls (disabled for built-ins). Edits
+// flow to the session immediately, so the viewport recolors next frame.
+func editAppearancePBR(s *app.Session, a *material.Appearance) {
+	editable := a.Source().Editable()
+	native.BeginDisabled(!editable)
+	spec := a.Spec()
+	changed := false
+	albedo := spec.Albedo.Array()
+	if native.ColorEdit4("Albedo", &albedo) {
+		spec.Albedo = rgbaOf(albedo)
+		changed = true
+	}
+	changed = native.InputFloat("Metallic", &spec.Metallic) || changed
+	changed = native.InputFloat("Roughness", &spec.Roughness) || changed
+	changed = native.InputFloat("Opacity", &spec.Opacity) || changed
+	emissive := spec.Emissive.Array()
+	if native.ColorEdit4("Emissive", &emissive) {
+		spec.Emissive = rgbaOf(emissive)
+		changed = true
+	}
+	native.EndDisabled()
+	if changed && editable {
+		s.UpdateAppearance(a.ID(), spec)
+	}
+}
+
+// rgbaOf converts an ImGui [4]float32 color into a material color.
+func rgbaOf(c [4]float32) material.Rgba {
+	return material.Rgba{R: c[0], G: c[1], B: c[2], A: c[3]}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -422,7 +422,7 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		}
 
 		bodies := activeBodies(s)
-		list := renderer.BuildDrawList(bodies, cam, ops.DefaultQuality())
+		list := renderer.BuildDrawList(bodies, cam, ops.DefaultQuality(), s.SurfaceLookup())
 		// Paint the selected body cyan so a browser/viewport pick reads in the 3D view
 		// (a no-op in sketch mode, where the selection is sketch entities, not bodies).
 		list = highlightSelection(list, s.Selection().First(), bodies)

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -51,6 +51,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawExtrudeDialog(s)
 	drawStatusBar(s)
 	drawPreferencesWindow(s)
+	drawMaterialsWindow(s)
 	drawFileDialog(s)
 	return activated
 }
@@ -125,6 +126,9 @@ func drawMenuBar(s *app.Session) string {
 		native.EndMenu()
 	}
 	if native.BeginMenu("Tools") {
+		if native.MenuItem("Materials") {
+			showMaterials = !showMaterials
+		}
 		if native.MenuItem("Preferences") {
 			showPreferences = !showPreferences
 		}

--- a/head/ui/materials_window.go
+++ b/head/ui/materials_window.go
@@ -1,0 +1,145 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/material"
+)
+
+// showMaterials toggles the Materials window (Tools ▸ Materials). UI state, so it lives in
+// the head. The selection ids persist across frames so the editor keeps its target.
+var (
+	showMaterials      bool
+	selectedMaterialID string
+	selectedAppearance string
+	matNameBuf         [64]byte
+	apprNameBuf        [64]byte
+)
+
+// drawMaterialsWindow renders the Materials browser/editor: pick or duplicate a material or
+// appearance, edit a project-scoped copy (built-ins are read-only), assign it to the active
+// part, and read the part's physical properties. Edits flow straight to the session, so the
+// viewport recolors next frame (ADR-0022).
+func drawMaterialsWindow(s *app.Session) {
+	if !showMaterials {
+		return
+	}
+	native.SetNextWindowSizeOnce(420, 560)
+	if native.Begin("Materials") && native.BeginTabBar("##materials-tabs") {
+		if native.BeginTabItem("Materials") {
+			drawMaterialTab(s)
+			native.EndTabItem()
+		}
+		if native.BeginTabItem("Appearances") {
+			drawAppearanceTabContent(s)
+			native.EndTabItem()
+		}
+		if native.BeginTabItem("Physical") {
+			drawPhysicalReadout(s)
+			native.EndTabItem()
+		}
+		native.EndTabBar()
+	}
+	native.End()
+}
+
+// drawMaterialTab renders the material selector, actions, and property editor.
+func drawMaterialTab(s *app.Session) {
+	lib := s.Materials()
+	if _, ok := lib.Material(selectedMaterialID); !ok && len(lib.Materials()) > 0 {
+		selectedMaterialID = lib.Materials()[0].ID()
+	}
+	drawMaterialSelector(s)
+	m, ok := lib.Material(selectedMaterialID)
+	if !ok {
+		return
+	}
+	drawMaterialActions(s, m)
+	native.Separator()
+	editMaterialProps(s, m)
+}
+
+// drawMaterialSelector renders the material dropdown.
+func drawMaterialSelector(s *app.Session) {
+	current := selectedMaterialID
+	if m, ok := s.Materials().Material(selectedMaterialID); ok {
+		current = m.DisplayName()
+	}
+	if !native.BeginCombo("Material", current) {
+		return
+	}
+	for _, m := range s.Materials().Materials() {
+		if native.Selectable(m.DisplayName(), m.ID() == selectedMaterialID) {
+			selectedMaterialID = m.ID()
+		}
+	}
+	native.EndCombo()
+}
+
+// drawMaterialActions renders duplicate + assign-to-part for the selected material.
+func drawMaterialActions(s *app.Session, m *material.Material) {
+	native.InputText("Copy name", matNameBuf[:])
+	native.SameLine()
+	if native.Button("Duplicate##mat") {
+		if dup, err := s.DuplicateMaterial(m.ID(), bufString(matNameBuf[:])); err == nil {
+			selectedMaterialID = dup.ID()
+			clearBuf(matNameBuf[:])
+		}
+	}
+	if native.Button("Assign to part") {
+		_ = s.AssignMaterial("", m.ID())
+	}
+}
+
+// editMaterialProps renders the editable property fields (disabled for built-ins).
+func editMaterialProps(s *app.Session, m *material.Material) {
+	editable := m.Source().Editable()
+	native.BeginDisabled(!editable)
+	spec := m.Spec()
+	changed := false
+	dbl("Density (g/cm³)", &spec.Density, &changed)
+	native.SeparatorText("Mechanical")
+	dbl("Young's modulus (GPa)", &spec.Mechanical.YoungsModulus, &changed)
+	dbl("Poisson's ratio", &spec.Mechanical.PoissonsRatio, &changed)
+	dbl("Yield strength (MPa)", &spec.Mechanical.YieldStrength, &changed)
+	dbl("Tensile strength (MPa)", &spec.Mechanical.UltimateTensileStrength, &changed)
+	native.SeparatorText("Thermal")
+	dbl("Conductivity (W/m·K)", &spec.Thermal.Conductivity, &changed)
+	dbl("Expansion (1/K)", &spec.Thermal.ExpansionCoeff, &changed)
+	dbl("Specific heat (J/kg·K)", &spec.Thermal.SpecificHeat, &changed)
+	native.SeparatorText("Electrical")
+	dbl("Resistivity (Ω·m)", &spec.Electrical.Resistivity, &changed)
+	dbl("Rel. permittivity", &spec.Electrical.RelativePermittivity, &changed)
+	native.EndDisabled()
+	if changed && editable {
+		s.UpdateMaterial(m.ID(), spec)
+	}
+}
+
+// dbl draws a float64 field, OR-ing its change into changed.
+func dbl(label string, v *float64, changed *bool) {
+	if native.InputDouble(label, v) {
+		*changed = true
+	}
+}
+
+// drawPhysicalReadout shows the active part's computed mass properties.
+func drawPhysicalReadout(s *app.Session) {
+	props, ok := s.PhysicalProperties()
+	if !ok {
+		native.Text("No active part.")
+		return
+	}
+	native.Text(fmt.Sprintf("Mass:     %.3f g", props.Mass))
+	native.Text(fmt.Sprintf("Volume:   %.3f cm³", props.Volume))
+	native.Text(fmt.Sprintf("Area:     %.3f cm²", props.Area))
+	native.Text(fmt.Sprintf("Density:  %.3f g/cm³", props.Density))
+	native.Text(fmt.Sprintf("Centroid: (%.2f, %.2f, %.2f) cm",
+		props.Centroid[0], props.Centroid[1], props.Centroid[2]))
+}

--- a/head/ui/materials_window_test.go
+++ b/head/ui/materials_window_test.go
@@ -1,0 +1,35 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// TestInWindowMaterialsWindowDrawsAllTabs opens the real window with the Materials window
+// visible and runs frames, so a mismatched ImGui Begin/End (tab bar, combo, disabled) in the
+// material/appearance/physical panes would trip Dear ImGui's assertions. It just needs to
+// run without aborting.
+func TestInWindowMaterialsWindowDrawsAllTabs(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+
+	showMaterials = true
+	defer func() { showMaterials = false }()
+
+	// A couple of frames so the window appears and its default tab renders, plus selecting
+	// the first built-in material populates the (disabled) property editor.
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	// The library the window reads must be non-empty (the combos would otherwise be blank).
+	if len(s.Materials().Materials()) == 0 {
+		t.Fatal("materials library empty during window draw")
+	}
+}

--- a/implementation-plan/M19-materials-appearances/_milestone.md
+++ b/implementation-plan/M19-materials-appearances/_milestone.md
@@ -1,0 +1,58 @@
+---
+milestone: M19
+name: Materials & Appearances
+status: in-progress
+---
+
+# M19 — Materials & Appearances
+
+Two linked subsystems: **Appearance** (metallic-roughness PBR — what the renderer shows) and
+**Material** (real-world physical properties: density + mechanical/thermal/electrical, linked
+to an appearance). Materials and appearances are assignable to bodies, customizable
+(duplicate-and-edit), shareable across a project's documents, and embedded per-document for
+portability. Excludes 3D image-texture maps (deferred) — solid PBR values only.
+
+See [ADR-0022](../../architecture/decisions/ADR-0022-materials-appearances.md).
+
+## Goals
+
+- Author and assign appearances/materials to bodies, with a live-updating viewport.
+- Custom assets project-scoped (shared across documents) and embedded per-document.
+- A physical-properties readout (mass/volume/area/centroid) from the assigned material.
+- The whole surface on the public API for add-ins.
+
+## In scope
+
+- `model/material`: typed Appearance/Material assets, Library, built-in catalog, assignment
+  store (by reference key) with the appearance-source override chain.
+- Document embedding + project DesignData library persistence.
+- Renderer PBR surface resolution; `ops` mass properties.
+- `api` contract + `addin/router` + the head Materials window.
+
+## Out of scope (later)
+
+- Image-based texture maps (albedo/normal/roughness) + UVs.
+- Face-level override *rendering* (mesh split per face); GGX/IBL shading.
+- Material-driven simulation (M18) beyond the property data it consumes.
+
+## Exit criteria
+
+- Assign a material to a part, see the viewport recolor live, duplicate an appearance and
+  alter its albedo, read the mass; reopen the `.obk` and the assignment + custom asset
+  persist; another document in the project reuses the project-library asset.
+
+## Depends on
+
+M07 (B-rep bodies), M08 (part features), M05 (UI shell), ADR-0018, ADR-0020, ADR-0021.
+
+## Features
+
+| Feature | Title |
+|---------|-------|
+| F01 | Appearance & Material object model + built-in catalog |
+| F02 | Scope tiers: project library + document embedding + persistence |
+| F03 | Assignment & override chain (by reference key) |
+| F04 | Renderer PBR surface resolution |
+| F05 | Mass / physical properties |
+| F06 | Public API: appearances/materials/assign/physical-properties |
+| F07 | UI: Materials window (browser, editors, assign, readout) |

--- a/kernel/ops/massprops.go
+++ b/kernel/ops/massprops.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// GeometryProperties is the density-independent mass-properties of a closed body: the
+// enclosed volume, the surface area, and the centroid (center of mass for a uniform
+// body). Mass = density × Volume is left to the caller, which owns the material density.
+// Lengths are in database units, so Volume is units³ and Area units².
+type GeometryProperties struct {
+	Volume   float64
+	Area     float64
+	Centroid math.Point3
+}
+
+// BodyGeometryProperties computes the volume, area, and centroid of a body from its
+// tessellation at quality q. Volume and centroid use the divergence-theorem
+// signed-tetrahedron sum over the triangulated surface (exact for planar faces; it
+// converges with q for curved ones); area sums the triangle areas. A non-solid or empty
+// body yields zero volume.
+func BodyGeometryProperties(b *topo.Body, q Quality) GeometryProperties {
+	mesh, _ := TessellateBody(b, q)
+	return meshGeometryProperties(mesh)
+}
+
+// meshGeometryProperties is the pure computation over a triangle mesh, factored out so it
+// is testable without a body. Each triangle (a,b,c) forms a tetrahedron with the origin;
+// the signed tetra volumes sum to the enclosed volume regardless of where the origin sits
+// (the parts outside the body cancel), and the volume-weighted tetra centroids give the
+// body centroid. Each triangle is first oriented outward using the mesh's per-vertex
+// normals, so the sum is correct even when a tessellator does not guarantee globally
+// consistent winding across faces (without this the divergence sum is not
+// translation-invariant — see TestVolumeIsTranslationInvariant).
+func meshGeometryProperties(mesh *Mesh) GeometryProperties {
+	origin := math.P3(0, 0, 0)
+	var vol, area, cx, cy, cz float64
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		ia, ib, ic := mesh.Indices[t], mesh.Indices[t+1], mesh.Indices[t+2]
+		a, b, c := mesh.Positions[ia], mesh.Positions[ib], mesh.Positions[ic]
+		// Force outward winding: if the geometric normal opposes the (outward) shading
+		// normal, swap two vertices.
+		if outwardRef(mesh, ia, ib, ic).Dot(a.VectorTo(b).Cross(a.VectorTo(c))) < 0 {
+			b, c = c, b
+		}
+		sv := float64(origin.VectorTo(a).Dot(origin.VectorTo(b).Cross(origin.VectorTo(c)))) / 6
+		vol += sv
+		cx += sv * float64(a.X+b.X+c.X) / 4
+		cy += sv * float64(a.Y+b.Y+c.Y) / 4
+		cz += sv * float64(a.Z+b.Z+c.Z) / 4
+		area += float64(a.VectorTo(b).Cross(a.VectorTo(c)).Length()) / 2
+	}
+	centroid := origin
+	if vol != 0 {
+		centroid = math.P3(math.Scalar(cx/vol), math.Scalar(cy/vol), math.Scalar(cz/vol))
+	}
+	if vol < 0 {
+		vol = -vol // orientation may flip the sign; the enclosed volume is its magnitude
+	}
+	return GeometryProperties{Volume: vol, Area: area, Centroid: centroid}
+}
+
+// outwardRef returns the triangle's reference outward direction — the sum of its three
+// vertex normals (the tessellator writes outward shading normals).
+func outwardRef(mesh *Mesh, ia, ib, ic int) math.Vector3 {
+	return mesh.Normals[ia].Add(mesh.Normals[ib]).Add(mesh.Normals[ic])
+}

--- a/kernel/ops/massprops_test.go
+++ b/kernel/ops/massprops_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	m "github.com/Oblikovati/oblikovati/math"
+)
+
+// A corner tetrahedron with legs s has volume s³/6 and centroid (s/4,s/4,s/4) — an
+// analytic check that the divergence-theorem volume/centroid are correct (planar faces
+// make tessellation exact).
+func TestTetraVolumeAndCentroid(t *testing.T) {
+	const s = 2.0
+	gp := BodyGeometryProperties(tetra(s, m.V3(0, 0, 0)), DefaultQuality())
+
+	wantVol := s * s * s / 6
+	if math.Abs(gp.Volume-wantVol) > 1e-6 {
+		t.Errorf("Volume = %v, want %v", gp.Volume, wantVol)
+	}
+	want := s / 4
+	if math.Abs(float64(gp.Centroid.X)-want) > 1e-6 ||
+		math.Abs(float64(gp.Centroid.Y)-want) > 1e-6 ||
+		math.Abs(float64(gp.Centroid.Z)-want) > 1e-6 {
+		t.Errorf("Centroid = %v, want (%v,%v,%v)", gp.Centroid, want, want, want)
+	}
+}
+
+// Volume must be translation-invariant even though the tetra method references the
+// origin — the off-origin parts cancel.
+func TestVolumeIsTranslationInvariant(t *testing.T) {
+	atOrigin := BodyGeometryProperties(tetra(2, m.V3(0, 0, 0)), DefaultQuality())
+	moved := BodyGeometryProperties(tetra(2, m.V3(100, -50, 25)), DefaultQuality())
+	if math.Abs(atOrigin.Volume-moved.Volume) > 1e-6 {
+		t.Errorf("volume changed under translation: %v vs %v", atOrigin.Volume, moved.Volume)
+	}
+}

--- a/model/compdef/material_assign_test.go
+++ b/model/compdef/material_assign_test.go
@@ -2,7 +2,11 @@
 
 package compdef
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/model/material"
+)
 
 // Assignments are keyed by persistent reference keys, so Recompute (which regenerates the
 // bodies) must leave the assignment store intact — otherwise a material would vanish every
@@ -20,4 +24,38 @@ func TestAssignmentsSurviveRecompute(t *testing.T) {
 	if got := def.Assignments().BodyMaterials()["abcd"]; got != "aluminum-6061" {
 		t.Errorf("body material after Recompute = %q, want \"aluminum-6061\"", got)
 	}
+}
+
+// The materials section must survive a full recipe round-trip (Marshal → Apply through
+// YAML), restoring the document's embedded appearance and its assignment.
+func TestMaterialsRecipeRoundTrip(t *testing.T) {
+	def := NewPartComponentDefinition()
+	def.Assets().PutAppearance(material.NewAppearance("doc-blue", material.SourceDocument,
+		material.AppearanceSpec{DisplayName: "Doc Blue", Albedo: parseColor(t, "#2040ffff"), Opacity: 1}))
+	def.Assignments().SetPartAppearance("doc-blue")
+
+	yaml, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	restored := NewPartComponentDefinition()
+	if err := restored.ApplyRecipe(yaml); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	a, ok := restored.Assets().Appearance("doc-blue")
+	if !ok || a.Albedo() != parseColor(t, "#2040ffff") {
+		t.Errorf("embedded appearance not restored from recipe: %v ok=%v", a, ok)
+	}
+	if restored.Assignments().PartAppearance() != "doc-blue" {
+		t.Errorf("assignment not restored: %q", restored.Assignments().PartAppearance())
+	}
+}
+
+func parseColor(t *testing.T, hex string) material.Rgba {
+	t.Helper()
+	c, err := material.ParseColor(hex)
+	if err != nil {
+		t.Fatalf("ParseColor(%q): %v", hex, err)
+	}
+	return c
 }

--- a/model/compdef/material_assign_test.go
+++ b/model/compdef/material_assign_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import "testing"
+
+// Assignments are keyed by persistent reference keys, so Recompute (which regenerates the
+// bodies) must leave the assignment store intact — otherwise a material would vanish every
+// time the model recomputes.
+func TestAssignmentsSurviveRecompute(t *testing.T) {
+	def := NewPartComponentDefinition()
+	def.Assignments().SetPartMaterial("steel")
+	def.Assignments().SetBodyMaterial("abcd", "aluminum-6061")
+
+	def.Recompute()
+
+	if got := def.Assignments().PartMaterial(); got != "steel" {
+		t.Errorf("part material after Recompute = %q, want \"steel\"", got)
+	}
+	if got := def.Assignments().BodyMaterials()["abcd"]; got != "aluminum-6061" {
+		t.Errorf("body material after Recompute = %q, want \"aluminum-6061\"", got)
+	}
+}

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -35,6 +35,9 @@ type PartComponentDefinition struct {
 	// assignments survive Recompute (keyed by persistent reference key, not body id), so a
 	// material/appearance stays put when the body it is on is regenerated.
 	assignments *material.AssignmentStore
+	// assets are the document's embedded appearance/material copies (the non-built-in
+	// assets it uses), making the .obk self-contained (ADR-0022).
+	assets *material.AssetSet
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature
@@ -52,12 +55,17 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		units:       param.DefaultUnitsOfMeasure(),
 		eop:         endOfPartAtEnd,
 		assignments: material.NewAssignmentStore(),
+		assets:      material.NewAssetSet(),
 	}
 }
 
 // Assignments returns the part's material/appearance assignment store. It is keyed by
 // persistent reference keys, so it is unaffected by Recompute.
 func (d *PartComponentDefinition) Assignments() *material.AssignmentStore { return d.assignments }
+
+// Assets returns the part's embedded appearance/material set (the document-owned copies of
+// the non-built-in assets it uses).
+func (d *PartComponentDefinition) Assets() *material.AssetSet { return d.assets }
 
 // AddPart creates a new part document in ws with a realized part component
 // definition installed (not the bare doc-package placeholder), makes it active, and

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Oblikovati/oblikovati/model/doc"
 	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/identity"
+	"github.com/Oblikovati/oblikovati/model/material"
 	"github.com/Oblikovati/oblikovati/model/param"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
@@ -31,6 +32,9 @@ type PartComponentDefinition struct {
 	units    param.UnitsOfMeasure  // document display units (length/angle/…)
 	version  uint64
 	eop      int // end-of-part feature index; endOfPartAtEnd ⇒ full program
+	// assignments survive Recompute (keyed by persistent reference key, not body id), so a
+	// material/appearance stays put when the body it is on is regenerated.
+	assignments *material.AssignmentStore
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature
@@ -39,16 +43,21 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 	params := param.NewParameters()
 	keys := identity.NewKeyManager()
 	return &PartComponentDefinition{
-		bodies:   topo.NewSurfaceBodies(),
-		params:   params,
-		sketches: sketch.NewSketches(),
-		features: feature.NewPartFeatures(params, keys),
-		keys:     keys,
-		work:     feature.NewWorkGeometry(),
-		units:    param.DefaultUnitsOfMeasure(),
-		eop:      endOfPartAtEnd,
+		bodies:      topo.NewSurfaceBodies(),
+		params:      params,
+		sketches:    sketch.NewSketches(),
+		features:    feature.NewPartFeatures(params, keys),
+		keys:        keys,
+		work:        feature.NewWorkGeometry(),
+		units:       param.DefaultUnitsOfMeasure(),
+		eop:         endOfPartAtEnd,
+		assignments: material.NewAssignmentStore(),
 	}
 }
+
+// Assignments returns the part's material/appearance assignment store. It is keyed by
+// persistent reference keys, so it is unaffected by Recompute.
+func (d *PartComponentDefinition) Assignments() *material.AssignmentStore { return d.assignments }
 
 // AddPart creates a new part document in ws with a realized part component
 // definition installed (not the bare doc-package placeholder), makes it active, and

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Oblikovati/oblikovati/model/doc"
 	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/material"
 	"github.com/Oblikovati/oblikovati/model/param"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
@@ -34,6 +35,7 @@ type partRecipe struct {
 	WorkFeatures []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
 	Sketches     []sketch.SketchData       `yaml:"sketches,omitempty"`
 	Features     []feature.FeatureData     `yaml:"features,omitempty"`
+	Materials    *material.RecipeData      `yaml:"materials,omitempty"`
 }
 
 // sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
@@ -92,6 +94,7 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		WorkFeatures: work,
 		Sketches:     sketches,
 		Features:     features,
+		Materials:    d.materialsRecipe(),
 	}
 	if d.eop != endOfPartAtEnd {
 		eop := d.eop
@@ -121,11 +124,26 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 	if err := d.features.ApplyRecipe(r.Features, sketchIndex{d.sketches}, d.work); err != nil {
 		return fmt.Errorf("compdef: restore features: %w", err)
 	}
+	if r.Materials != nil {
+		if err := material.ApplyRecipe(*r.Materials, d.assets, d.assignments); err != nil {
+			return fmt.Errorf("compdef: restore materials: %w", err)
+		}
+	}
 	if r.EndOfPart != nil {
 		d.SetEndOfPart(*r.EndOfPart)
 	}
 	d.Recompute()
 	return nil
+}
+
+// materialsRecipe captures the document's embedded assets and assignments, or nil when
+// the part has neither (keeps an un-styled part's recipe minimal).
+func (d *PartComponentDefinition) materialsRecipe() *material.RecipeData {
+	data := material.MarshalRecipe(d.assets, d.assignments)
+	if len(data.Appearances) == 0 && len(data.Materials) == 0 && data.Assignments == nil {
+		return nil
+	}
+	return &data
 }
 
 // unitsRecipe captures the preferred display-unit name for each category.

--- a/model/material/appearance.go
+++ b/model/material/appearance.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import "github.com/Oblikovati/api/contract"
+
+// AppearanceSpec is the editable content of an appearance — everything but its identity
+// and source. Carrying the editable fields as one value keeps construction and edits
+// (which must respect the read-only rule for built-ins) in one place.
+type AppearanceSpec struct {
+	DisplayName string
+	Albedo      Rgba
+	Metallic    float32
+	Roughness   float32
+	Emissive    Rgba
+	Opacity     float32
+}
+
+// Appearance is one PBR appearance asset. It satisfies [contract.Appearance].
+type Appearance struct {
+	id     string
+	source Source
+	spec   AppearanceSpec
+}
+
+var _ contract.Appearance = (*Appearance)(nil)
+
+// NewAppearance builds an appearance with a stable id, a source, and its spec.
+func NewAppearance(id string, source Source, spec AppearanceSpec) *Appearance {
+	return &Appearance{id: id, source: source, spec: spec}
+}
+
+// ID / DisplayName / Source / Albedo / Metallic / Roughness / Emissive / Opacity satisfy
+// the read-only public contract.
+func (a *Appearance) ID() string          { return a.id }
+func (a *Appearance) DisplayName() string { return a.spec.DisplayName }
+func (a *Appearance) Source() Source      { return a.source }
+func (a *Appearance) Albedo() Rgba        { return a.spec.Albedo }
+func (a *Appearance) Metallic() float32   { return a.spec.Metallic }
+func (a *Appearance) Roughness() float32  { return a.spec.Roughness }
+func (a *Appearance) Emissive() Rgba      { return a.spec.Emissive }
+func (a *Appearance) Opacity() float32    { return a.spec.Opacity }
+
+// Spec returns a copy of the editable fields (the editor reads it to populate controls).
+func (a *Appearance) Spec() AppearanceSpec { return a.spec }
+
+// SetSpec replaces the editable fields. It is a no-op on a built-in (read-only); only
+// project/document assets are editable (see [types.AssetSource.Editable]).
+func (a *Appearance) SetSpec(spec AppearanceSpec) {
+	if !a.source.Editable() {
+		return
+	}
+	a.spec = spec
+}
+
+// duplicate returns an independent copy under a new id/name and source — a full snapshot
+// of the spec, so editing the copy never touches the original.
+func (a *Appearance) duplicate(id, name string, source Source) *Appearance {
+	spec := a.spec
+	spec.DisplayName = name
+	return &Appearance{id: id, source: source, spec: spec}
+}

--- a/model/material/assetset.go
+++ b/model/material/assetset.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+// AssetSet is the appearances and materials a single document embeds — a copy of every
+// non-built-in asset it uses, so the .obk is self-contained and portable even without the
+// project library it was authored against (ADR-0022). Built-in assets are not embedded
+// (they are always reproducible from the catalog), so the set stays small.
+type AssetSet struct {
+	appearances map[string]*Appearance
+	materials   map[string]*Material
+}
+
+// NewAssetSet returns an empty document asset set.
+func NewAssetSet() *AssetSet {
+	return &AssetSet{appearances: map[string]*Appearance{}, materials: map[string]*Material{}}
+}
+
+// PutAppearance / PutMaterial embed (or replace) an asset under its id.
+func (s *AssetSet) PutAppearance(a *Appearance) { s.appearances[a.id] = a }
+func (s *AssetSet) PutMaterial(m *Material)     { s.materials[m.id] = m }
+
+// Appearance / Material look up an embedded asset by id.
+func (s *AssetSet) Appearance(id string) (*Appearance, bool) {
+	a, ok := s.appearances[id]
+	return a, ok
+}
+func (s *AssetSet) Material(id string) (*Material, bool) { m, ok := s.materials[id]; return m, ok }
+
+// Appearances / Materials return the embedded assets (order is unspecified; callers that
+// need determinism sort by id).
+func (s *AssetSet) Appearances() []*Appearance {
+	out := make([]*Appearance, 0, len(s.appearances))
+	for _, a := range s.appearances {
+		out = append(out, a)
+	}
+	return out
+}
+
+func (s *AssetSet) Materials() []*Material {
+	out := make([]*Material, 0, len(s.materials))
+	for _, m := range s.materials {
+		out = append(out, m)
+	}
+	return out
+}
+
+// MergedLookup resolves asset ids over a document's embedded assets first, then the
+// session catalog (built-ins + project). It satisfies [AssetLookup], so the renderer and
+// browser see the document's own copies before the shared catalog — the document-embedded
+// asset is authoritative for portability.
+type MergedLookup struct {
+	Embedded *AssetSet
+	Catalog  *Library
+}
+
+// Appearance / Material look up an id, embedded set first.
+func (m MergedLookup) Appearance(id string) (*Appearance, bool) {
+	if m.Embedded != nil {
+		if a, ok := m.Embedded.Appearance(id); ok {
+			return a, true
+		}
+	}
+	return m.Catalog.Appearance(id)
+}
+
+func (m MergedLookup) Material(id string) (*Material, bool) {
+	if m.Embedded != nil {
+		if mat, ok := m.Embedded.Material(id); ok {
+			return mat, true
+		}
+	}
+	return m.Catalog.Material(id)
+}
+
+// DefaultAppearance defers to the catalog's neutral default.
+func (m MergedLookup) DefaultAppearance() *Appearance { return m.Catalog.DefaultAppearance() }

--- a/model/material/assignment.go
+++ b/model/material/assignment.go
@@ -54,9 +54,18 @@ func (s *AssignmentStore) BodyAppearances() map[string]string {
 }
 func (s *AssignmentStore) FaceAppearances() map[string]string { return copyMap(s.faceAppearance) }
 
+// AssetLookup resolves asset ids to assets. Both [Library] (the session catalog) and a
+// [MergedLookup] (document-embedded assets over the catalog) satisfy it, so the same
+// precedence logic serves the browser and the renderer regardless of where an asset lives.
+type AssetLookup interface {
+	Appearance(id string) (*Appearance, bool)
+	Material(id string) (*Material, bool)
+	DefaultAppearance() *Appearance
+}
+
 // EffectiveMaterial returns the material governing a body (its override, else the part
 // default), or false when none is assigned.
-func (s *AssignmentStore) EffectiveMaterial(lib *Library, bodyKey string) (*Material, bool) {
+func (s *AssignmentStore) EffectiveMaterial(look AssetLookup, bodyKey string) (*Material, bool) {
 	id := s.bodyMaterial[bodyKey]
 	if id == "" {
 		id = s.partMaterial
@@ -64,30 +73,39 @@ func (s *AssignmentStore) EffectiveMaterial(lib *Library, bodyKey string) (*Mate
 	if id == "" {
 		return nil, false
 	}
-	return lib.Material(id)
+	return look.Material(id)
 }
 
 // EffectiveAppearance resolves the appearance shown for a body/face along the precedence
 // chain. faceKey may be "" to resolve at body level. It always returns a non-nil
 // appearance (the neutral default when nothing else applies).
-func (s *AssignmentStore) EffectiveAppearance(lib *Library, bodyKey, faceKey string) *Appearance {
+func (s *AssignmentStore) EffectiveAppearance(look AssetLookup, bodyKey, faceKey string) *Appearance {
 	if faceKey != "" {
-		if a := lib.appearanceOrNil(s.faceAppearance[faceKey]); a != nil {
+		if a := apprOrNil(look, s.faceAppearance[faceKey]); a != nil {
 			return a
 		}
 	}
-	if a := lib.appearanceOrNil(s.bodyAppearance[bodyKey]); a != nil {
+	if a := apprOrNil(look, s.bodyAppearance[bodyKey]); a != nil {
 		return a
 	}
-	if m, ok := s.EffectiveMaterial(lib, bodyKey); ok {
-		if a := lib.appearanceOrNil(m.AppearanceID()); a != nil {
+	if m, ok := s.EffectiveMaterial(look, bodyKey); ok {
+		if a := apprOrNil(look, m.AppearanceID()); a != nil {
 			return a
 		}
 	}
-	if a := lib.appearanceOrNil(s.partAppearance); a != nil {
+	if a := apprOrNil(look, s.partAppearance); a != nil {
 		return a
 	}
-	return lib.defaultAppearance()
+	return look.DefaultAppearance()
+}
+
+// apprOrNil returns the appearance for id via look, or nil for an empty/unknown id.
+func apprOrNil(look AssetLookup, id string) *Appearance {
+	if id == "" {
+		return nil
+	}
+	a, _ := look.Appearance(id)
+	return a
 }
 
 // setOrClear sets key→id, or deletes key when id is empty.

--- a/model/material/assignment.go
+++ b/model/material/assignment.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import "encoding/hex"
+
+// AssignmentStore records which material/appearance is assigned where in a part, keyed by
+// the persistent hex reference key of a body or face — stable across Recompute, unlike the
+// transient body id. It holds a part-default material and appearance plus per-body and
+// per-face overrides.
+//
+// Resolving a surface's effective appearance follows Inventor's AppearanceSourceType
+// precedence: face override → body appearance override → body material's appearance →
+// part material's appearance → part default appearance → the neutral default.
+type AssignmentStore struct {
+	partMaterial   string
+	partAppearance string
+	bodyMaterial   map[string]string // bodyKey → material id
+	bodyAppearance map[string]string // bodyKey → appearance id
+	faceAppearance map[string]string // faceKey → appearance id
+}
+
+// NewAssignmentStore returns an empty store (no assignments — everything resolves to the
+// default appearance).
+func NewAssignmentStore() *AssignmentStore {
+	return &AssignmentStore{
+		bodyMaterial:   map[string]string{},
+		bodyAppearance: map[string]string{},
+		faceAppearance: map[string]string{},
+	}
+}
+
+// RefKey is the canonical hex encoding of a topology reference key ([]byte) used as the
+// map key, so callers in the head/app convert a body/face key consistently.
+func RefKey(key []byte) string { return hex.EncodeToString(key) }
+
+// SetPartMaterial / SetPartAppearance set the part-level defaults ("" clears).
+func (s *AssignmentStore) SetPartMaterial(id string)   { s.partMaterial = id }
+func (s *AssignmentStore) SetPartAppearance(id string) { s.partAppearance = id }
+
+// SetBodyMaterial / SetBodyAppearance / SetFaceAppearance set an override for one
+// body/face key; an empty id removes the override.
+func (s *AssignmentStore) SetBodyMaterial(key, id string)   { setOrClear(s.bodyMaterial, key, id) }
+func (s *AssignmentStore) SetBodyAppearance(key, id string) { setOrClear(s.bodyAppearance, key, id) }
+func (s *AssignmentStore) SetFaceAppearance(key, id string) { setOrClear(s.faceAppearance, key, id) }
+
+// PartMaterial / PartAppearance / BodyMaterials / BodyAppearances / FaceAppearances expose
+// the raw assignments for persistence (the maps are copies).
+func (s *AssignmentStore) PartMaterial() string             { return s.partMaterial }
+func (s *AssignmentStore) PartAppearance() string           { return s.partAppearance }
+func (s *AssignmentStore) BodyMaterials() map[string]string { return copyMap(s.bodyMaterial) }
+func (s *AssignmentStore) BodyAppearances() map[string]string {
+	return copyMap(s.bodyAppearance)
+}
+func (s *AssignmentStore) FaceAppearances() map[string]string { return copyMap(s.faceAppearance) }
+
+// EffectiveMaterial returns the material governing a body (its override, else the part
+// default), or false when none is assigned.
+func (s *AssignmentStore) EffectiveMaterial(lib *Library, bodyKey string) (*Material, bool) {
+	id := s.bodyMaterial[bodyKey]
+	if id == "" {
+		id = s.partMaterial
+	}
+	if id == "" {
+		return nil, false
+	}
+	return lib.Material(id)
+}
+
+// EffectiveAppearance resolves the appearance shown for a body/face along the precedence
+// chain. faceKey may be "" to resolve at body level. It always returns a non-nil
+// appearance (the neutral default when nothing else applies).
+func (s *AssignmentStore) EffectiveAppearance(lib *Library, bodyKey, faceKey string) *Appearance {
+	if faceKey != "" {
+		if a := lib.appearanceOrNil(s.faceAppearance[faceKey]); a != nil {
+			return a
+		}
+	}
+	if a := lib.appearanceOrNil(s.bodyAppearance[bodyKey]); a != nil {
+		return a
+	}
+	if m, ok := s.EffectiveMaterial(lib, bodyKey); ok {
+		if a := lib.appearanceOrNil(m.AppearanceID()); a != nil {
+			return a
+		}
+	}
+	if a := lib.appearanceOrNil(s.partAppearance); a != nil {
+		return a
+	}
+	return lib.defaultAppearance()
+}
+
+// setOrClear sets key→id, or deletes key when id is empty.
+func setOrClear(m map[string]string, key, id string) {
+	if id == "" {
+		delete(m, key)
+		return
+	}
+	m[key] = id
+}
+
+// copyMap returns an independent copy of a string map (defensive, for persistence reads).
+func copyMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/model/material/assignment_test.go
+++ b/model/material/assignment_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import "testing"
+
+func TestEffectiveAppearancePrecedence(t *testing.T) {
+	lib := NewLibrary()
+	st := NewAssignmentStore()
+	const body, face = "bodykey", "facekey"
+
+	// Nothing assigned → neutral default.
+	if got := st.EffectiveAppearance(lib, body, ""); got.ID() != DefaultAppearanceID {
+		t.Errorf("unassigned body appearance = %q, want %q", got.ID(), DefaultAppearanceID)
+	}
+
+	// Part-default material → that material's appearance.
+	st.SetPartMaterial("steel") // steel material → "steel" appearance
+	if got := st.EffectiveAppearance(lib, body, ""); got.ID() != "steel" {
+		t.Errorf("with part material, appearance = %q, want \"steel\"", got.ID())
+	}
+
+	// Body material override beats the part default.
+	st.SetBodyMaterial(body, "aluminum-6061") // → "aluminum" appearance
+	if got := st.EffectiveAppearance(lib, body, ""); got.ID() != "aluminum" {
+		t.Errorf("with body material, appearance = %q, want \"aluminum\"", got.ID())
+	}
+
+	// Body appearance override beats the material's appearance.
+	st.SetBodyAppearance(body, "oak")
+	if got := st.EffectiveAppearance(lib, body, ""); got.ID() != "oak" {
+		t.Errorf("with body appearance override, = %q, want \"oak\"", got.ID())
+	}
+
+	// Face override beats everything.
+	st.SetFaceAppearance(face, "abs-black")
+	if got := st.EffectiveAppearance(lib, body, face); got.ID() != "abs-black" {
+		t.Errorf("with face override, = %q, want \"abs-black\"", got.ID())
+	}
+	// A different face (no override) still resolves to the body override.
+	if got := st.EffectiveAppearance(lib, body, "otherface"); got.ID() != "oak" {
+		t.Errorf("other face = %q, want \"oak\" (body override)", got.ID())
+	}
+}
+
+func TestEffectiveMaterialOverride(t *testing.T) {
+	lib := NewLibrary()
+	st := NewAssignmentStore()
+	st.SetPartMaterial("steel")
+	st.SetBodyMaterial("b1", "aluminum-6061")
+
+	if m, ok := st.EffectiveMaterial(lib, "b1"); !ok || m.ID() != "aluminum-6061" {
+		t.Errorf("body b1 material = %v, want aluminum-6061", m)
+	}
+	if m, ok := st.EffectiveMaterial(lib, "b2"); !ok || m.ID() != "steel" {
+		t.Errorf("body b2 material = %v, want steel (part default)", m)
+	}
+}
+
+func TestSetEmptyClearsAssignment(t *testing.T) {
+	st := NewAssignmentStore()
+	st.SetBodyMaterial("b1", "steel")
+	st.SetBodyMaterial("b1", "") // clear
+	if len(st.BodyMaterials()) != 0 {
+		t.Errorf("empty id did not clear the assignment: %v", st.BodyMaterials())
+	}
+}

--- a/model/material/builtin.go
+++ b/model/material/builtin.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/api/types"
+)
+
+// DefaultAppearanceID is the neutral appearance applied when a body has no material or
+// appearance assigned — it reproduces the renderer's pre-materials default gray, so an
+// un-assigned model looks exactly as it did before this subsystem.
+const DefaultAppearanceID = "default"
+
+// seedBuiltins fills a fresh library with the shipped, read-only catalog: a neutral
+// default plus a few representative metals, plastics, and wood, each with a paired
+// appearance. Property values follow common engineering references (Inventor-comparable).
+func seedBuiltins(l *Library) {
+	for _, a := range builtinAppearances() {
+		l.AddAppearance(a)
+	}
+	for _, m := range builtinMaterials() {
+		l.AddMaterial(m)
+	}
+}
+
+// builtinAppearances returns the shipped appearance catalog.
+func builtinAppearances() []*Appearance {
+	a := func(id, name, albedo string, metallic, roughness float32) *Appearance {
+		return NewAppearance(id, SourceBuiltin, AppearanceSpec{
+			DisplayName: name, Albedo: mustColor(albedo), Metallic: metallic, Roughness: roughness,
+			Emissive: mustColor("#000000ff"), Opacity: 1,
+		})
+	}
+	return []*Appearance{
+		a(DefaultAppearanceID, "Default", "#b3b8bdff", 0, 0.6),
+		a("steel", "Steel", "#8a8d92ff", 0.9, 0.40),
+		a("aluminum", "Aluminum", "#c8ccd0ff", 0.9, 0.35),
+		a("abs-black", "ABS (Black)", "#1a1a1aff", 0, 0.50),
+		a("abs-white", "ABS (White)", "#e8e8e8ff", 0, 0.50),
+		a("oak", "Oak", "#b88a4fff", 0, 0.70),
+	}
+}
+
+// builtinMaterials returns the shipped material catalog, each referencing a built-in
+// appearance by id.
+func builtinMaterials() []*Material {
+	return []*Material{
+		NewMaterial("steel", SourceBuiltin, MaterialSpec{
+			DisplayName: "Steel", Density: 7.85, AppearanceID: "steel",
+			Mechanical: Mechanical{YoungsModulus: 210, PoissonsRatio: 0.30, YieldStrength: 350, UltimateTensileStrength: 420},
+			Thermal:    Thermal{Conductivity: 50, ExpansionCoeff: 12e-6, SpecificHeat: 480},
+			Electrical: Electrical{Resistivity: 1.7e-7, RelativePermittivity: 1},
+		}),
+		NewMaterial("aluminum-6061", SourceBuiltin, MaterialSpec{
+			DisplayName: "Aluminum 6061", Density: 2.70, AppearanceID: "aluminum",
+			Mechanical: Mechanical{YoungsModulus: 68.9, PoissonsRatio: 0.33, YieldStrength: 276, UltimateTensileStrength: 310},
+			Thermal:    Thermal{Conductivity: 167, ExpansionCoeff: 23.6e-6, SpecificHeat: 896},
+			Electrical: Electrical{Resistivity: 3.99e-8, RelativePermittivity: 1},
+		}),
+		NewMaterial("abs-plastic", SourceBuiltin, MaterialSpec{
+			DisplayName: "ABS Plastic", Density: 1.06, AppearanceID: "abs-black",
+			Mechanical: Mechanical{YoungsModulus: 2.1, PoissonsRatio: 0.35, YieldStrength: 40, UltimateTensileStrength: 44},
+			Thermal:    Thermal{Conductivity: 0.17, ExpansionCoeff: 90e-6, SpecificHeat: 1300},
+			Electrical: Electrical{Resistivity: 1e15, RelativePermittivity: 3.0},
+		}),
+		NewMaterial("oak-wood", SourceBuiltin, MaterialSpec{
+			DisplayName: "Oak Wood", Density: 0.75, AppearanceID: "oak",
+			Mechanical: Mechanical{YoungsModulus: 11, PoissonsRatio: 0.35, YieldStrength: 40, UltimateTensileStrength: 50},
+			Thermal:    Thermal{Conductivity: 0.17, ExpansionCoeff: 5e-6, SpecificHeat: 1700},
+			Electrical: Electrical{Resistivity: 1e14, RelativePermittivity: 2.0},
+		}),
+	}
+}
+
+// hex parses an authored built-in color literal, panicking with the offending value on a
+// malformed constant (a programming error caught by the package tests, not a runtime
+// condition).
+func mustColor(s string) Rgba {
+	c, err := types.ParseHex(s)
+	if err != nil {
+		panic(fmt.Sprintf("material: malformed built-in color %q: %v", s, err))
+	}
+	return c
+}

--- a/model/material/doc.go
+++ b/model/material/doc.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package material owns the application's appearances and materials (ADR-0022).
+//
+// An Appearance is a metallic-roughness PBR description (what the renderer shows); a
+// Material is a physical-world material (density + mechanical/thermal/electrical
+// properties) that references an Appearance by id. Both are assets with a [Source]
+// (built-in, project, or document), held in a per-session [Library] that mirrors the
+// theme library: lookups by id, duplicate/edit/remove, and a monotonic revision counter
+// the head watches to refresh the viewport live.
+//
+// Inventor models these as generic Asset/AssetValue bags; we use concrete typed structs
+// (consistent with model/param and model/sketch), keeping Inventor's names and the
+// appearance source/override precedence. The package is pure data with no cgo/renderer
+// dependency, so it is fully headless-testable; the head maps an effective Appearance to
+// the renderer's PBR surface.
+package material
+
+import "github.com/Oblikovati/api/types"
+
+// Aliases of the canonical Apache-2.0 value types so callers program against the material
+// package without importing api/types directly (ADR-0018).
+type (
+	Source             = types.AssetSource
+	Rgba               = types.Rgba
+	Mechanical         = types.Mechanical
+	Thermal            = types.Thermal
+	Electrical         = types.Electrical
+	PhysicalProperties = types.PhysicalProperties
+)
+
+const (
+	SourceBuiltin  = types.AssetBuiltin
+	SourceProject  = types.AssetProject
+	SourceDocument = types.AssetDocument
+)

--- a/model/material/doc.go
+++ b/model/material/doc.go
@@ -34,3 +34,7 @@ const (
 	SourceProject  = types.AssetProject
 	SourceDocument = types.AssetDocument
 )
+
+// ParseColor parses a "#RRGGBBAA" (or "#RRGGBB") hex color into an Rgba — re-exported
+// from the canonical types parser so the head editors and recipe code share one path.
+func ParseColor(s string) (Rgba, error) { return types.ParseHex(s) }

--- a/model/material/library.go
+++ b/model/material/library.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Library is the set of appearances and materials available to a session: the shipped
+// built-ins, the active project's shared assets, and the assets embedded in open
+// documents, keyed by id and kept in insertion order for stable display. A monotonic
+// revision counter is bumped on any change that affects the rendered look (add, edit,
+// duplicate, remove) so the head can refresh the viewport on the next frame — the same
+// live-update mechanism as the theme library.
+type Library struct {
+	appearances map[string]*Appearance
+	materials   map[string]*Material
+	apprOrder   []string
+	matOrder    []string
+	revision    uint64
+}
+
+// NewLibrary returns a library seeded with the shipped built-in catalog.
+func NewLibrary() *Library {
+	lib := &Library{appearances: map[string]*Appearance{}, materials: map[string]*Material{}, revision: 1}
+	seedBuiltins(lib)
+	return lib
+}
+
+// Revision returns the change counter; compare it across frames to detect edits.
+func (l *Library) Revision() uint64 { return l.revision }
+
+// Appearances / Materials return the assets in insertion order. Callers must not mutate
+// the slices.
+func (l *Library) Appearances() []*Appearance {
+	out := make([]*Appearance, 0, len(l.apprOrder))
+	for _, id := range l.apprOrder {
+		out = append(out, l.appearances[id])
+	}
+	return out
+}
+
+func (l *Library) Materials() []*Material {
+	out := make([]*Material, 0, len(l.matOrder))
+	for _, id := range l.matOrder {
+		out = append(out, l.materials[id])
+	}
+	return out
+}
+
+// Appearance / Material look up an asset by id.
+func (l *Library) Appearance(id string) (*Appearance, bool) { a, ok := l.appearances[id]; return a, ok }
+func (l *Library) Material(id string) (*Material, bool)     { m, ok := l.materials[id]; return m, ok }
+
+// appearanceOrNil returns the appearance for id, or nil for an empty/unknown id — the
+// form the assignment resolver wants so it can fall through the precedence chain.
+func (l *Library) appearanceOrNil(id string) *Appearance {
+	if id == "" {
+		return nil
+	}
+	return l.appearances[id]
+}
+
+// defaultAppearance returns the neutral built-in appearance, the resolver's last resort.
+// It is always present (seeded by the built-in catalog).
+func (l *Library) defaultAppearance() *Appearance { return l.appearances[DefaultAppearanceID] }
+
+// AddAppearance / AddMaterial insert an asset (built-in seeding, library/document load),
+// replacing any existing asset with the same id without disturbing display order. They do
+// not bump the revision — loading is not a user edit.
+func (l *Library) AddAppearance(a *Appearance) {
+	if _, exists := l.appearances[a.id]; !exists {
+		l.apprOrder = append(l.apprOrder, a.id)
+	}
+	l.appearances[a.id] = a
+}
+
+func (l *Library) AddMaterial(m *Material) {
+	if _, exists := l.materials[m.id]; !exists {
+		l.matOrder = append(l.matOrder, m.id)
+	}
+	l.materials[m.id] = m
+}
+
+// DuplicateAppearance copies base into a new editable asset of the given source under
+// name, adds it, and bumps the revision. It errors on an unknown base or empty name.
+func (l *Library) DuplicateAppearance(baseID, name string, source Source) (*Appearance, error) {
+	base, ok := l.appearances[baseID]
+	if !ok {
+		return nil, fmt.Errorf("material: appearance base %q not found", baseID)
+	}
+	if name == "" {
+		return nil, fmt.Errorf("material: appearance name is empty")
+	}
+	dup := base.duplicate(l.freshID(name, func(id string) bool { _, ok := l.appearances[id]; return ok }), name, source)
+	l.AddAppearance(dup)
+	l.revision++
+	return dup, nil
+}
+
+// DuplicateMaterial copies base into a new editable asset under name.
+func (l *Library) DuplicateMaterial(baseID, name string, source Source) (*Material, error) {
+	base, ok := l.materials[baseID]
+	if !ok {
+		return nil, fmt.Errorf("material: material base %q not found", baseID)
+	}
+	if name == "" {
+		return nil, fmt.Errorf("material: material name is empty")
+	}
+	dup := base.duplicate(l.freshID(name, func(id string) bool { _, ok := l.materials[id]; return ok }), name, source)
+	l.AddMaterial(dup)
+	l.revision++
+	return dup, nil
+}
+
+// EditAppearance / EditMaterial replace an editable asset's spec and bump the revision.
+// A no-op for an unknown id or a read-only built-in.
+func (l *Library) EditAppearance(id string, spec AppearanceSpec) {
+	if a, ok := l.appearances[id]; ok && a.Source().Editable() {
+		a.SetSpec(spec)
+		l.revision++
+	}
+}
+
+func (l *Library) EditMaterial(id string, spec MaterialSpec) {
+	if m, ok := l.materials[id]; ok && m.Source().Editable() {
+		m.SetSpec(spec)
+		l.revision++
+	}
+}
+
+// RemoveAppearance / RemoveMaterial delete a non-built-in asset and bump the revision.
+func (l *Library) RemoveAppearance(id string) error {
+	a, ok := l.appearances[id]
+	if !ok {
+		return fmt.Errorf("material: appearance %q not found", id)
+	}
+	if !a.Source().Editable() {
+		return fmt.Errorf("material: built-in appearance %q cannot be removed", id)
+	}
+	delete(l.appearances, id)
+	l.apprOrder = removeID(l.apprOrder, id)
+	l.revision++
+	return nil
+}
+
+func (l *Library) RemoveMaterial(id string) error {
+	m, ok := l.materials[id]
+	if !ok {
+		return fmt.Errorf("material: material %q not found", id)
+	}
+	if !m.Source().Editable() {
+		return fmt.Errorf("material: built-in material %q cannot be removed", id)
+	}
+	delete(l.materials, id)
+	l.matOrder = removeID(l.matOrder, id)
+	l.revision++
+	return nil
+}
+
+// freshID returns a slug of name that exists reports as free (suffixing -2, -3… on
+// collision), so two "Brushed Aluminum" copies get distinct stable ids.
+func (l *Library) freshID(name string, exists func(id string) bool) string {
+	base := slug(name)
+	id := base
+	for n := 2; exists(id); n++ {
+		id = fmt.Sprintf("%s-%d", base, n)
+	}
+	return id
+}
+
+// slug turns a display name into a lower-case, alphanumeric-with-dashes id.
+func slug(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "asset"
+	}
+	return out
+}
+
+// removeID returns ids with the named one removed (order preserved).
+func removeID(ids []string, id string) []string {
+	out := ids[:0:0]
+	for _, x := range ids {
+		if x != id {
+			out = append(out, x)
+		}
+	}
+	return out
+}

--- a/model/material/library.go
+++ b/model/material/library.go
@@ -53,18 +53,9 @@ func (l *Library) Materials() []*Material {
 func (l *Library) Appearance(id string) (*Appearance, bool) { a, ok := l.appearances[id]; return a, ok }
 func (l *Library) Material(id string) (*Material, bool)     { m, ok := l.materials[id]; return m, ok }
 
-// appearanceOrNil returns the appearance for id, or nil for an empty/unknown id — the
-// form the assignment resolver wants so it can fall through the precedence chain.
-func (l *Library) appearanceOrNil(id string) *Appearance {
-	if id == "" {
-		return nil
-	}
-	return l.appearances[id]
-}
-
-// defaultAppearance returns the neutral built-in appearance, the resolver's last resort.
-// It is always present (seeded by the built-in catalog).
-func (l *Library) defaultAppearance() *Appearance { return l.appearances[DefaultAppearanceID] }
+// DefaultAppearance returns the neutral built-in appearance, the resolver's last resort.
+// It is always present (seeded by the built-in catalog). Part of [AssetLookup].
+func (l *Library) DefaultAppearance() *Appearance { return l.appearances[DefaultAppearanceID] }
 
 // AddAppearance / AddMaterial insert an asset (built-in seeding, library/document load),
 // replacing any existing asset with the same id without disturbing display order. They do

--- a/model/material/library_test.go
+++ b/model/material/library_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import "testing"
+
+func TestBuiltinsPresentAndReadOnly(t *testing.T) {
+	lib := NewLibrary()
+	if len(lib.Appearances()) == 0 || len(lib.Materials()) == 0 {
+		t.Fatal("built-in catalog is empty")
+	}
+	steel, ok := lib.Material("steel")
+	if !ok {
+		t.Fatal("built-in material \"steel\" missing")
+	}
+	if steel.Source() != SourceBuiltin || steel.Source().Editable() {
+		t.Errorf("steel source = %q (editable=%v), want builtin/read-only", steel.Source(), steel.Source().Editable())
+	}
+	// SetSpec must be a no-op on a built-in.
+	before := steel.Density()
+	steel.SetSpec(MaterialSpec{Density: 999})
+	if steel.Density() != before {
+		t.Error("SetSpec mutated a built-in material")
+	}
+}
+
+// Every built-in material must reference an appearance that exists, or the renderer
+// resolver would fall through to the default for a "known" material.
+func TestBuiltinMaterialsReferenceRealAppearances(t *testing.T) {
+	lib := NewLibrary()
+	for _, m := range lib.Materials() {
+		if _, ok := lib.Appearance(m.AppearanceID()); !ok {
+			t.Errorf("material %q references missing appearance %q", m.ID(), m.AppearanceID())
+		}
+	}
+}
+
+func TestDuplicateAppearanceIsEditableSnapshot(t *testing.T) {
+	lib := NewLibrary()
+	r0 := lib.Revision()
+	dup, err := lib.DuplicateAppearance("steel", "My Steel", SourceProject)
+	if err != nil {
+		t.Fatalf("DuplicateAppearance: %v", err)
+	}
+	if dup.Source() != SourceProject || !dup.Source().Editable() {
+		t.Errorf("dup source = %q, want editable project", dup.Source())
+	}
+	if lib.Revision() <= r0 {
+		t.Error("duplicate did not bump the revision")
+	}
+	// Editing the copy must not touch the built-in it came from.
+	spec := dup.Spec()
+	spec.Albedo = mustColor("#ff0000ff")
+	lib.EditAppearance(dup.ID(), spec)
+	steel, _ := lib.Appearance("steel")
+	if steel.Albedo() == dup.Albedo() {
+		t.Error("editing the duplicate leaked into the built-in appearance")
+	}
+}
+
+func TestDuplicateNamesGetDistinctIDs(t *testing.T) {
+	lib := NewLibrary()
+	a, _ := lib.DuplicateAppearance("steel", "Custom", SourceProject)
+	b, _ := lib.DuplicateAppearance("steel", "Custom", SourceProject)
+	if a.ID() == b.ID() {
+		t.Errorf("two duplicates share id %q; ids must be unique", a.ID())
+	}
+}
+
+func TestRemoveRejectsBuiltin(t *testing.T) {
+	lib := NewLibrary()
+	if err := lib.RemoveMaterial("steel"); err == nil {
+		t.Error("removing a built-in material should fail")
+	}
+	dup, _ := lib.DuplicateMaterial("steel", "Temp", SourceProject)
+	if err := lib.RemoveMaterial(dup.ID()); err != nil {
+		t.Fatalf("RemoveMaterial(custom): %v", err)
+	}
+	if _, ok := lib.Material(dup.ID()); ok {
+		t.Error("removed material still present")
+	}
+}

--- a/model/material/material.go
+++ b/model/material/material.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import "github.com/Oblikovati/api/contract"
+
+// MaterialSpec is the editable content of a material — density, the property groups, and
+// the id of the appearance it renders with.
+type MaterialSpec struct {
+	DisplayName  string
+	Density      float64 // g/cm³
+	Mechanical   Mechanical
+	Thermal      Thermal
+	Electrical   Electrical
+	AppearanceID string
+}
+
+// Material is one physical-world material asset. It satisfies [contract.Material].
+type Material struct {
+	id     string
+	source Source
+	spec   MaterialSpec
+}
+
+var _ contract.Material = (*Material)(nil)
+
+// NewMaterial builds a material with a stable id, a source, and its spec.
+func NewMaterial(id string, source Source, spec MaterialSpec) *Material {
+	return &Material{id: id, source: source, spec: spec}
+}
+
+// ID / DisplayName / Source / Density / Mechanical / Thermal / Electrical / AppearanceID
+// satisfy the read-only public contract.
+func (m *Material) ID() string             { return m.id }
+func (m *Material) DisplayName() string    { return m.spec.DisplayName }
+func (m *Material) Source() Source         { return m.source }
+func (m *Material) Density() float64       { return m.spec.Density }
+func (m *Material) Mechanical() Mechanical { return m.spec.Mechanical }
+func (m *Material) Thermal() Thermal       { return m.spec.Thermal }
+func (m *Material) Electrical() Electrical { return m.spec.Electrical }
+func (m *Material) AppearanceID() string   { return m.spec.AppearanceID }
+
+// Spec returns a copy of the editable fields.
+func (m *Material) Spec() MaterialSpec { return m.spec }
+
+// SetSpec replaces the editable fields; a no-op on a built-in (read-only).
+func (m *Material) SetSpec(spec MaterialSpec) {
+	if !m.source.Editable() {
+		return
+	}
+	m.spec = spec
+}
+
+// duplicate returns an independent copy under a new id/name and source.
+func (m *Material) duplicate(id, name string, source Source) *Material {
+	spec := m.spec
+	spec.DisplayName = name
+	return &Material{id: id, source: source, spec: spec}
+}

--- a/model/material/recipe.go
+++ b/model/material/recipe.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"sort"
+
+	"github.com/Oblikovati/api/types"
+)
+
+// AppearanceRecipe / MaterialRecipe / AssignmentRecipe are the persisted YAML shapes of
+// the materials data — embedded in a document's recipe and stored in the project library
+// (ADR-0020/0022). Colors are "#RRGGBBAA" hex for readable, git-diffable files.
+type AppearanceRecipe struct {
+	ID          string  `yaml:"id"`
+	DisplayName string  `yaml:"name"`
+	Albedo      string  `yaml:"albedo"`
+	Metallic    float32 `yaml:"metallic"`
+	Roughness   float32 `yaml:"roughness"`
+	Emissive    string  `yaml:"emissive,omitempty"`
+	Opacity     float32 `yaml:"opacity"`
+}
+
+type MaterialRecipe struct {
+	ID           string           `yaml:"id"`
+	DisplayName  string           `yaml:"name"`
+	Density      float64          `yaml:"density"`
+	Mechanical   types.Mechanical `yaml:"mechanical,omitempty"`
+	Thermal      types.Thermal    `yaml:"thermal,omitempty"`
+	Electrical   types.Electrical `yaml:"electrical,omitempty"`
+	AppearanceID string           `yaml:"appearance,omitempty"`
+}
+
+type AssignmentRecipe struct {
+	PartMaterial   string            `yaml:"partMaterial,omitempty"`
+	PartAppearance string            `yaml:"partAppearance,omitempty"`
+	BodyMaterial   map[string]string `yaml:"bodyMaterial,omitempty"`
+	BodyAppearance map[string]string `yaml:"bodyAppearance,omitempty"`
+	FaceAppearance map[string]string `yaml:"faceAppearance,omitempty"`
+}
+
+// RecipeData is the materials section embedded in a part's recipe: the document's own
+// assets plus its assignments.
+type RecipeData struct {
+	Appearances []AppearanceRecipe `yaml:"appearances,omitempty"`
+	Materials   []MaterialRecipe   `yaml:"materials,omitempty"`
+	Assignments *AssignmentRecipe  `yaml:"assignments,omitempty"`
+}
+
+// MarshalRecipe captures a document's embedded asset set and assignments as RecipeData,
+// in a deterministic (id-sorted) order so the YAML diffs cleanly.
+func MarshalRecipe(set *AssetSet, assign *AssignmentStore) RecipeData {
+	var data RecipeData
+	for _, a := range sortAppearances(set.Appearances()) {
+		data.Appearances = append(data.Appearances, appearanceToRecipe(a))
+	}
+	for _, m := range sortMaterials(set.Materials()) {
+		data.Materials = append(data.Materials, materialToRecipe(m))
+	}
+	data.Assignments = assignmentRecipe(assign)
+	return data
+}
+
+// ApplyRecipe restores embedded assets (as document-source) into set and assignments into
+// assign. A malformed color aborts the load (no silent black surfaces).
+func ApplyRecipe(data RecipeData, set *AssetSet, assign *AssignmentStore) error {
+	for _, ar := range data.Appearances {
+		a, err := recipeToAppearance(ar, SourceDocument)
+		if err != nil {
+			return err
+		}
+		set.PutAppearance(a)
+	}
+	for _, mr := range data.Materials {
+		set.PutMaterial(recipeToMaterial(mr, SourceDocument))
+	}
+	if data.Assignments != nil {
+		applyAssignmentRecipe(assign, data.Assignments)
+	}
+	return nil
+}
+
+func appearanceToRecipe(a *Appearance) AppearanceRecipe {
+	return AppearanceRecipe{
+		ID: a.id, DisplayName: a.spec.DisplayName,
+		Albedo: a.spec.Albedo.Hex(), Metallic: a.spec.Metallic, Roughness: a.spec.Roughness,
+		Emissive: a.spec.Emissive.Hex(), Opacity: a.spec.Opacity,
+	}
+}
+
+func recipeToAppearance(r AppearanceRecipe, source Source) (*Appearance, error) {
+	albedo, err := types.ParseHex(r.Albedo)
+	if err != nil {
+		return nil, err
+	}
+	emissive := types.Rgba{A: 1}
+	if r.Emissive != "" {
+		if emissive, err = types.ParseHex(r.Emissive); err != nil {
+			return nil, err
+		}
+	}
+	return NewAppearance(r.ID, source, AppearanceSpec{
+		DisplayName: r.DisplayName, Albedo: albedo, Metallic: r.Metallic,
+		Roughness: r.Roughness, Emissive: emissive, Opacity: r.Opacity,
+	}), nil
+}
+
+func materialToRecipe(m *Material) MaterialRecipe {
+	return MaterialRecipe{
+		ID: m.id, DisplayName: m.spec.DisplayName, Density: m.spec.Density,
+		Mechanical: m.spec.Mechanical, Thermal: m.spec.Thermal, Electrical: m.spec.Electrical,
+		AppearanceID: m.spec.AppearanceID,
+	}
+}
+
+func recipeToMaterial(r MaterialRecipe, source Source) *Material {
+	return NewMaterial(r.ID, source, MaterialSpec{
+		DisplayName: r.DisplayName, Density: r.Density,
+		Mechanical: r.Mechanical, Thermal: r.Thermal, Electrical: r.Electrical,
+		AppearanceID: r.AppearanceID,
+	})
+}
+
+// assignmentRecipe captures the store, or nil when nothing is assigned (keeps the recipe
+// minimal).
+func assignmentRecipe(assign *AssignmentStore) *AssignmentRecipe {
+	r := &AssignmentRecipe{
+		PartMaterial:   assign.partMaterial,
+		PartAppearance: assign.partAppearance,
+		BodyMaterial:   nonEmpty(assign.bodyMaterial),
+		BodyAppearance: nonEmpty(assign.bodyAppearance),
+		FaceAppearance: nonEmpty(assign.faceAppearance),
+	}
+	if r.PartMaterial == "" && r.PartAppearance == "" &&
+		r.BodyMaterial == nil && r.BodyAppearance == nil && r.FaceAppearance == nil {
+		return nil
+	}
+	return r
+}
+
+// applyAssignmentRecipe writes a recipe's assignments back into a store.
+func applyAssignmentRecipe(assign *AssignmentStore, r *AssignmentRecipe) {
+	assign.partMaterial = r.PartMaterial
+	assign.partAppearance = r.PartAppearance
+	assign.bodyMaterial = orEmpty(r.BodyMaterial)
+	assign.bodyAppearance = orEmpty(r.BodyAppearance)
+	assign.faceAppearance = orEmpty(r.FaceAppearance)
+}
+
+func sortAppearances(in []*Appearance) []*Appearance {
+	sort.Slice(in, func(i, j int) bool { return in[i].id < in[j].id })
+	return in
+}
+
+func sortMaterials(in []*Material) []*Material {
+	sort.Slice(in, func(i, j int) bool { return in[i].id < in[j].id })
+	return in
+}
+
+// nonEmpty returns m, or nil when empty (so an empty map is omitted from YAML).
+func nonEmpty(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	return copyMap(m)
+}
+
+// orEmpty returns m, or a fresh empty map when nil (so a store never holds a nil map).
+func orEmpty(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
+}

--- a/model/material/recipe_test.go
+++ b/model/material/recipe_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import "testing"
+
+func TestRecipeRoundTripEmbedsAssetsAndAssignments(t *testing.T) {
+	set := NewAssetSet()
+	assign := NewAssignmentStore()
+	set.PutAppearance(NewAppearance("custom-red", SourceDocument, AppearanceSpec{
+		DisplayName: "Custom Red", Albedo: mustColor("#ff0000ff"),
+		Metallic: 0.2, Roughness: 0.5, Emissive: mustColor("#000000ff"), Opacity: 1,
+	}))
+	assign.SetPartAppearance("custom-red")
+	assign.SetBodyMaterial("bodykey", "steel")
+
+	data := MarshalRecipe(set, assign)
+
+	// Restore into a fresh document.
+	set2, assign2 := NewAssetSet(), NewAssignmentStore()
+	if err := ApplyRecipe(data, set2, assign2); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	a, ok := set2.Appearance("custom-red")
+	if !ok {
+		t.Fatal("embedded appearance not restored")
+	}
+	if a.Source() != SourceDocument {
+		t.Errorf("restored appearance source = %q, want document", a.Source())
+	}
+	if a.Albedo() != mustColor("#ff0000ff") || a.Metallic() != 0.2 {
+		t.Errorf("restored appearance lost PBR fields: %+v", a.Spec())
+	}
+	if assign2.PartAppearance() != "custom-red" || assign2.BodyMaterials()["bodykey"] != "steel" {
+		t.Errorf("assignments not restored: part=%q body=%v", assign2.PartAppearance(), assign2.BodyMaterials())
+	}
+}
+
+// An un-styled document produces no materials section (empty asset set + no assignments).
+func TestMarshalRecipeEmptyWhenUnstyled(t *testing.T) {
+	data := MarshalRecipe(NewAssetSet(), NewAssignmentStore())
+	if len(data.Appearances) != 0 || len(data.Materials) != 0 || data.Assignments != nil {
+		t.Errorf("unstyled document produced a non-empty materials recipe: %+v", data)
+	}
+}
+
+func TestRecipeRejectsBadColor(t *testing.T) {
+	data := RecipeData{Appearances: []AppearanceRecipe{{ID: "x", Albedo: "not-a-color"}}}
+	if err := ApplyRecipe(data, NewAssetSet(), NewAssignmentStore()); err == nil {
+		t.Error("ApplyRecipe accepted a malformed color")
+	}
+}

--- a/model/material/store.go
+++ b/model/material/store.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
+)
+
+// FileSystem is the small filesystem seam the project [Store] depends on, so library IO is
+// testable with an in-memory fake. ReadFile returns an error for a missing file (first
+// run); the caller treats that as "no library yet".
+type FileSystem interface {
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, data []byte) error // create/overwrite, making parent dirs
+}
+
+// Store loads and saves the project's shared asset library — the catalog every document of
+// a project picks from (ADR-0022). It lives in the project's design-data directory as two
+// readable YAML files, appearances.yaml and materials.yaml.
+type Store struct {
+	dir string
+	fs  FileSystem
+}
+
+// NewStore builds a store over a project design-data directory.
+func NewStore(designDataDir string, fs FileSystem) *Store {
+	return &Store{dir: designDataDir, fs: fs}
+}
+
+type appearanceLibraryFile struct {
+	Appearances []AppearanceRecipe `yaml:"appearances"`
+}
+
+type materialLibraryFile struct {
+	Materials []MaterialRecipe `yaml:"materials"`
+}
+
+// Load folds the project library's appearances and materials into lib as project-source
+// assets. A missing library (first run) is not an error. A malformed color aborts the
+// load (a corrupt library should fail loudly, not render black).
+func (s *Store) Load(lib *Library) error {
+	if data, ok := s.read(s.appearancePath()); ok {
+		var f appearanceLibraryFile
+		if err := yamlcodec.Unmarshal(data, &f); err != nil {
+			return fmt.Errorf("material: parse %q: %w", s.appearancePath(), err)
+		}
+		for _, r := range f.Appearances {
+			a, err := recipeToAppearance(r, SourceProject)
+			if err != nil {
+				return fmt.Errorf("material: %q: %w", s.appearancePath(), err)
+			}
+			lib.AddAppearance(a)
+		}
+	}
+	if data, ok := s.read(s.materialPath()); ok {
+		var f materialLibraryFile
+		if err := yamlcodec.Unmarshal(data, &f); err != nil {
+			return fmt.Errorf("material: parse %q: %w", s.materialPath(), err)
+		}
+		for _, r := range f.Materials {
+			lib.AddMaterial(recipeToMaterial(r, SourceProject))
+		}
+	}
+	return nil
+}
+
+// Save writes the library's project-source assets back to the design-data directory. Only
+// project assets are persisted — built-ins are reproducible and document assets belong to
+// their .obk.
+func (s *Store) Save(lib *Library) error {
+	var af appearanceLibraryFile
+	for _, a := range sortAppearances(projectAppearances(lib)) {
+		af.Appearances = append(af.Appearances, appearanceToRecipe(a))
+	}
+	appr, err := yamlcodec.Marshal(af)
+	if err != nil {
+		return fmt.Errorf("material: marshal appearances: %w", err)
+	}
+	if err := s.fs.WriteFile(s.appearancePath(), appr); err != nil {
+		return err
+	}
+	var mf materialLibraryFile
+	for _, m := range sortMaterials(projectMaterials(lib)) {
+		mf.Materials = append(mf.Materials, materialToRecipe(m))
+	}
+	mats, err := yamlcodec.Marshal(mf)
+	if err != nil {
+		return fmt.Errorf("material: marshal materials: %w", err)
+	}
+	return s.fs.WriteFile(s.materialPath(), mats)
+}
+
+// read returns a file's bytes, or (nil,false) when it is absent/unreadable.
+func (s *Store) read(path string) ([]byte, bool) {
+	data, err := s.fs.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+func (s *Store) appearancePath() string { return filepath.Join(s.dir, "appearances.yaml") }
+func (s *Store) materialPath() string   { return filepath.Join(s.dir, "materials.yaml") }
+
+// projectAppearances / projectMaterials filter a library to its project-source assets.
+func projectAppearances(lib *Library) []*Appearance {
+	var out []*Appearance
+	for _, a := range lib.Appearances() {
+		if a.Source() == SourceProject {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func projectMaterials(lib *Library) []*Material {
+	var out []*Material
+	for _, m := range lib.Materials() {
+		if m.Source() == SourceProject {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// OSFileSystem is the production [FileSystem]: real files under the project design-data
+// directory.
+type OSFileSystem struct{}
+
+// ReadFile reads a file's contents.
+func (OSFileSystem) ReadFile(path string) ([]byte, error) { return os.ReadFile(path) }
+
+// WriteFile writes data, creating parent directories as needed.
+func (OSFileSystem) WriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/model/material/store_test.go
+++ b/model/material/store_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeFS is an in-memory FileSystem for store tests — no real disk IO.
+type fakeFS struct{ files map[string][]byte }
+
+func newFakeFS() *fakeFS { return &fakeFS{files: map[string][]byte{}} }
+
+func (f *fakeFS) ReadFile(path string) ([]byte, error) {
+	data, ok := f.files[path]
+	if !ok {
+		return nil, &missingError{path}
+	}
+	return data, nil
+}
+
+func (f *fakeFS) WriteFile(path string, data []byte) error {
+	f.files[path] = data
+	return nil
+}
+
+type missingError struct{ path string }
+
+func (e *missingError) Error() string { return "missing: " + e.path }
+
+func TestStoreSaveLoadProjectAssets(t *testing.T) {
+	fs := newFakeFS()
+	store := NewStore("/proj/DesignData", fs)
+
+	src := NewLibrary()
+	dup, _ := src.DuplicateAppearance("steel", "Brushed Alu", SourceProject)
+	spec := dup.Spec()
+	spec.Albedo = mustColor("#c0c4c8ff")
+	src.EditAppearance(dup.ID(), spec)
+	if _, err := src.DuplicateMaterial("aluminum-6061", "Shop Alu", SourceProject); err != nil {
+		t.Fatalf("DuplicateMaterial: %v", err)
+	}
+	if err := store.Save(src); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// A second session loads the project library and sees the custom assets.
+	dst := NewLibrary()
+	if err := store.Load(dst); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, ok := dst.Appearance(dup.ID())
+	if !ok || got.Source() != SourceProject || got.Albedo() != mustColor("#c0c4c8ff") {
+		t.Errorf("project appearance not loaded: %v ok=%v", got, ok)
+	}
+	if _, ok := dst.Material("shop-alu"); !ok {
+		t.Errorf("project material not loaded; have %d materials", len(dst.Materials()))
+	}
+	// Built-ins must NOT be written to the project library file.
+	if data, ok := fs.files["/proj/DesignData/materials.yaml"]; ok && strings.Contains(string(data), "id: steel") {
+		t.Error("built-in material was persisted to the project library")
+	}
+}
+
+func TestStoreLoadEmptyOnFirstRun(t *testing.T) {
+	store := NewStore("/proj/DesignData", newFakeFS())
+	lib := NewLibrary()
+	before := len(lib.Materials())
+	if err := store.Load(lib); err != nil {
+		t.Fatalf("Load on empty project: %v", err)
+	}
+	if len(lib.Materials()) != before {
+		t.Errorf("empty project Load changed the library (%d → %d)", before, len(lib.Materials()))
+	}
+}

--- a/renderer/drawlist.go
+++ b/renderer/drawlist.go
@@ -21,15 +21,40 @@ const (
 
 // DrawItem is one batch of geometry to draw — geometry-as-data, independent of any
 // GPU type. ObjectID is written to the id-buffer for picking; Color is the base
-// shading color.
+// (albedo) color and Metallic/Roughness/Emissive/Opacity carry the rest of the PBR
+// surface (ADR-0022) for the GPU shader — the basic shader uses albedo today and the
+// other terms feed a future GGX upgrade.
 type DrawItem struct {
 	Primitive Primitive
 	Positions []math.Point3
 	Normals   []math.Vector3
 	Indices   []int
 	Color     [4]float32
+	Metallic  float32
+	Roughness float32
+	Emissive  [3]float32
+	Opacity   float32
 	ObjectID  uint64
 }
+
+// Surface is a resolved PBR appearance for one body — what [SurfaceLookup] returns. It is
+// the renderer-side value the model's effective Appearance maps onto, keeping the renderer
+// independent of the material package.
+type Surface struct {
+	Albedo    [4]float32
+	Metallic  float32
+	Roughness float32
+	Emissive  [3]float32
+	Opacity   float32
+}
+
+// SurfaceLookup returns the surface to shade a body with. BuildDrawList calls it per body;
+// a nil lookup means "use the neutral default" (the pre-materials look).
+type SurfaceLookup func(b *topo.Body) Surface
+
+// defaultSurface is the neutral material used for an un-assigned body — its albedo is the
+// pre-materials default gray, so a model with no assignments looks unchanged.
+var defaultSurface = Surface{Albedo: defaultSurfaceColor, Metallic: 0, Roughness: 0.6, Opacity: 1}
 
 // TriangleCount / LineCount report the primitive count of an item.
 func (d DrawItem) TriangleCount() int {
@@ -79,7 +104,7 @@ var edgeColor = [4]float32{0.1, 0.1, 0.12, 1}
 // list at the given quality: each visible body contributes a shaded triangle item
 // (its tessellation) and a wireframe line item (its edges), tagged with the body's
 // object id for picking. Bodies outside the view are culled.
-func BuildDrawList(bodies []*topo.Body, cam scene.Camera, q ops.Quality) DrawList {
+func BuildDrawList(bodies []*topo.Body, cam scene.Camera, q ops.Quality, lookup SurfaceLookup) DrawList {
 	var items []DrawItem
 	for _, b := range bodies {
 		if !visible(cam, b.RangeBox()) {
@@ -87,7 +112,7 @@ func BuildDrawList(bodies []*topo.Body, cam scene.Camera, q ops.Quality) DrawLis
 		}
 		mesh, edges := ops.TessellateBody(b, q)
 		if mesh.TriangleCount() > 0 {
-			items = append(items, triangleItem(b.ID(), mesh))
+			items = append(items, triangleItem(b.ID(), mesh, surfaceFor(b, lookup)))
 		}
 		if line := lineItem(b.ID(), edges); line != nil {
 			items = append(items, *line)
@@ -96,14 +121,27 @@ func BuildDrawList(bodies []*topo.Body, cam scene.Camera, q ops.Quality) DrawLis
 	return DrawList{Items: items}
 }
 
-// triangleItem builds the shaded surface item for a body's mesh.
-func triangleItem(objectID uint64, mesh *ops.Mesh) DrawItem {
+// surfaceFor returns the body's resolved surface, or the neutral default when no lookup is
+// supplied (headless tests, or before materials are wired).
+func surfaceFor(b *topo.Body, lookup SurfaceLookup) Surface {
+	if lookup == nil {
+		return defaultSurface
+	}
+	return lookup(b)
+}
+
+// triangleItem builds the shaded surface item for a body's mesh with its PBR surface.
+func triangleItem(objectID uint64, mesh *ops.Mesh, s Surface) DrawItem {
 	return DrawItem{
 		Primitive: Triangles,
 		Positions: mesh.Positions,
 		Normals:   mesh.Normals,
 		Indices:   mesh.Indices,
-		Color:     defaultSurfaceColor,
+		Color:     s.Albedo,
+		Metallic:  s.Metallic,
+		Roughness: s.Roughness,
+		Emissive:  s.Emissive,
+		Opacity:   s.Opacity,
 		ObjectID:  objectID,
 	}
 }

--- a/renderer/drawlist_test.go
+++ b/renderer/drawlist_test.go
@@ -56,7 +56,7 @@ func frontCamera() scene.Camera {
 }
 
 func TestBuildDrawListEmitsSurfacesAndWireframe(t *testing.T) {
-	list := BuildDrawList([]*topo.Body{box(2, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality())
+	list := BuildDrawList([]*topo.Body{box(2, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality(), nil)
 	if len(list.Items) != 2 {
 		t.Fatalf("draw items = %d, want 2 (surface + wireframe)", len(list.Items))
 	}
@@ -76,7 +76,7 @@ func TestBuildDrawListEmitsSurfacesAndWireframe(t *testing.T) {
 
 func TestObjectIDsTagEachBody(t *testing.T) {
 	a, b := box(1, math.V3(0, 0, 0)), box(1, math.V3(3, 0, 0))
-	list := BuildDrawList([]*topo.Body{a, b}, frontCamera(), ops.DefaultQuality())
+	list := BuildDrawList([]*topo.Body{a, b}, frontCamera(), ops.DefaultQuality(), nil)
 	ids := map[uint64]bool{}
 	for _, it := range list.Items {
 		ids[it.ObjectID] = true
@@ -89,13 +89,13 @@ func TestObjectIDsTagEachBody(t *testing.T) {
 // TestTranslationInvariance is a metamorphic oracle (ADR-0014): translating the
 // scene must not change how much is drawn.
 func TestTranslationInvariance(t *testing.T) {
-	atOrigin := BuildDrawList([]*topo.Body{box(2, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality())
+	atOrigin := BuildDrawList([]*topo.Body{box(2, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality(), nil)
 	// Move both the body and the camera by the same offset → identical draw list size.
 	off := math.V3(7, -3, 0)
 	cam := frontCamera()
 	cam.Eye = cam.Eye.TranslateBy(off)
 	cam.Target = cam.Target.TranslateBy(off)
-	moved := BuildDrawList([]*topo.Body{box(2, off)}, cam, ops.DefaultQuality())
+	moved := BuildDrawList([]*topo.Body{box(2, off)}, cam, ops.DefaultQuality(), nil)
 	if atOrigin.Triangles() != moved.Triangles() || atOrigin.Lines() != moved.Lines() {
 		t.Errorf("translation changed draw counts: %d/%d vs %d/%d",
 			atOrigin.Triangles(), atOrigin.Lines(), moved.Triangles(), moved.Lines())
@@ -105,7 +105,7 @@ func TestTranslationInvariance(t *testing.T) {
 func TestBodyBehindCameraIsCulled(t *testing.T) {
 	cam := frontCamera()                 // looking from z=30 toward z=0 (forward −Z)
 	behind := box(2, math.V3(0, 0, 100)) // box well behind the eye
-	list := BuildDrawList([]*topo.Body{behind}, cam, ops.DefaultQuality())
+	list := BuildDrawList([]*topo.Body{behind}, cam, ops.DefaultQuality(), nil)
 	if len(list.Items) != 0 {
 		t.Errorf("body behind the camera not culled: %d items", len(list.Items))
 	}
@@ -113,7 +113,7 @@ func TestBodyBehindCameraIsCulled(t *testing.T) {
 
 func TestNullBackendRecordsFrames(t *testing.T) {
 	var be Backend = &NullBackend{}
-	list := BuildDrawList([]*topo.Body{box(1, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality())
+	list := BuildDrawList([]*topo.Body{box(1, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality(), nil)
 	be.Render(list)
 	be.Render(list)
 	null := be.(*NullBackend)
@@ -134,5 +134,25 @@ func TestDrawItemPrimitiveCounts(t *testing.T) {
 	}
 	if line.LineCount() != 2 || line.TriangleCount() != 0 {
 		t.Error("line item counts wrong")
+	}
+}
+
+// A SurfaceLookup must drive the triangle item's PBR fields (albedo + metallic/roughness);
+// the wireframe item keeps the edge color.
+func TestBuildDrawListAppliesSurfaceLookup(t *testing.T) {
+	want := Surface{Albedo: [4]float32{0.2, 0.4, 0.8, 1}, Metallic: 0.9, Roughness: 0.3, Opacity: 1}
+	list := BuildDrawList([]*topo.Body{box(2, math.V3(0, 0, 0))}, frontCamera(), ops.DefaultQuality(),
+		func(*topo.Body) Surface { return want })
+	var tri *DrawItem
+	for i := range list.Items {
+		if list.Items[i].Primitive == Triangles {
+			tri = &list.Items[i]
+		}
+	}
+	if tri == nil {
+		t.Fatal("no triangle item produced")
+	}
+	if tri.Color != want.Albedo || tri.Metallic != want.Metallic || tri.Roughness != want.Roughness {
+		t.Errorf("surface not applied: color=%v metallic=%v roughness=%v", tri.Color, tri.Metallic, tri.Roughness)
 	}
 }


### PR DESCRIPTION
## What

Implements the **Materials & Appearances** subsystem (ADR-0022). Every body previously rendered with one hardcoded gray; now bodies carry assignable materials and PBR appearances, with a mass/physical-properties readout. Pairs with the merged contract PR (Oblikovati.API#3).

### Model (`model/material`, pure)
- Typed **Appearance** (metallic-roughness PBR) and **Material** (density + mechanical/thermal/electrical, linked to an appearance) assets; a **Library** with a revision counter; a shipped built-in catalog (steel, aluminium, ABS, oak…).
- **AssignmentStore** on `PartComponentDefinition`, keyed by persistent **reference key** so it survives `Recompute`, with the Inventor appearance-source override chain (face → body appearance → body material → part material → part default → neutral default).

### Persistence
- Documents embed the non-built-in assets they use (`AssetSet`) + assignments in the part recipe, so an `.obk` is self-contained and round-trips. `MergedLookup` resolves embedded-over-catalog.
- Project library **Store** reads/writes the shared catalog as `appearances.yaml`/`materials.yaml` in the project design-data dir, behind a `FileSystem` seam.

### Renderer & mass props
- `DrawItem` gains PBR terms; `BuildDrawList` takes a `SurfaceLookup` resolver (renderer stays model-free). `Session.SurfaceLookup()` maps each body to its effective appearance.
- `ops.BodyGeometryProperties`: volume/area/centroid via the divergence-theorem signed-tetrahedron sum (oriented outward; translation-invariant). Mass = density × volume.

### API & UI
- `addin/router` serves `appearances.*` / `materials.*` / `model.assign*` / `model.physicalProperties`.
- Head **Tools ▸ Materials** window: browse/duplicate/edit materials & appearances (built-ins read-only), assign to the part, read mass — viewport recolors live.

## Why

Gives the model real materials (for properties/mass and future simulation) and authorable, shareable PBR appearances, on the public API and resolved purely so the renderer stays testable.

## Tests

`go test ./...` green across core + head: model duplicate/edit/library revision, override-chain precedence, recipe round-trip (embedded assets + assignments), project-library save/load (fake FS), mass ≈ density × volume (analytic), router `materials.*`/assign/physical-properties, and an in-window smoke of the Materials window.

## Follow-ons (out of scope, noted in ADR-0022)
Image-texture maps; face-level override *rendering* (mesh split); GGX shading; wiring the head's project-library directory to an active `DesignProject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)