### PR TITLE
M20 F04: Replace Face — real geometry + UI (DoD)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -105,8 +105,14 @@ func cutFeatureCommands() []*CommandDefinition {
 	}
 }
 
-// localFaceCommands are the F04 local face operations (shell, offset face, draft).
+// localFaceCommands are the F04 local face operations — the metric edits (shell, offset
+// face, draft) plus the topology edits (delete face, replace face).
 func localFaceCommands() []*CommandDefinition {
+	return append(faceMetricCommands(), faceTopologyCommands()...)
+}
+
+// faceMetricCommands move faces by a distance/angle (shell, offset face, draft).
+func faceMetricCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		NewCommand("Modify.Shell", "Shell", "Modify", func(s *Session) error {
 			s.StartTool(NewShellTool())
@@ -126,12 +132,24 @@ func localFaceCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("draft").WithButtonStyle(LargeIconButton).
 			WithTooltip("Draft — taper selected faces by an angle about the pull direction."),
+	}
+}
+
+// faceTopologyCommands change which faces exist (delete face + heal, replace face).
+func faceTopologyCommands() []*CommandDefinition {
+	return []*CommandDefinition{
 		NewCommand("Modify.DeleteFace", "Delete Face", "Modify", func(s *Session) error {
 			s.StartTool(NewDeleteFaceTool())
 			return nil
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("delete-face").WithButtonStyle(LargeIconButton).
 			WithTooltip("Delete Face — remove selected faces and heal the openings."),
+		NewCommand("Modify.ReplaceFace", "Replace Face", "Modify", func(s *Session) error {
+			s.StartTool(NewReplaceFaceTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("replace-face").WithButtonStyle(LargeIconButton).
+			WithTooltip("Replace Face — move selected faces onto a target face's plane."),
 	}
 }
 

--- a/app/replace_face_session.go
+++ b/app/replace_face_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Replace Face tool's property window.
+
+// ActiveReplaceFace returns the running Replace Face tool, or nil when the active tool is not
+// a replace-face (or there is none).
+func (s *Session) ActiveReplaceFace() *ReplaceFaceTool {
+	if s.tool == nil {
+		return nil
+	}
+	r, _ := s.tool.tool.(*ReplaceFaceTool)
+	return r
+}

--- a/app/replace_face_tool.go
+++ b/app/replace_face_tool.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// ReplaceFaceTool is the interactive Replace Face command: click the faces to replace, then
+// switch to target mode and click the face whose plane they should take, and OK. The picked
+// faces move onto the target's plane and the neighbours retrim.
+type ReplaceFaceTool struct {
+	faces         []FaceHandle
+	target        *FaceHandle
+	pickingTarget bool
+	added         *feature.PartFeature
+}
+
+// NewReplaceFaceTool returns a replace-face tool (starting in replace-face selection).
+func NewReplaceFaceTool() *ReplaceFaceTool { return &ReplaceFaceTool{} }
+
+// Name implements [Tool].
+func (t *ReplaceFaceTool) Name() string { return "Replace Face" }
+
+// Start sets the selection filter to faces.
+func (t *ReplaceFaceTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+
+// Pick routes a click to the target slot when in target mode, else appends a face to replace.
+func (t *ReplaceFaceTool) Pick(_ *Session, sel Selectable) {
+	f, ok := sel.(FaceHandle)
+	if !ok {
+		return
+	}
+	if t.pickingTarget {
+		fc := f
+		t.target = &fc
+		return
+	}
+	if !t.hasFace(f) {
+		t.faces = append(t.faces, f)
+	}
+}
+
+func (t *ReplaceFaceTool) hasFace(f FaceHandle) bool {
+	for _, h := range t.faces {
+		if h == f {
+			return true
+		}
+	}
+	return false
+}
+
+// SetPickingTarget switches between picking the faces to replace and the target face.
+func (t *ReplaceFaceTool) SetPickingTarget(b bool) { t.pickingTarget = b }
+
+// PickingTarget reports whether the next click sets the target face.
+func (t *ReplaceFaceTool) PickingTarget() bool { return t.pickingTarget }
+
+// Faces returns the faces to replace (for the UI to list/highlight).
+func (t *ReplaceFaceTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
+
+// PickedTarget reports the target face if one has been chosen.
+func (t *ReplaceFaceTool) PickedTarget() (FaceHandle, bool) {
+	if t.target == nil {
+		return FaceHandle{}, false
+	}
+	return *t.target, true
+}
+
+// CanCommit reports whether at least one face and a target are picked.
+func (t *ReplaceFaceTool) CanCommit() bool { return len(t.faces) > 0 && t.target != nil }
+
+// Commit replaces the picked faces with the target's plane on the active part and
+// recomputes; a sick feature keeps the tool open by returning an error.
+func (t *ReplaceFaceTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	keys := make([][]byte, len(t.faces))
+	for i, f := range t.faces {
+		keys[i] = f.Face.ReferenceKey()
+	}
+	t.added = feature.NewModifyFeatures(part.Features()).AddReplaceFace(keys, t.target.Face.ReferenceKey())
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("replace face: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *ReplaceFaceTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user through the replace-face steps.
+func (t *ReplaceFaceTool) Prompt(*Session) string {
+	if len(t.faces) == 0 {
+		return "Click the faces to replace"
+	}
+	if t.target == nil {
+		return "Switch to target, then click the face whose plane to use"
+	}
+	return "Click OK to replace"
+}
+
+// Cancel restores the default selection filter.
+func (t *ReplaceFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }

--- a/app/replace_face_tool_test.go
+++ b/app/replace_face_tool_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// TestReplaceFaceToolEndToEnd drives the Replace Face UI: click the top face to replace,
+// switch to target mode, click the top face as the target (identity replace), OK — and
+// asserts a valid solid results (vol 8). Geometric correctness for non-identity targets is
+// covered by the kernel ReplaceFaces tests.
+func TestReplaceFaceToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 2) // 2×2×2
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+
+	r := NewReplaceFaceTool()
+	s.StartTool(r)
+	s.Click(50, 50) // pick the face to replace
+	if r.CanCommit() {
+		t.Fatal("replace ready before a target is picked")
+	}
+	r.SetPickingTarget(true)
+	s.Click(50, 50) // pick the target face
+	if !r.CanCommit() {
+		t.Fatal("replace not ready after face + target")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if rr := ops.Validate(body); !rr.Valid || !body.IsSolid() {
+		t.Fatalf("replaced body not a valid solid: %+v", rr)
+	}
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, 8) > 1e-6 {
+		t.Errorf("identity replace volume = %g, want 8", got)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestReplaceFaceViaRibbonCommand starts the tool from its ribbon command.
+func TestReplaceFaceViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.ReplaceFace"); err != nil {
+		t.Fatalf("execute Modify.ReplaceFace: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*ReplaceFaceTool); !ok {
+		t.Fatal("Replace Face command did not start the tool")
+	}
+}
+
+// TestReplaceFaceNeedsTarget checks the tool needs both a face and a target.
+func TestReplaceFaceNeedsTarget(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+	r := NewReplaceFaceTool()
+	s.StartTool(r)
+	s.Click(0, 0) // a face to replace
+	if r.CanCommit() {
+		t.Error("replace ready with no target")
+	}
+	r.SetPickingTarget(true)
+	s.Click(0, 0) // the target
+	if !r.CanCommit() {
+		t.Error("replace not ready after face + target")
+	}
+}

--- a/head/icon/assets/replace-face.svg
+++ b/head/icon/assets/replace-face.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="10" width="8" height="10"/><rect x="13" y="4" width="8" height="10"/><path d="M11 8 H13" stroke-dasharray="2 1"/><path d="M11.5 12 L13 8 L14.5 12"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -59,6 +59,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawFaceOffsetDialog(s)
 	drawDraftDialog(s)
 	drawDeleteFaceDialog(s)
+	drawReplaceFaceDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/replace_face_dialog.go
+++ b/head/ui/replace_face_dialog.go
@@ -1,0 +1,53 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Replace Face flow in the head: while the tool runs, a modeless options window lists
+// the picked faces, a toggle to pick the target face, and the chosen target, then OK/Cancel.
+var replaceFaceUI = struct{ open bool }{}
+
+// drawReplaceFaceDialog shows the replace-face options window while the tool is active.
+func drawReplaceFaceDialog(s *app.Session) {
+	r := s.ActiveReplaceFace()
+	if r == nil {
+		replaceFaceUI.open = false
+		return
+	}
+	replaceFaceUI.open = true
+	native.SetNextWindowSize(320, 170)
+	if native.Begin("Replace Face") {
+		native.Text("Faces to replace: " + strconv.Itoa(len(r.Faces())))
+		pickTarget := r.PickingTarget()
+		if native.Checkbox("Pick target face", &pickTarget) {
+			r.SetPickingTarget(pickTarget)
+		}
+		native.Text("Target: " + targetLabel(r))
+		native.BeginDisabled(!r.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}
+
+// targetLabel reports whether a target face has been chosen.
+func targetLabel(r *app.ReplaceFaceTool) string {
+	if _, ok := r.PickedTarget(); ok {
+		return "selected"
+	}
+	return "none"
+}

--- a/kernel/ops/replace_face.go
+++ b/kernel/ops/replace_face.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// ReplaceFaces replaces the surface of each selected face with the target plane and retrims
+// the neighbours (via [rebuildWithPlanes]): the selected faces are moved onto target and
+// every vertex re-solves at its faces' new plane intersections. It is the planar form of
+// "replace face with a surface" — e.g. raising a step's top onto a higher face's plane. The
+// topology is preserved, so the result stays valid for a target that does not invert a face.
+func ReplaceFaces(solid *topo.Body, faceKeys [][]byte, target geom.Plane) (*topo.Body, error) {
+	sel, err := resolveFaceSet(solid, faceKeys)
+	if err != nil {
+		return nil, err
+	}
+	return rebuildWithPlanes(solid, "replace-face", func(f *topo.Face) geom.Plane {
+		if sel[f.ID()] {
+			return target
+		}
+		return f.Geometry().(geom.Plane)
+	}), nil
+}
+
+// PlaneOfFace returns the plane of a face by its reference key (the target source for a
+// replace-face), or ok=false if the key no longer resolves or the face is not planar.
+func PlaneOfFace(solid *topo.Body, key []byte) (geom.Plane, bool) {
+	f, ok := solid.FindFaceByKey(key)
+	if !ok {
+		return geom.Plane{}, false
+	}
+	pl, planar := f.Geometry().(geom.Plane)
+	return pl, planar
+}

--- a/kernel/ops/replace_face_test.go
+++ b/kernel/ops/replace_face_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// TestReplaceFaceParallelGrows replaces the top face of a 2×2×2 box (z=2) with a parallel
+// plane at z=3: the box grows to 2×2×3 (vol 12), a valid solid.
+func TestReplaceFaceParallelGrows(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	target, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	res, err := ops.ReplaceFaces(box, [][]byte{topFaceKey(t, box)}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("replaced body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-12) > 1e-6 {
+		t.Errorf("replace-face volume = %g, want 12", got)
+	}
+}
+
+// TestReplaceFaceTiltedIsValid replaces the top face with a tilted plane and checks the
+// result is still a valid solid (a wedge top).
+func TestReplaceFaceTiltedIsValid(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	target, _ := geom.NewPlane(math.P3(0, 0, 2), math.V3(0, 1, 4)) // tilts about X through z=2
+	res, err := ops.ReplaceFaces(box, [][]byte{topFaceKey(t, box)}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("tilted replace not a valid solid: %+v", r)
+	}
+}
+
+// TestReplaceFaceLostKeyErrors reports a vanished face key so the feature can go Sick.
+func TestReplaceFaceLostKeyErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	target, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	if _, err := ops.ReplaceFaces(box, [][]byte{[]byte("ghost")}, target); err == nil {
+		t.Error("replace-face with a lost key should error")
+	}
+}

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -78,13 +78,32 @@ func (f *faceEditFeature) Recompute(in Input) (Output, error) {
 // the recipe serialize every face-edit feature uniformly (they share this shape).
 func (f *faceEditFeature) FaceKeys() [][]byte { return f.faceKeys }
 
-// SplitFeature, ReplaceFaceFeature and ThickenFeature are the direct edits whose geometry
-// still defers (phase C).
+// SplitFeature and ThickenFeature are the direct edits whose geometry still defers (phase C).
 type (
-	SplitFeature       struct{ faceEditFeature }
-	ReplaceFaceFeature struct{ faceEditFeature }
-	ThickenFeature     struct{ faceEditFeature }
+	SplitFeature   struct{ faceEditFeature }
+	ThickenFeature struct{ faceEditFeature }
 )
+
+// ReplaceFaceFeature replaces the picked faces' surface with that of a target face.
+type ReplaceFaceFeature struct {
+	faceEditFeature
+	targetKey []byte
+}
+
+// TargetKey returns the reference key of the face whose plane replaces the picked faces.
+func (f *ReplaceFaceFeature) TargetKey() []byte { return f.targetKey }
+
+// Recompute replaces the picked faces with the target face's plane on the running body (see
+// kernel/ops/replace_face.go); a lost picked or target face makes the feature go Sick.
+func (f *ReplaceFaceFeature) Recompute(in Input) (Output, error) {
+	return retopoFacesBody(in, f.faceKeys, f.kind, func(b *topo.Body, keys [][]byte) (*topo.Body, error) {
+		target, ok := ops.PlaneOfFace(b, f.targetKey)
+		if !ok {
+			return nil, fmt.Errorf("replace-face: target face reference lost")
+		}
+		return ops.ReplaceFaces(b, keys, target)
+	})
+}
 
 // DeleteFaceFeature removes the picked faces and heals the openings (extends neighbours).
 type DeleteFaceFeature struct{ faceEditFeature }
@@ -170,8 +189,8 @@ func (c *ModifyFeatures) AddDeleteFace(faceKeys [][]byte) *PartFeature {
 	return c.engine.Add(&DeleteFaceFeature{faceEditFeature{kind: "delete-face", faceKeys: faceKeys}})
 }
 
-func (c *ModifyFeatures) AddReplaceFace(faceKeys [][]byte) *PartFeature {
-	return c.engine.Add(&ReplaceFaceFeature{faceEditFeature{kind: "replace-face", faceKeys: faceKeys}})
+func (c *ModifyFeatures) AddReplaceFace(faceKeys [][]byte, targetKey []byte) *PartFeature {
+	return c.engine.Add(&ReplaceFaceFeature{faceEditFeature: faceEditFeature{kind: "replace-face", faceKeys: faceKeys}, targetKey: targetKey})
 }
 
 func (c *ModifyFeatures) AddThicken(faceKeys [][]byte) *PartFeature {

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -72,11 +72,10 @@ func TestDirectEditsResolveThenDefer(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fs).AddBase(body)
 	mod := NewModifyFeatures(fs)
-	// move-face, face-offset and delete-face are real now (see their own tests); the rest defer.
+	// move/offset/delete/replace-face are real now (see their own tests); split & thicken defer.
 	feats := map[string]*PartFeature{
-		"split":        mod.AddSplit([][]byte{face}),
-		"replace-face": mod.AddReplaceFace([][]byte{face}),
-		"thicken":      mod.AddThicken([][]byte{face}),
+		"split":   mod.AddSplit([][]byte{face}),
+		"thicken": mod.AddThicken([][]byte{face}),
 	}
 	fs.Recompute()
 	for name, pf := range feats {
@@ -139,6 +138,30 @@ func TestDeleteFaceHealsInModel(t *testing.T) {
 	}
 	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 8) > 1e-6 {
 		t.Errorf("healed volume = %g, want 8", got)
+	}
+}
+
+// TestReplaceFaceIdentityIsValid exercises the replace-face feature wiring and key
+// resolution on a box: replacing the top face with its own plane is a valid no-op (vol 8).
+// Geometric correctness for non-identity targets is covered by the kernel ReplaceFaces tests
+// (a same-body parallel/stepped target needs a stepped solid to set up).
+func TestReplaceFaceIdentityIsValid(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var top []byte
+	for _, f := range box.Faces() {
+		if f.Geometry().NormalAt(0, 0).Z > 0.99 {
+			top = f.ReferenceKey()
+		}
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	rf := NewModifyFeatures(fs).AddReplaceFace([][]byte{top}, top) // replace top with its own plane
+	fs.Recompute()
+	if !rf.Health().OK() {
+		t.Fatalf("replace-face sick: %+v", rf.Health())
+	}
+	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 8) > 1e-6 {
+		t.Errorf("identity replace-face volume = %g, want 8", got)
 	}
 }
 

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -205,6 +205,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Translation: []float64{t.X, t.Y, t.Z}}
 	case *FaceOffsetFeature:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Distance: f.Distance()}
+	case *ReplaceFaceFeature:
+		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Target: encodeKey(f.TargetKey())}
 	case faceEditor:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	default:

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -16,6 +16,7 @@ type FaceEditData struct {
 	Faces       []string  `yaml:"faces"`
 	Translation []float64 `yaml:"translation,omitempty"` // move-face: dx, dy, dz
 	Distance    float64   `yaml:"distance,omitempty"`    // face-offset
+	Target      string    `yaml:"target,omitempty"`      // replace-face: source face key
 }
 
 // faceEditor is satisfied by every direct face-edit feature (they embed faceEditFeature),
@@ -45,7 +46,11 @@ func restoreFaceEdit(fs *PartFeatures, kind string, d *FaceEditData) (*PartFeatu
 	case "delete-face":
 		return m.AddDeleteFace(keys), nil
 	case "replace-face":
-		return m.AddReplaceFace(keys), nil
+		target, err := decodeKey(d.Target)
+		if err != nil {
+			return nil, err
+		}
+		return m.AddReplaceFace(keys, target), nil
 	case "thicken":
 		return m.AddThicken(keys), nil
 	default:

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -199,7 +199,7 @@ func TestFaceEditFeaturesRoundTrip(t *testing.T) {
 	m.AddMoveFace([][]byte{[]byte("f-move")}, math.V3(1, 2, 3))
 	m.AddFaceOffset([][]byte{[]byte("f-off")}, 0.5)
 	m.AddDeleteFace([][]byte{[]byte("f-del")})
-	m.AddReplaceFace([][]byte{[]byte("f-rep")})
+	m.AddReplaceFace([][]byte{[]byte("f-rep")}, []byte("f-target"))
 	m.AddThicken([][]byte{[]byte("f-thick")})
 
 	data, err := fs.MarshalRecipe(oneSketch{})


### PR DESCRIPTION
## What

Continues **F04 Local Face Operations** (after Shell #33, Move/Offset #34, Draft #35, Delete Face #37). Turns the deferred replace-face stub into a real edit.

**Kernel — `ops.ReplaceFaces`:** sets the selected faces' surface to a target plane and retrims the neighbours (via `rebuildWithPlanes`) — the planar form of "replace face with a surface", e.g. raising a step's top onto a higher face's plane. `ops.PlaneOfFace` resolves a target face's plane by key.

**Model:** `ReplaceFaceFeature` carries a target face key; `Recompute` resolves the target's plane on the running body and calls `ops.ReplaceFaces` (lost picked/target face → Sick). The `.obk` codec (`FaceEditData.Target`) round-trips the key.

**UI (DoD):** `ReplaceFaceTool` (pick faces, toggle to pick the target face), `Modify.ReplaceFace` ribbon command, `head/ui/replace_face_dialog.go` (with a "pick target" checkbox), `replace-face.svg`. The Modify local-face builder split into metric (shell/offset/draft) and topology (delete/replace) groups (funlen).

## Tests

- kernel: parallel raise → vol 12, tilted target valid, lost-key error.
- model: `TestReplaceFaceIdentityIsValid` (wiring + key resolution + round-trip).
- app e2e: `TestReplaceFaceToolEndToEnd` / `ViaRibbonCommand` / `NeedsTarget`.

`go test ./...`, vet, lint, `-race` green; head/ui (cgo) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)