### PR TITLE
Fix browser duplicate-id assert and add feature parameter editing

### DIFF
--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// Editing a placed feature's parameters — Inventor's double-click-to-edit on a browser
+// feature node. Double-clicking re-opens the feature as the session's "feature edit";
+// the head shows a dialog bound to its parameters (today an extrude's distance), and OK
+// recomputes the part so the change flows through the feature history. Cancel restores
+// the values captured when the edit opened. Only extrude is editable so far — other
+// feature kinds open no edit (BeginEditFeature is a no-op for them).
+
+// featureEditState holds the feature being edited and a snapshot of its parameters, so
+// Cancel can restore them. It is non-nil exactly while an edit dialog is open.
+type featureEditState struct {
+	feature *feature.PartFeature
+	origDir float64 // original extent distance (database units), for Cancel
+	origOp  ops.PartFeatureOperation
+}
+
+// BeginEditFeature re-opens an extrude feature for parameter editing (the browser
+// double-click path), snapshotting its distance and operation so Cancel can restore
+// them. A non-extrude feature is not editable yet, so this is a no-op for it.
+func (s *Session) BeginEditFeature(h FeatureHandle) {
+	ext, ok := h.Feature.Definition().(*feature.ExtrudeFeature)
+	if !ok {
+		return
+	}
+	s.featureEdit = &featureEditState{feature: h.Feature, origDir: ext.DistanceValue(), origOp: ext.Operation()}
+}
+
+// IsEditingFeature reports whether a feature edit dialog should be open.
+func (s *Session) IsEditingFeature() bool { return s.featureEdit != nil }
+
+// EditingFeatureName returns the name of the feature being edited (the dialog title),
+// or "" when none is being edited.
+func (s *Session) EditingFeatureName() string {
+	if s.featureEdit == nil {
+		return ""
+	}
+	return s.featureEdit.feature.Name()
+}
+
+// editingExtrude returns the extrude being edited, or false when no edit is open.
+func (s *Session) editingExtrude() (*feature.ExtrudeFeature, bool) {
+	if s.featureEdit == nil {
+		return nil, false
+	}
+	ext, ok := s.featureEdit.feature.Definition().(*feature.ExtrudeFeature)
+	return ext, ok
+}
+
+// EditFeatureDistanceDisplay returns the edited extrude's distance in the document's
+// length unit (the value the dialog field shows), or 0 when no extrude is being edited.
+func (s *Session) EditFeatureDistanceDisplay() float64 {
+	ext, ok := s.editingExtrude()
+	if !ok {
+		return 0
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(ext.DistanceValue(), param.Length))
+}
+
+// SetEditFeatureDistanceDisplay sets the edited extrude's distance from a value given in
+// the document's length unit (e.g. 25 mm). The change is applied on CommitFeatureEdit.
+func (s *Session) SetEditFeatureDistanceDisplay(value float64) {
+	if ext, ok := s.editingExtrude(); ok {
+		ext.SetDistance(s.DocumentUnits().FromPreferred(value, param.Length).Value)
+	}
+}
+
+// CommitFeatureEdit recomputes the part with the edited parameters and closes the edit.
+// A sick result (e.g. a zero distance) keeps the edit open by returning an error so the
+// dialog can stay up for correction — mirroring the extrude tool's commit.
+func (s *Session) CommitFeatureEdit() error {
+	if s.featureEdit == nil {
+		return errors.New("app: no feature is being edited")
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	pf := s.featureEdit.feature
+	part.Features().MarkDirty(pf)
+	part.Recompute()
+	if !pf.Health().OK() {
+		return errors.New("feature edit: " + pf.Health().Reason)
+	}
+	s.featureEdit = nil
+	return nil
+}
+
+// CancelFeatureEdit restores the feature's snapshotted parameters, recomputes, and
+// closes the edit — so an aborted edit leaves the part exactly as it was.
+func (s *Session) CancelFeatureEdit() {
+	if s.featureEdit == nil {
+		return
+	}
+	if ext, ok := s.editingExtrude(); ok {
+		ext.SetDistance(s.featureEdit.origDir)
+		ext.SetOperation(s.featureEdit.origOp)
+	}
+	if part, err := activePart(s); err == nil {
+		part.Features().MarkDirty(s.featureEdit.feature)
+		part.Recompute()
+	}
+	s.featureEdit = nil
+}

--- a/app/feature_edit_test.go
+++ b/app/feature_edit_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// extrudedFeatureSession returns a session with one committed extrude (5 cm tall, 2×2
+// base) and a handle to that feature — the starting point for the edit-on-double-click
+// flow tests.
+func extrudedFeatureSession(t *testing.T) (*Session, FeatureHandle) {
+	t.Helper()
+	s := topDownPickerOverSquare(t)
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	s.Click(200, 200)  // pick the profile
+	ext.SetDistance(5) // 5 cm (database units)
+	if err := s.OK(); err != nil {
+		t.Fatalf("seed extrude: %v", err)
+	}
+	return s, FeatureHandle{Feature: ext.AddedFeature()}
+}
+
+func TestBeginEditFeatureOpensExtrudeAtItsDistance(t *testing.T) {
+	s, h := extrudedFeatureSession(t)
+	s.BeginEditFeature(h)
+	if !s.IsEditingFeature() {
+		t.Fatal("BeginEditFeature should open an edit for an extrude")
+	}
+	if s.EditingFeatureName() != h.Feature.Name() {
+		t.Errorf("editing name = %q, want %q", s.EditingFeatureName(), h.Feature.Name())
+	}
+	// Database 5 cm shows as 50 mm in the document's display unit.
+	if d := s.EditFeatureDistanceDisplay(); d < 49.99 || d > 50.01 {
+		t.Errorf("edit distance display = %v, want ~50 mm", d)
+	}
+}
+
+func TestCommitFeatureEditRecomputesTheBody(t *testing.T) {
+	s, h := extrudedFeatureSession(t)
+	s.BeginEditFeature(h)
+	s.SetEditFeatureDistanceDisplay(80) // 80 mm = 8 cm
+	if err := s.CommitFeatureEdit(); err != nil {
+		t.Fatalf("CommitFeatureEdit: %v", err)
+	}
+	if s.IsEditingFeature() {
+		t.Error("a successful commit should close the edit")
+	}
+	if z := partBodies(s)()[0].RangeBox().Diagonal().Z; z < 7.99 || z > 8.01 {
+		t.Errorf("body height after edit = %v, want ~8 cm", z)
+	}
+}
+
+func TestCancelFeatureEditRestoresTheDistance(t *testing.T) {
+	s, h := extrudedFeatureSession(t)
+	s.BeginEditFeature(h)
+	s.SetEditFeatureDistanceDisplay(80) // change it, then back out
+	s.CancelFeatureEdit()
+	if s.IsEditingFeature() {
+		t.Error("cancel should close the edit")
+	}
+	if z := partBodies(s)()[0].RangeBox().Diagonal().Z; z < 4.99 || z > 5.01 {
+		t.Errorf("body height after cancel = %v, want ~5 cm (unchanged)", z)
+	}
+}
+
+func TestFeatureEditAPIsAreNoOpsWhenNotEditing(t *testing.T) {
+	s, _ := extrudedFeatureSession(t)
+	if s.IsEditingFeature() || s.EditingFeatureName() != "" || s.EditFeatureDistanceDisplay() != 0 {
+		t.Error("no edit should be open before BeginEditFeature")
+	}
+	if err := s.CommitFeatureEdit(); err == nil {
+		t.Error("CommitFeatureEdit with no edit should error")
+	}
+	s.CancelFeatureEdit() // must not panic
+}

--- a/app/session.go
+++ b/app/session.go
@@ -33,6 +33,7 @@ type Session struct {
 	sketchReturnCam scene.Camera
 	activeSketch    *sketch.Sketch
 	pendingDim      *sketch.DimensionConstraint
+	featureEdit     *featureEditState
 	overlays        []renderer.DrawItem
 	addins          *AddInManager
 	grid            *GridSettings

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -54,9 +54,22 @@ func drawSelectableNode(s *app.Session, n app.BrowserNode) {
 	if native.Selectable(n.Label, current == n.Select) {
 		s.SelectBrowserNode(n)
 	}
+	openFeatureEditOnDoubleClick(s, n)
 	drawNodeMenu(s, n)
 	if current != nil && n.Select == current && current != browserSync.last {
 		native.SetScrollHereY()
+	}
+}
+
+// openFeatureEditOnDoubleClick re-opens a feature node's parameter editor when its row is
+// double-clicked (Inventor's edit-on-double-click). Only feature nodes carry an editor;
+// double-clicking other nodes does nothing.
+func openFeatureEditOnDoubleClick(s *app.Session, n app.BrowserNode) {
+	if !native.IsItemHovered() || !native.IsMouseDoubleClicked(native.MouseLeft) {
+		return
+	}
+	if h, ok := n.Select.(app.FeatureHandle); ok {
+		s.BeginEditFeature(h)
 	}
 }
 

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -49,6 +49,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawViewportPanel(win, s)
 	drawDimensionPopup(s)
 	drawExtrudeDialog(s)
+	drawFeatureEditDialog(s)
 	drawStatusBar(s)
 	drawPreferencesWindow(s)
 	drawMaterialsWindow(s)

--- a/head/ui/feature_edit_dialog.go
+++ b/head/ui/feature_edit_dialog.go
@@ -1,0 +1,54 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The feature-edit flow in the head: double-clicking a feature in the model browser
+// opens this dialog bound to the feature's parameters (today an extrude's distance). OK
+// recomputes the part with the new values; Cancel restores the values captured when the
+// edit opened. The distance is in the document's length unit (e.g. mm), matching the
+// extrude tool's dialog.
+
+// featureEditUI holds the dialog's distance field across frames and whether it was open
+// last frame (so it seeds the field once when the edit opens).
+var featureEditUI struct {
+	distance float32
+	open     bool
+}
+
+// drawFeatureEditDialog shows the parameter editor while a feature edit is open and keeps
+// the feature's distance in sync with the field each frame; OK commits, Cancel reverts.
+func drawFeatureEditDialog(s *app.Session) {
+	if !s.IsEditingFeature() {
+		featureEditUI.open = false
+		return
+	}
+	if !featureEditUI.open { // edit just opened — seed the field from the feature's value
+		featureEditUI.distance = float32(s.EditFeatureDistanceDisplay())
+		featureEditUI.open = true
+	}
+	native.SetNextWindowSize(280, 132)
+	if native.Begin("Edit Feature") {
+		native.Text(s.EditingFeatureName())
+		native.Text("Distance (" + s.LengthUnitName() + ")")
+		native.InputFloat("##edit-feature-distance", &featureEditUI.distance)
+		s.SetEditFeatureDistanceDisplay(float64(featureEditUI.distance)) // keep the feature in sync
+		if native.Button("OK") {
+			if err := s.CommitFeatureEdit(); err == nil { // a sick result keeps the dialog open
+				featureEditUI.open = false
+			}
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelFeatureEdit()
+			featureEditUI.open = false
+		}
+	}
+	native.End()
+}

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/model/health"
@@ -79,6 +80,20 @@ func (fs *PartFeatures) ByName(name string) (*PartFeature, bool) {
 		}
 	}
 	return nil, false
+}
+
+// UniqueName returns base suffixed with the smallest positive integer that is not
+// already a feature name (Inventor numbers features Extrusion1, Extrusion2, …). A
+// caller names a newly added feature with this so the browser shows distinct rows and
+// Dear ImGui derives a distinct id per node — two nodes sharing a label trips ImGui's
+// duplicate-id assertion on hover.
+func (fs *PartFeatures) UniqueName(base string) string {
+	for n := 1; ; n++ {
+		name := base + strconv.Itoa(n)
+		if _, taken := fs.ByName(name); !taken {
+			return name
+		}
+	}
 }
 
 // Result returns the body state after evaluating up to the end-of-part marker.

