### PR TITLE
M20 F03: Fillet — real rolling-ball blend with cylinder faces + UI (DoD)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -116,6 +116,12 @@ func cutFeatureCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("chamfer").WithButtonStyle(LargeIconButton).
 			WithTooltip("Chamfer — bevel selected edges by a setback distance."),
+		NewCommand("Modify.Fillet", "Fillet", "Modify", func(s *Session) error {
+			s.StartTool(NewFilletTool())
+			return nil
+		}).WithTab("3D Model").WithAlias("F").WithEnable(notInSketch).
+			WithIcon("fillet").WithButtonStyle(LargeIconButton).
+			WithTooltip("Fillet — round selected convex edges with a rolling-ball radius."),
 	}
 }
 

--- a/app/fillet_session.go
+++ b/app/fillet_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Fillet tool's property window.
+
+// ActiveFillet returns the running Fillet tool, or nil when the active tool is not a fillet
+// (or there is none).
+func (s *Session) ActiveFillet() *FilletTool {
+	if s.tool == nil {
+		return nil
+	}
+	f, _ := s.tool.tool.(*FilletTool)
+	return f
+}

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// FilletTool is the interactive Fillet command: activate it, click one or more convex edges,
+// set the radius in the property window, and OK to round them. Each picked edge becomes a
+// rolling-ball cylinder blend on the active part.
+type FilletTool struct {
+	edges  []EdgeHandle
+	radius float64
+	added  *feature.PartFeature
+}
+
+// NewFilletTool returns a fillet tool with a default 1-unit radius.
+func NewFilletTool() *FilletTool { return &FilletTool{radius: 1} }
+
+// Name implements [Tool].
+func (t *FilletTool) Name() string { return "Fillet" }
+
+// Start sets the selection filter to edges so clicks pick edges to round.
+func (t *FilletTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+
+// Pick appends the clicked edge (ignoring one already chosen).
+func (t *FilletTool) Pick(_ *Session, sel Selectable) {
+	e, ok := sel.(EdgeHandle)
+	if !ok || t.hasEdge(e) {
+		return
+	}
+	t.edges = append(t.edges, e)
+}
+
+func (t *FilletTool) hasEdge(e EdgeHandle) bool {
+	for _, h := range t.edges {
+		if h == e {
+			return true
+		}
+	}
+	return false
+}
+
+// SetRadius/Radius set the fillet radius (database units).
+func (t *FilletTool) SetRadius(r float64) { t.radius = r }
+func (t *FilletTool) Radius() float64     { return t.radius }
+
+// Edges returns the picked edges (for the UI to list/highlight).
+func (t *FilletTool) Edges() []EdgeHandle { return append([]EdgeHandle(nil), t.edges...) }
+
+// CanCommit reports whether at least one edge is picked and the radius is positive.
+func (t *FilletTool) CanCommit() bool { return len(t.edges) > 0 && t.radius > 0 }
+
+// Commit rounds the picked edges on the active part and recomputes; a sick feature (a
+// non-convex edge or a radius that overruns the geometry) keeps the tool open via an error.
+func (t *FilletTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	keys := make([][]byte, len(t.edges))
+	for i, e := range t.edges {
+		keys[i] = e.Edge.ReferenceKey()
+	}
+	r := t.radius
+	t.added = feature.NewDressUpFeatures(part.Features()).AddFillet(keys, func() float64 { return r })
+	part.Recompute()
+	if !t.added.Health().OK() {
+		return errors.New("fillet: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *FilletTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// Prompt guides the user through the fillet steps.
+func (t *FilletTool) Prompt(*Session) string {
+	if len(t.edges) == 0 {
+		return "Click one or more edges to fillet"
+	}
+	return "Set the radius, then click OK"
+}
+
+// Cancel restores the default selection filter.
+func (t *FilletTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }

--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// TestFilletToolEndToEnd drives the Fillet UI: start the tool, click a vertical edge of a
+// 2×2×2 block, set the radius, OK — and asserts a valid solid with a cylinder face and the
+// rolling-ball volume. r=0.5, edge length 2: 8 − (r²−πr²/4)·2.
+func TestFilletToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 2) // 2×2×2, vol 8
+	edge := verticalEdgeOf(t, block)
+	s.SetPicker(stubPicker{sel: edge})
+
+	f := NewFilletTool()
+	s.StartTool(f)
+	s.Click(50, 50)
+	f.SetRadius(0.5)
+	if !f.CanCommit() {
+		t.Fatal("fillet not ready after edge + radius")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("filleted body not a valid solid: %+v", r)
+	}
+	cyls := 0
+	for _, fc := range body.Faces() {
+		if _, ok := fc.Geometry().(geom.Cylinder); ok {
+			cyls++
+		}
+	}
+	if cyls != 1 {
+		t.Errorf("filleted body has %d cylinder faces, want 1", cyls)
+	}
+	want := 8 - (0.5*0.5-stdmath.Pi*0.25*0.25)*2
+	if got := ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-4}).Volume; relErrApp(got, want) > 1e-3 {
+		t.Errorf("fillet volume = %g, want ≈ %g", got, want)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestFilletViaRibbonCommand drives the Fillet from its ribbon command/alias.
+func TestFilletViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.Fillet"); err != nil {
+		t.Fatalf("execute Modify.Fillet: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*FilletTool); !ok {
+		t.Fatal("Fillet command did not start the fillet tool")
+	}
+	s.Click(1, 1)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if v := ops.BodyGeometryProperties(activePartDef(t, s).SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; v >= 8 {
+		t.Errorf("fillet did not round material: volume %g, want < 8", v)
+	}
+}
+
+// TestFilletToolNeedsEdge checks the tool is not committable until an edge is picked.
+func TestFilletToolNeedsEdge(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	f := NewFilletTool()
+	s.StartTool(f)
+	if f.CanCommit() {
+		t.Error("fillet ready with no edge picked")
+	}
+	s.Click(0, 0)
+	if !f.CanCommit() {
+		t.Error("fillet not ready after picking an edge")
+	}
+}

--- a/head/icon/assets/fillet.svg
+++ b/head/icon/assets/fillet.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20 V12 A8 8 0 0 1 12 4 H20"/><path d="M4 4 H8 M4 4 V8" stroke-dasharray="2 2"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -55,6 +55,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawSweepDialog(s)
 	drawHoleDialog(s)
 	drawChamferDialog(s)
+	drawFilletDialog(s)
 	drawShellDialog(s)
 	drawFaceOffsetDialog(s)
 	drawDraftDialog(s)

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// The Fillet flow in the head: while the Fillet tool runs, a modeless options window shows
+// the picked-edge count and the blend radius (database units), then OK/Cancel.
+var filletUI = struct {
+	radius float32
+	open   bool
+}{radius: 1}
+
+// drawFilletDialog shows the fillet options window while the Fillet tool is active.
+func drawFilletDialog(s *app.Session) {
+	f := s.ActiveFillet()
+	if f == nil {
+		filletUI.open = false
+		return
+	}
+	if !filletUI.open {
+		filletUI.radius = float32(f.Radius())
+		filletUI.open = true
+	}
+	native.SetNextWindowSize(300, 160)
+	if native.Begin("Fillet") {
+		native.Text("Edges: " + strconv.Itoa(len(f.Edges())) + " (click convex edges to round)")
+		native.Text("Radius (" + s.LengthUnitName() + ")")
+		native.InputFloat("##fillet-radius", &filletUI.radius)
+		f.SetRadius(float64(filletUI.radius))
+		native.BeginDisabled(!f.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/kernel/ops/assemble_curved.go
+++ b/kernel/ops/assemble_curved.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// filletLoop is one boundary loop of a face as a ring of points with the curve along each
+// segment: curves[i] runs pts[i]→pts[(i+1)%n], or nil for a straight line. (Used to build
+// curved-faced results like fillets, where some edges are arcs.)
+type filletLoop struct {
+	pts    []math.Point3
+	curves []geom.Curve3
+}
+
+// filletFace is a result face: its surface (plane, cylinder, …) and boundary loops (outer
+// first).
+type filletFace struct {
+	surface geom.Surface
+	loops   []filletLoop
+}
+
+// edgeRec remembers a built shared edge and the direction it was stored in, so a second
+// face referencing the same vertex pair gets it reversed.
+type edgeRec struct {
+	edge     *topo.Edge
+	from, to int
+}
+
+// assembleBody welds the faces' loop points into a watertight body: one shared edge per
+// undirected vertex pair (carrying the curve the first user supplied, oriented its way), and
+// a face per surface. A closed result (every edge used twice) is a solid. Curves let a face
+// carry arc edges (a fillet's end arcs) alongside straight ones.
+func assembleBody(faces []filletFace, tag string) *topo.Body {
+	w := newPointWelder()
+	rings := make([][][]int, len(faces))
+	for i, f := range faces {
+		for _, l := range f.loops {
+			rings[i] = append(rings[i], w.weldRing(l.pts))
+		}
+	}
+	bld := topo.NewBuilder(curvedSolid(faces, rings, w.points), topo.NewLineage(topo.Tok(tag, "body", 0)))
+	tv := make([]*topo.Vertex, len(w.points))
+	for i, p := range w.points {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(tag, "v", i)))
+	}
+	ec := &edgeCatalog{bld: bld, verts: w.points, tv: tv, edges: map[[2]int]edgeRec{}, tag: tag}
+	for fi, f := range faces {
+		specs := make([]topo.LoopSpec, len(f.loops))
+		for li, ring := range rings[fi] {
+			specs[li] = curvedLoopSpec(li == 0, ring, f.loops[li].curves, ec)
+		}
+		bld.AddFace(f.surface, topo.NewLineage(topo.Tok(tag, "f", fi)), specs...)
+	}
+	return bld.Build()
+}
+
+// curvedSolid reports whether every undirected edge of the faces is used exactly twice (the
+// combinatorial test for a closed solid), computed before assembly to set the builder mode.
+func curvedSolid(faces []filletFace, rings [][][]int, _ []math.Point3) bool {
+	use := map[[2]int]int{}
+	for fi := range faces {
+		for _, ring := range rings[fi] {
+			for k := 0; k < len(ring); k++ {
+				use[canon2(ring[k], ring[(k+1)%len(ring)])]++
+			}
+		}
+	}
+	for _, c := range use {
+		if c != 2 {
+			return false
+		}
+	}
+	return true
+}
+
+// edgeCatalog creates one shared topo edge per undirected vertex pair on demand, reusing it
+// (reversed) for the second face.
+type edgeCatalog struct {
+	bld   *topo.Builder
+	verts []math.Point3
+	tv    []*topo.Vertex
+	edges map[[2]int]edgeRec
+	tag   string
+}
+
+// use returns the loop use for the directed segment a→b with the given curve (nil ⇒ a line),
+// creating the shared edge the first time in its a→b direction.
+func (c *edgeCatalog) use(a, b int, curve geom.Curve3) topo.Use {
+	key := canon2(a, b)
+	if rec, ok := c.edges[key]; ok {
+		return topo.Use{Edge: rec.edge, Reversed: rec.from != a}
+	}
+	if curve == nil {
+		curve = geom.NewLineSegment(c.verts[a], c.verts[b])
+	}
+	e := c.bld.AddEdge(curve, c.tv[a], c.tv[b], topo.NewLineage(topo.Tok(c.tag, "e", len(c.edges))))
+	c.edges[key] = edgeRec{edge: e, from: a, to: b}
+	return topo.Use{Edge: e, Reversed: false}
+}
+
+// curvedLoopSpec builds a face loop from a ring of welded indices and the per-segment curves.
+func curvedLoopSpec(outer bool, ring []int, curves []geom.Curve3, ec *edgeCatalog) topo.LoopSpec {
+	uses := make([]topo.Use, len(ring))
+	for k := range ring {
+		uses[k] = ec.use(ring[k], ring[(k+1)%len(ring)], curveAt(curves, k))
+	}
+	if outer {
+		return topo.OuterLoop(uses...)
+	}
+	return topo.InnerLoop(uses...)
+}
+
+// curveAt returns curves[k] if present, else nil (a straight segment).
+func curveAt(curves []geom.Curve3, k int) geom.Curve3 {
+	if k < len(curves) {
+		return curves[k]
+	}
+	return nil
+}

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// FilletEdges rounds the selected convex straight edges of a planar solid with a constant-
+// radius rolling-ball blend: each edge between two planar faces is replaced by a cylinder
+// face of radius r tangent to both, the two faces are retrimmed back to the tangent lines,
+// and the end faces gain a quarter-arc at the rounded corner. All edges are resolved and
+// solved on the original body, then applied in a single rebuild, so independent edges that
+// share a face (e.g. the four verticals of a box) all retrim that face correctly. Convex,
+// straight edges with one extra face at each end (box/prism edges); chains, corners where
+// fillets meet, and concave edges are follow-ups.
+func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, error) {
+	if r <= 0 {
+		return nil, fmt.Errorf("fillet: radius %g must be > 0", r)
+	}
+	fils := make([]edgeFillet, 0, len(edgeKeys))
+	for _, k := range edgeKeys {
+		e, ok := body.FindEdgeByKey(k)
+		if !ok {
+			return nil, fmt.Errorf("fillet: edge reference lost: %x", k)
+		}
+		ef, err := computeEdgeFillet(body, e, r)
+		if err != nil {
+			return nil, err
+		}
+		fils = append(fils, ef)
+	}
+	res := assembleBody(filletResultFaces(body, fils), "fillet")
+	if rep := Validate(res); !rep.Valid || !res.IsSolid() {
+		return nil, fmt.Errorf("fillet: result is not a valid solid %v", rep.Issues)
+	}
+	return res, nil
+}
+
+// corner is one rounded end of a filleted edge: the cylinder centre at that end, the tangent
+// points on faces a/b, and the arc midpoint (the cylinder point nearest the sharp corner).
+type corner struct {
+	a, b    *topo.Face
+	cen     math.Point3 // cylinder centre at this end
+	ta, tb  math.Point3
+	mid     math.Point3
+	endFace *topo.Face
+	vertex  *topo.Vertex
+}
+
+// tOf returns the tangent point on face f (a or b).
+func (c corner) tOf(f *topo.Face) math.Point3 {
+	if f == c.a {
+		return c.ta
+	}
+	return c.tb
+}
+
+// edgeFillet is a fully solved fillet of one edge: its two faces, the cylinder, and the two
+// rounded corners.
+type edgeFillet struct {
+	a, b   *topo.Face
+	cyl    geom.Cylinder
+	c0, c1 corner
+	edge   *topo.Edge
+}
+
+// computeEdgeFillet solves the rolling-ball geometry for one convex straight edge.
+func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64) (edgeFillet, error) {
+	a, b, nA, nB, err := edgePlanarFaces(e)
+	if err != nil {
+		return edgeFillet{}, err
+	}
+	axis, err := math.UnitVector3FromVector(e.StartVertex().Point().VectorTo(e.EndVertex().Point()))
+	if err != nil {
+		return edgeFillet{}, fmt.Errorf("fillet: degenerate edge")
+	}
+	off := nA.Add(nB).Scale(-r / (1 + nA.Dot(nB))) // centre offset from the edge into the solid
+	mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point())
+	if !PointInsideBody(body, mid.TranslateBy(off)) { // convex ⇒ the rolling-ball centre is inside
+		return edgeFillet{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
+	}
+	c0, err := cornerAt(e.StartVertex(), a, b, nA, nB, off, r)
+	if err != nil {
+		return edgeFillet{}, err
+	}
+	c1, err := cornerAt(e.EndVertex(), a, b, nA, nB, off, r)
+	if err != nil {
+		return edgeFillet{}, err
+	}
+	cyl, err := geom.NewCylinder(c0.cen, axis.AsVector(), r)
+	if err != nil {
+		return edgeFillet{}, err
+	}
+	return edgeFillet{a: a, b: b, cyl: cyl, c0: c0, c1: c1, edge: e}, nil
+}
+
+// edgePlanarFaces returns the edge's two faces and their outward normals, erroring unless
+// the edge bounds exactly two planar faces.
+func edgePlanarFaces(e *topo.Edge) (a, b *topo.Face, nA, nB math.Vector3, err error) {
+	faces := e.Faces()
+	if len(faces) != 2 {
+		return nil, nil, nA, nB, fmt.Errorf("fillet: edge bounds %d faces, need 2", len(faces))
+	}
+	pa, oka := faces[0].Geometry().(geom.Plane)
+	pb, okb := faces[1].Geometry().(geom.Plane)
+	if !oka || !okb {
+		return nil, nil, nA, nB, fmt.Errorf("fillet: both faces of the edge must be planar")
+	}
+	return faces[0], faces[1], pa.Normal(), pb.Normal(), nil
+}
+
+// cornerAt solves a fillet corner at vertex v: the centre (v + off), the tangent points on
+// the two faces, the arc midpoint, and the end face (the face at v other than a/b).
+func cornerAt(v *topo.Vertex, a, b *topo.Face, nA, nB math.Vector3, off math.Vector3, r float64) (corner, error) {
+	c := v.Point().TranslateBy(off)
+	end := endFaceAt(v, a, b)
+	if end == nil {
+		return corner{}, fmt.Errorf("fillet: edge endpoint has no end face to round")
+	}
+	toward, err := math.UnitVector3FromVector(c.VectorTo(v.Point()))
+	if err != nil {
+		return corner{}, fmt.Errorf("fillet: degenerate corner")
+	}
+	return corner{
+		a: a, b: b, endFace: end, vertex: v, cen: c,
+		ta:  c.TranslateBy(nA.Scale(r)),
+		tb:  c.TranslateBy(nB.Scale(r)),
+		mid: c.TranslateBy(toward.AsVector().Scale(r)),
+	}, nil
+}
+
+// endFaceAt returns the face meeting at v that is neither a nor b (the end cap the fillet
+// rounds), or nil if there is none.
+func endFaceAt(v *topo.Vertex, a, b *topo.Face) *topo.Face {
+	for _, e := range v.Edges() {
+		for _, f := range e.Faces() {
+			if f != a && f != b {
+				return f
+			}
+		}
+	}
+	return nil
+}

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// filletResultFaces builds the faces of the filleted body: every original face transformed
+// for the fillets touching it (its A/B corners pulled back to the tangent points, its end
+// corners replaced by an arc), plus one cylinder face per filleted edge.
+func filletResultFaces(body *topo.Body, fils []edgeFillet) []filletFace {
+	abSubst, endCorner := filletMaps(fils)
+	var out []filletFace
+	for _, f := range body.Faces() {
+		out = append(out, transformFace(f, abSubst[f], endCorner[f]))
+	}
+	for _, ef := range fils {
+		out = append(out, cylinderFace(ef))
+	}
+	return out
+}
+
+// filletMaps indexes, per face: the corner-vertex → tangent-point pullbacks (where the face
+// is a fillet's A or B face), and the corner-vertex → corner arc (where it is the end face).
+func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*topo.Face]map[uint64]corner) {
+	ab := map[*topo.Face]map[uint64]math.Point3{}
+	ends := map[*topo.Face]map[uint64]corner{}
+	put := func(m map[*topo.Face]map[uint64]math.Point3, f *topo.Face, id uint64, p math.Point3) {
+		if m[f] == nil {
+			m[f] = map[uint64]math.Point3{}
+		}
+		m[f][id] = p
+	}
+	for _, ef := range fils {
+		for _, c := range []corner{ef.c0, ef.c1} {
+			put(ab, c.a, c.vertex.ID(), c.ta)
+			put(ab, c.b, c.vertex.ID(), c.tb)
+			if ends[c.endFace] == nil {
+				ends[c.endFace] = map[uint64]corner{}
+			}
+			ends[c.endFace][c.vertex.ID()] = c
+		}
+	}
+	return ab, ends
+}
+
+// transformFace rebuilds a face's loops, pulling A/B corners to their tangent points and
+// expanding each end corner into a tangent-point-to-tangent-point arc. A face untouched by
+// any fillet is copied unchanged.
+func transformFace(f *topo.Face, subs map[uint64]math.Point3, ends map[uint64]corner) filletFace {
+	ff := filletFace{surface: f.Geometry()}
+	for _, l := range f.Loops() {
+		ff.loops = append(ff.loops, transformLoop(f, l, subs, ends))
+	}
+	return ff
+}
+
+// transformLoop walks a loop's edge uses and applies the per-vertex fillet substitutions.
+func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends map[uint64]corner) filletLoop {
+	uses := l.EdgeUses()
+	n := len(uses)
+	var fl filletLoop
+	for i, u := range uses {
+		v := useFromVertex(u)
+		switch {
+		case ends != nil && hasCorner(ends, v):
+			c := ends[v.ID()]
+			tIn := c.tOf(otherFace(uses[(i-1+n)%n].Edge(), f))
+			tOut := c.tOf(otherFace(u.Edge(), f))
+			arc, _ := geom.Arc3dByThreePoints(tIn, c.mid, tOut)
+			fl.add(tIn, arc)
+			fl.add(tOut, nil)
+		case subs != nil && hasSubst(subs, v):
+			fl.add(subs[v.ID()], nil)
+		default:
+			fl.add(v.Point(), nil)
+		}
+	}
+	return fl
+}
+
+func hasCorner(ends map[uint64]corner, v *topo.Vertex) bool { _, ok := ends[v.ID()]; return ok }
+func hasSubst(subs map[uint64]math.Point3, v *topo.Vertex) bool {
+	_, ok := subs[v.ID()]
+	return ok
+}
+
+// add appends a point and the curve of the segment leaving it (nil ⇒ straight).
+func (l *filletLoop) add(p math.Point3, curve geom.Curve3) {
+	l.pts = append(l.pts, p)
+	l.curves = append(l.curves, curve)
+}
+
+// useFromVertex returns the from-vertex of an edge use (honouring reversal).
+func useFromVertex(u *topo.EdgeUse) *topo.Vertex {
+	if u.Reversed() {
+		return u.Edge().EndVertex()
+	}
+	return u.Edge().StartVertex()
+}
+
+// otherFace returns the face sharing edge e that is not f.
+func otherFace(e *topo.Edge, f *topo.Face) *topo.Face {
+	for _, g := range e.Faces() {
+		if g != f {
+			return g
+		}
+	}
+	return nil
+}
+
+// cylinderFace builds the rolling-ball cylinder face: tangent line on A, end arc, tangent
+// line on B, end arc — wound so its geometric normal matches the cylinder's outward radial.
+func cylinderFace(ef edgeFillet) filletFace {
+	c0, c1 := ef.c0, ef.c1
+	arc1, _ := geom.Arc3dByThreePoints(c1.ta, c1.mid, c1.tb) // TA1 → TB1 at end 1
+	arc0, _ := geom.Arc3dByThreePoints(c0.tb, c0.mid, c0.ta) // TB0 → TA0 at end 0
+	loop := filletLoop{
+		pts:    []math.Point3{c0.ta, c1.ta, c1.tb, c0.tb},
+		curves: []geom.Curve3{nil, arc1, nil, arc0},
+	}
+	if cylinderLoopFlipped(ef.cyl, loop) {
+		loop = reverseFilletLoop(loop, ef)
+	}
+	return filletFace{surface: ef.cyl, loops: []filletLoop{loop}}
+}
+
+// cylinderLoopFlipped reports whether the loop winds against the cylinder's outward normal at
+// the first end arc's midpoint (so it should be reversed for a consistent, outward face).
+func cylinderLoopFlipped(cyl geom.Cylinder, loop filletLoop) bool {
+	a, b, c := loop.pts[0], loop.pts[1], loop.pts[2]
+	n := a.VectorTo(b).Cross(a.VectorTo(c))
+	u, v := cyl.ParamAt(centroidPts(loop.pts))
+	return n.Dot(cyl.NormalAt(u, v)) < 0
+}
+
+// reverseFilletLoop reverses the cylinder loop (and rebuilds its arcs in the new direction).
+func reverseFilletLoop(_ filletLoop, ef edgeFillet) filletLoop {
+	c0, c1 := ef.c0, ef.c1
+	arc0, _ := geom.Arc3dByThreePoints(c0.ta, c0.mid, c0.tb) // TA0 → TB0
+	arc1, _ := geom.Arc3dByThreePoints(c1.tb, c1.mid, c1.ta) // TB1 → TA1
+	return filletLoop{
+		pts:    []math.Point3{c0.ta, c0.tb, c1.tb, c1.ta},
+		curves: []geom.Curve3{arc0, nil, arc1, nil},
+	}
+}

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// verticalEdgeKey returns a vertical edge (start/end share X,Y) of a box.
+func verticalEdgeKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, e := range b.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			return e.ReferenceKey()
+		}
+	}
+	t.Fatal("no vertical edge")
+	return nil
+}
+
+// hasCylinderFace reports whether the body has at least n cylindrical faces.
+func hasCylinderFaces(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// filletNotch is the cross-section area a fillet of radius r removes at a convex 90° edge:
+// the square corner r² minus the quarter disc πr²/4.
+func filletNotch(r float64) float64 { return r*r - stdmath.Pi*r*r/4 }
+
+// TestFilletOneEdge rounds one vertical edge of a 2×2×2 box (r=0.5): a valid solid with one
+// cylinder face, volume 8 − (r²−πr²/4)·L (L=2). The headline rolling-ball-fillet acceptance.
+func TestFilletOneEdge(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	res, err := ops.FilletEdges(box, [][]byte{verticalEdgeKey(t, box)}, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("filleted box not a valid solid: %+v", r)
+	}
+	if n := hasCylinderFaces(res); n != 1 {
+		t.Errorf("filleted box has %d cylinder faces, want 1", n)
+	}
+	// The cylinder face is exact; the measured volume is its faceted approximation, so check
+	// at a fine tessellation tolerance where it has converged to the analytic value.
+	want := 8 - filletNotch(0.5)*2
+	if got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume; stdmath.Abs(got-want) > 1e-3 {
+		t.Errorf("fillet volume = %g, want ≈ %g", got, want)
+	}
+}
+
+// TestFilletFourVerticalEdges rounds all four vertical edges of a 2×2×2 box in one pass:
+// a validated manifold solid with four quarter-cylinder faces of radius 0.5 (the F03
+// acceptance). Volume 8 − 4·(r²−πr²/4)·L.
+func TestFilletFourVerticalEdges(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	var keys [][]byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	if len(keys) != 4 {
+		t.Fatalf("found %d vertical edges, want 4", len(keys))
+	}
+	res, err := ops.FilletEdges(box, keys, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("filleted box not a valid solid: %+v", r)
+	}
+	if n := hasCylinderFaces(res); n != 4 {
+		t.Errorf("filleted box has %d cylinder faces, want 4", n)
+	}
+	want := 8 - 4*filletNotch(0.5)*2
+	if got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume; stdmath.Abs(got-want) > 1e-3 {
+		t.Errorf("four-edge fillet volume = %g, want ≈ %g", got, want)
+	}
+}
+
+// TestFilletLostKeyErrors checks a non-convex (concave) edge is rejected rather than
+// producing garbage. A box has no concave edges, so a lost key stands in for the error path.
+func TestFilletLostKeyErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.FilletEdges(box, [][]byte{[]byte("ghost")}, 0.5); err == nil {
+		t.Error("fillet with a lost key should error")
+	}
+}
+
+// TestFilletRadiusMustBePositive guards the radius.
+func TestFilletRadiusMustBePositive(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.FilletEdges(box, [][]byte{verticalEdgeKey(t, box)}, 0); err == nil {
+		t.Error("zero radius should error")
+	}
+}

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/doc"
 	"github.com/Oblikovati/oblikovati/model/feature"
