### PR TITLE
feat(commands): render toggle-button state (active accent + relabel)

### DIFF
--- a/addin/router/commands.go
+++ b/addin/router/commands.go
@@ -54,6 +54,27 @@ func createCommand(s *app.Session, args json.RawMessage) (json.RawMessage, error
 	return ok()
 }
 
+// setCommandState updates one of an add-in's commands' live ribbon state: its active
+// (highlighted/accent) flag and an optional relabel (wire.MethodCommandsSetState).
+func setCommandState(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetCommandStateArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if in.ID == "" {
+		return nil, errors.New("commands.setState: id is required")
+	}
+	cmd, found := s.Commands().ByID(in.ID)
+	if !found {
+		return nil, fmt.Errorf("commands.setState: unknown command %q", in.ID)
+	}
+	cmd.SetActiveState(in.Active)
+	if in.DisplayName != "" {
+		cmd.SetDisplayName(in.DisplayName)
+	}
+	return ok()
+}
+
 // executeCommand runs the command with the given id (the same path a ribbon click
 // takes), surfacing a disabled/unknown command as an error.
 func executeCommand(s *app.Session, args json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/ribbon_test.go
+++ b/addin/router/ribbon_test.go
@@ -109,3 +109,31 @@ func TestCommandsListReportsRibbonAndEnvironment(t *testing.T) {
 		t.Errorf("Sketch.Line = %+v, want sketch environment", line)
 	}
 }
