### PR TITLE
M20 (curved B-rep 2/3): shared curved-edge discretization

### DIFF
--- a/kernel/ops/earclip.go
+++ b/kernel/ops/earclip.go
@@ -10,16 +10,17 @@ import (
 	"github.com/Oblikovati/oblikovati/math/predicate"
 )
 
-// tessellatePlanarFace triangulates a planar face's outer boundary by ear-clipping
-// (using the exact orientation predicate), giving a watertight triangulation whose
-// vertices are exactly the boundary vertices — chordal tolerance is met trivially
-// since the facets lie in the face plane.
-func tessellatePlanarFace(f *topo.Face) *Mesh {
+// tessellatePlanarFace triangulates a planar face's boundary by ear-clipping (using
+// the exact orientation predicate), giving a watertight triangulation. The boundary
+// comes from [loopBoundary], so a planar face bordered by a curved edge (e.g. a fillet's
+// flat end cap) follows the arc — sampled identically to the curved neighbour, no
+// T-junctions — rather than chording across it.
+func tessellatePlanarFace(f *topo.Face, q Quality) *Mesh {
 	normal := f.Geometry().NormalAt(0, 0)
 	flat := planeProjector(normal)
-	boundary3D := faceOuterBoundary(f)
+	boundary3D := faceOuterBoundary(f, q)
 	boundary2D := project2D(boundary3D, flat)
-	if holes3D := faceHoleBoundaries(f); len(holes3D) > 0 {
+	if holes3D := faceHoleBoundaries(f, q); len(holes3D) > 0 {
 		holes2D := make([][]math.Point2, len(holes3D))
 		for i, h := range holes3D {
 			holes2D[i] = project2D(h, flat)
@@ -45,38 +46,25 @@ func project2D(pts []math.Point3, flat func(math.Point3) math.Point2) []math.Poi
 	return out
 }
 
-// faceOuterBoundary returns the ordered vertices of a face's outer loop.
-func faceOuterBoundary(f *topo.Face) []math.Point3 {
+// faceOuterBoundary returns the discretized point ring of a face's outer loop.
+func faceOuterBoundary(f *topo.Face, q Quality) []math.Point3 {
 	for _, l := range f.Loops() {
 		if l.IsOuter() {
-			return loopVertices(l)
+			return loopBoundary(l, q)
 		}
 	}
 	return nil
 }
 
-// faceHoleBoundaries returns the ordered vertices of each of a face's inner (hole) loops.
-func faceHoleBoundaries(f *topo.Face) [][]math.Point3 {
+// faceHoleBoundaries returns the discretized point ring of each inner (hole) loop.
+func faceHoleBoundaries(f *topo.Face, q Quality) [][]math.Point3 {
 	var holes [][]math.Point3
 	for _, l := range f.Loops() {
 		if !l.IsOuter() {
-			holes = append(holes, loopVertices(l))
+			holes = append(holes, loopBoundary(l, q))
 		}
 	}
 	return holes
-}
-
-// loopVertices returns a loop's ordered vertex points (honouring edge-use reversal).
-func loopVertices(l *topo.Loop) []math.Point3 {
-	pts := make([]math.Point3, 0, len(l.EdgeUses()))
-	for _, u := range l.EdgeUses() {
-		v := u.Edge().StartVertex()
-		if u.Reversed() {
-			v = u.Edge().EndVertex()
-		}
-		pts = append(pts, v.Point())
-	}
-	return pts
 }
 
 // earClip triangulates a simple polygon, returning triangles as index triples into

--- a/kernel/ops/edge_discretize.go
+++ b/kernel/ops/edge_discretize.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Curved edges must be sampled into the SAME chord polyline by every face that uses
+// them, or two faces meeting at an arc would tessellate it differently and leave a
+// T-junction (a crack) in the mesh. discretizeEdge derives the polyline only from the
+// edge (its curve, in its natural start→end parameter order), so any caller gets the
+// identical result; loopBoundary then orients per edge use and concatenates. A straight
+// edge yields just its two endpoints, so polyhedral faces are unaffected.
+
+// discretizeEdge samples an edge's curve into a chord polyline (start vertex → end
+// vertex) meeting the chordal tolerance. Endpoints are snapped to the edge's vertices
+// so adjacent edges share exact points.
+func discretizeEdge(e *topo.Edge, q Quality) []math.Point3 {
+	c := e.Geometry()
+	lo, hi := c.Domain()
+	ts := adaptiveParams(func(t float64) math.Point3 { return c.PointAt(t) }, lo, hi, q.tol())
+	pts := make([]math.Point3, len(ts))
+	for i, t := range ts {
+		pts[i] = c.PointAt(t)
+	}
+	pts[0] = e.StartVertex().Point()
+	pts[len(pts)-1] = e.EndVertex().Point()
+	return pts
+}
+
+// loopBoundary returns a loop's boundary as an ordered point ring, each edge sampled
+// by [discretizeEdge] and oriented to the edge use, with shared vertices not repeated.
+// Both faces of a curved edge get matching interior points (watertight, no T-junctions).
+func loopBoundary(l *topo.Loop, q Quality) []math.Point3 {
+	var out []math.Point3
+	for _, u := range l.EdgeUses() {
+		pts := discretizeEdge(u.Edge(), q)
+		if u.Reversed() {
+			pts = reverse3(pts)
+		}
+		if len(out) > 0 {
+			pts = pts[1:] // drop the point shared with the previous edge's end
+		}
+		out = append(out, pts...)
+	}
+	if n := len(out); n > 1 && out[0].DistanceTo(out[n-1]) < weldPointTol {
+		out = out[:n-1] // drop the closing duplicate (last == first)
+	}
+	return out
+}
+
+// reverse3 returns the points in reverse order (new slice).
+func reverse3(pts []math.Point3) []math.Point3 {
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[len(pts)-1-i] = p
+	}
+	return out
+}
+
+// weldPointTol is the distance under which two boundary points are the same vertex.
+const weldPointTol = 1e-9

--- a/kernel/ops/edge_discretize_test.go
+++ b/kernel/ops/edge_discretize_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// halfDiskFace builds a planar (XY) half-disk face of radius r: a CCW outer loop of
+// the semicircle arc (angle 0→π through the top) plus the diameter segment back.
+func halfDiskFace(t *testing.T, r float64) *topo.Face {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "halfdisk", 0))
+	bld := topo.NewBuilder(false, lin)
+	a := math.P3(r, 0, 0)  // angle 0
+	b := math.P3(-r, 0, 0) // angle π
+	va := bld.AddVertex(a, lin)
+	vb := bld.AddVertex(b, lin)
+	arc, err := geom.NewArc3d(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), r, 0, stdmath.Pi)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eArc := bld.AddEdge(arc, va, vb, lin)                       // A→B along the top arc
+	eSeg := bld.AddEdge(geom.NewLineSegment(b, a), vb, va, lin) // B→A along the diameter
+	plane, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bld.AddFace(plane, lin,
+		topo.OuterLoop(topo.Use{Edge: eArc}, topo.Use{Edge: eSeg}))
+	return bld.Build().Faces()[0]
+}
+
+// meshArea sums the triangle areas of a mesh.
+func meshArea(m *Mesh) float64 {
+	var sum float64
+	for i := 0; i+2 < len(m.Indices); i += 3 {
+		a, b, c := m.Positions[m.Indices[i]], m.Positions[m.Indices[i+1]], m.Positions[m.Indices[i+2]]
+		sum += a.VectorTo(b).Cross(a.VectorTo(c)).Length() / 2
+	}
+	return sum
+}
+
+// TestPlanarFaceFollowsCurvedEdge tessellates a half-disk whose curved boundary is an
+// arc edge: the boundary must follow the arc (area → πr²/2), not chord straight across
+// the diameter of the semicircle (which would halve the area). Regression for the
+// tessellator that used loop vertices only (every edge treated as a chord).
+func TestPlanarFaceFollowsCurvedEdge(t *testing.T) {
+	const r = 2.0
+	f := halfDiskFace(t, r)
+	mesh := TessellateFace(f, Quality{ChordTolerance: 1e-3})
+	if mesh.VertexCount() <= 4 {
+		t.Fatalf("arc boundary not subdivided: %d vertices", mesh.VertexCount())
+	}
+	want := stdmath.Pi * r * r / 2
+	if got := meshArea(mesh); stdmath.Abs(got-want) > 0.01 {
+		t.Errorf("half-disk mesh area = %g, want ≈ %g", got, want)
+	}
+}
+
+// TestDiscretizeEdgeIsShared checks both directions of the same arc edge produce the
+// identical point set (reversed) — the property that keeps shared edges crack-free.
+func TestDiscretizeEdgeIsShared(t *testing.T) {
+	f := halfDiskFace(t, 2)
+	var arc *topo.Edge
+	for _, e := range f.Edges() {
+		if _, ok := e.Geometry().(geom.Arc3d); ok {
+			arc = e
+		}
+	}
+	if arc == nil {
+		t.Fatal("no arc edge on the half-disk")
+	}
+	fwd := discretizeEdge(arc, Quality{ChordTolerance: 1e-2})
+	rev := reverse3(discretizeEdge(arc, Quality{ChordTolerance: 1e-2}))
+	if len(fwd) != len(rev) {
+		t.Fatalf("forward %d vs reversed %d points", len(fwd), len(rev))
+	}
+	for i := range fwd {
+		if fwd[i].DistanceTo(rev[len(rev)-1-i]) > 1e-12 {
+			t.Errorf("discretization not symmetric at %d", i)
+		}
+	}
+}

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -78,7 +78,7 @@ func TessellateBody(b *topo.Body, q Quality) (*Mesh, [][]math.Point3) {
 // outer boundary (watertight); curved faces are sampled on an adaptive UV grid.
 func TessellateFace(f *topo.Face, q Quality) *Mesh {
 	if _, planar := f.Geometry().(geom.Plane); planar {
-		return tessellatePlanarFace(f)
+		return tessellatePlanarFace(f, q)
 	}
 	return tessellateCurvedFace(f, q)
 }


### PR DESCRIPTION
## What

Second of three PBIs in the curved-B-rep stack (after #30 `Surface.ParamAt`).

The tessellator built face boundaries from loop **vertices only**, so every edge — including arcs — was a straight chord, and two faces meeting at a curved edge could subdivide it differently and leave a crack (T-junction).

- `discretizeEdge(e, q)` samples an edge's curve into a chord polyline meeting the chordal tolerance, derived **solely from the edge** (its curve, natural start→end order) — so every face that uses the edge gets the identical points. Endpoints snap to the edge's vertices.
- `loopBoundary(l, q)` orients each edge's polyline to its use and concatenates without repeating shared vertices.
- `tessellatePlanarFace` now builds its boundaries this way (Quality threaded through). Straight edges yield just their endpoints, so **polyhedral faces are unchanged**.

## Why

A fillet's flat end-cap (planar) borders the fillet cylinder (curved) along an arc; both must sample that arc identically or the mesh cracks. This is the shared-sampling primitive the trimmed curved-face tessellation (next PBI) builds on.

## Tests

A planar half-disk bounded by an arc edge tessellates to ≈ πr²/2 with a subdivided boundary (follows the arc, not a chord); an edge discretizes identically in both directions. Full `go test ./...`, vet, lint green locally; existing polyhedral tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)