### PR TITLE
feat(views): per-document views with per-view cameras (Phase 1)

### DIFF
--- a/addin/router/camera.go
+++ b/addin/router/camera.go
@@ -13,14 +13,24 @@ import (
 	"oblikovati/scene"
 )
 
-// getCamera returns the viewport camera as a look-at frame (wire.MethodViewGetCamera).
-func getCamera(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
-	return json.Marshal(cameraView(s.Camera()))
+// getCamera returns a document's active-view camera as a look-at frame (Document 0 ⇒ the
+// active document) — wire.MethodViewGetCamera.
+func getCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.GetCameraArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	cam, err := s.ViewCamera(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(cameraView(cam))
 }
 
-// setCamera moves the viewport camera to the requested look-at frame, keeping the
-// camera's viewport size, and echoes the result (wire.MethodViewSetCamera). It rejects a
-// non-finite or degenerate frame so a bad presenter packet can never corrupt the view.
+// setCamera moves a document's active-view camera to the requested look-at frame, keeping
+// the viewport size, and echoes the result (Document 0 ⇒ active document) —
+// wire.MethodViewSetCamera. It rejects a non-finite or degenerate frame so a bad presenter
+// packet can never corrupt the view.
 func setCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	var a wire.SetCameraArgs
 	if err := decode(args, &a); err != nil {
@@ -29,13 +39,22 @@ func setCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	if err := validateCameraArgs(a); err != nil {
 		return nil, err
 	}
-	cam := s.Camera() // preserve Width/Height; override only the look-at frame + fov
+	cam, err := s.ViewCamera(a.Document) // preserve Width/Height; override the look-at frame
+	if err != nil {
+		return nil, err
+	}
 	cam.Eye = math.P3(a.Eye[0], a.Eye[1], a.Eye[2])
 	cam.Target = math.P3(a.Target[0], a.Target[1], a.Target[2])
 	cam.Up = math.V3(a.Up[0], a.Up[1], a.Up[2])
 	cam.FOV = a.FOV
-	s.SetCamera(cam)
-	return json.Marshal(cameraView(s.Camera()))
+	if err := s.SetViewCamera(a.Document, cam); err != nil {
+		return nil, err
+	}
+	out, err := s.ViewCamera(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(cameraView(out))
 }
 
 // cameraView projects a scene.Camera onto the wire look-at DTO.

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -80,6 +80,13 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewGetCamera] = getCamera
 	r.handlers[wire.MethodViewSetCamera] = setCamera
 	r.handlers[wire.MethodInteractionState] = interactionState
+	r.handlers[wire.MethodViewsList] = listViews
+	r.handlers[wire.MethodViewsAdd] = addView
+	r.handlers[wire.MethodViewsActivate] = activateView
+	r.handlers[wire.MethodViewsClose] = closeView
+	r.handlers[wire.MethodViewsRename] = renameView
+	r.handlers[wire.MethodViewsGetLayout] = getLayout
+	r.handlers[wire.MethodViewsSetLayout] = setLayout
 }
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query

