### PR TITLE
M25 PBI-330: watertight closed-surface + periodic-band tessellation

### DIFF
--- a/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-330-watertight-curved-tessellation.md
+++ b/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-330-watertight-curved-tessellation.md
@@ -23,6 +23,47 @@ weldable). **Therefore the fix is [PBI-324 edge snapping](../F02-edge-surface-sn
 meshers (this PBI). Keep this PBI only as a fallback if snapping can't reconcile an edge that's off
 BOTH adjacent surfaces. Status: superseded-by PBI-324 for the EDF case.
 
+## CORRECTION (2026-06-08, after PBI-324 shipped + was verified on EDF): the premise above was WRONG
+
+PBI-324 (edge snapping) is **done, wired into import, and DOES NOT fix EDF** — reopening this PBI as the
+real fix. The "imported edges sit ~mm off their surfaces" claim conflated two quantities: the **free-edge
+partner gap** (0.017–8.56 mm, the distance between unpaired mesh edges) is NOT the **edge-off-surface
+residual** — measured directly, EDF's edges sit ~0.3 µm (median) ON their surfaces. Snapping them
+therefore does nothing for watertightness (EDF body3 stayed 69 free edges), and snapping the B-spline-
+adjacent ones made it WORSE (69→75) by folding the NURBS CDT. **So the EDF leak IS mesher-internal**, as
+this PBI originally said: (1) the grid meshers (`structuredGridMesh`/`gridPatchMesh`) vs the NURBS CDT
+sample shared edges differently, and (2) the NURBS metric CDT itself leaves T-junctions/folds on body3.
+The fix is this PBI's "conform the meshers to the shared `discretizeEdge` boundary" OR a mesh-sew
+post-process — independent of edge snapping. (Also: `TessellateBody` free-edge counts are
+non-deterministic on some imported solids — fix that first so the metric is reproducible.)
+
+## Phased plan + progress (2026-06-08, after determinism fix landed)
+
+Prerequisite DONE: `TessellateBody` is now deterministic (CDT cavity + fold-repair map order), so
+free-edge counts are stable, measurable numbers. Per-face diagnosis split the leaks into two
+mechanisms, tackled in phases:
+
+- **Phase 1 — closed-surface watertightness (DONE).** A bare closed surface (OCC's whole sphere = 1
+  face, 0 seam edges) fell to the full-domain grid, which duplicated the periodic seam (u=0≡2π → welded
+  degree-4 edges) and degenerated the poles (zero-area quads → degree-32). `kernel/ops/closed_surface_mesh.go`
+  (`closedDomainMesh`, replacing the naive `gridMesh` in `fullDomainGridMesh`) wraps the seam onto the
+  first column and shares one vertex per pole row, fanning its ring. **sphere 66→0 free edges**, area
+  ≈4πr²; tests in `closed_surface_mesh_test.go`; OCC oracle + full kernel suite green.
+- **Phase 2a — periodic band seam (DONE).** A full cylinder/cone side (`periodicBandGrid`) dropped one
+  cell at the seam: the seam vertex's angle read back as ~2π−ε (tiny negative coordinate), so `us`
+  landed only at ~2π with no 0 column → 31 cells for a 32-segment circle → a one-cell crack against the
+  caps (the leak appears one cell in, not at the seam, because the cap polygon and band grid misalign by
+  one). Fix: `bracketPeriod` snaps the seam sample to 0 and brackets a closed [0, 2π], and the band now
+  routes through `closedDomainMesh` (wraps the seam onto one column). **cylinder 4→0, cone_frustum 0,
+  cone_sharp 33→0** — the apex cone too (NOTE: this also subsumed the planned Phase 3). Edges are
+  exactly on-surface (residual ~3e-15 mm) — this is a grid-conformance bug, not off-surface.
+- **Phase 2b — sphere-cap / gridPatchMesh conformance (NEXT).** Remaining: filleted_box 36 (the sphere
+  corner-fillets' `gridPatchMesh` boundary), EDF body0 4 / body2 8. Same class — make the sphere-cap
+  CDT boundary the exact shared `discretizeEdge` polyline.
+- **Phase 4 — NURBS CDT watertightness (EDF body3 = 69).** The metric pcurve mesher leaves
+  T-junctions/folds at face boundaries shared with grid faces; needs the boundary to be a hard shared
+  polyline AND the interior CDT to not subdivide boundary segments. Hardest; do last.
+
 ## Why (measured root cause, 2026-06-08)
 
 The tessellated body is **not watertight** on bodies with curved analytic faces — EDF body3 (the duct)

--- a/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-330-watertight-curved-tessellation.md
+++ b/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-330-watertight-curved-tessellation.md
@@ -57,12 +57,19 @@ mechanisms, tackled in phases:
   routes through `closedDomainMesh` (wraps the seam onto one column). **cylinder 4→0, cone_frustum 0,
   cone_sharp 33→0** — the apex cone too (NOTE: this also subsumed the planned Phase 3). Edges are
   exactly on-surface (residual ~3e-15 mm) — this is a grid-conformance bug, not off-surface.
-- **Phase 2b — sphere-cap / gridPatchMesh conformance (NEXT).** Remaining: filleted_box 36 (the sphere
-  corner-fillets' `gridPatchMesh` boundary), EDF body0 4 / body2 8. Same class — make the sphere-cap
-  CDT boundary the exact shared `discretizeEdge` polyline.
-- **Phase 4 — NURBS CDT watertightness (EDF body3 = 69).** The metric pcurve mesher leaves
-  T-junctions/folds at face boundaries shared with grid faces; needs the boundary to be a hard shared
-  polyline AND the interior CDT to not subdivide boundary segments. Hardest; do last.
+- **Phase 2b — sphere-cap / gridPatchMesh robustness (DONE).** filleted_box 36 was the sphere corner-
+  fillet caps whose `(u,v)` reaches the pole (v=±π/2, all u collapse) or wraps the seam: the CDT tore
+  them into a non-manifold mesh (interior holes / pole overlaps, visible only after a 3D weld). The cap
+  boundary was already the exact shared edge points, so the fix is robustness, not conformance:
+  `gridPatchMesh` now checks the result (`patchIsManifold` = welded free edges ≤ loop boundary) and
+  falls back to the plane-based `boundaryPatchMesh` (watertight, boundary-only) when the CDT tore. Only
+  torn caps fall back; smooth caps (and the refinement test patch) keep their interior nodes.
+  **filleted_box 36→0; EDF total 81→44** (the fallback fixed EDF's pole-degenerate caps too). Guard:
+  filleted_box added to `TestImportedAnalyticPrimitivesWatertight` + `weldedFreeEdgeCount`/
+  `patchIsManifold` unit tests.
+- **Phase 4 — NURBS CDT watertightness (EDF remaining ≈44).** The metric pcurve mesher (and the few
+  remaining grid↔NURBS edges) leave T-junctions/folds at face boundaries; needs the boundary to be a
+  hard shared polyline AND the interior CDT to not subdivide boundary segments. Hardest; do last.
 
 ## Why (measured root cause, 2026-06-08)
 

--- a/kernel/ops/closed_surface_mesh.go
+++ b/kernel/ops/closed_surface_mesh.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import "oblikovati/kernel/geom"
+
+// A bare closed surface — a whole sphere imported as ONE face with no seam edge (0 loops) — has no
+// trim to reduce, so it falls to the full-domain grid. A naive UV grid is NOT watertight on a closed
+// surface: it emits a separate column for the periodic seam (u=0 and u=2π trace the same points →
+// duplicated edges, welded degree 4) and collapses a pole row to many coincident vertices joined by
+// zero-area quads (a high-degree pole). closedDomainMesh fixes both — it WRAPS a periodic seam back
+// onto the first column (no duplicate seam) and shares ONE vertex per pole row, fanning its neighbour
+// ring (no zero-area triangles) — so the closed surface meshes watertight. On a non-closed surface (no
+// periodic seam, no pole row) it reduces to the plain UV grid. (M25 PBI-330)
+func closedDomainMesh(s geom.Surface, us, vs []float64) *Mesh {
+	cols := len(us)
+	uWrap := cols > 2 && columnsCoincide(s, us[0], us[cols-1], vs)
+	if uWrap {
+		cols-- // the last column repeats the first (the seam); cells wrap onto column 0 instead
+	}
+	m := &Mesh{}
+	poles := poleRowVertices(m, s, us[:cols], vs)
+	idx := closedGridVertices(m, s, us[:cols], vs, poles)
+	emitClosedGrid(m, idx, uWrap)
+	return m
+}
+
+// columnsCoincide reports whether the surface columns at parameters u0 and u1 trace the same points at
+// every v — a periodic seam (u0=0, u1=2π on a sphere/cylinder).
+func columnsCoincide(s geom.Surface, u0, u1 float64, vs []float64) bool {
+	for _, v := range vs {
+		if s.PointAt(u0, v).DistanceTo(s.PointAt(u1, v)) > weldPointTol {
+			return false
+		}
+	}
+	return true
+}
+
+// poleRowVertices returns, per v-row, a single shared vertex index when that row degenerates to one
+// point (a pole: every column coincides), or -1 for a normal row. Sharing one vertex (not one per
+// column) is what removes the high-degree pole the naive grid produces.
+func poleRowVertices(m *Mesh, s geom.Surface, us, vs []float64) []int {
+	out := make([]int, len(vs))
+	for j, v := range vs {
+		out[j] = -1
+		if rowIsPole(s, us, v) {
+			out[j] = m.addVertex(s.PointAt(us[0], v), s.NormalAt(us[0], v))
+		}
+	}
+	return out
+}
+
+// rowIsPole reports whether every column of the v-row collapses to one point (a surface pole).
+func rowIsPole(s geom.Surface, us []float64, v float64) bool {
+	p0 := s.PointAt(us[0], v)
+	for _, u := range us[1:] {
+		if s.PointAt(u, v).DistanceTo(p0) > weldPointTol {
+			return false
+		}
+	}
+	return true
+}
+
+// closedGridVertices builds the cols×rows vertex-index grid, reusing the shared pole vertex on a pole
+// row so adjacent cells fan to one point instead of meshing zero-area quads.
+func closedGridVertices(m *Mesh, s geom.Surface, us, vs []float64, poles []int) [][]int {
+	idx := make([][]int, len(us))
+	for i, u := range us {
+		idx[i] = make([]int, len(vs))
+		for j, v := range vs {
+			if poles[j] >= 0 {
+				idx[i][j] = poles[j]
+				continue
+			}
+			idx[i][j] = m.addVertex(s.PointAt(u, v), s.NormalAt(u, v))
+		}
+	}
+	return idx
+}
+
+// emitClosedGrid triangulates the vertex grid, wrapping the last column onto the first when uWrap, and
+// skipping the zero-area triangle of a cell that touches a collapsed pole vertex.
+func emitClosedGrid(m *Mesh, idx [][]int, uWrap bool) {
+	cols := len(idx)
+	for i := 0; i < cols; i++ {
+		ni := i + 1
+		if ni >= cols {
+			if !uWrap {
+				break // open seam: no cell past the last column
+			}
+			ni = 0
+		}
+		for j := 0; j+1 < len(idx[i]); j++ {
+			emitClosedTri(m, idx[i][j], idx[ni][j], idx[ni][j+1])
+			emitClosedTri(m, idx[i][j], idx[ni][j+1], idx[i][j+1])
+		}
+	}
+}
+
+// emitClosedTri adds triangle abc wound to agree with its vertices' surface normals, skipping it when a
+// collapsed pole vertex makes two corners coincide (a zero-area triangle).
+func emitClosedTri(m *Mesh, a, b, c int) {
+	if a == b || b == c || a == c {
+		return
+	}
+	if windingOpposesNormals(m.Positions[a], m.Positions[b], m.Positions[c], m.Normals[a], m.Normals[b], m.Normals[c]) {
+		b, c = c, b
+	}
+	m.addTriangle(a, b, c)
+}

--- a/kernel/ops/closed_surface_mesh_test.go
+++ b/kernel/ops/closed_surface_mesh_test.go
@@ -56,15 +56,17 @@ func TestClosedDomainMeshSphereArea(t *testing.T) {
 	}
 }
 
-// TestImportedAnalyticPrimitivesWatertight pins M25 PBI-330 Phases 1–2: every imported solid bounded by
+// TestImportedAnalyticPrimitivesWatertight pins M25 PBI-330 Phases 1–2b: every imported solid bounded by
 // closed/periodic analytic faces tessellates watertight (0 free edges). Each previously leaked — sphere
-// 66 (seam+poles, Phase 1), cylinder 4 and cone_sharp 33 (the band dropped its seam cell, Phase 2) —
-// and the cone/cylinder caps must still pair with the band. Boundary-trimmed primitives (partial_*,
-// drilled/chamfered box) guard that the fixes did not break the non-closed paths.
+// 66 (seam+poles, Phase 1), cylinder 4 and cone_sharp 33 (the band dropped its seam cell, Phase 2a),
+// filleted_box 36 (pole-degenerate sphere corner-fillet caps the CDT tore, Phase 2b) — and the caps must
+// still pair with their neighbours. Boundary-trimmed primitives (partial_*, drilled/chamfered box) guard
+// that the fixes did not break the non-closed paths.
 func TestImportedAnalyticPrimitivesWatertight(t *testing.T) {
 	for _, name := range []string{
 		"sphere", "cylinder", "cone_frustum", "cone_sharp", "torus",
 		"partial_cylinder", "drilled_box", "chamfered_box", "box_with_boss",
+		"filleted_box", "partial_sphere",
 	} {
 		data, err := os.ReadFile(filepath.Join("..", "exchange", "step", "testdata", "occ", name+".step"))
 		if err != nil {

--- a/kernel/ops/closed_surface_mesh_test.go
+++ b/kernel/ops/closed_surface_mesh_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati/kernel/exchange"
+	"oblikovati/kernel/exchange/step"
+	"oblikovati/kernel/geom"
+	"oblikovati/math"
+)
+
+// sphereGrid builds the full-domain (u,v) breakpoints a bare sphere face tessellates over, matching
+// fullDomainGridMesh's sampling.
+func sphereGrid(s geom.Sphere, q Quality) (us, vs []float64) {
+	uLo, uHi := s.UDomain()
+	vLo, vHi := s.VDomain()
+	us = adaptiveParams(func(u float64) math.Point3 { return s.PointAt(u, (vLo+vHi)/2) }, uLo, uHi, q.tol(), q.angleTol())
+	vs = adaptiveParams(func(v float64) math.Point3 { return s.PointAt((uLo+uHi)/2, v) }, vLo, vHi, q.tol(), q.angleTol())
+	return us, vs
+}
+
+// TestClosedDomainMeshSphereWatertight pins the M25 PBI-330 fix: a whole sphere (a closed, periodic,
+// pole-capped surface) meshes WATERTIGHT — the seam wraps and each pole is one shared vertex, so no
+// edge is left unpaired. A naive UV grid duplicated the seam and degenerated the poles (66 free edges).
+func TestClosedDomainMeshSphereWatertight(t *testing.T) {
+	s, err := geom.NewSphere(math.P3(0, 0, 0), 5)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	us, vs := sphereGrid(s, DefaultQuality())
+	m := closedDomainMesh(s, us, vs)
+	if free := freeEdgeCount(m); free != 0 {
+		t.Errorf("sphere meshed with %d free edges; want 0 (watertight)", free)
+	}
+}
+
+// TestClosedDomainMeshSphereArea pins that the watertight sphere mesh has ~the analytic surface area
+// (a chord-faceted inscribed mesh is slightly under 4πr²) — i.e. wrapping the seam and collapsing the
+// poles did not drop or double-count any area.
+func TestClosedDomainMeshSphereArea(t *testing.T) {
+	const r = 5.0
+	s, err := geom.NewSphere(math.P3(0, 0, 0), r)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	us, vs := sphereGrid(s, DefaultQuality())
+	got := meshGeometryProperties(closedDomainMesh(s, us, vs)).Area
+	want := 4 * stdmath.Pi * r * r
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("sphere mesh area %.3f; want ~%.3f (4πr²), off by %.1f%%", got, want, rel*100)
+	}
+}
+
+// TestImportedAnalyticPrimitivesWatertight pins M25 PBI-330 Phases 1–2: every imported solid bounded by
+// closed/periodic analytic faces tessellates watertight (0 free edges). Each previously leaked — sphere
+// 66 (seam+poles, Phase 1), cylinder 4 and cone_sharp 33 (the band dropped its seam cell, Phase 2) —
+// and the cone/cylinder caps must still pair with the band. Boundary-trimmed primitives (partial_*,
+// drilled/chamfered box) guard that the fixes did not break the non-closed paths.
+func TestImportedAnalyticPrimitivesWatertight(t *testing.T) {
+	for _, name := range []string{
+		"sphere", "cylinder", "cone_frustum", "cone_sharp", "torus",
+		"partial_cylinder", "drilled_box", "chamfered_box", "box_with_boss",
+	} {
+		data, err := os.ReadFile(filepath.Join("..", "exchange", "step", "testdata", "occ", name+".step"))
+		if err != nil {
+			t.Fatalf("read %s.step: %v", name, err)
+		}
+		bodies, _, err := step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: 1})
+		if err != nil || len(bodies) == 0 {
+			t.Fatalf("import %s.step: %v (n=%d)", name, err, len(bodies))
+		}
+		total := 0
+		for _, b := range bodies {
+			mesh, _ := TessellateBody(b, DefaultQuality())
+			total += freeEdgeCount(mesh)
+		}
+		if total != 0 {
+			t.Errorf("%s tessellated with %d free edges; want 0 (watertight)", name, total)
+		}
+	}
+}
+
+// TestClosedDomainMeshOpenSurfaceIsPlainGrid pins the no-op case: a non-closed surface (a clamped plane
+// patch — no periodic seam, no pole) tessellates as a plain (cols-1)×(rows-1)×2 grid, unchanged.
+func TestClosedDomainMeshOpenSurfaceIsPlainGrid(t *testing.T) {
+	p, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	us := []float64{0, 1, 2, 3}
+	vs := []float64{0, 1, 2}
+	m := closedDomainMesh(p, us, vs)
+	wantTris := (len(us) - 1) * (len(vs) - 1) * 2
+	if got := len(m.Indices) / 3; got != wantTris {
+		t.Errorf("open plane grid produced %d triangles; want %d (plain grid, no wrap/pole)", got, wantTris)
+	}
+}

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -28,7 +28,62 @@ func gridPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point
 	if len(tris) == 0 {
 		return boundaryPatchMesh(s, outer3D, holes3D)
 	}
-	return patchMeshFrom(pos, nrm, tris)
+	m := patchMeshFrom(pos, nrm, tris)
+	if !patchIsManifold(m, loops) {
+		// The cap's (u,v) is degenerate — it reaches the sphere pole (v=±π/2, where all u collapse) or
+		// wraps the seam — so the CDT in that distorted space tears the interior into a non-manifold
+		// mesh (the filleted_box corner caps). Fall back to the best-fit-plane boundary triangulation,
+		// which is watertight (no interior nodes, but a small corner octant reads fine).
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	return m
+}
+
+// patchIsManifold reports whether the patch mesh is no LESS watertight than its input boundary: after
+// welding coincident 3D vertices, its unpaired (degree≠2) edges must not EXCEED the loops' edge count
+// (a clean cap's only unpaired edges ARE its boundary, == the loops). A pole/seam-degenerate cap whose
+// CDT tore leaves interior holes (extra unpaired edges) or pole overlaps (degree>2) — both push the
+// count over the boundary and trigger the fallback. Welds because the tear shows only in 3D: distinct
+// (u,v) nodes coincide at the sphere pole. (A benign over-extraction, count < boundary, is kept.)
+func patchIsManifold(m *Mesh, loops [][]int) bool {
+	want := 0
+	for _, l := range loops {
+		want += len(l)
+	}
+	return weldedFreeEdgeCount(m) <= want
+}
+
+// weldedFreeEdgeCount welds coincident vertices (by [weldKey]) and counts edges not shared by exactly
+// two triangles — the watertightness metric for a single mesh.
+func weldedFreeEdgeCount(m *Mesh) int {
+	canon := map[[3]int64]int{}
+	weld := make([]int, len(m.Positions))
+	for i, p := range m.Positions {
+		k := weldKey(p)
+		if c, ok := canon[k]; ok {
+			weld[i] = c
+		} else {
+			canon[k], weld[i] = i, i
+		}
+	}
+	deg := map[[2]int]int{}
+	for t := 0; 3*t+2 < len(m.Indices); t++ {
+		v := [3]int{weld[m.Indices[3*t]], weld[m.Indices[3*t+1]], weld[m.Indices[3*t+2]]}
+		for k := 0; k < 3; k++ {
+			a, b := v[k], v[(k+1)%3]
+			if a > b {
+				a, b = b, a
+			}
+			deg[[2]int{a, b}]++
+		}
+	}
+	free := 0
+	for _, d := range deg {
+		if d != 2 {
+			free++
+		}
+	}
+	return free
 }
 
 // interiorUVGrid returns staggered (u,v) points strictly inside the trim (inside the outer loop,

--- a/kernel/ops/refined_patch_test.go
+++ b/kernel/ops/refined_patch_test.go
@@ -94,3 +94,33 @@ func TestGridPatchMeshAddsInteriorNodes(t *testing.T) {
 		t.Errorf("%d of %d triangles wind against their vertex normals", bad, m.TriangleCount())
 	}
 }
+
+// TestWeldedFreeEdgeCount pins the watertightness metric the sphere-cap fallback decision uses: a
+// closed tetrahedron welds to 0 free edges; dropping a face exposes 3 boundary edges.
+func TestWeldedFreeEdgeCount(t *testing.T) {
+	m := &Mesh{
+		Positions: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(0, 0, 1)},
+		Indices:   []int{0, 2, 1, 0, 1, 3, 1, 2, 3, 0, 3, 2}, // all 4 faces: closed
+	}
+	if free := weldedFreeEdgeCount(m); free != 0 {
+		t.Errorf("closed tetrahedron has %d free edges; want 0", free)
+	}
+	m.Indices = m.Indices[:9] // drop one face → an open shell with a 3-edge boundary
+	if free := weldedFreeEdgeCount(m); free != 3 {
+		t.Errorf("tetrahedron missing one face has %d free edges; want 3", free)
+	}
+}
+
+// TestPatchIsManifoldTolerance pins the fallback threshold: a patch whose welded free edges do not
+// exceed its loop boundary is kept (manifold), one that exceeds it (a torn cap) is rejected.
+func TestPatchIsManifoldTolerance(t *testing.T) {
+	// one triangle, loop of its 3 vertices: 3 boundary edges == want 3 → kept.
+	tri := &Mesh{Positions: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0)}, Indices: []int{0, 1, 2}}
+	if !patchIsManifold(tri, [][]int{{0, 1, 2}}) {
+		t.Error("a single triangle with a 3-vertex loop should be manifold (3 free == want 3)")
+	}
+	// same triangle but claim a smaller loop (want 2) → 3 free > 2 → rejected (a torn patch).
+	if patchIsManifold(tri, [][]int{{0, 1}}) {
+		t.Error("free edges (3) exceeding the loop (2) should be rejected as torn")
+	}
+}

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -233,25 +233,6 @@ func clamp01(x float64) float64 {
 	return x
 }
 
