### PR TITLE
M24 F02 PBI-315: curvature-aware fold detection + edge-flip repair

### DIFF
--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-315-curvature-aware-no-fold.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-315-curvature-aware-no-fold.md
@@ -3,7 +3,7 @@ milestone: M24
 feature: F02
 pbi: PBI-315
 title: Curvature-aware triangulation with fold detection + repair
-status: planned
+status: done
 estimate: L
 ---
 

--- a/kernel/ops/fold_repair.go
+++ b/kernel/ops/fold_repair.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati/math"
+)
+
+// foldDihedralTol: two triangles sharing an edge are a FOLD when their geometric (cross-product)
+// normals point apart by more than this — cos(angle) < −foldDihedralTol — i.e. the meshed surface
+// creases back on itself. A (u,v) Delaunay triangulation lifted to 3D can fold where the (u,v)→3D
+// map is strongly non-conformal (the imported-NURBS "staircase"); repairFolds flips such edges.
+const foldDihedralTol = 0.2
+
+// repairFolds flips interior edges whose two triangles fold (oppose in 3D) to the quad's other
+// diagonal when that removes the fold, sweeping up to maxPasses times. Each new triangle is rewound
+// to agree with its vertex normals (windingOpposesNormals), so orientation stays consistent.
+// Returns the number of flips applied.
+func repairFolds(m *Mesh, maxPasses int) int {
+	total := 0
+	for pass := 0; pass < maxPasses; pass++ {
+		flips := repairFoldPass(m)
+		total += flips
+		if flips == 0 {
+			break
+		}
+	}
+	return total
+}
+
+// repairFoldPass flips every flippable fold edge once, skipping edges whose triangles were already
+// flipped this pass (their adjacency is stale until the next pass rebuilds it). Returns the flips.
+func repairFoldPass(m *Mesh) int {
+	adj := edgeTriMap(m)
+	dirty := map[int]bool{}
+	flips := 0
+	for e, ts := range adj {
+		if len(ts) != 2 || dirty[ts[0]] || dirty[ts[1]] {
+			continue
+		}
+		if tryFlipFold(m, e, ts[0], ts[1], adj) {
+			dirty[ts[0]], dirty[ts[1]] = true, true
+			flips++
+		}
+	}
+	return flips
+}
+
+// tryFlipFold flips edge e (shared by t0,t1) to the quad's other diagonal if t0,t1 fold and the
+// flip is valid (apexes found, no duplicate edge, new triangles non-degenerate + not folding).
+func tryFlipFold(m *Mesh, e edgeKey, t0, t1 int, adj map[edgeKey][]int) bool {
+	if !trianglesFold(m, t0, t1) {
+		return false
+	}
+	c, d := apexOf(m, t0, e), apexOf(m, t1, e)
+	if c < 0 || d < 0 {
+		return false
+	}
+	if _, exists := adj[sortedEdge(c, d)]; exists {
+		return false // flipping would duplicate an existing edge (non-manifold)
+	}
+	return attemptFlip(m, t0, t1, e.a, e.b, c, d)
+}
+
+type edgeKey struct{ a, b int }
+
+func sortedEdge(a, b int) edgeKey {
+	if a > b {
+		a, b = b, a
+	}
+	return edgeKey{a, b}
+}
+
+// edgeTriMap maps each undirected edge to the triangles using it.
+func edgeTriMap(m *Mesh) map[edgeKey][]int {
+	adj := make(map[edgeKey][]int, len(m.Indices))
+	for t := 0; 3*t+2 < len(m.Indices); t++ {
+		v := [3]int{m.Indices[3*t], m.Indices[3*t+1], m.Indices[3*t+2]}
+		for k := 0; k < 3; k++ {
+			e := sortedEdge(v[k], v[(k+1)%3])
+			adj[e] = append(adj[e], t)
+		}
+	}
+	return adj
+}
+
+// apexOf returns triangle t's vertex not on edge e, or -1 if e is not an edge of t.
+func apexOf(m *Mesh, t int, e edgeKey) int {
+	v := [3]int{m.Indices[3*t], m.Indices[3*t+1], m.Indices[3*t+2]}
+	onEdge := func(x int) bool { return x == e.a || x == e.b }
+	if onEdge(v[0]) && onEdge(v[1]) && !onEdge(v[2]) {
+		return v[2]
+	}
+	if onEdge(v[1]) && onEdge(v[2]) && !onEdge(v[0]) {
+		return v[0]
+	}
+	if onEdge(v[0]) && onEdge(v[2]) && !onEdge(v[1]) {
+		return v[1]
+	}
+	return -1
+}
+
+// triGeomNormal returns triangle t's (un-normalized) geometric normal.
+func triGeomNormal(m *Mesh, t int) math.Vector3 {
+	a, b, c := m.Positions[m.Indices[3*t]], m.Positions[m.Indices[3*t+1]], m.Positions[m.Indices[3*t+2]]
+	return a.VectorTo(b).Cross(a.VectorTo(c))
+}
+
+// trianglesFold reports whether triangles t0,t1 oppose (a fold).
+func trianglesFold(m *Mesh, t0, t1 int) bool {
+	return normalsOppose(triGeomNormal(m, t0), triGeomNormal(m, t1))
+}
+
+func normalsOppose(n0, n1 math.Vector3) bool {
+	l0, l1 := stdmath.Sqrt(float64(n0.Dot(n0))), stdmath.Sqrt(float64(n1.Dot(n1)))
+	if l0 == 0 || l1 == 0 {
+		return false
+	}
+	return float64(n0.Dot(n1))/(l0*l1) < -foldDihedralTol
+}
+
+// attemptFlip rewrites triangles t0,t1 (sharing edge a-b, apexes c,d) to the diagonal c-d when the
+// new triangles are non-degenerate and do not themselves fold — otherwise leaves the mesh unchanged
+// and returns false. New triangles are rewound to their vertex normals.
+func attemptFlip(m *Mesh, t0, t1, a, b, c, d int) bool {
+	n0 := m.Positions[c].VectorTo(m.Positions[a]).Cross(m.Positions[c].VectorTo(m.Positions[d]))
+	n1 := m.Positions[c].VectorTo(m.Positions[d]).Cross(m.Positions[c].VectorTo(m.Positions[b]))
+	if degenerateNormal(n0) || degenerateNormal(n1) || normalsOppose(n0, n1) {
+		return false
+	}
+	writeTriangle(m, t0, c, a, d)
+	writeTriangle(m, t1, c, d, b)
+	return true
+}
+
+func degenerateNormal(n math.Vector3) bool { return float64(n.Dot(n)) < 1e-20 }
+
+// writeTriangle sets triangle t to (i,j,k), rewound so its geometric normal agrees with the
+// vertices' surface normals (consistent with the rest of the patch).
+func writeTriangle(m *Mesh, t, i, j, k int) {
+	if windingOpposesNormals(m.Positions[i], m.Positions[j], m.Positions[k], m.Normals[i], m.Normals[j], m.Normals[k]) {
+		j, k = k, j
+	}
+	m.Indices[3*t], m.Indices[3*t+1], m.Indices[3*t+2] = i, j, k
+}

