### PR TITLE
M20 F04: Draft feature — real geometry + UI (DoD)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -81,9 +81,14 @@ func modelTabCommands() []*CommandDefinition {
 	return append(cmds, modifyFeatureCommands()...)
 }
 
-// modifyFeatureCommands are the 3D Model tab's "Modify" panel — features that cut or
-// alter existing material (hole, …).
+// modifyFeatureCommands are the 3D Model tab's "Modify" panel: the material-cutting
+// features (hole/chamfer) plus the local face operations (shell/offset/draft).
 func modifyFeatureCommands() []*CommandDefinition {
+	return append(cutFeatureCommands(), localFaceCommands()...)
+}
+
+// cutFeatureCommands are the Modify features that remove material against picked topology.
+func cutFeatureCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		NewCommand("Modify.Hole", "Hole", "Modify", func(s *Session) error {
 			s.StartTool(NewHoleTool())
@@ -97,6 +102,12 @@ func modifyFeatureCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("chamfer").WithButtonStyle(LargeIconButton).
 			WithTooltip("Chamfer — bevel selected edges by a setback distance."),
+	}
+}
+
+// localFaceCommands are the F04 local face operations (shell, offset face, draft).
+func localFaceCommands() []*CommandDefinition {
+	return []*CommandDefinition{
 		NewCommand("Modify.Shell", "Shell", "Modify", func(s *Session) error {
 			s.StartTool(NewShellTool())
 			return nil
@@ -109,6 +120,12 @@ func modifyFeatureCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("face-offset").WithButtonStyle(LargeIconButton).
 			WithTooltip("Offset Face — move selected faces along their normal, retrimming neighbours."),
+		NewCommand("Modify.Draft", "Draft", "Modify", func(s *Session) error {
+			s.StartTool(NewDraftTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("draft").WithButtonStyle(LargeIconButton).
+			WithTooltip("Draft — taper selected faces by an angle about the pull direction."),
 	}
 }
 

--- a/app/draft_session.go
+++ b/app/draft_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Draft tool's property window.
+
+// ActiveDraft returns the running Draft tool, or nil when the active tool is not a draft
+// (or there is none).
+func (s *Session) ActiveDraft() *DraftTool {
+	if s.tool == nil {
+		return nil
+	}
+	d, _ := s.tool.tool.(*DraftTool)
+	return d
+}

--- a/app/draft_tool.go
+++ b/app/draft_tool.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// degToRad converts the draft angle the UI takes in degrees to the radians the feature uses.
+const degToRad = stdmath.Pi / 180
+
+// DraftTool is the interactive Draft command: activate it, click one or more faces, set the
+// draft angle (degrees) in the property window, and OK to taper them about the +Z pull
+// direction (the mould-pull default). Negative angle leans the face in, positive out.
+type DraftTool struct {
+	faces    []FaceHandle
+	angleDeg float64
+	added    *feature.PartFeature
+}
+
+// NewDraftTool returns a draft tool with a default 3° angle.
+func NewDraftTool() *DraftTool { return &DraftTool{angleDeg: 3} }
+
+// Name implements [Tool].
+func (t *DraftTool) Name() string { return "Draft" }
+
+// Start sets the selection filter to faces.
+func (t *DraftTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+
+// Pick appends the clicked face (ignoring a duplicate).
+func (t *DraftTool) Pick(_ *Session, sel Selectable) {
+	f, ok := sel.(FaceHandle)
+	if !ok || t.hasFace(f) {
+		return
+	}
+	t.faces = append(t.faces, f)
+}
+
+func (t *DraftTool) hasFace(f FaceHandle) bool {
+	for _, h := range t.faces {
+		if h == f {
+			return true
+		}
+	}
+	return false
+}
+
+// SetAngleDegrees/AngleDegrees set the draft angle in degrees (signed).
+func (t *DraftTool) SetAngleDegrees(a float64) { t.angleDeg = a }
+func (t *DraftTool) AngleDegrees() float64     { return t.angleDeg }
+
+// Faces returns the picked faces (for the UI to list/highlight).
+func (t *DraftTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
+
+// CanCommit reports whether at least one face is picked and the angle is non-zero.
+func (t *DraftTool) CanCommit() bool { return len(t.faces) > 0 && t.angleDeg != 0 }
+
+// Commit tapers the picked faces on the active part and recomputes; a sick feature keeps
+// the tool open by returning an error.
+func (t *DraftTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	keys := make([][]byte, len(t.faces))
+	for i, f := range t.faces {
+		keys[i] = f.Face.ReferenceKey()
+	}
+	rad := t.angleDeg * degToRad
+	t.added = feature.NewDressUpFeatures(part.Features()).AddDraft(keys, func() float64 { return rad })
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("draft: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *DraftTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user through the draft steps.
+func (t *DraftTool) Prompt(*Session) string {
+	if len(t.faces) == 0 {
+		return "Click one or more faces to draft"
+	}
+	return "Set the angle, then click OK"
+}
+
+// Cancel restores the default selection filter.
+func (t *DraftTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }

--- a/app/draft_tool_test.go
+++ b/app/draft_tool_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// plusXFaceOf returns the body's +X-facing planar face (a vertical side of the block).
+func plusXFaceOf(t *testing.T, b *topo.Body) *topo.Face {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if f.Geometry().NormalAt(0, 0).X > 0.9 {
+			return f
+		}
+	}
+	t.Fatal("no +X face found")
+	return nil
+}
+
+// TestDraftToolEndToEnd drives the Draft UI: start the tool, click a side face of a 2×2×2
+// block, set an inward angle, OK — and asserts the side tapered (volume dropped, still a
+// valid solid). atan(0.25) ≈ 14.04°, inward ⇒ removes a 4·tan = 1 wedge ⇒ vol 7.
+func TestDraftToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 2) // 2×2×2, vol 8
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: plusXFaceOf(t, block), Body: block}})
+
+	d := NewDraftTool()
+	s.StartTool(d)
+	s.Click(50, 50)
+	d.SetAngleDegrees(-stdmath.Atan(0.25) * 180 / stdmath.Pi)
+	if !d.CanCommit() {
+		t.Fatal("draft not ready after face + angle")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	def := activePartDef(t, s)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("drafted body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, 7) > 1e-6 {
+		t.Errorf("draft volume = %g, want 7", got)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestDraftViaRibbonCommand drives the Draft from its ribbon command.
+func TestDraftViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: plusXFaceOf(t, block), Body: block}})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.Draft"); err != nil {
+		t.Fatalf("execute Modify.Draft: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*DraftTool); !ok {
+		t.Fatal("Draft command did not start the draft tool")
+	}
+	s.Click(1, 1)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := activePartDef(t, s)
+	// The default angle is +3° (taper outward), so the volume changes from the 8 baseline.
+	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; stdmath.Abs(v-8) < 1e-6 {
+		t.Errorf("draft did not change the body: volume %g, want ≠ 8", v)
+	}
+}
+
+// TestDraftToolNeedsFace checks the tool is not committable until a face is picked.
+func TestDraftToolNeedsFace(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: plusXFaceOf(t, block), Body: block}})
+	d := NewDraftTool()
+	s.StartTool(d)
+	if d.CanCommit() {
+		t.Error("draft ready with no face picked")
+	}
+	s.Click(0, 0)
+	if !d.CanCommit() {
+		t.Error("draft not ready after picking a face")
+	}
+}

