### PR TITLE
Extrude: full extent modes, direction, two-direction, taper, options window

### DIFF
--- a/addin/opregistry/extrude.go
+++ b/addin/opregistry/extrude.go
@@ -19,10 +19,14 @@ import (
 
 // extrudeArgs is the argument shape for the "extrude" operation (mirrors the schema).
 type extrudeArgs struct {
-	SketchIndex  int    `json:"sketchIndex"`
-	ProfileIndex int    `json:"profileIndex"`
-	Distance     string `json:"distance"`  // e.g. "50 mm", "5 cm"
-	Operation    string `json:"operation"` // join|cut|intersect|new (default new)
+	SketchIndex    int    `json:"sketchIndex"`
+	ProfileIndex   int    `json:"profileIndex"`
+	Distance       string `json:"distance"`                 // e.g. "50 mm", "5 cm"
+	Operation      string `json:"operation"`                // join|cut|intersect|new (default new)
+	Extent         string `json:"extent,omitempty"`         // distance|through-all|to-next (default distance)
+	Direction      string `json:"direction,omitempty"`      // positive|negative|symmetric (default positive)
+	SecondDistance string `json:"secondDistance,omitempty"` // asymmetric two-direction depth
+	Taper          string `json:"taper,omitempty"`          // draft angle, e.g. "3 deg"
 }
 
 // extrudeResult reports the created feature and the resulting body count.
@@ -37,10 +41,14 @@ const extrudeSchema = `{
   "properties": {
     "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch to extrude (see model.tree)."},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which closed profile of the sketch to extrude."},
-    "distance": {"type": "string", "description": "Extrude depth with units, e.g. \"50 mm\" or \"5 cm\"."},
-    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new", "description": "Boolean against existing bodies."}
+    "distance": {"type": "string", "description": "Extrude depth with units, e.g. \"50 mm\" or \"5 cm\". Required for distance and distance-from-face extents."},
+    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new", "description": "Boolean against existing bodies."},
+    "extent": {"type": "string", "enum": ["distance", "through-all", "to-next"], "default": "distance", "description": "How the extrude terminates."},
+    "direction": {"type": "string", "enum": ["positive", "negative", "symmetric"], "default": "positive", "description": "Which side(s) of the sketch plane to grow."},
+    "secondDistance": {"type": "string", "description": "Asymmetric two-direction depth on the negative side, e.g. \"10 mm\"."},
+    "taper": {"type": "string", "description": "Draft angle, e.g. \"3 deg\" (positive widens away from the sketch)."}
   },
-  "required": ["sketchIndex", "distance"]
+  "required": ["sketchIndex"]
 }`
 
 // extrudeDescriptor is the self-describing "extrude" operation: turn a closed sketch
@@ -60,39 +68,110 @@ func applyExtrude(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	in, sk, op, depth, err := resolveExtrude(part, raw)
+	in, sk, extent, op, taper, err := resolveExtrude(part, raw)
 	if err != nil {
 		return nil, err
 	}
 	pf := feature.NewExtrudeFeatures(part.Features()).
-		AddByDistanceExtent(sk, in.ProfileIndex, op, func() float64 { return depth })
+		AddExtrude(sk, []int{in.ProfileIndex}, op, extent, taper)
 	part.Recompute()
 	return json.Marshal(extrudeResult{Feature: pf.Name(), Kind: pf.Kind(), Bodies: len(part.SurfaceBodies().All())})
 }
 
 // resolveExtrude decodes and validates the extrude args against the part: the target
-// sketch, the boolean operation, and the extent distance in database units.
-func resolveExtrude(part *compdef.PartComponentDefinition, raw json.RawMessage) (extrudeArgs, *sketch.Sketch, ops.PartFeatureOperation, float64, error) {
+// sketch, the boolean operation, the full extent (type/direction/distances), and the
+// taper, in database units.
+func resolveExtrude(part *compdef.PartComponentDefinition, raw json.RawMessage) (extrudeArgs, *sketch.Sketch, feature.Extent, ops.PartFeatureOperation, float64, error) {
 	var in extrudeArgs
 	if err := json.Unmarshal(raw, &in); err != nil {
-		return in, nil, 0, 0, fmt.Errorf("extrude: invalid args: %w", err)
+		return in, nil, feature.Extent{}, 0, 0, fmt.Errorf("extrude: invalid args: %w", err)
 	}
 	sk, err := sketchAt(part, in.SketchIndex)
 	if err != nil {
-		return in, nil, 0, 0, err
+		return in, nil, feature.Extent{}, 0, 0, err
 	}
 	op, err := parseOperation(in.Operation)
 	if err != nil {
-		return in, nil, 0, 0, err
+		return in, nil, feature.Extent{}, 0, 0, err
 	}
-	dist, err := part.Units().Parse(in.Distance, param.Length)
+	extent, err := buildExtent(part, in)
 	if err != nil {
-		return in, nil, 0, 0, fmt.Errorf("extrude: distance %q: %w", in.Distance, err)
+		return in, nil, feature.Extent{}, 0, 0, err
 	}
-	if dist.Value == 0 {
-		return in, nil, 0, 0, errors.New("extrude: distance is zero")
+	taper, err := parseTaperAngle(part, in.Taper)
+	if err != nil {
+		return in, nil, feature.Extent{}, 0, 0, err
 	}
-	return in, sk, op, dist.Value, nil
+	return in, sk, extent, op, taper, nil
+}
+
+// buildExtent assembles the model extent from the request: the extent type and direction,
+// plus the distance(s) for the distance extent.
+func buildExtent(part *compdef.PartComponentDefinition, in extrudeArgs) (feature.Extent, error) {
+	etype, err := parseExtentType(in.Extent)
+	if err != nil {
+		return feature.Extent{}, err
+	}
+	ext := feature.Extent{Type: etype, Direction: parseExtentDirection(in.Direction)}
+	if etype != feature.DistanceExtent {
+		return ext, nil // through-all / to-next are gauged from the model, not a distance
+	}
+	d, err := part.Units().Parse(in.Distance, param.Length)
+	if err != nil {
+		return feature.Extent{}, fmt.Errorf("extrude: distance %q: %w", in.Distance, err)
+	}
+	if d.Value == 0 {
+		return feature.Extent{}, errors.New("extrude: distance is zero")
+	}
+	ext.Distance = func() float64 { return d.Value }
+	if in.SecondDistance != "" {
+		d2, err := part.Units().Parse(in.SecondDistance, param.Length)
+		if err != nil {
+			return feature.Extent{}, fmt.Errorf("extrude: secondDistance %q: %w", in.SecondDistance, err)
+		}
+		ext.Distance2 = func() float64 { return d2.Value }
+	}
+	return ext, nil
+}
+
+// parseTaperAngle parses an optional draft angle ("" ⇒ no taper).
+func parseTaperAngle(part *compdef.PartComponentDefinition, expr string) (float64, error) {
+	if strings.TrimSpace(expr) == "" {
+		return 0, nil
+	}
+	a, err := part.Units().Parse(expr, param.Angle)
+	if err != nil {
+		return 0, fmt.Errorf("extrude: taper %q: %w", expr, err)
+	}
+	return a.Value, nil
+}
+
+// parseExtentType maps an extent name to its model type (empty ⇒ distance). Reference
+// extents (to-face / from-to / distance-from-face) need a target plane and are not yet
+// exposed over the JSON API.
+func parseExtentType(name string) (feature.ExtentType, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "distance":
+		return feature.DistanceExtent, nil
+	case "through-all", "throughall":
+		return feature.ThroughAllExtent, nil
+	case "to-next", "tonext":
+		return feature.ToNextExtent, nil
+	default:
+		return 0, fmt.Errorf("extrude: unknown extent %q (want distance|through-all|to-next)", name)
+	}
+}
+
+// parseExtentDirection maps a direction name to its model value (empty/unknown ⇒ positive).
+func parseExtentDirection(name string) feature.ExtentDirection {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "negative":
+		return feature.NegativeDir
+	case "symmetric":
+		return feature.SymmetricDir
+	default:
+		return feature.PositiveDir
+	}
 }
 
 // sketchAt returns the part's sketch at index i, bounds-checked.

--- a/addin/router/extrude_modes_test.go
+++ b/addin/router/extrude_modes_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import "testing"
+
+// extrudeBodies is the slimmed result shape of a features.add extrude call.
+type extrudeBodies struct {
+	Bodies int `json:"bodies"`
+}
+
+func TestExtrudeSymmetricDirectionViaAPI(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var sk struct {
+		SketchIndex int `json:"sketchIndex"`
+	}
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &sk)
+	var rect struct {
+		Profiles int `json:"profiles"`
+	}
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &rect)
+
+	var ext extrudeBodies
+	call(t, r, s, "features.add",
+		`{"kind":"extrude","args":{"sketchIndex":0,"distance":"50 mm","direction":"symmetric","taper":"3 deg"}}`, &ext)
+	if ext.Bodies != 1 {
+		t.Fatalf("symmetric extrude via API produced %d bodies, want 1", ext.Bodies)
+	}
+}
+
+func TestExtrudeUnknownExtentRejectedByAPI(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"10 mm","height":"10 mm"}`, &struct{}{})
+	if _, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"extrude","args":{"sketchIndex":0,"distance":"5 mm","extent":"nonsense"}}`)); err == nil {
+		t.Error("expected an error for an unknown extent")
+	}
+}

