### PR TITLE
feat: headless viewport probing — host-side capture + debug renders

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -80,6 +80,9 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewListDisplayModes] = listDisplayModes
 	r.handlers[wire.MethodViewGetCamera] = getCamera
 	r.handlers[wire.MethodViewSetCamera] = setCamera
+	r.handlers[wire.MethodViewportCapture] = captureViewport
+	r.handlers[wire.MethodViewportSetNormalDebug] = setNormalDebug
+	r.handlers[wire.MethodViewportSetMeshColors] = setMeshColors
 	r.handlers[wire.MethodInteractionState] = interactionState
 	r.handlers[wire.MethodInteractionSetNotice] = interactionSetNotice
 	r.handlers[wire.MethodViewsList] = listViews

--- a/addin/router/viewport.go
+++ b/addin/router/viewport.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"path/filepath"
+
+	"oblikovati/api/wire"
+	"oblikovati/app"
+)
+
+// defaultCapturePath is where viewport.capture writes when no Path is given — distinct from the
+// Tools ▸ Save Viewport PNG path so a programmatic capture never clobbers a manual one.
+var defaultCapturePath = filepath.Join("/tmp", "oblikovati-capture.png")
+
+// captureViewport requests a PNG of the active document's viewport framebuffer
+// (wire.MethodViewportCapture). It only FLAGS the request — the head writes the file after the next
+// frame renders, so the image is exactly what is on screen — and returns the path it will write plus
+// the current viewport pixel size, so the caller can poll the path (or its mtime) for completion.
+func captureViewport(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CaptureViewportArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	path := in.Path
+	if path == "" {
+		path = defaultCapturePath
+	}
+	s.RequestViewportCapture(path)
+	cam := s.Camera()
+	return json.Marshal(wire.CaptureViewportResult{Path: path, Width: cam.Width, Height: cam.Height})
+}
+
+// setNormalDebug turns the viewport's normal-debug render on/off (wire.MethodViewportSetNormalDebug);
+// the head applies it on the next frame.
+func setNormalDebug(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetNormalDebugArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	s.SetNormalDebug(in.On)
+	return json.Marshal(wire.NormalDebugResult(in))
+}
+
+// setMeshColors turns the mesh-debug-colors render on/off (wire.MethodViewportSetMeshColors); the
+// head's draw-list cache rebuilds with per-face/per-triangle colors on the next frame.
+func setMeshColors(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetMeshColorsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	s.SetMeshColors(in.On, in.PerTriangle)
+	return json.Marshal(wire.MeshColorsResult(in))
+}

