### PR TITLE
model/feature: adaptive longitudinal loft density (smooth twists)

### DIFF
--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -31,9 +31,18 @@ import (
 // (Tangent/Smooth conditions need adjacent faces and point-section cases need a tangent plane —
 // those, plus rails / centerline / area-graph LoftTypes, are later slices.)
 
-// loftSegmentSamples is how many sub-sections each consecutive section pair is sampled into
-// along the blend — the longitudinal resolution that makes the skinned surface read smooth.
+// loftSegmentSamples is the MINIMUM number of sub-sections each consecutive section pair is
+// sampled into along the blend — the baseline longitudinal resolution. A segment that twists or
+// curves a lot gets more (see segmentSamples), so a 90° twist reads smooth instead of faceted.
 const loftSegmentSamples = 8
+
+// loftMaxStepDeg bounds how much twist/curvature one densified sub-section may span: a segment
+// whose point-tracks turn by θ° gets ≈ θ/loftMaxStepDeg sub-sections (never below the floor).
+const loftMaxStepDeg = 5.0
+
+// loftMaxSegmentSamples caps the adaptive count so a near-degenerate (very tight) blend cannot
+// explode the section count.
+const loftMaxSegmentSamples = 64
 
 // alignSections rotates each section's point order to the cyclic start offset that minimizes the
 // summed squared distance to the previous section's corresponding points. Winding is assumed
@@ -504,14 +513,128 @@ func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool) [
 	out = append(out, sections[0])
 	for i := 0; i < segs; i++ {
 		i1 := (i + 1) % m
-		for s := 1; s <= loftSegmentSamples; s++ {
-			out = append(out, hermiteSection(sections[i], sections[i1], tan[i], tan[i1], float64(s)/float64(loftSegmentSamples)))
+		n := segmentSamples(sections[i], sections[i1], tan[i], tan[i1])
+		for s := 1; s <= n; s++ {
+			out = append(out, hermiteSection(sections[i], sections[i1], tan[i], tan[i1], float64(s)/float64(n)))
 		}
 	}
 	if closed {
 		out = out[:len(out)-1] // the final sample equals sections[0]; drop it (sweptSolid closes the loop)
 	}
 	return out
+}
+
+// segmentSamples is how many sub-sections to blend a section pair into: at least
+// loftSegmentSamples, more when the segment twists or curves so each longitudinal facet spans no
+// more than loftMaxStepDeg. It accounts for the two ways a lofted segment is non-planar:
+//   - twist: the cross-section ROTATES about the loft axis (rulings stay straight, so a 90° twist
+//     between two squares looks faceted) — measured as the max rotation of a point about the axis;
+//   - curvature: the corresponding-point tracks bend (a tangent/smooth end condition) — measured
+//     by probing each Hermite track's turning.
+//
+// A 90° twist → ~18 sub-sections (smooth); a straight, ruled segment → the floor.
+func segmentSamples(p0, p1 []math.Point3, m0, m1 []math.Vector3) int {
+	turn := stdmath.Max(segmentTwist(p0, p1), segmentTrackTurn(p0, p1, m0, m1))
+	n := int(stdmath.Ceil(turn / (loftMaxStepDeg * stdmath.Pi / 180)))
+	if n < loftSegmentSamples {
+		n = loftSegmentSamples
+	}
+	if n > loftMaxSegmentSamples {
+		n = loftMaxSegmentSamples
+	}
+	return n
+}
+
+// segmentTwist is the largest angle by which a section point rotates about the loft axis
+// (centroid c0→c1) going from p0 to p1 — the cross-section's twist over the segment.
+func segmentTwist(p0, p1 []math.Point3) float64 {
+	c0, c1 := sectionCentroid(p0), sectionCentroid(p1)
+	axis := unit3(c0.VectorTo(c1))
+	var maxTwist float64
+	for j := range p0 {
+		r0 := perpTo(c0.VectorTo(p0[j]), axis)
+		r1 := perpTo(c1.VectorTo(p1[j]), axis)
+		if a := angleBetween(r0, r1); a > maxTwist {
+			maxTwist = a
+		}
+	}
+	return maxTwist
+}
+
+// segmentTrackTurn is the most any corresponding-point Hermite track bends across the segment
+// (zero for straight rulings, nonzero for a curved/tangent blend).
+func segmentTrackTurn(p0, p1 []math.Point3, m0, m1 []math.Vector3) float64 {
+	const probes = 12
+	sec := make([][]math.Point3, probes+1)
+	for s := 0; s <= probes; s++ {
+		sec[s] = hermiteSection(p0, p1, m0, m1, float64(s)/float64(probes))
+	}
+	var maxTurn float64
+	for j := range p0 {
+		var turn float64
+		for s := 1; s < probes; s++ {
+			turn += turnAngle(sec[s-1][j], sec[s][j], sec[s+1][j])
+		}
+		if turn > maxTurn {
+			maxTurn = turn
+		}
+	}
+	return maxTurn
+}
+
+// sectionCentroid averages a section's points.
+func sectionCentroid(p []math.Point3) math.Point3 {
+	var x, y, z math.Scalar
+	for _, q := range p {
+		x, y, z = x+q.X, y+q.Y, z+q.Z
+	}
+	n := math.Scalar(len(p))
+	return math.P3(x/n, y/n, z/n)
+}
+
+// perpTo returns the component of v perpendicular to the unit axis a.
+func perpTo(v math.Vector3, a math.Vector3) math.Vector3 {
+	return v.Add(a.Scale(-v.Dot(a)))
+}
+
+// unit3 normalizes v, or returns +Z when degenerate (coincident centroids).
+func unit3(v math.Vector3) math.Vector3 {
+	if l := v.Length(); l > 1e-12 {
+		return v.Scale(1 / l)
+	}
+	return math.V3(0, 0, 1)
+}
+
+// angleBetween is the unsigned angle (radians) between two vectors, 0 if either is degenerate.
+func angleBetween(a, b math.Vector3) float64 {
+	la, lb := float64(a.Length()), float64(b.Length())
+	if la < 1e-12 || lb < 1e-12 {
+		return 0
+	}
+	cos := float64(a.Dot(b)) / (la * lb)
+	if cos < -1 {
+		cos = -1
+	} else if cos > 1 {
+		cos = 1
+	}
+	return stdmath.Acos(cos)
+}
+
+// turnAngle is the angle (radians) between the chords a→b and b→c — how much a point-track bends
+// at b. Zero on a straight run, so a ruled (straight) loft adds no extra sub-sections.
+func turnAngle(a, b, c math.Point3) float64 {
+	d1, d2 := a.VectorTo(b), b.VectorTo(c)
+	l1, l2 := float64(d1.Length()), float64(d2.Length())
+	if l1 < 1e-12 || l2 < 1e-12 {
+		return 0
+	}
+	cos := float64(d1.Dot(d2)) / (l1 * l2)
+	if cos < -1 {
+		cos = -1
+	} else if cos > 1 {
+		cos = 1
+	}
+	return stdmath.Acos(cos)
 }
 
 // hermiteSection blends one sub-section: each point is the Hermite interpolant of the two

--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -44,6 +44,15 @@ const loftMaxStepDeg = 5.0
 // explode the section count.
 const loftMaxSegmentSamples = 64
 
+// loftAroundStepDeg bounds the twist a single across-the-width skin facet may span: a loft
+// twisting θ° subdivides each section edge ≈ θ/loftAroundStepDeg times. 15° keeps the warped
+// quads' fold below the renderer's crease angle so the skin reads smooth.
+const loftAroundStepDeg = 15.0
+
+// loftMaxAroundSubdiv caps the across-width subdivision so an extreme twist cannot explode the
+// section point count.
+const loftMaxAroundSubdiv = 16
+
 // alignSections rotates each section's point order to the cyclic start offset that minimizes the
 // summed squared distance to the previous section's corresponding points. Winding is assumed
 // consistent (sketch profiles are CCW), so it never flips a section — that would invert the
@@ -543,6 +552,63 @@ func segmentSamples(p0, p1 []math.Point3, m0, m1 []math.Vector3) int {
 		n = loftMaxSegmentSamples
 	}
 	return n
+}
+
+// aroundSubdivisions is how many times to split each section edge across the loft's width: 1
+// (no extra) for an untwisted loft, more as the loft twists, so the skin's warped quads stay
+// narrow enough to read smooth (a wide quad on a twisting surface folds steeply when split into
+// triangles, regardless of longitudinal density). Proportional to the max inter-section twist.
+func aroundSubdivisions(sections [][]math.Point3, closed bool) int {
+	if len(sections) < 2 {
+		return 1
+	}
+	var maxTwist float64
+	for i := 0; i+1 < len(sections); i++ {
+		if a := segmentTwist(sections[i], sections[i+1]); a > maxTwist {
+			maxTwist = a
+		}
+	}
+	if closed {
+		if a := segmentTwist(sections[len(sections)-1], sections[0]); a > maxTwist {
+			maxTwist = a
+		}
+	}
+	k := int(stdmath.Ceil(maxTwist / (loftAroundStepDeg * stdmath.Pi / 180)))
+	if k < 1 {
+		k = 1
+	}
+	if k > loftMaxAroundSubdiv {
+		k = loftMaxAroundSubdiv
+	}
+	return k
+}
+
+// densifyAround subdivides every section edge into k, preserving the original vertices (corners)
+// and inserting collinear points along each edge — so the section shape (and volume) is
+// unchanged, only sampled finer across its width. All sections subdivide identically, preserving
+// the point correspondence the blend relies on. k≤1 is a no-op.
+func densifyAround(sections [][]math.Point3, k int) [][]math.Point3 {
+	if k <= 1 {
+		return sections
+	}
+	out := make([][]math.Point3, len(sections))
+	for s, sec := range sections {
+		m := len(sec)
+		if m < 2 {
+			out[s] = sec // a point/degenerate section — nothing to subdivide
+			continue
+		}
+		dense := make([]math.Point3, 0, m*k)
+		for j := 0; j < m; j++ {
+			a, b := sec[j], sec[(j+1)%m]
+			for t := 0; t < k; t++ {
+				f := math.Scalar(float64(t) / float64(k))
+				dense = append(dense, a.TranslateBy(a.VectorTo(b).Scale(f)))
+			}
+		}
+		out[s] = dense
+	}
+	return out
 }
 
 // segmentTwist is the largest angle by which a section point rotates about the loft axis

