### PR TITLE
M20: chamfer flat triangular blend at three-edge corners (default)

### DIFF
--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -12,19 +12,30 @@ import (
 // edges, set the setback distance in the property window, and OK to bevel them. Each
 // picked edge becomes a wedge cut on the active part.
 type ChamferTool struct {
-	edges    []EdgeHandle
-	distance float64
-	added    *feature.PartFeature
+	edges       []EdgeHandle
+	distance    float64
+	flatCorners bool
+	added       *feature.PartFeature
 }
 
-// NewChamferTool returns a chamfer tool with a default 1-unit setback.
-func NewChamferTool() *ChamferTool { return &ChamferTool{distance: 1} }
+// NewChamferTool returns a chamfer tool with a default 1-unit setback and flat three-edge
+// corners (overridden from the session preference in Start).
+func NewChamferTool() *ChamferTool { return &ChamferTool{distance: 1, flatCorners: true} }
 
 // Name implements [Tool].
 func (t *ChamferTool) Name() string { return "Chamfer" }
 
-// Start sets the selection filter to edges so clicks pick edges to bevel.
-func (t *ChamferTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+// Start sets the selection filter to edges and seeds the corner treatment from the
+// session's chamfer preference.
+func (t *ChamferTool) Start(s *Session) {
+	t.flatCorners = s.ChamferFlatCorners()
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+}
+
+// SetFlatCorners/FlatCorners choose whether a vertex where three picked edges meet is
+// blended into a flat triangular face (true) or left pointy (false).
+func (t *ChamferTool) SetFlatCorners(flat bool) { t.flatCorners = flat }
+func (t *ChamferTool) FlatCorners() bool        { return t.flatCorners }
 
 // Pick appends the clicked edge (ignoring one already chosen, so a double-click does not
 // duplicate it).
@@ -67,7 +78,7 @@ func (t *ChamferTool) Commit(s *Session) error {
 		keys[i] = e.Edge.ReferenceKey()
 	}
 	d := t.distance
-	t.added = feature.NewDressUpFeatures(part.Features()).AddChamfer(keys, func() float64 { return d })
+	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferCorners(keys, func() float64 { return d }, t.flatCorners)
 	part.Recompute()
 	if !t.added.Health().OK() {
 		return errors.New("chamfer: " + t.added.Health().Reason)

--- a/app/chamfer_tool_test.go
+++ b/app/chamfer_tool_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
 )
 
 // activePartDef returns the active document's part component definition.
@@ -80,6 +81,27 @@ func TestChamferViaRibbonCommand(t *testing.T) {
 	def := activePartDef(t, s)
 	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; v >= 8 {
 		t.Errorf("chamfer did not remove material: volume %g, want < 8", v)
+	}
+}
+
+// TestChamferToolSeedsCornerPreference checks the tool adopts the session's default
+// corner treatment on Start, and that the chosen treatment reaches the committed feature.
+func TestChamferToolSeedsCornerPreference(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	s.SetChamferFlatCorners(false)
+
+	ch := NewChamferTool()
+	s.StartTool(ch)
+	if ch.FlatCorners() {
+		t.Error("tool should have seeded pointy corners from the session preference")
+	}
+	s.Click(1, 1)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def := ch.AddedFeature().Definition().(*feature.ChamferFeature).Definition(); def.FlatCorners {
+		t.Error("committed chamfer should carry the pointy preference")
 	}
 }
 

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -59,6 +59,14 @@ func (g *GridSettings) SetSpacingIn(value float64, u param.UnitsOfMeasure) error
 	return nil
 }
 
+// ChamferFlatCorners reports the default corner treatment new Chamfer tools start with:
+// true blends a vertex where three chamfered edges meet into a flat triangular face (the
+// Inventor default), false leaves the three chamfer planes meeting at a point.
+func (s *Session) ChamferFlatCorners() bool { return s.chamferFlatCorners }
+
+// SetChamferFlatCorners sets the default corner treatment for new chamfers.
+func (s *Session) SetChamferFlatCorners(flat bool) { s.chamferFlatCorners = flat }
+
 // Grid returns the session's sketch-grid settings (created on first use).
 func (s *Session) Grid() *GridSettings {
 	if s.grid == nil {

--- a/app/session.go
+++ b/app/session.go
@@ -22,27 +22,28 @@ import (
 // it through Execute / the input methods (Click, PressKey…) — there is no GPU or
 // window involved, so "operating the UI" is fully unit-testable (ADR-0014/0004).
 type Session struct {
-	workspace       *doc.Workspace
-	commands        *CommandManager
-	bus             *event.Bus
-	selection       *Selection
-	tool            *ToolInstance
-	picker          Picker
-	camera          scene.Camera
-	camTween        cameraTween
-	sketchReturnCam scene.Camera
-	activeSketch    *sketch.Sketch
-	pendingDim      *sketch.DimensionConstraint
-	featureEdit     *featureEditState
-	overlays        []renderer.DrawItem
-	addins          *AddInManager
-	grid            *GridSettings
-	themes          *theme.Library
-	themeStore      *theme.Store
-	materials       *material.Library
-	materialStore   *material.Store
-	notice          string               // last user-facing notice (e.g. a failed-commit reason)
-	visualStyle     renderer.VisualStyle // how the scene is drawn (View tab's Visual Style)
+	workspace          *doc.Workspace
+	commands           *CommandManager
+	bus                *event.Bus
+	selection          *Selection
+	tool               *ToolInstance
+	picker             Picker
+	camera             scene.Camera
+	camTween           cameraTween
+	sketchReturnCam    scene.Camera
+	activeSketch       *sketch.Sketch
+	pendingDim         *sketch.DimensionConstraint
+	featureEdit        *featureEditState
+	overlays           []renderer.DrawItem
+	addins             *AddInManager
+	grid               *GridSettings
+	themes             *theme.Library
+	themeStore         *theme.Store
+	materials          *material.Library
+	materialStore      *material.Store
+	notice             string               // last user-facing notice (e.g. a failed-commit reason)
+	visualStyle        renderer.VisualStyle // how the scene is drawn (View tab's Visual Style)
+	chamferFlatCorners bool                 // default three-edge-corner treatment for new chamfers
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in
@@ -69,13 +70,14 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 
 func newSession(store doc.Store) *Session {
 	return &Session{
-		workspace:   doc.NewWorkspace(store),
-		commands:    NewCommandManager(),
-		bus:         event.NewBus(),
-		selection:   NewSelection(),
-		camera:      scene.NewCamera(800, 600),
-		addins:      NewAddInManager(),
-		visualStyle: renderer.ShadedWithEdges,
+		workspace:          doc.NewWorkspace(store),
+		commands:           NewCommandManager(),
+		bus:                event.NewBus(),
+		selection:          NewSelection(),
+		camera:             scene.NewCamera(800, 600),
+		addins:             NewAddInManager(),
+		visualStyle:        renderer.ShadedWithEdges,
+		chamferFlatCorners: true, // match Inventor's default flat three-edge-corner blend
 	}
 }
 

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -14,9 +14,10 @@ import (
 // The Chamfer flow in the head: while the Chamfer tool runs, a modeless options window
 // shows the picked-edge count and the setback distance (database units), then OK/Cancel.
 var chamferUI = struct {
-	distance float32
-	open     bool
-}{distance: 1}
+	distance    float32
+	flatCorners bool
+	open        bool
+}{distance: 1, flatCorners: true}
 
 // drawChamferDialog shows the chamfer options window while the Chamfer tool is active.
 func drawChamferDialog(s *app.Session) {
@@ -27,14 +28,18 @@ func drawChamferDialog(s *app.Session) {
 	}
 	if !chamferUI.open {
 		chamferUI.distance = float32(c.Distance())
+		chamferUI.flatCorners = c.FlatCorners()
 		chamferUI.open = true
 	}
-	native.SetNextWindowSize(300, 160)
+	native.SetNextWindowSize(300, 190)
 	if native.Begin("Chamfer") {
 		native.Text("Edges: " + strconv.Itoa(len(c.Edges())) + " (click edges to bevel)")
 		native.Text("Distance (" + s.LengthUnitName() + ")")
 		native.InputFloat("##chamfer-distance", &chamferUI.distance)
 		c.SetDistance(float64(chamferUI.distance))
+		if native.Checkbox("Flat corner (3 edges)", &chamferUI.flatCorners) {
+			c.SetFlatCorners(chamferUI.flatCorners)
+		}
 		native.BeginDisabled(!c.CanCommit())
 		if native.Button("OK") {
 			_ = s.OK()

--- a/head/ui/preferences_window.go
+++ b/head/ui/preferences_window.go
@@ -27,6 +27,10 @@ func drawPreferencesWindow(s *app.Session) {
 			drawGridTab(s)
 			native.EndTabItem()
 		}
+		if native.BeginTabItem("Modeling") {
+			drawModelingTab(s)
+			native.EndTabItem()
+		}
 		if native.BeginTabItem("Theme") {
 			drawAppearanceTab(s)
 			native.EndTabItem()
@@ -34,6 +38,15 @@ func drawPreferencesWindow(s *app.Session) {
 		native.EndTabBar()
 	}
 	native.End()
+}
+
+// drawModelingTab renders modeling-feature preferences (the default chamfer corner
+// treatment for now).
+func drawModelingTab(s *app.Session) {
+	flat := s.ChamferFlatCorners()
+	if native.Checkbox("Chamfer: flat triangular face at 3-edge corners", &flat) {
+		s.SetChamferFlatCorners(flat)
+	}
 }
 
 // drawGridTab renders the sketch-grid preference fields.

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -4,18 +4,26 @@ package feature
 
 import (
 	"fmt"
+	stdmath "math"
+	"sort"
 
+	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 )
 
 // chamferEdges bevels each selected edge by cutting a triangular wedge tool that runs
-// along it. All wedge tools are built from the original body up front (a boolean rebuilds
+// along it. All cut tools are built from the original body up front (a boolean rebuilds
 // topology with new lineage, so a reference key would not survive the first cut), then
 // each is subtracted in turn. Convex edges only in phase A — a concave edge would add
 // material, which is a follow-up.
-func chamferEdges(in Input, keys [][]byte, dist float64, feat string) (Output, error) {
+//
+// When flatCorners is set, every vertex where exactly three selected edges meet also gets
+// a tetrahedron cut that trims the pointy three-plane intersection into one flat
+// triangular face — the way Inventor blends such a corner by default. With it clear the
+// three chamfer planes are left to meet at a point.
+func chamferEdges(in Input, keys [][]byte, dist float64, feat string, flatCorners bool) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -23,9 +31,16 @@ func chamferEdges(in Input, keys [][]byte, dist float64, feat string) (Output, e
 	if dist <= 0 {
 		return Output{}, fmt.Errorf("chamfer: distance %g must be > 0", dist)
 	}
-	tools, err := chamferTools(body, keys, dist, feat)
+	edges, err := resolveEdges(body, keys)
 	if err != nil {
 		return Output{}, err
+	}
+	tools, err := chamferWedges(edges, dist, feat)
+	if err != nil {
+		return Output{}, err
+	}
+	if flatCorners {
+		tools = append(tools, cornerCutTools(edges, dist, feat)...)
 	}
 	result := body
 	for _, tool := range tools {
@@ -36,15 +51,24 @@ func chamferEdges(in Input, keys [][]byte, dist float64, feat string) (Output, e
 	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
 }
 
-// chamferTools resolves every edge key against the original body and builds its wedge,
-// erroring if a key is lost (so the feature goes sick honestly).
-func chamferTools(body *topo.Body, keys [][]byte, dist float64, feat string) ([]*topo.Body, error) {
-	tools := make([]*topo.Body, 0, len(keys))
+// resolveEdges binds every edge key against the original body, erroring if a key is lost
+// (so the feature goes sick honestly).
+func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, error) {
+	edges := make([]*topo.Edge, len(keys))
 	for i, k := range keys {
 		edge, ok := body.FindEdgeByKey(k)
 		if !ok {
 			return nil, fmt.Errorf("chamfer: edge reference lost")
 		}
+		edges[i] = edge
+	}
+	return edges, nil
+}
+
+// chamferWedges builds the bevel wedge for each resolved edge.
+func chamferWedges(edges []*topo.Edge, dist float64, feat string) ([]*topo.Body, error) {
+	tools := make([]*topo.Body, 0, len(edges))
+	for i, edge := range edges {
 		tool, err := chamferWedge(edge, dist, fmt.Sprintf("%s/w%d", feat, i))
 		if err != nil {
 			return nil, err
@@ -91,4 +115,250 @@ func interiorDir(f *topo.Face, edgeMid math.Point3, e math.UnitVector3) math.Vec
 		return math.V3(0, 0, 0)
 	}
 	return u.AsVector()
+}
+
+// threeEdgeCorner is a vertex where exactly three selected edges meet — the corner that
+// gets a flat triangular blend.
+type threeEdgeCorner struct {
+	vertex *topo.Vertex
+	edges  [3]*topo.Edge
+}
+
+// cornerCutTools builds the flat-corner blend cut for every three-edge corner among the
+// selected edges. A degenerate corner (collinear edges, zero-volume tetra) is skipped.
+func cornerCutTools(edges []*topo.Edge, dist float64, feat string) []*topo.Body {
+	tools := make([]*topo.Body, 0)
+	for i, c := range threeEdgeCorners(edges) {
+		if tool, ok := cornerTetra(c, dist, fmt.Sprintf("%s/c%d", feat, i)); ok {
+			tools = append(tools, tool)
+		}
+	}
+	return tools
+}
+
+// threeEdgeCorners groups the selected edges by shared vertex and returns the corners
+// where exactly three of them meet, ordered by vertex id so the cut sequence (and the
+// lineage it stamps) is reproducible across recomputes.
+func threeEdgeCorners(edges []*topo.Edge) []threeEdgeCorner {
+	at := map[uint64][]*topo.Edge{}
+	verts := map[uint64]*topo.Vertex{}
+	for _, e := range edges {
+		for _, v := range e.Vertices() {
+			at[v.ID()] = append(at[v.ID()], e)
+			verts[v.ID()] = v
+		}
+	}
+	corners := make([]threeEdgeCorner, 0)
+	for id, es := range at {
+		if len(es) == 3 {
+			corners = append(corners, threeEdgeCorner{vertex: verts[id], edges: [3]*topo.Edge{es[0], es[1], es[2]}})
+		}
+	}
+	sort.Slice(corners, func(i, j int) bool { return corners[i].vertex.ID() < corners[j].vertex.ID() })
+	return corners
+}
+
+// cornerTetra builds the tetrahedron cut that flattens a three-edge corner. Once the three
+// edge wedges are cut, their chamfer faces meet at a single pointy tip (the three chamfer
+// planes' intersection). Subtracting the tetra whose apex is that tip and whose three base
+// vertices are the outer ends of the chamfer-pair edges (see cornerBasePoints) trims the
+// protruding tip and exposes one flat triangular face. ok is false when any of the defining
+// planes are parallel/degenerate.
+func cornerTetra(c threeEdgeCorner, dist float64, feat string) (*topo.Body, bool) {
+	planes, ok := cornerChamferPlanes(c, dist)
+	if !ok {
+		return nil, false
+	}
+	tip, ok := threePlaneIntersection(planes[0], planes[1], planes[2])
+	if !ok {
+		return nil, false
+	}
+	base, ok := cornerBasePoints(c, planes)
+	if !ok || degenerateTetra(tip, base) {
+		return nil, false
+	}
+	return buildTetra([4]math.Point3{tip, base[0], base[1], base[2]}, feat), true
+}
+
+// cornerBasePoints returns the three vertices of the flat triangular face. For each pair of
+// edges, the vertex is where their two chamfer planes meet the original face the two edges
+// share — the outer vertex the chamfer-pair edge runs to. Each tetra side face then lands
+// on a chamfer plane, so the boolean trims the pointy tip cleanly and exposes the triangle.
+func cornerBasePoints(c threeEdgeCorner, planes [3]geom.Plane) ([3]math.Point3, bool) {
+	pairs := [3][2]int{{0, 1}, {0, 2}, {1, 2}}
+	var base [3]math.Point3
+	for k, pr := range pairs {
+		shared, ok := sharedFacePlane(c.edges[pr[0]], c.edges[pr[1]], c.vertex)
+		if !ok {
+			return base, false
+		}
+		q, ok := threePlaneIntersection(planes[pr[0]], planes[pr[1]], shared)
+		if !ok {
+			return base, false
+		}
+		base[k] = q
+	}
+	return base, true
+}
+
+// sharedFacePlane returns the plane of the original face that two corner edges share (each
+// edge bounds two faces; two edges meeting at a convex corner share exactly one).
+func sharedFacePlane(a, b *topo.Edge, corner *topo.Vertex) (geom.Plane, bool) {
+	f := sharedFace(a, b)
+	if f == nil {
+		return geom.Plane{}, false
+	}
+	pl, err := geom.NewPlane(corner.Point(), f.Geometry().NormalAt(0, 0))
+	if err != nil {
+		return geom.Plane{}, false
+	}
+	return pl, true
+}
+
+// sharedFace returns the single face bounding both edges, or nil if they share none.
+func sharedFace(a, b *topo.Edge) *topo.Face {
+	for _, fa := range a.Faces() {
+		for _, fb := range b.Faces() {
+			if fa.ID() == fb.ID() {
+				return fa
+			}
+		}
+	}
+	return nil
+}
+
+// cornerChamferPlanes builds the chamfer-face plane of each of the corner's three edges.
+func cornerChamferPlanes(c threeEdgeCorner, dist float64) ([3]geom.Plane, bool) {
+	var planes [3]geom.Plane
+	for i, e := range c.edges {
+		pl, ok := chamferPlane(e, c.vertex, dist)
+		if !ok {
+			return planes, false
+		}
+		planes[i] = pl
+	}
+	return planes, true
+}
+
+// chamferPlane reconstructs the plane of an edge's chamfer face at this corner: through the
+// face's two setback offsets (dist along each adjacent face interior) and parallel to the
+// edge — the same hypotenuse plane chamferWedge cuts with.
+func chamferPlane(e *topo.Edge, corner *topo.Vertex, dist float64) (geom.Plane, bool) {
+	faces := e.Faces()
+	if len(faces) != 2 {
+		return geom.Plane{}, false
+	}
+	dir, ok := edgeDirFrom(e, corner)
+	if !ok {
+		return geom.Plane{}, false
+	}
+	p := corner.Point()
+	t1, t2 := interiorDir(faces[0], p, dir), interiorDir(faces[1], p, dir)
+	if t1.LengthSquared() == 0 || t2.LengthSquared() == 0 {
+		return geom.Plane{}, false
+	}
+	pl, err := geom.NewPlaneFromAxes(p.TranslateBy(t1.Scale(dist)), dir.AsVector(), t2.Sub(t1))
+	if err != nil {
+		return geom.Plane{}, false
+	}
+	return pl, true
+}
+
+// threePlaneIntersection returns the single point common to three planes via Cramer's rule,
+// or ok=false when they share no unique point (near-zero normal determinant).
+func threePlaneIntersection(a, b, c geom.Plane) (math.Point3, bool) {
+	n1, n2, n3 := a.Normal(), b.Normal(), c.Normal()
+	det := n1.Dot(n2.Cross(n3))
+	if stdmath.Abs(float64(det)) < 1e-12 {
+		return math.Point3{}, false
+	}
+	d1 := a.Origin.AsVector().Dot(n1)
+	d2 := b.Origin.AsVector().Dot(n2)
+	d3 := c.Origin.AsVector().Dot(n3)
+	num := n2.Cross(n3).Scale(d1).Add(n3.Cross(n1).Scale(d2)).Add(n1.Cross(n2).Scale(d3))
+	return math.P3(0, 0, 0).TranslateBy(num.Scale(1 / det)), true
+}
+
+// edgeDirFrom returns the unit direction leaving v along edge e toward its other vertex.
+func edgeDirFrom(e *topo.Edge, v *topo.Vertex) (math.UnitVector3, bool) {
+	other := e.EndVertex()
+	if other.ID() == v.ID() {
+		other = e.StartVertex()
+	}
+	u, err := math.UnitVector3FromVector(v.Point().VectorTo(other.Point()))
+	if err != nil {
+		return math.UnitVector3{}, false
+	}
+	return u, true
+}
+
+// degenerateTetra reports whether the apex and the three base points are (near) coplanar,
+// so the cut solid would have no volume (scalar triple product ≈ 0).
+func degenerateTetra(apex math.Point3, base [3]math.Point3) bool {
+	a := apex.VectorTo(base[0])
+	b := apex.VectorTo(base[1])
+	c := apex.VectorTo(base[2])
+	return stdmath.Abs(float64(a.Cross(b).Dot(c))) < 1e-12
+}
+
+// tetraEdges holds the six edges of a tetrahedron keyed by their ascending vertex-index
+// pair, so the four triangular faces can share them with the right traversal direction.
+type tetraEdges map[[2]int]*topo.Edge
+
+// use returns the oriented use that traverses the tetra edge from vertex i to vertex j.
+func (te tetraEdges) use(i, j int) topo.Use {
+	if i < j {
+		return topo.Fwd(te[[2]int{i, j}])
+	}
+	return topo.Rev(te[[2]int{j, i}])
+}
+
+// buildTetra assembles a solid tetrahedron from four points as a boolean cut tool. Each
+// triangular face is planar with its plane oriented outward (away from the opposite
+// vertex) and its loop wound to match, so the body is a valid closed solid the boolean can
+// subtract. Vertex 0 is the apex; 1..3 the base.
+func buildTetra(p [4]math.Point3, feat string) *topo.Body {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	var v [4]*topo.Vertex
+	for i := range p {
+		v[i] = bld.AddVertex(p[i], topo.NewLineage(topo.Tok(feat, "vertex", i)))
+	}
+	edges := newTetraEdges(bld, p, v, feat)
+	faces := [4][3]int{{1, 2, 3}, {0, 2, 3}, {0, 1, 3}, {0, 1, 2}}
+	opposite := [4]int{0, 1, 2, 3}
+	for fi, tri := range faces {
+		addTetraFace(bld, p, edges, tri, opposite[fi], feat, fi)
+	}
+	return bld.Build()
+}
+
+// newTetraEdges builds the six line-segment edges of the tetrahedron, each stored under
+// its ascending vertex-index pair.
+func newTetraEdges(bld *topo.Builder, p [4]math.Point3, v [4]*topo.Vertex, feat string) tetraEdges {
+	pairs := [6][2]int{{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}}
+	te := make(tetraEdges, 6)
+	for k, pr := range pairs {
+		te[pr] = bld.AddEdge(geom.NewLineSegment(p[pr[0]], p[pr[1]]), v[pr[0]], v[pr[1]], topo.NewLineage(topo.Tok(feat, "edge", k)))
+	}
+	return te
+}
+
+// addTetraFace adds the triangular face through corner triple tri, flipping the traversal
+// so its plane normal points away from the opposite vertex (outward) and winding the loop
+// to match. A near-degenerate triangle is dropped (cornerTetra already filters flat
+// tetras).
+func addTetraFace(bld *topo.Builder, p [4]math.Point3, te tetraEdges, tri [3]int, opp int, feat string, fi int) {
+	a, b, c := tri[0], tri[1], tri[2]
+	n := p[a].VectorTo(p[b]).Cross(p[a].VectorTo(p[c]))
+	if n.Dot(p[a].VectorTo(p[opp])) > 0 { // points toward the interior vertex → flip
+		b, c = c, b
+		n = n.Negate()
+	}
+	unit, err := math.UnitVector3FromVector(n)
+	if err != nil {
+		return
+	}
+	surf, _ := geom.NewPlane(p[a], unit.AsVector())
+	loop := topo.OuterLoop(te.use(a, b), te.use(b, c), te.use(c, a))
+	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "face", fi)), loop)
 }

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -40,10 +40,13 @@ func (f *FilletFeature) Recompute(in Input) (Output, error) {
 	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), "fillet")
 }
 
-// ChamferDefinition bevels selected edges by a distance.
+// ChamferDefinition bevels selected edges by a distance. FlatCorners blends a vertex
+// where three selected edges meet into a flat triangular face (the Inventor default);
+// when false the three chamfer planes are left to meet at a point.
 type ChamferDefinition struct {
-	EdgeKeys [][]byte
-	Distance func() float64
+	EdgeKeys    [][]byte
+	Distance    func() float64
+	FlatCorners bool
 }
 
 // ChamferFeature is an equal-distance edge chamfer.
@@ -58,7 +61,7 @@ func (c *ChamferFeature) Kind() string                   { return "chamfer" }
 // Recompute bevels each selected (convex) edge by cutting a wedge tool along it via the
 // boolean. See chamfer.go.
 func (c *ChamferFeature) Recompute(in Input) (Output, error) {
-	return chamferEdges(in, c.def.EdgeKeys, callOrZero(c.def.Distance), featOr(c.featName, "chamfer"))
+	return chamferEdges(in, c.def.EdgeKeys, callOrZero(c.def.Distance), featOr(c.featName, "chamfer"), c.def.FlatCorners)
 }
 
 // ShellDefinition hollows a body, removing the selected faces, to a wall thickness.
@@ -151,9 +154,16 @@ func (c *DressUpFeatures) AddFillet(edgeKeys [][]byte, radius func() float64) *P
 	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius}})
 }
 
-// AddChamfer bevels the given edges by distance.
+// AddChamfer bevels the given edges by distance, blending three-edge corners flat (the
+// default treatment). Use [AddChamferCorners] to choose the pointy corner instead.
 func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64) *PartFeature {
-	cf := &ChamferFeature{def: &ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance}}
+	return c.AddChamferCorners(edgeKeys, distance, true)
+}
+
+// AddChamferCorners bevels the given edges by distance; flatCorners selects whether a
+// three-edge corner is blended into a flat triangular face (true) or left pointy (false).
+func (c *DressUpFeatures) AddChamferCorners(edgeKeys [][]byte, distance func() float64, flatCorners bool) *PartFeature {
+	cf := &ChamferFeature{def: &ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, FlatCorners: flatCorners}}
 	pf := c.engine.Add(cf)
 	pf.SetName(c.engine.UniqueName("Chamfer"))
 	cf.featName = pf.name

--- a/model/feature/dressup_test.go
+++ b/model/feature/dressup_test.go
@@ -77,6 +77,73 @@ func TestChamferAllFourVerticalEdges(t *testing.T) {
 	}
 }
 
