### PR TITLE
feat(script): embedded sandboxed Lua scripting runtime (Phase 1)

### DIFF
--- a/architecture/decisions/ADR-0028-embedded-lua-scripting.md
+++ b/architecture/decisions/ADR-0028-embedded-lua-scripting.md
@@ -1,0 +1,109 @@
+# ADR-0028 — Embedded Lua scripting runtime (pure-Go, sandboxed, wire-mirrored)
+
+**Status:** Proposed (2026-06-07)
+**Context:** First-party, integral scripting in the GPL-v2 app (not an add-in).
+Implementation plan: [lua-scripting-plan.md](../lua-scripting-plan.md).
+**Builds on / refines:** [ADR-0013](ADR-0013-ilogic-embedded-scripting.md) (embedded
+scripting drives the public API; named "Lua via a pure-Go VM" as a candidate),
+[ADR-0016](ADR-0016-shared-library-addins-mcp-bridge.md) (session-goroutine dispatch),
+[ADR-0018](ADR-0018-apache-api-contract-module.md) (`api/wire` is the automation
+surface), [ADR-0008](ADR-0008-cgo-boundary.md) (cgo confined to the platform edge).
+
+## Problem
+
+Users need to automate the model with scripts: drive parameters, build sketches and
+features, batch operations — from the GUI, the CLI, and (later) the MCP bridge. The
+hard constraints:
+
+1. **A buggy or malicious script must NEVER crash, hang, or escape the host.**
+2. **Everything in `oblikovati/api` must be callable** from a script, and stay callable
+   automatically as the contract grows — no per-method scripting glue.
+3. The model is **not goroutine-safe**; API calls must run on the **session
+   goroutine** (ADR-0016), yet a looping script must not freeze the UI.
+
+## Decision
+
+### 1. Runtime: `github.com/yuin/gopher-lua` (pure-Go Lua 5.1 VM, MIT), behind a seam.
+
+Pure Go means **no cgo**, so a script bug is a Go panic we `recover()` — not a
+segfault that kills the process. This is the only runtime choice that can *guarantee*
+requirement #1, and it keeps the core cgo-free and headless-testable (ADR-0008). A cgo
+**LuaJIT** binding is faster but introduces a real crash surface (FFI + C VM) that
+directly violates #1; the workload is API-call-bound, not numeric, so we do not need
+its speed. gopher-lua's instruction-count hook + `SetContext` give us the timeout and
+cancellation primitives we need. MIT is GPL-v2-compatible.
+
+The VM is wrapped behind a project-owned `script.Engine` interface (the only
+`gopher-lua` importer is `script/gopherlua`), so the engine is swappable later **only
+if** the crash/quota guarantees can be re-proven on the new path.
+
+### 2. Safety / sandbox model.
+
+- **Opt-in stdlib.** The VM starts with nothing; we open only `base` (with
+  `dofile/loadfile/load/loadstring/require/collectgarbage/print` stripped), `table`,
+  `string`, `math` (deterministic seed). **`os`, `io`, `debug`, `package`/`require`,
+  any FFI are NEVER opened** — no filesystem, OS, network, process, or code loading.
+- **The only host capability is one global `oblikovati` table** (`call`, captured
+  `print`, `methods`, plus Phase-2 typed groups). All host power flows through that one
+  audited door, which itself only reaches the model via `Router.Handle` on the session
+  goroutine — i.e. a script can do exactly what an add-in/MCP client can, no more.
+- **Resource limits:** an **instruction-count quota** (opcode hook, checked every N
+  ops), a **wall-clock timeout** (`context.WithTimeout`), and a **memory cap**
+  (bounded call-stack/registry + allocation guard). Breach → a Lua error that unwinds
+  the VM and returns as an error.
+- **Cancellable:** the run's `context.Context` drives the quota hook and the dispatch
+  submit, so Stop / Ctrl-C / shutdown unwinds promptly.
+- **Panic containment:** `Engine.Run` wraps the VM in `defer recover()` → any panic
+  becomes a returned error, never a process crash; `Router.Handle` recovers a second
+  time on the host-call side. Script errors are surfaced to the console/CLI/slog,
+  **never fatal to the app.**
+
+### 3. API exposure: auto-mirror the wire surface via one generic bridge.
+
+A single global `oblikovati.call(method, argsTable) -> resultTable` marshals the Lua
+table → JSON → `Router.Handle` (over the session-goroutine dispatcher) → JSON → Lua
+table. The conversion is purely structural, so **no per-method code exists**: every
+`api/wire` method + DTO is callable the instant it is registered in `addin/router`,
+with zero scripting-package changes. The method strings ARE the public API.
+Phase-2 typed convenience tables (`oblikovati.documents.*`, mirroring `api/client`
+groups) are thin sugar **auto-derived** from the `api/wire` constants, not hand-written.
+`oblikovati.methods()` exposes the registered method list for discoverability.
+
+### 4. Concurrency model: script on a worker, host calls dispatched to the session.
+
+The script runs on its **own worker goroutine** (it may loop/compute freely — that
+never touches the model). Each `oblikovati.call` blocks the worker and **submits a job
+to the existing `addin/dispatch.Dispatcher`** — the same seam add-ins use — which the
+GUI frame loop `Drain`s (bounded batch per frame) on the session goroutine, runs
+`Router.Handle`, and replies. The call *feels* synchronous to Lua while the **UI never
+freezes**. CLI mode (no frame loop, no UI to protect) uses a direct in-proc caller
+behind the same `ScriptCaller` abstraction. One script per session (run lock) for
+deterministic ordering.
+
+## Consequences
+
+- **Crash-safe by construction.** No cgo ⇒ recoverable panics; the host survives any
+  script. Validated by a containment test suite (infinite loop, error, panic, sandbox
+  escape, cancellation, memory bomb).
+- **Zero-maintenance API coverage.** New contract methods are scriptable for free.
+- **No contract change for Phase 1–2.** All new code is GPL-v2 in `/source` under a
+  new `script/` package tree; Lua rides the existing `api/wire` surface. Only the
+  optional Phase-3 MCP `script.run` adds a contract-first `api/wire`/`api/client` pair.
+- **Reuses existing seams** (`addin/router`, `addin/dispatch`, `app.Session`,
+  `api/wire`, `api/client`) — no new concurrency primitive.
+- **Accepted trade-offs:** interpreter speed (~10-30× slower than LuaJIT, irrelevant
+  for an I/O-bound workload); a small instruction-hook overhead (mitigated by count
+  granularity); scripts can mutate the model (intended; serialized, undoable via
+  commands/transactions, and a future read-only capability gate can filter method
+  names at the single `ScriptCaller` choke point).
+
+## Alternatives considered
+
+- **cgo LuaJIT** — rejected: crash surface violates the no-crash requirement; cgo in
+  the core violates ADR-0008.
+- **Starlark (pure-Go, deterministic)** — viable and named in ADR-0013, but not Lua
+  (the product target), and its non-Turing-complete-by-default model is more awkward
+  for general automation scripts. gopher-lua gives us real Lua with the same
+  pure-Go/no-cgo safety property.
+- **Per-method hand-written bindings** — rejected: violates requirement #2 (coverage
+  would lag the contract and duplicate DTOs, against ADR-0018).

--- a/architecture/decisions/ADR-0028-embedded-lua-scripting.md
+++ b/architecture/decisions/ADR-0028-embedded-lua-scripting.md
@@ -23,7 +23,7 @@ hard constraints:
 
 ## Decision
 
-### 1. Runtime: `github.com/yuin/gopher-lua` (pure-Go Lua 5.1 VM, MIT), behind a seam.
+### 1. Runtime: `github.com/yuin/gopher-lua` (pure-Go Lua 5.1 VM, MIT), behind a seam
 
 Pure Go means **no cgo**, so a script bug is a Go panic we `recover()` — not a
 segfault that kills the process. This is the only runtime choice that can *guarantee*
@@ -37,7 +37,7 @@ The VM is wrapped behind a project-owned `script.Engine` interface (the only
 `gopher-lua` importer is `script/gopherlua`), so the engine is swappable later **only
 if** the crash/quota guarantees can be re-proven on the new path.
 
-### 2. Safety / sandbox model.
+### 2. Safety / sandbox model
 
 - **Opt-in stdlib.** The VM starts with nothing; we open only `base` (with
   `dofile/loadfile/load/loadstring/require/collectgarbage/print` stripped), `table`,
@@ -58,7 +58,7 @@ if** the crash/quota guarantees can be re-proven on the new path.
   time on the host-call side. Script errors are surfaced to the console/CLI/slog,
   **never fatal to the app.**
 
-### 3. API exposure: auto-mirror the wire surface via one generic bridge.
+### 3. API exposure: auto-mirror the wire surface via one generic bridge
 
 A single global `oblikovati.call(method, argsTable) -> resultTable` marshals the Lua
 table → JSON → `Router.Handle` (over the session-goroutine dispatcher) → JSON → Lua
