### PR TITLE
plan: M24 — Tolerant NURBS Surface Meshing milestone

### DIFF
--- a/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/PBI-312-paramnear-seeded-projection.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/PBI-312-paramnear-seeded-projection.md
@@ -1,0 +1,45 @@
+---
+milestone: M24
+feature: F01
+pbi: PBI-312
+title: ParamNear seeded surface projection + ADR
+status: planned
+estimate: S
+---
+
+# PBI-312 — `ParamNear` seeded surface projection + ADR
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F01 On-surface pcurves & boundary
+
+## Goal
+
+Add a seeded closest-point projection on a NURBS surface so a marching caller can keep a curve on
+a single smooth branch, and record the milestone's approach in an ADR.
+
+## Scope / work
+
+- `func (s BSplineSurface) ParamNear(q math.Point3, u0, v0 float64) (u, v float64)` in
+  `kernel/geom/paramat.go`: start from `(u0,v0)` (clamped to domain), run the existing
+  `surfaceProjectStep` to convergence — no `surfaceGridSeed`. Reuse the existing step.
+- Write **ADR-00XX — Tolerant NURBS surface meshing**: imported edge curves lie ~mm off their
+  surfaces (a tolerance reality, not a bug); we mesh each face *on its surface* with interior
+  nodes and **stitch shared edges within tolerance** rather than re-project the off-surface
+  boundary (which inflates volume). Records the measured failure table from the milestone.
+
+## API contracts (interfaces / enums / collections)
+
+- `geom.BSplineSurface.ParamNear(q, u0, v0) (u, v float64)` — internal kernel API.
+
+## Acceptance criteria
+
+- For points sampled **on** a known B-spline surface, `ParamNear` seeded from a nearby `(u,v)`
+  returns a `(u,v)` whose `PointAt` round-trips to the sample within tight tolerance.
+- For two nearby points straddling a near-fold, `ParamNear` (seeded from the same prior `(u,v)`)
+  returns **nearby** `(u,v)` for both, where independent `ParamAt` returns far-apart `(u,v)`
+  (the branch-jump). Unit-tested on a constructed folded patch.
+- ADR-00XX committed and linked from the milestone.
+- `go test ./kernel/geom/...` green; lint clean.
+
+## Depends on
+
+`kernel/geom/paramat.go`.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/PBI-313-march-projected-pcurves.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/PBI-313-march-projected-pcurves.md
@@ -1,0 +1,44 @@
+---
+milestone: M24
+feature: F01
+pbi: PBI-313
+title: March-projected per-edge pcurves (non-self-intersecting boundary)
+status: planned
+estimate: M
+---
+
+# PBI-313 — March-projected per-edge pcurves (non-self-intersecting boundary)
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F01 On-surface pcurves & boundary
+
+## Goal
+
+Build a face's boundary `(u,v)` by marching `ParamNear` along each loop, producing a smooth,
+non-self-intersecting pcurve where independent `ParamAt` self-intersects.
+
+## Scope / work
+
+- In `kernel/ops`, a `marchUV(s geom.BSplineSurface, loop []math.Point3) []math.Point2`: first
+  point via `ParamAt` (grid-seeded), each subsequent point via `ParamNear` seeded from the
+  previous. Apply to the outer loop and each hole.
+- Guard the loop closure (last point's `(u,v)` should be near the first's) and a re-seed if a
+  step diverges (the projection failed) — fall back to `ParamAt` for that point.
+- Not yet wired into tessellation — exposed for F02/F03. (Keep `trimmedPatchMesh` as-is this PBI.)
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) `ops.marchUV(surface, loop) []Point2`.
+
+## Acceptance criteria
+
+- On a constructed B-spline patch whose boundary makes independent `ParamAt` self-intersect,
+  `marchUV` returns a boundary `(u,v)` polygon with **zero self-intersections** (segment-pair
+  intersection test) — committed unit test.
+- The pcurve's `PointAt` stays within tolerance of the input loop points (it is the same curve,
+  re-parametrised smoothly).
+- `go test ./kernel/ops/...` green; lint clean. No change to existing tessellation output yet
+  (the OCC oracle volume is byte-identical to pre-PBI).
+
+## Depends on
+
+PBI-312 (`ParamNear`).

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/_feature.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/_feature.md
@@ -1,0 +1,50 @@
+---
+milestone: M24
+feature: F01
+name: On-surface pcurves & boundary
+status: planned
+---
+
+# M24 · F01 — On-surface pcurves & boundary
+
+The foundation: a **smooth, non-self-intersecting `(u,v)` boundary on the surface** for a
+freeform face. Today the boundary `(u,v)` comes from calling `Surface.ParamAt` independently per
+edge point; near a fold those calls snap to different local minima, so the boundary
+**self-intersects** — which makes a boundary-only triangulation fold and an interior grid
+over-enclose. The fix is to compute each edge's **pcurve** by march-projection: project the first
+point with the full grid search, then each subsequent point seeded from the previous point's
+`(u,v)` (`ParamNear`), so the curve stays on one smooth branch.
+
+This was prototyped (and reverted) during diagnosis; it demonstrably produced a smooth boundary
+and fixed the big duct faces' folds. F01 lands it properly with isolation tests and the ADR. It
+is infrastructure — on its own it does not change the mesh (boundary-only still folds on curved
+faces); F02/F03 consume it.
+
+## In scope
+
+- `geom.BSplineSurface.ParamNear(q, u0, v0)` — seeded surface projection (no grid search).
+- `ops` march-projected pcurve builder for a face's boundary loops (outer + holes).
+- A test that the resulting `(u,v)` boundary is **non-self-intersecting** where independent
+  `ParamAt` self-intersects.
+- ADR-00XX recording the on-surface-with-tolerance meshing approach.
+
+## Out of scope
+
+- Interior node generation (F02) and shared-edge stitching (F03).
+- Reading STEP-supplied pcurves (absent in the driving case).
+
+## Key API contracts delivered
+
+- `geom.BSplineSurface.ParamNear` (internal kernel API).
+- (internal) `ops` pcurve builder.
+
+## Depends on
+
+`kernel/geom/paramat.go` (`surfaceProjectStep`, `surfaceGridSeed`), `kernel/ops/tessellate_trim.go`.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-312](PBI-312-paramnear-seeded-projection.md) | `ParamNear` seeded surface projection + ADR |
+| [PBI-313](PBI-313-march-projected-pcurves.md) | March-projected per-edge pcurves (non-self-intersecting boundary) |

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-314-adaptive-trim-clipped-nodes.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-314-adaptive-trim-clipped-nodes.md
@@ -1,0 +1,47 @@
+---
+milestone: M24
+feature: F02
+pbi: PBI-314
+title: Deflection-adaptive, strictly trim-clipped interior nodes
+status: planned
+estimate: L
+---
+
+# PBI-314 — Deflection-adaptive, strictly trim-clipped interior nodes
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F02 Trim-respecting adaptive interior
+
+## Goal
+
+Generate interior `(u,v)` nodes for a NURBS face whose density follows the surface curvature and
+which lie **strictly inside the trim** — no spill into holes or past the boundary (the cause of
+the +20–70% over-enclosure).
+
+## Scope / work
+
+- A node generator over the pcurve `(u,v)` bbox: step from `ops.Quality` (chord/angle tolerance)
+  scaled by local curvature, so flat regions are coarse and curved regions dense
+  (OpenCASCADE range-splitter style). Staggered rows for triangle quality.
+- **Strict trim clipping**: keep a node only if `insideTrim(outerPcurve, holePcurves, node)` with
+  a margin ≥ a fraction of the local step, so no node sits on or just outside the boundary or
+  inside a hole. Use the smooth F01 pcurves (reliable point-in-polygon), not the jittery raw
+  `(u,v)`.
+- Pure function (nodes from pcurves + quality); unit-testable without a full face.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) `ops` interior-node generator `(outerPcurve, holePcurves, surface, quality) → []uv`.
+
+## Acceptance criteria
+
+- **No spill**: on a NURBS patch with a hole (synthetic), every generated node passes an
+  independent point-in-trim test; **zero** nodes land inside the hole or outside the outer loop
+  (committed test).
+- **Adaptive density**: a high-curvature patch gets more nodes than a near-flat one of equal
+  `(u,v)` extent at the same `Quality` (asserted by node-count ratio).
+- Determinism: same inputs → same nodes.
+- `go test ./kernel/ops/...` green; lint clean.
+
+## Depends on
+
+F01 (pcurves for the boundary + point-in-trim).

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-315-curvature-aware-no-fold.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-315-curvature-aware-no-fold.md
@@ -1,0 +1,46 @@
+---
+milestone: M24
+feature: F02
+pbi: PBI-315
+title: Curvature-aware triangulation with fold detection + repair
+status: planned
+estimate: L
+---
+
+# PBI-315 — Curvature-aware triangulation with fold detection + repair
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F02 Trim-respecting adaptive interior
+
+## Goal
+
+Triangulate (pcurve boundary + interior nodes) so the lifted 3D mesh does **not fold** — no
+adjacent triangles whose surface normals oppose — even where the `(u,v)→3D` map is strongly
+non-conformal.
+
+## Scope / work
+
+- CDT the point set in `(u,v)` (reuse `cdt.go`), lift to 3D via `PointAt`, wind by vertex normals
+  (`windingOpposesNormals`).
+- **Fold detector**: an interior edge whose two triangles' 3D geometric normals oppose
+  (dot < threshold·|n||n|) is a fold. After triangulation, find folds and repair: edge-flip the
+  offending diagonal, or insert a node at the fold and re-triangulate locally, until no fold
+  remains or a bounded number of passes elapse.
+- If folds persist (a genuinely degenerate `(u,v)` region), increase local node density there
+  (driving the F02 generator) rather than leaving a fold.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) `ops` fold detector + repair pass over a `Mesh`.
+
+## Acceptance criteria
+
+- On the constructed strongly-curved patch that folds today (body-0-like), the meshed result has
+  **0 fold-edges** (committed fold-detector test).
+- Triangle winding stays consistent (every triangle agrees with its vertex normals).
+- Area conservation: the meshed surface area is within tolerance of a densely-sampled reference
+  area for the patch (no overlap from a bad repair).
+- `go test ./kernel/ops/...` green; lint clean.
+
+## Depends on
+
+PBI-314 (interior nodes), `kernel/ops/cdt.go`.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-316-wire-nurbs-face-mesher.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-316-wire-nurbs-face-mesher.md
@@ -1,0 +1,49 @@
+---
+milestone: M24
+feature: F02
+pbi: PBI-316
+title: Wire the NURBS face mesher (oracle-gated)
+status: planned
+estimate: M
+---
+
+# PBI-316 — Wire the NURBS face mesher (oracle-gated)
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F02 Trim-respecting adaptive interior
+
+## Goal
+
+Route B-spline faces through the new on-surface interior-node mesher (pcurve boundary + adaptive
+trim-clipped interior + non-folding triangulation), replacing `trimmedPatchMesh`, **only if** it
+holds the volume oracle.
+
+## Scope / work
+
+- Assemble F01+F02 into `nurbsPatchMesh(s, outer3D, holes3D)`: march-projected pcurves → adaptive
+  trim-clipped interior nodes → CDT → fold-repair → mesh. Boundary nodes lifted **on-surface**
+  (`PointAt` of the pcurve), interior likewise — consistent, so no exact-vs-on-surface overlap.
+  (F03 then makes the on-surface boundary consistent across faces.)
+- Route `geom.BSplineSurface` non-rectangular faces to it in `tessellate_trim.go`
+  (`nonRectangularMesh`); analytic faces unchanged.
+- **Gate on the oracle**: measure EDF total volume and per-face folds. This PBI may still leave a
+  per-face seam (F03 fixes that) but must NOT over-enclose — the volume must be within tolerance
+  of OCC (no +20–70%). If a face inflates, fall back to the boundary-only path for that face
+  (a guard) so the milestone never regresses volume.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) `ops.nurbsPatchMesh`; dispatch in `tessellateCurvedFace`/`nonRectangularMesh`.
+
+## Acceptance criteria
+
+- EDF.STEP external freeform faces are **fold-free** (committed detector) and the total volume is
+  **within tolerance of OCC** (no inflation) — the per-face inflation guard ensures no regression.
+- The OCC oracle suite stays green; the EDF volume does not regress below the current 101.5%
+  baseline beyond the stated tolerance.
+- Live confirmation (shaded + Normal-Debug, Save-Viewport-PNG): the staircase is gone on the
+  external faces.
+- `go test ./kernel/...` green; lint clean.
+
+## Depends on
+
+F01 (pcurves), PBI-314 (interior), PBI-315 (no-fold), the OCC oracle.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/_feature.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/_feature.md
@@ -1,0 +1,51 @@
+---
+milestone: M24
+feature: F02
+name: Trim-respecting adaptive interior
+status: planned
+---
+
+# M24 · F02 — Trim-respecting adaptive interior
+
+The heart of the milestone: generate **interior nodes that follow the surface curvature** so the
+face stops folding, **without over-enclosing** the volume. Every naive interior-node attempt
+inflated the EDF volume +20–70% because the `(u,v)` grid + CDT spilled past the real trim (into
+holes, beyond the boundary on complex faces). F02 makes the interior strictly trim-respecting and
+deflection-adaptive, and makes the triangulation curvature-aware so it does not fold in 3D — gated
+at every step by the OCC volume oracle (the metric that exposed the inflation).
+
+## In scope
+
+- A **deflection-adaptive** `(u,v)` node spacing from `ops.Quality` (chord/angle tolerance) and
+  the surface's local curvature — the OpenCASCADE range-splitter idea (dense where curved, coarse
+  where flat).
+- **Strict trim clipping**: an interior node survives only if it is inside the outer pcurve and
+  outside every hole pcurve, by a robust point-in-polygon with a margin so nodes never sit on or
+  just-outside the boundary.
+- A **curvature-aware** triangulation of (pcurve boundary + interior) that does not fold: detect
+  and repair fold edges (adjacent triangles whose 3D normals oppose) by local re-triangulation
+  or node nudging, or reject nodes that would fold.
+- The wired NURBS face mesher replacing `trimmedPatchMesh` for B-spline faces, **on-surface**
+  (boundary + interior via the pcurve), gated by the oracle.
+
+## Out of scope
+
+- Cross-face consistency / gaps (F03 — shared-edge stitching).
+- Analytic surfaces (their interior path already exists: `gridPatchMesh` for spheres,
+  `structuredGridMesh` for cylinders/cones).
+
+## Key API contracts delivered
+
+- (internal) `ops` deflection-adaptive interior node generator; the NURBS face mesher.
+
+## Depends on
+
+F01 (pcurves), `kernel/ops/{cdt,refined_patch,tessellate_trim}.go`, the OCC oracle.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-314](PBI-314-adaptive-trim-clipped-nodes.md) | Deflection-adaptive, strictly trim-clipped interior nodes |
+| [PBI-315](PBI-315-curvature-aware-no-fold.md) | Curvature-aware triangulation with fold detection + repair |
+| [PBI-316](PBI-316-wire-nurbs-face-mesher.md) | Wire the NURBS face mesher (oracle-gated) |

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F03-shared-edge-stitching/PBI-317-shared-edge-polyline-binding.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F03-shared-edge-stitching/PBI-317-shared-edge-polyline-binding.md
@@ -1,0 +1,45 @@
+---
+milestone: M24
+feature: F03
+pbi: PBI-317
+title: Bind face boundary to the shared edge polyline (no gaps)
+status: planned
+estimate: L
+---
+
+# PBI-317 — Bind face boundary to the shared edge polyline (no gaps)
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F03 Tolerant shared-edge stitching
+
+## Goal
+
+Both faces of an edge use the SAME 3D points (the shared `discretizeEdge` polyline) as their
+boundary vertices, while the face interior meshes on its own surface — so the two face meshes meet
+exactly at the edge.
+
+## Scope / work
+
+- In the NURBS face mesher (PBI-316), the boundary loop's 3D vertices are the **shared edge
+  polyline points** (`loopBoundary` / `discretizeEdge`, already shared between neighbours), not
+  `PointAt` of the pcurve. The pcurve `(u,v)` still drives the 2D CDT connectivity + interior
+  placement; only the boundary VERTICES bind to the shared points.
+- The first interior ring sits a controlled step inside the boundary so the stitch band triangles
+  (shared edge ↔ first interior ring) are well-shaped and do not fold (they span the ~mm
+  edge/surface offset uniformly).
+- Keep the on-surface interior; the boundary lip is the tolerance, distributed evenly.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) NURBS face mesher boundary = shared edge points; interior = on-surface nodes.
+
+## Acceptance criteria
+
+- Two adjacent freeform faces sharing an edge produce boundary vertices that **coincide exactly**
+  (same shared points) — a committed test on a synthetic two-face patch.
+- No fold introduced in the stitch band (fold detector = 0).
+- EDF volume stays within oracle tolerance; OCC oracle green.
+- `go test ./kernel/...` green; lint clean.
+
+## Depends on
+
+PBI-316, `kernel/ops/edge_discretize.go`.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F03-shared-edge-stitching/PBI-318-watertight-assembled-body.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F03-shared-edge-stitching/PBI-318-watertight-assembled-body.md
@@ -1,0 +1,42 @@
+---
+milestone: M24
+feature: F03
+pbi: PBI-318
+title: Watertight assembled body across the edge/surface tolerance
+status: planned
+estimate: M
+---
+
+# PBI-318 — Watertight assembled body across the edge/surface tolerance
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F03 Tolerant shared-edge stitching
+
+## Goal
+
+Guarantee the assembled body mesh is watertight (no free-edge gaps beyond tolerance) despite the
+imported edge/surface offset, now that every face binds to shared edge polylines.
+
+## Scope / work
+
+- A body-level free-edge / manifold check over the merged per-face meshes: every shared edge is
+  used by exactly two faces and its vertices coincide; report any gap exceeding the model
+  tolerance.
+- Reconcile any remaining mismatch (e.g. a degenerate or seam edge) — weld coincident shared
+  vertices; flag genuinely non-manifold input rather than silently gapping.
+- Confirm mass-properties volume is unaffected (the per-face meshes already share edge points).
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) body watertightness/free-edge check (test helper + optional debug surface).
+
+## Acceptance criteria
+
+- EDF.STEP assembled body: no free-edge gap exceeds the model tolerance (committed check);
+  free-edge count equals the genuine open-boundary count (0 for the closed solids).
+- Volume within oracle tolerance of OCC; OCC oracle green.
+- Live: no cracks visible between freeform faces (shaded, Save-Viewport-PNG).
+- `go test ./kernel/...` green; lint clean.
+
+## Depends on
+
+PBI-317.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F03-shared-edge-stitching/_feature.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F03-shared-edge-stitching/_feature.md
@@ -1,0 +1,46 @@
+---
+milestone: M24
+feature: F03
+name: Tolerant shared-edge stitching
+status: planned
+---
+
+# M24 · F03 — Tolerant shared-edge stitching
+
+Make adjacent freeform faces meet without gaps, folds, or double-counting. After F02 each face
+meshes smooth on its **own** surface, but its on-surface boundary differs from the neighbour's by
+the ~mm edge/surface tolerance — so the assembled body has seams. The classic fix (OpenCASCADE
+`BRepMesh`) is to mesh each **edge once** as a single 3D polyline and have **both** adjacent faces
+bind to those exact shared points; each face then meshes its interior on its surface and stitches
+to the shared edge points. The body stays watertight despite no face's surface passing exactly
+through the edge.
+
+## In scope
+
+- A per-edge shared discretization (one polyline per topological edge) cached and reused by both
+  faces of the edge — `discretizeEdge` already yields a shared polyline; F03 ensures both faces'
+  meshes **use those exact points** as boundary vertices (not each face's own on-surface pcurve
+  points).
+- A stitch band between the shared edge polyline and the face's on-surface interior nodes (the
+  pcurve drives connectivity; the boundary vertices are the shared edge points).
+- A watertightness check: no free edge / gap on the assembled body beyond the model tolerance.
+
+## Out of scope
+
+- Healing the underlying B-rep (moving edges onto surfaces) — a model-level effort.
+- Non-manifold / degenerate edge handling beyond what import already produces.
+
+## Key API contracts delivered
+
+- (internal) shared-edge polyline cache; face mesher binding boundary to shared points.
+
+## Depends on
+
+F01, F02, `kernel/ops/edge_discretize.go` (`discretizeEdge`/`loopBoundary`), `kernel/topo`.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-317](PBI-317-shared-edge-polyline-binding.md) | Bind face boundary to the shared edge polyline (no gaps) |
+| [PBI-318](PBI-318-watertight-assembled-body.md) | Watertight assembled body across the edge/surface tolerance |

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F04-oracle-gating-regression/PBI-319-fold-area-detectors-fixture.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F04-oracle-gating-regression/PBI-319-fold-area-detectors-fixture.md
@@ -1,0 +1,36 @@
+---
+milestone: M24
+feature: F04
+pbi: PBI-319
+title: Fold + over-enclosure detectors and a trimmed-NURBS OCC fixture
+status: planned
+estimate: M
+---
+
+# PBI-319 — Fold + over-enclosure detectors and a trimmed-NURBS OCC fixture
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F04 Oracle gating & EDF regression
+
+## Goal
+
+Make the diagnostic metrics permanent tests, and add a freeform-NURBS fixture the oracle can gate.
+
+## Scope / work
+
+- Commit a **fold detector** (interior edge whose two triangles' 3D normals oppose) and a
+  **per-face-area / over-enclosure** check as test helpers in `kernel/ops`/`kernel/exchange/step`.
+- Generate a synthetic **trimmed B-spline patch with a hole** via `test-utilities/step-oracle`
+  (OpenCASCADE) → `testdata/occ/`, with its `getMass` volume in the oracle JSON.
+- Extend `occ_oracle_test.go` to assert, for the freeform fixture: volume within tolerance AND
+  0 fold-edges AND no over-enclosure.
+
+## Acceptance criteria
+
+- The freeform-NURBS fixture passes volume + fold + over-enclosure assertions.
+- The detectors are deterministic and unit-tested on hand-built meshes (a known fold, a known
+  clean mesh).
+- OCC oracle suite green; lint clean.
+
+## Depends on
+
+F02 (the mesher), `test-utilities/step-oracle`, the gmsh SDK.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F04-oracle-gating-regression/PBI-320-edf-end-to-end-regression.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F04-oracle-gating-regression/PBI-320-edf-end-to-end-regression.md
@@ -1,0 +1,35 @@
+---
+milestone: M24
+feature: F04
+pbi: PBI-320
+title: EDF end-to-end volume + fold regression
+status: planned
+estimate: S
+---
+
+# PBI-320 — EDF end-to-end volume + fold regression
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F04 Oracle gating & EDF regression
+
+## Goal
+
+Pin the driving case: EDF.STEP imports fold-free and volume-correct, as a committed regression.
+
+## Scope / work
+
+- A local/CI regression that imports `EDF.STEP`, asserts total volume within tolerance of the OCC
+  ground truth (207,002) and **0 fold-edges** across all faces.
+- Keep EDF out of the public/clean-room path (it is a third-party model) — a local fixture path /
+  CI artifact, skipped when absent, per the repo's clean-room rule.
+- Final live confirmation on the running head (shaded + Normal-Debug, all bodies): no staircase,
+  no slivers, external surfaces smooth.
+
+## Acceptance criteria
+
+- EDF regression: volume within tolerance, 0 fold-edges; skipped cleanly when the model is absent.
+- Live: the external freeform faces read smooth in shaded and Normal-Debug.
+- Milestone exit criteria all met; OCC oracle green; lint clean.
+
+## Depends on
+
+F02, F03, F04 PBI-319.

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F04-oracle-gating-regression/_feature.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F04-oracle-gating-regression/_feature.md
@@ -1,0 +1,44 @@
+---
+milestone: M24
+feature: F04
+name: Oracle gating & EDF regression
+status: planned
+---
+
+# M24 · F04 — Oracle gating & EDF regression
+
+Lock the milestone in with committed, automated guards so the freeform mesher can never silently
+regress: fold / over-enclosure / per-face-area detectors as tests, a synthetic trimmed-NURBS OCC
+fixture in the oracle suite, and the EDF model as an end-to-end volume + fold regression. These are
+the metrics that exposed every failed attempt during diagnosis; making them permanent tests is the
+exit gate.
+
+## In scope
+
+- A committed **fold detector** (adjacent triangles with opposing 3D normals) run on the oracle
+  fixtures' faces — assert 0 on freeform faces.
+- A committed **over-enclosure / per-face-area** check (mesh area vs densely-sampled reference;
+  total volume vs OCC `getMass`).
+- A synthetic **trimmed freeform-NURBS** OCC fixture (a B-spline patch with a hole) added to
+  `testdata/occ/` via the generator.
+- EDF.STEP wired as an end-to-end volume + fold regression (kept out of the public path per the
+  clean-room rule; a local/CI fixture).
+
+## Out of scope
+
+- New geometry kinds; this is validation only.
+
+## Key API contracts delivered
+
+- Committed detectors + oracle fixtures (test infrastructure).
+
+## Depends on
+
+F02, F03, the OCC oracle (`kernel/exchange/step/occ_oracle_test.go`), the gmsh SDK ground truth.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-319](PBI-319-fold-area-detectors-fixture.md) | Fold + over-enclosure detectors and a trimmed-NURBS OCC fixture |
+| [PBI-320](PBI-320-edf-end-to-end-regression.md) | EDF end-to-end volume + fold regression |