--- a/model/feature/engine_test.go
+++ b/model/feature/engine_test.go
@@ -55,6 +55,25 @@ func TestRecomputeProducesBodies(t *testing.T) {
 	}
 }
 
+func TestUniqueNameNumbersFromOneAndSkipsTaken(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	if got := fs.UniqueName("Extrusion"); got != "Extrusion1" {
+		t.Errorf("first unique name = %q, want Extrusion1", got)
+	}
+	a := fs.Add(body())
+	a.SetName("Extrusion1")
+	b := fs.Add(body())
+	b.SetName("Extrusion2")
+	if got := fs.UniqueName("Extrusion"); got != "Extrusion3" {
+		t.Errorf("unique name with 1,2 taken = %q, want Extrusion3", got)
+	}
+	// A gap is filled by the smallest free integer, not the next after the max.
+	b.SetName("Extrusion9")
+	if got := fs.UniqueName("Extrusion"); got != "Extrusion2" {
+		t.Errorf("unique name with 1,9 taken = %q, want Extrusion2", got)
+	}
+}
+
 func TestEditingEarlyFeatureReusesCleanPrefix(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	a := fs.Add(body())

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -39,6 +39,23 @@ func (e *ExtrudeFeature) Definition() *ExtrudeDefinition { return e.def }
 // Kind implements [Feature].
 func (e *ExtrudeFeature) Kind() string { return "extrude" }
 
+// DistanceValue returns the current extent distance (database units) — the value a
+// feature editor shows when re-opening the extrude.
+func (e *ExtrudeFeature) DistanceValue() float64 { return e.def.Extent.distance() }
+
+// SetDistance replaces the extent with a constant distance, keeping the extent type and
+// direction — the feature editor's distance field writes through here. Mark the feature
+// dirty and recompute afterwards for the change to take effect.
+func (e *ExtrudeFeature) SetDistance(d float64) {
+	e.def.Extent.Distance = func() float64 { return d }
+}
+
+// Operation returns the boolean operation applied against the existing bodies.
+func (e *ExtrudeFeature) Operation() ops.PartFeatureOperation { return e.def.Operation }
+
+// SetOperation changes the boolean operation (join/cut/intersect/new-body).
+func (e *ExtrudeFeature) SetOperation(op ops.PartFeatureOperation) { e.def.Operation = op }
+
 // Recompute resolves the profile, builds the prism solid at the extent distance,
 // and applies the operation against the running bodies.
 func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
@@ -92,8 +109,9 @@ func (c *ExtrudeFeatures) AddByDistanceExtent(skt *sketch.Sketch, profileIndex i
 		Sketch: skt, ProfileIndex: profileIndex, Operation: op,
 		Extent: Extent{Type: DistanceExtent, Distance: distance},
 	}
-	ef := &ExtrudeFeature{def: def, featName: "Extrusion"}
+	ef := &ExtrudeFeature{def: def}
 	pf := c.engine.Add(ef)
+	pf.SetName(c.engine.UniqueName("Extrusion")) // Extrusion1, Extrusion2, … (Inventor's naming)
 	ef.featName = pf.name
 	return pf
 }

