### PR TITLE
kernel/ops: mesh sphere caps with interior (u,v) nodes (smooth, not a boundary fan)

### DIFF
--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -3,9 +3,115 @@
 package ops
 
 import (
+	stdmath "math"
+
 	"oblikovati/kernel/geom"
 	"oblikovati/math"
 )
+
+// gridPatchMesh meshes an analytic curved patch (a sphere cap) over its OWN (u,v) parameter space
+// with INTERIOR nodes, not just a boundary fan. The trim loops (exact 3D points, so the patch stays
+// watertight with its neighbours) plus a staggered interior (u,v) grid are constrained-Delaunay
+// triangulated in (u,v); interior points + per-vertex surface normals make the cap read as a smooth
+// curved surface instead of the flat radiating fan a boundary-only triangulation produces (the EDF
+// inner bell-mouth slivers). Mirrors OpenCASCADE's BRepMesh range-splitter approach (interior nodes
+// on a deflection-spaced staggered grid within the trimmed range). Caller must have a valid (u,v)
+// (toUVLoops ok) — i.e. the patch does not straddle a pole/seam.
+func gridPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+	uv, pos, nrm, loops := patchLoops2D(s, outer3D, holes3D, outerUV, holesUV)
+	for _, g := range interiorUVGrid(outerUV, holesUV) {
+		uv = append(uv, g)
+		pos = append(pos, s.PointAt(g[0], g[1]))
+		nrm = append(nrm, s.NormalAt(g[0], g[1]))
+	}
+	tris := constrainedDelaunay(uv, loops)
+	if len(tris) == 0 {
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	return patchMeshFrom(pos, nrm, tris)
+}
+
+// interiorUVGrid returns staggered (u,v) points strictly inside the trim (inside the outer loop,
+// outside the holes), on a grid sized to the outer loop's median edge length so the interior density
+// matches the boundary's. Alternate rows are offset half a step for better-shaped triangles.
+func interiorUVGrid(outer []math.Point2, holes [][]math.Point2) [][2]float64 {
+	umin, umax, vmin, vmax, step := uvBounds(outer)
+	if step <= 0 {
+		return nil
+	}
+	var pts [][2]float64
+	row := 0
+	for v := vmin + step/2; v < vmax; v += step {
+		off := 0.0
+		if row%2 == 1 {
+			off = step / 2
+		}
+		row++
+		for u := umin + step/2 + off; u < umax; u += step {
+			p := [2]float64{u, v}
+			if insideUVTrim(outer, holes, p) {
+				pts = append(pts, p)
+			}
+		}
+	}
+	return pts
+}
+
+func uvBounds(outer []math.Point2) (umin, umax, vmin, vmax, step float64) {
+	umin, vmin = stdmath.Inf(1), stdmath.Inf(1)
+	umax, vmax = stdmath.Inf(-1), stdmath.Inf(-1)
+	var lens []float64
+	for i, p := range outer {
+		x, y := float64(p.X), float64(p.Y)
+		umin, umax = stdmath.Min(umin, x), stdmath.Max(umax, x)
+		vmin, vmax = stdmath.Min(vmin, y), stdmath.Max(vmax, y)
+		q := outer[(i+1)%len(outer)]
+		lens = append(lens, stdmath.Hypot(float64(q.X)-x, float64(q.Y)-y))
+	}
+	return umin, umax, vmin, vmax, medianLen(lens)
+}
+
+func medianLen(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	c := append([]float64(nil), xs...)
+	for i := range c {
+		for j := i + 1; j < len(c); j++ {
+			if c[j] < c[i] {
+				c[i], c[j] = c[j], c[i]
+			}
+		}
+	}
+	return c[len(c)/2]
+}
+
+func insideUVTrim(outer []math.Point2, holes [][]math.Point2, p [2]float64) bool {
+	if !pointInUVPoly(outer, p) {
+		return false
+	}
+	for _, h := range holes {
+		if pointInUVPoly(h, p) {
+			return false
+		}
+	}
+	return true
+}
+
+func pointInUVPoly(poly []math.Point2, p [2]float64) bool {
+	in := false
+	n := len(poly)
+	for i, j := 0, n-1; i < n; j, i = i, i+1 {
+		yi, yj := float64(poly[i].Y), float64(poly[j].Y)
+		if (yi > p[1]) != (yj > p[1]) {
+			xi, xj := float64(poly[i].X), float64(poly[j].X)
+			if p[0] < (xj-xi)*(p[1]-yi)/(yj-yi)+xi {
+				in = !in
+			}
+		}
+	}
+	return in
+}
 
 // trimmedPatchMesh meshes a non-rectangular curved patch via a constrained Delaunay triangulation
 // of its boundary loops. The 2D embedding to triangulate in is chosen by patchProjection: the

--- a/kernel/ops/refined_patch_test.go
+++ b/kernel/ops/refined_patch_test.go
@@ -57,3 +57,40 @@ func TestRefinedTrimmedMeshConcavePatch(t *testing.T) {
 		t.Errorf("%d triangles wind against their vertex normals", bad)
 	}
 }
