### PR TITLE
ClientGraphics + InteractionGraphics viewport overlays (M05-F05)

### DIFF
--- a/addin/router/graphics.go
+++ b/addin/router/graphics.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/clientgraphics"
+)
+
+// setClientGraphics submits or replaces a named client-graphics group (idempotent by
+// clientId) and echoes its node/primitive counts (wire.MethodClientGraphicsSet).
+func setClientGraphics(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.SetClientGraphicsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	g, err := clientgraphics.DecodeGroup(a)
+	if err != nil {
+		return nil, err
+	}
+	s.Graphics().Set(g)
+	return json.Marshal(wire.SetClientGraphicsResult{
+		ClientId: g.Name(), NodeCount: g.NodeCount(), PrimitiveCount: g.PrimitiveCount(),
+	})
+}
+
+// listClientGraphics enumerates the live graphics groups across all lanes, sorted by
+// client id (wire.MethodClientGraphicsList).
+func listClientGraphics(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	groups := s.Graphics().Groups()
+	out := make([]wire.ClientGraphicsInfo, len(groups))
+	for i, g := range groups {
+		out[i] = wire.ClientGraphicsInfo{
+			ClientId: g.Name(), Lane: g.Lane(), Visible: g.Visible(),
+			NodeCount: g.NodeCount(), PrimitiveCount: g.PrimitiveCount(),
+		}
+	}
+	return json.Marshal(wire.ListClientGraphicsResult{Groups: out})
+}
+
+// deleteClientGraphics removes a named group (wire.MethodClientGraphicsDelete).
+func deleteClientGraphics(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.DeleteClientGraphicsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	s.Graphics().Delete(a.ClientId)
+	return ok()
+}
+
+// setClientGraphicsVisible toggles a group's visibility without resubmitting its geometry
+// (wire.MethodClientGraphicsSetVisible).
+func setClientGraphicsVisible(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.SetClientGraphicsVisibleArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	if err := s.Graphics().SetVisible(a.ClientId, a.Visible); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// updateInteractionGraphics replaces a transient interaction lane's nodes — the
+// rubber-band/manipulator update path (wire.MethodInteractionGraphicsUpdate).
+func updateInteractionGraphics(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.UpdateInteractionGraphicsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	g, err := clientgraphics.DecodeGroup(wire.SetClientGraphicsArgs{ClientId: interactionClientID(a.Lane), Lane: a.Lane, Nodes: a.Nodes})
+	if err != nil {
+		return nil, err
+	}
+	s.Graphics().ReplaceLane(clientgraphics.Lane(a.Lane), []clientgraphics.Group{g})
+	return ok()
+}
+
+// clearInteractionGraphics drops every transient interaction lane — what a command calls
+// on commit/cancel (wire.MethodInteractionGraphicsClear).
+func clearInteractionGraphics(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	s.Graphics().ClearInteraction()
+	return ok()
+}
+
+// interactionClientID is the reserved group key for one interaction lane, so an Update
+// replaces (rather than accumulates) the lane's content each call.
+func interactionClientID(lane string) string { return "__interaction__/" + lane }

--- a/addin/router/graphics_test.go
+++ b/addin/router/graphics_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/addin/opregistry"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// callGraphics dispatches a graphics method through the router and fails on error.
+func callGraphics(t *testing.T, r *Router, s *app.Session, method string, args any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal %s args: %v", method, err)
+	}
+	out, err := r.Handle(s, method, raw)
+	if err != nil {
+		t.Fatalf("%s: %v", method, err)
+	}
+	return out
+}
+
+// heatmapArgs is a one-triangle group colored per vertex through a blue→red mapper — a
+// minimal simulation-result overlay.
+func heatmapArgs() wire.SetClientGraphicsArgs {
+	return wire.SetClientGraphicsArgs{ClientId: "fea", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+		Kind:         string(types.GraphicsTriangles),
+		Coordinates:  []float64{0, 0, 0, 1, 0, 0, 0, 1, 0},
+		Indices:      []int{0, 1, 2},
+		Scalars:      []float64{0, 0.5, 1},
+		ColorBinding: string(types.GraphicsColorPerVertex),
+		ColorMapper:  &wire.GraphicsColorMapper{Values: []float64{0, 1}, Colors: []float32{0, 0, 1, 1, 1, 0, 0, 1}},
+	}}}}}
+}
+
+// TestGraphicsEndToEndAppearsInFrame is the e2e: an add-in pushes a heatmap mesh, lines and
+// a label through the router, and they show up in the rendered frame (heatmap with
+// per-vertex colors) and in the label channel.
+func TestGraphicsEndToEndAppearsInFrame(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+
+	var set wire.SetClientGraphicsResult
+	if err := json.Unmarshal(callGraphics(t, r, s, wire.MethodClientGraphicsSet, heatmapArgs()), &set); err != nil {
+		t.Fatalf("decode set result: %v", err)
+	}
+	if set.PrimitiveCount != 1 {
+		t.Errorf("set primitiveCount = %d, want 1", set.PrimitiveCount)
+	}
+	callGraphics(t, r, s, wire.MethodClientGraphicsSet, wire.SetClientGraphicsArgs{
+		ClientId: "vectors", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+			Kind: string(types.GraphicsLines), Coordinates: []float64{0, 0, 0, 1, 1, 1}, Indices: []int{0, 1},
+		}}}},
+	})
+	callGraphics(t, r, s, wire.MethodClientGraphicsSet, wire.SetClientGraphicsArgs{
+		ClientId: "label", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+			Kind: string(types.GraphicsText), Text: "12 MPa", Anchor: []float64{0, 0, 0},
+		}}}},
+	})
+
+	be := &renderer.NullBackend{}
+	s.RenderFrame(be)
+	frame := be.LastFrame()
+
+	heatmap := findHeatmap(frame)
+	if heatmap == nil {
+		t.Fatal("heatmap triangle item missing from frame")
+	}
+	if len(heatmap.Colors) != 3 || heatmap.Colors[0] != ([4]float32{0, 0, 1, 1}) {
+		t.Errorf("heatmap per-vertex colors = %v, want blue→red", heatmap.Colors)
+	}
+	if frame.Lines() < 1 {
+		t.Error("vector line item missing from frame")
+	}
+	if labels := s.GraphicsLabels(); len(labels) != 1 || labels[0].Text != "12 MPa" {
+		t.Errorf("labels = %+v, want one '12 MPa'", labels)
+	}
+}
+
+// findHeatmap returns the per-vertex-colored triangle item in the frame, or nil.
+func findHeatmap(frame renderer.DrawList) *renderer.DrawItem {
+	for i := range frame.Items {
+		if frame.Items[i].Primitive == renderer.Triangles && len(frame.Items[i].Colors) > 0 {
+			return &frame.Items[i]
+		}
+	}
+	return nil
+}
+
+func TestGraphicsListAndDelete(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	callGraphics(t, r, s, wire.MethodClientGraphicsSet, heatmapArgs())
+
+	var list wire.ListClientGraphicsResult
+	if err := json.Unmarshal(callGraphics(t, r, s, wire.MethodClientGraphicsList, struct{}{}), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.Groups) != 1 || list.Groups[0].ClientId != "fea" {
+		t.Fatalf("list = %+v, want one group 'fea'", list.Groups)
+	}
+
+	callGraphics(t, r, s, wire.MethodClientGraphicsDelete, wire.DeleteClientGraphicsArgs{ClientId: "fea"})
+	if got := len(s.Graphics().Groups()); got != 0 {
+		t.Errorf("group count after delete = %d, want 0", got)
+	}
+}
+
+// TestInteractionGraphicsUpdateThenClear checks a transient preview shows in the frame and
+// the clear method drops it (the command-end path).
+func TestInteractionGraphicsUpdateThenClear(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	callGraphics(t, r, s, wire.MethodInteractionGraphicsUpdate, wire.UpdateInteractionGraphicsArgs{
+		Lane: string(types.GraphicsLanePreview),
+		Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+			Kind: string(types.GraphicsLines), Coordinates: []float64{0, 0, 0, 2, 0, 0}, Indices: []int{0, 1},
+		}}}},
+	})
+	be := &renderer.NullBackend{}
+	s.RenderFrame(be)
+	if be.LastFrame().Lines() < 1 {
+		t.Fatal("interaction preview line missing from frame")
+	}
+
+	callGraphics(t, r, s, wire.MethodInteractionGraphicsClear, struct{}{})
+	if got := len(s.Graphics().Groups()); got != 0 {
+		t.Errorf("groups after clear = %d, want 0", got)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -36,6 +36,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerStandardHandlers()
 	r.registerMaterialHandlers()
 	r.registerLightingHandlers()
+	r.registerGraphicsHandlers()
 	return r
 }
 
@@ -178,6 +179,17 @@ func (r *Router) registerLightingHandlers() {
 	r.handlers[wire.MethodEnvironmentSet] = setEnvironment
 	r.handlers[wire.MethodEnvironmentListPresets] = listEnvironmentPresets
 	r.handlers[wire.MethodEnvironmentLoadImage] = loadEnvironmentImage
+}
+
+// registerGraphicsHandlers wires the client/interaction graphics methods — the add-in
+// overlay surface for drawing meshes, heatmaps, lines, markers and labels (M05-F05).
+func (r *Router) registerGraphicsHandlers() {
+	r.handlers[wire.MethodClientGraphicsSet] = setClientGraphics
+	r.handlers[wire.MethodClientGraphicsList] = listClientGraphics
+	r.handlers[wire.MethodClientGraphicsDelete] = deleteClientGraphics
+	r.handlers[wire.MethodClientGraphicsSetVisible] = setClientGraphicsVisible
+	r.handlers[wire.MethodInteractionGraphicsUpdate] = updateInteractionGraphics
+	r.handlers[wire.MethodInteractionGraphicsClear] = clearInteractionGraphics
 }
 
 // Handle dispatches method with its JSON args (empty args become {}), returning the

--- a/app/client_graphics_test.go
+++ b/app/client_graphics_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/model/clientgraphics"
+)
+
+// noopTool is a minimal Tool that commits on demand — enough to drive the tool-teardown
+// path that clears interaction graphics.
+type noopTool struct{ ready bool }
+
+func (t *noopTool) Name() string              { return "noop" }
+func (t *noopTool) Start(*Session)            {}
+func (t *noopTool) Pick(*Session, Selectable) {}
+func (t *noopTool) CanCommit() bool           { return t.ready }
+func (t *noopTool) Commit(*Session) error     { return nil }
+func (t *noopTool) Cancel(*Session)           {}
+
+// previewLine seeds the preview interaction lane with one line group.
+func previewLine(s *Session) {
+	g, err := clientgraphics.DecodeGroup(wire.SetClientGraphicsArgs{
+		ClientId: "x", Lane: string(types.GraphicsLanePreview),
+		Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+			Kind: string(types.GraphicsLines), Coordinates: []float64{0, 0, 0, 1, 0, 0}, Indices: []int{0, 1},
+		}}}},
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.Graphics().ReplaceLane(clientgraphics.LanePreview, []clientgraphics.Group{g})
+}
+
+func TestCancelToolClearsInteractionGraphics(t *testing.T) {
+	s := NewSession()
+	s.StartTool(&noopTool{})
+	previewLine(s)
+	s.CancelTool()
+	if got := len(s.Graphics().Groups()); got != 0 {
+		t.Errorf("cancel should clear interaction graphics, got %d groups", got)
+	}
+}
+
+func TestCommitClearsInteractionGraphics(t *testing.T) {
+	s := NewSession()
+	s.StartTool(&noopTool{ready: true})
+	previewLine(s)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if got := len(s.Graphics().Groups()); got != 0 {
+		t.Errorf("commit should clear interaction graphics, got %d groups", got)
+	}
+}
+
+func TestStartingNewToolClearsPriorInteractionGraphics(t *testing.T) {
+	s := NewSession()
+	s.StartTool(&noopTool{})
+	previewLine(s)
+	s.StartTool(&noopTool{}) // replacing a tool drops its preview
+	if got := len(s.Graphics().Groups()); got != 0 {
+		t.Errorf("starting a new tool should clear the prior preview, got %d groups", got)
+	}
+}
+
+// TestPersistentGraphicsSurviveToolTeardown guards that only the interaction lanes are
+// cleared — document-owned client graphics outlive commands.
+func TestPersistentGraphicsSurviveToolTeardown(t *testing.T) {
+	s := NewSession()
+	g, err := clientgraphics.DecodeGroup(wire.SetClientGraphicsArgs{
+		ClientId: "keep", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+			Kind: string(types.GraphicsPoints), Coordinates: []float64{0, 0, 0},
+		}}}},
+	})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	s.Graphics().Set(g)
+	s.StartTool(&noopTool{})
+	s.CancelTool()
+	if got := len(s.Graphics().Groups()); got != 1 {
+		t.Errorf("persistent graphics should survive, got %d groups", got)
+	}
+}

