### PR TITLE
test(script): bundled Lua examples + unit & integration tests

### DIFF
--- a/script/examples/create_parameters.lua
+++ b/script/examples/create_parameters.lua
@@ -1,0 +1,12 @@
+-- create_parameters: add user parameters to a fresh part, one driven by an
+-- expression in inches (stored in the document's units) and one in millimetres,
+-- then list them back. Demonstrates parameters.add with unit-bearing expressions.
+oblikovati.documents.create{ type = "part", name = "create-parameters-demo" }
+
+oblikovati.parameters.add{ name = "Width", expression = "3 in" }
+oblikovati.parameters.add{ name = "Height", expression = "40 mm" }
+
+local ps = oblikovati.parameters.list()
+for _, p in ipairs(ps.parameters) do
+  print(p.name .. " = " .. p.value)
+end

--- a/script/examples/examples.go
+++ b/script/examples/examples.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package examples bundles ready-to-run Lua programs that drive the model through the
+// public wire API (ADR-0028). They double as a starter script library and as the corpus
+// for the scripting integration tests: each program is self-contained (it creates its own
+// document), so it runs unchanged from the GUI console, the CLI, or scripts.run.
+//
+// The programs are clean-room ports of common parametric-modelling scenarios (create
+// parameters, sketch + extrude, revolve, read physical properties), expressed against this
+// project's own API.
+package examples
+
+import (
+	"embed"
+	"io/fs"
+	"sort"
+)
+
+//go:embed *.lua
+var fsys embed.FS
+
+// Names returns the bundled example filenames (e.g. "extrude_block.lua"), sorted.
+func Names() ([]string, error) {
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Source returns the Lua source of a named example (e.g. examples.Source("extrude_block.lua")).
+func Source(name string) (string, error) {
+	b, err := fsys.ReadFile(name)
+	return string(b), err
+}

--- a/script/examples/examples_test.go
+++ b/script/examples/examples_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package examples_test
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"oblikovati/addin/opregistry"
+	"oblikovati/addin/router"
+	"oblikovati/app"
+	"oblikovati/script"
+	"oblikovati/script/bridge"
+	"oblikovati/script/examples"
+	"oblikovati/script/gopherlua"
+	"oblikovati/script/runner"
+)
+
+// runExample runs a bundled example against a real Session + router (the in-proc CLI
+// wiring) and returns the router + session so a test can query the resulting model
+// independently of whatever the script itself printed.
+func runExample(t *testing.T, name string) (*router.Router, *app.Session) {
+	t.Helper()
+	s := app.NewSession()
+	rtr := router.New(opregistry.Default())
+	caller := bridge.NewDirectCaller(rtr.Handle, s)
+	r := runner.New(gopherlua.New(), caller, rtr.Methods)
+	src, err := examples.Source(name)
+	if err != nil {
+		t.Fatalf("load %s: %v", name, err)
+	}
+	res, err := r.Run(context.Background(), src, script.Limits{Wall: 10 * time.Second}, nil)
+	if err != nil {
+		t.Fatalf("run %s: %v", name, err)
+	}
+	if res.Err != nil {
+		t.Fatalf("%s script error: %v", name, res.Err)
+	}
+	return rtr, s
+}
+
+// query invokes a wire method on the same session and decodes the JSON result into v.
+func query(t *testing.T, rtr *router.Router, s *app.Session, method, args string, v any) {
+	t.Helper()
+	out, err := rtr.Handle(s, method, []byte(args))
+	if err != nil {
+		t.Fatalf("%s: %v", method, err)
+	}
+	if v != nil {
+		if err := json.Unmarshal(out, v); err != nil {
+			t.Fatalf("%s: decode: %v", method, err)
+		}
+	}
+}
+
+// TestAllExamplesRun is the corpus guard: every bundled example must run to completion
+// against the real model without a script error, so a contract change that breaks an
+// example is caught here.
+func TestAllExamplesRun(t *testing.T) {
+	names, err := examples.Names()
+	if err != nil {
+		t.Fatalf("list examples: %v", err)
+	}
+	if len(names) == 0 {
+		t.Fatal("no bundled examples found")
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) { runExample(t, name) })
+	}
+}
+
+type paramList struct {
+	Parameters []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	} `json:"parameters"`
+}
+
+func paramValue(pl paramList, name string) (string, bool) {
+	for _, p := range pl.Parameters {
+		if p.Name == name {
+			return p.Value, true
+		}
+	}
+	return "", false
+}
+
+func TestExampleCreateParameters(t *testing.T) {
+	rtr, s := runExample(t, "create_parameters.lua")
+	var pl paramList
+	query(t, rtr, s, "parameters.list", "{}", &pl)
+	if v, ok := paramValue(pl, "Width"); !ok || !strings.Contains(v, "76.2") {
+		t.Errorf("Width = %q (ok=%v), want ~76.2 mm (3 in)", v, ok)
+	}
+	if v, ok := paramValue(pl, "Height"); !ok || !strings.Contains(v, "40") {
+		t.Errorf("Height = %q (ok=%v), want 40 mm", v, ok)
+	}
+}
+
+func TestExampleSetParameter(t *testing.T) {
+	rtr, s := runExample(t, "set_parameter.lua")
+	var p struct {
+		Value string `json:"value"`
+	}
+	query(t, rtr, s, "parameters.get", `{"name":"Length"}`, &p)
+	if !strings.Contains(p.Value, "88.9") { // 3.5 in
+		t.Errorf("Length = %q, want ~88.9 mm (3.5 in)", p.Value)
+	}
+}
+
+func TestExampleSketchLines(t *testing.T) {
+	rtr, s := runExample(t, "sketch_lines.lua")
+	var ents struct {
+		Entities []struct {
+			Kind string `json:"kind"`
+		} `json:"entities"`
+	}
+	query(t, rtr, s, "sketch.entities", `{"sketchIndex":0}`, &ents)
+	lines := 0
+	for _, e := range ents.Entities {
+		if e.Kind == "line" {
+			lines++
+		}
+	}
+	if lines != 7 { // 3 (triangle) + 4 (rectangle)
+		t.Errorf("line count = %d, want 7", lines)
+	}
+}
+
+// physProps is the model.physicalProperties result shape (api/types.PhysicalProperties).
+type physProps struct {
+	Volume   float64    `json:"volume"`
+	Area     float64    `json:"area"`
+	Centroid [3]float64 `json:"centroid"`
+}
+
+func TestExampleExtrudeBlock(t *testing.T) {
+	rtr, s := runExample(t, "extrude_block.lua")
+	var p physProps
+	query(t, rtr, s, "model.physicalProperties", "{}", &p)
+	if math.Abs(p.Volume-12) > 0.05 { // 4*3*1 cm
+		t.Errorf("block volume = %.4f cm3, want 12", p.Volume)
+	}
+}
+
+func TestExampleRevolveTube(t *testing.T) {
+	rtr, s := runExample(t, "revolve_tube.lua")
+	var p physProps
+	query(t, rtr, s, "model.physicalProperties", "{}", &p)
+	want := 16 * math.Pi // pi*(3^2-1^2)*2
+	if rel := math.Abs(p.Volume-want) / want; rel > 0.03 {
+		t.Errorf("tube volume = %.4f cm3, want ~%.4f (rel err %.3f)", p.Volume, want, rel)
+	}
+}
+
+func TestExampleMassProperties(t *testing.T) {
+	rtr, s := runExample(t, "mass_properties.lua")
+	var p physProps
+	query(t, rtr, s, "model.physicalProperties", "{}", &p)
+	if math.Abs(p.Volume-8) > 0.05 { // 2 cm cube
+		t.Errorf("cube volume = %.4f cm3, want 8", p.Volume)
+	}
+	if math.Abs(p.Area-24) > 0.1 { // 6 faces * 4 cm2
+		t.Errorf("cube area = %.4f cm2, want 24", p.Area)
+	}
+	for i, c := range p.Centroid {
+		if math.Abs(c-1) > 0.05 { // centred at (1,1,1) cm
+			t.Errorf("centroid[%d] = %.4f, want ~1", i, c)
+		}
+	}
+}

