### PR TITLE
kernel/ops: mesh sphere-cap-over-pole as a trim, not a torn full-domain grid

### DIFF
--- a/kernel/ops/periodic_band_test.go
+++ b/kernel/ops/periodic_band_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// TestPeriodicBandGridRejectsNonBand guards the sphere-cap-over-the-pole fix: periodicBandGrid must
+// only accept a genuine latitude band (boundary = two full-longitude circles), not a boundary that
+// wanders across latitudes (a cap straddling the pole). Accepting the latter gridded its whole
+// us×vs box and tore at the pole (340-triangle full-sphere fan on the EDF bell-mouth).
+func TestPeriodicBandGridRejectsNonBand(t *testing.T) {
+	s, err := geom.NewSphere(math.P3(0, 0, 0), 10)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	// A genuine band: points on two constant-latitude circles spanning full longitude → accepted.
+	var band []math.Point3
+	for _, lat := range []float64{-0.3, 0.3} {
+		for k := 0; k < 8; k++ {
+			band = append(band, s.PointAt(2*stdmath.Pi*float64(k)/8, lat))
+		}
+	}
+	if _, _, ok := periodicBandGrid(s, band, nil); !ok {
+		t.Error("two full-longitude latitude circles should be accepted as a band")
+	}
+	// A boundary spiralling across many latitudes is NOT a band (a cap near the pole) → rejected,
+	// so it falls through to the boundary triangulator instead of a torn full-domain grid.
+	var spiral []math.Point3
+	for k := 0; k < 16; k++ {
+		lat := -0.3 + 1.2*float64(k)/16 // wanders across latitudes, up toward the pole
+		spiral = append(spiral, s.PointAt(2*stdmath.Pi*float64(k)/16, lat))
+	}
+	if _, _, ok := periodicBandGrid(s, spiral, nil); ok {
+		t.Error("a boundary wandering across latitudes is not a band; must be rejected")
+	}
+}

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -7,22 +7,20 @@ import (
 	"oblikovati/math"
 )
 
