### PR TITLE
step/topomap: fix stray wedge across imported circular holes (full-circle seam parametrization)

### DIFF
--- a/kernel/exchange/step/hole_triangulation_test.go
+++ b/kernel/exchange/step/hole_triangulation_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package step_test
+
+import (
+	stdmath "math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati/kernel/exchange"
+	"oblikovati/kernel/exchange/step"
+	"oblikovati/kernel/geom"
+	"oblikovati/kernel/ops"
+	"oblikovati/kernel/topo"
+	"oblikovati/math"
+)
+
+// TestImportedHoleNotTriangulatedOver guards the full-circle seam fix: a planar face bordering a
+// circular hole must not have any triangle covering the hole. The bug was a full-circle edge
+// whose parametrization did not start at its seam vertex, so discretizeEdge snapped the
+// endpoints onto a ring that started elsewhere — a self-touching ring that earcut filled with a
+// stray "wedge" across the hole (visible as red/green stray triangles in the drilled box).
+func TestImportedHoleNotTriangulatedOver(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "occ", "drilled_box.step"))
+	if err != nil {
+		t.Fatalf("read drilled_box.step: %v", err)
+	}
+	bodies, _, err := step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: 1})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	covering := 0
+	for _, b := range bodies {
+		for _, f := range b.Faces() {
+			if _, ok := f.Geometry().(geom.Plane); !ok {
+				continue
+			}
+			covering += holeCoveringTriangles(f)
+		}
+	}
+	if covering > 0 {
+		t.Errorf("%d planar triangles cover a hole (want 0) — the seam ring is self-touching again", covering)
+	}
+}
+
+// holeCoveringTriangles counts a planar face's mesh triangles whose centroid lies inside one of
+// the face's hole loops — a triangle that should not exist (the hole interior must stay empty).
+func holeCoveringTriangles(f *topo.Face) int {
+	holes := faceHoleDiscs(f)
+	if len(holes) == 0 {
+		return 0
+	}
+	m := ops.TessellateFace(f, ops.DefaultQuality())
+	n := 0
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		a, b, c := m.Positions[m.Indices[t]], m.Positions[m.Indices[t+1]], m.Positions[m.Indices[t+2]]
+		mx := (float64(a.X) + float64(b.X) + float64(c.X)) / 3
+		my := (float64(a.Y) + float64(b.Y) + float64(c.Y)) / 3
+		for _, h := range holes {
+			if stdmath.Hypot(mx-h.cx, my-h.cy) < h.r*0.85 { // 0.85 to avoid rim-adjacent false positives
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+type holeDisc struct{ cx, cy, r float64 }
+
+// faceHoleDiscs approximates each inner (hole) loop by its centroid and radius, in the same XY
+// the planar triangulation uses (the fixtures' holes lie in Z planes, so XY suffices here).
+func faceHoleDiscs(f *topo.Face) []holeDisc {
+	var out []holeDisc
+	for _, l := range f.Loops() {
+		if l.IsOuter() {
+			continue
+		}
+		var pts []math.Point3
+		for _, u := range l.EdgeUses() {
+			pts = append(pts, ops.TessellateEdge(u.Edge(), ops.DefaultQuality())...)
+		}
+		if len(pts) < 3 {
+			continue
+		}
+		var cx, cy float64
+		for _, p := range pts {
+			cx, cy = cx+float64(p.X), cy+float64(p.Y)
+		}
+		cx, cy = cx/float64(len(pts)), cy/float64(len(pts))
+		var r float64
+		for _, p := range pts {
+			if d := stdmath.Hypot(float64(p.X)-cx, float64(p.Y)-cy); d > r {
+				r = d
+			}
+		}
+		out = append(out, holeDisc{cx, cy, r})
+	}
+	return out
+}

--- a/kernel/exchange/step/topomap/brep_from_step_test.go
+++ b/kernel/exchange/step/topomap/brep_from_step_test.go
@@ -182,12 +182,24 @@ func TestCircleEdgeTrimsArcAndFullCircle(t *testing.T) {
 	if stdmath.Abs(arc.SweepAngle+3*stdmath.Pi/2) > 1e-12 {
 		t.Fatalf("CW sweep = %g, want -3*pi/2", arc.SweepAngle)
 	}
-	curve, err = circleEdge(circle, start, start, true)
+	// A full-circle seam parametrizes FROM the seam vertex: PointAt(0) must equal the vertex, so
+	// discretizeEdge's endpoint snap is a no-op and the boundary ring is a clean simple ring (not
+	// the self-touching ring that produced a stray wedge across a bordering hole). Use a seam
+	// vertex NOT at the circle's natural RefDir (+X) to exercise the alignment.
+	seam := math.P3(0, 2, 0)
+	curve, err = circleEdge(circle, seam, seam, true)
 	if err != nil {
 		t.Fatalf("circleEdge full circle: %v", err)
 	}
-	if _, ok := curve.(geom.Circle); !ok {
-		t.Fatalf("full circle returned %T, want Circle", curve)
+	full, ok := curve.(geom.Arc3d)
+	if !ok {
+		t.Fatalf("full circle returned %T, want Arc3d", curve)
+	}
+	if stdmath.Abs(full.SweepAngle-2*stdmath.Pi) > 1e-12 {
+		t.Fatalf("full-circle sweep = %g, want 2*pi", full.SweepAngle)
+	}
+	if p := full.PointAt(0); p.DistanceTo(seam) > 1e-9 {
+		t.Fatalf("full circle PointAt(0) = %v, want the seam vertex %v", p, seam)
 	}
 }
 

--- a/kernel/exchange/step/topomap/build_edge.go
+++ b/kernel/exchange/step/topomap/build_edge.go
@@ -94,11 +94,16 @@ func ellipseAngle(e geommap.EllipseParams, p math.Point3) float64 {
 }
 
 // circleEdge trims a CIRCLE to the arc/circle between two vertices. Coincident
-// endpoints (a seam vertex) keep the full Circle; otherwise it builds an Arc3d whose
+// endpoints (a seam vertex) keep the full circle; otherwise it builds an Arc3d whose
 // sweep runs start→end in the sense the circle's frame (and same_sense) imply.
 func circleEdge(c geommap.CircleParams, start, end math.Point3, sameSense bool) (geom.Curve3, error) {
 	if start.DistanceTo(end) < seamTol {
-		return geom.NewCircle(c.Center, c.Normal, c.Radius)
+		// A full-circle seam. Parametrize the circle FROM the seam vertex (RefDir aimed at
+		// `start`), so PointAt(0) == the vertex and discretizeEdge's endpoint snap is a no-op.
+		// A plain NewCircle uses an arbitrary RefDir, so PointAt(0) lands elsewhere and snapping
+		// both endpoints to the seam vertex yields a self-touching ring — which earcut fills with
+		// a stray wedge across the hole on the planar face that borders this loop.
+		return geom.NewArc3d(c.Center, c.Normal, c.Center.VectorTo(start), c.Radius, 0, twoPi)
 	}
 	startAng := circleAngle(c, start)
 	ccw := positiveSweep(startAng, circleAngle(c, end)) // CCW arc start→end


### PR DESCRIPTION
## What
An imported planar face bordering a circular hole rendered a stray **wedge of triangles across the hole** (the inverted/extra triangles seen in the drilled box via the Normal Debug view).

## Root cause
A full-circle `EDGE_CURVE` (start==end seam vertex) was mapped to a plain `geom.Circle` whose RefDir — hence `PointAt(0)` — is arbitrary, **not** the seam vertex. `discretizeEdge` snaps the ring's first/last points to the seam vertex while the interior points follow the circle's own parametrization, so the ring opens with a chord jump (`0° → 79° → … → 0°`) — a **self-touching ring** that earcut fills with a hole-spanning triangle. (The cylinder wall was unaffected because it tessellates via `periodicBandGrid`, which re-evaluates the surface and doesn't rely on the edge ring.)

## Fix
Build the seam circle as an `Arc3d` with RefDir aimed at the seam vertex (full 2π sweep), so `PointAt(0) == the vertex` and the endpoint snap is a no-op → a clean simple boundary ring. The analytic shape is unchanged; only the parametrization start moves.

## Tests
- New integration test: no planar triangle covers a hole in the imported drilled box.
- Updated `circleEdge` unit test: a full-circle seam returns an Arc3d whose `PointAt(0)` is the seam vertex.
- OCC oracle suite still 14/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)