### PR TITLE
Model browser: nested chronological tree, double-click edit, edit-scope, pickable user planes (#132)

### DIFF
--- a/app/browser.go
+++ b/app/browser.go
@@ -4,8 +4,11 @@ package app
 
 import (
 	"fmt"
+	"sort"
 
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
 )
 
 // The browser tree reflects the active document's structure — parameters, sketches,
@@ -35,6 +38,15 @@ func (n *BrowserNode) selectableChild(label, kind string, sel Selectable) {
 	c.Select = sel
 }
 
+// selectableBranch appends a child that is BOTH selectable and a parent (a feature row that
+// nests its consumed sketch), returning it so callers can add children. The head renders a
+// node with a non-nil Select and children as an expandable, clickable tree node.
+func (n *BrowserNode) selectableBranch(label, kind string, sel Selectable) *BrowserNode {
+	c := n.child(label, kind)
+	c.Select = sel
+	return c
+}
+
 // BuildBrowser builds the browser tree for the active document. An empty session
 // yields an empty root; a part document yields parameter, sketch, and feature
 // branches reflecting its component definition.
@@ -50,52 +62,151 @@ func BuildBrowser(s *Session) BrowserNode {
 	return root
 }
 
-// addPartBranches adds the origin, parameters, solid bodies, sketches and features of a
-// part. Sketch/feature/body nodes are selectable so clicking one syncs the 3D view (and
-// a viewport pick lights up the matching node).
+// addPartBranches builds the part's browser tree: the static Origin and Parameters folders,
+// the Solid Bodies folder, then the chronological model timeline. The timeline interleaves
+// user work features, sketches, and features by global creation order, nesting a consumed
+// sketch under the feature that uses it (Inventor's model tree) — there is no separate
+// Sketches branch, so a sketch's dependency on an earlier work plane/feature is visible
+// (issue #132). Sketch/feature/datum nodes are selectable so clicking one syncs the 3D view.
 func addPartBranches(root *BrowserNode, part *compdef.PartComponentDefinition) {
-	origin := root.child("Origin", "origin")
-	for _, wp := range part.OriginPlanes() {
-		origin.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
-	}
-	addOriginAxesAndPoint(origin, part)
+	addOriginBranch(root, part)
 	params := root.child("Parameters", "parameters")
 	for _, p := range part.Parameters().All() {
 		params.child(p.Name(), "parameter")
 	}
 	addBodyBranch(root, part)
-	addUserWorkPlanes(root, part)
-	addUserWorkAxesAndPoints(root, part)
-	sketches := root.child("Sketches", "sketches")
-	for i := 0; i < part.Sketches().Count(); i++ {
-		sk := part.Sketches().Item(i)
-		sketches.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
+	addModelTimeline(root, part)
+}
+
+// timelineEntry is one node placed in the part's chronological tree: the global creation
+// stamp it sorts by, and a builder that appends it (with any nested children) under root.
+type timelineEntry struct {
+	seq    uint64
+	append func(root *BrowserNode)
+}
+
+// addModelTimeline appends the user work features, top-level sketches, and features in
+// global creation order. A sketch consumed by exactly one feature (and not shared) is
+// "absorbed": it is omitted here and nested under that feature instead.
+func addModelTimeline(root *BrowserNode, part *compdef.PartComponentDefinition) {
+	absorber := sketchAbsorbers(part)
+	var entries []timelineEntry
+	entries = appendWorkPlaneEntries(entries, part)
+	entries = appendWorkAxisPointEntries(entries, part)
+	entries = appendTopLevelSketchEntries(entries, part, absorber)
+	entries = appendFeatureEntries(entries, part, absorber)
+
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].seq < entries[j].seq })
+	for _, e := range entries {
+		e.append(root)
 	}
