### PR TITLE
feat: Visual Style (Shaded / Shaded with Edges / Wireframe) in the View tab

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -2,7 +2,11 @@
 
 package app
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/renderer"
+)
 
 // RegisterStandardCommands wires Inventor's standard ribbon for a session: the 3D Model
 // tab (Create 2D Sketch, Extrude), the contextual Sketch tab (the full geometry-tool
@@ -282,8 +286,13 @@ func constrainCommands() []*CommandDefinition {
 	return cmds
 }
 
-// viewTabCommands are the View tab navigation commands.
+// viewTabCommands are the View tab commands: navigation plus the Visual Style presets.
 func viewTabCommands() []*CommandDefinition {
+	return append(viewNavigateCommands(), visualStyleCommands()...)
+}
+
+// viewNavigateCommands are the View tab's Navigate panel.
+func viewNavigateCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		NewCommand("View.ZoomAll", "Zoom All", "Navigate", func(s *Session) error {
 			s.FitView()
@@ -295,6 +304,28 @@ func viewTabCommands() []*CommandDefinition {
 			return nil
 		}).WithTab("View").WithIcon("home").WithButtonStyle(LargeIconButton).
 			WithTooltip("Home View — the default isometric view, framed to fit."),
+	}
+}
+
+// visualStyleCommands are the View tab's Visual Style panel: how the model is drawn (Shaded,
+// Shaded with Edges, Wireframe — Inventor's display-mode presets our renderer supports).
+func visualStyleCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		NewCommand("View.Shaded", "Shaded", "Visual Style", func(s *Session) error {
+			s.SetVisualStyle(renderer.Shaded)
+			return nil
+		}).WithTab("View").WithIcon("shaded").
+			WithTooltip("Shaded — lit faces, no edges."),
+		NewCommand("View.ShadedWithEdges", "Shaded with Edges", "Visual Style", func(s *Session) error {
+			s.SetVisualStyle(renderer.ShadedWithEdges)
+			return nil
+		}).WithTab("View").WithIcon("shaded-edges").
+			WithTooltip("Shaded with Edges — lit faces with the edge wireframe."),
+		NewCommand("View.Wireframe", "Wireframe", "Visual Style", func(s *Session) error {
+			s.SetVisualStyle(renderer.Wireframe)
+			return nil
+		}).WithTab("View").WithIcon("wireframe").
+			WithTooltip("Wireframe — edges only, no shaded faces."),
 	}
 }
 