-	"github.com/Oblikovati/oblikovati/model/health"
 	"github.com/Oblikovati/oblikovati/model/param"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/persistence"
@@ -161,19 +160,20 @@ func TestFilletEdgeKeyRebindsAfterReopen(t *testing.T) {
 	fillet := feature.NewDressUpFeatures(def.Features()).
 		AddFillet([][]byte{edgeKey}, func() float64 { return 0.2 })
 	def.Recompute()
-	if fillet.Health().Status != health.Warning {
-		t.Fatalf("fillet health before save = %v, want Warning (edge resolved, geometry deferred)", fillet.Health().Status)
+	if !fillet.Health().OK() {
+		t.Fatalf("fillet health before save = %v, want OK (edge resolved, real blend built)", fillet.Health().Status)
 	}
 
 	reopened := reopenThroughStore(t, d)
 	// The reopened extrude regenerates the body with the same lineage, so the fillet's
-	// edge key must re-bind — proving reference keys survive save→reopen.
+	// edge key must re-bind and the blend rebuild — proving reference keys survive
+	// save→reopen (a lost key would make the fillet Sick).
 	got, ok := featureByKind(reopened.Features(), "fillet")
 	if !ok {
 		t.Fatal("fillet feature missing after reopen")
 	}
-	if got.Health().Status != health.Warning {
-		t.Errorf("fillet health after reopen = %v, want Warning (edge key must re-bind, not be lost/Sick)", got.Health().Status)
+	if !got.Health().OK() {
+		t.Errorf("fillet health after reopen = %v, want OK (edge key must re-bind, not be lost/Sick)", got.Health().Status)
 	}
 }
 

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -34,10 +34,10 @@ func (f *FilletFeature) Definition() *FilletDefinition { return f.def }
 // Kind implements [Feature].
 func (f *FilletFeature) Kind() string { return "fillet" }
 
-// Recompute resolves the picked edges against the running body, then defers the
-// rounding geometry.
+// Recompute rounds the picked convex edges on the running body with a real rolling-ball
+// blend (cylinder faces). See fillet.go.
 func (f *FilletFeature) Recompute(in Input) (Output, error) {
-	return resolveEdgesThenDefer(in, f.def.EdgeKeys, "fillet")
+	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), "fillet")
 }
 
 // ChamferDefinition bevels selected edges by a distance.
