### PR TITLE
M20: Definition of Done = UI + e2e; Revolve brought fully to it

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -82,6 +82,12 @@ func modelTabCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithAlias("E").WithEnable(notInSketch).
 			WithIcon("extrude").WithButtonStyle(LargeIconButton).
 			WithTooltip("Extrude — add depth to a sketch profile to create or modify a solid."),
+		NewCommand("Create.Revolve", "Revolve", "Create", func(s *Session) error {
+			s.StartTool(NewRevolveTool())
+			return nil
+		}).WithTab("3D Model").WithAlias("R").WithEnable(notInSketch).
+			WithIcon("revolve").WithButtonStyle(LargeIconButton).
+			WithTooltip("Revolve — spin a sketch profile about an axis to create or modify a solid."),
 	}
 }
 

--- a/app/revolve_session.go
+++ b/app/revolve_session.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Revolve tool's property window: the head reads/sets the axis
+// and angle through the tool without touching its internals, mirroring the Extrude
+// bridge.
+
+// ActiveRevolve returns the running Revolve tool, or nil when the active tool is not a
+// revolve (or there is none).
+func (s *Session) ActiveRevolve() *RevolveTool {
+	if s.tool == nil {
+		return nil
+	}
+	rv, _ := s.tool.tool.(*RevolveTool)
+	return rv
+}

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// RevolveTool is the interactive Revolve command: activate it, click a sketch region,
+// choose the axis of revolution and the swept angle in the property window, and OK to
+// add a revolve feature to the active part. It mirrors [ExtrudeTool] and is driven
+// entirely by session input so a test exercises the full flow with synthetic clicks.
+type RevolveTool struct {
+	profile   *ProfileHandle
+	axis      feature.WorkRef // origin axis (X/Y/Z) or a user work axis
+	angle     float64         // swept angle in radians; 0 ⇒ full revolution
+	operation ops.PartFeatureOperation
+	added     *feature.PartFeature
+}
+
+// NewRevolveTool returns a revolve tool defaulting to a full revolution about the Y
+// origin axis that creates a new body.
+func NewRevolveTool() *RevolveTool {
+	return &RevolveTool{axis: feature.OriginYAxis, operation: ops.NewBody}
+}
+
+// Name implements [Tool].
+func (t *RevolveTool) Name() string { return "Revolve" }
+
+// Start sets the selection filter to profiles so clicks pick a region.
+func (t *RevolveTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+
+// Pick captures the region the user clicked.
+func (t *RevolveTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		pc := p
+		t.profile = &pc
+	}
+}
+
+// The options the property window drives: the revolution axis, the swept angle, and the
+// boolean operation.
+func (t *RevolveTool) SetAxis(ref feature.WorkRef)              { t.axis = ref }
+func (t *RevolveTool) Axis() feature.WorkRef                    { return t.axis }
+func (t *RevolveTool) SetAngle(radians float64)                 { t.angle = radians }
+func (t *RevolveTool) Angle() float64                           { return t.angle }
+func (t *RevolveTool) SetOperation(op ops.PartFeatureOperation) { t.operation = op }
+func (t *RevolveTool) Operation() ops.PartFeatureOperation      { return t.operation }
+
+// SetFullRevolution sets the angle to a full turn (0, the model's "full" sentinel).
+func (t *RevolveTool) SetFullRevolution() { t.angle = 0 }
+
+// IsFullRevolution reports whether the tool will sweep a full turn.
+func (t *RevolveTool) IsFullRevolution() bool { return t.angle <= 0 }
+
+// PickedProfile returns the picked region (and true), or false when none picked yet.
+func (t *RevolveTool) PickedProfile() (ProfileHandle, bool) {
+	if t.profile == nil {
+		return ProfileHandle{}, false
+	}
+	return *t.profile, true
+}
+
+// CanCommit reports whether a region has been picked (the axis has a default).
+func (t *RevolveTool) CanCommit() bool { return t.profile != nil }
+
+// Commit adds the revolve feature to the active part and recomputes; a sick feature
+// (open profile, missing axis) keeps the tool open by returning an error.
+func (t *RevolveTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	axis, ok := part.WorkGeometry().AxisByRef(t.axis)
+	if !ok {
+		return errors.New("revolve: axis " + string(t.axis) + " not found")
+	}
+	angle := t.angle
+	t.added = feature.NewRevolveFeatures(part.Features()).
+		Add(t.profile.Sketch, t.profile.ProfileIndex, axis, func() float64 { return angle }, t.operation)
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("revolve: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *RevolveTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user through the revolve steps (Inventor's status-bar prompts).
+func (t *RevolveTool) Prompt(*Session) string {
+	if t.profile == nil {
+		return "Select a region to revolve"
+	}
+	return "Set the axis and angle, then click OK"
+}
+
+// Preview returns a transient outline of the region to revolve, so the viewport shows
+// what will be swept before OK. Empty until a region is picked.
+func (t *RevolveTool) Preview(*Session) []renderer.DrawItem {
+	if t.profile == nil || t.profile.ProfileIndex >= t.profile.Sketch.Profiles().Count() {
+		return nil
+	}
+	poly := t.profile.Sketch.Profiles().Item(t.profile.ProfileIndex).OuterLoop().Polygon()
+	plane := t.profile.Sketch.Plane()
+	pts := make([]math.Point3, len(poly))
+	idx := make([]int, 0, 2*len(poly))
+	for i, p := range poly {
+		pts[i] = plane.ToModel(p)
+		idx = append(idx, i, (i+1)%len(poly))
+	}
+	return []renderer.DrawItem{{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}}}
+}
+
+// Cancel restores the default selection filter.
+func (t *RevolveTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// FullTurn is the swept angle of a complete revolution, for the property window's
+// "Full" button to set an explicit angle when the user switches to a partial angle.
+const FullTurn = 2 * stdmath.Pi

--- a/app/revolve_tool_test.go
+++ b/app/revolve_tool_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// newPartWithOffsetSquare sets up a session whose active part has a sketch with one
+// closed square at x∈[x0,x0+side], y∈[0,side] — a profile offset from the Y axis so a
+// revolve about Y produces a washer. Returns the session and that profile handle.
+func newPartWithOffsetSquare(t *testing.T, x0, side float64) (*Session, ProfileHandle) {
+	t.Helper()
+	s := NewSession()
+	def := compdef.NewPartComponentDefinition()
+	pd, err := s.Workspace().Add(doc.Part, "part.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	pd.SetContent(def)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(x0, 0))
+	c1 := sk.Points().Add(math.P2(x0+side, 0))
+	c2 := sk.Points().Add(math.P2(x0+side, side))
+	c3 := sk.Points().Add(math.P2(x0, side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return s, ProfileHandle{Sketch: sk, ProfileIndex: 0}
+}
+
+// TestRevolveToolEndToEnd drives the Revolve UI with synthetic input — start the tool,
+// click the profile, accept the default full revolution about Y, OK — and asserts a
+// validated washer solid (inner r=2, outer r=4, height 2 ⇒ 24π) lands in the part.
+func TestRevolveToolEndToEnd(t *testing.T) {
+	s, profile := newPartWithOffsetSquare(t, 2, 2)
+	s.SetPicker(stubPicker{sel: profile})
+
+	rv := NewRevolveTool()
+	s.StartTool(rv)  // ribbon: click "Revolve"
+	s.Click(120, 90) // viewport: click the profile
+	// default axis = Y origin, default angle = full revolution
+	if err := s.OK(); err != nil { // dialog: OK
+		t.Fatalf("OK: %v", err)
+	}
+
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("part has %d bodies after revolve, want 1", def.SurfaceBodies().Count())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("revolved body not a valid solid: %+v", r)
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2 // 24π
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, want) > 0.01 {
+		t.Errorf("washer volume = %g, want ≈%g (24π)", got, want)
+	}
+	if def.Features().Count() != 1 || !def.Features().Item(0).Health().OK() {
+		t.Error("revolve feature missing or unhealthy")
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestRevolveViaCommandAlias shows the ribbon command launching the tool by its alias,
+// then a partial-angle revolve through the property-window setters.
+func TestRevolveViaCommandAlias(t *testing.T) {
+	s, profile := newPartWithOffsetSquare(t, 2, 2)
+	s.SetPicker(stubPicker{sel: profile})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.PressKey(KeyEvent{Key: "R"}); err != nil { // type the "R" alias
+		t.Fatalf("alias: %v", err)
+	}
+	rv, ok := s.ActiveTool().Tool().(*RevolveTool)
+	if !ok {
+		t.Fatal("Revolve alias did not start the revolve tool")
+	}
+	s.Click(1, 1)                   // pick the profile
+	rv.SetAxis(feature.OriginYAxis) // property window: axis = Y
+	rv.SetAngle(stdmath.Pi / 2)     // property window: 90°
+	if !rv.CanCommit() {
+		t.Fatal("tool not ready after picking a profile")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	want := stdmath.Pi * (4*4 - 2*2) * 2 / 4 // quarter washer
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, want) > 0.02 {
+		t.Errorf("quarter-washer volume = %g, want ≈%g", got, want)
+	}
+}
+
+func TestRevolveToolNeedsProfile(t *testing.T) {
+	s, profile := newPartWithOffsetSquare(t, 2, 2)
+	s.SetPicker(stubPicker{sel: profile})
+	rv := NewRevolveTool()
+	s.StartTool(rv)
+	if rv.CanCommit() {
+		t.Error("tool ready with no profile picked")
+	}
+	s.Click(0, 0)
+	if !rv.CanCommit() {
+		t.Error("tool not ready after picking a profile")
+	}
+}
+
+// relErrApp is the relative error helper for app-layer geometry assertions.
+func relErrApp(got, want float64) float64 {
+	if want == 0 {
+		return stdmath.Abs(got)
+	}
+	return stdmath.Abs(got-want) / stdmath.Abs(want)
+}

--- a/head/icon/assets/revolve.svg
+++ b/head/icon/assets/revolve.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="3" x2="4" y2="21"/><rect x="9" y="8" width="6" height="8"/><path d="M15 8 a6 4 0 0 1 0 8" stroke-dasharray="2 2"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -49,6 +49,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawViewportPanel(win, s)
 	drawDimensionPopup(s)
 	drawExtrudeDialog(s)
+	drawRevolveDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/revolve_dialog.go
+++ b/head/ui/revolve_dialog.go
@@ -1,0 +1,132 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The Revolve flow in the head: while the Revolve tool runs, a modeless options window
+// (Inventor's Revolve property panel) lets the user choose the output operation, the
+// axis of revolution and the swept angle (or a full revolution), then OK/Cancel. The
+// picked region is outlined in the viewport by the tool's preview. The angle is shown
+// in degrees.
+var revolveUI = struct {
+	angleDeg float32
+	open     bool
+}{angleDeg: 360}
+
+// revolveAxes names each origin axis for the axis combo, paired with its work reference.
+var revolveAxes = []struct {
+	label string
+	ref   feature.WorkRef
+}{{"X Axis", feature.OriginXAxis}, {"Y Axis", feature.OriginYAxis}, {"Z Axis", feature.OriginZAxis}}
+
+// drawRevolveDialog shows the revolve options window while the Revolve tool is active,
+// syncing each control with the tool every frame; OK commits, Cancel aborts.
+func drawRevolveDialog(s *app.Session) {
+	rv := s.ActiveRevolve()
+	if rv == nil {
+		revolveUI.open = false
+		return
+	}
+	if !revolveUI.open {
+		revolveUI.angleDeg = seedRevolveAngle(rv)
+		revolveUI.open = true
+	}
+	native.SetNextWindowSize(300, 240)
+	if native.Begin("Revolve") {
+		drawRevolveProfileText(rv)
+		revolveOperationCombo(rv)
+		revolveAxisCombo(rv)
+		drawRevolveAngle(rv)
+		drawRevolveButtons(s, rv)
+	}
+	native.End()
+}
+
+// seedRevolveAngle returns the dialog's initial angle in degrees from the tool (a full
+// revolution shows 360).
+func seedRevolveAngle(rv *app.RevolveTool) float32 {
+	if rv.IsFullRevolution() {
+		return 360
+	}
+	return float32(rv.Angle() * 180 / stdmath.Pi)
+}
+
+func drawRevolveProfileText(rv *app.RevolveTool) {
+	if _, ok := rv.PickedProfile(); !ok {
+		native.Text("Click a region to revolve")
+	}
+}
+
+func revolveOperationCombo(rv *app.RevolveTool) {
+	preview := "New Solid"
+	for _, o := range extrudeOperations {
+		if o.op == rv.Operation() {
+			preview = o.label
+		}
+	}
+	if native.BeginCombo("Output", preview) {
+		for _, o := range extrudeOperations {
+			if native.Selectable(o.label, o.op == rv.Operation()) {
+				rv.SetOperation(o.op)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+func revolveAxisCombo(rv *app.RevolveTool) {
+	preview := "Y Axis"
+	for _, a := range revolveAxes {
+		if a.ref == rv.Axis() {
+			preview = a.label
+		}
+	}
+	if native.BeginCombo("Axis", preview) {
+		for _, a := range revolveAxes {
+			if native.Selectable(a.label, a.ref == rv.Axis()) {
+				rv.SetAxis(a.ref)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+// drawRevolveAngle offers a full-revolution checkbox and, when unchecked, an angle field
+// in degrees written back to the tool as radians.
+func drawRevolveAngle(rv *app.RevolveTool) {
+	full := rv.IsFullRevolution()
+	if native.Checkbox("Full revolution", &full) {
+		if full {
+			rv.SetFullRevolution()
+		} else {
+			rv.SetAngle(float64(revolveUI.angleDeg) * stdmath.Pi / 180)
+		}
+	}
+	if full {
+		return
+	}
+	native.Text("Angle (deg)")
+	native.InputFloat("##revolve-angle", &revolveUI.angleDeg)
+	rv.SetAngle(float64(revolveUI.angleDeg) * stdmath.Pi / 180)
+}
+
+func drawRevolveButtons(s *app.Session, rv *app.RevolveTool) {
+	native.BeginDisabled(!rv.CanCommit())
+	if native.Button("OK") {
+		_ = s.OK() // a failed commit (e.g. open profile) keeps the tool open
+	}
+	native.EndDisabled()
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelTool()
+	}
+}

--- a/implementation-plan/CONVENTIONS.md
+++ b/implementation-plan/CONVENTIONS.md
@@ -100,6 +100,31 @@ approach follows the layer (full strategy: `../architecture/testing/`):
 A PBI is "done" when its acceptance criteria are green in CI, not when it renders
 something that looks right.
 
+## Definition of Done — every user-facing feature ships its UI (MANDATORY)
+
+A modeling feature is **not done when its model layer + serialization + unit tests
+are green**. It is done only when a user can invoke it in the application and an
+**end-to-end test drives that UI and validates the resulting geometry**. Every
+user-facing feature ships **all four** of these, mirroring Extrude (the reference):
+
+1. **Model** (`model/feature`): the `Definition → Add → Feature` triangle, `.obk`
+   serialize round-trip, and unit tests.
+2. **Command & interaction** (`app/`): a `CommandDefinition` ribbon button registered
+   in `app/commands_standard.go` (`NewCommand(id,name,panel,…).WithTab("3D Model")
+   .WithIcon(…).WithTooltip(…)`), plus an interactive `Tool` (`app/<feat>_tool.go` —
+   `Start`/`Pick`/`Set*`/`Commit`) and/or a settings window that edits the feature's
+   inputs and writes them through to the definition.
+3. **Property window** (`head/ui/<feat>_dialog.go`): the rendered Dear ImGui dialog —
+   value fields, option combos, OK/Cancel, and in-canvas preview/highlight.
+4. **End-to-end tests** (`app/<feat>_tool_test.go`): drive the command (by alias or
+   synthetic click) → set the tool/dialog fields → commit → assert the feature lands
+   in the model with the **expected geometry** (validated manifold, volume, etc.).
+   The reference tests are `TestExtrudeToolEndToEnd`, `TestExtrudeViaCommandAlias`,
+   `TestExtrudeDialogPathBuildsSolid`.
+
+A feature whose only entry point is a Go API call, with no ribbon button, no property
+window, and no UI-driven test, is **incomplete** regardless of model-layer coverage.
+
 ## Naming (mirror the contract library)
 
 `XFeature` / `XFeatures` / `XDefinition` / `XProxy` / `XEnumerator` / `XEvents` /

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -39,8 +39,16 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 
 ### M20 — Feature Completion & Geometry Parity
 
+**Definition of Done (CONVENTIONS.md):** a feature is done only with UI exposure (ribbon
+button + property window) **and** end-to-end UI tests, not model+serialize alone. The
+rows below marked "model-complete, UI pending" satisfy the model layer but still need
+their ribbon command, property window, and e2e UI tests to count as done. **Revolve** is
+the first brought fully to the new DoD (ribbon button `R`, `head/ui` property window,
+app-layer e2e tests driving command→tool→OK→validated solid).
+
 | PBI | Title | Status | Go package | Notes |
 |-----|-------|:------:|------------|-------|
+| 173-UI | Revolve UI (ribbon + property window + e2e) | ✅ | `app`, `head/ui`, `model/feature` | `RevolveTool` + `Create.Revolve` ribbon command (alias `R`) + `head/ui/revolve_dialog.go` property window (output/axis/angle) + `revolve.svg`. E2e: `TestRevolveToolEndToEnd` (click profile → full revolution → OK → validated 24π washer), `TestRevolveViaCommandAlias` (alias `R` → 90° quarter washer), `TestRevolveToolNeedsProfile`. `WorkGeometry.AxisByRef` added. **Reference for retrofitting the other M20 features' UI.** |
 | 174 | Sweep & loft bodies | ✅ | `model/feature` | `SweepFeature` (profile placed along a 3D path, oriented to the local tangent, optional twist) and `LoftFeature` (blend through ordered `(sketch,profile)` sections resampled to a common point count, optional closed) generate real faceted solids via the shared `sweptSolid` primitive. A 2×2 square swept along an L-path is a valid elbow; a 4×4→2×2 square loft is an exact frustum (V=140/3). New `SweepFeatures`/`LoftFeatures` collections + `SweepData`/`LoftData` `.obk` codecs (path as 3D points, sections as sketch+profile indices). `SweepDefinition.Path` is now a `Path3D`; `LoftDefinition` carries `LoftSection{Sketch,ProfileIndex}`. Guide rails, path-frame torsion-minimization and section alignment are follow-ups. |
 | 173 | Revolve & coil surfaces of revolution | ✅ | `model/feature` | `RevolveFeature` and `CoilFeature` now generate **real faceted solids** via a shared `sweptSolid` primitive (cross-section loops → `subd.ToBody` cage → B-rep, re-oriented outward by signed volume). Revolve: full (closed, no caps) or partial (capped) about a `WorkAxis`; a square x∈[2,4]×y∈[0,2] revolved 360° about Y is a validated washer of volume 24π (±1%). Coil: helical placement (pitch/revolutions, taper recorded) capped at both ends; climbs pitch·revs + profile height. New `CoilFeatures` collection + `CoilData` `.obk` codec (axis by WorkRef like revolve). Curved profile edges and exact analytic surfaces are a later refinement; profiles must not touch the axis (pole handling pending). |
 | 189 | Decal, Reference, Client, Mark & Finish | ✅ | `model/feature` | Five cosmetic/reference parity features (`DecalFeature`/`ReferenceFeature`/`ClientFeature`/`MarkFeature`/`FinishFeature` + `*Definition` + `CosmeticFeatures` collection). Pass-through recompute (no geometry change) carrying their payload — decal image+face, reference label+source key, add-in id+attributes, mark faces+text, finish faces+spec — all round-tripping through `.obk`. Completes 5 more Inventor `*Feature` types toward parity. |

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -184,6 +184,17 @@ func (g *WorkGeometry) axis(ref WorkRef) (*WorkAxis, error) {
 	return w, nil
 }
 
+// AxisByRef returns the work axis with the given reference (e.g. [OriginYAxis]) — the
+// exported lookup the UI uses to resolve a chosen revolve/coil axis. Reports false when
+// no such axis exists.
+func (g *WorkGeometry) AxisByRef(ref WorkRef) (*WorkAxis, bool) {
+	a, err := g.axis(ref)
+	if err != nil {
+		return nil, false
+	}
+	return a, true
+}
+
 func (g *WorkGeometry) point(ref WorkRef) (math.Point3, error) {
 	if p, isVertex, err := g.vertexPoint(ref); isVertex {
 		return p, err


### PR DESCRIPTION
## What

Two things:

1. **A real Definition of Done** (`implementation-plan/CONVENTIONS.md`): a user-facing feature is done **only** when it has a ribbon button + property window **and** end-to-end tests that drive those UI components and validate the resulting geometry — *not* when the model layer + serialization + unit tests are green. Mirrors how Extrude is wired across model → app (command/tool) → `head/ui` (dialog) → e2e.

2. **Revolve brought fully to that bar**, as the reference retrofit:
   - `app/revolve_tool.go` — `RevolveTool`: pick a region, choose the axis (origin X/Y/Z) and swept angle, OK.
   - `Create.Revolve` ribbon command (alias **R**) in `commands_standard.go` + `revolve.svg` icon.
   - `head/ui/revolve_dialog.go` — the Dear ImGui **property window** (output / axis / angle / full-revolution, OK/Cancel), wired into `chrome.go`.
   - `WorkGeometry.AxisByRef` exported so the tool resolves the chosen origin axis.

## Why

Feedback: features were being declared done at the model layer with no way to invoke them in the app and no UI-driven tests. A modeling feature nobody can click is not delivered. This encodes the rule and demonstrates it.

## Tests (end-to-end, driving the UI)

- `TestRevolveToolEndToEnd`: start the tool → synthetic click on the profile → default full revolution about Y → `OK` → assert a **validated 24π washer** solid + healthy feature in the active part, tool closed.
- `TestRevolveViaCommandAlias`: ribbon alias **R** launches the tool → set axis/angle via the property-window setters → 90° → **quarter washer** volume.
- `TestRevolveToolNeedsProfile`: OK gated until a region is picked.
- `head/ui` compiles (cgo); full `make ci` green (fmt-check, vet, lint, `-race` across `./...`).

## Follow-up

The other M20 model-complete features (sweep / loft / coil / move / patterns / cosmetic) still need the same UI retrofit (ribbon button + property window + e2e) to count as done under the new DoD — `PROGRESS.md` records this, and I'll work through them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)