### PR TITLE
M20: planar B-rep boolean (sound under chaining) + coplanar faces; wire into ops.Boolean

### DIFF
--- a/kernel/brep/arrange2d.go
+++ b/kernel/brep/arrange2d.go
@@ -56,6 +56,14 @@ func planarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
 	for e := range edges {
 		out = append(out, e)
 	}
+	// Sort for determinism (map iteration order is random and was producing
+	// run-to-run-different arrangements on tolerance-fragile inputs).
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] != out[j][0] {
+			return out[i][0] < out[j][0]
+		}
+		return out[i][1] < out[j][1]
+	})
 	return weld.points, out
 }
 

--- a/kernel/brep/arrange2d_trace.go
+++ b/kernel/brep/arrange2d_trace.go
@@ -100,10 +100,13 @@ func nestFaces(cycles [][]math.Point2) []Face2D {
 }
 
 // smallestContainer returns the index of the smallest CCW cycle strictly containing
-// cycle i (its direct parent in the nesting), or −1 if it is top-level.
+// cycle i (its direct parent in the nesting), or −1 if it is top-level. The probe sits
+// just inside cycle i's boundary (an edge midpoint nudged inward), so it is in cycle i's
+// own region — not at a shared-boundary vertex (ambiguous) and not near the centre where a
+// concentric inner cycle would swallow it (which made a frame look nested in its own hole).
 func smallestContainer(ccw [][]math.Point2, i int) int {
+	probe := probeJustInside(ccw[i])
 	best, bestArea := -1, stdmath.Inf(1)
-	probe := ccw[i][0]
 	for j, c := range ccw {
 		if j == i || !pointInPolygon2D(probe, c) {
 			continue
@@ -113,6 +116,16 @@ func smallestContainer(ccw [][]math.Point2, i int) int {
 		}
 	}
 	return best
+}
+
+// probeJustInside returns a point just inside a CCW loop near its first edge: the edge
+// midpoint nudged along the inward (left) normal by a small fraction of the edge length.
+func probeJustInside(loop []math.Point2) math.Point2 {
+	a, b := loop[0], loop[1]
+	e := a.VectorTo(b)
+	mid := math.P2((a.X+b.X)/2, (a.Y+b.Y)/2)
+	left := math.V2(-e.Y, e.X) // interior side of a CCW loop
+	return mid.TranslateBy(left.Scale(1e-4))
 }
 
 func reversedLoop(loop []math.Point2) []math.Point2 {

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Op is a boolean operation between two solids.
+type Op int
+
+const (
+	Union        Op = iota // A ∪ B
+	Difference             // A − B
+	Intersection           // A ∩ B
+)
+
+// ErrNonPlanar is returned when an operand has a non-planar face (the planar B-rep
+// boolean handles planar-faceted solids; curved-face booleans need NURBS work).
+var ErrNonPlanar = errors.New("brep: boolean requires planar-faceted solids")
+
+// subFace is one region a face is split into, with an interior point for classification
+// and the outward normal it should carry in the result.
+type subFace struct {
+	outer  []math.Point3
+	holes  [][]math.Point3
+	normal math.Vector3
+	point  math.Point3
+}
+
+// Boolean computes A op B as a clean planar B-rep: it imprints the face–face intersection
+// segments, splits each face along them (the 2D arrangement), classifies the sub-faces
+// against the other solid, keeps the ones the operation calls for (reversing B's where
+// needed), and stitches them into a watertight solid. Unlike the triangle-soup CSG this
+// produces a low-face-count result and is sound under chaining. Coplanar (shared-plane)
+// faces are a follow-up — operands that don't share a face plane work today.
+func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
+	fa, oka := facesOf(a)
+	fb, okb := facesOf(b)
+	if !oka || !okb {
+		return nil, ErrNonPlanar
+	}
+	impA, impB := imprintAll(fa, fb)
+	var kept []subFace
+	kept = append(kept, selectFaces(fa, impA, b, op, false)...)
+	kept = append(kept, selectFaces(fb, impB, a, op, true)...)
+	return stitch(kept)
+}
+
+// imprintAll computes, for every crossing face pair, the shared intersection segment and
+// records it on both faces (by index).
+func imprintAll(fa, fb []planarFace) (impA, impB [][][2]math.Point3) {
+	impA = make([][][2]math.Point3, len(fa))
+	impB = make([][][2]math.Point3, len(fb))
+	for i := range fa {
+		for j := range fb {
+			segs := imprint(fa[i], fb[j])
+			impA[i] = append(impA[i], segs...)
+			impB[j] = append(impB[j], segs...)
+		}
+	}
+	return impA, impB
+}
+
+// imprint returns the 3D segments of the intersection line of two faces' planes clipped
+// to where both faces overlap (empty when parallel or non-overlapping).
+func imprint(a, b planarFace) [][2]math.Point3 {
+	p0, dir, ok := planeLine(a.plane, b.plane)
+	if !ok {
+		return nil
+	}
+	overlap := intersectIntervals(faceLineIntervals(a, p0, dir), faceLineIntervals(b, p0, dir))
+	var segs [][2]math.Point3
+	for _, iv := range overlap {
+		if iv[1]-iv[0] > 1e-9 {
+			segs = append(segs, [2]math.Point3{p0.TranslateBy(dir.Scale(iv[0])), p0.TranslateBy(dir.Scale(iv[1]))})
+		}
+	}
+	return segs
+}
+
+// intersectIntervals returns the overlaps of two sorted interval sets.
+func intersectIntervals(a, b [][2]float64) [][2]float64 {
+	var out [][2]float64
+	for _, x := range a {
+		for _, y := range b {
+			lo, hi := maxf(x[0], y[0]), minf(x[1], y[1])
+			if hi > lo {
+				out = append(out, [2]float64{lo, hi})
+			}
+		}
+	}
+	return out
+}
+
+func maxf(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minf(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// selectFaces splits each face by its imprints, classifies every material sub-face
+// against `other`, and keeps the ones this operation wants. When the faces belong to B
+// (isB), a Difference reverses them (they become the cut walls).
+func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, op Op, isB bool) []subFace {
+	var kept []subFace
+	for i, f := range faces {
+		for _, sf := range splitFace(f, imprints[i]) {
+			if !keep(op, isB, insideSolid(other, sf.point)) {
+				continue
+			}
+			if op == Difference && isB {
+				sf = reverseSubFace(sf)
+			}
+			kept = append(kept, sf)
+		}
+	}
+	return kept
+}
+
+// keep encodes the boolean selection table: which sub-faces (by side and inside/outside
+// the other solid) survive each operation.
+func keep(op Op, isB, inside bool) bool {
+	switch op {
+	case Union:
+		return !inside // both sides keep their outside-the-other parts
+	case Intersection:
+		return inside // both sides keep their inside-the-other parts
+	default: // Difference: keep A outside B, and B inside A (reversed)
+		if isB {
+			return inside
+		}
+		return !inside
+	}
+}
+
+// reverseSubFace flips a sub-face's orientation (normal and loop windings) so it faces
+// into the cavity a Difference carves.
+func reverseSubFace(sf subFace) subFace {
+	sf.normal = sf.normal.Scale(-1)
+	sf.outer = reverseRing(sf.outer)
+	for i := range sf.holes {
+		sf.holes[i] = reverseRing(sf.holes[i])
+	}
+	return sf
+}
+
+func reverseRing(r []math.Point3) []math.Point3 {
+	out := make([]math.Point3, len(r))
+	for i, p := range r {
+		out[len(r)-1-i] = p
+	}
+	return out
+}

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -45,8 +45,8 @@ func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
 	}
 	impA, impB := imprintAll(fa, fb)
 	var kept []subFace
-	kept = append(kept, selectFaces(fa, impA, b, op, false)...)
-	kept = append(kept, selectFaces(fb, impB, a, op, true)...)
+	kept = append(kept, selectFaces(fa, impA, b, fb, op, false)...)
+	kept = append(kept, selectFaces(fb, impB, a, fa, op, true)...)
 	return stitch(kept)
 }
 
