### PR TITLE
feat(addin): implement meeting-addin API prerequisites (camera, interaction, bounded txn, edit event)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -12,6 +12,7 @@ package events
 import (
 	"encoding/json"
 
+	"oblikovati/api/wire"
 	"oblikovati/app"
 	"oblikovati/event"
 	"oblikovati/model/doc"
@@ -49,7 +50,26 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.CommandEnded) event.Outcome {
 			return relay(sink, wireEvent{Type: "command.ended", Command: e.ID, Failed: e.Failed})
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
+			return relayEdit(sink, e)
+		}),
 	}
+}
+
+// relayEdit serializes a committed edit as the contract's [wire.EditCommittedEvent] (the
+// mutation expressed as the wire request that produced it) and hands it to sink, so a
+// collaboration add-in can replay it on remote peers (ADR-0004).
+func relayEdit(sink Sink, e app.EditCommitted) event.Outcome {
+	ev := wire.EditCommittedEvent{
+		Type:     wire.EventEditCommitted,
+		Document: uint64(e.Document),
+		Method:   e.Method,
+		Args:     json.RawMessage(e.Args),
+	}
+	if b, err := json.Marshal(ev); err == nil {
+		sink(b)
+	}
+	return event.Continue()
 }
 
 // relay serializes ev and hands it to sink; it never vetoes (passive listener).

--- a/addin/router/camera.go
+++ b/addin/router/camera.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	stdmath "math"
+
+	"oblikovati/api/wire"
+	"oblikovati/app"
+	"oblikovati/math"
+	"oblikovati/scene"
+)
+
+// getCamera returns the viewport camera as a look-at frame (wire.MethodViewGetCamera).
+func getCamera(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(cameraView(s.Camera()))
+}
+
+// setCamera moves the viewport camera to the requested look-at frame, keeping the
+// camera's viewport size, and echoes the result (wire.MethodViewSetCamera). It rejects a
+// non-finite or degenerate frame so a bad presenter packet can never corrupt the view.
+func setCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.SetCameraArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	if err := validateCameraArgs(a); err != nil {
+		return nil, err
+	}
+	cam := s.Camera() // preserve Width/Height; override only the look-at frame + fov
+	cam.Eye = math.P3(a.Eye[0], a.Eye[1], a.Eye[2])
+	cam.Target = math.P3(a.Target[0], a.Target[1], a.Target[2])
+	cam.Up = math.V3(a.Up[0], a.Up[1], a.Up[2])
+	cam.FOV = a.FOV
+	s.SetCamera(cam)
+	return json.Marshal(cameraView(s.Camera()))
+}
+
+// cameraView projects a scene.Camera onto the wire look-at DTO.
+func cameraView(c scene.Camera) wire.CameraView {
+	return wire.CameraView{
+		Eye:    [3]float64{c.Eye.X, c.Eye.Y, c.Eye.Z},
+		Target: [3]float64{c.Target.X, c.Target.Y, c.Target.Z},
+		Up:     [3]float64{c.Up.X, c.Up.Y, c.Up.Z},
+		FOV:    c.FOV,
+	}
+}
+
+// validateCameraArgs rejects a camera frame that would produce an invalid view: any
+// non-finite component, a non-positive or ≥π field of view, a zero eye→target distance,
+// a zero-length up vector, or an up parallel to the view direction.
+func validateCameraArgs(a wire.SetCameraArgs) error {
+	for _, v := range []float64{a.Eye[0], a.Eye[1], a.Eye[2], a.Target[0], a.Target[1], a.Target[2], a.Up[0], a.Up[1], a.Up[2], a.FOV} {
+		if stdmath.IsNaN(v) || stdmath.IsInf(v, 0) {
+			return fmt.Errorf("view.setCamera: non-finite camera component in %+v", a)
+		}
+	}
+	if a.FOV <= 0 || a.FOV >= stdmath.Pi {
+		return fmt.Errorf("view.setCamera: fov %v out of range (expected 0 < fov < π)", a.FOV)
+	}
+	eye := math.P3(a.Eye[0], a.Eye[1], a.Eye[2])
+	target := math.P3(a.Target[0], a.Target[1], a.Target[2])
+	up := math.V3(a.Up[0], a.Up[1], a.Up[2])
+	const eps = 1e-9
+	if eye.DistanceTo(target) < eps {
+		return fmt.Errorf("view.setCamera: eye and target coincide at %v", a.Eye)
+	}
+	if up.Length() < eps {
+		return fmt.Errorf("view.setCamera: up vector is zero %v", a.Up)
+	}
+	if up.IsParallelTo(eye.VectorTo(target), eps) {
+		return fmt.Errorf("view.setCamera: up %v is parallel to the view direction", a.Up)
+	}
+	return nil
+}

