### PR TITLE
plan: M24 PBI-316 finding — (u,v) interior non-conformal; redirect to 3D-space refinement (PBI-321)

### DIFF
--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-316-wire-nurbs-face-mesher.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-316-wire-nurbs-face-mesher.md
@@ -3,8 +3,7 @@ milestone: M24
 feature: F02
 pbi: PBI-316
 title: Wire the NURBS face mesher (oracle-gated)
-status: planned
-estimate: M
+status: blocked
 ---
 
 # PBI-316 — Wire the NURBS face mesher (oracle-gated)
@@ -13,37 +12,34 @@ estimate: M
 
 ## Goal
 
-Route B-spline faces through the new on-surface interior-node mesher (pcurve boundary + adaptive
+Route B-spline faces through an on-surface interior-node mesher (pcurve boundary + adaptive
 trim-clipped interior + non-folding triangulation), replacing `trimmedPatchMesh`, **only if** it
 holds the volume oracle.
 
-## Scope / work
+## BLOCKED — finding (2026-06-08): the (u,v)-interior approach is a dead end for imported faces
 
-- Assemble F01+F02 into `nurbsPatchMesh(s, outer3D, holes3D)`: march-projected pcurves → adaptive
-  trim-clipped interior nodes → CDT → fold-repair → mesh. Boundary nodes lifted **on-surface**
-  (`PointAt` of the pcurve), interior likewise — consistent, so no exact-vs-on-surface overlap.
-  (F03 then makes the on-surface boundary consistent across faces.)
-- Route `geom.BSplineSurface` non-rectangular faces to it in `tessellate_trim.go`
-  (`nonRectangularMesh`); analytic faces unchanged.
-- **Gate on the oracle**: measure EDF total volume and per-face folds. This PBI may still leave a
-  per-face seam (F03 fixes that) but must NOT over-enclose — the volume must be within tolerance
-  of OCC (no +20–70%). If a face inflates, fall back to the boundary-only path for that face
-  (a guard) so the milestone never regresses volume.
+Assembled `nurbsPatchMesh` (F01 marchUV pcurve + F02 PBI-314 interior grid + PBI-315 fold repair)
+and wired it; measured on EDF.STEP. It **inflated the body volume +33%** (281k vs the 210k baseline,
+OCC truth 207k). Diagnosis (all measured, then reverted):
 
-## API contracts (interfaces / enums / collections)
+- The marchUV pcurves are **clean** (0 self-intersections on every EDF face) and per-face areas
+  match the boundary-only mesh (~1.0 ratio) — F01 works.
+- But the interior `(u,v)` nodes' `PointAt` lands **~15% of the face size off** the true trim
+  surface (13–25 mm on faces 61–147 mm across), **uniformly**, on every imported face. The
+  imported rational-NURBS **parameterization is non-conformal**: a `(u,v)` point inside the trim's
+  `(u,v)` boundary does NOT map to a 3D point inside the trim. So a `(u,v)` interior grid cannot
+  refine these faces — it samples the wrong part of the surface and over-encloses.
+- A `ParamAt`-vs-pcurve **branch mismatch** also flipped boundary normals against the interior
+  (fixed by `nurbsBoundaryLoops`), but that was secondary; the parameterization is the wall.
+- A **deviation guard** (fall back if interior nodes stray from the boundary-only mesh) cannot
+  distinguish a non-conformal error from a **legitimate bulge** — both deviate from the flat
+  boundary-only mesh — so it falls back even a correct conformal dome. No usable guard on this path.
 
-- (internal) `ops.nurbsPatchMesh`; dispatch in `tessellateCurvedFace`/`nonRectangularMesh`.
+**Conclusion:** F02's `(u,v)`-grid interior is the wrong primitive for imported non-conformal
+NURBS. The mesher must refine in **3D space**, not `(u,v)`. The F01 pcurve, PBI-314 adaptive
+density, and PBI-315 fold repair stay valid + tested; only the interior *sampling* changes. Reverted
+the wiring; develop stays at the correct boundary-only baseline (210k). See PBI-321.
 
-## Acceptance criteria
+## Superseded by
 
-- EDF.STEP external freeform faces are **fold-free** (committed detector) and the total volume is
-  **within tolerance of OCC** (no inflation) — the per-face inflation guard ensures no regression.
-- The OCC oracle suite stays green; the EDF volume does not regress below the current 101.5%
-  baseline beyond the stated tolerance.
-- Live confirmation (shaded + Normal-Debug, Save-Viewport-PNG): the staircase is gone on the
-  external faces.
-- `go test ./kernel/...` green; lint clean.
-
-## Depends on
-
-F01 (pcurves), PBI-314 (interior), PBI-315 (no-fold), the OCC oracle.
+[PBI-321 — 3D-space interior refinement](PBI-321-3d-space-refinement.md).

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-321-3d-space-refinement.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-321-3d-space-refinement.md
@@ -1,0 +1,52 @@
+---
+milestone: M24
+feature: F02
+pbi: PBI-321
+title: 3D-space interior refinement (replaces the (u,v) grid)
+status: planned
+estimate: L
+---
+
+# PBI-321 — 3D-space interior refinement (replaces the (u,v) grid)
+
+**Milestone:** M24 Tolerant NURBS Surface Meshing  ·  **Feature:** F02 Trim-respecting adaptive interior
+
+## Why (supersedes PBI-316's interior)
+
+PBI-316 proved a `(u,v)`-grid interior cannot refine imported NURBS faces: their parameterization is
+**non-conformal**, so a `(u,v)` point inside the trim maps ~15% of the face size OFF the trim
+surface (over-encloses, +33% volume). The interior must be refined in **3D space**, where new points
+stay near the true surface and `ParamAt` is reliable.
+
+## Approach
+
+Refine the **boundary-only** mesh (`trimmedPatchMesh` — watertight, correct volume, but it folds /
+is coarse on a curved face) by **3D subdivision + surface projection**:
+
+- Repeatedly take an interior triangle that is too coarse (its `ParamAt→PointAt` centroid deviates
+  from the triangle plane by more than `q.ChordTolerance`) or that folds, insert the **projected
+  centroid** (`PointAt(ParamAt(centroid))` — the centroid lies on the chord, near the surface, so
+  the projection is reliable, unlike a `(u,v)` grid point), and re-triangulate locally.
+- **Never subdivide a boundary edge** — boundary vertices stay the exact shared edge points, so the
+  body stays watertight (no T-junctions with neighbour faces). Only interior edges/faces refine.
+- Run PBI-315 fold repair after; the new points follow the real surface, so the chord-fold the
+  boundary-only mesh had is removed.
+- The refinement is curvature-adaptive (PBI-314's deflection idea, but driven by 3D triangle
+  deviation, not a `(u,v)` step), so flat regions stay coarse.
+
+This keeps the watertight boundary + correct volume of `trimmedPatchMesh` and adds curvature in 3D,
+sidestepping the non-conformal `(u,v)` entirely.
+
+## Acceptance criteria
+
+- **EDF.STEP**: external freeform faces fold-free (committed fold detector → 0) AND total volume
+  within tolerance of OCC `getMass` (no inflation; the boundary-only baseline is 210k / OCC 207k).
+- A conformal dome patch refines (more triangles than boundary-only) AND a constructed strongly
+  curved imported-like face is fold-free, both with area within tolerance of a dense reference.
+- No boundary vertex moves (watertightness preserved); OCC oracle green; lint clean.
+- Live confirmation on EDF (shaded + Normal-Debug): the staircase is gone, surfaces read smooth.
+
+## Depends on
+
+`trimmedPatchMesh` (the watertight baseline), F01 (pcurve, for the boundary), PBI-315 (fold repair),
+the OCC oracle. Reuses the merged PBI-314 adaptive-density idea (re-targeted to 3D deviation).

--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/_feature.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/_feature.md
@@ -44,8 +44,15 @@ F01 (pcurves), `kernel/ops/{cdt,refined_patch,tessellate_trim}.go`, the OCC orac
 
 ## Backlog items
 
-| PBI | Title |
-|-----|-------|
-| [PBI-314](PBI-314-adaptive-trim-clipped-nodes.md) | Deflection-adaptive, strictly trim-clipped interior nodes |
-| [PBI-315](PBI-315-curvature-aware-no-fold.md) | Curvature-aware triangulation with fold detection + repair |
-| [PBI-316](PBI-316-wire-nurbs-face-mesher.md) | Wire the NURBS face mesher (oracle-gated) |
+| PBI | Title | Status |
+|-----|-------|--------|
+| [PBI-314](PBI-314-adaptive-trim-clipped-nodes.md) | Deflection-adaptive, strictly trim-clipped interior nodes | done (merged) |
+| [PBI-315](PBI-315-curvature-aware-no-fold.md) | Curvature-aware triangulation with fold detection + repair | done (merged) |
+| [PBI-316](PBI-316-wire-nurbs-face-mesher.md) | Wire the NURBS face mesher — **BLOCKED**: (u,v) interior is non-conformal on imported faces | superseded |
+| [PBI-321](PBI-321-3d-space-refinement.md) | 3D-space interior refinement (replaces the (u,v) grid) | planned |
+
+> **Finding (PBI-316):** the `(u,v)`-grid interior cannot refine imported NURBS — their
+> parameterization is non-conformal (interior `(u,v)` maps ~15% of the face off the trim →
+> +33% volume). F01 pcurve + PBI-314 density + PBI-315 fold-repair stay valid; only the interior
+> *sampling* moves from `(u,v)` to **3D space** (PBI-321). PBI-314/315 are merged but not yet
+> production-wired (their tests exercise them); PBI-321 wires the 3D-refined mesher.


### PR DESCRIPTION
Records the key finding from attempting PBI-316 (wiring the NURBS face mesher) and redirects F02.

**Finding:** the `(u,v)`-grid interior (F02) cannot refine imported NURBS faces. Measured on EDF.STEP: the marchUV pcurves are clean (0 self-intersections) but the interior `(u,v)` nodes' `PointAt` lands **~15% of the face size off the trim surface**, uniformly — the imported rational-NURBS **parameterization is non-conformal**, so a `(u,v)` inside the trim boundary doesn't map inside the trim in 3D → **+33% volume**. A deviation guard can't tell this from a legitimate bulge.

The wiring was reverted — **develop stays at the correct 210k baseline**; F01 (pcurves) + PBI-314 (adaptive density) + PBI-315 (fold repair) remain merged and tested.

**Redirect — PBI-321:** refine in **3D space**, not `(u,v)` — subdivide the watertight boundary-only mesh by inserting projected centroids of coarse interior triangles (centroid lies near the surface → projection reliable), never touching boundary edges (watertight) + fold repair. Only the interior *sampling* changes; F01/PBI-314/315 stay valid.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)