### PR TITLE
Improve head document workflows and model browser visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ ipch/
 
 # Visual Studio profiler
 *.psess
+.local-native-lib/
 *.vsp
 *.vspx
 *.sap

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ vet: ## Run go vet (cgo-free)
 .PHONY: lint
 lint: ## Run golangci-lint (install with `make tools`)
 	golangci-lint run
+	$(MAKE) -C head lint
 
 .PHONY: docs-lint
 docs-lint: ## Lint the docs (markdownlint via npx; needs node). Link check runs in CI (lychee).

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -25,6 +25,10 @@ func BrowserMenu(n BrowserNode) []BrowserMenuItem {
 		return featureMenu(n.Select)
 	case "workplane":
 		return workPlaneMenu(n.Select)
+	case "workaxis":
+		return workAxisMenu(n.Select)
+	case "body":
+		return bodyMenu(n.Select)
 	default:
 		return nil
 	}
@@ -81,4 +85,26 @@ func workPlaneMenu(sel Selectable) []BrowserMenuItem {
 			return nil
 		}},
 	}
+}
+
+func workAxisMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(WorkAxisHandle)
+	if !ok {
+		return nil
+	}
+	return []BrowserMenuItem{{Label: "Visibility", Enabled: true, Invoke: func(*Session) error {
+		h.Axis.SetVisible(!h.Axis.Visible())
+		return nil
+	}}}
+}
+
+func bodyMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(BodyHandle)
+	if !ok {
+		return nil
+	}
+	return []BrowserMenuItem{{Label: "Visibility", Enabled: true, Invoke: func(s *Session) error {
+		s.ToggleBodyVisibility(h.Body)
+		return nil
+	}}}
 }

--- a/app/browser_menu_test.go
+++ b/app/browser_menu_test.go
@@ -86,8 +86,42 @@ func TestBrowserMenuByKind(t *testing.T) {
 	if labels := menuLabels(BrowserMenu(findNode(t, root, "workplane"))); !equalStrings(labels, []string{"New Sketch", "Visibility"}) {
 		t.Errorf("workplane menu = %v", labels)
 	}
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "workaxis"))); !equalStrings(labels, []string{"Visibility"}) {
+		t.Errorf("workaxis menu = %v", labels)
+	}
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "body"))); !equalStrings(labels, []string{"Visibility"}) {
+		t.Errorf("body menu = %v", labels)
+	}
 	if m := BrowserMenu(findNode(t, root, "parameters")); m != nil {
 		t.Errorf("parameters folder should have no menu, got %v", menuLabels(m))
+	}
+}
+
+func TestBrowserMenuWorkAxisVisibilityToggles(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	node := findNode(t, BuildBrowser(s), "workaxis")
+	axis := node.Select.(WorkAxisHandle).Axis
+	before := axis.Visible()
+	if err := menuItem(t, BrowserMenu(node), "Visibility").Invoke(s); err != nil {
+		t.Fatalf("Visibility: %v", err)
+	}
+	if axis.Visible() == before {
+		t.Error("axis Visibility menu item did not toggle visibility")
+	}
+}
+
+func TestBrowserMenuBodyVisibilityToggles(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	node := findNode(t, BuildBrowser(s), "body")
+	body := node.Select.(BodyHandle).Body
+	if !s.BodyVisible(body) {
+		t.Fatal("body should start visible")
+	}
+	if err := menuItem(t, BrowserMenu(node), "Visibility").Invoke(s); err != nil {
+		t.Fatalf("Visibility: %v", err)
+	}
+	if s.BodyVisible(body) || len(s.VisibleBodies()) != 0 {
+		t.Fatal("body Visibility menu item did not hide the body from visible scene bodies")
 	}
 }
 

