### PR TITLE
kernel/ops: wind curved-patch triangles by their own vertex normals (fix inverted b-spline patches)

### DIFF
--- a/kernel/ops/boundary_patch_winding_test.go
+++ b/kernel/ops/boundary_patch_winding_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// TestBoundaryPatchConsistentWinding guards the curved-patch orientation fix: a curved face
+// triangulated from its boundary must wind EVERY triangle to agree with its own vertices'
+// normals, so none renders back-facing among front-facing (the inverted-normal patches seen on
+// imported freeform b-spline faces). The earlier centroid-sampled flip mis-oriented triangles on
+// a curved patch because the flat triangle's centroid lies off the surface.
+func TestBoundaryPatchConsistentWinding(t *testing.T) {
+	sphere, err := geom.NewSphere(math.P3(0, 0, 0), 10)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	// A cap rim: a ring of points on the sphere at 45° latitude (a strongly curved patch with no
+	// interior point, so its triangles span the curvature — where the centroid sample failed).
+	const n = 24
+	var rim []math.Point3
+	for i := 0; i < n; i++ {
+		a := 2 * stdmath.Pi * float64(i) / float64(n)
+		rim = append(rim, math.P3(
+			math.Scalar(10*stdmath.Cos(stdmath.Pi/4)*stdmath.Cos(a)),
+			math.Scalar(10*stdmath.Cos(stdmath.Pi/4)*stdmath.Sin(a)),
+			math.Scalar(10*stdmath.Sin(stdmath.Pi/4))))
+	}
+	m := boundaryPatchMesh(sphere, rim, nil)
+	if m.TriangleCount() == 0 {
+		t.Fatal("cap patch produced no triangles")
+	}
+	bad := 0
+	for tri := 0; tri+2 < len(m.Indices); tri += 3 {
+		i0, i1, i2 := m.Indices[tri], m.Indices[tri+1], m.Indices[tri+2]
+		a, b, c := m.Positions[i0], m.Positions[i1], m.Positions[i2]
+		gn := a.VectorTo(b).Cross(a.VectorTo(c))
+		sn := m.Normals[i0].Add(m.Normals[i1]).Add(m.Normals[i2])
+		if gn.Dot(sn) < 0 {
+			bad++
+		}
+	}
+	if bad > 0 {
+		t.Errorf("%d of %d patch triangles wind against their vertex normals (inconsistent)", bad, m.TriangleCount())
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -79,7 +79,12 @@ func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.P
 	}
 	for _, tri := range tris {
 		a, b, c := tri[0], tri[1], tri[2]
-		if triangleFlipped(s, pos[a], pos[b], pos[c]) {
+		// Wind each triangle to agree with its OWN vertices' surface normals (what shading and
+		// mass-props read), not the surface normal at the triangle centroid: on a curved patch
+		// the flat-triangle centroid lies off the surface, so ParamAt(centroid) returns a wrong
+		// (u,v) and flips some triangles inconsistently — the back-facing patches seen in
+		// Normal-Debug. Averaging the three vertex normals is consistent for every triangle.
+		if windingOpposesNormals(pos[a], pos[b], pos[c], m.Normals[a], m.Normals[b], m.Normals[c]) {
 			b, c = c, b
 		}
 		m.addTriangle(a, b, c)
@@ -149,6 +154,15 @@ func triangleFlipped(s geom.Surface, a, b, c math.Point3) bool {
 	cen := math.P3((a.X+b.X+c.X)/3, (a.Y+b.Y+c.Y)/3, (a.Z+b.Z+c.Z)/3)
 	u, v := s.ParamAt(cen)
 	return n.Dot(s.NormalAt(u, v)) < 0
+}
+
+// windingOpposesNormals reports whether triangle abc's geometric (cross-product) normal opposes
+// the triangle's per-vertex shading normals (their sum). Used to wind a patch consistently with
+// the normals each vertex actually carries — robust on a curved patch where the flat triangle's
+// centroid is off the surface (unlike triangleFlipped's centroid sample).
+func windingOpposesNormals(a, b, c math.Point3, na, nb, nc math.Vector3) bool {
+	gn := a.VectorTo(b).Cross(a.VectorTo(c))
+	return gn.Dot(na.Add(nb).Add(nc)) < 0
 }
 
 // isoRectangleGrid returns the sorted u and v grid lines when the UV boundary is an


### PR DESCRIPTION
## What
Imported freeform b-spline faces showed **back-facing patches among front-facing** (red blobs in Normal-Debug on EDF.STEP's top view) — inconsistent winding within a single face.

## Cause
`boundaryPatchMesh` oriented each triangle with `triangleFlipped`, which samples the surface normal at the triangle **centroid**. On a curved patch the flat triangle's centroid lies *off* the surface, so `ParamAt(centroid)` returns a wrong (u,v) → wrong normal → some triangles flipped against the per-vertex normals the mesh actually carries.

## Fix
Wind each triangle to agree with its **own three vertex normals** (`windingOpposesNormals`) — the same normals shading and mass-props use — which is consistent for every triangle on a curved patch.

## Verified
- EDF.STEP: several b-spline/cylinder faces with **MIXED winding → zero**; volume unchanged (winding doesn't affect the normal-reoriented mass-props).
- New regression test tessellates a strongly-curved sphere-cap patch and asserts every triangle agrees with its vertex normals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)