### PR TITLE
plan: M25 — Imported B-Rep Healing (pcurves, snapping, sewing) — unblocks M24

### DIFF
--- a/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-322-projection-api.md
+++ b/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-322-projection-api.md
@@ -1,0 +1,44 @@
+---
+milestone: M25
+feature: F01
+pbi: PBI-322
+title: Robust point/curve-to-surface projection API
+status: planned
+estimate: M
+---
+
+# PBI-322 — Robust point/curve-to-surface projection API
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F01 Robust projection & pcurve reconstruction
+
+## Goal
+
+Promote the verified surface projection into a first-class, reusable API the healing passes build on:
+a point inversion (closest `(u,v)`) and a curve-on-surface projection (a continuous pcurve).
+
+## Scope / work
+
+- `ProjectPointToSurface(s, p) (u, v, dist)`: multi-seed (coarse grid) + Newton/Gauss-Newton (the
+  verified `surfaceProjectStep`), returning the global-closest `(u,v)` and the residual distance.
+  Handle periodic domains (wrap) and report the residual so callers know the off-surface gap.
+- `ProjectCurveToSurface(s, pts) []Point2`: march along an ordered curve sampling, each point seeded
+  from the previous (`ParamNear`), giving a continuous, non-self-intersecting pcurve (generalises
+  `ops.marchUV` into `geom`/a shared package).
+- M24 already proved `ParamNear` ≈ brute-force; this PBI is API shape + periodicity, not new numerics.
+
+## API contracts (interfaces / enums / collections)
+
+- `ProjectPointToSurface`, `ProjectCurveToSurface` (kernel geometry API).
+
+## Acceptance criteria
+
+- On constructed surfaces (plane, cylinder, sphere, a curved B-spline), point inversion round-trips
+  on-surface points to tolerance and returns the residual for off-surface points; matches a
+  brute-force dense-grid closest point within tolerance.
+- A periodic (cylinder/sphere-longitude) projection returns `(u,v)` in domain without seam jumps.
+- `ProjectCurveToSurface` of a sampled edge is continuous (no `(u,v)` jumps) and non-self-intersecting.
+- Unit-tested; lint clean.
+
+## Depends on
+
+M24 `ParamNear`/`surfaceProjectStep` (verified), `kernel/geom`.

--- a/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-323-pcurve-reconstruction.md
+++ b/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-323-pcurve-reconstruction.md
@@ -1,0 +1,44 @@
+---
+milestone: M25
+feature: F01
+pbi: PBI-323
+title: Reconstruct + attach per-edge pcurves bounding each trim
+status: planned
+estimate: L
+---
+
+# PBI-323 — Reconstruct + attach per-edge pcurves bounding each trim
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F01 Robust projection & pcurve reconstruction
+
+## Goal
+
+Give every imported edge an accurate pcurve on each adjacent face, attached to the topology, so the
+trim region is exact in `(u,v)` — the data SolidWorks omits and the mesher needs.
+
+## Scope / work
+
+- For each face, project its boundary edges onto its surface (`ProjectCurveToSurface`) to build the
+  outer + hole pcurve loops; pick the `(u,v)` sheet (for periodic/seam surfaces) whose enclosed
+  region is the actual trim (e.g. by testing an interior sample's on-surface residual).
+- Attach the pcurve to the topology per edge-use (a `CoEdge.Pcurve` on the face), so
+  `kernel/ops` tessellation reads the exact `(u,v)` instead of re-deriving it.
+- Validate each reconstructed pcurve: continuous, non-self-intersecting, and its interior `(u,v)`
+  samples have small on-surface residual AND lie within the face's 3D bounds (the trim, not a
+  folded elsewhere region).
+
+## API contracts (interfaces / enums / collections)
+
+- `topo` `CoEdge`/`EdgeUse` pcurve field + accessor; pcurve population in the STEP import/heal path.
+
+## Acceptance criteria
+
+- EDF.STEP: every freeform face gets outer + hole pcurves; an interior `(u,v)` sample inside the
+  outer pcurve (outside holes) has on-surface residual within tolerance AND maps within the face's
+  3D bbox — i.e. the pcurve interior IS the trim (the M24 over-enclosure root, now fixed by data).
+- A committed check: the reconstructed pcurve round-trips the boundary points (`PointAt` ≈ edge).
+- OCC oracle green (pcurve attachment does not change existing tessellation that already worked).
+
+## Depends on
+
+PBI-322 (projection), `kernel/topo`, the STEP import path.

