### PR TITLE
M20: feature-completion milestone + body-transform foundation (PBI-190)

### DIFF
--- a/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-171-boolean-face-split.md
+++ b/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-171-boolean-face-split.md
@@ -1,0 +1,50 @@
+---
+milestone: M20
+feature: F01
+pbi: PBI-171
+title: Face-splitting solid/solid boolean
+status: planned
+estimate: XL
+---
+
+# PBI-171 — Face-splitting solid/solid boolean
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F01 Intersecting Booleans
+
+## Goal
+
+Extend `ops.Boolean` past Phase-A to handle **intersecting** solids: compute the
+surface–surface intersection, imprint split edges on both bodies, classify the
+resulting face regions, and assemble Join/Cut/Intersect/NewBody results.
+
+## Scope / work
+
+- Surface–surface intersection → intersection segments (planar faces first:
+  segment = the line where two planes cross, clipped to both face boundaries).
+- Imprint: split each crossed face along the intersection, inserting new edges and
+  vertices with deterministic lineage.
+- Region classification using `PointInsideBody` (ray-cast) → inside / outside / on.
+- Assemble the kept face set per `PartFeatureOperation`; rebuild a valid manifold body.
+- Reference-key lineage on every new face/edge so it rebinds after recompute.
+
+## API contracts (interfaces / enums / collections)
+
+- `ops.Boolean` (extended); no new public DTO (the feature DTOs already exist).
+
+## Acceptance criteria
+
+- Two overlapping axis-aligned boxes: **Join** → one validated manifold solid whose
+  volume = V1 + V2 − Voverlap; **Cut** → V1 − Voverlap; **Intersect** → Voverlap.
+- Result faces carry stable reference keys that rebind across a recompute.
+- Disjoint/containment Phase-A cases still pass (no regression).
+
+## Depends on
+
+M07 (`kernel/ops`, `kernel/topo`, `math/predicate`).
+
+## Notes
+
+The single biggest unblocker in M20 — Cut, Split, Hole, Emboss, and most
+sheet-metal/plastic features reduce to this. Start with the axis-aligned/planar
+case (exact predicates), generalize to arbitrary planar faces, leave curved–curved
+intersection to the NURBS follow-up (F02).

--- a/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-172-cut-split-combine-geometry.md
+++ b/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-172-cut-split-combine-geometry.md
@@ -1,0 +1,45 @@
+---
+milestone: M20
+feature: F01
+pbi: PBI-172
+title: Cut / Split / Combine real geometry
+status: planned
+estimate: M
+---
+
+# PBI-172 — Cut / Split / Combine real geometry
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F01 Intersecting Booleans
+
+## Goal
+
+With PBI-171 landed, complete the features that are pure booleans: `CombineFeature`
+(already Phase-A), `SplitFeature` (split a body/face by a tool), and a new
+`CutFeature` (subtract a tool body) — all emitting validated geometry.
+
+## Scope / work
+
+- `CombineFeature`: route intersecting cases through the new boolean.
+- `SplitFeature`: split the running solid by a work plane / surface / sketch into
+  the kept piece(s); split-faces mode for face splitting.
+- `CutFeature(s)`/`CutDefinition`: subtract a tool body (full triangle + Add).
+- Health: tool that misses the body → Warning, not crash.
+
+## API contracts (interfaces / enums / collections)
+
+- `CutFeature`,`CutFeatures`,`CutDefinition`,`CutFeatureProxy`; `SplitFeature` geometry.
+
+## Acceptance criteria
+
+- Splitting a box by its mid-plane yields the requested half as a validated solid.
+- A cut tool overlapping a block removes exactly the overlap volume.
+- Combine of two intersecting blocks (join) is manifold with the union volume.
+- All recompute when a driving parameter changes; serialize round-trips.
+
+## Depends on
+
+PBI-171.
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092).

--- a/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/_feature.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F01
+name: Intersecting Booleans
+status: in-progress
+---
+
+# M20 · F01 — Intersecting Booleans
+
+The general solid/solid boolean that splits faces along the intersection curve —
+the Phase-C kernel op M07·PBI-082 deferred. This is the single biggest unblocker:
+Cut, Split, Hole, Combine, Emboss, and most sheet-metal/plastic features all reduce
+to "intersect two bodies and keep/discard regions."
+
+## In scope
+
+- Surface–surface intersection segments → an imprint of split edges on both bodies.
+- Region classification (inside/outside/on) and union/subtract/intersect assembly.
+- Lineage on every new face/edge so reference keys survive recompute.
+- Completion of `CombineFeature`/`SplitFeature`/`CutFeature` to real geometry.
+
+## Out of scope
+
+- Tolerant near-coincident sew (Phase-D, stays `ops.Sew`).
+
+## Key API contracts delivered
+
+- `ops.Boolean` extended past Phase-A; `CutFeature(s)`/`CutDefinition`; `SplitFeature`
+  real geometry.
+
+## Depends on
+
+M07 (`kernel/ops`, `math/predicate`).
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-171](PBI-171-boolean-face-split.md) | Face-splitting solid/solid boolean |
+| [PBI-172](PBI-172-cut-split-combine-geometry.md) | Cut / Split / Combine real geometry |

--- a/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/PBI-173-revolve-coil-surfaces.md
+++ b/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/PBI-173-revolve-coil-surfaces.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F02
+pbi: PBI-173
+title: Revolve & coil surfaces of revolution
+status: planned
+estimate: M
+---
+
+# PBI-173 — Revolve & coil surfaces of revolution
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F02 Swept-Surface Generation
+
+## Goal
+
+Generate solids of revolution from a profile + axis so `RevolveFeature` and `CoilFeature` stop deferring.
+
+## Scope / work
+
+Analytic surface-of-revolution generator (full + partial angle); cap faces; helical sweep for coil (pitch/revolutions/taper); lineage on all faces.
+
+## API contracts (interfaces / enums / collections)
+
+- `RevolveFeature`/`CoilFeature` real geometry; `ops.Revolve`.
+
+## Acceptance criteria
+
+- A rectangle revolved 360° about an offset axis is a validated manifold annulus solid
+- a partial angle yields start/end cap faces
+- coil generates the helical body
+- recompute on angle/pitch change.
+
+## Depends on
+
+M07, M08
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/PBI-174-sweep-loft-nurbs.md
+++ b/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/PBI-174-sweep-loft-nurbs.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F02
+pbi: PBI-174
+title: Sweep & loft NURBS bodies
+status: planned
+estimate: L
+---
+
+# PBI-174 — Sweep & loft NURBS bodies
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F02 Swept-Surface Generation
+
+## Goal
+
+Sweep a profile along a path and loft between sections into real B-rep solids/surfaces.
+
+## Scope / work
+
+Profile-along-path sweep (translational + path frames); ruled/NURBS loft between 2+ sections; closed/open; rib as a bounded thin sweep.
+
+## API contracts (interfaces / enums / collections)
+
+- `SweepFeature`/`LoftFeature`/`RibFeature` real geometry; `ops.Sweep`/`ops.Loft`.
+
+## Acceptance criteria
+
+- A circle swept along an L-path is a validated solid
+- a loft between two squares is manifold
+- rib fills to the next face
+- recompute on input change.
+
+## Depends on
+
+M07, M08
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/_feature.md
@@ -1,0 +1,21 @@
+---
+milestone: M20
+feature: F02
+name: Swept-Surface Generation
+status: planned
+---
+
+# M20 · F02 — Swept-Surface Generation
+
+Surfaces of revolution and swept/lofted/coil surfaces so Revolve/Sweep/Loft/Coil/Rib emit real solids.
+
+## Depends on
+
+M07, M08
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-173](PBI-173-revolve-coil-surfaces.md) | Revolve & coil surfaces of revolution |
+| [PBI-174](PBI-174-sweep-loft-nurbs.md) | Sweep & loft NURBS bodies |