@@ -69,7 +69,7 @@ Phase-2 typed convenience tables (`oblikovati.documents.*`, mirroring `api/clien
 groups) are thin sugar **auto-derived** from the `api/wire` constants, not hand-written.
 `oblikovati.methods()` exposes the registered method list for discoverability.
 
-### 4. Concurrency model: script on a worker, host calls dispatched to the session.
+### 4. Concurrency model: script on a worker, host calls dispatched to the session
 
 The script runs on its **own worker goroutine** (it may loop/compute freely — that
 never touches the model). Each `oblikovati.call` blocks the worker and **submits a job

--- a/architecture/lua-scripting-plan.md
+++ b/architecture/lua-scripting-plan.md
@@ -323,7 +323,7 @@ GPL-2.0-only` (run `scripts/add-spdx-headers.py`).
 All Phase-1/2 logic is pure Go → fully unit-testable with no GPU and no cgo.
 
 **Model-effect tests (`script/runner` + `script/bridge`).**
-- Run a script that calls `documents.*` / `sketch.* `/ `parameters.*` against a real
+- Run a script that calls `documents.*` / `sketch.*` / `parameters.*` against a real
   `*app.Session` (in-proc `ScriptCaller` over `router.Handle`) and assert the model
   changed (e.g. a rectangle exists, a parameter equals the set value). This proves the
   table↔JSON↔router round-trip end to end.

--- a/architecture/lua-scripting-plan.md
+++ b/architecture/lua-scripting-plan.md
@@ -1,0 +1,426 @@
+# Lua Scripting — Implementation Plan
+
+**Status:** Proposed (planning only — no code yet)
+**Scope:** Integral, first-party Lua scripting in the GPL-v2 application (`/source`,
+i.e. this `oblikovati` module). **Not** an add-in.
+**Companion ADR:** [ADR-0028 — Embedded Lua scripting runtime](decisions/ADR-0028-embedded-lua-scripting.md)
+**Builds on:** ADR-0013 (embedded scripting drives the public API), ADR-0016
+(in-process dispatch / session goroutine), ADR-0018 (Apache-2.0 `api/wire` is the
+automation surface), ADR-0008 (cgo confined to the platform edge).
+
+---
+
+## 1. Goal & non-goals
+
+**Goal.** Let a user run a Lua script that drives the live model through the exact
+same method surface (`oblikovati/api/wire`) that add-ins and the MCP bridge use, from
+the GUI (a script console), from the CLI (`oblikovati-cli script run file.lua`), and
+(later) from the MCP bridge — with a sandbox so a buggy or malicious script can never
+crash, hang, or exfiltrate from the host.
+
+**Non-goals (this plan).**
+- Document-embedded *rules* (iLogic-style, event-triggered, persisted in the part) —
+  that is ADR-0013's separate feature; this plan delivers the **runtime + bindings**
+  it will later sit on. Persistence/events are Phase 3.
+- A new GUI scripting *language editor* with IntelliSense — Phase 2 ships a minimal
+  console; a richer editor is a follow-on.
+- Any change to the public contract. Phase 1 rides the existing wire surface; no
+  `api/*` additions are required (see §9).
+
+---
+
+## 2. Runtime choice — `yuin/gopher-lua`
+
+**Decision: `github.com/yuin/gopher-lua` (pure-Go Lua 5.1 VM, MIT).** Wrapped behind a
+project-owned interface so the VM is swappable.
+
+| Criterion | gopher-lua (pure Go) | LuaJIT via cgo |
+|---|---|---|
+| Crash isolation | **No cgo → a script bug is a Go panic we `recover()`**; the host process is never at risk. | A bug in the C VM or the binding is a real segfault that takes the whole process down. Directly violates requirement #1. |
+| Headless-testable core | **Pure Go, `CGO_ENABLED=0`** — fits the cgo-free, headless-tested core (ADR-0008); tests run anywhere. | Needs a C toolchain + LuaJIT on every build/test machine; cgo in the core is exactly what ADR-0008 keeps out. |
+| Timeouts / quotas | **Native instruction-count hook** (`SetMyOpcountHook` / `context`-aware `SetContext`) → enforce instruction budget + wall-clock + cancellation. | Possible via `lua_sethook`, but the binding + recovery story is far harder and a runaway C loop is unkillable from Go. |
+| Memory cap | `RegistrySize` / `CallStackSize` limits; we add an allocation-tracking guard (§7). | Manual `lua_Alloc` interception. |
+| Sandbox | Library registration is **opt-in** — we open *only* the libs we choose (§6). | Same idea, more surface (FFI must be hard-disabled). |
+| License | MIT — compatible with GPL-v2. | MIT/Lua — compatible, but moot given crash risk. |
+| Performance | Interpreted, ~10-30× slower than LuaJIT. Acceptable: scripts are I/O-bound on `oblikovati.call` (each call hops to the session goroutine), not on tight Lua numerics. | Much faster, irrelevant for an API-driven workload. |
+
+**Conclusion.** The whole point of requirement #1 is "a buggy/malicious script must
+NEVER crash the host." A pure-Go VM makes that a `recover()` instead of a segfault,
+and matches the cgo-free core. We pay an interpreter-speed cost that does not matter
+for an API-call-bound workload. If a future numeric-heavy use case ever needs LuaJIT,
+the wrapper interface (§4) lets us swap the engine without touching call sites; the
+sandbox/quota guarantees would have to be re-proven for the cgo path.
+
+---
+
+## 3. Package layout (in `/source`, GPL-v2)
+
+A new top-level package tree `script/` (sibling to `addin/`, `app/`, `command/`):
+
+```
+script/
+  doc.go                      # package doc + SPDX
+  engine.go                   # Engine interface (the project-owned VM seam) + Result/Limits types
+  gopherlua/
+    vm.go                     # gopher-lua–backed Engine impl (the ONLY file that imports gopher-lua)
+    sandbox.go                # stdlib allow/deny: open only safe libs, strip the rest
+    quota.go                  # instruction-count hook + wall-clock + ctx cancel + mem guard
+    convert.go                # Lua table <-> JSON ([]byte) <-> Lua table marshalling
+  bridge/
+    call.go                   # the `oblikovati.call(method, argsTable)->resultTable` global
+    caller.go                 # ScriptCaller: adapts a client.Caller onto the session goroutine
+    api_tables.go             # (Phase 2) generated typed convenience tables (oblikovati.documents.*, …)
+  runner/
+    runner.go                 # ScriptRunner: own goroutine, wires Engine+bridge+limits+ctx, returns Result
+  console/                    # (Phase 2) headless console state (history, output buffer) — UI-agnostic
+    console.go
+```
+
+Rules honoured: one responsibility per file, <500 lines each, the third-party import
+(`gopher-lua`) lives behind `script.Engine` and appears in exactly one subpackage
+(`script/gopherlua`). Everything except a future head panel is pure Go and
+headless-testable.
+
+### 3.1 The engine seam (project-owned interface)
+
+```go
+// script/engine.go
+package script
+
+type Limits struct {
+    Instructions uint64        // hard opcode budget (0 = unlimited, tests only)
+    Wall         time.Duration // wall-clock deadline
+    MemBytes     int64         // approximate allocation cap
+}
+
+type Result struct {
+    Stdout   string            // script print() output
+    Err      error             // script error (syntax/runtime/quota/panic), nil on success
+    Op       uint64            // opcodes executed (for metrics/tests)
+    Duration time.Duration
+}
+
+// Engine runs one script source against a set of host globals under Limits. It must
+// NEVER panic to its caller: a script panic, syntax error, quota breach, or context
+// cancellation all come back as Result.Err. Implementations wrap a concrete VM.
+type Engine interface {
+    Run(ctx context.Context, source string, globals Globals, lim Limits) Result
+}
+
+// Globals is what the host injects into the sandbox: the call bridge plus print.
+type Globals struct {
+    Call  CallFunc   // backs oblikovati.call(method, args)
+    Print func(string)
+}
+
+type CallFunc func(method string, argsJSON []byte) (resultJSON []byte, err error)
+```
+
+This is the only surface the rest of the app sees. Swapping VM = new `Engine` impl.
+
+---
+
+## 4. API exposure — automatic mirroring of the wire surface
+
+**Mechanism: a single generic bridge, `oblikovati.call`, that round-trips through the
+existing `Router.Handle`.** The method strings ARE the public API (`documents.activate`,
+`sketch.rectangle`, `features.list`, …). The bridge never enumerates them:
+
+```lua
+local r = oblikovati.call("sketch.rectangle", { sketch = id, x1=0, y1=0, x2=10, y2=5 })
+-- r is the decoded JSON response as a Lua table
+```
+
+Data flow for one call:
+
+```
+Lua table  ──convert.go──▶  JSON []byte  ──ScriptCaller.Call──▶ dispatch.Submit
+   ▲                                                                 │ (session goroutine)
+   │                                                          Router.Handle(s, method, req)
+   └───────── Lua table ◀──convert.go── JSON []byte ◀── result ◀────┘
+```
+
+- `convert.go` does Lua-table ⇄ JSON purely structurally (tables→objects/arrays,
+  numbers/strings/bools/nil), so **no per-method code exists**. Any DTO that
+  marshals as JSON works automatically.
+- `ScriptCaller` is a `client.Caller` (`Call(method, req) ([]byte, error)`) — the
+  same interface `api/client` already consumes. It marshals the call onto the
+  session goroutine via `dispatch.Dispatcher` (§5).
+- The *host wiring* hands the runner a `client.Caller` that closes over
+  `func(m, b) { return router.Handle(session, m, b) }` (GUI/CLI in-proc) — identical
+  to how `head/cmd/oblikovati-head/addins.go` already wires the router into the
+  add-in host.
+
+**Why coverage stays automatic.** When a new wire method + DTO is added (contract-first
+per ADR-0018) and registered in `addin/router`, it is *immediately* callable from Lua
+as `oblikovati.call("new.method", {...})` with **zero scripting-package changes**. The
+bridge is method-name- and schema-agnostic by construction.
+
+**Discoverability helper (cheap, optional):** `oblikovati.methods()` returns the sorted
+list of registered method names (the router already exposes its handler map; surface a
+read-only `Router.Methods() []string`). This makes the surface introspectable from a
+script/console without coupling to any specific method.
+
+### 4.1 Phase-2 typed convenience tables (ergonomic sugar, still auto-derived)
+
+On top of the generic bridge, expose grouped tables mirroring the `api/client` groups:
+
+```lua
+oblikovati.documents.activate{ id = "..." }
+oblikovati.sketch.rectangle{ ... }
+oblikovati.features.list{ ... }
+```
+
+These are **thin sugar over `oblikovati.call`**, generated from the `api/wire` method
+constants by namespace prefix (`documents.*`, `sketch.*`, …) at startup — *not*
+hand-written per method. A small code-gen step (or a reflective walk over the wire
+constants) keeps them in lockstep with the contract. If the generic `call` is enough
+for Phase 1, these are deferred to Phase 2.
+
+---
+
+## 5. Concurrency / dispatch model
+
+The model is **not** goroutine-safe; `Router.Handle` must run on the **session
+goroutine** (ADR-0016, the same constraint add-ins live under).
+
+- The **script runs on its own worker goroutine** (the `ScriptRunner`). It may loop,
+  compute, recurse — none of that touches the model.
+- Each `oblikovati.call` from the script blocks the worker and **submits a `Job` to
+  the existing `dispatch.Dispatcher`**; the GUI frame loop `Drain`s it on the session
+  goroutine, runs `Router.Handle`, and replies. The script gets the result
+  synchronously (it *feels* synchronous to Lua), but the **UI never freezes** —
+  rendering keeps draining one bounded batch per frame.
+- This is **the same seam add-ins already use** (`dispatch.Submit` ⇄ `Drain`), so
+  scripting introduces no new concurrency primitive — it reuses `addin/dispatch`.
+- **Headless / CLI mode** has no frame loop. The runner there runs a tiny pump
+  goroutine that `Drain`s the dispatcher in a loop until the script finishes (or the
+  session is single-goroutine and we call `Router.Handle` directly behind the
+  `ScriptCaller` — for CLI there is no UI to protect, so a direct in-proc caller is
+  simplest and correct). The `ScriptCaller` abstraction lets GUI (dispatched) and CLI
+  (direct) share the same bridge.
+- **Cancellation:** the `context.Context` passed to `Engine.Run` is the same ctx used
+  by the quota hook (§7) and by `dispatch.Submit`. Cancelling it (console "Stop"
+  button, CLI Ctrl-C, app shutdown) unwinds a blocked call and trips the instruction
+  hook so the script stops promptly.
+- **One script at a time per session** (a run lock). Concurrent scripts mutating the
+  same model is out of scope; the lock makes behaviour deterministic and the dispatch
+  ordering obvious.
+
+---
+
+## 6. Sandbox policy (exact stdlib allow/deny)
+
+`gopher-lua` lets us choose which standard libraries to open. We start from **nothing**
+and open only safe libs. We do **not** call `lua.NewState()` with default libs;
+instead we register a curated set.
+
+**ALLOW (opened):**
+- `base` — but with the dangerous globals **removed after open**:
+  strip `dofile`, `loadfile`, `load`, `loadstring`, `require`, `collectgarbage`
+  (we control GC), `print` (replaced by our captured `print` → output buffer).
+  Keep: `assert`, `error`, `pcall`, `xpcall`, `select`, `type`, `tostring`,
+  `tonumber`, `pairs`, `ipairs`, `next`, `rawget/rawset/rawequal/rawlen`, `unpack`,
+  `setmetatable`, `getmetatable`.
+- `table`, `string`, `math` — pure, deterministic, no I/O. (`math.random` seeded
+  deterministically per run, or removed if determinism is required for rules.)
+- `coroutine` — pure control flow, no I/O. (Optional; include only if needed.)
+
+**DENY (never opened):**
+- `os` (clock, time, env, exit, execute, remove, rename, tmpname) — no OS access.
+- `io` (files, stdin/stdout, popen) — no filesystem/process.
+- `debug` (getinfo, sethook from script, setmetatable bypass) — no introspection/escape.
+- `package` / `require` — no loading external code.
+- Any FFI (N/A for gopher-lua; explicitly never added).
+
+**The ONLY host capability injected** is the `oblikovati` global table (`call`,
+`print`/console output, `methods`, and Phase-2 typed tables). All host power flows
+through that one audited door, which itself only reaches the model via `Router.Handle`
+on the session goroutine — i.e. scripts can do exactly what an add-in/MCP client can
+do, no more.
+
+---
+
+## 7. Resource limits & error handling
+
+**Instruction quota (the primary runaway guard).** Install a count hook
+(`L.SetContext(ctx)` + an opcode-count hook) that, every N opcodes, (a) checks
+`ctx.Err()` and (b) decrements the instruction budget; on breach it raises a Lua error
+that unwinds the VM. This kills `while true do end` deterministically. N is tuned so
+the hook overhead is small (§10 risk).
+
+**Wall-clock timeout.** A `context.WithTimeout` (config default, e.g. 5 s GUI / 30 s
+CLI, overridable) cancels the ctx; the hook observes it. Belt-and-suspenders with the
+instruction budget (a script blocked in a long host call is cut by the dispatch ctx,
+not the opcode hook).
+
+**Memory cap.** Bound `CallStackSize` and `RegistrySize` at state creation, and track
+approximate allocation via a periodic check in the count hook (string/table growth);
+on breach, raise a Lua error. (gopher-lua has no hard allocator cap, so this is
+best-effort + the instruction/time guards backstop true runaways.)
+
+**Panic containment (the absolute guarantee).** `Engine.Run` wraps the VM call in
+`defer recover()`. Any panic from the VM, a binding, or `convert.go` becomes
+`Result.Err`, never a process crash. `Router.Handle` *also* already recovers panics
+(see `addin/router/logs_test.go: TestHandleRecoversPanicIntoError`), so a panic inside
+a host call is contained at two layers.
+
+**Error surfacing.** Syntax errors, runtime errors, quota/timeout breaches, and
+recovered panics all return as `Result.Err` with the offending line/method in the
+message (per CLAUDE.md: messages include the offending value). They are written to the
+console output / CLI stderr / a slog record — **never fatal to the app**.
+
+---
+
+## 8. Integration points
+
+**Head (GUI) — Phase 2.**
+- A **Script Console panel** (ImGui): a source editor pane, a "Run" and a "Stop"
+  button (Stop cancels the ctx), and an output/error log pane fed by the console
+  state in `script/console`. The panel calls the `ScriptRunner` with the
+  dispatched `ScriptCaller`.
+- A **"Run Script…"** command (`command/` + `app/commands_*`) that opens a file and
+  runs it. Ribbon home: a **Tools tab → Manage panel** (consistent with the
+  Inventor-derived ribbon map in `architecture/mapping/`; place alongside add-in/macro
+  tooling, not on a modeling panel).
+
+**CLI — Phase 1.**
+- `oblikovati-cli script run <file.lua>` (a new `cmd_script.go` + a `script` case in
+  `cmd/oblikovati-cli/main.go`'s `run` switch). It opens/creates a `*app.Session`
+  (reusing the existing CLI session setup), builds an in-proc `ScriptCaller` over
+  `router.Handle`, runs the file under default CLI limits, prints script output to
+  stdout and errors to stderr, exits non-zero on `Result.Err`. CGO-free.
+- Optional `--doc <file.obk>` to run against an existing document and `--save <out>`.
+
+**MCP bridge — Phase 3 (note only).** The bridge can expose a `script.run` wire
+method (contract-first: a `MethodScriptRun` + request/response DTO in `api/wire`, a
+router handler that runs source via the `ScriptRunner`, a `client.Scripts()` group)
+so an LLM can submit a whole Lua program in one call instead of N tool calls. This is
+the only contract-first addition the whole effort needs, and only in Phase 3.
+
+**Reuse, don't duplicate:** `addin/router` (the method surface), `addin/dispatch`
+(the session-goroutine seam), `app.Session` (the model owner), `api/wire` (method
+names), `api/client` (`Caller`, and the typed groups for Phase-2 sugar).
+
+---
+
+## 9. Contract-first impact (ADR-0018)
+
+- **Phase 1 & 2: none.** Lua rides the existing `api/wire` surface via the generic
+  bridge. No new method-name constants, DTOs, or `api/contract` interfaces. All new
+  code is GPL-v2 in `/source` under `script/`.
+- **Phase 3 (only if MCP `script.run` is wanted):** add `MethodScriptRun` + DTOs in
+  `api/wire` and a `client.Scripts()` group in `api/client` (Apache-2.0) *first*, then
+  the router handler in `/source`. This is the standard two-part flow.
+
+Every new exported `.go` file in `/source` carries `SPDX-License-Identifier:
+GPL-2.0-only` (run `scripts/add-spdx-headers.py`).
+
+---
+
+## 10. Testing strategy (headless, against `*app.Session`)
+
+All Phase-1/2 logic is pure Go → fully unit-testable with no GPU and no cgo.
+
+**Model-effect tests (`script/runner` + `script/bridge`).**
+- Run a script that calls `documents.*` / `sketch.* `/ `parameters.*` against a real
+  `*app.Session` (in-proc `ScriptCaller` over `router.Handle`) and assert the model
+  changed (e.g. a rectangle exists, a parameter equals the set value). This proves the
+  table↔JSON↔router round-trip end to end.
+
+**Containment tests (the safety spec — the heart of requirement #1).**
+- *Infinite loop* (`while true do end`) → returns `Result.Err` (quota/timeout), host
+  survives, asserts within a bounded wall-clock.
+- *Script error* (`error("boom")`, nil index) → `Result.Err` carries line + message,
+  no panic escapes.
+- *Forced panic path* (a fake `CallFunc`/Engine that panics) → recovered into
+  `Result.Err`; a follow-up run on the same session still works (process intact).
+- *Sandbox escape attempts* → `os`, `io`, `require`, `debug`, `loadstring` are all
+  `nil` in the script env (table-driven test asserting each global is absent).
+- *Cancellation* → cancel the ctx mid-run; `Run` returns promptly with a
+  cancellation error.
+- *Memory* → an allocation-bomb script trips the mem/instruction guard, not the host.
+
+**Conversion tests (`script/gopherlua/convert`).** Round-trip nested
+table↔JSON↔table: objects, arrays, numbers, bools, nil, deep nesting; reject cyclic
+tables with a clear error.
+
+**CLI test (`cmd/oblikovati-cli`).** `script run` on a fixture `.lua` creates the
+expected model / exits 0; a failing script exits non-zero with the error on stderr.
+
+Mocks are named fakes (e.g. `fakeCaller`, `panicEngine`) per CLAUDE.md, not inline
+stubs.
+
+---
+
+## 11. Phased rollout
+
+**Phase 1 — runtime + generic bridge + sandbox + CLI (no UI, no contract change).**
+1. `script.Engine` interface + `script/gopherlua` impl (sandbox + quota + convert).
+2. `script/bridge` (`oblikovati.call`, `ScriptCaller`, in-proc caller over `router.Handle`).
+3. `script/runner` (worker goroutine, limits, ctx, recover).
+4. `oblikovati-cli script run`.
+5. Full headless test suite (§10), especially the containment spec.
+6. ADR-0028 → Accepted.
+
+**Phase 2 — typed sugar + GUI console.**
+1. `oblikovati.documents.*` / typed tables auto-derived from `api/wire` groups.
+2. `script/console` state + head Script Console panel + "Run Script…" command on the
+   Tools/Manage ribbon panel; Stop/cancel.
+3. `oblikovati.methods()` discoverability; output/error pane wiring.
+4. UI e2e tests (per the project's "DoD = UI + e2e" rule).
+
+**Phase 3 — events, library, persistence, MCP.**
+1. Event/callback hooks so scripts can subscribe to the event bus (foundation for
+   ADR-0013 rules: `on("parameterChanged", fn)`).
+2. A bundled script library / examples; saved scripts; (later) document-embedded
+   rules persisted in the model (ADR-0013 territory).
+3. Contract-first `script.run` wire method + `client.Scripts()` so the MCP bridge can
+   run whole programs.
+
+---
+
+## 12. Risks & mitigations
+
+- **Instruction-hook overhead.** A per-opcode hook is costly. *Mitigation:* run the
+  hook every N opcodes (count granularity), not every op; benchmark to pick N that
+  keeps overhead <~5% while still cutting a runaway within a few ms. Workload is
+  API-bound, so Lua-side opcode rate is modest anyway.
+- **A long script blocking the session goroutine.** Only the *host call* runs on the
+  session goroutine, and the frame loop drains a **bounded batch per frame**
+  (`addInDrainPerFrame`, already 32), so even a chatty script can't starve rendering.
+  A single *slow handler* could stall one frame — same risk add-ins already have; the
+  dispatch timeout backstops it.
+- **Exposing mutating methods.** Scripts can do anything an add-in/MCP client can
+  (create/delete/modify). That is the intended power. *Mitigation:* it all goes
+  through `commands`/transactions (undoable), the run lock serialises it, and a future
+  capability gate (a read-only mode for untrusted scripts) can filter method names at
+  the `ScriptCaller` before dispatch — the single choke point makes that trivial later.
+- **Determinism.** `math.random`/any clock would make rules non-deterministic.
+  *Mitigation:* seed deterministically per run (or drop `math.random` for the rules
+  use case); `os`/`io` already denied. Document the guarantee.
+- **gopher-lua performance.** ~10-30× slower than LuaJIT for pure numerics.
+  *Mitigation:* accept it (workload is I/O-bound on host calls); the `Engine` seam
+  lets us swap to a faster VM later **only if** we can re-prove the crash/quota
+  guarantees on that path.
+- **Two layers of recover masking real bugs.** *Mitigation:* recovered panics are
+  logged (slog, with stack) before being converted to `Result.Err`, so genuine host
+  bugs are still visible in observability.
+
+---
+
+## 13. Key files / packages (summary)
+
+- New: `script/` (engine seam), `script/gopherlua/` (the only gopher-lua importer +
+  sandbox/quota/convert), `script/bridge/` (the auto-mirroring `oblikovati.call` +
+  `ScriptCaller`), `script/runner/`, `script/console/` (Phase 2),
+  `cmd/oblikovati-cli/cmd_script.go`, head Script Console panel (Phase 2).
+- Reused unchanged: `addin/router` (`Router.Handle`), `addin/dispatch` (`Dispatcher`),
+  `app.Session`, `api/wire` (method constants), `api/client` (`Caller` + typed groups).
+- Contract-first additions: **none** until Phase 3's optional `script.run` wire method.
+
+---
+
+*Plan author note:* this plan extends ADR-0013's already-recorded intent ("Lua via a
+pure-Go VM" driving "the same public API") into a concrete, sandboxed, headless-tested
+runtime. The companion decision is recorded in ADR-0028.

--- a/cmd/oblikovati-cli/cmd_script.go
+++ b/cmd/oblikovati-cli/cmd_script.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"oblikovati/addin/opregistry"
+	"oblikovati/addin/router"
+	"oblikovati/app"
+	"oblikovati/persistence"
+	"oblikovati/script"
+	"oblikovati/script/bridge"
+	"oblikovati/script/gopherlua"
+	"oblikovati/script/runner"
+)
+
+// cmdScript runs a Lua script against a headless session. It links no native code, so
+// it stays CGO-free (ADR-0008); the script drives the model through the same wire
+// surface add-ins and the MCP bridge use, sandboxed (ADR-0028):
+//
+//	oblikovati-cli script run build.lua
+//	oblikovati-cli script run build.lua --doc in.obk --save out.obk
+func cmdScript(args []string, out io.Writer) error {
+	if len(args) == 0 || args[0] != "run" {
+		return fmt.Errorf("script: expected `run <file.lua>`, got %q", joinArgs(args))
+	}
+	return cmdScriptRun(args[1:], out)
+}
+
+// cmdScriptRun parses the `script run` operands/flags, builds a session + in-proc
+// caller, runs the file under the CLI limits, prints script output to out and errors to
+// stderr, and returns a non-nil error (→ non-zero exit) when the script fails.
+func cmdScriptRun(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("script run", flag.ContinueOnError)
+	fs.SetOutput(out)
+	docPath := fs.String("doc", "", "open an existing .obk document before running")
+	savePath := fs.String("save", "", "save the active document to this path after a successful run")
+	// The file path is the sole positional and must come first; flags (which take
+	// values) follow it. flag.Parse stops at the first non-flag, so parse from arg[1:].
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return fmt.Errorf("script run: expected <file.lua> as the first argument, got %q", joinArgs(args))
+	}
+	file := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("script run: unexpected extra argument %q", fs.Arg(0))
+	}
+	src, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("script run: read %q: %w", file, err)
+	}
+	return runScriptFile(string(src), *docPath, *savePath, out)
+}
+
+// runScriptFile wires a store-backed session and the in-proc router caller, optionally
+// opens a document, runs source, then optionally saves. Script print() goes to out; a
+// script failure becomes the returned error.
+func runScriptFile(source, docPath, savePath string, out io.Writer) error {
+	session := app.NewSessionWithStore(persistence.NewPackageStore())
+	if docPath != "" {
+		if _, err := session.OpenDocument(docPath); err != nil {
+			return fmt.Errorf("script run: open %q: %w", docPath, err)
+		}
+	}
+	res := runOnSession(session, source, out)
+	if res.Err != nil {
+		return fmt.Errorf("script run: %w", res.Err)
+	}
+	return saveIfRequested(session, savePath, out)
+}
+
+// runOnSession builds the runner over a DirectCaller (CLI: synchronous, no UI to
+// protect) and runs source under the CLI limits, forwarding print() to out.
+func runOnSession(session *app.Session, source string, out io.Writer) script.Result {
+	rtr := router.New(opregistry.Default())
+	caller := bridge.NewDirectCaller(rtr.Handle, session)
+	run := runner.New(gopherlua.New(), caller, rtr.Methods)
+	res, err := run.Run(context.Background(), source, runner.DefaultCLILimits, func(line string) {
+		fmt.Fprintln(out, line)
+	})
+	if err != nil { // ErrBusy can't happen on a fresh runner; surface defensively.
+		return script.Result{Err: err}
+	}
+	return res
+}
+
+// saveIfRequested writes the active document to savePath when set, so a script that
+// builds a model can persist it for an e2e fixture.
+func saveIfRequested(session *app.Session, savePath string, out io.Writer) error {
+	if savePath == "" {
+		return nil
+	}
+	if err := session.SaveActiveDocumentAs(savePath); err != nil {
+		return fmt.Errorf("script run: save %q: %w", savePath, err)
+	}
+	fmt.Fprintf(out, "saved active document to %s\n", savePath)
+	return nil
+}
+
+// joinArgs renders args for an error message; empty becomes "<none>".
+func joinArgs(args []string) string {
+	if len(args) == 0 {
+		return "<none>"
+	}
+	return args[0]
+}