--- a/addin/router/views.go
+++ b/addin/router/views.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati/api/wire"
+	"oblikovati/app"
+	"oblikovati/model/doc"
+)
+
+// listViews enumerates a document's views with their cameras, the active index, and the
+// tiling layout (Document 0 ⇒ active) — wire.MethodViewsList.
+func listViews(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.ListViewsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(listViewsResult(d))
+}
+
+// addView creates a new view of a document and makes it active, returning it
+// (wire.MethodViewsAdd).
+func addView(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.AddViewArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	i, err := s.AddView(a.Document, a.Name, a.CopyActiveCamera)
+	if err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(viewInfo(i, d.Views().All()[i], i == d.Views().ActiveIndex()))
+}
+
+// activateView makes the indexed view active, returning the updated collection
+// (wire.MethodViewsActivate).
+func activateView(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.ActivateViewArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.Views().Activate(a.Index); err != nil {
+		return nil, err
+	}
+	return json.Marshal(listViewsResult(d))
+}
+
+// closeView removes the indexed view (refused for the last view), returning the updated
+// collection (wire.MethodViewsClose).
+func closeView(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.CloseViewArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.Views().Close(a.Index); err != nil {
+		return nil, err
+	}
+	return json.Marshal(listViewsResult(d))
+}
+
+// renameView sets the indexed view's name, returning it (wire.MethodViewsRename).
+func renameView(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.RenameViewArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.Views().Rename(a.Index, a.Name); err != nil {
+		return nil, err
+	}
+	return json.Marshal(viewInfo(a.Index, d.Views().All()[a.Index], a.Index == d.Views().ActiveIndex()))
+}
+
+// getLayout returns a document's tiling layout (wire.MethodViewsGetLayout).
+func getLayout(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.ListViewsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.LayoutResult{Document: a.Document, Layout: d.Views().Layout()})
+}
+
+// setLayout chooses how a document's views are tiled (wire.MethodViewsSetLayout).
+func setLayout(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.SetLayoutArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	d, err := s.DocumentByID(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	d.Views().SetLayout(a.Layout)
+	return json.Marshal(wire.LayoutResult{Document: a.Document, Layout: d.Views().Layout()})
+}
+
+// listViewsResult renders a document's whole view collection into the wire DTO.
+func listViewsResult(d *doc.Document) wire.ListViewsResult {
+	vs := d.Views()
+	all := vs.All()
+	out := make([]wire.ViewInfo, len(all))
+	for i, v := range all {
+		out[i] = viewInfo(i, v, i == vs.ActiveIndex())
+	}
+	return wire.ListViewsResult{Views: out, ActiveIndex: vs.ActiveIndex(), Layout: vs.Layout()}
+}
+
+// viewInfo renders one view (index, name, active flag, camera) into the wire DTO.
+func viewInfo(i int, v *doc.View, active bool) wire.ViewInfo {
+	return wire.ViewInfo{
+		Index:  i,
+		Name:   v.Name,
+		Active: active,
+		Camera: wire.CameraView{
+			Eye:    [3]float64{v.Eye.X, v.Eye.Y, v.Eye.Z},
+			Target: [3]float64{v.Target.X, v.Target.Y, v.Target.Z},
+			Up:     [3]float64{v.Up.X, v.Up.Y, v.Up.Z},
+			FOV:    v.FOV,
+		},
+	}
+}

--- a/addin/router/views_test.go
+++ b/addin/router/views_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati/api/types"
+	"oblikovati/api/wire"
+)
+
+// TestViewsLifecycleOverTheAPI drives the views.* surface against a live session: a fresh
+// document has one active view; add/activate/rename/close and layout all round-trip, and
+// closing the last view is refused.
+func TestViewsLifecycleOverTheAPI(t *testing.T) {
+	r, s := seededSession(t)
+
+	var list wire.ListViewsResult
+	call(t, r, s, "views.list", "{}", &list)
+	if len(list.Views) != 1 || !list.Views[0].Active || list.Layout != types.LayoutSingle {
+		t.Fatalf("fresh document views = %+v, want one active view, single layout", list)
+	}
+
+	var added wire.ViewInfo
+	call(t, r, s, "views.add", `{"name":"Iso","copyActiveCamera":true}`, &added)
+	if added.Index != 1 || added.Name != "Iso" || !added.Active {
+		t.Fatalf("add = %+v, want index 1 'Iso' active", added)
+	}
+
+	call(t, r, s, "views.list", "{}", &list)
+	if len(list.Views) != 2 || list.ActiveIndex != 1 {
+		t.Fatalf("after add views=%d active=%d, want 2 active=1", len(list.Views), list.ActiveIndex)
+	}
+
+	call(t, r, s, "views.activate", `{"index":0}`, &list)
+	if list.ActiveIndex != 0 {
+		t.Fatalf("after activate(0) active=%d, want 0", list.ActiveIndex)
+	}
+
+	var ri wire.ViewInfo
+	call(t, r, s, "views.rename", `{"index":0,"name":"Front"}`, &ri)
+	if ri.Name != "Front" {
+		t.Errorf("rename = %q, want Front", ri.Name)
+	}
+
+	var lay wire.LayoutResult
+	call(t, r, s, "views.setLayout", `{"layout":4}`, &lay)
+	if lay.Layout != types.LayoutFour {
+		t.Errorf("setLayout = %v, want four", lay.Layout)
+	}
+	call(t, r, s, "views.getLayout", "{}", &lay)
+	if lay.Layout != types.LayoutFour {
+		t.Errorf("getLayout = %v, want four", lay.Layout)
+	}
+
+	call(t, r, s, "views.close", `{"index":1}`, &list)
+	if len(list.Views) != 1 {
+		t.Fatalf("after close views=%d, want 1", len(list.Views))
+	}
+	if _, err := r.Handle(s, "views.close", []byte(`{"index":0}`)); err == nil {
+		t.Fatal("closing the last view should error")
+	}
+}
+
+// TestCameraReflectedInActiveViewListing checks set_camera updates the active view's camera
+// as reported by views.list — proving camera is per-view.
+func TestCameraReflectedInActiveViewListing(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "view.setCamera", `{"eye":[9,8,7],"target":[1,2,3],"up":[0,1,0],"fov":0.7}`, nil)
+
+	var list wire.ListViewsResult
+	call(t, r, s, "views.list", "{}", &list)
+	got := list.Views[list.ActiveIndex].Camera
+	if got.Eye != [3]float64{9, 8, 7} || got.Target != [3]float64{1, 2, 3} {
+		t.Fatalf("active view camera = %+v, want eye[9 8 7] target[1 2 3]", got)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -100,16 +100,41 @@ func newSession(store doc.Store) *Session {
 // AddIns returns the add-in registry (ApplicationAddIns).
 func (s *Session) AddIns() *AddInManager { return s.addins }
 
-// Camera returns the viewport camera (used by picking and sketch tools); SetCamera
-// updates it (the window feeds orbit/zoom in production) and keeps the picker's view in
-// sync so a click hit-tests against the current camera.
-func (s *Session) Camera() scene.Camera { return s.camera }
+// Camera returns the active view's camera sized to the current viewport. Camera state is
+// per-view — a document owns a Views collection and each view owns a camera — so switching
+// documents or views shows that view's saved camera rather than resetting it. The
+// transient viewport pixel size is carried on the session's cached frame; with no active
+// document the cached frame is returned as a fallback.
+func (s *Session) Camera() scene.Camera {
+	if v := s.ActiveView(); v != nil {
+		c := s.camera // carry the transient viewport pixel size (Width/Height)
+		c.Eye, c.Target, c.Up, c.FOV = v.Eye, v.Target, v.Up, v.FOV
+		return c
+	}
+	return s.camera
+}
 
+// SetCamera applies c to the active view (the per-view source of truth), caches the frame
+// (for the no-document fallback and the pixel size), marks the view framed, and keeps the
+// picker's view in sync so a click hit-tests against the current camera.
 func (s *Session) SetCamera(c scene.Camera) {
 	s.camera = c
+	if v := s.ActiveView(); v != nil {
+		v.Eye, v.Target, v.Up, v.FOV = c.Eye, c.Target, c.Up, c.FOV
+		v.Framed = true
+	}
 	if ca, ok := s.picker.(interface{ SetCamera(scene.Camera) }); ok {
 		ca.SetCamera(c)
 	}
+}
+
+// ActiveView returns the active document's active view, or nil when no document is active.
+func (s *Session) ActiveView() *doc.View {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil
+	}
+	return d.Views().Active()
 }
 
 // EnterSketch activates a sketch for editing (the Sketch environment); ExitSketch

--- a/app/view.go
+++ b/app/view.go
@@ -9,11 +9,13 @@ import "oblikovati/math"
 // switches to the default isometric view and frames it. Both are no-ops on an empty
 // model. A ribbon command's Run calls these, and a test can call them directly.
 
-// FitView reframes the camera so the whole active part fits the viewport.
-func (s *Session) FitView() { s.camera = s.camera.Fit(s.modelBounds()) }
+// FitView reframes the camera so the whole active part fits the viewport. It writes
+// through the active view (SetCamera) so the framing is remembered per view.
+func (s *Session) FitView() { s.SetCamera(s.Camera().Fit(s.modelBounds())) }
 
-// HomeView switches to the default isometric view, framed to fit the active part.
-func (s *Session) HomeView() { s.camera = s.camera.Home(s.modelBounds()) }
+// HomeView switches to the default isometric view, framed to fit the active part, writing
+// through the active view so the framing is remembered.
+func (s *Session) HomeView() { s.SetCamera(s.Camera().Home(s.modelBounds())) }
 
 // modelBounds is the union of the active part's body bounding boxes (empty if none).
 func (s *Session) modelBounds() math.Box {

--- a/app/views.go
+++ b/app/views.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati/model/doc"
+	"oblikovati/scene"
+)
+
+// DocumentByID resolves a document by its session id; id 0 means the active document. It
+// is the entry point for the document-addressed view/camera API (a Document field of 0
+// targets the active document).
+func (s *Session) DocumentByID(id uint64) (*doc.Document, error) {
+	if id == 0 {
+		d := s.ActiveDocument()
+		if d == nil {
+			return nil, ErrNoActiveDoc
+		}
+		return d, nil
+	}
+	for _, d := range s.Workspace().Documents() {
+		if uint64(d.ID()) == id {
+			return d, nil
+		}
+	}
+	return nil, fmt.Errorf("app: no document with id %d", id)
+}
+
+// AddView adds a new view to a document (id 0 = active) and makes it active, returning its
+// index. With copyActiveCamera the new view starts at the document's current active-view
+// camera; otherwise it gets a default view that the UI Home-fits the first time it is
+// shown. An empty name is auto-numbered ("View N").
+func (s *Session) AddView(docID uint64, name string, copyActiveCamera bool) (int, error) {
+	d, err := s.DocumentByID(docID)
+	if err != nil {
+		return 0, err
+	}
+	vs := d.Views()
+	if name == "" {
+		name = fmt.Sprintf("View %d", vs.Count()+1)
+	}
+	nv := doc.DefaultView(name)
+	if copyActiveCamera {
+		cur := vs.Active()
+		nv.Eye, nv.Target, nv.Up, nv.FOV, nv.Framed = cur.Eye, cur.Target, cur.Up, cur.FOV, cur.Framed
+	}
+	return vs.Add(nv), nil
+}
+
+// ViewCamera returns a document's active-view camera (id 0 = active document), sized to
+// the current viewport.
+func (s *Session) ViewCamera(docID uint64) (scene.Camera, error) {
+	d, err := s.DocumentByID(docID)
+	if err != nil {
+		return scene.Camera{}, err
+	}
+	v := d.Views().Active()
+	c := s.camera // carry the transient viewport pixel size
+	c.Eye, c.Target, c.Up, c.FOV = v.Eye, v.Target, v.Up, v.FOV
+	return c, nil
+}
+
+// SetViewCamera applies c to a document's active view (id 0 = active document). When the
+// addressed document is the active one this routes through SetCamera (picker + cache
+// sync); otherwise it writes the off-screen document's view frame directly.
+func (s *Session) SetViewCamera(docID uint64, c scene.Camera) error {
+	d, err := s.DocumentByID(docID)
+	if err != nil {
+		return err
+	}
+	if d == s.ActiveDocument() {
+		s.SetCamera(c)
+		return nil
+	}
+	v := d.Views().Active()
+	v.Eye, v.Target, v.Up, v.FOV, v.Framed = c.Eye, c.Target, c.Up, c.FOV, true
+	return nil
+}

--- a/app/views_session_test.go
+++ b/app/views_session_test.go
@@ -20,6 +20,13 @@ func addPart(t *testing.T, s *Session, name string) *doc.Document {
 	return d
 }
 
+func activate(t *testing.T, s *Session, d *doc.Document) {
+	t.Helper()
+	if err := s.Workspace().SetActiveDocument(d); err != nil {
+		t.Fatalf("activate %s: %v", d.DisplayName(), err)
+	}
+}
+
 // TestCameraIsPerDocumentAcrossSwitch is the regression for the reported bug: switching
 // the active document must restore that document's camera, not reset it.
 func TestCameraIsPerDocumentAcrossSwitch(t *testing.T) {
@@ -27,21 +34,21 @@ func TestCameraIsPerDocumentAcrossSwitch(t *testing.T) {
 	a := addPart(t, s, "a.obk")
 	b := addPart(t, s, "b.obk")
 
-	s.Workspace().SetActiveDocument(a)
+	activate(t, s, a)
 	ca := s.Camera()
 	ca.Eye = math.P3(11, 0, 0)
 	s.SetCamera(ca)
 
-	s.Workspace().SetActiveDocument(b)
+	activate(t, s, b)
 	cb := s.Camera()
 	cb.Eye = math.P3(0, 22, 0)
 	s.SetCamera(cb)
 
-	s.Workspace().SetActiveDocument(a)
+	activate(t, s, a)
 	if got := s.Camera().Eye; got != math.P3(11, 0, 0) {
 		t.Fatalf("doc A camera not restored after switch: eye=%v, want (11,0,0)", got)
 	}
-	s.Workspace().SetActiveDocument(b)
+	activate(t, s, b)
 	if got := s.Camera().Eye; got != math.P3(0, 22, 0) {
 		t.Fatalf("doc B camera not restored after switch: eye=%v, want (0,22,0)", got)
 	}
@@ -50,7 +57,7 @@ func TestCameraIsPerDocumentAcrossSwitch(t *testing.T) {
 func TestAddViewAndDocumentByID(t *testing.T) {
 	s := NewSession()
 	a := addPart(t, s, "a.obk")
-	s.Workspace().SetActiveDocument(a)
+	activate(t, s, a)
 
 	// Distinct active-view camera, then a copied view should start at it.
 	ca := s.Camera()

--- a/app/views_session_test.go
+++ b/app/views_session_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati/math"
+	"oblikovati/model/compdef"
+	"oblikovati/model/doc"
+)
+
+func addPart(t *testing.T, s *Session, name string) *doc.Document {
+	t.Helper()
+	d, err := s.Workspace().Add(doc.Part, name, true)
+	if err != nil {
+		t.Fatalf("add %s: %v", name, err)
+	}
+	d.SetContent(compdef.NewPartComponentDefinition())
+	return d
+}
+
+// TestCameraIsPerDocumentAcrossSwitch is the regression for the reported bug: switching
+// the active document must restore that document's camera, not reset it.
+func TestCameraIsPerDocumentAcrossSwitch(t *testing.T) {
+	s := NewSession()
+	a := addPart(t, s, "a.obk")
+	b := addPart(t, s, "b.obk")
+
+	s.Workspace().SetActiveDocument(a)
+	ca := s.Camera()
+	ca.Eye = math.P3(11, 0, 0)
+	s.SetCamera(ca)
+
+	s.Workspace().SetActiveDocument(b)
+	cb := s.Camera()
+	cb.Eye = math.P3(0, 22, 0)
+	s.SetCamera(cb)
+
+	s.Workspace().SetActiveDocument(a)
+	if got := s.Camera().Eye; got != math.P3(11, 0, 0) {
+		t.Fatalf("doc A camera not restored after switch: eye=%v, want (11,0,0)", got)
+	}
+	s.Workspace().SetActiveDocument(b)
+	if got := s.Camera().Eye; got != math.P3(0, 22, 0) {
+		t.Fatalf("doc B camera not restored after switch: eye=%v, want (0,22,0)", got)
+	}
+}
+
+func TestAddViewAndDocumentByID(t *testing.T) {
+	s := NewSession()
+	a := addPart(t, s, "a.obk")
+	s.Workspace().SetActiveDocument(a)
+
+	// Distinct active-view camera, then a copied view should start at it.
+	ca := s.Camera()
+	ca.Eye = math.P3(5, 6, 7)
+	s.SetCamera(ca)
+	i, err := s.AddView(0, "Iso", true)
+	if err != nil || i != 1 {
+		t.Fatalf("AddView: i=%d err=%v", i, err)
+	}
+	if got := a.Views().Active().Eye; got != math.P3(5, 6, 7) {
+		t.Errorf("copied view eye = %v, want (5,6,7)", got)
+	}
+	// DocumentByID(0) is the active document; an unknown id errors.
+	if d, err := s.DocumentByID(0); err != nil || d != a {
+		t.Errorf("DocumentByID(0) = %v,%v want active doc", d, err)
+	}
+	if _, err := s.DocumentByID(999999); err == nil {
+		t.Error("DocumentByID(unknown) should error")
+	}
+}

--- a/cmd/oblikovati-cli/cli_test.go
+++ b/cmd/oblikovati-cli/cli_test.go
@@ -67,8 +67,8 @@ func TestInfoJSONIsParseable(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &report); err != nil {
 		t.Fatalf("info --json emitted invalid JSON %q: %v", out, err)
 	}
-	if report.Type != "part" || report.Name != "plate" || report.SchemaVersion != 2 {
-		t.Errorf("report = %+v, want {2 part plate}", report)
+	if report.Type != "part" || report.Name != "plate" || report.SchemaVersion != 3 {
+		t.Errorf("report = %+v, want {3 part plate}", report)
 	}
 }
 

--- a/head/ui/chrome_doctabs.go
+++ b/head/ui/chrome_doctabs.go
@@ -34,6 +34,12 @@ func followActiveDocument(s *app.Session) {
 	if active == nil || s.CameraAnimating() {
 		return
 	}
+	// Camera state is per-view now: a view that has already been framed (saved, loaded, or
+	// navigated) keeps its camera, so switching documents restores each one's view instead
+	// of resetting it. Only a brand-new, never-framed view is Home-fit on first show.
+	if v := s.ActiveView(); v == nil || v.Framed {
+		return
+	}
 	// Frame the geometry if there is any; otherwise center on the model origin so the
 	// part's coordinate planes are visible rather than a void (Home keeps the current
 	// target on an empty model, so point it at the origin first).

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -39,7 +39,8 @@ type Document struct {
 	open             bool
 	visible          bool
 	compacted        bool
-	referencedBy     int // how many open documents reference this one (maintained by the graph, M03-F04)
+	referencedBy     int            // how many open documents reference this one (maintained by the graph, M03-F04)
+	views            *DocumentViews // per-document view collection (cameras); lazily seeded by Views()
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;

--- a/model/doc/views.go
+++ b/model/doc/views.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"errors"
+	"fmt"
+	stdmath "math"
+
+	"oblikovati/api/types"
+	"oblikovati/math"
+)
+
+// ErrLastView is returned by [DocumentViews.Close] when asked to remove the only view —
+// a document must always retain at least one view.
+var ErrLastView = errors.New("doc: cannot close the last view of a document")
+
+// viewIndexError reports an out-of-range view index, naming the operation and bounds.
+func viewIndexError(op string, i, n int) error {
+	return fmt.Errorf("doc: %s view index %d out of range [0,%d)", op, i, n)
+}
+
+// View is one view of a document: a named camera frame (Inventor's View.Camera). A
+// document owns a collection of views and each has its own camera, which is why
+// switching documents (or views) restores that view's camera rather than resetting it.
+//
+// The frame is stored as math value types (not the renderer's scene.Camera) so the model
+// layer carries no rendering dependency; the session converts to/from scene.Camera and
+// supplies the transient viewport pixel size. Eye/Target are points, Up a vector, FOV the
+// vertical field of view in radians.
+type View struct {
+	Name   string
+	Eye    math.Point3
+	Target math.Point3
+	Up     math.Vector3
+	FOV    float64
+	// Framed reports whether this view's camera has been fitted to the model yet. A
+	// brand-new default view starts unframed so the UI Home-fits it the first time it is
+	// shown; a saved/loaded or user-navigated view is framed, so switching to it restores
+	// its camera instead of resetting the view (the per-document camera fix).
+	Framed bool
+}
+
+// DefaultView is the framing a brand-new view starts at (matching scene.NewCamera): an
+// eye on +Z looking at the origin, Y up, 45° vertical FOV. The session re-frames it to
+// the model the first time the view is shown.
+func DefaultView(name string) *View {
+	return &View{
+		Name:   name,
+		Eye:    math.P3(0, 0, 10),
+		Target: math.P3(0, 0, 0),
+		Up:     math.V3(0, 1, 0),
+		FOV:    stdmath.Pi / 4,
+	}
+}
+
+// DocumentViews is a document's view collection (Inventor's Document.Views): the ordered
+// views, which one is active, and how they tile in the viewport. A document always has at
+// least one view — the zero collection lazily seeds a default via [Document.Views].
+type DocumentViews struct {
+	views  []*View
+	active int
+	layout types.ViewLayout
+}
+
+// Views returns the document's view collection, seeding a single default view on first
+// use so a document is never viewless (Inventor: a document always has ≥1 view).
+func (d *Document) Views() *DocumentViews {
+	if d.views == nil {
+		d.views = &DocumentViews{views: []*View{DefaultView("View 1")}, layout: types.LayoutSingle}
+	}
+	return d.views
+}
+
+// RestoreViews replaces the document's collection with views loaded from disk (each is
+// already framed), the active index, and the layout. An empty set is ignored so the lazy
+// default view stands; an out-of-range active index is clamped. Used by persistence on open.
+func (d *Document) RestoreViews(views []*View, active int, layout types.ViewLayout) {
+	if len(views) == 0 {
+		return
+	}
+	if active < 0 || active >= len(views) {
+		active = 0
+	}
+	if !layout.IsValid() {
+		layout = types.LayoutSingle
+	}
+	d.views = &DocumentViews{views: views, active: active, layout: layout}
+}
+
+// All returns the views in order (do not mutate the slice).
+func (vs *DocumentViews) All() []*View { return vs.views }
+
+// Count is the number of views.
+func (vs *DocumentViews) Count() int { return len(vs.views) }
+
+// ActiveIndex is the index of the active view.
+func (vs *DocumentViews) ActiveIndex() int { return vs.active }
+
+// Active returns the active view (never nil — the collection always holds ≥1 view).
+func (vs *DocumentViews) Active() *View { return vs.views[vs.active] }
+
+// Layout returns the current tiling layout.
+func (vs *DocumentViews) Layout() types.ViewLayout { return vs.layout }
+
+// SetLayout sets the tiling layout, ignoring an undefined value.
+func (vs *DocumentViews) SetLayout(l types.ViewLayout) {
+	if l.IsValid() {
+		vs.layout = l
+	}
+}
+
+// Add appends v and makes it the active view, returning its index.
+func (vs *DocumentViews) Add(v *View) int {
+	vs.views = append(vs.views, v)
+	vs.active = len(vs.views) - 1
+	return vs.active
+}
+
+// Activate makes the view at index i active. Out-of-range is an error.
+func (vs *DocumentViews) Activate(i int) error {
+	if i < 0 || i >= len(vs.views) {
+		return viewIndexError("activate", i, len(vs.views))
+	}
+	vs.active = i
+	return nil
+}
+
+// Rename sets the name of the view at index i.
+func (vs *DocumentViews) Rename(i int, name string) error {
+	if i < 0 || i >= len(vs.views) {
+		return viewIndexError("rename", i, len(vs.views))
+	}
+	vs.views[i].Name = name
+	return nil
+}
+
+// Close removes the view at index i. Closing the last remaining view is refused (a
+// document always has ≥1 view); the active index is kept in range.
+func (vs *DocumentViews) Close(i int) error {
+	if i < 0 || i >= len(vs.views) {
+		return viewIndexError("close", i, len(vs.views))
+	}
+	if len(vs.views) == 1 {
+		return ErrLastView
+	}
+	vs.views = append(vs.views[:i], vs.views[i+1:]...)
+	if vs.active >= len(vs.views) {
+		vs.active = len(vs.views) - 1
+	}
+	return nil
+}

--- a/model/doc/views_test.go
+++ b/model/doc/views_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati/api/types"
+)
+
+func TestDocumentSeedsOneDefaultView(t *testing.T) {
+	d := newDocument(Part, "t.obk", nil, true)
+	vs := d.Views()
+	if vs.Count() != 1 || vs.Active() == nil || vs.Active().Name != "View 1" {
+		t.Fatalf("default views = %+v, want one 'View 1'", vs.All())
+	}
+	if vs.Layout() != types.LayoutSingle {
+		t.Errorf("default layout = %v, want single", vs.Layout())
+	}
+}
+
+func TestDocumentViewsAddActivateRenameClose(t *testing.T) {
+	vs := newDocument(Part, "t.obk", nil, true).Views()
+
+	i := vs.Add(DefaultView("Iso"))
+	if i != 1 || vs.ActiveIndex() != 1 || vs.Active().Name != "Iso" {
+		t.Fatalf("after Add active = %d (%q), want index 1 'Iso'", vs.ActiveIndex(), vs.Active().Name)
+	}
+	if err := vs.Rename(0, "Front"); err != nil || vs.All()[0].Name != "Front" {
+		t.Fatalf("Rename(0): err=%v name=%q", err, vs.All()[0].Name)
+	}
+	if err := vs.Activate(0); err != nil || vs.ActiveIndex() != 0 {
+		t.Fatalf("Activate(0): err=%v active=%d", err, vs.ActiveIndex())
+	}
+	if err := vs.Activate(9); err == nil {
+		t.Error("Activate out of range should error")
+	}
+	// Close one of two; active index stays valid.
+	if err := vs.Close(1); err != nil || vs.Count() != 1 {
+		t.Fatalf("Close(1): err=%v count=%d", err, vs.Count())
+	}
+	if vs.ActiveIndex() != 0 {
+		t.Errorf("active index after close = %d, want 0", vs.ActiveIndex())
+	}
+}
+
+func TestDocumentViewsRefusesClosingLast(t *testing.T) {
+	vs := newDocument(Part, "t.obk", nil, true).Views()
+	if err := vs.Close(0); !errors.Is(err, ErrLastView) {
+		t.Fatalf("Close last view err = %v, want ErrLastView", err)
+	}
+}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -50,6 +50,7 @@ func (p *Package) marshal() ([]byte, error) {
 		DocumentType:  p.manifest.DocumentType,
 		DisplayName:   p.manifest.DisplayName,
 		Model:         p.model,
+		Views:         p.views,
 		Data:          p.streams,
 	})
 }
@@ -69,6 +70,7 @@ func decode(raw []byte) (*Package, error) {
 		}
 	}
 	p.model = doc.Model
+	p.views = doc.Views
 	for name, data := range doc.Data {
 		p.WriteStream(name, data)
 	}

--- a/persistence/manifest.go
+++ b/persistence/manifest.go
@@ -6,8 +6,10 @@ package persistence
 // whenever the on-disk layout changes and add a [Migration] from the prior version so
 // old files keep opening (architecture core/05). v2 is the YAML single-file format
 // (ADR-0020); v1 and earlier were the ZIP-package format and are not migrated (the
-// only pre-v2 files were regenerable fixtures).
-const CurrentSchemaVersion = 2
+// only pre-v2 files were regenerable fixtures). v3 adds the optional `views:` section
+// (per-document cameras) — additive, so the v2→v3 step is a no-op (a v2 file simply has
+// no views and the host seeds a default view on open).
+const CurrentSchemaVersion = 3
 
 // Manifest is the document's identity header: schema version (for migration), the
 // root document kind, and the display name. On disk these are the top-level fields of

--- a/persistence/migration.go
+++ b/persistence/migration.go
@@ -15,7 +15,11 @@ type Migration func(*Package) error
 // version. It is empty at the v2 (YAML) baseline: the pre-v2 ZIP format is not
 // migrated (ADR-0020). Register a step here whenever [CurrentSchemaVersion] is bumped
 // past 2; never remove one — it is the only path forward for files in the wild.
-var migrations = map[int]Migration{}
+var migrations = map[int]Migration{
+	// v2 → v3 added the optional `views:` section. It is additive: a v2 file carries no
+	// views, and the host seeds a default view on open, so there is nothing to transform.
+	2: func(*Package) error { return nil },
+}
 
 // Migrate upgrades a document to [CurrentSchemaVersion], applying each registered step
 // in order and stamping the new version into the manifest. A document with no manifest

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -2,7 +2,11 @@
 
 package persistence
 
-import "errors"
+import (
+	"errors"
+
+	"oblikovati/persistence/yamlcodec"
+)
 
 // errNoManifest reports a document with no manifest — not a valid document file
 // (though still a valid container of arbitrary data sections, e.g. for DataIO).
@@ -21,11 +25,18 @@ type StreamStat struct {
 // file (ADR-0020). Stream bytes are copied in and out so a Package never shares
 // backing arrays with its callers.
 type Package struct {
-	manifest Manifest          // identity; the zero value means "no manifest"
-	model    []byte            // recipe YAML bytes; nil ⇒ no model
-	streams  map[string][]byte // named binary data sections
-	order    []string          // data-section insertion order, for stable enumeration
+	manifest Manifest                // identity; the zero value means "no manifest"
+	model    []byte                  // recipe YAML bytes; nil ⇒ no model
+	views    *yamlcodec.ViewsSection // per-document view collection (cameras); nil ⇒ none
+	streams  map[string][]byte       // named binary data sections
+	order    []string                // data-section insertion order, for stable enumeration
 }
+
+// Views returns the package's view collection (cameras), or nil if it carries none.
+func (p *Package) Views() *yamlcodec.ViewsSection { return p.views }
+
+// SetViews stores the document's view collection to be written under the `views:` section.
+func (p *Package) SetViews(v *yamlcodec.ViewsSection) { p.views = v }
 
 // NewPackage returns an empty package.
 func NewPackage() *Package {

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"os"
 
+	"oblikovati/api/types"
+	"oblikovati/math"
 	"oblikovati/model/doc"
+	"oblikovati/persistence/yamlcodec"
 )
 
 // PackageStore is the [doc.Store] backed by .obk packages on disk. Injected into a
@@ -43,6 +46,7 @@ func (s *PackageStore) Save(d *doc.Document) error {
 		}
 		pkg.SetModelYAML(model)
 	}
+	pkg.SetViews(viewsSection(d))
 	return pkg.Save(d.FullFileName())
 }
 
