### PR TITLE
M20 F04: Thicken — surface→solid + UI (DoD); completes F04

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -82,9 +82,23 @@ func modelTabCommands() []*CommandDefinition {
 }
 
 // modifyFeatureCommands are the 3D Model tab's "Modify" panel: the material-cutting
-// features (hole/chamfer) plus the local face operations (shell/offset/draft).
+// features (hole/chamfer), the local face operations (shell/offset/draft/delete/replace),
+// and surface→solid (thicken).
 func modifyFeatureCommands() []*CommandDefinition {
-	return append(cutFeatureCommands(), localFaceCommands()...)
+	cmds := append(cutFeatureCommands(), localFaceCommands()...)
+	return append(cmds, surfaceSolidCommands()...)
+}
+
+// surfaceSolidCommands are the Modify features that turn a surface body into a solid.
+func surfaceSolidCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		NewCommand("Modify.Thicken", "Thicken", "Modify", func(s *Session) error {
+			s.StartTool(NewThickenTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("thicken").WithButtonStyle(LargeIconButton).
+			WithTooltip("Thicken — turn the active surface body into a solid of a wall thickness."),
+	}
 }
 
 // cutFeatureCommands are the Modify features that remove material against picked topology.

--- a/app/thicken_session.go
+++ b/app/thicken_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Thicken tool's property window.
+
+// ActiveThicken returns the running Thicken tool, or nil when the active tool is not a
+// thicken (or there is none).
+func (s *Session) ActiveThicken() *ThickenTool {
+	if s.tool == nil {
+		return nil
+	}
+	th, _ := s.tool.tool.(*ThickenTool)
+	return th
+}

--- a/app/thicken_tool.go
+++ b/app/thicken_tool.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// ThickenTool is the interactive Thicken command: with a surface (sheet) body active, set
+// the wall thickness in the property window and OK to turn it into a solid slab. It takes no
+// face picks — it thickens the running surface body.
+type ThickenTool struct {
+	thickness float64
+	added     *feature.PartFeature
+}
+
+// NewThickenTool returns a thicken tool with a default 1-unit thickness.
+func NewThickenTool() *ThickenTool { return &ThickenTool{thickness: 1} }
+
+// Name implements [Tool].
+func (t *ThickenTool) Name() string { return "Thicken" }
+
+// Start clears the selection filter (thicken needs no picks).
+func (t *ThickenTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// Pick is a no-op — thicken acts on the running surface body, not a selection.
+func (t *ThickenTool) Pick(*Session, Selectable) {}
+
+// SetThickness/Thickness set the wall thickness (database units).
+func (t *ThickenTool) SetThickness(d float64) { t.thickness = d }
+func (t *ThickenTool) Thickness() float64     { return t.thickness }
+
+// CanCommit reports whether the thickness is positive.
+func (t *ThickenTool) CanCommit() bool { return t.thickness > 0 }
+
+// Commit thickens the active part's running surface body into a solid and recomputes; a sick
+// feature (no surface body, or not thickenable) keeps the tool open by returning an error.
+func (t *ThickenTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewModifyFeatures(part.Features()).AddThicken(t.thickness)
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("thicken: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *ThickenTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user.
+func (t *ThickenTool) Prompt(*Session) string { return "Set the thickness, then click OK" }
+
+// Cancel restores the default selection filter.
+func (t *ThickenTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }

--- a/app/thicken_tool_test.go
+++ b/app/thicken_tool_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// newPartWithSurface returns a session whose active part's running body is a 2×3 planar
+// surface patch (a sheet) — the input a thicken turns into a solid.
+func newPartWithSurface(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	def := compdef.NewPartComponentDefinition()
+	pd, err := s.Workspace().Add(doc.Part, "part.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	pd.SetContent(def)
+	feature.NewBaseFeatures(def.Features()).AddBase(patchSurface(2, 3))
+	def.Recompute()
+	if def.SurfaceBodies().Count() != 1 || def.SurfaceBodies().Item(0).IsSolid() {
+		t.Fatal("expected one surface (non-solid) base body")
+	}
+	return s
+}
+
+// patchSurface builds a one-face planar surface body [0,w]×[0,h] at z=0.
+func patchSurface(w, h float64) *topo.Body {
+	lin := topo.NewLineage(topo.Tok("test", "patch", 0))
+	bld := topo.NewBuilder(false, lin)
+	p := []math.Point3{{X: 0, Y: 0}, {X: w, Y: 0}, {X: w, Y: h}, {X: 0, Y: h}}
+	v := make([]*topo.Vertex, 4)
+	for i, q := range p {
+		v[i] = bld.AddVertex(q, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := range p {
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[(i+1)%4]), v[i], v[(i+1)%4], lin)
+		uses[i] = topo.Use{Edge: e}
+	}
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, lin, topo.OuterLoop(uses...))
+	return bld.Build()
+}
+
+// TestThickenToolEndToEnd drives the Thicken UI: with a 2×3 surface patch active, start the
+// tool, set thickness 0.5, OK — and asserts a valid slab solid of volume 3.
+func TestThickenToolEndToEnd(t *testing.T) {
+	s := newPartWithSurface(t)
+	th := NewThickenTool()
+	s.StartTool(th)
+	th.SetThickness(0.5)
+	if !th.CanCommit() {
+		t.Fatal("thicken not ready after thickness")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("thickened body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, 3) > 1e-6 {
+		t.Errorf("slab volume = %g, want 3", got)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestThickenViaRibbonCommand starts the tool from its ribbon command.
+func TestThickenViaRibbonCommand(t *testing.T) {
+	s := newPartWithSurface(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.Thicken"); err != nil {
+		t.Fatalf("execute Modify.Thicken: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*ThickenTool); !ok {
+		t.Fatal("Thicken command did not start the tool")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if !activePartDef(t, s).SurfaceBodies().Item(0).IsSolid() {
+		t.Error("thicken did not produce a solid")
+	}
+}

--- a/head/icon/assets/thicken.svg
+++ b/head/icon/assets/thicken.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 8 H21"/><rect x="3" y="13" width="18" height="6"/><path d="M6 8 V13 M18 8 V13" stroke-dasharray="2 2"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -60,6 +60,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawDraftDialog(s)
 	drawDeleteFaceDialog(s)
 	drawReplaceFaceDialog(s)
+	drawThickenDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/thicken_dialog.go
+++ b/head/ui/thicken_dialog.go
@@ -1,0 +1,46 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Thicken flow in the head: while the tool runs, a modeless options window takes the
+// wall thickness applied to the active surface body, then OK/Cancel.
+var thickenUI = struct {
+	thickness float32
+	open      bool
+}{thickness: 1}
+
+// drawThickenDialog shows the thicken options window while the Thicken tool is active.
+func drawThickenDialog(s *app.Session) {
+	th := s.ActiveThicken()
+	if th == nil {
+		thickenUI.open = false
+		return
+	}
+	if !thickenUI.open {
+		thickenUI.thickness = float32(th.Thickness())
+		thickenUI.open = true
+	}
+	native.SetNextWindowSize(300, 140)
+	if native.Begin("Thicken") {
+		native.Text("Thickness (" + s.LengthUnitName() + ")")
+		native.InputFloat("##thicken-thickness", &thickenUI.thickness)
+		th.SetThickness(float64(thickenUI.thickness))
+		native.BeginDisabled(!th.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/kernel/ops/thicken.go
+++ b/kernel/ops/thicken.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Thicken turns a planar surface (sheet) body into a solid of wall thickness t: each face is
+// copied to both sides (offset ±t/2 along its normal) and the free-boundary edges (used by a
+// single face) are closed with side walls. A single planar patch becomes a slab; a connected
+// planar sheet becomes a thick shell. Curved or creased sheets (where per-face offsets don't
+// meet) are a follow-up. It errors when the result is not a valid solid.
+func Thicken(surface *topo.Body, t float64) (*topo.Body, error) {
+	if t <= 0 {
+		return nil, fmt.Errorf("thicken: thickness %g must be > 0", t)
+	}
+	half := t / 2
+	var loops []ploop
+	for _, f := range surface.Faces() {
+		n := f.Geometry().NormalAt(0, 0)
+		loops = append(loops, slabCaps(f, n, half)...)
+		loops = append(loops, slabWalls(f, n, half)...)
+	}
+	body := buildSolidFromLoops(loops)
+	if r := Validate(body); !r.Valid || !body.IsSolid() {
+		return nil, fmt.Errorf("thicken: result is not a valid solid %v", r.Issues)
+	}
+	return body, nil
+}
+
+// slabCaps returns the top (offset +half, same winding) and bottom (offset −half, reversed)
+// copies of a face — the two outer skins of the slab.
+func slabCaps(f *topo.Face, n math.Vector3, half float64) []ploop {
+	top := ploop{normal: n}
+	bottom := ploop{normal: n.Scale(-1)}
+	for _, l := range f.Loops() {
+		pts := loopPoints3(l)
+		top.rings = append(top.rings, offsetRing(pts, n, half))
+		bottom.rings = append(bottom.rings, reverse3(offsetRing(pts, n, -half)))
+	}
+	return []ploop{top, bottom}
+}
+
+// slabWalls returns a side-wall quad for each free-boundary edge of the face (an edge used by
+// a single face), connecting the top and bottom skins.
+func slabWalls(f *topo.Face, n math.Vector3, half float64) []ploop {
+	var walls []ploop
+	for _, l := range f.Loops() {
+		for _, u := range l.EdgeUses() {
+			if len(u.Edge().Uses()) != 1 {
+				continue // shared (interior) edge — the offset skins already meet here
+			}
+			a, b := useEndpoints(u)
+			at, ab := a.TranslateBy(n.Scale(half)), a.TranslateBy(n.Scale(-half))
+			bt, bb := b.TranslateBy(n.Scale(half)), b.TranslateBy(n.Scale(-half))
+			wn := outwardWall(a.VectorTo(b), n)
+			walls = append(walls, ploop{normal: wn, rings: [][]math.Point3{{at, ab, bb, bt}}})
+		}
+	}
+	return walls
+}
+
+// useEndpoints returns an edge use's start and end points in its traversal direction.
+func useEndpoints(u *topo.EdgeUse) (math.Point3, math.Point3) {
+	s, e := u.Edge().StartVertex(), u.Edge().EndVertex()
+	if u.Reversed() {
+		s, e = e, s
+	}
+	return s.Point(), e.Point()
+}
+
+// outwardWall returns the wall's outward normal: perpendicular to the edge and the face
+// normal, pointing away from the face interior (edge × normal for a CCW loop).
+func outwardWall(edge, n math.Vector3) math.Vector3 {
+	w, err := math.UnitVector3FromVector(edge.Cross(n))
+	if err != nil {
+		return n
+	}
+	return w.AsVector()
+}
+
+// offsetRing returns the loop points shifted by d along n.
+func offsetRing(pts []math.Point3, n math.Vector3, d float64) []math.Point3 {
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[i] = p.TranslateBy(n.Scale(d))
+	}
+	return out
+}
+
+// loopPoints3 returns a loop's vertices in traversal order.
+func loopPoints3(l *topo.Loop) []math.Point3 {
+	var pts []math.Point3
+	for _, u := range l.EdgeUses() {
+		s, _ := useEndpoints(u)
+		pts = append(pts, s)
+	}
+	return pts
+}

--- a/kernel/ops/thicken_test.go
+++ b/kernel/ops/thicken_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// planarPatch builds a one-face surface (non-solid) body: the rectangle [0,w]×[0,h] in the
+// z=0 plane (normal +Z).
+func planarPatch(t *testing.T, w, h float64) *topo.Body {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "patch", 0))
+	bld := topo.NewBuilder(false, lin)
+	p := []math.Point3{{X: 0, Y: 0}, {X: w, Y: 0}, {X: w, Y: h}, {X: 0, Y: h}}
+	v := make([]*topo.Vertex, 4)
+	for i, q := range p {
+		v[i] = bld.AddVertex(q, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := range p {
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[(i+1)%4]), v[i], v[(i+1)%4], lin)
+		uses[i] = topo.Use{Edge: e}
+	}
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, lin, topo.OuterLoop(uses...))
+	return bld.Build()
+}
+
+// TestThickenPatchToSlab thickens a 2×3 planar patch by 0.5 into a slab solid of volume
+// 2·3·0.5 = 3, validated.
+func TestThickenPatchToSlab(t *testing.T) {
+	patch := planarPatch(t, 2, 3)
+	if patch.IsSolid() {
+		t.Fatal("patch should be a surface body, not a solid")
+	}
+	slab, err := ops.Thicken(patch, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(slab); !r.Valid || !slab.IsSolid() {
+		t.Fatalf("thickened patch not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(slab, ops.DefaultQuality()).Volume; stdmath.Abs(got-3) > 1e-6 {
+		t.Errorf("slab volume = %g, want 3", got)
+	}
+}
+
+// TestThickenThicknessMustBePositive guards the thickness.
+func TestThickenThicknessMustBePositive(t *testing.T) {
+	if _, err := ops.Thicken(planarPatch(t, 1, 1), 0); err == nil {
+		t.Error("zero thickness should error")
+	}
+}

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -78,11 +78,31 @@ func (f *faceEditFeature) Recompute(in Input) (Output, error) {
 // the recipe serialize every face-edit feature uniformly (they share this shape).
 func (f *faceEditFeature) FaceKeys() [][]byte { return f.faceKeys }
 
-// SplitFeature and ThickenFeature are the direct edits whose geometry still defers (phase C).
-type (
-	SplitFeature   struct{ faceEditFeature }
-	ThickenFeature struct{ faceEditFeature }
-)
+// SplitFeature is the direct edit whose geometry still defers (phase C).
+type SplitFeature struct{ faceEditFeature }
+
+// ThickenFeature turns the running surface (sheet) body into a solid of a wall thickness.
+type ThickenFeature struct{ thickness float64 }
+
+// Kind implements [Feature].
+func (f *ThickenFeature) Kind() string { return "thicken" }
+
+// Thickness returns the wall thickness (for the UI / serialization).
+func (f *ThickenFeature) Thickness() float64 { return f.thickness }
+
+// Recompute thickens the running surface body into a solid (see kernel/ops/thicken.go); a
+// non-surface or non-thickenable body makes the feature go Sick.
+func (f *ThickenFeature) Recompute(in Input) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	result, err := ops.Thicken(body, f.thickness)
+	if err != nil {
+		return Output{}, fmt.Errorf("thicken: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
 
 // ReplaceFaceFeature replaces the picked faces' surface with that of a target face.
 type ReplaceFaceFeature struct {
@@ -193,6 +213,7 @@ func (c *ModifyFeatures) AddReplaceFace(faceKeys [][]byte, targetKey []byte) *Pa
 	return c.engine.Add(&ReplaceFaceFeature{faceEditFeature: faceEditFeature{kind: "replace-face", faceKeys: faceKeys}, targetKey: targetKey})
 }
 
-func (c *ModifyFeatures) AddThicken(faceKeys [][]byte) *PartFeature {
-	return c.engine.Add(&ThickenFeature{faceEditFeature{kind: "thicken", faceKeys: faceKeys}})
+// AddThicken thickens the running surface body into a solid of the given wall thickness.
+func (c *ModifyFeatures) AddThicken(thickness float64) *PartFeature {
+	return c.engine.Add(&ThickenFeature{thickness: thickness})
 }

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -6,7 +6,9 @@ import (
 	stdmath "math"
 	"testing"
 
+	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/health"
 	"github.com/Oblikovati/oblikovati/model/sketch"
@@ -72,10 +74,9 @@ func TestDirectEditsResolveThenDefer(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fs).AddBase(body)
 	mod := NewModifyFeatures(fs)
-	// move/offset/delete/replace-face are real now (see their own tests); split & thicken defer.
+	// Only split still defers; the other direct edits are real (see their own tests).
 	feats := map[string]*PartFeature{
-		"split":   mod.AddSplit([][]byte{face}),
-		"thicken": mod.AddThicken([][]byte{face}),
+		"split": mod.AddSplit([][]byte{face}),
 	}
 	fs.Recompute()
 	for name, pf := range feats {
@@ -163,6 +164,45 @@ func TestReplaceFaceIdentityIsValid(t *testing.T) {
 	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 8) > 1e-6 {
 		t.Errorf("identity replace-face volume = %g, want 8", got)
 	}
+}
+
+// TestThickenSurfaceToSlab thickens a planar surface patch (added as the base body) into a
+// slab solid through the feature engine: 2×3 patch × 0.5 = vol 3, a valid solid.
+func TestThickenSurfaceToSlab(t *testing.T) {
+	patch := patchSurfaceBody(2, 3)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(patch)
+	th := NewModifyFeatures(fs).AddThicken(0.5)
+	fs.Recompute()
+	if !th.Health().OK() {
+		t.Fatalf("thicken sick: %+v", th.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("thickened patch not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, 3) > 1e-6 {
+		t.Errorf("slab volume = %g, want 3", got)
+	}
+}
+
+// patchSurfaceBody builds a one-face planar surface (non-solid) body [0,w]×[0,h] at z=0.
+func patchSurfaceBody(w, h float64) *topo.Body {
+	lin := topo.NewLineage(topo.Tok("test", "patch", 0))
+	bld := topo.NewBuilder(false, lin)
+	p := []math.Point3{{X: 0, Y: 0}, {X: w, Y: 0}, {X: w, Y: h}, {X: 0, Y: h}}
+	v := make([]*topo.Vertex, 4)
+	for i, q := range p {
+		v[i] = bld.AddVertex(q, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := range p {
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[(i+1)%4]), v[i], v[(i+1)%4], lin)
+		uses[i] = topo.Use{Edge: e}
+	}
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, lin, topo.OuterLoop(uses...))
+	return bld.Build()
 }
 
 // squarePoly returns a unit square offset by dx; planeXY is the XY sketch plane.

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -40,6 +40,7 @@ type FeatureData struct {
 	BoundaryPatch *BoundaryPatchData `yaml:"boundaryPatch,omitempty"`
 	RuledSurface  *RuledSurfaceData  `yaml:"ruledSurface,omitempty"`
 	FaceEdit      *FaceEditData      `yaml:"faceEdit,omitempty"`
+	Thicken       *ThickenData       `yaml:"thicken,omitempty"`
 	Revolve       *RevolveData       `yaml:"revolve,omitempty"`
 	Coil          *CoilData          `yaml:"coil,omitempty"`
 	Sweep         *SweepData         `yaml:"sweep,omitempty"`
@@ -207,6 +208,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Distance: f.Distance()}
 	case *ReplaceFaceFeature:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Target: encodeKey(f.TargetKey())}
+	case *ThickenFeature:
+		fd.Thicken = &ThickenData{Value: f.Thickness()}
 	case faceEditor:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	default:
@@ -292,8 +295,13 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreBoundaryPatch(fs, fd.BoundaryPatch, sk)
 	case "ruled-surface":
 		return restoreRuledSurface(fs, fd.RuledSurface, sk)
-	case "split", "move-face", "face-offset", "delete-face", "replace-face", "thicken":
+	case "split", "move-face", "face-offset", "delete-face", "replace-face":
 		return restoreFaceEdit(fs, fd.Kind, fd.FaceEdit)
+	case "thicken":
+		if fd.Thicken == nil {
+			return nil, fmt.Errorf("thicken feature is missing its payload")
+		}
+		return NewModifyFeatures(fs).AddThicken(fd.Thicken.Value), nil
 	case "revolve":
 		return restoreRevolve(fs, fd.Revolve, sk, work)
 	case "coil":

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -19,6 +19,11 @@ type FaceEditData struct {
 	Target      string    `yaml:"target,omitempty"`      // replace-face: source face key
 }
 
+// ThickenData is a thicken feature: the wall thickness applied to the running surface body.
+type ThickenData struct {
+	Value float64 `yaml:"value"`
+}
+
 // faceEditor is satisfied by every direct face-edit feature (they embed faceEditFeature),
 // exposing the picked face keys for serialization.
 type faceEditor interface {
@@ -51,8 +56,6 @@ func restoreFaceEdit(fs *PartFeatures, kind string, d *FaceEditData) (*PartFeatu
 			return nil, err
 		}
 		return m.AddReplaceFace(keys, target), nil
-	case "thicken":
-		return m.AddThicken(keys), nil
 	default:
 		return nil, fmt.Errorf("unknown face-edit kind %q", kind)
 	}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -200,7 +200,7 @@ func TestFaceEditFeaturesRoundTrip(t *testing.T) {
 	m.AddFaceOffset([][]byte{[]byte("f-off")}, 0.5)
 	m.AddDeleteFace([][]byte{[]byte("f-del")})
 	m.AddReplaceFace([][]byte{[]byte("f-rep")}, []byte("f-target"))
-	m.AddThicken([][]byte{[]byte("f-thick")})
+	m.AddThicken(0.5)
 
 	data, err := fs.MarshalRecipe(oneSketch{})
 	if err != nil {


### PR DESCRIPTION
## What

The final **F04 Local Face Operations** feature (after Shell #33, Move/Offset #34, Draft #35, Delete Face #37, Replace Face #38). Turns the deferred thicken stub into a real surface→solid.

**Kernel — `ops.Thicken`:** copies each planar face of a sheet body to both sides (offset ±t/2 along its normal) and closes the free-boundary edges (used by a single face) with side walls, welding into a slab. A single planar patch → a slab; a connected planar sheet → a thick shell. Curved/creased sheets are a follow-up. Reuses `buildSolidFromLoops`.

**Model:** `ThickenFeature` is now a thickness over the running surface body (not a faceEdit); `Recompute` calls `ops.Thicken`. New `ThickenData` codec; thicken split out of the face-edit serialization path.

**UI (DoD):** `ThickenTool` (no picks — thickens the active surface body, set thickness), `Modify.Thicken` ribbon command, `head/ui/thicken_dialog.go`, `thicken.svg`.

## Tests

- kernel: 2×3 patch × 0.5 → slab vol 3, valid; positive-thickness guard.
- model: `TestThickenSurfaceToSlab`.
- app e2e: `TestThickenToolEndToEnd` / `ViaRibbonCommand` (a planar surface base body is the fixture).

**With this, all of F04 ships with real geometry + DoD UI:** shell, move/offset face, draft, delete face + heal, replace face, thicken.

`go test ./...`, vet, lint, `-race` green; head/ui (cgo) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)