--- a/cmd/oblikovati-cli/cmd_script_test.go
+++ b/cmd/oblikovati-cli/cmd_script_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeScript writes src to a temp .lua file and returns its path.
+func writeScript(t *testing.T, src string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "script.lua")
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	return path
+}
+
+func TestScriptRunBuildsAndSavesDocument(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "built.obk")
+	lua := writeScript(t, `oblikovati.call("documents.create", { type = "part", name = "built" })
+	                       oblikovati.call("parameters.add", { name = "width", expression = "4 cm" })
+	                       print("done")`)
+	stdout, err := runCLI(t, "script", "run", lua, "--save", out)
+	if err != nil {
+		t.Fatalf("script run: %v", err)
+	}
+	if !strings.Contains(stdout, "done") {
+		t.Errorf("script print() missing from output: %q", stdout)
+	}
+	if _, statErr := os.Stat(out); statErr != nil {
+		t.Fatalf("expected saved document %s: %v", out, statErr)
+	}
+	// The saved document round-trips: info reports the part.
+	info, err := runCLI(t, "info", out)
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if !strings.Contains(info, "type: part") {
+		t.Errorf("saved doc info = %q, want a part", info)
+	}
+}
+
+func TestScriptRunFailingScriptExitsNonZero(t *testing.T) {
+	lua := writeScript(t, `error("intentional failure value")`)
+	out, err := runCLI(t, "script", "run", lua)
+	if err == nil {
+		t.Fatal("a failing script must return a non-nil error (non-zero exit)")
+	}
+	if !strings.Contains(err.Error(), "intentional failure value") {
+		t.Errorf("error should carry the offending value, got %q", err.Error())
+	}
+	_ = out
+}
+
+func TestScriptRunSandboxEscapeFails(t *testing.T) {
+	lua := writeScript(t, `local f = io.open("/etc/passwd", "r")`)
+	if _, err := runCLI(t, "script", "run", lua); err == nil {
+		t.Fatal("io must be denied: the script should fail, not read the filesystem")
+	}
+}
+
+func TestScriptRunMissingFileErrors(t *testing.T) {
+	if _, err := runCLI(t, "script", "run", "/no/such/file.lua"); err == nil {
+		t.Fatal("a missing script file must error")
+	}
+}
+
+func TestScriptRunBadUsageErrors(t *testing.T) {
+	if _, err := runCLI(t, "script"); err == nil {
+		t.Fatal("`script` with no subcommand must error")
+	}
+	if _, err := runCLI(t, "script", "frobnicate"); err == nil {
+		t.Fatal("an unknown script subcommand must error")
+	}
+}

