### PR TITLE
feat(script): typed convenience tables (Lua Phase 2 complete)

### DIFF
--- a/architecture/decisions/ADR-0028-embedded-lua-scripting.md
+++ b/architecture/decisions/ADR-0028-embedded-lua-scripting.md
@@ -1,9 +1,9 @@
 # ADR-0028 — Embedded Lua scripting runtime (pure-Go, sandboxed, wire-mirrored)
 
 **Status:** Accepted (2026-06-07) — Phase 1 (runtime + sandbox + generic bridge + CLI)
-shipped in PR #75; the Phase 2 GUI Script Console shipped in PR #82 (typed sugar tables
-still outstanding); Phase 3 (events, persistence, MCP `script.run`) is parked. Per-phase
-status: [lua-scripting-plan.md §11](../lua-scripting-plan.md#11-phased-rollout).
+shipped in PR #75; Phase 2 (GUI Script Console PR #82 + typed convenience tables)
+shipped; Phase 3 (events, persistence, MCP `script.run`) is parked. Per-phase status:
+[lua-scripting-plan.md §11](../lua-scripting-plan.md#11-phased-rollout).
 **Context:** First-party, integral scripting in the GPL-v2 app (not an add-in).
 Implementation plan: [lua-scripting-plan.md](../lua-scripting-plan.md).
 **Builds on / refines:** [ADR-0013](ADR-0013-ilogic-embedded-scripting.md) (embedded

--- a/architecture/lua-scripting-plan.md
+++ b/architecture/lua-scripting-plan.md
@@ -1,8 +1,8 @@
 # Lua Scripting — Implementation Plan
 
-**Status:** Phase 1 shipped (PR #75); Phase 2 in progress — the GUI Script Console
-shipped (PR #82, merged to `develop` 2026-06-07), typed sugar tables outstanding;
-Phase 3 parked. See [§11 Phased rollout](#11-phased-rollout) for the per-phase status.
+**Status:** Phase 1 shipped (PR #75); Phase 2 shipped (GUI Script Console PR #82 +
+typed convenience tables, merged to `develop` 2026-06-07); Phase 3 parked. See
+[§11 Phased rollout](#11-phased-rollout) for the per-phase status.
 **Scope:** Integral, first-party Lua scripting in the GPL-v2 application (`/source`,
 i.e. this `oblikovati` module). **Not** an add-in.
 **Companion ADR:** [ADR-0028 — Embedded Lua scripting runtime](decisions/ADR-0028-embedded-lua-scripting.md)
@@ -381,10 +381,12 @@ backstopped by a **bounded registry / call-stack** for the memory cap.
 future hooked VM — or a swapped `Engine` — would wire a real opcode counter onto;
 `script/gopherlua/quota.go: instructionBudget` is its single anchor point.
 
-**Phase 2 — typed sugar + GUI console. 🔄 IN PROGRESS (the GUI console shipped; typed
-sugar outstanding).** The GUI Script Console shipped in PR #82 (merged to `develop`
-2026-06-07); the typed convenience tables are the remaining Phase-2 item:
-1. ⏳ `oblikovati.documents.*` / typed tables auto-derived from `api/wire` groups.
+**Phase 2 — typed sugar + GUI console. ✅ SHIPPED.** The GUI Script Console shipped in
+PR #82 and the typed convenience tables completed it (both merged to `develop`
+2026-06-07):
+1. ✅ `oblikovati.documents.*` / typed tables auto-derived from `api/wire` method names
+   (`oblikovati.methods()`): each `group.method` becomes `oblikovati.group.method{…}`,
+   thin sugar over `oblikovati.call`, in lockstep with the contract by construction.
 2. ✅ `script/console` state (Console + async Controller) + the head Script Console
    panel (source editor, Run/Stop/Clear, output pane, status) on the **Manage ▸
    Scripts** ribbon panel; Stop/cancel. The panel drives the `DispatchedCaller` over

--- a/script/gopherlua/host.go
+++ b/script/gopherlua/host.go
@@ -49,6 +49,9 @@ func joinPrintArgs(s *lua.LState) string {
 // bridge marshals onto the session goroutine (ADR-0028 §3).
 func installOblikovati(l *lua.LState, g script.Globals) {
 	tb := l.NewTable()
+	// Typed group sugar first, so the reserved call/methods entries below can never be
+	// shadowed by a (hypothetical) method whose group segment is "call" or "methods".
+	installTypedGroups(l, tb, g)
 	l.SetField(tb, "call", l.NewFunction(callBinding(g.Call)))
 	l.SetField(tb, "methods", l.NewFunction(methodsBinding(g.Methods)))
 	l.SetGlobal("oblikovati", tb)
@@ -63,20 +66,77 @@ func callBinding(call script.CallFunc) lua.LGFunction {
 	return func(l *lua.LState) int {
 		method := l.CheckString(1)
 		args := l.OptTable(2, l.NewTable())
-		argsJSON, err := tableToJSON(args)
-		if err != nil {
-			l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
-		}
-		resJSON, err := callHost(call, method, argsJSON)
-		if err != nil {
-			l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
-		}
-		result, err := jsonToTable(l, resJSON)
-		if err != nil {
-			l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
-		}
-		l.Push(result)
-		return 1
+		return invokeMethod(l, call, method, args)
+	}
+}
+
+// invokeMethod marshals args→JSON, calls the host method, and pushes the JSON reply as a
+// Lua table; any conversion or call failure is raised as a Lua error naming the method so
+// the script can pcall it. Shared by oblikovati.call and the typed group leaves.
+func invokeMethod(l *lua.LState, call script.CallFunc, method string, args *lua.LTable) int {
+	argsJSON, err := tableToJSON(args)
+	if err != nil {
+		l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
+	}
+	resJSON, err := callHost(call, method, argsJSON)
+	if err != nil {
+		l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
+	}
+	result, err := jsonToTable(l, resJSON)
+	if err != nil {
+		l.RaiseError("oblikovati.call(%q): %s", method, err.Error())
+	}
+	l.Push(result)
+	return 1
+}
+
+// installTypedGroups builds the ergonomic grouped tables — oblikovati.documents.activate{…},
+// oblikovati.sketch.rectangle{…}, … — as thin sugar over the generic call door. Each
+// registered method name (group.method, from g.Methods) becomes a nested function that
+// forwards to g.Call with that fixed method, so the sugar stays in lockstep with the
+// contract by construction: a new wire method is callable both as oblikovati.call("g.m", …)
+// and oblikovati.g.m{…} with zero code change here (ADR-0028 §4.1).
+func installTypedGroups(l *lua.LState, root *lua.LTable, g script.Globals) {
+	if g.Methods == nil || g.Call == nil {
+		return
+	}
+	for _, method := range g.Methods() {
+		installTypedMethod(l, root, g.Call, method)
+	}
+}
+
+// installTypedMethod places one method's leaf function under its dotted namespace, creating
+// intermediate group tables as needed. A name with no dot has no group and is skipped (the
+// generic oblikovati.call still reaches it).
+func installTypedMethod(l *lua.LState, root *lua.LTable, call script.CallFunc, method string) {
+	segs := strings.Split(method, ".")
+	if len(segs) < 2 {
+		return
+	}
+	parent := root
+	for _, seg := range segs[:len(segs)-1] {
+		parent = subTable(l, parent, seg)
+	}
+	l.SetField(parent, segs[len(segs)-1], l.NewFunction(groupLeaf(call, method)))
+}
+
+// subTable returns parent[name] as a table, creating it when absent (or when a non-table
+// value somehow sits there), so the group namespace can grow incrementally.
+func subTable(l *lua.LState, parent *lua.LTable, name string) *lua.LTable {
+	if existing, ok := l.GetField(parent, name).(*lua.LTable); ok {
+		return existing
+	}
+	t := l.NewTable()
+	l.SetField(parent, name, t)
+	return t
+}
+
+// groupLeaf is a typed-group entry — oblikovati.<group>.<method>(argsTable) → result — with
+// the method name fixed at install time, so args is the sole optional argument.
+func groupLeaf(call script.CallFunc, method string) lua.LGFunction {
+	return func(l *lua.LState) int {
+		args := l.OptTable(1, l.NewTable())
+		return invokeMethod(l, call, method, args)
 	}
 }
 

--- a/script/gopherlua/typedgroups_test.go
+++ b/script/gopherlua/typedgroups_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gopherlua
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"oblikovati/script"
+)
+
+// globalsWithMethods builds Globals exposing both the fake call door and a fixed method
+// list, so the typed group sugar (oblikovati.<group>.<method>) is installed.
+func globalsWithMethods(f *fakeCall, methods ...string) script.Globals {
+	return script.Globals{
+		Call:    f.call,
+		Print:   func(string) {},
+		Methods: func() []string { return methods },
+	}
+}
+
+// TestTypedGroupForwardsToCall: oblikovati.documents.create{…} forwards to the host with
+// the fixed method name and the args table, and returns the decoded reply — identical to
+// oblikovati.call("documents.create", {…}) but ergonomic.
+func TestTypedGroupForwardsToCall(t *testing.T) {
+	f := &fakeCall{reply: []byte(`{"id":9}`)}
+	g := globalsWithMethods(f, "documents.create", "documents.list")
+	src := `local r = oblikovati.documents.create{ type = "part", name = "lid" }
+	        print(r.id)`
+	res := New().Run(context.Background(), src, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("Run: %v", res.Err)
+	}
+	if f.method != "documents.create" {
+		t.Errorf("method = %q, want documents.create", f.method)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(f.argsJSON, &got); err != nil {
+		t.Fatalf("args not JSON: %v", err)
+	}
+	if got["type"] != "part" || got["name"] != "lid" {
+		t.Errorf("args round-trip wrong: %v", got)
+	}
+	if !strings.Contains(res.Stdout, "9") {
+		t.Errorf("typed group did not return the decoded reply: %q", res.Stdout)
+	}
+}
+
+// TestTypedGroupNoArgs: a method invoked with no argument table sends an empty object, so
+// argument-less calls like oblikovati.documents.list() work.
+func TestTypedGroupNoArgs(t *testing.T) {
+	f := &fakeCall{reply: []byte(`{"documents":[]}`)}
+	g := globalsWithMethods(f, "documents.list")
+	res := New().Run(context.Background(), `oblikovati.documents.list()`, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("Run: %v", res.Err)
+	}
+	if f.method != "documents.list" {
+		t.Errorf("method = %q, want documents.list", f.method)
+	}
+	if strings.TrimSpace(string(f.argsJSON)) != "{}" {
+		t.Errorf("no-arg call should send an empty object, got %q", f.argsJSON)
+	}
+}
+
+// TestTypedGroupsShareNamespace: two methods in the same group land under one table.
+func TestTypedGroupsShareNamespace(t *testing.T) {
+	f := &fakeCall{reply: []byte(`{}`)}
+	g := globalsWithMethods(f, "sketch.rectangle", "sketch.line")
+	src := `assert(type(oblikovati.sketch) == "table")
+	        assert(type(oblikovati.sketch.rectangle) == "function")
+	        assert(type(oblikovati.sketch.line) == "function")`
+	res := New().Run(context.Background(), src, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("both methods should share the sketch table: %v", res.Err)
+	}
+}
+
+// TestTypedGroupErrorIsCatchable: a host error from a typed-group call is raised as a Lua
+// error the script can pcall, same as the generic door.
+func TestTypedGroupErrorIsCatchable(t *testing.T) {
+	f := &fakeCall{err: errBoom}
+	g := globalsWithMethods(f, "documents.create")
+	src := `local ok = pcall(function() oblikovati.documents.create{} end)
+	        if ok then error("expected failure") end
+	        print("caught")`
+	res := New().Run(context.Background(), src, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("pcall should let the script handle the host error: %v", res.Err)
+	}
+	if !strings.Contains(res.Stdout, "caught") {
+		t.Errorf("typed-group host error not catchable: %q", res.Stdout)
+	}
+}
+
+// TestCallAndMethodsSurviveTypedGroups: installing the groups must not shadow the reserved
+// oblikovati.call / oblikovati.methods entries.
+func TestCallAndMethodsSurviveTypedGroups(t *testing.T) {
+	f := &fakeCall{reply: []byte(`{}`)}
+	g := globalsWithMethods(f, "documents.list")
+	src := `assert(type(oblikovati.call) == "function")
+	        assert(type(oblikovati.methods) == "function")
+	        assert(#oblikovati.methods() == 1)`
+	res := New().Run(context.Background(), src, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("reserved entries should survive: %v", res.Err)
+	}
+}
+
+// TestNoTypedGroupsWithoutMethods: with no Methods provider, no group tables exist (only the
+// generic call door), so the sugar is opt-in on discoverability being wired.
+func TestNoTypedGroupsWithoutMethods(t *testing.T) {
+	f := &fakeCall{reply: []byte(`{}`)}
+	g := script.Globals{Call: f.call, Print: func(string) {}}
+	res := New().Run(context.Background(), `assert(oblikovati.documents == nil)`, g, script.Limits{Wall: time.Second})
+	if res.Err != nil {
+		t.Fatalf("no groups should exist without a Methods provider: %v", res.Err)
+	}
+}

--- a/script/runner/runner_test.go
+++ b/script/runner/runner_test.go
@@ -63,6 +63,26 @@ func assertParameter(t *testing.T, r *ScriptRunner, name, wantValue string) {
 	}
 }
 
+// TestTypedGroupSugarAffectsModel proves the auto-derived group tables
+// (oblikovati.documents.create{…}) drive the real model end to end, identical to the
+// generic oblikovati.call path (ADR-0028 §4.1).
+func TestTypedGroupSugarAffectsModel(t *testing.T) {
+	r, s := newRealRunner()
+	src := `oblikovati.documents.create{ type = "part", name = "block" }
+	        oblikovati.parameters.add{ name = "depth", expression = "5 cm" }`
+	res, err := r.Run(context.Background(), src, fastLimits(), nil)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("script: %v", res.Err)
+	}
+	if s.ActiveDocument() == nil {
+		t.Fatal("typed-group script did not create a document")
+	}
+	assertParameter(t, r, "depth", "50 mm")
+}
+
 func TestRunInfiniteLoopReturnsErrorHostSurvives(t *testing.T) {
 	r, _ := newRealRunner()
 	res, err := r.Run(context.Background(), "while true do end", script.Limits{Wall: 150 * time.Millisecond}, nil)


### PR DESCRIPTION
## What

Adds the auto-derived **typed convenience tables** to the embedded Lua runtime —
`oblikovati.documents.create{…}`, `oblikovati.parameters.add{…}`,
`oblikovati.sketch.*`, … — the last item of **Phase 2** (ADR-0028 §4.1). With the
GUI console (#82) already shipped, this completes Phase 2.

## Why

The generic door `oblikovati.call("documents.create", {…})` is stringly-typed.
Grouped tables read naturally and are discoverable, but must never drift from the
contract or duplicate per-method glue (ADR-0028 requirement #2).

## How

At VM setup each registered method name from `oblikovati.methods()` (the router's
handler list) is split on `.` and installed as a nested function that forwards to the
**same** `oblikovati.call` with that fixed method. So a new wire method is callable
both as `oblikovati.call("g.m", …)` and `oblikovati.g.m{…}` the instant it is
registered — zero scripting-package change, in lockstep by construction. Groups
install before the reserved `call`/`methods` entries so they can't be shadowed. The
shared marshal→call→convert core was extracted (`invokeMethod`) so the generic door
and the group leaves share one implementation.

## Tests / verification

- `script/gopherlua`: forwarding to the fixed method + args, no-arg → empty object,
  shared group namespace, catchable host error, reserved `call`/`methods` survive,
  opt-in on a `Methods` provider.
- `script/runner`: end-to-end test driving the **real model** through the sugar
  (`oblikovati.documents.create{…}` + `oblikovati.parameters.add{…}`, read back).
- **Live**: `oblikovati-cli script run` of a typed-sugar script created a part, set a
  parameter, and listed it back (`width = 80 mm`, 126 methods available).

Contract-first impact: **none**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)