### PR TITLE
M24 F02 PBI-314: deflection-adaptive, trim-clipped interior nodes

### DIFF
--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-314-adaptive-trim-clipped-nodes.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-314-adaptive-trim-clipped-nodes.md
@@ -3,7 +3,7 @@ milestone: M24
 feature: F02
 pbi: PBI-314
 title: Deflection-adaptive, strictly trim-clipped interior nodes
-status: planned
+status: done
 estimate: L
 ---
 

--- a/kernel/ops/nurbs_interior.go
+++ b/kernel/ops/nurbs_interior.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// maxInteriorCells bounds the grid so a pathological curvature estimate cannot explode the node
+// count; minInteriorCells keeps a curved face from collapsing to a single coarse quad.
+const (
+	maxInteriorCells = 64
+	minInteriorCells = 2
+)
+
+// adaptiveInteriorNodes returns interior (u,v) nodes for a trimmed NURBS face: a staggered grid
+// whose spacing follows the surface's curvature (a flat face gets none, a curved face gets dense
+// nodes at the same Quality), kept STRICTLY inside the trim — inside the outer pcurve, outside every
+// hole, and at least a margin off the boundary so no node spills past the trim or sits on it (the
+// over-enclosure that inflated the volume in every naive attempt — ADR-0030 / M24 F02). The pcurves
+// are the smooth march-projected boundary (F01); their point-in-polygon test is therefore reliable.
+func adaptiveInteriorNodes(s geom.Surface, outer []math.Point2, holes [][]math.Point2, q Quality) [][2]float64 {
+	umin, umax, vmin, vmax := uvBBox(outer)
+	stepU, stepV := adaptiveStep(s, umin, umax, vmin, vmax, q)
+	if stepU <= 0 || stepV <= 0 {
+		return nil
+	}
+	margin := 0.3 * stdmath.Min(stepU, stepV)
+	var pts [][2]float64
+	row := 0
+	for v := vmin + stepV/2; v < vmax; v += stepV {
+		off := 0.0
+		if row%2 == 1 {
+			off = stepU / 2 // stagger alternate rows for better-shaped triangles
+		}
+		row++
+		for u := umin + stepU/2 + off; u < umax; u += stepU {
+			if p := [2]float64{u, v}; clearOfTrim(outer, holes, p, margin) {
+				pts = append(pts, p)
+			}
+		}
+	}
+	return pts
+}
+
+// adaptiveStep picks the (u,v) grid spacing so the surface's chord deviation over a cell stays
+// within q.ChordTolerance. The whole-region sagitta D scales ~quadratically with cell size, so a
+// cell fraction f ≈ sqrt(tol/D) hits the tolerance; the result is clamped to [min,max] cells.
+func adaptiveStep(s geom.Surface, umin, umax, vmin, vmax float64, q Quality) (stepU, stepV float64) {
+	uExt, vExt := umax-umin, vmax-vmin
+	if uExt <= 0 || vExt <= 0 {
+		return 0, 0
+	}
+	tol := q.ChordTolerance
+	if tol <= 0 {
+		tol = DefaultQuality().ChordTolerance
+	}
+	d := regionSagitta(s, umin, umax, vmin, vmax)
+	frac := 1.0
+	if d > tol {
+		frac = stdmath.Sqrt(tol / d)
+	}
+	return clampStep(uExt*frac, uExt), clampStep(vExt*frac, vExt)
+}
+
+func clampStep(step, ext float64) float64 {
+	return stdmath.Max(ext/maxInteriorCells, stdmath.Min(step, ext/minInteriorCells))
+}
+
+// regionSagitta estimates how far the surface bulges from the flat bilinear quad spanning the (u,v)
+// region — a curvature proxy: 0 for a planar patch, large for a tightly-curved one.
+func regionSagitta(s geom.Surface, umin, umax, vmin, vmax float64) float64 {
+	c00, c10 := s.PointAt(umin, vmin), s.PointAt(umax, vmin)
+	c01, c11 := s.PointAt(umin, vmax), s.PointAt(umax, vmax)
+	var max float64
+	for _, f := range [][2]float64{{0.25, 0.25}, {0.5, 0.5}, {0.75, 0.75}, {0.25, 0.75}, {0.75, 0.25}} {
+		u, v := umin+f[0]*(umax-umin), vmin+f[1]*(vmax-vmin)
+		flat := bilerp(c00, c10, c01, c11, f[0], f[1])
+		if d := float64(s.PointAt(u, v).DistanceTo(flat)); d > max {
+			max = d
+		}
+	}
+	return max
+}
+
+// bilerp bilinearly interpolates the four corners at (fu, fv) ∈ [0,1]².
+func bilerp(c00, c10, c01, c11 math.Point3, fu, fv float64) math.Point3 {
+	x := lerp2(c00.X, c10.X, c01.X, c11.X, fu, fv)
+	y := lerp2(c00.Y, c10.Y, c01.Y, c11.Y, fu, fv)
+	z := lerp2(c00.Z, c10.Z, c01.Z, c11.Z, fu, fv)
+	return math.P3(x, y, z)
+}
+
+func lerp2(a00, a10, a01, a11 math.Scalar, fu, fv float64) math.Scalar {
+	bottom := float64(a00) + (float64(a10)-float64(a00))*fu
+	top := float64(a01) + (float64(a11)-float64(a01))*fu
+	return math.Scalar(bottom + (top-bottom)*fv)
+}
+
+// clearOfTrim reports whether p is inside the trim AND at least `margin` (in u and v) from the
+// boundary, by requiring p and its four axis neighbours to be inside — so no node sits on or just
+// past the boundary, the seam that lets a node spill and over-enclose.
+func clearOfTrim(outer []math.Point2, holes [][]math.Point2, p [2]float64, margin float64) bool {
+	for _, off := range [][2]float64{{0, 0}, {margin, 0}, {-margin, 0}, {0, margin}, {0, -margin}} {
+		if !insideUVTrim(outer, holes, [2]float64{p[0] + off[0], p[1] + off[1]}) {
+			return false
+		}
+	}
+	return true
+}
+
+// uvBBox returns the (u,v) bounding box of a pcurve loop.
+func uvBBox(loop []math.Point2) (umin, umax, vmin, vmax float64) {
+	umin, vmin = stdmath.Inf(1), stdmath.Inf(1)
+	umax, vmax = stdmath.Inf(-1), stdmath.Inf(-1)
+	for _, p := range loop {
+		umin, umax = stdmath.Min(umin, float64(p.X)), stdmath.Max(umax, float64(p.X))
+		vmin, vmax = stdmath.Min(vmin, float64(p.Y)), stdmath.Max(vmax, float64(p.Y))
+	}
+	return umin, umax, vmin, vmax
+}

