### PR TITLE
fix: corner-blend sphere patch tessellation cracking (pole-degenerate UV)

### DIFF
--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -148,6 +148,58 @@ func TestFilletCornerBlend(t *testing.T) {
 	}
 }
 
+// meshOpenEdges counts the welded mesh edges not shared by exactly two triangles — i.e. the
+// cracks. A watertight tessellation has zero.
+func meshOpenEdges(m *ops.Mesh) int {
+	grid := func(x float64) int64 { return int64(stdmath.Round(x / 1e-5)) }
+	id := map[[3]int64]int{}
+	vid := func(i int) int {
+		p := m.Positions[i]
+		k := [3]int64{grid(p.X), grid(p.Y), grid(p.Z)}
+		if v, ok := id[k]; ok {
+			return v
+		}
+		v := len(id)
+		id[k] = v
+		return v
+	}
+	use := map[[2]int]int{}
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		vs := [3]int{vid(m.Indices[t]), vid(m.Indices[t+1]), vid(m.Indices[t+2])}
+		for _, e := range [][2]int{{vs[0], vs[1]}, {vs[1], vs[2]}, {vs[2], vs[0]}} {
+			if e[0] > e[1] {
+				e[0], e[1] = e[1], e[0]
+			}
+			use[e]++
+		}
+	}
+	open := 0
+	for _, c := range use {
+		if c != 2 {
+			open++
+		}
+	}
+	return open
+}
+
+// TestFilletCornerBlendMeshWatertight checks the corner blend's TESSELLATION is watertight at
+// a fine quality — the spherical patch's lat/long UV is degenerate where a box corner lands on
+// the pole, so it must be flattened onto a tangent plane (else the ear-clip stalls and cracks).
+func TestFilletCornerBlendMeshWatertight(t *testing.T) {
+	box := shellBox(4, 3, 5)
+	keys := cornerEdgeKeys(t, box)
+	res, err := ops.FilletEdges(box, keys, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("corner-blend mesh at tol %g has %d open edges, want watertight", tol, open)
+		}
+	}
+}
+
 // TestFilletAllBoxEdges rounds every edge of a 2×2×2 box: 12 cylinder fillets joined by 8
 // spherical corner patches into a valid solid (a fully-rounded box), with material removed.
 func TestFilletAllBoxEdges(t *testing.T) {

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -41,19 +41,21 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 			return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 		}
 	}
-	// A non-rectangular trim (e.g. a corner sphere patch): triangulate the boundary in UV.
-	return boundaryUVMesh(s, outerUV, outer3D, holesUV, holes3D)
+	// A non-rectangular trim (e.g. a corner sphere patch): triangulate the boundary.
+	return boundaryPatchMesh(s, outer3D, holes3D)
 }
 
