### PR TITLE
M25 PBI-330: watertight curved tessellation — consistent winding + perf guards

### DIFF
--- a/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-330-watertight-curved-tessellation.md
+++ b/implementation-plan/M25-import-brep-healing/F03-face-sewing/PBI-330-watertight-curved-tessellation.md
@@ -67,9 +67,18 @@ mechanisms, tackled in phases:
   **filleted_box 36→0; EDF total 81→44** (the fallback fixed EDF's pole-degenerate caps too). Guard:
   filleted_box added to `TestImportedAnalyticPrimitivesWatertight` + `weldedFreeEdgeCount`/
   `patchIsManifold` unit tests.
-- **Phase 4 — NURBS CDT watertightness (EDF remaining ≈44).** The metric pcurve mesher (and the few
-  remaining grid↔NURBS edges) leave T-junctions/folds at face boundaries; needs the boundary to be a
-  hard shared polyline AND the interior CDT to not subdivide boundary segments. Hardest; do last.
+- **Phase 4 — remaining EDF leaks (IN PROGRESS; 44→36).** Diagnosis: the remaining leaks are NOT mainly
+  NURBS — they are trimmed analytic walls + a mixed grid↔NURBS↔plane core.
+  - **Done (body2 8→0):** a non-iso-rectangular trimmed cylinder/cone wall fell to `boundaryPatchMesh`
+    (best-fit-plane ear-clip), which tears a curved wall that lies in no plane. `nonRectangularMesh` now
+    routes cyl/cone to `metricWallMesh` — a CDT in METRIC-SCALED (u,v) (√E,√G, generalising the NURBS
+    metric mesher; `metricScale` now clamps the cylinder's infinite v-domain). Isotropic interior grids
+    explode on a cylinder's anisotropic (u,v); the metric scaling + deflection-bounded interior fixes
+    both correctness and the node-count blow-up. EDF total 44→36; all OCC fixtures still 0.
+  - **Remaining (body3 32, body0 4):** distributed across band/iso-rectangle cyl/cone (`structuredGridMesh`
+    re-sampling its own grid lines, not the shared `discretizeEdge`) + B-spline + plane edges. Likely
+    needs the band/iso-rectangle grid to emit its boundary ROW as the exact edge points, OR a
+    `TessellateBody` mesh-sew (weld + zip T-junctions) for the mixed remainder. Hardest; next.
 
 ## Why (measured root cause, 2026-06-08)
 

--- a/kernel/ops/nurbs_pcurve_mesh.go
+++ b/kernel/ops/nurbs_pcurve_mesh.go
@@ -45,9 +45,11 @@ func nurbsPcurveMesh(f *topo.Face, q Quality) *Mesh {
 
 // metricScale returns the mean 3D length of a unit step in u and in v (√E, √G of the first
 // fundamental form), sampled over the domain — the per-axis scale that makes (u,v) ≈ isometric to 3D.
-func metricScale(s geom.BSplineSurface) (su, sv float64) {
-	ulo, uhi := s.UDomain()
-	vlo, vhi := s.VDomain()
+// Generalised from B-splines to any surface (a cylinder/cone has a strongly anisotropic (u,v): u is an
+// angle, v a length). Infinite analytic domains (a cylinder's axial v) are clamped to a finite window.
+func metricScale(s geom.Surface) (su, sv float64) {
+	ulo, uhi := clampSpan(s.UDomain())
+	vlo, vhi := clampSpan(s.VDomain())
 	var sumU, sumV float64
 	const n = 4
 	for i := 0; i <= n; i++ {
@@ -70,14 +72,14 @@ func metricScale(s geom.BSplineSurface) (su, sv float64) {
 // patchBuilder accumulates the mesh vertices: exact/ on-surface 3D positions + normals, plus the
 // metric-scaled (u,v) coordinates the CDT triangulates in.
 type patchBuilder struct {
-	s      geom.BSplineSurface
+	s      geom.Surface
 	su, sv float64
 	pos    []math.Point3
 	nrm    []math.Vector3
 	scaled [][2]float64
 }
 
-func newPatchBuilder(s geom.BSplineSurface, su, sv float64) *patchBuilder {
+func newPatchBuilder(s geom.Surface, su, sv float64) *patchBuilder {
 	return &patchBuilder{s: s, su: su, sv: sv}
 }
 

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -238,19 +238,37 @@ func patchLoops2D(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3
 	return uv, pos, nrm, loops
 }
 
-// patchMeshFrom builds the 3D mesh from the CDT triangles, winding each to agree with its own
-// vertex normals (consistent on a curved patch — see windingOpposesNormals).
+// patchMeshFrom builds the 3D mesh from a CDT's triangles, winding each CONSISTENTLY by its 2D (u,v)
+// orientation: a triangle wound CCW in (u,v) faces +NormalAt in 3D (the surface contract is NormalAt ≡
+// du×dv normalised, and a CCW (u,v) triangle's geometric normal lies along +du×dv), so the whole patch
+// is oriented one way and TessellateFace flips it once for a reversed face. Winding per-triangle by the
+// 3D vertex normals instead (windingOpposesNormals) flips UNRELIABLY on a high-curvature freeform patch,
+// where a flat triangle's geometric normal is nearly perpendicular to its averaged vertex normals — the
+// back-facing red triangles seen on the EDF duct's NURBS walls. uv is the same 2D space the CDT ran in
+// (the surface (u,v) or a positively-scaled metric (u,v), so its orientation matches (u,v)).
 func patchMeshFrom(pos []math.Point3, nrm []math.Vector3, tris [][3]int) *Mesh {
 	m := &Mesh{}
 	for i := range pos {
 		m.addVertex(pos[i], nrm[i])
 	}
+	// The CDT returns a CONSISTENTLY-oriented triangulation (every interior edge traversed once each way).
+	// Re-winding per-triangle to agree with its vertex normals BREAKS that consistency on a curved patch:
+	// a thin sliver's flat geometric normal opposes its smooth vertex normals, so it flips and folds
+	// against its neighbours — the back-facing red triangles on the EDF duct's NURBS walls. So keep the
+	// CDT's winding and flip the WHOLE patch ONCE if it faces inward overall (an aggregate, area-weighted
+	// vote that no single sliver can sway). TessellateFace flips again for a reversed face.
+	var agree float64
 	for _, t := range tris {
-		a, b, c := t[0], t[1], t[2]
-		if windingOpposesNormals(pos[a], pos[b], pos[c], nrm[a], nrm[b], nrm[c]) {
-			b, c = c, b
+		gn := pos[t[0]].VectorTo(pos[t[1]]).Cross(pos[t[0]].VectorTo(pos[t[2]]))
+		agree += float64(gn.Dot(nrm[t[0]].Add(nrm[t[1]]).Add(nrm[t[2]])))
+	}
+	flip := agree < 0
+	for _, t := range tris {
+		if flip {
+			m.addTriangle(t[0], t[2], t[1])
+		} else {
+			m.addTriangle(t[0], t[1], t[2])
 		}
-		m.addTriangle(a, b, c)
 	}
 	return m
 }

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -86,35 +86,6 @@ func weldedFreeEdgeCount(m *Mesh) int {
 	return free
 }
 
-// metricWallMesh triangulates a trimmed analytic wall (a cylinder/cone) in its METRIC-SCALED (u,v) —
-// each axis scaled by its mean 3D length (√E, √G) so the strongly anisotropic parameter space (u angle,
-// v length) becomes ≈isometric to 3D. That gives a well-shaped, deflection-bounded interior (the same
-// metric triangulation the NURBS mesher uses), where the best-fit-plane ear-clip tore a curved wall
-// that lies in no plane (the EDF trimmed-cylinder leaks) and the ISOTROPIC interior grid exploded the
-// node count. Exact 3D boundary points keep it watertight with neighbours; folds are repaired; falls
-// back to the plane ear-clip if the CDT is empty or tears (patchIsManifold).
-func metricWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2, q Quality) *Mesh {
-	su, sv := metricScale(s)
-	b := newPatchBuilder(s, su, sv)
-	loops := [][]int{b.addLoop(outer3D, outerUV)}
-	for i := range holes3D {
-		loops = append(loops, b.addLoop(holes3D[i], holesUV[i]))
-	}
-	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q) {
-		b.addInterior(g)
-	}
-	tris := constrainedDelaunay(b.scaled, loops)
-	if len(tris) == 0 {
-		return boundaryPatchMesh(s, outer3D, holes3D)
-	}
-	m := patchMeshFrom(b.pos, b.nrm, tris)
-	repairFolds(m, 8)
-	if !patchIsManifold(m, loops) {
-		return boundaryPatchMesh(s, outer3D, holes3D)
-	}
-	return m
-}
-
 // interiorUVGrid returns staggered (u,v) points strictly inside the trim (inside the outer loop,
 // outside the holes), on a grid sized to the outer loop's median edge length so the interior density
 // matches the boundary's. Alternate rows are offset half a step for better-shaped triangles.

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -86,6 +86,35 @@ func weldedFreeEdgeCount(m *Mesh) int {
 	return free
 }
 
+// metricWallMesh triangulates a trimmed analytic wall (a cylinder/cone) in its METRIC-SCALED (u,v) —
+// each axis scaled by its mean 3D length (√E, √G) so the strongly anisotropic parameter space (u angle,
+// v length) becomes ≈isometric to 3D. That gives a well-shaped, deflection-bounded interior (the same
+// metric triangulation the NURBS mesher uses), where the best-fit-plane ear-clip tore a curved wall
+// that lies in no plane (the EDF trimmed-cylinder leaks) and the ISOTROPIC interior grid exploded the
+// node count. Exact 3D boundary points keep it watertight with neighbours; folds are repaired; falls
+// back to the plane ear-clip if the CDT is empty or tears (patchIsManifold).
+func metricWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2, q Quality) *Mesh {
+	su, sv := metricScale(s)
+	b := newPatchBuilder(s, su, sv)
+	loops := [][]int{b.addLoop(outer3D, outerUV)}
+	for i := range holes3D {
+		loops = append(loops, b.addLoop(holes3D[i], holesUV[i]))
+	}
+	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q) {
+		b.addInterior(g)
+	}
+	tris := constrainedDelaunay(b.scaled, loops)
+	if len(tris) == 0 {
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	m := patchMeshFrom(b.pos, b.nrm, tris)
+	repairFolds(m, 8)
+	if !patchIsManifold(m, loops) {
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	return m
+}
+
 // interiorUVGrid returns staggered (u,v) points strictly inside the trim (inside the outer loop,
 // outside the holes), on a grid sized to the outer loop's median edge length so the interior density
 // matches the boundary's. Alternate rows are offset half a step for better-shaped triangles.

--- a/kernel/ops/refined_patch_test.go
+++ b/kernel/ops/refined_patch_test.go
@@ -124,3 +124,21 @@ func TestPatchIsManifoldTolerance(t *testing.T) {
 		t.Error("free edges (3) exceeding the loop (2) should be rejected as torn")
 	}
 }
+
+// TestMetricScaleCylinder pins the metric generalisation to analytic surfaces: a cylinder's (u,v) is
+// anisotropic — a unit step in u (angle) spans R in 3D, in v (axial) spans 1 — and its v-domain is
+// INFINITE, which metricScale must clamp instead of sampling ±Inf. So su≈R, sv≈1.
+func TestMetricScaleCylinder(t *testing.T) {
+	const r = 7.0
+	cyl, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r)
+	if err != nil {
+		t.Fatalf("NewCylinder: %v", err)
+	}
+	su, sv := metricScale(cyl)
+	if stdmath.Abs(su-r) > 1e-9 {
+		t.Errorf("su = %g; want the radius %g (3D length of a unit angular step)", su, r)
+	}
+	if stdmath.Abs(sv-1) > 1e-9 {
+		t.Errorf("sv = %g; want 1 (3D length of a unit axial step)", sv)
+	}
+}

--- a/kernel/ops/refined_patch_test.go
+++ b/kernel/ops/refined_patch_test.go
@@ -81,17 +81,32 @@ func TestGridPatchMeshAddsInteriorNodes(t *testing.T) {
 	if m.TriangleCount() <= n {
 		t.Errorf("expected interior refinement, got %d triangles (no interior nodes added)", m.TriangleCount())
 	}
-	bad := 0
+	// The patch must be CONSISTENTLY oriented — no shared edge traversed the same direction by both its
+	// triangles (that is a fold / back-face) — and wound outward in aggregate. A per-triangle normal test
+	// is too strict: a thin sliver's flat geometric normal can oppose its averaged vertex normals while
+	// the triangle is correctly wound with its neighbours (see patchMeshFrom's global winding).
+	dir := map[[2]int]int{}
+	var agree float64
 	for i := 0; i+2 < len(m.Indices); i += 3 {
-		a, b, c := m.Positions[m.Indices[i]], m.Positions[m.Indices[i+1]], m.Positions[m.Indices[i+2]]
+		ia, ib, ic := m.Indices[i], m.Indices[i+1], m.Indices[i+2]
+		dir[[2]int{ia, ib}]++
+		dir[[2]int{ib, ic}]++
+		dir[[2]int{ic, ia}]++
+		a, b, c := m.Positions[ia], m.Positions[ib], m.Positions[ic]
 		gn := a.VectorTo(b).Cross(a.VectorTo(c))
-		sn := m.Normals[m.Indices[i]].Add(m.Normals[m.Indices[i+1]]).Add(m.Normals[m.Indices[i+2]])
-		if gn.Dot(sn) < 0 {
-			bad++
+		agree += float64(gn.Dot(m.Normals[ia].Add(m.Normals[ib]).Add(m.Normals[ic])))
+	}
+	folds := 0
+	for _, c := range dir {
+		if c > 1 {
+			folds++
 		}
 	}
-	if bad > 0 {
-		t.Errorf("%d of %d triangles wind against their vertex normals", bad, m.TriangleCount())
+	if folds > 0 {
+		t.Errorf("%d shared edges traversed the same direction by both triangles (fold/back-face)", folds)
+	}
+	if agree <= 0 {
+		t.Errorf("patch winds inward overall (aggregate gn·normal = %g)", agree)
 	}
 }
 

--- a/kernel/ops/tessellate_bench_test.go
+++ b/kernel/ops/tessellate_bench_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"oblikovati/kernel/exchange"
+	"oblikovati/kernel/exchange/step"
+	"oblikovati/kernel/topo"
+)
+
+// Performance accountability for tessellation — the import→render hot path. TessellateBody runs in the
+// viewport every time geometry changes (cached per geometry version), so a pathological mesher (e.g.
+// routing faces through the O(n²) constrained-Delaunay, which once made ONE cone face take 2.4s and
+// froze import) must be caught, not silently shipped. The benchmarks measure; the budget TESTS fail
+// the suite on a catastrophic regression.
+
+// perfFixtures are the committed OCC solids that exercise the analytic / sphere-cap-CDT / hole paths.
+var perfFixtures = []string{
+	"filleted_box", "sphere", "cone_frustum", "cone_sharp",
+	"drilled_box", "torus", "partial_sphere", "chamfered_box",
+}
+
+// occBodies imports a committed OCC fixture's bodies once.
+func occBodies(tb testing.TB, name string) []*topo.Body {
+	return stepBodies(tb, filepath.Join("..", "exchange", "step", "testdata", "occ", name+".step"))
+}
+
+// stepBodies imports a STEP file's bodies, skipping the caller if the file is unavailable.
+func stepBodies(tb testing.TB, path string) []*topo.Body {
+	tb.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Skipf("%s unavailable: %v", path, err)
+		return nil
+	}
+	bodies, _, err := step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: 1})
+	if err != nil {
+		tb.Fatalf("import %s: %v", path, err)
+	}
+	return bodies
+}
+
+// BenchmarkTessellateBody measures full-body tessellation per committed fixture — the import-render hot
+// path. Run: go test -bench=TessellateBody ./kernel/ops
+func BenchmarkTessellateBody(b *testing.B) {
+	for _, name := range perfFixtures {
+		bodies := occBodies(b, name)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for _, body := range bodies {
+					TessellateBody(body, DefaultQuality())
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkConstrainedDelaunay measures the CDT at increasing boundary (constraint) + total sizes — to
+// catch any super-linear regression in its scaling, the failure mode behind the import freeze.
+func BenchmarkConstrainedDelaunay(b *testing.B) {
+	for _, n := range []int{32, 64, 128, 256} {
+		pts, loops := circleWithInteriorGrid(n)
+		b.Run(fmt.Sprintf("boundary%d", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				constrainedDelaunay(pts, loops)
+			}
+		})
+	}
+}
+
+// circleWithInteriorGrid builds a CDT input: an n-point circle boundary (n hard constraints) plus an
+// interior point grid — a stand-in for the dense trimmed-wall inputs the mesher feeds the CDT.
+func circleWithInteriorGrid(n int) (pts [][2]float64, loops [][]int) {
+	for i := 0; i < n; i++ {
+		a := 2 * stdmath.Pi * float64(i) / float64(n)
+		pts = append(pts, [2]float64{50 * stdmath.Cos(a), 50 * stdmath.Sin(a)})
+	}
+	loop := make([]int, n)
+	for i := range loop {
+		loop[i] = i
+	}
+	for y := -40; y <= 40; y += 8 {
+		for x := -40; x <= 40; x += 8 {
+			pts = append(pts, [2]float64{float64(x), float64(y)})
+		}
+	}
+	return pts, [][]int{loop}
+}
+
+// TestTessellationBudget is the accountability guard: tessellating every committed OCC fixture must stay
+// WELL under a generous wall-clock budget (~40× the tens-of-ms baseline). A pathological mesher
+// regression that affects these shapes fails the suite instead of degrading import silently. Generous
+// so it never flakes on a slow CI box — it catches catastrophic (10×+) regressions; the benchmarks
+// track micro ones. The heavy real model is guarded separately (see TestHeavyModelBudget).
+func TestTessellationBudget(t *testing.T) {
+	const budget = 2 * time.Second
+	bodies := map[string][]*topo.Body{}
+	for _, name := range perfFixtures {
+		bodies[name] = occBodies(t, name)
+	}
+	start := time.Now()
+	for _, bs := range bodies {
+		for _, body := range bs {
+			TessellateBody(body, DefaultQuality())
+		}
+	}
+	if d := time.Since(start); d > budget {
+		t.Errorf("tessellating the OCC fixtures took %v; budget %v — a mesher perf regression?", d, budget)
+	}
+}
+
+// TestHeavyModelBudget guards the heavy REAL model named by OBK_PERF_STEP (e.g. an imported EDF duct:
+// trimmed cones + freeform NURBS) — the case the committed fixtures don't reach, and exactly where the
+// O(n²) CDT regression bit (50 ms → 3.5 s). Skipped when OBK_PERF_STEP is unset, so set it locally:
+//
+//	OBK_PERF_STEP=/path/EDF.STEP go test -run TestHeavyModelBudget ./kernel/ops
+func TestHeavyModelBudget(t *testing.T) {
+	path := os.Getenv("OBK_PERF_STEP")
+	if path == "" {
+		t.Skip("set OBK_PERF_STEP=/path/model.step to run the heavy-model tessellation budget")
+	}
+	bodies := stepBodies(t, path)
+	const budget = 700 * time.Millisecond // ~14× the ~50 ms baseline; the metricWall freeze was 3.5 s
+	start := time.Now()
+	for _, body := range bodies {
+		TessellateBody(body, DefaultQuality())
+	}
+	if d := time.Since(start); d > budget {
+		t.Errorf("tessellating %s took %v; budget %v — a mesher perf regression?", path, d, budget)
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -100,24 +100,15 @@ func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.P
 	} else {
 		tris = earClip(outer2D)
 	}
-	m := &Mesh{}
-	for _, p := range pos {
+	// The ear-clip output is consistently oriented in the projection plane; patchMeshFrom keeps that
+	// winding and flips the whole patch once if it faces inward overall. Winding each triangle to its
+	// own vertex normals instead flips slivers inconsistently — the back-facing hole walls in Normal-Debug.
+	nrm := make([]math.Vector3, len(pos))
+	for i, p := range pos {
 		u, v := s.ParamAt(p)
-		m.addVertex(p, s.NormalAt(u, v))
+		nrm[i] = s.NormalAt(u, v)
 	}
-	for _, tri := range tris {
-		a, b, c := tri[0], tri[1], tri[2]
-		// Wind each triangle to agree with its OWN vertices' surface normals (what shading and
-		// mass-props read), not the surface normal at the triangle centroid: on a curved patch
-		// the flat-triangle centroid lies off the surface, so ParamAt(centroid) returns a wrong
-		// (u,v) and flips some triangles inconsistently — the back-facing patches seen in
-		// Normal-Debug. Averaging the three vertex normals is consistent for every triangle.
-		if windingOpposesNormals(pos[a], pos[b], pos[c], m.Normals[a], m.Normals[b], m.Normals[c]) {
-			b, c = c, b
-		}
-		m.addTriangle(a, b, c)
-	}
-	return m
+	return patchMeshFrom(pos, nrm, tris)
 }
 
 // patchProjection picks the 2D embedding to ear-clip a curved patch's boundary in. A B-spline

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -58,23 +58,21 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
-	return nonRectangularMesh(s, outer3D, holes3D, outerUV, holesUV, q)
+	return nonRectangularMesh(s, outer3D, holes3D, outerUV, holesUV)
 }
 
-// nonRectangularMesh meshes a non-iso-rectangular curved trim in the surface's OWN (u,v): a sphere,
-// cylinder or cone unrolls to a non-degenerate (u,v) here (toUVLoops already unwrapped the seam and
-// rejected pole-straddling loops), so a constrained-Delaunay triangulation with interior nodes
-// (gridPatchMesh) conforms to the exact boundary AND reads smooth — where the best-fit-plane ear-clip
-// (boundaryPatchMesh) tore a curved wall that lies in no single plane (the EDF trimmed-cylinder leaks).
-// A B-spline uses the same CDT without interior Steiner points (trimmedPatchMesh). gridPatchMesh's
-// manifold check still falls back to the plane ear-clip if a particular (u,v) defeats the CDT. A torus
-// keeps the ear-clip: its (u,v) is doubly periodic, so no single embedding is non-degenerate.
-func nonRectangularMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2, q Quality) *Mesh {
+// nonRectangularMesh meshes a non-iso-rectangular curved trim. A sphere cap is meshed over its own
+// (u,v) with interior nodes (gridPatchMesh) so it reads smooth; a B-spline uses the same CDT without
+// interior Steiner points (trimmedPatchMesh). Everything else — cylinder, cone, torus — keeps the
+// best-fit-plane boundary ear-clip (boundaryPatchMesh): it is coarse and can leave a small watertight
+// gap on a trimmed wall, but it is O(boundary) fast. (Routing cyl/cone through the (u,v) CDT closed
+// those gaps but made a few large cone trims pathologically slow — a 122-triangle face took 2.4s,
+// because the O(n²) CDT chokes on ~120 boundary constraints + interior nodes — freezing import. The
+// watertightness gain there is not worth the freeze; a faster constrained triangulation is the fix.)
+func nonRectangularMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
 	switch s.(type) {
 	case geom.Sphere:
-		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV) // isotropic (u,v): interior nodes for smoothness
-	case geom.Cylinder, geom.Cone:
-		return metricWallMesh(s, outer3D, holes3D, outerUV, holesUV, q) // anisotropic (u,v): metric-scaled CDT
+		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
 	case geom.BSplineSurface:
 		return trimmedPatchMesh(s, outer3D, holes3D)
 	}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -58,20 +58,24 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
-	return nonRectangularMesh(s, outer3D, holes3D, outerUV, holesUV)
+	return nonRectangularMesh(s, outer3D, holes3D, outerUV, holesUV, q)
 }
 
-// nonRectangularMesh meshes a non-iso-rectangular curved trim. A sphere cap is meshed over its own
-// (u,v) with interior nodes so the curved cap reads smooth (not the flat radiating fan a boundary
-// triangulation gives — the inner bell-mouth slivers). A B-spline patch is constrained-Delaunay
-// triangulated in its (u,v), robust to the slightly self-intersecting boundary ParamAt inversion
-// produces. Other analytic patches keep the boundary ear-clip: their (u,v) can be degenerate at a
-// pole/seam and a wrapping wall folds onto itself in any single embedding.
-func nonRectangularMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
-	if _, isSphere := s.(geom.Sphere); isSphere {
-		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
-	}
-	if _, isSpline := s.(geom.BSplineSurface); isSpline {
+// nonRectangularMesh meshes a non-iso-rectangular curved trim in the surface's OWN (u,v): a sphere,
+// cylinder or cone unrolls to a non-degenerate (u,v) here (toUVLoops already unwrapped the seam and
+// rejected pole-straddling loops), so a constrained-Delaunay triangulation with interior nodes
+// (gridPatchMesh) conforms to the exact boundary AND reads smooth — where the best-fit-plane ear-clip
+// (boundaryPatchMesh) tore a curved wall that lies in no single plane (the EDF trimmed-cylinder leaks).
+// A B-spline uses the same CDT without interior Steiner points (trimmedPatchMesh). gridPatchMesh's
+// manifold check still falls back to the plane ear-clip if a particular (u,v) defeats the CDT. A torus
+// keeps the ear-clip: its (u,v) is doubly periodic, so no single embedding is non-degenerate.
+func nonRectangularMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2, q Quality) *Mesh {
+	switch s.(type) {
+	case geom.Sphere:
+		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV) // isotropic (u,v): interior nodes for smoothness
+	case geom.Cylinder, geom.Cone:
+		return metricWallMesh(s, outer3D, holes3D, outerUV, holesUV, q) // anisotropic (u,v): metric-scaled CDT
+	case geom.BSplineSurface:
 		return trimmedPatchMesh(s, outer3D, holes3D)
 	}
 	return boundaryPatchMesh(s, outer3D, holes3D)


### PR DESCRIPTION
## What
Phase-4 work on **M25 import healing** (PBI-330), targeting watertight curved-face tessellation:

- **Consistent NURBS patch winding** (`67100e6`): `patchMeshFrom` now keeps the CDT's consistent winding plus one global flip, instead of re-winding per triangle — which was producing back-facing/folded freeform triangles. Corner/seam back-faces are gone.
- **Consistent hole winding** (`591f860`): `boundaryPatchMesh` routes through `patchMeshFrom`, fixing inverted holes.
- **Reverted the metric-scaled (u,v)-CDT routing** for trimmed cyl/cone walls (`3b36089`, reverting `e4fdd62`): it closed body2 but froze import (one cone face 2.4s, full EDF 3.55s). The watertightness tail needs a faster constrained triangulation, not the O(n²) CDT.
- **Perf guards + benchmarks** (`8182154`): `TestHeavyModelBudget` (gated on `OBK_PERF_STEP`, EDF < 700ms — catches the 3.5s freeze), `TestTessellationBudget` (fixtures < 2s), plus benchmarks.

## Why
Imported freeform faces were rendering folded/back-facing because of per-triangle re-winding. This lands the winding fix and installs perf guards so the next attempt at the watertightness tail can't silently reintroduce the import freeze.

## Tests
- `go build ./kernel/...`, `go vet ./kernel/ops/...` clean.
- Full kernel suite green (`go test ./kernel/...`).
- `OBK_PERF_STEP=…/EDF.STEP go test -run TestHeavyModelBudget ./kernel/ops` → 74ms, well under the 700ms budget.

Files are disjoint from `feat/mcp-viewport-probing` (kernel/ops + PBI docs only), so the two merge to develop without conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)