### PR TITLE
B-rep boolean (Option A) step 1: 2D planar arrangement

### DIFF
--- a/kernel/brep/arrange2d.go
+++ b/kernel/brep/arrange2d.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package brep implements the planar-faced B-rep boolean (M20·F01, the Option-A kernel):
+// imprint face–face intersections, split faces along them via a 2D planar arrangement,
+// classify the sub-faces against the other solid, and stitch the kept faces into a clean,
+// low-face-count, chainable B-rep. This file is the keystone 2D arrangement: it subdivides
+// a set of undirected segments into the bounded faces they enclose (with holes), which the
+// 3D boolean uses to split each planar face by its imprint segments.
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// arrTol is the planar-arrangement coincidence/intersection tolerance (database units).
+const arrTol = 1e-9
+
+// Face2D is one region of a planar arrangement: a counter-clockwise outer loop and any
+// clockwise hole loops nested directly inside it.
+type Face2D struct {
+	Outer []math.Point2
+	Holes [][]math.Point2
+}
+
+// Arrange computes the planar subdivision induced by the undirected segments and returns
+// the bounded faces (the regions they enclose), each with its holes. The unbounded outer
+// region is excluded. Segments are split at every interior crossing and coincident
+// endpoints are welded, so the result is a valid cell complex.
+func Arrange(segments [][2]math.Point2) []Face2D {
+	pts, edges := planarize(segments)
+	if len(edges) == 0 {
+		return nil
+	}
+	cycles := traceCycles(pts, edges)
+	return nestFaces(cycles)
+}
+
+// planarize splits every segment at its intersections with the others and welds the
+// resulting points, returning the welded points and the elementary (crossing-free)
+// undirected edges as index pairs.
+func planarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
+	weld := newWelder()
+	edges := map[[2]int]bool{}
+	for i, seg := range segments {
+		for _, e := range splitOne(seg, segments, i, weld) {
+			if e[0] != e[1] {
+				edges[canonEdge(e[0], e[1])] = true
+			}
+		}
+	}
+	out := make([][2]int, 0, len(edges))
+	for e := range edges {
+		out = append(out, e)
+	}
+	return weld.points, out
+}
+
+// splitOne returns segment i's elementary edges: the chain of welded vertex indices along
+// it, split at every interior intersection with another segment.
+func splitOne(seg [2]math.Point2, all [][2]math.Point2, i int, weld *welder) [][2]int {
+	si := geom.NewLineSegment2d(seg[0], seg[1])
+	type cut struct {
+		t float64
+		p math.Point2
+	}
+	cuts := []cut{{0, seg[0]}, {1, seg[1]}}
+	for j, other := range all {
+		if j == i {
+			continue
+		}
+		if p, s, _, ok := geom.Segment2dIntersection(si, geom.NewLineSegment2d(other[0], other[1]), arrTol); ok && s > arrTol && s < 1-arrTol {
+			cuts = append(cuts, cut{s, p})
+		}
+	}
+	sort.Slice(cuts, func(a, b int) bool { return cuts[a].t < cuts[b].t })
+	var chain [][2]int
+	prev := weld.add(cuts[0].p)
+	for k := 1; k < len(cuts); k++ {
+		cur := weld.add(cuts[k].p)
+		if cur != prev {
+			chain = append(chain, [2]int{prev, cur})
+			prev = cur
+		}
+	}
+	return chain
+}
+
+// welder merges coincident points onto a shared index list (a coincidence grid).
+type welder struct {
+	index  map[[2]int64]int
+	points []math.Point2
+}
+
+func newWelder() *welder { return &welder{index: map[[2]int64]int{}} }
+
+func (w *welder) add(p math.Point2) int {
+	const grid = 1e-7
+	k := [2]int64{int64(stdmath.Round(p.X / grid)), int64(stdmath.Round(p.Y / grid))}
+	if i, ok := w.index[k]; ok {
+		return i
+	}
+	w.index[k] = len(w.points)
+	w.points = append(w.points, p)
+	return len(w.points) - 1
+}
+
+func canonEdge(a, b int) [2]int {
+	if a < b {
+		return [2]int{a, b}
+	}
+	return [2]int{b, a}
+}
+
+// signedArea2D returns the shoelace signed area of a loop (positive = counter-clockwise).
+func signedArea2D(loop []math.Point2) float64 {
+	a := 0.0
+	for i, n := 0, len(loop); i < n; i++ {
+		j := (i + 1) % n
+		a += loop[i].X*loop[j].Y - loop[j].X*loop[i].Y
+	}
+	return a / 2
+}
+
+// pointInPolygon2D reports whether p is strictly inside the polygon (even–odd ray cast).
+func pointInPolygon2D(p math.Point2, poly []math.Point2) bool {
+	in := false
+	for i, n := 0, len(poly); i < n; i++ {
+		a, b := poly[i], poly[(i+1)%n]
+		if (a.Y > p.Y) != (b.Y > p.Y) {
+			x := a.X + (p.Y-a.Y)/(b.Y-a.Y)*(b.X-a.X)
+			if p.X < x {
+				in = !in
+			}
+		}
+	}
+	return in
+}