--- a/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/_feature.md
+++ b/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/_feature.md
@@ -1,0 +1,43 @@
+---
+milestone: M25
+feature: F01
+name: Robust projection & pcurve reconstruction
+status: planned
+---
+
+# M25 · F01 — Robust projection & pcurve reconstruction
+
+The core of healing: give every imported edge an accurate **pcurve** (its `(u,v)` curve on each
+adjacent face's surface), so the trim region is known exactly in parameter space. Built on a
+formalised surface point-inversion projector — M24 verified the existing `ParamNear` is sound
+(matches brute-force closest-point), so this is about *using* it to reconstruct pcurves, with the
+seam / periodicity / correct-sheet handling that makes the pcurve interior stay on the trim.
+
+## In scope
+
+- A formal `ProjectPointToSurface` (multi-seed + branch/periodicity-aware) over the verified
+  `ParamNear`, and a `ProjectCurveToSurface` that marches an edge curve onto a surface (the
+  `ops.marchUV` technique), producing a continuous, non-self-intersecting pcurve.
+- **Pcurve reconstruction**: for each edge, build its pcurve on each adjacent face and attach it to
+  the topology (an `EdgeUse`/`CoEdge` pcurve), so tessellation/operations consume the exact `(u,v)`.
+- Seam/periodic handling so the pcurve picks the `(u,v)` sheet whose interior is the actual trim.
+
+## Out of scope
+
+- Snapping the 3D edge onto the surface (F02) — F01 computes the pcurve; F02 moves the geometry.
+- Sewing (F03), orientation (F04).
+
+## Key API contracts delivered
+
+- `geom`/`kernel` `ProjectPointToSurface`, `ProjectCurveToSurface`; pcurve storage on the topology.
+
+## Depends on
+
+M24 `ParamNear` (verified projector) + `ops.marchUV`; `kernel/topo` (edge/face/coedge).
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-322](PBI-322-projection-api.md) | Robust point/curve-to-surface projection API |
+| [PBI-323](PBI-323-pcurve-reconstruction.md) | Reconstruct + attach per-edge pcurves bounding each trim |

--- a/implementation-plan/M25-import-brep-healing/F02-edge-surface-snapping/PBI-324-edge-onto-surface.md
+++ b/implementation-plan/M25-import-brep-healing/F02-edge-surface-snapping/PBI-324-edge-onto-surface.md
@@ -1,0 +1,41 @@
+---
+milestone: M25
+feature: F02
+pbi: PBI-324
+title: Snap edge curves onto their faces' surfaces within tolerance
+status: planned
+estimate: M
+---
+
+# PBI-324 — Snap edge curves onto their faces' surfaces within tolerance
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F02 Edge/surface tolerance snapping
+
+## Goal
+
+Make each edge's discretized boundary lie on its adjacent surfaces (within tolerance) so the two
+faces of an edge mesh the same points — removing the ~1.9 mm off-surface gap.
+
+## Scope / work
+
+- For each edge shared by faces A and B, derive its boundary samples from the pcurves
+  (`A.PointAt(pcurveA)`, `B.PointAt(pcurveB)`) and reconcile to a single shared polyline (e.g. the
+  average, or A's, recording the max deviation as the edge tolerance). Use that one polyline for
+  both faces' tessellation boundary.
+- Record the residual (the import gap) as the edge's tolerance; surface it for validation.
+- Leave well-formed edges (already on-surface, tiny residual) untouched.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) shared edge polyline + per-edge tolerance in the heal path.
+
+## Acceptance criteria
+
+- EDF.STEP: after snapping, an edge's polyline lies on BOTH adjacent surfaces within the recorded
+  tolerance (committed check); the two faces use identical boundary points.
+- A clean OCC fixture (edges already on surfaces) is unchanged (residual ~0, no movement).
+- OCC oracle green.
+
+## Depends on
+
+PBI-323 (pcurves).