--- a/cmd/oblikovati-cli/main.go
+++ b/cmd/oblikovati-cli/main.go
@@ -44,13 +44,15 @@ func run(args []string, out io.Writer) error {
 		return cmdImport(args[1:], out)
 	case "export":
 		return cmdExport(args[1:], out)
+	case "script":
+		return cmdScript(args[1:], out)
 	case "version":
 		return cmdVersion(out)
 	case "help", "-h", "--help":
 		fmt.Fprintln(out, usage)
 		return nil
 	default:
-		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|import|export|version)", args[0])
+		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|import|export|script|version)", args[0])
 	}
 }
 
@@ -64,4 +66,5 @@ usage:
   oblikovati-cli save-as <src> <dst>
   oblikovati-cli import <mesh-file.stl|.obj|.3mf> <dst.obk>
   oblikovati-cli export <src.obk> <mesh-file.stl|.obj|.3mf> [low|medium|high]
+  oblikovati-cli script run <file.lua> [--doc in.obk] [--save out.obk]
   oblikovati-cli version`

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module oblikovati
 go 1.22
 
 require (
+	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
-	golang.org/x/text v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 	oblikovati/api v0.0.0
 )
+
+require golang.org/x/text v0.22.0 // indirect
 
 // oblikovati/api is the Apache-2.0 contract, now a sibling repo
 // (../Oblikovati.API). It is resolved for local development via the go.work

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/script/bridge/call.go
+++ b/script/bridge/call.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package bridge
+
+import (
+	"oblikovati/api/client"
+	"oblikovati/script"
+)
+
+// CallFuncOf adapts a client.Caller into the script.CallFunc that backs
+// oblikovati.call. It is the single line of glue between the API transport surface
+// (client.Caller, what add-ins consume) and the script engine's host door — the
+// conversion of Lua tables to/from JSON happens inside the engine (convert.go), so
+// this layer only forwards the (method, JSON) pair (ADR-0028 §3).
+//
+// Example:
+//
+//	caller := bridge.NewDirectCaller(router.Handle, session)
+//	globals := script.Globals{Call: bridge.CallFuncOf(caller), Methods: rtr.Methods}
+func CallFuncOf(caller client.Caller) script.CallFunc {
+	return func(method string, argsJSON []byte) ([]byte, error) {
+		return caller.Call(method, argsJSON)
+	}
+}

--- a/script/bridge/caller.go
+++ b/script/bridge/caller.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package bridge connects the sandboxed script runtime to the host's wire method
+// surface. It defines the two client.Caller flavours a script can run behind — a
+// direct in-proc caller (CLI, no UI to protect) and a dispatched caller (the head,
+// where each call must hop to the session goroutine) — and the generic
+// oblikovati.call adapter that turns a client.Caller into a script.CallFunc.
+//
+// The bridge is method-name- and schema-agnostic by construction: it forwards
+// (method, JSON) pairs verbatim, so every oblikovati/api/wire method is callable from
+// Lua the instant it is registered in addin/router, with zero per-method code
+// (ADR-0028 §3).
+package bridge
+
+import (
+	"context"
+	"fmt"
+
+	"oblikovati/addin/dispatch"
+	"oblikovati/api/client"
+	"oblikovati/app"
+)
+
+// RouteFunc is the host's method router as a bare function: addin/router's
+// Router.Handle bound to one *app.Session. Injecting it (rather than importing router
+// here) keeps the bridge decoupled from the router package and trivially fakeable.
+type RouteFunc func(s *app.Session, method string, req []byte) ([]byte, error)
+
+// DirectCaller runs each host call synchronously on the calling goroutine. Correct for
+// the single-threaded CLI, where there is no frame loop and no UI to protect: the
+// script worker calls straight into Router.Handle (ADR-0028 §4, CLI mode).
+type DirectCaller struct {
+	route   RouteFunc
+	session *app.Session
+}
+
+// NewDirectCaller binds route to session for synchronous in-proc calls.
+func NewDirectCaller(route RouteFunc, session *app.Session) *DirectCaller {
+	return &DirectCaller{route: route, session: session}
+}
+
+// Call satisfies client.Caller by invoking the router directly on this goroutine.
+func (c *DirectCaller) Call(method string, req []byte) ([]byte, error) {
+	if c.route == nil {
+		return nil, fmt.Errorf("bridge: DirectCaller has no route for %q", method)
+	}
+	return c.route(c.session, method, req)
+}
+
+var _ client.Caller = (*DirectCaller)(nil)
+
+// DispatchedCaller marshals each host call onto the session goroutine via the existing
+// addin/dispatch.Dispatcher — the same seam add-ins use — so a looping script never
+// touches the model off-goroutine and the UI frame loop keeps draining (ADR-0028 §4).
+// The head wires this in Phase 2; it is built and tested now so the seam is real.
+type DispatchedCaller struct {
+	route      RouteFunc
+	session    *app.Session
+	dispatcher *dispatch.Dispatcher
+	ctx        context.Context
+}
+
+// NewDispatchedCaller binds route+session to dispatcher; ctx cancels a blocked submit
+// (Stop/shutdown). A nil ctx means context.Background().
+func NewDispatchedCaller(route RouteFunc, session *app.Session, d *dispatch.Dispatcher, ctx context.Context) *DispatchedCaller {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &DispatchedCaller{route: route, session: session, dispatcher: d, ctx: ctx}
+}
+
+// Call satisfies client.Caller by submitting the routed call as a dispatch.Job and
+// blocking until the session goroutine drains it (or ctx fires / the dispatcher closes).
+func (c *DispatchedCaller) Call(method string, req []byte) ([]byte, error) {
+	if c.route == nil || c.dispatcher == nil {
+		return nil, fmt.Errorf("bridge: DispatchedCaller not wired for %q", method)
+	}
+	return c.dispatcher.Submit(c.ctx, func() ([]byte, error) {
+		return c.route(c.session, method, req)
+	})
+}
+
+var _ client.Caller = (*DispatchedCaller)(nil)

--- a/script/bridge/caller_test.go
+++ b/script/bridge/caller_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package bridge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"oblikovati/addin/dispatch"
+	"oblikovati/app"
+)
+
+// recordingRoute is a named fake RouteFunc that records the method it saw and returns a
+// scripted reply — exercising the caller wiring without the real router.
+type recordingRoute struct {
+	reply  []byte
+	err    error
+	method string
+}
+
+func (r *recordingRoute) route(_ *app.Session, method string, _ []byte) ([]byte, error) {
+	r.method = method
+	return r.reply, r.err
+}
+
+func TestDirectCallerInvokesRoute(t *testing.T) {
+	rec := &recordingRoute{reply: []byte(`{"ok":true}`)}
+	c := NewDirectCaller(rec.route, app.NewSession())
+	out, err := c.Call("documents.list", []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if rec.method != "documents.list" {
+		t.Errorf("method = %q, want documents.list", rec.method)
+	}
+	if string(out) != `{"ok":true}` {
+		t.Errorf("reply not forwarded: %s", out)
+	}
+}
+
+func TestDirectCallerWithoutRouteErrors(t *testing.T) {
+	c := NewDirectCaller(nil, app.NewSession())
+	if _, err := c.Call("x", nil); err == nil {
+		t.Fatal("a caller with no route must error, not panic")
+	}
+}
+
+func TestDirectCallerSurfacesRouteError(t *testing.T) {
+	rec := &recordingRoute{err: errors.New("nope")}
+	c := NewDirectCaller(rec.route, app.NewSession())
+	if _, err := c.Call("x", nil); err == nil {
+		t.Fatal("route error must surface")
+	}
+}
+
+func TestDispatchedCallerRunsOnDrainGoroutine(t *testing.T) {
+	rec := &recordingRoute{reply: []byte(`{"drained":true}`)}
+	d := dispatch.New(4)
+	c := NewDispatchedCaller(rec.route, app.NewSession(), d, context.Background())
+
+	// The call blocks until something drains the dispatcher (the "session goroutine").
+	resCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		out, err := c.Call("model.tree", []byte(`{}`))
+		resCh <- out
+		errCh <- err
+	}()
+	waitForPending(t, d)
+	d.Drain(0)
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if out := <-resCh; string(out) != `{"drained":true}` {
+		t.Errorf("reply not forwarded: %s", out)
+	}
+	if rec.method != "model.tree" {
+		t.Errorf("method = %q, want model.tree", rec.method)
+	}
+}
+
+func TestDispatchedCallerCancelledContextErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d := dispatch.New(1)
+	c := NewDispatchedCaller((&recordingRoute{}).route, app.NewSession(), d, ctx)
+	if _, err := c.Call("x", nil); err == nil {
+		t.Fatal("a cancelled context must fail the submit")
+	}
+}
+
+// waitForPending blocks until the dispatcher has a queued job (the worker reached
+// Submit), so the test drains deterministically without sleeping a fixed interval.
+func waitForPending(t *testing.T, d *dispatch.Dispatcher) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for d.Pending() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("no job was submitted to the dispatcher")
+		}
+	}
+}

--- a/script/engine.go
+++ b/script/engine.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package script is the embedded-scripting seam for the GPL application: it lets a
+// user run a Lua program that drives the live model through the exact same wire
+// method surface (oblikovati/api/wire) that add-ins and the MCP bridge use, under a
+// sandbox so a buggy or malicious script can never crash, hang, or escape the host
+// (ADR-0028).
+//
+// The concrete Lua VM (gopher-lua) lives behind the Engine interface in the
+// script/gopherlua subpackage — the only place that imports the third-party VM — so
+// the runtime is swappable without touching call sites. script/bridge builds the one
+// host door (the oblikovati global) over a wire Caller, and script/runner stitches
+// the engine, the bridge, and the resource limits together on a worker goroutine.
+package script
+
+import (
+	"context"
+	"time"
+)
+
+// Limits bounds one script run so a runaway can never starve the host. A zero field
+// means "unbounded" and is intended for tests only — production callers always set
+// all three (see runner.DefaultCLILimits).
+type Limits struct {
+	Instructions uint64        // hard opcode budget across the run (0 = unlimited)
+	Wall         time.Duration // wall-clock deadline (0 = no deadline)
+	MemBytes     int64         // approximate Lua allocation cap (0 = unbounded)
+}
+
+// Result reports the outcome of one Run. Err is the single channel for every failure
+// mode — syntax error, runtime error, quota breach, context cancellation, or a
+// recovered panic — so a caller never has to handle a panic. Op and Duration are for
+// metrics and the containment tests.
+type Result struct {
+	Stdout   string        // captured print() output
+	Err      error         // nil on success; otherwise the failure (never a panic)
+	Op       uint64        // opcodes executed (best-effort; for metrics/tests)
+	Duration time.Duration // wall-clock spent in Run
+}
+
+// CallFunc backs the oblikovati.call(method, argsTable) host door. It takes a method
+// name and the JSON-encoded args table and returns the JSON-encoded result. It runs
+// (logically) on the host's session goroutine — script/bridge marshals it there.
+type CallFunc func(method string, argsJSON []byte) (resultJSON []byte, err error)
+
+// Globals is everything the host injects into the otherwise-empty sandbox: the call
+// door, the captured print sink, and the introspection list. Nothing else reaches the
+// host (ADR-0028 §2).
+type Globals struct {
+	Call    CallFunc        // backs oblikovati.call
+	Print   func(string)    // backs the captured print(); nil discards
+	Methods func() []string // backs oblikovati.methods(); nil yields an empty list
+}
+
+// Engine runs one Lua source against a set of host Globals under Limits. It MUST NEVER
+// panic to its caller: a script panic, syntax error, quota breach, or context
+// cancellation all come back as Result.Err. Implementations wrap a concrete VM.
+//
+// Example:
+//
+//	eng := gopherlua.New()
+//	res := eng.Run(ctx, `oblikovati.call("documents.list", {})`, globals, lim)
+//	if res.Err != nil { log.Print(res.Err) }
+type Engine interface {
+	Run(ctx context.Context, source string, globals Globals, lim Limits) Result
+}

--- a/script/gopherlua/convert.go
+++ b/script/gopherlua/convert.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// maxConvertDepth bounds nesting so a deeply recursive or cyclic table raises a clear
+// error instead of overflowing the Go stack. 64 is well past any real DTO.
+const maxConvertDepth = 64
+
+// tableToJSON marshals a Lua value (typically the args table) to its JSON encoding,
+// purely structurally: a Lua table becomes a JSON array when it is a 1..n integer
+// sequence, otherwise a JSON object; numbers/strings/bools/nil map directly. This is
+// what makes the bridge method-agnostic — any DTO that marshals as JSON round-trips
+// with zero per-method code (ADR-0028 §3).
+func tableToJSON(v lua.LValue) ([]byte, error) {
+	g, err := luaToGo(v, 0)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(g)
+}
+
+// luaToGo converts one Lua value to a JSON-marshalable Go value, recursing into tables.
+// It rejects nesting past maxConvertDepth (the cyclic/too-deep guard) and unsupported
+// types (functions, userdata, threads) with a message naming the offending Lua type.
+func luaToGo(v lua.LValue, depth int) (interface{}, error) {
+	if depth > maxConvertDepth {
+		return nil, fmt.Errorf("script: table nesting exceeds %d (cyclic or too deep)", maxConvertDepth)
+	}
+	switch t := v.(type) {
+	case *lua.LNilType:
+		return nil, nil
+	case lua.LBool:
+		return bool(t), nil
+	case lua.LNumber:
+		return float64(t), nil
+	case lua.LString:
+		return string(t), nil
+	case *lua.LTable:
+		return tableToGo(t, depth)
+	default:
+		return nil, fmt.Errorf("script: cannot convert Lua %s to JSON", v.Type().String())
+	}
+}
+
+// tableToGo converts a Lua table to either a []interface{} (when it is a dense
+// 1..n array) or a map[string]interface{} (otherwise), recursing through luaToGo.
+func tableToGo(tb *lua.LTable, depth int) (interface{}, error) {
+	if n := tb.Len(); n > 0 && isSequence(tb, n) {
+		return sequenceToGo(tb, n, depth)
+	}
+	return mapToGo(tb, depth)
+}
+
+// isSequence reports whether tb is a dense 1..n integer-keyed array (so it should
+// marshal as a JSON array, not an object).
+func isSequence(tb *lua.LTable, n int) bool {
+	count := 0
+	tb.ForEach(func(k, _ lua.LValue) {
+		if num, ok := k.(lua.LNumber); ok && num == lua.LNumber(math.Trunc(float64(num))) {
+			count++
+		}
+	})
+	return count == n
+}
+
+// sequenceToGo converts a 1..n Lua array to a Go slice.
+func sequenceToGo(tb *lua.LTable, n, depth int) ([]interface{}, error) {
+	out := make([]interface{}, 0, n)
+	for i := 1; i <= n; i++ {
+		g, err := luaToGo(tb.RawGetInt(i), depth+1)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
+// mapToGo converts a Lua table to a Go map keyed by the string form of each key, so
+// the result marshals to a JSON object. Non-string keys are stringified.
+func mapToGo(tb *lua.LTable, depth int) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	var convErr error
+	tb.ForEach(func(k, val lua.LValue) {
+		if convErr != nil {
+			return
+		}
+		g, err := luaToGo(val, depth+1)
+		if err != nil {
+			convErr = err
+			return
+		}
+		out[k.String()] = g
+	})
+	return out, convErr
+}
+
+// jsonToTable decodes a JSON document into a fresh Lua value on l: objects become
+// tables keyed by field, arrays become 1..n tables, scalars map directly. An empty or
+// null input yields an empty table so a handler that returns no body still gives the
+// script a table to index.
+func jsonToTable(l *lua.LState, data []byte) (lua.LValue, error) {
+	if len(data) == 0 {
+		return l.NewTable(), nil
+	}
+	var g interface{}
+	if err := json.Unmarshal(data, &g); err != nil {
+		return nil, fmt.Errorf("script: decode result JSON: %w", err)
+	}
+	return goToLua(l, g), nil
+}
+
+// goToLua converts a decoded JSON value (from encoding/json) into a Lua value on l.
+func goToLua(l *lua.LState, g interface{}) lua.LValue {
+	switch t := g.(type) {
+	case nil:
+		return lua.LNil
+	case bool:
+		return lua.LBool(t)
+	case float64:
+		return lua.LNumber(t)
+	case string:
+		return lua.LString(t)
+	case []interface{}:
+		return sliceToTable(l, t)
+	case map[string]interface{}:
+		return objectToTable(l, t)
+	default:
+		return lua.LString(fmt.Sprintf("%v", t))
+	}
+}
+
+// sliceToTable builds a 1..n Lua array table from a Go slice.
+func sliceToTable(l *lua.LState, s []interface{}) *lua.LTable {
+	tb := l.NewTable()
+	for _, e := range s {
+		tb.Append(goToLua(l, e))
+	}
+	return tb
+}
+
+// objectToTable builds a Lua table from a Go map, inserting keys in sorted order so
+// the conversion is deterministic (repeatable tests, stable iteration).
+func objectToTable(l *lua.LState, m map[string]interface{}) *lua.LTable {
+	tb := l.NewTable()
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		tb.RawSetString(k, goToLua(l, m[k]))
+	}
+	return tb
+}

--- a/script/gopherlua/convert_test.go
+++ b/script/gopherlua/convert_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+// roundTrip decodes json into a Lua value and back, so a test asserts the structural
+// table↔JSON↔table conversion is lossless (the property the generic bridge relies on).
+func roundTrip(t *testing.T, jsonIn string) string {
+	t.Helper()
+	l := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer l.Close()
+	v, err := jsonToTable(l, []byte(jsonIn))
+	if err != nil {
+		t.Fatalf("jsonToTable(%q): %v", jsonIn, err)
+	}
+	out, err := tableToJSON(v)
+	if err != nil {
+		t.Fatalf("tableToJSON: %v", err)
+	}
+	return string(out)
+}
+
+func TestConvertRoundTripsNestedShapes(t *testing.T) {
+	// NOTE: JSON null is intentionally NOT round-tripped — Lua cannot store nil in a
+	// table (assigning nil deletes the key), so a null field becomes an absent field.
+	// That is a documented property of any Lua bridge, asserted separately below.
+	cases := []string{
+		`{"a":1,"b":"two","c":true}`,
+		`{"nested":{"x":[1,2,3],"y":{"z":false}}}`,
+		`[1,2,3]`,
+		`{"arr":[{"k":1},{"k":2}],"flag":true}`,
+	}
+	for _, in := range cases {
+		got := roundTrip(t, in)
+		if !jsonEqual(t, in, got) {
+			t.Errorf("round-trip changed shape: in=%s out=%s", in, got)
+		}
+	}
+}
+
+func TestConvertNullBecomesAbsentField(t *testing.T) {
+	// Lua tables cannot hold nil, so a JSON null key drops out on round-trip. Pin the
+	// behaviour so a future change to convert.go is a conscious decision.
+	got := roundTrip(t, `{"present":1,"gone":null}`)
+	if !jsonEqual(t, `{"present":1}`, got) {
+		t.Errorf("null field should drop, got %s", got)
+	}
+}
+
+func TestConvertEmptyInputYieldsTable(t *testing.T) {
+	l := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer l.Close()
+	v, err := jsonToTable(l, nil)
+	if err != nil {
+		t.Fatalf("jsonToTable(nil): %v", err)
+	}
+	if v.Type() != lua.LTTable {
+		t.Fatalf("empty input: want table, got %s", v.Type())
+	}
+}
+
+func TestConvertRejectsCyclicTable(t *testing.T) {
+	l := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer l.Close()
+	tb := l.NewTable()
+	tb.RawSetString("self", tb) // cycle
+	_, err := tableToJSON(tb)
+	if err == nil {
+		t.Fatal("expected an error for a cyclic table")
+	}
+	if !strings.Contains(err.Error(), "nesting") {
+		t.Errorf("error should name the nesting limit, got %q", err.Error())
+	}
+}
+
+func TestConvertRejectsFunctionValue(t *testing.T) {
+	l := lua.NewState(lua.Options{SkipOpenLibs: true})
+	defer l.Close()
+	tb := l.NewTable()
+	tb.RawSetString("fn", l.NewFunction(func(*lua.LState) int { return 0 }))
+	_, err := tableToJSON(tb)
+	if err == nil {
+		t.Fatal("expected an error converting a function value")
+	}
+	if !strings.Contains(err.Error(), "function") {
+		t.Errorf("error should name the offending Lua type, got %q", err.Error())
+	}
+}
+
+// jsonEqual compares two JSON documents structurally (key order / whitespace agnostic).
+func jsonEqual(t *testing.T, a, b string) bool {
+	t.Helper()
+	var va, vb interface{}
+	if err := json.Unmarshal([]byte(a), &va); err != nil {
+		t.Fatalf("unmarshal %q: %v", a, err)
+	}
+	if err := json.Unmarshal([]byte(b), &vb); err != nil {
+		t.Fatalf("unmarshal %q: %v", b, err)
+	}
+	ba, _ := json.Marshal(va)
+	bb, _ := json.Marshal(vb)
+	return string(ba) == string(bb)
+}

--- a/script/gopherlua/errors.go
+++ b/script/gopherlua/errors.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import "fmt"
+
+// errNoCaller reports that oblikovati.call was invoked but no host CallFunc was wired
+// into Globals — a host misconfiguration, named with the offending method.
+func errNoCaller(method string) error {
+	return fmt.Errorf("oblikovati.call(%q): no host caller configured", method)
+}

--- a/script/gopherlua/host.go
+++ b/script/gopherlua/host.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import (
+	"strings"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"oblikovati/script"
+)
+
+// outputSink accumulates a script's print() output for Result.Stdout. It is also
+// forwarded line-by-line to the host's Print callback (the console/CLI) as it arrives.
+type outputSink struct{ b strings.Builder }
+
+func (o *outputSink) String() string { return o.b.String() }
+
+// registerPrint installs a captured print(...) that joins its arguments with tabs and a
+// trailing newline (Lua's print semantics), appends to the sink, and forwards each line
+// to host (the console/CLI). The dangerous default print was stripped in the sandbox;
+// this is the only print the script sees, so it can never reach a real stdout fd.
+func registerPrint(l *lua.LState, host func(string), out *outputSink) {
+	l.SetGlobal("print", l.NewFunction(func(s *lua.LState) int {
+		line := joinPrintArgs(s)
+		out.b.WriteString(line)
+		out.b.WriteByte('\n')
+		if host != nil {
+			host(line)
+		}
+		return 0
+	}))
+}
+
+// joinPrintArgs renders print's arguments the way Lua's print does: each argument's
+// tostring form, separated by a tab.
+func joinPrintArgs(s *lua.LState) string {
+	n := s.GetTop()
+	parts := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		parts = append(parts, s.ToStringMeta(s.Get(i)).String())
+	}
+	return strings.Join(parts, "\t")
+}
+
+// installOblikovati registers the single host door: a global `oblikovati` table with
+// `call(method, argsTable) -> resultTable` and `methods() -> {names}`. All host power
+// flows through this one audited table; it reaches the model only via g.Call, which the
+// bridge marshals onto the session goroutine (ADR-0028 §3).
+func installOblikovati(l *lua.LState, g script.Globals) {
+	tb := l.NewTable()
+	l.SetField(tb, "call", l.NewFunction(callBinding(g.Call)))
+	l.SetField(tb, "methods", l.NewFunction(methodsBinding(g.Methods)))
+	l.SetGlobal("oblikovati", tb)
+}
+
+// callBinding adapts a script.CallFunc into the Lua `oblikovati.call(method, args)`
+// function: it reads the method string and optional args table, marshals the table to
+// JSON, invokes call, and converts the JSON result back to a Lua table pushed as the
+// single return value. Any conversion or call error is raised as a Lua error so the
+// script can pcall it (and an unhandled one surfaces as Result.Err with the line).
+func callBinding(call script.CallFunc) lua.LGFunction {
+	return func(l *lua.LState) int {
+		method := l.CheckString(1)
+		args := l.OptTable(2, l.NewTable())
+		argsJSON, err := tableToJSON(args)
+		if err != nil {
+			l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
+		}
+		resJSON, err := callHost(call, method, argsJSON)
+		if err != nil {
+			l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
+		}
+		result, err := jsonToTable(l, resJSON)
+		if err != nil {
+			l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
+		}
+		l.Push(result)
+		return 1
+	}
+}
+
+// callHost guards a nil CallFunc (a misconfigured Globals) with a clear error rather
+// than a nil-call panic — the message names the offending method per CLAUDE.md.
+func callHost(call script.CallFunc, method string, argsJSON []byte) ([]byte, error) {
+	if call == nil {
+		return nil, errNoCaller(method)
+	}
+	return call(method, argsJSON)
+}
+
+// methodsBinding adapts the Methods provider into `oblikovati.methods()`, returning a
+// 1..n array table of the registered method names (empty when no provider is wired).
+func methodsBinding(list func() []string) lua.LGFunction {
+	return func(l *lua.LState) int {
+		tb := l.NewTable()
+		if list != nil {
+			for _, m := range list() {
+				tb.Append(lua.LString(m))
+			}
+		}
+		l.Push(tb)
+		return 1
+	}
+}

--- a/script/gopherlua/quota.go
+++ b/script/gopherlua/quota.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import (
+	"context"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"oblikovati/script"
+)
+
+// runDeadline derives the effective wall-clock deadline for one run from the caller's
+// context and the Wall limit. gopher-lua's context-aware main loop checks ctx.Done()
+// every opcode (vm.go mainLoopWithContext), so a cancellable context is what
+// deterministically unwinds a runaway like `while true do end` — it is the primary
+// runaway guard this VM can enforce per-opcode. The returned cancel MUST be called.
+func runDeadline(parent context.Context, lim script.Limits) (context.Context, context.CancelFunc) {
+	if lim.Wall <= 0 {
+		return context.WithCancel(parent)
+	}
+	return context.WithTimeout(parent, lim.Wall)
+}
+
+// applyMemoryLimits bounds the VM's data and call stacks at state creation, the only
+// hard memory ceiling gopher-lua offers without its os.Exit-on-breach SetMx watchdog
+// (which we deliberately do NOT use — it would crash the host, violating ADR-0028 §1).
+// A non-positive MemBytes leaves the library defaults in place.
+//
+// MemBytes is translated to a registry size (each registry slot is one LValue); the
+// call stack is kept proportionally bounded so deep recursion errors rather than grows
+// unbounded. This is best-effort: the wall-clock guard backstops a true allocation bomb.
+func memoryOptions(lim script.Limits) lua.Options {
+	opts := lua.Options{SkipOpenLibs: true}
+	if lim.MemBytes <= 0 {
+		return opts
+	}
+	const bytesPerSlot = 32 // conservative LValue footprint estimate
+	slots := int(lim.MemBytes / bytesPerSlot)
+	if slots < minRegistrySize {
+		slots = minRegistrySize
+	}
+	opts.RegistrySize = slots
+	opts.RegistryMaxSize = slots // hard cap: registry cannot grow past the budget
+	opts.CallStackSize = callStackFor(slots)
+	return opts
+}
+
+const (
+	minRegistrySize  = 1024
+	maxCallStackSize = 4096
+)
+
+// callStackFor sizes the call stack proportionally to the registry budget, clamped so
+// a small memory cap still allows useful recursion and a large one stays bounded.
+func callStackFor(slots int) int {
+	cs := slots / 16
+	if cs < 256 {
+		cs = 256
+	}
+	if cs > maxCallStackSize {
+		cs = maxCallStackSize
+	}
+	return cs
+}
+
+// instructionBudget is the seam for an opcode-budget guard. gopher-lua exposes no
+// public opcode hook, so the instruction count cannot be enforced directly on this VM;
+// the wall-clock context is the enforced runaway guard (runDeadline). This function
+// records the budget for metrics (Result.Op) and is the single place a future hooked VM
+// (or a swapped Engine) would wire a real opcode counter — keeping Limits.Instructions
+// a live part of the contract per the plan (ADR-0028).
+func instructionBudget(lim script.Limits) uint64 { return lim.Instructions }

--- a/script/gopherlua/sandbox.go
+++ b/script/gopherlua/sandbox.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import lua "github.com/yuin/gopher-lua"
+
+// deniedGlobals are the base-library names stripped after OpenBase so a script can
+// neither load external code, touch the OS/filesystem, nor reach into the VM:
+//   - load/loadstring/loadfile/dofile/require: no code loading (ADR-0028 §2).
+//   - collectgarbage: we control GC, not the script.
+//   - print: replaced by the captured sink in registerPrint.
+//   - module/newproxy: legacy/escape-prone base entries we don't expose.
+var deniedGlobals = []string{
+	"load", "loadstring", "loadfile", "dofile", "require",
+	"collectgarbage", "print", "module", "newproxy",
+}
+
+// openSafeLibs registers ONLY the deterministic, no-I/O standard libraries on L:
+// base (then stripped), table, string, math. os, io, debug, package/require, and any
+// FFI are NEVER opened — they are simply absent from the script environment. This is
+// the allow-list half of the sandbox; the deny half is "we never call their opener".
+func openSafeLibs(l *lua.LState) {
+	openers := []struct {
+		name string
+		open lua.LGFunction
+	}{
+		{lua.BaseLibName, lua.OpenBase},
+		{lua.TabLibName, lua.OpenTable},
+		{lua.StringLibName, lua.OpenString},
+		{lua.MathLibName, lua.OpenMath},
+	}
+	for _, o := range openers {
+		l.Push(l.NewFunction(o.open))
+		l.Push(lua.LString(o.name))
+		l.Call(1, 0)
+	}
+	stripDeniedGlobals(l)
+}
+
+// stripDeniedGlobals removes each deniedGlobals name from the global table, so the
+// dangerous base-library entries opened by OpenBase are gone before any user code runs.
+func stripDeniedGlobals(l *lua.LState) {
+	for _, name := range deniedGlobals {
+		l.SetGlobal(name, lua.LNil)
+	}
+}
+
+// deniedLibNames lists the standard-library globals a containment test asserts are
+// absent from the sandbox. It is the executable form of the deny policy (ADR-0028 §2):
+// if any of these becomes reachable, TestSandboxDeniesGlobals fails.
+var deniedLibNames = []string{
+	"os", "io", "debug", "package", "require",
+	"load", "loadstring", "loadfile", "dofile", "collectgarbage",
+}

--- a/script/gopherlua/vm.go
+++ b/script/gopherlua/vm.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package gopherlua is the ONLY importer of github.com/yuin/gopher-lua. It implements
+// the project-owned script.Engine seam over the pure-Go Lua 5.1 VM: an opt-in
+// sandbox (sandbox.go), context/memory resource limits (quota.go), structural Lua⇄JSON
+// conversion (convert.go), and total panic containment here (ADR-0028). No other
+// package may import gopher-lua, so the VM stays swappable behind script.Engine.
+package gopherlua
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
+	lua "github.com/yuin/gopher-lua"
+
+	"oblikovati/script"
+)
+
+// Engine is the gopher-lua-backed script.Engine. It holds no per-run state — each Run
+// builds a fresh, isolated LState — so one Engine is safe to reuse across runs (the
+// runner serialises them with a per-session lock).
+type Engine struct{}
+
+// New returns a gopher-lua Engine. It is the only constructor the rest of the app
+// calls to obtain a script.Engine implementation.
+func New() *Engine { return &Engine{} }
+
+// compile-time proof the gopher-lua impl satisfies the project-owned seam.
+var _ script.Engine = (*Engine)(nil)
+
+// Run executes source against globals under lim and returns the outcome. It NEVER
+// panics to its caller: a VM panic, a binding panic, or a convert panic is recovered
+// into Result.Err (the absolute guarantee of ADR-0028 §2). Syntax errors, runtime
+// errors, and context cancellation (timeout/Stop) likewise come back as Result.Err.
+func (e *Engine) Run(ctx context.Context, source string, globals script.Globals, lim script.Limits) (res script.Result) {
+	start := time.Now()
+	defer func() {
+		res.Duration = time.Since(start)
+		res.Op = instructionBudget(lim)
+		if rec := recover(); rec != nil {
+			res.Err = recoveredPanic(rec)
+		}
+	}()
+	return e.runGuarded(ctx, source, globals, lim, start)
+}
+
+// runGuarded builds the sandboxed state, applies the deadline, injects the host door,
+// and runs the source. It is the body the outer Run recovers around.
+func (e *Engine) runGuarded(ctx context.Context, source string, g script.Globals, lim script.Limits, start time.Time) script.Result {
+	l := lua.NewState(memoryOptions(lim))
+	defer l.Close()
+	openSafeLibs(l)
+
+	runCtx, cancel := runDeadline(ctx, lim)
+	defer cancel()
+	l.SetContext(runCtx)
+
+	var out outputSink
+	registerPrint(l, g.Print, &out)
+	installOblikovati(l, g)
+
+	err := l.DoString(source)
+	return script.Result{Stdout: out.String(), Err: doErr(err, runCtx), Duration: time.Since(start)}
+}
+
+// recoveredPanic turns a recovered value into a logged, descriptive error so a genuine
+// host bug stays visible in observability (slog + stack) yet is never fatal to the app
+// (ADR-0028 §2, risk "two layers of recover masking real bugs").
+func recoveredPanic(rec interface{}) error {
+	stack := string(debug.Stack())
+	slog.Error("script: recovered panic in Lua VM", "value", rec, "stack", stack)
+	return fmt.Errorf("script: recovered panic: %v", rec)
+}
+
+// doErr maps DoString's error to the run's failure, preferring the context error so a
+// timeout/cancel surfaces as such rather than as the Lua "context deadline exceeded"
+// re-raise. A nil DoString error with an expired context still reports the context
+// error (defensive); otherwise it returns the Lua error verbatim (it carries the line).
+func doErr(luaErr error, ctx context.Context) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("script: %w", ctx.Err())
+	}
+	return luaErr
+}

--- a/script/gopherlua/vm_test.go
+++ b/script/gopherlua/vm_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"oblikovati/script"
+)
+
+// errBoom is a sentinel host-call error used by the pcall containment test.
+var errBoom = errors.New("host call failed")
+
+// fakeCall is a named fake CallFunc that records the last method/args and returns a
+// scripted reply (or error) — the host door under test without a real router.
+type fakeCall struct {
+	reply    []byte
+	err      error
+	panicMsg string
+	method   string
+	argsJSON []byte
+}
+
+func (f *fakeCall) call(method string, argsJSON []byte) ([]byte, error) {
+	f.method = method
+	f.argsJSON = argsJSON
+	if f.panicMsg != "" {
+		panic(f.panicMsg)
+	}
+	return f.reply, f.err
+}
+
+func globalsWith(f *fakeCall) script.Globals {
+	return script.Globals{Call: f.call, Print: func(string) {}}
+}
+
+func TestRunCallsHostAndConvertsResult(t *testing.T) {
+	f := &fakeCall{reply: []byte(`{"id":7,"name":"box"}`)}
+	src := `local r = oblikovati.call("documents.create", { type = "part", name = "box" })
+	        print(r.id)
+	        print(r.name)`
+	res := New().Run(context.Background(), src, globalsWith(f), script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("Run: %v", res.Err)
+	}
+	if f.method != "documents.create" {
+		t.Errorf("method = %q, want documents.create", f.method)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(f.argsJSON, &got); err != nil {
+		t.Fatalf("args not JSON: %v", err)
+	}
+	if got["type"] != "part" || got["name"] != "box" {
+		t.Errorf("args round-trip wrong: %v", got)
+	}
+	if !strings.Contains(res.Stdout, "7") || !strings.Contains(res.Stdout, "box") {
+		t.Errorf("stdout missing converted result: %q", res.Stdout)
+	}
+}
+
+func TestRunInfiniteLoopHitsWallClock(t *testing.T) {
+	start := time.Now()
+	res := New().Run(context.Background(), "while true do end", script.Globals{}, script.Limits{Wall: 150 * time.Millisecond})
+	if res.Err == nil {
+		t.Fatal("infinite loop must return an error, not hang")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("loop not cut promptly: %v", elapsed)
+	}
+}
+
+func TestRunSyntaxErrorReturnsError(t *testing.T) {
+	res := New().Run(context.Background(), "this is not lua %%%", script.Globals{}, script.Limits{Wall: time.Second})
+	if res.Err == nil {
+		t.Fatal("syntax error must return an error")
+	}
+}
+
+func TestRunRuntimeErrorCarriesMessage(t *testing.T) {
+	res := New().Run(context.Background(), `error("boom-value")`, script.Globals{}, script.Limits{Wall: time.Second})
+	if res.Err == nil {
+		t.Fatal("runtime error must return an error")
+	}
+	if !strings.Contains(res.Err.Error(), "boom-value") {
+		t.Errorf("error should carry the offending value: %q", res.Err.Error())
+	}
+}
+
+func TestRunRecoversHostCallPanic(t *testing.T) {
+	f := &fakeCall{panicMsg: "host blew up"}
+	res := New().Run(context.Background(), `oblikovati.call("x", {})`, globalsWith(f), script.Limits{Wall: time.Second})
+	if res.Err == nil {
+		t.Fatal("a panicking host call must be recovered into an error")
+	}
+	// The host survives: a second run on the same engine still works.
+	ok := New().Run(context.Background(), `print("alive")`, script.Globals{Print: func(string) {}}, script.Limits{Wall: time.Second})
+	if ok.Err != nil {
+		t.Fatalf("engine should survive a recovered panic: %v", ok.Err)
+	}
+}
+
+func TestRunHostCallErrorIsCatchableWithPcall(t *testing.T) {
+	f := &fakeCall{err: errBoom}
+	src := `local ok, msg = pcall(function() oblikovati.call("x", {}) end)
+	        if ok then error("expected failure") end
+	        print("caught")`
+	res := New().Run(context.Background(), src, globalsWith(f), script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("pcall should let the script handle the host error: %v", res.Err)
+	}
+	if !strings.Contains(res.Stdout, "caught") {
+		t.Errorf("script did not catch the host error: %q", res.Stdout)
+	}
+}
+
+func TestRunCancellationStopsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	start := time.Now()
+	res := New().Run(ctx, "while true do end", script.Globals{}, script.Limits{})
+	if res.Err == nil {
+		t.Fatal("a cancelled context must stop the run with an error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("cancellation not honoured promptly: %v", elapsed)
+	}
+}
+
+func TestSandboxDeniesGlobals(t *testing.T) {
+	for _, name := range deniedLibNames {
+		src := "if " + name + " ~= nil then error(\"" + name + " is reachable\") end"
+		res := New().Run(context.Background(), src, script.Globals{}, script.Limits{Wall: time.Second})
+		if res.Err != nil {
+			t.Errorf("denied global %q: %v", name, res.Err)
+		}
+	}
+}
+
+func TestSandboxAllowsSafeLibs(t *testing.T) {
+	src := `assert(math.floor(3.7) == 3)
+	        assert(string.upper("a") == "A")
+	        local t = {1,2,3}; assert(#t == 3)`
+	res := New().Run(context.Background(), src, script.Globals{}, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("safe libs should be available: %v", res.Err)
+	}
+}
+
+func TestMethodsBindingExposesList(t *testing.T) {
+	g := script.Globals{
+		Print:   func(string) {},
+		Methods: func() []string { return []string{"a.b", "c.d"} },
+	}
+	res := New().Run(context.Background(), `print(#oblikovati.methods())`, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("Run: %v", res.Err)
+	}
+	if !strings.Contains(res.Stdout, "2") {
+		t.Errorf("methods() should expose 2 names, stdout=%q", res.Stdout)
+	}
+}

