### PR TITLE
M25: metric-aware NURBS face triangulation (fixes the imported-freeform staircase)

### DIFF
--- a/kernel/ops/nurbs_pcurve_mesh.go
+++ b/kernel/ops/nurbs_pcurve_mesh.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati/kernel/geom"
+	"oblikovati/kernel/topo"
+	"oblikovati/math"
+)
+
+// nurbsPcurveMesh meshes a B-spline face from its reconstructed pcurves (M25 F01) with a METRIC-AWARE
+// triangulation. The over-enclosure of every prior attempt was folded triangles, not bad geometry
+// (every sampled point lies exactly on OCC's surface): a plain (u,v) Delaunay twists in 3D because u
+// and v have very different 3D scales (anisotropy). So the boundary pcurve + deflection-adaptive
+// interior nodes are triangulated in METRIC-SCALED (u,v) — each axis scaled by its mean 3D length
+// (√E, √G), making the parameter space ≈ isometric to 3D, so the Delaunay yields well-shaped 3D
+// triangles. Points lift via PointAt (exact forward eval, no projection); the boundary keeps the exact
+// 3D edge points (watertight). Returns nil to fall back.
+func nurbsPcurveMesh(f *topo.Face, q Quality) *Mesh {
+	s, ok := f.Geometry().(geom.BSplineSurface)
+	if !ok {
+		return nil
+	}
+	outerUV, outer3D, holesUV, holes3D := facePcurveLoops(f, q)
+	if len(outer3D) < 3 {
+		return nil
+	}
+	su, sv := metricScale(s)
+	b := newPatchBuilder(s, su, sv)
+	loops := [][]int{b.addLoop(outer3D, outerUV)}
+	for i := range holes3D {
+		loops = append(loops, b.addLoop(holes3D[i], holesUV[i]))
+	}
+	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q) {
+		b.addInterior(g)
+	}
+	tris := constrainedDelaunay(b.scaled, loops)
+	if len(tris) == 0 {
+		return nil
+	}
+	m := patchMeshFrom(b.pos, b.nrm, tris)
+	repairFolds(m, 8)
+	return m
+}
+
+// metricScale returns the mean 3D length of a unit step in u and in v (√E, √G of the first
+// fundamental form), sampled over the domain — the per-axis scale that makes (u,v) ≈ isometric to 3D.
+func metricScale(s geom.BSplineSurface) (su, sv float64) {
+	ulo, uhi := s.UDomain()
+	vlo, vhi := s.VDomain()
+	var sumU, sumV float64
+	const n = 4
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= n; j++ {
+			du, dv := s.DerivativesAt(ulo+(uhi-ulo)*float64(i)/n, vlo+(vhi-vlo)*float64(j)/n)
+			sumU += du.Length()
+			sumV += dv.Length()
+		}
+	}
+	su, sv = sumU/float64((n+1)*(n+1)), sumV/float64((n+1)*(n+1))
+	if su <= 0 {
+		su = 1
+	}
+	if sv <= 0 {
+		sv = 1
+	}
+	return su, sv
+}
+
+// patchBuilder accumulates the mesh vertices: exact/ on-surface 3D positions + normals, plus the
+// metric-scaled (u,v) coordinates the CDT triangulates in.
+type patchBuilder struct {
+	s      geom.BSplineSurface
+	su, sv float64
+	pos    []math.Point3
+	nrm    []math.Vector3
+	scaled [][2]float64
+}
+
+func newPatchBuilder(s geom.BSplineSurface, su, sv float64) *patchBuilder {
+	return &patchBuilder{s: s, su: su, sv: sv}
+}
+
+// addLoop appends a boundary loop: exact 3D edge points (watertight) with normal + scaled (u,v) from
+// the pcurve. Returns the loop's vertex indices.
+func (b *patchBuilder) addLoop(loop3D []math.Point3, loop2D []math.Point2) []int {
+	idx := make([]int, len(loop3D))
+	for i, p := range loop3D {
+		idx[i] = b.add(p, float64(loop2D[i].X), float64(loop2D[i].Y))
+	}
+	return idx
+}
+
+// addInterior appends an interior node at parameters g, lifted on-surface via PointAt.
+func (b *patchBuilder) addInterior(g [2]float64) {
+	b.add(b.s.PointAt(g[0], g[1]), g[0], g[1])
+}
+
+func (b *patchBuilder) add(p math.Point3, u, v float64) int {
+	idx := len(b.pos)
+	b.pos = append(b.pos, p)
+	b.nrm = append(b.nrm, b.s.NormalAt(u, v))
+	b.scaled = append(b.scaled, [2]float64{u * b.su, v * b.sv})
+	return idx
+}
+
+// facePcurveLoops returns each loop's (u,v) pcurve and matching exact 3D polyline, concatenating the
+// loop's edge-uses (pcurve from healing, 3D from the same edge discretization), dropping the point
+// shared with the previous edge and the closing duplicate — like loopBoundary.
+func facePcurveLoops(f *topo.Face, q Quality) (outerUV []math.Point2, outer3D []math.Point3, holesUV [][]math.Point2, holes3D [][]math.Point3) {
+	for _, l := range f.Loops() {
+		uv, p3 := concatLoopPcurve(f.Geometry(), l, q)
+		if l.IsOuter() {
+			outerUV, outer3D = uv, p3
+		} else {
+			holesUV = append(holesUV, uv)
+			holes3D = append(holes3D, p3)
+		}
+	}
+	return outerUV, outer3D, holesUV, holes3D
+}
+
+func concatLoopPcurve(s geom.Surface, l *topo.Loop, q Quality) (uv []math.Point2, p3 []math.Point3) {
+	for _, u := range l.EdgeUses() {
+		pts := discretizeEdge(u.Edge(), q)
+		if u.Reversed() {
+			pts = reverse3(pts)
+		}
+		pc := u.Pcurve()
+		if len(pc) != len(pts) {
+			pc = geom.ProjectCurveToSurface(s, pts) // no/stale pcurve: reconstruct on the fly
+		}
+		if len(p3) > 0 {
+			pc, pts = pc[1:], pts[1:] // drop the point shared with the previous edge
+		}
+		uv = append(uv, pc...)
+		p3 = append(p3, pts...)
+	}
+	if n := len(p3); n > 1 && p3[0].DistanceTo(p3[n-1]) < weldPointTol {
+		uv, p3 = uv[:n-1], p3[:n-1]
+	}
+	return uv, p3
+}