--- a/implementation-plan/M25-import-brep-healing/F02-edge-surface-snapping/PBI-325-vertex-edge-merge.md
+++ b/implementation-plan/M25-import-brep-healing/F02-edge-surface-snapping/PBI-325-vertex-edge-merge.md
@@ -1,0 +1,37 @@
+---
+milestone: M25
+feature: F02
+pbi: PBI-325
+title: Merge near-coincident vertices + degenerate edges
+status: planned
+estimate: S
+---
+
+# PBI-325 — Merge near-coincident vertices + degenerate edges
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F02 Edge/surface tolerance snapping
+
+## Goal
+
+Collapse near-coincident vertices and drop degenerate/zero-length edges within the model tolerance,
+so the topology is clean before sewing.
+
+## Scope / work
+
+- Merge vertices within tolerance (a spatial weld), rewiring incident edges.
+- Drop zero-length / degenerate edges (sphere-pole / sliver artifacts) and fix the loops that used them.
+- Tolerance-driven; idempotent.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) vertex weld + degenerate-edge cleanup in the heal path.
+
+## Acceptance criteria
+
+- A model with duplicated near-coincident vertices welds to the expected unique count; loops stay valid.
+- Degenerate edges removed without breaking face loops.
+- Clean fixtures unchanged; OCC oracle green; lint clean.
+
+## Depends on
+
+PBI-324; `kernel/topo`.

--- a/implementation-plan/M25-import-brep-healing/F02-edge-surface-snapping/_feature.md
+++ b/implementation-plan/M25-import-brep-healing/F02-edge-surface-snapping/_feature.md
@@ -1,0 +1,40 @@
+---
+milestone: M25
+feature: F02
+name: Edge/surface tolerance snapping
+status: planned
+---
+
+# M25 · F02 — Edge/surface tolerance snapping
+
+Close the ~mm gap between imported edge curves and their faces' surfaces, and merge near-coincident
+vertices/edges, so faces genuinely share their boundaries. With F01's pcurves, an edge's "true"
+position on a surface is `PointAt(pcurve)`; F02 reconciles the (possibly differing) representations
+across the two faces of an edge into one shared curve within the model tolerance.
+
+## In scope
+
+- Snap each edge's 3D curve onto a representative that lies on both adjacent surfaces within
+  tolerance (or record the residual as the edge tolerance, OCCT-style), so the boundary the two
+  faces mesh is the same.
+- Merge near-coincident vertices and degenerate/duplicate edges within the model tolerance.
+
+## Out of scope
+
+- Sewing the faces into shells (F03 — F02 reconciles geometry; F03 builds the shared topology).
+- Pcurve computation (F01).
+
+## Key API contracts delivered
+
+- (internal) edge/vertex snapping + merge in the heal path; per-edge tolerance.
+
+## Depends on
+
+F01 (pcurves), `kernel/topo`, the model tolerance from M02/M07.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-324](PBI-324-edge-onto-surface.md) | Snap edge curves onto their faces' surfaces within tolerance |
+| [PBI-325](PBI-325-vertex-edge-merge.md) | Merge near-coincident vertices + degenerate edges |

--- a/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-326-edge-matching.md
+++ b/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-326-edge-matching.md
@@ -1,0 +1,40 @@
+---
+milestone: M25
+feature: F03
+pbi: PBI-326
+title: Match + merge shared edges across faces by proximity
+status: planned
+estimate: L
+---
+
+# PBI-326 — Match + merge shared edges across faces by proximity
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F03 Face sewing into watertight shells
+
+## Goal
+
+Find pairs of face-boundary edges that are the same physical edge (coincident within tolerance) and
+merge them into one shared edge with a coedge per face.
+
+## Scope / work
+
+- Index boundary edges spatially (by endpoint positions + midpoint); pair edges whose endpoints +
+  curve coincide within the edge tolerance (handle reversed orientation).
+- Merge each matched pair into a single `Edge` referenced by two `CoEdge`s (the two faces), using
+  the F02 shared polyline; keep each face's own pcurve.
+- Leave unmatched edges as free/open boundary.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) edge-match index + merge; shared `Edge` with two coedges.
+
+## Acceptance criteria
+
+- EDF.STEP: the expected number of edges are matched + merged (each interior edge shared by exactly
+  two faces); a synthetic two-face patch sews into one shared edge.
+- Reversed-orientation edge pairs match correctly.
+- No false merges across a genuine open boundary; OCC oracle green; lint clean.
+
+## Depends on
+
+PBI-324/325 (snapped, clean edges), `kernel/topo`.