--- a/app/extrude_modes_test.go
+++ b/app/extrude_modes_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// squareRegion adds a 2×2 square sketch to the part and recomputes so its profile is
+// detected, returning the sketch.
+func squareRegion(def *compdef.PartComponentDefinition) *sketch.Sketch {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(-1, -1))
+	c1 := sk.Points().Add(math.P2(1, -1))
+	c2 := sk.Points().Add(math.P2(1, 1))
+	c3 := sk.Points().Add(math.P2(-1, 1))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	def.Recompute()
+	return sk
+}
+
+func TestExtrudeToolSymmetricExtentFlowsToGeometry(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := squareRegion(def)
+	tool := NewExtrudeTool()
+	s.StartTool(tool)
+	tool.Pick(s, ProfileHandle{Sketch: sk, ProfileIndex: 0})
+	tool.SetDirection(feature.SymmetricDir)
+	tool.SetDistance(6) // model units (cm)
+	if !tool.CanCommit() {
+		t.Fatal("tool should be committable with a region and distance")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) != 1 {
+		t.Fatalf("got %d bodies, want 1", len(bodies))
+	}
+	// Symmetric distance 6 → the solid spans z ∈ [-3, 3].
+	lo, hi := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range bodies[0].Vertices() {
+		z := float64(v.Point().Z)
+		lo, hi = stdmath.Min(lo, z), stdmath.Max(hi, z)
+	}
+	if stdmath.Abs(lo+3) > 1e-9 || stdmath.Abs(hi-3) > 1e-9 {
+		t.Errorf("symmetric extrude z-range = [%g,%g], want [-3,3]", lo, hi)
+	}
+}
+
+func TestExtrudeToolThroughAllNeedsNoDistance(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := squareRegion(def)
+	tool := NewExtrudeTool()
+	s.StartTool(tool)
+	tool.Pick(s, ProfileHandle{Sketch: sk, ProfileIndex: 0})
+	tool.SetExtentType(feature.ThroughAllExtent)
+	// Through-all is gauged from the model, so no distance is required to commit.
+	if !tool.CanCommit() {
+		t.Error("through-all extrude should be committable without a distance")
+	}
+}

