### PR TITLE
fix(step): import real B-rep STEP (b-spline + rational) + surface import errors

### DIFF
--- a/head/ui/file_action_test.go
+++ b/head/ui/file_action_test.go
@@ -1,0 +1,23 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati/app"
+)
+
+// TestApplyFileActionSurfacesImportError guards that a failed import reports the underlying
+// (kernel) error in the status bar (s.Notice), not just to stderr — so an import that does
+// nothing tells the user why, instead of failing silently.
+func TestApplyFileActionSurfacesImportError(t *testing.T) {
+	s := app.NewSession()
+	applyFileAction(s, fileAction{Kind: dialogImport, Path: "/no/such/file.step"})
+	if n := s.Notice(); !strings.Contains(n, "Import failed") {
+		t.Errorf("notice = %q, want it to report the import failure", n)
+	}
+}

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"oblikovati/api/types"
 	"oblikovati/app"
@@ -204,30 +205,57 @@ func drawExportResolution() {
 	}
 }
 
-// applyFileAction performs the confirmed file operation. A successful Save As becomes
-// the document's path, so a later File ▸ Save writes straight through. Import/Export route a
-// foreign format (STL/OBJ/3MF/STEP) by extension; failures go to stderr (no message box yet).
+// applyFileAction performs the confirmed file operation and reports the outcome — success
+// or the underlying (kernel) error — in the status bar so the user always knows what
+// happened, instead of an import/export silently doing nothing. A successful Save As
+// becomes the document's path, so a later File ▸ Save writes straight through.
 func applyFileAction(s *app.Session, act fileAction) {
+	name := filepath.Base(act.Path)
 	switch act.Kind {
 	case dialogOpen:
 		if _, err := s.OpenDocument(act.Path); err != nil {
-			fmt.Fprintf(os.Stderr, "open %q: %v\n", act.Path, err)
+			fileNotice(s, "Open failed: %v", err)
+		} else {
+			fileNotice(s, "Opened %s", name)
 		}
 	case dialogSaveAs:
 		if err := s.SaveActiveDocumentAs(act.Path); err != nil {
-			fmt.Fprintf(os.Stderr, "save as %q: %v\n", act.Path, err)
+			fileNotice(s, "Save failed: %v", err)
+		} else {
+			fileNotice(s, "Saved %s", name)
 		}
 	case dialogLoadHDR:
 		s.LoadEnvironmentFile(act.Path) // the decode happens lazily on the next viewport frame
 	case dialogImport:
-		if _, err := s.ImportFile(act.Path); err != nil {
-			fmt.Fprintf(os.Stderr, "import %q: %v\n", act.Path, err)
+		if res, err := s.ImportFile(act.Path); err != nil {
+			fileNotice(s, "Import failed: %v", err)
+		} else {
+			fileNotice(s, "Imported %s (%d %s)", name, res.BodyCount, plural(res.BodyCount, "body", "bodies"))
 		}
 	case dialogExport:
 		if _, err := s.ExportFile(act.Path, types.MeshResolution(act.Resolution)); err != nil {
-			fmt.Fprintf(os.Stderr, "export %q: %v\n", act.Path, err)
+			fileNotice(s, "Export failed: %v", err)
+		} else {
+			fileNotice(s, "Exported %s", name)
 		}
 	}
+}
+
+// fileNotice shows a file-operation outcome in the status bar (s.Notice) and mirrors it to
+// stderr for the logs. The status bar is the user-facing channel — a kernel import error
+// (e.g. an unsupported STEP entity) now surfaces here rather than vanishing to stderr.
+func fileNotice(s *app.Session, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	s.SetNotice(msg)
+	fmt.Fprintln(os.Stderr, msg)
+}
+
+// plural picks the singular or plural word for n.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
 }
 
 // saveActive saves the active document in place, falling back to the Save As modal when
@@ -239,6 +267,8 @@ func saveActive(s *app.Session) {
 		return
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "save: %v\n", err)
+		fileNotice(s, "Save failed: %v", err)
+		return
 	}
+	fileNotice(s, "Saved")
 }