@@ -70,7 +74,44 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 			return nil, fmt.Errorf("persistence: load %q: %w", fullDocumentName, err)
 		}
 	}
+	restoreViews(d, pkg.Views())
 	return d, nil
+}
+
+// viewsSection projects a document's view collection (cameras) onto the persisted section.
+func viewsSection(d *doc.Document) *yamlcodec.ViewsSection {
+	vs := d.Views()
+	sec := &yamlcodec.ViewsSection{Active: vs.ActiveIndex(), Layout: int32(vs.Layout())}
+	for _, v := range vs.All() {
+		sec.Views = append(sec.Views, yamlcodec.ViewFrame{
+			Name:   v.Name,
+			Eye:    [3]float64{v.Eye.X, v.Eye.Y, v.Eye.Z},
+			Target: [3]float64{v.Target.X, v.Target.Y, v.Target.Z},
+			Up:     [3]float64{v.Up.X, v.Up.Y, v.Up.Z},
+			FOV:    v.FOV,
+		})
+	}
+	return sec
+}
+
+// restoreViews rebuilds a document's view collection from the persisted section (each
+// loaded view is framed). A nil/empty section leaves the lazily-seeded default view.
+func restoreViews(d *doc.Document, sec *yamlcodec.ViewsSection) {
+	if sec == nil || len(sec.Views) == 0 {
+		return
+	}
+	views := make([]*doc.View, len(sec.Views))
+	for i, f := range sec.Views {
+		views[i] = &doc.View{
+			Name:   f.Name,
+			Eye:    math.P3(f.Eye[0], f.Eye[1], f.Eye[2]),
+			Target: math.P3(f.Target[0], f.Target[1], f.Target[2]),
+			Up:     math.V3(f.Up[0], f.Up[1], f.Up[2]),
+			FOV:    f.FOV,
+			Framed: true,
+		}
+	}
+	d.RestoreViews(views, sec.Active, types.ViewLayout(sec.Layout))
 }
 
 // Exists reports whether a package file is present at fullDocumentName.

