### PR TITLE
feat(material): exhaustive built-in catalog with PBR + FEA-ready data

### DIFF
--- a/addin/router/material.go
+++ b/addin/router/material.go
@@ -26,7 +26,8 @@ func materialInfo(m *material.Material) wire.MaterialInfo {
 	return wire.MaterialInfo{
 		ID: m.ID(), DisplayName: m.DisplayName(), Source: string(m.Source()),
 		Density: m.Density(), Mechanical: m.Mechanical(), Thermal: m.Thermal(),
-		Electrical: m.Electrical(), AppearanceID: m.AppearanceID(),
+		Electrical: m.Electrical(), IsotropyClass: string(m.IsotropyClass()),
+		Anisotropic: m.Anisotropic(), AppearanceID: m.AppearanceID(),
 	}
 }
 
@@ -127,7 +128,9 @@ func updateMaterial(s *app.Session, args json.RawMessage) (json.RawMessage, erro
 	}
 	s.UpdateMaterial(in.ID, material.MaterialSpec{
 		DisplayName: in.DisplayName, Density: in.Density, Mechanical: in.Mechanical,
-		Thermal: in.Thermal, Electrical: in.Electrical, AppearanceID: in.AppearanceID,
+		Thermal: in.Thermal, Electrical: in.Electrical,
+		IsotropyClass: material.IsotropyClass(in.IsotropyClass), Anisotropic: in.Anisotropic,
+		AppearanceID: in.AppearanceID,
 	})
 	m, ok := s.Materials().Material(in.ID)
 	if !ok {

--- a/architecture/decisions/ADR-0024-embedded-material-catalog.md
+++ b/architecture/decisions/ADR-0024-embedded-material-catalog.md
@@ -1,0 +1,61 @@
+# ADR-0024 — Embedded built-in material & appearance catalog (YAML, go:embed)
+
+**Status:** accepted (user decision, 2026-06-04) · **Relates to:**
+[ADR-0022](ADR-0022-materials-appearances.md) (materials & appearances subsystem),
+[ADR-0020](ADR-0020-yaml-git-friendly-document-format.md) (YAML asset recipes),
+[ADR-0023](ADR-0023-viewport-display-modes.md) (Realistic PBR display mode that
+renders these appearances).
+
+## Context
+
+ADR-0022 shipped the materials/appearances subsystem with a placeholder built-in
+catalog: four materials and six appearances hand-coded as Go literals in
+`model/material/builtin.go`. To make Realistic mode useful we want a real,
+industry-representative library — periodic-table metals (Z ≤ 83), steel and aluminium
+alloys, plastics/resins, woods and composites — each with sourced mechanical, thermal
+and electrical properties and a physically-based PBR appearance.
+
+That is ~100+ entries. Encoding them as Go literals would blow past CLAUDE.md's
+500-line file limit, bury reviewable data in code, and make value diffs noisy. The
+asset data already has a canonical persisted shape — `AppearanceRecipe` /
+`MaterialRecipe` YAML (ADR-0020) — and a tested converter (`recipeToAppearance` /
+`recipeToMaterial`).
+
+## Decision
+
+1. **The built-in catalog ships as embedded YAML, not Go literals.** Category files live
+   in `model/material/catalog/` (`01-metals.yaml`, `02-steels.yaml`, `03-aluminum.yaml`,
+   `04-plastics.yaml`, `05-woods.yaml`, `06-composites.yaml`), embedded via `go:embed`
+   and loaded by `loadCatalog` in `catalog.go`. The numeric prefix fixes display order.
+   Files reuse the existing `RecipeData` shape, so there is **no new type or wire
+   surface** — this is implementation-only (no `../Oblikovati.API` change).
+
+2. **Built-ins load as `SourceBuiltin` (read-only).** `seedBuiltins` adds the neutral
+   `default` appearance (kept in code so `DefaultAppearanceID` is guaranteed present even
+   if a file is edited), then folds every catalog file in. A malformed file or colour is
+   a **build defect**: it panics, caught by the package tests — never a runtime branch.
+
+3. **Admission rule: reliable data only.** An entry ships only when every mechanical,
+   thermal and electrical field has a sourced value (`TestEveryMaterialHasReliableProperties`
+   enforces non-zero). Reactive/liquid metals and grades without dependable structural
+   data are omitted rather than guessed. Each file header cites its sources (ASM, CRC,
+   MatWeb, USDA FPL Wood Handbook, CMH-17, manufacturer datasheets).
+
+4. **Appearances are physically-based for the Realistic shader.** Metals use measured F0
+   reflectance base colours (Lagarde/UE4/Filament chart) authored in **sRGB** — the
+   shader linearises albedo (`mesh.frag`: `f0 = toLinear(albedo)`, ADR-0023) — with
+   `metallic = 1.0` and a finish-dependent roughness. Dielectrics use `metallic = 0.0`;
+   optically clear grades (acrylic, PC, PETG…) carry `opacity < 1.0`. Grain/weave texture
+   maps remain deferred (ADR-0022 §2): appearances are flat diffuse tones for now.
+
+## Consequences
+
+- The library grows from 4/6 to ~115 materials / ~88 appearances with no code-size or
+  type-surface cost; values are reviewed as data and diff cleanly.
+- A few legacy ids (`steel`, `aluminum-6061`, `aluminum`, `oak`, `abs-black`) are kept as
+  real entries so existing cross-package tests and assignments stay valid.
+- Catalog correctness is now test-guarded (count, unique ids, complete properties, PBR
+  ranges, required ids). Editing a YAML file re-runs through the same gates.
+- Future work: texture-map appearances (needs binary document sections + UVs), and
+  per-anisotropy-direction material data for woods/composites (current values are the
+  conventional single-axis engineering figures, documented in each file header).

--- a/architecture/decisions/ADR-0025-anisotropic-material-properties.md
+++ b/architecture/decisions/ADR-0025-anisotropic-material-properties.md
@@ -1,0 +1,60 @@
+# ADR-0025 — Anisotropic material properties (isotropy class + orthotropic elastic group)
+
+**Status:** accepted (user decision, 2026-06-04) · **Relates to:**
+[ADR-0022](ADR-0022-materials-appearances.md) (materials subsystem),
+[ADR-0024](ADR-0024-embedded-material-catalog.md) (the catalog this data ships in),
+[ADR-0018](ADR-0018-apache-api-contract-module.md) (API split this followed).
+
+## Context
+
+The `Material` model (ADR-0022) stores **scalar, isotropic** structural properties:
+`Mechanical{YoungsModulus, PoissonsRatio, YieldStrength, UltimateTensileStrength}`. For
+an eventual FEA capability this is exactly right for metals, alloys and bulk plastics —
+isotropic linear-static / modal / linear thermal-stress analysis needs only E, ν, ρ and α
+(shear modulus is derived, `G = E/2(1+ν)`).
+
+It is **wrong** for materials whose stiffness is direction-dependent: woods (orthotropic;
+transverse modulus ≈ 1/20 of longitudinal) and fibre-reinforced composites (a UD carbon
+lamina is ~135 GPa axial vs ~10 GPa transverse). Feeding a single-axis E to a solver as
+isotropic produces an incorrect stress field, not a conservative one. We want the catalog
+**simulation-ready now**, before solver work starts, so the data isn't re-sourced later.
+
+## Decision
+
+1. **Add an isotropy class + an optional orthotropic elastic group, contract-first.** New
+   in `api/types` (Apache-2.0): `IsotropyClass` (`isotropic` / `orthotropic` /
+   `transversely-isotropic`; empty == isotropic, with an `Anisotropic()` predicate) and
+   `AnisotropicElastic` — the nine independent orthotropic constants (E1,E2,E3, G12,G23,G13,
+   ν12,ν23,ν13) plus directional CTE (α1,α2,α3) for orthotropic thermal stress, in the
+   material principal axes. `contract.Material` gains `IsotropyClass()` / `Anisotropic()`;
+   `wire.MaterialInfo` gains the two fields (so a future FEA add-in reads them over the
+   wire). Then the GPL impl: `MaterialSpec` / `MaterialRecipe` fields, accessors, the
+   YAML `isotropy:` / `orthotropic:` keys (orthotropic is a pointer so isotropic materials
+   serialize no block).
+
+2. **Scope = elastic + thermal only.** The group carries stiffness and CTE — enough for
+   orthotropic linear-static and thermal-stress FEA. **Out of scope** (separate future
+   gaps, unchanged by this ADR): plastic hardening curves, and directional/failure
+   strength allowables for composites (Tsai-Wu/Hashin) — those are criterion- and
+   layup-specific and will be added when a solver and failure model are chosen. Until
+   then `Mechanical.YieldStrength`/`UTS` remain the equivalent scalar strengths.
+
+3. **Only genuinely anisotropic catalog entries are tagged.** Woods → orthotropic
+   (constants derived per species from its longitudinal modulus via the FPL Wood Handbook
+   average elastic ratios). UD carbon/glass/aramid laminae → transversely-isotropic;
+   balanced-weave carbon, G10/FR4, plywood and OSB → orthotropic. **Random-mat composites
+   stay isotropic** (chopped-strand fiberglass, SMC, carbon-filled nylon, MDF are in-plane
+   isotropic), as do all metals and bulk plastics. Sources are cited in each catalog file.
+
+## Consequences
+
+- The catalog is FEA-ready for the realistic first target (isotropic linear analysis) **and**
+  for orthotropic linear/thermal analysis of wood and composites, with no later re-sourcing.
+- Zero migration: empty class = isotropic, so every existing material and serialized file is
+  valid unchanged; the orthotropic block is omitted for isotropic assets.
+- Test-guarded: an anisotropic material must carry a complete positive elastic group, and a
+  populated group must declare a non-isotropic class (a forgotten tag fails the build).
+- The orthotropic constants for woods are **derived from standard FPL ratios**, not per-
+  specimen measurements; transverse CTE values are representative for timber. Documented in
+  the catalog headers; refine against species-specific data if a wood-specific analysis
+  needs it.

--- a/model/material/builtin.go
+++ b/model/material/builtin.go
@@ -13,70 +13,30 @@ import (
 // un-assigned model looks exactly as it did before this subsystem.
 const DefaultAppearanceID = "default"
 
-// seedBuiltins fills a fresh library with the shipped, read-only catalog: a neutral
-// default plus a few representative metals, plastics, and wood, each with a paired
-// appearance. Property values follow common engineering references (Inventor-comparable).
+// seedBuiltins fills a fresh library with the shipped, read-only catalog: the neutral
+// default appearance (always present, the resolver's last resort) followed by the
+// embedded category catalogs (metals, steels, aluminium, plastics, woods, composites,
+// ADR-0024). A malformed embedded file is a build defect, so it panics with the
+// offending file — caught by the package tests, never reached at runtime.
 func seedBuiltins(l *Library) {
-	for _, a := range builtinAppearances() {
-		l.AddAppearance(a)
-	}
-	for _, m := range builtinMaterials() {
-		l.AddMaterial(m)
+	l.AddAppearance(defaultAppearance())
+	if err := loadCatalog(l); err != nil {
+		panic(fmt.Sprintf("material: built-in catalog: %v", err))
 	}
 }
 
-// builtinAppearances returns the shipped appearance catalog.
-func builtinAppearances() []*Appearance {
-	a := func(id, name, albedo string, metallic, roughness float32) *Appearance {
-		return NewAppearance(id, SourceBuiltin, AppearanceSpec{
-			DisplayName: name, Albedo: mustColor(albedo), Metallic: metallic, Roughness: roughness,
-			Emissive: mustColor("#000000ff"), Opacity: 1,
-		})
-	}
-	return []*Appearance{
-		a(DefaultAppearanceID, "Default", "#b3b8bdff", 0, 0.6),
-		a("steel", "Steel", "#8a8d92ff", 0.9, 0.40),
-		a("aluminum", "Aluminum", "#c8ccd0ff", 0.9, 0.35),
-		a("abs-black", "ABS (Black)", "#1a1a1aff", 0, 0.50),
-		a("abs-white", "ABS (White)", "#e8e8e8ff", 0, 0.50),
-		a("oak", "Oak", "#b88a4fff", 0, 0.70),
-	}
+// defaultAppearance is the neutral gray fallback, kept in code (not the YAML catalog) so
+// DefaultAppearanceID is guaranteed present even if a catalog file is hand-edited.
+func defaultAppearance() *Appearance {
+	return NewAppearance(DefaultAppearanceID, SourceBuiltin, AppearanceSpec{
+		DisplayName: "Default", Albedo: mustColor("#b3b8bdff"), Metallic: 0, Roughness: 0.6,
+		Emissive: mustColor("#000000ff"), Opacity: 1,
+	})
 }
 
-// builtinMaterials returns the shipped material catalog, each referencing a built-in
-// appearance by id.
-func builtinMaterials() []*Material {
-	return []*Material{
-		NewMaterial("steel", SourceBuiltin, MaterialSpec{
-			DisplayName: "Steel", Density: 7.85, AppearanceID: "steel",
-			Mechanical: Mechanical{YoungsModulus: 210, PoissonsRatio: 0.30, YieldStrength: 350, UltimateTensileStrength: 420},
-			Thermal:    Thermal{Conductivity: 50, ExpansionCoeff: 12e-6, SpecificHeat: 480},
-			Electrical: Electrical{Resistivity: 1.7e-7, RelativePermittivity: 1},
-		}),
-		NewMaterial("aluminum-6061", SourceBuiltin, MaterialSpec{
-			DisplayName: "Aluminum 6061", Density: 2.70, AppearanceID: "aluminum",
-			Mechanical: Mechanical{YoungsModulus: 68.9, PoissonsRatio: 0.33, YieldStrength: 276, UltimateTensileStrength: 310},
-			Thermal:    Thermal{Conductivity: 167, ExpansionCoeff: 23.6e-6, SpecificHeat: 896},
-			Electrical: Electrical{Resistivity: 3.99e-8, RelativePermittivity: 1},
-		}),
-		NewMaterial("abs-plastic", SourceBuiltin, MaterialSpec{
-			DisplayName: "ABS Plastic", Density: 1.06, AppearanceID: "abs-black",
-			Mechanical: Mechanical{YoungsModulus: 2.1, PoissonsRatio: 0.35, YieldStrength: 40, UltimateTensileStrength: 44},
-			Thermal:    Thermal{Conductivity: 0.17, ExpansionCoeff: 90e-6, SpecificHeat: 1300},
-			Electrical: Electrical{Resistivity: 1e15, RelativePermittivity: 3.0},
-		}),
-		NewMaterial("oak-wood", SourceBuiltin, MaterialSpec{
-			DisplayName: "Oak Wood", Density: 0.75, AppearanceID: "oak",
-			Mechanical: Mechanical{YoungsModulus: 11, PoissonsRatio: 0.35, YieldStrength: 40, UltimateTensileStrength: 50},
-			Thermal:    Thermal{Conductivity: 0.17, ExpansionCoeff: 5e-6, SpecificHeat: 1700},
-			Electrical: Electrical{Resistivity: 1e14, RelativePermittivity: 2.0},
-		}),
-	}
-}
-
-// hex parses an authored built-in color literal, panicking with the offending value on a
-// malformed constant (a programming error caught by the package tests, not a runtime
-// condition).
+// mustColor parses an authored built-in color literal, panicking with the offending
+// value on a malformed constant (a programming error caught by the package tests, not a
+// runtime condition).
 func mustColor(s string) Rgba {
 	c, err := types.ParseHex(s)
 	if err != nil {

--- a/model/material/catalog.go
+++ b/model/material/catalog.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
+)
+
+// catalogFiles holds the shipped, read-only material catalog: one YAML file per category
+// (metals, steels, aluminium, plastics, woods, composites), numbered so they load in a
+// stable display order. Keeping the catalog as data (ADR-0024) rather than Go literals
+// lets the ~100-entry library stay reviewable and under the file-size limit.
+//
+//go:embed catalog/*.yaml
+var catalogFiles embed.FS
+
+// loadCatalog parses every embedded catalog file in sorted order and folds its
+// appearances and materials into l as built-in (read-only) assets. The files ship with
+// the binary, so a parse error or malformed colour is a build defect; it is returned for
+// the caller (seedBuiltins) to turn into a panic the package tests catch — never a
+// runtime condition.
+func loadCatalog(l *Library) error {
+	names, err := fs.Glob(catalogFiles, "catalog/*.yaml")
+	if err != nil {
+		return fmt.Errorf("material: list catalog: %w", err)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := loadCatalogFile(l, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// loadCatalogFile reads one catalog file and adds its appearances and materials to l as
+// built-ins, naming the offending file and asset id on any malformed colour.
+func loadCatalogFile(l *Library, name string) error {
+	data, err := catalogFiles.ReadFile(name)
+	if err != nil {
+		return fmt.Errorf("material: read catalog %q: %w", name, err)
+	}
+	var rd RecipeData
+	if err := yamlcodec.Unmarshal(data, &rd); err != nil {
+		return fmt.Errorf("material: parse catalog %q: %w", name, err)
+	}
+	for _, ar := range rd.Appearances {
+		a, err := recipeToAppearance(ar, SourceBuiltin)
+		if err != nil {
+			return fmt.Errorf("material: catalog %q appearance %q: %w", name, ar.ID, err)
+		}
+		l.AddAppearance(a)
+	}
+	for _, mr := range rd.Materials {
+		l.AddMaterial(recipeToMaterial(mr, SourceBuiltin))
+	}
+	return nil
+}

--- a/model/material/catalog/01-metals.yaml
+++ b/model/material/catalog/01-metals.yaml
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Built-in catalog: elemental metals industrially used, atomic number Z <= 83 (Bismuth).
+# Only elements with reliable mechanical, thermal AND electrical data are included; pure
+# reactive/liquid metals (Na, K, Ca, Hg) and metals without dependable structural data
+# (Mn, Ga, Tc, Tl) are intentionally omitted.
+#
+# Property sources (typical / annealed, room temperature):
+#   - Density, thermal conductivity, linear expansion, specific heat, electrical
+#     resistivity: CRC Handbook of Chemistry and Physics (97th ed.); ASM Metals
+#     Reference Book (3rd ed.); MatWeb element datasheets.
+#   - Young's modulus, Poisson's ratio, yield & ultimate tensile strength: ASM
+#     Metals Handbook Vol. 2; AZoM material profiles; MatWeb. Strength values are for
+#     commercially pure, annealed wrought form unless noted; brittle elements list an
+#     approximate tensile/flexural figure (no distinct yield) and are tagged "brittle".
+#
+# Appearance base colors (albedo) are physically-based metal F0 reflectance values in
+# sRGB, after the Lagarde/UE4/Filament metal reference chart; the Realistic shader
+# linearises them (mesh.frag: f0 = toLinear(albedo)). metallic = 1.0 for every pure
+# metal; roughness encodes a representative polished-to-satin finish.
+#
+# Units: density g/cm3 | youngsModulus GPa | yield & UTS MPa | conductivity W/(m*K)
+#        expansionCoeff 1/K | specificHeat J/(kg*K) | resistivity ohm*m | relativePermittivity -
+
+appearances:
+  - {id: beryllium,  name: Beryllium,  albedo: "#c2c1baff", metallic: 1.0, roughness: 0.45, opacity: 1.0}
+  - {id: magnesium,  name: Magnesium,  albedo: "#c6c4bdff", metallic: 1.0, roughness: 0.50, opacity: 1.0}
+  - {id: aluminum,   name: Aluminum,   albedo: "#f4f5f5ff", metallic: 1.0, roughness: 0.30, opacity: 1.0}
+  - {id: titanium,   name: Titanium,   albedo: "#c3bab1ff", metallic: 1.0, roughness: 0.38, opacity: 1.0}
+  - {id: vanadium,   name: Vanadium,   albedo: "#c3c6c8ff", metallic: 1.0, roughness: 0.40, opacity: 1.0}
+  - {id: chromium,   name: Chromium,   albedo: "#c4c5c5ff", metallic: 1.0, roughness: 0.22, opacity: 1.0}
+  - {id: iron,       name: Iron,       albedo: "#c4c7c7ff", metallic: 1.0, roughness: 0.42, opacity: 1.0}
+  - {id: cobalt,     name: Cobalt,     albedo: "#d2d2d0ff", metallic: 1.0, roughness: 0.38, opacity: 1.0}
+  - {id: nickel,     name: Nickel,     albedo: "#d4ccc0ff", metallic: 1.0, roughness: 0.32, opacity: 1.0}
+  - {id: copper,     name: Copper,     albedo: "#fad0c0ff", metallic: 1.0, roughness: 0.30, opacity: 1.0}
+  - {id: zinc,       name: Zinc,       albedo: "#d2d6d8ff", metallic: 1.0, roughness: 0.50, opacity: 1.0}
+  - {id: zirconium,  name: Zirconium,  albedo: "#c9ccccff", metallic: 1.0, roughness: 0.40, opacity: 1.0}
+  - {id: niobium,    name: Niobium,    albedo: "#c4c6c9ff", metallic: 1.0, roughness: 0.40, opacity: 1.0}
+  - {id: molybdenum, name: Molybdenum, albedo: "#cdd0cfff", metallic: 1.0, roughness: 0.38, opacity: 1.0}
+  - {id: ruthenium,  name: Ruthenium,  albedo: "#c8c7c2ff", metallic: 1.0, roughness: 0.35, opacity: 1.0}
+  - {id: rhodium,    name: Rhodium,    albedo: "#d8d6d2ff", metallic: 1.0, roughness: 0.20, opacity: 1.0}
+  - {id: palladium,  name: Palladium,  albedo: "#cfccc4ff", metallic: 1.0, roughness: 0.25, opacity: 1.0}
+  - {id: silver,     name: Silver,     albedo: "#fcfaf5ff", metallic: 1.0, roughness: 0.22, opacity: 1.0}
+  - {id: cadmium,    name: Cadmium,    albedo: "#cdd0d2ff", metallic: 1.0, roughness: 0.45, opacity: 1.0}
+  - {id: indium,     name: Indium,     albedo: "#d3d6d8ff", metallic: 1.0, roughness: 0.50, opacity: 1.0}
+  - {id: tin,        name: Tin,        albedo: "#d6d9dbff", metallic: 1.0, roughness: 0.40, opacity: 1.0}
+  - {id: antimony,   name: Antimony,   albedo: "#c6c8cbff", metallic: 1.0, roughness: 0.45, opacity: 1.0}
+  - {id: hafnium,    name: Hafnium,    albedo: "#c2c4c5ff", metallic: 1.0, roughness: 0.40, opacity: 1.0}
+  - {id: tantalum,   name: Tantalum,   albedo: "#b8bcc4ff", metallic: 1.0, roughness: 0.38, opacity: 1.0}
+  - {id: tungsten,   name: Tungsten,   albedo: "#c9cbc9ff", metallic: 1.0, roughness: 0.38, opacity: 1.0}
+  - {id: rhenium,    name: Rhenium,    albedo: "#c4c4c2ff", metallic: 1.0, roughness: 0.38, opacity: 1.0}
+  - {id: osmium,     name: Osmium,     albedo: "#b8bcc6ff", metallic: 1.0, roughness: 0.35, opacity: 1.0}
+  - {id: iridium,    name: Iridium,    albedo: "#d0d1cfff", metallic: 1.0, roughness: 0.28, opacity: 1.0}
+  - {id: platinum,   name: Platinum,   albedo: "#d4cdc1ff", metallic: 1.0, roughness: 0.25, opacity: 1.0}
+  - {id: gold,       name: Gold,       albedo: "#ffe29bff", metallic: 1.0, roughness: 0.24, opacity: 1.0}
+  - {id: lead,       name: Lead,       albedo: "#9fa4adff", metallic: 1.0, roughness: 0.50, opacity: 1.0}
+  - {id: bismuth,    name: Bismuth,    albedo: "#b9a9a0ff", metallic: 1.0, roughness: 0.45, opacity: 1.0}
+
+materials:
+  - id: beryllium
+    name: Beryllium
+    density: 1.85
+    appearance: beryllium
+    mechanical: {youngsModulus: 287, poissonsRatio: 0.032, yieldStrength: 240, ultimateTensileStrength: 370}
+    thermal:    {conductivity: 200, expansionCoeff: 11.3e-6, specificHeat: 1825}
+    electrical: {resistivity: 3.6e-8, relativePermittivity: 1}
+  - id: magnesium
+    name: Magnesium
+    density: 1.74
+    appearance: magnesium
+    mechanical: {youngsModulus: 45, poissonsRatio: 0.29, yieldStrength: 40, ultimateTensileStrength: 160}
+    thermal:    {conductivity: 156, expansionCoeff: 24.8e-6, specificHeat: 1023}
+    electrical: {resistivity: 4.39e-8, relativePermittivity: 1}
+  - id: aluminum-1100
+    name: Aluminum (Pure, 1100)
+    density: 2.71
+    appearance: aluminum
+    mechanical: {youngsModulus: 69, poissonsRatio: 0.33, yieldStrength: 34, ultimateTensileStrength: 90}
+    thermal:    {conductivity: 222, expansionCoeff: 23.6e-6, specificHeat: 904}
+    electrical: {resistivity: 2.99e-8, relativePermittivity: 1}
+  - id: titanium-cp
+    name: Titanium (CP Grade 2)
+    density: 4.51
+    appearance: titanium
+    mechanical: {youngsModulus: 105, poissonsRatio: 0.34, yieldStrength: 275, ultimateTensileStrength: 345}
+    thermal:    {conductivity: 16.4, expansionCoeff: 8.6e-6, specificHeat: 523}
+    electrical: {resistivity: 4.2e-7, relativePermittivity: 1}
+  - id: vanadium
+    name: Vanadium
+    density: 6.11
+    appearance: vanadium
+    mechanical: {youngsModulus: 128, poissonsRatio: 0.37, yieldStrength: 380, ultimateTensileStrength: 460}
+    thermal:    {conductivity: 30.7, expansionCoeff: 8.4e-6, specificHeat: 489}
+    electrical: {resistivity: 1.97e-7, relativePermittivity: 1}
+  - id: chromium
+    name: Chromium
+    density: 7.19
+    appearance: chromium
+    # brittle at room temperature: yield/UTS are approximate tensile figures
+    mechanical: {youngsModulus: 279, poissonsRatio: 0.21, yieldStrength: 131, ultimateTensileStrength: 282}
+    thermal:    {conductivity: 93.9, expansionCoeff: 4.9e-6, specificHeat: 449}
+    electrical: {resistivity: 1.25e-7, relativePermittivity: 1}
+  - id: iron-pure
+    name: Iron (Pure)
+    density: 7.87
+    appearance: iron
+    mechanical: {youngsModulus: 211, poissonsRatio: 0.29, yieldStrength: 50, ultimateTensileStrength: 200}
+    thermal:    {conductivity: 80.4, expansionCoeff: 11.8e-6, specificHeat: 449}
+    electrical: {resistivity: 9.71e-8, relativePermittivity: 1}
+  - id: cobalt
+    name: Cobalt
+    density: 8.90
+    appearance: cobalt
+    mechanical: {youngsModulus: 209, poissonsRatio: 0.31, yieldStrength: 225, ultimateTensileStrength: 800}
+    thermal:    {conductivity: 100, expansionCoeff: 13.0e-6, specificHeat: 421}
+    electrical: {resistivity: 6.24e-8, relativePermittivity: 1}
+  - id: nickel
+    name: Nickel
+    density: 8.90
+    appearance: nickel
+    mechanical: {youngsModulus: 200, poissonsRatio: 0.31, yieldStrength: 148, ultimateTensileStrength: 462}
+    thermal:    {conductivity: 90.9, expansionCoeff: 13.4e-6, specificHeat: 444}
+    electrical: {resistivity: 6.99e-8, relativePermittivity: 1}
+  - id: copper-c110
+    name: Copper (C110)
+    density: 8.96
+    appearance: copper
+    mechanical: {youngsModulus: 128, poissonsRatio: 0.34, yieldStrength: 70, ultimateTensileStrength: 220}
+    thermal:    {conductivity: 391, expansionCoeff: 16.5e-6, specificHeat: 385}
+    electrical: {resistivity: 1.71e-8, relativePermittivity: 1}
+  - id: zinc
+    name: Zinc
+    density: 7.14
+    appearance: zinc
+    mechanical: {youngsModulus: 108, poissonsRatio: 0.25, yieldStrength: 110, ultimateTensileStrength: 150}
+    thermal:    {conductivity: 116, expansionCoeff: 30.2e-6, specificHeat: 388}
+    electrical: {resistivity: 5.9e-8, relativePermittivity: 1}
+  - id: zirconium
+    name: Zirconium
+    density: 6.52
+    appearance: zirconium
+    mechanical: {youngsModulus: 88, poissonsRatio: 0.34, yieldStrength: 230, ultimateTensileStrength: 330}
+    thermal:    {conductivity: 22.6, expansionCoeff: 5.7e-6, specificHeat: 278}
+    electrical: {resistivity: 4.21e-7, relativePermittivity: 1}
+  - id: niobium
+    name: Niobium
+    density: 8.57
+    appearance: niobium
+    mechanical: {youngsModulus: 105, poissonsRatio: 0.40, yieldStrength: 240, ultimateTensileStrength: 275}
+    thermal:    {conductivity: 53.7, expansionCoeff: 7.3e-6, specificHeat: 265}
+    electrical: {resistivity: 1.52e-7, relativePermittivity: 1}
+  - id: molybdenum
+    name: Molybdenum
+    density: 10.22
+    appearance: molybdenum
+    mechanical: {youngsModulus: 329, poissonsRatio: 0.31, yieldStrength: 415, ultimateTensileStrength: 690}
+    thermal:    {conductivity: 138, expansionCoeff: 4.8e-6, specificHeat: 251}
+    electrical: {resistivity: 5.34e-8, relativePermittivity: 1}
+  - id: ruthenium
+    name: Ruthenium
+    density: 12.37
+    appearance: ruthenium
+    # hard, low-ductility: strength figures approximate
+    mechanical: {youngsModulus: 447, poissonsRatio: 0.30, yieldStrength: 370, ultimateTensileStrength: 510}
+    thermal:    {conductivity: 117, expansionCoeff: 6.4e-6, specificHeat: 238}
+    electrical: {resistivity: 7.1e-8, relativePermittivity: 1}
+  - id: rhodium
+    name: Rhodium
+    density: 12.41
+    appearance: rhodium
+    mechanical: {youngsModulus: 380, poissonsRatio: 0.26, yieldStrength: 70, ultimateTensileStrength: 951}
+    thermal:    {conductivity: 150, expansionCoeff: 8.2e-6, specificHeat: 243}
+    electrical: {resistivity: 4.3e-8, relativePermittivity: 1}
+  - id: palladium
+    name: Palladium
+    density: 12.02
+    appearance: palladium
+    mechanical: {youngsModulus: 121, poissonsRatio: 0.39, yieldStrength: 55, ultimateTensileStrength: 180}
+    thermal:    {conductivity: 71.8, expansionCoeff: 11.8e-6, specificHeat: 244}
+    electrical: {resistivity: 1.05e-7, relativePermittivity: 1}
+  - id: silver
+    name: Silver
+    density: 10.49
+    appearance: silver
+    mechanical: {youngsModulus: 83, poissonsRatio: 0.37, yieldStrength: 55, ultimateTensileStrength: 170}
+    thermal:    {conductivity: 429, expansionCoeff: 18.9e-6, specificHeat: 235}
+    electrical: {resistivity: 1.59e-8, relativePermittivity: 1}
+  - id: cadmium
+    name: Cadmium
+    density: 8.65
+    appearance: cadmium
+    mechanical: {youngsModulus: 50, poissonsRatio: 0.30, yieldStrength: 28, ultimateTensileStrength: 71}
+    thermal:    {conductivity: 96.6, expansionCoeff: 30.8e-6, specificHeat: 232}
+    electrical: {resistivity: 7.27e-8, relativePermittivity: 1}
+  - id: indium
+    name: Indium
+    density: 7.31
+    appearance: indium
+    mechanical: {youngsModulus: 11, poissonsRatio: 0.45, yieldStrength: 2.5, ultimateTensileStrength: 4.5}
+    thermal:    {conductivity: 81.8, expansionCoeff: 32.1e-6, specificHeat: 233}
+    electrical: {resistivity: 8.37e-8, relativePermittivity: 1}
+  - id: tin
+    name: Tin
+    density: 7.27
+    appearance: tin
+    mechanical: {youngsModulus: 50, poissonsRatio: 0.36, yieldStrength: 11, ultimateTensileStrength: 15}
+    thermal:    {conductivity: 66.8, expansionCoeff: 22.0e-6, specificHeat: 228}
+    electrical: {resistivity: 1.15e-7, relativePermittivity: 1}
+  - id: antimony
+    name: Antimony
+    density: 6.68
+    appearance: antimony
+    # brittle metalloid: yield approximated to tensile strength
+    mechanical: {youngsModulus: 55, poissonsRatio: 0.25, yieldStrength: 11, ultimateTensileStrength: 11}
+    thermal:    {conductivity: 24.4, expansionCoeff: 11.0e-6, specificHeat: 207}
+    electrical: {resistivity: 4.0e-7, relativePermittivity: 1}
+  - id: hafnium
+    name: Hafnium
+    density: 13.31
+    appearance: hafnium
+    mechanical: {youngsModulus: 78, poissonsRatio: 0.37, yieldStrength: 240, ultimateTensileStrength: 450}
+    thermal:    {conductivity: 23.0, expansionCoeff: 5.9e-6, specificHeat: 144}
+    electrical: {resistivity: 3.31e-7, relativePermittivity: 1}
+  - id: tantalum
+    name: Tantalum
+    density: 16.69
+    appearance: tantalum
+    mechanical: {youngsModulus: 186, poissonsRatio: 0.34, yieldStrength: 180, ultimateTensileStrength: 205}
+    thermal:    {conductivity: 57.5, expansionCoeff: 6.3e-6, specificHeat: 140}
+    electrical: {resistivity: 1.31e-7, relativePermittivity: 1}
+  - id: tungsten
+    name: Tungsten
+    density: 19.25
+    appearance: tungsten
+    mechanical: {youngsModulus: 411, poissonsRatio: 0.28, yieldStrength: 750, ultimateTensileStrength: 980}
+    thermal:    {conductivity: 173, expansionCoeff: 4.5e-6, specificHeat: 132}
+    electrical: {resistivity: 5.28e-8, relativePermittivity: 1}
+  - id: rhenium
+    name: Rhenium
+    density: 21.02
+    appearance: rhenium
+    mechanical: {youngsModulus: 463, poissonsRatio: 0.30, yieldStrength: 290, ultimateTensileStrength: 1070}
+    thermal:    {conductivity: 48.0, expansionCoeff: 6.2e-6, specificHeat: 137}
+    electrical: {resistivity: 1.8e-7, relativePermittivity: 1}
+  - id: osmium
+    name: Osmium
+    density: 22.59
+    appearance: osmium
+    # hardest elemental metal, brittle: yield approximated to compressive/tensile figure
+    mechanical: {youngsModulus: 559, poissonsRatio: 0.25, yieldStrength: 1000, ultimateTensileStrength: 1000}
+    thermal:    {conductivity: 87.6, expansionCoeff: 5.1e-6, specificHeat: 130}
+    electrical: {resistivity: 8.1e-8, relativePermittivity: 1}
+  - id: iridium
+    name: Iridium
+    density: 22.56
+    appearance: iridium
+    mechanical: {youngsModulus: 528, poissonsRatio: 0.26, yieldStrength: 490, ultimateTensileStrength: 1100}
+    thermal:    {conductivity: 147, expansionCoeff: 6.4e-6, specificHeat: 131}
+    electrical: {resistivity: 4.71e-8, relativePermittivity: 1}
+  - id: platinum
+    name: Platinum
+    density: 21.45
+    appearance: platinum
+    mechanical: {youngsModulus: 168, poissonsRatio: 0.38, yieldStrength: 70, ultimateTensileStrength: 165}
+    thermal:    {conductivity: 71.6, expansionCoeff: 8.8e-6, specificHeat: 133}
+    electrical: {resistivity: 1.06e-7, relativePermittivity: 1}
+  - id: gold
+    name: Gold
+    density: 19.30
+    appearance: gold
+    mechanical: {youngsModulus: 79, poissonsRatio: 0.44, yieldStrength: 30, ultimateTensileStrength: 120}
+    thermal:    {conductivity: 318, expansionCoeff: 14.2e-6, specificHeat: 129}
+    electrical: {resistivity: 2.21e-8, relativePermittivity: 1}
+  - id: lead
+    name: Lead
+    density: 11.34
+    appearance: lead
+    mechanical: {youngsModulus: 16, poissonsRatio: 0.44, yieldStrength: 12, ultimateTensileStrength: 18}
+    thermal:    {conductivity: 35.3, expansionCoeff: 28.9e-6, specificHeat: 129}
+    electrical: {resistivity: 2.08e-7, relativePermittivity: 1}
+  - id: bismuth
+    name: Bismuth
+    density: 9.78
+    appearance: bismuth
+    # brittle: tensile figure approximate, no distinct yield
+    mechanical: {youngsModulus: 32, poissonsRatio: 0.33, yieldStrength: 70, ultimateTensileStrength: 70}
+    thermal:    {conductivity: 7.97, expansionCoeff: 13.4e-6, specificHeat: 122}
+    electrical: {resistivity: 1.29e-6, relativePermittivity: 1}

--- a/model/material/catalog/02-steels.yaml
+++ b/model/material/catalog/02-steels.yaml
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Built-in catalog: carbon, alloy, tool and stainless steels plus cast irons — the
+# ferrous grades most used in mechanical design.
+#
+# Property sources (room temperature, condition noted per grade):
+#   - Strength & elastic data: ASM Metals Handbook Vol. 1 (Properties and Selection:
+#     Irons, Steels); MatWeb grade datasheets; AZoM. Carbon/alloy strengths are for the
+#     common delivery condition (cold-drawn or quenched-and-tempered); tool steels are
+#     hardened-and-tempered; stainless grades are annealed unless noted.
+#   - Thermal & electrical: ASM; MatWeb; engineeringtoolbox.com.
+#   - Cast irons are brittle with no distinct yield; the yield figure given is the
+#     0.2%-offset / proof figure where defined, else approximated to tensile strength.
+#
+# Appearances are physically-based ferrous metal looks (metallic = 1.0). Roughness
+# separates polished stainless from satin carbon steel, as-cast iron and galvanised
+# spangle. Base colors are neutral iron-grey F0 reflectance in sRGB.
+#
+# Units: density g/cm3 | youngsModulus GPa | yield & UTS MPa | conductivity W/(m*K)
+#        expansionCoeff 1/K | specificHeat J/(kg*K) | resistivity ohm*m | relativePermittivity -
+
+appearances:
+  - {id: steel,            name: Steel (Carbon),    albedo: "#bcbfc0ff", metallic: 1.0, roughness: 0.45, opacity: 1.0}
+  - {id: stainless-steel,  name: Stainless Steel,   albedo: "#cdd0d1ff", metallic: 1.0, roughness: 0.30, opacity: 1.0}
+  - {id: tool-steel,       name: Tool Steel,        albedo: "#b2b4b6ff", metallic: 1.0, roughness: 0.35, opacity: 1.0}
+  - {id: cast-iron,        name: Cast Iron,         albedo: "#a6a8a9ff", metallic: 1.0, roughness: 0.60, opacity: 1.0}
+  - {id: galvanized-steel, name: Galvanized Steel,  albedo: "#cfd4d6ff", metallic: 1.0, roughness: 0.48, opacity: 1.0}
+
+materials:
+  - id: steel
+    name: Steel (AISI 1018, Cold Drawn)
+    density: 7.87
+    appearance: steel
+    mechanical: {youngsModulus: 205, poissonsRatio: 0.29, yieldStrength: 370, ultimateTensileStrength: 440}
+    thermal:    {conductivity: 51.9, expansionCoeff: 11.5e-6, specificHeat: 486}
+    electrical: {resistivity: 1.59e-7, relativePermittivity: 1}
+  - id: steel-a36
+    name: Steel (ASTM A36 Structural)
+    density: 7.85
+    appearance: steel
+    mechanical: {youngsModulus: 200, poissonsRatio: 0.26, yieldStrength: 250, ultimateTensileStrength: 400}
+    thermal:    {conductivity: 50.0, expansionCoeff: 11.7e-6, specificHeat: 486}
+    electrical: {resistivity: 1.5e-7, relativePermittivity: 1}
+  - id: steel-1045
+    name: Steel (AISI 1045, Cold Drawn)
+    density: 7.87
+    appearance: steel
+    mechanical: {youngsModulus: 200, poissonsRatio: 0.29, yieldStrength: 530, ultimateTensileStrength: 625}
+    thermal:    {conductivity: 49.8, expansionCoeff: 11.5e-6, specificHeat: 486}
+    electrical: {resistivity: 1.6e-7, relativePermittivity: 1}
+  - id: steel-4140
+    name: Steel (AISI 4140 Chromoly, Q&T)
+    density: 7.85
+    appearance: steel
+    mechanical: {youngsModulus: 205, poissonsRatio: 0.29, yieldStrength: 655, ultimateTensileStrength: 1020}
+    thermal:    {conductivity: 42.6, expansionCoeff: 12.3e-6, specificHeat: 473}
+    electrical: {resistivity: 2.2e-7, relativePermittivity: 1}
+  - id: steel-4340
+    name: Steel (AISI 4340 Alloy, Q&T)
+    density: 7.85
+    appearance: steel
+    mechanical: {youngsModulus: 205, poissonsRatio: 0.29, yieldStrength: 862, ultimateTensileStrength: 1110}
+    thermal:    {conductivity: 44.5, expansionCoeff: 12.3e-6, specificHeat: 475}
+    electrical: {resistivity: 2.48e-7, relativePermittivity: 1}
+  - id: steel-1095
+    name: Steel (AISI 1095 Spring, Annealed)
+    density: 7.85
+    appearance: tool-steel
+    mechanical: {youngsModulus: 205, poissonsRatio: 0.29, yieldStrength: 525, ultimateTensileStrength: 685}
+    thermal:    {conductivity: 46.7, expansionCoeff: 11.0e-6, specificHeat: 477}
+    electrical: {resistivity: 1.8e-7, relativePermittivity: 1}
+  - id: steel-d2
+    name: Tool Steel (AISI D2, Hardened)
+    density: 7.70
+    appearance: tool-steel
+    mechanical: {youngsModulus: 210, poissonsRatio: 0.30, yieldStrength: 1550, ultimateTensileStrength: 1900}
+    thermal:    {conductivity: 20.0, expansionCoeff: 10.4e-6, specificHeat: 460}
+    electrical: {resistivity: 6.5e-7, relativePermittivity: 1}
+  - id: steel-a2
+    name: Tool Steel (AISI A2, Hardened)
+    density: 7.86
+    appearance: tool-steel
+    mechanical: {youngsModulus: 203, poissonsRatio: 0.30, yieldStrength: 1380, ultimateTensileStrength: 1620}
+    thermal:    {conductivity: 24.0, expansionCoeff: 10.7e-6, specificHeat: 460}
+    electrical: {resistivity: 6.0e-7, relativePermittivity: 1}
+  - id: steel-o1
+    name: Tool Steel (AISI O1, Hardened)
+    density: 7.81
+    appearance: tool-steel
+    mechanical: {youngsModulus: 205, poissonsRatio: 0.30, yieldStrength: 1400, ultimateTensileStrength: 1500}
+    thermal:    {conductivity: 30.0, expansionCoeff: 11.5e-6, specificHeat: 460}
+    electrical: {resistivity: 5.0e-7, relativePermittivity: 1}
+  - id: steel-h13
+    name: Tool Steel (AISI H13, Hot Work)
+    density: 7.80
+    appearance: tool-steel
+    mechanical: {youngsModulus: 210, poissonsRatio: 0.30, yieldStrength: 1380, ultimateTensileStrength: 1740}
+    thermal:    {conductivity: 24.3, expansionCoeff: 10.4e-6, specificHeat: 460}
+    electrical: {resistivity: 5.2e-7, relativePermittivity: 1}
+  - id: stainless-304
+    name: Stainless Steel (AISI 304, Annealed)
+    density: 8.00
+    appearance: stainless-steel
+    mechanical: {youngsModulus: 193, poissonsRatio: 0.29, yieldStrength: 215, ultimateTensileStrength: 505}
+    thermal:    {conductivity: 16.2, expansionCoeff: 17.3e-6, specificHeat: 500}
+    electrical: {resistivity: 7.2e-7, relativePermittivity: 1}
+  - id: stainless-316
+    name: Stainless Steel (AISI 316, Annealed)
+    density: 8.00
+    appearance: stainless-steel
+    mechanical: {youngsModulus: 193, poissonsRatio: 0.27, yieldStrength: 290, ultimateTensileStrength: 580}
+    thermal:    {conductivity: 16.3, expansionCoeff: 15.9e-6, specificHeat: 500}
+    electrical: {resistivity: 7.4e-7, relativePermittivity: 1}
+  - id: stainless-316l
+    name: Stainless Steel (AISI 316L, Annealed)
+    density: 8.00
+    appearance: stainless-steel
+    mechanical: {youngsModulus: 193, poissonsRatio: 0.27, yieldStrength: 170, ultimateTensileStrength: 485}
+    thermal:    {conductivity: 16.3, expansionCoeff: 15.9e-6, specificHeat: 500}
+    electrical: {resistivity: 7.4e-7, relativePermittivity: 1}
+  - id: stainless-430
+    name: Stainless Steel (AISI 430, Ferritic)
+    density: 7.70
+    appearance: stainless-steel
+    mechanical: {youngsModulus: 200, poissonsRatio: 0.28, yieldStrength: 310, ultimateTensileStrength: 515}
+    thermal:    {conductivity: 26.1, expansionCoeff: 10.4e-6, specificHeat: 460}
+    electrical: {resistivity: 6.0e-7, relativePermittivity: 1}
+  - id: stainless-410
+    name: Stainless Steel (AISI 410, Martensitic)
+    density: 7.74
+    appearance: stainless-steel
+    mechanical: {youngsModulus: 200, poissonsRatio: 0.28, yieldStrength: 415, ultimateTensileStrength: 585}
+    thermal:    {conductivity: 24.9, expansionCoeff: 9.9e-6, specificHeat: 460}
+    electrical: {resistivity: 5.7e-7, relativePermittivity: 1}
+  - id: stainless-17-4ph
+    name: Stainless Steel (17-4 PH, H900)
+    density: 7.75
+    appearance: stainless-steel
+    mechanical: {youngsModulus: 196, poissonsRatio: 0.27, yieldStrength: 1170, ultimateTensileStrength: 1310}
+    thermal:    {conductivity: 18.4, expansionCoeff: 10.8e-6, specificHeat: 460}
+    electrical: {resistivity: 8.0e-7, relativePermittivity: 1}
+  - id: cast-iron-gray
+    name: Cast Iron (Gray, Class 40)
+    density: 7.15
+    appearance: cast-iron
+    # brittle: no distinct yield, value approximated to tensile strength
+    mechanical: {youngsModulus: 100, poissonsRatio: 0.26, yieldStrength: 275, ultimateTensileStrength: 290}
+    thermal:    {conductivity: 53.0, expansionCoeff: 11.0e-6, specificHeat: 490}
+    electrical: {resistivity: 1.1e-6, relativePermittivity: 1}
+  - id: cast-iron-ductile
+    name: Cast Iron (Ductile, 65-45-12)
+    density: 7.10
+    appearance: cast-iron
+    mechanical: {youngsModulus: 168, poissonsRatio: 0.29, yieldStrength: 310, ultimateTensileStrength: 448}
+    thermal:    {conductivity: 33.0, expansionCoeff: 11.6e-6, specificHeat: 460}
+    electrical: {resistivity: 6.0e-7, relativePermittivity: 1}
+  - id: steel-galvanized
+    name: Steel (Galvanized, Structural)
+    density: 7.85
+    appearance: galvanized-steel
+    mechanical: {youngsModulus: 200, poissonsRatio: 0.29, yieldStrength: 250, ultimateTensileStrength: 350}
+    thermal:    {conductivity: 50.0, expansionCoeff: 11.7e-6, specificHeat: 480}
+    electrical: {resistivity: 1.5e-7, relativePermittivity: 1}

--- a/model/material/catalog/03-aluminum.yaml
+++ b/model/material/catalog/03-aluminum.yaml
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Built-in catalog: wrought and cast aluminium alloys most used in mechanical design.
+# Commercially-pure 1100 lives in 01-metals.yaml; the wrought alloys here share its
+# "aluminum" appearance, cast alloys use the duller "aluminum-cast" look.
+#
+# Property sources (room temperature, temper noted per alloy):
+#   - Strength & elastic data: Aluminum Association / ASM Metals Handbook Vol. 2
+#     (Properties and Selection: Nonferrous Alloys); MatWeb alloy datasheets; AZoM.
+#     Strengths are for the listed temper (T-condition).
+#   - Thermal & electrical: MatWeb; ASM; engineeringtoolbox.com. Thermal conductivity
+#     and resistivity vary with temper; values are for the listed condition.
+#
+# Units: density g/cm3 | youngsModulus GPa | yield & UTS MPa | conductivity W/(m*K)
+#        expansionCoeff 1/K | specificHeat J/(kg*K) | resistivity ohm*m | relativePermittivity -
+
+appearances:
+  - {id: aluminum-cast, name: Aluminum (Cast), albedo: "#d8dadbff", metallic: 1.0, roughness: 0.50, opacity: 1.0}
+
+materials:
+  - id: aluminum-2011
+    name: Aluminum 2011 (T3)
+    density: 2.82
+    appearance: aluminum
+    mechanical: {youngsModulus: 70, poissonsRatio: 0.33, yieldStrength: 295, ultimateTensileStrength: 380}
+    thermal:    {conductivity: 152, expansionCoeff: 22.9e-6, specificHeat: 864}
+    electrical: {resistivity: 4.3e-8, relativePermittivity: 1}
+  - id: aluminum-2014
+    name: Aluminum 2014 (T6)
+    density: 2.80
+    appearance: aluminum
+    mechanical: {youngsModulus: 73, poissonsRatio: 0.33, yieldStrength: 414, ultimateTensileStrength: 483}
+    thermal:    {conductivity: 154, expansionCoeff: 23.0e-6, specificHeat: 880}
+    electrical: {resistivity: 4.3e-8, relativePermittivity: 1}
+  - id: aluminum-2024
+    name: Aluminum 2024 (T3)
+    density: 2.78
+    appearance: aluminum
+    mechanical: {youngsModulus: 73, poissonsRatio: 0.33, yieldStrength: 345, ultimateTensileStrength: 483}
+    thermal:    {conductivity: 121, expansionCoeff: 23.2e-6, specificHeat: 875}
+    electrical: {resistivity: 5.8e-8, relativePermittivity: 1}
+  - id: aluminum-3003
+    name: Aluminum 3003 (H14)
+    density: 2.73
+    appearance: aluminum
+    mechanical: {youngsModulus: 69, poissonsRatio: 0.33, yieldStrength: 145, ultimateTensileStrength: 150}
+    thermal:    {conductivity: 159, expansionCoeff: 23.2e-6, specificHeat: 893}
+    electrical: {resistivity: 3.7e-8, relativePermittivity: 1}
+  - id: aluminum-5052
+    name: Aluminum 5052 (H32)
+    density: 2.68
+    appearance: aluminum
+    mechanical: {youngsModulus: 70, poissonsRatio: 0.33, yieldStrength: 195, ultimateTensileStrength: 230}
+    thermal:    {conductivity: 138, expansionCoeff: 23.8e-6, specificHeat: 880}
+    electrical: {resistivity: 4.9e-8, relativePermittivity: 1}
+  - id: aluminum-5083
+    name: Aluminum 5083 (H116)
+    density: 2.66
+    appearance: aluminum
+    mechanical: {youngsModulus: 71, poissonsRatio: 0.33, yieldStrength: 215, ultimateTensileStrength: 305}
+    thermal:    {conductivity: 117, expansionCoeff: 24.2e-6, specificHeat: 900}
+    electrical: {resistivity: 5.9e-8, relativePermittivity: 1}
+  - id: aluminum-6061
+    name: Aluminum 6061 (T6)
+    density: 2.70
+    appearance: aluminum
+    mechanical: {youngsModulus: 68.9, poissonsRatio: 0.33, yieldStrength: 276, ultimateTensileStrength: 310}
+    thermal:    {conductivity: 167, expansionCoeff: 23.6e-6, specificHeat: 896}
+    electrical: {resistivity: 3.99e-8, relativePermittivity: 1}
+  - id: aluminum-6063
+    name: Aluminum 6063 (T6)
+    density: 2.69
+    appearance: aluminum
+    mechanical: {youngsModulus: 68.9, poissonsRatio: 0.33, yieldStrength: 214, ultimateTensileStrength: 241}
+    thermal:    {conductivity: 200, expansionCoeff: 23.4e-6, specificHeat: 900}
+    electrical: {resistivity: 3.3e-8, relativePermittivity: 1}
+  - id: aluminum-6082
+    name: Aluminum 6082 (T6)
+    density: 2.70
+    appearance: aluminum
+    mechanical: {youngsModulus: 70, poissonsRatio: 0.33, yieldStrength: 250, ultimateTensileStrength: 290}
+    thermal:    {conductivity: 170, expansionCoeff: 23.1e-6, specificHeat: 900}
+    electrical: {resistivity: 3.8e-8, relativePermittivity: 1}
+  - id: aluminum-7050
+    name: Aluminum 7050 (T7451)
+    density: 2.83
+    appearance: aluminum
+    mechanical: {youngsModulus: 72, poissonsRatio: 0.33, yieldStrength: 469, ultimateTensileStrength: 524}
+    thermal:    {conductivity: 157, expansionCoeff: 23.5e-6, specificHeat: 860}
+    electrical: {resistivity: 4.5e-8, relativePermittivity: 1}
+  - id: aluminum-7075
+    name: Aluminum 7075 (T6)
+    density: 2.81
+    appearance: aluminum
+    mechanical: {youngsModulus: 71.7, poissonsRatio: 0.33, yieldStrength: 503, ultimateTensileStrength: 572}
+    thermal:    {conductivity: 130, expansionCoeff: 23.6e-6, specificHeat: 960}
+    electrical: {resistivity: 5.2e-8, relativePermittivity: 1}
+  - id: aluminum-a356
+    name: Aluminum A356 (T6, Cast)
+    density: 2.67
+    appearance: aluminum-cast
+    mechanical: {youngsModulus: 72.4, poissonsRatio: 0.33, yieldStrength: 165, ultimateTensileStrength: 230}
+    thermal:    {conductivity: 151, expansionCoeff: 21.5e-6, specificHeat: 963}
+    electrical: {resistivity: 4.4e-8, relativePermittivity: 1}
+  - id: aluminum-380
+    name: Aluminum 380 (Die Cast)
+    density: 2.74
+    appearance: aluminum-cast
+    mechanical: {youngsModulus: 71, poissonsRatio: 0.33, yieldStrength: 159, ultimateTensileStrength: 324}
+    thermal:    {conductivity: 96, expansionCoeff: 21.8e-6, specificHeat: 963}
+    electrical: {resistivity: 7.5e-8, relativePermittivity: 1}

--- a/model/material/catalog/04-plastics.yaml
+++ b/model/material/catalog/04-plastics.yaml
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Built-in catalog: thermoplastics, thermoset resins and one elastomer — the polymers
+# most used in mechanical design, 3D printing and tooling.
+#
+# Property sources (room temperature, typical injection-moulded / cast grade):
+#   - Mechanical (modulus, yield/tensile): MatWeb generic-grade datasheets; manufacturer
+#     data (e.g. Victrex PEEK, SABIC Ultem); Granta CES EduPack polymer records; AZoM.
+#     Polymer strength is grade- and rate-dependent; values are representative, not a
+#     design minimum. For elastomers/soft grades yield ~ tensile (no sharp yield).
+#   - Thermal (conductivity, expansion, specific heat) & electrical (volume resistivity,
+#     dielectric constant at ~1 MHz): MatWeb; manufacturer data; engineeringtoolbox.com.
+#
+# Appearances are dielectric (metallic = 0.0). Roughness encodes finish (glossy cast vs
+# matte printed); opacity < 1.0 marks the optically clear/translucent grades (acrylic,
+# polycarbonate, PETG, PS) so they read as transparent in Realistic mode. Albedo is the
+# resin's representative sRGB body colour.
+#
+# Units: density g/cm3 | youngsModulus GPa | yield & UTS MPa | conductivity W/(m*K)
+#        expansionCoeff 1/K | specificHeat J/(kg*K) | resistivity ohm*m | relativePermittivity -
+
+appearances:
+  - {id: abs-black,       name: ABS (Black),       albedo: "#1a1a1aff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: abs-white,       name: ABS (White),       albedo: "#e8e8e8ff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: pla,             name: PLA,               albedo: "#ececdfff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: petg,            name: PETG,              albedo: "#cfe0e4ff", metallic: 0.0, roughness: 0.18, opacity: 0.85}
+  - {id: pet,             name: PET,               albedo: "#dfe7e6ff", metallic: 0.0, roughness: 0.20, opacity: 0.90}
+  - {id: polycarbonate,   name: Polycarbonate,     albedo: "#d7e0e2ff", metallic: 0.0, roughness: 0.12, opacity: 0.80}
+  - {id: acrylic,         name: Acrylic (PMMA),    albedo: "#e6efefff", metallic: 0.0, roughness: 0.08, opacity: 0.75}
+  - {id: nylon,           name: Nylon,             albedo: "#ece9e0ff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: acetal,          name: Acetal (POM),      albedo: "#edeeeeff", metallic: 0.0, roughness: 0.35, opacity: 1.0}
+  - {id: polypropylene,   name: Polypropylene,     albedo: "#e8eae6ff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: hdpe,            name: HDPE,              albedo: "#e9ebe8ff", metallic: 0.0, roughness: 0.50, opacity: 1.0}
+  - {id: ldpe,            name: LDPE,              albedo: "#eef0eeff", metallic: 0.0, roughness: 0.55, opacity: 0.95}
+  - {id: pvc,             name: PVC (Rigid),       albedo: "#d9dcd7ff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: ptfe,            name: PTFE,              albedo: "#f2f3f1ff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: peek,            name: PEEK,              albedo: "#c8a86aff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: ultem,           name: PEI (Ultem),       albedo: "#c79a4eff", metallic: 0.0, roughness: 0.30, opacity: 0.90}
+  - {id: polystyrene,     name: Polystyrene,       albedo: "#e8edf0ff", metallic: 0.0, roughness: 0.12, opacity: 0.80}
+  - {id: hips,            name: HIPS,              albedo: "#ededebff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: pvdf,            name: PVDF,              albedo: "#f0f1efff", metallic: 0.0, roughness: 0.35, opacity: 1.0}
+  - {id: epoxy-resin,     name: Epoxy Resin,       albedo: "#d9c9a8ff", metallic: 0.0, roughness: 0.25, opacity: 0.90}
+  - {id: polyester-resin, name: Polyester Resin,   albedo: "#e3ddc9ff", metallic: 0.0, roughness: 0.30, opacity: 0.90}
+  - {id: polyurethane,    name: Polyurethane,      albedo: "#e6dccbff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: silicone,        name: Silicone Rubber,   albedo: "#e8e2dcff", metallic: 0.0, roughness: 0.55, opacity: 0.95}
+
+materials:
+  - id: abs-plastic
+    name: ABS
+    density: 1.06
+    appearance: abs-black
+    mechanical: {youngsModulus: 2.1, poissonsRatio: 0.35, yieldStrength: 40, ultimateTensileStrength: 44}
+    thermal:    {conductivity: 0.17, expansionCoeff: 90e-6, specificHeat: 1300}
+    electrical: {resistivity: 1e15, relativePermittivity: 2.9}
+  - id: pla
+    name: PLA
+    density: 1.24
+    appearance: pla
+    mechanical: {youngsModulus: 3.5, poissonsRatio: 0.36, yieldStrength: 50, ultimateTensileStrength: 50}
+    thermal:    {conductivity: 0.13, expansionCoeff: 68e-6, specificHeat: 1800}
+    electrical: {resistivity: 1e14, relativePermittivity: 3.0}
+  - id: petg
+    name: PETG
+    density: 1.27
+    appearance: petg
+    mechanical: {youngsModulus: 2.1, poissonsRatio: 0.38, yieldStrength: 50, ultimateTensileStrength: 50}
+    thermal:    {conductivity: 0.20, expansionCoeff: 68e-6, specificHeat: 1200}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+  - id: pet
+    name: PET
+    density: 1.38
+    appearance: pet
+    mechanical: {youngsModulus: 2.8, poissonsRatio: 0.40, yieldStrength: 55, ultimateTensileStrength: 75}
+    thermal:    {conductivity: 0.24, expansionCoeff: 70e-6, specificHeat: 1200}
+    electrical: {resistivity: 1e16, relativePermittivity: 3.4}
+  - id: polycarbonate
+    name: Polycarbonate (PC)
+    density: 1.20
+    appearance: polycarbonate
+    mechanical: {youngsModulus: 2.3, poissonsRatio: 0.37, yieldStrength: 62, ultimateTensileStrength: 66}
+    thermal:    {conductivity: 0.20, expansionCoeff: 65e-6, specificHeat: 1200}
+    electrical: {resistivity: 1e14, relativePermittivity: 3.0}
+  - id: acrylic-pmma
+    name: Acrylic (PMMA)
+    density: 1.18
+    appearance: acrylic
+    mechanical: {youngsModulus: 3.2, poissonsRatio: 0.37, yieldStrength: 70, ultimateTensileStrength: 72}
+    thermal:    {conductivity: 0.19, expansionCoeff: 70e-6, specificHeat: 1450}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.3}
+  - id: nylon-6
+    name: Nylon 6 (PA6)
+    density: 1.14
+    appearance: nylon
+    mechanical: {youngsModulus: 2.7, poissonsRatio: 0.39, yieldStrength: 45, ultimateTensileStrength: 70}
+    thermal:    {conductivity: 0.25, expansionCoeff: 80e-6, specificHeat: 1600}
+    electrical: {resistivity: 1e13, relativePermittivity: 3.8}
+  - id: nylon-66
+    name: Nylon 66 (PA66)
+    density: 1.14
+    appearance: nylon
+    mechanical: {youngsModulus: 3.0, poissonsRatio: 0.39, yieldStrength: 55, ultimateTensileStrength: 82}
+    thermal:    {conductivity: 0.25, expansionCoeff: 80e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e13, relativePermittivity: 4.0}
+  - id: acetal-pom
+    name: Acetal (POM)
+    density: 1.41
+    appearance: acetal
+    mechanical: {youngsModulus: 3.1, poissonsRatio: 0.35, yieldStrength: 65, ultimateTensileStrength: 70}
+    thermal:    {conductivity: 0.31, expansionCoeff: 110e-6, specificHeat: 1500}
+    electrical: {resistivity: 1e13, relativePermittivity: 3.7}
+  - id: polypropylene
+    name: Polypropylene (PP)
+    density: 0.905
+    appearance: polypropylene
+    mechanical: {youngsModulus: 1.5, poissonsRatio: 0.42, yieldStrength: 33, ultimateTensileStrength: 35}
+    thermal:    {conductivity: 0.17, expansionCoeff: 100e-6, specificHeat: 1920}
+    electrical: {resistivity: 1e15, relativePermittivity: 2.2}
+  - id: hdpe
+    name: HDPE
+    density: 0.95
+    appearance: hdpe
+    mechanical: {youngsModulus: 1.0, poissonsRatio: 0.42, yieldStrength: 26, ultimateTensileStrength: 33}
+    thermal:    {conductivity: 0.48, expansionCoeff: 120e-6, specificHeat: 1900}
+    electrical: {resistivity: 1e15, relativePermittivity: 2.3}
+  - id: ldpe
+    name: LDPE
+    density: 0.92
+    appearance: ldpe
+    mechanical: {youngsModulus: 0.25, poissonsRatio: 0.45, yieldStrength: 11, ultimateTensileStrength: 12}
+    thermal:    {conductivity: 0.33, expansionCoeff: 200e-6, specificHeat: 2300}
+    electrical: {resistivity: 1e15, relativePermittivity: 2.2}
+  - id: pvc-rigid
+    name: PVC (Rigid)
+    density: 1.40
+    appearance: pvc
+    mechanical: {youngsModulus: 3.0, poissonsRatio: 0.38, yieldStrength: 50, ultimateTensileStrength: 52}
+    thermal:    {conductivity: 0.16, expansionCoeff: 80e-6, specificHeat: 1000}
+    electrical: {resistivity: 1e14, relativePermittivity: 3.4}
+  - id: ptfe
+    name: PTFE
+    density: 2.20
+    appearance: ptfe
+    mechanical: {youngsModulus: 0.5, poissonsRatio: 0.46, yieldStrength: 14, ultimateTensileStrength: 25}
+    thermal:    {conductivity: 0.25, expansionCoeff: 130e-6, specificHeat: 1010}
+    electrical: {resistivity: 1e18, relativePermittivity: 2.1}
+  - id: peek
+    name: PEEK
+    density: 1.32
+    appearance: peek
+    mechanical: {youngsModulus: 3.6, poissonsRatio: 0.40, yieldStrength: 97, ultimateTensileStrength: 100}
+    thermal:    {conductivity: 0.25, expansionCoeff: 47e-6, specificHeat: 1340}
+    electrical: {resistivity: 1e16, relativePermittivity: 3.2}
+  - id: pei-ultem
+    name: PEI (Ultem 1000)
+    density: 1.27
+    appearance: ultem
+    mechanical: {youngsModulus: 3.0, poissonsRatio: 0.36, yieldStrength: 105, ultimateTensileStrength: 105}
+    thermal:    {conductivity: 0.22, expansionCoeff: 56e-6, specificHeat: 1100}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.15}
+  - id: polystyrene
+    name: Polystyrene (GPPS)
+    density: 1.05
+    appearance: polystyrene
+    mechanical: {youngsModulus: 3.2, poissonsRatio: 0.34, yieldStrength: 45, ultimateTensileStrength: 50}
+    thermal:    {conductivity: 0.14, expansionCoeff: 70e-6, specificHeat: 1300}
+    electrical: {resistivity: 1e16, relativePermittivity: 2.5}
+  - id: hips
+    name: HIPS
+    density: 1.05
+    appearance: hips
+    mechanical: {youngsModulus: 2.0, poissonsRatio: 0.34, yieldStrength: 25, ultimateTensileStrength: 30}
+    thermal:    {conductivity: 0.14, expansionCoeff: 80e-6, specificHeat: 1300}
+    electrical: {resistivity: 1e16, relativePermittivity: 2.5}
+  - id: pvdf
+    name: PVDF
+    density: 1.78
+    appearance: pvdf
+    mechanical: {youngsModulus: 2.0, poissonsRatio: 0.40, yieldStrength: 50, ultimateTensileStrength: 50}
+    thermal:    {conductivity: 0.19, expansionCoeff: 120e-6, specificHeat: 1300}
+    electrical: {resistivity: 1e14, relativePermittivity: 8.0}
+  - id: epoxy-resin
+    name: Epoxy Resin (Cast)
+    density: 1.15
+    appearance: epoxy-resin
+    mechanical: {youngsModulus: 3.0, poissonsRatio: 0.35, yieldStrength: 40, ultimateTensileStrength: 65}
+    thermal:    {conductivity: 0.19, expansionCoeff: 60e-6, specificHeat: 1000}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.6}
+  - id: polyester-resin
+    name: Polyester Resin (Cast)
+    density: 1.20
+    appearance: polyester-resin
+    mechanical: {youngsModulus: 3.2, poissonsRatio: 0.37, yieldStrength: 45, ultimateTensileStrength: 55}
+    thermal:    {conductivity: 0.17, expansionCoeff: 100e-6, specificHeat: 1200}
+    electrical: {resistivity: 1e14, relativePermittivity: 3.3}
+  - id: polyurethane
+    name: Polyurethane (Rigid)
+    density: 1.20
+    appearance: polyurethane
+    mechanical: {youngsModulus: 1.5, poissonsRatio: 0.40, yieldStrength: 35, ultimateTensileStrength: 40}
+    thermal:    {conductivity: 0.21, expansionCoeff: 100e-6, specificHeat: 1800}
+    electrical: {resistivity: 1e12, relativePermittivity: 4.0}
+  - id: silicone-rubber
+    name: Silicone Rubber
+    density: 1.10
+    appearance: silicone
+    # elastomer: very low modulus, yield ~ tensile (no sharp yield)
+    mechanical: {youngsModulus: 0.01, poissonsRatio: 0.48, yieldStrength: 5, ultimateTensileStrength: 8}
+    thermal:    {conductivity: 0.20, expansionCoeff: 250e-6, specificHeat: 1300}
+    electrical: {resistivity: 1e13, relativePermittivity: 3.0}

--- a/model/material/catalog/05-woods.yaml
+++ b/model/material/catalog/05-woods.yaml
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Built-in catalog: solid woods most used in furniture, construction and joinery.
+#
+# Wood is ORTHOTROPIC; entries carry both a scalar summary and the full orthotropic
+# elastic group (ADR-0025) so they are ready for FEA without re-sourcing.
+#
+# Scalar fields (mechanical/thermal/electrical) are the standard engineering values
+# measured PARALLEL TO THE GRAIN at 12% moisture content, from the USDA Forest Products
+# Laboratory "Wood Handbook" (FPL-GTR-282) and the Wood Database (wood-database.com):
+#   - youngsModulus: modulus of elasticity along the grain (= orthotropic E1).
+#   - yieldStrength: maximum crushing strength in compression parallel to grain (wood has
+#     no metallic yield; conventional design-strength proxy). UTS = modulus of rupture.
+#   - thermal.expansionCoeff: longitudinal thermal expansion (= orthotropic alpha1).
+#
+# The `orthotropic` block gives the direction-dependent constants in the material axes
+# 1=longitudinal, 2=radial, 3=tangential. They are derived from E1 using the FPL Wood
+# Handbook average elastic RATIOS (Table 5-1) for hardwoods / softwoods:
+#   hardwood: E2/E1=0.10 E3/E1=0.05 G12/E1=0.066 G13/E1=0.060 G23/E1=0.013
+#             nu12(LR)=0.37 nu13(LT)=0.42 nu23(RT)=0.47
+#   softwood: E2/E1=0.075 E3/E1=0.043 G12/E1=0.061 G13/E1=0.069 G23/E1=0.007
+#             nu12(LR)=0.32 nu13(LT)=0.42 nu23(RT)=0.40
+# Transverse thermal expansion (alpha2 radial, alpha3 tangential) is representative for
+# timber (Wood Handbook ch.4: transverse CTE is ~6-10x longitudinal).
+#
+# Appearances are dielectric (metallic = 0.0), high roughness, representative finished
+# sRGB body colour (no grain texture map yet).
+#
+# Units: density g/cm3 | E & G GPa | yield & UTS MPa | conductivity W/(m*K)
+#        expansionCoeff & alpha 1/K | specificHeat J/(kg*K) | resistivity ohm*m | nu, eps_r -
+
+appearances:
+  - {id: oak,         name: Oak (Red),        albedo: "#b88a4fff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: oak-white,   name: Oak (White),      albedo: "#c2a06aff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: maple,       name: Maple,            albedo: "#d8b98aff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+  - {id: birch,       name: Birch,            albedo: "#e0c89cff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+  - {id: beech,       name: Beech,            albedo: "#cda982ff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+  - {id: ash,         name: Ash,              albedo: "#d6c19aff", metallic: 0.0, roughness: 0.68, opacity: 1.0}
+  - {id: walnut,      name: Walnut,           albedo: "#5c4327ff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: mahogany,    name: Mahogany,         albedo: "#8a4b32ff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+  - {id: cherry,      name: Cherry,           albedo: "#9c5a3cff", metallic: 0.0, roughness: 0.60, opacity: 1.0}
+  - {id: teak,        name: Teak,             albedo: "#b1814aff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+  - {id: pine,        name: Pine,             albedo: "#d8b074ff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: pine-white,  name: Pine (White),     albedo: "#e3cfa0ff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: douglas-fir, name: Douglas Fir,      albedo: "#c79a5eff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: spruce,      name: Spruce,           albedo: "#e0cba0ff", metallic: 0.0, roughness: 0.72, opacity: 1.0}
+  - {id: cedar,       name: Cedar (Red),      albedo: "#b07a52ff", metallic: 0.0, roughness: 0.72, opacity: 1.0}
+  - {id: balsa,       name: Balsa,            albedo: "#e8dcc0ff", metallic: 0.0, roughness: 0.75, opacity: 1.0}
+  - {id: bamboo,      name: Bamboo,           albedo: "#d6b87aff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+
+materials:
+  - id: oak-red
+    name: Oak, Red
+    density: 0.63
+    appearance: oak
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 12.5, poissonsRatio: 0.37, yieldStrength: 47, ultimateTensileStrength: 99}
+    thermal:    {conductivity: 0.16, expansionCoeff: 4.9e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 12.5, e2: 1.25, e3: 0.63, g12: 0.83, g23: 0.16, g13: 0.75, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.9e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: oak-white
+    name: Oak, White
+    density: 0.68
+    appearance: oak-white
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 12.3, poissonsRatio: 0.37, yieldStrength: 51, ultimateTensileStrength: 105}
+    thermal:    {conductivity: 0.17, expansionCoeff: 4.9e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 12.3, e2: 1.23, e3: 0.62, g12: 0.81, g23: 0.16, g13: 0.74, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.9e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: maple-hard
+    name: Maple, Hard (Sugar)
+    density: 0.63
+    appearance: maple
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 12.6, poissonsRatio: 0.37, yieldStrength: 54, ultimateTensileStrength: 109}
+    thermal:    {conductivity: 0.16, expansionCoeff: 4.8e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 12.6, e2: 1.26, e3: 0.63, g12: 0.83, g23: 0.16, g13: 0.76, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.8e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: birch-yellow
+    name: Birch, Yellow
+    density: 0.62
+    appearance: birch
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 13.9, poissonsRatio: 0.37, yieldStrength: 56, ultimateTensileStrength: 114}
+    thermal:    {conductivity: 0.16, expansionCoeff: 4.8e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 13.9, e2: 1.39, e3: 0.70, g12: 0.92, g23: 0.18, g13: 0.83, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.8e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: beech
+    name: Beech, American
+    density: 0.64
+    appearance: beech
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 11.9, poissonsRatio: 0.37, yieldStrength: 50, ultimateTensileStrength: 103}
+    thermal:    {conductivity: 0.16, expansionCoeff: 4.8e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 11.9, e2: 1.19, e3: 0.60, g12: 0.79, g23: 0.15, g13: 0.71, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.8e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: ash-white
+    name: Ash, White
+    density: 0.60
+    appearance: ash
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 12.0, poissonsRatio: 0.37, yieldStrength: 51, ultimateTensileStrength: 103}
+    thermal:    {conductivity: 0.15, expansionCoeff: 4.9e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 12.0, e2: 1.20, e3: 0.60, g12: 0.79, g23: 0.16, g13: 0.72, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.9e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: walnut-black
+    name: Walnut, Black
+    density: 0.55
+    appearance: walnut
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 11.6, poissonsRatio: 0.37, yieldStrength: 52, ultimateTensileStrength: 101}
+    thermal:    {conductivity: 0.14, expansionCoeff: 4.8e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 11.6, e2: 1.16, e3: 0.58, g12: 0.77, g23: 0.15, g13: 0.70, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.8e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: mahogany
+    name: Mahogany, Honduran
+    density: 0.50
+    appearance: mahogany
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 10.0, poissonsRatio: 0.37, yieldStrength: 46, ultimateTensileStrength: 79}
+    thermal:    {conductivity: 0.13, expansionCoeff: 4.5e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 10.0, e2: 1.00, e3: 0.50, g12: 0.66, g23: 0.13, g13: 0.60, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.5e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: cherry-black
+    name: Cherry, Black
+    density: 0.50
+    appearance: cherry
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 10.3, poissonsRatio: 0.37, yieldStrength: 49, ultimateTensileStrength: 85}
+    thermal:    {conductivity: 0.13, expansionCoeff: 4.7e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 10.3, e2: 1.03, e3: 0.52, g12: 0.68, g23: 0.13, g13: 0.62, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.7e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: teak
+    name: Teak
+    density: 0.65
+    appearance: teak
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 12.3, poissonsRatio: 0.37, yieldStrength: 58, ultimateTensileStrength: 100}
+    thermal:    {conductivity: 0.16, expansionCoeff: 4.5e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 12.3, e2: 1.23, e3: 0.62, g12: 0.81, g23: 0.16, g13: 0.74, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.5e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: pine-southern-yellow
+    name: Pine, Southern Yellow (Loblolly)
+    density: 0.59
+    appearance: pine
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 14.8, poissonsRatio: 0.32, yieldStrength: 58, ultimateTensileStrength: 100}
+    thermal:    {conductivity: 0.15, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 14.8, e2: 1.11, e3: 0.64, g12: 0.90, g23: 0.10, g13: 1.02, nu12: 0.32, nu23: 0.40, nu13: 0.42, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: pine-eastern-white
+    name: Pine, Eastern White
+    density: 0.35
+    appearance: pine-white
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 8.5, poissonsRatio: 0.32, yieldStrength: 33, ultimateTensileStrength: 59}
+    thermal:    {conductivity: 0.11, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 8.5, e2: 0.64, e3: 0.37, g12: 0.52, g23: 0.06, g13: 0.59, nu12: 0.32, nu23: 0.40, nu13: 0.42, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: douglas-fir
+    name: Douglas Fir
+    density: 0.48
+    appearance: douglas-fir
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 13.4, poissonsRatio: 0.29, yieldStrength: 50, ultimateTensileStrength: 85}
+    thermal:    {conductivity: 0.13, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 13.4, e2: 1.01, e3: 0.58, g12: 0.82, g23: 0.09, g13: 0.92, nu12: 0.29, nu23: 0.40, nu13: 0.45, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: spruce-sitka
+    name: Spruce, Sitka
+    density: 0.40
+    appearance: spruce
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 9.9, poissonsRatio: 0.32, yieldStrength: 39, ultimateTensileStrength: 70}
+    thermal:    {conductivity: 0.12, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 9.9, e2: 0.74, e3: 0.43, g12: 0.60, g23: 0.07, g13: 0.68, nu12: 0.32, nu23: 0.40, nu13: 0.42, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: cedar-western-red
+    name: Cedar, Western Red
+    density: 0.32
+    appearance: cedar
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 7.7, poissonsRatio: 0.32, yieldStrength: 31, ultimateTensileStrength: 52}
+    thermal:    {conductivity: 0.10, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 7.7, e2: 0.58, e3: 0.33, g12: 0.47, g23: 0.05, g13: 0.53, nu12: 0.32, nu23: 0.40, nu13: 0.42, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: balsa
+    name: Balsa
+    density: 0.16
+    appearance: balsa
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 3.4, poissonsRatio: 0.37, yieldStrength: 12, ultimateTensileStrength: 19}
+    thermal:    {conductivity: 0.055, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 3.4, e2: 0.34, e3: 0.17, g12: 0.22, g23: 0.04, g13: 0.20, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}
+  - id: bamboo
+    name: Bamboo (Moso, Laminated)
+    density: 0.70
+    appearance: bamboo
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 15.0, poissonsRatio: 0.37, yieldStrength: 55, ultimateTensileStrength: 120}
+    thermal:    {conductivity: 0.17, expansionCoeff: 4.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e15, relativePermittivity: 3.0}
+    orthotropic: {e1: 15.0, e2: 1.50, e3: 0.75, g12: 0.99, g23: 0.20, g13: 0.90, nu12: 0.37, nu23: 0.47, nu13: 0.42, alpha1: 4.0e-6, alpha2: 30e-6, alpha3: 40e-6}

--- a/model/material/catalog/06-composites.yaml
+++ b/model/material/catalog/06-composites.yaml
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Built-in catalog: fibre-reinforced polymers and engineered wood panels.
+#
+# Composites are anisotropic and lay-up dependent; the scalar figures are representative
+# in-plane values for the stated reinforcement and fibre fraction, NOT a design allowable.
+# Unidirectional laminates carry a `transversely-isotropic` orthotropic group (axis 1 =
+# fibre, 2 = 3 = transverse); balanced-weave and panel products carry an `orthotropic`
+# group; random-mat products (chopped strand, SMC, carbon-filled nylon, MDF) are in-plane
+# ISOTROPIC and ship the scalar group only. Orthotropic constants ready for FEA (ADR-0025).
+#
+# Property sources:
+#   - FRP laminate engineering constants (E1/E2, G12, nu12, CTE): ASM Handbook Vol. 21
+#     (Composites); CMH-17 / MIL-HDBK-17 generic carbon-epoxy & glass-epoxy lamina data;
+#     Barbero "Introduction to Composite Materials Design"; manufacturer laminate data.
+#     G23 follows the transverse-isotropy relation G23 = E2 / (2*(1+nu23)).
+#   - G10/FR4 laminate: NEMA LI-1 / manufacturer (Garolite) datasheets.
+#   - Engineered wood (plywood, OSB, MDF): APA panel design data; EN 622/EN 300.
+#     yieldStrength is the in-plane compressive/bending design-strength proxy.
+#   - Carbon laminates conduct along the fibre (low resistivity); glass/aramid laminates
+#     and wood panels are insulators.
+#
+# Appearances: carbon laminates are dark with a glossy clear-coat (low roughness, but
+# dielectric matrix so metallic = 0.0); others are matte dielectrics. Albedo is a
+# representative finished sRGB body colour (no weave/grain texture map yet).
+#
+# Units: density g/cm3 | E & G GPa | yield & UTS MPa | conductivity W/(m*K)
+#        expansionCoeff & alpha 1/K | specificHeat J/(kg*K) | resistivity ohm*m | nu, eps_r -
+
+appearances:
+  - {id: cfrp,        name: Carbon Fiber (Gloss),  albedo: "#1c1e22ff", metallic: 0.0, roughness: 0.25, opacity: 1.0}
+  - {id: cfrp-nylon,  name: Carbon-Filled Nylon,   albedo: "#26282bff", metallic: 0.0, roughness: 0.55, opacity: 1.0}
+  - {id: fiberglass,  name: Fiberglass,            albedo: "#d8d9d2ff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: g10,         name: G10 / FR4,             albedo: "#b6bd7aff", metallic: 0.0, roughness: 0.40, opacity: 1.0}
+  - {id: aramid,      name: Aramid (Kevlar),       albedo: "#c9a227ff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: smc,         name: SMC (Molded),          albedo: "#d5d3ccff", metallic: 0.0, roughness: 0.45, opacity: 1.0}
+  - {id: plywood,     name: Plywood,               albedo: "#d2b483ff", metallic: 0.0, roughness: 0.65, opacity: 1.0}
+  - {id: osb,         name: OSB,                   albedo: "#c9a86aff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+  - {id: mdf,         name: MDF,                   albedo: "#b8956aff", metallic: 0.0, roughness: 0.70, opacity: 1.0}
+
+materials:
+  - id: cfrp-unidirectional
+    name: Carbon Fiber/Epoxy (UD, 0deg)
+    density: 1.60
+    appearance: cfrp
+    isotropy: transversely-isotropic
+    # brittle laminate: scalar yield ~ tensile (no yield plateau)
+    mechanical: {youngsModulus: 135, poissonsRatio: 0.30, yieldStrength: 1200, ultimateTensileStrength: 1500}
+    thermal:    {conductivity: 5.0, expansionCoeff: 2.0e-6, specificHeat: 900}
+    electrical: {resistivity: 1.5e-5, relativePermittivity: 1}
+    orthotropic: {e1: 135, e2: 10, e3: 10, g12: 5.0, g23: 3.57, g13: 5.0, nu12: 0.30, nu23: 0.40, nu13: 0.30, alpha1: -0.5e-6, alpha2: 28e-6, alpha3: 28e-6}
+  - id: cfrp-woven
+    name: Carbon Fiber/Epoxy (Woven, Quasi-Iso)
+    density: 1.55
+    appearance: cfrp
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 70, poissonsRatio: 0.30, yieldStrength: 500, ultimateTensileStrength: 600}
+    thermal:    {conductivity: 5.0, expansionCoeff: 3.0e-6, specificHeat: 900}
+    electrical: {resistivity: 1.5e-5, relativePermittivity: 1}
+    orthotropic: {e1: 70, e2: 70, e3: 8, g12: 5.0, g23: 3.5, g13: 3.5, nu12: 0.05, nu23: 0.30, nu13: 0.30, alpha1: 2e-6, alpha2: 2e-6, alpha3: 30e-6}
+  - id: cfrp-nylon
+    name: Carbon-Filled Nylon (Printed)
+    density: 1.30
+    appearance: cfrp-nylon
+    mechanical: {youngsModulus: 8.0, poissonsRatio: 0.38, yieldStrength: 70, ultimateTensileStrength: 90}
+    thermal:    {conductivity: 0.30, expansionCoeff: 40e-6, specificHeat: 1400}
+    electrical: {resistivity: 1e6, relativePermittivity: 3.0}
+  - id: gfrp-eglass
+    name: E-Glass/Epoxy (UD, 0deg)
+    density: 2.00
+    appearance: fiberglass
+    isotropy: transversely-isotropic
+    mechanical: {youngsModulus: 45, poissonsRatio: 0.28, yieldStrength: 900, ultimateTensileStrength: 1000}
+    thermal:    {conductivity: 0.35, expansionCoeff: 7.0e-6, specificHeat: 1000}
+    electrical: {resistivity: 1e13, relativePermittivity: 4.5}
+    orthotropic: {e1: 45, e2: 12, e3: 12, g12: 5.0, g23: 4.29, g13: 5.0, nu12: 0.28, nu23: 0.40, nu13: 0.28, alpha1: 7e-6, alpha2: 25e-6, alpha3: 25e-6}
+  - id: fiberglass-csm
+    name: Fiberglass (Chopped Strand/Polyester)
+    density: 1.50
+    appearance: fiberglass
+    mechanical: {youngsModulus: 7.0, poissonsRatio: 0.30, yieldStrength: 100, ultimateTensileStrength: 120}
+    thermal:    {conductivity: 0.30, expansionCoeff: 25e-6, specificHeat: 1000}
+    electrical: {resistivity: 1e13, relativePermittivity: 4.5}
+  - id: g10-fr4
+    name: G10 / FR4 (Glass/Epoxy Laminate)
+    density: 1.85
+    appearance: g10
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 24, poissonsRatio: 0.18, yieldStrength: 300, ultimateTensileStrength: 340}
+    thermal:    {conductivity: 0.30, expansionCoeff: 14e-6, specificHeat: 1100}
+    electrical: {resistivity: 1e12, relativePermittivity: 4.7}
+    orthotropic: {e1: 24, e2: 24, e3: 18, g12: 7.0, g23: 3.5, g13: 3.5, nu12: 0.12, nu23: 0.18, nu13: 0.18, alpha1: 14e-6, alpha2: 14e-6, alpha3: 70e-6}
+  - id: aramid-epoxy
+    name: Aramid (Kevlar)/Epoxy (UD, 0deg)
+    density: 1.38
+    appearance: aramid
+    isotropy: transversely-isotropic
+    mechanical: {youngsModulus: 76, poissonsRatio: 0.34, yieldStrength: 1200, ultimateTensileStrength: 1400}
+    thermal:    {conductivity: 0.50, expansionCoeff: 2.0e-6, specificHeat: 1100}
+    electrical: {resistivity: 1e14, relativePermittivity: 4.0}
+    orthotropic: {e1: 76, e2: 5.5, e3: 5.5, g12: 2.3, g23: 1.96, g13: 2.3, nu12: 0.34, nu23: 0.40, nu13: 0.34, alpha1: -2e-6, alpha2: 60e-6, alpha3: 60e-6}
+  - id: smc
+    name: SMC (Glass/Polyester, Molded)
+    density: 1.90
+    appearance: smc
+    mechanical: {youngsModulus: 11, poissonsRatio: 0.30, yieldStrength: 80, ultimateTensileStrength: 82}
+    thermal:    {conductivity: 0.20, expansionCoeff: 20e-6, specificHeat: 1200}
+    electrical: {resistivity: 1e13, relativePermittivity: 4.5}
+  - id: plywood-structural
+    name: Plywood (Softwood, Structural)
+    density: 0.55
+    appearance: plywood
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 7.0, poissonsRatio: 0.30, yieldStrength: 30, ultimateTensileStrength: 35}
+    thermal:    {conductivity: 0.13, expansionCoeff: 6.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e14, relativePermittivity: 3.0}
+    orthotropic: {e1: 7.0, e2: 4.5, e3: 0.5, g12: 0.6, g23: 0.5, g13: 0.5, nu12: 0.20, nu23: 0.30, nu13: 0.30, alpha1: 6e-6, alpha2: 6e-6, alpha3: 30e-6}
+  - id: osb
+    name: OSB (Oriented Strand Board)
+    density: 0.65
+    appearance: osb
+    isotropy: orthotropic
+    mechanical: {youngsModulus: 5.5, poissonsRatio: 0.30, yieldStrength: 20, ultimateTensileStrength: 28}
+    thermal:    {conductivity: 0.13, expansionCoeff: 6.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e13, relativePermittivity: 3.0}
+    orthotropic: {e1: 5.5, e2: 3.0, e3: 0.4, g12: 1.0, g23: 0.5, g13: 0.5, nu12: 0.20, nu23: 0.30, nu13: 0.30, alpha1: 6e-6, alpha2: 6e-6, alpha3: 30e-6}
+  - id: mdf
+    name: MDF (Medium-Density Fiberboard)
+    density: 0.75
+    appearance: mdf
+    mechanical: {youngsModulus: 3.6, poissonsRatio: 0.25, yieldStrength: 18, ultimateTensileStrength: 30}
+    thermal:    {conductivity: 0.10, expansionCoeff: 6.0e-6, specificHeat: 1700}
+    electrical: {resistivity: 1e12, relativePermittivity: 3.0}

--- a/model/material/catalog_test.go
+++ b/model/material/catalog_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package material
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/persistence/yamlcodec"
+)
+
+// TestCatalogPopulatesLibrary guards against a regression where an embedded file fails to
+// load silently (e.g. a renamed glob): the shipped catalog must seed a substantial set.
+func TestCatalogPopulatesLibrary(t *testing.T) {
+	lib := NewLibrary()
+	if got := len(lib.Materials()); got < 100 {
+		t.Errorf("built-in materials = %d, want >= 100 (catalog failed to load?)", got)
+	}
+	if got := len(lib.Appearances()); got < 80 {
+		t.Errorf("built-in appearances = %d, want >= 80 (catalog failed to load?)", got)
+	}
+}
+
+// TestCatalogIDsUnique fails loudly on a duplicate id across files. AddAppearance/
+// AddMaterial replace silently, so a copy-paste collision would otherwise hide one entry.
+func TestCatalogIDsUnique(t *testing.T) {
+	apprIDs, matIDs := map[string]string{}, map[string]string{}
+	forEachCatalogFile(t, func(name string, rd RecipeData) {
+		for _, a := range rd.Appearances {
+			if prev, dup := apprIDs[a.ID]; dup {
+				t.Errorf("appearance id %q duplicated in %q and %q", a.ID, prev, name)
+			}
+			apprIDs[a.ID] = name
+		}
+		for _, m := range rd.Materials {
+			if prev, dup := matIDs[m.ID]; dup {
+				t.Errorf("material id %q duplicated in %q and %q", m.ID, prev, name)
+			}
+			matIDs[m.ID] = name
+		}
+	})
+}
+
+// TestEveryMaterialHasReliableProperties enforces the catalog's admission rule: an entry
+// ships only when every mechanical, thermal and electrical field is present (non-zero).
+func TestEveryMaterialHasReliableProperties(t *testing.T) {
+	for _, m := range NewLibrary().Materials() {
+		mech, th, el := m.Mechanical(), m.Thermal(), m.Electrical()
+		checks := []struct {
+			label string
+			v     float64
+		}{
+			{"density", m.Density()},
+			{"youngsModulus", mech.YoungsModulus},
+			{"poissonsRatio", mech.PoissonsRatio},
+			{"yieldStrength", mech.YieldStrength},
+			{"ultimateTensileStrength", mech.UltimateTensileStrength},
+			{"conductivity", th.Conductivity},
+			{"expansionCoeff", th.ExpansionCoeff},
+			{"specificHeat", th.SpecificHeat},
+			{"resistivity", el.Resistivity},
+			{"relativePermittivity", el.RelativePermittivity},
+		}
+		for _, c := range checks {
+			if c.v <= 0 {
+				t.Errorf("material %q: %s = %v, want > 0 (incomplete data must not ship)", m.ID(), c.label, c.v)
+			}
+		}
+	}
+}
+
+// TestAppearanceValuesInRange keeps PBR inputs physical: metallic/roughness/opacity in
+// [0,1], and opacity strictly positive so no built-in renders fully invisible.
+func TestAppearanceValuesInRange(t *testing.T) {
+	for _, a := range NewLibrary().Appearances() {
+		if a.Metallic() < 0 || a.Metallic() > 1 {
+			t.Errorf("appearance %q: metallic = %v, want [0,1]", a.ID(), a.Metallic())
+		}
+		if a.Roughness() < 0 || a.Roughness() > 1 {
+			t.Errorf("appearance %q: roughness = %v, want [0,1]", a.ID(), a.Roughness())
+		}
+		if a.Opacity() <= 0 || a.Opacity() > 1 {
+			t.Errorf("appearance %q: opacity = %v, want (0,1]", a.ID(), a.Opacity())
+		}
+	}
+}
+
+// TestRequiredIDsPresent pins the handful of ids that other packages and tests reference,
+// so a catalog edit can't silently break material assignment elsewhere.
+func TestRequiredIDsPresent(t *testing.T) {
+	lib := NewLibrary()
+	for _, id := range []string{DefaultAppearanceID, "steel", "aluminum", "oak", "abs-black"} {
+		if _, ok := lib.Appearance(id); !ok {
+			t.Errorf("required built-in appearance %q missing", id)
+		}
+	}
+	for _, id := range []string{"steel", "aluminum-6061"} {
+		if _, ok := lib.Material(id); !ok {
+			t.Errorf("required built-in material %q missing", id)
+		}
+	}
+}
+
+// TestAnisotropicMaterialsAreComplete enforces the simulation-readiness invariant: a
+// material declared orthotropic/transversely-isotropic must carry a full positive elastic
+// group, and conversely a populated elastic group must declare a non-isotropic class (so a
+// forgotten `isotropy:` tag can't ship). Metals and bulk plastics stay isotropic with none.
+func TestAnisotropicMaterialsAreComplete(t *testing.T) {
+	for _, m := range NewLibrary().Materials() {
+		o := m.Anisotropic()
+		anis := m.IsotropyClass().Anisotropic()
+		if anis {
+			for _, c := range []struct {
+				label string
+				v     float64
+			}{
+				{"e1", o.E1}, {"e2", o.E2}, {"e3", o.E3},
+				{"g12", o.G12}, {"g23", o.G23}, {"g13", o.G13},
+			} {
+				if c.v <= 0 {
+					t.Errorf("material %q (%s): orthotropic %s = %v, want > 0", m.ID(), m.IsotropyClass(), c.label, c.v)
+				}
+			}
+			continue
+		}
+		if o.E1 != 0 || o.E2 != 0 || o.E3 != 0 {
+			t.Errorf("material %q is isotropic but carries orthotropic data (%+v) — missing isotropy tag?", m.ID(), o)
+		}
+	}
+}
+
+// TestOrthotropicSurvivesRecipeRoundTrip locks the YAML persistence: an anisotropic
+// material keeps its elastic group through marshal/unmarshal, an isotropic one writes no
+// orthotropic block (pointer stays nil, so saved files don't gain empty {e1:0,...} noise).
+func TestOrthotropicSurvivesRecipeRoundTrip(t *testing.T) {
+	lib := NewLibrary()
+	oak, _ := lib.Material("oak-red")
+	r := materialToRecipe(oak)
+	if r.Orthotropic == nil {
+		t.Fatal("oak-red recipe lost its orthotropic block")
+	}
+	back := recipeToMaterial(r, SourceBuiltin)
+	if back.Anisotropic() != oak.Anisotropic() {
+		t.Errorf("orthotropic round-trip changed data: %+v -> %+v", oak.Anisotropic(), back.Anisotropic())
+	}
+
+	steel, _ := lib.Material("steel")
+	if got := materialToRecipe(steel); got.Orthotropic != nil {
+		t.Errorf("isotropic steel emitted an orthotropic block: %+v", *got.Orthotropic)
+	}
+}
+
+// forEachCatalogFile parses every embedded catalog file and invokes fn — a fake-free way
+// to assert over the shipped data directly (the embed.FS is the production source).
+func forEachCatalogFile(t *testing.T, fn func(name string, rd RecipeData)) {
+	t.Helper()
+	names, err := fs.Glob(catalogFiles, "catalog/*.yaml")
+	if err != nil {
+		t.Fatalf("glob catalog: %v", err)
+	}
+	if len(names) == 0 {
+		t.Fatal("no catalog files embedded")
+	}
+	for _, name := range names {
+		data, err := catalogFiles.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %q: %v", name, err)
+		}
+		var rd RecipeData
+		if err := yamlcodec.Unmarshal(data, &rd); err != nil {
+			t.Fatalf("parse %q: %v", name, err)
+		}
+		fn(name, rd)
+	}
+}

--- a/model/material/catalog_test.go
+++ b/model/material/catalog_test.go
@@ -114,8 +114,12 @@ func TestAnisotropicMaterialsAreComplete(t *testing.T) {
 				label string
 				v     float64
 			}{
-				{"e1", o.E1}, {"e2", o.E2}, {"e3", o.E3},
-				{"g12", o.G12}, {"g23", o.G23}, {"g13", o.G13},
+				{"e1", o.E1},
+				{"e2", o.E2},
+				{"e3", o.E3},
+				{"g12", o.G12},
+				{"g23", o.G23},
+				{"g13", o.G13},
 			} {
 				if c.v <= 0 {
 					t.Errorf("material %q (%s): orthotropic %s = %v, want > 0", m.ID(), m.IsotropyClass(), c.label, c.v)

--- a/model/material/doc.go
+++ b/model/material/doc.go
@@ -26,6 +26,8 @@ type (
 	Mechanical         = types.Mechanical
 	Thermal            = types.Thermal
 	Electrical         = types.Electrical
+	IsotropyClass      = types.IsotropyClass
+	AnisotropicElastic = types.AnisotropicElastic
 	PhysicalProperties = types.PhysicalProperties
 )
 
@@ -33,6 +35,10 @@ const (
 	SourceBuiltin  = types.AssetBuiltin
 	SourceProject  = types.AssetProject
 	SourceDocument = types.AssetDocument
+
+	Isotropic             = types.Isotropic
+	Orthotropic           = types.Orthotropic
+	TransverselyIsotropic = types.TransverselyIsotropic
 )
 
 // ParseColor parses a "#RRGGBBAA" (or "#RRGGBB") hex color into an Rgba — re-exported

--- a/model/material/material.go
+++ b/model/material/material.go
@@ -7,12 +7,17 @@ import "github.com/Oblikovati/api/contract"
 // MaterialSpec is the editable content of a material — density, the property groups, and
 // the id of the appearance it renders with.
 type MaterialSpec struct {
-	DisplayName  string
-	Density      float64 // g/cm³
-	Mechanical   Mechanical
-	Thermal      Thermal
-	Electrical   Electrical
-	AppearanceID string
+	DisplayName string
+	Density     float64 // g/cm³
+	Mechanical  Mechanical
+	Thermal     Thermal
+	Electrical  Electrical
+	// IsotropyClass / Anisotropic describe direction-dependent elasticity for FEA
+	// (ADR-0025). Empty class + zero Anisotropic means an ordinary isotropic material, so
+	// metals and bulk plastics carry nothing extra.
+	IsotropyClass IsotropyClass
+	Anisotropic   AnisotropicElastic
+	AppearanceID  string
 }
 
 // Material is one physical-world material asset. It satisfies [contract.Material].
@@ -39,6 +44,19 @@ func (m *Material) Mechanical() Mechanical { return m.spec.Mechanical }
 func (m *Material) Thermal() Thermal       { return m.spec.Thermal }
 func (m *Material) Electrical() Electrical { return m.spec.Electrical }
 func (m *Material) AppearanceID() string   { return m.spec.AppearanceID }
+
+// IsotropyClass reports the material's elastic symmetry, normalising an unset class to
+// Isotropic so callers never see the empty string (contract guarantee).
+func (m *Material) IsotropyClass() IsotropyClass {
+	if m.spec.IsotropyClass == "" {
+		return Isotropic
+	}
+	return m.spec.IsotropyClass
+}
+
+// Anisotropic returns the direction-dependent elastic constants (zero for an isotropic
+// material).
+func (m *Material) Anisotropic() AnisotropicElastic { return m.spec.Anisotropic }
 
 // Spec returns a copy of the editable fields.
 func (m *Material) Spec() MaterialSpec { return m.spec }

--- a/model/material/recipe.go
+++ b/model/material/recipe.go
@@ -22,13 +22,17 @@ type AppearanceRecipe struct {
 }
 
 type MaterialRecipe struct {
-	ID           string           `yaml:"id"`
-	DisplayName  string           `yaml:"name"`
-	Density      float64          `yaml:"density"`
-	Mechanical   types.Mechanical `yaml:"mechanical,omitempty"`
-	Thermal      types.Thermal    `yaml:"thermal,omitempty"`
-	Electrical   types.Electrical `yaml:"electrical,omitempty"`
-	AppearanceID string           `yaml:"appearance,omitempty"`
+	ID          string           `yaml:"id"`
+	DisplayName string           `yaml:"name"`
+	Density     float64          `yaml:"density"`
+	Mechanical  types.Mechanical `yaml:"mechanical,omitempty"`
+	Thermal     types.Thermal    `yaml:"thermal,omitempty"`
+	Electrical  types.Electrical `yaml:"electrical,omitempty"`
+	// Isotropy / Orthotropic capture direction-dependent elasticity (ADR-0025). Orthotropic
+	// is a pointer so the block is omitted entirely for ordinary isotropic materials.
+	Isotropy     types.IsotropyClass       `yaml:"isotropy,omitempty"`
+	Orthotropic  *types.AnisotropicElastic `yaml:"orthotropic,omitempty"`
+	AppearanceID string                    `yaml:"appearance,omitempty"`
 }
 
 type AssignmentRecipe struct {
@@ -106,19 +110,28 @@ func recipeToAppearance(r AppearanceRecipe, source Source) (*Appearance, error) 
 }
 
 func materialToRecipe(m *Material) MaterialRecipe {
-	return MaterialRecipe{
+	r := MaterialRecipe{
 		ID: m.id, DisplayName: m.spec.DisplayName, Density: m.spec.Density,
 		Mechanical: m.spec.Mechanical, Thermal: m.spec.Thermal, Electrical: m.spec.Electrical,
-		AppearanceID: m.spec.AppearanceID,
+		Isotropy: m.spec.IsotropyClass, AppearanceID: m.spec.AppearanceID,
 	}
+	if m.spec.IsotropyClass.Anisotropic() {
+		o := m.spec.Anisotropic
+		r.Orthotropic = &o
+	}
+	return r
 }
 
 func recipeToMaterial(r MaterialRecipe, source Source) *Material {
-	return NewMaterial(r.ID, source, MaterialSpec{
+	spec := MaterialSpec{
 		DisplayName: r.DisplayName, Density: r.Density,
 		Mechanical: r.Mechanical, Thermal: r.Thermal, Electrical: r.Electrical,
-		AppearanceID: r.AppearanceID,
-	})
+		IsotropyClass: r.Isotropy, AppearanceID: r.AppearanceID,
+	}
+	if r.Orthotropic != nil {
+		spec.Anisotropic = *r.Orthotropic
+	}
+	return NewMaterial(r.ID, source, spec)
 }
 
 // assignmentRecipe captures the store, or nil when nothing is assigned (keeps the recipe


### PR DESCRIPTION
## What

Replaces the placeholder 4-material / 6-appearance built-ins with an embedded YAML catalog — **~115 materials / 88 appearances**:

| Category | Coverage |
|---|---|
| Metals | industrially-used elements Z≤83 (Be…Bi) |
| Steels | carbon / alloy / tool / stainless + cast irons |
| Aluminium | wrought + cast alloys |
| Plastics | thermoplastics & thermoset resins |
| Woods | common solid woods (FPL Wood Handbook) |
| Composites | carbon/glass/aramid FRP, G10, engineered-wood panels |

Each entry has sourced **mechanical / thermal / electrical** properties and a **physically-based metallic-roughness appearance** authored in sRGB (the M23 Realistic shader linearises albedo → correct in Realistic mode).

Woods and fibre composites additionally carry **orthotropic / transversely-isotropic** elastic constants (depends on the API-repo contract, merged in Oblikovati.API#9) so the catalog is **FEA-ready**. Random-mat composites, metals and bulk plastics stay isotropic.

## How

- Catalog ships as `go:embed` YAML (`model/material/catalog/*.yaml`), loaded as read-only built-ins via `catalog.go` → `seedBuiltins`. Reuses the existing `RecipeData` shape — no new type/wire surface beyond the API PR.
- The `default` appearance stays in code so `DefaultAppearanceID` is always present.

## Tests

New `catalog_test.go` guards: catalog size, unique ids, complete (non-zero) properties, PBR ranges, required ids, anisotropy completeness, and YAML round-trip. `go test ./model/material/... ./addin/router/... ./app/... ./model/compdef/...` green; gofmt + `go vet` clean.

## ADRs

- **ADR-0024** — embedded YAML catalog (storage decision).
- **ADR-0025** — anisotropic material properties (FEA readiness).

> Depends on Oblikovati.API#9 (already merged to `develop`); CI resolves the contract from this repo's `develop` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)