--- a/model/feature/extrude_test.go
+++ b/model/feature/extrude_test.go
@@ -122,6 +122,41 @@ func TestUngeneratedFeaturesGoSick(t *testing.T) {
 	}
 }
 
+func TestExtrudesGetUniqueInventorNames(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ex := NewExtrudeFeatures(fs)
+	a := ex.AddByDistanceExtent(squareSketch(2), 0, ops.NewBody, func() float64 { return 3 })
+	b := ex.AddByDistanceExtent(squareSketchAt(2, 10), 0, ops.NewBody, func() float64 { return 3 })
+	// Distinct names keep the browser rows — and Dear ImGui's per-node ids — unique.
+	if a.Name() != "Extrusion1" || b.Name() != "Extrusion2" {
+		t.Errorf("extrude names = %q, %q; want Extrusion1, Extrusion2", a.Name(), b.Name())
+	}
+}
+
+func TestExtrudeSetDistanceAndOperationDriveRecompute(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	pf := NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketch(2), 0, ops.NewBody, func() float64 { return 5 })
+	ext := pf.Definition().(*ExtrudeFeature)
+	fs.Recompute()
+	if z := fs.Result()[0].RangeBox().Diagonal().Z; !approxEq(z, 5) {
+		t.Fatalf("initial height = %v, want 5", z)
+	}
+	if ext.DistanceValue() != 5 || ext.Operation() != ops.NewBody {
+		t.Fatalf("read back distance/op = %v/%v, want 5/NewBody", ext.DistanceValue(), ext.Operation())
+	}
+	// Editing the distance through the feature (the double-click edit path) grows the solid.
+	ext.SetDistance(8)
+	ext.SetOperation(ops.Join)
+	fs.MarkDirty(pf)
+	fs.Recompute()
+	if z := fs.Result()[0].RangeBox().Diagonal().Z; !approxEq(z, 8) {
+		t.Errorf("height after SetDistance(8) = %v, want 8", z)
+	}
+	if ext.Operation() != ops.Join {
+		t.Errorf("operation after SetOperation = %v, want Join", ext.Operation())
+	}
+}
+
 func approxEq(a, b float64) bool { return a-b < 1e-9 && b-a < 1e-9 }
 
 // squareSketchAt is squareSketch translated by (dx,0) so two extrudes are disjoint.