-// refinedTrimmedMesh meshes a non-rectangular curved patch with INTERIOR points, not just its
-// boundary. The trim loops are mapped to the surface's (u,v) and meshed with a constrained
-// Delaunay triangulation (the loop edges are hard constraints; an interior (u,v) grid refines the
-// patch). This is robust where boundary-only ear-clipping fails — a slightly self-intersecting
-// (u,v) boundary (from ParamAt inversion on a rational patch) no longer tears, the CDT respects
-// concave trims exactly (no triangle bridges a notch), and the interior points make a strongly
-// curved patch read smooth. Boundary points keep their exact 3D positions (shared with the
-// neighbour face, so the patch stays watertight). Used for B-spline faces (their (u,v) is
-// well-behaved); analytic patches keep boundaryPatchMesh (their (u,v) degenerates at a pole/seam).
-// Falls back to boundaryPatchMesh if the CDT yields nothing.
-func refinedTrimmedMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) *Mesh {
-	// No interior Steiner points: ParamAt on a rational patch returns a distorted (u,v), so PointAt
-	// of a freshly sampled interior (u,v) lands off the trimmed region and inflates the mesh. We
-	// mesh only the boundary loops (their exact 3D points), relying on the CDT's constraint recovery
-	// + domain flood to stay watertight where boundary-only ear-clipping tears.
-	uv, pos, nrm, loops := patchBoundaryUV(s, outer3D, holes3D)
+// trimmedPatchMesh meshes a non-rectangular curved patch via a constrained Delaunay triangulation
+// of its boundary loops. The 2D embedding to triangulate in is chosen by patchProjection: the
+// surface's own (u,v) for a B-spline (where the trim loops are a simple polygon), or the boundary's
+// best-fit plane for an analytic surface (whose (u,v) degenerates at a pole/seam). The CDT is robust
+// where boundary-only ear-clipping tears (boundary segments are recovered by edge flips) and exact
+// on concave trims and holes (the domain flood respects the constrained edges); it meshes the real
+// trim region, not the surface's whole UV domain (which fullDomainGridMesh did — the torn full-sphere
+// fan). No interior Steiner points: ParamAt's distorted (u,v) makes a freshly sampled interior
+// point's PointAt land off the patch and inflate the mesh, so refinement stays boundary-only and the
+// exact 3D boundary points are kept (watertight with neighbour faces). Falls back to
+// boundaryPatchMesh if the CDT yields nothing.
+func trimmedPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) *Mesh {
+	outer2D, holes2D := patchProjection(s, outer3D, holes3D)
+	uv, pos, nrm, loops := patchLoops2D(s, outer3D, holes3D, outer2D, holes2D)
 	tris := constrainedDelaunay(uv, loops)
 	if len(tris) == 0 {
 		return boundaryPatchMesh(s, outer3D, holes3D)
@@ -30,23 +28,22 @@ func refinedTrimmedMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.
 	return patchMeshFrom(pos, nrm, tris)
 }
 
-// patchBoundaryUV maps each boundary loop into (u,v) (keeping its exact 3D points + normals) and
-// returns the (u,v) coords, parallel 3D positions and normals, and the loops as index sequences.
-func patchBoundaryUV(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) (uv [][2]float64, pos []math.Point3, nrm []math.Vector3, loops [][]int) {
-	addLoop := func(loop []math.Point3) []int {
+// patchLoops2D pairs each boundary loop's chosen 2D embedding (outer2D/holes2D) with its exact 3D
+// point and surface normal, returning the (u,v/plane) coords, parallel positions and normals, and
+// the loops as index sequences for the CDT.
+func patchLoops2D(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outer2D []math.Point2, holes2D [][]math.Point2) (uv [][2]float64, pos []math.Point3, nrm []math.Vector3, loops [][]int) {
+	loops3D := append([][]math.Point3{outer3D}, holes3D...)
+	loops2D := append([][]math.Point2{outer2D}, holes2D...)
+	for li, loop := range loops3D {
 		idx := make([]int, len(loop))
 		for i, p := range loop {
 			u, v := s.ParamAt(p)
 			idx[i] = len(uv)
-			uv = append(uv, [2]float64{u, v})
+			uv = append(uv, [2]float64{float64(loops2D[li][i].X), float64(loops2D[li][i].Y)})
 			pos = append(pos, p)
 			nrm = append(nrm, s.NormalAt(u, v))
 		}
-		return idx
-	}
-	loops = [][]int{addLoop(outer3D)}
-	for _, h := range holes3D {
-		loops = append(loops, addLoop(h))
+		loops = append(loops, idx)
 	}
 	return uv, pos, nrm, loops
 }

--- a/kernel/ops/refined_patch_test.go
+++ b/kernel/ops/refined_patch_test.go
@@ -12,7 +12,7 @@ import (
 
 // unitPatch is a flat bilinear B-spline surface over the unit square in z=0 (PointAt(u,v)=(u,v,0)),
 // so an L-shaped trim on it has a known 3D area — a controlled stand-in for an imported freeform
-// face that exercises refinedTrimmedMesh end to end (ParamAt → CDT → 3D mesh).
+// face that exercises trimmedPatchMesh end to end (ParamAt → CDT → 3D mesh).
 func unitPatch(t *testing.T) geom.BSplineSurface {
 	t.Helper()
 	ctrl := [][]math.Point3{
@@ -35,7 +35,7 @@ func TestRefinedTrimmedMeshConcavePatch(t *testing.T) {
 		math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 0.5, 0),
 		math.P3(0.5, 0.5, 0), math.P3(0.5, 1, 0), math.P3(0, 1, 0),
 	}
-	m := refinedTrimmedMesh(s, outer, nil)
+	m := trimmedPatchMesh(s, outer, nil)
 	if m.TriangleCount() == 0 {
 		t.Fatal("patch produced no triangles")
 	}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -40,20 +40,28 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 		if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
 			return structuredGridMesh(s, us, vs) // full cylinder/cone side: exact area
 		}
-		return fullDomainGridMesh(s, q) // seam-crossing periodic face we can't reduce
+		// A SINGLY-periodic surface (a sphere: periodic longitude, bounded latitude) whose (u,v)
+		// degenerates here is a cap straddling the pole — mesh its real boundary trim via the CDT in
+		// the best-fit plane, not the whole sphere (fullDomainGridMesh gave the torn radiating fan).
+		// A doubly-periodic surface (a torus) keeps the full-domain grid: its seam boundary bounds no
+		// planar trim, so the CDT would be meaningless.
+		if isPeriodic(s.UDomain()) != isPeriodic(s.VDomain()) {
+			return trimmedPatchMesh(s, outer3D, holes3D)
+		}
+		return fullDomainGridMesh(s, q) // doubly-periodic / aperiodic seam face we can't reduce
 	}
 	if len(holesUV) == 0 {
 		if us, vs, isRect := isoRectangleGrid(outerUV); isRect {
 			return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 		}
 	}
-	// A non-rectangular trim. A B-spline patch is meshed with a constrained Delaunay triangulation
-	// in (u,v) — interior grid points for smoothness, the trim loops as hard constraints — which is
-	// robust to the slightly self-intersecting (u,v) boundary that ParamAt inversion produces on a
-	// rational patch (where boundary-only ear-clipping tears). Analytic patches keep the boundary
-	// ear-clip (their (u,v) can be degenerate at a pole/seam, where the best-fit plane is safer).
+	// A non-rectangular trim. A B-spline patch is meshed by a constrained Delaunay triangulation in
+	// its own (u,v), robust to the slightly self-intersecting boundary ParamAt inversion produces on
+	// a rational patch (where boundary-only ear-clipping tears). Analytic patches keep the boundary
+	// ear-clip: their (u,v) can be degenerate at a pole/seam, and a wrapping wall folds onto itself
+	// in the best-fit plane (where the CDT can't recover the crossing constraints).
 	if _, isSpline := s.(geom.BSplineSurface); isSpline {
-		return refinedTrimmedMesh(s, outer3D, holes3D)
+		return trimmedPatchMesh(s, outer3D, holes3D)
 	}
 	return boundaryPatchMesh(s, outer3D, holes3D)
 }
@@ -286,6 +294,13 @@ func periodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Po
 	}
 	if len(us) < 2 || len(vs) < 2 {
 		return nil, nil, false // degenerate (e.g. a cone closing to its apex — one rim circle)
+	}
+	// A genuine band's boundary is two full-period edge circles, so the NON-periodic direction has
+	// exactly two distinct values. More than two means the boundary wanders in that direction (a
+	// sphere cap straddling the pole, not a latitude band): gridding its full us×vs bounding box
+	// would cover non-trim area and tear at the pole, so reject it for the boundary triangulator.
+	if (uPer && len(vs) != 2) || (vPer && len(us) != 2) {
+		return nil, nil, false
 	}
 	return us, vs, true
 }


