### PR TITLE
Parameters dialog (Manage ▸ Parameters) + parameter-model upgrades

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -28,9 +28,30 @@ func standardCommands() []*CommandDefinition {
 	var cmds []*CommandDefinition
 	cmds = append(cmds, modelTabCommands()...)
 	cmds = append(cmds, workFeatureCommands()...)
+	cmds = append(cmds, manageTabCommands()...)
 	cmds = append(cmds, sketchTabCommands()...)
 	cmds = append(cmds, viewTabCommands()...)
 	return cmds
+}
+
+// manageTabCommands are the Manage tab's Parameters panel: open the Parameters dialog
+// (Inventor's Manage ▸ Parameters). Enabled whenever a part is active.
+func manageTabCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		NewCommand("Manage.Parameters", "Parameters", "Parameters", func(s *Session) error {
+			s.OpenParameters()
+			return nil
+		}).WithTab("Manage").WithEnable(hasActivePart).
+			WithIcon("parameters").WithButtonStyle(LargeIconButton).
+			WithTooltip("Parameters — add, edit, and organize the model and user parameters that drive the part."),
+	}
+}
+
+// hasActivePart reports whether the active document is a part (the Parameters dialog
+// needs one to read and edit).
+func hasActivePart(s *Session) bool {
+	_, err := activePart(s)
+	return err == nil
 }
 
 // workFeatureCommands are the 3D Model tab's Work Features panel: the datum-plane

