### PR TITLE
M24 F01 PBI-313: march-projected per-edge pcurves

### DIFF
--- a/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/PBI-313-march-projected-pcurves.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/PBI-313-march-projected-pcurves.md
@@ -3,7 +3,7 @@ milestone: M24
 feature: F01
 pbi: PBI-313
 title: March-projected per-edge pcurves (non-self-intersecting boundary)
-status: planned
+status: done
 estimate: M
 ---
 

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/_feature.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F01-pcurves-on-surface-boundary/_feature.md
@@ -2,7 +2,7 @@
 milestone: M24
 feature: F01
 name: On-surface pcurves & boundary
-status: planned
+status: in-progress
 ---
 
 # M24 · F01 — On-surface pcurves & boundary

--- a/kernel/ops/pcurve.go
+++ b/kernel/ops/pcurve.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// marchUV builds a face boundary's pcurve in the surface's (u,v): the first point is projected
+// with a full grid search, then each subsequent point is projected SEEDED from the previous
+// point's (u,v) (geom.BSplineSurface.ParamNear). Seeding keeps the curve on one smooth branch, so
+// it does not self-intersect where independent ParamAt would — adjacent points snapping to
+// different local minima near a near-fold (the imported edges sit ~mm off the surface, ADR-0030).
+// A non-self-intersecting boundary is the prerequisite for a non-folding interior triangulation
+// (M24 F02) and a reliable point-in-trim test. The 3D positions are unchanged — this only assigns
+// each point a smooth (u,v).
+func marchUV(s geom.BSplineSurface, loop []math.Point3) []math.Point2 {
+	out := make([]math.Point2, len(loop))
+	if len(loop) == 0 {
+		return out
+	}
+	pu, pv := s.ParamAt(loop[0])
+	out[0] = math.P2(math.Scalar(pu), math.Scalar(pv))
+	for i := 1; i < len(loop); i++ {
+		pu, pv = s.ParamNear(loop[i], pu, pv)
+		out[i] = math.P2(math.Scalar(pu), math.Scalar(pv))
+	}
+	return out
+}

--- a/kernel/ops/pcurve_test.go
+++ b/kernel/ops/pcurve_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// foldSurface folds exactly in v: PointAt(u,v) = (u, 2v(1−v), 0), so v and 1−v map to the SAME 3D
+// point (a 2-to-1 fold). Independent ParamAt is genuinely ambiguous there and snaps adjacent
+// boundary points to different sides (the jitter that self-intersects the (u,v) boundary); a march
+// seeded from the previous point stays on one side — the property the tolerant mesher needs.
+func foldSurface(t *testing.T) geom.BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 1, 0), math.P3(0, 0, 0)},
+		{math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(1, 0, 0)},
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}}
+	s, err := geom.NewBSplineSurface(1, 2, ctrl, w, []float64{0, 0, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	return s
+}
+
+func selfIntersections(raw []math.Point2) int {
+	// Drop consecutive coincident points (the loop double-adds corners) so zero-length edges do
+	// not produce spurious crossings.
+	var poly []math.Point2
+	for i, p := range raw {
+		if i == 0 || float64(p.X) != float64(raw[i-1].X) || float64(p.Y) != float64(raw[i-1].Y) {
+			poly = append(poly, p)
+		}
+	}
+	at := func(i int) [2]float64 { return [2]float64{float64(poly[i].X), float64(poly[i].Y)} }
+	n, count := len(poly), 0
+	for i := 0; i < n; i++ {
+		for j := i + 2; j < n; j++ {
+			if i == 0 && j == n-1 {
+				continue // the closing edge is adjacent to edge 0
+			}
+			if segmentsCross(at(i), at((i+1)%n), at(j), at((j+1)%n)) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func TestMarchUVNonSelfIntersecting(t *testing.T) {
+	s := foldSurface(t)
+	// A loop entirely on one side of the fold (v < 0.5). Every point also exists at 1−v, so
+	// independent ParamAt jitters between the two sides; marchUV keeps it on the v<0.5 side.
+	var loop []math.Point3
+	add := func(u, v float64) { loop = append(loop, s.PointAt(u, v)) }
+	for u := 0.2; u <= 0.8; u += 0.1 {
+		add(u, 0.1)
+	}
+	for v := 0.1; v <= 0.3; v += 0.05 {
+		add(0.8, v)
+	}
+	for u := 0.8; u >= 0.2; u -= 0.1 {
+		add(u, 0.3)
+	}
+	for v := 0.3; v >= 0.1; v -= 0.05 {
+		add(0.2, v)
+	}
+
+	marched := marchUV(s, loop)
+
+	// marchUV's guarantee: a simple (non-self-intersecting) boundary that stays on ONE side of the
+	// fold. (The branch-selection mechanism is proven in geom.TestParamNearSelectsBranchBySeed; the
+	// end-to-end win over independent ParamAt is gated on EDF in M24 F04.)
+	if si := selfIntersections(marched); si != 0 {
+		t.Errorf("marchUV boundary self-intersects %d times; expected 0 (a simple pcurve)", si)
+	}
+	first := float64(marched[0].Y) < 0.5
+	for i, p := range marched {
+		if (float64(p.Y) < 0.5) != first {
+			t.Errorf("marchUV point %d crossed the fold (v=%.3f); the pcurve must stay single-branch", i, p.Y)
+		}
+	}
+	// For context: independent ParamAt is free to jitter across the fold on this 2-to-1 surface.
+	indep := make([]math.Point2, len(loop))
+	for i, p := range loop {
+		u, v := s.ParamAt(p)
+		indep[i] = math.P2(math.Scalar(u), math.Scalar(v))
+	}
+	t.Logf("self-intersections: marchUV=%d independent ParamAt=%d", selfIntersections(marched), selfIntersections(indep))
+}
+
+func TestMarchUVRoundTrip(t *testing.T) {
+	s := foldSurface(t)
+	var loop []math.Point3
+	for u := 0.2; u <= 0.8; u += 0.15 {
+		loop = append(loop, s.PointAt(u, 0.3))
+	}
+	for i, p := range marchUV(s, loop) {
+		if got := s.PointAt(float64(p.X), float64(p.Y)); float64(got.DistanceTo(loop[i])) > 1e-4 {
+			t.Errorf("marchUV round-trip off by %.5f at %d", got.DistanceTo(loop[i]), i)
+		}
+	}
+}


### PR DESCRIPTION
Completes **M24 F01** (on-surface pcurves). `marchUV` builds a face boundary's `(u,v)` by chaining `ParamNear` (each point seeded from the previous), keeping the pcurve on **one smooth branch** instead of the self-intersecting jitter independent `ParamAt` produces near a fold.

- Infrastructure only — **not wired into tessellation yet** (F02 consumes it); OCC oracle volume unchanged.
- Tests on a 2-to-1 fold surface: marchUV is **non-self-intersecting**, stays **single-branch**, and round-trips. (Branch mechanism proven in PBI-312; end-to-end win gated on EDF in F04.)

F01 done (PBI-312 + 313). Next: **F02** — trim-respecting adaptive interior nodes + curvature-aware non-folding triangulation (the over-enclosure + fold fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)