--- a/implementation-plan/M20-feature-completion-geometry/F03-fillet-chamfer-geometry/PBI-175-rolling-ball-fillet.md
+++ b/implementation-plan/M20-feature-completion-geometry/F03-fillet-chamfer-geometry/PBI-175-rolling-ball-fillet.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F03
+pbi: PBI-175
+title: Rolling-ball edge fillet
+status: planned
+estimate: M
+---
+
+# PBI-175 — Rolling-ball edge fillet
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F03 Fillet & Chamfer Geometry
+
+## Goal
+
+Replace a convex/concave edge with a constant-radius rolling-ball blend face.
+
+## Scope / work
+
+Constant-radius edge fillet (cylinder/torus blend faces); edge-set chains; variable radius + setback recorded; trim/rebuild adjacent faces; lineage preserved.
+
+## API contracts (interfaces / enums / collections)
+
+- `FilletFeature` real geometry; `ops.FilletEdges`.
+
+## Acceptance criteria
+
+- Filleting the 4 vertical edges of a box yields a validated manifold solid with 4 quarter-cylinder faces of the right radius
+- lost edge → Sick
+- recompute on radius change.
+
+## Depends on
+
+M07, M09
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F03-fillet-chamfer-geometry/PBI-176-chamfer-corner-round.md
+++ b/implementation-plan/M20-feature-completion-geometry/F03-fillet-chamfer-geometry/PBI-176-chamfer-corner-round.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F03
+pbi: PBI-176
+title: Chamfer & corner-round
+status: planned
+estimate: M
+---
+
+# PBI-176 — Chamfer & corner-round
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F03 Fillet & Chamfer Geometry
+
+## Goal
+
+Flat chamfer faces (distance / distance-angle / two-distance) and corner-round.
+
+## Scope / work
+
+Edge chamfer planar faces; the three chamfer input modes; corner-round at vertices; lineage.
+
+## API contracts (interfaces / enums / collections)
+
+- `ChamferFeature` real geometry; `ops.ChamferEdges`.
+
+## Acceptance criteria
+
+- Chamfering a box edge yields a validated solid with one planar chamfer face at the right setback
+- two-distance asymmetric verified
+- recompute on distance change.
+
+## Depends on
+
+M07, M09
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F03-fillet-chamfer-geometry/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F03-fillet-chamfer-geometry/_feature.md
@@ -1,0 +1,21 @@
+---
+milestone: M20
+feature: F03
+name: Fillet & Chamfer Geometry
+status: planned
+---
+
+# M20 · F03 — Fillet & Chamfer Geometry
+
+Rolling-ball fillets and chamfer faces on picked edges, replacing the resolve-then-defer stubs.
+
+## Depends on
+
+M07, M09
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-175](PBI-175-rolling-ball-fillet.md) | Rolling-ball edge fillet |
+| [PBI-176](PBI-176-chamfer-corner-round.md) | Chamfer & corner-round |

--- a/implementation-plan/M20-feature-completion-geometry/F04-local-face-ops/PBI-177-move-delete-replace-face-draft.md
+++ b/implementation-plan/M20-feature-completion-geometry/F04-local-face-ops/PBI-177-move-delete-replace-face-draft.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F04
+pbi: PBI-177
+title: Move / delete / replace face & draft
+status: planned
+estimate: M
+---
+
+# PBI-177 — Move / delete / replace face & draft
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F04 Local Face Operations
+
+## Goal
+
+Local operations that retopologize selected faces of the running solid.
+
+## Scope / work
+
+Move-face (translate/rotate a face, re-trim neighbours); offset-face; delete-face + heal; replace-face; face draft about a pull direction.
+
+## API contracts (interfaces / enums / collections)
+
+- `MoveFaceFeature`/`FaceOffsetFeature`/`DeleteFaceFeature`/`ReplaceFaceFeature`/`FaceDraftFeature` real geometry.
+
+## Acceptance criteria
+
+- Moving the top face of a box up grows the solid and stays manifold
+- deleting a face then healing closes the body
+- draft tilts the face by the angle
+- recompute on input.
+
+## Depends on
+
+M07, M09
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F04-local-face-ops/PBI-178-shell-thicken.md
+++ b/implementation-plan/M20-feature-completion-geometry/F04-local-face-ops/PBI-178-shell-thicken.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F04
+pbi: PBI-178
+title: Shell & thicken
+status: planned
+estimate: M
+---
+
+# PBI-178 — Shell & thicken
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F04 Local Face Operations
+
+## Goal
+
+Hollow a solid to a wall thickness with removed faces, and thicken a surface to a solid.
+
+## Scope / work
+
+Inward/outward/both shell with removed-face openings; thicken a surface body by a thickness (offset both sides + side walls); lineage.
+
+## API contracts (interfaces / enums / collections)
+
+- `ShellFeature`/`ThickenFeature` real geometry; `ops.Shell`/`ops.Thicken`.
+
+## Acceptance criteria
+
+- Shelling a box with the top removed yields a 5-wall open box of the right wall thickness, validated
+- thickening a planar patch yields a slab solid
+- recompute on thickness change.
+
+## Depends on
+
+M07, M09
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F04-local-face-ops/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F04-local-face-ops/_feature.md
@@ -1,0 +1,21 @@
+---
+milestone: M20
+feature: F04
+name: Local Face Operations
+status: planned
+---
+
+# M20 · F04 — Local Face Operations
+
+Move/offset/delete/replace face, draft, shell, and thicken producing real geometry.
+
+## Depends on
+
+M07, M09
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-177](PBI-177-move-delete-replace-face-draft.md) | Move / delete / replace face & draft |
+| [PBI-178](PBI-178-shell-thicken.md) | Shell & thicken |

--- a/implementation-plan/M20-feature-completion-geometry/F05-sheet-metal-environment/PBI-179-sheet-metal-rules.md
+++ b/implementation-plan/M20-feature-completion-geometry/F05-sheet-metal-environment/PBI-179-sheet-metal-rules.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F05
+pbi: PBI-179
+title: Sheet-metal definition, styles & rules
+status: planned
+estimate: L
+---
+
+# PBI-179 — Sheet-metal definition, styles & rules
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F05 Sheet-Metal Environment & Rules
+
+## Goal
+
+A `SheetMetalComponentDefinition` driven by a rule (thickness/bend radius/K-factor/unfold method) that every SM feature reads.
+
+## Scope / work
+
+`SheetMetalComponentDefinition` (wraps a part def); `SheetMetalStyle`/`SheetMetalRule` (Thickness/BendRadius/KFactor/relief); `UnfoldMethod` (linear/bend-table); active-rule resolution; .obk round-trip.
+
+## API contracts (interfaces / enums / collections)
+
+- `SheetMetalComponentDefinition`, `SheetMetalStyles`, `SheetMetalRule`, `KFactor`, `UnfoldMethod`, `BendAllowance` helper.
+
+## Acceptance criteria
+
+- A new SM part carries a default rule
+- thickness/radius/K-factor read back
+- a bend-allowance helper computes arc length from radius+angle+K
+- round-trips through .obk.
+
+## Depends on
+
+M07, M08
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F05-sheet-metal-environment/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F05-sheet-metal-environment/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F05
+name: Sheet-Metal Environment & Rules
+status: planned
+---
+
+# M20 · F05 — Sheet-Metal Environment & Rules
+
+The sheet-metal component definition, styles/rules (thickness, bend radius, K-factor), and unfold methods.
+
+## Depends on
+
+M07, M08
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-179](PBI-179-sheet-metal-rules.md) | Sheet-metal definition, styles & rules |

--- a/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/PBI-180-face-flange.md
+++ b/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/PBI-180-face-flange.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F06
+pbi: PBI-180
+title: Face & Flange features
+status: planned
+estimate: M
+---
+
+# PBI-180 — Face & Flange features
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F06 Sheet-Metal Wall & Bend Features
+
+## Goal
+
+The base `FaceFeature` (a thickened sketch wall) and `FlangeFeature` (a wall + bend off an edge).
+
+## Scope / work
+
+`FaceFeature` = profile thickened by rule thickness; `FlangeFeature` off a selected edge at an angle with a bend of the rule radius; flange width/extents; bend region geometry.
+
+## API contracts (interfaces / enums / collections)
+
+- `FaceFeature(s)`/`FlangeFeature(s)`/`*Definition`.
+
+## Acceptance criteria
+
+- A face creates a flat wall of rule thickness
+- a 90° flange off its edge adds a wall joined by a bend arc of the rule radius
+- validated solid
+- recompute on angle.
+
+## Depends on
+
+M20·F05
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/PBI-181-bend-fold-hem.md
+++ b/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/PBI-181-bend-fold-hem.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F06
+pbi: PBI-181
+title: Bend, Fold & Hem features
+status: planned
+estimate: M
+---
+
+# PBI-181 — Bend, Fold & Hem features
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F06 Sheet-Metal Wall & Bend Features
+
+## Goal
+
+`BendFeature` (bend along a line), `FoldFeature` (fold about a sketch line), `HemFeature` (folded edge).
+
+## Scope / work
+
+Bend across a face along a bend line; fold a wall about a line by an angle; hem (single/teardrop/rolled/double) at an edge; all consume the rule.
+
+## API contracts (interfaces / enums / collections)
+
+- `BendFeature(s)`/`FoldFeature(s)`/`HemFeature(s)`/`*Definition`.
+
+## Acceptance criteria
+
+- Folding a wall 90° about a line yields two walls + a bend
+- a single hem folds the edge back the hem gap
+- validated
+- recompute on angle/radius.
+
+## Depends on
+
+M20·F05
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/PBI-182-contour-lofted.md
+++ b/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/PBI-182-contour-lofted.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F06
+pbi: PBI-182
+title: ContourFlange, ContourRoll & LoftedFlange
+status: planned
+estimate: M
+---
+
+# PBI-182 — ContourFlange, ContourRoll & LoftedFlange
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F06 Sheet-Metal Wall & Bend Features
+
+## Goal
+
+Sweep/loft the SM wall set: contour flange (open profile swept along edge), contour roll (revolved), lofted flange (between two profiles).
+
+## Scope / work
+
+ContourFlange = open profile thickened+swept along a path; ContourRoll = revolved SM wall; LoftedFlange = transition between two sketch profiles with bends.
+
+## API contracts (interfaces / enums / collections)
+
+- `ContourFlangeFeature(s)`/`ContourRollFeature(s)`/`LoftedFlangeFeature(s)`/`*Definition`.
+
+## Acceptance criteria
+
+- A contour flange sweeps its profile into a multi-bend wall
+- a lofted flange transitions square→round
+- validated solids
+- recompute on input.
+
+## Depends on
+
+M20·F05
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F06-sheet-metal-wall-bend/_feature.md
@@ -1,0 +1,22 @@
+---
+milestone: M20
+feature: F06
+name: Sheet-Metal Wall & Bend Features
+status: planned
+---
+
+# M20 · F06 — Sheet-Metal Wall & Bend Features
+
+Face, Flange, ContourFlange, ContourRoll, Hem, Bend, Fold, LoftedFlange.
+
+## Depends on
+
+M20·F05
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-180](PBI-180-face-flange.md) | Face & Flange features |
+| [PBI-181](PBI-181-bend-fold-hem.md) | Bend, Fold & Hem features |
+| [PBI-182](PBI-182-contour-lofted.md) | ContourFlange, ContourRoll & LoftedFlange |