--- a/script/runner/runner.go
+++ b/script/runner/runner.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package runner stitches a script.Engine, a host Globals door, and resource Limits
+// together and runs one script on a dedicated worker goroutine. It owns the run lock
+// (one script per ScriptRunner at a time, for deterministic dispatch ordering) and the
+// default Limits for the CLI and GUI (ADR-0028 §4, §5).
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"oblikovati/api/client"
+	"oblikovati/script"
+	"oblikovati/script/bridge"
+)
+
+// ErrBusy is returned when a Run is requested while another is in flight on the same
+// ScriptRunner (the one-script-per-session lock, ADR-0028 §4).
+var ErrBusy = errors.New("runner: a script is already running")
+
+// DefaultCLILimits are the headless CLI defaults: a generous wall-clock and memory cap
+// so a real automation script finishes, while still bounding a runaway. The CLI has no
+// UI to protect, so the budget is larger than the GUI's.
+var DefaultCLILimits = script.Limits{
+	Instructions: 0, // gopher-lua exposes no opcode hook; the wall-clock is the enforced guard
+	Wall:         30 * time.Second,
+	MemBytes:     256 << 20, // 256 MiB
+}
+
+// DefaultGUILimits are the interactive defaults: a short wall-clock so a buggy console
+// script can't stall a frame for long, backstopped by the bounded dispatcher drain.
+var DefaultGUILimits = script.Limits{
+	Instructions: 0,
+	Wall:         5 * time.Second,
+	MemBytes:     128 << 20, // 128 MiB
+}
+
+// ScriptRunner runs Lua sources against one host caller under one engine. It is reused
+// across runs; the run lock serialises them.
+type ScriptRunner struct {
+	engine  script.Engine
+	caller  client.Caller
+	methods func() []string
+	mu      sync.Mutex // the run lock: one script at a time
+	running bool
+}
+
+// New builds a runner. engine is the VM (e.g. gopherlua.New()); caller is the host
+// transport (a bridge.DirectCaller for the CLI, a bridge.DispatchedCaller for the
+// head); methods backs oblikovati.methods() for discoverability (may be nil).
+func New(engine script.Engine, caller client.Caller, methods func() []string) *ScriptRunner {
+	return &ScriptRunner{engine: engine, caller: caller, methods: methods}
+}
+
+// Run executes source under lim on a fresh worker goroutine and returns its Result.
+// It holds the run lock for the duration (ErrBusy if a run is already in flight), wires
+// the host door from the caller, and forwards print output to onPrint (may be nil).
+// ctx cancellation (Stop / Ctrl-C / shutdown) unwinds the run promptly via the engine's
+// context-aware loop.
+func (r *ScriptRunner) Run(ctx context.Context, source string, lim script.Limits, onPrint func(string)) (script.Result, error) {
+	if !r.acquire() {
+		return script.Result{}, ErrBusy
+	}
+	defer r.release()
+	globals := script.Globals{
+		Call:    bridge.CallFuncOf(r.caller),
+		Print:   onPrint,
+		Methods: r.methods,
+	}
+	return r.runOnWorker(ctx, source, globals, lim), nil
+}
+
+// runOnWorker runs engine.Run on a dedicated goroutine so the script's own computation
+// (loops, recursion) never executes on the caller's goroutine; the caller blocks on the
+// result. Host API calls hop to the session goroutine inside the caller (bridge), not
+// here — this goroutine is purely the Lua interpreter's.
+func (r *ScriptRunner) runOnWorker(ctx context.Context, source string, g script.Globals, lim script.Limits) script.Result {
+	done := make(chan script.Result, 1)
+	go func() { done <- r.engine.Run(ctx, source, g, lim) }()
+	return <-done
+}
+
+// acquire takes the run lock; returns false if a run is already in flight.
+func (r *ScriptRunner) acquire() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.running {
+		return false
+	}
+	r.running = true
+	return true
+}
+
+// release frees the run lock.
+func (r *ScriptRunner) release() {
+	r.mu.Lock()
+	r.running = false
+	r.mu.Unlock()
+}

