### PR TITLE
fix: fillet over corner edges fails loudly (clear error + status notice)

### DIFF
--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 )
 
 // TestFilletToolEndToEnd drives the Fillet UI: start the tool, click a vertical edge of a
@@ -71,6 +72,42 @@ func TestFilletViaRibbonCommand(t *testing.T) {
 	if v := ops.BodyGeometryProperties(activePartDef(t, s).SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; v >= 8 {
 		t.Errorf("fillet did not round material: volume %g, want < 8", v)
 	}
+}
+
+// TestFilletCornerEdgesSurfaceNotice checks that committing a fillet over edges that meet at
+// a corner (unsupported) fails loudly: the tool stays open and the session carries a notice
+// the status bar shows — so the user is not left with a silent "nothing happened".
+func TestFilletCornerEdgesSurfaceNotice(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	f := NewFilletTool()
+	s.StartTool(f)
+	for _, e := range cornerEdges(block) { // three edges meeting at one corner
+		f.Pick(s, EdgeHandle{Edge: e})
+	}
+	if err := s.OK(); err == nil {
+		t.Fatal("filleting corner edges should fail")
+	}
+	if s.ActiveTool() == nil {
+		t.Error("a failed commit should keep the fillet tool open")
+	}
+	if s.Notice() == "" {
+		t.Error("a failed commit should set a status-bar notice, not fail silently")
+	}
+	if v := ops.BodyGeometryProperties(activePartDef(t, s).SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, 8) > 1e-6 {
+		t.Errorf("body should be unchanged (vol 8) after a failed fillet, got %g", v)
+	}
+}
+
+// cornerEdges returns the three edges meeting at the (0,0,0) corner of a box.
+func cornerEdges(b *topo.Body) []*topo.Edge {
+	var out []*topo.Edge
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if (a.X == 0 && a.Y == 0 && a.Z == 0) || (c.X == 0 && c.Y == 0 && c.Z == 0) {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // TestFilletToolNeedsEdge checks the tool is not committable until an edge is picked.

--- a/app/session.go
+++ b/app/session.go
@@ -41,7 +41,12 @@ type Session struct {
 	themeStore      *theme.Store
 	materials       *material.Library
 	materialStore   *material.Store
+	notice          string // last user-facing notice (e.g. a failed-commit reason)
 }
+
+// Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in
+// the status bar so a failed OK is not silent.
+func (s *Session) Notice() string { return s.notice }
 
 // NewSession creates an empty in-memory session with no persistence store. Its
 // documents live only in memory — Save/Open return "no store configured" — which

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -20,6 +20,7 @@ func (s *Session) StartTool(t Tool) {
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
 	}
+	s.notice = ""
 	s.tool = &ToolInstance{tool: t}
 	t.Start(s)
 }
@@ -46,14 +47,17 @@ func (s *Session) OK() error {
 		return errors.New("app: active tool is not ready to commit")
 	}
 	if err := s.tool.tool.Commit(s); err != nil {
-		return err // keep the tool open so the user can fix the input
+		s.notice = err.Error() // surface why (the status bar shows it); keep the tool open
+		return err
 	}
+	s.notice = ""
 	s.tool = nil
 	return nil
 }
 
 // CancelTool abandons the active tool (Inventor's Escape / Cancel).
 func (s *Session) CancelTool() {
+	s.notice = ""
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
 		s.tool = nil

--- a/app/statusbar.go
+++ b/app/statusbar.go
@@ -21,12 +21,13 @@ type StatusBar struct {
 	ToolActive     bool   // whether a tool is running (so OK/Cancel show)
 	CanCommit      bool   // whether OK should be enabled
 	SelectionCount int    // size of the current selection set
+	Notice         string // last user-facing notice (a failed-commit reason), or ""
 }
 
 // BuildStatus assembles the status bar from the session: the active tool's prompt and
-// commit-readiness, or "Ready" when idle, plus the selection count.
+// commit-readiness, or "Ready" when idle, plus the selection count and any notice.
 func BuildStatus(s *Session) StatusBar {
-	sb := StatusBar{Prompt: "Ready", SelectionCount: s.Selection().Count()}
+	sb := StatusBar{Prompt: "Ready", SelectionCount: s.Selection().Count(), Notice: s.Notice()}
 	ti := s.ActiveTool()
 	if ti == nil {
 		return sb

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -104,6 +104,10 @@ func drawStatusBar(s *app.Session) {
 		}
 		native.SameLine()
 		native.Text(selectionText(sb.SelectionCount))
+		if sb.Notice != "" {
+			native.SameLine()
+			native.Text("— " + sb.Notice)
+		}
 	}
 	native.End()
 }

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -22,12 +22,19 @@ func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, err
 	if r <= 0 {
 		return nil, fmt.Errorf("fillet: radius %g must be > 0", r)
 	}
-	fils := make([]edgeFillet, 0, len(edgeKeys))
+	edges := make([]*topo.Edge, 0, len(edgeKeys))
 	for _, k := range edgeKeys {
 		e, ok := body.FindEdgeByKey(k)
 		if !ok {
 			return nil, fmt.Errorf("fillet: edge reference lost: %x", k)
 		}
+		edges = append(edges, e)
+	}
+	if err := noSharedCorners(edges); err != nil {
+		return nil, err
+	}
+	fils := make([]edgeFillet, 0, len(edges))
+	for _, e := range edges {
 		ef, err := computeEdgeFillet(body, e, r)
 		if err != nil {
 			return nil, err
@@ -39,6 +46,22 @@ func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, err
 		return nil, fmt.Errorf("fillet: result is not a valid solid %v", rep.Issues)
 	}
 	return res, nil
+}
+
+// noSharedCorners rejects a set of edges where two meet at a common vertex: filleting them
+// together needs a corner blend (a spherical/toroidal patch where the rounds meet), which is
+// not yet supported. The clear error lets the UI tell the user to pick non-adjacent edges.
+func noSharedCorners(edges []*topo.Edge) error {
+	seen := map[uint64]bool{}
+	for _, e := range edges {
+		for _, v := range []*topo.Vertex{e.StartVertex(), e.EndVertex()} {
+			if seen[v.ID()] {
+				return fmt.Errorf("fillet: selected edges meet at a corner — corner blends are not yet supported; fillet adjacent edges one at a time or pick non-adjacent edges")
+			}
+			seen[v.ID()] = true
+		}
+	}
+	return nil
 }
 
 // corner is one rounded end of a filleted edge: the cylinder centre at that end, the tangent

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -4,6 +4,7 @@ package ops_test
 
 import (
 	stdmath "math"
+	"strings"
 	"testing"
 
 	"github.com/Oblikovati/oblikovati/kernel/geom"
@@ -96,6 +97,29 @@ func TestFilletLostKeyErrors(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	if _, err := ops.FilletEdges(box, [][]byte{[]byte("ghost")}, 0.5); err == nil {
 		t.Error("fillet with a lost key should error")
+	}
+}
+
+// TestFilletSharedCornerErrors checks that filleting edges meeting at a corner (a fillet-
+// fillet corner, not yet supported) returns a clear error rather than a broken solid.
+func TestFilletSharedCornerErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	var keys [][]byte
+	for _, e := range box.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if (a.X == 0 && a.Y == 0 && a.Z == 0) || (c.X == 0 && c.Y == 0 && c.Z == 0) {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	if len(keys) != 3 {
+		t.Fatalf("found %d edges at the corner, want 3", len(keys))
+	}
+	_, err := ops.FilletEdges(box, keys, 0.3)
+	if err == nil {
+		t.Fatal("filleting edges that meet at a corner should error")
+	}
+	if !strings.Contains(err.Error(), "corner") {
+		t.Errorf("error %q should mention the corner-blend limitation", err)
 	}
 }
 


### PR DESCRIPTION
## Symptom

Selecting edges of the demo cube that **meet at a shared corner** and clicking OK on Fillet did nothing.

## Cause

Two compounding issues:
1. Filleting a **fillet-fillet corner** (edges sharing a vertex) isn't supported yet — the single-pass rebuild produced an invalid solid, so `FilletEdges` errored.
2. That error was **swallowed**: the status bar and every tool dialog do `_ = s.OK()`, so a failed commit just left the tool open with no feedback ("nothing happens").

## Fix

1. **Clear kernel error:** `ops.FilletEdges` now detects edges sharing a vertex up front and returns a specific message — *"selected edges meet at a corner — corner blends are not yet supported; fillet adjacent edges one at a time or pick non-adjacent edges"* — instead of a generic "not a valid solid".
2. **Surface failures:** `Session` records a failed commit's reason as a **notice** (cleared on tool start/cancel and on success), and the status bar displays it. Now *any* tool's OK failure tells the user why.

Independent (non-adjacent) edges still fillet fine — only true fillet-fillet corners are rejected (a noted follow-up: corner blends via sphere/torus patches).

## Tests

- kernel: `TestFilletSharedCornerErrors` (corner edges → error mentioning "corner").
- app: `TestFilletCornerEdgesSurfaceNotice` (commit fails, tool stays open, `Session.Notice()` set, body unchanged).

`go test ./...`, vet, lint green; head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)