### PR TITLE
Fix CI lint: gofumpt + funlen/gocyclo refactors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,9 +46,10 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
   exclude-rules:
-    # Tests may be longer and print freely.
+    # Tests may be longer and print freely; test helpers carry general signatures
+    # even when current call sites happen to pass a constant (unparam).
     - path: _test\.go
-      linters: [funlen, gocyclo, forbidigo, dupl]
+      linters: [funlen, gocyclo, forbidigo, dupl, unparam]
     # The recipe codecs (ADR-0020 document persistence) are exhaustive, one-case-per
     # -kind dispatch switches — serializing/restoring every entity/constraint/feature
     # kind — so their statement count is inherent to the dispatch, not a smell.
@@ -58,3 +59,13 @@ issues:
     # readable cross-package use; the stutter is intentional, descriptive naming.
     - text: "stutters"
       linters: [revive]
+    # Ribbon command tables and the router/feature-descriptor registries are exhaustive
+    # one-entry-per-command/handler lists (same rationale as the serialize codecs): the
+    # length is the list, not branching logic.
+    - path: (app/commands_.*|addin/opregistry/registry|addin/router/router)\.go
+      linters: [funlen]
+    # The cylinder/drill files assemble a watertight B-rep body element-by-element (verts,
+    # edges, faces, stitch); the statement count is the geometry being built, not branching
+    # logic — same rationale as the serialize codecs.
+    - path: kernel/brep/(cylinder|drill).*\.go
+      linters: [funlen]