--- a/kernel/exchange/step/geommap/bspline_from_step.go
+++ b/kernel/exchange/step/geommap/bspline_from_step.go
@@ -11,8 +11,9 @@ import (
 )
 
 // bsplineSurfaceFromStep maps B_SPLINE_SURFACE_WITH_KNOTS into a geom.BSplineSurface.
-// Parameters: u_degree, v_degree, control_points_list, surface_form, u_closed,
-// v_closed, self_intersect, u_multiplicities, v_multiplicities, u_knots, v_knots.
+// Parameters (0-indexed, including the leading entity name): 0 name, 1 u_degree,
+// 2 v_degree, 3 control_points_list, 4 surface_form, 5 u_closed, 6 v_closed,
+// 7 self_intersect, 8 u_multiplicities, 9 v_multiplicities, 10 u_knots, 11 v_knots.
 // Knots are expanded from the (knot, multiplicity) compact form the kernel does not
 // use. Weights are unit (non-rational); RATIONAL surfaces are deferred (warned by
 // the caller via the unsupported path until the rational complex form is handled).
@@ -21,7 +22,7 @@ func bsplineSurfaceFromStep(g *part21.EntityGraph, ent *part21.RawEntity, scale 
 	if err != nil {
 		return nil, err
 	}
-	ctrl, err := controlNet(g, ent.Params, 2, scale)
+	ctrl, err := controlNet(g, ent.Params, 3, scale)
 	if err != nil {
 		return nil, err
 	}
@@ -33,24 +34,24 @@ func bsplineSurfaceFromStep(g *part21.EntityGraph, ent *part21.RawEntity, scale 
 	return geom.NewBSplineSurface(uDeg, vDeg, ctrl, weights, uKnots, vKnots)
 }
 
-// degreePair reads the u/v degrees (parameters 0 and 1).
+// degreePair reads the u/v degrees (parameters 1 and 2, after the entity name).
 func degreePair(params []part21.Value) (uDeg, vDeg int, err error) {
-	if uDeg, err = intParam(params, 0); err != nil {
+	if uDeg, err = intParam(params, 1); err != nil {
 		return 0, 0, fmt.Errorf("geommap: B_SPLINE_SURFACE u_degree: %w", err)
 	}
-	if vDeg, err = intParam(params, 1); err != nil {
+	if vDeg, err = intParam(params, 2); err != nil {
 		return 0, 0, fmt.Errorf("geommap: B_SPLINE_SURFACE v_degree: %w", err)
 	}
 	return uDeg, vDeg, nil
 }
 
-// surfaceKnots reads and expands the u/v knot vectors (multiplicities at 7/8,
-// distinct knots at 9/10).
+// surfaceKnots reads and expands the u/v knot vectors (multiplicities at 8/9,
+// distinct knots at 10/11 — after the leading entity name).
 func surfaceKnots(params []part21.Value, _, _ int) (uKnots, vKnots []float64, err error) {
-	if uKnots, err = expandedKnots(params, 7, 9); err != nil {
+	if uKnots, err = expandedKnots(params, 8, 10); err != nil {
 		return nil, nil, fmt.Errorf("geommap: B_SPLINE_SURFACE u knots: %w", err)
 	}
-	if vKnots, err = expandedKnots(params, 8, 10); err != nil {
+	if vKnots, err = expandedKnots(params, 9, 11); err != nil {
 		return nil, nil, fmt.Errorf("geommap: B_SPLINE_SURFACE v knots: %w", err)
 	}
 	return uKnots, vKnots, nil

--- a/kernel/exchange/step/geommap/curve_from_step.go
+++ b/kernel/exchange/step/geommap/curve_from_step.go
@@ -59,6 +59,9 @@ func Curve(g *part21.EntityGraph, id int, scale float64) (MappedCurve, error) {
 	if err != nil {
 		return MappedCurve{}, err
 	}
+	if len(ent.Components) > 0 { // complex instance, e.g. a rational (weighted) B-spline
+		return rationalBSplineCurve(g, ent, scale)
+	}
 	switch ent.Keyword {
 	case "LINE":
 		return MappedCurve{Kind: CurveLine}, nil
@@ -91,18 +94,19 @@ func circleFromStep(g *part21.EntityGraph, ent *part21.RawEntity, scale float64)
 }
 
 // bsplineCurveFromStep maps B_SPLINE_CURVE_WITH_KNOTS into a bounded geom.BSplineCurve.
-// Parameters: degree, control_points_list, curve_form, closed, self_intersect,
-// knot_multiplicities, knots. Non-rational (unit weights); RATIONAL is deferred.
+// Parameters (0-indexed, including the leading entity name): 0 name, 1 degree,
+// 2 control_points_list, 3 curve_form, 4 closed, 5 self_intersect, 6 knot_multiplicities,
+// 7 knots. Non-rational (unit weights); RATIONAL is deferred.
 func bsplineCurveFromStep(g *part21.EntityGraph, ent *part21.RawEntity, scale float64) (MappedCurve, error) {
-	degree, err := intParam(ent.Params, 0)
+	degree, err := intParam(ent.Params, 1)
 	if err != nil {
 		return MappedCurve{}, fmt.Errorf("geommap: B_SPLINE_CURVE degree: %w", err)
 	}
-	ctrl, err := pointRefList(g, ent.Params, 1, scale)
+	ctrl, err := pointRefList(g, ent.Params, 2, scale)
 	if err != nil {
 		return MappedCurve{}, err
 	}
-	knots, err := expandedKnots(ent.Params, 5, 6)
+	knots, err := expandedKnots(ent.Params, 6, 7)
 	if err != nil {
 		return MappedCurve{}, fmt.Errorf("geommap: B_SPLINE_CURVE knots: %w", err)
 	}

--- a/kernel/exchange/step/geommap/curve_from_step_test.go
+++ b/kernel/exchange/step/geommap/curve_from_step_test.go
@@ -39,7 +39,7 @@ func TestCurveBSplineWithKnots(t *testing.T) {
 	g := graphOf(t, "#1=CARTESIAN_POINT('',(0.,0.,0.));\n"+
 		"#2=CARTESIAN_POINT('',(1.,0.,0.));\n"+
 		"#3=CARTESIAN_POINT('',(1.,1.,0.));\n"+
-		"#4=B_SPLINE_CURVE_WITH_KNOTS(2,(#1,#2,#3),.UNSPECIFIED.,.F.,.F.,(3,3),(0.,1.),.UNSPECIFIED.);")
+		"#4=B_SPLINE_CURVE_WITH_KNOTS('NONE',2,(#1,#2,#3),.UNSPECIFIED.,.F.,.F.,(3,3),(0.,1.),.UNSPECIFIED.);")
 	mc, err := Curve(g, 4, 5.0)
 	if err != nil {
 		t.Fatalf("Curve B_SPLINE_CURVE_WITH_KNOTS: %v", err)
@@ -59,7 +59,7 @@ func TestCurveBSplineRejectsMalformedKnots(t *testing.T) {
 	g := graphOf(t, "#1=CARTESIAN_POINT('',(0.,0.,0.));\n"+
 		"#2=CARTESIAN_POINT('',(1.,0.,0.));\n"+
 		"#3=CARTESIAN_POINT('',(1.,1.,0.));\n"+
-		"#4=B_SPLINE_CURVE_WITH_KNOTS(2,(#1,#2,#3),.UNSPECIFIED.,.F.,.F.,(3),(0.,1.),.UNSPECIFIED.);")
+		"#4=B_SPLINE_CURVE_WITH_KNOTS('NONE',2,(#1,#2,#3),.UNSPECIFIED.,.F.,.F.,(3),(0.,1.),.UNSPECIFIED.);")
 	if _, err := Curve(g, 4, 1.0); err == nil {
 		t.Fatal("B_SPLINE_CURVE_WITH_KNOTS accepted mismatched knot multiplicities")
 	}

--- a/kernel/exchange/step/geommap/rational_bspline_from_step.go
+++ b/kernel/exchange/step/geommap/rational_bspline_from_step.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geommap
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati/kernel/exchange/step/part21"
+	"oblikovati/kernel/geom"
+)
+
+// Rational (weighted) B-splines arrive as STEP complex instances — a single #id that
+// combines several supertype components, e.g.
+//
+//	#id =( BOUNDED_CURVE() B_SPLINE_CURVE(deg, ctrl, …)
+//	       B_SPLINE_CURVE_WITH_KNOTS(mults, knots, …) CURVE()
+//	       GEOMETRIC_REPRESENTATION_ITEM() RATIONAL_B_SPLINE_CURVE(weights)
+//	       REPRESENTATION_ITEM(name) )
+//
+// The geometry is split across the parts: B_SPLINE_CURVE carries degree + control points,
+// B_SPLINE_CURVE_WITH_KNOTS the knot vector, and RATIONAL_B_SPLINE_CURVE the per-control-
+// point weights. Unlike a simple instance, a component's parameters carry NO leading entity
+// name (the name lives on REPRESENTATION_ITEM), so each part is indexed from 0. SolidWorks
+// and most kernels export every freeform curve/surface this way, so a real-world STEP is
+// unimportable without it.
+
+// complexPartParams returns the parameters of a complex instance's component by keyword,
+// or false when the instance has no such part.
+func complexPartParams(ent *part21.RawEntity, keyword string) ([]part21.Value, bool) {
+	for i := range ent.Components {
+		if ent.Components[i].Keyword == keyword {
+			return ent.Components[i].Params, true
+		}
+	}
+	return nil, false
+}
+
+// rationalBSplineCurve maps a RATIONAL_B_SPLINE_CURVE complex instance to a weighted
+// geom.BSplineCurve. Returns ErrUnsupportedCurve if the instance is some other complex type.
+func rationalBSplineCurve(g *part21.EntityGraph, ent *part21.RawEntity, scale float64) (MappedCurve, error) {
+	bc, ok1 := complexPartParams(ent, "B_SPLINE_CURVE")
+	bk, ok2 := complexPartParams(ent, "B_SPLINE_CURVE_WITH_KNOTS")
+	rb, ok3 := complexPartParams(ent, "RATIONAL_B_SPLINE_CURVE")
+	if !ok1 || !ok2 || !ok3 {
+		return MappedCurve{}, ErrUnsupportedCurve{Keyword: complexKeyword(ent), ID: ent.ID}
+	}
+	degree, err := intParam(bc, 0)
+	if err != nil {
+		return MappedCurve{}, fmt.Errorf("geommap: rational B_SPLINE_CURVE degree: %w", err)
+	}
+	ctrl, err := pointRefList(g, bc, 1, scale)
+	if err != nil {
+		return MappedCurve{}, err
+	}
+	knots, err := expandedKnots(bk, 0, 1)
+	if err != nil {
+		return MappedCurve{}, fmt.Errorf("geommap: rational B_SPLINE_CURVE knots: %w", err)
+	}
+	weights, err := floatList(rb, 0)
+	if err != nil {
+		return MappedCurve{}, fmt.Errorf("geommap: rational B_SPLINE_CURVE weights: %w", err)
+	}
+	curve, err := geom.NewBSplineCurve(degree, ctrl, weights, knots)
+	return MappedCurve{Kind: CurveBSpline, BSpline: curve}, err
+}
+
+// rationalBSplineSurface maps a RATIONAL_B_SPLINE_SURFACE complex instance to a weighted
+// geom.BSplineSurface. Returns ErrUnsupportedSurface if the instance is some other complex type.
+func rationalBSplineSurface(g *part21.EntityGraph, ent *part21.RawEntity, scale float64) (geom.Surface, error) {
+	bs, ok1 := complexPartParams(ent, "B_SPLINE_SURFACE")
+	bk, ok2 := complexPartParams(ent, "B_SPLINE_SURFACE_WITH_KNOTS")
+	rb, ok3 := complexPartParams(ent, "RATIONAL_B_SPLINE_SURFACE")
+	if !ok1 || !ok2 || !ok3 {
+		return nil, ErrUnsupportedSurface{Keyword: complexKeyword(ent), ID: ent.ID}
+	}
+	uDeg, vDeg, err := rationalSurfaceDegrees(bs)
+	if err != nil {
+		return nil, err
+	}
+	ctrl, err := controlNet(g, bs, 2, scale)
+	if err != nil {
+		return nil, err
+	}
+	uKnots, vKnots, err := rationalSurfaceKnots(bk)
+	if err != nil {
+		return nil, err
+	}
+	weights, err := floatNet(rb, 0)
+	if err != nil {
+		return nil, fmt.Errorf("geommap: rational B_SPLINE_SURFACE weights: %w", err)
+	}
+	return geom.NewBSplineSurface(uDeg, vDeg, ctrl, weights, uKnots, vKnots)
+}
+
+// rationalSurfaceDegrees reads the u/v degrees from the B_SPLINE_SURFACE component
+// (parameters 0 and 1 — a component carries no leading name).
+func rationalSurfaceDegrees(bs []part21.Value) (uDeg, vDeg int, err error) {
+	if uDeg, err = intParam(bs, 0); err != nil {
+		return 0, 0, fmt.Errorf("geommap: rational B_SPLINE_SURFACE u_degree: %w", err)
+	}
+	if vDeg, err = intParam(bs, 1); err != nil {
+		return 0, 0, fmt.Errorf("geommap: rational B_SPLINE_SURFACE v_degree: %w", err)
+	}
+	return uDeg, vDeg, nil
+}
+
+// rationalSurfaceKnots reads and expands the u/v knot vectors from the
+// B_SPLINE_SURFACE_WITH_KNOTS component (multiplicities at 0/1, distinct knots at 2/3).
+func rationalSurfaceKnots(bk []part21.Value) (uKnots, vKnots []float64, err error) {
+	if uKnots, err = expandedKnots(bk, 0, 2); err != nil {
+		return nil, nil, fmt.Errorf("geommap: rational B_SPLINE_SURFACE u knots: %w", err)
+	}
+	if vKnots, err = expandedKnots(bk, 1, 3); err != nil {
+		return nil, nil, fmt.Errorf("geommap: rational B_SPLINE_SURFACE v knots: %w", err)
+	}
+	return uKnots, vKnots, nil
+}
+
+// floatNet reads a rectangular grid of reals (a list of lists) at parameter i — the
+// rational surface's weight net.
+func floatNet(params []part21.Value, i int) ([][]float64, error) {
+	if i >= len(params) {
+		return nil, fmt.Errorf("missing float-grid parameter %d (have %d)", i, len(params))
+	}
+	rows, err := params[i].AsList()
+	if err != nil {
+		return nil, err
+	}
+	net := make([][]float64, len(rows))
+	for r, row := range rows {
+		items, listErr := row.AsList()
+		if listErr != nil {
+			return nil, listErr
+		}
+		net[r] = make([]float64, len(items))
+		for c, item := range items {
+			if net[r][c], err = item.AsFloat(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return net, nil
+}
+
+// complexKeyword renders a complex instance's component keywords for an error message
+// (e.g. "(BOUNDED_CURVE B_SPLINE_CURVE …)"), or the plain keyword for a simple instance.
+func complexKeyword(ent *part21.RawEntity) string {
+	if len(ent.Components) == 0 {
+		return ent.Keyword
+	}
+	names := make([]string, len(ent.Components))
+	for i := range ent.Components {
+		names[i] = ent.Components[i].Keyword
+	}
+	return "(" + strings.Join(names, " ") + ")"
+}

--- a/kernel/exchange/step/geommap/rational_bspline_from_step_test.go
+++ b/kernel/exchange/step/geommap/rational_bspline_from_step_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geommap
+
+import (
+	"testing"
+
+	"oblikovati/kernel/geom"
+)
+
+// TestRationalBSplineCurveFromComplexInstance maps a SolidWorks-style rational b-spline
+// curve — a STEP complex instance whose geometry is split across BOUNDED_CURVE /
+// B_SPLINE_CURVE / B_SPLINE_CURVE_WITH_KNOTS / RATIONAL_B_SPLINE_CURVE components (no
+// per-component name) — and checks the degree, control points, knots, and the non-unit
+// weights all land. This is the form a real STEP export uses for every freeform curve.
+func TestRationalBSplineCurveFromComplexInstance(t *testing.T) {
+	g := graphOf(t, "#1=CARTESIAN_POINT('',(0.,0.,0.));\n"+
+		"#2=CARTESIAN_POINT('',(1.,0.,0.));\n"+
+		"#3=CARTESIAN_POINT('',(2.,1.,0.));\n"+
+		"#4=CARTESIAN_POINT('',(3.,1.,0.));\n"+
+		"#5=( BOUNDED_CURVE() B_SPLINE_CURVE(3,(#1,#2,#3,#4),.UNSPECIFIED.,.F.,.F.) "+
+		"B_SPLINE_CURVE_WITH_KNOTS((4,4),(0.,1.),.UNSPECIFIED.) CURVE() "+
+		"GEOMETRIC_REPRESENTATION_ITEM() RATIONAL_B_SPLINE_CURVE((1.,0.8,0.8,1.)) "+
+		"REPRESENTATION_ITEM('') );")
+	mc, err := Curve(g, 5, 10.0)
+	if err != nil {
+		t.Fatalf("rational B-spline curve: %v", err)
+	}
+	if mc.Kind != CurveBSpline {
+		t.Fatalf("mapped to kind %d, want CurveBSpline", mc.Kind)
+	}
+	bc := mc.BSpline
+	if bc.Degree != 3 || len(bc.Ctrl) != 4 || len(bc.Knots) != 8 || len(bc.Weights) != 4 {
+		t.Fatalf("shape: degree %d ctrl %d knots %d weights %d", bc.Degree, len(bc.Ctrl), len(bc.Knots), len(bc.Weights))
+	}
+	if !near(bc.Weights[1], 0.8) {
+		t.Errorf("weight[1] = %v, want 0.8 (rational weights must be read)", bc.Weights[1])
+	}
+	if !near(float64(bc.Ctrl[3].X), 30) { // scaled by 10
+		t.Errorf("scaled control point = %v, want X=30", bc.Ctrl[3])
+	}
+}
+
+// TestRationalBSplineSurfaceFromComplexInstance maps a rational b-spline surface complex
+// instance and checks the degrees, control net, and non-unit weights land.
+func TestRationalBSplineSurfaceFromComplexInstance(t *testing.T) {
+	g := graphOf(t, "#1=CARTESIAN_POINT('',(0.,0.,0.));\n"+
+		"#2=CARTESIAN_POINT('',(1.,0.,0.));\n"+
+		"#3=CARTESIAN_POINT('',(0.,1.,0.));\n"+
+		"#4=CARTESIAN_POINT('',(1.,1.,1.));\n"+
+		"#5=( BOUNDED_SURFACE() B_SPLINE_SURFACE(1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,.F.,.F.,.F.) "+
+		"B_SPLINE_SURFACE_WITH_KNOTS((2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.) "+
+		"GEOMETRIC_REPRESENTATION_ITEM() RATIONAL_B_SPLINE_SURFACE(((1.,0.9),(0.9,1.))) "+
+		"REPRESENTATION_ITEM('') SURFACE() );")
+	s, err := Surface(g, 5, 10.0)
+	if err != nil {
+		t.Fatalf("rational B-spline surface: %v", err)
+	}
+	bs, ok := s.(geom.BSplineSurface)
+	if !ok {
+		t.Fatalf("mapped to %T, want BSplineSurface", s)
+	}
+	if bs.UDegree != 1 || bs.VDegree != 1 || len(bs.Ctrl) != 2 || len(bs.Ctrl[0]) != 2 {
+		t.Fatalf("shape: degree %d/%d net %dx%d", bs.UDegree, bs.VDegree, len(bs.Ctrl), len(bs.Ctrl[0]))
+	}
+	if !near(bs.Weights[0][1], 0.9) {
+		t.Errorf("weight[0][1] = %v, want 0.9", bs.Weights[0][1])
+	}
+	if !near(float64(bs.Ctrl[1][1].Z), 10) { // scaled by 10
+		t.Errorf("scaled control point = %v, want Z=10", bs.Ctrl[1][1])
+	}
+}

--- a/kernel/exchange/step/geommap/surface_from_step.go
+++ b/kernel/exchange/step/geommap/surface_from_step.go
@@ -30,6 +30,9 @@ func Surface(g *part21.EntityGraph, id int, scale float64) (geom.Surface, error)
 	if err != nil {
 		return nil, err
 	}
+	if len(ent.Components) > 0 { // complex instance, e.g. a rational (weighted) B-spline
+		return rationalBSplineSurface(g, ent, scale)
+	}
 	switch ent.Keyword {
 	case "PLANE":
 		return planeFromStep(g, ent, scale)

--- a/kernel/exchange/step/geommap/surface_from_step_test.go
+++ b/kernel/exchange/step/geommap/surface_from_step_test.go
@@ -148,7 +148,7 @@ func TestBSplineSurfaceWithKnotsFromStep(t *testing.T) {
 		"#2=CARTESIAN_POINT('',(1.,0.,0.));\n"+
 		"#3=CARTESIAN_POINT('',(0.,1.,0.));\n"+
 		"#4=CARTESIAN_POINT('',(1.,1.,1.));\n"+
-		"#5=B_SPLINE_SURFACE_WITH_KNOTS(1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,.F.,.F.,.F.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);")
+		"#5=B_SPLINE_SURFACE_WITH_KNOTS('NONE',1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,.F.,.F.,.F.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);")
 	s, err := Surface(g, 5, 10.0)
 	if err != nil {
 		t.Fatalf("Surface B_SPLINE_SURFACE_WITH_KNOTS: %v", err)
@@ -170,7 +170,7 @@ func TestBSplineSurfaceFromStepRejectsMalformedKnots(t *testing.T) {
 		"#2=CARTESIAN_POINT('',(1.,0.,0.));\n"+
 		"#3=CARTESIAN_POINT('',(0.,1.,0.));\n"+
 		"#4=CARTESIAN_POINT('',(1.,1.,1.));\n"+
-		"#5=B_SPLINE_SURFACE_WITH_KNOTS(1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,.F.,.F.,.F.,(2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);")
+		"#5=B_SPLINE_SURFACE_WITH_KNOTS('NONE',1,1,((#1,#2),(#3,#4)),.UNSPECIFIED.,.F.,.F.,.F.,(2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);")
 	if _, err := Surface(g, 5, 1.0); err == nil {
 		t.Fatal("B_SPLINE_SURFACE_WITH_KNOTS accepted mismatched u knot multiplicities")
 	}


### PR DESCRIPTION
## Bug

Importing `EDF.STEP` (a SolidWorks AP214 export) imported **nothing**, with no message to the user.

## Three fixes

1. **B-spline off-by-one.** `B_SPLINE_CURVE_WITH_KNOTS` / `B_SPLINE_SURFACE_WITH_KNOTS`
   readers ignored the leading entity-name field, so they read the name (`'NONE'`) as the
   degree → *"expected integer parameter, got string"*. The unit tests used hand-written
   entities **without** a name field, so the bug passed tests but broke every real file
   (the CIRCLE reader, correctly reading placement at param 1, was the tell). Fixed the
   indices and corrected the fixtures to include the name.

2. **Rational (weighted) b-splines.** These arrive as STEP **complex instances**
   `( BOUNDED_CURVE() B_SPLINE_CURVE(…) B_SPLINE_CURVE_WITH_KNOTS(…) RATIONAL_B_SPLINE_CURVE(weights) … )`,
   which geommap rejected as *"unsupported curve"*. Most kernels (incl. SolidWorks) export
   every freeform curve/surface this way, so a real STEP was unimportable. Map the complex
   form to the kernel's weighted `BSplineCurve`/`BSplineSurface` (component params carry no
   name, so they index from 0).

3. **Silent failure.** `File ▸ Import` wrote errors to stderr only. Route every file-action
   outcome (open/save/import/export) to the **status bar** via `s.SetNotice`, so a kernel
   error — or `Imported X (N bodies)` — is shown. (Addresses the "errors should appear in
   the status bar" request.)

## Result

`EDF.STEP` now imports **as a solid** (verified via `oblikovati-cli import`).

## Tests

Rational curve/surface complex-instance unit tests; corrected with-knots fixtures (now
include the entity name, matching real STEP); a status-bar error-propagation test. Full
`kernel/exchange` + `head/ui` suites green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)