--- a/script/examples/examples_unit_test.go
+++ b/script/examples/examples_unit_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package examples_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"oblikovati/api/client"
+	"oblikovati/script"
+	"oblikovati/script/examples"
+	"oblikovati/script/gopherlua"
+	"oblikovati/script/runner"
+)
+
+// exampleMethods is the wire surface the bundled examples touch. It backs both the typed
+// sugar (oblikovati.<group>.<method>) and the unit-test fake, decoupling the unit tests
+// from the live router.
+var exampleMethods = []string{
+	"documents.create",
+	"parameters.add", "parameters.set", "parameters.get", "parameters.list",
+	"sketch.create", "sketch.addEntity", "sketch.rectangle", "sketch.entities",
+	"features.add", "model.physicalProperties",
+}
+
+// recordingCaller is a named fake client.Caller: it records every method called and
+// returns canned JSON so a read-back in the script can proceed, with no real model. It
+// lets a unit test assert the *shape* of an example (which wire calls it issues) in
+// isolation.
+type recordingCaller struct{ methods []string }
+
+func (c *recordingCaller) Call(method string, _ []byte) ([]byte, error) {
+	c.methods = append(c.methods, method)
+	return cannedReply(method), nil
+}
+
+var _ client.Caller = (*recordingCaller)(nil)
+
+// cannedReply returns a minimal valid response for the methods the examples read back.
+func cannedReply(method string) []byte {
+	switch method {
+	case "sketch.create":
+		return []byte(`{"sketchIndex":0}`)
+	case "parameters.list":
+		return []byte(`{"parameters":[{"name":"Width","value":"76.2 mm"}]}`)
+	case "parameters.get":
+		return []byte(`{"value":"88.9 mm"}`)
+	case "sketch.entities":
+		return []byte(`{"entities":[{"kind":"line"}]}`)
+	case "model.physicalProperties":
+		return []byte(`{"volume":12,"area":24,"centroid":[1,1,1]}`)
+	default:
+		return []byte(`{}`)
+	}
+}
+
+// callsFor runs an example against the recording fake and returns the methods it issued.
+func callsFor(t *testing.T, name string) []string {
+	t.Helper()
+	c := &recordingCaller{}
+	r := runner.New(gopherlua.New(), c, func() []string { return exampleMethods })
+	src, err := examples.Source(name)
+	if err != nil {
+		t.Fatalf("load %s: %v", name, err)
+	}
+	res, err := r.Run(context.Background(), src, script.Limits{Wall: 5 * time.Second}, nil)
+	if err != nil {
+		t.Fatalf("run %s: %v", name, err)
+	}
+	if res.Err != nil {
+		t.Fatalf("%s script error: %v", name, res.Err)
+	}
+	return c.methods
+}
+
+func count(methods []string, want string) int {
+	n := 0
+	for _, m := range methods {
+		if m == want {
+			n++
+		}
+	}
+	return n
+}
+
+// requireMethods asserts each wanted method was called at least minCount times.
+func requireMethods(t *testing.T, got []string, wanted map[string]int) {
+	t.Helper()
+	for m, min := range wanted {
+		if c := count(got, m); c < min {
+			t.Errorf("expected %q at least %d time(s), got %d (calls: %v)", m, min, c, got)
+		}
+	}
+}
+
+func TestUnitCreateParameters(t *testing.T) {
+	requireMethods(t, callsFor(t, "create_parameters.lua"), map[string]int{
+		"documents.create": 1, "parameters.add": 2, "parameters.list": 1,
+	})
+}
+
+func TestUnitSetParameter(t *testing.T) {
+	requireMethods(t, callsFor(t, "set_parameter.lua"), map[string]int{
+		"documents.create": 1, "parameters.add": 1, "parameters.set": 1, "parameters.get": 1,
+	})
+}
+
+func TestUnitSketchLines(t *testing.T) {
+	requireMethods(t, callsFor(t, "sketch_lines.lua"), map[string]int{
+		"documents.create": 1, "sketch.create": 1, "sketch.addEntity": 3,
+		"sketch.rectangle": 1, "sketch.entities": 1,
+	})
+}
+
+func TestUnitExtrudeBlock(t *testing.T) {
+	requireMethods(t, callsFor(t, "extrude_block.lua"), map[string]int{
+		"documents.create": 1, "sketch.create": 1, "sketch.rectangle": 1,
+		"features.add": 1, "model.physicalProperties": 1,
+	})
+}
+
+func TestUnitRevolveTube(t *testing.T) {
+	requireMethods(t, callsFor(t, "revolve_tube.lua"), map[string]int{
+		"documents.create": 1, "sketch.create": 1, "sketch.addEntity": 4,
+		"features.add": 1, "model.physicalProperties": 1,
+	})
+}
+
+func TestUnitMassProperties(t *testing.T) {
+	requireMethods(t, callsFor(t, "mass_properties.lua"), map[string]int{
+		"documents.create": 1, "sketch.create": 1, "sketch.rectangle": 1,
+		"features.add": 1, "model.physicalProperties": 1,
+	})
+}