--- a/kernel/ops/fold_repair_test.go
+++ b/kernel/ops/fold_repair_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati/math"
+)
+
+func countFolds(m *Mesh) int {
+	c := 0
+	for _, ts := range edgeTriMap(m) {
+		if len(ts) == 2 && trianglesFold(m, ts[0], ts[1]) {
+			c++
+		}
+	}
+	return c
+}
+
+func TestRepairFoldsFixesAFold(t *testing.T) {
+	// A non-planar quad triangulated on the diagonal that folds (normals oppose); flipping to the
+	// other diagonal removes the fold.
+	m := &Mesh{
+		Positions: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 1), math.P3(2, 0, 0), math.P3(1, 1, 1)},
+		Normals:   []math.Vector3{math.V3(0, 1, 0), math.V3(0, 1, 0), math.V3(0, 1, 0), math.V3(0, 1, 0)},
+		Indices:   []int{0, 1, 2, 0, 2, 3},
+	}
+	if countFolds(m) == 0 {
+		t.Fatal("test setup should contain a fold")
+	}
+	folded := totalTriArea(m)
+	repairFolds(m, 4)
+	if c := countFolds(m); c != 0 {
+		t.Errorf("repairFolds left %d fold edges; want 0", c)
+	}
+	if m.TriangleCount() != 2 {
+		t.Errorf("a flip must preserve the triangle count, got %d", m.TriangleCount())
+	}
+	// The fold's diagonal spans the crease, so its triangles over-cover; the repaired diagonal must
+	// not increase total area (no overlap introduced).
+	if repaired := totalTriArea(m); repaired > folded+1e-9 {
+		t.Errorf("repair increased area: folded=%.4f repaired=%.4f", folded, repaired)
+	}
+}
+
+func totalTriArea(m *Mesh) float64 {
+	var a float64
+	for t := 0; 3*t+2 < len(m.Indices); t++ {
+		n := triGeomNormal(m, t)
+		a += stdmath.Sqrt(float64(n.Dot(n))) / 2
+	}
+	return a
+}
+
+func TestRepairFoldsPreservesCleanMesh(t *testing.T) {
+	// A flat, fold-free quad: repairFolds must do nothing.
+	m := &Mesh{
+		Positions: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0)},
+		Normals:   []math.Vector3{math.V3(0, 0, 1), math.V3(0, 0, 1), math.V3(0, 0, 1), math.V3(0, 0, 1)},
+		Indices:   []int{0, 1, 2, 0, 2, 3},
+	}
+	before := append([]int(nil), m.Indices...)
+	if n := repairFolds(m, 4); n != 0 {
+		t.Errorf("clean mesh needed %d flips; want 0", n)
+	}
+	for i := range before {
+		if m.Indices[i] != before[i] {
+			t.Errorf("clean mesh was modified at index %d", i)
+		}
+	}
+}


### PR DESCRIPTION
**M24 F02.** `repairFolds` removes the fold a (u,v) Delaunay can produce when lifted to a strongly-curved 3D surface (the imported-NURBS staircase): it finds interior edges whose two triangles' geometric normals **oppose**, and flips them to the quad's other diagonal when that removes the fold (keeping new triangles non-degenerate + consistently wound by vertex normals), sweeping until none remain.

Tests: a non-planar quad on the folding diagonal → repaired to **0 folds**, triangle count preserved, area not increased; a clean quad left untouched. **Not wired yet** — PBI-316 assembles F01 (pcurves) + F02 (adaptive interior + fold repair) into `nurbsPatchMesh`, oracle-gated.

(macOS CI = pre-existing `TestFilletAllBoxEdges` flake, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)