### PR TITLE
Work planes: full constructor parity, ribbon tools, selection, visibility

### DIFF
--- a/addin/router/model.go
+++ b/addin/router/model.go
@@ -50,5 +50,9 @@ func modelSelection(s *app.Session, _ json.RawMessage) (json.RawMessage, error) 
 	for i, it := range items {
 		kinds[i] = int(it.SelectionKind())
 	}
-	return json.Marshal(wire.SelectionResult{Count: len(items), Kinds: kinds})
+	return json.Marshal(wire.SelectionResult{
+		Count: len(items),
+		Kinds: kinds,
+		Refs:  s.Selection().References(),
+	})
 }

--- a/addin/router/model_selection_test.go
+++ b/addin/router/model_selection_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+func TestModelSelectionReportsReferences(t *testing.T) {
+	r, s := emptyPartSession(t)
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	// Select the XY origin plane and the X origin axis; their references should come back
+	// parallel to the kinds, ready to feed workPlanes.create.
+	s.Selection().Add(app.WorkPlaneHandle{Plane: part.OriginPlanes()[0]})
+	s.Selection().Add(app.WorkAxisHandle{Axis: part.WorkAxes().Item(0)})
+
+	var sel wire.SelectionResult
+	call(t, r, s, "model.selection", "{}", &sel)
+	if sel.Count != 2 || len(sel.Refs) != 2 {
+		t.Fatalf("selection = %+v, want 2 items with 2 refs", sel)
+	}
+	if sel.Refs[0] != types.WorkRefXYPlane || sel.Refs[1] != types.WorkRefXAxis {
+		t.Errorf("refs = %v, want [%s %s]", sel.Refs, types.WorkRefXYPlane, types.WorkRefXAxis)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -57,6 +57,8 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodSketchRectangle] = sketchRectangle
 	r.handlers[wire.MethodFeaturesList] = r.listFeatureKinds
 	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
+	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes
+	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
 	r.handlers[wire.MethodThemeActive] = themeActive
 	r.handlers[wire.MethodThemeList] = themeList
 }

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// listWorkPlanes enumerates the active part's datum planes (origin frame first, then
+// user planes) with their current geometry and health.
+func listWorkPlanes(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	planes := part.WorkPlanes()
+	out := make([]wire.WorkPlaneInfo, planes.Count())
+	for i := 0; i < planes.Count(); i++ {
+		wp := planes.Item(i)
+		out[i] = wire.WorkPlaneInfo{
+			Index:    i,
+			Name:     wp.Name(),
+			Ref:      string(wp.Key()),
+			Origin:   point3Slice(wp.Plane().Origin()),
+			Normal:   vector3Slice(wp.Plane().Normal().AsVector()),
+			IsOrigin: wp.IsCoordinateSystemElement(),
+			Healthy:  wp.Health().OK(),
+		}
+	}
+	return json.Marshal(wire.ListWorkPlanesResult{Planes: out})
+}
+
+// createWorkPlanes adds a datum plane of the requested kind to the active part and
+// recomputes. An unsatisfiable definition still creates the plane (reported healthy=false)
+// — the call only fails on bad arguments (unknown kind, wrong reference count, …).
+func createWorkPlanes(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.CreateWorkPlaneArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	wp, err := buildWorkPlane(part, in)
+	if err != nil {
+		return nil, err
+	}
+	part.Recompute()
+	return json.Marshal(wire.CreateWorkPlaneResult{
+		Index:   part.WorkPlanes().Count() - 1,
+		Ref:     string(wp.Key()),
+		Name:    wp.Name(),
+		Healthy: wp.Health().OK(),
+	})
+}
+
+// refPlaneCtor builds a work plane from exactly its references (no scalar parameters);
+// refPlaneCtors is the table of the kinds that need only references, keeping
+// buildWorkPlane's body to the kinds with extra inputs (offset, angle, fixed frame).
+type refPlaneCtor struct {
+	arity int
+	build func(*feature.WorkPlanes, []feature.WorkRef) *feature.WorkPlane
+}
+
+var refPlaneCtors = map[types.WorkPlaneKind]refPlaneCtor{
+	types.WorkPlaneThreePoints: {3, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByThreePoints(r[0], r[1], r[2])
+	}},
+	types.WorkPlanePlaneAndPoint: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByPlaneAndPoint(r[0], r[1])
+	}},
+	types.WorkPlaneTwoPlanes: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByTwoPlanes(r[0], r[1])
+	}},
+	types.WorkPlaneTwoLines: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByTwoLines(r[0], r[1])
+	}},
+	types.WorkPlaneNormalToCurve: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByNormalToCurve(r[0], r[1])
+	}},
+	types.WorkPlaneTorusMidPlane: {1, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane { return p.AddByTorusMidPlane(r[0]) }},
+	types.WorkPlanePointAndTangent: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByPointAndTangent(r[0], r[1])
+	}},
+	types.WorkPlanePlaneAndTangent: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByPlaneAndTangent(r[0], r[1])
+	}},
+	types.WorkPlaneLineAndTangent: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByLineAndTangent(r[0], r[1])
+	}},
+}
+
+// buildWorkPlane dispatches a create request to the matching model constructor.
+func buildWorkPlane(part *compdef.PartComponentDefinition, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+	planes := part.WorkPlanes()
+	refs := toWorkRefs(in.Refs)
+	kind := types.WorkPlaneKind(in.Kind)
+	if c, ok := refPlaneCtors[kind]; ok {
+		if len(refs) != c.arity {
+			return nil, fmt.Errorf("workPlanes.create: %s needs %d references, got %d", in.Kind, c.arity, len(refs))
+		}
+		return c.build(planes, refs), nil
+	}
+	switch kind {
+	case types.WorkPlaneOffset:
+		return addOffsetPlane(part, refs, in)
+	case types.WorkPlaneLinePlaneAngle:
+		return addAnglePlane(part, refs, in)
+	case types.WorkPlaneFixed:
+		return addFixedWorkPlane(part.WorkPlanes(), in)
+	default:
+		return nil, fmt.Errorf("workPlanes.create: unknown kind %q (see api/types WorkPlane*)", in.Kind)
+	}
+}
+
+// addOffsetPlane builds the plane-offset kind: one base plane reference + a distance.
+func addOffsetPlane(part *compdef.PartComponentDefinition, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+	if len(refs) != 1 {
+		return nil, fmt.Errorf("workPlanes.create: %s needs 1 reference, got %d", in.Kind, len(refs))
+	}
+	d, err := modelLength(part, in.Offset)
+	if err != nil {
+		return nil, err
+	}
+	return part.WorkPlanes().AddByPlaneAndOffset(refs[0], func() float64 { return d }), nil
+}
+
+// addAnglePlane builds the line-plane-angle kind: a line + a plane reference + an angle.
+func addAnglePlane(part *compdef.PartComponentDefinition, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("workPlanes.create: %s needs 2 references, got %d", in.Kind, len(refs))
+	}
+	a, err := modelAngle(part, in.Angle)
+	if err != nil {
+		return nil, err
+	}
+	return part.WorkPlanes().AddByLinePlaneAndAngle(refs[0], refs[1], func() float64 { return a }), nil
+}
+
+// addFixedWorkPlane builds an AddFixed plane from its origin point and two axis vectors.
+func addFixedWorkPlane(planes *feature.WorkPlanes, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+	origin, err := parseCoords(in.Origin, "origin")
+	if err != nil {
+		return nil, err
+	}
+	x, err := parseAxisVector(in.XAxis, "xaxis")
+	if err != nil {
+		return nil, err
+	}
+	y, err := parseAxisVector(in.YAxis, "yaxis")
+	if err != nil {
+		return nil, err
+	}
+	o := math.P3(origin[0], origin[1], origin[2])
+	return planes.AddFixed(func() math.Point3 { return o }, x, y), nil
+}
+
+// toWorkRefs converts the request's reference strings to model work references.
+func toWorkRefs(refs []string) []feature.WorkRef {
+	out := make([]feature.WorkRef, len(refs))
+	for i, r := range refs {
+		out[i] = feature.WorkRef(r)
+	}
+	return out
+}
+
+// modelLength parses a unit-bearing distance ("10 mm") into a model value (cm).
+func modelLength(part *compdef.PartComponentDefinition, expr string) (float64, error) {
+	q, err := part.Units().Parse(expr, param.Length)
+	if err != nil {
+		return 0, fmt.Errorf("workPlanes.create: offset %q: %w", expr, err)
+	}
+	return q.Value, nil
+}
+
+// modelAngle parses a unit-bearing angle ("45 deg") into a model value (radians).
+func modelAngle(part *compdef.PartComponentDefinition, expr string) (float64, error) {
+	q, err := part.Units().Parse(expr, param.Angle)
+	if err != nil {
+		return 0, fmt.Errorf("workPlanes.create: angle %q: %w", expr, err)
+	}
+	return q.Value, nil
+}
+
+// parseCoords requires a 3-component coordinate slice, naming what for errors.
+func parseCoords(s []float64, what string) ([]float64, error) {
+	if len(s) != 3 {
+		return nil, fmt.Errorf("workPlanes.create: %s needs 3 components, got %d", what, len(s))
+	}
+	return s, nil
+}
+
+// parseAxisVector requires a 3-component direction and normalizes it to a unit vector.
+func parseAxisVector(s []float64, what string) (math.UnitVector3, error) {
+	if _, err := parseCoords(s, what); err != nil {
+		return math.UnitVector3{}, err
+	}
+	return math.NewUnitVector3(s[0], s[1], s[2])
+}
+
+// point3Slice / vector3Slice render geometry as [x,y,z] for the wire DTOs.
+func point3Slice(p math.Point3) []float64 {
+	return []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+}
+
+func vector3Slice(v math.Vector3) []float64 {
+	return []float64{float64(v.X), float64(v.Y), float64(v.Z)}
+}