--- a/script/examples/extrude_block.lua
+++ b/script/examples/extrude_block.lua
@@ -1,0 +1,11 @@
+-- extrude_block: sketch a rectangle and extrude it into a solid block.
+-- Demonstrates the sketch -> profile -> extrude feature flow. A 40x30 mm
+-- rectangle extruded 10 mm is a 4x3x1 cm block = 12 cm^3.
+oblikovati.documents.create{ type = "part", name = "extrude-block-demo" }
+oblikovati.sketch.create{ plane = "XY" }
+oblikovati.sketch.rectangle{ sketchIndex = 0, width = "40 mm", height = "30 mm" }
+
+oblikovati.features.add{ kind = "extrude", args = { sketchIndex = 0, profileIndex = 0, distance = "10 mm" } }
+
+local props = oblikovati.model.physicalProperties()
+print(string.format("volume = %.3f cm3", props.volume))

--- a/script/examples/mass_properties.lua
+++ b/script/examples/mass_properties.lua
@@ -1,0 +1,11 @@
+-- mass_properties: build a 2 cm cube and read its physical properties (volume,
+-- surface area, centre of mass). Demonstrates model.physicalProperties.
+oblikovati.documents.create{ type = "part", name = "mass-properties-demo" }
+oblikovati.sketch.create{ plane = "XY" }
+oblikovati.sketch.rectangle{ sketchIndex = 0, width = "20 mm", height = "20 mm" }
+oblikovati.features.add{ kind = "extrude", args = { sketchIndex = 0, profileIndex = 0, distance = "20 mm" } }
+
+local p = oblikovati.model.physicalProperties()
+print(string.format("volume = %.3f cm3", p.volume))
+print(string.format("area = %.3f cm2", p.area))
+print(string.format("centroid = (%.3f, %.3f, %.3f) cm", p.centroid[1], p.centroid[2], p.centroid[3]))

