### PR TITLE
M25 PBI-330: continuous pcurve march — imported-NURBS watertightness

### DIFF
--- a/kernel/ops/nurbs_pcurve_mesh.go
+++ b/kernel/ops/nurbs_pcurve_mesh.go
@@ -123,6 +123,7 @@ func facePcurveLoops(f *topo.Face, q Quality) (outerUV []math.Point2, outer3D []
 }
 
 func concatLoopPcurve(s geom.Surface, l *topo.Loop, q Quality) (uv []math.Point2, p3 []math.Point3) {
+	needProject := false
 	for _, u := range l.EdgeUses() {
 		pts := discretizeEdge(u.Edge(), q)
 		if u.Reversed() {
@@ -130,6 +131,7 @@ func concatLoopPcurve(s geom.Surface, l *topo.Loop, q Quality) (uv []math.Point2
 		}
 		pc := u.Pcurve()
 		if len(pc) != len(pts) {
+			needProject = true
 			pc = geom.ProjectCurveToSurface(s, pts) // no/stale pcurve: reconstruct on the fly
 		}
 		if len(p3) > 0 {
@@ -140,6 +142,16 @@ func concatLoopPcurve(s geom.Surface, l *topo.Loop, q Quality) (uv []math.Point2
 	}
 	if n := len(p3); n > 1 && p3[0].DistanceTo(p3[n-1]) < weldPointTol {
 		uv, p3 = uv[:n-1], p3[:n-1]
+	}
+	// Per-edge projection re-seeds a fresh GLOBAL closest point at each edge's start; on a self-proximal
+	// NURBS (the EDF bell-mouth lip) that start can snap to the wrong sheet, so the concatenated (u,v)
+	// loop self-intersects — and constrainedDelaunay then silently drops those crossing boundary
+	// constraints (insertConstraint gives up), cracking the face against its neighbours. When any edge
+	// had to be projected, re-derive the WHOLE loop's (u,v) in ONE continuous march (each point seeded
+	// from the previous, so it stays on one sheet across edge joins). Stored pcurves (a healed body,
+	// every edge with a matching pcurve) are kept verbatim.
+	if needProject {
+		uv = geom.ProjectCurveToSurface(s, p3)
 	}
 	return uv, p3
 }

--- a/kernel/ops/watertight_test.go
+++ b/kernel/ops/watertight_test.go
@@ -3,6 +3,7 @@
 package ops
 
 import (
+	"os"
 	"testing"
 
 	"oblikovati/kernel/brep"
@@ -64,5 +65,28 @@ func TestCleanCurvedSolidIsWatertight(t *testing.T) {
 	mesh, _ := TessellateBody(cyl, DefaultQuality())
 	if free := freeEdgeCount(mesh); free != 0 {
 		t.Errorf("clean cylinder solid tessellated with %d free edges; want 0 (watertight)", free)
+	}
+}
+
+// TestImportedNurbsDuctWatertight guards the M25 fix that made imported NURBS faces conform to their
+// neighbours: concatLoopPcurve projects each boundary loop's pcurve in ONE continuous march, so a
+// self-proximal NURBS face (the EDF bell-mouth lip) no longer lands edge-starts on the wrong sheet,
+// self-intersect in (u,v) and make the CDT silently drop boundary constraints — which used to crack
+// the duct body (28 free edges) against its cone/cylinder/plane neighbours. Env-gated on the heavy
+// model (not a committed fixture; same OBK_PERF_STEP convention as TestHeavyModelBudget). Per-body free
+// edges before the fix: 4/0/4/28/0/0; after: 4/0/4/0/0/0 — so no body may exceed a small bound, which
+// regresses hard (to 28) if per-edge pcurve projection returns. The residual 4+4 on the auxiliary
+// bodies is a separate analytic grid-conformance issue (not this fix).
+func TestImportedNurbsDuctWatertight(t *testing.T) {
+	path := os.Getenv("OBK_PERF_STEP")
+	if path == "" {
+		t.Skip("set OBK_PERF_STEP=/path/EDF.STEP to run the imported-NURBS watertightness guard")
+	}
+	for i, body := range stepBodies(t, path) {
+		mesh, _ := TessellateBody(body, DefaultQuality())
+		if free := freeEdgeCount(mesh); free > 8 {
+			t.Errorf("imported body %d tessellated with %d free edges; want ≤8 "+
+				"(a NURBS-face pcurve conformance regression cracks the duct body to ~28)", i, free)
+		}
 	}
 }


### PR DESCRIPTION
## What
Fixes the imported-NURBS watertightness tail on the EDF duct: **body3 went from 28 free edges to 0**, the bell-mouth throat now renders fully green (was a red back-face wedge), at no tessellation-time cost (77 ms, no CDT freeze).

## Why / root cause
The duct imports as a topologically closed solid (every edge shared by 2 faces) yet tessellated leaky. Diagnosed by per-shared-edge segment comparison: the leaks were **cross-face** and **every one was on a B-spline face** (`face #0`, the bell-mouth lip) that dropped ~23 of its 321 boundary segments its cone/cylinder/plane neighbours emitted.

`concatLoopPcurve` reconstructed each boundary edge's pcurve with a **separate** `ProjectCurveToSurface` call, which re-seeds a fresh **global** closest-point at every edge's first sample. On a self-proximal NURBS face (the lip curls back near itself) that seed snaps to the **wrong sheet** at an edge join, so the concatenated `(u,v)` loop **self-intersects** (face #0: 3 self-intersections; the conforming faces: 0). `constrainedDelaunay` then can't recover the crossing boundary constraints (`insertConstraint` silently gives up) and `extractDomain` leaks across them.

## Fix
When any edge lacked a stored pcurve, re-derive the whole loop's `(u,v)` in **one continuous march** (each point seeded from the previous) so it stays on a single sheet across edge joins. Stored pcurves (a healed body) are kept verbatim. 12-line change in `concatLoopPcurve`.

## Verification
- EDF `body3`: 28 → **0** free edges; self-intersections 3 → 0; total EDF 36 → 8 (residual 4+4 on `body0`/`body2` is a separate analytic grid-conformance issue, not this path).
- **Live**: rebuilt head, re-imported EDF — the throat red wedge is gone, duct renders fully green, throat tessellation dense/clean.
- Tessellation time unchanged (77 ms; the reverted metric-CDT route had frozen at 3.5 s).
- Full kernel suite + OCC oracle green; `gofmt`/`vet`/`golangci-lint` clean.

## Regression guard
`TestImportedNurbsDuctWatertight` (env-gated on `OBK_PERF_STEP`, the EDF model, same convention as `TestHeavyModelBudget`) asserts no imported body exceeds 8 free edges. Confirmed it **fails** (body3 → 32) when the per-edge projection is restored, and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)