--- a/kernel/ops/nurbs_interior_test.go
+++ b/kernel/ops/nurbs_interior_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// uvSquare returns a densified square loop in (u,v) from (lo,lo) to (hi,hi), n points per side.
+func uvSquare(lo, hi float64, n int) []math.Point2 {
+	var loop []math.Point2
+	add := func(u, v float64) { loop = append(loop, math.P2(math.Scalar(u), math.Scalar(v))) }
+	step := (hi - lo) / float64(n)
+	for i := 0; i < n; i++ {
+		add(lo+float64(i)*step, lo)
+	}
+	for i := 0; i < n; i++ {
+		add(hi, lo+float64(i)*step)
+	}
+	for i := 0; i < n; i++ {
+		add(hi-float64(i)*step, hi)
+	}
+	for i := 0; i < n; i++ {
+		add(lo, hi-float64(i)*step)
+	}
+	return loop
+}
+
+// domeSurface is a strongly-curved bicubic-ish B-spline: a 3×3 net with the centre lifted to z=2.
+func domeSurface(t *testing.T) geom.BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 1, 0), math.P3(0, 2, 0)},
+		{math.P3(1, 0, 0), math.P3(1, 1, 2), math.P3(1, 2, 0)},
+		{math.P3(2, 0, 0), math.P3(2, 1, 0), math.P3(2, 2, 0)},
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}}
+	s, err := geom.NewBSplineSurface(2, 2, ctrl, w, []float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	return s
+}
+
+func TestAdaptiveInteriorNoSpill(t *testing.T) {
+	s := domeSurface(t)
+	outer := uvSquare(0.1, 0.9, 8)
+	holes := [][]math.Point2{uvSquare(0.4, 0.6, 6)}
+	nodes := adaptiveInteriorNodes(s, outer, holes, DefaultQuality())
+	if len(nodes) == 0 {
+		t.Fatal("a curved patch should get interior nodes")
+	}
+	for _, n := range nodes {
+		if !insideUVTrim(outer, holes, n) {
+			t.Errorf("node %v is outside the trim (spill)", n)
+		}
+		if n[0] > 0.4 && n[0] < 0.6 && n[1] > 0.4 && n[1] < 0.6 {
+			t.Errorf("node %v landed inside the hole", n)
+		}
+	}
+}
+
+func TestAdaptiveInteriorDensityFollowsCurvature(t *testing.T) {
+	flat := unitPatch(t) // z=0 bilinear (from refined_patch_test.go)
+	dome := domeSurface(t)
+	outer := uvSquare(0.05, 0.95, 8)
+	nFlat := len(adaptiveInteriorNodes(flat, outer, nil, DefaultQuality()))
+	nDome := len(adaptiveInteriorNodes(dome, outer, nil, DefaultQuality()))
+	if nDome <= nFlat {
+		t.Errorf("curved patch should get more interior nodes than flat: dome=%d flat=%d", nDome, nFlat)
+	}
+}
+
+func TestAdaptiveInteriorDeterministic(t *testing.T) {
+	s := domeSurface(t)
+	outer := uvSquare(0.1, 0.9, 8)
+	a := adaptiveInteriorNodes(s, outer, nil, DefaultQuality())
+	b := adaptiveInteriorNodes(s, outer, nil, DefaultQuality())
+	if len(a) != len(b) {
+		t.Fatalf("non-deterministic node count: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("non-deterministic node %d: %v vs %v", i, a[i], b[i])
+		}
+	}
+}


### PR DESCRIPTION
**M24 F02** (the over-enclosure fix). `adaptiveInteriorNodes` generates interior `(u,v)` nodes for a trimmed NURBS face:
- **curvature-adaptive** spacing (whole-region sagitta vs `ChordTolerance` → a flat face gets few nodes, a curved face dense, at the same Quality),
- **strictly trim-clipped**: inside the outer pcurve, outside every hole, and a margin off the boundary (point + 4 axis-neighbours all inside) — the fix for the spill that inflated volume +20–70% in every naive attempt.

Pure function over the F01 march-projected pcurves; **not wired into tessellation yet** (PBI-316). Tests: no-spill on a holed dome patch, density-follows-curvature (dome > flat), determinism. ops + OCC oracle green; lint clean.

(macOS CI will show the pre-existing `TestFilletAllBoxEdges` flake — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)