--- a/script/runner/runner_test.go
+++ b/script/runner/runner_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"oblikovati/addin/opregistry"
+	"oblikovati/addin/router"
+	"oblikovati/api/client"
+	"oblikovati/app"
+	"oblikovati/script"
+	"oblikovati/script/bridge"
+	"oblikovati/script/gopherlua"
+)
+
+// newRealRunner builds a runner over a real Session + router (the in-proc CLI wiring),
+// returning the runner and the session so a test can assert model effects.
+func newRealRunner() (*ScriptRunner, *app.Session) {
+	s := app.NewSession()
+	rtr := router.New(opregistry.Default())
+	caller := bridge.NewDirectCaller(rtr.Handle, s)
+	return New(gopherlua.New(), caller, rtr.Methods), s
+}
+
+func TestRunScriptAffectsModel(t *testing.T) {
+	r, s := newRealRunner()
+	src := `oblikovati.call("documents.create", { type = "part", name = "block" })
+	        oblikovati.call("parameters.add", { name = "width", expression = "4 cm" })`
+	res, err := r.Run(context.Background(), src, fastLimits(), nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("script: %v", res.Err)
+	}
+	if s.ActiveDocument() == nil {
+		t.Fatal("script did not create a document")
+	}
+	assertParameter(t, r, "width", "40 mm")
+}
+
+// assertParameter runs a follow-up script that reads the parameter back, proving the
+// table↔JSON↔router round-trip both ways (the model really changed).
+func assertParameter(t *testing.T, r *ScriptRunner, name, wantValue string) {
+	t.Helper()
+	var line string
+	src := `local ps = oblikovati.call("parameters.list", {})
+	        for _, p in ipairs(ps.parameters) do
+	          if p.name == "` + name + `" then print(p.value) end
+	        end`
+	res, err := r.Run(context.Background(), src, fastLimits(), func(s string) { line = s })
+	if err != nil || res.Err != nil {
+		t.Fatalf("read-back run: err=%v scriptErr=%v", err, res.Err)
+	}
+	if strings.TrimSpace(line) != wantValue {
+		t.Errorf("parameter %q = %q, want %q", name, line, wantValue)
+	}
+}
+
+func TestRunInfiniteLoopReturnsErrorHostSurvives(t *testing.T) {
+	r, _ := newRealRunner()
+	res, err := r.Run(context.Background(), "while true do end", script.Limits{Wall: 150 * time.Millisecond}, nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Err == nil {
+		t.Fatal("infinite loop must yield a script error")
+	}
+	// Host survives: a normal script still runs afterwards.
+	ok, _ := r.Run(context.Background(), `print("alive")`, fastLimits(), nil)
+	if ok.Err != nil {
+		t.Fatalf("host did not survive the runaway: %v", ok.Err)
+	}
+}
+
+// panicEngine is a named fake script.Engine whose Run panics, proving the runner's
+// engine is the recover seam (a panicking engine must not crash the process).
+type panicEngine struct{}
+
+func (panicEngine) Run(context.Context, string, script.Globals, script.Limits) script.Result {
+	panic("engine exploded")
+}
+
+func TestRunSurfacesRecoveredEnginePanicAsError(t *testing.T) {
+	// The script.Engine contract is that Run NEVER panics to its caller (ADR-0028 §2);
+	// the real gopherlua engine recovers internally. recoveringAdapter models that
+	// contract over a panicking engine, and this test pins that the runner plumbs the
+	// recovered error through as Result.Err — not as a process crash.
+	r := New(recoveringAdapter{panicEngine{}}, &nopCaller{}, nil)
+	res, err := r.Run(context.Background(), "noop", fastLimits(), nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Err == nil {
+		t.Fatal("a recovered engine panic must surface as a script error")
+	}
+}
+
+func TestRunLockRejectsConcurrentRun(t *testing.T) {
+	r := New(blockingEngine{started: make(chan struct{}), release: make(chan struct{})}, &nopCaller{}, nil)
+	be := r.engine.(blockingEngine)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = r.Run(context.Background(), "first", fastLimits(), nil)
+	}()
+	<-be.started
+	if _, err := r.Run(context.Background(), "second", fastLimits(), nil); err != ErrBusy {
+		t.Errorf("second concurrent run: err = %v, want ErrBusy", err)
+	}
+	close(be.release)
+	wg.Wait()
+}
+
+func fastLimits() script.Limits { return script.Limits{Wall: 2 * time.Second} }
+
+// nopCaller is a named fake client.Caller that returns an empty object.
+type nopCaller struct{}
+
+func (*nopCaller) Call(string, []byte) ([]byte, error) { return []byte(`{}`), nil }
+
+var _ client.Caller = (*nopCaller)(nil)
+
+// recoveringAdapter wraps an engine so its panic is recovered into Result.Err, matching
+// the real gopherlua engine's contract (used to test the runner's lock/result plumbing
+// against a panic without crashing the test process).
+type recoveringAdapter struct{ inner script.Engine }
+
+func (a recoveringAdapter) Run(ctx context.Context, src string, g script.Globals, lim script.Limits) (res script.Result) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			res.Err = fmt.Errorf("recovered panic: %v", rec)
+		}
+	}()
+	return a.inner.Run(ctx, src, g, lim)
+}
+
+// blockingEngine blocks in Run until released, so a test can observe the run lock.
+type blockingEngine struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b blockingEngine) Run(context.Context, string, script.Globals, script.Limits) script.Result {
+	close(b.started)
+	<-b.release
+	return script.Result{}
+}


