### PR TITLE
Boolean robustness (twisted-loft), pattern source-tool replication, full MCP diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,46 @@ jobs:
       - run: go mod edit -replace github.com/Oblikovati/api="$GITHUB_WORKSPACE/_api"
       - run: go test -race ./...
 
+  # cgo GUI head (Vulkan + Dear ImGui). The PR test/race/build jobs above run `./...`
+  # on the ROOT module only and with CGO_ENABLED=0, so the head module was previously
+  # never compiled OR tested on a PR — its build could break and its end-to-end UI
+  # in-window tests never ran (they `t.Skip` when no Vulkan/display is present). This
+  # job closes that gap (REPORT.md §8 / DoD U-axis):
+  #   1. builds the whole head module (catches cgo/binding breakage on every PR);
+  #   2. runs head tests under a SOFTWARE Vulkan ICD (mesa lavapipe) + a virtual
+  #      display (xvfb) so the in-window e2e tests actually execute instead of
+  #      skipping. Tests still skip cleanly if lavapipe can't provide a device, so
+  #      the job never goes flaky — but on a healthy runner the UI tests run for real.
+  head:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: Oblikovati/Oblikovati.API
+          ref: develop
+          path: _api
+      - uses: actions/setup-go@v5
+        with:
+          # Match build.yml's head-linux toolchain.
+          go-version: "1.24"
+          cache: false
+      - run: go -C head mod edit -replace github.com/Oblikovati/api="$GITHUB_WORKSPACE/_api"
+      - name: Install cgo + headless-Vulkan deps
+        run: |
+          sudo apt-get update
+          # libglfw3-dev/libvulkan-dev/pkg-config: the cgo build (head/internal/native
+          # uses `#cgo pkg-config: glfw3 vulkan`). mesa-vulkan-drivers: lavapipe software
+          # ICD so a GPU-less runner still exposes a Vulkan 1.3 device. xvfb: a virtual
+          # X display so GLFW window creation succeeds headlessly.
+          sudo apt-get install -y libglfw3-dev libvulkan-dev pkg-config mesa-vulkan-drivers xvfb
+      - name: Build head
+        working-directory: head
+        run: CGO_ENABLED=1 go build ./...
+      - name: Test head (xvfb + lavapipe)
+        working-directory: head
+        run: xvfb-run -a go test ./...
+
   # Confirm the cgo-free core cross-compiles for every shipping target.
   build:
     runs-on: ubuntu-latest

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The dress-up (subtractive/modifying) feature operations — fillet, chamfer, shell, draft.
+// Each acts on an existing body's edges or faces, referenced by key (get_reference_keys), and
+// follows the extrude descriptor shape: a JSON schema + an Apply that builds the feature and
+// recomputes. They are how an MCP driver exercises the subtractive kernel end to end.
+
+// edgeDressArgs is the shared shape of the edge-referencing operations (fillet, chamfer).
+type edgeDressArgs struct {
+	EdgeRefs []string `json:"edgeRefs"`
+	Radius   string   `json:"radius,omitempty"`   // fillet
+	Distance string   `json:"distance,omitempty"` // chamfer
+}
+
+const filletSchema = `{
+  "type": "object",
+  "properties": {
+    "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to round (from get_reference_keys)."},
+    "radius": {"type": "string", "description": "Fillet radius with units, e.g. \"3 mm\"."}
+  },
+  "required": ["edgeRefs", "radius"]
+}`
+
+const chamferSchema = `{
+  "type": "object",
+  "properties": {
+    "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to bevel (from get_reference_keys)."},
+    "distance": {"type": "string", "description": "Chamfer setback with units, e.g. \"2 mm\"."}
+  },
+  "required": ["edgeRefs", "distance"]
+}`
+
+func filletDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "fillet", Summary: "Round picked edges of a body by a radius.", Schema: json.RawMessage(filletSchema), Apply: applyFillet}
+}
+
+func chamferDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "chamfer", Summary: "Bevel picked edges of a body by a setback distance.", Schema: json.RawMessage(chamferSchema), Apply: applyChamfer}
+}
+
+func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in edgeDressArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.EdgeRefs) == 0 {
+		return nil, errors.New("fillet: edgeRefs is empty")
+	}
+	r, err := lengthValue(part, in.Radius, "fillet: radius")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddFillet(refKeys(in.EdgeRefs), constFn(r))
+	return recomputeResult(part, pf)
+}
+
+func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in edgeDressArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.EdgeRefs) == 0 {
+		return nil, errors.New("chamfer: edgeRefs is empty")
+	}
+	d, err := lengthValue(part, in.Distance, "chamfer: distance")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddChamfer(refKeys(in.EdgeRefs), constFn(d))
+	return recomputeResult(part, pf)
+}
+
+// faceDressArgs is the shared shape of the face-referencing operations (shell, draft).
+type faceDressArgs struct {
+	FaceRefs  []string `json:"faceRefs"`
+	Thickness string   `json:"thickness,omitempty"` // shell
+	Angle     string   `json:"angle,omitempty"`     // draft
+}
+
+const shellSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to remove, hollowing the body (from get_reference_keys)."},
+    "thickness": {"type": "string", "description": "Remaining wall thickness with units, e.g. \"1 mm\"."}
+  },
+  "required": ["faceRefs", "thickness"]
+}`
+
+const draftSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to draft (from get_reference_keys)."},
+    "angle": {"type": "string", "description": "Draft angle with units, e.g. \"3 deg\"."}
+  },
+  "required": ["faceRefs", "angle"]
+}`
+
+func shellDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "shell", Summary: "Hollow a body to a wall thickness, removing the picked faces.", Schema: json.RawMessage(shellSchema), Apply: applyShell}
+}
+
+func draftDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "draft", Summary: "Taper picked faces by a draft angle.", Schema: json.RawMessage(draftSchema), Apply: applyDraft}
+}
+
+func applyShell(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in faceDressArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.FaceRefs) == 0 {
+		return nil, errors.New("shell: faceRefs is empty")
+	}
+	th, err := lengthValue(part, in.Thickness, "shell: thickness")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddShell(refKeys(in.FaceRefs), constFn(th))
+	return recomputeResult(part, pf)
+}
+
+func applyDraft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in faceDressArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.FaceRefs) == 0 {
+		return nil, errors.New("draft: faceRefs is empty")
+	}
+	a, err := angleValue(part, in.Angle, "draft: angle")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddDraft(refKeys(in.FaceRefs), constFn(a))
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/extrude.go
+++ b/addin/opregistry/extrude.go
@@ -29,13 +29,6 @@ type extrudeArgs struct {
 	Taper          string `json:"taper,omitempty"`          // draft angle, e.g. "3 deg"
 }
 
-// extrudeResult reports the created feature and the resulting body count.
-type extrudeResult struct {
-	Feature string `json:"feature"`
-	Kind    string `json:"kind"`
-	Bodies  int    `json:"bodies"`
-}
-
 const extrudeSchema = `{
   "type": "object",
   "properties": {
@@ -74,8 +67,9 @@ func applyExtrude(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	}
 	pf := feature.NewExtrudeFeatures(part.Features()).
 		AddExtrude(sk, []int{in.ProfileIndex}, op, extent, taper)
-	part.Recompute()
-	return json.Marshal(extrudeResult{Feature: pf.Name(), Kind: pf.Kind(), Bodies: len(part.SurfaceBodies().All())})
+	// Uniform feature result (feature/kind/bodies/healthy/reason), shared with every other
+	// operation so callers read one shape — and so an unhealthy extrude is reported, not hidden.
+	return recomputeResult(part, pf)
 }
 
 // resolveExtrude decodes and validates the extrude args against the part: the target

--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// The remaining feature operations that need a custom resolver: sweep (a profile along a path
+// sketch's chain), move body (a transform), replace face, core/cavity tooling, split solid by
+// a work plane, and a sketch-driven pattern.
+
+// --- sweep -----------------------------------------------------------------
+
+type sweepArgs struct {
+	SketchIndex     int    `json:"sketchIndex"`
+	ProfileIndex    int    `json:"profileIndex"`
+	PathSketchIndex int    `json:"pathSketchIndex"`
+	PathIndex       int    `json:"pathIndex"`
+	Twist           string `json:"twist,omitempty"`
+	Operation       string `json:"operation,omitempty"`
+}
+
+const sweepSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the profile to sweep."},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "pathSketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the open path (rail) to sweep along."},
+    "pathIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which open path of the path sketch (see list_sketch_profiles / the sketch's chains)."},
+    "twist": {"type": "string", "description": "Optional twist along the path, e.g. \"90 deg\"."},
+    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
+  },
+  "required": ["sketchIndex", "pathSketchIndex"]
+}`
+
+func sweepDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "sweep", Summary: "Sweep a profile along an open path (rail) into a solid.", Schema: json.RawMessage(sweepSchema), Apply: applySweep}
+}
+
+func applySweep(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in sweepArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	profileSk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	path, err := pathFromSketch(part, in.PathSketchIndex, in.PathIndex)
+	if err != nil {
+		return nil, err
+	}
+	twist := 0.0
+	if strings.TrimSpace(in.Twist) != "" {
+		if twist, err = angleValue(part, in.Twist, "sweep: twist"); err != nil {
+			return nil, err
+		}
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewSweepFeatures(part.Features()).Add(profileSk, in.ProfileIndex, path, constFn(twist), op)
+	return recomputeResult(part, pf)
+}
+
+// pathFromSketch lifts a 2D sketch's open path (chain) to a 3D sweep rail via the sketch's
+// plane — the same construction the interactive sweep tool uses.
+func pathFromSketch(part *compdef.PartComponentDefinition, sketchIndex, pathIndex int) (*sketch.Path3D, error) {
+	sk, err := sketchAt(part, sketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	paths := sk.Paths()
+	if pathIndex < 0 || pathIndex >= len(paths) {
+		return nil, fmt.Errorf("sweep: path %d not found (path sketch has %d paths)", pathIndex, len(paths))
+	}
+	p := paths[pathIndex]
+	plane := sk.Plane()
+	pts := p.Points()
+	chain := make([]*sketch.Point3D, len(pts))
+	for i, q := range pts {
+		chain[i] = sketch.NewPoint3D(plane.ToModel(q))
+	}
+	return sketch.NewPath3D(chain, p.IsClosed()), nil
+}
+
+// --- move body -------------------------------------------------------------
+
+type moveBodyArgs struct {
+	BodyIndex   int       `json:"bodyIndex"`
+	Translation []float64 `json:"translation"`
+}
+
+const moveBodySchema = `{
+  "type": "object",
+  "properties": {
+    "bodyIndex": {"type": "integer", "minimum": 0, "description": "Body to move (model.tree body order)."},
+    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Move vector [x,y,z] in cm."}
+  },
+  "required": ["bodyIndex", "translation"]
+}`
+
+func moveBodyDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "moveBody", Summary: "Move a solid body by a translation.", Schema: json.RawMessage(moveBodySchema), Apply: applyMoveBody}
+}
+
+func applyMoveBody(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in moveBodyArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	t, err := vec3(in.Translation, "moveBody: translation")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddMove(in.BodyIndex, math.Translation4(t))
+	return recomputeResult(part, pf)
+}
+
+// --- replace face ----------------------------------------------------------
+
+type replaceFaceArgs struct {
+	FaceRefs  []string `json:"faceRefs"`
+	TargetRef string   `json:"targetRef"`
+}
+
+const replaceFaceSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to replace (get_reference_keys)."},
+    "targetRef": {"type": "string", "description": "Reference key of the face whose surface replaces them."}
+  },
+  "required": ["faceRefs", "targetRef"]
+}`
+
+func replaceFaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "replaceFace", Summary: "Replace picked faces with another face's surface (direct edit).", Schema: json.RawMessage(replaceFaceSchema), Apply: applyReplaceFace}
+}
+
+func applyReplaceFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in replaceFaceArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.FaceRefs) == 0 || in.TargetRef == "" {
+		return nil, errors.New("replaceFace: faceRefs and targetRef are required")
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddReplaceFace(refKeys(in.FaceRefs), []byte(in.TargetRef))
+	return recomputeResult(part, pf)
+}
+
+// --- core/cavity -----------------------------------------------------------
+
+type coreCavityArgs struct {
+	Axis      string  `json:"axis,omitempty"`
+	Position  string  `json:"position"`
+	Shrinkage float64 `json:"shrinkage,omitempty"`
+}
+
+const coreCavitySchema = `{
+  "type": "object",
+  "properties": {
+    "axis": {"type": "string", "enum": ["z", "x", "y"], "default": "z", "description": "Draw direction the parting plane is perpendicular to."},
+    "position": {"type": "string", "description": "Parting-plane position along the axis, e.g. \"10 mm\"."},
+    "shrinkage": {"type": "number", "default": 0, "description": "Shrinkage compensation fraction, e.g. 0.02."}
+  },
+  "required": ["position"]
+}`
+
+func coreCavityDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "coreCavity", Summary: "Split the body at a parting plane into core and cavity tooling.", Schema: json.RawMessage(coreCavitySchema), Apply: applyCoreCavity}
+}
+
+func applyCoreCavity(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in coreCavityArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	pos, err := lengthValue(part, in.Position, "coreCavity: position")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewCoreCavityFeatures(part.Features()).AddByPartingPlane(partingAxis(in.Axis), pos, in.Shrinkage)
+	return recomputeResult(part, pf)
+}
+
+func partingAxis(name string) feature.PartingAxis {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "x":
+		return feature.PartingX
+	case "y":
+		return feature.PartingY
+	default:
+		return feature.PartingZ
+	}
+}
+
+// --- split solid -----------------------------------------------------------
+
+type splitSolidArgs struct {
+	WorkPlaneIndex int    `json:"workPlaneIndex"`
+	Keep           string `json:"keep,omitempty"`
+}
+
+const splitSolidSchema = `{
+  "type": "object",
+  "properties": {
+    "workPlaneIndex": {"type": "integer", "minimum": 0, "description": "Index of the work plane to split along (see list_work_planes)."},
+    "keep": {"type": "string", "enum": ["both", "positive", "negative"], "default": "both", "description": "Which side(s) of the plane to keep."}
+  },
+  "required": ["workPlaneIndex"]
+}`
+
+func splitSolidDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "splitSolid", Summary: "Split the solid along a work plane, keeping one or both halves.", Schema: json.RawMessage(splitSolidSchema), Apply: applySplitSolid}
+}
+
+func applySplitSolid(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in splitSolidArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	planes := part.WorkPlanes()
+	if in.WorkPlaneIndex < 0 || in.WorkPlaneIndex >= planes.Count() {
+		return nil, fmt.Errorf("splitSolid: work plane %d out of range (part has %d)", in.WorkPlaneIndex, planes.Count())
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddSplitSolid(planes.Item(in.WorkPlaneIndex), splitSide(in.Keep))
+	return recomputeResult(part, pf)
+}
+
+func splitSide(name string) feature.SplitSide {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "positive":
+		return feature.SplitPositive
+	case "negative":
+		return feature.SplitNegative
+	default:
+		return feature.SplitBoth
+	}
+}
+
+// --- sketch-driven pattern -------------------------------------------------
+
+type sketchDrivenArgs struct {
+	SourceFeatures []string    `json:"sourceFeatures"`
+	Points         [][]float64 `json:"points"`
+}
+
+const sketchDrivenSchema = `{
+  "type": "object",
+  "properties": {
+    "sourceFeatures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Names of the features to replicate (see model.tree)."},
+    "points": {"type": "array", "minItems": 1, "items": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}, "description": "Placement points [[x,y,z],...] in cm, one occurrence per point."}
+  },
+  "required": ["sourceFeatures", "points"]
+}`
+
+func sketchDrivenDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "patternSketchDriven", Summary: "Replicate features at a set of points (sketch-driven pattern).", Schema: json.RawMessage(sketchDrivenSchema), Apply: applySketchDriven}
+}
+
+func applySketchDriven(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in sketchDrivenArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	ids, err := featureIDsByName(part, in.SourceFeatures)
+	if err != nil {
+		return nil, err
+	}
+	pts := make([]math.Point3, len(in.Points))
+	for i, p := range in.Points {
+		if pts[i], err = point3(p, "patternSketchDriven: points"); err != nil {
+			return nil, err
+		}
+	}
+	feature.NewPatternFeatures(part.Features()).AddSketchDriven(ids, func() []math.Point3 { return pts })
+	return lastFeatureResult(part)
+}

--- a/addin/opregistry/feature_extras.go
+++ b/addin/opregistry/feature_extras.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// Two more face-referenced features: a boss (a cylindrical stud raised from a face) and a
+// cosmetic thread applied to a cylindrical face. Both take a single faceRef reference key.
+
+type bossArgs struct {
+	FaceRef  string `json:"faceRef"`
+	Diameter string `json:"diameter"`
+	Height   string `json:"height"`
+}
+
+const bossSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRef": {"type": "string", "description": "Reference key of the planar face to grow the boss from (get_reference_keys)."},
+    "diameter": {"type": "string", "description": "Boss diameter, e.g. \"8 mm\"."},
+    "height": {"type": "string", "description": "Boss height, e.g. \"5 mm\"."}
+  },
+  "required": ["faceRef", "diameter", "height"]
+}`
+
+func bossDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "boss", Summary: "Raise a cylindrical boss from a face.", Schema: json.RawMessage(bossSchema), Apply: applyBoss}
+}
+
+func applyBoss(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in bossArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.FaceRef == "" {
+		return nil, errors.New("boss: faceRef is empty")
+	}
+	dia, err := lengthValue(part, in.Diameter, "boss: diameter")
+	if err != nil {
+		return nil, err
+	}
+	h, err := lengthValue(part, in.Height, "boss: height")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewBossFeatures(part.Features()).Add([]byte(in.FaceRef), constFn(dia), constFn(h))
+	return recomputeResult(part, pf)
+}
+
+type threadArgs struct {
+	FaceRef     string `json:"faceRef"`
+	Designation string `json:"designation"`
+}
+
+const threadSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRef": {"type": "string", "description": "Reference key of the cylindrical face to thread (get_reference_keys)."},
+    "designation": {"type": "string", "description": "Thread designation, e.g. \"M8x1.25\"."}
+  },
+  "required": ["faceRef", "designation"]
+}`
+
+func threadDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "thread", Summary: "Apply a cosmetic thread to a cylindrical face.", Schema: json.RawMessage(threadSchema), Apply: applyThread}
+}
+
+func applyThread(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in threadArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.FaceRef == "" || in.Designation == "" {
+		return nil, errors.New("thread: faceRef and designation are required")
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddThread([]byte(in.FaceRef), in.Designation)
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/feature_freeform.go
+++ b/addin/opregistry/feature_freeform.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The freeform (T-spline) primitive features: a box, a plane, and a quadball, each a
+// subdivision cage that becomes editable freeform geometry. They take only dimensions and a
+// subdivision level — no sketch or body — so they are the simplest add_feature kinds to drive.
+
+type freeformArgs struct {
+	SizeX  string `json:"sizeX,omitempty"`
+	SizeY  string `json:"sizeY,omitempty"`
+	SizeZ  string `json:"sizeZ,omitempty"`
+	Radius string `json:"radius,omitempty"`
+	Level  int    `json:"level,omitempty"`
+}
+
+const freeformBoxSchema = `{
+  "type": "object",
+  "properties": {
+    "sizeX": {"type": "string", "description": "Box X size, e.g. \"40 mm\"."},
+    "sizeY": {"type": "string", "description": "Box Y size, e.g. \"30 mm\"."},
+    "sizeZ": {"type": "string", "description": "Box Z size, e.g. \"20 mm\"."},
+    "level": {"type": "integer", "minimum": 0, "default": 1, "description": "Subdivision level of the cage."}
+  },
+  "required": ["sizeX", "sizeY", "sizeZ"]
+}`
+
+const freeformPlaneSchema = `{
+  "type": "object",
+  "properties": {
+    "sizeX": {"type": "string", "description": "Plane X size, e.g. \"40 mm\"."},
+    "sizeY": {"type": "string", "description": "Plane Y size, e.g. \"30 mm\"."},
+    "level": {"type": "integer", "minimum": 0, "default": 1}
+  },
+  "required": ["sizeX", "sizeY"]
+}`
+
+const freeformQuadBallSchema = `{
+  "type": "object",
+  "properties": {
+    "radius": {"type": "string", "description": "Quadball radius, e.g. \"20 mm\"."},
+    "level": {"type": "integer", "minimum": 0, "default": 1}
+  },
+  "required": ["radius"]
+}`
+
+func freeformBoxDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "freeformBox", Summary: "Create a freeform (T-spline) box primitive.", Schema: json.RawMessage(freeformBoxSchema), Apply: applyFreeformBox}
+}
+
+func freeformPlaneDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "freeformPlane", Summary: "Create a freeform (T-spline) plane primitive.", Schema: json.RawMessage(freeformPlaneSchema), Apply: applyFreeformPlane}
+}
+
+func freeformQuadBallDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "freeformQuadBall", Summary: "Create a freeform (T-spline) quadball (sphere) primitive.", Schema: json.RawMessage(freeformQuadBallSchema), Apply: applyFreeformQuadBall}
+}
+
+func applyFreeformBox(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFreeform(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	sx, err := lengthValue(part, in.SizeX, "freeformBox: sizeX")
+	if err != nil {
+		return nil, err
+	}
+	sy, err := lengthValue(part, in.SizeY, "freeformBox: sizeY")
+	if err != nil {
+		return nil, err
+	}
+	sz, err := lengthValue(part, in.SizeZ, "freeformBox: sizeZ")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewFreeformFeatures(part.Features()).AddBox(sx, sy, sz, freeformLevel(in.Level))
+	return recomputeResult(part, pf)
+}
+
+func applyFreeformPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFreeform(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	sx, err := lengthValue(part, in.SizeX, "freeformPlane: sizeX")
+	if err != nil {
+		return nil, err
+	}
+	sy, err := lengthValue(part, in.SizeY, "freeformPlane: sizeY")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewFreeformFeatures(part.Features()).AddPlane(sx, sy, freeformLevel(in.Level))
+	return recomputeResult(part, pf)
+}
+
+func applyFreeformQuadBall(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFreeform(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	r, err := lengthValue(part, in.Radius, "freeformQuadBall: radius")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewFreeformFeatures(part.Features()).AddQuadBall(r, freeformLevel(in.Level))
+	return recomputeResult(part, pf)
+}
+
+func decodeFreeform(s *app.Session, raw json.RawMessage) (*compdef.PartComponentDefinition, freeformArgs, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, freeformArgs{}, err
+	}
+	var in freeformArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, freeformArgs{}, err
+	}
+	return part, in, nil
+}
+
+func freeformLevel(level int) int {
+	if level <= 0 {
+		return 1
+	}
+	return level
+}

--- a/addin/opregistry/feature_modify.go
+++ b/addin/opregistry/feature_modify.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The direct-edit / modify features: combine (boolean two bodies), thicken (a surface body),
+// trim (by a plane), and the face direct edits (move/offset/delete/split). Body inputs are
+// indices (model.tree body order); face inputs are reference keys (get_reference_keys).
+
+// --- combine ---------------------------------------------------------------
+
+type combineArgs struct {
+	TargetIndex int    `json:"targetIndex"`
+	ToolIndex   int    `json:"toolIndex"`
+	Operation   string `json:"operation"`
+}
+
+const combineSchema = `{
+  "type": "object",
+  "properties": {
+    "targetIndex": {"type": "integer", "minimum": 0, "description": "Body kept (index in model.tree body order)."},
+    "toolIndex": {"type": "integer", "minimum": 0, "description": "Body combined into the target."},
+    "operation": {"type": "string", "enum": ["join", "cut", "intersect"], "default": "join"}
+  },
+  "required": ["targetIndex", "toolIndex", "operation"]
+}`
+
+func combineDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "combine", Summary: "Boolean two solid bodies (join/cut/intersect).", Schema: json.RawMessage(combineSchema), Apply: applyCombine}
+}
+
+func applyCombine(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in combineArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddCombine(in.TargetIndex, in.ToolIndex, op)
+	return recomputeResult(part, pf)
+}
+
+// --- thicken ---------------------------------------------------------------
+
+type thickenArgs struct {
+	Thickness string `json:"thickness"`
+}
+
+const thickenSchema = `{
+  "type": "object",
+  "properties": {"thickness": {"type": "string", "description": "Wall thickness to add to the surface body, e.g. \"2 mm\"."}},
+  "required": ["thickness"]
+}`
+
+func thickenDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "thicken", Summary: "Thicken a surface body into a solid.", Schema: json.RawMessage(thickenSchema), Apply: applyThicken}
+}
+
+func applyThicken(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in thickenArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	th, err := lengthValue(part, in.Thickness, "thicken: thickness")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddThicken(th)
+	return recomputeResult(part, pf)
+}
+
+// --- trim ------------------------------------------------------------------
+
+type trimArgs struct {
+	Origin       []float64 `json:"origin"`
+	Normal       []float64 `json:"normal"`
+	KeepPositive bool      `json:"keepPositive,omitempty"`
+}
+
+const trimSchema = `{
+  "type": "object",
+  "properties": {
+    "origin": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Cutting-plane origin [x,y,z] in cm."},
+    "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Cutting-plane normal [x,y,z]."},
+    "keepPositive": {"type": "boolean", "default": true, "description": "Keep the half on the +normal side."}
+  },
+  "required": ["origin", "normal"]
+}`
+
+func trimDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "trim", Summary: "Trim the body with a cutting plane, keeping one half.", Schema: json.RawMessage(trimSchema), Apply: applyTrim}
+}
+
+func applyTrim(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in trimArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	origin, err := point3(in.Origin, "trim: origin")
+	if err != nil {
+		return nil, err
+	}
+	normal, err := vec3(in.Normal, "trim: normal")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewTrimFeatures(part.Features()).AddByPlane(origin, normal, in.KeepPositive)
+	return recomputeResult(part, pf)
+}
+
+// --- face direct edits (move / offset / delete / split) --------------------
+
+type faceEditArgs struct {
+	FaceRefs    []string  `json:"faceRefs"`
+	Translation []float64 `json:"translation,omitempty"` // moveFace
+	Distance    string    `json:"distance,omitempty"`    // faceOffset
+}
+
+const moveFaceSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to move (get_reference_keys)."},
+    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Move vector [x,y,z] in cm."}
+  },
+  "required": ["faceRefs", "translation"]
+}`
+
+const faceOffsetSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to offset (get_reference_keys)."},
+    "distance": {"type": "string", "description": "Offset distance with units, e.g. \"2 mm\"."}
+  },
+  "required": ["faceRefs", "distance"]
+}`
+
+const deleteFaceSchema = `{
+  "type": "object",
+  "properties": {"faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to delete (get_reference_keys)."}},
+  "required": ["faceRefs"]
+}`
+
+const splitFaceSchema = `{
+  "type": "object",
+  "properties": {"faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to split (get_reference_keys)."}},
+  "required": ["faceRefs"]
+}`
+
+func moveFaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "moveFace", Summary: "Move picked faces by a vector (direct edit).", Schema: json.RawMessage(moveFaceSchema), Apply: applyMoveFace}
+}
+
+func faceOffsetDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "faceOffset", Summary: "Offset picked faces by a distance (direct edit).", Schema: json.RawMessage(faceOffsetSchema), Apply: applyFaceOffset}
+}
+
+func deleteFaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "deleteFace", Summary: "Delete picked faces, healing the body (direct edit).", Schema: json.RawMessage(deleteFaceSchema), Apply: applyDeleteFace}
+}
+
+func splitFaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "split", Summary: "Split picked faces along their intersections (direct edit).", Schema: json.RawMessage(splitFaceSchema), Apply: applySplitFace}
+}
+
+func applyMoveFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFaceEdit(s, raw, "moveFace")
+	if err != nil {
+		return nil, err
+	}
+	t, err := vec3(in.Translation, "moveFace: translation")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddMoveFace(refKeys(in.FaceRefs), t)
+	return recomputeResult(part, pf)
+}
+
+func applyFaceOffset(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFaceEdit(s, raw, "faceOffset")
+	if err != nil {
+		return nil, err
+	}
+	d, err := lengthValue(part, in.Distance, "faceOffset: distance")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddFaceOffset(refKeys(in.FaceRefs), d)
+	return recomputeResult(part, pf)
+}
+
+func applyDeleteFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFaceEdit(s, raw, "deleteFace")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddDeleteFace(refKeys(in.FaceRefs))
+	return recomputeResult(part, pf)
+}
+
+func applySplitFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeFaceEdit(s, raw, "split")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddSplit(refKeys(in.FaceRefs))
+	return recomputeResult(part, pf)
+}
+
+// decodeFaceEdit is the shared front of the face direct-edit operations: active part + decoded
+// args with a non-empty faceRefs.
+func decodeFaceEdit(s *app.Session, raw json.RawMessage, op string) (*compdef.PartComponentDefinition, faceEditArgs, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, faceEditArgs{}, err
+	}
+	var in faceEditArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, faceEditArgs{}, err
+	}
+	if len(in.FaceRefs) == 0 {
+		return nil, faceEditArgs{}, errors.New(op + ": faceRefs is empty")
+	}
+	return part, in, nil
+}

--- a/addin/opregistry/feature_pattern.go
+++ b/addin/opregistry/feature_pattern.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The pattern features replicate one or more existing features (referenced by name, as shown
+// in model.tree) — rectangular grid, circular array, and mirror. The source features are
+// resolved to their ids; the layout is given numerically (counts, steps, axis, plane normal).
+
+type patternArgs struct {
+	SourceFeatures []string  `json:"sourceFeatures"`
+	CountX         int       `json:"countX,omitempty"`
+	CountY         int       `json:"countY,omitempty"`
+	StepX          []float64 `json:"stepX,omitempty"`
+	StepY          []float64 `json:"stepY,omitempty"`
+	Count          int       `json:"count,omitempty"`
+	Angle          string    `json:"angle,omitempty"`
+	AxisPoint      []float64 `json:"axisPoint,omitempty"`
+	AxisDir        []float64 `json:"axisDir,omitempty"`
+	Normal         []float64 `json:"normal,omitempty"`
+	Origin         []float64 `json:"origin,omitempty"`
+}
+
+const rectPatternSchema = `{
+  "type": "object",
+  "properties": {
+    "sourceFeatures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Names of the features to replicate (see model.tree), e.g. [\"Extrusion1\"]."},
+    "countX": {"type": "integer", "minimum": 1, "default": 2},
+    "countY": {"type": "integer", "minimum": 1, "default": 1},
+    "stepX": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the first direction [x,y,z] in cm."},
+    "stepY": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the second direction [x,y,z] in cm."}
+  },
+  "required": ["sourceFeatures", "stepX"]
+}`
+
+const circPatternSchema = `{
+  "type": "object",
+  "properties": {
+    "sourceFeatures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Names of the features to replicate (see model.tree)."},
+    "count": {"type": "integer", "minimum": 1, "default": 4},
+    "angle": {"type": "string", "description": "Total sweep angle, e.g. \"360 deg\"."},
+    "axisPoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "A point on the rotation axis [x,y,z] (default origin)."},
+    "axisDir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Rotation axis direction [x,y,z] (default +Z)."}
+  },
+  "required": ["sourceFeatures", "count", "angle"]
+}`
+
+const mirrorSchema = `{
+  "type": "object",
+  "properties": {
+    "sourceFeatures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Names of the features to mirror (see model.tree)."},
+    "origin": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "A point on the mirror plane [x,y,z] (default origin)."},
+    "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Mirror-plane normal [x,y,z], e.g. [1,0,0] for the YZ plane."}
+  },
+  "required": ["sourceFeatures", "normal"]
+}`
+
+func rectPatternDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "patternRectangular", Summary: "Replicate features on a rectangular grid.", Schema: json.RawMessage(rectPatternSchema), Apply: applyRectPattern}
+}
+
+func circPatternDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "patternCircular", Summary: "Replicate features in a circular array about an axis.", Schema: json.RawMessage(circPatternSchema), Apply: applyCircPattern}
+}
+
+func mirrorDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "mirror", Summary: "Mirror features across a plane.", Schema: json.RawMessage(mirrorSchema), Apply: applyMirror}
+}
+
+// decodePattern resolves the active part, decoded args, and the source-feature ids common to
+// every pattern operation.
+func decodePattern(s *app.Session, raw json.RawMessage) (*compdef.PartComponentDefinition, patternArgs, []feature.ID, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, patternArgs{}, nil, err
+	}
+	var in patternArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, patternArgs{}, nil, err
+	}
+	ids, err := featureIDsByName(part, in.SourceFeatures)
+	if err != nil {
+		return nil, patternArgs{}, nil, err
+	}
+	return part, in, ids, nil
+}
+
+func applyRectPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, ids, err := decodePattern(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	stepX, err := vec3(in.StepX, "patternRectangular: stepX")
+	if err != nil {
+		return nil, err
+	}
+	stepY := math.Vector3{}
+	if len(in.StepY) == 3 {
+		if stepY, err = vec3(in.StepY, "patternRectangular: stepY"); err != nil {
+			return nil, err
+		}
+	}
+	cx, cy := defaultInt(in.CountX, 2), defaultInt(in.CountY, 1)
+	feature.NewPatternFeatures(part.Features()).AddRectangular(ids, constIntFn(cx), constIntFn(cy), stepX, stepY)
+	return lastFeatureResult(part)
+}
+
+func applyCircPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, ids, err := decodePattern(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	angle, err := angleValue(part, in.Angle, "patternCircular: angle")
+	if err != nil {
+		return nil, err
+	}
+	feature.NewPatternFeatures(part.Features()).AddCircular(ids, constIntFn(defaultInt(in.Count, 4)), constFn(angle), originOr(in.AxisPoint), zAxisOr(in.AxisDir))
+	return lastFeatureResult(part)
+}
+
+func applyMirror(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, ids, err := decodePattern(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(in.Normal) != 3 {
+		return nil, errors.New("mirror: normal needs 3 components [x,y,z]")
+	}
+	normal, _ := vec3(in.Normal, "mirror: normal")
+	feature.NewPatternFeatures(part.Features()).AddMirror(ids, nil, originOr(in.Origin), normal)
+	return lastFeatureResult(part)
+}
+
+func defaultInt(v, def int) int {
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+func originOr(a []float64) math.Point3 {
+	if len(a) == 3 {
+		p, _ := point3(a, "point")
+		return p
+	}
+	return math.P3(0, 0, 0)
+}
+
+func zAxisOr(a []float64) math.Vector3 {
+	if len(a) == 3 {
+		v, _ := vec3(a, "axis")
+		return v
+	}
+	return math.V3(0, 0, 1)
+}

--- a/addin/opregistry/feature_refs.go
+++ b/addin/opregistry/feature_refs.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/param"
+)
+
+// Shared plumbing for the topology-referencing feature operations (fillet, chamfer, shell,
+// draft, hole). Over the JSON API there is no viewport pick, so these operations take
+// persistent reference-key strings (from model.referenceKeys / get_reference_keys) and the
+// model resolves them lazily against the current topology — the same keys edges/faces report.
+
+// refKeys converts reference-key strings to the model's [][]byte key form. The keys are the
+// exact strings model.referenceKeys emits (string(topo.ReferenceKey())), so the byte round
+// trip is lossless and resolves against the body they came from.
+func refKeys(refs []string) [][]byte {
+	keys := make([][]byte, len(refs))
+	for i, r := range refs {
+		keys[i] = []byte(r)
+	}
+	return keys
+}
+
+// lengthValue parses a unit-bearing length ("5 mm") in database units, naming field on error.
+func lengthValue(part *compdef.PartComponentDefinition, expr, field string) (float64, error) {
+	v, err := part.Units().Parse(expr, param.Length)
+	if err != nil {
+		return 0, fmt.Errorf("%s %q: %w", field, expr, err)
+	}
+	return v.Value, nil
+}
+
+// angleValue parses a unit-bearing angle ("3 deg") in database units (radians), naming field.
+func angleValue(part *compdef.PartComponentDefinition, expr, field string) (float64, error) {
+	v, err := part.Units().Parse(expr, param.Angle)
+	if err != nil {
+		return 0, fmt.Errorf("%s %q: %w", field, expr, err)
+	}
+	return v.Value, nil
+}
+
+// featureResult is the common reply for a feature operation: the created feature's name and
+// kind, the resulting body count, and its health (so a caller learns whether the kernel could
+// build the geometry — an unhealthy result is reported, not hidden).
+type featureResult struct {
+	Feature string `json:"feature"`
+	Kind    string `json:"kind"`
+	Bodies  int    `json:"bodies"`
+	Healthy bool   `json:"healthy"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// lastFeatureResult recomputes and reports the most recently added feature — used by the
+// builders (pattern/mirror) that register through the engine and return a definition object
+// rather than the *PartFeature the engine wraps it in.
+func lastFeatureResult(part *compdef.PartComponentDefinition) (json.RawMessage, error) {
+	feats := part.Features()
+	if feats.Count() == 0 {
+		return nil, fmt.Errorf("no feature was added")
+	}
+	return recomputeResult(part, feats.Item(feats.Count()-1))
+}
+
+// recomputeResult recomputes the part and reports the new feature's outcome. The feature stays
+// in the tree even when unhealthy, so model.tree / referenceKeys can inspect it.
+func recomputeResult(part *compdef.PartComponentDefinition, pf *feature.PartFeature) (json.RawMessage, error) {
+	part.Recompute()
+	h := pf.Health()
+	return json.Marshal(featureResult{
+		Feature: pf.Name(), Kind: pf.Kind(), Bodies: len(part.SurfaceBodies().All()),
+		Healthy: h.OK(), Reason: h.Reason,
+	})
+}
+
+// constFn wraps a constant as the func() float64 the model builders take for live parameters.
+func constFn(v float64) func() float64 { return func() float64 { return v } }
+
+// constIntFn wraps a constant as the func() int the pattern builders take for live counts.
+func constIntFn(v int) func() int { return func() int { return v } }
+
+// axisFromRef resolves a work-axis reference (an origin axis like "origin/axis/y", or a user
+// axis) to the part's work axis. An empty ref defaults to the Y origin axis (a common revolve
+// axis). It errors when the ref names no axis.
+func axisFromRef(part *compdef.PartComponentDefinition, ref string) (*feature.WorkAxis, error) {
+	if ref == "" {
+		ref = string(feature.OriginYAxis)
+	}
+	axis, ok := part.WorkGeometry().AxisByRef(feature.WorkRef(ref))
+	if !ok {
+		return nil, fmt.Errorf("axis ref %q not found (try origin/axis/x|y|z)", ref)
+	}
+	return axis, nil
+}
+
+// featureIDByName resolves an existing feature's name (as shown in model.tree, e.g.
+// "Extrusion1") to its id — the handle pattern/mirror replicate. Errors when unknown.
+func featureIDByName(part *compdef.PartComponentDefinition, name string) (feature.ID, error) {
+	f, ok := part.Features().ByName(name)
+	if !ok {
+		return 0, fmt.Errorf("feature %q not found (see model.tree)", name)
+	}
+	return f.ID(), nil
+}
+
+// featureIDsByName resolves several feature names to their ids.
+func featureIDsByName(part *compdef.PartComponentDefinition, names []string) ([]feature.ID, error) {
+	ids := make([]feature.ID, len(names))
+	for i, n := range names {
+		id, err := featureIDByName(part, n)
+		if err != nil {
+			return nil, err
+		}
+		ids[i] = id
+	}
+	return ids, nil
+}
+
+// vec3 / point3 convert a JSON [x,y,z] triple to model vectors/points, erroring on bad arity.
+func vec3(a []float64, field string) (math.Vector3, error) {
+	if len(a) != 3 {
+		return math.Vector3{}, fmt.Errorf("%s needs 3 components [x,y,z], got %d", field, len(a))
+	}
+	return math.V3(math.Scalar(a[0]), math.Scalar(a[1]), math.Scalar(a[2])), nil
+}
+
+func point3(a []float64, field string) (math.Point3, error) {
+	v, err := vec3(a, field)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	return v.AsPoint(), nil
+}

--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The additive sketch-profile solid features beyond extrude: revolve, rib, emboss, coil, and
+// loft. Each consumes one or more closed/open sketch profiles (by sketchIndex/profileIndex)
+// and follows the extrude descriptor shape, so add_feature can drive the whole additive set.
+
+// --- revolve ---------------------------------------------------------------
+
+type revolveArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	AxisRef      string `json:"axisRef,omitempty"`
+	Angle        string `json:"angle"`
+	Operation    string `json:"operation,omitempty"`
+}
+
+const revolveSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "axisRef": {"type": "string", "description": "Work-axis reference to revolve about, e.g. \"origin/axis/y\" (default). See get_reference_keys / list_work_planes."},
+    "angle": {"type": "string", "description": "Revolve angle with units, e.g. \"360 deg\"."},
+    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new"}
+  },
+  "required": ["sketchIndex", "angle"]
+}`
+
+func revolveDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "revolve", Summary: "Revolve a closed sketch profile about an axis into a solid.", Schema: json.RawMessage(revolveSchema), Apply: applyRevolve}
+}
+
+func applyRevolve(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in revolveArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	axis, err := axisFromRef(part, in.AxisRef)
+	if err != nil {
+		return nil, err
+	}
+	angle, err := angleValue(part, in.Angle, "revolve: angle")
+	if err != nil {
+		return nil, err
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewRevolveFeatures(part.Features()).Add(sk, in.ProfileIndex, axis, constFn(angle), op)
+	return recomputeResult(part, pf)
+}
+
+// --- rib -------------------------------------------------------------------
+
+type ribArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	Thickness    string `json:"thickness"`
+	Depth        string `json:"depth"`
+	Operation    string `json:"operation,omitempty"`
+}
+
+const ribSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "thickness": {"type": "string", "description": "Rib wall thickness, e.g. \"2 mm\"."},
+    "depth": {"type": "string", "description": "How far the rib grows toward the body, e.g. \"10 mm\"."},
+    "operation": {"type": "string", "enum": ["new", "join"], "default": "join"}
+  },
+  "required": ["sketchIndex", "thickness", "depth"]
+}`
+
+func ribDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "rib", Summary: "Thicken an open sketch profile into a support rib.", Schema: json.RawMessage(ribSchema), Apply: applyRib}
+}
+
+func applyRib(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in ribArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	th, err := lengthValue(part, in.Thickness, "rib: thickness")
+	if err != nil {
+		return nil, err
+	}
+	depth, err := lengthValue(part, in.Depth, "rib: depth")
+	if err != nil {
+		return nil, err
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewRibFeatures(part.Features()).Add(sk, in.ProfileIndex, constFn(th), constFn(depth), op)
+	return recomputeResult(part, pf)
+}
+
+// --- emboss ----------------------------------------------------------------
+
+type embossArgs struct {
+	SketchIndex    int    `json:"sketchIndex"`
+	ProfileIndices []int  `json:"profileIndices,omitempty"`
+	ProfileIndex   int    `json:"profileIndex"`
+	Depth          string `json:"depth"`
+	Engrave        bool   `json:"engrave,omitempty"`
+}
+
+const embossSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndices": {"type": "array", "items": {"type": "integer", "minimum": 0}, "description": "Profiles to emboss; omit to use profileIndex."},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "depth": {"type": "string", "description": "Raise (or, with engrave, cut) depth, e.g. \"1 mm\"."},
+    "engrave": {"type": "boolean", "default": false, "description": "Cut into the face instead of raising from it."}
+  },
+  "required": ["sketchIndex", "depth"]
+}`
+
+func embossDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "emboss", Summary: "Raise or engrave a sketch profile on a face.", Schema: json.RawMessage(embossSchema), Apply: applyEmboss}
+}
+
+func applyEmboss(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in embossArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	depth, err := lengthValue(part, in.Depth, "emboss: depth")
+	if err != nil {
+		return nil, err
+	}
+	profiles := in.ProfileIndices
+	if len(profiles) == 0 {
+		profiles = []int{in.ProfileIndex}
+	}
+	pf := feature.NewEmbossFeatures(part.Features()).Add(sk, profiles, constFn(depth), in.Engrave, 0)
+	return recomputeResult(part, pf)
+}
+
+// --- coil ------------------------------------------------------------------
+
+type coilArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	AxisRef      string `json:"axisRef,omitempty"`
+	Pitch        string `json:"pitch"`
+	Revolutions  string `json:"revolutions"`
+	Operation    string `json:"operation,omitempty"`
+}
+
+const coilSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "axisRef": {"type": "string", "description": "Work-axis reference to coil about, e.g. \"origin/axis/z\" (default)."},
+    "pitch": {"type": "string", "description": "Axial rise per revolution, e.g. \"5 mm\"."},
+    "revolutions": {"type": "string", "description": "Number of turns, e.g. \"4\"."},
+    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
+  },
+  "required": ["sketchIndex", "pitch", "revolutions"]
+}`
+
+func coilDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "coil", Summary: "Sweep a profile along a helix into a spring/thread.", Schema: json.RawMessage(coilSchema), Apply: applyCoil}
+}
+
+func applyCoil(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in coilArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	axisRef := in.AxisRef
+	if axisRef == "" {
+		axisRef = string(feature.OriginZAxis)
+	}
+	axis, err := axisFromRef(part, axisRef)
+	if err != nil {
+		return nil, err
+	}
+	pitch, err := lengthValue(part, in.Pitch, "coil: pitch")
+	if err != nil {
+		return nil, err
+	}
+	revs, err := strconv.ParseFloat(strings.TrimSpace(in.Revolutions), 64)
+	if err != nil {
+		return nil, fmt.Errorf("coil: revolutions %q must be a number: %w", in.Revolutions, err)
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewCoilFeatures(part.Features()).Add(sk, in.ProfileIndex, axis, constFn(pitch), constFn(revs), 0, op)
+	return recomputeResult(part, pf)
+}
+
+// --- loft ------------------------------------------------------------------
+
+type loftSectionRef struct {
+	SketchIndex  int `json:"sketchIndex"`
+	ProfileIndex int `json:"profileIndex"`
+}
+
+type loftArgs struct {
+	Sections  []loftSectionRef `json:"sections"`
+	Closed    bool             `json:"closed,omitempty"`
+	Operation string           `json:"operation,omitempty"`
+}
+
+const loftSchema = `{
+  "type": "object",
+  "properties": {
+    "sections": {"type": "array", "minItems": 2, "items": {"type": "object", "properties": {"sketchIndex": {"type": "integer"}, "profileIndex": {"type": "integer"}}, "required": ["sketchIndex"]}, "description": "Ordered cross-section profiles (>= 2) to loft through."},
+    "closed": {"type": "boolean", "default": false},
+    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
+  },
+  "required": ["sections"]
+}`
+
+func loftDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "loft", Summary: "Blend two or more profiles into a solid (loft).", Schema: json.RawMessage(loftSchema), Apply: applyLoft}
+}
+
+func applyLoft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in loftArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.Sections) < 2 {
+		return nil, errors.New("loft: needs >= 2 sections")
+	}
+	sections := make([]feature.LoftSection, len(in.Sections))
+	for i, r := range in.Sections {
+		sk, serr := sketchAt(part, r.SketchIndex)
+		if serr != nil {
+			return nil, serr
+		}
+		sections[i] = feature.LoftSection{Sketch: sk, ProfileIndex: r.ProfileIndex}
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewLoftFeatures(part.Features()).Add(sections, in.Closed, op)
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/feature_surface.go
+++ b/addin/opregistry/feature_surface.go
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The surfacing features: build surface bodies (boundary patch, ruled surface), modify them
+// (surface offset, extend), and convert between surfaces and solids (thicken — see
+// feature_modify.go, midSurface, stitch, sculpt). Profile-based surfaces take a sketch
+// profile; the rest act on the part's existing surface/solid bodies.
+
+// --- boundary patch --------------------------------------------------------
+
+type patchArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	Condition    string `json:"condition,omitempty"`
+}
+
+const boundaryPatchSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "condition": {"type": "string", "enum": ["free", "tangent"], "default": "free", "description": "Edge continuity to neighbouring faces."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+func boundaryPatchDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "boundaryPatch", Summary: "Fill a closed sketch loop with a surface patch.", Schema: json.RawMessage(boundaryPatchSchema), Apply: applyBoundaryPatch}
+}
+
+func applyBoundaryPatch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in patchArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	cond := feature.PatchFree
+	if strings.EqualFold(in.Condition, "tangent") {
+		cond = feature.PatchTangent
+	}
+	pf := feature.NewBoundaryPatchFeatures(part.Features()).Add(sk, in.ProfileIndex, cond)
+	return recomputeResult(part, pf)
+}
+
+// --- ruled surface ---------------------------------------------------------
+
+type ruledArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	Type         string `json:"type,omitempty"`
+	Distance     string `json:"distance"`
+}
+
+const ruledSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "type": {"type": "string", "enum": ["normal", "tangent", "perpendicular"], "default": "normal", "description": "Direction of the straight rulings."},
+    "distance": {"type": "string", "description": "Ruling length, e.g. \"10 mm\"."}
+  },
+  "required": ["sketchIndex", "distance"]
+}`
+
+func ruledSurfaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "ruledSurface", Summary: "Sweep straight rulings off a profile into a surface.", Schema: json.RawMessage(ruledSchema), Apply: applyRuledSurface}
+}
+
+func applyRuledSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in ruledArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	dist, err := lengthValue(part, in.Distance, "ruledSurface: distance")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewRuledSurfaceFeatures(part.Features()).AddByDistance(sk, in.ProfileIndex, ruledType(in.Type), constFn(dist))
+	return recomputeResult(part, pf)
+}
+
+func ruledType(name string) feature.RuledSurfaceType {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "tangent":
+		return feature.RuledTangent
+	case "perpendicular":
+		return feature.RuledPerpendicular
+	default:
+		return feature.RuledNormal
+	}
+}
+
+// --- surface offset / extend / midSurface / stitch / sculpt ----------------
+
+type surfaceDistArgs struct {
+	Distance          string `json:"distance,omitempty"`
+	EdgeRef           string `json:"edgeRef,omitempty"`
+	MaxThickness      string `json:"maxThickness,omitempty"`
+	Tolerance         string `json:"tolerance,omitempty"`
+	MaintainAsSurface bool   `json:"maintainAsSurface,omitempty"`
+	Operation         string `json:"operation,omitempty"`
+}
+
+const surfaceOffsetSchema = `{
+  "type": "object",
+  "properties": {"distance": {"type": "string", "description": "Offset distance for the surface bodies, e.g. \"2 mm\"."}},
+  "required": ["distance"]
+}`
+
+const extendSchema = `{
+  "type": "object",
+  "properties": {
+    "edgeRef": {"type": "string", "description": "Reference key of the surface edge to extend (get_reference_keys)."},
+    "distance": {"type": "string", "description": "Extend distance, e.g. \"5 mm\"."}
+  },
+  "required": ["edgeRef", "distance"]
+}`
+
+const midSurfaceSchema = `{
+  "type": "object",
+  "properties": {"maxThickness": {"type": "string", "description": "Max wall thickness to pair into a mid-surface, e.g. \"3 mm\"."}},
+  "required": ["maxThickness"]
+}`
+
+const stitchSchema = `{
+  "type": "object",
+  "properties": {
+    "tolerance": {"type": "string", "description": "Stitch gap tolerance, e.g. \"0.1 mm\".", "default": "0.1 mm"},
+    "maintainAsSurface": {"type": "boolean", "default": false, "description": "Keep a surface body instead of solidifying a closed quilt."}
+  }
+}`
+
+const sculptSchema = `{
+  "type": "object",
+  "properties": {
+    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"},
+    "tolerance": {"type": "string", "description": "Sculpt tolerance, e.g. \"0.1 mm\".", "default": "0.1 mm"}
+  }
+}`
+
+func surfaceOffsetDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "surfaceOffset", Summary: "Offset the part's surface bodies by a distance.", Schema: json.RawMessage(surfaceOffsetSchema), Apply: applySurfaceOffset}
+}
+
+func extendDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "extend", Summary: "Extend a surface body past a picked edge.", Schema: json.RawMessage(extendSchema), Apply: applyExtend}
+}
+
+func midSurfaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "midSurface", Summary: "Build the mid-surface between thin-wall face pairs.", Schema: json.RawMessage(midSurfaceSchema), Apply: applyMidSurface}
+}
+
+func stitchDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "stitch", Summary: "Stitch surface bodies into a quilt (or solid).", Schema: json.RawMessage(stitchSchema), Apply: applyStitch}
+}
+
+func sculptDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "sculpt", Summary: "Combine surfaces and solids into a sculpted body.", Schema: json.RawMessage(sculptSchema), Apply: applySculpt}
+}
+
+func applySurfaceOffset(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeSurface(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	d, err := lengthValue(part, in.Distance, "surfaceOffset: distance")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewSurfaceOffsetFeatures(part.Features()).AddByDistance(constFn(d))
+	return recomputeResult(part, pf)
+}
+
+func applyExtend(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeSurface(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	if in.EdgeRef == "" {
+		return nil, errors.New("extend: edgeRef is empty")
+	}
+	d, err := lengthValue(part, in.Distance, "extend: distance")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewExtendFeatures(part.Features()).Add([]byte(in.EdgeRef), constFn(d))
+	return recomputeResult(part, pf)
+}
+
+func applyMidSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeSurface(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	th, err := lengthValue(part, in.MaxThickness, "midSurface: maxThickness")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewMidSurfaceFeatures(part.Features()).AddByThickness(th)
+	return recomputeResult(part, pf)
+}
+
+func applyStitch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeSurface(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	tol, err := toleranceValue(part, in.Tolerance)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewStitchFeatures(part.Features()).Add(tol, in.MaintainAsSurface)
+	return recomputeResult(part, pf)
+}
+
+func applySculpt(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, in, err := decodeSurface(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	tol, err := toleranceValue(part, in.Tolerance)
+	if err != nil {
+		return nil, err
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewSculptFeatures(part.Features()).Add(op, tol)
+	return recomputeResult(part, pf)
+}
+
+// decodeSurface is the shared front of the surface operations (active part + decoded args).
+func decodeSurface(s *app.Session, raw json.RawMessage) (part *compdef.PartComponentDefinition, in surfaceDistArgs, err error) {
+	p, perr := modelaccess.ActivePart(s)
+	if perr != nil {
+		return nil, surfaceDistArgs{}, perr
+	}
+	if jerr := json.Unmarshal(raw, &in); jerr != nil {
+		return nil, surfaceDistArgs{}, jerr
+	}
+	return p, in, nil
+}
+
+// toleranceValue parses a stitch/sculpt tolerance ("" ⇒ 0.1 mm = 0.01 cm).
+func toleranceValue(part *compdef.PartComponentDefinition, expr string) (float64, error) {
+	if strings.TrimSpace(expr) == "" {
+		return 0.01, nil
+	}
+	v, err := lengthValue(part, expr, "tolerance")
+	if err != nil {
+		return 0, fmt.Errorf("invalid tolerance: %w", err)
+	}
+	return v, nil
+}

--- a/addin/opregistry/hole.go
+++ b/addin/opregistry/hole.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The hole operation — a subtractive drilled hole on a picked face, referenced by key
+// (get_reference_keys). With a depth it is a blind drilled hole; without one it drills through
+// all. Counterbore/countersink/tapped variants follow the same shape (HoleFeatures.Add*).
+
+type holeArgs struct {
+	FaceRef         string `json:"faceRef"`
+	Type            string `json:"type,omitempty"` // drilled (default) | counterbore | countersink | tapped
+	Diameter        string `json:"diameter"`
+	Depth           string `json:"depth,omitempty"` // omit (drilled) ⇒ through-all
+	CounterDiameter string `json:"counterDiameter,omitempty"`
+	CounterDepth    string `json:"counterDepth,omitempty"`
+	SinkDiameter    string `json:"sinkDiameter,omitempty"`
+	IncludedAngle   string `json:"includedAngle,omitempty"`
+	Designation     string `json:"designation,omitempty"`
+}
+
+const holeSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRef": {"type": "string", "description": "Reference key of the planar face to drill into (from get_reference_keys)."},
+    "type": {"type": "string", "enum": ["drilled", "counterbore", "countersink", "tapped"], "default": "drilled", "description": "Hole style."},
+    "diameter": {"type": "string", "description": "Hole diameter with units, e.g. \"5 mm\"."},
+    "depth": {"type": "string", "description": "Blind hole depth, e.g. \"8 mm\". Omit (drilled only) for a through-all hole."},
+    "counterDiameter": {"type": "string", "description": "Counterbore diameter (type=counterbore)."},
+    "counterDepth": {"type": "string", "description": "Counterbore depth (type=counterbore)."},
+    "sinkDiameter": {"type": "string", "description": "Countersink top diameter (type=countersink)."},
+    "includedAngle": {"type": "string", "description": "Countersink included angle, e.g. \"90 deg\" (type=countersink)."},
+    "designation": {"type": "string", "description": "Thread designation, e.g. \"M5x0.8\" (type=tapped)."}
+  },
+  "required": ["faceRef", "diameter"]
+}`
+
+func holeDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "hole", Summary: "Drill a hole into a picked face: drilled (blind/through), counterbore, countersink, or tapped.", Schema: json.RawMessage(holeSchema), Apply: applyHole}
+}
+
+func applyHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in holeArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.FaceRef == "" {
+		return nil, errors.New("hole: faceRef is empty")
+	}
+	dia, err := lengthValue(part, in.Diameter, "hole: diameter")
+	if err != nil {
+		return nil, err
+	}
+	pf, err := buildHole(part, in, dia)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, pf)
+}
+
+// buildHole dispatches on the hole type, resolving the extra dimensions each variant needs.
+func buildHole(part *compdef.PartComponentDefinition, in holeArgs, dia float64) (*feature.PartFeature, error) {
+	holes := feature.NewHoleFeatures(part.Features())
+	key := []byte(in.FaceRef)
+	switch in.Type {
+	case "", "drilled":
+		if in.Depth == "" {
+			return holes.AddDrilledThrough(key, constFn(dia)), nil
+		}
+		depth, err := lengthValue(part, in.Depth, "hole: depth")
+		if err != nil {
+			return nil, err
+		}
+		return holes.AddDrilled(key, constFn(dia), constFn(depth)), nil
+	case "counterbore":
+		depth, cdia, cdepth, err := threeLengths(part, in.Depth, in.CounterDiameter, in.CounterDepth, "hole counterbore")
+		if err != nil {
+			return nil, err
+		}
+		return holes.AddCounterbore(key, constFn(dia), constFn(depth), constFn(cdia), constFn(cdepth)), nil
+	case "countersink":
+		depth, sdia, err := twoLengths(part, in.Depth, in.SinkDiameter, "hole countersink")
+		if err != nil {
+			return nil, err
+		}
+		angle, err := angleValue(part, in.IncludedAngle, "hole: includedAngle")
+		if err != nil {
+			return nil, err
+		}
+		return holes.AddCountersink(key, constFn(dia), constFn(depth), constFn(sdia), constFn(angle)), nil
+	case "tapped":
+		depth, err := lengthValue(part, in.Depth, "hole: depth")
+		if err != nil {
+			return nil, err
+		}
+		if in.Designation == "" {
+			return nil, errors.New("hole: tapped needs a designation, e.g. \"M5x0.8\"")
+		}
+		return holes.AddTapped(key, constFn(dia), constFn(depth), in.Designation), nil
+	default:
+		return nil, fmt.Errorf("hole: unknown type %q (want drilled|counterbore|countersink|tapped)", in.Type)
+	}
+}
+
+func twoLengths(part *compdef.PartComponentDefinition, a, b, ctx string) (float64, float64, error) {
+	av, err := lengthValue(part, a, ctx+": depth")
+	if err != nil {
+		return 0, 0, err
+	}
+	bv, err := lengthValue(part, b, ctx+": diameter")
+	if err != nil {
+		return 0, 0, err
+	}
+	return av, bv, nil
+}
+
+func threeLengths(part *compdef.PartComponentDefinition, a, b, c, ctx string) (float64, float64, float64, error) {
+	av, bv, err := twoLengths(part, a, b, ctx)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	cv, err := lengthValue(part, c, ctx+": counterDepth")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return av, bv, cv, nil
+}

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -75,8 +75,59 @@ func (r *Registry) All() []*OperationDescriptor {
 // if a built-in descriptor is malformed, since that is a programming error.
 func Default() *Registry {
 	r := New()
-	if err := r.Register(extrudeDescriptor()); err != nil {
-		panic(fmt.Sprintf("opregistry: seeding default registry: %v", err))
+	// The full built-in feature surface, so add_feature (and the MCP bridge) can drive every
+	// modeling operation: additive profile features, the subtractive/dress-up family (by edge/
+	// face reference key), direct edits, patterns, and freeform primitives.
+	for _, d := range []*OperationDescriptor{
+		// Additive profile features.
+		extrudeDescriptor(),
+		revolveDescriptor(),
+		ribDescriptor(),
+		embossDescriptor(),
+		coilDescriptor(),
+		loftDescriptor(),
+		// Subtractive / dress-up (edge & face reference keys).
+		filletDescriptor(),
+		chamferDescriptor(),
+		shellDescriptor(),
+		draftDescriptor(),
+		holeDescriptor(),
+		bossDescriptor(),
+		threadDescriptor(),
+		// Direct edits and booleans.
+		combineDescriptor(),
+		thickenDescriptor(),
+		trimDescriptor(),
+		moveFaceDescriptor(),
+		faceOffsetDescriptor(),
+		deleteFaceDescriptor(),
+		splitFaceDescriptor(),
+		replaceFaceDescriptor(),
+		moveBodyDescriptor(),
+		splitSolidDescriptor(),
+		coreCavityDescriptor(),
+		// Additive along a path / patterns.
+		sweepDescriptor(),
+		rectPatternDescriptor(),
+		circPatternDescriptor(),
+		mirrorDescriptor(),
+		sketchDrivenDescriptor(),
+		// Surfacing.
+		boundaryPatchDescriptor(),
+		ruledSurfaceDescriptor(),
+		surfaceOffsetDescriptor(),
+		extendDescriptor(),
+		midSurfaceDescriptor(),
+		stitchDescriptor(),
+		sculptDescriptor(),
+		// Freeform primitives.
+		freeformBoxDescriptor(),
+		freeformPlaneDescriptor(),
+		freeformQuadBallDescriptor(),
+	} {
+		if err := r.Register(d); err != nil {
+			panic(fmt.Sprintf("opregistry: seeding default registry: %v", err))
+		}
 	}
 	return r
 }

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -9,19 +9,36 @@ import (
 	"github.com/Oblikovati/oblikovati/app"
 )
 
-func TestDefaultHasExtrude(t *testing.T) {
+// TestDefaultDescriptors checks the default registry exposes the additive extrude plus the
+// subtractive/dress-up family, and that each descriptor is complete with valid-JSON schema —
+// so add_feature (and the MCP bridge) can drive every one of them.
+func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
-	d, ok := r.ByName("extrude")
-	if !ok {
-		t.Fatal("default registry missing extrude")
+	all := []string{
+		"extrude", "revolve", "rib", "emboss", "coil", "loft",
+		"fillet", "chamfer", "shell", "draft", "hole", "boss", "thread",
+		"combine", "thicken", "trim", "moveFace", "faceOffset", "deleteFace", "split",
+		"replaceFace", "moveBody", "splitSolid", "coreCavity",
+		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
+		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
+		"freeformBox", "freeformPlane", "freeformQuadBall",
 	}
-	if d.Summary == "" || len(d.Schema) == 0 || d.Apply == nil {
-		t.Fatalf("extrude descriptor incomplete: %+v", d)
+	if got := len(r.All()); got != len(all) {
+		t.Errorf("default registry has %d operations, want %d", got, len(all))
 	}
-	// Schema must be valid JSON so it can be served as-is to an LLM.
-	var schema map[string]any
-	if err := json.Unmarshal(d.Schema, &schema); err != nil {
-		t.Fatalf("extrude schema is not valid JSON: %v", err)
+	for _, name := range all {
+		d, ok := r.ByName(name)
+		if !ok {
+			t.Errorf("default registry missing %q", name)
+			continue
+		}
+		if d.Summary == "" || len(d.Schema) == 0 || d.Apply == nil {
+			t.Errorf("descriptor %q incomplete: %+v", name, d)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(d.Schema, &schema); err != nil {
+			t.Errorf("%q schema is not valid JSON: %v", name, err)
+		}
 	}
 }
 

--- a/addin/router/logs.go
+++ b/addin/router/logs.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// logsTail serves wire.MethodLogsTail: a cursor-paged tail of the operation trace. It reads
+// the router's own [trace.Buffer] (the one Handle fills), so a driver can poll for new records
+// with the previous NextSeq and watch the kernel work in real time. It is registered like any
+// method but is excluded from self-tracing in Router.record.
+func (r *Router) logsTail(_ *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.LogsTailArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	return json.Marshal(r.trace.Tail(in.SinceSeq, in.Level, in.Max))
+}

--- a/addin/router/logs_test.go
+++ b/addin/router/logs_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/addin/opregistry"
+	"github.com/Oblikovati/oblikovati/app"
+)
+
+// TestHandleRecoversPanicIntoError: a panicking handler does not crash the host — Handle
+// returns a detailed, method-named error and records it (with a stack) in the trace.
+func TestHandleRecoversPanicIntoError(t *testing.T) {
+	r := New(opregistry.Default())
+	r.handlers["test.boom"] = func(*app.Session, json.RawMessage) (json.RawMessage, error) {
+		panic("kaboom")
+	}
+	s := app.NewSession()
+
+	_, err := r.Handle(s, "test.boom", []byte("{}"))
+	if err == nil || !strings.Contains(err.Error(), "test.boom: panic") || !strings.Contains(err.Error(), "kaboom") {
+		t.Fatalf("err = %v, want a method-named panic error", err)
+	}
+	// The host is still usable after the recovered panic.
+	if _, err := r.Handle(s, wire.MethodDocumentsList, []byte("{}")); err != nil {
+		t.Fatalf("router unusable after panic: %v", err)
+	}
+
+	res := r.trace.Tail(0, "error", 0)
+	if len(res.Records) != 1 {
+		t.Fatalf("error-level records = %d, want 1 (the panic)", len(res.Records))
+	}
+	rec := res.Records[0]
+	if rec.Method != "test.boom" || rec.Panic == "" || rec.Stack == "" {
+		t.Errorf("panic record = %+v, want method+panic+stack", rec)
+	}
+}
+
+// TestHandleTracesEachCall: a successful and a failing call each append one trace entry, with
+// the failure carrying a method-prefixed error.
+func TestHandleTracesEachCall(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+
+	if _, err := r.Handle(s, wire.MethodDocumentsList, []byte("{}")); err != nil {
+		t.Fatalf("documents.list: %v", err)
+	}
+	// model.tree with no active part fails — proves failures are traced + named.
+	if _, err := r.Handle(s, wire.MethodModelTree, []byte("{}")); err == nil {
+		t.Fatal("model.tree with no part should fail")
+	}
+
+	res := r.trace.Tail(0, "", 0)
+	if len(res.Records) != 2 {
+		t.Fatalf("trace has %d records, want 2", len(res.Records))
+	}
+	if !res.Records[0].OK || res.Records[0].Method != wire.MethodDocumentsList {
+		t.Errorf("rec0 = %+v, want ok documents.list", res.Records[0])
+	}
+	if res.Records[1].OK || !strings.HasPrefix(res.Records[1].Error, wire.MethodModelTree) {
+		t.Errorf("rec1 = %+v, want failed model.tree with prefixed error", res.Records[1])
+	}
+}
+
+// TestLogsTailNotSelfTraced: polling logs.tail must not append to the trace it reads.
+func TestLogsTailNotSelfTraced(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+
+	out, err := r.Handle(s, wire.MethodLogsTail, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("logs.tail: %v", err)
+	}
+	var res wire.LogsResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(res.Records) != 0 {
+		t.Errorf("logs.tail recorded itself: %+v", res.Records)
+	}
+}

--- a/addin/router/model_reference_keys.go
+++ b/addin/router/model_reference_keys.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"github.com/Oblikovati/api/wire"
+
+	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// referenceKeys surfaces the active part's topology (faces/edges/vertices) with their
+// persistent reference keys. Over the wire there is no viewport pick, so this is how an
+// add-in obtains a key to feed back into the key consumers (include, surface curves,
+// project geometry, attributes). Each entry carries a representative point so the caller
+// can recognise which face/edge/vertex it is.
+func referenceKeys(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var out wire.ReferenceKeysResult
+	for _, b := range part.SurfaceBodies().All() {
+		out.Bodies = append(out.Bodies, bodyTopology(b))
+	}
+	return json.Marshal(out)
+}
+
+// bodyTopology collects one body's faces/edges/vertices as reference keys + representative
+// points (face range-box centre, edge midpoint, vertex position).
+func bodyTopology(b *topo.Body) wire.BodyTopology {
+	var bt wire.BodyTopology
+	for _, f := range b.Faces() {
+		bt.Faces = append(bt.Faces, wire.TopologyRef{Key: string(f.ReferenceKey()), Point: topoRefPoint(f.RangeBox().Center())})
+	}
+	for _, e := range b.Edges() {
+		bt.Edges = append(bt.Edges, wire.TopologyRef{Key: string(e.ReferenceKey()), Point: topoRefPoint(e.RangeBox().Center())})
+	}
+	for _, v := range b.Vertices() {
+		bt.Vertices = append(bt.Vertices, wire.TopologyRef{Key: string(v.ReferenceKey()), Point: topoRefPoint(v.Point())})
+	}
+	return bt
+}
+
+// topoRefPoint flattens a point to [x,y,z].
+func topoRefPoint(p math.Point3) []float64 {
+	return []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -13,11 +13,15 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/Oblikovati/api/wire"
 
 	"github.com/Oblikovati/oblikovati/addin/opregistry"
+	"github.com/Oblikovati/oblikovati/addin/trace"
 	"github.com/Oblikovati/oblikovati/app"
 )
 
@@ -28,18 +32,24 @@ type handlerFunc func(s *app.Session, args json.RawMessage) (json.RawMessage, er
 type Router struct {
 	ops      *opregistry.Registry
 	handlers map[string]handlerFunc
+	trace    *trace.Buffer
 }
 
 // New builds a router whose feature operations come from ops.
 func New(ops *opregistry.Registry) *Router {
-	r := &Router{ops: ops, handlers: map[string]handlerFunc{}}
+	r := &Router{ops: ops, handlers: map[string]handlerFunc{}, trace: trace.NewBuffer(0)}
 	r.registerStandardHandlers()
 	r.registerTransactionHandlers()
 	r.registerMaterialHandlers()
 	r.registerLightingHandlers()
 	r.registerGraphicsHandlers()
+	r.handlers[wire.MethodLogsTail] = r.logsTail
 	return r
 }
+
+// Trace returns the router's operation-trace buffer, so the host can install its slog handler
+// (slog.SetDefault) and have kernel logs land in the same stream the router fills.
+func (r *Router) Trace() *trace.Buffer { return r.trace }
 
 // registerStandardHandlers wires the command/document/parameter/model/sketch/feature/theme
 // methods.
@@ -54,6 +64,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodParametersSet] = setParameter
 	r.handlers[wire.MethodModelTree] = modelTree
 	r.handlers[wire.MethodModelSelection] = modelSelection
+	r.handlers[wire.MethodModelReferenceKeys] = referenceKeys
 	r.registerSketchHandlers()
 	r.handlers[wire.MethodFeaturesList] = r.listFeatureKinds
 	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
@@ -203,7 +214,7 @@ func (r *Router) registerGraphicsHandlers() {
 
 // Handle dispatches method with its JSON args (empty args become {}), returning the
 // JSON result, or an error for an unknown method or a failed handler.
-func (r *Router) Handle(s *app.Session, method string, req []byte) ([]byte, error) {
+func (r *Router) Handle(s *app.Session, method string, req []byte) (resp []byte, err error) {
 	h, ok := r.handlers[method]
 	if !ok {
 		return nil, fmt.Errorf("router: unknown method %q", method)
@@ -212,7 +223,44 @@ func (r *Router) Handle(s *app.Session, method string, req []byte) ([]byte, erro
 	if len(req) == 0 {
 		args = json.RawMessage("{}")
 	}
-	return h(s, args)
+	// Recover any handler panic into a detailed error (method + value + stack) so a kernel bug
+	// hit by a driver is reported and traced, not fatal. logs.tail is not self-traced (a poll
+	// must not flood the very buffer it reads). See Workstream A/B of the diagnostics plan.
+	start := time.Now()
+	defer func() {
+		if rec := recover(); rec != nil {
+			stack := string(debug.Stack())
+			err = fmt.Errorf("%s: panic: %v", method, rec)
+			resp = nil
+			r.record(method, time.Since(start), false, "", err.Error(), stack)
+		}
+	}()
+	out, herr := h(s, args)
+	if herr != nil {
+		herr = methodError(method, herr)
+		r.record(method, time.Since(start), false, herr.Error(), "", "")
+		return nil, herr
+	}
+	r.record(method, time.Since(start), true, "", "", "")
+	return out, nil
+}
+
+// record appends an operation entry to the trace, except for logs.tail itself (so polling the
+// trace does not append to it).
+func (r *Router) record(method string, dur time.Duration, ok bool, errMsg, panicMsg, stack string) {
+	if method == wire.MethodLogsTail {
+		return
+	}
+	r.trace.RecordOp(method, dur, ok, errMsg, panicMsg, stack)
+}
+
+// methodError prefixes err with the method name when the handler did not already (so every
+// failure names the operation that produced it).
+func methodError(method string, err error) error {
+	if strings.HasPrefix(err.Error(), method) {
+		return err
+	}
+	return fmt.Errorf("%s: %w", method, err)
 }
 
 // Methods returns the supported method names, sorted — used by self-description.

--- a/addin/router/sketch.go
+++ b/addin/router/sketch.go
@@ -28,12 +28,28 @@ func createSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	plane, name, err := parsePlane(in.Plane)
+	plane, name, err := sketchCreatePlane(part, in)
 	if err != nil {
 		return nil, err
 	}
 	part.Sketches().Add(plane)
 	return json.Marshal(wire.CreateSketchResult{SketchIndex: part.Sketches().Count() - 1, Plane: name})
+}
+
+// sketchCreatePlane resolves the plane a new sketch starts on: a user work plane (when
+// WorkPlaneIndex is set — the way to sketch on a plane built on a feature-created face) or an
+// origin plane otherwise.
+func sketchCreatePlane(part *compdef.PartComponentDefinition, in wire.CreateSketchArgs) (sketch.Plane, string, error) {
+	if in.WorkPlaneIndex == nil {
+		return parsePlane(in.Plane)
+	}
+	planes := part.WorkPlanes()
+	i := *in.WorkPlaneIndex
+	if i < 0 || i >= planes.Count() {
+		return sketch.Plane{}, "", fmt.Errorf("sketch.create: work plane %d out of range (part has %d)", i, planes.Count())
+	}
+	wp := planes.Item(i)
+	return wp.Plane(), wp.Name(), nil
 }
 
 // sketchRectangle adds a closed rectangle (one profile) to a sketch, ready to extrude.

--- a/addin/router/sketch3d_surface_curves.go
+++ b/addin/router/sketch3d_surface_curves.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Oblikovati/oblikovati/addin/modelaccess"
 	"github.com/Oblikovati/oblikovati/app"
 	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
@@ -37,9 +38,76 @@ func addSketch3DSurfaceCurve(s *app.Session, raw json.RawMessage) (json.RawMessa
 		return intersectionCurve3D(part, sk, in)
 	case types.Sketch3DEntitySilhouette:
 		return silhouetteCurve3D(part, sk, in)
+	case types.Sketch3DEntityOnFace:
+		return onFaceCurve3D(part, sk, in)
+	case types.Sketch3DEntityProjectToSurface:
+		return projectToSurfaceCurve3D(part, sk, in)
+	case types.Sketch3DEntityOffset:
+		return offsetCurve3(sk, in)
 	default:
-		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: unsupported kind %q (want intersection|silhouette)", in.Kind)
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: unsupported kind %q (want intersection|silhouette|onFace|projectToSurface|offset)", in.Kind)
 	}
+}
+
+// projectToSurfaceCurve3D resolves an in-sketch source curve + a target face (associative)
+// and adds its perpendicular projection onto the face's surface.
+func projectToSurfaceCurve3D(part *compdef.PartComponentDefinition, sk *sketch.Sketch3D, in wire.AddSketch3DSurfaceCurveArgs) (json.RawMessage, error) {
+	if len(in.FaceRefs) != 1 {
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: projectToSurface needs 1 face ref, got %d", len(in.FaceRefs))
+	}
+	src, err := sk.SourceCurve3(sketch.ID(in.SourceEntityID))
+	if err != nil {
+		return nil, err
+	}
+	if !part.FaceKeyResolves(in.FaceRefs[0]) {
+		return surfaceCurveUnhealthy(in.Kind)
+	}
+	c := sk.AddProjectToSurfaceCurve3DRef(src, compdef.NewFaceRefSource(part, in.FaceRefs[0]))
+	return surfaceCurveResult(c.EntityID(), in.Kind)
+}
+
+// offsetCurve3 resolves an in-sketch source curve and adds its offset by OffsetDistance in
+// the plane with the given Normal.
+func offsetCurve3(sk *sketch.Sketch3D, in wire.AddSketch3DSurfaceCurveArgs) (json.RawMessage, error) {
+	src, err := sk.SourceCurve3(sketch.ID(in.SourceEntityID))
+	if err != nil {
+		return nil, err
+	}
+	normal, err := vector3Arg(in.Normal)
+	if err != nil {
+		return nil, err
+	}
+	c := sk.AddOffsetCurve3(src, in.OffsetDistance, normal)
+	return surfaceCurveResult(c.EntityID(), in.Kind)
+}
+
+// onFaceCurve3D resolves one face ref and adds an (associative) curve in its parameter
+// space from the request's flat UV polyline.
+func onFaceCurve3D(part *compdef.PartComponentDefinition, sk *sketch.Sketch3D, in wire.AddSketch3DSurfaceCurveArgs) (json.RawMessage, error) {
+	if len(in.FaceRefs) != 1 {
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: onFace needs 1 face ref, got %d", len(in.FaceRefs))
+	}
+	uv, err := uvPairs(in.UV) // validate the request shape before resolving the reference
+	if err != nil {
+		return nil, err
+	}
+	if !part.FaceKeyResolves(in.FaceRefs[0]) {
+		return surfaceCurveUnhealthy(in.Kind)
+	}
+	c := sk.AddOnFaceCurve3DRef(compdef.NewFaceRefSource(part, in.FaceRefs[0]), uv)
+	return surfaceCurveResult(c.EntityID(), in.Kind)
+}
+
+// uvPairs converts a flat [u0,v0,u1,v1,…] slice into parameter-space points (≥ 2 points).
+func uvPairs(flat []float64) ([]math.Point2, error) {
+	if len(flat) < 4 || len(flat)%2 != 0 {
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: onFace uv needs an even count ≥ 4, got %d", len(flat))
+	}
+	out := make([]math.Point2, len(flat)/2)
+	for i := range out {
+		out[i] = math.P2(math.Scalar(flat[2*i]), math.Scalar(flat[2*i+1]))
+	}
+	return out, nil
 }
 
 // intersectionCurve3D resolves two face refs and adds their (associative) intersection.

--- a/addin/router/sketch3d_test.go
+++ b/addin/router/sketch3d_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Oblikovati/api/wire"
 
 	"github.com/Oblikovati/oblikovati/addin/modelaccess"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/feature"
@@ -751,6 +752,235 @@ func TestSketch3DSurfaceCurveErrors(t *testing.T) {
 		if _, err := r.Handle(s, "sketch3d.addSurfaceCurve", []byte(b)); err == nil {
 			t.Errorf("expected error for %s", b)
 		}
+	}
+}
+
+// TestSketch3DOnFaceCurveOverAPI adds an on-face parameter-space curve via /api, resolving
+// the face ref to its surface (M22-F11).
+func TestSketch3DOnFaceCurveOverAPI(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := string(part.SurfaceBodies().All()[0].Faces()[0].ReferenceKey())
+
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var res wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "onFace", FaceRefs: []string{ref}, UV: []float64{0, 0, 1, 0, 1, 1},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &res)
+	if !res.Healthy || res.EntityID == 0 {
+		t.Fatalf("onFace = %+v, want healthy with an id", res)
+	}
+
+	var ents wire.EnumerateEntities3DResult
+	call(t, r, s, "sketch3d.entities", `{"sketchIndex":0}`, &ents)
+	if len(ents.Entities) != 1 || ents.Entities[0].Kind != "onFace" {
+		t.Fatalf("entities = %+v, want one onFace", ents.Entities)
+	}
+}
+
+// TestSketch3DOnFaceCurveErrors: a lost ref is unhealthy; a malformed UV is an error.
+func TestSketch3DOnFaceCurveErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+
+	var lost wire.AddSketch3DSurfaceCurveResult
+	call(t, r, s, "sketch3d.addSurfaceCurve", `{"sketchIndex":0,"kind":"onFace","faceRefs":["nope"],"uv":[0,0,1,1]}`, &lost)
+	if lost.Healthy {
+		t.Error("onFace with a lost face ref should report unhealthy")
+	}
+	// An odd-length UV is a request error.
+	if _, err := r.Handle(s, "sketch3d.addSurfaceCurve", []byte(`{"sketchIndex":0,"kind":"onFace","faceRefs":["a"],"uv":[0,0,1]}`)); err == nil {
+		t.Error("expected an error for an odd-length onFace uv")
+	}
+}
+
+// TestSketch3DProjectAndOffsetOverAPI adds project-to-surface and offset curves whose
+// source is an in-sketch line resolved by entity id (M22-F11).
+func TestSketch3DProjectAndOffsetOverAPI(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := string(part.SurfaceBodies().All()[0].Faces()[0].ReferenceKey())
+
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var line wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0,0],[3,0,4]]}`, &line)
+	if line.EntityID == 0 {
+		t.Fatal("source line has no entity id")
+	}
+
+	// Project the source line onto a part face (associative surface).
+	var proj wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "projectToSurface", FaceRefs: []string{ref}, SourceEntityID: line.EntityID,
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &proj)
+	if !proj.Healthy || proj.EntityID == 0 {
+		t.Fatalf("projectToSurface = %+v, want healthy with an id", proj)
+	}
+
+	// Offset the source line in the XY plane.
+	var off wire.AddSketch3DSurfaceCurveResult
+	args, _ = json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "offset", SourceEntityID: line.EntityID, OffsetDistance: 2, Normal: []float64{0, 0, 1},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &off)
+	if !off.Healthy || off.EntityID == 0 {
+		t.Fatalf("offset = %+v, want healthy with an id", off)
+	}
+
+	// An unknown source entity id is an error.
+	if _, err := r.Handle(s, "sketch3d.addSurfaceCurve", []byte(`{"sketchIndex":0,"kind":"offset","sourceEntityId":99999,"normal":[0,0,1]}`)); err == nil {
+		t.Error("expected an error for an unknown source entity id")
+	}
+}
+
+// TestSketch3DSurfaceCurveRebindsOnRecompute is the F11 keystone: a surface curve bound to
+// a part face by reference key FOLLOWS that face when the part recomputes (the associative
+// SurfaceSource re-resolves the moved surface). An onFace curve on the top face tracks the
+// extrude height as a driving parameter changes.
+func TestSketch3DSurfaceCurveRebindsOnRecompute(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := topFaceKey(t, part)
+
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var res wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "onFace", FaceRefs: []string{ref}, UV: []float64{0, 0, 1, 0, 1, 1},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &res)
+	if !res.Healthy {
+		t.Fatal("onFace curve not healthy")
+	}
+
+	z1 := onFaceMaxZ(t, part, res.EntityID) // top face at 50mm = 5cm
+	if stdmath.Abs(z1-5) > 0.5 {
+		t.Fatalf("initial curve z=%v cm, want ~5", z1)
+	}
+
+	// Grow the extrude and recompute (destroys + regenerates the body); the top face moves
+	// to z = 8cm and the same reference key rebinds to it.
+	setExtrudeDistance(t, part, 8)
+
+	z2 := onFaceMaxZ(t, part, res.EntityID)
+	if stdmath.Abs(z2-8) > 0.5 || z2 <= z1 {
+		t.Fatalf("after recompute curve z=%v cm, want ~8 (followed the moved face); z1=%v", z2, z1)
+	}
+}
+
+// setExtrudeDistance changes the part's extrude feature to distance d (db units) and
+// recomputes, so the body is regenerated.
+func setExtrudeDistance(t *testing.T, part *compdef.PartComponentDefinition, d float64) {
+	t.Helper()
+	feats := part.Features()
+	for i := 0; i < feats.Count(); i++ {
+		pf := feats.Item(i)
+		if ext, ok := pf.Definition().(*feature.ExtrudeFeature); ok {
+			ext.SetDistance(d)
+			feats.MarkDirty(pf)
+			part.Recompute()
+			return
+		}
+	}
+	t.Fatal("no extrude feature found")
+}
+
+// topFaceKey returns the reference key of the part's top (+Z normal) planar face.
+func topFaceKey(t *testing.T, part *compdef.PartComponentDefinition) string {
+	t.Helper()
+	for _, b := range part.SurfaceBodies().All() {
+		for _, f := range b.Faces() {
+			if pl, ok := f.Geometry().(geom.Plane); ok && float64(pl.Normal().Z) > 0.9 {
+				return string(f.ReferenceKey())
+			}
+		}
+	}
+	t.Fatal("no top (+Z) face found")
+	return ""
+}
+
+// onFaceMaxZ evaluates the onFace surface curve with the given entity id and returns the
+// maximum z of its points (the face's height).
+func onFaceMaxZ(t *testing.T, part *compdef.PartComponentDefinition, id uint64) float64 {
+	t.Helper()
+	sk := part.Sketches3D().Item(0)
+	e, ok := sk.EntityByID(sketch.ID(id))
+	if !ok {
+		t.Fatalf("no entity %d in the 3D sketch", id)
+	}
+	c, ok := e.(*sketch.OnFaceCurve3D)
+	if !ok {
+		t.Fatalf("entity %d is %T, want *OnFaceCurve3D", id, e)
+	}
+	maxZ := -1e18
+	for _, p := range c.Evaluate() {
+		if float64(p.Z) > maxZ {
+			maxZ = float64(p.Z)
+		}
+	}
+	return maxZ
+}
+
+// TestModelReferenceKeysSurfacesAndRoundTrips: model.referenceKeys exposes a box's
+// topology with keys, and a surfaced face key is consumable by a key consumer (the F08
+// round-trip that makes the whole reference-key workflow usable over the wire).
+func TestModelReferenceKeysSurfacesAndRoundTrips(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	if len(keys.Bodies) != 1 {
+		t.Fatalf("bodies = %d, want 1", len(keys.Bodies))
+	}
+	b := keys.Bodies[0]
+	if len(b.Faces) != 6 || len(b.Edges) != 12 || len(b.Vertices) != 8 {
+		t.Fatalf("box topology = %d faces / %d edges / %d vertices, want 6/12/8", len(b.Faces), len(b.Edges), len(b.Vertices))
+	}
+	for _, f := range b.Faces {
+		if f.Key == "" || len(f.Point) != 3 {
+			t.Fatalf("face ref = %+v, want a key and a 3-coord point", f)
+		}
+	}
+
+	// The surfaced key is consumable: feed it straight into a surface-curve constructor.
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var sc wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "onFace", FaceRefs: []string{b.Faces[0].Key}, UV: []float64{0, 0, 1, 0, 1, 1},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &sc)
+	if !sc.Healthy {
+		t.Fatal("a surfaced face key should be consumable by addSurfaceCurve")
 	}
 }
 

--- a/addin/router/sketch_edit.go
+++ b/addin/router/sketch_edit.go
@@ -70,23 +70,32 @@ func applyTransform(part *compdef.PartComponentDefinition, sk *sketch.Sketch, en
 // curveEditOp dispatches the single-curve edit ops (trim/split/extend), which act on the
 // first selected line at a pick point (Vector).
 func curveEditOp(sk *sketch.Sketch, ents []sketch.Entity, in wire.TransformSketchArgs) ([]sketch.Entity, error) {
-	l, ok := ents[0].(*sketch.Line)
-	if !ok {
-		return nil, fmt.Errorf("sketch.transform: %s currently supports lines only (got %T)", in.Op, ents[0])
-	}
 	pick, err := vector2AsPoint(in.Vector)
 	if err != nil {
 		return nil, err
 	}
-	switch in.Op {
-	case "trim":
-		return sk.TrimLine(l, pick)
-	case "split":
-		return sk.SplitLine(l, pick)
-	default: // extend
-		_, err := sk.ExtendLine(l, pickNearerEnd(l, pick))
-		return nil, err
+	// Trim accepts any curve target (line/circle/arc); split/extend act on lines.
+	if in.Op == "trim" {
+		switch e := ents[0].(type) {
+		case *sketch.Line:
+			return sk.TrimLine(e, pick)
+		case *sketch.Circle:
+			return sk.TrimCircle(e, pick)
+		case *sketch.Arc:
+			return sk.TrimArc(e, pick)
+		default:
+			return nil, fmt.Errorf("sketch.transform: trim unsupported target %T", ents[0])
+		}
 	}
+	l, ok := ents[0].(*sketch.Line)
+	if !ok {
+		return nil, fmt.Errorf("sketch.transform: %s currently supports lines only (got %T)", in.Op, ents[0])
+	}
+	if in.Op == "split" {
+		return sk.SplitLine(l, pick)
+	}
+	_, err = sk.ExtendLine(l, pickNearerEnd(l, pick)) // extend
+	return nil, err
 }
 
 // vector2AsPoint reads the [x,y] pick point from the transform's Vector field.

--- a/addin/router/work_plane_face_test.go
+++ b/addin/router/work_plane_face_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/Oblikovati/api/wire"
+)
+
+// TestWorkPlaneOnFaceThenSketch covers the feature-interaction path: a work plane built on a
+// body face a feature created (toWorkRefs tags the topology key as a FaceRef), then a sketch
+// on that work plane (sketch.create workPlaneIndex). Both were impossible before — the work
+// plane could only offset an origin plane, and a sketch could only sit on an origin plane.
+func TestWorkPlaneOnFaceThenSketch(t *testing.T) {
+	r, s := seededSession(t) // a part with one closed rectangle profile
+
+	// Extrude the profile into a body so it has B-rep faces.
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"10 mm"}}`, nil)
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	if len(keys.Bodies) == 0 || len(keys.Bodies[0].Faces) == 0 {
+		t.Fatal("extruded body exposes no faces")
+	}
+	faceKey := keys.Bodies[0].Faces[0].Key
+
+	// Work plane offset from that feature-created face (FaceRef resolution).
+	var wp wire.CreateWorkPlaneResult
+	args := fmt.Sprintf(`{"kind":"plane-offset","refs":[%s],"offset":"5 mm"}`, jsonString(faceKey))
+	call(t, r, s, "workPlanes.create", args, &wp)
+	if !wp.Healthy {
+		t.Fatalf("work plane on a feature face is unhealthy (index %d)", wp.Index)
+	}
+
+	// Sketch on that work plane.
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create", fmt.Sprintf(`{"workPlaneIndex":%d}`, wp.Index), &sk)
+	if sk.SketchIndex < 1 {
+		t.Fatalf("sketch on work plane got index %d, want a new sketch beyond the seeded one", sk.SketchIndex)
+	}
+}
+
+// jsonString quotes s as a JSON string literal (the reference key may contain control bytes).
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -5,6 +5,7 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Oblikovati/api/types"
 	"github.com/Oblikovati/api/wire"
@@ -168,10 +169,19 @@ func addFixedWorkPlane(planes *feature.WorkPlanes, in wire.CreateWorkPlaneArgs) 
 }
 
 // toWorkRefs converts the request's reference strings to model work references.
+// toWorkRefs wraps reference strings as work refs. An origin reference ("origin/plane/xy",
+// "origin/axis/z", …) and a user work plane/axis name are plain plane/axis refs; any other
+// string is a B-rep topology reference key (from model.referenceKeys) and is tagged as a
+// FaceRef so the resolver builds the plane on that body face — the way a work plane lands on a
+// surface a feature created. (Edge/vertex-based kinds over the wire are a known limitation.)
 func toWorkRefs(refs []string) []feature.WorkRef {
 	out := make([]feature.WorkRef, len(refs))
 	for i, r := range refs {
-		out[i] = feature.WorkRef(r)
+		if strings.HasPrefix(r, "origin/") {
+			out[i] = feature.WorkRef(r)
+		} else {
+			out[i] = feature.FaceRef([]byte(r))
+		}
 	}
 	return out
 }

--- a/addin/trace/sloghandler.go
+++ b/addin/trace/sloghandler.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package trace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Oblikovati/api/wire"
+)
+
+// SlogHandler returns a [slog.Handler] that appends every record at or above min into this
+// buffer (as a structured entry: Method empty, Message set). Installing it as the default
+// logger (slog.SetDefault) means any future kernel logging flows into the same trace the
+// router fills, so a single Tail sees both operations and logs interleaved by Seq.
+func (b *Buffer) SlogHandler(min slog.Level) slog.Handler {
+	return &slogHandler{buf: b, min: min}
+}
+
+// slogHandler folds an slog.Record (message + attrs) into a flat [wire.LogRecord]; attrs are
+// rendered "key=value" onto the message so the wire shape stays simple.
+type slogHandler struct {
+	buf    *Buffer
+	min    slog.Level
+	prefix string // accumulated "key=value" attrs from WithAttrs, space-separated
+	group  string // current group name (prefixes attr keys)
+}
+
+func (h *slogHandler) Enabled(_ context.Context, l slog.Level) bool { return l >= h.min }
+
+// Handle renders the record and pushes it to the buffer (never erroring — a dropped log must
+// not break the operation that logged it).
+func (h *slogHandler) Handle(_ context.Context, r slog.Record) error {
+	parts := make([]string, 0, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		parts = append(parts, h.render(a))
+		return true
+	})
+	h.buf.push(wire.LogRecord{
+		Level:      slogLevelName(r.Level),
+		Message:    joinMessage(r.Message, h.prefix, strings.Join(parts, " ")),
+		TimeMillis: r.Time.UnixMilli(),
+	})
+	return nil
+}
+
+// WithAttrs returns a handler that prepends the given attrs to every record's message.
+func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	rendered := make([]string, len(attrs))
+	for i, a := range attrs {
+		rendered[i] = h.render(a)
+	}
+	return &slogHandler{buf: h.buf, min: h.min, group: h.group, prefix: joinFields(h.prefix, strings.Join(rendered, " "))}
+}
+
+// WithGroup returns a handler whose subsequent attr keys are namespaced under name.
+func (h *slogHandler) WithGroup(name string) slog.Handler {
+	return &slogHandler{buf: h.buf, min: h.min, prefix: h.prefix, group: joinGroup(h.group, name)}
+}
+
+// render formats one attr as "key=value", namespaced by the current group.
+func (h *slogHandler) render(a slog.Attr) string {
+	key := a.Key
+	if h.group != "" {
+		key = h.group + "." + key
+	}
+	return fmt.Sprintf("%s=%v", key, a.Value.Any())
+}
+
+// joinMessage assembles the final message text from the base message and any attr fields.
+func joinMessage(msg, prefix, attrs string) string {
+	return joinFields(msg, joinFields(prefix, attrs))
+}
+
+func joinFields(a, b string) string {
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return a + " " + b
+	}
+}
+
+func joinGroup(a, b string) string {
+	if a == "" {
+		return b
+	}
+	return a + "." + b
+}
+
+// slogLevelName maps an slog.Level to the trace's lowercase level vocabulary.
+func slogLevelName(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError:
+		return "error"
+	case l >= slog.LevelWarn:
+		return "warn"
+	case l >= slog.LevelInfo:
+		return "info"
+	default:
+		return "debug"
+	}
+}

--- a/addin/trace/trace.go
+++ b/addin/trace/trace.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package trace is the host's in-memory operation trace: a thread-safe ring buffer of
+// [wire.LogRecord]s that the add-in router fills (one record per served method call, with
+// timing and outcome) and that any [log/slog] logger can append to. It backs the diagnostics
+// surface (wire.MethodLogsTail) so a driver can watch the kernel work in real time, see
+// detailed errors, and catch panics while stress-testing — there is no other logging in the
+// core today, so this trace is the single source of truth for "what the kernel just did".
+package trace
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Oblikovati/api/wire"
+)
+
+// DefaultCapacity is the ring size when [NewBuffer] is given a non-positive capacity — large
+// enough to survive a burst of stress-test calls between polls without dropping.
+const DefaultCapacity = 4096
+
+// defaultTailMax caps a Tail with no explicit Max, so a poll can't return an unbounded slice.
+const defaultTailMax = 500
+
+// Buffer is a bounded, monotonic record stream. Records carry a gap-free Seq (assigned on
+// push); when the ring overflows the oldest are dropped and counted, so a slow poller learns
+// it missed some. All methods are safe for concurrent use.
+type Buffer struct {
+	mu       sync.Mutex
+	records  []wire.LogRecord
+	capacity int
+	nextSeq  uint64
+	dropped  uint64
+}
+
+// NewBuffer returns a trace buffer holding up to capacity records (DefaultCapacity if <= 0).
+func NewBuffer(capacity int) *Buffer {
+	if capacity <= 0 {
+		capacity = DefaultCapacity
+	}
+	return &Buffer{capacity: capacity}
+}
+
+// push assigns the next Seq, stamps the time if unset, appends, and evicts the oldest beyond
+// capacity (counting the eviction as dropped).
+func (b *Buffer) push(r wire.LogRecord) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nextSeq++
+	r.Seq = b.nextSeq
+	if r.TimeMillis == 0 {
+		r.TimeMillis = time.Now().UnixMilli()
+	}
+	b.records = append(b.records, r)
+	if over := len(b.records) - b.capacity; over > 0 {
+		b.dropped += uint64(over)
+		b.records = b.records[over:]
+	}
+}
+
+// RecordOp appends an operation entry: a router method call with its duration and outcome.
+// A non-empty panicMsg marks a recovered kernel panic (the bug signal) and carries its stack.
+func (b *Buffer) RecordOp(method string, dur time.Duration, ok bool, errMsg, panicMsg, stack string) {
+	b.push(wire.LogRecord{
+		Level:          opLevel(ok, panicMsg),
+		Method:         method,
+		DurationMicros: dur.Microseconds(),
+		OK:             ok,
+		Error:          errMsg,
+		Panic:          panicMsg,
+		Stack:          stack,
+	})
+}
+
+// opLevel maps an operation outcome to a severity: panic ⇒ error, plain failure ⇒ warn, ok ⇒ info.
+func opLevel(ok bool, panicMsg string) string {
+	switch {
+	case panicMsg != "":
+		return "error"
+	case !ok:
+		return "warn"
+	default:
+		return "info"
+	}
+}
+
+// Tail returns records with Seq > sinceSeq, at or above the given minimum level (empty ⇒ all),
+// oldest-first and capped to max (defaultTailMax if <= 0). NextSeq is the cursor to poll with
+// next (the highest Seq scanned this call), so repeated tailing yields only new records.
+func (b *Buffer) Tail(sinceSeq uint64, level string, max int) wire.LogsResult {
+	if max <= 0 {
+		max = defaultTailMax
+	}
+	minRank := levelRank(level)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	res := wire.LogsResult{NextSeq: sinceSeq, Dropped: b.dropped}
+	for _, r := range b.records {
+		if r.Seq <= sinceSeq {
+			continue
+		}
+		res.NextSeq = r.Seq
+		if levelRank(r.Level) >= minRank {
+			res.Records = append(res.Records, r)
+		}
+		if len(res.Records) >= max {
+			break
+		}
+	}
+	return res
+}
+
+// levelRank orders severities so a minimum-level filter is a simple comparison; an unknown or
+// empty level ranks below everything (so the "all" filter and unlabeled records always pass).
+func levelRank(level string) int {
+	switch level {
+	case "debug":
+		return 1
+	case "info":
+		return 2
+	case "warn":
+		return 3
+	case "error":
+		return 4
+	default:
+		return 0
+	}
+}

--- a/addin/trace/trace_test.go
+++ b/addin/trace/trace_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package trace
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestRecordOpAndTailCursor(t *testing.T) {
+	b := NewBuffer(0)
+	b.RecordOp("a.one", 100*time.Microsecond, true, "", "", "")
+	b.RecordOp("a.two", 200*time.Microsecond, false, "a.two: bad", "", "")
+
+	res := b.Tail(0, "", 0)
+	if len(res.Records) != 2 {
+		t.Fatalf("got %d records, want 2", len(res.Records))
+	}
+	if res.Records[0].Method != "a.one" || res.Records[0].Level != "info" {
+		t.Errorf("rec0 = %+v, want a.one/info", res.Records[0])
+	}
+	if res.Records[1].Level != "warn" || res.Records[1].Error != "a.two: bad" {
+		t.Errorf("rec1 = %+v, want warn + error text", res.Records[1])
+	}
+	// Cursor: polling with NextSeq returns only newer records.
+	if got := b.Tail(res.NextSeq, "", 0); len(got.Records) != 0 {
+		t.Errorf("tail after cursor returned %d, want 0", len(got.Records))
+	}
+	b.RecordOp("a.three", 0, true, "", "", "")
+	if got := b.Tail(res.NextSeq, "", 0); len(got.Records) != 1 || got.Records[0].Method != "a.three" {
+		t.Errorf("incremental tail = %+v, want only a.three", got.Records)
+	}
+}
+
+func TestTailLevelFilter(t *testing.T) {
+	b := NewBuffer(0)
+	b.RecordOp("ok", 0, true, "", "", "")            // info
+	b.RecordOp("warn", 0, false, "x", "", "")        // warn
+	b.RecordOp("boom", 0, false, "", "panic", "stk") // error
+	res := b.Tail(0, "warn", 0)
+	if len(res.Records) != 2 {
+		t.Fatalf("warn+ filter got %d, want 2", len(res.Records))
+	}
+	for _, r := range res.Records {
+		if r.Level == "info" {
+			t.Errorf("info record leaked past warn filter: %+v", r)
+		}
+	}
+}
+
+func TestRingDropsOldestAndCounts(t *testing.T) {
+	b := NewBuffer(3)
+	for i := 0; i < 5; i++ {
+		b.RecordOp("m", 0, true, "", "", "")
+	}
+	res := b.Tail(0, "", 0)
+	if len(res.Records) != 3 {
+		t.Fatalf("ring kept %d, want capacity 3", len(res.Records))
+	}
+	if res.Dropped != 2 {
+		t.Errorf("dropped = %d, want 2", res.Dropped)
+	}
+	if res.Records[0].Seq != 3 {
+		t.Errorf("oldest retained Seq = %d, want 3 (1,2 evicted)", res.Records[0].Seq)
+	}
+}
+
+func TestSlogHandlerCaptured(t *testing.T) {
+	b := NewBuffer(0)
+	log := slog.New(b.SlogHandler(slog.LevelInfo))
+	log.Info("hello", "k", 7)
+	log.Debug("ignored") // below the handler minimum
+	res := b.Tail(0, "", 0)
+	if len(res.Records) != 1 {
+		t.Fatalf("captured %d records, want 1 (debug filtered)", len(res.Records))
+	}
+	r := res.Records[0]
+	if r.Method != "" || r.Level != "info" || r.Message == "" {
+		t.Errorf("slog record = %+v, want structured info entry", r)
+	}
+}

--- a/app/auto_dimension_command_test.go
+++ b/app/auto_dimension_command_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// TestAutoDimensionCommandConstrainsSketch drives the Auto Dimension ribbon command
+// end-to-end: an under-constrained rectangle becomes fully (well-)constrained.
+func TestAutoDimensionCommandConstrainsSketch(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	sk := def.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	sk.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 3))
+	if sk.DegreesOfFreedom() == 0 {
+		t.Fatal("rectangle should start under-constrained")
+	}
+
+	if err := s.Execute("Sketch.AutoDimension"); err != nil {
+		t.Fatalf("Execute Sketch.AutoDimension: %v", err)
+	}
+
+	a := sk.AnalyzeConstraints()
+	if a.DOF != 0 || a.Redundant != 0 {
+		t.Fatalf("after Auto Dimension: DOF=%d Redundant=%d, want 0/0", a.DOF, a.Redundant)
+	}
+}
+
+func TestAutoDimensionCommandRegistered(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if _, ok := s.Commands().ByID("Sketch.AutoDimension"); !ok {
+		t.Error("Sketch.AutoDimension command not registered")
+	}
+}

--- a/app/command.go
+++ b/app/command.go
@@ -53,6 +53,8 @@ type CommandDefinition struct {
 	enabled     func(*Session) bool
 	active      func(*Session) bool // for a ComboControl option: is this the current selection?
 	run         func(*Session) error
+	variants    []*CommandDefinition // split-button dropdown entries (Inventor's variant flyout)
+	isVariant   bool                 // true ⇒ reachable only via a head command's dropdown, never its own panel button
 }
 
 // NewCommand starts a command definition with the required fields. Use the With*
@@ -108,6 +110,24 @@ func (c *CommandDefinition) WithEnable(p func(*Session) bool) *CommandDefinition
 	c.enabled = p
 	return c
 }
+
+// WithVariants attaches a split-button dropdown to this command — Inventor's variant
+// flyout, where one ribbon head (e.g. "Rectangle") fronts a list of related geometry
+// tools (Three Point, Two Point Center, …). The head still runs its own action when
+// clicked; the variants appear only in its dropdown, never as standalone panel buttons,
+// so the canonical panel-head count is unchanged. Variants are registered for id lookup
+// (so [Session.Execute] can run them) by [RegisterStandardCommands].
+func (c *CommandDefinition) WithVariants(variants ...*CommandDefinition) *CommandDefinition {
+	for _, v := range variants {
+		v.isVariant = true
+	}
+	c.variants = variants
+	return c
+}
+
+// Variants returns this command's split-button dropdown entries (nil if it is a plain
+// button). The slice is the live backing array; callers must not mutate it.
+func (c *CommandDefinition) Variants() []*CommandDefinition { return c.variants }
 
 // WithActive sets the predicate that reports whether this command is the *current* selection
 // of its combo group — used to drive the highlighted item of a ribbon selection box (a panel

--- a/app/commands_sketch.go
+++ b/app/commands_sketch.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"strings"
+)
+
+// The contextual 2D Sketch tab, built from the command registry to mirror Inventor's
+// ribbon (see architecture/mapping/inventor-ribbon-structure.md): panels Create, Modify,
+// Pattern, Constrain, Exit. Split out of commands_standard.go (which exceeded the file-size
+// limit) so the sketch ribbon lives in one place.
+
+// sketchTabCommands assembles the Sketch tab in panel order.
+func sketchTabCommands() []*CommandDefinition {
+	cmds := createCommands()
+	cmds = append(cmds, sketchModifyCommands()...)
+	cmds = append(cmds, sketchPatternCommands()...)
+	cmds = append(cmds, sketchFormatCommands()...)
+	// Constrain panel (Inventor order): Dimension, Auto Dimension, then the constraint
+	// tools — there is no separate "Dimension" panel in the Inventor Sketch tab.
+	cmds = append(cmds, NewCommand("Sketch.Dimension", "Dimension", "Constrain", func(s *Session) error {
+		s.StartTool(newDimensionTool())
+		return nil
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithAlias("D").WithEnable(inSketch).
+		WithIcon("dimension").WithButtonStyle(SmallIconButton).
+		WithTooltip("Dimension — then pick points/a line/a circle/two lines to dimension."))
+	cmds = append(cmds, NewCommand("Sketch.AutoDimension", "Auto Dimension", "Constrain", func(s *Session) error {
+		sk := s.ActiveSketch()
+		if sk == nil {
+			return errors.New("auto dimension: no active sketch")
+		}
+		sk.AutoDimension()
+		return nil
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
+		WithIcon("auto-dimension").WithButtonStyle(SmallIconButton).
+		WithTooltip("Auto Dimension — fully constrain the sketch with dimensions and grounds."))
+	cmds = append(cmds, constrainCommands()...)
+	cmds = append(cmds, NewCommand("Sketch.Project", "Project Geometry", "Draw", func(s *Session) error {
+		s.StartTool(NewProjectGeometryTool())
+		return nil
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
+		WithIcon("project-geometry").WithButtonStyle(SmallIconButton).
+		WithTooltip("Project Geometry — pick part edges/vertices to reference onto the sketch plane."))
+	return append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
+		return s.FinishSketch()
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
+		WithIcon("finish-sketch").WithButtonStyle(LargeIconButton).
+		WithTooltip("Finish Sketch — leave the sketch environment and update the part."))
+}
+
+// sketchToolEntry is one tool-launching command (id/label/alias/tooltip + factory).
+// variants, when present, become the entry's split-button dropdown (Inventor's variant
+// flyout): sibling tools reachable from the head's arrow, not their own panel buttons.
+type sketchToolEntry struct {
+	id, name, alias, tip string
+	start                func() Tool
+	variants             []sketchToolEntry
+}
+
+// newToolCommand builds one tool-launching command (no alias/icon for variants, which only
+// appear in a dropdown). The factory is captured per-call so each command starts its own tool.
+func newToolCommand(panel string, e sketchToolEntry) *CommandDefinition {
+	start := e.start
+	return NewCommand(e.id, e.name, panel, func(s *Session) error {
+		s.StartTool(start())
+		return nil
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).WithTooltip(e.tip)
+}
+
+// buildToolCommands turns a table of tool entries into ribbon commands on the given panel,
+// attaching each entry's variants as its split-button dropdown.
+func buildToolCommands(panel string, entries []sketchToolEntry) []*CommandDefinition {
+	cmds := make([]*CommandDefinition, len(entries))
+	for i, e := range entries {
+		cmd := newToolCommand(panel, e).WithAlias(e.alias).
+			WithIcon(strings.ToLower(e.name)).WithButtonStyle(SmallIconButton)
+		if len(e.variants) > 0 {
+			variants := make([]*CommandDefinition, len(e.variants))
+			for j, v := range e.variants {
+				variants[j] = newToolCommand(panel, v)
+			}
+			cmd.WithVariants(variants...)
+		}
+		cmds[i] = cmd
+	}
+	return cmds
+}
+
+// sketchModifyCommands are the Sketch tab's Modify panel (Inventor order: Move, Copy,
+// Rotate, Scale, Trim, Extend, Split, Offset; Stretch is a follow-up). Each starts an
+// interactive tool the user feeds geometry.
+func sketchModifyCommands() []*CommandDefinition {
+	return buildToolCommands("Modify", []sketchToolEntry{
+		{id: "Sketch.Move", name: "Move", tip: "Move — select geometry, then set the move vector.", start: func() Tool { return NewSketchMoveTool() }},
+		{id: "Sketch.Copy", name: "Copy", tip: "Copy — select geometry, then set the copy offset.", start: func() Tool { return NewSketchCopyTool() }},
+		{id: "Sketch.Rotate", name: "Rotate", tip: "Rotate — select geometry, then set the center and angle.", start: func() Tool { return NewSketchRotateTool() }},
+		{id: "Sketch.Scale", name: "Scale", tip: "Scale — select geometry, then set the center and factor.", start: func() Tool { return NewSketchScaleTool() }},
+		{id: "Sketch.Stretch", name: "Stretch", tip: "Stretch — pick vertices to move, then set the vector.", start: func() Tool { return NewSketchStretchTool() }},
+		{id: "Sketch.Trim", name: "Trim", alias: "X", tip: "Trim — pick the curve segment to remove up to its crossings.", start: func() Tool { return NewSketchTrimTool() }},
+		{id: "Sketch.Extend", name: "Extend", alias: "EX", tip: "Extend — pick near a line end to lengthen it to the next crossing.", start: func() Tool { return NewSketchExtendTool() }},
+		{id: "Sketch.Split", name: "Split", alias: "SX", tip: "Split — pick the point to split a curve into two.", start: func() Tool { return NewSketchSplitTool() }},
+		{id: "Sketch.Offset", name: "Offset", alias: "O", tip: "Offset — pick a curve to offset by a distance.", start: func() Tool { return NewSketchOffsetTool(0.5) }},
+	})
+}
+
+// sketchPatternCommands are the Sketch tab's Pattern panel (Rectangular, Circular, Mirror).
+func sketchPatternCommands() []*CommandDefinition {
+	return buildToolCommands("Pattern", []sketchToolEntry{
+		{id: "Sketch.RectangularPattern", name: "Rectangular", tip: "Rectangular Pattern — select geometry, then set directions and counts.", start: func() Tool { return NewSketchRectPatternTool() }},
+		{id: "Sketch.CircularPattern", name: "Circular", tip: "Circular Pattern — select geometry, then set center, count and angle.", start: func() Tool { return NewSketchCircPatternTool() }},
+		{id: "Sketch.Mirror", name: "Mirror", alias: "MI", tip: "Mirror — pick geometry, then a mirror line.", start: func() Tool { return NewSketchMirrorTool() }},
+	})
+}
+
+// createCommands are the Sketch tab's Create panel — the geometry tools (plus Fillet,
+// which Inventor places in Create, not Modify).
+func createCommands() []*CommandDefinition {
+	return buildToolCommands("Create", []sketchToolEntry{
+		{id: "Sketch.Line", name: "Line", alias: "L", tip: "Line — draw a line between two points.", start: func() Tool { return NewLineTool() }},
+		{id: "Sketch.Rectangle", name: "Rectangle", alias: "REC", tip: "Rectangle — draw a two-corner rectangle.", start: func() Tool { return NewRectangleTool() }, variants: []sketchToolEntry{
+			{id: "Sketch.Rectangle.ThreePoint", name: "Three Point Rectangle", tip: "Three Point Rectangle — base edge then width.", start: func() Tool { return NewThreePointRectangleTool() }},
+			{id: "Sketch.Rectangle.Center", name: "Two Point Center Rectangle", tip: "Two Point Center Rectangle — center then a corner.", start: func() Tool { return NewCenterRectangleTool() }},
+		}},
+		{id: "Sketch.Circle", name: "Circle", alias: "C", tip: "Circle — draw a circle from its center and radius.", start: func() Tool { return NewCircleTool() }, variants: []sketchToolEntry{
+			{id: "Sketch.Circle.ThreePoint", name: "Three Point Circle", tip: "Three Point Circle — the circle through three points.", start: func() Tool { return NewThreePointCircleTool() }},
+		}},
+		{id: "Sketch.Arc", name: "Arc", alias: "A", tip: "Arc — draw a three-point arc.", start: func() Tool { return NewArcTool() }, variants: []sketchToolEntry{
+			{id: "Sketch.Arc.CenterPoint", name: "Center Point Arc", tip: "Center Point Arc — center, start, then end.", start: func() Tool { return NewCenterPointArcTool() }},
+		}},
+		{id: "Sketch.Slot", name: "Slot", tip: "Slot — click two centre points for a straight slot.", start: func() Tool { return NewSketchSlotTool(1) }, variants: []sketchToolEntry{
+			{id: "Sketch.Slot.CenterArc", name: "Center Point Arc Slot", tip: "Center Point Arc Slot — center, start, then end.", start: func() Tool { return NewCenterPointArcSlotTool(1) }},
+			{id: "Sketch.Slot.ThreePointArc", name: "Three Point Arc Slot", tip: "Three Point Arc Slot — start, a point on the arc, then end.", start: func() Tool { return NewThreePointArcSlotTool(1) }},
+		}},
+		{id: "Sketch.Spline", name: "Spline", alias: "SPL", tip: "Spline — draw an interpolated curve through fit points.", start: func() Tool { return NewSplineTool() }, variants: []sketchToolEntry{
+			{id: "Sketch.Spline.ControlVertex", name: "Control Vertex Spline", tip: "Control Vertex Spline — draw a curve from its control polygon.", start: func() Tool { return NewControlVertexSplineTool() }},
+		}},
+		{id: "Sketch.Ellipse", name: "Ellipse", alias: "EL", tip: "Ellipse — draw an ellipse from center and axes.", start: func() Tool { return NewEllipseTool() }},
+		{id: "Sketch.Polygon", name: "Polygon", alias: "POL", tip: "Polygon — draw a regular inscribed polygon.", start: func() Tool { return NewPolygonTool(6) }},
+		{id: "Sketch.Fillet", name: "Fillet", alias: "FF", tip: "Fillet — pick two lines to round their corner.", start: func() Tool { return NewSketchFilletTool(0.5) }},
+		{id: "Sketch.Chamfer", name: "Chamfer", tip: "Chamfer — pick two lines to bevel their corner.", start: func() Tool { return NewSketchChamferTool(0.5) }},
+		{id: "Sketch.Text", name: "Text", tip: "Text — click an anchor, then type the text.", start: func() Tool { return NewSketchTextTool() }},
+		{id: "Sketch.Point", name: "Point", alias: "PT", tip: "Point — place sketch points.", start: func() Tool { return NewPointTool() }},
+	})
+}
+
+// constrainCommands are the Sketch tab's Constrain panel — each starts an interactive
+// constraint tool the user then feeds geometry (Inventor's tool-first flow).
+func constrainCommands() []*CommandDefinition {
+	cmds := make([]*CommandDefinition, len(constraintToolDefs))
+	for i, d := range constraintToolDefs {
+		newTool := d.new
+		cmds[i] = NewCommand(d.id, d.name, "Constrain", func(s *Session) error {
+			s.StartTool(newTool())
+			return nil
+		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).WithTooltip(d.tooltip).
+			WithIcon(strings.ToLower(d.name)).WithButtonStyle(SmallIconButton)
+	}
+	return cmds
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -3,8 +3,6 @@
 package app
 
 import (
-	"strings"
-
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
@@ -18,6 +16,13 @@ func RegisterStandardCommands(s *Session) error {
 	for _, c := range standardCommands() {
 		if err := s.Commands().Add(c); err != nil {
 			return err
+		}
+		// Variants are flyout-only (skipped by BuildRibbon), but must be registered so a
+		// dropdown selection can be dispatched by id through Session.Execute.
+		for _, v := range c.Variants() {
+			if err := s.Commands().Add(v); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -125,7 +130,70 @@ func modelTabCommands() []*CommandDefinition {
 	}
 	cmds = append(cmds, sketch3DToolCommands()...)
 	cmds = append(cmds, solidFeatureCommands()...)
-	return append(cmds, modifyFeatureCommands()...)
+	cmds = append(cmds, modifyFeatureCommands()...)
+	cmds = append(cmds, patternFeatureCommands()...)
+	return append(cmds, surfaceFeatureCommands()...)
+}
+
+// surfaceFeatureCommands are the 3D Model tab's Surface panel (canonical: Patch, Stitch, Sculpt,
+// Extend, Trim, Rule Fillet). Patch fills a closed sketch region with a surface.
+func surfaceFeatureCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		NewCommand("Surface.Patch", "Patch", "Surface", func(s *Session) error {
+			s.StartTool(NewPatchTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).
+			WithIcon("patch").WithButtonStyle(LargeIconButton).
+			WithTooltip("Patch — fill a closed sketch boundary with a surface."),
+		NewCommand("Surface.Trim", "Trim", "Surface", func(s *Session) error {
+			s.StartTool(NewSurfaceTrimTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).
+			WithIcon("surface-trim").WithButtonStyle(LargeIconButton).
+			WithTooltip("Trim — cut a surface with a work plane and keep one side."),
+		NewCommand("Surface.Stitch", "Stitch", "Surface", func(s *Session) error {
+			s.StartTool(NewStitchTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).
+			WithIcon("stitch").WithButtonStyle(LargeIconButton).
+			WithTooltip("Stitch — weld surface bodies into one quilt (a closed quilt becomes a solid)."),
+		NewCommand("Surface.Sculpt", "Sculpt", "Surface", func(s *Session) error {
+			s.StartTool(NewSculptTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).
+			WithIcon("sculpt").WithButtonStyle(LargeIconButton).
+			WithTooltip("Sculpt — fill the volume bounded by surfaces into a solid."),
+		NewCommand("Surface.Extend", "Extend", "Surface", func(s *Session) error {
+			s.StartTool(NewExtendTool())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).
+			WithIcon("surface-extend").WithButtonStyle(LargeIconButton).
+			WithTooltip("Extend — grow a surface outward along a boundary edge."),
+	}
+}
+
+// patternFeatureCommands are the 3D Model tab's Pattern panel: replicate selected features
+// as real placed copies (canonical ribbon: Rectangular, Circular, Sketch Driven, Mirror;
+// Sketch Driven is a follow-up). Each starts an interactive tool fed the source features.
+func patternFeatureCommands() []*CommandDefinition {
+	pats := []struct {
+		id, name, icon, tip string
+		start               func() Tool
+	}{
+		{"Modify.RectangularPattern", "Rectangular", "rectangular-pattern", "Rectangular Pattern — select features, set counts and spacing.", func() Tool { return NewFeatureRectPatternTool() }},
+		{"Modify.CircularPattern", "Circular", "circular-pattern", "Circular Pattern — select features, set count and angle.", func() Tool { return NewFeatureCircPatternTool() }},
+		{"Modify.Mirror", "Mirror", "mirror", "Mirror — select features, set the mirror-plane normal.", func() Tool { return NewFeatureMirrorTool() }},
+	}
+	cmds := make([]*CommandDefinition, len(pats))
+	for i, p := range pats {
+		start := p.start
+		cmds[i] = NewCommand(p.id, p.name, "Pattern", func(s *Session) error {
+			s.StartTool(start())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).WithTooltip(p.tip).
+			WithIcon(p.icon).WithButtonStyle(SmallIconButton)
+	}
+	return cmds
 }
 
 // sketch3DToolCommands are the contextual 3D-sketch tools, enabled only while a 3D sketch
@@ -179,7 +247,33 @@ func sketch3DToolCommand(id, name, icon, tip string, newTool func() Tool) *Comma
 // and surface→solid (thicken).
 func modifyFeatureCommands() []*CommandDefinition {
 	cmds := append(cutFeatureCommands(), localFaceCommands()...)
-	return append(cmds, surfaceSolidCommands()...)
+	cmds = append(cmds, surfaceSolidCommands()...)
+	return append(cmds, directEditCommands()...)
+}
+
+// directEditCommands are the Modify features that combine or relocate existing geometry:
+// Combine (boolean of two bodies), Move Face (direct edit), Move (relocate a body). They
+// were model-complete (M09/M20) but had no ribbon tool.
+func directEditCommands() []*CommandDefinition {
+	defs := []struct {
+		id, name, icon, tip string
+		start               func() Tool
+	}{
+		{"Modify.Combine", "Combine", "combine", "Combine — boolean two bodies (Join/Cut/Intersect).", func() Tool { return NewCombineTool() }},
+		{"Modify.Split", "Split", "split", "Split — divide the part by a work plane into two bodies, or trim one side away.", func() Tool { return NewSplitTool() }},
+		{"Modify.MoveFace", "Move Face", "move-face", "Move Face — translate picked faces, retopologizing the solid.", func() Tool { return NewMoveFaceTool() }},
+		{"Modify.MoveBodies", "Move Bodies", "move-bodies", "Move Bodies — relocate a body by a vector.", func() Tool { return NewMoveBodyTool() }},
+	}
+	cmds := make([]*CommandDefinition, len(defs))
+	for i, d := range defs {
+		start := d.start
+		cmds[i] = NewCommand(d.id, d.name, "Modify", func(s *Session) error {
+			s.StartTool(start())
+			return nil
+		}).WithTab("3D Model").WithEnable(hasActivePart).WithTooltip(d.tip).
+			WithIcon(d.icon).WithButtonStyle(SmallIconButton)
+	}
+	return cmds
 }
 
 // surfaceSolidCommands are the Modify features that turn a surface body into a solid.
@@ -312,98 +406,25 @@ func sweptSolidCommands() []*CommandDefinition {
 		}).WithTab("3D Model").WithEnable(notInSketch).
 			WithIcon("coil").WithButtonStyle(LargeIconButton).
 			WithTooltip("Coil — sweep a sketch profile along a helix to create or modify a solid."),
-	}
-}
-
-// sketchTabCommands are the contextual Sketch tab: geometry creation, constraints,
-// dimension, and Finish Sketch — all gated on being in the sketch environment.
-func sketchTabCommands() []*CommandDefinition {
-	cmds := createCommands()
-	cmds = append(cmds, sketchModifyCommands()...)
-	cmds = append(cmds, constrainCommands()...)
-	cmds = append(cmds, NewCommand("Sketch.Project", "Project Geometry", "Draw", func(s *Session) error {
-		s.StartTool(NewProjectGeometryTool())
-		return nil
-	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
-		WithIcon("project-geometry").WithButtonStyle(SmallIconButton).
-		WithTooltip("Project Geometry — pick part edges/vertices to reference onto the sketch plane."))
-	cmds = append(cmds, NewCommand("Sketch.Dimension", "Dimension", "Dimension", func(s *Session) error {
-		s.StartTool(newDimensionTool())
-		return nil
-	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithAlias("D").WithEnable(inSketch).
-		WithIcon("dimension").WithButtonStyle(SmallIconButton).
-		WithTooltip("Dimension — then pick points/a line/a circle/two lines to dimension."))
-	return append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
-		return s.FinishSketch()
-	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
-		WithIcon("finish-sketch").WithButtonStyle(LargeIconButton).
-		WithTooltip("Finish Sketch — leave the sketch environment and update the part."))
-}
-
-// sketchModifyCommands are the Sketch tab's Modify panel — the operations that edit
-// existing sketch geometry (offset, mirror, sketch fillet). Each starts an interactive
-// tool that the user feeds geometry, mirroring the constraint tools' flow.
-func sketchModifyCommands() []*CommandDefinition {
-	mods := []struct {
-		id, name, alias, tip string
-		start                func() Tool
-	}{
-		{"Sketch.Offset", "Offset", "O", "Offset — pick a curve to offset by a distance.", func() Tool { return NewSketchOffsetTool(0.5) }},
-		{"Sketch.Mirror", "Mirror", "MI", "Mirror — pick geometry, then a mirror line.", func() Tool { return NewSketchMirrorTool() }},
-		{"Sketch.Fillet", "Sketch Fillet", "FF", "Sketch Fillet — pick two lines to round their corner.", func() Tool { return NewSketchFilletTool(0.5) }},
-	}
-	cmds := make([]*CommandDefinition, len(mods))
-	for i, m := range mods {
-		start := m.start
-		cmds[i] = NewCommand(m.id, m.name, "Modify", func(s *Session) error {
-			s.StartTool(start())
+		NewCommand("Create.Rib", "Rib", "Create", func(s *Session) error {
+			s.StartTool(NewRibTool())
 			return nil
-		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithAlias(m.alias).WithEnable(inSketch).
-			WithTooltip(m.tip).WithIcon(strings.ToLower(m.name)).WithButtonStyle(SmallIconButton)
-	}
-	return cmds
-}
-
-// createCommands are the Sketch tab's Create panel — the geometry tools.
-func createCommands() []*CommandDefinition {
-	create := []struct {
-		id, name, alias, tip string
-		start                func() Tool
-	}{
-		{"Sketch.Line", "Line", "L", "Line — draw a line between two points.", func() Tool { return NewLineTool() }},
-		{"Sketch.Rectangle", "Rectangle", "REC", "Rectangle — draw a two-corner rectangle.", func() Tool { return NewRectangleTool() }},
-		{"Sketch.Circle", "Circle", "C", "Circle — draw a circle from its center and radius.", func() Tool { return NewCircleTool() }},
-		{"Sketch.Arc", "Arc", "A", "Arc — draw a three-point arc.", func() Tool { return NewArcTool() }},
-		{"Sketch.Spline", "Spline", "SPL", "Spline — draw an interpolated curve through fit points.", func() Tool { return NewSplineTool() }},
-		{"Sketch.Ellipse", "Ellipse", "EL", "Ellipse — draw an ellipse from center and axes.", func() Tool { return NewEllipseTool() }},
-		{"Sketch.Polygon", "Polygon", "POL", "Polygon — draw a regular inscribed polygon.", func() Tool { return NewPolygonTool(6) }},
-		{"Sketch.Point", "Point", "PT", "Point — place sketch points.", func() Tool { return NewPointTool() }},
-	}
-	cmds := make([]*CommandDefinition, len(create))
-	for i, c := range create {
-		start := c.start
-		cmds[i] = NewCommand(c.id, c.name, "Create", func(s *Session) error {
-			s.StartTool(start())
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("rib").WithButtonStyle(LargeIconButton).
+			WithTooltip("Rib — thicken an open sketch profile into a reinforcing wall joined to the part."),
+		NewCommand("Create.Emboss", "Emboss", "Create", func(s *Session) error {
+			s.StartTool(NewEmbossTool())
 			return nil
-		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithAlias(c.alias).WithEnable(inSketch).WithTooltip(c.tip).
-			WithIcon(strings.ToLower(c.name)).WithButtonStyle(SmallIconButton)
-	}
-	return cmds
-}
-
-// constrainCommands are the Sketch tab's Constrain panel — each starts an interactive
-// constraint tool that the user then feeds geometry (Inventor's tool-first flow).
-func constrainCommands() []*CommandDefinition {
-	cmds := make([]*CommandDefinition, len(constraintToolDefs))
-	for i, d := range constraintToolDefs {
-		newTool := d.new
-		cmds[i] = NewCommand(d.id, d.name, "Constrain", func(s *Session) error {
-			s.StartTool(newTool())
+		}).WithTab("3D Model").WithEnable(notInSketch).
+			WithIcon("emboss").WithButtonStyle(LargeIconButton).
+			WithTooltip("Emboss — raise or engrave a closed sketch profile on the part."),
+		NewCommand("Create.Decal", "Decal", "Create", func(s *Session) error {
+			s.StartTool(NewDecalTool())
 			return nil
-		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).WithTooltip(d.tooltip).
-			WithIcon(strings.ToLower(d.name)).WithButtonStyle(SmallIconButton)
+		}).WithTab("3D Model").WithEnable(hasActivePart).
+			WithIcon("decal").WithButtonStyle(LargeIconButton).
+			WithTooltip("Decal — project an image onto a face (cosmetic)."),
 	}
-	return cmds
 }
 
 // viewTabCommands are the View tab commands: navigation, the Visual Style presets, and the

--- a/app/commands_standard_test.go
+++ b/app/commands_standard_test.go
@@ -26,9 +26,9 @@ func TestStandardRibbonHasSketchCreatePanel(t *testing.T) {
 	if !ok {
 		t.Fatal("Sketch tab has no Create panel")
 	}
-	// Line, Rectangle, Circle, Arc, Spline, Ellipse, Polygon, Point.
-	if len(panel.Buttons) != 8 {
-		t.Errorf("Sketch Create panel has %d tools, want 8", len(panel.Buttons))
+	// Line, Rectangle, Circle, Arc, Slot, Spline, Ellipse, Polygon, Fillet, Chamfer, Text, Point.
+	if len(panel.Buttons) != 12 {
+		t.Errorf("Sketch Create panel has %d tools, want 12", len(panel.Buttons))
 	}
 }
 

--- a/app/decal_tool.go
+++ b/app/decal_tool.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// DecalTool is the interactive Decal command (Create panel): click a face, give an image
+// resource, and OK to place a decal on it. A decal is cosmetic — it does not change the solid —
+// so it cannot fail; the image is the resource id/path the renderer projects onto the face.
+type DecalTool struct {
+	face  *FaceHandle
+	image string
+	added *feature.DecalFeature
+}
+
+// NewDecalTool returns a decal tool.
+func NewDecalTool() *DecalTool { return &DecalTool{} }
+
+// Name implements [Tool].
+func (t *DecalTool) Name() string { return "Decal" }
+
+// Start filters selection to faces.
+func (t *DecalTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+
+// Pick captures the target face.
+func (t *DecalTool) Pick(_ *Session, sel Selectable) {
+	if f, ok := sel.(FaceHandle); ok {
+		fc := f
+		t.face = &fc
+	}
+}
+
+// SetImage/Image drive the decal's image resource.
+func (t *DecalTool) SetImage(s string) { t.image = s }
+func (t *DecalTool) Image() string     { return t.image }
+
+// Params exposes the image resource for the generic property dialog.
+func (t *DecalTool) Params() ToolParams {
+	return ToolParams{Texts: []TextParam{{Label: "Image", Get: t.Image, Set: t.SetImage}}}
+}
+
+// PickedFace returns the target face (if any) for the unified tool highlight.
+func (t *DecalTool) PickedFace() (FaceHandle, bool) {
+	if t.face == nil {
+		return FaceHandle{}, false
+	}
+	return *t.face, true
+}
+
+// CanCommit reports whether a face is picked and an image is set.
+func (t *DecalTool) CanCommit() bool { return t.face != nil && t.image != "" }
+
+// Commit places the decal on the picked face and recomputes.
+func (t *DecalTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewCosmeticFeatures(part.Features()).AddDecal(t.face.Face.ReferenceKey(), t.image)
+	part.Recompute()
+	s.recordEdit(part, "Decal")
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *DecalTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the decal created on commit (for inspection/tests).
+func (t *DecalTool) AddedFeature() *feature.DecalFeature { return t.added }

--- a/app/decal_tool_test.go
+++ b/app/decal_tool_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/model/compdef"
+)
+
+// TestDecalToolEndToEnd drives the Decal UI: pick a face, set an image, OK — and asserts the
+// decal feature is recorded (cosmetic: the body is unchanged).
+func TestDecalToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	before := def.SurfaceBodies().Count()
+
+	decal := NewDecalTool()
+	s.StartTool(decal)
+	s.Click(100, 100)
+	decal.SetImage("logo.png")
+	if !decal.CanCommit() {
+		t.Fatal("decal not ready after face + image")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if decal.AddedFeature() == nil {
+		t.Error("decal feature not created")
+	}
+	if def.SurfaceBodies().Count() != before {
+		t.Errorf("decal changed body count %d→%d; a decal is cosmetic", before, def.SurfaceBodies().Count())
+	}
+}
+
+func TestDecalViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Create.Decal"); err != nil {
+		t.Fatalf("execute Create.Decal: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*DecalTool); !ok {
+		t.Fatal("Decal command did not start the decal tool")
+	}
+}

--- a/app/emboss_tool.go
+++ b/app/emboss_tool.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// EmbossTool is the interactive Emboss command: pick one or more closed sketch regions, set the
+// depth and whether to engrave (cut) or raise (join), then OK to emboss the active part. It
+// exposes its parameters through ParameterizedTool, so the head renders the generic dialog.
+type EmbossTool struct {
+	profiles []ProfileHandle
+	depth    float64
+	engrave  bool
+	added    *feature.PartFeature
+}
+
+// NewEmbossTool returns an emboss tool defaulting to a 1-unit raised emboss.
+func NewEmbossTool() *EmbossTool { return &EmbossTool{depth: 1} }
+
+// Name implements [Tool].
+func (t *EmbossTool) Name() string { return "Emboss" }
+
+// Start filters selection to closed regions so clicks pick a profile.
+func (t *EmbossTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+
+// Pick captures a single clicked region (replacing any previous selection).
+func (t *EmbossTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		t.profiles = []ProfileHandle{p}
+	}
+}
+
+// PickWithMods extends the selection on Ctrl+click (toggling), to emboss several regions at once.
+func (t *EmbossTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
+	p, ok := sel.(ProfileHandle)
+	if !ok {
+		return
+	}
+	if !mods.Has(CtrlMod) {
+		t.Pick(s, sel)
+		return
+	}
+	if i := indexOfProfile(t.profiles, p); i >= 0 {
+		t.profiles = append(t.profiles[:i], t.profiles[i+1:]...)
+		return
+	}
+	t.profiles = append(t.profiles, p)
+}
+
+// The options the property window drives: depth (database units) and engrave (cut vs raise).
+func (t *EmbossTool) SetDepth(d float64) { t.depth = d }
+func (t *EmbossTool) Depth() float64     { return t.depth }
+func (t *EmbossTool) SetEngrave(v bool)  { t.engrave = v }
+func (t *EmbossTool) Engrave() bool      { return t.engrave }
+
+// Params exposes the emboss depth and engrave flag for the generic property dialog.
+func (t *EmbossTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{{Label: "Depth", Get: t.Depth, Set: t.SetDepth}},
+		Bools:  []BoolParam{{Label: "Engrave (cut)", Get: t.Engrave, Set: t.SetEngrave}},
+	}
+}
+
+// PickedProfiles returns the picked regions for the unified tool highlight.
+func (t *EmbossTool) PickedProfiles() []ProfileHandle {
+	return append([]ProfileHandle(nil), t.profiles...)
+}
+
+// CanCommit reports whether a region is picked and the depth is positive.
+func (t *EmbossTool) CanCommit() bool { return len(t.profiles) > 0 && t.depth > 0 }
+
+// Commit embosses the active part and recomputes; a sick feature keeps the tool open.
+func (t *EmbossTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	skt := t.profiles[0].Sketch
+	d, eng := t.depth, t.engrave
+	t.added = feature.NewEmbossFeatures(part.Features()).Add(skt, profileIndicesOn(t.profiles, skt), func() float64 { return d }, eng, 0)
+	part.Recompute()
+	s.recordEdit(part, "Emboss")
+	if !t.added.Health().OK() {
+		return errors.New("emboss: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *EmbossTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *EmbossTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/emboss_tool_test.go
+++ b/app/emboss_tool_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// partWithTopRegion builds a 6×6×2 block and a 2×2 closed region sketched on its top face.
+func partWithTopRegion(t *testing.T) (*Session, *compdef.PartComponentDefinition, ProfileHandle) {
+	t.Helper()
+	s, _ := newPartWithBlock(t, 6) // block on XY, z 0..2, vol 72
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	top, _ := sketch.NewPlane(math.P3(0, 0, 2), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	es := def.Sketches().Add(top)
+	c0 := es.Points().Add(math.P2(2, 2))
+	c1 := es.Points().Add(math.P2(4, 2))
+	c2 := es.Points().Add(math.P2(4, 4))
+	c3 := es.Points().Add(math.P2(2, 4))
+	es.Lines().Add(c0, c1)
+	es.Lines().Add(c1, c2)
+	es.Lines().Add(c2, c3)
+	es.Lines().Add(c3, c0)
+	return s, def, ProfileHandle{Sketch: es, ProfileIndex: 0}
+}
+
+// TestEmbossToolEndToEnd drives the Emboss UI: pick a region, set a depth, OK — and asserts the
+// raised emboss added material (block 72 + 2×2×1 = 76).
+func TestEmbossToolEndToEnd(t *testing.T) {
+	s, def, region := partWithTopRegion(t)
+	s.SetPicker(stubPicker{sel: region})
+
+	emb := NewEmbossTool()
+	s.StartTool(emb)
+	s.Click(100, 100)
+	emb.SetDepth(1)
+	if !emb.CanCommit() {
+		t.Fatal("emboss tool not ready after picking a region + depth")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("embossed body not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(v, 76) > 0.01 {
+		t.Errorf("embossed volume = %g, want ≈76 (72 + 2×2×1)", v)
+	}
+}
+
+// Engrave mode cuts material (block 72 − 2×2×1 = 68).
+func TestEmbossToolEngraves(t *testing.T) {
+	s, def, region := partWithTopRegion(t)
+	s.SetPicker(stubPicker{sel: region})
+
+	emb := NewEmbossTool()
+	s.StartTool(emb)
+	s.Click(100, 100)
+	emb.SetDepth(1)
+	emb.SetEngrave(true)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, 68) > 0.01 {
+		t.Errorf("engraved volume = %g, want ≈68 (72 − 2×2×1)", v)
+	}
+}
+
+func TestEmbossViaRibbonCommand(t *testing.T) {
+	s, _, _ := partWithTopRegion(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Create.Emboss"); err != nil {
+		t.Fatalf("execute Create.Emboss: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*EmbossTool); !ok {
+		t.Fatal("Emboss command did not start the emboss tool")
+	}
+}

--- a/app/extend_tool.go
+++ b/app/extend_tool.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// ExtendTool is the interactive Extend command (Surface panel): click a surface's boundary edge
+// and set a distance to grow the face outward along that edge. It exposes the distance through
+// ParameterizedTool for the generic dialog.
+type ExtendTool struct {
+	edge     *EdgeHandle
+	distance float64
+	added    *feature.PartFeature
+}
+
+// NewExtendTool returns an extend tool defaulting to a 1-unit extension.
+func NewExtendTool() *ExtendTool { return &ExtendTool{distance: 1} }
+
+// Name implements [Tool].
+func (t *ExtendTool) Name() string { return "Extend" }
+
+// Start filters selection to edges so clicks pick a boundary edge.
+func (t *ExtendTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+
+// Pick captures the boundary edge to extend.
+func (t *ExtendTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		ec := e
+		t.edge = &ec
+	}
+}
+
+// Edges returns the picked boundary edge (one or none) for the unified tool highlight.
+func (t *ExtendTool) Edges() []EdgeHandle {
+	if t.edge == nil {
+		return nil
+	}
+	return []EdgeHandle{*t.edge}
+}
+
+// SetDistance/Distance drive how far the edge extends.
+func (t *ExtendTool) SetDistance(d float64) { t.distance = d }
+func (t *ExtendTool) Distance() float64     { return t.distance }
+
+// Params exposes the extension distance for the generic property dialog.
+func (t *ExtendTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{{Label: "Distance", Get: t.Distance, Set: t.SetDistance}}}
+}
+
+// CanCommit reports whether an edge is picked and the distance is positive.
+func (t *ExtendTool) CanCommit() bool { return t.edge != nil && t.distance > 0 }
+
+// Commit extends the surface along the picked edge and recomputes.
+func (t *ExtendTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	d := t.distance
+	t.added = feature.NewExtendFeatures(part.Features()).Add(t.edge.Edge.ReferenceKey(), func() float64 { return d })
+	part.Recompute()
+	s.recordEdit(part, "Extend")
+	if !t.added.Health().OK() {
+		return errors.New("extend: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *ExtendTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *ExtendTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/extend_tool_test.go
+++ b/app/extend_tool_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// patchWithBottomEdge gives a part holding a 4×4 surface patch and its bottom boundary edge.
+func patchWithBottomEdge(t *testing.T) (*Session, *compdef.PartComponentDefinition, *topo.Edge) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(4, 0))
+	c2 := sk.Points().Add(math.P2(4, 4))
+	c3 := sk.Points().Add(math.P2(0, 4))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewBoundaryPatchFeatures(def.Features()).Add(sk, 0, feature.PatchFree)
+	def.Recompute()
+	var bottom *topo.Edge
+	for _, e := range def.SurfaceBodies().Item(0).Edges() {
+		if e.StartVertex().Point().Y == 0 && e.EndVertex().Point().Y == 0 {
+			bottom = e
+		}
+	}
+	if bottom == nil {
+		t.Fatal("no bottom edge on the patch")
+	}
+	return s, def, bottom
+}
+
+// TestExtendToolEndToEnd drives the Extend UI: pick the bottom edge, set a distance, OK — the
+// patch grows to y∈[-2,4].
+func TestExtendToolEndToEnd(t *testing.T) {
+	s, def, bottom := patchWithBottomEdge(t)
+	s.SetPicker(stubPicker{sel: EdgeHandle{Edge: bottom}})
+
+	ext := NewExtendTool()
+	s.StartTool(ext)
+	s.Click(100, 100)
+	ext.SetDistance(2)
+	if !ext.CanCommit() {
+		t.Fatal("extend tool not ready after edge + distance")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	box := def.SurfaceBodies().Item(0).RangeBox()
+	if stdmath.Abs(float64(box.Min.Y)+2) > 1e-6 || stdmath.Abs(float64(box.Max.Y)-4) > 1e-6 {
+		t.Errorf("extended y-span = [%v,%v], want [-2,4]", box.Min.Y, box.Max.Y)
+	}
+}
+
+func TestExtendViaRibbonCommand(t *testing.T) {
+	s, _, bottom := patchWithBottomEdge(t)
+	s.SetPicker(stubPicker{sel: EdgeHandle{Edge: bottom}})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.Extend"); err != nil {
+		t.Fatalf("execute Surface.Extend: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*ExtendTool); !ok {
+		t.Fatal("Extend command did not start the extend tool")
+	}
+}

--- a/app/feature_modify_tools.go
+++ b/app/feature_modify_tools.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// Modify-panel tools whose geometry already existed but had no UI: Move Face (a direct
+// edit translating picked faces), Combine (boolean of two bodies) and Move (relocate a
+// body). Each gathers its picks + parameters and adds the model feature on OK; the
+// geometry is model-tested, so these are interaction shells. Parameters edit through the
+// generic property dialog.
+
+// bodyIndexOf returns the index of body b in the part's running body list, or -1.
+func bodyIndexOf(part *compdef.PartComponentDefinition, b *topo.Body) int {
+	for i, x := range part.SurfaceBodies().All() {
+		if x == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// --- Move Face ------------------------------------------------------------
+
+// MoveFaceTool translates one or more picked faces by a vector, retopologizing the solid.
+type MoveFaceTool struct {
+	faces      []FaceHandle
+	dx, dy, dz float64
+	added      *feature.PartFeature
+}
+
+func NewMoveFaceTool() *MoveFaceTool { return &MoveFaceTool{} }
+func (t *MoveFaceTool) Name() string { return "Move Face" }
+func (t *MoveFaceTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
+}
+func (t *MoveFaceTool) Pick(_ *Session, sel Selectable) {
+	if f, ok := sel.(FaceHandle); ok {
+		t.faces = append(t.faces, f)
+	}
+}
+
+// Faces returns the picked faces for the unified tool highlight.
+func (t *MoveFaceTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
+func (t *MoveFaceTool) Cancel(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter())
+	t.faces = nil
+}
+func (t *MoveFaceTool) Prompt(*Session) string {
+	if len(t.faces) == 0 {
+		return "Click the faces to move."
+	}
+	return "Set the move vector, then OK."
+}
+func (t *MoveFaceTool) CanCommit() bool {
+	return len(t.faces) > 0 && (t.dx != 0 || t.dy != 0 || t.dz != 0)
+}
+
+func (t *MoveFaceTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	keys := make([][]byte, len(t.faces))
+	for i, f := range t.faces {
+		keys[i] = f.Face.ReferenceKey()
+	}
+	t.added = feature.NewModifyFeatures(part.Features()).AddMoveFace(keys, math.V3(math.Scalar(t.dx), math.Scalar(t.dy), math.Scalar(t.dz)))
+	part.Recompute()
+	s.recordEdit(part, "Move Face")
+	s.Selection().SetFilter(NewSelectionFilter())
+	if !t.added.Health().OK() {
+		return errors.New("move face: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+func (t *MoveFaceTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{"Δ X", func() float64 { return t.dx }, func(v float64) { t.dx = v }},
+		{"Δ Y", func() float64 { return t.dy }, func(v float64) { t.dy = v }},
+		{"Δ Z", func() float64 { return t.dz }, func(v float64) { t.dz = v }},
+	}}
+}
+
+// --- Combine --------------------------------------------------------------
+
+// CombineTool booleans two picked bodies (Join/Cut/Intersect): the first pick is the
+// target, the second the tool body.
+type CombineTool struct {
+	bodies []*topo.Body
+	op     ops.PartFeatureOperation
+	added  *feature.PartFeature
+}
+
+func NewCombineTool() *CombineTool  { return &CombineTool{op: ops.Join} }
+func (t *CombineTool) Name() string { return "Combine" }
+func (t *CombineTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectBody))
+}
+func (t *CombineTool) Pick(_ *Session, sel Selectable) {
+	if b, ok := sel.(BodyHandle); ok {
+		t.bodies = append(t.bodies, b.Body)
+	}
+}
+func (t *CombineTool) Cancel(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter())
+	t.bodies = nil
+}
+func (t *CombineTool) Prompt(*Session) string {
+	return "Pick the target body, then the tool body; set the operation; OK."
+}
+func (t *CombineTool) CanCommit() bool { return len(t.bodies) >= 2 }
+
+func (t *CombineTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	ti, tj := bodyIndexOf(part, t.bodies[0]), bodyIndexOf(part, t.bodies[1])
+	if ti < 0 || tj < 0 {
+		return errors.New("combine: a picked body is not in the active part")
+	}
+	t.added = feature.NewModifyFeatures(part.Features()).AddCombine(ti, tj, t.op)
+	part.Recompute()
+	s.recordEdit(part, "Combine")
+	s.Selection().SetFilter(NewSelectionFilter())
+	if !t.added.Health().OK() {
+		return errors.New("combine: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// SetOperation chooses Join (0), Cut (1) or Intersect (2).
+func (t *CombineTool) SetOperation(op ops.PartFeatureOperation) { t.op = op }
+
+func (t *CombineTool) Params() ToolParams {
+	return ToolParams{Ints: []IntParam{
+		{"Operation (0=Join 1=Cut 2=Intersect)", func() int { return int(t.op) }, func(n int) { t.op = ops.PartFeatureOperation(n) }},
+	}}
+}
+
+// --- Move (body) ----------------------------------------------------------
+
+// MoveBodyTool relocates a picked body by a translation, preserving its reference keys.
+type MoveBodyTool struct {
+	bodies     []*topo.Body
+	dx, dy, dz float64
+	added      *feature.PartFeature
+}
+
+func NewMoveBodyTool() *MoveBodyTool { return &MoveBodyTool{} }
+func (t *MoveBodyTool) Name() string { return "Move Bodies" }
+func (t *MoveBodyTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectBody))
+}
+func (t *MoveBodyTool) Pick(_ *Session, sel Selectable) {
+	if b, ok := sel.(BodyHandle); ok {
+		t.bodies = append(t.bodies, b.Body)
+	}
+}
+func (t *MoveBodyTool) Cancel(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter())
+	t.bodies = nil
+}
+func (t *MoveBodyTool) Prompt(*Session) string {
+	if len(t.bodies) == 0 {
+		return "Pick a body to move."
+	}
+	return "Set the move vector, then OK."
+}
+func (t *MoveBodyTool) CanCommit() bool {
+	return len(t.bodies) > 0 && (t.dx != 0 || t.dy != 0 || t.dz != 0)
+}
+
+func (t *MoveBodyTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	idx := bodyIndexOf(part, t.bodies[0])
+	if idx < 0 {
+		return errors.New("move: the picked body is not in the active part")
+	}
+	xf := math.Translation4(math.V3(math.Scalar(t.dx), math.Scalar(t.dy), math.Scalar(t.dz)))
+	t.added = feature.NewModifyFeatures(part.Features()).AddMove(idx, xf)
+	part.Recompute()
+	s.recordEdit(part, "Move Bodies")
+	s.Selection().SetFilter(NewSelectionFilter())
+	if !t.added.Health().OK() {
+		return errors.New("move: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+func (t *MoveBodyTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{"Δ X", func() float64 { return t.dx }, func(v float64) { t.dx = v }},
+		{"Δ Y", func() float64 { return t.dy }, func(v float64) { t.dy = v }},
+		{"Δ Z", func() float64 { return t.dz }, func(v float64) { t.dz = v }},
+	}}
+}

--- a/app/feature_modify_tools_test.go
+++ b/app/feature_modify_tools_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// Moving the top face of a block outward grows its volume.
+func TestMoveFaceTool(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+	def := activePartDef(t, s)
+	vol0 := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+
+	tool := NewMoveFaceTool()
+	tool.dz = 2
+	s.StartTool(tool)
+	s.Click(100, 100) // pick the top face
+	if err := s.OK(); err != nil {
+		t.Fatalf("move face OK: %v", err)
+	}
+	if s.ActiveTool() != nil {
+		t.Fatal("move-face tool should deactivate after OK")
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("moved body invalid: %+v", r)
+	}
+	vol1 := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+	if vol1 <= vol0 {
+		t.Fatalf("moving top face +Z should grow volume: %g → %g", vol0, vol1)
+	}
+}
+
+// Combining two bodies (Join) yields a single body.
+func TestCombineTool(t *testing.T) {
+	s, def, src := extrudedPart(t)
+	pat := NewFeatureRectPatternTool() // default 2×1 → a second body
+	s.StartTool(pat)
+	s.feedPick(src)
+	if err := s.OK(); err != nil {
+		t.Fatalf("pattern setup OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 2 {
+		t.Fatalf("setup wanted 2 bodies, got %d", def.SurfaceBodies().Count())
+	}
+
+	tool := NewCombineTool() // Join
+	s.StartTool(tool)
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(0)})
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(1)})
+	if err := s.OK(); err != nil {
+		t.Fatalf("combine OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("after join = %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+}
+
+// Moving a body translates it.
+func TestMoveBodyTool(t *testing.T) {
+	s, def, _ := extrudedPart(t)
+	minX0 := float64(def.SurfaceBodies().Item(0).RangeBox().Min.X)
+
+	tool := NewMoveBodyTool()
+	tool.dx = 10
+	s.StartTool(tool)
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(0)})
+	if err := s.OK(); err != nil {
+		t.Fatalf("move body OK: %v", err)
+	}
+	minX1 := float64(def.SurfaceBodies().Item(0).RangeBox().Min.X)
+	if math.Abs(minX1-(minX0+10)) > 1e-6 {
+		t.Fatalf("body min.X = %g, want %g (shifted by 10)", minX1, minX0+10)
+	}
+}
+
+func TestDirectEditCommandsRegistered(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	for _, id := range []string{"Modify.Combine", "Modify.MoveFace", "Modify.MoveBodies"} {
+		if _, ok := s.Commands().ByID(id); !ok {
+			t.Errorf("command %q not registered", id)
+		}
+	}
+}

--- a/app/feature_pattern_tools.go
+++ b/app/feature_pattern_tools.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// The feature-level Pattern and Mirror tools replicate one or more source features (picked
+// in the browser or viewport as FeatureHandles) into real placed copies. They gather the
+// source feature ids + parameters and add the pattern/mirror feature on OK; the geometry
+// lives in model/feature and is tested there, so these are interaction shells driven
+// headlessly here. Parameters are edited through the generic tool-param dialog.
+
+// featureSelectTool collects the source features (by id) the pattern/mirror replicates.
+type featureSelectTool struct {
+	sources []feature.ID
+	added   *feature.PartFeature
+}
+
+// Pick collects a feature pick (a FeatureHandle from the browser or graphics).
+func (t *featureSelectTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(FeatureHandle); ok && h.Feature != nil {
+		t.sources = append(t.sources, h.Feature.ID())
+	}
+}
+
+func (t *featureSelectTool) Start(*Session)  {}
+func (t *featureSelectTool) Cancel(*Session) { t.sources = nil }
+
+// patternFeatures resolves the active part and its pattern-feature collection, erroring on
+// no part or no selected source.
+func (t *featureSelectTool) patternFeatures(s *Session, op string) (*feature.PatternFeatures, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(t.sources) == 0 {
+		return nil, errors.New(op + ": select a feature to pattern first")
+	}
+	return feature.NewPatternFeatures(part.Features()), nil
+}
+
+// finishPattern recomputes the part, records the edit and reports a sick pattern.
+func (t *featureSelectTool) finishPattern(s *Session, added *feature.PartFeature, label string) error {
+	part, _ := activePart(s)
+	t.added = added
+	part.Recompute()
+	s.recordEdit(part, label)
+	if !added.Health().OK() {
+		return errors.New(label + ": " + added.Health().Reason)
+	}
+	return nil
+}
+
+// --- Rectangular ----------------------------------------------------------
+
+// FeatureRectPatternTool patterns the source features on a grid (countX along +X by
+// spacingX, countY along +Y by spacingY).
+type FeatureRectPatternTool struct {
+	featureSelectTool
+	countX, countY     int
+	spacingX, spacingY float64
+}
+
+func NewFeatureRectPatternTool() *FeatureRectPatternTool {
+	return &FeatureRectPatternTool{countX: 2, countY: 1, spacingX: 2, spacingY: 2}
+}
+func (t *FeatureRectPatternTool) Name() string { return "Rectangular Pattern" }
+func (t *FeatureRectPatternTool) Prompt(*Session) string {
+	return "Select features, set the counts and spacing, then OK."
+}
+func (t *FeatureRectPatternTool) CanCommit() bool {
+	return len(t.sources) > 0 && t.countX >= 1 && t.countY >= 1 && t.countX*t.countY > 1
+}
+
+func (t *FeatureRectPatternTool) Commit(s *Session) error {
+	pats, err := t.patternFeatures(s, "rectangular pattern")
+	if err != nil {
+		return err
+	}
+	cx, cy := t.countX, t.countY
+	pats.AddRectangular(t.sources, func() int { return cx }, func() int { return cy },
+		math.V3(math.Scalar(t.spacingX), 0, 0), math.V3(0, math.Scalar(t.spacingY), 0))
+	return t.finishPattern(s, lastPartFeature(s), "Rectangular Pattern")
+}
+
+func (t *FeatureRectPatternTool) Params() ToolParams {
+	return ToolParams{
+		Ints: []IntParam{
+			{"Count X", func() int { return t.countX }, func(n int) { t.countX = n }},
+			{"Count Y", func() int { return t.countY }, func(n int) { t.countY = n }},
+		},
+		Floats: []FloatParam{
+			{"Spacing X", func() float64 { return t.spacingX }, func(v float64) { t.spacingX = v }},
+			{"Spacing Y", func() float64 { return t.spacingY }, func(v float64) { t.spacingY = v }},
+		},
+	}
+}
+
+// --- Circular -------------------------------------------------------------
+
+// FeatureCircPatternTool patterns the source features around the Z axis: count copies over
+// totalAngle (radians).
+type FeatureCircPatternTool struct {
+	featureSelectTool
+	count      int
+	totalAngle float64
+}
+
+func NewFeatureCircPatternTool() *FeatureCircPatternTool {
+	return &FeatureCircPatternTool{count: 4, totalAngle: 2 * 3.141592653589793}
+}
+func (t *FeatureCircPatternTool) Name() string { return "Circular Pattern" }
+func (t *FeatureCircPatternTool) Prompt(*Session) string {
+	return "Select features, set the count and angle, then OK."
+}
+func (t *FeatureCircPatternTool) CanCommit() bool { return len(t.sources) > 0 && t.count >= 2 }
+
+func (t *FeatureCircPatternTool) Commit(s *Session) error {
+	pats, err := t.patternFeatures(s, "circular pattern")
+	if err != nil {
+		return err
+	}
+	n := t.count
+	a := t.totalAngle
+	pats.AddCircular(t.sources, func() int { return n }, func() float64 { return a },
+		math.P3(0, 0, 0), math.V3(0, 0, 1))
+	return t.finishPattern(s, lastPartFeature(s), "Circular Pattern")
+}
+
+func (t *FeatureCircPatternTool) Params() ToolParams {
+	return ToolParams{
+		Ints: []IntParam{{"Count", func() int { return t.count }, func(n int) { t.count = n }}},
+		Floats: []FloatParam{{"Angle (deg)", func() float64 { return degFromRad(t.totalAngle) },
+			func(d float64) { t.totalAngle = radFromDeg(d) }}},
+	}
+}
+
+// --- Mirror ---------------------------------------------------------------
+
+// FeatureMirrorTool mirrors the source features across the plane through the origin with
+// the given normal (default the YZ plane, normal +X).
+type FeatureMirrorTool struct {
+	featureSelectTool
+	normal math.Vector3
+}
+
+func NewFeatureMirrorTool() *FeatureMirrorTool {
+	return &FeatureMirrorTool{normal: math.V3(1, 0, 0)}
+}
+func (t *FeatureMirrorTool) Name() string { return "Mirror" }
+func (t *FeatureMirrorTool) Prompt(*Session) string {
+	return "Select features, set the mirror-plane normal, then OK."
+}
+func (t *FeatureMirrorTool) CanCommit() bool {
+	return len(t.sources) > 0 && t.normal.Length() > 0
+}
+
+func (t *FeatureMirrorTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if len(t.sources) == 0 {
+		return errors.New("mirror: select a feature to mirror first")
+	}
+	feature.NewPatternFeatures(part.Features()).AddMirror(t.sources, nil, math.P3(0, 0, 0), t.normal)
+	return t.finishPattern(s, lastPartFeature(s), "Mirror")
+}
+
+func (t *FeatureMirrorTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{"Normal X", func() float64 { return float64(t.normal.X) }, func(v float64) { t.normal.X = math.Scalar(v) }},
+		{"Normal Y", func() float64 { return float64(t.normal.Y) }, func(v float64) { t.normal.Y = math.Scalar(v) }},
+		{"Normal Z", func() float64 { return float64(t.normal.Z) }, func(v float64) { t.normal.Z = math.Scalar(v) }},
+	}}
+}
+
+// lastPartFeature returns the most-recently-added feature — the pattern/mirror just
+// created (the Pattern Add* methods return the raw feature, not its PartFeature wrapper).
+func lastPartFeature(s *Session) *feature.PartFeature {
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	fs := part.Features()
+	if fs.Count() == 0 {
+		return nil
+	}
+	return fs.Item(fs.Count() - 1)
+}

--- a/app/feature_pattern_tools_test.go
+++ b/app/feature_pattern_tools_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/model/compdef"
+)
+
+// extrudedPart builds a part with one extrude feature (the source to pattern) and returns
+// the session, the part definition, and the extrude's feature handle.
+func extrudedPart(t *testing.T) (*Session, *compdef.PartComponentDefinition, FeatureHandle) {
+	t.Helper()
+	s, profile := newPartWithSquare(t, 2)
+	s.SetPicker(stubPicker{sel: profile})
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	s.Click(120, 90)
+	ext.SetDistance(5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("extrude OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if def.Features().Count() != 1 {
+		t.Fatalf("expected 1 source feature, got %d", def.Features().Count())
+	}
+	return s, def, FeatureHandle{Feature: def.Features().Item(0)}
+}
+
+func TestFeatureRectPatternTool(t *testing.T) {
+	s, def, src := extrudedPart(t)
+	tool := NewFeatureRectPatternTool()
+	tool.countX = 3 // a 3×1 grid → 2 new copies
+	s.StartTool(tool)
+	s.feedPick(src)
+	if err := s.OK(); err != nil {
+		t.Fatalf("rectangular pattern OK: %v", err)
+	}
+	if s.ActiveTool() != nil {
+		t.Fatal("pattern tool should deactivate after OK")
+	}
+	if def.SurfaceBodies().Count() != 3 {
+		t.Fatalf("bodies after 3×1 pattern = %d, want 3", def.SurfaceBodies().Count())
+	}
+}
+
+func TestFeatureMirrorTool(t *testing.T) {
+	s, def, src := extrudedPart(t)
+	tool := NewFeatureMirrorTool() // default normal +X → mirror across YZ
+	s.StartTool(tool)
+	s.feedPick(src)
+	if err := s.OK(); err != nil {
+		t.Fatalf("mirror OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 2 {
+		t.Fatalf("bodies after mirror = %d, want 2 (original + reflection)", def.SurfaceBodies().Count())
+	}
+}
+
+func TestFeatureCircPatternTool(t *testing.T) {
+	s, def, src := extrudedPart(t)
+	tool := NewFeatureCircPatternTool() // count 4 over 360°
+	s.StartTool(tool)
+	s.feedPick(src)
+	if err := s.OK(); err != nil {
+		t.Fatalf("circular pattern OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() <= 1 {
+		t.Fatalf("bodies after circular pattern = %d, want > 1", def.SurfaceBodies().Count())
+	}
+}
+
+// Selecting nothing leaves the tool unable to commit.
+func TestFeaturePatternNeedsSource(t *testing.T) {
+	s, _, _ := extrudedPart(t)
+	tool := NewFeatureRectPatternTool()
+	s.StartTool(tool)
+	if tool.CanCommit() {
+		t.Error("pattern with no source selected should not be committable")
+	}
+}
+
+func TestPatternFeatureCommandsRegistered(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	for _, id := range []string{"Modify.RectangularPattern", "Modify.CircularPattern", "Modify.Mirror"} {
+		if _, ok := s.Commands().ByID(id); !ok {
+			t.Errorf("command %q not registered", id)
+		}
+	}
+}

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"errors"
+	stdmath "math"
 
 	"github.com/Oblikovati/oblikovati/model/feature"
 )
@@ -13,14 +14,24 @@ import (
 // the face centroid along the inward normal) into the active part. Diameter and depth are
 // in database units; the property window converts to the document's display unit.
 type HoleTool struct {
-	face     *FaceHandle
-	diameter float64
-	depth    float64
-	added    *feature.PartFeature
+	face        *FaceHandle
+	diameter    float64
+	depth       float64
+	through     bool // Through All: drill through the part with a true cylinder wall
+	counterbore bool // counterbore: a flat recess above the bore
+	countersink bool // countersink: a conical recess above the bore
+	cDiameter   float64
+	cDepth      float64
+	sinkAngle   float64 // countersink included angle (radians)
+	pointAngle  float64 // drilled blind-hole drill point: included angle (radians; 0 = flat)
+	added       *feature.PartFeature
 }
 
-// NewHoleTool returns a hole tool with a default Ø1 × 2 drilled hole.
-func NewHoleTool() *HoleTool { return &HoleTool{diameter: 1, depth: 2} }
+// NewHoleTool returns a hole tool with a default Ø1 × 2 drilled hole and a 118° drill point
+// (the standard twist-drill angle, matching Inventor's default).
+func NewHoleTool() *HoleTool {
+	return &HoleTool{diameter: 1, depth: 2, cDiameter: 2, cDepth: 0.5, sinkAngle: stdmath.Pi / 2, pointAngle: 118 * stdmath.Pi / 180}
+}
 
 // Name implements [Tool].
 func (t *HoleTool) Name() string { return "Hole" }
@@ -42,6 +53,42 @@ func (t *HoleTool) Diameter() float64     { return t.diameter }
 func (t *HoleTool) SetDepth(d float64)    { t.depth = d }
 func (t *HoleTool) Depth() float64        { return t.depth }
 
+// SetThroughAll/ThroughAll drive the "Through All" extent: when on, the hole drills through
+// the whole part (an exact cylinder wall) and the depth is ignored.
+func (t *HoleTool) SetThroughAll(v bool) { t.through = v }
+func (t *HoleTool) ThroughAll() bool     { return t.through }
+
+// SetCounterbore/Counterbore toggle the flat counterbore profile (a recess above the bore);
+// setting it clears the countersink (the profiles are exclusive).
+func (t *HoleTool) SetCounterbore(v bool) {
+	t.counterbore = v
+	if v {
+		t.countersink = false
+	}
+}
+func (t *HoleTool) Counterbore() bool            { return t.counterbore }
+func (t *HoleTool) SetCounterDiameter(d float64) { t.cDiameter = d }
+func (t *HoleTool) CounterDiameter() float64     { return t.cDiameter }
+func (t *HoleTool) SetCounterDepth(d float64)    { t.cDepth = d }
+func (t *HoleTool) CounterDepth() float64        { return t.cDepth }
+
+// SetCountersink/Countersink toggle the conical countersink profile; setting it clears the
+// counterbore. The recess uses the counterbore diameter and the sink (included) angle.
+func (t *HoleTool) SetCountersink(v bool) {
+	t.countersink = v
+	if v {
+		t.counterbore = false
+	}
+}
+func (t *HoleTool) Countersink() bool      { return t.countersink }
+func (t *HoleTool) SetSinkAngle(a float64) { t.sinkAngle = a }
+func (t *HoleTool) SinkAngle() float64     { return t.sinkAngle }
+
+// SetPointAngle/PointAngle drive a drilled blind hole's drill-point included angle (radians);
+// 0 gives a flat bottom.
+func (t *HoleTool) SetPointAngle(a float64) { t.pointAngle = a }
+func (t *HoleTool) PointAngle() float64     { return t.pointAngle }
+
 // PickedFace returns the placement face (and true), or false when none picked yet.
 func (t *HoleTool) PickedFace() (FaceHandle, bool) {
 	if t.face == nil {
@@ -50,8 +97,21 @@ func (t *HoleTool) PickedFace() (FaceHandle, bool) {
 	return *t.face, true
 }
 
-// CanCommit reports whether a face is picked and the diameter/depth are positive.
-func (t *HoleTool) CanCommit() bool { return t.face != nil && t.diameter > 0 && t.depth > 0 }
+// CanCommit reports whether a face is picked, the diameter is positive, the depth is positive
+// (unless Through All), and — for a counterbore — the recess is larger than the bore and shallow
+// enough to leave bore below it.
+func (t *HoleTool) CanCommit() bool {
+	if t.face == nil || t.diameter <= 0 || (!t.through && t.depth <= 0) {
+		return false
+	}
+	if t.counterbore && (t.cDiameter <= t.diameter || t.cDepth <= 0 || (!t.through && t.depth <= t.cDepth)) {
+		return false
+	}
+	if t.countersink && (t.cDiameter <= t.diameter || t.sinkAngle <= 0 || t.sinkAngle >= stdmath.Pi) {
+		return false
+	}
+	return true
+}
 
 // Commit drills the hole into the active part and recomputes; a sick feature (lost face,
 // boolean failure) keeps the tool open by returning an error.
@@ -60,10 +120,7 @@ func (t *HoleTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	key := t.face.Face.ReferenceKey()
-	d, depth := t.diameter, t.depth
-	t.added = feature.NewHoleFeatures(part.Features()).
-		AddDrilled(key, func() float64 { return d }, func() float64 { return depth })
+	t.added = t.addFeature(feature.NewHoleFeatures(part.Features()))
 	part.Recompute()
 	s.recordEdit(part, "Hole")
 	if !t.added.Health().OK() {
@@ -72,6 +129,32 @@ func (t *HoleTool) Commit(s *Session) error {
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
+
+// addFeature creates the hole feature matching the tool's options (counterbore vs drilled,
+// through vs depth), capturing the current values into the recipe's closures.
+func (t *HoleTool) addFeature(holes *feature.HoleFeatures) *feature.PartFeature {
+	key := t.face.Face.ReferenceKey()
+	d, depth, cd, cdep, ang := t.diameter, t.depth, t.cDiameter, t.cDepth, t.sinkAngle
+	switch {
+	case t.countersink:
+		pf := holes.AddCountersink(key, konst(d), konst(depth), konst(cd), konst(ang))
+		pf.Definition().(*feature.HoleFeature).Definition().ThroughAll = t.through
+		return pf
+	case t.counterbore:
+		pf := holes.AddCounterbore(key, konst(d), konst(depth), konst(cd), konst(cdep))
+		pf.Definition().(*feature.HoleFeature).Definition().ThroughAll = t.through
+		return pf
+	case t.through:
+		return holes.AddDrilledThrough(key, konst(d))
+	default:
+		pf := holes.AddDrilled(key, konst(d), konst(depth))
+		pf.Definition().(*feature.HoleFeature).Definition().PointAngle = konst(t.pointAngle)
+		return pf
+	}
+}
+
+// konst wraps a captured value as a parameter closure.
+func konst(v float64) func() float64 { return func() float64 { return v } }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *HoleTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/hole_tool_test.go
+++ b/app/hole_tool_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
@@ -91,6 +92,154 @@ func TestHoleToolEndToEnd(t *testing.T) {
 	}
 	if s.ActiveTool() != nil {
 		t.Error("tool should have closed after OK")
+	}
+}
+
+// TestHoleToolThroughAll drives the Hole UI with the Through All option: pick the top face,
+// set the diameter, tick Through All (no depth needed), OK — and asserts the result has a
+// TRUE cylinder wall (one curved face) rather than a faceted prism.
+func TestHoleToolThroughAll(t *testing.T) {
+	s, block := newPartWithBlock(t, 4) // 4×4×2 block, vol 32
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+
+	hole := NewHoleTool()
+	s.StartTool(hole)
+	s.Click(100, 100)
+	hole.SetDiameter(2)
+	hole.SetThroughAll(true) // no depth set on purpose
+	if !hole.CanCommit() {
+		t.Fatal("through-all hole not ready with face + diameter (depth not required)")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("drilled body not a valid solid: %+v", r)
+	}
+	cyl := 0
+	for _, f := range body.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cyl++
+		}
+	}
+	if cyl != 1 {
+		t.Errorf("through-all hole produced %d cylinder faces, want 1 (true wall)", cyl)
+	}
+}
+
+// TestHoleToolCounterbore drives the Hole UI in counterbore mode: pick the face, set bore +
+// recess, tick Through All, OK — and asserts two true cylinder walls (recess + bore).
+func TestHoleToolCounterbore(t *testing.T) {
+	s, block := newPartWithBlock(t, 8) // 8×8×2 block
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+
+	hole := NewHoleTool()
+	s.StartTool(hole)
+	s.Click(100, 100)
+	hole.SetDiameter(2)
+	hole.SetCounterbore(true)
+	hole.SetCounterDiameter(4)
+	hole.SetCounterDepth(0.5)
+	hole.SetThroughAll(true)
+	if !hole.CanCommit() {
+		t.Fatal("counterbore not ready with face + bore + recess")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("counterbored body not a valid solid: %+v", r)
+	}
+	cyl := 0
+	for _, f := range body.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cyl++
+		}
+	}
+	if cyl != 2 {
+		t.Errorf("counterbore produced %d cylinder faces, want 2 (recess + bore)", cyl)
+	}
+}
+
+// TestHoleToolCountersink drives the Hole UI in countersink mode: pick the face, set bore +
+// sink Ø + angle, Through All, OK — and asserts a true cone wall plus a cylinder bore wall.
+func TestHoleToolCountersink(t *testing.T) {
+	s, block := newPartWithBlock(t, 10) // 10×10×2 block
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+
+	hole := NewHoleTool()
+	s.StartTool(hole)
+	s.Click(100, 100)
+	hole.SetDiameter(1)
+	hole.SetCountersink(true)
+	hole.SetCounterDiameter(2)
+	hole.SetSinkAngle(stdmath.Pi / 2) // 90°
+	hole.SetThroughAll(true)
+	if !hole.CanCommit() {
+		t.Fatal("countersink not ready with face + bore + sink")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("countersunk body not a valid solid: %+v", r)
+	}
+	cone, cyl := 0, 0
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cone++
+		case geom.Cylinder:
+			cyl++
+		}
+	}
+	if cone != 1 || cyl != 1 {
+		t.Errorf("countersink produced %d cone / %d cylinder faces, want 1 / 1", cone, cyl)
+	}
+}
+
+// TestHoleToolConicalPoint drives the Hole UI for a blind drilled hole with the default 118°
+// drill point: pick the face, set a depth shallower than the block, OK — and asserts a true
+// cone tip plus a cylinder bore.
+func TestHoleToolConicalPoint(t *testing.T) {
+	s, block := newPartWithBlock(t, 8) // 8×8×2 block
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+
+	hole := NewHoleTool()
+	s.StartTool(hole)
+	s.Click(100, 100)
+	hole.SetDiameter(1)
+	hole.SetDepth(1) // blind (< thickness 2); default 118° point
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("conical-point body not a valid solid: %+v", r)
+	}
+	cone, cyl := 0, 0
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cone++
+		case geom.Cylinder:
+			cyl++
+		}
+	}
+	if cone != 1 || cyl != 1 {
+		t.Errorf("conical-point hole produced %d cone / %d cylinder faces, want 1 / 1", cone, cyl)
 	}
 }
 

--- a/app/loft_tool.go
+++ b/app/loft_tool.go
@@ -54,6 +54,10 @@ func (t *LoftTool) Sections() []ProfileHandle {
 	return append([]ProfileHandle(nil), t.sections...)
 }
 
+// PickedProfiles is the unified-tool-highlight accessor; it aliases Sections so the head
+// outlines every picked cross-section the same way it does other profile-picking tools.
+func (t *LoftTool) PickedProfiles() []ProfileHandle { return t.Sections() }
+
 // CanCommit reports whether at least two cross-sections have been picked.
 func (t *LoftTool) CanCommit() bool { return len(t.sections) >= 2 }
 

--- a/app/patch_tool.go
+++ b/app/patch_tool.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// PatchTool is the interactive Patch command (Surface panel): click a closed sketch region to
+// fill it with a surface (a boundary patch). It auto-commits on the pick — one click makes the
+// patch — matching Inventor's lightweight surfacing flow.
+type PatchTool struct {
+	profile *ProfileHandle
+	added   *feature.PartFeature
+}
+
+// NewPatchTool returns a patch tool.
+func NewPatchTool() *PatchTool { return &PatchTool{} }
+
+// Name implements [Tool].
+func (t *PatchTool) Name() string { return "Patch" }
+
+// Start filters selection to closed regions.
+func (t *PatchTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+
+// Pick captures the clicked closed region.
+func (t *PatchTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		pc := p
+		t.profile = &pc
+	}
+}
+
+// AutoCommitOnPick finishes the patch the moment a region is clicked.
+func (t *PatchTool) AutoCommitOnPick() bool { return true }
+
+// PickedProfile returns the clicked region (if any) for the unified tool highlight.
+func (t *PatchTool) PickedProfile() (ProfileHandle, bool) {
+	if t.profile == nil {
+		return ProfileHandle{}, false
+	}
+	return *t.profile, true
+}
+
+// CanCommit reports whether a region has been picked.
+func (t *PatchTool) CanCommit() bool { return t.profile != nil }
+
+// Commit fills the region with a boundary-patch surface and recomputes.
+func (t *PatchTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewBoundaryPatchFeatures(part.Features()).
+		Add(t.profile.Sketch, t.profile.ProfileIndex, feature.PatchFree)
+	part.Recompute()
+	s.recordEdit(part, "Patch")
+	if !t.added.Health().OK() {
+		return errors.New("patch: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *PatchTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *PatchTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/patch_tool_test.go
+++ b/app/patch_tool_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// partWithSquareRegion gives an empty part with a 4×4 closed region sketched on XY.
+func partWithSquareRegion(t *testing.T) (*Session, *compdef.PartComponentDefinition, ProfileHandle) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(4, 0))
+	c2 := sk.Points().Add(math.P2(4, 4))
+	c3 := sk.Points().Add(math.P2(0, 4))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return s, def, ProfileHandle{Sketch: sk, ProfileIndex: 0}
+}
+
+// TestPatchToolEndToEnd drives the Patch UI: click a closed region — it auto-commits a surface
+// (a one-face sheet body, not a solid).
+func TestPatchToolEndToEnd(t *testing.T) {
+	s, def, region := partWithSquareRegion(t)
+	s.SetPicker(stubPicker{sel: region})
+
+	s.StartTool(NewPatchTool())
+	s.Click(1, 1) // pick the region → auto-commit
+
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("after patch: %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if body.IsSolid() {
+		t.Error("patch should be a surface (sheet) body, not a solid")
+	}
+	if n := len(body.Faces()); n != 1 {
+		t.Errorf("patch has %d faces, want 1", n)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("patch should auto-commit and close the tool on pick")
+	}
+}
+
+func TestPatchViaRibbonCommand(t *testing.T) {
+	s, _, region := partWithSquareRegion(t)
+	s.SetPicker(stubPicker{sel: region})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.Patch"); err != nil {
+		t.Fatalf("execute Surface.Patch: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*PatchTool); !ok {
+		t.Fatal("Patch command did not start the patch tool")
+	}
+}

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -88,7 +88,34 @@ func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, boo
 	if sel, t, ok := p.nearestProfile(origin, dir, filter); ok {
 		cands = append(cands, pickCandidate{t, sel})
 	}
+	if sel, t, ok := p.nearestSketchCurve(origin, dir, filter); ok {
+		cands = append(cands, pickCandidate{t, sel})
+	}
 	return nearestCandidate(cands)
+}
+
+// nearestSketchCurve returns the sketch line the ray passes nearest (within the pick radius, in
+// any visible sketch), when the filter accepts sketch entities — so a sketch line/centerline can
+// be picked in the part view (e.g. a revolve axis). Lines only today (the kind used as an axis).
+func (p *RayPicker) nearestSketchCurve(origin math.Point3, dir math.Vector3, filter *SelectionFilter) (Selectable, float64, bool) {
+	if p.sketches == nil || !filter.Accepts(SelectSketchEntity) {
+		return nil, stdmath.Inf(1), false
+	}
+	tol := pickPixelRadius * p.camera.WorldPerPixel()
+	var hit Selectable
+	best := stdmath.Inf(1)
+	for _, sk := range p.sketches() {
+		plane := sk.Plane()
+		for i := 0; i < sk.Lines().Count(); i++ {
+			l := sk.Lines().Item(i)
+			a := plane.ToModel(l.StartPoint().Position())
+			b := plane.ToModel(l.EndPoint().Position())
+			if d, t, ok := raySegmentDistance(origin, dir, a, b); ok && d <= tol && t < best {
+				best, hit = t, SketchEntityHandle{Entity: l}
+			}
+		}
+	}
+	return hit, best, hit != nil
 }
 
 // snapPick returns the precise snap the cursor lands on — a datum point, datum axis, body

--- a/app/raypicker_sketchcurve_test.go
+++ b/app/raypicker_sketchcurve_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// TestRayPickerSelectsSketchCenterline checks the part-view ray picker can hit a sketch line
+// (a centerline) under the SketchEntity filter — what lets the Revolve tool pick its axis.
+func TestRayPickerSelectsSketchCenterline(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2) // 2×2 square on XY
+	mid := profile.Sketch.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(2, 1))
+	mid.SetCenterline(true)
+
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(1, 1, 20) // straight down over the midline's centre (1,1)
+	cam.Target = math.P3(1, 1, 0)
+	cam.Up = math.V3(0, 1, 0)
+	s.SetPicker(NewRayPicker(cam, partBodies(s)).
+		WithSketches(func() []*sketch.Sketch { return []*sketch.Sketch{profile.Sketch} }))
+
+	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+	s.Click(200, 200) // centre pixel → ray passes through the midline at (1,1)
+
+	if s.Selection().Count() != 1 {
+		t.Fatalf("sketch-curve pick selected %d, want 1", s.Selection().Count())
+	}
+	h, ok := s.Selection().First().(SketchEntityHandle)
+	if !ok || h.Entity != mid {
+		t.Fatalf("selected %T, want the centerline", s.Selection().First())
+	}
+}

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -9,19 +9,53 @@ import (
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
 )
+
+// preselectCenterline chooses the centerline a revolve should auto-select once a profile is
+// picked, following Inventor's rules over the visible sketches:
+//   - exactly one centerline in the profile's own sketch → that one;
+//   - several in the profile's sketch → none (the user must pick);
+//   - none in the profile's sketch but exactly one visible overall → that one;
+//   - otherwise → none.
+func preselectCenterline(profileSketch *sketch.Sketch, sketches []*sketch.Sketch) (*sketch.Sketch, *sketch.Line, bool) {
+	var allSk []*sketch.Sketch
+	var all, same []*sketch.Line
+	for _, sk := range sketches {
+		for _, l := range sk.Centerlines() {
+			allSk = append(allSk, sk)
+			all = append(all, l)
+			if sk == profileSketch {
+				same = append(same, l)
+			}
+		}
+	}
+	switch {
+	case len(same) == 1:
+		return profileSketch, same[0], true
+	case len(same) > 1:
+		return nil, nil, false
+	case len(all) == 1:
+		return allSk[0], all[0], true
+	default:
+		return nil, nil, false
+	}
+}
 
 // RevolveTool is the interactive Revolve command: activate it, click a sketch region,
 // choose the axis of revolution and the swept angle in the property window, and OK to
 // add a revolve feature to the active part. It mirrors [ExtrudeTool] and is driven
 // entirely by session input so a test exercises the full flow with synthetic clicks.
 type RevolveTool struct {
-	profile   *ProfileHandle
-	axis      feature.WorkRef // origin axis (X/Y/Z) or a user work axis
-	angle     float64         // swept angle in radians; 0 ⇒ full revolution
-	operation ops.PartFeatureOperation
-	added     *feature.PartFeature
+	profile      *ProfileHandle
+	axis         feature.WorkRef // origin axis (X/Y/Z) or a user work axis (fallback)
+	useCenterln  bool            // revolve about the sketch's own (single) centerline
+	centerline   *sketch.Line    // a specific centerline picked/pre-selected as the axis
+	centerlineSk *sketch.Sketch  // the centerline's sketch
+	angle        float64         // swept angle in radians; 0 ⇒ full revolution
+	operation    ops.PartFeatureOperation
+	added        *feature.PartFeature
 }
 
 // NewRevolveTool returns a revolve tool defaulting to a full revolution about the Y
@@ -36,12 +70,56 @@ func (t *RevolveTool) Name() string { return "Revolve" }
 // Start sets the selection filter to profiles so clicks pick a region.
 func (t *RevolveTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
 
-// Pick captures the region the user clicked.
-func (t *RevolveTool) Pick(_ *Session, sel Selectable) {
-	if p, ok := sel.(ProfileHandle); ok {
-		pc := p
+// Pick captures the region (then auto-advances to the centerline axis, pre-selecting one per
+// Inventor's rules) or, once a profile is set, a centerline the user clicks to override it.
+func (t *RevolveTool) Pick(s *Session, sel Selectable) {
+	switch h := sel.(type) {
+	case ProfileHandle:
+		pc := h
 		t.profile = &pc
+		t.advanceToCenterline(s)
+	case SketchEntityHandle:
+		if l, ok := h.Entity.(*sketch.Line); ok && l.IsCenterline() {
+			t.centerline, t.centerlineSk = l, sketchOfLine(s, l)
+		}
 	}
+}
+
+// advanceToCenterline moves the selection from the profile to the axis: it pre-selects a
+// centerline (if the rules resolve one) and filters selection to sketch entities so the user can
+// pick a different centerline.
+func (t *RevolveTool) advanceToCenterline(s *Session) {
+	if sk, line, ok := preselectCenterline(t.profile.Sketch, visiblePartSketches(s)); ok {
+		t.centerline, t.centerlineSk = line, sk
+	}
+	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+}
+
+// visiblePartSketches returns the active part's visible 2D sketches (the centerline candidates).
+func visiblePartSketches(s *Session) []*sketch.Sketch {
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	var out []*sketch.Sketch
+	for i := 0; i < part.Sketches().Count(); i++ {
+		if sk := part.Sketches().Item(i); sk.Visible() {
+			out = append(out, sk)
+		}
+	}
+	return out
+}
+
+// sketchOfLine finds which visible part sketch holds the line.
+func sketchOfLine(s *Session, line *sketch.Line) *sketch.Sketch {
+	for _, sk := range visiblePartSketches(s) {
+		for i := 0; i < sk.Lines().Count(); i++ {
+			if sk.Lines().Item(i) == line {
+				return sk
+			}
+		}
+	}
+	return nil
 }
 
 // The options the property window drives: the revolution axis, the swept angle, and the
@@ -52,6 +130,59 @@ func (t *RevolveTool) SetAngle(radians float64)                 { t.angle = radi
 func (t *RevolveTool) Angle() float64                           { return t.angle }
 func (t *RevolveTool) SetOperation(op ops.PartFeatureOperation) { t.operation = op }
 func (t *RevolveTool) Operation() ops.PartFeatureOperation      { return t.operation }
+
+// SetUseCenterline/UseCenterline choose to revolve about the sketch's own centerline (ignoring
+// the axis selection) — the common Inventor flow when the profile sketch carries a centerline.
+func (t *RevolveTool) SetUseCenterline(v bool) { t.useCenterln = v }
+func (t *RevolveTool) UseCenterline() bool     { return t.useCenterln }
+
+// Centerline returns the picked/pre-selected centerline axis (and true), or false when the axis
+// is not a centerline yet — the head highlights it on hover and shows it as the chosen axis.
+func (t *RevolveTool) Centerline() (*sketch.Line, bool) { return t.centerline, t.centerline != nil }
+
+// CenterlineOutline returns the chosen centerline's 2D endpoints and its sketch plane, for the
+// head to draw the selected axis (like a profile outline). False when no centerline is chosen.
+func (t *RevolveTool) CenterlineOutline() ([]math.Point2, sketch.Plane, bool) {
+	if t.centerline == nil || t.centerlineSk == nil {
+		return nil, sketch.Plane{}, false
+	}
+	return lineOutline2D(t.centerline), t.centerlineSk.Plane(), true
+}
+
+// lineOutline2D returns a line's two endpoints as a 2D polyline.
+func lineOutline2D(l *sketch.Line) []math.Point2 {
+	return []math.Point2{l.StartPoint().Position(), l.EndPoint().Position()}
+}
+
+// HoveredCenterlineOutline returns the 2D outline + plane of a centerline under the cursor while
+// a revolve tool is choosing its axis (a profile is picked), for the head to highlight the
+// candidate axis. ok=false otherwise.
+func (s *Session) HoveredCenterlineOutline(px, py float64) ([]math.Point2, sketch.Plane, bool) {
+	rv := s.ActiveRevolve()
+	if rv == nil {
+		return nil, sketch.Plane{}, false
+	}
+	if _, picked := rv.PickedProfile(); !picked {
+		return nil, sketch.Plane{}, false
+	}
+	sel, found := s.PickAt(px, py, NewSelectionFilter(SelectSketchEntity))
+	if !found {
+		return nil, sketch.Plane{}, false
+	}
+	h, isEnt := sel.(SketchEntityHandle)
+	if !isEnt {
+		return nil, sketch.Plane{}, false
+	}
+	l, isLine := h.Entity.(*sketch.Line)
+	if !isLine || !l.IsCenterline() {
+		return nil, sketch.Plane{}, false
+	}
+	sk := sketchOfLine(s, l)
+	if sk == nil {
+		return nil, sketch.Plane{}, false
+	}
+	return lineOutline2D(l), sk.Plane(), true
+}
 
 // SetFullRevolution sets the angle to a full turn (0, the model's "full" sentinel).
 func (t *RevolveTool) SetFullRevolution() { t.angle = 0 }
@@ -77,13 +208,20 @@ func (t *RevolveTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	axis, ok := part.WorkGeometry().AxisByRef(t.axis)
-	if !ok {
-		return errors.New("revolve: axis " + string(t.axis) + " not found")
-	}
 	angle := t.angle
-	t.added = feature.NewRevolveFeatures(part.Features()).
-		Add(t.profile.Sketch, t.profile.ProfileIndex, axis, func() float64 { return angle }, t.operation)
+	revolves := feature.NewRevolveFeatures(part.Features())
+	switch {
+	case t.centerline != nil: // a specific picked/pre-selected centerline
+		t.added = revolves.AddAboutCenterlineLine(t.profile.Sketch, t.profile.ProfileIndex, t.centerlineSk, t.centerline, func() float64 { return angle }, t.operation)
+	case t.useCenterln: // "about the sketch's own centerline" (auto, single)
+		t.added = revolves.AddAboutCenterline(t.profile.Sketch, t.profile.ProfileIndex, func() float64 { return angle }, t.operation)
+	default:
+		axis, ok := part.WorkGeometry().AxisByRef(t.axis)
+		if !ok {
+			return errors.New("revolve: axis " + string(t.axis) + " not found")
+		}
+		t.added = revolves.Add(t.profile.Sketch, t.profile.ProfileIndex, axis, func() float64 { return angle }, t.operation)
+	}
 	part.Recompute()
 	s.recordEdit(part, "Revolve")
 	if !t.added.Health().OK() {

--- a/app/revolve_tool_test.go
+++ b/app/revolve_tool_test.go
@@ -38,6 +38,121 @@ func newPartWithOffsetSquare(t *testing.T, x0, side float64) (*Session, ProfileH
 	return s, ProfileHandle{Sketch: sk, ProfileIndex: 0}
 }
 
+// mkCenterlineSketch builds a sketch holding n vertical centerlines (no profile geometry).
+func mkCenterlineSketch(n int) *sketch.Sketch {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	for i := 0; i < n; i++ {
+		cl := sk.Lines().AddByTwoPoints(math.P2(math.Scalar(i), 0), math.P2(math.Scalar(i), 1))
+		cl.SetCenterline(true)
+	}
+	return sk
+}
+
+// TestPreselectCenterlineRules covers Inventor's pre-selection rules.
+func TestPreselectCenterlineRules(t *testing.T) {
+	one := mkCenterlineSketch(1) // one in the profile's sketch → pre-select it
+	if _, l, ok := preselectCenterline(one, []*sketch.Sketch{one}); !ok || l == nil {
+		t.Error("single in-sketch centerline should pre-select")
+	}
+	two := mkCenterlineSketch(2) // several in the profile's sketch → user must choose
+	if _, _, ok := preselectCenterline(two, []*sketch.Sketch{two}); ok {
+		t.Error("multiple in-sketch centerlines should NOT pre-select")
+	}
+	empty, elsewhere := mkCenterlineSketch(0), mkCenterlineSketch(1) // one visible elsewhere
+	if sk, _, ok := preselectCenterline(empty, []*sketch.Sketch{empty, elsewhere}); !ok || sk != elsewhere {
+		t.Error("single centerline elsewhere should pre-select")
+	}
+	same, other := mkCenterlineSketch(1), mkCenterlineSketch(1) // same-sketch one wins (rule 2)
+	if sk, _, ok := preselectCenterline(same, []*sketch.Sketch{same, other}); !ok || sk != same {
+		t.Error("the profile-sketch centerline should win over one elsewhere")
+	}
+	none, a, b := mkCenterlineSketch(0), mkCenterlineSketch(1), mkCenterlineSketch(1) // several elsewhere
+	if _, _, ok := preselectCenterline(none, []*sketch.Sketch{none, a, b}); ok {
+		t.Error("several elsewhere, none in-sketch → no pre-select")
+	}
+}
+
+// TestRevolveToolPreselectsCenterline: clicking the profile auto-advances and pre-selects the
+// sketch's single centerline as the axis (no axis pick, no toggle needed).
+func TestRevolveToolPreselectsCenterline(t *testing.T) {
+	s, profile := newPartWithOffsetSquare(t, 2, 2)
+	cl := profile.Sketch.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	cl.SetCenterline(true)
+	s.SetPicker(stubPicker{sel: profile})
+
+	rv := NewRevolveTool()
+	s.StartTool(rv)
+	s.Click(1, 1) // pick the profile → auto-advance + pre-select the centerline
+	if line, ok := rv.Centerline(); !ok || line != cl {
+		t.Fatal("profile pick should pre-select the sketch's centerline")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	want := stdmath.Pi * (4*4 - 2*2) * 2
+	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, want) > 0.01 {
+		t.Errorf("pre-selected centerline washer = %g, want ≈%g", v, want)
+	}
+}
+
+// TestRevolveToolMultipleCenterlinesNeedsPick: two centerlines ⇒ no pre-select; the user clicks
+// the one to use and the revolve follows it.
+func TestRevolveToolMultipleCenterlinesNeedsPick(t *testing.T) {
+	s, profile := newPartWithOffsetSquare(t, 2, 2)
+	vert := profile.Sketch.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	vert.SetCenterline(true)
+	horiz := profile.Sketch.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(2, 0))
+	horiz.SetCenterline(true)
+	s.SetPicker(stubPicker{sel: profile})
+
+	rv := NewRevolveTool()
+	s.StartTool(rv)
+	s.Click(1, 1) // profile picked, but two centerlines ⇒ none pre-selected
+	if _, ok := rv.Centerline(); ok {
+		t.Fatal("two centerlines must not pre-select")
+	}
+	rv.Pick(s, SketchEntityHandle{Entity: vert}) // user picks the vertical one
+	if line, ok := rv.Centerline(); !ok || line != vert {
+		t.Fatal("picking a centerline should set it as the axis")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	want := stdmath.Pi * (4*4 - 2*2) * 2
+	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, want) > 0.01 {
+		t.Errorf("about the vertical centerline = %g, want ≈%g (24π)", v, want)
+	}
+}
+
+// TestRevolveToolAboutCenterline drives the Revolve UI with the "about centerline" option: the
+// profile sketch carries a vertical centerline (the Y axis), so revolving about it (no axis
+// pick) produces the same washer.
+func TestRevolveToolAboutCenterline(t *testing.T) {
+	s, profile := newPartWithOffsetSquare(t, 2, 2)
+	cl := profile.Sketch.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	cl.SetCenterline(true)
+	s.SetPicker(stubPicker{sel: profile})
+
+	rv := NewRevolveTool()
+	s.StartTool(rv)
+	s.Click(120, 90)
+	rv.SetUseCenterline(true)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("centerline-revolved body not a valid solid: %+v", r)
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(got, want) > 0.01 {
+		t.Errorf("centerline-revolved washer = %g, want ≈%g (24π)", got, want)
+	}
+}
+
 // TestRevolveToolEndToEnd drives the Revolve UI with synthetic input — start the tool,
 // click the profile, accept the default full revolution about Y, OK — and asserts a
 // validated washer solid (inner r=2, outer r=4, height 2 ⇒ 24π) lands in the part.

--- a/app/rib_tool.go
+++ b/app/rib_tool.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// RibTool is the interactive Rib command: with an open sketch profile (the active sketch, or
+// the part's most recent sketch holding an open path), set the wall thickness and depth in the
+// property window and OK to thicken the profile into a rib joined to the active part. It exposes
+// its parameters through ParameterizedTool, so the head renders the generic dialog.
+type RibTool struct {
+	profile   *sketch.Sketch
+	pathIndex int
+	thickness float64
+	depth     float64
+	added     *feature.PartFeature
+}
+
+// NewRibTool returns a rib tool with a default 1×2 wall.
+func NewRibTool() *RibTool { return &RibTool{thickness: 1, depth: 2} }
+
+// Name implements [Tool].
+func (t *RibTool) Name() string { return "Rib" }
+
+// Start resolves the open profile to rib: the active sketch if one is open, otherwise the
+// part's most recent sketch that has an open path.
+func (t *RibTool) Start(s *Session) { t.profile, t.pathIndex = ribProfile(s) }
+
+// Pick is unused — the rib operates on the resolved open profile, not a viewport selection.
+func (t *RibTool) Pick(*Session, Selectable) {}
+
+// The options the property window drives: thickness and signed depth (database units).
+func (t *RibTool) SetThickness(v float64) { t.thickness = v }
+func (t *RibTool) Thickness() float64     { return t.thickness }
+func (t *RibTool) SetDepth(v float64)     { t.depth = v }
+func (t *RibTool) Depth() float64         { return t.depth }
+
+// Params exposes the rib's thickness and depth for the generic property dialog.
+func (t *RibTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{Label: "Thickness", Get: t.Thickness, Set: t.SetThickness},
+		{Label: "Depth", Get: t.Depth, Set: t.SetDepth},
+	}}
+}
+
+// CanCommit reports whether an open profile was resolved and the thickness/depth are usable.
+func (t *RibTool) CanCommit() bool { return t.profile != nil && t.thickness > 0 && t.depth != 0 }
+
+// Commit thickens the profile into a rib joined to the active part and recomputes; a sick
+// feature keeps the tool open by returning an error.
+func (t *RibTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	th, d := t.thickness, t.depth
+	t.added = feature.NewRibFeatures(part.Features()).Add(t.profile, t.pathIndex, konst(th), konst(d), ops.Join)
+	part.Recompute()
+	s.recordEdit(part, "Rib")
+	if !t.added.Health().OK() {
+		return errors.New("rib: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// Cancel abandons the tool with no change.
+func (t *RibTool) Cancel(*Session) {}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *RibTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// ribProfile picks the sketch + open-path index the rib operates on: the active sketch if it
+// has an open path, else the part's most recent sketch that does. Returns nil when none.
+func ribProfile(s *Session) (*sketch.Sketch, int) {
+	if sk := s.ActiveSketch(); sk != nil {
+		if i, ok := firstOpenPath(sk); ok {
+			return sk, i
+		}
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return nil, 0
+	}
+	sks := part.Sketches()
+	for i := sks.Count() - 1; i >= 0; i-- {
+		if j, ok := firstOpenPath(sks.Item(i)); ok {
+			return sks.Item(i), j
+		}
+	}
+	return nil, 0
+}
+
+// firstOpenPath returns the index of the sketch's first open (non-closed) path.
+func firstOpenPath(sk *sketch.Sketch) (int, bool) {
+	for i, p := range sk.Paths() {
+		if !p.IsClosed() {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/app/rib_tool_test.go
+++ b/app/rib_tool_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// ribbedPart builds a 6×6×2 block and adds a sketch with an open line within the footprint
+// (the rib profile), returning the session and part.
+func ribbedPart(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s, _ := newPartWithBlock(t, 6) // block on XY, z 0..2
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	rs := def.Sketches().Add(sketch.XYPlane())
+	rs.Lines().AddByTwoPoints(math.P2(1, 3), math.P2(5, 3)) // open path inside the block
+	return s, def
+}
+
+// TestRibToolEndToEnd drives the Rib UI: with an open profile sketched, start the tool, set
+// thickness and depth, OK — and asserts a valid solid that joined the rib to the block.
+func TestRibToolEndToEnd(t *testing.T) {
+	s, def := ribbedPart(t)
+
+	rib := NewRibTool()
+	s.StartTool(rib) // resolves the open profile at Start
+	rib.SetThickness(1)
+	rib.SetDepth(3) // up through and above the block → joins
+	if !rib.CanCommit() {
+		t.Fatal("rib tool not ready (profile + thickness + depth)")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("after rib: %d bodies, want 1 (joined)", def.SurfaceBodies().Count())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("ribbed body not a valid solid: %+v", r)
+	}
+	if !rib.AddedFeature().Health().OK() {
+		t.Fatalf("rib feature sick: %+v", rib.AddedFeature().Health())
+	}
+}
+
+func TestRibViaRibbonCommand(t *testing.T) {
+	s, _ := ribbedPart(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Create.Rib"); err != nil { // ribbon: click the Rib button
+		t.Fatalf("execute Create.Rib: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*RibTool); !ok {
+		t.Fatal("Rib command did not start the rib tool")
+	}
+}

--- a/app/ribbon.go
+++ b/app/ribbon.go
@@ -17,10 +17,22 @@ package app
 const DefaultTab = "Tools"
 
 // RibbonButton is a command rendered as a ribbon control, with its current enabled
-// state resolved from the command's predicate against the session.
+// state resolved from the command's predicate against the session. A button with a
+// non-empty Variants list renders as a split button (Inventor's variant flyout): the
+// command's own action on the button, the variants in a dropdown.
 type RibbonButton struct {
-	Command *CommandDefinition
-	Enabled bool
+	Command  *CommandDefinition
+	Enabled  bool
+	Variants []RibbonVariant
+}
+
+// RibbonVariant is one entry of a split button's dropdown: the command to run when chosen
+// and the label/tooltip to show for it, with its enabled state resolved this frame.
+type RibbonVariant struct {
+	CommandID string
+	Label     string
+	Tooltip   string
+	Enabled   bool
 }
 
 // RibbonPanel groups the buttons of one command category within a tab. When Selector is
@@ -69,12 +81,35 @@ func BuildRibbon(s *Session) Ribbon {
 	env := currentEnvironment(s)
 	b := ribbonBuilder{tabIndex: map[string]int{}, panelIndex: map[string]map[string]int{}}
 	for _, c := range s.commands.All() {
+		// Variant commands are flyout-only: they render inside their head's dropdown
+		// (resolveVariants below), never as their own panel button.
+		if c.isVariant {
+			continue
+		}
 		if c.appearsOnRibbon(key) && environmentShows(c.environment, env) {
-			b.add(c, c.IsEnabled(s))
+			b.add(RibbonButton{Command: c, Enabled: c.IsEnabled(s), Variants: resolveVariants(c, s)})
 		}
 	}
 	finalizeSelectors(b.tabs, s)
 	return Ribbon{Key: key, Tabs: b.tabs}
+}
+
+// resolveVariants turns a head command's variant definitions into dropdown entries with
+// each variant's enabled state resolved against the session this frame.
+func resolveVariants(c *CommandDefinition, s *Session) []RibbonVariant {
+	if len(c.variants) == 0 {
+		return nil
+	}
+	out := make([]RibbonVariant, len(c.variants))
+	for i, v := range c.variants {
+		out[i] = RibbonVariant{
+			CommandID: v.ID(),
+			Label:     v.DisplayName(),
+			Tooltip:   v.Tooltip(),
+			Enabled:   v.IsEnabled(s),
+		}
+	}
+	return out
 }
 
 // finalizeSelectors turns any panel whose commands are ComboControls into a selection box:
@@ -112,16 +147,14 @@ type ribbonBuilder struct {
 	panelIndex map[string]map[string]int // tab name → panel name → index within the tab
 }
 
-func (b *ribbonBuilder) add(c *CommandDefinition, enabled bool) {
-	tab := c.Tab()
+func (b *ribbonBuilder) add(btn RibbonButton) {
+	tab := btn.Command.Tab()
 	if tab == "" {
 		tab = DefaultTab
 	}
 	ti := b.tabAt(tab)
-	pi := b.panelAt(tab, ti, c.Category())
-	b.tabs[ti].Panels[pi].Buttons = append(
-		b.tabs[ti].Panels[pi].Buttons, RibbonButton{Command: c, Enabled: enabled},
-	)
+	pi := b.panelAt(tab, ti, btn.Command.Category())
+	b.tabs[ti].Panels[pi].Buttons = append(b.tabs[ti].Panels[pi].Buttons, btn)
 }
 
 func (b *ribbonBuilder) tabAt(name string) int {

--- a/app/ribbon_alignment_test.go
+++ b/app/ribbon_alignment_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// hasButton reports whether a ribbon panel contains a button with the given display name.
+func hasButton(p RibbonPanel, name string) bool {
+	for _, b := range p.Buttons {
+		if b.Command.DisplayName() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSketchTabPanelsMatchInventor locks the Sketch tab's panel placement to the canonical
+// ribbon (architecture/mapping/inventor-ribbon-structure.md): Fillet in Create, Mirror in
+// Pattern, Dimension/Auto Dimension in Constrain, and NO standalone "Dimension" panel.
+func TestSketchTabPanelsMatchInventor(t *testing.T) {
+	s := registeredSession(t)
+	enterSketchEnv(t, s)
+	tab, ok := BuildRibbon(s).Tab("Sketch")
+	if !ok {
+		t.Fatal("no Sketch tab")
+	}
+
+	create, ok := tab.Panel("Create")
+	if !ok || !hasButton(create, "Fillet") {
+		t.Error("Sketch Create panel should contain Fillet")
+	}
+
+	modify, ok := tab.Panel("Modify")
+	if !ok {
+		t.Fatal("no Modify panel")
+	}
+	if hasButton(modify, "Mirror") || hasButton(modify, "Fillet") {
+		t.Error("Modify panel must not contain Mirror or Fillet (moved to Pattern/Create)")
+	}
+	for _, want := range []string{"Move", "Copy", "Rotate", "Scale", "Stretch", "Offset", "Trim", "Extend", "Split"} {
+		if !hasButton(modify, want) {
+			t.Errorf("Modify panel missing %q", want)
+		}
+	}
+
+	pattern, ok := tab.Panel("Pattern")
+	if !ok {
+		t.Fatal("no Pattern panel")
+	}
+	for _, want := range []string{"Rectangular", "Circular", "Mirror"} {
+		if !hasButton(pattern, want) {
+			t.Errorf("Pattern panel missing %q", want)
+		}
+	}
+
+	constrain, ok := tab.Panel("Constrain")
+	if !ok || !hasButton(constrain, "Dimension") || !hasButton(constrain, "Auto Dimension") {
+		t.Error("Constrain panel should contain Dimension and Auto Dimension")
+	}
+
+	if _, exists := tab.Panel("Dimension"); exists {
+		t.Error("there must be no standalone 'Dimension' panel (Inventor has none)")
+	}
+}

--- a/app/ribbon_flyout_test.go
+++ b/app/ribbon_flyout_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// createButton returns the Sketch Create-panel button with the given display name.
+func createButton(t *testing.T, s *Session, name string) RibbonButton {
+	t.Helper()
+	tab, ok := BuildRibbon(s).Tab("Sketch")
+	if !ok {
+		t.Fatal("no Sketch tab")
+	}
+	create, ok := tab.Panel("Create")
+	if !ok {
+		t.Fatal("no Create panel")
+	}
+	for _, b := range create.Buttons {
+		if b.Command.DisplayName() == name {
+			return b
+		}
+	}
+	t.Fatalf("Create panel has no %q button", name)
+	return RibbonButton{}
+}
+
+// The Create-panel heads carry their Inventor variant flyouts as dropdown entries.
+func TestCreatePanelHeadsHaveVariants(t *testing.T) {
+	s := registeredSession(t)
+	enterSketchEnv(t, s)
+	wantVariants := map[string][]string{
+		"Rectangle": {"Three Point Rectangle", "Two Point Center Rectangle"},
+		"Circle":    {"Three Point Circle"},
+		"Arc":       {"Center Point Arc"},
+		"Slot":      {"Center Point Arc Slot", "Three Point Arc Slot"},
+		"Spline":    {"Control Vertex Spline"},
+	}
+	for head, want := range wantVariants {
+		btn := createButton(t, s, head)
+		got := make([]string, len(btn.Variants))
+		for i, v := range btn.Variants {
+			got[i] = v.Label
+		}
+		if len(got) != len(want) {
+			t.Errorf("%s head has variants %v, want %v", head, got, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("%s variant[%d] = %q, want %q", head, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// A variant is registered for id dispatch but never appears as its own Create-panel button.
+func TestVariantsDispatchButAreNotPanelButtons(t *testing.T) {
+	s := registeredSession(t)
+	enterSketchEnv(t, s)
+
+	const variantID = "Sketch.Rectangle.ThreePoint"
+	if _, ok := s.Commands().ByID(variantID); !ok {
+		t.Fatalf("variant %q not registered for dispatch", variantID)
+	}
+	if err := s.Execute(variantID); err != nil {
+		t.Fatalf("Execute(%q): %v", variantID, err)
+	}
+	if s.ActiveTool() == nil {
+		t.Error("executing a variant should start its tool")
+	}
+
+	tab, _ := BuildRibbon(s).Tab("Sketch")
+	create, _ := tab.Panel("Create")
+	for _, b := range create.Buttons {
+		if b.Command.ID() == variantID {
+			t.Errorf("variant %q must not be a standalone Create-panel button", variantID)
+		}
+	}
+}
+
+// Variant dropdown entries reflect the head's enable state (disabled outside a sketch).
+func TestVariantsEnabledOnlyInSketch(t *testing.T) {
+	s := registeredSession(t)
+	enterSketchEnv(t, s)
+	for _, v := range createButton(t, s, "Rectangle").Variants {
+		if !v.Enabled {
+			t.Errorf("variant %q should be enabled inside a sketch", v.Label)
+		}
+	}
+}

--- a/app/sculpt_tool.go
+++ b/app/sculpt_tool.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// SculptTool is the interactive Sculpt command (Surface panel): fill the volume bounded by the
+// running surface bodies into a solid. It takes no pick (it acts on all bounding surfaces); the
+// dialog drives the closing tolerance. The bounding surfaces must enclose a closed cell, else the
+// feature goes sick.
+type SculptTool struct {
+	tolerance float64
+	added     *feature.PartFeature
+}
+
+// NewSculptTool returns a sculpt tool defaulting to an exact (zero-tolerance) close.
+func NewSculptTool() *SculptTool { return &SculptTool{} }
+
+// Name implements [Tool].
+func (t *SculptTool) Name() string { return "Sculpt" }
+
+// Start has nothing to select — sculpt acts on every bounding surface.
+func (t *SculptTool) Start(*Session) {}
+
+// Pick is unused.
+func (t *SculptTool) Pick(*Session, Selectable) {}
+
+// SetTolerance/Tolerance drive the coincidence tolerance for closing the bounding surfaces.
+func (t *SculptTool) SetTolerance(v float64) { t.tolerance = v }
+func (t *SculptTool) Tolerance() float64     { return t.tolerance }
+
+// Params exposes the closing tolerance for the generic property dialog.
+func (t *SculptTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{{Label: "Tolerance", Get: t.Tolerance, Set: t.SetTolerance}}}
+}
+
+// CanCommit is always true — sculpt acts on whatever bounding surfaces are present (Commit
+// validates that they enclose a volume).
+func (t *SculptTool) CanCommit() bool { return true }
+
+// Commit fills the bounded volume into a solid and recomputes; open surfaces keep the tool open.
+func (t *SculptTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewSculptFeatures(part.Features()).Add(ops.NewBody, t.tolerance)
+	part.Recompute()
+	s.recordEdit(part, "Sculpt")
+	if !t.added.Health().OK() {
+		return errors.New("sculpt: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// Cancel abandons the tool with no change.
+func (t *SculptTool) Cancel(*Session) {}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *SculptTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sculpt_tool_test.go
+++ b/app/sculpt_tool_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// cubeFaceSheet builds a single-face surface body over the 4 corners (wound for an outward plane).
+func cubeFaceSheet(feat string, p0, p1, p2, p3 math.Point3) *topo.Body {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	surf, _ := geom.NewPlane(p0, p0.VectorTo(p1).Cross(p1.VectorTo(p2)))
+	pts := []math.Point3{p0, p1, p2, p3}
+	v := make([]*topo.Vertex, 4)
+	for i, p := range pts {
+		v[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(feat, "vertex", i)))
+	}
+	uses := make([]topo.Use, 4)
+	for i := 0; i < 4; i++ {
+		j := (i + 1) % 4
+		uses[i] = topo.Fwd(bld.AddEdge(geom.NewLineSegment(pts[i], pts[j]), v[i], v[j], topo.NewLineage(topo.Tok(feat, "edge", i))))
+	}
+	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "face", 0)), topo.OuterLoop(uses...))
+	return bld.Build()
+}
+
+// partWithCubeShell gives a part whose running state is the six surface faces of a unit cube.
+func partWithCubeShell(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	p := math.P3
+	faces := []*topo.Body{
+		cubeFaceSheet("bottom", p(0, 0, 0), p(0, 1, 0), p(1, 1, 0), p(1, 0, 0)),
+		cubeFaceSheet("top", p(0, 0, 1), p(1, 0, 1), p(1, 1, 1), p(0, 1, 1)),
+		cubeFaceSheet("front", p(0, 0, 0), p(1, 0, 0), p(1, 0, 1), p(0, 0, 1)),
+		cubeFaceSheet("back", p(0, 1, 0), p(0, 1, 1), p(1, 1, 1), p(1, 1, 0)),
+		cubeFaceSheet("left", p(0, 0, 0), p(0, 0, 1), p(0, 1, 1), p(0, 1, 0)),
+		cubeFaceSheet("right", p(1, 0, 0), p(1, 1, 0), p(1, 1, 1), p(1, 0, 1)),
+	}
+	feature.NewBaseFeatures(def.Features()).AddBase(faces...)
+	def.Recompute()
+	return s, def
+}
+
+// TestSculptToolEndToEnd drives the Sculpt UI: with the six cube faces present, OK fills the
+// bounded volume into a single unit-volume solid.
+func TestSculptToolEndToEnd(t *testing.T) {
+	s, def := partWithCubeShell(t)
+
+	s.StartTool(NewSculptTool())
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("after sculpt: %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if !body.IsSolid() {
+		t.Error("sculpt of a closed shell should yield a solid")
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-1) > 1e-6 {
+		t.Errorf("sculpted volume = %g, want 1 (unit cube)", v)
+	}
+}
+
+func TestSculptViaRibbonCommand(t *testing.T) {
+	s, _ := partWithCubeShell(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.Sculpt"); err != nil {
+		t.Fatalf("execute Surface.Sculpt: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*SculptTool); !ok {
+		t.Fatal("Sculpt command did not start the sculpt tool")
+	}
+}

--- a/app/sketch3d_geometry_tools.go
+++ b/app/sketch3d_geometry_tools.go
@@ -223,11 +223,39 @@ func (t *Helix3DTool) Commit(s *Session) error {
 // Cancel implements [Tool].
 func (t *Helix3DTool) Cancel(*Session) {}
 
-// compile-time assertions that the 3D sketch tools satisfy the Tool interface.
+// --- Params (generic property dialog) -------------------------------------
+// The 3D tools take their points from viewport clicks; the dialog edits the scalar/bool
+// inputs (radius/pitch/turns/winding).
+
+func (t *Circle3DTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{{"Radius", func() float64 { return t.radius }, func(r float64) { t.radius = r }}}}
+}
+
+func (t *Helix3DTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{
+			{"Radius", func() float64 { return t.radius }, func(r float64) { t.radius = r }},
+			{"Pitch", func() float64 { return t.pitch }, func(p float64) { t.pitch = p }},
+			{"Turns", func() float64 { return t.turns }, func(n float64) { t.turns = n }},
+		},
+		Bools: []BoolParam{{"Clockwise", func() bool { return t.clockwise }, func(b bool) { t.clockwise = b }}},
+	}
+}
+
+func (t *Arc3DTool) Params() ToolParams {
+	return ToolParams{Bools: []BoolParam{{"Counter-clockwise", func() bool { return t.ccw }, func(b bool) { t.ccw = b }}}}
+}
+
+// compile-time assertions that the 3D sketch tools satisfy the Tool interface (and that the
+// parameterized ones expose the property dialog).
 var (
 	_ Tool = (*Line3DTool)(nil)
 	_ Tool = (*Point3DTool)(nil)
 	_ Tool = (*Circle3DTool)(nil)
 	_ Tool = (*Arc3DTool)(nil)
 	_ Tool = (*Helix3DTool)(nil)
+
+	_ ParameterizedTool = (*Circle3DTool)(nil)
+	_ ParameterizedTool = (*Helix3DTool)(nil)
+	_ ParameterizedTool = (*Arc3DTool)(nil)
 )

--- a/app/sketch_create_tools.go
+++ b/app/sketch_create_tools.go
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// Additional Create-panel tools: Chamfer (two-line bevel, sibling of Fillet), Slot (a
+// two-point centre axis + width), and Text (an anchor + string). Their geometry lives in
+// model/sketch and is tested there; these tools are the interaction shells, tested via the
+// app's headless click/pick path.
+
+// SketchChamferTool bevels the corner between two picked lines (like Fillet, but a flat
+// cut). It uses an equal setback on both lines.
+type SketchChamferTool struct {
+	pickCollector
+	distance math.Scalar
+}
+
+// NewSketchChamferTool makes a chamfer tool with the given default setback.
+func NewSketchChamferTool(distance float64) *SketchChamferTool {
+	return &SketchChamferTool{pickCollector: pickCollector{want: 2}, distance: math.Scalar(distance)}
+}
+
+func (t *SketchChamferTool) Name() string                  { return "Chamfer" }
+func (t *SketchChamferTool) Start(*Session)                {}
+func (t *SketchChamferTool) Pick(_ *Session, s Selectable) { t.take(s) }
+func (t *SketchChamferTool) CanCommit() bool               { return t.ready() }
+func (t *SketchChamferTool) AutoCommitOnPick() bool        { return true }
+func (t *SketchChamferTool) Cancel(*Session)               { t.reset() }
+func (t *SketchChamferTool) Prompt(*Session) string        { return "Pick two lines to chamfer." }
+
+// SetDistance sets the chamfer setback.
+func (t *SketchChamferTool) SetDistance(d float64) { t.distance = math.Scalar(d) }
+
+// Commit chamfers the two picked lines.
+func (t *SketchChamferTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errors.New("chamfer: no active sketch")
+	}
+	l1, l2, err := twoPickedLines(t.picks)
+	if err != nil {
+		return err
+	}
+	_, err = sk.AddChamfer(l1, l2, t.distance, t.distance)
+	return err
+}
+
+// SketchSlotTool draws a straight slot from two centre-axis clicks and a width.
+type SketchSlotTool struct {
+	points []math.Point2
+	width  math.Scalar
+}
+
+// NewSketchSlotTool makes a slot tool with the given default width.
+func NewSketchSlotTool(width float64) *SketchSlotTool {
+	return &SketchSlotTool{width: math.Scalar(width)}
+}
+
+func (t *SketchSlotTool) Name() string              { return "Slot" }
+func (t *SketchSlotTool) Start(*Session)            {}
+func (t *SketchSlotTool) Pick(*Session, Selectable) {}
+func (t *SketchSlotTool) Cancel(*Session)           { t.points = nil }
+func (t *SketchSlotTool) AutoCommits() bool         { return true }
+func (t *SketchSlotTool) CanCommit() bool           { return len(t.points) == 2 }
+func (t *SketchSlotTool) Prompt(*Session) string {
+	if len(t.points) == 0 {
+		return "Click the slot's first centre point."
+	}
+	return "Click the slot's second centre point."
+}
+
+// ClickAt records a centre-axis endpoint from a clicked pixel (snapped).
+func (t *SketchSlotTool) ClickAt(s *Session, px, py float64) {
+	if p, ok := s.sketchClickPoint(px, py); ok {
+		t.points = append(t.points, p)
+	}
+}
+
+// SetWidth sets the slot width.
+func (t *SketchSlotTool) SetWidth(w float64) { t.width = math.Scalar(w) }
+
+// Commit creates the straight slot.
+func (t *SketchSlotTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errors.New("slot: no active sketch")
+	}
+	_, err := sk.AddStraightSlot(t.points[0], t.points[1], t.width)
+	return err
+}
+
+// CenterPointArcSlotTool draws an arc-shaped slot whose centre line is an arc given by its
+// center, start and end (Inventor's Center Point Arc Slot); the width is a parameter.
+type CenterPointArcSlotTool struct {
+	collectClicks
+	width math.Scalar
+}
+
+// NewCenterPointArcSlotTool makes a center-point arc-slot tool with the given default width.
+func NewCenterPointArcSlotTool(width float64) *CenterPointArcSlotTool {
+	return &CenterPointArcSlotTool{width: math.Scalar(width)}
+}
+
+func (t *CenterPointArcSlotTool) Name() string              { return "Center Point Arc Slot" }
+func (t *CenterPointArcSlotTool) Start(*Session)            {}
+func (t *CenterPointArcSlotTool) Pick(*Session, Selectable) {}
+func (t *CenterPointArcSlotTool) Cancel(*Session)           { t.reset() }
+func (t *CenterPointArcSlotTool) CanCommit() bool           { return len(t.pts) == 3 }
+func (t *CenterPointArcSlotTool) AutoCommits() bool         { return true }
+
+// SetWidth sets the slot width.
+func (t *CenterPointArcSlotTool) SetWidth(w float64) { t.width = math.Scalar(w) }
+
+// Commit creates the arc slot; it sweeps CCW when the end lies CCW of the start about the
+// center (the cross product of the two radii is positive).
+func (t *CenterPointArcSlotTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("center point arc slot")
+	}
+	center, start, end := t.pts[0], t.pts[1], t.pts[2]
+	_, err := sk.AddArcSlot(center, start, end, t.width, leftTurn(center, start, end))
+	return err
+}
+
+// Prompt guides the center, start and end of the slot's arc.
+func (t *CenterPointArcSlotTool) Prompt(*Session) string {
+	switch len(t.pts) {
+	case 0:
+		return "Click the arc slot center"
+	case 1:
+		return "Click the slot's first centre point"
+	case 2:
+		return "Click the slot's second centre point"
+	default:
+		return "Click OK to create the slot"
+	}
+}
+
+func (t *CenterPointArcSlotTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{scalarParam("Width", &t.width)}}
+}
+
+// ThreePointArcSlotTool draws an arc-shaped slot whose centre line is the arc through three
+// clicked points — start, a point on the arc, then end (Inventor's Three Point Arc Slot).
+type ThreePointArcSlotTool struct {
+	collectClicks
+	width math.Scalar
+}
+
+// NewThreePointArcSlotTool makes a three-point arc-slot tool with the given default width.
+func NewThreePointArcSlotTool(width float64) *ThreePointArcSlotTool {
+	return &ThreePointArcSlotTool{width: math.Scalar(width)}
+}
+
+func (t *ThreePointArcSlotTool) Name() string              { return "Three Point Arc Slot" }
+func (t *ThreePointArcSlotTool) Start(*Session)            {}
+func (t *ThreePointArcSlotTool) Pick(*Session, Selectable) {}
+func (t *ThreePointArcSlotTool) Cancel(*Session)           { t.reset() }
+func (t *ThreePointArcSlotTool) CanCommit() bool           { return len(t.pts) == 3 }
+func (t *ThreePointArcSlotTool) AutoCommits() bool         { return true }
+
+// SetWidth sets the slot width.
+func (t *ThreePointArcSlotTool) SetWidth(w float64) { t.width = math.Scalar(w) }
+
+// Commit fits the centre arc's center as the circumcentre of start, through and end, then
+// creates the arc slot; the sweep follows the start→through→end orientation.
+func (t *ThreePointArcSlotTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("three point arc slot")
+	}
+	start, through, end := t.pts[0], t.pts[1], t.pts[2]
+	center, ok := circumcenter(start, through, end)
+	if !ok {
+		return errors.New("three point arc slot: the three points are collinear")
+	}
+	_, err := sk.AddArcSlot(center, start, end, t.width, leftTurn(start, through, end))
+	return err
+}
+
+// Prompt guides the start, a point on the arc, then the end.
+func (t *ThreePointArcSlotTool) Prompt(*Session) string {
+	switch len(t.pts) {
+	case 0:
+		return "Click the slot's first centre point"
+	case 1:
+		return "Click a point on the slot's arc"
+	case 2:
+		return "Click the slot's second centre point"
+	default:
+		return "Click OK to create the slot"
+	}
+}
+
+func (t *ThreePointArcSlotTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{scalarParam("Width", &t.width)}}
+}
+
+// SketchTextTool places a text box at a clicked anchor; the string and height are set
+// before committing (Inventor's text dialog). It does not auto-commit — the user enters
+// the text first.
+type SketchTextTool struct {
+	anchor *math.Point2
+	text   string
+	height math.Scalar
+}
+
+// NewSketchTextTool makes a text tool with a default height.
+func NewSketchTextTool() *SketchTextTool { return &SketchTextTool{height: 1} }
+
+func (t *SketchTextTool) Name() string              { return "Text" }
+func (t *SketchTextTool) Start(*Session)            {}
+func (t *SketchTextTool) Pick(*Session, Selectable) {}
+func (t *SketchTextTool) Cancel(*Session)           { t.anchor, t.text = nil, "" }
+func (t *SketchTextTool) CanCommit() bool           { return t.anchor != nil && t.text != "" }
+func (t *SketchTextTool) Prompt(*Session) string {
+	if t.anchor == nil {
+		return "Click to place the text anchor."
+	}
+	return "Type the text, then OK."
+}
+
+// ClickAt sets the text anchor from a clicked pixel (snapped).
+func (t *SketchTextTool) ClickAt(s *Session, px, py float64) {
+	if p, ok := s.sketchClickPoint(px, py); ok {
+		t.anchor = &p
+	}
+}
+
+// SetText and SetHeight set the string and character height.
+func (t *SketchTextTool) SetText(text string) { t.text = text }
+func (t *SketchTextTool) SetHeight(h float64) { t.height = math.Scalar(h) }
+
+// Commit creates the text box.
+func (t *SketchTextTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errors.New("text: no active sketch")
+	}
+	if t.anchor == nil || t.text == "" {
+		return errors.New("text: needs an anchor and a non-empty string")
+	}
+	sk.TextBoxes().Add(*t.anchor, t.text, t.height, 0, sketch.TextLeft)
+	return nil
+}
+
+// --- Params (generic property dialog) -------------------------------------
+
+func (t *SketchChamferTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{scalarParam("Distance", &t.distance)}}
+}
+
+func (t *SketchSlotTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{scalarParam("Width", &t.width)}}
+}
+
+func (t *SketchTextTool) Params() ToolParams {
+	return ToolParams{
+		Texts:  []TextParam{{"Text", func() string { return t.text }, func(s string) { t.text = s }}},
+		Floats: []FloatParam{scalarParam("Height", &t.height)},
+	}
+}

--- a/app/sketch_create_tools_test.go
+++ b/app/sketch_create_tools_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+// Chamfer bevels the corner of two picked lines, adding the bevel line.
+func TestSketchChamferTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	corner := sk.Points().Add(gmath.P2(0, 0))
+	l1 := sk.Lines().Add(corner, sk.Points().Add(gmath.P2(4, 0)))
+	l2 := sk.Lines().Add(corner, sk.Points().Add(gmath.P2(0, 4)))
+	before := sk.Lines().Count()
+
+	tool := NewSketchChamferTool(1)
+	s.StartTool(tool)
+	s.feedPick(SketchEntityHandle{Entity: l1})
+	s.feedPick(SketchEntityHandle{Entity: l2}) // second pick auto-commits
+
+	if s.ActiveTool() != nil {
+		t.Fatal("chamfer tool should deactivate after two picks")
+	}
+	if sk.Lines().Count() != before+1 {
+		t.Fatalf("lines after chamfer = %d, want %d (the bevel)", sk.Lines().Count(), before+1)
+	}
+}
+
+// Slot draws a straight slot from two centre clicks (two lines + two arc caps).
+func TestSketchSlotTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	tool := NewSketchSlotTool(1)
+	s.StartTool(tool)
+	s.Click(80, 100)
+	s.Click(120, 100) // second click auto-commits
+
+	if s.ActiveTool() != nil {
+		t.Fatal("slot tool should deactivate after two clicks")
+	}
+	if sk.Lines().Count() < 2 || sk.Arcs().Count() < 2 {
+		t.Fatalf("slot made %d lines / %d arcs, want >=2 each", sk.Lines().Count(), sk.Arcs().Count())
+	}
+}
+
+// Text places a text box at the clicked anchor once a string is set.
+func TestSketchTextTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	tool := NewSketchTextTool()
+	s.StartTool(tool)
+	s.Click(100, 100) // anchor (does not auto-commit — text is entered first)
+	tool.SetText("HELLO")
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sk.TextBoxes().Count() != 1 {
+		t.Fatalf("text boxes = %d, want 1", sk.TextBoxes().Count())
+	}
+}
+
+// Text with no string is not ready to commit.
+func TestSketchTextToolNeedsString(t *testing.T) {
+	s, _ := sketchSession(t)
+	tool := NewSketchTextTool()
+	s.StartTool(tool)
+	s.Click(100, 100)
+	if err := s.OK(); err == nil {
+		t.Error("text without a string should not commit")
+	}
+}
+
+func TestSketchCreateToolsRegistered(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	for _, id := range []string{"Sketch.Slot", "Sketch.Chamfer", "Sketch.Text"} {
+		if _, ok := s.Commands().ByID(id); !ok {
+			t.Errorf("command %q not registered", id)
+		}
+	}
+}

--- a/app/sketch_format.go
+++ b/app/sketch_format.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "github.com/Oblikovati/oblikovati/model/sketch"
+
+// The Sketch tab's Format panel: toggle the selected sketch geometry between normal and
+// construction, or mark/unmark selected lines as centerlines (an axis for revolve/mirror).
+
+// ToggleConstruction flips the construction flag on every selected sketch curve, returning how
+// many it changed. Construction geometry shapes constraints but is excluded from profiles.
+func (s *Session) ToggleConstruction() int {
+	n := 0
+	for _, it := range s.Selection().Items() {
+		h, ok := it.(SketchEntityHandle)
+		if !ok {
+			continue
+		}
+		if c, ok := h.Entity.(interface {
+			IsConstruction() bool
+			SetConstruction(bool)
+		}); ok {
+			c.SetConstruction(!c.IsConstruction())
+			n++
+		}
+	}
+	return n
+}
+
+// ToggleCenterline flips the centerline flag on every selected sketch line (an axis for
+// revolve/mirror/symmetry; centerlines are always construction).
+func (s *Session) ToggleCenterline() int {
+	n := 0
+	for _, it := range s.Selection().Items() {
+		h, ok := it.(SketchEntityHandle)
+		if !ok {
+			continue
+		}
+		if l, ok := h.Entity.(*sketch.Line); ok {
+			l.SetCenterline(!l.IsCenterline())
+			n++
+		}
+	}
+	return n
+}
+
+// sketchFormatCommands is the Sketch tab's Format panel: toggle Construction / Centerline on the
+// selected sketch geometry (matching Inventor's Format panel).
+func sketchFormatCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		NewCommand("Sketch.Construction", "Construction", "Format", func(s *Session) error {
+			s.ToggleConstruction()
+			return nil
+		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
+			WithIcon("construction").WithButtonStyle(SmallIconButton).
+			WithTooltip("Construction — toggle the selected geometry as construction (excluded from profiles)."),
+		NewCommand("Sketch.Centerline", "Centerline", "Format", func(s *Session) error {
+			s.ToggleCenterline()
+			return nil
+		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
+			WithIcon("centerline").WithButtonStyle(SmallIconButton).
+			WithTooltip("Centerline — toggle the selected line(s) as a centerline axis (revolve/mirror)."),
+	}
+}

--- a/app/sketch_format_test.go
+++ b/app/sketch_format_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// squareWithMidline draws a 4×4 square plus a midline (which, as normal geometry, splits it into
+// two regions), returning the active sketch and the midline.
+func squareWithMidline(t *testing.T) (*Session, *sketch.Sketch, *sketch.Line) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	sk.Lines().AddByTwoPoints(math.P2(4, 0), math.P2(4, 4))
+	sk.Lines().AddByTwoPoints(math.P2(4, 4), math.P2(0, 4))
+	sk.Lines().AddByTwoPoints(math.P2(0, 4), math.P2(0, 0))
+	mid := sk.Lines().AddByTwoPoints(math.P2(0, 2), math.P2(4, 2))
+	if sk.Profiles().Count() != 2 {
+		t.Fatalf("setup: midline should split the square into 2 regions, got %d", sk.Profiles().Count())
+	}
+	return s, sk, mid
+}
+
+// Toggling Centerline on the selected midline removes it from profiles (it no longer closes a
+// region) and marks it as an axis.
+func TestSketchCenterlineToggle(t *testing.T) {
+	s, sk, mid := squareWithMidline(t)
+	s.Selection().Add(SketchEntityHandle{Entity: mid})
+	if n := s.ToggleCenterline(); n != 1 {
+		t.Fatalf("ToggleCenterline changed %d entities, want 1", n)
+	}
+	if !mid.IsCenterline() || !mid.IsConstruction() {
+		t.Error("midline should now be a centerline (and construction)")
+	}
+	if sk.Profiles().Count() != 1 {
+		t.Errorf("after centerline toggle the square has %d regions, want 1", sk.Profiles().Count())
+	}
+	if len(sk.Centerlines()) != 1 {
+		t.Errorf("Centerlines() = %d, want 1", len(sk.Centerlines()))
+	}
+}
+
+// Toggling Construction on the selected midline likewise drops it from profiles.
+func TestSketchConstructionToggle(t *testing.T) {
+	s, sk, mid := squareWithMidline(t)
+	s.Selection().Add(SketchEntityHandle{Entity: mid})
+	if n := s.ToggleConstruction(); n != 1 {
+		t.Fatalf("ToggleConstruction changed %d entities, want 1", n)
+	}
+	if !mid.IsConstruction() {
+		t.Error("midline should now be construction")
+	}
+	if sk.Profiles().Count() != 1 {
+		t.Errorf("after construction toggle the square has %d regions, want 1", sk.Profiles().Count())
+	}
+}
+
+func TestSketchFormatCommandsRegistered(t *testing.T) {
+	s, _, mid := squareWithMidline(t)
+	s.Selection().Add(SketchEntityHandle{Entity: mid})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Sketch.Centerline"); err != nil {
+		t.Fatalf("execute Sketch.Centerline: %v", err)
+	}
+	if !mid.IsCenterline() {
+		t.Error("Sketch.Centerline command did not mark the line")
+	}
+}

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -49,6 +49,11 @@ func (t *SketchFilletTool) Prompt(*Session) string        { return "Pick two lin
 // SetRadius sets the fillet radius.
 func (t *SketchFilletTool) SetRadius(r float64) { t.radius = math.Scalar(r) }
 
+// Params exposes the fillet radius to the generic property dialog.
+func (t *SketchFilletTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{scalarParam("Radius", &t.radius)}}
+}
+
 // Commit applies the fillet to the two picked lines.
 func (t *SketchFilletTool) Commit(s *Session) error {
 	sk := s.ActiveSketch()
@@ -84,6 +89,11 @@ func (t *SketchOffsetTool) Prompt(*Session) string        { return "Pick a curve
 
 // SetDistance sets the offset distance.
 func (t *SketchOffsetTool) SetDistance(d float64) { t.distance = math.Scalar(d) }
+
+// Params exposes the offset distance to the generic property dialog.
+func (t *SketchOffsetTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{scalarParam("Distance", &t.distance)}}
+}
 
 // Commit offsets the picked curve.
 func (t *SketchOffsetTool) Commit(s *Session) error {

--- a/app/sketch_transform_tools.go
+++ b/app/sketch_transform_tools.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// The sketch transform/pattern tools (Move, Copy, Rotate, Scale; Rectangular, Circular
+// pattern) gather a variable selection set and apply a model edit with the tool's
+// parameters on OK — they do not auto-commit. The viewport/dialog feeds the parameters
+// through the Set* methods; the behavior lives in model/sketch and is tested headlessly
+// here (the head dialog is a thin numeric-entry shell over these setters).
+
+// sketchSelectTool is the shared selection collector: it is fed entity picks (PickSnap)
+// and is ready once at least one entity is selected. Concrete tools embed it and add their
+// parameters + Commit.
+type sketchSelectTool struct {
+	picks []sketch.Entity
+}
+
+func (t *sketchSelectTool) PickSnap(ent sketch.Entity, _ SnapResult) { t.picks = append(t.picks, ent) }
+func (t *sketchSelectTool) Pick(*Session, Selectable)                {}
+func (t *sketchSelectTool) Start(*Session)                           {}
+func (t *sketchSelectTool) Cancel(*Session)                          { t.picks = nil }
+func (t *sketchSelectTool) CanCommit() bool                          { return len(t.picks) > 0 }
+
+// Selected returns the gathered entities (for the head/preview).
+func (t *sketchSelectTool) Selected() []sketch.Entity { return t.picks }
+
+// activeSketchOrErr resolves the active sketch or an error labelled with op.
+func activeSketchOrErr(s *Session, op string) (*sketch.Sketch, error) {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return nil, errors.New(op + ": no active sketch")
+	}
+	return sk, nil
+}
+
+// --- Move / Copy ----------------------------------------------------------
+
+// SketchMoveTool translates the selection by a vector (set via SetVector or a base→target
+// point pair).
+type SketchMoveTool struct {
+	sketchSelectTool
+	vector math.Vector2
+}
+
+func NewSketchMoveTool() *SketchMoveTool { return &SketchMoveTool{} }
+func (t *SketchMoveTool) Name() string   { return "Move" }
+func (t *SketchMoveTool) Prompt(*Session) string {
+	return "Select geometry, set the move vector, then OK."
+}
+
+// SetVector sets the displacement; SetByPoints derives it from a base and target point.
+func (t *SketchMoveTool) SetVector(dx, dy float64) {
+	t.vector = math.V2(math.Scalar(dx), math.Scalar(dy))
+}
+func (t *SketchMoveTool) SetByPoints(base, target math.Point2) { t.vector = base.VectorTo(target) }
+
+func (t *SketchMoveTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "move")
+	if err != nil {
+		return err
+	}
+	sk.MoveEntities(t.picks, t.vector)
+	return nil
+}
+
+// SketchCopyTool duplicates the selection, offset by a vector.
+type SketchCopyTool struct {
+	sketchSelectTool
+	vector math.Vector2
+}
+
+func NewSketchCopyTool() *SketchCopyTool { return &SketchCopyTool{} }
+func (t *SketchCopyTool) Name() string   { return "Copy" }
+func (t *SketchCopyTool) Prompt(*Session) string {
+	return "Select geometry, set the copy offset, then OK."
+}
+func (t *SketchCopyTool) SetVector(dx, dy float64) {
+	t.vector = math.V2(math.Scalar(dx), math.Scalar(dy))
+}
+func (t *SketchCopyTool) SetByPoints(base, target math.Point2) { t.vector = base.VectorTo(target) }
+
+func (t *SketchCopyTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "copy")
+	if err != nil {
+		return err
+	}
+	if len(sk.CopyEntities(t.picks, t.vector)) == 0 {
+		return errors.New("copy: produced no geometry")
+	}
+	return nil
+}
+
+// SketchStretchTool moves only the picked vertices (points) by a vector, deforming the
+// geometry that shares them — Inventor's Stretch, where endpoints inside the window move
+// and the rest stay. It collects point picks (a non-point pick is ignored).
+type SketchStretchTool struct {
+	points []*sketch.Point
+	vector math.Vector2
+}
+
+func NewSketchStretchTool() *SketchStretchTool         { return &SketchStretchTool{} }
+func (t *SketchStretchTool) Name() string              { return "Stretch" }
+func (t *SketchStretchTool) Start(*Session)            {}
+func (t *SketchStretchTool) Pick(*Session, Selectable) {}
+func (t *SketchStretchTool) Cancel(*Session)           { t.points = nil }
+func (t *SketchStretchTool) CanCommit() bool           { return len(t.points) > 0 }
+func (t *SketchStretchTool) Prompt(*Session) string {
+	return "Pick the vertices to stretch, set the vector, then OK."
+}
+
+// PickSnap collects point picks (vertices); non-point picks are ignored.
+func (t *SketchStretchTool) PickSnap(ent sketch.Entity, _ SnapResult) {
+	if p, ok := ent.(*sketch.Point); ok {
+		t.points = append(t.points, p)
+	}
+}
+
+// SetVector sets the displacement; SetByPoints derives it from a base and target point.
+func (t *SketchStretchTool) SetVector(dx, dy float64) {
+	t.vector = math.V2(math.Scalar(dx), math.Scalar(dy))
+}
+func (t *SketchStretchTool) SetByPoints(base, target math.Point2) { t.vector = base.VectorTo(target) }
+
+func (t *SketchStretchTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "stretch")
+	if err != nil {
+		return err
+	}
+	sk.MovePoints(t.points, t.vector)
+	return nil
+}
+
+// --- Rotate / Scale -------------------------------------------------------
+
+// SketchRotateTool rotates the selection about a center by an angle (radians).
+type SketchRotateTool struct {
+	sketchSelectTool
+	center math.Point2
+	angle  float64
+}
+
+func NewSketchRotateTool() *SketchRotateTool { return &SketchRotateTool{} }
+func (t *SketchRotateTool) Name() string     { return "Rotate" }
+func (t *SketchRotateTool) Prompt(*Session) string {
+	return "Select geometry, set the center and angle, then OK."
+}
+func (t *SketchRotateTool) SetCenter(x, y float64) {
+	t.center = math.P2(math.Scalar(x), math.Scalar(y))
+}
+func (t *SketchRotateTool) SetAngle(radians float64) { t.angle = radians }
+
+func (t *SketchRotateTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "rotate")
+	if err != nil {
+		return err
+	}
+	sk.RotateEntities(t.picks, t.center, t.angle)
+	return nil
+}
+
+// SketchScaleTool scales the selection about a center by a factor.
+type SketchScaleTool struct {
+	sketchSelectTool
+	center math.Point2
+	factor float64
+}
+
+func NewSketchScaleTool() *SketchScaleTool { return &SketchScaleTool{factor: 1} }
+func (t *SketchScaleTool) Name() string    { return "Scale" }
+func (t *SketchScaleTool) Prompt(*Session) string {
+	return "Select geometry, set the center and factor, then OK."
+}
+func (t *SketchScaleTool) SetCenter(x, y float64) {
+	t.center = math.P2(math.Scalar(x), math.Scalar(y))
+}
+func (t *SketchScaleTool) SetFactor(f float64) { t.factor = f }
+
+func (t *SketchScaleTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "scale")
+	if err != nil {
+		return err
+	}
+	if t.factor <= 0 {
+		return errors.New("scale: factor must be positive")
+	}
+	sk.ScaleEntities(t.picks, t.center, t.factor)
+	return nil
+}
+
+// --- Rectangular / Circular pattern ---------------------------------------
+
+// SketchRectPatternTool patterns the selection in a grid: count1 copies along step1 and
+// count2 along step2 (each step is the full per-copy displacement vector).
+type SketchRectPatternTool struct {
+	sketchSelectTool
+	step1  math.Vector2
+	count1 int
+	step2  math.Vector2
+	count2 int
+}
+
+func NewSketchRectPatternTool() *SketchRectPatternTool {
+	return &SketchRectPatternTool{count1: 2, count2: 1}
+}
+func (t *SketchRectPatternTool) Name() string { return "Rectangular Pattern" }
+func (t *SketchRectPatternTool) Prompt(*Session) string {
+	return "Select geometry, set the two directions and counts, then OK."
+}
+func (t *SketchRectPatternTool) SetStep1(dx, dy float64) {
+	t.step1 = math.V2(math.Scalar(dx), math.Scalar(dy))
+}
+func (t *SketchRectPatternTool) SetStep2(dx, dy float64) {
+	t.step2 = math.V2(math.Scalar(dx), math.Scalar(dy))
+}
+func (t *SketchRectPatternTool) SetCount1(n int) { t.count1 = n }
+func (t *SketchRectPatternTool) SetCount2(n int) { t.count2 = n }
+
+// CanCommit also requires the grid to make more than one instance.
+func (t *SketchRectPatternTool) CanCommit() bool {
+	return len(t.picks) > 0 && t.count1 >= 1 && t.count2 >= 1 && t.count1*t.count2 > 1
+}
+
+func (t *SketchRectPatternTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "rectangular pattern")
+	if err != nil {
+		return err
+	}
+	_, err = sk.RectangularPattern(t.picks, t.step1, t.count1, t.step2, t.count2)
+	return err
+}
+
+// SketchCircPatternTool patterns the selection around a center: count copies spread over
+// totalAngle (radians).
+type SketchCircPatternTool struct {
+	sketchSelectTool
+	center     math.Point2
+	count      int
+	totalAngle float64
+}
+
+func NewSketchCircPatternTool() *SketchCircPatternTool {
+	return &SketchCircPatternTool{count: 4, totalAngle: 2 * stdmath.Pi}
+}
+func (t *SketchCircPatternTool) Name() string { return "Circular Pattern" }
+func (t *SketchCircPatternTool) Prompt(*Session) string {
+	return "Select geometry, set the center, count and angle, then OK."
+}
+func (t *SketchCircPatternTool) SetCenter(x, y float64) {
+	t.center = math.P2(math.Scalar(x), math.Scalar(y))
+}
+func (t *SketchCircPatternTool) SetCount(n int)            { t.count = n }
+func (t *SketchCircPatternTool) SetTotalAngle(rad float64) { t.totalAngle = rad }
+
+func (t *SketchCircPatternTool) CanCommit() bool { return len(t.picks) > 0 && t.count >= 2 }
+
+func (t *SketchCircPatternTool) Commit(s *Session) error {
+	sk, err := activeSketchOrErr(s, "circular pattern")
+	if err != nil {
+		return err
+	}
+	_, err = sk.CircularPattern(t.picks, t.center, t.count, t.totalAngle)
+	return err
+}
+
+// --- Params (generic property dialog) -------------------------------------
+
+func (t *SketchMoveTool) Params() ToolParams {
+	return ToolParams{Floats: xyParams("Δ", &t.vector.X, &t.vector.Y)}
+}
+
+func (t *SketchCopyTool) Params() ToolParams {
+	return ToolParams{Floats: xyParams("Δ", &t.vector.X, &t.vector.Y)}
+}
+
+func (t *SketchStretchTool) Params() ToolParams {
+	return ToolParams{Floats: xyParams("Δ", &t.vector.X, &t.vector.Y)}
+}
+
+func (t *SketchRotateTool) Params() ToolParams {
+	return ToolParams{Floats: append(xyParams("Center", &t.center.X, &t.center.Y),
+		FloatParam{"Angle (deg)", func() float64 { return degFromRad(t.angle) }, func(d float64) { t.angle = radFromDeg(d) }})}
+}
+
+func (t *SketchScaleTool) Params() ToolParams {
+	return ToolParams{Floats: append(xyParams("Center", &t.center.X, &t.center.Y),
+		FloatParam{"Factor", func() float64 { return t.factor }, func(f float64) { t.factor = f }})}
+}
+
+func (t *SketchRectPatternTool) Params() ToolParams {
+	floats := append(xyParams("Step 1", &t.step1.X, &t.step1.Y), xyParams("Step 2", &t.step2.X, &t.step2.Y)...)
+	return ToolParams{
+		Floats: floats,
+		Ints: []IntParam{
+			{"Count 1", func() int { return t.count1 }, func(n int) { t.count1 = n }},
+			{"Count 2", func() int { return t.count2 }, func(n int) { t.count2 = n }},
+		},
+	}
+}
+
+func (t *SketchCircPatternTool) Params() ToolParams {
+	return ToolParams{
+		Floats: append(xyParams("Center", &t.center.X, &t.center.Y),
+			FloatParam{"Angle (deg)", func() float64 { return degFromRad(t.totalAngle) }, func(d float64) { t.totalAngle = radFromDeg(d) }}),
+		Ints: []IntParam{{"Count", func() int { return t.count }, func(n int) { t.count = n }}},
+	}
+}

--- a/app/sketch_transform_tools_test.go
+++ b/app/sketch_transform_tools_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+// near2 asserts a 2D point within tolerance.
+func near2(t *testing.T, got gmath.Point2, x, y float64) {
+	t.Helper()
+	if !got.IsEqualTo(gmath.P2(gmath.Scalar(x), gmath.Scalar(y)), 1e-9) {
+		t.Errorf("point = %v, want (%v,%v)", got, x, y)
+	}
+}
+
+func TestSketchMoveTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(1, 0))
+	tool := NewSketchMoveTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{})
+	tool.SetVector(5, 0)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if s.ActiveTool() != nil {
+		t.Fatal("move tool should deactivate after OK")
+	}
+	near2(t, l.A.Position(), 5, 0)
+	near2(t, l.B.Position(), 6, 0)
+}
+
+func TestSketchCopyTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(1, 0))
+	tool := NewSketchCopyTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{})
+	tool.SetVector(0, 3)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sk.Lines().Count() != 2 {
+		t.Fatalf("lines after copy = %d, want 2", sk.Lines().Count())
+	}
+	near2(t, l.A.Position(), 0, 0) // the original is untouched
+}
+
+func TestSketchRotateTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(gmath.P2(1, 0), gmath.P2(2, 0))
+	tool := NewSketchRotateTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{})
+	tool.SetCenter(0, 0)
+	tool.SetAngle(stdmath.Pi / 2)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	near2(t, l.A.Position(), 0, 1) // (1,0) rotated 90° about origin
+	near2(t, l.B.Position(), 0, 2)
+}
+
+func TestSketchScaleTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(gmath.P2(2, 0), 1)
+	tool := NewSketchScaleTool()
+	s.StartTool(tool)
+	tool.PickSnap(c, SnapResult{})
+	tool.SetCenter(0, 0)
+	tool.SetFactor(2)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	near2(t, c.Center.Position(), 4, 0)
+	if stdmath.Abs(float64(c.Radius)-2) > 1e-9 {
+		t.Errorf("radius = %v, want 2", c.Radius)
+	}
+}
+
+func TestSketchScaleToolRejectsNonPositive(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(gmath.P2(2, 0), 1)
+	tool := NewSketchScaleTool()
+	s.StartTool(tool)
+	tool.PickSnap(c, SnapResult{})
+	tool.SetFactor(0)
+	if err := s.OK(); err == nil {
+		t.Error("scale with factor 0 should error")
+	}
+}
+
+func TestSketchRectPatternTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(gmath.P2(0, 0), 0.5)
+	tool := NewSketchRectPatternTool()
+	s.StartTool(tool)
+	tool.PickSnap(c, SnapResult{})
+	tool.SetStep1(2, 0)
+	tool.SetCount1(3) // 3 columns, 1 row → 2 new copies
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sk.Circles().Count() != 3 {
+		t.Fatalf("circles after rect pattern = %d, want 3", sk.Circles().Count())
+	}
+}
+
+func TestSketchCircPatternTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(gmath.P2(2, 0), 0.5)
+	tool := NewSketchCircPatternTool()
+	s.StartTool(tool)
+	tool.PickSnap(c, SnapResult{})
+	tool.SetCenter(0, 0)
+	tool.SetCount(4)
+	tool.SetTotalAngle(2 * stdmath.Pi)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sk.Circles().Count() != 4 {
+		t.Fatalf("circles after circular pattern = %d, want 4", sk.Circles().Count())
+	}
+}
+
+func TestSketchStretchTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+	tool := NewSketchStretchTool()
+	s.StartTool(tool)
+	tool.PickSnap(l.B, SnapResult{}) // pick only the B endpoint
+	tool.SetVector(0, 3)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if s.ActiveTool() != nil {
+		t.Fatal("stretch tool should deactivate after OK")
+	}
+	near2(t, l.A.Position(), 0, 0) // A stays
+	near2(t, l.B.Position(), 4, 3) // B stretched up
+}
+
+// A pattern that would make only one instance is not ready to commit.
+func TestSketchRectPatternNeedsMoreThanOne(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(gmath.P2(0, 0), 0.5)
+	tool := NewSketchRectPatternTool()
+	s.StartTool(tool)
+	tool.PickSnap(c, SnapResult{})
+	tool.SetCount1(1)
+	tool.SetCount2(1)
+	if tool.CanCommit() {
+		t.Error("a 1×1 rectangular pattern should not be committable")
+	}
+}

--- a/app/sketch_trim_tools.go
+++ b/app/sketch_trim_tools.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// The Trim/Extend/Split tools are single-pick sketch-entity tools: the user clicks a
+// curve at a location, and the click's snap point (carried by PickSnap) is the pick the
+// underlying model edit needs — TrimLine/SplitLine cut at that point, ExtendLine extends
+// the nearer end. They commit on the pick (then deactivate) like the other modify tools.
+// The model behavior is tested headlessly here; the head only forwards picks.
+
+// curveEditPick captures the one entity+point pick the trim/extend/split tools share. It
+// satisfies SketchEntityTool (PickSnap) and the auto-commit-on-pick capability.
+type curveEditPick struct {
+	ent   sketch.Entity
+	point math.Point2
+	has   bool
+}
+
+// PickSnap records the picked entity and the snapped click location on it.
+func (c *curveEditPick) PickSnap(ent sketch.Entity, snap SnapResult) {
+	c.ent, c.point, c.has = ent, snap.Point, true
+}
+
+func (c *curveEditPick) CanCommit() bool        { return c.has }
+func (c *curveEditPick) AutoCommitOnPick() bool { return true }
+func (c *curveEditPick) reset()                 { c.ent, c.has = nil, false }
+
+// pickedLine resolves the pick to a line (the kinds trim/extend/split currently edit).
+func (c *curveEditPick) pickedLine() (*sketch.Line, error) {
+	if !c.has {
+		return nil, errors.New("no curve picked")
+	}
+	l, ok := c.ent.(*sketch.Line)
+	if !ok {
+		return nil, errors.New("pick must be a line")
+	}
+	return l, nil
+}
+
+// SketchTrimTool removes the picked segment of a line up to its nearest crossings with
+// other sketch geometry (lines, circles, arcs).
+type SketchTrimTool struct{ curveEditPick }
+
+// NewSketchTrimTool makes a trim tool.
+func NewSketchTrimTool() *SketchTrimTool { return &SketchTrimTool{} }
+
+func (t *SketchTrimTool) Name() string              { return "Trim" }
+func (t *SketchTrimTool) Start(*Session)            {}
+func (t *SketchTrimTool) Pick(*Session, Selectable) {}
+func (t *SketchTrimTool) Cancel(*Session)           { t.reset() }
+func (t *SketchTrimTool) Prompt(*Session) string    { return "Pick the curve segment to trim." }
+
+// Commit trims the picked curve (line, circle or arc) at the pick point.
+func (t *SketchTrimTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errors.New("trim: no active sketch")
+	}
+	if !t.has {
+		return errors.New("trim: no curve picked")
+	}
+	var err error
+	switch e := t.ent.(type) {
+	case *sketch.Line:
+		_, err = sk.TrimLine(e, t.point)
+	case *sketch.Circle:
+		_, err = sk.TrimCircle(e, t.point)
+	case *sketch.Arc:
+		_, err = sk.TrimArc(e, t.point)
+	default:
+		err = fmt.Errorf("trim: unsupported target %T", t.ent)
+	}
+	return err
+}
+
+// SketchExtendTool lengthens the picked line's nearer end to the next crossing of its
+// support with other sketch geometry.
+type SketchExtendTool struct{ curveEditPick }
+
+// NewSketchExtendTool makes an extend tool.
+func NewSketchExtendTool() *SketchExtendTool { return &SketchExtendTool{} }
+
+func (t *SketchExtendTool) Name() string              { return "Extend" }
+func (t *SketchExtendTool) Start(*Session)            {}
+func (t *SketchExtendTool) Pick(*Session, Selectable) {}
+func (t *SketchExtendTool) Cancel(*Session)           { t.reset() }
+func (t *SketchExtendTool) Prompt(*Session) string    { return "Pick near the line end to extend." }
+
+// Commit extends whichever end of the picked line is nearer the pick point.
+func (t *SketchExtendTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errors.New("extend: no active sketch")
+	}
+	l, err := t.pickedLine()
+	if err != nil {
+		return fmt.Errorf("extend: %w", err)
+	}
+	_, err = sk.ExtendLine(l, nearerToEndB(l, t.point))
+	return err
+}
+
+// SketchSplitTool splits the picked line into two at the pick point.
+type SketchSplitTool struct{ curveEditPick }
+
+// NewSketchSplitTool makes a split tool.
+func NewSketchSplitTool() *SketchSplitTool { return &SketchSplitTool{} }
+
+func (t *SketchSplitTool) Name() string              { return "Split" }
+func (t *SketchSplitTool) Start(*Session)            {}
+func (t *SketchSplitTool) Pick(*Session, Selectable) {}
+func (t *SketchSplitTool) Cancel(*Session)           { t.reset() }
+func (t *SketchSplitTool) Prompt(*Session) string    { return "Pick the point to split the curve." }
+
+// Commit splits the picked line at the pick point.
+func (t *SketchSplitTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errors.New("split: no active sketch")
+	}
+	l, err := t.pickedLine()
+	if err != nil {
+		return fmt.Errorf("split: %w", err)
+	}
+	_, err = sk.SplitLine(l, t.point)
+	return err
+}
+
+// nearerToEndB reports whether p is closer to the line's B end than its A end (so extend
+// lengthens the picked end).
+func nearerToEndB(l *sketch.Line, p math.Point2) bool {
+	return p.DistanceTo(l.B.Position()) <= p.DistanceTo(l.A.Position())
+}

--- a/app/sketch_trim_tools_test.go
+++ b/app/sketch_trim_tools_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// nearXY asserts a point's X within tolerance (the trim tools move endpoints along X here).
+func nearXY(t *testing.T, got, want float64) {
+	t.Helper()
+	if stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("X = %v, want %v", got, want)
+	}
+}
+
+// TestSketchTrimToolRemovesPickedSegment drives the Trim tool end-to-end: pick the middle
+// of a line between two crossings → the picked segment is removed.
+func TestSketchTrimToolRemovesPickedSegment(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(6, 0))
+	sk.Lines().AddByTwoPoints(math.P2(2, -1), math.P2(2, 1)) // crossing at x=2
+	sk.Lines().AddByTwoPoints(math.P2(4, -1), math.P2(4, 1)) // crossing at x=4
+
+	tool := NewSketchTrimTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{Kind: SnapOnCurve, Point: math.P2(3, 0)}) // pick the middle
+	s.autoCommitAfterPick()
+
+	if s.ActiveTool() != nil {
+		t.Fatal("trim tool should deactivate after the pick")
+	}
+	nearXY(t, float64(l.B.Position().X), 2) // reshaped original keeps [0,2]
+}
+
+// TestSketchTrimToolCutsAtCircleCrossing proves the tool benefits from the curve-aware
+// crossing engine: a line trimmed where a circle crosses it.
+func TestSketchTrimToolCutsAtCircleCrossing(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(math.P2(-3, 0), math.P2(3, 0))
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), 1) // crosses at (±1,0)
+
+	tool := NewSketchTrimTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{Kind: SnapOnCurve, Point: math.P2(0, 0)}) // pick inside the circle
+	s.autoCommitAfterPick()
+
+	if s.ActiveTool() != nil {
+		t.Fatal("trim tool should deactivate after the pick")
+	}
+	nearXY(t, float64(l.B.Position().X), -1) // kept stub is [-3,-1]
+}
+
+// TestSketchExtendToolLengthensNearerEnd: picking near the B end extends it to the next
+// crossing of the line's support.
+func TestSketchExtendToolLengthensNearerEnd(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(2, 0))
+	sk.Lines().AddByTwoPoints(math.P2(5, -1), math.P2(5, 1)) // support crossing at x=5
+
+	tool := NewSketchExtendTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{Kind: SnapOnCurve, Point: math.P2(2, 0)}) // near the B end
+	s.autoCommitAfterPick()
+
+	if s.ActiveTool() != nil {
+		t.Fatal("extend tool should deactivate after the pick")
+	}
+	nearXY(t, float64(l.B.Position().X), 5)
+}
+
+// TestSketchSplitToolSplitsAtPoint: the picked point splits the line into two.
+func TestSketchSplitToolSplitsAtPoint(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	before := sk.Lines().Count()
+
+	tool := NewSketchSplitTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{Kind: SnapOnCurve, Point: math.P2(2, 0)})
+	s.autoCommitAfterPick()
+
+	if s.ActiveTool() != nil {
+		t.Fatal("split tool should deactivate after the pick")
+	}
+	if sk.Lines().Count() != before+1 {
+		t.Fatalf("lines after split = %d, want %d", sk.Lines().Count(), before+1)
+	}
+	nearXY(t, float64(l.B.Position().X), 2) // first half ends at the split point
+}
+
+// TestSketchTrimToolTrimsCircleTarget: trimming a circle that two lines cross replaces it
+// with the complementary arc.
+func TestSketchTrimToolTrimsCircleTarget(t *testing.T) {
+	s, sk := sketchSession(t)
+	c := sk.Circles().AddByCenterRadius(math.P2(0, 0), 2)
+	sk.Lines().AddByTwoPoints(math.P2(0, -3), math.P2(0, 3)) // crosses at (0,±2)
+
+	tool := NewSketchTrimTool()
+	s.StartTool(tool)
+	tool.PickSnap(c, SnapResult{Kind: SnapOnCurve, Point: math.P2(2, 0)}) // pick the right half
+	s.autoCommitAfterPick()
+
+	if s.ActiveTool() != nil {
+		t.Fatal("trim tool should deactivate after the pick")
+	}
+	if sk.Circles().Count() != 0 || sk.Arcs().Count() != 1 {
+		t.Fatalf("after circle trim: circles=%d arcs=%d, want 0 and 1", sk.Circles().Count(), sk.Arcs().Count())
+	}
+}
+
+// TestSketchTrimToolRejectsNonCurve: a point pick keeps the tool open with an error.
+func TestSketchTrimToolRejectsNonCurve(t *testing.T) {
+	s, sk := sketchSession(t)
+	p := sk.Points().Add(math.P2(0, 0))
+
+	tool := NewSketchTrimTool()
+	s.StartTool(tool)
+	tool.PickSnap(p, SnapResult{Kind: SnapPoint, Point: math.P2(0, 0)})
+	if err := tool.Commit(s); err == nil {
+		t.Error("trimming a point target should error")
+	}
+}
+
+func TestSketchTrimExtendSplitCommandsRegistered(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	for _, id := range []string{"Sketch.Trim", "Sketch.Extend", "Sketch.Split"} {
+		if _, ok := s.Commands().ByID(id); !ok {
+			t.Errorf("command %q not registered", id)
+		}
+	}
+}

--- a/app/sketch_variant_tools.go
+++ b/app/sketch_variant_tools.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// The variant geometry tools — the entries of the Sketch tab's split-button dropdowns
+// (Inventor's variant flyouts). Each is a sibling of a Create-panel head tool that draws
+// the same kind of geometry a different way: Rectangle (Three Point, Two Point Center),
+// Circle (Three Point), Arc (Center Point), Slot (Center Point Arc, Three Point Arc),
+// Spline (Control Vertex). They reuse the model/sketch composite builders, which already
+// produce the underlying lines/arcs; these are the interaction shells, tested via the
+// app's headless click path like their heads.
+
+// ThreePointRectangleTool draws a rectangle from three corners: a base edge (first two
+// clicks) then the perpendicular extent (third click), so it is not axis-aligned.
+type ThreePointRectangleTool struct{ collectClicks }
+
+// NewThreePointRectangleTool returns a three-point rectangle tool.
+func NewThreePointRectangleTool() *ThreePointRectangleTool { return &ThreePointRectangleTool{} }
+
+func (t *ThreePointRectangleTool) Name() string              { return "Three Point Rectangle" }
+func (t *ThreePointRectangleTool) Start(*Session)            {}
+func (t *ThreePointRectangleTool) Pick(*Session, Selectable) {}
+func (t *ThreePointRectangleTool) Cancel(*Session)           { t.reset() }
+func (t *ThreePointRectangleTool) CanCommit() bool           { return len(t.pts) == 3 }
+func (t *ThreePointRectangleTool) AutoCommits() bool         { return true }
+
+// Commit adds the rectangle's four lines from the three clicked corners.
+func (t *ThreePointRectangleTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("three point rectangle")
+	}
+	_, err := sk.AddRectangleByThreePoints(t.pts[0], t.pts[1], t.pts[2])
+	return err
+}
+
+// Prompt guides the base edge then the width (Inventor's status-bar prompts).
+func (t *ThreePointRectangleTool) Prompt(*Session) string {
+	switch len(t.pts) {
+	case 0:
+		return "Click the first corner of the rectangle"
+	case 1:
+		return "Click the end of the first edge"
+	case 2:
+		return "Click to set the rectangle width"
+	default:
+		return "Click OK to create the rectangle"
+	}
+}
+
+// CenterRectangleTool draws an axis-aligned rectangle from its center and a corner, so the
+// center stays put as the rectangle grows (Inventor's Two Point Center Rectangle).
+type CenterRectangleTool struct{ collectClicks }
+
+// NewCenterRectangleTool returns a center rectangle tool.
+func NewCenterRectangleTool() *CenterRectangleTool { return &CenterRectangleTool{} }
+
+func (t *CenterRectangleTool) Name() string              { return "Two Point Center Rectangle" }
+func (t *CenterRectangleTool) Start(*Session)            {}
+func (t *CenterRectangleTool) Pick(*Session, Selectable) {}
+func (t *CenterRectangleTool) Cancel(*Session)           { t.reset() }
+func (t *CenterRectangleTool) CanCommit() bool           { return len(t.pts) == 2 }
+func (t *CenterRectangleTool) AutoCommits() bool         { return true }
+
+// Commit adds the rectangle's four lines centered on the first click.
+func (t *CenterRectangleTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("center rectangle")
+	}
+	sk.AddRectangleByCenter(t.pts[0], t.pts[1])
+	return nil
+}
+
+// Prompt guides the center then a corner.
+func (t *CenterRectangleTool) Prompt(*Session) string {
+	if len(t.pts) == 0 {
+		return "Click the center of the rectangle"
+	}
+	return "Click a corner of the rectangle"
+}
+
+// ThreePointCircleTool draws the circle passing through three clicked points (Inventor's
+// Three Point Circle), the dual of the center-radius head tool.
+type ThreePointCircleTool struct{ collectClicks }
+
+// NewThreePointCircleTool returns a three-point circle tool.
+func NewThreePointCircleTool() *ThreePointCircleTool { return &ThreePointCircleTool{} }
+
+func (t *ThreePointCircleTool) Name() string              { return "Three Point Circle" }
+func (t *ThreePointCircleTool) Start(*Session)            {}
+func (t *ThreePointCircleTool) Pick(*Session, Selectable) {}
+func (t *ThreePointCircleTool) Cancel(*Session)           { t.reset() }
+func (t *ThreePointCircleTool) CanCommit() bool           { return len(t.pts) == 3 }
+func (t *ThreePointCircleTool) AutoCommits() bool         { return true }
+
+// Commit fits and adds the circle through the three clicked points.
+func (t *ThreePointCircleTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("three point circle")
+	}
+	_, err := sk.Circles().AddByThreePoints(t.pts[0], t.pts[1], t.pts[2])
+	return err
+}
+
+// Prompt guides the three points the circle passes through.
+func (t *ThreePointCircleTool) Prompt(*Session) string {
+	switch len(t.pts) {
+	case 0:
+		return "Click the first point on the circle"
+	case 1:
+		return "Click the second point on the circle"
+	case 2:
+		return "Click the third point on the circle"
+	default:
+		return "Click OK to create the circle"
+	}
+}
+
+// CenterPointArcTool draws an arc from its center, a start point (sets the radius) and an
+// end point (sets the sweep), the dual of the three-point head arc tool.
+type CenterPointArcTool struct{ collectClicks }
+
+// NewCenterPointArcTool returns a center-point arc tool.
+func NewCenterPointArcTool() *CenterPointArcTool { return &CenterPointArcTool{} }
+
+func (t *CenterPointArcTool) Name() string              { return "Center Point Arc" }
+func (t *CenterPointArcTool) Start(*Session)            {}
+func (t *CenterPointArcTool) Pick(*Session, Selectable) {}
+func (t *CenterPointArcTool) Cancel(*Session)           { t.reset() }
+func (t *CenterPointArcTool) CanCommit() bool           { return len(t.pts) == 3 }
+func (t *CenterPointArcTool) AutoCommits() bool         { return true }
+
+// Commit adds the arc; it sweeps counter-clockwise when the end lies CCW of the start
+// about the center (the cross product of the two radii is positive).
+func (t *CenterPointArcTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("center point arc")
+	}
+	center, start, end := t.pts[0], t.pts[1], t.pts[2]
+	sk.Arcs().AddByCenterStartEnd(center, start, end, leftTurn(center, start, end))
+	return nil
+}
+
+// Prompt guides the center, start and end of the arc.
+func (t *CenterPointArcTool) Prompt(*Session) string {
+	switch len(t.pts) {
+	case 0:
+		return "Click the arc center"
+	case 1:
+		return "Click the arc start point"
+	case 2:
+		return "Click the arc end point"
+	default:
+		return "Click OK to create the arc"
+	}
+}
+
+// ControlVertexSplineTool draws a B-spline from its control polygon (the clicked points are
+// control vertices, not points the curve passes through), the dual of the interpolation
+// head spline tool. OK finishes the curve.
+type ControlVertexSplineTool struct{ collectClicks }
+
+// NewControlVertexSplineTool returns a control-vertex spline tool.
+func NewControlVertexSplineTool() *ControlVertexSplineTool { return &ControlVertexSplineTool{} }
+
+func (t *ControlVertexSplineTool) Name() string              { return "Control Vertex Spline" }
+func (t *ControlVertexSplineTool) Start(*Session)            {}
+func (t *ControlVertexSplineTool) Pick(*Session, Selectable) {}
+func (t *ControlVertexSplineTool) Cancel(*Session)           { t.reset() }
+func (t *ControlVertexSplineTool) CanCommit() bool           { return len(t.pts) >= 2 }
+
+// Commit adds the spline from the clicked control polygon.
+func (t *ControlVertexSplineTool) Commit(s *Session) error {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return errNoSketch("control vertex spline")
+	}
+	sk.Splines().AddByControlPoints(append([]math.Point2(nil), t.pts...), false)
+	return nil
+}
+
+// Prompt guides successive control vertices.
+func (t *ControlVertexSplineTool) Prompt(*Session) string {
+	if len(t.pts) < 2 {
+		return "Click control vertices for the spline"
+	}
+	return "Click more vertices, or OK to finish"
+}
+
+// Compile-time checks that the variant tools satisfy the interactive-tool contracts the
+// session drives them through (the fixed-arity ones auto-commit; the spline finishes on OK).
+var (
+	_ Tool           = (*ThreePointRectangleTool)(nil)
+	_ PlaneClickTool = (*ThreePointRectangleTool)(nil)
+	_ AutoCommitTool = (*ThreePointRectangleTool)(nil)
+	_ Tool           = (*ControlVertexSplineTool)(nil)
+	_ PlaneClickTool = (*ControlVertexSplineTool)(nil)
+)

--- a/app/sketch_variant_tools_test.go
+++ b/app/sketch_variant_tools_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// Three Point Rectangle: a base edge then a width, producing four lines (non-axis-aligned).
+func TestThreePointRectangleTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewThreePointRectangleTool())
+	s.Click(60, 100)  // first corner
+	s.Click(140, 100) // end of the base edge
+	s.Click(140, 140) // width — auto-commits on the third click
+	if s.ActiveTool() != nil {
+		t.Fatal("three-point rectangle should deactivate after three clicks")
+	}
+	if sk.Lines().Count() != 4 {
+		t.Fatalf("three-point rectangle made %d lines, want 4", sk.Lines().Count())
+	}
+}
+
+// Two Point Center Rectangle: a center then a corner, producing four lines.
+func TestCenterRectangleTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewCenterRectangleTool())
+	s.Click(100, 100) // center
+	s.Click(140, 140) // corner — auto-commits on the second click
+	if s.ActiveTool() != nil {
+		t.Fatal("center rectangle should deactivate after two clicks")
+	}
+	if sk.Lines().Count() != 4 {
+		t.Fatalf("center rectangle made %d lines, want 4", sk.Lines().Count())
+	}
+}
+
+// Three Point Circle: the circle through three clicked points.
+func TestThreePointCircleTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewThreePointCircleTool())
+	s.Click(60, 100)
+	s.Click(140, 100)
+	s.Click(100, 60) // auto-commits on the third click
+	if sk.Circles().Count() != 1 {
+		t.Fatalf("three-point circle added %d circles, want 1", sk.Circles().Count())
+	}
+	if r := sk.Circles().Item(0).Radius; r <= 0 {
+		t.Errorf("circle radius = %v, want > 0", r)
+	}
+}
+
+// Three Point Circle rejects three collinear points (no circumcircle).
+func TestThreePointCircleToolRejectsCollinear(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewThreePointCircleTool())
+	s.Click(40, 100)
+	s.Click(100, 100)
+	s.Click(160, 100)
+	if err := s.OK(); err == nil {
+		t.Error("collinear three-point circle should fail to commit")
+	}
+	if sk.Circles().Count() != 0 {
+		t.Errorf("collinear circle added %d circles, want 0", sk.Circles().Count())
+	}
+}
+
+// Center Point Arc: center, start, end produces one arc.
+func TestCenterPointArcTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewCenterPointArcTool())
+	s.Click(100, 100) // center
+	s.Click(140, 100) // start
+	s.Click(100, 140) // end — auto-commits on the third click
+	if sk.Arcs().Count() != 1 {
+		t.Fatalf("center-point arc added %d arcs, want 1", sk.Arcs().Count())
+	}
+}
+
+// Center Point Arc Slot: center, start, end produces the slot's lines and arc caps.
+func TestCenterPointArcSlotTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewCenterPointArcSlotTool(1))
+	s.Click(100, 100)
+	s.Click(140, 100)
+	s.Click(100, 140) // auto-commits on the third click
+	if s.ActiveTool() != nil {
+		t.Fatal("center-point arc slot should deactivate after three clicks")
+	}
+	if sk.Arcs().Count() < 2 {
+		t.Fatalf("arc slot made %d arcs, want >=2 (the two caps plus the slot arcs)", sk.Arcs().Count())
+	}
+}
+
+// Three Point Arc Slot: start, a point on the arc, end produces the slot.
+func TestThreePointArcSlotTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewThreePointArcSlotTool(1))
+	s.Click(60, 100)
+	s.Click(100, 60)
+	s.Click(140, 100) // auto-commits on the third click
+	if sk.Arcs().Count() < 2 {
+		t.Fatalf("three-point arc slot made %d arcs, want >=2", sk.Arcs().Count())
+	}
+}
+
+// Three Point Arc Slot rejects three collinear centre points.
+func TestThreePointArcSlotToolRejectsCollinear(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewThreePointArcSlotTool(1))
+	s.Click(40, 100)
+	s.Click(100, 100)
+	s.Click(160, 100)
+	if err := s.OK(); err == nil {
+		t.Error("collinear three-point arc slot should fail to commit")
+	}
+	if sk.Arcs().Count() != 0 {
+		t.Errorf("collinear arc slot added %d arcs, want 0", sk.Arcs().Count())
+	}
+}
+
+// Control Vertex Spline: the clicked points are control vertices; OK finishes the curve.
+func TestControlVertexSplineTool(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.StartTool(NewControlVertexSplineTool())
+	s.Click(60, 100)
+	s.Click(100, 120)
+	s.Click(140, 100)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sk.Splines().Count() != 1 {
+		t.Fatalf("control-vertex spline added %d splines, want 1", sk.Splines().Count())
+	}
+}

--- a/app/split_session.go
+++ b/app/split_session.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Split tool's property window (mirrors the other feature bridges).
+
+// ActiveSplit returns the running Split tool, or nil when the active tool is not a split.
+func (s *Session) ActiveSplit() *SplitTool {
+	if s.tool == nil {
+		return nil
+	}
+	t, _ := s.tool.tool.(*SplitTool)
+	return t
+}

--- a/app/split_tool.go
+++ b/app/split_tool.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// SplitTool is the interactive Split command: pick a work plane to cut with, choose whether to
+// split the part into two bodies (the default) or trim away one side, then OK to divide the
+// active part. The cutting plane may be pre-selected in the browser/3D view before invoking.
+type SplitTool struct {
+	plane *feature.WorkPlane
+	keep  feature.SplitSide
+	added *feature.PartFeature
+}
+
+// NewSplitTool returns a split tool defaulting to a full split into two bodies.
+func NewSplitTool() *SplitTool { return &SplitTool{keep: feature.SplitBoth} }
+
+// Name implements [Tool].
+func (t *SplitTool) Name() string { return "Split" }
+
+// Start adopts a pre-selected work plane and filters selection to work planes.
+func (t *SplitTool) Start(s *Session) {
+	if wp := s.SelectedWorkPlane(); wp != nil {
+		t.plane = wp
+	}
+	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+}
+
+// Pick captures the work plane the user clicked.
+func (t *SplitTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(WorkPlaneHandle); ok {
+		t.plane = h.Plane
+	}
+}
+
+// SetKeep/Keep drive which side(s) the split keeps (both = split, one side = trim).
+func (t *SplitTool) SetKeep(k feature.SplitSide) { t.keep = k }
+func (t *SplitTool) Keep() feature.SplitSide     { return t.keep }
+
+// Keep convenience setters + label, so the head can drive the choice without importing the
+// model's enum.
+func (t *SplitTool) SetKeepBoth()     { t.keep = feature.SplitBoth }
+func (t *SplitTool) SetKeepPositive() { t.keep = feature.SplitPositive }
+func (t *SplitTool) SetKeepNegative() { t.keep = feature.SplitNegative }
+func (t *SplitTool) KeepLabel() string {
+	switch t.keep {
+	case feature.SplitPositive:
+		return "Trim (keep front side)"
+	case feature.SplitNegative:
+		return "Trim (keep back side)"
+	default:
+		return "Split into two bodies"
+	}
+}
+
+// PickedPlane returns the cutting plane (and true), or false when none picked yet.
+func (t *SplitTool) PickedPlane() (*feature.WorkPlane, bool) { return t.plane, t.plane != nil }
+
+// CanCommit reports whether a cutting plane has been picked.
+func (t *SplitTool) CanCommit() bool { return t.plane != nil }
+
+// Commit splits the active part by the plane and recomputes; a sick feature keeps the tool open.
+func (t *SplitTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewModifyFeatures(part.Features()).AddSplitSolid(t.plane, t.keep)
+	part.Recompute()
+	s.recordEdit(part, "Split")
+	if !t.added.Health().OK() {
+		return errors.New("split: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *SplitTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *SplitTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/split_tool_test.go
+++ b/app/split_tool_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// partWithMidPlane builds a side×side×2 block and a work plane at z=1 cutting through it.
+func partWithMidPlane(t *testing.T, side float64) (*Session, *compdef.PartComponentDefinition, *feature.WorkPlane) {
+	t.Helper()
+	s, _ := newPartWithBlock(t, side) // block on XY, z 0..2
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 1 })
+	def.Recompute()
+	return s, def, wp
+}
+
+// TestSplitToolEndToEnd drives the Split UI: pick a cutting work plane, OK — and asserts the
+// part divided into two valid solids.
+func TestSplitToolEndToEnd(t *testing.T) {
+	s, def, wp := partWithMidPlane(t, 6)
+
+	split := NewSplitTool()
+	s.StartTool(split)
+	split.Pick(s, WorkPlaneHandle{Plane: wp})
+	if !split.CanCommit() {
+		t.Fatal("split tool not ready after picking a plane")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 2 {
+		t.Fatalf("after split: %d bodies, want 2", def.SurfaceBodies().Count())
+	}
+	for i := 0; i < def.SurfaceBodies().Count(); i++ {
+		b := def.SurfaceBodies().Item(i)
+		if r := ops.Validate(b); !r.Valid || !b.IsSolid() {
+			t.Fatalf("split piece %d not a valid solid: %+v", i, r)
+		}
+	}
+}
+
+// Trim mode (keep one side) leaves a single body.
+func TestSplitToolTrimsOneSide(t *testing.T) {
+	s, def, wp := partWithMidPlane(t, 6)
+
+	split := NewSplitTool()
+	s.StartTool(split)
+	split.Pick(s, WorkPlaneHandle{Plane: wp})
+	split.SetKeepNegative()
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Errorf("after trim: %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+}
+
+func TestSplitNeedsPlane(t *testing.T) {
+	s, _, _ := partWithMidPlane(t, 4)
+	split := NewSplitTool()
+	s.StartTool(split)
+	if split.CanCommit() {
+		t.Error("split committable with no plane picked")
+	}
+}
+
+func TestSplitViaRibbonCommand(t *testing.T) {
+	s, _, _ := partWithMidPlane(t, 4)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.Split"); err != nil {
+		t.Fatalf("execute Modify.Split: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*SplitTool); !ok {
+		t.Fatal("Split command did not start the split tool")
+	}
+}

--- a/app/stitch_tool.go
+++ b/app/stitch_tool.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// StitchTool is the interactive Stitch command (Surface panel): weld the running surface bodies
+// into one quilt, promoting a closed quilt to a solid unless "keep as surface" is set. It takes
+// no pick (it operates on all surfaces); the property dialog drives the tolerance and that flag.
+type StitchTool struct {
+	tolerance   float64
+	keepSurface bool
+	added       *feature.PartFeature
+}
+
+// NewStitchTool returns a stitch tool defaulting to an exact (zero-tolerance) weld.
+func NewStitchTool() *StitchTool { return &StitchTool{} }
+
+// Name implements [Tool].
+func (t *StitchTool) Name() string { return "Stitch" }
+
+// Start has nothing to select — stitch welds every running surface body.
+func (t *StitchTool) Start(*Session) {}
+
+// Pick is unused.
+func (t *StitchTool) Pick(*Session, Selectable) {}
+
+// The options the dialog drives: weld tolerance and whether to keep a closed quilt as a surface.
+func (t *StitchTool) SetTolerance(v float64) { t.tolerance = v }
+func (t *StitchTool) Tolerance() float64     { return t.tolerance }
+func (t *StitchTool) SetKeepSurface(v bool)  { t.keepSurface = v }
+func (t *StitchTool) KeepSurface() bool      { return t.keepSurface }
+
+// Params exposes the tolerance and keep-as-surface flag for the generic property dialog.
+func (t *StitchTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{{Label: "Tolerance", Get: t.Tolerance, Set: t.SetTolerance}},
+		Bools:  []BoolParam{{Label: "Keep as surface", Get: t.KeepSurface, Set: t.SetKeepSurface}},
+	}
+}
+
+// CanCommit is always true — stitch acts on whatever surfaces are present (Commit validates).
+func (t *StitchTool) CanCommit() bool { return true }
+
+// Commit welds the running surface bodies and recomputes; a failed weld keeps the tool open.
+func (t *StitchTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewStitchFeatures(part.Features()).Add(t.tolerance, t.keepSurface)
+	part.Recompute()
+	s.recordEdit(part, "Stitch")
+	if !t.added.Health().OK() {
+		return errors.New("stitch: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// Cancel abandons the tool with no change.
+func (t *StitchTool) Cancel(*Session) {}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *StitchTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/stitch_tool_test.go
+++ b/app/stitch_tool_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// patchRect adds a boundary-patch surface over the rectangle [x0,x1]×[0,2] on XY.
+func patchRect(def *compdef.PartComponentDefinition, x0, x1 float64) {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	a := sk.Points().Add(math.P2(math.Scalar(x0), 0))
+	b := sk.Points().Add(math.P2(math.Scalar(x1), 0))
+	c := sk.Points().Add(math.P2(math.Scalar(x1), 2))
+	d := sk.Points().Add(math.P2(math.Scalar(x0), 2))
+	sk.Lines().Add(a, b)
+	sk.Lines().Add(b, c)
+	sk.Lines().Add(c, d)
+	sk.Lines().Add(d, a)
+	feature.NewBoundaryPatchFeatures(def.Features()).Add(sk, 0, feature.PatchFree)
+}
+
+// twoAdjacentPatches gives a part with two coplanar patches sharing the x=2 edge.
+func twoAdjacentPatches(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	patchRect(def, 0, 2)
+	patchRect(def, 2, 4)
+	def.Recompute()
+	if def.SurfaceBodies().Count() != 2 {
+		t.Fatalf("setup: %d surface bodies, want 2", def.SurfaceBodies().Count())
+	}
+	return s, def
+}
+
+// TestStitchToolEndToEnd drives the Stitch UI: with two adjacent patches present, OK welds them
+// into one surface quilt (two faces, shared edge no longer a boundary).
+func TestStitchToolEndToEnd(t *testing.T) {
+	s, def := twoAdjacentPatches(t)
+
+	s.StartTool(NewStitchTool())
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("after stitch: %d bodies, want 1 (one quilt)", def.SurfaceBodies().Count())
+	}
+	if n := len(def.SurfaceBodies().Item(0).Faces()); n != 2 {
+		t.Errorf("stitched quilt has %d faces, want 2", n)
+	}
+}
+
+func TestStitchViaRibbonCommand(t *testing.T) {
+	s, _ := twoAdjacentPatches(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.Stitch"); err != nil {
+		t.Fatalf("execute Surface.Stitch: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*StitchTool); !ok {
+		t.Fatal("Stitch command did not start the stitch tool")
+	}
+}

--- a/app/surface_trim_tool.go
+++ b/app/surface_trim_tool.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"github.com/Oblikovati/oblikovati/model/feature"
+)
+
+// SurfaceTrimTool is the interactive Trim command (Surface panel): pick a work plane to cut the
+// running surface body with and keep one side. The cutting plane may be pre-selected before
+// invoking. It exposes "keep positive side" through ParameterizedTool for the generic dialog.
+type SurfaceTrimTool struct {
+	plane        *feature.WorkPlane
+	keepPositive bool
+	added        *feature.PartFeature
+}
+
+// NewSurfaceTrimTool returns a trim tool defaulting to keeping the +normal side.
+func NewSurfaceTrimTool() *SurfaceTrimTool { return &SurfaceTrimTool{keepPositive: true} }
+
+// Name implements [Tool].
+func (t *SurfaceTrimTool) Name() string { return "Trim" }
+
+// Start adopts a pre-selected work plane and filters selection to work planes.
+func (t *SurfaceTrimTool) Start(s *Session) {
+	if wp := s.SelectedWorkPlane(); wp != nil {
+		t.plane = wp
+	}
+	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+}
+
+// Pick captures the cutting work plane.
+func (t *SurfaceTrimTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(WorkPlaneHandle); ok {
+		t.plane = h.Plane
+	}
+}
+
+// SetKeepPositive/KeepPositive choose which side of the plane survives.
+func (t *SurfaceTrimTool) SetKeepPositive(v bool) { t.keepPositive = v }
+func (t *SurfaceTrimTool) KeepPositive() bool     { return t.keepPositive }
+
+// Params exposes the keep-side flag for the generic property dialog.
+func (t *SurfaceTrimTool) Params() ToolParams {
+	return ToolParams{Bools: []BoolParam{{Label: "Keep positive side", Get: t.KeepPositive, Set: t.SetKeepPositive}}}
+}
+
+// PickedPlane returns the cutting plane (and true), or false when none picked yet.
+func (t *SurfaceTrimTool) PickedPlane() (*feature.WorkPlane, bool) { return t.plane, t.plane != nil }
+
+// CanCommit reports whether a cutting plane has been picked.
+func (t *SurfaceTrimTool) CanCommit() bool { return t.plane != nil }
+
+// Commit trims the running surface body by the plane and recomputes.
+func (t *SurfaceTrimTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	sp := t.plane.Plane()
+	t.added = feature.NewTrimFeatures(part.Features()).AddByPlane(sp.Origin(), sp.Normal().AsVector(), t.keepPositive)
+	part.Recompute()
+	s.recordEdit(part, "Trim")
+	if !t.added.Health().OK() {
+		return errors.New("trim: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *SurfaceTrimTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *SurfaceTrimTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/surface_trim_tool_test.go
+++ b/app/surface_trim_tool_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/feature"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// patchedPartWithCutPlane gives a part holding a 4×4 surface patch (on XY) and a work plane at
+// x=2 (YZ offset 2, normal +X) to trim it with.
+func patchedPartWithCutPlane(t *testing.T) (*Session, *compdef.PartComponentDefinition, *feature.WorkPlane) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(4, 0))
+	c2 := sk.Points().Add(math.P2(4, 4))
+	c3 := sk.Points().Add(math.P2(0, 4))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewBoundaryPatchFeatures(def.Features()).Add(sk, 0, feature.PatchFree)
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginYZPlane, func() float64 { return 2 })
+	def.Recompute()
+	return s, def, wp
+}
+
+// TestSurfaceTrimToolEndToEnd drives the Trim UI: pick the x=2 plane, keep the +X side, OK — and
+// asserts the patch is trimmed to x∈[2,4].
+func TestSurfaceTrimToolEndToEnd(t *testing.T) {
+	s, def, wp := patchedPartWithCutPlane(t)
+
+	trim := NewSurfaceTrimTool()
+	s.StartTool(trim)
+	trim.Pick(s, WorkPlaneHandle{Plane: wp})
+	if !trim.CanCommit() {
+		t.Fatal("trim tool not ready after picking a plane")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	box := def.SurfaceBodies().Item(0).RangeBox()
+	if stdmath.Abs(float64(box.Min.X)-2) > 1e-6 || stdmath.Abs(float64(box.Max.X)-4) > 1e-6 {
+		t.Errorf("trimmed x-span = [%v,%v], want [2,4]", box.Min.X, box.Max.X)
+	}
+}
+
+func TestSurfaceTrimViaRibbonCommand(t *testing.T) {
+	s, _, _ := patchedPartWithCutPlane(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.Trim"); err != nil {
+		t.Fatalf("execute Surface.Trim: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*SurfaceTrimTool); !ok {
+		t.Fatal("Trim command did not start the surface trim tool")
+	}
+}

--- a/app/tool_highlight_contract_test.go
+++ b/app/tool_highlight_contract_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// The head highlights every tool's picks uniformly (head/ui/tool_highlight.go: toolPicks) by
+// looking for one of these pick-accessor interfaces. A tool that picks B-rep geometry in the
+// viewport (a face, edge or sketch region) but exposes none of them would get no highlight — an
+// inconsistency. This test pins the contract: keep it green by giving any new view-picking tool
+// the matching accessor (Edges/Faces/PickedProfiles/PickedProfile/PickedFace).
+
+type edgesAccessor interface{ Edges() []EdgeHandle }
+type facesAccessor interface{ Faces() []FaceHandle }
+type profilesAccessor interface{ PickedProfiles() []ProfileHandle }
+type profileAccessor interface{ PickedProfile() (ProfileHandle, bool) }
+type faceAccessor interface{ PickedFace() (FaceHandle, bool) }
+
+// exposesPickAccessor mirrors the head's toolPicks: does the tool expose any pick accessor the
+// unified highlight can read?
+func exposesPickAccessor(t Tool) bool {
+	switch t.(type) {
+	case edgesAccessor, facesAccessor, profilesAccessor, profileAccessor, faceAccessor:
+		return true
+	default:
+		return false
+	}
+}
+
+// viewGeometryPickers are the tools that pick a B-rep face/edge or a sketch region in the
+// viewport (filters SelectFace/SelectEdge/SelectProfile). Body- and plane-picking tools are
+// excluded: bodies are highlighted by the per-body recolor and planes by the plane overlay.
+func viewGeometryPickers() []Tool {
+	return []Tool{
+		NewExtrudeTool(), NewRevolveTool(), NewSweepTool(), NewCoilTool(), NewLoftTool(),
+		NewEmbossTool(), NewPatchTool(), NewDecalTool(),
+		NewChamferTool(), NewFilletTool(), NewExtendTool(), NewHoleTool(),
+		NewShellTool(), NewDraftTool(), NewFaceOffsetTool(), NewReplaceFaceTool(),
+		NewDeleteFaceTool(), NewMoveFaceTool(),
+	}
+}
+
+func TestViewPickingToolsExposeHighlightAccessor(t *testing.T) {
+	for _, tool := range viewGeometryPickers() {
+		if !exposesPickAccessor(tool) {
+			t.Errorf("tool %q picks viewport geometry but exposes no highlight accessor "+
+				"(want one of Edges/Faces/PickedProfiles/PickedProfile/PickedFace)", tool.Name())
+		}
+	}
+}

--- a/app/tool_params.go
+++ b/app/tool_params.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "github.com/Oblikovati/oblikovati/math"
+
+// Tool parameter descriptors: a Tool may expose a set of editable parameters (a label +
+// a bound get/set per value) so the head can render ONE generic property dialog for any
+// tool instead of a bespoke cgo dialog per tool (core/09 reflection-driven editing). The
+// descriptors are pure data with closures over the tool's fields, so the wiring is tested
+// headlessly here and the head only renders the fields.
+
+// FloatParam is an editable floating-point tool parameter (e.g. a distance or angle).
+type FloatParam struct {
+	Label string
+	Get   func() float64
+	Set   func(float64)
+}
+
+// IntParam is an editable integer tool parameter (e.g. a pattern count).
+type IntParam struct {
+	Label string
+	Get   func() int
+	Set   func(int)
+}
+
+// TextParam is an editable string tool parameter (e.g. the text-box string).
+type TextParam struct {
+	Label string
+	Get   func() string
+	Set   func(string)
+}
+
+// BoolParam is an editable boolean tool parameter (e.g. a helix's clockwise flag),
+// rendered as a checkbox.
+type BoolParam struct {
+	Label string
+	Get   func() bool
+	Set   func(bool)
+}
+
+// ToolParams is the set of editable parameters a tool exposes; the head renders each
+// non-empty group as a labelled input row.
+type ToolParams struct {
+	Floats []FloatParam
+	Ints   []IntParam
+	Texts  []TextParam
+	Bools  []BoolParam
+}
+
+// Empty reports whether the tool exposes no parameters (so the head shows no dialog).
+func (p ToolParams) Empty() bool {
+	return len(p.Floats) == 0 && len(p.Ints) == 0 && len(p.Texts) == 0 && len(p.Bools) == 0
+}
+
+// ParameterizedTool is a Tool that exposes editable parameters for the property dialog.
+// The head queries the active tool for this interface each frame and, when present,
+// renders the generic dialog bound to the tool's parameters.
+type ParameterizedTool interface {
+	Tool
+	Params() ToolParams
+}
+
+// degrees/radians conversion for angle parameters surfaced to the user in degrees.
+const radPerDeg = 0.017453292519943295
+
+func degFromRad(rad float64) float64 { return rad / radPerDeg }
+func radFromDeg(deg float64) float64 { return deg * radPerDeg }
+
+// xyParams binds a vector/point's X and Y as two float params with the given label prefix.
+func xyParams(prefix string, x, y *math.Scalar) []FloatParam {
+	return []FloatParam{
+		{prefix + " X", func() float64 { return float64(*x) }, func(v float64) { *x = math.Scalar(v) }},
+		{prefix + " Y", func() float64 { return float64(*y) }, func(v float64) { *y = math.Scalar(v) }},
+	}
+}
+
+// scalarParam binds a single math.Scalar field as a float param.
+func scalarParam(label string, p *math.Scalar) FloatParam {
+	return FloatParam{label, func() float64 { return float64(*p) }, func(v float64) { *p = math.Scalar(v) }}
+}

--- a/app/tool_params_test.go
+++ b/app/tool_params_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+func floatLabels(p ToolParams) []string {
+	out := make([]string, len(p.Floats))
+	for i, f := range p.Floats {
+		out[i] = f.Label
+	}
+	return out
+}
+
+func intLabels(p ToolParams) []string {
+	out := make([]string, len(p.Ints))
+	for i, v := range p.Ints {
+		out[i] = v.Label
+	}
+	return out
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Every parameterized sketch tool exposes the expected labelled fields for the generic
+// property dialog.
+func TestToolParamsLabels(t *testing.T) {
+	cases := []struct {
+		tool   ParameterizedTool
+		floats []string
+		ints   []string
+		texts  int
+	}{
+		{NewSketchMoveTool(), []string{"Δ X", "Δ Y"}, nil, 0},
+		{NewSketchCopyTool(), []string{"Δ X", "Δ Y"}, nil, 0},
+		{NewSketchStretchTool(), []string{"Δ X", "Δ Y"}, nil, 0},
+		{NewSketchRotateTool(), []string{"Center X", "Center Y", "Angle (deg)"}, nil, 0},
+		{NewSketchScaleTool(), []string{"Center X", "Center Y", "Factor"}, nil, 0},
+		{NewSketchRectPatternTool(), []string{"Step 1 X", "Step 1 Y", "Step 2 X", "Step 2 Y"}, []string{"Count 1", "Count 2"}, 0},
+		{NewSketchCircPatternTool(), []string{"Center X", "Center Y", "Angle (deg)"}, []string{"Count"}, 0},
+		{NewSketchSlotTool(1), []string{"Width"}, nil, 0},
+		{NewSketchChamferTool(0.5), []string{"Distance"}, nil, 0},
+		{NewSketchTextTool(), []string{"Height"}, nil, 1},
+		{NewSketchFilletTool(0.5), []string{"Radius"}, nil, 0},
+		{NewSketchOffsetTool(0.5), []string{"Distance"}, nil, 0},
+	}
+	for _, c := range cases {
+		p := c.tool.Params()
+		if !sameStrings(floatLabels(p), c.floats) {
+			t.Errorf("%s floats = %v, want %v", c.tool.Name(), floatLabels(p), c.floats)
+		}
+		if !sameStrings(intLabels(p), c.ints) {
+			t.Errorf("%s ints = %v, want %v", c.tool.Name(), intLabels(p), c.ints)
+		}
+		if len(p.Texts) != c.texts {
+			t.Errorf("%s texts = %d, want %d", c.tool.Name(), len(p.Texts), c.texts)
+		}
+	}
+}
+
+// Setting a float param (what the dialog does) drives the committed geometry — proving the
+// closures are bound to the tool's real fields.
+func TestToolParamFloatWiresThrough(t *testing.T) {
+	s, sk := sketchSession(t)
+	l := sk.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(1, 0))
+	tool := NewSketchMoveTool()
+	s.StartTool(tool)
+	tool.PickSnap(l, SnapResult{})
+	tool.Params().Floats[0].Set(5) // Δ X = 5 via the dialog binding
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	near2(t, l.A.Position(), 5, 0)
+}
+
+// An angle param is surfaced in degrees and converted to radians on the tool.
+func TestToolParamAngleInDegrees(t *testing.T) {
+	tool := NewSketchRotateTool()
+	for _, f := range tool.Params().Floats {
+		if f.Label == "Angle (deg)" {
+			f.Set(90)
+		}
+	}
+	// 90° == π/2 rad; read it back through the same binding.
+	var got float64
+	for _, f := range tool.Params().Floats {
+		if f.Label == "Angle (deg)" {
+			got = f.Get()
+		}
+	}
+	if got != 90 {
+		t.Errorf("angle round-trip = %v deg, want 90", got)
+	}
+}
+
+// A text param sets the tool's string.
+func TestToolParamTextWiresThrough(t *testing.T) {
+	s, sk := sketchSession(t)
+	tool := NewSketchTextTool()
+	s.StartTool(tool)
+	s.Click(100, 100)
+	tool.Params().Texts[0].Set("HI")
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sk.TextBoxes().Count() != 1 {
+		t.Fatalf("text boxes = %d, want 1", sk.TextBoxes().Count())
+	}
+}
+
+func boolLabels(p ToolParams) []string {
+	out := make([]string, len(p.Bools))
+	for i, b := range p.Bools {
+		out[i] = b.Label
+	}
+	return out
+}
+
+// The parameterized 3D-sketch tools expose their scalar/bool inputs to the generic dialog.
+func TestSketch3DToolParams(t *testing.T) {
+	if got := floatLabels(NewCircle3DTool().Params()); !sameStrings(got, []string{"Radius"}) {
+		t.Errorf("Circle3D floats = %v, want [Radius]", got)
+	}
+	hp := NewHelix3DTool().Params()
+	if !sameStrings(floatLabels(hp), []string{"Radius", "Pitch", "Turns"}) || !sameStrings(boolLabels(hp), []string{"Clockwise"}) {
+		t.Errorf("Helix3D params = %v / %v, want [Radius Pitch Turns] / [Clockwise]", floatLabels(hp), boolLabels(hp))
+	}
+	if got := boolLabels(NewArc3DTool().Params()); !sameStrings(got, []string{"Counter-clockwise"}) {
+		t.Errorf("Arc3D bools = %v, want [Counter-clockwise]", got)
+	}
+}
+
+// Setting a 3D tool's float and bool params via the dialog bindings mutates the tool.
+func TestSketch3DToolParamWiring(t *testing.T) {
+	h := NewHelix3DTool()
+	for _, f := range h.Params().Floats {
+		if f.Label == "Pitch" {
+			f.Set(2.5)
+		}
+	}
+	for _, b := range h.Params().Bools {
+		if b.Label == "Clockwise" {
+			b.Set(true)
+		}
+	}
+	var pitch float64
+	var cw bool
+	for _, f := range h.Params().Floats {
+		if f.Label == "Pitch" {
+			pitch = f.Get()
+		}
+	}
+	for _, b := range h.Params().Bools {
+		if b.Label == "Clockwise" {
+			cw = b.Get()
+		}
+	}
+	if pitch != 2.5 || !cw {
+		t.Errorf("after Set: pitch=%v clockwise=%v, want 2.5/true", pitch, cw)
+	}
+}
+
+// A tool with no parameters reports Empty so the head shows no dialog.
+func TestToolParamsEmpty(t *testing.T) {
+	if !(ToolParams{}).Empty() {
+		t.Error("zero ToolParams should be Empty")
+	}
+	if NewSketchMoveTool().Params().Empty() {
+		t.Error("Move tool should expose parameters")
+	}
+}

--- a/architecture/core/03-geometry-kernel.md
+++ b/architecture/core/03-geometry-kernel.md
@@ -63,6 +63,21 @@ near degeneracies. `math/predicate` provides these in pure Go (they are integer/
 expansion arithmetic — no cgo needed). `ops` uses them for all branching decisions
 (which side of a plane, do these intersect) so topology stays consistent.
 
+**Known gap — partial penetration (2026-06-05).** The planar B-rep boolean
+(`kernel/brep`, the four-stage imprint → split → classify → stitch pipeline) is correct for
+**clean through-overlaps** but not yet for **partial penetrations** or **concave faceted-wall
+crossings**. The 2D arrangement (`Arrange`/`traceCycles`) only subdivides a face when the imprint
+segments **close a loop on that face**; a tool that pokes part-way in, or crosses a re-entrant
+faceted wall, leaves **dangling/partial segments** (the loop would close only across a face
+boundary) which `traceCycles` drops — so the overlap is left un-cut and the result goes
+**non-manifold / inverted-normal**. This surfaced as a deformed mesh on lofted-blade unions. The
+real fix assembles imprint segments into closed loops across faces and handles T-vertices /
+dangling edges (PBI-199). A *precondition* — twisted swept/loft bodies emitting **warped
+non-planar quad** faces (which the boolean imprinted against an approximating plane) — is fixed
+by triangulating those quads in `model/feature/swept.go` (PBI-174). Note also: a post-hoc
+orientation repair does **not** fix the inverted normals; the cut, not the winding, is what's
+wrong.
+
 ## Concurrency
 
 The kernel is **pure functions over immutable inputs** (ADR-0007): `Extrude(profile,

--- a/architecture/core/09-ui-imgui.md
+++ b/architecture/core/09-ui-imgui.md
@@ -4,6 +4,11 @@
 (M05-F04). Implements ADR-0004. Borrows realtime-3d §10 (reflection-driven property
 editing) and §12 (one-window, no OS popups).*
 
+> **Ribbon layout is specified by [../mapping/inventor-ribbon-structure.md](../mapping/inventor-ribbon-structure.md)**
+> — the canonical tab→panel→button tree Oblikovati mirrors from Inventor. The ribbon is
+> *generated* from the command registry (below), but every command's tab/panel placement
+> must follow that document.
+
 ## Split of responsibilities
 
 - **ImGui owns the chrome**: ribbon/toolbars, browser tree, parameter table,

--- a/architecture/decisions/ADR-0027-curved-face-boolean.md
+++ b/architecture/decisions/ADR-0027-curved-face-boolean.md
@@ -1,0 +1,94 @@
+# ADR-0027 — Curved-face B-rep boolean (K1b)
+
+**Status:** accepted, in progress (slice 1 landed 2026-06-04)
+**Context:** REPORT.md §6 (G-09), DEFERRALS.md, PARTDOC-PLAN.md Phase 4.
+
+## Problem
+
+`kernel/brep` does an exact boolean only for **planar** faces (`facesOf` returns
+`ok=false` on any curved face; `ops.Boolean` then falls back to triangle-soup **BSP CSG**).
+Consequences:
+
+- A drilled **Hole** / **Boss** is a faceted 32-gon, not a clean cylinder face.
+- **Fillet** results and any curved boolean are tessellated soup: high face count, **not
+  exact under chaining**, and their faces carry no stable lineage (reference keys don't
+  survive — even K1a doesn't help, since K1a lives in the planar path).
+
+K1b makes analytic curved faces (cylinder, cone, sphere, torus) **first-class** in the
+exact B-rep boolean, so curved results are single faces with surviving reference keys and
+are exact under chaining.
+
+## Decision
+
+Generalize the planar boolean's pipeline rather than write a parallel one. The four stages
+stay (imprint → split → classify → stitch); each is lifted from "plane + 3D point loops" to
+"any analytic surface + curved trim loops":
+
+1. **Face model.** Replace `planarFace{plane, normal, loops}` with a face carrying its
+   `geom.Surface` + boundary loops as **`geom.Curve3`** edges (lines *and* circles/arcs),
+   keeping the source lineage (K1a threading already in place).
+2. **Imprint = exact surface∩surface curves.** Use **`geom.IntersectSurfacesAnalytic`**
+   (slice 1, done) for the analytic pairs it solves in closed form (plane∩plane → line,
+   plane∩cylinder ⟂ axis → circle, plane∩sphere → circle); fall back to the numeric tracer
+   `IntersectSurfaceSurface` (faceted) for the rest (oblique ellipse, cylinder∩cylinder,
+   torus). Exact curves are what keep a hole a single clean face.
+3. **Split in parameter space.** Map a face's boundary + imprint curves into the surface's
+   (u,v) domain via `Surface.ParamAt`, run the existing 2D arrangement there, lift sub-face
+   loops back to 3D. (Cylinders/cones unroll to a periodic u; spheres/tori are doubly
+   periodic — handle the seam.)
+4. **Classify + stitch.** Classification (inside/outside via ray cast; coplanar table) is
+   unchanged. Stitch welds curved edges (shared circle/arc per undirected vertex pair) and
+   emits faces carrying the source surface + lineage (reuse K1a's `faceLineage`).
+
+## Slicing (incremental, each shippable + tested)
+
+- **Slice 1 — exact analytic intersection curves.** `geom.IntersectSurfacesAnalytic`:
+  plane∩plane → line, plane∩cylinder → circle (⟂) / ellipse (oblique), plane∩sphere →
+  circle, plane∩cone → circle (⟂); line-pair / curved-curved pairs defer to the numeric
+  tracer. + tests. **DONE 2026-06-04.**
+- **Slice 2 — curved face model + edge representation** in `kernel/brep` (surface + curve3
+  loops); planar path keeps working through it. **DONE 2026-06-04:** `SolidCylinder` builds
+  the first analytic curved solid (true cylinder side face + closed-circle edges + periodic
+  seam); it validates (manifold, watertight) AND tessellates with correct area/volume.
+- **Slice 2b — periodic-face tessellation. DONE 2026-06-04.** The trimmed-face tessellator
+  (PBI-32) only handled partial (fillet) bands; a full 2π-periodic side fell back to the
+  surface's whole (unbounded) UV domain → wrong area/volume. Fixed with `ops.periodicBandGrid`:
+  a full-seam-wrap loop is gridded over the entire period (reusing the boundary's own circle-
+  edge samples, so it stays watertight with the caps) and the boundary's bounded range in the
+  other direction. Tested at the ops level (face area = 2π·r·h) and brep level (volume = π·r²·h).
+- **Slice 3 — plane∩cylinder boolean. DONE 2026-06-04.** `brep.CutCylindricalHole` drills a
+  clean through-hole in a planar slab: the two pierced faces gain a circular hole, a single
+  true cylinder face forms the wall, and the result is a watertight solid with the right
+  volume (slab − inscribed bore). Needed a new primitive — **face sense**: `topo.Face.Reversed`
+  + `Builder.AddReversedFace`, honored by `ops.TessellateFace` (negates normals + flips
+  winding). A cut wall's surface normal points into the removed material, so its face is
+  reversed; planar cuts fake this by building a flipped plane, but a cylinder can't be flipped,
+  so the sense flag is the general mechanism (the planar boolean can adopt it later). Copied
+  and pierced faces keep their source lineage, so **every original face's reference key survives
+  the curved cut** (extends K1a to curved booleans). Partial/blind holes still error (later
+  slices). Tested: validity/watertight/face-count, volume, key survival, oversize rejection.
+- **Slice 4 — sphere/cone**, then **cylinder∩cylinder** (numeric-curve imprint). Also
+  generalize beyond the through-hole specialization to the arrangement-based curved boolean.
+- **Slice 5 — curved edge/vertex key survival**; retire the BSP-CSG fallback for the
+  analytic cases; route Hole/Fillet through it. **Partly done 2026-06-04:** the **Hole
+  feature** routes a Through-All hole on a planar slab through `CutCylindricalHole` (true
+  cylinder wall, full DoD: model + Hole UI Through-All option + head checkbox + persistence +
+  e2e), **blind holes** through `CutBlindCylindricalHole` (cylinder wall + flat bottom disk),
+  and **counterbores** through `CutCounterboreHole` (recess wall + annular shoulder + bore wall,
+  built in one assembly — the exact cutters can't be chained because they need an all-planar
+  input), **countersinks** through `CutCountersinkHole` (a true CONE frustum recess sharing
+  a transition circle with the bore wall; the periodic-band tessellator handles the cone's
+  varying radius), and **conical drill points** through `CutBlindConicalHole` (cone tip closing
+  the bore; needed `ops.coneApexFan`, a fan to the cone's apex pole for a cone whose only
+  boundary is one rim circle). The **Hole feature now has full Inventor parity** (drilled
+  flat/point, through, blind, counterbore, countersink) with real curved geometry. Remaining for
+  K1b: the general (non-slab) curved arrangement boolean, curved edge/vertex key survival, Fillet.
+
+Until a slice lands, the affected case keeps using the BSP-CSG fallback (correct, just
+faceted) — no regression.
+
+## Consequences
+
+- Hole/Boss/Fillet become clean, low-face-count, chain-exact, with stable face keys.
+- Larger than K1a; spans several PBIs. The BSP-CSG fallback stays as the safety net for
+  unhandled pairs.

--- a/architecture/mapping/inventor-ribbon-structure.md
+++ b/architecture/mapping/inventor-ribbon-structure.md
@@ -1,0 +1,239 @@
+# Inventor Ribbon Structure — canonical reference
+
+**This is the source of truth for the ribbon layout** (tabs → panels → buttons) Oblikovati
+targets for parity. Every ribbon command's **tab** and **panel** placement (the `.WithTab`
++ panel arg in `app/commands_standard.go`) must match this tree. When adding or moving a
+command, place it in the panel named here — do not invent panels.
+
+Captured from Autodesk Inventor 2026.1 (Default). Internal names (`id_Tab…`) are Inventor's
+command-IDs, kept for traceability. Oblikovati uses the same tab/panel **names**; button
+availability is incremental (see PROGRESS.md), but placement must follow this structure.
+
+> See also: [core/09-ui-imgui.md](../core/09-ui-imgui.md) (how the ribbon is built from the
+> command registry) and the per-feature DoD in
+> [implementation-plan/CONVENTIONS.md](../../implementation-plan/CONVENTIONS.md).
+
+## Canonical structure
+
+```yaml
+autodesk_inventor_ribbon:
+  version: "2026.1-Default"
+  environments:
+
+    - name: "ZeroDoc Environment"
+      internal_name: "ZeroDoc"
+      description: "Ribbon layout active when no files are open (My Home / Startup state)"
+      tabs:
+        - name: "Get Started"
+          internal_name: "id_TabGetStarted"
+          panels:
+            - name: "Launch"
+              buttons: [New, Open, Projects, Configure Default Templates]
+            - name: "New File"
+              buttons: [Part, Assembly, Drawing, Presentation]
+            - name: "My Home"
+              buttons: [Home, Reset Layout]
+            - name: "Support"
+              buttons: [What's New, Help, Tutorials, Community, Guided Tutorials]
+
+        - name: "Tools"
+          internal_name: "id_TabTools"
+          panels:
+            - name: "Options"
+              buttons: [Application Options]
+            - name: "Customize"
+              buttons: [Customize User Commands]
+            - name: "iLogic"
+              buttons: [iLogic Browser, iLogic Event Triggers]
+
+    - name: "Part Environment (.ipt)"
+      internal_name: "Part"
+      description: "Standard 3D solid part design workspace"
+      tabs:
+        - name: "3D Model"
+          internal_name: "id_TabModel"
+          panels:
+            - name: "Sketch"
+              buttons: [Start 2D Sketch, Start 3D Sketch]
+            - name: "Create"
+              buttons: [Extrude, Revolve, Sweep, Loft, Coil, Rib, Emboss, Decal]
+            - name: "Modify"
+              buttons: [Hole, Fillet, Chamfer, Shell, Draft, Thread, Split, Direct, Combine, Thicken/Offset]
+            - name: "Work Features"
+              buttons: [Plane, Axis, Point, Coordinate System]
+            - name: "Pattern"
+              buttons: [Rectangular, Circular, Sketch Driven, Mirror]
+            - name: "Freeform"
+              buttons: [Box, Cylinder, Sphere, Torus, Quadball, Plane, Face]
+            - name: "Surface"
+              buttons: [Patch, Stitch, Sculpt, Extend, Trim, Rule Fillet]
+
+        - name: "Sketch"
+          internal_name: "id_TabSketch"
+          panels:
+            - name: "Create"
+              buttons: [Line, Circle, Arc, Rectangle, Slot, Spline, Fillet, Chamfer, Text, Point]
+            - name: "Modify"
+              buttons: [Move, Copy, Rotate, Scale, Stretch, Trim, Extend, Split, Offset]
+            - name: "Pattern"
+              buttons: [Rectangular, Circular, Mirror]
+            - name: "Constrain"
+              buttons: [Dimension, Auto Dimension, Coincident, Collinear, Concentric, Fix, Parallel, Perpendicular, Horizontal, Vertical, Tangent, Smooth, Symmetric, Equal]
+            - name: "Format"
+              buttons: [Construction, Centerline]
+            - name: "Exit"
+              buttons: [Finish Sketch]
+
+    - name: "Sheet Metal Environment (.ipt)"
+      internal_name: "SheetMetal"
+      description: "Specialized part environment for uniform thickness manufacturing"
+      tabs:
+        - name: "Sheet Metal"
+          internal_name: "id_TabSheetMetal"
+          panels:
+            - name: "Setup"
+              buttons: [Sheet Metal Defaults]
+            - name: "Create"
+              buttons: [Face, Flange, Contour Flange, Hem, Bend, Fold]
+            - name: "Modify"
+              buttons: [Cut, Corner Chamfer, Corner Round, Corner Seam, Punch Tool]
+            - name: "Flat Pattern"
+              buttons: [Go to Flat Pattern, Create Flat Pattern]
+
+    - name: "Assembly Environment (.iam)"
+      internal_name: "Assembly"
+      description: "Multi-component assembly workspace"
+      tabs:
+        - name: "Assemble"
+          internal_name: "id_TabAssemble"
+          panels:
+            - name: "Component"
+              buttons: [Place from Content Center, Place, Create Component, Replace, Replace All]
+            - name: "Position"
+              buttons: [Move Component, Rotate Component, Grip Snap, Free Move, Free Rotate]
+            - name: "Relationships"
+              buttons: [Constrain, Joint, Assemble, Show, Hide All, Unground and Root]
+            - name: "Pattern"
+              buttons: [Pattern Component, Mirror Component, Copy Component]
+
+        - name: "Design"
+          internal_name: "id_TabDesign"
+          panels:
+            - name: "Fasten"
+              buttons: [Bolted Connection, Pin, Joint, Clevis Pin]
+            - name: "Frame"
+              buttons: [Insert Frame, Change Frame, Miter, Trim/Extend, Notch, Lengthen/Shorten]
+            - name: "Power Transmission"
+              buttons: [Shaft, Gear, Bearing, Belt, Chain, O-Ring, Cam]
+
+    - name: "Drawing Environment (.idw / .dwg)"
+      internal_name: "Drawing"
+      description: "2D manufacturing documentation workspace"
+      tabs:
+        - name: "Place Views"
+          internal_name: "id_TabPlaceViews"
+          panels:
+            - name: "Create"
+              buttons: [Base, Projected, Auxiliary, Section, Detail, Overlay, Draft View]
+            - name: "Modify View"
+              buttons: [Break, Break Out, Crop, Slice]
+
+        - name: "Annotate"
+          internal_name: "id_TabAnnotate"
+          panels:
+            - name: "Dimension"
+              buttons: [Dimension, Baseline, Chain, Ordinate]
+            - name: "Feature Notes"
+              buttons: [Hole and Thread, Chamfer, Thread, Surface Texture, Welding Symbol]
+            - name: "Table"
+              buttons: [Parts List, General Table, Hole Table, Revision Table]
+
+    - name: "Presentation Environment (.ipn)"
+      internal_name: "Presentation"
+      description: "Exploded views and animation tracking"
+      tabs:
+        - name: "Presentation"
+          internal_name: "id_TabPresentation"
+          panels:
+            - name: "Create View"
+              buttons: [Create View]
+            - name: "Component"
+              buttons: [Tweak Components, Clear Tweaks]
+            - name: "Camera"
+              buttons: [Capture Camera, Restore Camera]
+            - name: "Publish"
+              buttons: [Video, Raster Image]
+
+    - name: "Global Active Context Utilities"
+      internal_name: "GlobalUtilities"
+      description: "Diagnostic and visibility tabs persistent across all open files"
+      tabs:
+        - name: "Tools"
+          internal_name: "id_TabToolsGlobal"
+          panels:
+            - name: "Options"
+              buttons: [Application Options, Document Settings]
+            - name: "Content Center"
+              buttons: [Editor, Favorites, Batch Publisher]
+            - name: "Material and Appearance"
+              buttons: [Materials, Appearances]
+            - name: "Options 2"
+              buttons: [Add-Ins, VBA Editor, Run Macro]
+
+        - name: "Inspect"
+          internal_name: "id_TabInspect"
+          panels:
+            - name: "Measure"
+              buttons: [Measure, Region Properties]
+            - name: "Interference"
+              buttons: [Analyze Interference]
+
+        - name: "View"
+          internal_name: "id_TabView"
+          panels:
+            - name: "Appearance"
+              buttons: [Visual Style, Shadow, Reflection, Orthographic, Perspective]
+            - name: "Navigate"
+              buttons: [Zoom, Pan, Orbit, Look At, ViewCube]
+            - name: "Windows"
+              buttons: [Switch Windows, Cascade, Tile Horizontally, Tile Vertically]
+```
+
+## Current deviations (to align — tracked 2026-06-04)
+
+Audit of `app/commands_standard.go` against the tree above. These are placement bugs to
+fix as the affected features are touched (the commands work; they're in the wrong panel):
+
+| Command | Was | Correct panel (per tree) | Status |
+|---------|-----|--------------------------|:------:|
+| Sketch `Dimension` | `Dimension` | **`Constrain`** | ✅ fixed 2026-06-04 |
+| Sketch `Auto Dimension` | `Dimension` | **`Constrain`** | ✅ fixed 2026-06-04 |
+| Sketch `Mirror` | `Modify` | **`Pattern`** | ✅ fixed 2026-06-04 |
+| Sketch `Fillet` | `Modify` | **`Create`** | ✅ fixed 2026-06-04 |
+| Sketch `Project Geometry` | `Draw` | (not in this tree's Sketch tab; verify) | review |
+| Part `Offset Face`/`Thicken` | `Modify` | `Modify` has **`Thicken/Offset`** (combined) | ok-ish |
+
+The Sketch tab now matches the tree (panels: Create, Modify, Pattern, Constrain, Exit;
+plus a non-canonical `Draw` panel holding Project Geometry — under review). Locked by
+`app.TestSketchTabPanelsMatchInventor`. **Modify** = Move/Copy/Rotate/Scale/Stretch/Trim/
+Extend/Split/Offset; **Pattern** = Rectangular/Circular/Mirror; **Create** = the full
+canonical set incl. Slot/Fillet/Chamfer/Text (plus Ellipse/Polygon extras); **Constrain** =
+Dimension/Auto Dimension/constraints; **Exit** = Finish (all built 2026-06-04). **The
+Sketch 2D tab is at full button parity with the tree.** Parameterized tools share one
+generic property dialog (`app.ParameterizedTool` → `head/ui/tool_params_dialog.go`).
+Follow-up: Stretch's head interaction is vertex-window selection (the model/tool work on an
+explicit point set today).
+
+Notes:
+- The **`Dimension` panel does not exist** in the Inventor Sketch tab — dimensions live in
+  **`Constrain`**. The standalone `Dimension` panel we use must be merged into `Constrain`.
+- Sketch **`Modify`** should be: Move, Copy, Rotate, Scale, Stretch, Trim, Extend, Split,
+  Offset. We currently also have Mirror (→ Pattern) and Fillet (→ Create) there.
+- Part **`Surface`** panel buttons are Patch, Stitch, Sculpt, Extend, Trim, Rule Fillet —
+  when the M10 surfacing features get UI (PARTDOC-PLAN Phase 5), place them here, not in a
+  new panel.
+- Part **`Pattern`** panel (Rectangular, Circular, Sketch Driven, Mirror) is where the
+  flagship pattern/mirror UI (PARTDOC-PLAN Phase 3, finding U-01) must land.
+- Out-of-scope environments (SheetMetal/Assembly/Drawing/Presentation) are included for
+  completeness; do not build them until PartDocument is complete (see PARTDOC-PLAN.md at
+  the repo root).

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -42,6 +43,9 @@ type addInHost struct {
 func startAddIns(session *app.Session) *addInHost {
 	d := dispatch.New(64)
 	rtr := router.New(opregistry.Default())
+	// Route kernel logs into the router's operation trace so a driver can read both the
+	// op-trace and any slog records over the bridge (logs.tail / tail_logs).
+	slog.SetDefault(slog.New(rtr.Trace().SlogHandler(slog.LevelInfo)))
 	addinhost.SetHost(d, func(method string, req []byte) ([]byte, error) {
 		return rtr.Handle(session, method, req)
 	}, hostCallTimeout)

--- a/head/demo.obk
+++ b/head/demo.obk
@@ -1,0 +1,75 @@
+schemaVersion: 2
+documentType: 1
+displayName: demo
+model:
+    units:
+        angle: deg
+        area: mm^2
+        length: mm
+        mass: kg
+        time: s
+        volume: mm^3
+    parameters:
+        - name: width
+          kind: user
+          expression: 4 cm
+    sketches:
+        - plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 1
+                - 0
+                - 0
+            yAxis:
+                - 0
+                - 1
+                - 0
+          points:
+            - id: 2
+              x: 0
+              "y": 0
+              standalone: true
+            - id: 3
+              x: 4
+              "y": 0
+              standalone: true
+            - id: 4
+              x: 4
+              "y": 3
+              standalone: true
+            - id: 5
+              x: 0
+              "y": 3
+              standalone: true
+          entities:
+            - id: 6
+              kind: line
+              points:
+                - 2
+                - 3
+            - id: 7
+              kind: line
+              points:
+                - 3
+                - 4
+            - id: 8
+              kind: line
+              points:
+                - 4
+                - 5
+            - id: 9
+              kind: line
+              points:
+                - 5
+                - 2
+    features:
+        - kind: extrude
+          name: extrude
+          extrude:
+            sketch: 0
+            profile: 0
+            operation: newBody
+            distance: 5

--- a/head/internal/addinhost/uiaddin_test.go
+++ b/head/internal/addinhost/uiaddin_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Oblikovati/oblikovati/addin/opregistry"
 	"github.com/Oblikovati/oblikovati/addin/router"
 	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
+	"github.com/Oblikovati/oblikovati/model/doc"
 )
 
 // TestAddInExtendsRibbonAndActsOnClick is the end-to-end proof of add-in UI
@@ -27,6 +29,17 @@ func TestAddInExtendsRibbonAndActsOnClick(t *testing.T) {
 	so := buildFixture(t, "uiaddin")
 
 	s := app.NewSession()
+	// The fixture creates its button with no explicit ribbon, which defaults to the
+	// Part ribbon (CommandDefinition.appearsOnRibbon). Open an active part document so
+	// BuildRibbon yields the Part ribbon — this mirrors how an add-in button is used in
+	// practice and the core router test's seededSession setup. Without it the session is
+	// on the ZeroDoc ribbon and the button is correctly excluded.
+	pd, err := s.Workspace().Add(doc.Part, "test.obk", true)
+	if err != nil {
+		t.Fatalf("add part document: %v", err)
+	}
+	pd.SetContent(compdef.NewPartComponentDefinition())
+
 	d := dispatch.New(8)
 	defer d.Close()
 	rtr := router.New(opregistry.Default())

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -93,6 +93,9 @@ int  obk_ig_is_item_deactivated_after_edit(void);
 // begin_combo/end_combo bracket the theme selector dropdown.
 void obk_ig_set_style_color(const char* name, float r, float g, float b, float a);
 int  obk_ig_color_edit4(const char* label, float* rgba);
+void obk_ig_draw_line(float x1, float y1, float x2, float y2, float r, float g, float b, float a, float thickness);
+void obk_ig_draw_triangle_filled(float x1, float y1, float x2, float y2, float x3, float y3, float r, float g, float b, float a);
+void obk_ig_draw_text(float x, float y, float r, float g, float b, float a, const char* s);
 int  obk_ig_begin_combo(const char* label, const char* preview);
 void obk_ig_end_combo(void);
 
@@ -257,6 +260,29 @@ func ColorEdit4(label string, c *[4]float32) bool {
 	cl, free := cstr(label)
 	defer free()
 	return C.obk_ig_color_edit4(cl, (*C.float)(unsafe.Pointer(&c[0]))) != 0
+}
+
+// DrawLine draws a screen-space line in the current window's draw list (color is 0..1
+// RGBA). Used for free-form overlays like the viewport's axis-orientation gizmo; call it
+// inside the owning window's Begin/End so it clips to that window.
+func DrawLine(x1, y1, x2, y2 float32, c [4]float32, thickness float32) {
+	C.obk_ig_draw_line(C.float(x1), C.float(y1), C.float(x2), C.float(y2),
+		C.float(c[0]), C.float(c[1]), C.float(c[2]), C.float(c[3]), C.float(thickness))
+}
+
+// DrawTriangleFilled fills a screen-space triangle in the current window's draw list
+// (color is 0..1 RGBA) — e.g. the axis gizmo's arrowheads.
+func DrawTriangleFilled(x1, y1, x2, y2, x3, y3 float32, c [4]float32) {
+	C.obk_ig_draw_triangle_filled(C.float(x1), C.float(y1), C.float(x2), C.float(y2),
+		C.float(x3), C.float(y3), C.float(c[0]), C.float(c[1]), C.float(c[2]), C.float(c[3]))
+}
+
+// DrawText draws a screen-space text label at (x,y) in the current window's draw list
+// (color is 0..1 RGBA), using the default font — e.g. the axis gizmo's X/Y/Z letters.
+func DrawText(x, y float32, s string, c [4]float32) {
+	cs, free := cstr(s)
+	defer free()
+	C.obk_ig_draw_text(C.float(x), C.float(y), C.float(c[0]), C.float(c[1]), C.float(c[2]), C.float(c[3]), cs)
 }
 
 // BeginCombo / EndCombo bracket a dropdown showing preview as the closed value; when

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -133,6 +133,27 @@ void obk_ig_set_style_color(const char* name, float r, float g, float b, float a
 int  obk_ig_color_edit4(const char* label, float* rgba) {
     return ImGui::ColorEdit4(label, rgba) ? 1 : 0;
 }
+
+// Window-draw-list primitives: free-form 2D shapes painted over the current window's
+// content (e.g. the viewport's axis-orientation gizmo). Coordinates are screen-space
+// pixels; colors are 0..1 RGBA packed to IM_COL32. Drawing happens within the current
+// window's clip rect, so callers must invoke these inside the window's Begin/End.
+static ImU32 obk_col32(float r, float g, float b, float a) {
+    return IM_COL32((int)(r * 255), (int)(g * 255), (int)(b * 255), (int)(a * 255));
+}
+void obk_ig_draw_line(float x1, float y1, float x2, float y2,
+                      float r, float g, float b, float a, float thickness) {
+    ImGui::GetWindowDrawList()->AddLine(ImVec2(x1, y1), ImVec2(x2, y2),
+                                        obk_col32(r, g, b, a), thickness);
+}
+void obk_ig_draw_triangle_filled(float x1, float y1, float x2, float y2, float x3, float y3,
+                                 float r, float g, float b, float a) {
+    ImGui::GetWindowDrawList()->AddTriangleFilled(ImVec2(x1, y1), ImVec2(x2, y2),
+                                                  ImVec2(x3, y3), obk_col32(r, g, b, a));
+}
+void obk_ig_draw_text(float x, float y, float r, float g, float b, float a, const char* s) {
+    ImGui::GetWindowDrawList()->AddText(ImVec2(x, y), obk_col32(r, g, b, a), s);
+}
 int  obk_ig_begin_combo(const char* label, const char* preview) {
     return ImGui::BeginCombo(label, preview) ? 1 : 0;
 }

--- a/head/ui/axis_gizmo.go
+++ b/head/ui/axis_gizmo.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// This file has no cgo build tag: projecting the world axes onto the screen plane is
+// pure Go (like navigate.go), so the triad geometry is unit-tested without the native
+// stack. axis_gizmo_draw.go (cgo) anchors the result in the viewport corner and paints
+// it with the ImGui draw list.
+package ui
+
+import (
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// Axis-triad colors follow the universal CAD convention (X red, Y green, Z blue) and are
+// deliberately theme-independent — users read axis identity by color across every CAD app.
+var (
+	axisColorX = [4]float32{0.90, 0.23, 0.27, 1}
+	axisColorY = [4]float32{0.42, 0.74, 0.28, 1}
+	axisColorZ = [4]float32{0.24, 0.50, 0.92, 1}
+)
+
+// axisArrow is one world axis projected onto the gizmo's 2D screen plane: tipX/tipY is
+// the arrow tip's pixel offset from the gizmo center (y grows downward), depth is the
+// axis' camera-forward component (larger ⇒ pointing away from the viewer) used to paint
+// the triad back-to-front, and label/color identify the axis.
+type axisArrow struct {
+	tipX, tipY float32
+	depth      float64
+	color      [4]float32
+	label      string
+}
+
+// axisTriad projects the +X/+Y/+Z world axes onto the camera's screen plane, scaled to
+// radius pixels, and returns them sorted back-to-front so a painter draws the arrow
+// nearest the viewer last (on top). Only the camera's ORIENTATION is used, so the triad
+// spins to match the view but never pans or scales with zoom — it stays pinned wherever
+// the caller anchors the center. Example: axisTriad(session.Camera(), 30).
+func axisTriad(cam scene.Camera, radius float32) []axisArrow {
+	fwd := normVec(cam.Forward())
+	right := normVec(fwd.Cross(cam.Up))
+	up := right.Cross(fwd) // forward ⟂ right and both unit ⟹ already unit
+	arrows := []axisArrow{
+		projectAxis(math.V3(1, 0, 0), right, up, fwd, radius, axisColorX, "X"),
+		projectAxis(math.V3(0, 1, 0), right, up, fwd, radius, axisColorY, "Y"),
+		projectAxis(math.V3(0, 0, 1), right, up, fwd, radius, axisColorZ, "Z"),
+	}
+	sort.SliceStable(arrows, func(i, j int) bool { return arrows[i].depth > arrows[j].depth })
+	return arrows
+}
+
+// projectAxis maps one world axis onto the (right, up) screen basis: screen x grows
+// rightward, screen y grows downward (hence the negated up component, matching
+// renderer.Project's Vulkan y-down convention). depth is the axis' forward component.
+func projectAxis(axis, right, up, fwd math.Vector3, radius float32, color [4]float32, label string) axisArrow {
+	return axisArrow{
+		tipX:  float32(axis.Dot(right)) * radius,
+		tipY:  float32(-axis.Dot(up)) * radius,
+		depth: axis.Dot(fwd),
+		color: color,
+		label: label,
+	}
+}
+
+// normVec returns v scaled to unit length, or v unchanged when it is zero-length (no
+// direction to normalize).
+func normVec(v math.Vector3) math.Vector3 {
+	l := v.Length()
+	if l == 0 {
+		return v
+	}
+	return v.Scale(1 / l)
+}

--- a/head/ui/axis_gizmo_draw.go
+++ b/head/ui/axis_gizmo_draw.go
@@ -1,0 +1,56 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+const (
+	axisGizmoMargin = 46  // gizmo-center inset from the viewport's bottom-left corner, px
+	axisGizmoRadius = 30  // arrow length from center to tip, px
+	axisArrowHead   = 9   // arrowhead length along the shaft, px
+	axisShaftWidth  = 2.4 // shaft line thickness, px
+)
+
+// drawAxisGizmo paints the orientation triad (three colored arrows for +X/+Y/+Z) in the
+// viewport's bottom-left corner, over the already-drawn image. originX/originY is the
+// image's top-left in screen space (native.ItemRectMin right after the image) and ph its
+// height. The triad reads the live camera, so it always shows which way each axis points
+// for the current view (ADR-0004). Must be called inside the viewport window so the
+// ImGui window draw list and its clip rect are the viewport's.
+func drawAxisGizmo(cam scene.Camera, originX, originY float32, ph int) {
+	cx := originX + axisGizmoMargin
+	cy := originY + float32(ph) - axisGizmoMargin
+	for _, a := range axisTriad(cam, axisGizmoRadius) {
+		tipX, tipY := cx+a.tipX, cy+a.tipY
+		native.DrawLine(cx, cy, tipX, tipY, a.color, axisShaftWidth)
+		drawArrowhead(cx, cy, tipX, tipY, a.color)
+		native.DrawText(tipX+3, tipY-7, a.label, a.color)
+	}
+}
+
+// drawArrowhead fills a small triangle at the tip pointing along the shaft from the
+// center. A near-zero shaft (axis pointing straight at the viewer) is skipped: there is
+// no in-plane direction to orient the head.
+func drawArrowhead(cx, cy, tipX, tipY float32, color [4]float32) {
+	dx, dy := tipX-cx, tipY-cy
+	l := float32(stdmath.Hypot(float64(dx), float64(dy)))
+	if l < 1e-3 {
+		return
+	}
+	ux, uy := dx/l, dy/l                                   // unit shaft direction
+	px, py := -uy, ux                                      // in-plane perpendicular
+	bx, by := tipX-ux*axisArrowHead, tipY-uy*axisArrowHead // head base center
+	const halfW = axisArrowHead * 0.45
+	native.DrawTriangleFilled(
+		tipX, tipY,
+		bx+px*halfW, by+py*halfW,
+		bx-px*halfW, by-py*halfW,
+		color)
+}

--- a/head/ui/axis_gizmo_test.go
+++ b/head/ui/axis_gizmo_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"math"
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/scene"
+)
+
+// frontCamera looks straight down −Z (Inventor's default), so +X points screen-right,
+// +Y screen-up, and +Z straight at the viewer.
+func frontCamera() scene.Camera {
+	cam := scene.NewCamera(800, 600)
+	cam.Eye = gmath.P3(0, 0, 10)
+	cam.Target = gmath.P3(0, 0, 0)
+	cam.Up = gmath.V3(0, 1, 0)
+	return cam
+}
+
+func findArrow(arrows []axisArrow, label string) (axisArrow, bool) {
+	for _, a := range arrows {
+		if a.label == label {
+			return a, true
+		}
+	}
+	return axisArrow{}, false
+}
+
+// A front view must put +X to the right (+tipX), +Y up (−tipY because screen y is down),
+// and leave Z with no screen extent (it points at the camera).
+func TestAxisTriadFrontViewScreenDirections(t *testing.T) {
+	arrows := axisTriad(frontCamera(), 30)
+
+	x, _ := findArrow(arrows, "X")
+	if x.tipX <= 0 || math.Abs(float64(x.tipY)) > 1e-3 {
+		t.Fatalf("X arrow: got tip (%.3f,%.3f), want +x, ~0 y", x.tipX, x.tipY)
+	}
+	y, _ := findArrow(arrows, "Y")
+	if y.tipY >= 0 || math.Abs(float64(y.tipX)) > 1e-3 {
+		t.Fatalf("Y arrow: got tip (%.3f,%.3f), want -y (up on screen), ~0 x", y.tipX, y.tipY)
+	}
+	z, _ := findArrow(arrows, "Z")
+	if math.Hypot(float64(z.tipX), float64(z.tipY)) > 1e-3 {
+		t.Fatalf("Z arrow: got tip (%.3f,%.3f), want ~origin (points at viewer)", z.tipX, z.tipY)
+	}
+}
+
+// The tip offset must scale with the requested radius (the gizmo is screen-constant size).
+func TestAxisTriadRadiusScalesTip(t *testing.T) {
+	x30, _ := findArrow(axisTriad(frontCamera(), 30), "X")
+	x60, _ := findArrow(axisTriad(frontCamera(), 60), "X")
+	if math.Abs(float64(x60.tipX-2*x30.tipX)) > 1e-3 {
+		t.Fatalf("doubling radius should double tipX: got %.3f then %.3f", x30.tipX, x60.tipX)
+	}
+}
+
+// Painter order: the arrow pointing most toward the viewer (most-negative depth) is drawn
+// last, so it lands on top. On the front view that is +Z.
+func TestAxisTriadSortedBackToFront(t *testing.T) {
+	arrows := axisTriad(frontCamera(), 30)
+	for i := 1; i < len(arrows); i++ {
+		if arrows[i-1].depth < arrows[i].depth {
+			t.Fatalf("arrows not sorted far→near: %v", arrows)
+		}
+	}
+	if arrows[len(arrows)-1].label != "Z" {
+		t.Fatalf("front view should draw Z (toward viewer) last, got %q", arrows[len(arrows)-1].label)
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -48,6 +48,8 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawBrowser(s)
 	drawViewportPanel(win, s)
 	drawDimensionPopup(s)
+	drawToolParamsDialog(s) // generic dialog for parameterized sketch tools
+	drawSketch3DSettings(s) // 3D-sketch settings while editing one
 	drawExtrudeDialog(s)
 	drawRevolveDialog(s)
 	drawCoilDialog(s)
@@ -62,6 +64,7 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawDeleteFaceDialog(s)
 	drawReplaceFaceDialog(s)
 	drawThickenDialog(s)
+	drawSplitDialog(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawStatusBar(s)

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -143,7 +143,9 @@ func drawSelectorPanel(panel app.RibbonPanel) string {
 
 // drawRibbonButton renders one command in its configured style (text, small icon, or
 // large icon), greyed when its predicate is false, with the command tooltip on hover.
-// It returns the command id when clicked this frame, else "".
+// A command with variants renders as a split button: the head control plus a dropdown
+// arrow listing the variant tools (Inventor's variant flyout). It returns the id of the
+// command (head or chosen variant) clicked this frame, else "".
 func drawRibbonButton(btn app.RibbonButton) string {
 	native.BeginDisabled(!btn.Enabled)
 	clicked := drawButtonControl(btn)
@@ -151,7 +153,38 @@ func drawRibbonButton(btn app.RibbonButton) string {
 	if clicked {
 		return btn.Command.ID()
 	}
+	if len(btn.Variants) > 0 {
+		return drawVariantDropdown(btn)
+	}
 	return ""
+}
+
+// variantArrowWidth is the pixel width of a split button's dropdown arrow box — just wide
+// enough for the combo's caret, since its preview text is empty (the head shows the label).
+const variantArrowWidth = 18
+
+// drawVariantDropdown renders a split button's dropdown next to its head: a narrow combo
+// whose entries are the variant tools. Choosing one returns its command id so the caller
+// runs it; a disabled variant is shown greyed and is not selectable. Returns "" if nothing
+// was chosen this frame.
+func drawVariantDropdown(btn app.RibbonButton) string {
+	native.SameLine()
+	native.SetNextItemWidth(variantArrowWidth)
+	var chosen string
+	if native.BeginCombo("##"+btn.Command.ID()+"-variants", "") {
+		for _, v := range btn.Variants {
+			native.BeginDisabled(!v.Enabled)
+			if native.Selectable(v.Label, false) {
+				chosen = v.CommandID
+			}
+			native.EndDisabled()
+			if v.Tooltip != "" {
+				native.SetItemTooltip(v.Tooltip)
+			}
+		}
+		native.EndCombo()
+	}
+	return chosen
 }
 
 // drawButtonControl draws the command's clickable control and its tooltip, returning

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -46,6 +46,10 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		}
 		list, gfxLabels := clientGraphicsOverlay(s, cam, list)
 		renderViewportImage(win, s, cam, list, pw, ph, cx, cy)
+		// Pinned to the corner over the freshly drawn image (ItemRectMin is its screen
+		// origin), before any label items so it reads the image rect, not a label's.
+		ox, oy := native.ItemRectMin()
+		drawAxisGizmo(cam, ox, oy, ph)
 		drawClientGraphicsLabels(cx, cy, cam, gfxLabels)
 		if s.InSketch() && len(dims) > 0 {
 			if d := drawDimensionLabels(cx, cy, cam, sketchPlane, dims); d != nil {
@@ -136,8 +140,9 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	list.Items = append(list.Items, partSketchOverlays(s)...)
 	list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
 	list.Items = append(list.Items, selectedEdgeOverlay(s)...)
-	list.Items = append(list.Items, extrudeHoverHighlight(s)...)
-	list.Items = append(list.Items, extrudeProfileHighlight(s)...)
+	list.Items = append(list.Items, toolHoverHighlight(s)...)
+	list.Items = append(list.Items, toolSelectedHighlight(s)...)
+	list.Items = append(list.Items, revolveCenterlineHighlight(s)...)
 	list.Items = append(list.Items, activeToolPreviewItems(s)...)
 	return list
 }

--- a/head/ui/edge_highlight.go
+++ b/head/ui/edge_highlight.go
@@ -9,19 +9,13 @@ import (
 	"github.com/Oblikovati/oblikovati/renderer"
 )
 
-// Edge selection has no per-body recolor (an edge is not a body), so picked edges are
-// highlighted by drawing them as overlay lines in the selection colour. This covers the
-// edges an active edge tool (chamfer, fillet, …) has gathered and a lone selected edge, so
-// the user sees their pick land.
+// Edge selection has no per-body recolor (an edge is not a body), so a lone edge selected
+// outside any tool is highlighted by drawing it as an overlay line in the selection colour.
+// Edges gathered by an active tool (chamfer, fillet, …) are highlighted by the unified
+// toolSelectedHighlight (toolPicks/drawSelectable), so they are not handled here.
 
-// edgeLister is any tool that exposes the edges it has picked (e.g. the Chamfer tool).
-type edgeLister interface {
-	Edges() []app.EdgeHandle
-}
-
-// selectedEdgeOverlay draws the currently picked edges in the selection colour: the active
-// edge tool's gathered edges, or a single edge selected outside a tool. Returns nil when
-// there are none.
+// selectedEdgeOverlay draws a single edge selected outside a tool in the selection colour.
+// Returns nil when there is none.
 func selectedEdgeOverlay(s *app.Session) []renderer.DrawItem {
 	edges := highlightedEdges(s)
 	if len(edges) == 0 {
@@ -40,25 +34,15 @@ func selectedEdgeOverlay(s *app.Session) []renderer.DrawItem {
 	return []renderer.DrawItem{lineItem(acc, selectionHighlight)}
 }
 
-// highlightedEdges returns the edges to highlight: the active edge tool's picks, else a lone
-// selected edge.
+// highlightedEdges returns a lone selected edge (outside any tool) to highlight. An active
+// tool's gathered edges flow through the unified toolSelectedHighlight, so they are skipped
+// here to avoid drawing them twice.
 func highlightedEdges(s *app.Session) []*topo.Edge {
-	if at := s.ActiveTool(); at != nil {
-		if el, ok := at.Tool().(edgeLister); ok {
-			return edgesOf(el.Edges())
-		}
+	if s.ActiveTool() != nil {
+		return nil
 	}
 	if h, ok := s.Selection().First().(app.EdgeHandle); ok {
 		return []*topo.Edge{h.Edge}
 	}
 	return nil
-}
-
-// edgesOf unwraps edge handles to their topo edges.
-func edgesOf(handles []app.EdgeHandle) []*topo.Edge {
-	out := make([]*topo.Edge, 0, len(handles))
-	for _, h := range handles {
-		out = append(out, h.Edge)
-	}
-	return out
 }

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -176,42 +176,6 @@ func drawExtrudeButtons(s *app.Session, ext *app.ExtrudeTool) {
 	}
 }
 
-// extrudeProfileHighlight outlines every region picked for extrude (and their holes) in
-// the selection color, so the user sees what they have gathered. Returns nil when no
-// extrude tool is active or nothing is picked yet.
-func extrudeProfileHighlight(s *app.Session) []renderer.DrawItem {
-	ext := s.ActiveExtrude()
-	if ext == nil {
-		return nil
-	}
-	var items []renderer.DrawItem
-	for _, ph := range ext.PickedProfiles() {
-		items = append(items, profileOutline(ph, sketchSelectedColor)...)
-	}
-	return items
-}
-
-// extrudeHoverHighlight outlines the region under the cursor in the candidate color
-// while the Extrude tool is active, so the user sees which closed area a click would
-// pick. Returns nil when no extrude tool is active, the cursor is off any region, or
-// that region is already selected (it is then already drawn in the selected color).
-func extrudeHoverHighlight(s *app.Session) []renderer.DrawItem {
-	ext := s.ActiveExtrude()
-	if ext == nil || !native.IsItemHovered() {
-		return nil
-	}
-	x, y := viewportCursor()
-	sel, ok := s.PickAt(x, y, app.NewSelectionFilter(app.SelectProfile))
-	if !ok {
-		return nil
-	}
-	ph, isProfile := sel.(app.ProfileHandle)
-	if !isProfile || isPickedProfile(ext, ph) {
-		return nil
-	}
-	return profileOutline(ph, sketchCandidateColor)
-}
-
 // profileOutline returns the wireframe of a region's outer loop and holes in color.
 // Returns nil when the region index is stale (sketch edited under the selection).
 func profileOutline(ph app.ProfileHandle, color [4]float32) []renderer.DrawItem {
@@ -225,16 +189,6 @@ func profileOutline(ph app.ProfileHandle, color [4]float32) []renderer.DrawItem 
 		acc.polyline(ph.Sketch.Plane(), hole.Polygon(), true)
 	}
 	return appendGrid(nil, acc, color)
-}
-
-// isPickedProfile reports whether ph is already in the tool's selection.
-func isPickedProfile(ext *app.ExtrudeTool, ph app.ProfileHandle) bool {
-	for _, p := range ext.PickedProfiles() {
-		if p == ph {
-			return true
-		}
-	}
-	return false
 }
 
 // activeToolPreviewItems returns the active tool's transient preview (the Extrude prism

--- a/head/ui/hole_dialog.go
+++ b/head/ui/hole_dialog.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	stdmath "math"
+
 	"github.com/Oblikovati/oblikovati/app"
 	"github.com/Oblikovati/oblikovati/head/internal/native"
 )
@@ -13,9 +15,14 @@ import (
 // the user set the diameter and depth (database units), then OK/Cancel. The placement
 // face is the one clicked in the viewport.
 var holeUI = struct {
-	diameter, depth float32
-	open            bool
-}{diameter: 1, depth: 2}
+	diameter, depth          float32
+	through                  bool
+	counterbore, countersink bool
+	cDiameter, cDepth        float32
+	sinkAngleDeg             float32
+	pointAngleDeg            float32
+	open                     bool
+}{diameter: 1, depth: 2, cDiameter: 2, cDepth: 0.5, sinkAngleDeg: 90, pointAngleDeg: 118}
 
 // drawHoleDialog shows the hole options window while the Hole tool is active.
 func drawHoleDialog(s *app.Session) {
@@ -27,9 +34,16 @@ func drawHoleDialog(s *app.Session) {
 	if !holeUI.open {
 		holeUI.diameter = float32(h.Diameter())
 		holeUI.depth = float32(h.Depth())
+		holeUI.through = h.ThroughAll()
+		holeUI.counterbore = h.Counterbore()
+		holeUI.countersink = h.Countersink()
+		holeUI.cDiameter = float32(h.CounterDiameter())
+		holeUI.cDepth = float32(h.CounterDepth())
+		holeUI.sinkAngleDeg = float32(h.SinkAngle() * 180 / stdmath.Pi)
+		holeUI.pointAngleDeg = float32(h.PointAngle() * 180 / stdmath.Pi)
 		holeUI.open = true
 	}
-	native.SetNextWindowSize(300, 180)
+	native.SetNextWindowSize(300, 390)
 	if native.Begin("Hole") {
 		if _, ok := h.PickedFace(); !ok {
 			native.Text("Click a planar face to place the hole on")
@@ -37,12 +51,53 @@ func drawHoleDialog(s *app.Session) {
 		native.Text("Diameter (" + s.LengthUnitName() + ")")
 		native.InputFloat("##hole-diameter", &holeUI.diameter)
 		h.SetDiameter(float64(holeUI.diameter))
+		native.Checkbox("Through All", &holeUI.through)
+		h.SetThroughAll(holeUI.through)
+		native.BeginDisabled(holeUI.through) // depth is ignored when drilling through
 		native.Text("Depth (" + s.LengthUnitName() + ")")
 		native.InputFloat("##hole-depth", &holeUI.depth)
+		native.EndDisabled()
 		h.SetDepth(float64(holeUI.depth))
+		// Drill point applies to a plain blind drilled hole (not through, no recess).
+		native.BeginDisabled(holeUI.through || holeUI.counterbore || holeUI.countersink)
+		native.Text("Drill point angle (deg, 0 = flat)")
+		native.InputFloat("##hole-pang", &holeUI.pointAngleDeg)
+		h.SetPointAngle(float64(holeUI.pointAngleDeg) * stdmath.Pi / 180)
+		native.EndDisabled()
+		drawRecess(s, h)
 		drawHoleButtons(s, h)
 	}
 	native.End()
+}
+
+// drawRecess renders the counterbore/countersink toggles (mutually exclusive) and their
+// parameters: a counterbore's recess Ø + depth, or a countersink's sink Ø + included angle.
+func drawRecess(s *app.Session, h *app.HoleTool) {
+	if native.Checkbox("Counterbore", &holeUI.counterbore) {
+		h.SetCounterbore(holeUI.counterbore)
+		holeUI.countersink = h.Countersink() // the tool clears the other profile
+	}
+	native.BeginDisabled(!holeUI.counterbore)
+	native.Text("Counterbore Ø (" + s.LengthUnitName() + ")")
+	native.InputFloat("##hole-cdia", &holeUI.cDiameter)
+	native.Text("Counterbore depth (" + s.LengthUnitName() + ")")
+	native.InputFloat("##hole-cdepth", &holeUI.cDepth)
+	h.SetCounterDepth(float64(holeUI.cDepth))
+	native.EndDisabled()
+
+	if native.Checkbox("Countersink", &holeUI.countersink) {
+		h.SetCountersink(holeUI.countersink)
+		holeUI.counterbore = h.Counterbore()
+	}
+	native.BeginDisabled(!holeUI.countersink)
+	native.Text("Countersink Ø (" + s.LengthUnitName() + ")")
+	native.InputFloat("##hole-sdia", &holeUI.cDiameter)
+	native.Text("Countersink angle (deg)")
+	native.InputFloat("##hole-sang", &holeUI.sinkAngleDeg)
+	h.SetSinkAngle(float64(holeUI.sinkAngleDeg) * stdmath.Pi / 180)
+	native.EndDisabled()
+
+	h.SetCounterDiameter(float64(holeUI.cDiameter)) // shared recess/sink diameter
 }
 
 func drawHoleButtons(s *app.Session, h *app.HoleTool) {

--- a/head/ui/revolve_dialog.go
+++ b/head/ui/revolve_dialog.go
@@ -18,8 +18,9 @@ import (
 // picked region is outlined in the viewport by the tool's preview. The angle is shown
 // in degrees.
 var revolveUI = struct {
-	angleDeg float32
-	open     bool
+	angleDeg   float32
+	centerline bool
+	open       bool
 }{angleDeg: 360}
 
 // revolveAxes names each origin axis for the axis combo, paired with its work reference.
@@ -38,13 +39,18 @@ func drawRevolveDialog(s *app.Session) {
 	}
 	if !revolveUI.open {
 		revolveUI.angleDeg = seedRevolveAngle(rv)
+		revolveUI.centerline = rv.UseCenterline()
 		revolveUI.open = true
 	}
-	native.SetNextWindowSize(300, 240)
+	native.SetNextWindowSize(300, 270)
 	if native.Begin("Revolve") {
 		drawRevolveProfileText(rv)
 		revolveOperationCombo(rv)
+		native.Checkbox("About sketch centerline", &revolveUI.centerline)
+		rv.SetUseCenterline(revolveUI.centerline)
+		native.BeginDisabled(revolveUI.centerline) // the axis is the centerline now
 		revolveAxisCombo(rv)
+		native.EndDisabled()
 		drawRevolveAngle(rv)
 		drawRevolveButtons(s, rv)
 	}

--- a/head/ui/revolve_highlight.go
+++ b/head/ui/revolve_highlight.go
@@ -1,0 +1,37 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// revolveCenterlineHighlight draws the Revolve axis centerline — a sketch line, which the generic
+// tool highlight (drawSelectable, B-rep only) does not cover. The chosen centerline shows in the
+// selection colour; a centerline under the cursor while choosing the axis shows as a candidate.
+// (The profile itself is highlighted by the generic toolHoverHighlight/toolSelectedHighlight.)
+func revolveCenterlineHighlight(s *app.Session) []renderer.DrawItem {
+	rv := s.ActiveRevolve()
+	if rv == nil {
+		return nil
+	}
+	var items []renderer.DrawItem
+	if pts, plane, ok := rv.CenterlineOutline(); ok {
+		acc := &segAccum{}
+		acc.polyline(plane, pts, false)
+		items = appendGrid(items, acc, sketchSelectedColor)
+	}
+	if native.IsItemHovered() {
+		x, y := viewportCursor()
+		if pts, plane, ok := s.HoveredCenterlineOutline(x, y); ok {
+			acc := &segAccum{}
+			acc.polyline(plane, pts, false)
+			items = appendGrid(items, acc, sketchCandidateColor)
+		}
+	}
+	return items
+}

--- a/head/ui/sketch3d_settings.go
+++ b/head/ui/sketch3d_settings.go
@@ -1,0 +1,36 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// drawSketch3DSettings shows a small settings window while a 3D sketch is being edited
+// (Inventor's 3D Sketch settings): sketch visibility, dimension display, and deferred
+// updates. It edits the active sketch directly through its accessors (the same properties
+// the sketch3d.setProperty wire method toggles).
+func drawSketch3DSettings(s *app.Session) {
+	sk := s.ActiveSketch3D()
+	if sk == nil {
+		return
+	}
+	if native.Begin("3D Sketch Settings") {
+		visible := sk.Visible()
+		if native.Checkbox("Visible", &visible) {
+			sk.SetVisible(visible)
+		}
+		dims := sk.DimensionsVisible()
+		if native.Checkbox("Show dimensions", &dims) {
+			sk.SetDimensionsVisible(dims)
+		}
+		defer3d := sk.DeferUpdates()
+		if native.Checkbox("Defer updates", &defer3d) {
+			sk.SetDeferUpdates(defer3d)
+		}
+	}
+	native.End()
+}

--- a/head/ui/split_dialog.go
+++ b/head/ui/split_dialog.go
@@ -1,0 +1,47 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// drawSplitDialog shows the Split options while the Split tool is active: the user picks a work
+// plane in the view, chooses split-vs-trim, and OKs. The keep choice is driven through the
+// tool's convenience setters so the head needs no model enum.
+func drawSplitDialog(s *app.Session) {
+	t := s.ActiveSplit()
+	if t == nil {
+		return
+	}
+	native.SetNextWindowSize(300, 170)
+	if native.Begin("Split") {
+		if _, ok := t.PickedPlane(); !ok {
+			native.Text("Select a work plane to cut with")
+		} else {
+			native.Text("Mode: " + t.KeepLabel())
+		}
+		if native.Button("Split into two") {
+			t.SetKeepBoth()
+		}
+		if native.Button("Trim — keep front side") {
+			t.SetKeepPositive()
+		}
+		if native.Button("Trim — keep back side") {
+			t.SetKeepNegative()
+		}
+		native.BeginDisabled(!t.CanCommit())
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.EndDisabled()
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -1,0 +1,115 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/renderer"
+)
+
+// Unified tool highlighting: every interactive tool gives the SAME feedback — the selectable
+// under the cursor (that the tool's filter would pick) is outlined in the candidate colour, and
+// what the tool has already picked is outlined in the selection colour. Both run off one per-kind
+// dispatcher (drawSelectable) and the tool's existing pick accessors (toolPicks), so a new tool
+// needs no head-side highlight code. Work planes and sketch curves keep their own overlays
+// (planesOverlay/hoveredPlane and revolveCenterlineHighlight) since they are not B-rep selectables.
+
+// drawSelectable returns the overlay wireframe for one selectable in colour — the kinds tools
+// pick in the 3D view (a sketch profile region, a B-rep edge, a B-rep face). Other kinds (work
+// planes, sketch entities) are drawn by their dedicated overlays and return nil here.
+func drawSelectable(sel app.Selectable, color [4]float32) []renderer.DrawItem {
+	switch h := sel.(type) {
+	case app.ProfileHandle:
+		return profileOutline(h, color)
+	case app.EdgeHandle:
+		return edgeWire([]*topo.Edge{h.Edge}, color)
+	case app.FaceHandle:
+		return edgeWire(h.Face.Edges(), color)
+	}
+	return nil
+}
+
+// edgeWire draws the given edges as overlay lines in colour (the shared edge/face wireframe).
+func edgeWire(edges []*topo.Edge, color [4]float32) []renderer.DrawItem {
+	acc := &segAccum{}
+	for _, e := range edges {
+		pts := ops.TessellateEdge(e, ops.DefaultQuality())
+		for i := 0; i+1 < len(pts); i++ {
+			acc.addSegment(pts[i], pts[i+1])
+		}
+	}
+	if len(acc.pos) == 0 {
+		return nil
+	}
+	return []renderer.DrawItem{lineItem(acc, color)}
+}
+
+// toolHoverHighlight outlines the selectable under the cursor that the active tool would pick,
+// in the candidate colour — the same hover feedback for every tool.
+func toolHoverHighlight(s *app.Session) []renderer.DrawItem {
+	if s.ActiveTool() == nil || !native.IsItemHovered() {
+		return nil
+	}
+	filter := s.Selection().Filter()
+	if filter == nil {
+		return nil
+	}
+	x, y := viewportCursor()
+	sel, ok := s.PickAt(x, y, filter)
+	if !ok {
+		return nil
+	}
+	return drawSelectable(sel, sketchCandidateColor)
+}
+
+// toolSelectedHighlight outlines everything the active tool has picked, in the selection colour —
+// gathered from the tool's existing accessors (toolPicks), so all tools highlight their picks.
+func toolSelectedHighlight(s *app.Session) []renderer.DrawItem {
+	at := s.ActiveTool()
+	if at == nil {
+		return nil
+	}
+	var items []renderer.DrawItem
+	for _, sel := range toolPicks(at.Tool()) {
+		items = append(items, drawSelectable(sel, selectionHighlight)...)
+	}
+	return items
+}
+
+// toolPicks gathers the selectables a tool has picked from whichever accessor interfaces it
+// already implements (Edges/Faces/PickedProfiles/PickedProfile/PickedFace) — no per-tool method.
+func toolPicks(t app.Tool) []app.Selectable {
+	var picks []app.Selectable
+	if el, ok := t.(interface{ Edges() []app.EdgeHandle }); ok {
+		for _, e := range el.Edges() {
+			picks = append(picks, e)
+		}
+	}
+	if fl, ok := t.(interface{ Faces() []app.FaceHandle }); ok {
+		for _, f := range fl.Faces() {
+			picks = append(picks, f)
+		}
+	}
+	if pl, ok := t.(interface{ PickedProfiles() []app.ProfileHandle }); ok {
+		for _, p := range pl.PickedProfiles() {
+			picks = append(picks, p)
+		}
+	} else if pp, ok := t.(interface {
+		PickedProfile() (app.ProfileHandle, bool)
+	}); ok {
+		if ph, has := pp.PickedProfile(); has {
+			picks = append(picks, ph)
+		}
+	}
+	if hf, ok := t.(interface{ PickedFace() (app.FaceHandle, bool) }); ok {
+		if fh, has := hf.PickedFace(); has {
+			picks = append(picks, fh)
+		}
+	}
+	return picks
+}

--- a/head/ui/tool_params_dialog.go
+++ b/head/ui/tool_params_dialog.go
@@ -1,0 +1,118 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"bytes"
+
+	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/head/internal/native"
+)
+
+// One generic property dialog serves every tool that exposes parameters
+// (app.ParameterizedTool) — the sketch Move/Copy/Rotate/Scale/Stretch, the rectangular/
+// circular patterns, Slot/Chamfer/Text/Fillet/Offset — instead of a bespoke cgo dialog per
+// tool (core/09 reflection-driven editing). It renders each parameter as a labelled input
+// bound to the tool's field; OK commits, Cancel aborts. Modeless: the user still picks
+// geometry in the viewport.
+
+// toolText is the persistent edit buffer for a tool's text parameter (Dear ImGui's
+// InputText needs a stable buffer across frames).
+var toolText = struct {
+	buf  []byte
+	open bool
+}{buf: make([]byte, 256)}
+
+// drawToolParamsDialog shows the generic parameter dialog while a parameterized tool runs.
+func drawToolParamsDialog(s *app.Session) {
+	ti := s.ActiveTool()
+	if ti == nil {
+		toolText.open = false
+		return
+	}
+	pt, ok := ti.Tool().(app.ParameterizedTool)
+	if !ok {
+		toolText.open = false
+		return
+	}
+	params := pt.Params()
+	if params.Empty() {
+		toolText.open = false
+		return
+	}
+	native.SetNextWindowSize(280, 240)
+	if native.Begin(ti.Name()) {
+		drawToolFloatParams(params)
+		drawToolIntParams(params)
+		drawToolBoolParams(params)
+		drawToolTextParams(params)
+		drawToolParamButtons(s)
+	}
+	native.End()
+}
+
+func drawToolBoolParams(params app.ToolParams) {
+	for _, b := range params.Bools {
+		v := b.Get()
+		if native.Checkbox(b.Label, &v) {
+			b.Set(v)
+		}
+	}
+}
+
+func drawToolFloatParams(params app.ToolParams) {
+	for _, f := range params.Floats {
+		v := float32(f.Get())
+		if native.InputFloat(f.Label, &v) {
+			f.Set(float64(v))
+		}
+	}
+}
+
+func drawToolIntParams(params app.ToolParams) {
+	for _, n := range params.Ints {
+		v := int32(n.Get())
+		if native.InputInt(n.Label, &v) {
+			n.Set(int(v))
+		}
+	}
+}
+
+// drawToolTextParams renders the text params, seeding the shared buffer once when the
+// dialog opens so the user's typing persists across frames.
+func drawToolTextParams(params app.ToolParams) {
+	if len(params.Texts) == 0 {
+		toolText.open = false
+		return
+	}
+	tp := params.Texts[0]
+	if !toolText.open {
+		seedToolText(tp.Get())
+		toolText.open = true
+	}
+	if native.InputText(tp.Label, toolText.buf) {
+		tp.Set(string(bytes.TrimRight(toolText.buf, "\x00")))
+	}
+}
+
+// drawToolParamButtons draws OK/Cancel; OK is disabled until the tool is ready.
+func drawToolParamButtons(s *app.Session) {
+	native.BeginDisabled(!s.ActiveTool().Tool().CanCommit())
+	if native.Button("OK") {
+		_ = s.OK()
+	}
+	native.EndDisabled()
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelTool()
+	}
+}
+
+func seedToolText(text string) {
+	for i := range toolText.buf {
+		toolText.buf[i] = 0
+	}
+	copy(toolText.buf, text)
+}

--- a/implementation-plan/CONVENTIONS.md
+++ b/implementation-plan/CONVENTIONS.md
@@ -110,7 +110,10 @@ user-facing feature ships **all four** of these, mirroring Extrude (the referenc
 1. **Model** (`model/feature`): the `Definition → Add → Feature` triangle, `.obk`
    serialize round-trip, and unit tests.
 2. **Command & interaction** (`app/`): a `CommandDefinition` ribbon button registered
-   in `app/commands_standard.go` (`NewCommand(id,name,panel,…).WithTab("3D Model")
+   in `app/commands_standard.go`. Its **tab and panel placement MUST match the canonical
+   ribbon tree** in
+   [`architecture/mapping/inventor-ribbon-structure.md`](../architecture/mapping/inventor-ribbon-structure.md)
+   — do not invent tabs/panels. (`NewCommand(id,name,panel,…).WithTab("3D Model")
    .WithIcon(…).WithTooltip(…)`), plus an interactive `Tool` (`app/<feat>_tool.go` —
    `Start`/`Pick`/`Set*`/`Commit`) and/or a settings window that edits the feature's
    inputs and writes them through to the definition.
@@ -124,6 +127,27 @@ user-facing feature ships **all four** of these, mirroring Extrude (the referenc
 
 A feature whose only entry point is a Go API call, with no ribbon button, no property
 window, and no UI-driven test, is **incomplete** regardless of model-layer coverage.
+
+## Status model — three axes, not one ✅ (MANDATORY for trackers)
+
+A single ✅ has historically hidden two failure modes: a feature with a complete model
+layer but no UI, and a feature whose `Recompute` resolves its inputs then returns the
+body **unchanged** (`ErrDeferred`/`NotYetImplemented`) — i.e. produces no geometry. To
+keep PROGRESS.md and milestone tables honest, every PBI is graded on **three
+independent axes**:
+
+- **M (Model):** the `Definition → Add → Feature` triangle + `.obk` serialize
+  round-trip + model unit tests are green.
+- **G (Geometry):** the feature produces **real geometry**. An `ErrDeferred` or
+  `NotYetImplemented` code path on the feature's primary case means **G ⬜**, no matter
+  how complete M is. (Passthrough-with-Warning is *not* G-done.)
+- **U (UI + e2e):** ribbon command + dialog/property window + preferences (where
+  Inventor exposes them) + an end-to-end test driving the UI to validated geometry,
+  per the Definition of Done above.
+
+Write the grade as `M✅ G✅ U⬜`. A PBI is **Done** only when **all three** are ✅;
+anything else is 🟦 and must show the per-axis flags so the gap is visible. A purely
+infrastructural PBI (no geometry, no UI) is exempt from G/U and says so explicitly.
 
 ## Naming (mirror the contract library)
 

--- a/implementation-plan/DEFERRALS.md
+++ b/implementation-plan/DEFERRALS.md
@@ -1,0 +1,83 @@
+# Deferral Ledger
+
+_Generated 2026-06-04 during the audit (see [REPORT.md](../../REPORT.md) §6). This is the
+canonical, code-derived list of where "done" means "scaffolded": every
+`NotYetImplemented`, every `ErrDeferred` passthrough, and the in-code `follow-up` /
+`phase B/C/D` / `deferred` comments in non-test source._
+
+How to read the **G-impact** column (per CONVENTIONS.md "Status model"):
+
+- **G⬜** — the feature's primary case produces **no geometry** here (hard blocker on its
+  Geometry axis).
+- **partial** — the common case works; this is a missing sub-case / quality refinement.
+- **n/a** — infrastructural (bootstrap) or a comment only.
+
+Regenerate with:
+```
+grep -rn 'NotYetImplemented\|ErrDeferred' --include=*.go . | grep -v _test.go
+grep -rni 'follow-up\|phase [bcd]\|later refinement\|deferred' --include=*.go . | grep -v _test.go
+```
+
+---
+
+## A. Hard `NotYetImplemented` (returns an error — feature is unbuilt)
+
+| Site | What is missing | Feature / PBI | G-impact |
+|------|-----------------|---------------|:--------:|
+| ~~`model/feature/sketched_features.go:238`~~ | **Rib** generation **RESOLVED 2026-06-04** — thickened-band wall extruded by a finite Depth + combine; tested (wall vol=8, L-path solid). **Full DoD 2026-06-04**: `RibFeatures.Add`, serialize round-trip, `RibTool` + `Create.Rib` ribbon + generic dialog + e2e. "To-next" part-bounding is the only refinement. | RibFeature / PBI-096 | ~~G⬜~~ → **G✅ U✅** |
+| `kernel/ops/validate.go:67` | **Tolerant Sew** (stitch near-coincident topology) | PBI-084 | **G⬜** (stitch only welds exact-coincident) |
+| `kernel/ops/surface_edit.go` | **Trim** — **multi-face DONE 2026-06-05 (K5)** (clip each planar face + weld; folded sheets/quilts work). Remaining: trimming a body with any **curved** face (NURBS surface–surface trim). | TrimFeature / PBI-111 | planar (single+multi-face) ✅; curved ⬜ |
+| `kernel/ops/surface_edit.go` | **Surface offset** — **multi-face (coplanar) DONE 2026-06-05 (K5)** (translate each face + weld). Remaining: **folded** multi-face (intersect adjacent offset planes) and **curved** faces (parallel NURBS surface). | SurfaceOffsetFeature / PBI-112 | planar single + coplanar-multi ✅; folded/curved ⬜ |
+| ~~`kernel/geom/transform.go:36,60`~~ | ~~Transform of NURBS curves/surfaces~~ **RESOLVED 2026-06-04 (K2)** — control-point transform, exact for affine; weights/knots/degree invariant. Other exotic curve types (Polyline/EllipticalArc/Helix3d) still NYI. | body transform / pattern / mirror / move (PBI-190/191) | ~~G⬜~~ → **G✅ for NURBS** |
+| `cmd/oblikovati/main.go:19` | windowed runtime bootstrap via this entry | PBI-001 | n/a (the `head` binary is the real entry) |
+
+## B. `ErrDeferred` passthrough (inputs resolve, body returned **unchanged**)
+
+These read as health **Warning**, not Sick, so they look "ok" in the tree but change
+no geometry.
+
+| Site | Feature | PBI | G-impact |
+|------|---------|-----|:--------:|
+| `model/feature/dressup.go:134` | Dress-up deferred path (the deferred dress-up features that route through here) | M09 F02/F03 | **G⬜** for any dress-up still on this path |
+| `model/feature/hole_boss.go` (defers boss) | **Boss** | PBI-103 | **G⬜** |
+| `model/feature/surface_edit.go` (ExtendFeature) | **Extend** — **planar DONE 2026-06-05 (K5)**: `ops.ExtendByEdge` grows a planar surface along a boundary edge; `ExtendTool` + `Surface.Extend` ribbon. Remaining: multi-face / curved-surface extend (NURBS). | PBI-111 | ~~G⬜~~ → **G✅ (planar)** |
+| `model/feature/surface.go:156` | **RuledTangent** / **RuledPerpendicular** ruled-surface modes | PBI-109 | **G⬜** for those modes (RuledNormal works) |
+| `model/feature/surface_edit.go:103` | direct surface edit deferred path | M10 | **G⬜** for that op |
+| `model/feature/modify.go:81` | **Split** — Split Solid / Trim Solid by a work plane **DONE 2026-06-05** (`SplitSolidFeature` + `ops.SplitSolidByPlane` + `SplitTool` + ribbon + serialize + e2e). The deferred `SplitFeature` (face-edit shape) remains as **Split Face** (split faces by a plane/curve), still G⬜. | PBI-106 | ~~G⬜~~ → **G✅ (solid)**; Split Face still ⬜ |
+
+## C. Kernel-phase / quality follow-ups (common case works; refinement pending)
+
+| Site | Refinement deferred | Phase |
+|------|---------------------|:-----:|
+| `kernel/ops/fillet.go:20` | fillet edge-chains, fillet-fillet corner blends, concave edges | B |
+| `kernel/ops/thicken.go:16` | thicken of creased/curved sheets | follow-up |
+| `kernel/ops/shell.go:16` | outward / both-sides shell (inward only today) | follow-up |
+| `kernel/ops/move_face.go:15` | move large enough to collapse/invert a face (retopology) | follow-up |
+| `kernel/ops/tessellate_trim.go:23` | general constrained triangulation of trim regions (iso-rectangle bands + **full periodic bands** [K1b 2b, done 2026-06-04] + small boundary patches now work; holes / arbitrary non-rectangular trims remain) | follow-up |
+| `kernel/ops/stitch.go:25` | tolerant (gap-band) stitching | D |
+| `kernel/brep/boolean.go:39` | booleans where operands **share a face plane** the general way; **and (2026-06-05) PARTIAL PENETRATION / concave faceted-wall crossing** — the 2D arrangement only cuts a face when imprint segments close a loop *on it*, so a tool that pokes part-way in / crosses a re-entrant wall leaves dangling segments → overlap left un-cut → non-manifold / inverted normals. Tracked as **PBI-199**; repro = skipped fan e2e. Dead-end: post-stitch orientation-repair does NOT fix it. | follow-up / **PBI-199** |
+| `kernel/brep/boolean_stitch.go` | **face reference-key survival through a boolean** — **DONE 2026-06-04 (K1a)**: result faces carry their source face's lineage (single-piece → exact key; split → child token); tested. *Remaining:* edge/vertex key survival; cross-operand collision when operands share lineage. | follow-up (edges) |
+| `model/feature/mold.go:17` | mold part-shaped pocket + silhouette parting (general solid-solid boolean) | C |
+| `model/feature/extent.go:41`, `extrude_extent.go:151` | angled/curved extrude trims ("to-next/to-face" curved) | C |
+| `model/feature/sweep_loft.go:18` | guide rails, centerline twist, swept *surfaces* | refinement |
+| `model/feature/sketched_features.go:19` | curved profile edges, exact analytic/NURBS swept surfaces (revolve/coil) | refinement |
+| ~~`model/feature/patterns.go:22`~~ | source-only (vs whole-solid) pattern replication + per-feature provenance — **DONE 2026-06-05 (PBI-191)**: `ToolFeature`/`OperationalFeature` + `Input.SourceTool`; a pattern re-applies the source's cut/join per occurrence (one body, N holes/blades) instead of N copies; all boolean tool features incl. Hole carry the contract; a deferred source (Boss) replicates nothing. | ~~follow-up~~ → **done** |
+| `model/feature/swept.go` | ~~twisted/lofted **warped non-planar quad** side faces broke the planar boolean~~ — **DONE 2026-06-05 (PBI-174)**: `sideQuad`/`quadPlanar` triangulate a non-coplanar side quad so `sweptSolid` stays planar-faceted. | done |
+| `model/sketch/edit_trim.go:26` | trim/extend against **curves** (lines only today) | follow-up |
+| `model/sketch/curvesample_spline*.go` | true NURBS spline fidelity (polyline approximation today) | kernel |
+| `model/sketch/path.go:30` | sampling **arc** path segments into the rail polyline | refinement |
+| `model/sketch/inference.go:24` | inference **glyph overlay** in the UI | UI |
+
+---
+
+## Summary
+
+- **Functional no-ops (G⬜) marked otherwise-done:** Boss, Split Face,
+  RuledTangent/Perpendicular, tolerant Sew, deferred dress-up/surface-edit paths.
+  (NURBS body-transform **resolved 2026-06-04, K2**.) **These should not carry a ✅
+  until their G axis is green.**
+- **Highest-risk quality follow-up:** reference-key survival through a boolean
+  (`kernel/brep/boolean_stitch.go:17`) — picks on boolean output (Hole/Combine/Cut)
+  don't rebind after an edit, undermining parametric robustness.
+- Each row above should become a tracked issue and be linked from the owning PBI's
+  **G** axis in PROGRESS.md.

--- a/implementation-plan/M19-materials-appearances/F01-object-model-catalog/PBI-192-asset-object-model.md
+++ b/implementation-plan/M19-materials-appearances/F01-object-model-catalog/PBI-192-asset-object-model.md
@@ -1,0 +1,28 @@
+# PBI-192 — Appearance/Material asset object model + built-in catalog
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03). Grade: **M✅ · G n/a · U n/a**.
+
+## Goal
+
+Typed PBR `Appearance` and physical `Material` assets with a built-in catalog.
+
+## Scope / work
+
+- `Appearance`: albedo, metallic, roughness, emissive, opacity, source, id, name.
+- `Material`: density, `Mechanical`/`Thermal`/`Electrical`, `IsotropyClass` +
+  `AnisotropicElastic`, `AppearanceID`, source, id, name.
+- Built-in catalog seeded at init (`builtin.go`, embedded `catalog/`).
+
+## API contracts
+
+`api/contract.Appearance`, `api/contract.Material`; `api/types.{AssetSource,Mechanical,
+Thermal,Electrical,IsotropyClass,AnisotropicElastic,Rgba}`.
+
+## Acceptance criteria
+
+- `model/material` types satisfy the contracts (compile-time assertions).
+- Built-in catalog loads; `catalog_test.go` green; colors parse (`builtin.go`).
+
+## Depends on
+
+ADR-0022, ADR-0024, ADR-0025.

--- a/implementation-plan/M19-materials-appearances/F01-object-model-catalog/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F01-object-model-catalog/_feature.md
@@ -1,0 +1,25 @@
+# M19 · F01 — Appearance & Material object model + built-in catalog
+
+> **Backfilled 2026-06-04 from shipped code** (this milestone was implemented before its
+> feature/PBI files existed — see REPORT.md D-03). Grades reflect actual code state.
+
+## Scope (in)
+
+Typed `Appearance` (metallic-roughness PBR: albedo/metallic/roughness/emissive/opacity)
+and `Material` (density + mechanical/thermal/electrical, isotropy class + anisotropic
+elastic constants, → appearance by id) asset objects, plus a built-in catalog seeded at
+init.
+
+## Scope (out)
+
+Image-texture maps; per-document scoping (F02); rendering (F04).
+
+## Code (as built)
+
+`model/material/{appearance.go,material.go,catalog.go,catalog/,builtin.go}`.
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-192](PBI-192-asset-object-model.md) | Appearance/Material assets + built-in catalog | M✅ G n/a U n/a |

--- a/implementation-plan/M19-materials-appearances/F02-scope-persistence/PBI-193-scope-and-persistence.md
+++ b/implementation-plan/M19-materials-appearances/F02-scope-persistence/PBI-193-scope-and-persistence.md
@@ -1,0 +1,23 @@
+# PBI-193 — Asset scope tiers + document embedding + persistence
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03). Grade: **M✅ · G n/a · U n/a**.
+
+## Goal
+
+Built-in / project-library / document-embedded asset tiers that persist and share.
+
+## Scope / work
+
+- `AssetSet`/`Library` containers; duplicate-and-edit custom assets.
+- `.obk` round-trip of embedded assets (`recipe.go`); project DesignData library
+  shared across a project's documents (`store.go`).
+
+## Acceptance criteria
+
+- Custom appearance survives `.obk` save→reopen (`recipe_test.go`).
+- A second document resolves a project-library asset (`library_test.go`,
+  `store_test.go`).
+
+## Depends on
+
+PBI-192, ADR-0020 (.obk format).

--- a/implementation-plan/M19-materials-appearances/F02-scope-persistence/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F02-scope-persistence/_feature.md
@@ -1,0 +1,19 @@
+# M19 · F02 — Scope tiers: project library + document embedding + persistence
+
+> **Backfilled 2026-06-04 from shipped code.** See REPORT.md D-03.
+
+## Scope (in)
+
+Asset `Source` tiers (built-in / project-library / document-embedded); duplicate-and-edit
+custom assets; `.obk` round-trip of embedded assets; project DesignData library sharing
+across documents.
+
+## Code (as built)
+
+`model/material/{assetset.go,library.go,store.go,recipe.go}` (+ `*_test.go`).
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-193](PBI-193-scope-and-persistence.md) | Asset scope tiers + embedding + persistence | M✅ G n/a U n/a |

--- a/implementation-plan/M19-materials-appearances/F03-assignment-override/PBI-194-assignment-override-chain.md
+++ b/implementation-plan/M19-materials-appearances/F03-assignment-override/PBI-194-assignment-override-chain.md
@@ -1,0 +1,21 @@
+# PBI-194 — Assignment store + override chain by reference key
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03). Grade: **M✅ · G n/a · U via F07**.
+
+## Goal
+
+Assign material/appearance to a body, surviving recompute, with a defined override chain.
+
+## Scope / work
+
+- Assignment store keyed by `identity.RefKey` (survives recompute/reopen).
+- Override chain: explicit body appearance > material's appearance > default.
+
+## Acceptance criteria
+
+- Assignment re-binds after recompute (`assignment_test.go`).
+- Override precedence resolves to the explicit body appearance when set.
+
+## Depends on
+
+PBI-192, M03 reference keys.

--- a/implementation-plan/M19-materials-appearances/F03-assignment-override/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F03-assignment-override/_feature.md
@@ -1,0 +1,19 @@
+# M19 · F03 — Assignment & override chain (by reference key)
+
+> **Backfilled 2026-06-04 from shipped code.** See REPORT.md D-03.
+
+## Scope (in)
+
+Assign material/appearance to a body (and the appearance-source override chain:
+material's appearance vs explicit body appearance) keyed by **reference key** so the
+assignment survives recompute.
+
+## Code (as built)
+
+`model/material/assignment.go` (+ `assignment_test.go`).
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-194](PBI-194-assignment-override-chain.md) | Assignment store + override chain by ref key | M✅ G n/a U(see F07) |

--- a/implementation-plan/M19-materials-appearances/F04-renderer-pbr/PBI-195-renderer-pbr-resolution.md
+++ b/implementation-plan/M19-materials-appearances/F04-renderer-pbr/PBI-195-renderer-pbr-resolution.md
@@ -1,0 +1,22 @@
+# PBI-195 — Appearance → draw-list PBR surface resolution
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03). Grade: **M✅ · G✅ · U via F07**.
+
+## Goal
+
+The viewport shows a body's assigned appearance and recolors live on reassignment.
+
+## Scope / work
+
+- Draw-list items carry resolved PBR surface values (`renderer/drawlist.go`).
+- `app/material_ops.go` resolves the effective appearance per body into the frame.
+- Solid metallic-roughness only (no GGX/IBL/textures — out of scope, → M23/later).
+
+## Acceptance criteria
+
+- Assigning an appearance changes the draw item's surface values (metamorphic test on
+  the null backend).
+
+## Depends on
+
+PBI-194, M05 client graphics, ADR-0022.

--- a/implementation-plan/M19-materials-appearances/F04-renderer-pbr/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F04-renderer-pbr/_feature.md
@@ -1,0 +1,23 @@
+# M19 · F04 — Renderer PBR surface resolution
+
+> **Backfilled 2026-06-04 from shipped code.** See REPORT.md D-03.
+
+## Scope (in)
+
+Resolve a body's effective appearance → PBR surface values the draw list carries, so the
+viewport recolors live on assignment. Solid (non-textured) metallic-roughness only.
+
+## Scope (out)
+
+GGX/IBL shading + image textures (M23 / later); per-face override *rendering* (mesh split).
+
+## Code (as built)
+
+`renderer/drawlist.go` (surface fields), `app/material_ops.go` (resolution into the
+session draw list).
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-195](PBI-195-renderer-pbr-resolution.md) | Appearance → draw-list PBR surface | M✅ G✅ U(viewport, see F07) |

--- a/implementation-plan/M19-materials-appearances/F05-physical-properties/PBI-196-physical-properties.md
+++ b/implementation-plan/M19-materials-appearances/F05-physical-properties/PBI-196-physical-properties.md
@@ -1,0 +1,22 @@
+# PBI-196 — Mass / physical properties from assigned material
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03). Grade: **M✅ · G✅ · U via F07**.
+
+## Goal
+
+Read mass/volume/area/centroid for a part using the assigned material's density.
+
+## Scope / work
+
+- `kernel/ops/massprops.go` computes volume/centroid/area from the B-rep; mass =
+  density × volume.
+- Also the M18·F01 enabler (cross-referenced; this is where mass properties live).
+
+## Acceptance criteria
+
+- Known solid → analytic volume/centroid within tolerance.
+- Mass tracks the assigned material density.
+
+## Depends on
+
+PBI-194, M07 B-rep. **Cross-ref:** M18·F01 (PBI-165 mass-properties).

--- a/implementation-plan/M19-materials-appearances/F05-physical-properties/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F05-physical-properties/_feature.md
@@ -1,0 +1,19 @@
+# M19 · F05 — Mass / physical properties
+
+> **Backfilled 2026-06-04 from shipped code.** See REPORT.md D-03.
+
+## Scope (in)
+
+Mass / volume / surface-area / centroid readout for a part, using the assigned material's
+density. Shared with M18 (analysis) which consumes the same property data.
+
+## Code (as built)
+
+`kernel/ops/massprops.go`; consumed via `app/materials.go` readout. (This is also the
+M18·F01 mass-properties enabler — cross-referenced there.)
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-196](PBI-196-physical-properties.md) | Mass properties from assigned material | M✅ G✅ U(readout, see F07) |

--- a/implementation-plan/M19-materials-appearances/F06-public-api/PBI-197-public-api.md
+++ b/implementation-plan/M19-materials-appearances/F06-public-api/PBI-197-public-api.md
@@ -1,0 +1,26 @@
+# PBI-197 — Materials/appearances public API (wire + client + router)
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03). Grade: **M✅ · G n/a · U n/a**.
+
+## Goal
+
+Add-ins can list/get/create/update appearances & materials, assign, and read physics.
+
+## API contracts
+
+- `api/wire`: `appearances.{list,get,create,update}`, `materials.{list,get,create,update}`,
+  `model.{assignMaterial,assignAppearance,physicalProperties}` (+ `AssetRefArgs` DTO).
+- `api/contract.{Appearance,Material}`; typed `api/client` group.
+
+## Scope / work
+
+`addin/router` handlers keyed on the wire constants; dogfood client suite.
+
+## Acceptance criteria
+
+- Dogfood: create appearance → assign → physicalProperties returns mass (router test).
+- `var _ contract.X` assertions hold.
+
+## Depends on
+
+PBI-192..196, ADR-0018.

--- a/implementation-plan/M19-materials-appearances/F06-public-api/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F06-public-api/_feature.md
@@ -1,0 +1,21 @@
+# M19 · F06 — Public API: appearances / materials / assign / physical-properties
+
+> **Backfilled 2026-06-04 from shipped code.** See REPORT.md D-03.
+
+## Scope (in)
+
+`/api` surface for add-ins: list/get/create/update appearances & materials, assign to
+model, read physical properties.
+
+## Code (as built)
+
+- `api/contract/{appearance.go,material.go}` (typed interfaces).
+- `api/wire`: `appearances.{list,get,create,update}`, `materials.{list,get,create,update}`,
+  `model.{assignMaterial,assignAppearance,physicalProperties}`.
+- `addin/router` handlers + `api/client` typed group.
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-197](PBI-197-public-api.md) | Materials/appearances wire + client + router | M✅ G n/a U n/a |

--- a/implementation-plan/M19-materials-appearances/F07-materials-ui/PBI-198-materials-ui.md
+++ b/implementation-plan/M19-materials-appearances/F07-materials-ui/PBI-198-materials-ui.md
@@ -1,0 +1,27 @@
+# PBI-198 — Materials window (browser, editors, assign, readout)
+
+> **Backfilled from shipped code 2026-06-04** (REPORT.md D-03).
+> Grade: **M✅ · U🟦 (e2e unverified — see REPORT.md §8)**.
+
+## Goal
+
+A user can browse/edit/assign materials & appearances in the head and see the result.
+
+## Scope / work
+
+- `head/ui/materials_window.go`, `appearance_editor.go`, `appearance_tab.go`,
+  `preferences_window.go`; `app/materials.go` session bridges.
+- Assign-to-selection; appearance editor (albedo/metallic/roughness/emissive/opacity);
+  physical-properties readout.
+
+## Acceptance criteria (DoD)
+
+- End-to-end: open Materials window → duplicate appearance → edit albedo → assign to
+  selection → **viewport recolors live** → read mass (the milestone exit criterion).
+- **Gap:** `head` tests are excluded from the `CGO_ENABLED=0` CI run (REPORT.md §8), so
+  the e2e assertion is **not currently verified in CI**. Add a head-test gate before
+  grading **U✅**.
+
+## Depends on
+
+PBI-195..197, M05 UI shell, ADR-0021.

--- a/implementation-plan/M19-materials-appearances/F07-materials-ui/_feature.md
+++ b/implementation-plan/M19-materials-appearances/F07-materials-ui/_feature.md
@@ -1,0 +1,27 @@
+# M19 · F07 — UI: Materials window (browser, editors, assign, readout)
+
+> **Backfilled 2026-06-04 from shipped code.** See REPORT.md D-03.
+
+## Scope (in)
+
+The head Materials/Appearance UI: asset browser, appearance editor (albedo/metallic/
+roughness/…), material editor, assign-to-selection, physical-properties readout, and the
+Preferences integration.
+
+## Code (as built)
+
+`head/ui/{materials_window.go,appearance_editor.go,appearance_tab.go,preferences_window.go}`
+(+ `materials_window_test.go`), `app/materials.go` session bridges.
+
+## DoD note
+
+Per CONVENTIONS "Definition of Done", verify there is an **end-to-end test** driving
+assign → live viewport recolor → readout (the milestone's exit criterion). `head` tests
+are **not run in the `CGO_ENABLED=0` CI suite** — see REPORT.md §8 (recommend a head-test
+CI gate before grading U✅).
+
+## PBIs
+
+| PBI | Title | Grade |
+|-----|-------|-------|
+| [PBI-198](PBI-198-materials-ui.md) | Materials window + editors + assign + readout | M✅ U🟦 (e2e unverified, see §8) |

--- a/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-171-boolean-face-split.md
+++ b/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-171-boolean-face-split.md
@@ -48,3 +48,46 @@ The single biggest unblocker in M20 — Cut, Split, Hole, Emboss, and most
 sheet-metal/plastic features reduce to this. Start with the axis-aligned/planar
 case (exact predicates), generalize to arbitrary planar faces, leave curved–curved
 intersection to the NURBS follow-up (F02).
+
+## Findings 2026-06-05 — robustness gaps (the planar boolean works, but not for every overlap)
+
+The four-stage planar pipeline (imprint → split → classify → stitch) is implemented and
+correct for clean overlaps, but a deep modelling session (a parametric fan with lofted blades)
+exposed two distinct robustness gaps that produce **non-manifold / inverted-normal** results.
+Both are reproduced and isolated; see `kernel/brep/` and the skipped fan e2e in
+`oblikovati-mcp-bridge/bridge/e2e_fan_validate_test.go` (the acceptance spec for the fix).
+
+1. **Partial penetration is not cut (the core gap).** `splitFace` runs the 2D arrangement
+   (`Arrange`/`traceCycles`) which only subdivides a face when the imprint segments form a
+   **closed loop** on it. When a tool pokes **part-way** into a face — or crosses a **concave
+   faceted wall** (e.g. a blade spanning out through a 32-gon bore) — the per-face-pair imprint
+   produces **dangling/partial segments** whose loop closes only *across* adjacent face
+   boundaries. `traceCycles` drops the dangling edges → the face is never split → the
+   overlapping material is not removed → the tool stitches as a coincident shell (edges used by
+   3–4 faces, or a manifold-but-mis-oriented result). Instrumented evidence: a fan blade join
+   had `imprintSegs=86` but only ~13 face subdivisions. **The fix must assemble imprint segments
+   into closed loops across face boundaries and handle T-vertices / dangling edges in the
+   arrangement** — see PBI-199.
+
+2. **Coincident / near-tangent faces** (the documented "coplanar follow-up"). `boolean_coplanar.go`
+   handles area-coincident coplanar faces, but a tool face that is *coincident with* or *grazes
+   near-tangent to* the target (especially a faceted curved wall) is not robustly resolved.
+
+Dead-end recorded so it is **not retried**: a post-stitch *orientation-repair* pass (flood-fill
+orientation across shared edges, flip the minority) does NOT fix the inverted normals — the
+mis-orientation is a symptom of the un-cut overlap (1), not a cleanly re-orientable manifold, so
+flood-fill cannot resolve it. The fix must act at the imprint/arrangement stage, not on the output.
+
+Interim safety net (unchanged): `ops.booleanGeneral` already falls back to triangle-soup BSP CSG
+when `brep.Boolean` returns `ErrNonPlanar`; a guarded "CSG-repairs-a-non-manifold-planar-result"
+fallback was prototyped but rejected (turns clean B-reps into heavy triangle soup and still
+degrades under pattern chaining).
+
+### Related fix that landed (precondition for this boolean)
+
+Twisted **lofts/sweeps/revolves** were emitting **warped (non-planar) ruled quad** side faces as
+single "planar" faces, so the boolean imprinted against an *approximating* plane and segments
+landed offset from the true edges (~0.875·twist; even 0.001 rad broke the loop closure). FIXED in
+`model/feature/swept.go` (`sideQuad`/`quadPlanar` triangulate a non-coplanar side quad) — see
+PBI-174. This restores the planar-faceted invariant the boolean requires; it is a separate fix
+from the arrangement gap above.

--- a/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-199-boolean-partial-penetration.md
+++ b/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/PBI-199-boolean-partial-penetration.md
@@ -1,0 +1,73 @@
+---
+milestone: M20
+feature: F01
+pbi: PBI-199
+title: Boolean robustness — partial penetration & concave-wall crossing
+status: planned
+estimate: XL
+---
+
+# PBI-199 — Boolean robustness: partial penetration & concave-wall crossing
+
+**Milestone:** M20 Feature Completion & Geometry Parity  ·  **Feature:** F01 Intersecting Booleans
+
+## Goal
+
+Make the planar B-rep boolean (`kernel/brep`) resolve **partial penetrations** and **concave
+faceted-wall crossings**, not just clean through-overlaps. Today such a union/cut produces a
+**non-manifold or inverted-normal** body because the 2D arrangement only cuts a face when the
+imprint segments close into a loop *on that face* — a tool that pokes part-way in, or crosses a
+re-entrant faceted wall, leaves dangling segments and the overlap is never removed. See
+PBI-171 "Findings 2026-06-05" for the full diagnosis.
+
+## Root cause (instrumented)
+
+- `imprint` is computed per **face pair** and clipped to each face's extent, so a tool's
+  footprint on a target face arrives as a **soup of open segments**; when the footprint loop
+  closes only *across* a face boundary (multi-facet crossing) or ends *inside* the face (partial
+  penetration), the segments dangle.
+- `Arrange` → `planarize` → `traceCycles` keeps only **closed cycles**; dangling edges are
+  dropped, so `splitFace` returns the face whole.
+- Evidence: a fan blade JOIN reported `imprintSegs=86`, `split=75`, `dropped=13`, `kept=62` =
+  inputs (no net split) → blade welded as a coincident shell (edges used by 3–4 faces).
+
+## Scope / work
+
+- **Assemble the imprint into closed loops** spanning multiple faces: chain the per-face-pair
+  segments end-to-end (welding shared endpoints), closing each loop against the target's own
+  face-boundary edges (insert **T-vertices** where a loop crosses a boundary).
+- **Split with dangling/T-vertex support** in the arrangement so a partial-penetration footprint
+  (open polyline closed by the face boundary) produces inside/outside regions.
+- Propagate split vertices to the neighbour face sharing each boundary edge (the stitch already
+  does this for through-cuts via `splitRingTJunctions`; extend to the partial case).
+- Harden the **coincident / near-tangent** face handling for faceted curved walls (the
+  "coplanar follow-up" in `boolean_coplanar.go`).
+- Keep the BSP-CSG fallback as the safety net for anything still unhandled.
+
+## Acceptance criteria
+
+- Unskip and pass `oblikovati-mcp-bridge/bridge/e2e_fan_validate_test.go`:
+  `TestBladeJoinBooleanIsTheDefect` (minimal: valid body + valid blade crossing a concave bore
+  wall → JOIN is a valid manifold solid) and `TestFanBodyStaysManifold` (full fan valid after
+  every feature, incl. the 7-blade circular pattern).
+- A bar that pokes part-way into a face (does not exit the opposite side) → Cut/Join is a valid
+  manifold solid with the correct volume.
+- A blade that crosses a concave faceted cylindrical wall → valid manifold, consistent normals.
+- No regression on the existing planar-boolean tests (`kernel/brep`, `kernel/ops`).
+
+## Do NOT (recorded dead-end)
+
+- A post-stitch orientation-repair pass (flood-fill + flip the minority) does **not** fix this —
+  the mis-orientation is a symptom of the un-cut overlap, not a re-orientable manifold. Fix the
+  imprint/arrangement, not the output.
+
+## Depends on
+
+PBI-171 (the planar pipeline). Related: the warped-quad precondition fix landed in PBI-174.
+
+## Notes
+
+This is the genuinely large piece behind the "deformed mesh / inverted normals" a user hit with
+lofted-blade unions. The warped-quad triangulation (PBI-174) removed the *gross* deformity (the
+twisted blade itself was non-planar); this PBI removes the *localised* deformity where the tool
+crosses a concave faceted wall.

--- a/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/_feature.md
+++ b/implementation-plan/M20-feature-completion-geometry/F01-intersecting-booleans/_feature.md
@@ -38,3 +38,13 @@ M07 (`kernel/ops`, `math/predicate`).
 |-----|-------|
 | [PBI-171](PBI-171-boolean-face-split.md) | Face-splitting solid/solid boolean |
 | [PBI-172](PBI-172-cut-split-combine-geometry.md) | Cut / Split / Combine real geometry |
+| [PBI-199](PBI-199-boolean-partial-penetration.md) | Boolean robustness — partial penetration & concave-wall crossing |
+
+## Known robustness gap (2026-06-05)
+
+The pipeline is correct for **clean through-overlaps** but not for **partial penetrations** or
+**concave faceted-wall crossings** — the 2D arrangement only cuts a face when imprint segments
+close a loop *on it*, so a tool that pokes part-way in / crosses a re-entrant wall leaves
+dangling segments and the overlap is left un-cut (non-manifold / inverted normals). Tracked as
+PBI-199; reproduced by the skipped fan e2e. A precondition (twisted-loft warped quads) was fixed
+in PBI-174.

--- a/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/PBI-174-sweep-loft-nurbs.md
+++ b/implementation-plan/M20-feature-completion-geometry/F02-swept-surface-generation/PBI-174-sweep-loft-nurbs.md
@@ -39,3 +39,23 @@ M07, M08
 Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
 `Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
 `addin/router` handler, `.obk` round-trip, and executable tests.
+
+## Fix 2026-06-05 — twisted sides must be planar-faceted (or booleans break)
+
+`sweptSolid` connects consecutive sections with **quad** side faces. When the sections are
+**twisted/rotated** relative to each other (a lofted fan blade, a coil, a swept profile that
+rotates), that quad is a **warped ruled surface — non-planar**. Emitted as a single face, the
+cage→B-rep converter fits it to an **approximating plane**, which silently breaks the planar
+boolean: it imprints against the approximate plane, so the intersection segments land **offset
+from the body's true edges** (offset ≈ 0.875·twist — even a **0.001 rad** twist was enough), the
+imprint loop fails to close, the face is not split, and a partial-penetration union goes
+**non-manifold (deformed mesh / inverted normals)**.
+
+**Fixed** in `model/feature/swept.go`: `sideQuad`/`quadPlanar` split a side quad into two
+**exact-planar triangles** when its four corners are not coplanar (tol 1e-8, below the
+arrangement's 1e-7 weld grid); planar (untwisted) quads stay single faces for a low face count.
+This restores the **planar-faceted invariant** every consumer of `sweptSolid`
+(revolve/sweep/loft/coil/rib) relies on. Regression:
+`model/feature/blade_twist_min_test.go::TestTwistedLoftUnionStaysManifold` (a twisted blade
+unioned into a hub is valid/manifold at every twist 0 → 0.3 rad). This is the *precondition* for
+the boolean robustness work; the remaining concave-wall-crossing deformity is **PBI-199**.

--- a/implementation-plan/M20-feature-completion-geometry/F12-body-transform/PBI-191-pattern-mirror-geometry.md
+++ b/implementation-plan/M20-feature-completion-geometry/F12-body-transform/PBI-191-pattern-mirror-geometry.md
@@ -39,3 +39,25 @@ M07
 Follows the canonical feature pattern set by Extrude (M08·PBI-092): full
 `Definition → Add → Feature(+Proxy)` triangle, `/api` `wire`+`client`+`contract`,
 `addin/router` handler, `.obk` round-trip, and executable tests.
+
+## Fix 2026-06-05 — pattern replicates the source feature's TOOL, not the whole body
+
+A pattern/mirror must re-apply the **source feature's own contribution** at each occurrence, not
+copy the whole running solid. Copying the body split a patterned cut/join into **N separate
+bodies** (a patterned hole gave N solids instead of one body with N holes; a patterned lofted
+blade gave 7 bodies, not one fan). Landed:
+
+- `feature.ToolFeature` / `OperationalFeature` (`model/feature/feature.go`): a boolean feature
+  exposes its `Operation()` (Cut/Join/Intersect) and, where it builds a discrete prism/sweep
+  solid, its `ToolBody()`. The engine's `Input.SourceTool` resolver
+  (`engine.go::sourceTool`) prefers the cached tool, else derives the before/after **delta**
+  (`sourceDelta`); `nonEmpty` treats an empty difference as "no contribution".
+- Pattern replication (`patterns.go::replicate`/`replicateTool`): for a boolean source it
+  transforms the source tool per occurrence and re-applies the **same boolean** against the
+  running result (one body, N holes/bosses); a boolean source whose tool cannot be recovered
+  (a **deferred** feature, e.g. Boss) replicates **nothing** rather than duplicating the body.
+- Coverage: **all** boolean tool features implement the contract — Extrude, Revolve, Coil, Rib,
+  Emboss, Loft, Sweep (ToolBody) and **Hole** (caches its drill cylinder); **Boss** is
+  `OperationalFeature` only (geometry still deferred). Pinned by `toolfeature_test.go`,
+  `patterns_test.go` (`TestPatternOfCutKeepsOneBody`/`TestPatternOfJoinMergesIntoOneBody`),
+  `hole_boss_test.go::TestPatternOfHoleCutsEachOccurrence`.

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -3,6 +3,13 @@
 Live tracker for building Oblikovati against [the roadmap](README.md). Updated as
 each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (green in CI).
 
+> **⚠ Audited 2026-06-04 (see [REPORT.md](../../REPORT.md)).** The milestone table below
+> was reconciled against the actual code. It had been wrong in both directions —
+> under-reporting shipped work (M16/M18/M19/M23) and over-stating completion against the
+> Definition of Done (M05/M09/M10/M21). Per CONVENTIONS.md "Status model", a feature is
+> **Done** only when **Model + Geometry + UI/e2e** are all green; ✅ here now means all
+> three, 🟦 means partial. Several rows previously ✅ are model-complete only.
+
 - **Code root:** `/source` (Go module `github.com/Oblikovati/oblikovati`, go 1.22).
 - **"Done" means:** acceptance criteria green via `make ci` (build + vet + lint +
   `CGO_ENABLED=0 go test ./...` + race), per [CONVENTIONS.md](CONVENTIONS.md).
@@ -19,24 +26,25 @@ each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (
 | M02 | Units, Parameters & Expressions | ✅ | All 4 features done → `model/param` (units, expression engine, parameter model, dependency graph). |
 | M03 | Documents, Persistence & Identity | ✅ | All 6 features done → `model/doc` (Document/Workspace/refs/FileManager), `persistence` (.obk), `model/identity` (reference keys), `model/health`, `model/attr` (attributes + iProperties). |
 | M04 | Transactions, Undo & Events | ✅ | All 4 features done → `command` (undo/redo/transactions/checkpoints) + `event` (typed bus) + `model/doc` core event sets & `ChangeManager`. |
-| M05 | UI, Commands, Add-ins | ✅ | Headless logic (pure-Go, 93.7%): command + interaction/selection framework, **end-to-end Extrude via synthetic clicks → solid**, ribbon/browser models, add-in platform (**sample add-in → ribbon button → interactive command** = exit criterion), client/preview graphics + null backend. **cgo head DONE** (`source/head`, separate module): vendored Dear ImGui 1.92.8 + GLFW + **Vulkan 1.3** — Go drives the frame loop and ImGui chrome (menu/ribbon/browser from the live Session) + a **3D Vulkan viewport** (offscreen color+depth, lit-triangle/flat-line pipelines) rendering `renderer.DrawList` of the extruded box. Runs with **zero Vulkan validation errors**. ADR-0004/0005 honored. |
+| M05 | UI, Commands, Add-ins | 🟦 | **[audit: ✅→🟦 — framework done; DoD UI exists for only 14/44 feature types, see REPORT.md §5]** Headless logic (pure-Go, 93.7%): command + interaction/selection framework, **end-to-end Extrude via synthetic clicks → solid**, ribbon/browser models, add-in platform (**sample add-in → ribbon button → interactive command** = exit criterion), client/preview graphics + null backend. **cgo head DONE** (`source/head`, separate module): vendored Dear ImGui 1.92.8 + GLFW + **Vulkan 1.3** — Go drives the frame loop and ImGui chrome (menu/ribbon/browser from the live Session) + a **3D Vulkan viewport** (offscreen color+depth, lit-triangle/flat-line pipelines) rendering `renderer.DrawList` of the extruded box. Runs with **zero Vulkan validation errors**. ADR-0004/0005 honored. |
 | M06 | Sketching & Constraint Solver | ✅ | All 6 features → `model/sketch`: sketches, entities, geometric/dimensional/3D constraints, inference, Newton/LM solver + DOF, profiles & paths. **Headless first (M05/M16 deferred).** |
 | M07 | B-Rep Kernel & Topology | ✅ | All 4 features → `kernel/topo` + `math/predicate` + `kernel/ops` (tessellation/validation/Phase-A booleans) + `model/compdef` (PartComponentDefinition). General intersecting booleans + tolerant sew deferred to kernel phase C/D. |
 | M08 | Part: Sketched & Work Features | ✅ | All 4 features → `model/feature` (recompute engine, datums/UCS, extrude solid generator + sketched-feature defs, derived/base features). Revolve+sweep/loft/coil generation deferred to kernel phase A/B. |
-| M09 | Part: Dress-up & Pattern | ✅ | All 4 features → `model/feature` (dress-up, hole/boss, patterns/mirror, modify/direct). Combine real (Phase-A booleans); fillet/hole/face-edit geometry deferred (phase B/C) with reference-key input resolution + Warning/Sick health; pattern element bookkeeping real. |
-| M10 | Surfacing & Freeform | ✅ | All 4 features done → `model/feature` (patch/ruled/sculpt/stitch/knit; trim/surface-offset/mid-surface; **sub-D freeform**; **mesh import + mold core/cavity**) + `kernel/ops` (`Stitch`, `TrimByPlane`, `OffsetSurface`, `MidSurfaces`) + new **`kernel/subd`** (Catmull–Clark). |
+| M09 | Part: Dress-up & Pattern | 🟦 | **[audit: ✅→🟦 — dress-up geometry landed in M20, but patterns/mirror/combine/face-edits have NO ribbon/dialog UI (U⬜) and boss/split still defer geometry (G⬜); see REPORT.md §5/§6]** All 4 features → `model/feature` (dress-up, hole/boss, patterns/mirror, modify/direct). Combine real (Phase-A booleans); fillet/hole/face-edit geometry deferred (phase B/C) with reference-key input resolution + Warning/Sick health; pattern element bookkeeping real. |
+| M10 | Surfacing & Freeform | 🟦 | **[audit: ✅→🟦 — model layer done but ZERO ribbon/dialog UI (U⬜) for any surfacing feature, and several ops defer geometry (extend, ruled-tangent/perp, curved trim/offset = G⬜); see REPORT.md §5/§6]** All 4 features done → `model/feature` (patch/ruled/sculpt/stitch/knit; trim/surface-offset/mid-surface; **sub-D freeform**; **mesh import + mold core/cavity**) + `kernel/ops` (`Stitch`, `TrimByPlane`, `OffsetSurface`, `MidSurfaces`) + new **`kernel/subd`** (Catmull–Clark). |
 | M11 | Assembly & Instancing | ⬜ | |
 | M12 | Assembly Constraints/Joints | ⬜ | |
 | M13 | Sheet Metal | ⬜ | |
 | M14 | Drawing & Documentation | ⬜ | |
 | M15 | Design Automation | ⬜ | |
-| M16 | Visualization & Presentation | ⬜ | |
-| M17 | Interoperability & Translation | ⬜ | |
-| M18 | Analysis & Simulation | ⬜ | |
+| M16 | Visualization & Presentation | 🟦 | **[audit: ⬜→🟦]** Lighting/IBL/shadows shipped: `app/lighting.go`, `renderer/{environment,lighting,lighting_styles}.go`, `View.*` ribbon (HDR/shadows). Presentations/animation not started. |
+| M17 | Interoperability & Translation | ⬜ | Only ASCII-STL parse (in `model/feature/mesh.go`). No translator framework / STEP / IGES / DWG. |
+| M18 | Analysis & Simulation | 🟦 | **[audit: ⬜→🟦]** `kernel/ops/massprops.go` (mass properties) exists. Measure/interference/FEA/dynamic/tolerance not started. |
+| M19 | Materials & Appearances | 🟦 | **[audit: added — was absent from this table]** Real: `model/material`, `app/materials*.go`, head Materials/Appearance/Preferences windows. `_milestone.md` exists but **PBI files to backfill**. Image textures + GGX/IBL out of scope. |
 | M20 | Feature Completion & Geometry Parity | 🟦 | Consolidated drive of every remaining Inventor `*Feature` to real geometry: kernel enablers (intersecting booleans, swept surfaces, fillet, local face ops, body transform) + sheet-metal + plastic + misc model features. |
-| M23 | Renderer Display-Mode Parity & Realistic PBR | ⬜ | Brings the viewport to full Inventor `DisplayModeEnum` parity (PBIs 300–311): the public `DisplayMode` contract + Visual Style gallery (F01), a **software PBR** Realistic mode (GGX + IBL + tone mapping, no hardware RT — F02), real-time **viewport hidden-line** removal feeding modes 8707/8711/8712 (F03), and an **NPR framework** + the four stylized modes Monochrome/Watercolor/Illustration/Technical-Illustration (F04). See [ADR-0023](../architecture/decisions/ADR-0023-viewport-display-modes.md). |
-| M21 | Sketch2D Feature Completion (2D Parity) | ✅ | **All 11 features + every follow-up done** (PBIs 200–221). Full Inventor 2D-sketch parity (ex-DWG) over `/api`: entities (lines/circles/arcs/points, ellipse, **elliptical arc**, splines incl. **control/fixed/offset/equation curve**, rectangles, polygons, **straight+arc slots**, **fillet/chamfer**, offset, image, **fill region**, **text**, **project geometry**), full geometric constraints (incl. **ground/offset/pattern**) + dimensional constraints (incl. **offset/3-point-angle/ellipse-radius**), constraint-status/DOF + **AutoDimension**, move/rotate/copy/mirror + **trim/extend/split**, rect/circular patterns, profiles. Discriminated `Kind`-keyed wire methods + typed `client.Sketch`; every PBI has model + dogfood e2e tests; new **Modify-panel UI tools** (offset/mirror/fillet) with e2e. lint/vet/**race** green; model cov 81%, router cov 72%. Minor residual follow-ups noted per-PBI (curve-trim, tangent/spline dims). |
-| M22 | Sketch3D Feature Completion (3D Parity) | 🟦 | Bring `Sketch3D` to full Inventor parity across API+kernel+UI, **including** surface-derived curves (new kernel surface-intersection machinery). 12 features (F01–F12), PBIs 230–247. **Done (model+API+kernel+router, all tested):** F01 spine (`contract.Sketch3D` + wire/client + router + `Sketches3D` in the part + `SketchData3D` round-trip), F02 base entities (point/line/circle/arc), F03 conics + splines (ellipse/elliptical-arc, interpolation/control/fixed splines + equation curve), F04 helical curves (new `kernel/geom.Helix3d`, 100%), F05 geometric constraints (parallel/perp/midpoint/ground/parallel-to-axis+plane), F06 dimensions (distance/line-length/radius/point-plane/two-line-angle + drive), F07 constraint status/DOF/defer, F09 profiles & paths (chain detection by endpoint coincidence; `Profile3D`/`Paths3D` over `sketch3d.profiles`/`paths`). **Kernel: F10 DONE (both PBIs)** — `kernel/geom` surface↔curve intersection + point projection (PBI-243: `ClosestPointOnSurface`/`SignedDistanceToSurface`/`IntersectCurveSurface`) and surface↔surface intersection + silhouette (PBI-244: marching-squares tracer → `IntersectSurfaceSurface`/`Silhouette`); 100% on new files, 98.9% package. F08 edit ops (move/rotate/copy/delete over `sketch3d.transform`) **and Include** (`sketch3d.include` links part edges/vertices by reference key as associative reference geometry via the PointSource/CurveSource seam). F11 surface-derived curves (Intersection/Silhouette/ProjectToSurface/OnFace/OffsetCurve3 over the F10 kernel; **intersection + silhouette over `/api`** via `sketch3d.addSurfaceCurve` resolving part faces by reference key; recompute-derived, serialize-skipped). F12 **app-layer UI** ("3D Sketch" ribbon + edit environment + interactive Line/Point/Circle/Arc/Helix tools + Finish, e2e-tested headless). **Pending (polish):** F08 GetReferenceKey surfacing; F11 associative rebind on recompute (SurfaceSource seam) + project/on-face/offset `/api`; F12 `head/ui` ImGui dialogs + `Sketch3DSettings`. |
+| M23 | Renderer Display-Mode Parity & Realistic PBR | 🟦 | **[audit: ⬜→🟦]** `renderer/visualstyle.go` + `View.{Realistic,Watercolor,Monochrome,Illustration,TechnicalIllustration,ShadedWithHiddenEdges,WireframeWithHiddenEdges,...}` ribbon commands shipped. Depth of software-PBR/NPR/hidden-line vs full parity unverified. Original scope: Brings the viewport to full Inventor `DisplayModeEnum` parity (PBIs 300–311): the public `DisplayMode` contract + Visual Style gallery (F01), a **software PBR** Realistic mode (GGX + IBL + tone mapping, no hardware RT — F02), real-time **viewport hidden-line** removal feeding modes 8707/8711/8712 (F03), and an **NPR framework** + the four stylized modes Monochrome/Watercolor/Illustration/Technical-Illustration (F04). See [ADR-0023](../architecture/decisions/ADR-0023-viewport-display-modes.md). |
+| M21 | Sketch2D Feature Completion (2D Parity) | 🟦 | **[audit: ✅→🟦 pending verification — model+API+dogfood e2e strong, but full head-UI parity per tool and residual follow-ups (curve-trim, tangent/spline dims) not independently confirmed; see REPORT.md §9]** **All 11 features + every follow-up done** (PBIs 200–221). Full Inventor 2D-sketch parity (ex-DWG) over `/api`: entities (lines/circles/arcs/points, ellipse, **elliptical arc**, splines incl. **control/fixed/offset/equation curve**, rectangles, polygons, **straight+arc slots**, **fillet/chamfer**, offset, image, **fill region**, **text**, **project geometry**), full geometric constraints (incl. **ground/offset/pattern**) + dimensional constraints (incl. **offset/3-point-angle/ellipse-radius**), constraint-status/DOF + **AutoDimension**, move/rotate/copy/mirror + **trim/extend/split**, rect/circular patterns, profiles. Discriminated `Kind`-keyed wire methods + typed `client.Sketch`; every PBI has model + dogfood e2e tests; new **Modify-panel UI tools** (offset/mirror/fillet) with e2e. lint/vet/**race** green; model cov 81%, router cov 72%. Minor residual follow-ups noted per-PBI (curve-trim, tangent/spline dims). |
+| M22 | Sketch3D Feature Completion (3D Parity) | ✅ | **[audit 2026-06-04: F08/F11/F12 residuals closed → feature-complete]** All surface-curve kinds on `/api` (intersection/silhouette/onFace/projectToSurface/offset) with associative rebind verified; `model.referenceKeys` surfacing (F08); head tool-param dialogs + Sketch3DSettings (F12). Bring `Sketch3D` to full Inventor parity across API+kernel+UI, **including** surface-derived curves (new kernel surface-intersection machinery). 12 features (F01–F12), PBIs 230–247. **Done (model+API+kernel+router, all tested):** F01 spine (`contract.Sketch3D` + wire/client + router + `Sketches3D` in the part + `SketchData3D` round-trip), F02 base entities (point/line/circle/arc), F03 conics + splines (ellipse/elliptical-arc, interpolation/control/fixed splines + equation curve), F04 helical curves (new `kernel/geom.Helix3d`, 100%), F05 geometric constraints (parallel/perp/midpoint/ground/parallel-to-axis+plane), F06 dimensions (distance/line-length/radius/point-plane/two-line-angle + drive), F07 constraint status/DOF/defer, F09 profiles & paths (chain detection by endpoint coincidence; `Profile3D`/`Paths3D` over `sketch3d.profiles`/`paths`). **Kernel: F10 DONE (both PBIs)** — `kernel/geom` surface↔curve intersection + point projection (PBI-243: `ClosestPointOnSurface`/`SignedDistanceToSurface`/`IntersectCurveSurface`) and surface↔surface intersection + silhouette (PBI-244: marching-squares tracer → `IntersectSurfaceSurface`/`Silhouette`); 100% on new files, 98.9% package. F08 edit ops (move/rotate/copy/delete over `sketch3d.transform`) **and Include** (`sketch3d.include` links part edges/vertices by reference key as associative reference geometry via the PointSource/CurveSource seam). F11 surface-derived curves (Intersection/Silhouette/ProjectToSurface/OnFace/OffsetCurve3 over the F10 kernel; **intersection + silhouette over `/api`** via `sketch3d.addSurfaceCurve` resolving part faces by reference key; recompute-derived, serialize-skipped). F12 **app-layer UI** ("3D Sketch" ribbon + edit environment + interactive Line/Point/Circle/Arc/Helix tools + Finish, e2e-tested headless). **Pending (polish):** F08 GetReferenceKey surfacing; F11 associative rebind on recompute (SurfaceSource seam) + project/on-face/offset `/api`; F12 `head/ui` ImGui dialogs + `Sketch3DSettings`. |
 
 ## PBI log (most recent first)
 
@@ -98,12 +106,13 @@ app-layer e2e tests driving command→tool→OK→validated solid).
 | 174-UI-loft | Loft UI (ribbon + property window + e2e) | ✅ | `app`, `head/ui` | `LoftTool` (each picked region → a `LoftSection`) + `Create.Loft` ribbon command + `head/ui/loft_dialog.go` (section count / output / closed-loop) + `loft.svg`. E2e: `TestLoftToolEndToEnd` (click two sections → OK → validated frustum V=140/3), `TestLoftViaRibbonCommand`, `TestLoftToolNeedsTwoSections`. New `seqPicker` test helper drives multi-section clicks. |
 | 173-UI-coil | Coil UI (ribbon + property window + e2e) | ✅ | `app`, `head/ui` | `CoilTool` + `Create.Coil` ribbon command + `head/ui/coil_dialog.go` property window (output/axis/pitch/revolutions) + `coil.svg`. E2e: `TestCoilToolEndToEnd` (click profile → pitch 2 × 3 revs → OK → valid helix climbing ≈7), `TestCoilViaRibbonCommand`, `TestCoilToolNeedsProfileAndRevolutions`. Solid-feature commands split into `solidFeatureCommands()`. |
 | 173-UI | Revolve UI (ribbon + property window + e2e) | ✅ | `app`, `head/ui`, `model/feature` | `RevolveTool` + `Create.Revolve` ribbon command (alias `R`) + `head/ui/revolve_dialog.go` property window (output/axis/angle) + `revolve.svg`. E2e: `TestRevolveToolEndToEnd` (click profile → full revolution → OK → validated 24π washer), `TestRevolveViaCommandAlias` (alias `R` → 90° quarter washer), `TestRevolveToolNeedsProfile`. `WorkGeometry.AxisByRef` added. **Reference for retrofitting the other M20 features' UI.** |
-| 174 | Sweep & loft bodies | ✅ | `model/feature` | `SweepFeature` (profile placed along a 3D path, oriented to the local tangent, optional twist) and `LoftFeature` (blend through ordered `(sketch,profile)` sections resampled to a common point count, optional closed) generate real faceted solids via the shared `sweptSolid` primitive. A 2×2 square swept along an L-path is a valid elbow; a 4×4→2×2 square loft is an exact frustum (V=140/3). New `SweepFeatures`/`LoftFeatures` collections + `SweepData`/`LoftData` `.obk` codecs (path as 3D points, sections as sketch+profile indices). `SweepDefinition.Path` is now a `Path3D`; `LoftDefinition` carries `LoftSection{Sketch,ProfileIndex}`. Guide rails, path-frame torsion-minimization and section alignment are follow-ups. |
+| 174 | Sweep & loft bodies | ✅ | `model/feature` | `SweepFeature` (profile placed along a 3D path, oriented to the local tangent, optional twist) and `LoftFeature` (blend through ordered `(sketch,profile)` sections resampled to a common point count, optional closed) generate real faceted solids via the shared `sweptSolid` primitive. A 2×2 square swept along an L-path is a valid elbow; a 4×4→2×2 square loft is an exact frustum (V=140/3). New `SweepFeatures`/`LoftFeatures` collections + `SweepData`/`LoftData` `.obk` codecs (path as 3D points, sections as sketch+profile indices). `SweepDefinition.Path` is now a `Path3D`; `LoftDefinition` carries `LoftSection{Sketch,ProfileIndex}`. Guide rails, path-frame torsion-minimization and section alignment are follow-ups. **Fix 2026-06-05:** a **twisted** loft/sweep makes warped (non-planar) quad side faces; emitted as single faces they broke the planar boolean (imprint offset → loop won't close → non-manifold). `sweptSolid` now triangulates a non-coplanar side quad (`sideQuad`/`quadPlanar`), restoring the planar-faceted invariant; regression `TestTwistedLoftUnionStaysManifold`. |
 | 173 | Revolve & coil surfaces of revolution | ✅ | `model/feature` | `RevolveFeature` and `CoilFeature` now generate **real faceted solids** via a shared `sweptSolid` primitive (cross-section loops → `subd.ToBody` cage → B-rep, re-oriented outward by signed volume). Revolve: full (closed, no caps) or partial (capped) about a `WorkAxis`; a square x∈[2,4]×y∈[0,2] revolved 360° about Y is a validated washer of volume 24π (±1%). Coil: helical placement (pitch/revolutions, taper recorded) capped at both ends; climbs pitch·revs + profile height. New `CoilFeatures` collection + `CoilData` `.obk` codec (axis by WorkRef like revolve). Curved profile edges and exact analytic surfaces are a later refinement; profiles must not touch the axis (pole handling pending). |
 | 189 | Decal, Reference, Client, Mark & Finish | ✅ | `model/feature` | Five cosmetic/reference parity features (`DecalFeature`/`ReferenceFeature`/`ClientFeature`/`MarkFeature`/`FinishFeature` + `*Definition` + `CosmeticFeatures` collection). Pass-through recompute (no geometry change) carrying their payload — decal image+face, reference label+source key, add-in id+attributes, mark faces+text, finish faces+spec — all round-tripping through `.obk`. Completes 5 more Inventor `*Feature` types toward parity. |
-| 191 | Pattern & mirror real duplication | ✅ | `model/feature`, `math` | Rectangular/Circular/SketchDriven patterns and Mirror now emit **real placed copies** via `ops.TransformBody` (distinct lineage per copy → independent reference keys), appended as validated solids; per-element suppression drops only that copy. Definitions carry the occurrence geometry (grid `StepX`/`StepY`, axis point+dir, sketch points, mirror plane origin+normal) and round-trip through `.obk`. `math.Reflection4(origin, normal)` (det −1) added for the mirror. A 1×3 pattern of a unit cube → 3 solids at x={0,2,4}; mirror across x=0 → reflected solid in x∈[−1,0]. Boolean-union into one body (vs. separate placed solids) and source-only (vs. whole-solid) replication await M20·F01. |
+| 191 | Pattern & mirror real duplication | ✅ | `model/feature`, `math` | Rectangular/Circular/SketchDriven patterns and Mirror now emit **real placed copies** via `ops.TransformBody` (distinct lineage per copy → independent reference keys), appended as validated solids; per-element suppression drops only that copy. Definitions carry the occurrence geometry (grid `StepX`/`StepY`, axis point+dir, sketch points, mirror plane origin+normal) and round-trip through `.obk`. `math.Reflection4(origin, normal)` (det −1) added for the mirror. A 1×3 pattern of a unit cube → 3 solids at x={0,2,4}; mirror across x=0 → reflected solid in x∈[−1,0]. **Source-only replication DONE 2026-06-05:** `ToolFeature`/`OperationalFeature` + `Input.SourceTool` make a pattern re-apply the source feature's cut/join per occurrence (one body with N holes/blades, not N copies); all boolean tool features incl. Hole carry the contract; a deferred source (Boss) replicates nothing. (See PBI-191 notes.) |
 | 190 | Body transform op & Move feature | ✅ | `kernel/geom`, `kernel/ops`, `model/feature`, `math` | `geom.TransformCurve`/`TransformSurface` (similarity-transform dispatchers over the analytic curve/surface types) + `ops.TransformBody` (clones a body's combinatorial topology, maps geometry, reverses winding on reflection so normals stay outward → stays a valid manifold under translate/rotate/reflect/uniform-scale; rejects non-uniform scale). A caller `derive` either preserves reference keys (in-place Move) or makes distinct-key copies (pattern/mirror). `MoveFeature`/`MoveDefinition` relocates a running body in place (keys survive); `math.Matrix4FromCells` persists the transform as 16 cells → `.obk` round-trips. The shared enabler for pattern/mirror geometry (PBI-191). |
-| 171 | Face-splitting solid/solid boolean | ⬜ | `kernel/ops` | Planned — the biggest unblocker (Cut/Split/Hole/Emboss/sheet-metal). |
+| 171 | Face-splitting solid/solid boolean | 🟡 | `kernel/brep`, `kernel/ops` | Planar imprint→split→classify→stitch pipeline works for **clean through-overlaps** (low-face-count, chain-exact, K1a key survival). **Robustness gap (2026-06-05):** partial penetrations / concave faceted-wall crossings leave dangling imprint segments the 2D arrangement won't cut → non-manifold / inverted normals (the lofted-fan deformity). Outstanding work tracked as **PBI-199**; precondition (twisted-loft warped quads) fixed in PBI-174. |
+| 199 | Boolean robustness — partial penetration & concave-wall crossing | ⬜ | `kernel/brep` | Planned (XL) — assemble imprint segments into closed loops across face boundaries, handle T-vertices / dangling edges so a tool poking part-way in or crossing a re-entrant faceted wall cuts correctly. Acceptance = the skipped fan e2e (`TestBladeJoinBooleanIsTheDefect`, `TestFanBodyStaysManifold`). Dead-end: post-stitch orientation repair does NOT fix it. |
 
 ### M10 — Surfacing & Freeform Modeling
 
@@ -257,6 +266,373 @@ app-layer e2e tests driving command→tool→OK→validated solid).
 
 ## Session log
 
+- **2026-06-05:** **Sketch construction lines + centerlines.** Construction geometry already
+  existed in the model (entity flag, excluded from `normalGeometry`/profiles, serialized) but had
+  no UI. Added **centerlines** (new): `entityBase.centerline` (implies construction, so it never
+  closes a profile), `Line.Axis3D(plane)` (model-space axis for revolve/mirror), `Sketch.Centerlines()`,
+  and serialization (`EntityData.Centerline`). UI: a Sketch-tab **Format panel** with `Sketch.
+  Construction` and `Sketch.Centerline` toggle commands (`Session.ToggleConstruction/ToggleCenterline`
+  over the sketch selection) — amended the canonical ribbon doc to add the Format panel it was
+  missing. The sketch **Mirror** tool already picks a `*Line` axis, so a centerline drives it with
+  no change. Tests: model (centerline excluded from profiles vs. a normal midline that splits;
+  axis derivation; mirror across a centerline; round-trip) + app e2e (toggle construction/centerline
+  on a selected midline → region count drops 2→1; ribbon Execute). Full suite + head + SPDX green.
+- **2026-06-05:** **Revolve centerline picker — Inventor-accurate selection.** Reworked the axis
+  selection to match Inventor: a separate centerline picker with smart **pre-selection** and
+  profile→axis **auto-advance**. `preselectCenterline` (pure, 5 cases tested): one centerline in
+  the profile's sketch → pre-select; several in it → user must pick; none in it but one visible
+  overall → that one; else none. On profile pick the tool auto-advances (filter → SketchEntity)
+  and pre-selects; the user can click any centerline to override. Model now revolves about a
+  **specific** centerline (`RevolveDefinition.AxisCenterline` + `AddAboutCenterlineLine`),
+  serialized by (sketch,line) index (1-based; empty = profile-sketch auto centerline; a WorkRef =
+  explicit work axis). The **ray picker** gained sketch-curve picking (`nearestSketchCurve`,
+  reusing `raySegmentDistance`) so a centerline is selectable in the part view. Head: profile-area
+  + centerline **hover highlights** (candidate colour) and picked-profile + chosen-centerline
+  highlights (selected colour), mirroring Extrude; "About sketch centerline" dialog checkbox.
+  Tests: preselect rules, tool pre-select + manual-pick flows, raypicker centerline pick, model
+  washer (= explicit-Y 24π), serialize round-trip. Full suite + head + SPDX green. Sketch mirror
+  already consumed centerlines; revolve now matches Inventor's picker UX.
+- **2026-06-05:** **Extend (Surface) — real geometry + full DoD (was G⬜).** `ops.ExtendByEdge`
+  grows a planar surface by sliding a boundary edge's endpoints outward (in-plane, perpendicular
+  to the edge, away from the face). Realigned the model `ExtendFeature` from the unused identity
+  `Ref` to a topo `[]byte` edge key (the proven chamfer pattern; re-resolved via FindEdgeByKey each
+  recompute) — so the deferred ErrDeferred path is gone. `ExtendTool` (pick a boundary edge +
+  distance) + `Surface.Extend` ribbon command. Tested kernel (grow + lost-edge), model (grow + sick
+  on lost edge, key survives recompute), app e2e (pick edge → y∈[-2,4]; ribbon). Multi-face and
+  curved-surface extend remain phase-C (NURBS). Full suite + head + SPDX green.
+- **2026-06-05:** **K5 — multi-face surface ops (Trim + Offset).** Generalized the surface-edit
+  kernel beyond single planar faces: `ops.TrimByPlane` now clips EACH planar face by the cutting
+  plane and welds the kept faces back into one sheet (folded sheets / stitched quilts trim
+  correctly), and `ops.OffsetSurface` offsets a multi-face **coplanar** quilt (translate each face
+  + weld). Shared a new `buildSheet` welder (coincident-vertex merge, one edge per pair); migrated
+  MidSurfaces to it; replaced the old single-face `buildPlanarBody`. The model Trim feature and
+  `SurfaceTrimTool` get multi-face for free. Tested (multi-face trim → 2 faces, x∈[1,4]; coplanar
+  offset → 2 faces flat). **Honest scope:** this completes the MULTI-FACE half of K5; the CURVED
+  half — NURBS surface–surface trim and parallel-surface offset of curved/folded faces — is
+  genuine NURBS work that remains (it needs a curved surface-trim engine, not a planar clip).
+  Full suite + head + SPDX green.
+- **2026-06-05:** **Decal — UI completion; Create panel now fully populated.** `DecalTool` places
+  an image (a resource id) on a picked face — cosmetic, no solid change. `Create.Decal` ribbon
+  command (the last canonical Create-panel button). `DecalFeature` already existed; adds the UI +
+  e2e (pick face → set image → decal recorded, body unchanged; ribbon Execute). **The canonical
+  3D-Model Create panel [Extrude, Revolve, Sweep, Loft, Coil, Rib, Emboss, Decal] is now all
+  wired.** Full suite + head + SPDX green.
+- **2026-06-05:** **Sculpt (Surface panel) — UI completion (geometry was already real).**
+  `SculptTool` fills the volume bounded by the running surface bodies into a solid (parameter-only:
+  closing tolerance). `Surface.Sculpt` ribbon command. `SculptFeature` already existed; adds the
+  UI + e2e (six cube-face sheets → unit-volume solid; ribbon Execute). The output operation
+  (Join/Cut vs new body) is stored but geometry-unwired in the model, so the tool defaults to a
+  new body and does not expose it (would mislead) — wiring it is a model refinement. Full suite +
+  head + SPDX green. **Surface panel UI now done for Patch/Trim/Stitch/Sculpt; the remaining
+  Surface tools (Extend, Rule Fillet) need kernel geometry (K5), not just UI.**
+- **2026-06-05:** **Stitch (Surface panel) — UI completion (geometry was already real).**
+  `StitchTool` welds the running surface bodies into one quilt (closed → solid unless "keep as
+  surface"); parameter-only (tolerance + keep-surface), no pick. `Surface.Stitch` ribbon command.
+  `StitchFeature`/`ops.Stitch` already existed; adds the UI + e2e (two adjacent patches → one
+  2-face quilt; ribbon Execute). Full suite + head + SPDX green. Tolerant (gap-band) sew is the
+  geometry refinement (K3); Extend/Sculpt/Rule-Fillet are the remaining Surface tools.
+- **2026-06-05:** **Surface Trim — UI completion (geometry was already real).** `SurfaceTrimTool`
+  cuts the running surface body with a picked work plane, keeping one side (ParameterizedTool: a
+  "keep positive side" bool). `Surface.Trim` ribbon command (Surface panel). `TrimFeature` +
+  `ops.TrimByPlane` geometry/serialize already existed; adds the UI + e2e (patch a 4×4 surface,
+  trim by an x=2 work plane → x∈[2,4]; ribbon Execute). Full suite + head + SPDX green. Curved/
+  multi-face trim (K5) is the geometry refinement; Extend/Stitch/Sculpt are the next Surface tools.
+- **2026-06-05:** **Patch (Surface panel) — UI completion (geometry was already real).** First of
+  the Surface-panel tools: `PatchTool` fills a closed sketch region with a boundary-patch surface,
+  auto-committing on the region pick (one-click surfacing). `Surface.Patch` ribbon command (the
+  canonical Surface panel, finally created in the 3D Model tab). `BoundaryPatchFeature` geometry +
+  serialization already existed; this adds the missing UI + e2e (surface sheet body, 1 face, not a
+  solid; ribbon Execute). Full suite + head + SPDX green. Next Surface tools: Trim, Extend, Stitch.
+- **2026-06-05:** **Emboss — new Create feature, full DoD.** `EmbossFeature` raises (Join) or
+  engraves (Cut) a closed sketch profile on the part: the region is extruded a shallow depth along
+  the sketch-plane normal. Built on the shared `buildPrism`+`combine` machinery — extracted two
+  package helpers (`resolveClosedProfiles`, `buildProfilePrisms`) now shared by Extrude and Emboss
+  (refactor of the touched extrude code; its tests confirm no regression). `EmbossFeatures.Add`,
+  serialize round-trip (`EmbossData`), `EmbossTool` (ParameterizedTool: Depth + Engrave, multi-
+  region pick) + `Create.Emboss` ribbon (canonical Create panel; generic dialog, no bespoke cgo).
+  Tests: model (raise → +vol, engrave → −vol, error), serialize round-trip, app e2e (raise/engrave/
+  ribbon). Full suite + head + SPDX green. Wrapping onto a curved face is the remaining refinement.
+- **2026-06-05:** **Split Solid / Trim Solid — new feature, full DoD (was G⬜).** `ops.SplitSolidByPlane`
+  divides a solid by an infinite plane into the pieces on each side (intersect with a large
+  half-space box per side, so each piece is capped by a clean planar cross-section). New
+  `SplitSolidFeature` (`AddSplitSolid(plane, keep)`, `SplitBoth`/`Positive`/`Negative` for split
+  vs trim) referencing a cutting **work plane**; serialize round-trip (`SplitSolidData`). UI:
+  `SplitTool` (pick a work plane, choose split/trim) + `Modify.Split` ribbon command (canonical
+  Modify panel) + head dialog. Tests at kernel (mid/oblique/miss, valid solids, volumes sum),
+  model (divide + trim + round-trip), app e2e (pick plane → OK → 2 bodies; trim → 1; ribbon).
+  Two bugs found & fixed building the half-space box WITHOUT subd (subd is unreachable from ops —
+  `subd_test`→`ops` would cycle): edges must be stored canonically (min→max) to match the
+  Reversed convention, and the negative-side box must swap U/V to stay right-handed (else the
+  canonical rings wind inward → inside-out box → broken boolean). Full suite + head + SPDX green.
+- **2026-06-04:** **Rib feature completed to full DoD (UI + persistence; geometry was already real).**
+  Rib had real geometry (`RibFeature.Recompute` thickens an open profile into a wall) but no
+  collection method, no serialization, and no UI — so it wasn't DoD-complete. Added: `RibFeatures.
+  Add` (named, engine-bound), `RibData` + serialize/restore wired into the recipe registry, an
+  interactive **`RibTool`** (a `ParameterizedTool` — resolves the open profile from the active or
+  most-recent open-path sketch at Start, exposes Thickness + Depth, joins the wall to the part),
+  and a **Create-panel ribbon command** `Create.Rib` (matching the canonical Inventor Create panel
+  [Extrude…Coil, **Rib**, Emboss, Decal]; the head renders the generic property dialog, no bespoke
+  cgo). Tests: model collection (named + vol), serialize round-trip, app e2e (tool flow + ribbon
+  Execute). Full suite + head + SPDX green. Rib's "to-next" part-bounding remains the only
+  refinement. **This closes the last Phase-3 UI gap for a real-geometry Create feature.**
+- **2026-06-04:** **Conical drill point — Hole feature reaches Inventor parity (step 4/4 DONE).**
+  `brep.CutBlindConicalHole`: a cylinder bore closed by a true CONE tip (the twist-drill shape;
+  118° included = 59° half-angle default). Needed a new tessellation primitive: **cone-apex
+  (pole) fan** — `ops.coneApexFan` meshes a cone whose only boundary is a single rim circle by
+  fanning to the apex pole (a geometric tip, not a topology vertex). It's tried before the band
+  path and guarded to fire only for a single-circle (constant-v) cone boundary, so a countersink
+  frustum (two rim circles) is still gridded as a band. Subtlety found & fixed: a lone full-
+  circle loop de-duplicates to a span just under 2π, so `toUVLoops` wrongly succeeded into a
+  degenerate iso-rectangle — the apex fan now runs first. Wired into the Hole feature via
+  `HoleDefinition.PointAngle` (0 = flat); the HoleTool defaults to 118° (Inventor's default), the
+  head dialog exposes the angle (0 = flat). Full DoD: kernel (1 cone + 1 cylinder, volume =
+  cylinder + ⅓cone, apex-exits rejection), ops (apex-fan area = π·r²/sin), model, app e2e, and
+  serialize round-trip. Full suite + head + SPDX green. **Hole feature now has all four profiles
+  (drilled flat/point, through, blind, counterbore, countersink) with real curved geometry.**
+- **2026-06-04:** **Cone-face support + countersink holes (Hole parity steps 2-3/4).** Confirmed
+  the periodic-band tessellator handles a CONE frustum (varying radius) — `ops` test, lateral
+  area π(r1+r2)·slant — the foundation. Then `brep.CutCountersinkHole`: a true cone frustum
+  recess widening to the sink Ø at the surface, sharing a transition circle directly with the
+  cylinder bore wall (no shoulder), built in one assembly. The cone widens toward the surface
+  (axis points back out, apex deep). Wired into the Hole feature as **exact-only** (a wrong
+  faceted cone is worse than a clear error for the rare unsupported shape): `HoleDefinition`
+  gained `CounterAngle` (included angle) reusing `CounterDiameter` for the sink Ø;
+  `AddCountersink`. Full DoD: Hole UI countersink toggle (mutually exclusive with counterbore,
+  sink Ø + angle in degrees, head dialog), persistence (`HoleData.CounterAngle`), and tests at
+  kernel (1 cone + 1 cylinder wall, volume = frustum + bore), model, app e2e, and serialize
+  round-trip. Full suite + head + SPDX green. **Remaining (step 4):** the 118° conical drill
+  point — needs cone-APEX (pole) tessellation, distinct from the band case.
+- **2026-06-04:** **Counterbore holes — exact stepped geometry, full DoD (Hole parity step 1/4).**
+  `brep.CutCounterboreHole`: a shallow recess (counterRadius × counterDepth) stepping via a flat
+  **annular shoulder** to a bore (through or blind), built in ONE assembly from the planar slab —
+  two true cylinder walls + the shoulder. Built directly (not by chaining two curved cuts, which
+  would feed a curved body to the planar-only boolean and produce a non-manifold mess — that's
+  the curved-input boolean, a later slice). `HoleFeature.cutCounterbore` prefers it, falling back
+  to sequential planar prism cuts (which stay planar, so they chain) for unsupported shapes. Full
+  DoD: model (`HoleDefinition.CounterDiameter/Depth` + `AddCounterbore`), Hole UI (counterbore
+  toggle + recess Ø/depth, head dialog fields), persistence (`HoleData.Counter*`), and tests at
+  kernel (through+blind, 2 cyl faces, volume), model, app e2e, and serialize round-trip levels.
+  Full suite + head + SPDX green. **Next (Hole parity 2-4):** cone-face support → countersink →
+  118° conical drill point.
+- **2026-06-04:** **Blind holes now drill an EXACT cylinder wall + flat bottom (K1b).**
+  `brep.CutBlindCylindricalHole`: a cylinder entering one planar face and stopping at depth
+  inside the material → entry face holed + true cylinder wall + a flat circular bottom disk
+  (facing the opening), watertight, vol = part − inscribed bore. Uses the same face-sense
+  primitive (reversed wall). Verified the pocket stays inside via `insideSolid` (else error).
+  `HoleFeature.drill` now prefers it for any blind hole, falling back to the faceted boolean
+  only for unsupported shapes (bore clips a face, depth exits) — so existing depth≥thickness
+  "through via depth" tests keep the faceted path unchanged. Tested at kernel (validity/
+  watertight/face-count 1 cyl + 7 planar/volume, through-depth rejection) and model (blind
+  depth<thickness → 1 cylinder face + flat bottom) levels. Full suite + head + SPDX green.
+  Follow-up: conical drill point (Inventor's default 118° tip).
+- **2026-06-04:** **Hole feature now drills a TRUE cylinder wall (K1b consumed end-to-end).**
+  Wired `brep.CutCylindricalHole` into the actual Hole feature as a full vertical slice:
+  `HoleDefinition.ThroughAll` + `HoleFeatures.AddDrilledThrough`; `HoleFeature.drill` routes a
+  Through-All hole on a planar slab to the exact curved boolean (one cylinder face, not a
+  32-gon prism), falling back to the faceted boolean (drilled `throughDepth`) for blind holes
+  and unsupported shapes. UI: `HoleTool` gained a Through-All option (depth not required when
+  set) and the head hole dialog a "Through All" checkbox (disables the depth field). Persisted
+  (`HoleData.ThroughAll`, round-trips). Tested across all layers — model (through hole → 1
+  cylinder face, vol = slab − π·r²·h), app e2e (pick face → tick Through All → OK → true wall),
+  serialize round-trip. Full headless suite + head build + SPDX green. Blind exact cylinders
+  and the general (non-slab) curved boolean remain later K1b slices.
+- **2026-06-04:** **K1b slice 3 — first end-to-end curved boolean: a clean drilled hole.**
+  `brep.CutCylindricalHole(slab, base, axis, radius)` drills a cylindrical through-hole in a
+  planar-faced slab: the two pierced faces gain a circular hole, a single TRUE cylinder face
+  forms the wall, and the result is a watertight solid with the correct volume (slab − inscribed
+  bore). This needed a new B-rep primitive — **face sense**: `topo.Face.Reversed` +
+  `topo.Builder.AddReversedFace`, honored by `ops.TessellateFace` (negates the mesh normals and
+  flips triangle winding). A Difference cut wall's surface normal points INTO the removed
+  material, so its face is "reversed"; the planar boolean fakes this by building a flipped
+  `Plane`, but a cylinder's normal is intrinsically outward-radial and can't be flipped — the
+  sense flag is the general fix (the planar path can adopt it later). Because copied + pierced
+  faces keep their source lineage, **every original face's reference key survives the curved
+  cut** (extends K1a to curved booleans). Partial/blind holes error (later slices). Tested at
+  topo (sense flag), ops (reversed mesh flip), and brep (validity/watertight/face-count, volume
+  = slab − π·r²·h, key survival, oversize rejection) levels. Full headless suite + head build
+  green. **Next:** slice 4 — sphere/cone + the general arrangement-based curved boolean.
+- **2026-06-04:** **K1b slices 2 + 2b — first analytic curved solid, correctly tessellated.**
+  Confirmed the topo model already supports analytic curved faces: `topo.AddEdge` allows
+  **closed-circle edges** (start==end) and `ops.Validate` counts edge *uses*, so a **periodic
+  cylinder side face** (seam edge with two opposite uses) is a valid manifold solid. Built
+  `brep.SolidCylinder` — one true cylinder face + two planar caps sharing two closed circles +
+  a seam. It validates AND is watertight. **Closed the tessellation gap (2b):** a full-2π side
+  loop can't be unwrapped, so it used to fall back to the surface's whole *unbounded* UV domain
+  → wrong area/volume (183.7 vs 62.8). New `ops.periodicBandGrid` grids a full-seam-wrap face
+  over its true trim — the whole period (reusing the boundary's own circle-edge samples so it
+  stays watertight with the caps) × the boundary's bounded range. Now face area = 2π·r·h and
+  solid volume = π·r²·h (inscribed, a hair under). Tested at ops + brep levels; ops/brep suites
+  green. **Next:** slice 3 — wire `SolidCylinder` as the cut tool → a clean drilled hole.
+- **2026-06-04:** **K1b started — curved-face boolean, slice 1: exact analytic surface
+  intersections.** New [ADR-0027](../architecture/decisions/ADR-0027-curved-face-boolean.md)
+  lays out the curved-boolean architecture (generalize the planar pipeline's face model to
+  `geom.Surface` + `geom.Curve3` loops; exact-curve imprints; param-space split; reuse K1a
+  lineage) and a 5-slice plan. Slice 1 landed: `geom.IntersectSurfacesAnalytic` returns
+  EXACT intersection curves for the pairs the boolean needs — plane∩plane → line, plane∩
+  cylinder → circle (⟂) / **ellipse** (oblique), plane∩sphere → circle, plane∩**cone** →
+  circle (⟂) — and reports `handled=false` for line-pair / curved-curved pairs so the
+  caller falls back to the numeric tracer. 10 tests (radius/center exactness incl. the
+  oblique ellipse minor=r / major=r√2, miss/parallel/tangent → no curve, order-
+  independence, parallel-cylinder defers). Core suite green. **Next slices:** curved face
+  model → plane∩cylinder boolean end-to-end (clean hole) → edge-key survival + retire BSP.
+- **2026-06-04:** **K1a unlock realized — boolean-output references proven at the feature
+  level.** `TestCombineFaceKeySurvivesIntoResultAndRecompute`: a face picked on box A keeps
+  its reference key after Combining with an overlapping box B (planar boolean carries the
+  lineage) AND after a height-driven recompute — so a downstream fillet/dimension/sketch on
+  a combined solid stays bound across edits. Reviewed the rest: the deferred boolean
+  features need MORE than K1a — **Split** needs a definition redesign (its `faceKeys` shape
+  doesn't model split-by-plane), and **Hole/Fillet** survival + exact chaining need the XL
+  curved-face boolean (**K1b**). So K1a's unlock = parametric robustness on the planar
+  Combine/Cut path, now validated end-to-end.
+- **2026-06-04:** **K1a — face reference-key survival through the planar boolean (G-09).**
+  The planar B-rep boolean re-synthesized lineage, so picks on Combine/Cut output were lost
+  on edit. Now the source face's lineage is threaded `planarFace → subFace → builtFace →
+  AddFace`: a face surviving whole keeps its **exact** reference key; a face split into
+  several pieces gets distinct child tokens (`…/brep:split#k`). Tested: Union and Cut both
+  keep an untouched face's key; disjoint union still valid (vol 16); no boolean-correctness
+  regressions. **Remaining K1:** edge/vertex key survival; the XL curved-face boolean (K1b)
+  replacing the BSP-CSG fallback so Hole/Fillet faces survive + chain exactly.
+- **2026-06-04:** **Phase 4 start — Rib geometry made real (was NotYetImplemented, G-01).**
+  `RibFeature.Recompute` now builds a wall: the open sketch path is offset ±Thickness/2 into
+  a closed band (`thickenPath` + vertex-normal averaging + CCW orient) and extruded by a
+  finite `Depth` along the plane normal via the shared `buildPrism`, then `combine`d with the
+  running body. Added `Depth` to `RibDefinition`; removed the NYI. Tests: straight rib vol=8
+  (4×1×2), L-path → one solid, needs-depth→sick. ("To-next" bounding + a ribbon tool are
+  follow-ups; core suite + vet green.)
+- **2026-06-04:** **Phase 3 start — feature Pattern & Mirror UI (closes finding U-01).**
+  The flagship gap: rectangular/circular/sketch-driven patterns + mirror had real geometry
+  (M20-191) but no ribbon tool. Added `app/feature_pattern_tools.go` — `FeatureRectPattern`/
+  `FeatureCircPattern`/`FeatureMirror` tools (select source features as `FeatureHandle`
+  picks, set params, commit via `feature.NewPatternFeatures(part.Features()).Add*` +
+  Recompute) + a **Pattern panel** in the 3D Model tab (canonical placement) + `Params()`
+  so they render in the generic property dialog. e2e: extrude→select feature→3×1 rect
+  pattern = 3 bodies; mirror = 2; circular > 1; needs-source guard; registration. Core
+  suite + head + vet green. (Sketch-driven pattern tool = follow-up.)
+- **2026-06-04:** **Phase 3 cont. — Combine / Move Face / Move Bodies UI (closes U-02).**
+  `app/feature_modify_tools.go` — `CombineTool` (pick two bodies + Join/Cut/Intersect),
+  `MoveFaceTool` (translate picked faces), `MoveBodyTool` (relocate a body); all on the
+  3D Model **Modify** panel via `directEditCommands()` + `Params()` dialogs. e2e: combine
+  join 2→1 body; move-face +Z grows volume; move-body shifts min.X by 10; registration.
+  Core suite + head + vet green. **Phase 3 UI-only features done** (patterns/mirror/combine/
+  move-face/move); remaining: Sketch-Driven pattern tool + Phase 4 deferred-geometry
+  features (Rib/Split/Emboss/Thread).
+- **2026-06-04:** **Phase 2 (Sketch3D) start — onFace surface curve over /api (M22-F11).**
+  The router exposed only intersection/silhouette surface curves; added **onFace** (a curve
+  in a referenced face's parameter space) end-to-end: `api/wire` UV field, new model
+  `Sketch3D.AddOnFaceCurve3DRef` (associative over a `SurfaceSource`), router dispatch with
+  a flat-UV→points parser (request-shape validated before ref-resolve), and typed client
+  `AddOnFaceCurve`. Dogfood router test (extrude→onFace on a face by ref key→healthy; lost
+  ref→unhealthy; bad UV→error) + client + model tests. **Then projectToSurface + offset**:
+  new `Sketch3D.SourceCurve3` resolver (sketch entity id → `geom.Curve3` for line/circle/
+  arc/ellipse/elliptical-arc/helix) + `AddProjectToSurfaceCurve3DRef` (associative surface)
+  + wire `SourceEntityID`/`OffsetDistance`/`Normal` + router project/offset cases + client
+  `AddProjectToSurfaceCurve`/`AddOffsetCurve`. Dogfood: extrude→add a 3D line→project it on
+  a face + offset it in-plane (both healthy); unknown source id→error. **All five surface-
+  curve kinds (intersection/silhouette/onFace/projectToSurface/offset) are now on /api —
+  the F11 /api gap is closed.** api module + core suite + vet + SPDX green.
+  **F11 associative rebind verified:** `TestSketch3DSurfaceCurveRebindsOnRecompute` — an
+  onFace curve bound to the top face by reference key follows it from z=5cm→8cm when the
+  extrude is grown and the part recomputes (the `FaceRefSource` re-resolves the regenerated
+  surface via `FindFaceByKey`). **M22-F11 is effectively complete** (all surface-curve
+  kinds + associativity); remaining Sketch3D residuals: F08 GetReferenceKey surfacing, F12
+  head dialogs/Sketch3DSettings.
+- **2026-06-04:** **Sketch3D F08 — reference-key surfacing (`model.referenceKeys`).** There
+  was no way over /api to *obtain* a part face/edge/vertex reference key (handlers only
+  *consumed* them), so the include/surface-curve/project workflow was unusable headlessly.
+  Added `model.referenceKeys` (wire `TopologyRef`/`BodyTopology`/`ReferenceKeysResult` +
+  router enumerating the part's bodies → faces/edges/vertices with key + representative
+  point + typed client `Model.ReferenceKeys`). Round-trip test: extrude→referenceKeys
+  returns a box's exact 6/12/8 topology with keys→a surfaced face key is consumable by
+  addSurfaceCurve. **M22-F08 done.** Remaining Sketch3D residual: F12 head dialogs +
+  Sketch3DSettings. api module + core suite + vet + SPDX green.
+- **2026-06-04:** **Sketch3D F12 — head dialogs + Sketch3DSettings → Phase 2 complete.**
+  Extended the generic tool-param framework with `BoolParam` (checkbox) and gave the
+  parameterized 3D tools `Params()`: Circle3D (radius), Helix3D (radius/pitch/turns +
+  clockwise), Arc3D (counter-clockwise) — so they render through the same
+  `head/ui/tool_params_dialog.go` (no bespoke cgo per tool). Added a **`Sketch3DSettings`**
+  head window (visible / show-dimensions / defer-updates over the active sketch's
+  accessors). Param labels + float/bool wiring tested headlessly; head builds + ui tests
+  green; core suite green. **M22 (Sketch3D) feature-complete (F01–F12) — PARTDOC-PLAN Phase
+  2 done.** (Head in-window e2e for the 3D dialogs runs under the new CI head job.)
+- **2026-06-04:** **Stretch tool + generic tool-parameter dialog (head DoD layer).**
+  (a) **Stretch** — new model `MovePoints` (moves only the listed vertices, deforming
+  shared geometry) + `SketchStretchTool` (picks vertices, sets a vector) → the last Sketch
+  Modify button; **the 2D Sketch tab is now at full button parity** with the canonical
+  ribbon. (b) **Generic parameter dialog** — an `app.ParameterizedTool` interface
+  (`tool_params.go`: Float/Int/Text param descriptors with get/set closures bound to the
+  tool's fields) implemented by all 11 param-bearing sketch tools (Move/Copy/Rotate/Scale/
+  Stretch, Rect/Circ pattern, Slot/Chamfer/Text/Fillet/Offset), rendered by ONE cgo dialog
+  (`head/ui/tool_params_dialog.go`) instead of 11 bespoke ones (core/09 reflection-driven
+  editing). Param wiring + labels tested headlessly; head builds + ui tests green; angles
+  surfaced in degrees. Core suite green.
+- **2026-06-04:** **Sketch Create tools completed — Slot, Chamfer, Text.** Added the
+  remaining Create-panel tools over existing model ops (`AddStraightSlot`/`AddChamfer`/
+  `TextBoxes.Add`): Slot (two centre clicks + width, auto-commits), Chamfer (two-line
+  bevel, sibling of Fillet), Text (anchor click + string, commits on OK). App e2e for each
+  + registration; Create-panel parity test bumped to 12 buttons. **The 2D Sketch tab is now
+  at button parity with the canonical ribbon** except Modify **Stretch** (deferred:
+  vertex-window selection). Core suite + head green.
+- **2026-06-04:** **Sketch Modify/Pattern tools built + commands refactored.** Added the
+  missing Sketch tools: **Move, Copy, Rotate, Scale** (Modify panel) and **Rectangular,
+  Circular** patterns (Pattern panel), each an app `Tool` over the existing model ops
+  (`MoveEntities`/`RotateEntities`/`CopyEntities`/`RectangularPattern`/`CircularPattern`)
+  plus new model **`ScaleEntities`** (scales points *and* circle/ellipse radii — the affine
+  path doesn't). Tools gather a selection (PickSnap) + parameters (setters) and apply on
+  `OK`; behavior tested headlessly (model + app e2e). **Refactor (per action plan):** split
+  the 2D-sketch ribbon out of the 507-line `commands_standard.go` into `commands_sketch.go`
+  (now 385/126 lines, both <500) and de-duplicated the three near-identical command-table
+  loops into one `buildToolCommands` helper. Panel placement locked by
+  `TestSketchTabPanelsMatchInventor`. Deferred: **Stretch** (vertex-window selection) and
+  the head ImGui param dialogs (thin layer over the setters). Core suite + head green.
+- **2026-06-04:** **Canonical Inventor ribbon structure documented (user direction).** Our
+  ribbon panels deviated from Inventor's; captured the authoritative tab→panel→button tree
+  in [`../architecture/mapping/inventor-ribbon-structure.md`](../architecture/mapping/inventor-ribbon-structure.md)
+  (2026.1 Default) as the source of truth, linked from CONVENTIONS (DoD) and core/09-ui.
+  Then aligned the whole **Sketch tab** to it: Dimension + Auto Dimension → **Constrain**
+  (no phantom "Dimension" panel), **Mirror → Pattern** (new panel), **Fillet → Create**;
+  Modify now = Offset/Trim/Extend/Split. Locked by `app.TestSketchTabPanelsMatchInventor`.
+  Remaining (missing *tools*, not misplacements): Create Slot/Chamfer/Text, Modify Move/
+  Copy/Rotate/Scale/Stretch, Pattern Rectangular/Circular; non-canonical `Draw` panel
+  (Project Geometry) under review. Part Pattern/Surface panels reserved for upcoming UI.
+  Core suite + head green.
+- **2026-06-04:** **Audit + PartDocument-completion kickoff (REPORT.md / PARTDOC-PLAN.md).**
+  Full code-vs-docs audit (REPORT.md at repo root); reconciled this tracker, README totals
+  (24 milestones / 135 features / 262 PBIs), and backfilled M19's missing feature/PBI
+  files; added the three-axis status model (Model/Geometry/UI+e2e) to CONVENTIONS.md and a
+  deferral ledger (DEFERRALS.md). Added a `head` cgo CI job (lavapipe+xvfb) so the e2e UI
+  tests finally run. **Phase 0 enablers:** fixed **T-01** (`TestAddInExtendsRibbonAndActsOnClick`
+  — a stale test driving a ZeroDoc session against a Part-ribbon-defaulted add-in button,
+  not a product bug) and **K2** (`geom.TransformCurve/Surface` now handle NURBS via
+  control-point transform — exact for affine; weights/knots/degree invariant; 5 tests).
+  **Phase 1 (Sketch2D) — curve trim/extend, two horizontal slices landed:**
+  (1) *kernel-shared* **2D analytic intersection** primitives — `LineCircle2dIntersection`,
+  `SegmentCircle2dIntersection`, `Circle2dCircle2dIntersection`, `Arc2d.ContainsAngle/
+  ContainsPoint` (`kernel/geom`, 100% on the intersection funcs);
+  (2) *model-domain* — `model/sketch` line **trim & extend now cut against circles and
+  arcs** (honoring arc sweep), via `edit_trim_curves.go` adapters + a generalized
+  crossing/extension engine, closing the line-only follow-up noted in `edit_trim.go`;
+  (3) *ui-domain* — **Trim / Extend / Split sketch tools** (`app/sketch_trim_tools.go`) +
+  ribbon commands (`Sketch.Trim`/`Extend`/`Split`, aliases X/EX/SX, Modify panel) + 6
+  headless e2e tests driving pick→commit→validated edit. **Curve-trim/extend now meets the
+  DoD** (model+geometry+UI+e2e) at the same bar as the offset/mirror tools (click tools,
+  no dialog); (4) *enhancement* — trimming a **circle or arc as the target**
+  (`edit_trim_curve_targets.go`): a trimmed circle becomes its complementary arc, a trimmed
+  arc keeps the remaining arc(s); Trim tool + router `sketch.transform` dispatch on
+  line/circle/arc. Also fixed a latent bug where `removeEntity` left a deleted curve in its
+  typed collection — new `deleteEntity` prunes both. **Curve trim/extend/split is now
+  complete across line/circle/arc.** K1 (boolean robustness) parked per user direction.
+  Core suite + head green.
+- **2026-06-04:** **Sketch2D residual — AutoDimension rewritten to be well-constrained +
+  given a ribbon command.** The old `AutoDimension` grounded whole *entities* until DOF=0,
+  which double-fixed shared points and left the sketch **over-constrained** (redundant). It
+  now greedily adds candidates — length/radius **dimensions** first, then per-**point**
+  grounds — each accepted only if it lowers DOF *without* raising redundancy (rank-guarded
+  via `AnalyzeConstraints`), so the result is **WellConstrained, 0 redundancy**, and
+  dimensions are real/editable + placed at current values (geometry-preserving). Added
+  `DimensionConstraints.Delete` (prunes the dim + its parameter) for the trials. UI:
+  `Sketch.AutoDimension` ribbon command (Dimension panel) + e2e; the `sketch.autoDimension`
+  wire method already existed. Tests assert well-constrained/no-redundancy/real-dims/
+  geometry-preserved. Core suite + head green.
 - **2026-06-02:** **Usable Extrude in the head: distance dialog + profile-pick feedback
   (M05 UI, user direction).** Even with finished sketches now pickable, the head had no
   way to *complete* an extrude — picking a profile stored it on the tool with no highlight,

--- a/implementation-plan/README.md
+++ b/implementation-plan/README.md
@@ -25,7 +25,7 @@ rules (units, identity, transactions, events) that apply to every milestone.
 | **M02** | [Units, Parameters & Expressions](M02-units-parameters-expressions/_milestone.md) | 4 | 10 | M00 |
 | **M03** | [Documents, Persistence & Identity](M03-documents-persistence-identity/_milestone.md) | 6 | 13 | M00, M02 |
 | **M04** | [Transactions, Undo & Events](M04-transactions-undo-events/_milestone.md) | 4 | 8 | M03 |
-| **M05** | [Application UI, Commands, Interaction & Add-in Platform](M05-ui-commands-addins/_milestone.md) | 5 | 12 | M04 |
+| **M05** | [Application UI, Commands, Interaction & Add-in Platform](M05-ui-commands-addins/_milestone.md) | 6 | 21 | M04 |
 | **M06** | [2D/3D Sketching & Constraint Solver](M06-sketching-constraints/_milestone.md) | 6 | 13 | M01, M02, M05 |
 | **M07** | [B-Rep Modeling Kernel & Topology](M07-brep-kernel-topology/_milestone.md) | 4 | 8 | M01, M03 |
 | **M08** | [Part Modeling: Sketched & Work Features](M08-part-sketched-work-features/_milestone.md) | 4 | 12 | M06, M07 |
@@ -39,9 +39,16 @@ rules (units, identity, transactions, events) that apply to every milestone.
 | **M16** | [Visualization, Appearances, Styles & Presentations](M16-visualization-presentation/_milestone.md) | 4 | 7 | M07, M11 |
 | **M17** | [Interoperability & Translation](M17-interoperability-translation/_milestone.md) | 4 | 6 | M07 |
 | **M18** | [Analysis, Measurement & Simulation](M18-analysis-simulation/_milestone.md) | 5 | 7 | M07, M11, M16 |
+| **M19** | [Materials & Appearances](M19-materials-appearances/_milestone.md) | 7¹ | 7¹ | M07, M16 |
 | **M20** | [Feature Completion & Geometry Parity](M20-feature-completion-geometry/_milestone.md) | 15 | 24 | M08, M09, M10 |
 | **M21** | [Sketch2D Feature Completion (2D Parity)](M21-sketch2d-feature-completion/_milestone.md) | 11 | 22 | M06, M08 |
+| **M22** | [Sketch3D Feature Completion (3D Parity)](M22-sketch3d-feature-completion/_milestone.md) | 12 | 18 | M06, M07, M08 |
 | **M23** | [Renderer Display-Mode Parity & Realistic PBR](M23-renderer-display-modes/_milestone.md) | 4 | 12 | M07, M16, M19 |
+
+¹ M19 (Materials & Appearances) shipped real code (`model/material`, `app/materials*`,
+head Materials/Appearance windows) ahead of its plan files; its 7 feature/PBI files were
+**backfilled from the code on 2026-06-04** (see audit REPORT.md / ACTION-PLAN.md). The
+F07 (Materials UI) e2e grade is unverified pending a head-test CI gate.
 
 ## Dependency spine
 
@@ -75,6 +82,13 @@ generation for each modeling capability are delivered incrementally alongside M0
 
 ## Totals
 
-- Milestones: **19**
-- Features: **85**
-- PBIs: **170**
+_(Reconciled against the filesystem on 2026-06-04 — see audit REPORT.md. Counts are
+`_feature.md` / `PBI-*.md` file counts.)_
+
+- Milestones: **24** (M00–M23)
+- Features: **135** (incl. M19's 7 backfilled feature files — note ¹ above)
+- PBIs: **262** (incl. M19's 7 backfilled PBIs)
+
+> Note: these are *planned* counts (files that exist), not *done* counts. For actual
+> completion status — graded on the three axes Model / Geometry / UI+e2e
+> (see CONVENTIONS.md "Status model") — read [PROGRESS.md](PROGRESS.md).

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -23,12 +23,14 @@ const (
 var ErrNonPlanar = errors.New("brep: boolean requires planar-faceted solids")
 
 // subFace is one region a face is split into, with an interior point for classification
-// and the outward normal it should carry in the result.
+// and the outward normal it should carry in the result. lineage carries the source face's
+// lineage forward so the result face's reference key survives the boolean (K1a).
 type subFace struct {
-	outer  []math.Point3
-	holes  [][]math.Point3
-	normal math.Vector3
-	point  math.Point3
+	outer   []math.Point3
+	holes   [][]math.Point3
+	normal  math.Vector3
+	point   math.Point3
+	lineage topo.Lineage
 }
 
 // Boolean computes A op B as a clean planar B-rep: it imprints the face–face intersection
@@ -121,13 +123,31 @@ func minf(a, b float64) float64 {
 func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, others []planarFace, op Op, isB bool) []subFace {
 	var kept []subFace
 	for i, f := range faces {
+		var fromFace []subFace
 		for _, sf := range splitFace(f, imprints[i]) {
 			if out, ok := classifySubFace(sf, f, other, others, op, isB); ok {
-				kept = append(kept, out)
+				fromFace = append(fromFace, out)
 			}
 		}
+		// A face that survives as a single piece carries its source lineage unchanged, so
+		// its reference key is identical after the boolean (K1a). A face split into several
+		// kept pieces gives each a distinct child lineage (parent + split#k).
+		for k := range fromFace {
+			if len(fromFace) == 1 {
+				fromFace[k].lineage = f.lineage
+			} else {
+				fromFace[k].lineage = splitLineage(f.lineage, k)
+			}
+		}
+		kept = append(kept, fromFace...)
 	}
 	return kept
+}
+
+// splitLineage derives a distinct child lineage for the k-th piece of a face split into
+// several by the boolean.
+func splitLineage(parent topo.Lineage, k int) topo.Lineage {
+	return topo.NewLineage(append(parent.Tokens(), topo.Tok("brep", "split", k))...)
 }
 
 // classifySubFace decides whether a sub-face survives. A fragment coplanar with a face of

--- a/kernel/brep/boolean_geom.go
+++ b/kernel/brep/boolean_geom.go
@@ -10,12 +10,14 @@ import (
 	"github.com/Oblikovati/oblikovati/math"
 )
 
-// planarFace is a planar face flattened for the boolean: its plane, outward normal, and
-// boundary loops as 3D point rings (loops[0] = outer, the rest = holes).
+// planarFace is a planar face flattened for the boolean: its plane, outward normal,
+// boundary loops as 3D point rings (loops[0] = outer, the rest = holes), and the source
+// face's lineage so a result face can carry it forward (reference-key survival, K1a).
 type planarFace struct {
-	plane  geom.Plane
-	normal math.Vector3
-	loops  [][]math.Point3
+	plane   geom.Plane
+	normal  math.Vector3
+	loops   [][]math.Point3
+	lineage topo.Lineage
 }
 
 // facesOf flattens a body's planar faces. A non-planar face makes it return ok=false (the
@@ -27,7 +29,7 @@ func facesOf(b *topo.Body) ([]planarFace, bool) {
 		if !ok {
 			return nil, false
 		}
-		out = append(out, planarFace{plane: pl, normal: f.Geometry().NormalAt(0, 0), loops: loopRings(f)})
+		out = append(out, planarFace{plane: pl, normal: f.Geometry().NormalAt(0, 0), loops: loopRings(f), lineage: f.Lineage()})
 	}
 	return out, true
 }

--- a/kernel/brep/boolean_refkey_test.go
+++ b/kernel/brep/boolean_refkey_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// boxNamed builds a box whose faces carry the given feature name in their lineage, so two
+// operands can have distinct reference keys.
+func boxNamed(name string, px, py, pz, sx, sy, sz float64) *topo.Body {
+	m := subd.Box(sx, sy, sz)
+	for i := range m.Verts {
+		m.Verts[i] = m.Verts[i].TranslateBy(math.V3(px, py, pz))
+	}
+	return subd.ToBody(m, name)
+}
+
+// faceWithNormal returns the first face whose outward normal points along dir.
+func faceWithNormal(b *topo.Body, dir math.Vector3) *topo.Face {
+	for _, f := range b.Faces() {
+		if f.Geometry().NormalAt(0, 0).Dot(dir) > 0.9 {
+			return f
+		}
+	}
+	return nil
+}
+
+// K1a: a face that survives a boolean unchanged keeps its reference key, so a pick made
+// before the boolean rebinds to the result face afterwards.
+func TestBooleanPreservesSurvivingFaceKey(t *testing.T) {
+	a := boxNamed("partA", 0, 0, 0, 2, 2, 2)
+	b := boxNamed("partB", 5, 0, 0, 2, 2, 2) // disjoint: every A face survives whole
+
+	key := a.Faces()[0].ReferenceKey()
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := res.FindFaceByKey(key); !ok {
+		t.Fatal("a surviving face's reference key did not carry through the union (K1a)")
+	}
+}
+
+// A face untouched by a Cut keeps its key (the part-side pick survives a hole/cut edit).
+func TestBooleanCutPreservesUntouchedFaceKey(t *testing.T) {
+	// A=[0,2]³; B overlaps the top, leaving A's bottom face (z=0, normal −Z) untouched.
+	a := boxNamed("part", 0, 0, 0, 2, 2, 2)
+	b := boxNamed("tool", 1, 0.5, 0.5, 2, 2, 2)
+	bottom := faceWithNormal(a, math.V3(0, 0, -1))
+	if bottom == nil {
+		t.Fatal("no bottom face on A")
+	}
+	key := bottom.ReferenceKey()
+
+	res, err := brep.Boolean(brep.Difference, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := res.FindFaceByKey(key); !ok {
+		t.Fatal("the untouched bottom face's key did not survive the cut (K1a)")
+	}
+}
+
+// Sanity: the disjoint union is still a valid two-shell solid (volume 16).
+func TestBooleanDisjointUnionValid(t *testing.T) {
+	a := boxNamed("a", 0, 0, 0, 2, 2, 2)
+	b := boxNamed("b", 5, 0, 0, 2, 2, 2)
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil || res == nil {
+		t.Fatalf("disjoint union: %v", err)
+	}
+	if v := vol(res); stdmath.Abs(v-16) > 1e-6 {
+		t.Errorf("disjoint union volume = %g, want 16", v)
+	}
+}

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -14,7 +14,9 @@ import (
 // stitch welds the kept sub-faces into a watertight B-rep: coincident vertices merge, one
 // shared edge per undirected vertex pair, and a face per sub-face (outer loop oriented CCW
 // about its normal, holes CW). The body is a solid when every edge is used exactly twice.
-// Lineage is freshly synthesized (operand reference-key survival is a follow-up).
+// Result faces carry their source face's lineage (K1a), so a face surviving the boolean
+// keeps its reference key; edges/vertices still get fresh lineage (edge-key survival is a
+// follow-up, as edges are routinely split by the operation).
 func stitch(faces []subFace) (*topo.Body, error) {
 	if len(faces) == 0 {
 		return nil, nil
@@ -28,7 +30,7 @@ func stitch(faces []subFace) (*topo.Body, error) {
 			rings = append(rings, w.ring(orientRing(h, sf.normal, false)))
 		}
 		surf, _ := geom.NewPlane(centroid3(sf.outer), sf.normal)
-		out[i] = builtFace{rings, surf}
+		out[i] = builtFace{rings: rings, surf: surf, lineage: sf.lineage}
 	}
 	// Pass 2: with all vertices known, split every loop edge at any welded vertex lying on
 	// it — propagating each imprint split-point to the neighbour face sharing that edge, so
@@ -114,10 +116,11 @@ func collectSegHits(pa math.Point3, ab math.Vector3, lenSq float64, onRing map[i
 }
 
 // builtFace is a welded sub-face ready for assembly: its loop rings (vertex indices, outer
-// first) and its planar surface.
+// first), its planar surface, and the source lineage to carry onto the result face (K1a).
 type builtFace struct {
-	rings [][]int
-	surf  geom.Plane
+	rings   [][]int
+	surf    geom.Plane
+	lineage topo.Lineage
 }
 
 // assemble builds the topo body from welded vertices, per-face loop rings, and the edge
@@ -134,9 +137,18 @@ func assemble(verts []math.Point3, faces []builtFace, edgeUse map[[2]int]int) *t
 		for ri, r := range f.rings {
 			specs[ri] = loopSpec(ri == 0, r, edges)
 		}
-		bld.AddFace(f.surf, topo.NewLineage(topo.Tok("brep", "face", fi)), specs...)
+		bld.AddFace(f.surf, faceLineage(f, fi), specs...)
 	}
 	return bld.Build()
+}
+
+// faceLineage uses the source face's carried lineage when present (K1a reference-key
+// survival), falling back to a synthesized one for any face without a source.
+func faceLineage(f builtFace, fi int) topo.Lineage {
+	if len(f.lineage.Tokens()) > 0 {
+		return f.lineage
+	}
+	return topo.NewLineage(topo.Tok("brep", "face", fi))
 }
 
 // allEdgesPaired reports whether every undirected edge is used exactly twice — the

--- a/kernel/brep/cylinder.go
+++ b/kernel/brep/cylinder.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// SolidCylinder builds a closed analytic cylinder B-rep (K1b): one true cylindrical side
+// face (not faceted) plus two planar circular caps, sharing two closed-circle edges and a
+// vertical seam edge. axis must be a unit vector. It is the first analytic curved solid in
+// the kernel and the clean drill-tool body the curved boolean will subtract.
+//
+// Topology (the classic periodic cylinder): the side is a periodic face made simply-
+// connected by the seam — its loop runs up the seam, around the top circle, down the seam,
+// around the bottom circle, so the seam carries two opposite uses and each circle is shared
+// with its cap in opposite orientations (a valid manifold solid per ops.Validate).
+//
+// The full 2π-periodic side tessellates over its true trim via ops.periodicBandGrid (so its
+// area/volume are correct, a hair under exact from chord inscription). This constructor is
+// not yet wired into the boolean — that is K1b slice 3 (a cylinder Cut → a clean drilled hole).
+func SolidCylinder(baseCenter math.Point3, axis math.Vector3, radius, height float64) (*topo.Body, error) {
+	bottom, err := geom.NewCircle(baseCenter, axis, radius)
+	if err != nil {
+		return nil, err
+	}
+	topCenter := baseCenter.TranslateBy(axis.Scale(math.Scalar(height)))
+	// Share the bottom circle's frame so the seam is a single vertical line at angle 0.
+	top := geom.Circle{Center: topCenter, Normal: bottom.Normal, RefDir: bottom.RefDir, Radius: radius}
+
+	side, err := geom.NewCylinder(baseCenter, axis, radius)
+	if err != nil {
+		return nil, err
+	}
+	capBottom, err := geom.NewPlane(baseCenter, axis.Scale(-1)) // outward = −axis
+	if err != nil {
+		return nil, err
+	}
+	capTop, err := geom.NewPlane(topCenter, axis) // outward = +axis
+	if err != nil {
+		return nil, err
+	}
+
+	vbp, vtp := bottom.PointAt(0), top.PointAt(0) // seam endpoints (angle 0 on each circle)
+	bld := topo.NewBuilder(true, cylLin("body", 0))
+	vb := bld.AddVertex(vbp, cylLin("v", 0))
+	vt := bld.AddVertex(vtp, cylLin("v", 1))
+	eb := bld.AddEdge(bottom, vb, vb, cylLin("e", 0)) // closed bottom circle
+	et := bld.AddEdge(top, vt, vt, cylLin("e", 1))    // closed top circle
+	es := bld.AddEdge(geom.NewLineSegment(vbp, vtp), vb, vt, cylLin("e", 2))
+
+	bld.AddFace(capBottom, cylLin("f", 0), topo.OuterLoop(topo.Rev(eb)))
+	bld.AddFace(capTop, cylLin("f", 1), topo.OuterLoop(topo.Fwd(et)))
+	// Periodic side: seam up, top circle (opposite the cap), seam down, bottom circle.
+	bld.AddFace(side, cylLin("f", 2), topo.OuterLoop(topo.Fwd(es), topo.Rev(et), topo.Rev(es), topo.Fwd(eb)))
+	return bld.Build(), nil
+}
+
+func cylLin(role string, i int) topo.Lineage { return topo.NewLineage(topo.Tok("cylinder", role, i)) }

--- a/kernel/brep/cylinder_test.go
+++ b/kernel/brep/cylinder_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// SolidCylinder builds a valid analytic solid: one true cylinder face + two planar caps,
+// with a volume of π·r²·h (the first curved-face B-rep in the kernel, K1b slice 2).
+func TestSolidCylinderIsValidAnalyticSolid(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(cyl); !r.Valid || !cyl.IsSolid() {
+		t.Fatalf("solid cylinder is not a valid solid: %+v", r)
+	}
+	if len(cyl.Faces()) != 3 {
+		t.Fatalf("faces = %d, want 3 (two caps + one side)", len(cyl.Faces()))
+	}
+
+	nCyl, nPlane := 0, 0
+	for _, f := range cyl.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			nCyl++
+		case geom.Plane:
+			nPlane++
+		}
+	}
+	if nCyl != 1 || nPlane != 2 {
+		t.Errorf("face surfaces = %d cylinder / %d plane, want 1 / 2 (a real curved face)", nCyl, nPlane)
+	}
+	// The full 2π-periodic side now tessellates over its true trim (periodicBandGrid), so the
+	// volume is the inscribed polyhedron's ≈ π·r²·h — always a hair UNDER exact (chords inside
+	// the arc), here ~2.5% at default circle resolution.
+	want := stdmath.Pi * 4 * 5 // π·r²·h
+	if v := vol(cyl); v > want+1e-9 || (want-v)/want > 0.03 {
+		t.Errorf("volume = %g, want a hair under %g (π·2²·5, inscribed)", v, want)
+	}
+}
+
+// The side is a periodic face: its seam edge carries two opposite uses (watertight).
+func TestSolidCylinderWatertight(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(1, 2, 0), math.V3(0, 0, 1), 1.5, 3)
+	if open := ops.BoundaryEdges(cyl); len(open) != 0 {
+		t.Fatalf("solid cylinder has %d boundary edges, want 0 (watertight)", len(open))
+	}
+}

--- a/kernel/brep/drill.go
+++ b/kernel/brep/drill.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// CutCylindricalHole drills a clean cylindrical through-hole in a planar-faced slab — the
+// first end-to-end plane∩cylinder boolean (K1b slice 3) and the geometry a "through all"
+// Hole feature needs. The cylinder axis (line through base along axisDir) must enter and
+// exit through two planar faces whose interiors fully contain the hole circle; every other
+// face is parallel to the axis and is copied unchanged. The result is a TRUE curved B-rep:
+// the two pierced faces gain a circular hole, a single cylinder face forms the hole wall
+// (its material side faces the axis, AddReversedFace), and — because copied/pierced faces
+// keep their source lineage — every original face's reference key survives the cut (K1a/K1b).
+//
+// Partial holes (the circle clipping a face boundary, or a blind hole) need the general
+// curved arrangement and return an error here — that is a later K1b slice.
+func CutCylindricalHole(slab *topo.Body, base math.Point3, axisDir math.Vector3, radius float64) (*topo.Body, error) {
+	if radius <= 0 {
+		return nil, fmt.Errorf("brep: drill radius must be positive, got %g", radius)
+	}
+	ua := unit(axisDir)
+	if ua.LengthSquared() < 0.5 {
+		return nil, fmt.Errorf("brep: drill axis direction is degenerate: %+v", axisDir)
+	}
+	copied, caps, err := classifyDrillFaces(slab, base, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	return assembleDrilled(copied, caps, ua, radius)
+}
+
+// drillCap is a planar face the hole axis pierces (an entry/exit face), with the pierce
+// point and its parameter along the axis (used to order entry before exit).
+type drillCap struct {
+	face   planarFace
+	center math.Point3
+	param  float64
+}
+
+// classifyDrillFaces splits the slab's planar faces into the two the axis drills through
+// (perpendicular to the axis, interior fully containing the circle) and the rest (copied).
+func classifyDrillFaces(slab *topo.Body, base math.Point3, ua math.Vector3, radius float64) (copied []planarFace, caps []drillCap, err error) {
+	faces, ok := facesOf(slab)
+	if !ok {
+		return nil, nil, ErrNonPlanar
+	}
+	for _, f := range faces {
+		if stdmath.Abs(float64(f.normal.Dot(ua))) < 1-1e-7 {
+			copied = append(copied, f) // a wall the hole runs alongside — unchanged
+			continue
+		}
+		t := pierceParam(base, ua, f.plane)
+		c := base.TranslateBy(ua.Scale(math.Scalar(t)))
+		if !circleInsideFace(c, f, radius) {
+			return nil, nil, fmt.Errorf("brep: hole circle (r=%g at %+v) does not fit inside the pierced face; partial holes need the general boolean", radius, c)
+		}
+		caps = append(caps, drillCap{face: f, center: c, param: t})
+	}
+	if len(caps) != 2 {
+		return nil, nil, fmt.Errorf("brep: a through-hole needs exactly 2 perpendicular pierced faces, found %d", len(caps))
+	}
+	if caps[0].param > caps[1].param {
+		caps[0], caps[1] = caps[1], caps[0]
+	}
+	return copied, caps, nil
+}
+
+// pierceParam returns the parameter t where the axis line (base + t·ua) meets the plane.
+func pierceParam(base math.Point3, ua math.Vector3, pl geom.Plane) float64 {
+	n := unit(pl.Normal())
+	return float64(base.VectorTo(pl.Origin).Dot(n)) / float64(ua.Dot(n))
+}
+
+// circleInsideFace reports whether the hole circle (center, radius, in the face plane) lies
+// strictly inside the face — its center and a ring of rim samples are all in the face interior.
+func circleInsideFace(center math.Point3, f planarFace, radius float64) bool {
+	if !pointInFace2D(to2D(f.plane, center), f) {
+		return false
+	}
+	u, v := f.plane.UAxis.AsVector(), f.plane.VAxis.AsVector()
+	const samples = 24
+	for i := 0; i < samples; i++ {
+		a := 2 * stdmath.Pi * float64(i) / samples
+		rim := center.TranslateBy(u.Scale(math.Scalar(radius * stdmath.Cos(a)))).TranslateBy(v.Scale(math.Scalar(radius * stdmath.Sin(a))))
+		if !pointInFace2D(to2D(f.plane, rim), f) {
+			return false
+		}
+	}
+	return true
+}
+
+// assembleDrilled welds the copied + pierced planar faces, adds a circular hole to each
+// pierced face, and joins them with a single cylinder wall face into a watertight solid.
+func assembleDrilled(copied []planarFace, caps []drillCap, ua math.Vector3, radius float64) (*topo.Body, error) {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("brep", "drill", 0)))
+	planar := append(append([]planarFace{}, copied...), caps[0].face, caps[1].face)
+
+	w := newWelder3()
+	rings, edgeUse := weldPlanarFaces(w, planar)
+	tv := make([]*topo.Vertex, len(w.points))
+	for i, p := range w.points {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
+	}
+	lineEdges := buildEdges(bld, w.points, tv, edgeUse)
+	holeLo, holeHi, seam, cyl, err := buildHoleEdges(bld, caps, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+
+	loEntry, hiEntry := len(planar)-2, len(planar)-1
+	for fi, f := range planar {
+		specs := planarLoopSpecs(rings[fi], lineEdges)
+		switch fi {
+		case loEntry:
+			specs = append(specs, topo.InnerLoop(topo.Fwd(holeLo)))
+		case hiEntry:
+			specs = append(specs, topo.InnerLoop(topo.Fwd(holeHi)))
+		}
+		bld.AddFace(f.plane, f.lineage, specs...) // copied/pierced faces keep their key (K1a)
+	}
+	// The wall's surface normal is outward-radial, so its material side faces the axis.
+	bld.AddReversedFace(cyl, topo.NewLineage(topo.Tok("brep", "wall", 0)),
+		topo.OuterLoop(topo.Rev(holeLo), topo.Fwd(seam), topo.Rev(holeHi), topo.Rev(seam)))
+	return bld.Build(), nil
+}
+
+// weldPlanarFaces welds every face's loops to shared vertex indices and tallies undirected
+// edge uses (so faces sharing a box edge resolve to one edge).
+func weldPlanarFaces(w *welder3, planar []planarFace) (rings [][][]int, edgeUse map[[2]int]int) {
+	rings = make([][][]int, len(planar))
+	edgeUse = map[[2]int]int{}
+	for fi, f := range planar {
+		for _, loop := range f.loops {
+			r := w.ring(loop)
+			rings[fi] = append(rings[fi], r)
+			for i := range r {
+				edgeUse[canonEdge(r[i], r[(i+1)%len(r)])]++
+			}
+		}
+	}
+	return rings, edgeUse
+}
+
+// planarLoopSpecs turns a face's welded rings (outer first) into loop specs on shared edges.
+func planarLoopSpecs(faceRings [][]int, edges map[[2]int]*topo.Edge) []topo.LoopSpec {
+	specs := make([]topo.LoopSpec, len(faceRings))
+	for ri, r := range faceRings {
+		specs[ri] = loopSpec(ri == 0, r, edges)
+	}
+	return specs
+}
+
+// buildHoleEdges builds the two closed hole circles (sharing a frame so the seam is axial),
+// the seam edge joining them, and the wall cylinder. The circles are reused by both a pierced
+// face (as a hole) and the wall, so they stitch the wall to the slab watertight.
+func buildHoleEdges(bld *topo.Builder, caps []drillCap, ua math.Vector3, radius float64) (holeLo, holeHi, seam *topo.Edge, cyl geom.Cylinder, err error) {
+	circLo, err := geom.NewCircle(caps[0].center, ua, radius)
+	if err != nil {
+		return nil, nil, nil, geom.Cylinder{}, err
+	}
+	circHi := geom.Circle{Center: caps[1].center, Normal: circLo.Normal, RefDir: circLo.RefDir, Radius: radius}
+	pLo, pHi := circLo.PointAt(0), circHi.PointAt(0)
+	vLo := bld.AddVertex(pLo, topo.NewLineage(topo.Tok("brep", "seam", 0)))
+	vHi := bld.AddVertex(pHi, topo.NewLineage(topo.Tok("brep", "seam", 1)))
+	holeLo = bld.AddEdge(circLo, vLo, vLo, topo.NewLineage(topo.Tok("brep", "hole", 0)))
+	holeHi = bld.AddEdge(circHi, vHi, vHi, topo.NewLineage(topo.Tok("brep", "hole", 1)))
+	seam = bld.AddEdge(geom.NewLineSegment(pLo, pHi), vLo, vHi, topo.NewLineage(topo.Tok("brep", "seam", 2)))
+	cyl, err = geom.NewCylinder(caps[0].center, ua, radius)
+	return holeLo, holeHi, seam, cyl, err
+}

--- a/kernel/brep/drill_blind.go
+++ b/kernel/brep/drill_blind.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// CutBlindCylindricalHole drills a flat-bottomed blind hole (K1b): the cylinder enters one
+// planar face and stops at `depth` inside the material, so the result adds a circular hole in
+// the entry face, a true cylinder wall, and a flat circular bottom disk (facing back toward
+// the opening). The hole must stay entirely inside the part (the bottom and its rim interior),
+// the entry face must be planar and perpendicular to the axis with the circle fitting inside,
+// and every other face is copied unchanged (keeping its reference key). A conical drill point
+// and a hole that exits/clips a face are later slices — those return an error here so the
+// caller can fall back to the faceted boolean.
+func CutBlindCylindricalHole(slab *topo.Body, base math.Point3, axisDir math.Vector3, radius, depth float64) (*topo.Body, error) {
+	if radius <= 0 || depth <= 0 {
+		return nil, fmt.Errorf("brep: blind hole needs radius>0 and depth>0, got r=%g depth=%g", radius, depth)
+	}
+	ua := unit(axisDir)
+	if ua.LengthSquared() < 0.5 {
+		return nil, fmt.Errorf("brep: drill axis direction is degenerate: %+v", axisDir)
+	}
+	copied, entry, err := classifyBlindDrill(slab, base, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	bottom := base.TranslateBy(ua.Scale(math.Scalar(depth)))
+	if err := checkBlindFits(slab, entry, bottom, radius); err != nil {
+		return nil, err
+	}
+	return assembleBlind(copied, entry, base, bottom, ua, radius)
+}
+
+// classifyBlindDrill finds the single planar entry face (perpendicular to the axis, with the
+// base on its plane and the circle inside) and returns every other face as copied-unchanged.
+func classifyBlindDrill(slab *topo.Body, base math.Point3, ua math.Vector3, radius float64) (copied []planarFace, entry planarFace, err error) {
+	faces, ok := facesOf(slab)
+	if !ok {
+		return nil, planarFace{}, ErrNonPlanar
+	}
+	found := false
+	for _, f := range faces {
+		isEntry := float64(f.normal.Dot(ua)) < -1+1e-7 && stdmath.Abs(pierceParam(base, ua, f.plane)) < 1e-6
+		if !isEntry {
+			copied = append(copied, f)
+			continue
+		}
+		if !circleInsideFace(base, f, radius) {
+			return nil, planarFace{}, fmt.Errorf("brep: blind hole circle (r=%g) does not fit inside the entry face", radius)
+		}
+		if found {
+			return nil, planarFace{}, fmt.Errorf("brep: ambiguous entry face for blind hole at %+v", base)
+		}
+		entry, found = f, true
+	}
+	if !found {
+		return nil, planarFace{}, fmt.Errorf("brep: no planar entry face perpendicular to the drill axis at %+v", base)
+	}
+	return copied, entry, nil
+}
+
+// checkBlindFits verifies the hole bottom (centre and rim) stays strictly inside the part, so
+// the blind pocket does not exit or clip another face.
+func checkBlindFits(slab *topo.Body, entry planarFace, bottom math.Point3, radius float64) error {
+	if !insideSolid(slab, bottom) {
+		return fmt.Errorf("brep: blind hole bottom at %+v is outside the part (depth too large)", bottom)
+	}
+	u, v := entry.plane.UAxis.AsVector(), entry.plane.VAxis.AsVector()
+	const samples = 8
+	for i := 0; i < samples; i++ {
+		a := 2 * stdmath.Pi * float64(i) / samples
+		rim := bottom.TranslateBy(u.Scale(math.Scalar(radius * stdmath.Cos(a)))).TranslateBy(v.Scale(math.Scalar(radius * stdmath.Sin(a))))
+		if !insideSolid(slab, rim) {
+			return fmt.Errorf("brep: blind hole (r=%g) does not stay inside the part", radius)
+		}
+	}
+	return nil
+}
+
+// assembleBlind welds the bore (entry hole + cylinder wall) and caps it with a flat bottom disk
+// whose outward normal faces back toward the opening (−axis).
+func assembleBlind(copied []planarFace, entry planarFace, base, bottom math.Point3, ua math.Vector3, radius float64) (*topo.Body, error) {
+	bld, holeBot, err := blindBore(copied, entry, base, bottom, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	botPlane, err := geom.NewPlane(bottom, ua.Scale(-1))
+	if err != nil {
+		return nil, err
+	}
+	bld.AddFace(botPlane, topo.NewLineage(topo.Tok("brep", "holebottom", 0)), topo.OuterLoop(topo.Fwd(holeBot)))
+	return bld.Build(), nil
+}
+
+// blindBore welds the copied + entry planar faces, holes the entry, and adds the cylinder wall.
+// It returns the builder and the bottom rim edge so the caller can cap the bore (a flat disk for
+// a drilled flat bottom, or a cone for a conical drill point).
+func blindBore(copied []planarFace, entry planarFace, base, bottom math.Point3, ua math.Vector3, radius float64) (*topo.Builder, *topo.Edge, error) {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("brep", "drill", 0)))
+	planar := append(append([]planarFace{}, copied...), entry)
+
+	w := newWelder3()
+	rings, edgeUse := weldPlanarFaces(w, planar)
+	tv := make([]*topo.Vertex, len(w.points))
+	for i, p := range w.points {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
+	}
+	lineEdges := buildEdges(bld, w.points, tv, edgeUse)
+	holeEntry, holeBot, seam, cyl, err := buildHoleEdges(bld, []drillCap{{center: base}, {center: bottom}}, ua, radius)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	entryIdx := len(planar) - 1
+	for fi, f := range planar {
+		specs := planarLoopSpecs(rings[fi], lineEdges)
+		if fi == entryIdx {
+			specs = append(specs, topo.InnerLoop(topo.Fwd(holeEntry))) // entry keeps its key (K1a)
+		}
+		bld.AddFace(f.plane, f.lineage, specs...)
+	}
+	// Hole wall: surface normal is outward-radial, so its material side faces the axis.
+	bld.AddReversedFace(cyl, topo.NewLineage(topo.Tok("brep", "wall", 0)),
+		topo.OuterLoop(topo.Rev(holeEntry), topo.Fwd(seam), topo.Rev(holeBot), topo.Rev(seam)))
+	return bld, holeBot, nil
+}

--- a/kernel/brep/drill_blind_test.go
+++ b/kernel/brep/drill_blind_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// A blind hole (depth less than the thickness) is a clean watertight solid: a cylinder wall
+// plus a flat bottom disk, removing an inscribed cylinder of material.
+func TestCutBlindCylindricalHole(t *testing.T) {
+	// 10×10×4 slab, Ø4 blind hole 3 deep along +Z from the bottom face (z=0).
+	d, err := brep.CutBlindCylindricalHole(box(0, 0, 0, 10, 10, 4), math.P3(5, 5, 0), math.V3(0, 0, 1), 2, 3)
+	if err != nil {
+		t.Fatalf("CutBlindCylindricalHole: %v", err)
+	}
+	if r := ops.Validate(d); !r.Valid || !d.IsSolid() {
+		t.Fatalf("blind-drilled slab is not a valid solid: %+v", r)
+	}
+	if open := ops.BoundaryEdges(d); len(open) != 0 {
+		t.Fatalf("blind hole has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	nCyl, nPlane := 0, 0
+	for _, f := range d.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			nCyl++
+		case geom.Plane:
+			nPlane++
+		}
+	}
+	if nCyl != 1 || nPlane != 7 {
+		t.Errorf("faces = %d cylinder / %d plane, want 1 / 7 (wall + 6 slab faces + flat bottom)", nCyl, nPlane)
+	}
+	// Removed = an inscribed Ø4 cylinder 3 deep: a hair under π·r²·depth.
+	const bore = stdmath.Pi * 2 * 2 * 3
+	removed := 10.0*10.0*4.0 - vol(d)
+	if removed <= 0 || removed > bore+1e-9 || (bore-removed)/bore > 0.04 {
+		t.Errorf("removed volume = %g, want a hair under %g (π·r²·depth)", removed, bore)
+	}
+}
+
+// A depth that would punch through the part is rejected (the through specialization or the
+// general boolean handles that), rather than building a broken body.
+func TestCutBlindRejectsThroughDepth(t *testing.T) {
+	_, err := brep.CutBlindCylindricalHole(box(0, 0, 0, 10, 10, 4), math.P3(5, 5, 0), math.V3(0, 0, 1), 2, 5)
+	if err == nil {
+		t.Error("expected an error for a blind depth that exits the part, got nil")
+	}
+}

--- a/kernel/brep/drill_conical.go
+++ b/kernel/brep/drill_conical.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// CutBlindConicalHole drills a blind hole with a conical drill point (K1b): a cylinder bore of
+// `radius` to `depth` (the full-diameter depth) closed by a true CONE tip — the shape a twist
+// drill leaves. pointHalfAngle is the half-angle between the axis and the cone surface (a 118°
+// included drill point is half-angle 59°). The tip's apex is a geometric pole, not a topology
+// vertex, so the cone face's only boundary is the bore-bottom circle (tessellated as an apex
+// fan). The whole pocket, apex included, must stay inside the part or this returns an error.
+func CutBlindConicalHole(slab *topo.Body, base math.Point3, axisDir math.Vector3, radius, depth, pointHalfAngle float64) (*topo.Body, error) {
+	if radius <= 0 || depth <= 0 {
+		return nil, fmt.Errorf("brep: conical hole needs radius>0 and depth>0, got r=%g depth=%g", radius, depth)
+	}
+	if pointHalfAngle <= 0 || pointHalfAngle >= stdmath.Pi/2 {
+		return nil, fmt.Errorf("brep: drill point half-angle %g must be in (0, π/2)", pointHalfAngle)
+	}
+	ua := unit(axisDir)
+	if ua.LengthSquared() < 0.5 {
+		return nil, fmt.Errorf("brep: drill axis direction is degenerate: %+v", axisDir)
+	}
+	copied, entry, err := classifyBlindDrill(slab, base, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	bottom := base.TranslateBy(ua.Scale(math.Scalar(depth)))
+	apex := bottom.TranslateBy(ua.Scale(math.Scalar(radius / stdmath.Tan(pointHalfAngle))))
+	if err := checkBlindFits(slab, entry, bottom, radius); err != nil {
+		return nil, err
+	}
+	if !insideSolid(slab, apex) {
+		return nil, fmt.Errorf("brep: conical drill point at %+v exits the part", apex)
+	}
+	return assembleBlindConical(copied, entry, base, bottom, apex, ua, radius, pointHalfAngle)
+}
+
+// assembleBlindConical welds the bore and caps it with a cone tip (apex deep on the axis), whose
+// material side faces the axis (a reversed face) like the cylinder wall.
+func assembleBlindConical(copied []planarFace, entry planarFace, base, bottom, apex math.Point3, ua math.Vector3, radius, halfAngle float64) (*topo.Body, error) {
+	bld, holeBot, err := blindBore(copied, entry, base, bottom, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	tip, err := geom.NewCone(apex, ua.Scale(-1), halfAngle) // axis points back up toward the rim
+	if err != nil {
+		return nil, err
+	}
+	bld.AddReversedFace(tip, topo.NewLineage(topo.Tok("brep", "drillpoint", 0)), topo.OuterLoop(topo.Fwd(holeBot)))
+	return bld.Build(), nil
+}

--- a/kernel/brep/drill_conical_test.go
+++ b/kernel/brep/drill_conical_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// A blind hole with a conical drill point: a Ø2 bore 2 deep closed by a 118° cone tip in a
+// 10×10×6 slab. Valid watertight solid; removed = cylinder + cone-tip volume.
+func TestCutBlindConicalHole(t *testing.T) {
+	const half = 59.0 * stdmath.Pi / 180 // 118° included drill point
+	d, err := brep.CutBlindConicalHole(box(0, 0, 0, 10, 10, 6), math.P3(5, 5, 6), math.V3(0, 0, -1), 1, 2, half)
+	if err != nil {
+		t.Fatalf("CutBlindConicalHole: %v", err)
+	}
+	if r := ops.Validate(d); !r.Valid || !d.IsSolid() {
+		t.Fatalf("conical-drilled slab is not a valid solid: %+v", r)
+	}
+	if open := ops.BoundaryEdges(d); len(open) != 0 {
+		t.Fatalf("conical hole has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if n := countConeFaces(d); n != 1 {
+		t.Errorf("conical hole has %d cone faces, want 1 (the drill point)", n)
+	}
+	if n := countCylFaces(d); n != 1 {
+		t.Errorf("conical hole has %d cylinder faces, want 1 (the bore)", n)
+	}
+	// Removed = cylinder (π·r²·2) + cone tip (⅓·π·r²·tipHeight), tipHeight = r/tan(half).
+	tip := 1.0 / stdmath.Tan(half)
+	want := stdmath.Pi*1*1*2 + stdmath.Pi*1*1*tip/3
+	removed := 10.0*10.0*6.0 - vol(d)
+	if removed <= 0 || removed > want+1e-9 || (want-removed)/want > 0.04 {
+		t.Errorf("removed volume = %g, want a hair under %g (cylinder + cone tip)", removed, want)
+	}
+}
+
+// A conical point deep enough to exit the part is rejected.
+func TestCutBlindConicalRejectsDeepTip(t *testing.T) {
+	const half = 59.0 * stdmath.Pi / 180
+	_, err := brep.CutBlindConicalHole(box(0, 0, 0, 10, 10, 3), math.P3(5, 5, 3), math.V3(0, 0, -1), 1, 3, half)
+	if err == nil {
+		t.Error("expected an error for a conical hole that exits the part, got nil")
+	}
+}

--- a/kernel/brep/drill_counterbore.go
+++ b/kernel/brep/drill_counterbore.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// CutCounterboreHole drills a counterbore (K1b): a shallow recess of counterRadius × counterDepth
+// at the entry face, stepping down via a flat annular shoulder to a bore of boreRadius that
+// either goes through (boreThrough) or stops boreLen below the shoulder. The result is one
+// assembly built from a planar slab — entry holed, recess wall, annular shoulder, bore wall, and
+// either a holed exit face or a flat bottom — so it does NOT chain two curved cuts (which would
+// trip the planar-only boolean). Every untouched face is copied and keeps its reference key.
+// Unsupported shapes (a circle clipping a face, a blind bore that exits) return an error.
+func CutCounterboreHole(slab *topo.Body, base math.Point3, axisDir math.Vector3, boreRadius, boreLen, counterRadius, counterDepth float64, boreThrough bool) (*topo.Body, error) {
+	if boreRadius <= 0 || counterRadius <= boreRadius || counterDepth <= 0 || (!boreThrough && boreLen <= 0) {
+		return nil, fmt.Errorf("brep: counterbore needs 0<boreR(%g)<counterR(%g), counterDepth(%g)>0, boreLen(%g)>0 unless through", boreRadius, counterRadius, counterDepth, boreLen)
+	}
+	ua := unit(axisDir)
+	if ua.LengthSquared() < 0.5 {
+		return nil, fmt.Errorf("brep: drill axis direction is degenerate: %+v", axisDir)
+	}
+	copied, entry, err := classifyBlindDrill(slab, base, ua, counterRadius)
+	if err != nil {
+		return nil, err
+	}
+	shoulder := base.TranslateBy(ua.Scale(math.Scalar(counterDepth)))
+	end, exitIdx, copied, err := counterboreEnd(slab, copied, entry, base, shoulder, ua, boreRadius, boreLen, boreThrough)
+	if err != nil {
+		return nil, err
+	}
+	return assembleCounterbore(copied, entry, exitIdx, base, shoulder, end, ua, boreRadius, counterRadius, boreThrough)
+}
+
+// counterboreEnd resolves where the bore ends: a through bore finds the exit face (returned via
+// its index in the copied list); a blind bore stops inside and is checked for containment.
+func counterboreEnd(slab *topo.Body, copied []planarFace, entry planarFace, base, shoulder math.Point3, ua math.Vector3, boreRadius, boreLen float64, through bool) (end math.Point3, exitIdx int, rest []planarFace, err error) {
+	if !through {
+		end = shoulder.TranslateBy(ua.Scale(math.Scalar(boreLen)))
+		if err := checkBlindFits(slab, entry, end, boreRadius); err != nil {
+			return math.Point3{}, -1, nil, err
+		}
+		return end, -1, copied, nil
+	}
+	for i, f := range copied {
+		if float64(f.normal.Dot(ua)) <= 1-1e-7 {
+			continue
+		}
+		c := base.TranslateBy(ua.Scale(math.Scalar(pierceParam(base, ua, f.plane))))
+		if circleInsideFace(c, f, boreRadius) {
+			return c, i, copied, nil
+		}
+	}
+	return math.Point3{}, -1, nil, fmt.Errorf("brep: counterbore bore (r=%g) found no through exit face", boreRadius)
+}
+
+// assembleCounterbore welds the planar faces (copied + entry + optional exit), holes the entry
+// with the recess and the exit with the bore, and adds the recess wall, annular shoulder, bore
+// wall, and (blind) flat bottom.
+func assembleCounterbore(copied []planarFace, entry planarFace, exitIdx int, base, shoulder, end math.Point3, ua math.Vector3, boreRadius, counterRadius float64, through bool) (*topo.Body, error) {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("brep", "cbore", 0)))
+	// Copied faces lead the welded list, so a through exit keeps its copied-slice index here;
+	// entry is appended after them.
+	planar := append(append([]planarFace{}, copied...), entry)
+	entryIdx := len(planar) - 1
+
+	w := newWelder3()
+	rings, edgeUse := weldPlanarFaces(w, planar)
+	tv := make([]*topo.Vertex, len(w.points))
+	for i, p := range w.points {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
+	}
+	lineEdges := buildEdges(bld, w.points, tv, edgeUse)
+
+	eEntry, eShoulderOut, recessSeam, recessCyl, err := buildHoleEdges(bld, []drillCap{{center: base}, {center: shoulder}}, ua, counterRadius)
+	if err != nil {
+		return nil, err
+	}
+	eShoulderIn, eEnd, boreSeam, boreCyl, err := buildHoleEdges(bld, []drillCap{{center: shoulder}, {center: end}}, ua, boreRadius)
+	if err != nil {
+		return nil, err
+	}
+
+	for fi, f := range planar {
+		specs := planarLoopSpecs(rings[fi], lineEdges)
+		switch fi {
+		case entryIdx:
+			specs = append(specs, topo.InnerLoop(topo.Fwd(eEntry)))
+		case exitIdx:
+			specs = append(specs, topo.InnerLoop(topo.Fwd(eEnd)))
+		}
+		bld.AddFace(f.plane, f.lineage, specs...) // copied/holed faces keep their key (K1a)
+	}
+
+	shPlane, err := geom.NewPlane(shoulder, ua.Scale(-1))
+	if err != nil {
+		return nil, err
+	}
+	bld.AddFace(shPlane, topo.NewLineage(topo.Tok("brep", "shoulder", 0)),
+		topo.OuterLoop(topo.Fwd(eShoulderOut)), topo.InnerLoop(topo.Fwd(eShoulderIn)))
+	bld.AddReversedFace(recessCyl, topo.NewLineage(topo.Tok("brep", "recesswall", 0)),
+		topo.OuterLoop(topo.Rev(eEntry), topo.Fwd(recessSeam), topo.Rev(eShoulderOut), topo.Rev(recessSeam)))
+	bld.AddReversedFace(boreCyl, topo.NewLineage(topo.Tok("brep", "borewall", 0)),
+		topo.OuterLoop(topo.Rev(eShoulderIn), topo.Fwd(boreSeam), topo.Rev(eEnd), topo.Rev(boreSeam)))
+	if !through {
+		botPlane, err := geom.NewPlane(end, ua.Scale(-1))
+		if err != nil {
+			return nil, err
+		}
+		bld.AddFace(botPlane, topo.NewLineage(topo.Tok("brep", "holebottom", 0)), topo.OuterLoop(topo.Fwd(eEnd)))
+	}
+	return bld.Build(), nil
+}

--- a/kernel/brep/drill_counterbore_test.go
+++ b/kernel/brep/drill_counterbore_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// countCylFaces returns how many of a body's faces are true cylinder faces.
+func countCylFaces(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// A through counterbore: Ø4 recess 1 deep stepping to a Ø2 bore through an 8×8×4 slab.
+// Valid watertight solid with two cylinder walls (recess + bore) and an annular shoulder.
+func TestCutCounterboreThrough(t *testing.T) {
+	d, err := brep.CutCounterboreHole(box(0, 0, 0, 8, 8, 4), math.P3(4, 4, 4), math.V3(0, 0, -1), 1, 0, 2, 1, true)
+	if err != nil {
+		t.Fatalf("CutCounterboreHole: %v", err)
+	}
+	if r := ops.Validate(d); !r.Valid || !d.IsSolid() {
+		t.Fatalf("counterbored slab is not a valid solid: %+v", r)
+	}
+	if open := ops.BoundaryEdges(d); len(open) != 0 {
+		t.Fatalf("counterbore has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if n := countCylFaces(d); n != 2 {
+		t.Errorf("counterbore has %d cylinder faces, want 2 (recess + bore wall)", n)
+	}
+	// Removed = recess (Ø4×1) + bore (Ø2×3 below the shoulder), inscribed (a hair under).
+	const want = stdmath.Pi*2*2*1 + stdmath.Pi*1*1*3
+	removed := 8.0*8.0*4.0 - vol(d)
+	if removed <= 0 || removed > want+1e-9 || (want-removed)/want > 0.04 {
+		t.Errorf("removed volume = %g, want a hair under %g", removed, want)
+	}
+}
+
+// A blind counterbore stops inside the part: it adds a flat bore bottom too.
+func TestCutCounterboreBlind(t *testing.T) {
+	d, err := brep.CutCounterboreHole(box(0, 0, 0, 8, 8, 6), math.P3(4, 4, 6), math.V3(0, 0, -1), 1, 2, 2, 1, false)
+	if err != nil {
+		t.Fatalf("CutCounterboreHole (blind): %v", err)
+	}
+	if r := ops.Validate(d); !r.Valid || !d.IsSolid() {
+		t.Fatalf("blind counterbore is not a valid solid: %+v", r)
+	}
+	if n := countCylFaces(d); n != 2 {
+		t.Errorf("blind counterbore has %d cylinder faces, want 2", n)
+	}
+}

--- a/kernel/brep/drill_countersink.go
+++ b/kernel/brep/drill_countersink.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// CutCountersinkHole drills a countersink (K1b): a conical recess that widens to sinkRadius at
+// the entry face and narrows (at the cone half-angle) down to the bore, which continues through
+// or blind. The result is one assembly from the planar slab — entry holed, a true CONE frustum
+// wall, the shared transition circle, a cylinder bore wall, and a holed exit or flat bottom.
+// Like the counterbore it is built directly (not by chaining curved cuts). The cone widens
+// toward the surface, so its axis points back out of the part (apex deep inside).
+func CutCountersinkHole(slab *topo.Body, base math.Point3, axisDir math.Vector3, boreRadius, boreLen, sinkRadius, sinkHalfAngle float64, boreThrough bool) (*topo.Body, error) {
+	if boreRadius <= 0 || sinkRadius <= boreRadius || sinkHalfAngle <= 0 || sinkHalfAngle >= stdmath.Pi/2 {
+		return nil, fmt.Errorf("brep: countersink needs 0<boreR(%g)<sinkR(%g) and 0<halfAngle(%g)<π/2", boreRadius, sinkRadius, sinkHalfAngle)
+	}
+	ua := unit(axisDir)
+	uaUnit, err := math.UnitVector3FromVector(ua)
+	if err != nil {
+		return nil, fmt.Errorf("brep: drill axis direction is degenerate: %+v", axisDir)
+	}
+	copied, entry, err := classifyBlindDrill(slab, base, ua, sinkRadius)
+	if err != nil {
+		return nil, err
+	}
+	tan := stdmath.Tan(sinkHalfAngle)
+	depthCS := (sinkRadius - boreRadius) / tan
+	trans := base.TranslateBy(ua.Scale(math.Scalar(depthCS)))
+	apex := base.TranslateBy(ua.Scale(math.Scalar(sinkRadius / tan))) // r=0 deep on the axis
+	cone, err := geom.NewCone(apex, ua.Scale(-1), sinkHalfAngle)      // widens back toward the surface
+	if err != nil {
+		return nil, err
+	}
+	end, exitIdx, copied, err := counterboreEnd(slab, copied, entry, base, trans, ua, boreRadius, boreLen, boreThrough)
+	if err != nil {
+		return nil, err
+	}
+	return assembleCountersink(copied, entry, exitIdx, base, trans, end, uaUnit, cone, boreRadius, sinkRadius, boreThrough)
+}
+
+// assembleCountersink welds the planar faces, holes the entry with the sink opening, and closes
+// the recess with a cone frustum wall, a cylinder bore wall (sharing the transition circle), and
+// a holed exit or flat bottom.
+func assembleCountersink(copied []planarFace, entry planarFace, exitIdx int, base, trans, end math.Point3, ua math.UnitVector3, cone geom.Cone, boreRadius, sinkRadius float64, through bool) (*topo.Body, error) {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("brep", "csink", 0)))
+	planar := append(append([]planarFace{}, copied...), entry)
+	entryIdx := len(planar) - 1
+
+	w := newWelder3()
+	rings, edgeUse := weldPlanarFaces(w, planar)
+	tv := make([]*topo.Vertex, len(w.points))
+	for i, p := range w.points {
+		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
+	}
+	lineEdges := buildEdges(bld, w.points, tv, edgeUse)
+
+	// All circles share the cone's Ref so the cone seam is a straight ruling (angle 0). Seam
+	// vertices are shared between each circle and the seams (and the transition between both
+	// walls), so the body is watertight.
+	entryC := geom.Circle{Center: base, Normal: ua, RefDir: cone.Ref, Radius: sinkRadius}
+	transC := geom.Circle{Center: trans, Normal: ua, RefDir: cone.Ref, Radius: boreRadius}
+	endC := geom.Circle{Center: end, Normal: ua, RefDir: cone.Ref, Radius: boreRadius}
+	pE, pT, pB := entryC.PointAt(0), transC.PointAt(0), endC.PointAt(0)
+	vE := bld.AddVertex(pE, csinkLin("seam", 0))
+	vT := bld.AddVertex(pT, csinkLin("seam", 1))
+	vB := bld.AddVertex(pB, csinkLin("seam", 2))
+	eEntry := bld.AddEdge(entryC, vE, vE, csinkLin("sink", 0))
+	eTrans := bld.AddEdge(transC, vT, vT, csinkLin("trans", 0))
+	eEnd := bld.AddEdge(endC, vB, vB, csinkLin("bore", 0))
+	coneSeam := bld.AddEdge(geom.NewLineSegment(pE, pT), vE, vT, csinkLin("coneseam", 0))
+	boreSeam := bld.AddEdge(geom.NewLineSegment(pT, pB), vT, vB, csinkLin("boreseam", 0))
+	boreCyl, err := geom.NewCylinder(trans, ua.AsVector(), boreRadius)
+	if err != nil {
+		return nil, err
+	}
+
+	for fi, f := range planar {
+		specs := planarLoopSpecs(rings[fi], lineEdges)
+		switch fi {
+		case entryIdx:
+			specs = append(specs, topo.InnerLoop(topo.Fwd(eEntry)))
+		case exitIdx:
+			specs = append(specs, topo.InnerLoop(topo.Fwd(eEnd)))
+		}
+		bld.AddFace(f.plane, f.lineage, specs...) // keeps reference keys (K1a)
+	}
+	bld.AddReversedFace(cone, topo.NewLineage(topo.Tok("brep", "sinkwall", 0)),
+		topo.OuterLoop(topo.Rev(eEntry), topo.Fwd(coneSeam), topo.Rev(eTrans), topo.Rev(coneSeam)))
+	bld.AddReversedFace(boreCyl, topo.NewLineage(topo.Tok("brep", "borewall", 0)),
+		topo.OuterLoop(topo.Fwd(eTrans), topo.Fwd(boreSeam), topo.Rev(eEnd), topo.Rev(boreSeam)))
+	if !through {
+		botPlane, err := geom.NewPlane(end, ua.AsVector().Scale(-1))
+		if err != nil {
+			return nil, err
+		}
+		bld.AddFace(botPlane, topo.NewLineage(topo.Tok("brep", "holebottom", 0)), topo.OuterLoop(topo.Fwd(eEnd)))
+	}
+	return bld.Build(), nil
+}
+
+// csinkLin is the lineage for a generated countersink edge/vertex.
+func csinkLin(role string, i int) topo.Lineage { return topo.NewLineage(topo.Tok("brep", role, i)) }

--- a/kernel/brep/drill_countersink_test.go
+++ b/kernel/brep/drill_countersink_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// countConeFaces returns how many of a body's faces are true cone faces.
+func countConeFaces(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cone); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// A through countersink: a 90° cone widening to Ø4 at the surface, narrowing to a Ø2 bore
+// through a 10×10×6 slab. Valid watertight solid with a cone wall + a cylinder bore wall.
+func TestCutCountersinkThrough(t *testing.T) {
+	const ha = stdmath.Pi / 4 // 90° included → 45° half-angle, tan = 1
+	d, err := brep.CutCountersinkHole(box(0, 0, 0, 10, 10, 6), math.P3(5, 5, 6), math.V3(0, 0, -1), 1, 0, 2, ha, true)
+	if err != nil {
+		t.Fatalf("CutCountersinkHole: %v", err)
+	}
+	if r := ops.Validate(d); !r.Valid || !d.IsSolid() {
+		t.Fatalf("countersunk slab is not a valid solid: %+v", r)
+	}
+	if open := ops.BoundaryEdges(d); len(open) != 0 {
+		t.Fatalf("countersink has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if n := countConeFaces(d); n != 1 {
+		t.Errorf("countersink has %d cone faces, want 1 (the sink wall)", n)
+	}
+	if n := countCylFaces(d); n != 1 {
+		t.Errorf("countersink has %d cylinder faces, want 1 (the bore wall)", n)
+	}
+	// Removed = a frustum (R=2 → r=1 over depthCS=1) + the bore (Ø2 over the remaining 5).
+	const depthCS = (2.0 - 1.0) / 1.0
+	frustum := stdmath.Pi * depthCS / 3 * (2*2 + 2*1 + 1*1)
+	bore := stdmath.Pi * 1 * 1 * (6 - depthCS)
+	want := frustum + bore
+	removed := 10.0*10.0*6.0 - vol(d)
+	if removed <= 0 || removed > want+1e-9 || (want-removed)/want > 0.04 {
+		t.Errorf("removed volume = %g, want a hair under %g (frustum + bore)", removed, want)
+	}
+}

--- a/kernel/brep/drill_test.go
+++ b/kernel/brep/drill_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/brep"
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// drilledSlab is a 10×10×4 box with a through-hole of radius 2 along +Z at its centre.
+func drilledSlab(t *testing.T) *topo.Body {
+	t.Helper()
+	got, err := brep.CutCylindricalHole(box(0, 0, 0, 10, 10, 4), math.P3(5, 5, 0), math.V3(0, 0, 1), 2)
+	if err != nil {
+		t.Fatalf("CutCylindricalHole: %v", err)
+	}
+	return got
+}
+
+// K1b slice 3: a cylinder cut through a planar slab is a clean watertight solid — six planar
+// faces (the two pierced ones now holed) plus a single TRUE cylinder wall face.
+func TestCutCylindricalHoleIsValidSolid(t *testing.T) {
+	d := drilledSlab(t)
+	if r := ops.Validate(d); !r.Valid || !d.IsSolid() {
+		t.Fatalf("drilled slab is not a valid solid: %+v", r)
+	}
+	if open := ops.BoundaryEdges(d); len(open) != 0 {
+		t.Fatalf("drilled slab has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	nCyl, nPlane := 0, 0
+	for _, f := range d.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			nCyl++
+		case geom.Plane:
+			nPlane++
+		}
+	}
+	if nCyl != 1 || nPlane != 6 {
+		t.Errorf("faces = %d cylinder / %d plane, want 1 / 6 (one hole wall, six slab faces)", nCyl, nPlane)
+	}
+}
+
+// The drilled volume is the slab minus the (inscribed) cylinder — proving the wall's material
+// side faces the axis (a reversed face), so the removed core is subtracted, not added.
+func TestCutCylindricalHoleVolume(t *testing.T) {
+	const slab, bore = 10.0 * 10.0 * 4.0, stdmath.Pi * 2 * 2 * 4 // box, π·r²·h
+	removed := slab - vol(drilledSlab(t))
+	if removed <= 0 {
+		t.Fatalf("removed volume = %g, want positive (material drilled out)", removed)
+	}
+	if removed > bore+1e-9 || (bore-removed)/bore > 0.04 {
+		t.Errorf("removed volume = %g, want a hair under %g (π·r²·h, inscribed)", removed, bore)
+	}
+}
+
+// A slab face the hole runs alongside is copied unchanged, so its reference key survives the
+// cut and a pick made before drilling rebinds to the result face (K1a/K1b on a curved cut).
+func TestDrillPreservesUntouchedFaceKey(t *testing.T) {
+	slab := box(0, 0, 0, 10, 10, 4)
+	side := faceWithNormal(slab, math.V3(1, 0, 0)) // the +X wall, parallel to the drill axis
+	if side == nil {
+		t.Fatal("no +X face on the slab")
+	}
+	key := side.ReferenceKey()
+	d, err := brep.CutCylindricalHole(slab, math.P3(5, 5, 0), math.V3(0, 0, 1), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := d.FindFaceByKey(key); !ok {
+		t.Error("the +X face's reference key did not survive the drill")
+	}
+}
+
+// A hole whose circle spills past the face boundary needs the general boolean, not this
+// through-hole specialization — it must error rather than build a broken body.
+func TestDrillRejectsOversizeHole(t *testing.T) {
+	_, err := brep.CutCylindricalHole(box(0, 0, 0, 10, 10, 4), math.P3(5, 5, 0), math.V3(0, 0, 1), 8)
+	if err == nil {
+		t.Error("expected an error for a hole larger than the face, got nil")
+	}
+}

--- a/kernel/geom/arc2d.go
+++ b/kernel/geom/arc2d.go
@@ -69,3 +69,30 @@ func (a Arc2d) Domain() (lo, hi float64) { return 0, 1 }
 func (a Arc2d) Length() float64 {
 	return stdmath.Abs(a.Radius * a.SweepAngle)
 }
+
+// ContainsAngle reports whether the absolute angle theta lies within the arc's swept
+// range (inclusive, within tol radians), for either sweep direction. A full-circle arc
+// (|SweepAngle| ≥ 2π) contains every angle.
+func (a Arc2d) ContainsAngle(theta, tol float64) bool {
+	if tol < 0 {
+		tol = 0
+	}
+	if a.SweepAngle >= 0 {
+		return wrapPositive(theta-a.StartAngle) <= a.SweepAngle+tol
+	}
+	return wrapPositive(a.StartAngle-theta) <= -a.SweepAngle+tol
+}
+
+// ContainsPoint reports whether p — assumed on or near the arc's circle — lies within the
+// arc's angular sweep. The geometric tol is converted to an angular slack (tol/Radius) so
+// an endpoint touch still counts; used to filter circle-crossing points onto the arc.
+func (a Arc2d) ContainsPoint(p math.Point2, tol float64) bool {
+	if tol < 0 {
+		tol = 0
+	}
+	angTol := 0.0
+	if a.Radius > 0 {
+		angTol = tol / a.Radius
+	}
+	return a.ContainsAngle(angleOf2d(a.Center, p), angTol)
+}

--- a/kernel/geom/bspline_curve2d.go
+++ b/kernel/geom/bspline_curve2d.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "github.com/Oblikovati/oblikovati/math"
+
+// BSplineCurve2d is the 2D (sketch-space) NURBS curve (contract: BSplineCurve2d): a
+// rational B-spline of the given Degree over a 2D control polygon (Ctrl) with per-point
+// Weights and a Knots vector (length len(Ctrl)+Degree+1). It satisfies [Curve2] and is the
+// planar analogue of [BSplineCurve].
+type BSplineCurve2d struct {
+	Degree  int
+	Ctrl    []math.Point2
+	Weights []float64
+	Knots   []float64
+}
+
+// NewBSplineCurve2d builds a rational 2D B-spline curve, validating the
+// degree/control/weight/knot size relationships and that weights are positive. The input
+// slices are copied so the value stays immutable.
+func NewBSplineCurve2d(degree int, ctrl []math.Point2, weights, knots []float64) (BSplineCurve2d, error) {
+	if err := validateBSpline(degree, len(ctrl), len(weights), len(knots)); err != nil {
+		return BSplineCurve2d{}, err
+	}
+	if err := requirePositiveWeights(weights); err != nil {
+		return BSplineCurve2d{}, err
+	}
+	return BSplineCurve2d{
+		Degree:  degree,
+		Ctrl:    append([]math.Point2(nil), ctrl...),
+		Weights: append([]float64(nil), weights...),
+		Knots:   append([]float64(nil), knots...),
+	}, nil
+}
+
+// NewBSplineCurve2dUniformWeights builds a non-rational 2D B-spline (all weights 1).
+func NewBSplineCurve2dUniformWeights(degree int, ctrl []math.Point2, knots []float64) (BSplineCurve2d, error) {
+	return NewBSplineCurve2d(degree, ctrl, unitWeights(len(ctrl)), knots)
+}
+
+// PointAt returns the curve position at parameter t.
+func (c BSplineCurve2d) PointAt(t float64) math.Point2 {
+	span := findSpan(len(c.Ctrl)-1, c.Degree, t, c.Knots)
+	n := basisFuns(span, c.Degree, t, c.Knots)
+	var h homog2
+	for k := 0; k <= c.Degree; k++ {
+		i := span - c.Degree + k
+		h.add(c.Ctrl[i], c.Weights[i]*n[k])
+	}
+	return h.point()
+}
+
+// TangentAt returns the curve derivative dP/dt at parameter t.
+func (c BSplineCurve2d) TangentAt(t float64) math.Vector2 {
+	span := findSpan(len(c.Ctrl)-1, c.Degree, t, c.Knots)
+	n, dn := basisAndFirstDerivs(span, c.Degree, t, c.Knots)
+	var value, deriv homog2
+	for k := 0; k <= c.Degree; k++ {
+		i := span - c.Degree + k
+		value.add(c.Ctrl[i], c.Weights[i]*n[k])
+		deriv.add(c.Ctrl[i], c.Weights[i]*dn[k])
+	}
+	return value.deriv(deriv)
+}
+
+// Domain returns the parametric range [Knots[Degree], Knots[len−1−Degree]].
+func (c BSplineCurve2d) Domain() (lo, hi float64) {
+	return c.Knots[c.Degree], c.Knots[len(c.Knots)-1-c.Degree]
+}
+
+// homog2 is the 2D analogue of [homog]: a weighted homogeneous accumulator (numerator
+// A = Σ wᵢ·Pᵢ, weight w = Σ wᵢ) for evaluating a rational planar B-spline and its tangent.
+type homog2 struct {
+	a math.Vector2
+	w float64
+}
+
+// add accumulates control point p with the already-basis-scaled weight.
+func (h *homog2) add(p math.Point2, weight float64) {
+	h.a = h.a.Add(p.AsVector().Scale(math.Scalar(weight)))
+	h.w += weight
+}
+
+// point returns the rational position A/w.
+func (h homog2) point() math.Point2 {
+	return h.a.Scale(math.Scalar(1 / h.w)).AsPoint()
+}
+
+// deriv applies the rational quotient rule d(A/w) = (d.a − point·d.w)/w.
+func (h homog2) deriv(d homog2) math.Vector2 {
+	point := h.point()
+	return d.a.Sub(point.AsVector().Scale(math.Scalar(d.w))).Scale(math.Scalar(1 / h.w))
+}
+
+var _ Curve2 = BSplineCurve2d{}

--- a/kernel/geom/circle.go
+++ b/kernel/geom/circle.go
@@ -46,3 +46,20 @@ func (c Circle) Domain() (lo, hi float64) { return 0, 1 }
 
 // Circumference returns 2πr.
 func (c Circle) Circumference() float64 { return twoPi * c.Radius }
+
+// CircleByThreePoints builds the unique 3D circle through three points (contract:
+// CreateCircleByThreePoints): it lies in the plane the points span and is centered at
+// their circumcenter, with RefDir pointing from the center to the first point. It errors
+// when the points are collinear (no finite circle passes through them).
+func CircleByThreePoints(a, b, c math.Point3) (Circle, error) {
+	n, e1, e2, err := planarFrame(a, b, c)
+	if err != nil {
+		return Circle{}, err
+	}
+	// Project into the points' plane (a at the origin), fit the 2D circumcenter there,
+	// then lift the center back to 3D — the same construction as Arc3dByThreePoints.
+	center2, _ := circumcenter2d(math.P2(0, 0), projectInto(a, e1, e2, b), projectInto(a, e1, e2, c))
+	center := a.TranslateBy(e1.Scale(center2.X)).TranslateBy(e2.Scale(center2.Y))
+	ref, _ := math.UnitVector3FromVector(center.VectorTo(a))
+	return Circle{Center: center, Normal: n, RefDir: ref, Radius: center.DistanceTo(a)}, nil
+}

--- a/kernel/geom/elliptical_cone.go
+++ b/kernel/geom/elliptical_cone.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// EllipticalCone is a cone of elliptical cross-section (contract: EllipticalCone) with its
+// Apex on the axis along AxisDir. Ref is the in-plane major-axis direction (perpendicular
+// to AxisDir); MajorAngle and MinorAngle are the half-angles (radians) between the axis and
+// the surface along the major and minor directions. At axial distance v the semi-axes are
+// v·tan(MajorAngle) and v·tan(MinorAngle). Parameters are (u = angle in [0,2π], v ≥ 0):
+// P(u,v) = Apex + v·AxisDir + v·tan(MajorAngle)·cos u·Ref + v·tan(MinorAngle)·sin u·(AxisDir×Ref).
+type EllipticalCone struct {
+	Apex       math.Point3
+	AxisDir    math.UnitVector3
+	Ref        math.UnitVector3
+	MajorAngle float64
+	MinorAngle float64
+	binormal   math.Vector3
+}
+
+// NewEllipticalCone builds an elliptical cone from an apex, axis direction, the major-axis
+// direction (projected onto the plane perpendicular to the axis), and the two half-angles.
+// Errors on a zero axis or a half angle outside the open interval (0, π/2).
+func NewEllipticalCone(apex math.Point3, axisDir, majorAxis math.Vector3, majorAngle, minorAngle float64) (EllipticalCone, error) {
+	for _, ang := range [2]float64{majorAngle, minorAngle} {
+		if ang <= 0 || ang >= stdmath.Pi/2 {
+			return EllipticalCone{}, fmt.Errorf("geom: elliptical cone half angle %g out of range (0, π/2)", ang)
+		}
+	}
+	a, err := math.UnitVector3FromVector(axisDir)
+	if err != nil {
+		return EllipticalCone{}, err
+	}
+	ref := planarRef(a, majorAxis)
+	return EllipticalCone{Apex: apex, AxisDir: a, Ref: ref, MajorAngle: majorAngle, MinorAngle: minorAngle, binormal: a.Cross(ref)}, nil
+}
+
+// PointAt returns the point at (u, v).
+func (c EllipticalCone) PointAt(u, v float64) math.Point3 {
+	cos, sin := cosSin(u)
+	rMaj, rMin := v*stdmath.Tan(c.MajorAngle), v*stdmath.Tan(c.MinorAngle)
+	radial := c.Ref.AsVector().Scale(rMaj * cos).Add(c.binormal.Scale(rMin * sin))
+	return c.Apex.TranslateBy(c.AxisDir.AsVector().Scale(v)).TranslateBy(radial)
+}
+
+// DerivativesAt returns ∂P/∂u (around the ellipse) and ∂P/∂v (along the slant).
+func (c EllipticalCone) DerivativesAt(u, v float64) (du, dv math.Vector3) {
+	cos, sin := cosSin(u)
+	tMaj, tMin := stdmath.Tan(c.MajorAngle), stdmath.Tan(c.MinorAngle)
+	du = c.Ref.AsVector().Scale(-v * tMaj * sin).Add(c.binormal.Scale(v * tMin * cos))
+	dv = c.AxisDir.AsVector().Add(c.Ref.AsVector().Scale(tMaj * cos)).Add(c.binormal.Scale(tMin * sin))
+	return du, dv
+}
+
+// NormalAt returns the outward unit normal (du×dv normalized); it is the zero vector at the
+// apex, where the partials degenerate.
+func (c EllipticalCone) NormalAt(u, v float64) math.Vector3 {
+	du, dv := c.DerivativesAt(u, v)
+	return normalFromPartials(du, dv)
+}
+
+// UDomain returns the periodic angular range [0, 2π].
+func (c EllipticalCone) UDomain() (lo, hi float64) { return fullCircleDomain() }
+
+// VDomain returns the half-open axial range [0, +Inf).
+func (c EllipticalCone) VDomain() (lo, hi float64) { return 0, stdmath.Inf(1) }
+
+// ParamAt inverts PointAt: the angle of the ellipse and the distance from the apex along
+// the axis. Dividing the projected components by the per-direction tangents (the v factor
+// cancels in the ratio) reproduces an on-surface point's u exactly.
+func (c EllipticalCone) ParamAt(q math.Point3) (u, v float64) {
+	d := c.Apex.VectorTo(q)
+	v = d.Dot(c.AxisDir.AsVector())
+	r := d.Sub(c.AxisDir.AsVector().Scale(v))
+	uMaj := r.Dot(c.Ref.AsVector()) / stdmath.Tan(c.MajorAngle)
+	uMin := r.Dot(c.binormal) / stdmath.Tan(c.MinorAngle)
+	return wrap2pi(stdmath.Atan2(uMin, uMaj)), v
+}
+
+var _ Surface = EllipticalCone{}

--- a/kernel/geom/elliptical_cylinder.go
+++ b/kernel/geom/elliptical_cylinder.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// EllipticalCylinder is an infinite cylinder of elliptical cross-section (contract:
+// EllipticalCylinder) about the axis line through Origin along AxisDir. Ref is the in-plane
+// major-axis direction (perpendicular to AxisDir) with semi-axis MajorRadius; the minor
+// semi-axis MinorRadius runs along AxisDir×Ref. Parameters are (u = angle in [0,2π], v =
+// signed distance along the axis):
+// P(u,v) = Origin + v·AxisDir + MajorRadius·cos u·Ref + MinorRadius·sin u·(AxisDir×Ref).
+type EllipticalCylinder struct {
+	Origin      math.Point3
+	AxisDir     math.UnitVector3
+	Ref         math.UnitVector3
+	MajorRadius float64
+	MinorRadius float64
+	binormal    math.Vector3
+}
+
+// NewEllipticalCylinder builds an elliptical cylinder from an axis point and direction, the
+// major-axis direction (projected onto the plane perpendicular to the axis), and the two
+// semi-radii. Errors on a zero axis direction.
+func NewEllipticalCylinder(origin math.Point3, axisDir, majorAxis math.Vector3, majorR, minorR float64) (EllipticalCylinder, error) {
+	a, err := math.UnitVector3FromVector(axisDir)
+	if err != nil {
+		return EllipticalCylinder{}, err
+	}
+	ref := planarRef(a, majorAxis)
+	return EllipticalCylinder{
+		Origin: origin, AxisDir: a, Ref: ref, MajorRadius: majorR, MinorRadius: minorR,
+		binormal: a.Cross(ref),
+	}, nil
+}
+
+// PointAt returns the point at (u, v).
+func (c EllipticalCylinder) PointAt(u, v float64) math.Point3 {
+	cos, sin := cosSin(u)
+	radial := c.Ref.AsVector().Scale(c.MajorRadius * cos).Add(c.binormal.Scale(c.MinorRadius * sin))
+	return c.Origin.TranslateBy(c.AxisDir.AsVector().Scale(v)).TranslateBy(radial)
+}
+
+// DerivativesAt returns ∂P/∂u (around the ellipse) and ∂P/∂v (the axis direction).
+func (c EllipticalCylinder) DerivativesAt(u, _ float64) (du, dv math.Vector3) {
+	cos, sin := cosSin(u)
+	du = c.Ref.AsVector().Scale(-c.MajorRadius * sin).Add(c.binormal.Scale(c.MinorRadius * cos))
+	return du, c.AxisDir.AsVector()
+}
+
+// NormalAt returns the outward unit normal (du×dv normalized).
+func (c EllipticalCylinder) NormalAt(u, v float64) math.Vector3 {
+	du, dv := c.DerivativesAt(u, v)
+	return normalFromPartials(du, dv)
+}
+
+// UDomain returns the periodic angular range [0, 2π].
+func (c EllipticalCylinder) UDomain() (lo, hi float64) { return fullCircleDomain() }
+
+// VDomain returns the unbounded axial range.
+func (c EllipticalCylinder) VDomain() (lo, hi float64) { return unboundedDomain() }
+
+// ParamAt inverts PointAt: the angle of the ellipse and the signed distance along the
+// axis. The radii rescale the projected components before the atan2 so an on-surface point
+// reproduces its u exactly.
+func (c EllipticalCylinder) ParamAt(q math.Point3) (u, v float64) {
+	d := c.Origin.VectorTo(q)
+	v = d.Dot(c.AxisDir.AsVector())
+	r := d.Sub(c.AxisDir.AsVector().Scale(v))
+	return wrap2pi(stdmath.Atan2(r.Dot(c.binormal)/c.MinorRadius, r.Dot(c.Ref.AsVector())/c.MajorRadius)), v
+}
+
+var _ Surface = EllipticalCylinder{}

--- a/kernel/geom/fitted_bspline.go
+++ b/kernel/geom/fitted_bspline.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Fitted (interpolating) B-splines pass *through* their input points, unlike the
+// control-polygon constructors in bspline_curve*.go. The standard global-interpolation
+// construction (The NURBS Book, A9.1) is used: chord-length parameters, averaged knots, and
+// a basis-collocation linear system A·P = Q solved for the control points P. The curve is
+// non-rational (unit weights) and cubic where there are enough points (degree min(3, n)).
+
+// NewFittedBSplineCurve builds the non-rational B-spline that interpolates the given 3D
+// points in order (contract: CreateFittedBSplineCurve). It needs >= 2 points and errors on
+// coincident/degenerate input (no chord length to parameterize by).
+func NewFittedBSplineCurve(points []math.Point3) (BSplineCurve, error) {
+	degree, err := fitDegree(len(points))
+	if err != nil {
+		return BSplineCurve{}, err
+	}
+	ctrl, knots, err := fitInterpolation(coords3(points), degree)
+	if err != nil {
+		return BSplineCurve{}, err
+	}
+	return NewBSplineCurveUniformWeights(degree, points3(ctrl), knots)
+}
+
+// NewFittedBSplineCurve2d is the 2D analogue of [NewFittedBSplineCurve] (contract:
+// CreateFittedBSplineCurve2d).
+func NewFittedBSplineCurve2d(points []math.Point2) (BSplineCurve2d, error) {
+	degree, err := fitDegree(len(points))
+	if err != nil {
+		return BSplineCurve2d{}, err
+	}
+	ctrl, knots, err := fitInterpolation(coords2(points), degree)
+	if err != nil {
+		return BSplineCurve2d{}, err
+	}
+	return NewBSplineCurve2dUniformWeights(degree, points2(ctrl), knots)
+}
+
+// fitDegree picks the interpolation degree for a point count: cubic when there are >= 4
+// points, otherwise count−1 (degree 1 for two points, 2 for three). Errors below 2 points.
+func fitDegree(count int) (int, error) {
+	if count < 2 {
+		return 0, fmt.Errorf("geom: fitted B-spline needs >= 2 points, got %d", count)
+	}
+	if count-1 < 3 {
+		return count - 1, nil
+	}
+	return 3, nil
+}
+
+// fitInterpolation returns the control points (same coordinate shape as pts) and knot
+// vector of the degree-p B-spline interpolating the rows of pts in order.
+func fitInterpolation(pts [][]float64, p int) (ctrl [][]float64, knots []float64, err error) {
+	ubar, err := chordParams(pts)
+	if err != nil {
+		return nil, nil, err
+	}
+	knots = averagedKnots(ubar, p)
+	a := collocation(ubar, p, knots)
+	b := cloneRows(pts)
+	if err := gaussSolve(a, b); err != nil {
+		return nil, nil, err
+	}
+	return b, knots, nil
+}
+
+// chordParams returns the chord-length parameters ū∈[0,1] for the points (ū₀=0, ūₙ=1),
+// erroring when the total chord length is zero (all points coincident).
+func chordParams(pts [][]float64) ([]float64, error) {
+	n := len(pts)
+	cum := make([]float64, n)
+	for k := 1; k < n; k++ {
+		cum[k] = cum[k-1] + coordDist(pts[k-1], pts[k])
+	}
+	total := cum[n-1]
+	if total == 0 {
+		return nil, fmt.Errorf("geom: fitted B-spline needs distinct points (total chord length 0)")
+	}
+	u := make([]float64, n)
+	for k := range u {
+		u[k] = cum[k] / total
+	}
+	u[n-1] = 1
+	return u, nil
+}
+
+// averagedKnots returns the clamped knot vector (length n+p+2) from the parameters ū by
+// the averaging rule (The NURBS Book eq. 9.8): p+1 zeros, then internal knots that are
+// running averages of p consecutive parameters, then p+1 ones.
+func averagedKnots(ubar []float64, p int) []float64 {
+	n := len(ubar) - 1
+	m := n + p + 1
+	knots := make([]float64, m+1)
+	for i := m - p; i <= m; i++ {
+		knots[i] = 1
+	}
+	for j := 1; j <= n-p; j++ {
+		sum := 0.0
+		for i := j; i <= j+p-1; i++ {
+			sum += ubar[i]
+		}
+		knots[j+p] = sum / float64(p)
+	}
+	return knots
+}
+
+// collocation builds the (n+1)×(n+1) basis matrix A where A[k][i] = Nᵢ,ₚ(ūₖ): the linear
+// system whose solution is the interpolating control points.
+func collocation(ubar []float64, p int, knots []float64) [][]float64 {
+	n := len(ubar) - 1
+	a := make([][]float64, n+1)
+	for k := range a {
+		row := make([]float64, n+1)
+		span := findSpan(n, p, ubar[k], knots)
+		basis := basisFuns(span, p, ubar[k], knots)
+		for l := 0; l <= p; l++ {
+			row[span-p+l] = basis[l]
+		}
+		a[k] = row
+	}
+	return a
+}
+
+// gaussSolve solves A·X = B in place (Gauss–Jordan with partial pivoting), leaving the
+// solution in B. A is n×n; B is n×rhs. Errors when A is singular.
+func gaussSolve(a, b [][]float64) error {
+	for col := range a {
+		piv := pivotRow(a, col)
+		if stdmath.Abs(a[piv][col]) < 1e-12 {
+			return fmt.Errorf("geom: interpolation matrix is singular at column %d", col)
+		}
+		a[col], a[piv] = a[piv], a[col]
+		b[col], b[piv] = b[piv], b[col]
+		eliminate(a, b, col)
+	}
+	for i := range a {
+		scaleRow(b[i], 1/a[i][i])
+	}
+	return nil
+}
+
+// pivotRow returns the row at or below col with the largest magnitude in that column.
+func pivotRow(a [][]float64, col int) int {
+	piv := col
+	for r := col + 1; r < len(a); r++ {
+		if stdmath.Abs(a[r][col]) > stdmath.Abs(a[piv][col]) {
+			piv = r
+		}
+	}
+	return piv
+}
+
+// eliminate zeroes column col in every row but col, applying the same operations to b.
+func eliminate(a, b [][]float64, col int) {
+	for r := range a {
+		if r == col {
+			continue
+		}
+		f := a[r][col] / a[col][col]
+		if f == 0 {
+			continue
+		}
+		for c := col; c < len(a); c++ {
+			a[r][c] -= f * a[col][c]
+		}
+		for c := range b[r] {
+			b[r][c] -= f * b[col][c]
+		}
+	}
+}
+
+// scaleRow multiplies every entry of row by s.
+func scaleRow(row []float64, s float64) {
+	for c := range row {
+		row[c] *= s
+	}
+}
+
+// coordDist returns the Euclidean distance between two coordinate tuples of equal length.
+func coordDist(a, b []float64) float64 {
+	sum := 0.0
+	for i := range a {
+		d := a[i] - b[i]
+		sum += d * d
+	}
+	return stdmath.Sqrt(sum)
+}
+
+// cloneRows deep-copies a row-major matrix so it can be mutated in place.
+func cloneRows(m [][]float64) [][]float64 {
+	out := make([][]float64, len(m))
+	for i, row := range m {
+		out[i] = append([]float64(nil), row...)
+	}
+	return out
+}
+
+// coords3 / points3 convert between 3D points and {x,y,z} coordinate rows.
+func coords3(pts []math.Point3) [][]float64 {
+	out := make([][]float64, len(pts))
+	for i, p := range pts {
+		out[i] = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+	}
+	return out
+}
+
+func points3(rows [][]float64) []math.Point3 {
+	out := make([]math.Point3, len(rows))
+	for i, r := range rows {
+		out[i] = math.Point3{X: math.Scalar(r[0]), Y: math.Scalar(r[1]), Z: math.Scalar(r[2])}
+	}
+	return out
+}
+
+// coords2 / points2 convert between 2D points and {x,y} coordinate rows.
+func coords2(pts []math.Point2) [][]float64 {
+	out := make([][]float64, len(pts))
+	for i, p := range pts {
+		out[i] = []float64{float64(p.X), float64(p.Y)}
+	}
+	return out
+}
+
+func points2(rows [][]float64) []math.Point2 {
+	out := make([]math.Point2, len(rows))
+	for i, r := range rows {
+		out[i] = math.P2(math.Scalar(r[0]), math.Scalar(r[1]))
+	}
+	return out
+}

--- a/kernel/geom/intersect2d_circle.go
+++ b/kernel/geom/intersect2d_circle.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Analytic 2D line/segment↔circle and circle↔circle intersection. Unlike
+// [Segment2dIntersection] (which the region detector uses on faceted curves), these are
+// exact on the analytic circle — what sketch trim/extend/split needs to cut a curve at
+// its true crossing rather than at a facet vertex. Arc crossings are these circle
+// results filtered by [Arc2d.ContainsPoint].
+
+// LineCircle2dIntersection returns the points where the infinite line l crosses circle c:
+// none (line misses), one (tangent, within tol), or two. tol<=0 uses the default
+// geometric tolerance.
+func LineCircle2dIntersection(l Line2d, c Circle2d, tol float64) []math.Point2 {
+	tol = geomTol(tol)
+	dir := l.Dir.AsVector() // unit
+	foot := l.Origin.TranslateBy(dir.Scale(l.Origin.VectorTo(c.Center).Dot(dir)))
+	dist := foot.DistanceTo(c.Center)
+	if dist > c.Radius+tol {
+		return nil
+	}
+	half := stdmath.Sqrt(stdmath.Max(0, c.Radius*c.Radius-dist*dist))
+	if half <= tol {
+		return []math.Point2{foot}
+	}
+	return []math.Point2{foot.TranslateBy(dir.Scale(half)), foot.TranslateBy(dir.Scale(-half))}
+}
+
+// SegmentCircle2dIntersection is [LineCircle2dIntersection] restricted to the segment's
+// extent: only crossings whose foot lies on seg (within tol) are returned. A degenerate
+// (zero-length) segment yields none.
+func SegmentCircle2dIntersection(seg LineSegment2d, c Circle2d, tol float64) []math.Point2 {
+	tol = geomTol(tol)
+	line, err := NewLine2d(seg.StartPoint, seg.StartPoint.VectorTo(seg.EndPoint))
+	if err != nil {
+		return nil
+	}
+	var out []math.Point2
+	for _, p := range LineCircle2dIntersection(line, c, tol) {
+		if onSegment2d(seg, p, tol) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Circle2dCircle2dIntersection returns the points where two circles cross: none
+// (disjoint, one inside the other, or concentric), one (tangent, within tol), or two.
+func Circle2dCircle2dIntersection(c1, c2 Circle2d, tol float64) []math.Point2 {
+	tol = geomTol(tol)
+	d := c1.Center.DistanceTo(c2.Center)
+	if d <= tol { // concentric: no isolated crossing (none, or the whole circle if equal)
+		return nil
+	}
+	if d > c1.Radius+c2.Radius+tol || d < stdmath.Abs(c1.Radius-c2.Radius)-tol {
+		return nil
+	}
+	// Distance from c1.Center to the radical line, along the center direction.
+	a := (d*d + c1.Radius*c1.Radius - c2.Radius*c2.Radius) / (2 * d)
+	dir := c1.Center.VectorTo(c2.Center).Scale(1 / d) // unit
+	mid := c1.Center.TranslateBy(dir.Scale(a))
+	h2 := c1.Radius*c1.Radius - a*a
+	if h2 <= tol*tol {
+		return []math.Point2{mid}
+	}
+	h := stdmath.Sqrt(h2)
+	perp := math.V2(-dir.Y, dir.X)
+	return []math.Point2{mid.TranslateBy(perp.Scale(h)), mid.TranslateBy(perp.Scale(-h))}
+}
+
+// onSegment2d reports whether p (assumed on the segment's support line) lies between the
+// endpoints, within a tol-derived parameter slack so an endpoint touch still counts.
+func onSegment2d(seg LineSegment2d, p math.Point2, tol float64) bool {
+	v := seg.StartPoint.VectorTo(seg.EndPoint)
+	lenSq := v.LengthSquared()
+	if lenSq == 0 {
+		return false
+	}
+	t := seg.StartPoint.VectorTo(p).Dot(v) / lenSq
+	eps := tol / stdmath.Sqrt(lenSq) // geometric tol → parameter slack
+	return t >= -eps && t <= 1+eps
+}
+
+// geomTol resolves a non-positive tolerance to the package's default geometric tolerance.
+func geomTol(tol float64) float64 {
+	if tol <= 0 {
+		return math.DefaultTolerance
+	}
+	return tol
+}

--- a/kernel/geom/intersect2d_circle_test.go
+++ b/kernel/geom/intersect2d_circle_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// nearPoint2 reports whether two 2D points coincide within a geometric tolerance.
+func nearPoint2(p, q math.Point2) bool { return p.IsEqualTo(q, 1e-9) }
+
+// onCircle asserts each point lies on the circle (center distance == radius).
+func onCircle(t *testing.T, pts []math.Point2, c Circle2d) {
+	t.Helper()
+	for _, p := range pts {
+		if !near(p.DistanceTo(c.Center), c.Radius) {
+			t.Errorf("point %v not on circle (dist %g, r %g)", p, p.DistanceTo(c.Center), c.Radius)
+		}
+	}
+}
+
+func mustLine2d(t *testing.T, ox, oy, dx, dy float64) Line2d {
+	t.Helper()
+	l, err := NewLine2d(math.P2(math.Scalar(ox), math.Scalar(oy)), math.V2(math.Scalar(dx), math.Scalar(dy)))
+	if err != nil {
+		t.Fatalf("NewLine2d: %v", err)
+	}
+	return l
+}
+
+// --- LineCircle2dIntersection ---------------------------------------------
+
+func TestLineCircleTwoPoints(t *testing.T) {
+	c := NewCircle2d(math.P2(0, 0), 2)
+	pts := LineCircle2dIntersection(mustLine2d(t, 0, 0, 1, 0), c, 0)
+	if len(pts) != 2 {
+		t.Fatalf("got %d points, want 2", len(pts))
+	}
+	onCircle(t, pts, c)
+}
+
+func TestLineCircleTangentIsOnePoint(t *testing.T) {
+	c := NewCircle2d(math.P2(0, 0), 2)
+	pts := LineCircle2dIntersection(mustLine2d(t, 0, 2, 1, 0), c, 0) // y = 2, tangent at top
+	if len(pts) != 1 {
+		t.Fatalf("got %d points, want 1 (tangent)", len(pts))
+	}
+	if !nearPoint2(pts[0], math.P2(0, 2)) {
+		t.Errorf("tangent point = %v, want (0,2)", pts[0])
+	}
+}
+
+func TestLineCircleMissesIsNone(t *testing.T) {
+	c := NewCircle2d(math.P2(0, 0), 2)
+	if pts := LineCircle2dIntersection(mustLine2d(t, 0, 3, 1, 0), c, 0); len(pts) != 0 {
+		t.Errorf("got %d points, want 0 (miss)", len(pts))
+	}
+}
+
+// --- SegmentCircle2dIntersection ------------------------------------------
+
+func TestSegmentCircleFiltersToExtent(t *testing.T) {
+	c := NewCircle2d(math.P2(0, 0), 2)
+	// Segment from (0,0) to (3,0) crosses the circle only at (2,0); (-2,0) is off-segment.
+	seg := NewLineSegment2d(math.P2(0, 0), math.P2(3, 0))
+	pts := SegmentCircle2dIntersection(seg, c, 0)
+	if len(pts) != 1 || !nearPoint2(pts[0], math.P2(2, 0)) {
+		t.Fatalf("got %v, want one point (2,0)", pts)
+	}
+}
+
+func TestSegmentCircleDegenerateIsNone(t *testing.T) {
+	c := NewCircle2d(math.P2(0, 0), 2)
+	seg := NewLineSegment2d(math.P2(1, 1), math.P2(1, 1))
+	if pts := SegmentCircle2dIntersection(seg, c, 0); len(pts) != 0 {
+		t.Errorf("degenerate segment gave %d points, want 0", len(pts))
+	}
+}
+
+// --- Circle2dCircle2dIntersection -----------------------------------------
+
+func TestCircleCircleTwoPoints(t *testing.T) {
+	c1 := NewCircle2d(math.P2(0, 0), 2)
+	c2 := NewCircle2d(math.P2(3, 0), 2)
+	pts := Circle2dCircle2dIntersection(c1, c2, 0)
+	if len(pts) != 2 {
+		t.Fatalf("got %d points, want 2", len(pts))
+	}
+	onCircle(t, pts, c1)
+	onCircle(t, pts, c2)
+	h := stdmath.Sqrt(2*2 - 1.5*1.5)
+	for _, p := range pts {
+		if !near(float64(p.X), 1.5) || !near(stdmath.Abs(float64(p.Y)), h) {
+			t.Errorf("point %v, want x=1.5 y=±%g", p, h)
+		}
+	}
+}
+
+func TestCircleCircleTangentExternal(t *testing.T) {
+	c1 := NewCircle2d(math.P2(0, 0), 2)
+	c2 := NewCircle2d(math.P2(4, 0), 2) // d = r1+r2
+	pts := Circle2dCircle2dIntersection(c1, c2, 1e-6)
+	if len(pts) != 1 || !nearPoint2(pts[0], math.P2(2, 0)) {
+		t.Fatalf("got %v, want one tangent point (2,0)", pts)
+	}
+}
+
+func TestCircleCircleDisjointConcentricNested(t *testing.T) {
+	c1 := NewCircle2d(math.P2(0, 0), 2)
+	cases := map[string]Circle2d{
+		"disjoint":   NewCircle2d(math.P2(5, 0), 2),
+		"concentric": NewCircle2d(math.P2(0, 0), 1),
+		"nested":     NewCircle2d(math.P2(0.5, 0), 0.5), // wholly inside c1, no contact
+	}
+	for name, c2 := range cases {
+		if pts := Circle2dCircle2dIntersection(c1, c2, 0); len(pts) != 0 {
+			t.Errorf("%s: got %d points, want 0", name, len(pts))
+		}
+	}
+}
+
+// --- Arc2d.ContainsAngle / ContainsPoint ----------------------------------
+
+func TestArcContainsAnglePositiveSweep(t *testing.T) {
+	a := NewArc2d(math.P2(0, 0), 1, 0, stdmath.Pi) // upper half, CCW
+	if !a.ContainsAngle(stdmath.Pi/2, 0) {
+		t.Error("π/2 should be on the upper-half arc")
+	}
+	if a.ContainsAngle(-stdmath.Pi/2, 0) {
+		t.Error("−π/2 should NOT be on the upper-half arc")
+	}
+}
+
+func TestArcContainsAngleNegativeSweep(t *testing.T) {
+	a := NewArc2d(math.P2(0, 0), 1, 0, -stdmath.Pi) // lower half, CW
+	if !a.ContainsAngle(-stdmath.Pi/2, 0) {
+		t.Error("−π/2 should be on the lower-half arc")
+	}
+	if a.ContainsAngle(stdmath.Pi/2, 0) {
+		t.Error("π/2 should NOT be on the lower-half arc")
+	}
+}
+
+func TestArcContainsPointFiltersCircleCrossings(t *testing.T) {
+	a := NewArc2d(math.P2(0, 0), 1, 0, stdmath.Pi) // upper half
+	if !a.ContainsPoint(math.P2(0, 1), 0) {
+		t.Error("(0,1) should be on the upper-half arc")
+	}
+	if a.ContainsPoint(math.P2(0, -1), 0) {
+		t.Error("(0,-1) should NOT be on the upper-half arc")
+	}
+}
+
+func TestArcContainsGuardsNegativeTolAndZeroRadius(t *testing.T) {
+	a := NewArc2d(math.P2(0, 0), 1, 0, stdmath.Pi)
+	// Negative tol is clamped to 0 (no slack), so an in-sweep angle still passes.
+	if !a.ContainsAngle(stdmath.Pi/2, -1) {
+		t.Error("negative tol should be treated as 0, not reject an interior angle")
+	}
+	// Zero-radius arc: ContainsPoint must not divide by zero; it falls back to 0 slack.
+	z := NewArc2d(math.P2(0, 0), 0, 0, stdmath.Pi)
+	if z.ContainsPoint(math.P2(0, -1), -1) {
+		t.Error("(0,-1) is below a zero-radius upper-half arc; should not be contained")
+	}
+}
+
+func TestArcContainsAngleFullCircle(t *testing.T) {
+	a := NewArc2d(math.P2(0, 0), 1, 0, twoPi)
+	for _, th := range []float64{0, stdmath.Pi / 2, stdmath.Pi, -stdmath.Pi / 2, 3} {
+		if !a.ContainsAngle(th, 0) {
+			t.Errorf("full circle should contain angle %g", th)
+		}
+	}
+}

--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// IntersectSurfacesAnalytic returns the EXACT intersection curves of two analytic surfaces
+// for the pairs the curved-face boolean (K1b) relies on: plane∩plane → a line; plane∩
+// cylinder (plane ⟂ axis) → a circle; plane∩sphere → a circle. handled is false for the
+// pairs it does not solve in closed form (an oblique plane∩cylinder ellipse, cylinder∩
+// cylinder, anything with a torus) — the caller falls back to the numeric tracer
+// [IntersectSurfaceSurface]. An empty result with handled==true means the surfaces are
+// known not to cross (parallel planes, a sphere clear of the plane, a tangent touch).
+//
+// Returning exact curves (a real circle, not a 64-gon) is what lets a drilled hole be a
+// single cylindrical face with a stable reference key, rather than faceted soup.
+func IntersectSurfacesAnalytic(a, b Surface) (curves []Curve3, handled bool) {
+	if pl, ok := a.(Plane); ok {
+		return intersectPlaneSurface(pl, b)
+	}
+	if pl, ok := b.(Plane); ok {
+		return intersectPlaneSurface(pl, a)
+	}
+	return nil, false
+}
+
+func intersectPlaneSurface(pl Plane, other Surface) ([]Curve3, bool) {
+	switch o := other.(type) {
+	case Plane:
+		return planePlaneCurve(pl, o)
+	case Cylinder:
+		return planeCylinderCurve(pl, o)
+	case Sphere:
+		return planeSphereCurve(pl, o)
+	case Cone:
+		return planeConeCurve(pl, o)
+	default:
+		return nil, false
+	}
+}
+
+// planePlaneCurve returns the intersection line of two planes (empty when parallel).
+func planePlaneCurve(a, b Plane) ([]Curve3, bool) {
+	na, nb := unitVec3(a.Normal()), unitVec3(b.Normal())
+	dir := na.Cross(nb)
+	if dir.Length() < 1e-9 {
+		return nil, true // parallel or coincident: no isolated intersection curve
+	}
+	// A point on both planes (Goldman): p = (da·(nb×dir) + db·(dir×na)) / |dir|².
+	da := na.Dot(a.Origin.AsVector())
+	db := nb.Dot(b.Origin.AsVector())
+	num := nb.Cross(dir).Scale(da).Add(dir.Cross(na).Scale(db))
+	k := 1 / dir.LengthSquared()
+	p := math.P3(num.X*math.Scalar(k), num.Y*math.Scalar(k), num.Z*math.Scalar(k))
+	ln, err := NewLine(p, dir)
+	if err != nil {
+		return nil, true
+	}
+	return []Curve3{ln}, true
+}
+
+// planeCylinderCurve returns the conic a plane cuts from a cylinder: a circle when the
+// plane is perpendicular to the axis, an ellipse when oblique. A plane parallel to the axis
+// (a line pair) is left to the numeric tracer.
+func planeCylinderCurve(pl Plane, cyl Cylinder) ([]Curve3, bool) {
+	n := unitVec3(pl.Normal())
+	axis := cyl.AxisDir.AsVector()
+	cosA := float64(axis.Dot(n)) // both unit; |cosA| = cos∠(axis, plane normal)
+	abs := stdmath.Abs(cosA)
+	if abs < 1e-6 { // axis ∥ plane → 0/1/2 lines, not a conic
+		return nil, false
+	}
+	t := n.Dot(cyl.Origin.VectorTo(pl.Origin)) / axis.Dot(n)
+	center := cyl.Origin.TranslateBy(axis.Scale(t))
+	if abs > 1-1e-6 { // perpendicular → circle
+		c, err := NewCircle(center, axis, cyl.Radius)
+		if err != nil {
+			return nil, true
+		}
+		return []Curve3{c}, true
+	}
+	// Oblique → ellipse: minor radius = r, major = r/|cosA|; major axis is the cylinder
+	// axis projected into the plane.
+	majorDir := axis.Add(n.Scale(math.Scalar(-cosA)))
+	e, err := NewEllipseFull(center, n, majorDir, cyl.Radius/abs, cyl.Radius)
+	if err != nil {
+		return nil, true
+	}
+	return []Curve3{e}, true
+}
+
+// planeConeCurve returns the circle where a plane perpendicular to a cone's axis cuts it
+// (radius grows with distance from the apex); an oblique plane (ellipse/parabola/hyperbola)
+// is left to the numeric tracer, and a plane through the apex yields a point (no curve).
+func planeConeCurve(pl Plane, cone Cone) ([]Curve3, bool) {
+	n := unitVec3(pl.Normal())
+	axis := cone.AxisDir.AsVector()
+	denom := axis.Dot(n)
+	if stdmath.Abs(float64(denom)) < 1-1e-6 { // not perpendicular → conic section, defer
+		return nil, false
+	}
+	t := n.Dot(cone.Apex.VectorTo(pl.Origin)) / denom
+	r := stdmath.Abs(float64(t)) * stdmath.Tan(cone.HalfAngle)
+	if r < 1e-9 { // plane through the apex
+		return nil, true
+	}
+	center := cone.Apex.TranslateBy(axis.Scale(t))
+	c, err := NewCircle(center, axis, r)
+	if err != nil {
+		return nil, true
+	}
+	return []Curve3{c}, true
+}
+
+// planeSphereCurve returns the circle where a plane cuts a sphere (empty when the plane
+// misses or merely touches the sphere).
+func planeSphereCurve(pl Plane, sp Sphere) ([]Curve3, bool) {
+	n := unitVec3(pl.Normal())
+	d := float64(n.Dot(pl.Origin.VectorTo(sp.Center))) // signed distance, center to plane
+	if stdmath.Abs(d) >= sp.Radius-1e-9 {
+		return nil, true // clear of, or tangent to, the plane: no circle
+	}
+	r := stdmath.Sqrt(sp.Radius*sp.Radius - d*d)
+	center := sp.Center.TranslateBy(n.Scale(math.Scalar(-d))) // foot of the center on the plane
+	c, err := NewCircle(center, n, r)
+	if err != nil {
+		return nil, true
+	}
+	return []Curve3{c}, true
+}
+
+// unitVec3 normalizes v (returning it unchanged if degenerate).
+func unitVec3(v math.Vector3) math.Vector3 {
+	if l := float64(v.Length()); l > 0 {
+		return v.Scale(math.Scalar(1 / l))
+	}
+	return v
+}

--- a/kernel/geom/intersect_analytic_test.go
+++ b/kernel/geom/intersect_analytic_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+func mustPlane(t *testing.T, ox, oy, oz, nx, ny, nz float64) Plane {
+	t.Helper()
+	pl, err := NewPlane(math.P3(math.Scalar(ox), math.Scalar(oy), math.Scalar(oz)), math.V3(math.Scalar(nx), math.Scalar(ny), math.Scalar(nz)))
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	return pl
+}
+
+// A plane perpendicular to a cylinder axis cuts it in an exact circle of the cylinder's
+// radius.
+func TestAnalyticPlaneCylinderIsCircle(t *testing.T) {
+	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), cyl)
+	if !ok || len(curves) != 1 {
+		t.Fatalf("plane∩cylinder = %v ok=%v, want one curve", curves, ok)
+	}
+	c, isCircle := curves[0].(Circle)
+	if !isCircle || !near(c.Radius, 2) || !near(float64(c.Center.Z), 0) {
+		t.Errorf("circle = %+v, want radius 2 at z=0", c)
+	}
+}
+
+// Cutting a plane at z=3 through a sphere of radius 5 gives a circle of radius 4.
+func TestAnalyticPlaneSphereSmallCircle(t *testing.T) {
+	sp, _ := NewSphere(math.P3(0, 0, 0), 5)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 3, 0, 0, 1), sp)
+	if !ok || len(curves) != 1 {
+		t.Fatalf("plane∩sphere = %v ok=%v, want one curve", curves, ok)
+	}
+	c := curves[0].(Circle)
+	if !near(c.Radius, 4) || !near(float64(c.Center.Z), 3) {
+		t.Errorf("circle = %+v, want radius 4 at z=3", c)
+	}
+}
+
+// A plane clear of the sphere is handled with no curve (not a fallback).
+func TestAnalyticPlaneSphereMiss(t *testing.T) {
+	sp, _ := NewSphere(math.P3(0, 0, 0), 5)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 10, 0, 0, 1), sp)
+	if !ok || len(curves) != 0 {
+		t.Errorf("plane clear of sphere = %v ok=%v, want handled with no curve", curves, ok)
+	}
+}
+
+// Two planes meet in a line; argument order does not matter.
+func TestAnalyticPlanePlaneIsLine(t *testing.T) {
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), mustPlane(t, 0, 0, 0, 1, 0, 0))
+	if !ok || len(curves) != 1 {
+		t.Fatalf("plane∩plane = %v ok=%v, want one line", curves, ok)
+	}
+	if _, isLine := curves[0].(Line); !isLine {
+		t.Errorf("plane∩plane curve = %T, want a Line", curves[0])
+	}
+}
+
+// Parallel planes are handled (no intersection curve).
+func TestAnalyticParallelPlanes(t *testing.T) {
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), mustPlane(t, 0, 0, 5, 0, 0, 1))
+	if !ok || len(curves) != 0 {
+		t.Errorf("parallel planes = %v ok=%v, want handled with no curve", curves, ok)
+	}
+}
+
+// An oblique plane∩cylinder is an exact ellipse: minor = radius, major = radius/|cosA|
+// (here the 45° tilt gives cosA = 1/√2, so major = 2√2).
+func TestAnalyticObliquePlaneCylinderIsEllipse(t *testing.T) {
+	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 1), cyl)
+	if !ok || len(curves) != 1 {
+		t.Fatalf("oblique plane∩cylinder = %v ok=%v, want one ellipse", curves, ok)
+	}
+	e, isEllipse := curves[0].(EllipseFull)
+	if !isEllipse || !near(e.MinorRadius, 2) || !near(e.MajorRadius, 2*stdmath.Sqrt2) {
+		t.Errorf("ellipse = %+v, want minor 2 major %g", e, 2*stdmath.Sqrt2)
+	}
+}
+
+// A plane parallel to the cylinder axis (a line pair) is left to the numeric tracer.
+func TestAnalyticPlaneParallelToCylinderDefers(t *testing.T) {
+	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	if _, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 0), cyl); ok {
+		t.Error("a plane parallel to the cylinder axis should defer (handled=false)")
+	}
+}
+
+// A plane perpendicular to a cone's axis cuts a circle of radius distance×tan(halfAngle).
+func TestAnalyticPlaneConeIsCircle(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/4) // tan 45° = 1
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 3, 0, 0, 1), cone)
+	if !ok || len(curves) != 1 {
+		t.Fatalf("plane∩cone = %v ok=%v, want one circle", curves, ok)
+	}
+	c := curves[0].(Circle)
+	if !near(c.Radius, 3) || !near(float64(c.Center.Z), 3) {
+		t.Errorf("cone circle = %+v, want radius 3 at z=3", c)
+	}
+}
+
+// Argument order is symmetric (cylinder first).
+func TestAnalyticOrderIndependent(t *testing.T) {
+	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	curves, ok := IntersectSurfacesAnalytic(cyl, mustPlane(t, 0, 0, 0, 0, 0, 1))
+	if !ok || len(curves) != 1 {
+		t.Errorf("cylinder∩plane (swapped) = %v ok=%v, want one circle", curves, ok)
+	}
+}

--- a/kernel/geom/plane.go
+++ b/kernel/geom/plane.go
@@ -39,6 +39,18 @@ func NewPlaneFromAxes(origin math.Point3, uAxis, vAxis math.Vector3) (Plane, err
 	return Plane{Origin: origin, UAxis: u, VAxis: v}, nil
 }
 
+// PlaneByThreePoints builds the plane through three points (contract:
+// CreatePlaneByThreePoints): its origin is the first point, its U axis runs toward the
+// second, and its normal is (a→b)×(a→c). It errors when the points are collinear (they
+// span no plane).
+func PlaneByThreePoints(a, b, c math.Point3) (Plane, error) {
+	_, e1, e2, err := planarFrame(a, b, c)
+	if err != nil {
+		return Plane{}, err
+	}
+	return NewPlaneFromAxes(a, e1, e2)
+}
+
 // Normal returns the unit plane normal UAxis×VAxis.
 func (p Plane) Normal() math.Vector3 {
 	return p.UAxis.Cross(p.VAxis)

--- a/kernel/geom/polyline.go
+++ b/kernel/geom/polyline.go
@@ -89,6 +89,53 @@ func (p Polyline2d) Length() float64 {
 	return total
 }
 
+// PolylineFromCurve3 tessellates a 3D curve into a polyline of `segments` straight chords
+// (contract: CreatePolyline3dFromCurve), sampling the curve at segments+1 equally-spaced
+// parameters across its domain. It errors when segments < 1 or the curve's domain is
+// unbounded (an infinite line has no finite polyline form).
+func PolylineFromCurve3(c Curve3, segments int) (Polyline, error) {
+	ts, err := sampleParams(c.Domain, segments)
+	if err != nil {
+		return Polyline{}, err
+	}
+	verts := make([]math.Point3, len(ts))
+	for i, t := range ts {
+		verts[i] = c.PointAt(t)
+	}
+	return NewPolyline(verts)
+}
+
+// PolylineFromCurve2 is the 2D analogue of [PolylineFromCurve3] (contract:
+// CreatePolyline2dFromCurve).
+func PolylineFromCurve2(c Curve2, segments int) (Polyline2d, error) {
+	ts, err := sampleParams(c.Domain, segments)
+	if err != nil {
+		return Polyline2d{}, err
+	}
+	verts := make([]math.Point2, len(ts))
+	for i, t := range ts {
+		verts[i] = c.PointAt(t)
+	}
+	return NewPolyline2d(verts)
+}
+
+// sampleParams returns segments+1 equally-spaced parameters spanning the [lo, hi] domain,
+// validating the count and rejecting an unbounded domain (which has no finite tessellation).
+func sampleParams(domain func() (lo, hi float64), segments int) ([]float64, error) {
+	if segments < 1 {
+		return nil, fmt.Errorf("geom: polyline-from-curve needs >= 1 segment, got %d", segments)
+	}
+	lo, hi := domain()
+	if stdmath.IsInf(lo, 0) || stdmath.IsInf(hi, 0) {
+		return nil, fmt.Errorf("geom: cannot tessellate an unbounded curve (domain [%g, %g])", lo, hi)
+	}
+	ts := make([]float64, segments+1)
+	for i := range ts {
+		ts[i] = lo + (hi-lo)*float64(i)/float64(segments)
+	}
+	return ts, nil
+}
+
 // locateSegment maps parameter t∈[0,1] to a segment index and the local
 // fraction within it, clamping out-of-range t to the endpoints. vertexCount is
 // assumed >= 2 (enforced by the constructors).

--- a/kernel/geom/transform.go
+++ b/kernel/geom/transform.go
@@ -32,6 +32,8 @@ func TransformCurve(c Curve3, m math.Matrix4) (Curve3, error) {
 		return transformCircle(g, m, scale)
 	case Arc3d:
 		return transformArc(g, m, scale)
+	case BSplineCurve:
+		return transformBSplineCurve(g, m), nil
 	default:
 		return nil, build.NotYetImplemented(fmt.Sprintf("geom.TransformCurve: %T", c))
 	}
@@ -56,6 +58,8 @@ func TransformSurface(s Surface, m math.Matrix4) (Surface, error) {
 		return NewSphere(m.TransformPoint(g.Center), g.Radius*scale)
 	case Torus:
 		return transformTorus(g, m, scale)
+	case BSplineSurface:
+		return transformBSplineSurface(g, m), nil
 	default:
 		return nil, build.NotYetImplemented(fmt.Sprintf("geom.TransformSurface: %T", s))
 	}
@@ -104,6 +108,49 @@ func transformTorus(t Torus, m math.Matrix4, scale float64) (Torus, error) {
 	out, err := NewTorus(m.TransformPoint(t.Center), m.TransformVector(t.AxisDir.AsVector()),
 		t.MajorRadius*scale, t.MinorRadius*scale)
 	return out, err
+}
+
+// transformBSplineCurve maps a rational B-spline by transforming its control points.
+// This is exact for any affine m: the rational basis functions are a partition of
+// unity, so T(C(t)) = Σ Rᵢ(t)·T(Pᵢ); weights, knots and degree are invariant. (The
+// public entry point still gates on similarity for consistency with the analytic
+// types, but the control-point map itself needs no such restriction.) It cannot
+// fail — the control count, weights and knots are unchanged, so the value stays valid.
+func transformBSplineCurve(c BSplineCurve, m math.Matrix4) BSplineCurve {
+	ctrl := make([]math.Point3, len(c.Ctrl))
+	for i, p := range c.Ctrl {
+		ctrl[i] = m.TransformPoint(p)
+	}
+	return BSplineCurve{
+		Degree:  c.Degree,
+		Ctrl:    ctrl,
+		Weights: append([]float64(nil), c.Weights...),
+		Knots:   append([]float64(nil), c.Knots...),
+	}
+}
+
+// transformBSplineSurface maps a rational B-spline surface by transforming its control
+// net; see [transformBSplineCurve] for why this is exact. Weights, knots and degrees
+// are invariant.
+func transformBSplineSurface(s BSplineSurface, m math.Matrix4) BSplineSurface {
+	ctrl := make([][]math.Point3, len(s.Ctrl))
+	for i, row := range s.Ctrl {
+		ctrl[i] = make([]math.Point3, len(row))
+		for j, p := range row {
+			ctrl[i][j] = m.TransformPoint(p)
+		}
+	}
+	weights := make([][]float64, len(s.Weights))
+	for i, row := range s.Weights {
+		weights[i] = append([]float64(nil), row...)
+	}
+	return BSplineSurface{
+		UDegree: s.UDegree, VDegree: s.VDegree,
+		Ctrl:    ctrl,
+		Weights: weights,
+		UKnots:  append([]float64(nil), s.UKnots...),
+		VKnots:  append([]float64(nil), s.VKnots...),
+	}
 }
 
 // similarityScale returns the uniform scale factor of m and rejects non-uniform

--- a/kernel/geom/transform_test.go
+++ b/kernel/geom/transform_test.go
@@ -215,8 +215,20 @@ func TestTransformSurfaceRejectsNonUniform(t *testing.T) {
 	}
 }
 
+// unsupportedSurface is a Surface the transform dispatcher does not know about, used
+// to exercise the default (NotYetImplemented) branch — every concrete geom.Surface
+// (plane/cylinder/cone/sphere/torus/NURBS) is now transformable (NURBS via K2).
+type unsupportedSurface struct{}
+
+func (unsupportedSurface) PointAt(u, v float64) math.Point3                 { return math.P3(0, 0, 0) }
+func (unsupportedSurface) DerivativesAt(u, v float64) (du, dv math.Vector3) { return }
+func (unsupportedSurface) NormalAt(u, v float64) math.Vector3               { return math.V3(0, 0, 0) }
+func (unsupportedSurface) UDomain() (lo, hi float64)                        { return 0, 1 }
+func (unsupportedSurface) VDomain() (lo, hi float64)                        { return 0, 1 }
+func (unsupportedSurface) ParamAt(p math.Point3) (u, v float64)             { return 0, 0 }
+
 func TestTransformSurfaceUnsupportedType(t *testing.T) {
-	if _, err := TransformSurface(sampleBSplineSurface(t), math.Identity4()); err == nil {
+	if _, err := TransformSurface(unsupportedSurface{}, math.Identity4()); err == nil {
 		t.Error("an unsupported surface type should return NotYetImplemented")
 	}
 }
@@ -229,4 +241,104 @@ func unitZ(t *testing.T) math.UnitVector3 {
 		t.Fatal(err)
 	}
 	return u
+}
+
+// --- TransformCurve / TransformSurface: NURBS (K2) -------------------------
+
+// sameFloats reports element-wise scalar equality within tolerance.
+func sameFloats(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !near(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// nurbsTestSimilarity is a non-trivial similarity (scale ∘ rotate ∘ translate) that
+// exercises all three components of the affine map.
+func nurbsTestSimilarity(t *testing.T) math.Matrix4 {
+	t.Helper()
+	return math.Translation4(math.V3(3, -2, 5)).
+		Mul(math.Rotation4(stdmath.Pi/3, unitZ(t), math.P3(0, 0, 0))).
+		Mul(math.Scale4(2, 2, 2))
+}
+
+// TestTransformBSplineCurveMatchesAffineOnEval is the metamorphic identity: because the
+// rational basis is a partition of unity, transform-then-evaluate equals
+// evaluate-then-transform at every parameter.
+func TestTransformBSplineCurveMatchesAffineOnEval(t *testing.T) {
+	c := quarterCircleNURBS(t)
+	m := nurbsTestSimilarity(t)
+	got, err := TransformCurve(c, m)
+	if err != nil {
+		t.Fatalf("TransformCurve: %v", err)
+	}
+	for _, tt := range []float64{0, 0.25, 0.5, 0.75, 1} {
+		want := m.TransformPoint(c.PointAt(tt))
+		if !nearPoint(got.PointAt(tt), want) {
+			t.Errorf("t=%g: PointAt = %v, want %v", tt, got.PointAt(tt), want)
+		}
+	}
+}
+
+// TestTransformBSplineCurvePreservesWeightsKnotsDegree: only the control points move.
+func TestTransformBSplineCurvePreservesWeightsKnotsDegree(t *testing.T) {
+	c := quarterCircleNURBS(t)
+	out, err := TransformCurve(c, math.Translation4(math.V3(1, 2, 3)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bc := out.(BSplineCurve)
+	if bc.Degree != c.Degree {
+		t.Errorf("degree = %d, want %d", bc.Degree, c.Degree)
+	}
+	if !sameFloats(bc.Weights, c.Weights) || !sameFloats(bc.Knots, c.Knots) {
+		t.Errorf("weights/knots changed: w=%v k=%v", bc.Weights, bc.Knots)
+	}
+	for i, p := range bc.Ctrl {
+		want := math.P3(c.Ctrl[i].X+1, c.Ctrl[i].Y+2, c.Ctrl[i].Z+3)
+		if !nearPoint(p, want) {
+			t.Errorf("ctrl[%d] = %v, want translated %v", i, p, want)
+		}
+	}
+}
+
+// TestTransformBSplineCurveDoesNotMutateInput: the input value stays immutable.
+func TestTransformBSplineCurveDoesNotMutateInput(t *testing.T) {
+	c := quarterCircleNURBS(t)
+	before := append([]math.Point3(nil), c.Ctrl...)
+	if _, err := TransformCurve(c, math.Scale4(2, 2, 2)); err != nil {
+		t.Fatal(err)
+	}
+	for i := range before {
+		if !nearPoint(c.Ctrl[i], before[i]) {
+			t.Errorf("input ctrl[%d] mutated to %v", i, c.Ctrl[i])
+		}
+	}
+}
+
+// TestTransformBSplineSurfaceMatchesAffineOnEval is the surface metamorphic identity.
+func TestTransformBSplineSurfaceMatchesAffineOnEval(t *testing.T) {
+	s := sampleBSplineSurface(t)
+	m := nurbsTestSimilarity(t)
+	got, err := TransformSurface(s, m)
+	if err != nil {
+		t.Fatalf("TransformSurface: %v", err)
+	}
+	bs := got.(BSplineSurface)
+	if bs.UDegree != s.UDegree || bs.VDegree != s.VDegree {
+		t.Errorf("degrees = (%d,%d), want (%d,%d)", bs.UDegree, bs.VDegree, s.UDegree, s.VDegree)
+	}
+	for _, u := range []float64{0, 0.5, 1} {
+		for _, v := range []float64{0, 0.5, 1} {
+			want := m.TransformPoint(s.PointAt(u, v))
+			if !nearPoint(bs.PointAt(u, v), want) {
+				t.Errorf("(u,v)=(%g,%g): %v, want %v", u, v, bs.PointAt(u, v), want)
+			}
+		}
+	}
 }

--- a/kernel/geom/transient_gaps_test.go
+++ b/kernel/geom/transient_gaps_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// --- CircleByThreePoints / PlaneByThreePoints ------------------------------
+
+func TestCircleByThreePoints(t *testing.T) {
+	// Three points on the unit circle in the XY plane at angles 0, 90, 180.
+	a, b, c := math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(-1, 0, 0)
+	circ, err := CircleByThreePoints(a, b, c)
+	if err != nil {
+		t.Fatalf("CircleByThreePoints: %v", err)
+	}
+	if !nearPoint(circ.Center, math.P3(0, 0, 0)) {
+		t.Errorf("center = %v, want origin", circ.Center)
+	}
+	if stdmath.Abs(circ.Radius-1) > 1e-9 {
+		t.Errorf("radius = %v, want 1", circ.Radius)
+	}
+	for _, p := range []math.Point3{a, b, c} {
+		if stdmath.Abs(circ.Center.DistanceTo(p)-circ.Radius) > 1e-9 {
+			t.Errorf("point %v not on the circle", p)
+		}
+	}
+}
+
+func TestCircleByThreePointsCollinearFails(t *testing.T) {
+	_, err := CircleByThreePoints(math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(2, 0, 0))
+	if err == nil {
+		t.Error("collinear points should not define a circle")
+	}
+}
+
+func TestPlaneByThreePoints(t *testing.T) {
+	a, b, c := math.P3(0, 0, 1), math.P3(2, 0, 1), math.P3(0, 3, 1)
+	pl, err := PlaneByThreePoints(a, b, c)
+	if err != nil {
+		t.Fatalf("PlaneByThreePoints: %v", err)
+	}
+	// All three points lie on the plane: (p−Origin)·Normal == 0.
+	n := pl.Normal()
+	for _, p := range []math.Point3{a, b, c} {
+		if d := pl.Origin.VectorTo(p).Dot(n); stdmath.Abs(d) > 1e-9 {
+			t.Errorf("point %v off-plane by %v", p, d)
+		}
+	}
+	// The plane is z=1, so the normal is ±Z.
+	if stdmath.Abs(stdmath.Abs(n.Z)-1) > 1e-9 {
+		t.Errorf("normal = %v, want ±Z", n)
+	}
+}
+
+func TestPlaneByThreePointsCollinearFails(t *testing.T) {
+	_, err := PlaneByThreePoints(math.P3(0, 0, 0), math.P3(1, 1, 1), math.P3(2, 2, 2))
+	if err == nil {
+		t.Error("collinear points should not define a plane")
+	}
+}
+
+// --- EllipticalCylinder ----------------------------------------------------
+
+func TestEllipticalCylinderPointAndParam(t *testing.T) {
+	c, err := NewEllipticalCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 3, 1)
+	if err != nil {
+		t.Fatalf("NewEllipticalCylinder: %v", err)
+	}
+	if !nearPoint(c.PointAt(0, 0), math.P3(3, 0, 0)) {
+		t.Errorf("PointAt(0,0) = %v, want major-axis tip (3,0,0)", c.PointAt(0, 0))
+	}
+	if !nearPoint(c.PointAt(stdmath.Pi/2, 2), math.P3(0, 1, 2)) {
+		t.Errorf("PointAt(π/2,2) = %v, want (0,1,2)", c.PointAt(stdmath.Pi/2, 2))
+	}
+	// ParamAt inverts PointAt on the surface.
+	for _, uv := range [][2]float64{{0.5, 1.3}, {2.0, -0.7}, {4.1, 2.2}} {
+		gotU, gotV := c.ParamAt(c.PointAt(uv[0], uv[1]))
+		if stdmath.Abs(gotU-uv[0]) > 1e-9 || stdmath.Abs(gotV-uv[1]) > 1e-9 {
+			t.Errorf("ParamAt∘PointAt(%v) = (%v,%v)", uv, gotU, gotV)
+		}
+	}
+}
+
+func TestEllipticalCylinderNormalOutwardUnit(t *testing.T) {
+	c, _ := NewEllipticalCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 3, 1)
+	n := c.NormalAt(0, 0)
+	if stdmath.Abs(n.Length()-1) > 1e-9 {
+		t.Errorf("normal length = %v, want 1", n.Length())
+	}
+	if !nearVec(n, math.V3(1, 0, 0)) { // outward at the major-axis tip
+		t.Errorf("normal at (0,0) = %v, want +X", n)
+	}
+}
+
+// --- EllipticalCone --------------------------------------------------------
+
+func TestEllipticalConePointAndParam(t *testing.T) {
+	c, err := NewEllipticalCone(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), stdmath.Pi/4, stdmath.Pi/6)
+	if err != nil {
+		t.Fatalf("NewEllipticalCone: %v", err)
+	}
+	// At v=2,u=0 the major semi-axis is 2·tan(π/4)=2, so the point is (2,0,2).
+	if !nearPoint(c.PointAt(0, 2), math.P3(2, 0, 2)) {
+		t.Errorf("PointAt(0,2) = %v, want (2,0,2)", c.PointAt(0, 2))
+	}
+	for _, uv := range [][2]float64{{0.5, 1.3}, {2.0, 0.7}, {4.1, 2.2}} {
+		gotU, gotV := c.ParamAt(c.PointAt(uv[0], uv[1]))
+		if stdmath.Abs(gotU-uv[0]) > 1e-9 || stdmath.Abs(gotV-uv[1]) > 1e-9 {
+			t.Errorf("ParamAt∘PointAt(%v) = (%v,%v)", uv, gotU, gotV)
+		}
+	}
+}
+
+func TestEllipticalConeRejectsBadAngle(t *testing.T) {
+	if _, err := NewEllipticalCone(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 0, stdmath.Pi/6); err == nil {
+		t.Error("a zero half angle should be rejected")
+	}
+	if _, err := NewEllipticalCone(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), stdmath.Pi/4, stdmath.Pi); err == nil {
+		t.Error("a half angle >= π/2 should be rejected")
+	}
+}
+
+// --- BSplineCurve2d --------------------------------------------------------
+
+func TestBSplineCurve2dQuadratic(t *testing.T) {
+	// A clamped degree-2 curve over three control points is the quadratic Bézier.
+	ctrl := []math.Point2{math.P2(0, 0), math.P2(1, 2), math.P2(2, 0)}
+	knots := []float64{0, 0, 0, 1, 1, 1}
+	c, err := NewBSplineCurve2dUniformWeights(2, ctrl, knots)
+	if err != nil {
+		t.Fatalf("NewBSplineCurve2d: %v", err)
+	}
+	if !nearPoint2(c.PointAt(0), ctrl[0]) || !nearPoint2(c.PointAt(1), ctrl[2]) {
+		t.Errorf("endpoints = %v,%v, want %v,%v", c.PointAt(0), c.PointAt(1), ctrl[0], ctrl[2])
+	}
+	if !nearPoint2(c.PointAt(0.5), math.P2(1, 1)) { // 0.25P0+0.5P1+0.25P2
+		t.Errorf("midpoint = %v, want (1,1)", c.PointAt(0.5))
+	}
+	if tan := c.TangentAt(0); !nearVec2(tan, math.V2(2, 4)) { // 2(P1−P0)
+		t.Errorf("TangentAt(0) = %v, want (2,4)", tan)
+	}
+}
+
+// --- PolylineFromCurve -----------------------------------------------------
+
+func TestPolylineFromCurve3OnCircle(t *testing.T) {
+	circ, _ := NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	pl, err := PolylineFromCurve3(circ, 8)
+	if err != nil {
+		t.Fatalf("PolylineFromCurve3: %v", err)
+	}
+	if len(pl.Vertices) != 9 {
+		t.Fatalf("got %d vertices, want 9 (8 segments + 1)", len(pl.Vertices))
+	}
+	for _, v := range pl.Vertices {
+		if stdmath.Abs(v.DistanceTo(math.P3(0, 0, 0))-2) > 1e-9 {
+			t.Errorf("vertex %v not on the circle of radius 2", v)
+		}
+	}
+}
+
+func TestPolylineFromCurveRejectsUnbounded(t *testing.T) {
+	line, _ := NewLine(math.P3(0, 0, 0), math.V3(1, 0, 0)) // infinite domain
+	if _, err := PolylineFromCurve3(line, 4); err == nil {
+		t.Error("an unbounded curve has no finite polyline")
+	}
+	circ, _ := NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 1)
+	if _, err := PolylineFromCurve3(circ, 0); err == nil {
+		t.Error("zero segments should be rejected")
+	}
+}
+
+// --- FittedBSplineCurve ----------------------------------------------------
+
+func TestFittedBSplineCurve3dInterpolates(t *testing.T) {
+	pts := []math.Point3{math.P3(0, 0, 0), math.P3(1, 1, 0), math.P3(2, 0, 1), math.P3(3, 1, 0)}
+	c, err := NewFittedBSplineCurve(pts)
+	if err != nil {
+		t.Fatalf("NewFittedBSplineCurve: %v", err)
+	}
+	for k, u := range chordParamsOracle3(pts) {
+		if got := c.PointAt(u); !nearPoint(got, pts[k]) {
+			t.Errorf("curve at ū=%v = %v, want input point %v", u, got, pts[k])
+		}
+	}
+}
+
+func TestFittedBSplineCurve2dInterpolates(t *testing.T) {
+	pts := []math.Point2{math.P2(0, 0), math.P2(1, 2), math.P2(3, 1)}
+	c, err := NewFittedBSplineCurve2d(pts)
+	if err != nil {
+		t.Fatalf("NewFittedBSplineCurve2d: %v", err)
+	}
+	for k, u := range chordParamsOracle2(pts) {
+		if got := c.PointAt(u); !nearPoint2(got, pts[k]) {
+			t.Errorf("curve at ū=%v = %v, want input point %v", u, got, pts[k])
+		}
+	}
+}
+
+func TestFittedBSplineTwoPointsIsLine(t *testing.T) {
+	c, err := NewFittedBSplineCurve([]math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0)})
+	if err != nil {
+		t.Fatalf("NewFittedBSplineCurve: %v", err)
+	}
+	if c.Degree != 1 {
+		t.Errorf("degree = %d, want 1 for two points", c.Degree)
+	}
+	if !nearPoint(c.PointAt(0.5), math.P3(1, 0, 0)) {
+		t.Errorf("midpoint = %v, want (1,0,0)", c.PointAt(0.5))
+	}
+}
+
+func TestFittedBSplineRejectsCoincident(t *testing.T) {
+	_, err := NewFittedBSplineCurve([]math.Point3{math.P3(1, 1, 1), math.P3(1, 1, 1)})
+	if err == nil {
+		t.Error("coincident points have no chord length and should be rejected")
+	}
+}
+
+// nearVec / nearVec2 compare vectors within 1e-9.
+func nearVec(a, b math.Vector3) bool  { return a.Sub(b).Length() < 1e-9 }
+func nearVec2(a, b math.Vector2) bool { return a.Sub(b).Length() < 1e-9 }
+
+// chordParamsOracle3 / chordParamsOracle2 reproduce the constructor's chord-length
+// parameterization independently, giving the parameters at which a true interpolating
+// spline must reproduce its input points.
+func chordParamsOracle3(pts []math.Point3) []float64 {
+	d := make([]float64, len(pts))
+	for k := 1; k < len(pts); k++ {
+		d[k] = d[k-1] + float64(pts[k-1].DistanceTo(pts[k]))
+	}
+	return normalizeCumulative(d)
+}
+
+func chordParamsOracle2(pts []math.Point2) []float64 {
+	d := make([]float64, len(pts))
+	for k := 1; k < len(pts); k++ {
+		d[k] = d[k-1] + float64(pts[k-1].DistanceTo(pts[k]))
+	}
+	return normalizeCumulative(d)
+}
+
+func normalizeCumulative(d []float64) []float64 {
+	total := d[len(d)-1]
+	u := make([]float64, len(d))
+	for k := range u {
+		u[k] = d[k] / total
+	}
+	u[len(u)-1] = 1
+	return u
+}

--- a/kernel/ops/split.go
+++ b/kernel/ops/split.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// SplitSolidByPlane divides a solid into the pieces lying on each side of an infinite plane,
+// returning the negative-normal side first then the positive. It intersects the body with a
+// large half-space box on each side (so each piece is capped by a clean planar cross-section).
+// A plane that misses the body yields a single piece (the whole body). Used by the Split feature
+// and Trim Solid (keep one side).
+func SplitSolidByPlane(body *topo.Body, plane geom.Plane) ([]*topo.Body, error) {
+	ext := splitExtent(body, plane.Origin)
+	var pieces []*topo.Body
+	for _, positive := range []bool{false, true} {
+		piece, err := Boolean(Intersect, body, halfSpaceBox(plane, ext, positive))
+		if err != nil {
+			return nil, err
+		}
+		if piece != nil && len(piece.Faces()) > 0 {
+			pieces = append(pieces, piece)
+		}
+	}
+	return pieces, nil
+}
+
+// splitExtent returns a half-width large enough for a cutting half-space anchored at the plane
+// origin to cover the whole body — twice the farthest body-corner distance from that origin, so
+// the box reaches the body even when the plane sits well outside it.
+func splitExtent(b *topo.Body, origin math.Point3) float64 {
+	bx := b.RangeBox()
+	far := 0.0
+	for _, x := range [2]math.Scalar{bx.Min.X, bx.Max.X} {
+		for _, y := range [2]math.Scalar{bx.Min.Y, bx.Max.Y} {
+			for _, z := range [2]math.Scalar{bx.Min.Z, bx.Max.Z} {
+				if d := float64(origin.DistanceTo(math.Point3{X: x, Y: y, Z: z})); d > far {
+					far = d
+				}
+			}
+		}
+	}
+	return 2*far + 1
+}
+
+// halfSpaceBox builds a large oriented box covering one side of the plane: its near face lies on
+// the plane and it extends `ext` along ±normal and ±ext in the plane's U/V. For the negative
+// side U and V swap so the (u,v,n) frame stays right-handed — the canonical box rings are wound
+// outward only for a right-handed frame.
+func halfSpaceBox(plane geom.Plane, ext float64, positive bool) *topo.Body {
+	u, v := plane.UAxis.AsVector(), plane.VAxis.AsVector()
+	n := unit(plane.Normal())
+	if !positive {
+		u, v, n = v, u, n.Scale(-1)
+	}
+	o := plane.Origin.TranslateBy(u.Scale(math.Scalar(-ext))).TranslateBy(v.Scale(math.Scalar(-ext)))
+	corner := func(x, y, z float64) math.Point3 {
+		return o.TranslateBy(u.Scale(math.Scalar(2 * ext * x))).
+			TranslateBy(v.Scale(math.Scalar(2 * ext * y))).
+			TranslateBy(n.Scale(math.Scalar(ext * z)))
+	}
+	c := [8]math.Point3{
+		corner(0, 0, 0), corner(1, 0, 0), corner(1, 1, 0), corner(0, 1, 0),
+		corner(0, 0, 1), corner(1, 0, 1), corner(1, 1, 1), corner(0, 1, 1),
+	}
+	return boxFromCorners(c)
+}
+
+// boxFromCorners builds a closed box B-rep from 8 corners in the canonical 0..7 order. Each of
+// the six quad faces derives its outward normal from the ring's Newell normal flipped to point
+// away from the box centre, reversing the ring when needed so the loop winds CCW about that
+// outward normal (plane normal and winding stay consistent — the boolean and volume both rely on
+// it). (Lives here so the split has no dependency on the subd package.)
+func boxFromCorners(c [8]math.Point3) *topo.Body {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("split", "box", 0)))
+	tv := make([]*topo.Vertex, 8)
+	for i := range c {
+		tv[i] = bld.AddVertex(c[i], topo.NewLineage(topo.Tok("split", "vertex", i)))
+	}
+	edges := map[[2]int]*topo.Edge{}
+	// Edges are stored canonically (min→max vertex) so the Reversed: a>b convention in the
+	// loops below is consistent regardless of the order a face first traverses them; each gets a
+	// distinct lineage (colliding reference keys break the downstream boolean).
+	edge := func(a, b int) *topo.Edge {
+		k := [2]int{a, b}
+		if a > b {
+			k = [2]int{b, a}
+		}
+		if e, ok := edges[k]; ok {
+			return e
+		}
+		e := bld.AddEdge(geom.NewLineSegment(c[k[0]], c[k[1]]), tv[k[0]], tv[k[1]],
+			topo.NewLineage(topo.Tok("split", "edge", len(edges))))
+		edges[k] = e
+		return e
+	}
+	// The six rings are pre-wound CCW about their outward normals (the canonical box layout),
+	// so each face's plane uses the ring's own Newell normal directly — winding and normal agree.
+	rings := [6][4]int{
+		{0, 3, 2, 1}, {4, 5, 6, 7}, {0, 1, 5, 4}, {3, 7, 6, 2}, {0, 4, 7, 3}, {1, 2, 6, 5},
+	}
+	for fi, ring := range rings {
+		pts := []math.Point3{c[ring[0]], c[ring[1]], c[ring[2]], c[ring[3]]}
+		pl, _ := geom.NewPlane(quadCentroid(pts), newellUnit(pts))
+		uses := make([]topo.Use, 4)
+		for i := 0; i < 4; i++ {
+			a, b := ring[i], ring[(i+1)%4]
+			uses[i] = topo.Use{Edge: edge(a, b), Reversed: a > b}
+		}
+		bld.AddFace(pl, topo.NewLineage(topo.Tok("split", "face", fi)), topo.OuterLoop(uses...))
+	}
+	return bld.Build()
+}
+
+// quadCentroid averages corner positions.
+func quadCentroid(pts []math.Point3) math.Point3 {
+	var sx, sy, sz math.Scalar
+	for _, p := range pts {
+		sx, sy, sz = sx+p.X, sy+p.Y, sz+p.Z
+	}
+	n := math.Scalar(len(pts))
+	return math.Point3{X: sx / n, Y: sy / n, Z: sz / n}
+}
+
+// unit returns v normalized, or v unchanged if it is degenerate.
+func unit(v math.Vector3) math.Vector3 {
+	if u, err := math.UnitVector3FromVector(v); err == nil {
+		return u.AsVector()
+	}
+	return v
+}

--- a/kernel/ops/split_test.go
+++ b/kernel/ops/split_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+func splitBox(sx, sy, sz float64) *topo.Body {
+	return subd.ToBody(subd.Box(sx, sy, sz), "box")
+}
+
+// Splitting a 4×4×4 box by the mid-plane z=2 yields two valid 4×4×2 solids (vol 32 each).
+func TestSplitSolidByMidPlane(t *testing.T) {
+	plane, _ := geom.NewPlane(math.P3(0, 0, 2), math.V3(0, 0, 1))
+	pieces, err := ops.SplitSolidByPlane(splitBox(4, 4, 4), plane)
+	if err != nil {
+		t.Fatalf("SplitSolidByPlane: %v", err)
+	}
+	if len(pieces) != 2 {
+		t.Fatalf("split yielded %d pieces, want 2", len(pieces))
+	}
+	for i, p := range pieces {
+		if r := ops.Validate(p); !r.Valid || !p.IsSolid() {
+			t.Fatalf("piece %d not a valid solid: %+v", i, r)
+		}
+		if v := ops.BodyGeometryProperties(p, ops.DefaultQuality()).Volume; stdmath.Abs(v-32) > 1e-6 {
+			t.Errorf("piece %d volume = %g, want 32 (half the box)", i, v)
+		}
+	}
+}
+
+// A plane clear of the body leaves it whole (one piece).
+func TestSplitPlaneMissesBody(t *testing.T) {
+	plane, _ := geom.NewPlane(math.P3(0, 0, 100), math.V3(0, 0, 1))
+	pieces, err := ops.SplitSolidByPlane(splitBox(2, 2, 2), plane)
+	if err != nil {
+		t.Fatalf("SplitSolidByPlane: %v", err)
+	}
+	if len(pieces) != 1 {
+		t.Errorf("split by a missing plane gave %d pieces, want 1 (whole body)", len(pieces))
+	}
+}
+
+// Splitting by an oblique plane still gives two valid solids whose volumes sum to the original.
+func TestSplitSolidByObliquePlane(t *testing.T) {
+	plane, _ := geom.NewPlane(math.P3(2, 2, 2), math.V3(1, 0, 1))
+	pieces, err := ops.SplitSolidByPlane(splitBox(4, 4, 4), plane)
+	if err != nil {
+		t.Fatalf("SplitSolidByPlane: %v", err)
+	}
+	if len(pieces) != 2 {
+		t.Fatalf("oblique split yielded %d pieces, want 2", len(pieces))
+	}
+	sum := 0.0
+	for _, p := range pieces {
+		if r := ops.Validate(p); !r.Valid || !p.IsSolid() {
+			t.Fatalf("oblique piece not a valid solid: %+v", r)
+		}
+		sum += ops.BodyGeometryProperties(p, ops.DefaultQuality()).Volume
+	}
+	if stdmath.Abs(sum-64) > 1e-6 {
+		t.Errorf("oblique split volumes sum to %g, want 64 (the whole box)", sum)
+	}
+}

--- a/kernel/ops/surface_edit.go
+++ b/kernel/ops/surface_edit.go
@@ -56,38 +56,109 @@ func useStart(u *topo.EdgeUse) math.Point3 {
 
 // buildPlanarBody builds a one-face planar surface body from an ordered model-space
 // polygon and a surface normal, with stable per-feature lineage.
-func buildPlanarBody(poly []math.Point3, normal math.Vector3, feat string) *topo.Body {
+// sheetPatch is one planar face of a surface body: its boundary polygon and outward normal.
+type sheetPatch struct {
+	poly   []math.Point3
+	normal math.Vector3
+}
+
+// buildSheet welds the patches into one planar-faced surface body: coincident boundary vertices
+// merge and faces sharing an edge reconnect (one edge per undirected vertex pair). A single
+// patch yields a one-face sheet; several patches yield a quilt. Patches with <3 points are
+// dropped.
+func buildSheet(patches []sheetPatch, feat string) *topo.Body {
+	w := &sheetWelder{index: map[[3]int64]int{}}
+	rings := make([][]int, 0, len(patches))
+	normals := make([]math.Vector3, 0, len(patches))
+	for _, p := range patches {
+		if r := w.ring(p.poly); len(r) >= 3 {
+			rings = append(rings, r)
+			normals = append(normals, p.normal)
+		}
+	}
 	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok(feat, "body", 0)))
-	surf, _ := geom.NewPlane(poly[0], normal)
-	n := len(poly)
-	v := make([]*topo.Vertex, n)
-	for i, p := range poly {
-		v[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(feat, "vertex", i)))
+	tv := make([]*topo.Vertex, len(w.points))
+	for i, pt := range w.points {
+		tv[i] = bld.AddVertex(pt, topo.NewLineage(topo.Tok(feat, "vertex", i)))
 	}
-	uses := make([]topo.Use, n)
-	for i := 0; i < n; i++ {
-		j := (i + 1) % n
-		e := bld.AddEdge(geom.NewLineSegment(poly[i], poly[j]), v[i], v[j], topo.NewLineage(topo.Tok(feat, "edge", i)))
-		uses[i] = topo.Fwd(e)
+	edges := map[[2]int]*topo.Edge{}
+	edge := func(a, b int) *topo.Edge {
+		k := [2]int{a, b}
+		if a > b {
+			k = [2]int{b, a}
+		}
+		if e, ok := edges[k]; ok {
+			return e
+		}
+		e := bld.AddEdge(geom.NewLineSegment(w.points[k[0]], w.points[k[1]]), tv[k[0]], tv[k[1]], topo.NewLineage(topo.Tok(feat, "edge", len(edges))))
+		edges[k] = e
+		return e
 	}
-	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "patch", 0)), topo.OuterLoop(uses...))
+	for fi, r := range rings {
+		surf, _ := geom.NewPlane(w.points[r[0]], normals[fi])
+		uses := make([]topo.Use, len(r))
+		for i := range r {
+			a, b := r[i], r[(i+1)%len(r)]
+			uses[i] = topo.Use{Edge: edge(a, b), Reversed: a > b}
+		}
+		bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "patch", fi)), topo.OuterLoop(uses...))
+	}
 	return bld.Build()
 }
 
-// TrimByPlane trims a single-face planar surface body with a cutting plane, keeping
-// the half on the plane's positive (keepPositive) or negative side. It clips the
-// boundary polygon against the cutting plane and rebuilds the trimmed patch. General
-// surface–surface trimming (curved tools, multi-face splitting) is phase C.
+// sheetWelder merges coincident boundary points onto a shared index list (a fine grid snap).
+type sheetWelder struct {
+	index  map[[3]int64]int
+	points []math.Point3
+}
+
+func (w *sheetWelder) add(p math.Point3) int {
+	const grid = 1e-7
+	k := [3]int64{int64(stdmath.Round(float64(p.X) / grid)), int64(stdmath.Round(float64(p.Y) / grid)), int64(stdmath.Round(float64(p.Z) / grid))}
+	if i, ok := w.index[k]; ok {
+		return i
+	}
+	w.index[k] = len(w.points)
+	w.points = append(w.points, p)
+	return len(w.points) - 1
+}
+
+// ring welds a boundary polygon to vertex indices, dropping consecutive (and wrap-around) dups.
+func (w *sheetWelder) ring(poly []math.Point3) []int {
+	var out []int
+	for _, p := range poly {
+		i := w.add(p)
+		if len(out) == 0 || out[len(out)-1] != i {
+			out = append(out, i)
+		}
+	}
+	if len(out) > 1 && out[0] == out[len(out)-1] {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// TrimByPlane trims a planar surface body (single or multi-face) with a cutting plane, keeping
+// the half on the plane's positive (keepPositive) or negative side. Each face's boundary polygon
+// is clipped against the plane; kept faces are welded back into one sheet (a shared fold edge
+// clips identically on both faces, so it reconnects). Trimming a body with any curved face
+// (NURBS surface–surface trimming) is the remaining phase-C work.
 func TrimByPlane(body *topo.Body, origin math.Point3, normal math.Vector3, keepPositive bool, feat string) (*topo.Body, error) {
 	faces := planarFaces(body)
-	if len(faces) != 1 {
-		return nil, build.NotYetImplemented("PBI-111-trim-multiface-or-curved")
+	if len(faces) == 0 || len(faces) != len(body.Faces()) {
+		return nil, build.NotYetImplemented("PBI-111-trim-curved") // any curved face
 	}
-	clipped := clipHalfSpace(facePolygon(faces[0]), origin, normal, keepPositive)
-	if len(clipped) < 3 {
+	var patches []sheetPatch
+	for _, f := range faces {
+		clipped := clipHalfSpace(facePolygon(f), origin, normal, keepPositive)
+		if len(clipped) >= 3 {
+			patches = append(patches, sheetPatch{poly: clipped, normal: f.Geometry().(geom.Plane).Normal()})
+		}
+	}
+	if len(patches) == 0 {
 		return nil, errors.New("trim: nothing remains on the keep side of the cutting plane")
 	}
-	return buildPlanarBody(clipped, faces[0].Geometry().(geom.Plane).Normal(), feat), nil
+	return buildSheet(patches, feat), nil
 }
 
 // clipHalfSpace clips a planar polygon against one half-space (Sutherland–Hodgman),
@@ -130,17 +201,82 @@ func lerpToPlane(a, b math.Point3, da, db float64) math.Point3 {
 // normal, producing a new parallel surface body. Curved-face offset is phase C.
 func OffsetSurface(body *topo.Body, distance float64, feat string) (*topo.Body, error) {
 	faces := planarFaces(body)
+	if len(faces) == 0 || len(faces) != len(body.Faces()) {
+		return nil, build.NotYetImplemented("PBI-112-offset-curved") // any curved face
+	}
+	// Each face translates along its own normal. That reconnects only when faces sharing an edge
+	// have the same normal (a coplanar quilt or a single face); a folded sheet would split at the
+	// fold (its offset needs intersecting adjacent offset planes — a later refinement).
+	n0 := faces[0].Geometry().(geom.Plane).Normal()
+	patches := make([]sheetPatch, len(faces))
+	for i, f := range faces {
+		nrm := f.Geometry().(geom.Plane).Normal()
+		if i > 0 && !sameDirection(nrm, n0) {
+			return nil, build.NotYetImplemented("PBI-112-offset-folded-multiface")
+		}
+		shift := nrm.Scale(distance)
+		src := facePolygon(f)
+		moved := make([]math.Point3, len(src))
+		for j, p := range src {
+			moved[j] = p.TranslateBy(shift)
+		}
+		patches[i] = sheetPatch{poly: moved, normal: nrm}
+	}
+	return buildSheet(patches, feat), nil
+}
+
+// ExtendByEdge extends a planar surface's boundary edge outward by distance, growing the face:
+// the edge's two endpoints slide along the in-plane direction perpendicular to the edge, away
+// from the face. A multi-face body or a curved face is the remaining phase-C (NURBS) work.
+func ExtendByEdge(body *topo.Body, edgeKey []byte, distance float64, feat string) (*topo.Body, error) {
+	edge, ok := body.FindEdgeByKey(edgeKey)
+	if !ok {
+		return nil, errors.New("extend: edge reference lost")
+	}
+	faces := edge.Faces()
 	if len(faces) != 1 {
-		return nil, build.NotYetImplemented("PBI-112-offset-multiface-or-curved")
+		return nil, build.NotYetImplemented("PBI-111-extend-multiface")
 	}
-	normal := faces[0].Geometry().(geom.Plane).Normal()
-	shift := normal.Scale(distance)
-	src := facePolygon(faces[0])
-	moved := make([]math.Point3, len(src))
-	for i, p := range src {
-		moved[i] = p.TranslateBy(shift)
+	pl, ok := faces[0].Geometry().(geom.Plane)
+	if !ok {
+		return nil, build.NotYetImplemented("PBI-111-extend-curved")
 	}
-	return buildPlanarBody(moved, normal, feat), nil
+	poly := facePolygon(faces[0])
+	a, b := edge.StartVertex().Point(), edge.EndVertex().Point()
+	shift := extendDir(pl.Normal(), a, b, centroid(poly)).Scale(distance)
+	moved := make([]math.Point3, len(poly))
+	for i, p := range poly {
+		if coincidentPt(p, a) || coincidentPt(p, b) {
+			moved[i] = p.TranslateBy(shift)
+		} else {
+			moved[i] = p
+		}
+	}
+	return buildSheet([]sheetPatch{{poly: moved, normal: pl.Normal()}}, feat), nil
+}
+
+// extendDir is the in-plane unit direction perpendicular to edge a→b pointing away from the
+// face centroid c (so an extended boundary grows outward).
+func extendDir(normal math.Vector3, a, b, c math.Point3) math.Vector3 {
+	perp := unit3(normal.Cross(a.VectorTo(b)))
+	if float64(perp.Dot(a.Midpoint(b).VectorTo(c))) > 0 { // points toward the interior → flip
+		perp = perp.Scale(-1)
+	}
+	return perp
+}
+
+func coincidentPt(a, b math.Point3) bool { return float64(a.DistanceTo(b)) < 1e-7 }
+
+// sameDirection reports whether two normals point the same way (within tolerance).
+func sameDirection(a, b math.Vector3) bool {
+	return float64(unit3(a).Dot(unit3(b))) > 1-1e-7
+}
+
+func unit3(v math.Vector3) math.Vector3 {
+	if u, err := math.UnitVector3FromVector(v); err == nil {
+		return u.AsVector()
+	}
+	return v
 }
 
 // MidPatch is one extracted mid-surface: the surface body lying halfway between a
@@ -209,7 +345,7 @@ func midPatch(a, b *topo.Face, feat string, idx int) MidPatch {
 	for i, p := range polyA {
 		moved[i] = p.TranslateBy(shift)
 	}
-	return MidPatch{Body: buildPlanarBody(moved, na, feat+"-mid-"+strconv.Itoa(idx)), Thickness: sep}
+	return MidPatch{Body: buildSheet([]sheetPatch{{poly: moved, normal: na}}, feat+"-mid-"+strconv.Itoa(idx)), Thickness: sep}
 }
 
 // centroid returns the average of a polygon's vertices.

--- a/kernel/ops/surface_edit_test.go
+++ b/kernel/ops/surface_edit_test.go
@@ -40,6 +40,83 @@ func TestTrimByPlaneKeepsHalf(t *testing.T) {
 	}
 }
 
+// twoQuadSheet is a 2-face coplanar quilt (two unit-deep quads sharing the x=2 edge on z=0).
+func twoQuadSheet(t *testing.T) *topo.Body {
+	t.Helper()
+	q1 := quadBody("q1", math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(2, 2, 0), math.P3(0, 2, 0))
+	q2 := quadBody("q2", math.P3(2, 0, 0), math.P3(4, 0, 0), math.P3(4, 2, 0), math.P3(2, 2, 0))
+	sheet, err := Stitch([]*topo.Body{q1, q2}, 0, true, "sheet")
+	if err != nil {
+		t.Fatalf("Stitch setup: %v", err)
+	}
+	if len(sheet.Faces()) != 2 {
+		t.Fatalf("setup sheet has %d faces, want 2", len(sheet.Faces()))
+	}
+	return sheet
+}
+
+// K5: trimming a MULTI-FACE planar sheet clips each face and welds the kept ones back.
+func TestTrimMultiFaceSheet(t *testing.T) {
+	trimmed, err := TrimByPlane(twoQuadSheet(t), math.P3(1, 0, 0), math.V3(1, 0, 0), true, "trim")
+	if err != nil {
+		t.Fatalf("TrimByPlane multi-face: %v", err)
+	}
+	if len(trimmed.Faces()) != 2 {
+		t.Errorf("trimmed sheet has %d faces, want 2 (clipped quad + whole quad)", len(trimmed.Faces()))
+	}
+	box := trimmed.RangeBox()
+	if !approx(box.Min.X, 1) || !approx(box.Max.X, 4) {
+		t.Errorf("trimmed x-span = [%v,%v], want [1,4]", box.Min.X, box.Max.X)
+	}
+}
+
+// K5: offsetting a MULTI-FACE coplanar quilt translates every face along the shared normal.
+func TestOffsetMultiFaceCoplanar(t *testing.T) {
+	off, err := OffsetSurface(twoQuadSheet(t), 0.5, "off")
+	if err != nil {
+		t.Fatalf("OffsetSurface multi-face: %v", err)
+	}
+	if len(off.Faces()) != 2 {
+		t.Errorf("offset quilt has %d faces, want 2", len(off.Faces()))
+	}
+	box := off.RangeBox()
+	if !approx(box.Min.Z, 0.5) || !approx(box.Max.Z, 0.5) {
+		t.Errorf("offset z = [%v,%v], want flat at 0.5", box.Min.Z, box.Max.Z)
+	}
+}
+
+// K5: extending a planar surface's boundary edge grows the face outward by the distance.
+func TestExtendByEdgeGrowsFace(t *testing.T) {
+	patch := quadBody("p", math.P3(0, 0, 0), math.P3(4, 0, 0), math.P3(4, 4, 0), math.P3(0, 4, 0))
+	var key []byte // the bottom edge (both endpoints at y=0)
+	for _, e := range patch.Edges() {
+		if approx(float64(e.StartVertex().Point().Y), 0) && approx(float64(e.EndVertex().Point().Y), 0) {
+			key = e.ReferenceKey()
+		}
+	}
+	if key == nil {
+		t.Fatal("no bottom edge found")
+	}
+	ext, err := ExtendByEdge(patch, key, 2, "ext")
+	if err != nil {
+		t.Fatalf("ExtendByEdge: %v", err)
+	}
+	box := ext.RangeBox()
+	if !approx(box.Min.Y, -2) || !approx(box.Max.Y, 4) {
+		t.Errorf("extended y-span = [%v,%v], want [-2,4]", box.Min.Y, box.Max.Y)
+	}
+	if !approx(box.Min.X, 0) || !approx(box.Max.X, 4) {
+		t.Errorf("extended x-span = [%v,%v], want [0,4] (unchanged)", box.Min.X, box.Max.X)
+	}
+}
+
+func TestExtendByEdgeLostEdgeErrors(t *testing.T) {
+	patch := quadBody("p", math.P3(0, 0, 0), math.P3(4, 0, 0), math.P3(4, 4, 0), math.P3(0, 4, 0))
+	if _, err := ExtendByEdge(patch, []byte("ghost"), 2, "ext"); err == nil {
+		t.Error("extending a lost edge should error")
+	}
+}
+
 func TestTrimByPlaneEmptyErrors(t *testing.T) {
 	patch := quadBody("p", math.P3(0, 0, 0), math.P3(4, 0, 0), math.P3(4, 4, 0), math.P3(0, 4, 0))
 	// Keep the x ≥ 10 side — nothing remains.

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -77,10 +77,32 @@ func TessellateBody(b *topo.Body, q Quality) (*Mesh, [][]math.Point3) {
 // TessellateFace facets a face. Planar faces are triangulated exactly from their
 // outer boundary (watertight); curved faces are sampled on an adaptive UV grid.
 func TessellateFace(f *topo.Face, q Quality) *Mesh {
+	mesh := tessellateFaceSurface(f, q)
+	if f.Reversed() {
+		reverseMesh(mesh) // cut wall: surface normal points into the removed material
+	}
+	return mesh
+}
+
+// tessellateFaceSurface meshes a face by its surface kind, ignoring its sense.
+func tessellateFaceSurface(f *topo.Face, q Quality) *Mesh {
 	if _, planar := f.Geometry().(geom.Plane); planar {
 		return tessellatePlanarFace(f, q)
 	}
 	return tessellateCurvedFace(f, q)
+}
+
+// reverseMesh flips a reversed face's sense (see topo.Face.Reversed): every outward normal
+// negates and every triangle's winding reverses, so the face presents its true material side
+// to shading and to the divergence-theorem volume (mass-properties orient triangles by these
+// per-vertex normals — see meshGeometryProperties).
+func reverseMesh(m *Mesh) {
+	for i := range m.Normals {
+		m.Normals[i] = m.Normals[i].Scale(-1)
+	}
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		m.Indices[t+1], m.Indices[t+2] = m.Indices[t+2], m.Indices[t+1]
+	}
 }
 
 // mergeMesh appends src's geometry into dst, offsetting indices.

--- a/kernel/ops/tessellate_sense_test.go
+++ b/kernel/ops/tessellate_sense_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// unitQuadFace builds a unit square on z=0 with surface normal +Z, optionally with reversed
+// sense (its material side then faces −Z — the shape of a Difference cut wall).
+func unitQuadFace(reversed bool) *topo.Face {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("t", "body", 0)))
+	lin := topo.NewLineage(topo.Tok("t", "x", 0))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	c := [4]math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0)}
+	v := [4]*topo.Vertex{}
+	for i, p := range c {
+		v[i] = bld.AddVertex(p, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := range c {
+		j := (i + 1) % 4
+		uses[i] = topo.Fwd(bld.AddEdge(geom.NewLineSegment(c[i], c[j]), v[i], v[j], lin))
+	}
+	if reversed {
+		bld.AddReversedFace(pl, lin, topo.OuterLoop(uses...))
+	} else {
+		bld.AddFace(pl, lin, topo.OuterLoop(uses...))
+	}
+	return bld.Build().Faces()[0]
+}
+
+// A reversed face tessellates to the same surface with NEGATED normals and REVERSED triangle
+// winding, so a curved cut wall (whose surface normal points into the removed material)
+// presents its true material side to shading and the divergence-theorem volume.
+func TestReversedFaceFlipsNormalsAndWinding(t *testing.T) {
+	q := ops.DefaultQuality()
+	plain := ops.TessellateFace(unitQuadFace(false), q)
+	rev := ops.TessellateFace(unitQuadFace(true), q)
+	if plain.TriangleCount() != rev.TriangleCount() || plain.VertexCount() != rev.VertexCount() {
+		t.Fatalf("reversed face changed mesh size: %d/%d vs %d/%d", plain.TriangleCount(), plain.VertexCount(), rev.TriangleCount(), rev.VertexCount())
+	}
+	for i := range plain.Normals {
+		if plain.Normals[i].Add(rev.Normals[i]).Length() > 1e-9 {
+			t.Fatalf("normal %d not negated: %+v vs %+v", i, plain.Normals[i], rev.Normals[i])
+		}
+	}
+	if geomNormalZ(plain) <= 0 || geomNormalZ(rev) >= 0 {
+		t.Errorf("winding not reversed: plain z=%g (want +), reversed z=%g (want −)", geomNormalZ(plain), geomNormalZ(rev))
+	}
+}
+
+// geomNormalZ returns the z-component of the first triangle's geometric (winding) normal.
+func geomNormalZ(m *ops.Mesh) float64 {
+	a, b, c := m.Positions[m.Indices[0]], m.Positions[m.Indices[1]], m.Positions[m.Indices[2]]
+	return float64(a.VectorTo(b).Cross(a.VectorTo(c)).Z)
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -32,9 +32,15 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if len(outer3D) < 3 {
 		return fullDomainGridMesh(s, q)
 	}
+	if m, isFan := coneApexFan(s, outer3D); isFan {
+		return m // a cone closing to its apex (a drill point): a fan from the apex to the rim
+	}
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
-		return fullDomainGridMesh(s, q) // seam-crossing periodic face
+		if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
+			return structuredGridMesh(s, us, vs) // full cylinder/cone side: exact area
+		}
+		return fullDomainGridMesh(s, q) // seam-crossing periodic face we can't reduce
 	}
 	if len(holesUV) == 0 {
 		if us, vs, isRect := isoRectangleGrid(outerUV); isRect {
@@ -199,6 +205,79 @@ func emitCellOutward(m *Mesh, s geom.Surface, u0, u1, v0, v1 float64, a, b, c, d
 func (m *Mesh) cellNormal(a, b, c int) math.Vector3 {
 	pa, pb, pc := m.Positions[a], m.Positions[b], m.Positions[c]
 	return pa.VectorTo(pb).Cross(pa.VectorTo(pc))
+}
+
+// periodicBandGrid handles a full-period curved band — a complete cylinder/cone side whose
+// loop runs up the seam, around a full circle, down the seam and back, so toUVLoops can't
+// unwrap it (the loop spans the whole 2π). Its trim is simply the entire period in the
+// periodic parameter and the boundary's own range in the other. The grid reuses the
+// boundary's parameter samples (the shared circle-edge discretization) so the band stays
+// watertight with its caps, and closes the period so the last cell wraps back to the seam.
+// ok=false when it isn't a single-periodic band or carries holes (those need a constrained
+// triangulation — still the full-domain fallback).
+func periodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) (us, vs []float64, ok bool) {
+	uPer, vPer := isPeriodic(s.UDomain()), isPeriodic(s.VDomain())
+	if uPer == vPer || len(holes3D) != 0 {
+		return nil, nil, false // need exactly one periodic direction and no holes
+	}
+	uu := make([]float64, len(outer3D))
+	vv := make([]float64, len(outer3D))
+	for i, p := range outer3D {
+		uu[i], vv[i] = s.ParamAt(p)
+	}
+	if uPer {
+		us, vs = closePeriod(sortUnique(uu)), sortUnique(vv)
+	} else {
+		us, vs = sortUnique(uu), closePeriod(sortUnique(vv))
+	}
+	if len(us) < 2 || len(vs) < 2 {
+		return nil, nil, false // degenerate (e.g. a cone closing to its apex — one rim circle)
+	}
+	return us, vs, true
+}
+
+// coneApexFan tessellates a cone face that closes to its apex (a drill point): its single rim
+// circle (outer3D) fans to the apex pole, which is not a topology vertex but the surface's
+// geometric tip. Each triangle is wound to agree with the cone normal (a reversed face then
+// flips it). ok=false unless the surface is a cone whose boundary is a SINGLE circle at one
+// axial level (a frustum, with two rim circles, spans v and is handled as a band instead).
+func coneApexFan(s geom.Surface, outer3D []math.Point3) (*Mesh, bool) {
+	cone, ok := s.(geom.Cone)
+	if !ok || len(outer3D) < 3 {
+		return nil, false
+	}
+	vMin, vMax := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, p := range outer3D {
+		_, v := cone.ParamAt(p)
+		vMin, vMax = stdmath.Min(vMin, v), stdmath.Max(vMax, v)
+	}
+	if vMax-vMin > trimBorderTol {
+		return nil, false // a frustum (two rim circles), not an apex cap
+	}
+	m := &Mesh{}
+	apex := m.addVertex(cone.Apex, cone.AxisDir.AsVector().Scale(-1)) // axial normal at the pole
+	rim := make([]int, len(outer3D))
+	for i, p := range outer3D {
+		u, v := cone.ParamAt(p)
+		rim[i] = m.addVertex(p, cone.NormalAt(u, v))
+	}
+	for i := range outer3D {
+		b, c := rim[i], rim[(i+1)%len(outer3D)]
+		if triangleFlipped(cone, cone.Apex, m.Positions[b], m.Positions[c]) {
+			b, c = c, b
+		}
+		m.addTriangle(apex, b, c)
+	}
+	return m, true
+}
+
+// closePeriod appends the 2π wrap line to a [0,2π) sample set so the band's final cell
+// closes back onto the seam (no-op if a 2π sample is already present).
+func closePeriod(g []float64) []float64 {
+	if len(g) == 0 || g[len(g)-1] < 2*stdmath.Pi-trimBorderTol {
+		return append(g, 2*stdmath.Pi)
+	}
+	return g
 }
 
 // toUVLoops maps the boundary loops to parameter space, unwrapping periodic parameters so

--- a/kernel/ops/tessellate_trim_test.go
+++ b/kernel/ops/tessellate_trim_test.go
@@ -64,6 +64,120 @@ func TestTrimmedCurvedFaceArea(t *testing.T) {
 	}
 }
 
+// fullCylinderFace builds the complete 2π periodic side of a cylinder (radius r, height h):
+// two closed-circle edges and a seam, with the classic periodic loop (up the seam, around
+// the top circle, down the seam, around the bottom). The shape produced by brep.SolidCylinder.
+func fullCylinderFace(t *testing.T, r, h float64) *topo.Face {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "fcyl", 0))
+	bld := topo.NewBuilder(false, lin)
+	cyl, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot, err := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	top := geom.Circle{Center: math.P3(0, 0, math.Scalar(h)), Normal: bot.Normal, RefDir: bot.RefDir, Radius: bot.Radius}
+	pb, pt := bot.PointAt(0), top.PointAt(0)
+	vb, vt := bld.AddVertex(pb, lin), bld.AddVertex(pt, lin)
+	eb := bld.AddEdge(bot, vb, vb, lin)
+	et := bld.AddEdge(top, vt, vt, lin)
+	es := bld.AddEdge(geom.NewLineSegment(pb, pt), vb, vt, lin)
+	bld.AddFace(cyl, lin, topo.OuterLoop(topo.Fwd(es), topo.Rev(et), topo.Rev(es), topo.Fwd(eb)))
+	return bld.Build().Faces()[0]
+}
+
+// TestFullPeriodicCylinderFaceArea tessellates the complete 2π cylinder side and checks the
+// mesh area equals the analytic lateral area 2π·r·h (a hair under, inscribed). Regression for
+// periodicBandGrid: before it, a full-seam-wrap loop fell back to the surface's whole UV
+// domain (unbounded height) and got the area/volume badly wrong.
+func TestFullPeriodicCylinderFaceArea(t *testing.T) {
+	const r, h = 2.0, 5.0
+	mesh := TessellateFace(fullCylinderFace(t, r, h), DefaultQuality())
+	want := 2 * stdmath.Pi * r * h // ≈ 62.83
+	if got := meshArea(mesh); got > want+1e-9 || (want-got)/want > 0.03 {
+		t.Errorf("full cylinder side area = %g, want a hair under %g (2π·r·h, inscribed)", got, want)
+	}
+}
+
+// fullConeFrustumFace builds the complete 2π band of a cone between v∈[v1,v2] (radii r=v·tan):
+// two closed-circle edges and a straight ruling seam, with the same periodic loop as a cylinder.
+func fullConeFrustumFace(t *testing.T, halfAngle, v1, v2 float64) *topo.Face {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "cone", 0))
+	bld := topo.NewBuilder(false, lin)
+	cone, err := geom.NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), halfAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	circle := func(v float64) geom.Circle {
+		c, err := geom.NewCircle(math.P3(0, 0, math.Scalar(v)), math.V3(0, 0, 1), v*stdmath.Tan(halfAngle))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	lo, hi := circle(v1), circle(v2)
+	hi = geom.Circle{Center: hi.Center, Normal: lo.Normal, RefDir: lo.RefDir, Radius: hi.Radius}
+	pLo, pHi := lo.PointAt(0), hi.PointAt(0)
+	vLo, vHi := bld.AddVertex(pLo, lin), bld.AddVertex(pHi, lin)
+	eLo := bld.AddEdge(lo, vLo, vLo, lin)
+	eHi := bld.AddEdge(hi, vHi, vHi, lin)
+	es := bld.AddEdge(geom.NewLineSegment(pLo, pHi), vLo, vHi, lin)
+	bld.AddFace(cone, lin, topo.OuterLoop(topo.Fwd(es), topo.Rev(eHi), topo.Rev(es), topo.Fwd(eLo)))
+	return bld.Build().Faces()[0]
+}
+
+// TestConeFrustumFaceArea tessellates a full cone frustum band and checks the mesh area equals
+// the analytic lateral area π(r1+r2)·slant (a hair under, inscribed). Proves the periodic-band
+// tessellator handles a cone (varying radius), the foundation countersink holes build on.
+func TestConeFrustumFaceArea(t *testing.T) {
+	const ha = stdmath.Pi / 4 // 45°, tan = 1
+	const v1, v2 = 2.0, 4.0   // r1=2, r2=4
+	mesh := TessellateFace(fullConeFrustumFace(t, ha, v1, v2), DefaultQuality())
+	r1, r2 := v1*stdmath.Tan(ha), v2*stdmath.Tan(ha)
+	slant := (v2 - v1) / stdmath.Cos(ha)
+	want := stdmath.Pi * (r1 + r2) * slant // ≈ 53.3
+	if got := meshArea(mesh); got > want+1e-9 || (want-got)/want > 0.03 {
+		t.Errorf("cone frustum area = %g, want a hair under %g (π(r1+r2)·slant, inscribed)", got, want)
+	}
+}
+
+// coneApexFace builds a full cone closing to its apex: a single rim-circle boundary (no seam),
+// the shape of a drill point. apex at origin, axis +Z, rim at v=vRim.
+func coneApexFace(t *testing.T, halfAngle, vRim float64) *topo.Face {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "tip", 0))
+	bld := topo.NewBuilder(false, lin)
+	cone, err := geom.NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), halfAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rim, err := geom.NewCircle(math.P3(0, 0, math.Scalar(vRim)), math.V3(0, 0, 1), vRim*stdmath.Tan(halfAngle))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := bld.AddVertex(rim.PointAt(0), lin)
+	e := bld.AddEdge(rim, v, v, lin)
+	bld.AddFace(cone, lin, topo.OuterLoop(topo.Fwd(e)))
+	return bld.Build().Faces()[0]
+}
+
+// TestConeApexFaceArea tessellates a cone closing to its apex and checks the mesh area equals
+// the analytic lateral area π·r²/sin(halfAngle) (a hair under, inscribed). Proves the apex-fan
+// path, the foundation a conical drill point builds on.
+func TestConeApexFaceArea(t *testing.T) {
+	const ha, vRim = stdmath.Pi / 4, 2.0 // 45°, rim radius 2
+	mesh := TessellateFace(coneApexFace(t, ha, vRim), DefaultQuality())
+	r := vRim * stdmath.Tan(ha)
+	want := stdmath.Pi * r * r / stdmath.Sin(ha) // π·r²/sin(halfAngle) ≈ 17.77
+	if got := meshArea(mesh); got > want+1e-9 || (want-got)/want > 0.03 {
+		t.Errorf("cone apex area = %g, want a hair under %g (π·r²/sin, inscribed)", got, want)
+	}
+}
+
 // TestTrimmedCurvedFaceOutwardWinding checks every emitted triangle winds outward (its
 // geometric normal agrees with the cylinder's outward radial), needed for correct
 // divergence-theorem volume of curved-faced solids.

--- a/kernel/topo/accessors_test.go
+++ b/kernel/topo/accessors_test.go
@@ -79,6 +79,29 @@ func TestInnerLoopFace(t *testing.T) {
 	}
 }
 
+// AddFace yields a face whose sense agrees with its surface; AddReversedFace flags the sense
+// as opposite (a Difference cut wall), keeping every other property identical.
+func TestReversedFaceSense(t *testing.T) {
+	bld := NewBuilder(false, NewLineage(Tok("f", "body", 0)))
+	lin := NewLineage(Tok("f", "x", 0))
+	a := bld.AddVertex(math.P3(0, 0, 0), lin)
+	b := bld.AddVertex(math.P3(1, 0, 0), lin)
+	c := bld.AddVertex(math.P3(0, 1, 0), lin)
+	tri := func() LoopSpec {
+		ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, lin)
+		bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, lin)
+		ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, lin)
+		return OuterLoop(Fwd(ab), Fwd(bc), Fwd(ca))
+	}
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if bld.AddFace(pl, lin, tri()).Reversed() {
+		t.Error("AddFace produced a reversed face")
+	}
+	if !bld.AddReversedFace(pl, lin, tri()).Reversed() {
+		t.Error("AddReversedFace did not set the reversed sense")
+	}
+}
+
 func TestFindEdgeByBogusKey(t *testing.T) {
 	body := buildTetra()
 	bogus := referenceKey(KindEdge, NewLineage(Tok("ghost", "edge", 42)))

--- a/kernel/topo/builder.go
+++ b/kernel/topo/builder.go
@@ -71,6 +71,14 @@ func (bld *Builder) AddFace(surface geom.Surface, lineage Lineage, loops ...Loop
 	return f
 }
 
+// AddReversedFace adds a face whose outward (material) side is opposite its surface normal —
+// the cut wall a Difference carves (see Face.Reversed). Identical to AddFace but for the sense.
+func (bld *Builder) AddReversedFace(surface geom.Surface, lineage Lineage, loops ...LoopSpec) *Face {
+	f := bld.AddFace(surface, lineage, loops...)
+	f.reversed = true
+	return f
+}
+
 // buildLoop creates a loop and its edge-uses, linking each use back onto its edge.
 func (bld *Builder) buildLoop(f *Face, spec LoopSpec) *Loop {
 	loop := &Loop{id: nextID(), face: f, outer: spec.Outer}

--- a/kernel/topo/topology.go
+++ b/kernel/topo/topology.go
@@ -113,11 +113,12 @@ func (l *Loop) Face() *Face { return l.face }
 
 // Face is a 2-dimensional entity: a bounded region of a surface, bounded by loops.
 type Face struct {
-	id      uint64
-	surface geom.Surface
-	loops   []*Loop
-	shell   *Shell
-	lineage Lineage
+	id       uint64
+	surface  geom.Surface
+	loops    []*Loop
+	shell    *Shell
+	lineage  Lineage
+	reversed bool
 }
 
 func (f *Face) ID() uint64           { return f.id }
@@ -127,6 +128,12 @@ func (f *Face) ReferenceKey() []byte { return referenceKey(KindFace, f.lineage) 
 
 // Geometry returns the face's underlying transient surface (a Plane/Cylinder…).
 func (f *Face) Geometry() geom.Surface { return f.surface }
+
+// Reversed reports whether the face's outward (material) side is OPPOSITE its surface
+// normal — true for the cut wall a Difference carves, where the surface (e.g. a cylinder's
+// outward-radial normal) points into the removed material. Tessellation and mass-properties
+// negate the surface normal for such faces. Most faces (sense agrees with surface) are false.
+func (f *Face) Reversed() bool { return f.reversed }
 
 // Loops returns the face's boundary loops (outer first by construction).
 func (f *Face) Loops() []*Loop { return append([]*Loop(nil), f.loops...) }

--- a/math/box.go
+++ b/math/box.go
@@ -94,6 +94,23 @@ func (b Box) Union(o Box) Box {
 	return b.ExtendPoint(o.Min).ExtendPoint(o.Max)
 }
 
+// FarthestPoint returns the box corner farthest along dir — the box's support point in
+// that direction (Inventor's TransientGeometry.GetFarmostPoint). On each axis it takes Max
+// when dir's component is non-negative and Min when it is negative; dir need not be unit.
+// On the empty box the result is degenerate (Min>Max), like the box itself.
+func (b Box) FarthestPoint(dir Vector3) Point3 {
+	return Point3{farAxis(b.Min.X, b.Max.X, dir.X), farAxis(b.Min.Y, b.Max.Y, dir.Y), farAxis(b.Min.Z, b.Max.Z, dir.Z)}
+}
+
+// farAxis picks the box extent (lo or hi) farther along a single axis: hi when the
+// direction component points that way (>= 0), lo otherwise.
+func farAxis(lo, hi, d Scalar) Scalar {
+	if d < 0 {
+		return lo
+	}
+	return hi
+}
+
 // Corners returns the eight corner points, ordered by the bits of the index:
 // bit0=X, bit1=Y, bit2=Z choosing Min(0)/Max(1) on that axis.
 func (b Box) Corners() [8]Point3 {

--- a/math/box_test.go
+++ b/math/box_test.go
@@ -69,6 +69,23 @@ func TestBoxUnionAndCorners(t *testing.T) {
 	}
 }
 
+func TestBoxFarthestPoint(t *testing.T) {
+	b := NewBox(P3(-1, -2, -3), P3(4, 5, 6))
+	cases := []struct {
+		dir  Vector3
+		want Point3
+	}{
+		{V3(1, 1, 1), P3(4, 5, 6)},       // toward Max on every axis
+		{V3(-1, -1, -1), P3(-1, -2, -3)}, // toward Min on every axis
+		{V3(1, -1, 0), P3(4, -2, 6)},     // mixed; the zero component picks Max
+	}
+	for _, c := range cases {
+		if got := b.FarthestPoint(c.dir); got != c.want {
+			t.Errorf("FarthestPoint(%v) = %v, want %v", c.dir, got, c.want)
+		}
+	}
+}
+
 func TestBox2d(t *testing.T) {
 	b := Box2dFromPoints(P2(0, 0), P2(4, 2))
 	if got := b.Area(); got != 8 {

--- a/model/feature/blade_twist_min_test.go
+++ b/model/feature/blade_twist_min_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// A twisted loft has warped (non-planar) ruled side faces. sweptSolid triangulates those so the
+// body stays planar-faceted; without it the planar boolean's imprint segments land offset from
+// the true edges and a partial-penetration union goes non-manifold (the deformed fan blade).
+// This pins the fix: a box hub UNION a twisted-loft blade (which pokes part-way into the hub)
+// must be a valid manifold solid at every twist — even a 0.001 rad twist used to break it.
+func TestTwistedLoftUnionStaysManifold(t *testing.T) {
+	xy := sketch.XYPlane()
+	square := []math.Point2{{X: -0.675, Y: -0.675}, {X: 0.675, Y: -0.675}, {X: 0.675, Y: 0.675}, {X: -0.675, Y: 0.675}}
+	root := []math.Point3{{X: 0.6, Y: -0.08, Z: 0}, {X: 2.35, Y: -0.08, Z: 0}, {X: 2.35, Y: 0.08, Z: 0}, {X: 0.6, Y: 0.08, Z: 0}}
+
+	for _, twist := range []float64{0, 0.001, 0.05, 0.3} {
+		cx, cy := 1.475, 0.0
+		c, s := stdmath.Cos(twist), stdmath.Sin(twist)
+		tip := make([]math.Point3, 4)
+		for i, p := range root {
+			dx, dy := p.X-cx, p.Y-cy
+			tip[i] = math.Point3{X: cx + dx*c - dy*s, Y: cy + dx*s + dy*c, Z: 1.4}
+		}
+		blade, err := sweptSolid([][]math.Point3{root, tip}, false, "blade")
+		if err != nil {
+			t.Fatalf("twist=%.3f sweptSolid: %v", twist, err)
+		}
+		hub := buildPrism(square, xy, span{near: 0, far: 1.5}, 0, "hub")
+		res, err := ops.Boolean(ops.Join, hub, blade)
+		if err != nil {
+			t.Fatalf("twist=%.3f join: %v", twist, err)
+		}
+		if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+			t.Errorf("twist=%.3f union not a valid solid: manifold=%v closed=%v orient=%v issues=%v",
+				twist, r.Manifold, r.Closed, r.OrientationOK, r.Issues[:min(4, len(r.Issues))])
+		}
+	}
+}

--- a/model/feature/combine_refkey_test.go
+++ b/model/feature/combine_refkey_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// negXFaceKey returns the reference key of the body's first face whose outward normal is −X.
+func negXFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if f.Geometry().NormalAt(0, 0).Dot(math.V3(-1, 0, 0)) > 0.9 {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatal("no −X face")
+	return nil
+}
+
+// TestCombineFaceKeySurvivesIntoResultAndRecompute is the feature-level proof of K1a: a
+// face picked on box A keeps its reference key after A is Combined with an overlapping box
+// B (the planar boolean carries the lineage), and still resolves after a parameter-driven
+// recompute — so a downstream reference (fillet/dimension/sketch) on the combined solid
+// stays bound across edits.
+func TestCombineFaceKeySurvivesIntoResultAndRecompute(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	exA := NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketch(4), 0, ops.NewBody, func() float64 { return 5 })
+	fs.Recompute()
+
+	// A's −X face (at x=0) is far from where B will overlap, so it survives the boolean whole.
+	aKey := negXFaceKey(t, fs.Result()[0])
+
+	// Add an overlapping box B and Join them (intersecting → the planar B-rep boolean).
+	NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketchAt(4, 2), 0, ops.NewBody, func() float64 { return 5 })
+	NewModifyFeatures(fs).AddCombine(0, 1, ops.Join)
+	fs.Recompute()
+
+	combined := fs.Result()
+	if len(combined) != 1 {
+		t.Fatalf("after join = %d bodies, want 1", len(combined))
+	}
+	if _, ok := combined[0].FindFaceByKey(aKey); !ok {
+		t.Fatal("A's face key did not survive INTO the combine result (K1a)")
+	}
+
+	// Edit: grow A's height and recompute; the same key still binds.
+	exA.Definition().(*ExtrudeFeature).SetDistance(8)
+	fs.MarkDirty(exA)
+	fs.Recompute()
+	if _, ok := fs.Result()[0].FindFaceByKey(aKey); !ok {
+		t.Fatal("A's face key did not survive the recompute after the combine (K1a)")
+	}
+}

--- a/model/feature/cylinder_tool.go
+++ b/model/feature/cylinder_tool.go
@@ -65,6 +65,33 @@ func perpAxis(n math.UnitVector3) math.UnitVector3 {
 	return u
 }
 
+// throughDepth returns a drill depth that fully exits the body along the inward axis: the
+// farthest extent of the body's range box from center, plus an overhang for a clean exit face.
+// Used as the faceted fallback when an exact through-hole isn't possible (see HoleFeature.drill).
+func throughDepth(body *topo.Body, center math.Point3, into math.UnitVector3) float64 {
+	axis := into.AsVector()
+	far := 0.0
+	for _, c := range boxCorners(body.RangeBox()) {
+		if d := float64(center.VectorTo(c).Dot(axis)); d > far {
+			far = d
+		}
+	}
+	return far + cutterOverhang
+}
+
+// boxCorners returns the eight corners of an axis-aligned box.
+func boxCorners(b math.Box) []math.Point3 {
+	out := make([]math.Point3, 0, 8)
+	for _, x := range [2]math.Scalar{b.Min.X, b.Max.X} {
+		for _, y := range [2]math.Scalar{b.Min.Y, b.Max.Y} {
+			for _, z := range [2]math.Scalar{b.Min.Z, b.Max.Z} {
+				out = append(out, math.Point3{X: x, Y: y, Z: z})
+			}
+		}
+	}
+	return out
+}
+
 // faceVertexPoints returns the positions of a face's bounding vertices.
 func faceVertexPoints(f *topo.Face) []math.Point3 {
 	vs := f.Vertices()

--- a/model/feature/emboss.go
+++ b/model/feature/emboss.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// EmbossDefinition is the recipe for an emboss: a closed sketch profile raised from (or engraved
+// into) the part by a depth along the sketch-plane normal. Engrave cuts; raise joins.
+type EmbossDefinition struct {
+	Sketch         *sketch.Sketch
+	ProfileIndices []int
+	Depth          func() float64
+	Engrave        bool    // cut into the face instead of raising from it
+	Taper          float64 // draft angle (radians)
+}
+
+// EmbossFeature raises or engraves a closed profile on the part (Inventor's Emboss): the profile
+// is extruded a shallow depth along the sketch-plane normal and joined (raise) or cut (engrave).
+// (Wrapping the emboss onto a curved face is a refinement; the planar emboss works today.)
+type EmbossFeature struct {
+	def      *EmbossDefinition
+	featName string
+	tool     *topo.Body // last raised/engraved prism, exposed so a pattern can replicate it
+}
+
+// Definition returns the emboss recipe.
+func (f *EmbossFeature) Definition() *EmbossDefinition { return f.def }
+
+// Kind implements [Feature].
+func (f *EmbossFeature) Kind() string { return "emboss" }
+
+// Operation and ToolBody let a pattern/mirror replicate this feature with the right boolean —
+// an engrave cuts, a raise joins (see [ToolFeature]).
+func (f *EmbossFeature) Operation() ops.PartFeatureOperation {
+	if f.def.Engrave {
+		return ops.Cut
+	}
+	return ops.Join
+}
+func (f *EmbossFeature) ToolBody() *topo.Body { return f.tool }
+
+// Recompute extrudes the profile(s) by the depth and joins (raise) or cuts (engrave) the part.
+func (f *EmbossFeature) Recompute(in Input) (Output, error) {
+	profiles, err := resolveClosedProfiles(f.def.Sketch, f.def.ProfileIndices, "emboss")
+	if err != nil {
+		return Output{}, err
+	}
+	d := callOrZero(f.def.Depth)
+	if d <= 0 {
+		return Output{}, fmt.Errorf("emboss: depth %g must be > 0", d)
+	}
+	sp, op := orderedSpan(0, d), ops.Join
+	if f.def.Engrave {
+		sp, op = orderedSpan(0, -d), ops.Cut // cut into the part, below the sketch plane
+	}
+	f.tool = buildProfilePrisms(profiles, f.def.Sketch.Plane(), sp, f.def.Taper, featOr(f.featName, "emboss"))
+	bodies, err := combine(in.Bodies, f.tool, op)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// EmbossFeatures adds emboss features into the engine.
+type EmbossFeatures struct{ engine *PartFeatures }
+
+// NewEmbossFeatures binds the collection to an engine.
+func NewEmbossFeatures(engine *PartFeatures) *EmbossFeatures { return &EmbossFeatures{engine} }
+
+// Add adds an emboss of the sketch's closed profile(s); engrave cuts instead of raising.
+func (c *EmbossFeatures) Add(skt *sketch.Sketch, profileIndices []int, depth func() float64, engrave bool, taper float64) *PartFeature {
+	def := &EmbossDefinition{Sketch: skt, ProfileIndices: profileIndices, Depth: depth, Engrave: engrave, Taper: taper}
+	ef := &EmbossFeature{def: def}
+	pf := c.engine.Add(ef)
+	pf.SetName(c.engine.UniqueName("Emboss"))
+	ef.featName = pf.name
+	return pf
+}
+
+// resolveClosedProfiles returns the closed sketch profiles at the given indices — the shared
+// profile resolution for solid-from-region features (extrude, emboss). `what` names the caller
+// in errors.
+func resolveClosedProfiles(sk *sketch.Sketch, indices []int, what string) ([]*sketch.Profile, error) {
+	all := sk.Profiles()
+	if len(indices) == 0 {
+		return nil, fmt.Errorf("%s: no profile selected", what)
+	}
+	out := make([]*sketch.Profile, 0, len(indices))
+	for _, idx := range indices {
+		if idx < 0 || idx >= all.Count() {
+			return nil, fmt.Errorf("%s: profile %d not found (sketch has %d)", what, idx, all.Count())
+		}
+		p := all.Item(idx)
+		if !p.IsClosed() {
+			return nil, fmt.Errorf("%s: profile is open (cannot form a solid)", what)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// buildProfilePrisms extrudes each closed profile to a prism over span sp (with taper), merging
+// several into one tool body — the shared prism builder for extrude/emboss.
+func buildProfilePrisms(profiles []*sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+	prisms := make([]*topo.Body, len(profiles))
+	for i, p := range profiles {
+		name := feat
+		if len(profiles) > 1 {
+			name = fmt.Sprintf("%s/p%d", feat, i)
+		}
+		prisms[i] = buildPrism(p.OuterLoop().Polygon(), plane, sp, taper, name)
+	}
+	if len(prisms) == 1 {
+		return prisms[0]
+	}
+	return topo.MergeBodies(topo.NewLineage(topo.Tok(feat, "merged", 0)), true, prisms...)
+}

--- a/model/feature/emboss_test.go
+++ b/model/feature/emboss_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// squareOn builds a sketch on the given plane with a side×side square at offset (dx,dx).
+func squareOn(plane sketch.Plane, side, dx float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(plane)
+	c0 := s.Points().Add(math.P2(math.Scalar(dx), math.Scalar(dx)))
+	c1 := s.Points().Add(math.P2(math.Scalar(dx+side), math.Scalar(dx)))
+	c2 := s.Points().Add(math.P2(math.Scalar(dx+side), math.Scalar(dx+side)))
+	c3 := s.Points().Add(math.P2(math.Scalar(dx), math.Scalar(dx+side)))
+	s.Lines().Add(c0, c1)
+	s.Lines().Add(c1, c2)
+	s.Lines().Add(c2, c3)
+	s.Lines().Add(c3, c0)
+	return s
+}
+
+// embossedBlock builds a 10×10×2 block (vol 200) and returns the engine for an emboss test.
+func embossedBlock(t *testing.T) *PartFeatures {
+	t.Helper()
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketch(10), 0, ops.NewBody, func() float64 { return 2 })
+	return fs
+}
+
+// A raised emboss adds a 4×4×1 boss on the top face → block volume + 16.
+func TestEmbossRaisesMaterial(t *testing.T) {
+	fs := embossedBlock(t)
+	es := squareOn(planeAtZ(2), 4, 3) // 4×4 square centred-ish on the z=2 top
+	emb := NewEmbossFeatures(fs).Add(es, []int{0}, func() float64 { return 1 }, false, 0)
+	fs.Recompute()
+	if !emb.Health().OK() {
+		t.Fatalf("emboss went sick: %+v", emb.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("embossed body not valid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-216) > 1e-6 {
+		t.Errorf("raised emboss volume = %g, want 216 (200 + 4×4×1)", v)
+	}
+}
+
+// An engraved emboss cuts a 4×4×1 pocket into the top face → block volume − 16.
+func TestEmbossEngravesMaterial(t *testing.T) {
+	fs := embossedBlock(t)
+	es := squareOn(planeAtZ(2), 4, 3)
+	emb := NewEmbossFeatures(fs).Add(es, []int{0}, func() float64 { return 1 }, true, 0) // engrave
+	fs.Recompute()
+	if !emb.Health().OK() {
+		t.Fatalf("engrave went sick: %+v", emb.Health())
+	}
+	if v := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; stdmath.Abs(v-184) > 1e-6 {
+		t.Errorf("engraved volume = %g, want 184 (200 − 4×4×1)", v)
+	}
+}
+
+func TestEmbossNeedsDepthAndProfile(t *testing.T) {
+	fs := embossedBlock(t)
+	es := squareOn(planeAtZ(2), 4, 3)
+	emb := NewEmbossFeatures(fs).Add(es, nil, func() float64 { return 1 }, false, 0) // no profile
+	fs.Recompute()
+	if emb.Health().OK() {
+		t.Error("emboss with no profile should be sick")
+	}
+}

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/model/health"
 	"github.com/Oblikovati/oblikovati/model/identity"
@@ -140,8 +141,93 @@ func (fs *PartFeatures) evaluate(pf *PartFeature, bodies []*topo.Body, sick map[
 		return bodies
 	}
 	pf.recomputes++
-	out, err := pf.feature.Recompute(Input{Bodies: bodies, Params: fs.params, Keys: fs.keys})
+	out, err := pf.feature.Recompute(Input{Bodies: bodies, Params: fs.params, Keys: fs.keys, SourceTool: fs.sourceTool})
 	return fs.classify(pf, bodies, out, err, sick)
+}
+
+// sourceTool resolves a source feature's geometric contribution for a pattern/mirror: the
+// tool body it added or removed (the before/after delta) and the operation it applied. A
+// new-body or undeterminable source returns ok=false, so the replicator copies the whole
+// body instead (the right behavior for placing independent solids).
+func (fs *PartFeatures) sourceTool(id ID) (*topo.Body, ops.PartFeatureOperation, bool) {
+	idx := -1
+	for i, it := range fs.items {
+		if it.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, ops.NewBody, false
+	}
+	f := fs.items[idx].feature
+	op := operationOf(f)
+	// Prefer the source feature's own tool (a clean prism) over a before/after difference,
+	// which can degenerate on curved geometry.
+	if tf, ok := f.(ToolFeature); ok {
+		if tool := tf.ToolBody(); tool != nil {
+			return tool, op, true
+		}
+	}
+	tool, derr := sourceDelta(lastSolid(fs.prefixBodies(idx)), lastSolid(fs.items[idx].cached), op)
+	if derr != nil || tool == nil {
+		return nil, op, false
+	}
+	return tool, op, true
+}
+
+// operationOf returns a feature's boolean operation, or NewBody when it does not apply one
+// (so its replication falls back to copying whole bodies).
+func operationOf(f Feature) ops.PartFeatureOperation {
+	if of, ok := f.(OperationalFeature); ok {
+		return of.Operation()
+	}
+	return ops.NewBody
+}
+
+// sourceDelta returns the material a feature contributed: for a cut, before−after (the
+// removed chunk, the tool clipped to the body); for join/intersect, after−before (the added
+// chunk). NewBody, an absent state, or a feature that contributed nothing (a deferred feature,
+// before == after → an empty difference) yields no delta, so the caller adds nothing for that
+// source rather than copying the whole body.
+func sourceDelta(before, after *topo.Body, op ops.PartFeatureOperation) (*topo.Body, error) {
+	switch op {
+	case ops.Cut:
+		if before == nil || after == nil {
+			return nil, nil
+		}
+		d, err := ops.Boolean(ops.Cut, before, after)
+		return nonEmpty(d), err
+	case ops.Join, ops.Intersect:
+		if after == nil {
+			return nil, nil
+		}
+		if before == nil {
+			return after, nil
+		}
+		d, err := ops.Boolean(ops.Cut, after, before)
+		return nonEmpty(d), err
+	default:
+		return nil, nil
+	}
+}
+
+// nonEmpty returns b unless it is an empty body (no faces) — an empty difference means the
+// source contributed nothing to replicate, so the pattern adds nothing rather than copying.
+func nonEmpty(b *topo.Body) *topo.Body {
+	if b == nil || len(b.Faces()) == 0 {
+		return nil
+	}
+	return b
+}
+
+// lastBody returns the last body of a running state (the one a feature's boolean acts on),
+// or nil when empty.
+func lastSolid(bodies []*topo.Body) *topo.Body {
+	if len(bodies) == 0 {
+		return nil
+	}
+	return bodies[len(bodies)-1]
 }
 
 // classify turns a feature's recompute result into health + the running body state:

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -4,7 +4,6 @@ package feature
 
 import (
 	"errors"
-	"fmt"
 	stdmath "math"
 
 	"github.com/Oblikovati/oblikovati/kernel/geom"
@@ -31,7 +30,13 @@ type ExtrudeDefinition struct {
 type ExtrudeFeature struct {
 	def      *ExtrudeDefinition
 	featName string
+	tool     *topo.Body // last prism built, exposed so a pattern can replicate this feature
 }
+
+// ToolBody returns the prism this feature last combined into the model — the clean tool a
+// pattern replicates at each occurrence (more robust than diffing before/after bodies,
+// especially for curved geometry). It is nil before the first recompute.
+func (e *ExtrudeFeature) ToolBody() *topo.Body { return e.tool }
 
 // Definition returns the extrude recipe (round-trippable, serializable).
 func (e *ExtrudeFeature) Definition() *ExtrudeDefinition { return e.def }
@@ -79,7 +84,8 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 	if sp.depth() == 0 {
 		return Output{}, errors.New("extrude: the extent has zero depth")
 	}
-	bodies, err := combine(in.Bodies, e.buildTool(profiles, plane, sp), e.def.Operation)
+	e.tool = e.buildTool(profiles, plane, sp)
+	bodies, err := combine(in.Bodies, e.tool, e.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -90,14 +96,7 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 // prisms into one body. The regions are distinct cells of the same sketch, so they never
 // overlap — a shell merge is exactly their union and avoids the intersecting Join.
 func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, plane sketch.Plane, sp span) *topo.Body {
-	prisms := make([]*topo.Body, len(profiles))
-	for i, p := range profiles {
-		prisms[i] = buildPrism(p.OuterLoop().Polygon(), plane, sp, e.def.Taper, e.prismFeat(i, len(profiles)))
-	}
-	if len(prisms) == 1 {
-		return prisms[0]
-	}
-	return topo.MergeBodies(topo.NewLineage(topo.Tok(e.featName, "merged", 0)), true, prisms...)
+	return buildProfilePrisms(profiles, plane, sp, e.def.Taper, e.featName)
 }
 
 // outerPolygons returns each profile's outer-loop polygon, the input the span resolver
@@ -110,34 +109,10 @@ func outerPolygons(profiles []*sketch.Profile) [][]math.Point2 {
 	return out
 }
 
-// prismFeat namespaces each region's prism lineage; a single-profile extrude keeps the
-// bare feature name so its persistent face IDs are unchanged.
-func (e *ExtrudeFeature) prismFeat(i, n int) string {
-	if n == 1 {
-		return e.featName
-	}
-	return fmt.Sprintf("%s/p%d", e.featName, i)
-}
-
-// resolveProfiles re-derives the selected closed regions from the sketch, erroring
-// (→ sick) when one is missing or open, or when none is selected.
+// resolveProfiles re-derives the selected closed regions from the sketch (the shared
+// resolver), erroring (→ sick) when one is missing or open, or when none is selected.
 func (e *ExtrudeFeature) resolveProfiles() ([]*sketch.Profile, error) {
-	all := e.def.Sketch.Profiles()
-	if len(e.def.ProfileIndices) == 0 {
-		return nil, errors.New("extrude: no profile selected")
-	}
-	out := make([]*sketch.Profile, 0, len(e.def.ProfileIndices))
-	for _, idx := range e.def.ProfileIndices {
-		if idx < 0 || idx >= all.Count() {
-			return nil, fmt.Errorf("extrude: profile %d not found (sketch has %d)", idx, all.Count())
-		}
-		p := all.Item(idx)
-		if !p.IsClosed() {
-			return nil, errors.New("extrude: profile is open (cannot form a solid)")
-		}
-		out = append(out, p)
-	}
-	return out, nil
+	return resolveClosedProfiles(e.def.Sketch, e.def.ProfileIndices, "extrude")
 }
 
 // ExtrudeFeatures is the collection of extrude features, adding into the engine.

--- a/model/feature/feature.go
+++ b/model/feature/feature.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync/atomic"
 
+	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/model/identity"
 	"github.com/Oblikovati/oblikovati/model/param"
@@ -36,10 +37,33 @@ type Ref struct {
 // Input is what the engine hands a feature on recompute: the running body state
 // (the result of the clean prefix), the parameter set, and the key manager for
 // resolving [Ref] inputs.
+//
+// SourceTool lets a feature that replicates another (a pattern/mirror) recover the
+// geometric contribution of a source feature: the tool body it added or removed and the
+// boolean operation it used, computed from the source's cached before/after body state. A
+// pattern uses it to re-apply a cut/join at each occurrence (so patterning a hole cuts N
+// holes in one body) instead of duplicating the whole body. It is nil for features the
+// engine does not resolve sources for; ok is false when the id is unknown or has no delta.
 type Input struct {
-	Bodies []*topo.Body
-	Params *param.Parameters
-	Keys   *identity.KeyManager
+	Bodies     []*topo.Body
+	Params     *param.Parameters
+	Keys       *identity.KeyManager
+	SourceTool func(id ID) (tool *topo.Body, op ops.PartFeatureOperation, ok bool)
+}
+
+// OperationalFeature is a feature that applies a boolean operation against the running
+// bodies (extrude, the modify booleans, …). A pattern reads the source's operation through
+// it to decide how to replicate the source (cut/join/intersect vs a new-body copy).
+type OperationalFeature interface {
+	Operation() ops.PartFeatureOperation
+}
+
+// ToolFeature is an [OperationalFeature] that can hand a pattern the exact tool body it
+// combined (its prism/sweep solid). Replicating that clean tool is more robust than diffing
+// the running bodies — the difference can degenerate on curved geometry.
+type ToolFeature interface {
+	OperationalFeature
+	ToolBody() *topo.Body
 }
 
 // Output is what a feature produces: the new running body state.

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -4,17 +4,22 @@ package feature
 
 import (
 	"fmt"
+	stdmath "math"
 
+	"github.com/Oblikovati/oblikovati/kernel/brep"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 )
 
 // Hole and boss features place parametric cylindrical cuts/bosses on a picked placement
-// face (held by reference key, re-resolved each recompute). A hole drills a faceted
-// cylinder at the face centroid along the inward normal and subtracts it via the general
-// boolean. Boss geometry still defers (ErrDeferred → Warning). A lost placement face →
-// Sick. Point placement (vs. the face centroid) and counterbore/countersink profiles are
-// follow-ups.
+// face (held by reference key, re-resolved each recompute). A hole drills at the face
+// centroid along the inward normal with an EXACT cylinder wall (K1b): a Through All hole on a
+// planar slab via brep.CutCylindricalHole, a blind hole via brep.CutBlindCylindricalHole
+// (flat bottom, or a conical drill point when PointAngle is set). A counterbore adds a flat
+// recess + shoulder; a countersink a true cone recess (exact-only). Unsupported drilled/
+// counterbore shapes fall back to the faceted boolean. Boss geometry still defers (ErrDeferred →
+// Warning). A lost placement face → Sick. Point placement (vs. the face centroid) is a follow-up.
 
 // HoleTapInfo carries thread data for a tapped hole, consumed by hole tables (M14).
 type HoleTapInfo struct {
@@ -37,6 +42,11 @@ type HoleDefinition struct {
 	PlacementFaceKey []byte
 	Diameter         func() float64
 	Depth            func() float64
+	ThroughAll       bool           // drill all the way through (depth ignored)
+	CounterDiameter  func() float64 // recess/sink diameter (Counterbore + Countersink)
+	CounterDepth     func() float64 // counterbore recess depth (CounterboreHole)
+	CounterAngle     func() float64 // countersink included angle, radians (CountersinkHole)
+	PointAngle       func() float64 // drilled blind-hole point: included angle, radians (0 = flat)
 	Type             HoleType
 	Tap              HoleTapInfo
 }
@@ -45,6 +55,7 @@ type HoleDefinition struct {
 type HoleFeature struct {
 	def      *HoleDefinition
 	featName string
+	tool     *topo.Body // the drill cylinder of the last recompute, for pattern replication
 }
 
 // Definition returns the hole recipe.
@@ -53,8 +64,19 @@ func (h *HoleFeature) Definition() *HoleDefinition { return h.def }
 // Kind implements [Feature].
 func (h *HoleFeature) Kind() string { return "hole" }
 
-// Recompute resolves the placement face, drills a faceted cylinder at its centroid along
-// the inward normal, and subtracts it from the running body via the boolean.
+// Operation reports that a hole removes material, so a pattern of a hole re-cuts the bore at
+// each occurrence (one body with N holes) instead of copying the whole solid. Implements
+// [OperationalFeature].
+func (h *HoleFeature) Operation() ops.PartFeatureOperation { return ops.Cut }
+
+// ToolBody returns the drill cylinder the last recompute cut, so a pattern replicates a clean
+// bore at each occurrence rather than diffing the running solid (which degenerates once the
+// bore makes a face curved). For a counterbore/countersink the tool is the main bore cylinder —
+// the dominant cut — so a pattern of one reproduces its bores. Implements [ToolFeature].
+func (h *HoleFeature) ToolBody() *topo.Body { return h.tool }
+
+// Recompute resolves the placement face, then drills at its centroid along the inward normal
+// (see drill), subtracting the hole from the running body.
 func (h *HoleFeature) Recompute(in Input) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
@@ -65,19 +87,133 @@ func (h *HoleFeature) Recompute(in Input) (Output, error) {
 		return Output{}, fmt.Errorf("hole: placement face reference lost")
 	}
 	r, depth := callOrZero(h.def.Diameter)/2, callOrZero(h.def.Depth)
-	if r <= 0 || depth <= 0 {
-		return Output{}, fmt.Errorf("hole: diameter %g and depth %g must both be > 0", 2*r, depth)
+	if r <= 0 {
+		return Output{}, fmt.Errorf("hole: diameter %g must be > 0", 2*r)
+	}
+	if !h.def.ThroughAll && depth <= 0 {
+		return Output{}, fmt.Errorf("hole: depth %g must be > 0 (or set ThroughAll)", depth)
 	}
 	into, err := math.UnitVector3FromVector(face.Geometry().NormalAt(0, 0).Scale(-1))
 	if err != nil {
 		return Output{}, fmt.Errorf("hole: placement face has no normal")
 	}
-	tool := drillTool(centroidOf(faceVertexPoints(face)), into, r, depth, featOr(h.featName, "hole"))
-	res, err := ops.Boolean(ops.Cut, body, tool)
+	center := centroidOf(faceVertexPoints(face))
+	h.tool = h.buildTool(body, center, into, r, depth)
+	res, err := h.drill(body, center, into, r, depth)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+}
+
+// buildTool returns the clean drill cylinder a pattern replicates: the bore radius along the
+// inward normal, spanning the body for a through hole or the requested depth for a blind one.
+// It mirrors the cut the brep cutters apply (a counterbore's recess is omitted — the bore is
+// the dominant geometry), so a pattern of the hole reproduces a sensible bore at each spot.
+func (h *HoleFeature) buildTool(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) *topo.Body {
+	if h.def.ThroughAll {
+		depth = throughDepth(body, center, into)
+	}
+	return drillTool(center, into, r, depth, featOr(h.featName, "hole"))
+}
+
+// drill cuts the hole by its type: a counterbore is a shallow recess plus the bore, anything
+// else a single cylinder.
+func (h *HoleFeature) drill(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+	switch h.def.Type {
+	case CounterboreHole:
+		return h.cutCounterbore(body, center, into, r, depth)
+	case CountersinkHole:
+		return h.cutCountersink(body, center, into, r, depth)
+	default:
+		return h.cutDrilled(body, center, into, r, depth)
+	}
+}
+
+// cutDrilled cuts a plain drilled hole: through, or blind with either a conical drill point
+// (PointAngle > 0) or a flat bottom. A conical point that the part can't fit falls back to the
+// flat/faceted blind cut.
+func (h *HoleFeature) cutDrilled(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+	if h.def.ThroughAll {
+		return h.cutCylinder(body, center, into, r, depth, true)
+	}
+	if angle := callOrZero(h.def.PointAngle); angle > 0 {
+		if res, err := brep.CutBlindConicalHole(body, center, into.AsVector(), r, depth, angle/2); err == nil {
+			return res, nil
+		}
+	}
+	return h.cutCylinder(body, center, into, r, depth, false)
+}
+
+// cutCountersink drills a conical countersink (recess widening to the sink diameter at the
+// surface) above the bore. The exact builder produces a true cone wall; an unsupported part
+// shape returns the error (a faceted cone approximation would be worse than a clear failure).
+func (h *HoleFeature) cutCountersink(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+	cr, angle := callOrZero(h.def.CounterDiameter)/2, callOrZero(h.def.CounterAngle)
+	if cr <= r {
+		return nil, fmt.Errorf("countersink: sink Ø %g must exceed bore Ø %g", 2*cr, 2*r)
+	}
+	if angle <= 0 || angle >= stdmath.Pi {
+		return nil, fmt.Errorf("countersink: included angle %g must be in (0, π)", angle)
+	}
+	half := angle / 2
+	depthCS := (cr - r) / stdmath.Tan(half)
+	if !h.def.ThroughAll && depth <= depthCS {
+		return nil, fmt.Errorf("countersink: total depth %g must exceed the sink depth %g", depth, depthCS)
+	}
+	return brep.CutCountersinkHole(body, center, into.AsVector(), r, depth-depthCS, cr, half, h.def.ThroughAll)
+}
+
+// cutCounterbore drills a counterbore: a shallow recess stepping down to the bore. The exact
+// path (brep.CutCounterboreHole) builds the stepped result in one shot — two cylinder walls and
+// an annular shoulder — from the planar slab; it does NOT chain two curved cuts (the second
+// would feed a curved body to the planar-only boolean). The faceted fallback cuts the recess
+// then the bore as sequential planar prisms (each stays planar, so it chains fine).
+func (h *HoleFeature) cutCounterbore(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+	cr, cd := callOrZero(h.def.CounterDiameter)/2, callOrZero(h.def.CounterDepth)
+	if cr <= r {
+		return nil, fmt.Errorf("counterbore: recess Ø %g must exceed bore Ø %g", 2*cr, 2*r)
+	}
+	if cd <= 0 || (!h.def.ThroughAll && depth <= cd) {
+		return nil, fmt.Errorf("counterbore: recess depth %g must be > 0 and less than total depth %g", cd, depth)
+	}
+	if res, err := brep.CutCounterboreHole(body, center, into.AsVector(), r, depth-cd, cr, cd, h.def.ThroughAll); err == nil {
+		return res, nil
+	}
+	return h.facetedCounterbore(body, center, into, r, depth, cr, cd)
+}
+
+// facetedCounterbore is the fallback for shapes the exact builder rejects: cut the recess prism,
+// then the bore prism from the shoulder (both planar cuts, so they chain through the boolean).
+func (h *HoleFeature) facetedCounterbore(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth, cr, cd float64) (*topo.Body, error) {
+	stepped, err := ops.Boolean(ops.Cut, body, drillTool(center, into, cr, cd, featOr(h.featName, "hole")))
+	if err != nil {
+		return nil, err
+	}
+	shoulder := center.TranslateBy(into.AsVector().Scale(math.Scalar(cd)))
+	boreLen := depth - cd
+	if h.def.ThroughAll {
+		boreLen = throughDepth(stepped, shoulder, into)
+	}
+	return ops.Boolean(ops.Cut, stepped, drillTool(shoulder, into, r, boreLen, featOr(h.featName, "hole")))
+}
+
+// cutCylinder cuts a single cylindrical hole, preferring an EXACT cylinder wall (K1b): a
+// through hole via brep.CutCylindricalHole, a blind hole via brep.CutBlindCylindricalHole
+// (wall + flat bottom). When the part shape isn't supported (the bore clips a face, or a blind
+// depth would exit), it falls back to the faceted boolean — a through-cut when `through`, the
+// requested depth otherwise.
+func (h *HoleFeature) cutCylinder(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, through bool) (*topo.Body, error) {
+	if through {
+		if res, err := brep.CutCylindricalHole(body, center, into.AsVector(), r); err == nil {
+			return res, nil
+		}
+		depth = throughDepth(body, center, into) // unsupported shape → faceted through-cut
+	} else if res, err := brep.CutBlindCylindricalHole(body, center, into.AsVector(), r, depth); err == nil {
+		return res, nil
+	}
+	tool := drillTool(center, into, r, depth, featOr(h.featName, "hole"))
+	return ops.Boolean(ops.Cut, body, tool)
 }
 
 // BossDefinition is the recipe for a boss: a raised cylinder on a placement face.
@@ -96,6 +232,12 @@ func (b *BossFeature) Recompute(in Input) (Output, error) {
 	return resolveFacesThenDefer(in, [][]byte{b.def.PlacementFaceKey}, "boss")
 }
 
+// Operation reports that a boss adds material, so once boss geometry lands a pattern of a boss
+// unions its raised cylinder at each occurrence. Until then its geometry defers (it builds no
+// body), so a pattern of a boss replicates nothing rather than copying the whole solid — the
+// empty-delta path in [sourceDelta]/[patternBase.replicate]. Implements [OperationalFeature].
+func (b *BossFeature) Operation() ops.PartFeatureOperation { return ops.Join }
+
 // HoleFeatures and BossFeatures add hole/boss features into the engine.
 type (
 	HoleFeatures struct{ engine *PartFeatures }
@@ -109,6 +251,31 @@ func NewBossFeatures(engine *PartFeatures) *BossFeatures { return &BossFeatures{
 // AddDrilled adds a simple drilled hole on the placement face.
 func (c *HoleFeatures) AddDrilled(faceKey []byte, diameter, depth func() float64) *PartFeature {
 	return c.addHole(&HoleDefinition{PlacementFaceKey: faceKey, Diameter: diameter, Depth: depth, Type: DrilledHole})
+}
+
+// AddDrilledThrough adds a drilled hole that goes all the way through the part (an exact
+// cylinder wall on a planar-faced slab); depth is unused.
+func (c *HoleFeatures) AddDrilledThrough(faceKey []byte, diameter func() float64) *PartFeature {
+	return c.addHole(&HoleDefinition{PlacementFaceKey: faceKey, Diameter: diameter, Depth: constFloat(0), ThroughAll: true, Type: DrilledHole})
+}
+
+// AddCounterbore adds a counterbore hole: a shallow recess (counterDiameter × counterDepth)
+// at the placement face above the main bore (diameter × depth). Set ThroughAll on the returned
+// definition for a through bore.
+func (c *HoleFeatures) AddCounterbore(faceKey []byte, diameter, depth, counterDiameter, counterDepth func() float64) *PartFeature {
+	return c.addHole(&HoleDefinition{
+		PlacementFaceKey: faceKey, Diameter: diameter, Depth: depth,
+		CounterDiameter: counterDiameter, CounterDepth: counterDepth, Type: CounterboreHole,
+	})
+}
+
+// AddCountersink adds a countersink hole: a conical recess (sinkDiameter at the surface,
+// included angle) above the main bore (diameter × depth). Set ThroughAll for a through bore.
+func (c *HoleFeatures) AddCountersink(faceKey []byte, diameter, depth, sinkDiameter, includedAngle func() float64) *PartFeature {
+	return c.addHole(&HoleDefinition{
+		PlacementFaceKey: faceKey, Diameter: diameter, Depth: depth,
+		CounterDiameter: sinkDiameter, CounterAngle: includedAngle, Type: CountersinkHole,
+	})
 }
 
 // AddTapped adds a tapped hole with thread data.

--- a/model/feature/hole_boss_test.go
+++ b/model/feature/hole_boss_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/health"
@@ -67,6 +68,174 @@ func TestHoleDrillsThroughForReal(t *testing.T) {
 	}
 }
 
+func TestHoleThroughAllProducesCylinderWall(t *testing.T) {
+	// A 4×4×2 block, Ø2 hole through the top face. ThroughAll routes through the curved
+	// boolean → a TRUE cylinder wall (one curved face), not a 32-gon prism.
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=2 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	hole := NewHoleFeatures(fs).AddDrilledThrough(top, func() float64 { return 2 })
+	fs.Recompute()
+	if !hole.Health().OK() {
+		t.Fatalf("through-all hole sick: %+v", hole.Health())
+	}
+	res := fs.Result()
+	if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+		t.Fatalf("drilled body not a valid solid: %+v", r)
+	}
+	cylFaces := 0
+	for _, f := range res[0].Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cylFaces++
+		}
+	}
+	if cylFaces != 1 {
+		t.Errorf("through-all hole has %d cylinder faces, want 1 (a true wall, not faceted)", cylFaces)
+	}
+	// Removed = an inscribed Ø2 cylinder over thickness 2: a hair under π·1²·2.
+	bore := stdmath.Pi * 1 * 1 * 2
+	removed := 32 - ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume
+	if removed > bore+1e-9 || (bore-removed)/bore > 0.03 {
+		t.Errorf("removed = %g, want a hair under %g (π·r²·h)", removed, bore)
+	}
+}
+
+func TestBlindHoleProducesCylinderWallAndFlatBottom(t *testing.T) {
+	// 4×4×2 block, Ø2 hole only 1 deep (blind) → exact cylinder wall + flat bottom disk.
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=2 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	hole := NewHoleFeatures(fs).AddDrilled(top, func() float64 { return 2 }, func() float64 { return 1 }) // depth 1 < 2 ⇒ blind
+	fs.Recompute()
+	if !hole.Health().OK() {
+		t.Fatalf("blind hole sick: %+v", hole.Health())
+	}
+	res := fs.Result()
+	if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+		t.Fatalf("blind-drilled body not a valid solid: %+v", r)
+	}
+	cyl := 0
+	for _, f := range res[0].Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cyl++
+		}
+	}
+	if cyl != 1 {
+		t.Errorf("blind hole has %d cylinder faces, want 1 (true wall, not faceted)", cyl)
+	}
+	// Removed = an inscribed Ø2 cylinder 1 deep: a hair under π·1²·1.
+	bore := stdmath.Pi * 1 * 1 * 1
+	removed := 32 - ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume
+	if removed > bore+1e-9 || (bore-removed)/bore > 0.03 {
+		t.Errorf("removed = %g, want a hair under %g (π·r²·depth)", removed, bore)
+	}
+}
+
+func TestCounterboreHoleProducesTwoWallsAndShoulder(t *testing.T) {
+	// 8×8×4 block. Counterbore: Ø4 recess 1 deep + Ø2 bore through (total depth 4).
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 8, Y: 0}, {X: 8, Y: 8}, {X: 0, Y: 8}}, sketch.XYPlane(), span{near: 0, far: 4}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=4 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	cb := NewHoleFeatures(fs).AddCounterbore(top,
+		func() float64 { return 2 }, func() float64 { return 4 }, // bore Ø2 × full depth
+		func() float64 { return 4 }, func() float64 { return 1 }) // recess Ø4 × 1
+	cb.Definition().(*HoleFeature).Definition().ThroughAll = true // bore goes through
+	fs.Recompute()
+	if !cb.Health().OK() {
+		t.Fatalf("counterbore sick: %+v", cb.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("counterbored body not a valid solid: %+v", r)
+	}
+	cyl := 0
+	for _, f := range body.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cyl++
+		}
+	}
+	if cyl != 2 {
+		t.Errorf("counterbore has %d cylinder faces, want 2 (recess wall + bore wall)", cyl)
+	}
+	// Removed = recess (Ø4 over the top 1) + bore (Ø2 over the remaining 3): inscribed, a hair
+	// under the analytic sum (the bore only removes material below the shoulder).
+	removed := 8.0*8.0*4.0 - ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*2*2*1 + stdmath.Pi*1*1*3
+	if removed > want+1e-9 || (want-removed)/want > 0.03 {
+		t.Errorf("removed = %g, want a hair under %g (recess + bore)", removed, want)
+	}
+}
+
+func TestCountersinkHoleProducesConeWall(t *testing.T) {
+	// 10×10×6 block. Countersink: Ø4 sink at 90° included narrowing to a Ø2 bore through.
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 10, Y: 0}, {X: 10, Y: 10}, {X: 0, Y: 10}}, sketch.XYPlane(), span{near: 0, far: 6}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=6 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	cs := NewHoleFeatures(fs).AddCountersink(top,
+		func() float64 { return 2 }, func() float64 { return 6 }, // bore Ø2 × full depth
+		func() float64 { return 4 }, func() float64 { return stdmath.Pi / 2 }) // sink Ø4, 90°
+	cs.Definition().(*HoleFeature).Definition().ThroughAll = true
+	fs.Recompute()
+	if !cs.Health().OK() {
+		t.Fatalf("countersink sick: %+v", cs.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("countersunk body not a valid solid: %+v", r)
+	}
+	cone, cyl := 0, 0
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cone++
+		case geom.Cylinder:
+			cyl++
+		}
+	}
+	if cone != 1 || cyl != 1 {
+		t.Errorf("countersink has %d cone / %d cylinder faces, want 1 / 1 (sink wall + bore wall)", cone, cyl)
+	}
+}
+
+func TestDrilledHoleWithConicalPoint(t *testing.T) {
+	// 8×8×6 block, Ø2 blind hole 3 deep with a 118° drill point → cylinder bore + cone tip.
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 8, Y: 0}, {X: 8, Y: 8}, {X: 0, Y: 8}}, sketch.XYPlane(), span{near: 0, far: 6}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=6 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	hole := NewHoleFeatures(fs).AddDrilled(top, func() float64 { return 2 }, func() float64 { return 3 })
+	hole.Definition().(*HoleFeature).Definition().PointAngle = func() float64 { return 118 * stdmath.Pi / 180 }
+	fs.Recompute()
+	if !hole.Health().OK() {
+		t.Fatalf("conical-point hole sick: %+v", hole.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("conical-point body not a valid solid: %+v", r)
+	}
+	cone, cyl := 0, 0
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cone++
+		case geom.Cylinder:
+			cyl++
+		}
+	}
+	if cone != 1 || cyl != 1 {
+		t.Errorf("conical-point hole has %d cone / %d cylinder faces, want 1 / 1 (tip + bore)", cone, cyl)
+	}
+}
+
 func TestHoleGoesSickOnLostFace(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fs).AddBase(prismBody())
@@ -86,5 +255,51 @@ func TestHoleBossDefinitionAccessors(t *testing.T) {
 	b := NewBossFeatures(fs).Add([]byte("f"), func() float64 { return 1 }, func() float64 { return 2 })
 	if b.Definition().(*BossFeature).Definition().Diameter() != 1 {
 		t.Error("boss definition not accessible")
+	}
+}
+
+// TestPatternOfHoleCutsEachOccurrence pins the fix that made a hole patternable: a hole exposes
+// its drill cylinder as a [ToolFeature], so a pattern re-cuts the bore at every occurrence in
+// one body — the earlier bug copied the whole solid into N bodies, and an unhandled source made
+// the pattern a no-op. The same hole, alone vs. patterned 3×, must stay one solid yet remove ~2
+// extra bores of material. (Bounds, not an exact volume: occurrence 0 is cut by the exact brep
+// cutter while the replicated occurrences use the faceted drill tool, so the bores differ by a
+// few percent — the band proves "two more holes" without over-fitting that gap.)
+func TestPatternOfHoleCutsEachOccurrence(t *testing.T) {
+	// A 16×4×2 block centred on X (spans −8..8): a Ø2 hole at the top-face centroid (x=0),
+	// patterned 3× by +3 in X → bores at x=0,3,6, all clear of the x=±8 edges.
+	corners := []math.Point2{{X: -8, Y: -2}, {X: 8, Y: -2}, {X: 8, Y: 2}, {X: -8, Y: 2}}
+	blockVol := 16.0 * 4.0 * 2.0
+
+	holeVol := func(t *testing.T, patterned bool) (float64, int) {
+		t.Helper()
+		fs := NewPartFeatures(nil, nil)
+		block := buildPrism(corners, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+		NewBaseFeatures(fs).AddBase(block)
+		hole := NewHoleFeatures(fs).AddDrilled(block.Faces()[1].ReferenceKey(), func() float64 { return 2 }, func() float64 { return 3 })
+		if patterned {
+			NewPatternFeatures(fs).AddRectangular([]ID{hole.ID()},
+				func() int { return 3 }, func() int { return 1 }, math.V3(3, 0, 0), noStep)
+		}
+		fs.Recompute()
+		res := fs.Result()
+		if len(res) != 1 {
+			t.Fatalf("patterned=%v → %d bodies, want 1", patterned, len(res))
+		}
+		if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+			t.Fatalf("patterned=%v body not a valid solid: %+v", patterned, r)
+		}
+		return ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume, len(res)
+	}
+
+	single, _ := holeVol(t, false)
+	bore := blockVol - single // one bore's removed volume
+	if bore <= 0 {
+		t.Fatalf("single hole removed no material (vol %g >= block %g)", single, blockVol)
+	}
+	pattern, _ := holeVol(t, true)
+	extra := single - pattern // the two replicated bores
+	if extra < 1.5*bore || extra > 2.5*bore {
+		t.Errorf("patterned hole removed %g extra (%.2f bores), want ~2 bores (one body, three holes)", extra, extra/bore)
 	}
 }

--- a/model/feature/patterns.go
+++ b/model/feature/patterns.go
@@ -112,6 +112,70 @@ func appendCopies(bodies, copies []*topo.Body) []*topo.Body {
 	return append(out, copies...)
 }
 
+// replicate produces the patterned body state. When the single source feature added or
+// removed material (a cut/join/intersect), it re-applies that source's tool at each active
+// occurrence with the same boolean — so patterning a hole cuts N holes in one body, and
+// patterning a boss unions N bosses into one body. A boolean source whose tool cannot be
+// recovered (a deferred feature that built no geometry, or a degenerate delta) replicates
+// nothing — copying the whole running body would wrongly multiply it. Only a new-body/base
+// source falls back to placing whole-body copies as independent solids.
+func (p *patternBase) replicate(in Input, sources []ID, transforms []math.Matrix4, feat string) (Output, error) {
+	tool, op, ok := singleSourceTool(in, sources)
+	if booleanReplicable(op) {
+		if !ok {
+			return Output{Bodies: in.Bodies}, nil
+		}
+		return p.replicateTool(in.Bodies, tool, op, transforms, feat)
+	}
+	copies, err := p.placeCopies(in.Bodies, transforms, feat)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: appendCopies(in.Bodies, copies)}, nil
+}
+
+// replicateTool re-applies the source tool, transformed by each active occurrence, against
+// the running result with the source operation (the original sits at occurrence 0 already).
+func (p *patternBase) replicateTool(bodies []*topo.Body, tool *topo.Body, op ops.PartFeatureOperation, transforms []math.Matrix4, feat string) (Output, error) {
+	if len(bodies) == 0 {
+		return Output{Bodies: bodies}, nil
+	}
+	running := append([]*topo.Body(nil), bodies...)
+	last := len(running) - 1
+	for k := 1; k < len(transforms); k++ {
+		if p.suppressed[k] {
+			continue
+		}
+		tk, err := ops.TransformBody(tool, transforms[k], copyLineage(feat, k, 0))
+		if err != nil {
+			return Output{}, err
+		}
+		res, err := ops.Boolean(op, running[last], tk)
+		if err != nil {
+			return Output{}, err
+		}
+		if res != nil && len(res.Faces()) > 0 {
+			running[last] = res
+		}
+	}
+	return Output{Bodies: running}, nil
+}
+
+// singleSourceTool returns the tool + operation of a lone source feature (the common case);
+// it declines multi-source patterns and missing resolvers, leaving them to the copy path.
+func singleSourceTool(in Input, sources []ID) (*topo.Body, ops.PartFeatureOperation, bool) {
+	if in.SourceTool == nil || len(sources) != 1 {
+		return nil, ops.NewBody, false
+	}
+	return in.SourceTool(sources[0])
+}
+
+// booleanReplicable reports whether an operation is one the pattern re-applies as a boolean
+// (a material change), as opposed to a new-body placement.
+func booleanReplicable(op ops.PartFeatureOperation) bool {
+	return op == ops.Cut || op == ops.Join || op == ops.Intersect
+}
+
 // RectangularPatternDefinition replicates the running solid in a 2D grid. StepX/StepY
 // are the per-occurrence offset vectors (direction × spacing); element (ix,iy) sits at
 // StepX·ix + StepY·iy, with (0,0) the original.
@@ -136,11 +200,7 @@ func (r *RectangularPatternFeature) Recompute(in Input) (Output, error) {
 	nx, ny := callOr1(r.def.CountX), callOr1(r.def.CountY)
 	r.rebuild(nx * ny)
 	transforms := rectTransforms(nx, ny, r.def.StepX, r.def.StepY)
-	copies, err := r.placeCopies(in.Bodies, transforms, "rect-pattern")
-	if err != nil {
-		return Output{}, err
-	}
-	return Output{Bodies: appendCopies(in.Bodies, copies)}, nil
+	return r.replicate(in, r.def.SourceFeatures, transforms, "rect-pattern")
 }
 
 // rectTransforms returns the grid of occurrence transforms in row-major (ix + iy·nx)
@@ -182,11 +242,7 @@ func (c *CircularPatternFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	copies, err := c.placeCopies(in.Bodies, transforms, "circ-pattern")
-	if err != nil {
-		return Output{}, err
-	}
-	return Output{Bodies: appendCopies(in.Bodies, copies)}, nil
+	return c.replicate(in, c.def.SourceFeatures, transforms, "circ-pattern")
 }
 
 // circTransforms returns count occurrence rotations about the axis at angle/count
@@ -224,11 +280,7 @@ func (s *SketchDrivenPatternFeature) Recompute(in Input) (Output, error) {
 	points := callPoints(s.def.Points)
 	s.rebuild(len(points))
 	transforms := sketchTransforms(points)
-	copies, err := s.placeCopies(in.Bodies, transforms, "sketch-pattern")
-	if err != nil {
-		return Output{}, err
-	}
-	return Output{Bodies: appendCopies(in.Bodies, copies)}, nil
+	return s.replicate(in, s.def.SourceFeatures, transforms, "sketch-pattern")
 }
 
 // sketchTransforms returns a translation per sketch point relative to the first point
@@ -270,11 +322,7 @@ func (m *MirrorFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	transforms := []math.Matrix4{math.Identity4(), math.Reflection4(m.def.Origin, normal)}
-	copies, err := m.placeCopies(in.Bodies, transforms, "mirror")
-	if err != nil {
-		return Output{}, err
-	}
-	return Output{Bodies: appendCopies(in.Bodies, copies)}, nil
+	return m.replicate(in, m.def.SourceFeatures, transforms, "mirror")
 }
 
 // PatternFeatures adds pattern/mirror features into the engine.

--- a/model/feature/patterns_test.go
+++ b/model/feature/patterns_test.go
@@ -139,6 +139,48 @@ func TestCircularAndSketchDrivenPlaceCopies(t *testing.T) {
 	}
 }
 
+// TestPatternOfCutKeepsOneBody: patterning a CUT feature must replicate the cut (one body
+// with N holes), not duplicate the whole body into N solids. (Regression for the wheel: a
+// circular pattern of a bolt-hole cut was producing N separate bodies.)
+func TestPatternOfCutKeepsOneBody(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	// A 10x10x5 base box.
+	NewExtrudeFeatures(fs).AddExtrude(squareSketch(10), []int{0}, ops.NewBody,
+		Extent{Type: DistanceExtent, Direction: PositiveDir, Distance: func() float64 { return 5 }}, 0)
+	// A 2x2 hole cut through it near a corner.
+	cut := NewExtrudeFeatures(fs).AddExtrude(squareSketchAt(2, 1), []int{0}, ops.Cut,
+		Extent{Type: ThroughAllExtent, Direction: SymmetricDir, Distance: func() float64 { return 10 }}, 0)
+	// Pattern the cut three times along X — three holes, still one body.
+	NewPatternFeatures(fs).AddRectangular([]ID{cut.ID()},
+		func() int { return 3 }, func() int { return 1 }, math.V3(3, 0, 0), noStep)
+	fs.Recompute()
+
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("pattern of a cut → %d bodies, want 1 (one body with three holes)", len(res))
+	}
+	if !ops.Validate(res[0]).Valid {
+		t.Errorf("patterned-cut body is invalid: %v", ops.Validate(res[0]).Issues)
+	}
+}
+
+// TestPatternOfJoinMergesIntoOneBody: patterning a JOIN feature must union the copies into the
+// running body, not leave them as separate solids.
+func TestPatternOfJoinMergesIntoOneBody(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddExtrude(squareSketch(10), []int{0}, ops.NewBody,
+		Extent{Type: DistanceExtent, Direction: PositiveDir, Distance: func() float64 { return 5 }}, 0)
+	// A small boss joined on top, overlapping the base so the union is one body.
+	boss := NewExtrudeFeatures(fs).AddExtrude(squareSketchAt(2, 1), []int{0}, ops.Join,
+		Extent{Type: DistanceExtent, Direction: PositiveDir, Distance: func() float64 { return 8 }}, 0)
+	NewPatternFeatures(fs).AddRectangular([]ID{boss.ID()},
+		func() int { return 2 }, func() int { return 1 }, math.V3(3, 0, 0), noStep)
+	fs.Recompute()
+	if got := len(fs.Result()); got != 1 {
+		t.Fatalf("pattern of a join → %d bodies, want 1 merged body", got)
+	}
+}
+
 // patIDOf returns the engine id of a pattern feature (it is the last one added of
 // its source set — found by identity).
 func patIDOf(fs *PartFeatures, f Feature) ID {

--- a/model/feature/revolve_test.go
+++ b/model/feature/revolve_test.go
@@ -8,8 +8,41 @@ import (
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/health"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
+
+// TestRevolveAboutSketchCenterline spins a profile about the sketch's own centerline (Inventor's
+// common flow), producing the same washer as revolving about an explicit Y work axis.
+func TestRevolveAboutSketchCenterline(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := offsetSquareSketch(2, 2)                                // square x∈[2,4], y∈[0,2]
+	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2)) // vertical centerline = Y axis
+	cl.SetCenterline(true)
+	pf := NewRevolveFeatures(fs).AddAboutCenterline(sk, 0, nil, ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("revolve about centerline sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("centerline-revolved body not a valid solid: %+v", r)
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2 // 24π washer
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.01 {
+		t.Errorf("centerline-revolved washer = %g, want ≈%g (24π)", got, want)
+	}
+}
+
+// A revolve with neither an axis nor a sketch centerline is sick.
+func TestRevolveNoAxisOrCenterlineSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	pf := NewRevolveFeatures(fs).AddAboutCenterline(offsetSquareSketch(2, 2), 0, nil, ops.NewBody)
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Errorf("revolve with no axis/centerline = %v, want sick", pf.Health().Status)
+	}
+}
 
 // offsetSquareSketch returns a sketch with a square in the XY plane spanning
 // x∈[x0,x0+side], y∈[0,side] — a profile offset from the Y axis for revolving.

--- a/model/feature/rib_test.go
+++ b/model/feature/rib_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
+)
+
+// A rib over a straight open path is a wall of length×thickness×depth.
+func TestRibGeneratesWall(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0)) // open path, length 4
+
+	rib := &RibFeature{def: &RibDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Thickness: func() float64 { return 1 },
+		Depth:     func() float64 { return 2 },
+		Operation: ops.NewBody,
+	}}
+	pf := fs.Add(rib)
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("rib went sick: %+v", pf.Health())
+	}
+	bodies := fs.Result()
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		t.Fatalf("rib result = %d bodies, want 1 solid", len(bodies))
+	}
+	if r := ops.Validate(bodies[0]); !r.Valid {
+		t.Fatalf("rib body invalid: %+v", r)
+	}
+	vol := ops.BodyGeometryProperties(bodies[0], ops.DefaultQuality()).Volume
+	if stdmath.Abs(vol-8) > 1e-6 { // 4 (length) × 1 (thickness) × 2 (depth)
+		t.Errorf("rib volume = %g, want 8", vol)
+	}
+}
+
+// The RibFeatures collection adds a named, healthy rib (the path the Rib tool drives).
+func TestRibFeaturesAddNamesAndBuilds(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+
+	pf := NewRibFeatures(fs).Add(sk, 0, func() float64 { return 1 }, func() float64 { return 2 }, ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("rib went sick: %+v", pf.Health())
+	}
+	if pf.Name() != "Rib1" {
+		t.Errorf("rib name = %q, want Rib1", pf.Name())
+	}
+	if vol := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; stdmath.Abs(vol-8) > 1e-6 {
+		t.Errorf("rib volume = %g, want 8", vol)
+	}
+}
+
+// An L-shaped open path ribs into a connected wall (two segments → one solid).
+func TestRibLShapedPath(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	corner := sk.Points().Add(math.P2(4, 0))
+	sk.Lines().Add(sk.Points().Add(math.P2(0, 0)), corner)
+	sk.Lines().Add(corner, sk.Points().Add(math.P2(4, 3)))
+
+	rib := &RibFeature{def: &RibDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Thickness: func() float64 { return 1 },
+		Depth:     func() float64 { return 2 },
+		Operation: ops.NewBody,
+	}}
+	pf := fs.Add(rib)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("L-rib went sick: %+v", pf.Health())
+	}
+	bodies := fs.Result()
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		t.Fatalf("L-rib = %d bodies, want 1 solid", len(bodies))
+	}
+}
+
+// A degenerate definition (no depth) reports sick, not a crash.
+func TestRibNeedsDepth(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	rib := &RibFeature{def: &RibDefinition{Sketch: sk, ProfileIndex: 0, Thickness: func() float64 { return 1 }, Operation: ops.NewBody}}
+	pf := fs.Add(rib)
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("a rib with no depth should be sick")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -19,18 +19,21 @@ import (
 // FeatureData is the serializable form of one history feature. Exactly one payload
 // pointer is set, matching Kind.
 type FeatureData struct {
-	Kind       string         `yaml:"kind"`
-	Name       string         `yaml:"name,omitempty"`
-	Suppressed bool           `yaml:"suppressed,omitempty"`
-	Extrude    *ExtrudeData   `yaml:"extrude,omitempty"`
-	Fillet     *EdgeDressData `yaml:"fillet,omitempty"`
-	Chamfer    *EdgeDressData `yaml:"chamfer,omitempty"`
-	Shell      *FaceDressData `yaml:"shell,omitempty"`
-	Draft      *FaceDressData `yaml:"draft,omitempty"`
-	Thread     *ThreadData    `yaml:"thread,omitempty"`
-	Hole       *HoleData      `yaml:"hole,omitempty"`
-	Boss       *BossData      `yaml:"boss,omitempty"`
-	Combine    *CombineData   `yaml:"combine,omitempty"`
+	Kind       string          `yaml:"kind"`
+	Name       string          `yaml:"name,omitempty"`
+	Suppressed bool            `yaml:"suppressed,omitempty"`
+	Extrude    *ExtrudeData    `yaml:"extrude,omitempty"`
+	Fillet     *EdgeDressData  `yaml:"fillet,omitempty"`
+	Chamfer    *EdgeDressData  `yaml:"chamfer,omitempty"`
+	Shell      *FaceDressData  `yaml:"shell,omitempty"`
+	Draft      *FaceDressData  `yaml:"draft,omitempty"`
+	Thread     *ThreadData     `yaml:"thread,omitempty"`
+	Hole       *HoleData       `yaml:"hole,omitempty"`
+	Boss       *BossData       `yaml:"boss,omitempty"`
+	Rib        *RibData        `yaml:"rib,omitempty"`
+	Emboss     *EmbossData     `yaml:"emboss,omitempty"`
+	Combine    *CombineData    `yaml:"combine,omitempty"`
+	SplitSolid *SplitSolidData `yaml:"splitSolid,omitempty"`
 
 	RectPattern   *RectPatternData         `yaml:"rectangularPattern,omitempty"`
 	CircPattern   *CircPatternData         `yaml:"circularPattern,omitempty"`
@@ -115,6 +118,24 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Hole = h
 	case *BossFeature:
 		fd.Boss = &BossData{Face: encodeKey(f.def.PlacementFaceKey), Diameter: evalFloat(f.def.Diameter), Height: evalFloat(f.def.Height)}
+	case *RibFeature:
+		rd, err := serializeRib(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Rib = rd
+	case *EmbossFeature:
+		ed, err := serializeEmboss(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Emboss = ed
+	case *SplitSolidFeature:
+		sd, err := serializeSplitSolid(f.def)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SplitSolid = sd
 	case *CombineFeature:
 		op, err := operationName(f.def.Operation)
 		if err != nil {
@@ -311,6 +332,12 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSweep(fs, fd.Sweep, sk)
 	case "loft":
 		return restoreLoft(fs, fd.Loft, sk)
+	case "rib":
+		return restoreRib(fs, fd.Rib, sk)
+	case "emboss":
+		return restoreEmboss(fs, fd.Emboss, sk)
+	case "splitSolid":
+		return restoreSplitSolid(fs, fd.SplitSolid, work)
 	case "move":
 		return restoreMove(fs, fd.Move)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_emboss.go
+++ b/model/feature/serialize_emboss.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// EmbossData is an emboss's recipe: its closed profile(s) (a sketch + region indices), the
+// depth, whether it engraves (cut) instead of raises (join), and a draft taper.
+type EmbossData struct {
+	Sketch   int     `yaml:"sketch"`
+	Profiles []int   `yaml:"profiles"`
+	Depth    float64 `yaml:"depth"`
+	Engrave  bool    `yaml:"engrave,omitempty"`
+	Taper    float64 `yaml:"taper,omitempty"`
+}
+
+func serializeEmboss(def *EmbossDefinition, sk SketchIndexer) (*EmbossData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("emboss references a sketch that is not in the part")
+	}
+	return &EmbossData{
+		Sketch: idx, Profiles: append([]int(nil), def.ProfileIndices...),
+		Depth: evalFloat(def.Depth), Engrave: def.Engrave, Taper: def.Taper,
+	}, nil
+}
+
+func restoreEmboss(fs *PartFeatures, d *EmbossData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("emboss feature is missing its payload")
+	}
+	skt, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("emboss references sketch index %d, which does not exist", d.Sketch)
+	}
+	return NewEmbossFeatures(fs).Add(skt, d.Profiles, constFloat(d.Depth), d.Engrave, d.Taper), nil
+}

--- a/model/feature/serialize_rib.go
+++ b/model/feature/serialize_rib.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// RibData is a rib's recipe: its open profile (a sketch + path index), wall thickness, signed
+// depth along the sketch-plane normal, and the boolean operation joining it to the part.
+type RibData struct {
+	Sketch    int     `yaml:"sketch"`
+	Profile   int     `yaml:"profile"`
+	Thickness float64 `yaml:"thickness"`
+	Depth     float64 `yaml:"depth"`
+	Operation string  `yaml:"operation"`
+}
+
+func serializeRib(def *RibDefinition, sk SketchIndexer) (*RibData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("rib references a sketch that is not in the part")
+	}
+	op, err := operationName(def.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return &RibData{
+		Sketch: idx, Profile: def.ProfileIndex,
+		Thickness: evalFloat(def.Thickness), Depth: evalFloat(def.Depth), Operation: op,
+	}, nil
+}
+
+func restoreRib(fs *PartFeatures, d *RibData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("rib feature is missing its payload")
+	}
+	skt, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("rib references sketch index %d, which does not exist", d.Sketch)
+	}
+	op, err := parseOperation(d.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return NewRibFeatures(fs).Add(skt, d.Profile, constFloat(d.Thickness), constFloat(d.Depth), op), nil
+}

--- a/model/feature/serialize_solid.go
+++ b/model/feature/serialize_solid.go
@@ -12,12 +12,17 @@ import "fmt"
 // HoleData is a hole's recipe: the placement face (reference key), diameter/depth,
 // the hole geometry type, and optional tap data.
 type HoleData struct {
-	Face        string  `yaml:"face"`
-	Diameter    float64 `yaml:"diameter"`
-	Depth       float64 `yaml:"depth"`
-	Type        string  `yaml:"type"`
-	Tapped      bool    `yaml:"tapped,omitempty"`
-	Designation string  `yaml:"designation,omitempty"`
+	Face            string  `yaml:"face"`
+	Diameter        float64 `yaml:"diameter"`
+	Depth           float64 `yaml:"depth"`
+	ThroughAll      bool    `yaml:"throughAll,omitempty"`
+	CounterDiameter float64 `yaml:"counterDiameter,omitempty"`
+	CounterDepth    float64 `yaml:"counterDepth,omitempty"`
+	CounterAngle    float64 `yaml:"counterAngle,omitempty"`
+	PointAngle      float64 `yaml:"pointAngle,omitempty"`
+	Type            string  `yaml:"type"`
+	Tapped          bool    `yaml:"tapped,omitempty"`
+	Designation     string  `yaml:"designation,omitempty"`
 }
 
 // BossData is a boss's recipe: a raised cylinder on a placement face.
@@ -40,12 +45,17 @@ func serializeHole(def *HoleDefinition) (*HoleData, error) {
 		return nil, err
 	}
 	return &HoleData{
-		Face:        encodeKey(def.PlacementFaceKey),
-		Diameter:    evalFloat(def.Diameter),
-		Depth:       evalFloat(def.Depth),
-		Type:        kind,
-		Tapped:      def.Tap.Tapped,
-		Designation: def.Tap.Designation,
+		Face:            encodeKey(def.PlacementFaceKey),
+		Diameter:        evalFloat(def.Diameter),
+		Depth:           evalFloat(def.Depth),
+		ThroughAll:      def.ThroughAll,
+		CounterDiameter: evalFloat(def.CounterDiameter),
+		CounterDepth:    evalFloat(def.CounterDepth),
+		CounterAngle:    evalFloat(def.CounterAngle),
+		PointAngle:      evalFloat(def.PointAngle),
+		Type:            kind,
+		Tapped:          def.Tap.Tapped,
+		Designation:     def.Tap.Designation,
 	}, nil
 }
 
@@ -63,12 +73,22 @@ func restoreHole(fs *PartFeatures, h *HoleData) (*PartFeature, error) {
 	}
 	holes := NewHoleFeatures(fs)
 	var pf *PartFeature
-	if h.Tapped {
+	switch {
+	case h.Tapped:
 		pf = holes.AddTapped(key, constFloat(h.Diameter), constFloat(h.Depth), h.Designation)
-	} else {
+	case holeType == CounterboreHole:
+		pf = holes.AddCounterbore(key, constFloat(h.Diameter), constFloat(h.Depth), constFloat(h.CounterDiameter), constFloat(h.CounterDepth))
+	case holeType == CountersinkHole:
+		pf = holes.AddCountersink(key, constFloat(h.Diameter), constFloat(h.Depth), constFloat(h.CounterDiameter), constFloat(h.CounterAngle))
+	case h.ThroughAll:
+		pf = holes.AddDrilledThrough(key, constFloat(h.Diameter))
+	default:
 		pf = holes.AddDrilled(key, constFloat(h.Diameter), constFloat(h.Depth))
 	}
-	pf.feature.(*HoleFeature).def.Type = holeType
+	def := pf.feature.(*HoleFeature).def
+	def.Type = holeType
+	def.ThroughAll = h.ThroughAll
+	def.PointAngle = constFloat(h.PointAngle)
 	return pf, nil
 }
 

--- a/model/feature/serialize_split.go
+++ b/model/feature/serialize_split.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SplitSolidData is a solid split's recipe: the cutting work plane (by WorkRef) and which
+// side(s) to keep.
+type SplitSolidData struct {
+	Plane string `yaml:"plane"`
+	Keep  string `yaml:"keep,omitempty"`
+}
+
+// splitSideNames map the kept-side enum to/from a stable name.
+var splitSideNames = map[SplitSide]string{SplitBoth: "both", SplitPositive: "positive", SplitNegative: "negative"}
+
+func splitSideName(s SplitSide) string {
+	if n, ok := splitSideNames[s]; ok {
+		return n
+	}
+	return "both"
+}
+
+func parseSplitSide(name string) (SplitSide, error) {
+	for s, n := range splitSideNames {
+		if n == name {
+			return s, nil
+		}
+	}
+	if name == "" {
+		return SplitBoth, nil
+	}
+	return SplitBoth, fmt.Errorf("unknown split side %q", name)
+}
+
+func serializeSplitSolid(def *SplitSolidDefinition) (*SplitSolidData, error) {
+	if def.Plane == nil {
+		return nil, fmt.Errorf("split references no cutting plane")
+	}
+	return &SplitSolidData{Plane: string(def.Plane.Key()), Keep: splitSideName(def.Keep)}, nil
+}
+
+func restoreSplitSolid(fs *PartFeatures, d *SplitSolidData, work *WorkGeometry) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("split feature is missing its payload")
+	}
+	wp, err := resolvePlaneRef(work, d.Plane)
+	if err != nil {
+		return nil, err
+	}
+	keep, err := parseSplitSide(d.Keep)
+	if err != nil {
+		return nil, err
+	}
+	return NewModifyFeatures(fs).AddSplitSolid(wp, keep), nil
+}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -158,6 +158,151 @@ func TestSolidFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestThroughAllHoleRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewHoleFeatures(fs).AddDrilledThrough([]byte("face-9"), func() float64 { return 3 })
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	hole := fresh.Item(0).Definition().(*HoleFeature).Definition()
+	if !hole.ThroughAll || string(hole.PlacementFaceKey) != "face-9" || hole.Diameter() != 3 {
+		t.Errorf("restored hole = throughAll %v face %q d %v, want true face-9 3", hole.ThroughAll, hole.PlacementFaceKey, hole.Diameter())
+	}
+}
+
+func TestCounterboreHoleRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	cb := NewHoleFeatures(fs).AddCounterbore([]byte("face-3"),
+		func() float64 { return 2 }, func() float64 { return 6 },
+		func() float64 { return 4 }, func() float64 { return 1 })
+	cb.Definition().(*HoleFeature).Definition().ThroughAll = true
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	h := fresh.Item(0).Definition().(*HoleFeature).Definition()
+	if h.Type != CounterboreHole || !h.ThroughAll || h.CounterDiameter() != 4 || h.CounterDepth() != 1 {
+		t.Errorf("restored counterbore = type %d through %v cØ %v cDepth %v, want counterbore true 4 1",
+			h.Type, h.ThroughAll, h.CounterDiameter(), h.CounterDepth())
+	}
+}
+
+func TestCountersinkHoleRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewHoleFeatures(fs).AddCountersink([]byte("face-4"),
+		func() float64 { return 2 }, func() float64 { return 5 },
+		func() float64 { return 4 }, func() float64 { return 1.5708 })
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	h := fresh.Item(0).Definition().(*HoleFeature).Definition()
+	if h.Type != CountersinkHole || h.CounterDiameter() != 4 || h.CounterAngle() != 1.5708 {
+		t.Errorf("restored countersink = type %d sinkØ %v angle %v, want countersink 4 1.5708",
+			h.Type, h.CounterDiameter(), h.CounterAngle())
+	}
+}
+
+func TestDrilledHolePointAngleRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	pf := NewHoleFeatures(fs).AddDrilled([]byte("face-7"), func() float64 { return 2 }, func() float64 { return 4 })
+	pf.Definition().(*HoleFeature).Definition().PointAngle = func() float64 { return 2.0594 } // ~118°
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	h := fresh.Item(0).Definition().(*HoleFeature).Definition()
+	if h.PointAngle == nil {
+		t.Fatal("restored hole lost its point angle")
+	}
+	if got := h.PointAngle(); got != 2.0594 {
+		t.Errorf("restored point angle = %v, want 2.0594", got)
+	}
+}
+
+func TestRibRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	fs := NewPartFeatures(nil, nil)
+	NewRibFeatures(fs).Add(sk, 0, func() float64 { return 1.5 }, func() float64 { return 3 }, ops.Join)
+
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	rib := fresh.Item(0).Definition().(*RibFeature).Definition()
+	if rib.ProfileIndex != 0 || rib.Thickness() != 1.5 || rib.Depth() != 3 || rib.Operation != ops.Join {
+		t.Errorf("restored rib = profile %d thickness %v depth %v op %v, want 0 1.5 3 Join",
+			rib.ProfileIndex, rib.Thickness(), rib.Depth(), rib.Operation)
+	}
+}
+
+func TestEmbossRoundTrip(t *testing.T) {
+	sk := squareSketch(4)
+	fs := NewPartFeatures(nil, nil)
+	NewEmbossFeatures(fs).Add(sk, []int{0}, func() float64 { return 0.8 }, true, 0.1)
+
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	e := fresh.Item(0).Definition().(*EmbossFeature).Definition()
+	if !e.Engrave || e.Depth() != 0.8 || len(e.ProfileIndices) != 1 || e.Taper != 0.1 {
+		t.Errorf("restored emboss = engrave %v depth %v profiles %v taper %v, want true 0.8 [0] 0.1",
+			e.Engrave, e.Depth(), e.ProfileIndices, e.Taper)
+	}
+}
+
+func TestRevolveAboutCenterlineRoundTrip(t *testing.T) {
+	sk := offsetSquareSketch(2, 2)
+	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	cl.SetCenterline(true)
+	fs := NewPartFeatures(nil, nil)
+	NewRevolveFeatures(fs).AddAboutCenterline(sk, 0, func() float64 { return 0 }, ops.NewBody)
+
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	rv := fresh.Item(0).Definition().(*RevolveFeature).Definition()
+	if rv.Axis != nil {
+		t.Error("a centerline revolve must restore with a nil axis (centerline mode)")
+	}
+}
+
 func TestPatternFeaturesRebindSourceByIndex(t *testing.T) {
 	sk := sketch.NewSketches().Add(sketch.XYPlane())
 	fs := NewPartFeatures(nil, nil)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/sketch"
 )
 
 // This file serializes a part's USER work features (planes/axes/points) into the
@@ -232,11 +233,13 @@ func restorePointFeature(c *WorkPoints, d WorkFeatureData) error {
 // WorkRef, typically an origin axis or a user work axis), the swept angle, and the
 // boolean operation. Generation is still deferred, but the definition round-trips.
 type RevolveData struct {
-	Sketch    int     `yaml:"sketch"`
-	Profile   int     `yaml:"profile"`
-	Axis      string  `yaml:"axis"`
-	Angle     float64 `yaml:"angle,omitempty"` // 0 ⇒ full revolution
-	Operation string  `yaml:"operation"`
+	Sketch     int     `yaml:"sketch"`
+	Profile    int     `yaml:"profile"`
+	Axis       string  `yaml:"axis,omitempty"`       // a work-axis WorkRef; empty ⇒ centerline mode
+	AxisSketch int     `yaml:"axisSketch,omitempty"` // 1-based sketch index of a specific centerline (0 = none)
+	AxisLine   int     `yaml:"axisLine,omitempty"`   // that centerline's line index
+	Angle      float64 `yaml:"angle,omitempty"`      // 0 ⇒ full revolution
+	Operation  string  `yaml:"operation"`
 }
 
 func serializeRevolve(def *RevolveDefinition, sk SketchIndexer) (*RevolveData, error) {
@@ -244,20 +247,32 @@ func serializeRevolve(def *RevolveDefinition, sk SketchIndexer) (*RevolveData, e
 	if !ok {
 		return nil, fmt.Errorf("revolve references a sketch that is not in the part")
 	}
-	if def.Axis == nil {
-		return nil, fmt.Errorf("revolve has no axis")
-	}
 	op, err := operationName(def.Operation)
 	if err != nil {
 		return nil, err
 	}
-	return &RevolveData{
-		Sketch:    idx,
-		Profile:   def.ProfileIndex,
-		Axis:      string(def.Axis.Key()),
-		Angle:     evalFloat(def.Angle),
-		Operation: op,
-	}, nil
+	d := &RevolveData{Sketch: idx, Profile: def.ProfileIndex, Angle: evalFloat(def.Angle), Operation: op}
+	switch {
+	case def.Axis != nil:
+		d.Axis = string(def.Axis.Key())
+	case def.AxisCenterline != nil: // a specific centerline (1-based so 0 means "none")
+		asi, ok := sk.IndexOf(def.AxisCenterlineSketch)
+		if !ok {
+			return nil, fmt.Errorf("revolve axis centerline references a sketch not in the part")
+		}
+		d.AxisSketch, d.AxisLine = asi+1, lineIndexOf(def.AxisCenterlineSketch, def.AxisCenterline)
+	}
+	return d, nil // both empty ⇒ revolve about the profile sketch's own centerline
+}
+
+// lineIndexOf returns the position of line within the sketch's line collection (-1 if absent).
+func lineIndexOf(sk *sketch.Sketch, line *sketch.Line) int {
+	for i := 0; i < sk.Lines().Count(); i++ {
+		if sk.Lines().Item(i) == line {
+			return i
+		}
+	}
+	return -1
 }
 
 func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *WorkGeometry) (*PartFeature, error) {
@@ -268,6 +283,24 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 	if !ok {
 		return nil, fmt.Errorf("revolve references sketch index %d, which does not exist", d.Sketch)
 	}
+	op, err := parseOperation(d.Operation)
+	if err != nil {
+		return nil, err
+	}
+	angle := d.Angle
+	if d.AxisSketch > 0 { // a specific centerline (1-based index)
+		axisSk, ok := sk.At(d.AxisSketch - 1)
+		if !ok {
+			return nil, fmt.Errorf("revolve axis centerline references sketch index %d, which does not exist", d.AxisSketch-1)
+		}
+		if d.AxisLine < 0 || d.AxisLine >= axisSk.Lines().Count() {
+			return nil, fmt.Errorf("revolve axis centerline references line %d out of range", d.AxisLine)
+		}
+		return NewRevolveFeatures(fs).AddAboutCenterlineLine(skt, d.Profile, axisSk, axisSk.Lines().Item(d.AxisLine), func() float64 { return angle }, op), nil
+	}
+	if d.Axis == "" { // revolve about the profile sketch's own (single) centerline
+		return NewRevolveFeatures(fs).AddAboutCenterline(skt, d.Profile, func() float64 { return angle }, op), nil
+	}
 	if work == nil {
 		return nil, fmt.Errorf("revolve needs the part's work geometry to resolve its axis")
 	}
@@ -275,11 +308,6 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 	if err != nil {
 		return nil, fmt.Errorf("revolve axis: %w", err)
 	}
-	op, err := parseOperation(d.Operation)
-	if err != nil {
-		return nil, err
-	}
-	angle := d.Angle
 	return NewRevolveFeatures(fs).Add(skt, d.Profile, axis, func() float64 { return angle }, op), nil
 }
 

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	stdmath "math"
 
-	"github.com/Oblikovati/oblikovati/build"
 	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
@@ -23,23 +23,33 @@ import (
 // use a proportional share (so a 90° revolve gets ~1/4 the facets).
 const revolveSegments = 64
 
-// RevolveDefinition is the recipe for a revolve: a profile spun about an axis.
+// RevolveDefinition is the recipe for a revolve: a profile spun about an axis. The axis is, in
+// precedence: an explicit work axis; else a specific centerline (AxisCenterline on its sketch);
+// else the profile sketch's single centerline (auto).
 type RevolveDefinition struct {
-	Sketch       *sketch.Sketch
-	ProfileIndex int
-	Axis         *WorkAxis
-	Angle        func() float64 // 0 ⇒ full revolution
-	Operation    ops.PartFeatureOperation
+	Sketch               *sketch.Sketch
+	ProfileIndex         int
+	Axis                 *WorkAxis
+	AxisCenterline       *sketch.Line   // a specific centerline to revolve about
+	AxisCenterlineSketch *sketch.Sketch // the centerline's sketch (for its plane)
+	Angle                func() float64 // 0 ⇒ full revolution
+	Operation            ops.PartFeatureOperation
 }
 
 // RevolveFeature spins a profile about an axis.
 type RevolveFeature struct {
 	def      *RevolveDefinition
 	featName string
+	tool     *topo.Body // last solid of revolution, exposed so a pattern can replicate it
 }
 
 func (r *RevolveFeature) Definition() *RevolveDefinition { return r.def }
 func (r *RevolveFeature) Kind() string                   { return "revolve" }
+
+// Operation and ToolBody let a pattern/mirror replicate this feature with the right boolean
+// (see [ToolFeature]).
+func (r *RevolveFeature) Operation() ops.PartFeatureOperation { return r.def.Operation }
+func (r *RevolveFeature) ToolBody() *topo.Body                { return r.tool }
 
 // Recompute resolves the profile, spins it about the axis into a faceted solid of
 // revolution, and applies the operation against the running bodies.
@@ -48,19 +58,50 @@ func (r *RevolveFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	if r.def.Axis == nil {
-		return Output{}, errors.New("revolve: no axis of revolution")
-	}
-	sections, closed := revolveSections(prof, r.def.Sketch.Plane(), r.def.Axis, callOrZero(r.def.Angle))
-	tool, err := sweptSolid(sections, closed, featOr(r.featName, "revolve"))
+	axis, err := r.revolveAxis()
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, tool, r.def.Operation)
+	sections, closed := revolveSections(prof, r.def.Sketch.Plane(), axis, callOrZero(r.def.Angle))
+	r.tool, err = sweptSolid(sections, closed, featOr(r.featName, "revolve"))
+	if err != nil {
+		return Output{}, err
+	}
+	bodies, err := combine(in.Bodies, r.tool, r.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// revolveAxis resolves the axis of revolution: an explicit work axis if set, otherwise the
+// sketch's single centerline (Inventor's "revolve about the sketch centerline"). No axis and no
+// (or several) centerlines → Sick.
+func (r *RevolveFeature) revolveAxis() (*WorkAxis, error) {
+	if r.def.Axis != nil {
+		return r.def.Axis, nil
+	}
+	if r.def.AxisCenterline != nil {
+		return centerlineAxis(r.def.AxisCenterline, r.def.AxisCenterlineSketch)
+	}
+	cls := r.def.Sketch.Centerlines()
+	if len(cls) == 0 {
+		return nil, errors.New("revolve: no axis of revolution (set an axis or add a sketch centerline)")
+	}
+	if len(cls) > 1 {
+		return nil, errors.New("revolve: ambiguous axis — the sketch has multiple centerlines; pick one")
+	}
+	return centerlineAxis(cls[0], r.def.Sketch)
+}
+
+// centerlineAxis turns a centerline line on its sketch into a transient axis of revolution.
+func centerlineAxis(line *sketch.Line, sk *sketch.Sketch) (*WorkAxis, error) {
+	o, d := line.Axis3D(sk.Plane())
+	dir, err := math.UnitVector3FromVector(d)
+	if err != nil {
+		return nil, errors.New("revolve: the centerline is degenerate")
+	}
+	return &WorkAxis{origin: o, dir: dir}, nil
 }
 
 // revolveSections places the profile (in model space) at evenly-spaced angles about the
@@ -134,6 +175,27 @@ func (c *RevolveFeatures) Add(skt *sketch.Sketch, profileIndex int, axis *WorkAx
 	return pf
 }
 
+// AddAboutCenterline adds a revolve that spins the profile about the sketch's own centerline
+// (the common case: profile + centerline in one sketch). The sketch must hold exactly one.
+func (c *RevolveFeatures) AddAboutCenterline(skt *sketch.Sketch, profileIndex int, angle func() float64, op ops.PartFeatureOperation) *PartFeature {
+	return c.Add(skt, profileIndex, nil, angle, op)
+}
+
+// AddAboutCenterlineLine adds a revolve about a SPECIFIC centerline (on axisSketch) — used when
+// the chosen axis isn't simply the profile sketch's lone centerline (several centerlines, or one
+// in another sketch).
+func (c *RevolveFeatures) AddAboutCenterlineLine(profileSketch *sketch.Sketch, profileIndex int, axisSketch *sketch.Sketch, axisLine *sketch.Line, angle func() float64, op ops.PartFeatureOperation) *PartFeature {
+	def := &RevolveDefinition{
+		Sketch: profileSketch, ProfileIndex: profileIndex,
+		AxisCenterline: axisLine, AxisCenterlineSketch: axisSketch, Angle: angle, Operation: op,
+	}
+	rf := &RevolveFeature{def: def}
+	pf := c.engine.Add(rf)
+	pf.SetName(c.engine.UniqueName("Revolution"))
+	rf.featName = pf.name
+	return pf
+}
+
 // CoilDefinition is the recipe for a coil (helical sweep).
 type CoilDefinition struct {
 	Sketch       *sketch.Sketch
@@ -149,10 +211,15 @@ type CoilDefinition struct {
 type CoilFeature struct {
 	def      *CoilDefinition
 	featName string
+	tool     *topo.Body // last helical solid, exposed so a pattern can replicate it
 }
 
 func (c *CoilFeature) Definition() *CoilDefinition { return c.def }
 func (c *CoilFeature) Kind() string                { return "coil" }
+
+// Operation and ToolBody let a pattern/mirror replicate this feature (see [ToolFeature]).
+func (c *CoilFeature) Operation() ops.PartFeatureOperation { return c.def.Operation }
+func (c *CoilFeature) ToolBody() *topo.Body                { return c.tool }
 
 // Recompute resolves the profile and sweeps it along a helix about the axis (pitch per
 // revolution × revolutions) into a faceted solid, then applies the operation.
@@ -169,11 +236,11 @@ func (c *CoilFeature) Recompute(in Input) (Output, error) {
 		return Output{}, fmt.Errorf("coil: revolutions must be > 0, got %g", revs)
 	}
 	sections := coilSections(prof, c.def.Sketch.Plane(), c.def.Axis, callOrZero(c.def.Pitch), revs)
-	tool, err := sweptSolid(sections, false, featOr(c.featName, "coil"))
+	c.tool, err = sweptSolid(sections, false, featOr(c.featName, "coil"))
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, tool, c.def.Operation)
+	bodies, err := combine(in.Bodies, c.tool, c.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -221,19 +288,135 @@ func (c *CoilFeatures) Add(skt *sketch.Sketch, profileIndex int, axis *WorkAxis,
 	return pf
 }
 
-// RibDefinition is the recipe for a rib: a thin support from an open profile.
+// RibDefinition is the recipe for a rib: a thin wall from an open profile (a sketch path).
 type RibDefinition struct {
 	Sketch       *sketch.Sketch
-	ProfileIndex int
-	Thickness    func() float64
+	ProfileIndex int            // index into the sketch's open paths
+	Thickness    func() float64 // wall thickness, centered on the path
+	Depth        func() float64 // signed extent along the sketch-plane normal
 	Operation    ops.PartFeatureOperation
 }
 
-// RibFeature thickens an open profile into a support.
-type RibFeature struct{ def *RibDefinition }
+// RibFeature thickens an open sketch profile (a path) into a wall: the path is offset by
+// ±Thickness/2 in the sketch plane to a closed band, then extruded Depth along the plane
+// normal and combined with the running body. (Inventor's "to-next" bounding against the
+// part is a refinement — Depth gives the finite extent today.)
+type RibFeature struct {
+	def  *RibDefinition
+	tool *topo.Body // last rib wall, exposed so a pattern can replicate it
+}
 
 func (r *RibFeature) Definition() *RibDefinition { return r.def }
 func (r *RibFeature) Kind() string               { return "rib" }
-func (r *RibFeature) Recompute(Input) (Output, error) {
-	return Output{}, build.NotYetImplemented("PBI-096-rib-generation")
+
+// Operation and ToolBody let a pattern/mirror replicate this feature (see [ToolFeature]).
+func (r *RibFeature) Operation() ops.PartFeatureOperation { return r.def.Operation }
+func (r *RibFeature) ToolBody() *topo.Body                { return r.tool }
+
+func (r *RibFeature) Recompute(in Input) (Output, error) {
+	pts, err := r.pathPoints()
+	if err != nil {
+		return Output{}, err
+	}
+	if r.def.Thickness == nil || r.def.Depth == nil {
+		return Output{}, errors.New("rib: thickness and depth must be set")
+	}
+	t, d := r.def.Thickness(), r.def.Depth()
+	if t <= 0 || d == 0 {
+		return Output{}, fmt.Errorf("rib: need positive thickness and non-zero depth, got t=%g d=%g", t, d)
+	}
+	band := ensureCCW2(thickenPath(pts, t))
+	r.tool = buildPrism(band, r.def.Sketch.Plane(), orderedSpan(0, d), 0, "rib")
+	bodies, err := combine(in.Bodies, r.tool, r.def.Operation)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// pathPoints resolves the rib's open profile (a sketch path) to its ordered points.
+func (r *RibFeature) pathPoints() ([]math.Point2, error) {
+	paths := r.def.Sketch.Paths()
+	if r.def.ProfileIndex < 0 || r.def.ProfileIndex >= len(paths) {
+		return nil, fmt.Errorf("rib: path index %d out of range (%d open paths)", r.def.ProfileIndex, len(paths))
+	}
+	pts := paths[r.def.ProfileIndex].Points()
+	if len(pts) < 2 {
+		return nil, errors.New("rib: the open profile needs at least two points")
+	}
+	return pts, nil
+}
+
+// RibFeatures adds ribs into the engine.
+type RibFeatures struct{ engine *PartFeatures }
+
+// NewRibFeatures binds the collection to an engine.
+func NewRibFeatures(engine *PartFeatures) *RibFeatures { return &RibFeatures{engine} }
+
+// Add adds a rib that thickens the sketch's open profile (by index) into a wall of the given
+// thickness, extruded the signed depth along the sketch-plane normal, joined to the part.
+func (c *RibFeatures) Add(skt *sketch.Sketch, profileIndex int, thickness, depth func() float64, op ops.PartFeatureOperation) *PartFeature {
+	def := &RibDefinition{Sketch: skt, ProfileIndex: profileIndex, Thickness: thickness, Depth: depth, Operation: op}
+	pf := c.engine.Add(&RibFeature{def: def})
+	pf.SetName(c.engine.UniqueName("Rib"))
+	return pf
+}
+
+// thickenPath offsets a polyline by ±t/2 into a closed band polygon (left side forward,
+// right side back) so it can be extruded as a wall.
+func thickenPath(pts []math.Point2, t float64) []math.Point2 {
+	h := math.Scalar(t / 2)
+	n := len(pts)
+	band := make([]math.Point2, 0, 2*n)
+	for i := 0; i < n; i++ { // left side
+		band = append(band, pts[i].TranslateBy(vertexNormal2(pts, i).Scale(h)))
+	}
+	for i := n - 1; i >= 0; i-- { // right side, reversed → closed loop
+		band = append(band, pts[i].TranslateBy(vertexNormal2(pts, i).Scale(-h)))
+	}
+	return band
+}
+
+// vertexNormal2 is the unit in-plane normal at vertex i (averaged perpendicular of the
+// adjacent segments).
+func vertexNormal2(pts []math.Point2, i int) math.Vector2 {
+	var sum math.Vector2
+	if i > 0 {
+		sum = sum.Add(segNormal2(pts[i-1], pts[i]))
+	}
+	if i < len(pts)-1 {
+		sum = sum.Add(segNormal2(pts[i], pts[i+1]))
+	}
+	if l := float64(sum.Length()); l > 0 {
+		return sum.Scale(math.Scalar(1 / l))
+	}
+	return math.V2(0, 0)
+}
+
+// segNormal2 is the unit left normal of segment a→b.
+func segNormal2(a, b math.Point2) math.Vector2 {
+	d := a.VectorTo(b)
+	n := math.V2(-d.Y, d.X)
+	if l := float64(n.Length()); l > 0 {
+		return n.Scale(math.Scalar(1 / l))
+	}
+	return math.V2(0, 0)
+}
+
+// ensureCCW2 returns the polygon wound counter-clockwise (positive signed area) so the
+// prism builder gives it outward normals.
+func ensureCCW2(poly []math.Point2) []math.Point2 {
+	var area float64
+	for i := range poly {
+		j := (i + 1) % len(poly)
+		area += float64(poly[i].X*poly[j].Y - poly[j].X*poly[i].Y)
+	}
+	if area >= 0 {
+		return poly
+	}
+	rev := make([]math.Point2, len(poly))
+	for i, p := range poly {
+		rev[len(poly)-1-i] = p
+	}
+	return rev
 }

--- a/model/feature/split_solid.go
+++ b/model/feature/split_solid.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// SplitSide selects which side(s) of the cutting plane a solid split keeps: both pieces (a true
+// split into separate bodies), or only the +normal / −normal side (a Trim Solid).
+type SplitSide uint8
+
+const (
+	SplitBoth     SplitSide = iota // keep both pieces (split into bodies)
+	SplitPositive                  // keep the side the plane normal points toward (trim)
+	SplitNegative                  // keep the opposite side (trim)
+)
+
+// SplitSolidDefinition is the recipe for a solid split: a cutting work plane and which side(s)
+// to keep, re-resolved each recompute.
+type SplitSolidDefinition struct {
+	Plane *WorkPlane
+	Keep  SplitSide
+}
+
+// SplitSolidFeature divides the running solid bodies by a plane (Inventor's Split Solid / Trim
+// Solid): each solid is cut into the pieces on each side of the plane, and Keep filters them.
+type SplitSolidFeature struct{ def *SplitSolidDefinition }
+
+// Definition returns the split recipe.
+func (f *SplitSolidFeature) Definition() *SplitSolidDefinition { return f.def }
+
+// Kind implements [Feature].
+func (f *SplitSolidFeature) Kind() string { return "splitSolid" }
+
+// Recompute resolves the cutting plane and splits every running solid body by it, keeping the
+// requested side(s). A lost plane → Sick; surface (non-solid) bodies pass through unchanged.
+func (f *SplitSolidFeature) Recompute(in Input) (Output, error) {
+	if f.def.Plane == nil {
+		return Output{}, errors.New("split: no cutting plane")
+	}
+	plane, err := geomPlaneOf(f.def.Plane)
+	if err != nil {
+		return Output{}, err
+	}
+	var out []*topo.Body
+	for _, b := range in.Bodies {
+		if !b.IsSolid() {
+			out = append(out, b)
+			continue
+		}
+		pieces, err := ops.SplitSolidByPlane(b, plane)
+		if err != nil {
+			return Output{}, err
+		}
+		out = append(out, keepSplitSides(pieces, plane, f.def.Keep)...)
+	}
+	return Output{Bodies: out}, nil
+}
+
+// geomPlaneOf converts a work plane's sketch plane to a kernel plane for the split.
+func geomPlaneOf(wp *WorkPlane) (geom.Plane, error) {
+	sp := wp.Plane()
+	gp, err := geom.NewPlane(sp.Origin(), sp.Normal().AsVector())
+	if err != nil {
+		return geom.Plane{}, fmt.Errorf("split: cutting plane is degenerate: %w", err)
+	}
+	return gp, nil
+}
+
+// keepSplitSides filters the pieces by which side of the plane each piece's centroid lies on
+// (SplitBoth keeps all). Used to implement Trim Solid (keep one side).
+func keepSplitSides(pieces []*topo.Body, plane geom.Plane, keep SplitSide) []*topo.Body {
+	if keep == SplitBoth {
+		return pieces
+	}
+	var out []*topo.Body
+	for _, p := range pieces {
+		c := ops.BodyGeometryProperties(p, ops.DefaultQuality()).Centroid
+		side := float64(plane.Origin.VectorTo(c).Dot(plane.Normal()))
+		if (keep == SplitPositive && side > 0) || (keep == SplitNegative && side < 0) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// AddSplitSolid adds a feature that splits the running solids by a work plane, keeping the
+// requested side(s).
+func (c *ModifyFeatures) AddSplitSolid(plane *WorkPlane, keep SplitSide) *PartFeature {
+	pf := c.engine.Add(&SplitSolidFeature{def: &SplitSolidDefinition{Plane: plane, Keep: keep}})
+	pf.SetName(c.engine.UniqueName("Split"))
+	return pf
+}

--- a/model/feature/split_solid_test.go
+++ b/model/feature/split_solid_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/subd"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
+)
+
+// midPlaneAt builds work geometry with an XY work plane offset to z, recomputed and ready.
+func midPlaneAt(z float64) (*WorkGeometry, *WorkPlane) {
+	g := NewWorkGeometry()
+	g.Recompute(nil)
+	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return z })
+	g.Recompute(nil)
+	return g, wp
+}
+
+func boxBody() *topo.Body { return subd.ToBody(subd.Box(4, 4, 4), "box") }
+
+// A solid split by a mid work plane divides the part into two valid solids (each half-volume).
+func TestSplitSolidFeatureDividesBox(t *testing.T) {
+	_, wp := midPlaneAt(2)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(boxBody())
+	split := NewModifyFeatures(fs).AddSplitSolid(wp, SplitBoth)
+	fs.Recompute()
+
+	if !split.Health().OK() {
+		t.Fatalf("split went sick: %+v", split.Health())
+	}
+	pieces := fs.Result()
+	if len(pieces) != 2 {
+		t.Fatalf("split result = %d bodies, want 2", len(pieces))
+	}
+	for _, p := range pieces {
+		if v := ops.BodyGeometryProperties(p, ops.DefaultQuality()).Volume; stdmath.Abs(v-32) > 1e-6 {
+			t.Errorf("piece volume = %g, want 32", v)
+		}
+	}
+}
+
+// Trim Solid (keep one side) leaves a single body — the kept half.
+func TestSplitSolidFeatureTrimsOneSide(t *testing.T) {
+	_, wp := midPlaneAt(2)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(boxBody())
+	NewModifyFeatures(fs).AddSplitSolid(wp, SplitNegative) // keep below z=2
+	fs.Recompute()
+
+	pieces := fs.Result()
+	if len(pieces) != 1 {
+		t.Fatalf("trim result = %d bodies, want 1 (kept side)", len(pieces))
+	}
+	if v := ops.BodyGeometryProperties(pieces[0], ops.DefaultQuality()).Volume; stdmath.Abs(v-32) > 1e-6 {
+		t.Errorf("kept volume = %g, want 32", v)
+	}
+}
+
+// The split's plane reference and kept side round-trip through the recipe.
+func TestSplitSolidRoundTrip(t *testing.T) {
+	g, wp := midPlaneAt(2)
+	fs := NewPartFeatures(nil, nil)
+	NewModifyFeatures(fs).AddSplitSolid(wp, SplitPositive)
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, g); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*SplitSolidFeature).Definition()
+	if def.Keep != SplitPositive || def.Plane == nil || def.Plane.Key() != wp.Key() {
+		t.Errorf("restored split = keep %d plane %v, want positive + the z=2 plane", def.Keep, def.Plane)
+	}
+}

--- a/model/feature/surface_edit.go
+++ b/model/feature/surface_edit.go
@@ -79,15 +79,19 @@ func (c *TrimFeatures) AddByPlane(origin math.Point3, normal math.Vector3, keepP
 	return pf
 }
 
-// ExtendDefinition is the recipe for extending a surface edge to a distance/target.
+// ExtendDefinition is the recipe for extending a planar surface's boundary edge outward by a
+// distance (the edge held by reference key, re-resolved each recompute).
 type ExtendDefinition struct {
-	Edge     Ref
+	EdgeKey  []byte
 	Distance func() float64
 }
 
-// ExtendFeature extends a surface edge (PBI-111). The edge-to-target geometry is a
-// later kernel phase; the feature validates a target surface exists then defers.
-type ExtendFeature struct{ def *ExtendDefinition }
+// ExtendFeature extends a planar surface body's boundary edge, growing the face (PBI-111).
+// Multi-face and curved-surface extension are the remaining phase-C (NURBS) work.
+type ExtendFeature struct {
+	def      *ExtendDefinition
+	featName string
+}
 
 // Definition returns the extend recipe.
 func (e *ExtendFeature) Definition() *ExtendDefinition { return e.def }
@@ -95,12 +99,17 @@ func (e *ExtendFeature) Definition() *ExtendDefinition { return e.def }
 // Kind implements [Feature].
 func (e *ExtendFeature) Kind() string { return "extend" }
 
-// Recompute checks a target surface exists, then defers the extension geometry.
+// Recompute resolves the boundary edge and extends its face outward; a lost edge → Sick.
 func (e *ExtendFeature) Recompute(in Input) (Output, error) {
-	if _, err := lastBody(in, "extend"); err != nil {
+	body, err := lastBody(in, "extend")
+	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: in.Bodies}, ErrDeferred
+	extended, err := ops.ExtendByEdge(body, e.def.EdgeKey, callOrZero(e.def.Distance), e.featName)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceLast(in.Bodies, extended)}, nil
 }
 
 // ExtendFeatures adds extend features into the engine.
@@ -109,9 +118,12 @@ type ExtendFeatures struct{ engine *PartFeatures }
 // NewExtendFeatures binds the collection to a feature engine.
 func NewExtendFeatures(engine *PartFeatures) *ExtendFeatures { return &ExtendFeatures{engine: engine} }
 
-// Add extends the edge by distance toward a target (geometry deferred to phase C).
-func (c *ExtendFeatures) Add(edge Ref, distance func() float64) *PartFeature {
-	return c.engine.Add(&ExtendFeature{def: &ExtendDefinition{Edge: edge, Distance: distance}})
+// Add extends the boundary edge (by reference key) outward by distance.
+func (c *ExtendFeatures) Add(edgeKey []byte, distance func() float64) *PartFeature {
+	ef := &ExtendFeature{def: &ExtendDefinition{EdgeKey: edgeKey, Distance: distance}, featName: "Extend"}
+	pf := c.engine.Add(ef)
+	ef.featName = pf.name
+	return pf
 }
 
 // SurfaceOffsetDefinition is the recipe for a surface offset: the distance along the

--- a/model/feature/surface_edit_test.go
+++ b/model/feature/surface_edit_test.go
@@ -40,17 +40,37 @@ func TestTrimFeatureGoesSickWhenNothingKept(t *testing.T) {
 	}
 }
 
-func TestExtendFeatureDefers(t *testing.T) {
+func TestExtendFeatureGrowsSurface(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	patchSurface(fs) // 4×4 patch on z=0
+	fs.Recompute()
+	var key []byte // the bottom boundary edge (both endpoints at y=0)
+	for _, e := range fs.Result()[0].Edges() {
+		if e.StartVertex().Point().Y == 0 && e.EndVertex().Point().Y == 0 {
+			key = e.ReferenceKey()
+		}
+	}
+	if key == nil {
+		t.Fatal("no bottom edge on the patch")
+	}
+	pf := NewExtendFeatures(fs).Add(key, func() float64 { return 2 })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("extend went sick: %+v", pf.Health())
+	}
+	box := fs.Result()[0].RangeBox()
+	if !approxEq(box.Min.Y, -2) || !approxEq(box.Max.Y, 4) {
+		t.Errorf("extended y-span = [%v,%v], want [-2,4]", box.Min.Y, box.Max.Y)
+	}
+}
+
+func TestExtendFeatureSickOnLostEdge(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	patchSurface(fs)
-	pf := NewExtendFeatures(fs).Add(Ref{}, func() float64 { return 2 })
+	NewExtendFeatures(fs).Add([]byte("ghost"), func() float64 { return 2 })
 	fs.Recompute()
-	if pf.Health().Status != health.Warning {
-		t.Errorf("extend = %v, want warning (geometry deferred)", pf.Health().Status)
-	}
-	// The target surface passes through unchanged.
-	if len(fs.Result()) != 1 {
-		t.Errorf("extend passthrough has %d bodies, want 1", len(fs.Result()))
+	if fs.Item(fs.Count()-1).Health().Status != health.Sick {
+		t.Error("extend on a lost edge should be sick")
 	}
 }
 

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
+	"github.com/Oblikovati/oblikovati/kernel/topo"
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 )
@@ -32,10 +33,16 @@ type SweepDefinition struct {
 type SweepFeature struct {
 	def      *SweepDefinition
 	featName string
+	tool     *topo.Body // last swept solid, exposed so a pattern can replicate this feature
 }
 
 func (s *SweepFeature) Definition() *SweepDefinition { return s.def }
 func (s *SweepFeature) Kind() string                 { return "sweep" }
+
+// Operation and ToolBody expose this feature's boolean op and tool so a pattern/mirror can
+// replicate it correctly (cut/join the swept solid at each occurrence) — see [ToolFeature].
+func (s *SweepFeature) Operation() ops.PartFeatureOperation { return s.def.Operation }
+func (s *SweepFeature) ToolBody() *topo.Body                { return s.tool }
 
 // Recompute resolves the profile, places it along the path tangents into a faceted
 // solid, and applies the operation against the running bodies.
@@ -48,11 +55,11 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 		return Output{}, errors.New("sweep: path needs at least two points")
 	}
 	sections := sweepSections(prof, s.def.Sketch.Plane(), s.def.Path.Points(), callOrZero(s.def.Twist))
-	tool, err := sweptSolid(sections, s.def.Path.IsClosed(), featOr(s.featName, "sweep"))
+	s.tool, err = sweptSolid(sections, s.def.Path.IsClosed(), featOr(s.featName, "sweep"))
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, tool, s.def.Operation)
+	bodies, err := combine(in.Bodies, s.tool, s.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -141,10 +148,16 @@ type LoftDefinition struct {
 type LoftFeature struct {
 	def      *LoftDefinition
 	featName string
+	tool     *topo.Body // last lofted solid, exposed so a pattern can replicate this feature
 }
 
 func (l *LoftFeature) Definition() *LoftDefinition { return l.def }
 func (l *LoftFeature) Kind() string                { return "loft" }
+
+// Operation and ToolBody expose this feature's boolean op and tool so a pattern/mirror can
+// replicate it correctly (cut/join the lofted solid at each occurrence) — see [ToolFeature].
+func (l *LoftFeature) Operation() ops.PartFeatureOperation { return l.def.Operation }
+func (l *LoftFeature) ToolBody() *topo.Body                { return l.tool }
 
 // Recompute resolves each section profile, resamples them to a common point count, and
 // blends them into a faceted solid.
@@ -153,11 +166,11 @@ func (l *LoftFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	tool, err := sweptSolid(sections, l.def.Closed, featOr(l.featName, "loft"))
+	l.tool, err = sweptSolid(sections, l.def.Closed, featOr(l.featName, "loft"))
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, tool, l.def.Operation)
+	bodies, err := combine(in.Bodies, l.tool, l.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/swept.go
+++ b/model/feature/swept.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"fmt"
+	stdmath "math"
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/kernel/subd"
@@ -74,13 +75,40 @@ func sectionMesh(sections [][]math.Point3, closedLoop bool) subd.Mesh {
 		ns := (s + 1) % k
 		for i := 0; i < n; i++ {
 			j := (i + 1) % n
-			faces = append(faces, []int{s*n + i, s*n + j, ns*n + j, ns*n + i})
+			a, b, c, d := s*n+i, s*n+j, ns*n+j, ns*n+i
+			faces = append(faces, sideQuad(verts, a, b, c, d)...)
 		}
 	}
 	if !closedLoop {
 		faces = append(faces, reversedRow(0, n), row(k-1, n))
 	}
 	return subd.Mesh{Verts: verts, Faces: faces}
+}
+
+// sideQuad emits a side face between two sections as a single quad when its four corners are
+// coplanar, or as two triangles when they are not. A twisted/lofted side is a warped (ruled,
+// non-planar) quad; left as one face the cage→B-rep converter fits it to an APPROXIMATING plane,
+// so the planar boolean's imprint segments land offset from the body's true edges and an imprint
+// loop fails to close (a partial-penetration union goes non-manifold — the deformed fan blade).
+// Splitting a warped quad into exact-planar triangles restores the planar-faceted invariant the
+// boolean relies on. (Twisted-loft boolean defect, 2026-06.)
+func sideQuad(verts []math.Point3, a, b, c, d int) [][]int {
+	if quadPlanar(verts[a], verts[b], verts[c], verts[d]) {
+		return [][]int{{a, b, c, d}}
+	}
+	return [][]int{{a, b, c}, {a, c, d}}
+}
+
+// quadPlanar reports whether the four corners lie in a common plane, within a tight absolute
+// tolerance (below the arrangement's weld grid, 1e-7, so any quad the boolean would mis-imprint
+// is triangulated). The deviation is the out-of-plane distance of d from the plane through a,b,c.
+func quadPlanar(a, b, c, d math.Point3) bool {
+	nrm := a.VectorTo(b).Cross(a.VectorTo(c))
+	mag := nrm.Length()
+	if mag < 1e-12 {
+		return true // a,b,c are collinear: no plane to deviate from (caller's quad is degenerate)
+	}
+	return stdmath.Abs(a.VectorTo(d).Dot(nrm)/mag) < 1e-8
 }
 
 // row returns the vertex indices of section s in order; reversedRow reverses them (the

--- a/model/feature/toolfeature_test.go
+++ b/model/feature/toolfeature_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/ops"
+)
+
+// Every boolean (material-changing) feature must expose its tool and operation via
+// [ToolFeature], so a pattern/mirror replicates it correctly — re-applying the source's
+// cut/join at each occurrence instead of copying the whole body (the bug that split a
+// patterned hole/blade into N solids). These compile-time assertions fail the build if any
+// loses the contract; the runtime replication itself is covered by the extrude pattern tests
+// (TestPatternOfCutKeepsOneBody / TestPatternOfJoinMergesIntoOneBody) and the fan loft e2e.
+var (
+	_ ToolFeature = (*ExtrudeFeature)(nil)
+	_ ToolFeature = (*RevolveFeature)(nil)
+	_ ToolFeature = (*CoilFeature)(nil)
+	_ ToolFeature = (*RibFeature)(nil)
+	_ ToolFeature = (*EmbossFeature)(nil)
+	_ ToolFeature = (*LoftFeature)(nil)
+	_ ToolFeature = (*SweepFeature)(nil)
+	_ ToolFeature = (*HoleFeature)(nil) // a hole caches its drill cylinder as the replicable tool
+)
+
+// Boss geometry still defers, so it has no tool body yet, but it must still report its operation
+// so a pattern of a boss is treated as a (currently empty) join rather than a whole-body copy.
+var _ OperationalFeature = (*BossFeature)(nil)
+
+// TestEveryBooleanFeatureExposesItsTool documents the contract above at test time too: each
+// listed feature reports its operation through OperationalFeature (extrude here as the
+// reference), so operationOf resolves it for the pattern engine rather than defaulting to a
+// new-body copy.
+func TestEveryBooleanFeatureExposesItsTool(t *testing.T) {
+	var f Feature = &ExtrudeFeature{def: &ExtrudeDefinition{Operation: ops.Cut}}
+	tf, ok := f.(ToolFeature)
+	if !ok {
+		t.Fatal("ExtrudeFeature must implement ToolFeature")
+	}
+	if tf.Operation() != ops.Cut {
+		t.Errorf("Operation() = %v, want Cut", tf.Operation())
+	}
+}

--- a/model/feature/work_surface_ref.go
+++ b/model/feature/work_surface_ref.go
@@ -29,8 +29,20 @@ func (g *WorkGeometry) facePlane(ref WorkRef) (sketch.Plane, bool, error) {
 	if !ok {
 		return sketch.Plane{}, true, fmt.Errorf("work geometry: face %q is not planar", ref)
 	}
-	sp, err := sketch.NewPlane(pl.Origin, pl.UAxis, pl.VAxis)
+	// Origin the plane at the part origin projected onto it (Inventor's sketch-on-face
+	// convention), not the surface's parametric origin — which for an extruded/tessellated cap
+	// sits at a rim vertex, so a sketch on the plane would be positioned 2D-(0,0) at the rim
+	// (geometry placed there lands off the body). The projection keeps the in-plane axes.
+	sp, err := sketch.NewPlane(projectOntoPlane(math.P3(0, 0, 0), pl), pl.UAxis, pl.VAxis)
 	return sp, true, err
+}
+
+// projectOntoPlane returns the foot of the perpendicular from p to the plane pl (p moved
+// along the plane normal until it lies on the plane).
+func projectOntoPlane(p math.Point3, pl geom.Plane) math.Point3 {
+	n := pl.Normal()
+	dist := p.VectorTo(pl.Origin).Dot(n)
+	return p.TranslateBy(n.Scale(dist))
 }
 
 // Surface-tangent work planes are built on a B-rep face the user picked, not on

--- a/model/feature/work_surface_ref_test.go
+++ b/model/feature/work_surface_ref_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// TestProjectOntoPlaneUsesPartOrigin: a sketch plane on a face is origined at the part origin
+// projected onto the face, not the face surface's parametric origin. A planar surface whose
+// origin sits at a rim point (3,0,1) must still project the world origin to the centre (0,0,1)
+// — so a sketch on the plane is positioned relative to the part frame, not an arbitrary corner.
+// (Regression: the work-plane-on-face origin landed on a rim vertex, placing geometry off the body.)
+func TestProjectOntoPlaneUsesPartOrigin(t *testing.T) {
+	pl, err := geom.NewPlane(math.P3(3, 0, 1), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	got := projectOntoPlane(math.P3(0, 0, 0), pl)
+	if !got.IsEqualTo(math.P3(0, 0, 1), 1e-9) {
+		t.Errorf("projected origin = %v, want the disc centre (0,0,1)", got)
+	}
+
+	// An off-axis world point projects to its foot on the plane (the normal component removed).
+	if got := projectOntoPlane(math.P3(2, -1, 9), pl); !got.IsEqualTo(math.P3(2, -1, 1), 1e-9) {
+		t.Errorf("projection = %v, want (2,-1,1)", got)
+	}
+}

--- a/model/sketch/auto_dimension.go
+++ b/model/sketch/auto_dimension.go
@@ -2,31 +2,112 @@
 
 package sketch
 
-import "github.com/Oblikovati/oblikovati/math"
+import (
+	"fmt"
 
-// AutoDimension fully constrains the sketch by grounding its under-constrained geometry in
-// insertion order until 0 DOF remains (Inventor's Auto Dimension reaching a fully-defined
-// sketch). It returns the number of ground constraints it added. A sketch that is already
-// fully constrained adds nothing.
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// AutoDimension fully constrains the sketch (Inventor's Auto Dimension): it greedily adds
+// constraints — real length/radius dimensions first, then point grounds to anchor the
+// rest — until 0 DOF remains. Each candidate is accepted only if it strictly reduces the
+// DOF *without* introducing redundancy, so the result is **well-constrained, never
+// over-constrained** (unlike grounding whole entities, which double-fixes shared points).
+// It returns the number of constraints added; an already-constrained sketch adds nothing.
 func (s *Sketch) AutoDimension() int {
-	count := 0
-	for _, e := range s.Entities() {
-		if s.DegreesOfFreedom() == 0 {
-			break
+	added := 0
+	for s.DegreesOfFreedom() > 0 {
+		if !s.applyOneAutoCandidate() {
+			break // no candidate can reduce DOF further without redundancy
 		}
-		if isAnnotation(e) {
-			continue
-		}
-		s.GeometricConstraints().AddGround(e)
-		count++
+		added++
 	}
-	return count
+	return added
 }
 
-// isAnnotation reports whether an entity carries no constrainable points (image/fill/text/
-// derived curves) and so cannot be grounded.
-func isAnnotation(e Entity) bool {
-	return len(entityPoints(e)) == 0
+// applyOneAutoCandidate adds the first candidate that strictly lowers DOF without adding
+// redundancy, returning whether one was applied. Candidates are trial-added and undone if
+// they don't help (the rank analysis is non-mutating, so trials don't move geometry).
+func (s *Sketch) applyOneAutoCandidate() bool {
+	before := s.AnalyzeConstraints()
+	for _, add := range s.autoCandidates() {
+		undo := add()
+		after := s.AnalyzeConstraints()
+		if after.DOF < before.DOF && after.Redundant <= before.Redundant {
+			return true
+		}
+		undo()
+	}
+	return false
+}
+
+// autoCandidates lists the constraints AutoDimension may add, each as an add→undo pair:
+// length dimensions on lines, radius dimensions on circles/arcs, then a ground per unique
+// point to anchor any remaining (translational/positional) freedom.
+func (s *Sketch) autoCandidates() []func() func() {
+	dc := s.DimensionConstraints()
+	var cs []func() func()
+	for _, e := range s.Entities() {
+		switch g := e.(type) {
+		case *Line:
+			line := g
+			cs = append(cs, dimCandidate(func() (*DimensionConstraint, error) {
+				return dc.AddDistance(line.A, line.B, lengthExpr(line.A.Position().DistanceTo(line.B.Position())))
+			}, dc))
+		case *Circle:
+			circ := g
+			cs = append(cs, dimCandidate(func() (*DimensionConstraint, error) {
+				return dc.AddRadius(circ, lengthExpr(circ.Radius))
+			}, dc))
+		case *Arc:
+			arc := g
+			cs = append(cs, dimCandidate(func() (*DimensionConstraint, error) {
+				return dc.AddDistance(arc.Center, arc.Start, lengthExpr(arc.Radius()))
+			}, dc))
+		}
+	}
+	for _, p := range s.uniqueEntityPoints() {
+		p := p
+		cs = append(cs, func() func() {
+			g := s.GeometricConstraints().AddGroundPoints(p)
+			return func() { s.GeometricConstraints().Delete(g) }
+		})
+	}
+	return cs
+}
+
+// dimCandidate wraps a dimension factory as an add→undo pair (a failed add is a no-op
+// candidate that the caller rejects via the unchanged DOF).
+func dimCandidate(add func() (*DimensionConstraint, error), dc *DimensionConstraints) func() func() {
+	return func() func() {
+		d, err := add()
+		if err != nil {
+			return func() {}
+		}
+		return func() { dc.Delete(d) }
+	}
+}
+
+// uniqueEntityPoints returns each distinct constrainable point referenced by the sketch's
+// entities, in first-seen order.
+func (s *Sketch) uniqueEntityPoints() []*Point {
+	seen := map[*Point]bool{}
+	var out []*Point
+	for _, e := range s.Entities() {
+		for _, p := range entityPoints(e) {
+			if !seen[p] {
+				seen[p] = true
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+// lengthExpr formats a database-unit (cm) length as a dimension expression at full
+// precision, so a dimension placed by AutoDimension pins the current geometry exactly.
+func lengthExpr(cm math.Scalar) string {
+	return fmt.Sprintf("%.12g cm", float64(cm))
 }
 
 // OffsetChain offsets a connected chain of lines (given in order, end-to-start) by signed

--- a/model/sketch/auto_dimension_test.go
+++ b/model/sketch/auto_dimension_test.go
@@ -33,6 +33,65 @@ func TestAutoDimensionIdempotentWhenFull(t *testing.T) {
 	}
 }
 
+// The improvement over grounding whole entities: AutoDimension leaves the sketch
+// WELL-constrained (0 DOF, no redundancy), never over-constrained.
+func TestAutoDimensionIsWellConstrainedNotRedundant(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 3))
+	s.AutoDimension()
+	a := s.AnalyzeConstraints()
+	if a.DOF != 0 || a.Redundant != 0 || a.Status != WellConstrained {
+		t.Fatalf("after AutoDimension: DOF=%d Redundant=%d Status=%v, want 0/0/WellConstrained", a.DOF, a.Redundant, a.Status)
+	}
+}
+
+// AutoDimension prefers real, editable dimensions (not only grounds).
+func TestAutoDimensionAddsRealDimensions(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 3))
+	s.AutoDimension()
+	if s.DimensionConstraints().Count() == 0 {
+		t.Error("AutoDimension added no dimensions (should place length dims, not only grounds)")
+	}
+}
+
+// A free circle (center + radius = 3 DOF) auto-dimensions to a well-constrained sketch
+// including a radius dimension.
+func TestAutoDimensionCircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.Circles().AddByCenterRadius(gmath.P2(1, 2), 2)
+	s.AutoDimension()
+	a := s.AnalyzeConstraints()
+	if a.DOF != 0 || a.Redundant != 0 {
+		t.Fatalf("circle AutoDimension: DOF=%d Redundant=%d, want 0/0", a.DOF, a.Redundant)
+	}
+	if s.DimensionConstraints().Count() == 0 {
+		t.Error("expected a radius dimension on the circle")
+	}
+}
+
+// Dimensions are placed at current values, so auto-dimensioning then solving does not move
+// the geometry.
+func TestAutoDimensionPreservesGeometry(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 3))
+	s.AutoDimension()
+	s.Solve()
+	if !pointAt(s, gmath.P2(4, 3)) {
+		t.Error("AutoDimension + Solve moved the geometry; (4,3) corner is gone")
+	}
+}
+
+// pointAt reports whether any constrainable point sits at q.
+func pointAt(s *Sketch, q gmath.Point2) bool {
+	for _, p := range s.uniqueEntityPoints() {
+		if math.Abs(float64(p.X)-float64(q.X)) < 1e-6 && math.Abs(float64(p.Y)-float64(q.Y)) < 1e-6 {
+			return true
+		}
+	}
+	return false
+}
+
 func TestOffsetChainStaysConnected(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	// An L: (0,0)→(4,0)→(4,3), sharing the corner (4,0).

--- a/model/sketch/centerline_test.go
+++ b/model/sketch/centerline_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+// squareSk draws a side×side square (a closed region) on the sketch.
+func squareSk(s *Sketch, side float64) {
+	a := s.Points().Add(gmath.P2(0, 0))
+	b := s.Points().Add(gmath.P2(gmath.Scalar(side), 0))
+	c := s.Points().Add(gmath.P2(gmath.Scalar(side), gmath.Scalar(side)))
+	d := s.Points().Add(gmath.P2(0, gmath.Scalar(side)))
+	s.Lines().Add(a, b)
+	s.Lines().Add(b, c)
+	s.Lines().Add(c, d)
+	s.Lines().Add(d, a)
+}
+
+// A centerline (like any construction geometry) is excluded from profiles, so a midline drawn
+// as a centerline does NOT split the region.
+func TestCenterlineDoesNotCloseProfile(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	squareSk(s, 4)
+	if got := s.Profiles().Count(); got != 1 {
+		t.Fatalf("square = %d profiles, want 1", got)
+	}
+	cl := s.Lines().AddByTwoPoints(gmath.P2(0, 2), gmath.P2(4, 2)) // midline
+	cl.SetCenterline(true)
+	if !cl.IsConstruction() {
+		t.Error("a centerline must be construction geometry")
+	}
+	if got := s.Profiles().Count(); got != 1 {
+		t.Errorf("centerline split the region into %d profiles, want 1 (it must not close paths)", got)
+	}
+}
+
+// Control: the SAME midline as ordinary geometry DOES split the square into two regions —
+// confirming the centerline exclusion above is what keeps it whole.
+func TestNormalMidlineSplitsProfile(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	squareSk(s, 4)
+	s.Lines().AddByTwoPoints(gmath.P2(0, 2), gmath.P2(4, 2))
+	if got := s.Profiles().Count(); got != 2 {
+		t.Errorf("normal midline gave %d regions, want 2", got)
+	}
+}
+
+// A centerline is reported by Centerlines() and yields a model-space axis for revolve/mirror.
+func TestCenterlineAxisAndAccessor(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	cl := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(0, 4)) // vertical (Y) axis
+	cl.SetCenterline(true)
+	if len(s.Centerlines()) != 1 {
+		t.Fatalf("Centerlines() = %d, want 1", len(s.Centerlines()))
+	}
+	o, dir := cl.Axis3D(XYPlane())
+	if !o.IsEqualTo(gmath.P3(0, 0, 0), 1e-9) {
+		t.Errorf("axis origin = %v, want (0,0,0)", o)
+	}
+	if float64(dir.X) != 0 || float64(dir.Y) != 4 || float64(dir.Z) != 0 {
+		t.Errorf("axis dir = %v, want (0,4,0)", dir)
+	}
+}
+
+// A centerline drives a sketch mirror (MirrorEntities already reflects across a *Line).
+func TestMirrorAcrossCenterline(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	cl := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(0, 4)) // mirror about the Y axis (x=0)
+	cl.SetCenterline(true)
+	src := s.Lines().AddByTwoPoints(gmath.P2(2, 1), gmath.P2(3, 1))
+	mirrored := s.MirrorEntities([]Entity{src}, cl)
+	if len(mirrored) != 1 {
+		t.Fatalf("mirror produced %d entities, want 1", len(mirrored))
+	}
+	ln := mirrored[0].(*Line)
+	if float64(ln.A.Position().X) != -2 || float64(ln.B.Position().X) != -3 {
+		t.Errorf("mirrored x = (%v,%v), want (-2,-3)", ln.A.Position().X, ln.B.Position().X)
+	}
+}
+
+func TestCenterlineRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	cl := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(5, 0))
+	cl.SetCenterline(true)
+	out := roundTrip(t, sc)
+	cls := out.Centerlines()
+	if len(cls) != 1 || !cls[0].IsConstruction() {
+		t.Errorf("after round trip: %d centerlines (want 1, construction)", len(cls))
+	}
+}

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -135,6 +135,20 @@ func (dc *DimensionConstraints) All() []*DimensionConstraint {
 func (dc *DimensionConstraints) Count() int                      { return len(dc.items) }
 func (dc *DimensionConstraints) Item(i int) *DimensionConstraint { return dc.items[i] }
 
+// Delete removes a dimension and its backing parameter (used when the user deletes a
+// dimension and by AutoDimension's rank trials). Returns whether it was present. The
+// parameter is just-created with no dependents in the trial case, so its removal is safe.
+func (dc *DimensionConstraints) Delete(d *DimensionConstraint) bool {
+	for i, x := range dc.items {
+		if x == d {
+			dc.items = append(dc.items[:i], dc.items[i+1:]...)
+			_ = dc.params.Delete(d.param.ID())
+			return true
+		}
+	}
+	return false
+}
+
 // AddDistance dimensions the distance between two points to expression (e.g. "25 mm").
 func (dc *DimensionConstraints) AddDistance(a, b *Point, expression string) (*DimensionConstraint, error) {
 	measure := func() float64 { return a.Position().DistanceTo(b.Position()) }

--- a/model/sketch/edit_ops.go
+++ b/model/sketch/edit_ops.go
@@ -72,6 +72,60 @@ func (s *Sketch) MirrorEntities(ents []Entity, line *Line) []Entity {
 	return s.cloneEntities(ents, reflection(line.A.Position(), d))
 }
 
+// MovePoints translates a specific set of points by v — the primitive behind Stretch,
+// which moves only the selected vertices and leaves the rest, deforming the geometry that
+// shares them (a line with one endpoint stretched grows/angles). A point is moved once
+// even if listed twice; nil entries are skipped.
+func (s *Sketch) MovePoints(pts []*Point, v math.Vector2) {
+	seen := map[*Point]bool{}
+	for _, p := range pts {
+		if p == nil || seen[p] {
+			continue
+		}
+		p.SetPosition(p.Position().TranslateBy(v))
+		seen[p] = true
+	}
+}
+
+// ScaleEntities scales a selection in place about center by factor, enlarging both the
+// point positions and the explicit radii of circles/ellipses (arc radii follow their
+// points automatically). A non-positive factor is rejected as a no-op. Scale is not an
+// affine2 (which is rigid/reflection only — it would not touch the radius fields).
+func (s *Sketch) ScaleEntities(ents []Entity, center math.Point2, factor float64) {
+	if factor <= 0 {
+		return
+	}
+	seen := map[*Point]bool{}
+	for _, e := range ents {
+		for _, p := range entityPoints(e) {
+			if !seen[p] {
+				p.SetPosition(scaleAbout(center, p.Position(), factor))
+				seen[p] = true
+			}
+		}
+		scaleEntityRadius(e, factor)
+	}
+}
+
+// scaleAbout returns p scaled by f about center.
+func scaleAbout(center, p math.Point2, f float64) math.Point2 {
+	return math.P2(center.X+math.Scalar(f)*(p.X-center.X), center.Y+math.Scalar(f)*(p.Y-center.Y))
+}
+
+// scaleEntityRadius scales the explicit radius fields not derived from points.
+func scaleEntityRadius(e Entity, f float64) {
+	switch v := e.(type) {
+	case *Circle:
+		v.Radius *= math.Scalar(f)
+	case *Ellipse:
+		v.MajorRadius *= math.Scalar(f)
+		v.MinorRadius *= math.Scalar(f)
+	case *EllipticalArc:
+		v.MajorRadius *= math.Scalar(f)
+		v.MinorRadius *= math.Scalar(f)
+	}
+}
+
 // transformInPlace applies a to the unique points of the selection (and any ellipse axis
 // directions), mutating the existing geometry.
 func (s *Sketch) transformInPlace(ents []Entity, a affine2) {

--- a/model/sketch/edit_ops_scale_test.go
+++ b/model/sketch/edit_ops_scale_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"math"
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+// Scaling a circle about the origin scales both its center position and its radius.
+func TestScaleEntitiesScalesPointsAndRadius(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	c := s.Circles().AddByCenterRadius(gmath.P2(2, 0), 1)
+	s.ScaleEntities([]Entity{c}, gmath.P2(0, 0), 2)
+	if !c.Center.Position().IsEqualTo(gmath.P2(4, 0), 1e-9) {
+		t.Errorf("center = %v, want (4,0)", c.Center.Position())
+	}
+	if math.Abs(float64(c.Radius)-2) > 1e-9 {
+		t.Errorf("radius = %v, want 2", c.Radius)
+	}
+}
+
+// Scaling a line scales its endpoint positions about the center.
+func TestScaleEntitiesScalesLine(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(1, 0), gmath.P2(2, 0))
+	s.ScaleEntities([]Entity{l}, gmath.P2(0, 0), 3)
+	if !l.A.Position().IsEqualTo(gmath.P2(3, 0), 1e-9) || !l.B.Position().IsEqualTo(gmath.P2(6, 0), 1e-9) {
+		t.Errorf("line = %v→%v, want (3,0)→(6,0)", l.A.Position(), l.B.Position())
+	}
+}
+
+// A non-positive factor is rejected as a no-op.
+func TestScaleEntitiesNonPositiveIsNoop(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	c := s.Circles().AddByCenterRadius(gmath.P2(2, 0), 1)
+	s.ScaleEntities([]Entity{c}, gmath.P2(0, 0), 0)
+	if !c.Center.Position().IsEqualTo(gmath.P2(2, 0), 1e-9) || math.Abs(float64(c.Radius)-1) > 1e-9 {
+		t.Error("zero factor should leave geometry unchanged")
+	}
+}
+
+// MovePoints (the Stretch primitive) moves only the listed vertices, deforming geometry
+// that shares them: stretching one line endpoint leaves the other fixed.
+func TestMovePointsMovesOnlySelected(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+	s.MovePoints([]*Point{l.B}, gmath.V2(0, 3))
+	if !l.A.Position().IsEqualTo(gmath.P2(0, 0), 1e-9) {
+		t.Errorf("A moved to %v, want it fixed at (0,0)", l.A.Position())
+	}
+	if !l.B.Position().IsEqualTo(gmath.P2(4, 3), 1e-9) {
+		t.Errorf("B = %v, want (4,3)", l.B.Position())
+	}
+}

--- a/model/sketch/edit_trim.go
+++ b/model/sketch/edit_trim.go
@@ -26,7 +26,7 @@ func (s *Sketch) SplitLine(l *Line, pick math.Point2) ([]Entity, error) {
 // with other lines (the most common case; curve intersections are a follow-up). Returns
 // the surviving line(s). If pick lies before any intersection, an end stub is removed.
 func (s *Sketch) TrimLine(l *Line, pick math.Point2) ([]Entity, error) {
-	cuts := append([]float64{0, 1}, s.lineCrossings(l)...)
+	cuts := append([]float64{0, 1}, s.lineEntityCrossings(l)...)
 	sort.Float64s(cuts)
 	cuts = dedupeSorted(cuts)
 	lo, hi, ok := bracketParam(cuts, projectParamOnLine(l, pick))
@@ -41,7 +41,7 @@ func (s *Sketch) reshapeTrimmed(l *Line, lo, hi float64) []Entity {
 	a, b := l.A.Position(), l.B.Position()
 	switch {
 	case lo <= 1e-9 && hi >= 1-1e-9: // whole line removed
-		s.removeEntity(l)
+		s.deleteEntity(l)
 		return nil
 	case lo <= 1e-9: // trim the front: keep [hi, 1]
 		l.A = s.newPoint(lerp(a, b, hi))
@@ -71,36 +71,24 @@ func (s *Sketch) ExtendLine(l *Line, atEnd bool) (*Line, error) {
 	return l, nil
 }
 
-// lineCrossings returns the parameters in (0,1) along l where it crosses another line.
-func (s *Sketch) lineCrossings(l *Line) []float64 {
-	var out []float64
-	for _, e := range s.ents {
-		m, ok := e.(*Line)
-		if !ok || m == l {
-			continue
-		}
-		if t, u, ok := lineLineParams(l, m); ok && u > -1e-9 && u < 1+1e-9 && t > 1e-9 && t < 1-1e-9 {
-			out = append(out, t)
-		}
-	}
-	return out
-}
-
 // nearestExtension returns the closest intersection of l's infinite support with another
-// line, lying beyond the picked end.
+// line, circle or arc, lying beyond the picked end. (Crossings are found via the kernel
+// 2D intersection primitives in edit_trim_curves.go.)
 func (s *Sketch) nearestExtension(l *Line, atEnd bool) (math.Point2, bool) {
+	support, err := entityLine2d(l)
+	if err != nil {
+		return math.Point2{}, false
+	}
 	bestT, found := 0.0, false
 	for _, e := range s.ents {
-		m, ok := e.(*Line)
-		if !ok || m == l {
+		if e == Entity(l) {
 			continue
 		}
-		t, u, ok := lineLineParams(l, m)
-		if !ok || u < -1e-9 || u > 1+1e-9 {
-			continue
-		}
-		if beyond := pickBeyond(t, atEnd); beyond && (!found || closerParam(t, bestT, atEnd)) {
-			bestT, found = t, true
+		for _, p := range supportEntityHits(support, e) {
+			t := projectParamOnLine(l, p)
+			if pickBeyond(t, atEnd) && (!found || closerParam(t, bestT, atEnd)) {
+				bestT, found = t, true
+			}
 		}
 	}
 	return lerpLine(l, bestT), found

--- a/model/sketch/edit_trim_curve_targets.go
+++ b/model/sketch/edit_trim_curve_targets.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+	stdmath "math"
+	"sort"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// Trimming a circle or arc as the target (not just a cutting curve). A circle trimmed at
+// its crossings becomes the complementary arc; an arc trimmed at its crossings keeps the
+// remaining arc(s). Crossing geometry reuses the kernel 2D intersection primitives.
+
+// circleEntityHits returns the points where circle cc crosses every entity except exclude.
+func (s *Sketch) circleEntityHits(cc geom.Circle2d, exclude Entity) []math.Point2 {
+	var out []math.Point2
+	for _, e := range s.ents {
+		if e == exclude {
+			continue
+		}
+		switch g := e.(type) {
+		case *Line:
+			out = append(out, geom.SegmentCircle2dIntersection(entitySegment2d(g), cc, 0)...)
+		case *Circle:
+			out = append(out, geom.Circle2dCircle2dIntersection(cc, entityCircle2d(g), 0)...)
+		case *Arc:
+			out = append(out, arcFilter(entityArc2d(g), geom.Circle2dCircle2dIntersection(cc, arcCircle(g), 0))...)
+		}
+	}
+	return out
+}
+
+// TrimCircle removes the picked arc of the circle (the gap between the two crossings
+// bracketing the pick) and replaces the circle with the complementary arc. It needs at
+// least two crossings; otherwise the closed circle cannot be opened.
+func (s *Sketch) TrimCircle(c *Circle, pick math.Point2) ([]Entity, error) {
+	center := c.Center.Position()
+	var angs []float64
+	for _, p := range s.circleEntityHits(entityCircle2d(c), Entity(c)) {
+		angs = append(angs, wrap2pi(angleOfPoint(center, p)))
+	}
+	sort.Float64s(angs)
+	angs = dedupeSorted(angs)
+	if len(angs) < 2 {
+		return nil, fmt.Errorf("trim: a circle needs at least two crossings to open, found %d", len(angs))
+	}
+	lo, hi := circularBracket(angs, wrap2pi(angleOfPoint(center, pick)))
+	r := c.Radius
+	// Removed gap is lo→hi CCW; the kept arc is its complement, hi→lo CCW.
+	arc := s.arcs.AddByCenterStartEnd(center, pointAtAngle(center, r, hi), pointAtAngle(center, r, lo), true)
+	s.deleteEntity(c)
+	return []Entity{arc}, nil
+}
+
+// TrimArc removes the picked sub-arc (between adjacent crossings, with the arc's own ends
+// as boundaries) and keeps the remaining arc(s) — one when an end stub is removed, two
+// when an interior bite is taken.
+func (s *Sketch) TrimArc(a *Arc, pick math.Point2) ([]Entity, error) {
+	arc := entityArc2d(a)
+	cuts := []float64{0, 1}
+	for _, p := range s.circleEntityHits(arcCircle(a), Entity(a)) {
+		if t, ok := arcParamOf(arc, p); ok && t > 1e-9 && t < 1-1e-9 {
+			cuts = append(cuts, t)
+		}
+	}
+	sort.Float64s(cuts)
+	cuts = dedupeSorted(cuts)
+	pt, _ := arcParamOf(arc, pick)
+	lo, hi, ok := bracketParam(cuts, pt)
+	if !ok {
+		return nil, fmt.Errorf("trim: no arc segment found for the pick point (t=%.4g)", pt)
+	}
+	return s.reshapeTrimmedArc(a, arc, lo, hi), nil
+}
+
+// reshapeTrimmedArc rebuilds arc a with the [lo, hi] parameter span removed.
+func (s *Sketch) reshapeTrimmedArc(a *Arc, arc geom.Arc2d, lo, hi float64) []Entity {
+	switch {
+	case lo <= 1e-9 && hi >= 1-1e-9: // whole arc removed
+		s.deleteEntity(a)
+		return nil
+	case lo <= 1e-9: // trim the front: keep [hi, 1]
+		a.Start = s.newPoint(arc.PointAt(hi))
+		return []Entity{a}
+	case hi >= 1-1e-9: // trim the tail: keep [0, lo]
+		a.End = s.newPoint(arc.PointAt(lo))
+		return []Entity{a}
+	default: // interior bite: keep [0, lo] and [hi, 1]
+		end := a.End.Position()
+		tail := s.arcs.AddByCenterStartEnd(a.Center.Position(), arc.PointAt(hi), end, a.CounterClockwise)
+		a.End = s.newPoint(arc.PointAt(lo))
+		return []Entity{a, tail}
+	}
+}
+
+// arcParamOf returns the parameter t∈[0,1] of point p along the arc (by angle), and
+// whether it lies within the arc's sweep.
+func arcParamOf(arc geom.Arc2d, p math.Point2) (float64, bool) {
+	rel := angleOfPoint(arc.Center, p) - arc.StartAngle
+	if arc.SweepAngle < 0 {
+		rel = -rel
+	}
+	t := wrap2pi(rel) / stdmath.Abs(arc.SweepAngle)
+	return t, t <= 1+1e-7
+}
+
+// circularBracket returns the adjacent pair of (sorted, unique, [0,2π)) crossing angles
+// whose counter-clockwise gap contains pa — the segment the user picked to remove.
+func circularBracket(angs []float64, pa float64) (lo, hi float64) {
+	for i := 0; i+1 < len(angs); i++ {
+		if pa >= angs[i] && pa < angs[i+1] {
+			return angs[i], angs[i+1]
+		}
+	}
+	return angs[len(angs)-1], angs[0] // the wrap gap through 0
+}
+
+// pointAtAngle returns the point at angle ang on a circle of the given center and radius.
+func pointAtAngle(center math.Point2, r math.Scalar, ang float64) math.Point2 {
+	return math.P2(center.X+r*math.Scalar(stdmath.Cos(ang)), center.Y+r*math.Scalar(stdmath.Sin(ang)))
+}

--- a/model/sketch/edit_trim_curve_targets_test.go
+++ b/model/sketch/edit_trim_curve_targets_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"math"
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+// nearPt asserts a point within tolerance.
+func nearPt(t *testing.T, got gmath.Point2, wantX, wantY float64) {
+	t.Helper()
+	if math.Abs(float64(got.X)-wantX) > 1e-9 || math.Abs(float64(got.Y)-wantY) > 1e-9 {
+		t.Errorf("point = %v, want (%v,%v)", got, wantX, wantY)
+	}
+}
+
+// A circle crossed by a diameter line, trimmed on one side, becomes the opposite arc.
+func TestTrimCircleBecomesComplementArc(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	c := s.Circles().AddByCenterRadius(gmath.P2(0, 0), 2)
+	s.Lines().AddByTwoPoints(gmath.P2(0, -3), gmath.P2(0, 3)) // crosses at (0,2),(0,-2)
+
+	parts, err := s.TrimCircle(c, gmath.P2(2, 0)) // pick the right half to remove
+	if err != nil {
+		t.Fatalf("TrimCircle: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("trim circle made %d parts, want 1 arc", len(parts))
+	}
+	if s.Circles().Count() != 0 || s.Arcs().Count() != 1 {
+		t.Fatalf("circles=%d arcs=%d, want 0 and 1", s.Circles().Count(), s.Arcs().Count())
+	}
+	arc := s.Arcs().Item(0)
+	nearPt(t, arc.Center.Position(), 0, 0)
+	if math.Abs(float64(arc.Radius())-2) > 1e-9 {
+		t.Errorf("arc radius = %v, want 2", arc.Radius())
+	}
+	// Kept arc spans the left half: it passes through (-2,0).
+	if !arcPassesThrough(arc, gmath.P2(-2, 0)) {
+		t.Error("kept arc should pass through (-2,0) (the left half)")
+	}
+	if arcPassesThrough(arc, gmath.P2(2, 0)) {
+		t.Error("removed right half should not be on the kept arc")
+	}
+}
+
+// A circle with fewer than two crossings cannot be opened.
+func TestTrimCircleNeedsTwoCrossings(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	c := s.Circles().AddByCenterRadius(gmath.P2(0, 0), 2)
+	if _, err := s.TrimCircle(c, gmath.P2(2, 0)); err == nil {
+		t.Error("trimming a circle with no crossings should error")
+	}
+}
+
+// An upper-semicircle arc trimmed past its single crossing keeps the front stub.
+func TestTrimArcKeepsFrontStub(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(gmath.P2(0, 0), gmath.P2(2, 0), gmath.P2(-2, 0), true) // 0→π
+	s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(0, 3))                                   // crosses at (0,2), t=0.5
+
+	parts, err := s.TrimArc(arc, gmath.P2(-1.414213562, 1.414213562)) // pick at t≈0.75 (upper left)
+	if err != nil {
+		t.Fatalf("TrimArc: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("trim arc made %d parts, want 1", len(parts))
+	}
+	nearPt(t, arc.End.Position(), 0, 2) // tail removed; kept [0,0.5] ends at (0,2)
+}
+
+// An arc with two interior crossings, picked in the middle, splits into two arcs.
+func TestTrimArcInteriorBiteMakesTwo(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(gmath.P2(0, 0), gmath.P2(2, 0), gmath.P2(-2, 0), true) // 0→π
+	s.Lines().AddByTwoPoints(gmath.P2(1, -3), gmath.P2(1, 3))                                  // crosses at (1,√3), t=1/3
+	s.Lines().AddByTwoPoints(gmath.P2(-1, -3), gmath.P2(-1, 3))                                // crosses at (-1,√3), t=2/3
+
+	parts, err := s.TrimArc(arc, gmath.P2(0, 2)) // pick the top (t=0.5), between the crossings
+	if err != nil {
+		t.Fatalf("TrimArc: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("interior bite made %d parts, want 2", len(parts))
+	}
+	if s.Arcs().Count() != 2 {
+		t.Fatalf("arcs after bite = %d, want 2", s.Arcs().Count())
+	}
+}
+
+// arcPassesThrough reports whether q lies on the arc (on its circle and within its sweep).
+func arcPassesThrough(a *Arc, q gmath.Point2) bool {
+	ka := entityArc2d(a)
+	if math.Abs(a.Center.Position().DistanceTo(q)-float64(a.Radius())) > 1e-6 {
+		return false
+	}
+	_, ok := arcParamOf(ka, q)
+	return ok
+}

--- a/model/sketch/edit_trim_curves.go
+++ b/model/sketch/edit_trim_curves.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"github.com/Oblikovati/oblikovati/kernel/geom"
+	"github.com/Oblikovati/oblikovati/math"
+)
+
+// curveHitTol is the angular/positional slack used when filtering a circle crossing onto
+// an arc's sweep (so an intersection at an arc endpoint still counts).
+const curveHitTol = 1e-7
+
+// This file generalizes line trim/extend to cut against circles and arcs, not only other
+// lines (the follow-up noted in edit_trim.go). The sketch entities are adapted to the
+// kernel's analytic 2D types and the exact intersection primitives in kernel/geom do the
+// geometry; arc crossings are circle crossings filtered to the arc's sweep.
+
+// entitySegment2d adapts a sketch line to a kernel 2D segment.
+func entitySegment2d(l *Line) geom.LineSegment2d {
+	return geom.NewLineSegment2d(l.A.Position(), l.B.Position())
+}
+
+// entityLine2d adapts a sketch line to a kernel 2D *infinite* line (A along A→B). It
+// errors on a degenerate (zero-length) line.
+func entityLine2d(l *Line) (geom.Line2d, error) {
+	return geom.NewLine2d(l.A.Position(), l.Direction())
+}
+
+// entityCircle2d adapts a sketch circle to a kernel 2D circle.
+func entityCircle2d(c *Circle) geom.Circle2d {
+	return geom.NewCircle2d(c.Center.Position(), float64(c.Radius))
+}
+
+// entityArc2d adapts a sketch arc to a kernel 2D arc, deriving the start angle and signed
+// sweep (CCW positive) from its endpoints and winding flag.
+func entityArc2d(a *Arc) geom.Arc2d {
+	c := a.Center.Position()
+	start := angleOfPoint(c, a.Start.Position())
+	end := angleOfPoint(c, a.End.Position())
+	sweep := wrap2pi(end - start)
+	if !a.CounterClockwise {
+		sweep = -wrap2pi(start - end)
+	}
+	return geom.NewArc2d(c, float64(a.Radius()), start, sweep)
+}
+
+// wrap2pi maps an angle delta into [0, 2π).
+func wrap2pi(d float64) float64 {
+	d = stdmath.Mod(d, 2*stdmath.Pi)
+	if d < 0 {
+		d += 2 * stdmath.Pi
+	}
+	return d
+}
+
+// segmentEntityHits returns the points where segment seg crosses entity e (a line, circle
+// or arc); other entity kinds yield none.
+func segmentEntityHits(seg geom.LineSegment2d, e Entity) []math.Point2 {
+	switch g := e.(type) {
+	case *Line:
+		if p, _, _, ok := geom.Segment2dIntersection(seg, entitySegment2d(g), 0); ok {
+			return []math.Point2{p}
+		}
+	case *Circle:
+		return geom.SegmentCircle2dIntersection(seg, entityCircle2d(g), 0)
+	case *Arc:
+		return arcFilter(entityArc2d(g), geom.SegmentCircle2dIntersection(seg, arcCircle(g), 0))
+	}
+	return nil
+}
+
+// supportEntityHits returns the points where the infinite line crosses entity e — used by
+// extend, which reaches past the line's endpoints to the nearest support crossing.
+func supportEntityHits(line geom.Line2d, e Entity) []math.Point2 {
+	switch g := e.(type) {
+	case *Line:
+		if other, err := entityLine2d(g); err == nil {
+			if p, ok := geom.Line2dIntersection(line, other, 0); ok {
+				return []math.Point2{p}
+			}
+		}
+	case *Circle:
+		return geom.LineCircle2dIntersection(line, entityCircle2d(g), 0)
+	case *Arc:
+		return arcFilter(entityArc2d(g), geom.LineCircle2dIntersection(line, arcCircle(g), 0))
+	}
+	return nil
+}
+
+// arcCircle is the full circle underlying an arc.
+func arcCircle(a *Arc) geom.Circle2d {
+	return geom.NewCircle2d(a.Center.Position(), float64(a.Radius()))
+}
+
+// arcFilter keeps only the points that lie within the arc's sweep.
+func arcFilter(arc geom.Arc2d, pts []math.Point2) []math.Point2 {
+	var out []math.Point2
+	for _, p := range pts {
+		if arc.ContainsPoint(p, curveHitTol) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// lineEntityCrossings returns the parameters in (0,1) along l where it crosses any other
+// line, circle or arc in the sketch. It supersedes the line-only lineCrossings.
+func (s *Sketch) lineEntityCrossings(l *Line) []float64 {
+	seg := entitySegment2d(l)
+	var out []float64
+	for _, e := range s.ents {
+		if e == Entity(l) {
+			continue
+		}
+		for _, p := range segmentEntityHits(seg, e) {
+			if t := projectParamOnLine(l, p); t > 1e-9 && t < 1-1e-9 {
+				out = append(out, t)
+			}
+		}
+	}
+	return out
+}

--- a/model/sketch/edit_trim_curves_test.go
+++ b/model/sketch/edit_trim_curves_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"math"
+	"testing"
+
+	gmath "github.com/Oblikovati/oblikovati/math"
+)
+
+// nearX asserts a point's X coordinate.
+func nearX(t *testing.T, p gmath.Point2, want float64) {
+	t.Helper()
+	if math.Abs(float64(p.X)-want) > 1e-9 {
+		t.Errorf("X = %v, want %v", p.X, want)
+	}
+}
+
+// A line crossing a circle is trimmed at the two chord crossings: picking the segment
+// inside the circle removes it and leaves the two outside stubs.
+func TestTrimLineAtCircleCrossings(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(-3, 0), gmath.P2(3, 0))
+	s.Circles().AddByCenterRadius(gmath.P2(0, 0), 1) // crosses at (±1,0)
+	parts, err := s.TrimLine(l, gmath.P2(0, 0))      // pick the chord inside the circle
+	if err != nil {
+		t.Fatalf("TrimLine: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("trim left %d parts, want 2 (the two outside stubs)", len(parts))
+	}
+	nearX(t, l.B.Position(), -1) // reshaped original keeps [-3,-1]
+}
+
+// A line trimmed at an arc crossing: only the crossing within the arc's sweep cuts the
+// line (the other circle crossing is outside the sweep and ignored).
+func TestTrimLineAtArcCrossingHonorsSweep(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(-3, 0), gmath.P2(3, 0))
+	// Left semicircle (angles π/2→3π/2) crosses the line only at (-1,0); (1,0) is outside.
+	s.Arcs().AddByCenterStartEnd(gmath.P2(0, 0), gmath.P2(0, 1), gmath.P2(0, -1), true)
+	parts, err := s.TrimLine(l, gmath.P2(0, 0)) // pick right of the single crossing at (-1,0)
+	if err != nil {
+		t.Fatalf("TrimLine: %v", err)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("trim left %d parts, want 1 (single crossing)", len(parts))
+	}
+	nearX(t, l.B.Position(), -1) // pick is right of the crossing → tail removed, keeps [-3,-1]
+}
+
+// A short line extends past its B end to the nearest crossing of its support with a circle.
+func TestExtendLineToCircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(-3, 0), gmath.P2(-2, 0)) // B end at x=-2
+	s.Circles().AddByCenterRadius(gmath.P2(0, 0), 1)                // support crosses at (±1,0)
+	if _, err := s.ExtendLine(l, true); err != nil {                // extend the B end
+		t.Fatalf("ExtendLine: %v", err)
+	}
+	nearX(t, l.B.Position(), -1) // nearest crossing beyond B is (-1,0)
+}
+
+// Extending toward an arc reaches only a crossing within the arc's sweep.
+func TestExtendLineToArc(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(-3, 0), gmath.P2(-2, 0))
+	// Left semicircle: support crossing at (-1,0) is in-sweep, (1,0) is not.
+	s.Arcs().AddByCenterStartEnd(gmath.P2(0, 0), gmath.P2(0, 1), gmath.P2(0, -1), true)
+	if _, err := s.ExtendLine(l, true); err != nil {
+		t.Fatalf("ExtendLine: %v", err)
+	}
+	nearX(t, l.B.Position(), -1)
+}
+
+// Extending with no reachable geometry beyond the end errors (no line/curve to reach).
+func TestExtendLineNoTargetErrors(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(1, 0))
+	s.Circles().AddByCenterRadius(gmath.P2(0, 5), 1) // off the support line entirely
+	if _, err := s.ExtendLine(l, true); err == nil {
+		t.Error("extend should fail when nothing lies beyond the picked end")
+	}
+}

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -24,10 +24,11 @@ func (p *Point) Position() math.Point2 { return math.P2(p.X, p.Y) }
 // SetPosition moves the point (used by the solver and by drags).
 func (p *Point) SetPosition(q math.Point2) { p.X, p.Y = q.X, q.Y }
 
-// entityBase carries the id and construction flag shared by curve entities.
+// entityBase carries the id, construction flag, and centerline flag shared by curve entities.
 type entityBase struct {
 	id           ID
 	construction bool
+	centerline   bool
 }
 
 func newEntity() entityBase { return entityBase{id: nextID()} }
@@ -35,12 +36,20 @@ func newEntity() entityBase { return entityBase{id: nextID()} }
 // EntityID implements [Entity].
 func (e *entityBase) EntityID() ID { return e.id }
 
-// IsConstruction reports whether the entity is construction (reference) geometry —
-// it shapes constraints but is not part of a profile.
-func (e *entityBase) IsConstruction() bool { return e.construction }
+// IsConstruction reports whether the entity is construction (reference) geometry — it shapes
+// constraints but is not part of a profile. A centerline is always construction (an axis never
+// closes a profile).
+func (e *entityBase) IsConstruction() bool { return e.construction || e.centerline }
 
-// SetConstruction toggles construction geometry.
+// SetConstruction toggles plain construction geometry.
 func (e *entityBase) SetConstruction(c bool) { e.construction = c }
+
+// IsCenterline reports whether the entity is a centerline — construction geometry that also
+// serves as an axis (revolve axis, mirror/symmetry axis, diameter dimensions).
+func (e *entityBase) IsCenterline() bool { return e.centerline }
+
+// SetCenterline marks the entity as a centerline (implying construction; see IsConstruction).
+func (e *entityBase) SetCenterline(c bool) { e.centerline = c }
 
 // Line is a straight segment between two constrainable endpoints.
 type Line struct {
@@ -55,6 +64,13 @@ func (l *Line) EndPoint() *Point   { return l.B }
 
 // Direction returns the (unnormalized) vector from A to B.
 func (l *Line) Direction() math.Vector2 { return l.A.Position().VectorTo(l.B.Position()) }
+
+// Axis3D returns the line as a model-space axis (origin at A, direction A→B) on the given sketch
+// plane — used to drive a revolve/mirror axis from a centerline.
+func (l *Line) Axis3D(plane Plane) (origin math.Point3, dir math.Vector3) {
+	a, b := plane.ToModel(l.A.Position()), plane.ToModel(l.B.Position())
+	return a, a.VectorTo(b)
+}
 
 // Length returns the current endpoint distance.
 func (l *Line) Length() math.Scalar { return l.A.Position().DistanceTo(l.B.Position()) }

--- a/model/sketch/entity_collections.go
+++ b/model/sketch/entity_collections.go
@@ -31,6 +31,28 @@ func (c *Lines) Add(a, b *Point) *Line {
 // Count returns the number of lines; Item returns the i-th.
 func (c *Lines) Count() int       { return len(c.items) }
 func (c *Lines) Item(i int) *Line { return c.items[i] }
+func (c *Lines) remove(l *Line)   { c.items = removeItem(c.items, l) }
+
+// Centerlines returns the sketch's centerline lines (axes for revolve/mirror/symmetry).
+func (s *Sketch) Centerlines() []*Line {
+	var out []*Line
+	for _, l := range s.lines.items {
+		if l.IsCenterline() {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// removeItem drops the first occurrence of x from xs (used by the collections' remove).
+func removeItem[T comparable](xs []T, x T) []T {
+	for i, v := range xs {
+		if v == x {
+			return append(xs[:i], xs[i+1:]...)
+		}
+	}
+	return xs
+}
 
 // Circles creates and tracks circles.
 type Circles struct {
@@ -56,6 +78,7 @@ func (c *Circles) Add(center *Point, radius math.Scalar) *Circle {
 // Count returns the number of circles; Item returns the i-th.
 func (c *Circles) Count() int         { return len(c.items) }
 func (c *Circles) Item(i int) *Circle { return c.items[i] }
+func (c *Circles) remove(x *Circle)   { c.items = removeItem(c.items, x) }
 
 // Arcs creates and tracks arcs.
 type Arcs struct {
@@ -86,6 +109,7 @@ func (c *Arcs) Add(center, start, end *Point, ccw bool) *Arc {
 // Count returns the number of arcs; Item returns the i-th.
 func (c *Arcs) Count() int      { return len(c.items) }
 func (c *Arcs) Item(i int) *Arc { return c.items[i] }
+func (c *Arcs) remove(a *Arc)   { c.items = removeItem(c.items, a) }
 
 // Ellipses creates and tracks ellipses.
 type Ellipses struct {

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -66,6 +66,7 @@ type EntityData struct {
 	Closed       bool      `yaml:"closed,omitempty"`
 	Fit          bool      `yaml:"fit,omitempty"`
 	Construction bool      `yaml:"construction,omitempty"`
+	Centerline   bool      `yaml:"centerline,omitempty"` // line only: an axis
 	ImageRef     string    `yaml:"imageRef,omitempty"`   // image only
 	Anchor       []float64 `yaml:"anchor,omitempty"`     // image/text: [x, y]
 	Size         []float64 `yaml:"size,omitempty"`       // image only: [w, h]
@@ -191,7 +192,7 @@ func serializePlane(p Plane) PlaneData {
 func serializeEntity(e Entity) (EntityData, error) {
 	switch v := e.(type) {
 	case *Line:
-		return EntityData{ID: int(v.id), Kind: "line", Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction}, nil
+		return EntityData{ID: int(v.id), Kind: "line", Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction, Centerline: v.centerline}, nil
 	case *Circle:
 		return EntityData{ID: int(v.id), Kind: "circle", Points: []int{int(v.Center.id)}, Radius: float64(v.Radius), Construction: v.construction}, nil
 	case *Arc:

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -110,6 +110,11 @@ func (r *sketchRestorer) restoreEntities(entities []EntityData) error {
 			return err
 		}
 		e.(interface{ SetConstruction(bool) }).SetConstruction(ed.Construction)
+		if ed.Centerline {
+			if cl, ok := e.(interface{ SetCenterline(bool) }); ok {
+				cl.SetCenterline(true)
+			}
+		}
 		r.entityMap[ed.ID] = e
 	}
 	return nil

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -235,6 +235,21 @@ func (s *Sketch) removeEntity(e Entity) bool {
 	return false
 }
 
+// deleteEntity removes e from the entity list AND its typed collection, so an edit that
+// drops a curve (e.g. a whole-curve trim) leaves no dangling collection entry that
+// Count/Item/serialization would still report.
+func (s *Sketch) deleteEntity(e Entity) {
+	s.removeEntity(e)
+	switch t := e.(type) {
+	case *Line:
+		s.lines.remove(t)
+	case *Circle:
+		s.circles.remove(t)
+	case *Arc:
+		s.arcs.remove(t)
+	}
+}
+
 // newPoint creates a constrainable point at pos and registers it as a solver
 // variable. Curve factories use it for endpoints/centers (not added to Entities).
 func (s *Sketch) newPoint(pos math.Point2) *Point {

--- a/model/sketch/surface_curves_3d.go
+++ b/model/sketch/surface_curves_3d.go
@@ -3,6 +3,8 @@
 package sketch
 
 import (
+	"fmt"
+
 	"github.com/Oblikovati/oblikovati/kernel/geom"
 	"github.com/Oblikovati/oblikovati/math"
 )
@@ -200,14 +202,57 @@ func (s *Sketch3D) AddSilhouetteCurve3DRef(surface SurfaceSource, viewDir math.V
 
 // AddProjectToSurfaceCurve3D adds the projection of source onto a fixed surface.
 func (s *Sketch3D) AddProjectToSurfaceCurve3D(source geom.Curve3, surface geom.Surface) *ProjectToSurfaceCurve3D {
-	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: StaticSurface(surface)}
+	return s.AddProjectToSurfaceCurve3DRef(source, StaticSurface(surface))
+}
+
+// AddProjectToSurfaceCurve3DRef projects a source curve onto a surface source (the surface
+// is associative and rebinds on recompute; the source curve is a fixed snapshot).
+func (s *Sketch3D) AddProjectToSurfaceCurve3DRef(source geom.Curve3, surface SurfaceSource) *ProjectToSurfaceCurve3D {
+	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: surface}
 	s.addEntity3D(c)
 	return c
 }
 
+// SourceCurve3 resolves a curve entity in this sketch (by id) to its kernel curve — the
+// source for a project/offset surface curve. It errors if the id is unknown or the entity
+// is not a curve.
+func (s *Sketch3D) SourceCurve3(id ID) (geom.Curve3, error) {
+	e, ok := s.EntityByID(id)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: no entity with id %d", id)
+	}
+	return curve3OfEntity(e)
+}
+
+// curve3OfEntity maps a 3D-sketch entity to its kernel curve.
+func curve3OfEntity(e Entity) (geom.Curve3, error) {
+	switch v := e.(type) {
+	case *Line3D:
+		return geom.NewLineSegment(v.A.Position(), v.B.Position()), nil
+	case *Circle3D:
+		return v.Curve()
+	case *Arc3D:
+		return v.Curve()
+	case *Ellipse3D:
+		return v.Curve()
+	case *EllipticalArc3D:
+		return v.Curve()
+	case *HelicalCurve3D:
+		return v.Curve()
+	default:
+		return nil, fmt.Errorf("sketch3d: entity %T is not a source curve", e)
+	}
+}
+
 // AddOnFaceCurve3D adds a curve drawn in a fixed surface's parameter space (the uv samples).
 func (s *Sketch3D) AddOnFaceCurve3D(surface geom.Surface, uv []math.Point2) *OnFaceCurve3D {
-	c := &OnFaceCurve3D{entityBase: newEntity(), Surface: StaticSurface(surface), UV: append([]math.Point2(nil), uv...)}
+	return s.AddOnFaceCurve3DRef(StaticSurface(surface), uv)
+}
+
+// AddOnFaceCurve3DRef adds an on-face curve over a surface source (associative: it rebinds
+// to the referenced face's surface on recompute).
+func (s *Sketch3D) AddOnFaceCurve3DRef(surface SurfaceSource, uv []math.Point2) *OnFaceCurve3D {
+	c := &OnFaceCurve3D{entityBase: newEntity(), Surface: surface, UV: append([]math.Point2(nil), uv...)}
 	s.addEntity3D(c)
 	return c
 }

--- a/theme/defaults.go
+++ b/theme/defaults.go
@@ -8,101 +8,113 @@ import (
 	"github.com/Oblikovati/api/types"
 )
 
-// DefaultDark is the shipped dark theme. Its viewport/overlay/icon colors reproduce the
-// values the head hardcoded before theming (so the default look is unchanged); the
-// chrome colors are a coherent dark Dear ImGui palette. Built fresh on each call so the
-// library holds an independent copy.
+// DefaultDark is the shipped dark theme. Its colors follow Autodesk Inventor's dark
+// design spec (../../inventor-color.md): the cool blue-gray "Light Logic" surface stack,
+// the #0696D7 brand accent, cyan pre-highlight/selection, green under-constrained sketch
+// geometry and translucent-orange work planes. Built fresh on each call so the library
+// holds an independent copy.
 func DefaultDark() *Theme { return New("Dark", KindDark, mustPalette(darkHex)) }
 
-// DefaultLight is the shipped light theme — the same token set tuned for a light shell.
+// DefaultLight is the shipped light theme — the same Inventor token set tuned for the
+// neutral-gray light shell (white/#F5F5F5/#D9D9D9 surfaces).
 func DefaultLight() *Theme { return New("Light", KindLight, mustPalette(lightHex)) }
 
 // Builtins returns the two shipped themes, dark first (the out-of-the-box default).
 func Builtins() []*Theme { return []*Theme{DefaultDark(), DefaultLight()} }
 
-// darkHex reproduces the pre-theming hardcoded overlay/icon colors (head/ui) and pairs
-// them with a dark chrome palette. See ADR-0021 for the token meanings.
+// autodeskBlue500 is Inventor's primary brand accent (inventor-color.md §2): the
+// "On/Active/Selected/Focus" color shared by both themes (active tab, selection,
+// checkmark, slider grab, focus). The secondary #38ABDF outline accent is not a separate
+// token here — TokenChromeBorder drives every panel separator, so it stays neutral.
+const autodeskBlue500 = "#0696d7ff"
+
+// darkHex maps every token to Inventor's dark theme (inventor-color.md). Surfaces use the
+// three "Light Logic" levels (L3 base #222933 → L2 mid #3B4453 → L1 highest #454F61);
+// text/icons sit at #A2A6B0. See ADR-0021 for the token meanings.
 var darkHex = map[string]string{
-	// Chrome
-	string(types.TokenChromeWindowBg):      "#1e2127ff",
-	string(types.TokenChromePanelBg):       "#262a31ff",
-	string(types.TokenChromePopupBg):       "#1a1c22ff",
-	string(types.TokenChromeMenuBarBg):     "#15171cff",
-	string(types.TokenChromeHeaderBg):      "#2a2f38ff",
-	string(types.TokenChromeText):          "#d9dce1ff",
-	string(types.TokenChromeTextDisabled):  "#6b7280ff",
-	string(types.TokenChromeBorder):        "#3a3f49ff",
-	string(types.TokenChromeControlBg):     "#262a31ff",
-	string(types.TokenChromeControlHover):  "#2f343cff",
-	string(types.TokenChromeControlActive): "#3a414bff",
-	string(types.TokenChromeButton):        "#2a2f38ff",
-	string(types.TokenChromeButtonHover):   "#353b45ff",
-	string(types.TokenChromeButtonActive):  "#454d59ff",
-	string(types.TokenChromeAccent):        "#3fb6ffff",
-	string(types.TokenChromeScrollbar):     "#3a3f49ff",
-	// Viewport 2D (pre-theming head values)
-	string(types.TokenViewportBg):       "#1a1c21ff", // viewport.cpp clear {0.10,0.11,0.13}
-	string(types.TokenGridMinor):        "#454a54ff", // grid_overlay.go gridMinorColor
-	string(types.TokenGridMajor):        "#666e7aff", // grid_overlay.go gridMajorColor
-	string(types.TokenGridAxis):         "#8c99adff", // grid_overlay.go gridAxisColor
-	string(types.TokenSketchGeometry):   "#ffc733ff", // sketch_overlay.go sketchColor
-	string(types.TokenSketchSelected):   "#4de6ffff", // sketch_overlay.go sketchSelectedColor
-	string(types.TokenSketchCandidate):  "#66ff73ff", // sketch_overlay.go sketchCandidateColor
-	string(types.TokenSketchPreview):    "#f2f2ffff", // chrome.go previewColor
-	string(types.TokenDimensionDriving): "#73d980ff", // dimension_overlay.go dimensionColor
-	string(types.TokenDimensionDriven):  "#8cb3f2ff", // dimension_overlay.go dimensionDrivenColor
-	string(types.TokenSnapGlyph):        "#ffffffff", // snap_glyph.go snapGlyphColor
-	// Gizmos 3D (pre-theming head values)
-	string(types.TokenPlaneFaint):         "#738099ff", // plane_overlay.go faintPlaneColor
-	string(types.TokenPlaneHover):         "#ffb333ff", // plane_overlay.go hoverPlaneColor
-	string(types.TokenPlaneSelected):      "#4dd9ffff", // plane_overlay.go selectedPlaneColor
-	string(types.TokenPlaneFill):          "#73809933", // plane_overlay.go translucent plane fill
-	string(types.TokenSelectionHighlight): "#4dd9ffff", // highlight.go selectionHighlight
-	// Icons (pre-theming head values)
-	string(types.TokenIconTint):     "#d9dee6ff", // icon_cache.go iconTint
-	string(types.TokenIconDisabled): "#6b7280ff",
+	// Chrome — Light Logic surface stack (§1 Dark Theme, §6 summary)
+	string(types.TokenChromeWindowBg):      "#222933ff", // L3 base: app frame / empty canvas
+	string(types.TokenChromeMenuBarBg):     "#222933ff", // L3: top frame bar
+	string(types.TokenChromePanelBg):       "#3b4453ff", // L2 mid: property panels / dialogs
+	string(types.TokenChromeHeaderBg):      "#3b4453ff", // L2: inactive title / tree header
+	string(types.TokenChromePopupBg):       "#454f61ff", // L1 highest: flyouts / floating panels
+	string(types.TokenChromeText):          "#a2a6b0ff", // default text/icon
+	string(types.TokenChromeTextDisabled):  "#6c7382ff", // muted blue-gray
+	string(types.TokenChromeBorder):        "#4a5466ff", // subtle separator above the surfaces
+	string(types.TokenChromeControlBg):     "#2c333fff", // inset field well (darker than panel)
+	string(types.TokenChromeControlHover):  "#3b4453ff",
+	string(types.TokenChromeControlActive): "#454f61ff",
+	string(types.TokenChromeButton):        "#3b4453ff", // L2: buttons / inactive tabs
+	string(types.TokenChromeButtonHover):   "#454f61ff",
+	string(types.TokenChromeButtonActive):  "#515c70ff",
+	string(types.TokenChromeAccent):        autodeskBlue500, // On/Active/Selected/Focus (§2)
+	string(types.TokenChromeScrollbar):     "#3b4453ff",
+	// Viewport 2D (§4 Dark canvas, §5 interactive/constraint states)
+	string(types.TokenViewportBg):       "#1e232bff", // "Dark" scheme solid canvas
+	string(types.TokenGridMinor):        "#3a424eff",
+	string(types.TokenGridMajor):        "#55606eff",
+	string(types.TokenGridAxis):         "#8c99adff",
+	string(types.TokenSketchGeometry):   "#5fb158ff", // under-constrained green (§5.2)
+	string(types.TokenSketchSelected):   "#00bfffff", // selection deep cyan (§5.1)
+	string(types.TokenSketchCandidate):  "#00ffffff", // pre-highlight bright cyan (§5.1)
+	string(types.TokenSketchPreview):    "#d1deeeff", // focus light (§2)
+	string(types.TokenDimensionDriving): "#c5cad3ff", // legible neutral annotation
+	string(types.TokenDimensionDriven):  "#8d96a3ff", // driven/reference indigo gray (§5.2)
+	string(types.TokenSnapGlyph):        "#ffffffff",
+	// Gizmos 3D (§5.3 reference infrastructure)
+	string(types.TokenPlaneFaint):         "#e37a22ff", // translucent-orange work plane border
+	string(types.TokenPlaneHover):         "#f09d4fff", // brighter surface orange on hover
+	string(types.TokenPlaneSelected):      "#00bfffff", // selection cyan
+	string(types.TokenPlaneFill):          "#e37a224d", // orange at ~30% opacity
+	string(types.TokenSelectionHighlight): "#00bfffff", // picked-element cyan (§5.1)
+	// Icons (§3 semantic palette — gray main body on dark)
+	string(types.TokenIconTint):     "#a2a6b0ff",
+	string(types.TokenIconDisabled): "#6c7382ff",
 }
 
-// lightHex is a light-shell palette over the same token set.
+// lightHex maps every token to Inventor's neutral-gray light theme (inventor-color.md §1
+// Light Theme): white foreground (L1) over #F5F5F5 panels (L2) over the #D9D9D9 frame
+// edge (L3). Viewport cyans/greens are toned a step darker so they stay visible on the
+// light canvas.
 var lightHex = map[string]string{
-	// Chrome
-	string(types.TokenChromeWindowBg):      "#f3f4f6ff",
-	string(types.TokenChromePanelBg):       "#ffffffff",
-	string(types.TokenChromePopupBg):       "#ffffffff",
-	string(types.TokenChromeMenuBarBg):     "#e6e8ebff",
-	string(types.TokenChromeHeaderBg):      "#dfe3e8ff",
-	string(types.TokenChromeText):          "#1c1f24ff",
+	// Chrome — neutral-gray Light Logic stack
+	string(types.TokenChromeWindowBg):      "#d9d9d9ff", // L3 base: frame edge
+	string(types.TokenChromeMenuBarBg):     "#f5f5f5ff", // L2: top toolbar
+	string(types.TokenChromePanelBg):       "#f5f5f5ff", // L2 mid: panels / dialogs
+	string(types.TokenChromeHeaderBg):      "#e9ebedff", // inactive title / tree header
+	string(types.TokenChromePopupBg):       "#ffffffff", // L1 highest: flyouts / foreground
+	string(types.TokenChromeText):          "#2b2f36ff", // dark body text (legible)
 	string(types.TokenChromeTextDisabled):  "#9aa0a8ff",
 	string(types.TokenChromeBorder):        "#c7ccd3ff",
-	string(types.TokenChromeControlBg):     "#ffffffff",
-	string(types.TokenChromeControlHover):  "#eceef1ff",
-	string(types.TokenChromeControlActive): "#dde1e6ff",
-	string(types.TokenChromeButton):        "#e6e8ebff",
-	string(types.TokenChromeButtonHover):   "#dde1e6ff",
-	string(types.TokenChromeButtonActive):  "#cfd4daff",
-	string(types.TokenChromeAccent):        "#1f7fd6ff",
+	string(types.TokenChromeControlBg):     "#ffffffff", // L1: text inputs / foreground fields
+	string(types.TokenChromeControlHover):  "#f0f1f3ff",
+	string(types.TokenChromeControlActive): "#e4e6e9ff",
+	string(types.TokenChromeButton):        "#f5f5f5ff", // L2: buttons / inactive tabs
+	string(types.TokenChromeButtonHover):   "#e9ebedff",
+	string(types.TokenChromeButtonActive):  "#dcdee1ff",
+	string(types.TokenChromeAccent):        autodeskBlue500, // primary accent (§2)
 	string(types.TokenChromeScrollbar):     "#c7ccd3ff",
 	// Viewport 2D
-	string(types.TokenViewportBg):       "#e8eaedff",
+	string(types.TokenViewportBg):       "#d4dce4ff", // light blue-gray "Sky"-style canvas
 	string(types.TokenGridMinor):        "#c2c7cfff",
 	string(types.TokenGridMajor):        "#a8aeb8ff",
 	string(types.TokenGridAxis):         "#7f8794ff",
-	string(types.TokenSketchGeometry):   "#c77f00ff",
-	string(types.TokenSketchSelected):   "#0a84c7ff",
-	string(types.TokenSketchCandidate):  "#1faa3aff",
-	string(types.TokenSketchPreview):    "#5a5a99ff",
-	string(types.TokenDimensionDriving): "#2f9e45ff",
-	string(types.TokenDimensionDriven):  "#3f66c7ff",
+	string(types.TokenSketchGeometry):   "#4f9e48ff", // under-constrained green (toned)
+	string(types.TokenSketchSelected):   "#0098ccff", // selection cyan (toned for light)
+	string(types.TokenSketchCandidate):  "#00b3b3ff", // pre-highlight cyan (toned for light)
+	string(types.TokenSketchPreview):    "#5a6b85ff",
+	string(types.TokenDimensionDriving): "#404652ff",
+	string(types.TokenDimensionDriven):  "#8d96a3ff", // driven/reference indigo gray (§5.2)
 	string(types.TokenSnapGlyph):        "#1c1f24ff",
 	// Gizmos 3D
-	string(types.TokenPlaneFaint):         "#8c99adff",
-	string(types.TokenPlaneHover):         "#d98a00ff",
-	string(types.TokenPlaneSelected):      "#0a84c7ff",
-	string(types.TokenPlaneFill):          "#5a6b8533",
-	string(types.TokenSelectionHighlight): "#0a84c7ff",
-	// Icons
-	string(types.TokenIconTint):     "#3a3f49ff",
-	string(types.TokenIconDisabled): "#aeb4bdff",
+	string(types.TokenPlaneFaint):         "#e37a22ff", // work plane orange
+	string(types.TokenPlaneHover):         "#e08a2aff",
+	string(types.TokenPlaneSelected):      "#0098ccff", // selection cyan
+	string(types.TokenPlaneFill):          "#e37a224d", // orange at ~30% opacity
+	string(types.TokenSelectionHighlight): "#0098ccff",
+	// Icons (§3 — gray icon linework on light)
+	string(types.TokenIconTint):     "#666b73ff",
+	string(types.TokenIconDisabled): "#b0b5bdff",
 }
 
 // mustPalette builds a palette from a built-in hex map, panicking with the offending


### PR DESCRIPTION
Large slice of GPL-host work from a deep modelling + diagnostics session. Lands on `develop`; depends on Oblikovati.API#13 (already merged) for the `logs.tail` contract.

## What & why

**Geometry / boolean fixes** (`kernel/`, `model/`)
- A user hit a **deformed, non-manifold mesh** on a parametric fan with lofted blades. Root cause: a **twisted loft/sweep** emits **warped (non-planar) ruled quad** side faces; emitted as single "planar" faces, the planar boolean imprinted against an *approximating* plane → segments offset from the true edges (even 0.001 rad twist broke it) → union went non-manifold. **Fix:** `sweptSolid` triangulates a non-coplanar side quad (`sideQuad`/`quadPlanar`), restoring the planar-faceted invariant (PBI-174).
- **Pattern/mirror now replicate the source feature's tool, not the whole body** — `ToolFeature`/`OperationalFeature` + `Input.SourceTool` re-apply the source's cut/join per occurrence (one body with N holes/blades, not N solids). Hole caches its drill cylinder; a deferred Boss replicates nothing (PBI-191).

**MCP host surface + diagnostics** (`addin/`)
- All **39 `add_feature` kinds** registered in `opregistry` so every tool/feature is runtime-testable.
- New `addin/trace`: op-trace ring buffer + slog handler; `router.Handle` times each call, **recovers panics**, and serves `logs.tail` for real-time troubleshooting.

**UI** (`app/`, `head/`) — hole/loft/revolve tools+dialogs, sketch-modify & sketch3d tools, ribbon placement, highlight wiring; head installs the trace slog handler.

**Docs** — PBI-171 findings, new **PBI-199** (the remaining concave-bore-crossing robustness work), PBI-174/191/DEFERRALS/PROGRESS + architecture geometry-kernel note. The post-stitch orientation-repair dead-end is recorded so it is not retried.

## Known follow-up (tracked, not in scope here)
- **PBI-199**: partial penetration through a concave faceted wall (the blade tip crossing the bore) still leaves localised inverted normals. Reproduced by the (skipped) fan e2e in the add-ins repo, which is the acceptance spec.

## Test
`gofmt`/`go vet` clean; `go test ./...` green; cgo head builds. (Built binaries excluded from the commits.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)