### PR TITLE
M20 (curved B-rep 1/3): Surface.ParamAt point→parameter inversion

### DIFF
--- a/kernel/geom/geom_internal.go
+++ b/kernel/geom/geom_internal.go
@@ -38,6 +38,39 @@ func wrapPositive(delta float64) float64 {
 	return d
 }
 
+// wrap2pi maps any angle into the half-open range [0, 2π) — the canonical form
+// for an inverted angular parameter (see ParamAt).
+func wrap2pi(a float64) float64 {
+	d := stdmath.Mod(a, twoPi)
+	if d < 0 {
+		d += twoPi
+	}
+	return d
+}
+
+// clampUnit constrains x to [−1, 1] so it is a valid argument to asin/acos after
+// the rounding of a normalized-direction component.
+func clampUnit(x float64) float64 {
+	if x > 1 {
+		return 1
+	}
+	if x < -1 {
+		return -1
+	}
+	return x
+}
+
+// clampTo constrains x to [lo, hi].
+func clampTo(x, lo, hi float64) float64 {
+	if x < lo {
+		return lo
+	}
+	if x > hi {
+		return hi
+	}
+	return x
+}
+
 // signedArea2 returns twice the signed area of triangle (a, b, c). Positive
 // means the three points wind counter-clockwise.
 func signedArea2(a, b, c math.Point2) float64 {

--- a/kernel/geom/paramat.go
+++ b/kernel/geom/paramat.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// ParamAt inversions for the analytic surfaces are closed-form: each undoes its
+// PointAt by projecting p onto the surface's frame. Angular parameters come back
+// in [0, 2π) (wrap2pi) and match the forward radial(u) = cos u·Ref + sin u·binormal
+// convention via u = atan2(p·binormal, p·Ref). The NURBS surface has no closed form,
+// so it falls back to a coarse grid seed plus projected Gauss–Newton steps.
+
+// ParamAt returns (u, v) = ((p−Origin)·UAxis, (p−Origin)·VAxis).
+func (p Plane) ParamAt(q math.Point3) (u, v float64) {
+	d := p.Origin.VectorTo(q)
+	return d.Dot(p.UAxis.AsVector()), d.Dot(p.VAxis.AsVector())
+}
+
+// ParamAt returns the angle around the axis and the signed distance along it.
+func (c Cylinder) ParamAt(q math.Point3) (u, v float64) {
+	d := c.Origin.VectorTo(q)
+	v = d.Dot(c.AxisDir.AsVector())
+	r := d.Sub(c.AxisDir.AsVector().Scale(v))
+	return wrap2pi(stdmath.Atan2(r.Dot(c.binormal), r.Dot(c.Ref.AsVector()))), v
+}
+
+// ParamAt returns the angle around the axis and the distance from the apex along it.
+func (c Cone) ParamAt(q math.Point3) (u, v float64) {
+	d := c.Apex.VectorTo(q)
+	v = d.Dot(c.AxisDir.AsVector())
+	r := d.Sub(c.AxisDir.AsVector().Scale(v))
+	return wrap2pi(stdmath.Atan2(r.Dot(c.binormal), r.Dot(c.Ref.AsVector()))), v
+}
+
+// ParamAt returns the longitude u ∈ [0, 2π) and latitude v ∈ [−π/2, π/2] of the
+// closest point on the sphere (the radial direction from the center to q).
+func (s Sphere) ParamAt(q math.Point3) (u, v float64) {
+	d := unitOrZero(s.Center.VectorTo(q))
+	return wrap2pi(stdmath.Atan2(d.Y, d.X)), stdmath.Asin(clampUnit(d.Z))
+}
+
+// ParamAt returns the around-axis angle u and around-tube angle v, both in [0, 2π).
+func (t Torus) ParamAt(q math.Point3) (u, v float64) {
+	d := t.Center.VectorTo(q)
+	axial := d.Dot(t.AxisDir.AsVector())
+	planar := d.Sub(t.AxisDir.AsVector().Scale(axial))
+	u = wrap2pi(stdmath.Atan2(planar.Dot(t.binormal), planar.Dot(t.Ref.AsVector())))
+	v = wrap2pi(stdmath.Atan2(axial, planar.Length()-t.MajorRadius)) // ρ = Minor·cos v, axial = Minor·sin v
+	return u, v
+}
+
+// ParamAt projects q onto the NURBS surface numerically: a coarse grid seed then
+// projected Gauss–Newton steps (Piegl & Tiller A6, simplified), staying in domain.
+func (s BSplineSurface) ParamAt(q math.Point3) (u, v float64) {
+	uLo, uHi := s.UDomain()
+	vLo, vHi := s.VDomain()
+	u, v = surfaceGridSeed(s, q, uLo, uHi, vLo, vHi)
+	for i := 0; i < 40; i++ {
+		u, v = surfaceProjectStep(s, q, u, v, uLo, uHi, vLo, vHi)
+	}
+	return u, v
+}
+
+// surfaceGridSeed returns the sampled (u, v) over a coarse grid whose point is
+// nearest q — the starting guess for the Gauss–Newton refinement.
+func surfaceGridSeed(s Surface, q math.Point3, uLo, uHi, vLo, vHi float64) (float64, float64) {
+	const n = 16
+	bu, bv, bd := uLo, vLo, stdmath.Inf(1)
+	for i := 0; i <= n; i++ {
+		u := uLo + (uHi-uLo)*float64(i)/n
+		for j := 0; j <= n; j++ {
+			v := vLo + (vHi-vLo)*float64(j)/n
+			if d := s.PointAt(u, v).DistanceSquaredTo(q); d < bd {
+				bu, bv, bd = u, v, d
+			}
+		}
+	}
+	return bu, bv
+}
+
+// surfaceProjectStep advances (u, v) toward q by projecting the residual onto each
+// partial derivative, clamped to the domain.
+func surfaceProjectStep(s Surface, q math.Point3, u, v, uLo, uHi, vLo, vHi float64) (float64, float64) {
+	du, dv := s.DerivativesAt(u, v)
+	res := s.PointAt(u, v).VectorTo(q)
+	return clampTo(u+projectParam(res, du), uLo, uHi), clampTo(v+projectParam(res, dv), vLo, vHi)
+}
+
+// projectParam returns res·d / |d|² — the parameter step reducing the residual
+// along d (zero when d is degenerate).
+func projectParam(res, d math.Vector3) float64 {
+	denom := d.LengthSquared()
+	if denom < math.DefaultTolerance {
+		return 0
+	}
+	return res.Dot(d) / denom
+}

--- a/kernel/geom/paramat_test.go
+++ b/kernel/geom/paramat_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// TestParamAtInvertsPointAt checks ParamAt is a right inverse of PointAt in point
+// space: PointAt(ParamAt(PointAt(u,v))) == PointAt(u,v). Comparing points (not
+// parameters) sidesteps periodic-wrap/branch ambiguity. Reuses the shared
+// sampleSurfaces fixture (one interior (u,v) per surface type).
+func TestParamAtInvertsPointAt(t *testing.T) {
+	for _, c := range sampleSurfaces(t) {
+		want := c.s.PointAt(c.u, c.v)
+		ru, rv := c.s.ParamAt(want)
+		if got := c.s.PointAt(ru, rv); got.DistanceTo(want) > 1e-6 {
+			t.Errorf("%s ParamAt round-trip at (%g,%g): got %v, want %v", c.name, c.u, c.v, got, want)
+		}
+	}
+}
+
+// TestParamAtFootOfOffSurfacePoint checks the metric-foot property where it holds
+// exactly — plane/cylinder/sphere, whose normal is a parameter-frame direction: a
+// point pushed off along the normal inverts to the foot directly beneath it. (Cone
+// and torus give a frame projection that is not the exact metric foot off-surface;
+// see the interface doc — irrelevant to tessellation, which inverts on-surface points.)
+func TestParamAtFootOfOffSurfacePoint(t *testing.T) {
+	metricFoot := map[string]bool{"plane": true, "cylinder": true, "sphere": true}
+	for _, c := range sampleSurfaces(t) {
+		if !metricFoot[c.name] {
+			continue
+		}
+		foot := c.s.PointAt(c.u, c.v)
+		n := c.s.NormalAt(c.u, c.v)
+		off := foot.TranslateBy(n.Scale(0.25))
+		ru, rv := c.s.ParamAt(off)
+		if got := c.s.PointAt(ru, rv); got.DistanceTo(foot) > 1e-6 {
+			t.Errorf("%s ParamAt foot at (%g,%g): got %v, want %v", c.name, c.u, c.v, got, foot)
+		}
+	}
+}
+
+// TestParamAtAnalyticAngles checks the closed-form angular inversion is exact (not
+// just point-consistent) for the analytic surfaces away from the seam.
+func TestParamAtAnalyticAngles(t *testing.T) {
+	cyl, err := NewCylinder(math.P3(1, 2, 3), math.V3(0, 0, 1), 2)
+	must(t, err)
+	u, v := cyl.ParamAt(cyl.PointAt(1.0, 4.0))
+	if !nearAngle(u, 1.0) || !near(v, 4.0) {
+		t.Errorf("cylinder ParamAt = (%g,%g), want (1,4)", u, v)
+	}
+}
+
+func near(a, b float64) bool      { return a-b < 1e-9 && b-a < 1e-9 }
+func nearAngle(a, b float64) bool { return near(a, b) }
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kernel/geom/surface.go
+++ b/kernel/geom/surface.go
@@ -23,6 +23,14 @@ type Surface interface {
 	// directions (around an axis) return [0, 2π], unbounded ones return ±Inf.
 	UDomain() (lo, hi float64)
 	VDomain() (lo, hi float64)
+	// ParamAt inverts PointAt: for a point on the surface it reproduces PointAt's
+	// parameters (angular ones wrapped to [0, 2π)) — exactly for the analytic
+	// surfaces, numerically for NURBS. This on-surface inverse is what trimmed-face
+	// tessellation needs (loop vertices lie on the face's surface). Off-surface, it
+	// returns the frame projection along the parameter directions, which equals the
+	// metric nearest point for the plane, cylinder and sphere but not exactly for the
+	// cone or torus (where it is still a stable, continuous projection).
+	ParamAt(p math.Point3) (u, v float64)
 }
 
 // normalFromPartials returns the unit normal du×dv, or zero when the partials


### PR DESCRIPTION
## What

First of three PBIs building the **curved B-rep stack** that a proper rolling-ball fillet (and exact cylindrical holes / curved shells) needs. Parks fillet itself until the stack lands.

Adds `ParamAt(p) (u, v)` to the `geom.Surface` interface — the inverse of `PointAt`:
- **closed-form** for the five analytic surfaces (project p onto the surface's axis/angle frame; angular params wrapped to `[0, 2π)`),
- **numeric** for NURBS (coarse grid seed + projected Gauss–Newton).

For an on-surface point it is the exact inverse — the case trimmed-face tessellation needs (trim-loop vertices lie on the face's surface). Off-surface it is a stable frame projection (the metric nearest point for plane/cylinder/sphere; a continuous projection for cone/torus, documented on the interface).

## Why

The tessellator currently treats curved faces by meshing the surface's *full* UV domain, ignoring trim loops, because there is no way to map a loop vertex back to `(u, v)`. `ParamAt` is that missing primitive. (Next: shared curved-edge discretization, then trimmed curved-face tessellation.)

## Tests

`PointAt(ParamAt(PointAt(u,v))) == PointAt(u,v)` for every surface type, exact analytic angle inversion, NURBS projection onto a bilinear patch, metric-foot property for plane/cylinder/sphere. `go test ./...`, vet, lint all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)