### PR DESCRIPTION
## What

Phase 1 of **ADR-0028 — embedded Lua scripting**: a first-party, sandboxed Lua runtime that drives the live model through the exact same `api/wire` method surface that add-ins and the MCP bridge use, plus an `oblikovati-cli script run <file.lua>` runner. No public-contract change — Lua rides the existing wire surface.

New `script/` package tree (all GPL-2.0-only, headless, cgo-free):

- **`script/engine.go`** — the project-owned `script.Engine` seam (`Run(ctx, source, globals, lim) Result`) plus `Limits`/`Globals`/`CallFunc`. The only surface the rest of the app sees, so the VM is swappable.
- **`script/gopherlua/`** — the ONLY importer of `github.com/yuin/gopher-lua` (pure-Go Lua 5.1, MIT): the VM impl (`vm.go`), the opt-in sandbox (`sandbox.go`), resource limits (`quota.go`), structural Lua⇄JSON conversion (`convert.go`), and the `oblikovati` host door (`host.go`).
- **`script/bridge/`** — the generic `oblikovati.call(method, argsTable) → resultTable` adapter over `client.Caller`, with a synchronous `DirectCaller` (CLI) and a session-goroutine `DispatchedCaller` (head, over `addin/dispatch`).
- **`script/runner/`** — `ScriptRunner`: worker goroutine + one-script-per-session run lock + default CLI/GUI `Limits`.
- **`cmd/oblikovati-cli/cmd_script.go`** — `script run <file.lua> [--doc in.obk] [--save out.obk]`.