--- a/implementation-plan/M20-feature-completion-geometry/F07-sheet-metal-corners/PBI-183-corner-features.md
+++ b/implementation-plan/M20-feature-completion-geometry/F07-sheet-metal-corners/PBI-183-corner-features.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F07
+pbi: PBI-183
+title: Corner, CornerChamfer, CornerRound & CornerSeam
+status: planned
+estimate: M
+---
+
+# PBI-183 — Corner, CornerChamfer, CornerRound & CornerSeam
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F07 Sheet-Metal Corner Features
+
+## Goal
+
+Treat the meeting of two flanges: round/chamfer the corner and apply a seam relief.
+
+## Scope / work
+
+`CornerFeature` (relief at a bend corner); `CornerChamferFeature`; `CornerRoundFeature`; `CornerSeamFeature` (gap/overlap/rip between adjacent walls).
+
+## API contracts (interfaces / enums / collections)
+
+- `CornerFeature(s)`/`CornerChamferFeature(s)`/`CornerRoundFeature(s)`/`CornerSeamFeature(s)`.
+
+## Acceptance criteria
+
+- Two flanges meeting at a corner get a seam with the specified gap
+- a corner-round rounds the outer corner
+- validated
+- recompute on gap/radius.
+
+## Depends on
+
+M20·F06
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F07-sheet-metal-corners/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F07-sheet-metal-corners/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F07
+name: Sheet-Metal Corner Features
+status: planned
+---
+
+# M20 · F07 — Sheet-Metal Corner Features
+
+Corner, CornerChamfer, CornerRound, CornerSeam between flanges.
+
+## Depends on
+
+M20·F06
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-183](PBI-183-corner-features.md) | Corner, CornerChamfer, CornerRound & CornerSeam |

--- a/implementation-plan/M20-feature-completion-geometry/F08-sheet-metal-modify/PBI-184-sm-modify.md
+++ b/implementation-plan/M20-feature-completion-geometry/F08-sheet-metal-modify/PBI-184-sm-modify.md
@@ -1,0 +1,42 @@
+---
+milestone: M20
+feature: F08
+pbi: PBI-184
+title: Cut, Rip, PunchTool, CosmeticBend, Unfold/Refold
+status: planned
+estimate: L
+---
+
+# PBI-184 — Cut, Rip, PunchTool, CosmeticBend, Unfold/Refold
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F08 Sheet-Metal Modify & Cosmetic
+
+## Goal
+
+The SM modify features: thickness-aware cut, rip a closed wall open, place a punch, mark a cosmetic bend, and unfold/refold selected bends in the model.
+
+## Scope / work
+
+`CutFeature` (SM cut normal to face, optional follow-thickness); `RipFeature` (open a wall along a line/points); `PunchToolFeature` (place an iFeature punch); `CosmeticBendFeature` (annotation bend); `UnfoldFeature`/`RefoldFeature` (flatten/restore selected bends).
+
+## API contracts (interfaces / enums / collections)
+
+- `CutFeature(s)`/`RipFeature(s)`/`PunchToolFeature(s)`/`CosmeticBendFeature(s)`/`UnfoldFeature(s)`/`RefoldFeature(s)`.
+
+## Acceptance criteria
+
+- An SM cut removes material through the wall
+- a rip opens a closed box
+- unfold flattens one bend then refold restores it
+- validated
+- recompute.
+
+## Depends on
+
+M20·F06, M20·F01
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F08-sheet-metal-modify/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F08-sheet-metal-modify/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F08
+name: Sheet-Metal Modify & Cosmetic
+status: planned
+---
+
+# M20 · F08 — Sheet-Metal Modify & Cosmetic
+
+Cut, Rip, PunchTool, CosmeticBend, Unfold, Refold.
+
+## Depends on
+
+M20·F06, M20·F01
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-184](PBI-184-sm-modify.md) | Cut, Rip, PunchTool, CosmeticBend, Unfold/Refold |

--- a/implementation-plan/M20-feature-completion-geometry/F09-flat-pattern/PBI-185-flat-pattern-unfold.md
+++ b/implementation-plan/M20-feature-completion-geometry/F09-flat-pattern/PBI-185-flat-pattern-unfold.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F09
+pbi: PBI-185
+title: Flat-pattern unfold solver
+status: planned
+estimate: M
+---
+
+# PBI-185 — Flat-pattern unfold solver
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F09 Flat Pattern
+
+## Goal
+
+Compute the flat pattern: unfold every bend by its allowance into a single planar sheet with bend lines.
+
+## Scope / work
+
+Bend graph traversal from a base face; per-bend allowance (K-factor/bend-table) flattening; `FlatPattern` model (extents, bend lines, punch centers); kept in sync with the folded model.
+
+## API contracts (interfaces / enums / collections)
+
+- `FlatPattern`, `FlatPatternFeatures`, `BendLine`, bend-allowance computation.
+
+## Acceptance criteria
+
+- An L-shaped two-wall part unfolds to one rectangle whose length = wall1 + allowance + wall2
+- bend line recorded at the right offset
+- recompute when a wall length changes.
+
+## Depends on
+
+M20·F06
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F09-flat-pattern/PBI-186-flat-export.md
+++ b/implementation-plan/M20-feature-completion-geometry/F09-flat-pattern/PBI-186-flat-export.md
@@ -1,0 +1,39 @@
+---
+milestone: M20
+feature: F09
+pbi: PBI-186
+title: Flat-pattern DXF/DWG export
+status: planned
+estimate: M
+---
+
+# PBI-186 — Flat-pattern DXF/DWG export
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F09 Flat Pattern
+
+## Goal
+
+Export the flat pattern outline + bend lines to a 2D DXF for manufacturing.
+
+## Scope / work
+
+DXF writer (outer/inner loops as polylines, bend lines on a layer); behind a thin `FlatExporter` interface.
+
+## API contracts (interfaces / enums / collections)
+
+- `FlatExporter`, `ExportFlatPatternDXF`.
+
+## Acceptance criteria
+
+- Exporting an unfolded part writes a DXF whose polyline closes to the flat extents and whose bend-line layer holds the bend lines
+- re-import parses to the same loop.
+
+## Depends on
+
+M20·F06
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F09-flat-pattern/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F09-flat-pattern/_feature.md
@@ -1,0 +1,21 @@
+---
+milestone: M20
+feature: F09
+name: Flat Pattern
+status: planned
+---
+
+# M20 · F09 — Flat Pattern
+
+Unfold the folded model to a flat sheet with correct bend allowances; export to DXF/DWG.
+
+## Depends on
+
+M20·F06
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-185](PBI-185-flat-pattern-unfold.md) | Flat-pattern unfold solver |
+| [PBI-186](PBI-186-flat-export.md) | Flat-pattern DXF/DWG export |

