### PR TITLE
fix(head): synchronize offscreen viewport depth attachment

### DIFF
--- a/head/internal/native/head.h
+++ b/head/internal/native/head.h
@@ -21,7 +21,12 @@ struct HeadContext {
     VkQueue                  queue = VK_NULL_HANDLE;
     VkDescriptorPool         descriptorPool = VK_NULL_HANDLE;
     ImGui_ImplVulkanH_Window window_data;
-    uint32_t                 minImageCount = 2;
+    // Triple buffering: with FIFO present, 2 images locks rendering to an integer
+    // fraction of the vsync rate and stutters when a frame runs long; 3 lets a finished
+    // frame queue while the next renders. (Vulkan best-practices
+    // vkCreateSwapchainKHR-suboptimal-swapchain-image-count.) Clamped to surface caps by
+    // ImGui_ImplVulkanH_CreateOrResizeWindow.
+    uint32_t                 minImageCount = 3;
     bool                     swapChainRebuild = false;
     Viewport*                viewport = nullptr; // 3D scene render target (lazy)
     IconTextures*            icons = nullptr;    // ribbon-icon texture cache (lazy)

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -98,13 +98,37 @@ void create_render_pass(HeadContext* c, Viewport* v) {
     sub.pColorAttachments = &colorRef;
     sub.pDepthStencilAttachment = &depthRef;
 
-    VkSubpassDependency dep{};
-    dep.srcSubpass = VK_SUBPASS_EXTERNAL;
-    dep.dstSubpass = 0;
-    dep.srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-    dep.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dep.srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
-    dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    // Two external dependencies keep the offscreen target hazard-free across frames. The
+    // color+depth images are reused every frame and ImGui samples the color image in its
+    // main pass between our frames, so BOTH attachments' prior use must be ordered before
+    // this pass's layout transition + load. The depth attachment in particular needs the
+    // early/late fragment-test stages with DEPTH_STENCIL_ATTACHMENT_WRITE; without it the
+    // sync validator flags SYNC-HAZARD-WRITE-AFTER-WRITE on the attachment-1 depth load
+    // (loadOp CLEAR) vs. the layout transition.
+    VkSubpassDependency deps[2]{};
+    // [0] Before the pass: the previous frame's color sample (fragment-shader read) and
+    // depth write must finish before we transition layouts and clear/write again.
+    deps[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+    deps[0].dstSubpass = 0;
+    deps[0].srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                           VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                           VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    deps[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                           VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+                           VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+    deps[0].srcAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                            VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    deps[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                            VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                            VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    // [1] After the pass: the color write must be visible to ImGui sampling the image as a
+    // texture in the main swapchain pass.
+    deps[1].srcSubpass = 0;
+    deps[1].dstSubpass = VK_SUBPASS_EXTERNAL;
+    deps[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    deps[1].dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+    deps[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    deps[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
     VkRenderPassCreateInfo rp{};
     rp.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -112,8 +136,8 @@ void create_render_pass(HeadContext* c, Viewport* v) {
     rp.pAttachments = atts;
     rp.subpassCount = 1;
     rp.pSubpasses = &sub;
-    rp.dependencyCount = 1;
-    rp.pDependencies = &dep;
+    rp.dependencyCount = 2;
+    rp.pDependencies = deps;
     vkCreateRenderPass(c->device, &rp, nullptr, &v->renderPass);
 }
 


### PR DESCRIPTION
## What

Fixes a Vulkan synchronization hazard in the 3D viewport''s offscreen render pass, and clears one best-practices advisory.

- **Depth-attachment sync hazard (the real bug).** `create_render_pass` in `head/internal/native/viewport.cpp` declared a single subpass dependency that only synchronized the **color** attachment, leaving the **depth** attachment (attachment 1) with no barrier. The depth image memory is reused every frame, so each frame''s `loadOp=CLEAR` write raced the previous frame''s depth write. Replaced the lone dependency with the canonical pair of external dependencies covering **both** color and depth — the pre-pass dependency adds the early/late fragment-test stages and depth-stencil read/write access so the depth layout transition + clear is ordered after the prior depth write; the post-pass dependency makes the color write visible to ImGui sampling the target.
- **Swapchain image count.** Bumped `minImageCount` 2 → 3 (triple buffering) in `head/internal/native/head.h` to clear `BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count`. Clamped to surface caps by `ImGui_ImplVulkanH`.

## Why

Running `oblikovati-head` under `VK_LAYER_KHRONOS_validation` reported, per 30-frame run:
- `SYNC-HAZARD-WRITE-AFTER-WRITE` (severity **ERROR / SPEC**) ×60 — `vkCmdBeginRenderPass(): Hazard WRITE_AFTER_WRITE vs. layout transition in subpass 0 for attachment 1 aspect depth during load with loadOp VK_ATTACHMENT_LOAD_OP_CLEAR`.
- `vkCreateSwapchainKHR-suboptimal-swapchain-image-count` ×2.

## Verification

Re-ran `oblikovati-head -frames 30` under the validation layer (core + sync + thread-safety + best-practices):
- sync-hazard count **60 → 0**
- swapchain warning **2 → 0**
- **0** remaining errors / spec violations
- `head` `go test ./...` passes (cgo, mingw-w64 + Vulkan SDK on Windows).

Remaining validation output is solely BestPractices **PERF** advisories about small dedicated allocations, originating from the vendored Dear ImGui Vulkan backend and the viewport''s by-design per-frame host-visible buffers; silencing those would require a Vulkan Memory Allocator (sub-allocation) and is out of scope here.

## Notes

The fix lives in cgo C++ (`internal/native`), which has no test harness in the headless cgo-free CI; a regression test would need the validation layer + a GPU at runtime. Verified manually as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)