## Why

Users need to automate the model with scripts from the CLI (and later the GUI/MCP) under three hard constraints, all met here:

1. **A buggy/malicious script must never crash, hang, or escape the host.** Pure-Go VM ⇒ a script bug is a Go panic we `recover()` into `Result.Err`, not a segfault. The sandbox opens only `base`(stripped)/`table`/`string`/`math`; `os`, `io`, `debug`, `package`/`require`, `load*`/`dofile`, and any FFI are never reachable. A wall-clock `context` (checked per-opcode by gopher-lua) cuts a runaway loop; the registry/call-stack are bounded for an approximate memory cap. (The `SetMx` OOM watchdog is deliberately **not** used — it calls `os.Exit`, which would crash the host.)
2. **Everything in `api/wire` is callable, automatically.** `oblikovati.call` round-trips a Lua table → JSON → `client.Caller` → `Router.Handle` → JSON → Lua table purely structurally, so a new wire method is scriptable the instant it is registered — zero per-method code. `oblikovati.methods()` lists the surface.
3. **The model is not goroutine-safe.** The script runs on its own worker goroutine; each host call hops to the session goroutine via the existing `addin/dispatch.Dispatcher` (the `DispatchedCaller` seam the head will use). The CLI, having no UI to protect, uses the synchronous `DirectCaller` behind the same `client.Caller` interface.

## Tests (headless, F.I.R.S.T)

- **Model effect:** a script creates a document + parameter against a real `*app.Session` and a follow-up script reads it back (`width = 40 mm`) — proving the table↔JSON↔router round-trip both ways.
- **Conversion:** nested object/array/scalar round-trips; cyclic-table and function-value rejection; documented JSON-`null`→absent-field behaviour.
- **Containment (the safety spec):** infinite loop → error (host survives a follow-up run); syntax/runtime error → error carrying the offending value; recovered host-call panic → error + host survives; every denied global is `nil`; cancelled context stops promptly; `pcall` can catch a host error.
- **CLI:** `script run` builds and `--save`s a part that `info` reports; a failing script exits non-zero with the value on the error; an `io`/sandbox escape fails; missing-file and bad-usage errors.

`go build ./...`, `go vet ./...`, and `golangci-lint run` are clean; the touched-package tests pass.

## Deferred (per the plan)

- **Phase 2:** typed `oblikovati.documents.*` sugar tables auto-derived from `api/wire` groups; the head Script Console panel + "Run Script…" command. The `DispatchedCaller` seam is built and tested now so the head can plug in directly.
- **Phase 3:** event/callback hooks, a script library, document-embedded rules, and the contract-first MCP `script.run` wire method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)