### PR TITLE
Fix docs-links CI: drop broken ../../REPORT.md links

### DIFF
--- a/implementation-plan/DEFERRALS.md
+++ b/implementation-plan/DEFERRALS.md
@@ -1,6 +1,6 @@
 # Deferral Ledger
 
-_Generated 2026-06-04 during the audit (see [REPORT.md](../../REPORT.md) §6). This is the
+_Generated 2026-06-04 during the audit (see REPORT.md §6). This is the
 canonical, code-derived list of where "done" means "scaffolded": every
 `NotYetImplemented`, every `ErrDeferred` passthrough, and the in-code `follow-up` /
 `phase B/C/D` / `deferred` comments in non-test source._

--- a/implementation-plan/PROGRESS.md
+++ b/implementation-plan/PROGRESS.md
@@ -3,7 +3,7 @@
 Live tracker for building Oblikovati against [the roadmap](README.md). Updated as
 each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (green in CI).
 
-> **⚠ Audited 2026-06-04 (see [REPORT.md](../../REPORT.md)).** The milestone table below
+> **⚠ Audited 2026-06-04 (see REPORT.md).** The milestone table below
 > was reconciled against the actual code. It had been wrong in both directions —
 > under-reporting shipped work (M16/M18/M19/M23) and over-stating completion against the
 > Definition of Done (M05/M09/M10/M21). Per CONVENTIONS.md "Status model", a feature is


### PR DESCRIPTION
REPORT.md is a workspace-root audit artifact, not in this repo, so the `[REPORT.md](../../REPORT.md)` links in DEFERRALS.md/PROGRESS.md resolve outside the checkout and fail the lychee `docs-links` job (the other docs reference it as plain text, which lychee ignores). Converts the two links to plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)