### PR TITLE
feat(script): Script Console GUI (Lua scripting Phase 2)

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -39,26 +39,26 @@ const (
 // CommandManager entry. Its Run is invoked when the button is clicked or the alias is
 // typed; Enabled greys it out. State lives in the [Session] it acts on, not here.
 type CommandDefinition struct {
-	id          string
-	displayName string
-	tab         string // ribbon tab (e.g. "3D Model"); empty ⇒ the default "Tools" tab
-	category    string // ribbon panel within the tab (e.g. "Create")
-	kind        ControlKind
-	alias       string // typed command alias (e.g. "E" → Extrude), Inventor-style
-	tooltip     string
-	iconKey     string      // icon asset key (e.g. "extrude"); empty ⇒ no icon
-	buttonStyle ButtonStyle // ribbon render style; zero value ⇒ text-only
-	ribbons     []RibbonKey // ribbons this command appears on; empty ⇒ the Part ribbon
-	environment Environment // ribbon environment; BaseEnvironment ⇒ always shown
-	enabled     func(*Session) bool
-	active      func(*Session) bool // for a ComboControl option: is this the current selection?
-	forcedActive     bool           // runtime active flag (commands.setState); see hasForcedActive
-	hasForcedActive  bool           // true ⇒ forcedActive overrides the active predicate
-	forcedEnabled    bool           // runtime enabled flag (commands.setState); see hasForcedEnabled
-	hasForcedEnabled bool           // true ⇒ forcedEnabled overrides the enabled predicate
-	run         func(*Session) error
-	variants    []*CommandDefinition // split-button dropdown entries (Inventor's variant flyout)
-	isVariant   bool                 // true ⇒ reachable only via a head command's dropdown, never its own panel button
+	id               string
+	displayName      string
+	tab              string // ribbon tab (e.g. "3D Model"); empty ⇒ the default "Tools" tab
+	category         string // ribbon panel within the tab (e.g. "Create")
+	kind             ControlKind
+	alias            string // typed command alias (e.g. "E" → Extrude), Inventor-style
+	tooltip          string
+	iconKey          string      // icon asset key (e.g. "extrude"); empty ⇒ no icon
+	buttonStyle      ButtonStyle // ribbon render style; zero value ⇒ text-only
+	ribbons          []RibbonKey // ribbons this command appears on; empty ⇒ the Part ribbon
+	environment      Environment // ribbon environment; BaseEnvironment ⇒ always shown
+	enabled          func(*Session) bool
+	active           func(*Session) bool // for a ComboControl option: is this the current selection?
+	forcedActive     bool                // runtime active flag (commands.setState); see hasForcedActive
+	hasForcedActive  bool                // true ⇒ forcedActive overrides the active predicate
+	forcedEnabled    bool                // runtime enabled flag (commands.setState); see hasForcedEnabled
+	hasForcedEnabled bool                // true ⇒ forcedEnabled overrides the enabled predicate
+	run              func(*Session) error
+	variants         []*CommandDefinition // split-button dropdown entries (Inventor's variant flyout)
+	isVariant        bool                 // true ⇒ reachable only via a head command's dropdown, never its own panel button
 }
 
 // NewCommand starts a command definition with the required fields. Use the With*

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -55,8 +55,9 @@ func getStartedCommands() []*CommandDefinition {
 	}
 }
 
-// manageTabCommands are the Manage tab's Parameters panel: open the Parameters dialog
-// (Inventor's Manage ▸ Parameters). Enabled whenever a part is active.
+// manageTabCommands are the Manage tab: the Parameters panel (Inventor's Manage ▸
+// Parameters, needs an active part) and the Scripts panel (the Script Console — our
+// equivalent of Manage ▸ iLogic, ADR-0028).
 func manageTabCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		NewCommand("Manage.Parameters", "Parameters", "Parameters", func(s *Session) error {
@@ -65,6 +66,7 @@ func manageTabCommands() []*CommandDefinition {
 		}).WithTab("Manage").WithEnable(hasActivePart).
 			WithIcon("parameters").WithButtonStyle(LargeIconButton).
 			WithTooltip("Parameters — add, edit, and organize the model and user parameters that drive the part."),
+		scriptConsoleCommand(),
 	}
 }
 