+// edgesAtCorner returns the reference keys of every box edge touching the point p.
+func edgesAtCorner(b *topo.Body, p math.Point3) [][]byte {
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		if e.StartVertex().Point().IsEqualTo(p, 1e-9) || e.EndVertex().Point().IsEqualTo(p, 1e-9) {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	return keys
+}
+
+// chamferedCorner chamfers the three edges meeting at the box's (0,0,0) corner and returns
+// the resulting body, with flat or pointy corner treatment.
+func chamferedCorner(t *testing.T, flat bool) *topo.Body {
+	t.Helper()
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	keys := edgesAtCorner(box, math.P3(0, 0, 0))
+	if len(keys) != 3 {
+		t.Fatalf("found %d edges at the corner, want 3", len(keys))
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	ch := NewDressUpFeatures(fs).AddChamferCorners(keys, func() float64 { return 0.5 }, flat)
+	fs.Recompute()
+	if !ch.Health().OK() {
+		t.Fatalf("corner chamfer (flat=%v) sick: %+v", flat, ch.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("corner chamfer (flat=%v) not a valid solid: %+v", flat, r)
+	}
+	return res
+}
+
+// hasFlatCornerFace reports whether the body carries the triangular blend face on the
+// corner's diagonal plane — the flat-corner result. Its outward normal points away from
+// the solid toward the (0,0,0) corner, i.e. along (−1,−1,−1)/√3.
+func hasFlatCornerFace(b *topo.Body) bool {
+	for _, f := range b.Faces() {
+		n := f.Geometry().NormalAt(0, 0)
+		if len(f.Edges()) == 3 && n.X < -0.5 && n.Y < -0.5 && n.Z < -0.5 {
+			return true
+		}
+	}
+	return false
+}
+
+// TestChamferFlatCornerBlendsThreeEdges checks that flat-corner chamfering three edges of a
+// box corner trims the pointy three-plane tip into a triangular face, removing the extra
+// sliver of material the pointy treatment keeps.
+func TestChamferFlatCornerBlendsThreeEdges(t *testing.T) {
+	flat := chamferedCorner(t, true)
+	pointy := chamferedCorner(t, false)
+
+	if !hasFlatCornerFace(flat) {
+		t.Error("flat-corner chamfer did not produce a triangular blend face")
+	}
+	if hasFlatCornerFace(pointy) {
+		t.Error("pointy chamfer unexpectedly produced a flat triangular corner face")
+	}
+	volFlat := ops.BodyGeometryProperties(flat, ops.DefaultQuality()).Volume
+	volPointy := ops.BodyGeometryProperties(pointy, ops.DefaultQuality()).Volume
+	if !(volFlat < volPointy) {
+		t.Errorf("flat corner volume %g should be less than pointy %g (it trims the tip)", volFlat, volPointy)
+	}
+}
+
 // prismBody builds a unit-square prism via the extrude generator (for real edges).
 func prismBody() *topo.Body {
 	return buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1}, {X: 0, Y: 1}}, sketch.XYPlane(), span{near: 0, far: 1}, 0, "ext")

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -98,7 +98,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 	case *FilletFeature:
 		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius)}
 	case *ChamferFeature:
-		fd.Chamfer = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Distance)}
+		flat := f.def.FlatCorners
+		fd.Chamfer = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Distance), FlatCorners: &flat}
 	case *ShellFeature:
 		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness)}
 	case *FaceDraftFeature:
@@ -255,7 +256,7 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if err != nil {
 			return nil, err
 		}
-		return du.AddChamfer(d.keys, constFloat(d.value)), nil
+		return du.AddChamferCorners(d.keys, constFloat(d.value), chamferFlatCornersOr(fd.Chamfer.FlatCorners)), nil
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -24,10 +24,13 @@ func draftPull(p []float64) math.Vector3 {
 // and re-bind to the regenerated topology after recompute.
 
 // EdgeDressData is an edge-based dress-up (fillet radius / chamfer distance): the
-// picked edges as reference keys plus the scalar value.
+// picked edges as reference keys plus the scalar value. FlatCorners is chamfer-only and a
+// pointer so an absent value (older recipes, or a fillet) is distinguishable from an
+// explicit false; absent restores as the flat-corner default (see chamferFlatCornersOr).
 type EdgeDressData struct {
-	Edges []string `yaml:"edges"`
-	Value float64  `yaml:"value"`
+	Edges       []string `yaml:"edges"`
+	Value       float64  `yaml:"value"`
+	FlatCorners *bool    `yaml:"flatCorners,omitempty"`
 }
 
 // FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked
@@ -115,3 +118,12 @@ func evalFloat(fn func() float64) float64 {
 }
 
 func constFloat(v float64) func() float64 { return func() float64 { return v } }
+
+// chamferFlatCornersOr reads a serialized chamfer's flat-corner flag, defaulting an absent
+// value (older recipes) to the flat-corner default so reopening matches a fresh chamfer.
+func chamferFlatCornersOr(p *bool) bool {
+	if p == nil {
+		return true
+	}
+	return *p
+}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -89,6 +89,40 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestChamferFlatCornersRoundTrip checks the chamfer corner treatment survives a recipe
+// round trip in both states, and that an older recipe with no flag restores as flat (the
+// default, matching a freshly created chamfer).
+func TestChamferFlatCornersRoundTrip(t *testing.T) {
+	for _, flat := range []bool{true, false} {
+		fs := NewPartFeatures(nil, nil)
+		NewDressUpFeatures(fs).AddChamferCorners([][]byte{[]byte("edge")}, func() float64 { return 0.3 }, flat)
+		data, err := fs.MarshalRecipe(oneSketch{})
+		if err != nil {
+			t.Fatalf("MarshalRecipe(flat=%v): %v", flat, err)
+		}
+		if data[0].Chamfer.FlatCorners == nil || *data[0].Chamfer.FlatCorners != flat {
+			t.Fatalf("serialized FlatCorners = %v, want %v", data[0].Chamfer.FlatCorners, flat)
+		}
+		fresh := NewPartFeatures(nil, nil)
+		if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+			t.Fatalf("ApplyRecipe(flat=%v): %v", flat, err)
+		}
+		if got := fresh.Item(0).Definition().(*ChamferFeature).Definition().FlatCorners; got != flat {
+			t.Errorf("restored FlatCorners = %v, want %v", got, flat)
+		}
+	}
+
+	// An older recipe without the flag restores as flat (the default).
+	fresh := NewPartFeatures(nil, nil)
+	legacy := []FeatureData{{Kind: "chamfer", Chamfer: &EdgeDressData{Edges: []string{}, Value: 0.3}}}
+	if err := fresh.ApplyRecipe(legacy, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe(legacy): %v", err)
+	}
+	if !fresh.Item(0).Definition().(*ChamferFeature).Definition().FlatCorners {
+		t.Error("legacy chamfer without flatCorners should restore as flat")
+	}
+}
+
 func TestSolidFeaturesRoundTrip(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewHoleFeatures(fs).AddTapped([]byte("face-1"), func() float64 { return 6 }, func() float64 { return 10 }, "M6x1")


### PR DESCRIPTION
## What

When three chamfered edges meet at a corner, generate a **flat triangular face** there instead of the pointy three-plane intersection — and make it the default, matching how Inventor handles such corners. A preference and a per-feature toggle keep the old pointy behavior available.

## Why

Previously every three-edge corner came to a sharp point where the three chamfer planes met. That's geometrically valid but does not match Inventor's default (a flat triangular blend), which the user expects.

## How it works

Edge chamfering still cuts one wedge per edge. When three selected edges share a vertex, a **corner tetrahedron** is also subtracted:
- **apex** = the point where the three chamfer-face planes intersect (the pointy tip);
- **base vertices** = for each pair of edges, where their two chamfer planes meet the original face the two edges share — so every tetra side face lands on a chamfer plane and the boolean trims the tip cleanly into one flat triangle.

Corners are cut in vertex-id order for reproducible lineage; degenerate/parallel corners are skipped. Corners of valence > 3 keep the pointy intersection (flagged as a follow-up).

## Surface

- **Model**: `ChamferDefinition.FlatCorners`; new `AddChamferCorners(...)` (`AddChamfer` defaults to flat).
- **Persistence**: `EdgeDressData.FlatCorners *bool` — a pointer so an absent flag in older recipes restores as flat (matching a fresh chamfer).
- **App**: `Session.ChamferFlatCorners()` preference (default true); `ChamferTool` seeds from it on Start.
- **Head UI**: "Flat corner (3 edges)" checkbox in the Chamfer options window + a Modeling tab in Preferences.

No public API/wire surface touched — chamfer is internal, driven in-proc.

## Tests

- `TestChamferFlatCornerBlendsThreeEdges` — flat produces a triangular blend face and removes more material than pointy; pointy produces no such face.
- `TestChamferFlatCornersRoundTrip` — both states round-trip; legacy recipes restore as flat.
- `TestChamferToolSeedsCornerPreference` — the tool adopts the session default and carries it to the committed feature.

`go build ./...`, `go vet ./...`, `go test ./...`, and the cgo head `ui` build all pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)