--- a/app/parameters.go
+++ b/app/parameters.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// The Manage ▸ Parameters dialog is driven through the session: the head asks for
+// presentation-ready rows (strings/bools only — the units and formatting stay here, as
+// with the sketch-grid preference) and calls the edit verbs in parameters_edit.go, which
+// mutate the active part's parameters and recompute. State is the open flag plus the
+// part's own [param.Parameters]; there is no separate dialog model to keep in sync.
+
+// OpenParameters / CloseParameters / ParametersOpen drive the dialog's visibility.
+func (s *Session) OpenParameters()      { s.paramsDialogOpen = true }
+func (s *Session) CloseParameters()     { s.paramsDialogOpen = false }
+func (s *Session) ParametersOpen() bool { return s.paramsDialogOpen }
+
+// ParameterRow is one parameter rendered for the dialog: identity plus the already-
+// formatted text the table cells show. Value/Equation are in the document's display units.
+type ParameterRow struct {
+	ID         param.ID
+	Name       string
+	UnitName   string // "mm", "deg", "Text", "Boolean", …
+	ValueType  string // "numeric" | "text" | "boolean"
+	Equation   string // expression, quoted text, or true/false
+	Value      string // formatted nominal value
+	Comment    string
+	Group      string
+	Options    []string // dropdown choices when multi-value (list + current custom value)
+	Tolerance  string   // formatted band, "" when none
+	IsKey      bool
+	Export     bool
+	Editable   bool
+	MultiValue bool
+	Healthy    bool
+	Health     string // reason when not healthy
+}
+
+// ParameterRows returns the active part's parameters split into the Model and User tables
+// (Inventor's two lists), each filtered by the search query (matched across name, equation,
+// and comment). With no active part both slices are empty.
+func (s *Session) ParameterRows(filter string) (model, user []ParameterRow) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, nil
+	}
+	q := strings.ToLower(strings.TrimSpace(filter))
+	for _, p := range part.Parameters().All() {
+		row := s.parameterRow(part.Parameters(), p)
+		if !matchParameter(row, q) {
+			continue
+		}
+		if p.Kind() == param.UserParam {
+			user = append(user, row)
+		} else {
+			model = append(model, row)
+		}
+	}
+	return model, user
+}
+
+// parameterRow projects one parameter into its presentation row.
+func (s *Session) parameterRow(ps *param.Parameters, p *param.Parameter) ParameterRow {
+	group, _ := ps.GroupOf(p.ID())
+	row := ParameterRow{
+		ID: p.ID(), Name: p.Name(), ValueType: valueTypeName(p), Equation: p.Expression(),
+		Comment: p.Comment, Group: group, IsKey: p.IsKey, Export: p.ExposedAsProperty,
+		Editable: p.Kind().Editable(), MultiValue: p.IsMultiValue(),
+		Healthy: p.Health().OK(), Health: p.Health().Reason,
+	}
+	s.fillRowValue(&row, p)
+	if p.IsMultiValue() {
+		row.Options = multiValueOptions(p)
+	}
+	return row
+}
+
+// fillRowValue formats the unit name, displayed value, and tolerance for a row, branching
+// on the parameter's value flavor.
+func (s *Session) fillRowValue(row *ParameterRow, p *param.Parameter) {
+	switch {
+	case p.IsText():
+		row.UnitName, row.Value = "Text", p.Text()
+	case p.IsBoolean():
+		row.UnitName, row.Value = "Boolean", p.Expression()
+	default:
+		u := s.DocumentUnits()
+		row.UnitName, row.Value = u.PreferredName(p.Unit()), u.Format(p.Value())
+		if t := p.Tolerance(); t != (param.Tolerance{}) {
+			row.Tolerance = u.Format(param.Q(t.Upper, p.Unit())) + " / " + u.Format(param.Q(t.Lower, p.Unit()))
+		}
+	}
+}
+
+// valueTypeName names a parameter's value flavor for the row.
+func valueTypeName(p *param.Parameter) string {
+	switch {
+	case p.IsText():
+		return "text"
+	case p.IsBoolean():
+		return "boolean"
+	default:
+		return "numeric"
+	}
+}
+
+// multiValueOptions returns the dropdown choices for a multi-value parameter: its fixed
+// list plus the current value when that value is a custom one outside the list.
+func multiValueOptions(p *param.Parameter) []string {
+	list := p.ExpressionList()
+	current := p.Expression()
+	for _, v := range list {
+		if v == current {
+			return list
+		}
+	}
+	if p.AllowsCustomValue() {
+		return append(list, current)
+	}
+	return list
+}
+
+// matchParameter reports whether a row matches the lowercased search query (empty matches
+// all), searched across the name, equation, and comment — Inventor's parameter search.
+func matchParameter(row ParameterRow, query string) bool {
+	if query == "" {
+		return true
+	}
+	hay := strings.ToLower(row.Name + "\x00" + row.Equation + "\x00" + row.Comment)
+	return strings.Contains(hay, query)
+}

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -65,9 +65,11 @@ func (s *Session) SetParameterBool(id param.ID, value bool) error {
 func (s *Session) SetParameterComment(id param.ID, comment string) error {
 	return s.editParam(id, func(p *param.Parameter) error { p.Comment = comment; return nil })
 }
+
 func (s *Session) SetParameterKey(id param.ID, key bool) error {
 	return s.editParam(id, func(p *param.Parameter) error { p.IsKey = key; return nil })
 }
+
 func (s *Session) SetParameterExport(id param.ID, export bool) error {
 	return s.editParam(id, func(p *param.Parameter) error { p.ExposedAsProperty = export; return nil })
 }
@@ -84,6 +86,7 @@ func (s *Session) SetParameterTolerance(id param.ID, upper, lower float64, kind 
 func (s *Session) SetParameterValueList(id param.ID, list []string, allowCustom bool) error {
 	return s.editParam(id, func(p *param.Parameter) error { return p.SetExpressionList(list, allowCustom) })
 }
+
 func (s *Session) ClearParameterValueList(id param.ID) error {
 	return s.editParam(id, func(p *param.Parameter) error { p.ClearExpressionList(); return nil })
 }
@@ -105,6 +108,7 @@ func (s *Session) DeleteParameter(id param.ID) error {
 func (s *Session) AddParameterToGroup(id param.ID, group string) error {
 	return s.editParameters(func(ps *param.Parameters) error { return ps.AddToGroup(id, group) })
 }
+
 func (s *Session) RemoveParameterFromGroup(id param.ID) error {
 	return s.editParameters(func(ps *param.Parameters) error { return ps.RemoveFromGroup(id) })
 }
@@ -114,6 +118,7 @@ func (s *Session) RemoveParameterFromGroup(id param.ID) error {
 func (s *Session) RenameParameterGroup(oldName, newName string) error {
 	return s.editParameters(func(ps *param.Parameters) error { return ps.RenameGroup(oldName, newName) })
 }
+
 func (s *Session) DeleteParameterGroup(name string) error {
 	return s.editParameters(func(ps *param.Parameters) error { return ps.DeleteGroup(name) })
 }

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// Edit verbs for the Parameters dialog. Each resolves the active part, mutates its
+// parameter collection, then recomputes the part so a model parameter's edit flows into
+// the features that consume it; a failure surfaces through the session notice (the status
+// bar) rather than a panic, matching the rest of the app.
+
+// AddNumericUserParameter adds a numeric user parameter from an expression.
+func (s *Session) AddNumericUserParameter(name, expression string) error {
+	return s.editParameters(func(ps *param.Parameters) error {
+		_, err := ps.AddUserParameter(name, expression)
+		return err
+	})
+}
+
+// AddTextUserParameter adds a text user parameter.
+func (s *Session) AddTextUserParameter(name, value string) error {
+	return s.editParameters(func(ps *param.Parameters) error {
+		_, err := ps.AddTextUserParameter(name, value)
+		return err
+	})
+}
+
+// AddBooleanUserParameter adds a true/false user parameter.
+func (s *Session) AddBooleanUserParameter(name string, value bool) error {
+	return s.editParameters(func(ps *param.Parameters) error {
+		_, err := ps.AddBooleanUserParameter(name, value)
+		return err
+	})
+}
+
+// SetParameterName renames a parameter (dependent expressions re-track by id).
+func (s *Session) SetParameterName(id param.ID, name string) error {
+	return s.editParameters(func(ps *param.Parameters) error { return ps.Rename(id, name) })
+}
+
+// SetParameterEquation sets a parameter's equation: an expression for numeric parameters
+// (a list choice when multi-value), or the literal for text parameters.
+func (s *Session) SetParameterEquation(id param.ID, equation string) error {
+	return s.editParam(id, func(p *param.Parameter) error {
+		if p.IsMultiValue() {
+			return p.SelectValue(equation)
+		}
+		if p.IsText() {
+			return p.SetText(equation)
+		}
+		return p.SetExpression(equation)
+	})
+}
+
+// SetParameterBool sets a true/false parameter's value.
+func (s *Session) SetParameterBool(id param.ID, value bool) error {
+	return s.editParam(id, func(p *param.Parameter) error { return p.SetBool(value) })
+}
+
+// SetParameterComment / SetParameterKey / SetParameterExport set the presentation flags.
+func (s *Session) SetParameterComment(id param.ID, comment string) error {
+	return s.editParam(id, func(p *param.Parameter) error { p.Comment = comment; return nil })
+}
+func (s *Session) SetParameterKey(id param.ID, key bool) error {
+	return s.editParam(id, func(p *param.Parameter) error { p.IsKey = key; return nil })
+}
+func (s *Session) SetParameterExport(id param.ID, export bool) error {
+	return s.editParam(id, func(p *param.Parameter) error { p.ExposedAsProperty = export; return nil })
+}
+
+// SetParameterTolerance sets a numeric parameter's engineering tolerance band.
+func (s *Session) SetParameterTolerance(id param.ID, upper, lower float64, kind param.ModelValueType) error {
+	return s.editParam(id, func(p *param.Parameter) error {
+		p.SetTolerance(param.Tolerance{Upper: upper, Lower: lower, Type: kind})
+		return nil
+	})
+}
+
+// SetParameterValueList makes a parameter multi-value; ClearParameterValueList reverts it.
+func (s *Session) SetParameterValueList(id param.ID, list []string, allowCustom bool) error {
+	return s.editParam(id, func(p *param.Parameter) error { return p.SetExpressionList(list, allowCustom) })
+}
+func (s *Session) ClearParameterValueList(id param.ID) error {
+	return s.editParam(id, func(p *param.Parameter) error { p.ClearExpressionList(); return nil })
+}
+
+// CopyParameterToUser duplicates a parameter as a new user parameter.
+func (s *Session) CopyParameterToUser(id param.ID) error {
+	return s.editParameters(func(ps *param.Parameters) error {
+		_, err := ps.CopyToUser(id)
+		return err
+	})
+}
+
+// DeleteParameter removes a parameter (its dependents go sick on the lost reference).
+func (s *Session) DeleteParameter(id param.ID) error {
+	return s.editParameters(func(ps *param.Parameters) error { return ps.Delete(id) })
+}
+
+// AddParameterToGroup / RemoveParameterFromGroup manage a parameter's group membership.
+func (s *Session) AddParameterToGroup(id param.ID, group string) error {
+	return s.editParameters(func(ps *param.Parameters) error { return ps.AddToGroup(id, group) })
+}
+func (s *Session) RemoveParameterFromGroup(id param.ID) error {
+	return s.editParameters(func(ps *param.Parameters) error { return ps.RemoveFromGroup(id) })
+}
+
+// RenameParameterGroup / DeleteParameterGroup manage the custom groups themselves
+// (deleting a group also deletes its member parameters).
+func (s *Session) RenameParameterGroup(oldName, newName string) error {
+	return s.editParameters(func(ps *param.Parameters) error { return ps.RenameGroup(oldName, newName) })
+}
+func (s *Session) DeleteParameterGroup(name string) error {
+	return s.editParameters(func(ps *param.Parameters) error { return ps.DeleteGroup(name) })
+}
+
+// editParam resolves the parameter by id and applies edit, then recomputes.
+func (s *Session) editParam(id param.ID, edit func(*param.Parameter) error) error {
+	return s.editParameters(func(ps *param.Parameters) error {
+		p, ok := ps.ByID(id)
+		if !ok {
+			return fmt.Errorf("app: no parameter with id %d", id)
+		}
+		return edit(p)
+	})
+}
+
+// editParameters runs edit against the active part's parameter collection, records any
+// error as the session notice, recomputes the part on success, and returns the error.
+func (s *Session) editParameters(edit func(*param.Parameters) error) error {
+	part, err := activePart(s)
+	if err != nil {
+		s.notice = err.Error()
+		return err
+	}
+	if err := edit(part.Parameters()); err != nil {
+		s.notice = err.Error()
+		return err
+	}
+	s.notice = ""
+	part.Recompute()
+	return nil
+}

--- a/app/parameters_test.go
+++ b/app/parameters_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// newSessionWithPart returns a session whose active document is an empty part — enough to
+// drive the Parameters dialog headlessly.
+func newSessionWithPart(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "Part1", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	return s
+}
+
+// partParams returns the active part's parameter collection.
+func partParams(t *testing.T, s *Session) *param.Parameters {
+	t.Helper()
+	part, err := activePart(s)
+	if err != nil {
+		t.Fatalf("activePart: %v", err)
+	}
+	return part.Parameters()
+}
+
+// rowByName finds a parameter row by name across the model and user tables.
+func rowByName(rows []ParameterRow, name string) (ParameterRow, bool) {
+	for _, r := range rows {
+		if r.Name == name {
+			return r, true
+		}
+	}
+	return ParameterRow{}, false
+}
+
+func TestParametersCommandOpensDialog(t *testing.T) {
+	s := newSessionWithPart(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if s.ParametersOpen() {
+		t.Fatal("dialog should start closed")
+	}
+	if err := s.Execute("Manage.Parameters"); err != nil {
+		t.Fatalf("Execute Manage.Parameters: %v", err)
+	}
+	if !s.ParametersOpen() {
+		t.Error("Manage.Parameters should open the dialog")
+	}
+	if _, ok := BuildRibbon(s).Tab("Manage"); !ok {
+		t.Error("Manage tab should exist on the ribbon")
+	}
+	s.CloseParameters()
+	if s.ParametersOpen() {
+		t.Error("CloseParameters should close the dialog")
+	}
+}
+
+// TestParameterRowsSplitAndFilter checks Model vs User splitting and the search filter.
+func TestParameterRowsSplitAndFilter(t *testing.T) {
+	s := newSessionWithPart(t)
+	ps := partParams(t, s)
+	if _, err := ps.AddModelParameter("d0", "10 mm"); err != nil {
+		t.Fatalf("AddModelParameter: %v", err)
+	}
+	_ = s.AddNumericUserParameter("width", "20 mm")
+	_ = s.AddTextUserParameter("finish", "anodized")
+
+	model, user := s.ParameterRows("")
+	if _, ok := rowByName(model, "d0"); !ok {
+		t.Error("d0 should be in the model table")
+	}
+	if len(user) != 2 {
+		t.Errorf("user rows = %d, want 2", len(user))
+	}
+	if w, ok := rowByName(user, "width"); !ok || w.Value != "20 mm" {
+		t.Errorf("width row = %+v ok=%v, want value 20 mm", w, ok)
+	}
+
+	// Search matches across name/equation/comment; "anod" only hits the text parameter.
+	_, filtered := s.ParameterRows("anod")
+	if len(filtered) != 1 || filtered[0].Name != "finish" {
+		t.Errorf("filtered user rows = %+v, want only finish", filtered)
+	}
+}
+
+// TestParameterEditFlow drives the dialog's edit verbs end to end.
+func TestParameterEditFlow(t *testing.T) {
+	s := newSessionWithPart(t)
+	if err := s.AddNumericUserParameter("len", "10 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter: %v", err)
+	}
+	ps := partParams(t, s)
+	id := mustParamID(t, ps, "len")
+
+	if err := s.SetParameterEquation(id, "25 mm"); err != nil {
+		t.Fatalf("SetParameterEquation: %v", err)
+	}
+	if err := s.SetParameterComment(id, "the length"); err != nil {
+		t.Fatalf("SetParameterComment: %v", err)
+	}
+	_ = s.SetParameterKey(id, true)
+	_ = s.SetParameterExport(id, true)
+
+	_, user := s.ParameterRows("")
+	row, _ := rowByName(user, "len")
+	if row.Value != "25 mm" || row.Comment != "the length" || !row.IsKey || !row.Export {
+		t.Errorf("edited row = %+v, want value 25 mm, comment set, key+export", row)
+	}
+
+	// Multi-value: make a list, select a value, then reject an off-list value.
+	if err := s.SetParameterValueList(id, []string{"25 mm", "30 mm"}, false); err != nil {
+		t.Fatalf("SetParameterValueList: %v", err)
+	}
+	if err := s.SetParameterEquation(id, "30 mm"); err != nil {
+		t.Fatalf("select list value: %v", err)
+	}
+	if err := s.SetParameterEquation(id, "99 mm"); err == nil {
+		t.Error("selecting an off-list value should fail when custom is not allowed")
+	}
+
+	// Groups: add, then the row reports membership.
+	if err := s.AddParameterToGroup(id, "Frame"); err != nil {
+		t.Fatalf("AddParameterToGroup: %v", err)
+	}
+	_, user = s.ParameterRows("")
+	if row, _ := rowByName(user, "len"); row.Group != "Frame" {
+		t.Errorf("group = %q, want Frame", row.Group)
+	}
+
+	// Copy to user, then delete the original.
+	if err := s.CopyParameterToUser(id); err != nil {
+		t.Fatalf("CopyParameterToUser: %v", err)
+	}
+	if _, ok := ps.ByName("len_copy"); !ok {
+		t.Error("copy len_copy should exist")
+	}
+	if err := s.DeleteParameter(id); err != nil {
+		t.Fatalf("DeleteParameter: %v", err)
+	}
+	if _, ok := ps.ByName("len"); ok {
+		t.Error("len should be deleted")
+	}
+}
+
+// TestAddBooleanAndTextParameters covers the non-numeric add verbs and their rows.
+func TestAddBooleanAndTextParameters(t *testing.T) {
+	s := newSessionWithPart(t)
+	if err := s.AddBooleanUserParameter("vented", true); err != nil {
+		t.Fatalf("AddBooleanUserParameter: %v", err)
+	}
+	_, user := s.ParameterRows("")
+	row, ok := rowByName(user, "vented")
+	if !ok || row.ValueType != "boolean" || row.Equation != "true" {
+		t.Errorf("boolean row = %+v ok=%v, want boolean/true", row, ok)
+	}
+	id := mustParamID(t, partParams(t, s), "vented")
+	if err := s.SetParameterBool(id, false); err != nil {
+		t.Fatalf("SetParameterBool: %v", err)
+	}
+	_, user = s.ParameterRows("")
+	if row, _ := rowByName(user, "vented"); row.Equation != "false" {
+		t.Errorf("after SetParameterBool(false) equation = %q, want false", row.Equation)
+	}
+}
+
+func mustParamID(t *testing.T, ps *param.Parameters, name string) param.ID {
+	t.Helper()
+	p, ok := ps.ByName(name)
+	if !ok {
+		t.Fatalf("no parameter named %q", name)
+	}
+	return p.ID()
+}

--- a/app/session.go
+++ b/app/session.go
@@ -44,6 +44,7 @@ type Session struct {
 	notice             string               // last user-facing notice (e.g. a failed-commit reason)
 	visualStyle        renderer.VisualStyle // how the scene is drawn (View tab's Visual Style)
 	chamferFlatCorners bool                 // default three-edge-corner treatment for new chamfers
+	paramsDialogOpen   bool                 // the Manage ▸ Parameters dialog is open
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/head/icon/assets/parameters.svg
+++ b/head/icon/assets/parameters.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9 H21"/><path d="M9 9 V20"/><path d="M6 14 H6.5"/><path d="M6 17 H6.5"/><path d="M12 14 H18"/><path d="M12 17 H16"/></svg>

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -79,6 +79,7 @@ void obk_ig_end_table(void);
 void obk_ig_set_next_item_width(float w);
 void obk_ig_push_id_int(int id);
 void obk_ig_pop_id(void);
+int  obk_ig_is_item_deactivated_after_edit(void);
 
 // Theming verbs (ADR-0021). set_style_color overwrites one persistent ImGuiStyle color,
 // addressed by its ImGui name (e.g. "WindowBg", "Button") so Go never hardcodes the
@@ -278,6 +279,11 @@ func SetNextItemWidth(w float32) { C.obk_ig_set_next_item_width(C.float(w)) }
 // labels across rows do not collide. Pair every PushIDInt with a PopID.
 func PushIDInt(id int) { C.obk_ig_push_id_int(C.int(id)) }
 func PopID()           { C.obk_ig_pop_id() }
+
+// IsItemDeactivatedAfterEdit reports whether the most recent item was edited and then
+// committed this frame (Enter or focus loss) — so a text cell commits once the user is
+// done, not on every keystroke.
+func IsItemDeactivatedAfterEdit() bool { return C.obk_ig_is_item_deactivated_after_edit() != 0 }
 
 // SeparatorText draws a labeled horizontal separator (used as panel titles).
 func SeparatorText(s string) {

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -262,6 +262,7 @@ func TableSetupColumn(label string) {
 	defer free()
 	C.obk_ig_table_setup_column(c)
 }
+
 func TableSetupScrollFreeze(cols, rows int) {
 	C.obk_ig_table_setup_scroll_freeze(C.int(cols), C.int(rows))
 }

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -64,6 +64,22 @@ void obk_ig_set_next_window_pos(float x, float y);
 void obk_ig_set_next_window_size(float w, float h);
 void obk_ig_set_next_window_size_first_use(float w, float h);
 
+// Table verbs (the Parameters dialog grid). begin_table opens a bordered, row-striped,
+// vertically scrolling table of `columns` columns; pair with end_table only when it
+// returned non-zero. setup_column/setup_scroll_freeze/headers_row define the header;
+// next_row/next_column advance the cursor (next_column returns visibility). push_id_int/
+// pop_id scope per-row widget ids so identical cell labels don't collide.
+int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_h);
+void obk_ig_table_setup_column(const char* label);
+void obk_ig_table_setup_scroll_freeze(int cols, int rows);
+void obk_ig_table_headers_row(void);
+void obk_ig_table_next_row(void);
+int  obk_ig_table_next_column(void);
+void obk_ig_end_table(void);
+void obk_ig_set_next_item_width(float w);
+void obk_ig_push_id_int(int id);
+void obk_ig_pop_id(void);
+
 // Theming verbs (ADR-0021). set_style_color overwrites one persistent ImGuiStyle color,
 // addressed by its ImGui name (e.g. "WindowBg", "Button") so Go never hardcodes the
 // enum index (which shifts between ImGui versions); an unknown name is ignored.
@@ -226,6 +242,42 @@ func BeginCombo(label, preview string) bool {
 }
 
 func EndCombo() { C.obk_ig_end_combo() }
+
+// BeginTable opens a bordered, row-striped, scrolling table of columns columns sized to
+// (w, h) (0 ⇒ fit content / fill avail). Draw its rows only when it returns true, and
+// pair every true with EndTable. Define headers with TableSetupColumn + TableHeadersRow.
+func BeginTable(id string, columns int, w, h float32) bool {
+	c, free := cstr(id)
+	defer free()
+	return C.obk_ig_begin_table(c, C.int(columns), C.float(w), C.float(h)) != 0
+}
+func EndTable() { C.obk_ig_end_table() }
+
+// TableSetupColumn declares the next header column; TableSetupScrollFreeze keeps the
+// first cols columns / rows rows pinned while scrolling; TableHeadersRow emits the
+// header row from the declared columns.
+func TableSetupColumn(label string) {
+	c, free := cstr(label)
+	defer free()
+	C.obk_ig_table_setup_column(c)
+}
+func TableSetupScrollFreeze(cols, rows int) {
+	C.obk_ig_table_setup_scroll_freeze(C.int(cols), C.int(rows))
+}
+func TableHeadersRow() { C.obk_ig_table_headers_row() }
+
+// TableNextRow starts a new row; TableNextColumn advances to the next cell and reports
+// whether it is visible (so a Go loop can skip clipped cells).
+func TableNextRow()         { C.obk_ig_table_next_row() }
+func TableNextColumn() bool { return C.obk_ig_table_next_column() != 0 }
+
+// SetNextItemWidth sets the width of the next widget (-1 ⇒ fill the cell/column).
+func SetNextItemWidth(w float32) { C.obk_ig_set_next_item_width(C.float(w)) }
+
+// PushIDInt / PopID scope an integer id (a parameter's id) so identical cell-widget
+// labels across rows do not collide. Pair every PushIDInt with a PopID.
+func PushIDInt(id int) { C.obk_ig_push_id_int(C.int(id)) }
+func PopID()           { C.obk_ig_pop_id() }
 
 // SeparatorText draws a labeled horizontal separator (used as panel titles).
 func SeparatorText(s string) {

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -129,6 +129,23 @@ int  obk_ig_begin_combo(const char* label, const char* preview) {
 }
 void obk_ig_end_combo(void)                  { ImGui::EndCombo(); }
 
+// Table verbs (the Parameters dialog grid). A fixed flag set gives the dialog its
+// bordered, row-striped, resizable, vertically scrolling grid; the Go side owns layout.
+int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_h) {
+    ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                            ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY;
+    return ImGui::BeginTable(id, columns, flags, ImVec2(outer_w, outer_h)) ? 1 : 0;
+}
+void obk_ig_table_setup_column(const char* label)      { ImGui::TableSetupColumn(label); }
+void obk_ig_table_setup_scroll_freeze(int cols, int rows) { ImGui::TableSetupScrollFreeze(cols, rows); }
+void obk_ig_table_headers_row(void)                    { ImGui::TableHeadersRow(); }
+void obk_ig_table_next_row(void)                       { ImGui::TableNextRow(); }
+int  obk_ig_table_next_column(void)                    { return ImGui::TableNextColumn() ? 1 : 0; }
+void obk_ig_end_table(void)                            { ImGui::EndTable(); }
+void obk_ig_set_next_item_width(float w)               { ImGui::SetNextItemWidth(w); }
+void obk_ig_push_id_int(int id)                        { ImGui::PushID(id); }
+void obk_ig_pop_id(void)                               { ImGui::PopID(); }
+
 // want_capture_mouse reports whether ImGui consumed the pointer this frame, so the Go
 // loop knows when NOT to forward a click to the 3D viewport (picking).
 int  obk_ig_want_capture_mouse(void)         { return ImGui::GetIO().WantCaptureMouse ? 1 : 0; }

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -145,6 +145,7 @@ void obk_ig_end_table(void)                            { ImGui::EndTable(); }
 void obk_ig_set_next_item_width(float w)               { ImGui::SetNextItemWidth(w); }
 void obk_ig_push_id_int(int id)                        { ImGui::PushID(id); }
 void obk_ig_pop_id(void)                               { ImGui::PopID(); }
+int  obk_ig_is_item_deactivated_after_edit(void)       { return ImGui::IsItemDeactivatedAfterEdit() ? 1 : 0; }
 
 // want_capture_mouse reports whether ImGui consumed the pointer this frame, so the Go
 // loop knows when NOT to forward a click to the 3D viewport (picking).

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -65,6 +65,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)
+	drawParametersWindow(s)
 	drawPreferencesWindow(s)
 	drawMaterialsWindow(s)
 	drawFileDialog(s)

--- a/head/ui/parameters_dialogs.go
+++ b/head/ui/parameters_dialogs.go
@@ -1,0 +1,161 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// The Parameters dialog's three small popups: the Value List Editor (multi-value), the
+// Tolerance editor, and Add to Group. Each is a modeless window gated on a target id in
+// parametersUI, opened from the row context menu and committed back through a session verb.
+
+// toleranceTypes pairs the model-value selector with its label, in enum order.
+var toleranceTypes = []struct {
+	kind  param.ModelValueType
+	label string
+}{
+	{param.Nominal, "Nominal"}, {param.Upper, "Upper"}, {param.Lower, "Lower"}, {param.Median, "Median"},
+}
+
+// openValueListDialog seeds and opens the Value List Editor for a parameter, pre-filling
+// its current list (one entry per line).
+func openValueListDialog(row app.ParameterRow) {
+	parametersUI.listFor = row.ID
+	clearBuf(parametersUI.listText[:])
+	copy(parametersUI.listText[:], strings.Join(row.Options, "\n"))
+}
+
+// drawValueListEditor renders the Value List Editor while a target is set.
+func drawValueListEditor(s *app.Session) {
+	if parametersUI.listFor == 0 {
+		return
+	}
+	native.SetNextWindowSize(320, 220)
+	if native.Begin("Value List Editor") {
+		native.Text("One value per line (or comma-separated):")
+		native.InputText("##value-list", parametersUI.listText[:])
+		native.Checkbox("Allow custom values", &parametersUI.listCustom)
+		if native.Button("OK") {
+			applyValueList(s)
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			parametersUI.listFor = 0
+		}
+	}
+	native.End()
+}
+
+// applyValueList parses the edited text into a list and sets it on the parameter.
+func applyValueList(s *app.Session) {
+	list := splitValues(bufString(parametersUI.listText[:]))
+	if err := s.SetParameterValueList(parametersUI.listFor, list, parametersUI.listCustom); err == nil {
+		parametersUI.listFor = 0
+	}
+}
+
+// splitValues splits the editor text on newlines and commas, trimming blanks.
+func splitValues(text string) []string {
+	fields := strings.FieldsFunc(text, func(r rune) bool { return r == '\n' || r == ',' })
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if v := strings.TrimSpace(f); v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// openToleranceDialog seeds and opens the Tolerance editor.
+func openToleranceDialog(row app.ParameterRow) {
+	parametersUI.tolFor = row.ID
+	parametersUI.tolUpper, parametersUI.tolLower, parametersUI.tolType = 0, 0, 0
+}
+
+// drawToleranceEditor renders the Tolerance editor while a target is set. The deviations
+// are entered in the document's database units (the same convention as the model band).
+func drawToleranceEditor(s *app.Session) {
+	if parametersUI.tolFor == 0 {
+		return
+	}
+	native.SetNextWindowSize(300, 200)
+	if native.Begin("Tolerance") {
+		native.InputFloat("Upper", &parametersUI.tolUpper)
+		native.InputFloat("Lower", &parametersUI.tolLower)
+		drawToleranceTypeCombo()
+		if native.Button("OK") {
+			applyTolerance(s)
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			parametersUI.tolFor = 0
+		}
+	}
+	native.End()
+}
+
+// drawToleranceTypeCombo chooses which value of the band the model consumes.
+func drawToleranceTypeCombo() {
+	if !native.BeginCombo("Model value", toleranceTypes[parametersUI.tolType].label) {
+		return
+	}
+	for i, t := range toleranceTypes {
+		if native.Selectable(t.label, i == parametersUI.tolType) {
+			parametersUI.tolType = i
+		}
+	}
+	native.EndCombo()
+}
+
+// applyTolerance commits the edited band to the parameter.
+func applyTolerance(s *app.Session) {
+	kind := toleranceTypes[parametersUI.tolType].kind
+	err := s.SetParameterTolerance(parametersUI.tolFor, float64(parametersUI.tolUpper), float64(parametersUI.tolLower), kind)
+	if err == nil {
+		parametersUI.tolFor = 0
+	}
+}
+
+// openGroupDialog seeds and opens the Add to Group dialog.
+func openGroupDialog(row app.ParameterRow) {
+	parametersUI.groupFor = row.ID
+	clearBuf(parametersUI.groupName[:])
+}
+
+// drawAddToGroupDialog renders the Add to Group dialog while a target is set.
+func drawAddToGroupDialog(s *app.Session) {
+	if parametersUI.groupFor == 0 {
+		return
+	}
+	native.SetNextWindowSize(300, 140)
+	if native.Begin("Add to Group") {
+		native.Text("Group name:")
+		native.InputText("##group-name", parametersUI.groupName[:])
+		if native.Button("OK") {
+			applyGroup(s)
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			parametersUI.groupFor = 0
+		}
+	}
+	native.End()
+}
+
+// applyGroup assigns the parameter to the named group.
+func applyGroup(s *app.Session) {
+	name := strings.TrimSpace(bufString(parametersUI.groupName[:]))
+	if name == "" {
+		return
+	}
+	if err := s.AddParameterToGroup(parametersUI.groupFor, name); err == nil {
+		parametersUI.groupFor = 0
+	}
+}

--- a/head/ui/parameters_inwindow_test.go
+++ b/head/ui/parameters_inwindow_test.go
@@ -1,0 +1,46 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+)
+
+// TestInWindowParametersDialogDraws drives the real chrome with the Parameters dialog
+// open over a part that has every parameter flavor, for a few frames. It exercises the
+// table bindings, the multi-value combo, and the value cells on real hardware — a guard
+// that the dialog renders without crashing. Skips when no display/Vulkan is available.
+func TestInWindowParametersDialogDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := app.NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "Part1", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if err := s.AddNumericUserParameter("width", "20 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter: %v", err)
+	}
+	_ = s.AddTextUserParameter("finish", "anodized")
+	_ = s.AddBooleanUserParameter("vented", true)
+	id, _ := s.ActiveDocument().Content().(*compdef.PartComponentDefinition).Parameters().ByName("width")
+	_ = s.SetParameterValueList(id.ID(), []string{"20 mm", "25 mm"}, true)
+	s.OpenParameters()
+
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	if !s.ParametersOpen() {
+		t.Error("Parameters dialog should still be open after drawing")
+	}
+}

--- a/head/ui/parameters_row.go
+++ b/head/ui/parameters_row.go
@@ -1,0 +1,184 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// One parameter row and the popups it can open. Editable cells commit on focus loss
+// (IsItemDeactivatedAfterEdit) so a name is not renamed on every keystroke; per-cell
+// buffers are dropped after a commit so the model's reformatted value re-seeds them.
+
+// drawParameterRow draws one table row: the eight cells plus the right-click menu.
+func drawParameterRow(s *app.Session, row app.ParameterRow) {
+	native.PushIDInt(int(row.ID))
+	defer native.PopID()
+	native.TableNextRow()
+
+	native.TableNextColumn()
+	drawNameCell(s, row)
+	drawRowContextMenu(s, row)
+	native.TableNextColumn()
+	native.Text(row.UnitName)
+	native.TableNextColumn()
+	drawEquationCell(s, row)
+	native.TableNextColumn()
+	drawValueCell(row)
+	native.TableNextColumn()
+	native.Text(row.Tolerance)
+	native.TableNextColumn()
+	drawFlagCell(s, row, "##key", row.IsKey, s.SetParameterKey)
+	native.TableNextColumn()
+	drawFlagCell(s, row, "##export", row.Export, s.SetParameterExport)
+	native.TableNextColumn()
+	drawCommentCell(s, row)
+}
+
+// drawNameCell edits (or shows) the parameter name.
+func drawNameCell(s *app.Session, row app.ParameterRow) {
+	if !row.Editable {
+		native.Text(row.Name)
+		return
+	}
+	editCell(s, "name", row.ID, row.Name, func(v string) error { return s.SetParameterName(row.ID, v) })
+}
+
+// drawEquationCell edits the equation: a dropdown for multi-value, a checkbox for boolean,
+// a text field for everything else editable, or plain text for read-only parameters.
+func drawEquationCell(s *app.Session, row app.ParameterRow) {
+	switch {
+	case row.MultiValue:
+		drawEquationCombo(s, row)
+	case row.ValueType == "boolean":
+		v := row.Equation == "true"
+		native.SetNextItemWidth(-1)
+		if native.Checkbox("##eq-bool", &v) {
+			_ = s.SetParameterBool(row.ID, v)
+		}
+	case row.Editable:
+		editCell(s, "eq", row.ID, row.Equation, func(v string) error { return s.SetParameterEquation(row.ID, v) })
+	default:
+		native.Text(row.Equation)
+	}
+}
+
+// drawEquationCombo offers the multi-value choices as a dropdown.
+func drawEquationCombo(s *app.Session, row app.ParameterRow) {
+	native.SetNextItemWidth(-1)
+	if !native.BeginCombo("##eq-list", row.Equation) {
+		return
+	}
+	for _, opt := range row.Options {
+		if native.Selectable(opt, opt == row.Equation) {
+			_ = s.SetParameterEquation(row.ID, opt)
+		}
+	}
+	native.EndCombo()
+}
+
+// drawValueCell shows the evaluated value, flagging an unhealthy parameter.
+func drawValueCell(row app.ParameterRow) {
+	if !row.Healthy {
+		native.Text("⚠ " + row.Value)
+		if native.IsItemHovered() && row.Health != "" {
+			native.SetItemTooltip(row.Health)
+		}
+		return
+	}
+	native.Text(row.Value)
+}
+
+// drawCommentCell edits (or shows) the comment.
+func drawCommentCell(s *app.Session, row app.ParameterRow) {
+	if !row.Editable {
+		native.Text(row.Comment)
+		return
+	}
+	editCell(s, "comment", row.ID, row.Comment, func(v string) error { return s.SetParameterComment(row.ID, v) })
+}
+
+// drawFlagCell draws a Key/Export checkbox (disabled for read-only parameters).
+func drawFlagCell(s *app.Session, row app.ParameterRow, id string, value bool, set func(param.ID, bool) error) {
+	v := value
+	native.BeginDisabled(!row.Editable)
+	if native.Checkbox(id, &v) {
+		_ = set(row.ID, v)
+	}
+	native.EndDisabled()
+}
+
+// editCell draws a text field seeded once from value; on commit (focus loss) it calls set
+// and drops the buffer so the reformatted model value re-seeds it next frame.
+func editCell(s *app.Session, field string, id param.ID, value string, set func(string) error) {
+	key := field + ":" + idKey(id)
+	buf := cellBuf(key, value)
+	native.SetNextItemWidth(-1)
+	native.InputText("##"+field, buf)
+	if native.IsItemDeactivatedAfterEdit() {
+		_ = set(bufString(buf))
+		delete(parametersUI.cells, key)
+	}
+}
+
+// cellBuf returns the persistent edit buffer for a cell, seeding it from seed on creation.
+func cellBuf(key, seed string) []byte {
+	if b, ok := parametersUI.cells[key]; ok {
+		return b
+	}
+	b := make([]byte, paramBufLen)
+	copy(b, seed)
+	parametersUI.cells[key] = b
+	return b
+}
+
+// drawRowContextMenu is the right-click menu for the row's name cell.
+func drawRowContextMenu(s *app.Session, row app.ParameterRow) {
+	if !native.BeginPopupContextItem("##row-menu") {
+		return
+	}
+	if native.MenuItem("Copy to User Parameter") {
+		_ = s.CopyParameterToUser(row.ID)
+	}
+	if row.Editable && native.MenuItem("Delete Parameter") {
+		_ = s.DeleteParameter(row.ID)
+	}
+	if native.MenuItem("Add to Group…") {
+		openGroupDialog(row)
+	}
+	if row.Group != "" && native.MenuItem("Remove from Group") {
+		_ = s.RemoveParameterFromGroup(row.ID)
+	}
+	if row.Editable && row.ValueType != "boolean" {
+		drawMultiValueMenuItems(s, row)
+	}
+	if row.Editable && row.ValueType == "numeric" && native.MenuItem("Edit Tolerance…") {
+		openToleranceDialog(row)
+	}
+	native.EndPopup()
+}
+
+// drawMultiValueMenuItems adds the make/edit/clear multi-value entries.
+func drawMultiValueMenuItems(s *app.Session, row app.ParameterRow) {
+	if row.MultiValue {
+		if native.MenuItem("Edit Multi-Value List…") {
+			openValueListDialog(row)
+		}
+		if native.MenuItem("Make Single Value") {
+			_ = s.ClearParameterValueList(row.ID)
+		}
+		return
+	}
+	if native.MenuItem("Make Multi-Value…") {
+		openValueListDialog(row)
+	}
+}
+
+// idKey renders a parameter id as a stable buffer-key string.
+func idKey(id param.ID) string { return strconv.FormatUint(uint64(id), 10) }

--- a/head/ui/parameters_window.go
+++ b/head/ui/parameters_window.go
@@ -1,0 +1,156 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// The Parameters dialog (Manage ▸ Parameters): a search box, the Model and User
+// parameter tables, an Add row, and Done. The session owns the parameters and the edit
+// verbs; this file is pure layout, reading presentation rows each frame and calling the
+// verbs on change. Per-cell text buffers are seeded once and dropped after a commit so
+// the model's reformatted value shows next frame.
+
+const paramBufLen = 128
+
+// parametersUI is the dialog's cross-frame widget state.
+var parametersUI = struct {
+	search   [paramBufLen]byte
+	cells    map[string][]byte // per-cell InputText buffers, keyed "field:id"
+	addKind  int               // 0 numeric, 1 text, 2 boolean
+	addName  [paramBufLen]byte
+	addValue [paramBufLen]byte
+	addBool  bool
+
+	listFor    param.ID // multi-value list editor target (0 ⇒ closed)
+	listText   [512]byte
+	listCustom bool
+	tolFor     param.ID // tolerance editor target (0 ⇒ closed)
+	tolUpper   float32
+	tolLower   float32
+	tolType    int
+	groupFor   param.ID // add-to-group target (0 ⇒ closed)
+	groupName  [paramBufLen]byte
+}{}
+
+var addKindNames = []string{"Numeric", "Text", "True/False"}
+
+// drawParametersWindow renders the Parameters dialog while it is open.
+func drawParametersWindow(s *app.Session) {
+	if !s.ParametersOpen() {
+		return
+	}
+	if parametersUI.cells == nil {
+		parametersUI.cells = map[string][]byte{}
+	}
+	native.SetNextWindowSizeOnce(820, 520)
+	if native.Begin("Parameters") {
+		native.SetNextItemWidth(-1)
+		native.InputText("##param-search", parametersUI.search[:])
+		model, user := s.ParameterRows(bufString(parametersUI.search[:]))
+		drawParameterSection(s, "Model Parameters", "##model-params", model)
+		drawParameterSection(s, "User Parameters", "##user-params", user)
+		drawAddParameterRow(s)
+		native.Separator()
+		if native.Button("Done") {
+			s.CloseParameters()
+		}
+	}
+	native.End()
+	drawValueListEditor(s)
+	drawToleranceEditor(s)
+	drawAddToGroupDialog(s)
+}
+
+// drawParameterSection draws one labeled table (Model or User), or a placeholder line when
+// it is empty.
+func drawParameterSection(s *app.Session, title, id string, rows []app.ParameterRow) {
+	native.SeparatorText(title)
+	if len(rows) == 0 {
+		native.Text("  (none)")
+		return
+	}
+	if !native.BeginTable(id, 8, 0, paramTableHeight(len(rows))) {
+		return
+	}
+	for _, c := range []string{"Name", "Unit", "Equation", "Value", "Tol.", "Key", "Export", "Comment"} {
+		native.TableSetupColumn(c)
+	}
+	native.TableSetupScrollFreeze(0, 1)
+	native.TableHeadersRow()
+	for _, row := range rows {
+		drawParameterRow(s, row)
+	}
+	native.EndTable()
+}
+
+// paramTableHeight caps a table at eight visible rows so both tables and the Add row fit.
+func paramTableHeight(rows int) float32 {
+	const rowPx, headerPx, maxRows = 24, 26, 8
+	if rows > maxRows {
+		rows = maxRows
+	}
+	return float32(headerPx + rows*rowPx)
+}
+
+// drawAddParameterRow draws the bottom Add control: a kind chooser, a name and value
+// field, and the Add button — Inventor's Add Numeric / Text / True-False drop-down.
+func drawAddParameterRow(s *app.Session) {
+	native.Separator()
+	native.Text("Add")
+	native.SameLine()
+	native.SetNextItemWidth(120)
+	if native.BeginCombo("##add-kind", addKindNames[parametersUI.addKind]) {
+		for i, name := range addKindNames {
+			if native.Selectable(name, i == parametersUI.addKind) {
+				parametersUI.addKind = i
+			}
+		}
+		native.EndCombo()
+	}
+	native.SameLine()
+	native.SetNextItemWidth(140)
+	native.InputText("##add-name", parametersUI.addName[:])
+	native.SameLine()
+	drawAddValueField()
+	native.SameLine()
+	if native.Button("Add") {
+		commitAddParameter(s)
+	}
+}
+
+// drawAddValueField draws the value editor for the chosen add-kind (a checkbox for
+// True/False, a text field otherwise).
+func drawAddValueField() {
+	if parametersUI.addKind == 2 {
+		native.Checkbox("value##add-bool", &parametersUI.addBool)
+		return
+	}
+	native.SetNextItemWidth(140)
+	native.InputText("##add-value", parametersUI.addValue[:])
+}
+
+// commitAddParameter adds a parameter of the chosen kind and, on success, clears the Add
+// fields so the row is ready for the next entry.
+func commitAddParameter(s *app.Session) {
+	name := bufString(parametersUI.addName[:])
+	value := bufString(parametersUI.addValue[:])
+	var err error
+	switch parametersUI.addKind {
+	case 1:
+		err = s.AddTextUserParameter(name, value)
+	case 2:
+		err = s.AddBooleanUserParameter(name, parametersUI.addBool)
+	default:
+		err = s.AddNumericUserParameter(name, value)
+	}
+	if err == nil {
+		clearBuf(parametersUI.addName[:])
+		clearBuf(parametersUI.addValue[:])
+	}
+}

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -29,13 +29,14 @@ var _ doc.RecipeContent = (*PartComponentDefinition)(nil)
 // parameters. Sketches and features join it in later phases. The realized B-rep is
 // never stored — ApplyRecipe recomputes it.
 type partRecipe struct {
-	Units        map[string]string         `yaml:"units,omitempty"`
-	EndOfPart    *int                      `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
-	Parameters   []parameterRecipe         `yaml:"parameters,omitempty"`
-	WorkFeatures []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
-	Sketches     []sketch.SketchData       `yaml:"sketches,omitempty"`
-	Features     []feature.FeatureData     `yaml:"features,omitempty"`
-	Materials    *material.RecipeData      `yaml:"materials,omitempty"`
+	Units           map[string]string         `yaml:"units,omitempty"`
+	EndOfPart       *int                      `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
+	Parameters      []parameterRecipe         `yaml:"parameters,omitempty"`
+	ParameterGroups []string                  `yaml:"parameterGroups,omitempty"` // custom group names, in order
+	WorkFeatures    []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
+	Sketches        []sketch.SketchData       `yaml:"sketches,omitempty"`
+	Features        []feature.FeatureData     `yaml:"features,omitempty"`
+	Materials       *material.RecipeData      `yaml:"materials,omitempty"`
 }
 
 // sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
@@ -58,14 +59,35 @@ func (si sketchIndex) At(i int) (*sketch.Sketch, bool) {
 	return si.sketches.Item(i), true
 }
 
-// parameterRecipe is one parameter: an editable parameter carries an Expression; a
-// read-only parameter (reference/derived) carries a measured Value + Unit.
+// parameterRecipe is one parameter. A numeric editable parameter carries an Expression; a
+// text/boolean parameter carries Text/Bool (ValueType names the flavor); a read-only
+// parameter (reference/derived) carries a measured Value + Unit. The remaining fields are
+// the shared presentation/behavior state (comment, key, export, precision, tolerance,
+// multi-value list, group membership).
 type parameterRecipe struct {
-	Name       string  `yaml:"name"`
-	Kind       string  `yaml:"kind"`
-	Expression string  `yaml:"expression,omitempty"`
-	Value      float64 `yaml:"value,omitempty"`
-	Unit       string  `yaml:"unit,omitempty"`
+	Name        string           `yaml:"name"`
+	Kind        string           `yaml:"kind"`
+	ValueType   string           `yaml:"valueType,omitempty"` // "text" | "boolean"; numeric when empty
+	Expression  string           `yaml:"expression,omitempty"`
+	Text        string           `yaml:"text,omitempty"`
+	Bool        bool             `yaml:"bool,omitempty"`
+	Value       float64          `yaml:"value,omitempty"`
+	Unit        string           `yaml:"unit,omitempty"`
+	Comment     string           `yaml:"comment,omitempty"`
+	Key         bool             `yaml:"key,omitempty"`
+	Export      bool             `yaml:"export,omitempty"`
+	Precision   int              `yaml:"precision,omitempty"`
+	Tolerance   *toleranceRecipe `yaml:"tolerance,omitempty"`
+	ExprList    []string         `yaml:"expressionList,omitempty"`
+	AllowCustom bool             `yaml:"allowCustomValue,omitempty"`
+	Group       string           `yaml:"group,omitempty"`
+}
+
+// toleranceRecipe is the persisted form of a non-zero engineering tolerance.
+type toleranceRecipe struct {
+	Upper float64 `yaml:"upper,omitempty"`
+	Lower float64 `yaml:"lower,omitempty"`
+	Type  uint8   `yaml:"type,omitempty"`
 }
 
 // unitCategories are the display-unit categories a document persists, in a stable
@@ -89,12 +111,13 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		return nil, fmt.Errorf("compdef: marshal work features: %w", err)
 	}
 	r := partRecipe{
-		Units:        d.unitsRecipe(),
-		Parameters:   d.parametersRecipe(),
-		WorkFeatures: work,
-		Sketches:     sketches,
-		Features:     features,
-		Materials:    d.materialsRecipe(),
+		Units:           d.unitsRecipe(),
+		Parameters:      d.parametersRecipe(),
+		ParameterGroups: d.params.Groups(),
+		WorkFeatures:    work,
+		Sketches:        sketches,
+		Features:        features,
+		Materials:       d.materialsRecipe(),
 	}
 	if d.eop != endOfPartAtEnd {
 		eop := d.eop
@@ -112,7 +135,7 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 	if err := d.applyUnits(r.Units); err != nil {
 		return err
 	}
-	if err := d.applyParameters(r.Parameters); err != nil {
+	if err := d.applyParameters(r.ParameterGroups, r.Parameters); err != nil {
 		return err
 	}
 	if err := feature.ApplyWork(d.work, r.WorkFeatures); err != nil {
@@ -179,59 +202,112 @@ func (d *PartComponentDefinition) parametersRecipe() []parameterRecipe {
 	}
 	out := make([]parameterRecipe, 0, len(all))
 	for _, p := range all {
-		pr := parameterRecipe{Name: p.Name(), Kind: p.Kind().String()}
-		if p.Kind().Editable() {
-			pr.Expression = p.Expression()
-		} else {
-			pr.Value, pr.Unit = p.Value().Value, p.Value().Unit.String()
-		}
-		out = append(out, pr)
+		out = append(out, d.parameterRecipeOf(p))
 	}
 	return out
 }
 
-// applyParameters re-adds each parameter in recipe order. A parse error (bad
-// expression, duplicate name, unknown kind/unit) aborts the load rather than dropping
-// the parameter silently.
-func (d *PartComponentDefinition) applyParameters(params []parameterRecipe) error {
+// parameterRecipeOf captures one parameter's persisted form: its value (by flavor) plus
+// the shared comment/key/export/precision/tolerance/multi-value/group state.
+func (d *PartComponentDefinition) parameterRecipeOf(p *param.Parameter) parameterRecipe {
+	pr := parameterRecipe{
+		Name: p.Name(), Kind: p.Kind().String(),
+		Comment: p.Comment, Key: p.IsKey, Export: p.ExposedAsProperty, Precision: p.Precision,
+	}
+	switch {
+	case p.IsText():
+		pr.ValueType, pr.Text = "text", p.Text()
+	case p.IsBoolean():
+		pr.ValueType, pr.Bool = "boolean", p.Bool()
+	case p.Kind().Editable():
+		pr.Expression = p.Expression()
+	default:
+		pr.Value, pr.Unit = p.Value().Value, p.Value().Unit.String()
+	}
+	if t := p.Tolerance(); t != (param.Tolerance{}) {
+		pr.Tolerance = &toleranceRecipe{Upper: t.Upper, Lower: t.Lower, Type: uint8(t.Type)}
+	}
+	if p.IsMultiValue() {
+		pr.ExprList, pr.AllowCustom = p.ExpressionList(), p.AllowsCustomValue()
+	}
+	if g, ok := d.params.GroupOf(p.ID()); ok {
+		pr.Group = g
+	}
+	return pr
+}
+
+// applyParameters re-creates the custom groups (in their saved order) then re-adds each
+// parameter in recipe order. A parse error (bad expression, duplicate name, unknown
+// kind/unit) aborts the load rather than dropping the parameter silently.
+func (d *PartComponentDefinition) applyParameters(groups []string, params []parameterRecipe) error {
+	for _, g := range groups {
+		if err := d.params.AddGroup(g); err != nil {
+			return fmt.Errorf("compdef: restore parameter group %q: %w", g, err)
+		}
+	}
 	for _, pr := range params {
-		if err := d.addParameter(pr); err != nil {
+		p, err := d.addParameter(pr)
+		if err != nil {
+			return fmt.Errorf("compdef: restore parameter %q: %w", pr.Name, err)
+		}
+		if err := d.applyParameterState(p, pr); err != nil {
 			return fmt.Errorf("compdef: restore parameter %q: %w", pr.Name, err)
 		}
 	}
 	return nil
 }
 
-// addParameter re-creates one parameter from its recipe entry.
-func (d *PartComponentDefinition) addParameter(pr parameterRecipe) error {
+// addParameter re-creates one parameter's value from its recipe entry, returning it so the
+// shared state can be applied. Read-only parameters return nil (no editable state to set).
+func (d *PartComponentDefinition) addParameter(pr parameterRecipe) (*param.Parameter, error) {
+	switch pr.ValueType {
+	case "text":
+		return d.params.AddTextUserParameter(pr.Name, pr.Text)
+	case "boolean":
+		return d.params.AddBooleanUserParameter(pr.Name, pr.Bool)
+	}
 	switch pr.Kind {
 	case param.UserParam.String():
-		_, err := d.params.AddUserParameter(pr.Name, pr.Expression)
-		return err
+		return d.params.AddUserParameter(pr.Name, pr.Expression)
 	case param.ModelParam.String():
-		_, err := d.params.AddModelParameter(pr.Name, pr.Expression)
-		return err
+		return d.params.AddModelParameter(pr.Name, pr.Expression)
 	case param.TableParam.String():
-		_, err := d.params.AddTableParameter(pr.Name, pr.Expression)
-		return err
+		return d.params.AddTableParameter(pr.Name, pr.Expression)
 	case param.ReferenceParam.String():
 		return d.addReadOnlyParameter(pr, d.params.AddReferenceParameter)
 	case param.DerivedParam.String():
 		return d.addReadOnlyParameter(pr, d.params.AddDerivedParameter)
 	default:
-		return fmt.Errorf("unknown parameter kind %q (want user|model|table|reference|derived)", pr.Kind)
+		return nil, fmt.Errorf("unknown parameter kind %q (want user|model|table|reference|derived)", pr.Kind)
 	}
+}
+
+// applyParameterState restores the shared presentation/behavior fields onto a freshly
+// re-added parameter: comment, key, export, precision, tolerance, multi-value list, group.
+func (d *PartComponentDefinition) applyParameterState(p *param.Parameter, pr parameterRecipe) error {
+	p.Comment, p.IsKey, p.ExposedAsProperty, p.Precision = pr.Comment, pr.Key, pr.Export, pr.Precision
+	if pr.Tolerance != nil {
+		p.SetTolerance(param.Tolerance{Upper: pr.Tolerance.Upper, Lower: pr.Tolerance.Lower, Type: param.ModelValueType(pr.Tolerance.Type)})
+	}
+	if len(pr.ExprList) > 0 {
+		if err := p.SetExpressionList(pr.ExprList, pr.AllowCustom); err != nil {
+			return err
+		}
+	}
+	if pr.Group != "" {
+		return d.params.AddToGroup(p.ID(), pr.Group)
+	}
+	return nil
 }
 
 // addReadOnlyParameter rebuilds a read-only parameter's measured quantity from its
 // value + unit and adds it through the given collection method.
-func (d *PartComponentDefinition) addReadOnlyParameter(pr parameterRecipe, add func(string, param.Quantity) (*param.Parameter, error)) error {
+func (d *PartComponentDefinition) addReadOnlyParameter(pr parameterRecipe, add func(string, param.Quantity) (*param.Parameter, error)) (*param.Parameter, error) {
 	unit, ok := unitCategoryByName(pr.Unit)
 	if !ok {
-		return fmt.Errorf("unknown unit %q", pr.Unit)
+		return nil, fmt.Errorf("unknown unit %q", pr.Unit)
 	}
-	_, err := add(pr.Name, param.Q(pr.Value, unit))
-	return err
+	return add(pr.Name, param.Q(pr.Value, unit))
 }
 
 // unitCategoryByName maps a category name (param.Unit.String()) back to its Unit.

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -82,6 +82,52 @@ func TestParametersSurviveRoundTrip(t *testing.T) {
 	}
 }
 
+// TestParameterFieldsSurviveRoundTrip exercises the extended parameter recipe: text and
+// boolean parameters, comment/key/export/tolerance/multi-value state, and group membership.
+func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	ps := d.Content().(*compdef.PartComponentDefinition).Parameters()
+
+	num, _ := ps.AddUserParameter("len", "10 mm")
+	num.Comment, num.IsKey, num.ExposedAsProperty = "the length", true, true
+	num.SetTolerance(param.Tolerance{Upper: 0.01, Lower: -0.02, Type: param.Median})
+	_ = num.SetExpressionList([]string{"10 mm", "20 mm"}, true)
+	txt, _ := ps.AddTextUserParameter("material", "steel")
+	flag, _ := ps.AddBooleanUserParameter("vented", true)
+	_ = ps.AddToGroup(num.ID(), "Frame")
+	_ = ps.AddToGroup(txt.ID(), "Frame")
+
+	r := reopenThroughStore(t, d).Parameters()
+
+	rl, _ := r.ByName("len")
+	if rl.Comment != "the length" || !rl.IsKey || !rl.ExposedAsProperty {
+		t.Errorf("len comment/key/export not restored: %+v", rl)
+	}
+	if tol := rl.Tolerance(); tol.Upper != 0.01 || tol.Lower != -0.02 || tol.Type != param.Median {
+		t.Errorf("tolerance = %+v, want {0.01 -0.02 Median}", tol)
+	}
+	if !rl.IsMultiValue() || !rl.AllowsCustomValue() || len(rl.ExpressionList()) != 2 {
+		t.Errorf("multi-value not restored: %v custom=%v", rl.ExpressionList(), rl.AllowsCustomValue())
+	}
+	if g, _ := r.GroupOf(rl.ID()); g != "Frame" {
+		t.Errorf("len group = %q, want Frame", g)
+	}
+
+	rt, _ := r.ByName("material")
+	if !rt.IsText() || rt.Text() != "steel" {
+		t.Errorf("text parameter not restored: isText=%v text=%q", rt.IsText(), rt.Text())
+	}
+	rf, _ := r.ByName("vented")
+	if !rf.IsBoolean() || !rf.Bool() {
+		t.Errorf("boolean parameter not restored: isBool=%v val=%v", rf.IsBoolean(), rf.Bool())
+	}
+	if g, _ := r.GroupOf(rt.ID()); g != "Frame" {
+		t.Errorf("material group = %q, want Frame", g)
+	}
+	_ = flag
+}
+
 func TestSketchGeometrySurvivesRoundTrip(t *testing.T) {
 	ws := doc.NewWorkspace(nil)
 	d, _ := compdef.AddPart(ws, "Part1", true)

--- a/model/param/expression_list.go
+++ b/model/param/expression_list.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "fmt"
+
+// Multi-value parameters (Inventor's ExpressionList): a parameter can offer a fixed list
+// of allowed expressions chosen from a dropdown, optionally accepting one custom value
+// outside the list. The current selection is just the parameter's expression — the
+// dropdown the UI shows is the list plus the current value when it is a custom one, so
+// there is at most one custom value at a time ("only one custom value", per the journey).
+
+// SetExpressionList makes the parameter multi-value with the given choices. allowCustom
+// permits selecting a value outside the list. An empty list clears the multi-value state.
+// It does not change the current value.
+func (p *Parameter) SetExpressionList(list []string, allowCustom bool) error {
+	if !p.kind.Editable() {
+		return fmt.Errorf("param: %s parameter %q is read-only", p.kind, p.name)
+	}
+	p.exprList = append([]string(nil), list...)
+	p.allowCustom = allowCustom && len(list) > 0
+	return nil
+}
+
+// ClearExpressionList drops the multi-value choices, returning the parameter to a plain
+// single value (its current value is kept).
+func (p *Parameter) ClearExpressionList() {
+	p.exprList, p.allowCustom = nil, false
+}
+
+// ExpressionList returns the multi-value choices (empty when single-valued).
+func (p *Parameter) ExpressionList() []string {
+	return append([]string(nil), p.exprList...)
+}
+
+// IsMultiValue reports whether the parameter offers a list of choices.
+func (p *Parameter) IsMultiValue() bool { return len(p.exprList) > 0 }
+
+// AllowsCustomValue reports whether a value outside the list is accepted.
+func (p *Parameter) AllowsCustomValue() bool { return p.allowCustom }
+
+// SelectValue sets the parameter to one of its list choices (or to a custom value when
+// allowed), routing to the numeric or text setter. It errors when the value is not in the
+// list and custom values are not allowed.
+func (p *Parameter) SelectValue(expr string) error {
+	if p.IsMultiValue() && !p.allowCustom && !contains(p.exprList, expr) {
+		return fmt.Errorf("param: %q is not an allowed value for %q", expr, p.name)
+	}
+	if p.IsText() {
+		return p.SetText(expr)
+	}
+	return p.SetExpression(expr)
+}
+
+// contains reports whether s is in list.
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/model/param/expression_list_test.go
+++ b/model/param/expression_list_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "testing"
+
+func TestExpressionListRoundTrip(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 mm")
+	if p.IsMultiValue() {
+		t.Fatal("a fresh parameter should be single-valued")
+	}
+	if err := p.SetExpressionList([]string{"10 mm", "20 mm", "30 mm"}, false); err != nil {
+		t.Fatalf("SetExpressionList: %v", err)
+	}
+	if !p.IsMultiValue() || len(p.ExpressionList()) != 3 {
+		t.Errorf("list = %v, want 3 entries multi-value", p.ExpressionList())
+	}
+}
+
+func TestSelectValueFromList(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 mm")
+	_ = p.SetExpressionList([]string{"10 mm", "20 mm"}, false)
+
+	if err := p.SelectValue("20 mm"); err != nil {
+		t.Fatalf("SelectValue: %v", err)
+	}
+	if !approxScalar(p.Value().Value, 2.0) { // 20 mm = 2 cm
+		t.Errorf("value = %v, want 2", p.Value().Value)
+	}
+	if err := p.SelectValue("99 mm"); err == nil {
+		t.Error("selecting a value outside the list (custom not allowed) should fail")
+	}
+}
+
+func TestCustomValueOverwrites(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 mm")
+	_ = p.SetExpressionList([]string{"10 mm", "20 mm"}, true)
+
+	if err := p.SelectValue("35 mm"); err != nil { // a custom value is allowed
+		t.Fatalf("custom SelectValue: %v", err)
+	}
+	if !approxScalar(p.Value().Value, 3.5) {
+		t.Errorf("value = %v, want 3.5", p.Value().Value)
+	}
+	// Picking a different custom value replaces it — there is only ever one current value.
+	if err := p.SelectValue("40 mm"); err != nil {
+		t.Fatalf("second custom SelectValue: %v", err)
+	}
+	if !approxScalar(p.Value().Value, 4.0) {
+		t.Errorf("value = %v, want 4", p.Value().Value)
+	}
+	if l := p.ExpressionList(); len(l) != 2 { // the fixed list is unchanged by custom values
+		t.Errorf("list = %v, want the original 2 entries", l)
+	}
+}
+
+func TestClearExpressionList(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 mm")
+	_ = p.SetExpressionList([]string{"10 mm", "20 mm"}, false)
+	p.ClearExpressionList()
+	if p.IsMultiValue() {
+		t.Error("ClearExpressionList should make the parameter single-valued")
+	}
+}

--- a/model/param/group.go
+++ b/model/param/group.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Custom parameter groups (Inventor's CustomParameterGroups) let a user organize
+// parameters into named groups. Membership is a simple parameter→group-name map; group
+// names are kept in creation order for stable display. Deleting a group also deletes its
+// member parameters (per the journey: "rename or delete a group (and its parameters)").
+
+// Groups returns the custom group names in creation order.
+func (ps *Parameters) Groups() []string {
+	return append([]string(nil), ps.groupOrder...)
+}
+
+// AddGroup creates a new, empty custom group. It rejects an empty or duplicate name.
+func (ps *Parameters) AddGroup(name string) error {
+	if name == "" {
+		return fmt.Errorf("param: group name must not be empty")
+	}
+	if ps.hasGroup(name) {
+		return fmt.Errorf("param: a group named %q already exists", name)
+	}
+	ps.groupOrder = append(ps.groupOrder, name)
+	return nil
+}
+
+// RenameGroup renames a group, retargeting its members. It rejects a clash with another
+// group and an unknown source name.
+func (ps *Parameters) RenameGroup(oldName, newName string) error {
+	if !ps.hasGroup(oldName) {
+		return fmt.Errorf("param: no group named %q", oldName)
+	}
+	if newName != oldName && ps.hasGroup(newName) {
+		return fmt.Errorf("param: a group named %q already exists", newName)
+	}
+	for i, g := range ps.groupOrder {
+		if g == oldName {
+			ps.groupOrder[i] = newName
+		}
+	}
+	for id, g := range ps.groupOf {
+		if g == oldName {
+			ps.groupOf[id] = newName
+		}
+	}
+	return nil
+}
+
+// DeleteGroup removes a group and deletes every parameter that belonged to it.
+func (ps *Parameters) DeleteGroup(name string) error {
+	if !ps.hasGroup(name) {
+		return fmt.Errorf("param: no group named %q", name)
+	}
+	for _, id := range ps.GroupMembers(name) {
+		if p, ok := ps.byID[id]; ok {
+			ps.remove(p)
+		}
+	}
+	ps.dropGroupName(name)
+	return nil
+}
+
+// AddToGroup assigns a parameter to a group, creating the group if it does not exist yet.
+func (ps *Parameters) AddToGroup(id ID, name string) error {
+	if _, ok := ps.byID[id]; !ok {
+		return fmt.Errorf("param: no parameter with id %d", id)
+	}
+	if !ps.hasGroup(name) {
+		if err := ps.AddGroup(name); err != nil {
+			return err
+		}
+	}
+	ps.groupOf[id] = name
+	return nil
+}
+
+// RemoveFromGroup detaches a parameter from its group (the parameter itself is kept).
+func (ps *Parameters) RemoveFromGroup(id ID) error {
+	if _, ok := ps.byID[id]; !ok {
+		return fmt.Errorf("param: no parameter with id %d", id)
+	}
+	delete(ps.groupOf, id)
+	return nil
+}
+
+// GroupOf returns the group a parameter belongs to, or false when it is ungrouped.
+func (ps *Parameters) GroupOf(id ID) (string, bool) {
+	g, ok := ps.groupOf[id]
+	return g, ok
+}
+
+// GroupMembers returns the ids of the parameters in a group, in collection order.
+func (ps *Parameters) GroupMembers(name string) []ID {
+	var out []ID
+	for _, id := range ps.order {
+		if ps.groupOf[id] == name {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// CopyToUser duplicates a parameter as a new user parameter named "<name>_copy" (with a
+// numeric suffix if needed), carrying over its value, comment, key, export, and any
+// multi-value list. The copy is independent of the source.
+func (ps *Parameters) CopyToUser(id ID) (*Parameter, error) {
+	src, ok := ps.byID[id]
+	if !ok {
+		return nil, fmt.Errorf("param: no parameter with id %d", id)
+	}
+	copyParam, err := ps.addCopyValue(src)
+	if err != nil {
+		return nil, err
+	}
+	copyParam.Comment = src.Comment
+	copyParam.IsKey = src.IsKey
+	copyParam.ExposedAsProperty = src.ExposedAsProperty
+	copyParam.Precision = src.Precision
+	copyParam.tol = src.tol
+	_ = copyParam.SetExpressionList(src.exprList, src.allowCustom)
+	return copyParam, nil
+}
+
+// addCopyValue creates the user-parameter copy with the source's value, routed by flavor.
+func (ps *Parameters) addCopyValue(src *Parameter) (*Parameter, error) {
+	name := ps.uniqueCopyName(src.name)
+	switch {
+	case src.IsText():
+		return ps.AddTextUserParameter(name, src.text)
+	case src.IsBoolean():
+		return ps.AddBooleanUserParameter(name, src.Bool())
+	default:
+		return ps.AddUserParameter(name, src.Expression())
+	}
+}
+
+// uniqueCopyName returns "<base>_copy", appending a counter until the name is free.
+func (ps *Parameters) uniqueCopyName(base string) string {
+	name := base + "_copy"
+	for n := 2; ; n++ {
+		if _, taken := ps.byName[name]; !taken {
+			return name
+		}
+		name = base + "_copy" + strconv.Itoa(n)
+	}
+}
+
+func (ps *Parameters) hasGroup(name string) bool {
+	for _, g := range ps.groupOrder {
+		if g == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (ps *Parameters) dropGroupName(name string) {
+	for i, g := range ps.groupOrder {
+		if g == name {
+			ps.groupOrder = append(ps.groupOrder[:i], ps.groupOrder[i+1:]...)
+			return
+		}
+	}
+}

--- a/model/param/group_test.go
+++ b/model/param/group_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "testing"
+
+func TestGroupLifecycle(t *testing.T) {
+	ps := NewParameters()
+	a, _ := ps.AddUserParameter("a", "1 mm")
+	b, _ := ps.AddUserParameter("b", "2 mm")
+
+	if err := ps.AddToGroup(a.ID(), "Bracket"); err != nil { // auto-creates the group
+		t.Fatalf("AddToGroup: %v", err)
+	}
+	_ = ps.AddToGroup(b.ID(), "Bracket")
+	if g, ok := ps.GroupOf(a.ID()); !ok || g != "Bracket" {
+		t.Errorf("GroupOf(a) = %q,%v, want Bracket,true", g, ok)
+	}
+	if m := ps.GroupMembers("Bracket"); len(m) != 2 {
+		t.Errorf("members = %v, want 2", m)
+	}
+
+	if err := ps.RenameGroup("Bracket", "Frame"); err != nil {
+		t.Fatalf("RenameGroup: %v", err)
+	}
+	if g, _ := ps.GroupOf(a.ID()); g != "Frame" {
+		t.Errorf("after rename GroupOf(a) = %q, want Frame", g)
+	}
+
+	if err := ps.RemoveFromGroup(b.ID()); err != nil {
+		t.Fatalf("RemoveFromGroup: %v", err)
+	}
+	if _, ok := ps.GroupOf(b.ID()); ok {
+		t.Error("b should be ungrouped after RemoveFromGroup")
+	}
+}
+
+// TestDeleteGroupRemovesMembers checks deleting a group also deletes its parameters.
+func TestDeleteGroupRemovesMembers(t *testing.T) {
+	ps := NewParameters()
+	a, _ := ps.AddUserParameter("a", "1 mm")
+	keep, _ := ps.AddUserParameter("keep", "2 mm")
+	_ = ps.AddToGroup(a.ID(), "G")
+
+	if err := ps.DeleteGroup("G"); err != nil {
+		t.Fatalf("DeleteGroup: %v", err)
+	}
+	if _, ok := ps.ByID(a.ID()); ok {
+		t.Error("grouped parameter should be deleted with its group")
+	}
+	if _, ok := ps.ByID(keep.ID()); !ok {
+		t.Error("ungrouped parameter should survive")
+	}
+	if len(ps.Groups()) != 0 {
+		t.Errorf("groups = %v, want none", ps.Groups())
+	}
+}
+
+func TestCopyToUser(t *testing.T) {
+	ps := NewParameters()
+	src, _ := ps.AddModelParameter("d0", "5 mm")
+	src.Comment = "depth"
+	src.IsKey = true
+
+	cp, err := ps.CopyToUser(src.ID())
+	if err != nil {
+		t.Fatalf("CopyToUser: %v", err)
+	}
+	if cp.Name() != "d0_copy" {
+		t.Errorf("copy name = %q, want d0_copy", cp.Name())
+	}
+	if cp.Kind() != UserParam {
+		t.Errorf("copy kind = %v, want user", cp.Kind())
+	}
+	if !approxScalar(cp.Value().Value, 0.5) || cp.Comment != "depth" || !cp.IsKey {
+		t.Errorf("copy did not carry value/comment/key: %+v", cp)
+	}
+	// A second copy gets a distinct name and is independent of the source.
+	cp2, _ := ps.CopyToUser(src.ID())
+	if cp2.Name() != "d0_copy2" {
+		t.Errorf("second copy name = %q, want d0_copy2", cp2.Name())
+	}
+	_ = cp.SetExpression("9 mm")
+	if approxScalar(src.Value().Value, 0.9) {
+		t.Error("editing the copy must not change the source")
+	}
+}

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -54,6 +54,7 @@ type Parameter struct {
 	name   string
 	expr   Expr
 	value  Quantity
+	text   string // the value when this is a Text parameter (Unit == Text)
 	tol    Tolerance
 	kind   ParameterKind
 	health Health
@@ -77,6 +78,19 @@ func (p *Parameter) Kind() ParameterKind { return p.kind }
 
 // Unit returns the unit of the evaluated value.
 func (p *Parameter) Unit() Unit { return p.value.Unit }
+
+// IsText / IsBoolean / IsNumeric report the parameter's value flavor. Only numeric
+// parameters support expressions and tolerances (Inventor: "Only numeric parameters
+// support expressions"); text and true/false parameters carry a literal value.
+func (p *Parameter) IsText() bool    { return p.value.Unit == Text }
+func (p *Parameter) IsBoolean() bool { return p.value.Unit == Boolean }
+func (p *Parameter) IsNumeric() bool { return !p.IsText() && !p.IsBoolean() }
+
+// Text returns the literal of a text parameter ("" for non-text parameters).
+func (p *Parameter) Text() string { return p.text }
+
+// Bool returns the value of a true/false parameter (false for non-boolean parameters).
+func (p *Parameter) Bool() bool { return p.IsBoolean() && p.value.Value != 0 }
 
 // Value returns the evaluated quantity (database units).
 func (p *Parameter) Value() Quantity { return p.value }
@@ -105,6 +119,9 @@ func (p *Parameter) SetExpression(src string) error {
 	if !p.kind.Editable() {
 		return fmt.Errorf("param: %s parameter %q is read-only", p.kind, p.name)
 	}
+	if !p.IsNumeric() {
+		return fmt.Errorf("param: %q is a %s parameter; only numeric parameters take expressions", p.name, p.value.Unit)
+	}
 	e, err := Parse(src)
 	if err != nil {
 		return err
@@ -120,11 +137,57 @@ func (p *Parameter) SetValue(q Quantity) error {
 	if !p.kind.Editable() {
 		return fmt.Errorf("param: %s parameter %q is read-only", p.kind, p.name)
 	}
+	if !p.IsNumeric() {
+		return fmt.Errorf("param: %q is a %s parameter; use SetText/SetBool", p.name, p.value.Unit)
+	}
 	p.expr = constantExpr(q)
 	p.value = q
 	p.health = Health{Status: Healthy}
 	return nil
 }
+
+// SetText sets the literal of a text parameter. It errors for read-only kinds and for
+// non-text parameters. The stored expression is the value quoted (Inventor surfaces a
+// text parameter's equation as a quoted string).
+func (p *Parameter) SetText(s string) error {
+	if !p.kind.Editable() {
+		return fmt.Errorf("param: %s parameter %q is read-only", p.kind, p.name)
+	}
+	if !p.IsText() {
+		return fmt.Errorf("param: %q is not a text parameter (unit %s)", p.name, p.value.Unit)
+	}
+	p.text = s
+	p.expr = literalExpr(strconv.Quote(s))
+	p.health = Health{Status: Healthy}
+	return nil
+}
+
+// SetBool sets the value of a true/false parameter. It errors for read-only kinds and for
+// non-boolean parameters. Booleans are stored as 0/1 in the value quantity.
+func (p *Parameter) SetBool(b bool) error {
+	if !p.kind.Editable() {
+		return fmt.Errorf("param: %s parameter %q is read-only", p.kind, p.name)
+	}
+	if !p.IsBoolean() {
+		return fmt.Errorf("param: %q is not a true/false parameter (unit %s)", p.name, p.value.Unit)
+	}
+	p.value = Q(boolValue(b), Boolean)
+	p.expr = literalExpr(strconv.FormatBool(b))
+	p.health = Health{Status: Healthy}
+	return nil
+}
+
+// boolValue maps a bool to its 0/1 stored representation.
+func boolValue(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// literalExpr wraps a fixed source string as an [Expr] for non-numeric parameters: its
+// Source is the text the UI shows, and it is never evaluated through the graph.
+func literalExpr(src string) Expr { return Expr{src: src} }
 
 // reevaluateConstant evaluates a reference-free expression immediately; an
 // expression with references is marked OutOfDate for the dependency graph.

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -59,6 +59,9 @@ type Parameter struct {
 	kind   ParameterKind
 	health Health
 
+	exprList    []string // multi-value choices (empty ⇒ single-valued); see expression_list.go
+	allowCustom bool     // a value outside exprList is accepted (the one custom value)
+
 	Comment           string
 	IsKey             bool
 	Visible           bool

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -77,6 +77,37 @@ func (ps *Parameters) AddModelParameter(name, expression string) (*Parameter, er
 	return ps.addEditable(name, expression, ModelParam)
 }
 
+// AddTextUserParameter adds an editable user parameter holding a text literal. Text
+// parameters carry no expression and take no part in the dependency graph.
+func (ps *Parameters) AddTextUserParameter(name, value string) (*Parameter, error) {
+	p, err := ps.add(name, UserParam)
+	if err != nil {
+		return nil, err
+	}
+	p.value = Q(0, Text)
+	if err := p.SetText(value); err != nil {
+		ps.remove(p)
+		return nil, err
+	}
+	ps.onParameterAdded(p)
+	return p, nil
+}
+
+// AddBooleanUserParameter adds an editable user parameter holding a true/false value.
+func (ps *Parameters) AddBooleanUserParameter(name string, value bool) (*Parameter, error) {
+	p, err := ps.add(name, UserParam)
+	if err != nil {
+		return nil, err
+	}
+	p.value = Q(0, Boolean)
+	if err := p.SetBool(value); err != nil {
+		ps.remove(p)
+		return nil, err
+	}
+	ps.onParameterAdded(p)
+	return p, nil
+}
+
 // AddTableParameter adds an editable table parameter (iPart member value).
 func (ps *Parameters) AddTableParameter(name, expression string) (*Parameter, error) {
 	return ps.addEditable(name, expression, TableParam)

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -18,6 +18,11 @@ type Parameters struct {
 	// of parameters p's expression reads; dependents[p] is the reverse.
 	drivenBy   map[ID]idSet
 	dependents map[ID]idSet
+
+	// Custom parameter groups (Inventor's CustomParameterGroups): names in creation
+	// order plus each parameter's group membership. See group.go.
+	groupOrder []string
+	groupOf    map[ID]string
 }
 
 // idSet is a set of parameter ids.
@@ -28,6 +33,7 @@ func NewParameters() *Parameters {
 	return &Parameters{
 		byID: map[ID]*Parameter{}, byName: map[string]ID{}, nextID: 1,
 		drivenBy: map[ID]idSet{}, dependents: map[ID]idSet{},
+		groupOf: map[ID]string{},
 	}
 }
 
@@ -210,6 +216,7 @@ func (ps *Parameters) remove(p *Parameter) {
 		delete(ps.drivenBy[d], p.id)
 	}
 	delete(ps.dependents, p.id)
+	delete(ps.groupOf, p.id)
 	delete(ps.byID, p.id)
 	delete(ps.byName, p.name)
 	for i, id := range ps.order {

--- a/model/param/text_bool_test.go
+++ b/model/param/text_bool_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "testing"
+
+func TestAddTextUserParameter(t *testing.T) {
+	ps := NewParameters()
+	p, err := ps.AddTextUserParameter("material", "steel")
+	if err != nil {
+		t.Fatalf("AddTextUserParameter: %v", err)
+	}
+	if !p.IsText() || p.IsNumeric() {
+		t.Errorf("value flavor = (text %v numeric %v), want text", p.IsText(), p.IsNumeric())
+	}
+	if p.Text() != "steel" {
+		t.Errorf("Text = %q, want steel", p.Text())
+	}
+	if p.Expression() != `"steel"` { // surfaced as a quoted literal
+		t.Errorf("Expression = %q, want \"steel\" quoted", p.Expression())
+	}
+	if !p.Health().OK() {
+		t.Errorf("health = %+v, want healthy", p.Health())
+	}
+}
+
+func TestAddBooleanUserParameter(t *testing.T) {
+	ps := NewParameters()
+	p, err := ps.AddBooleanUserParameter("vented", true)
+	if err != nil {
+		t.Fatalf("AddBooleanUserParameter: %v", err)
+	}
+	if !p.IsBoolean() || !p.Bool() {
+		t.Errorf("got (boolean %v value %v), want boolean true", p.IsBoolean(), p.Bool())
+	}
+	if p.Expression() != "true" {
+		t.Errorf("Expression = %q, want true", p.Expression())
+	}
+	if err := p.SetBool(false); err != nil {
+		t.Fatalf("SetBool: %v", err)
+	}
+	if p.Bool() || p.Expression() != "false" {
+		t.Errorf("after SetBool(false): value %v expr %q, want false/false", p.Bool(), p.Expression())
+	}
+}
+
+func TestEditTextParameter(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddTextUserParameter("label", "a")
+	if err := p.SetText("b c"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+	if p.Text() != "b c" || p.Expression() != `"b c"` {
+		t.Errorf("Text=%q Expression=%q, want \"b c\"", p.Text(), p.Expression())
+	}
+}
+
+// TestNumericOpsRejectedOnNonNumeric proves text/bool parameters refuse expressions and
+// numeric SetValue, and numeric parameters refuse SetText/SetBool.
+func TestNumericOpsRejectedOnNonNumeric(t *testing.T) {
+	ps := NewParameters()
+	text, _ := ps.AddTextUserParameter("t", "x")
+	if err := text.SetExpression("1 mm"); err == nil {
+		t.Error("SetExpression on a text parameter should fail")
+	}
+	if err := text.SetValue(Q(1, Length)); err == nil {
+		t.Error("SetValue on a text parameter should fail")
+	}
+
+	num, _ := ps.AddUserParameter("n", "1 mm")
+	if err := num.SetText("hi"); err == nil {
+		t.Error("SetText on a numeric parameter should fail")
+	}
+	if err := num.SetBool(true); err == nil {
+		t.Error("SetBool on a numeric parameter should fail")
+	}
+}


### PR DESCRIPTION
## What

Adds Inventor's **Manage ▸ Parameters** dialog and the underlying parameter-model functionality to back it: text & true/false parameters, multi-value lists, custom groups, copy-to-user, search, and full persistence.

## Why

We already had a strong *numeric* parameter model (expressions, dependency graph, units, tolerance) but it was only visible **read-only** in the browser tree. There was no Parameters dialog, no Manage tab, and no support for the non-numeric parameter types or organization features described in the [journey](experiments/inventor-docs-scraper/.../GUID-595F9D8E-...).

## How it's built (7 focused commits)

1. **`param`: text & true/false parameters** — a parameter can hold a literal string or bool (not just a numeric `Quantity`); `SetExpression`/`SetValue` reject them and `SetText`/`SetBool` reject numeric params.
2. **`param`: multi-value lists** — expression list + allow-custom, `SelectValue` with the "one custom value" rule.
3. **`param`: groups + copy-to-user** — custom groups (delete-group deletes members), `CopyToUser` → `<name>_copy`.
4. **`compdef`: persistence** — the recipe round-trips text/bool/comment/key/export/tolerance/multi-value/groups.
5. **`app`: Manage tab + bridge** — `Manage.Parameters` command, a string/float `ParameterRow` view model with **search filtering**, and edit verbs that recompute the part. Fully **headless-e2e-tested**.
6. **`native`: imgui table bindings** — `BeginTable`/columns/rows + `SetNextItemWidth`/`PushID`/`IsItemDeactivatedAfterEdit`.
7. **`head`: the dialog** — Model/User tables, editable cells (commit on focus loss), Key/Export checkboxes, multi-value dropdown, right-click menu (copy/delete/group/multi-value/tolerance), Add row, and Value-List / Tolerance / Add-to-Group popups.

No public wire/contract changes — parameters are driven in-proc; value-type is derived from the existing `param.Unit`.

## Tests

- `model/param`: text/bool, multi-value, groups, copy-to-user unit tests.
- `model/compdef`: full parameter round-trip (text/bool/tolerance/multi-value/groups).
- `app`: end-to-end dialog flow (open, add each type, edit equation→recompute, filter, multi-value select, group add/remove, copy, delete).
- `head/ui`: in-window smoke driving the dialog over a part with every parameter flavor (skips without a GPU).

`go build/vet/test ./...`, the cgo `head` build, `gofmt`, and SPDX headers all clean.

## Deferred

XML import/export (Import/Export to XML, export-to-BOM) is intentionally **not** in this PR — it was de-prioritized. Easy follow-up; nothing here depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)