--- a/addin/router/work_planes_test.go
+++ b/addin/router/work_planes_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/wire"
+)
+
+func TestWorkPlanesListIncludesOriginFrame(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if len(list.Planes) != 3 {
+		t.Fatalf("fresh part has %d work planes, want 3 origin planes", len(list.Planes))
+	}
+	for _, p := range list.Planes {
+		if !p.IsOrigin || !p.Healthy {
+			t.Errorf("origin plane %q: isOrigin=%v healthy=%v, want both true", p.Name, p.IsOrigin, p.Healthy)
+		}
+	}
+}
+
+func TestWorkPlanesCreateOffsetThenList(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
+	if !res.Healthy {
+		t.Fatalf("offset plane not healthy: %+v", res)
+	}
+	if res.Index != 3 { // after the 3 origin planes
+		t.Errorf("new plane index = %d, want 3", res.Index)
+	}
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if len(list.Planes) != 4 {
+		t.Fatalf("after create, %d planes, want 4", len(list.Planes))
+	}
+	created := list.Planes[3]
+	// "10 mm" is 1.0 cm in model units; the XY plane offset +Z lands at z=1.
+	if created.IsOrigin || len(created.Origin) != 3 || created.Origin[2] != 1 {
+		t.Errorf("created plane = %+v, want a user plane at z=1", created)
+	}
+}
+
+func TestWorkPlanesCreateMidplane(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"two-planes","refs":["origin/plane/xy","origin/plane/xz"]}`, &res)
+	if !res.Healthy {
+		t.Errorf("midplane not healthy: %+v", res)
+	}
+}
+
+func TestWorkPlanesCreateUnknownKind(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPlanes.create", []byte(`{"kind":"no-such-kind"}`)); err == nil {
+		t.Error("expected error for unknown work-plane kind")
+	}
+}
+
+func TestWorkPlanesCreateWrongReferenceCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// three-points needs 3 references; supplying 2 is a bad request.
+	if _, err := r.Handle(s, "workPlanes.create",
+		[]byte(`{"kind":"three-points","refs":["origin/point/center","origin/axis/x"]}`)); err == nil {
+		t.Error("expected error for wrong reference count")
+	}
+}
+
+func TestWorkPlanesCreateBadOffsetExpression(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPlanes.create",
+		[]byte(`{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"ten"}`)); err == nil {
+		t.Error("expected error for an unparseable offset expression")
+	}
+}

--- a/app/browser.go
+++ b/app/browser.go
@@ -18,7 +18,7 @@ import (
 // clicking "XY Plane" selects the plane to sketch on).
 type BrowserNode struct {
 	Label    string
-	Kind     string // "document" | "origin" | "workplane" | "parameters" | "parameter" | "bodies" | "body" | "sketches" | "sketch" | "feature"
+	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketches" | "sketch" | "feature"
 	Select   Selectable
 	Children []BrowserNode
 }
@@ -58,11 +58,14 @@ func addPartBranches(root *BrowserNode, part *compdef.PartComponentDefinition) {
 	for _, wp := range part.OriginPlanes() {
 		origin.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
 	}
+	addOriginAxesAndPoint(origin, part)
 	params := root.child("Parameters", "parameters")
 	for _, p := range part.Parameters().All() {
 		params.child(p.Name(), "parameter")
 	}
 	addBodyBranch(root, part)
+	addUserWorkPlanes(root, part)
+	addUserWorkAxesAndPoints(root, part)
 	sketches := root.child("Sketches", "sketches")
 	for i := 0; i < part.Sketches().Count(); i++ {
 		sk := part.Sketches().Item(i)
@@ -72,6 +75,55 @@ func addPartBranches(root *BrowserNode, part *compdef.PartComponentDefinition) {
 	for i := 0; i < features.Count(); i++ {
 		f := features.Item(i)
 		root.selectableChild(f.Name(), "feature", FeatureHandle{Feature: f})
+	}
+}
+
+// addUserWorkPlanes adds the part's user-created datum planes (offset, midplane, …) as
+// top-level selectable nodes, so a plane made from the ribbon shows in the tree and can
+// be re-picked (to sketch on, or as input to another datum). The origin coordinate-system
+// planes live in the Origin folder, so they are skipped here.
+func addUserWorkPlanes(root *BrowserNode, part *compdef.PartComponentDefinition) {
+	planes := part.WorkPlanes()
+	for i := 0; i < planes.Count(); i++ {
+		if wp := planes.Item(i); !wp.IsCoordinateSystemElement() {
+			root.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
+		}
+	}
+}
+
+// addOriginAxesAndPoint completes the Origin folder with the X/Y/Z axes and the center
+// point (the planes are added by the caller), so the whole origin coordinate frame is
+// selectable — the reference inputs for axis/point-driven work planes (Inventor's Origin
+// folder holds all seven elements).
+func addOriginAxesAndPoint(origin *BrowserNode, part *compdef.PartComponentDefinition) {
+	axes := part.WorkAxes()
+	for i := 0; i < axes.Count(); i++ {
+		if a := axes.Item(i); a.IsCoordinateSystemElement() {
+			origin.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
+		}
+	}
+	points := part.WorkPoints()
+	for i := 0; i < points.Count(); i++ {
+		if p := points.Item(i); p.IsCoordinateSystemElement() {
+			origin.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
+		}
+	}
+}
+
+// addUserWorkAxesAndPoints adds user-created datum axes and points as top-level
+// selectable nodes (the origin ones live in the Origin folder).
+func addUserWorkAxesAndPoints(root *BrowserNode, part *compdef.PartComponentDefinition) {
+	axes := part.WorkAxes()
+	for i := 0; i < axes.Count(); i++ {
+		if a := axes.Item(i); !a.IsCoordinateSystemElement() {
+			root.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
+		}
+	}
+	points := part.WorkPoints()
+	for i := 0; i < points.Count(); i++ {
+		if p := points.Item(i); !p.IsCoordinateSystemElement() {
+			root.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
+		}
 	}
 }
 

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -62,7 +62,7 @@ func featureMenu(sel Selectable) []BrowserMenuItem {
 	}
 }
 
-// workPlaneMenu offers New Sketch on the plane (the model has no plane-visibility flag yet).
+// workPlaneMenu offers New Sketch on the plane and a Visibility toggle.
 func workPlaneMenu(sel Selectable) []BrowserMenuItem {
 	h, ok := sel.(WorkPlaneHandle)
 	if !ok {
@@ -72,6 +72,10 @@ func workPlaneMenu(sel Selectable) []BrowserMenuItem {
 		{Label: "New Sketch", Enabled: true, Invoke: func(s *Session) error {
 			_, err := s.CreateSketch(h.Plane.Plane())
 			return err
+		}},
+		{Label: "Visibility", Enabled: true, Invoke: func(*Session) error {
+			h.Plane.SetVisible(!h.Plane.Visible())
+			return nil
 		}},
 	}
 }

--- a/app/browser_menu_test.go
+++ b/app/browser_menu_test.go
@@ -83,7 +83,7 @@ func TestBrowserMenuByKind(t *testing.T) {
 	if labels := menuLabels(BrowserMenu(findNode(t, root, "feature"))); !equalStrings(labels, []string{"Suppress", "Delete"}) {
 		t.Errorf("feature menu = %v", labels)
 	}
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "workplane"))); !equalStrings(labels, []string{"New Sketch"}) {
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "workplane"))); !equalStrings(labels, []string{"New Sketch", "Visibility"}) {
 		t.Errorf("workplane menu = %v", labels)
 	}
 	if m := BrowserMenu(findNode(t, root, "parameters")); m != nil {

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -23,9 +23,42 @@ func RegisterStandardCommands(s *Session) error {
 func standardCommands() []*CommandDefinition {
 	var cmds []*CommandDefinition
 	cmds = append(cmds, modelTabCommands()...)
+	cmds = append(cmds, workFeatureCommands()...)
 	cmds = append(cmds, sketchTabCommands()...)
 	cmds = append(cmds, viewTabCommands()...)
 	return cmds
+}
+
+// workFeatureCommands are the 3D Model tab's Work Features panel: the datum-plane
+// constructors. Each button is always live in the part environment (Inventor's Work Plane
+// behavior) — click it and, if the right geometry is already selected it builds the datum
+// at once, otherwise it starts a guided pick that prompts for the inputs and commits when
+// they are gathered. So a click is never inert, whether or not anything was pre-selected.
+func workFeatureCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		NewCommand("WorkPlane.Offset", "Offset Plane", "Work Features", func(s *Session) error {
+			s.StartTool(NewOffsetWorkPlaneTool()) // always opens the distance dialog (Inventor's flow)
+			return nil
+		}).WithTab("3D Model").WithEnable(canStartWorkPlane).
+			WithIcon("work-plane-offset").WithButtonStyle(LargeIconButton).
+			WithTooltip("Offset Plane — a work plane parallel to a plane, offset by a distance. Pick a plane, then enter the offset."),
+		NewCommand("WorkPlane.Midplane", "Midplane", "Work Features", startWorkPlane(newMidplaneWorkPlaneTool)).
+			WithTab("3D Model").WithEnable(canStartWorkPlane).
+			WithIcon("work-plane-midplane").WithButtonStyle(SmallIconButton).
+			WithTooltip("Midplane — a work plane bisecting two planes. Pick two planes when prompted."),
+		NewCommand("WorkPlane.ThreePoints", "Three Points", "Work Features", startWorkPlane(newThreePointWorkPlaneTool)).
+			WithTab("3D Model").WithEnable(canStartWorkPlane).
+			WithIcon("work-plane-3pt").WithButtonStyle(SmallIconButton).
+			WithTooltip("Three Points — a work plane through three points or model vertices. Pick three when prompted."),
+		NewCommand("WorkPlane.Tangent", "Tangent to Face", "Work Features", startWorkPlane(newTangentWorkPlaneTool)).
+			WithTab("3D Model").WithEnable(canStartWorkPlane).
+			WithIcon("work-plane-tangent").WithButtonStyle(SmallIconButton).
+			WithTooltip("Tangent to Face — a work plane parallel to a plane and tangent to a cylindrical/spherical face. Pick a plane then a face."),
+		NewCommand("WorkPlane.NormalToAxis", "Normal to Axis", "Work Features", startWorkPlane(newNormalToAxisWorkPlaneTool)).
+			WithTab("3D Model").WithEnable(canStartWorkPlane).
+			WithIcon("work-plane-normal").WithButtonStyle(SmallIconButton).
+			WithTooltip("Normal to Axis — a work plane through a point, normal to an axis. Pick an axis then a point."),
+	}
 }
 
 // modelTabCommands are the 3D Model tab: starting a sketch and the solid features.

--- a/app/offset_plane_session.go
+++ b/app/offset_plane_session.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "github.com/Oblikovati/oblikovati/model/param"
+
+// Session bridge for the Offset Plane tool's UI: the head reads/sets the offset in the
+// document's display unit (e.g. mm) without touching database units or the tool's
+// internals — the same shape as the Extrude bridge.
+
+// ActiveOffsetPlane returns the running Offset Plane tool, or nil when the active tool is
+// not an offset-plane (or there is none).
+func (s *Session) ActiveOffsetPlane() *OffsetWorkPlaneTool {
+	if s.tool == nil {
+		return nil
+	}
+	t, _ := s.tool.tool.(*OffsetWorkPlaneTool)
+	return t
+}
+
+// OffsetDistanceDisplay returns the active offset tool's distance in the document's length
+// unit (the value the input field shows), or 0 when no offset tool is active.
+func (s *Session) OffsetDistanceDisplay() float64 {
+	t := s.ActiveOffsetPlane()
+	if t == nil {
+		return 0
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(t.Distance(), param.Length))
+}
+
+// SetOffsetDistanceDisplay sets the active offset tool's distance from a value given in the
+// document's length unit (e.g. 25 mm), converting to database units. A no-op when no offset
+// tool is active.
+func (s *Session) SetOffsetDistanceDisplay(value float64) {
+	if t := s.ActiveOffsetPlane(); t != nil {
+		t.SetDistance(s.DocumentUnits().FromPreferred(value, param.Length).Value)
+	}
+}

--- a/app/offset_plane_tool.go
+++ b/app/offset_plane_tool.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// OffsetWorkPlaneTool is Inventor's Plane-and-Offset work-plane interaction: pick the
+// plane (or planar face) to offset from, then type the offset distance and OK. Unlike the
+// no-value datum tools it does NOT auto-commit on the pick — an offset with no distance is
+// meaningless, so the tool gathers the value first (the fix for Offset dropping a plane at
+// a fixed distance without asking). The distance is held in model (database) units; the
+// session bridge converts to/from the document's display unit for the dialog field.
+type OffsetWorkPlaneTool struct {
+	base     *feature.WorkPlane
+	distance float64 // offset in model units; 0 until the user sets it (so OK stays disabled)
+	added    *feature.WorkPlane
+	prev     *SelectionFilter
+}
+
+// NewOffsetWorkPlaneTool returns an offset-plane tool awaiting a plane pick and distance.
+func NewOffsetWorkPlaneTool() *OffsetWorkPlaneTool { return &OffsetWorkPlaneTool{} }
+
+// Name implements [Tool].
+func (t *OffsetWorkPlaneTool) Name() string { return "Offset Plane" }
+
+// Start filters selection to work planes and seeds the base from a pre-selected plane (so
+// a user who picked a plane first only needs to enter the distance).
+func (t *OffsetWorkPlaneTool) Start(s *Session) {
+	t.prev = s.Selection().Filter()
+	t.base = s.SelectedWorkPlane()
+	s.Selection().Clear()
+	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+}
+
+// Pick records the plane to offset from.
+func (t *OffsetWorkPlaneTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(WorkPlaneHandle); ok {
+		t.base = h.Plane
+	}
+}
+
+// SetDistance / Distance hold the offset in model units (set from the dialog field via the
+// session bridge, which converts the displayed value from the document's length unit).
+func (t *OffsetWorkPlaneTool) SetDistance(d float64) { t.distance = d }
+func (t *OffsetWorkPlaneTool) Distance() float64     { return t.distance }
+
+// BasePicked reports whether the plane to offset from has been chosen, so the dialog knows
+// to prompt for the pick vs. the distance.
+func (t *OffsetWorkPlaneTool) BasePicked() bool { return t.base != nil }
+
+// CanCommit requires a base plane and a non-zero offset (so OK stays disabled until both
+// are gathered — the tool never silently creates a plane).
+func (t *OffsetWorkPlaneTool) CanCommit() bool { return t.base != nil && t.distance != 0 }
+
+// Commit creates the offset work plane at the entered distance and recomputes.
+func (t *OffsetWorkPlaneTool) Commit(s *Session) error {
+	s.Selection().SetFilter(t.prev)
+	if t.base == nil {
+		return errors.New("offset plane: no base plane picked")
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	d := t.distance
+	t.added = finishWorkPlane(part, part.WorkPlanes().AddByPlaneAndOffset(t.base.Key(), func() float64 { return d }))
+	return nil
+}
+
+// Cancel restores the prior selection filter with no change.
+func (t *OffsetWorkPlaneTool) Cancel(s *Session) { s.Selection().SetFilter(t.prev) }
+
+// Prompt guides the user through the two steps (Inventor's status-bar prompts).
+func (t *OffsetWorkPlaneTool) Prompt(*Session) string {
+	if t.base == nil {
+		return "Select a plane or planar face to offset from"
+	}
+	return "Enter the offset distance, then click OK"
+}
+
+// AddedPlane returns the plane created on commit (for inspection/tests).
+func (t *OffsetWorkPlaneTool) AddedPlane() *feature.WorkPlane { return t.added }

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -22,8 +22,14 @@ type RayPicker struct {
 	camera   scene.Camera
 	bodies   func() []*topo.Body
 	planes   func() []*feature.WorkPlane
+	points   func() []*feature.WorkPoint
+	axes     func() []*feature.WorkAxis
 	sketches func() []*sketch.Sketch
 }
+
+// pickPixelRadius is how close (in pixels) the cursor must be to a datum point or axis to
+// snap it — small explicit targets are picked by screen proximity, not by depth.
+const pickPixelRadius = 8.0
 
 // NewRayPicker builds a picker over a camera and a provider of the current scene
 // bodies (e.g. the active part's SurfaceBodies).
@@ -45,6 +51,18 @@ func (p *RayPicker) WithSketches(sketches func() []*sketch.Sketch) *RayPicker {
 	return p
 }
 
+// WithPoints / WithAxes add providers of the part's datum points and axes, so a click on
+// one snaps to it (the reference inputs for point/axis-driven work planes).
+func (p *RayPicker) WithPoints(points func() []*feature.WorkPoint) *RayPicker {
+	p.points = points
+	return p
+}
+
+func (p *RayPicker) WithAxes(axes func() []*feature.WorkAxis) *RayPicker {
+	p.axes = axes
+	return p
+}
+
 // SetCamera updates the view used for picking.
 func (p *RayPicker) SetCamera(c scene.Camera) { p.camera = c }
 
@@ -55,6 +73,14 @@ func (p *RayPicker) SetCamera(c scene.Camera) { p.camera = c }
 // profiles (the append order), so a solid in front wins over the sketch on its face.
 func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, bool) {
 	origin, dir := p.camera.RayThrough(x, y)
+	// Precise datum snaps win first: a point, then an axis, the cursor lands on is the
+	// target the user is aiming at, even with a face behind it (Inventor's snap order).
+	if pt, _ := p.nearestPoint(origin, dir); pt != nil && filter.Accepts(SelectWorkPoint) {
+		return WorkPointHandle{Point: pt}, true
+	}
+	if ax, _ := p.nearestAxis(origin, dir); ax != nil && filter.Accepts(SelectWorkAxis) {
+		return WorkAxisHandle{Axis: ax}, true
+	}
 	var cands []pickCandidate
 	if face, body, t := p.nearestFace(origin, dir); face != nil {
 		if sel, ok := facePick(face, body, filter); ok {
@@ -182,6 +208,66 @@ func facePick(face *topo.Face, body *topo.Body, filter *SelectionFilter) (Select
 	default:
 		return nil, false
 	}
+}
+
+// nearestPoint returns the closest datum point within the pixel-snap radius of the ray,
+// and the forward ray parameter (or nil/Inf if none).
+func (p *RayPicker) nearestPoint(origin math.Point3, dir math.Vector3) (*feature.WorkPoint, float64) {
+	if p.points == nil {
+		return nil, stdmath.Inf(1)
+	}
+	tol := pickPixelRadius * p.camera.WorldPerPixel()
+	var hit *feature.WorkPoint
+	best := stdmath.Inf(1)
+	for _, wp := range p.points() {
+		t := origin.VectorTo(wp.Point()).Dot(dir)
+		if t <= 0 || t >= best {
+			continue
+		}
+		if origin.TranslateBy(dir.Scale(t)).DistanceTo(wp.Point()) <= tol {
+			best, hit = t, wp
+		}
+	}
+	return hit, best
+}
+
+// nearestAxis returns the closest datum axis within the pixel-snap radius of the ray, and
+// the forward ray parameter at the closest approach (or nil/Inf if none).
+func (p *RayPicker) nearestAxis(origin math.Point3, dir math.Vector3) (*feature.WorkAxis, float64) {
+	if p.axes == nil {
+		return nil, stdmath.Inf(1)
+	}
+	tol := pickPixelRadius * p.camera.WorldPerPixel()
+	var hit *feature.WorkAxis
+	best := stdmath.Inf(1)
+	for _, ax := range p.axes() {
+		if t, d, ok := rayAxisDistance(origin, dir, ax); ok && t < best && d <= tol {
+			best, hit = t, ax
+		}
+	}
+	return hit, best
+}
+
+// rayAxisDistance returns the forward ray parameter and world distance at the closest
+// approach between the camera ray (origin, unit dir) and an infinite work axis. ok is
+// false when the ray is parallel to the axis or the closest approach is behind the camera.
+func rayAxisDistance(origin math.Point3, dir math.Vector3, ax *feature.WorkAxis) (float64, float64, bool) {
+	u := ax.Direction().AsVector()
+	w0 := ax.Origin().VectorTo(origin) // O − A
+	b := dir.Dot(u)
+	denom := 1 - b*b
+	if math.IsNearZero(denom, math.DefaultTolerance) {
+		return 0, 0, false
+	}
+	d, e := dir.Dot(w0), u.Dot(w0)
+	sc := (b*e - d) / denom // ray parameter at closest approach
+	if sc <= 0 {
+		return 0, 0, false
+	}
+	tc := (e - b*d) / denom // axis parameter at closest approach
+	rayPoint := origin.TranslateBy(dir.Scale(sc))
+	axisPoint := ax.Origin().TranslateBy(u.Scale(tc))
+	return sc, rayPoint.DistanceTo(axisPoint), true
 }
 
 // rayWorkPlane intersects a ray with a work plane and reports the forward parameter

--- a/app/selection.go
+++ b/app/selection.go
@@ -22,6 +22,8 @@ const (
 	SelectSketchEntity
 	SelectWorkPlane
 	SelectSketch
+	SelectWorkPoint
+	SelectWorkAxis
 )
 
 // Selectable is anything the selection set can hold. Concrete handles wrap the
@@ -76,6 +78,17 @@ func (SketchHandle) SelectionKind() SelectionKind { return SelectSketch }
 type WorkPlaneHandle struct{ Plane *feature.WorkPlane }
 
 func (WorkPlaneHandle) SelectionKind() SelectionKind { return SelectWorkPlane }
+
+// WorkPointHandle / WorkAxisHandle wrap a picked datum point / axis — the reference
+// inputs for the work-plane constructors that build on points or lines (three points,
+// normal to a curve, two lines).
+type (
+	WorkPointHandle struct{ Point *feature.WorkPoint }
+	WorkAxisHandle  struct{ Axis *feature.WorkAxis }
+)
+
+func (WorkPointHandle) SelectionKind() SelectionKind { return SelectWorkPoint }
+func (WorkAxisHandle) SelectionKind() SelectionKind  { return SelectWorkAxis }
 
 // SelectionFilter restricts which selection kinds a pick accepts — Inventor's
 // SelectionFilterEnum. A zero filter (no kinds) accepts everything.
@@ -145,4 +158,34 @@ func (s *Selection) First() Selectable {
 		return nil
 	}
 	return s.items[0]
+}
+
+// References returns, parallel to Items, the work-feature reference for each selected
+// entity — a datum plane/axis/point key, or a face/vertex reference — the string an
+// automation client passes to a work-plane constructor. Entities with no such reference
+// (a body, a sketch entity) yield an empty string, so the slice stays index-aligned.
+func (s *Selection) References() []string {
+	refs := make([]string, len(s.items))
+	for i, it := range s.items {
+		refs[i] = string(selectionRef(it))
+	}
+	return refs
+}
+
+// selectionRef maps a selectable to its work-feature reference (empty when it has none).
+func selectionRef(it Selectable) feature.WorkRef {
+	switch h := it.(type) {
+	case WorkPlaneHandle:
+		return h.Plane.Key()
+	case WorkAxisHandle:
+		return h.Axis.Key()
+	case WorkPointHandle:
+		return h.Point.Key()
+	case FaceHandle:
+		return feature.FaceRef(h.Face.ReferenceKey())
+	case VertexHandle:
+		return feature.VertexRef(h.Vertex.ReferenceKey())
+	default:
+		return ""
+	}
 }

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -183,6 +183,12 @@ func (s *Session) PressKey(e KeyEvent) error {
 			return s.OK()
 		}
 		return nil
+	case "v", "V":
+		// Toggle visibility of the selected work plane(s) (Autodesk Fusion's V binding;
+		// Inventor has no default visibility hotkey). No-op when nothing applicable is
+		// selected, so V stays free for other contexts.
+		s.ToggleSelectedWorkPlaneVisibility()
+		return nil
 	default:
 		if _, ok := s.commands.ByAlias(e.Key); ok {
 			return s.Invoke(e.Key)

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// Work-plane creation from the 3D Model ribbon's Work Features panel. These mirror the
+// Sketch.Create2D flow: read the current selection, add the datum to the active part's
+// work geometry, and recompute so the browser and 3D view show it. The selection-driven
+// constructors (midplane, three points, tangent, normal-to-axis) build directly from the
+// picked entities; the Offset constructor needs a distance value, so it has its own tool
+// with a dialog ([OffsetWorkPlaneTool]) rather than a one-shot creation method here.
+
+// SelectedWorkPlanes returns every selected work plane, in selection order — the inputs
+// for the multi-plane constructors (e.g. a midplane between two planes).
+func (s *Session) SelectedWorkPlanes() []*feature.WorkPlane {
+	var planes []*feature.WorkPlane
+	for _, it := range s.selection.Items() {
+		if h, ok := it.(WorkPlaneHandle); ok {
+			planes = append(planes, h.Plane)
+		}
+	}
+	return planes
+}
+
+// CreateMidplaneWorkPlane adds a work plane bisecting the two selected planes, then
+// recomputes. It errors when fewer than two work planes are selected.
+func (s *Session) CreateMidplaneWorkPlane() (*feature.WorkPlane, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	planes := s.SelectedWorkPlanes()
+	if len(planes) < 2 {
+		return nil, errors.New("app: select two work planes to make a midplane between them")
+	}
+	wp := part.WorkPlanes().AddByTwoPlanes(planes[0].Key(), planes[1].Key())
+	return finishWorkPlane(part, wp), nil
+}
+
+// uniqueWorkPlaneName returns "Work Plane{n}" with the smallest n not already used by a
+// work plane, so browser nodes carry distinct labels (Dear ImGui derives a node id from
+// the label and asserts on duplicates — see PartFeatures.UniqueName).
+func uniqueWorkPlaneName(planes *feature.WorkPlanes) string {
+	taken := make(map[string]bool, planes.Count())
+	for i := 0; i < planes.Count(); i++ {
+		taken[planes.Item(i).Name()] = true
+	}
+	for n := 1; ; n++ {
+		if name := "Work Plane" + strconv.Itoa(n); !taken[name] {
+			return name
+		}
+	}
+}
+
+// canMidplaneWorkPlane enables the Midplane command: two work planes are selected.
+func canMidplaneWorkPlane(s *Session) bool {
+	return !s.InSketch() && len(s.SelectedWorkPlanes()) >= 2
+}
+
+// ToggleSelectedWorkPlaneVisibility flips the Visible flag of every selected work plane —
+// the action behind the browser's Visibility menu item and the V keyboard shortcut. The
+// viewport rebuilds from live state each frame, so the change shows immediately with no
+// recompute (visibility is display-only).
+func (s *Session) ToggleSelectedWorkPlaneVisibility() {
+	for _, wp := range s.SelectedWorkPlanes() {
+		wp.SetVisible(!wp.Visible())
+	}
+}
+
+// SelectedWorkAxes returns every selected datum axis, in selection order.
+func (s *Session) SelectedWorkAxes() []*feature.WorkAxis {
+	var axes []*feature.WorkAxis
+	for _, it := range s.selection.Items() {
+		if h, ok := it.(WorkAxisHandle); ok {
+			axes = append(axes, h.Axis)
+		}
+	}
+	return axes
+}
+
+// SelectedFace returns the first selected B-rep face, or false.
+func (s *Session) SelectedFace() (*topo.Face, bool) {
+	for _, it := range s.selection.Items() {
+		if h, ok := it.(FaceHandle); ok {
+			return h.Face, true
+		}
+	}
+	return nil, false
+}
+
+// selectedPointRefs gathers point references from the selection — datum points by their
+// key and B-rep vertices by a vertex reference — the point inputs the three-point and
+// normal-to-axis constructors accept.
+func (s *Session) selectedPointRefs() []feature.WorkRef {
+	var refs []feature.WorkRef
+	for _, it := range s.selection.Items() {
+		switch h := it.(type) {
+		case WorkPointHandle:
+			refs = append(refs, h.Point.Key())
+		case VertexHandle:
+			refs = append(refs, feature.VertexRef(h.Vertex.ReferenceKey()))
+		}
+	}
+	return refs
+}
+
+// CreateThreePointWorkPlane adds a work plane through the first three selected points
+// (datum points or model vertices), then recomputes.
+func (s *Session) CreateThreePointWorkPlane() (*feature.WorkPlane, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	refs := s.selectedPointRefs()
+	if len(refs) < 3 {
+		return nil, errors.New("app: select three points (datum points or model vertices) for a three-point plane")
+	}
+	return finishWorkPlane(part, part.WorkPlanes().AddByThreePoints(refs[0], refs[1], refs[2])), nil
+}
+
+// CreateNormalToAxisWorkPlane adds a work plane through the selected point, normal to the
+// selected axis, then recomputes.
+func (s *Session) CreateNormalToAxisWorkPlane() (*feature.WorkPlane, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	axes, refs := s.SelectedWorkAxes(), s.selectedPointRefs()
+	if len(axes) < 1 || len(refs) < 1 {
+		return nil, errors.New("app: select an axis and a point for a normal-to-axis plane")
+	}
+	return finishWorkPlane(part, part.WorkPlanes().AddByNormalToCurve(axes[0].Key(), refs[0])), nil
+}
+
+// CreateTangentWorkPlane adds a work plane parallel to the selected plane and tangent to
+// the selected face (a cylinder/sphere), then recomputes.
+func (s *Session) CreateTangentWorkPlane() (*feature.WorkPlane, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	base := s.SelectedWorkPlane()
+	face, ok := s.SelectedFace()
+	if base == nil || !ok {
+		return nil, errors.New("app: select a plane and a face for a tangent plane")
+	}
+	wp := part.WorkPlanes().AddByPlaneAndTangent(base.Key(), feature.FaceRef(face.ReferenceKey()))
+	return finishWorkPlane(part, wp), nil
+}
+
+// finishWorkPlane gives a freshly created datum a unique browser name and recomputes the
+// part, the shared tail of every Create*WorkPlane action.
+func finishWorkPlane(part partWorkPlanes, wp *feature.WorkPlane) *feature.WorkPlane {
+	wp.SetName(uniqueWorkPlaneName(part.WorkPlanes()))
+	part.Recompute()
+	return wp
+}
+
+// partWorkPlanes is the slice of the active part finishWorkPlane needs (its datum-plane
+// collection and recompute), kept small so the helper does not depend on the whole part.
+type partWorkPlanes interface {
+	WorkPlanes() *feature.WorkPlanes
+	Recompute()
+}
+
+// canThreePointWorkPlane enables Three Points: three point references are selected.
+func canThreePointWorkPlane(s *Session) bool {
+	return !s.InSketch() && len(s.selectedPointRefs()) >= 3
+}
+
+// canNormalToAxisWorkPlane enables Normal to Axis: an axis and a point are selected.
+func canNormalToAxisWorkPlane(s *Session) bool {
+	return !s.InSketch() && len(s.SelectedWorkAxes()) >= 1 && len(s.selectedPointRefs()) >= 1
+}
+
+// canTangentWorkPlane enables Tangent to Face: a plane and a face are selected.
+func canTangentWorkPlane(s *Session) bool {
+	if s.InSketch() {
+		return false
+	}
+	_, hasFace := s.SelectedFace()
+	return hasFace && s.SelectedWorkPlane() != nil
+}

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// selectPlanes adds the given origin/work planes to the session selection.
+func selectPlanes(s *Session, planes ...*feature.WorkPlane) {
+	for _, p := range planes {
+		s.Selection().Add(WorkPlaneHandle{Plane: p})
+	}
+}
+
+// addUserPoint adds a datum point at p to the part and returns it (a selectable input
+// for three-point planes).
+func addUserPoint(def *compdef.PartComponentDefinition, p math.Point3) *feature.WorkPoint {
+	return def.WorkPoints().AddByPosition(func() math.Point3 { return p })
+}
+
+// boxTopFace extrudes a unit box and returns one of its (planar) faces with its body, a
+// FaceHandle input for the Tangent command's wiring.
+func boxTopFace(t *testing.T, def *compdef.PartComponentDefinition) (*topo.Face, *topo.Body) {
+	t.Helper()
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(-1, -1))
+	c1 := sk.Points().Add(math.P2(1, -1))
+	c2 := sk.Points().Add(math.P2(1, 1))
+	c3 := sk.Points().Add(math.P2(-1, 1))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 3 })
+	def.Recompute()
+	body := def.SurfaceBodies().All()[0]
+	return body.Faces()[0], body
+}
+
+func TestOffsetWorkPlaneToolWaitsForDistanceThenCreates(t *testing.T) {
+	s, def := emptyPartSession(t)
+	before := def.WorkPlanes().Count()
+	tool := NewOffsetWorkPlaneTool()
+	s.StartTool(tool)
+	// Pick the base plane: not committable yet — the distance is still unset.
+	tool.Pick(s, WorkPlaneHandle{Plane: def.OriginPlanes()[0]}) // XY plane (normal +Z)
+	if tool.CanCommit() {
+		t.Fatal("offset tool should not be committable before a distance is entered")
+	}
+	// Enter 25 mm via the session bridge (what the dialog field does), then commit.
+	s.SetOffsetDistanceDisplay(25)
+	if !tool.CanCommit() {
+		t.Fatal("offset tool should be committable once base and distance are set")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if def.WorkPlanes().Count() != before+1 {
+		t.Errorf("offset created %d planes, want 1", def.WorkPlanes().Count()-before)
+	}
+	// 25 mm is 2.5 cm in model units; the XY plane offset +Z lands at z=2.5.
+	wp := tool.AddedPlane()
+	if wp == nil || !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 2.5), 1e-9) {
+		t.Errorf("offset plane origin = %v, want (0,0,2.5)", wp.Plane().Origin())
+	}
+}
+
+func TestOffsetWorkPlaneToolNotCommittableWithoutBase(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	tool := NewOffsetWorkPlaneTool()
+	s.StartTool(tool)
+	s.SetOffsetDistanceDisplay(10) // a distance but no plane picked
+	if tool.CanCommit() {
+		t.Error("offset tool should not commit without a base plane")
+	}
+}
+
+func TestCreateMidplaneWorkPlane(t *testing.T) {
+	s, def := emptyPartSession(t)
+	selectPlanes(s, def.OriginPlanes()[0], def.OriginPlanes()[1]) // XY + XZ
+	wp, err := s.CreateMidplaneWorkPlane()
+	if err != nil {
+		t.Fatalf("CreateMidplaneWorkPlane: %v", err)
+	}
+	if !wp.Health().OK() {
+		t.Errorf("midplane sick: %+v", wp.Health())
+	}
+}
+
+func TestCreateMidplaneNeedsTwoPlanes(t *testing.T) {
+	s, def := emptyPartSession(t)
+	selectPlanes(s, def.OriginPlanes()[0]) // only one
+	if _, err := s.CreateMidplaneWorkPlane(); err == nil {
+		t.Error("midplane with one plane selected should error")
+	}
+}
+
+func TestCreatedWorkPlanesAppearInBrowserWithUniqueNames(t *testing.T) {
+	s, def := emptyPartSession(t)
+	for i := 0; i < 2; i++ {
+		s.Selection().Clear()
+		selectPlanes(s, def.OriginPlanes()[0], def.OriginPlanes()[1])
+		if _, err := s.CreateMidplaneWorkPlane(); err != nil {
+			t.Fatalf("CreateMidplaneWorkPlane #%d: %v", i+1, err)
+		}
+	}
+	var labels []string
+	for _, c := range BuildBrowser(s).Children {
+		if c.Kind != "workplane" {
+			continue
+		}
+		if c.Select == nil {
+			t.Errorf("work plane node %q is not selectable", c.Label)
+		}
+		labels = append(labels, c.Label)
+	}
+	if len(labels) != 2 || labels[0] == labels[1] {
+		t.Errorf("browser work plane labels = %v, want two distinct nodes", labels)
+	}
+}
+
+func TestCreateThreePointWorkPlaneFromPoints(t *testing.T) {
+	s, def := emptyPartSession(t)
+	a := addUserPoint(def, math.P3(0, 0, 0))
+	b := addUserPoint(def, math.P3(2, 0, 0))
+	c := addUserPoint(def, math.P3(0, 2, 0))
+	s.Selection().Add(WorkPointHandle{Point: a})
+	s.Selection().Add(WorkPointHandle{Point: b})
+	s.Selection().Add(WorkPointHandle{Point: c})
+	wp, err := s.CreateThreePointWorkPlane()
+	if err != nil {
+		t.Fatalf("CreateThreePointWorkPlane: %v", err)
+	}
+	if !wp.Health().OK() || !wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, 0, 1), 1e-9) {
+		t.Errorf("three-point plane health=%v normal=%v, want healthy +Z", wp.Health(), wp.Plane().Normal())
+	}
+}
+
+func TestCreateThreePointNeedsThreePoints(t *testing.T) {
+	s, def := emptyPartSession(t)
+	s.Selection().Add(WorkPointHandle{Point: addUserPoint(def, math.P3(0, 0, 0))})
+	if _, err := s.CreateThreePointWorkPlane(); err == nil {
+		t.Error("three-point with one point should error")
+	}
+}
+
+func TestCreateNormalToAxisWorkPlane(t *testing.T) {
+	s, def := emptyPartSession(t)
+	// Origin X axis (axis 0) + origin center point (point 0): a plane through the origin,
+	// normal to X (a YZ-oriented plane).
+	s.Selection().Add(WorkAxisHandle{Axis: def.WorkAxes().Item(0)})
+	s.Selection().Add(WorkPointHandle{Point: def.WorkPoints().Item(0)})
+	wp, err := s.CreateNormalToAxisWorkPlane()
+	if err != nil {
+		t.Fatalf("CreateNormalToAxisWorkPlane: %v", err)
+	}
+	if !wp.Health().OK() || !wp.Plane().Normal().AsVector().IsParallelTo(math.V3(1, 0, 0), 1e-9) {
+		t.Errorf("normal-to-axis plane health=%v normal=%v, want healthy +X", wp.Health(), wp.Plane().Normal())
+	}
+}
+
+func TestCreateTangentWorkPlaneWiring(t *testing.T) {
+	s, def := emptyPartSession(t)
+	face, body := boxTopFace(t, def)
+	before := def.WorkPlanes().Count()
+	selectPlanes(s, def.OriginPlanes()[0])
+	s.Selection().Add(FaceHandle{Face: face, Body: body})
+	if _, err := s.CreateTangentWorkPlane(); err != nil {
+		t.Fatalf("CreateTangentWorkPlane: %v", err)
+	}
+	if def.WorkPlanes().Count() != before+1 {
+		t.Errorf("tangent command added %d planes, want 1", def.WorkPlanes().Count()-before)
+	}
+}
+
+func TestOffsetWorkPlaneButtonOpensDistanceDialogNotInstantCreate(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	before := def.WorkPlanes().Count()
+	if err := s.Execute("WorkPlane.Offset"); err != nil {
+		t.Fatalf("execute Offset: %v", err)
+	}
+	// The button must NOT drop a plane immediately — it opens the offset tool/dialog.
+	if s.ActiveOffsetPlane() == nil {
+		t.Fatal("Offset should start the offset-plane tool")
+	}
+	if def.WorkPlanes().Count() != before {
+		t.Error("Offset created a plane without asking for a distance")
+	}
+	// Pick a plane and a distance in the dialog, then OK.
+	origin := originFolder(BuildBrowser(s))
+	s.SelectBrowserNode(origin.Children[0]) // XY Plane → fed to the tool as the base
+	if def.WorkPlanes().Count() != before {
+		t.Error("picking the base plane should not yet create the plane (distance pending)")
+	}
+	s.SetOffsetDistanceDisplay(15)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if def.WorkPlanes().Count() != before+1 {
+		t.Errorf("offset created %d planes after OK, want 1", def.WorkPlanes().Count()-before)
+	}
+}
+
+func TestOffsetWorkPlaneButtonSeedsPreselectedPlane(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	selectPlanes(s, def.OriginPlanes()[0])
+	if err := s.Execute("WorkPlane.Offset"); err != nil {
+		t.Fatalf("execute Offset: %v", err)
+	}
+	tool := s.ActiveOffsetPlane()
+	if tool == nil || !tool.BasePicked() {
+		t.Fatal("a pre-selected plane should seed the offset tool's base, leaving only the distance")
+	}
+}
+
+func TestMidplaneToolCommitsAfterTwoPicks(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	before := def.WorkPlanes().Count()
+	if err := s.Execute("WorkPlane.Midplane"); err != nil {
+		t.Fatalf("execute Midplane: %v", err)
+	}
+	origin := originFolder(BuildBrowser(s))
+	s.SelectBrowserNode(origin.Children[0]) // XY plane — not enough yet
+	if s.ActiveTool() == nil {
+		t.Fatal("Midplane tool should stay open after one plane")
+	}
+	s.SelectBrowserNode(origin.Children[1]) // XZ plane — now commit
+	if s.ActiveTool() != nil {
+		t.Error("Midplane tool should auto-commit after the second plane")
+	}
+	if def.WorkPlanes().Count() != before+1 {
+		t.Errorf("midplane tool created %d planes, want 1", def.WorkPlanes().Count()-before)
+	}
+}
+
+func TestToggleWorkPlaneVisibilitySessionAndKeyboard(t *testing.T) {
+	s, def := emptyPartSession(t)
+	xy := def.OriginPlanes()[0]
+	selectPlanes(s, xy)
+	if !xy.Visible() {
+		t.Fatal("plane should start visible")
+	}
+	// The session method toggles every selected plane.
+	s.ToggleSelectedWorkPlaneVisibility()
+	if xy.Visible() {
+		t.Error("ToggleSelectedWorkPlaneVisibility should hide the selected plane")
+	}
+	// The V keyboard shortcut toggles it back.
+	if err := s.PressKey(KeyEvent{Key: "V"}); err != nil {
+		t.Fatalf("PressKey V: %v", err)
+	}
+	if !xy.Visible() {
+		t.Error("V should toggle the selected plane's visibility back on")
+	}
+}
+
+func TestWorkPlaneBrowserVisibilityMenuToggles(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	node := originFolder(BuildBrowser(s)).Children[0] // XY plane node
+	wp := node.Select.(WorkPlaneHandle).Plane
+	menu := BrowserMenu(node)
+	var vis BrowserMenuItem
+	for _, m := range menu {
+		if m.Label == "Visibility" {
+			vis = m
+		}
+	}
+	if vis.Invoke == nil {
+		t.Fatal("workplane menu has no Visibility item")
+	}
+	before := wp.Visible()
+	if err := vis.Invoke(s); err != nil {
+		t.Fatalf("invoke Visibility: %v", err)
+	}
+	if wp.Visible() == before {
+		t.Error("Visibility menu item should toggle the plane's visibility")
+	}
+}
+
+func TestWorkPlaneButtonsDisabledInSketch(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if _, err := s.CreateSketchOnOrigin(OriginXY); err != nil {
+		t.Fatalf("enter sketch: %v", err)
+	}
+	if c, _ := s.Commands().ByID("WorkPlane.Offset"); c.IsEnabled(s) {
+		t.Error("Work Plane buttons should be disabled inside the sketch environment")
+	}
+}
+
+func TestPickerSnapsToWorkPoint(t *testing.T) {
+	s, def := emptyPartSession(t)
+	p := NewRayPicker(s.Camera(), func() []*topo.Body { return def.SurfaceBodies().All() }).
+		WithPoints(func() []*feature.WorkPoint { return []*feature.WorkPoint{def.WorkPoints().Item(0)} })
+	sel, ok := p.Pick(100, 100, NewSelectionFilter()) // center pixel maps to the origin center
+	if !ok {
+		t.Fatal("center pick hit nothing, expected the origin point")
+	}
+	if _, isPoint := sel.(WorkPointHandle); !isPoint {
+		t.Errorf("center pick = %T, want WorkPointHandle", sel)
+	}
+}
+
+func TestPickerSnapsToWorkAxis(t *testing.T) {
+	s, def := emptyPartSession(t)
+	p := NewRayPicker(s.Camera(), func() []*topo.Body { return def.SurfaceBodies().All() }).
+		WithAxes(func() []*feature.WorkAxis { return []*feature.WorkAxis{def.WorkAxes().Item(0)} })
+	sel, ok := p.Pick(100, 100, NewSelectionFilter(SelectWorkAxis)) // X axis passes through the origin
+	if !ok {
+		t.Fatal("center pick missed the origin axis")
+	}
+	if _, isAxis := sel.(WorkAxisHandle); !isAxis {
+		t.Errorf("center pick = %T, want WorkAxisHandle", sel)
+	}
+}
+
+func TestWorkFeatureRibbonCommandsRegistered(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	for _, id := range []string{
+		"WorkPlane.Offset", "WorkPlane.Midplane",
+		"WorkPlane.ThreePoints", "WorkPlane.Tangent", "WorkPlane.NormalToAxis",
+	} {
+		c, ok := s.Commands().ByID(id)
+		if !ok {
+			t.Fatalf("command %q not registered", id)
+		}
+		if c.Tab() != "3D Model" || c.Category() != "Work Features" {
+			t.Errorf("%q is on tab %q/panel %q, want 3D Model/Work Features", id, c.Tab(), c.Category())
+		}
+	}
+	// Every Work Features button is always live in the part environment (it guides the
+	// pick when nothing is selected), so none is greyed out.
+	for _, id := range []string{
+		"WorkPlane.Offset", "WorkPlane.Midplane",
+		"WorkPlane.ThreePoints", "WorkPlane.Tangent", "WorkPlane.NormalToAxis",
+	} {
+		if c, _ := s.Commands().ByID(id); !c.IsEnabled(s) {
+			t.Errorf("%q should be enabled in the part environment", id)
+		}
+	}
+}

--- a/app/work_plane_tool.go
+++ b/app/work_plane_tool.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "github.com/Oblikovati/oblikovati/model/feature"
+
+// WorkPlaneTool is the guided-pick interaction behind every Work Features ribbon button:
+// activated with nothing pre-selected, it restricts the selection filter to the kinds the
+// constructor needs, prompts the user, collects picks (in the 3D view or browser) into the
+// selection, and auto-commits the moment enough are gathered — mirroring Create 2D Sketch.
+// It reuses the Session's Create*WorkPlane methods (which read the selection) for the
+// commit, so the interactive and pre-selected paths build the datum the same way.
+type WorkPlaneTool struct {
+	name   string
+	prompt string
+	filter *SelectionFilter
+	ready  func(*Session) bool                        // enough picked to build?
+	create func(*Session) (*feature.WorkPlane, error) // build from the current selection
+	prev   *SelectionFilter
+	sess   *Session
+}
+
+// Name implements [Tool].
+func (t *WorkPlaneTool) Name() string { return t.name }
+
+// Start restricts selection to the tool's kinds and clears any prior picks so the tool
+// gathers a fresh set.
+func (t *WorkPlaneTool) Start(s *Session) {
+	t.sess = s
+	t.prev = s.Selection().Filter()
+	s.Selection().Clear()
+	s.Selection().SetFilter(t.filter)
+}
+
+// Pick adds the clicked entity to the selection (the constructor reads it on commit).
+func (t *WorkPlaneTool) Pick(s *Session, sel Selectable) { s.Selection().Add(sel) }
+
+// CanCommit is true once the selection satisfies the constructor.
+func (t *WorkPlaneTool) CanCommit() bool { return t.sess != nil && t.ready(t.sess) }
+
+// AutoCommitOnPick finishes the tool as soon as the last needed pick lands.
+func (t *WorkPlaneTool) AutoCommitOnPick() bool { return true }
+
+// Commit restores the prior filter and builds the datum from the gathered picks.
+func (t *WorkPlaneTool) Commit(s *Session) error {
+	s.Selection().SetFilter(t.prev)
+	_, err := t.create(s)
+	return err
+}
+
+// Cancel restores the prior filter with no change.
+func (t *WorkPlaneTool) Cancel(s *Session) { s.Selection().SetFilter(t.prev) }
+
+// Prompt is the status-bar guidance shown while the tool gathers its picks.
+func (t *WorkPlaneTool) Prompt(*Session) string { return t.prompt }
+
+func newMidplaneWorkPlaneTool() *WorkPlaneTool {
+	return &WorkPlaneTool{
+		name: "Midplane", prompt: "Select two planes to bisect",
+		filter: NewSelectionFilter(SelectWorkPlane),
+		ready:  canMidplaneWorkPlane, create: (*Session).CreateMidplaneWorkPlane,
+	}
+}
+
+func newThreePointWorkPlaneTool() *WorkPlaneTool {
+	return &WorkPlaneTool{
+		name: "Three Points", prompt: "Select three points or model vertices",
+		filter: NewSelectionFilter(SelectWorkPoint, SelectVertex),
+		ready:  canThreePointWorkPlane, create: (*Session).CreateThreePointWorkPlane,
+	}
+}
+
+func newTangentWorkPlaneTool() *WorkPlaneTool {
+	return &WorkPlaneTool{
+		name: "Tangent to Face", prompt: "Select a plane, then a cylindrical/spherical face",
+		filter: NewSelectionFilter(SelectWorkPlane, SelectFace),
+		ready:  canTangentWorkPlane, create: (*Session).CreateTangentWorkPlane,
+	}
+}
+
+func newNormalToAxisWorkPlaneTool() *WorkPlaneTool {
+	return &WorkPlaneTool{
+		name: "Normal to Axis", prompt: "Select an axis, then a point on it",
+		filter: NewSelectionFilter(SelectWorkAxis, SelectWorkPoint, SelectVertex),
+		ready:  canNormalToAxisWorkPlane, create: (*Session).CreateNormalToAxisWorkPlane,
+	}
+}
+
+// startWorkPlane is a Work Features command action: build the datum immediately when the
+// current selection already satisfies the constructor, otherwise start the guided tool so
+// the click always does something (the fix for an inert, pre-selection-gated button).
+func startWorkPlane(makeTool func() *WorkPlaneTool) func(*Session) error {
+	return func(s *Session) error {
+		t := makeTool()
+		if t.ready(s) {
+			_, err := t.create(s)
+			return err
+		}
+		s.StartTool(t)
+		return nil
+	}
+}
+
+// canStartWorkPlane enables the Work Features buttons whenever a part is active and no
+// sketch is open — the buttons are always live (like Create 2D Sketch) and guide the pick
+// when nothing is pre-selected, rather than greying out.
+func canStartWorkPlane(s *Session) bool {
+	if s.InSketch() {
+		return false
+	}
+	_, err := activePart(s)
+	return err == nil
+}

--- a/app/workplane_test.go
+++ b/app/workplane_test.go
@@ -121,13 +121,19 @@ func TestBrowserHasOriginFolderWithSelectablePlanes(t *testing.T) {
 	if origin == nil {
 		t.Fatal("browser has no Origin folder")
 	}
-	if len(origin.Children) != 3 {
-		t.Fatalf("Origin folder has %d planes, want 3", len(origin.Children))
+	// The Origin folder holds the full coordinate frame: 3 planes, 3 axes, 1 center point.
+	if len(origin.Children) != 7 {
+		t.Fatalf("Origin folder has %d elements, want 7 (3 planes, 3 axes, 1 point)", len(origin.Children))
 	}
+	kinds := map[string]int{}
 	for _, n := range origin.Children {
 		if n.Select == nil {
-			t.Errorf("origin plane node %q is not selectable", n.Label)
+			t.Errorf("origin node %q is not selectable", n.Label)
 		}
+		kinds[n.Kind]++
+	}
+	if kinds["workplane"] != 3 || kinds["workaxis"] != 3 || kinds["workpoint"] != 1 {
+		t.Errorf("Origin folder kinds = %v, want 3 planes / 3 axes / 1 point", kinds)
 	}
 }
 

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -129,6 +129,8 @@ func seedPart(s *app.Session) {
 	s.SetPicker(app.NewRayPicker(s.Camera(),
 		func() []*topo.Body { return activeBodies(s) }).
 		WithPlanes(func() []*feature.WorkPlane { return activeOriginPlanes(s) }).
+		WithPoints(func() []*feature.WorkPoint { return activeWorkPoints(s) }).
+		WithAxes(func() []*feature.WorkAxis { return activeWorkAxes(s) }).
 		WithSketches(func() []*sketch.Sketch { return activeSketches(s) }))
 
 	// Frame the box (centered ~(2,1.5,2.5)) from a three-quarter view.
@@ -155,6 +157,34 @@ func activeOriginPlanes(s *app.Session) []*feature.WorkPlane {
 		return p.OriginPlanes()
 	}
 	return nil
+}
+
+// activeWorkPoints / activeWorkAxes return the active part's datum points/axes (origin
+// and user), so the picker can snap a click to them as work-plane reference inputs.
+func activeWorkPoints(s *app.Session) []*feature.WorkPoint {
+	p, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil
+	}
+	points := p.WorkPoints()
+	out := make([]*feature.WorkPoint, 0, points.Count())
+	for i := 0; i < points.Count(); i++ {
+		out = append(out, points.Item(i))
+	}
+	return out
+}
+
+func activeWorkAxes(s *app.Session) []*feature.WorkAxis {
+	p, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil
+	}
+	axes := p.WorkAxes()
+	out := make([]*feature.WorkAxis, 0, axes.Count())
+	for i := 0; i < axes.Count(); i++ {
+		out = append(out, axes.Item(i))
+	}
+	return out
 }
 
 // activeSketches returns the active part's visible sketches (nil if none), so the picker

--- a/head/icon/assets/work-plane-3pt.svg
+++ b/head/icon/assets/work-plane-3pt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16 L13 16 L21 8 L11 8 Z"/><circle cx="6" cy="14" r="1.4" fill="#000" stroke="none"/><circle cx="17" cy="10" r="1.4" fill="#000" stroke="none"/><circle cx="13" cy="15" r="1.4" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/work-plane-midplane.svg
+++ b/head/icon/assets/work-plane-midplane.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6 L11 6 L17 2 L9 2 Z"/><path d="M7 22 L15 22 L21 18 L13 18 Z"/><path d="M5 14 L13 14 L19 10 L11 10 Z" stroke-dasharray="2 2"/></svg>

--- a/head/icon/assets/work-plane-normal.svg
+++ b/head/icon/assets/work-plane-normal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 18 L13 18 L21 12 L11 12 Z"/><path d="M12 15 L12 3 M9 6 L12 3 L15 6"/></svg>

--- a/head/icon/assets/work-plane-offset.svg
+++ b/head/icon/assets/work-plane-offset.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 14 L13 14 L21 8 L11 8 Z"/><path d="M3 19 L13 19 L21 13 L11 13 Z" stroke-dasharray="2 2"/></svg>

--- a/head/icon/assets/work-plane-tangent.svg
+++ b/head/icon/assets/work-plane-tangent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="13" r="6"/><path d="M17 3 L17 21"/></svg>

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -172,6 +172,15 @@ VkPipeline create_pipeline(HeadContext* c, Viewport* v, VkPrimitiveTopology topo
     VkPipelineColorBlendAttachmentState cba{};
     cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    // Standard alpha blending so translucent overlays (work-plane fills) show through.
+    // Opaque geometry has alpha 1, so src*1 + dst*0 = src — solids are unaffected.
+    cba.blendEnable = VK_TRUE;
+    cba.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    cba.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    cba.colorBlendOp = VK_BLEND_OP_ADD;
+    cba.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    cba.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    cba.alphaBlendOp = VK_BLEND_OP_ADD;
     VkPipelineColorBlendStateCreateInfo cb{};
     cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
     cb.attachmentCount = 1;

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -49,6 +49,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawViewportPanel(win, s)
 	drawDimensionPopup(s)
 	drawExtrudeDialog(s)
+	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)
 	drawPreferencesWindow(s)

--- a/head/ui/offset_plane_dialog.go
+++ b/head/ui/offset_plane_dialog.go
@@ -1,0 +1,59 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Offset Plane flow in the head: while the Offset Plane tool runs, a small dialog
+// prompts for the base plane (picked in the view/browser) and then an editable offset
+// distance, OK/Cancel. Without it the tool could pick a plane but never get a distance, so
+// OK stayed disabled — Inventor asks for the distance rather than dropping a plane at a
+// fixed offset. The distance is in the document's length unit (e.g. mm).
+
+// offsetPlaneUI holds the dialog's distance field across frames and whether the dialog was
+// open last frame (so it seeds the field once when the tool opens).
+var offsetPlaneUI = struct {
+	distance float32
+	open     bool
+}{distance: 10}
+
+// drawOffsetPlaneDialog shows the offset editor while the Offset Plane tool is active and
+// keeps the tool's distance in sync with the field each frame; OK commits, Cancel aborts.
+func drawOffsetPlaneDialog(s *app.Session) {
+	t := s.ActiveOffsetPlane()
+	if t == nil {
+		offsetPlaneUI.open = false
+		return
+	}
+	if !offsetPlaneUI.open { // tool just opened — seed the field from its current offset
+		if d := s.OffsetDistanceDisplay(); d != 0 {
+			offsetPlaneUI.distance = float32(d)
+		}
+		offsetPlaneUI.open = true
+	}
+	native.SetNextWindowSize(300, 124)
+	if native.Begin("Offset Plane") {
+		if !t.BasePicked() {
+			native.Text("Select a plane or planar face to offset from")
+		} else {
+			native.Text("Offset (" + s.LengthUnitName() + ")")
+			native.InputFloat("##offset-distance", &offsetPlaneUI.distance)
+			s.SetOffsetDistanceDisplay(float64(offsetPlaneUI.distance)) // keep the tool in sync
+		}
+		native.BeginDisabled(!t.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK() // a failed commit keeps the tool open
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -11,23 +11,28 @@ import (
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
-// planesOverlay draws the part's origin work planes as finite squares (border +
-// diagonals) in the viewport, so the user can see and click them to choose a sketch
-// host. The selected plane is highlighted; the plane under the cursor is shown in the
-// hover color (the focus the user is about to pick). Shown outside the sketch
-// environment.
+// planesOverlay draws the part's work planes — the origin frame AND user-created datums —
+// each as a translucent filled square with a solid square border (Inventor's datum-plane
+// look), so a created work plane is visible and can be clicked. Hidden planes (Visibility
+// toggled off) are skipped. The selected plane's border is highlighted; the plane under
+// the cursor uses the hover color. Shown outside the sketch environment.
 func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *feature.WorkPlane) []renderer.DrawItem {
 	if part == nil {
 		return nil
 	}
 	var items []renderer.DrawItem
-	for _, wp := range part.OriginPlanes() {
-		items = append(items, planeBorder(wp, planeColor(wp, selected, hovered)))
+	planes := part.WorkPlanes()
+	for i := 0; i < planes.Count(); i++ {
+		wp := planes.Item(i)
+		if !wp.Visible() {
+			continue
+		}
+		items = append(items, planeFill(wp), planeBorder(wp, planeColor(wp, selected, hovered)))
 	}
 	return items
 }
 
-// planeColor chooses a plane's draw color: selected wins, then hovered, then faint.
+// planeColor chooses a plane border's draw color: selected wins, then hovered, then faint.
 func planeColor(wp, selected, hovered *feature.WorkPlane) [4]float32 {
 	switch wp {
 	case selected:
@@ -39,9 +44,9 @@ func planeColor(wp, selected, hovered *feature.WorkPlane) [4]float32 {
 	}
 }
 
-// planeBorder builds the border-and-diagonals line item of a work plane's display
-// square, mapped from the plane's 2D frame into model space.
-func planeBorder(wp *feature.WorkPlane, color [4]float32) renderer.DrawItem {
+// planeCorners maps a work plane's display square into model space (the four corners in
+// CCW order), shared by the fill and the border.
+func planeCorners(wp *feature.WorkPlane) []math.Point3 {
 	pl := wp.Plane()
 	s := wp.DisplaySize()
 	corners2D := []math.Point2{math.P2(-s, -s), math.P2(s, -s), math.P2(s, s), math.P2(-s, s)}
@@ -49,7 +54,30 @@ func planeBorder(wp *feature.WorkPlane, color [4]float32) renderer.DrawItem {
 	for i, c := range corners2D {
 		pos[i] = pl.ToModel(c)
 	}
-	// Border 0-1-2-3-0 plus the two diagonals 0-2 and 1-3.
-	idx := []int{0, 1, 1, 2, 2, 3, 3, 0, 0, 2, 1, 3}
+	return pos
+}
+
+// planeFill builds the translucent filled quad of a work plane's display square (two
+// triangles). The fill color is the theme's plane-fill albedo and its alpha is the
+// opacity (TokenPlaneFill), so the plane is see-through; the plane normal is supplied so
+// the lit overlay pass shades it consistently.
+func planeFill(wp *feature.WorkPlane) renderer.DrawItem {
+	pos := planeCorners(wp)
+	n := wp.Plane().Normal().AsVector()
+	return renderer.DrawItem{
+		Primitive: renderer.Triangles,
+		Positions: pos,
+		Normals:   []math.Vector3{n, n, n, n},
+		Indices:   []int{0, 1, 2, 0, 2, 3},
+		Color:     planeFillColor,
+		Opacity:   planeFillColor[3],
+	}
+}
+
+// planeBorder builds the square-border line item of a work plane's display square (the
+// four edges, no diagonals), mapped from the plane's 2D frame into model space.
+func planeBorder(wp *feature.WorkPlane, color [4]float32) renderer.DrawItem {
+	pos := planeCorners(wp)
+	idx := []int{0, 1, 1, 2, 2, 3, 3, 0} // border 0-1-2-3-0
 	return renderer.DrawItem{Primitive: renderer.Lines, Positions: pos, Indices: idx, Color: color}
 }

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -26,6 +26,7 @@ var (
 	dimensionColor, dimensionDrivenColor                   [4]float32
 	snapGlyphColor, pointMarkerColor                       [4]float32
 	faintPlaneColor, hoverPlaneColor, selectedPlaneColor   [4]float32
+	planeFillColor                                         [4]float32 // translucent plane fill (alpha = opacity)
 	selectionHighlight                                     [4]float32 // picked-body highlight
 	iconTint                                               [4]float32 // ribbon glyph tint
 	windowClearColor                                       [3]float32 // swapchain (chrome) clear
@@ -73,6 +74,7 @@ func refreshThemeColors(t contract.Theme) {
 	faintPlaneColor = arr(types.TokenPlaneFaint)
 	hoverPlaneColor = arr(types.TokenPlaneHover)
 	selectedPlaneColor = arr(types.TokenPlaneSelected)
+	planeFillColor = arr(types.TokenPlaneFill)
 	selectionHighlight = arr(types.TokenSelectionHighlight)
 	iconTint = arr(types.TokenIconTint)
 	c := t.Color(types.TokenChromeWindowBg)

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -99,6 +99,17 @@ func (b *Body) FindEdgeByKey(key []byte) (*Edge, bool) {
 	return nil, false
 }
 
+// FindVertexByKey re-binds a vertex reference key by lineage — used to resolve a picked
+// B-rep vertex as a work-feature point input after the body is rebuilt.
+func (b *Body) FindVertexByKey(key []byte) (*Vertex, bool) {
+	for _, v := range b.Vertices() {
+		if bytes.Equal(v.ReferenceKey(), key) {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
 // MergeBodies combines the shells of several bodies into one (a multi-lump body),
 // re-parenting each shell. Used by a boolean Join of non-touching bodies
 // (kernel/ops). The input bodies should not be used afterward.

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -88,8 +88,14 @@ func (d *PartComponentDefinition) Features() *feature.PartFeatures { return d.fe
 // SurfaceBodies, advancing the geometry version. This is the part-level
 // orchestration that turns the feature history into the evaluated result.
 func (d *PartComponentDefinition) Recompute() {
-	d.work.Recompute()
+	// Two passes around the feature program: the first so features can reference work
+	// axes/planes (e.g. a revolve axis); the second so surface-tangent work planes can
+	// resolve their picked faces against the freshly built body. The first pass sees the
+	// previous result, which is correct for body-independent work features and harmless
+	// for body-dependent ones (refreshed by the second pass).
+	d.work.Recompute(d.features.Result())
 	d.features.Recompute()
+	d.work.Recompute(d.features.Result())
 	d.bodies = topo.NewSurfaceBodies()
 	for _, b := range d.features.Result() {
 		d.bodies.Add(b)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -22,7 +22,10 @@ type WorkFeatureData struct {
 	Kind       string    `yaml:"kind"`
 	Refs       []string  `yaml:"refs,omitempty"`
 	Offset     float64   `yaml:"offset,omitempty"`   // plane-offset
-	Position   []float64 `yaml:"position,omitempty"` // point position [x,y,z]
+	Angle      float64   `yaml:"angle,omitempty"`    // line-plane-angle
+	Position   []float64 `yaml:"position,omitempty"` // point position / fixed-frame origin [x,y,z]
+	XAxis      []float64 `yaml:"xaxis,omitempty"`    // fixed-frame X axis [x,y,z]
+	YAxis      []float64 `yaml:"yaxis,omitempty"`    // fixed-frame Y axis [x,y,z]
 }
 
 // MarshalWork projects the user work features into the recipe, in creation order.
@@ -56,7 +59,15 @@ func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
 	switch v := def.(type) {
 	case offsetPlaneDef:
 		d.Offset = v.offset()
-	case threePointPlaneDef:
+	case fixedFramePlaneDef:
+		p := v.origin()
+		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+		d.XAxis, d.YAxis = unitSlice(v.x), unitSlice(v.y)
+	case linePlaneAnglePlaneDef:
+		d.Angle = v.angle()
+	case threePointPlaneDef, planeAndPointPlaneDef, twoPlanesPlaneDef, twoLinesPlaneDef,
+		normalToCurvePlaneDef, torusMidPlaneDef, pointAndTangentPlaneDef,
+		planeAndTangentPlaneDef, lineAndTangentPlaneDef:
 		// references only
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work plane definition %q", def.kindName())
@@ -99,48 +110,122 @@ func ApplyWork(g *WorkGeometry, data []WorkFeatureData) error {
 }
 
 func restoreWorkFeature(g *WorkGeometry, d WorkFeatureData) error {
-	switch d.Collection + "/" + d.Kind {
-	case "plane/plane-offset":
-		base, err := workRefAt(d.Refs, 0)
-		if err != nil {
-			return err
-		}
-		off := d.Offset
-		g.WorkPlanes().AddByPlaneAndOffset(base, func() float64 { return off })
-	case "plane/three-points":
-		r, err := workRefs(d.Refs, 3)
-		if err != nil {
-			return err
-		}
-		g.WorkPlanes().AddByThreePoints(r[0], r[1], r[2])
-	case "axis/two-points":
-		r, err := workRefs(d.Refs, 2)
-		if err != nil {
-			return err
-		}
-		g.WorkAxes().AddByTwoPoints(r[0], r[1])
-	case "axis/plane-intersection":
-		r, err := workRefs(d.Refs, 2)
-		if err != nil {
-			return err
-		}
-		g.WorkAxes().AddByPlaneIntersection(r[0], r[1])
-	case "point/position":
-		if len(d.Position) != 3 {
-			return fmt.Errorf("position point needs 3 coordinates, got %d", len(d.Position))
-		}
-		pos := math.P3(d.Position[0], d.Position[1], d.Position[2])
-		g.WorkPoints().AddByPosition(func() math.Point3 { return pos })
-	case "point/plane-axis-intersection":
-		r, err := workRefs(d.Refs, 2)
-		if err != nil {
-			return err
-		}
-		g.WorkPoints().AddByPlaneAndAxisIntersection(r[0], r[1])
+	switch d.Collection {
+	case "plane":
+		return restorePlaneFeature(g.WorkPlanes(), d)
+	case "axis":
+		return restoreAxisFeature(g.WorkAxes(), d)
+	case "point":
+		return restorePointFeature(g.WorkPoints(), d)
 	default:
-		return fmt.Errorf("no restore codec for work feature %s/%s", d.Collection, d.Kind)
+		return fmt.Errorf("unknown work collection %q", d.Collection)
+	}
+}
+
+// restorePlaneFeature rebuilds one user work plane from its recipe. Reference-only kinds
+// resolve through workRefs; fixed-frame/offset/angle kinds also carry scalar parameters,
+// re-installed as closures so a recompute re-reads them.
+func restorePlaneFeature(c *WorkPlanes, d WorkFeatureData) error {
+	switch d.Kind {
+	case "plane-offset":
+		return restoreRefPlane(d, 1, func(r []WorkRef) {
+			off := d.Offset
+			c.AddByPlaneAndOffset(r[0], func() float64 { return off })
+		})
+	case "three-points":
+		return restoreRefPlane(d, 3, func(r []WorkRef) { c.AddByThreePoints(r[0], r[1], r[2]) })
+	case "fixed-frame":
+		return restoreFixedFrame(c, d)
+	case "plane-point":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPlaneAndPoint(r[0], r[1]) })
+	case "two-planes":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByTwoPlanes(r[0], r[1]) })
+	case "line-plane-angle":
+		return restoreRefPlane(d, 2, func(r []WorkRef) {
+			ang := d.Angle
+			c.AddByLinePlaneAndAngle(r[0], r[1], func() float64 { return ang })
+		})
+	case "two-lines":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByTwoLines(r[0], r[1]) })
+	case "normal-to-curve":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByNormalToCurve(r[0], r[1]) })
+	case "torus-midplane":
+		return restoreRefPlane(d, 1, func(r []WorkRef) { c.AddByTorusMidPlane(r[0]) })
+	case "point-tangent":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPointAndTangent(r[0], r[1]) })
+	case "plane-tangent":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPlaneAndTangent(r[0], r[1]) })
+	case "line-tangent":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByLineAndTangent(r[0], r[1]) })
+	default:
+		return fmt.Errorf("no restore codec for work plane kind %q", d.Kind)
+	}
+}
+
+// restoreRefPlane resolves d's n references and calls add with them, centralizing the
+// arity check so each plane kind above stays a single line.
+func restoreRefPlane(d WorkFeatureData, n int, add func([]WorkRef)) error {
+	r, err := workRefs(d.Refs, n)
+	if err != nil {
+		return err
+	}
+	add(r)
+	return nil
+}
+
+// restoreFixedFrame rebuilds an AddFixed plane from its origin and two in-plane axes.
+func restoreFixedFrame(c *WorkPlanes, d WorkFeatureData) error {
+	origin, err := point3From(d.Position, "fixed-frame origin")
+	if err != nil {
+		return err
+	}
+	x, err := unit3From(d.XAxis, "fixed-frame X axis")
+	if err != nil {
+		return err
+	}
+	y, err := unit3From(d.YAxis, "fixed-frame Y axis")
+	if err != nil {
+		return err
+	}
+	c.AddFixed(func() math.Point3 { return origin }, x, y)
+	return nil
+}
+
+func restoreAxisFeature(c *WorkAxes, d WorkFeatureData) error {
+	r, err := workRefs(d.Refs, 2)
+	if err != nil {
+		return err
+	}
+	switch d.Kind {
+	case "two-points":
+		c.AddByTwoPoints(r[0], r[1])
+	case "plane-intersection":
+		c.AddByPlaneIntersection(r[0], r[1])
+	default:
+		return fmt.Errorf("no restore codec for work axis kind %q", d.Kind)
 	}
 	return nil
+}
+
+func restorePointFeature(c *WorkPoints, d WorkFeatureData) error {
+	switch d.Kind {
+	case "position":
+		pos, err := point3From(d.Position, "position point")
+		if err != nil {
+			return err
+		}
+		c.AddByPosition(func() math.Point3 { return pos })
+		return nil
+	case "plane-axis-intersection":
+		r, err := workRefs(d.Refs, 2)
+		if err != nil {
+			return err
+		}
+		c.AddByPlaneAndAxisIntersection(r[0], r[1])
+		return nil
+	default:
+		return fmt.Errorf("no restore codec for work point kind %q", d.Kind)
+	}
 }
 
 // RevolveData is a revolve's recipe: the sketch profile, the revolution axis (a
@@ -210,7 +295,7 @@ func refStrings(refs []WorkRef) []string {
 	return out
 }
 
-// workRefs requires exactly n references; workRefAt fetches one by position.
+// workRefs requires exactly n references, converting them from their string form.
 func workRefs(refs []string, n int) ([]WorkRef, error) {
 	if len(refs) != n {
 		return nil, fmt.Errorf("expected %d references, got %d", n, len(refs))
@@ -222,9 +307,24 @@ func workRefs(refs []string, n int) ([]WorkRef, error) {
 	return out, nil
 }
 
-func workRefAt(refs []string, i int) (WorkRef, error) {
-	if i >= len(refs) {
-		return "", fmt.Errorf("missing reference %d (have %d)", i, len(refs))
+// unitSlice renders a unit vector as its [x,y,z] components for YAML.
+func unitSlice(u math.UnitVector3) []float64 {
+	v := u.AsVector()
+	return []float64{float64(v.X), float64(v.Y), float64(v.Z)}
+}
+
+// point3From reads a 3-component coordinate slice into a point, naming what for errors.
+func point3From(s []float64, what string) (math.Point3, error) {
+	if len(s) != 3 {
+		return math.Point3{}, fmt.Errorf("%s needs 3 coordinates, got %d", what, len(s))
 	}
-	return WorkRef(refs[i]), nil
+	return math.P3(s[0], s[1], s[2]), nil
+}
+
+// unit3From reads a 3-component slice into a unit vector (erroring on a zero vector).
+func unit3From(s []float64, what string) (math.UnitVector3, error) {
+	if len(s) != 3 {
+		return math.UnitVector3{}, fmt.Errorf("%s needs 3 components, got %d", what, len(s))
+	}
+	return math.NewUnitVector3(s[0], s[1], s[2])
 }

--- a/model/feature/work_features_test.go
+++ b/model/feature/work_features_test.go
@@ -60,7 +60,7 @@ func TestOffsetWorkPlaneMovesWithParameter(t *testing.T) {
 	if err := off.SetExpression("12 cm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	g.Recompute()
+	g.Recompute(nil)
 	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 12), wtol) {
 		t.Errorf("after param change, plane origin = %v, want (0,0,12)", wp.Plane().Origin())
 	}
@@ -136,6 +136,22 @@ func TestWorkFeatureNamesAndKeys(t *testing.T) {
 	up := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 1, 1) })
 	if up.Key() != WorkRef("point/1") {
 		t.Errorf("first user point key = %q, want point/1", up.Key())
+	}
+}
+
+func TestWorkPlaneVisibilityDefaultsTrueAndToggles(t *testing.T) {
+	g := NewWorkGeometry()
+	// Origin planes and user planes are visible by default.
+	if !g.WorkPlanes().Item(0).Visible() {
+		t.Error("origin plane should be visible by default")
+	}
+	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	if !wp.Visible() {
+		t.Error("a new user work plane should be visible by default")
+	}
+	wp.SetVisible(false)
+	if wp.Visible() {
+		t.Error("SetVisible(false) should hide the plane")
 	}
 }
 

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -7,6 +7,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
@@ -22,15 +26,17 @@ type WorkRef string
 
 // Well-known origin references — the static coordinate system every part document has
 // from creation (Inventor's "Origin" folder): a center point, the X/Y/Z axes, and the
-// XY/XZ/YZ planes. They are grounded coordinate-system elements.
+// XY/XZ/YZ planes. They are grounded coordinate-system elements. The reference strings
+// are the canonical, Apache-2.0 contract vocabulary ([types] WorkRef*), aliased here so
+// /source and the public API can never drift (ADR-0018).
 const (
-	OriginCenter  WorkRef = "origin/point/center"
-	OriginXAxis   WorkRef = "origin/axis/x"
-	OriginYAxis   WorkRef = "origin/axis/y"
-	OriginZAxis   WorkRef = "origin/axis/z"
-	OriginXYPlane WorkRef = "origin/plane/xy"
-	OriginXZPlane WorkRef = "origin/plane/xz"
-	OriginYZPlane WorkRef = "origin/plane/yz"
+	OriginCenter  WorkRef = types.WorkRefCenter
+	OriginXAxis   WorkRef = types.WorkRefXAxis
+	OriginYAxis   WorkRef = types.WorkRefYAxis
+	OriginZAxis   WorkRef = types.WorkRefZAxis
+	OriginXYPlane WorkRef = types.WorkRefXYPlane
+	OriginXZPlane WorkRef = types.WorkRefXZPlane
+	OriginYZPlane WorkRef = types.WorkRefYZPlane
 )
 
 // workResolver resolves a WorkRef to its current geometry. [WorkGeometry] implements
@@ -39,6 +45,7 @@ type workResolver interface {
 	plane(WorkRef) (sketch.Plane, error)
 	axis(WorkRef) (*WorkAxis, error)
 	point(WorkRef) (math.Point3, error)
+	surface(WorkRef) (geom.Surface, error)
 }
 
 // WorkGeometry is a part's construction-geometry frame: the static origin coordinate
@@ -50,7 +57,9 @@ type WorkGeometry struct {
 	axes    *WorkAxes
 	points  *WorkPoints
 	ucs     *UserCoordinateSystems
-	userSeq []userEntry // user work features in global creation order (for serialization)
+	userSeq []userEntry  // user work features in global creation order (for serialization)
+	bodies  []*topo.Body // the running solid result, so surface-tangent work planes can
+	// resolve a picked B-rep face's reference key to its surface (set each Recompute).
 }
 
 // userEntry records a user work feature's collection and index in global creation
@@ -99,8 +108,13 @@ func (g *WorkGeometry) OriginPlanes() []*WorkPlane {
 }
 
 // Recompute re-derives every work feature in order (origin first, grounded; then user
-// features, which may reference earlier ones).
-func (g *WorkGeometry) Recompute() {
+// features, which may reference earlier ones). bodies is the part's current solid
+// result, against which surface-tangent work planes resolve their picked faces; pass
+// nil when no body exists yet (those planes then go Sick until one does). The part
+// recomputes work geometry once before the feature program (so features can reference
+// work axes/planes) and once after (so tangent planes see the freshly built body).
+func (g *WorkGeometry) Recompute(bodies []*topo.Body) {
+	g.bodies = bodies
 	for i := 0; i < g.points.Count(); i++ {
 		g.points.Item(i).recompute(g)
 	}
@@ -155,6 +169,9 @@ func (g *WorkGeometry) axis(ref WorkRef) (*WorkAxis, error) {
 }
 
 func (g *WorkGeometry) point(ref WorkRef) (math.Point3, error) {
+	if p, isVertex, err := g.vertexPoint(ref); isVertex {
+		return p, err
+	}
 	if i, ok := userIndex(ref, "point"); ok {
 		if i < 0 || i >= g.points.Count() {
 			return math.Point3{}, fmt.Errorf("work geometry: no work point %q", ref)

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -83,6 +83,7 @@ type WorkPlane struct {
 	displaySize      float64
 	coordinateSystem bool
 	grounded         bool
+	visible          bool
 }
 
 // ID/Key/Name identify the datum; Health reports its last recompute state.
@@ -102,6 +103,11 @@ func (w *WorkPlane) DisplaySize() float64 { return w.displaySize }
 // Grounded reports whether its geometry is fixed (the absolute document frame).
 func (w *WorkPlane) IsCoordinateSystemElement() bool { return w.coordinateSystem }
 func (w *WorkPlane) Grounded() bool                  { return w.grounded }
+
+// Visible reports whether the datum is drawn in the viewport; SetVisible toggles it
+// (Inventor's per-work-feature Visibility). New planes are visible by default.
+func (w *WorkPlane) Visible() bool     { return w.visible }
+func (w *WorkPlane) SetVisible(v bool) { w.visible = v }
 
 // recompute re-derives the plane from its definition, going sick on failure (e.g.
 // degenerate three points) rather than producing garbage.
@@ -131,7 +137,7 @@ func newWorkPlanes(g *WorkGeometry) *WorkPlanes {
 func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) {
 	w := &WorkPlane{
 		id: nextID(), key: key, name: name, def: fixedPlaneDef{plane: plane},
-		displaySize: defaultOriginPlaneSize, coordinateSystem: true, grounded: true,
+		displaySize: defaultOriginPlaneSize, coordinateSystem: true, grounded: true, visible: true,
 	}
 	c.track(w)
 }
@@ -139,20 +145,21 @@ func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) {
 // AddByPlaneAndOffset creates a user plane parallel to base, offset by the value the
 // closure returns (typically a parameter), so the datum moves when that param changes.
 func (c *WorkPlanes) AddByPlaneAndOffset(base WorkRef, offset func() float64) *WorkPlane {
-	return c.addUser("WorkPlane", offsetPlaneDef{base: base, offset: offset})
+	return c.addUser(offsetPlaneDef{base: base, offset: offset})
 }
 
 // AddByThreePoints creates a user plane through three referenced points.
 func (c *WorkPlanes) AddByThreePoints(a, b, cc WorkRef) *WorkPlane {
-	return c.addUser("WorkPlane", threePointPlaneDef{a: a, b: b, c: cc})
+	return c.addUser(threePointPlaneDef{a: a, b: b, c: cc})
 }
 
 // addUser adds a user datum plane, keying it by its position so references stay stable,
-// and records it in the part's global creation order.
-func (c *WorkPlanes) addUser(name string, def planeDefinition) *WorkPlane {
+// and records it in the part's global creation order. All user planes start named
+// "WorkPlane"; the app renames them uniquely (e.g. "Work Plane1") on creation.
+func (c *WorkPlanes) addUser(def planeDefinition) *WorkPlane {
 	w := &WorkPlane{
-		id: nextID(), key: userRef("plane", len(c.items)), name: name, def: def,
-		displaySize: defaultOriginPlaneSize,
+		id: nextID(), key: userRef("plane", len(c.items)), name: "WorkPlane", def: def,
+		displaySize: defaultOriginPlaneSize, visible: true,
 	}
 	c.track(w)
 	c.g.recordUser("plane", len(c.items)-1)

--- a/model/feature/work_plane_defs.go
+++ b/model/feature/work_plane_defs.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// These are the work-plane definitions that build on other work features (planes,
+// axes, points) resolved through the [workResolver] — the reference-model half of
+// Inventor's WorkPlanes constructors. The surface-tangent half (built on a B-rep face)
+// lives in work_plane_tangent.go. Every definition captures its references + scalar
+// parameters so it round-trips and re-derives on recompute (work_plane.go owns the
+// WorkPlane/WorkPlanes types and the offset/three-point definitions).
+
+// fixedFramePlaneDef is a user plane fixed in space by an origin and two in-plane axes
+// (Inventor's AddFixed) — absolute geometry, unlike the offset/three-point planes that
+// float on their references. The origin is a closure so it can track a parameter.
+type fixedFramePlaneDef struct {
+	origin func() math.Point3
+	x, y   math.UnitVector3
+}
+
+func (d fixedFramePlaneDef) kindName() string { return "fixed-frame" }
+func (d fixedFramePlaneDef) refs() []WorkRef  { return nil }
+func (d fixedFramePlaneDef) eval(workResolver) (sketch.Plane, error) {
+	return sketch.NewPlane(d.origin(), d.x, d.y)
+}
+
+// planeAndPointPlaneDef is a plane parallel to a base plane through a point (Inventor's
+// AddByPlaneAndPoint): it inherits the base orientation and is repositioned at the point.
+type planeAndPointPlaneDef struct {
+	base  WorkRef
+	point WorkRef
+}
+
+func (d planeAndPointPlaneDef) kindName() string { return "plane-point" }
+func (d planeAndPointPlaneDef) refs() []WorkRef  { return []WorkRef{d.base, d.point} }
+func (d planeAndPointPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	base, err := r.plane(d.base)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	p, err := r.point(d.point)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return sketch.NewPlane(p, base.XAxis(), base.YAxis())
+}
+
+// twoPlanesPlaneDef bisects two planes (Inventor's AddByTwoPlanes): the dihedral-angle
+// bisector through their intersection line, or the mid-plane when they are parallel.
+type twoPlanesPlaneDef struct{ p1, p2 WorkRef }
+
+func (d twoPlanesPlaneDef) kindName() string { return "two-planes" }
+func (d twoPlanesPlaneDef) refs() []WorkRef  { return []WorkRef{d.p1, d.p2} }
+func (d twoPlanesPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	p1, err := r.plane(d.p1)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	p2, err := r.plane(d.p2)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return bisectingPlane(p1, p2)
+}
+
+// linePlaneAnglePlaneDef passes through a line at a given angle from a plane, swung
+// about the line (Inventor's AddByLinePlaneAndAngle). The angle is a closure so it can
+// track a parameter (the datum re-angles when the parameter changes).
+type linePlaneAnglePlaneDef struct {
+	line  WorkRef
+	base  WorkRef
+	angle func() float64
+}
+
+func (d linePlaneAnglePlaneDef) kindName() string { return "line-plane-angle" }
+func (d linePlaneAnglePlaneDef) refs() []WorkRef  { return []WorkRef{d.line, d.base} }
+func (d linePlaneAnglePlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	line, err := r.axis(d.line)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	base, err := r.plane(d.base)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeThroughLineAtAngle(line, base, d.angle())
+}
+
+// twoLinesPlaneDef builds a plane from two lines: Line1 is the X axis and the normal is
+// Line1×Line2 (Inventor's AddByTwoLines) — so the plane holds Line1 and, if they are
+// coplanar, Line2 as well.
+type twoLinesPlaneDef struct{ l1, l2 WorkRef }
+
+func (d twoLinesPlaneDef) kindName() string { return "two-lines" }
+func (d twoLinesPlaneDef) refs() []WorkRef  { return []WorkRef{d.l1, d.l2} }
+func (d twoLinesPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	l1, err := r.axis(d.l1)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	l2, err := r.axis(d.l2)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	x := l1.Direction()
+	normal, err := math.UnitVector3FromVector(x.AsVector().Cross(l2.Direction().AsVector()))
+	if err != nil {
+		return sketch.Plane{}, errors.New("the two lines are parallel, so no plane is defined")
+	}
+	y, err := math.UnitVector3FromVector(normal.AsVector().Cross(x.AsVector()))
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return sketch.NewPlane(l1.Origin(), x, y)
+}
+
+// normalToCurvePlaneDef passes through a point and is normal to a curve there (Inventor's
+// AddByNormalToCurve). Only linear curves (work axes) are supported in phase A; the
+// plane's normal is the axis direction.
+type normalToCurvePlaneDef struct {
+	curve WorkRef
+	point WorkRef
+}
+
+func (d normalToCurvePlaneDef) kindName() string { return "normal-to-curve" }
+func (d normalToCurvePlaneDef) refs() []WorkRef  { return []WorkRef{d.curve, d.point} }
+func (d normalToCurvePlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	axis, err := r.axis(d.curve)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	p, err := r.point(d.point)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeFromOriginNormal(p, axis.Direction())
+}
+
+// AddFixed creates a user plane fixed at origin with the given in-plane axes.
+//
+//	x, _ := math.NewUnitVector3(1, 0, 0)
+//	y, _ := math.NewUnitVector3(0, 1, 0)
+//	wp := planes.AddFixed(func() math.Point3 { return math.P3(0, 0, 5) }, x, y)
+func (c *WorkPlanes) AddFixed(origin func() math.Point3, x, y math.UnitVector3) *WorkPlane {
+	return c.addUser(fixedFramePlaneDef{origin: origin, x: x, y: y})
+}
+
+// AddByPlaneAndPoint creates a plane parallel to base passing through point.
+//
+//	wp := planes.AddByPlaneAndPoint(feature.OriginXYPlane, apex.Key())
+func (c *WorkPlanes) AddByPlaneAndPoint(base, point WorkRef) *WorkPlane {
+	return c.addUser(planeAndPointPlaneDef{base: base, point: point})
+}
+
+// AddByTwoPlanes creates the bisecting plane of p1 and p2.
+//
+//	wp := planes.AddByTwoPlanes(feature.OriginXYPlane, feature.OriginXZPlane)
+func (c *WorkPlanes) AddByTwoPlanes(p1, p2 WorkRef) *WorkPlane {
+	return c.addUser(twoPlanesPlaneDef{p1: p1, p2: p2})
+}
+
+// AddByLinePlaneAndAngle creates a plane through line at angle (radians) from base.
+//
+//	wp := planes.AddByLinePlaneAndAngle(feature.OriginXAxis, feature.OriginXYPlane,
+//		func() float64 { return 0.7853981633974483 }) // 45° in radians
+func (c *WorkPlanes) AddByLinePlaneAndAngle(line, base WorkRef, angle func() float64) *WorkPlane {
+	return c.addUser(linePlaneAnglePlaneDef{line: line, base: base, angle: angle})
+}
+
+// AddByTwoLines creates a plane from two lines (l1 is the X axis).
+//
+//	wp := planes.AddByTwoLines(feature.OriginXAxis, feature.OriginYAxis)
+func (c *WorkPlanes) AddByTwoLines(l1, l2 WorkRef) *WorkPlane {
+	return c.addUser(twoLinesPlaneDef{l1: l1, l2: l2})
+}
+
+// AddByNormalToCurve creates a plane through point, normal to the curve (a work axis).
+//
+//	wp := planes.AddByNormalToCurve(feature.OriginZAxis, top.Key())
+func (c *WorkPlanes) AddByNormalToCurve(curve, point WorkRef) *WorkPlane {
+	return c.addUser(normalToCurvePlaneDef{curve: curve, point: point})
+}
+
+// bisectingPlane returns the plane that bisects p1 and p2. Intersecting planes give the
+// dihedral bisector (normal n1+n2) through a point on their intersection line; parallel
+// planes give the mid-plane, parallel to both and halfway between them.
+func bisectingPlane(p1, p2 sketch.Plane) (sketch.Plane, error) {
+	origin, _, err := planeIntersectionLine(p1, p2)
+	if err != nil {
+		n1 := p1.Normal().AsVector()
+		dist := n1.Dot(p1.Origin().VectorTo(p2.Origin()))
+		mid := p1.Origin().TranslateBy(n1.Scale(dist / 2))
+		return sketch.NewPlane(mid, p1.XAxis(), p1.YAxis())
+	}
+	normal, err := math.UnitVector3FromVector(p1.Normal().AsVector().Add(p2.Normal().AsVector()))
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeFromOriginNormal(origin, normal)
+}
+
+// planeThroughLineAtAngle returns the plane that holds line and is rotated about it by
+// angle (radians) away from base's orientation. The zero-angle normal is base's normal
+// projected perpendicular to the line (so the result always contains the line); errors
+// when base is perpendicular to the line, where the reference orientation is undefined.
+func planeThroughLineAtAngle(line *WorkAxis, base sketch.Plane, angle float64) (sketch.Plane, error) {
+	dir := line.Direction().AsVector()
+	bn := base.Normal().AsVector()
+	n0, err := math.UnitVector3FromVector(bn.Sub(dir.Scale(bn.Dot(dir))))
+	if err != nil {
+		return sketch.Plane{}, errors.New("input plane is perpendicular to the line; the angle is undefined")
+	}
+	rotated := math.Rotation4(angle, line.Direction(), line.Origin()).TransformVector(n0.AsVector())
+	normal, err := math.UnitVector3FromVector(rotated)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeFromOriginNormal(line.Origin(), normal)
+}
+
+// planeFromOriginNormal builds a sketch plane at origin with the given normal, choosing
+// an arbitrary in-plane X axis (the surface/datum frame's roll is unconstrained for the
+// definitions that fix only a normal — bisector, angle, normal-to-curve, tangent).
+func planeFromOriginNormal(origin math.Point3, normal math.UnitVector3) (sketch.Plane, error) {
+	x, err := perpendicularTo(normal)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	y, err := math.UnitVector3FromVector(normal.AsVector().Cross(x.AsVector()))
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return sketch.NewPlane(origin, x, y)
+}
+
+// perpendicularTo returns a unit vector perpendicular to n, crossing it with whichever
+// principal axis is least aligned with it (so the cross is well-conditioned).
+func perpendicularTo(n math.UnitVector3) (math.UnitVector3, error) {
+	seed := math.V3(1, 0, 0)
+	if d := n.AsVector().Dot(seed); d > 0.9 || d < -0.9 {
+		seed = math.V3(0, 1, 0)
+	}
+	return math.UnitVector3FromVector(n.AsVector().Cross(seed))
+}

--- a/model/feature/work_plane_parity_test.go
+++ b/model/feature/work_plane_parity_test.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"reflect"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// These cover the WorkPlanes constructors added for Inventor parity: the reference-model
+// ones (built on planes/axes/points) and the surface-tangent ones (built on a B-rep
+// face), plus the recipe round-trip for every new kind.
+
+func TestAddFixedWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddFixed(func() math.Point3 { return math.P3(1, 2, 3) }, mustX(), mustY())
+	if !wp.Health().OK() {
+		t.Fatalf("fixed plane sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Origin().IsEqualTo(math.P3(1, 2, 3), wtol) ||
+		!wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("fixed plane origin=%v normal=%v, want (1,2,3)/+Z", wp.Plane().Origin(), wp.Plane().Normal())
+	}
+}
+
+func TestPlaneAndPointWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(5, 6, 7) })
+	wp := g.WorkPlanes().AddByPlaneAndPoint(OriginXYPlane, pt.Key())
+	if !wp.Plane().Origin().IsEqualTo(math.P3(5, 6, 7), wtol) ||
+		!wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("plane-point origin=%v normal=%v, want (5,6,7)/+Z", wp.Plane().Origin(), wp.Plane().Normal())
+	}
+}
+
+func TestTwoPlanesBisector(t *testing.T) {
+	g := NewWorkGeometry()
+	// XY (+Z) bisected with XZ (−Y) → normal halfway between, on the X-axis intersection.
+	wp := g.WorkPlanes().AddByTwoPlanes(OriginXYPlane, OriginXZPlane)
+	if !wp.Health().OK() {
+		t.Fatalf("bisector sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, -1, 1), wtol) {
+		t.Errorf("bisector normal=%v, want parallel to (0,-1,1)", wp.Plane().Normal())
+	}
+	// Parallel planes bisect at the mid-plane: XY and XY+10 → z=5.
+	off := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 10 })
+	mid := g.WorkPlanes().AddByTwoPlanes(OriginXYPlane, off.Key())
+	if !mid.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) {
+		t.Errorf("mid-plane origin=%v, want z=5", mid.Plane().Origin())
+	}
+}
+
+func TestLinePlaneAndAngle(t *testing.T) {
+	g := NewWorkGeometry()
+	// XY plane swung 90° about the X axis: normal +Z → ±Y, still holding the X axis.
+	wp := g.WorkPlanes().AddByLinePlaneAndAngle(OriginXAxis, OriginXYPlane, func() float64 { return stdmath.Pi / 2 })
+	if !wp.Health().OK() {
+		t.Fatalf("line-plane-angle sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, 1, 0), wtol) {
+		t.Errorf("swung normal=%v, want parallel to Y", wp.Plane().Normal())
+	}
+	if d := wp.Plane().Normal().AsVector().Dot(math.V3(1, 0, 0)); !math.IsNearZero(d, wtol) {
+		t.Errorf("swung plane does not hold the X axis (normal·X=%g)", d)
+	}
+}
+
+func TestTwoLinesWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddByTwoLines(OriginXAxis, OriginYAxis)
+	if !wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("two-lines normal=%v, want +Z", wp.Plane().Normal())
+	}
+	// Parallel lines have no plane → sick.
+	off := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	axB := g.WorkAxes().AddByPlaneIntersection(OriginXYPlane, OriginXZPlane) // along X
+	bad := g.WorkPlanes().AddByTwoLines(OriginXAxis, axB.Key())
+	_ = off
+	if bad.Health().OK() {
+		t.Error("two parallel lines should give a sick plane")
+	}
+}
+
+func TestNormalToCurveWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 4) })
+	wp := g.WorkPlanes().AddByNormalToCurve(OriginZAxis, pt.Key())
+	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 4), wtol) ||
+		!wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("normal-to-curve origin=%v normal=%v, want (0,0,4)/+Z", wp.Plane().Origin(), wp.Plane().Normal())
+	}
+}
+
+func TestPointAndTangentWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	body, key := faceBody(t, mustCylinder(t)) // axis +Z, radius 2 at origin
+	g.Recompute([]*topo.Body{body})
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(2, 0, 0) }) // on the surface
+	wp := g.WorkPlanes().AddByPointAndTangent(pt.Key(), FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("point-tangent sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Origin().IsEqualTo(math.P3(2, 0, 0), wtol) ||
+		!wp.Plane().Normal().AsVector().IsParallelTo(math.V3(1, 0, 0), wtol) {
+		t.Errorf("point-tangent origin=%v normal=%v, want (2,0,0)/+X", wp.Plane().Origin(), wp.Plane().Normal())
+	}
+}
+
+func TestPlaneAndTangentWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	body, key := faceBody(t, mustCylinder(t))
+	g.Recompute([]*topo.Body{body})
+	// YZ plane normal is +X (⊥ the cylinder axis), so the parallel tangent sits at x=2.
+	wp := g.WorkPlanes().AddByPlaneAndTangent(OriginYZPlane, FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("plane-tangent sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Origin().IsEqualTo(math.P3(2, 0, 0), wtol) {
+		t.Errorf("plane-tangent origin=%v, want (2,0,0)", wp.Plane().Origin())
+	}
+	// A reference plane not perpendicular to the axis has no parallel tangent → sick.
+	bad := g.WorkPlanes().AddByPlaneAndTangent(OriginXYPlane, FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if bad.Health().OK() {
+		t.Error("XY plane (parallel to axis) should give a sick tangent plane")
+	}
+}
+
+func TestLineAndTangentWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	body, key := faceBody(t, mustCylinder(t)) // axis +Z, radius 2
+	g.Recompute([]*topo.Body{body})
+	a := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(4, 0, 0) })
+	b := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(4, 0, 1) })
+	line := g.WorkAxes().AddByTwoPoints(a.Key(), b.Key()) // parallel to +Z, offset 4
+	wp := g.WorkPlanes().AddByLineAndTangent(line.Key(), FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("line-tangent sick: %+v", wp.Health())
+	}
+	n := wp.Plane().Normal().AsVector()
+	if !math.IsNearZero(n.Dot(math.V3(0, 0, 1)), wtol) {
+		t.Errorf("line-tangent plane should hold the +Z line (normal·Z=%g)", n.Dot(math.V3(0, 0, 1)))
+	}
+	// Tangency: the cylinder axis (origin) is exactly radius 2 from the plane.
+	dist := wp.Plane().Origin().VectorTo(math.P3(0, 0, 0)).Dot(n)
+	if !math.IsNearZero(dist*dist-4, 1e-6) {
+		t.Errorf("axis-to-plane distance %g, want radius 2", dist)
+	}
+}
+
+func TestTorusMidPlaneWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	tor, err := geom.NewTorus(math.P3(0, 0, 5), math.V3(0, 0, 1), 4, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, key := faceBody(t, tor)
+	g.Recompute([]*topo.Body{body})
+	wp := g.WorkPlanes().AddByTorusMidPlane(FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) ||
+		!wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("torus mid-plane origin=%v normal=%v, want (0,0,5)/+Z", wp.Plane().Origin(), wp.Plane().Normal())
+	}
+}
+
+func TestThreePointPlaneFromModelVertices(t *testing.T) {
+	g := NewWorkGeometry()
+	body, keys := triangleBody(t) // three vertices in the z=0 plane
+	g.Recompute([]*topo.Body{body})
+	wp := g.WorkPlanes().AddByThreePoints(VertexRef(keys[0]), VertexRef(keys[1]), VertexRef(keys[2]))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("three-point plane from vertices sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("normal = %v, want +Z", wp.Plane().Normal())
+	}
+	// When the vertices are gone (no body) the datum goes sick, not garbage.
+	g.Recompute(nil)
+	if wp.Health().OK() {
+		t.Error("three-point plane should go sick when its vertices are lost")
+	}
+}
+
+func TestTangentWorkPlaneSickWhenFaceLost(t *testing.T) {
+	g := NewWorkGeometry()
+	// A face reference that never binds (no body) must go sick, not panic or guess.
+	wp := g.WorkPlanes().AddByTorusMidPlane(FaceRef([]byte("ghost")))
+	g.Recompute(nil)
+	if wp.Health().OK() {
+		t.Error("tangent plane with an unbound face should be sick")
+	}
+}
+
+func TestWorkPlaneRecipeRoundTrip(t *testing.T) {
+	g := seedAllWorkPlanes()
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	again, err := MarshalWork(restored)
+	if err != nil {
+		t.Fatalf("re-MarshalWork: %v", err)
+	}
+	if !reflect.DeepEqual(data, again) {
+		t.Errorf("recipe did not round-trip:\n first=%+v\n again=%+v", data, again)
+	}
+}
+
+// seedAllWorkPlanes builds a geometry exercising every new plane kind, so the round-trip
+// test covers each codec. Face refs are synthetic (the structural recipe round-trips
+// without a body; tangent geometry is covered by the body-backed tests above).
+func seedAllWorkPlanes() *WorkGeometry {
+	g := NewWorkGeometry()
+	p1 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 0, 0) })
+	p2 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 0) })
+	p3 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 1) })
+	ax := g.WorkAxes().AddByTwoPoints(OriginCenter, p3.Key())
+	fk := FaceRef([]byte("face-key"))
+	g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 2 })
+	g.WorkPlanes().AddByThreePoints(p1.Key(), p2.Key(), p3.Key())
+	g.WorkPlanes().AddFixed(func() math.Point3 { return math.P3(1, 2, 3) }, mustX(), mustY())
+	g.WorkPlanes().AddByPlaneAndPoint(OriginXYPlane, p1.Key())
+	g.WorkPlanes().AddByTwoPlanes(OriginXYPlane, OriginXZPlane)
+	g.WorkPlanes().AddByLinePlaneAndAngle(OriginXAxis, OriginXYPlane, func() float64 { return 0.5 })
+	g.WorkPlanes().AddByTwoLines(OriginXAxis, OriginYAxis)
+	g.WorkPlanes().AddByNormalToCurve(ax.Key(), p3.Key())
+	g.WorkPlanes().AddByTorusMidPlane(fk)
+	g.WorkPlanes().AddByPointAndTangent(p1.Key(), fk)
+	g.WorkPlanes().AddByPlaneAndTangent(OriginXYPlane, fk)
+	g.WorkPlanes().AddByLineAndTangent(ax.Key(), fk)
+	return g
+}
+
+// faceBody wraps a surface in a one-face body and returns the face's reference key, so
+// a surface-tangent work plane can resolve it through the work geometry.
+func faceBody(t *testing.T, surface geom.Surface) (*topo.Body, []byte) {
+	t.Helper()
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("f", "body", 0)))
+	f := bld.AddFace(surface, topo.NewLineage(topo.Tok("f", "face", 0)))
+	return bld.Build(), f.ReferenceKey()
+}
+
+func mustCylinder(t *testing.T) geom.Cylinder {
+	t.Helper()
+	c, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// triangleBody builds a one-face triangular body and returns the reference keys of its
+// three corner vertices, so a three-point work plane can be built on model vertices.
+func triangleBody(t *testing.T) (*topo.Body, [3][]byte) {
+	t.Helper()
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("f", "body", 0)))
+	a := bld.AddVertex(math.P3(0, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", 0)))
+	b := bld.AddVertex(math.P3(2, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", 1)))
+	c := bld.AddVertex(math.P3(0, 2, 0), topo.NewLineage(topo.Tok("f", "vertex", 2)))
+	seg := func(p, q *topo.Vertex) geom.LineSegment { return geom.NewLineSegment(p.Point(), q.Point()) }
+	ab := bld.AddEdge(seg(a, b), a, b, topo.NewLineage(topo.Tok("f", "edge", 0)))
+	bc := bld.AddEdge(seg(b, c), b, c, topo.NewLineage(topo.Tok("f", "edge", 1)))
+	ca := bld.AddEdge(seg(c, a), c, a, topo.NewLineage(topo.Tok("f", "edge", 2)))
+	pl, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bld.AddFace(pl, topo.NewLineage(topo.Tok("f", "face", 0)), topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	return bld.Build(), [3][]byte{a.ReferenceKey(), b.ReferenceKey(), c.ReferenceKey()}
+}

--- a/model/feature/work_plane_tangent.go
+++ b/model/feature/work_plane_tangent.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// These are the surface-tangent work-plane definitions — Inventor's WorkPlanes
+// constructors that build on a B-rep face (a cylinder/cone/sphere/torus) rather than on
+// another work feature. The face is named by a face [WorkRef] (work_surface_ref.go),
+// re-bound to the running body each recompute. The analytic surfaces expose their axis/
+// centre/radius (kernel/geom), so the tangent geometry is closed-form; sub-cases that
+// have no closed-form single answer (e.g. a plane tangent to a torus parallel to a
+// reference plane) report a Sick reason rather than guessing, consistent with the rest
+// of the work-feature engine (degenerate input → sick, never garbage).
+
+// torusMidPlaneDef is the mid-plane of a torus: through its centre, normal to its axis
+// (Inventor's AddByTorusMidPlane).
+type torusMidPlaneDef struct{ face WorkRef }
+
+func (d torusMidPlaneDef) kindName() string { return "torus-midplane" }
+func (d torusMidPlaneDef) refs() []WorkRef  { return []WorkRef{d.face} }
+func (d torusMidPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	s, err := r.surface(d.face)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	t, ok := s.(geom.Torus)
+	if !ok {
+		return sketch.Plane{}, fmt.Errorf("torus mid-plane needs a torus face, got %T", s)
+	}
+	return planeFromOriginNormal(t.Center, t.AxisDir)
+}
+
+// pointAndTangentPlaneDef is the surface's tangent plane at a point on it (Inventor's
+// AddByPointAndTangent): through the point, normal = the surface normal there.
+type pointAndTangentPlaneDef struct{ point, face WorkRef }
+
+func (d pointAndTangentPlaneDef) kindName() string { return "point-tangent" }
+func (d pointAndTangentPlaneDef) refs() []WorkRef  { return []WorkRef{d.point, d.face} }
+func (d pointAndTangentPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	p, err := r.point(d.point)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	s, err := r.surface(d.face)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	n, err := surfaceNormalAtPoint(s, p)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeFromOriginNormal(p, n)
+}
+
+// planeAndTangentPlaneDef is parallel to a reference plane and tangent to the surface
+// (Inventor's AddByPlaneAndTangent). Closed-form for cylinders and spheres; other
+// surfaces report a Sick reason.
+type planeAndTangentPlaneDef struct{ base, face WorkRef }
+
+func (d planeAndTangentPlaneDef) kindName() string { return "plane-tangent" }
+func (d planeAndTangentPlaneDef) refs() []WorkRef  { return []WorkRef{d.base, d.face} }
+func (d planeAndTangentPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	base, err := r.plane(d.base)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	s, err := r.surface(d.face)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeParallelTangent(base, s)
+}
+
+// lineAndTangentPlaneDef holds a line and is tangent to the surface (Inventor's
+// AddByLineAndTangent). Closed-form for a cylindrical face whose axis is parallel to the
+// line (the canonical case — a datum through an edge, tangent to a round); other
+// configurations report a Sick reason.
+type lineAndTangentPlaneDef struct{ line, face WorkRef }
+
+func (d lineAndTangentPlaneDef) kindName() string { return "line-tangent" }
+func (d lineAndTangentPlaneDef) refs() []WorkRef  { return []WorkRef{d.line, d.face} }
+func (d lineAndTangentPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	line, err := r.axis(d.line)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	s, err := r.surface(d.face)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeThroughLineTangent(line, s)
+}
+
+// AddByTorusMidPlane creates the mid-plane of the torus face.
+//
+//	wp := planes.AddByTorusMidPlane(feature.FaceRef(torusFace.ReferenceKey()))
+func (c *WorkPlanes) AddByTorusMidPlane(face WorkRef) *WorkPlane {
+	return c.addUser(torusMidPlaneDef{face: face})
+}
+
+// AddByPointAndTangent creates the tangent plane of a surface at a point on it.
+//
+//	wp := planes.AddByPointAndTangent(p.Key(), feature.FaceRef(cylFace.ReferenceKey()))
+func (c *WorkPlanes) AddByPointAndTangent(point, face WorkRef) *WorkPlane {
+	return c.addUser(pointAndTangentPlaneDef{point: point, face: face})
+}
+
+// AddByPlaneAndTangent creates a plane parallel to base and tangent to the surface
+// (cylinder or sphere).
+//
+//	wp := planes.AddByPlaneAndTangent(feature.OriginXZPlane, feature.FaceRef(cylKey))
+func (c *WorkPlanes) AddByPlaneAndTangent(base, face WorkRef) *WorkPlane {
+	return c.addUser(planeAndTangentPlaneDef{base: base, face: face})
+}
+
+// AddByLineAndTangent creates a plane through line and tangent to the surface (a
+// cylinder whose axis is parallel to the line).
+//
+//	wp := planes.AddByLineAndTangent(edgeAxis.Key(), feature.FaceRef(cylKey))
+func (c *WorkPlanes) AddByLineAndTangent(line, face WorkRef) *WorkPlane {
+	return c.addUser(lineAndTangentPlaneDef{line: line, face: face})
+}
+
+// FaceRef encodes a B-rep face's persistent reference key as a WorkRef, for the
+// surface-tangent constructors above. It is the public spelling of the internal
+// face-reference encoding (work_surface_ref.go).
+func FaceRef(key []byte) WorkRef { return faceRef(key) }
+
+// surfaceNormalAtPoint returns the outward unit normal of an analytic surface at a point
+// lying on it. Each case derives the normal from the surface's axis/centre, so the point
+// need not be parameter-inverted.
+func surfaceNormalAtPoint(s geom.Surface, p math.Point3) (math.UnitVector3, error) {
+	switch g := s.(type) {
+	case geom.Cylinder:
+		return outwardRadial(g.Origin, g.AxisDir, p)
+	case geom.Sphere:
+		return math.UnitVector3FromVector(g.Center.VectorTo(p))
+	case geom.Cone:
+		return coneNormalAtPoint(g, p)
+	case geom.Torus:
+		return torusNormalAtPoint(g, p)
+	default:
+		return math.UnitVector3{}, fmt.Errorf("tangent work plane: unsupported surface %T", s)
+	}
+}
+
+// outwardRadial returns the unit vector from the axis (origin, dir) to p, perpendicular
+// to the axis — the surface normal of a cylinder at p.
+func outwardRadial(origin math.Point3, dir math.UnitVector3, p math.Point3) (math.UnitVector3, error) {
+	rel := origin.VectorTo(p)
+	foot := origin.TranslateBy(dir.AsVector().Scale(rel.Dot(dir.AsVector())))
+	return math.UnitVector3FromVector(foot.VectorTo(p))
+}
+
+// coneNormalAtPoint returns the cone's outward normal at p: cos(half)·radial − sin(half)·axis.
+func coneNormalAtPoint(c geom.Cone, p math.Point3) (math.UnitVector3, error) {
+	radial, err := outwardRadial(c.Apex, c.AxisDir, p)
+	if err != nil {
+		return math.UnitVector3{}, err
+	}
+	cosH, sinH := stdmath.Cos(c.HalfAngle), stdmath.Sin(c.HalfAngle)
+	n := radial.AsVector().Scale(cosH).Sub(c.AxisDir.AsVector().Scale(sinH))
+	return math.UnitVector3FromVector(n)
+}
+
+// torusNormalAtPoint returns the torus normal at p: the unit vector from the nearest
+// tube-centreline point (centre + Major·radial) to p.
+func torusNormalAtPoint(t geom.Torus, p math.Point3) (math.UnitVector3, error) {
+	rel := t.Center.VectorTo(p)
+	planar := rel.Sub(t.AxisDir.AsVector().Scale(rel.Dot(t.AxisDir.AsVector())))
+	radial, err := math.UnitVector3FromVector(planar)
+	if err != nil {
+		return math.UnitVector3{}, fmt.Errorf("torus tangent: point is on the torus axis")
+	}
+	tubeCenter := t.Center.TranslateBy(radial.AsVector().Scale(t.MajorRadius))
+	return math.UnitVector3FromVector(tubeCenter.VectorTo(p))
+}
+
+// planeParallelTangent returns the plane parallel to base (same normal) that is tangent
+// to the surface. For a cylinder the reference normal must be perpendicular to the axis
+// (otherwise no parallel plane is tangent along a line); the tangent point is on the +N
+// side of the axis/centre (the opposite tangent is the −N plane).
+func planeParallelTangent(base sketch.Plane, s geom.Surface) (sketch.Plane, error) {
+	n := base.Normal().AsVector()
+	switch g := s.(type) {
+	case geom.Cylinder:
+		if !math.IsNearZero(n.Dot(g.AxisDir.AsVector()), math.DefaultTolerance) {
+			return sketch.Plane{}, fmt.Errorf("reference plane is not parallel to the cylinder axis")
+		}
+		origin := g.Origin.TranslateBy(n.Scale(g.Radius))
+		return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+	case geom.Sphere:
+		origin := g.Center.TranslateBy(n.Scale(g.Radius))
+		return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+	default:
+		return sketch.Plane{}, fmt.Errorf("plane tangent to a %T is supported for cylinders and spheres only", s)
+	}
+}
+
+// planeThroughLineTangent returns the plane that holds the line and is tangent to the
+// surface. Supported for a cylinder whose axis is parallel to the line; the tangent is
+// solved in the cross-section (a tangent line from the line's projection to the radius
+// circle), so the line must lie outside the cylinder.
+func planeThroughLineTangent(line *WorkAxis, s geom.Surface) (sketch.Plane, error) {
+	g, ok := s.(geom.Cylinder)
+	if !ok {
+		return sketch.Plane{}, fmt.Errorf("tangent-to-line work plane supports cylindrical faces only, got %T", s)
+	}
+	if !line.Direction().IsParallelTo(g.AxisDir, math.DefaultTolerance) {
+		return sketch.Plane{}, fmt.Errorf("the line must be parallel to the cylinder axis")
+	}
+	a := line.Origin()
+	normal, err := cylinderTangentNormal(a, g)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return planeFromOriginNormal(a, normal)
+}
+
+// cylinderTangentNormal returns the normal of the plane that holds the axis-parallel line
+// through a and is tangent to the cylinder — solved in the cross-section as a tangent line
+// from a's projection to the radius circle (the line must lie outside the cylinder).
+func cylinderTangentNormal(a math.Point3, g geom.Cylinder) (math.UnitVector3, error) {
+	rel := g.Origin.VectorTo(a)
+	perp := rel.Sub(g.AxisDir.AsVector().Scale(rel.Dot(g.AxisDir.AsVector())))
+	d := perp.Length()
+	if d < g.Radius-math.DefaultTolerance {
+		return math.UnitVector3{}, fmt.Errorf("the line is inside the cylinder (offset %g < radius %g); no tangent plane", d, g.Radius)
+	}
+	u, err := math.UnitVector3FromVector(perp)
+	if err != nil {
+		return math.UnitVector3{}, fmt.Errorf("the line is on the cylinder axis; the tangent plane is undefined")
+	}
+	w := g.AxisDir.Cross(u)
+	cosA := g.Radius / d
+	sinA := stdmath.Sqrt(stdmath.Max(0, 1-cosA*cosA))
+	return math.UnitVector3FromVector(u.AsVector().Scale(cosA).Add(w.Scale(sinA)))
+}

--- a/model/feature/work_surface_ref.go
+++ b/model/feature/work_surface_ref.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Surface-tangent work planes are built on a B-rep face the user picked, not on
+// another work feature. A face is named by its persistent topological reference key
+// (kernel topo lineage key — the same key dress-up features hold), re-bound to the
+// running body each recompute via FindFaceByKey, so the datum follows the face through
+// upstream edits (parametric-cad §7). To keep work features uniformly addressed by a
+// single [WorkRef], a face key is folded into a WorkRef with a "face/" prefix and a
+// URL-safe base64 of the binary key (RawURLEncoding has no '/' or '+', so it never
+// collides with the WorkRef path separator).
+
+const faceRefPrefix = "face/"
+
+// faceRef encodes a B-rep face reference key as a WorkRef.
+//
+//	wp := planes.AddByTorusMidPlane(faceRef(face.ReferenceKey()))
+func faceRef(key []byte) WorkRef {
+	return WorkRef(faceRefPrefix + base64.RawURLEncoding.EncodeToString(key))
+}
+
+// parseFaceRef decodes a face WorkRef back to its binary reference key. The bool is
+// false when ref is not a face reference (so callers can distinguish "not a face" from
+// a corrupt key, which is returned as an error).
+func parseFaceRef(ref WorkRef) ([]byte, bool, error) {
+	s := string(ref)
+	if !strings.HasPrefix(s, faceRefPrefix) {
+		return nil, false, nil
+	}
+	key, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(s, faceRefPrefix))
+	if err != nil {
+		return nil, true, fmt.Errorf("work geometry: corrupt face reference %q: %w", ref, err)
+	}
+	return key, true, nil
+}
+
+// surface resolves a face WorkRef to its surface geometry by re-binding the reference
+// key against the running body. It errors if ref is not a face reference, if no body
+// has been built yet, or if the key no longer binds (the face was removed upstream) —
+// the last case is what makes a tangent work plane go Sick and surface for re-selection.
+func (g *WorkGeometry) surface(ref WorkRef) (geom.Surface, error) {
+	key, isFace, err := parseFaceRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	if !isFace {
+		return nil, fmt.Errorf("work geometry: %q is not a face reference", ref)
+	}
+	if len(g.bodies) == 0 {
+		return nil, fmt.Errorf("work geometry: no body yet to resolve face %q", ref)
+	}
+	for _, b := range g.bodies {
+		if f, ok := b.FindFaceByKey(key); ok {
+			return f.Geometry(), nil
+		}
+	}
+	return nil, fmt.Errorf("work geometry: face reference %q is lost", ref)
+}
+
+const vertexRefPrefix = "vertex/"
+
+// VertexRef encodes a B-rep vertex's reference key as a point WorkRef, so a picked solid
+// vertex can be a point input to a work feature (e.g. a three-point plane through three
+// model vertices). Resolved against the running body, like a face reference.
+func VertexRef(key []byte) WorkRef {
+	return WorkRef(vertexRefPrefix + base64.RawURLEncoding.EncodeToString(key))
+}
+
+// vertexPoint resolves a vertex WorkRef to its position against the running body. The
+// bool is false when ref is not a vertex reference (so [WorkGeometry.point] can fall
+// through to its other reference kinds); a vertex reference that no longer binds is an
+// error (the work feature then goes Sick).
+func (g *WorkGeometry) vertexPoint(ref WorkRef) (math.Point3, bool, error) {
+	s := string(ref)
+	if !strings.HasPrefix(s, vertexRefPrefix) {
+		return math.Point3{}, false, nil
+	}
+	key, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(s, vertexRefPrefix))
+	if err != nil {
+		return math.Point3{}, true, fmt.Errorf("work geometry: corrupt vertex reference %q: %w", ref, err)
+	}
+	for _, b := range g.bodies {
+		if v, ok := b.FindVertexByKey(key); ok {
+			return v.Point(), true, nil
+		}
+	}
+	return math.Point3{}, true, fmt.Errorf("work geometry: vertex reference %q is lost", ref)
+}

--- a/theme/defaults.go
+++ b/theme/defaults.go
@@ -56,6 +56,7 @@ var darkHex = map[string]string{
 	string(types.TokenPlaneFaint):         "#738099ff", // plane_overlay.go faintPlaneColor
 	string(types.TokenPlaneHover):         "#ffb333ff", // plane_overlay.go hoverPlaneColor
 	string(types.TokenPlaneSelected):      "#4dd9ffff", // plane_overlay.go selectedPlaneColor
+	string(types.TokenPlaneFill):          "#73809933", // plane_overlay.go translucent plane fill
 	string(types.TokenSelectionHighlight): "#4dd9ffff", // highlight.go selectionHighlight
 	// Icons (pre-theming head values)
 	string(types.TokenIconTint):     "#d9dee6ff", // icon_cache.go iconTint
@@ -97,6 +98,7 @@ var lightHex = map[string]string{
 	string(types.TokenPlaneFaint):         "#8c99adff",
 	string(types.TokenPlaneHover):         "#d98a00ff",
 	string(types.TokenPlaneSelected):      "#0a84c7ff",
+	string(types.TokenPlaneFill):          "#5a6b8533",
 	string(types.TokenSelectionHighlight): "#0a84c7ff",
 	// Icons
 	string(types.TokenIconTint):     "#3a3f49ff",

--- a/theme/token.go
+++ b/theme/token.go
@@ -83,6 +83,7 @@ var tokenInfos = map[Token]TokenInfo{
 	types.TokenPlaneFaint:          {types.TokenPlaneFaint, "Work plane", GroupGizmos},
 	types.TokenPlaneHover:          {types.TokenPlaneHover, "Work plane (hover)", GroupGizmos},
 	types.TokenPlaneSelected:       {types.TokenPlaneSelected, "Work plane (selected)", GroupGizmos},
+	types.TokenPlaneFill:           {types.TokenPlaneFill, "Work plane fill (alpha = opacity)", GroupGizmos},
 	types.TokenSelectionHighlight:  {types.TokenSelectionHighlight, "Selection highlight", GroupGizmos},
 	types.TokenIconTint:            {types.TokenIconTint, "Icon tint", GroupIcons},
 	types.TokenIconDisabled:        {types.TokenIconDisabled, "Icon (disabled)", GroupIcons},


### PR DESCRIPTION
## What

Builds work planes end to end — kernel/model → API → ribbon — to match Inventor's datum-plane workflow. Implements the contract added in Oblikovati.API#4 (merged).

**Model**
- All **12 WorkPlanes constructors**: reference-model (AddFixed, PlaneAndPoint, TwoPlanes, LinePlaneAndAngle, TwoLines, NormalToCurve) + surface-tangent (PointAndTangent, PlaneAndTangent, LineAndTangent, TorusMidPlane), each round-tripping through the `.obk` recipe.
- Tangent planes resolve a picked B-rep **face** by reference key against the running body; `WorkGeometry.Recompute` runs before **and** after the feature program so tangents see the freshly built solid. B-rep **vertices** are resolvable as point references (three-point planes on model corners).
- Per-plane **visibility** property.

**API host** (`addin/router`): `workPlanes.list` / `workPlanes.create` handlers keyed on the wire contract; `model.selection` returns each entity's reference.

**Head / app UI**
- 3D Model **Work Features** ribbon panel. Every button is always live and starts a guided pick when nothing is pre-selected. **Offset opens a distance dialog** (no longer drops a plane at a fixed offset).
- Selection of work points/axes and B-rep faces/vertices; the ray-picker snaps to datum points and axes; the browser lists the full origin frame and user datums.
- Work planes render as a **translucent filled square + border** (not wireframe); fill albedo/opacity is the `gizmo.plane_fill` theme token, and alpha blending is enabled in the Vulkan pipeline. **Visibility** toggles from the browser menu and the **V** shortcut.

## Why

The previous build had only 2 of Inventor's 12 constructors, no UI to create work planes, and created planes were invisible. This closes the gap so datum planes are fully usable from the ribbon and the automation API.

## Notes / follow-ups

- The **V** visibility shortcut is the Autodesk Fusion convention — Inventor has no default visibility hotkey. Easy to rebind.
- Plane-tangent is closed-form for cylinder/sphere; line-tangent for a cylinder with the line parallel to its axis — other surface sub-cases report Sick rather than guessing.
- Visibility is in-session only (not yet persisted to `.obk`).

## Testing

`go build ./...` (incl. the cgo head), `go vet`, and the full `go test ./...` suite pass; gofmt + SPDX clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)