+}
+
+// sketchAbsorbers maps each absorbed sketch to the single feature that nests it. A sketch is
+// absorbed when exactly one feature consumes it AND it is not shared (Inventor's Share Sketch
+// keeps a sketch at top level even when consumed, and lets several features consume it).
+func sketchAbsorbers(part *compdef.PartComponentDefinition) map[*sketch.Sketch]*feature.PartFeature {
+	consumers := map[*sketch.Sketch][]*feature.PartFeature{}
 	features := part.Features()
 	for i := 0; i < features.Count(); i++ {
 		f := features.Item(i)
-		root.selectableChild(f.Name(), "feature", FeatureHandle{Feature: f})
-	}
-}
-
-// addUserWorkPlanes adds the part's user-created datum planes (offset, midplane, …) as
-// top-level selectable nodes, so a plane made from the ribbon shows in the tree and can
-// be re-picked (to sketch on, or as input to another datum). The origin coordinate-system
-// planes live in the Origin folder, so they are skipped here.
-func addUserWorkPlanes(root *BrowserNode, part *compdef.PartComponentDefinition) {
-	planes := part.WorkPlanes()
-	for i := 0; i < planes.Count(); i++ {
-		if wp := planes.Item(i); !wp.IsCoordinateSystemElement() {
-			root.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
+		for _, sk := range f.ConsumedSketches() {
+			consumers[sk] = append(consumers[sk], f)
 		}
 	}
+	absorber := make(map[*sketch.Sketch]*feature.PartFeature, len(consumers))
+	for sk, fs := range consumers {
+		if len(fs) == 1 && !sk.Shared() {
+			absorber[sk] = fs[0]
+		}
+	}
+	return absorber
 }
 
-// addOriginAxesAndPoint completes the Origin folder with the X/Y/Z axes and the center
-// point (the planes are added by the caller), so the whole origin coordinate frame is
-// selectable — the reference inputs for axis/point-driven work planes (Inventor's Origin
-// folder holds all seven elements).
-func addOriginAxesAndPoint(origin *BrowserNode, part *compdef.PartComponentDefinition) {
+// appendWorkPlaneEntries adds the user-created datum planes at their creation position.
+// The origin coordinate-system planes live in the Origin folder, so they are skipped here.
+func appendWorkPlaneEntries(entries []timelineEntry, part *compdef.PartComponentDefinition) []timelineEntry {
+	planes := part.WorkPlanes()
+	for i := 0; i < planes.Count(); i++ {
+		wp := planes.Item(i)
+		if wp.IsCoordinateSystemElement() {
+			continue
+		}
+		entries = append(entries, timelineEntry{wp.Seq(), func(root *BrowserNode) {
+			root.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
+		}})
+	}
+	return entries
+}
+
+// appendWorkAxisPointEntries adds the user-created datum axes and points at their creation
+// position (the origin ones live in the Origin folder).
+func appendWorkAxisPointEntries(entries []timelineEntry, part *compdef.PartComponentDefinition) []timelineEntry {
+	axes := part.WorkAxes()
+	for i := 0; i < axes.Count(); i++ {
+		a := axes.Item(i)
+		if a.IsCoordinateSystemElement() {
+			continue
+		}
+		entries = append(entries, timelineEntry{a.Seq(), func(root *BrowserNode) {
+			root.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
+		}})
+	}
+	points := part.WorkPoints()
+	for i := 0; i < points.Count(); i++ {
+		p := points.Item(i)
+		if p.IsCoordinateSystemElement() {
+			continue
+		}
+		entries = append(entries, timelineEntry{p.Seq(), func(root *BrowserNode) {
+			root.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
+		}})
+	}
+	return entries
+}
+
+// appendTopLevelSketchEntries adds the sketches that are NOT absorbed under a feature
+// (unconsumed, shared, or consumed by several features) at their creation position.
+func appendTopLevelSketchEntries(entries []timelineEntry, part *compdef.PartComponentDefinition, absorber map[*sketch.Sketch]*feature.PartFeature) []timelineEntry {
+	sketches := part.Sketches()
+	for i := 0; i < sketches.Count(); i++ {
+		sk := sketches.Item(i)
+		if absorber[sk] != nil {
+			continue
+		}
+		entries = append(entries, timelineEntry{sk.Seq(), func(root *BrowserNode) {
+			root.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
+		}})
+	}
+	return entries
+}
+
+// appendFeatureEntries adds each feature at its creation position, nesting the sketch(es)
+// it absorbs as children so the consumed sketch reads as part of the feature.
+func appendFeatureEntries(entries []timelineEntry, part *compdef.PartComponentDefinition, absorber map[*sketch.Sketch]*feature.PartFeature) []timelineEntry {
+	features := part.Features()
+	for i := 0; i < features.Count(); i++ {
+		f := features.Item(i)
+		entries = append(entries, timelineEntry{f.Seq(), func(root *BrowserNode) {
+			node := root.selectableBranch(f.Name(), "feature", FeatureHandle{Feature: f})
+			for _, sk := range f.ConsumedSketches() {
+				if absorber[sk] == f {
+					node.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
+				}
+			}
+		}})
+	}
+	return entries
+}
+
+// addOriginBranch fills the Origin folder with the seven coordinate-system elements (three
+// planes, three axes, the center point), all selectable — the reference inputs for
+// axis/point-driven work planes (Inventor's Origin folder).
+func addOriginBranch(root *BrowserNode, part *compdef.PartComponentDefinition) {
+	origin := root.child("Origin", "origin")
+	for _, wp := range part.OriginPlanes() {
+		origin.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
+	}
 	axes := part.WorkAxes()
 	for i := 0; i < axes.Count(); i++ {
 		if a := axes.Item(i); a.IsCoordinateSystemElement() {
@@ -106,23 +217,6 @@ func addOriginAxesAndPoint(origin *BrowserNode, part *compdef.PartComponentDefin
 	for i := 0; i < points.Count(); i++ {
 		if p := points.Item(i); p.IsCoordinateSystemElement() {
 			origin.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
-		}
-	}
-}
-
-// addUserWorkAxesAndPoints adds user-created datum axes and points as top-level
-// selectable nodes (the origin ones live in the Origin folder).
-func addUserWorkAxesAndPoints(root *BrowserNode, part *compdef.PartComponentDefinition) {
-	axes := part.WorkAxes()
-	for i := 0; i < axes.Count(); i++ {
-		if a := axes.Item(i); !a.IsCoordinateSystemElement() {
-			root.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
-		}
-	}
-	points := part.WorkPoints()
-	for i := 0; i < points.Count(); i++ {
-		if p := points.Item(i); !p.IsCoordinateSystemElement() {
-			root.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
 		}
 	}
 }

--- a/app/browser_actions.go
+++ b/app/browser_actions.go
@@ -27,6 +27,15 @@ func (s *Session) EditSketch(sk *sketch.Sketch) error {
 	return nil
 }
 
+// BeginEditSketch re-enters a sketch for geometry editing (browser double-click). It mirrors
+// the "Edit Sketch" menu action; a nil/missing sketch or an already-open editor is a no-op.
+func (s *Session) BeginEditSketch(h SketchHandle) {
+	if h.Sketch == nil {
+		return
+	}
+	_ = s.EditSketch(h.Sketch)
+}
+
 // DeleteSketch removes a sketch from the active part. If it is the one being edited the
 // environment is exited first so the editor never points at a freed sketch.
 func (s *Session) DeleteSketch(sk *sketch.Sketch) error {
@@ -65,6 +74,23 @@ func (s *Session) DeleteFeature(f *feature.PartFeature) error {
 	s.selection.Clear()
 	part.Recompute()
 	s.recordEdit(part, "Delete Feature")
+	return nil
+}
+
+// ToggleSketchShared flips a sketch's Shared flag (the browser's Share/Unshare Sketch). A
+// shared sketch stays at the browser's top level even when a feature consumes it, and may be
+// consumed by several features (issue #132). It changes only browser structure, not geometry,
+// so it records an edit for undo without recomputing.
+func (s *Session) ToggleSketchShared(sk *sketch.Sketch) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if sk == nil {
+		return errors.New("app: ToggleSketchShared with nil sketch")
+	}
+	sk.SetShared(!sk.Shared())
+	s.recordEdit(part, "Share Sketch")
 	return nil
 }
 

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -34,14 +34,22 @@ func BrowserMenu(n BrowserNode) []BrowserMenuItem {
 	}
 }
 
-// sketchMenu offers Edit Sketch, a Visibility toggle, and Delete.
+// sketchMenu offers Edit Sketch, a Share/Unshare toggle, a Visibility toggle, and Delete.
+// Share Sketch (Inventor's command) keeps the sketch at the browser's top level even after a
+// feature consumes it, and lets several features consume it (issue #132); the label reflects
+// the current state.
 func sketchMenu(sel Selectable) []BrowserMenuItem {
 	h, ok := sel.(SketchHandle)
 	if !ok {
 		return nil
 	}
+	shareLabel := "Share Sketch"
+	if h.Sketch.Shared() {
+		shareLabel = "Unshare Sketch"
+	}
 	return []BrowserMenuItem{
 		{Label: "Edit Sketch", Enabled: true, Invoke: func(s *Session) error { return s.EditSketch(h.Sketch) }},
+		{Label: shareLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleSketchShared(h.Sketch) }},
 		{Label: "Visibility", Enabled: true, Invoke: func(*Session) error {
 			h.Sketch.SetVisible(!h.Sketch.Visible())
 			return nil

--- a/app/browser_menu_test.go
+++ b/app/browser_menu_test.go
@@ -77,7 +77,7 @@ func TestBrowserMenuByKind(t *testing.T) {
 	s, _ := extrudedBoxPart(t)
 	root := BuildBrowser(s)
 
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "sketch"))); !equalStrings(labels, []string{"Edit Sketch", "Visibility", "Delete"}) {
+	if labels := menuLabels(BrowserMenu(findNode(t, root, "sketch"))); !equalStrings(labels, []string{"Edit Sketch", "Share Sketch", "Visibility", "Delete"}) {
 		t.Errorf("sketch menu = %v", labels)
 	}
 	if labels := menuLabels(BrowserMenu(findNode(t, root, "feature"))); !equalStrings(labels, []string{"Edit", "Suppress", "Delete"}) {

--- a/app/browser_timeline_test.go
+++ b/app/browser_timeline_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// childrenKinds lists the kinds of a node's direct children, for asserting tree shape.
+func childrenKinds(n BrowserNode) []string {
+	kinds := make([]string, len(n.Children))
+	for i, c := range n.Children {
+		kinds[i] = c.Kind
+	}
+	return kinds
+}
+
+// topLevelKind reports whether the part root has a direct child of the given kind.
+func hasTopLevelKind(root BrowserNode, kind string) bool {
+	for _, c := range root.Children {
+		if c.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBrowserNestsConsumedSketchUnderFeature is the issue-#132 core: there is no top-level
+// Sketches branch; a sketch consumed by one feature is nested under that feature instead.
+func TestBrowserNestsConsumedSketchUnderFeature(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	root := BuildBrowser(s)
+
+	// No "sketches" folder remains at the top level.
+	if hasTopLevelKind(root, "sketches") {
+		t.Error("the special Sketches branch must be gone")
+	}
+	// The sketch must NOT be a direct child of the root (it is absorbed).
+	if hasTopLevelKind(root, "sketch") {
+		t.Error("a consumed sketch must not appear at the top level")
+	}
+	// The feature node carries the sketch as its child.
+	feat := findNode(t, root, "feature")
+	if kinds := childrenKinds(feat); len(kinds) != 1 || kinds[0] != "sketch" {
+		t.Errorf("feature children = %v, want one nested sketch", kinds)
+	}
+	if _, ok := findNode(t, feat, "sketch").Select.(SketchHandle); !ok {
+		t.Error("nested sketch is not selectable with a SketchHandle")
+	}
+}
+
+// TestBrowserKeepsSharedSketchAtTopLevel: a Shared sketch stays at the top level even though a
+// feature consumes it (Inventor's Share Sketch), so it can feed several features.
+func TestBrowserKeepsSharedSketchAtTopLevel(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	def.Sketches().Item(0).SetShared(true)
+	root := BuildBrowser(s)
+
+	if !hasTopLevelKind(root, "sketch") {
+		t.Error("a shared sketch must remain at the top level")
+	}
+	if kinds := childrenKinds(findNode(t, root, "feature")); len(kinds) != 0 {
+		t.Errorf("feature must not absorb a shared sketch; children = %v", kinds)
+	}
+}
+
+// TestBrowserOrdersTimelineByCreation: a work plane created after the extrude, and a later
+// sketch on it, appear in creation order — proving the chronological interleave.
+func TestBrowserOrdersTimelineByCreation(t *testing.T) {
+	s, def := extrudedBoxPart(t) // sketch1 → extrude
+	def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	def.Sketches().Add(sketch.XYPlane()) // a later, unconsumed sketch
+	def.Recompute()
+
+	root := BuildBrowser(s)
+	order := timelineKinds(root)
+	// Expected top-level timeline order: the absorbing feature, then the work plane, then the
+	// trailing unconsumed sketch (the consumed sketch is nested, not in this list).
+	want := []string{"feature", "workplane", "sketch"}
+	if !equalStrings(order, want) {
+		t.Errorf("timeline order = %v, want %v", order, want)
+	}
+}
+
+// timelineKinds lists the kinds of the root's direct children that belong to the model
+// timeline (excluding the static Origin/Parameters/Solid Bodies folders).
+func timelineKinds(root BrowserNode) []string {
+	var out []string
+	for _, c := range root.Children {
+		switch c.Kind {
+		case "origin", "parameters", "bodies":
+			continue
+		default:
+			out = append(out, c.Kind)
+		}
+	}
+	return out
+}
+
+// TestToggleSketchSharedRoundTripsThroughMenu drives the Share/Unshare action and checks the
+// menu label and browser placement flip accordingly.
+func TestToggleSketchSharedRoundTripsThroughMenu(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	sk := def.Sketches().Item(0)
+
+	if err := s.ToggleSketchShared(sk); err != nil {
+		t.Fatalf("ToggleSketchShared: %v", err)
+	}
+	if !sk.Shared() {
+		t.Fatal("sketch should be shared after toggling")
+	}
+	root := BuildBrowser(s)
+	if !hasTopLevelKind(root, "sketch") {
+		t.Error("shared sketch should be top level after toggle")
+	}
+	labels := menuLabels(BrowserMenu(findNode(t, root, "sketch")))
+	if len(labels) < 2 || labels[1] != "Unshare Sketch" {
+		t.Errorf("shared sketch menu = %v, want Unshare Sketch entry", labels)
+	}
+
+	// Unshare → the sketch is absorbed again.
+	if err := s.ToggleSketchShared(sk); err != nil {
+		t.Fatalf("ToggleSketchShared(unshare): %v", err)
+	}
+	if BuildBrowser(s); hasTopLevelKind(BuildBrowser(s), "sketch") {
+		t.Error("unshared consumed sketch should nest under its feature again")
+	}
+}

--- a/app/edit_scope.go
+++ b/app/edit_scope.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Edit-scope visibility (issue #132): while a feature, sketch, or work plane is being edited,
+// everything created AFTER it is hidden. The model is uncertain what a mid-history edit will
+// invalidate, and trailing geometry can obstruct the view, so Inventor rolls the part back to
+// the edited node for the duration of the edit. We engage the feature engine's end-of-part
+// marker to drop trailing feature geometry, and the head's overlays consult [Session.EditScopeSeq]
+// to drop trailing work planes/axes/sketches. Both use the shared creation stamp (model/seq).
+
+// editScope records the in-progress edit's cutoff: the edited node's creation stamp, and the
+// feature engine's end-of-part marker to restore when the edit closes.
+type editScope struct {
+	active   bool
+	seq      uint64 // hide every node whose Seq() is strictly greater than this
+	savedEOP int    // feature engine EOP index to restore on endEditScope (eopAll ⇒ -1)
+}
+
+// EditScopeSeq returns the active edit's cutoff stamp and true while an edit is open; callers
+// (the head's plane/axis/sketch overlays) hide any node whose Seq() exceeds it. ok is false
+// when no edit is in progress, so everything is shown normally.
+func (s *Session) EditScopeSeq() (uint64, bool) {
+	return s.editScope.seq, s.editScope.active
+}
+
+// EditScopeHides reports whether a node with the given creation stamp is hidden by the active
+// edit (created strictly after the edited node). False when no edit is open.
+func (s *Session) EditScopeHides(nodeSeq uint64) bool {
+	return s.editScope.active && nodeSeq > s.editScope.seq
+}
+
+// beginEditScope opens an edit centered on the node with stamp scopeSeq: it rolls the feature
+// engine back to just after that node (so trailing feature geometry vanishes) and records the
+// prior end-of-part marker for restoration. Recomputes so the rolled-back model shows at once.
+func (s *Session) beginEditScope(scopeSeq uint64) {
+	part, err := activePart(s)
+	if err != nil {
+		return
+	}
+	feats := part.Features()
+	s.editScope = editScope{active: true, seq: scopeSeq, savedEOP: feats.EndOfPartIndex()}
+	for i := 0; i < feats.Count(); i++ {
+		if feats.Item(i).Seq() > scopeSeq {
+			_ = feats.SetEndOfPart(feats.Item(i)) // exclude this feature and everything after it
+			part.Recompute()
+			return
+		}
+	}
+	feats.RollToEnd() // nothing was created after the edited node
+	part.Recompute()
+}
+
+// endEditScope closes the active edit, restoring the end-of-part marker captured at open. The
+// caller recomputes afterward (Commit/Cancel/FinishSketch already do). A no-op when no edit is
+// open, so it is safe to call unconditionally on every edit exit.
+func (s *Session) endEditScope() {
+	if !s.editScope.active {
+		return
+	}
+	saved := s.editScope.savedEOP
+	s.editScope = editScope{}
+	part, err := activePart(s)
+	if err != nil {
+		return
+	}
+	feats := part.Features()
+	if saved < 0 || saved >= feats.Count() {
+		feats.RollToEnd()
+		return
+	}
+	_ = feats.SetEndOfPart(feats.Item(saved))
+}

--- a/app/edit_scope_test.go
+++ b/app/edit_scope_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// twoExtrudePart builds a part with two independent extrudes (sketch1→extrude1, then
+// sketch2→extrude2), returning the session, part, and both features in creation order — the
+// fixture for edit-scope rollback (editing extrude1 must hide extrude2).
+func twoExtrudePart(t *testing.T) (*Session, *compdef.PartComponentDefinition, *feature.PartFeature, *feature.PartFeature) {
+	t.Helper()
+	s, def := emptyPartSession(t)
+	mkBox := func(originX float64) *feature.PartFeature {
+		sk := def.Sketches().Add(sketch.XYPlane())
+		c0 := sk.Points().Add(math.P2(originX, 0))
+		c1 := sk.Points().Add(math.P2(originX+1, 0))
+		c2 := sk.Points().Add(math.P2(originX+1, 1))
+		c3 := sk.Points().Add(math.P2(originX, 1))
+		sk.Lines().Add(c0, c1)
+		sk.Lines().Add(c1, c2)
+		sk.Lines().Add(c2, c3)
+		sk.Lines().Add(c3, c0)
+		return feature.NewExtrudeFeatures(def.Features()).
+			AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 1 })
+	}
+	f1 := mkBox(0)
+	f2 := mkBox(3)
+	def.Recompute()
+	return s, def, f1, f2
+}
+
+// TestBeginEditFeatureRollsBackToEditedFeature is the issue-#132 edit-scope regression:
+// editing an earlier feature rolls the part back to it (its successor and everything after
+// are excluded), and the scope reports later nodes as hidden. Commit restores full evaluation.
+func TestBeginEditFeatureRollsBackToEditedFeature(t *testing.T) {
+	s, def, f1, f2 := twoExtrudePart(t)
+	if def.Features().EndOfPartIndex() != -1 {
+		t.Fatalf("part should start fully evaluated, EOP=%d", def.Features().EndOfPartIndex())
+	}
+
+	s.BeginEditFeature(FeatureHandle{Feature: f1})
+
+	if _, active := s.EditScopeSeq(); !active {
+		t.Fatal("edit scope should be active while editing")
+	}
+	if !s.EditScopeHides(f2.Seq()) {
+		t.Error("the later feature must be hidden by the edit scope")
+	}
+	if s.EditScopeHides(f1.Seq()) {
+		t.Error("the edited feature itself must NOT be hidden")
+	}
+	// The engine is rolled back to exclude f2 (index 1).
+	if got := def.Features().EndOfPartIndex(); got != 1 {
+		t.Errorf("EOP during edit = %d, want 1 (f2 excluded)", got)
+	}
+
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit edit: %v", err)
+	}
+	if _, active := s.EditScopeSeq(); active {
+		t.Error("edit scope must clear on commit")
+	}
+	if got := def.Features().EndOfPartIndex(); got != -1 {
+		t.Errorf("EOP after commit = %d, want -1 (full evaluation restored)", got)
+	}
+}
+
+// TestEditScopeRestoredOnCancel: cancelling a feature edit also restores full evaluation.
+func TestEditScopeRestoredOnCancel(t *testing.T) {
+	s, def, f1, _ := twoExtrudePart(t)
+	s.BeginEditFeature(FeatureHandle{Feature: f1})
+	s.CancelTool()
+	if _, active := s.EditScopeSeq(); active {
+		t.Error("edit scope must clear on cancel")
+	}
+	if got := def.Features().EndOfPartIndex(); got != -1 {
+		t.Errorf("EOP after cancel = %d, want -1", got)
+	}
+}
+
+// TestEditScopeHidesTrailingSketch: editing the first feature hides a sketch created later.
+func TestEditScopeHidesTrailingSketch(t *testing.T) {
+	s, def, f1, _ := twoExtrudePart(t)
+	later := def.Sketches().Add(sketch.XYPlane()) // created after both features
+	def.Recompute()
+
+	s.BeginEditFeature(FeatureHandle{Feature: f1})
+	if !s.EditScopeHides(later.Seq()) {
+		t.Error("a sketch created after the edited feature must be hidden")
+	}
+}

--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -88,6 +88,7 @@ func (t *FeatureEditTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
+	s.endEditScope() // restore full evaluation before the final rebuild
 	part.Features().MarkDirty(t.feature)
 	part.Recompute()
 	s.recordEdit(part, "Edit "+t.feature.Name())
@@ -108,6 +109,7 @@ func (t *FeatureEditTool) Cancel(s *Session) {
 			restore()
 		}
 	}
+	s.endEditScope() // restore full evaluation before rebuilding with the reverted values
 	if part, err := activePart(s); err == nil {
 		part.Features().MarkDirty(t.feature)
 		part.Recompute()
@@ -169,6 +171,7 @@ func (s *Session) BeginEditFeature(h FeatureHandle) {
 	if !t.editable() {
 		return
 	}
+	s.beginEditScope(h.Feature.Seq()) // roll back to this feature: hide everything after it
 	s.StartTool(t)
 }
 

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -37,8 +37,9 @@ func NewRayPicker(camera scene.Camera, bodies func() []*topo.Body) *RayPicker {
 	return &RayPicker{camera: camera, bodies: bodies}
 }
 
-// WithPlanes adds a provider of selectable work planes (the part's origin planes), so
-// the picker can resolve a click on a datum plane in empty space.
+// WithPlanes adds a provider of selectable work planes (origin AND visible user datums),
+// so the picker can resolve a click on a datum plane in empty space — e.g. to pick a
+// ribbon-created plane as a new sketch's host.
 func (p *RayPicker) WithPlanes(planes func() []*feature.WorkPlane) *RayPicker {
 	p.planes = planes
 	return p

--- a/app/ribbon_browser_addin_test.go
+++ b/app/ribbon_browser_addin_test.go
@@ -75,8 +75,10 @@ func TestBrowserReflectsPartStructure(t *testing.T) {
 	for _, c := range root.Children {
 		byKind[c.Kind]++
 	}
-	if byKind["parameters"] != 1 || byKind["sketches"] != 1 {
-		t.Errorf("browser branches = %v, want parameters+sketches", byKind)
+	// The special "sketches" branch is gone (issue #132): an unconsumed sketch is a top-level
+	// timeline node, alongside the Parameters folder.
+	if byKind["parameters"] != 1 || byKind["sketches"] != 0 || byKind["sketch"] != 1 {
+		t.Errorf("browser branches = %v, want parameters + one top-level sketch, no sketches folder", byKind)
 	}
 	// The parameter we added shows under Parameters.
 	for _, c := range root.Children {

--- a/app/session.go
+++ b/app/session.go
@@ -65,6 +65,7 @@ type Session struct {
 	normalDebug        bool                     // viewport normal-debug render (front green / back red); head reads each frame
 	meshColors         bool                     // viewport mesh-debug-colors render (each face/triangle a distinct color)
 	meshColorsPerTri   bool                     // when meshColors: color per TRIANGLE (else per B-rep face)
+	editScope          editScope                // while editing a node, hide everything created after it (issue #132)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in
@@ -160,6 +161,7 @@ func (s *Session) ActiveView() *doc.View {
 func (s *Session) EnterSketch(sk *sketch.Sketch) {
 	s.activeSketch = sk
 	sk.Edit()
+	s.beginEditScope(sk.Seq()) // hide features/datums created after this sketch while editing it
 	s.sketchReturnCam = s.camera
 	s.animateCameraTo(s.camera.Facing(
 		sk.Plane().Origin(), sk.Plane().Normal().AsVector(), sk.Plane().YAxis().AsVector(),
@@ -172,6 +174,7 @@ func (s *Session) ExitSketch() {
 		s.activeSketch.ExitEdit()
 		s.activeSketch = nil
 		s.pendingDim = nil // no dangling edit box after leaving the sketch
+		s.endEditScope()   // restore the rolled-back features (caller recomputes)
 		s.animateCameraTo(s.sketchReturnCam, sketchViewTweenSeconds)
 	}
 }

--- a/app/work_plane_edit.go
+++ b/app/work_plane_edit.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
+)
+
+// Editing a placed work plane — Inventor's double-click / browser "Edit" on a datum plane.
+// Only the plane-and-offset kind carries a single scalar to edit (its offset distance); the
+// other plane kinds (three-point, tangent, …) are defined purely by references and have no
+// value to type, so they are not opened for edit here (a follow-up redefine flow). Each
+// change recomputes live; OK keeps it, Cancel restores the distance captured when editing
+// opened. See issue #132.
+
+// WorkPlaneEditTool edits one offset work plane's distance in place.
+type WorkPlaneEditTool struct {
+	plane    *feature.WorkPlane
+	distance float64 // current edited offset, model units
+	original float64 // offset captured at open, for Cancel
+}
+
+// newWorkPlaneEditTool captures the plane's current offset as the edit's starting value.
+func newWorkPlaneEditTool(wp *feature.WorkPlane) *WorkPlaneEditTool {
+	d, _ := wp.OffsetDistance()
+	return &WorkPlaneEditTool{plane: wp, distance: d, original: d}
+}
+
+// Name implements [Tool].
+func (t *WorkPlaneEditTool) Name() string { return "Edit " + t.plane.Name() }
+
+// Start is a no-op: the plane is already chosen, the dialog only edits its distance.
+func (t *WorkPlaneEditTool) Start(*Session) {}
+
+// Pick ignores viewport picks: an offset edit takes only a typed distance, no geometry.
+func (t *WorkPlaneEditTool) Pick(*Session, Selectable) {}
+
+// SetDistance / Distance hold the offset in model units (the head's dialog reads/sets these
+// through the session bridge, converting to/from the document's length unit).
+func (t *WorkPlaneEditTool) SetDistance(d float64) { t.distance = d }
+func (t *WorkPlaneEditTool) Distance() float64     { return t.distance }
+
+// CanCommit allows committing any distance (including 0 — a coincident plane is valid).
+func (t *WorkPlaneEditTool) CanCommit() bool { return true }
+
+// Commit writes the edited distance onto the plane, recomputes, and records the edit.
+func (t *WorkPlaneEditTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if !t.plane.SetOffsetDistance(t.distance) {
+		return errors.New("work plane edit: plane is not an editable offset plane")
+	}
+	s.endEditScope()
+	part.Recompute()
+	s.recordEdit(part, "Edit "+t.plane.Name())
+	return nil
+}
+
+// Cancel restores the offset captured at open and recomputes.
+func (t *WorkPlaneEditTool) Cancel(s *Session) {
+	t.plane.SetOffsetDistance(t.original)
+	s.endEditScope()
+	if part, err := activePart(s); err == nil {
+		part.Recompute()
+	}
+}
+
+// BeginEditWorkPlane opens an offset work plane for distance editing (browser double-click /
+// Edit menu). Origin coordinate-system planes and non-offset plane kinds have nothing to
+// edit, so they are a no-op (matching a feature with no editable parameters).
+func (s *Session) BeginEditWorkPlane(h WorkPlaneHandle) {
+	if h.Plane == nil || h.Plane.IsCoordinateSystemElement() {
+		return
+	}
+	if _, ok := h.Plane.OffsetDistance(); !ok {
+		return
+	}
+	s.beginEditScope(h.Plane.Seq())
+	s.StartTool(newWorkPlaneEditTool(h.Plane))
+}
+
+// --- session bridge for the head dialog (offset in the document's length unit) ---
+
+// ActiveWorkPlaneEdit returns the running work-plane edit tool, or nil.
+func (s *Session) ActiveWorkPlaneEdit() *WorkPlaneEditTool {
+	if s.tool == nil {
+		return nil
+	}
+	t, _ := s.tool.tool.(*WorkPlaneEditTool)
+	return t
+}
+
+// EditPlaneName returns the name of the work plane being edited (the dialog title), or "".
+func (s *Session) EditPlaneName() string {
+	if t := s.ActiveWorkPlaneEdit(); t != nil {
+		return t.plane.Name()
+	}
+	return ""
+}
+
+// EditPlaneOffsetDisplay returns the edited offset in the document's length unit.
+func (s *Session) EditPlaneOffsetDisplay() float64 {
+	t := s.ActiveWorkPlaneEdit()
+	if t == nil {
+		return 0
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(t.Distance(), param.Length))
+}
+
+// SetEditPlaneOffsetDisplay sets the edited offset from a value in the document's length unit.
+func (s *Session) SetEditPlaneOffsetDisplay(value float64) {
+	if t := s.ActiveWorkPlaneEdit(); t != nil {
+		t.SetDistance(s.DocumentUnits().FromPreferred(value, param.Length).Value)
+	}
+}

--- a/app/work_plane_edit_test.go
+++ b/app/work_plane_edit_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// TestWorkPlaneOffsetIsEditable: an offset plane exposes its distance and re-derives when set,
+// so the plane (and anything built on it) follows the edited value after recompute.
+func TestWorkPlaneOffsetIsEditable(t *testing.T) {
+	_, def := emptyPartSession(t)
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	def.Recompute()
+
+	if d, ok := wp.OffsetDistance(); !ok || d != 2 {
+		t.Fatalf("OffsetDistance = (%v,%v), want (2,true)", d, ok)
+	}
+	if !wp.SetOffsetDistance(5) {
+		t.Fatal("SetOffsetDistance should succeed for an offset plane")
+	}
+	def.Recompute()
+	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), 1e-9) {
+		t.Errorf("edited offset plane origin = %v, want (0,0,5)", wp.Plane().Origin())
+	}
+}
+
+// TestOriginPlaneIsNotOffsetEditable: an origin coordinate-system plane has no offset to edit.
+func TestOriginPlaneIsNotOffsetEditable(t *testing.T) {
+	_, def := emptyPartSession(t)
+	if _, ok := def.OriginPlanes()[0].OffsetDistance(); ok {
+		t.Error("an origin plane must not report an editable offset")
+	}
+}
+
+// TestBeginEditWorkPlaneOpensOffsetEditor: double-clicking a user offset plane opens the edit
+// tool seeded with its current offset, and OK writes the new distance; origin planes are a no-op.
+func TestBeginEditWorkPlaneOpensOffsetEditor(t *testing.T) {
+	s, def := emptyPartSession(t)
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	def.Recompute()
+
+	// An origin plane is not editable: no tool starts.
+	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: def.OriginPlanes()[0]})
+	if s.ActiveWorkPlaneEdit() != nil {
+		t.Fatal("origin plane double-click must not open an edit")
+	}
+
+	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: wp})
+	tool := s.ActiveWorkPlaneEdit()
+	if tool == nil {
+		t.Fatal("editing a user offset plane should open the work-plane edit tool")
+	}
+	if tool.Distance() != 2 {
+		t.Errorf("edit tool seeded distance = %v, want 2", tool.Distance())
+	}
+	if _, active := s.EditScopeSeq(); !active {
+		t.Error("editing a work plane should engage the edit scope")
+	}
+
+	tool.SetDistance(7)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit work-plane edit: %v", err)
+	}
+	if d, _ := wp.OffsetDistance(); d != 7 {
+		t.Errorf("committed offset = %v, want 7", d)
+	}
+	if _, active := s.EditScopeSeq(); active {
+		t.Error("edit scope must clear after committing the work-plane edit")
+	}
+}
+
+// TestBeginEditWorkPlaneCancelRestoresOffset: cancelling restores the pre-edit distance.
+func TestBeginEditWorkPlaneCancelRestoresOffset(t *testing.T) {
+	s, def := emptyPartSession(t)
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	def.Recompute()
+
+	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: wp})
+	s.ActiveWorkPlaneEdit().SetDistance(9)
+	s.CancelTool()
+	if d, _ := wp.OffsetDistance(); d != 2 {
+		t.Errorf("offset after cancel = %v, want 2 (restored)", d)
+	}
+}
+
+// TestBeginEditSketchEntersEnvironment: double-clicking a sketch enters the sketch environment.
+func TestBeginEditSketchEntersEnvironment(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	sk := def.Sketches().Item(0)
+	s.BeginEditSketch(SketchHandle{Sketch: sk})
+	if !s.InSketch() || s.ActiveSketch() != sk {
+		t.Error("BeginEditSketch should enter the sketch environment on the given sketch")
+	}
+}

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -29,6 +29,26 @@ func (s *Session) SelectedWorkPlanes() []*feature.WorkPlane {
 	return planes
 }
 
+// PickableWorkPlanes returns the work planes the viewport hit-test should offer: every
+// origin plane (always pickable as a sketch host — Inventor's Origin folder — even though
+// origin planes default to hidden) plus every VISIBLE user-created datum. User planes were
+// previously absent from the picker, so a ribbon-created plane could not be clicked as a
+// new sketch's reference in the 3D view (issue #132); the head feeds this to the RayPicker.
+func (s *Session) PickableWorkPlanes() []*feature.WorkPlane {
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	planes := part.WorkPlanes()
+	out := make([]*feature.WorkPlane, 0, planes.Count())
+	for i := 0; i < planes.Count(); i++ {
+		if wp := planes.Item(i); wp.IsCoordinateSystemElement() || wp.Visible() {
+			out = append(out, wp)
+		}
+	}
+	return out
+}
+
 // CreateMidplaneWorkPlane adds a work plane bisecting the two selected planes, then
 // recomputes. It errors when fewer than two work planes are selected.
 func (s *Session) CreateMidplaneWorkPlane() (*feature.WorkPlane, error) {

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -73,6 +73,37 @@ func TestOffsetWorkPlaneToolWaitsForDistanceThenCreates(t *testing.T) {
 	}
 }
 
+// TestPickableWorkPlanesIncludesVisibleUserPlanes is the issue-#132 regression: the viewport
+// picker must offer ribbon-created user planes (not only the origin frame), so a new sketch
+// can be hosted on one by clicking it in the 3D view. A hidden user plane drops out.
+func TestPickableWorkPlanesIncludesVisibleUserPlanes(t *testing.T) {
+	s, def := emptyPartSession(t)
+	origin := len(def.OriginPlanes()) // the always-pickable coordinate-system planes
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+
+	got := s.PickableWorkPlanes()
+	if len(got) != origin+1 {
+		t.Fatalf("PickableWorkPlanes = %d, want %d (origin) + 1 user plane", len(got), origin)
+	}
+	if !containsPlane(got, wp) {
+		t.Errorf("PickableWorkPlanes omitted the visible user plane %p", wp)
+	}
+
+	wp.SetVisible(false)
+	if got := s.PickableWorkPlanes(); len(got) != origin || containsPlane(got, wp) {
+		t.Errorf("a hidden user plane must not be pickable: got %d planes (want %d)", len(got), origin)
+	}
+}
+
+func containsPlane(planes []*feature.WorkPlane, want *feature.WorkPlane) bool {
+	for _, p := range planes {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestOffsetWorkPlaneToolNotCommittableWithoutBase(t *testing.T) {
 	s, _ := emptyPartSession(t)
 	tool := NewOffsetWorkPlaneTool()

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -179,7 +179,7 @@ func seedPart(s *app.Session) {
 	// staying bound to this seeded part.
 	s.SetPicker(app.NewRayPicker(s.Camera(),
 		func() []*topo.Body { return activeBodies(s) }).
-		WithPlanes(func() []*feature.WorkPlane { return activeOriginPlanes(s) }).
+		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }).
 		WithPoints(func() []*feature.WorkPoint { return activeWorkPoints(s) }).
 		WithAxes(func() []*feature.WorkAxis { return activeWorkAxes(s) }).
 		WithSketches(func() []*sketch.Sketch { return activeSketches(s) }))
@@ -196,15 +196,6 @@ func seedPart(s *app.Session) {
 // the picker's hit-test so it follows the current document.
 func activeBodies(s *app.Session) []*topo.Body {
 	return s.VisibleBodies()
-}
-
-// activeOriginPlanes returns the active part's origin work planes (nil if none), so
-// the picker can hit-test the current document's planes.
-func activeOriginPlanes(s *app.Session) []*feature.WorkPlane {
-	if p, err := modelaccess.ActivePart(s); err == nil {
-		return p.OriginPlanes()
-	}
-	return nil
 }
 
 // activeWorkPoints / activeWorkAxes return the active part's datum points/axes (origin

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -34,6 +34,7 @@ void obk_ig_end_tab_item(void);
 int  obk_ig_collapsing_header(const char* l);
 void obk_ig_set_next_item_open(int open, int first_use);
 int  obk_ig_tree_node(const char* label);
+int  obk_ig_tree_node_selectable(const char* label, int selected);
 void obk_ig_tree_pop(void);
 void obk_ig_bullet_text(const char* s);
 void obk_ig_set_item_tooltip(const char* s);
@@ -461,6 +462,17 @@ func TreeNode(label string) bool {
 	c, free := cstr(label)
 	defer free()
 	return C.obk_ig_tree_node(c) != 0
+}
+
+// TreeNodeSelectable draws a tree node that is BOTH expandable and selectable (a browser
+// feature row that nests its consumed sketch): the disclosure arrow toggles it open, while
+// a click on the label selects rather than expands. selected draws it highlighted. Returns
+// whether it is expanded (call TreePop only when true). Pair with IsItemClicked for the
+// click and IsItemHovered/IsMouseDoubleClicked for edit-on-double-click.
+func TreeNodeSelectable(label string, selected bool) bool {
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_tree_node_selectable(c, cBool(selected)) != 0
 }
 func TreePop() { C.obk_ig_tree_pop() }
 

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -73,6 +73,14 @@ void obk_ig_set_next_item_open(int open, int first_use) {
     ImGui::SetNextItemOpen(open != 0, first_use != 0 ? ImGuiCond_FirstUseEver : ImGuiCond_Always);
 }
 int  obk_ig_tree_node(const char* label)     { return ImGui::TreeNode(label) ? 1 : 0; }
+// tree_node_selectable is an expandable AND clickable row: OpenOnArrow keeps the label
+// click free for selection (the caller reads IsItemClicked), the arrow toggles open, and
+// SpanAvailWidth makes the whole row the hit target. Selected draws it highlighted.
+int  obk_ig_tree_node_selectable(const char* label, int selected) {
+    ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth;
+    if (selected != 0) flags |= ImGuiTreeNodeFlags_Selected;
+    return ImGui::TreeNodeEx(label, flags) ? 1 : 0;
+}
 void obk_ig_tree_pop(void)                   { ImGui::TreePop(); }
 void obk_ig_bullet_text(const char* s)       { ImGui::BulletText("%s", s); }
 void obk_ig_set_item_tooltip(const char* s)  { ImGui::SetItemTooltip("%s", s); }

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -51,6 +51,8 @@ func drawNode(s *app.Session, n app.BrowserNode) {
 	native.PushIDInt(browserNodeSeq)
 	defer native.PopID()
 	switch {
+	case n.Select != nil && len(n.Children) > 0:
+		drawSelectableBranchNode(s, n)
 	case n.Select != nil:
 		drawSelectableNode(s, n)
 	case len(n.Children) == 0:
@@ -60,6 +62,29 @@ func drawNode(s *app.Session, n app.BrowserNode) {
 	}
 }
 
+// drawSelectableBranchNode draws a node that is both selectable and a parent — a feature row
+// that nests its consumed sketch. The disclosure arrow toggles it open; a click on the label
+// selects it (and a double-click opens its editor), so expansion and selection don't fight.
+func drawSelectableBranchNode(s *app.Session, n app.BrowserNode) {
+	current := s.Selection().First()
+	open := native.TreeNodeSelectable(n.Label, current == n.Select)
+	if native.IsItemClicked(native.MouseLeft) {
+		s.SelectBrowserNode(n)
+	}
+	openEditOnDoubleClick(s, n)
+	drawNodeMenu(s, n)
+	if current != nil && n.Select == current && current != browserSync.last {
+		native.SetScrollHereY()
+	}
+	if !open {
+		return
+	}
+	for _, child := range n.Children {
+		drawNode(s, child)
+	}
+	native.TreePop()
+}
+
 // drawSelectableNode draws a clickable row that selects the node, offers its context menu,
 // and scrolls itself into view when it is the node the selection just changed to.
 func drawSelectableNode(s *app.Session, n app.BrowserNode) {
@@ -67,22 +92,28 @@ func drawSelectableNode(s *app.Session, n app.BrowserNode) {
 	if native.Selectable(n.Label, current == n.Select) {
 		s.SelectBrowserNode(n)
 	}
-	openFeatureEditOnDoubleClick(s, n)
+	openEditOnDoubleClick(s, n)
 	drawNodeMenu(s, n)
 	if current != nil && n.Select == current && current != browserSync.last {
 		native.SetScrollHereY()
 	}
 }
 
-// openFeatureEditOnDoubleClick re-opens a feature node's parameter editor when its row is
-// double-clicked (Inventor's edit-on-double-click). Only feature nodes carry an editor;
-// double-clicking other nodes does nothing.
-func openFeatureEditOnDoubleClick(s *app.Session, n app.BrowserNode) {
+// openEditOnDoubleClick opens the edit mode for the double-clicked node (Inventor's
+// edit-on-double-click), dispatching by node type: a feature opens its parameter editor, a
+// sketch re-enters the sketch environment, and a user work plane opens its redefine tool.
+// A node with nothing to edit (the origin frame, a non-editable feature) does nothing.
+func openEditOnDoubleClick(s *app.Session, n app.BrowserNode) {
 	if !native.IsItemHovered() || !native.IsMouseDoubleClicked(native.MouseLeft) {
 		return
 	}
-	if h, ok := n.Select.(app.FeatureHandle); ok {
+	switch h := n.Select.(type) {
+	case app.FeatureHandle:
 		s.BeginEditFeature(h)
+	case app.SketchHandle:
+		s.BeginEditSketch(h)
+	case app.WorkPlaneHandle:
+		s.BeginEditWorkPlane(h)
 	}
 }
 

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -74,6 +74,7 @@ func drawChromeDialogs(s *app.Session) {
 	drawSurfaceFeatureDialogs(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
+	drawWorkPlaneEditDialog(s)
 }
 
 func drawSolidFeatureDialogs(s *app.Session) {

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -364,8 +364,9 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 // the extrude / active-tool previews) to list.
 func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane, list renderer.DrawList) renderer.DrawList {
 	part := activePart(s)
-	list.Items = append(list.Items, planesOverlay(part, s.SelectedWorkPlane(), hovered)...)
-	list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s))...)
+	hidden := s.EditScopeHides // hide datums created after the node being edited (issue #132)
+	list.Items = append(list.Items, planesOverlay(part, s.SelectedWorkPlane(), hovered, hidden)...)
+	list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s), hidden)...)
 	list.Items = append(list.Items, partSketchOverlays(s)...)
 	list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
 	list.Items = append(list.Items, selectedEdgeOverlay(s)...)

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -16,7 +16,7 @@ import (
 // look), so a created work plane is visible and can be clicked. Hidden planes (Visibility
 // toggled off) are skipped. The selected plane's border is highlighted; the plane under
 // the cursor uses the hover color. Shown outside the sketch environment.
-func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *feature.WorkPlane) []renderer.DrawItem {
+func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *feature.WorkPlane, hidden scopeFilter) []renderer.DrawItem {
 	if part == nil {
 		return nil
 	}
@@ -24,7 +24,7 @@ func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *fea
 	planes := part.WorkPlanes()
 	for i := 0; i < planes.Count(); i++ {
 		wp := planes.Item(i)
-		if !wp.Visible() {
+		if !wp.Visible() || hidden(wp.Seq()) {
 			continue
 		}
 		items = append(items, planeFill(wp), planeBorder(wp, planeColor(wp, selected, hovered)))
@@ -32,7 +32,7 @@ func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *fea
 	return items
 }
 
-func axesOverlay(part *compdef.PartComponentDefinition, selected *feature.WorkAxis) []renderer.DrawItem {
+func axesOverlay(part *compdef.PartComponentDefinition, selected *feature.WorkAxis, hidden scopeFilter) []renderer.DrawItem {
 	if part == nil {
 		return nil
 	}
@@ -40,12 +40,17 @@ func axesOverlay(part *compdef.PartComponentDefinition, selected *feature.WorkAx
 	items := make([]renderer.DrawItem, 0, axes.Count())
 	for i := 0; i < axes.Count(); i++ {
 		axis := axes.Item(i)
-		if axis.Visible() {
+		if axis.Visible() && !hidden(axis.Seq()) {
 			items = append(items, axisLine(axis, axisColor(axis, selected)))
 		}
 	}
 	return items
 }
+
+// scopeFilter reports whether a node with the given creation stamp is hidden by an active
+// edit (created after the edited node). It is [app.Session.EditScopeHides], passed in so the
+// overlay stays decoupled from the session type.
+type scopeFilter func(seq uint64) bool
 
 func axisColor(axis, selected *feature.WorkAxis) [4]float32 {
 	if axis == selected {

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -26,7 +26,7 @@ func partSketchOverlays(s *app.Session) []renderer.DrawItem {
 	var items []renderer.DrawItem
 	for i := 0; i < part.Sketches().Count(); i++ {
 		sk := part.Sketches().Item(i)
-		if !sk.Visible() || sk.IsEditing() {
+		if !sk.Visible() || sk.IsEditing() || s.EditScopeHides(sk.Seq()) {
 			continue
 		}
 		items = append(items, sketchOverlay(sk, allEntitiesWhenSelected(sk, selected), nil)...)
@@ -45,7 +45,7 @@ func partSketchPoints(s *app.Session, hWorld float64) []renderer.DrawItem {
 	var items []renderer.DrawItem
 	for i := 0; i < part.Sketches().Count(); i++ {
 		sk := part.Sketches().Item(i)
-		if !sk.Visible() || sk.IsEditing() {
+		if !sk.Visible() || sk.IsEditing() || s.EditScopeHides(sk.Seq()) {
 			continue
 		}
 		if item, ok := pointsOverlay(sk.Plane(), sk, hWorld); ok {

--- a/head/ui/work_plane_edit_dialog.go
+++ b/head/ui/work_plane_edit_dialog.go
@@ -1,0 +1,51 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Editing a placed offset work plane (browser double-click): a small dialog edits its offset
+// distance and OK/Cancel, mirroring the Offset Plane creation dialog. While it is open the
+// model is rolled back to the plane (edit-scope, issue #132), so the change previews against
+// only the geometry that existed when the plane was made. The distance is in the document's
+// length unit.
+
+// workPlaneEditUI holds the dialog's distance field across frames and whether it was open last
+// frame (so it seeds the field once when the edit opens).
+var workPlaneEditUI = struct {
+	distance float32
+	open     bool
+}{distance: 10}
+
+// drawWorkPlaneEditDialog shows the offset editor while a work-plane edit is active, keeping
+// the tool's distance in sync with the field each frame; OK commits, Cancel restores.
+func drawWorkPlaneEditDialog(s *app.Session) {
+	t := s.ActiveWorkPlaneEdit()
+	if t == nil {
+		workPlaneEditUI.open = false
+		return
+	}
+	if !workPlaneEditUI.open { // edit just opened — seed the field from the plane's current offset
+		workPlaneEditUI.distance = float32(s.EditPlaneOffsetDisplay())
+		workPlaneEditUI.open = true
+	}
+	native.SetNextWindowSize(300, 110)
+	if native.Begin("Edit Work Plane") {
+		native.Text("Offset (" + s.LengthUnitName() + ")")
+		native.InputFloat("##edit-plane-offset", &workPlaneEditUI.distance)
+		s.SetEditPlaneOffsetDisplay(float64(workPlaneEditUI.distance)) // keep the tool in sync
+		if native.Button("OK") {
+			_ = s.OK()
+		}
+		native.SameLine()
+		if native.Button("Cancel") {
+			s.CancelTool()
+		}
+	}
+	native.End()
+}

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -296,7 +296,7 @@ func TestCreationOrderAndSharedSurviveRoundTrip(t *testing.T) {
 	def.Recompute()
 
 	// The stamps must reflect creation order before saving.
-	if !(sk1.Seq() < ext.Seq() && ext.Seq() < wp.Seq() && wp.Seq() < sk2.Seq()) {
+	if !strictlyAscending(sk1.Seq(), ext.Seq(), wp.Seq(), sk2.Seq()) {
 		t.Fatalf("pre-save creation order wrong: sk1=%d ext=%d wp=%d sk2=%d",
 			sk1.Seq(), ext.Seq(), wp.Seq(), sk2.Seq())
 	}
@@ -306,7 +306,7 @@ func TestCreationOrderAndSharedSurviveRoundTrip(t *testing.T) {
 	rext := reopened.Features().Item(0)
 	rwp := reopened.WorkPlanes().Item(reopened.WorkPlanes().Count() - 1)
 
-	if !(rs1.Seq() < rext.Seq() && rext.Seq() < rwp.Seq() && rwp.Seq() < rs2.Seq()) {
+	if !strictlyAscending(rs1.Seq(), rext.Seq(), rwp.Seq(), rs2.Seq()) {
 		t.Errorf("reopened creation order wrong: sk1=%d ext=%d wp=%d sk2=%d",
 			rs1.Seq(), rext.Seq(), rwp.Seq(), rs2.Seq())
 	}
@@ -316,6 +316,17 @@ func TestCreationOrderAndSharedSurviveRoundTrip(t *testing.T) {
 	if !rs2.Shared() {
 		t.Error("sketch2's Shared flag was lost on reopen")
 	}
+}
+
+// strictlyAscending reports whether the creation stamps increase at every step (the
+// chronological order the browser interleaves by).
+func strictlyAscending(seqs ...uint64) bool {
+	for i := 1; i < len(seqs); i++ {
+		if seqs[i] <= seqs[i-1] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestFilletEdgeKeyRebindsAfterReopen(t *testing.T) {

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -277,6 +277,47 @@ func rectangle(s *sketch.Sketch, w, h float64) {
 	s.Lines().Add(c3, c0)
 }
 
+// TestCreationOrderAndSharedSurviveRoundTrip is the issue-#132 persistence regression: the
+// global creation stamps that interleave sketches/work planes/features, and a sketch's
+// Shared flag, must round-trip so a reopened browser shows the same chronological tree.
+func TestCreationOrderAndSharedSurviveRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+
+	// Build in a deliberate order: sketch1 → extrude → work plane → sketch2 (shared).
+	sk1 := def.Sketches().Add(sketch.XYPlane())
+	rectangle(sk1, 4, 3)
+	ext := feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk1, 0, ops.NewBody, func() float64 { return 5 })
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	sk2 := def.Sketches().Add(sketch.XYPlane())
+	sk2.SetShared(true)
+	def.Recompute()
+
+	// The stamps must reflect creation order before saving.
+	if !(sk1.Seq() < ext.Seq() && ext.Seq() < wp.Seq() && wp.Seq() < sk2.Seq()) {
+		t.Fatalf("pre-save creation order wrong: sk1=%d ext=%d wp=%d sk2=%d",
+			sk1.Seq(), ext.Seq(), wp.Seq(), sk2.Seq())
+	}
+
+	reopened := reopenThroughStore(t, d)
+	rs1, rs2 := reopened.Sketches().Item(0), reopened.Sketches().Item(1)
+	rext := reopened.Features().Item(0)
+	rwp := reopened.WorkPlanes().Item(reopened.WorkPlanes().Count() - 1)
+
+	if !(rs1.Seq() < rext.Seq() && rext.Seq() < rwp.Seq() && rwp.Seq() < rs2.Seq()) {
+		t.Errorf("reopened creation order wrong: sk1=%d ext=%d wp=%d sk2=%d",
+			rs1.Seq(), rext.Seq(), rwp.Seq(), rs2.Seq())
+	}
+	if rs1.Shared() {
+		t.Error("sketch1 must not be shared after reopen")
+	}
+	if !rs2.Shared() {
+		t.Error("sketch2's Shared flag was lost on reopen")
+	}
+}
+
 func TestFilletEdgeKeyRebindsAfterReopen(t *testing.T) {
 	ws := doc.NewWorkspace(nil)
 	d, _ := compdef.AddPart(ws, "Part1", true)

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -12,6 +12,7 @@ import (
 	"oblikovati.org/model/health"
 	"oblikovati.org/model/identity"
 	"oblikovati.org/model/param"
+	"oblikovati.org/model/seq"
 	"oblikovati.org/model/text"
 )
 
@@ -68,7 +69,7 @@ func NewPartFeatures(params *param.Parameters, keys *identity.KeyManager) *PartF
 
 // Add appends a feature (initially dirty) with its dependency feature ids.
 func (fs *PartFeatures) Add(f Feature, deps ...ID) *PartFeature {
-	pf := &PartFeature{id: nextID(), name: f.Kind(), feature: f, deps: deps, dirty: true, health: health.Healthy}
+	pf := &PartFeature{id: nextID(), name: f.Kind(), feature: f, deps: deps, dirty: true, health: health.Healthy, seq: seq.Next()}
 	fs.items = append(fs.items, pf)
 	fs.byID[pf.id] = pf
 	return pf

--- a/model/feature/part_feature.go
+++ b/model/feature/part_feature.go
@@ -21,10 +21,18 @@ type PartFeature struct {
 	dirty      bool
 	recomputes int
 	cached     []*topo.Body
+	seq        uint64 // global creation stamp; see model/seq
 }
 
 // ID returns the feature's stable handle (unchanged by rename).
 func (f *PartFeature) ID() ID { return f.id }
+
+// Seq returns the feature's global creation stamp, shared with sketches and work
+// features so the browser interleaves all three by creation order (issue #132).
+func (f *PartFeature) Seq() uint64 { return f.seq }
+
+// setSeq overrides the creation stamp (used when restoring a saved recipe).
+func (f *PartFeature) setSeq(v uint64) { f.seq = v }
 
 // Name/SetName get and set the display name; the id is stable across renames.
 func (f *PartFeature) Name() string     { return f.name }

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/seq"
 	"oblikovati.org/model/sketch"
 )
 
@@ -22,6 +23,7 @@ type FeatureData struct {
 	Kind       string          `yaml:"kind"`
 	Name       string          `yaml:"name,omitempty"`
 	Suppressed bool            `yaml:"suppressed,omitempty"`
+	Seq        uint64          `yaml:"seq,omitempty"` // global creation stamp; see model/seq
 	Extrude    *ExtrudeData    `yaml:"extrude,omitempty"`
 	Fillet     *EdgeDressData  `yaml:"fillet,omitempty"`
 	Chamfer    *EdgeDressData  `yaml:"chamfer,omitempty"`
@@ -91,7 +93,7 @@ func (fs *PartFeatures) indexByID() map[ID]int {
 }
 
 func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (FeatureData, error) {
-	fd := FeatureData{Kind: pf.Kind(), Name: pf.name, Suppressed: pf.suppress}
+	fd := FeatureData{Kind: pf.Kind(), Name: pf.name, Suppressed: pf.suppress, Seq: pf.seq}
 	switch f := pf.feature.(type) {
 	case *ExtrudeFeature:
 		ed, err := serializeExtrude(f.def, sk)
@@ -362,13 +364,18 @@ func evalInt(fn func() int) int {
 
 func constInt(v int) func() int { return func() int { return v } }
 
-// applyFeatureState restores the per-feature engine state (name, suppression).
+// applyFeatureState restores the per-feature engine state (name, suppression, and the
+// global creation stamp so a reopened document keeps its sketch/feature/work interleaving).
 func applyFeatureState(pf *PartFeature, fd FeatureData) {
 	if fd.Name != "" {
 		pf.SetName(fd.Name)
 	}
 	if fd.Suppressed {
 		pf.SetSuppressed(true)
+	}
+	if fd.Seq != 0 {
+		pf.setSeq(fd.Seq)
+		seq.Bump(fd.Seq)
 	}
 }
 

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/seq"
 	"oblikovati.org/model/sketch"
 )
 
@@ -21,6 +22,7 @@ import (
 type WorkFeatureData struct {
 	Collection string    `yaml:"collection"` // plane | axis | point
 	Kind       string    `yaml:"kind"`
+	Seq        uint64    `yaml:"seq,omitempty"` // global creation stamp; see model/seq
 	Refs       []string  `yaml:"refs,omitempty"`
 	Offset     float64   `yaml:"offset,omitempty"`   // plane-offset
 	Angle      float64   `yaml:"angle,omitempty"`    // line-plane-angle
@@ -43,23 +45,40 @@ func MarshalWork(g *WorkGeometry) ([]WorkFeatureData, error) {
 }
 
 func serializeWorkFeature(g *WorkGeometry, e userEntry) (WorkFeatureData, error) {
+	d, s, err := serializeWorkDef(g, e)
+	if err != nil {
+		return WorkFeatureData{}, err
+	}
+	d.Seq = s
+	return d, nil
+}
+
+// serializeWorkDef encodes the work feature's definition and returns its creation stamp,
+// so MarshalWork can persist the global order shared with sketches/features (issue #132).
+func serializeWorkDef(g *WorkGeometry, e userEntry) (WorkFeatureData, uint64, error) {
 	switch e.collection {
 	case "plane":
-		return serializePlaneDef(g.planes.Item(e.index).def)
+		w := g.planes.Item(e.index)
+		d, err := serializePlaneDef(w.def)
+		return d, w.seq, err
 	case "axis":
-		return serializeAxisDef(g.axes.Item(e.index).def)
+		w := g.axes.Item(e.index)
+		d, err := serializeAxisDef(w.def)
+		return d, w.seq, err
 	case "point":
-		return serializePointDef(g.points.Item(e.index).def)
+		w := g.points.Item(e.index)
+		d, err := serializePointDef(w.def)
+		return d, w.seq, err
 	default:
-		return WorkFeatureData{}, fmt.Errorf("unknown work collection %q", e.collection)
+		return WorkFeatureData{}, 0, fmt.Errorf("unknown work collection %q", e.collection)
 	}
 }
 
 func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
 	d := WorkFeatureData{Collection: "plane", Kind: def.kindName(), Refs: refStrings(def.refs())}
 	switch v := def.(type) {
-	case offsetPlaneDef:
-		d.Offset = v.offset()
+	case *offsetPlaneDef:
+		d.Offset = v.distance() // persist the effective distance, including any browser edit
 	case fixedFramePlaneDef:
 		p := v.origin()
 		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
@@ -106,8 +125,27 @@ func ApplyWork(g *WorkGeometry, data []WorkFeatureData) error {
 		if err := restoreWorkFeature(g, d); err != nil {
 			return fmt.Errorf("work feature %d (%s/%s): %w", i, d.Collection, d.Kind, err)
 		}
+		restoreWorkSeq(g, d)
 	}
 	return nil
+}
+
+// restoreWorkSeq pins the just-restored work feature's creation stamp to its saved value
+// (the Add* call above gave it a fresh one), so a reopened document keeps the original
+// sketch/feature/work interleaving. The restored feature is the last in its collection.
+func restoreWorkSeq(g *WorkGeometry, d WorkFeatureData) {
+	if d.Seq == 0 {
+		return
+	}
+	switch d.Collection {
+	case "plane":
+		g.planes.Item(g.planes.Count() - 1).seq = d.Seq
+	case "axis":
+		g.axes.Item(g.axes.Count() - 1).seq = d.Seq
+	case "point":
+		g.points.Item(g.points.Count() - 1).seq = d.Seq
+	}
+	seq.Bump(d.Seq)
 }
 
 func restoreWorkFeature(g *WorkGeometry, d WorkFeatureData) error {

--- a/model/feature/sketch_consumer.go
+++ b/model/feature/sketch_consumer.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "oblikovati.org/model/sketch"
+
+// SketchConsumer is implemented by feature definitions that consume one or more sketches
+// as profile/path/centerline input. The model browser uses it to nest a consumed sketch
+// UNDER the feature that uses it — Inventor's chronological model tree — instead of listing
+// every sketch in a separate branch (issue #132). Implementations return every distinct
+// non-nil sketch the feature depends on; a feature that consumes no sketch (a dress-up, a
+// boolean, a work feature) simply does not implement this interface.
+//
+// Example: an extrude returns its single profile sketch, so the browser draws that sketch as
+// a child of "Extrude1" rather than at the top level.
+type SketchConsumer interface {
+	ConsumedSketches() []*sketch.Sketch
+}
+
+// ConsumedSketches returns the sketches this feature consumes, or nil when it consumes none.
+// It forwards to the wrapped feature when that feature is a [SketchConsumer], so callers work
+// uniformly across every feature kind.
+func (f *PartFeature) ConsumedSketches() []*sketch.Sketch {
+	if c, ok := f.feature.(SketchConsumer); ok {
+		return c.ConsumedSketches()
+	}
+	return nil
+}
+
+// nonNilSketches collects the non-nil sketches from the arguments, de-duplicating by
+// pointer so a feature that names the same sketch twice (e.g. a revolve whose profile and
+// centerline live in one sketch) reports it once.
+func nonNilSketches(sks ...*sketch.Sketch) []*sketch.Sketch {
+	var out []*sketch.Sketch
+	for _, sk := range sks {
+		if sk == nil {
+			continue
+		}
+		if !containsSketch(out, sk) {
+			out = append(out, sk)
+		}
+	}
+	return out
+}
+
+func containsSketch(in []*sketch.Sketch, want *sketch.Sketch) bool {
+	for _, sk := range in {
+		if sk == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile-time proof that every sketch-consuming feature reports its sketches, so the
+// browser's nesting stays complete as feature kinds evolve.
+var (
+	_ SketchConsumer = (*ExtrudeFeature)(nil)
+	_ SketchConsumer = (*EmbossFeature)(nil)
+	_ SketchConsumer = (*RevolveFeature)(nil)
+	_ SketchConsumer = (*CoilFeature)(nil)
+	_ SketchConsumer = (*RibFeature)(nil)
+	_ SketchConsumer = (*SweepFeature)(nil)
+	_ SketchConsumer = (*LoftFeature)(nil)
+	_ SketchConsumer = (*BoundaryPatchFeature)(nil)
+	_ SketchConsumer = (*RuledSurfaceFeature)(nil)
+)
+
+// --- per-feature consumed-sketch reporting (the sketches that feed each feature's geometry) ---
+
+func (e *ExtrudeFeature) ConsumedSketches() []*sketch.Sketch { return nonNilSketches(e.def.Sketch) }
+func (f *EmbossFeature) ConsumedSketches() []*sketch.Sketch  { return nonNilSketches(f.def.Sketch) }
+func (c *CoilFeature) ConsumedSketches() []*sketch.Sketch    { return nonNilSketches(c.def.Sketch) }
+func (r *RibFeature) ConsumedSketches() []*sketch.Sketch     { return nonNilSketches(r.def.Sketch) }
+func (s *SweepFeature) ConsumedSketches() []*sketch.Sketch   { return nonNilSketches(s.def.Sketch) }
+
+func (r *RevolveFeature) ConsumedSketches() []*sketch.Sketch {
+	return nonNilSketches(r.def.Sketch, r.def.AxisCenterlineSketch)
+}
+
+func (r *RuledSurfaceFeature) ConsumedSketches() []*sketch.Sketch {
+	return nonNilSketches(r.def.Sketch)
+}
+
+func (l *LoftFeature) ConsumedSketches() []*sketch.Sketch {
+	sks := make([]*sketch.Sketch, 0, len(l.def.Sections))
+	for _, s := range l.def.Sections {
+		sks = append(sks, s.Sketch) // nil for point/face sections — nonNilSketches drops them
+	}
+	return nonNilSketches(sks...)
+}
+
+func (b *BoundaryPatchFeature) ConsumedSketches() []*sketch.Sketch {
+	loops := b.def.Loops
+	if loops == nil {
+		return nil
+	}
+	sks := make([]*sketch.Sketch, 0, loops.Count())
+	for i := 0; i < loops.Count(); i++ {
+		sks = append(sks, loops.Item(i).Sketch)
+	}
+	return nonNilSketches(sks...)
+}

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
+	"oblikovati.org/model/seq"
 	"oblikovati.org/model/sketch"
 )
 
@@ -76,9 +77,11 @@ type WorkAxis struct {
 	visible          bool
 	coordinateSystem bool
 	grounded         bool
+	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
 }
 
 func (w *WorkAxis) ID() ID                          { return w.id }
+func (w *WorkAxis) Seq() uint64                     { return w.seq }
 func (w *WorkAxis) Key() WorkRef                    { return w.key }
 func (w *WorkAxis) Name() string                    { return w.name }
 func (w *WorkAxis) Health() health.Health           { return w.health }
@@ -134,7 +137,7 @@ func (c *WorkAxes) AddByPlaneIntersection(p1, p2 WorkRef) *WorkAxis {
 }
 
 func (c *WorkAxes) addUser(def axisDefinition) *WorkAxis {
-	w := &WorkAxis{id: nextID(), key: userRef("axis", len(c.items)), name: "WorkAxis", def: def, visible: true}
+	w := &WorkAxis{id: nextID(), key: userRef("axis", len(c.items)), name: "WorkAxis", def: def, visible: true, seq: seq.Next()}
 	c.track(w)
 	c.g.recordUser("axis", len(c.items)-1)
 	return w
@@ -208,9 +211,11 @@ type WorkPoint struct {
 	health           health.Health
 	coordinateSystem bool
 	grounded         bool
+	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
 }
 
 func (w *WorkPoint) ID() ID                          { return w.id }
+func (w *WorkPoint) Seq() uint64                     { return w.seq }
 func (w *WorkPoint) Key() WorkRef                    { return w.key }
 func (w *WorkPoint) Name() string                    { return w.name }
 func (w *WorkPoint) Health() health.Health           { return w.health }
@@ -260,7 +265,7 @@ func (c *WorkPoints) AddByPlaneAndAxisIntersection(plane, axis WorkRef) *WorkPoi
 }
 
 func (c *WorkPoints) addUser(def pointDefinition) *WorkPoint {
-	w := &WorkPoint{id: nextID(), key: userRef("point", len(c.items)), name: "WorkPoint", def: def}
+	w := &WorkPoint{id: nextID(), key: userRef("point", len(c.items)), name: "WorkPoint", def: def, seq: seq.Next()}
 	c.track(w)
 	c.g.recordUser("point", len(c.items)-1)
 	return w

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
+	"oblikovati.org/model/seq"
 	"oblikovati.org/model/sketch"
 )
 
@@ -34,20 +35,35 @@ func (d fixedPlaneDef) refs() []WorkRef                         { return nil }
 func (d fixedPlaneDef) eval(workResolver) (sketch.Plane, error) { return d.plane, nil }
 
 // offsetPlaneDef is a plane parallel to a base plane, offset along its normal by a
-// (parametric) distance — Inventor's PlaneAndOffset definition.
+// (parametric) distance — Inventor's PlaneAndOffset definition. The distance comes from the
+// offset closure (a constant or a parameter), unless an explicit edited value overrides it
+// (the browser's "edit work plane", issue #132). It is stored behind a pointer so an edit
+// mutates the live definition.
 type offsetPlaneDef struct {
 	base   WorkRef
 	offset func() float64
+	edited *float64 // explicit edited distance (model units); wins over offset when set
 }
 
-func (d offsetPlaneDef) kindName() string { return "plane-offset" }
-func (d offsetPlaneDef) refs() []WorkRef  { return []WorkRef{d.base} }
-func (d offsetPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+func (d *offsetPlaneDef) kindName() string { return "plane-offset" }
+func (d *offsetPlaneDef) refs() []WorkRef  { return []WorkRef{d.base} }
+
+// distance returns the offset currently in effect (the edited value if one was set, else the
+// closure's value); setDistance pins an explicit edited distance.
+func (d *offsetPlaneDef) distance() float64 {
+	if d.edited != nil {
+		return *d.edited
+	}
+	return d.offset()
+}
+func (d *offsetPlaneDef) setDistance(v float64) { d.edited = &v }
+
+func (d *offsetPlaneDef) eval(r workResolver) (sketch.Plane, error) {
 	base, err := r.plane(d.base)
 	if err != nil {
 		return sketch.Plane{}, err
 	}
-	origin := base.Origin().TranslateBy(base.Normal().AsVector().Scale(d.offset()))
+	origin := base.Origin().TranslateBy(base.Normal().AsVector().Scale(d.distance()))
 	return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
 }
 
@@ -84,11 +100,14 @@ type WorkPlane struct {
 	coordinateSystem bool
 	grounded         bool
 	visible          bool
+	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
 }
 
 // ID/Key/Name identify the datum; Health reports its last recompute state.
 func (w *WorkPlane) ID() ID                { return w.id }
 func (w *WorkPlane) Key() WorkRef          { return w.key }
+func (w *WorkPlane) Seq() uint64           { return w.seq }
+func (w *WorkPlane) setSeq(v uint64)       { w.seq = v }
 func (w *WorkPlane) Name() string          { return w.name }
 func (w *WorkPlane) SetName(n string)      { w.name = n }
 func (w *WorkPlane) Health() health.Health { return w.health }
@@ -108,6 +127,28 @@ func (w *WorkPlane) Grounded() bool                  { return w.grounded }
 // (Inventor's per-work-feature Visibility). User planes are visible by default.
 func (w *WorkPlane) Visible() bool     { return w.visible }
 func (w *WorkPlane) SetVisible(v bool) { w.visible = v }
+
+// OffsetDistance returns the plane's offset distance in model units and true when this is a
+// plane-and-offset datum (the editable kind, Inventor's most common parametric work plane);
+// ok is false for every other plane kind, which has no single scalar to edit.
+func (w *WorkPlane) OffsetDistance() (float64, bool) {
+	if d, ok := w.def.(*offsetPlaneDef); ok {
+		return d.distance(), true
+	}
+	return 0, false
+}
+
+// SetOffsetDistance pins an offset plane's distance to v (model units) and re-derives the
+// plane, returning true on success. It is a no-op (false) for non-offset planes. The owning
+// part must recompute afterward so dependent sketches/features follow the moved plane.
+func (w *WorkPlane) SetOffsetDistance(v float64) bool {
+	d, ok := w.def.(*offsetPlaneDef)
+	if !ok {
+		return false
+	}
+	d.setDistance(v)
+	return true
+}
 
 // recompute re-derives the plane from its definition, going sick on failure (e.g.
 // degenerate three points) rather than producing garbage.
@@ -145,7 +186,7 @@ func (c *WorkPlanes) addOrigin(key WorkRef, name string, plane sketch.Plane) {
 // AddByPlaneAndOffset creates a user plane parallel to base, offset by the value the
 // closure returns (typically a parameter), so the datum moves when that param changes.
 func (c *WorkPlanes) AddByPlaneAndOffset(base WorkRef, offset func() float64) *WorkPlane {
-	return c.addUser(offsetPlaneDef{base: base, offset: offset})
+	return c.addUser(&offsetPlaneDef{base: base, offset: offset})
 }
 
 // AddByThreePoints creates a user plane through three referenced points.
@@ -159,7 +200,7 @@ func (c *WorkPlanes) AddByThreePoints(a, b, cc WorkRef) *WorkPlane {
 func (c *WorkPlanes) addUser(def planeDefinition) *WorkPlane {
 	w := &WorkPlane{
 		id: nextID(), key: userRef("plane", len(c.items)), name: "WorkPlane", def: def,
-		displaySize: defaultOriginPlaneSize, visible: true,
+		displaySize: defaultOriginPlaneSize, visible: true, seq: seq.Next(),
 	}
 	c.track(w)
 	c.g.recordUser("plane", len(c.items)-1)

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -107,7 +107,6 @@ type WorkPlane struct {
 func (w *WorkPlane) ID() ID                { return w.id }
 func (w *WorkPlane) Key() WorkRef          { return w.key }
 func (w *WorkPlane) Seq() uint64           { return w.seq }
-func (w *WorkPlane) setSeq(v uint64)       { w.seq = v }
 func (w *WorkPlane) Name() string          { return w.name }
 func (w *WorkPlane) SetName(n string)      { w.name = n }
 func (w *WorkPlane) Health() health.Health { return w.health }

--- a/model/seq/seq.go
+++ b/model/seq/seq.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package seq provides one process-wide monotonic creation clock so modeling nodes that
+// live in separate collections — sketches, work features, and part features — share a
+// single creation order. The model browser interleaves them by this stamp (Inventor's
+// chronological model tree, issue #132), and edit-scope visibility uses it to tell what
+// was created "after" the node being edited.
+//
+// Stamps are only ever compared within one document, so a single global clock is
+// sufficient (cross-document ordering is never meaningful). A loaded document restores
+// its nodes' saved stamps and calls [Bump] so freshly created nodes still sort after them.
+package seq
+
+import "sync/atomic"
+
+// clock is the shared monotonic source. It mirrors the package-level id counter the
+// feature engine already uses (model/feature.idSeq), kept here so both the sketch and
+// feature packages can stamp from the same sequence without an import cycle.
+var clock atomic.Uint64
+
+// Next returns the next creation stamp: strictly increasing and never zero. Zero is
+// reserved for the static origin coordinate frame, which must always sort first.
+//
+// Example: sk.seq = seq.Next() — stamped once, when the sketch is added to its collection.
+func Next() uint64 { return clock.Add(1) }
+
+// Bump raises the clock floor to at least v, so a node created after a document is loaded
+// (its peers' stamps restored from the recipe) still receives a strictly larger stamp than
+// every restored one. Safe for concurrent use; a no-op when v is already below the floor.
+func Bump(v uint64) {
+	for {
+		cur := clock.Load()
+		if v <= cur || clock.CompareAndSwap(cur, v) {
+			return
+		}
+	}
+}

--- a/model/seq/seq_test.go
+++ b/model/seq/seq_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package seq
+
+import "testing"
+
+func TestNextIsStrictlyIncreasingAndNonZero(t *testing.T) {
+	a := Next()
+	b := Next()
+	if a == 0 {
+		t.Fatal("Next returned 0, which is reserved for the origin frame")
+	}
+	if b <= a {
+		t.Fatalf("Next not increasing: a=%d b=%d", a, b)
+	}
+}
+
+func TestBumpRaisesFloorButNeverLowersIt(t *testing.T) {
+	high := Next() + 1000
+	Bump(high)
+	if got := Next(); got <= high {
+		t.Fatalf("after Bump(%d), Next=%d; want > %d", high, got, high)
+	}
+	// A bump below the current floor must not rewind the clock.
+	before := Next()
+	Bump(1) // far below the floor
+	if got := Next(); got <= before {
+		t.Fatalf("Bump(1) rewound the clock: before=%d after=%d", before, got)
+	}
+}

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -22,6 +22,8 @@ import (
 type SketchData struct {
 	Name         string           `yaml:"name,omitempty"`
 	Hidden       bool             `yaml:"hidden,omitempty"`
+	Shared       bool             `yaml:"shared,omitempty"` // Inventor PlanarSketch.Shared (issue #132)
+	Seq          uint64           `yaml:"seq,omitempty"`    // global creation stamp; see model/seq
 	Color        string           `yaml:"color,omitempty"`
 	LineType     string           `yaml:"lineType,omitempty"`
 	LineWeight   float64          `yaml:"lineWeight,omitempty"`
@@ -138,6 +140,8 @@ func serializeSketch(s *Sketch) (SketchData, error) {
 	sd := SketchData{
 		Name:         s.name,
 		Hidden:       !s.visible,
+		Shared:       s.shared,
+		Seq:          s.seq,
 		Color:        s.color,
 		LineType:     s.lineType,
 		LineWeight:   s.lineWeight,

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/seq"
 )
 
 // This file defines the git-friendly YAML projection of a 3D sketch (ADR-0020) and its
@@ -20,6 +21,8 @@ type SketchData3D struct {
 	Name         string            `yaml:"name,omitempty"`
 	Hidden       bool              `yaml:"hidden,omitempty"`
 	DimsHidden   bool              `yaml:"dimsHidden,omitempty"`
+	Shared       bool              `yaml:"shared,omitempty"` // Inventor Sketch3D.Shared (issue #132)
+	Seq          uint64            `yaml:"seq,omitempty"`    // global creation stamp; see model/seq
 	Color        string            `yaml:"color,omitempty"`
 	DeferUpdates bool              `yaml:"deferUpdates,omitempty"`
 	Points       []Point3DData     `yaml:"points,omitempty"`
@@ -116,6 +119,8 @@ func serializeSketch3D(s *Sketch3D) (SketchData3D, error) {
 		Name:         s.name,
 		Hidden:       !s.visible,
 		DimsHidden:   !s.dimensionsVisible,
+		Shared:       s.shared,
+		Seq:          s.seq,
 		Color:        s.color,
 		DeferUpdates: s.deferUpdates,
 	}
@@ -343,8 +348,13 @@ func (c *Sketches3D) restoreSketch3D(sd SketchData3D) error {
 	s := c.AddNamed(sd.Name)
 	s.visible = !sd.Hidden
 	s.dimensionsVisible = !sd.DimsHidden
+	s.shared = sd.Shared
 	s.color = sd.Color
 	s.deferUpdates = sd.DeferUpdates
+	if sd.Seq != 0 {
+		s.seq = sd.Seq
+		seq.Bump(sd.Seq)
+	}
 	// Re-create points, mapping their saved ids onto the freshly minted ones so
 	// constraints can re-bind by id.
 	idmap := make(map[int]*Point3D, len(sd.Points))

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/seq"
 )
 
 // ApplyRecipe rebuilds the sketches from their serialized form, in order. It is the
@@ -79,10 +80,24 @@ func restoreSketchProps(s *Sketch, sd SketchData) {
 		s.SetName(sd.Name)
 	}
 	s.SetVisible(!sd.Hidden)
+	s.SetShared(sd.Shared)
+	restoreSeq(s, sd.Seq)
 	s.SetColor(sd.Color)
 	s.SetLineType(sd.LineType)
 	s.SetLineWeight(sd.LineWeight)
 	s.SetDeferUpdates(sd.DeferUpdates)
+}
+
+// restoreSeq pins the sketch's creation stamp to its saved value (so reopened documents
+// keep the original sketch/feature/work-feature interleaving) and raises the global clock
+// past it. A legacy recipe with no stamp keeps the fresh one sc.Add assigned, which still
+// orders sketches among themselves by load order.
+func restoreSeq(s *Sketch, saved uint64) {
+	if saved == 0 {
+		return
+	}
+	s.SetSeq(saved)
+	seq.Bump(saved)
 }
 
 // sketchRestorer carries the id→object maps while rebuilding one sketch.

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
 	"oblikovati.org/model/param"
+	"oblikovati.org/model/seq"
 )
 
 // ID is the session-stable handle of a sketch or sketch entity, used by
@@ -34,6 +35,8 @@ type base struct {
 	name    string
 	editing bool
 	visible bool
+	shared  bool   // Inventor PlanarSketch.Shared: stays visible at top level, may feed many features
+	seq     uint64 // global creation stamp, shared with features/work features; see model/seq
 	health  health.Health
 
 	// Display + solve overrides (Inventor Sketch.Color/LineType/LineWeight/DeferUpdates).
@@ -44,7 +47,7 @@ type base struct {
 }
 
 func newBase(name string) base {
-	return base{id: nextID(), name: name, visible: true, health: health.Healthy}
+	return base{id: nextID(), name: name, visible: true, seq: seq.Next(), health: health.Healthy}
 }
 
 // ID returns the sketch's session id.
@@ -66,6 +69,17 @@ func (b *base) ExitEdit() { b.editing = false }
 // Visible reports whether the sketch is shown; SetVisible toggles it.
 func (b *base) Visible() bool     { return b.visible }
 func (b *base) SetVisible(v bool) { b.visible = v }
+
+// Shared reports whether the sketch is shared (Inventor PlanarSketch.Shared): a shared
+// sketch stays at the browser's top level even after a feature consumes it, and may be
+// consumed by several features. SetShared toggles it (browser "Share Sketch", issue #132).
+func (b *base) Shared() bool     { return b.shared }
+func (b *base) SetShared(s bool) { b.shared = s }
+
+// Seq returns the sketch's global creation stamp; SetSeq overrides it when restoring a
+// saved recipe so reopened documents keep their original interleaving.
+func (b *base) Seq() uint64     { return b.seq }
+func (b *base) SetSeq(v uint64) { b.seq = v }
 
 // Health returns the sketch's solve health (set by the solver, M06-F05).
 func (b *base) Health() health.Health { return b.health }


### PR DESCRIPTION
Fixes the four Model Browser / work-plane / sketch behaviours reported in #132.

## What & why

**1. No special Sketches branch (nested chronological tree).**
Sketches lived in a flat `Sketches` folder, divorced from the feature timeline,
so you couldn't see that a sketch sits on a work plane built from an earlier
feature. The browser now interleaves user work features, sketches, and features
in one tree by global **creation order**; a sketch consumed by exactly one
feature **nests under that feature** (Inventor's model tree). A **Shared** sketch
(Inventor `PlanarSketch.Shared`, new right-click **Share / Unshare Sketch**) stays
at top level and may feed several features.

**2. Double-click opens edit mode for sketches and work planes (not only features).**
Double-click now dispatches by node type: features open their parameter editor
(unchanged), sketches re-enter the sketch environment, and offset work planes open
a distance editor (new `WorkPlaneEditTool` + dialog). Offset planes were made
editable for this. *(Three-point/tangent plane redefine is a follow-up — double-click
is a no-op there, like a non-editable feature.)*

**3. Edit-scope visibility — hide everything created after the edited node.**
While editing a feature/sketch/work plane, the feature engine is rolled back via
its end-of-part marker (trailing feature geometry disappears) and the head's
plane/axis/sketch overlays skip nodes created after the edit cutoff. Restored on
commit/cancel/finish.

**4. User work planes are pickable in the 3D view.**
The ray picker was fed only the origin planes, so a ribbon-created plane couldn't
be clicked as a new sketch's host. It now receives every visible work plane.

## How
A new process-wide creation clock (`model/seq`) — the same package-atomic pattern
the feature engine already uses for ids — stamps every sketch, feature, and user
work feature with a `Seq()` at creation (origin frame = 0). The stamp is persisted
in the recipe and powers both the chronological interleave (#1) and the
"what came after" cutoff (#3). `SketchConsumer` reports each feature's consumed
sketches for nesting. No public `api/wire` change — browser, `Shared`, and the
edit flow are internal model/app/head.

## Tests
- `model/seq`: monotonic clock + bump floor.
- model: seq stamping + `.obk` round-trip preserves creation order & `Shared`;
  offset-plane editability; `ConsumedSketches` per feature kind.
- app: browser nesting (consumed→nested, shared→top-level, timeline order),
  Share toggle, `BeginEditSketch`/`BeginEditWorkPlane`, edit-scope sets EOP and
  restores on commit/cancel, picker resolves a user plane.
- head: `ui` package tests pass (TreeNodeSelectable rendering path).
- Live: rebuilt head driven over the mcp-bridge builds a multi-feature part with
  exact volume and renders cleanly (no model/render regression). Browser-panel and
  mouse-driven behaviours aren't exposed by the bridge, so they're covered by the
  app/head unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)