### PR TITLE
plan: M24 blocked by import quality — imported NURBS surfaces are unsamplable

### DIFF
--- a/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-321-3d-space-refinement.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/F02-trim-respecting-interior/PBI-321-3d-space-refinement.md
@@ -3,9 +3,24 @@ milestone: M24
 feature: F02
 pbi: PBI-321
 title: 3D-space interior refinement (replaces the (u,v) grid)
-status: planned
+status: blocked
 estimate: L
 ---
+
+> **BLOCKED (2026-06-08): the imported surfaces are unsamplable, not just non-conformal.**
+> Implemented 3D-space refinement — split bulging interior edges, projecting the chord MIDPOINT
+> onto the surface (`PointAt(ParamAt(mid))`). On EDF it was WORSE: 1369 folds, +33% volume. The
+> midpoints lie between trim points, yet `ParamAt(midpoint)` STILL lands far off — the imported
+> rational-NURBS surfaces are pathological (non-conformal AND `ParamAt` finds a distant closest
+> point), so **no interior sampling via the surface is reliable**. Even edge-flip repair on the
+> boundary-only mesh (no new samples) only goes 13→12 folds — the fold is inherent to a
+> boundary-only triangulation of a curved face and there are no trustworthy interior points to
+> flip with. **Only the edge curves (the boundary) are reliable; the surface interior is not.**
+> This is an **import-quality** blocker, not a mesher one. M24 cannot mesh these faces fold-free
+> from the available data. The real fix is **import healing** — reparameterize the imported NURBS
+> (or compute reliable pcurves) so the surface can be sampled — a separate effort upstream of the
+> mesher. F01 (pcurves) + PBI-314 (adaptive density) + PBI-315 (fold repair) stay merged + tested,
+> ready to use once the surface is reliable. Reverted to the boundary-only baseline (210k).
 
 # PBI-321 — 3D-space interior refinement (replaces the (u,v) grid)
 

--- a/implementation-plan/M24-tolerant-nurbs-meshing/_milestone.md
+++ b/implementation-plan/M24-tolerant-nurbs-meshing/_milestone.md
@@ -1,10 +1,23 @@
 ---
 milestone: M24
 name: Tolerant NURBS Surface Meshing (imported B-rep)
-status: planned
+status: blocked
 ---
 
 # M24 — Tolerant NURBS Surface Meshing (imported B-rep)
+
+> **STATUS — blocked by import quality (2026-06-08).** F01 (on-surface pcurves) + F02 PBI-314/315
+> (adaptive interior nodes + fold repair) are built, merged, and unit-tested. But wiring them
+> (PBI-316) and the 3D-space fallback (PBI-321) both proved the EDF's imported rational-NURBS faces
+> **cannot be meshed fold-free from the available data**: the parameterization is non-conformal AND
+> `Surface.ParamAt` of any interior point (a `(u,v)` grid node OR a 3D chord midpoint) lands ~15% of
+> the face size OFF the trim, so every interior sample over-encloses (+33% volume). Only the edge
+> curves are reliable; the surface interior is not. The chord-fold is then inherent to a
+> boundary-only triangulation and edge flips alone barely move it (13→12). **The real fix is
+> upstream: import healing** — reparameterize the imported NURBS / compute reliable pcurves so the
+> surface can be sampled (a separate milestone). develop stays at the correct boundary-only baseline
+> (~101.5% of OCC); the F01/PBI-314/315 blocks remain ready for when the surface is reliable. Full
+> evidence: PBI-316, PBI-321, and the `step-import-status` / `m24-tolerant-nurbs-mesher` memories.
 
 Mesh trimmed **freeform (B-spline/NURBS) faces** of imported B-reps so curved external
 surfaces render **smooth, fold-free, and volume-correct**. Today


### PR DESCRIPTION
Records the definitive M24 conclusion. Projecting interior chord midpoints onto the surface lands ~15% of the face off the trim (1369 folds, +33%) — same as the (u,v) grid: the imported rational-NURBS surfaces are pathological (non-conformal + ParamAt finds distant closest points), so **no interior sampling via the surface is reliable**. Edge-flip repair alone only moves folds 13→12. **Only the edge curves are reliable.** M24 can't mesh these faces fold-free from the available data — an **import-quality** blocker; the real fix is upstream import healing (reparameterize NURBS / compute pcurves). develop stays at the correct boundary-only baseline (~101.5% of OCC); F01 + PBI-314/315 remain merged + tested. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)