--- a/script/examples/revolve_tube.lua
+++ b/script/examples/revolve_tube.lua
@@ -1,0 +1,16 @@
+-- revolve_tube: revolve a rectangular profile offset from the Y axis into a tube
+-- (annular cylinder). Demonstrates a closed line profile + the revolve feature.
+-- The profile spans radius 1..3 cm and height 2 cm, so the volume is
+-- pi*(3^2 - 1^2)*2 = 16*pi ~= 50.265 cm^3.
+oblikovati.documents.create{ type = "part", name = "revolve-tube-demo" }
+oblikovati.sketch.create{ plane = "XY" }
+
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{1, 0}, {3, 0}} }
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{3, 0}, {3, 2}} }
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{3, 2}, {1, 2}} }
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{1, 2}, {1, 0}} }
+
+oblikovati.features.add{ kind = "revolve", args = { sketchIndex = 0, profileIndex = 0, angle = "360 deg" } }
+
+local props = oblikovati.model.physicalProperties()
+print(string.format("volume = %.3f cm3", props.volume))

--- a/script/examples/set_parameter.lua
+++ b/script/examples/set_parameter.lua
@@ -1,0 +1,9 @@
+-- set_parameter: add a parameter, then change its expression and read the new
+-- evaluated value back. Demonstrates parameters.set + parameters.get.
+oblikovati.documents.create{ type = "part", name = "set-parameter-demo" }
+
+oblikovati.parameters.add{ name = "Length", expression = "2 in" }
+oblikovati.parameters.set{ name = "Length", expression = "3.5 in" }
+
+local p = oblikovati.parameters.get{ name = "Length" }
+print("Length = " .. p.value)