--- a/app/render.go
+++ b/app/render.go
@@ -33,7 +33,7 @@ func (s *Session) Overlays() []renderer.DrawItem {
 // RenderFrame builds the frame draw list — the active part's bodies, the persistent
 // overlays, and the active tool's transient preview — and submits it to the backend.
 func (s *Session) RenderFrame(backend renderer.Backend) {
-	list := renderer.BuildDrawList(s.sceneBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup())
+	list := renderer.BuildDrawListStyled(s.sceneBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup(), s.visualStyle)
 	list.Items = append(list.Items, s.overlays...)
 	if s.tool != nil {
 		if p, ok := s.tool.tool.(Previewable); ok {

--- a/app/session.go
+++ b/app/session.go
@@ -41,12 +41,19 @@ type Session struct {
 	themeStore      *theme.Store
 	materials       *material.Library
 	materialStore   *material.Store
-	notice          string // last user-facing notice (e.g. a failed-commit reason)
+	notice          string               // last user-facing notice (e.g. a failed-commit reason)
+	visualStyle     renderer.VisualStyle // how the scene is drawn (View tab's Visual Style)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in
 // the status bar so a failed OK is not silent.
 func (s *Session) Notice() string { return s.notice }
+
+// VisualStyle returns the active scene visual style (default Shaded with Edges).
+func (s *Session) VisualStyle() renderer.VisualStyle { return s.visualStyle }
+
+// SetVisualStyle sets how the scene is drawn (the View tab's Visual Style).
+func (s *Session) SetVisualStyle(v renderer.VisualStyle) { s.visualStyle = v }
 
 // NewSession creates an empty in-memory session with no persistence store. Its
 // documents live only in memory — Save/Open return "no store configured" — which
@@ -62,12 +69,13 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 
 func newSession(store doc.Store) *Session {
 	return &Session{
-		workspace: doc.NewWorkspace(store),
-		commands:  NewCommandManager(),
-		bus:       event.NewBus(),
-		selection: NewSelection(),
-		camera:    scene.NewCamera(800, 600),
-		addins:    NewAddInManager(),
+		workspace:   doc.NewWorkspace(store),
+		commands:    NewCommandManager(),
+		bus:         event.NewBus(),
+		selection:   NewSelection(),
+		camera:      scene.NewCamera(800, 600),
+		addins:      NewAddInManager(),
+		visualStyle: renderer.ShadedWithEdges,
 	}
 }
 

--- a/app/visual_style_test.go
+++ b/app/visual_style_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// TestVisualStyleDefault checks a new session draws Shaded with Edges (so model edges are
+// visible by default).
+func TestVisualStyleDefault(t *testing.T) {
+	if s := NewSession(); s.VisualStyle() != renderer.ShadedWithEdges {
+		t.Errorf("default visual style = %v, want Shaded with Edges", s.VisualStyle())
+	}
+}
+
+// TestVisualStyleCommands checks the View-tab Visual Style commands set the session style.
+func TestVisualStyleCommands(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	cases := map[string]renderer.VisualStyle{
+		"View.Shaded":          renderer.Shaded,
+		"View.Wireframe":       renderer.Wireframe,
+		"View.ShadedWithEdges": renderer.ShadedWithEdges,
+	}
+	for cmd, want := range cases {
+		if err := s.Execute(cmd); err != nil {
+			t.Fatalf("execute %s: %v", cmd, err)
+		}
+		if s.VisualStyle() != want {
+			t.Errorf("after %s, visual style = %v, want %v", cmd, s.VisualStyle(), want)
+		}
+	}
+}

--- a/head/icon/assets/shaded-edges.svg
+++ b/head/icon/assets/shaded-edges.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#bbb" stroke="#000" stroke-width="1.5" stroke-linejoin="round"><path d="M12 3 L20 7.5 V16.5 L12 21 L4 16.5 V7.5 Z"/><path d="M12 3 V12 M12 12 L20 7.5 M12 12 L4 7.5 M12 12 V21" fill="none"/></svg>

--- a/head/icon/assets/shaded.svg
+++ b/head/icon/assets/shaded.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000" stroke="#000" stroke-width="1.5" stroke-linejoin="round"><path d="M12 3 L20 7.5 V16.5 L12 21 L4 16.5 V7.5 Z"/></svg>

--- a/head/icon/assets/wireframe.svg
+++ b/head/icon/assets/wireframe.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.5" stroke-linejoin="round"><path d="M12 3 L20 7.5 V16.5 L12 21 L4 16.5 V7.5 Z"/><path d="M12 3 V12 M12 12 L20 7.5 M12 12 L4 7.5 M12 12 V21"/></svg>

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -445,7 +445,7 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		}
 
 		bodies := activeBodies(s)
-		list := renderer.BuildDrawList(bodies, cam, ops.DefaultQuality(), s.SurfaceLookup())
+		list := renderer.BuildDrawListStyled(bodies, cam, ops.DefaultQuality(), s.SurfaceLookup(), s.VisualStyle())
 		// Paint the selected body cyan so a browser/viewport pick reads in the 3D view
 		// (a no-op in sketch mode, where the selection is sketch entities, not bodies).
 		list = highlightSelection(list, s.Selection().First(), bodies)

--- a/renderer/drawlist.go
+++ b/renderer/drawlist.go
@@ -100,22 +100,55 @@ var defaultSurfaceColor = [4]float32{0.7, 0.72, 0.75, 1}
 // edgeColor is the wireframe color.
 var edgeColor = [4]float32{0.1, 0.1, 0.12, 1}
 
-// BuildDrawList is the pure function that turns the visible scene bodies into a draw
-// list at the given quality: each visible body contributes a shaded triangle item
-// (its tessellation) and a wireframe line item (its edges), tagged with the body's
-// object id for picking. Bodies outside the view are culled.
+// VisualStyle selects how the scene bodies are drawn (Inventor's Visual Style / display
+// mode). Our flat-shaded renderer supports the three that map to it directly; the richer
+// Inventor presets (realistic/monochrome/illustration, hidden-edge removal) need NPR work.
+type VisualStyle uint8
+
+const (
+	// Shaded draws lit faces only (no wireframe).
+	Shaded VisualStyle = iota
+	// ShadedWithEdges draws lit faces with the edge wireframe over them (the default).
+	ShadedWithEdges
+	// Wireframe draws the edges only (no shaded faces) — every edge visible.
+	Wireframe
+)
+
+// String returns a stable, user-facing name.
+func (v VisualStyle) String() string {
+	switch v {
+	case Shaded:
+		return "Shaded"
+	case Wireframe:
+		return "Wireframe"
+	default:
+		return "Shaded with Edges"
+	}
+}
+
+// BuildDrawList turns the visible scene bodies into a draw list at the given quality in the
+// default Shaded-with-Edges style. Bodies outside the view are culled.
 func BuildDrawList(bodies []*topo.Body, cam scene.Camera, q ops.Quality, lookup SurfaceLookup) DrawList {
+	return BuildDrawListStyled(bodies, cam, q, lookup, ShadedWithEdges)
+}
+
+// BuildDrawListStyled is BuildDrawList honoring a visual style: each visible body contributes
+// a shaded triangle item (unless Wireframe) and/or a wireframe line item (unless Shaded),
+// tagged with the body's object id for picking.
+func BuildDrawListStyled(bodies []*topo.Body, cam scene.Camera, q ops.Quality, lookup SurfaceLookup, style VisualStyle) DrawList {
 	var items []DrawItem
 	for _, b := range bodies {
 		if !visible(cam, b.RangeBox()) {
 			continue
 		}
 		mesh, edges := ops.TessellateBody(b, q)
-		if mesh.TriangleCount() > 0 {
+		if style != Wireframe && mesh.TriangleCount() > 0 {
 			items = append(items, triangleItem(b.ID(), mesh, surfaceFor(b, lookup)))
 		}
-		if line := lineItem(b.ID(), edges); line != nil {
-			items = append(items, *line)
+		if style != Shaded {
+			if line := lineItem(b.ID(), edges); line != nil {
+				items = append(items, *line)
+			}
 		}
 	}
 	return DrawList{Items: items}

--- a/renderer/drawlist_test.go
+++ b/renderer/drawlist_test.go
@@ -74,6 +74,23 @@ func TestBuildDrawListEmitsSurfacesAndWireframe(t *testing.T) {
 	}
 }
 
+func TestVisualStyleSelectsItems(t *testing.T) {
+	b := box(2, math.V3(0, 0, 0))
+	cam := frontCamera()
+	shaded := BuildDrawListStyled([]*topo.Body{b}, cam, ops.DefaultQuality(), nil, Shaded)
+	if shaded.Triangles() != 12 || shaded.Lines() != 0 {
+		t.Errorf("Shaded = %d tris / %d lines, want 12 / 0", shaded.Triangles(), shaded.Lines())
+	}
+	withEdges := BuildDrawListStyled([]*topo.Body{b}, cam, ops.DefaultQuality(), nil, ShadedWithEdges)
+	if withEdges.Triangles() != 12 || withEdges.Lines() != 12 {
+		t.Errorf("ShadedWithEdges = %d tris / %d lines, want 12 / 12", withEdges.Triangles(), withEdges.Lines())
+	}
+	wire := BuildDrawListStyled([]*topo.Body{b}, cam, ops.DefaultQuality(), nil, Wireframe)
+	if wire.Triangles() != 0 || wire.Lines() != 12 {
+		t.Errorf("Wireframe = %d tris / %d lines, want 0 / 12", wire.Triangles(), wire.Lines())
+	}
+}
+
 func TestObjectIDsTagEachBody(t *testing.T) {
 	a, b := box(1, math.V3(0, 0, 0)), box(1, math.V3(3, 0, 0))
 	list := BuildDrawList([]*topo.Body{a, b}, frontCamera(), ops.DefaultQuality(), nil)


### PR DESCRIPTION
## What

Adds Inventor's **Visual Style** presets (`DisplayModeEnum`) to the View tab, so the model can be drawn **Shaded**, **Shaded with Edges**, or **Wireframe**. Wireframe (faces off) shows *every* edge — which is what's needed to inspect e.g. a non-watertight corner that shaded display hides behind the faces.

- **renderer:** `VisualStyle` enum + `BuildDrawListStyled`, which emits the shaded triangle item (unless Wireframe) and/or the edge line item (unless Shaded) per body. `BuildDrawList` keeps the default Shaded-with-Edges behavior (existing callers/tests unchanged).
- **app:** `Session` carries the visual style (default Shaded with Edges); View-tab ribbon commands `View.Shaded` / `View.ShadedWithEdges` / `View.Wireframe` set it. The head *and* the headless `RenderFrame` draw in the session's style.
- **head:** the viewport draws with `s.VisualStyle()`; shaded / shaded-edges / wireframe icons.

Our flat-shaded Vulkan renderer supports these three; Inventor's richer presets (realistic / monochrome / watercolor / illustration, hidden-edge removal) need NPR/hidden-line work and are out of scope.

## Tests

- renderer: per-style item counts (box → 12 tris/0 lines Shaded, 12/12 ShadedWithEdges, 0/12 Wireframe).
- app: default style is Shaded with Edges; the three ribbon commands set the style.

`go test ./...`, vet, lint green; head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)