--- a/addin/router/camera_test.go
+++ b/addin/router/camera_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati/api/wire"
+)
+
+// TestCameraRoundTrips drives view.setCamera then view.getCamera and asserts the look-at
+// frame survives — the dogfood proof the camera contract reaches the session and back.
+func TestCameraRoundTrips(t *testing.T) {
+	r, s := seededSession(t)
+	args := `{"eye":[10,20,30],"target":[1,2,3],"up":[0,1,0],"fov":0.8}`
+
+	var set wire.CameraView
+	call(t, r, s, "view.setCamera", args, &set)
+	if set.Eye != [3]float64{10, 20, 30} || set.Target != [3]float64{1, 2, 3} || set.FOV != 0.8 {
+		t.Fatalf("setCamera = %+v, want eye=[10 20 30] target=[1 2 3] fov=0.8", set)
+	}
+
+	var got wire.CameraView
+	call(t, r, s, "view.getCamera", "{}", &got)
+	if got != set {
+		t.Fatalf("getCamera = %+v, want %+v", got, set)
+	}
+}
+
+// TestSetCameraRejectsInvalidFrames checks degenerate/out-of-range frames are errors, not
+// a silently corrupted view.
+func TestSetCameraRejectsInvalidFrames(t *testing.T) {
+	r, s := seededSession(t)
+	cases := map[string]string{
+		"coincident eye/target": `{"eye":[1,1,1],"target":[1,1,1],"up":[0,1,0],"fov":0.8}`,
+		"fov out of range":      `{"eye":[0,0,10],"target":[0,0,0],"up":[0,1,0],"fov":0}`,
+		"up parallel to view":   `{"eye":[0,0,10],"target":[0,0,0],"up":[0,0,1],"fov":0.8}`,
+		"zero up":               `{"eye":[0,0,10],"target":[0,0,0],"up":[0,0,0],"fov":0.8}`,
+	}
+	for name, args := range cases {
+		if _, err := r.Handle(s, "view.setCamera", []byte(args)); err == nil {
+			t.Errorf("%s: expected an error, got none", name)
+		}
+	}
+}

--- a/addin/router/edit_committed_test.go
+++ b/addin/router/edit_committed_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati/api/wire"
+	"oblikovati/app"
+	"oblikovati/event"
+)
+
+// TestEditCommittedEmittedForMutationsOnly checks the router emits an EditCommitted event
+// (carrying the wire method + args) for a document-mutating call and nothing for a
+// read-only call — the capture seam for operational replication (ADR-0004).
+func TestEditCommittedEmittedForMutationsOnly(t *testing.T) {
+	r, s := seededSession(t)
+
+	var got []app.EditCommitted
+	sub := event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+	defer sub.Cancel()
+
+	// Read-only call must not emit.
+	call(t, r, s, "parameters.list", "{}", nil)
+	if len(got) != 0 {
+		t.Fatalf("read-only call emitted edit.committed: %+v", got)
+	}
+
+	// Mutation emits exactly one event with the originating method + args.
+	call(t, r, s, "parameters.set", `{"name":"width","expression":"6 cm"}`, nil)
+	if len(got) != 1 {
+		t.Fatalf("mutation emitted %d edit.committed events, want 1", len(got))
+	}
+	if got[0].Method != wire.MethodParametersSet {
+		t.Errorf("event method = %q, want %q", got[0].Method, wire.MethodParametersSet)
+	}
+	var a wire.ParameterSetArgs
+	if err := json.Unmarshal(got[0].Args, &a); err != nil {
+		t.Fatalf("event args not valid JSON: %v", err)
+	}
+	if a.Name != "width" || a.Expression != "6 cm" {
+		t.Errorf("event args = %+v, want width=6 cm", a)
+	}
+}