+
+// TestSetCommandState checks an add-in can toggle its command's active flag and relabel it
+// (the meeting add-in's Presenter/Follow toggles) via commands.setState.
+func TestSetCommandState(t *testing.T) {
+	s := app.NewSession()
+	r := New(opregistry.Default())
+	call(t, r, s, "commands.create",
+		`{"id":"acme.toggle","displayName":"Toggle","ribbon":"Part","tab":"Add-Ins","category":"Acme"}`, nil)
+	call(t, r, s, "commands.setState", `{"id":"acme.toggle","active":true,"displayName":"On"}`, nil)
+
+	cmd, ok := s.Commands().ByID("acme.toggle")
+	if !ok {
+		t.Fatal("acme.toggle should exist")
+	}
+	if !cmd.IsActive(s) {
+		t.Error("setState active=true should make IsActive true")
+	}
+	if cmd.DisplayName() != "On" {
+		t.Errorf("displayName = %q, want On", cmd.DisplayName())
+	}
+	call(t, r, s, "commands.setState", `{"id":"acme.toggle","active":false}`, nil)
+	if cmd.IsActive(s) {
+		t.Error("setState active=false should clear IsActive")
+	}
+	if cmd.DisplayName() != "On" {
+		t.Errorf("empty displayName should keep the label, got %q", cmd.DisplayName())
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -183,6 +183,7 @@ func (r *Router) registerCommandHandlers() {
 	r.handlers[wire.MethodCommandsList] = listCommands
 	r.handlers[wire.MethodCommandsExecute] = executeCommand
 	r.handlers[wire.MethodCommandsCreate] = createCommand
+	r.handlers[wire.MethodCommandsSetState] = setCommandState
 	r.handlers[wire.MethodRibbonList] = ribbonList
 }
 

--- a/app/command.go
+++ b/app/command.go
@@ -52,6 +52,8 @@ type CommandDefinition struct {
 	environment Environment // ribbon environment; BaseEnvironment ⇒ always shown
 	enabled     func(*Session) bool
 	active      func(*Session) bool // for a ComboControl option: is this the current selection?
+	forcedActive    bool            // runtime active flag (commands.setState); see hasForcedActive
+	hasForcedActive bool            // true ⇒ forcedActive overrides the active predicate
 	run         func(*Session) error
 	variants    []*CommandDefinition // split-button dropdown entries (Inventor's variant flyout)
 	isVariant   bool                 // true ⇒ reachable only via a head command's dropdown, never its own panel button
@@ -137,10 +139,25 @@ func (c *CommandDefinition) WithActive(p func(*Session) bool) *CommandDefinition
 	return c
 }
 
-// IsActive reports whether this command is its combo group's current selection.
+// IsActive reports whether this command renders as active/selected: a runtime flag set via
+// SetActiveState (an add-in's commands.setState) wins, else the WithActive predicate.
 func (c *CommandDefinition) IsActive(s *Session) bool {
+	if c.hasForcedActive {
+		return c.forcedActive
+	}
 	return c.active != nil && c.active(s)
 }
+
+// SetActiveState sets the runtime active flag (overriding any WithActive predicate) so an
+// add-in can toggle a stateful button's highlighted look via commands.setState.
+func (c *CommandDefinition) SetActiveState(active bool) {
+	c.forcedActive = active
+	c.hasForcedActive = true
+}
+
+// SetDisplayName relabels the command at runtime (commands.setState), e.g. a toggle button
+// switching between "Presenter" and "Presenting".
+func (c *CommandDefinition) SetDisplayName(name string) { c.displayName = name }
 
 // Ribbons returns the ribbons the command appears on, resolving the default (the Part ribbon)
 // so a caller always sees the effective placement. The slice is a copy.

--- a/app/ribbon.go
+++ b/app/ribbon.go
@@ -31,6 +31,7 @@ const (
 type RibbonButton struct {
 	Command  *CommandDefinition
 	Enabled  bool
+	Active   bool // renders highlighted (accent) — a stateful toggle that is currently on
 	Variants []RibbonVariant
 }
 
@@ -95,7 +96,7 @@ func BuildRibbon(s *Session) Ribbon {
 			continue
 		}
 		if c.appearsOnRibbon(key) && environmentShows(c.environment, env) {
-			b.add(RibbonButton{Command: c, Enabled: c.IsEnabled(s), Variants: resolveVariants(c, s)})
+			b.add(RibbonButton{Command: c, Enabled: c.IsEnabled(s), Active: c.IsActive(s), Variants: resolveVariants(c, s)})
 		}
 	}
 	finalizeSelectors(b.tabs, s)

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -96,6 +96,8 @@ int  obk_ig_is_item_deactivated_after_edit(void);
 // color_edit4 is the swatch+picker editing a 4-float RGBA in place (1 on change).
 // begin_combo/end_combo bracket the theme selector dropdown.
 void obk_ig_set_style_color(const char* name, float r, float g, float b, float a);
+void obk_ig_push_style_color(const char* name, float r, float g, float b, float a);
+void obk_ig_pop_style_color(int n);
 int  obk_ig_color_edit4(const char* label, float* rgba);
 void obk_ig_draw_line(float x1, float y1, float x2, float y2, float r, float g, float b, float a, float thickness);
 void obk_ig_draw_triangle_filled(float x1, float y1, float x2, float y2, float x3, float y3, float r, float g, float b, float a);
@@ -257,6 +259,18 @@ func SetStyleColor(name string, c [4]float32) {
 	defer free()
 	C.obk_ig_set_style_color(cn, C.float(c[0]), C.float(c[1]), C.float(c[2]), C.float(c[3]))
 }
+
+// PushStyleColor overrides one Dear ImGui style color (by ImGui name, e.g. "Button") for
+// the widgets drawn until the matching PopStyleColor — so a single control can render in,
+// say, the accent color without disturbing the global theme. Pair every push with a pop.
+func PushStyleColor(name string, c [4]float32) {
+	cn, free := cstr(name)
+	defer free()
+	C.obk_ig_push_style_color(cn, C.float(c[0]), C.float(c[1]), C.float(c[2]), C.float(c[3]))
+}
+
+// PopStyleColor undoes the last n PushStyleColor calls.
+func PopStyleColor(n int) { C.obk_ig_pop_style_color(C.int(n)) }
 
 // ColorEdit4 draws a color swatch that opens a picker, editing the RGBA in place and
 // returning true on the frame the color changed — the per-token control in the

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -144,6 +144,15 @@ void obk_ig_set_style_color(const char* name, float r, float g, float b, float a
     ImGui::GetStyle().Colors[idx] = ImVec4(r, g, b, a);
 }
 
+// Scoped color override: pushes onto ImGui's style stack until obk_ig_pop_style_color.
+void obk_ig_push_style_color(const char* name, float r, float g, float b, float a) {
+    int idx = obk_col_index(name);
+    if (idx < 0) return;
+    ImGui::PushStyleColor((ImGuiCol)idx, ImVec4(r, g, b, a));
+}
+
+void obk_ig_pop_style_color(int n) { ImGui::PopStyleColor(n); }
+
 int  obk_ig_color_edit4(const char* label, float* rgba) {
     return ImGui::ColorEdit4(label, rgba) ? 1 : 0;
 }

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -192,6 +192,12 @@ func drawVariantDropdown(btn app.RibbonButton) string {
 // when its glyph texture is unavailable (missing asset or upload failure), so a missing
 // icon never hides the command.
 func drawButtonControl(btn app.RibbonButton) bool {
+	if btn.Active { // a toggled-on stateful control renders in the accent color
+		native.PushStyleColor("Button", accentColor)
+		native.PushStyleColor("ButtonHovered", accentColor)
+		native.PushStyleColor("ButtonActive", accentColor)
+		defer native.PopStyleColor(3)
+	}
 	if px, ok := iconSizeFor(btn.Command.ButtonStyle()); ok {
 		if tex, ok := icons.texture(btn.Command.Icon(), px); ok {
 			return drawIconButton(btn, tex, float32(px))

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -29,6 +29,7 @@ var (
 	planeFillColor                                         [4]float32 // translucent plane fill (alpha = opacity)
 	selectionHighlight                                     [4]float32 // picked-body highlight
 	iconTint                                               [4]float32 // ribbon glyph tint
+	accentColor                                            [4]float32 // active/toggled ribbon button
 	windowClearColor                                       [3]float32 // swapchain (chrome) clear
 )
 
@@ -65,6 +66,7 @@ func refreshThemeColors(t contract.Theme) {
 	refreshPlaneThemeColors(arr)
 	selectionHighlight = arr(types.TokenSelectionHighlight)
 	iconTint = arr(types.TokenIconTint)
+	accentColor = arr(types.TokenChromeAccent)
 	c := t.Color(types.TokenChromeWindowBg)
 	windowClearColor = [3]float32{c.R, c.G, c.B}
 }


### PR DESCRIPTION
Host side of `commands.setState`: a runtime active flag + relabel on `CommandDefinition`, an `addin/router` handler, and ribbon rendering of the active state in the accent color (new native `PushStyleColor`/`PopStyleColor` scoped bindings + a themed `accentColor`). Drives the meeting add-in's Presenter/Follow toggles. 🤖 Generated with [Claude Code](https://claude.com/claude-code)