### PR TITLE
Extrude by region: split shapes, multi-select, curved profiles

### DIFF
--- a/app/extrude_multiselect_test.go
+++ b/app/extrude_multiselect_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// newPartWithTwoSquares sets up a part whose sketch holds two disjoint square regions
+// (a gap apart), returning the session and a profile handle for each region.
+func newPartWithTwoSquares(t *testing.T, side, gap float64) (*Session, ProfileHandle, ProfileHandle) {
+	t.Helper()
+	s := NewSession()
+	def := compdef.NewPartComponentDefinition()
+	pd, err := s.Workspace().Add(doc.Part, "part.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	pd.SetContent(def)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	addToolSquare(sk, 0, side)
+	addToolSquare(sk, gap, side)
+	if n := sk.Profiles().Count(); n != 2 {
+		t.Fatalf("two-square sketch has %d regions, want 2", n)
+	}
+	return s, ProfileHandle{Sketch: sk, ProfileIndex: 0}, ProfileHandle{Sketch: sk, ProfileIndex: 1}
+}
+
+// addToolSquare adds a side×side square with lower-left corner at (dx,0).
+func addToolSquare(sk *sketch.Sketch, dx, side float64) {
+	c0 := sk.Points().Add(math.P2(dx, 0))
+	c1 := sk.Points().Add(math.P2(dx+side, 0))
+	c2 := sk.Points().Add(math.P2(dx+side, side))
+	c3 := sk.Points().Add(math.P2(dx, side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}
+
+func TestExtrudeToolCtrlAccumulatesRegions(t *testing.T) {
+	_, r0, r1 := newPartWithTwoSquares(t, 2, 10)
+	ext := NewExtrudeTool()
+	ext.Pick(nil, r0)                  // plain click: one region
+	ext.PickWithMods(nil, r1, CtrlMod) // Ctrl+click: add the second
+	if got := ext.PickedProfiles(); len(got) != 2 || got[0] != r0 || got[1] != r1 {
+		t.Fatalf("picked = %v, want [r0 r1]", got)
+	}
+	// Ctrl+click an already-picked region toggles it off.
+	ext.PickWithMods(nil, r0, CtrlMod)
+	if got := ext.PickedProfiles(); len(got) != 1 || got[0] != r1 {
+		t.Fatalf("after toggle = %v, want [r1]", got)
+	}
+	// A plain click (no modifier) replaces the whole selection.
+	ext.PickWithMods(nil, r0, 0)
+	if got := ext.PickedProfiles(); len(got) != 1 || got[0] != r0 {
+		t.Fatalf("after plain pick = %v, want [r0]", got)
+	}
+}
+
+func TestExtrudeToolCtrlMultiSelectMergesIntoOneBody(t *testing.T) {
+	s, r0, r1 := newPartWithTwoSquares(t, 2, 10)
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	ext.Pick(s, r0)
+	ext.PickWithMods(s, r1, CtrlMod)
+	ext.SetDistance(4)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("two-region extrude produced %d bodies, want 1 merged", def.SurfaceBodies().Count())
+	}
+	if got := len(def.SurfaceBodies().Item(0).Faces()); got != 12 {
+		t.Errorf("merged body has %d faces, want 12 (two prisms)", got)
+	}
+}
+
+// coordPicker resolves clicks to different selectables by x coordinate, so a test can
+// click two different regions through the real Pointer path (modifier plumbing).
+type coordPicker struct {
+	left, right Selectable
+	split       float64
+}
+
+func (p coordPicker) Pick(x, _ float64, filter *SelectionFilter) (Selectable, bool) {
+	sel := p.left
+	if x >= p.split {
+		sel = p.right
+	}
+	if sel == nil || !filter.Accepts(sel.SelectionKind()) {
+		return nil, false
+	}
+	return sel, true
+}
+
+func TestExtrudeCtrlClickThroughPointerCapturesBothRegions(t *testing.T) {
+	s, r0, r1 := newPartWithTwoSquares(t, 2, 10)
+	s.SetPicker(coordPicker{left: r0, right: r1, split: 100})
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	s.Pointer(PointerEvent{X: 10, Y: 10, Button: LeftButton})                 // pick region 0
+	s.Pointer(PointerEvent{X: 200, Y: 10, Button: LeftButton, Mods: CtrlMod}) // Ctrl+click region 1
+	if got := ext.PickedProfiles(); len(got) != 2 {
+		t.Fatalf("Ctrl+click through Pointer captured %d regions, want 2 (%v)", len(got), got)
+	}
+}

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -9,16 +9,17 @@ import (
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
-// ExtrudeTool is the interactive Extrude command: activate it, click a sketch
-// profile, set a distance, and OK to add an extrude feature to the active part —
-// the full Inventor extrude flow, driven entirely by session input so a test
-// exercises it with synthetic clicks. It is the worked example proving geometry
-// flows end to end from the UI.
+// ExtrudeTool is the interactive Extrude command: activate it, hover a sketch region
+// (a closed area) and click to pick it, Ctrl+click more regions to extrude together,
+// set a distance, and OK to add an extrude feature to the active part — the full
+// Inventor extrude flow, driven entirely by session input so a test exercises it with
+// synthetic clicks. It is the worked example proving geometry flows end to end.
 type ExtrudeTool struct {
-	profile   *ProfileHandle
+	profiles  []ProfileHandle
 	distance  float64
 	operation ops.PartFeatureOperation
 	added     *feature.PartFeature
@@ -32,14 +33,45 @@ func NewExtrudeTool() *ExtrudeTool {
 // Name implements [Tool].
 func (t *ExtrudeTool) Name() string { return "Extrude" }
 
-// Start sets the selection filter to profiles (so clicks pick a profile).
+// Start sets the selection filter to profiles (so clicks pick a region).
 func (t *ExtrudeTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
 
-// Pick captures the profile the user clicked.
+// Pick captures the region the user clicked, replacing any previous selection (a plain
+// click selects a single region).
 func (t *ExtrudeTool) Pick(_ *Session, sel Selectable) {
 	if p, ok := sel.(ProfileHandle); ok {
-		t.profile = &p
+		t.profiles = []ProfileHandle{p}
 	}
+}
+
+// PickWithMods extends the selection on Ctrl+click — adding the region, or removing it
+// if it was already picked (toggle) — and replaces it otherwise. This is how the user
+// gathers several closed paths into one extrusion.
+func (t *ExtrudeTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
+	p, ok := sel.(ProfileHandle)
+	if !ok {
+		return
+	}
+	if !mods.Has(CtrlMod) {
+		t.Pick(s, sel)
+		return
+	}
+	if i := indexOfProfile(t.profiles, p); i >= 0 {
+		t.profiles = append(t.profiles[:i], t.profiles[i+1:]...)
+		return
+	}
+	t.profiles = append(t.profiles, p)
+}
+
+// indexOfProfile returns the position of p in handles, or -1. ProfileHandle is
+// comparable (sketch pointer + region index), so equality identifies the same region.
+func indexOfProfile(handles []ProfileHandle, p ProfileHandle) int {
+	for i, h := range handles {
+		if h == p {
+			return i
+		}
+	}
+	return -1
 }
 
 // SetDistance sets the extrusion distance (the value the in-canvas field / spinner
@@ -49,31 +81,41 @@ func (t *ExtrudeTool) SetDistance(d float64) { t.distance = d }
 // Distance returns the current extrusion distance (database units).
 func (t *ExtrudeTool) Distance() float64 { return t.distance }
 
-// PickedProfile returns the profile the user clicked (and true), or false when none has
-// been picked yet — so the UI can highlight the selected profile and prompt otherwise.
+// PickedProfiles returns the regions the user has picked (in click order), for the UI
+// to highlight. Empty until the first pick.
+func (t *ExtrudeTool) PickedProfiles() []ProfileHandle {
+	return append([]ProfileHandle(nil), t.profiles...)
+}
+
+// PickedProfile returns the first picked region (and true), or false when none has been
+// picked yet — a convenience for single-region UI/tests.
 func (t *ExtrudeTool) PickedProfile() (ProfileHandle, bool) {
-	if t.profile == nil {
+	if len(t.profiles) == 0 {
 		return ProfileHandle{}, false
 	}
-	return *t.profile, true
+	return t.profiles[0], true
 }
 
 // SetOperation chooses join/cut/intersect/new-body.
 func (t *ExtrudeTool) SetOperation(op ops.PartFeatureOperation) { t.operation = op }
 
-// CanCommit reports whether a profile and a non-zero distance have been gathered.
-func (t *ExtrudeTool) CanCommit() bool { return t.profile != nil && t.distance != 0 }
+// CanCommit reports whether at least one region and a non-zero distance are gathered.
+func (t *ExtrudeTool) CanCommit() bool { return len(t.profiles) > 0 && t.distance != 0 }
 
 // Commit adds the extrude feature to the active part and recomputes; a sick feature
-// (e.g. an open profile) keeps the tool open by returning an error.
+// (e.g. an open profile) keeps the tool open by returning an error. All picked regions
+// must lie on one sketch (a single extrude consumes one sketch's regions); picks on
+// other sketches are ignored.
 func (t *ExtrudeTool) Commit(s *Session) error {
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
+	skt := t.profiles[0].Sketch
+	indices := profileIndicesOn(t.profiles, skt)
 	dist := t.distance
 	t.added = feature.NewExtrudeFeatures(part.Features()).
-		AddByDistanceExtent(t.profile.Sketch, t.profile.ProfileIndex, t.operation, func() float64 { return dist })
+		AddByDistanceExtentProfiles(skt, indices, t.operation, func() float64 { return dist })
 	part.Recompute()
 	if !t.added.Health().OK() {
 		return errors.New("extrude: " + t.added.Health().Reason)
@@ -82,14 +124,25 @@ func (t *ExtrudeTool) Commit(s *Session) error {
 	return nil
 }
 
+// profileIndicesOn returns the region indices among handles that belong to sketch skt.
+func profileIndicesOn(handles []ProfileHandle, skt *sketch.Sketch) []int {
+	var out []int
+	for _, h := range handles {
+		if h.Sketch == skt {
+			out = append(out, h.ProfileIndex)
+		}
+	}
+	return out
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ExtrudeTool) AddedFeature() *feature.PartFeature { return t.added }
 
 // Prompt guides the user through the extrude steps (Inventor's status-bar prompts).
 func (t *ExtrudeTool) Prompt(*Session) string {
 	switch {
-	case t.profile == nil:
-		return "Select a profile to extrude"
+	case len(t.profiles) == 0:
+		return "Select a region to extrude (Ctrl+click to add more)"
 	case t.distance == 0:
 		return "Specify the extrude distance"
 	default:
@@ -97,19 +150,31 @@ func (t *ExtrudeTool) Prompt(*Session) string {
 	}
 }
 
-// Preview returns a transient wireframe of the prism the tool will create — the
-// bottom and top profile loops plus vertical connectors — so the viewport shows a
-// live preview before OK (Inventor's in-canvas preview). Empty until a profile and
-// distance are set.
+// Preview returns a transient wireframe of the prisms the tool will create — each
+// picked region's bottom and top loops plus vertical connectors — so the viewport
+// shows a live preview before OK (Inventor's in-canvas preview). Empty until a region
+// and distance are set.
 func (t *ExtrudeTool) Preview(*Session) []renderer.DrawItem {
 	if !t.CanCommit() {
 		return nil
 	}
-	plane := t.profile.Sketch.Plane()
-	poly := t.profile.Sketch.Profiles().Item(t.profile.ProfileIndex).OuterLoop().Polygon()
-	up := plane.Normal().AsVector().Scale(t.distance)
+	var items []renderer.DrawItem
+	for _, ph := range t.profiles {
+		if ph.ProfileIndex >= ph.Sketch.Profiles().Count() {
+			continue
+		}
+		poly := ph.Sketch.Profiles().Item(ph.ProfileIndex).OuterLoop().Polygon()
+		items = append(items, prismWireframe(ph.Sketch.Plane(), poly, t.distance))
+	}
+	return items
+}
+
+// prismWireframe builds the line-primitive draw item outlining the prism a region's
+// polygon sweeps to distance dist along the sketch plane normal.
+func prismWireframe(plane sketch.Plane, poly []math.Point2, dist float64) renderer.DrawItem {
+	up := plane.Normal().AsVector().Scale(dist)
 	n := len(poly)
-	var pts []math.Point3
+	pts := make([]math.Point3, 0, 2*n)
 	for _, p := range poly { // bottom ring [0,n)
 		pts = append(pts, plane.ToModel(p))
 	}
@@ -123,7 +188,7 @@ func (t *ExtrudeTool) Preview(*Session) []renderer.DrawItem {
 		idx = append(idx, n+i, n+j) // top loop
 		idx = append(idx, i, n+i)   // vertical
 	}
-	return []renderer.DrawItem{{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}}}
+	return renderer.DrawItem{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}}
 }
 
 // Cancel restores the default selection filter.

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -74,6 +74,23 @@ func (s *Session) feedPick(sel Selectable) {
 	s.autoCommitAfterPick()
 }
 
+// modifierPicker is a Tool whose pick behavior depends on held modifiers — e.g. Extrude
+// adds a region to its set on Ctrl+click rather than replacing the single selection.
+type modifierPicker interface {
+	PickWithMods(*Session, Selectable, Modifier)
+}
+
+// feedPickMods is feedPick for graphics clicks that carry modifiers: a modifier-aware
+// tool sees the held keys (Ctrl to extend a multi-selection); others get the plain pick.
+func (s *Session) feedPickMods(sel Selectable, mods Modifier) {
+	if mp, ok := s.tool.tool.(modifierPicker); ok {
+		mp.PickWithMods(s, sel, mods)
+	} else {
+		s.tool.tool.Pick(s, sel)
+	}
+	s.autoCommitAfterPick()
+}
+
 // autoCommitAfterPick commits the active tool when it opts into auto-commit and is now
 // ready (used after both 3D picks and snap-aware sketch-entity picks).
 func (s *Session) autoCommitAfterPick() {
@@ -137,7 +154,7 @@ func (s *Session) Pointer(e PointerEvent) {
 		return
 	}
 	if s.tool != nil {
-		s.feedPick(sel)
+		s.feedPickMods(sel, e.Mods)
 		return
 	}
 	if !e.Mods.Has(ShiftMod) && !e.Mods.Has(CtrlMod) {

--- a/app/statusbar_test.go
+++ b/app/statusbar_test.go
@@ -21,8 +21,8 @@ func TestBuildStatusGuidesExtrude(t *testing.T) {
 	if !sb.ToolActive || sb.ToolName != "Extrude" || sb.CanCommit {
 		t.Fatalf("started status = %+v, want active Extrude, not yet committable", sb)
 	}
-	if sb.Prompt != "Select a profile to extrude" {
-		t.Errorf("initial prompt = %q, want select-profile guidance", sb.Prompt)
+	if sb.Prompt != "Select a region to extrude (Ctrl+click to add more)" {
+		t.Errorf("initial prompt = %q, want select-region guidance", sb.Prompt)
 	}
 
 	s.Click(120, 90) // synthetic click picks the profile

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -53,6 +53,7 @@ int  obk_ig_is_item_clicked(int button);
 void obk_ig_item_rect_min(float* x, float* y);
 void obk_ig_mouse_pos(float* x, float* y);
 int  obk_ig_key_shift(void);
+int  obk_ig_key_ctrl(void);
 int  obk_ig_escape_pressed(void);
 float obk_ig_mouse_wheel(void);
 float obk_ig_delta_time(void);
@@ -381,6 +382,9 @@ func MousePos() (float32, float32) {
 
 // KeyShift reports whether a Shift key is held (orbit modifier).
 func KeyShift() bool { return C.obk_ig_key_shift() != 0 }
+
+// KeyCtrl reports whether a Ctrl key is held (multi-select modifier).
+func KeyCtrl() bool { return C.obk_ig_key_ctrl() != 0 }
 
 // EscapePressed reports whether Esc was pressed this frame (cancel the active tool).
 func EscapePressed() bool { return C.obk_ig_escape_pressed() != 0 }

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -158,6 +158,7 @@ void obk_ig_mouse_pos(float* x, float* y) {
     *y = p.y;
 }
 int  obk_ig_key_shift(void)                  { return ImGui::GetIO().KeyShift ? 1 : 0; }
+int  obk_ig_key_ctrl(void)                   { return ImGui::GetIO().KeyCtrl ? 1 : 0; }
 // escape_pressed fires once on the frame Esc is pressed (cancel the active tool).
 int  obk_ig_escape_pressed(void)             { return ImGui::IsKeyPressed(ImGuiKey_Escape) ? 1 : 0; }
 float obk_ig_mouse_wheel(void)               { return ImGui::GetIO().MouseWheel; }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -453,6 +453,7 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		} else {
 			list.Items = append(list.Items, planesOverlay(activePart(s), s.SelectedWorkPlane(), hovered)...)
 			list.Items = append(list.Items, partSketchOverlays(s)...)
+			list.Items = append(list.Items, extrudeHoverHighlight(s)...)
 			list.Items = append(list.Items, extrudeProfileHighlight(s)...)
 			list.Items = append(list.Items, activeToolPreviewItems(s)...)
 		}
@@ -495,7 +496,10 @@ func handleViewportClick(s *app.Session) {
 	x, y := viewportCursor()
 	e := app.PointerEvent{X: x, Y: y, Button: app.LeftButton}
 	if native.KeyShift() {
-		e.Mods = app.ShiftMod
+		e.Mods |= app.ShiftMod
+	}
+	if native.KeyCtrl() {
+		e.Mods |= app.CtrlMod // Ctrl+click adds a region to a multi-region extrude
 	}
 	s.Pointer(e)
 }

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	"strconv"
+
 	"github.com/Oblikovati/oblikovati/app"
 	"github.com/Oblikovati/oblikovati/head/internal/native"
 	"github.com/Oblikovati/oblikovati/renderer"
@@ -39,9 +41,10 @@ func drawExtrudeDialog(s *app.Session) {
 	}
 	native.SetNextWindowSize(280, 132)
 	if native.Begin("Extrude") {
-		_, picked := ext.PickedProfile()
-		if !picked {
-			native.Text("Click a sketch profile to extrude")
+		if n := len(ext.PickedProfiles()); n == 0 {
+			native.Text("Click a region to extrude (Ctrl+click to add more)")
+		} else if n > 1 {
+			native.Text("Extruding " + strconv.Itoa(n) + " regions")
 		}
 		native.Text("Distance (" + s.LengthUnitName() + ")")
 		native.InputFloat("##extrude-distance", &extrudeUI.distance)
@@ -59,16 +62,46 @@ func drawExtrudeDialog(s *app.Session) {
 	native.End()
 }
 
-// extrudeProfileHighlight outlines the profile picked for extrude (and its holes) in the
-// selection color, so the user sees what they clicked. Returns nil when no extrude tool
-// is active or no profile is picked yet.
+// extrudeProfileHighlight outlines every region picked for extrude (and their holes) in
+// the selection color, so the user sees what they have gathered. Returns nil when no
+// extrude tool is active or nothing is picked yet.
 func extrudeProfileHighlight(s *app.Session) []renderer.DrawItem {
 	ext := s.ActiveExtrude()
 	if ext == nil {
 		return nil
 	}
-	ph, ok := ext.PickedProfile()
-	if !ok || ph.ProfileIndex >= ph.Sketch.Profiles().Count() {
+	var items []renderer.DrawItem
+	for _, ph := range ext.PickedProfiles() {
+		items = append(items, profileOutline(ph, sketchSelectedColor)...)
+	}
+	return items
+}
+
+// extrudeHoverHighlight outlines the region under the cursor in the candidate color
+// while the Extrude tool is active, so the user sees which closed area a click would
+// pick. Returns nil when no extrude tool is active, the cursor is off any region, or
+// that region is already selected (it is then already drawn in the selected color).
+func extrudeHoverHighlight(s *app.Session) []renderer.DrawItem {
+	ext := s.ActiveExtrude()
+	if ext == nil || !native.IsItemHovered() {
+		return nil
+	}
+	x, y := viewportCursor()
+	sel, ok := s.PickAt(x, y, app.NewSelectionFilter(app.SelectProfile))
+	if !ok {
+		return nil
+	}
+	ph, isProfile := sel.(app.ProfileHandle)
+	if !isProfile || isPickedProfile(ext, ph) {
+		return nil
+	}
+	return profileOutline(ph, sketchCandidateColor)
+}
+
+// profileOutline returns the wireframe of a region's outer loop and holes in color.
+// Returns nil when the region index is stale (sketch edited under the selection).
+func profileOutline(ph app.ProfileHandle, color [4]float32) []renderer.DrawItem {
+	if ph.ProfileIndex >= ph.Sketch.Profiles().Count() {
 		return nil
 	}
 	prof := ph.Sketch.Profiles().Item(ph.ProfileIndex)
@@ -77,7 +110,17 @@ func extrudeProfileHighlight(s *app.Session) []renderer.DrawItem {
 	for _, hole := range prof.InnerLoops() {
 		acc.polyline(ph.Sketch.Plane(), hole.Polygon(), true)
 	}
-	return appendGrid(nil, acc, sketchSelectedColor)
+	return appendGrid(nil, acc, color)
+}
+
+// isPickedProfile reports whether ph is already in the tool's selection.
+func isPickedProfile(ext *app.ExtrudeTool, ph app.ProfileHandle) bool {
+	for _, p := range ext.PickedProfiles() {
+		if p == ph {
+			return true
+		}
+	}
+	return false
 }
 
 // activeToolPreviewItems returns the active tool's transient preview (the Extrude prism

--- a/kernel/geom/intersect2d.go
+++ b/kernel/geom/intersect2d.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "github.com/Oblikovati/oblikovati/math"
+
+// Segment2dIntersection is the one intersection primitive the sketch region detector
+// needs: because every sketch curve (line, arc, spline, circle, ellipse) is faceted
+// into straight segments before the planar arrangement is built (the same faceting the
+// extrude prism uses), every curve–curve crossing reduces to a segment–segment
+// crossing. This keeps the arrangement exact at the facet resolution and consistent
+// with the downstream solid.
+//
+// It returns the crossing point and the parameters s,t∈[0,1] along a and b. ok is false
+// when the segments are parallel (no single crossing) or do not actually overlap. Pass
+// tol <= 0 for the default; tol widens the [0,1] acceptance so a touch at an endpoint
+// (a T-junction) still counts.
+func Segment2dIntersection(a, b LineSegment2d, tol float64) (pt math.Point2, s, t float64, ok bool) {
+	tol = paramTol(tol)
+	r := a.StartPoint.VectorTo(a.EndPoint)
+	d := b.StartPoint.VectorTo(b.EndPoint)
+	denom := r.Cross(d)
+	if math.IsNearZero(denom, math.DefaultTolerance) {
+		return math.Point2{}, 0, 0, false // parallel or degenerate
+	}
+	w := a.StartPoint.VectorTo(b.StartPoint)
+	s = w.Cross(d) / denom
+	t = w.Cross(r) / denom
+	if s < -tol || s > 1+tol || t < -tol || t > 1+tol {
+		return math.Point2{}, 0, 0, false
+	}
+	return a.PointAt(clampUnitParam(s)), clampUnitParam(s), clampUnitParam(t), true
+}
+
+// paramTol resolves a non-positive tolerance to a small default for the [0,1]
+// parameter-range test (separate from the geometric DefaultTolerance).
+func paramTol(tol float64) float64 {
+	if tol <= 0 {
+		return 1e-9
+	}
+	return tol
+}
+
+// clampUnitParam pins a parameter into [0,1] (a crossing reported just outside the
+// range by tol resolves to the nearest endpoint).
+func clampUnitParam(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/kernel/geom/intersect2d_test.go
+++ b/kernel/geom/intersect2d_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+func TestSegment2dIntersection(t *testing.T) {
+	cases := []struct {
+		name   string
+		a, b   LineSegment2d
+		wantOK bool
+		wantPt math.Point2
+		wantS  float64
+		wantT  float64
+	}{
+		{
+			name:   "cross at center",
+			a:      NewLineSegment2d(math.P2(-1, 0), math.P2(1, 0)),
+			b:      NewLineSegment2d(math.P2(0, -1), math.P2(0, 1)),
+			wantOK: true, wantPt: math.P2(0, 0), wantS: 0.5, wantT: 0.5,
+		},
+		{
+			name:   "T-junction: b's start lands on a's interior",
+			a:      NewLineSegment2d(math.P2(0, 0), math.P2(10, 0)),
+			b:      NewLineSegment2d(math.P2(4, 0), math.P2(4, 5)),
+			wantOK: true, wantPt: math.P2(4, 0), wantS: 0.4, wantT: 0,
+		},
+		{
+			name:   "parallel: no crossing",
+			a:      NewLineSegment2d(math.P2(0, 0), math.P2(10, 0)),
+			b:      NewLineSegment2d(math.P2(0, 1), math.P2(10, 1)),
+			wantOK: false,
+		},
+		{
+			name:   "disjoint: lines cross but segments do not reach",
+			a:      NewLineSegment2d(math.P2(0, 0), math.P2(1, 0)),
+			b:      NewLineSegment2d(math.P2(5, -1), math.P2(5, 1)),
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pt, s, tt, ok := Segment2dIntersection(c.a, c.b, 0)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if !pt.IsEqualTo(c.wantPt, 1e-9) {
+				t.Errorf("pt = %v, want %v", pt, c.wantPt)
+			}
+			if !math.IsNearZero(s-c.wantS, 1e-9) || !math.IsNearZero(tt-c.wantT, 1e-9) {
+				t.Errorf("s,t = %v,%v want %v,%v", s, tt, c.wantS, c.wantT)
+			}
+		})
+	}
+}

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -19,11 +19,11 @@ import (
 // taper. It re-derives the profile from its sketch each recompute (so sketch edits
 // flow through), going sick if the profile is gone or open.
 type ExtrudeDefinition struct {
-	Sketch       *sketch.Sketch
-	ProfileIndex int
-	Operation    ops.PartFeatureOperation
-	Extent       Extent
-	Taper        float64 // draft angle (radians); 0 in phase A (planar sides)
+	Sketch         *sketch.Sketch
+	ProfileIndices []int // one or more sketch regions, extruded together into one feature
+	Operation      ops.PartFeatureOperation
+	Extent         Extent
+	Taper          float64 // draft angle (radians); 0 in phase A (planar sides)
 }
 
 // ExtrudeFeature turns a profile into a prism and combines it with the running
@@ -62,7 +62,7 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 	if e.def.Extent.Type != DistanceExtent {
 		return Output{}, build.NotYetImplemented("PBI-092-extent-" + fmt.Sprint(e.def.Extent.Type))
 	}
-	profile, err := e.resolveProfile()
+	profiles, err := e.resolveProfiles()
 	if err != nil {
 		return Output{}, err
 	}
@@ -70,26 +70,56 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 	if dist == 0 {
 		return Output{}, errors.New("extrude distance is zero")
 	}
-	prism := buildPrism(profile.OuterLoop().Polygon(), e.def.Sketch.Plane(), dist, e.featName)
-	bodies, err := combine(in.Bodies, prism, e.def.Operation)
+	bodies, err := combine(in.Bodies, e.buildTool(profiles, dist), e.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
 }
 
-// resolveProfile re-derives the closed profile from the sketch, erroring (→ sick)
-// when it is missing or open (a lost/invalid input).
-func (e *ExtrudeFeature) resolveProfile() (*sketch.Profile, error) {
-	profiles := e.def.Sketch.Profiles()
-	if e.def.ProfileIndex < 0 || e.def.ProfileIndex >= profiles.Count() {
-		return nil, fmt.Errorf("extrude: profile %d not found (sketch has %d)", e.def.ProfileIndex, profiles.Count())
+// buildTool extrudes each selected region into a prism and merges the prisms into one
+// body. The regions are distinct cells of the same sketch, so they never overlap — a
+// shell merge is exactly their union and avoids the unimplemented intersecting Join.
+func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, dist float64) *topo.Body {
+	plane := e.def.Sketch.Plane()
+	prisms := make([]*topo.Body, len(profiles))
+	for i, p := range profiles {
+		prisms[i] = buildPrism(p.OuterLoop().Polygon(), plane, dist, e.prismFeat(i, len(profiles)))
 	}
-	p := profiles.Item(e.def.ProfileIndex)
-	if !p.IsClosed() {
-		return nil, errors.New("extrude: profile is open (cannot form a solid)")
+	if len(prisms) == 1 {
+		return prisms[0]
 	}
-	return p, nil
+	return topo.MergeBodies(topo.NewLineage(topo.Tok(e.featName, "merged", 0)), true, prisms...)
+}
+
+// prismFeat namespaces each region's prism lineage; a single-profile extrude keeps the
+// bare feature name so its persistent face IDs are unchanged.
+func (e *ExtrudeFeature) prismFeat(i, n int) string {
+	if n == 1 {
+		return e.featName
+	}
+	return fmt.Sprintf("%s/p%d", e.featName, i)
+}
+
+// resolveProfiles re-derives the selected closed regions from the sketch, erroring
+// (→ sick) when one is missing or open, or when none is selected.
+func (e *ExtrudeFeature) resolveProfiles() ([]*sketch.Profile, error) {
+	all := e.def.Sketch.Profiles()
+	if len(e.def.ProfileIndices) == 0 {
+		return nil, errors.New("extrude: no profile selected")
+	}
+	out := make([]*sketch.Profile, 0, len(e.def.ProfileIndices))
+	for _, idx := range e.def.ProfileIndices {
+		if idx < 0 || idx >= all.Count() {
+			return nil, fmt.Errorf("extrude: profile %d not found (sketch has %d)", idx, all.Count())
+		}
+		p := all.Item(idx)
+		if !p.IsClosed() {
+			return nil, errors.New("extrude: profile is open (cannot form a solid)")
+		}
+		out = append(out, p)
+	}
+	return out, nil
 }
 
 // ExtrudeFeatures is the collection of extrude features, adding into the engine.
@@ -102,11 +132,17 @@ func NewExtrudeFeatures(engine *PartFeatures) *ExtrudeFeatures {
 	return &ExtrudeFeatures{engine: engine}
 }
 
-// AddByDistanceExtent adds an extrude of the sketch's profileIndex profile, growing
-// distance (a closure, typically a parameter) under the given operation.
+// AddByDistanceExtent adds an extrude of a single sketch region, growing distance (a
+// closure, typically a parameter) under the given operation.
 func (c *ExtrudeFeatures) AddByDistanceExtent(skt *sketch.Sketch, profileIndex int, op ops.PartFeatureOperation, distance func() float64) *PartFeature {
+	return c.AddByDistanceExtentProfiles(skt, []int{profileIndex}, op, distance)
+}
+
+// AddByDistanceExtentProfiles adds an extrude of one or more sketch regions, merged
+// into one body — the multi-region selection the Extrude tool gathers with Ctrl+click.
+func (c *ExtrudeFeatures) AddByDistanceExtentProfiles(skt *sketch.Sketch, profileIndices []int, op ops.PartFeatureOperation, distance func() float64) *PartFeature {
 	def := &ExtrudeDefinition{
-		Sketch: skt, ProfileIndex: profileIndex, Operation: op,
+		Sketch: skt, ProfileIndices: append([]int(nil), profileIndices...), Operation: op,
 		Extent: Extent{Type: DistanceExtent, Distance: distance},
 	}
 	ef := &ExtrudeFeature{def: def}
@@ -150,8 +186,26 @@ func buildPrism(poly []math.Point2, plane sketch.Plane, dist float64, feat strin
 	}
 	be, te, ve := prismEdges(bld, bottom, top, feat)
 	addCaps(bld, bottom, top, be, te, plane, feat)
-	addSides(bld, bottom, be, te, ve, plane, feat)
+	addSides(bld, bottom, be, te, ve, plane, outwardSign(poly), feat)
 	return bld.Build()
+}
+
+// outwardSign returns +1 when the profile polygon is wound counter-clockwise in the
+// sketch plane and −1 when clockwise. Side-wall normals are built as edgeDir×normal,
+// which points away from the interior only for a CCW loop; profile detection does not
+// guarantee a winding, so a clockwise loop must flip the side normals to stay coherent
+// with the (fixed up/down) caps — otherwise the prism is "inside-out" and breaks
+// rendering, volume, and downstream booleans.
+func outwardSign(poly []math.Point2) float64 {
+	area := 0.0
+	for i, n := 0, len(poly); i < n; i++ {
+		j := (i + 1) % n
+		area += poly[i].X*poly[j].Y - poly[j].X*poly[i].Y
+	}
+	if area < 0 {
+		return -1
+	}
+	return 1
 }
 
 // prismEdges builds the bottom, top and vertical edges and returns them.
@@ -183,14 +237,16 @@ func addCaps(bld *topo.Builder, bottom, top []*topo.Vertex, be, te []*topo.Edge,
 	bld.AddFace(topPlane, topo.NewLineage(topo.Tok(feat, "end-cap", 0)), topo.OuterLoop(topLoop...))
 }
 
-// addSides builds one planar side wall per profile edge.
-func addSides(bld *topo.Builder, bottom []*topo.Vertex, be, te, ve []*topo.Edge, plane sketch.Plane, feat string) {
+// addSides builds one planar side wall per profile edge. sign flips the computed
+// outward normal for a clockwise profile (see outwardSign) so every wall faces away
+// from the solid's interior.
+func addSides(bld *topo.Builder, bottom []*topo.Vertex, be, te, ve []*topo.Edge, plane sketch.Plane, sign float64, feat string) {
 	n := len(bottom)
 	normal := plane.Normal().AsVector()
 	for i := 0; i < n; i++ {
 		j := (i + 1) % n
 		edgeDir := bottom[i].Point().VectorTo(bottom[j].Point())
-		outward, err := math.UnitVector3FromVector(edgeDir.Cross(normal))
+		outward, err := math.UnitVector3FromVector(edgeDir.Cross(normal).Scale(sign))
 		surf := sideSurface(bottom[i].Point(), outward, err)
 		loop := topo.OuterLoop(topo.Fwd(be[i]), topo.Fwd(ve[j]), topo.Rev(te[i]), topo.Rev(ve[i]))
 		bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "side", i)), loop)

--- a/model/feature/extrude_shapes_test.go
+++ b/model/feature/extrude_shapes_test.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// Extrusion-shape coverage for complex closed paths — arcs, ellipses, splines, and
+// their mixtures — regression for the bug where loops with arcs flattened to chords
+// (so the prism enclosed no/incorrect volume). Each case asserts the solid is
+// watertight, manifold, correctly oriented, has the expected bounding box, and that
+// its volume equals the cross-section polygon's area times the extrude height (the
+// prism faithfully follows the sampled curve, not a chord).
+
+// extrudeProfile extrudes profile profileIndex of sk by height as a new body and
+// returns the resulting solid, failing the test if it goes sick.
+func extrudeProfile(t *testing.T, sk *sketch.Sketch, profileIndex int, height float64) *topo.Body {
+	t.Helper()
+	fs := NewPartFeatures(nil, nil)
+	pf := NewExtrudeFeatures(fs).AddByDistanceExtent(sk, profileIndex, ops.NewBody, func() float64 { return height })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("extrude went sick: %+v", pf.Health())
+	}
+	bodies := fs.Result()
+	if len(bodies) != 1 {
+		t.Fatalf("result has %d bodies, want 1", len(bodies))
+	}
+	return bodies[0]
+}
+
+// assertWatertightSolid asserts the body is a closed, manifold, consistently oriented
+// solid (the invariants every extruded prism must hold).
+func assertWatertightSolid(t *testing.T, b *topo.Body) {
+	t.Helper()
+	if !b.IsSolid() {
+		t.Error("extrude result is not a solid")
+	}
+	if open := ops.BoundaryEdges(b); len(open) != 0 {
+		t.Errorf("solid has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if r := ops.Validate(b); !r.Valid {
+		t.Errorf("solid failed validation: %+v", r.Issues)
+	}
+}
+
+// assertPrismVolume asserts the mesh volume equals the cross-section area times the
+// height — i.e. the prism is exactly the swept profile polygon, arcs and all.
+func assertPrismVolume(t *testing.T, b *topo.Body, sk *sketch.Sketch, profileIndex int, height float64) {
+	t.Helper()
+	poly := sk.Profiles().Item(profileIndex).OuterLoop().Polygon()
+	want := polygonArea(poly) * height
+	got := meshVolume(b)
+	if rel := stdmath.Abs(got-want) / want; rel > 1e-3 {
+		t.Errorf("prism volume = %.6f, want %.6f (cross-section %.6f × height %.1f)", got, want, polygonArea(poly), height)
+	}
+}
+
+func TestExtrudeHalfDiscFromArcAndLine(t *testing.T) {
+	const r, h = 5.0, 4.0
+	sk := halfDiscSketch(r)
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+	assertPrismVolume(t, b, sk, 0, h)
+	// The faceted half-disc area is within a few percent of the analytic πr²/2.
+	if a := polygonArea(sk.Profiles().Item(0).OuterLoop().Polygon()); relErr(a, stdmath.Pi*r*r/2) > 0.02 {
+		t.Errorf("half-disc cross-section area = %.4f, want ≈ %.4f", a, stdmath.Pi*r*r/2)
+	}
+}
+
+func TestExtrudeStadiumFromTwoArcsTwoLines(t *testing.T) {
+	const l, r, h = 10.0, 3.0, 4.0
+	sk := stadiumSketch(l, r)
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+	assertPrismVolume(t, b, sk, 0, h)
+	box := b.RangeBox().Diagonal()
+	if !approxEq(box.X, l+2*r) || !approxEq(box.Y, 2*r) || !approxEq(box.Z, h) {
+		t.Errorf("stadium box = %v, want (%.1f, %.1f, %.1f)", box, l+2*r, 2*r, h)
+	}
+	if a := polygonArea(sk.Profiles().Item(0).OuterLoop().Polygon()); relErr(a, 2*r*l+stdmath.Pi*r*r) > 0.02 {
+		t.Errorf("stadium cross-section area = %.4f, want ≈ %.4f", a, 2*r*l+stdmath.Pi*r*r)
+	}
+}
+
+func TestExtrudeRoundedRectangleFilletedCorners(t *testing.T) {
+	const w, ht, r, h = 12.0, 8.0, 2.0, 5.0
+	sk := roundedRectSketch(w, ht, r)
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+	assertPrismVolume(t, b, sk, 0, h)
+	box := b.RangeBox().Diagonal()
+	if !approxEq(box.X, w) || !approxEq(box.Y, ht) || !approxEq(box.Z, h) {
+		t.Errorf("rounded-rect box = %v, want (%.1f, %.1f, %.1f)", box, w, ht, h)
+	}
+	// Area = full rectangle minus the four corners the fillets round off: 4r² − πr².
+	want := w*ht - (4-stdmath.Pi)*r*r
+	if a := polygonArea(sk.Profiles().Item(0).OuterLoop().Polygon()); relErr(a, want) > 0.02 {
+		t.Errorf("rounded-rect area = %.4f, want ≈ %.4f", a, want)
+	}
+}
+
+func TestExtrudeEllipse(t *testing.T) {
+	const a, bb, h = 6.0, 3.0, 4.0
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), a, bb)
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+	assertPrismVolume(t, b, sk, 0, h)
+	box := b.RangeBox().Diagonal()
+	if !approxEq(box.X, 2*a) || !approxEq(box.Y, 2*bb) || !approxEq(box.Z, h) {
+		t.Errorf("ellipse box = %v, want (%.1f, %.1f, %.1f)", box, 2*a, 2*bb, h)
+	}
+	if ar := polygonArea(sk.Profiles().Item(0).OuterLoop().Polygon()); relErr(ar, stdmath.Pi*a*bb) > 0.02 {
+		t.Errorf("ellipse area = %.4f, want ≈ %.4f", ar, stdmath.Pi*a*bb)
+	}
+}
+
+func TestExtrudeClosedSplineBlob(t *testing.T) {
+	const h = 4.0
+	// A closed fit-spline through points roughly on a circle of radius 5 → a smooth
+	// blob enclosing a positive area near πr².
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Splines().AddByPoints(ringPoints(6, 5), true)
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+	assertPrismVolume(t, b, sk, 0, h)
+	if a := polygonArea(sk.Profiles().Item(0).OuterLoop().Polygon()); a < 60 || a > 90 {
+		t.Errorf("closed-spline blob area = %.4f, want roughly π·5² ≈ 78.5", a)
+	}
+}
+
+func TestExtrudeMixedLinesArcSpline(t *testing.T) {
+	const h = 3.0
+	sk := mixedLineArcSplineSketch()
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+	assertPrismVolume(t, b, sk, 0, h)
+}
+
+func TestExtrudeTwoComplexClosedPathsAsSeparateBodies(t *testing.T) {
+	// "One or more closed paths": a sketch holding two disjoint complex loops yields
+	// two profiles; each extrudes independently into its own valid solid.
+	const h = 4.0
+	sk := stadiumSketch(8, 2)
+	sk.Ellipses().Add(math.P2(30, 0), math.V2(1, 0), 4, 2) // a second, disjoint region
+	if n := sk.Profiles().Count(); n != 2 {
+		t.Fatalf("sketch has %d profiles, want 2 disjoint closed paths", n)
+	}
+	for i := 0; i < 2; i++ {
+		b := extrudeProfile(t, sk, i, h)
+		assertWatertightSolid(t, b)
+		assertPrismVolume(t, b, sk, i, h)
+	}
+}
+
+func TestExtrudeMultipleRegionsMergeIntoOneBody(t *testing.T) {
+	// Two disjoint square regions in one sketch, extruded together as one feature →
+	// a single body whose volume is the sum of the two prisms.
+	const side, gap, h = 2.0, 10.0, 4.0
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	addSquareAt(sk, 0, side)
+	addSquareAt(sk, gap, side)
+	if n := sk.Profiles().Count(); n != 2 {
+		t.Fatalf("sketch has %d regions, want 2", n)
+	}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewExtrudeFeatures(fs).AddByDistanceExtentProfiles(sk, []int{0, 1}, ops.NewBody, func() float64 { return h })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("multi-region extrude went sick: %+v", pf.Health())
+	}
+	if len(fs.Result()) != 1 {
+		t.Fatalf("result has %d bodies, want 1 merged", len(fs.Result()))
+	}
+	b := fs.Result()[0]
+	assertWatertightSolid(t, b)
+	if got, want := meshVolume(b), 2*side*side*h; relErr(got, want) > 1e-3 {
+		t.Errorf("merged volume = %.4f, want %.4f (two %g×%g prisms)", got, want, side, side)
+	}
+}
+
+func TestExtrudeSplitRegionsRebuildWholeShape(t *testing.T) {
+	// A rectangle split by a line into two regions; extruding both regions together
+	// reconstitutes the full rectangle's prism (regression for the reported bug).
+	const w, ht, h = 10.0, 6.0, 3.0
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	addSquareRect(sk, 0, 0, w, ht)
+	sk.Lines().Add(sk.Points().Add(math.P2(0, 3)), sk.Points().Add(math.P2(w, 3))) // divider
+	if n := sk.Profiles().Count(); n != 2 {
+		t.Fatalf("split rectangle has %d regions, want 2", n)
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtentProfiles(sk, []int{0, 1}, ops.NewBody, func() float64 { return h })
+	fs.Recompute()
+	b := fs.Result()[0]
+	assertWatertightSolid(t, b)
+	if got, want := meshVolume(b), w*ht*h; relErr(got, want) > 1e-3 {
+		t.Errorf("split-then-merge volume = %.4f, want %.4f (whole rectangle)", got, want)
+	}
+}
+
+// --- shape builders ------------------------------------------------------------
+
+// addSquareRect adds a closed rectangle [x0,y0]–[x1,y1] sharing corner points.
+func addSquareRect(s *sketch.Sketch, x0, y0, x1, y1 float64) {
+	c00 := s.Points().Add(math.P2(x0, y0))
+	c10 := s.Points().Add(math.P2(x1, y0))
+	c11 := s.Points().Add(math.P2(x1, y1))
+	c01 := s.Points().Add(math.P2(x0, y1))
+	s.Lines().Add(c00, c10)
+	s.Lines().Add(c10, c11)
+	s.Lines().Add(c11, c01)
+	s.Lines().Add(c01, c00)
+}
+
+// addSquareAt adds a side×side square with its lower-left corner at (dx,0).
+func addSquareAt(s *sketch.Sketch, dx, side float64) { addSquareRect(s, dx, 0, dx+side, side) }
+
+// halfDiscSketch is a diameter line closed by a semicircular arc of radius r.
+func halfDiscSketch(r float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	left := s.Points().Add(math.P2(-r, 0))
+	right := s.Points().Add(math.P2(r, 0))
+	s.Lines().Add(right, left)
+	s.Arcs().Add(s.Points().Add(math.P2(0, 0)), left, right, true)
+	return s
+}
+
+// stadiumSketch is a discorectangle: two horizontal lines of length l joined by two
+// semicircular end caps of radius r (left cap centered at the origin).
+func stadiumSketch(l, r float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	tl := s.Points().Add(math.P2(0, r))
+	tr := s.Points().Add(math.P2(l, r))
+	br := s.Points().Add(math.P2(l, -r))
+	bl := s.Points().Add(math.P2(0, -r))
+	s.Lines().Add(tl, tr)
+	s.Arcs().Add(s.Points().Add(math.P2(l, 0)), tr, br, false) // right cap, through (l+r,0)
+	s.Lines().Add(br, bl)
+	s.Arcs().Add(s.Points().Add(math.P2(0, 0)), bl, tl, false) // left cap, through (-r,0)
+	return s
+}
+
+// roundedRectSketch is a w×ht rectangle centered at the origin with its four corners
+// replaced by quarter-circle fillets of radius r (four lines + four arcs).
+func roundedRectSketch(w, ht, r float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	hw, hh := w/2, ht/2
+	// Tangent points where each straight edge meets a corner fillet.
+	rt := s.Points().Add(math.P2(hw, hh-r))  // right edge, top end
+	rb := s.Points().Add(math.P2(hw, -hh+r)) // right edge, bottom end
+	bl := s.Points().Add(math.P2(-hw+r, -hh))
+	br := s.Points().Add(math.P2(hw-r, -hh))
+	lt := s.Points().Add(math.P2(-hw, hh-r))
+	lb := s.Points().Add(math.P2(-hw, -hh+r))
+	tl := s.Points().Add(math.P2(-hw+r, hh))
+	tr := s.Points().Add(math.P2(hw-r, hh))
+	s.Lines().Add(rb, rt)                                             // right edge
+	s.Arcs().Add(s.Points().Add(math.P2(hw-r, hh-r)), rt, tr, true)   // top-right fillet
+	s.Lines().Add(tr, tl)                                             // top edge
+	s.Arcs().Add(s.Points().Add(math.P2(-hw+r, hh-r)), tl, lt, true)  // top-left fillet
+	s.Lines().Add(lt, lb)                                             // left edge
+	s.Arcs().Add(s.Points().Add(math.P2(-hw+r, -hh+r)), lb, bl, true) // bottom-left fillet
+	s.Lines().Add(bl, br)                                             // bottom edge
+	s.Arcs().Add(s.Points().Add(math.P2(hw-r, -hh+r)), br, rb, true)  // bottom-right fillet
+	return s
+}
+
+// mixedLineArcSplineSketch is a closed loop made of three different curve kinds: a
+// base line, a semicircular arc on the right, and a fit spline arcing back to start.
+func mixedLineArcSplineSketch() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(10, 0))
+	c := s.Points().Add(math.P2(10, 6))
+	s.Lines().Add(a, b)                                      // base
+	s.Arcs().Add(s.Points().Add(math.P2(10, 3)), b, c, true) // right semicircle bulge
+	s.Splines().AddWithPoints([]*sketch.Point{               // spline lid back to start
+		c,
+		s.Points().Add(math.P2(6, 9)),
+		s.Points().Add(math.P2(2, 8)),
+		a,
+	}, false, true)
+	return s
+}
+
+// ringPoints returns n points evenly spaced on a circle of radius r, for a closed
+// spline that traces a smooth blob.
+func ringPoints(n int, r float64) []math.Point2 {
+	pts := make([]math.Point2, n)
+	for i := range pts {
+		a := 2 * stdmath.Pi * float64(i) / float64(n)
+		pts[i] = math.P2(r*stdmath.Cos(a), r*stdmath.Sin(a))
+	}
+	return pts
+}
+
+// --- measurement helpers -------------------------------------------------------
+
+// polygonArea is the absolute shoelace area of a closed polygon.
+func polygonArea(poly []math.Point2) float64 {
+	a := 0.0
+	for i, n := 0, len(poly); i < n; i++ {
+		j := (i + 1) % n
+		a += poly[i].X*poly[j].Y - poly[j].X*poly[i].Y
+	}
+	return stdmath.Abs(a) / 2
+}
+
+// meshVolume returns the enclosed volume of a closed triangle mesh via the signed
+// tetrahedron sum (divergence theorem). Each triangle is first oriented outward using
+// its vertex normals, so the sum is correct regardless of the tessellator's winding.
+func meshVolume(b *topo.Body) float64 {
+	mesh, _ := ops.TessellateBody(b, ops.DefaultQuality())
+	vol := 0.0
+	for t := 0; t < mesh.TriangleCount(); t++ {
+		i, j, k := mesh.Indices[3*t], mesh.Indices[3*t+1], mesh.Indices[3*t+2]
+		p0, p1, p2 := mesh.Positions[i], mesh.Positions[j], mesh.Positions[k]
+		if p0.VectorTo(p1).Cross(p0.VectorTo(p2)).Dot(mesh.Normals[i]) < 0 {
+			p1, p2 = p2, p1 // flip to outward winding
+		}
+		vol += p0.AsVector().Dot(p1.AsVector().Cross(p2.AsVector()))
+	}
+	return vol / 6
+}
+
+func relErr(got, want float64) float64 { return stdmath.Abs(got-want) / stdmath.Abs(want) }

--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -4,15 +4,25 @@ package feature
 
 import "fmt"
 
-// ExtrudeData is an extrude's recipe: which sketch profile, the boolean operation, and
-// the distance extent. The distance is the evaluated growth (a fixed value on reopen;
-// parametric distance expressions arrive with the dimension-driven extent API).
+// ExtrudeData is an extrude's recipe: which sketch region(s), the boolean operation,
+// and the distance extent. The distance is the evaluated growth (a fixed value on
+// reopen; parametric distance expressions arrive with the dimension-driven extent API).
 type ExtrudeData struct {
 	Sketch    int     `yaml:"sketch"`
-	Profile   int     `yaml:"profile"`
+	Profile   int     `yaml:"profile,omitempty"`  // legacy single-region key; read for back-compat
+	Profiles  []int   `yaml:"profiles,omitempty"` // one or more regions (current form)
 	Operation string  `yaml:"operation"`
 	Distance  float64 `yaml:"distance"`
 	Taper     float64 `yaml:"taper,omitempty"`
+}
+
+// extrudeProfiles returns the region indices a payload selects, accepting both the
+// current `profiles` list and an older file's scalar `profile` key.
+func (ed *ExtrudeData) extrudeProfiles() []int {
+	if len(ed.Profiles) > 0 {
+		return ed.Profiles
+	}
+	return []int{ed.Profile}
 }
 
 func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, error) {
@@ -29,7 +39,7 @@ func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, e
 	}
 	return &ExtrudeData{
 		Sketch:    idx,
-		Profile:   def.ProfileIndex,
+		Profiles:  append([]int(nil), def.ProfileIndices...),
 		Operation: op,
 		Distance:  def.Extent.distance(),
 		Taper:     def.Taper,
@@ -54,7 +64,7 @@ func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartF
 		return nil, err
 	}
 	dist := ed.Distance
-	pf := NewExtrudeFeatures(fs).AddByDistanceExtent(skt, ed.Profile, op, func() float64 { return dist })
+	pf := NewExtrudeFeatures(fs).AddByDistanceExtentProfiles(skt, ed.extrudeProfiles(), op, func() float64 { return dist })
 	if ed.Taper != 0 {
 		pf.feature.(*ExtrudeFeature).def.Taper = ed.Taper
 	}

--- a/model/feature/surface.go
+++ b/model/feature/surface.go
@@ -275,6 +275,6 @@ func buildRuledBand(poly []math.Point2, plane sketch.Plane, dist float64, feat s
 		top[i] = bld.AddVertex(b.TranslateBy(up), topo.NewLineage(topo.Tok(feat, "vertex", n+i)))
 	}
 	be, te, ve := prismEdges(bld, bottom, top, feat)
-	addSides(bld, bottom, be, te, ve, plane, feat)
+	addSides(bld, bottom, be, te, ve, plane, outwardSign(poly), feat)
 	return bld.Build()
 }

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Region detection is a planar-subdivision problem: the regions a feature can extrude
+// are the minimal closed cells the sketch curves carve the plane into, so a curve that
+// divides a shape (an arc splitting a rectangle, two crossing lines, overlapping
+// circles) yields several regions, not one. The naive degree-2 chain walk could not do
+// this. Instead every curve is faceted into straight segments (the same faceting the
+// extrude prism uses — see curvesample.go), every crossing reduces to a segment
+// crossing (geom.Segment2dIntersection), and the faceted segments form a planar graph
+// (an "arrangement"); faces.go then extracts the cells.
+
+// arrMergeTol is the distance under which two arrangement endpoints are treated as the
+// same node. It is coarser than DefaultTolerance so a computed crossing point and a
+// curve endpoint that land on it snap together despite float error.
+const arrMergeTol = 1e-6
+
+// arrEdge is one straight sub-segment of a faceted curve, between two merged nodes,
+// remembering the sketch entity it came from (for the loop's entity list).
+type arrEdge struct {
+	u, v   int
+	entity Entity
+}
+
+// arrangement is the planar graph: merged nodes (unique positions) and the straight
+// sub-segments connecting them, with a coordinate index for node merging and a set to
+// drop duplicate edges (which would break the rotational face walk).
+type arrangement struct {
+	nodes []math.Point2
+	edges []arrEdge
+	index map[[2]int64]int
+	seen  map[[2]int]bool
+}
+
+// buildArrangement facets the entities, splits every facet at its crossings with other
+// entities, and merges coincident endpoints into a planar graph.
+func buildArrangement(entities []Entity) *arrangement {
+	segs := collectSegments(entities)
+	cuts := intersectionCuts(segs)
+	a := &arrangement{index: map[[2]int64]int{}, seen: map[[2]int]bool{}}
+	for i, s := range segs {
+		pts := splitPoints(s, cuts[i])
+		for k := 0; k+1 < len(pts); k++ {
+			a.addEdge(pts[k], pts[k+1], s.entity)
+		}
+	}
+	return a
+}
+
+// taggedSeg is a single faceted segment of an entity (the unit the arrangement is
+// built from).
+type taggedSeg struct {
+	a, b   math.Point2
+	entity Entity
+}
+
+// collectSegments facets every entity into straight segments (closed curves wrap back
+// to their first point), each tagged with its source entity.
+func collectSegments(entities []Entity) []taggedSeg {
+	var out []taggedSeg
+	for _, e := range entities {
+		pts, closed := entityPolyline(e)
+		for k := 0; k+1 < len(pts); k++ {
+			out = append(out, taggedSeg{pts[k], pts[k+1], e})
+		}
+		if closed && len(pts) >= 2 {
+			out = append(out, taggedSeg{pts[len(pts)-1], pts[0], e})
+		}
+	}
+	return out
+}
+
+// entityPolyline returns an entity's faceted polyline and whether it is inherently
+// closed (so the caller wraps it). Reuses the curve samplers in curvesample.go.
+func entityPolyline(e Entity) (pts []math.Point2, closed bool) {
+	switch t := e.(type) {
+	case *Circle:
+		return sampleCircle(t), true
+	case *Ellipse:
+		return sampleEllipseEntity(t), true
+	case *Spline:
+		if t.Closed {
+			return sampleSplineEntity(t), true
+		}
+		return naturalPolyline(t), false
+	default:
+		return naturalPolyline(e), false // Line, Arc, open Spline
+	}
+}
+
+// cut is a crossing along a segment: the parameter t∈[0,1] where it occurs and the
+// canonical crossing point (shared by both segments so they merge to one node).
+type cut struct {
+	param float64
+	pt    math.Point2
+}
+
+// intersectionCuts finds, for every segment, the points where other entities' segments
+// cross it. Facets of the same entity are skipped (they only share endpoints, they do
+// not cross), which also avoids O(n²) self-pairs within one curve.
+func intersectionCuts(segs []taggedSeg) [][]cut {
+	cuts := make([][]cut, len(segs))
+	for i := 0; i < len(segs); i++ {
+		for j := i + 1; j < len(segs); j++ {
+			if segs[i].entity == segs[j].entity {
+				continue
+			}
+			pt, s, t, ok := geom.Segment2dIntersection(
+				geom.NewLineSegment2d(segs[i].a, segs[i].b),
+				geom.NewLineSegment2d(segs[j].a, segs[j].b), arrMergeTol)
+			if !ok {
+				continue
+			}
+			cuts[i] = append(cuts[i], cut{s, pt})
+			cuts[j] = append(cuts[j], cut{t, pt})
+		}
+	}
+	return cuts
+}
+
+// splitPoints returns a segment's points in order: its start, the interior crossing
+// points (sorted, endpoint-coincident ones dropped), and its end.
+func splitPoints(s taggedSeg, cuts []cut) []math.Point2 {
+	sort.Slice(cuts, func(i, j int) bool { return cuts[i].param < cuts[j].param })
+	pts := []math.Point2{s.a}
+	for _, c := range cuts {
+		if c.param <= arrMergeTol || c.param >= 1-arrMergeTol {
+			continue // a crossing at an endpoint splits nothing
+		}
+		if pts[len(pts)-1].IsEqualTo(c.pt, arrMergeTol) {
+			continue
+		}
+		pts = append(pts, c.pt)
+	}
+	return append(pts, s.b)
+}
+
+// node returns the index of the merged node at p, creating it on first sight. Points
+// within arrMergeTol quantize to the same grid cell and so share a node.
+func (a *arrangement) node(p math.Point2) int {
+	key := [2]int64{
+		int64(stdmath.Round(p.X / arrMergeTol)),
+		int64(stdmath.Round(p.Y / arrMergeTol)),
+	}
+	if id, ok := a.index[key]; ok {
+		return id
+	}
+	id := len(a.nodes)
+	a.nodes = append(a.nodes, p)
+	a.index[key] = id
+	return id
+}
+
+// addEdge adds an undirected edge between the nodes at p and q, dropping zero-length
+// and duplicate edges (a repeated node pair would give the face walk two identical
+// rotational directions).
+func (a *arrangement) addEdge(p, q math.Point2, e Entity) {
+	u, v := a.node(p), a.node(q)
+	if u == v {
+		return
+	}
+	key := [2]int{u, v}
+	if u > v {
+		key = [2]int{v, u}
+	}
+	if a.seen[key] {
+		return
+	}
+	a.seen[key] = true
+	a.edges = append(a.edges, arrEdge{u, v, e})
+}

--- a/model/sketch/curvesample.go
+++ b/model/sketch/curvesample.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Region detection and the extruded cross-section need each curved sketch entity as
+// a polyline that follows the real curve, not a chord between its endpoints. The
+// endpoint-only walk used before flattened every arc/spline into a straight line, so
+// an extrude of a profile with arcs came out wrong (the loop's polygon enclosed no
+// area). These samplers replace that.
+
+// curveSamples is how many straight segments a curved entity is approximated with;
+// it matches sampleCircle so a circle and a full-turn arc agree in resolution.
+const curveSamples = circleSamples
+
+// traversalPolyline returns entity e's polyline walked in loop order — from its near
+// endpoint toward its far endpoint — EXCLUDING the far endpoint. The next entity in
+// the loop contributes that point as its own start (and the closing entity's far end
+// is the loop's first point), so dropping it keeps the loop polygon free of duplicate
+// vertices. A straight line yields a single point; a curved entity yields its start
+// plus interior samples so the loop follows the curve, not a chord.
+func traversalPolyline(e Entity, reversed bool) []math.Point2 {
+	pts := naturalPolyline(e)
+	if reversed {
+		reverseInPlace2(pts)
+	}
+	if len(pts) == 0 {
+		return pts
+	}
+	return pts[:len(pts)-1]
+}
+
+// naturalPolyline samples entity e from its natural start to its natural end,
+// endpoints inclusive. Unknown entities degrade to their endpoint chord.
+func naturalPolyline(e Entity) []math.Point2 {
+	switch t := e.(type) {
+	case *Line:
+		return []math.Point2{t.A.Position(), t.B.Position()}
+	case *Arc:
+		return sampleArcEntity(t)
+	case *Spline:
+		return sampleSplineEntity(t)
+	default:
+		a, b, ok := segmentEnds(e)
+		if !ok {
+			return nil
+		}
+		return []math.Point2{a.Position(), b.Position()}
+	}
+}
+
+// sampleArcEntity samples a circular arc from its Start to its End along the true
+// arc (respecting CounterClockwise), endpoints inclusive.
+func sampleArcEntity(a *Arc) []math.Point2 {
+	c := a.Center.Position()
+	r := a.Radius()
+	start := angleOfPoint(c, a.Start.Position())
+	sweep := arcSweepSigned(a, c, start)
+	pts := make([]math.Point2, curveSamples+1)
+	for i := range pts {
+		ang := start + sweep*float64(i)/float64(curveSamples)
+		pts[i] = math.P2(c.X+r*stdmath.Cos(ang), c.Y+r*stdmath.Sin(ang))
+	}
+	return pts
+}
+
+// arcSweepSigned returns the signed sweep from start to the arc's end in the arc's
+// winding direction (positive counter-clockwise, negative clockwise). A start==end
+// arc is a full turn (±2π) rather than a zero sweep. (Distinct from dimension.go's
+// arcSweep, which is the unsigned magnitude used for angular dimensions.)
+func arcSweepSigned(a *Arc, center math.Point2, start float64) float64 {
+	sweep := angleOfPoint(center, a.End.Position()) - start
+	if a.CounterClockwise {
+		for sweep <= 0 {
+			sweep += 2 * stdmath.Pi
+		}
+		return sweep
+	}
+	for sweep >= 0 {
+		sweep -= 2 * stdmath.Pi
+	}
+	return sweep
+}
+
+// sampleEllipseEntity samples a full ellipse's perimeter (counter-clockwise in its
+// major/minor frame) for a standalone closed loop.
+func sampleEllipseEntity(e *Ellipse) []math.Point2 {
+	c := e.Center.Position()
+	ux, uy := unitAxis(e.MajorAxis)
+	pts := make([]math.Point2, curveSamples)
+	for i := range pts {
+		a := 2 * stdmath.Pi * float64(i) / float64(curveSamples)
+		mx, my := e.MajorRadius*stdmath.Cos(a), e.MinorRadius*stdmath.Sin(a)
+		pts[i] = math.P2(c.X+mx*ux-my*uy, c.Y+mx*uy+my*ux)
+	}
+	return pts
+}
+
+// angleOfPoint returns the angle of the vector from center to p, in (−π, π].
+func angleOfPoint(center, p math.Point2) float64 {
+	v := center.VectorTo(p)
+	return stdmath.Atan2(v.Y, v.X)
+}
+
+// unitAxis returns the normalized components of v, falling back to +X for a zero
+// vector (so a degenerate major axis still yields a usable frame).
+func unitAxis(v math.Vector2) (float64, float64) {
+	l := v.Length()
+	if l < math.DefaultTolerance {
+		return 1, 0
+	}
+	return v.X / l, v.Y / l
+}
+
+// reverseInPlace2 reverses a slice of points in place.
+func reverseInPlace2(pts []math.Point2) {
+	for i, j := 0, len(pts)-1; i < j; i, j = i+1, j-1 {
+		pts[i], pts[j] = pts[j], pts[i]
+	}
+}

--- a/model/sketch/curvesample_spline.go
+++ b/model/sketch/curvesample_spline.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "github.com/Oblikovati/oblikovati/math"
+
+// A sketch spline only stores its defining points; region detection and the faceted
+// extruded cross-section need a smooth polyline through them. Both fit and control
+// splines are interpolated here with a uniform Catmull–Rom: it passes through the
+// points and is naturally periodic for a closed loop. Exact approximating (control-
+// point) NURBS fidelity is a B-rep curve concern, deferred to the kernel; this
+// representative polygon only has to follow the curve closely enough to detect the
+// region and facet the prism — strictly better than the chord it replaced.
+
+// splineSamplesPerSpan is how many straight segments approximate each span between
+// two consecutive spline points.
+const splineSamplesPerSpan = 8
+
+// sampleSplineEntity approximates a spline with a smooth polyline. A closed spline
+// wraps to its first point (no duplicate closing vertex, like sampleCircle); an open
+// one runs first→last with both endpoints included.
+func sampleSplineEntity(sp *Spline) []math.Point2 {
+	pts := splinePositions(sp)
+	if len(pts) < 3 {
+		return pts // a 1- or 2-point spline is just its chord
+	}
+	if sp.Closed {
+		return catmullRomClosed(pts)
+	}
+	return catmullRomOpen(pts)
+}
+
+// splinePositions returns the spline's defining-point positions.
+func splinePositions(sp *Spline) []math.Point2 {
+	out := make([]math.Point2, len(sp.Points))
+	for i, p := range sp.Points {
+		out[i] = p.Position()
+	}
+	return out
+}
+
+// catmullRomOpen samples an open spline through pts, endpoints duplicated as the
+// phantom neighbours so the curve starts and ends exactly on the first/last point.
+func catmullRomOpen(pts []math.Point2) []math.Point2 {
+	n := len(pts)
+	out := []math.Point2{}
+	for i := 0; i < n-1; i++ {
+		out = append(out, spanSamples(pts[clampIndex(i-1, n-1)], pts[i], pts[i+1], pts[clampIndex(i+2, n-1)])...)
+	}
+	return append(out, pts[n-1]) // include the final endpoint
+}
+
+// catmullRomClosed samples a closed spline, wrapping neighbour indices around the
+// loop; the closing vertex is omitted (the loop wraps back to pts[0]).
+func catmullRomClosed(pts []math.Point2) []math.Point2 {
+	n := len(pts)
+	out := []math.Point2{}
+	for i := 0; i < n; i++ {
+		out = append(out, spanSamples(pts[(i-1+n)%n], pts[i], pts[(i+1)%n], pts[(i+2)%n])...)
+	}
+	return out
+}
+
+// spanSamples returns the Catmull–Rom samples on the p1→p2 span at t∈[0,1): p1 and
+// the interior points, but not p2 (the next span contributes it).
+func spanSamples(p0, p1, p2, p3 math.Point2) []math.Point2 {
+	out := make([]math.Point2, splineSamplesPerSpan)
+	for j := 0; j < splineSamplesPerSpan; j++ {
+		out[j] = catmullRomPoint(p0, p1, p2, p3, float64(j)/float64(splineSamplesPerSpan))
+	}
+	return out
+}
+
+// catmullRomPoint evaluates the uniform Catmull–Rom spline of the p1→p2 span (with
+// neighbours p0,p3) at local parameter t∈[0,1].
+func catmullRomPoint(p0, p1, p2, p3 math.Point2, t float64) math.Point2 {
+	t2, t3 := t*t, t*t*t
+	return math.P2(
+		0.5*(2*p1.X+(-p0.X+p2.X)*t+(2*p0.X-5*p1.X+4*p2.X-p3.X)*t2+(-p0.X+3*p1.X-3*p2.X+p3.X)*t3),
+		0.5*(2*p1.Y+(-p0.Y+p2.Y)*t+(2*p0.Y-5*p1.Y+4*p2.Y-p3.Y)*t2+(-p0.Y+3*p1.Y-3*p2.Y+p3.Y)*t3),
+	)
+}
+
+// clampIndex clamps i to [0, hi] — used to reuse an open spline's endpoints as their
+// own phantom neighbours.
+func clampIndex(i, hi int) int {
+	if i < 0 {
+		return 0
+	}
+	if i > hi {
+		return hi
+	}
+	return i
+}

--- a/model/sketch/detection.go
+++ b/model/sketch/detection.go
@@ -31,21 +31,40 @@ func detectLoops(entities []Entity) (closed []Loop, open []Loop) {
 	return append(closed, c...), o
 }
 
-// standaloneLoop returns a one-entity closed loop for an inherently closed curve.
+// standaloneLoop returns a one-entity closed loop for an inherently closed curve: a
+// circle, a full ellipse, or a spline flagged closed.
 func standaloneLoop(e Entity) (Loop, bool) {
-	if c, ok := e.(*Circle); ok {
-		return Loop{entities: []ProfileEntity{{Entity: c}}, polygon: sampleCircle(c), closed: true}, true
+	switch t := e.(type) {
+	case *Circle:
+		return oneEntityLoop(t, sampleCircle(t)), true
+	case *Ellipse:
+		return oneEntityLoop(t, sampleEllipseEntity(t)), true
+	case *Spline:
+		if t.Closed {
+			return oneEntityLoop(t, sampleSplineEntity(t)), true
+		}
 	}
 	return Loop{}, false
 }
 
-// segmentEnds returns the endpoints of an open segment entity (line or arc).
+// oneEntityLoop wraps a single closed entity and its sampled polygon as a loop.
+func oneEntityLoop(e Entity, polygon []math.Point2) Loop {
+	return Loop{entities: []ProfileEntity{{Entity: e}}, polygon: polygon, closed: true}
+}
+
+// segmentEnds returns the endpoints of an open segment entity (line, arc, or an open
+// spline — joined to its neighbours by its first/last defining point).
 func segmentEnds(e Entity) (a, b *Point, ok bool) {
 	switch t := e.(type) {
 	case *Line:
 		return t.A, t.B, true
 	case *Arc:
 		return t.Start, t.End, true
+	case *Spline:
+		if !t.Closed && len(t.Points) >= 2 {
+			return t.Points[0], t.Points[len(t.Points)-1], true
+		}
+		return nil, nil, false
 	default:
 		return nil, nil, false
 	}
@@ -89,7 +108,7 @@ func walkChain(start int, segs []segment, adj map[*Point][]int, used []bool) Loo
 		s := segs[idx]
 		next, reversed := otherEnd(s, cur)
 		entities = append(entities, ProfileEntity{Entity: s.entity, reversed: reversed})
-		polygon = append(polygon, cur.Position())
+		polygon = append(polygon, traversalPolyline(s.entity, reversed)...)
 		cur = next
 		if cur == startPoint {
 			return Loop{entities: entities, polygon: polygon, closed: true}

--- a/model/sketch/detection_arc_test.go
+++ b/model/sketch/detection_arc_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// polygonArea is the shoelace area (absolute) of a closed polygon.
+func polygonArea(poly []math.Point2) float64 {
+	a := 0.0
+	n := len(poly)
+	for i := 0; i < n; i++ {
+		j := (i + 1) % n
+		a += poly[i].X*poly[j].Y - poly[j].X*poly[i].Y
+	}
+	return stdmath.Abs(a) / 2
+}
+
+// TestArcLoopPolygonFollowsArc is a regression for the extrude-of-arcs bug: a
+// half-disc (a diameter line + a semicircular arc) must yield a polygon whose area
+// approaches πr²/2, not the zero-area chord the old endpoint-only walk produced.
+func TestArcLoopPolygonFollowsArc(t *testing.T) {
+	const r = 5.0
+	s := NewSketches().Add(XYPlane())
+	left := s.Points().Add(math.P2(-r, 0))
+	right := s.Points().Add(math.P2(r, 0))
+	s.Lines().Add(right, left)                                             // diameter (closes the loop)
+	s.Arcs().Add(s.Points().Add(math.P2(0, 0)), left, right, true /*ccw*/) // semicircle over the top
+
+	ps := s.Profiles()
+	if ps.Count() != 1 {
+		t.Fatalf("profile count = %d, want 1", ps.Count())
+	}
+	p := ps.Item(0)
+	if !p.IsClosed() {
+		t.Fatal("half-disc profile is not closed")
+	}
+	got := polygonArea(p.OuterLoop().Polygon())
+	want := stdmath.Pi * r * r / 2
+	if stdmath.Abs(got-want)/want > 0.02 { // within 2% of the true semicircle area
+		t.Errorf("half-disc polygon area = %.3f, want ≈ %.3f (arc flattened to a chord?)", got, want)
+	}
+}

--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -94,17 +94,40 @@ func (ps *Profiles) All() []*Profile {
 	return out
 }
 
-// Profiles detects regions in the sketch from its non-construction geometry: closed
-// loops become closed profiles (with inner/outer classification by nesting); a
-// connected but unclosed chain becomes a single open profile.
+// Profiles detects regions in the sketch from its non-construction geometry: it builds
+// a planar arrangement of the (faceted) curves and extracts the minimal closed cells —
+// so a dividing curve splits a shape into several regions (arrangement.go / regions.go).
+// Cells are classified into outer boundaries and holes by even–odd nesting; geometry
+// that bounds no cell (a connected but unclosed chain) becomes an open profile.
 func (s *Sketch) Profiles() *Profiles {
-	loops, openChains := detectLoops(s.normalGeometry())
+	ents := s.normalGeometry()
+	loops := detectRegions(ents)
 	ps := &Profiles{}
 	ps.items = append(ps.items, groupRegions(loops)...)
-	for _, chain := range openChains {
+	for _, chain := range openChainsOutside(ents, loops) {
 		ps.items = append(ps.items, &Profile{outer: chain})
 	}
 	return ps
+}
+
+// openChainsOutside returns the open chains formed by entities that bound no detected
+// region — the geometry an extrude rightly rejects but a surface may consume. Entities
+// already used by a region are excluded so a dividing curve is not also reported open.
+func openChainsOutside(ents []Entity, loops []Loop) []Loop {
+	used := map[Entity]bool{}
+	for _, l := range loops {
+		for _, pe := range l.entities {
+			used[pe.Entity] = true
+		}
+	}
+	var leftover []Entity
+	for _, e := range ents {
+		if !used[e] {
+			leftover = append(leftover, e)
+		}
+	}
+	_, open := detectLoops(leftover)
+	return open
 }
 
 // normalGeometry returns the sketch's non-construction curve entities.

--- a/model/sketch/regions.go
+++ b/model/sketch/regions.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// faces.go's job: turn the planar graph (arrangement.go) into the minimal closed cells
+// (regions). It is a standard half-edge (DCEL) face traversal: each undirected edge
+// becomes two opposed half-edges; at each node the outgoing half-edges are sorted by
+// direction angle; the face boundary is followed by, at each arrival, taking the
+// next-clockwise outgoing half-edge (twin then previous in CCW order). Every minimal
+// bounded cell is traced once; the unbounded face of each component is the opposite
+// orientation and is dropped by keeping only positive-area cycles.
+
+// regionAreaEps discards near-degenerate cycles (collinear spurs) that enclose no area.
+const regionAreaEps = 1e-9
+
+// detectRegions returns the closed minimal cells of the sketch as loops, with the
+// originating entities recorded per loop.
+func detectRegions(entities []Entity) []Loop {
+	a := buildArrangement(entities)
+	edges := a.prunedEdges()
+	if len(edges) == 0 {
+		return nil
+	}
+	hes := a.buildHalfEdges(edges)
+	return a.walkFaces(hes)
+}
+
+// prunedEdges drops dangling edges (those with a degree-1 endpoint) repeatedly, so
+// open chains and antennae do not pollute the face walk; only edges that lie on a cycle
+// survive.
+func (a *arrangement) prunedEdges() []arrEdge {
+	alive := make([]bool, len(a.edges))
+	for i := range alive {
+		alive[i] = true
+	}
+	for changed := true; changed; {
+		changed = false
+		deg := a.degrees(alive)
+		for i, e := range a.edges {
+			if alive[i] && (deg[e.u] < 2 || deg[e.v] < 2) {
+				alive[i], changed = false, true
+			}
+		}
+	}
+	var out []arrEdge
+	for i, e := range a.edges {
+		if alive[i] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// degrees counts the live-edge degree of every node.
+func (a *arrangement) degrees(alive []bool) []int {
+	deg := make([]int, len(a.nodes))
+	for i, e := range a.edges {
+		if alive[i] {
+			deg[e.u]++
+			deg[e.v]++
+		}
+	}
+	return deg
+}
+
+// halfEdge is one directed side of an edge: origin/dest nodes, the outgoing direction
+// angle (for rotational sorting), its twin, the next half-edge around the face, and the
+// source entity (for the loop's entity list).
+type halfEdge struct {
+	origin, dest int
+	angle        float64
+	twin, next   int
+	entity       Entity
+}
+
+// buildHalfEdges creates the two half-edges per edge, sorts each node's outgoing
+// half-edges by angle, and links every half-edge's next around its face.
+func (a *arrangement) buildHalfEdges(edges []arrEdge) []halfEdge {
+	hes := make([]halfEdge, 0, 2*len(edges))
+	out := map[int][]int{}
+	for _, e := range edges {
+		i := len(hes)
+		hes = append(hes,
+			halfEdge{origin: e.u, dest: e.v, angle: segAngle(a.nodes[e.u], a.nodes[e.v]), twin: i + 1, entity: e.entity},
+			halfEdge{origin: e.v, dest: e.u, angle: segAngle(a.nodes[e.v], a.nodes[e.u]), twin: i, entity: e.entity})
+		out[e.u] = append(out[e.u], i)
+		out[e.v] = append(out[e.v], i+1)
+	}
+	for v := range out {
+		sort.Slice(out[v], func(i, j int) bool { return hes[out[v][i]].angle < hes[out[v][j]].angle })
+	}
+	for h := range hes {
+		hes[h].next = nextAroundFace(hes, out, h)
+	}
+	return hes
+}
+
+// nextAroundFace returns the half-edge that continues h's face boundary: arrive at
+// dest along h, then leave on the outgoing half-edge just clockwise of h's twin (the
+// previous one in the CCW-sorted rotation), which keeps the bounded cell on one side.
+func nextAroundFace(hes []halfEdge, out map[int][]int, h int) int {
+	list := out[hes[h].dest]
+	i := indexOf(list, hes[h].twin)
+	return list[(i-1+len(list))%len(list)]
+}
+
+// indexOf returns the position of v in s (or -1, which cannot occur here as the twin is
+// always present in its origin's outgoing list).
+func indexOf(s []int, v int) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// walkFaces traces every face once and returns those that enclose positive area (the
+// bounded minimal cells; each component's unbounded face is negative and dropped).
+func (a *arrangement) walkFaces(hes []halfEdge) []Loop {
+	visited := make([]bool, len(hes))
+	var loops []Loop
+	for start := range hes {
+		if visited[start] {
+			continue
+		}
+		cycle := traceFace(hes, visited, start)
+		poly := a.cyclePolygon(hes, cycle)
+		if signedArea2d(poly) > regionAreaEps {
+			loops = append(loops, Loop{entities: cycleEntities(hes, cycle), polygon: poly, closed: true})
+		}
+	}
+	return loops
+}
+
+// traceFace follows next() from start until it returns, marking each half-edge visited.
+func traceFace(hes []halfEdge, visited []bool, start int) []int {
+	var cycle []int
+	for cur := start; !visited[cur]; cur = hes[cur].next {
+		visited[cur] = true
+		cycle = append(cycle, cur)
+	}
+	return cycle
+}
+
+// cyclePolygon returns the polygon of a face cycle (its half-edges' origin points).
+func (a *arrangement) cyclePolygon(hes []halfEdge, cycle []int) []math.Point2 {
+	poly := make([]math.Point2, len(cycle))
+	for i, h := range cycle {
+		poly[i] = a.nodes[hes[h].origin]
+	}
+	return poly
+}
+
+// cycleEntities returns the loop's entities, collapsing consecutive facets of the same
+// entity (and the wrap-around) into one ProfileEntity. The reversed flag is best-effort
+// (false): the entity list is informational; geometry flows through the polygon.
+func cycleEntities(hes []halfEdge, cycle []int) []ProfileEntity {
+	var ents []ProfileEntity
+	for _, h := range cycle {
+		e := hes[h].entity
+		if len(ents) > 0 && ents[len(ents)-1].Entity == e {
+			continue
+		}
+		ents = append(ents, ProfileEntity{Entity: e})
+	}
+	if len(ents) > 1 && ents[0].Entity == ents[len(ents)-1].Entity {
+		ents = ents[:len(ents)-1] // the loop wrapped on the same entity
+	}
+	return ents
+}
+
+// segAngle returns the angle of the from→to direction.
+func segAngle(from, to math.Point2) float64 {
+	v := from.VectorTo(to)
+	return stdmath.Atan2(v.Y, v.X)
+}
+
+// signedArea2d is the shoelace signed area (positive counter-clockwise).
+func signedArea2d(poly []math.Point2) float64 {
+	area := 0.0
+	for i, n := 0, len(poly); i < n; i++ {
+		j := (i + 1) % n
+		area += poly[i].X*poly[j].Y - poly[j].X*poly[i].Y
+	}
+	return area / 2
+}

--- a/model/sketch/regions_test.go
+++ b/model/sketch/regions_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// regionAreas returns the (absolute) outer-loop area of every detected profile, so a
+// test can assert how a sketch was carved into regions independent of their order.
+func regionAreas(s *Sketch) []float64 {
+	ps := s.Profiles()
+	var out []float64
+	for i := 0; i < ps.Count(); i++ {
+		p := ps.Item(i)
+		if p.IsClosed() {
+			out = append(out, stdmath.Abs(signedArea2d(p.OuterLoop().Polygon())))
+		}
+	}
+	return out
+}
+
+func TestRectangleSplitByLineYieldsTwoRegions(t *testing.T) {
+	// The reported bug: a rectangle with a divider must become two regions, each
+	// bounded by part of the rectangle and the divider — not one region ignoring it.
+	s := NewSketches().Add(XYPlane())
+	addRectangle(s, 0, 0, 10, 6)
+	mid := s.Lines() // a horizontal divider whose ends land on the left/right edges (T-junctions)
+	mid.Add(s.Points().Add(math.P2(0, 3)), s.Points().Add(math.P2(10, 3)))
+	if got := regionAreas(s); len(got) != 2 || !approxArea(got, 30) {
+		t.Fatalf("split rectangle regions = %v, want two of area 30", got)
+	}
+}
+
+func TestRectangleSplitByArcYieldsTwoRegions(t *testing.T) {
+	// A shallow arc dividing the rectangle (its endpoints sit on the side edges). The
+	// two regions' areas sum to the rectangle's 100 regardless of the arc's bulge.
+	s := NewSketches().Add(XYPlane())
+	addRectangle(s, 0, 0, 10, 10)
+	left := s.Points().Add(math.P2(0, 5))
+	right := s.Points().Add(math.P2(10, 5))
+	s.Arcs().Add(s.Points().Add(math.P2(5, -10)), left, right, false) // shallow bulge up to y≈5.8, inside
+	areas := regionAreas(s)
+	if len(areas) != 2 {
+		t.Fatalf("arc-split rectangle regions = %d, want 2 (%v)", len(areas), areas)
+	}
+	if sum := areas[0] + areas[1]; !math.IsNearZero(sum-100, 1e-6) {
+		t.Errorf("region areas %v sum to %.4f, want 100", areas, sum)
+	}
+}
+
+func TestSquareWithBothDiagonalsYieldsFourTriangles(t *testing.T) {
+	// Two diagonals that cross mid-span (no shared point at the crossing) → 4 cells.
+	s := NewSketches().Add(XYPlane())
+	bl := s.Points().Add(math.P2(0, 0))
+	br := s.Points().Add(math.P2(10, 0))
+	tr := s.Points().Add(math.P2(10, 10))
+	tl := s.Points().Add(math.P2(0, 10))
+	s.Lines().Add(bl, br)
+	s.Lines().Add(br, tr)
+	s.Lines().Add(tr, tl)
+	s.Lines().Add(tl, bl)
+	s.Lines().Add(bl, tr) // diagonal /
+	s.Lines().Add(br, tl) // diagonal \ — crosses the first at (5,5)
+	areas := regionAreas(s)
+	if len(areas) != 4 {
+		t.Fatalf("square+diagonals regions = %d, want 4 triangles (%v)", len(areas), areas)
+	}
+	for _, a := range areas {
+		if !math.IsNearZero(a-25, 1e-6) {
+			t.Errorf("triangle area = %.4f, want 25 (%v)", a, areas)
+		}
+	}
+}
+
+func TestOverlappingCirclesYieldThreeRegions(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.Circles().AddByCenterRadius(math.P2(0, 0), 3)
+	s.Circles().AddByCenterRadius(math.P2(4, 0), 3)
+	if got := regionAreas(s); len(got) != 3 {
+		t.Fatalf("two overlapping circles → %d regions, want 3 (lens + two crescents): %v", len(got), got)
+	}
+}
+
+func TestPlainRectangleStillOneRegion(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	addRectangle(s, 0, 0, 4, 3)
+	if got := regionAreas(s); len(got) != 1 || !math.IsNearZero(got[0]-12, 1e-6) {
+		t.Fatalf("plain rectangle regions = %v, want one of area 12", got)
+	}
+}
+
+// approxArea reports whether every area in got is within tol of want.
+func approxArea(got []float64, want float64) bool {
+	for _, a := range got {
+		if !math.IsNearZero(a-want, 1e-6) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What

Reworks the Extrude tool to select **closed regions** (areas), and rebuilds the region detection that feeds it.

- **Region detection** is now a planar arrangement → minimal-cell extraction. A dividing curve actually splits a shape: a rectangle cut by an arc → two regions, crossing diagonals → four triangles, overlapping circles → three regions. Shared endpoints, T-junctions, and mid-span crossings are all handled.
- **Curved profiles extrude correctly.** Arcs/splines/ellipses are faceted along their true geometry instead of collapsing to a chord, and side-wall normals follow the profile winding so a clockwise loop no longer extrudes inside-out.
- **One extrude can consume several regions**, merged into a single body.
- **The tool picks by hover + Ctrl-click**: hover highlights the region under the cursor, click selects it, Ctrl+click adds/removes more, OK extrudes them together.

## Why

Selecting individual lines/arcs was the wrong model, and the old degree-2 loop walk couldn't tell two areas apart — a rectangle split by an arc extruded as the whole rectangle, ignoring the divider. Curved loops also enclosed the wrong area because every curve was flattened to a chord.

## How it's verified

- New unit tests: segment intersections; region counts/areas for split/crossing/overlapping sketches; faceted-solid volume == cross-section × height for arcs/splines/ellipses; multi-region merge (incl. split-then-merge rebuilding the whole shape); the tool's Ctrl accumulate/toggle/replace through both the tool API and the real pointer path.
- `golangci-lint run ./...`, `go vet`, `gofmt` all clean; full suite green; the cgo head builds and its tests pass.
- Head interaction (hover/Ctrl highlight) builds and is covered by the existing ui tests, but the Vulkan window itself needs a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)