### PR DESCRIPTION
## What

Fixes two issues with feature nodes in the model browser:

1. **Duplicate-id assertion on hover.** Creating multiple extrusions named every feature after its `Kind()` (`"extrude"`), so the browser drew identical rows. Dear ImGui derives a widget id from the visible label, and two nodes sharing a label trips its duplicate-id assertion when the row is hovered.
2. **No way to edit a placed feature.** Extrude parameters could only be set while the tool was live.

## Why / How

- Extrudes are now named uniquely — `Extrusion1`, `Extrusion2`, … (Inventor's convention) — via a new `PartFeatures.UniqueName`, giving each browser node a distinct label and a distinct ImGui id, which clears the assert.
- Double-clicking a feature node re-opens it in an `Edit Feature` dialog bound to its distance, mirroring the existing dimension edit-on-double-click flow. OK recomputes the part (keeping the dialog open on a sick result); Cancel restores the values captured when the edit opened. `ExtrudeFeature` gained get/set accessors for its distance and operation so the edit can drive a recompute.

## Tests

- `UniqueName` numbering + gap-filling, unique extrude names, `SetDistance`/`SetOperation` driving recompute.
- App-layer begin/commit/cancel/no-op edit paths (headless, via the extrude tool).
- `go test ./...` (core) and head `ui` tests pass; `golangci-lint v1.59.1` clean on the root module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)