--- a/app/session.go
+++ b/app/session.go
@@ -61,6 +61,10 @@ type Session struct {
 	lightingPanelOpen  bool                     // the View ▸ Lighting settings panel is open
 	loadEnvRequested   bool                     // a "Load HDR…" was requested; the head opens the file dialog
 	scriptConsoleOpen  bool                     // the Manage ▸ Scripts ▸ Script Console panel is open
+	capturePath        string                   // a requested viewport PNG capture path; the head writes it after render
+	normalDebug        bool                     // viewport normal-debug render (front green / back red); head reads each frame
+	meshColors         bool                     // viewport mesh-debug-colors render (each face/triangle a distinct color)
+	meshColorsPerTri   bool                     // when meshColors: color per TRIANGLE (else per B-rep face)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/app/viewport_capture.go
+++ b/app/viewport_capture.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Viewport capture is the headless "screenshot" seam: the viewport.capture wire method (and the MCP
+// bridge that exposes it) flags a path here, and the head's render loop writes the framebuffer to it
+// AFTER the frame renders — so the PNG is exactly what is on screen. One-shot, mirroring the Tools ▸
+// Save Viewport PNG menu action; lets an add-in / Claude grab the rendered image without a human.
+
+// RequestViewportCapture flags that the viewport framebuffer should be written to a PNG at path.
+func (s *Session) RequestViewportCapture(path string) { s.capturePath = path }
+
+// TakeViewportCapture returns the pending capture path and clears it (ok=false when none pending).
+func (s *Session) TakeViewportCapture() (path string, ok bool) {
+	if s.capturePath == "" {
+		return "", false
+	}
+	path, s.capturePath = s.capturePath, ""
+	return path, true
+}
+
+// SetNormalDebug enables/disables the viewport's normal-debug render (front-facing GREEN, back-facing
+// RED) — the headless way to inspect winding/orientation. The head applies it on the next frame.
+func (s *Session) SetNormalDebug(on bool) { s.normalDebug = on }
+
+// NormalDebug reports whether normal-debug render is enabled.
+func (s *Session) NormalDebug() bool { return s.normalDebug }
+
+// SetMeshColors enables/disables the viewport's mesh-debug-colors render — each B-rep face (or each
+// TRIANGLE when perTriangle) painted a distinct, index-derived color, so a rendered region maps back
+// to a face/triangle index in the mesh data.
+func (s *Session) SetMeshColors(on, perTriangle bool) {
+	s.meshColors, s.meshColorsPerTri = on, perTriangle
+}
+
+// MeshColors reports whether mesh-debug-colors render is enabled, and whether it colors per triangle.
+func (s *Session) MeshColors() (on, perTriangle bool) { return s.meshColors, s.meshColorsPerTri }

--- a/architecture/testing/02-live-viewport-probing.md
+++ b/architecture/testing/02-live-viewport-probing.md
@@ -1,0 +1,71 @@
+# Live viewport probing (import → render → capture → analyse)
+
+How to drive the **running** application headlessly to import a CAD file, frame it, switch on a
+debug render, capture the viewport framebuffer as a PNG, and inspect it — the loop for diagnosing
+tessellation/render defects (back-faces, cracks, wrong face sense) without a human at the screen.
+
+It runs over the **MCP bridge** add-in, which serves the `api/wire` surface as MCP tools on
+`http://127.0.0.1:7800/mcp`. The relevant tools (all forward to wire methods):
+
+| tool | wire method | what it does |
+|---|---|---|
+| `import_file` | `documents.import` | import STEP/STL/OBJ/3MF into the active part |
+| `execute_command {id:"View.Home"}` | `commands.execute` | frame the model, default isometric (`View.ZoomAll` = fit, keep angle) |
+| `set_camera {eye,target,up,fov}` | `view.setCamera` | exact angle — **keep fixed across probes for comparable captures** |
+| `set_normal_debug {on}` | `viewport.setNormalDebug` | front-facing **green** / back-facing **red** (winding / flipped-normal defects) |
+| `set_face_colors {on}` | `viewport.setFaceColors` | every B-rep face a distinct color = `faceDebugColor(globalFaceIndex)` — map a region back to a face index |
+| `capture_viewport {path}` | `viewport.capture` | write the framebuffer to a PNG (host writes it the next frame, **atomically**) and return it as an MCP image |
+
+## The loop
+
+1. **Build the app** (the head binary links the kernel changes you're testing):
+
+   ```sh
+   cd Oblikovati/head && OBK_ADDINS_DIR=$(pwd)/addins go build -o oblikovati-head ./cmd/oblikovati-head
+   ```
+
+2. **Build + install the MCP bridge** into the app's add-in folder (`make install` builds the
+   c-shared `.so` and copies it + `manifest.json` to `Oblikovati/head/addins`):
+
+   ```sh
+   cd Oblikovati.AddIns/oblikovati-mcp-bridge && make install
+   ```
+
+3. **Restart the app** so it loads the rebuilt head + the new `.so`. It serves MCP on `:7800`:
+
+   ```sh
+   pkill -f '[o]blikovati-head'; sleep 2
+   cd Oblikovati/head && setsid env OBK_ADDINS_DIR=$(pwd)/addins ./oblikovati-head >/tmp/obk-head.log 2>&1 </dev/null &
+   sleep 10 && ss -ltn | grep -q :7800 && echo "MCP up"
+   ```
+
+4. **Import + frame + debug-render + capture** in one shot with the `mcpshot` driver (it closes all
+   docs, creates a part, imports, frames, sets the debug mode, captures):
+
+   ```sh
+   cd Oblikovati.AddIns/oblikovati-mcp-bridge && go build -o mcpshot ./cmd/mcpshot
+   # normal-debug (default): front green / back red
+   ./mcpshot --file /path/EDF.STEP --out /tmp/oblikovati-capture.png
+   # face-index colors instead:
+   ./mcpshot --file /path/EDF.STEP --faces=true --normals=false
+   # a FIXED angle for repeatable comparison across probes:
+   ./mcpshot --file /path/EDF.STEP --eye=120,-120,120 --target=25,0,25
+   ```
+
+5. **Analyse** the PNG — read `/tmp/oblikovati-capture.png` (it is a real local file, atomically
+   written, so a reader never sees it mid-write).
+
+## Notes
+
+- **Consistent angles.** The default frames with `View.Home`; for A/B comparisons across code
+  changes pass the same `--eye/--target` every time so the captures are pixel-comparable. Record the
+  angles you settle on in the probe command (or a tiny wrapper script) so a later session reproduces them.
+- **Camera too close on a bare import.** A programmatic `import_file` does NOT auto-frame (the GUI's
+  File▸Import does); always frame with `--home` (or `set_camera`) before capturing.
+- **The viewport tessellation cache** (`head/ui/viewport_cache.go`, keyed on `ModelGeometryVersion`
+  + style + visible bodies + face-index flag) means an expensive tessellation runs once, not per
+  frame — so a slow capture points at the tessellation cost itself, not the cache. (A pathological
+  mesher can still freeze the one tessellation on import / on any cache-invalidating change.)
+- **Headless E2E vs live.** The bridge's `go test ./bridge` E2E spins up the host in-process and is
+  the place to assert *model* behaviour; the *render* (framebuffer) only exists in the live windowed
+  app, so `capture_viewport` must be probed against a running `oblikovati-head`, not the E2E test.

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -24,7 +24,7 @@ import (
 // the scene — rebuilt from the model each frame (renderer.BuildDrawList) and projected
 // with the navigated camera — always reflects current model and view state (ADR-0004).
 func drawViewportPanel(win *native.Window, s *app.Session) {
-	win.SetViewportNormalDebug(normalDebugOn) // Tools ▸ Normal Debug (front green / back red)
+	win.SetViewportNormalDebug(normalDebugOn || s.NormalDebug()) // Tools ▸ Normal Debug, or viewport.setNormalDebug
 	if native.Begin("Viewport") {
 		drawDocumentTabs(s)
 		// View configuration (layout, new/close view) lives on the View ribbon tab's

--- a/head/ui/viewport_cache.go
+++ b/head/ui/viewport_cache.go
@@ -33,6 +33,9 @@ var bodyGeometryCache struct {
 // place) and the overlays (which append) never corrupt the cached list.
 func cachedBodyDrawList(s *app.Session, cam scene.Camera) renderer.DrawList {
 	build := func() renderer.DrawList {
+		if on, perTri := s.MeshColors(); on { // each face/triangle a distinct color (viewport.setMeshColors)
+			return renderer.BuildDrawListMeshColors(activeBodies(s), cam, ops.DefaultQuality(), perTri)
+		}
 		return renderer.BuildDrawListStyled(activeBodies(s), cam, ops.DefaultQuality(), s.SurfaceLookup(), s.VisualStyle())
 	}
 	key := bodyGeometryKey(s)
@@ -57,6 +60,13 @@ func bodyGeometryKey(s *app.Session) string {
 	b.WriteString(part.ModelGeometryVersion())
 	b.WriteByte('|')
 	b.WriteString(strconv.Itoa(int(s.VisualStyle())))
+	if on, perTri := s.MeshColors(); on { // mesh-debug-colors uses a different builder; key it apart
+		if perTri {
+			b.WriteString("|tricolors")
+		} else {
+			b.WriteString("|facecolors")
+		}
+	}
 	for _, body := range s.VisibleBodies() {
 		b.WriteByte('|')
 		b.WriteString(strconv.FormatUint(body.ID(), 10))

--- a/head/ui/viewport_screenshot.go
+++ b/head/ui/viewport_screenshot.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	"os"
+
 	"oblikovati/app"
 	"oblikovati/head/internal/native"
 )
@@ -20,6 +22,15 @@ var screenshotRequested bool
 // the end of drawViewportPanel — AFTER the viewport has rendered this frame, so the offscreen
 // image readback reflects exactly what is on screen.
 func serviceScreenshot(win *native.Window, s *app.Session) {
+	if path, ok := s.TakeViewportCapture(); ok { // viewport.capture wire method / MCP bridge
+		// Write atomically (temp + rename) so a remote reader polling the path never sees the PNG
+		// mid-write (it was reading a 33-byte header-only file before the IDAT landed).
+		if tmp := path + ".tmp"; win.SaveViewportPNG(tmp) != nil {
+			fileNotice(s, "viewport.capture failed to render")
+		} else if err := os.Rename(tmp, path); err != nil {
+			fileNotice(s, "viewport.capture failed: %v", err)
+		}
+	}
 	if !screenshotRequested {
 		return
 	}

--- a/renderer/mesh_colors_debug.go
+++ b/renderer/mesh_colors_debug.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package renderer
+
+import (
+	stdmath "math"
+
+	"oblikovati/kernel/ops"
+	"oblikovati/kernel/topo"
+	"oblikovati/math"
+	"oblikovati/scene"
+)
+
+// BuildDrawListMeshColors builds a SHADED draw list where each mesh primitive is painted a distinct,
+// index-derived color — the "mesh debug colors" render. It lets a viewer map a rendered region back to
+// the mesh data: a defect you SEE (a back-face, a crack) to the primitive you diagnose in code.
+//   - perTriangle=false: each B-rep FACE a color = meshDebugColor(globalFaceIndex). Face N reproducible.
+//   - perTriangle=true:  each TRIANGLE a color = meshDebugColor(globalTriIndex). Triangles never share a
+//     vertex (so the color is per-triangle), which finds an individual triangle in the mesh.
+//
+// The global index runs across all bodies in face/triangle order, so a primitive's color is stable.
+func BuildDrawListMeshColors(bodies []*topo.Body, cam scene.Camera, q ops.Quality, perTriangle bool) DrawList {
+	shading := PassSetFor(ShadedWithEdges).Faces
+	var items []DrawItem
+	index := 0
+	for _, b := range bodies {
+		if !visible(cam, b.RangeBox()) {
+			index += primitiveCount(b, q, perTriangle) // keep the global index stable under cull
+			continue
+		}
+		if it, ok := meshColorItem(b, q, perTriangle, shading, &index); ok {
+			items = append(items, it)
+		}
+	}
+	return DrawList{Items: items}
+}
+
+// meshColorItem accumulates one body's per-face/per-triangle colored geometry into a single draw item,
+// advancing the running primitive index.
+func meshColorItem(b *topo.Body, q ops.Quality, perTriangle bool, shading Shading, index *int) (DrawItem, bool) {
+	var pos []math.Point3
+	var nrm []math.Vector3
+	var cols [][4]float32
+	var idx []int
+	for _, f := range b.Faces() {
+		m := ops.TessellateFace(f, q)
+		if perTriangle {
+			addTriangleColored(&pos, &nrm, &cols, &idx, m, index)
+		} else {
+			addFaceColored(&pos, &nrm, &cols, &idx, m, meshDebugColor(*index))
+			*index++
+		}
+	}
+	if len(idx) == 0 {
+		return DrawItem{}, false
+	}
+	return DrawItem{
+		Primitive: Triangles, Positions: pos, Normals: nrm, Indices: idx, Colors: cols,
+		Color: defaultSurfaceColor, Roughness: 0.6, Opacity: 1, Shading: shading, ObjectID: b.ID(),
+	}, true
+}
+
+// addFaceColored appends a face's mesh with one shared color for all its vertices.
+func addFaceColored(pos *[]math.Point3, nrm *[]math.Vector3, cols *[][4]float32, idx *[]int, m *ops.Mesh, c [4]float32) {
+	base := len(*pos)
+	for i := range m.Positions {
+		*pos, *nrm, *cols = append(*pos, m.Positions[i]), append(*nrm, m.Normals[i]), append(*cols, c)
+	}
+	for _, vi := range m.Indices {
+		*idx = append(*idx, base+vi)
+	}
+}
+
+// addTriangleColored appends a face's mesh with one color PER TRIANGLE — each triangle gets its own
+// three (un-shared) vertices so no two triangles share a color.
+func addTriangleColored(pos *[]math.Point3, nrm *[]math.Vector3, cols *[][4]float32, idx *[]int, m *ops.Mesh, index *int) {
+	for t := 0; 3*t+2 < len(m.Indices); t++ {
+		c := meshDebugColor(*index)
+		*index++
+		for k := 0; k < 3; k++ {
+			v := m.Indices[3*t+k]
+			*idx = append(*idx, len(*pos))
+			*pos, *nrm, *cols = append(*pos, m.Positions[v]), append(*nrm, m.Normals[v]), append(*cols, c)
+		}
+	}
+}
+
+// primitiveCount returns how many face/triangle indices a body consumes, so the running index stays
+// aligned when the body is frustum-culled.
+func primitiveCount(b *topo.Body, q ops.Quality, perTriangle bool) int {
+	if !perTriangle {
+		return len(b.Faces())
+	}
+	n := 0
+	for _, f := range b.Faces() {
+		n += ops.TessellateFace(f, q).TriangleCount()
+	}
+	return n
+}
+
+// meshDebugColor maps a primitive index to a distinct, reproducible RGBA. Hues are spaced by the
+// golden ratio so consecutive primitives get well-separated colors; mid saturation/value keeps them
+// readable.
+func meshDebugColor(i int) [4]float32 {
+	hue := stdmath.Mod(float64(i)*0.61803398875, 1.0)
+	r, g, b := hsvToRGB(hue, 0.62, 0.92)
+	return [4]float32{float32(r), float32(g), float32(b), 1}
+}
+
+// hsvToRGB converts h,s,v in [0,1] to r,g,b in [0,1].
+func hsvToRGB(h, s, v float64) (r, g, b float64) {
+	i := stdmath.Floor(h * 6)
+	f := h*6 - i
+	p := v * (1 - s)
+	q := v * (1 - f*s)
+	t := v * (1 - (1-f)*s)
+	switch int(i) % 6 {
+	case 0:
+		return v, t, p
+	case 1:
+		return q, v, p
+	case 2:
+		return p, v, t
+	case 3:
+		return p, q, v
+	case 4:
+		return t, p, v
+	default:
+		return v, p, q
+	}
+}


### PR DESCRIPTION
## What
Implements the **host side** of an import→render→capture loop so an add-in / the MCP bridge can drive the live app and *see* the result with no human at the screen. This is the source-side implementation of the `viewport.*` wire contract that landed in Oblikovati.API#28.

- **`viewport.capture`** (`addin/router/viewport.go`, `app/viewport_capture.go`): flags a PNG path the head writes *after* the next frame, atomic temp+rename so a remote reader never sees a half-written file; serviced in `head/ui/viewport_screenshot.go` alongside the existing menu item.
- **`viewport.setNormalDebug`**: Session-driven front-green / back-red facing render (was a GUI-only menu toggle), applied each frame in `chrome_viewport.go`.
- **`viewport.setMeshColors {on, perTriangle}`**: a new mesh-debug-colors render (`renderer/mesh_colors_debug.go`) painting each B-rep face — or each triangle — a distinct golden-ratio-spaced, index-reproducible color, so a captured pixel maps back to a face/triangle index. Built via the existing per-vertex Colors path (no shader change); the viewport cache keys on the mode.

Runbook: `architecture/testing/02-live-viewport-probing.md`.

## Why
This unlocks the live-app visual-probing workflow (the `mcpshot` driver in the bridge): import a STEP, switch to a debug render, capture, and read the PNG back — the foundation for diagnosing the EDF tessellation defects against the running renderer instead of in-proc tests only.

## Tests
- `go build ./...` clean.
- `go test ./app/... ./addin/router/... ./renderer/... ./head/ui/...` all green.
- Disjoint from `feat/m25-pbi330-phase4-nurbs-watertight` (addin/router + app + head + renderer + architecture only), so the two merge to develop without conflicting.

Depends on Oblikovati.API#28 (merged) for the `wire`/`client` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)