-// gridMesh builds a mesh from a UV breakpoint grid.
-func gridMesh(s geom.Surface, us, vs []float64) *Mesh {
-	m := &Mesh{}
-	idx := make([][]int, len(us))
-	for i, u := range us {
-		idx[i] = make([]int, len(vs))
-		for j, v := range vs {
-			idx[i][j] = m.addVertex(s.PointAt(u, v), s.NormalAt(u, v))
-		}
-	}
-	for i := 0; i+1 < len(us); i++ {
-		for j := 0; j+1 < len(vs); j++ {
-			m.addTriangle(idx[i][j], idx[i+1][j], idx[i+1][j+1])
-			m.addTriangle(idx[i][j], idx[i+1][j+1], idx[i][j+1])
-		}
-	}
-	return m
-}
-
 // clampSpan replaces infinite domain bounds with a finite window.
 func clampSpan(lo, hi float64) (float64, float64) {
 	const window = 10

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -43,7 +43,7 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
 		if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
-			return structuredGridMesh(s, us, vs) // full cylinder/cone side: exact area
+			return closedDomainMesh(s, us, vs) // full cylinder/cone side: wraps the seam watertight
 		}
 		// A SINGLY-periodic surface (a sphere: periodic longitude, bounded latitude) whose (u,v)
 		// degenerates here is a cap straddling the pole — mesh its real boundary trim via the CDT in