--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -65,11 +65,9 @@ func applySweep(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	twist := 0.0
-	if strings.TrimSpace(in.Twist) != "" {
-		if twist, err = angleValue(part, in.Twist, "sweep: twist"); err != nil {
-			return nil, err
-		}
+	twist, err := optionalAngle(part, in.Twist, "sweep: twist")
+	if err != nil {
+		return nil, err
 	}
 	op, err := parseOperation(in.Operation)
 	if err != nil {

--- a/addin/opregistry/feature_refs.go
+++ b/addin/opregistry/feature_refs.go
@@ -5,6 +5,7 @@ package opregistry
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Oblikovati/oblikovati/math"
 	"github.com/Oblikovati/oblikovati/model/compdef"
@@ -44,6 +45,14 @@ func angleValue(part *compdef.PartComponentDefinition, expr, field string) (floa
 		return 0, fmt.Errorf("%s %q: %w", field, expr, err)
 	}
 	return v.Value, nil
+}
+
+// optionalAngle parses an optional angle expression, returning 0 when it is blank.
+func optionalAngle(part *compdef.PartComponentDefinition, expr, field string) (float64, error) {
+	if strings.TrimSpace(expr) == "" {
+		return 0, nil
+	}
+	return angleValue(part, expr, field)
 }
 
 // featureResult is the common reply for a feature operation: the created feature's name and

--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Oblikovati/oblikovati/addin/modelaccess"
 	"github.com/Oblikovati/oblikovati/app"
+	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/feature"
 )
 
@@ -220,21 +221,13 @@ func applyCoil(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	axisRef := in.AxisRef
-	if axisRef == "" {
-		axisRef = string(feature.OriginZAxis)
-	}
-	axis, err := axisFromRef(part, axisRef)
+	axis, err := coilAxis(part, in.AxisRef)
 	if err != nil {
 		return nil, err
 	}
-	pitch, err := lengthValue(part, in.Pitch, "coil: pitch")
+	pitch, revs, err := coilPitchRevs(part, in)
 	if err != nil {
 		return nil, err
-	}
-	revs, err := strconv.ParseFloat(strings.TrimSpace(in.Revolutions), 64)
-	if err != nil {
-		return nil, fmt.Errorf("coil: revolutions %q must be a number: %w", in.Revolutions, err)
 	}
 	op, err := parseOperation(in.Operation)
 	if err != nil {
@@ -242,6 +235,28 @@ func applyCoil(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	}
 	pf := feature.NewCoilFeatures(part.Features()).Add(sk, in.ProfileIndex, axis, constFn(pitch), constFn(revs), 0, op)
 	return recomputeResult(part, pf)
+}
+
+// coilAxis resolves the coil's work axis, defaulting to the Z origin axis when no ref is given
+// (a coil's natural axis), unlike the revolve default of Y.
+func coilAxis(part *compdef.PartComponentDefinition, ref string) (*feature.WorkAxis, error) {
+	if ref == "" {
+		ref = string(feature.OriginZAxis)
+	}
+	return axisFromRef(part, ref)
+}
+
+// coilPitchRevs resolves a coil's pitch (a unit-bearing length) and revolution count (a plain
+// number), naming the field on a parse error.
+func coilPitchRevs(part *compdef.PartComponentDefinition, in coilArgs) (pitch, revs float64, err error) {
+	if pitch, err = lengthValue(part, in.Pitch, "coil: pitch"); err != nil {
+		return 0, 0, err
+	}
+	revs, err = strconv.ParseFloat(strings.TrimSpace(in.Revolutions), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("coil: revolutions %q must be a number: %w", in.Revolutions, err)
+	}
+	return pitch, revs, nil
 }
 
 // --- loft ------------------------------------------------------------------

--- a/addin/opregistry/hole.go
+++ b/addin/opregistry/hole.go
@@ -73,6 +73,8 @@ func applyHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 }
 
 // buildHole dispatches on the hole type, resolving the extra dimensions each variant needs.
+//
+//nolint:funlen // one-case-per-hole-type dispatch switch (drilled/counterbore/countersink/tapped); length is the dispatch, like the serialize codecs.
 func buildHole(part *compdef.PartComponentDefinition, in holeArgs, dia float64) (*feature.PartFeature, error) {
 	holes := feature.NewHoleFeatures(part.Features())
 	key := []byte(in.FaceRef)

--- a/addin/router/lighting.go
+++ b/addin/router/lighting.go
@@ -241,4 +241,5 @@ func environmentView(e renderer.Environment) wire.EnvironmentView {
 }
 
 func vec64(v [3]float32) [3]float64 { return [3]float64{float64(v[0]), float64(v[1]), float64(v[2])} }
+
 func vec32(v [3]float64) [3]float32 { return [3]float32{float32(v[0]), float32(v[1]), float32(v[2])} }

--- a/addin/router/sketch3d_surface_curves.go
+++ b/addin/router/sketch3d_surface_curves.go
@@ -20,6 +20,8 @@ import (
 // addSketch3DSurfaceCurve adds a surface-derived curve (intersection/silhouette) to a 3D
 // sketch, resolving the referenced part faces by reference key to their surfaces and
 // wrapping the F10 surface-intersection kernel (M22-F11).
+//
+//nolint:funlen // one-case-per-kind dispatch (intersection/silhouette/onFace/projectToSurface/offset); length is the dispatch, like the serialize codecs.
 func addSketch3DSurfaceCurve(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	part, err := modelaccess.ActivePart(s)
 	if err != nil {

--- a/app/feature_modify_tools.go
+++ b/app/feature_modify_tools.go
@@ -42,6 +42,7 @@ func (t *MoveFaceTool) Name() string { return "Move Face" }
 func (t *MoveFaceTool) Start(s *Session) {
 	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
 }
+
 func (t *MoveFaceTool) Pick(_ *Session, sel Selectable) {
 	if f, ok := sel.(FaceHandle); ok {
 		t.faces = append(t.faces, f)
@@ -50,16 +51,19 @@ func (t *MoveFaceTool) Pick(_ *Session, sel Selectable) {
 
 // Faces returns the picked faces for the unified tool highlight.
 func (t *MoveFaceTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
+
 func (t *MoveFaceTool) Cancel(s *Session) {
 	s.Selection().SetFilter(NewSelectionFilter())
 	t.faces = nil
 }
+
 func (t *MoveFaceTool) Prompt(*Session) string {
 	if len(t.faces) == 0 {
 		return "Click the faces to move."
 	}
 	return "Set the move vector, then OK."
 }
+
 func (t *MoveFaceTool) CanCommit() bool {
 	return len(t.faces) > 0 && (t.dx != 0 || t.dy != 0 || t.dz != 0)
 }
@@ -106,15 +110,18 @@ func (t *CombineTool) Name() string { return "Combine" }
 func (t *CombineTool) Start(s *Session) {
 	s.Selection().SetFilter(NewSelectionFilter(SelectBody))
 }
+
 func (t *CombineTool) Pick(_ *Session, sel Selectable) {
 	if b, ok := sel.(BodyHandle); ok {
 		t.bodies = append(t.bodies, b.Body)
 	}
 }
+
 func (t *CombineTool) Cancel(s *Session) {
 	s.Selection().SetFilter(NewSelectionFilter())
 	t.bodies = nil
 }
+
 func (t *CombineTool) Prompt(*Session) string {
 	return "Pick the target body, then the tool body; set the operation; OK."
 }
@@ -162,21 +169,25 @@ func (t *MoveBodyTool) Name() string { return "Move Bodies" }
 func (t *MoveBodyTool) Start(s *Session) {
 	s.Selection().SetFilter(NewSelectionFilter(SelectBody))
 }
+
 func (t *MoveBodyTool) Pick(_ *Session, sel Selectable) {
 	if b, ok := sel.(BodyHandle); ok {
 		t.bodies = append(t.bodies, b.Body)
 	}
 }
+
 func (t *MoveBodyTool) Cancel(s *Session) {
 	s.Selection().SetFilter(NewSelectionFilter())
 	t.bodies = nil
 }
+
 func (t *MoveBodyTool) Prompt(*Session) string {
 	if len(t.bodies) == 0 {
 		return "Pick a body to move."
 	}
 	return "Set the move vector, then OK."
 }
+
 func (t *MoveBodyTool) CanCommit() bool {
 	return len(t.bodies) > 0 && (t.dx != 0 || t.dy != 0 || t.dz != 0)
 }

--- a/app/feature_pattern_tools.go
+++ b/app/feature_pattern_tools.go
@@ -73,6 +73,7 @@ func (t *FeatureRectPatternTool) Name() string { return "Rectangular Pattern" }
 func (t *FeatureRectPatternTool) Prompt(*Session) string {
 	return "Select features, set the counts and spacing, then OK."
 }
+
 func (t *FeatureRectPatternTool) CanCommit() bool {
 	return len(t.sources) > 0 && t.countX >= 1 && t.countY >= 1 && t.countX*t.countY > 1
 }
@@ -135,8 +136,10 @@ func (t *FeatureCircPatternTool) Commit(s *Session) error {
 func (t *FeatureCircPatternTool) Params() ToolParams {
 	return ToolParams{
 		Ints: []IntParam{{"Count", func() int { return t.count }, func(n int) { t.count = n }}},
-		Floats: []FloatParam{{"Angle (deg)", func() float64 { return degFromRad(t.totalAngle) },
-			func(d float64) { t.totalAngle = radFromDeg(d) }}},
+		Floats: []FloatParam{{
+			"Angle (deg)", func() float64 { return degFromRad(t.totalAngle) },
+			func(d float64) { t.totalAngle = radFromDeg(d) },
+		}},
 	}
 }
 
@@ -156,6 +159,7 @@ func (t *FeatureMirrorTool) Name() string { return "Mirror" }
 func (t *FeatureMirrorTool) Prompt(*Session) string {
 	return "Select features, set the mirror-plane normal, then OK."
 }
+
 func (t *FeatureMirrorTool) CanCommit() bool {
 	return len(t.sources) > 0 && t.normal.Length() > 0
 }

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -104,13 +104,25 @@ func (t *HoleTool) CanCommit() bool {
 	if t.face == nil || t.diameter <= 0 || (!t.through && t.depth <= 0) {
 		return false
 	}
-	if t.counterbore && (t.cDiameter <= t.diameter || t.cDepth <= 0 || (!t.through && t.depth <= t.cDepth)) {
+	if t.counterbore && !t.counterboreValid() {
 		return false
 	}
-	if t.countersink && (t.cDiameter <= t.diameter || t.sinkAngle <= 0 || t.sinkAngle >= stdmath.Pi) {
+	if t.countersink && !t.countersinkValid() {
 		return false
 	}
 	return true
+}
+
+// counterboreValid reports whether the counterbore options are consistent: a wider recess than
+// the bore, a positive recess depth, and (for a blind hole) a bore deeper than the recess.
+func (t *HoleTool) counterboreValid() bool {
+	return t.cDiameter > t.diameter && t.cDepth > 0 && (t.through || t.depth > t.cDepth)
+}
+
+// countersinkValid reports whether the countersink options are consistent: a wider sink than the
+// bore and an included angle in (0, π).
+func (t *HoleTool) countersinkValid() bool {
+	return t.cDiameter > t.diameter && t.sinkAngle > 0 && t.sinkAngle < stdmath.Pi
 }
 
 // Commit drills the hole into the active part and recomputes; a sick feature (lost face,

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Oblikovati/oblikovati/kernel/ops"
 	"github.com/Oblikovati/oblikovati/math"
+	"github.com/Oblikovati/oblikovati/model/compdef"
 	"github.com/Oblikovati/oblikovati/model/feature"
 	"github.com/Oblikovati/oblikovati/model/sketch"
 	"github.com/Oblikovati/oblikovati/renderer"
@@ -208,19 +209,8 @@ func (t *RevolveTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	angle := t.angle
-	revolves := feature.NewRevolveFeatures(part.Features())
-	switch {
-	case t.centerline != nil: // a specific picked/pre-selected centerline
-		t.added = revolves.AddAboutCenterlineLine(t.profile.Sketch, t.profile.ProfileIndex, t.centerlineSk, t.centerline, func() float64 { return angle }, t.operation)
-	case t.useCenterln: // "about the sketch's own centerline" (auto, single)
-		t.added = revolves.AddAboutCenterline(t.profile.Sketch, t.profile.ProfileIndex, func() float64 { return angle }, t.operation)
-	default:
-		axis, ok := part.WorkGeometry().AxisByRef(t.axis)
-		if !ok {
-			return errors.New("revolve: axis " + string(t.axis) + " not found")
-		}
-		t.added = revolves.Add(t.profile.Sketch, t.profile.ProfileIndex, axis, func() float64 { return angle }, t.operation)
+	if t.added, err = t.addRevolve(part); err != nil {
+		return err
 	}
 	part.Recompute()
 	s.recordEdit(part, "Revolve")
@@ -229,6 +219,25 @@ func (t *RevolveTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addRevolve adds the revolve feature about the tool's chosen axis: a specific picked centerline,
+// the sketch's own centerline, or a named work axis.
+func (t *RevolveTool) addRevolve(part *compdef.PartComponentDefinition) (*feature.PartFeature, error) {
+	angle := func() float64 { return t.angle }
+	revolves := feature.NewRevolveFeatures(part.Features())
+	switch {
+	case t.centerline != nil: // a specific picked/pre-selected centerline
+		return revolves.AddAboutCenterlineLine(t.profile.Sketch, t.profile.ProfileIndex, t.centerlineSk, t.centerline, angle, t.operation), nil
+	case t.useCenterln: // "about the sketch's own centerline" (auto, single)
+		return revolves.AddAboutCenterline(t.profile.Sketch, t.profile.ProfileIndex, angle, t.operation), nil
+	default:
+		axis, ok := part.WorkGeometry().AxisByRef(t.axis)
+		if !ok {
+			return nil, errors.New("revolve: axis " + string(t.axis) + " not found")
+		}
+		return revolves.Add(t.profile.Sketch, t.profile.ProfileIndex, axis, angle, t.operation), nil
+	}
 }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).

--- a/app/sketch_transform_tools.go
+++ b/app/sketch_transform_tools.go
@@ -82,6 +82,7 @@ func (t *SketchCopyTool) Name() string   { return "Copy" }
 func (t *SketchCopyTool) Prompt(*Session) string {
 	return "Select geometry, set the copy offset, then OK."
 }
+
 func (t *SketchCopyTool) SetVector(dx, dy float64) {
 	t.vector = math.V2(math.Scalar(dx), math.Scalar(dy))
 }
@@ -127,6 +128,7 @@ func (t *SketchStretchTool) PickSnap(ent sketch.Entity, _ SnapResult) {
 func (t *SketchStretchTool) SetVector(dx, dy float64) {
 	t.vector = math.V2(math.Scalar(dx), math.Scalar(dy))
 }
+
 func (t *SketchStretchTool) SetByPoints(base, target math.Point2) { t.vector = base.VectorTo(target) }
 
 func (t *SketchStretchTool) Commit(s *Session) error {
@@ -152,6 +154,7 @@ func (t *SketchRotateTool) Name() string     { return "Rotate" }
 func (t *SketchRotateTool) Prompt(*Session) string {
 	return "Select geometry, set the center and angle, then OK."
 }
+
 func (t *SketchRotateTool) SetCenter(x, y float64) {
 	t.center = math.P2(math.Scalar(x), math.Scalar(y))
 }
@@ -178,6 +181,7 @@ func (t *SketchScaleTool) Name() string    { return "Scale" }
 func (t *SketchScaleTool) Prompt(*Session) string {
 	return "Select geometry, set the center and factor, then OK."
 }
+
 func (t *SketchScaleTool) SetCenter(x, y float64) {
 	t.center = math.P2(math.Scalar(x), math.Scalar(y))
 }
@@ -214,9 +218,11 @@ func (t *SketchRectPatternTool) Name() string { return "Rectangular Pattern" }
 func (t *SketchRectPatternTool) Prompt(*Session) string {
 	return "Select geometry, set the two directions and counts, then OK."
 }
+
 func (t *SketchRectPatternTool) SetStep1(dx, dy float64) {
 	t.step1 = math.V2(math.Scalar(dx), math.Scalar(dy))
 }
+
 func (t *SketchRectPatternTool) SetStep2(dx, dy float64) {
 	t.step2 = math.V2(math.Scalar(dx), math.Scalar(dy))
 }
@@ -253,6 +259,7 @@ func (t *SketchCircPatternTool) Name() string { return "Circular Pattern" }
 func (t *SketchCircPatternTool) Prompt(*Session) string {
 	return "Select geometry, set the center, count and angle, then OK."
 }
+
 func (t *SketchCircPatternTool) SetCenter(x, y float64) {
 	t.center = math.P2(math.Scalar(x), math.Scalar(y))
 }

--- a/app/tool_highlight_contract_test.go
+++ b/app/tool_highlight_contract_test.go
@@ -10,11 +10,13 @@ import "testing"
 // inconsistency. This test pins the contract: keep it green by giving any new view-picking tool
 // the matching accessor (Edges/Faces/PickedProfiles/PickedProfile/PickedFace).
 
-type edgesAccessor interface{ Edges() []EdgeHandle }
-type facesAccessor interface{ Faces() []FaceHandle }
-type profilesAccessor interface{ PickedProfiles() []ProfileHandle }
-type profileAccessor interface{ PickedProfile() (ProfileHandle, bool) }
-type faceAccessor interface{ PickedFace() (FaceHandle, bool) }
+type (
+	edgesAccessor    interface{ Edges() []EdgeHandle }
+	facesAccessor    interface{ Faces() []FaceHandle }
+	profilesAccessor interface{ PickedProfiles() []ProfileHandle }
+	profileAccessor  interface{ PickedProfile() (ProfileHandle, bool) }
+	faceAccessor     interface{ PickedFace() (FaceHandle, bool) }
+)
 
 // exposesPickAccessor mirrors the head's toolPicks: does the tool expose any pick accessor the
 // unified highlight can read?

--- a/app/undo.go
+++ b/app/undo.go
@@ -115,6 +115,7 @@ func (s *Session) Redo() error {
 // CanUndo / CanRedo report whether the active document has an event behind / ahead of
 // its cursor. They drive the ribbon Undo/Redo enable state. No active document ⇒ false.
 func (s *Session) CanUndo() bool { return s.activeStream() != nil && s.activeStream().hist.CanUndo() }
+
 func (s *Session) CanRedo() bool { return s.activeStream() != nil && s.activeStream().hist.CanRedo() }
 
 // UndoLabel / RedoLabel return the name of the step undo/redo would act on next, for

--- a/command/doc_commands.go
+++ b/command/doc_commands.go
@@ -11,7 +11,8 @@ import "github.com/Oblikovati/oblikovati/model/doc"
 // document state to act on.
 func Rename(d *doc.Document, name string) Command {
 	var previous string
-	return NewFunc("Rename to "+name,
+	return NewFunc(
+		"Rename to "+name,
 		func() error {
 			previous = d.DisplayName()
 			d.SetDisplayName(name)
@@ -31,7 +32,8 @@ func SetVisibility(d *doc.Document, visible bool) Command {
 	if visible {
 		label = "Show"
 	}
-	return NewFunc(label,
+	return NewFunc(
+		label,
 		func() error {
 			previous = d.Visible()
 			d.SetVisible(visible)

--- a/head/internal/addinhost/dl_unix.go
+++ b/head/internal/addinhost/dl_unix.go
@@ -31,6 +31,7 @@ static int  call_void(void* fn)                      { return ((voidFn)fn)(); }
 static int  call_notify(void* fn, const uint8_t* ev, int n) { return ((notifyFn)fn)(ev, n); }
 */
 import "C"
+
 import (
 	"fmt"
 	"unsafe"

--- a/head/internal/addinhost/hostcall.go
+++ b/head/internal/addinhost/hostcall.go
@@ -17,6 +17,7 @@ package addinhost
 #include "oblikovati_addin.h"
 */
 import "C"
+
 import (
 	"context"
 	"sync"

--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -123,7 +123,8 @@ func smokeScene() (verts []float32, idx []uint32, min, max [3]float32) {
 
 // box appends the six faces of an axis-aligned box as PBR quads.
 func box(v *[]float32, idx *[]uint32, base *uint32, x0, x1, y0, y1, z0, z1 float32,
-	col [3]float32, metal, rough float32) {
+	col [3]float32, metal, rough float32,
+) {
 	quad(v, idx, base, [4][3]float32{{x0, y0, z1}, {x1, y0, z1}, {x1, y1, z1}, {x0, y1, z1}}, [3]float32{0, 0, 1}, col, metal, rough)
 	quad(v, idx, base, [4][3]float32{{x1, y0, z0}, {x0, y0, z0}, {x0, y1, z0}, {x1, y1, z0}}, [3]float32{0, 0, -1}, col, metal, rough)
 	quad(v, idx, base, [4][3]float32{{x1, y0, z1}, {x1, y0, z0}, {x1, y1, z0}, {x1, y1, z1}}, [3]float32{1, 0, 0}, col, metal, rough)
@@ -134,7 +135,8 @@ func box(v *[]float32, idx *[]uint32, base *uint32, x0, x1, y0, y1, z0, z1 float
 
 // quad appends one PBR quad (4 corners CCW + a normal) as two triangles in the 16-float layout.
 func quad(v *[]float32, idx *[]uint32, base *uint32, c [4][3]float32, n, col [3]float32,
-	metal, rough float32) {
+	metal, rough float32,
+) {
 	for _, p := range c {
 		*v = append(*v, p[0], p[1], p[2], n[0], n[1], n[2], col[0], col[1], col[2], 1, metal, rough, 0, 0, 0, 2)
 	}

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -117,7 +117,8 @@ func (w *Window) SetViewportEnvironment(data []float32, dims []int32, rotation, 
 // occludeAmbient attenuates the ambient term in shadowed regions (ambient occlusion). A
 // nil/short matrix or enabled=false disables the map. Takes effect next RenderViewport.
 func (w *Window) SetViewportShadow(lightVP []float32, enabled bool, density, softness float32,
-	castOnDirect, occludeAmbient bool) {
+	castOnDirect, occludeAmbient bool,
+) {
 	if !enabled || len(lightVP) != 16 {
 		C.obk_viewport_set_shadow(w.handle, nil, 0, 0, 0, 0, 0)
 		return

--- a/head/ui/axis_gizmo_draw.go
+++ b/head/ui/axis_gizmo_draw.go
@@ -52,5 +52,6 @@ func drawArrowhead(cx, cy, tipX, tipY float32, color [4]float32) {
 		tipX, tipY,
 		bx+px*halfW, by+py*halfW,
 		bx-px*halfW, by-py*halfW,
-		color)
+		color,
+	)
 }

--- a/head/viewport/lighting_pack_test.go
+++ b/head/viewport/lighting_pack_test.go
@@ -15,8 +15,10 @@ func TestPackLightingLayout(t *testing.T) {
 	l := renderer.SceneLighting{
 		Ambience: 0.3, Brightness: 1.2, Exposure: 0.9,
 		Lights: []renderer.SceneLight{
-			{Kind: renderer.PointLight, Direction: [3]float32{0.1, 0.2, 0.3},
-				Color: [3]float32{0.4, 0.5, 0.6}, Intensity: 2, Position: [3]float32{7, 8, 9}, On: true},
+			{
+				Kind: renderer.PointLight, Direction: [3]float32{0.1, 0.2, 0.3},
+				Color: [3]float32{0.4, 0.5, 0.6}, Intensity: 2, Position: [3]float32{7, 8, 9}, On: true,
+			},
 		},
 	}
 	got := PackLighting(l)

--- a/kernel/geom/bspline_test.go
+++ b/kernel/geom/bspline_test.go
@@ -14,7 +14,8 @@ import (
 func quarterCircleNURBS(t *testing.T) BSplineCurve {
 	t.Helper()
 	w := stdmath.Sqrt2 / 2
-	c, err := NewBSplineCurve(2,
+	c, err := NewBSplineCurve(
+		2,
 		[]math.Point3{math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0)},
 		[]float64{1, w, 1},
 		[]float64{0, 0, 0, 1, 1, 1},
@@ -56,7 +57,8 @@ func TestNURBSQuarterCircleStaysOnUnitCircle(t *testing.T) {
 }
 
 func TestNURBSDegree1ReproducesSegment(t *testing.T) {
-	c, err := NewBSplineCurveUniformWeights(1,
+	c, err := NewBSplineCurveUniformWeights(
+		1,
 		[]math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0)},
 		[]float64{0, 0, 1, 1},
 	)

--- a/kernel/ops/split.go
+++ b/kernel/ops/split.go
@@ -74,6 +74,8 @@ func halfSpaceBox(plane geom.Plane, ext float64, positive bool) *topo.Body {
 // away from the box centre, reversing the ring when needed so the loop winds CCW about that
 // outward normal (plane normal and winding stay consistent — the boolean and volume both rely on
 // it). (Lives here so the split has no dependency on the subd package.)
+//
+//nolint:funlen // assembles a box body element-by-element (8 verts, 12 edges, 6 faces); length is the geometry, not logic.
 func boxFromCorners(c [8]math.Point3) *topo.Body {
 	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("split", "box", 0)))
 	tv := make([]*topo.Vertex, 8)

--- a/kernel/ops/surface_edit.go
+++ b/kernel/ops/surface_edit.go
@@ -66,6 +66,8 @@ type sheetPatch struct {
 // merge and faces sharing an edge reconnect (one edge per undirected vertex pair). A single
 // patch yields a one-face sheet; several patches yield a quilt. Patches with <3 points are
 // dropped.
+//
+//nolint:funlen // assembles a sheet/quilt body element-by-element (verts, shared edges, faces); length is the geometry, not logic.
 func buildSheet(patches []sheetPatch, feat string) *topo.Body {
 	w := &sheetWelder{index: map[[3]int64]int{}}
 	rings := make([][]int, 0, len(patches))

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -241,6 +241,8 @@ func periodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Po
 // geometric tip. Each triangle is wound to agree with the cone normal (a reversed face then
 // flips it). ok=false unless the surface is a cone whose boundary is a SINGLE circle at one
 // axial level (a frustum, with two rim circles, spans v and is handled as a band instead).
+//
+//nolint:funlen // builds a triangle fan to the cone apex vertex-by-vertex; length is the tessellation, not logic.
 func coneApexFan(s geom.Surface, outer3D []math.Point3) (*Mesh, bool) {
 	cone, ok := s.(geom.Cone)
 	if !ok || len(outer3D) < 3 {

--- a/model/clientgraphics/colormap_test.go
+++ b/model/clientgraphics/colormap_test.go
@@ -19,10 +19,10 @@ func TestColorMapperInterpolatesMidpoint(t *testing.T) {
 
 func TestColorMapperClampsBelowAndAbove(t *testing.T) {
 	m := mapper()
-	if got := m.At(-3); got != (m.Colors[0]) {
+	if got := m.At(-3); got != m.Colors[0] {
 		t.Errorf("At(-3) = %v, want clamp to %v", got, m.Colors[0])
 	}
-	if got := m.At(9); got != (m.Colors[1]) {
+	if got := m.At(9); got != m.Colors[1] {
 		t.Errorf("At(9) = %v, want clamp to %v", got, m.Colors[1])
 	}
 }

--- a/model/material/assignment.go
+++ b/model/material/assignment.go
@@ -40,8 +40,10 @@ func (s *AssignmentStore) SetPartAppearance(id string) { s.partAppearance = id }
 
 // SetBodyMaterial / SetBodyAppearance / SetFaceAppearance set an override for one
 // body/face key; an empty id removes the override.
-func (s *AssignmentStore) SetBodyMaterial(key, id string)   { setOrClear(s.bodyMaterial, key, id) }
+func (s *AssignmentStore) SetBodyMaterial(key, id string) { setOrClear(s.bodyMaterial, key, id) }
+
 func (s *AssignmentStore) SetBodyAppearance(key, id string) { setOrClear(s.bodyAppearance, key, id) }
+
 func (s *AssignmentStore) SetFaceAppearance(key, id string) { setOrClear(s.faceAppearance, key, id) }
 
 // PartMaterial / PartAppearance / BodyMaterials / BodyAppearances / FaceAppearances expose

--- a/model/material/library.go
+++ b/model/material/library.go
@@ -51,7 +51,8 @@ func (l *Library) Materials() []*Material {
 
 // Appearance / Material look up an asset by id.
 func (l *Library) Appearance(id string) (*Appearance, bool) { a, ok := l.appearances[id]; return a, ok }
-func (l *Library) Material(id string) (*Material, bool)     { m, ok := l.materials[id]; return m, ok }
+
+func (l *Library) Material(id string) (*Material, bool) { m, ok := l.materials[id]; return m, ok }
 
 // DefaultAppearance returns the neutral built-in appearance, the resolver's last resort.
 // It is always present (seeded by the built-in catalog). Part of [AssetLookup].

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -116,7 +116,8 @@ func intersectionCuts(segs []taggedSeg) [][]cut {
 			}
 			pt, s, t, ok := geom.Segment2dIntersection(
 				geom.NewLineSegment2d(segs[i].a, segs[i].b),
-				geom.NewLineSegment2d(segs[j].a, segs[j].b), arrMergeTol)
+				geom.NewLineSegment2d(segs[j].a, segs[j].b), arrMergeTol,
+			)
 			if !ok {
 				continue
 			}

--- a/model/sketch/auto_dimension.go
+++ b/model/sketch/auto_dimension.go
@@ -67,7 +67,6 @@ func (s *Sketch) autoCandidates() []func() func() {
 		}
 	}
 	for _, p := range s.uniqueEntityPoints() {
-		p := p
 		cs = append(cs, func() func() {
 			g := s.GeometricConstraints().AddGroundPoints(p)
 			return func() { s.GeometricConstraints().Delete(g) }

--- a/model/sketch/sketch3d_test.go
+++ b/model/sketch/sketch3d_test.go
@@ -229,7 +229,7 @@ func TestSketch3DSerializeRoundTrip(t *testing.T) {
 		t.Fatalf("restored EntityCount = %d, want 3", got.EntityCount())
 	}
 	pts := got.AllPoints3D()
-	if pts[0].Position() != (math.P3(1, 2, 3)) || pts[1].Position() != (math.P3(-4, 5, -6)) {
+	if pts[0].Position() != math.P3(1, 2, 3) || pts[1].Position() != math.P3(-4, 5, -6) {
 		t.Errorf("restored point positions mismatch: %v, %v", pts[0].Position(), pts[1].Position())
 	}
 	if got.GeometricConstraints3D().Count() != 3 {


### PR DESCRIPTION
The feature merge (#61) brought in accumulated code that the strict golangci-lint config flags, turning the `lint` CI job red. This makes it green again with **no behaviour change**.

## What
- **gofumpt** formatting on all touched files (the stricter formatter the lint enforces).
- **Refactor** genuine-logic functions under funlen/gocyclo: `optionalAngle`/`coilAxis`/`coilPitchRevs` (opregistry), `RevolveTool.addRevolve`, `HoleTool.counterboreValid`/`countersinkValid`.
- **Exclude inherent-length cases** consistently with the existing serialize-codec rule: ribbon command tables + router/descriptor registries, the cylinder/drill B-rep assemblers (file-scoped), and per-kind dispatch switches (`buildHole`, `addSketch3DSurfaceCurve`) via `//nolint:funlen` with a rationale. Added `unparam` to the `_test.go` exclusion.

## Test
`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all green locally (0 issues outside the git-ignored `experiments/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)