--- a/kernel/brep/arrange2d_test.go
+++ b/kernel/brep/arrange2d_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// seg is a terse segment constructor for tests.
+func seg(x0, y0, x1, y1 float64) [2]math.Point2 {
+	return [2]math.Point2{math.P2(x0, y0), math.P2(x1, y1)}
+}
+
+// squareSegs returns the four edges of an axis-aligned square [x0,x1]×[y0,y1].
+func squareSegs(x0, y0, x1, y1 float64) [][2]math.Point2 {
+	return [][2]math.Point2{
+		seg(x0, y0, x1, y0), seg(x1, y0, x1, y1), seg(x1, y1, x0, y1), seg(x0, y1, x0, y0),
+	}
+}
+
+// faceAreas returns the absolute outer-loop areas of the faces, sorted ascending.
+func faceAreas(faces []Face2D) []float64 {
+	out := make([]float64, len(faces))
+	for i, f := range faces {
+		out[i] = stdmath.Abs(signedArea2D(f.Outer))
+	}
+	sort.Float64s(out)
+	return out
+}
+
+func TestArrangeSingleSquare(t *testing.T) {
+	faces := Arrange(squareSegs(0, 0, 2, 2))
+	if len(faces) != 1 {
+		t.Fatalf("square → %d faces, want 1", len(faces))
+	}
+	if a := stdmath.Abs(signedArea2D(faces[0].Outer)); stdmath.Abs(a-4) > 1e-9 {
+		t.Errorf("square area = %g, want 4", a)
+	}
+	if len(faces[0].Holes) != 0 {
+		t.Errorf("square has %d holes, want 0", len(faces[0].Holes))
+	}
+}
+
+func TestArrangeChordSplitsInTwo(t *testing.T) {
+	segs := append(squareSegs(0, 0, 2, 2), seg(1, 0, 1, 2)) // vertical mid chord
+	faces := Arrange(segs)
+	if len(faces) != 2 {
+		t.Fatalf("square+chord → %d faces, want 2", len(faces))
+	}
+	for _, a := range faceAreas(faces) {
+		if stdmath.Abs(a-2) > 1e-9 {
+			t.Errorf("half area = %g, want 2", a)
+		}
+	}
+}
+
+func TestArrangePlusSplitsInFour(t *testing.T) {
+	segs := squareSegs(0, 0, 2, 2)
+	segs = append(segs, seg(1, 0, 1, 2), seg(0, 1, 2, 1)) // a full cross
+	faces := Arrange(segs)
+	if len(faces) != 4 {
+		t.Fatalf("square+cross → %d faces, want 4", len(faces))
+	}
+	for _, a := range faceAreas(faces) {
+		if stdmath.Abs(a-1) > 1e-9 {
+			t.Errorf("quarter area = %g, want 1", a)
+		}
+	}
+}
+
+func TestArrangeNestedSquareIsHoleAndFace(t *testing.T) {
+	// A big square with a disjoint small square inside → the annulus (big with a hole)
+	// plus the inner square as its own face.
+	segs := append(squareSegs(0, 0, 6, 6), squareSegs(2, 2, 4, 4)...)
+	faces := Arrange(segs)
+	if len(faces) != 2 {
+		t.Fatalf("nested squares → %d faces, want 2", len(faces))
+	}
+	var annulus, inner *Face2D
+	for i := range faces {
+		if stdmath.Abs(signedArea2D(faces[i].Outer)) > 20 {
+			annulus = &faces[i]
+		} else {
+			inner = &faces[i]
+		}
+	}
+	if annulus == nil || inner == nil {
+		t.Fatal("expected one big (annulus) and one small (inner) face")
+	}
+	if len(annulus.Holes) != 1 {
+		t.Errorf("annulus has %d holes, want 1", len(annulus.Holes))
+	}
+	if a := stdmath.Abs(signedArea2D(inner.Outer)); stdmath.Abs(a-4) > 1e-9 {
+		t.Errorf("inner face area = %g, want 4", a)
+	}
+}