--- a/addin/router/interaction.go
+++ b/addin/router/interaction.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati/api/wire"
+	"oblikovati/app"
+)
+
+// interactionState reports whether the local user is mid-action, so a collaboration
+// add-in can gate/buffer incoming remote edits (wire.MethodInteractionState).
+//
+// Busy is true when an interactive tool is running or a bounded transaction is open.
+// ActiveCommand is intentionally left empty for now: the router runs on the session
+// goroutine, so a command executed via commands.execute completes before any concurrent
+// query could observe it — the durable interactive state is the active tool.
+func interactionState(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	st := wire.InteractionState{InTransaction: s.InTransaction()}
+	if t := s.ActiveTool(); t != nil {
+		st.ActiveTool = t.Name()
+	}
+	st.Busy = st.ActiveTool != "" || st.InTransaction
+	return json.Marshal(st)
+}

--- a/addin/router/interaction_test.go
+++ b/addin/router/interaction_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati/addin/opregistry"
+	"oblikovati/api/wire"
+	"oblikovati/app"
+)
+
+// TestInteractionStateIdleVsInTransaction checks interaction.state reports idle on a fresh
+// session and flags Busy/InTransaction once a bounded transaction is open — the signal a
+// collaboration add-in gates remote edits on (ADR-0005).
+func TestInteractionStateIdleVsInTransaction(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+
+	var st wire.InteractionState
+	call(t, r, s, "interaction.state", "{}", &st)
+	if st.Busy || st.InTransaction || st.ActiveTool != "" {
+		t.Fatalf("fresh session should be idle, got %+v", st)
+	}
+
+	call(t, r, s, "transaction.begin", `{"label":"x"}`, nil)
+	call(t, r, s, "interaction.state", "{}", &st)
+	if !st.InTransaction || !st.Busy {
+		t.Fatalf("inside a transaction state should be busy/inTransaction, got %+v", st)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -77,14 +77,20 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewGetDisplayMode] = getDisplayMode
 	r.handlers[wire.MethodViewSetDisplayMode] = setDisplayMode
 	r.handlers[wire.MethodViewListDisplayModes] = listDisplayModes
+	r.handlers[wire.MethodViewGetCamera] = getCamera
+	r.handlers[wire.MethodViewSetCamera] = setCamera
+	r.handlers[wire.MethodInteractionState] = interactionState
 }
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query
-// the active document's transaction-event stream (transaction.undo/redo/state).
+// the active document's transaction-event stream (transaction.undo/redo/state), plus the
+// bounded transaction.begin/end that coalesce a batch into one undo step.
 func (r *Router) registerTransactionHandlers() {
 	r.handlers[wire.MethodTransactionUndo] = undoTransaction
 	r.handlers[wire.MethodTransactionRedo] = redoTransaction
 	r.handlers[wire.MethodTransactionState] = transactionState
+	r.handlers[wire.MethodTransactionBegin] = beginTransaction
+	r.handlers[wire.MethodTransactionEnd] = endTransaction
 }
 
 // registerSketchHandlers wires the 2D-sketch methods: the spine + enumeration here, and
@@ -244,7 +250,47 @@ func (r *Router) Handle(s *app.Session, method string, req []byte) (resp []byte,
 		return nil, herr
 	}
 	r.record(method, time.Since(start), true, "", "", "")