### PR DESCRIPTION
## What
The outer EDF duct shell was clean after the CDT (#102), but looking into the **inlet** showed the inner bell-mouth still **torn** (jagged red slivers in Normal-Debug). Root cause: a sphere cap whose boundary straddles the pole fails `toUVLoops`, then `periodicBandGrid` wrongly accepted it as a latitude band and `structuredGridMesh` gridded its whole `us×vs` box — covering non-trim area and collapsing to degenerate slivers at the pole (a **340-triangle full-sphere fan**, 54 free edges). The volume hid it (small face).

## Fix
- `periodicBandGrid` accepts only a **genuine band**: the non-periodic direction must have exactly two distinct values (the two full-period edge circles). A boundary wandering across latitudes is rejected.
- The failed-`(u,v)` fallback routes a **singly-periodic** surface (sphere cap) to the CDT boundary triangulator (meshes the real trim), while a **doubly-periodic** surface (torus — its seam bounds no planar trim) keeps the full-domain grid.
- Generalised `refinedTrimmedMesh`→`trimmedPatchMesh`: 2D embedding is the surface's (u,v) for a B-spline or the boundary's best-fit plane for an analytic patch.

## Result
- EDF.STEP **torn faces 1 → 0** (inner bell-mouth clean); total volume unchanged ~210,142 (~101.5% of OCC).
- New regression test for the band rejection; OCC oracle (incl. **torus**) green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)