### PR TITLE
M25 F01: projection API + pcurve reconstruction (PBI-322/323)

### DIFF
--- a/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-322-projection-api.md
+++ b/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-322-projection-api.md
@@ -3,7 +3,7 @@ milestone: M25
 feature: F01
 pbi: PBI-322
 title: Robust point/curve-to-surface projection API
-status: planned
+status: done
 estimate: M
 ---
 

--- a/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-323-pcurve-reconstruction.md
+++ b/implementation-plan/M25-import-brep-healing/F01-pcurves-projection/PBI-323-pcurve-reconstruction.md
@@ -3,7 +3,7 @@ milestone: M25
 feature: F01
 pbi: PBI-323
 title: Reconstruct + attach per-edge pcurves bounding each trim
-status: planned
+status: done
 estimate: L
 ---
 

--- a/kernel/geom/projection.go
+++ b/kernel/geom/projection.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "oblikovati/math"
+
+// ProjectPointToSurface returns the parameters (u, v) of the point on s closest to p, plus the
+// residual distance |s.PointAt(u,v) − p|. It builds on each surface's ParamAt — closed-form for the
+// analytic surfaces, a grid-seeded Gauss–Newton inversion for NURBS (verified against a brute-force
+// dense-grid closest point: M24 measured them equal to ~2 decimals). The residual is what import
+// healing needs: it is the gap between an imported edge and the face's surface (the ~mm STEP
+// authoring tolerance, M25), so callers can decide whether the edge must be snapped on.
+//
+// Example: u, v, gap := ProjectPointToSurface(face.Geometry(), edgePoint).
+func ProjectPointToSurface(s Surface, p math.Point3) (u, v, dist float64) {
+	u, v = s.ParamAt(p)
+	return u, v, float64(s.PointAt(u, v).DistanceTo(p))
+}
+
+// ProjectCurveToSurface projects an ordered 3D polyline (an edge's discretization) onto s, returning
+// its parameter-space curve — its PCURVE. It MARCHES: the first point is projected from scratch, then
+// each subsequent point is seeded from the previous point's (u, v). Seeding keeps the pcurve on one
+// smooth branch, so it does not self-intersect where independent per-point projection jitters near a
+// near-fold (adjacent points snapping to different local minima — the imported-NURBS reality,
+// ADR-0030). Analytic surfaces invert exactly and stably, so seeding is a no-op for them; it matters
+// only for NURBS, where it is the prerequisite for a valid trim region in (u, v) (M25 F01).
+//
+// Example: pcurve := ProjectCurveToSurface(face.Geometry(), edgePolyline).
+func ProjectCurveToSurface(s Surface, pts []math.Point3) []math.Point2 {
+	out := make([]math.Point2, len(pts))
+	if len(pts) == 0 {
+		return out
+	}
+	u, v, _ := ProjectPointToSurface(s, pts[0])
+	out[0] = math.P2(math.Scalar(u), math.Scalar(v))
+	for i := 1; i < len(pts); i++ {
+		u, v = seededParam(s, pts[i], u, v)
+		out[i] = math.P2(math.Scalar(u), math.Scalar(v))
+	}
+	return out
+}
+
+// seededParam projects q onto s starting from the seed (u0, v0). For a NURBS surface this is the
+// seeded Gauss–Newton march (BSplineSurface.ParamNear) that stays on one branch; the analytic
+// surfaces invert exactly from any seed, so they delegate to their closed-form ParamAt.
+func seededParam(s Surface, q math.Point3, u0, v0 float64) (u, v float64) {
+	if bs, ok := s.(BSplineSurface); ok {
+		return bs.ParamNear(q, u0, v0)
+	}
+	return s.ParamAt(q)
+}