--- a/persistence/views_test.go
+++ b/persistence/views_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati/api/types"
+	"oblikovati/math"
+	"oblikovati/model/doc"
+	"oblikovati/persistence/yamlcodec"
+)
+
+// TestViewsRoundTripThroughPackage checks the views section survives a save → open through
+// the .obk file (cameras, active index, and layout).
+func TestViewsRoundTripThroughPackage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v.obk")
+	p := NewPackage()
+	if err := p.SetManifest(Manifest{SchemaVersion: CurrentSchemaVersion, DocumentType: 1, DisplayName: "Part1"}); err != nil {
+		t.Fatalf("SetManifest: %v", err)
+	}
+	p.SetViews(&yamlcodec.ViewsSection{
+		Views: []yamlcodec.ViewFrame{
+			{Name: "Front", Eye: [3]float64{0, 0, 10}, Target: [3]float64{0, 0, 0}, Up: [3]float64{0, 1, 0}, FOV: 0.78},
+			{Name: "Iso", Eye: [3]float64{5, 6, 7}, Target: [3]float64{1, 2, 3}, Up: [3]float64{0, 1, 0}, FOV: 0.6},
+		},
+		Active: 1, Layout: int32(types.LayoutFour),
+	})
+	if err := p.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := OpenPackage(path)
+	if err != nil {
+		t.Fatalf("OpenPackage: %v", err)
+	}
+	vs := got.Views()
+	if vs == nil || len(vs.Views) != 2 || vs.Active != 1 || vs.Layout != int32(types.LayoutFour) {
+		t.Fatalf("views section = %+v, want 2 views active=1 layout=four", vs)
+	}
+	if vs.Views[1].Name != "Iso" || vs.Views[1].Eye != [3]float64{5, 6, 7} {
+		t.Errorf("view[1] = %+v, want Iso eye[5 6 7]", vs.Views[1])
+	}
+}
+
+// TestV2DocumentMigratesToV3WithoutViews checks a pre-views (v2) file opens, migrates to
+// the current version, and simply carries no views section.
+func TestV2DocumentMigratesToV3WithoutViews(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.obk")
+	p := NewPackage()
+	if err := p.SetManifest(Manifest{SchemaVersion: 2, DocumentType: 1, DisplayName: "Old"}); err != nil {
+		t.Fatalf("SetManifest: %v", err)
+	}
+	if err := p.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := OpenPackage(path) // OpenPackage runs the migration pipeline
+	if err != nil {
+		t.Fatalf("OpenPackage: %v", err)
+	}
+	m, _ := got.Manifest()
+	if m.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("schema = v%d, want migrated to v%d", m.SchemaVersion, CurrentSchemaVersion)
+	}
+	if got.Views() != nil {
+		t.Errorf("a v2 document should carry no views section, got %+v", got.Views())
+	}
+}
+
+// TestStoreViewsHelpersRoundTrip checks the store's document↔section projection: a
+// document's views project to the section and restore into another document (framed).
+func TestStoreViewsHelpersRoundTrip(t *testing.T) {
+	src, err := doc.Restore(doc.Part, "a.obk", "A")
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	src.Views().Active().Name = "Front"
+	src.Views().Add(doc.DefaultView("Iso"))
+	src.Views().Active().Eye = math.P3(9, 9, 9)
+	src.Views().SetLayout(types.LayoutTwoH)
+
+	dst, err := doc.Restore(doc.Part, "b.obk", "B")
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	restoreViews(dst, viewsSection(src))
+
+	if dst.Views().Count() != 2 || dst.Views().Layout() != types.LayoutTwoH {
+		t.Fatalf("restored views=%d layout=%v, want 2 / twoH", dst.Views().Count(), dst.Views().Layout())
+	}
+	got := dst.Views().All()[1]
+	if got.Eye != math.P3(9, 9, 9) || !got.Framed {
+		t.Errorf("restored view[1] = %+v, want eye(9,9,9) framed", got)
+	}
+}

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -118,17 +118,29 @@ func UnmarshalDocument(raw []byte) (Document, error) {
 		d.Model = b
 	}
 	d.Views = od.Views
