### PR TITLE
head: depth-bias work-plane fills (stop z-fighting with coplanar geometry)

### DIFF
--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -63,7 +63,7 @@ func RunViewportSmoke(maxFrames int) int {
 	for i := 0; i < maxFrames && !w.ShouldClose(); i++ {
 		w.BeginFrame()
 		w.RenderViewport(0, 1280, 720, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx))
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 	if path := os.Getenv("OBK_SMOKE_PNG"); path != "" {

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -263,6 +263,10 @@ VkPipeline create_pipeline(HeadContext* c, Viewport* v, VkPrimitiveTopology topo
     rs.cullMode = VK_CULL_MODE_NONE;
     rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
     rs.lineWidth = 1.0f;
+    // Depth bias is dynamic (set per draw via vkCmdSetDepthBias): zero for solid geometry, a
+    // small push-back for coplanar reference overlays (work-plane fills) so the solid wins the
+    // depth test instead of z-fighting. Enabled here so the dynamic state takes effect.
+    rs.depthBiasEnable = VK_TRUE;
 
     VkPipelineMultisampleStateCreateInfo ms{};
     ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
@@ -292,10 +296,11 @@ VkPipeline create_pipeline(HeadContext* c, Viewport* v, VkPrimitiveTopology topo
     cb.attachmentCount = 1;
     cb.pAttachments = &cba;
 
-    VkDynamicState dyn[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+    VkDynamicState dyn[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR,
+                            VK_DYNAMIC_STATE_DEPTH_BIAS};
     VkPipelineDynamicStateCreateInfo dynState{};
     dynState.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-    dynState.dynamicStateCount = 2;
+    dynState.dynamicStateCount = 3;
     dynState.pDynamicStates = dyn;
 
     VkGraphicsPipelineCreateInfo ci{};
@@ -968,7 +973,8 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
                          const float* lineV, int lineVC, const uint32_t* lineIdx, int lineIC,
                          const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC,
                          const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
-                         const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC) {
+                         const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
+                         int triBiasFirst) {
     HeadContext* c = (HeadContext*)h;
     Viewport* v = c->viewport;
     if (!v || w <= 0 || hh <= 0) return;
@@ -1060,6 +1066,7 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
     VkRect2D scissor{{0, 0}, {(uint32_t)w, (uint32_t)hh}};
     vkCmdSetViewport(v->cmd, 0, 1, &vpRect);
     vkCmdSetScissor(v->cmd, 0, 1, &scissor);
+    vkCmdSetDepthBias(v->cmd, 0.0f, 0.0f, 0.0f); // default: solid geometry draws at zero bias
 
     // The scene-lighting + environment set (set 0) is shared by the skybox and every geometry
     // pipeline; bind it once, before any draw, so the background renders even with no geometry.
@@ -1106,7 +1113,19 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
         if (triIC > 0) {
             pushLit(v->normalDebug ? 2.0f : 1.0f);
             vkCmdBindPipeline(v->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->triPipeline);
-            vkCmdDrawIndexed(v->cmd, (uint32_t)triIC, 1, (uint32_t)triFirst, triBase, 0);
+            int opaque = triBiasFirst;
+            if (opaque < 0 || opaque > triIC) opaque = triIC; // guard against a bad split index
+            if (opaque > 0) {
+                vkCmdDrawIndexed(v->cmd, (uint32_t)opaque, 1, (uint32_t)triFirst, triBase, 0);
+            }
+            // Reference-overlay fills (work planes) draw last with a small depth push-back so a
+            // coplanar solid face wins the depth test (no z-fighting); reset after.
+            if (triIC - opaque > 0) {
+                vkCmdSetDepthBias(v->cmd, 2.0f, 0.0f, 2.0f);
+                vkCmdDrawIndexed(v->cmd, (uint32_t)(triIC - opaque), 1,
+                                 (uint32_t)(triFirst + opaque), triBase, 0);
+                vkCmdSetDepthBias(v->cmd, 0.0f, 0.0f, 0.0f);
+            }
         }
         // 3) solid edges — depth-tested, so only the visible portions appear.
         if (lineIC > 0) {

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -18,7 +18,8 @@ void     obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp,
                              const float* lineV, int lineVC, const uint32_t* lineIdx, int lineIC,
                              const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC,
                              const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
-                             const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC);
+                             const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
+                             int triBiasFirst);
 void     obk_viewport_set_clear(void* h, float r, float g, float b);
 void     obk_viewport_set_normal_debug(void* h, int on);
 void     obk_viewport_set_lighting(void* h, const float* data, int n);
@@ -74,6 +75,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 	hidVerts []float32, hidVCount int, hidIdx []uint32,
 	topTriVerts []float32, topTriVCount int, topTriIdx []uint32,
 	topLineVerts []float32, topLineVCount int, topLineIdx []uint32,
+	triBiasFirst int,
 ) {
 	C.obk_viewport_render(win.handle, C.int(slot), C.int(w), C.int(h),
 		(*C.float)(unsafe.Pointer(&mvp[0])), floatPtr(camPos),
@@ -82,7 +84,8 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 		floatPtr(lineVerts), C.int(lineVCount), uint32Ptr(lineIdx), C.int(len(lineIdx)),
 		floatPtr(hidVerts), C.int(hidVCount), uint32Ptr(hidIdx), C.int(len(hidIdx)),
 		floatPtr(topTriVerts), C.int(topTriVCount), uint32Ptr(topTriIdx), C.int(len(topTriIdx)),
-		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)))
+		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)),
+		C.int(triBiasFirst))
 }
 
 // SetViewportClear sets the 3D pass background color (themed); it takes effect on the

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -331,7 +331,8 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 		m.LineVerts, m.LineVCount, m.LineIndices,
 		m.HidVerts, m.HidVCount, m.HidIndices,
 		m.TopTriVerts, m.TopTriVCount, m.TopTriIndices,