--- a/kernel/geom/projection_test.go
+++ b/kernel/geom/projection_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati/math"
+)
+
+func TestProjectPointToSurfaceOnSurface(t *testing.T) {
+	s := cProfileSurface(t)
+	for _, uv := range [][2]float64{{0.5, 0.5}, {0.25, 0.7}, {0.8, 0.15}} {
+		want := s.PointAt(uv[0], uv[1])
+		u, v, dist := ProjectPointToSurface(s, want)
+		if dist > 1e-4 {
+			t.Errorf("on-surface point at %v: residual %.6f, want ~0", uv, dist)
+		}
+		if got := s.PointAt(u, v); float64(got.DistanceTo(want)) > 1e-4 {
+			t.Errorf("on-surface point at %v: PointAt(%g,%g)=%v want %v", uv, u, v, got, want)
+		}
+	}
+}
+
+func TestProjectPointToSurfaceResidualIsOffSurfaceGap(t *testing.T) {
+	s := cProfileSurface(t)
+	// Offset a surface point along the normal by a known gap (the M25 edge-off-surface case).
+	u0, v0 := 0.5, 0.5
+	base := s.PointAt(u0, v0)
+	n := s.NormalAt(u0, v0)
+	const gap = 0.1
+	off := base.TranslateBy(n.Scale(gap))
+	_, _, dist := ProjectPointToSurface(s, off)
+	if stdmath.Abs(dist-gap) > 1e-3 {
+		t.Errorf("residual for a point %.3f off the surface = %.4f, want ~%.3f", gap, dist, gap)
+	}
+}
+
+func TestProjectCurveToSurfaceIsContinuousPcurve(t *testing.T) {
+	s := cProfileSurface(t)
+	// A polyline of on-surface points along v=0.5, increasing u: its pcurve must round-trip and stay
+	// continuous + monotone in u (no branch jump).
+	var pts []math.Point3
+	const n = 12
+	for i := 0; i <= n; i++ {
+		u := 0.1 + 0.8*float64(i)/n
+		pts = append(pts, s.PointAt(u, 0.5))
+	}
+	pc := ProjectCurveToSurface(s, pts)
+	if len(pc) != len(pts) {
+		t.Fatalf("pcurve length %d, want %d", len(pc), len(pts))
+	}
+	for i := range pts {
+		if got := s.PointAt(float64(pc[i].X), float64(pc[i].Y)); float64(got.DistanceTo(pts[i])) > 1e-3 {
+			t.Errorf("pcurve[%d] does not round-trip: PointAt=%v want %v", i, got, pts[i])
+		}
+		if i > 0 && float64(pc[i].X) <= float64(pc[i-1].X) {
+			t.Errorf("pcurve u not monotone at %d: %g then %g (branch jump)", i, pc[i-1].X, pc[i].X)
+		}
+	}
+}
+
+func TestProjectCurveToSurfaceEmpty(t *testing.T) {
+	if got := ProjectCurveToSurface(cProfileSurface(t), nil); len(got) != 0 {
+		t.Errorf("empty input gave %d points", len(got))
+	}
+}

--- a/kernel/ops/pcurve_reconstruct.go
+++ b/kernel/ops/pcurve_reconstruct.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati/kernel/geom"
+	"oblikovati/kernel/topo"
+)
+
+// ReconstructFacePcurves computes and attaches the PCURVE to every edge-use of f: each edge is
+// discretized into the SAME chord polyline the mesher uses (discretizeEdge, so the pcurve aligns
+// with the mesh boundary exactly), oriented to the use, then projected onto f's surface
+// (geom.ProjectCurveToSurface — a seeded march that stays on one branch). This is the parameter-space
+// trim boundary SolidWorks STEP omits; with it the face's trim region is known exactly in (u,v),
+// which the tolerant NURBS mesher requires (M25 F01, ADR-0031). Idempotent: re-running recomputes.
+func ReconstructFacePcurves(f *topo.Face, q Quality) {
+	s := f.Geometry()
+	for _, l := range f.Loops() {
+		for _, u := range l.EdgeUses() {
+			pts := discretizeEdge(u.Edge(), q)
+			if u.Reversed() {
+				pts = reverse3(pts)
+			}
+			u.SetPcurve(geom.ProjectCurveToSurface(s, pts))
+		}
+	}
+}
+
+// ReconstructPcurves attaches pcurves to every face of a body (the import-healing entry point).
+func ReconstructPcurves(b *topo.Body, q Quality) {
+	for _, f := range b.Faces() {
+		ReconstructFacePcurves(f, q)
+	}
+}