--- a/implementation-plan/M20-feature-completion-geometry/F10-plastic-features/PBI-187-boss-emboss-grill-lip.md
+++ b/implementation-plan/M20-feature-completion-geometry/F10-plastic-features/PBI-187-boss-emboss-grill-lip.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F10
+pbi: PBI-187
+title: Boss, Emboss, Grill & Lip
+status: planned
+estimate: L
+---
+
+# PBI-187 — Boss, Emboss, Grill & Lip
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F10 Plastic Part Features
+
+## Goal
+
+The additive plastic features: mounting boss, embossed/engraved profile, ventilation grill, mating lip/groove.
+
+## Scope / work
+
+`PlasticBossFeature` (head+thread+ribs); `EmbossFeature` (raise/engrave/emboss-from-face a profile by a depth — boolean on the running solid); `GrillFeature` (island/rib/spar/draft set in a boundary); `LipFeature` (lip+groove along an edge path).
+
+## API contracts (interfaces / enums / collections)
+
+- `EmbossFeature(s)`/`GrillFeature(s)`/`LipFeature(s)`/plastic `BossFeature` variants + `*Definition`.
+
+## Acceptance criteria
+
+- An emboss raises a profile region into a validated solid
+- engrave cuts it
+- a lip runs along a top edge
+- recompute on depth.
+
+## Depends on
+
+M20·F01, M20·F03
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F10-plastic-features/PBI-188-rest-rulefillet-snapfit.md
+++ b/implementation-plan/M20-feature-completion-geometry/F10-plastic-features/PBI-188-rest-rulefillet-snapfit.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F10
+pbi: PBI-188
+title: Rest, RuleFillet & SnapFit
+status: planned
+estimate: M
+---
+
+# PBI-188 — Rest, RuleFillet & SnapFit
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F10 Plastic Part Features
+
+## Goal
+
+Rest pad, rule-based fillet over many edges, and snap-fit (cantilever/annular) connectors.
+
+## Scope / work
+
+`RestFeature` (a raised landing); `RuleFilletFeature` (fillet edges selected by a rule — all-around/between-faces/feature) reusing F03; `SnapFitFeature` (cantilever hook or annular ring).
+
+## API contracts (interfaces / enums / collections)
+
+- `RestFeature(s)`/`RuleFilletFeature(s)`/`SnapFitFeature(s)` + `*Definition`.
+
+## Acceptance criteria
+
+- A rule fillet rounds every edge matching the rule
+- a cantilever snap-fit adds a validated hook solid
+- recompute.
+
+## Depends on
+
+M20·F01, M20·F03
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F10-plastic-features/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F10-plastic-features/_feature.md
@@ -1,0 +1,21 @@
+---
+milestone: M20
+feature: F10
+name: Plastic Part Features
+status: planned
+---
+
+# M20 · F10 — Plastic Part Features
+
+Boss(plastic), Emboss, Grill, Lip, Rest, RuleFillet, SnapFit.
+
+## Depends on
+
+M20·F01, M20·F03
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-187](PBI-187-boss-emboss-grill-lip.md) | Boss, Emboss, Grill & Lip |
+| [PBI-188](PBI-188-rest-rulefillet-snapfit.md) | Rest, RuleFillet & SnapFit |

--- a/implementation-plan/M20-feature-completion-geometry/F11-cosmetic-reference/PBI-189-cosmetic-reference.md
+++ b/implementation-plan/M20-feature-completion-geometry/F11-cosmetic-reference/PBI-189-cosmetic-reference.md
@@ -1,0 +1,38 @@
+---
+milestone: M20
+feature: F11
+pbi: PBI-189
+title: Decal, Reference, Client, Mark & Finish
+status: planned
+estimate: M
+---
+
+# PBI-189 — Decal, Reference, Client, Mark & Finish
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F11 Cosmetic & Reference Features
+
+## Goal
+
+The features that annotate or reference rather than cut material, for full API/persistence parity.
+
+## Scope / work
+
+`DecalFeature` (image on a face via sketch); `ReferenceFeature` (frozen reference body from elsewhere); `ClientFeature` (add-in-owned feature with attribute payload); `MarkFeature` (laser/etch mark); `FinishFeature` (surface finish spec). Pass-through recompute; full triangle + .obk round-trip.
+
+## API contracts (interfaces / enums / collections)
+
+- `DecalFeature(s)`/`ReferenceFeature(s)`/`ClientFeature(s)`/`MarkFeature(s)`/`FinishFeature(s)` + `*Definition`.
+
+## Acceptance criteria
+
+- Each adds via its collection, round-trips through .obk, passes the running body through unchanged, and carries its payload (image ref/attributes/finish spec).
+
+## Depends on
+
+M08
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F11-cosmetic-reference/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F11-cosmetic-reference/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F11
+name: Cosmetic & Reference Features
+status: planned
+---
+
+# M20 · F11 — Cosmetic & Reference Features
+
+Decal, ReferenceFeature, ClientFeature, Mark, Finish — non-solid-modifying parity features.
+
+## Depends on
+
+M08
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-189](PBI-189-cosmetic-reference.md) | Decal, Reference, Client, Mark & Finish |

--- a/implementation-plan/M20-feature-completion-geometry/F12-body-transform/PBI-190-body-transform-op-move.md
+++ b/implementation-plan/M20-feature-completion-geometry/F12-body-transform/PBI-190-body-transform-op-move.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F12
+pbi: PBI-190
+title: Body transform op & Move feature
+status: planned
+estimate: M
+---
+
+# PBI-190 — Body transform op & Move feature
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F12 Body Transform Features
+
+## Goal
+
+A rigid transform (translate/rotate/reflect) of a B-rep body with stable lineage, plus the `MoveFeature`.
+
+## Scope / work
+
+`ops.TransformBody` (apply a 4×4 to every vertex, flip orientation on reflection, derive lineage); `MoveFeature` (free move/rotate of a body or face set by a transform).
+
+## API contracts (interfaces / enums / collections)
+
+- `ops.TransformBody`; `MoveFeature(s)`/`MoveDefinition`.
+
+## Acceptance criteria
+
+- Translating a box preserves volume/validity and shifts the range box
+- reflecting it keeps it manifold with outward normals
+- recompute on transform change.
+
+## Depends on
+
+M07
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F12-body-transform/PBI-191-pattern-mirror-geometry.md
+++ b/implementation-plan/M20-feature-completion-geometry/F12-body-transform/PBI-191-pattern-mirror-geometry.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F12
+pbi: PBI-191
+title: Pattern & mirror real duplication
+status: planned
+estimate: L
+---
+
+# PBI-191 — Pattern & mirror real duplication
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F12 Body Transform Features
+
+## Goal
+
+Make the existing Rectangular/Circular/SketchDriven patterns and Mirror emit real transformed copies via the new op.
+
+## Scope / work
+
+Wire `ops.TransformBody` into the pattern/mirror recompute so each active element is a real placed copy (booleaned into the result for join, kept separate for new-body); per-element suppression honored.
+
+## API contracts (interfaces / enums / collections)
+
+- `RectangularPatternFeature`/`CircularPatternFeature`/`SketchDrivenPatternFeature`/`MirrorFeature` real geometry.
+
+## Acceptance criteria
+
+- A 1×3 rectangular pattern of a boss yields three real placed solids at the right pitch
+- mirror reflects the source across a plane
+- suppressing element 2 removes only it
+- recompute.
+
+## Depends on
+
+M07
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F12-body-transform/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F12-body-transform/_feature.md
@@ -1,0 +1,21 @@
+---
+milestone: M20
+feature: F12
+name: Body Transform Features
+status: planned
+---
+
+# M20 · F12 — Body Transform Features
+
+A rigid body-transform kernel op that turns Move/Copy/Mirror and the existing patterns into real duplicated geometry.
+
+## Depends on
+
+M07
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-190](PBI-190-body-transform-op-move.md) | Body transform op & Move feature |
+| [PBI-191](PBI-191-pattern-mirror-geometry.md) | Pattern & mirror real duplication |

--- a/implementation-plan/M20-feature-completion-geometry/F13-direct-edit-simplify/PBI-192-direct-edit-simplify.md
+++ b/implementation-plan/M20-feature-completion-geometry/F13-direct-edit-simplify/PBI-192-direct-edit-simplify.md
@@ -1,0 +1,41 @@
+---
+milestone: M20
+feature: F13
+pbi: PBI-192
+title: DirectEdit, Simplify, Unwrap & ModelTolerance
+status: planned
+estimate: M
+---
+
+# PBI-192 — DirectEdit, Simplify, Unwrap & ModelTolerance
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F13 Direct-Edit & Simplify Features
+
+## Goal
+
+The whole-model editing features that don't fit a single local op.
+
+## Scope / work
+
+`DirectEditFeature` (move/size/scale/rotate/delete-face wrapper over F04 ops); `SimplifyFeature` (remove faces/fill voids/envelope to reduce a model); `UnwrapFeature` (flatten a curved face to a planar patch); `ModelToleranceFeature` (GD&T tolerance carrier on the model).
+
+## API contracts (interfaces / enums / collections)
+
+- `DirectEditFeature(s)`/`SimplifyFeature(s)`/`UnwrapFeature(s)`/`ModelToleranceFeature(s)` + `*Definition`.
+
+## Acceptance criteria
+
+- A direct-edit move dispatches to the F04 move-face op
+- simplify removes a selected feature set producing a validated lighter body
+- unwrap flattens a cylindrical face
+- round-trip.
+
+## Depends on
+
+M20·F04
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F13-direct-edit-simplify/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F13-direct-edit-simplify/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F13
+name: Direct-Edit & Simplify Features
+status: planned
+---
+
+# M20 · F13 — Direct-Edit & Simplify Features
+
+DirectEdit, Simplify, Unwrap, ModelTolerance.
+
+## Depends on
+
+M20·F04
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-192](PBI-192-direct-edit-simplify.md) | DirectEdit, Simplify, Unwrap & ModelTolerance |