--- a/implementation-plan/M24-tolerant-nurbs-meshing/_milestone.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/_milestone.md
@@ -1,0 +1,109 @@
+---
+milestone: M24
+name: Tolerant NURBS Surface Meshing (imported B-rep)
+status: planned
+---
+
+# M24 — Tolerant NURBS Surface Meshing (imported B-rep)
+
+Mesh trimmed **freeform (B-spline/NURBS) faces** of imported B-reps so curved external
+surfaces render **smooth, fold-free, and volume-correct**. Today
+[`kernel/ops/tessellate_trim.go`](../../kernel/ops/tessellate_trim.go) meshes a non-rectangular
+NURBS face from its **boundary loops only** (`trimmedPatchMesh` → the CDT in
+[`cdt.go`](../../kernel/ops/cdt.go)). A boundary-only triangulation of a *curved* face cannot
+follow the 3D curvature, so it **folds** — the diagonal "staircase" crease seen on EDF.STEP's
+external faces (15 fold-edges on body-0 faces 0/5). Interior nodes are required, but every
+naive attempt **inflated the divergence-theorem volume +20–70%** on the EDF model (see the
+diagnosis in `step-import-status` memory + the table below). This milestone builds the real
+tolerant mesher — the class of algorithm OpenCASCADE's `BRepMesh` implements — incrementally,
+gating **every** step with the OpenCASCADE `getMass` volume oracle so no step ships a regression.
+
+This is the deferred follow-on to the curved-face tessellation chain (#100 winding, #101 (u,v)
+ear-clip, #102 CDT, #103 sphere-cap band, #105 sphere-cap interior nodes), which brought EDF
+import from ~75% to **101.5%** of the OpenCASCADE volume and made analytic caps smooth. The one
+remaining defect is the freeform external faces folding.
+
+## Why the naive fixes failed (all measured on EDF.STEP; OCC truth = 207,002)
+
+| approach | EDF volume | result |
+|----------|-----------:|--------|
+| `(u,v)` boundary-only (today) | 210,087 (101.5%) | volume OK, **folds** (the staircase) |
+| best-fit-plane boundary-only | ~159,660 (75%) | folds **and** tears |
+| `(u,v)` + interior grid | ~276,548 (133%) | **over-encloses** |
+| structured grid over domain | ~303,800 (147%) | folds **and** over-encloses |
+| march-projected pcurve + interior | ~279,921 (135%) | big faces fold-free, still over-encloses |
+
+Two root causes, both confirmed:
+1. **Imported edge curves lie ~1.9 mm off their own surfaces** (a STEP tolerance reality;
+   `Surface.ParamAt` correctly returns the *closest* surface point — verified not a solver bug, a
+   Gauss–Newton step gave the identical residual). So on-surface interior nodes do not align with
+   the off-surface shared boundary → overlap.
+2. **No single 2D embedding works for every face** (the surface's own `(u,v)` self-intersects
+   from `ParamAt` jitter near folds; the best-fit plane self-intersects on big wrapping patches),
+   and an interior `(u,v)` grid + CDT **over-encloses** on complex/holed trims.
+
+The march-projected pcurve (project each edge point seeded from the previous point's `(u,v)`,
+`ParamNear`) **does** produce a smooth, non-self-intersecting boundary and fixed the big duct
+faces' folds — it is the foundation this milestone builds on.
+
+## Goals
+
+- Trimmed NURBS faces mesh **smooth** (no fold/staircase) and **volume-correct** (within the OCC
+  oracle tolerance), with **interior** nodes following the surface.
+- A **tolerant shared-edge** representation so adjacent faces meet without gaps, folds, or
+  double-counting — the watertightness that survives the ~mm edge/surface import tolerance.
+- **Deflection-adaptive** node density (the OpenCASCADE range-splitter idea) so flat regions are
+  coarse and high-curvature regions are dense, driven by `ops.Quality`.
+- Every step **gated by the volume oracle** and by committed fold / over-enclosure detectors —
+  no eyeballing, no regressions.
+
+## In scope
+
+- Smooth per-edge **pcurves** computed by march-projection (`ParamNear`), shared by both
+  adjacent faces — the on-surface, non-self-intersecting boundary.
+- **Trim-respecting** interior node generation: a deflection-adaptive `(u,v)` grid that stays
+  strictly inside the trim (inside outer, outside every hole) with no spill.
+- **Curvature-aware** face triangulation (CDT of boundary + interior) that does not fold in 3D.
+- **Tolerant shared-edge stitching**: mesh each edge once (one polyline), both faces bind to it,
+  so the body stays watertight despite the edge/surface tolerance.
+- Fold-freeness + over-enclosure + per-face-area committed detectors; OCC oracle extended with a
+  freeform-NURBS fixture; the EDF model as an end-to-end volume regression.
+
+## Out of scope (handled elsewhere / deferred)
+
+- **Analytic** face meshing (planes, cylinders, cones, tori, sphere caps) — already correct
+  (`structuredGridMesh` / `coneApexFan` / `gridPatchMesh`); M24 touches only the freeform path.
+- **Exact analytic B-rep operations** on NURBS (boolean, offset) — geometry, not meshing.
+- **Re-projecting / healing** the imported B-rep to remove the edge/surface gap at the model
+  level (a separate import-healing effort); M24 tolerates the gap in the mesher.
+- Reading STEP **pcurves** when present — irrelevant for the driving case (SolidWorks writes
+  `0 SURFACE_CURVE`); M24 computes pcurves by projection. (A future optimization may consume them.)
+
+## Exit criteria
+
+- EDF.STEP imports with the external freeform faces **fold-free** (the committed fold detector
+  reports 0 fold-edges on every face) and the total volume stays within the oracle tolerance of
+  OpenCASCADE's `getMass` (no inflation; target ≤ a few % of 207,002).
+- A synthetic **trimmed freeform-NURBS** OCC fixture (a B-spline patch with a hole) meshes within
+  volume tolerance and fold-free, committed in the oracle suite.
+- Adjacent freeform faces share an edge polyline: no per-face gap exceeds the model tolerance
+  (a watertightness/free-edge check on the assembled body).
+- Live confirmation on EDF (shaded + Normal-Debug): the staircase is gone, the external surfaces
+  read smooth — using the Save-Viewport-PNG loop.
+- All existing tessellation tests + the OCC oracle stay green at every PBI; lint clean.
+
+## Depends on
+
+M07 (B-rep topology + tessellation, `kernel/ops`), M17 (STEP import, `kernel/exchange/step`),
+the curved-face chain in `kernel/ops/{tessellate_trim,cdt,refined_patch}.go`, the OCC oracle
+(`kernel/exchange/step/occ_oracle_test.go` + gmsh SDK ground truth). A new
+**ADR-00XX (tolerant NURBS meshing)** records the on-surface-with-tolerance approach (F01).
+
+## Features
+
+| ID | Feature | PBIs | Summary |
+|----|---------|:----:|---------|
+| **F01** | [On-surface pcurves & boundary](F01-pcurves-on-surface-boundary/_feature.md) | 2 | `ParamNear` seeded projection + march-projected per-edge pcurves (smooth, non-self-intersecting on-surface boundary); the ADR. |
+| **F02** | [Trim-respecting adaptive interior](F02-trim-respecting-interior/_feature.md) | 3 | Deflection-adaptive interior `(u,v)` nodes clipped strictly to the trim (the over-enclosure fix) + curvature-aware non-folding CDT. |
+| **F03** | [Tolerant shared-edge stitching](F03-shared-edge-stitching/_feature.md) | 2 | Mesh each edge once; both faces bind to the shared polyline so the body stays watertight across the ~mm edge/surface tolerance. |
+| **F04** | [Oracle gating & EDF regression](F04-oracle-gating-regression/_feature.md) | 2 | Committed fold / over-enclosure / per-face-area detectors, a synthetic trimmed-NURBS OCC fixture, and EDF as an end-to-end volume regression. |

--- a/implementation-plan/README.md
+++ b/implementation-plan/README.md
@@ -44,6 +44,7 @@ rules (units, identity, transactions, events) that apply to every milestone.
 | **M21** | [Sketch2D Feature Completion (2D Parity)](M21-sketch2d-feature-completion/_milestone.md) | 11 | 22 | M06, M08 |
 | **M22** | [Sketch3D Feature Completion (3D Parity)](M22-sketch3d-feature-completion/_milestone.md) | 12 | 18 | M06, M07, M08 |
 | **M23** | [Renderer Display-Mode Parity & Realistic PBR](M23-renderer-display-modes/_milestone.md) | 4 | 12 | M07, M16, M19 |
+| **M24** | [Tolerant NURBS Surface Meshing (imported B-rep)](M24-tolerant-nurbs-meshing/_milestone.md) | 4 | 9 | M07, M17 |
 
 ¹ M19 (Materials & Appearances) shipped real code (`model/material`, `app/materials*`,
 head Materials/Appearance windows) ahead of its plan files; its 7 feature/PBI files were
@@ -85,9 +86,9 @@ generation for each modeling capability are delivered incrementally alongside M0
 _(Reconciled against the filesystem on 2026-06-04 — see audit REPORT.md. Counts are
 `_feature.md` / `PBI-*.md` file counts.)_
 
-- Milestones: **24** (M00–M23)
-- Features: **135** (incl. M19's 7 backfilled feature files — note ¹ above)
-- PBIs: **262** (incl. M19's 7 backfilled PBIs)
+- Milestones: **25** (M00–M24)
+- Features: **139** (incl. M19's 7 backfilled feature files — note ¹ above)
+- PBIs: **271** (incl. M19's 7 backfilled PBIs)
 
 > Note: these are *planned* counts (files that exist), not *done* counts. For actual
 > completion status — graded on the three axes Model / Geometry / UI+e2e


### PR DESCRIPTION
Scopes the deferred tolerant NURBS mesher as a proper milestone (the fix for the freeform-face folding / staircase on imported B-reps that the curved-face chain #100–#105 left open).

**4 features, 9 PBIs (312–320), each gated by the OpenCASCADE volume oracle:**
- **F01** on-surface pcurves — march-projected `ParamNear` (the foundation; prototyped during diagnosis).
- **F02** trim-respecting adaptive interior nodes + curvature-aware non-folding triangulation — the over-enclosure (+20–70%) and fold fix.
- **F03** tolerant shared-edge stitching — watertight across the ~1.9mm imported edge/surface tolerance.
- **F04** committed fold/over-enclosure detectors + freeform-NURBS OCC fixture + EDF end-to-end regression.

The milestone records the measured failure table from diagnosis (every quick approach and its EDF volume) so the implementation builds on findings, not guesses. Planning only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)