@@ -115,22 +115,9 @@ func (t *ThreadFeature) Recompute(in Input) (Output, error) {
 	return resolveFacesThenDefer(in, [][]byte{t.def.FaceKey}, "thread")
 }
 
-// resolveEdgesThenDefer resolves edge keys against the running body and, if all
-// bind, defers the geometry (passthrough + ErrDeferred); a lost key is a Sick error.
-func resolveEdgesThenDefer(in Input, keys [][]byte, kind string) (Output, error) {
-	body, err := runningBody(in)
-	if err != nil {
-		return Output{}, err
-	}
-	for _, k := range keys {
-		if _, ok := body.FindEdgeByKey(k); !ok {
-			return Output{}, fmt.Errorf("%s: edge reference lost", kind)
-		}
-	}
-	return Output{Bodies: in.Bodies}, ErrDeferred
-}
-
-// resolveFacesThenDefer is the face-input analogue.
+// resolveFacesThenDefer resolves face keys against the running body and, if all bind, defers
+// the geometry (passthrough + ErrDeferred); a lost key is a Sick error. (Still used by the
+// thread cosmetic feature.)
 func resolveFacesThenDefer(in Input, keys [][]byte, kind string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {

--- a/model/feature/dressup_test.go
+++ b/model/feature/dressup_test.go
@@ -82,18 +82,31 @@ func prismBody() *topo.Body {
 	return buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 1}}, sketch.XYPlane(), span{near: 0, far: 1}, 0, "ext")
 }
 