+	// A document-mutating method that succeeded is a committed edit: emit it as the wire
+	// request that produced it, so a collaboration add-in can replicate it (ADR-0004).
+	// First cut: only router-path edits; local UI edits are not yet captured.
+	if mutatingMethods[method] {
+		s.EmitEditCommitted(method, req)
+	}
 	return out, nil
+}
+
+// mutatingMethods is the set of router methods that commit a document mutation worth
+// replicating to collaboration peers as an edit.committed event. It is a curated
+// allowlist: a method missing here simply is not broadcast (a known first-cut gap,
+// failing safe), whereas a read-only method must never appear (it would broadcast noise).
+var mutatingMethods = map[string]bool{
+	wire.MethodDocumentsCreate:        true,
+	wire.MethodDocumentsImport:        true,
+	wire.MethodParametersAdd:          true,
+	wire.MethodParametersSet:          true,
+	wire.MethodFeaturesAdd:            true,
+	wire.MethodWorkPlanesCreate:       true,
+	wire.MethodModelAssignMaterial:    true,
+	wire.MethodModelAssignAppearance:  true,
+	wire.MethodSketchCreate:           true,
+	wire.MethodSketchRectangle:        true,
+	wire.MethodSketchDelete:           true,
+	wire.MethodSketchEdit:             true,
+	wire.MethodSketchExitEdit:         true,
+	wire.MethodSketchSolve:            true,
+	wire.MethodSketchAddEntity:        true,
+	wire.MethodSketchAddConstraint:    true,
+	wire.MethodSketchDeleteConstraint: true,
+	wire.MethodSketchAddDimension:     true,
+	wire.MethodSketchDriveDimension:   true,
+	wire.MethodSketchSetProperty:      true,
+	wire.MethodSketchTransform:        true,
+	wire.MethodSketchAddPattern:       true,
+	wire.MethodSketchOffset:           true,
+	wire.MethodSketchProject:          true,
+	wire.MethodTransactionUndo:        true,
+	wire.MethodTransactionRedo:        true,
+	wire.MethodTransactionEnd:         true,
 }
 
 // record appends an operation entry to the trace, except for logs.tail itself (so polling the

--- a/addin/router/transaction_bounds_test.go
+++ b/addin/router/transaction_bounds_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati/addin/opregistry"
+	"oblikovati/api/wire"
+	"oblikovati/app"
+)
+
+// TestBoundedTransactionCoalescesEdits checks transaction.begin/end fold several recording
+// edits into a single, named undo step — the team-shared-undo primitive of ADR-0005.
+func TestBoundedTransactionCoalescesEdits(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+
+	call(t, r, s, "transaction.begin", `{"label":"batch"}`, nil)
+	if err := s.AddNumericUserParameter("h", "3 cm"); err != nil {
+		t.Fatalf("add h: %v", err)
+	}
+	if err := s.AddNumericUserParameter("w", "4 cm"); err != nil {
+		t.Fatalf("add w: %v", err)
+	}
+
+	// Inside the open transaction, nothing is undoable yet (recording is deferred).
+	var st wire.UndoState
+	call(t, r, s, "transaction.state", "{}", &st)
+	if st.CanUndo {
+		t.Fatalf("inside open transaction nothing should be undoable, got %+v", st)
+	}
+
+	var end wire.UndoState
+	call(t, r, s, "transaction.end", "{}", &end)
+	if !end.CanUndo || end.NextUndo != "batch" {
+		t.Fatalf("after end want one undoable step 'batch', got %+v", end)
+	}
+
+	// A single undo reverts the whole batch.
+	call(t, r, s, "transaction.undo", "{}", &st)
+	if st.CanUndo {
+		t.Fatalf("one undo should revert the whole batch, got %+v", st)
+	}
+}
+
+// TestEndTransactionWithoutBeginErrors guards the unbalanced case.
+func TestEndTransactionWithoutBeginErrors(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	if _, err := r.Handle(s, "transaction.end", nil); err == nil {
+		t.Fatal("expected an error ending with no open transaction")
+	}
+}