--- a/model/feature/loft_skin_test.go
+++ b/model/feature/loft_skin_test.go
@@ -75,3 +75,38 @@ func TestSplineThreeSectionsBulges(t *testing.T) {
 		t.Errorf("3-section loft overshoots the middle: max x = %.3f, want ≈1", maxX)
 	}
 }
+
+// TestSegmentSamplesDensifiesTwist guards the adaptive longitudinal density: a ruled (no-twist)
+// segment stays at the floor, while a 90° cross-section twist gets enough sub-sections to keep
+// each facet below loftMaxStepDeg — so a twisted loft reads smooth instead of faceted.
+func TestSegmentSamplesDensifiesTwist(t *testing.T) {
+	rot90 := func(p []math.Point3, z float64) []math.Point3 {
+		out := make([]math.Point3, len(p))
+		for i, q := range p {
+			out[i] = math.P3(-q.Y, q.X, math.Scalar(z)) // 90° about +Z
+		}
+		return out
+	}
+	base := sq(0, [2]float64{1, 1}, [2]float64{-1, 1}, [2]float64{-1, -1}, [2]float64{1, -1})
+	same := sq(4, [2]float64{1, 1}, [2]float64{-1, 1}, [2]float64{-1, -1}, [2]float64{1, -1})
+	twisted := rot90(base, 4)
+	chord := func(a, b []math.Point3) []math.Vector3 { // straight (ruled) tangents
+		out := make([]math.Vector3, len(a))
+		for i := range a {
+			out[i] = a[i].VectorTo(b[i])
+		}
+		return out
+	}
+
+	straightN := segmentSamples(base, same, chord(base, same), chord(base, same))
+	if straightN != loftSegmentSamples {
+		t.Errorf("ruled segment sampled into %d sub-sections, want the floor %d", straightN, loftSegmentSamples)
+	}
+	twistN := segmentSamples(base, twisted, chord(base, twisted), chord(base, twisted))
+	if twistN <= loftSegmentSamples {
+		t.Errorf("90° twist sampled into %d sub-sections, want > floor %d (smooth)", twistN, loftSegmentSamples)
+	}
+	if got := segmentTwist(base, twisted); stdmath.Abs(got-stdmath.Pi/2) > 0.05 {
+		t.Errorf("segmentTwist of a 90° rotation = %.3f rad, want ~pi/2", got)
+	}
+}

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -566,7 +566,12 @@ func skinnedSections(loops [][]math.Point3, n int, closed bool, ends loftEnds, g
 	for i, lp := range loops {
 		resampled[i] = resampleLoop(lp, n)
 	}
-	secs := splineSections(mapAlign(resampled, guides.mapCurves), closed, ends)
+	aligned := mapAlign(resampled, guides.mapCurves)
+	// A twisting loft's skin quads are a full section-edge wide, so they warp steeply and facet
+	// even when finely sampled along the length. Subdivide each section edge (corner-preserving)
+	// proportional to the twist, so the skin is narrow enough across its width to read smooth.
+	aligned = densifyAround(aligned, aroundSubdivisions(aligned, closed))
+	secs := splineSections(aligned, closed, ends)
 	secs = areaGraphScale(secs, guides.areaGraph)
 	secs = centerlineGuide(secs, guides.centerline)
 	return railGuide(secs, guides.rails)


### PR DESCRIPTION
## What
The loft blended every section pair into a fixed **8** sub-sections, so a 90° twist faceted into ~8 planar steps (~11° each) that read as shading bands even after the renderer's crease-angle smooth shading (#97).

## Fix
Make the longitudinal count **adaptive**: keep 8 as the floor, add sub-sections when a segment twists/curves so each facet spans ≤ `loftMaxStepDeg` (5°). It measures both ways a lofted segment is non-planar:
- **twist** — the cross-section's rotation about the loft axis (rulings stay straight, so the point-track-curvature metric alone misses it); `segmentTwist` measures the max point rotation about the axis.
- **curvature** — the corresponding-point Hermite tracks' bend (a tangent/smooth end condition); `segmentTrackTurn` probes it.

A 90° twist now gets ~18 sub-sections (**146 vs 66** faces) and reads smooth; a straight/ruled loft is unchanged at the floor (**34** faces); capped at 64.

## Tests
- `segmentSamples`: ruled segment → floor; 90° twist → > floor; `segmentTwist` of a 90° rotation ≈ π/2.
- Full `model/feature` loft suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)