### PR TITLE
feat(addin): implement interaction.setNotice

### DIFF
--- a/addin/router/interaction.go
+++ b/addin/router/interaction.go
@@ -24,3 +24,14 @@ func interactionState(s *app.Session, _ json.RawMessage) (json.RawMessage, error
 	st.Busy = st.ActiveTool != "" || st.InTransaction
 	return json.Marshal(st)
 }
+
+// interactionSetNotice puts a transient add-in message in the status bar
+// (wire.MethodInteractionSetNotice) — e.g. a collaboration add-in's connection status.
+func interactionSetNotice(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var a wire.SetNoticeArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return nil, err
+	}
+	s.SetNotice(a.Message)
+	return json.Marshal(wire.OKResult{OK: true})
+}

--- a/addin/router/interaction_test.go
+++ b/addin/router/interaction_test.go
@@ -32,3 +32,14 @@ func TestInteractionStateIdleVsInTransaction(t *testing.T) {
 		t.Fatalf("inside a transaction state should be busy/inTransaction, got %+v", st)
 	}
 }
+
+// TestInteractionSetNotice checks an add-in can post a transient status-bar message, so a
+// collaboration add-in's connection state is visible to the user (not just in logs).
+func TestInteractionSetNotice(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	call(t, r, s, "interaction.setNotice", `{"message":"Meeting: connected"}`, nil)
+	if s.Notice() != "Meeting: connected" {
+		t.Errorf("notice = %q, want %q", s.Notice(), "Meeting: connected")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -80,6 +80,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewGetCamera] = getCamera
 	r.handlers[wire.MethodViewSetCamera] = setCamera
 	r.handlers[wire.MethodInteractionState] = interactionState
+	r.handlers[wire.MethodInteractionSetNotice] = interactionSetNotice
 	r.handlers[wire.MethodViewsList] = listViews
 	r.handlers[wire.MethodViewsAdd] = addView
 	r.handlers[wire.MethodViewsActivate] = activateView

--- a/app/session.go
+++ b/app/session.go
@@ -66,6 +66,11 @@ type Session struct {
 // the status bar so a failed OK is not silent.
 func (s *Session) Notice() string { return s.notice }
 
+// SetNotice puts a transient user-facing message in the status bar — used by an add-in to
+// surface state the user can't otherwise see (e.g. a collaboration add-in's connection
+// status). Cleared on the next user input, like any notice.
+func (s *Session) SetNotice(msg string) { s.notice = msg }
+
 // VisualStyle returns the active scene visual style (default Shaded with Edges).
 func (s *Session) VisualStyle() renderer.VisualStyle { return s.visualStyle }
 


### PR DESCRIPTION
Host side of `oblikovati/api`'s new `interaction.setNotice`: a `Session.SetNotice` setter + an `addin/router` handler. The status bar already renders `Session.Notice()`; this lets an add-in (the meeting add-in) post connection status there. Router test included. 🤖 Generated with [Claude Code](https://claude.com/claude-code)