### PR TITLE
Undo/redo as a per-document transaction-event stream

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -34,6 +34,7 @@ type Router struct {
 func New(ops *opregistry.Registry) *Router {
 	r := &Router{ops: ops, handlers: map[string]handlerFunc{}}
 	r.registerStandardHandlers()
+	r.registerTransactionHandlers()
 	r.registerMaterialHandlers()
 	r.registerLightingHandlers()
 	r.registerGraphicsHandlers()
@@ -63,6 +64,11 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewGetDisplayMode] = getDisplayMode
 	r.handlers[wire.MethodViewSetDisplayMode] = setDisplayMode
 	r.handlers[wire.MethodViewListDisplayModes] = listDisplayModes
+}
+
+// registerTransactionHandlers wires the undo/redo control methods — navigate and query
+// the active document's transaction-event stream (transaction.undo/redo/state).
+func (r *Router) registerTransactionHandlers() {
 	r.handlers[wire.MethodTransactionUndo] = undoTransaction
 	r.handlers[wire.MethodTransactionRedo] = redoTransaction
 	r.handlers[wire.MethodTransactionState] = transactionState

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -63,6 +63,9 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewGetDisplayMode] = getDisplayMode
 	r.handlers[wire.MethodViewSetDisplayMode] = setDisplayMode
 	r.handlers[wire.MethodViewListDisplayModes] = listDisplayModes
+	r.handlers[wire.MethodTransactionUndo] = undoTransaction
+	r.handlers[wire.MethodTransactionRedo] = redoTransaction
+	r.handlers[wire.MethodTransactionState] = transactionState
 }
 
 // registerSketchHandlers wires the 2D-sketch methods: the spine + enumeration here, and

--- a/addin/router/transactions.go
+++ b/addin/router/transactions.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// undoTransaction moves the active document's cursor back one transaction event, then
+// returns the resulting undo/redo state.
+func undoTransaction(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	if err := s.Undo(); err != nil {
+		return nil, err
+	}
+	return marshalUndoState(s)
+}
+
+// redoTransaction moves the cursor forward one transaction event, then returns the state.
+func redoTransaction(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	if err := s.Redo(); err != nil {
+		return nil, err
+	}
+	return marshalUndoState(s)
+}
+
+// transactionState reports what undo/redo can currently do (a read-only query).
+func transactionState(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return marshalUndoState(s)
+}
+
+// marshalUndoState renders the active document's cursor state into the wire DTO.
+func marshalUndoState(s *app.Session) (json.RawMessage, error) {
+	return json.Marshal(wire.UndoState{
+		CanUndo:  s.CanUndo(),
+		CanRedo:  s.CanRedo(),
+		NextUndo: s.UndoLabel(),
+		NextRedo: s.RedoLabel(),
+	})
+}

--- a/addin/router/transactions_test.go
+++ b/addin/router/transactions_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/addin/opregistry"
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// TestTransactionUndoRedoOverTheAPI drives the transaction.* control surface against a
+// live session: an edit makes undo available, transaction.undo moves the cursor back
+// (and exposes redo), transaction.redo moves it forward. NewPart opens the stream at the
+// empty-part baseline, and AddNumericUserParameter is a recording Session edit.
+func TestTransactionUndoRedoOverTheAPI(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+
+	var st wire.UndoState
+	call(t, r, s, "transaction.state", "{}", &st)
+	if st.CanUndo || st.CanRedo {
+		t.Fatalf("fresh part state = %+v, want nothing to undo/redo", st)
+	}
+
+	if err := s.AddNumericUserParameter("h", "3 cm"); err != nil {
+		t.Fatalf("add param: %v", err)
+	}
+	call(t, r, s, "transaction.state", "{}", &st)
+	if !st.CanUndo || st.NextUndo != "Edit Parameters" {
+		t.Fatalf("after edit state = %+v, want canUndo with nextUndo=Edit Parameters", st)
+	}
+
+	call(t, r, s, "transaction.undo", "{}", &st)
+	if st.CanUndo || !st.CanRedo || st.NextRedo != "Edit Parameters" {
+		t.Fatalf("after undo state = %+v, want canRedo with nextRedo=Edit Parameters", st)
+	}
+
+	call(t, r, s, "transaction.redo", "{}", &st)
+	if !st.CanUndo || st.CanRedo {
+		t.Fatalf("after redo state = %+v, want canUndo only", st)
+	}
+}
+
+// TestTransactionUndoNoActiveDocument: undo with no document errors cleanly (not a panic).
+func TestTransactionUndoNoActiveDocument(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := r.Handle(s, "transaction.undo", nil); err == nil {
+		t.Fatal("expected an error undoing with no active document")
+	}
+}

--- a/app/browser_actions.go
+++ b/app/browser_actions.go
@@ -45,6 +45,7 @@ func (s *Session) DeleteSketch(sk *sketch.Sketch) error {
 	}
 	s.selection.Clear()
 	part.Recompute()
+	s.recordEdit(part, "Delete Sketch")
 	return nil
 }
 
@@ -63,6 +64,7 @@ func (s *Session) DeleteFeature(f *feature.PartFeature) error {
 	}
 	s.selection.Clear()
 	part.Recompute()
+	s.recordEdit(part, "Delete Feature")
 	return nil
 }
 
@@ -78,5 +80,6 @@ func (s *Session) ToggleFeatureSuppressed(f *feature.PartFeature) error {
 	}
 	f.SetSuppressed(!f.Suppressed())
 	part.Recompute()
+	s.recordEdit(part, "Suppress Feature")
 	return nil
 }