--- a/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-327-shell-assembly.md
+++ b/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-327-shell-assembly.md
@@ -1,0 +1,39 @@
+---
+milestone: M25
+feature: F03
+pbi: PBI-327
+title: Assemble faces into shells; report free edges
+status: planned
+estimate: M
+---
+
+# PBI-327 — Assemble faces into shells; report free edges
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F03 Face sewing into watertight shells
+
+## Goal
+
+Group connected (now edge-sharing) faces into shells and report any remaining free edges, so the
+healed body is a coherent shell (closed where it should be).
+
+## Scope / work
+
+- Connected-component the faces over the shared-edge adjacency into shells.
+- Classify each shell closed (every edge shared by 2 faces) or open (has free edges); report free
+  edges + their count for validation.
+- Attach shells to the body in place of the loose face set.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) shell assembly; free-edge report.
+
+## Acceptance criteria
+
+- EDF.STEP: its solids assemble into closed shells with **0 free edges** (a watertight body), or the
+  free edges are reported (genuine openings).
+- A synthetic open surface stays open (free edges reported, not falsely closed).
+- OCC oracle green; lint clean.
+
+## Depends on
+
+PBI-326 (shared edges).

--- a/implementation-plan/M25-import-brep-healing/F03-face-sewing/_feature.md
+++ b/implementation-plan/M25-import-brep-healing/F03-face-sewing/_feature.md
@@ -1,0 +1,38 @@
+---
+milestone: M25
+feature: F03
+name: Face sewing into watertight shells
+status: planned
+---
+
+# M25 · F03 — Face sewing into watertight shells
+
+Build the shared-edge topology the raw STEP import lacks: identify which faces share an edge (by 3D
+proximity within tolerance) and stitch them into shells, so each interior edge is referenced by
+exactly its two faces and meshing/operations see a coherent watertight body — not a loose bag of faces.
+
+## In scope
+
+- Match boundary edges across faces by 3D proximity (within the F02 edge tolerance) and merge them
+  into single shared edges with two coedges (one per face).
+- Assemble connected faces into shells; report unshared (genuinely open / free) edges.
+
+## Out of scope
+
+- Orientation + validation (F04).
+- Self-intersection repair (out of milestone scope).
+
+## Key API contracts delivered
+
+- (internal) edge-matching + shell assembly in the heal path; shared-edge adjacency.
+
+## Depends on
+
+F02 (snapped edges + tolerance), `kernel/topo` (shell/edge/coedge).
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-326](PBI-326-edge-matching.md) | Match + merge shared edges across faces by proximity |
+| [PBI-327](PBI-327-shell-assembly.md) | Assemble faces into shells; report free edges |

--- a/implementation-plan/M25-import-brep-healing/F04-orientation-validation/PBI-328-orientation-validation.md
+++ b/implementation-plan/M25-import-brep-healing/F04-orientation-validation/PBI-328-orientation-validation.md
@@ -1,0 +1,38 @@
+---
+milestone: M25
+feature: F04
+pbi: PBI-328
+title: Coherent shell orientation + manifold/closed validation
+status: planned
+estimate: M
+---
+
+# PBI-328 — Coherent shell orientation + manifold/closed validation
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F04 Orientation, validation & oracle gate
+
+## Goal
+
+Make every healed shell consistently outward-oriented and validate it, so downstream consumers
+(mesher, mass-props, boolean) get a coherent body.
+
+## Scope / work
+
+- Propagate a consistent orientation over the shell via shared-edge use directions (each interior
+  edge traversed oppositely by its two coedges); flip faces to make it coherent.
+- Flip the whole shell if its signed volume is negative (outward = positive).
+- Validate: 2-manifold (each edge ≤ 2 faces), closed where expected; emit a healing report.
+
+## API contracts (interfaces / enums / collections)
+
+- (internal) shell orientation + manifold/closed validation + report.
+
+## Acceptance criteria
+
+- EDF.STEP shells are coherently outward (signed volume positive, matching OCC sign) and 2-manifold.
+- A deliberately mis-oriented synthetic shell is corrected.
+- OCC oracle green; lint clean.
+
+## Depends on
+
+PBI-327 (shells).

