### PR TITLE
M20 F04: Shell feature — real geometry + UI (DoD)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -97,6 +97,12 @@ func modifyFeatureCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("chamfer").WithButtonStyle(LargeIconButton).
 			WithTooltip("Chamfer — bevel selected edges by a setback distance."),
+		NewCommand("Modify.Shell", "Shell", "Modify", func(s *Session) error {
+			s.StartTool(NewShellTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("shell").WithButtonStyle(LargeIconButton).
+			WithTooltip("Shell — hollow the solid to a wall thickness, removing the selected faces."),
 	}
 }
 

--- a/app/shell_session.go
+++ b/app/shell_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Shell tool's property window.
+
+// ActiveShell returns the running Shell tool, or nil when the active tool is not a shell
+// (or there is none).
+func (s *Session) ActiveShell() *ShellTool {
+	if s.tool == nil {
+		return nil
+	}
+	sh, _ := s.tool.tool.(*ShellTool)
+	return sh
+}

--- a/app/shell_tool.go
+++ b/app/shell_tool.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// ShellTool is the interactive Shell command: activate it, click the faces to remove
+// (the openings), set the wall thickness in the property window, and OK to hollow the
+// active part to that thickness.
+type ShellTool struct {
+	faces     []FaceHandle
+	thickness float64
+	added     *feature.PartFeature
+}
+
+// NewShellTool returns a shell tool with a default 1-unit wall thickness.
+func NewShellTool() *ShellTool { return &ShellTool{thickness: 1} }
+
+// Name implements [Tool].
+func (t *ShellTool) Name() string { return "Shell" }
+
+// Start sets the selection filter to faces so clicks pick faces to open.
+func (t *ShellTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+
+// Pick appends the clicked face (ignoring one already chosen, so a double-click does not
+// duplicate it).
+func (t *ShellTool) Pick(_ *Session, sel Selectable) {
+	f, ok := sel.(FaceHandle)
+	if !ok || t.hasFace(f) {
+		return
+	}
+	t.faces = append(t.faces, f)
+}
+
+func (t *ShellTool) hasFace(f FaceHandle) bool {
+	for _, h := range t.faces {
+		if h == f {
+			return true
+		}
+	}
+	return false
+}
+
+// SetThickness/Thickness set the shell wall thickness (database units).
+func (t *ShellTool) SetThickness(d float64) { t.thickness = d }
+func (t *ShellTool) Thickness() float64     { return t.thickness }
+
+// Faces returns the picked removed-faces (for the UI to list/highlight).
+func (t *ShellTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
+
+// CanCommit reports whether at least one face is picked and the thickness is positive.
+// (A shell with no removed faces hollows to a closed void, which our planar engine does
+// not yet build, so we require at least one opening.)
+func (t *ShellTool) CanCommit() bool { return len(t.faces) > 0 && t.thickness > 0 }
+
+// Commit hollows the active part to the wall thickness, opening the picked faces, and
+// recomputes; a sick feature keeps the tool open by returning an error.
+func (t *ShellTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	keys := make([][]byte, len(t.faces))
+	for i, f := range t.faces {
+		keys[i] = f.Face.ReferenceKey()
+	}
+	th := t.thickness
+	t.added = feature.NewDressUpFeatures(part.Features()).AddShell(keys, func() float64 { return th })
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("shell: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *ShellTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user through the shell steps.
+func (t *ShellTool) Prompt(*Session) string {
+	if len(t.faces) == 0 {
+		return "Click the faces to remove (openings)"
+	}
+	return "Set the wall thickness, then click OK"
+}
+
+// Cancel restores the default selection filter.
+func (t *ShellTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }

--- a/app/shell_tool_test.go
+++ b/app/shell_tool_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// TestShellToolEndToEnd drives the Shell UI: start the tool, click the block's top face
+// (the opening), set the wall thickness, OK — and asserts the body is hollowed to a valid
+// open solid of the right volume. Block 4×4×2 (vol 32); cavity [0.5,3.5]²×[0.5,2] =
+// 3·3·1.5 = 13.5 ⇒ 18.5.
+func TestShellToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+
+	sh := NewShellTool()
+	s.StartTool(sh)   // ribbon: click "Shell"
+	s.Click(100, 100) // viewport: click the top face to open it
+	sh.SetThickness(0.5)
+	if !sh.CanCommit() {
+		t.Fatal("shell tool not ready after face + thickness")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	def := activePartDef(t, s)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("shelled body not a valid solid: %+v", r)
+	}
+	want := 32.0 - 3*3*1.5
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, want) > 1e-6 {
+		t.Errorf("shell volume = %g, want %g", got, want)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestShellViaRibbonCommand drives the Shell from its ribbon command.
+func TestShellViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.Shell"); err != nil {
+		t.Fatalf("execute Modify.Shell: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*ShellTool); !ok {
+		t.Fatal("Shell command did not start the shell tool")
+	}
+	s.Click(1, 1)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := activePartDef(t, s)
+	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; v >= 32 {
+		t.Errorf("shell did not hollow the body: volume %g, want < 32", v)
+	}
+}
+
+// TestShellToolNeedsFace checks the tool is not committable until a face is picked.
+func TestShellToolNeedsFace(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+	sh := NewShellTool()
+	s.StartTool(sh)
+	if sh.CanCommit() {
+		t.Error("shell ready with no face picked")
+	}
+	s.Click(0, 0)
+	if !sh.CanCommit() {
+		t.Error("shell not ready after picking a face")
+	}
+}

--- a/head/icon/assets/shell.svg
+++ b/head/icon/assets/shell.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7 L4 20 H20 V7"/><path d="M4 7 L12 3 L20 7"/><path d="M7 9 L7 17 H17 V9"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -55,6 +55,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawSweepDialog(s)
 	drawHoleDialog(s)
 	drawChamferDialog(s)
+	drawShellDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/shell_dialog.go
+++ b/head/ui/shell_dialog.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Shell flow in the head: while the Shell tool runs, a modeless options window shows
+// the picked removed-face count and the wall thickness (database units), then OK/Cancel.
+var shellUI = struct {
+	thickness float32
+	open      bool
+}{thickness: 1}
+
+// drawShellDialog shows the shell options window while the Shell tool is active.
+func drawShellDialog(s *app.Session) {
+	sh := s.ActiveShell()
+	if sh == nil {
+		shellUI.open = false
+		return
+	}
+	if !shellUI.open {
+		shellUI.thickness = float32(sh.Thickness())
+		shellUI.open = true
+	}
+	native.SetNextWindowSize(300, 160)
+	if native.Begin("Shell") {
+		native.Text("Removed faces: " + strconv.Itoa(len(sh.Faces())) + " (click faces to open)")
+		native.Text("Thickness (" + s.LengthUnitName() + ")")
+		native.InputFloat("##shell-thickness", &shellUI.thickness)
+		sh.SetThickness(float64(shellUI.thickness))
+		native.BeginDisabled(!sh.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/kernel/ops/shell.go
+++ b/kernel/ops/shell.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Shell hollows a planar-faceted solid to wall thickness t, leaving the removed faces as
+// openings. It builds the inner cavity solid by offsetting every KEPT face inward by t
+// (each face's plane shifted along −normal; a vertex moves to where its faces' offset
+// planes meet) while leaving the REMOVED faces in place — so the cavity stays flush with
+// them and the difference opens them (the coplanar B-rep rule). The result is solid − cavity.
+// Inward shell only; outward/both-sides are a follow-up.
+func Shell(solid *topo.Body, removedKeys [][]byte, t float64) (*topo.Body, error) {
+	if t <= 0 {
+		return nil, fmt.Errorf("shell: thickness %g must be > 0", t)
+	}
+	removed, err := resolveFaceSet(solid, removedKeys)
+	if err != nil {
+		return nil, err
+	}
+	cavity := offsetCavity(solid, removed, t)
+	return Boolean(Cut, solid, cavity)
+}
+
+// resolveFaceSet turns face reference keys into the set of face IDs to leave open, erroring
+// if a key no longer resolves (the feature must go Sick honestly).
+func resolveFaceSet(solid *topo.Body, keys [][]byte) (map[uint64]bool, error) {
+	set := make(map[uint64]bool, len(keys))
+	for _, k := range keys {
+		f, ok := solid.FindFaceByKey(k)
+		if !ok {
+			return nil, fmt.Errorf("shell: face reference lost")
+		}
+		set[f.ID()] = true
+	}
+	return set, nil
+}
+
+// offsetCavity clones the solid's topology with every vertex moved inward to the meeting
+// point of its faces' offset planes (removed faces contribute their original plane), giving
+// the inner solid whose subtraction hollows the shell.
+func offsetCavity(solid *topo.Body, removed map[uint64]bool, t float64) *topo.Body {
+	vf := vertexFaceMap(solid)
+	lin := topo.NewLineage(topo.Tok("shell", "cavity", 0))
+	bld := topo.NewBuilder(true, lin)
+	nv := make(map[uint64]*topo.Vertex, len(solid.Vertices()))
+	for i, v := range solid.Vertices() {
+		nv[v.ID()] = bld.AddVertex(innerVertex(v, vf[v.ID()], removed, t), topo.NewLineage(topo.Tok("shell", "v", i)))
+	}
+	ne := make(map[uint64]*topo.Edge, len(solid.Edges()))
+	for i, e := range solid.Edges() {
+		a, b := nv[e.StartVertex().ID()], nv[e.EndVertex().ID()]
+		ne[e.ID()] = bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, topo.NewLineage(topo.Tok("shell", "e", i)))
+	}
+	for i, f := range solid.Faces() {
+		bld.AddFace(offsetPlane(f, removed, t), topo.NewLineage(topo.Tok("shell", "f", i)), cloneLoops(f, ne)...)
+	}
+	return bld.Build()
+}
+
+// cloneLoops rebuilds a face's loop specs against the inner-solid edges, preserving each
+// edge use's direction and the outer/inner role.
+func cloneLoops(f *topo.Face, ne map[uint64]*topo.Edge) []topo.LoopSpec {
+	specs := make([]topo.LoopSpec, 0, len(f.Loops()))
+	for _, l := range f.Loops() {
+		uses := make([]topo.Use, 0, len(l.EdgeUses()))
+		for _, u := range l.EdgeUses() {
+			uses = append(uses, topo.Use{Edge: ne[u.Edge().ID()], Reversed: u.Reversed()})
+		}
+		if l.IsOuter() {
+			specs = append(specs, topo.OuterLoop(uses...))
+		} else {
+			specs = append(specs, topo.InnerLoop(uses...))
+		}
+	}
+	return specs
+}
+
+// offsetPlane returns a face's plane shifted inward by t (origin moved along −normal),
+// or the unchanged plane for a removed face.
+func offsetPlane(f *topo.Face, removed map[uint64]bool, t float64) geom.Plane {
+	pl := f.Geometry().(geom.Plane)
+	if removed[f.ID()] {
+		return pl
+	}
+	n := pl.Normal()
+	moved, _ := geom.NewPlaneFromAxes(pl.Origin.TranslateBy(n.Scale(-t)), pl.UAxis.AsVector(), pl.VAxis.AsVector())
+	return moved
+}
+
+// vertexFaceMap returns, per vertex ID, the faces meeting at that vertex.
+func vertexFaceMap(solid *topo.Body) map[uint64][]*topo.Face {
+	m := map[uint64][]*topo.Face{}
+	seen := map[[2]uint64]bool{}
+	for _, f := range solid.Faces() {
+		for _, e := range f.Edges() {
+			for _, v := range e.Vertices() {
+				if key := [2]uint64{v.ID(), f.ID()}; !seen[key] {
+					seen[key] = true
+					m[v.ID()] = append(m[v.ID()], f)
+				}
+			}
+		}
+	}
+	return m
+}
+
+// innerVertex returns where a vertex moves under the shell: the least-squares meeting point
+// of its (offset) face planes — exact for a 3-face corner, best-fit for more. Falls back to
+// the original position if the planes are degenerate (parallel normals).
+func innerVertex(v *topo.Vertex, faces []*topo.Face, removed map[uint64]bool, t float64) math.Point3 {
+	var a [3][3]float64
+	var b [3]float64
+	for _, f := range faces {
+		pl := f.Geometry().(geom.Plane)
+		n := pl.Normal()
+		d := n.Dot(pl.Origin.AsVector())
+		if !removed[f.ID()] {
+			d -= t
+		}
+		nv := [3]float64{n.X, n.Y, n.Z}
+		for i := 0; i < 3; i++ {
+			for j := 0; j < 3; j++ {
+				a[i][j] += nv[i] * nv[j]
+			}
+			b[i] += nv[i] * d
+		}
+	}
+	x, ok := solve3(a, b)
+	if !ok {
+		return v.Point()
+	}
+	return math.P3(x[0], x[1], x[2])
+}
+
+// solve3 solves the 3×3 system a·x = b by Cramer's rule, ok=false when a is singular.
+func solve3(a [3][3]float64, b [3]float64) ([3]float64, bool) {
+	det := det3(a)
+	if det < 1e-12 && det > -1e-12 {
+		return [3]float64{}, false
+	}
+	var x [3]float64
+	for c := 0; c < 3; c++ {
+		m := a
+		for r := 0; r < 3; r++ {
+			m[r][c] = b[r]
+		}
+		x[c] = det3(m) / det
+	}
+	return x, true
+}
+
+// det3 returns the determinant of a 3×3 matrix.
+func det3(m [3][3]float64) float64 {
+	return m[0][0]*(m[1][1]*m[2][2]-m[1][2]*m[2][1]) -
+		m[0][1]*(m[1][0]*m[2][2]-m[1][2]*m[2][0]) +
+		m[0][2]*(m[1][0]*m[2][1]-m[1][1]*m[2][0])
+}

--- a/kernel/ops/shell_test.go
+++ b/kernel/ops/shell_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// shellBox builds an axis-aligned box [0,sx]×[0,sy]×[0,sz].
+func shellBox(sx, sy, sz float64) *topo.Body {
+	return subd.ToBody(subd.Box(sx, sy, sz), "box")
+}
+
+// topFaceKey returns the reference key of the +Z (top) face.
+func topFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if f.Geometry().NormalAt(0, 0).Z > 0.99 {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatal("no +Z face found")
+	return nil
+}
+
+// TestShellOpenTopBox shells a 4×4×4 box with the top removed to wall thickness 0.5: a
+// 5-wall open cup. Outer 64 minus the open cavity [0.5,3.5]×[0.5,3.5]×[0.5,4] (3·3·3.5 =
+// 31.5) = 32.5, and the result must be a valid solid.
+func TestShellOpenTopBox(t *testing.T) {
+	box := shellBox(4, 4, 4)
+	res, err := ops.Shell(box, [][]byte{topFaceKey(t, box)}, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("shelled box not a valid solid: %+v", r)
+	}
+	want := 64.0 - 3*3*3.5
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("shell volume = %g, want %g", got, want)
+	}
+}
+
+// TestShellLostFaceErrors checks a vanished removed-face key is reported (so the feature
+// can go Sick) rather than silently shelling a closed box.
+func TestShellLostFaceErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.Shell(box, [][]byte{[]byte("ghost")}, 0.2); err == nil {
+		t.Error("shell with a lost face key should error")
+	}
+}
+
+// TestShellThicknessMustBePositive guards the thickness.
+func TestShellThicknessMustBePositive(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.Shell(box, [][]byte{topFaceKey(t, box)}, 0); err == nil {
+		t.Error("zero thickness should error")
+	}
+}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -67,12 +67,18 @@ type ShellDefinition struct {
 }
 
 // ShellFeature hollows a solid.
-type ShellFeature struct{ def *ShellDefinition }
+type ShellFeature struct {
+	def      *ShellDefinition
+	featName string
+}
 
 func (s *ShellFeature) Definition() *ShellDefinition { return s.def }
 func (s *ShellFeature) Kind() string                 { return "shell" }
+
+// Recompute hollows the running body to the wall thickness, opening the removed faces. See
+// shell.go.
 func (s *ShellFeature) Recompute(in Input) (Output, error) {
-	return resolveFacesThenDefer(in, s.def.RemovedFaceKeys, "shell")
+	return shellBody(in, s.def.RemovedFaceKeys, callOrZero(s.def.Thickness), featOr(s.featName, "shell"))
 }
 
 // FaceDraftDefinition tapers selected faces by an angle about a pull direction.
@@ -165,7 +171,11 @@ func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64)
 
 // AddShell hollows the body, removing the given faces, to thickness.
 func (c *DressUpFeatures) AddShell(removedFaceKeys [][]byte, thickness func() float64) *PartFeature {
-	return c.engine.Add(&ShellFeature{def: &ShellDefinition{RemovedFaceKeys: removedFaceKeys, Thickness: thickness}})
+	sf := &ShellFeature{def: &ShellDefinition{RemovedFaceKeys: removedFaceKeys, Thickness: thickness}}
+	pf := c.engine.Add(sf)
+	pf.SetName(c.engine.UniqueName("Shell"))
+	sf.featName = pf.name
+	return pf
 }
 
 // AddDraft tapers the given faces by angle.

--- a/model/feature/dressup_test.go
+++ b/model/feature/dressup_test.go
@@ -125,8 +125,8 @@ func TestShellDraftThreadResolveInputs(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fs).AddBase(body)
 	du := NewDressUpFeatures(fs)
+	// Draft and thread still defer their geometry (Warning); shell is real (see its own test).
 	feats := map[string]*PartFeature{
-		"shell":  du.AddShell([][]byte{face}, func() float64 { return 0.2 }),
 		"draft":  du.AddDraft([][]byte{face}, func() float64 { return 0.05 }),
 		"thread": du.AddThread(face, "M6x1"),
 	}
@@ -145,6 +145,32 @@ func TestShellDraftThreadResolveInputs(t *testing.T) {
 	fs.Recompute()
 	if bad.Health().Status != health.Sick {
 		t.Error("shell with a lost face should be sick")
+	}
+}
+
+// TestShellHollowsRunningBodyForReal shells the running body (a unit prism) with its top
+// face removed and checks the feature is healthy and the result a valid hollow solid.
+func TestShellHollowsRunningBodyForReal(t *testing.T) {
+	body := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 4}, 0, "box")
+	var top []byte
+	for _, f := range body.Faces() {
+		if f.Geometry().NormalAt(0, 0).Z > 0.99 {
+			top = f.ReferenceKey()
+		}
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(body)
+	sh := NewDressUpFeatures(fs).AddShell([][]byte{top}, func() float64 { return 0.5 })
+	fs.Recompute()
+	if !sh.Health().OK() {
+		t.Fatalf("shell sick: %+v", sh.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("shelled body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, 64-3*3*3.5) > 1e-6 {
+		t.Errorf("shell volume = %g, want %g", got, 64-3*3*3.5)
 	}
 }
 

--- a/model/feature/shell.go
+++ b/model/feature/shell.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// shellBody hollows the running body to a wall thickness, opening the removed faces, via
+// ops.Shell, and replaces it in the body list. A lost face key or non-positive thickness
+// is an error so the feature goes Sick. See kernel/ops/shell.go for the geometry.
+func shellBody(in Input, removedFaceKeys [][]byte, thickness float64, feat string) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	if thickness <= 0 {
+		return Output{}, fmt.Errorf("%s: thickness %g must be > 0", feat, thickness)
+	}
+	result, err := ops.Shell(body, removedFaceKeys, thickness)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}


### PR DESCRIPTION
## What

First of the **F04 Local Face Operations**. `ShellFeature` shipped as a deferred stub (Warning); it now hollows the solid for real, with full DoD UI.

**Kernel — `ops.Shell`:** builds the inner cavity solid by offsetting every **kept** face inward by the wall thickness (each face plane shifted along −normal; each vertex moved to where its faces' offset planes meet, via a 3×3 normal-equations solve) while leaving the **removed** faces in place — so the cavity stays flush with them and the difference opens them (the coplanar B-rep rule from #28). Result = `solid − cavity`. Inward shell only; outward/both-sides are a follow-up.

**Model:** `ShellFeature.Recompute` calls `ops.Shell` and replaces the running body (lost face key / non-positive thickness → Sick), instead of deferring.

**UI (DoD):** `ShellTool` (pick faces to open, set thickness), the `Modify.Shell` ribbon command, `head/ui/shell_dialog.go` property window, `shell.svg`.

## Why

Shelling is a core part feature, and its inward face-offset + retrim machinery is the foundation the rest of F04 (and a topological fillet) reuse. It also exercises the curved-tessellation/coplanar work just landed.

## Tests

- kernel: shells a 4×4×4 box, top removed, t=0.5 → valid solid, vol 32.5; lost-face and bad-thickness errors.
- model: `TestShellHollowsRunningBodyForReal` (healthy feature, vol 18.5 on a 4×4×2 block).
- app e2e: `TestShellToolEndToEnd` / `TestShellViaRibbonCommand` / `TestShellToolNeedsFace`.

`go test ./...`, vet, lint, `-race` green locally; head/ui (cgo) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)