--- a/app/render.go
+++ b/app/render.go
@@ -46,7 +46,7 @@ func (s *Session) GraphicsLabels() []clientgraphics.Label {
 // overlays, the active tool's transient preview, and the add-in client/interaction
 // graphics — and submits it to the backend.
 func (s *Session) RenderFrame(backend renderer.Backend) {
-	list := renderer.BuildDrawListStyled(s.sceneBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup(), s.visualStyle)
+	list := renderer.BuildDrawListStyled(s.VisibleBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup(), s.visualStyle)
 	list.Items = append(list.Items, s.overlays...)
 	if s.tool != nil {
 		if p, ok := s.tool.tool.(Previewable); ok {
@@ -59,10 +59,43 @@ func (s *Session) RenderFrame(backend renderer.Backend) {
 }
 
 // sceneBodies returns the bodies to draw — the active part's, if any.
-func (s *Session) sceneBodies() []*topo.Body {
+func (s *Session) sceneBodies() []*topo.Body { return s.VisibleBodies() }
+
+// VisibleBodies returns active-part bodies not hidden by browser visibility state.
+func (s *Session) VisibleBodies() []*topo.Body {
 	part, err := activePart(s)
 	if err != nil {
 		return nil
 	}
-	return part.SurfaceBodies().All()
+	var out []*topo.Body
+	for _, body := range part.SurfaceBodies().All() {
+		if s.BodyVisible(body) {
+			out = append(out, body)
+		}
+	}
+	return out
 }
+
+// BodyVisible reports whether body is included in the active scene body list.
+func (s *Session) BodyVisible(body *topo.Body) bool {
+	if body == nil {
+		return false
+	}
+	return !s.hiddenBodyKeys[string(body.ReferenceKey())]
+}
+
+// SetBodyVisible updates the browser-driven display state for one body.
+func (s *Session) SetBodyVisible(body *topo.Body, visible bool) {
+	if body == nil {
+		return
+	}
+	key := string(body.ReferenceKey())
+	if visible {
+		delete(s.hiddenBodyKeys, key)
+		return
+	}
+	s.hiddenBodyKeys[key] = true
+}
+
+// ToggleBodyVisibility flips the browser-driven display state for one body.
+func (s *Session) ToggleBodyVisibility(body *topo.Body) { s.SetBodyVisible(body, !s.BodyVisible(body)) }

--- a/app/render_test.go
+++ b/app/render_test.go
@@ -90,6 +90,17 @@ func TestRenderFrameNoActivePart(t *testing.T) {
 	}
 }
 
+func TestRenderFrameSkipsHiddenBody(t *testing.T) {
+	s := extrudedBox(t, 2, 4)
+	body := s.VisibleBodies()[0]
+	s.SetBodyVisible(body, false)
+	null := &renderer.NullBackend{}
+	s.RenderFrame(null)
+	if tris := null.LastFrame().Triangles(); tris != 0 {
+		t.Fatalf("hidden body rendered %d triangles, want 0", tris)
+	}
+}
+
 func frameItems(s *Session) int {
 	null := &renderer.NullBackend{}
 	s.RenderFrame(null)

--- a/app/session.go
+++ b/app/session.go
@@ -39,6 +39,7 @@ type Session struct {
 	activeSketch3D     *sketch.Sketch3D
 	pendingDim         *sketch.DimensionConstraint
 	overlays           []renderer.DrawItem
+	hiddenBodyKeys     map[string]bool
 	graphics           *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins             *AddInManager
 	grid               *GridSettings
@@ -86,6 +87,7 @@ func newSession(store doc.Store) *Session {
 		bus:                event.NewBus(),
 		selection:          NewSelection(),
 		camera:             scene.NewCamera(800, 600),
+		hiddenBodyKeys:     map[string]bool{},
 		graphics:           clientgraphics.NewStore(),
 		addins:             NewAddInManager(),
 		visualStyle:        renderer.ShadedWithEdges,

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -254,20 +254,20 @@ func TestToggleWorkPlaneVisibilitySessionAndKeyboard(t *testing.T) {
 	s, def := emptyPartSession(t)
 	xy := def.OriginPlanes()[0]
 	selectPlanes(s, xy)
-	if !xy.Visible() {
-		t.Fatal("plane should start visible")
+	if xy.Visible() {
+		t.Fatal("origin plane should start hidden")
 	}
 	// The session method toggles every selected plane.
 	s.ToggleSelectedWorkPlaneVisibility()
-	if xy.Visible() {
-		t.Error("ToggleSelectedWorkPlaneVisibility should hide the selected plane")
+	if !xy.Visible() {
+		t.Error("ToggleSelectedWorkPlaneVisibility should show the selected plane")
 	}
 	// The V keyboard shortcut toggles it back.
 	if err := s.PressKey(KeyEvent{Key: "V"}); err != nil {
 		t.Fatalf("PressKey V: %v", err)
 	}
-	if !xy.Visible() {
-		t.Error("V should toggle the selected plane's visibility back on")
+	if xy.Visible() {
+		t.Error("V should toggle the selected plane's visibility back off")
 	}
 }
 

--- a/head/Makefile
+++ b/head/Makefile
@@ -4,7 +4,29 @@
 export CGO_ENABLED := 1
 export GOTOOLCHAIN := go1.24.0
 
-.PHONY: build smoke run shaders clean
+HOST_NATIVE_LIB_DIR := /run/host/usr/lib/x86_64-linux-gnu
+HOST_PKG_CONFIG_DIR := $(HOST_NATIVE_LIB_DIR)/pkgconfig
+LOCAL_NATIVE_LIB_DIR := $(abspath $(CURDIR)/../.local-native-lib)
+
+ifneq ($(wildcard $(HOST_PKG_CONFIG_DIR)/glfw3.pc),)
+export PKG_CONFIG_PATH := $(HOST_PKG_CONFIG_DIR)$(if $(PKG_CONFIG_PATH),:$(PKG_CONFIG_PATH))
+export PKG_CONFIG_SYSROOT_DIR := /run/host
+export LD_LIBRARY_PATH := $(LOCAL_NATIVE_LIB_DIR)$(if $(LD_LIBRARY_PATH),:$(LD_LIBRARY_PATH))
+endif
+
+.PHONY: build smoke run run-watch lint test shaders native-libs clean
+
+# native-libs exposes only the host GLFW/Vulkan runtime libs to Flatpak builds.
+# Do not put the whole host libdir on LD_LIBRARY_PATH; it can load host libc into
+# the SDK process and break cgo.
+native-libs:
+	@if [ -d "$(HOST_NATIVE_LIB_DIR)" ]; then \
+		mkdir -p "$(LOCAL_NATIVE_LIB_DIR)"; \
+		ln -sfn "$(HOST_NATIVE_LIB_DIR)/libglfw.so" "$(LOCAL_NATIVE_LIB_DIR)/libglfw.so"; \
+		ln -sfn "$(HOST_NATIVE_LIB_DIR)/libglfw.so.3" "$(LOCAL_NATIVE_LIB_DIR)/libglfw.so.3"; \
+		ln -sfn "$(HOST_NATIVE_LIB_DIR)/libvulkan.so" "$(LOCAL_NATIVE_LIB_DIR)/libvulkan.so"; \
+		ln -sfn "$(HOST_NATIVE_LIB_DIR)/libvulkan.so.1" "$(LOCAL_NATIVE_LIB_DIR)/libvulkan.so.1"; \
+	fi
 
 # shaders recompiles the viewport GLSL to the embedded SPIR-V (needs glslangValidator
 # from glslang-tools). Run after editing internal/native/shaders/*.vert|frag.
@@ -16,20 +38,26 @@ shaders:
 		glslangValidator -V skybox.frag -o skybox.frag.spv
 
 # build compiles every head command (proves the cgo/Vulkan stack links).
-build:
+build: native-libs
 	go build ./...
+
+lint: native-libs
+	golangci-lint run ./...
+
+test: native-libs
+	go test ./...
 
 # smoke opens a real GLFW+Vulkan window, renders a few Dear ImGui frames, and exits 0
 # if the whole native stack initialized. Requires a display (X11/Wayland) + a Vulkan
 # driver (hardware or lavapipe).
-smoke:
+smoke: native-libs
 	go run ./cmd/headsmoke -frames 5
 
 # run launches the application. It points the add-in loader at ./addins (where
 # `make install` in add-in/oblikovati-mcp-bridge drops the built library), so any
 # installed add-in (e.g. the MCP bridge) loads at startup. Override with
 # OBK_ADDINS_DIR, and OBK_MCP_ADDR to move the MCP endpoint off 127.0.0.1:7800.
-run:
+run: native-libs
 	OBK_ADDINS_DIR=$(CURDIR)/addins go run ./cmd/oblikovati-head
 
 # run-watch launches the app under a relaunch loop with OBK_ADDIN_AUTORESTART=1, so a
@@ -38,7 +66,7 @@ run:
 # Go c-shared add-in cannot be swapped in a live process). The head binary is built
 # ONCE and the prebuilt binary is relaunched, so a .so swap restarts in ~1s (no cgo
 # recompile). Re-run this target after changing head source. Ctrl-C twice to stop.
-run-watch:
+run-watch: native-libs
 	go build -o oblikovati-head ./cmd/oblikovati-head
 	@while true; do \
 		OBK_ADDINS_DIR=$(CURDIR)/addins OBK_ADDIN_AUTORESTART=1 ./oblikovati-head || true; \

--- a/head/Part1
+++ b/head/Part1
@@ -1,6 +1,6 @@
 schemaVersion: 2
 documentType: 1
-displayName: demo
+displayName: Part1
 model:
     units:
         angle: deg
@@ -9,10 +9,6 @@ model:
         mass: kg
         time: s
         volume: mm^3
-    parameters:
-        - name: width
-          kind: user
-          expression: 4 cm
     sketches:
         - name: Sketch1
           plane:
@@ -21,51 +17,51 @@ model:
                 - 0
                 - 0
             xAxis:
-                - 1
                 - 0
+                - 1
                 - 0
             yAxis:
                 - 0
-                - 1
                 - 0
+                - 1
           points:
-            - id: 2
-              x: 0
-              "y": 0
+            - id: 11
+              x: -2.570897720126885
+              "y": 5.03803723630246
               standalone: true
-            - id: 3
-              x: 4
-              "y": 0
+            - id: 12
+              x: 3.0551026718996614
+              "y": 5.03803723630246
               standalone: true
-            - id: 4
-              x: 4
-              "y": 3
+            - id: 13
+              x: 3.0551026718996614
+              "y": -3.3202625264418963
               standalone: true
-            - id: 5
-              x: 0
-              "y": 3
+            - id: 14
+              x: -2.570897720126885
+              "y": -3.3202625264418963
               standalone: true
           entities:
-            - id: 6
+            - id: 15
               kind: line
               points:
-                - 2
-                - 3
-            - id: 7
+                - 11
+                - 12
+            - id: 16
               kind: line
               points:
-                - 3
-                - 4
-            - id: 8
+                - 12
+                - 13
+            - id: 17
               kind: line
               points:
-                - 4
-                - 5
-            - id: 9
+                - 13
+                - 14
+            - id: 18
               kind: line
               points:
-                - 5
-                - 2
+                - 14
+                - 11
     features:
         - kind: extrude
           name: Extrusion1
@@ -76,4 +72,4 @@ model:
             operation: newBody
             extent: distance
             direction: positive
-            distance: 5
+            distance: 10

--- a/head/blank.obk
+++ b/head/blank.obk
@@ -1,0 +1,26 @@
+schemaVersion: 2
+documentType: 1
+displayName: blank
+model:
+    units:
+        angle: deg
+        area: mm^2
+        length: mm
+        mass: kg
+        time: s
+        volume: mm^3
+    sketches:
+        - name: Sketch1
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 1
+                - 0
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1

--- a/head/cmd/headsmoke/main.go
+++ b/head/cmd/headsmoke/main.go
@@ -27,5 +27,5 @@ func main() {
 		fmt.Fprintf(os.Stderr, "head smoke failed at init step %d\n", code)
 		os.Exit(code)
 	}
-	fmt.Printf("head smoke ok: rendered up to %d frames\n", *frames)
+	fmt.Fprintf(os.Stdout, "head smoke ok: rendered up to %d frames\n", *frames)
 }

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -152,10 +152,7 @@ func seedPart(s *app.Session) {
 // activeBodies returns the active document's part bodies (nil if no active part), for
 // the picker's hit-test so it follows the current document.
 func activeBodies(s *app.Session) []*topo.Body {
-	if p, err := modelaccess.ActivePart(s); err == nil {
-		return p.SurfaceBodies().All()
-	}
-	return nil
+	return s.VisibleBodies()
 }
 
 // activeOriginPlanes returns the active part's origin work planes (nil if none), so
@@ -190,7 +187,9 @@ func activeWorkAxes(s *app.Session) []*feature.WorkAxis {
 	axes := p.WorkAxes()
 	out := make([]*feature.WorkAxis, 0, axes.Count())
 	for i := 0; i < axes.Count(); i++ {
-		out = append(out, axes.Item(i))
+		if ax := axes.Item(i); ax.Visible() {
+			out = append(out, ax)
+		}
 	}
 	return out
 }

--- a/head/demo2.obk
+++ b/head/demo2.obk
@@ -1,6 +1,6 @@
 schemaVersion: 2
 documentType: 1
-displayName: demo
+displayName: demo2
 model:
     units:
         angle: deg

--- a/head/internal/envimage/hdr.go
+++ b/head/internal/envimage/hdr.go
@@ -76,14 +76,13 @@ func readHDRHeader(r *bufio.Reader) (int, int, error) {
 // 4-byte header marks it, else reading flat RGBE pixels.
 func readHDRScanline(r *bufio.Reader, row []byte, w int) error {
 	var hdr [4]byte
-	if _, err := readFull(r, hdr[:]); err != nil {
+	if err := readFull(r, hdr[:]); err != nil {
 		return err
 	}
 	rle := hdr[0] == 2 && hdr[1] == 2 && int(hdr[2])<<8|int(hdr[3]) == w && w >= 8 && w < 0x8000
 	if !rle { // flat: hdr is the first pixel, read the rest
 		copy(row[:4], hdr[:])
-		_, err := readFull(r, row[4:])
-		return err
+		return readFull(r, row[4:])
 	}
 	for ch := 0; ch < 4; ch++ { // four RLE-encoded channel planes
 		if err := decodeRLEChannel(r, row, ch, w); err != nil {
@@ -134,14 +133,14 @@ func rgbeToFloat(r, g, b, e byte) (float32, float32, float32) {
 
 // readFull reads len(buf) bytes or returns an error (bufio.Reader has no io.ReadFull shortcut
 // that surfaces short reads as cleanly here).
-func readFull(r *bufio.Reader, buf []byte) (int, error) {
+func readFull(r *bufio.Reader, buf []byte) error {
 	n := 0
 	for n < len(buf) {
 		m, err := r.Read(buf[n:])
 		n += m
 		if err != nil {
-			return n, err
+			return err
 		}
 	}
-	return n, nil
+	return nil
 }

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -26,11 +26,13 @@ void obk_ig_separator_vertical(void);
 int  obk_ig_mouse_double_clicked(int button);
 int  obk_ig_begin_tab_bar(const char* id);
 int  obk_ig_begin_tab_item_ex(const char* label, int setSelected);
+int  obk_ig_begin_tab_item_closable(const char* label, int setSelected, int* open);
 int  obk_ig_selectable(const char* label, int selected);
 void obk_ig_end_tab_bar(void);
 int  obk_ig_begin_tab_item(const char* label);
 void obk_ig_end_tab_item(void);
 int  obk_ig_collapsing_header(const char* l);
+void obk_ig_set_next_item_open(int open, int first_use);
 int  obk_ig_tree_node(const char* label);
 void obk_ig_tree_pop(void);
 void obk_ig_bullet_text(const char* s);
@@ -374,6 +376,16 @@ func BeginTabItemSelected(label string, setSelected bool) bool {
 	return C.obk_ig_begin_tab_item_ex(c, cBool(setSelected)) != 0
 }
 
+// BeginTabItemClosable is BeginTabItemSelected with ImGui's close button. It reports
+// whether the tab content is visible and whether the tab should remain open.
+func BeginTabItemClosable(label string, setSelected bool) (bool, bool) {
+	c, free := cstr(label)
+	defer free()
+	open := C.int(1)
+	visible := C.obk_ig_begin_tab_item_closable(c, cBool(setSelected), &open) != 0
+	return visible, open != 0
+}
+
 // Selectable draws a clickable, highlightable row (browser entries); returns true when
 // clicked this frame.
 func Selectable(label string, selected bool) bool {
@@ -391,6 +403,8 @@ func CollapsingHeader(label string) bool {
 
 // TreeNode / TreePop bracket a tree node; TreeNode reports whether it is expanded
 // (only call TreePop when it returned true).
+func SetNextItemOpen(open, firstUse bool) { C.obk_ig_set_next_item_open(cBool(open), cBool(firstUse)) }
+
 func TreeNode(label string) bool {
 	c, free := cstr(label)
 	defer free()

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -52,6 +52,15 @@ int  obk_ig_begin_tab_item_ex(const char* l, int setSelected) {
     ImGuiTabItemFlags f = setSelected ? ImGuiTabItemFlags_SetSelected : 0;
     return ImGui::BeginTabItem(l, nullptr, f) ? 1 : 0;
 }
+// begin_tab_item_closable is the same tab primitive with ImGui's close affordance.
+// It writes open=0 on the frame the close button is clicked.
+int  obk_ig_begin_tab_item_closable(const char* l, int setSelected, int* open) {
+    bool p_open = (*open != 0);
+    ImGuiTabItemFlags f = setSelected ? ImGuiTabItemFlags_SetSelected : 0;
+    bool visible = ImGui::BeginTabItem(l, &p_open, f);
+    *open = p_open ? 1 : 0;
+    return visible ? 1 : 0;
+}
 void obk_ig_end_tab_item(void)               { ImGui::EndTabItem(); }
 // selectable is a clickable browser row; returns 1 on click. selected draws it
 // highlighted (the current selection).
@@ -60,6 +69,9 @@ int  obk_ig_selectable(const char* label, int selected) {
 }
 
 int  obk_ig_collapsing_header(const char* l) { return ImGui::CollapsingHeader(l) ? 1 : 0; }
+void obk_ig_set_next_item_open(int open, int first_use) {
+    ImGui::SetNextItemOpen(open != 0, first_use != 0 ? ImGuiCond_FirstUseEver : ImGuiCond_Always);
+}
 int  obk_ig_tree_node(const char* label)     { return ImGui::TreeNode(label) ? 1 : 0; }
 void obk_ig_tree_pop(void)                   { ImGui::TreePop(); }
 void obk_ig_bullet_text(const char* s)       { ImGui::BulletText("%s", s); }

--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -51,24 +51,9 @@ func RunViewportSmoke(maxFrames int) int {
 	}
 	defer w.Destroy()
 	w.InitViewport()
-
-	// A representative scene: a metallic cube on a matte ground plane, lit by a strong sun with
-	// the Outdoors HDR sky — so the readback PNG shows IBL reflections, the skybox, and a cast
-	// shadow on the ground.
 	verts, idx, min, max := smokeScene()
-	lightDir := [3]float32{0.5, 0.85, 0.4}
-	rig := renderer.SceneLightingFor(renderer.LightingSun)
-	rig.Lights[0].Direction = lightDir
-	w.SetViewportLighting(viewport.PackLighting(rig))
-	if img, ok, _ := envimage.Resolve(renderer.Environment{Preset: renderer.EnvOutdoors, Intensity: 1}); ok {
-		u := envimage.Flatten(envimage.MipChain(img))
-		w.SetViewportEnvironment(u.Data, u.Dims, 0, 1)
-	}
-	lvp := viewport.LightMatrix(min, max, lightDir)
-	w.SetViewportShadow(lvp[:], true, 0.6, 0.3, true, true) // cast on direct + occlude ambient
-
-	cam := scene.NewCamera(1280, 720)
-	cam.Eye, cam.Target, cam.Up = math.P3(3.5, 3, 5), math.P3(0, 0.4, 0), math.V3(0, 1, 0)
+	configureViewportSmokeLighting(w, min, max)
+	cam := smokeCamera()
 	mvp := renderer.ViewProjection(cam, 0.1, 100)
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
 	if inv, ok := viewport.Invert4x4(mvp); ok {
@@ -87,6 +72,25 @@ func RunViewportSmoke(maxFrames int) int {
 		}
 	}
 	return 0
+}
+
+func configureViewportSmokeLighting(w *Window, min, max [3]float32) {
+	lightDir := [3]float32{0.5, 0.85, 0.4}
+	rig := renderer.SceneLightingFor(renderer.LightingSun)
+	rig.Lights[0].Direction = lightDir
+	w.SetViewportLighting(viewport.PackLighting(rig))
+	if img, ok, _ := envimage.Resolve(renderer.Environment{Preset: renderer.EnvOutdoors, Intensity: 1}); ok {
+		u := envimage.Flatten(envimage.MipChain(img))
+		w.SetViewportEnvironment(u.Data, u.Dims, 0, 1)
+	}
+	lvp := viewport.LightMatrix(min, max, lightDir)
+	w.SetViewportShadow(lvp[:], true, 0.6, 0.3, true, true) // cast on direct + occlude ambient
+}
+
+func smokeCamera() scene.Camera {
+	cam := scene.NewCamera(1280, 720)
+	cam.Eye, cam.Target, cam.Up = math.P3(3.5, 3, 5), math.P3(0, 0.4, 0), math.V3(0, 1, 0)
+	return cam
 }
 
 // saveViewportPNG reads the offscreen color image back and writes it as a PNG (swapping the

--- a/head/ui/appearance_tab.go
+++ b/head/ui/appearance_tab.go
@@ -5,8 +5,6 @@
 package ui
 
 import (
-	"bytes"
-
 	"oblikovati/api/types"
 	"oblikovati/app"
 	"oblikovati/head/internal/native"
@@ -111,19 +109,4 @@ func errText(err error) string {
 		return err.Error()
 	}
 	return ""
-}
-
-// bufString reads the NUL-terminated text ImGui wrote into an InputText buffer.
-func bufString(b []byte) string {
-	if i := bytes.IndexByte(b, 0); i >= 0 {
-		return string(b[:i])
-	}
-	return string(b)
-}
-
-// clearBuf zeroes an InputText buffer (so the field empties after a successful action).
-func clearBuf(b []byte) {
-	for i := range b {
-		b[i] = 0
-	}
 }

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -76,6 +76,9 @@ func openFeatureEditOnDoubleClick(s *app.Session, n app.BrowserNode) {
 // drawBranchNode draws a collapsible folder and recurses into its children when open. A
 // branch may still carry a context menu (e.g. a work-plane row that owns children later).
 func drawBranchNode(s *app.Session, n app.BrowserNode) {
+	if n.Kind == "document" {
+		native.SetNextItemOpen(true, true)
+	}
 	open := native.TreeNode(n.Label)
 	drawNodeMenu(s, n)
 	if !open {

--- a/head/ui/buffers.go
+++ b/head/ui/buffers.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "bytes"
+
+// bufString reads the NUL-terminated text ImGui wrote into an InputText buffer.
+func bufString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		return string(b[:i])
+	}
+	return string(b)
+}
+
+// clearBuf zeroes an InputText buffer so the field empties after a successful action.
+func clearBuf(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -40,15 +40,7 @@ func drawChamferDialog(s *app.Session) {
 		if native.Checkbox("Flat corner (3 edges)", &chamferUI.flatCorners) {
 			c.SetFlatCorners(chamferUI.flatCorners)
 		}
-		native.BeginDisabled(!c.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawCommitCancelButtons(s, c.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -30,26 +30,53 @@ import (
 // function stays free of side effects on the model. The window is needed to render the
 // 3D viewport into its offscreen target.
 func DrawChrome(win *native.Window, s *app.Session) string {
+	prepareChromeFrame(win, s)
+	drawMenuBar(s)
+	activated := ""
+	if id := drawRibbon(s); id != "" {
+		activated = id
+	}
+	drawBrowser(s)
+	drawViewportIfPresent(win, s)
+	drawChromeDialogs(s)
+	drawStatusBar(s)
+	drawChromeWindows(s)
+	drawDocumentClosePrompt(s)
+	drawFileDialog(s)
+	return activated
+}
+
+func prepareChromeFrame(win *native.Window, s *app.Session) {
 	if icons == nil {
 		icons = newIconCache(win) // lazily bind the icon cache to this window
 	}
 	applyThemeIfChanged(win, s) // restyle ImGui + overlays when the theme changed (live preview)
 	handleKeyboard(s)
-	activated := drawMenuBar(s)
 	dockID := native.DockSpaceOverMain()
 	if !dockLaidOut {
 		native.DockDefaultLayout(dockID, "Ribbon", "Model", "Viewport", "Status")
 		dockLaidOut = true
 	}
 	followActiveDocument(s)
-	if id := drawRibbon(s); id != "" {
-		activated = id
+}
+
+func drawViewportIfPresent(win *native.Window, s *app.Session) {
+	if shouldDrawViewport(s) {
+		drawViewportPanel(win, s)
 	}
-	drawBrowser(s)
-	drawViewportPanel(win, s)
+}
+
+func drawChromeDialogs(s *app.Session) {
 	drawDimensionPopup(s)
 	drawToolParamsDialog(s) // generic dialog for parameterized sketch tools
 	drawSketch3DSettings(s) // 3D-sketch settings while editing one
+	drawSolidFeatureDialogs(s)
+	drawSurfaceFeatureDialogs(s)
+	drawOffsetPlaneDialog(s)
+	drawFeatureEditDialog(s)
+}
+
+func drawSolidFeatureDialogs(s *app.Session) {
 	drawExtrudeDialog(s)
 	drawRevolveDialog(s)
 	drawCoilDialog(s)
@@ -60,15 +87,18 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	drawThreadDialog(s)
 	drawFilletDialog(s)
 	drawShellDialog(s)
+	drawSplitDialog(s)
+}
+
+func drawSurfaceFeatureDialogs(s *app.Session) {
 	drawFaceOffsetDialog(s)
 	drawDraftDialog(s)
 	drawDeleteFaceDialog(s)
 	drawReplaceFaceDialog(s)
 	drawThickenDialog(s)
-	drawSplitDialog(s)
-	drawOffsetPlaneDialog(s)
-	drawFeatureEditDialog(s)
-	drawStatusBar(s)
+}
+
+func drawChromeWindows(s *app.Session) {
 	drawParametersWindow(s)
 	drawPreferencesWindow(s)
 	drawMaterialsWindow(s)
@@ -76,8 +106,6 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}
-	drawFileDialog(s)
-	return activated
 }
 
 // handleKeyboard routes global shortcuts to the session. Esc cancels the active tool at
@@ -122,7 +150,7 @@ func activeBodies(s *app.Session) []*topo.Body {
 	if part == nil {
 		return nil
 	}
-	return part.SurfaceBodies().All()
+	return s.VisibleBodies()
 }
 
 // activePart returns the active document's part component definition, or nil.

--- a/head/ui/chrome_doctabs.go
+++ b/head/ui/chrome_doctabs.go
@@ -8,7 +8,10 @@ import (
 	"oblikovati/app"
 	"oblikovati/head/internal/native"
 	"oblikovati/math"
+	"oblikovati/model/doc"
 )
+
+var closeDocumentModal documentCloseGuard
 
 // prevFramedDoc tracks which document the camera was last framed to, so switching
 // the active document (New Part, a tab, an add-in) reframes the view to the new one.
@@ -70,20 +73,22 @@ func drawDocumentTabs(s *app.Session) {
 
 	if native.BeginTabBar("##doc-tabs") {
 		for _, d := range docs {
-			selected := force && active != nil && d.ID() == active.ID()
-			open := native.BeginTabItemSelected(d.DisplayName(), selected)
-			// Only treat a tab as a user click on non-force frames. On a force frame we
-			// are asserting the active tab via SetSelected, which ImGui applies on the
-			// NEXT frame — so this frame BeginTabItem still reports the OLD visible tab.
-			// Acting on that would call SetActiveDocument for the old document and flip
-			// the active doc back, oscillating every frame.
-			if open && !force && (active == nil || d.ID() != active.ID()) {
-				_ = s.Workspace().SetActiveDocument(d)
-			}
-			if open {
-				native.EndTabItem()
-			}
+			drawDocumentTab(s, d, active, force)
 		}
 		native.EndTabBar()
+	}
+}
+
+func drawDocumentTab(s *app.Session, d *doc.Document, active *doc.Document, force bool) {
+	selected := force && active != nil && d.ID() == active.ID()
+	open, keep := native.BeginTabItemClosable(d.DisplayName(), selected)
+	if open && keep && !force && (active == nil || d.ID() != active.ID()) {
+		_ = s.Workspace().SetActiveDocument(d)
+	}
+	if open {
+		native.EndTabItem()
+	}
+	if !keep && closeDocumentModal.request(d) {
+		closeDocumentNow(s, d, false)
 	}
 }

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -11,10 +11,17 @@ import (
 
 // drawMenuBar renders the top menu bar. Only the few items that map to real session
 // verbs are wired; the rest grow with the feature set.
-func drawMenuBar(s *app.Session) string {
+func drawMenuBar(s *app.Session) {
 	if !native.BeginMainMenuBar() {
-		return ""
+		return
 	}
+	drawFileMenu(s)
+	drawEditMenu(s)
+	drawToolsMenu()
+	native.EndMainMenuBar()
+}
+
+func drawFileMenu(s *app.Session) {
 	if native.BeginMenu("File") {
 		if native.MenuItem("New Part") {
 			_, _ = s.NewPart()
@@ -37,6 +44,9 @@ func drawMenuBar(s *app.Session) string {
 		}
 		native.EndMenu()
 	}
+}
+
+func drawEditMenu(s *app.Session) {
 	if native.BeginMenu("Edit") {
 		// Undo/Redo name the step they act on (Inventor's "Undo Extrude") and grey out
 		// when the stream cursor is at an end. Keyboard equivalents: Ctrl+Z / Ctrl+Y.
@@ -52,6 +62,9 @@ func drawMenuBar(s *app.Session) string {
 		}
 		native.EndMenu()
 	}
+}
+
+func drawToolsMenu() {
 	if native.BeginMenu("Tools") {
 		if native.MenuItem("Materials") {
 			showMaterials = !showMaterials
@@ -61,8 +74,6 @@ func drawMenuBar(s *app.Session) string {
 		}
 		native.EndMenu()
 	}
-	native.EndMainMenuBar()
-	return ""
 }
 
 // undoLabel builds an Edit-menu label that names the step undo/redo would act on (e.g.

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati/head/internal/native"
 	"oblikovati/head/viewport"
 	"oblikovati/kernel/ops"
+	"oblikovati/model/clientgraphics"
 	"oblikovati/model/feature"
 	"oblikovati/model/sketch"
 	"oblikovati/renderer"
@@ -31,33 +32,34 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		native.InvisibleButton("##viewport-nav", float32(pw), float32(ph))
 
 		cam, hovered := updateViewportCamera(s, pw, ph)
-
-		bodies := activeBodies(s)
-		list := renderer.BuildDrawListStyled(bodies, cam, ops.DefaultQuality(), s.SurfaceLookup(), s.VisualStyle())
-		// Paint the selected body cyan so a browser/viewport pick reads in the 3D view
-		// (a no-op in sketch mode, where the selection is sketch entities, not bodies).
-		list = highlightSelection(list, s.Selection().First(), bodies)
-		var dims []app.DimensionView
-		var sketchPlane sketch.Plane
-		if s.InSketch() {
-			list, sketchPlane, dims = sketchOverlays(s, cam, list)
-		} else {
-			list = modelOverlays(s, cam, hovered, list)
-		}
+		list, sketchPlane, dims := viewportDrawList(s, cam, hovered)
 		list, gfxLabels := clientGraphicsOverlay(s, cam, list)
 		renderViewportImage(win, s, cam, list, pw, ph, cx, cy)
-		// Pinned to the corner over the freshly drawn image (ItemRectMin is its screen
-		// origin), before any label items so it reads the image rect, not a label's.
-		ox, oy := native.ItemRectMin()
-		drawAxisGizmo(cam, ox, oy, ph)
-		drawClientGraphicsLabels(cx, cy, cam, gfxLabels)
-		if s.InSketch() && len(dims) > 0 {
-			if d := drawDimensionLabels(cx, cy, cam, sketchPlane, dims); d != nil {
-				s.BeginEditDimension(d) // double-clicked a dimension's value
-			}
-		}
+		drawViewportOverlays(s, cam, sketchPlane, dims, gfxLabels, cx, cy, ph)
 	}
 	native.End()
+}
+
+func viewportDrawList(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane) (renderer.DrawList, sketch.Plane, []app.DimensionView) {
+	bodies := activeBodies(s)
+	list := renderer.BuildDrawListStyled(bodies, cam, ops.DefaultQuality(), s.SurfaceLookup(), s.VisualStyle())
+	list = highlightSelection(list, s.Selection().First(), bodies)
+	if s.InSketch() {
+		list, sketchPlane, dims := sketchOverlays(s, cam, list)
+		return list, sketchPlane, dims
+	}
+	return modelOverlays(s, cam, hovered, list), sketch.Plane{}, nil
+}
+
+func drawViewportOverlays(s *app.Session, cam scene.Camera, sketchPlane sketch.Plane, dims []app.DimensionView, labels []clientgraphics.Label, cx, cy float32, ph int) {
+	ox, oy := native.ItemRectMin()
+	drawAxisGizmo(cam, ox, oy, ph)
+	drawClientGraphicsLabels(cx, cy, cam, labels)
+	if s.InSketch() && len(dims) > 0 {
+		if d := drawDimensionLabels(cx, cy, cam, sketchPlane, dims); d != nil {
+			s.BeginEditDimension(d) // double-clicked a dimension's value
+		}
+	}
 }
 
 // updateViewportCamera sizes the camera to the panel and either advances the active camera
@@ -136,7 +138,9 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 // modelOverlays appends the 3D-model overlays (work planes, part sketches, selected edges, and
 // the extrude / active-tool previews) to list.
 func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane, list renderer.DrawList) renderer.DrawList {
-	list.Items = append(list.Items, planesOverlay(activePart(s), s.SelectedWorkPlane(), hovered)...)
+	part := activePart(s)
+	list.Items = append(list.Items, planesOverlay(part, s.SelectedWorkPlane(), hovered)...)
+	list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s))...)
 	list.Items = append(list.Items, partSketchOverlays(s)...)
 	list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
 	list.Items = append(list.Items, selectedEdgeOverlay(s)...)

--- a/head/ui/close_guard.go
+++ b/head/ui/close_guard.go
@@ -14,6 +14,39 @@ type closeGuard struct {
 	prompting bool
 }
 
+// documentCloseGuard tracks the document whose tab-close request is waiting for a
+// Save / Don't Save / Cancel answer.
+type documentCloseGuard struct {
+	pending *doc.Document
+}
+
+func (g *documentCloseGuard) request(d *doc.Document) bool {
+	if d == nil || !d.Dirty() {
+		return true
+	}
+	g.pending = d
+	return false
+}
+
+func (g *documentCloseGuard) cancel() { g.pending = nil }
+
+func (g *documentCloseGuard) discard(s *app.Session) {
+	if g.pending == nil {
+		return
+	}
+	closeDocumentNow(s, g.pending, true)
+	g.pending = nil
+}
+
+func (g *documentCloseGuard) closeIfClean(s *app.Session) bool {
+	if g.pending == nil || g.pending.Dirty() {
+		return false
+	}
+	closeDocumentNow(s, g.pending, false)
+	g.pending = nil
+	return true
+}
+
 // dirtyDocuments returns the open documents with unsaved changes — the ones a close
 // must warn about. Order follows the workspace's stable enumeration.
 func dirtyDocuments(s *app.Session) []*doc.Document {

--- a/head/ui/close_guard_draw.go
+++ b/head/ui/close_guard_draw.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati/app"
 	"oblikovati/head/internal/native"
+	"oblikovati/model/doc"
 )
 
 // closeModal is the chrome's single graceful-close prompt (UI state, head-local).
@@ -43,26 +44,35 @@ func drawCloseModal(s *app.Session) bool {
 	}
 	exit := false
 	if native.Begin("Save changes?") {
-		native.Text(fmt.Sprintf("%d document(s) have unsaved changes:", len(dirty)))
-		for _, d := range dirty {
-			native.Text("   - " + d.FullDocumentName())
-		}
-		if native.Button("Save") {
-			saveAllDirty(s) // never-saved docs route to the Save As modal below
-		}
-		native.SameLine()
-		if native.Button("Don't Save") {
-			closeModal.prompting = false
-			exit = true
-		}
-		native.SameLine()
-		if native.Button("Cancel") {
-			closeModal.prompting = false
-		}
+		drawDirtyDocumentList(dirty)
+		exit = drawCloseModalButtons(s)
 	}
 	native.End()
 	drawFileDialog(s) // render the Save As modal if saveAllDirty armed it
 	return exit
+}
+
+func drawDirtyDocumentList(dirty []*doc.Document) {
+	native.Text(fmt.Sprintf("%d document(s) have unsaved changes:", len(dirty)))
+	for _, d := range dirty {
+		native.Text("   - " + d.FullDocumentName())
+	}
+}
+
+func drawCloseModalButtons(s *app.Session) bool {
+	if native.Button("Save") {
+		saveAllDirty(s) // never-saved docs route to the Save As modal below
+	}
+	native.SameLine()
+	if native.Button("Don't Save") {
+		closeModal.prompting = false
+		return true
+	}
+	native.SameLine()
+	if native.Button("Cancel") {
+		closeModal.prompting = false
+	}
+	return false
 }
 
 // saveAllDirty saves the active document through the session (a never-saved document

--- a/head/ui/close_guard_test.go
+++ b/head/ui/close_guard_test.go
@@ -38,3 +38,70 @@ func TestDirtyDocuments(t *testing.T) {
 		t.Errorf("after clearing both, dirtyDocuments = %d, want 0", len(got))
 	}
 }
+
+func TestDocumentCloseGuardRequestsPromptOnlyForDirtyDocument(t *testing.T) {
+	s := app.NewSession()
+	d, err := compdef.AddPart(s.Workspace(), "dirty.obk", true)
+	if err != nil {
+		t.Fatalf("AddPart dirty: %v", err)
+	}
+	var guard documentCloseGuard
+	if guard.request(d) || guard.pending != d {
+		t.Fatalf("request dirty = close-now with pending %+v, want prompt", guard.pending)
+	}
+	d.ClearDirty()
+	guard.cancel()
+	if !guard.request(d) || guard.pending != nil {
+		t.Fatalf("request clean pending=%+v, want close-now and no prompt", guard.pending)
+	}
+}
+
+func TestDocumentCloseGuardDiscardClosesWithoutSaving(t *testing.T) {
+	s := app.NewSession()
+	d, err := compdef.AddPart(s.Workspace(), "dirty.obk", true)
+	if err != nil {
+		t.Fatalf("AddPart dirty: %v", err)
+	}
+	guard := documentCloseGuard{pending: d}
+	guard.discard(s)
+	if guard.pending != nil {
+		t.Fatalf("discard left pending %+v", guard.pending)
+	}
+	if got := len(s.Workspace().Documents()); got != 0 {
+		t.Fatalf("documents after discard = %d, want 0", got)
+	}
+}
+
+func TestDocumentCloseGuardCloseIfCleanWaitsUntilSaved(t *testing.T) {
+	s := app.NewSession()
+	d, err := compdef.AddPart(s.Workspace(), "dirty.obk", true)
+	if err != nil {
+		t.Fatalf("AddPart dirty: %v", err)
+	}
+	guard := documentCloseGuard{pending: d}
+	if guard.closeIfClean(s) {
+		t.Fatal("closeIfClean closed dirty document")
+	}
+	d.ClearDirty()
+	if !guard.closeIfClean(s) || guard.pending != nil {
+		t.Fatalf("closeIfClean pending=%+v, want closed clean document", guard.pending)
+	}
+}
+
+func TestDocumentNeedsSaveAsForUnsavedPartName(t *testing.T) {
+	s := app.NewSession()
+	unsaved, err := compdef.AddPart(s.Workspace(), "Part1", true)
+	if err != nil {
+		t.Fatalf("AddPart unsaved: %v", err)
+	}
+	if !documentNeedsSaveAs(unsaved) {
+		t.Fatal("documentNeedsSaveAs(Part1) = false, want true")
+	}
+	savedName, err := compdef.AddPart(s.Workspace(), "saved.obk", true)
+	if err != nil {
+		t.Fatalf("AddPart saved-name: %v", err)
+	}
+	if documentNeedsSaveAs(savedName) {
+		t.Fatal("documentNeedsSaveAs(saved.obk) = true, want false")
+	}
+}

--- a/head/ui/coil_dialog.go
+++ b/head/ui/coil_dialog.go
@@ -25,11 +25,7 @@ func drawCoilDialog(s *app.Session) {
 		coilUI.open = false
 		return
 	}
-	if !coilUI.open {
-		coilUI.pitch = float32(c.Pitch())
-		coilUI.revolutions = float32(c.Revolutions())
-		coilUI.open = true
-	}
+	refreshCoilUI(c)
 	native.SetNextWindowSize(300, 240)
 	if native.Begin("Coil") {
 		if _, ok := c.PickedProfile(); !ok {
@@ -46,6 +42,15 @@ func drawCoilDialog(s *app.Session) {
 		drawCoilButtons(s, c)
 	}
 	native.End()
+}
+
+func refreshCoilUI(c *app.CoilTool) {
+	if coilUI.open {
+		return
+	}
+	coilUI.pitch = float32(c.Pitch())
+	coilUI.revolutions = float32(c.Revolutions())
+	coilUI.open = true
 }
 
 func coilOperationCombo(c *app.CoilTool) {

--- a/head/ui/dialog_buttons.go
+++ b/head/ui/dialog_buttons.go
@@ -1,0 +1,22 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati/app"
+	"oblikovati/head/internal/native"
+)
+
+func drawCommitCancelButtons(s *app.Session, canCommit bool) {
+	native.BeginDisabled(!canCommit)
+	if native.Button("OK") {
+		_ = s.OK()
+	}
+	native.EndDisabled()
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelTool()
+	}
+}

--- a/head/ui/dimension_overlay.go
+++ b/head/ui/dimension_overlay.go
@@ -92,30 +92,44 @@ func drawDimensionPopup(s *app.Session) {
 		dimEdit.dim = nil
 		return
 	}
-	if d != dimEdit.dim { // a new edit opened — seed the buffer + remember the cursor
-		seedEditBuf(s.PendingDimensionExpression())
-		dimEdit.dim = d
-		mx, my := native.MousePos()
-		dimEdit.posX, dimEdit.posY = mx+dimPopupCursorOffset, my+dimPopupCursorOffset
-		dimEdit.place = true
-	}
-	if dimEdit.place { // position once at the cursor, then let the user drag it
-		native.SetNextWindowPos(dimEdit.posX, dimEdit.posY)
-		dimEdit.place = false
-	}
+	refreshDimensionEdit(s, d)
+	placeDimensionEditOnce()
 	native.SetNextWindowSize(260, 96)
 	if native.Begin("Edit Dimension") {
-		native.Text("Value")
-		native.InputText("##dim-value", dimEdit.buf)
-		if native.Button("OK") {
-			_ = s.CommitPendingDimension(editBufText()) // keeps box open on parse error
-		}
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelPendingDimension()
-		}
+		drawDimensionEditContents(s)
 	}
 	native.End()
+}
+
+func refreshDimensionEdit(s *app.Session, d *sketch.DimensionConstraint) {
+	if d == dimEdit.dim {
+		return
+	}
+	seedEditBuf(s.PendingDimensionExpression())
+	dimEdit.dim = d
+	mx, my := native.MousePos()
+	dimEdit.posX, dimEdit.posY = mx+dimPopupCursorOffset, my+dimPopupCursorOffset
+	dimEdit.place = true
+}
+
+func placeDimensionEditOnce() {
+	if !dimEdit.place {
+		return
+	}
+	native.SetNextWindowPos(dimEdit.posX, dimEdit.posY)
+	dimEdit.place = false
+}
+
+func drawDimensionEditContents(s *app.Session) {
+	native.Text("Value")
+	native.InputText("##dim-value", dimEdit.buf)
+	if native.Button("OK") {
+		_ = s.CommitPendingDimension(editBufText()) // keeps box open on parse error
+	}
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelPendingDimension()
+	}
 }
 
 // seedEditBuf copies expr into the edit buffer, NUL-terminated and zero-padded.

--- a/head/ui/document_close.go
+++ b/head/ui/document_close.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"oblikovati/app"
+	"oblikovati/model/doc"
+)
+
+func closeDocumentNow(s *app.Session, d *doc.Document, skipSave bool) {
+	if err := s.Workspace().Close(d, skipSave); err != nil {
+		fmt.Fprintf(os.Stderr, "close %q: %v\n", d.FullDocumentName(), err)
+	}
+}
+
+func documentNeedsSaveAs(d *doc.Document) bool {
+	return d != nil && !strings.HasSuffix(d.FullFileName(), doc.PackageExtension)
+}

--- a/head/ui/document_close_draw.go
+++ b/head/ui/document_close_draw.go
@@ -1,0 +1,54 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+
+	"oblikovati/app"
+	"oblikovati/head/internal/native"
+)
+
+// drawDocumentClosePrompt asks how to handle one dirty document whose tab close button
+// was clicked. The prompt remains open while Save As is resolving a never-saved file.
+func drawDocumentClosePrompt(s *app.Session) {
+	if closeDocumentModal.closeIfClean(s) || closeDocumentModal.pending == nil {
+		return
+	}
+	d := closeDocumentModal.pending
+	if native.Begin("Save document changes?##document-close") {
+		native.Text("Save changes to " + d.FullDocumentName() + " before closing?")
+		if native.Button("Save") {
+			savePendingDocumentClose(s)
+		}
+		native.SameLine()
+		if native.Button("Don't Save") {
+			closeDocumentModal.discard(s)
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			closeDocumentModal.cancel()
+		}
+	}
+	native.End()
+}
+
+func savePendingDocumentClose(s *app.Session) {
+	d := closeDocumentModal.pending
+	if d == nil {
+		return
+	}
+	if err := s.Workspace().SetActiveDocument(d); err != nil {
+		fmt.Fprintf(os.Stderr, "activate %q for close save: %v\n", d.FullDocumentName(), err)
+		return
+	}
+	if documentNeedsSaveAs(d) {
+		fileModal.openFor(dialogSaveAs)
+		return
+	}
+	saveActive(s)
+	closeDocumentModal.closeIfClean(s)
+}

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -35,15 +35,7 @@ func drawDraftDialog(s *app.Session) {
 		native.Text("Angle (degrees, +out / −in)")
 		native.InputFloat("##draft-angle", &draftUI.angle)
 		d.SetAngleDegrees(float64(draftUI.angle))
-		native.BeginDisabled(!d.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawCommitCancelButtons(s, d.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/face_offset_dialog.go
+++ b/head/ui/face_offset_dialog.go
@@ -35,15 +35,7 @@ func drawFaceOffsetDialog(s *app.Session) {
 		native.Text("Distance (" + s.LengthUnitName() + ", +out / −in)")
 		native.InputFloat("##face-offset-distance", &faceOffsetUI.distance)
 		o.SetDistance(float64(faceOffsetUI.distance))
-		native.BeginDisabled(!o.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawCommitCancelButtons(s, o.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/feature_edit_dialog.go
+++ b/head/ui/feature_edit_dialog.go
@@ -33,30 +33,39 @@ func drawFeatureEditDialog(s *app.Session) {
 	}
 	nParams := s.EditFeatureParamCount()
 	nRefs := s.EditFeatureRefSlotCount()
-	if !featureEditUI.open { // edit just opened — seed the fields from the feature's values
-		featureEditUI.values = make([]float32, nParams)
-		for i := 0; i < nParams; i++ {
-			featureEditUI.values[i] = float32(s.EditFeatureParamValue(i))
-		}
-		featureEditUI.open = true
-	}
+	refreshFeatureEditUI(s, nParams)
 	native.SetNextWindowSize(320, float32(108+nParams*30+nRefs*30))
 	if native.Begin("Edit Feature") {
 		native.Text(s.EditingFeatureName())
 		drawEditParams(s, nParams)
 		drawEditRefSlots(s, nRefs)
-		if native.Button("OK") {
-			if err := s.OK(); err == nil { // a sick result keeps the dialog open
-				featureEditUI.open = false
-			}
-		}
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
+		drawFeatureEditButtons(s)
+	}
+	native.End()
+}
+
+func refreshFeatureEditUI(s *app.Session, nParams int) {
+	if featureEditUI.open {
+		return
+	}
+	featureEditUI.values = make([]float32, nParams)
+	for i := 0; i < nParams; i++ {
+		featureEditUI.values[i] = float32(s.EditFeatureParamValue(i))
+	}
+	featureEditUI.open = true
+}
+
+func drawFeatureEditButtons(s *app.Session) {
+	if native.Button("OK") {
+		if err := s.OK(); err == nil { // a sick result keeps the dialog open
 			featureEditUI.open = false
 		}
 	}
-	native.End()
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelTool()
+		featureEditUI.open = false
+	}
 }
 
 // drawEditParams renders one field per editable scalar (an integer field for whole-number

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -2,7 +2,17 @@
 
 package ui
 
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
 
 // fileDialogMode is which file operation the path modal will perform on confirm. The
 // zero value (dialogClosed) means the modal is not showing.
@@ -18,8 +28,20 @@ const (
 )
 
 // pathBufferLen bounds the path the user can type. ImGui edits the buffer in place,
-// so it is a fixed array, not a growable slice; 512 covers any realistic file path.
-const pathBufferLen = 512
+// so it is a fixed array, not a growable slice; 1024 covers long Windows paths and
+// deep Unix project trees without making each dialog state large.
+const pathBufferLen = 1024
+
+const fileSearchBufferLen = 128
+
+// fileEntry is one row in the dialog's cross-platform directory browser.
+type fileEntry struct {
+	Name    string
+	Path    string
+	Dir     bool
+	Size    int64
+	ModTime time.Time
+}
 
 // fileDialog is the head's path-entry modal state: which operation is pending and the
 // path being typed. It is deliberately free of any native/cgo dependency so the
@@ -28,6 +50,11 @@ const pathBufferLen = 512
 type fileDialog struct {
 	mode       fileDialogMode
 	path       [pathBufferLen]byte
+	search     [fileSearchBufferLen]byte
+	cwd        string
+	entries    []fileEntry
+	roots      []string
+	errorText  string
 	resolution int // export mesh resolution: 0 low, 1 medium, 2 high
 }
 
@@ -47,7 +74,10 @@ var exportResolutionNames = []string{"low", "medium", "high"}
 func (d *fileDialog) openFor(mode fileDialogMode) {
 	d.mode = mode
 	d.path = [pathBufferLen]byte{}
+	d.search = [fileSearchBufferLen]byte{}
 	d.resolution = 1
+	d.roots = explorerRoots()
+	d.openDir(initialExplorerDir())
 }
 
 // isOpen reports whether the modal should render this frame.
@@ -69,6 +99,11 @@ func (d *fileDialog) title() string {
 	}
 }
 
+// filterHint names the file family surfaced by the browser for this operation.
+func (d *fileDialog) filterHint() string {
+	return strings.Join(d.allowedExts(), ", ")
+}
+
 // text returns the NUL-trimmed path the user has typed into the buffer.
 func (d *fileDialog) text() string {
 	if i := bytes.IndexByte(d.path[:], 0); i >= 0 {
@@ -77,10 +112,22 @@ func (d *fileDialog) text() string {
 	return string(d.path[:])
 }
 
+// searchText returns the NUL-trimmed explorer search text.
+func (d *fileDialog) searchText() string { return bufString(d.search[:]) }
+
+// targetPath resolves the typed/selected target against the current directory.
+func (d *fileDialog) targetPath() string {
+	text := strings.TrimSpace(d.text())
+	if text == "" {
+		return ""
+	}
+	return d.withDefaultExt(resolveExplorerPath(d.cwd, text))
+}
+
 // confirm dismisses the dialog and returns the action for its mode and typed path. A
 // blank path yields a dialogClosed action so the caller never acts on "".
 func (d *fileDialog) confirm() fileAction {
-	path := d.text()
+	path := d.targetPath()
 	mode := d.mode
 	res := exportResolutionNames[d.resolution]
 	d.cancel()
@@ -94,4 +141,198 @@ func (d *fileDialog) confirm() fileAction {
 func (d *fileDialog) cancel() {
 	d.mode = dialogClosed
 	d.path = [pathBufferLen]byte{}
+	d.search = [fileSearchBufferLen]byte{}
+	d.entries = nil
+	d.errorText = ""
+}
+
+// openDir changes the browser directory and refreshes its rows.
+func (d *fileDialog) openDir(dir string) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		d.errorText = fmt.Sprintf("open %q: %v", dir, err)
+		return
+	}
+	d.cwd = filepath.Clean(abs)
+	d.refresh()
+}
+
+// refresh reloads the current directory snapshot, preserving the current target path.
+func (d *fileDialog) refresh() {
+	entries, err := readExplorerDir(d.cwd)
+	if err != nil {
+		d.entries = nil
+		d.errorText = fmt.Sprintf("read %q: %v", d.cwd, err)
+		return
+	}
+	d.entries = entries
+	d.errorText = ""
+}
+
+// goParent moves to the containing directory when the platform path has one.
+func (d *fileDialog) goParent() {
+	parent := filepath.Dir(d.cwd)
+	if parent != d.cwd {
+		d.openDir(parent)
+	}
+}
+
+// chooseEntry selects a file target or enters a directory row.
+func (d *fileDialog) chooseEntry(e fileEntry) {
+	if e.Dir {
+		d.openDir(e.Path)
+		return
+	}
+	d.setTarget(e.Path)
+}
+
+// visibleEntries returns directory rows plus files matching search/filter state.
+func (d *fileDialog) visibleEntries() []fileEntry {
+	needle := strings.ToLower(strings.TrimSpace(d.searchText()))
+	var out []fileEntry
+	for _, e := range d.entries {
+		if d.entryVisible(e, needle) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (d *fileDialog) entryVisible(e fileEntry, needle string) bool {
+	if needle != "" && !strings.Contains(strings.ToLower(e.Name), needle) {
+		return false
+	}
+	return e.Dir || d.allowsFile(e.Name)
+}
+
+func (d *fileDialog) allowsFile(name string) bool {
+	exts := d.allowedExts()
+	if len(exts) == 0 {
+		return true
+	}
+	ext := strings.ToLower(filepath.Ext(name))
+	return containsString(exts, ext)
+}
+
+func (d *fileDialog) allowedExts() []string {
+	switch d.mode {
+	case dialogOpen, dialogSaveAs:
+		return []string{".obk"}
+	case dialogLoadHDR:
+		return []string{".hdr"}
+	case dialogImport, dialogExport:
+		return []string{".stl", ".obj", ".3mf", ".step", ".stp"}
+	default:
+		return nil
+	}
+}
+
+func (d *fileDialog) withDefaultExt(path string) string {
+	if d.mode == dialogSaveAs && filepath.Ext(path) == "" {
+		return path + ".obk"
+	}
+	return path
+}
+
+func (d *fileDialog) setTarget(path string) { copyText(d.path[:], path) }
+
+func readExplorerDir(dir string) ([]fileEntry, error) {
+	rows, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]fileEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, explorerEntry(dir, row))
+	}
+	sortExplorerEntries(entries)
+	return entries, nil
+}
+
+func explorerEntry(dir string, row fs.DirEntry) fileEntry {
+	info, _ := row.Info()
+	entry := fileEntry{Name: row.Name(), Path: filepath.Join(dir, row.Name()), Dir: row.IsDir()}
+	if info != nil {
+		entry.Size = info.Size()
+		entry.ModTime = info.ModTime()
+	}
+	return entry
+}
+
+func sortExplorerEntries(entries []fileEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Dir != entries[j].Dir {
+			return entries[i].Dir
+		}
+		return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
+	})
+}
+
+func initialExplorerDir() string {
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return home
+	}
+	return string(filepath.Separator)
+}
+
+func explorerRoots() []string {
+	if runtime.GOOS == "windows" {
+		return windowsRoots()
+	}
+	return uniquePaths([]string{string(filepath.Separator), homeDir()})
+}
+
+func windowsRoots() []string {
+	var roots []string
+	for drive := 'A'; drive <= 'Z'; drive++ {
+		root := string(drive) + `:\`
+		if _, err := os.Stat(root); err == nil {
+			roots = append(roots, root)
+		}
+	}
+	return roots
+}
+
+func homeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return home
+}
+
+func uniquePaths(paths []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range paths {
+		if p != "" && !seen[p] {
+			out = append(out, p)
+			seen[p] = true
+		}
+	}
+	return out
+}
+
+func resolveExplorerPath(cwd, text string) string {
+	if filepath.IsAbs(text) {
+		return filepath.Clean(text)
+	}
+	return filepath.Clean(filepath.Join(cwd, text))
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func copyText(dst []byte, text string) {
+	clearBuf(dst)
+	copy(dst, text)
 }

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -14,34 +14,182 @@ import (
 	"oblikovati/head/internal/native"
 )
 
-// fileModal is the chrome's single path-entry dialog (UI state, not model state, so it
-// lives here in the head). File-menu items arm it; drawFileDialog renders it.
+// fileModal is the chrome's single file explorer (UI state, not model state, so it lives
+// here in the head). File-menu items arm it; drawFileDialog renders it.
 var fileModal fileDialog
 
-// drawFileDialog renders the path modal when armed and applies a confirmed Open/Save As
-// to the session. DrawChrome calls it once per frame. Failures go to stderr — the head
-// has no message box yet (a fast-follow when the notification surface lands).
+// drawFileDialog renders the file explorer and applies a confirmed file operation.
 func drawFileDialog(s *app.Session) {
 	if !fileModal.isOpen() {
 		return
 	}
 	var act fileAction
+	native.SetNextWindowSizeOnce(760, 520)
 	if native.Begin(fileModal.title()) {
-		native.Text("File path:")
-		native.InputText("##file-path", fileModal.path[:])
-		if fileModal.mode == dialogExport { // mesh export density (ignored for STEP)
-			drawExportResolution()
-		}
-		if native.Button("OK") {
-			act = fileModal.confirm()
-		}
-		native.SameLine()
-		if native.Button("Cancel") {
-			fileModal.cancel()
-		}
+		drawExplorerHeader()
+		act = drawExplorerTable()
+		drawExplorerTarget()
+		act = drawExplorerActions(act)
 	}
 	native.End()
 	applyFileAction(s, act)
+}
+
+// drawExplorerHeader renders navigation, root selection, and search controls.
+func drawExplorerHeader() {
+	native.Text("Folder: " + fileModal.cwd)
+	if native.Button("Up") {
+		fileModal.goParent()
+	}
+	native.SameLine()
+	if native.Button("Home") {
+		fileModal.openDir(homeDir())
+	}
+	native.SameLine()
+	if native.Button("Refresh") {
+		fileModal.refresh()
+	}
+	drawRootChooser()
+	native.SetNextItemWidth(-1)
+	native.InputText("Search##file-search", fileModal.search[:])
+}
+
+// drawRootChooser lets Windows users jump between drive roots and Unix users jump home/root.
+func drawRootChooser() {
+	if len(fileModal.roots) == 0 || !native.BeginCombo("Location", fileModal.cwd) {
+		return
+	}
+	for _, root := range fileModal.roots {
+		if native.Selectable(root, root == fileModal.cwd) {
+			fileModal.openDir(root)
+		}
+	}
+	native.EndCombo()
+}
+
+// drawExplorerTable renders the current directory rows and returns a double-click action.
+func drawExplorerTable() fileAction {
+	native.SeparatorText("Files")
+	if fileModal.errorText != "" {
+		native.Text(fileModal.errorText)
+	}
+	if !native.BeginTable("##file-browser", 4, 0, 280) {
+		return fileAction{}
+	}
+	drawExplorerTableHeader()
+	act := drawExplorerRows(fileModal.visibleEntries())
+	native.EndTable()
+	return act
+}
+
+func drawExplorerTableHeader() {
+	for _, col := range []string{"Name", "Type", "Size", "Modified"} {
+		native.TableSetupColumn(col)
+	}
+	native.TableSetupScrollFreeze(0, 1)
+	native.TableHeadersRow()
+}
+
+func drawExplorerRows(entries []fileEntry) fileAction {
+	var act fileAction
+	for _, entry := range entries {
+		native.TableNextRow()
+		if rowAct := drawExplorerRow(entry); rowAct.Kind != dialogClosed {
+			act = rowAct
+		}
+	}
+	return act
+}
+
+func drawExplorerRow(entry fileEntry) fileAction {
+	if native.TableNextColumn() && native.Selectable(entryLabel(entry), fileModal.text() == entry.Path) {
+		fileModal.chooseEntry(entry)
+		return confirmOnDoubleClick(entry)
+	}
+	if native.TableNextColumn() {
+		native.Text(entryKind(entry))
+	}
+	if native.TableNextColumn() {
+		native.Text(entrySize(entry))
+	}
+	if native.TableNextColumn() {
+		native.Text(entryModified(entry))
+	}
+	return fileAction{}
+}
+
+func confirmOnDoubleClick(entry fileEntry) fileAction {
+	if entry.Dir || !native.IsMouseDoubleClicked(native.MouseLeft) {
+		return fileAction{}
+	}
+	return fileModal.confirm()
+}
+
+func entryLabel(entry fileEntry) string {
+	name := entry.Name
+	if entry.Dir {
+		name += string(os.PathSeparator)
+	}
+	return name + "##" + entry.Path
+}
+
+func entryKind(entry fileEntry) string {
+	if entry.Dir {
+		return "Folder"
+	}
+	return "File"
+}
+
+func entrySize(entry fileEntry) string {
+	if entry.Dir {
+		return ""
+	}
+	return fmt.Sprintf("%d", entry.Size)
+}
+
+func entryModified(entry fileEntry) string {
+	if entry.ModTime.IsZero() {
+		return ""
+	}
+	return entry.ModTime.Format("2006-01-02 15:04")
+}
+
+// drawExplorerTarget renders the final path field and mode-specific controls.
+func drawExplorerTarget() {
+	if hint := fileModal.filterHint(); hint != "" {
+		native.Text("Files: " + hint)
+	}
+	native.SetNextItemWidth(-1)
+	native.InputText("File name or path##file-path", fileModal.path[:])
+	if fileModal.mode == dialogExport {
+		drawExportResolution()
+	}
+}
+
+func drawExplorerActions(act fileAction) fileAction {
+	native.BeginDisabled(fileModal.targetPath() == "")
+	if native.Button(fileConfirmLabel()) {
+		act = fileModal.confirm()
+	}
+	native.EndDisabled()
+	native.SameLine()
+	if native.Button("Cancel") {
+		fileModal.cancel()
+	}
+	return act
+}
+
+func fileConfirmLabel() string {
+	switch fileModal.mode {
+	case dialogSaveAs:
+		return "Save"
+	case dialogImport:
+		return "Import"
+	case dialogExport:
+		return "Export"
+	default:
+		return "Open"
+	}
 }
 
 // drawExportResolution renders the mesh-export resolution selector (low/medium/high).

--- a/head/ui/file_dialog_test.go
+++ b/head/ui/file_dialog_test.go
@@ -2,7 +2,11 @@
 
 package ui
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // typePath simulates the user typing into the modal's in-place buffer — what
 // native.InputText writes each frame — so these tests exercise the state machine
@@ -12,16 +16,22 @@ func (d *fileDialog) typePath(s string) {
 	copy(d.path[:], s)
 }
 
+func (d *fileDialog) typeSearch(s string) {
+	d.search = [fileSearchBufferLen]byte{}
+	copy(d.search[:], s)
+}
+
 func TestFileDialogConfirmReturnsActionForMode(t *testing.T) {
 	var d fileDialog
 	d.openFor(dialogSaveAs)
 	if !d.isOpen() || d.title() != "Save As" {
 		t.Fatalf("openFor(SaveAs): isOpen=%v title=%q", d.isOpen(), d.title())
 	}
-	d.typePath("/models/part.obk")
+	path := filepath.Join(t.TempDir(), "part.obk")
+	d.typePath(path)
 	act := d.confirm()
-	if act.Kind != dialogSaveAs || act.Path != "/models/part.obk" {
-		t.Errorf("confirm() = %+v, want SaveAs /models/part.obk", act)
+	if act.Kind != dialogSaveAs || act.Path != path {
+		t.Errorf("confirm() = %+v, want SaveAs %q", act, path)
 	}
 	if d.isOpen() {
 		t.Error("dialog should be closed after confirm")
@@ -85,7 +95,80 @@ func TestFileDialogImportExportModes(t *testing.T) {
 	d.resolution = 2 // high
 	copy(d.path[:], "out.stl")
 	act := d.confirm()
-	if act.Kind != dialogExport || act.Path != "out.stl" || act.Resolution != "high" {
-		t.Errorf("export confirm = %+v, want {dialogExport, out.stl, high}", act)
+	want := filepath.Join(initialExplorerDir(), "out.stl")
+	if act.Kind != dialogExport || act.Path != want || act.Resolution != "high" {
+		t.Errorf("export confirm = %+v, want {dialogExport, %q, high}", act, want)
 	}
+}
+
+func TestFileDialogSearchFiltersAllowedFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeDialogFile(t, filepath.Join(dir, "alpha.obk"))
+	writeDialogFile(t, filepath.Join(dir, "beta.stl"))
+	var d fileDialog
+	d.openFor(dialogOpen)
+	d.openDir(dir)
+	d.typeSearch("alpha")
+	got := d.visibleEntries()
+	if len(got) != 1 || got[0].Name != "alpha.obk" {
+		t.Fatalf("visibleEntries = %+v, want only alpha.obk", got)
+	}
+}
+
+func TestFileDialogChooseDirectoryAndFile(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	file := filepath.Join(nested, "part.obk")
+	writeDialogFile(t, file)
+	var d fileDialog
+	d.openFor(dialogOpen)
+	d.openDir(dir)
+	d.chooseEntry(findDialogEntry(t, d.visibleEntries(), "nested"))
+	d.chooseEntry(findDialogEntry(t, d.visibleEntries(), "part.obk"))
+	if act := d.confirm(); act.Path != file || act.Kind != dialogOpen {
+		t.Fatalf("confirm after choose = %+v, want open %q", act, file)
+	}
+}
+
+func TestFileDialogSaveJoinsDirectoryAndDefaultExt(t *testing.T) {
+	dir := t.TempDir()
+	var d fileDialog
+	d.openFor(dialogSaveAs)
+	d.openDir(dir)
+	d.typePath("bracket")
+	act := d.confirm()
+	want := filepath.Join(dir, "bracket.obk")
+	if act.Kind != dialogSaveAs || act.Path != want {
+		t.Fatalf("confirm save = %+v, want save %q", act, want)
+	}
+}
+
+func TestFileDialogRefreshReportsDirectoryErrors(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogOpen)
+	d.openDir(filepath.Join(t.TempDir(), "missing"))
+	if d.errorText == "" || len(d.visibleEntries()) != 0 {
+		t.Fatalf("missing directory error=%q entries=%d", d.errorText, len(d.visibleEntries()))
+	}
+}
+
+func writeDialogFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+func findDialogEntry(t *testing.T, entries []fileEntry, name string) fileEntry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry
+		}
+	}
+	t.Fatalf("entry %q not found in %+v", name, entries)
+	return fileEntry{}
 }

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -35,15 +35,7 @@ func drawFilletDialog(s *app.Session) {
 		native.Text("Radius (" + s.LengthUnitName() + ")")
 		native.InputFloat("##fillet-radius", &filletUI.radius)
 		f.SetRadius(float64(filletUI.radius))
-		native.BeginDisabled(!f.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawCommitCancelButtons(s, f.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/highlight_test.go
+++ b/head/ui/highlight_test.go
@@ -24,7 +24,7 @@ func tinyBody() *topo.Body {
 
 func TestHighlightSelectionRecolorsOnlyTheSelectedBody(t *testing.T) {
 	b := tinyBody()
-	other := uint64(b.ID() + 1)
+	other := b.ID() + 1
 	base := [4]float32{0.5, 0.5, 0.5, 1}
 	list := renderer.DrawList{Items: []renderer.DrawItem{
 		{ObjectID: b.ID(), Color: base},

--- a/head/ui/hole_dialog.go
+++ b/head/ui/hole_dialog.go
@@ -31,48 +31,74 @@ func drawHoleDialog(s *app.Session) {
 		holeUI.open = false
 		return
 	}
-	if !holeUI.open {
-		holeUI.diameter = float32(h.Diameter())
-		holeUI.depth = float32(h.Depth())
-		holeUI.through = h.ThroughAll()
-		holeUI.counterbore = h.Counterbore()
-		holeUI.countersink = h.Countersink()
-		holeUI.cDiameter = float32(h.CounterDiameter())
-		holeUI.cDepth = float32(h.CounterDepth())
-		holeUI.sinkAngleDeg = float32(h.SinkAngle() * 180 / stdmath.Pi)
-		holeUI.pointAngleDeg = float32(h.PointAngle() * 180 / stdmath.Pi)
-		holeUI.open = true
-	}
+	refreshHoleUI(h)
 	native.SetNextWindowSize(300, 390)
 	if native.Begin("Hole") {
-		if _, ok := h.PickedFace(); !ok {
-			native.Text("Click a planar face to place the hole on")
-		}
-		native.Text("Diameter (" + s.LengthUnitName() + ")")
-		native.InputFloat("##hole-diameter", &holeUI.diameter)
-		h.SetDiameter(float64(holeUI.diameter))
-		native.Checkbox("Through All", &holeUI.through)
-		h.SetThroughAll(holeUI.through)
-		native.BeginDisabled(holeUI.through) // depth is ignored when drilling through
-		native.Text("Depth (" + s.LengthUnitName() + ")")
-		native.InputFloat("##hole-depth", &holeUI.depth)
-		native.EndDisabled()
-		h.SetDepth(float64(holeUI.depth))
-		// Drill point applies to a plain blind drilled hole (not through, no recess).
-		native.BeginDisabled(holeUI.through || holeUI.counterbore || holeUI.countersink)
-		native.Text("Drill point angle (deg, 0 = flat)")
-		native.InputFloat("##hole-pang", &holeUI.pointAngleDeg)
-		h.SetPointAngle(float64(holeUI.pointAngleDeg) * stdmath.Pi / 180)
-		native.EndDisabled()
+		drawHoleBody(s, h)
 		drawRecess(s, h)
 		drawHoleButtons(s, h)
 	}
 	native.End()
 }
 
+func refreshHoleUI(h *app.HoleTool) {
+	if holeUI.open {
+		return
+	}
+	holeUI.diameter = float32(h.Diameter())
+	holeUI.depth = float32(h.Depth())
+	holeUI.through = h.ThroughAll()
+	holeUI.counterbore = h.Counterbore()
+	holeUI.countersink = h.Countersink()
+	holeUI.cDiameter = float32(h.CounterDiameter())
+	holeUI.cDepth = float32(h.CounterDepth())
+	holeUI.sinkAngleDeg = float32(h.SinkAngle() * 180 / stdmath.Pi)
+	holeUI.pointAngleDeg = float32(h.PointAngle() * 180 / stdmath.Pi)
+	holeUI.open = true
+}
+
+func drawHoleBody(s *app.Session, h *app.HoleTool) {
+	if _, ok := h.PickedFace(); !ok {
+		native.Text("Click a planar face to place the hole on")
+	}
+	drawHoleSize(s, h)
+	drawHoleDepth(s, h)
+	drawHolePointAngle(h)
+}
+
+func drawHoleSize(s *app.Session, h *app.HoleTool) {
+	native.Text("Diameter (" + s.LengthUnitName() + ")")
+	native.InputFloat("##hole-diameter", &holeUI.diameter)
+	h.SetDiameter(float64(holeUI.diameter))
+	native.Checkbox("Through All", &holeUI.through)
+	h.SetThroughAll(holeUI.through)
+}
+
+func drawHoleDepth(s *app.Session, h *app.HoleTool) {
+	native.BeginDisabled(holeUI.through) // depth is ignored when drilling through
+	native.Text("Depth (" + s.LengthUnitName() + ")")
+	native.InputFloat("##hole-depth", &holeUI.depth)
+	native.EndDisabled()
+	h.SetDepth(float64(holeUI.depth))
+}
+
+func drawHolePointAngle(h *app.HoleTool) {
+	native.BeginDisabled(holeUI.through || holeUI.counterbore || holeUI.countersink)
+	native.Text("Drill point angle (deg, 0 = flat)")
+	native.InputFloat("##hole-pang", &holeUI.pointAngleDeg)
+	h.SetPointAngle(float64(holeUI.pointAngleDeg) * stdmath.Pi / 180)
+	native.EndDisabled()
+}
+
 // drawRecess renders the counterbore/countersink toggles (mutually exclusive) and their
 // parameters: a counterbore's recess Ø + depth, or a countersink's sink Ø + included angle.
 func drawRecess(s *app.Session, h *app.HoleTool) {
+	drawCounterbore(s, h)
+	drawCountersink(s, h)
+	h.SetCounterDiameter(float64(holeUI.cDiameter)) // shared recess/sink diameter
+}
+
+func drawCounterbore(s *app.Session, h *app.HoleTool) {
 	if native.Checkbox("Counterbore", &holeUI.counterbore) {
 		h.SetCounterbore(holeUI.counterbore)
 		holeUI.countersink = h.Countersink() // the tool clears the other profile
@@ -85,6 +111,9 @@ func drawRecess(s *app.Session, h *app.HoleTool) {
 	h.SetCounterDepth(float64(holeUI.cDepth))
 	native.EndDisabled()
 
+}
+
+func drawCountersink(s *app.Session, h *app.HoleTool) {
 	if native.Checkbox("Countersink", &holeUI.countersink) {
 		h.SetCountersink(holeUI.countersink)
 		holeUI.counterbore = h.Counterbore()
@@ -96,18 +125,8 @@ func drawRecess(s *app.Session, h *app.HoleTool) {
 	native.InputFloat("##hole-sang", &holeUI.sinkAngleDeg)
 	h.SetSinkAngle(float64(holeUI.sinkAngleDeg) * stdmath.Pi / 180)
 	native.EndDisabled()
-
-	h.SetCounterDiameter(float64(holeUI.cDiameter)) // shared recess/sink diameter
 }
 
 func drawHoleButtons(s *app.Session, h *app.HoleTool) {
-	native.BeginDisabled(!h.CanCommit())
-	if native.Button("OK") {
-		_ = s.OK()
-	}
-	native.EndDisabled()
-	native.SameLine()
-	if native.Button("Cancel") {
-		s.CancelTool()
-	}
+	drawCommitCancelButtons(s, h.CanCommit())
 }

--- a/head/ui/inwindow_test.go
+++ b/head/ui/inwindow_test.go
@@ -15,6 +15,7 @@ import (
 	"oblikovati/app"
 	"oblikovati/head/internal/native"
 	"oblikovati/math"
+	"oblikovati/model/compdef"
 	"oblikovati/scene"
 )
 
@@ -35,6 +36,7 @@ func newViewportWindow(t *testing.T) *native.Window {
 // framedSession is a session whose camera looks down −Z from a known distance.
 func framedSession() *app.Session {
 	s := app.NewSession()
+	_, _ = compdef.AddPart(s.Workspace(), "viewport-test.obk", true)
 	cam := scene.NewCamera(inWinW, inWinH)
 	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
 	s.SetCamera(cam)

--- a/head/ui/loft_dialog.go
+++ b/head/ui/loft_dialog.go
@@ -46,15 +46,7 @@ func drawLoftDialog(s *app.Session) {
 		loftUI.open = false
 		return
 	}
-	if !loftUI.open { // entering the tool: seed the editors from the tool's state
-		loftUI.first = seedLoftEndUI(l.FirstCondition())
-		loftUI.last = seedLoftEndUI(l.LastCondition())
-		loftUI.areaMid = float32(l.AreaMidScale())
-		if loftUI.areaMid == 0 {
-			loftUI.areaMid = 1
-		}
-	}
-	loftUI.open = true
+	refreshLoftUI(l)
 	native.SetNextWindowSize(340, 460)
 	if native.Begin("Loft") {
 		native.Text("Sections: " + strconv.Itoa(l.SectionCount()) + " (regions, or a vertex/point for an apex, or a face for tangency)")
@@ -64,16 +56,34 @@ func drawLoftDialog(s *app.Session) {
 		if native.Checkbox("Closed loop", &closed) {
 			l.SetClosed(closed)
 		}
-		if !closed { // a closed loft has no end sections, so conditions don't apply
-			native.Separator()
-			drawLoftEndCondition("Start section", &loftUI.first)
-			drawLoftEndCondition("End section", &loftUI.last)
-			l.SetFirstCondition(loftUI.first.toEnd())
-			l.SetLastCondition(loftUI.last.toEnd())
-		}
+		drawOpenLoftConditions(l, closed)
 		drawLoftButtons(s, l)
 	}
 	native.End()
+}
+
+func refreshLoftUI(l *app.LoftTool) {
+	if loftUI.open {
+		return
+	}
+	loftUI.first = seedLoftEndUI(l.FirstCondition())
+	loftUI.last = seedLoftEndUI(l.LastCondition())
+	loftUI.areaMid = float32(l.AreaMidScale())
+	if loftUI.areaMid == 0 {
+		loftUI.areaMid = 1
+	}
+	loftUI.open = true
+}
+
+func drawOpenLoftConditions(l *app.LoftTool, closed bool) {
+	if closed {
+		return
+	}
+	native.Separator()
+	drawLoftEndCondition("Start section", &loftUI.first)
+	drawLoftEndCondition("End section", &loftUI.last)
+	l.SetFirstCondition(loftUI.first.toEnd())
+	l.SetLastCondition(loftUI.last.toEnd())
 }
 
 // drawLoftEndCondition renders one end's condition combo plus, for an angle/direction takeoff,

--- a/head/ui/parameters_row.go
+++ b/head/ui/parameters_row.go
@@ -34,9 +34,9 @@ func drawParameterRow(s *app.Session, row app.ParameterRow) {
 	native.TableNextColumn()
 	native.Text(row.Tolerance)
 	native.TableNextColumn()
-	drawFlagCell(s, row, "##key", row.IsKey, s.SetParameterKey)
+	drawFlagCell(row, "##key", row.IsKey, s.SetParameterKey)
 	native.TableNextColumn()
-	drawFlagCell(s, row, "##export", row.Export, s.SetParameterExport)
+	drawFlagCell(row, "##export", row.Export, s.SetParameterExport)
 	native.TableNextColumn()
 	drawCommentCell(s, row)
 }
@@ -47,7 +47,7 @@ func drawNameCell(s *app.Session, row app.ParameterRow) {
 		native.Text(row.Name)
 		return
 	}
-	editCell(s, "name", row.ID, row.Name, func(v string) error { return s.SetParameterName(row.ID, v) })
+	editCell("name", row.ID, row.Name, func(v string) error { return s.SetParameterName(row.ID, v) })
 }
 
 // drawEquationCell edits the equation: a dropdown for multi-value, a checkbox for boolean,
@@ -63,7 +63,7 @@ func drawEquationCell(s *app.Session, row app.ParameterRow) {
 			_ = s.SetParameterBool(row.ID, v)
 		}
 	case row.Editable:
-		editCell(s, "eq", row.ID, row.Equation, func(v string) error { return s.SetParameterEquation(row.ID, v) })
+		editCell("eq", row.ID, row.Equation, func(v string) error { return s.SetParameterEquation(row.ID, v) })
 	default:
 		native.Text(row.Equation)
 	}
@@ -101,11 +101,11 @@ func drawCommentCell(s *app.Session, row app.ParameterRow) {
 		native.Text(row.Comment)
 		return
 	}
-	editCell(s, "comment", row.ID, row.Comment, func(v string) error { return s.SetParameterComment(row.ID, v) })
+	editCell("comment", row.ID, row.Comment, func(v string) error { return s.SetParameterComment(row.ID, v) })
 }
 
 // drawFlagCell draws a Key/Export checkbox (disabled for read-only parameters).
-func drawFlagCell(s *app.Session, row app.ParameterRow, id string, value bool, set func(param.ID, bool) error) {
+func drawFlagCell(row app.ParameterRow, id string, value bool, set func(param.ID, bool) error) {
 	v := value
 	native.BeginDisabled(!row.Editable)
 	if native.Checkbox(id, &v) {
@@ -116,7 +116,7 @@ func drawFlagCell(s *app.Session, row app.ParameterRow, id string, value bool, s
 
 // editCell draws a text field seeded once from value; on commit (focus loss) it calls set
 // and drops the buffer so the reformatted model value re-seeds it next frame.
-func editCell(s *app.Session, field string, id param.ID, value string, set func(string) error) {
+func editCell(field string, id param.ID, value string, set func(string) error) {
 	key := field + ":" + idKey(id)
 	buf := cellBuf(key, value)
 	native.SetNextItemWidth(-1)
@@ -152,16 +152,27 @@ func drawRowContextMenu(s *app.Session, row app.ParameterRow) {
 	if native.MenuItem("Add to Group…") {
 		openGroupDialog(row)
 	}
+	drawRowGroupMenuItems(s, row)
+	drawEditableRowMenuItems(s, row)
+	native.EndPopup()
+}
+
+func drawRowGroupMenuItems(s *app.Session, row app.ParameterRow) {
 	if row.Group != "" && native.MenuItem("Remove from Group") {
 		_ = s.RemoveParameterFromGroup(row.ID)
 	}
-	if row.Editable && row.ValueType != "boolean" {
+}
+
+func drawEditableRowMenuItems(s *app.Session, row app.ParameterRow) {
+	if !row.Editable {
+		return
+	}
+	if row.ValueType != "boolean" {
 		drawMultiValueMenuItems(s, row)
 	}
-	if row.Editable && row.ValueType == "numeric" && native.MenuItem("Edit Tolerance…") {
+	if row.ValueType == "numeric" && native.MenuItem("Edit Tolerance…") {
 		openToleranceDialog(row)
 	}
-	native.EndPopup()
 }
 
 // drawMultiValueMenuItems adds the make/edit/clear multi-value entries.

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -32,6 +32,28 @@ func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *fea
 	return items
 }
 
+func axesOverlay(part *compdef.PartComponentDefinition, selected *feature.WorkAxis) []renderer.DrawItem {
+	if part == nil {
+		return nil
+	}
+	axes := part.WorkAxes()
+	items := make([]renderer.DrawItem, 0, axes.Count())
+	for i := 0; i < axes.Count(); i++ {
+		axis := axes.Item(i)
+		if axis.Visible() {
+			items = append(items, axisLine(axis, axisColor(axis, selected)))
+		}
+	}
+	return items
+}
+
+func axisColor(axis, selected *feature.WorkAxis) [4]float32 {
+	if axis == selected {
+		return selectedPlaneColor
+	}
+	return faintPlaneColor
+}
+
 // planeColor chooses a plane border's draw color: selected wins, then hovered, then faint.
 func planeColor(wp, selected, hovered *feature.WorkPlane) [4]float32 {
 	switch wp {
@@ -80,4 +102,11 @@ func planeBorder(wp *feature.WorkPlane, color [4]float32) renderer.DrawItem {
 	pos := planeCorners(wp)
 	idx := []int{0, 1, 1, 2, 2, 3, 3, 0} // border 0-1-2-3-0
 	return renderer.DrawItem{Primitive: renderer.Lines, Positions: pos, Indices: idx, Color: color}
+}
+
+func axisLine(axis *feature.WorkAxis, color [4]float32) renderer.DrawItem {
+	const halfLen = 4.0
+	dir := axis.Direction().AsVector().Scale(halfLen)
+	pos := []math.Point3{axis.Origin().TranslateBy(dir.Scale(-1)), axis.Origin().TranslateBy(dir)}
+	return renderer.DrawItem{Primitive: renderer.Lines, Positions: pos, Indices: []int{0, 1}, Color: color, OnTop: true}
 }

--- a/head/ui/shell_dialog.go
+++ b/head/ui/shell_dialog.go
@@ -35,15 +35,7 @@ func drawShellDialog(s *app.Session) {
 		native.Text("Thickness (" + s.LengthUnitName() + ")")
 		native.InputFloat("##shell-thickness", &shellUI.thickness)
 		sh.SetThickness(float64(shellUI.thickness))
-		native.BeginDisabled(!sh.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawCommitCancelButtons(s, sh.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -81,6 +81,11 @@ func sketchOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool, candida
 	if sk == nil {
 		return nil
 	}
+	normal, sel, cand := sketchSegmentsFor(sk, selected, candidate)
+	return sketchItems(normal, sel, cand)
+}
+
+func sketchSegmentsFor(sk *sketch.Sketch, selected func(sketch.Entity) bool, candidate sketch.Entity) (*segAccum, *segAccum, *segAccum) {
 	normal, sel, cand := &segAccum{}, &segAccum{}, &segAccum{}
 	plane := sk.Plane()
 	pick := func(e sketch.Entity) *segAccum {
@@ -98,6 +103,10 @@ func sketchOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool, candida
 	addArcs(pick, plane, sk)
 	addEllipses(pick, plane, sk)
 	addSplines(pick, plane, sk)
+	return normal, sel, cand
+}
+
+func sketchItems(normal, sel, cand *segAccum) []renderer.DrawItem {
 	var items []renderer.DrawItem
 	items = appendGrid(items, normal, sketchColor)
 	items = appendGrid(items, sel, sketchSelectedColor)

--- a/head/ui/split_dialog.go
+++ b/head/ui/split_dialog.go
@@ -33,15 +33,7 @@ func drawSplitDialog(s *app.Session) {
 		if native.Button("Trim — keep back side") {
 			t.SetKeepNegative()
 		}
-		native.BeginDisabled(!t.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawCommitCancelButtons(s, t.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -59,9 +59,22 @@ func applyThemeIfChanged(win *native.Window, s *app.Session) {
 // the overlay builders read each frame.
 func refreshThemeColors(t contract.Theme) {
 	arr := func(tok types.ThemeToken) [4]float32 { return t.Color(tok).Array() }
+	refreshGridThemeColors(arr)
+	refreshSketchThemeColors(arr)
+	refreshPlaneThemeColors(arr)
+	selectionHighlight = arr(types.TokenSelectionHighlight)
+	iconTint = arr(types.TokenIconTint)
+	c := t.Color(types.TokenChromeWindowBg)
+	windowClearColor = [3]float32{c.R, c.G, c.B}
+}
+
+func refreshGridThemeColors(arr func(types.ThemeToken) [4]float32) {
 	gridMinorColor = arr(types.TokenGridMinor)
 	gridMajorColor = arr(types.TokenGridMajor)
 	gridAxisColor = arr(types.TokenGridAxis)
+}
+
+func refreshSketchThemeColors(arr func(types.ThemeToken) [4]float32) {
 	sketchColor = arr(types.TokenSketchGeometry)
 	sketchSelectedColor = arr(types.TokenSketchSelected)
 	sketchCandidateColor = arr(types.TokenSketchCandidate)
@@ -70,14 +83,13 @@ func refreshThemeColors(t contract.Theme) {
 	dimensionDrivenColor = arr(types.TokenDimensionDriven)
 	snapGlyphColor = arr(types.TokenSnapGlyph)
 	pointMarkerColor = sketchColor // placed points match the sketch wireframe
+}
+
+func refreshPlaneThemeColors(arr func(types.ThemeToken) [4]float32) {
 	faintPlaneColor = arr(types.TokenPlaneFaint)
 	hoverPlaneColor = arr(types.TokenPlaneHover)
 	selectedPlaneColor = arr(types.TokenPlaneSelected)
 	planeFillColor = arr(types.TokenPlaneFill)
-	selectionHighlight = arr(types.TokenSelectionHighlight)
-	iconTint = arr(types.TokenIconTint)
-	c := t.Color(types.TokenChromeWindowBg)
-	windowClearColor = [3]float32{c.R, c.G, c.B}
 }
 
 // WindowClearColor is the themed background the frame loop clears the swapchain to (the

--- a/head/ui/thread_dialog.go
+++ b/head/ui/thread_dialog.go
@@ -22,67 +22,78 @@ func drawThreadDialog(s *app.Session) {
 	}
 	native.SetNextWindowSize(340, 300)
 	if native.Begin("Thread") {
-		if t.HasFace() {
-			native.Text("Cylindrical face: selected")
-		} else {
-			native.Text("Click a cylindrical face to thread.")
-		}
-		native.Separator()
-
-		standards := feature.ThreadStandards()
-		std := standards[clampIdx(t.StandardIndex(), len(standards))]
-		if native.BeginCombo("Standard", fmt.Sprintf("%s (%s)", std, feature.StandardSystem(std))) {
-			for i, st := range standards {
-				if native.Selectable(fmt.Sprintf("%s (%s)", st, feature.StandardSystem(st)), i == t.StandardIndex()) {
-					t.SetStandardIndex(i)
-				}
-			}
-			native.EndCombo()
-		}
-		std = standards[clampIdx(t.StandardIndex(), len(standards))]
-
-		sizes := feature.ThreadSizes(std)
-		size := sizes[clampIdx(t.SizeIndex(), len(sizes))]
-		if native.BeginCombo("Size", size.Name) {
-			for i, sz := range sizes {
-				if native.Selectable(sz.Name, i == t.SizeIndex()) {
-					t.SetSizeIndex(i)
-				}
-			}
-			native.EndCombo()
-		}
-		size = sizes[clampIdx(t.SizeIndex(), len(sizes))]
-
-		pitch := size.Pitches[clampIdx(t.PitchIndex(), len(size.Pitches))]
-		if native.BeginCombo("Pitch", pitchLabel(size, pitch)) {
-			for i, p := range size.Pitches {
-				if native.Selectable(pitchLabel(size, p), i == t.PitchIndex()) {
-					t.SetPitchIndex(i)
-				}
-			}
-			native.EndCombo()
-		}
-
-		cut := t.Cut()
-		if native.Checkbox("Model real cut thread (else cosmetic)", &cut) {
-			t.SetCut(cut)
-		}
-		native.Separator()
-		if d, err := t.Designation(); err == nil {
-			native.Text("Designation: " + d)
-		}
-
-		native.BeginDisabled(!t.CanCommit())
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.EndDisabled()
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		drawThreadFaceStatus(t)
+		size := drawThreadStandardAndSize(t)
+		drawThreadPitch(t, size)
+		drawThreadCutAndDesignation(t)
+		drawCommitCancelButtons(s, t.CanCommit())
 	}
 	native.End()
+}
+
+func drawThreadFaceStatus(t *app.ThreadTool) {
+	if t.HasFace() {
+		native.Text("Cylindrical face: selected")
+	} else {
+		native.Text("Click a cylindrical face to thread.")
+	}
+	native.Separator()
+}
+
+func drawThreadStandardAndSize(t *app.ThreadTool) feature.ThreadSize {
+	standards := feature.ThreadStandards()
+	std := standards[clampIdx(t.StandardIndex(), len(standards))]
+	drawThreadStandardCombo(t, standards, std)
+	std = standards[clampIdx(t.StandardIndex(), len(standards))]
+	sizes := feature.ThreadSizes(std)
+	size := sizes[clampIdx(t.SizeIndex(), len(sizes))]
+	drawThreadSizeCombo(t, sizes, size)
+	return sizes[clampIdx(t.SizeIndex(), len(sizes))]
+}
+
+func drawThreadStandardCombo(t *app.ThreadTool, standards []feature.ThreadStandard, std feature.ThreadStandard) {
+	if native.BeginCombo("Standard", fmt.Sprintf("%s (%s)", std, feature.StandardSystem(std))) {
+		for i, st := range standards {
+			if native.Selectable(fmt.Sprintf("%s (%s)", st, feature.StandardSystem(st)), i == t.StandardIndex()) {
+				t.SetStandardIndex(i)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+func drawThreadSizeCombo(t *app.ThreadTool, sizes []feature.ThreadSize, size feature.ThreadSize) {
+	if native.BeginCombo("Size", size.Name) {
+		for i, sz := range sizes {
+			if native.Selectable(sz.Name, i == t.SizeIndex()) {
+				t.SetSizeIndex(i)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+func drawThreadPitch(t *app.ThreadTool, size feature.ThreadSize) {
+	pitch := size.Pitches[clampIdx(t.PitchIndex(), len(size.Pitches))]
+	if native.BeginCombo("Pitch", pitchLabel(size, pitch)) {
+		for i, p := range size.Pitches {
+			if native.Selectable(pitchLabel(size, p), i == t.PitchIndex()) {
+				t.SetPitchIndex(i)
+			}
+		}
+		native.EndCombo()
+	}
+}
+
+func drawThreadCutAndDesignation(t *app.ThreadTool) {
+	cut := t.Cut()
+	if native.Checkbox("Model real cut thread (else cosmetic)", &cut) {
+		t.SetCut(cut)
+	}
+	native.Separator()
+	if d, err := t.Designation(); err == nil {
+		native.Text("Designation: " + d)
+	}
 }
 
 // pitchLabel formats a pitch for the combo: "1.25 mm" (metric) or "20 TPI" (imperial).

--- a/head/ui/viewport_visibility.go
+++ b/head/ui/viewport_visibility.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "oblikovati/app"
+
+func shouldDrawViewport(s *app.Session) bool {
+	return s != nil && s.Workspace().Count() > 0
+}

--- a/head/ui/viewport_visibility_test.go
+++ b/head/ui/viewport_visibility_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati/app"
+	"oblikovati/model/compdef"
+)
+
+func TestShouldDrawViewportOnlyWithDocuments(t *testing.T) {
+	s := app.NewSession()
+	if shouldDrawViewport(s) {
+		t.Fatal("shouldDrawViewport(empty session) = true, want false")
+	}
+	if _, err := compdef.AddPart(s.Workspace(), "p.obk", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if !shouldDrawViewport(s) {
+		t.Fatal("shouldDrawViewport(session with document) = false, want true")
+	}
+}

--- a/head/ui/work_axis_selection.go
+++ b/head/ui/work_axis_selection.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati/app"
+	"oblikovati/model/feature"
+)
+
+func selectedWorkAxis(s *app.Session) *feature.WorkAxis {
+	for _, item := range s.Selection().Items() {
+		if h, ok := item.(app.WorkAxisHandle); ok {
+			return h.Axis
+		}
+	}
+	return nil
+}

--- a/head/viewport/matrix.go
+++ b/head/viewport/matrix.go
@@ -7,6 +7,15 @@ package viewport
 // reconstruct world-space view rays from clip space (ADR-0026 §5). It is the standard cofactor
 // (adjugate / determinant) inverse, kept in pure Go so it is unit-tested without a GPU.
 func Invert4x4(m [16]float32) ([16]float32, bool) {
+	inv := inverseCofactors(m)
+	det := m[0]*inv[0] + m[1]*inv[4] + m[2]*inv[8] + m[3]*inv[12]
+	if det == 0 {
+		return [16]float32{}, false
+	}
+	return scaleInverse(inv, 1.0/det), true
+}
+
+func inverseCofactors(m [16]float32) [16]float32 {
 	var inv [16]float32
 	inv[0] = m[5]*m[10]*m[15] - m[5]*m[11]*m[14] - m[9]*m[6]*m[15] + m[9]*m[7]*m[14] + m[13]*m[6]*m[11] - m[13]*m[7]*m[10]
 	inv[4] = -m[4]*m[10]*m[15] + m[4]*m[11]*m[14] + m[8]*m[6]*m[15] - m[8]*m[7]*m[14] - m[12]*m[6]*m[11] + m[12]*m[7]*m[10]
@@ -24,14 +33,12 @@ func Invert4x4(m [16]float32) ([16]float32, bool) {
 	inv[7] = m[0]*m[6]*m[11] - m[0]*m[7]*m[10] - m[4]*m[2]*m[11] + m[4]*m[3]*m[10] + m[8]*m[2]*m[7] - m[8]*m[3]*m[6]
 	inv[11] = -m[0]*m[5]*m[11] + m[0]*m[7]*m[9] + m[4]*m[1]*m[11] - m[4]*m[3]*m[9] - m[8]*m[1]*m[7] + m[8]*m[3]*m[5]
 	inv[15] = m[0]*m[5]*m[10] - m[0]*m[6]*m[9] - m[4]*m[1]*m[10] + m[4]*m[2]*m[9] + m[8]*m[1]*m[6] - m[8]*m[2]*m[5]
+	return inv
+}
 
-	det := m[0]*inv[0] + m[1]*inv[4] + m[2]*inv[8] + m[3]*inv[12]
-	if det == 0 {
-		return [16]float32{}, false
-	}
-	d := 1.0 / det
+func scaleInverse(inv [16]float32, d float32) [16]float32 {
 	for i := range inv {
 		inv[i] *= d
 	}
-	return inv, true
+	return inv
 }

--- a/model/compdef/workplane_test.go
+++ b/model/compdef/workplane_test.go
@@ -15,8 +15,21 @@ func TestPartHasThreeOriginPlanes(t *testing.T) {
 		if planes[i].Name() != n {
 			t.Errorf("origin plane %d = %q, want %q", i, planes[i].Name(), n)
 		}
+		if planes[i].Visible() {
+			t.Errorf("origin plane %q visible by default", n)
+		}
 		if planes[i].DisplaySize() <= 0 {
 			t.Errorf("%s has non-positive display size", n)
+		}
+	}
+}
+
+func TestPartOriginAxesStartInvisible(t *testing.T) {
+	d := NewPartComponentDefinition()
+	for i := 0; i < d.WorkAxes().Count(); i++ {
+		axis := d.WorkAxes().Item(i)
+		if axis.Visible() {
+			t.Errorf("origin axis %q visible by default", axis.Name())
 		}
 	}
 }

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -73,6 +73,7 @@ type WorkAxis struct {
 	origin           math.Point3
 	dir              math.UnitVector3
 	health           health.Health
+	visible          bool
 	coordinateSystem bool
 	grounded         bool
 }
@@ -85,6 +86,12 @@ func (w *WorkAxis) Origin() math.Point3             { return w.origin }
 func (w *WorkAxis) Direction() math.UnitVector3     { return w.dir }
 func (w *WorkAxis) IsCoordinateSystemElement() bool { return w.coordinateSystem }
 func (w *WorkAxis) Grounded() bool                  { return w.grounded }
+
+// Visible reports whether the datum axis is drawn in the viewport.
+func (w *WorkAxis) Visible() bool { return w.visible }
+
+// SetVisible toggles the datum axis viewport visibility.
+func (w *WorkAxis) SetVisible(v bool) { w.visible = v }
 
 // recompute re-derives the axis, going sick on a degenerate definition.
 func (w *WorkAxis) recompute(r workResolver) {
@@ -127,7 +134,7 @@ func (c *WorkAxes) AddByPlaneIntersection(p1, p2 WorkRef) *WorkAxis {
 }
 
 func (c *WorkAxes) addUser(def axisDefinition) *WorkAxis {
-	w := &WorkAxis{id: nextID(), key: userRef("axis", len(c.items)), name: "WorkAxis", def: def}
+	w := &WorkAxis{id: nextID(), key: userRef("axis", len(c.items)), name: "WorkAxis", def: def, visible: true}
 	c.track(w)
 	c.g.recordUser("axis", len(c.items)-1)
 	return w

--- a/model/feature/work_features_test.go
+++ b/model/feature/work_features_test.go
@@ -139,11 +139,10 @@ func TestWorkFeatureNamesAndKeys(t *testing.T) {
 	}
 }
 
-func TestWorkPlaneVisibilityDefaultsTrueAndToggles(t *testing.T) {
+func TestWorkPlaneVisibilityDefaultsAndToggles(t *testing.T) {
 	g := NewWorkGeometry()
-	// Origin planes and user planes are visible by default.
-	if !g.WorkPlanes().Item(0).Visible() {
-		t.Error("origin plane should be visible by default")
+	if g.WorkPlanes().Item(0).Visible() {
+		t.Error("origin plane should be hidden by default")
 	}
 	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
 	if !wp.Visible() {

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -105,7 +105,7 @@ func (w *WorkPlane) IsCoordinateSystemElement() bool { return w.coordinateSystem
 func (w *WorkPlane) Grounded() bool                  { return w.grounded }
 
 // Visible reports whether the datum is drawn in the viewport; SetVisible toggles it
-// (Inventor's per-work-feature Visibility). New planes are visible by default.
+// (Inventor's per-work-feature Visibility). User planes are visible by default.
 func (w *WorkPlane) Visible() bool     { return w.visible }
 func (w *WorkPlane) SetVisible(v bool) { w.visible = v }
 
@@ -137,7 +137,7 @@ func newWorkPlanes(g *WorkGeometry) *WorkPlanes {
 func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) {
 	w := &WorkPlane{
 		id: nextID(), key: key, name: name, def: fixedPlaneDef{plane: plane},
-		displaySize: defaultOriginPlaneSize, coordinateSystem: true, grounded: true, visible: true,
+		displaySize: defaultOriginPlaneSize, coordinateSystem: true, grounded: true,
 	}
 	c.track(w)
 }


### PR DESCRIPTION
## Summary
- add a file-explorer based open/save dialog and document-tab close flow with dirty-document save prompts
- hide the viewport when no documents are open and make model-browser roots open by default
- add visibility menus for work axes and solid bodies, axis overlays, and hidden-body render filtering
- make origin work planes and axes hidden by default when documents open
- wire head lint into the local lint target and clean up head lint findings

## Local validation
- make lint
- make test
- cd head && make test