-	if len(od.Data) > 0 {
-		d.Data = make(map[string][]byte, len(od.Data))
-		for name, enc := range od.Data {
-			b, err := base64.StdEncoding.DecodeString(enc)
-			if err != nil {
-				return Document{}, fmt.Errorf("yamlcodec: data section %q is not valid base64: %w", name, err)
-			}
-			d.Data[name] = b
-		}
+	data, err := decodeDataSections(od.Data)
+	if err != nil {
+		return Document{}, err
 	}
+	d.Data = data
 	return d, nil
+}
+
+// decodeDataSections base64-decodes the on-disk data sections into raw bytes, or nil when
+// there are none.
+func decodeDataSections(enc map[string]string) (map[string][]byte, error) {
+	if len(enc) == 0 {
+		return nil, nil
+	}
+	out := make(map[string][]byte, len(enc))
+	for name, s := range enc {
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("yamlcodec: data section %q is not valid base64: %w", name, err)
+		}
+		out[name] = b
+	}
+	return out, nil
 }
 
 // modelNode parses recipe YAML bytes into the mapping node to embed under `model:`.

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -36,6 +36,27 @@ type Document struct {
 	DisplayName   string
 	Model         []byte
 	Data          map[string][]byte
+	Views         *ViewsSection
+}
+
+// ViewFrame is the persisted camera of one view: a name and a look-at frame (eye, target,
+// up in model units; fov in radians). Stored natively (not base64) so the saved view is
+// readable in the YAML file.
+type ViewFrame struct {
+	Name   string     `yaml:"name,omitempty"`
+	Eye    [3]float64 `yaml:"eye"`
+	Target [3]float64 `yaml:"target"`
+	Up     [3]float64 `yaml:"up"`
+	FOV    float64    `yaml:"fov"`
+}
+
+// ViewsSection is a document's persisted view collection: the views, the active index, and
+// the tiling layout. A loaded view is, by definition, framed — the framed flag is not
+// persisted; the host marks loaded views framed on restore.
+type ViewsSection struct {
+	Views  []ViewFrame `yaml:"views"`
+	Active int         `yaml:"active,omitempty"`
+	Layout int32       `yaml:"layout,omitempty"`
 }
 
 // onDisk is the YAML projection of a Document: manifest at top level, recipe as a