-// boundaryUVMesh triangulates a curved face from its boundary loops alone (no interior Steiner
-// points): the loops are ear-clipped in (u,v) and lifted back to their exact 3D boundary
-// points, each triangle wound outward. The facets chord the curvature, so it is a coarse but
-// watertight covering of the exact trim region — right for small patches (corner blends);
-// larger non-rectangular curved faces would want a refined constrained triangulation.
-func boundaryUVMesh(s geom.Surface, outerUV []math.Point2, outer3D []math.Point3, holesUV [][]math.Point2, holes3D [][]math.Point3) *Mesh {
-	uv, pos := outerUV, outer3D
-	if len(holesUV) > 0 {
-		uv, pos = mergeHoles(outerUV, outer3D, holesUV, holes3D)
+// boundaryPatchMesh triangulates a curved face from its boundary loops alone (no interior
+// Steiner points): the loops are flattened onto their best-fit plane (NOT the surface's own
+// (u,v), which can be degenerate — e.g. a sphere patch corner landing on the lat/long pole),
+// ear-clipped there, and lifted back to their exact 3D boundary points, each triangle wound
+// outward. A coarse but watertight covering of the exact trim region — right for small patches
+// (corner blends); larger non-rectangular curved faces would want a refined triangulation.
+func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) *Mesh {
+	outer2D, holes2D := projectToPlane(outer3D, holes3D)
+	uv, pos := outer2D, outer3D
+	if len(holes2D) > 0 {
+		uv, pos = mergeHoles(outer2D, outer3D, holes2D, holes3D)
 	}
 	m := &Mesh{}
 	for _, p := range pos {
@@ -68,6 +70,61 @@ func boundaryUVMesh(s geom.Surface, outerUV []math.Point2, outer3D []math.Point3
 		m.addTriangle(a, b, c)
 	}
 	return m
+}
+
+// projectToPlane flattens the boundary loops onto the outer loop's best-fit plane (Newell
+// normal + an in-plane basis) — a non-degenerate 2D embedding of a single-valued patch.
+func projectToPlane(outer3D []math.Point3, holes3D [][]math.Point3) ([]math.Point2, [][]math.Point2) {
+	n := newellUnit(outer3D)
+	e1, e2 := planeBasis(n)
+	o := outer3D[0]
+	flat := func(p math.Point3) math.Point2 {
+		d := o.VectorTo(p)
+		return math.P2(d.Dot(e1), d.Dot(e2))
+	}
+	outer2D := make([]math.Point2, len(outer3D))
+	for i, p := range outer3D {
+		outer2D[i] = flat(p)
+	}
+	holes2D := make([][]math.Point2, len(holes3D))
+	for i, h := range holes3D {
+		hp := make([]math.Point2, len(h))
+		for j, p := range h {
+			hp[j] = flat(p)
+		}
+		holes2D[i] = hp
+	}
+	return outer2D, holes2D
+}
+
+// newellUnit returns a loop's unit normal by Newell's method (robust for non-planar loops).
+func newellUnit(loop []math.Point3) math.Vector3 {
+	var nx, ny, nz float64
+	n := len(loop)
+	for i := 0; i < n; i++ {
+		c, d := loop[i], loop[(i+1)%n]
+		nx += (c.Y - d.Y) * (c.Z + d.Z)
+		ny += (c.Z - d.Z) * (c.X + d.X)
+		nz += (c.X - d.X) * (c.Y + d.Y)
+	}
+	u, err := math.UnitVector3FromVector(math.V3(nx, ny, nz))
+	if err != nil {
+		return math.V3(0, 0, 1)
+	}
+	return u.AsVector()
+}
+
+// planeBasis returns two orthonormal in-plane vectors for the plane with unit normal n.
+func planeBasis(n math.Vector3) (e1, e2 math.Vector3) {
+	seed := math.V3(1, 0, 0)
+	if stdmath.Abs(n.X) > 0.9 {
+		seed = math.V3(0, 1, 0)
+	}
+	a, err := math.UnitVector3FromVector(n.Cross(seed))
+	if err != nil {
+		return math.V3(1, 0, 0), math.V3(0, 1, 0)
+	}
+	return a.AsVector(), n.Cross(a.AsVector())
 }
 
 // triangleFlipped reports whether triangle abc winds against the surface normal at its


### PR DESCRIPTION
## Symptom

Filleting the three edges at a box corner produced a result that **validated topologically** but whose tessellated/rendered mesh was **not watertight** at finer quality (4 → 16 open edges) — i.e. it looked non-manifold in the viewport.

## Cause

The spherical corner patch was triangulated in the sphere's own **longitude/latitude (u,v)**. An axis-aligned box always has a Z-face at every corner, so one of the patch's tangent-point corners lands exactly on the sphere's lat/long **pole**, where that parameterization is degenerate. The UV polygon collapsed there, the ear-clip stalled, and it left holes — more holes as more boundary points appeared at finer tolerance (so it happened to look watertight at the coarsest quality and broke as you zoomed/refined).

## Fix

Non-rectangular curved patches are now flattened onto their **best-fit plane** (Newell normal + in-plane basis) for the ear-clip — a non-degenerate embedding of the single-valued patch — instead of the surface's own UV. Per-vertex normals and outward winding still come from the surface. Iso-rectangle faces (cylinder/cone walls, fillet faces) keep the exact structured grid.

## Test

`TestFilletCornerBlendMeshWatertight` — the corner blend's mesh has **zero open edges** at 0.05 / 1e-2 / 1e-3 on a 4×3×5 box (the demo geometry), across corners.

`go test ./...`, vet, lint, `-race` green; head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)