-func TestFilletResolvesEdgeThenDefers(t *testing.T) {
-	body := prismBody()
-	edgeKey := body.Edges()[0].ReferenceKey()
-
+// TestFilletRoundsEdgeForReal rounds a vertical edge of a 2×2×2 box (r=0.5) through the
+// feature engine: a healthy feature whose result is a valid solid with a cylinder face.
+func TestFilletRoundsEdgeForReal(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var edge []byte
+	for _, e := range box.Edges() {
+		if a, b := e.StartVertex().Point(), e.EndVertex().Point(); a.X == b.X && a.Y == b.Y {
+			edge = e.ReferenceKey()
+			break
+		}
+	}
 	fs := NewPartFeatures(nil, nil)
-	NewBaseFeatures(fs).AddBase(body) // running body the fillet operates on
-	fillet := NewDressUpFeatures(fs).AddFillet([][]byte{edgeKey}, func() float64 { return 0.2 })
+	NewBaseFeatures(fs).AddBase(box)
+	fillet := NewDressUpFeatures(fs).AddFillet([][]byte{edge}, func() float64 { return 0.5 })
 	fs.Recompute()
-
-	// The edge resolves → the feature is healthy-but-deferred (Warning), not sick.
-	if fillet.Health().Status != health.Warning {
-		t.Fatalf("fillet health = %v, want warning (input resolved, geometry deferred)", fillet.Health().Status)
+	if !fillet.Health().OK() {
+		t.Fatalf("fillet sick: %+v", fillet.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("filleted body not a valid solid: %+v", r)
+	}
+	want := 8 - (0.5*0.5-stdmath.Pi*0.25*0.25)*2
+	if got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume; relErr(got, want) > 1e-3 {
+		t.Errorf("fillet volume = %g, want ≈ %g", got, want)
 	}
 }
 

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// filletBody rounds the selected convex edges of the running body to the given radius via
+// ops.FilletEdges (a real rolling-ball blend with cylinder faces), replacing it in the body
+// list. A lost edge, a non-convex edge, or a non-positive radius is an error so the feature
+// goes Sick. See kernel/ops/fillet.go for the geometry.
+func filletBody(in Input, edgeKeys [][]byte, radius float64, feat string) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	if radius <= 0 {
+		return Output{}, fmt.Errorf("%s: radius %g must be > 0", feat, radius)
+	}
+	result, err := ops.FilletEdges(body, edgeKeys, radius)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}


### PR DESCRIPTION
The payoff of the curved-B-rep stack: a constant-radius **rolling-ball fillet** that emits a real **cylinder face** (not a faceted approximation), completing F03.

## Kernel — `ops.FilletEdges`

For each convex straight edge between two planar faces it solves the rolling-ball geometry — centre offset `−r(nA+nB)/(1+nA·nB)`, the tangent points on each face, and the quarter-arc at each end — then:
- replaces the edge with a **cylinder face** tangent to both faces,
- retrims the two faces back to the tangent lines,
- turns each end face's corner into an **arc**.

All edges are solved on the original body and applied in **one rebuild**, so independent edges that share a face (the four verticals of a box) all retrim that face. Built on a new **curved-loop assembler** (`assemble_curved.go`) that welds faces carrying per-face surfaces (plane/cylinder) and per-edge curves (arcs). Non-convex edges error (→ Sick). Chains, fillet-fillet corners, and concave edges are follow-ups.

## Model & UI

- `FilletFeature.Recompute` now builds the real blend (was deferred). Reference keys re-bind through save→reopen.
- **DoD UI:** `FilletTool` (pick edges, set radius), `Modify.Fillet` ribbon command (alias **F**), `head/ui/fillet_dialog.go`, `fillet.svg`.

## Tests

- kernel: one edge → valid solid + 1 cylinder face, vol `8−(r²−πr²/4)·L`; **four-edge box → 4 cylinder faces, vol 7.5708** (the F03 acceptance), both convergent under tessellation refinement; lost-key / radius guards.
- model: `TestFilletRoundsEdgeForReal`; the edge-key rebind round-trip now expects a healthy blend.
- app e2e: `TestFilletToolEndToEnd` / `ViaRibbonCommand` / `NeedsEdge`.

`go test ./...`, vet, lint, `-race` green; head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)