--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -80,6 +80,7 @@ func (t *ChamferTool) Commit(s *Session) error {
 	d := t.distance
 	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferCorners(keys, func() float64 { return d }, t.flatCorners)
 	part.Recompute()
+	s.recordEdit(part, "Chamfer")
 	if !t.added.Health().OK() {
 		return errors.New("chamfer: " + t.added.Health().Reason)
 	}

--- a/app/coil_tool.go
+++ b/app/coil_tool.go
@@ -79,6 +79,7 @@ func (t *CoilTool) Commit(s *Session) error {
 	t.added = feature.NewCoilFeatures(part.Features()).Add(t.profile.Sketch, t.profile.ProfileIndex, axis,
 		func() float64 { return pitch }, func() float64 { return revs }, 0, t.operation)
 	part.Recompute()
+	s.recordEdit(part, "Coil")
 	if !t.added.Health().OK() {
 		return errors.New("coil: " + t.added.Health().Reason)
 	}

--- a/app/delete_face_tool.go
+++ b/app/delete_face_tool.go
@@ -62,6 +62,7 @@ func (t *DeleteFaceTool) Commit(s *Session) error {
 	}
 	t.added = feature.NewModifyFeatures(part.Features()).AddDeleteFace(keys)
 	part.Recompute()
+	s.recordEdit(part, "Delete Face")
 	if !t.added.Health().OK() {
 		return errors.New("delete face: " + t.added.Health().Reason)
 	}

--- a/app/draft_tool.go
+++ b/app/draft_tool.go
@@ -72,6 +72,7 @@ func (t *DraftTool) Commit(s *Session) error {
 	rad := t.angleDeg * degToRad
 	t.added = feature.NewDressUpFeatures(part.Features()).AddDraft(keys, func() float64 { return rad })
 	part.Recompute()
+	s.recordEdit(part, "Draft")
 	if !t.added.Health().OK() {
 		return errors.New("draft: " + t.added.Health().Reason)
 	}

--- a/app/events.go
+++ b/app/events.go
@@ -2,13 +2,17 @@
 
 package app
 
-import "github.com/Oblikovati/oblikovati/event"
+import (
+	"github.com/Oblikovati/oblikovati/event"
+	"github.com/Oblikovati/oblikovati/model/doc"
+)
 
 // Application UI events on the session bus. Stable TypeIDs (0x05xx = M05 UI).
 const (
-	tidCommandStarted   event.TypeID = 0x0501
-	tidCommandEnded     event.TypeID = 0x0502
-	tidSelectionChanged event.TypeID = 0x0503
+	tidCommandStarted    event.TypeID = 0x0501
+	tidCommandEnded      event.TypeID = 0x0502
+	tidSelectionChanged  event.TypeID = 0x0503
+	tidTransactionChange event.TypeID = 0x0504
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's
@@ -34,3 +38,13 @@ type SelectionChanged struct{ Count int }
 
 // EventID implements event.Event.
 func (SelectionChanged) EventID() event.TypeID { return tidSelectionChanged }
+
+// TransactionChanged fires (After) once per committed edit, undo, or redo on a
+// document's event stream — the coalesced "the model moved" signal (Inventor's
+// TransactionEvents). Document is the affected document's ID. The viewport reads model
+// state each frame, so this is for observers/add-ins and dirty-state tracking, not the
+// renderer.
+type TransactionChanged struct{ Document doc.ID }
+
+// EventID implements event.Event.
+func (TransactionChanged) EventID() event.TypeID { return tidTransactionChange }

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -159,6 +159,7 @@ func (t *ExtrudeTool) Commit(s *Session) error {
 	t.added = feature.NewExtrudeFeatures(part.Features()).
 		AddExtrude(skt, indices, t.operation, t.buildExtent(), t.taper)
 	part.Recompute()
+	s.recordEdit(part, "Extrude")
 	if !t.added.Health().OK() {
 		return errors.New("extrude: " + t.added.Health().Reason)
 	}

--- a/app/face_offset_tool.go
+++ b/app/face_offset_tool.go
@@ -67,6 +67,7 @@ func (t *FaceOffsetTool) Commit(s *Session) error {
 	}
 	t.added = feature.NewModifyFeatures(part.Features()).AddFaceOffset(keys, t.distance)
 	part.Recompute()
+	s.recordEdit(part, "Offset Face")
 	if !t.added.Health().OK() {
 		return errors.New("offset face: " + t.added.Health().Reason)
 	}

--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -89,6 +89,7 @@ func (s *Session) CommitFeatureEdit() error {
 	pf := s.featureEdit.feature
 	part.Features().MarkDirty(pf)
 	part.Recompute()
+	s.recordEdit(part, "Edit "+pf.Name())
 	if !pf.Health().OK() {
 		return errors.New("feature edit: " + pf.Health().Reason)
 	}

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -68,6 +68,7 @@ func (t *FilletTool) Commit(s *Session) error {
 	r := t.radius
 	t.added = feature.NewDressUpFeatures(part.Features()).AddFillet(keys, func() float64 { return r })
 	part.Recompute()
+	s.recordEdit(part, "Fillet")
 	if !t.added.Health().OK() {
 		return errors.New("fillet: " + t.added.Health().Reason)
 	}

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -65,6 +65,7 @@ func (t *HoleTool) Commit(s *Session) error {
 	t.added = feature.NewHoleFeatures(part.Features()).
 		AddDrilled(key, func() float64 { return d }, func() float64 { return depth })
 	part.Recompute()
+	s.recordEdit(part, "Hole")
 	if !t.added.Health().OK() {
 		return errors.New("hole: " + t.added.Health().Reason)
 	}

--- a/app/loft_tool.go
+++ b/app/loft_tool.go
@@ -70,6 +70,7 @@ func (t *LoftTool) Commit(s *Session) error {
 	}
 	t.added = feature.NewLoftFeatures(part.Features()).Add(sections, t.closed, t.operation)
 	part.Recompute()
+	s.recordEdit(part, "Loft")
 	if !t.added.Health().OK() {
 		return errors.New("loft: " + t.added.Health().Reason)
 	}

--- a/app/material_ops.go
+++ b/app/material_ops.go
@@ -37,6 +37,7 @@ func (s *Session) AssignMaterial(bodyKey, materialID string) error {
 		part.Assignments().SetBodyMaterial(bodyKey, materialID)
 	}
 	part.MarkChanged()
+	s.recordEdit(part, "Assign Material")
 	return nil
 }
 
@@ -62,6 +63,7 @@ func (s *Session) AssignAppearance(scope, key, appearanceID string) error {
 		return fmt.Errorf("app: unknown appearance scope %q", scope)
 	}
 	part.MarkChanged()
+	s.recordEdit(part, "Assign Appearance")
 	return nil
 }
 

--- a/app/offset_plane_tool.go
+++ b/app/offset_plane_tool.go
@@ -74,6 +74,7 @@ func (t *OffsetWorkPlaneTool) Commit(s *Session) error {
 	}
 	d, ref := t.distance, t.baseRef
 	t.added = finishWorkPlane(part, part.WorkPlanes().AddByPlaneAndOffset(ref, func() float64 { return d }))
+	s.recordEdit(part, "Offset Work Plane")
 	return nil
 }
 

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -148,5 +148,6 @@ func (s *Session) editParameters(edit func(*param.Parameters) error) error {
 	}
 	s.notice = ""
 	part.Recompute()
+	s.recordEdit(part, "Edit Parameters")
 	return nil
 }

--- a/app/replace_face_tool.go
+++ b/app/replace_face_tool.go
@@ -85,6 +85,7 @@ func (t *ReplaceFaceTool) Commit(s *Session) error {
 	}
 	t.added = feature.NewModifyFeatures(part.Features()).AddReplaceFace(keys, t.target.Face.ReferenceKey())
 	part.Recompute()
+	s.recordEdit(part, "Replace Face")
 	if !t.added.Health().OK() {
 		return errors.New("replace face: " + t.added.Health().Reason)
 	}

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -85,6 +85,7 @@ func (t *RevolveTool) Commit(s *Session) error {
 	t.added = feature.NewRevolveFeatures(part.Features()).
 		Add(t.profile.Sketch, t.profile.ProfileIndex, axis, func() float64 { return angle }, t.operation)
 	part.Recompute()
+	s.recordEdit(part, "Revolve")
 	if !t.added.Health().OK() {
 		return errors.New("revolve: " + t.added.Health().Reason)
 	}

--- a/app/session.go
+++ b/app/session.go
@@ -27,6 +27,7 @@ import (
 type Session struct {
 	workspace          *doc.Workspace
 	commands           *CommandManager
+	histories          map[doc.ID]*docHistory // per-document transaction-event streams (undo/redo)
 	bus                *event.Bus
 	selection          *Selection
 	tool               *ToolInstance
@@ -82,6 +83,7 @@ func newSession(store doc.Store) *Session {
 	return &Session{
 		workspace:          doc.NewWorkspace(store),
 		commands:           NewCommandManager(),
+		histories:          map[doc.ID]*docHistory{},
 		bus:                event.NewBus(),
 		selection:          NewSelection(),
 		camera:             scene.NewCamera(800, 600),
@@ -183,7 +185,12 @@ var ErrNeedsPath = errors.New("app: document has no file path yet; use Save As")
 //
 //	d, err := session.OpenDocument("/models/bracket.obk")
 func (s *Session) OpenDocument(path string) (*doc.Document, error) {
-	return s.workspace.Open(path, true)
+	d, err := s.workspace.Open(path, true)
+	if err != nil {
+		return nil, err
+	}
+	s.documentHistory(d) // open the event stream now so the first edit's before-snapshot is the open state
+	return d, nil
 }
 
 // NewPart creates a realized part document with a unique "PartN" name and makes it active
@@ -192,7 +199,12 @@ func (s *Session) OpenDocument(path string) (*doc.Document, error) {
 //
 //	d, err := session.NewPart()
 func (s *Session) NewPart() (*doc.Document, error) {
-	return compdef.AddPart(s.workspace, s.uniquePartName(), true)
+	d, err := compdef.AddPart(s.workspace, s.uniquePartName(), true)
+	if err != nil {
+		return nil, err
+	}
+	s.documentHistory(d) // open the event stream now so the first edit is undoable to the empty part
+	return d, nil
 }
 
 // uniquePartName returns the first "PartN" name not currently open, so New Part never clashes.

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -172,22 +172,32 @@ func (s *Session) Pointer(e PointerEvent) {
 	}
 }
 
+// undoRedoShortcut handles the Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z navigators over the active
+// document's transaction stream, returning handled=true when the keystroke was one of
+// them. It is a no-op while an interactive tool is mid-operation — Inventor forbids undo
+// while a transaction is in progress; the head additionally gates it on no text field
+// having keyboard focus.
+func (s *Session) undoRedoShortcut(e KeyEvent) (bool, error) {
+	if !e.Mods.Has(CtrlMod) || s.tool != nil {
+		return false, nil
+	}
+	switch e.Key {
+	case "z", "Z":
+		if e.Mods.Has(ShiftMod) {
+			return true, s.Redo()
+		}
+		return true, s.Undo()
+	case "y", "Y":
+		return true, s.Redo()
+	}
+	return false, nil
+}
+
 // PressKey routes a key press: Escape cancels the active tool, Enter commits it, and
 // otherwise a registered command alias runs (Inventor command aliases).
 func (s *Session) PressKey(e KeyEvent) error {
-	// Ctrl+Z / Ctrl+Y (Ctrl+Shift+Z) navigate the active document's transaction stream.
-	// Only when no interactive tool is mid-operation — Inventor forbids undo while a
-	// transaction is in progress; the head also gates this on text fields not having focus.
-	if e.Mods.Has(CtrlMod) && s.tool == nil {
-		switch e.Key {
-		case "z", "Z":
-			if e.Mods.Has(ShiftMod) {
-				return s.Redo()
-			}
-			return s.Undo()
-		case "y", "Y":
-			return s.Redo()
-		}
+	if handled, err := s.undoRedoShortcut(e); handled {
+		return err
 	}
 	switch e.Key {
 	case "Escape":

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -175,6 +175,20 @@ func (s *Session) Pointer(e PointerEvent) {
 // PressKey routes a key press: Escape cancels the active tool, Enter commits it, and
 // otherwise a registered command alias runs (Inventor command aliases).
 func (s *Session) PressKey(e KeyEvent) error {
+	// Ctrl+Z / Ctrl+Y (Ctrl+Shift+Z) navigate the active document's transaction stream.
+	// Only when no interactive tool is mid-operation — Inventor forbids undo while a
+	// transaction is in progress; the head also gates this on text fields not having focus.
+	if e.Mods.Has(CtrlMod) && s.tool == nil {
+		switch e.Key {
+		case "z", "Z":
+			if e.Mods.Has(ShiftMod) {
+				return s.Redo()
+			}
+			return s.Undo()
+		case "y", "Y":
+			return s.Redo()
+		}
+	}
 	switch e.Key {
 	case "Escape":
 		// Esc cancels the active tool at any point in its operation; with no tool it

--- a/app/shell_tool.go
+++ b/app/shell_tool.go
@@ -71,6 +71,7 @@ func (t *ShellTool) Commit(s *Session) error {
 	th := t.thickness
 	t.added = feature.NewDressUpFeatures(part.Features()).AddShell(keys, func() float64 { return th })
 	part.Recompute()
+	s.recordEdit(part, "Shell")
 	if !t.added.Health().OK() {
 		return errors.New("shell: " + t.added.Health().Reason)
 	}

--- a/app/sketch3d_env.go
+++ b/app/sketch3d_env.go
@@ -65,6 +65,7 @@ func (s *Session) FinishSketch3D() error {
 	s.ExitSketch3D()
 	if part, err := activePart(s); err == nil {
 		part.Recompute()
+		s.recordEdit(part, "3D Sketch")
 	}
 	return nil
 }

--- a/app/sketch_env.go
+++ b/app/sketch_env.go
@@ -92,6 +92,7 @@ func (s *Session) FinishSketch() error {
 	s.ExitSketch()
 	if part, err := activePart(s); err == nil {
 		part.Recompute()
+		s.recordEdit(part, "Sketch")
 	}
 	return nil
 }

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -88,6 +88,7 @@ func (t *SweepTool) Commit(s *Session) error {
 	t.added = feature.NewSweepFeatures(part.Features()).
 		Add(t.profile.Sketch, t.profile.ProfileIndex, path3d, func() float64 { return twist }, t.operation)
 	part.Recompute()
+	s.recordEdit(part, "Sweep")
 	if !t.added.Health().OK() {
 		return errors.New("sweep: " + t.added.Health().Reason)
 	}

--- a/app/thicken_tool.go
+++ b/app/thicken_tool.go
@@ -44,6 +44,7 @@ func (t *ThickenTool) Commit(s *Session) error {
 	}
 	t.added = feature.NewModifyFeatures(part.Features()).AddThicken(t.thickness)
 	part.Recompute()
+	s.recordEdit(part, "Thicken")
 	if !t.added.Health().OK() {
 		return errors.New("thicken: " + t.added.Health().Reason)
 	}

--- a/app/undo.go
+++ b/app/undo.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"bytes"
+
+	"github.com/Oblikovati/oblikovati/command"
+	"github.com/Oblikovati/oblikovati/event"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
+)
+
+// The part definition is the concrete RecipeStore a snapshot event navigates.
+var _ command.RecipeStore = (*compdef.PartComponentDefinition)(nil)
+
+// docHistory is one document's transaction-event stream: the [command.History] (the
+// cursor over the events) plus snapshot — the recipe the model holds at the current
+// cursor position. Every interaction appends a [command.RecipeEvent] whose before is
+// this snapshot and whose after is the recipe the interaction produced; undo/redo
+// move the cursor and restore the matching snapshot, then resync this field. The
+// stream begins when the document is opened (snapshot captures the open state), per
+// the event-sourcing model: current state is the fold of all events since open.
+type docHistory struct {
+	hist     *command.History
+	snapshot []byte
+}
+
+// resync sets snapshot to the recipe the document now holds — called after undo/redo
+// so the next new edit captures the correct before-snapshot for its event.
+func (dh *docHistory) resync(d *doc.Document) {
+	if part, ok := d.Content().(*compdef.PartComponentDefinition); ok {
+		dh.snapshot, _ = part.MarshalRecipe()
+	}
+}
+
+// documentHistory returns d's event stream, creating it (and capturing the open-state
+// snapshot as the stream's baseline) on first use. It is called eagerly when a
+// document is created or opened so the first edit's before-snapshot is the open state,
+// not the post-edit state. OnChange marks the document dirty and notifies observers
+// once per committed step, undo, or redo (the coalesced recompute/notify seam).
+func (s *Session) documentHistory(d *doc.Document) *docHistory {
+	if dh, ok := s.histories[d.ID()]; ok {
+		return dh
+	}
+	dh := &docHistory{hist: command.NewHistory()}
+	dh.resync(d)
+	dh.hist.OnChange(func() {
+		d.MarkDirty()
+		event.Emit(s.bus, event.After, TransactionChanged{Document: d.ID()})
+	})
+	s.histories[d.ID()] = dh
+	return dh
+}
+
+// recordEdit appends one transaction event for the interaction that just mutated the
+// active part's recipe. It is the single finalize chokepoint every edit routes
+// through, called right after the edit's existing part.Recompute(): it captures the
+// new recipe (the after-snapshot) and records it against the stream's current
+// snapshot, then advances the cursor. The recipe is the parametric input, independent
+// of the geometry recompute the caller already ran, so recordEdit does not recompute.
+// An edit that changed nothing (e.g. exiting a sketch untouched) leaves before==after
+// and records no event, so the stream holds only real changes.
+func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return
+	}
+	dh := s.documentHistory(d)
+	after, err := part.MarshalRecipe()
+	if err != nil || bytes.Equal(after, dh.snapshot) {
+		return
+	}
+	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
+	dh.snapshot = after
+}
+
+// Undo moves the active document's cursor back one transaction event, restoring the
+// prior recipe and recomputing. Redo moves it forward. Both are navigators over the
+// event stream — non-destructive: undo leaves the event available to redo until a new
+// edit truncates the forward branch.
+func (s *Session) Undo() error {
+	d := s.ActiveDocument()
+	if d == nil {
+		s.notice = ErrNoActiveDoc.Error()
+		return ErrNoActiveDoc
+	}
+	dh := s.documentHistory(d)
+	if err := dh.hist.Undo(); err != nil {
+		s.notice = err.Error()
+		return err
+	}
+	dh.resync(d)
+	s.notice = ""
+	return nil
+}
+
+// Redo re-applies the next event ahead of the active document's cursor.
+func (s *Session) Redo() error {
+	d := s.ActiveDocument()
+	if d == nil {
+		s.notice = ErrNoActiveDoc.Error()
+		return ErrNoActiveDoc
+	}
+	dh := s.documentHistory(d)
+	if err := dh.hist.Redo(); err != nil {
+		s.notice = err.Error()
+		return err
+	}
+	dh.resync(d)
+	s.notice = ""
+	return nil
+}
+
+// CanUndo / CanRedo report whether the active document has an event behind / ahead of
+// its cursor. They drive the ribbon Undo/Redo enable state. No active document ⇒ false.
+func (s *Session) CanUndo() bool { return s.activeStream() != nil && s.activeStream().hist.CanUndo() }
+func (s *Session) CanRedo() bool { return s.activeStream() != nil && s.activeStream().hist.CanRedo() }
+
+// UndoLabel / RedoLabel return the name of the step undo/redo would act on next, for
+// the ribbon tooltip ("Undo Extrude"); "" when there is nothing to act on.
+func (s *Session) UndoLabel() string { return lastLabel(s.undoLabels()) }
+func (s *Session) RedoLabel() string { return firstLabel(s.redoLabels()) }
+
+func (s *Session) undoLabels() []string {
+	if st := s.activeStream(); st != nil {
+		return st.hist.UndoLabels()
+	}
+	return nil
+}
+
+func (s *Session) redoLabels() []string {
+	if st := s.activeStream(); st != nil {
+		return st.hist.RedoLabels()
+	}
+	return nil
+}
+
+// activeStream returns the active document's stream without creating one — a read-only
+// query for the CanUndo/label accessors. nil when there is no active part document or
+// no edit has happened yet.
+func (s *Session) activeStream() *docHistory {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil
+	}
+	return s.histories[d.ID()]
+}
+
+// lastLabel / firstLabel pick the next-acted step from an ordered label slice:
+// UndoLabels is oldest-first (undo acts on the last), RedoLabels is redo-order (redo
+// acts on the first).
+func lastLabel(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	return labels[len(labels)-1]
+}
+
+func firstLabel(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	return labels[0]
+}

--- a/app/undo_test.go
+++ b/app/undo_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/model/compdef"
+)
+
+// partOf returns the active part definition — the geometry/recipe under test.
+func partOf(t *testing.T, s *Session) *compdef.PartComponentDefinition {
+	t.Helper()
+	def, ok := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		t.Fatal("active document is not a part")
+	}
+	return def
+}
+
+// trackFromHere opens the active document's transaction stream at the current recipe,
+// the baseline the first edit will undo back to. NewPart/OpenDocument do this in the
+// real app; the lower-level test setup (Workspace().Add) does not, so the stream-level
+// tests call it explicitly to mark "the document is now open with this content".
+func trackFromHere(s *Session) { s.documentHistory(s.ActiveDocument()) }
+
+// TestUndoRedoExtrudeNavigatesGeometry is the headline test: an extrude is one
+// transaction event; undo removes the solid (recompute from the prior recipe) while the
+// sketch survives; redo restores the identical body. Undo/redo are cursor moves, not a
+// geometry snapshot stack.
+func TestUndoRedoExtrudeNavigatesGeometry(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2)
+	trackFromHere(s) // baseline = part + sketch, no body yet
+	def := partOf(t, s)
+
+	s.SetPicker(stubPicker{sel: profile})
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	s.Click(120, 90)
+	ext.SetDistance(5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("after extrude: %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+	if !s.CanUndo() || s.UndoLabel() != "Extrude" {
+		t.Fatalf("CanUndo=%v UndoLabel=%q, want true/\"Extrude\"", s.CanUndo(), s.UndoLabel())
+	}
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 0 {
+		t.Errorf("after undo: %d bodies, want 0", def.SurfaceBodies().Count())
+	}
+	if def.Sketches().Count() != 1 {
+		t.Errorf("undo removed the sketch (count=%d); only the extrude should be undone", def.Sketches().Count())
+	}
+	if !s.CanRedo() || s.RedoLabel() != "Extrude" {
+		t.Fatalf("CanRedo=%v RedoLabel=%q, want true/\"Extrude\"", s.CanRedo(), s.RedoLabel())
+	}
+
+	if err := s.Redo(); err != nil {
+		t.Fatalf("Redo: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Errorf("after redo: %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+	if z := def.SurfaceBodies().Item(0).RangeBox().Diagonal().Z; z < 4.99 || z > 5.01 {
+		t.Errorf("redone extrude height = %v, want 5", z)
+	}
+}
+
+// TestUndoParameterAndRedoTruncation covers the parameter edit path and the rule that a
+// new edit made after undo truncates the forward (redo) branch of the stream.
+func TestUndoParameterAndRedoTruncation(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	trackFromHere(s)
+	def := partOf(t, s)
+	base := def.Parameters().Count()
+
+	if err := s.AddNumericUserParameter("d0", "10 mm"); err != nil {
+		t.Fatalf("add param: %v", err)
+	}
+	if def.Parameters().Count() != base+1 {
+		t.Fatalf("param count = %d, want %d", def.Parameters().Count(), base+1)
+	}
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if def.Parameters().Count() != base {
+		t.Errorf("after undo: param count = %d, want %d", def.Parameters().Count(), base)
+	}
+	if !s.CanRedo() {
+		t.Fatal("expected a redo branch after undo")
+	}
+
+	// A new edit while the cursor is behind the tip discards the redo branch.
+	if err := s.AddNumericUserParameter("d1", "20 mm"); err != nil {
+		t.Fatalf("add second param: %v", err)
+	}
+	if s.CanRedo() {
+		t.Error("new edit did not truncate the redo branch")
+	}
+	if _, ok := def.Parameters().ByName("d0"); ok {
+		t.Error("d0 should be gone — its event was discarded by the new edit")
+	}
+	if _, ok := def.Parameters().ByName("d1"); !ok {
+		t.Error("d1 should be present")
+	}
+}
+
+// TestCursorRoundTripFidelity: undoing k steps then redoing k restores the same logical
+// model state — the cursor is a lossless navigator over the event stream. (We compare
+// the parameter set rather than the raw recipe bytes because reset+apply reassigns
+// internal IDs, so the marshaled form is not byte-stable; the state is what undo must
+// preserve.)
+func TestCursorRoundTripFidelity(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	trackFromHere(s)
+	def := partOf(t, s)
+
+	names := []string{"p1", "p2", "p3"}
+	for i, expr := range []string{"1 mm", "2 mm", "3 mm"} {
+		if err := s.AddNumericUserParameter(names[i], expr); err != nil {
+			t.Fatalf("add %q: %v", names[i], err)
+		}
+	}
+	tipCount := def.Parameters().Count()
+
+	for i := 0; i < 3; i++ {
+		if err := s.Undo(); err != nil {
+			t.Fatalf("undo %d: %v", i, err)
+		}
+	}
+	if got := def.Parameters().Count(); got != tipCount-3 {
+		t.Fatalf("after undo×3: param count = %d, want %d", got, tipCount-3)
+	}
+	for i := 0; i < 3; i++ {
+		if err := s.Redo(); err != nil {
+			t.Fatalf("redo %d: %v", i, err)
+		}
+	}
+	if got := def.Parameters().Count(); got != tipCount {
+		t.Errorf("after redo×3: param count = %d, want %d", got, tipCount)
+	}
+	for _, n := range names {
+		if _, ok := def.Parameters().ByName(n); !ok {
+			t.Errorf("parameter %q missing after undo×3→redo×3; navigation is lossy", n)
+		}
+	}
+}
+
+// TestPerDocumentStreamsAreIsolated: each document owns its own stream — an edit in one
+// is invisible to another, and undo acts on the active document only.
+func TestPerDocumentStreamsAreIsolated(t *testing.T) {
+	s := NewSession()
+	a, err := s.NewPart()
+	if err != nil {
+		t.Fatalf("new part A: %v", err)
+	}
+	if err := s.AddNumericUserParameter("a0", "1 mm"); err != nil {
+		t.Fatalf("edit A: %v", err)
+	}
+
+	b, err := s.NewPart() // B becomes active, with an empty stream
+	if err != nil {
+		t.Fatalf("new part B: %v", err)
+	}
+	if s.CanUndo() {
+		t.Error("freshly created document B should have nothing to undo")
+	}
+
+	if err := s.Workspace().SetActiveDocument(a); err != nil {
+		t.Fatalf("activate A: %v", err)
+	}
+	if !s.CanUndo() || s.UndoLabel() != "Edit Parameters" {
+		t.Errorf("document A should still have its edit: CanUndo=%v label=%q", s.CanUndo(), s.UndoLabel())
+	}
+	_ = b
+}
+
+// TestUndoRedoKeyboardShortcuts checks the Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z bindings the
+// head forwards through PressKey, and that a bare "z" (no Ctrl) is not an undo.
+func TestUndoRedoKeyboardShortcuts(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	trackFromHere(s)
+	def := partOf(t, s)
+	if err := s.AddNumericUserParameter("d0", "10 mm"); err != nil {
+		t.Fatalf("add param: %v", err)
+	}
+	base := def.Parameters().Count()
+
+	if err := s.PressKey(KeyEvent{Key: "z", Mods: CtrlMod}); err != nil { // Ctrl+Z → undo
+		t.Fatalf("Ctrl+Z: %v", err)
+	}
+	if def.Parameters().Count() != base-1 {
+		t.Errorf("after Ctrl+Z: count = %d, want %d", def.Parameters().Count(), base-1)
+	}
+
+	if err := s.PressKey(KeyEvent{Key: "y", Mods: CtrlMod}); err != nil { // Ctrl+Y → redo
+		t.Fatalf("Ctrl+Y: %v", err)
+	}
+	if def.Parameters().Count() != base {
+		t.Errorf("after Ctrl+Y: count = %d, want %d", def.Parameters().Count(), base)
+	}
+
+	if err := s.PressKey(KeyEvent{Key: "z", Mods: CtrlMod | ShiftMod}); err == nil {
+		// Ctrl+Shift+Z is redo; nothing to redo here, so it returns the "nothing to redo"
+		// error — which proves it routed to redo, not undo.
+		t.Error("Ctrl+Shift+Z should have nothing to redo and error, but succeeded")
+	}
+
+	// A bare "z" is a command-alias lookup, never an undo.
+	if err := s.PressKey(KeyEvent{Key: "z"}); err != nil {
+		t.Fatalf("bare z: %v", err)
+	}
+	if def.Parameters().Count() != base {
+		t.Errorf("bare z changed the model (count=%d); only Ctrl+Z should undo", def.Parameters().Count())
+	}
+}

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -40,8 +40,9 @@ func (s *Session) CreateMidplaneWorkPlane() (*feature.WorkPlane, error) {
 	if len(planes) < 2 {
 		return nil, errors.New("app: select two work planes to make a midplane between them")
 	}
-	wp := part.WorkPlanes().AddByTwoPlanes(planes[0].Key(), planes[1].Key())
-	return finishWorkPlane(part, wp), nil
+	wp := finishWorkPlane(part, part.WorkPlanes().AddByTwoPlanes(planes[0].Key(), planes[1].Key()))
+	s.recordEdit(part, "Work Plane")
+	return wp, nil
 }
 
 // uniqueWorkPlaneName returns "Work Plane{n}" with the smallest n not already used by a
@@ -122,7 +123,9 @@ func (s *Session) CreateThreePointWorkPlane() (*feature.WorkPlane, error) {
 	if len(refs) < 3 {
 		return nil, errors.New("app: select three points (datum points or model vertices) for a three-point plane")
 	}
-	return finishWorkPlane(part, part.WorkPlanes().AddByThreePoints(refs[0], refs[1], refs[2])), nil
+	wp := finishWorkPlane(part, part.WorkPlanes().AddByThreePoints(refs[0], refs[1], refs[2]))
+	s.recordEdit(part, "Work Plane")
+	return wp, nil
 }
 
 // CreateNormalToAxisWorkPlane adds a work plane through the selected point, normal to the
@@ -136,7 +139,9 @@ func (s *Session) CreateNormalToAxisWorkPlane() (*feature.WorkPlane, error) {
 	if len(axes) < 1 || len(refs) < 1 {
 		return nil, errors.New("app: select an axis and a point for a normal-to-axis plane")
 	}
-	return finishWorkPlane(part, part.WorkPlanes().AddByNormalToCurve(axes[0].Key(), refs[0])), nil
+	wp := finishWorkPlane(part, part.WorkPlanes().AddByNormalToCurve(axes[0].Key(), refs[0]))
+	s.recordEdit(part, "Work Plane")
+	return wp, nil
 }
 
 // CreateTangentWorkPlane adds a work plane parallel to the selected plane and tangent to
@@ -151,8 +156,9 @@ func (s *Session) CreateTangentWorkPlane() (*feature.WorkPlane, error) {
 	if base == nil || !ok {
 		return nil, errors.New("app: select a plane and a face for a tangent plane")
 	}
-	wp := part.WorkPlanes().AddByPlaneAndTangent(base.Key(), feature.FaceRef(face.ReferenceKey()))
-	return finishWorkPlane(part, wp), nil
+	wp := finishWorkPlane(part, part.WorkPlanes().AddByPlaneAndTangent(base.Key(), feature.FaceRef(face.ReferenceKey())))
+	s.recordEdit(part, "Work Plane")
+	return wp, nil
 }
 
 // finishWorkPlane gives a freshly created datum a unique browser name and recomputes the

--- a/command/history.go
+++ b/command/history.go
@@ -47,6 +47,21 @@ func (h *History) Do(c Command) error {
 	return nil
 }
 
+// Record appends an already-applied command as a new undo step *without* applying
+// it, then clears the redo stream and fires one coalesced change. Use it (rather
+// than [History.Do]) for snapshot events whose mutation has already happened in the
+// model — the app edits the model, captures the before/after recipe, and records
+// the resulting [RecipeEvent]. If a transaction is open, the command joins it.
+func (h *History) Record(c Command) {
+	if h.open != nil {
+		h.open.cmds = append(h.open.cmds, c)
+		return
+	}
+	h.done = append(h.done, c)
+	h.undone = nil
+	h.notify()
+}
+
 // Len returns the number of committed undo steps.
 func (h *History) Len() int { return len(h.done) }
 

--- a/command/recipe_event.go
+++ b/command/recipe_event.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package command
+
+// RecipeStore is the seam a [RecipeEvent] navigates: something that can replace its
+// entire recipe with a previously-captured snapshot and recompute the geometry that
+// snapshot implies. A part's component definition satisfies it (MarshalRecipe captures
+// the snapshot the event stores; RestoreRecipe replaces+recomputes from it). Declared
+// here — and injected — so the command engine stays decoupled from the model packages
+// (no import of model/compdef; the dependency flows the other way).
+type RecipeStore interface {
+	// RestoreRecipe replaces the store's recipe (parameters, sketches, features, …)
+	// with the snapshot in model and recomputes the resulting geometry. It must be a
+	// full replace, not a merge, so navigating to any snapshot yields exactly that
+	// state regardless of what the store currently holds.
+	RestoreRecipe(model []byte) error
+}
+
+// RecipeEvent is one transaction event in a document's edit stream: it remembers
+// the recipe snapshot before and after a single interaction. Navigating the stream
+// (undo/redo) restores the corresponding snapshot and recomputes — so the current
+// model state is always the fold of the events up to the cursor, and moving the
+// cursor is O(1) restore rather than an O(n) replay from the document's open state.
+//
+// The mutation has already happened in the model when the event is built (the app
+// edits, then captures before/after), so the event is recorded via [History.Record]
+// (not Do): Apply re-establishes the after-snapshot for redo, Revert re-establishes
+// the before-snapshot for undo.
+type RecipeEvent struct {
+	label  string
+	before []byte
+	after  []byte
+	store  RecipeStore
+}
+
+// NewRecipeEvent builds a snapshot event from the before/after recipe bytes captured
+// around an interaction. before is the recipe as it was when the document reached
+// this point; after is the recipe the interaction produced.
+//
+// Example:
+//
+//	before, _ := def.MarshalRecipe()
+//	mutate()                          // the interaction
+//	after, _ := def.MarshalRecipe()
+//	history.Record(command.NewRecipeEvent("Extrude", before, after, def))
+func NewRecipeEvent(label string, before, after []byte, store RecipeStore) *RecipeEvent {
+	return &RecipeEvent{label: label, before: before, after: after, store: store}
+}
+
+// Label returns the event's undo-menu text.
+func (e *RecipeEvent) Label() string { return e.label }
+
+// Apply restores the after-snapshot and recomputes — the redo direction.
+func (e *RecipeEvent) Apply() error { return e.restore(e.after) }
+
+// Revert restores the before-snapshot and recomputes — the undo direction.
+func (e *RecipeEvent) Revert() error { return e.restore(e.before) }
+
+// restore replaces the store's recipe with one snapshot (which recomputes the geometry
+// it implies).
+func (e *RecipeEvent) restore(snapshot []byte) error {
+	return e.store.RestoreRecipe(snapshot)
+}

--- a/command/recipe_event_test.go
+++ b/command/recipe_event_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package command
+
+import "testing"
+
+// fakeRecipeStore is a named in-memory RecipeStore (CLAUDE.md: mock I/O with named
+// fakes). It records the snapshot it currently holds and counts restores, so a test
+// can assert exactly which snapshot a stream cursor restored.
+type fakeRecipeStore struct {
+	current  string
+	restores int
+}
+
+func (f *fakeRecipeStore) RestoreRecipe(model []byte) error {
+	f.current = string(model)
+	f.restores++
+	return nil
+}
+
+func TestRecipeEventApplyRevertRestoreSnapshots(t *testing.T) {
+	store := &fakeRecipeStore{current: "v1"}
+	e := NewRecipeEvent("Edit", []byte("v1"), []byte("v2"), store)
+	if e.Label() != "Edit" {
+		t.Fatalf("Label = %q", e.Label())
+	}
+	if err := e.Revert(); err != nil {
+		t.Fatalf("Revert: %v", err)
+	}
+	if store.current != "v1" {
+		t.Errorf("after Revert current = %q, want v1", store.current)
+	}
+	if err := e.Apply(); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if store.current != "v2" {
+		t.Errorf("after Apply current = %q, want v2", store.current)
+	}
+	if store.restores != 2 {
+		t.Errorf("restores = %d, want 2 (one per Apply/Revert)", store.restores)
+	}
+}
+
+// TestRecordNavigatesStreamWithoutReapplying is the core event-stream property: the
+// model is mutated first, the event is Recorded (not re-applied), and undo/redo move
+// a cursor through the stream restoring the right snapshot each step.
+func TestRecordNavigatesStreamWithoutReapplying(t *testing.T) {
+	store := &fakeRecipeStore{current: "base"}
+	h := NewHistory()
+
+	// Two interactions: base→a, then a→b. The model already holds the result when
+	// each event is recorded.
+	store.current = "a"
+	h.Record(NewRecipeEvent("first", []byte("base"), []byte("a"), store))
+	store.current = "b"
+	h.Record(NewRecipeEvent("second", []byte("a"), []byte("b"), store))
+
+	if got := store.restores; got != 0 {
+		t.Fatalf("Record must not restore; restores = %d", got)
+	}
+	if !h.CanUndo() || h.CanRedo() {
+		t.Fatalf("after two records: CanUndo=%v CanRedo=%v", h.CanUndo(), h.CanRedo())
+	}
+
+	if err := h.Undo(); err != nil { // cursor: b -> a
+		t.Fatalf("Undo: %v", err)
+	}
+	if store.current != "a" {
+		t.Errorf("after one undo current = %q, want a", store.current)
+	}
+	if err := h.Undo(); err != nil { // cursor: a -> base
+		t.Fatalf("Undo: %v", err)
+	}
+	if store.current != "base" {
+		t.Errorf("after two undos current = %q, want base", store.current)
+	}
+	if h.CanUndo() {
+		t.Error("cursor at start but CanUndo is true")
+	}
+
+	if err := h.Redo(); err != nil { // cursor: base -> a
+		t.Fatalf("Redo: %v", err)
+	}
+	if store.current != "a" {
+		t.Errorf("after redo current = %q, want a", store.current)
+	}
+}
+
+// TestRecordTruncatesRedoTail: an edit made after undo drops the events ahead of the
+// cursor (the redo branch), exactly like the done/Do path.
+func TestRecordTruncatesRedoTail(t *testing.T) {
+	store := &fakeRecipeStore{}
+	h := NewHistory()
+	h.Record(NewRecipeEvent("a", []byte("0"), []byte("1"), store))
+	h.Record(NewRecipeEvent("b", []byte("1"), []byte("2"), store))
+	_ = h.Undo() // cursor before "b"
+	if !h.CanRedo() {
+		t.Fatal("expected a redo branch after undo")
+	}
+	h.Record(NewRecipeEvent("c", []byte("1"), []byte("3"), store)) // new edit
+	if h.CanRedo() {
+		t.Error("new edit did not truncate the redo branch")
+	}
+	if want := []string{"a", "c"}; !equalStrings(h.UndoLabels(), want) {
+		t.Errorf("UndoLabels = %v, want %v", h.UndoLabels(), want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -12,6 +12,7 @@ void obk_ig_end_main_menu_bar(void);
 int  obk_ig_begin_menu(const char* label);
 void obk_ig_end_menu(void);
 int  obk_ig_menu_item(const char* label);
+int  obk_ig_menu_item_ex(const char* label, const char* shortcut, int enabled);
 int  obk_ig_begin(const char* name);
 void obk_ig_end(void);
 void obk_ig_text(const char* s);
@@ -56,6 +57,9 @@ void obk_ig_mouse_pos(float* x, float* y);
 int  obk_ig_key_shift(void);
 int  obk_ig_key_ctrl(void);
 int  obk_ig_escape_pressed(void);
+int  obk_ig_undo_pressed(void);
+int  obk_ig_redo_pressed(void);
+int  obk_ig_want_text_input(void);
 float obk_ig_mouse_wheel(void);
 float obk_ig_delta_time(void);
 void obk_ig_mouse_delta(float* dx, float* dy);
@@ -132,6 +136,18 @@ func MenuItem(label string) bool {
 	c, free := cstr(label)
 	defer free()
 	return C.obk_ig_menu_item(c) != 0
+}
+
+// MenuItemEx renders a menu item with a right-aligned shortcut hint and an enabled
+// state — a disabled item greys out and cannot be clicked (Inventor's Edit ▸ Undo when
+// there is nothing to undo). Reports whether it was activated this frame. shortcut "" or
+// enabled false are both honored.
+func MenuItemEx(label, shortcut string, enabled bool) bool {
+	cl, freeL := cstr(label)
+	defer freeL()
+	cs, freeS := cstr(shortcut)
+	defer freeS()
+	return C.obk_ig_menu_item_ex(cl, cs, cBool(enabled)) != 0
 }
 
 // Begin / End bracket a window; Begin reports whether its content is visible.
@@ -459,6 +475,17 @@ func KeyCtrl() bool { return C.obk_ig_key_ctrl() != 0 }
 
 // EscapePressed reports whether Esc was pressed this frame (cancel the active tool).
 func EscapePressed() bool { return C.obk_ig_escape_pressed() != 0 }
+
+// UndoPressed / RedoPressed report whether the Z / Y key was pressed this frame (the
+// caller pairs them with KeyCtrl and WantTextInput to form the Ctrl+Z / Ctrl+Y / Ctrl+
+// Shift+Z bindings only when no text field is capturing input).
+func UndoPressed() bool { return C.obk_ig_undo_pressed() != 0 }
+func RedoPressed() bool { return C.obk_ig_redo_pressed() != 0 }
+
+// WantTextInput reports whether an ImGui widget currently has keyboard text focus (a
+// text/number field being edited). Global shortcuts must be suppressed when it is true so
+// the field's own editing — including its built-in Ctrl+Z — keeps the keystroke.
+func WantTextInput() bool { return C.obk_ig_want_text_input() != 0 }
 
 // MouseWheel returns this frame's vertical scroll amount (zoom).
 func MouseWheel() float32 { return float32(C.obk_ig_mouse_wheel()) }

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -14,6 +14,12 @@ void obk_ig_end_main_menu_bar(void)          { ImGui::EndMainMenuBar(); }
 int  obk_ig_begin_menu(const char* label)    { return ImGui::BeginMenu(label) ? 1 : 0; }
 void obk_ig_end_menu(void)                   { ImGui::EndMenu(); }
 int  obk_ig_menu_item(const char* label)     { return ImGui::MenuItem(label) ? 1 : 0; }
+// menu_item_ex adds a right-aligned shortcut hint and an enabled flag (a disabled item
+// greys out and cannot be clicked). A "" shortcut passes NULL so none is drawn.
+int  obk_ig_menu_item_ex(const char* label, const char* shortcut, int enabled) {
+    const char* sc = (shortcut && shortcut[0]) ? shortcut : nullptr;
+    return ImGui::MenuItem(label, sc, false, enabled != 0) ? 1 : 0;
+}
 
 void obk_ig_set_next_window_pos(float x, float y)  { ImGui::SetNextWindowPos(ImVec2(x, y)); }
 void obk_ig_set_next_window_size(float w, float h) { ImGui::SetNextWindowSize(ImVec2(w, h)); }
@@ -182,6 +188,13 @@ int  obk_ig_key_shift(void)                  { return ImGui::GetIO().KeyShift ? 
 int  obk_ig_key_ctrl(void)                   { return ImGui::GetIO().KeyCtrl ? 1 : 0; }
 // escape_pressed fires once on the frame Esc is pressed (cancel the active tool).
 int  obk_ig_escape_pressed(void)             { return ImGui::IsKeyPressed(ImGuiKey_Escape) ? 1 : 0; }
+// undo/redo_pressed fire once on the frame Z / Y is pressed; the Go side gates them on
+// Ctrl (and not WantTextInput) to form the global Ctrl+Z / Ctrl+Y shortcuts.
+int  obk_ig_undo_pressed(void)               { return ImGui::IsKeyPressed(ImGuiKey_Z) ? 1 : 0; }
+int  obk_ig_redo_pressed(void)               { return ImGui::IsKeyPressed(ImGuiKey_Y) ? 1 : 0; }
+// want_text_input is true while a text/number field is being edited, so global shortcuts
+// stand down and let the field keep the keystroke (incl. its own Ctrl+Z).
+int  obk_ig_want_text_input(void)            { return ImGui::GetIO().WantTextInput ? 1 : 0; }
 float obk_ig_mouse_wheel(void)               { return ImGui::GetIO().MouseWheel; }
 float obk_ig_delta_time(void)                { return ImGui::GetIO().DeltaTime; }
 void obk_ig_mouse_delta(float* dx, float* dy) {

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -77,10 +77,25 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 }
 
 // handleKeyboard routes global shortcuts to the session. Esc cancels the active tool at
-// any point (or clears the selection when idle) — Inventor's universal cancel.
+// any point (or clears the selection when idle) — Inventor's universal cancel. Ctrl+Z /
+// Ctrl+Y (Ctrl+Shift+Z) navigate the undo stream, but only when no text field has focus,
+// so a field's own editing keeps the keystroke.
 func handleKeyboard(s *app.Session) {
 	if native.EscapePressed() {
 		_ = s.PressKey(app.KeyEvent{Key: "Escape"})
+	}
+	if !native.KeyCtrl() || native.WantTextInput() {
+		return
+	}
+	mods := app.CtrlMod
+	if native.KeyShift() {
+		mods |= app.ShiftMod
+	}
+	switch {
+	case native.UndoPressed():
+		_ = s.PressKey(app.KeyEvent{Key: "z", Mods: mods})
+	case native.RedoPressed():
+		_ = s.PressKey(app.KeyEvent{Key: "y", Mods: mods})
 	}
 }
 

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -31,6 +31,15 @@ func drawMenuBar(s *app.Session) string {
 		native.EndMenu()
 	}
 	if native.BeginMenu("Edit") {
+		// Undo/Redo name the step they act on (Inventor's "Undo Extrude") and grey out
+		// when the stream cursor is at an end. Keyboard equivalents: Ctrl+Z / Ctrl+Y.
+		if native.MenuItemEx(undoLabel("Undo", s.UndoLabel()), "Ctrl+Z", s.CanUndo()) {
+			_ = s.Undo()
+		}
+		if native.MenuItemEx(undoLabel("Redo", s.RedoLabel()), "Ctrl+Y", s.CanRedo()) {
+			_ = s.Redo()
+		}
+		native.Separator()
 		if native.MenuItem("Cancel Tool (Esc)") && s.ActiveTool() != nil {
 			s.CancelTool()
 		}
@@ -47,4 +56,13 @@ func drawMenuBar(s *app.Session) string {
 	}
 	native.EndMainMenuBar()
 	return ""
+}
+
+// undoLabel builds an Edit-menu label that names the step undo/redo would act on (e.g.
+// "Undo Extrude"), falling back to the bare verb when the stream cursor is at an end.
+func undoLabel(verb, step string) string {
+	if step == "" {
+		return verb
+	}
+	return verb + " " + step
 }

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -5,8 +5,10 @@ package compdef
 import (
 	"fmt"
 
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/model/doc"
 	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/identity"
 	"github.com/Oblikovati/oblikovati/model/material"
 	"github.com/Oblikovati/oblikovati/model/param"
 	"github.com/Oblikovati/oblikovati/model/sketch"
@@ -130,6 +132,35 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		r.EndOfPart = &eop
 	}
 	return yamlcodec.Marshal(r)
+}
+
+// RestoreRecipe replaces the part's entire recipe with the snapshot in model and
+// recomputes — the undo/redo restore path. Unlike [ApplyRecipe] (which loads onto a
+// fresh, empty definition and so merges additively), RestoreRecipe first resets the
+// definition to empty in place, so applying a snapshot to an already-populated part
+// yields exactly that snapshot rather than a union. The definition pointer is
+// preserved, so the document's Content and any held reference to it stay valid.
+func (d *PartComponentDefinition) RestoreRecipe(model []byte) error {
+	d.resetRecipe()
+	return d.ApplyRecipe(model)
+}
+
+// resetRecipe returns the definition's recipe-bearing state to the empty configuration
+// a freshly constructed part has (see [NewPartComponentDefinition]), reusing the
+// definition object so external references to it remain valid. Geometry is cleared too;
+// ApplyRecipe's recompute rebuilds it.
+func (d *PartComponentDefinition) resetRecipe() {
+	d.params = param.NewParameters()
+	d.keys = identity.NewKeyManager()
+	d.sketches = sketch.NewSketches()
+	d.sketches3D = sketch.NewSketches3D()
+	d.features = feature.NewPartFeatures(d.params, d.keys)
+	d.work = feature.NewWorkGeometry()
+	d.units = param.DefaultUnitsOfMeasure()
+	d.eop = endOfPartAtEnd
+	d.assignments = material.NewAssignmentStore()
+	d.assets = material.NewAssetSet()
+	d.bodies = topo.NewSurfaceBodies()
 }
 
 // ApplyRecipe restores the part from recipe YAML and recomputes (doc.RecipeContent).

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -118,6 +118,56 @@ func TestParametersSurviveRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRestoreRecipeReplacesRatherThanMerges is the regression test for the undo restore
+// path: applying a snapshot to an already-populated definition must yield exactly the
+// snapshot, not a union with what was there. (ApplyRecipe alone merges additively — it
+// is for loading onto a fresh part — so undo would otherwise duplicate sketches and
+// re-add parameters.)
+func TestRestoreRecipeReplacesRatherThanMerges(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, err := compdef.AddPart(ws, "Part1", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := d.Content().(*compdef.PartComponentDefinition)
+
+	// Snapshot an empty part, then populate it.
+	empty, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	def.Sketches().Add(sketch.XYPlane())
+	if _, err := def.Parameters().AddUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("add param: %v", err)
+	}
+	populated, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal populated: %v", err)
+	}
+
+	// Restoring the empty snapshot onto the populated part must clear the additions.
+	if err := def.RestoreRecipe(empty); err != nil {
+		t.Fatalf("RestoreRecipe(empty): %v", err)
+	}
+	if def.Sketches().Count() != 0 {
+		t.Errorf("after restore-empty: %d sketches, want 0 (merge, not replace)", def.Sketches().Count())
+	}
+	if _, ok := def.Parameters().ByName("w"); ok {
+		t.Error("after restore-empty: parameter w still present (merge, not replace)")
+	}
+
+	// Restoring the populated snapshot brings them back exactly once.
+	if err := def.RestoreRecipe(populated); err != nil {
+		t.Fatalf("RestoreRecipe(populated): %v", err)
+	}
+	if def.Sketches().Count() != 1 {
+		t.Errorf("after restore-populated: %d sketches, want 1", def.Sketches().Count())
+	}
+	if _, ok := def.Parameters().ByName("w"); !ok {
+		t.Error("after restore-populated: parameter w missing")
+	}
+}
+
 // TestParameterFieldsSurviveRoundTrip exercises the extended parameter recipe: text and
 // boolean parameters, comment/key/export/tolerance/multi-value state, and group membership.
 func TestParameterFieldsSurviveRoundTrip(t *testing.T) {


### PR DESCRIPTION
## What
Makes undo/redo actually work in the app, end to end.

- **`command`** — `RecipeEvent` stores the recipe snapshot before/after an interaction (memento) and navigates via a one-method `RecipeStore` seam; `History.Record` appends an already-applied event.
- **`model/compdef`** — `RestoreRecipe` replaces the part's whole recipe (reset in place, then `ApplyRecipe`), so navigating to any snapshot yields exactly that state. (Fixes a latent issue: plain `ApplyRecipe` merges additively — it's built for loading onto a fresh def — so undo would duplicate sketches / re-add params.)
- **`app`** — the `Session` owns one transaction stream per document, opened at `NewPart`/`OpenDocument`; every edit's existing `part.Recompute()` finalize records one event via `Session.recordEdit` (no-op guard skips unchanged recomputes). Edits now mark the document dirty.
- **UI** — Undo/Redo in the **Edit main menu** (named for the step, greyed at the ends of the stream) plus **Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z**, suppressed while a text field has focus.
- **`addin/router`** — serves `transaction.undo/redo/state` on the `api/wire` contract (paired API PR: Oblikovati/Oblikovati.API#12, merged).

## Why
The transaction engine (M04) was fully built and tested but unused — no edit routed through it and there was no UI/API, so undo did nothing in the running app. This adopts it, modeled as event sourcing: each interaction is a transaction event on a per-document stream; current state is the fold of events since open; undo/redo move a cursor (non-destructive).

## Tests
New e2e (`app/undo_test.go`): extrude undo/redo navigates geometry (body removed, sketch survives, redo restores); parameter undo + redo-branch truncation; per-document isolation; cursor round-trip fidelity; Ctrl+Z/Y bindings. Regression test for `RestoreRecipe` replace-vs-merge (`model/compdef`). Engine unit tests (`command`). Router + client round-trip tests. `make`-equivalent gates green locally (gofmt, vet, test 31/31); cgo head builds.

## Known follow-ups (not blockers)
- API/add-in *edit* paths (router `parameters.set`, `features.add`) bypass the Session edit methods, so add-in-driven edits aren't recorded as events yet.
- Recipe marshal isn't byte-idempotent across reset+apply (IDs reassigned) — undo *state* is correct, raw bytes differ.
- No document-close path exists yet, so per-document streams aren't pruned on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)