--- a/implementation-plan/M25-import-brep-healing/F04-orientation-validation/PBI-329-heal-oracle-edf.md
+++ b/implementation-plan/M25-import-brep-healing/F04-orientation-validation/PBI-329-heal-oracle-edf.md
@@ -1,0 +1,36 @@
+---
+milestone: M25
+feature: F04
+pbi: PBI-329
+title: Healing oracle + EDF end-to-end regression through M24
+status: planned
+estimate: M
+---
+
+# PBI-329 — Healing oracle + EDF end-to-end regression through M24
+
+**Milestone:** M25 Imported B-Rep Healing  ·  **Feature:** F04 Orientation, validation & oracle gate
+
+## Goal
+
+Lock the milestone: prove healing is safe on good input and that healed EDF meshes fold-free +
+volume-correct through the (already-built) M24 mesher — the M24 exit criterion, now reachable.
+
+## Scope / work
+
+- Wire healing into the STEP import path (heal-after-import), behind the model tolerance.
+- Extend the OCC oracle: healing a clean fixture is a **no-op** (volume + face count unchanged).
+- Enable the M24 NURBS mesher on the healed geometry; assert EDF freeform faces are fold-free
+  (committed fold detector → 0) and total volume within tolerance of OCC `getMass`.
+- Final live confirmation (shaded + Normal-Debug, Save-Viewport-PNG): the EDF staircase is gone.
+
+## Acceptance criteria
+
+- Healing a clean OCC fixture changes neither volume nor face count.
+- Healed EDF.STEP: 0 fold-edges on freeform faces; total volume within tolerance of OCC (no
+  inflation) — closing M24's exit criterion.
+- OCC oracle green; lint clean; live staircase gone.
+
+## Depends on
+
+F01–F03, PBI-328, the M24 mesher (F01 + PBI-314/315), the OCC oracle.

--- a/implementation-plan/M25-import-brep-healing/F04-orientation-validation/_feature.md
+++ b/implementation-plan/M25-import-brep-healing/F04-orientation-validation/_feature.md
@@ -1,0 +1,38 @@
+---
+milestone: M25
+feature: F04
+name: Orientation, validation & oracle gate
+status: planned
+---
+
+# M25 · F04 — Orientation, validation & oracle gate
+
+Finish the heal: orient each shell coherently outward, validate it (manifold/closed), and lock the
+whole milestone with the OpenCASCADE volume oracle + an EDF end-to-end regression that runs the
+healed geometry through the M24 mesher and checks it is fold-free and volume-correct.
+
+## In scope
+
+- Coherent shell orientation (every face outward) via shared-edge use directions + a global
+  volume-sign flip; report non-orientable / non-manifold input.
+- A validation pass (manifold, closed-where-expected) + a healing report (what changed).
+- Oracle gate: healing a clean fixture is a no-op; healed EDF → M24 mesher → fold-free + volume OK.
+
+## Out of scope
+
+- The mesher (M24).
+
+## Key API contracts delivered
+
+- (internal) shell orientation + validation; healing report; oracle/regression tests.
+
+## Depends on
+
+F01–F03; M24 mesher; the OCC oracle.
+
+## Backlog items
+
+| PBI | Title |
+|-----|-------|
+| [PBI-328](PBI-328-orientation-validation.md) | Coherent shell orientation + manifold/closed validation |
+| [PBI-329](PBI-329-heal-oracle-edf.md) | Healing oracle + EDF end-to-end regression through M24 |