--- a/kernel/brep/arrange2d_trace.go
+++ b/kernel/brep/arrange2d_trace.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// halfEdge is a directed use of an elementary edge (from→to); faces lie to its left.
+type halfEdge struct{ from, to int }
+
+// traceCycles walks the half-edge structure of the elementary edges into closed cycles
+// (each a loop of points). Counter-clockwise cycles bound faces; clockwise cycles are
+// holes or the unbounded outer region — [nestFaces] sorts them out.
+func traceCycles(pts []math.Point2, edges [][2]int) [][]math.Point2 {
+	hes, heID := buildHalfEdges(edges)
+	outgoing, pos := sortAround(pts, hes)
+	nextOf := func(id int) int {
+		he := hes[id]
+		twin := heID[[2]int{he.to, he.from}]
+		list := outgoing[he.to]
+		return list[(pos[twin]-1+len(list))%len(list)] // clockwise neighbour of the twin
+	}
+	visited := make([]bool, len(hes))
+	var cycles [][]math.Point2
+	for start := range hes {
+		if visited[start] {
+			continue
+		}
+		var loop []math.Point2
+		for id := start; !visited[id]; id = nextOf(id) {
+			visited[id] = true
+			loop = append(loop, pts[hes[id].from])
+		}
+		cycles = append(cycles, loop)
+	}
+	return cycles
+}
+
+// buildHalfEdges creates the two directed half-edges of each undirected edge and an index
+// from (from,to) to its half-edge id.
+func buildHalfEdges(edges [][2]int) ([]halfEdge, map[[2]int]int) {
+	hes := make([]halfEdge, 0, 2*len(edges))
+	id := map[[2]int]int{}
+	add := func(a, b int) {
+		id[[2]int{a, b}] = len(hes)
+		hes = append(hes, halfEdge{a, b})
+	}
+	for _, e := range edges {
+		add(e[0], e[1])
+		add(e[1], e[0])
+	}
+	return hes, id
+}
+
+// sortAround returns, per vertex, its outgoing half-edge ids sorted counter-clockwise by
+// direction angle, plus each half-edge's position within its from-vertex's sorted list.
+func sortAround(pts []math.Point2, hes []halfEdge) (map[int][]int, []int) {
+	outgoing := map[int][]int{}
+	for id, he := range hes {
+		outgoing[he.from] = append(outgoing[he.from], id)
+	}
+	angle := func(id int) float64 {
+		d := pts[hes[id].from].VectorTo(pts[hes[id].to])
+		return stdmath.Atan2(d.Y, d.X)
+	}
+	pos := make([]int, len(hes))
+	for _, list := range outgoing {
+		sort.Slice(list, func(a, b int) bool { return angle(list[a]) < angle(list[b]) })
+		for idx, id := range list {
+			pos[id] = idx
+		}
+	}
+	return outgoing, pos
+}
+
+// nestFaces keeps the counter-clockwise cycles as face outer loops and assigns each
+// directly-enclosing relationship: a CCW cycle nested one level inside another becomes a
+// hole of it (and remains a face in its own right — the arrangement of disjoint loops).
+func nestFaces(cycles [][]math.Point2) []Face2D {
+	var ccw [][]math.Point2
+	for _, c := range cycles {
+		if len(c) >= 3 && signedArea2D(c) > arrTol {
+			ccw = append(ccw, c)
+		}
+	}
+	faces := make([]Face2D, len(ccw))
+	for i, c := range ccw {
+		faces[i] = Face2D{Outer: c}
+	}
+	for i, inner := range ccw {
+		if p := smallestContainer(ccw, i); p >= 0 {
+			faces[p].Holes = append(faces[p].Holes, reversedLoop(inner))
+		}
+	}
+	return faces
+}
+
+// smallestContainer returns the index of the smallest CCW cycle strictly containing
+// cycle i (its direct parent in the nesting), or −1 if it is top-level.
+func smallestContainer(ccw [][]math.Point2, i int) int {
+	best, bestArea := -1, stdmath.Inf(1)
+	probe := ccw[i][0]
+	for j, c := range ccw {
+		if j == i || !pointInPolygon2D(probe, c) {
+			continue
+		}
+		if a := signedArea2D(c); a < bestArea {
+			best, bestArea = j, a
+		}
+	}
+	return best
+}
+
+func reversedLoop(loop []math.Point2) []math.Point2 {
+	out := make([]math.Point2, len(loop))
+	for i, p := range loop {
+		out[len(loop)-1-i] = p
+	}
+	return out
+}


### PR DESCRIPTION
## Context

Experiments (`experiments/fillet/`) showed the triangle-soup BSP CSG is **unsound when chained**: a single boolean on clean primitives is correct, but feeding a boolean's output (many coplanar triangular faces) back as a target makes it return the wrong solid (`box−w₁` = 7.75 ✓, then `−w₂` = 0.25 ✗). That blocks fillets, breaks multi-edge chamfer, and risks any feature sequence. You chose **Option A**: a proper B-rep boolean (imprint face–face intersections → split faces → classify → stitch) that yields clean, low-face-count, chainable topology.

## What

This is **step 1**: the keystone `kernel/brep` package — a robust **2D planar arrangement**. Given undirected segments it:
1. splits each at every interior crossing (`planarize`) and welds coincident points;
2. builds the half-edge structure and traces face cycles (`traceCycles`, CCW = bounded faces);
3. nests holes by containment (`nestFaces`).

It returns the bounded regions as `Face2D{Outer, Holes}`. The 3D boolean (next PR) will use it to split each planar face by its imprint segments into clean sub-faces.

## Tests

- square → 1 face; vertical chord → 2 equal halves; full cross → 4 quarters; a big square with a disjoint inner square → the annulus (one hole) **plus** the inner square as its own face.
- `make ci` green (vet, lint, `-race`); self-contained new package, nothing else touched.

## Next

Step 2: the 3D planar B-rep boolean on top of this (imprint + split + classify + stitch), replacing the triangle CSG for intersecting cases — fixing chaining and multi-edge chamfer, and unblocking fillets (incl. corner handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)