### PR TITLE
docs: fix cmd/oblikovati path mangled by the namespace rename

### DIFF
--- a/architecture/core/07-extensibility.md
+++ b/architecture/core/07-extensibility.md
@@ -24,7 +24,7 @@ func init() { registry.Features.Register(extrudeKind) }   // ← adding extrude 
 ```
 
 ```go
-// cmd/oblikovati.org/features.go — the host imports for side effects only
+// cmd/oblikovati/features.go — the host imports for side effects only
 import (
     _ "oblikovati.org/model/feature/extrude"
     _ "oblikovati.org/model/feature/revolve"


### PR DESCRIPTION
A one-line follow-up to #130: the namespace-rename pass wrongly rewrote the binary
cmd-dir path `cmd/oblikovati/` → `cmd/oblikovati.org/` in an ADR code comment
(only Go MODULE paths move, not the on-disk cmd directory). This commit was on the
#130 branch but landed after the merge, so it didn't make it into develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)