@@ -299,9 +299,9 @@ func periodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Po
 		uu[i], vv[i] = s.ParamAt(p)
 	}
 	if uPer {
-		us, vs = closePeriod(sortUnique(uu)), sortUnique(vv)
+		us, vs = bracketPeriod(uu), sortUnique(vv)
 	} else {
-		us, vs = sortUnique(uu), closePeriod(sortUnique(vv))
+		us, vs = sortUnique(uu), bracketPeriod(vv)
 	}
 	if len(us) < 2 || len(vs) < 2 {
 		return nil, nil, false // degenerate (e.g. a cone closing to its apex — one rim circle)
@@ -353,13 +353,22 @@ func coneApexFan(s geom.Surface, outer3D []math.Point3) (*Mesh, bool) {
 	return m, true
 }
 
-// closePeriod appends the 2π wrap line to a [0,2π) sample set so the band's final cell
-// closes back onto the seam (no-op if a 2π sample is already present).
-func closePeriod(g []float64) []float64 {
-	if len(g) == 0 || g[len(g)-1] < 2*stdmath.Pi-trimBorderTol {
-		return append(g, 2*stdmath.Pi)
+// bracketPeriod normalises a periodic direction's samples to span a CLOSED [0, 2π]: a seam sample whose
+// angle wrapped to just under 2π (a seam vertex at angle 0 read back as 2π−ε from a tiny negative
+// coordinate) is snapped to 0 — it is the 0 column — and an explicit 2π closer is appended. So the
+// first and last columns are the shared seam and EVERY segment, including the one across the seam, is a
+// grid cell. Without this the seam column landed only at ~2π, dropping the [0, first-sample] cell and
+// leaving a one-cell crack against the caps. closedDomainMesh then wraps [0, 2π] onto one seam column.
+func bracketPeriod(g []float64) []float64 {
+	out := make([]float64, 0, len(g)+1)
+	for _, x := range g {
+		if x > 2*stdmath.Pi-trimBorderTol {
+			x = 0 // a seam sample read back as ~2π is the 0 column
+		}
+		out = append(out, x)
 	}
-	return g
+	out = sortUnique(out)
+	return append(out, 2*stdmath.Pi)
 }
 
 // toUVLoops maps the boundary loops to parameter space, unwrapping periodic parameters so
@@ -481,5 +490,5 @@ func fullDomainGridMesh(s geom.Surface, q Quality) *Mesh {
 	vLo, vHi := clampSpan(s.VDomain())
 	us := adaptiveParams(func(u float64) math.Point3 { return s.PointAt(u, (vLo+vHi)/2) }, uLo, uHi, q.tol(), q.angleTol())
 	vs := adaptiveParams(func(v float64) math.Point3 { return s.PointAt((uLo+uHi)/2, v) }, vLo, vHi, q.tol(), q.angleTol())
-	return gridMesh(s, us, vs)
+	return closedDomainMesh(s, us, vs) // watertight on a closed surface (periodic seam + poles); else == gridMesh
 }

--- a/kernel/ops/tessellate_trim_coverage_test.go
+++ b/kernel/ops/tessellate_trim_coverage_test.go
@@ -46,12 +46,14 @@ func TestUVLoopHelpersAndPeriodClosure(t *testing.T) {
 	if _, ok := unwrap([]float64{0, stdmath.Pi, 2 * stdmath.Pi}); ok {
 		t.Fatal("unwrap accepted a full-period loop")
 	}
-	closed := closePeriod([]float64{0, stdmath.Pi})
-	if len(closed) != 3 || stdmath.Abs(closed[2]-2*stdmath.Pi) > 1e-12 {
-		t.Fatalf("closePeriod = %v", closed)
+	closed := bracketPeriod([]float64{0, stdmath.Pi})
+	if len(closed) != 3 || stdmath.Abs(closed[0]) > 1e-12 || stdmath.Abs(closed[2]-2*stdmath.Pi) > 1e-12 {
+		t.Fatalf("bracketPeriod = %v; want [0, π, 2π]", closed)
 	}
-	alreadyClosed := closePeriod([]float64{0, 2 * stdmath.Pi})
-	if len(alreadyClosed) != 2 {
-		t.Fatalf("closePeriod appended to already closed grid: %v", alreadyClosed)
+	// A seam sample read back as ~2π−ε must snap to the 0 column, so the period brackets [0, 2π] with the
+	// seam shared at both ends — the fix for the dropped seam cell (a one-cell crack against the caps).
+	seam := bracketPeriod([]float64{0.5, 1.0, 2*stdmath.Pi - 1e-9})
+	if len(seam) != 4 || stdmath.Abs(seam[0]) > 1e-12 || stdmath.Abs(seam[3]-2*stdmath.Pi) > 1e-12 {
+		t.Fatalf("bracketPeriod(seam≈2π) = %v; want [0, 0.5, 1, 2π]", seam)
 	}
 }


### PR DESCRIPTION
First increment of PBI-330 (watertight curved-face tessellation). Makes every imported solid bounded by **closed/periodic analytic faces** tessellate watertight. Independent of #118 (PBI-324 + determinism); the only overlap is a trivial PBI-330.md doc merge.

## Problem
Imported analytic solids tessellated non-watertight via two distinct mechanisms (found by per-face diagnosis, now that tessellation is deterministic):

1. **Bare closed surface** — OCC's whole sphere is 1 face with no seam edge, so it fell to the full-domain grid. A naive UV grid duplicated the periodic seam (`u=0≡2π` → welded degree-4 edges) and degenerated the poles (zero-area quads → degree-32): **66 free edges**.
2. **Periodic band seam** — a full cylinder/cone side dropped one grid cell: the seam vertex's angle reads back as `~2π−ε` (a tiny negative coordinate), so the band's `us` had no `0` column (only `~2π`) → **31 cells for a 32-segment circle** → a one-cell crack against the caps.

The rims were measured **exactly on-surface (residual ~3e-15 mm)** — these are grid-conformance bugs, not off-surface edges, so edge snapping (PBI-324) does not address them.

## Fix
- New `closedDomainMesh` (`kernel/ops/closed_surface_mesh.go`, replacing the naive `gridMesh`): wraps a periodic seam onto the first column and shares one vertex per pole row, fanning its ring. On a non-closed surface it reduces to the plain grid.
- `bracketPeriod` (replacing `closePeriod`): snaps the seam sample to `0` and brackets a closed `[0, 2π]`; the cylinder/cone band now routes through `closedDomainMesh` to wrap the seam.

## Result
| fixture | before | after |
|---|---|---|
| sphere | 66 | **0** |
| cylinder | 4 | **0** |
| cone_sharp | 33 | **0** |
| cone_frustum / torus / drilled_box / chamfered_box / partial_cylinder | 0 | 0 |

Every imported analytic primitive is now watertight. Curved area unchanged (same `PointAt` grid). Dead `gridMesh` removed.

## Tests
`TestImportedAnalyticPrimitivesWatertight` (9 fixtures) + `closedDomainMesh` (sphere watertight/area, open-surface no-op) + `bracketPeriod` seam-snap unit test. Full kernel suite + OCC oracle + brep green; lint clean (0 issues).

## Remaining PBI-330 (documented in the PBI doc, follow-up PRs)
- Phase 2b — sphere-cap `gridPatchMesh` conformance (filleted_box 36, EDF body0/body2)
- Phase 4 — NURBS metric CDT watertightness (EDF body3 69)

🤖 Generated with [Claude Code](https://claude.com/claude-code)