--- a/implementation-plan/M25-import-brep-healing/_milestone.md
+++ b/implementation-plan/M25-import-brep-healing/_milestone.md
@@ -1,0 +1,94 @@
+---
+milestone: M25
+name: Imported B-Rep Healing (pcurves, snapping, sewing)
+status: planned
+---
+
+# M25 — Imported B-Rep Healing (pcurves, snapping, sewing)
+
+Heal imported B-reps so their geometry is **self-consistent and meshable/operable** — the missing
+foundation that blocks [M24](../M24-tolerant-nurbs-meshing/_milestone.md) (tolerant NURBS meshing).
+This is the equivalent of OpenCASCADE's **`ShapeHealing` / `ShapeFix`** (reference checkout at
+[`OCCT/src/ModelingData/TKShHealing`](../../../OCCT/src) and `ModelingAlgorithms`): the pass every
+robust kernel runs on imported STEP/IGES before meshing or modelling.
+
+## Why (the M24 finding)
+
+EDF.STEP (SolidWorks export) imports with two structural defects that no mesher can paper over,
+proven during M24 (see the `m24-tolerant-nurbs-mesher` / `step-import-status` memories):
+
+1. **No pcurves.** SolidWorks writes `0 SURFACE_CURVE` — edges carry only 3D curves, not their 2D
+   `(u,v)` curve on each face's surface. So the mesher cannot know a face's trim region in `(u,v)`;
+   it must guess it by projection, and the guess's interior over-encloses (+33% volume on EDF).
+2. **Edges lie ~1.9 mm off their surfaces.** A STEP authoring tolerance: an edge's 3D curve does
+   not lie exactly on the adjacent faces' surfaces. So the faces are not truly shared along edges,
+   and the surface is **self-proximal** — a point inside a trim is closest to a *different* part of
+   the same surface, so closest-point projection (verified sound against brute-force in M24) lands
+   on the wrong part. No projector fixes this; the geometry itself must be healed.
+
+OCCT meshes these models because `ShapeFix` **rebuilds the pcurves** (exactly bounding each trim in
+`(u,v)`) and **snaps edges onto their surfaces** within tolerance, *then* sews and orients — so by
+the time `BRepMesh` runs, the `(u,v)` regions are exact and `PointAt` over them is single-valued.
+M25 builds that pass; M24's mesher (F01 pcurves + PBI-314/315, already merged + tested) then works.
+
+## Goals
+
+- Every imported face has **accurate pcurves** for its edges — the trim's `(u,v)` boundary, exact
+  enough that sampling its interior stays on the trim (no over-enclosure).
+- Edge 3D curves lie **on** their faces' surfaces within a controlled tolerance (the ~mm gap closed).
+- Faces are **sewn** into watertight shells along genuinely-shared edges (the shared-edge topology
+  the raw import lacks).
+- Shells are **coherently oriented** (outward) and **validated** (manifold/closed) — or the defect
+  is reported, never silently shipped.
+- Healing is **measured** against the OpenCASCADE volume oracle and gated so it never degrades a
+  model that was already fine.
+
+## In scope
+
+- A robust **surface point-inversion** API (formalising M24's verified `ParamNear`: multi-seed +
+  branch/periodicity handling) and a **curve-on-surface projection** built on it.
+- **Pcurve reconstruction** (`BRepLib::BuildCurves3d` analogue): march-project each edge onto each
+  adjacent surface, handling seams, periodicity, and the correct `(u,v)` sheet, and attach the
+  resulting pcurve to the topology so the mesher consumes it.
+- **Edge/vertex tolerance snapping**: pull edge curves onto their surfaces and merge
+  near-coincident vertices/edges within the model tolerance.
+- **Face sewing**: identify shared edges by 3D proximity and stitch faces into shells, recording the
+  shared-edge adjacency (so two faces of an edge mesh the SAME polyline).
+- **Orientation + validation**: coherent outward shell orientation and a manifold/closed check, with
+  a healing report.
+- Oracle gating + an EDF end-to-end regression: healed EDF → M24 mesher → fold-free + volume-correct.
+
+## Out of scope
+
+- The **mesher** itself (M24 — it consumes the healed geometry).
+- **Self-intersection / overlap removal** of grossly invalid solids (a deeper repair; M25 targets
+  tolerance-level defects: missing pcurves, off-surface edges, unshared edges).
+- Reading STEP-supplied pcurves when present (an optimisation; the driving case has none, so M25
+  reconstructs them).
+
+## Exit criteria
+
+- Healed EDF.STEP: every face has pcurves whose interior `(u,v)`, sampled, stays on the trim (a
+  point-on-trim check), edges lie on their surfaces within tolerance, and the body is a watertight
+  oriented shell — verified by committed tests.
+- With healing on, the **M24 mesher** produces the EDF freeform faces **fold-free** and the total
+  volume within tolerance of OpenCASCADE `getMass` (the M24 exit criterion, now reachable).
+- Healing a synthetic clean OCC fixture is a **no-op** (volume + face count unchanged) — never
+  degrades good input.
+- OCC oracle green; lint clean; live confirmation (shaded + Normal-Debug) that the EDF staircase is gone.
+
+## Depends on
+
+M07 (B-rep topology, `kernel/topo`), M17 (STEP import, `kernel/exchange/step`), M24's verified
+projector (`geom.BSplineSurface.ParamNear`) + pcurve marching (`ops.marchUV`) + mesher blocks. A new
+**ADR-0031 (imported B-rep healing)** records the heal-before-mesh pipeline and tolerance model.
+Reference: OpenCASCADE `ShapeHealing` (`OCCT/src`).
+
+## Features
+
+| ID | Feature | PBIs | Summary |
+|----|---------|:----:|---------|
+| **F01** | [Robust projection & pcurve reconstruction](F01-pcurves-projection/_feature.md) | 2 | Formalise the verified point-inversion projector; reconstruct + attach per-edge pcurves that exactly bound each trim in `(u,v)`. |
+| **F02** | [Edge/surface tolerance snapping](F02-edge-surface-snapping/_feature.md) | 2 | Pull edge curves onto their surfaces within tolerance; merge near-coincident vertices/edges. |
+| **F03** | [Face sewing into watertight shells](F03-face-sewing/_feature.md) | 2 | Identify shared edges by proximity and stitch faces into shells with shared-edge adjacency. |
+| **F04** | [Orientation, validation & oracle gate](F04-orientation-validation/_feature.md) | 2 | Coherent outward orientation + manifold/closed validation; healing oracle + EDF end-to-end regression through the M24 mesher. |