--- a/app/extrude_session.go
+++ b/app/extrude_session.go
@@ -42,3 +42,41 @@ func (s *Session) SetExtrudeDistanceDisplay(value float64) {
 func (s *Session) LengthUnitName() string {
 	return s.DocumentUnits().PreferredName(param.Length)
 }
+
+// AngleUnitName returns the document's preferred angle-unit name (e.g. "deg"), to label
+// the taper field.
+func (s *Session) AngleUnitName() string {
+	return s.DocumentUnits().PreferredName(param.Angle)
+}
+
+// ExtrudeSecondDistanceDisplay / SetExtrudeSecondDistanceDisplay read/write the active
+// extrude's asymmetric second-direction depth in the document's length unit.
+func (s *Session) ExtrudeSecondDistanceDisplay() float64 {
+	ext := s.ActiveExtrude()
+	if ext == nil {
+		return 0
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(ext.SecondDistance(), param.Length))
+}
+
+func (s *Session) SetExtrudeSecondDistanceDisplay(value float64) {
+	if ext := s.ActiveExtrude(); ext != nil {
+		ext.SetSecondDistance(s.DocumentUnits().FromPreferred(value, param.Length).Value)
+	}
+}
+
+// ExtrudeTaperDisplay / SetExtrudeTaperDisplay read/write the active extrude's draft
+// taper in the document's angle unit (e.g. degrees).
+func (s *Session) ExtrudeTaperDisplay() float64 {
+	ext := s.ActiveExtrude()
+	if ext == nil {
+		return 0
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(ext.Taper(), param.Angle))
+}
+
+func (s *Session) SetExtrudeTaperDisplay(value float64) {
+	if ext := s.ActiveExtrude(); ext != nil {
+		ext.SetTaper(s.DocumentUnits().FromPreferred(value, param.Angle).Value)
+	}
+}

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -19,15 +19,21 @@ import (
 // Inventor extrude flow, driven entirely by session input so a test exercises it with
 // synthetic clicks. It is the worked example proving geometry flows end to end.
 type ExtrudeTool struct {
-	profiles  []ProfileHandle
-	distance  float64
-	operation ops.PartFeatureOperation
-	added     *feature.PartFeature
+	profiles   []ProfileHandle
+	distance   float64 // primary depth, model units
+	distance2  float64 // asymmetric second-direction depth, model units
+	taper      float64 // draft angle, radians
+	extent     feature.ExtentType
+	direction  feature.ExtentDirection
+	asymmetric bool
+	operation  ops.PartFeatureOperation
+	added      *feature.PartFeature
 }
 
-// NewExtrudeTool returns an extrude tool defaulting to a new-body extrusion.
+// NewExtrudeTool returns an extrude tool defaulting to a positive distance extrusion that
+// creates a new body.
 func NewExtrudeTool() *ExtrudeTool {
-	return &ExtrudeTool{operation: ops.NewBody}
+	return &ExtrudeTool{operation: ops.NewBody, extent: feature.DistanceExtent, direction: feature.PositiveDir}
 }
 
 // Name implements [Tool].
@@ -81,6 +87,39 @@ func (t *ExtrudeTool) SetDistance(d float64) { t.distance = d }
 // Distance returns the current extrusion distance (database units).
 func (t *ExtrudeTool) Distance() float64 { return t.distance }
 
+// The extrude options the dialog drives: extent type, direction, the asymmetric
+// second-direction depth, and the draft taper. All values are database units / radians.
+func (t *ExtrudeTool) SetExtentType(e feature.ExtentType)     { t.extent = e }
+func (t *ExtrudeTool) ExtentType() feature.ExtentType         { return t.extent }
+func (t *ExtrudeTool) SetDirection(d feature.ExtentDirection) { t.direction = d }
+func (t *ExtrudeTool) Direction() feature.ExtentDirection     { return t.direction }
+func (t *ExtrudeTool) SetAsymmetric(on bool)                  { t.asymmetric = on }
+func (t *ExtrudeTool) Asymmetric() bool                       { return t.asymmetric }
+func (t *ExtrudeTool) SetSecondDistance(d float64)            { t.distance2 = d }
+func (t *ExtrudeTool) SecondDistance() float64                { return t.distance2 }
+func (t *ExtrudeTool) SetTaper(radians float64)               { t.taper = radians }
+func (t *ExtrudeTool) Taper() float64                         { return t.taper }
+
+// needsDistance reports whether the current extent is gauged by the distance field (vs.
+// measured from the model, like through-all / to-next).
+func (t *ExtrudeTool) needsDistance() bool {
+	return t.extent == feature.DistanceExtent || t.extent == feature.DistanceFromFaceExtent
+}
+
+// buildExtent assembles the model extent from the tool's option state.
+func (t *ExtrudeTool) buildExtent() feature.Extent {
+	ext := feature.Extent{Type: t.extent, Direction: t.direction}
+	if t.needsDistance() {
+		d := t.distance
+		ext.Distance = func() float64 { return d }
+		if t.asymmetric {
+			d2 := t.distance2
+			ext.Distance2 = func() float64 { return d2 }
+		}
+	}
+	return ext
+}
+
 // PickedProfiles returns the regions the user has picked (in click order), for the UI
 // to highlight. Empty until the first pick.
 func (t *ExtrudeTool) PickedProfiles() []ProfileHandle {
@@ -96,11 +135,15 @@ func (t *ExtrudeTool) PickedProfile() (ProfileHandle, bool) {
 	return t.profiles[0], true
 }
 
-// SetOperation chooses join/cut/intersect/new-body.
+// SetOperation chooses join/cut/intersect/new-body; Operation returns the current choice.
 func (t *ExtrudeTool) SetOperation(op ops.PartFeatureOperation) { t.operation = op }
+func (t *ExtrudeTool) Operation() ops.PartFeatureOperation      { return t.operation }
 
-// CanCommit reports whether at least one region and a non-zero distance are gathered.
-func (t *ExtrudeTool) CanCommit() bool { return len(t.profiles) > 0 && t.distance != 0 }
+// CanCommit reports whether enough input is gathered: at least one region, and — for a
+// distance-gauged extent — a non-zero distance.
+func (t *ExtrudeTool) CanCommit() bool {
+	return len(t.profiles) > 0 && (!t.needsDistance() || t.distance != 0)
+}
 
 // Commit adds the extrude feature to the active part and recomputes; a sick feature
 // (e.g. an open profile) keeps the tool open by returning an error. All picked regions
@@ -113,9 +156,8 @@ func (t *ExtrudeTool) Commit(s *Session) error {
 	}
 	skt := t.profiles[0].Sketch
 	indices := profileIndicesOn(t.profiles, skt)
-	dist := t.distance
 	t.added = feature.NewExtrudeFeatures(part.Features()).
-		AddByDistanceExtentProfiles(skt, indices, t.operation, func() float64 { return dist })
+		AddExtrude(skt, indices, t.operation, t.buildExtent(), t.taper)
 	part.Recompute()
 	if !t.added.Health().OK() {
 		return errors.New("extrude: " + t.added.Health().Reason)
@@ -143,10 +185,10 @@ func (t *ExtrudeTool) Prompt(*Session) string {
 	switch {
 	case len(t.profiles) == 0:
 		return "Select a region to extrude (Ctrl+click to add more)"
-	case t.distance == 0:
+	case t.needsDistance() && t.distance == 0:
 		return "Specify the extrude distance"
 	default:
-		return "Click OK to create the extrusion"
+		return "Set the extrude options and click OK"
 	}
 }
 
@@ -155,7 +197,9 @@ func (t *ExtrudeTool) Prompt(*Session) string {
 // shows a live preview before OK (Inventor's in-canvas preview). Empty until a region
 // and distance are set.
 func (t *ExtrudeTool) Preview(*Session) []renderer.DrawItem {
-	if !t.CanCommit() {
+	// Preview the swept prism only for a distance extent; model-gauged extents
+	// (through-all / to-next) have no fixed depth to draw until commit.
+	if len(t.profiles) == 0 || !t.needsDistance() || t.distance == 0 {
 		return nil
 	}
 	var items []renderer.DrawItem

--- a/app/statusbar_test.go
+++ b/app/statusbar_test.go
@@ -28,7 +28,7 @@ func TestBuildStatusGuidesExtrude(t *testing.T) {
 	s.Click(120, 90) // synthetic click picks the profile
 	ext.SetDistance(5)
 	sb = BuildStatus(s)
-	if !sb.CanCommit || sb.Prompt != "Click OK to create the extrusion" {
+	if !sb.CanCommit || sb.Prompt != "Set the extrude options and click OK" {
 		t.Errorf("after profile + distance: %+v, want committable OK prompt", sb)
 	}
 }

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -9,57 +9,171 @@ import (
 
 	"github.com/Oblikovati/oblikovati/app"
 	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
-// The Extrude flow in the head: while the Extrude tool runs, a small dialog lets the
-// user type a distance and OK/Cancel, and the picked profile is highlighted in the
-// viewport (with a live prism preview once a distance is set). Without this the tool
-// could capture a profile but never set a distance, so OK stayed disabled and extrude
-// looked broken. The distance is in the document's length unit (e.g. mm).
+// The Extrude flow in the head: while the Extrude tool runs, a modeless options window
+// (Inventor's Extrude property panel) lets the user pick the operation, the extent and
+// direction, the distance(s) and a draft taper, then OK/Cancel — and the picked profile is
+// highlighted in the viewport with a live prism preview. Distances are in the document's
+// length unit (e.g. mm), the taper in its angle unit (e.g. deg).
 
-// extrudeUI holds the dialog's distance field across frames and whether the dialog was
-// open last frame (so it seeds the field once when the tool opens).
+// extrudeUI holds the dialog's editable fields across frames and whether the dialog was
+// open last frame (so it seeds the fields once when the tool opens).
 var extrudeUI = struct {
-	distance float32
-	open     bool
+	distance, second, taper float32
+	open                    bool
 }{distance: 10}
 
-// drawExtrudeDialog shows the distance editor while the Extrude tool is active and keeps
-// the tool's distance in sync with the field each frame; OK commits, Cancel aborts.
+// drawExtrudeDialog shows the extrude options window while the Extrude tool is active,
+// syncing each control with the tool every frame; OK commits, Cancel aborts.
 func drawExtrudeDialog(s *app.Session) {
 	ext := s.ActiveExtrude()
 	if ext == nil {
 		extrudeUI.open = false
 		return
 	}
-	if !extrudeUI.open { // tool just opened — seed the field from its current distance
-		if d := s.ExtrudeDistanceDisplay(); d > 0 {
-			extrudeUI.distance = float32(d)
-		}
+	if !extrudeUI.open { // tool just opened — seed the fields from its current state
+		seedExtrudeFields(s)
 		extrudeUI.open = true
 	}
-	native.SetNextWindowSize(280, 132)
+	native.SetNextWindowSize(300, 300)
 	if native.Begin("Extrude") {
-		if n := len(ext.PickedProfiles()); n == 0 {
-			native.Text("Click a region to extrude (Ctrl+click to add more)")
-		} else if n > 1 {
-			native.Text("Extruding " + strconv.Itoa(n) + " regions")
-		}
-		native.Text("Distance (" + s.LengthUnitName() + ")")
-		native.InputFloat("##extrude-distance", &extrudeUI.distance)
-		s.SetExtrudeDistanceDisplay(float64(extrudeUI.distance)) // keep the tool in sync
-		native.BeginDisabled(!ext.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK() // a failed commit (e.g. open profile) keeps the tool open
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawExtrudeProfileText(ext)
+		extrudeOperationCombo(ext)
+		extrudeExtentCombo(ext)
+		extrudeDirectionCombo(ext)
+		drawExtrudeDistances(s, ext)
+		drawExtrudeTaper(s)
+		drawExtrudeButtons(s, ext)
 	}
 	native.End()
+}
+
+// seedExtrudeFields copies the tool's current distance/second/taper into the dialog fields.
+func seedExtrudeFields(s *app.Session) {
+	if d := s.ExtrudeDistanceDisplay(); d > 0 {
+		extrudeUI.distance = float32(d)
+	}
+	extrudeUI.second = float32(s.ExtrudeSecondDistanceDisplay())
+	extrudeUI.taper = float32(s.ExtrudeTaperDisplay())
+}
+
+func drawExtrudeProfileText(ext *app.ExtrudeTool) {
+	switch n := len(ext.PickedProfiles()); {
+	case n == 0:
+		native.Text("Click a region to extrude (Ctrl+click to add more)")
+	case n > 1:
+		native.Text("Extruding " + strconv.Itoa(n) + " regions")
+	}
+}
+
+// extrudeOperations / extrudeExtents / extrudeDirections name each enum value for its
+// combo, paired with the value the dialog writes back to the tool.
+var extrudeOperations = []struct {
+	label string
+	op    ops.PartFeatureOperation
+}{{"New Solid", ops.NewBody}, {"Join", ops.Join}, {"Cut", ops.Cut}, {"Intersect", ops.Intersect}}
+
+var extrudeExtents = []struct {
+	label string
+	t     feature.ExtentType
+}{{"Distance", feature.DistanceExtent}, {"Through All", feature.ThroughAllExtent}, {"To Next", feature.ToNextExtent}}
+
+var extrudeDirections = []struct {
+	label string
+	d     feature.ExtentDirection
+}{{"Default", feature.PositiveDir}, {"Flipped", feature.NegativeDir}, {"Symmetric", feature.SymmetricDir}}
+
+func extrudeOperationCombo(ext *app.ExtrudeTool) {
+	preview := "New Solid"
+	for _, o := range extrudeOperations {
+		if o.op == ext.Operation() {
+			preview = o.label
+		}
+	}
+	if native.BeginCombo("Output", preview) {
+		for _, o := range extrudeOperations {
+			if native.Selectable(o.label, o.op == ext.Operation()) {
+				ext.SetOperation(o.op)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+func extrudeExtentCombo(ext *app.ExtrudeTool) {
+	preview := "Distance"
+	for _, e := range extrudeExtents {
+		if e.t == ext.ExtentType() {
+			preview = e.label
+		}
+	}
+	if native.BeginCombo("Extents", preview) {
+		for _, e := range extrudeExtents {
+			if native.Selectable(e.label, e.t == ext.ExtentType()) {
+				ext.SetExtentType(e.t)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+func extrudeDirectionCombo(ext *app.ExtrudeTool) {
+	preview := "Default"
+	for _, d := range extrudeDirections {
+		if d.d == ext.Direction() {
+			preview = d.label
+		}
+	}
+	if native.BeginCombo("Direction", preview) {
+		for _, d := range extrudeDirections {
+			if native.Selectable(d.label, d.d == ext.Direction()) {
+				ext.SetDirection(d.d)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+// drawExtrudeDistances shows the distance field for distance-gauged extents, plus an
+// asymmetric two-direction toggle and its second-distance field.
+func drawExtrudeDistances(s *app.Session, ext *app.ExtrudeTool) {
+	if ext.ExtentType() != feature.DistanceExtent {
+		return
+	}
+	native.Text("Distance (" + s.LengthUnitName() + ")")
+	native.InputFloat("##extrude-distance", &extrudeUI.distance)
+	s.SetExtrudeDistanceDisplay(float64(extrudeUI.distance))
+	asym := ext.Asymmetric()
+	if native.Checkbox("Two directions", &asym) {
+		ext.SetAsymmetric(asym)
+	}
+	if asym {
+		native.Text("Second distance (" + s.LengthUnitName() + ")")
+		native.InputFloat("##extrude-second", &extrudeUI.second)
+		s.SetExtrudeSecondDistanceDisplay(float64(extrudeUI.second))
+	}
+}
+
+func drawExtrudeTaper(s *app.Session) {
+	native.Text("Taper (" + s.AngleUnitName() + ")")
+	native.InputFloat("##extrude-taper", &extrudeUI.taper)
+	s.SetExtrudeTaperDisplay(float64(extrudeUI.taper))
+}
+
+func drawExtrudeButtons(s *app.Session, ext *app.ExtrudeTool) {
+	native.BeginDisabled(!ext.CanCommit())
+	if native.Button("OK") {
+		_ = s.OK() // a failed commit (e.g. open profile) keeps the tool open
+	}
+	native.EndDisabled()
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelTool()
+	}
 }
 
 // extrudeProfileHighlight outlines every region picked for extrude (and their holes) in

--- a/model/feature/dressup_test.go
+++ b/model/feature/dressup_test.go
@@ -13,7 +13,7 @@ import (
 
 // prismBody builds a unit-square prism via the extrude generator (for real edges).
 func prismBody() *topo.Body {
-	return buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 1}}, sketch.XYPlane(), 1, "ext")
+	return buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 1}}, sketch.XYPlane(), span{near: 0, far: 1}, 0, "ext")
 }
 
 func TestFilletResolvesEdgeThenDefers(t *testing.T) {

--- a/model/feature/extent.go
+++ b/model/feature/extent.go
@@ -16,6 +16,8 @@ const (
 	ToFaceExtent
 	// FromToExtent: between two selected faces/work-planes.
 	FromToExtent
+	// DistanceFromFaceExtent: a distance measured from a selected face/work-plane.
+	DistanceFromFaceExtent
 )
 
 // ExtentDirection is which way a feature grows — the PartFeatureExtentDirectionEnum.
@@ -31,22 +33,36 @@ const (
 )
 
 // Extent describes a sketched feature's termination. Distance is a closure so the
-// extent tracks its driving parameter; the to-face/from-to reference inputs are
-// modeled as [Ref]s, resolved at recompute (used once those terminations generate
-// geometry, kernel phase B+).
+// extent tracks its driving parameter. Distance2 (when set) makes the extrude
+// asymmetric — Distance grows the positive side, Distance2 the negative side
+// (Inventor's two-direction extrude). The to/from terminations reference a work plane
+// (resolved like a revolve axis), used by the to-face / from-to / distance-from-face
+// modes; the geometry currently requires the target parallel to the sketch plane (a
+// flat cap), angled/curved trims being kernel phase C.
 type Extent struct {
 	Type      ExtentType
 	Direction ExtentDirection
 	Distance  func() float64
-	ToFace    Ref
-	FromFace  Ref
+	Distance2 func() float64 // asymmetric second-direction distance (nil ⇒ single direction)
+	ToPlane   *WorkPlane     // to-face / distance-from-face target (and the "to" of from-to)
+	FromPlane *WorkPlane     // from-to start
 }
 
-// signedDistance returns the growth distance for the positive side, honoring the
-// direction (symmetric returns the half-distance applied each way by the caller).
+// distance returns the primary growth distance (0 when unset).
 func (e Extent) distance() float64 {
 	if e.Distance == nil {
 		return 0
 	}
 	return e.Distance()
 }
+
+// distance2 returns the second-direction distance (0 when unset).
+func (e Extent) distance2() float64 {
+	if e.Distance2 == nil {
+		return 0
+	}
+	return e.Distance2()
+}
+
+// isAsymmetric reports whether a distinct second-direction distance is set.
+func (e Extent) isAsymmetric() bool { return e.Distance2 != nil }

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -5,8 +5,8 @@ package feature
 import (
 	"errors"
 	"fmt"
+	stdmath "math"
 
-	"github.com/Oblikovati/oblikovati/build"
 	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
@@ -56,40 +56,58 @@ func (e *ExtrudeFeature) Operation() ops.PartFeatureOperation { return e.def.Ope
 // SetOperation changes the boolean operation (join/cut/intersect/new-body).
 func (e *ExtrudeFeature) SetOperation(op ops.PartFeatureOperation) { e.def.Operation = op }
 
-// Recompute resolves the profile, builds the prism solid at the extent distance,
-// and applies the operation against the running bodies.
+// Extent returns the feature's termination (type/direction/distances/targets); SetExtent
+// replaces it — the feature editor and Extrude tool write the chosen mode through here.
+func (e *ExtrudeFeature) Extent() Extent           { return e.def.Extent }
+func (e *ExtrudeFeature) SetExtent(ext Extent)     { e.def.Extent = ext }
+func (e *ExtrudeFeature) Taper() float64           { return e.def.Taper }
+func (e *ExtrudeFeature) SetTaper(radians float64) { e.def.Taper = radians }
+
+// Recompute resolves the profile, computes the extent span (distance/through-all/to-face/
+// …), builds the prism solid the span sweeps, and applies the operation against the
+// running bodies.
 func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
-	if e.def.Extent.Type != DistanceExtent {
-		return Output{}, build.NotYetImplemented("PBI-092-extent-" + fmt.Sprint(e.def.Extent.Type))
-	}
 	profiles, err := e.resolveProfiles()
 	if err != nil {
 		return Output{}, err
 	}
-	dist := e.def.Extent.distance()
-	if dist == 0 {
-		return Output{}, errors.New("extrude distance is zero")
+	plane := e.def.Sketch.Plane()
+	sp, err := e.resolveSpan(in.Bodies, plane, outerPolygons(profiles))
+	if err != nil {
+		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, e.buildTool(profiles, dist), e.def.Operation)
+	if sp.depth() == 0 {
+		return Output{}, errors.New("extrude: the extent has zero depth")
+	}
+	bodies, err := combine(in.Bodies, e.buildTool(profiles, plane, sp), e.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
 }
 
-// buildTool extrudes each selected region into a prism and merges the prisms into one
-// body. The regions are distinct cells of the same sketch, so they never overlap — a
-// shell merge is exactly their union and avoids the unimplemented intersecting Join.
-func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, dist float64) *topo.Body {
-	plane := e.def.Sketch.Plane()
+// buildTool extrudes each selected region into a prism over the span and merges the
+// prisms into one body. The regions are distinct cells of the same sketch, so they never
+// overlap — a shell merge is exactly their union and avoids the intersecting Join.
+func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, plane sketch.Plane, sp span) *topo.Body {
 	prisms := make([]*topo.Body, len(profiles))
 	for i, p := range profiles {
-		prisms[i] = buildPrism(p.OuterLoop().Polygon(), plane, dist, e.prismFeat(i, len(profiles)))
+		prisms[i] = buildPrism(p.OuterLoop().Polygon(), plane, sp, e.def.Taper, e.prismFeat(i, len(profiles)))
 	}
 	if len(prisms) == 1 {
 		return prisms[0]
 	}
 	return topo.MergeBodies(topo.NewLineage(topo.Tok(e.featName, "merged", 0)), true, prisms...)
+}
+
+// outerPolygons returns each profile's outer-loop polygon, the input the span resolver
+// (to-next ray-casting) and the prism builder both consume.
+func outerPolygons(profiles []*sketch.Profile) [][]math.Point2 {
+	out := make([][]math.Point2, len(profiles))
+	for i, p := range profiles {
+		out[i] = p.OuterLoop().Polygon()
+	}
+	return out
 }
 
 // prismFeat namespaces each region's prism lineage; a single-profile extrude keeps the
@@ -141,9 +159,17 @@ func (c *ExtrudeFeatures) AddByDistanceExtent(skt *sketch.Sketch, profileIndex i
 // AddByDistanceExtentProfiles adds an extrude of one or more sketch regions, merged
 // into one body — the multi-region selection the Extrude tool gathers with Ctrl+click.
 func (c *ExtrudeFeatures) AddByDistanceExtentProfiles(skt *sketch.Sketch, profileIndices []int, op ops.PartFeatureOperation, distance func() float64) *PartFeature {
+	return c.AddExtrude(skt, profileIndices, op, Extent{Type: DistanceExtent, Distance: distance}, 0)
+}
+
+// AddExtrude adds an extrude of one or more regions with a fully-specified extent
+// (distance / through-all / to-face / from-to / to-next / distance-from-face), boolean
+// operation, and taper (draft) angle — the general constructor the Extrude tool and the
+// automation API drive. The distance constructors above delegate here.
+func (c *ExtrudeFeatures) AddExtrude(skt *sketch.Sketch, profileIndices []int, op ops.PartFeatureOperation, extent Extent, taper float64) *PartFeature {
 	def := &ExtrudeDefinition{
-		Sketch: skt, ProfileIndices: append([]int(nil), profileIndices...), Operation: op,
-		Extent: Extent{Type: DistanceExtent, Distance: distance},
+		Sketch: skt, ProfileIndices: append([]int(nil), profileIndices...),
+		Operation: op, Extent: extent, Taper: taper,
 	}
 	ef := &ExtrudeFeature{def: def}
 	pf := c.engine.Add(ef)
@@ -170,24 +196,81 @@ func combine(running []*topo.Body, body *topo.Body, op ops.PartFeatureOperation)
 	return out, nil
 }
 
-// buildPrism extrudes a closed polygon by distance along the plane normal, building
-// a watertight solid: a bottom cap, a top cap, and one planar side face per profile
-// edge, with lineage on each (start/end caps and indexed side walls).
-func buildPrism(poly []math.Point2, plane sketch.Plane, dist float64, feat string) *topo.Body {
+// buildPrism extrudes a closed polygon over the span (near→far offsets along the plane
+// normal) into a watertight solid: a near cap, a far cap, and one planar side face per
+// profile edge. A non-zero taper offsets the far loop by depth·tan(taper) so the sides
+// draft outward (positive) or inward (negative); the far cap stays perpendicular to the
+// normal, and each side stays a planar trapezoid.
+func buildPrism(poly []math.Point2, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
 	n := len(poly)
+	normal := plane.Normal().AsVector()
+	topPoly := taperedLoop(poly, sp.depth(), taper)
 	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
-	up := plane.Normal().AsVector().Scale(dist)
 	bottom := make([]*topo.Vertex, n)
 	top := make([]*topo.Vertex, n)
-	for i, p := range poly {
-		b := plane.ToModel(p)
+	for i := 0; i < n; i++ {
+		b := plane.ToModel(poly[i]).TranslateBy(normal.Scale(sp.near))
+		t := plane.ToModel(topPoly[i]).TranslateBy(normal.Scale(sp.far))
 		bottom[i] = bld.AddVertex(b, topo.NewLineage(topo.Tok(feat, "vertex", i)))
-		top[i] = bld.AddVertex(b.TranslateBy(up), topo.NewLineage(topo.Tok(feat, "vertex", n+i)))
+		top[i] = bld.AddVertex(t, topo.NewLineage(topo.Tok(feat, "vertex", n+i)))
 	}
 	be, te, ve := prismEdges(bld, bottom, top, feat)
-	addCaps(bld, bottom, top, be, te, plane, feat)
-	addSides(bld, bottom, be, te, ve, plane, outwardSign(poly), feat)
+	addCaps(bld, bottom, top, be, te, normal, feat)
+	addSides(bld, bottom, top, be, te, ve, outwardSign(poly), feat)
 	return bld.Build()
+}
+
+// taperedLoop returns the far-loop polygon: poly unchanged when taper is 0, else each
+// vertex offset along its outward bisector by depth·tan(taper) (positive widens).
+func taperedLoop(poly []math.Point2, depth, taper float64) []math.Point2 {
+	if taper == 0 {
+		return poly
+	}
+	delta := depth * stdmath.Tan(taper) * outwardSign(poly)
+	return offsetPolygon2D(poly, delta)
+}
+
+// offsetPolygon2D offsets each vertex outward by delta along the angle bisector of its two
+// incident edges (a simple miter offset, exact for convex corners).
+func offsetPolygon2D(poly []math.Point2, delta float64) []math.Point2 {
+	n := len(poly)
+	out := make([]math.Point2, n)
+	for i := 0; i < n; i++ {
+		prev := poly[(i-1+n)%n]
+		next := poly[(i+1)%n]
+		nIn := edgeNormal2D(prev, poly[i])
+		nOut := edgeNormal2D(poly[i], next)
+		bisect := math.V2(nIn.X+nOut.X, nIn.Y+nOut.Y)
+		u, err := math.UnitVector2FromVector(bisect)
+		if err != nil {
+			out[i] = poly[i]
+			continue
+		}
+		scale := delta / cosHalf(nIn, nOut)
+		out[i] = math.P2(poly[i].X+u.AsVector().X*scale, poly[i].Y+u.AsVector().Y*scale)
+	}
+	return out
+}
+
+// edgeNormal2D returns the left-hand unit normal of edge a→b (points outward for a CCW loop).
+func edgeNormal2D(a, b math.Point2) math.Vector2 {
+	d := math.V2(b.X-a.X, b.Y-a.Y)
+	u, err := math.UnitVector2FromVector(math.V2(d.Y, -d.X))
+	if err != nil {
+		return math.V2(0, 0)
+	}
+	return u.AsVector()
+}
+
+// cosHalf returns the cosine of the half-angle between two edge normals, the miter
+// factor that keeps the bisector offset's perpendicular distance equal to delta (clamped
+// so a near-straight corner does not blow up the offset).
+func cosHalf(nIn, nOut math.Vector2) float64 {
+	c := stdmath.Sqrt(stdmath.Max(0, (1+nIn.X*nOut.X+nIn.Y*nOut.Y)/2))
+	if c < 0.2 {
+		return 0.2
+	}
+	return c
 }
 
 // outwardSign returns +1 when the profile polygon is wound counter-clockwise in the
@@ -221,12 +304,12 @@ func prismEdges(bld *topo.Builder, bottom, top []*topo.Vertex, feat string) (be,
 	return be, te, ve
 }
 
-// addCaps builds the bottom (downward) and top (upward) cap faces.
-func addCaps(bld *topo.Builder, bottom, top []*topo.Vertex, be, te []*topo.Edge, plane sketch.Plane, feat string) {
+// addCaps builds the near (downward) and far (upward) cap faces, perpendicular to the
+// extrude normal at each end.
+func addCaps(bld *topo.Builder, bottom, top []*topo.Vertex, be, te []*topo.Edge, normal math.Vector3, feat string) {
 	n := len(bottom)
-	down := plane.Normal().AsVector().Negate()
-	bottomPlane, _ := geom.NewPlane(bottom[0].Point(), down)
-	topPlane, _ := geom.NewPlane(top[0].Point(), plane.Normal().AsVector())
+	bottomPlane, _ := geom.NewPlane(bottom[0].Point(), normal.Negate())
+	topPlane, _ := geom.NewPlane(top[0].Point(), normal)
 	bottomLoop := make([]topo.Use, n)
 	topLoop := make([]topo.Use, n)
 	for i := 0; i < n; i++ {
@@ -237,29 +320,28 @@ func addCaps(bld *topo.Builder, bottom, top []*topo.Vertex, be, te []*topo.Edge,
 	bld.AddFace(topPlane, topo.NewLineage(topo.Tok(feat, "end-cap", 0)), topo.OuterLoop(topLoop...))
 }
 
-// addSides builds one planar side wall per profile edge. sign flips the computed
-// outward normal for a clockwise profile (see outwardSign) so every wall faces away
-// from the solid's interior.
-func addSides(bld *topo.Builder, bottom []*topo.Vertex, be, te, ve []*topo.Edge, plane sketch.Plane, sign float64, feat string) {
+// addSides builds one planar side wall per profile edge, through the wall's corners so
+// the face tilts correctly when the extrude is tapered. sign flips the outward normal for
+// a clockwise profile (see outwardSign) so every wall faces away from the interior.
+func addSides(bld *topo.Builder, bottom, top []*topo.Vertex, be, te, ve []*topo.Edge, sign float64, feat string) {
 	n := len(bottom)
-	normal := plane.Normal().AsVector()
 	for i := 0; i < n; i++ {
 		j := (i + 1) % n
-		edgeDir := bottom[i].Point().VectorTo(bottom[j].Point())
-		outward, err := math.UnitVector3FromVector(edgeDir.Cross(normal).Scale(sign))
-		surf := sideSurface(bottom[i].Point(), outward, err)
+		surf := sideSurface(bottom[i].Point(), bottom[j].Point(), top[i].Point(), sign)
 		loop := topo.OuterLoop(topo.Fwd(be[i]), topo.Fwd(ve[j]), topo.Rev(te[i]), topo.Rev(ve[i]))
 		bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "side", i)), loop)
 	}
 }
 
-// sideSurface returns the side face's plane (falling back to a degenerate plane if
-// the edge was zero-length, which the validator will then flag).
-func sideSurface(origin math.Point3, outward math.UnitVector3, err error) geom.Surface {
+// sideSurface returns the side face's plane through corners b0,b1,t0 (b0→b1 along the
+// profile edge, b0→t0 up the wall), oriented outward by sign. Falls back to a degenerate
+// plane on a zero-area corner, which the validator then flags.
+func sideSurface(b0, b1, t0 math.Point3, sign float64) geom.Surface {
+	normal, err := math.UnitVector3FromVector(b0.VectorTo(b1).Cross(b0.VectorTo(t0)).Scale(sign))
 	if err != nil {
-		p, _ := geom.NewPlane(origin, math.V3(0, 0, 1))
+		p, _ := geom.NewPlane(b0, math.V3(0, 0, 1))
 		return p
 	}
-	p, _ := geom.NewPlane(origin, outward.AsVector())
+	p, _ := geom.NewPlane(b0, normal.AsVector())
 	return p
 }

--- a/model/feature/extrude_extent.go
+++ b/model/feature/extrude_extent.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// span is the pair of signed offsets (along the sketch-plane normal) the extrude sweeps
+// between: from near to far. Every extent mode reduces to a span, which the prism builder
+// then turns into geometry.
+type span struct{ near, far float64 }
+
+// depth returns the swept length (always non-negative).
+func (s span) depth() float64 { return stdmath.Abs(s.far - s.near) }
+
+// throughAllMargin pads a through-all span beyond the material so the boolean fully cuts.
+const throughAllMargin = 1.0
+
+// resolveSpan computes the extrude's span from its extent type, the running bodies (for
+// through-all / to-next), and any referenced work planes (for to-face / from-to).
+func (e *ExtrudeFeature) resolveSpan(bodies []*topo.Body, plane sketch.Plane, polys [][]math.Point2) (span, error) {
+	ex := e.def.Extent
+	switch ex.Type {
+	case DistanceExtent:
+		return distanceSpan(ex)
+	case ThroughAllExtent:
+		return throughAllSpan(ex, bodies, plane)
+	case ToNextExtent:
+		return toNextSpan(bodies, plane, polys)
+	case ToFaceExtent:
+		return toPlaneSpan(ex, plane)
+	case FromToExtent:
+		return fromToSpan(ex, plane)
+	case DistanceFromFaceExtent:
+		return distanceFromFaceSpan(ex, plane)
+	default:
+		return span{}, fmt.Errorf("extrude: unsupported extent type %d", ex.Type)
+	}
+}
+
+// distanceSpan turns a distance extent into a span, honoring the direction and the
+// optional asymmetric second distance.
+func distanceSpan(ex Extent) (span, error) {
+	d := ex.distance()
+	if d == 0 {
+		return span{}, errors.New("extrude distance is zero")
+	}
+	if ex.isAsymmetric() {
+		return span{near: -ex.distance2(), far: d}, nil
+	}
+	switch ex.Direction {
+	case NegativeDir:
+		return span{near: -d, far: 0}, nil
+	case SymmetricDir:
+		return span{near: -d / 2, far: d / 2}, nil
+	default:
+		return span{near: 0, far: d}, nil
+	}
+}
+
+// throughAllSpan spans the existing material along the normal (plus a margin) on the
+// side(s) the direction selects, so a cut/join goes through everything.
+func throughAllSpan(ex Extent, bodies []*topo.Body, plane sketch.Plane) (span, error) {
+	if len(bodies) == 0 {
+		return span{}, errors.New("extrude: through-all needs existing material")
+	}
+	lo, hi := normalExtent(bodies, plane)
+	switch ex.Direction {
+	case NegativeDir:
+		return span{near: lo - throughAllMargin, far: 0}, nil
+	case SymmetricDir:
+		return span{near: lo - throughAllMargin, far: hi + throughAllMargin}, nil
+	default:
+		return span{near: 0, far: hi + throughAllMargin}, nil
+	}
+}
+
+// toPlaneSpan extrudes from the sketch plane to the (parallel) target work plane.
+func toPlaneSpan(ex Extent, plane sketch.Plane) (span, error) {
+	d, err := signedDistanceToPlane(ex.ToPlane, plane, "to-face")
+	if err != nil {
+		return span{}, err
+	}
+	return orderedSpan(0, d), nil
+}
+
+// fromToSpan extrudes between two (parallel) target work planes.
+func fromToSpan(ex Extent, plane sketch.Plane) (span, error) {
+	from, err := signedDistanceToPlane(ex.FromPlane, plane, "from-to start")
+	if err != nil {
+		return span{}, err
+	}
+	to, err := signedDistanceToPlane(ex.ToPlane, plane, "from-to end")
+	if err != nil {
+		return span{}, err
+	}
+	return orderedSpan(from, to), nil
+}
+
+// distanceFromFaceSpan extrudes a distance whose far end is measured from a (parallel)
+// target work plane.
+func distanceFromFaceSpan(ex Extent, plane sketch.Plane) (span, error) {
+	base, err := signedDistanceToPlane(ex.ToPlane, plane, "distance-from-face")
+	if err != nil {
+		return span{}, err
+	}
+	d := ex.distance()
+	if d == 0 {
+		return span{}, errors.New("extrude distance is zero")
+	}
+	if ex.Direction == NegativeDir {
+		d = -d
+	}
+	return orderedSpan(0, base+d), nil
+}
+
+// toNextSpan extrudes up to the next face the profile meets along the normal, found by
+// ray-casting each profile vertex; the nearest forward hit sets the far offset.
+func toNextSpan(bodies []*topo.Body, plane sketch.Plane, polys [][]math.Point2) (span, error) {
+	if len(bodies) == 0 {
+		return span{}, errors.New("extrude: to-next needs existing material")
+	}
+	dir := plane.Normal().AsVector()
+	best := stdmath.Inf(1)
+	for _, poly := range polys {
+		for _, p := range poly {
+			origin := plane.ToModel(p)
+			for _, b := range bodies {
+				if _, t, ok := ops.RayCastFaces(b, origin, dir, ops.DefaultQuality()); ok && t > math.DefaultTolerance && t < best {
+					best = t
+				}
+			}
+		}
+	}
+	if stdmath.IsInf(best, 1) {
+		return span{}, errors.New("extrude: to-next found no face ahead of the profile")
+	}
+	return span{near: 0, far: best}, nil
+}
+
+// signedDistanceToPlane returns the distance from the sketch plane to a target work plane
+// measured along the sketch normal. The target must be parallel to the sketch plane
+// (a flat cap); angled/curved targets are kernel phase C.
+func signedDistanceToPlane(target *WorkPlane, plane sketch.Plane, what string) (float64, error) {
+	if target == nil {
+		return 0, fmt.Errorf("extrude: %s has no target plane", what)
+	}
+	n := plane.Normal().AsVector()
+	if !target.Plane().Normal().AsVector().IsParallelTo(n, math.DefaultTolerance) {
+		return 0, fmt.Errorf("extrude: %s target must be parallel to the sketch plane (angled trim is not supported yet)", what)
+	}
+	return plane.Origin().VectorTo(target.Plane().Origin()).Dot(n), nil
+}
+
+// orderedSpan returns a span with near ≤ far so the prism builder always sweeps upward.
+func orderedSpan(a, b float64) span {
+	if a <= b {
+		return span{near: a, far: b}
+	}
+	return span{near: b, far: a}
+}
+
+// normalExtent returns the min and max projection of all body vertices onto the sketch
+// normal, measured from the sketch-plane origin — the material's reach along the extrude.
+func normalExtent(bodies []*topo.Body, plane sketch.Plane) (lo, hi float64) {
+	n := plane.Normal().AsVector()
+	o := plane.Origin()
+	lo, hi = stdmath.Inf(1), stdmath.Inf(-1)
+	for _, b := range bodies {
+		for _, v := range b.Vertices() {
+			t := o.VectorTo(v.Point()).Dot(n)
+			lo, hi = stdmath.Min(lo, t), stdmath.Max(hi, t)
+		}
+	}
+	return lo, hi
+}

--- a/model/feature/extrude_modes_test.go
+++ b/model/feature/extrude_modes_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/model/param"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// bodyZRange returns the min and max Z of a body's vertices — the extrude reach.
+func bodyZRange(b *topo.Body) (lo, hi float64) {
+	lo, hi = stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range b.Vertices() {
+		z := float64(v.Point().Z)
+		lo, hi = stdmath.Min(lo, z), stdmath.Max(hi, z)
+	}
+	return lo, hi
+}
+
+// extrudeWith builds a fresh part, extrudes a 2×2 square with the given extent/taper, and
+// returns the resulting body.
+func extrudeWith(t *testing.T, ext Extent, taper float64) *topo.Body {
+	t.Helper()
+	fs := NewPartFeatures(param.NewParameters(), nil)
+	pf := NewExtrudeFeatures(fs).AddExtrude(squareSketch(2), []int{0}, ops.NewBody, ext, taper)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("extrude sick: %+v", pf.Health())
+	}
+	return fs.Result()[0]
+}
+
+func TestExtrudeSymmetricSpansBothSides(t *testing.T) {
+	body := extrudeWith(t, Extent{Type: DistanceExtent, Direction: SymmetricDir, Distance: func() float64 { return 6 }}, 0)
+	lo, hi := bodyZRange(body)
+	if !approxEq(lo, -3) || !approxEq(hi, 3) {
+		t.Errorf("symmetric extrude z-range = [%g,%g], want [-3,3]", lo, hi)
+	}
+}
+
+func TestExtrudeNegativeDirection(t *testing.T) {
+	body := extrudeWith(t, Extent{Type: DistanceExtent, Direction: NegativeDir, Distance: func() float64 { return 4 }}, 0)
+	lo, hi := bodyZRange(body)
+	if !approxEq(lo, -4) || !approxEq(hi, 0) {
+		t.Errorf("negative extrude z-range = [%g,%g], want [-4,0]", lo, hi)
+	}
+}
+
+func TestExtrudeAsymmetricTwoDirection(t *testing.T) {
+	body := extrudeWith(t, Extent{
+		Type:     DistanceExtent,
+		Distance: func() float64 { return 4 }, Distance2: func() float64 { return 2 },
+	}, 0)
+	lo, hi := bodyZRange(body)
+	if !approxEq(lo, -2) || !approxEq(hi, 4) {
+		t.Errorf("asymmetric extrude z-range = [%g,%g], want [-2,4]", lo, hi)
+	}
+}
+
+func TestExtrudeTaperWidensTopAndStaysValid(t *testing.T) {
+	// A positive taper drafts the walls outward: the far cap is larger than the 2×2 base.
+	body := extrudeWith(t, Extent{Type: DistanceExtent, Distance: func() float64 { return 5 }}, 0.2)
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("tapered extrude failed validation: %+v", r)
+	}
+	box := body.RangeBox()
+	if d := box.Diagonal(); d.X <= 2.0001 || d.Y <= 2.0001 {
+		t.Errorf("tapered extrude XY extent = (%g,%g), want > 2 (drafted outward)", d.X, d.Y)
+	}
+}
+
+func TestExtrudeToWorkPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	g.Recompute(nil)
+	target := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 7 }) // z=7
+	g.Recompute(nil)
+	body := extrudeWith(t, Extent{Type: ToFaceExtent, ToPlane: target}, 0)
+	lo, hi := bodyZRange(body)
+	if !approxEq(lo, 0) || !approxEq(hi, 7) {
+		t.Errorf("to-plane extrude z-range = [%g,%g], want [0,7]", lo, hi)
+	}
+}
+
+func TestExtrudeModeRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddExtrude(sk, []int{0}, ops.Cut,
+		Extent{Type: ThroughAllExtent, Direction: SymmetricDir, Distance: func() float64 { return 5 }}, 0.15)
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	ed := data[0].Extrude
+	if ed == nil || ed.Extent != "through-all" || ed.Direction != "symmetric" || ed.Taper != 0.15 || ed.Operation != "cut" {
+		t.Fatalf("marshaled extrude = %+v, want through-all/symmetric/cut/taper 0.15", ed)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	ef := fresh.Item(0).feature.(*ExtrudeFeature)
+	if ef.Extent().Type != ThroughAllExtent || ef.Extent().Direction != SymmetricDir || ef.Taper() != 0.15 {
+		t.Errorf("restored extent = %+v taper=%v, want through-all/symmetric/0.15", ef.Extent(), ef.Taper())
+	}
+}
+
+func TestExtrudeThroughAllSpansExistingMaterial(t *testing.T) {
+	// Through-all measures the existing material's reach along the normal and spans it
+	// (plus a margin). Tested with a new-body operation so it exercises the span without
+	// the kernel's intersecting boolean (overlapping cut/join is phase B).
+	fs := NewPartFeatures(param.NewParameters(), nil)
+	ex := NewExtrudeFeatures(fs)
+	ex.AddByDistanceExtent(squareSketch(4), 0, ops.NewBody, func() float64 { return 3 }) // block z0..3
+	tool := ex.AddExtrude(squareSketch(2), []int{0}, ops.NewBody,
+		Extent{Type: ThroughAllExtent, Direction: PositiveDir}, 0)
+	fs.Recompute()
+	if !tool.Health().OK() {
+		t.Fatalf("through-all sick: %+v", tool.Health())
+	}
+	// The block reaches z=3; the through-all prism spans to 3 + margin.
+	lo, hi := bodyZRange(fs.Result()[1])
+	if !approxEq(lo, 0) || !approxEq(hi, 3+throughAllMargin) {
+		t.Errorf("through-all z-range = [%g,%g], want [0,%g]", lo, hi, 3+throughAllMargin)
+	}
+}

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -14,8 +14,8 @@ import (
 func TestCombineJoinsTwoBodiesForReal(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	// Two disjoint prisms in the running state, then Combine them.
-	NewBaseFeatures(fs).AddBase(buildPrism(squarePoly(0), sketch.XYPlane(), 1, "a"))
-	NewBaseFeatures(fs).AddBase(buildPrism(squarePoly(10), sketch.XYPlane(), 1, "b"))
+	NewBaseFeatures(fs).AddBase(buildPrism(squarePoly(0), sketch.XYPlane(), span{near: 0, far: 1}, 0, "a"))
+	NewBaseFeatures(fs).AddBase(buildPrism(squarePoly(10), sketch.XYPlane(), span{near: 0, far: 1}, 0, "b"))
 	combine := NewModifyFeatures(fs).AddCombine(0, 1, ops.Join)
 	fs.Recompute()
 

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -184,7 +184,7 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 	du := NewDressUpFeatures(fs)
 	switch fd.Kind {
 	case "extrude":
-		return requireExtrude(fs, fd.Extrude, sk)
+		return requireExtrude(fs, fd.Extrude, sk, work)
 	case "fillet":
 		d, err := requireEdgeDress(fd.Fillet, "fillet")
 		if err != nil {

--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -4,16 +4,22 @@ package feature
 
 import "fmt"
 
-// ExtrudeData is an extrude's recipe: which sketch region(s), the boolean operation,
-// and the distance extent. The distance is the evaluated growth (a fixed value on
-// reopen; parametric distance expressions arrive with the dimension-driven extent API).
+// ExtrudeData is an extrude's recipe: which sketch region(s), the boolean operation, and
+// the full extent (type, direction, distances, taper, and any work-plane targets). The
+// distances are evaluated values (a fixed value on reopen; parametric expressions arrive
+// with the dimension-driven extent API).
 type ExtrudeData struct {
 	Sketch    int     `yaml:"sketch"`
 	Profile   int     `yaml:"profile,omitempty"`  // legacy single-region key; read for back-compat
 	Profiles  []int   `yaml:"profiles,omitempty"` // one or more regions (current form)
 	Operation string  `yaml:"operation"`
-	Distance  float64 `yaml:"distance"`
+	Extent    string  `yaml:"extent,omitempty"`    // distance|through-all|to-next|to-face|from-to|distance-from-face
+	Direction string  `yaml:"direction,omitempty"` // positive|negative|symmetric
+	Distance  float64 `yaml:"distance,omitempty"`
+	Distance2 float64 `yaml:"distance2,omitempty"` // asymmetric second-direction distance
 	Taper     float64 `yaml:"taper,omitempty"`
+	ToPlane   string  `yaml:"toPlane,omitempty"`   // WorkRef of the to-face / from-to end / distance-from-face target
+	FromPlane string  `yaml:"fromPlane,omitempty"` // WorkRef of the from-to start
 }
 
 // extrudeProfiles returns the region indices a payload selects, accepting both the
@@ -25,10 +31,22 @@ func (ed *ExtrudeData) extrudeProfiles() []int {
 	return []int{ed.Profile}
 }
 
+var extentNames = map[ExtentType]string{
+	DistanceExtent:         "distance",
+	ToNextExtent:           "to-next",
+	ThroughAllExtent:       "through-all",
+	ToFaceExtent:           "to-face",
+	FromToExtent:           "from-to",
+	DistanceFromFaceExtent: "distance-from-face",
+}
+
+var directionNames = map[ExtentDirection]string{
+	PositiveDir:  "positive",
+	NegativeDir:  "negative",
+	SymmetricDir: "symmetric",
+}
+
 func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, error) {
-	if def.Extent.Type != DistanceExtent {
-		return nil, fmt.Errorf("only distance extents are serializable (got extent type %d)", def.Extent.Type)
-	}
 	idx, ok := sk.IndexOf(def.Sketch)
 	if !ok {
 		return nil, fmt.Errorf("extrude references a sketch that is not in the part")
@@ -37,24 +55,33 @@ func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, e
 	if err != nil {
 		return nil, err
 	}
-	return &ExtrudeData{
-		Sketch:    idx,
-		Profiles:  append([]int(nil), def.ProfileIndices...),
-		Operation: op,
-		Distance:  def.Extent.distance(),
-		Taper:     def.Taper,
-	}, nil
+	ename, ok := extentNames[def.Extent.Type]
+	if !ok {
+		return nil, fmt.Errorf("extrude: unknown extent type %d", def.Extent.Type)
+	}
+	d := &ExtrudeData{
+		Sketch: idx, Profiles: append([]int(nil), def.ProfileIndices...), Operation: op,
+		Extent: ename, Direction: directionNames[def.Extent.Direction],
+		Distance: def.Extent.distance(), Distance2: def.Extent.distance2(), Taper: def.Taper,
+	}
+	if def.Extent.ToPlane != nil {
+		d.ToPlane = string(def.Extent.ToPlane.Key())
+	}
+	if def.Extent.FromPlane != nil {
+		d.FromPlane = string(def.Extent.FromPlane.Key())
+	}
+	return d, nil
 }
 
 // requireExtrude restores an extrude, erroring on a missing payload.
-func requireExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
+func requireExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer, work *WorkGeometry) (*PartFeature, error) {
 	if ed == nil {
 		return nil, fmt.Errorf("extrude feature is missing its payload")
 	}
-	return restoreExtrude(fs, ed, sk)
+	return restoreExtrude(fs, ed, sk, work)
 }
 
-func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartFeature, error) {
+func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer, work *WorkGeometry) (*PartFeature, error) {
 	skt, ok := sk.At(ed.Sketch)
 	if !ok {
 		return nil, fmt.Errorf("extrude references sketch index %d, which does not exist", ed.Sketch)
@@ -63,10 +90,64 @@ func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer) (*PartF
 	if err != nil {
 		return nil, err
 	}
-	dist := ed.Distance
-	pf := NewExtrudeFeatures(fs).AddByDistanceExtentProfiles(skt, ed.extrudeProfiles(), op, func() float64 { return dist })
-	if ed.Taper != 0 {
-		pf.feature.(*ExtrudeFeature).def.Taper = ed.Taper
+	extent, err := restoreExtent(ed, work)
+	if err != nil {
+		return nil, err
 	}
-	return pf, nil
+	return NewExtrudeFeatures(fs).AddExtrude(skt, ed.extrudeProfiles(), op, extent, ed.Taper), nil
+}
+
+// restoreExtent rebuilds the extent from its recipe, resolving any work-plane targets.
+func restoreExtent(ed *ExtrudeData, work *WorkGeometry) (Extent, error) {
+	ext := Extent{Type: parseExtentName(ed.Extent), Direction: parseDirectionName(ed.Direction)}
+	dist := ed.Distance
+	ext.Distance = func() float64 { return dist }
+	if ed.Distance2 != 0 {
+		d2 := ed.Distance2
+		ext.Distance2 = func() float64 { return d2 }
+	}
+	if ed.ToPlane != "" {
+		wp, err := resolvePlaneRef(work, ed.ToPlane)
+		if err != nil {
+			return Extent{}, err
+		}
+		ext.ToPlane = wp
+	}
+	if ed.FromPlane != "" {
+		wp, err := resolvePlaneRef(work, ed.FromPlane)
+		if err != nil {
+			return Extent{}, err
+		}
+		ext.FromPlane = wp
+	}
+	return ext, nil
+}
+
+// resolvePlaneRef resolves a work-plane reference string against the part's work geometry.
+func resolvePlaneRef(work *WorkGeometry, ref string) (*WorkPlane, error) {
+	if work == nil {
+		return nil, fmt.Errorf("extrude: plane reference %q needs the part's work geometry", ref)
+	}
+	return work.WorkPlaneByRef(WorkRef(ref))
+}
+
+// parseExtentName maps a recipe extent name to its type (empty/unknown ⇒ distance, the
+// back-compatible default for files written before extent modes).
+func parseExtentName(name string) ExtentType {
+	for t, n := range extentNames {
+		if n == name {
+			return t
+		}
+	}
+	return DistanceExtent
+}
+
+// parseDirectionName maps a recipe direction name to its value (empty/unknown ⇒ positive).
+func parseDirectionName(name string) ExtentDirection {
+	for d, n := range directionNames {
+		if n == name {
+			return d
+		}
+	}
+	return PositiveDir
 }

--- a/model/feature/surface.go
+++ b/model/feature/surface.go
@@ -275,6 +275,6 @@ func buildRuledBand(poly []math.Point2, plane sketch.Plane, dist float64, feat s
 		top[i] = bld.AddVertex(b.TranslateBy(up), topo.NewLineage(topo.Tok(feat, "vertex", n+i)))
 	}
 	be, te, ve := prismEdges(bld, bottom, top, feat)
-	addSides(bld, bottom, be, te, ve, plane, outwardSign(poly), feat)
+	addSides(bld, bottom, top, be, te, ve, outwardSign(poly), feat)
 	return bld.Build()
 }

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -154,6 +154,22 @@ func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
 	return w.Plane(), nil
 }
 
+// WorkPlaneByRef resolves a WorkRef to its *WorkPlane (origin or user) — for features
+// that reference a datum plane, e.g. an extrude's to-face / from-to target.
+func (g *WorkGeometry) WorkPlaneByRef(ref WorkRef) (*WorkPlane, error) {
+	if i, ok := userIndex(ref, "plane"); ok {
+		if i < 0 || i >= g.planes.Count() {
+			return nil, fmt.Errorf("work geometry: no work plane %q", ref)
+		}
+		return g.planes.Item(i), nil
+	}
+	w, ok := g.planes.byKey[ref]
+	if !ok {
+		return nil, fmt.Errorf("work geometry: unknown plane reference %q", ref)
+	}
+	return w, nil
+}
+
 func (g *WorkGeometry) axis(ref WorkRef) (*WorkAxis, error) {
 	if i, ok := userIndex(ref, "axis"); ok {
 		if i < 0 || i >= g.axes.Count() {


### PR DESCRIPTION
## What

Builds the Extrude feature toward the Inventor `ExtrudeDefinition` spec — all the extent **modes**, direction control, taper, and an in-canvas **options window** (Inventor's Extrude property panel).

**Model**
- **All six extent types**: distance, through-all, to-next, to-face, from-to, distance-from-face. Each resolves to a near/far **span** along the sketch normal — through-all gauges existing material, to-next ray-casts the next face, and the to/from modes measure to a referenced **work plane**.
- **Direction**: positive / negative / symmetric, plus an **asymmetric two-direction** depth.
- **Taper** (draft): the far loop is offset by `depth·tan(taper)` with corner-based planar side walls. The prism builder is generalized to a span + taper (and reused by the surface band builder).
- Extents + taper **round-trip** through the `.obk` recipe; to/from targets serialize by work-plane reference.

**Automation API** (`addin/opregistry`): the extrude descriptor gains `extent`, `direction`, `secondDistance`, and `taper` args.

**Head / app**: the Extrude tool carries the full extent/direction/taper/operation state, and the dialog is now an **options window** — Output (operation), Extents, Direction, Distance with a two-direction toggle + second distance, and a Taper field.

## Why

The previous extrude implemented only the distance extent (everything else returned `NotYetImplemented`), ignored direction/taper, and the dialog only had a distance field. This closes most of the gap to Inventor's extrude.

## Known limits (honest scoping)

- **To/From-To/Distance-From-Face** require the target **parallel to the sketch plane** (flat cap) — angled/curved trims need single-face `TrimByPlane` to grow into solid trimming (kernel phase C). The UI/API expose distance/through-all/to-next; the reference modes are model + serialization only for now.
- **Through-all / overlapping cut & join** depend on the kernel's intersecting boolean (`PBI-082`), which is still phase B — the span is computed correctly and will produce geometry once that lands.
- **Surface output** (open-profile sheets) needs a new kernel op and is not included.

## Testing

Model tests for symmetric/negative/asymmetric/taper/to-plane/through-all spans + recipe round-trip; app tests that the tool's options flow into geometry; API tests for the new args. Full `go test ./...` (incl. cgo head), `golangci-lint`, gofmt, and SPDX all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)