--- a/script/examples/sketch_lines.lua
+++ b/script/examples/sketch_lines.lua
@@ -1,0 +1,20 @@
+-- sketch_lines: draw a closed triangle from three connected lines, plus a
+-- rectangle, on a new sketch. Demonstrates sketch.create, sketch.addEntity (line),
+-- and sketch.rectangle. Coordinates are in centimetres (database units).
+oblikovati.documents.create{ type = "part", name = "sketch-lines-demo" }
+oblikovati.sketch.create{ plane = "XY" }
+
+-- Triangle: each line starts where the previous ended, closing back to the origin.
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{0, 0}, {4, 0}} }
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{4, 0}, {2, 3}} }
+oblikovati.sketch.addEntity{ sketchIndex = 0, kind = "line", points = {{2, 3}, {0, 0}} }
+
+-- A 5x5 cm rectangle adds four more lines.
+oblikovati.sketch.rectangle{ sketchIndex = 0, width = "5 cm", height = "5 cm" }
+
+local ents = oblikovati.sketch.entities{ sketchIndex = 0 }
+local lines = 0
+for _, e in ipairs(ents.entities) do
+  if e.kind == "line" then lines = lines + 1 end
+end
+print("lines = " .. lines)


### PR DESCRIPTION
## What

Improves embedded-Lua test coverage by porting common parametric-modelling scenarios
(the kind shipped as vendor API samples) to **clean-room Lua against this project's own
wire API**, each pinned by a **unit** and an **integration** test. The programs live in
`script/examples/` (embedded) and double as a starter **script library** runnable from
the GUI console, the CLI, or `scripts.run`.

## Examples (6, self-contained)

| file | exercises | check |
|---|---|---|
| `create_parameters.lua` | `parameters.add` (unit expressions) | 3 in → 76.2 mm |
| `set_parameter.lua` | `parameters.set` / `get` | 3.5 in → 88.9 mm |
| `sketch_lines.lua` | `sketch.addEntity` (line) + `sketch.rectangle` | 7 lines |
| `extrude_block.lua` | sketch → profile → `extrude` | 12 cm³ |
| `revolve_tube.lua` | closed line profile + `revolve` 360° | ~16π cm³ |
| `mass_properties.lua` | `model.physicalProperties` | 2 cm cube: 8 cm³ / 24 cm² / (1,1,1) |

## Tests (per example)

- **unit** — runs the program against a recording fake caller (typed sugar wired from a
  fixed method list) and asserts the wire calls it issues — its shape, in isolation, no
  model.
- **integration** — runs it against a real `Session` + router and verifies the resulting
  model **independently** (parameter values, line count, volume/area/centroid).
- plus a **corpus guard** that every bundled example runs without a script error.

## API gaps

None needed — the wire surface already covers these scenarios (parameters, sketch
entities incl. slot/polygon/polyline, extrude/revolve, physical properties). Moments of
inertia (in the vendor mass-properties sample) are deliberately not ported: the kernel
does not compute them, so that's a future kernel feature, not an API-exposure gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)