-		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices)
+		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices,
+		m.TriBiasFirst)
 	if tex := win.ViewportTexture(slot); tex != 0 {
 		native.SetCursorPos(cx, cy) // draw the image back over the invisible button
 		native.Image(tex, float32(pw), float32(ph))

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -93,6 +93,7 @@ func planeFill(wp *feature.WorkPlane) renderer.DrawItem {
 		Indices:   []int{0, 1, 2, 0, 2, 3},
 		Color:     planeFillColor,
 		Opacity:   planeFillColor[3],
+		Biased:    true, // a reference overlay: depth-bias it so a coplanar body face wins (no z-fight)
 	}
 }
 

--- a/head/viewport/flatten.go
+++ b/head/viewport/flatten.go
@@ -22,9 +22,14 @@ const VertexFloats = 16
 // Indices are 0-based within each stream's own vertex array (the pipeline applies the
 // vertex offset).
 type Mesh struct {
-	TriVerts       []float32
-	TriVCount      int
-	TriIndices     []uint32
+	TriVerts   []float32
+	TriVCount  int
+	TriIndices []uint32
+	// TriBiasFirst is the index into TriIndices at which the depth-biased triangles begin
+	// (Biased items — work-plane/ground-plane fills — are appended after the opaque triangles).
+	// The native pass draws [0,TriBiasFirst) at zero bias and [TriBiasFirst,len) with a small
+	// bias so coplanar reference overlays do not z-fight solid geometry.
+	TriBiasFirst   int
 	OccVerts       []float32
 	OccVCount      int
 	OccIndices     []uint32
@@ -49,6 +54,7 @@ type Mesh struct {
 // Occluder is set, and lines to the hidden stream when Hidden is set.
 func Flatten(list renderer.DrawList) Mesh {
 	var m Mesh
+	var biased []renderer.DrawItem
 	for _, item := range list.Items {
 		switch {
 		case item.OnTop && item.Primitive == renderer.Triangles:
@@ -57,6 +63,8 @@ func Flatten(list renderer.DrawList) Mesh {
 			m.TopLineVCount = appendItem(&m.TopLineVerts, &m.TopLineIndices, m.TopLineVCount, item)
 		case item.Primitive == renderer.Triangles && item.Occluder:
 			m.OccVCount = appendItem(&m.OccVerts, &m.OccIndices, m.OccVCount, item)
+		case item.Primitive == renderer.Triangles && item.Biased:
+			biased = append(biased, item) // appended after the opaque triangles, below
 		case item.Primitive == renderer.Triangles:
 			m.TriVCount = appendItem(&m.TriVerts, &m.TriIndices, m.TriVCount, item)
 		case item.Hidden:
@@ -64,6 +72,12 @@ func Flatten(list renderer.DrawList) Mesh {
 		default:
 			m.LineVCount = appendItem(&m.LineVerts, &m.LineIndices, m.LineVCount, item)
 		}
+	}
+	// Biased reference overlays go at the tail of the triangle stream so the native pass can draw
+	// them with a depth bias (after the opaque triangles at zero bias).
+	m.TriBiasFirst = len(m.TriIndices)
+	for _, item := range biased {
+		m.TriVCount = appendItem(&m.TriVerts, &m.TriIndices, m.TriVCount, item)
 	}
 	return m
 }

--- a/renderer/drawlist.go
+++ b/renderer/drawlist.go
@@ -51,7 +51,12 @@ type DrawItem struct {
 	// model) — the interaction-overlay lane and burn-through markers/labels of client
 	// graphics (Inventor's BurnThrough). The viewport routes these to the depth-disabled
 	// on-top pass (PBI-067); a headless NullBackend simply records them like any item.
-	OnTop    bool
+	OnTop bool
+	// Biased marks a translucent reference overlay (a work-plane / ground-plane fill) that should
+	// render with a small depth bias, so where it is coplanar with solid geometry the solid wins
+	// the depth test instead of z-fighting. Display only; routed to the biased tail of the
+	// triangle stream (see viewport.Flatten).
+	Biased   bool
 	ObjectID uint64
 }
 


### PR DESCRIPTION
## What
A work-plane fill coplanar with a body face (e.g. a loft cap sketched on that offset plane) z-fought the face — both wrote the same depth, producing a speckled moiré.

## Fix
Treat reference-overlay fills as **decals**: a `Biased` flag on `DrawItem` routes them to the tail of the triangle stream (`viewport.Flatten` records `TriBiasFirst`), and the native pass draws that range with a small **dynamic Vulkan depth bias** so a coplanar solid face wins the depth test, while the plane still draws normally in free space. Display only — geometry, mass properties, picking, and export are unchanged (the depth-bias mechanism already existed for the shadow map).

Confirmed live: the loft's work-plane moiré is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)