--- a/kernel/ops/pcurve_reconstruct_test.go
+++ b/kernel/ops/pcurve_reconstruct_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+)
+
+func TestReconstructFacePcurvesRoundTrips(t *testing.T) {
+	f := halfDiskFace(t, 2)
+	q := Quality{ChordTolerance: 1e-3}
+	ReconstructFacePcurves(f, q)
+	s := f.Geometry()
+	for _, l := range f.Loops() {
+		for _, u := range l.EdgeUses() {
+			pc := u.Pcurve()
+			pts := discretizeEdge(u.Edge(), q)
+			if u.Reversed() {
+				pts = reverse3(pts)
+			}
+			if len(pc) != len(pts) {
+				t.Fatalf("pcurve has %d points, edge discretization has %d", len(pc), len(pts))
+			}
+			for i := range pc {
+				got := s.PointAt(float64(pc[i].X), float64(pc[i].Y))
+				if d := float64(got.DistanceTo(pts[i])); d > 1e-3 {
+					t.Errorf("pcurve[%d] does not round-trip its edge point (off %.5f)", i, d)
+				}
+			}
+		}
+	}
+}
+
+// The arc edge must yield a multi-point pcurve (the curved boundary captured in (u,v)), not a chord.
+func TestReconstructFacePcurvesCapturesCurvedEdge(t *testing.T) {
+	f := halfDiskFace(t, 2)
+	ReconstructFacePcurves(f, Quality{ChordTolerance: 1e-3})
+	maxPts := 0
+	for _, l := range f.Loops() {
+		for _, u := range l.EdgeUses() {
+			if n := len(u.Pcurve()); n > maxPts {
+				maxPts = n
+			}
+		}
+	}
+	if maxPts <= 2 {
+		t.Errorf("arc edge pcurve not subdivided: longest pcurve is %d points", maxPts)
+	}
+}
+
+func TestReconstructFacePcurvesIdempotent(t *testing.T) {
+	f := halfDiskFace(t, 2)
+	q := Quality{ChordTolerance: 1e-3}
+	ReconstructFacePcurves(f, q)
+	first := len(f.Loops()[0].EdgeUses()[0].Pcurve())
+	ReconstructFacePcurves(f, q)
+	if again := len(f.Loops()[0].EdgeUses()[0].Pcurve()); again != first {
+		t.Errorf("re-running changed the pcurve length: %d then %d", first, again)
+	}
+}

--- a/kernel/topo/topology.go
+++ b/kernel/topo/topology.go
@@ -115,12 +115,22 @@ type EdgeUse struct {
 	edge     *Edge
 	loop     *Loop
 	reversed bool
+	pcurve   []math.Point2
 }
 
 // Edge returns the used edge; Reversed reports traversal direction; Loop the owner.
 func (u *EdgeUse) Edge() *Edge    { return u.edge }
 func (u *EdgeUse) Reversed() bool { return u.reversed }
 func (u *EdgeUse) Loop() *Loop    { return u.loop }
+
+// Pcurve returns this use's PCURVE: the edge's (u, v) curve on the loop's face surface, in the use's
+// traversal order. It is nil until import healing reconstructs it (M25) — SolidWorks STEP omits
+// pcurves — and, once present, gives the face's trim boundary exactly in parameter space (what the
+// NURBS mesher needs). Returned directly (not copied); callers must not mutate it.
+func (u *EdgeUse) Pcurve() []math.Point2 { return u.pcurve }
+
+// SetPcurve attaches the reconstructed pcurve (see [EdgeUse.Pcurve]).
+func (u *EdgeUse) SetPcurve(pc []math.Point2) { u.pcurve = pc }
 
 // Loop (EdgeLoop) is an ordered cycle of edge-uses bounding a face — the outer
 // boundary or an inner hole.


### PR DESCRIPTION
Completes **M25 F01** — the projection foundation + the pcurve data SolidWorks STEP omits.

**PBI-322 — projection API** (`kernel/geom/projection.go`):
- `ProjectPointToSurface(s, p) → (u, v, dist)`: closest parameters + residual gap (the imported edge-to-surface distance). Wraps M24-verified ParamAt.
- `ProjectCurveToSurface(s, pts) → pcurve`: marches an edge polyline into (u,v), seeded per point, so it stays on one branch (no self-intersection near a near-fold).

**PBI-323 — pcurve reconstruction** (`kernel/topo`, `kernel/ops`):
- `EdgeUse` carries a `pcurve` (`Pcurve()`/`SetPcurve`), nil until healed.
- `ReconstructFacePcurves`/`ReconstructPcurves` discretize each edge with the SAME polyline the mesher uses, orient to the use, and project onto the face surface → the exact trim boundary in (u,v) (the M24 over-enclosure root cause, now fixed by data).

Tests: NURBS projection round-trips + continuous + residual=gap; half-disk face pcurves round-trip every edge point, arc subdivided, idempotent. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)