### PR TITLE
fix: body-vertex picking (3-point plane) and offset plane from a face

### DIFF
--- a/app/offset_plane_tool.go
+++ b/app/offset_plane_tool.go
@@ -15,7 +15,8 @@ import (
 // a fixed distance without asking). The distance is held in model (database) units; the
 // session bridge converts to/from the document's display unit for the dialog field.
 type OffsetWorkPlaneTool struct {
-	base     *feature.WorkPlane
+	baseRef  feature.WorkRef // the plane or planar-face reference to offset from
+	hasBase  bool
 	distance float64 // offset in model units; 0 until the user sets it (so OK stays disabled)
 	added    *feature.WorkPlane
 	prev     *SelectionFilter
@@ -27,19 +28,24 @@ func NewOffsetWorkPlaneTool() *OffsetWorkPlaneTool { return &OffsetWorkPlaneTool
 // Name implements [Tool].
 func (t *OffsetWorkPlaneTool) Name() string { return "Offset Plane" }
 
-// Start filters selection to work planes and seeds the base from a pre-selected plane (so
-// a user who picked a plane first only needs to enter the distance).
+// Start filters selection to work planes and planar faces and seeds the base from a
+// pre-selected plane (so a user who picked a plane first only needs to enter the distance).
 func (t *OffsetWorkPlaneTool) Start(s *Session) {
 	t.prev = s.Selection().Filter()
-	t.base = s.SelectedWorkPlane()
+	if wp := s.SelectedWorkPlane(); wp != nil {
+		t.baseRef, t.hasBase = wp.Key(), true
+	}
 	s.Selection().Clear()
-	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane, SelectFace))
 }
 
-// Pick records the plane to offset from.
+// Pick records the plane or planar face to offset from.
 func (t *OffsetWorkPlaneTool) Pick(_ *Session, sel Selectable) {
-	if h, ok := sel.(WorkPlaneHandle); ok {
-		t.base = h.Plane
+	switch h := sel.(type) {
+	case WorkPlaneHandle:
+		t.baseRef, t.hasBase = h.Plane.Key(), true
+	case FaceHandle:
+		t.baseRef, t.hasBase = feature.FaceRef(h.Face.ReferenceKey()), true
 	}
 }
 
@@ -48,26 +54,26 @@ func (t *OffsetWorkPlaneTool) Pick(_ *Session, sel Selectable) {
 func (t *OffsetWorkPlaneTool) SetDistance(d float64) { t.distance = d }
 func (t *OffsetWorkPlaneTool) Distance() float64     { return t.distance }
 
-// BasePicked reports whether the plane to offset from has been chosen, so the dialog knows
-// to prompt for the pick vs. the distance.
-func (t *OffsetWorkPlaneTool) BasePicked() bool { return t.base != nil }
+// BasePicked reports whether the plane/face to offset from has been chosen, so the dialog
+// knows to prompt for the pick vs. the distance.
+func (t *OffsetWorkPlaneTool) BasePicked() bool { return t.hasBase }
 
-// CanCommit requires a base plane and a non-zero offset (so OK stays disabled until both
-// are gathered — the tool never silently creates a plane).
-func (t *OffsetWorkPlaneTool) CanCommit() bool { return t.base != nil && t.distance != 0 }
+// CanCommit requires a base and a non-zero offset (so OK stays disabled until both are
+// gathered — the tool never silently creates a plane).
+func (t *OffsetWorkPlaneTool) CanCommit() bool { return t.hasBase && t.distance != 0 }
 
 // Commit creates the offset work plane at the entered distance and recomputes.
 func (t *OffsetWorkPlaneTool) Commit(s *Session) error {
 	s.Selection().SetFilter(t.prev)
-	if t.base == nil {
-		return errors.New("offset plane: no base plane picked")
+	if !t.hasBase {
+		return errors.New("offset plane: no base plane or face picked")
 	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
-	d := t.distance
-	t.added = finishWorkPlane(part, part.WorkPlanes().AddByPlaneAndOffset(t.base.Key(), func() float64 { return d }))
+	d, ref := t.distance, t.baseRef
+	t.added = finishWorkPlane(part, part.WorkPlanes().AddByPlaneAndOffset(ref, func() float64 { return d }))
 	return nil
 }
 
@@ -76,7 +82,7 @@ func (t *OffsetWorkPlaneTool) Cancel(s *Session) { s.Selection().SetFilter(t.pre
 
 // Prompt guides the user through the two steps (Inventor's status-bar prompts).
 func (t *OffsetWorkPlaneTool) Prompt(*Session) string {
-	if t.base == nil {
+	if !t.hasBase {
 		return "Select a plane or planar face to offset from"
 	}
 	return "Enter the offset distance, then click OK"

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -73,18 +73,8 @@ func (p *RayPicker) SetCamera(c scene.Camera) { p.camera = c }
 // profiles (the append order), so a solid in front wins over the sketch on its face.
 func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, bool) {
 	origin, dir := p.camera.RayThrough(x, y)
-	// Precise datum snaps win first: a point, then an axis, the cursor lands on is the
-	// target the user is aiming at, even with a face behind it (Inventor's snap order).
-	if pt, _ := p.nearestPoint(origin, dir); pt != nil && filter.Accepts(SelectWorkPoint) {
-		return WorkPointHandle{Point: pt}, true
-	}
-	if ax, _ := p.nearestAxis(origin, dir); ax != nil && filter.Accepts(SelectWorkAxis) {
-		return WorkAxisHandle{Axis: ax}, true
-	}
-	// A body edge the cursor lands on (within the snap radius) wins over the face behind it,
-	// matching Inventor's edge snap — needed for chamfer/fillet/dress-up edge picks.
-	if e := p.nearestEdge(origin, dir); e != nil && filter.Accepts(SelectEdge) {
-		return EdgeHandle{Edge: e}, true
+	if sel, ok := p.snapPick(origin, dir, filter); ok {
+		return sel, true
 	}
 	var cands []pickCandidate
 	if face, body, t := p.nearestFace(origin, dir); face != nil {
@@ -99,6 +89,25 @@ func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, boo
 		cands = append(cands, pickCandidate{t, sel})
 	}
 	return nearestCandidate(cands)
+}
+
+// snapPick returns the precise snap the cursor lands on — a datum point, datum axis, body
+// vertex, then edge — each winning over the face behind it (Inventor's snap order). These
+// are exact targets (within the pixel-snap radius), so the first accepted one wins.
+func (p *RayPicker) snapPick(origin math.Point3, dir math.Vector3, filter *SelectionFilter) (Selectable, bool) {
+	if pt, _ := p.nearestPoint(origin, dir); pt != nil && filter.Accepts(SelectWorkPoint) {
+		return WorkPointHandle{Point: pt}, true
+	}
+	if ax, _ := p.nearestAxis(origin, dir); ax != nil && filter.Accepts(SelectWorkAxis) {
+		return WorkAxisHandle{Axis: ax}, true
+	}
+	if v := p.nearestVertex(origin, dir); v != nil && filter.Accepts(SelectVertex) {
+		return VertexHandle{Vertex: v}, true
+	}
+	if e := p.nearestEdge(origin, dir); e != nil && filter.Accepts(SelectEdge) {
+		return EdgeHandle{Edge: e}, true
+	}
+	return nil, false
 }
 
 // pickCandidate is one ray hit: its forward parameter and the selectable it resolves to.
@@ -182,6 +191,27 @@ func (p *RayPicker) nearestFace(origin math.Point3, dir math.Vector3) (*topo.Fac
 		}
 	}
 	return hitFace, hitBody, best
+}
+
+// nearestVertex returns the closest body vertex within the pixel-snap radius of the ray
+// (nearest by ray depth on ties), or nil — the hit-test for picking model vertices (e.g. a
+// three-point work plane through solid corners).
+func (p *RayPicker) nearestVertex(origin math.Point3, dir math.Vector3) *topo.Vertex {
+	tol := pickPixelRadius * p.camera.WorldPerPixel()
+	var hit *topo.Vertex
+	best := stdmath.Inf(1)
+	for _, b := range p.bodies() {
+		for _, v := range b.Vertices() {
+			t := origin.VectorTo(v.Point()).Dot(dir)
+			if t <= 0 || t >= best {
+				continue
+			}
+			if origin.TranslateBy(dir.Scale(t)).DistanceTo(v.Point()) <= tol {
+				best, hit = t, v
+			}
+		}
+	}
+	return hit
 }
 
 // nearestEdge returns the closest body edge whose polyline passes within the pixel-snap

--- a/app/raypicker_edge_test.go
+++ b/app/raypicker_edge_test.go
@@ -31,6 +31,26 @@ func TestRayPickerSelectsEdge(t *testing.T) {
 	}
 }
 
+// TestRayPickerSelectsVertex aims a ray straight at a box corner and checks the picker
+// returns that vertex — the path the three-point-plane tool relies on (the RayPicker had no
+// vertex picking, so model-vertex selection silently did nothing in the head).
+func TestRayPickerSelectsVertex(t *testing.T) {
+	s := extrudedBox(t, 2, 4) // box [0,2]×[0,2]×[0,4]
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(10, 0, 0)
+	cam.Target = math.P3(2, 0, 0)
+	p := NewRayPicker(cam, partBodies(s))
+
+	dir, _ := math.UnitVector3FromVector(math.V3(-1, 0, 0))
+	v := p.nearestVertex(math.P3(10, 0, 0), dir.AsVector()) // straight at the (2,0,0) corner
+	if v == nil {
+		t.Fatal("nearestVertex found no vertex aiming at the (2,0,0) corner")
+	}
+	if !v.Point().IsEqualTo(math.P3(2, 0, 0), 1e-9) {
+		t.Errorf("picked vertex %v, want (2,0,0)", v.Point())
+	}
+}
+
 // TestRayPickerEdgeFilter checks the edge pick is gated by the filter: a face-only filter
 // near an edge does not return an edge (it falls through to the face).
 func TestRayPickerEdgeFilter(t *testing.T) {

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -361,3 +361,30 @@ func TestWorkFeatureRibbonCommandsRegistered(t *testing.T) {
 		}
 	}
 }
+
+// TestOffsetWorkPlaneFromFace offsets a work plane from a picked planar face: the box's top
+// face (z=4) offset by 2 lands at z=6. Regression for the offset-plane tool ignoring face
+// picks (it filtered/handled work planes only, despite its "or planar face" prompt).
+func TestOffsetWorkPlaneFromFace(t *testing.T) {
+	s := extrudedBox(t, 2, 4) // box, top face at z=4
+	body := partBodies(s)()[0]
+	top := topFaceOf(t, body)
+
+	tool := NewOffsetWorkPlaneTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{Face: top, Body: body})
+	if !tool.BasePicked() {
+		t.Fatal("offset tool did not accept the picked planar face")
+	}
+	tool.SetDistance(2)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	wp := tool.AddedPlane()
+	if wp == nil {
+		t.Fatal("no plane created")
+	}
+	if z := wp.Plane().Origin().Z; z < 6-1e-9 || z > 6+1e-9 {
+		t.Errorf("offset-from-face plane Z = %g, want 6 (4 + 2)", z)
+	}
+}

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -141,6 +141,9 @@ func (g *WorkGeometry) seedOrigin() {
 
 // plane/axis/point implement workResolver, resolving a ref to its current geometry.
 func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
+	if pl, isFace, err := g.facePlane(ref); isFace {
+		return pl, err // a planar B-rep face used as a plane input (offset-from-face, etc.)
+	}
 	if i, ok := userIndex(ref, "plane"); ok {
 		if i < 0 || i >= g.planes.Count() {
 			return sketch.Plane{}, fmt.Errorf("work geometry: no work plane %q", ref)

--- a/model/feature/work_plane_parity_test.go
+++ b/model/feature/work_plane_parity_test.go
@@ -283,3 +283,24 @@ func triangleBody(t *testing.T) (*topo.Body, [3][]byte) {
 	bld.AddFace(pl, topo.NewLineage(topo.Tok("f", "face", 0)), topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
 	return bld.Build(), [3][]byte{a.ReferenceKey(), b.ReferenceKey(), c.ReferenceKey()}
 }
+
+// TestOffsetPlaneFromFace offsets a work plane from a planar B-rep face (FaceRef as the
+// base of AddByPlaneAndOffset): a face at z=3 (+Z) offset by 2 lands at z=5. Regression for
+// plane references not resolving a planar face (the offset-from-face work-plane bug).
+func TestOffsetPlaneFromFace(t *testing.T) {
+	g := NewWorkGeometry()
+	pl, err := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, key := faceBody(t, pl)
+	g.Recompute([]*topo.Body{body})
+	wp := g.WorkPlanes().AddByPlaneAndOffset(FaceRef(key), func() float64 { return 2 })
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("offset-from-face sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) {
+		t.Errorf("offset-from-face origin = %v, want (0,0,5)", wp.Plane().Origin())
+	}
+}

--- a/model/feature/work_surface_ref.go
+++ b/model/feature/work_surface_ref.go
@@ -9,7 +9,29 @@ import (
 
 	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
 )
+
+// facePlane resolves a planar B-rep face WorkRef to a sketch plane, so a picked planar face
+// can serve anywhere a plane reference is accepted (offset-from-face, midplane, …). The bool
+// is false when ref is not a face reference (the caller falls through to its other kinds); a
+// face that is non-planar or no longer binds is an error.
+func (g *WorkGeometry) facePlane(ref WorkRef) (sketch.Plane, bool, error) {
+	_, isFace, err := parseFaceRef(ref)
+	if !isFace || err != nil {
+		return sketch.Plane{}, isFace, err
+	}
+	surf, err := g.surface(ref)
+	if err != nil {
+		return sketch.Plane{}, true, err
+	}
+	pl, ok := surf.(geom.Plane)
+	if !ok {
+		return sketch.Plane{}, true, fmt.Errorf("work geometry: face %q is not planar", ref)
+	}
+	sp, err := sketch.NewPlane(pl.Origin, pl.UAxis, pl.VAxis)
+	return sp, true, err
+}
 
 // Surface-tangent work planes are built on a B-rep face the user picked, not on
 // another work feature. A face is named by its persistent topological reference key


### PR DESCRIPTION
Two more selection bugs in the work-plane tools (siblings of the edge-picking fix #41).

### 1. Vertex selection did nothing (e.g. three-point plane through cube corners)
`RayPicker` had no vertex hit-test — it picked datum WorkPoints but not **body vertices** — so the `SelectVertex` filter never matched. Added `RayPicker.nearestVertex` (closest body vertex within the pixel-snap radius) to the snap-priority picks (vertex, then edge, both winning over the face behind them). Extracted the snap chain into `snapPick` (funlen).

### 2. "Plane from a face reference" couldn't pick a face
The Offset Plane tool filtered/handled **work planes only**, despite its "*or planar face*" prompt, and `WorkGeometry.plane()` didn't resolve a face reference. Now:
- `plane()` falls through to **`facePlane`** — a planar B-rep face used as a plane input, via the existing face→surface resolver — so `AddByPlaneAndOffset` (and every plane-based constructor) accepts a `FaceRef`;
- `OffsetWorkPlaneTool` accepts a `FaceHandle` (base held as a `WorkRef`: a plane key or a `FaceRef`).

## Tests

- app: `TestRayPickerSelectsVertex`, `TestOffsetWorkPlaneFromFace` (face z=4 offset 2 → z=6).
- model: `TestOffsetPlaneFromFace` (a `FaceRef` base resolves and offsets).

`go test ./...`, vet, lint, `-race` green; head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)