--- a/implementation-plan/README.md
+++ b/implementation-plan/README.md
@@ -45,6 +45,7 @@ rules (units, identity, transactions, events) that apply to every milestone.
 | **M22** | [Sketch3D Feature Completion (3D Parity)](M22-sketch3d-feature-completion/_milestone.md) | 12 | 18 | M06, M07, M08 |
 | **M23** | [Renderer Display-Mode Parity & Realistic PBR](M23-renderer-display-modes/_milestone.md) | 4 | 12 | M07, M16, M19 |
 | **M24** | [Tolerant NURBS Surface Meshing (imported B-rep)](M24-tolerant-nurbs-meshing/_milestone.md) | 4 | 9 | M07, M17 |
+| **M25** | [Imported B-Rep Healing (pcurves, snapping, sewing)](M25-import-brep-healing/_milestone.md) | 4 | 8 | M07, M17, M24 |
 
 ¹ M19 (Materials & Appearances) shipped real code (`model/material`, `app/materials*`,
 head Materials/Appearance windows) ahead of its plan files; its 7 feature/PBI files were
@@ -86,9 +87,9 @@ generation for each modeling capability are delivered incrementally alongside M0
 _(Reconciled against the filesystem on 2026-06-04 — see audit REPORT.md. Counts are
 `_feature.md` / `PBI-*.md` file counts.)_
 
-- Milestones: **25** (M00–M24)
-- Features: **139** (incl. M19's 7 backfilled feature files — note ¹ above)
-- PBIs: **271** (incl. M19's 7 backfilled PBIs)
+- Milestones: **26** (M00–M25)
+- Features: **143** (incl. M19's 7 backfilled feature files — note ¹ above)
+- PBIs: **279** (incl. M19's 7 backfilled PBIs)
 
 > Note: these are *planned* counts (files that exist), not *done* counts. For actual
 > completion status — graded on the three axes Model / Geometry / UI+e2e


### PR DESCRIPTION
Scopes the foundation M24 turned out to need. M24 proved (brute-force) that the projector is **sound** and the blocker is the imported **geometry**: SolidWorks STEP has **no pcurves** and edges lie **~1.9mm off their surfaces**, making the surfaces **self-proximal** (a point inside a trim is closest to a different folded part). OCCT meshes these models because ** heals the import first**; M25 builds that pass.

**4 features, 8 PBIs (322–329):**
- **F01** robust point/curve→surface projection (formalising the verified `ParamNear`) + **pcurve reconstruction** (exact trim `(u,v)`, attached to topology) — the core unblocker.
- **F02** edge↔surface tolerance **snapping** + vertex/edge merge (close the ~1.9mm gap).
- **F03** **face sewing** into watertight shells (the shared-edge topology the raw import lacks).
- **F04** coherent **orientation** + manifold/closed **validation** + **oracle gate** (healing a clean fixture is a no-op; healed EDF → M24 mesher → fold-free + volume-correct, closing M24's exit criterion).

Reference: OpenCASCADE `ShapeHealing` (`OCCT/src`); new ADR-0031. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)