+
+// TestGridPatchMeshAddsInteriorNodes guards the sphere-cap smoothness fix: a curved sphere patch
+// must mesh with INTERIOR (u,v) nodes (a refined surface), not a boundary-only fan of long flat
+// triangles (the inner-bell-mouth slivers), and every triangle must agree with its vertex normals.
+func TestGridPatchMeshAddsInteriorNodes(t *testing.T) {
+	s, err := geom.NewSphere(math.P3(0, 0, 0), 10)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	// A 16-gon patch in (u,v) away from the pole/seam (a closed non-iso-rectangular trim).
+	const n = 16
+	cu, cv, r := 1.0, 0.4, 0.4
+	var uv []math.Point2
+	var p3 []math.Point3
+	for k := 0; k < n; k++ {
+		a := 2 * stdmath.Pi * float64(k) / n
+		u, v := cu+r*stdmath.Cos(a), cv+r*stdmath.Sin(a)
+		uv = append(uv, math.P2(math.Scalar(u), math.Scalar(v)))
+		p3 = append(p3, s.PointAt(u, v))
+	}
+	m := gridPatchMesh(s, p3, nil, uv, nil)
+	if m.TriangleCount() <= n {
+		t.Errorf("expected interior refinement, got %d triangles (no interior nodes added)", m.TriangleCount())
+	}
+	bad := 0
+	for i := 0; i+2 < len(m.Indices); i += 3 {
+		a, b, c := m.Positions[m.Indices[i]], m.Positions[m.Indices[i+1]], m.Positions[m.Indices[i+2]]
+		gn := a.VectorTo(b).Cross(a.VectorTo(c))
+		sn := m.Normals[m.Indices[i]].Add(m.Normals[m.Indices[i+1]]).Add(m.Normals[m.Indices[i+2]])
+		if gn.Dot(sn) < 0 {
+			bad++
+		}
+	}
+	if bad > 0 {
+		t.Errorf("%d of %d triangles wind against their vertex normals", bad, m.TriangleCount())
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -50,16 +50,22 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 		}
 		return fullDomainGridMesh(s, q) // doubly-periodic / aperiodic seam face we can't reduce
 	}
-	if len(holesUV) == 0 {
-		if us, vs, isRect := isoRectangleGrid(outerUV); isRect {
-			return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
-		}
+	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
+		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
-	// A non-rectangular trim. A B-spline patch is meshed by a constrained Delaunay triangulation in
-	// its own (u,v), robust to the slightly self-intersecting boundary ParamAt inversion produces on
-	// a rational patch (where boundary-only ear-clipping tears). Analytic patches keep the boundary
-	// ear-clip: their (u,v) can be degenerate at a pole/seam, and a wrapping wall folds onto itself
-	// in the best-fit plane (where the CDT can't recover the crossing constraints).
+	return nonRectangularMesh(s, outer3D, holes3D, outerUV, holesUV)
+}
+
+// nonRectangularMesh meshes a non-iso-rectangular curved trim. A sphere cap is meshed over its own
+// (u,v) with interior nodes so the curved cap reads smooth (not the flat radiating fan a boundary
+// triangulation gives — the inner bell-mouth slivers). A B-spline patch is constrained-Delaunay
+// triangulated in its (u,v), robust to the slightly self-intersecting boundary ParamAt inversion
+// produces. Other analytic patches keep the boundary ear-clip: their (u,v) can be degenerate at a
+// pole/seam and a wrapping wall folds onto itself in any single embedding.
+func nonRectangularMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+	if _, isSphere := s.(geom.Sphere); isSphere {
+		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
+	}
 	if _, isSpline := s.(geom.BSplineSurface); isSpline {
 		return trimmedPatchMesh(s, outer3D, holes3D)
 	}


### PR DESCRIPTION
## What
Imported **sphere caps** (the EDF inner bell-mouth) were triangulated from their **boundary alone** — a fan of long flat triangles across a *curved* cap → jagged radiating slivers (back-facing in Normal-Debug). Geometrically valid but coarse.

## Fix
Mesh a sphere cap with a valid `(u,v)` over its own parameter space with **interior nodes**: the trim loops (exact 3D points, watertight) + a staggered interior `(u,v)` grid sized to the boundary density, constrained-Delaunay triangulated in `(u,v)`; per-vertex surface normals make it read smooth. Mirrors OpenCASCADE `BRepMesh`'s range-splitter approach.

Scope: **spheres only** — a wrapping analytic wall folds in any single embedding and its `(u,v)` grid can spill past the trim, so cones/tori keep the boundary ear-clip; a sphere cap straddling the pole/seam (no valid `(u,v)`) still uses the plane boundary path.

## Result
- EDF hub caps **16 flat tris → refined curved mesh** (e.g. 16 → 420); imported volume essentially unchanged (~210,086, ~101.5% of OCC).
- New regression test (interior nodes added + consistent winding); OCC oracle green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)