### PR TITLE
fix(import,browser): unique imported-body names + ImGui-safe browser ids

### DIFF
--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -24,10 +24,15 @@ type browserSelectionSync struct{ last app.Selectable }
 
 var browserSync browserSelectionSync
 
+// browserNodeSeq numbers nodes in pre-order each frame so every row gets a unique Dear
+// ImGui id (see drawNode). Reset at the top of each browser draw.
+var browserNodeSeq int
+
 // drawBrowser renders the model browser tree from the active document, then records the
 // selection so the next frame can detect a change for scroll-sync.
 func drawBrowser(s *app.Session) {
 	if native.Begin("Model") {
+		browserNodeSeq = 0
 		drawNode(s, app.BuildBrowser(s))
 		browserSync.last = s.Selection().First()
 	}
@@ -36,7 +41,15 @@ func drawBrowser(s *app.Session) {
 
 // drawNode renders a browser node and its children: a selectable node as a clickable,
 // highlightable row; a branch as a collapsible tree node; a plain leaf as a bullet row.
+//
+// Each node pushes a unique id (its pre-order number) so two rows with the SAME display
+// label — several imported bodies, or two features of the same kind — never collide on one
+// Dear ImGui id, which would break the row's selection, expansion, and context menu. The
+// label is still what's shown; only the id is disambiguated.
 func drawNode(s *app.Session, n app.BrowserNode) {
+	browserNodeSeq++
+	native.PushIDInt(browserNodeSeq)
+	defer native.PopID()
 	switch {
 	case n.Select != nil:
 		drawSelectableNode(s, n)

--- a/model/feature/imported_body.go
+++ b/model/feature/imported_body.go
@@ -45,7 +45,11 @@ func (c *ImportedBodies) Add(body *topo.Body, path, format string) *PartFeature 
 }
 
 // AddAt records body index of a (possibly multi-body) source file as a feature, so reopen
-// re-imports the same body from the file.
+// re-imports the same body from the file. Each body gets a unique, readable name ("Imported
+// Body 1", "Imported Body 2", …) so a multi-solid STEP doesn't fill the browser with
+// identically-named rows (which would collide as Dear ImGui ids).
 func (c *ImportedBodies) AddAt(body *topo.Body, path, format string, index int) *PartFeature {
-	return c.engine.Add(&ImportedBodyFeature{body: body, Path: path, Format: format, Index: index})
+	pf := c.engine.Add(&ImportedBodyFeature{body: body, Path: path, Format: format, Index: index})
+	pf.SetName(c.engine.UniqueName("Imported Body"))
+	return pf
 }

--- a/model/feature/imported_body_test.go
+++ b/model/feature/imported_body_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "testing"
+
+// TestImportedBodiesGetUniqueNames guards that each body of a multi-solid import gets a
+// distinct, readable name (not the bare kind "importedBody" repeated) — repeated identical
+// names collide as Dear ImGui ids in the model browser and break it.
+func TestImportedBodiesGetUniqueNames(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	imp := NewImportedBodies(fs)
+	a := imp.AddAt(nil, "edf.step", "step", 0)
+	b := imp.AddAt(nil, "edf.step", "step", 1)
+	c := imp.AddAt(nil, "edf.step", "step", 2)
+
+	if a.Name() != "Imported Body1" {
+		t.Errorf("first imported body = %q, want Imported Body1", a.Name())
+	}
+	seen := map[string]bool{}
+	for _, pf := range []*PartFeature{a, b, c} {
+		if pf.Name() == "importedBody" {
+			t.Errorf("imported body kept the bare kind name %q", pf.Name())
+		}
+		if seen[pf.Name()] {
+			t.Errorf("duplicate imported-body name %q", pf.Name())
+		}
+		seen[pf.Name()] = true
+	}
+}


### PR DESCRIPTION
## Bug

Importing a multi-solid STEP (`EDF.STEP`, 6 solids) filled the model browser with rows all
named **"importedBody"** and **broke Dear ImGui** — the browser passes a node's display
label straight to ImGui as the widget id, so identical labels collide on one id (selection,
expansion, and context menus break; ImGui asserts on the duplicate).

## Fixes

1. **Unique imported-body names** (`model/feature/imported_body.go`): imported bodies were
   the one feature type that skipped the established `UniqueName()` auto-numbering — every
   other feature already names itself `Extrusion1`, `Hole1`, `Revolution1`, … `AddAt` now
   names them `Imported Body1`, `Imported Body2`, ….
2. **ImGui-safe browser** (`head/ui/browser_view.go`): defense-in-depth so labels never
   matter — `drawNode` pushes a unique per-node id (pre-order sequence) around each row, so
   two rows sharing a display label can never collide on an ImGui id (also disambiguates the
   per-node context-menu and scroll ids).

## Tests

`model/feature` unit test: a multi-body import yields distinct, non-"importedBody" names.
Existing `UniqueName` test still green; `head/ui` builds + lint clean.

Part of the STEP-import robustness work; the imported-geometry-looks-broken issue is a
separate follow-up (ground-truth volume comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)