--- a/addin/router/transactions.go
+++ b/addin/router/transactions.go
@@ -31,6 +31,28 @@ func transactionState(s *app.Session, _ json.RawMessage) (json.RawMessage, error
 	return marshalUndoState(s)
 }
 
+// beginTransaction opens a bounded transaction so a batch of edits coalesces into one
+// undo step (wire.MethodTransactionBegin).
+func beginTransaction(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.TransactionBeginArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	if err := s.BeginTransaction(a.Label); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.OKResult{OK: true})
+}
+
+// endTransaction closes the innermost open transaction and returns the resulting state
+// (wire.MethodTransactionEnd).
+func endTransaction(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	if err := s.EndTransaction(); err != nil {
+		return nil, err
+	}
+	return marshalUndoState(s)
+}
+
 // marshalUndoState renders the active document's cursor state into the wire DTO.
 func marshalUndoState(s *app.Session) (json.RawMessage, error) {
 	return json.Marshal(wire.UndoState{

--- a/app/events.go
+++ b/app/events.go
@@ -13,6 +13,7 @@ const (
 	tidCommandEnded      event.TypeID = 0x0502
 	tidSelectionChanged  event.TypeID = 0x0503
 	tidTransactionChange event.TypeID = 0x0504
+	tidEditCommitted     event.TypeID = 0x0505
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's
@@ -48,3 +49,31 @@ type TransactionChanged struct{ Document doc.ID }
 
 // EventID implements event.Event.
 func (TransactionChanged) EventID() event.TypeID { return tidTransactionChange }
+
+// EditCommitted fires (After) when a document mutation is applied through the method
+// router, carrying the very wire request that produced it (Method + raw Args). It is the
+// basis for operational replication in a collaboration add-in (oblikovati-meeting
+// ADR-0004): a remote peer replays Method/Args through its own client. Distinct from
+// TransactionChanged (which only signals "the model moved" with no payload).
+//
+// v1 scope: only router-path edits are emitted; edits made directly in the UI are not yet
+// captured. Args is the raw JSON request bytes (may be nil for a no-arg method).
+type EditCommitted struct {
+	Document doc.ID
+	Method   string
+	Args     []byte
+}
+
+// EventID implements event.Event.
+func (EditCommitted) EventID() event.TypeID { return tidEditCommitted }
+
+// EmitEditCommitted publishes an EditCommitted event for a router-applied mutation,
+// tagged with the active document's id (0 when none). The router calls this after a
+// mutating method succeeds.
+func (s *Session) EmitEditCommitted(method string, args []byte) {
+	var id doc.ID
+	if d := s.ActiveDocument(); d != nil {
+		id = d.ID()
+	}
+	event.Emit(s.bus, event.After, EditCommitted{Document: id, Method: method, Args: args})
+}

--- a/app/undo.go
+++ b/app/undo.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"bytes"
+	"errors"
 
 	"oblikovati/command"
 	"oblikovati/event"
@@ -24,6 +25,14 @@ var _ command.RecipeStore = (*compdef.PartComponentDefinition)(nil)
 type docHistory struct {
 	hist     *command.History
 	snapshot []byte
+
+	// groupDepth > 0 means a bounded transaction is open: per-edit recording is
+	// suppressed and the whole delta is recorded as one event when the outermost
+	// EndTransaction runs. groupLabel names that single coalesced step (the outermost
+	// Begin's label wins). While open, snapshot stays at the pre-group state, so it is
+	// exactly the "before" for the group. See BeginTransaction/EndTransaction.
+	groupDepth int
+	groupLabel string
 }
 
 // resync sets snapshot to the recipe the document now holds — called after undo/redo
@@ -67,12 +76,75 @@ func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string
 		return
 	}
 	dh := s.documentHistory(d)
+	if dh.groupDepth > 0 {
+		// Inside a bounded transaction: defer recording so the whole batch becomes one
+		// undo step at EndTransaction. snapshot is intentionally left untouched.
+		return
+	}
 	after, err := part.MarshalRecipe()
 	if err != nil || bytes.Equal(after, dh.snapshot) {
 		return
 	}
 	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
 	dh.snapshot = after
+}
+
+// ErrNoOpenTransaction is returned by EndTransaction when no bounded transaction is open.
+var ErrNoOpenTransaction = errors.New("app: no open transaction to end")
+
+// BeginTransaction opens a bounded transaction on the active document: every edit
+// recorded until the matching EndTransaction is coalesced into a single undo step named
+// label. Begin/End nest; the outermost Begin's label names the step and only the
+// outermost End commits it. A collaboration add-in wraps a drained batch of remote
+// operations in one Begin/End so the batch is one team-shared undo step (ADR-0005).
+func (s *Session) BeginTransaction(label string) error {
+	d := s.ActiveDocument()
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	dh := s.documentHistory(d)
+	if dh.groupDepth == 0 {
+		dh.groupLabel = label
+	}
+	dh.groupDepth++
+	return nil
+}
+
+// EndTransaction closes the innermost open bounded transaction. At depth 0 (the
+// outermost End) it records the whole accumulated delta as one event and advances the
+// cursor; a no-op group (before == after) records nothing.
+func (s *Session) EndTransaction() error {
+	d := s.ActiveDocument()
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	dh := s.documentHistory(d)
+	if dh.groupDepth == 0 {
+		return ErrNoOpenTransaction
+	}
+	dh.groupDepth--
+	if dh.groupDepth > 0 {
+		return nil // inner end: keep accumulating until the outermost End
+	}
+	label := dh.groupLabel
+	dh.groupLabel = ""
+	part, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return nil
+	}
+	after, err := part.MarshalRecipe()
+	if err != nil || bytes.Equal(after, dh.snapshot) {
+		return nil
+	}
+	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
+	dh.snapshot = after
+	return nil
+}
+
+// InTransaction reports whether a bounded transaction is open on the active document.
+func (s *Session) InTransaction() bool {
+	st := s.activeStream()
+	return st != nil && st.groupDepth > 0
 }
 
 // Undo moves the active document's cursor back one transaction event, restoring the


### PR DESCRIPTION
## What
Implements + tests the host side of the meeting-addin prerequisite contract added in **Oblikovati.API#20** (same branch name), wiring it to the live `*app.Session`.

- **Camera** — `view.getCamera`/`view.setCamera` map `wire.CameraView` ↔ `scene.Camera` over the existing `Session.Camera/SetCamera`; rejects non-finite/degenerate frames (eye≠target, 0<fov<π, up not parallel to view).
- **Interaction state** — `interaction.state` reports `Busy/ActiveTool/InTransaction` from `Session.ActiveTool()` + new `Session.InTransaction()`. `ActiveCommand` left empty (router runs on the session goroutine; a synchronous command is never observable).
- **Bounded transaction** — `Session.BeginTransaction/EndTransaction` suppress per-edit recording and record the whole delta as **one named, nestable undo step**; `recordEdit` defers while a group is open.
- **Committed-edit event** — `app.EditCommitted` emitted by `Router.Handle` after a successful **mutating** method (curated allowlist that fails safe), carrying the wire method+args; `addin/events` relays it as `wire.EditCommittedEvent`. **v1: router-path edits only**; local UI edits are a documented gap (ADR-0004).

## Why
Unblocks the reconciled `oblikovati-meeting` ADRs: presenter-follow (0003), operational replication (0004), remote-edit gating + team-shared undo (0005).

## Tests
`addin/router` (camera round-trip + rejection; interaction idle vs in-transaction; bounded-transaction coalescing + unbalanced-end; edit.committed for mutations only), `addin/events`, `app` all green; `go build/vet ./...`, gofmt, SPDX clean.

## Depends on
**Oblikovati.API#20** (same branch name) — CI resolves the matching API branch, which carries the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)