--- a/implementation-plan/M20-feature-completion-geometry/F14-ifeature-catalog/PBI-193-ifeature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F14-ifeature-catalog/PBI-193-ifeature.md
@@ -1,0 +1,39 @@
+---
+milestone: M20
+feature: F14
+pbi: PBI-193
+title: iFeature extract & place
+status: planned
+estimate: M
+---
+
+# PBI-193 — iFeature extract & place
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F14 iFeature Catalog
+
+## Goal
+
+Capture selected features + their parameters/inputs as an `iFeature` definition, and place parameterized instances.
+
+## Scope / work
+
+`iFeatureDefinition` (captured features, exposed parameters, input placeholders); extract from a part; `iFeatures.Add` places at a location binding the input references and overriding exposed params; .obk + catalog file round-trip.
+
+## API contracts (interfaces / enums / collections)
+
+- `iFeature(s)`/`iFeatureDefinition`/`iFeatureParameter`; catalog read/write behind a thin interface.
+
+## Acceptance criteria
+
+- Extracting a hole+fillet pair to an iFeature then placing it on another face reproduces both features with overridden diameter
+- round-trips.
+
+## Depends on
+
+M08, M20·F01
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F14-ifeature-catalog/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F14-ifeature-catalog/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F14
+name: iFeature Catalog
+status: planned
+---
+
+# M20 · F14 — iFeature Catalog
+
+Extract a feature set as a reusable catalog iFeature and place instances of it.
+
+## Depends on
+
+M08, M20·F01
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-193](PBI-193-ifeature.md) | iFeature extract & place |

--- a/implementation-plan/M20-feature-completion-geometry/F15-presentation-mesh/PBI-194-presentation-mesh.md
+++ b/implementation-plan/M20-feature-completion-geometry/F15-presentation-mesh/PBI-194-presentation-mesh.md
@@ -1,0 +1,40 @@
+---
+milestone: M20
+feature: F15
+pbi: PBI-194
+title: Presentation mesh & mesh→B-rep
+status: planned
+estimate: M
+---
+
+# PBI-194 — Presentation mesh & mesh→B-rep
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F15 Presentation Mesh Feature
+
+## Goal
+
+A `PresentationMeshFeature` (lightweight display mesh) and conversion of an imported mesh to a B-rep solid.
+
+## Scope / work
+
+`PresentationMeshFeature` wraps a `MeshGeometry` for display-only use (passes the solid through); `ops.MeshToBRep` converts a closed welded mesh to a faceted B-rep solid (one planar face per facet, shared edges/verts).
+
+## API contracts (interfaces / enums / collections)
+
+- `PresentationMeshFeature(s)`; `ops.MeshToBRep`.
+
+## Acceptance criteria
+
+- A tetra mesh converts to a validated 4-face solid
+- the presentation-mesh feature carries the mesh without altering the running body
+- round-trip.
+
+## Depends on
+
+M10
+
+## Notes
+
+Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
+`addin/router` handler, `.obk` round-trip, and executable tests.

--- a/implementation-plan/M20-feature-completion-geometry/F15-presentation-mesh/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F15-presentation-mesh/_feature.md
@@ -1,0 +1,20 @@
+---
+milestone: M20
+feature: F15
+name: Presentation Mesh Feature
+status: planned
+---
+
+# M20 · F15 — Presentation Mesh Feature
+
+PresentationMeshFeature plus mesh→B-rep conversion for downstream parametric use.
+
+## Depends on
+
+M10
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-194](PBI-194-presentation-mesh.md) | Presentation mesh & mesh→B-rep |

--- a/implementation-plan/M20-feature-completion-geometry/_milestone.md
+++ b/implementation-plan/M20-feature-completion-geometry/_milestone.md
@@ -1,0 +1,79 @@
+---
+milestone: M20
+name: Feature Completion & Geometry Parity
+status: in-progress
+---
+
+# M20 — Feature Completion & Geometry Parity
+
+The Extrude feature (M08·PBI-092) established the canonical feature pattern: the
+`Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`
+surface, `addin/router` handler, `.obk` serialize round-trip, UI/ribbon hook, and
+executable tests. This milestone drives **every remaining Inventor `*Feature` type
+to the same standard, with real generated geometry** — not just deferred recipes.
+
+Most part/surface features already exist as triangles whose geometry is *deferred*
+because the kernel's core solid operations were postponed (general intersecting
+booleans, NURBS sweeps, rolling-ball fillets — "Phase B/C/D, NotYetImplemented").
+This milestone implements those kernel operations first, then completes the
+features that sit on them, then adds the feature families with no presence yet:
+**sheet metal**, **plastic parts**, and the **misc model features** (move,
+direct-edit, reference, finish, mark, simplify, iFeature, presentation mesh).
+
+## Goals
+
+- Land the deferred kernel ops (intersecting booleans, swept surfaces, fillet,
+  local face ops, body transform) so existing deferred features emit real solids.
+- Complete the full sheet-metal environment, feature set, and flat-pattern unfold.
+- Complete the plastic-part feature set.
+- Complete the remaining misc model features for API/persistence parity.
+
+## In scope (every remaining `*Feature` in the Inventor API)
+
+- **Kernel enablers:** intersecting booleans, swept/lofted/revolved/coil surfaces,
+  rolling-ball fillet/chamfer, local face ops, rigid body transform.
+- **Geometry-completion** of deferred M08/M09/M10 features (Revolve, Sweep, Loft,
+  Coil, Rib, Fillet, Chamfer, Shell, Draft, Hole, Boss, Combine, Split, face edits,
+  Thicken, patterns, mirror).
+- **Sheet metal:** environment+rules; Face/Flange/ContourFlange/ContourRoll/Hem/
+  Bend/Fold/LoftedFlange; Corner/CornerChamfer/CornerRound/CornerSeam; Cut/Rip/
+  PunchTool/CosmeticBend/Unfold/Refold; FlatPattern + DXF.
+- **Plastic parts:** Boss(plastic)/Emboss/Grill/Lip/Rest/RuleFillet/SnapFit; Decal.
+- **Misc:** Move(body)/DirectEdit/Reference/Client/Finish/Mark/Simplify/Unwrap/
+  ModelTolerance/iFeature/PresentationMesh.
+
+## Out of scope (handled elsewhere)
+
+- Assembly features (M11/M12), drawing of features (M14), full materials (M19).
+
+## Exit criteria
+
+- Every Inventor `*Feature` type has a `Definition → Add → Feature(+Proxy)` triangle,
+  a `/api` surface, a `.obk` round-trip, and tests green in `make ci`.
+- The deferred features that depend on landed kernel ops now generate validated
+  manifold geometry (no longer Warning-deferred) and recompute on parameter change.
+- A sheet-metal part unfolds to a correct flat pattern and exports to DXF.
+
+## Depends on
+
+M08, M09, M10 (and the M07 kernel/ops foundation they extend).
+
+## Features
+
+| ID | Feature | PBIs | Summary |
+|----|---------|:----:|---------|
+| **F01** | [Intersecting Booleans](F01-intersecting-booleans/_feature.md) | 2 | Face-splitting solid/solid boolean (Phase-C); unblocks Cut/Split/Hole/Combine/Emboss/sheet-metal/plastics. |
+| **F02** | [Swept-Surface Generation](F02-swept-surface-generation/_feature.md) | 2 | Surfaces of revolution + sweep/loft/coil → real solids (Revolve/Sweep/Loft/Coil/Rib). |
+| **F03** | [Fillet & Chamfer Geometry](F03-fillet-chamfer-geometry/_feature.md) | 2 | Rolling-ball fillet, chamfer faces, variable/setback; corner-round. |
+| **F04** | [Local Face Operations](F04-local-face-ops/_feature.md) | 2 | Move/offset/delete/replace face, draft, shell, thicken real geometry. |
+| **F05** | [Sheet-Metal Environment & Rules](F05-sheet-metal-environment/_feature.md) | 1 | `SheetMetalComponentDefinition`, thickness/radius/K-factor styles, unfold methods. |
+| **F06** | [Sheet-Metal Wall & Bend Features](F06-sheet-metal-wall-bend/_feature.md) | 3 | Face, Flange, ContourFlange, ContourRoll, Hem, Bend, Fold, LoftedFlange. |
+| **F07** | [Sheet-Metal Corner Features](F07-sheet-metal-corners/_feature.md) | 1 | Corner, CornerChamfer, CornerRound, CornerSeam. |
+| **F08** | [Sheet-Metal Modify & Cosmetic](F08-sheet-metal-modify/_feature.md) | 1 | Cut, Rip, PunchTool, CosmeticBend, Unfold, Refold. |
+| **F09** | [Flat Pattern](F09-flat-pattern/_feature.md) | 2 | Unfold solver, bend allowance, flat extents, DXF/DWG export. |
+| **F10** | [Plastic Part Features](F10-plastic-features/_feature.md) | 2 | Boss(plastic), Emboss, Grill, Lip, Rest, RuleFillet, SnapFit. |
+| **F11** | [Cosmetic & Reference Features](F11-cosmetic-reference/_feature.md) | 1 | Decal, ReferenceFeature, ClientFeature, Mark, Finish. |
+| **F12** | [Body Transform Features](F12-body-transform/_feature.md) | 2 | Rigid body transform op → Move(body), Copy, Mirror-body, real pattern/mirror duplication. |
+| **F13** | [Direct-Edit & Simplify Features](F13-direct-edit-simplify/_feature.md) | 1 | DirectEdit, Simplify, Unwrap, ModelTolerance. |
+| **F14** | [iFeature Catalog](F14-ifeature-catalog/_feature.md) | 1 | Extract/place catalog iFeatures. |
+| **F15** | [Presentation Mesh Feature](F15-presentation-mesh/_feature.md) | 1 | `PresentationMeshFeature` + mesh→B-rep. |

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -41,7 +41,8 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 
 | PBI | Title | Status | Go package | Notes |
 |-----|-------|:------:|------------|-------|
