### PR TITLE
kernel/ops: triangulate b-spline patches in (u,v) (fix torn freeform faces + volume)

### DIFF
--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -58,7 +58,7 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 // outward. A coarse but watertight covering of the exact trim region — right for small patches
 // (corner blends); larger non-rectangular curved faces would want a refined triangulation.
 func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) *Mesh {
-	outer2D, holes2D := projectToPlane(outer3D, holes3D)
+	outer2D, holes2D := patchProjection(s, outer3D, holes3D)
 	pos := outer3D
 	var tris [][3]int
 	if len(holes2D) > 0 {
@@ -90,6 +90,30 @@ func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.P
 		m.addTriangle(a, b, c)
 	}
 	return m
+}
+
+// patchProjection picks the 2D embedding to ear-clip a curved patch's boundary in. A B-spline
+// patch is flattened in its OWN (u,v) parameter space, where the trim loops are a simple polygon;
+// the best-fit PLANE projection (used for the analytic surfaces, whose (u,v) can be degenerate at
+// a pole/seam) self-intersects for a large freeform patch and makes ear-clipping bail partway,
+// tearing the surface (the jagged duct lips). Lifting uses the exact 3D boundary points either way.
+func patchProjection(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) ([]math.Point2, [][]math.Point2) {
+	if _, isSpline := s.(geom.BSplineSurface); !isSpline {
+		return projectToPlane(outer3D, holes3D)
+	}
+	uv := func(pts []math.Point3) []math.Point2 {
+		out := make([]math.Point2, len(pts))
+		for i, p := range pts {
+			u, v := s.ParamAt(p)
+			out[i] = math.P2(math.Scalar(u), math.Scalar(v))
+		}
+		return out
+	}
+	holes2D := make([][]math.Point2, len(holes3D))
+	for i, h := range holes3D {
+		holes2D[i] = uv(h)
+	}
+	return uv(outer3D), holes2D
 }
 
 // projectToPlane flattens the boundary loops onto the outer loop's best-fit plane (Newell


### PR DESCRIPTION
## What
Trimmed b-spline faces (the EDF duct lips) rendered **torn/jagged** and the imported body volume was low (~75% of OpenCASCADE's exact value).

## Cause
`boundaryPatchMesh` flattened the curved patch boundary onto a best-fit **plane** and ear-clipped there. A large freeform patch **self-intersects** when flattened, so `earClip` bails partway → the face is under-triangulated (e.g. 63 boundary pts → 49 triangles). The missing triangles are holes in the otherwise-watertight mesh, which also skews the divergence-theorem volume.

## Fix
Triangulate b-spline patches in their **own (u,v) parameter space**, where the trim loops are a simple polygon → ear-clipping completes. The exact 3D boundary points + per-vertex normals lift it back. Analytic surfaces keep the plane projection (their (u,v) degenerates at poles/seams).

## Result
- EDF.STEP total volume **155,592 → 202,616** (~75% → ~98% of OCC `getMass`); torn lips gone.
- OCC oracle suite still green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)