### PR TITLE
M20 F03: fillet corner blends (spherical patches where rounded edges meet)

### DIFF
--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -74,18 +74,18 @@ func TestFilletViaRibbonCommand(t *testing.T) {
 	}
 }
 
-// TestFilletCornerEdgesSurfaceNotice checks that committing a fillet over edges that meet at
-// a corner (unsupported) fails loudly: the tool stays open and the session carries a notice
-// the status bar shows — so the user is not left with a silent "nothing happened".
-func TestFilletCornerEdgesSurfaceNotice(t *testing.T) {
+// TestFilletUnsupportedCornerSurfacesNotice checks that committing a fillet over an
+// unsupported corner config (two of the three edges at a vertex) fails loudly: the tool stays
+// open and the session carries a notice the status bar shows — not a silent "nothing happened".
+func TestFilletUnsupportedCornerSurfacesNotice(t *testing.T) {
 	s, block := newPartWithBlock(t, 2)
 	f := NewFilletTool()
 	s.StartTool(f)
-	for _, e := range cornerEdges(block) { // three edges meeting at one corner
+	for _, e := range cornerEdges(block)[:2] { // two of the three edges at one corner (unsupported)
 		f.Pick(s, EdgeHandle{Edge: e})
 	}
 	if err := s.OK(); err == nil {
-		t.Fatal("filleting corner edges should fail")
+		t.Fatal("filleting an unsupported corner config should fail")
 	}
 	if s.ActiveTool() == nil {
 		t.Error("a failed commit should keep the fillet tool open")

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -22,57 +22,54 @@ func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, err
 	if r <= 0 {
 		return nil, fmt.Errorf("fillet: radius %g must be > 0", r)
 	}
-	edges := make([]*topo.Edge, 0, len(edgeKeys))
-	for _, k := range edgeKeys {
-		e, ok := body.FindEdgeByKey(k)
-		if !ok {
-			return nil, fmt.Errorf("fillet: edge reference lost: %x", k)
-		}
-		edges = append(edges, e)
+	edges, err := resolveFilletEdges(body, edgeKeys)
+	if err != nil {
+		return nil, err
 	}
-	if err := noSharedCorners(edges); err != nil {
+	blends, err := computeBlends(edges, r)
+	if err != nil {
 		return nil, err
 	}
 	fils := make([]edgeFillet, 0, len(edges))
 	for _, e := range edges {
-		ef, err := computeEdgeFillet(body, e, r)
+		ef, err := computeEdgeFillet(body, e, r, blends)
 		if err != nil {
 			return nil, err
 		}
 		fils = append(fils, ef)
 	}
-	res := assembleBody(filletResultFaces(body, fils), "fillet")
+	res := assembleBody(filletResultFaces(body, fils, blends), "fillet")
 	if rep := Validate(res); !rep.Valid || !res.IsSolid() {
 		return nil, fmt.Errorf("fillet: result is not a valid solid %v", rep.Issues)
 	}
 	return res, nil
 }
 
-// noSharedCorners rejects a set of edges where two meet at a common vertex: filleting them
-// together needs a corner blend (a spherical/toroidal patch where the rounds meet), which is
-// not yet supported. The clear error lets the UI tell the user to pick non-adjacent edges.
-func noSharedCorners(edges []*topo.Edge) error {
-	seen := map[uint64]bool{}
-	for _, e := range edges {
-		for _, v := range []*topo.Vertex{e.StartVertex(), e.EndVertex()} {
-			if seen[v.ID()] {
-				return fmt.Errorf("fillet: selected edges meet at a corner — corner blends are not yet supported; fillet adjacent edges one at a time or pick non-adjacent edges")
-			}
-			seen[v.ID()] = true
+// resolveFilletEdges resolves the edge reference keys against the body, erroring on a lost key.
+func resolveFilletEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, error) {
+	edges := make([]*topo.Edge, 0, len(keys))
+	for _, k := range keys {
+		e, ok := body.FindEdgeByKey(k)
+		if !ok {
+			return nil, fmt.Errorf("fillet: edge reference lost: %x", k)
 		}
+		edges = append(edges, e)
 	}
-	return nil
+	return edges, nil
 }
 
 // corner is one rounded end of a filleted edge: the cylinder centre at that end, the tangent
 // points on faces a/b, and the arc midpoint (the cylinder point nearest the sharp corner).
+// At a blend corner the centre is the corner sphere's centre and the tangent points are the
+// sphere's tangents (the cylinder ends there and its arc joins the sphere patch).
 type corner struct {
 	a, b    *topo.Face
-	cen     math.Point3 // cylinder centre at this end
+	cen     math.Point3 // cylinder centre at this end (sphere centre when blended)
 	ta, tb  math.Point3
 	mid     math.Point3
-	endFace *topo.Face
+	endFace *topo.Face // the flat end cap to arc (nil at a blend corner)
 	vertex  *topo.Vertex
+	blend   bool
 }
 
 // tOf returns the tangent point on face f (a or b).
@@ -92,8 +89,9 @@ type edgeFillet struct {
 	edge   *topo.Edge
 }
 
-// computeEdgeFillet solves the rolling-ball geometry for one convex straight edge.
-func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64) (edgeFillet, error) {
+// computeEdgeFillet solves the rolling-ball geometry for one convex straight edge, using a
+// corner blend at either endpoint that is a shared corner.
+func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64, blends map[uint64]*cornerBlend) (edgeFillet, error) {
 	a, b, nA, nB, err := edgePlanarFaces(e)
 	if err != nil {
 		return edgeFillet{}, err
@@ -103,15 +101,11 @@ func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64) (edgeFillet, er
 		return edgeFillet{}, fmt.Errorf("fillet: degenerate edge")
 	}
 	off := nA.Add(nB).Scale(-r / (1 + nA.Dot(nB))) // centre offset from the edge into the solid
-	mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point())
-	if !PointInsideBody(body, mid.TranslateBy(off)) { // convex ⇒ the rolling-ball centre is inside
+	if mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point()); !PointInsideBody(body, mid.TranslateBy(off)) {
 		return edgeFillet{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
 	}
-	c0, err := cornerAt(e.StartVertex(), a, b, nA, nB, off, r)
-	if err != nil {
-		return edgeFillet{}, err
-	}
-	c1, err := cornerAt(e.EndVertex(), a, b, nA, nB, off, r)
+	in := cornerInputs{a: a, b: b, nA: nA, nB: nB, off: off, r: r, axis: axis.AsVector()}
+	c0, c1, err := edgeCorners(e, in, blends)
 	if err != nil {
 		return edgeFillet{}, err
 	}
@@ -120,6 +114,16 @@ func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64) (edgeFillet, er
 		return edgeFillet{}, err
 	}
 	return edgeFillet{a: a, b: b, cyl: cyl, c0: c0, c1: c1, edge: e}, nil
+}
+
+// edgeCorners solves the rounded corners at both endpoints of an edge (each blended when its
+// vertex is a shared corner).
+func edgeCorners(e *topo.Edge, in cornerInputs, blends map[uint64]*cornerBlend) (c0, c1 corner, err error) {
+	if c0, err = cornerAt(e.StartVertex(), in, blends[e.StartVertex().ID()]); err != nil {
+		return corner{}, corner{}, err
+	}
+	c1, err = cornerAt(e.EndVertex(), in, blends[e.EndVertex().ID()])
+	return c0, c1, err
 }
 
 // edgePlanarFaces returns the edge's two faces and their outward normals, erroring unless
@@ -137,24 +141,48 @@ func edgePlanarFaces(e *topo.Edge) (a, b *topo.Face, nA, nB math.Vector3, err er
 	return faces[0], faces[1], pa.Normal(), pb.Normal(), nil
 }
 
-// cornerAt solves a fillet corner at vertex v: the centre (v + off), the tangent points on
-// the two faces, the arc midpoint, and the end face (the face at v other than a/b).
-func cornerAt(v *topo.Vertex, a, b *topo.Face, nA, nB math.Vector3, off math.Vector3, r float64) (corner, error) {
-	c := v.Point().TranslateBy(off)
-	end := endFaceAt(v, a, b)
-	if end == nil {
+// cornerInputs bundles the per-edge data a corner needs.
+type cornerInputs struct {
+	a, b   *topo.Face
+	nA, nB math.Vector3
+	off    math.Vector3
+	axis   math.Vector3
+	r      float64
+}
+
+// cornerAt solves a fillet corner at vertex v. Without a blend it is a simple end: centre
+// v+off, tangent points r along each face normal, an arc on the end face. With a blend (v is
+// a shared corner) the centre is the blend sphere's centre and the tangent points are the
+// sphere's tangents on the two faces; the corner-end arc joins the sphere patch (no end
+// face), and the arc is registered on the blend.
+func cornerAt(v *topo.Vertex, in cornerInputs, blend *cornerBlend) (corner, error) {
+	cen := v.Point().TranslateBy(in.off)
+	ta := cen.TranslateBy(in.nA.Scale(in.r))
+	tb := cen.TranslateBy(in.nB.Scale(in.r))
+	var end *topo.Face
+	if blend != nil {
+		cen, ta, tb = blend.center, blend.tan[in.a.ID()], blend.tan[in.b.ID()]
+	} else if end = endFaceAt(v, in.a, in.b); end == nil {
 		return corner{}, fmt.Errorf("fillet: edge endpoint has no end face to round")
 	}
-	toward, err := math.UnitVector3FromVector(c.VectorTo(v.Point()))
-	if err != nil {
-		return corner{}, fmt.Errorf("fillet: degenerate corner")
+	mid := cen.TranslateBy(perpToward(cen, v.Point(), in.axis).Scale(in.r))
+	c := corner{a: in.a, b: in.b, endFace: end, vertex: v, cen: cen, ta: ta, tb: tb, mid: mid, blend: blend != nil}
+	if blend != nil {
+		blend.arcs = append(blend.arcs, blendArc{ta: ta, tb: tb, mid: mid})
 	}
-	return corner{
-		a: a, b: b, endFace: end, vertex: v, cen: c,
-		ta:  c.TranslateBy(nA.Scale(r)),
-		tb:  c.TranslateBy(nB.Scale(r)),
-		mid: c.TranslateBy(toward.AsVector().Scale(r)),
-	}, nil
+	return c, nil
+}
+
+// perpToward returns the unit direction from cen toward p projected into the plane
+// perpendicular to axis — the in-cross-section direction to the rounded corner.
+func perpToward(cen, p math.Point3, axis math.Vector3) math.Vector3 {
+	d := cen.VectorTo(p)
+	perp := d.Sub(axis.Scale(d.Dot(axis)))
+	u, err := math.UnitVector3FromVector(perp)
+	if err != nil {
+		return d
+	}
+	return u.AsVector()
 }
 
 // endFaceAt returns the face meeting at v that is neither a nor b (the end cap the fillet
@@ -168,4 +196,106 @@ func endFaceAt(v *topo.Vertex, a, b *topo.Face) *topo.Face {
 		}
 	}
 	return nil
+}
+
+// blendArc is one boundary arc of a corner sphere patch (shared with a cylinder fillet):
+// from ta to tb through mid, all on the sphere.
+type blendArc struct{ ta, tb, mid math.Point3 }
+
+// cornerBlend is a spherical corner patch where several filleted edges meet at one vertex:
+// the rolling-ball sphere tangent to the corner's faces, its tangent point on each face
+// (keyed by face id), and the arcs (filled in as the edges are solved) that bound the patch.
+type cornerBlend struct {
+	vertex *topo.Vertex
+	center math.Point3
+	sphere geom.Sphere
+	tan    map[uint64]math.Point3
+	arcs   []blendArc
+}
+
+// computeBlends finds the shared corners of the filleted edge set and solves a sphere patch
+// for each. A vertex where ≥2 filleted edges meet must be a fully-filleted trihedral corner
+// (exactly 3 of the selected edges, 3 faces) — the supported case (e.g. a box corner);
+// anything else errors clearly. Returns a map keyed by corner vertex id.
+func computeBlends(edges []*topo.Edge, r float64) (map[uint64]*cornerBlend, error) {
+	groups := map[uint64][]*topo.Edge{}
+	for _, e := range edges {
+		groups[e.StartVertex().ID()] = append(groups[e.StartVertex().ID()], e)
+		groups[e.EndVertex().ID()] = append(groups[e.EndVertex().ID()], e)
+	}
+	out := map[uint64]*cornerBlend{}
+	for vid, es := range groups {
+		if len(es) < 2 {
+			continue
+		}
+		v := vertexByID(es, vid)
+		faces := facesAtVertex(v)
+		if len(es) != 3 || len(faces) != 3 {
+			return nil, fmt.Errorf("fillet: corner blend needs exactly 3 mutually filleted edges at a 3-face vertex (got %d edges, %d faces); other corner configs are not yet supported", len(es), len(faces))
+		}
+		cb, err := solveBlend(v, faces, r)
+		if err != nil {
+			return nil, err
+		}
+		out[vid] = cb
+	}
+	return out, nil
+}
+
+// solveBlend builds the corner sphere from the three planar faces meeting at v (the point
+// at distance r from all three, inside) and its tangent points on each.
+func solveBlend(v *topo.Vertex, faces []*topo.Face, r float64) (*cornerBlend, error) {
+	var a [3][3]float64
+	var b [3]float64
+	for i, f := range faces {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok {
+			return nil, fmt.Errorf("fillet: corner face must be planar")
+		}
+		n := pl.Normal()
+		a[i] = [3]float64{n.X, n.Y, n.Z}
+		b[i] = n.Dot(pl.Origin.AsVector()) - r // distance r on the inside of each face
+	}
+	x, ok := solve3(a, b)
+	if !ok {
+		return nil, fmt.Errorf("fillet: cannot solve corner blend sphere (degenerate faces)")
+	}
+	s := math.P3(x[0], x[1], x[2])
+	sph, err := geom.NewSphere(s, r)
+	if err != nil {
+		return nil, err
+	}
+	tan := make(map[uint64]math.Point3, 3)
+	for _, f := range faces {
+		tan[f.ID()] = s.TranslateBy(f.Geometry().(geom.Plane).Normal().Scale(r))
+	}
+	return &cornerBlend{vertex: v, center: s, sphere: sph, tan: tan}, nil
+}
+
+// vertexByID returns the vertex with id vid from the edge set.
+func vertexByID(edges []*topo.Edge, vid uint64) *topo.Vertex {
+	for _, e := range edges {
+		if e.StartVertex().ID() == vid {
+			return e.StartVertex()
+		}
+		if e.EndVertex().ID() == vid {
+			return e.EndVertex()
+		}
+	}
+	return nil
+}
+
+// facesAtVertex returns the distinct faces meeting at v.
+func facesAtVertex(v *topo.Vertex) []*topo.Face {
+	seen := map[uint64]bool{}
+	var out []*topo.Face
+	for _, e := range v.Edges() {
+		for _, f := range e.Faces() {
+			if !seen[f.ID()] {
+				seen[f.ID()] = true
+				out = append(out, f)
+			}
+		}
+	}
+	return out
 }

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -9,9 +9,10 @@ import (
 )
 
 // filletResultFaces builds the faces of the filleted body: every original face transformed
-// for the fillets touching it (its A/B corners pulled back to the tangent points, its end
-// corners replaced by an arc), plus one cylinder face per filleted edge.
-func filletResultFaces(body *topo.Body, fils []edgeFillet) []filletFace {
+// for the fillets touching it (its A/B corners pulled back to the tangent points, its simple
+// end corners replaced by an arc), one cylinder face per filleted edge, and one sphere patch
+// per corner blend.
+func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*cornerBlend) []filletFace {
 	abSubst, endCorner := filletMaps(fils)
 	var out []filletFace
 	for _, f := range body.Faces() {
@@ -20,11 +21,16 @@ func filletResultFaces(body *topo.Body, fils []edgeFillet) []filletFace {
 	for _, ef := range fils {
 		out = append(out, cylinderFace(ef))
 	}
+	for _, cb := range blends {
+		out = append(out, spherePatchFace(cb))
+	}
 	return out
 }
 
 // filletMaps indexes, per face: the corner-vertex → tangent-point pullbacks (where the face
-// is a fillet's A or B face), and the corner-vertex → corner arc (where it is the end face).
+// is a fillet's A or B face — every corner, simple or blended), and the corner-vertex →
+// corner arc (only for SIMPLE end corners; a blend corner's arc lives on the sphere patch,
+// and all its faces just pull back to the sphere tangent points).
 func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*topo.Face]map[uint64]corner) {
 	ab := map[*topo.Face]map[uint64]math.Point3{}
 	ends := map[*topo.Face]map[uint64]corner{}
@@ -38,6 +44,9 @@ func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*
 		for _, c := range []corner{ef.c0, ef.c1} {
 			put(ab, c.a, c.vertex.ID(), c.ta)
 			put(ab, c.b, c.vertex.ID(), c.tb)
+			if c.blend {
+				continue // the rounded corner is the sphere patch, not an end-face arc
+			}
 			if ends[c.endFace] == nil {
 				ends[c.endFace] = map[uint64]corner{}
 			}
@@ -146,4 +155,88 @@ func reverseFilletLoop(_ filletLoop, ef edgeFillet) filletLoop {
 		pts:    []math.Point3{c0.ta, c0.tb, c1.tb, c1.ta},
 		curves: []geom.Curve3{arc0, nil, arc1, nil},
 	}
+}
+
+// spherePatchFace builds the corner sphere patch: a spherical triangle bounded by the blend's
+// three arcs (each shared with a cylinder fillet), wound so its normal points outward (away
+// from the sphere centre).
+func spherePatchFace(cb *cornerBlend) filletFace {
+	loop := chainArcs(cb.arcs)
+	if spherePatchFlipped(cb, loop) {
+		loop = reverseArcLoop(loop)
+	}
+	return filletFace{surface: cb.sphere, loops: []filletLoop{loop}}
+}
+
+// chainArcs links the blend's arcs head-to-tail into a closed loop (each tangent point is an
+// endpoint of exactly two arcs), with the arc curve on each segment.
+func chainArcs(arcs []blendArc) filletLoop {
+	used := make([]bool, len(arcs))
+	var fl filletLoop
+	cur := arcs[0].ta
+	for range arcs {
+		for j, a := range arcs {
+			if used[j] {
+				continue
+			}
+			from, to, ok := arcEndpoints(a, cur)
+			if !ok {
+				continue
+			}
+			used[j] = true
+			arc, _ := geom.Arc3dByThreePoints(from, a.mid, to)
+			fl.pts = append(fl.pts, from)
+			fl.curves = append(fl.curves, arc)
+			cur = to
+			break
+		}
+	}
+	return fl
+}
+
+// arcEndpoints orients an arc so it starts at cur (returning from=cur, to=other), or ok=false
+// when neither end is cur.
+func arcEndpoints(a blendArc, cur math.Point3) (from, to math.Point3, ok bool) {
+	switch {
+	case a.ta.DistanceTo(cur) < 1e-7:
+		return a.ta, a.tb, true
+	case a.tb.DistanceTo(cur) < 1e-7:
+		return a.tb, a.ta, true
+	}
+	return math.Point3{}, math.Point3{}, false
+}
+
+// spherePatchFlipped reports whether the loop winds against the sphere's outward normal at the
+// patch centroid (so it should be reversed to face outward).
+func spherePatchFlipped(cb *cornerBlend, loop filletLoop) bool {
+	c := centroidPts(loop.pts)
+	n := loop.pts[0].VectorTo(loop.pts[1]).Cross(loop.pts[0].VectorTo(loop.pts[2]))
+	return n.Dot(cb.center.VectorTo(c)) < 0
+}
+
+// reverseArcLoop reverses a closed arc loop, re-deriving each segment's arc in the new
+// direction (the arc midpoints are recovered from the original arcs).
+func reverseArcLoop(loop filletLoop) filletLoop {
+	n := len(loop.pts)
+	mids := arcMidpoints(loop)
+	var out filletLoop
+	for i := 0; i < n; i++ {
+		from := loop.pts[(n-i)%n]
+		to := loop.pts[(n-i-1+n)%n]
+		arc, _ := geom.Arc3dByThreePoints(from, mids[(n-i-1+n)%n], to)
+		out.pts = append(out.pts, from)
+		out.curves = append(out.curves, arc)
+	}
+	return out
+}
+
+// arcMidpoints samples each segment's arc curve at its midpoint (for re-orienting the loop).
+func arcMidpoints(loop filletLoop) []math.Point3 {
+	mids := make([]math.Point3, len(loop.curves))
+	for i, c := range loop.curves {
+		if c != nil {
+			mids[i] = c.PointAt(0.5)
+		}
+	}
+	return mids
 }

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -100,26 +100,88 @@ func TestFilletLostKeyErrors(t *testing.T) {
 	}
 }
 
-// TestFilletSharedCornerErrors checks that filleting edges meeting at a corner (a fillet-
-// fillet corner, not yet supported) returns a clear error rather than a broken solid.
-func TestFilletSharedCornerErrors(t *testing.T) {
-	box := shellBox(2, 2, 2)
+// cornerEdgeKeys returns the reference keys of the edges meeting at the (0,0,0) box corner.
+func cornerEdgeKeys(t *testing.T, b *topo.Body) [][]byte {
+	t.Helper()
 	var keys [][]byte
-	for _, e := range box.Edges() {
+	for _, e := range b.Edges() {
 		a, c := e.StartVertex().Point(), e.EndVertex().Point()
 		if (a.X == 0 && a.Y == 0 && a.Z == 0) || (c.X == 0 && c.Y == 0 && c.Z == 0) {
 			keys = append(keys, e.ReferenceKey())
 		}
 	}
+	return keys
+}
+
+// hasSphereFaces counts a body's spherical faces.
+func hasSphereFaces(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Sphere); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFilletCornerBlend rounds the three edges meeting at a box corner: the three cylinder
+// fillets are joined by a spherical corner patch into a valid solid (3 cylinders + 1 sphere),
+// with material removed (volume < 8). The corner-blend acceptance.
+func TestFilletCornerBlend(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	keys := cornerEdgeKeys(t, box)
 	if len(keys) != 3 {
 		t.Fatalf("found %d edges at the corner, want 3", len(keys))
 	}
+	res, err := ops.FilletEdges(box, keys, 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("corner-blended box not a valid solid: %+v", r)
+	}
+	if c, s := hasCylinderFaces(res), hasSphereFaces(res); c != 3 || s != 1 {
+		t.Errorf("got %d cylinder + %d sphere faces, want 3 + 1", c, s)
+	}
+	if v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume; v <= 7.5 || v >= 8 {
+		t.Errorf("corner-blend volume = %g, want material removed (7.5 < v < 8)", v)
+	}
+}
+
+// TestFilletAllBoxEdges rounds every edge of a 2×2×2 box: 12 cylinder fillets joined by 8
+// spherical corner patches into a valid solid (a fully-rounded box), with material removed.
+func TestFilletAllBoxEdges(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	var keys [][]byte
+	for _, e := range box.Edges() {
+		keys = append(keys, e.ReferenceKey())
+	}
+	res, err := ops.FilletEdges(box, keys, 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("fully-rounded box not a valid solid: %+v", r)
+	}
+	if c, s := hasCylinderFaces(res), hasSphereFaces(res); c != 12 || s != 8 {
+		t.Errorf("got %d cylinder + %d sphere faces, want 12 + 8", c, s)
+	}
+	if v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume; v >= 8 {
+		t.Errorf("fully-rounded box volume = %g, want < 8", v)
+	}
+}
+
+// TestFilletTwoEdgeCornerErrors checks an unsupported corner config (two of the three edges
+// at a vertex) errors clearly rather than producing a broken solid.
+func TestFilletTwoEdgeCornerErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	keys := cornerEdgeKeys(t, box)[:2] // two of the three edges meeting at the corner
 	_, err := ops.FilletEdges(box, keys, 0.3)
 	if err == nil {
-		t.Fatal("filleting edges that meet at a corner should error")
+		t.Fatal("filleting only two of the three edges at a corner should error")
 	}
 	if !strings.Contains(err.Error(), "corner") {
-		t.Errorf("error %q should mention the corner-blend limitation", err)
+		t.Errorf("error %q should mention the corner limitation", err)
 	}
 }
 

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -28,18 +28,55 @@ const trimBorderTol = 1e-6
 func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	s := f.Geometry()
 	outer3D := faceOuterBoundary(f, q)
-	if len(outer3D) < 3 || len(faceHoleBoundaries(f, q)) > 0 {
+	holes3D := faceHoleBoundaries(f, q)
+	if len(outer3D) < 3 {
 		return fullDomainGridMesh(s, q)
 	}
-	uv, _, ok := toUVLoops(s, outer3D, nil)
+	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
-		return fullDomainGridMesh(s, q)
+		return fullDomainGridMesh(s, q) // seam-crossing periodic face
 	}
-	us, vs, ok := isoRectangleGrid(uv)
-	if !ok {
-		return fullDomainGridMesh(s, q)
+	if len(holesUV) == 0 {
+		if us, vs, isRect := isoRectangleGrid(outerUV); isRect {
+			return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
+		}
 	}
-	return structuredGridMesh(s, us, vs)
+	// A non-rectangular trim (e.g. a corner sphere patch): triangulate the boundary in UV.
+	return boundaryUVMesh(s, outerUV, outer3D, holesUV, holes3D)
+}
+
+// boundaryUVMesh triangulates a curved face from its boundary loops alone (no interior Steiner
+// points): the loops are ear-clipped in (u,v) and lifted back to their exact 3D boundary
+// points, each triangle wound outward. The facets chord the curvature, so it is a coarse but
+// watertight covering of the exact trim region — right for small patches (corner blends);
+// larger non-rectangular curved faces would want a refined constrained triangulation.
+func boundaryUVMesh(s geom.Surface, outerUV []math.Point2, outer3D []math.Point3, holesUV [][]math.Point2, holes3D [][]math.Point3) *Mesh {
+	uv, pos := outerUV, outer3D
+	if len(holesUV) > 0 {
+		uv, pos = mergeHoles(outerUV, outer3D, holesUV, holes3D)
+	}
+	m := &Mesh{}
+	for _, p := range pos {
+		u, v := s.ParamAt(p)
+		m.addVertex(p, s.NormalAt(u, v))
+	}
+	for _, tri := range earClip(uv) {
+		a, b, c := tri[0], tri[1], tri[2]
+		if triangleFlipped(s, pos[a], pos[b], pos[c]) {
+			b, c = c, b
+		}
+		m.addTriangle(a, b, c)
+	}
+	return m
+}
+
+// triangleFlipped reports whether triangle abc winds against the surface normal at its
+// centroid (so it should be reversed to face outward).
+func triangleFlipped(s geom.Surface, a, b, c math.Point3) bool {
+	n := a.VectorTo(b).Cross(a.VectorTo(c))
+	cen := math.P3((a.X+b.X+c.X)/3, (a.Y+b.Y+c.Y)/3, (a.Z+b.Z+c.Z)/3)
+	u, v := s.ParamAt(cen)
+	return n.Dot(s.NormalAt(u, v)) < 0
 }
 
 // isoRectangleGrid returns the sorted u and v grid lines when the UV boundary is an


### PR DESCRIPTION
## What

Filleting edges that **meet at a corner** now works — the exact case that previously did nothing. Picking the 3 edges at a box corner (or all 12 edges → a fully-rounded box) produces a valid solid with a **spherical corner patch** joining the cylinder fillets.

## Kernel

`computeBlends` finds the shared corners among the selected edges. For a **trihedral corner** (3 mutually-filleted edges, 3 faces — a box corner) it solves the rolling-ball sphere (the point at distance `r` from all three faces) and its tangent point on each face. At a blend corner:
- each edge's cylinder ends at the sphere cross-section, and its end arc joins the sphere patch;
- the three faces pull back to the sphere tangents (no flat end-face arc);
- a **spherical-triangle patch** bounded by the three shared arcs is added.

Two-edge / higher-valence corners still error with a clear message (follow-ups).

## Tessellation fix

The sphere patch is **not** an iso-rectangle, so `tessellateCurvedFace` used to fall back to meshing the *whole sphere* — which made the corner-blend volume wrong (8.008 > 8). It now triangulates non-rectangular curved trims from their boundary loops in `(u,v)` via ear-clip (`boundaryUVMesh`), a watertight covering of the exact patch. Iso-rectangle faces (cylinder walls, fillet faces) keep the exact structured grid.

## Tests

- kernel: corner blend (3 cylinders + 1 sphere, vol < 8, converges 7.847→7.884), **fully-rounded box** (12 cylinders + 8 spheres), two-edge-corner error.
- app: unsupported-corner config surfaces the status notice.
- Single/four-edge fillets unchanged.

`go test ./...`, vet, lint, `-race` green; head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)