### PR TITLE
fix(head): visible InputText caret in light themes

### DIFF
--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -121,6 +121,7 @@ void obk_ig_end_disabled(void)               { ImGui::EndDisabled(); }
 static int obk_col_index(const char* name) {
     struct { const char* n; int c; } table[] = {
         {"Text", ImGuiCol_Text}, {"TextDisabled", ImGuiCol_TextDisabled},
+        {"InputTextCursor", ImGuiCol_InputTextCursor},
         {"WindowBg", ImGuiCol_WindowBg}, {"ChildBg", ImGuiCol_ChildBg},
         {"PopupBg", ImGuiCol_PopupBg}, {"Border", ImGuiCol_Border},
         {"FrameBg", ImGuiCol_FrameBg}, {"FrameBgHovered", ImGuiCol_FrameBgHovered},

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -113,7 +113,7 @@ var chromeBinding = map[types.ThemeToken][]string{
 	types.TokenChromePopupBg:       {"PopupBg"},
 	types.TokenChromeMenuBarBg:     {"MenuBarBg"},
 	types.TokenChromeHeaderBg:      {"TitleBg", "TitleBgCollapsed", "Header"},
-	types.TokenChromeText:          {"Text"},
+	types.TokenChromeText:          {"Text", "InputTextCursor"},
 	types.TokenChromeTextDisabled:  {"TextDisabled"},
 	types.TokenChromeBorder:        {"Border", "Separator"},
 	types.TokenChromeControlBg:     {"FrameBg"},

--- a/head/ui/theme_apply_test.go
+++ b/head/ui/theme_apply_test.go
@@ -43,6 +43,22 @@ func TestRefreshThemeColorsReadsActiveTheme(t *testing.T) {
 	refreshThemeColors(theme.DefaultDark()) // restore the package default for other tests
 }
 
+// TestInputTextCursorBoundToText guards the light-mode caret fix: ImGui 1.92 draws the
+// InputText caret with the dedicated ImGuiCol_InputTextCursor (not ImGuiCol_Text), so it
+// must be remapped with the text color — otherwise it keeps the dark-theme default and is
+// invisible on a light background.
+func TestInputTextCursorBoundToText(t *testing.T) {
+	bound := false
+	for _, slot := range chromeBinding[types.TokenChromeText] {
+		if slot == "InputTextCursor" {
+			bound = true
+		}
+	}
+	if !bound {
+		t.Error("InputTextCursor must be bound to TokenChromeText so the caret is visible in light themes")
+	}
+}
+
 func TestBufString(t *testing.T) {
 	buf := make([]byte, 16)
 	copy(buf, "My Dark\x00garbage")


### PR DESCRIPTION
ImGui 1.92 draws the InputText caret with the dedicated `ImGuiCol_InputTextCursor` (not `ImGuiCol_Text`). Our theme didn't remap that new slot, so it kept the dark-theme default — invisible on light backgrounds (dark mode worked by coincidence). Bind `InputTextCursor` to the text token + register the name in the color lookup. Guarded by TestInputTextCursorBoundToText.

🤖 Generated with [Claude Code](https://claude.com/claude-code)