### PR TITLE
feat(router): implement scripts.run (whole-program Lua over the wire)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -44,6 +44,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerGraphicsHandlers()
 	r.registerExchangeHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
+	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r
 }
 

--- a/addin/router/scripts.go
+++ b/addin/router/scripts.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"oblikovati/api/wire"
+	"oblikovati/app"
+	"oblikovati/script"
+	"oblikovati/script/gopherlua"
+)
+
+// Script-run budgets. The wall-clock bounds a runaway (the only enforced guard, since
+// gopher-lua has no opcode hook — ADR-0028 §7); the memory cap is best-effort via the
+// bounded VM. A caller may request a tighter/looser wall up to maxScriptWall.
+const (
+	defaultScriptWall = 10 * time.Second
+	maxScriptWall     = 60 * time.Second
+	scriptMemBytes    = 256 << 20 // 256 MiB
+)
+
+// scriptsRun runs a whole Lua program against the live model in one call
+// (wire.MethodScriptRun), so an MCP/LLM client can submit a complete automation program
+// instead of issuing N method calls. It runs the source INLINE on the calling goroutine —
+// the same one router.Handle is on (the session goroutine for the GUI via the dispatcher;
+// the only goroutine for the CLI) — with a host door that calls r.Handle re-entrantly.
+// router.Handle holds no lock, so the nested calls are safe and deadlock-free, and each
+// inner mutating call still emits its own edit.committed. The sandbox + wall-clock bound a
+// runaway (ADR-0028); a script failure is returned in the result (Error), not as a handler
+// error, so the caller always gets the output plus the reason.
+func (r *Router) scriptsRun(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ScriptRunArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(in.Source) == "" {
+		return nil, errors.New("scripts.run: source is required, got an empty program")
+	}
+	wall := scriptWall(in.WallMs)
+	ctx, cancel := context.WithTimeout(context.Background(), wall)
+	defer cancel()
+	globals := script.Globals{
+		Call:    func(method string, req []byte) ([]byte, error) { return r.Handle(s, method, req) },
+		Methods: r.Methods,
+	}
+	res := gopherlua.New().Run(ctx, in.Source, globals, script.Limits{Wall: wall, MemBytes: scriptMemBytes})
+	out := wire.ScriptRunResult{Output: res.Stdout, DurationMs: res.Duration.Milliseconds(), Ops: res.Op}
+	if res.Err != nil {
+		out.Error = res.Err.Error()
+	}
+	return json.Marshal(out)
+}
+
+// scriptWall resolves the per-run wall-clock budget: the requested milliseconds (clamped
+// to maxScriptWall) or the default when unset/non-positive.
+func scriptWall(ms int) time.Duration {
+	if ms <= 0 {
+		return defaultScriptWall
+	}
+	if d := time.Duration(ms) * time.Millisecond; d < maxScriptWall {
+		return d
+	}
+	return maxScriptWall
+}

--- a/addin/router/scripts_test.go
+++ b/addin/router/scripts_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"oblikovati/api/wire"
+)
+
+// argsJSON marshals a request struct to the JSON string the call helper expects.
+func argsJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return string(b)
+}
+
+// TestScriptsRunDrivesModelAndCapturesOutput: a program adds a parameter through the
+// re-entrant router and reads it back; the printed value proves the real model changed
+// (not just the script's VM), end to end via scripts.run.
+func TestScriptsRunDrivesModelAndCapturesOutput(t *testing.T) {
+	r, s := seededSession(t)
+	src := `oblikovati.parameters.add{ name = "depth", expression = "5 cm" }
+	        local p = oblikovati.parameters.get{ name = "depth" }
+	        print(p.value)`
+	var res wire.ScriptRunResult
+	call(t, r, s, wire.MethodScriptRun, argsJSON(t, wire.ScriptRunArgs{Source: src}), &res)
+	if res.Error != "" {
+		t.Fatalf("script error: %s", res.Error)
+	}
+	if !strings.Contains(res.Output, "50 mm") {
+		t.Errorf("output = %q, want it to contain the read-back value 50 mm", res.Output)
+	}
+}
+
+// TestScriptsRunReportsScriptErrorInResult: a runtime error rides in the result's Error
+// field (with the offending value), and the call itself succeeds at the transport level.
+func TestScriptsRunReportsScriptErrorInResult(t *testing.T) {
+	r, s := seededSession(t)
+	var res wire.ScriptRunResult
+	call(t, r, s, wire.MethodScriptRun, argsJSON(t, wire.ScriptRunArgs{Source: `error("boom-value")`}), &res)
+	if res.Error == "" || !strings.Contains(res.Error, "boom-value") {
+		t.Errorf("script error should be reported with the value, got %q", res.Error)
+	}
+}
+
+// TestScriptsRunRejectsEmptySource: an empty program is a request error (not a silent
+// no-op), naming the problem.
+func TestScriptsRunRejectsEmptySource(t *testing.T) {
+	r, s := seededSession(t)
+	if _, err := r.Handle(s, wire.MethodScriptRun, []byte(`{"source":"   "}`)); err == nil {
+		t.Fatal("empty source should be rejected")
+	}
+}
+
+// TestScriptsRunHonorsWallClock: an infinite loop is cut by the per-run wall-clock and
+// reported as a script error, promptly — the host is never hung.
+func TestScriptsRunHonorsWallClock(t *testing.T) {
+	r, s := seededSession(t)
+	start := time.Now()
+	var res wire.ScriptRunResult
+	call(t, r, s, wire.MethodScriptRun, argsJSON(t, wire.ScriptRunArgs{Source: "while true do end", WallMs: 150}), &res)
+	if res.Error == "" {
+		t.Fatal("an infinite loop must be reported as a script error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("wall-clock not honoured promptly: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## What

The GPL host handler for **`scripts.run`** (Lua Phase 3, ADR-0028 §8) — runs a whole
Lua program against the live model in one wire call. Pairs with the contract merged in
Oblikovati.API #27. Scripting is now reachable from the GUI console, the CLI, and the
MCP bridge.

## How

`(*Router).scriptsRun` runs the source **inline** on the calling goroutine — the same
one `router.Handle` is on (the session goroutine for the GUI via the dispatcher; the only
goroutine for the CLI) — through the sandboxed gopher-lua runtime, with a host door that
calls `r.Handle` **re-entrantly**. `router.Handle` holds no lock, so the nested calls are
safe and deadlock-free, and each inner mutating call still emits its own `edit.committed`.

- A per-run **wall-clock** (request-overridable via `wallMs`, default 10s, capped 60s)
  is the runaway guard (gopher-lua has no opcode hook — ADR-0028 §7).
- A **script** failure (syntax/runtime/quota/cancel) is returned in `ScriptRunResult.Error`
  with whatever `output` was printed; the call succeeds at the transport level.

Inline (not the worker-goroutine `ScriptRunner`) is deliberate: it keeps every host call
on the safe goroutine. The cost is that a script blocks the session for its (bounded)
duration — acceptable for the batch/automation use case this serves.

## Tests

Drives + reads back the real model end to end (`oblikovati.parameters.add` then `get`,
asserts `50 mm`); reports a runtime error with the offending value in the result; rejects
empty source; cuts `while true do end` by the wall-clock promptly. All headless.

A `run_script` MCP tool in the bridge follows in a separate Oblikovati.AddIns PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)