-| 171 | Face-splitting solid/solid boolean | 🟦 | `kernel/ops` | In progress — see branch `feat/m20-feature-completion`. |
+| 190 | Body transform op & Move feature | ✅ | `kernel/geom`, `kernel/ops`, `model/feature`, `math` | `geom.TransformCurve`/`TransformSurface` (similarity-transform dispatchers over the analytic curve/surface types) + `ops.TransformBody` (clones a body's combinatorial topology, maps geometry, reverses winding on reflection so normals stay outward → stays a valid manifold under translate/rotate/reflect/uniform-scale; rejects non-uniform scale). A caller `derive` either preserves reference keys (in-place Move) or makes distinct-key copies (pattern/mirror). `MoveFeature`/`MoveDefinition` relocates a running body in place (keys survive); `math.Matrix4FromCells` persists the transform as 16 cells → `.obk` round-trips. The shared enabler for pattern/mirror geometry (PBI-191). |
+| 171 | Face-splitting solid/solid boolean | ⬜ | `kernel/ops` | Planned — the biggest unblocker (Cut/Split/Hole/Emboss/sheet-metal). |
 
 ### M10 — Surfacing & Freeform Modeling
 

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -33,8 +33,15 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 | M16 | Visualization & Presentation | ⬜ | |
 | M17 | Interoperability & Translation | ⬜ | |
 | M18 | Analysis & Simulation | ⬜ | |
+| M20 | Feature Completion & Geometry Parity | 🟦 | Consolidated drive of every remaining Inventor `*Feature` to real geometry: kernel enablers (intersecting booleans, swept surfaces, fillet, local face ops, body transform) + sheet-metal + plastic + misc model features. |
 
 ## PBI log (most recent first)
+
+### M20 — Feature Completion & Geometry Parity
+
+| PBI | Title | Status | Go package | Notes |
+|-----|-------|:------:|------------|-------|
+| 171 | Face-splitting solid/solid boolean | 🟦 | `kernel/ops` | In progress — see branch `feat/m20-feature-completion`. |
 
 ### M10 — Surfacing & Freeform Modeling
 

--- a/implementation-plan/README.md
+++ b/implementation-plan/README.md
@@ -39,6 +39,7 @@ rules (units, identity, transactions, events) that apply to every milestone.
 | **M16** | [Visualization, Appearances, Styles & Presentations](M16-visualization-presentation/_milestone.md) | 4 | 7 | M07, M11 |
 | **M17** | [Interoperability & Translation](M17-interoperability-translation/_milestone.md) | 4 | 6 | M07 |
 | **M18** | [Analysis, Measurement & Simulation](M18-analysis-simulation/_milestone.md) | 5 | 7 | M07, M11, M16 |
+| **M20** | [Feature Completion & Geometry Parity](M20-feature-completion-geometry/_milestone.md) | 15 | 24 | M08, M09, M10 |
 
 ## Dependency spine
 

--- a/kernel/geom/transform.go
+++ b/kernel/geom/transform.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/build"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// TransformCurve maps a curve by m, which must be a similarity transform
+// (rotation, translation, reflection, and/or uniform scale). Non-uniform scale or
+// shear is rejected because it would turn an analytic curve (a circle, an arc)
+// into a different curve type that the analytic representation cannot hold.
+//
+// Example: rotating a circle's edge curve when its body is patterned:
+//
+//	c2, err := geom.TransformCurve(edge.Geometry(), math.Rotation4(a, axis, ctr))
+func TransformCurve(c Curve3, m math.Matrix4) (Curve3, error) {
+	scale, err := similarityScale(m)
+	if err != nil {
+		return nil, err
+	}
+	switch g := c.(type) {
+	case LineSegment:
+		return NewLineSegment(m.TransformPoint(g.StartPoint), m.TransformPoint(g.EndPoint)), nil
+	case Line:
+		return NewLine(m.TransformPoint(g.Origin), m.TransformVector(g.Dir.AsVector()))
+	case Circle:
+		return transformCircle(g, m, scale)
+	case Arc3d:
+		return transformArc(g, m, scale)
+	default:
+		return nil, build.NotYetImplemented(fmt.Sprintf("geom.TransformCurve: %T", c))
+	}
+}
+
+// TransformSurface maps a surface by m under the same similarity constraint as
+// [TransformCurve].
+func TransformSurface(s Surface, m math.Matrix4) (Surface, error) {
+	scale, err := similarityScale(m)
+	if err != nil {
+		return nil, err
+	}
+	switch g := s.(type) {
+	case Plane:
+		return NewPlaneFromAxes(m.TransformPoint(g.Origin),
+			m.TransformVector(g.UAxis.AsVector()), m.TransformVector(g.VAxis.AsVector()))
+	case Cylinder:
+		return transformCylinder(g, m, scale)
+	case Cone:
+		return transformCone(g, m)
+	case Sphere:
+		return NewSphere(m.TransformPoint(g.Center), g.Radius*scale)
+	case Torus:
+		return transformTorus(g, m, scale)
+	default:
+		return nil, build.NotYetImplemented(fmt.Sprintf("geom.TransformSurface: %T", s))
+	}
+}
+
+// transformCircle preserves the circle's reference frame (Normal, RefDir) so its
+// parameterization carries over, scaling the radius by the similarity factor.
+func transformCircle(c Circle, m math.Matrix4, scale float64) (Circle, error) {
+	n, err := math.UnitVector3FromVector(m.TransformVector(c.Normal.AsVector()))
+	if err != nil {
+		return Circle{}, err
+	}
+	ref, err := math.UnitVector3FromVector(m.TransformVector(c.RefDir.AsVector()))
+	if err != nil {
+		return Circle{}, err
+	}
+	return Circle{Center: m.TransformPoint(c.Center), Normal: n, RefDir: ref, Radius: c.Radius * scale}, nil
+}
+
+func transformArc(a Arc3d, m math.Matrix4, scale float64) (Arc3d, error) {
+	n, err := math.UnitVector3FromVector(m.TransformVector(a.Normal.AsVector()))
+	if err != nil {
+		return Arc3d{}, err
+	}
+	ref, err := math.UnitVector3FromVector(m.TransformVector(a.RefDir.AsVector()))
+	if err != nil {
+		return Arc3d{}, err
+	}
+	return Arc3d{
+		Center: m.TransformPoint(a.Center), Normal: n, RefDir: ref,
+		Radius: a.Radius * scale, StartAngle: a.StartAngle, SweepAngle: a.SweepAngle,
+	}, nil
+}
+
+func transformCylinder(c Cylinder, m math.Matrix4, scale float64) (Cylinder, error) {
+	out, err := NewCylinder(m.TransformPoint(c.Origin), m.TransformVector(c.AxisDir.AsVector()), c.Radius*scale)
+	return out, err
+}
+
+func transformCone(c Cone, m math.Matrix4) (Cone, error) {
+	out, err := NewCone(m.TransformPoint(c.Apex), m.TransformVector(c.AxisDir.AsVector()), c.HalfAngle)
+	return out, err
+}
+
+func transformTorus(t Torus, m math.Matrix4, scale float64) (Torus, error) {
+	out, err := NewTorus(m.TransformPoint(t.Center), m.TransformVector(t.AxisDir.AsVector()),
+		t.MajorRadius*scale, t.MinorRadius*scale)
+	return out, err
+}
+
+// similarityScale returns the uniform scale factor of m and rejects non-uniform
+// scale or shear (the analytic types cannot represent the result). The factor is
+// always positive; reflection (negative determinant) is a valid similarity whose
+// orientation flip is handled by the caller, not folded into the scale.
+func similarityScale(m math.Matrix4) (float64, error) {
+	sx := m.TransformVector(math.V3(1, 0, 0)).Length()
+	sy := m.TransformVector(math.V3(0, 1, 0)).Length()
+	sz := m.TransformVector(math.V3(0, 0, 1)).Length()
+	const tol = 1e-9
+	if sx <= tol || sy <= tol || sz <= tol {
+		return 0, fmt.Errorf("geom.similarityScale: degenerate transform (axis lengths %g,%g,%g)", sx, sy, sz)
+	}
+	if stdmath.Abs(sx-sy) > tol*sx || stdmath.Abs(sx-sz) > tol*sx {
+		return 0, fmt.Errorf("geom.similarityScale: non-uniform scale (axis lengths %g,%g,%g); only similarity transforms are supported", sx, sy, sz)
+	}
+	return (sx + sy + sz) / 3, nil
+}

--- a/kernel/ops/transform.go
+++ b/kernel/ops/transform.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// TransformBody returns a copy of b mapped by the similarity transform m
+// (rotation / translation / reflection / uniform scale), preserving the exact
+// combinatorial topology so the result stays a valid manifold.
+//
+// Each entity's lineage is remapped through derive: pass the identity for an
+// in-place Move (reference keys are preserved, so picks survive), or a
+// token-appending function for a pattern/mirror copy so every copy gets distinct
+// reference keys. Reflection (negative determinant) reverses every loop's winding
+// so face normals stay outward — the winding flip keeps each edge's two uses
+// oppositely oriented, so [Validate] still passes.
+//
+// Example — reflect a body across the X... plane for a mirror feature:
+//
+//	dst, err := ops.TransformBody(src, reflectM, func(l topo.Lineage) topo.Lineage {
+//	    return prepend(topo.Tok("mirror", "copy", 0), l)
+//	})
+func TransformBody(b *topo.Body, m math.Matrix4, derive func(topo.Lineage) topo.Lineage) (*topo.Body, error) {
+	if n := len(b.Shells()); n != 1 {
+		return nil, fmt.Errorf("ops.TransformBody: %d shells; only single-shell bodies are supported", n)
+	}
+	reflected := m.Determinant() < 0
+	bld := topo.NewBuilder(b.IsSolid(), derive(b.Lineage()))
+
+	verts := make(map[*topo.Vertex]*topo.Vertex, len(b.Vertices()))
+	for _, v := range b.Vertices() {
+		verts[v] = bld.AddVertex(m.TransformPoint(v.Point()), derive(v.Lineage()))
+	}
+	edges := make(map[*topo.Edge]*topo.Edge, len(b.Edges()))
+	for _, e := range b.Edges() {
+		curve, err := geom.TransformCurve(e.Geometry(), m)
+		if err != nil {
+			return nil, fmt.Errorf("ops.TransformBody: edge %d: %w", e.ID(), err)
+		}
+		edges[e] = bld.AddEdge(curve, verts[e.StartVertex()], verts[e.EndVertex()], derive(e.Lineage()))
+	}
+	for _, f := range b.Faces() {
+		surface, err := geom.TransformSurface(f.Geometry(), m)
+		if err != nil {
+			return nil, fmt.Errorf("ops.TransformBody: face %d: %w", f.ID(), err)
+		}
+		bld.AddFace(surface, derive(f.Lineage()), loopSpecs(f, edges, reflected)...)
+	}
+	return bld.Build(), nil
+}
+
+// loopSpecs rebuilds a face's loop specs against the cloned edges, reversing the
+// winding when the transform is a reflection so normals stay outward.
+func loopSpecs(f *topo.Face, edges map[*topo.Edge]*topo.Edge, reflected bool) []topo.LoopSpec {
+	specs := make([]topo.LoopSpec, 0, len(f.Loops()))
+	for _, l := range f.Loops() {
+		oldUses := l.EdgeUses()
+		uses := make([]topo.Use, len(oldUses))
+		for i, u := range oldUses {
+			uses[i] = topo.Use{Edge: edges[u.Edge()], Reversed: u.Reversed()}
+		}
+		if reflected {
+			uses = reverseWinding(uses)
+		}
+		if l.IsOuter() {
+			specs = append(specs, topo.OuterLoop(uses...))
+		} else {
+			specs = append(specs, topo.InnerLoop(uses...))
+		}
+	}
+	return specs
+}
+
+// reverseWinding flips a loop's traversal: reverse the edge-use order and invert
+// each reversed flag, yielding the same cycle walked the opposite way.
+func reverseWinding(uses []topo.Use) []topo.Use {
+	out := make([]topo.Use, len(uses))
+	for i, u := range uses {
+		out[len(uses)-1-i] = topo.Use{Edge: u.Edge, Reversed: !u.Reversed}
+	}
+	return out
+}

--- a/kernel/ops/transform_test.go
+++ b/kernel/ops/transform_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// boxBody builds a validated 2×2×2 solid box at the origin via the sub-D primitive.
+func boxBody(t *testing.T) *topo.Body {
+	t.Helper()
+	b := subd.ToBody(subd.Box(2, 2, 2), "src")
+	if !ops.Validate(b).Valid {
+		t.Fatal("boxBody: source box is not valid")
+	}
+	return b
+}
+
+func keepLineage(l topo.Lineage) topo.Lineage { return l }
+
+func TestTransformBodyTranslatePreservesVolume(t *testing.T) {
+	src := boxBody(t)
+	srcVol := ops.BodyGeometryProperties(src, ops.DefaultQuality()).Volume
+
+	dst, err := ops.TransformBody(src, math.Translation4(math.V3(10, 0, 0)), keepLineage)
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	if r := ops.Validate(dst); !r.Valid {
+		t.Fatalf("translated body invalid: %v", r.Issues)
+	}
+	if !dst.IsSolid() {
+		t.Fatal("translated body should stay solid")
+	}
+	box := dst.RangeBox()
+	if stdmath.Abs(box.Min.X-10) > 1e-9 || stdmath.Abs(box.Max.X-12) > 1e-9 {
+		t.Fatalf("range box X = [%g,%g], want [10,12]", box.Min.X, box.Max.X)
+	}
+	if got := ops.BodyGeometryProperties(dst, ops.DefaultQuality()).Volume; stdmath.Abs(got-srcVol) > 1e-6 {
+		t.Fatalf("volume changed under translation: got %g want %g", got, srcVol)
+	}
+}
+
+func TestTransformBodyReflectStaysManifoldAndOutward(t *testing.T) {
+	src := boxBody(t)
+	srcVol := ops.BodyGeometryProperties(src, ops.DefaultQuality()).Volume
+
+	reflect := math.Scale4(-1, 1, 1) // determinant -1
+	dst, err := ops.TransformBody(src, reflect, keepLineage)
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	r := ops.Validate(dst)
+	if !r.Valid || !r.Manifold || !r.OrientationOK || !r.Closed {
+		t.Fatalf("reflected body not a valid manifold solid: %+v", r)
+	}
+	box := dst.RangeBox()
+	if stdmath.Abs(box.Min.X-(-2)) > 1e-9 || stdmath.Abs(box.Max.X-0) > 1e-9 {
+		t.Fatalf("reflected range box X = [%g,%g], want [-2,0]", box.Min.X, box.Max.X)
+	}
+	// Volume magnitude is preserved by a reflection (the divergence-theorem sum
+	// stays positive because the winding flip keeps normals outward).
+	if got := ops.BodyGeometryProperties(dst, ops.DefaultQuality()).Volume; got <= 0 || stdmath.Abs(got-srcVol) > 1e-6 {
+		t.Fatalf("reflected volume = %g, want +%g (outward normals)", got, srcVol)
+	}
+}
+
+func TestTransformBodyIdentityLineageRebindsKeys(t *testing.T) {
+	src := boxBody(t)
+	srcFaceKey := src.Faces()[0].ReferenceKey()
+
+	dst, err := ops.TransformBody(src, math.Translation4(math.V3(1, 2, 3)), keepLineage)
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	if _, ok := dst.FindFaceByKey(srcFaceKey); !ok {
+		t.Fatal("identity-lineage move should preserve the source face reference key")
+	}
+}
+
+func TestTransformBodyCopyLineageGivesDistinctKeys(t *testing.T) {
+	src := boxBody(t)
+	srcFaceKey := src.Faces()[0].ReferenceKey()
+	copyN := func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append(l.Tokens(), topo.Tok("pattern", "copy", 1))...)
+	}
+
+	dst, err := ops.TransformBody(src, math.Translation4(math.V3(5, 0, 0)), copyN)
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	if !ops.Validate(dst).Valid {
+		t.Fatal("copy body should be valid")
+	}
+	if _, ok := dst.FindFaceByKey(srcFaceKey); ok {
+		t.Fatal("a distinct-lineage copy must not collide with the source's reference keys")
+	}
+}
+
+func TestTransformBodyRejectsNonUniformScale(t *testing.T) {
+	src := boxBody(t)
+	if _, err := ops.TransformBody(src, math.Scale4(2, 1, 1), keepLineage); err == nil {
+		t.Fatal("non-uniform scale should be rejected (analytic types cannot represent it)")
+	}
+}