@@ -45,6 +66,7 @@ type onDisk struct {
 	DocumentType  uint32            `yaml:"documentType,omitempty"`
 	DisplayName   string            `yaml:"displayName,omitempty"`
 	Model         yaml.Node         `yaml:"model,omitempty"`
+	Views         *ViewsSection     `yaml:"views,omitempty"`
 	Data          map[string]string `yaml:"data,omitempty"`
 }
 
@@ -63,6 +85,7 @@ func MarshalDocument(d Document) ([]byte, error) {
 		}
 		od.Model = *node
 	}
+	od.Views = d.Views
 	if len(d.Data) > 0 {
 		od.Data = make(map[string]string, len(d.Data))
 		for name, raw := range d.Data {
@@ -94,6 +117,7 @@ func UnmarshalDocument(raw []byte) (Document, error) {
 		}
 		d.Model = b
 	}
+	d.Views = od.Views
 	if len(od.Data) > 0 {
 		d.Data = make(map[string][]byte, len(od.Data))
 		for name, enc := range od.Data {


### PR DESCRIPTION
## What
Implements the **per-document Views model** (Inventor's Document → Views → Camera; roadmap M16-F03/PBI-154) and **fixes the camera-reset-on-document-switch bug**. Builds on the contract in **Oblikovati.API#21**.

- **model/doc**: `doc.View` (name + look-at frame + `framed`) and `DocumentViews` (ordered views, active index, layout) on `doc.Document`; a document always has ≥1 view (lazily seeded).
- **app**: `Session.Camera/SetCamera` now flow through the **active document's active view**, so switching documents restores each one's camera instead of resetting it. `FitView/HomeView` write through the active view; `AddView/ViewCamera/SetViewCamera` + `DocumentByID`. `followActiveDocument` Home-fits only an *unframed* view (the fix) and restores saved cameras otherwise.
- **addin/router**: `views.list/add/activate/close/rename/getLayout/setLayout`; camera get/set honor the optional `Document` address.
- **persistence**: a readable `views:` section in the `.obk` (cameras + active + layout); schema **v2→v3** with an additive (no-op) migration; views written/restored on save/open.

## Why
Camera was a single session-global field → switching documents reset the view and there was no multi-view concept. This is Phase 1 (model + API + persistence + bug fix); **Phase 2** (simultaneous tiled viewports — native multi-target renderer + tiled UI) follows in a separate PR.

## Tests
Regression (`TestCameraIsPerDocumentAcrossSwitch`) + unit tests across `model/doc`, `app`, `addin/router`, `persistence` (incl. `.obk` round-trip + v2→v3 migration). `go build ./...` (incl. cgo head), `go vet`, gofmt, SPDX all clean.

## Depends on
**Oblikovati.API#21** (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)