### PR TITLE
Fix planar-face tessellation winding (outward normal)

### DIFF
--- a/kernel/ops/earclip.go
+++ b/kernel/ops/earclip.go
@@ -136,15 +136,30 @@ func reverse(idx []int) {
 }
 
 // planeProjector returns a 2D projection that drops the normal's dominant axis,
-// preserving in-plane geometry for triangulation.
+// preserving in-plane geometry for triangulation. The two retained axes are ordered so
+// their cross product equals the normal's sign — i.e. a counter-clockwise loop in the
+// projection corresponds to the face's outward normal. This keeps the triangulation
+// wound consistently outward (every emitted triangle's geometric normal matches the
+// face normal), which the renderer ignores (it uses per-vertex normals) but boolean CSG
+// and divergence-theorem volume depend on. Without the sign-aware axis order, faces with
+// a negative-axis normal come out inward and the triangle soup is not a coherent solid.
 func planeProjector(n math.Vector3) func(math.Point3) math.Point2 {
 	ax, ay, az := stdmath.Abs(n.X), stdmath.Abs(n.Y), stdmath.Abs(n.Z)
 	switch {
-	case ax >= ay && ax >= az:
-		return func(p math.Point3) math.Point2 { return math.P2(p.Y, p.Z) }
-	case ay >= ax && ay >= az:
-		return func(p math.Point3) math.Point2 { return math.P2(p.Z, p.X) }
-	default:
-		return func(p math.Point3) math.Point2 { return math.P2(p.X, p.Y) }
+	case ax >= ay && ax >= az: // drop X: (Y,Z) for +X, (Z,Y) for −X
+		if n.X >= 0 {
+			return func(p math.Point3) math.Point2 { return math.P2(p.Y, p.Z) }
+		}
+		return func(p math.Point3) math.Point2 { return math.P2(p.Z, p.Y) }
+	case ay >= ax && ay >= az: // drop Y: (Z,X) for +Y, (X,Z) for −Y
+		if n.Y >= 0 {
+			return func(p math.Point3) math.Point2 { return math.P2(p.Z, p.X) }
+		}
+		return func(p math.Point3) math.Point2 { return math.P2(p.X, p.Z) }
+	default: // drop Z: (X,Y) for +Z, (Y,X) for −Z
+		if n.Z >= 0 {
+			return func(p math.Point3) math.Point2 { return math.P2(p.X, p.Y) }
+		}
+		return func(p math.Point3) math.Point2 { return math.P2(p.Y, p.X) }
 	}
 }

--- a/kernel/ops/tessellate_winding_test.go
+++ b/kernel/ops/tessellate_winding_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// offsetBoxBody builds a 2×2×2 box translated to corner (dx,dy,dz) by offsetting the
+// cage vertices (no TransformBody), isolating the tessellation winding.
+func offsetBoxBody(dx, dy, dz float64) *ops.Mesh {
+	m := subd.Box(2, 2, 2)
+	for i := range m.Verts {
+		m.Verts[i] = m.Verts[i].TranslateBy(math.V3(dx, dy, dz))
+	}
+	mesh, _ := ops.TessellateBody(subd.ToBody(m, "s"), ops.DefaultQuality())
+	return mesh
+}
+
+// meshSignedVolume is the divergence-theorem volume of a triangle mesh; it equals the
+// true volume only when every triangle is wound consistently outward.
+func meshSignedVolume(m *ops.Mesh) float64 {
+	v := 0.0
+	for i := 0; i+2 < len(m.Indices); i += 3 {
+		a := m.Positions[m.Indices[i]].AsVector()
+		b := m.Positions[m.Indices[i+1]].AsVector()
+		c := m.Positions[m.Indices[i+2]].AsVector()
+		v += a.Dot(b.Cross(c))
+	}
+	return v / 6
+}
+
+// TestTessellationWindingIsOutwardAndTranslationInvariant guards the planeProjector
+// orientation fix: a planar-faced solid must tessellate with consistently outward
+// winding, so its divergence-theorem volume equals the analytic volume regardless of
+// where it sits (a divergence sum is translation-invariant only for a watertight,
+// coherently-wound mesh). Before the fix, negative-axis-normal faces were wound inward
+// and an off-origin box reported 13.33 instead of 8.
+func TestTessellationWindingIsOutwardAndTranslationInvariant(t *testing.T) {
+	for _, off := range [][3]float64{{0, 0, 0}, {1, 0.5, 0.5}, {10, 20, 30}, {-5, -7, -9}} {
+		got := meshSignedVolume(offsetBoxBody(off[0], off[1], off[2]))
+		if stdmath.Abs(got-8) > 1e-9 {
+			t.Errorf("box at %v: tessellated volume = %g, want 8 (inconsistent winding?)", off, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

`planeProjector` dropped the normal's dominant axis but **ignored its sign**, so a face with a negative-axis normal projected onto a left-handed 2D basis. `earClip` then forces the polygon CCW *in the projection*, which wound those faces **inward**. The tessellated triangle soup was therefore not coherently oriented.

The fix orders the two retained projection axes by the normal's sign, so CCW-in-2D corresponds to the outward normal — every emitted triangle's geometric normal now matches the face normal.

## Why it matters

The renderer was unaffected (it shades from per-vertex normals), so the bug was invisible there. But anything that depends on triangle **winding** was wrong:

- `BodyGeometryProperties` volume/centroid use the divergence theorem, which is translation-invariant only for a watertight, consistently-wound mesh. An off-origin 2×2×2 box measured **13.33 instead of 8** (it was correct only for bodies symmetric about the origin, which masked the bug).
- The general **boolean CSG** (next) needs a coherently-oriented triangle soup as input.

## Tests

- `TestTessellationWindingIsOutwardAndTranslationInvariant`: a 2×2×2 box tessellates to volume 8 at the origin **and** at several off-origin/negative offsets (metamorphic translation-invariance) — previously failed off-origin.
- Full `make ci` green (fmt-check, vet, lint, `-race`); no regressions across `./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)