--- a/math/matrix4.go
+++ b/math/matrix4.go
@@ -30,6 +30,14 @@ func Identity4() Matrix4 {
 	}}
 }
 
+// Matrix4FromCells reconstructs a transform from its 16 row-major cells — the
+// inverse of [Matrix4.Cells], used to restore a persisted transform (Inventor's
+// PutMatrixData). The caller is responsible for the cells describing an affine
+// transform (bottom row (0,0,0,1)); no normalization is applied.
+func Matrix4FromCells(cells [16]Scalar) Matrix4 {
+	return Matrix4{cells}
+}
+
 // Translation4 returns a transform that displaces every point by v.
 func Translation4(v Vector3) Matrix4 {
 	t := Identity4()

--- a/math/matrix4_test.go
+++ b/math/matrix4_test.go
@@ -14,6 +14,13 @@ func TestMatrix4Identity(t *testing.T) {
 	}
 }
 
+func TestMatrix4FromCellsRoundTrip(t *testing.T) {
+	m := Rotation4(0.7, V3(0, 0, 1).AsUnit(), P3(1, 2, 3)).Mul(Translation4(V3(4, -5, 6)))
+	if got := Matrix4FromCells(m.Cells()); !got.IsEqualTo(m, 1e-12) {
+		t.Errorf("Matrix4FromCells(m.Cells()) != m:\n%v\n%v", got.Cells(), m.Cells())
+	}
+}
+
 func TestMatrix4Translation(t *testing.T) {
 	m := Translation4(V3(1, 2, 3))
 	if got := m.TransformPoint(P3(0, 0, 0)); got != (Point3{1, 2, 3}) {

--- a/model/feature/move.go
+++ b/model/feature/move.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// MoveFeature rigidly relocates a running body by a transform (translate / rotate /
+// reflect / uniform scale). Unlike a pattern it creates no copy: the body is moved
+// in place, so its reference keys are preserved (the identity lineage map) and picks
+// against it survive the move (Inventor's MoveFeature / direct-edit move-body).
+
+// MoveDefinition is the recipe: which running body (by index) and the transform.
+type MoveDefinition struct {
+	BodyIndex int
+	Transform math.Matrix4
+}
+
+// MoveFeature applies the definition's transform to the target body each recompute.
+type MoveFeature struct{ def *MoveDefinition }
+
+// Definition returns the move recipe.
+func (m *MoveFeature) Definition() *MoveDefinition { return m.def }
+
+// Kind implements [Feature].
+func (m *MoveFeature) Kind() string { return "move" }
+
+// Recompute transforms the target body in place, leaving the others untouched.
+func (m *MoveFeature) Recompute(in Input) (Output, error) {
+	if !validIndex(m.def.BodyIndex, in.Bodies) {
+		return Output{}, fmt.Errorf("move: invalid body index %d (have %d)", m.def.BodyIndex, len(in.Bodies))
+	}
+	moved, err := ops.TransformBody(in.Bodies[m.def.BodyIndex], m.def.Transform, keepLineage)
+	if err != nil {
+		return Output{}, err
+	}
+	out := append([]*topo.Body(nil), in.Bodies...)
+	out[m.def.BodyIndex] = moved
+	return Output{Bodies: out}, nil
+}
+
+// keepLineage is the identity lineage map: an in-place move keeps reference keys so
+// downstream features that picked the moved body's faces still resolve.
+func keepLineage(l topo.Lineage) topo.Lineage { return l }
+
+// AddMove relocates the running body at bodyIndex by transform.
+func (c *ModifyFeatures) AddMove(bodyIndex int, transform math.Matrix4) *PartFeature {
+	return c.engine.Add(&MoveFeature{def: &MoveDefinition{BodyIndex: bodyIndex, Transform: transform}})
+}

--- a/model/feature/move_test.go
+++ b/model/feature/move_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/health"
+)
+
+func TestMoveTranslatesRunningBody(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(prismBody()) // unit prism at the origin
+	move := NewModifyFeatures(fs).AddMove(0, math.Translation4(math.V3(5, 0, 0)))
+	fs.Recompute()
+
+	if !move.Health().OK() {
+		t.Fatalf("move sick: %+v", move.Health())
+	}
+	if len(fs.Result()) != 1 {
+		t.Fatalf("move result = %d bodies, want 1", len(fs.Result()))
+	}
+	got := fs.Result()[0]
+	if r := ops.Validate(got); !r.Valid {
+		t.Fatalf("moved body invalid: %v", r.Issues)
+	}
+	if box := got.RangeBox(); stdmath.Abs(box.Min.X-5) > 1e-9 || stdmath.Abs(box.Max.X-6) > 1e-9 {
+		t.Errorf("moved range box X = [%g,%g], want [5,6]", box.Min.X, box.Max.X)
+	}
+}
+
+func TestMoveRejectsBadIndex(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(prismBody())
+	bad := NewModifyFeatures(fs).AddMove(7, math.Identity4())
+	fs.Recompute()
+	if bad.Health().Status != health.Sick {
+		t.Errorf("move with bad index = %v, want sick", bad.Health().Status)
+	}
+}
+
+func TestMoveFeatureRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	tx := math.Rotation4(0.5, math.V3(0, 0, 1).AsUnit(), math.P3(0, 0, 0)).Mul(math.Translation4(math.V3(2, -3, 4)))
+	NewModifyFeatures(fs).AddMove(1, tx)
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 {
+		t.Fatalf("feature count after round trip = %d, want 1", fresh.Count())
+	}
+	def := fresh.Item(0).Definition().(*MoveFeature).Definition()
+	if def.BodyIndex != 1 {
+		t.Errorf("body index = %d, want 1", def.BodyIndex)
+	}
+	if !def.Transform.IsEqualTo(tx, 1e-12) {
+		t.Errorf("transform not preserved:\n%v\n%v", def.Transform.Cells(), tx.Cells())
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -41,6 +41,7 @@ type FeatureData struct {
 	RuledSurface  *RuledSurfaceData  `yaml:"ruledSurface,omitempty"`
 	FaceEdit      *FaceEditData      `yaml:"faceEdit,omitempty"`
 	Revolve       *RevolveData       `yaml:"revolve,omitempty"`
+	Move          *MoveData          `yaml:"move,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -151,6 +152,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.Revolve = rv
+	case *MoveFeature:
+		fd.Move = serializeMove(f.def)
 	case faceEditor:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	default:
@@ -240,6 +243,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreFaceEdit(fs, fd.Kind, fd.FaceEdit)
 	case "revolve":
 		return restoreRevolve(fs, fd.Revolve, sk, work)
+	case "move":
+		return restoreMove(fs, fd.Move)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize_move.go
+++ b/model/feature/serialize_move.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// MoveData is the serialized form of a MoveFeature: the target body index and the
+// transform as its 16 row-major cells (Inventor's GetMatrixData form). The cells are
+// the general affine form so any rigid move / mirror / uniform scale round-trips.
+type MoveData struct {
+	Body   int       `yaml:"body"`
+	Matrix []float64 `yaml:"matrix"`
+}
+
+// serializeMove projects a move recipe to its persisted form.
+func serializeMove(def *MoveDefinition) *MoveData {
+	cells := def.Transform.Cells()
+	return &MoveData{Body: def.BodyIndex, Matrix: cells[:]}
+}
+
+// restoreMove rebuilds a MoveFeature, erroring on a missing payload or a matrix that
+// is not 16 cells (no silent loss of the transform).
+func restoreMove(fs *PartFeatures, d *MoveData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("move feature is missing its payload")
+	}
+	if len(d.Matrix) != 16 {
+		return nil, fmt.Errorf("move feature matrix has %d cells, want 16", len(d.Matrix))
+	}
+	var cells [16]float64
+	copy(cells[:], d.Matrix)
+	m := NewModifyFeatures(fs)
+	return m.AddMove(d.Body, math.Matrix4FromCells(cells)), nil
+}


### PR DESCRIPTION
## What

Opens **M20 — Feature Completion & Geometry Parity**, the consolidated milestone that drives every remaining Inventor `*Feature` type to the Extrude standard *with real generated geometry*, and lands its first kernel enabler.

**Planning (the milestone):**
- New `implementation-plan/M20-feature-completion-geometry/` — 1 milestone, **15 feature tickets**, **24 PBIs** covering: kernel enablers (intersecting booleans, swept surfaces, fillet, local face ops, body transform), geometry-completion of the deferred M08/M09/M10 features, and the not-yet-present families: **sheet metal**, **plastic parts**, and **misc model features** (move, direct-edit, reference, finish, mark, simplify, iFeature, presentation mesh).
- Registered in `README.md` + `PROGRESS.md`.

**Implementation — F12 / PBI-190 (body transform):**
- `geom.TransformCurve` / `geom.TransformSurface`: similarity-transform dispatchers over the analytic curve/surface types (line/circle/arc + plane/cylinder/cone/sphere/torus); non-uniform scale/shear is rejected with the offending axis lengths.
- `ops.TransformBody`: clones a body's exact combinatorial topology while mapping its geometry; a caller-supplied lineage `derive` either **preserves reference keys** (an in-place Move) or makes a **distinct-key copy** (pattern/mirror elements). Reflection reverses loop winding so face normals stay outward — the result stays a valid manifold (verified against `Validate`).
- `MoveFeature` / `MoveDefinition`: relocates a running body in place (keys survive, so downstream picks still resolve); `math.Matrix4FromCells` persists the transform as 16 row-major cells → `.obk` round-trips.

## Why

Most part/surface features already exist as `Definition→Add→Feature` triangles whose geometry was *deferred* because the kernel's core solid ops were postponed. M20 lands those ops first, then completes the features on top. `ops.TransformBody` is the shared enabler for **Move, Mirror, and pattern duplication** (next: PBI-191), so it goes first.

## Tests

- `kernel/ops/transform_test.go`: translate preserves volume + shifts range box; reflect stays a valid manifold with positive (outward) volume; identity lineage rebinds source keys; copy lineage yields distinct keys; non-uniform scale rejected.
- `model/feature/move_test.go`: move translates the running body (validated manifold, shifted box), rejects a bad index (→ sick), and round-trips through the recipe.
- `math/matrix4_test.go`: `Matrix4FromCells(m.Cells()) == m`.
- Full `make ci` green locally (fmt-check, vet, lint, `-race` across `./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)