@@ -57,6 +57,11 @@ func imprintAll(fa, fb []planarFace) (impA, impB [][][2]math.Point3) {
 	impB = make([][][2]math.Point3, len(fb))
 	for i := range fa {
 		for j := range fb {
+			if coplanar(fa[i], fb[j]) {
+				impA[i] = append(impA[i], faceEdges3D(fb[j])...)
+				impB[j] = append(impB[j], faceEdges3D(fa[i])...)
+				continue
+			}
 			segs := imprint(fa[i], fb[j])
 			impA[i] = append(impA[i], segs...)
 			impB[j] = append(impB[j], segs...)
@@ -110,23 +115,36 @@ func minf(a, b float64) float64 {
 	return b
 }
 
-// selectFaces splits each face by its imprints, classifies every material sub-face
-// against `other`, and keeps the ones this operation wants. When the faces belong to B
-// (isB), a Difference reverses them (they become the cut walls).
-func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, op Op, isB bool) []subFace {
+// selectFaces splits each face by its imprints and keeps the material sub-faces this
+// operation wants, classifying each via [classifySubFace]. `others` is the other solid's
+// face list (for the coplanar overlap test); `other` is the body itself (for the ray cast).
+func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, others []planarFace, op Op, isB bool) []subFace {
 	var kept []subFace
 	for i, f := range faces {
 		for _, sf := range splitFace(f, imprints[i]) {
-			if !keep(op, isB, insideSolid(other, sf.point)) {
-				continue
+			if out, ok := classifySubFace(sf, f, other, others, op, isB); ok {
+				kept = append(kept, out)
 			}
-			if op == Difference && isB {
-				sf = reverseSubFace(sf)
-			}
-			kept = append(kept, sf)
 		}
 	}
 	return kept
+}
+
+// classifySubFace decides whether a sub-face survives. A fragment coplanar with a face of
+// the other solid follows the ON/ON table ([coplanarKeep]); otherwise it is kept by the
+// inside/outside table ([keep]) from a ray cast, with B's difference faces reversed to form
+// the cut walls.
+func classifySubFace(sf subFace, f planarFace, other *topo.Body, others []planarFace, op Op, isB bool) (subFace, bool) {
+	if covered, sameNormal := coplanarCover(f, sf.point, others); covered {
+		return sf, coplanarKeep(op, isB, sameNormal)
+	}
+	if !keep(op, isB, insideSolid(other, sf.point)) {
+		return sf, false
+	}
+	if op == Difference && isB {
+		sf = reverseSubFace(sf)
+	}
+	return sf, true
 }
 
 // keep encodes the boolean selection table: which sub-faces (by side and inside/outside

--- a/kernel/brep/boolean_classify.go
+++ b/kernel/brep/boolean_classify.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// insideSolid reports whether p is inside the solid b, by casting a skewed ray from p and
+// counting crossings of b's planar faces (odd ⇒ inside). The direction is off-axis to
+// avoid grazing a face plane or hitting an edge/vertex.
+func insideSolid(b *topo.Body, p math.Point3) bool {
+	faces, ok := facesOf(b)
+	if !ok {
+		return false
+	}
+	dir := math.V3(0.5773, 0.5774, 0.5775)
+	crossings := 0
+	for _, f := range faces {
+		if rayHitsFace(p, dir, f) {
+			crossings++
+		}
+	}
+	return crossings%2 == 1
+}
+
+// rayHitsFace reports whether the ray p+t·dir (t>0) passes through the face's polygon.
+func rayHitsFace(p math.Point3, dir math.Vector3, f planarFace) bool {
+	n := f.normal
+	den := dir.Dot(n)
+	if stdmath.Abs(den) < 1e-12 {
+		return false // ray parallel to the face plane
+	}
+	t := f.plane.Origin.VectorTo(p).Dot(n) / -den // n·(p+t dir) = n·origin ⇒ t = n·(origin−p)/(n·dir)
+	if t <= 1e-9 {
+		return false
+	}
+	hit := p.TranslateBy(dir.Scale(t))
+	return pointInFace2D(to2D(f.plane, hit), f)
+}

--- a/kernel/brep/boolean_coplanar.go
+++ b/kernel/brep/boolean_coplanar.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Coplanar (ON/ON) face fragments — where a face of A lies in the same plane as a face of B
+// and they overlap as an area, not a line — can't be classified by the plane-plane imprint
+// line nor by an inside/outside ray cast (the sample point sits exactly on the other solid's
+// boundary). They are handled by set-membership classification instead: split each face by
+// the other's coplanar outline, then keep fragments per [coplanarKeep]. See Mantyla,
+// "An Introduction to Solid Modeling" §12 (boolean set operations, coincident faces).
+
+// coplanar reports whether two planar faces lie in the same plane (parallel normals and a
+// shared point), so their overlap is an area rather than the line an imprint would find.
+func coplanar(a, b planarFace) bool {
+	if stdmath.Abs(a.normal.Dot(b.normal)) < 1-1e-7 {
+		return false // not parallel
+	}
+	return stdmath.Abs(b.plane.Origin.VectorTo(a.plane.Origin).Dot(b.normal)) < 1e-7
+}
+
+// faceEdges3D returns all of a face's loop edges as 3D segments — imprinted onto a coplanar
+// face so the shared-overlap region splits off as its own sub-face.
+func faceEdges3D(f planarFace) [][2]math.Point3 {
+	var segs [][2]math.Point3
+	for _, ring := range f.loops {
+		n := len(ring)
+		for i := 0; i < n; i++ {
+			segs = append(segs, [2]math.Point3{ring[i], ring[(i+1)%n]})
+		}
+	}
+	return segs
+}
+
+// coplanarCover reports whether sub-face point ip is covered by a coplanar face of the other
+// solid, and if so whether that face's normal agrees with f's (shared vs. anti-shared).
+func coplanarCover(f planarFace, ip math.Point3, others []planarFace) (covered, sameNormal bool) {
+	for _, o := range others {
+		if coplanar(f, o) && pointInFace2D(to2D(o.plane, ip), o) {
+			return true, f.normal.Dot(o.normal) > 0
+		}
+	}
+	return false, false
+}
+
+// coplanarKeep is the selection table for a coplanar overlap fragment. The shared boundary
+// is emitted once, as A's copy, so B's coplanar fragments always drop. For A: union and
+// intersection keep the same-normal (genuinely shared) fragment, while difference keeps the
+// anti-shared (flush-cut) fragment and drops the same-normal one (it becomes interior).
+func coplanarKeep(op Op, isB, sameNormal bool) bool {
+	if isB {
+		return false
+	}
+	if op == Difference {
+		return !sameNormal
+	}
+	return sameNormal // Union, Intersection
+}

--- a/kernel/brep/boolean_geom.go
+++ b/kernel/brep/boolean_geom.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// planarFace is a planar face flattened for the boolean: its plane, outward normal, and
+// boundary loops as 3D point rings (loops[0] = outer, the rest = holes).
+type planarFace struct {
+	plane  geom.Plane
+	normal math.Vector3
+	loops  [][]math.Point3
+}
+
+// facesOf flattens a body's planar faces. A non-planar face makes it return ok=false (the
+// planar B-rep boolean handles planar-faceted solids; curved faces need NURBS work).
+func facesOf(b *topo.Body) ([]planarFace, bool) {
+	var out []planarFace
+	for _, f := range b.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, planarFace{plane: pl, normal: f.Geometry().NormalAt(0, 0), loops: loopRings(f)})
+	}
+	return out, true
+}
+
+// loopRings returns a face's loops as ordered 3D point rings (outer loop first).
+func loopRings(f *topo.Face) [][]math.Point3 {
+	var outer [][]math.Point3
+	var holes [][]math.Point3
+	for _, l := range f.Loops() {
+		ring := loopPoints(l)
+		if l.IsOuter() {
+			outer = append(outer, ring)
+		} else {
+			holes = append(holes, ring)
+		}
+	}
+	return append(outer, holes...)
+}
+
+// loopPoints returns a loop's ordered vertices (honoring each edge use's direction).
+func loopPoints(l *topo.Loop) []math.Point3 {
+	uses := l.EdgeUses()
+	pts := make([]math.Point3, 0, len(uses))
+	for _, u := range uses {
+		v := u.Edge().StartVertex()
+		if u.Reversed() {
+			v = u.Edge().EndVertex()
+		}
+		pts = append(pts, v.Point())
+	}
+	return pts
+}
+
+// to2D / to3D convert between model space and a plane's local (u,v) coordinates.
+func to2D(pl geom.Plane, p math.Point3) math.Point2 {
+	d := pl.Origin.VectorTo(p)
+	return math.P2(d.Dot(pl.UAxis.AsVector()), d.Dot(pl.VAxis.AsVector()))
+}
+
+func to3D(pl geom.Plane, q math.Point2) math.Point3 {
+	return pl.Origin.TranslateBy(pl.UAxis.AsVector().Scale(q.X).Add(pl.VAxis.AsVector().Scale(q.Y)))
+}
+
+// planeLine returns a point and unit direction of the intersection line of two planes,
+// or ok=false when they are parallel. n·x = d form is taken from each plane's normal and
+// origin.
+func planeLine(a, b geom.Plane) (p0 math.Point3, dir math.Vector3, ok bool) {
+	na, nb := unit(a.Normal()), unit(b.Normal())
+	d := na.Cross(nb)
+	if d.LengthSquared() < 1e-18 {
+		return p0, dir, false
+	}
+	da, db := na.Dot(a.Origin.AsVector()), nb.Dot(b.Origin.AsVector())
+	// Point on both planes nearest the origin: p0 = (da(nb×d) + db(d×na)) / |d|².
+	num := nb.Cross(d).Scale(da).Add(d.Cross(na).Scale(db))
+	return math.P3(0, 0, 0).TranslateBy(num.Scale(1 / d.LengthSquared())), unit(d), true
+}
+
+func unit(v math.Vector3) math.Vector3 {
+	u, err := math.UnitVector3FromVector(v)
+	if err != nil {
+		return math.V3(0, 0, 0)
+	}
+	return u.AsVector()
+}
+
+// faceLineIntervals returns the parameter intervals (along p0+t·dir) where the line lies
+// inside the face (inside the outer ring and outside every hole), via even–odd crossings
+// projected into the face plane.
+func faceLineIntervals(f planarFace, p0 math.Point3, dir math.Vector3) [][2]float64 {
+	o2, d2 := to2D(f.plane, p0), to2Dvec(f.plane, dir)
+	if d2.LengthSquared() < 1e-18 {
+		return nil // the line is perpendicular to this plane (no in-plane extent)
+	}
+	var ts []float64
+	for _, ring := range f.loops {
+		ts = append(ts, ringCrossings(o2, d2, ring, f.plane)...)
+	}
+	stdSort(ts)
+	var out [][2]float64
+	for i := 0; i+1 < len(ts); i++ {
+		mid := (ts[i] + ts[i+1]) / 2
+		if pointInFace2D(o2.TranslateBy(d2.Scale(mid)), f) {
+			out = append(out, [2]float64{ts[i], ts[i+1]})
+		}
+	}
+	return out
+}
+
+func to2Dvec(pl geom.Plane, v math.Vector3) math.Vector2 {
+	return math.V2(v.Dot(pl.UAxis.AsVector()), v.Dot(pl.VAxis.AsVector()))
+}
+
+// ringCrossings returns the line parameters t where the 2D line (o2 + t·d2) crosses the
+// ring's edges.
+func ringCrossings(o2 math.Point2, d2 math.Vector2, ring []math.Point3, pl geom.Plane) []float64 {
+	var ts []float64
+	n := len(ring)
+	for i := 0; i < n; i++ {
+		a, b := to2D(pl, ring[i]), to2D(pl, ring[(i+1)%n])
+		if t, ok := lineSegCross(o2, d2, a, b); ok {
+			ts = append(ts, t)
+		}
+	}
+	return ts
+}
+
+// lineSegCross intersects the infinite line (o + t·d) with segment [a,b], returning the
+// line parameter t when they cross within the segment.
+func lineSegCross(o math.Point2, d math.Vector2, a, b math.Point2) (float64, bool) {
+	e := a.VectorTo(b)
+	den := d.Cross(e)
+	if stdmath.Abs(den) < 1e-12 {
+		return 0, false // parallel
+	}
+	ao := o.VectorTo(a)
+	t := ao.Cross(e) / den
+	s := ao.Cross(d) / den
+	if s < -1e-9 || s > 1+1e-9 {
+		return 0, false
+	}
+	return t, true
+}
+
+// pointInFace2D reports whether a 2D point is inside the face (in the outer ring, outside
+// holes).
+func pointInFace2D(q math.Point2, f planarFace) bool {
+	if len(f.loops) == 0 || !pointInPolygon2D(q, ring2D(f.plane, f.loops[0])) {
+		return false
+	}
+	for _, h := range f.loops[1:] {
+		if pointInPolygon2D(q, ring2D(f.plane, h)) {
+			return false
+		}
+	}
+	return true
+}
+
+func ring2D(pl geom.Plane, ring []math.Point3) []math.Point2 {
+	out := make([]math.Point2, len(ring))
+	for i, p := range ring {
+		out[i] = to2D(pl, p)
+	}
+	return out
+}
+
+func stdSort(ts []float64) {
+	for i := 1; i < len(ts); i++ {
+		for j := i; j > 0 && ts[j-1] > ts[j]; j-- {
+			ts[j-1], ts[j] = ts[j], ts[j-1]
+		}
+	}
+}

--- a/kernel/brep/boolean_split.go
+++ b/kernel/brep/boolean_split.go
@@ -51,29 +51,81 @@ func ring3D(pl geom.Plane, loop []math.Point2) []math.Point3 {
 	return out
 }
 
-// interiorPoint2D returns a point strictly inside the region (in the outer loop, outside
-// holes). It tries the vertex centroid, then triangle-fan centroids — robust for the
-// convex and mildly-non-convex regions the boolean produces.
+// interiorPoint2D returns a point STRICTLY inside the region (inside the outer loop,
+// outside holes). It probes just inside each outer edge (the midpoint nudged inward by a
+// small fraction of the edge length): such points hug the boundary, so unlike an ear
+// centroid they never fall in a central hole (a square frame) and never land on an edge
+// (which would make the inside/outside classification ambiguous). An ear-centroid pass is
+// the fallback for slivers where no edge probe lands clear.
 func interiorPoint2D(r Face2D) (math.Point2, bool) {
-	inHoles := func(p math.Point2) bool {
-		for _, h := range r.Holes {
-			if pointInPolygon2D(p, h) {
-				return true
+	poly := r.Outer
+	n := len(poly)
+	if n < 3 {
+		return math.Point2{}, false
+	}
+	for i := 0; i < n; i++ {
+		a, b := poly[i], poly[(i+1)%n]
+		e := a.VectorTo(b)
+		mid := math.P2((a.X+b.X)/2, (a.Y+b.Y)/2)
+		left := math.V2(-e.Y, e.X) // interior side of a CCW loop (magnitude = |edge|)
+		for _, f := range []float64{1e-3, 1e-2, 0.05, 0.2} {
+			p := mid.TranslateBy(left.Scale(f))
+			if pointInPolygon2D(p, poly) && !inHoles2D(p, r.Holes) {
+				return p, true
 			}
 		}
-		return false
 	}
-	ok := func(p math.Point2) bool { return pointInPolygon2D(p, r.Outer) && !inHoles(p) }
-	if c := centroid2D(r.Outer); ok(c) {
-		return c, true
-	}
-	for i := 1; i+1 < len(r.Outer); i++ {
-		c := centroid2D([]math.Point2{r.Outer[0], r.Outer[i], r.Outer[i+1]})
-		if ok(c) {
+	for i := 0; i < n; i++ { // fallback: ear centroids
+		prev, cur, next := poly[(i-1+n)%n], poly[i], poly[(i+1)%n]
+		if turn2D(prev, cur, next) <= arrTol || !earEmpty(poly, i) {
+			continue
+		}
+		if c := centroid2D([]math.Point2{prev, cur, next}); !inHoles2D(c, r.Holes) {
 			return c, true
 		}
 	}
 	return math.Point2{}, false
+}
+
+// turn2D returns the signed turn (cross product) at b going a→b→c (>0 = left/convex CCW).
+func turn2D(a, b, c math.Point2) float64 {
+	return b.VectorTo(c).Cross(a.VectorTo(b)) * -1
+}
+
+// earEmpty reports whether the triangle at vertex i (prev,cur,next) contains no other
+// vertex of the polygon — the ear test.
+func earEmpty(poly []math.Point2, i int) bool {
+	n := len(poly)
+	a, b, c := poly[(i-1+n)%n], poly[i], poly[(i+1)%n]
+	for j := 0; j < n; j++ {
+		if j == i || j == (i-1+n)%n || j == (i+1)%n {
+			continue
+		}
+		if pointInTriangle2D(poly[j], a, b, c) {
+			return false
+		}
+	}
+	return true
+}
+
+// pointInTriangle2D reports whether p is inside triangle abc (inclusive of edges).
+func pointInTriangle2D(p, a, b, c math.Point2) bool {
+	d1 := turn2D(a, b, p)
+	d2 := turn2D(b, c, p)
+	d3 := turn2D(c, a, p)
+	hasNeg := d1 < -arrTol || d2 < -arrTol || d3 < -arrTol
+	hasPos := d1 > arrTol || d2 > arrTol || d3 > arrTol
+	return !(hasNeg && hasPos)
+}
+
+// inHoles2D reports whether p lies in any hole loop.
+func inHoles2D(p math.Point2, holes [][]math.Point2) bool {
+	for _, h := range holes {
+		if pointInPolygon2D(p, h) {
+			return true
+		}
+	}
+	return false
 }
 
 // centroid2D returns the average of a point set.

--- a/kernel/brep/boolean_split.go
+++ b/kernel/brep/boolean_split.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// splitFace splits a face by its imprint segments via the 2D arrangement and returns the
+// material sub-faces (regions inside the original face), each carried back to 3D with an
+// interior point for classification. A face with no imprints yields itself unchanged.
+func splitFace(f planarFace, imprints [][2]math.Point3) []subFace {
+	segs := faceBoundarySegments(f)
+	for _, s := range imprints {
+		segs = append(segs, [2]math.Point2{to2D(f.plane, s[0]), to2D(f.plane, s[1])})
+	}
+	var out []subFace
+	for _, r := range Arrange(segs) {
+		ip, ok := interiorPoint2D(r)
+		if !ok || !pointInFace2D(ip, f) {
+			continue // a region outside the face's material (e.g. inside one of its holes)
+		}
+		sf := subFace{normal: f.normal, point: to3D(f.plane, ip), outer: ring3D(f.plane, r.Outer)}
+		for _, h := range r.Holes {
+			sf.holes = append(sf.holes, ring3D(f.plane, h))
+		}
+		out = append(out, sf)
+	}
+	return out
+}
+
+// faceBoundarySegments returns a face's loop edges as 2D segments in its plane.
+func faceBoundarySegments(f planarFace) [][2]math.Point2 {
+	var segs [][2]math.Point2
+	for _, ring := range f.loops {
+		n := len(ring)
+		for i := 0; i < n; i++ {
+			segs = append(segs, [2]math.Point2{to2D(f.plane, ring[i]), to2D(f.plane, ring[(i+1)%n])})
+		}
+	}
+	return segs
+}
+
+// ring3D lifts a 2D loop back to model space on the given plane.
+func ring3D(pl geom.Plane, loop []math.Point2) []math.Point3 {
+	out := make([]math.Point3, len(loop))
+	for i, q := range loop {
+		out[i] = to3D(pl, q)
+	}
+	return out
+}
+
+// interiorPoint2D returns a point strictly inside the region (in the outer loop, outside
+// holes). It tries the vertex centroid, then triangle-fan centroids — robust for the
+// convex and mildly-non-convex regions the boolean produces.
+func interiorPoint2D(r Face2D) (math.Point2, bool) {
+	inHoles := func(p math.Point2) bool {
+		for _, h := range r.Holes {
+			if pointInPolygon2D(p, h) {
+				return true
+			}
+		}
+		return false
+	}
+	ok := func(p math.Point2) bool { return pointInPolygon2D(p, r.Outer) && !inHoles(p) }
+	if c := centroid2D(r.Outer); ok(c) {
+		return c, true
+	}
+	for i := 1; i+1 < len(r.Outer); i++ {
+		c := centroid2D([]math.Point2{r.Outer[0], r.Outer[i], r.Outer[i+1]})
+		if ok(c) {
+			return c, true
+		}
+	}
+	return math.Point2{}, false
+}
+
+// centroid2D returns the average of a point set.
+func centroid2D(pts []math.Point2) math.Point2 {
+	var sx, sy float64
+	for _, p := range pts {
+		sx, sy = sx+p.X, sy+p.Y
+	}
+	n := float64(len(pts))
+	return math.P2(sx/n, sy/n)
+}

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -20,22 +20,97 @@ func stitch(faces []subFace) (*topo.Body, error) {
 		return nil, nil
 	}
 	w := newWelder3()
-	var out []builtFace
-	edgeUse := map[[2]int]int{}
-	for _, sf := range faces {
+	// Pass 1: weld every face's loops to vertex indices (collect the full vertex set).
+	out := make([]builtFace, len(faces))
+	for i, sf := range faces {
 		rings := [][]int{w.ring(orientRing(sf.outer, sf.normal, true))}
 		for _, h := range sf.holes {
 			rings = append(rings, w.ring(orientRing(h, sf.normal, false)))
 		}
-		for _, r := range rings {
+		surf, _ := geom.NewPlane(centroid3(sf.outer), sf.normal)
+		out[i] = builtFace{rings, surf}
+	}
+	// Pass 2: with all vertices known, split every loop edge at any welded vertex lying on
+	// it — propagating each imprint split-point to the neighbour face sharing that edge, so
+	// shared edges subdivide identically (eliminates cross-face T-junctions).
+	edgeUse := map[[2]int]int{}
+	for fi := range out {
+		for ri := range out[fi].rings {
+			out[fi].rings[ri] = splitRingTJunctions(out[fi].rings[ri], w.points)
+		}
+		for _, r := range out[fi].rings {
 			for i := 0; i < len(r); i++ {
 				edgeUse[canonEdge(r[i], r[(i+1)%len(r)])]++
 			}
 		}
-		surf, _ := geom.NewPlane(centroid3(sf.outer), sf.normal)
-		out = append(out, builtFace{rings, surf})
 	}
 	return assemble(w.points, out, edgeUse), nil
+}
+
+// splitRingTJunctions inserts, into each edge of the ring, any other vertex that lies in
+// its interior (sorted along the edge) — so a vertex that is a corner of a neighbour face
+// also subdivides this face's coincident edge.
+func splitRingTJunctions(ring []int, verts []math.Point3) []int {
+	n := len(ring)
+	out := make([]int, 0, n)
+	for i := 0; i < n; i++ {
+		a, b := ring[i], ring[(i+1)%n]
+		out = append(out, a)
+		mids := verticesOnSegment(a, b, ring, verts)
+		out = append(out, mids...)
+	}
+	return out
+}
+
+// segHit is a vertex found lying on a segment at parameter t along it.
+type segHit struct {
+	t float64
+	v int
+}
+
+// verticesOnSegment returns the vertices (excluding the ring's own) lying strictly on the
+// segment a→b, ordered by parameter along it.
+func verticesOnSegment(a, b int, ring []int, verts []math.Point3) []int {
+	pa := verts[a]
+	ab := pa.VectorTo(verts[b])
+	lenSq := ab.LengthSquared()
+	if lenSq == 0 {
+		return nil
+	}
+	hits := collectSegHits(pa, ab, lenSq, ringSet(ring), verts)
+	sort.Slice(hits, func(i, j int) bool { return hits[i].t < hits[j].t })
+	out := make([]int, len(hits))
+	for i, h := range hits {
+		out[i] = h.v
+	}
+	return out
+}
+
+// ringSet is the set of vertex indices used by a ring.
+func ringSet(ring []int) map[int]bool {
+	s := make(map[int]bool, len(ring))
+	for _, v := range ring {
+		s[v] = true
+	}
+	return s
+}
+
+// collectSegHits gathers the off-ring vertices that lie strictly interior to segment pa+ab.
+func collectSegHits(pa math.Point3, ab math.Vector3, lenSq float64, onRing map[int]bool, verts []math.Point3) []segHit {
+	var hits []segHit
+	for c := range verts {
+		if onRing[c] {
+			continue
+		}
+		t := pa.VectorTo(verts[c]).Dot(ab) / lenSq
+		if t <= 1e-7 || t >= 1-1e-7 {
+			continue
+		}
+		if pa.TranslateBy(ab.Scale(t)).DistanceTo(verts[c]) < 1e-6 {
+			hits = append(hits, segHit{t, c})
+		}
+	}
+	return hits
 }
 
 // builtFace is a welded sub-face ready for assembly: its loop rings (vertex indices, outer
@@ -48,14 +123,7 @@ type builtFace struct {
 // assemble builds the topo body from welded vertices, per-face loop rings, and the edge
 // use counts (to decide solid vs. surface).
 func assemble(verts []math.Point3, faces []builtFace, edgeUse map[[2]int]int) *topo.Body {
-	solid := true
-	for _, c := range edgeUse {
-		if c != 2 {
-			solid = false
-			break
-		}
-	}
-	bld := topo.NewBuilder(solid, topo.NewLineage(topo.Tok("brep", "body", 0)))
+	bld := topo.NewBuilder(allEdgesPaired(edgeUse), topo.NewLineage(topo.Tok("brep", "body", 0)))
 	tv := make([]*topo.Vertex, len(verts))
 	for i, p := range verts {
 		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
@@ -64,20 +132,36 @@ func assemble(verts []math.Point3, faces []builtFace, edgeUse map[[2]int]int) *t
 	for fi, f := range faces {
 		specs := make([]topo.LoopSpec, len(f.rings))
 		for ri, r := range f.rings {
-			uses := make([]topo.Use, len(r))
-			for i := range r {
-				a, b := r[i], r[(i+1)%len(r)]
-				uses[i] = topo.Use{Edge: edges[canonEdge(a, b)], Reversed: a > b}
-			}
-			if ri == 0 {
-				specs[ri] = topo.OuterLoop(uses...)
-			} else {
-				specs[ri] = topo.InnerLoop(uses...)
-			}
+			specs[ri] = loopSpec(ri == 0, r, edges)
 		}
 		bld.AddFace(f.surf, topo.NewLineage(topo.Tok("brep", "face", fi)), specs...)
 	}
 	return bld.Build()
+}
+
+// allEdgesPaired reports whether every undirected edge is used exactly twice — the
+// combinatorial test for a closed (solid) shell.
+func allEdgesPaired(edgeUse map[[2]int]int) bool {
+	for _, c := range edgeUse {
+		if c != 2 {
+			return false
+		}
+	}
+	return true
+}
+
+// loopSpec builds a face loop (outer or inner) from a ring of vertex indices, resolving each
+// directed pair to its shared edge (reversed when traversed high→low).
+func loopSpec(outer bool, ring []int, edges map[[2]int]*topo.Edge) topo.LoopSpec {
+	uses := make([]topo.Use, len(ring))
+	for i := range ring {
+		a, b := ring[i], ring[(i+1)%len(ring)]
+		uses[i] = topo.Use{Edge: edges[canonEdge(a, b)], Reversed: a > b}
+	}
+	if outer {
+		return topo.OuterLoop(uses...)
+	}
+	return topo.InnerLoop(uses...)
 }
 
 // buildEdges creates one shared topo edge per undirected vertex pair (sorted for stable

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// stitch welds the kept sub-faces into a watertight B-rep: coincident vertices merge, one
+// shared edge per undirected vertex pair, and a face per sub-face (outer loop oriented CCW
+// about its normal, holes CW). The body is a solid when every edge is used exactly twice.
+// Lineage is freshly synthesized (operand reference-key survival is a follow-up).
+func stitch(faces []subFace) (*topo.Body, error) {
+	if len(faces) == 0 {
+		return nil, nil
+	}
+	w := newWelder3()
+	var out []builtFace
+	edgeUse := map[[2]int]int{}
+	for _, sf := range faces {
+		rings := [][]int{w.ring(orientRing(sf.outer, sf.normal, true))}
+		for _, h := range sf.holes {
+			rings = append(rings, w.ring(orientRing(h, sf.normal, false)))
+		}
+		for _, r := range rings {
+			for i := 0; i < len(r); i++ {
+				edgeUse[canonEdge(r[i], r[(i+1)%len(r)])]++
+			}
+		}
+		surf, _ := geom.NewPlane(centroid3(sf.outer), sf.normal)
+		out = append(out, builtFace{rings, surf})
+	}
+	return assemble(w.points, out, edgeUse), nil
+}
+
+// builtFace is a welded sub-face ready for assembly: its loop rings (vertex indices, outer
+// first) and its planar surface.
+type builtFace struct {
+	rings [][]int
+	surf  geom.Plane
+}
+
+// assemble builds the topo body from welded vertices, per-face loop rings, and the edge
+// use counts (to decide solid vs. surface).
+func assemble(verts []math.Point3, faces []builtFace, edgeUse map[[2]int]int) *topo.Body {
+	solid := true
+	for _, c := range edgeUse {
+		if c != 2 {
+			solid = false
+			break
+		}
+	}
+	bld := topo.NewBuilder(solid, topo.NewLineage(topo.Tok("brep", "body", 0)))
+	tv := make([]*topo.Vertex, len(verts))
+	for i, p := range verts {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
+	}
+	edges := buildEdges(bld, verts, tv, edgeUse)
+	for fi, f := range faces {
+		specs := make([]topo.LoopSpec, len(f.rings))
+		for ri, r := range f.rings {
+			uses := make([]topo.Use, len(r))
+			for i := range r {
+				a, b := r[i], r[(i+1)%len(r)]
+				uses[i] = topo.Use{Edge: edges[canonEdge(a, b)], Reversed: a > b}
+			}
+			if ri == 0 {
+				specs[ri] = topo.OuterLoop(uses...)
+			} else {
+				specs[ri] = topo.InnerLoop(uses...)
+			}
+		}
+		bld.AddFace(f.surf, topo.NewLineage(topo.Tok("brep", "face", fi)), specs...)
+	}
+	return bld.Build()
+}
+
+// buildEdges creates one shared topo edge per undirected vertex pair (sorted for stable
+// lineage).
+func buildEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, edgeUse map[[2]int]int) map[[2]int]*topo.Edge {
+	keys := make([][2]int, 0, len(edgeUse))
+	for k := range edgeUse {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i][0] != keys[j][0] {
+			return keys[i][0] < keys[j][0]
+		}
+		return keys[i][1] < keys[j][1]
+	})
+	edges := make(map[[2]int]*topo.Edge, len(keys))
+	for i, k := range keys {
+		edges[k] = bld.AddEdge(geom.NewLineSegment(verts[k[0]], verts[k[1]]), tv[k[0]], tv[k[1]], topo.NewLineage(topo.Tok("brep", "edge", i)))
+	}
+	return edges
+}
+
+// welder3 merges coincident 3D points onto a shared index list.
+type welder3 struct {
+	index  map[[3]int64]int
+	points []math.Point3
+}
+
+func newWelder3() *welder3 { return &welder3{index: map[[3]int64]int{}} }
+
+func (w *welder3) add(p math.Point3) int {
+	const grid = 1e-6
+	k := [3]int64{int64(stdmath.Round(p.X / grid)), int64(stdmath.Round(p.Y / grid)), int64(stdmath.Round(p.Z / grid))}
+	if i, ok := w.index[k]; ok {
+		return i
+	}
+	w.index[k] = len(w.points)
+	w.points = append(w.points, p)
+	return len(w.points) - 1
+}
+
+// ring welds a 3D loop to vertex indices, dropping consecutive duplicates.
+func (w *welder3) ring(loop []math.Point3) []int {
+	var out []int
+	for _, p := range loop {
+		i := w.add(p)
+		if len(out) == 0 || out[len(out)-1] != i {
+			out = append(out, i)
+		}
+	}
+	if len(out) > 1 && out[0] == out[len(out)-1] {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// orientRing returns the loop wound so its Newell normal points along (outer) or against
+// (hole) the face normal.
+func orientRing(loop []math.Point3, normal math.Vector3, outer bool) []math.Point3 {
+	aligned := newell3(loop).Dot(normal) > 0
+	if aligned == outer {
+		return loop
+	}
+	return reverseRing(loop)
+}
+
+// newell3 returns a 3D loop's (unnormalized) Newell normal.
+func newell3(loop []math.Point3) math.Vector3 {
+	var nx, ny, nz float64
+	n := len(loop)
+	for i := 0; i < n; i++ {
+		c, d := loop[i], loop[(i+1)%n]
+		nx += (c.Y - d.Y) * (c.Z + d.Z)
+		ny += (c.Z - d.Z) * (c.X + d.X)
+		nz += (c.X - d.X) * (c.Y + d.Y)
+	}
+	return math.V3(nx, ny, nz)
+}
+
+func centroid3(loop []math.Point3) math.Point3 {
+	var sx, sy, sz float64
+	for _, p := range loop {
+		sx, sy, sz = sx+p.X, sy+p.Y, sz+p.Z
+	}
+	n := float64(len(loop))
+	return math.P3(sx/n, sy/n, sz/n)
+}

--- a/kernel/brep/boolean_test.go
+++ b/kernel/brep/boolean_test.go
@@ -75,8 +75,8 @@ func TestBRepIntersection(t *testing.T) {
 // two disjoint tools, each removing 0.5×1×1 = 0.5 ⇒ 8 − 0.5 − 0.5 = 7.
 func TestBRepChainedDifference(t *testing.T) {
 	a := box(0, 0, 0, 2, 2, 2)
-	t1 := box(-0.25, 0.5, 0.5, 0.5, 1, 1) // pokes through the −X face, removes 0.5×1×1
-	t2 := box(1.75, 0.5, 0.5, 0.5, 1, 1)  // pokes through the +X face, removes 0.5×1×1
+	t1 := box(-0.25, 0.5, 0.5, 0.75, 1, 1) // x∈[−0.25,0.5]: pokes through the −X face, removes 0.5×1×1
+	t2 := box(1.5, 0.5, 0.5, 0.75, 1, 1)   // x∈[1.5,2.25]: pokes through the +X face, removes 0.5×1×1
 	step1, err := brep.Boolean(brep.Difference, a, t1)
 	if err != nil {
 		t.Fatal(err)

--- a/kernel/brep/boolean_test.go
+++ b/kernel/brep/boolean_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// box builds a solid box [px,px+sx]×… by offsetting the cage vertices.
+func box(px, py, pz, sx, sy, sz float64) *topo.Body {
+	m := subd.Box(sx, sy, sz)
+	for i := range m.Verts {
+		m.Verts[i] = m.Verts[i].TranslateBy(math.V3(px, py, pz))
+	}
+	return subd.ToBody(m, "box")
+}
+
+func vol(b *topo.Body) float64 { return ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume }
+
+func checkSolid(t *testing.T, name string, b *topo.Body, want float64) {
+	t.Helper()
+	if b == nil {
+		t.Fatalf("%s: nil body", name)
+	}
+	if r := ops.Validate(b); !r.Valid || !b.IsSolid() {
+		t.Fatalf("%s: not a valid solid: %+v", name, r)
+	}
+	if got := vol(b); stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("%s volume = %g, want %g", name, got, want)
+	}
+}
+
+// Non-coplanar overlap (no shared face planes): A=[0,2]³ (8), B=[1,3]×[0.5,2.5]×[0.5,2.5]
+// (8); overlap = 1×1.5×1.5 = 2.25.
+func overlapping() (a, b *topo.Body) {
+	return box(0, 0, 0, 2, 2, 2), box(1, 0.5, 0.5, 2, 2, 2)
+}
+
+func TestBRepUnion(t *testing.T) {
+	a, b := overlapping()
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "union", res, 8+8-2.25)
+}
+
+func TestBRepDifference(t *testing.T) {
+	a, b := overlapping()
+	res, err := brep.Boolean(brep.Difference, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "difference", res, 8-2.25)
+}
+
+func TestBRepIntersection(t *testing.T) {
+	a, b := overlapping()
+	res, err := brep.Boolean(brep.Intersection, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "intersection", res, 2.25)
+}
+
+// TestBRepChainedDifference is the headline: a boolean's OUTPUT fed back as a boolean
+// input — the exact case the triangle-soup CSG got wrong (returned 0.25). A=[0,2]³ minus
+// two disjoint tools, each removing 0.5×1×1 = 0.5 ⇒ 8 − 0.5 − 0.5 = 7.
+func TestBRepChainedDifference(t *testing.T) {
+	a := box(0, 0, 0, 2, 2, 2)
+	t1 := box(-0.25, 0.5, 0.5, 0.5, 1, 1) // pokes through the −X face, removes 0.5×1×1
+	t2 := box(1.75, 0.5, 0.5, 0.5, 1, 1)  // pokes through the +X face, removes 0.5×1×1
+	step1, err := brep.Boolean(brep.Difference, a, t1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "chained step1", step1, 8-0.5)
+	step2, err := brep.Boolean(brep.Difference, step1, t2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "chained step2 (CSG gave 0.25!)", step2, 8-0.5-0.5)
+}

--- a/kernel/brep/boolean_test.go
+++ b/kernel/brep/boolean_test.go
@@ -70,6 +70,41 @@ func TestBRepIntersection(t *testing.T) {
 	checkSolid(t, "intersection", res, 2.25)
 }
 
+// TestBRepCoplanarUnion fuses two boxes flush along x=2: the shared internal wall (the
+// anti-shared coplanar overlap) must vanish, leaving one 4×2×2 = 16 solid.
+func TestBRepCoplanarUnion(t *testing.T) {
+	a, b := box(0, 0, 0, 2, 2, 2), box(2, 0, 0, 2, 2, 2)
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "coplanar union", res, 16)
+}
+
+// TestBRepCoplanarDifferencePocket cuts a tool whose top is flush with A's top (a same-
+// normal coplanar overlap) — an open-top square pocket. A's top becomes a frame; the pocket
+// region of A's top drops. 8 − 1×1×1 = 7.
+func TestBRepCoplanarDifferencePocket(t *testing.T) {
+	a := box(0, 0, 0, 2, 2, 2)
+	tool := box(0.5, 0.5, 1, 1, 1, 1) // z∈[1,2]; top z=2 coincides with A's top
+	res, err := brep.Boolean(brep.Difference, a, tool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "coplanar pocket", res, 7)
+}
+
+// TestBRepCoplanarIntersection intersects boxes sharing all four y/z faces (both span
+// [0,2]²) and overlapping x∈[1,2]: the coplanar shared faces must be kept once. 1×2×2 = 4.
+func TestBRepCoplanarIntersection(t *testing.T) {
+	a, b := box(0, 0, 0, 2, 2, 2), box(1, 0, 0, 2, 2, 2)
+	res, err := brep.Boolean(brep.Intersection, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkSolid(t, "coplanar intersection", res, 4)
+}
+
 // TestBRepChainedDifference is the headline: a boolean's OUTPUT fed back as a boolean
 // input — the exact case the triangle-soup CSG got wrong (returned 0.25). A=[0,2]³ minus
 // two disjoint tools, each removing 0.5×1×1 = 0.5 ⇒ 8 − 0.5 − 0.5 = 7.

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -3,6 +3,7 @@
 package ops
 
 import (
+	"github.com/Oblikovati/oblikovati/kernel/brep"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 )
@@ -52,13 +53,47 @@ func Boolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, erro
 	switch op {
 	case Join:
 		if rel == intersecting {
-			return booleanCSG(op, target, tool, lin)
+			return booleanGeneral(op, target, tool, lin)
 		}
 		return topo.MergeBodies(lin, true, target, tool), nil
 	case Cut:
 		return cut(lin, target, tool, rel)
 	default: // Intersect
 		return intersect(lin, target, tool, rel)
+	}
+}
+
+// booleanGeneral runs the general (face-splitting) boolean: the planar B-rep boolean first
+// — it is sound under chaining and yields a low-face-count solid — falling back to the
+// triangle-soup BSP CSG only when an operand has a non-planar face the B-rep path can't take
+// (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
+func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage) (*topo.Body, error) {
+	bop, ok := toBrepOp(op)
+	if !ok {
+		return booleanCSG(op, target, tool, lin)
+	}
+	body, err := brep.Boolean(bop, target, tool)
+	if err != nil {
+		return booleanCSG(op, target, tool, lin) // non-planar operand → triangle CSG
+	}
+	if body == nil {
+		return topo.MergeBodies(lin, true), nil
+	}
+	return body, nil
+}
+
+// toBrepOp maps the feature-level operation to the B-rep boolean operation (NewBody has no
+// B-rep analogue — it is handled before this point).
+func toBrepOp(op PartFeatureOperation) (brep.Op, bool) {
+	switch op {
+	case Join:
+		return brep.Union, true
+	case Cut:
+		return brep.Difference, true
+	case Intersect:
+		return brep.Intersection, true
+	default:
+		return 0, false
 	}
 }
 
@@ -90,7 +125,7 @@ func cut(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, e
 	case toolContainsTarget:
 		return topo.MergeBodies(lin, true), nil // target fully removed → empty
 	default: // targetContainsTool (a void/cavity) and intersecting need face splitting
-		return booleanCSG(Cut, target, tool, lin)
+		return booleanGeneral(Cut, target, tool, lin)
 	}
 }
 
@@ -103,7 +138,7 @@ func intersect(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.B
 	case toolContainsTarget:
 		return target, nil
 	default:
-		return booleanCSG(Intersect, target, tool, lin)
+		return booleanGeneral(Intersect, target, tool, lin)
 	}
 }
 

--- a/kernel/ops/earclip.go
+++ b/kernel/ops/earclip.go
@@ -15,40 +15,68 @@ import (
 // vertices are exactly the boundary vertices — chordal tolerance is met trivially
 // since the facets lie in the face plane.
 func tessellatePlanarFace(f *topo.Face) *Mesh {
-	boundary := faceOuterBoundary(f)
 	normal := f.Geometry().NormalAt(0, 0)
 	flat := planeProjector(normal)
-	poly := make([]math.Point2, len(boundary))
-	for i, p := range boundary {
-		poly[i] = flat(p)
+	boundary3D := faceOuterBoundary(f)
+	boundary2D := project2D(boundary3D, flat)
+	if holes3D := faceHoleBoundaries(f); len(holes3D) > 0 {
+		holes2D := make([][]math.Point2, len(holes3D))
+		for i, h := range holes3D {
+			holes2D[i] = project2D(h, flat)
+		}
+		boundary2D, boundary3D = mergeHoles(boundary2D, boundary3D, holes2D, holes3D)
 	}
 	m := &Mesh{}
-	for _, p := range boundary {
+	for _, p := range boundary3D {
 		m.addVertex(p, normal)
 	}
-	for _, tri := range earClip(poly) {
+	for _, tri := range earClip(boundary2D) {
 		m.addTriangle(tri[0], tri[1], tri[2])
 	}
 	return m
 }
 
+// project2D drops each point to the face plane via the projector.
+func project2D(pts []math.Point3, flat func(math.Point3) math.Point2) []math.Point2 {
+	out := make([]math.Point2, len(pts))
+	for i, p := range pts {
+		out[i] = flat(p)
+	}
+	return out
+}
+
 // faceOuterBoundary returns the ordered vertices of a face's outer loop.
 func faceOuterBoundary(f *topo.Face) []math.Point3 {
 	for _, l := range f.Loops() {
-		if !l.IsOuter() {
-			continue
+		if l.IsOuter() {
+			return loopVertices(l)
 		}
-		pts := make([]math.Point3, 0, len(l.EdgeUses()))
-		for _, u := range l.EdgeUses() {
-			v := u.Edge().StartVertex()
-			if u.Reversed() {
-				v = u.Edge().EndVertex()
-			}
-			pts = append(pts, v.Point())
-		}
-		return pts
 	}
 	return nil
+}
+
+// faceHoleBoundaries returns the ordered vertices of each of a face's inner (hole) loops.
+func faceHoleBoundaries(f *topo.Face) [][]math.Point3 {
+	var holes [][]math.Point3
+	for _, l := range f.Loops() {
+		if !l.IsOuter() {
+			holes = append(holes, loopVertices(l))
+		}
+	}
+	return holes
+}
+
+// loopVertices returns a loop's ordered vertex points (honouring edge-use reversal).
+func loopVertices(l *topo.Loop) []math.Point3 {
+	pts := make([]math.Point3, 0, len(l.EdgeUses()))
+	for _, u := range l.EdgeUses() {
+		v := u.Edge().StartVertex()
+		if u.Reversed() {
+			v = u.Edge().EndVertex()
+		}
+		pts = append(pts, v.Point())
+	}
+	return pts
 }
 
 // earClip triangulates a simple polygon, returning triangles as index triples into
@@ -97,26 +125,35 @@ func findEar(poly []math.Point2, idx []int) (int, bool) {
 	return 0, false
 }
 
-// anyInside reports whether any vertex other than the ear's three lies inside abc.
+// anyInside reports whether any reflex vertex (other than the ear's three) lies strictly
+// inside abc. Only reflex vertices can block an ear, and coincident bridge vertices (equal
+// to a corner) are skipped — both are required so hole-bridged polygons, which carry doubled
+// bridge vertices, still triangulate instead of stalling.
 func anyInside(poly []math.Point2, idx []int, ear int, a, b, c math.Point2) bool {
 	m := len(idx)
 	for k := 0; k < m; k++ {
 		if k == ear || k == (ear+m-1)%m || k == (ear+1)%m {
 			continue
 		}
-		if pointInTriangle(poly[idx[k]], a, b, c) {
+		p := poly[idx[k]]
+		if p == a || p == b || p == c {
+			continue // a doubled bridge vertex coincident with an ear corner — not blocking
+		}
+		if predicate.Orient2D(poly[idx[(k+m-1)%m]], p, poly[idx[(k+1)%m]]) > 0 {
+			continue // convex vertex — cannot block an ear
+		}
+		if pointInTriangle(p, a, b, c) {
 			return true
 		}
 	}
 	return false
 }
 
-// pointInTriangle reports whether p is inside CCW triangle abc (boundary counts as
-// inside to reject degenerate ears).
+// pointInTriangle reports whether p is strictly inside CCW triangle abc.
 func pointInTriangle(p, a, b, c math.Point2) bool {
-	return predicate.Orient2D(a, b, p) >= 0 &&
-		predicate.Orient2D(b, c, p) >= 0 &&
-		predicate.Orient2D(c, a, p) >= 0
+	return predicate.Orient2D(a, b, p) > 0 &&
+		predicate.Orient2D(b, c, p) > 0 &&
+		predicate.Orient2D(c, a, p) > 0
 }
 
 // signedArea returns the shoelace signed area (positive = CCW).

--- a/kernel/ops/earclip_holes.go
+++ b/kernel/ops/earclip_holes.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/math/predicate"
+)
+
+// mergeHoles bridges each hole loop into the outer loop, producing a single simple polygon
+// (the 2D copy for ear-clipping plus its 3D pre-image in lockstep) whose triangulation
+// equals the triangulation of the holed face. It is the textbook bridge construction
+// (Eberly, "Triangulation by Ear Clipping" §4): for each hole, pick its rightmost vertex,
+// find a mutually visible outer vertex, and splice the (CW) hole into the (CCW) outer along
+// a doubled bridge edge. Holes are processed right-to-left so an already-bridged hole is
+// just part of the growing outer for the next one.
+func mergeHoles(outer2D []math.Point2, outer3D []math.Point3, holes2D [][]math.Point2, holes3D [][]math.Point3) ([]math.Point2, []math.Point3) {
+	o2, o3 := orient(outer2D, outer3D, true) // outer CCW
+	order := holesByRightmost(holes2D)
+	for _, hi := range order {
+		h2, h3 := orient(holes2D[hi], holes3D[hi], false) // hole CW
+		ph := rightmost(h2)
+		mo := findVisibleVertex(o2, h2[ph])
+		o2, o3 = spliceBridge(o2, o3, mo, h2, h3, ph)
+	}
+	return o2, o3
+}
+
+// holesByRightmost orders hole indices by their rightmost vertex's X (descending), so the
+// hole nearest the outer's right boundary bridges first.
+func holesByRightmost(holes [][]math.Point2) []int {
+	order := make([]int, len(holes))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return holes[order[a]][rightmost(holes[order[a]])].X > holes[order[b]][rightmost(holes[order[b]])].X
+	})
+	return order
+}
+
+// rightmost returns the index of the loop's vertex with maximum X (ties broken by Y).
+func rightmost(loop []math.Point2) int {
+	best := 0
+	for i, p := range loop {
+		if p.X > loop[best].X || (p.X == loop[best].X && p.Y > loop[best].Y) {
+			best = i
+		}
+	}
+	return best
+}
+
+// orient returns the loop (2D and its 3D pre-image) reordered to the requested winding
+// (ccw=true → counter-clockwise).
+func orient(loop2D []math.Point2, loop3D []math.Point3, ccw bool) ([]math.Point2, []math.Point3) {
+	if (signedArea(loop2D) > 0) == ccw {
+		return loop2D, loop3D
+	}
+	r2 := make([]math.Point2, len(loop2D))
+	r3 := make([]math.Point3, len(loop3D))
+	for i := range loop2D {
+		r2[len(loop2D)-1-i] = loop2D[i]
+		r3[len(loop3D)-1-i] = loop3D[i]
+	}
+	return r2, r3
+}
+
+// spliceBridge inserts a hole into the outer loop after outer vertex mo: the doubled bridge
+// runs outer[mo] → hole[ph] → (whole hole) → hole[ph] → outer[mo], turning the annulus into
+// one simple polygon.
+func spliceBridge(o2 []math.Point2, o3 []math.Point3, mo int, h2 []math.Point2, h3 []math.Point3, ph int) ([]math.Point2, []math.Point3) {
+	n2 := make([]math.Point2, 0, len(o2)+len(h2)+2)
+	n3 := make([]math.Point3, 0, len(o3)+len(h3)+2)
+	n2 = append(n2, o2[:mo+1]...)
+	n3 = append(n3, o3[:mo+1]...)
+	for k := 0; k <= len(h2); k++ { // ph..around..ph (inclusive, so the hole closes)
+		j := (ph + k) % len(h2)
+		n2 = append(n2, h2[j])
+		n3 = append(n3, h3[j])
+	}
+	n2 = append(n2, o2[mo])
+	n3 = append(n3, o3[mo])
+	n2 = append(n2, o2[mo+1:]...)
+	n3 = append(n3, o3[mo+1:]...)
+	return n2, n3
+}
+
+// findVisibleVertex returns the index of an outer-loop vertex mutually visible from p (a
+// hole's rightmost vertex): cast a ray from p toward +X, take the hit edge's higher-X
+// endpoint M, and if any reflex outer vertex lies inside triangle (p, hit, M) blocking the
+// view, fall back to the blocker whose direction from p is closest to the +X ray.
+func findVisibleVertex(outer []math.Point2, p math.Point2) int {
+	mIdx, hit := rayHitEdge(outer, p)
+	if mIdx < 0 {
+		return 0
+	}
+	m := outer[mIdx]
+	best, bestAng, bestD := mIdx, stdmath.Inf(1), stdmath.Inf(1)
+	for i := range outer {
+		if i == mIdx || !isReflex(outer, i) {
+			continue
+		}
+		v := outer[i]
+		if !inTriAny(v, p, hit, m) {
+			continue
+		}
+		ang := stdmath.Abs(stdmath.Atan2(v.Y-p.Y, v.X-p.X))
+		if d := p.VectorTo(v).LengthSquared(); ang < bestAng || (ang == bestAng && d < bestD) {
+			best, bestAng, bestD = i, ang, d
+		}
+	}
+	return best
+}
+
+// rayHitEdge casts a ray from p toward +X and returns the index of the hit edge's higher-X
+// endpoint and the intersection point (mIdx = −1 if the ray hits nothing).
+func rayHitEdge(outer []math.Point2, p math.Point2) (int, math.Point2) {
+	n := len(outer)
+	mIdx, bestD, hit := -1, stdmath.Inf(1), math.Point2{}
+	for i := 0; i < n; i++ {
+		a, b := outer[i], outer[(i+1)%n]
+		if (a.Y > p.Y) == (b.Y > p.Y) {
+			continue // edge does not straddle the horizontal ray line
+		}
+		t := (p.Y - a.Y) / (b.Y - a.Y)
+		x := a.X + t*(b.X-a.X)
+		if x < p.X || x-p.X >= bestD {
+			continue
+		}
+		bestD, hit = x-p.X, math.P2(x, p.Y)
+		if a.X > b.X {
+			mIdx = i
+		} else {
+			mIdx = (i + 1) % n
+		}
+	}
+	return mIdx, hit
+}
+
+// isReflex reports whether vertex i of a CCW loop is reflex (interior angle > 180°).
+func isReflex(loop []math.Point2, i int) bool {
+	n := len(loop)
+	return predicate.Orient2D(loop[(i+n-1)%n], loop[i], loop[(i+1)%n]) < 0
+}
+
+// inTriAny reports whether p lies in triangle abc regardless of the triangle's winding.
+func inTriAny(p, a, b, c math.Point2) bool {
+	d1 := predicate.Orient2D(a, b, p)
+	d2 := predicate.Orient2D(b, c, p)
+	d3 := predicate.Orient2D(c, a, p)
+	return !((d1 < 0 || d2 < 0 || d3 < 0) && (d1 > 0 || d2 > 0 || d3 > 0))
+}

--- a/kernel/ops/earclip_holes_test.go
+++ b/kernel/ops/earclip_holes_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// signedTriArea2 returns twice the signed area of triangle abc.
+func signedTriArea2(a, b, c math.Point2) float64 {
+	return (b.X-a.X)*(c.Y-a.Y) - (c.X-a.X)*(b.Y-a.Y)
+}
+
+// TestMergeHolesTriangulatesAnnulus bridges a square hole into a square outer and checks
+// the ear-clipped triangles cover exactly the annulus area (outer 16 − hole 4 = 12), all
+// wound CCW. Regression for the tessellator that ignored holes and over-counted volume on
+// frame faces away from the origin plane (chained-difference +X pocket; see kernel/brep).
+func TestMergeHolesTriangulatesAnnulus(t *testing.T) {
+	outer := []math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}} // CCW, 16
+	hole := []math.Point2{{X: 1, Y: 1}, {X: 1, Y: 3}, {X: 3, Y: 3}, {X: 3, Y: 1}}  // 4
+	o3 := lift(outer)
+	merged2, merged3 := mergeHoles(outer, o3, [][]math.Point2{hole}, [][]math.Point3{lift(hole)})
+	if len(merged2) != len(merged3) {
+		t.Fatalf("merged 2D/3D length mismatch: %d vs %d", len(merged2), len(merged3))
+	}
+	var area float64
+	tris := earClip(merged2)
+	if len(tris) == 0 {
+		t.Fatal("ear-clipping a bridged annulus produced no triangles")
+	}
+	for _, tr := range tris {
+		a := signedTriArea2(merged2[tr[0]], merged2[tr[1]], merged2[tr[2]])
+		if a <= 0 {
+			t.Errorf("triangle %v not CCW (2·area = %g)", tr, a)
+		}
+		area += a / 2
+	}
+	if stdmath.Abs(area-12) > 1e-9 {
+		t.Errorf("annulus triangulated area = %g, want 12", area)
+	}
+}
+
+// lift trivially embeds 2D points at z=0 for the lockstep 3D loop.
+func lift(p []math.Point2) []math.Point3 {
+	out := make([]math.Point3, len(p))
+	for i, q := range p {
+		out[i] = math.P3(q.X, q.Y, 0)
+	}
+	return out
+}

--- a/model/feature/dressup_test.go
+++ b/model/feature/dressup_test.go
@@ -45,6 +45,37 @@ func TestChamferBevelsEdgeForReal(t *testing.T) {
 	}
 }
 
+// TestChamferAllFourVerticalEdges chains four wedge cuts on a 2×2×2 box (an octagonal
+// prism). Each cut feeds the previous result back into the boolean — the chaining case the
+// triangle-soup CSG got wrong; the B-rep boolean must keep it exact. Volume =
+// (4 − 4·½·0.5²)·2 = 7.
+func TestChamferAllFourVerticalEdges(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var verticals [][]byte
+	for _, e := range box.Edges() {
+		if a, b := e.StartVertex().Point(), e.EndVertex().Point(); a.X == b.X && a.Y == b.Y {
+			verticals = append(verticals, e.ReferenceKey())
+		}
+	}
+	if len(verticals) != 4 {
+		t.Fatalf("found %d vertical edges, want 4", len(verticals))
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	ch := NewDressUpFeatures(fs).AddChamfer(verticals, func() float64 { return 0.5 })
+	fs.Recompute()
+	if !ch.Health().OK() {
+		t.Fatalf("multi-edge chamfer sick: %+v", ch.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("octagonal prism not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, 7) > 1e-6 {
+		t.Errorf("four-edge chamfer volume = %g, want 7", got)
+	}
+}
+
 // prismBody builds a unit-square prism via the extrude generator (for real edges).
 func prismBody() *topo.Body {
 	return buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 1}}, sketch.XYPlane(), span{near: 0, far: 1}, 0, "ext")


### PR DESCRIPTION
## What

Completes the planar **B-rep boolean** in `kernel/brep` and makes it the primary engine behind `ops.Boolean`, replacing the triangle-soup BSP CSG for planar operands.

- **Imprint → split → classify → stitch** boolean producing watertight, low-face-count solids for union / difference / intersection.
- **Sound under chaining**: a boolean's output fed back as an input stays exact (the case the CSG got wrong — it returned 0.25 for a two-pocket difference).
- **Coplanar (ON/ON) face handling**: flush unions, flush pockets, shared-face intersections, and the chamfer wedge's faces that lie on the box are now classified by set-membership rules instead of an ambiguous inside/outside ray cast.
- **Planar tessellation with holes** (`kernel/ops`): the tessellator ignored inner loops and triangulated holed faces as filled polygons, over-counting divergence-theorem volume on any frame face off the origin plane. Now bridges holes into the outer loop (Eberly) then ear-clips.

`ops.Boolean` falls back to the BSP CSG only when an operand has a non-planar face (cylinder, cone, …).

## Why

The triangle-soup CSG was unsound when chained, which broke multi-feature edits — most visibly the **multi-edge chamfer**. With the B-rep boolean wired in, four chained wedge cuts now produce the exact octagonal prism.

## Tests

- `kernel/brep`: union / difference / intersection, chained difference (two disjoint pockets), coplanar union / difference-pocket / intersection.
- `kernel/ops`: annulus (holed-face) tessellation area regression.
- `model/feature`: four-edge chamfer (chained cuts) volume regression.

All of `go test ./...`, `go vet`, `golangci-lint`, and `-race` on the touched packages are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)