### PR TITLE
feat(commands): honor setState enabled override

### DIFF
--- a/addin/router/commands.go
+++ b/addin/router/commands.go
@@ -69,6 +69,9 @@ func setCommandState(s *app.Session, args json.RawMessage) (json.RawMessage, err
 		return nil, fmt.Errorf("commands.setState: unknown command %q", in.ID)
 	}
 	cmd.SetActiveState(in.Active)
+	if in.Enabled != nil {
+		cmd.SetEnabledState(*in.Enabled)
+	}
 	if in.DisplayName != "" {
 		cmd.SetDisplayName(in.DisplayName)
 	}

--- a/addin/router/ribbon_test.go
+++ b/addin/router/ribbon_test.go
@@ -136,4 +136,17 @@ func TestSetCommandState(t *testing.T) {
 	if cmd.DisplayName() != "On" {
 		t.Errorf("empty displayName should keep the label, got %q", cmd.DisplayName())
 	}
+
+	// enabled is an optional override: present ⇒ applied, absent ⇒ unchanged.
+	if !cmd.IsEnabled(s) {
+		t.Fatal("command should start enabled")
+	}
+	call(t, r, s, "commands.setState", `{"id":"acme.toggle","active":false,"enabled":false}`, nil)
+	if cmd.IsEnabled(s) {
+		t.Error("setState enabled=false should disable the command")
+	}
+	call(t, r, s, "commands.setState", `{"id":"acme.toggle","active":false,"enabled":true}`, nil)
+	if !cmd.IsEnabled(s) {
+		t.Error("setState enabled=true should re-enable the command")
+	}
 }

--- a/app/command.go
+++ b/app/command.go
@@ -52,8 +52,10 @@ type CommandDefinition struct {
 	environment Environment // ribbon environment; BaseEnvironment ⇒ always shown
 	enabled     func(*Session) bool
 	active      func(*Session) bool // for a ComboControl option: is this the current selection?
-	forcedActive    bool            // runtime active flag (commands.setState); see hasForcedActive
-	hasForcedActive bool            // true ⇒ forcedActive overrides the active predicate
+	forcedActive     bool           // runtime active flag (commands.setState); see hasForcedActive
+	hasForcedActive  bool           // true ⇒ forcedActive overrides the active predicate
+	forcedEnabled    bool           // runtime enabled flag (commands.setState); see hasForcedEnabled
+	hasForcedEnabled bool           // true ⇒ forcedEnabled overrides the enabled predicate
 	run         func(*Session) error
 	variants    []*CommandDefinition // split-button dropdown entries (Inventor's variant flyout)
 	isVariant   bool                 // true ⇒ reachable only via a head command's dropdown, never its own panel button
@@ -197,7 +199,18 @@ func (c *CommandDefinition) Environment() Environment { return c.environment }
 // IsEnabled reports whether the command may run in the given session (predicate true
 // or absent).
 func (c *CommandDefinition) IsEnabled(s *Session) bool {
+	if c.hasForcedEnabled {
+		return c.forcedEnabled
+	}
 	return c.enabled == nil || c.enabled(s)
+}
+
+// SetEnabledState sets a runtime enabled flag (overriding any WithEnabled predicate) so an
+// add-in can grey out or restore its commands via commands.setState — e.g. disabling its
+// presenter/follow controls until the user joins a session.
+func (c *CommandDefinition) SetEnabledState(enabled bool) {
+	c.forcedEnabled = enabled
+	c.hasForcedEnabled = true
 }
 
 // CommandManager is the registry of command definitions — Inventor's CommandManager


### PR DESCRIPTION
Host side of the optional `Enabled` on `commands.setState`: a runtime enabled flag on `CommandDefinition` + the router applying it. Lets an add-in grey out its controls (the meeting add-in disables Presenter/Follow/Bring until a Join). 🤖 Generated with [Claude Code](https://claude.com/claude-code)