--- a/kernel/ops/nurbs_pcurve_mesh_test.go
+++ b/kernel/ops/nurbs_pcurve_mesh_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// TestMetricScaleReflectsAnisotropy: a patch 10 units long in u and 1 in v must report su≈10·sv, so
+// the CDT scales u/v into a ≈isometric space (the fix that stopped the (u,v) Delaunay from twisting
+// in 3D and folding — M25). su = mean |∂P/∂u|, sv = mean |∂P/∂v|.
+func TestMetricScaleReflectsAnisotropy(t *testing.T) {
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 1, 0)},
+		{math.P3(10, 0, 0), math.P3(10, 1, 0)},
+	}
+	w := [][]float64{{1, 1}, {1, 1}}
+	s, err := geom.NewBSplineSurface(1, 1, ctrl, w, []float64{0, 0, 1, 1}, []float64{0, 0, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	su, sv := metricScale(s)
+	if r := su / sv; r < 8 || r > 12 {
+		t.Errorf("metricScale su/sv = %.2f, want ~10 (u spans 10×, v spans 1×)", r)
+	}
+}
+
+func TestMetricScaleNeverZero(t *testing.T) {
+	su, sv := metricScale(cProfileSurfaceOps(t))
+	if su <= 0 || sv <= 0 {
+		t.Errorf("metricScale returned non-positive (%g, %g)", su, sv)
+	}
+}
+
+func cProfileSurfaceOps(t *testing.T) geom.BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 2, 1), math.P3(0, 0, 2)},
+		{math.P3(2, 0, 0), math.P3(2, 2, 1), math.P3(2, 0, 2)},
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}}
+	s, err := geom.NewBSplineSurface(1, 2, ctrl, w, []float64{0, 0, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	return s
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -27,6 +27,11 @@ const trimBorderTol = 1e-6
 // tessellateCurvedFace meshes a curved face's trimmed region (see file doc).
 func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	s := f.Geometry()
+	if _, isSpline := s.(geom.BSplineSurface); isSpline {
+		if m := nurbsPcurveMesh(f, q); m != nil { // M25: metric-aware (u,v) triangulation
+			return m
+		}
+	}
 	outer3D := faceOuterBoundary(f, q)
 	holes3D := faceHoleBoundaries(f, q)
 	if len(outer3D) < 3 {


### PR DESCRIPTION
Fixes the imported-NURBS folding the whole M24/M25 effort chased — **EDF b-spline fold-edges 166 → 5**, surfaces read smooth, per-face area within 0–2% of OCC's exact areas.

## Root cause (proven, not guessed)
The over-enclosure of every prior attempt was **folded/twisted triangles, not bad geometry**: every sampled point lies *exactly* on OCC's surface (gmsh `getClosestPoint` = 0.000mm). A plain `(u,v)` Delaunay twists in 3D because `u` and `v` have very different 3D scales (anisotropy).

## Fix
`nurbsPcurveMesh` triangulates the pcurve trim boundary + deflection-adaptive interior nodes in **metric-scaled `(u,v)`** — each axis × its mean 3D length (√E, √G via `metricScale`), so the parameter space is ≈isometric to 3D and the Delaunay yields well-shaped 3D triangles. Points lift via `PointAt` (exact, no projection); the boundary keeps exact 3D edge points (watertight). Builds on F01 pcurves (#114).

**OCC oracle (incl. rational b-spline fillets) + full kernel suite pass; lint clean.**

## ⚠️ Known follow-up — read before merging
EDF *per-body* volume is off (total 210k→274k). This is **not** a triangulator defect and **not** introduced here: `meshGeometryProperties` orients triangles by the **shading normal**, which isn't consistently outward for some imported faces (wrong face sense). Per-body volume is wrong in the **baseline too** (body1=54%, body4=128% of OCC) — it just cancels to a near-OCC *total* by luck. The metric mesh cancels differently.

The real fix is **adjacency-based shell orientation** in mass-props (corrects both meshers → EDF ≈ OCC). It's a careful hot-path change, tracked separately.

**So this PR is a clear tessellation-quality win (the staircase) but, until the orientation fix lands, changes the EDF mass-props total.** Holding for your call on whether to merge now (quality win) or pair with the orientation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)