--- a/head/icon/assets/draft.svg
+++ b/head/icon/assets/draft.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 20 L9 4 H15 L18 20 Z"/><path d="M12 4 V20" stroke-dasharray="2 2"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -57,6 +57,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawChamferDialog(s)
 	drawShellDialog(s)
 	drawFaceOffsetDialog(s)
+	drawDraftDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Draft flow in the head: while the Draft tool runs, a modeless options window shows
+// the picked-face count and the draft angle (degrees, signed), then OK/Cancel.
+var draftUI = struct {
+	angle float32
+	open  bool
+}{angle: 3}
+
+// drawDraftDialog shows the draft options window while the Draft tool is active.
+func drawDraftDialog(s *app.Session) {
+	d := s.ActiveDraft()
+	if d == nil {
+		draftUI.open = false
+		return
+	}
+	if !draftUI.open {
+		draftUI.angle = float32(d.AngleDegrees())
+		draftUI.open = true
+	}
+	native.SetNextWindowSize(300, 160)
+	if native.Begin("Draft") {
+		native.Text("Faces: " + strconv.Itoa(len(d.Faces())) + " (click faces to draft)")
+		native.Text("Angle (degrees, +out / −in)")
+		native.InputFloat("##draft-angle", &draftUI.angle)
+		d.SetAngleDegrees(float64(draftUI.angle))
+		native.BeginDisabled(!d.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/kernel/ops/draft.go
+++ b/kernel/ops/draft.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// DraftFaces tapers the selected faces by angle about a pull direction — the mould-draft
+// operation. Each selected face is rotated about its hinge (the line where it meets the
+// neutral plane perpendicular to pull through the face's lowest vertex along pull), so the
+// face tilts by angle while its base stays put, and the neighbours retrim (via
+// [rebuildWithPlanes]). Faces perpendicular to pull (no hinge) are left unchanged. Positive
+// angle leans the face toward the pull axis (draws material in going along pull).
+func DraftFaces(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, angle float64) (*topo.Body, error) {
+	sel, err := resolveFaceSet(solid, faceKeys)
+	if err != nil {
+		return nil, err
+	}
+	p, perr := math.UnitVector3FromVector(pull)
+	if perr != nil {
+		return nil, perr
+	}
+	return rebuildWithPlanes(solid, "draft", func(f *topo.Face) geom.Plane {
+		if !sel[f.ID()] {
+			return f.Geometry().(geom.Plane)
+		}
+		return draftedPlane(f, p, angle)
+	}), nil
+}
+
+// draftedPlane returns a face's plane rotated by angle about its hinge (pull × normal),
+// pivoting on the face's lowest vertex along pull. Returns the unchanged plane when the
+// face is perpendicular to pull (the hinge is undefined).
+func draftedPlane(f *topo.Face, pull math.UnitVector3, angle float64) geom.Plane {
+	pl := f.Geometry().(geom.Plane)
+	hinge, err := math.UnitVector3FromVector(pull.AsVector().Cross(pl.Normal()))
+	if err != nil {
+		return pl // face normal parallel to pull → no draft
+	}
+	pivot := lowestVertexAlong(f, pull)
+	rot := math.Rotation4(angle, hinge, pivot)
+	newN := rot.TransformVector(pl.Normal())
+	moved, perr := geom.NewPlane(pivot, newN)
+	if perr != nil {
+		return pl
+	}
+	return moved
+}
+
+// lowestVertexAlong returns the face vertex with the smallest projection onto pull — a
+// point on the face plane that also lies on the neutral plane, hence on the hinge line.
+func lowestVertexAlong(f *topo.Face, pull math.UnitVector3) math.Point3 {
+	best := stdmath.Inf(1)
+	var p math.Point3
+	for _, e := range f.Edges() {
+		for _, v := range e.Vertices() {
+			if d := v.Point().AsVector().Dot(pull.AsVector()); d < best {
+				best, p = d, v.Point()
+			}
+		}
+	}
+	return p
+}

--- a/kernel/ops/draft_test.go
+++ b/kernel/ops/draft_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// TestDraftTapersSideFace drafts the +X face of a 2×2×2 box inward by atan(0.25) about +Z:
+// the face hinges at its base (z=0) and leans in, removing a 4·tan(angle)=1 wedge ⇒ vol 7.
+func TestDraftTapersSideFace(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	var side []byte
+	for _, f := range box.Faces() {
+		if f.Geometry().NormalAt(0, 0).X > 0.99 {
+			side = f.ReferenceKey()
+		}
+	}
+	res, err := ops.DraftFaces(box, [][]byte{side}, math.V3(0, 0, 1), -stdmath.Atan(0.25))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("drafted body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-7) > 1e-6 {
+		t.Errorf("draft volume = %g, want 7", got)
+	}
+}
+
+// TestDraftLostKeyErrors reports a vanished face key so the feature can go Sick.
+func TestDraftLostKeyErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.DraftFaces(box, [][]byte{[]byte("ghost")}, math.V3(0, 0, 1), 0.1); err == nil {
+		t.Error("draft with a lost key should error")
+	}
+}

--- a/model/feature/draft.go
+++ b/model/feature/draft.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// draftBody tapers the picked faces of the running body about the pull direction by angle
+// (via ops.DraftFaces) and replaces it; a lost face key (surfaced by the op) makes the
+// feature go Sick. See kernel/ops/draft.go for the geometry.
+func draftBody(in Input, faceKeys [][]byte, pull math.Vector3, angle float64, feat string) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	result, err := ops.DraftFaces(body, faceKeys, pull, angle)
+	if err != nil {
+		return Output{}, fmt.Errorf("%s: %w", feat, err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
 )
 
 // Dress-up features operate on existing topology picked by the user — edges to
@@ -84,6 +85,7 @@ func (s *ShellFeature) Recompute(in Input) (Output, error) {
 // FaceDraftDefinition tapers selected faces by an angle about a pull direction.
 type FaceDraftDefinition struct {
 	FaceKeys [][]byte
+	PullDir  math.Vector3
 	Angle    func() float64
 }
 
@@ -92,8 +94,10 @@ type FaceDraftFeature struct{ def *FaceDraftDefinition }
 
 func (d *FaceDraftFeature) Definition() *FaceDraftDefinition { return d.def }
 func (d *FaceDraftFeature) Kind() string                     { return "draft" }
+
+// Recompute tapers the picked faces about the pull direction by the angle (see draft.go).
 func (d *FaceDraftFeature) Recompute(in Input) (Output, error) {
-	return resolveFacesThenDefer(in, d.def.FaceKeys, "draft")
+	return draftBody(in, d.def.FaceKeys, d.def.PullDir, callOrZero(d.def.Angle), "draft")
 }
 
 // ThreadDefinition applies thread data to a cylindrical face (cosmetic in phase A).
@@ -178,9 +182,14 @@ func (c *DressUpFeatures) AddShell(removedFaceKeys [][]byte, thickness func() fl
 	return pf
 }
 
-// AddDraft tapers the given faces by angle.
+// AddDraft tapers the given faces by angle about the default +Z pull direction.
 func (c *DressUpFeatures) AddDraft(faceKeys [][]byte, angle func() float64) *PartFeature {
-	return c.engine.Add(&FaceDraftFeature{def: &FaceDraftDefinition{FaceKeys: faceKeys, Angle: angle}})
+	return c.AddDraftPull(faceKeys, math.V3(0, 0, 1), angle)
+}
+
+// AddDraftPull tapers the given faces by angle about an explicit pull direction.
+func (c *DressUpFeatures) AddDraftPull(faceKeys [][]byte, pull math.Vector3, angle func() float64) *PartFeature {
+	return c.engine.Add(&FaceDraftFeature{def: &FaceDraftDefinition{FaceKeys: faceKeys, PullDir: pull, Angle: angle}})
 }
 
 // AddThread tags a cylindrical face with thread data.

--- a/model/feature/dressup_test.go
+++ b/model/feature/dressup_test.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	stdmath "math"
 	"testing"
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
@@ -118,26 +119,23 @@ func TestDressUpWithNoBodyIsSick(t *testing.T) {
 	}
 }
 
-func TestShellDraftThreadResolveInputs(t *testing.T) {
+// TestThreadResolvesThenDefers checks the thread feature (still deferred geometry) resolves
+// its face and reports Warning, and that a lost-face shell goes Sick. (Shell and draft are
+// real now — see their own tests.)
+func TestThreadResolvesThenDefers(t *testing.T) {
 	body := prismBody()
 	face := body.Faces()[0].ReferenceKey()
 
 	fs := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fs).AddBase(body)
 	du := NewDressUpFeatures(fs)
-	// Draft and thread still defer their geometry (Warning); shell is real (see its own test).
-	feats := map[string]*PartFeature{
-		"draft":  du.AddDraft([][]byte{face}, func() float64 { return 0.05 }),
-		"thread": du.AddThread(face, "M6x1"),
-	}
+	th := du.AddThread(face, "M6x1")
 	fs.Recompute()
-	for name, pf := range feats {
-		if pf.Health().Status != health.Warning {
-			t.Errorf("%s health = %v, want warning (resolved + deferred)", name, pf.Health().Status)
-		}
-		if pf.Kind() != name {
-			t.Errorf("kind = %q, want %q", pf.Kind(), name)
-		}
+	if th.Health().Status != health.Warning {
+		t.Errorf("thread health = %v, want warning (resolved + deferred)", th.Health().Status)
+	}
+	if th.Kind() != "thread" {
+		t.Errorf("kind = %q, want thread", th.Kind())
 	}
 	// A shell referencing a vanished face goes sick.
 	bad := du.AddShell([][]byte{[]byte("ghost")}, func() float64 { return 0.2 })
@@ -145,6 +143,32 @@ func TestShellDraftThreadResolveInputs(t *testing.T) {
 	fs.Recompute()
 	if bad.Health().Status != health.Sick {
 		t.Error("shell with a lost face should be sick")
+	}
+}
+
+// TestDraftTapersFaceForReal drafts one side face of a 2×2×2 box inward by atan(0.25)
+// about +Z: the side tilts, removing a 4·tan = 1 wedge ⇒ vol 7, a valid solid.
+func TestDraftTapersFaceForReal(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var side []byte
+	for _, f := range box.Faces() {
+		if f.Geometry().NormalAt(0, 0).X > 0.99 {
+			side = f.ReferenceKey()
+		}
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	dr := NewDressUpFeatures(fs).AddDraft([][]byte{side}, func() float64 { return -stdmath.Atan(0.25) })
+	fs.Recompute()
+	if !dr.Health().OK() {
+		t.Fatalf("draft sick: %+v", dr.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("drafted body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, 7) > 1e-6 {
+		t.Errorf("draft volume = %g, want 7", got)
 	}
 }
 

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -101,7 +101,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 	case *ShellFeature:
 		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness)}
 	case *FaceDraftFeature:
-		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle)}
+		p := f.def.PullDir
+		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle), Pull: []float64{p.X, p.Y, p.Z}}
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation}
 	case *HoleFeature:
@@ -261,7 +262,7 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if err != nil {
 			return nil, err
 		}
-		return du.AddDraft(d.keys, constFloat(d.value)), nil
+		return du.AddDraftPull(d.keys, draftPull(fd.Draft.Pull), constFloat(d.value)), nil
 	case "thread":
 		if fd.Thread == nil {
 			return nil, fmt.Errorf("thread feature is missing its payload")

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -5,7 +5,18 @@ package feature
 import (
 	"encoding/base64"
 	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
 )
+
+// draftPull reads a serialized pull direction [dx,dy,dz], defaulting to +Z when absent
+// (older recipes / the common Z-up mould pull).
+func draftPull(p []float64) math.Vector3 {
+	if len(p) != 3 {
+		return math.V3(0, 0, 1)
+	}
+	return math.V3(p[0], p[1], p[2])
+}
 
 // This file holds the YAML codecs for the dress-up family (fillet/chamfer/shell/draft/
 // thread) and the reference-key + scalar helpers shared across feature codecs. Edge and
@@ -20,10 +31,11 @@ type EdgeDressData struct {
 }
 
 // FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked
-// faces as reference keys plus the scalar value.
+// faces as reference keys plus the scalar value, and (draft only) the pull direction.
 type FaceDressData struct {
-	Faces []string `yaml:"faces"`
-	Value float64  `yaml:"value"`
+	Faces []string  `yaml:"faces"`
+	Value float64   `yaml:"value"`
+	Pull  []float64 `yaml:"pull,omitempty"` // draft pull direction (dx,dy,dz); absent ⇒ +Z
 }
 
 // ThreadData tags a single cylindrical face (reference key) with a thread designation.


### PR DESCRIPTION
## What

Continues **F04 Local Face Operations** (after Shell #33, Move/Offset Face #34). Turns the deferred draft stub into a real mould-draft.

**Kernel — `ops.DraftFaces`:** tapers selected faces by an angle about a pull direction, reusing `rebuildWithPlanes`. Each selected face is rotated about its **hinge** (where it meets the neutral plane perpendicular to pull through the face's lowest vertex along pull), so the face tilts while its base stays put and the neighbours retrim. Faces perpendicular to pull are unchanged.

**Model:** `FaceDraftFeature.Recompute` calls `ops.DraftFaces`; `FaceDraftDefinition` gained a `PullDir` (default +Z); the draft `.obk` codec round-trips the pull direction.

**UI (DoD):** `DraftTool` (pick faces, set angle in degrees), `Modify.Draft` ribbon command, `head/ui/draft_dialog.go`, `draft.svg`. The Modify command builder split into cut (hole/chamfer) and local-face (shell/offset/draft) groups (funlen).

## Tests

- kernel: drafts a box side inward `atan(0.25)` → vol 7, valid; lost-key error.
- model: `TestDraftTapersFaceForReal`; thread-only deferred test; recipe round-trip.
- app e2e: `TestDraftToolEndToEnd` / `ViaRibbonCommand` / `NeedsFace`.

`go test ./...`, vet, lint, `-race` green; head/ui (cgo) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)