--- a/app/scripting.go
+++ b/app/scripting.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// scripting.go owns the session-side state of the Script Console panel and its ribbon
+// command. The runtime (the Lua engine + dispatched caller) lives in the head, which
+// reads ScriptConsoleOpen() each frame to decide whether to render the panel — the same
+// open-flag pattern the Lighting/Parameters panels use. See ADR-0028 / lua-scripting-plan.
+
+// OpenScriptConsole / CloseScriptConsole / ScriptConsoleOpen drive the Script Console panel.
+func (s *Session) OpenScriptConsole()      { s.scriptConsoleOpen = true }
+func (s *Session) CloseScriptConsole()     { s.scriptConsoleOpen = false }
+func (s *Session) ScriptConsoleOpen() bool { return s.scriptConsoleOpen }
+
+// ToggleScriptConsole flips the panel open/closed (the ribbon button's action).
+func (s *Session) ToggleScriptConsole() { s.scriptConsoleOpen = !s.scriptConsoleOpen }
+
+// scriptConsoleCommand is the Manage tab's "Script Console" button (our equivalent of
+// Inventor's Manage ▸ iLogic): it toggles the console panel that runs a sandboxed Lua
+// script against the live model through the public wire API (ADR-0028). Always enabled —
+// a script can create a document, so it is useful even with nothing open.
+func scriptConsoleCommand() *CommandDefinition {
+	return NewCommand("Manage.ScriptConsole", "Script Console", "Scripts", func(s *Session) error {
+		s.ToggleScriptConsole()
+		return nil
+	}).WithTab("Manage").
+		WithIcon("script-console").WithButtonStyle(LargeIconButton).
+		WithActive(func(s *Session) bool { return s.ScriptConsoleOpen() }).
+		WithTooltip("Script Console — run a sandboxed Lua script that drives the model through the public API.")
+}

