### PR TITLE
M20 F04: Delete Face + heal — real geometry + UI (DoD)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -126,6 +126,12 @@ func localFaceCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("draft").WithButtonStyle(LargeIconButton).
 			WithTooltip("Draft — taper selected faces by an angle about the pull direction."),
+		NewCommand("Modify.DeleteFace", "Delete Face", "Modify", func(s *Session) error {
+			s.StartTool(NewDeleteFaceTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("delete-face").WithButtonStyle(LargeIconButton).
+			WithTooltip("Delete Face — remove selected faces and heal the openings."),
 	}
 }
 

--- a/app/delete_face_session.go
+++ b/app/delete_face_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Delete Face tool's property window.
+
+// ActiveDeleteFace returns the running Delete Face tool, or nil when the active tool is not
+// a delete-face (or there is none).
+func (s *Session) ActiveDeleteFace() *DeleteFaceTool {
+	if s.tool == nil {
+		return nil
+	}
+	d, _ := s.tool.tool.(*DeleteFaceTool)
+	return d
+}

--- a/app/delete_face_tool.go
+++ b/app/delete_face_tool.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// DeleteFaceTool is the interactive Delete Face command: activate it, click the faces to
+// remove, and OK to delete them and heal the openings (the neighbours extend to meet) — e.g.
+// deleting a chamfer or fillet face restores the sharp edge.
+type DeleteFaceTool struct {
+	faces []FaceHandle
+	added *feature.PartFeature
+}
+
+// NewDeleteFaceTool returns a delete-face tool.
+func NewDeleteFaceTool() *DeleteFaceTool { return &DeleteFaceTool{} }
+
+// Name implements [Tool].
+func (t *DeleteFaceTool) Name() string { return "Delete Face" }
+
+// Start sets the selection filter to faces.
+func (t *DeleteFaceTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+
+// Pick appends the clicked face (ignoring a duplicate).
+func (t *DeleteFaceTool) Pick(_ *Session, sel Selectable) {
+	f, ok := sel.(FaceHandle)
+	if !ok || t.hasFace(f) {
+		return
+	}
+	t.faces = append(t.faces, f)
+}
+
+func (t *DeleteFaceTool) hasFace(f FaceHandle) bool {
+	for _, h := range t.faces {
+		if h == f {
+			return true
+		}
+	}
+	return false
+}
+
+// Faces returns the picked faces (for the UI to list/highlight).
+func (t *DeleteFaceTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
+
+// CanCommit reports whether at least one face is picked.
+func (t *DeleteFaceTool) CanCommit() bool { return len(t.faces) > 0 }
+
+// Commit deletes the picked faces on the active part and heals; a sick feature (the heal did
+// not close the body) keeps the tool open by returning an error.
+func (t *DeleteFaceTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	keys := make([][]byte, len(t.faces))
+	for i, f := range t.faces {
+		keys[i] = f.Face.ReferenceKey()
+	}
+	t.added = feature.NewModifyFeatures(part.Features()).AddDeleteFace(keys)
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("delete face: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *DeleteFaceTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user through the delete-face steps.
+func (t *DeleteFaceTool) Prompt(*Session) string {
+	if len(t.faces) == 0 {
+		return "Click the faces to delete and heal"
+	}
+	return "Click OK to delete and heal"
+}
+
+// Cancel restores the default selection filter.
+func (t *DeleteFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }

--- a/app/delete_face_tool_test.go
+++ b/app/delete_face_tool_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// chamferFaceHandleOf returns a handle to the body's chamfer (diagonal-normal) face.
+func chamferFaceHandleOf(t *testing.T, b *topo.Body) FaceHandle {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if n := f.Geometry().NormalAt(0, 0); stdmath.Abs(n.X) > 0.1 && stdmath.Abs(n.Y) > 0.1 {
+			return FaceHandle{Face: f, Body: b}
+		}
+	}
+	t.Fatal("no chamfer face")
+	return FaceHandle{}
+}
+
+// chamferOneEdge bevels a vertical edge of the active part's block via the Chamfer tool and
+// returns the resulting body — a setup with a chamfer face for the Delete Face tests.
+func chamferOneEdge(t *testing.T, s *Session, block *topo.Body) *topo.Body {
+	t.Helper()
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	ch := NewChamferTool()
+	s.StartTool(ch)
+	s.Click(50, 50)
+	ch.SetDistance(0.5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("chamfer OK: %v", err)
+	}
+	return activePartDef(t, s).SurfaceBodies().Item(0)
+}
+
+// TestDeleteFaceToolEndToEnd drives the Delete Face UI: chamfer a 2×2×2 block's edge (vol
+// 7.75), then start the tool, click the chamfer face, OK — and asserts the body healed back
+// to the sharp box (vol 8), a valid solid.
+func TestDeleteFaceToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	chamfered := chamferOneEdge(t, s, block)
+
+	s.SetPicker(stubPicker{sel: chamferFaceHandleOf(t, chamfered)})
+	d := NewDeleteFaceTool()
+	s.StartTool(d)
+	s.Click(50, 50)
+	if !d.CanCommit() {
+		t.Fatal("delete-face not ready after picking a face")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("healed body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, 8) > 1e-6 {
+		t.Errorf("healed volume = %g, want 8", got)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestDeleteFaceViaRibbonCommand drives Delete Face from its ribbon command.
+func TestDeleteFaceViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	chamfered := chamferOneEdge(t, s, block)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	s.SetPicker(stubPicker{sel: chamferFaceHandleOf(t, chamfered)})
+	if err := s.Execute("Modify.DeleteFace"); err != nil {
+		t.Fatalf("execute Modify.DeleteFace: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*DeleteFaceTool); !ok {
+		t.Fatal("Delete Face command did not start the tool")
+	}
+	s.Click(1, 1)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if v := ops.BodyGeometryProperties(activePartDef(t, s).SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, 8) > 1e-6 {
+		t.Errorf("delete-face did not heal to 8: volume %g", v)
+	}
+}
+
+// TestDeleteFaceToolNeedsFace checks the tool is not committable until a face is picked.
+func TestDeleteFaceToolNeedsFace(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	chamfered := chamferOneEdge(t, s, block)
+	s.SetPicker(stubPicker{sel: chamferFaceHandleOf(t, chamfered)})
+	d := NewDeleteFaceTool()
+	s.StartTool(d)
+	if d.CanCommit() {
+		t.Error("delete-face ready with no face picked")
+	}
+	s.Click(0, 0)
+	if !d.CanCommit() {
+		t.Error("delete-face not ready after picking a face")
+	}
+}

--- a/head/icon/assets/delete-face.svg
+++ b/head/icon/assets/delete-face.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 7 L5 20 H19 V7"/><path d="M5 7 L12 3 L19 7"/><path d="M9 11 L15 17 M15 11 L9 17"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -58,6 +58,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawShellDialog(s)
 	drawFaceOffsetDialog(s)
 	drawDraftDialog(s)
+	drawDeleteFaceDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/delete_face_dialog.go
+++ b/head/ui/delete_face_dialog.go
@@ -1,0 +1,41 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Delete Face flow in the head: while the tool runs, a modeless options window shows the
+// picked-face count, then OK/Cancel (there is no parameter — the heal is automatic).
+var deleteFaceUI = struct{ open bool }{}
+
+// drawDeleteFaceDialog shows the delete-face options window while the tool is active.
+func drawDeleteFaceDialog(s *app.Session) {
+	d := s.ActiveDeleteFace()
+	if d == nil {
+		deleteFaceUI.open = false
+		return
+	}
+	deleteFaceUI.open = true
+	native.SetNextWindowSize(300, 130)
+	if native.Begin("Delete Face") {
+		native.Text("Faces: " + strconv.Itoa(len(d.Faces())) + " (click faces to delete)")
+		native.Text("Neighbours heal to close the opening.")
+		native.BeginDisabled(!d.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/kernel/ops/delete_face.go
+++ b/kernel/ops/delete_face.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// DeleteFaces removes the selected faces from a planar solid and heals the openings by
+// extending the neighbouring faces until they meet again. Each vertex of a deleted face
+// slides along the line of its two surviving neighbour planes to the nearest OTHER neighbour
+// plane (the face the heal extends to meet); coincident results weld, collapsing the deleted
+// face's loop — e.g. deleting a chamfer face restores the sharp edge. It errors when the
+// heal does not produce a valid closed solid (a non-healable selection), so the feature can
+// go Sick rather than ship an open body.
+func DeleteFaces(solid *topo.Body, faceKeys [][]byte) (*topo.Body, error) {
+	del, err := resolveFaceSet(solid, faceKeys)
+	if err != nil {
+		return nil, err
+	}
+	moved := healedPositions(solid, del)
+	body := buildSolidFromLoops(survivingLoops(solid, del, moved))
+	if r := Validate(body); !r.Valid || !body.IsSolid() {
+		return nil, fmt.Errorf("delete-face: heal did not close the body %v", r.Issues)
+	}
+	return body, nil
+}
+
+// healedPositions returns, per vertex touching a deleted face, the position it heals to.
+func healedPositions(solid *topo.Body, del map[uint64]bool) map[uint64]math.Point3 {
+	vf := vertexFaceMap(solid)
+	ring := ringPlanes(solid, del)
+	moved := map[uint64]math.Point3{}
+	for _, v := range solid.Vertices() {
+		if touchesDeleted(vf[v.ID()], del) {
+			moved[v.ID()] = healedVertex(v, vf[v.ID()], del, ring)
+		}
+	}
+	return moved
+}
+
+// touchesDeleted reports whether any face at the vertex is being deleted.
+func touchesDeleted(faces []*topo.Face, del map[uint64]bool) bool {
+	for _, f := range faces {
+		if del[f.ID()] {
+			return true
+		}
+	}
+	return false
+}
+
+// ringPlanes returns the planes of every face that neighbours a deleted face (shares an
+// edge) but is not itself deleted — the surfaces the heal extends to.
+func ringPlanes(solid *topo.Body, del map[uint64]bool) []geom.Plane {
+	seen := map[uint64]bool{}
+	var out []geom.Plane
+	for _, f := range solid.Faces() {
+		if !del[f.ID()] {
+			continue
+		}
+		for _, e := range f.Edges() {
+			for _, nb := range e.Faces() {
+				if del[nb.ID()] || seen[nb.ID()] {
+					continue
+				}
+				seen[nb.ID()] = true
+				out = append(out, nb.Geometry().(geom.Plane))
+			}
+		}
+	}
+	return out
+}
+
+// healedVertex returns where a vertex on a deleted face moves: the meet of its surviving
+// face planes when ≥3 still pin it; otherwise it slides along the line of its two surviving
+// planes to the nearest ring plane (the neighbour the heal extends to meet).
+func healedVertex(v *topo.Vertex, faces []*topo.Face, del map[uint64]bool, ring []geom.Plane) math.Point3 {
+	survivors := survivingPlanes(faces, del)
+	if len(survivors) >= 3 {
+		if p, ok := meetOfPlanes(survivors); ok {
+			return p
+		}
+	}
+	if len(survivors) == 2 {
+		if p, ok := slideToNearest(survivors[0], survivors[1], ring, v.Point()); ok {
+			return p
+		}
+	}
+	return v.Point()
+}
+
+// survivingPlanes returns the planes of the vertex's faces that are not deleted.
+func survivingPlanes(faces []*topo.Face, del map[uint64]bool) []geom.Plane {
+	var out []geom.Plane
+	for _, f := range faces {
+		if !del[f.ID()] {
+			out = append(out, f.Geometry().(geom.Plane))
+		}
+	}
+	return out
+}
+
+// slideToNearest intersects the line of planes a,b with each ring plane and returns the
+// intersection nearest the original vertex (the face the heal extends to meet).
+func slideToNearest(a, b geom.Plane, ring []geom.Plane, v math.Point3) (math.Point3, bool) {
+	p0, dir, ok := twoPlaneLine(a, b)
+	if !ok {
+		return math.Point3{}, false
+	}
+	best, bestD, found := math.Point3{}, stdmath.Inf(1), false
+	for _, c := range ring {
+		t, hit := lineHitsPlane(p0, dir, c)
+		if !hit {
+			continue
+		}
+		p := p0.TranslateBy(dir.Scale(t))
+		if d := p.DistanceTo(v); d < bestD {
+			best, bestD, found = p, d, true
+		}
+	}
+	return best, found
+}
+
+// meetOfPlanes returns the least-squares meeting point of ≥3 planes (exact for 3).
+func meetOfPlanes(planes []geom.Plane) (math.Point3, bool) {
+	var a [3][3]float64
+	var b [3]float64
+	for _, pl := range planes {
+		n := pl.Normal()
+		d := n.Dot(pl.Origin.AsVector())
+		nv := [3]float64{n.X, n.Y, n.Z}
+		for i := 0; i < 3; i++ {
+			for j := 0; j < 3; j++ {
+				a[i][j] += nv[i] * nv[j]
+			}
+			b[i] += nv[i] * d
+		}
+	}
+	x, ok := solve3(a, b)
+	return math.P3(x[0], x[1], x[2]), ok
+}
+
+// twoPlaneLine returns a point and direction of the intersection line of two planes, or
+// ok=false when they are parallel.
+func twoPlaneLine(a, b geom.Plane) (math.Point3, math.Vector3, bool) {
+	na, nb := a.Normal(), b.Normal()
+	dir := na.Cross(nb)
+	if dir.LengthSquared() < 1e-18 {
+		return math.Point3{}, math.Vector3{}, false
+	}
+	da, db := na.Dot(a.Origin.AsVector()), nb.Dot(b.Origin.AsVector())
+	num := nb.Cross(dir).Scale(da).Add(dir.Cross(na).Scale(db))
+	return math.P3(0, 0, 0).TranslateBy(num.Scale(1 / dir.LengthSquared())), dir, true
+}
+
+// lineHitsPlane returns the parameter t where line p0+t·dir meets plane c.
+func lineHitsPlane(p0 math.Point3, dir math.Vector3, c geom.Plane) (float64, bool) {
+	n := c.Normal()
+	den := dir.Dot(n)
+	if stdmath.Abs(den) < 1e-12 {
+		return 0, false
+	}
+	return (n.Dot(c.Origin.AsVector()) - n.Dot(p0.AsVector())) / den, true
+}
+
+// ploop is a surviving face as 3D point rings (outer first) plus its normal, ready for
+// welding into a body.
+type ploop struct {
+	normal math.Vector3
+	rings  [][]math.Point3
+}
+
+// survivingLoops returns every non-deleted face as a point-ring loop with its vertices
+// remapped to their healed positions.
+func survivingLoops(solid *topo.Body, del map[uint64]bool, moved map[uint64]math.Point3) []ploop {
+	var out []ploop
+	for _, f := range solid.Faces() {
+		if del[f.ID()] {
+			continue
+		}
+		pl := ploop{normal: f.Geometry().NormalAt(0, 0)}
+		for _, l := range f.Loops() {
+			pl.rings = append(pl.rings, healedRing(l, moved))
+		}
+		out = append(out, pl)
+	}
+	return out
+}
+
+// healedRing returns a loop's vertices with healed positions substituted.
+func healedRing(l *topo.Loop, moved map[uint64]math.Point3) []math.Point3 {
+	var pts []math.Point3
+	for _, u := range l.EdgeUses() {
+		v := u.Edge().StartVertex()
+		if u.Reversed() {
+			v = u.Edge().EndVertex()
+		}
+		if p, ok := moved[v.ID()]; ok {
+			pts = append(pts, p)
+		} else {
+			pts = append(pts, v.Point())
+		}
+	}
+	return pts
+}
+
+// buildSolidFromLoops welds coincident loop points into a body, dropping the degenerate
+// (zero-length) edges that a heal collapses. One shared edge per undirected vertex pair; a
+// closed body (every edge used twice) is a solid.
+func buildSolidFromLoops(faces []ploop) *topo.Body {
+	w := newPointWelder()
+	rings := make([][][]int, len(faces))
+	for i, f := range faces {
+		for _, r := range f.rings {
+			rings[i] = append(rings[i], dropRepeats(w.weldRing(r)))
+		}
+	}
+	edgeUse := map[[2]int]int{}
+	for _, fr := range rings {
+		for _, r := range fr {
+			for k := 0; k < len(r); k++ {
+				edgeUse[canon2(r[k], r[(k+1)%len(r)])]++
+			}
+		}
+	}
+	return assembleLoops(w.points, faces, rings, edgeUse)
+}
+
+// assembleLoops builds the topo body from welded points, per-face loop index rings, and the
+// edge-use counts (every edge twice ⇒ solid).
+func assembleLoops(verts []math.Point3, faces []ploop, rings [][][]int, edgeUse map[[2]int]int) *topo.Body {
+	solid := true
+	for _, c := range edgeUse {
+		if c != 2 {
+			solid = false
+		}
+	}
+	bld := topo.NewBuilder(solid, topo.NewLineage(topo.Tok("delface", "body", 0)))
+	tv := make([]*topo.Vertex, len(verts))
+	for i, p := range verts {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("delface", "v", i)))
+	}
+	edges := buildSharedEdges(bld, verts, tv, edgeUse)
+	for fi, fr := range rings {
+		specs := make([]topo.LoopSpec, 0, len(fr))
+		for ri, r := range fr {
+			specs = append(specs, indexLoop(ri == 0, r, edges))
+		}
+		surf, _ := geom.NewPlane(centroidPts(faces[fi].rings[0]), faces[fi].normal)
+		bld.AddFace(surf, topo.NewLineage(topo.Tok("delface", "f", fi)), specs...)
+	}
+	return bld.Build()
+}
+
+// buildSharedEdges creates one shared edge per undirected vertex pair (sorted for stable
+// lineage).
+func buildSharedEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, edgeUse map[[2]int]int) map[[2]int]*topo.Edge {
+	keys := make([][2]int, 0, len(edgeUse))
+	for k := range edgeUse {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i][0] != keys[j][0] {
+			return keys[i][0] < keys[j][0]
+		}
+		return keys[i][1] < keys[j][1]
+	})
+	edges := make(map[[2]int]*topo.Edge, len(keys))
+	for i, k := range keys {
+		edges[k] = bld.AddEdge(geom.NewLineSegment(verts[k[0]], verts[k[1]]), tv[k[0]], tv[k[1]], topo.NewLineage(topo.Tok("delface", "e", i)))
+	}
+	return edges
+}
+
+// indexLoop builds a face loop from a ring of welded vertex indices.
+func indexLoop(outer bool, ring []int, edges map[[2]int]*topo.Edge) topo.LoopSpec {
+	uses := make([]topo.Use, len(ring))
+	for i := range ring {
+		a, b := ring[i], ring[(i+1)%len(ring)]
+		uses[i] = topo.Use{Edge: edges[canon2(a, b)], Reversed: a > b}
+	}
+	if outer {
+		return topo.OuterLoop(uses...)
+	}
+	return topo.InnerLoop(uses...)
+}
+
+// canon2 orders an undirected vertex-index pair.
+func canon2(a, b int) [2]int {
+	if a < b {
+		return [2]int{a, b}
+	}
+	return [2]int{b, a}
+}
+
+// dropRepeats removes consecutive (and wrap-around) duplicate indices — the degenerate edges
+// a heal collapses.
+func dropRepeats(r []int) []int {
+	var out []int
+	for _, x := range r {
+		if len(out) == 0 || out[len(out)-1] != x {
+			out = append(out, x)
+		}
+	}
+	for len(out) > 1 && out[0] == out[len(out)-1] {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// pointWelder merges coincident 3D points onto a shared index list (the weldGrid grid).
+type pointWelder struct {
+	index  map[[3]int64]int
+	points []math.Point3
+}
+
+func newPointWelder() *pointWelder { return &pointWelder{index: map[[3]int64]int{}} }
+
+func (w *pointWelder) add(p math.Point3) int {
+	k := [3]int64{int64(stdmath.Round(p.X / weldGrid)), int64(stdmath.Round(p.Y / weldGrid)), int64(stdmath.Round(p.Z / weldGrid))}
+	if i, ok := w.index[k]; ok {
+		return i
+	}
+	w.index[k] = len(w.points)
+	w.points = append(w.points, p)
+	return len(w.points) - 1
+}
+
+func (w *pointWelder) weldRing(r []math.Point3) []int {
+	out := make([]int, len(r))
+	for i, p := range r {
+		out[i] = w.add(p)
+	}
+	return out
+}
+
+// centroidPts averages a point set (a point on the face for its plane origin).
+func centroidPts(pts []math.Point3) math.Point3 {
+	var sx, sy, sz float64
+	for _, p := range pts {
+		sx, sy, sz = sx+p.X, sy+p.Y, sz+p.Z
+	}
+	n := float64(len(pts))
+	return math.P3(sx/n, sy/n, sz/n)
+}

--- a/kernel/ops/delete_face_test.go
+++ b/kernel/ops/delete_face_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// chamferedBox bevels one vertical edge of a 2×2×2 box (setback 0.5) via the chamfer
+// feature, returning the resulting solid (vol 7.75) — a body with a chamfer face to delete.
+func chamferedBox(t *testing.T) *topo.Body {
+	t.Helper()
+	box := shellBox(2, 2, 2)
+	var edge []byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			edge = e.ReferenceKey()
+			break
+		}
+	}
+	fs := feature.NewPartFeatures(nil, nil)
+	feature.NewBaseFeatures(fs).AddBase(box)
+	feature.NewDressUpFeatures(fs).AddChamfer([][]byte{edge}, func() float64 { return 0.5 })
+	fs.Recompute()
+	return fs.Result()[0]
+}
+
+// chamferFaceKey returns the bevel face — its normal is diagonal in XY (neither axis).
+func chamferFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if n := f.Geometry().NormalAt(0, 0); stdmath.Abs(n.X) > 0.1 && stdmath.Abs(n.Y) > 0.1 {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatal("no chamfer face")
+	return nil
+}
+
+// TestDeleteFaceHealsChamfer deletes the chamfer face of a beveled box: the two side faces
+// extend to meet at the original sharp edge, healing the box back to vol 8 — a valid solid.
+// The headline delete-face-then-heal acceptance.
+func TestDeleteFaceHealsChamfer(t *testing.T) {
+	chamfered := chamferedBox(t)
+	healed, err := ops.DeleteFaces(chamfered, [][]byte{chamferFaceKey(t, chamfered)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(healed); !r.Valid || !healed.IsSolid() {
+		t.Fatalf("healed body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(healed, ops.DefaultQuality()).Volume; stdmath.Abs(got-8) > 1e-6 {
+		t.Errorf("healed volume = %g, want 8 (sharp box restored)", got)
+	}
+}
+
+// TestDeleteFaceLostKeyErrors reports a vanished face key so the feature can go Sick.
+func TestDeleteFaceLostKeyErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.DeleteFaces(box, [][]byte{[]byte("ghost")}); err == nil {
+		t.Error("delete-face with a lost key should error")
+	}
+}

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -78,14 +78,22 @@ func (f *faceEditFeature) Recompute(in Input) (Output, error) {
 // the recipe serialize every face-edit feature uniformly (they share this shape).
 func (f *faceEditFeature) FaceKeys() [][]byte { return f.faceKeys }
 
-// SplitFeature, DeleteFaceFeature, ReplaceFaceFeature and ThickenFeature are the direct
-// edits whose geometry still defers (phase C).
+// SplitFeature, ReplaceFaceFeature and ThickenFeature are the direct edits whose geometry
+// still defers (phase C).
 type (
 	SplitFeature       struct{ faceEditFeature }
-	DeleteFaceFeature  struct{ faceEditFeature }
 	ReplaceFaceFeature struct{ faceEditFeature }
 	ThickenFeature     struct{ faceEditFeature }
 )
+
+// DeleteFaceFeature removes the picked faces and heals the openings (extends neighbours).
+type DeleteFaceFeature struct{ faceEditFeature }
+
+// Recompute deletes the picked faces from the running body and heals it (see
+// kernel/ops/delete_face.go); a non-healable selection makes the feature go Sick.
+func (f *DeleteFaceFeature) Recompute(in Input) (Output, error) {
+	return retopoFacesBody(in, f.faceKeys, f.kind, ops.DeleteFaces)
+}
 
 // MoveFaceFeature translates the picked faces by a vector, retrimming the neighbours.
 type MoveFaceFeature struct {

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	stdmath "math"
 	"testing"
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
@@ -71,10 +72,9 @@ func TestDirectEditsResolveThenDefer(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fs).AddBase(body)
 	mod := NewModifyFeatures(fs)
-	// move-face and face-offset are real now (see their own tests); the rest still defer.
+	// move-face, face-offset and delete-face are real now (see their own tests); the rest defer.
 	feats := map[string]*PartFeature{
 		"split":        mod.AddSplit([][]byte{face}),
-		"delete-face":  mod.AddDeleteFace([][]byte{face}),
 		"replace-face": mod.AddReplaceFace([][]byte{face}),
 		"thicken":      mod.AddThicken([][]byte{face}),
 	}
@@ -108,6 +108,37 @@ func TestMoveAndOffsetFaceRealGeometry(t *testing.T) {
 	}
 	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 12) > 1e-6 {
 		t.Errorf("move-face volume = %g, want 12", got)
+	}
+}
+
+// TestDeleteFaceHealsInModel chamfers a box edge then deletes the chamfer face through the
+// feature engine: the body heals back to the sharp box (vol 8), a valid solid.
+func TestDeleteFaceHealsInModel(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var edge []byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			edge = e.ReferenceKey()
+			break
+		}
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	NewDressUpFeatures(fs).AddChamfer([][]byte{edge}, func() float64 { return 0.5 })
+	fs.Recompute()
+	var chamfer []byte
+	for _, f := range fs.Result()[0].Faces() {
+		if n := f.Geometry().NormalAt(0, 0); stdmath.Abs(n.X) > 0.1 && stdmath.Abs(n.Y) > 0.1 {
+			chamfer = f.ReferenceKey()
+		}
+	}
+	del := NewModifyFeatures(fs).AddDeleteFace([][]byte{chamfer})
+	fs.Recompute()
+	if !del.Health().OK() {
+		t.Fatalf("delete-face sick: %+v", del.Health())
+	}
+	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 8) > 1e-6 {
+		t.Errorf("healed volume = %g, want 8", got)
 	}
 }
 


### PR DESCRIPTION
## What

Continues **F04 Local Face Operations** (after Shell #33, Move/Offset Face #34, Draft #35). Turns the deferred delete-face stub into a real heal.

**Kernel — `ops.DeleteFaces`:** removes the selected faces and closes the openings by extending the neighbours. Each vertex of a deleted face slides along the line of its two surviving neighbour planes to the **nearest other neighbour plane** (the face the heal extends to meet); coincident results weld, and the deleted face's loop collapses (degenerate edges dropped). Deleting a chamfer face restores the sharp edge. The result is re-validated; a non-healable selection errors so the feature goes Sick. Adds a small weld-and-build helper (`buildSolidFromLoops`).

**Model:** `DeleteFaceFeature.Recompute` calls `ops.DeleteFaces` (no parameter → `.obk` codec unchanged).

**UI (DoD):** `DeleteFaceTool` (pick faces), `Modify.DeleteFace` ribbon command, `head/ui/delete_face_dialog.go`, `delete-face.svg`.

## Tests

- kernel: chamfer a box edge then delete the chamfer face → sharp box vol 8, valid; lost-key error.
- model: `TestDeleteFaceHealsInModel`.
- app e2e: `TestDeleteFaceToolEndToEnd` / `ViaRibbonCommand` / `NeedsFace` (each chamfers an edge, then deletes the chamfer face via the tools).

`go test ./...`, vet, lint, `-race` green; head/ui (cgo) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)