--- a/app/commands_lighting.go
+++ b/app/commands_lighting.go
@@ -35,7 +35,6 @@ func lightingSettingsCommand() *CommandDefinition {
 func lightingStyleCommands() []*CommandDefinition {
 	var cmds []*CommandDefinition
 	for _, opt := range renderer.LightingStyleGallery() {
-		opt := opt
 		cmds = append(cmds, NewCommand("View.Lighting."+opt.Name, opt.Name, "Lighting Style",
 			func(s *Session) error { return s.SetLightingStyle(opt.Name) }).
 			WithTab("View").WithKind(ComboControl).
@@ -50,7 +49,6 @@ func lightingStyleCommands() []*CommandDefinition {
 func environmentCommands() []*CommandDefinition {
 	var cmds []*CommandDefinition
 	for _, opt := range renderer.EnvironmentGallery() {
-		opt := opt
 		cmds = append(cmds, NewCommand("View.Environment."+opt.Name, opt.Name, "Environment",
 			func(s *Session) error {
 				s.SetEnvironment(renderer.Environment{
@@ -93,7 +91,8 @@ func shadowCommands() []*CommandDefinition {
 // checked reports the current state. Enabling any shadow with a zero density seeds a visible
 // default so the toggle has an immediate effect.
 func shadowToggle(id, label, tip string, flip func(*renderer.ShadowSettings),
-	checked func(renderer.ShadowSettings) bool) *CommandDefinition {
+	checked func(renderer.ShadowSettings) bool,
+) *CommandDefinition {
 	return NewCommand(id, label, "Shadows", func(s *Session) error {
 		sh := s.ShadowSettings()
 		flip(&sh)

--- a/app/render.go
+++ b/app/render.go
@@ -5,6 +5,7 @@ package app
 import (
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/model/clientgraphics"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
@@ -30,8 +31,20 @@ func (s *Session) Overlays() []renderer.DrawItem {
 	return out
 }
 
+// Graphics returns the add-in client/interaction graphics store (M05-F05), the seam the
+// router mutates from clientGraphics.* / interactionGraphics.* calls.
+func (s *Session) Graphics() *clientgraphics.Store { return s.graphics }
+
+// GraphicsLabels returns the world-anchored text labels of the live client graphics, for
+// the UI head to draw via its projected-ImGui label path (text is not draw-list geometry).
+func (s *Session) GraphicsLabels() []clientgraphics.Label {
+	_, labels := s.graphics.Build(s.camera)
+	return labels
+}
+
 // RenderFrame builds the frame draw list — the active part's bodies, the persistent
-// overlays, and the active tool's transient preview — and submits it to the backend.
+// overlays, the active tool's transient preview, and the add-in client/interaction
+// graphics — and submits it to the backend.
 func (s *Session) RenderFrame(backend renderer.Backend) {
 	list := renderer.BuildDrawListStyled(s.sceneBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup(), s.visualStyle)
 	list.Items = append(list.Items, s.overlays...)
@@ -40,6 +53,8 @@ func (s *Session) RenderFrame(backend renderer.Backend) {
 			list.Items = append(list.Items, p.Preview(s)...)
 		}
 	}
+	graphics, _ := s.graphics.Build(s.camera)
+	list.Items = append(list.Items, graphics...)
 	backend.Render(list)
 }
 

--- a/app/session.go
+++ b/app/session.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Oblikovati/oblikovati/event"
+	"github.com/Oblikovati/oblikovati/model/clientgraphics"
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/doc"
 	"github.com/Oblikovati/oblikovati/model/material"
@@ -38,6 +39,7 @@ type Session struct {
 	pendingDim         *sketch.DimensionConstraint
 	featureEdit        *featureEditState
 	overlays           []renderer.DrawItem
+	graphics           *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins             *AddInManager
 	grid               *GridSettings
 	themes             *theme.Library
@@ -83,6 +85,7 @@ func newSession(store doc.Store) *Session {
 		bus:                event.NewBus(),
 		selection:          NewSelection(),
 		camera:             scene.NewCamera(800, 600),
+		graphics:           clientgraphics.NewStore(),
 		addins:             NewAddInManager(),
 		visualStyle:        renderer.ShadedWithEdges,
 		lightingStyle:      renderer.LightingDefault,

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -19,6 +19,7 @@ func (s *Session) SetPicker(p Picker) { s.picker = p }
 func (s *Session) StartTool(t Tool) {
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
+		s.graphics.ClearInteraction() // drop the previous tool's preview/overlay graphics
 	}
 	s.notice = ""
 	s.tool = &ToolInstance{tool: t}
@@ -52,6 +53,7 @@ func (s *Session) OK() error {
 	}
 	s.notice = ""
 	s.tool = nil
+	s.graphics.ClearInteraction() // a committed command's transient preview vanishes
 	return nil
 }
 
@@ -61,6 +63,7 @@ func (s *Session) CancelTool() {
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
 		s.tool = nil
+		s.graphics.ClearInteraction() // a cancelled command's transient preview vanishes
 	}
 }
 

--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -78,7 +78,7 @@ func RunViewportSmoke(maxFrames int) int {
 	for i := 0; i < maxFrames && !w.ShouldClose(); i++ {
 		w.BeginFrame()
 		w.RenderViewport(1280, 720, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil)
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 	if path := os.Getenv("OBK_SMOKE_PNG"); path != "" {

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -53,6 +53,8 @@ struct Viewport {
     VkPipeline      linePipeline = VK_NULL_HANDLE;
     VkPipeline      occluderPipeline = VK_NULL_HANDLE; // depth-only faces (hidden-line modes)
     VkPipeline      hiddenPipeline = VK_NULL_HANDLE;   // occluded edges (reversed depth test)
+    VkPipeline      topTriPipeline = VK_NULL_HANDLE;   // on-top faces (depth test disabled, PBI-067)
+    VkPipeline      topLinePipeline = VK_NULL_HANDLE;  // on-top lines (depth test disabled, PBI-067)
     VkPipeline      skyboxPipeline = VK_NULL_HANDLE;   // HDR environment background (no depth)
     VkShaderModule  vertModule = VK_NULL_HANDLE;
     VkShaderModule  fragModule = VK_NULL_HANDLE;
@@ -898,6 +900,12 @@ void obk_viewport_init(void* h, const uint32_t* vert, int vlen, const uint32_t* 
                                           VK_POLYGON_MODE_FILL, VK_FALSE, VK_COMPARE_OP_LESS_OR_EQUAL, VK_TRUE);
     v->hiddenPipeline = create_pipeline(c, v, VK_PRIMITIVE_TOPOLOGY_LINE_LIST,
                                         VK_POLYGON_MODE_FILL, VK_TRUE, VK_COMPARE_OP_GREATER, VK_FALSE);
+    // On-top faces/lines: depth test always passes and depth is not written, so client-
+    // graphics overlay/burn-through geometry draws over the model (PBI-067).
+    v->topTriPipeline = create_pipeline(c, v, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+                                        VK_POLYGON_MODE_FILL, VK_TRUE, VK_COMPARE_OP_ALWAYS, VK_FALSE);
+    v->topLinePipeline = create_pipeline(c, v, VK_PRIMITIVE_TOPOLOGY_LINE_LIST,
+                                         VK_POLYGON_MODE_FILL, VK_TRUE, VK_COMPARE_OP_ALWAYS, VK_FALSE);
     v->skyboxPipeline = create_skybox_pipeline(c, v);
     create_shadow_resources(c, v);
 
@@ -933,30 +941,38 @@ void obk_viewport_render(void* h, int w, int hh, const float* mvp, const float* 
                          const float* triV, int triVC, const uint32_t* triIdx, int triIC,
                          const float* occV, int occVC, const uint32_t* occIdx, int occIC,
                          const float* lineV, int lineVC, const uint32_t* lineIdx, int lineIC,
-                         const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC) {
+                         const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC,
+                         const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
+                         const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC) {
     HeadContext* c = (HeadContext*)h;
     Viewport* v = c->viewport;
     if (!v || w <= 0 || hh <= 0) return;
     ensure_target(c, v, w, hh);
 
-    // One interleaved vertex buffer and one index buffer hold the four streams back to back, in
-    // draw order: occluder faces, shaded tris, solid lines, hidden lines. Each stream's indices
-    // are 0-based within its own vertices, so each draw passes its vertexOffset (the stream's
-    // vertex base) and firstIndex (its offset in the index buffer).
+    // One interleaved vertex buffer and one index buffer hold the streams back to back, in
+    // draw order: occluder faces, shaded tris, solid lines, hidden lines, on-top tris, on-top
+    // lines. Each stream's indices are 0-based within its own vertices, so each draw passes its
+    // vertexOffset (the stream's vertex base) and firstIndex (its offset in the index buffer).
     const int occBase = 0, triBase = occVC, lineBase = occVC + triVC, hidBase = occVC + triVC + lineVC;
+    const int topTriBase = hidBase + hidVC, topLineBase = topTriBase + topTriVC;
     const int occFirst = 0, triFirst = occIC, lineFirst = occIC + triIC, hidFirst = occIC + triIC + lineIC;
+    const int topTriFirst = hidFirst + hidIC, topLineFirst = topTriFirst + topTriIC;
     std::vector<float> verts;
-    verts.reserve((size_t)(occVC + triVC + lineVC + hidVC) * kVertexFloats);
+    verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
     verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
     verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
     verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
     verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
+    verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
+    verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
     std::vector<uint32_t> idx;
-    idx.reserve((size_t)(occIC + triIC + lineIC + hidIC));
+    idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
     idx.insert(idx.end(), occIdx, occIdx + occIC);
     idx.insert(idx.end(), triIdx, triIdx + triIC);
     idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
     idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
+    idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
+    idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
     upload(c, &v->vbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, verts.data(),
            verts.size() * sizeof(float));
     upload(c, &v->ibuf, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, idx.data(),
@@ -1076,6 +1092,19 @@ void obk_viewport_render(void* h, int w, int hh, const float* mvp, const float* 
             pushLit(0.0f);
             vkCmdBindPipeline(v->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->hiddenPipeline);
             vkCmdDrawIndexed(v->cmd, (uint32_t)hidIC, 1, (uint32_t)hidFirst, hidBase, 0);
+        }
+        // 5) on-top faces — depth test disabled, so client-graphics overlays draw over the
+        //    model. Drawn flat-lit (the overlay color is authoritative), after everything else.
+        if (topTriIC > 0) {
+            pushLit(0.0f);
+            vkCmdBindPipeline(v->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->topTriPipeline);
+            vkCmdDrawIndexed(v->cmd, (uint32_t)topTriIC, 1, (uint32_t)topTriFirst, topTriBase, 0);
+        }
+        // 6) on-top lines — depth test disabled (burn-through markers/edges).
+        if (topLineIC > 0) {
+            pushLit(0.0f);
+            vkCmdBindPipeline(v->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->topLinePipeline);
+            vkCmdDrawIndexed(v->cmd, (uint32_t)topLineIC, 1, (uint32_t)topLineFirst, topLineBase, 0);
         }
     }
 
@@ -1255,6 +1284,8 @@ void obk_viewport_destroy(HeadContext* c) {
     vkDestroyPipeline(c->device, v->linePipeline, nullptr);
     vkDestroyPipeline(c->device, v->occluderPipeline, nullptr);
     vkDestroyPipeline(c->device, v->hiddenPipeline, nullptr);
+    vkDestroyPipeline(c->device, v->topTriPipeline, nullptr);
+    vkDestroyPipeline(c->device, v->topLinePipeline, nullptr);
     vkDestroyPipeline(c->device, v->skyboxPipeline, nullptr);
     vkDestroyPipelineLayout(c->device, v->layout, nullptr);
     vkDestroyRenderPass(c->device, v->renderPass, nullptr);

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -16,7 +16,9 @@ void     obk_viewport_render(void* h, int w, int hh, const float* mvp, const flo
                              const float* triV, int triVC, const uint32_t* triIdx, int triIC,
                              const float* occV, int occVC, const uint32_t* occIdx, int occIC,
                              const float* lineV, int lineVC, const uint32_t* lineIdx, int lineIC,
-                             const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC);
+                             const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC,
+                             const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
+                             const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC);
 void     obk_viewport_set_clear(void* h, float r, float g, float b);
 void     obk_viewport_set_lighting(void* h, const float* data, int n);
 void     obk_viewport_set_environment(void* h, const float* data, const int* dims, int levels,
@@ -60,19 +62,24 @@ func (w *Window) SetViewportSkybox(invVP []float32, show bool) {
 // column-major MVP, with camPos (3 floats, world-space camera eye) supplying the PBR view
 // vector. Triangle and line vertices are interleaved as 16 floats [pos.xyz, normal.xyz,
 // color.rgba, metallic, roughness, emissive.rgb, mode]; indices are 0-based within their own
-// vertex array.
+// vertex array. The topTri/topLine streams are drawn last with the depth test disabled, so
+// client-graphics overlay/burn-through geometry stays visible over the model (PBI-067).
 func (win *Window) RenderViewport(w, h int, mvp []float32, camPos []float32,
 	triVerts []float32, triVCount int, triIdx []uint32,
 	occVerts []float32, occVCount int, occIdx []uint32,
 	lineVerts []float32, lineVCount int, lineIdx []uint32,
 	hidVerts []float32, hidVCount int, hidIdx []uint32,
+	topTriVerts []float32, topTriVCount int, topTriIdx []uint32,
+	topLineVerts []float32, topLineVCount int, topLineIdx []uint32,
 ) {
 	C.obk_viewport_render(win.handle, C.int(w), C.int(h),
 		(*C.float)(unsafe.Pointer(&mvp[0])), floatPtr(camPos),
 		floatPtr(triVerts), C.int(triVCount), uint32Ptr(triIdx), C.int(len(triIdx)),
 		floatPtr(occVerts), C.int(occVCount), uint32Ptr(occIdx), C.int(len(occIdx)),
 		floatPtr(lineVerts), C.int(lineVCount), uint32Ptr(lineIdx), C.int(len(lineIdx)),
-		floatPtr(hidVerts), C.int(hidVCount), uint32Ptr(hidIdx), C.int(len(hidIdx)))
+		floatPtr(hidVerts), C.int(hidVCount), uint32Ptr(hidIdx), C.int(len(hidIdx)),
+		floatPtr(topTriVerts), C.int(topTriVCount), uint32Ptr(topTriIdx), C.int(len(topTriIdx)),
+		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)))
 }
 
 // SetViewportClear sets the 3D pass background color (themed); it takes effect on the

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -44,7 +44,9 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		} else {
 			list = modelOverlays(s, cam, hovered, list)
 		}
+		list, gfxLabels := clientGraphicsOverlay(s, cam, list)
 		renderViewportImage(win, s, cam, list, pw, ph, cx, cy)
+		drawClientGraphicsLabels(cx, cy, cam, gfxLabels)
 		if s.InSketch() && len(dims) > 0 {
 			if d := drawDimensionLabels(cx, cy, cam, sketchPlane, dims); d != nil {
 				s.BeginEditDimension(d) // double-clicked a dimension's value
@@ -95,7 +97,9 @@ func renderViewportImage(win *native.Window, s *app.Session, cam scene.Camera, l
 		m.TriVerts, m.TriVCount, m.TriIndices,
 		m.OccVerts, m.OccVCount, m.OccIndices,
 		m.LineVerts, m.LineVCount, m.LineIndices,
-		m.HidVerts, m.HidVCount, m.HidIndices)
+		m.HidVerts, m.HidVCount, m.HidIndices,
+		m.TopTriVerts, m.TopTriVCount, m.TopTriIndices,
+		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices)
 	if tex := win.ViewportTexture(); tex != 0 {
 		native.SetCursorPos(cx, cy) // draw the image back over the invisible button
 		native.Image(tex, float32(pw), float32(ph))

--- a/head/ui/client_graphics_overlay.go
+++ b/head/ui/client_graphics_overlay.go
@@ -1,0 +1,40 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/model/clientgraphics"
+	"github.com/Oblikovati/oblikovati/renderer"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// Add-in client/interaction graphics display (M05-F05): the geometry (meshes, heatmaps,
+// lines, point glyphs) rides the normal viewport draw list, like the work-plane and sketch
+// overlays; the text labels are 2D, drawn over the rendered image at each anchor's
+// projected pixel — the same split the dimension overlay uses.
+
+// clientGraphicsOverlay appends the live client/interaction graphics geometry to list and
+// returns the labels to draw after the image is blitted.
+func clientGraphicsOverlay(s *app.Session, cam scene.Camera, list renderer.DrawList) (renderer.DrawList, []clientgraphics.Label) {
+	items, labels := s.Graphics().Build(cam)
+	list.Items = append(list.Items, items...)
+	return list, labels
+}
+
+// drawClientGraphicsLabels overlays each client-graphics label's text at its projected
+// world anchor (the image has already been drawn at window-local cx,cy). Anchors behind the
+// camera are skipped.
+func drawClientGraphicsLabels(cx, cy float32, cam scene.Camera, labels []clientgraphics.Label) {
+	for _, l := range labels {
+		sx, sy, ok := renderer.Project(cam, viewportNear, viewportFar, l.Anchor)
+		if !ok {
+			continue
+		}
+		native.SetCursorPos(cx+float32(sx), cy+float32(sy))
+		native.Text(l.Text)
+	}
+}

--- a/head/viewport/flatten.go
+++ b/head/viewport/flatten.go
@@ -15,33 +15,46 @@ import "github.com/Oblikovati/oblikovati/renderer"
 // in one draw call (ADR-0023 §2).
 const VertexFloats = 16
 
-// Mesh is the flattened, GPU-ready geometry split into the four viewport streams: shaded
-// triangles, depth-only occluder triangles (hidden-line modes), solid edge lines, and dashed
-// hidden-edge lines (reversed depth test). Indices are 0-based within each stream's own vertex
-// array (the pipeline applies the vertex offset).
+// Mesh is the flattened, GPU-ready geometry split into the viewport streams: shaded
+// triangles, depth-only occluder triangles (hidden-line modes), solid edge lines, dashed
+// hidden-edge lines (reversed depth test), and the two on-top streams (triangles and lines
+// drawn with the depth test disabled — client-graphics overlay/burn-through, PBI-067).
+// Indices are 0-based within each stream's own vertex array (the pipeline applies the
+// vertex offset).
 type Mesh struct {
-	TriVerts    []float32
-	TriVCount   int
-	TriIndices  []uint32
-	OccVerts    []float32
-	OccVCount   int
-	OccIndices  []uint32
-	LineVerts   []float32
-	LineVCount  int
-	LineIndices []uint32
-	HidVerts    []float32
-	HidVCount   int
-	HidIndices  []uint32
+	TriVerts       []float32
+	TriVCount      int
+	TriIndices     []uint32
+	OccVerts       []float32
+	OccVCount      int
+	OccIndices     []uint32
+	LineVerts      []float32
+	LineVCount     int
+	LineIndices    []uint32
+	HidVerts       []float32
+	HidVCount      int
+	HidIndices     []uint32
+	TopTriVerts    []float32
+	TopTriVCount   int
+	TopTriIndices  []uint32
+	TopLineVerts   []float32
+	TopLineVCount  int
+	TopLineIndices []uint32
 }
 
-// Flatten splits a draw list into the four viewport streams, interleaving each vertex as
+// Flatten splits a draw list into the viewport streams, interleaving each vertex as
 // [pos.xyz, normal.xyz, color.rgba, metallic, roughness, emissive.rgb, mode] and rebasing
-// indices per item. Triangles route to the occluder stream when DrawItem.Occluder is set;
-// lines route to the hidden stream when DrawItem.Hidden is set.
+// indices per item. DrawItem.OnTop routes triangles/lines to the depth-disabled on-top
+// streams (drawn over the model); otherwise triangles route to the occluder stream when
+// Occluder is set, and lines to the hidden stream when Hidden is set.
 func Flatten(list renderer.DrawList) Mesh {
 	var m Mesh
 	for _, item := range list.Items {
 		switch {
+		case item.OnTop && item.Primitive == renderer.Triangles:
+			m.TopTriVCount = appendItem(&m.TopTriVerts, &m.TopTriIndices, m.TopTriVCount, item)
+		case item.OnTop:
+			m.TopLineVCount = appendItem(&m.TopLineVerts, &m.TopLineIndices, m.TopLineVCount, item)
 		case item.Primitive == renderer.Triangles && item.Occluder:
 			m.OccVCount = appendItem(&m.OccVerts, &m.OccIndices, m.OccVCount, item)
 		case item.Primitive == renderer.Triangles:
@@ -65,10 +78,11 @@ func appendItem(verts *[]float32, idx *[]uint32, base int, item renderer.DrawIte
 				float32(item.Normals[i].X), float32(item.Normals[i].Y), float32(item.Normals[i].Z),
 			}
 		}
+		c := vertexColor(item, i)
 		*verts = append(*verts,
 			float32(p.X), float32(p.Y), float32(p.Z),
 			n[0], n[1], n[2],
-			item.Color[0], item.Color[1], item.Color[2], item.Color[3],
+			c[0], c[1], c[2], c[3],
 			item.Metallic, item.Roughness,
 			item.Emissive[0], item.Emissive[1], item.Emissive[2],
 			float32(item.Shading))
@@ -77,4 +91,13 @@ func appendItem(verts *[]float32, idx *[]uint32, base int, item renderer.DrawIte
 		*idx = append(*idx, uint32(base+i))
 	}
 	return base + len(item.Positions)
+}
+
+// vertexColor returns vertex i's color: the per-vertex DrawItem.Colors entry when present
+// (client-graphics heatmaps / per-vertex binding), else the item's single broadcast Color.
+func vertexColor(item renderer.DrawItem, i int) [4]float32 {
+	if i < len(item.Colors) {
+		return item.Colors[i]
+	}
+	return item.Color
 }

--- a/head/viewport/flatten_test.go
+++ b/head/viewport/flatten_test.go
@@ -89,6 +89,52 @@ func TestFlattenCarriesShadingAndMaterial(t *testing.T) {
 	}
 }
 
+// TestFlattenEmitsPerVertexColors checks that DrawItem.Colors overrides the single Color
+// per vertex — the client-graphics heatmap path. Vertex 0 stays red, vertex 1 turns blue.
+func TestFlattenEmitsPerVertexColors(t *testing.T) {
+	item := triItem(0)
+	item.Colors = [][4]float32{{1, 0, 0, 1}, {0, 0, 1, 1}, {0, 1, 0, 1}}
+	m := Flatten(renderer.DrawList{Items: []renderer.DrawItem{item}})
+	// color is floats 6..10 of each vertex.
+	v0 := m.TriVerts[6:10]
+	v1 := m.TriVerts[VertexFloats+6 : VertexFloats+10]
+	if v0[2] != 0 || v1[2] != 1 {
+		t.Errorf("per-vertex colors not applied: v0=%v v1=%v", v0, v1)
+	}
+}
+
+// TestFlattenFallsBackToBroadcastColor checks that without Colors the single Color still
+// broadcasts to every vertex (legacy behavior preserved).
+func TestFlattenFallsBackToBroadcastColor(t *testing.T) {
+	m := Flatten(renderer.DrawList{Items: []renderer.DrawItem{triItem(0)}})
+	for v := 0; v < 3; v++ {
+		c := m.TriVerts[v*VertexFloats+6 : v*VertexFloats+10]
+		if c[0] != 1 || c[1] != 0 || c[2] != 0 || c[3] != 1 {
+			t.Fatalf("vertex %d color = %v, want broadcast red", v, c)
+		}
+	}
+}
+
+// TestFlattenRoutesOnTopToTopStreams checks that DrawItem.OnTop triangles and lines route
+// to the depth-disabled on-top streams rather than the regular ones (PBI-067).
+func TestFlattenRoutesOnTopToTopStreams(t *testing.T) {
+	tri := triItem(0)
+	tri.OnTop = true
+	ln := lineItem()
+	ln.OnTop = true
+	m := Flatten(renderer.DrawList{Items: []renderer.DrawItem{tri, ln}})
+	if m.TopTriVCount != 3 || len(m.TopTriIndices) != 3 {
+		t.Errorf("on-top triangles: vcount=%d idx=%d, want 3/3", m.TopTriVCount, len(m.TopTriIndices))
+	}
+	if m.TopLineVCount != 2 || len(m.TopLineIndices) != 2 {
+		t.Errorf("on-top lines: vcount=%d idx=%d, want 2/2", m.TopLineVCount, len(m.TopLineIndices))
+	}
+	// They must NOT have leaked into the regular streams.
+	if m.TriVCount != 0 || m.LineVCount != 0 {
+		t.Errorf("on-top items leaked into regular streams: tri=%d line=%d", m.TriVCount, m.LineVCount)
+	}
+}
+
 func TestFlattenLinesTolerateMissingNormals(t *testing.T) {
 	m := Flatten(renderer.DrawList{Items: []renderer.DrawItem{lineItem()}})
 	// Normal slot (floats 3..6) should be zero, not a panic / garbage.

--- a/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-064-client-graphics.md
+++ b/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-064-client-graphics.md
@@ -3,7 +3,7 @@ milestone: M05
 feature: F05
 pbi: PBI-064
 title: Client graphics datasets, nodes & primitives
-status: planned
+status: in-progress
 estimate: L
 ---
 
@@ -28,6 +28,29 @@ Implement the client-graphics object model for drawing add-in-owned geometry (li
 ## Acceptance criteria
 
 - An add-in draws persistent overlay geometry that saves/reloads.
+
+## Delivered
+
+Declarative bulk-group model (ADR-0018): one `clientGraphics.set` submits/replaces a
+named group of nodes → primitives, geometry shipped as flat arrays — the right shape for
+large simulation-result meshes over the wire.
+
+- API contract (`Oblikovati.API`, Apache-2.0): `types/graphics.go` enums,
+  `wire/graphics.go` DTOs (+ method constants), `contract/graphics.go` scalar view,
+  `client/graphics.go` typed `Graphics()` group with `AddMesh/AddHeatmap/AddLines/
+  AddPoints/AddLabel` helpers.
+- Host store + builder (`model/clientgraphics/`): per-lane `Store`, decode/validate,
+  `ColorMapper` (scalar→color heatmaps), point-glyph expansion, `Build(cam)` →
+  `renderer.DrawItem` + world-anchored `Label`s.
+- Renderer: per-vertex color (`renderer.DrawItem.Colors` + `head/viewport/flatten.go`) —
+  the FEA heatmap enabler — and an `OnTop` flag.
+- Router (`addin/router/graphics.go`): `clientGraphics.set/list/delete/setVisible`.
+- Render integration: `app/render.go` `RenderFrame` draws the graphics; the windowed
+  head draws geometry + projected text labels (`head/ui/client_graphics_overlay.go`).
+
+**Remaining for "saves/reloads":** persistence of `saveWithDocument` groups into the
+`.obk` YAML is deferred to **PBI-066** (the simulation-overlay use case is transient).
+True on-top rendering (depth-disabled pass) landed in **PBI-067**.
 
 ## Depends on
 

--- a/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-065-interaction-graphics.md
+++ b/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-065-interaction-graphics.md
@@ -3,7 +3,7 @@ milestone: M05
 feature: F05
 pbi: PBI-065
 title: Interaction (preview) graphics
-status: planned
+status: done
 estimate: M
 ---
 
@@ -27,6 +27,17 @@ Implement transient interaction graphics for command previews and manipulators t
 ## Acceptance criteria
 
 - A command shows a live preview that disappears on commit/cancel.
+
+## Delivered
+
+- `interactionGraphics.update` replaces a transient lane (overlay/preview) wholesale —
+  the rubber-band/manipulator update path — and `interactionGraphics.clear` drops both
+  lanes (`api/wire`, `api/client` `Graphics().Interaction()`).
+- The overlay/preview lanes are command-scoped: the session clears them on tool
+  commit/cancel and when a new tool starts (`app/session_input.go`), so previews vanish
+  on commit/cancel. Regression tests in `app/client_graphics_test.go`.
+- The declarative bulk-group model is shared with PBI-064 (one `clientgraphics.Store`,
+  one `Build(cam)` builder).
 
 ## Depends on
 

--- a/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-066-client-graphics-persistence.md
+++ b/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-066-client-graphics-persistence.md
@@ -1,0 +1,34 @@
+---
+milestone: M05
+feature: F05
+pbi: PBI-066
+title: Persist saveWithDocument client graphics in .obk
+status: planned
+estimate: M
+---
+
+# PBI-066 — Persist saveWithDocument client graphics in .obk
+
+**Milestone:** M05 Application UI, Commands, Interaction & Add-in Platform  ·  **Feature:** F05 Client Graphics
+
+## Goal
+
+Round-trip document-owned client graphics through the `.obk` YAML so an add-in's
+persistent overlay geometry survives save/reload — closing the remaining half of
+PBI-064's acceptance ("saves/reloads"). Follows the transient-first split: PBI-064
+delivered the full in-session object model + render; this adds durability.
+
+## Scope / work
+
+- A `saveWithDocument` flag on the graphics group (wire + `clientgraphics.Group`).
+- A YAML schema for groups/nodes/primitives + datasets (coordinates/indices/colors/
+  normals/scalars/mapper) under `yamlcodec`; serialize only flagged groups.
+- Load path: rehydrate flagged groups into the session `clientgraphics.Store` on open.
+
+## Acceptance criteria
+
+- An add-in draws persistent overlay geometry; after Save + reopen it is still shown.
+
+## Depends on
+
+PBI-064.

--- a/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-067-graphics-on-top-pass.md
+++ b/implementation-plan/M05-ui-commands-addins/F05-client-graphics/PBI-067-graphics-on-top-pass.md
@@ -1,0 +1,47 @@
+---
+milestone: M05
+feature: F05
+pbi: PBI-067
+title: Native depth-disabled pass for on-top graphics
+status: done
+estimate: M
+---
+
+# PBI-067 — Native depth-disabled pass for on-top graphics
+
+**Milestone:** M05 Application UI, Commands, Interaction & Add-in Platform  ·  **Feature:** F05 Client Graphics
+
+# Goal
+
+Render `OnTop` client/interaction graphics (the overlay lane and burn-through
+markers/labels — Inventor's BurnThrough) ignoring the depth test, so manipulators and
+always-visible annotations draw over the model instead of being occluded by it. The
+`renderer.DrawItem.OnTop` flag and the store/build plumbing already exist (PBI-064);
+this adds the GPU pass that honors it.
+
+## Scope / work
+
+- Extend `head/viewport` `Flatten` with on-top triangle + line streams routed when
+  `DrawItem.OnTop`.
+- Extend the cgo binding `head/internal/native/viewport.go` `RenderViewport` and the C++
+  Vulkan backend with a depth-test-disabled pipeline for those streams.
+
+## Acceptance criteria
+
+- An overlay-lane marker drawn behind a solid body is still fully visible.
+
+## Delivered
+
+- `head/viewport` `Mesh`/`Flatten` gained two on-top streams (`TopTri*`/`TopLine*`);
+  `DrawItem.OnTop` triangles/lines route there instead of the regular streams (unit-
+  tested in `flatten_test.go`).
+- The cgo binding `RenderViewport` and `obk_viewport_render` carry the two streams; the
+  C++ backend creates `topTriPipeline`/`topLinePipeline` with `VK_COMPARE_OP_ALWAYS` +
+  depth-write off and draws them last (after hidden edges) so they composite over the
+  model. `chrome_viewport.go` passes the streams through.
+- Overlay-lane graphics (and any primitive with `onTop`) now render over the model; the
+  prior depth-tested degradation is removed.
+
+## Depends on
+
+PBI-064.

--- a/implementation-plan/M05-ui-commands-addins/F05-client-graphics/_feature.md
+++ b/implementation-plan/M05-ui-commands-addins/F05-client-graphics/_feature.md
@@ -34,3 +34,14 @@ F04.
 |-----|-------|
 | [PBI-064](PBI-064-client-graphics.md) | Client graphics datasets, nodes & primitives |
 | [PBI-065](PBI-065-interaction-graphics.md) | Interaction (preview) graphics |
+| [PBI-066](PBI-066-client-graphics-persistence.md) | Persist saveWithDocument client graphics in .obk |
+| [PBI-067](PBI-067-graphics-on-top-pass.md) | Native depth-disabled pass for on-top graphics |
+
+## Status
+
+PBI-065 + PBI-067 done; PBI-064 in progress (in-session object model + render + on-top
+pass delivered; only `.obk` persistence (PBI-066) remains). The model is **declarative
+bulk groups** over the wire (one `clientGraphics.set` per group) rather than Inventor's
+chatty mutable object model — the right shape for large simulation-result overlays.
+Surface/Curve-from-B-rep-body primitives (`SurfaceGraphics`/`CurveGraphics`) are out of
+scope for now.

--- a/model/clientgraphics/build.go
+++ b/model/clientgraphics/build.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import (
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/renderer"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// Build turns every visible group in the store into frame geometry and labels: a flat
+// list of renderer.DrawItem (triangle meshes with resolved per-vertex colors, line lists,
+// and expanded point glyphs) plus the world-anchored text labels the UI head draws.
+// Overlay-lane primitives are marked OnTop (drawn over the model). The camera supplies the
+// billboard basis and pixel scale for screen-constant point glyphs.
+func (s *Store) Build(cam scene.Camera) ([]renderer.DrawItem, []Label) {
+	bb := newBillboard(cam)
+	wpp := cam.WorldPerPixel()
+	var items []renderer.DrawItem
+	var labels []Label
+	for _, g := range s.Groups() {
+		if !g.visible {
+			continue
+		}
+		for i := range g.nodes {
+			items, labels = buildNode(items, labels, &g.nodes[i], g.lane, bb, wpp)
+		}
+	}
+	return items, labels
+}
+
+// buildNode appends one node's primitives (placed by its transform, gated by its
+// visibility) to the running geometry and labels.
+func buildNode(items []renderer.DrawItem, labels []Label, n *Node, lane Lane, bb billboard, wpp float64) ([]renderer.DrawItem, []Label) {
+	if n.Visible != nil && !*n.Visible {
+		return items, labels
+	}
+	for i := range n.Primitives {
+		p := placedPrimitive(&n.Primitives[i], n)
+		if p.Kind == types.GraphicsText {
+			labels = append(labels, Label{Anchor: p.Anchor, Text: p.Text, Color: p.Color, FontSize: p.FontSize})
+			continue
+		}
+		if item, ok := buildPrimitive(p, lane, bb, wpp); ok {
+			items = append(items, item)
+		}
+	}
+	return items, labels
+}
+
+// placedPrimitive returns a copy of the primitive with the node transform applied to its
+// coordinates, normals and text anchor (identity nodes return the primitive unchanged).
+func placedPrimitive(p *Primitive, n *Node) Primitive {
+	if !n.HasTransform {
+		return *p
+	}
+	out := *p
+	out.Coords = transformPoints(n.Transform, p.Coords)
+	out.Normals = transformVectors(n.Transform, p.Normals)
+	out.Anchor = n.Transform.TransformPoint(p.Anchor)
+	return out
+}
+
+// buildPrimitive converts one non-text primitive into a draw item; ok is false for a kind
+// that produces no geometry (e.g. an empty primitive).
+func buildPrimitive(p Primitive, lane Lane, bb billboard, wpp float64) (renderer.DrawItem, bool) {
+	onTop := p.OnTop || lane == LaneOverlay
+	switch p.Kind {
+	case types.GraphicsPoints:
+		return pointItem(p, bb, wpp, onTop)
+	case types.GraphicsLines:
+		return lineItem(p, p.Indices, onTop)
+	case types.GraphicsLineStrip:
+		return lineItem(p, stripLineIndices(len(p.Coords)), onTop)
+	case types.GraphicsTriangles:
+		return triangleItem(p, p.Indices, onTop)
+	case types.GraphicsTriangleStrip:
+		return triangleItem(p, stripTriangleIndices(len(p.Coords)), onTop)
+	default:
+		return renderer.DrawItem{}, false
+	}
+}
+
+// triangleItem builds a shaded triangle draw item, resolving per-vertex colors from the
+// color set, scalars+mapper, or the overall color.
+func triangleItem(p Primitive, indices []int, onTop bool) (renderer.DrawItem, bool) {
+	if len(p.Coords) == 0 || len(indices) == 0 {
+		return renderer.DrawItem{}, false
+	}
+	item := renderer.DrawItem{
+		Primitive: renderer.Triangles,
+		Positions: p.Coords,
+		Normals:   p.Normals,
+		Indices:   indices,
+		Color:     applyOpacity(p.Color, p.Opacity),
+		Opacity:   opacityOf(p.Color, p.Opacity),
+		OnTop:     onTop,
+	}
+	if colors := vertexColors(p); colors != nil {
+		item.Colors = colors
+	}
+	return item, true
+}
+
+// lineItem builds a line-list draw item from the given index pairs.
+func lineItem(p Primitive, indices []int, onTop bool) (renderer.DrawItem, bool) {
+	if len(p.Coords) == 0 || len(indices) == 0 {
+		return renderer.DrawItem{}, false
+	}
+	item := renderer.DrawItem{
+		Primitive: renderer.Lines,
+		Positions: p.Coords,
+		Indices:   indices,
+		Color:     applyOpacity(p.Color, p.Opacity),
+		OnTop:     onTop,
+	}
+	if colors := vertexColors(p); colors != nil {
+		item.Colors = colors
+	}
+	return item, true
+}
+
+// pointItem expands a points primitive into a line-list draw item of glyph segments.
+func pointItem(p Primitive, bb billboard, wpp float64, onTop bool) (renderer.DrawItem, bool) {
+	segs := pointGlyphs(p, bb, wpp)
+	if len(segs) == 0 {
+		return renderer.DrawItem{}, false
+	}
+	item := renderer.DrawItem{Primitive: renderer.Lines, Color: applyOpacity(p.Color, p.Opacity), OnTop: onTop}
+	for _, s := range segs {
+		base := len(item.Positions)
+		item.Positions = append(item.Positions, s[0], s[1])
+		item.Indices = append(item.Indices, base, base+1)
+	}
+	return item, true
+}
+
+// vertexColors resolves a primitive's per-vertex color array, or nil to fall back to the
+// single broadcast Color. Explicit Colors win; otherwise Scalars through a ColorMapper.
+func vertexColors(p Primitive) [][4]float32 {
+	if p.ColorBinding == types.GraphicsColorOverall {
+		return nil
+	}
+	if len(p.Colors) == len(p.Coords) && len(p.Colors) > 0 {
+		return withOpacity(p.Colors, p.Opacity)
+	}
+	if p.Mapper != nil && len(p.Scalars) == len(p.Coords) && len(p.Scalars) > 0 {
+		out := make([][4]float32, len(p.Scalars))
+		for i, v := range p.Scalars {
+			out[i] = applyOpacity(p.Mapper.At(v), p.Opacity)
+		}
+		return out
+	}
+	return nil
+}
+
+// withOpacity returns colors with the primitive opacity folded into alpha (or the input
+// when opacity is unset).
+func withOpacity(colors [][4]float32, opacity float32) [][4]float32 {
+	if opacity <= 0 {
+		return colors
+	}
+	out := make([][4]float32, len(colors))
+	for i, c := range colors {
+		out[i] = applyOpacity(c, opacity)
+	}
+	return out
+}
+
+// applyOpacity returns color with alpha replaced by opacity when opacity is set (>0).
+func applyOpacity(color [4]float32, opacity float32) [4]float32 {
+	if opacity <= 0 {
+		return color
+	}
+	return [4]float32{color[0], color[1], color[2], opacity}
+}
+
+// opacityOf returns the triangle item's Opacity field (the primitive opacity, else the
+// color's alpha) so translucent meshes blend.
+func opacityOf(color [4]float32, opacity float32) float32 {
+	if opacity > 0 {
+		return opacity
+	}
+	return color[3]
+}
+
+// stripLineIndices builds consecutive-pair indices for a line strip of n vertices.
+func stripLineIndices(n int) []int {
+	if n < 2 {
+		return nil
+	}
+	out := make([]int, 0, (n-1)*2)
+	for i := 0; i+1 < n; i++ {
+		out = append(out, i, i+1)
+	}
+	return out
+}
+
+// stripTriangleIndices builds triangle indices for a triangle strip of n vertices,
+// alternating winding so the mesh stays consistently oriented.
+func stripTriangleIndices(n int) []int {
+	if n < 3 {
+		return nil
+	}
+	out := make([]int, 0, (n-2)*3)
+	for i := 0; i+2 < n; i++ {
+		if i%2 == 0 {
+			out = append(out, i, i+1, i+2)
+		} else {
+			out = append(out, i+1, i, i+2)
+		}
+	}
+	return out
+}
+
+// transformPoints applies a transform to a copy of pts.
+func transformPoints(t math.Matrix4, pts []math.Point3) []math.Point3 {
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[i] = t.TransformPoint(p)
+	}
+	return out
+}
+
+// transformVectors applies a transform's linear part to a copy of vecs.
+func transformVectors(t math.Matrix4, vecs []math.Vector3) []math.Vector3 {
+	out := make([]math.Vector3, len(vecs))
+	for i, v := range vecs {
+		out[i] = t.TransformVector(v)
+	}
+	return out
+}

--- a/model/clientgraphics/build_test.go
+++ b/model/clientgraphics/build_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/renderer"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+func testCamera() scene.Camera { return scene.NewCamera(100, 100) }
+
+func buildOne(t *testing.T, args wire.SetClientGraphicsArgs) ([]renderer.DrawItem, []Label) {
+	t.Helper()
+	s := NewStore()
+	s.Set(mustDecode(t, args))
+	return s.Build(testCamera())
+}
+
+// TestBuildHeatmapResolvesPerVertexColors is the headline case: scalars through a mapper
+// become per-vertex DrawItem.Colors, so the renderer shades the FEA gradient.
+func TestBuildHeatmapResolvesPerVertexColors(t *testing.T) {
+	args := wire.SetClientGraphicsArgs{ClientId: "fea", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+		Kind:         string(types.GraphicsTriangles),
+		Coordinates:  []float64{0, 0, 0, 1, 0, 0, 0, 1, 0},
+		Indices:      []int{0, 1, 2},
+		Scalars:      []float64{0, 0.5, 1},
+		ColorBinding: string(types.GraphicsColorPerVertex),
+		ColorMapper:  &wire.GraphicsColorMapper{Values: []float64{0, 1}, Colors: []float32{0, 0, 1, 1, 1, 0, 0, 1}},
+	}}}}}
+	items, _ := buildOne(t, args)
+	if len(items) != 1 || len(items[0].Colors) != 3 {
+		t.Fatalf("want one item with 3 per-vertex colors, got %d items", len(items))
+	}
+	// vertex 0 scalar 0 → blue, vertex 2 scalar 1 → red.
+	if items[0].Colors[0] != ([4]float32{0, 0, 1, 1}) || items[0].Colors[2] != ([4]float32{1, 0, 0, 1}) {
+		t.Errorf("endpoint colors = %v, want blue→red", items[0].Colors)
+	}
+}
+
+func TestBuildOverallColorLeavesPerVertexNil(t *testing.T) {
+	args := meshArgs("solid", LanePersistent)
+	args.Nodes[0].Primitives[0].Color = []float32{0.2, 0.4, 0.6, 1}
+	args.Nodes[0].Primitives[0].ColorBinding = string(types.GraphicsColorOverall)
+	items, _ := buildOne(t, args)
+	if len(items) != 1 || items[0].Colors != nil {
+		t.Fatalf("overall color should leave Colors nil, got %+v", items)
+	}
+	if items[0].Color != ([4]float32{0.2, 0.4, 0.6, 1}) {
+		t.Errorf("overall color = %v, want set", items[0].Color)
+	}
+}
+
+func TestBuildLinesUsesIndices(t *testing.T) {
+	args := wire.SetClientGraphicsArgs{ClientId: "ln", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+		Kind:        string(types.GraphicsLines),
+		Coordinates: []float64{0, 0, 0, 1, 1, 1},
+		Indices:     []int{0, 1},
+	}}}}}
+	items, _ := buildOne(t, args)
+	if len(items) != 1 || items[0].Primitive != renderer.Lines || items[0].LineCount() != 1 {
+		t.Fatalf("want one line item with 1 segment, got %+v", items)
+	}
+}
+
+func TestBuildLineStripDerivesPairs(t *testing.T) {
+	args := wire.SetClientGraphicsArgs{ClientId: "strip", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+		Kind:        string(types.GraphicsLineStrip),
+		Coordinates: []float64{0, 0, 0, 1, 0, 0, 2, 0, 0}, // 3 vertices → 2 segments
+	}}}}}
+	items, _ := buildOne(t, args)
+	if len(items) != 1 || items[0].LineCount() != 2 {
+		t.Fatalf("line strip of 3 should give 2 segments, got %+v", items)
+	}
+}
+
+func TestBuildPointsExpandToGlyphSegments(t *testing.T) {
+	args := wire.SetClientGraphicsArgs{ClientId: "pts", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+		Kind:        string(types.GraphicsPoints),
+		Coordinates: []float64{0, 0, 0, 5, 5, 5}, // 2 points
+		PointStyle:  string(types.GraphicsPointPlus),
+	}}}}}
+	items, _ := buildOne(t, args)
+	// A "plus" is 2 segments per point → 4 segments for 2 points.
+	if len(items) != 1 || items[0].LineCount() != 4 {
+		t.Fatalf("two plus glyphs should give 4 segments, got %+v", items)
+	}
+}
+
+func TestBuildTextBecomesLabelNotGeometry(t *testing.T) {
+	args := wire.SetClientGraphicsArgs{ClientId: "lbl", Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+		Kind:   string(types.GraphicsText),
+		Text:   "12.3 MPa",
+		Anchor: []float64{1, 2, 3},
+	}}}}}
+	items, labels := buildOne(t, args)
+	if len(items) != 0 {
+		t.Errorf("text should produce no draw items, got %d", len(items))
+	}
+	if len(labels) != 1 || labels[0].Text != "12.3 MPa" {
+		t.Fatalf("want one label '12.3 MPa', got %+v", labels)
+	}
+	if labels[0].Anchor.X != 1 || labels[0].Anchor.Y != 2 || labels[0].Anchor.Z != 3 {
+		t.Errorf("label anchor = %v, want (1,2,3)", labels[0].Anchor)
+	}
+}
+
+func TestBuildOverlayLaneMarksOnTop(t *testing.T) {
+	items, _ := buildOne(t, meshArgs("o", LaneOverlay))
+	if len(items) != 1 || !items[0].OnTop {
+		t.Errorf("overlay-lane item should be OnTop, got %+v", items)
+	}
+}
+
+func TestBuildInvisibleGroupProducesNothing(t *testing.T) {
+	s := NewStore()
+	g := mustDecode(t, meshArgs("h", LanePersistent))
+	s.Set(g)
+	if err := s.SetVisible("h", false); err != nil {
+		t.Fatalf("SetVisible: %v", err)
+	}
+	items, _ := s.Build(testCamera())
+	if len(items) != 0 {
+		t.Errorf("hidden group should produce no items, got %d", len(items))
+	}
+}
+
+func TestBuildAppliesNodeTransform(t *testing.T) {
+	args := meshArgs("xf", LanePersistent)
+	// Translate by (10,0,0) (row-major 4x4 with last column the translation).
+	args.Nodes[0].Transform = []float64{
+		1, 0, 0, 10,
+		0, 1, 0, 0,
+		0, 0, 1, 0,
+		0, 0, 0, 1,
+	}
+	items, _ := buildOne(t, args)
+	if len(items) != 1 {
+		t.Fatalf("want one item, got %d", len(items))
+	}
+	// First coordinate (0,0,0) should now sit at x=10.
+	if got := items[0].Positions[0].X; got != 10 {
+		t.Errorf("transformed x = %v, want 10", got)
+	}
+}

--- a/model/clientgraphics/colormap.go
+++ b/model/clientgraphics/colormap.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+// At maps a scalar value to a color by piecewise-linear interpolation between the mapper's
+// ascending Values stops, clamping to the end colors outside the range (Inventor's
+// GraphicsColorMapper). The mapper is assumed validated (len(Colors)==len(Values)>0) by
+// DecodeGroup, so the heatmap path never sees a malformed legend.
+func (m *ColorMapper) At(value float64) [4]float32 {
+	if value <= m.Values[0] {
+		return m.Colors[0]
+	}
+	last := len(m.Values) - 1
+	if value >= m.Values[last] {
+		return m.Colors[last]
+	}
+	hi := upperStop(m.Values, value)
+	return lerpColor(m.Colors[hi-1], m.Colors[hi], stopFraction(m.Values[hi-1], m.Values[hi], value))
+}
+
+// upperStop returns the index of the first stop strictly greater than value (value is
+// known to be inside the open range, so this is in [1, last]).
+func upperStop(values []float64, value float64) int {
+	for i := 1; i < len(values); i++ {
+		if values[i] > value {
+			return i
+		}
+	}
+	return len(values) - 1
+}
+
+// stopFraction returns value's position in [lo, hi] as 0..1 (0 if the interval is empty).
+func stopFraction(lo, hi, value float64) float32 {
+	span := hi - lo
+	if span == 0 {
+		return 0
+	}
+	return float32((value - lo) / span)
+}
+
+// lerpColor linearly interpolates two rgba colors by t in 0..1.
+func lerpColor(a, b [4]float32, t float32) [4]float32 {
+	return [4]float32{
+		a[0] + (b[0]-a[0])*t,
+		a[1] + (b[1]-a[1])*t,
+		a[2] + (b[2]-a[2])*t,
+		a[3] + (b[3]-a[3])*t,
+	}
+}

--- a/model/clientgraphics/colormap_test.go
+++ b/model/clientgraphics/colormap_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import "testing"
+
+func mapper() *ColorMapper {
+	// 0 → blue, 1 → red.
+	return &ColorMapper{Values: []float64{0, 1}, Colors: [][4]float32{{0, 0, 1, 1}, {1, 0, 0, 1}}}
+}
+
+func TestColorMapperInterpolatesMidpoint(t *testing.T) {
+	got := mapper().At(0.5)
+	want := [4]float32{0.5, 0, 0.5, 1}
+	if got != want {
+		t.Errorf("At(0.5) = %v, want %v", got, want)
+	}
+}
+
+func TestColorMapperClampsBelowAndAbove(t *testing.T) {
+	m := mapper()
+	if got := m.At(-3); got != (m.Colors[0]) {
+		t.Errorf("At(-3) = %v, want clamp to %v", got, m.Colors[0])
+	}
+	if got := m.At(9); got != (m.Colors[1]) {
+		t.Errorf("At(9) = %v, want clamp to %v", got, m.Colors[1])
+	}
+}
+
+func TestColorMapperPicksRightSegment(t *testing.T) {
+	// 0 → black, 0.5 → green, 1 → white. A quarter-way is half into the first segment.
+	m := &ColorMapper{Values: []float64{0, 0.5, 1}, Colors: [][4]float32{{0, 0, 0, 1}, {0, 1, 0, 1}, {1, 1, 1, 1}}}
+	got := m.At(0.25)
+	want := [4]float32{0, 0.5, 0, 1}
+	if got != want {
+		t.Errorf("At(0.25) = %v, want %v", got, want)
+	}
+}

--- a/model/clientgraphics/contract.go
+++ b/model/clientgraphics/contract.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import "github.com/Oblikovati/api/contract"
+
+// A Group satisfies the public scalar view of a client-graphics group (api/contract.
+// ClientGraphics). Richer access (the geometry itself) travels as wire DTOs, decoded by
+// DecodeGroup — no GPL model types cross the boundary.
+var _ contract.ClientGraphics = (*Group)(nil)

--- a/model/clientgraphics/decode.go
+++ b/model/clientgraphics/decode.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// DecodeGroup converts a wire submit request into a kernel-typed Group, validating the
+// flat-array shapes once at the boundary so Build can assume them. Lane defaults to
+// persistent; Visible defaults to true.
+func DecodeGroup(args wire.SetClientGraphicsArgs) (Group, error) {
+	if args.ClientId == "" {
+		return Group{}, fmt.Errorf("clientGraphics: empty clientId in %+v", args)
+	}
+	lane, err := decodeLane(args.Lane, LanePersistent)
+	if err != nil {
+		return Group{}, err
+	}
+	nodes, err := decodeNodes(args.Nodes)
+	if err != nil {
+		return Group{}, err
+	}
+	return Group{clientID: args.ClientId, lane: lane, visible: args.Visible == nil || *args.Visible, nodes: nodes}, nil
+}
+
+// decodeLane maps a wire lane string to a Lane, applying fallback for an empty value.
+func decodeLane(s string, fallback Lane) (Lane, error) {
+	switch lane := Lane(s); lane {
+	case "":
+		return fallback, nil
+	case LanePersistent, LaneOverlay, LanePreview:
+		return lane, nil
+	default:
+		return "", fmt.Errorf("clientGraphics: unknown lane %q, want persistent|overlay|preview", s)
+	}
+}
+
+// decodeNodes decodes each wire node, failing on the first malformed one.
+func decodeNodes(in []wire.GraphicsNode) ([]Node, error) {
+	out := make([]Node, len(in))
+	for i, n := range in {
+		node, err := decodeNode(n)
+		if err != nil {
+			return nil, fmt.Errorf("node[%d]: %w", i, err)
+		}
+		out[i] = node
+	}
+	return out, nil
+}
+
+// decodeNode decodes a node's transform/visibility and its primitives.
+func decodeNode(n wire.GraphicsNode) (Node, error) {
+	xf, has, err := decodeTransform(n.Transform)
+	if err != nil {
+		return Node{}, err
+	}
+	prims := make([]Primitive, len(n.Primitives))
+	for i, p := range n.Primitives {
+		prim, err := decodePrimitive(p)
+		if err != nil {
+			return Node{}, fmt.Errorf("primitive[%d]: %w", i, err)
+		}
+		prims[i] = prim
+	}
+	return Node{Transform: xf, HasTransform: has, Visible: n.Visible, Opacity: n.Opacity, Primitives: prims}, nil
+}
+
+// decodeTransform builds a Matrix4 from a 16-element row-major slice; an empty slice
+// means "no transform" (identity), any other length is an error.
+func decodeTransform(t []float64) (math.Matrix4, bool, error) {
+	if len(t) == 0 {
+		return math.Identity4(), false, nil
+	}
+	if len(t) != 16 {
+		return math.Matrix4{}, false, fmt.Errorf("transform has %d cells, want 16 (row-major 4x4)", len(t))
+	}
+	var cells [16]math.Scalar
+	copy(cells[:], t)
+	return math.Matrix4FromCells(cells), true, nil
+}
+
+// decodePrimitive validates and converts one wire primitive into kernel types.
+func decodePrimitive(p wire.GraphicsPrimitive) (Primitive, error) {
+	kind := types.GraphicsPrimitiveKind(p.Kind)
+	out := Primitive{
+		Kind: kind, Indices: p.Indices, Scalars: p.Scalars,
+		ColorBinding:  types.GraphicsColorBinding(p.ColorBinding),
+		NormalBinding: types.GraphicsNormalBinding(p.NormalBinding),
+		LineType:      types.GraphicsLineType(p.LineType), LineWeight: p.LineWeight,
+		PointStyle: types.GraphicsPointStyle(p.PointStyle), PointSize: p.PointSize,
+		Text: p.Text, FontSize: p.FontSize, Opacity: p.Opacity, OnTop: p.OnTop,
+	}
+	var err error
+	if out.Coords, err = decodePoints("coordinates", p.Coordinates); err != nil {
+		return Primitive{}, err
+	}
+	if out.Normals, err = decodeVectors("normals", p.Normals); err != nil {
+		return Primitive{}, err
+	}
+	if out.Colors, err = decodeColors("colors", p.Colors); err != nil {
+		return Primitive{}, err
+	}
+	if out.Color, err = decodeColor(p.Color); err != nil {
+		return Primitive{}, err
+	}
+	if out.Mapper, err = decodeMapper(p.ColorMapper); err != nil {
+		return Primitive{}, err
+	}
+	out.Anchor = anchorPoint(p.Anchor)
+	return out, nil
+}
+
+// decodePoints converts an xyz-triple flat array into points.
+func decodePoints(field string, a []float64) ([]math.Point3, error) {
+	if len(a)%3 != 0 {
+		return nil, fmt.Errorf("%s has %d values, want a multiple of 3 (xyz triples)", field, len(a))
+	}
+	out := make([]math.Point3, len(a)/3)
+	for i := range out {
+		out[i] = math.P3(a[i*3], a[i*3+1], a[i*3+2])
+	}
+	return out, nil
+}
+
+// decodeVectors converts an xyz-triple flat array into vectors.
+func decodeVectors(field string, a []float64) ([]math.Vector3, error) {
+	if len(a)%3 != 0 {
+		return nil, fmt.Errorf("%s has %d values, want a multiple of 3 (xyz triples)", field, len(a))
+	}
+	out := make([]math.Vector3, len(a)/3)
+	for i := range out {
+		out[i] = math.V3(a[i*3], a[i*3+1], a[i*3+2])
+	}
+	return out, nil
+}
+
+// decodeColors converts an rgba-quad flat array into colors.
+func decodeColors(field string, a []float32) ([][4]float32, error) {
+	if len(a)%4 != 0 {
+		return nil, fmt.Errorf("%s has %d values, want a multiple of 4 (rgba quads)", field, len(a))
+	}
+	out := make([][4]float32, len(a)/4)
+	for i := range out {
+		out[i] = [4]float32{a[i*4], a[i*4+1], a[i*4+2], a[i*4+3]}
+	}
+	return out, nil
+}
+
+// decodeColor reads an optional overall rgba color; empty means opaque white.
+func decodeColor(a []float32) ([4]float32, error) {
+	if len(a) == 0 {
+		return [4]float32{1, 1, 1, 1}, nil
+	}
+	if len(a) != 4 {
+		return [4]float32{}, fmt.Errorf("color has %d values, want 4 (rgba)", len(a))
+	}
+	return [4]float32{a[0], a[1], a[2], a[3]}, nil
+}
+
+// decodeMapper validates and converts a color mapper (len(Colors) == 4*len(Values)).
+func decodeMapper(m *wire.GraphicsColorMapper) (*ColorMapper, error) {
+	if m == nil {
+		return nil, nil
+	}
+	if len(m.Values) == 0 || len(m.Colors) != 4*len(m.Values) {
+		return nil, fmt.Errorf("colorMapper has %d values and %d color components, want components == 4*values", len(m.Values), len(m.Colors))
+	}
+	colors := make([][4]float32, len(m.Values))
+	for i := range colors {
+		colors[i] = [4]float32{m.Colors[i*4], m.Colors[i*4+1], m.Colors[i*4+2], m.Colors[i*4+3]}
+	}
+	return &ColorMapper{Values: m.Values, Colors: colors}, nil
+}
+
+// anchorPoint reads a text primitive's xyz anchor (short/empty → origin).
+func anchorPoint(a []float64) math.Point3 {
+	if len(a) < 3 {
+		return math.P3(0, 0, 0)
+	}
+	return math.P3(a[0], a[1], a[2])
+}

--- a/model/clientgraphics/glyph.go
+++ b/model/clientgraphics/glyph.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// defaultPointPixels is the on-screen half-size of a point glyph when the primitive gives
+// no PointSize — a marker a few pixels across, like the sketch snap glyphs.
+const defaultPointPixels = 6.0
+
+// glyphCircleSegments is the polygon resolution of a "circle" point glyph.
+const glyphCircleSegments = 16
+
+// billboard holds the camera-facing right/up axes used to draw screen-aligned glyphs so a
+// point marker keeps a constant on-screen size and orientation regardless of view.
+type billboard struct {
+	right math.Vector3
+	up    math.Vector3
+}
+
+// newBillboard derives the camera's right/up basis (forward = eye→target).
+func newBillboard(cam scene.Camera) billboard {
+	forward := cam.Forward()
+	right := normalize(forward.Cross(cam.Up))
+	return billboard{right: right, up: normalize(right.Cross(forward))}
+}
+
+// pointGlyphs expands a points primitive into glyph line segments (pairs of endpoints) at
+// the primitive's screen-constant size, using the camera billboard so every marker faces
+// the viewer. PointSize, when set, is the glyph's on-screen half-size in pixels.
+func pointGlyphs(p Primitive, bb billboard, worldPerPixel float64) [][2]math.Point3 {
+	pixels := p.PointSize
+	if pixels <= 0 {
+		pixels = defaultPointPixels
+	}
+	r := pixels * worldPerPixel
+	style := p.PointStyle
+	if style == "" {
+		style = types.GraphicsPointPlus
+	}
+	var segs [][2]math.Point3
+	for _, c := range p.Coords {
+		segs = append(segs, glyphSegments(style, c, bb, r)...)
+	}
+	return segs
+}
+
+// glyphSegments returns the line segments of one glyph centered at c.
+func glyphSegments(style types.GraphicsPointStyle, c math.Point3, bb billboard, r float64) [][2]math.Point3 {
+	switch style {
+	case types.GraphicsPointCross:
+		return diagonalGlyph(c, bb, r)
+	case types.GraphicsPointSquare, types.GraphicsPointDot:
+		return polygonGlyph(c, bb, r, 4, 0.25)
+	case types.GraphicsPointCircle:
+		return polygonGlyph(c, bb, r, glyphCircleSegments, 0)
+	default: // plus
+		return plusGlyph(c, bb, r)
+	}
+}
+
+// plusGlyph builds an axis-aligned "+" in the billboard plane.
+func plusGlyph(c math.Point3, bb billboard, r float64) [][2]math.Point3 {
+	return [][2]math.Point3{
+		{translate(c, bb.right, -r), translate(c, bb.right, r)},
+		{translate(c, bb.up, -r), translate(c, bb.up, r)},
+	}
+}
+
+// diagonalGlyph builds an "X" in the billboard plane.
+func diagonalGlyph(c math.Point3, bb billboard, r float64) [][2]math.Point3 {
+	d1 := bb.right.Add(bb.up)
+	d2 := bb.right.Sub(bb.up)
+	return [][2]math.Point3{
+		{c.TranslateBy(d1.Scale(-r)), c.TranslateBy(d1.Scale(r))},
+		{c.TranslateBy(d2.Scale(-r)), c.TranslateBy(d2.Scale(r))},
+	}
+}
+
+// polygonGlyph builds a closed n-gon of radius r in the billboard plane, rotated by
+// phaseTurns turns (e.g. 0.25 turns the 4-gon into an axis-aligned square).
+func polygonGlyph(c math.Point3, bb billboard, r float64, n int, phaseTurns float64) [][2]math.Point3 {
+	pts := make([]math.Point3, n)
+	for i := 0; i < n; i++ {
+		t := 2 * stdmath.Pi * (float64(i)/float64(n) + phaseTurns)
+		off := bb.right.Scale(r * stdmath.Cos(t)).Add(bb.up.Scale(r * stdmath.Sin(t)))
+		pts[i] = c.TranslateBy(off)
+	}
+	segs := make([][2]math.Point3, n)
+	for i := 0; i < n; i++ {
+		segs[i] = [2]math.Point3{pts[i], pts[(i+1)%n]}
+	}
+	return segs
+}
+
+// translate moves c by dir scaled by d.
+func translate(c math.Point3, dir math.Vector3, d float64) math.Point3 {
+	return c.TranslateBy(dir.Scale(d))
+}
+
+// normalize returns v as a unit vector, or the zero vector if v has no length.
+func normalize(v math.Vector3) math.Vector3 {
+	l := v.Length()
+	if l == 0 {
+		return v
+	}
+	return v.Scale(1 / l)
+}

--- a/model/clientgraphics/graphics.go
+++ b/model/clientgraphics/graphics.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package clientgraphics is the host-side store and renderer-builder for add-in client
+// and interaction graphics (Inventor's ClientGraphics + InteractionGraphics). Add-ins
+// submit declarative graphics groups over the wire (api/wire); the router decodes them
+// into this package's kernel-typed model, and Build turns the live groups into
+// renderer.DrawItem geometry (with per-vertex heatmap colors, glyphs and labels) for the
+// frame. It is pure Go with no cgo, so the whole path is headless-testable.
+//
+// Three lanes mirror Inventor's two surfaces: LanePersistent is document-owned
+// ClientGraphics; LaneOverlay and LanePreview are the command-scoped InteractionGraphics
+// lanes (overlay draws on top of the scene, preview draws depth-tested with it).
+package clientgraphics
+
+import (
+	"github.com/Oblikovati/api/types"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Lane is the display lane of a graphics group (a types.GraphicsLane value, kept as a
+// host alias so callers don't depend on the contract module everywhere).
+type Lane = types.GraphicsLane
+
+const (
+	LanePersistent = types.GraphicsLanePersistent
+	LaneOverlay    = types.GraphicsLaneOverlay
+	LanePreview    = types.GraphicsLanePreview
+)
+
+// ColorMapper maps a scalar value to a color by piecewise-linear interpolation across
+// ascending Values stops (Inventor's GraphicsColorMapper) — the heatmap legend.
+type ColorMapper struct {
+	Values []float64
+	Colors [][4]float32
+}
+
+// Primitive is one decoded drawable primitive: geometry in kernel types plus its
+// rendering attributes. Per-vertex color is resolved at Build from Colors, or Scalars
+// through Mapper, or the overall Color.
+type Primitive struct {
+	Kind          types.GraphicsPrimitiveKind
+	Coords        []math.Point3
+	Indices       []int
+	Colors        [][4]float32
+	Normals       []math.Vector3
+	Scalars       []float64
+	Mapper        *ColorMapper
+	Color         [4]float32
+	ColorBinding  types.GraphicsColorBinding
+	NormalBinding types.GraphicsNormalBinding
+	LineType      types.GraphicsLineType
+	LineWeight    float64
+	PointStyle    types.GraphicsPointStyle
+	PointSize     float64
+	Text          string
+	Anchor        math.Point3
+	FontSize      float64
+	Opacity       float32
+	OnTop         bool
+}
+
+// Node groups primitives under one optional transform and visibility/opacity.
+type Node struct {
+	Transform    math.Matrix4
+	HasTransform bool
+	Visible      *bool
+	Opacity      float32
+	Primitives   []Primitive
+}
+
+// Group is one named client-graphics group in a lane. It satisfies
+// contract.ClientGraphics via accessor methods (fields stay unexported so the method set
+// is the boundary).
+type Group struct {
+	clientID string
+	lane     Lane
+	visible  bool
+	nodes    []Node
+}
+
+// Name is the group's client id (its store key).
+func (g *Group) Name() string { return g.clientID }
+
+// Lane is the group's display lane (a types.GraphicsLane value as a string).
+func (g *Group) Lane() string { return string(g.lane) }
+
+// Visible reports whether the group is currently drawn.
+func (g *Group) Visible() bool { return g.visible }
+
+// NodeCount is the number of graphics nodes the group owns.
+func (g *Group) NodeCount() int { return len(g.nodes) }
+
+// PrimitiveCount totals the primitives across the group's nodes.
+func (g *Group) PrimitiveCount() int {
+	n := 0
+	for i := range g.nodes {
+		n += len(g.nodes[i].Primitives)
+	}
+	return n
+}
+
+// Label is a world-anchored text label extracted from a "text" primitive at Build —
+// drawn by the UI head's projected-ImGui path, not as draw-list geometry.
+type Label struct {
+	Anchor   math.Point3
+	Text     string
+	Color    [4]float32
+	FontSize float64
+}

--- a/model/clientgraphics/store.go
+++ b/model/clientgraphics/store.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Store holds the live graphics groups keyed by client id, across all lanes. It is the
+// single owner of add-in-submitted graphics for a session; Build reads it each frame.
+// Not safe for concurrent use — it is mutated and read on the session goroutine.
+type Store struct {
+	groups map[string]*Group
+}
+
+// NewStore returns an empty store.
+func NewStore() *Store { return &Store{groups: map[string]*Group{}} }
+
+// Set inserts or replaces a group (idempotent by client id) — the submit path.
+func (s *Store) Set(g Group) {
+	cp := g
+	s.groups[g.clientID] = &cp
+}
+
+// Delete removes a group; it is a no-op if the id is unknown.
+func (s *Store) Delete(clientID string) { delete(s.groups, clientID) }
+
+// SetVisible toggles a group's visibility without resubmitting geometry; it errors if the
+// id is unknown so a mis-keyed add-in call is diagnosable.
+func (s *Store) SetVisible(clientID string, visible bool) error {
+	g, ok := s.groups[clientID]
+	if !ok {
+		return fmt.Errorf("clientGraphics: no group %q to set visibility", clientID)
+	}
+	g.visible = visible
+	return nil
+}
+
+// ReplaceLane drops every group in a lane and inserts the given ones — the
+// InteractionGraphics update path, which replaces a transient lane wholesale. The
+// supplied groups are forced into the lane.
+func (s *Store) ReplaceLane(lane Lane, groups []Group) {
+	s.clearLane(lane)
+	for i := range groups {
+		groups[i].lane = lane
+		s.Set(groups[i])
+	}
+}
+
+// ClearInteraction drops the transient overlay and preview lanes — called when a command
+// or tool deactivates so previews vanish on commit/cancel.
+func (s *Store) ClearInteraction() {
+	s.clearLane(LaneOverlay)
+	s.clearLane(LanePreview)
+}
+
+// clearLane removes every group in one lane.
+func (s *Store) clearLane(lane Lane) {
+	for id, g := range s.groups {
+		if g.lane == lane {
+			delete(s.groups, id)
+		}
+	}
+}
+
+// Groups returns every group sorted by client id, for deterministic enumeration and
+// frame building (the renderer may reorder for batching, but the source order is stable).
+func (s *Store) Groups() []*Group {
+	out := make([]*Group, 0, len(s.groups))
+	for _, g := range s.groups {
+		out = append(out, g)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].clientID < out[j].clientID })
+	return out
+}

--- a/model/clientgraphics/store_test.go
+++ b/model/clientgraphics/store_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package clientgraphics
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/types"
+	"github.com/Oblikovati/api/wire"
+)
+
+// meshArgs is a minimal one-triangle persistent group submitted under clientID.
+func meshArgs(clientID string, lane types.GraphicsLane) wire.SetClientGraphicsArgs {
+	return wire.SetClientGraphicsArgs{
+		ClientId: clientID, Lane: string(lane),
+		Nodes: []wire.GraphicsNode{{Primitives: []wire.GraphicsPrimitive{{
+			Kind:        string(types.GraphicsTriangles),
+			Coordinates: []float64{0, 0, 0, 1, 0, 0, 0, 1, 0},
+			Indices:     []int{0, 1, 2},
+		}}}},
+	}
+}
+
+func mustDecode(t *testing.T, args wire.SetClientGraphicsArgs) Group {
+	t.Helper()
+	g, err := DecodeGroup(args)
+	if err != nil {
+		t.Fatalf("DecodeGroup: %v", err)
+	}
+	return g
+}
+
+func TestStoreSetReplacesByClientId(t *testing.T) {
+	s := NewStore()
+	s.Set(mustDecode(t, meshArgs("a", LanePersistent)))
+	s.Set(mustDecode(t, meshArgs("a", LanePersistent))) // same id replaces, not appends
+	if got := len(s.Groups()); got != 1 {
+		t.Errorf("group count = %d, want 1 after replace", got)
+	}
+}
+
+func TestStoreDeleteRemovesGroup(t *testing.T) {
+	s := NewStore()
+	s.Set(mustDecode(t, meshArgs("a", LanePersistent)))
+	s.Delete("a")
+	if got := len(s.Groups()); got != 0 {
+		t.Errorf("group count = %d, want 0 after delete", got)
+	}
+}
+
+func TestStoreSetVisibleUnknownErrors(t *testing.T) {
+	s := NewStore()
+	if err := s.SetVisible("missing", false); err == nil {
+		t.Error("SetVisible on unknown id should error")
+	}
+}
+
+func TestStoreClearInteractionKeepsPersistent(t *testing.T) {
+	s := NewStore()
+	s.Set(mustDecode(t, meshArgs("keep", LanePersistent)))
+	s.Set(mustDecode(t, meshArgs("over", LaneOverlay)))
+	s.Set(mustDecode(t, meshArgs("prev", LanePreview)))
+	s.ClearInteraction()
+	groups := s.Groups()
+	if len(groups) != 1 || groups[0].Name() != "keep" {
+		t.Errorf("after ClearInteraction groups = %v, want only persistent 'keep'", groups)
+	}
+}
+
+func TestStoreReplaceLaneForcesLane(t *testing.T) {
+	s := NewStore()
+	g := mustDecode(t, meshArgs("p", LanePersistent)) // submitted persistent...
+	s.ReplaceLane(LanePreview, []Group{g})            // ...but forced into preview
+	groups := s.Groups()
+	if len(groups) != 1 || groups[0].Lane() != string(LanePreview) {
+		t.Errorf("ReplaceLane: group lane = %v, want preview", groups)
+	}
+}
+
+func TestDecodeRejectsBadCoordinateArity(t *testing.T) {
+	args := meshArgs("a", LanePersistent)
+	args.Nodes[0].Primitives[0].Coordinates = []float64{0, 0} // not a multiple of 3
+	if _, err := DecodeGroup(args); err == nil {
+		t.Error("DecodeGroup should reject non-triple coordinates")
+	}
+}
+
+func TestDecodeRejectsBadTransform(t *testing.T) {
+	args := meshArgs("a", LanePersistent)
+	args.Nodes[0].Transform = []float64{1, 2, 3} // not 16 cells
+	if _, err := DecodeGroup(args); err == nil {
+		t.Error("DecodeGroup should reject a non-16-cell transform")
+	}
+}
+
+func TestGroupSatisfiesScalarContract(t *testing.T) {
+	g := mustDecode(t, meshArgs("a", LanePersistent))
+	if g.Name() != "a" || g.Lane() != string(LanePersistent) || !g.Visible() || g.NodeCount() != 1 || g.PrimitiveCount() != 1 {
+		t.Errorf("scalar view wrong: name=%q lane=%q vis=%v nodes=%d prims=%d",
+			g.Name(), g.Lane(), g.Visible(), g.NodeCount(), g.PrimitiveCount())
+	}
+}

--- a/renderer/drawlist.go
+++ b/renderer/drawlist.go
@@ -30,6 +30,10 @@ type DrawItem struct {
 	Normals   []math.Vector3
 	Indices   []int
 	Color     [4]float32
+	// Colors, when non-nil, gives a per-vertex color (len == len(Positions)) that
+	// overrides the single Color at flatten time — the heatmap/per-vertex-binding path
+	// for client graphics. nil keeps the legacy "broadcast Color to every vertex" behavior.
+	Colors    [][4]float32
 	Metallic  float32
 	Roughness float32
 	Emissive  [3]float32
@@ -42,7 +46,12 @@ type DrawItem struct {
 	Occluder bool
 	// Hidden marks a line item drawn only where it is occluded (reversed depth test) in a
 	// dashed style — the hidden-edge half of the wireframe/shaded-with-hidden modes.
-	Hidden   bool
+	Hidden bool
+	// OnTop marks an item that should draw ignoring the depth test (always visible over the
+	// model) — the interaction-overlay lane and burn-through markers/labels of client
+	// graphics (Inventor's BurnThrough). The viewport routes these to the depth-disabled
+	// on-top pass (PBI-067); a headless NullBackend simply records them like any item.
+	OnTop    bool
 	ObjectID uint64
 }
 


### PR DESCRIPTION
## What

Implements the host side of **ClientGraphics + InteractionGraphics** (M05-F05): add-ins can draw their own geometry — triangle meshes, per-vertex **heatmaps**, lines, point markers and world-anchored text labels — as overlays in the 3D viewport, persistent or as transient command previews. Pairs with the API contract in Oblikovati.API#11 (already merged).

## Why

Simulation add-ins (M18) need to overlay results — FEA stress/displacement heatmaps, vectors, probe markers, value labels — over the model, and commands need live previews. There was previously no way for an add-in to draw into the viewport.

## How

- **`model/clientgraphics`**: per-lane `Store` (persistent + transient overlay/preview), validating decode of the declarative wire groups, a scalar→color `ColorMapper` (heatmaps), screen-constant point-glyph expansion, and `Build(cam)` → `renderer.DrawItem` + world-anchored `Label`s.
- **`renderer.DrawItem`**: optional per-vertex `Colors` (the heatmap enabler) + an `OnTop` flag.
- **`app`**: the `Session` owns the store; `RenderFrame` appends the graphics; overlay/preview lanes clear on tool commit/cancel/restart (PBI-065).
- **`addin/router`**: `clientGraphics.set/list/delete/setVisible` + `interactionGraphics.update/clear`.
- **`head`**: the windowed viewport draws geometry + projected text labels, and a **depth-disabled on-top pass** (new `topTri`/`topLine` Vulkan pipelines, `VK_COMPARE_OP_ALWAYS`) so `OnTop` overlays render over the model (PBI-067).

## Commits

1. Core feature (PBI-064/065) — store, renderer per-vertex color, app/render integration, router, head labels.
2. On-top depth-disabled pass (PBI-067).

Each commit builds and tests independently (verified in isolation).

## Tests

- `model/clientgraphics`: store, color-mapper interpolation/clamp, glyphs, build (per-vertex colors, transforms, labels).
- `addin/router/graphics_test.go` **e2e**: an add-in pushes a heatmap + lines + label → they appear in the rendered frame with interpolated per-vertex colors; interaction update/clear.
- `app/client_graphics_test.go`: interaction lanes clear on tool teardown, persistent survive.
- `head/viewport/flatten_test.go`: per-vertex color emission + on-top stream routing.

`go test ./...` green (both modules); the cgo + C++ head builds; gofmt + SPDX clean.

## Deferred (tracked)

- **PBI-066** — `.obk` persistence of `saveWithDocument` groups (transient-first call).
- SurfaceGraphics/CurveGraphics-from-B-rep — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)