--- a/app/scripting_test.go
+++ b/app/scripting_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestScriptConsoleCommandToggles checks the Manage ▸ Script Console command opens and
+// closes the console panel and reports its open state (drives the head panel each frame).
+func TestScriptConsoleCommandToggles(t *testing.T) {
+	s := registeredSession(t)
+	if s.ScriptConsoleOpen() {
+		t.Fatal("console should start closed")
+	}
+	if err := s.Execute("Manage.ScriptConsole"); err != nil {
+		t.Fatalf("execute Manage.ScriptConsole: %v", err)
+	}
+	cmd, _ := s.Commands().ByID("Manage.ScriptConsole")
+	if !s.ScriptConsoleOpen() || !cmd.IsActive(s) {
+		t.Errorf("console should be open and command active after toggle")
+	}
+	if err := s.Execute("Manage.ScriptConsole"); err != nil {
+		t.Fatalf("re-toggle: %v", err)
+	}
+	if s.ScriptConsoleOpen() {
+		t.Errorf("console should be closed after second toggle")
+	}
+}
+
+// TestScriptConsoleOnManageTab checks the Script Console lands on the Manage tab's Scripts
+// panel (the ribbon exposes the control).
+func TestScriptConsoleOnManageTab(t *testing.T) {
+	s := registeredSession(t)
+	tab, ok := BuildRibbon(s).Tab("Manage")
+	if !ok {
+		t.Fatal("no Manage tab")
+	}
+	if _, ok := tab.Panel("Scripts"); !ok {
+		t.Errorf("Manage tab missing the Scripts panel")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -60,6 +60,7 @@ type Session struct {
 	paramsDialogOpen   bool                     // the Manage ▸ Parameters dialog is open
 	lightingPanelOpen  bool                     // the View ▸ Lighting settings panel is open
 	loadEnvRequested   bool                     // a "Load HDR…" was requested; the head opens the file dialog
+	scriptConsoleOpen  bool                     // the Manage ▸ Scripts ▸ Script Console panel is open
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,10 @@ import (
 	"oblikovati/app"
 	"oblikovati/event"
 	"oblikovati/head/internal/addinhost"
+	"oblikovati/script/bridge"
+	"oblikovati/script/console"
+	"oblikovati/script/gopherlua"
+	"oblikovati/script/runner"
 )
 
 // addInDrainPerFrame bounds how many queued add-in calls run per frame, so a burst
@@ -33,9 +38,10 @@ type addInHost struct {
 	dispatcher *dispatch.Dispatcher
 	loaded     []*addinhost.LoadedAddIn
 	subs       []event.Subscription
-	dir        string        // watched add-ins directory
-	watchDone  chan struct{} // closed by stop() to end the watcher goroutine
-	changed    int32         // set by the watcher when a library is replaced on disk
+	dir        string              // watched add-ins directory
+	watchDone  chan struct{}       // closed by stop() to end the watcher goroutine
+	changed    int32               // set by the watcher when a library is replaced on disk
+	script     *console.Controller // the Script Console runtime (Lua over the dispatched router)
 }
 
 // startAddIns wires the add-in subsystem: it installs the router as the host call
@@ -55,6 +61,9 @@ func startAddIns(session *app.Session) *addInHost {
 
 	dir := addInsDir()
 	h := &addInHost{dispatcher: d, dir: dir, watchDone: make(chan struct{})}
+	// The Script Console runs Lua over the SAME router + dispatcher add-ins use, so its
+	// host calls serialize onto the session goroutine and never freeze the UI (ADR-0028 §5).
+	h.script = newScriptController(rtr, session, d)
 	libs, err := addinhost.LoadDir(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "add-ins: %v\n", err)
@@ -75,6 +84,16 @@ func startAddIns(session *app.Session) *addInHost {
 		go h.watchAddIns()
 	}
 	return h
+}
+
+// newScriptController builds the Script Console runtime: a gopher-lua engine whose host
+// calls are marshalled onto the session goroutine via the dispatched caller (the same
+// dispatcher the frame loop drains), under the GUI resource limits. oblikovati.methods()
+// is backed by the router's registered method list for discoverability (ADR-0028).
+func newScriptController(rtr *router.Router, session *app.Session, d *dispatch.Dispatcher) *console.Controller {
+	caller := bridge.NewDispatchedCaller(rtr.Handle, session, d, context.Background())
+	run := runner.New(gopherlua.New(), caller, rtr.Methods)
+	return console.NewController(run, runner.DefaultGUILimits)
 }
 
 // activate registers and activates one loaded add-in.

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -57,6 +57,7 @@ func run(session *app.Session, maxFrames int) error {
 	// safely while the window stays responsive.
 	addins := startAddIns(session)
 	defer addins.stop(session)
+	ui.SetScriptController(addins.script) // the Manage ▸ Script Console panel drives this runtime
 
 	for frame := 0; ; frame++ {
 		if maxFrames > 0 && frame >= maxFrames {

--- a/head/go.mod
+++ b/head/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
 	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/head/go.sum
+++ b/head/go.sum
@@ -2,13 +2,15 @@ github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c h1:km8GpoQut05eY3GiY
 github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c/go.mod h1:cNQ3dwVJtS5Hmnjxy6AgTPd0Inb3pW05ftPSX7NZO7Q=
 github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef h1:Ch6Q+AZUxDBCVqdkI8FSpFyZDtCVBc2VmejdNrm5rRQ=
 github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef/go.mod h1:nXTWP6+gD5+LUJ8krVhhoeHjvHTutPxMYl5SvkcnJNE=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/head/icon/assets/script-console.svg
+++ b/head/icon/assets/script-console.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 8 H21"/><path d="M7 12 L9.5 14 L7 16"/><path d="M12.5 16 H17"/></svg>

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -46,6 +46,9 @@ int  obk_ig_input_float(const char* label, float* v);
 int  obk_ig_input_double(const char* label, double* v);
 int  obk_ig_input_int(const char* label, int* v);
 int  obk_ig_input_text(const char* label, char* buf, int buf_size);
+int  obk_ig_input_text_multiline(const char* label, char* buf, int buf_size, float w, float h);
+int  obk_ig_begin_child(const char* id, float w, float h, int border);
+void obk_ig_end_child(void);
 int  obk_ig_checkbox(const char* label, int* v);
 int  obk_ig_slider_float(const char* label, float* v, float lo, float hi);
 void obk_ig_begin_disabled(int disabled);
@@ -228,6 +231,30 @@ func InputText(label string, buf []byte) bool {
 	defer free()
 	return C.obk_ig_input_text(c, (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))) != 0
 }
+
+// InputTextMultiline draws a multi-line text editor over buf (NUL-terminated, edited in
+// place up to len(buf)-1 bytes) sized w×h logical pixels (0 ⇒ fill the available content
+// region). Returns true on the frame buf changed. The Script Console source pane uses it.
+func InputTextMultiline(label string, buf []byte, w, h float32) bool {
+	if len(buf) == 0 {
+		return false
+	}
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_input_text_multiline(c, (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf)), C.float(w), C.float(h)) != 0
+}
+
+// BeginChild opens a scrollable child region id sized w×h (0 ⇒ fill the remaining space);
+// border draws a frame. Always pair with EndChild even when it returns false — ImGui
+// requires the matching call regardless (used for the console's output pane).
+func BeginChild(id string, w, h float32, border bool) bool {
+	c, free := cstr(id)
+	defer free()
+	return C.obk_ig_begin_child(c, C.float(w), C.float(h), cBool(border)) != 0
+}
+
+// EndChild closes the region opened by BeginChild.
+func EndChild() { C.obk_ig_end_child() }
 
 // Checkbox draws a checkbox; returns true (and writes *v) when toggled.
 func Checkbox(label string, v *bool) bool {

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -93,6 +93,13 @@ int  obk_ig_input_float(const char* label, float* v) { return ImGui::InputFloat(
 int  obk_ig_input_double(const char* label, double* v) { return ImGui::InputDouble(label, v) ? 1 : 0; }
 int  obk_ig_input_int(const char* label, int* v)     { return ImGui::InputInt(label, v) ? 1 : 0; }
 int  obk_ig_input_text(const char* label, char* buf, int buf_size) { return ImGui::InputText(label, buf, (size_t)buf_size) ? 1 : 0; }
+int  obk_ig_input_text_multiline(const char* label, char* buf, int buf_size, float w, float h) {
+    return ImGui::InputTextMultiline(label, buf, (size_t)buf_size, ImVec2(w, h)) ? 1 : 0;
+}
+int  obk_ig_begin_child(const char* id, float w, float h, int border) {
+    return ImGui::BeginChild(id, ImVec2(w, h), border ? ImGuiChildFlags_Borders : 0) ? 1 : 0;
+}
+void obk_ig_end_child(void) { ImGui::EndChild(); }
 int  obk_ig_checkbox(const char* label, int* v) {
     bool b = (*v != 0);
     bool changed = ImGui::Checkbox(label, &b);

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -103,6 +103,7 @@ func drawChromeWindows(s *app.Session) {
 	drawPreferencesWindow(s)
 	drawMaterialsWindow(s)
 	drawLightingWindow(s)
+	drawScriptConsole(s)
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}

--- a/head/ui/script_console.go
+++ b/head/ui/script_console.go
@@ -1,0 +1,110 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"time"
+
+	"oblikovati/app"
+	"oblikovati/head/internal/native"
+	"oblikovati/script/console"
+)
+
+// scriptController is the head's live Script Console runtime (engine + dispatched caller),
+// injected by main once the add-in host's router + dispatcher are wired. It stays nil in
+// the headless UI tests and before injection, so the panel degrades to an inert message
+// rather than crashing.
+var scriptController *console.Controller
+
+// scriptSourceBuf is the editable Lua source the console edits in place. 64 KiB is ample
+// for an interactive console script; it persists across frames so the editor keeps text.
+var scriptSourceBuf = make([]byte, 64<<10)
+
+// editorHeight is the fixed height (logical px) of the source pane; the output pane below
+// fills the remaining window height.
+const editorHeight = 260
+
+// SetScriptController injects the console runtime. Called once at head startup, after the
+// add-in host (and thus the dispatcher the script's host calls hop through) exists.
+func SetScriptController(c *console.Controller) { scriptController = c }
+
+// drawScriptConsole renders the Manage ▸ Script Console panel when open: a Lua source
+// editor, Run/Stop/Clear controls, a streamed output pane, and the last run's status. The
+// run executes off the UI thread (the Controller), so a looping script never freezes the
+// frame loop (ADR-0028 §5).
+func drawScriptConsole(s *app.Session) {
+	if !s.ScriptConsoleOpen() {
+		return
+	}
+	native.SetNextWindowSizeOnce(640, 560)
+	if native.Begin("Script Console") {
+		drawScriptConsoleBody()
+	}
+	native.End()
+}
+
+// drawScriptConsoleBody renders the console contents once the window is open.
+func drawScriptConsoleBody() {
+	if scriptController == nil {
+		native.Text("Script runtime unavailable.")
+		return
+	}
+	snap := scriptController.Console().Snapshot()
+	drawScriptToolbar(snap.Running)
+	native.InputTextMultiline("##script-source", scriptSourceBuf, 0, editorHeight)
+	native.Separator()
+	drawScriptStatus(snap)
+	drawScriptOutput(snap)
+}
+
+// drawScriptToolbar renders Run (disabled mid-run), Stop (disabled when idle), and Clear.
+func drawScriptToolbar(running bool) {
+	native.BeginDisabled(running)
+	if native.Button("Run") {
+		_ = scriptController.Run(bufString(scriptSourceBuf))
+	}
+	native.EndDisabled()
+	native.SameLine()
+	native.BeginDisabled(!running)
+	if native.Button("Stop") {
+		scriptController.Stop()
+	}
+	native.EndDisabled()
+	native.SameLine()
+	if native.Button("Clear") {
+		scriptController.Console().Clear()
+	}
+}
+
+// drawScriptStatus shows whether a run is in flight or how the last one ended.
+func drawScriptStatus(snap console.Snapshot) {
+	switch {
+	case snap.Running:
+		native.Text("Running…")
+	case !snap.HasLast:
+		native.Text("Ready.")
+	case snap.Last.Err != nil:
+		native.Text("Error: " + snap.Last.Err.Error())
+	default:
+		native.Text(fmt.Sprintf("Done in %s.", snap.Last.Duration.Round(time.Millisecond)))
+	}
+}
+
+// drawScriptOutput renders the captured print() output in a scrollable pane that follows
+// the tail as new lines arrive.
+func drawScriptOutput(snap console.Snapshot) {
+	if !native.BeginChild("##script-output", 0, 0, true) {
+		native.EndChild()
+		return
+	}
+	for _, line := range snap.Output {
+		native.Text(line)
+	}
+	if snap.Running {
+		native.SetScrollHereY()
+	}
+	native.EndChild()
+}

--- a/head/ui/script_console_test.go
+++ b/head/ui/script_console_test.go
@@ -1,0 +1,95 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"oblikovati/addin/opregistry"
+	"oblikovati/addin/router"
+	"oblikovati/script"
+	"oblikovati/script/bridge"
+	"oblikovati/script/console"
+	"oblikovati/script/gopherlua"
+	"oblikovati/script/runner"
+)
+
+// directConsoleController builds a Script Console controller over a synchronous in-proc
+// caller (no dispatcher needed in a test) against a fresh session+router, so a run drives
+// the real Lua engine + wire surface.
+func directConsoleController() *console.Controller {
+	s := framedSession()
+	rtr := router.New(opregistry.Default())
+	caller := bridge.NewDirectCaller(rtr.Handle, s)
+	run := runner.New(gopherlua.New(), caller, rtr.Methods)
+	return console.NewController(run, script.Limits{Wall: 5 * time.Second})
+}
+
+// TestInWindowScriptConsoleRendersAndRuns opens the real window with the Script Console
+// visible and renders frames — so a mismatched ImGui Begin/End in the editor, output child,
+// or disabled toolbar (the new InputTextMultiline/BeginChild verbs) would trip Dear ImGui's
+// assertions. It then runs a script through the injected controller and asserts the streamed
+// print() output reaches the panel's snapshot.
+func TestInWindowScriptConsoleRendersAndRuns(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+
+	ctrl := directConsoleController()
+	SetScriptController(ctrl)
+	defer SetScriptController(nil)
+	s.OpenScriptConsole()
+	defer s.CloseScriptConsole()
+
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	// A couple of frames so the console window appears and its panes render.
+	frame()
+	frame()
+
+	if err := ctrl.Run(`print("hello from lua"); print(#oblikovati.methods() > 0)`); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for ctrl.Console().Running() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	// Render a few more frames so the output pane draws the streamed lines.
+	frame()
+	frame()
+
+	snap := ctrl.Console().Snapshot()
+	if !snap.HasLast || snap.Last.Err != nil {
+		t.Fatalf("script run failed: %+v", snap.Last)
+	}
+	if len(snap.Output) == 0 || snap.Output[0] != "hello from lua" {
+		t.Fatalf("console output = %v, want it to start with the printed line", snap.Output)
+	}
+}
+
+// TestInWindowScriptConsoleWithoutControllerIsInert: with no runtime injected (the headless
+// default), the open console renders an inert message instead of crashing.
+func TestInWindowScriptConsoleWithoutControllerIsInert(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	SetScriptController(nil)
+	s := framedSession()
+	s.OpenScriptConsole()
+	defer s.CloseScriptConsole()
+
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}

--- a/script/console/console.go
+++ b/script/console/console.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package console holds the UI-agnostic state of the Script Console (ADR-0028 §8,
+// lua-scripting-plan §3) and the Controller that runs a Lua source against the host
+// without blocking the caller. The state is mutex-guarded so the engine's print
+// callback (which fires on the script worker goroutine) and the UI render thread can
+// touch it safely; the head panel only ever reads a Snapshot and calls the Controller.
+//
+// Splitting the state + run orchestration out of the head keeps it pure Go and
+// headless-testable: the cgo ImGui panel becomes a thin renderer over this core.
+package console
+
+import (
+	"sync"
+
+	"oblikovati/script"
+)
+
+// maxOutputLines caps the retained output so a chatty or runaway script (which the
+// quota/timeout still stops) cannot grow the buffer without bound. Oldest lines drop.
+const maxOutputLines = 5000
+
+// Console is the live state of one Script Console: the captured output, whether a run
+// is in flight, and the outcome of the last finished run. It is safe for concurrent
+// use — AppendOutput is driven from the script worker goroutine while the UI reads
+// Snapshot from the render thread.
+type Console struct {
+	mu      sync.Mutex
+	output  []string
+	running bool
+	last    script.Result
+	hasLast bool
+}
+
+// New returns an empty console.
+func New() *Console { return &Console{} }
+
+// Snapshot is an immutable view of the console for one UI frame. Output is a copy, so
+// the renderer can hold it without racing AppendOutput.
+type Snapshot struct {
+	Output  []string      // captured print() lines, oldest first
+	Running bool          // a script is currently executing
+	Last    script.Result // outcome of the most recent finished run
+	HasLast bool          // false until the first run completes
+}
+
+// AppendOutput records one print() line (no trailing newline), dropping the oldest line
+// once the buffer is full. Called from the script worker goroutine via the engine's
+// Print callback.
+func (c *Console) AppendOutput(line string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.output = append(c.output, line)
+	if len(c.output) > maxOutputLines {
+		c.output = c.output[len(c.output)-maxOutputLines:]
+	}
+}
+
+// markRunning sets the in-flight flag; the Controller calls it when a run starts.
+func (c *Console) markRunning() {
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+}
+
+// finish records the run outcome and clears the in-flight flag. The Controller calls it
+// when a run completes (success, error, or cancellation).
+func (c *Console) finish(res script.Result) {
+	c.mu.Lock()
+	c.running = false
+	c.last = res
+	c.hasLast = true
+	c.mu.Unlock()
+}
+
+// Clear empties the output buffer (the console's "clear" action); it leaves the
+// last-result and running state untouched.
+func (c *Console) Clear() {
+	c.mu.Lock()
+	c.output = nil
+	c.mu.Unlock()
+}
+
+// Snapshot returns a consistent copy of the console state for rendering one frame.
+func (c *Console) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.output))
+	copy(out, c.output)
+	return Snapshot{Output: out, Running: c.running, Last: c.last, HasLast: c.hasLast}
+}
+
+// Running reports whether a run is currently in flight (a convenience over Snapshot for
+// the panel's button-enable checks).
+func (c *Console) Running() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.running
+}

--- a/script/console/console_test.go
+++ b/script/console/console_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package console_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"oblikovati/script"
+	"oblikovati/script/console"
+	"oblikovati/script/runner"
+)
+
+// scriptedEngine is a fake script.Engine whose behaviour is the injected fn, so a
+// console test can drive print()/result/blocking/cancellation deterministically without
+// the real Lua VM (no cgo, fast).
+type scriptedEngine struct {
+	fn func(ctx context.Context, g script.Globals) script.Result
+}
+
+func (e *scriptedEngine) Run(ctx context.Context, _ string, g script.Globals, _ script.Limits) script.Result {
+	return e.fn(ctx, g)
+}
+
+// nopCaller is a no-op client.Caller; the console tests never reach the host, so the
+// engine fn just ignores g.Call.
+type nopCaller struct{}
+
+func (nopCaller) Call(string, []byte) ([]byte, error) { return []byte("{}"), nil }
+
+// newTestController builds a Controller over a scripted engine with unbounded limits.
+func newTestController(fn func(ctx context.Context, g script.Globals) script.Result) *console.Controller {
+	r := runner.New(&scriptedEngine{fn: fn}, nopCaller{}, nil)
+	return console.NewController(r, script.Limits{})
+}
+
+// waitUntil polls cond until true or a short deadline (the run is async). FIRST: fast
+// and self-validating.
+func waitUntil(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}
+
+func TestControllerStreamsOutputAndRecordsResult(t *testing.T) {
+	c := newTestController(func(_ context.Context, g script.Globals) script.Result {
+		g.Print("hello")
+		g.Print("world")
+		return script.Result{Stdout: "hello\nworld\n"}
+	})
+	if err := c.Run("print('hi')"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	waitUntil(t, func() bool { return !c.Console().Running() })
+
+	snap := c.Console().Snapshot()
+	if !snap.HasLast || snap.Last.Err != nil {
+		t.Fatalf("expected a successful last result, got %+v", snap)
+	}
+	if len(snap.Output) != 2 || snap.Output[0] != "hello" || snap.Output[1] != "world" {
+		t.Fatalf("output = %v, want [hello world]", snap.Output)
+	}
+}
+
+// TestControllerRejectsConcurrentRun: a second Run while one is in flight is refused
+// with ErrBusy (so the "Run" button stays disabled mid-run).
+func TestControllerRejectsConcurrentRun(t *testing.T) {
+	release := make(chan struct{})
+	started := make(chan struct{})
+	c := newTestController(func(_ context.Context, _ script.Globals) script.Result {
+		close(started)
+		<-release
+		return script.Result{}
+	})
+	if err := c.Run("blocking"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	<-started
+	if err := c.Run("second"); err != runner.ErrBusy {
+		t.Fatalf("second Run error = %v, want ErrBusy", err)
+	}
+	close(release)
+	waitUntil(t, func() bool { return !c.Console().Running() })
+}
+
+// TestControllerStopCancelsRun: Stop cancels the run's context, unwinding a script that
+// waits on ctx, and the cancellation surfaces as the recorded result error.
+func TestControllerStopCancelsRun(t *testing.T) {
+	c := newTestController(func(ctx context.Context, _ script.Globals) script.Result {
+		<-ctx.Done()
+		return script.Result{Err: ctx.Err()}
+	})
+	if err := c.Run("loop"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	waitUntil(t, func() bool { return c.Console().Running() })
+	c.Stop()
+	waitUntil(t, func() bool { return !c.Console().Running() })
+
+	if snap := c.Console().Snapshot(); snap.Last.Err == nil {
+		t.Fatalf("stopped run should record a cancellation error, got %+v", snap.Last)
+	}
+}
+
+func TestConsoleClearEmptiesOutput(t *testing.T) {
+	co := console.New()
+	co.AppendOutput("a")
+	co.AppendOutput("b")
+	co.Clear()
+	if snap := co.Snapshot(); len(snap.Output) != 0 {
+		t.Fatalf("after Clear, output = %v, want empty", snap.Output)
+	}
+}
+
+// TestConsoleSnapshotIsCopy: mutating a returned snapshot must not corrupt the console.
+func TestConsoleSnapshotIsCopy(t *testing.T) {
+	co := console.New()
+	co.AppendOutput("keep")
+	snap := co.Snapshot()
+	snap.Output[0] = "tampered"
+	if got := co.Snapshot().Output[0]; got != "keep" {
+		t.Fatalf("snapshot is not a copy: console output became %q", got)
+	}
+}
+
+// TestConsoleCapsOutput: a flood of lines is bounded — the buffer drops the oldest and
+// keeps the most recent (the runaway-print guard).
+func TestConsoleCapsOutput(t *testing.T) {
+	co := console.New()
+	const flood = 6000
+	for i := 0; i < flood; i++ {
+		co.AppendOutput("line")
+	}
+	co.AppendOutput("last")
+	snap := co.Snapshot()
+	if len(snap.Output) >= flood {
+		t.Fatalf("output not capped: len = %d", len(snap.Output))
+	}
+	if snap.Output[len(snap.Output)-1] != "last" {
+		t.Fatalf("most recent line dropped: tail = %q", snap.Output[len(snap.Output)-1])
+	}
+}

--- a/script/console/controller.go
+++ b/script/console/controller.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package console
+
+import (
+	"context"
+	"sync"
+
+	"oblikovati/script"
+	"oblikovati/script/runner"
+)
+
+// Controller drives one Script Console: it starts a Lua source on a background
+// goroutine (so the UI render thread never blocks), streams print() output into the
+// Console, records the outcome, and lets the user cancel an in-flight run. It owns the
+// run's context so Stop unwinds a looping or long script promptly (ADR-0028 §5, §7).
+type Controller struct {
+	runner  *runner.ScriptRunner
+	console *Console
+	limits  script.Limits
+
+	mu     sync.Mutex
+	cancel context.CancelFunc // non-nil only while a run is in flight
+}
+
+// NewController wires a runner and the resource limits behind a fresh Console. Use
+// runner.DefaultGUILimits for the head so a buggy console script is bounded.
+func NewController(run *runner.ScriptRunner, limits script.Limits) *Controller {
+	return &Controller{runner: run, console: New(), limits: limits}
+}
+
+// Console exposes the live state the UI renders (its Snapshot/Running/Clear).
+func (c *Controller) Console() *Console { return c.console }
+
+// Run starts source on a background goroutine and returns immediately. It returns
+// runner.ErrBusy if a run is already in flight (the "Run" button must stay disabled
+// while running). Output streams to the Console as the script prints; the outcome is
+// recorded when it finishes.
+func (c *Controller) Run(source string) error {
+	c.mu.Lock()
+	if c.cancel != nil {
+		c.mu.Unlock()
+		return runner.ErrBusy
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	c.mu.Unlock()
+
+	c.console.markRunning()
+	go c.execute(ctx, source)
+	return nil
+}
+
+// execute runs the script to completion off the UI thread, recording the result (and
+// surfacing a runner-level error, e.g. ErrBusy, as the Result.Err) before clearing the
+// in-flight context.
+func (c *Controller) execute(ctx context.Context, source string) {
+	res, err := c.runner.Run(ctx, source, c.limits, c.console.AppendOutput)
+	if err != nil {
+		res = script.Result{Err: err}
+	}
+	c.console.finish(res)
+	c.mu.Lock()
+	if c.cancel != nil {
+		c.cancel() // release the context's resources
+		c.cancel = nil
+	}
+	c.mu.Unlock()
+}
+
+// Stop cancels an in-flight run (the console "Stop" button). It is a no-op when idle.
+func (c *Controller) Stop() {
+	c.mu.Lock()
+	cancel := c.cancel
+	c.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}


### PR DESCRIPTION
## What

Adds the **Script Console** — a GUI panel to write and run a sandboxed Lua script
against the live model from the head, the headline of Lua-scripting **Phase 2**
(ADR-0028 §8 / `architecture/lua-scripting-plan.md` §8, §11). Phase 1 (the runtime,
sandbox, generic `oblikovati.call` bridge, and CLI runner) shipped in #75; this
brings the same power to the GUI.

## Why

Phase 1 left scripting CLI-only. A user automating the model (driving parameters,
building sketches/features, batch ops) needs to do it interactively from the app,
with live output and a Stop button — and the project's definition of done is
"feature isn't done until it has a ribbon button + panel + end-to-end UI tests."

## How (three commits)

1. **Headless console core** (`script/console`) — UI-agnostic state (captured
   `print()` output with a bounded ring, in-flight flag, last `Result`, immutable
   `Snapshot`) + a `Controller` that runs a source on a background goroutine (the UI
   never blocks), streams output, rejects a concurrent run with `ErrBusy`, and
   cancels via `Stop`. Fully unit-tested with a scripted fake engine (no Lua VM, no
   cgo).
2. **gofmt** the `CommandDefinition` field alignment left misaligned by the earlier
   `commands.setState` work (whitespace only).
3. **GUI panel** —
   - `app`: a session open-flag + the "Script Console" toggle command on the
     **Manage ▸ Scripts** panel (our equivalent of Inventor's Manage ▸ iLogic),
     mirroring the Lighting panel's open/active pattern; always enabled.
   - `head/ui`: the panel (source editor, Run/Stop/Clear toolbar, streamed output
     pane, last-run status) over the controller snapshot.
   - `head/cmd`: wires the controller over a `DispatchedCaller` on the **same router
     + dispatcher add-ins use**, so a script's host calls serialize onto the session
     goroutine and the frame loop keeps draining (ADR-0028 §5) — a looping script
     can't freeze the UI.
   - `head/native`: new `InputTextMultiline` / `BeginChild` / `EndChild` ImGui verbs.
   - a `script-console` ribbon icon.

## Tests / verification

- `script/console`: streaming, result recording, concurrent-run rejection, Stop
  cancellation, clear, snapshot-copy isolation, output cap.
- `app`: the command toggles the panel + lands on the Manage ▸ Scripts panel.
- `head/ui` (cgo, real window): opens the Vulkan window with the console visible,
  runs a Lua script through an injected controller, and asserts the streamed
  `print()` output reaches the panel (exercising the new multiline/child verbs
  against Dear ImGui's Begin/End assertions); plus an un-injected console degrades
  to an inert message.
- **Live**: verified against the running head via the MCP bridge — `list_commands`
  shows `Manage.ScriptConsole` (Manage tab, Scripts category, enabled) and
  `get_ribbon` shows the Manage tab's Scripts panel with the control.

Contract-first impact: **none** (Phase 1–2 ride the existing `api/wire` surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)