### PR TITLE
M25 PBI-330: cross-face conformance repair for trimmed cyl/cone walls

### DIFF
--- a/kernel/ops/conformance_repair.go
+++ b/kernel/ops/conformance_repair.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati/kernel/geom"
+	"oblikovati/kernel/topo"
+	"oblikovati/math"
+)
+
+// Cross-face conformance repair (M25 PBI-330). A trimmed cylinder/cone wall meshed by the best-fit-plane
+// ear-clip (boundaryPatchMesh) can ABSORB a near-collinear point of a rim arc — a cyl/cone rim is an
+// iso-curve, nearly straight once projected — so it emits one fewer segment than its planar neighbour,
+// which keeps the arc curved and emits all of them. The two faces then disagree on the shared edge and
+// leave an unpaired (free) edge: a visible crack. This pass detects those free edges and re-meshes ONLY
+// the cyl/cone faces touching them (and their cyl/cone neighbours) with a BOUNDARY-ONLY constrained
+// Delaunay in metric (u,v), which keeps every boundary segment as a constraint (so it conforms) and
+// never folds (metric (u,v) is developable). A watertight body has no free edges, so it is left
+// completely untouched — no regression on bodies the ear-clip already meshes correctly. It deliberately
+// does NOT re-mesh planes: re-triangulating a planar multi-hole face cascades new mismatches, so a crack
+// where the PLANE is the absorber is left to a future pass.
+func conformCylConeFaces(faces []*topo.Face, idx map[*topo.Face]int, fm []*Mesh, q Quality) {
+	free := freeSegments(fm)
+	if len(free) == 0 {
+		return // watertight body: nothing to repair (and the hot path skips the weld below)
+	}
+	toFix := map[int]bool{}
+	for i, f := range faces {
+		if !meshTouchesFree(fm[i], free) {
+			continue
+		}
+		if isCylOrCone(f.Geometry()) {
+			toFix[i] = true
+		}
+		// The face MISSING the segment is the topo neighbour across the shared edge; re-mesh it too.
+		for _, e := range f.Edges() {
+			for _, nf := range e.Faces() {
+				if j, ok := idx[nf]; ok && j != i && isCylOrCone(nf.Geometry()) {
+					toFix[j] = true
+				}
+			}
+		}
+	}
+	for j := range toFix {
+		if m := conformingCylConeMesh(faces[j], q); m != nil {
+			fm[j] = m
+		}
+	}
+}
+
+func isCylOrCone(s geom.Surface) bool {
+	switch s.(type) {
+	case geom.Cylinder, geom.Cone:
+		return true
+	}
+	return false
+}
+
+// conformingCylConeMesh re-meshes a non-rectangular cyl/cone trim with a boundary-only metric-(u,v)
+// constrained Delaunay, the conforming alternative to the plane ear-clip. nil if not applicable (the
+// trim is a full periodic band / apex cap / iso-rectangle handled watertight by other meshers, or its
+// (u,v) degenerates).
+func conformingCylConeMesh(f *topo.Face, q Quality) *Mesh {
+	s := f.Geometry()
+	outer3D := faceOuterBoundary(f, q)
+	holes3D := faceHoleBoundaries(f, q)
+	if len(outer3D) < 3 {
+		return nil
+	}
+	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
+	if !ok {
+		return nil
+	}
+	if _, _, isRect := isoRectangleGrid(outerUV); isRect && len(holesUV) == 0 {
+		return nil // an iso-rectangle is already watertight via structuredGridMesh
+	}
+	su, sv := metricScale(s)
+	b := newPatchBuilder(s, su, sv)
+	loops := [][]int{b.addLoop(outer3D, outerUV)}
+	for i := range holes3D {
+		loops = append(loops, b.addLoop(holes3D[i], holesUV[i]))
+	}
+	tris := constrainedDelaunay(b.scaled, loops)
+	if len(tris) == 0 {
+		return nil
+	}
+	return patchMeshFrom(b.pos, b.nrm, tris)
+}
+
+// segKey is the collision-free, order-independent key of a welded segment: the quantized (1 µm grid,
+// matching freeEdgeCount) coordinates of both endpoints, the lexicographically smaller one first.
+type segKey [6]int64
+
+// freeSegments returns the welded segments that exactly ONE triangle uses across all face meshes — the
+// cross-face cracks (an interior manifold edge is used by two).
+func freeSegments(fm []*Mesh) map[segKey]bool {
+	deg := map[segKey]int{}
+	for _, m := range fm {
+		for t := 0; t+2 < len(m.Indices); t += 3 {
+			for k := 0; k < 3; k++ {
+				deg[weldSeg(m.Positions[m.Indices[t+k]], m.Positions[m.Indices[t+(k+1)%3]])]++
+			}
+		}
+	}
+	free := map[segKey]bool{}
+	for e, n := range deg {
+		if n == 1 {
+			free[e] = true
+		}
+	}
+	return free
+}
+
+// meshTouchesFree reports whether any edge of m is one of the free (unpaired) segments.
+func meshTouchesFree(m *Mesh, free map[segKey]bool) bool {
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		for k := 0; k < 3; k++ {
+			if free[weldSeg(m.Positions[m.Indices[t+k]], m.Positions[m.Indices[t+(k+1)%3]])] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func weldSeg(a, b math.Point3) segKey {
+	ka, kb := quantCoord(a), quantCoord(b)
+	if ka[0] > kb[0] || (ka[0] == kb[0] && (ka[1] > kb[1] || (ka[1] == kb[1] && ka[2] > kb[2]))) {
+		ka, kb = kb, ka
+	}
+	return segKey{ka[0], ka[1], ka[2], kb[0], kb[1], kb[2]}
+}
+
+func quantCoord(p math.Point3) [3]int64 {
+	v := math.Point3{}.VectorTo(p)
+	return [3]int64{
+		int64(float64(v.Dot(math.Vector3{X: 1})) * 1e6),
+		int64(float64(v.Dot(math.Vector3{Y: 1})) * 1e6),
+		int64(float64(v.Dot(math.Vector3{Z: 1})) * 1e6),
+	}
+}

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -76,11 +76,22 @@ func TessellateEdge(e *topo.Edge, q Quality) []math.Point3 {
 	return pts
 }
 
-// TessellateBody facets every face into one mesh and every edge into a polyline.
+// TessellateBody facets every face into one mesh and every edge into a polyline. After the per-face
+// meshing it runs a cross-face conformance repair (conformCylConeFaces) that re-meshes only the
+// cyl/cone faces touching a crack so a trimmed wall conforms to its planar neighbour; a watertight body
+// has no cracks and is untouched.
 func TessellateBody(b *topo.Body, q Quality) (*Mesh, [][]math.Point3) {
+	faces := b.Faces()
+	fm := make([]*Mesh, len(faces))
+	idx := make(map[*topo.Face]int, len(faces))
+	for i, f := range faces {
+		fm[i] = TessellateFace(f, q)
+		idx[f] = i
+	}
+	conformCylConeFaces(faces, idx, fm, q)
 	mesh := &Mesh{}
-	for _, f := range b.Faces() {
-		mergeMesh(mesh, TessellateFace(f, q))
+	for _, m := range fm {
+		mergeMesh(mesh, m)
 	}
 	var edges [][]math.Point3
 	for _, e := range b.Edges() {

--- a/kernel/ops/watertight_test.go
+++ b/kernel/ops/watertight_test.go
@@ -73,20 +73,28 @@ func TestCleanCurvedSolidIsWatertight(t *testing.T) {
 // self-proximal NURBS face (the EDF bell-mouth lip) no longer lands edge-starts on the wrong sheet,
 // self-intersect in (u,v) and make the CDT silently drop boundary constraints — which used to crack
 // the duct body (28 free edges) against its cone/cylinder/plane neighbours. Env-gated on the heavy
-// model (not a committed fixture; same OBK_PERF_STEP convention as TestHeavyModelBudget). Per-body free
-// edges before the fix: 4/0/4/28/0/0; after: 4/0/4/0/0/0 — so no body may exceed a small bound, which
-// regresses hard (to 28) if per-edge pcurve projection returns. The residual 4+4 on the auxiliary
-// bodies is a separate analytic grid-conformance issue (not this fix).
+// model (not a committed fixture; same OBK_PERF_STEP convention as TestHeavyModelBudget). It also guards
+// the cross-face conformance repair (conformCylConeFaces): a trimmed cyl/cone whose plane ear-clip
+// absorbed a rim-arc point is re-meshed with the metric-(u,v) CDT so it conforms to its neighbour.
+// Per-body free edges across the M25 fixes: pcurve continuity 4/0/4/28/0/0 → conformance repair
+// 4/0/0/0/0/0 (total 4). The remaining 4 are body0's plane-side absorber (a separate future pass). Assert
+// the TOTAL stays ≤4 — it regresses hard (to 8, then 36) if either fix is lost.
 func TestImportedNurbsDuctWatertight(t *testing.T) {
 	path := os.Getenv("OBK_PERF_STEP")
 	if path == "" {
 		t.Skip("set OBK_PERF_STEP=/path/EDF.STEP to run the imported-NURBS watertightness guard")
 	}
+	total := 0
 	for i, body := range stepBodies(t, path) {
 		mesh, _ := TessellateBody(body, DefaultQuality())
-		if free := freeEdgeCount(mesh); free > 8 {
-			t.Errorf("imported body %d tessellated with %d free edges; want ≤8 "+
-				"(a NURBS-face pcurve conformance regression cracks the duct body to ~28)", i, free)
+		free := freeEdgeCount(mesh)
+		total += free
+		if free > 4 {
+			t.Errorf("imported body %d tessellated with %d free edges; want ≤4 "+
+				"(a pcurve-continuity or cyl/cone conformance regression cracks a body)", i, free)
 		}
+	}
+	if total > 4 {
+		t.Errorf("imported model total free edges = %d; want ≤4 (watertightness regression)", total)
 	}
 }


### PR DESCRIPTION
## What
Closes the cross-face cracks on the EDF mounting brackets (e.g. the cylinder face the user selected, body2 #16): **EDF total free edges 8 → 4**, with **no regression** (body3 stays 0) and **no perf cost** (~80 ms).

## Why / root cause
A trimmed cylinder/cone wall meshed by the best-fit-plane ear-clip (`boundaryPatchMesh`) **absorbs a near-collinear point of a rim arc** — a cyl/cone rim is an iso-curve, nearly straight once projected — so it emits one fewer segment than its planar neighbour (which keeps the arc curved and emits all of them). The two faces then disagree on the shared edge → an unpaired free edge → a visible crack. Confirmed on the selected face by per-shared-edge segment comparison (cylinder misses 2 segments of a 17-pt arc its plane neighbour keeps).

## Fix
After per-face meshing, `TessellateBody` runs `conformCylConeFaces`: find the unpaired (free) segments, and re-mesh **only** the cyl/cone faces touching them (and their cyl/cone neighbours) with a **boundary-only constrained Delaunay in metric (u,v)**:
- The CDT keeps every boundary segment as a **constraint** → it cannot drop them (unlike the ear-clip).
- Metric (√E,√G) scaling makes (u,v) **developable** → it never folds, unlike the best-fit plane on a wrapping wall (which is why a plain plane-CDT regressed body3).
- **Boundary-only** (no interior Steiner nodes) → O(boundary), no CDT freeze (the earlier freeze was the metric CDT *with* a dense interior grid).
- A **watertight body has no free edges and is left untouched** → bodies the ear-clip already meshes correctly can't regress.
- Planes are intentionally **not** re-meshed (re-triangulating a planar multi-hole face cascades new mismatches); a crack where the plane is the absorber (body0's residual 4) is left to a follow-up.

## Verification
- EDF per-body free edges: 4/0/4/0/0/0 → **4/0/0/0/0/0** (total 8→4); body3 unchanged at 0.
- Tessellation time unchanged (~80 ms; `TestHeavyModelBudget` green).
- Full kernel suite + OCC oracle green; `gofmt`/`vet`/`golangci-lint` clean.
- Live: re-imported EDF renders clean green (normal-debug).
- Guard: `TestImportedNurbsDuctWatertight` tightened to assert total ≤ 4 (regresses to 8 if this pass is lost).

Builds on #122 (NURBS pcurve continuity, body3 28→0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)