### PR TITLE
Work-plane redefine: edit three-point/tangent/angle planes on double-click (#132 follow-up)

### DIFF
--- a/app/work_plane_edit.go
+++ b/app/work_plane_edit.go
@@ -9,82 +9,176 @@ import (
 	"oblikovati.org/model/param"
 )
 
-// Editing a placed work plane — Inventor's double-click / browser "Edit" on a datum plane.
-// Only the plane-and-offset kind carries a single scalar to edit (its offset distance); the
-// other plane kinds (three-point, tangent, …) are defined purely by references and have no
-// value to type, so they are not opened for edit here (a follow-up redefine flow). Each
-// change recomputes live; OK keeps it, Cancel restores the distance captured when editing
-// opened. See issue #132.
+// Editing / redefining a placed work plane — Inventor's double-click / browser "Edit" on a
+// datum plane. An offset plane edits its distance; a reference-built plane (three points, two
+// planes, a tangent face, …) re-picks those references; a line-plane-angle plane edits its
+// angle. This mirrors the feature-edit flow (app/feature_edit.go): scalar fields plus armed
+// reference slots that route viewport/browser picks. Each change recomputes live; OK keeps it,
+// Cancel restores the definition captured when editing opened. See issue #132.
 
-// WorkPlaneEditTool edits one offset work plane's distance in place.
+// WorkPlaneEditTool edits one placed work plane: its scalar inputs (offset/angle) and its
+// re-pickable reference slots. armed is the index of the slot currently collecting picks (-1
+// when none is armed and clicks are ignored).
 type WorkPlaneEditTool struct {
-	plane    *feature.WorkPlane
-	distance float64 // current edited offset, model units
-	original float64 // offset captured at open, for Cancel
+	plane      *feature.WorkPlane
+	scalars    []feature.EditableParam
+	origScalar []float64
+	slots      []feature.WorkRefSlot
+	restoreDef func() // restores the whole definition (refs + scalars) on Cancel
+	armed      int
 }
 
-// newWorkPlaneEditTool captures the plane's current offset as the edit's starting value.
 func newWorkPlaneEditTool(wp *feature.WorkPlane) *WorkPlaneEditTool {
-	d, _ := wp.OffsetDistance()
-	return &WorkPlaneEditTool{plane: wp, distance: d, original: d}
+	t := &WorkPlaneEditTool{
+		plane:      wp,
+		scalars:    wp.EditableScalars(),
+		slots:      wp.RedefineSlots(),
+		restoreDef: wp.SnapshotDefinition(),
+		armed:      -1,
+	}
+	t.origScalar = make([]float64, len(t.scalars))
+	for i, p := range t.scalars {
+		t.origScalar[i] = p.Get()
+	}
+	return t
 }
+
+func (t *WorkPlaneEditTool) editable() bool { return len(t.scalars) > 0 || len(t.slots) > 0 }
 
 // Name implements [Tool].
 func (t *WorkPlaneEditTool) Name() string { return "Edit " + t.plane.Name() }
 
-// Start is a no-op: the plane is already chosen, the dialog only edits its distance.
-func (t *WorkPlaneEditTool) Start(*Session) {}
+// Start clears any armed slot (clicks do nothing until the user presses a slot's Select).
+func (t *WorkPlaneEditTool) Start(*Session) { t.armed = -1 }
 
-// Pick ignores viewport picks: an offset edit takes only a typed distance, no geometry.
-func (t *WorkPlaneEditTool) Pick(*Session, Selectable) {}
+// Pick routes a viewport/browser pick to the armed reference slot: it maps the pick to a
+// WorkRef of the slot's kind, re-points the plane, and recomputes so the change is immediate.
+func (t *WorkPlaneEditTool) Pick(s *Session, sel Selectable) {
+	if t.armed < 0 || t.armed >= len(t.slots) {
+		return
+	}
+	slot := t.slots[t.armed]
+	ref, ok := workRefOf(sel, slot.Kind)
+	if !ok {
+		return
+	}
+	slot.Set(ref)
+	t.disarm(s) // a single-reference slot is satisfied by one pick
+	t.recompute(s)
+}
 
-// SetDistance / Distance hold the offset in model units (the head's dialog reads/sets these
-// through the session bridge, converting to/from the document's length unit).
-func (t *WorkPlaneEditTool) SetDistance(d float64) { t.distance = d }
-func (t *WorkPlaneEditTool) Distance() float64     { return t.distance }
-
-// CanCommit allows committing any distance (including 0 — a coincident plane is valid).
+// CanCommit reports the edit is always committable (an invalid redefinition goes Sick and
+// keeps the dialog open via Commit's error).
 func (t *WorkPlaneEditTool) CanCommit() bool { return true }
 
-// Commit writes the edited distance onto the plane, recomputes, and records the edit.
+// Commit recomputes with the edited scalars/references, ends the edit scope, and records the
+// edit. A sick plane returns an error so the dialog stays open for correction.
 func (t *WorkPlaneEditTool) Commit(s *Session) error {
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
-	if !t.plane.SetOffsetDistance(t.distance) {
-		return errors.New("work plane edit: plane is not an editable offset plane")
-	}
 	s.endEditScope()
 	part.Recompute()
 	s.recordEdit(part, "Edit "+t.plane.Name())
+	s.Selection().SetFilter(NewSelectionFilter())
+	if !t.plane.Health().OK() {
+		return errors.New("work plane edit: " + t.plane.Health().Reason)
+	}
 	return nil
 }
 
-// Cancel restores the offset captured at open and recomputes.
+// Cancel restores the snapshotted scalars and definition, recomputes, and clears the filter.
 func (t *WorkPlaneEditTool) Cancel(s *Session) {
-	t.plane.SetOffsetDistance(t.original)
+	for i, p := range t.scalars {
+		p.Set(t.origScalar[i])
+	}
+	t.restoreDef()
 	s.endEditScope()
+	if part, err := activePart(s); err == nil {
+		part.Recompute()
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+
+// Arm puts the i-th reference slot into pick mode (its kind's filter).
+func (t *WorkPlaneEditTool) Arm(s *Session, i int) {
+	if i < 0 || i >= len(t.slots) {
+		return
+	}
+	t.armed = i
+	s.Selection().SetFilter(NewSelectionFilter(workRefFilterKinds(t.slots[i].Kind)...))
+}
+
+// ArmedSlot returns the index of the reference slot currently collecting picks, or -1.
+func (t *WorkPlaneEditTool) ArmedSlot() int { return t.armed }
+
+func (t *WorkPlaneEditTool) disarm(s *Session) {
+	t.armed = -1
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+
+func (t *WorkPlaneEditTool) recompute(s *Session) {
 	if part, err := activePart(s); err == nil {
 		part.Recompute()
 	}
 }
 
-// BeginEditWorkPlane opens an offset work plane for distance editing (browser double-click /
-// Edit menu). Origin coordinate-system planes and non-offset plane kinds have nothing to
-// edit, so they are a no-op (matching a feature with no editable parameters).
+// workRefOf maps a viewport/browser pick to a feature.WorkRef of the slot's kind: a work plane
+// or planar face for a plane slot, a work axis for an axis slot, a work point for a point slot,
+// a B-rep face for a face slot. ok=false for a mismatched pick.
+func workRefOf(sel Selectable, kind feature.WorkRefKind) (feature.WorkRef, bool) {
+	switch kind {
+	case feature.WorkRefPlane:
+		if h, ok := sel.(WorkPlaneHandle); ok {
+			return h.Plane.Key(), true
+		}
+		if h, ok := sel.(FaceHandle); ok {
+			return feature.FaceRef(h.Face.ReferenceKey()), true
+		}
+	case feature.WorkRefAxis:
+		if h, ok := sel.(WorkAxisHandle); ok {
+			return h.Axis.Key(), true
+		}
+	case feature.WorkRefPoint:
+		if h, ok := sel.(WorkPointHandle); ok {
+			return h.Point.Key(), true
+		}
+	case feature.WorkRefFace:
+		if h, ok := sel.(FaceHandle); ok {
+			return feature.FaceRef(h.Face.ReferenceKey()), true
+		}
+	}
+	return "", false
+}
+
+// workRefFilterKinds maps a redefine slot's kind to the selection-filter kinds that pick it.
+func workRefFilterKinds(kind feature.WorkRefKind) []SelectionKind {
+	switch kind {
+	case feature.WorkRefPlane:
+		return []SelectionKind{SelectWorkPlane, SelectFace} // a planar face is a valid plane ref
+	case feature.WorkRefAxis:
+		return []SelectionKind{SelectWorkAxis}
+	case feature.WorkRefPoint:
+		return []SelectionKind{SelectWorkPoint}
+	default: // WorkRefFace
+		return []SelectionKind{SelectFace}
+	}
+}
+
+// BeginEditWorkPlane opens a work plane for editing (browser double-click / Edit menu). Origin
+// coordinate-system planes and plane kinds with nothing to edit (fixed-frame) are a no-op.
 func (s *Session) BeginEditWorkPlane(h WorkPlaneHandle) {
 	if h.Plane == nil || h.Plane.IsCoordinateSystemElement() {
 		return
 	}
-	if _, ok := h.Plane.OffsetDistance(); !ok {
+	t := newWorkPlaneEditTool(h.Plane)
+	if !t.editable() {
 		return
 	}
 	s.beginEditScope(h.Plane.Seq())
-	s.StartTool(newWorkPlaneEditTool(h.Plane))
+	s.StartTool(t)
 }
-
-// --- session bridge for the head dialog (offset in the document's length unit) ---
 
 // ActiveWorkPlaneEdit returns the running work-plane edit tool, or nil.
 func (s *Session) ActiveWorkPlaneEdit() *WorkPlaneEditTool {
@@ -95,6 +189,9 @@ func (s *Session) ActiveWorkPlaneEdit() *WorkPlaneEditTool {
 	return t
 }
 
+// IsEditingWorkPlane reports whether a work-plane edit dialog should be open.
+func (s *Session) IsEditingWorkPlane() bool { return s.ActiveWorkPlaneEdit() != nil }
+
 // EditPlaneName returns the name of the work plane being edited (the dialog title), or "".
 func (s *Session) EditPlaneName() string {
 	if t := s.ActiveWorkPlaneEdit(); t != nil {
@@ -103,18 +200,100 @@ func (s *Session) EditPlaneName() string {
 	return ""
 }
 
-// EditPlaneOffsetDisplay returns the edited offset in the document's length unit.
-func (s *Session) EditPlaneOffsetDisplay() float64 {
-	t := s.ActiveWorkPlaneEdit()
-	if t == nil {
-		return 0
+// --- scalar accessors (the dialog reads/writes in the document's units) ---
+
+// EditPlaneScalarCount returns how many editable scalar fields the open edit has.
+func (s *Session) EditPlaneScalarCount() int {
+	if t := s.ActiveWorkPlaneEdit(); t != nil {
+		return len(t.scalars)
 	}
-	return s.DocumentUnits().ToPreferred(param.Q(t.Distance(), param.Length))
+	return 0
 }
 
-// SetEditPlaneOffsetDisplay sets the edited offset from a value in the document's length unit.
-func (s *Session) SetEditPlaneOffsetDisplay(value float64) {
+// EditPlaneScalarLabel returns the i-th scalar field's label.
+func (s *Session) EditPlaneScalarLabel(i int) string {
+	if p, ok := s.editPlaneScalar(i); ok {
+		return p.Label
+	}
+	return ""
+}
+
+// EditPlaneScalarUnitName returns the i-th scalar field's unit name ("mm", "deg", …), or "".
+func (s *Session) EditPlaneScalarUnitName(i int) string {
+	p, ok := s.editPlaneScalar(i)
+	if !ok {
+		return ""
+	}
+	switch p.Unit {
+	case param.Length:
+		return s.LengthUnitName()
+	case param.Angle:
+		return s.AngleUnitName()
+	default:
+		return ""
+	}
+}
+
+// EditPlaneScalarValue returns the i-th scalar in the document's preferred unit.
+func (s *Session) EditPlaneScalarValue(i int) float64 {
+	p, ok := s.editPlaneScalar(i)
+	if !ok {
+		return 0
+	}
+	if p.Unit == param.Unitless {
+		return p.Get()
+	}
+	return s.DocumentUnits().ToPreferred(param.Q(p.Get(), p.Unit))
+}
+
+// SetEditPlaneScalarValue sets the i-th scalar from a value in the document's preferred unit.
+func (s *Session) SetEditPlaneScalarValue(i int, value float64) {
+	p, ok := s.editPlaneScalar(i)
+	if !ok {
+		return
+	}
+	if p.Unit == param.Unitless {
+		p.Set(value)
+		return
+	}
+	p.Set(s.DocumentUnits().FromPreferred(value, p.Unit).Value)
+}
+
+func (s *Session) editPlaneScalar(i int) (feature.EditableParam, bool) {
+	t := s.ActiveWorkPlaneEdit()
+	if t == nil || i < 0 || i >= len(t.scalars) {
+		return feature.EditableParam{}, false
+	}
+	return t.scalars[i], true
+}
+
+// --- reference-slot accessors (re-pick geometry) ---
+
+// EditPlaneRefSlotCount returns how many reference slots the open edit has.
+func (s *Session) EditPlaneRefSlotCount() int {
 	if t := s.ActiveWorkPlaneEdit(); t != nil {
-		t.SetDistance(s.DocumentUnits().FromPreferred(value, param.Length).Value)
+		return len(t.slots)
+	}
+	return 0
+}
+
+// EditPlaneRefSlotLabel returns the i-th slot's label (e.g. "Tangent face").
+func (s *Session) EditPlaneRefSlotLabel(i int) string {
+	if t := s.ActiveWorkPlaneEdit(); t != nil && i >= 0 && i < len(t.slots) {
+		return t.slots[i].Label
+	}
+	return ""
+}
+
+// EditPlaneRefSlotArmed reports whether the i-th slot is currently collecting picks.
+func (s *Session) EditPlaneRefSlotArmed(i int) bool {
+	t := s.ActiveWorkPlaneEdit()
+	return t != nil && t.ArmedSlot() == i
+}
+
+// EditPlaneArmRefSlot arms the i-th reference slot for picking (sets the pick filter).
+func (s *Session) EditPlaneArmRefSlot(i int) {
+	if t := s.ActiveWorkPlaneEdit(); t != nil {
+		t.Arm(s, i)
 	}
 }

--- a/app/work_plane_edit_test.go
+++ b/app/work_plane_edit_test.go
@@ -37,7 +37,8 @@ func TestOriginPlaneIsNotOffsetEditable(t *testing.T) {
 }
 
 // TestBeginEditWorkPlaneOpensOffsetEditor: double-clicking a user offset plane opens the edit
-// tool seeded with its current offset, and OK writes the new distance; origin planes are a no-op.
+// tool seeded with its current offset (in the document's mm), and OK writes the new distance;
+// origin planes are a no-op.
 func TestBeginEditWorkPlaneOpensOffsetEditor(t *testing.T) {
 	s, def := emptyPartSession(t)
 	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
@@ -50,23 +51,26 @@ func TestBeginEditWorkPlaneOpensOffsetEditor(t *testing.T) {
 	}
 
 	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: wp})
-	tool := s.ActiveWorkPlaneEdit()
-	if tool == nil {
+	if s.ActiveWorkPlaneEdit() == nil {
 		t.Fatal("editing a user offset plane should open the work-plane edit tool")
 	}
-	if tool.Distance() != 2 {
-		t.Errorf("edit tool seeded distance = %v, want 2", tool.Distance())
+	if s.EditPlaneScalarCount() != 1 || s.EditPlaneScalarLabel(0) != "Offset" {
+		t.Fatalf("offset edit should expose one Offset scalar, got count=%d label=%q",
+			s.EditPlaneScalarCount(), s.EditPlaneScalarLabel(0))
+	}
+	if got := s.EditPlaneScalarValue(0); got != 20 { // 2 cm shown as 20 mm
+		t.Errorf("seeded offset = %v mm, want 20", got)
 	}
 	if _, active := s.EditScopeSeq(); !active {
 		t.Error("editing a work plane should engage the edit scope")
 	}
 
-	tool.SetDistance(7)
+	s.SetEditPlaneScalarValue(0, 70) // 70 mm = 7 cm
 	if err := s.OK(); err != nil {
 		t.Fatalf("commit work-plane edit: %v", err)
 	}
 	if d, _ := wp.OffsetDistance(); d != 7 {
-		t.Errorf("committed offset = %v, want 7", d)
+		t.Errorf("committed offset = %v, want 7 cm", d)
 	}
 	if _, active := s.EditScopeSeq(); active {
 		t.Error("edit scope must clear after committing the work-plane edit")
@@ -80,10 +84,65 @@ func TestBeginEditWorkPlaneCancelRestoresOffset(t *testing.T) {
 	def.Recompute()
 
 	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: wp})
-	s.ActiveWorkPlaneEdit().SetDistance(9)
+	s.SetEditPlaneScalarValue(0, 90)
 	s.CancelTool()
 	if d, _ := wp.OffsetDistance(); d != 2 {
 		t.Errorf("offset after cancel = %v, want 2 (restored)", d)
+	}
+}
+
+// TestRedefineThreePointPlaneViaPick: double-clicking a three-point plane opens a redefine with
+// three point slots; arming one and feeding a point pick re-points the plane and recomputes.
+func TestRedefineThreePointPlaneViaPick(t *testing.T) {
+	s, def := emptyPartSession(t)
+	a := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 0) })
+	b := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 0, 0) })
+	c := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 0) })
+	wp := def.WorkPlanes().AddByThreePoints(a.Key(), b.Key(), c.Key())
+	def.Recompute()
+
+	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: wp})
+	tool := s.ActiveWorkPlaneEdit()
+	if tool == nil {
+		t.Fatal("a three-point plane should be redefinable")
+	}
+	if s.EditPlaneRefSlotCount() != 3 {
+		t.Fatalf("three-point redefine slots = %d, want 3", s.EditPlaneRefSlotCount())
+	}
+
+	// Re-point the third corner above the plane → it tilts off +Z.
+	up := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 1) })
+	s.EditPlaneArmRefSlot(2)
+	if !s.EditPlaneRefSlotArmed(2) {
+		t.Fatal("slot 2 should be armed after EditPlaneArmRefSlot(2)")
+	}
+	tool.Pick(s, WorkPointHandle{Point: up})
+	if wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), 1e-6) {
+		t.Error("re-picking point 3 did not re-tilt the plane")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit redefine: %v", err)
+	}
+}
+
+// TestRedefineCancelRestoresReference: cancelling a redefine restores the original references.
+func TestRedefineCancelRestoresReference(t *testing.T) {
+	s, def := emptyPartSession(t)
+	a := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 0) })
+	b := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 0, 0) })
+	c := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 0) })
+	wp := def.WorkPlanes().AddByThreePoints(a.Key(), b.Key(), c.Key())
+	def.Recompute()
+	want := wp.Plane().Normal().AsVector()
+
+	s.BeginEditWorkPlane(WorkPlaneHandle{Plane: wp})
+	up := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 1) })
+	s.EditPlaneArmRefSlot(2)
+	s.ActiveWorkPlaneEdit().Pick(s, WorkPointHandle{Point: up})
+	s.CancelTool()
+	def.Recompute()
+	if !wp.Plane().Normal().AsVector().IsEqualTo(want, 1e-9) {
+		t.Errorf("after cancel, plane normal = %v, want restored %v", wp.Plane().Normal(), want)
 	}
 }
 

--- a/head/ui/work_plane_edit_dialog.go
+++ b/head/ui/work_plane_edit_dialog.go
@@ -5,47 +5,95 @@
 package ui
 
 import (
+	"fmt"
+
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
 
-// Editing a placed offset work plane (browser double-click): a small dialog edits its offset
-// distance and OK/Cancel, mirroring the Offset Plane creation dialog. While it is open the
-// model is rolled back to the plane (edit-scope, issue #132), so the change previews against
-// only the geometry that existed when the plane was made. The distance is in the document's
-// length unit.
+// Editing / redefining a placed work plane (browser double-click): an offset plane edits its
+// distance, a line-plane-angle plane edits its angle, and a reference-built plane (three
+// points, two planes, a tangent face, …) re-picks its references. The dialog mirrors the
+// feature-edit dialog — one field per editable scalar, one row per reference slot with a
+// Select button that arms it for viewport/browser picking. While it is open the model is
+// rolled back to the plane (edit-scope, issue #132). Scalars are in the document's unit.
 
-// workPlaneEditUI holds the dialog's distance field across frames and whether it was open last
-// frame (so it seeds the field once when the edit opens).
-var workPlaneEditUI = struct {
-	distance float32
-	open     bool
-}{distance: 10}
+// workPlaneEditUI holds the dialog's per-scalar field values across frames and whether it was
+// open last frame (so it seeds the fields once when the edit opens).
+var workPlaneEditUI struct {
+	values []float32
+	open   bool
+}
 
-// drawWorkPlaneEditDialog shows the offset editor while a work-plane edit is active, keeping
-// the tool's distance in sync with the field each frame; OK commits, Cancel restores.
+// drawWorkPlaneEditDialog shows the scalar + reference editor while a work-plane edit is open.
 func drawWorkPlaneEditDialog(s *app.Session) {
-	t := s.ActiveWorkPlaneEdit()
-	if t == nil {
+	if !s.IsEditingWorkPlane() {
 		workPlaneEditUI.open = false
 		return
 	}
-	if !workPlaneEditUI.open { // edit just opened — seed the field from the plane's current offset
-		workPlaneEditUI.distance = float32(s.EditPlaneOffsetDisplay())
-		workPlaneEditUI.open = true
-	}
-	native.SetNextWindowSize(300, 110)
+	nScalars := s.EditPlaneScalarCount()
+	nRefs := s.EditPlaneRefSlotCount()
+	refreshWorkPlaneEditUI(s, nScalars)
+	native.SetNextWindowSize(320, float32(104+nScalars*30+nRefs*30))
 	if native.Begin("Edit Work Plane") {
-		native.Text("Offset (" + s.LengthUnitName() + ")")
-		native.InputFloat("##edit-plane-offset", &workPlaneEditUI.distance)
-		s.SetEditPlaneOffsetDisplay(float64(workPlaneEditUI.distance)) // keep the tool in sync
-		if native.Button("OK") {
-			_ = s.OK()
-		}
-		native.SameLine()
-		if native.Button("Cancel") {
-			s.CancelTool()
-		}
+		native.Text(s.EditPlaneName())
+		drawWorkPlaneScalars(s, nScalars)
+		drawWorkPlaneRefSlots(s, nRefs)
+		drawWorkPlaneEditButtons(s)
 	}
 	native.End()
+}
+
+func refreshWorkPlaneEditUI(s *app.Session, nScalars int) {
+	if workPlaneEditUI.open {
+		return
+	}
+	workPlaneEditUI.values = make([]float32, nScalars)
+	for i := 0; i < nScalars; i++ {
+		workPlaneEditUI.values[i] = float32(s.EditPlaneScalarValue(i))
+	}
+	workPlaneEditUI.open = true
+}
+
+// drawWorkPlaneScalars renders one field per editable scalar (offset/angle), syncing it to the
+// plane each frame.
+func drawWorkPlaneScalars(s *app.Session, n int) {
+	for i := 0; i < n && i < len(workPlaneEditUI.values); i++ {
+		label := s.EditPlaneScalarLabel(i)
+		if u := s.EditPlaneScalarUnitName(i); u != "" {
+			label += " (" + u + ")"
+		}
+		native.Text(label)
+		native.InputFloat(fmt.Sprintf("##edit-plane-scalar-%d", i), &workPlaneEditUI.values[i])
+		s.SetEditPlaneScalarValue(i, float64(workPlaneEditUI.values[i])) // keep the plane in sync
+	}
+}
+
+// drawWorkPlaneRefSlots renders one row per reference slot: a label and a Select button that
+// arms the slot for viewport/browser picking (highlighted while armed).
+func drawWorkPlaneRefSlots(s *app.Session, n int) {
+	for i := 0; i < n; i++ {
+		native.Text(s.EditPlaneRefSlotLabel(i))
+		native.SameLine()
+		selectLabel := "Select"
+		if s.EditPlaneRefSlotArmed(i) {
+			selectLabel = "Selecting… (click geometry)"
+		}
+		if native.Button(fmt.Sprintf("%s##edit-plane-ref-%d", selectLabel, i)) {
+			s.EditPlaneArmRefSlot(i)
+		}
+	}
+}
+
+func drawWorkPlaneEditButtons(s *app.Session) {
+	if native.Button("OK") {
+		if err := s.OK(); err == nil { // a sick result keeps the dialog open
+			workPlaneEditUI.open = false
+		}
+	}
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelTool()
+		workPlaneEditUI.open = false
+	}
 }

--- a/model/feature/work_plane_redefine.go
+++ b/model/feature/work_plane_redefine.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "oblikovati.org/model/param"
+
+// Redefining a placed work plane — Inventor's "redefine feature" for datum planes. A plane
+// built from references (three points, two planes, a tangent face, …) is edited by re-picking
+// those references; a plane with a scalar (offset distance, line-plane angle) also exposes that
+// value. RedefineSlots and EditableScalars are the two halves the editor drives; together they
+// make every user work plane editable on browser double-click (issue #132 follow-up). A plane
+// whose definition has neither (the origin frame, an absolute fixed-frame plane) reports both
+// empty and is not opened for editing.
+
+// WorkRefKind is the kind of geometry a redefine slot accepts, so the editor sets the right
+// pick filter and the caller maps the pick to the matching [WorkRef].
+type WorkRefKind int
+
+const (
+	// WorkRefPlane accepts a plane reference: a work plane or a planar B-rep face.
+	WorkRefPlane WorkRefKind = iota
+	// WorkRefAxis accepts a line/axis reference: a work axis (or a linear edge, later).
+	WorkRefAxis
+	// WorkRefPoint accepts a point reference: a work point.
+	WorkRefPoint
+	// WorkRefFace accepts a B-rep face reference (the surface a tangent plane is built on).
+	WorkRefFace
+)
+
+// WorkRefSlot is one re-pickable reference of a placed work plane. Set rebinds the slot to a
+// new reference: it mutates the definition and swaps it back into the plane, so the next
+// recompute re-derives the plane from the chosen geometry. The editor arms a slot, resolves a
+// pick to a [WorkRef] of the slot's Kind, and calls Set.
+type WorkRefSlot struct {
+	Label string
+	Kind  WorkRefKind
+	Set   func(WorkRef)
+}
+
+// RedefineSlots returns the plane's re-pickable reference inputs in display order, or nil when
+// the definition has none (the origin frame, fixed-geometry planes). Each slot's Set captures a
+// copy of the current definition, replaces the one reference, and reassigns w.def — so the
+// definition value structs need no pointer plumbing (offsetPlaneDef, already a pointer, is
+// handled by mutating it directly).
+func (w *WorkPlane) RedefineSlots() []WorkRefSlot {
+	if slots := w.pointPlaneSlots(); slots != nil {
+		return slots
+	}
+	if slots := w.linePlaneSlots(); slots != nil {
+		return slots
+	}
+	return w.tangentSlots()
+}
+
+// pointPlaneSlots returns the slots for the planes defined by plane/point references (offset,
+// three-point, plane-and-point, two-planes); nil for the other kinds.
+func (w *WorkPlane) pointPlaneSlots() []WorkRefSlot {
+	switch d := w.def.(type) {
+	case *offsetPlaneDef:
+		return []WorkRefSlot{{"Base plane", WorkRefPlane, func(r WorkRef) { d.base = r }}}
+	case threePointPlaneDef:
+		return []WorkRefSlot{
+			{"Point 1", WorkRefPoint, func(r WorkRef) { d.a = r; w.def = d }},
+			{"Point 2", WorkRefPoint, func(r WorkRef) { d.b = r; w.def = d }},
+			{"Point 3", WorkRefPoint, func(r WorkRef) { d.c = r; w.def = d }},
+		}
+	case planeAndPointPlaneDef:
+		return []WorkRefSlot{
+			{"Base plane", WorkRefPlane, func(r WorkRef) { d.base = r; w.def = d }},
+			{"Through point", WorkRefPoint, func(r WorkRef) { d.point = r; w.def = d }},
+		}
+	case twoPlanesPlaneDef:
+		return []WorkRefSlot{
+			{"Plane 1", WorkRefPlane, func(r WorkRef) { d.p1 = r; w.def = d }},
+			{"Plane 2", WorkRefPlane, func(r WorkRef) { d.p2 = r; w.def = d }},
+		}
+	default:
+		return nil
+	}
+}
+
+// linePlaneSlots returns the slots for the planes defined by a line/axis (line-plane-angle,
+// two-lines, normal-to-curve); nil for the other kinds.
+func (w *WorkPlane) linePlaneSlots() []WorkRefSlot {
+	switch d := w.def.(type) {
+	case linePlaneAnglePlaneDef:
+		return []WorkRefSlot{
+			{"Line", WorkRefAxis, func(r WorkRef) { d.line = r; w.def = d }},
+			{"Plane", WorkRefPlane, func(r WorkRef) { d.base = r; w.def = d }},
+		}
+	case twoLinesPlaneDef:
+		return []WorkRefSlot{
+			{"Line 1", WorkRefAxis, func(r WorkRef) { d.l1 = r; w.def = d }},
+			{"Line 2", WorkRefAxis, func(r WorkRef) { d.l2 = r; w.def = d }},
+		}
+	case normalToCurvePlaneDef:
+		return []WorkRefSlot{
+			{"Curve", WorkRefAxis, func(r WorkRef) { d.curve = r; w.def = d }},
+			{"Point", WorkRefPoint, func(r WorkRef) { d.point = r; w.def = d }},
+		}
+	default:
+		return nil
+	}
+}
+
+// tangentSlots returns the slots for the surface-tangent planes (built on a B-rep face), each
+// of which exposes that face as a re-pickable WorkRefFace; nil for every other kind.
+func (w *WorkPlane) tangentSlots() []WorkRefSlot {
+	switch d := w.def.(type) {
+	case torusMidPlaneDef:
+		return []WorkRefSlot{{"Torus face", WorkRefFace, func(r WorkRef) { d.face = r; w.def = d }}}
+	case pointAndTangentPlaneDef:
+		return []WorkRefSlot{
+			{"Point", WorkRefPoint, func(r WorkRef) { d.point = r; w.def = d }},
+			{"Tangent face", WorkRefFace, func(r WorkRef) { d.face = r; w.def = d }},
+		}
+	case planeAndTangentPlaneDef:
+		return []WorkRefSlot{
+			{"Parallel plane", WorkRefPlane, func(r WorkRef) { d.base = r; w.def = d }},
+			{"Tangent face", WorkRefFace, func(r WorkRef) { d.face = r; w.def = d }},
+		}
+	case lineAndTangentPlaneDef:
+		return []WorkRefSlot{
+			{"Line", WorkRefAxis, func(r WorkRef) { d.line = r; w.def = d }},
+			{"Tangent face", WorkRefFace, func(r WorkRef) { d.face = r; w.def = d }},
+		}
+	default:
+		return nil
+	}
+}
+
+// EditableScalars returns the plane's editable scalar inputs in display order, or nil when it
+// has none. Reuses the feature [EditableParam] shape (get/set in database units), so the head
+// renders and the session converts them exactly like a feature's scalar fields.
+func (w *WorkPlane) EditableScalars() []EditableParam {
+	switch d := w.def.(type) {
+	case *offsetPlaneDef:
+		return []EditableParam{{
+			Label: "Offset", Unit: param.Length,
+			Get: func() float64 { return d.distance() },
+			Set: func(v float64) { d.setDistance(v) },
+		}}
+	case linePlaneAnglePlaneDef:
+		// d is a copy of the value-typed def, so Set must reassign w.def for the edit to stick
+		// (unlike *offsetPlaneDef above, which is mutated through its pointer).
+		return []EditableParam{{
+			Label: "Angle", Unit: param.Angle,
+			Get: func() float64 { return d.angle() },
+			Set: func(v float64) { d.angle = func() float64 { return v }; w.def = d },
+		}}
+	default:
+		return nil
+	}
+}
+
+// IsRedefinable reports whether the plane exposes any editable scalar or reference, i.e. whether
+// browser double-click should open it for editing.
+func (w *WorkPlane) IsRedefinable() bool {
+	return len(w.EditableScalars()) > 0 || len(w.RedefineSlots()) > 0
+}
+
+// SnapshotDefinition captures the plane's current definition and returns a closure that
+// restores it — an edit's Cancel calls it to undo any re-picked references and scalar changes
+// in one step. The offset plane is a pointer (mutated in place), so its value is snapshotted;
+// every other kind is restored by swapping the captured definition value back.
+func (w *WorkPlane) SnapshotDefinition() func() {
+	saved := w.def
+	if op, ok := saved.(*offsetPlaneDef); ok {
+		cp := *op
+		return func() { *op = cp; w.def = op }
+	}
+	return func() { w.def = saved }
+}

--- a/model/feature/work_plane_redefine_test.go
+++ b/model/feature/work_plane_redefine_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestRedefineThreePointPlaneRepicksPoint is the core redefine regression: re-pointing a
+// three-point plane's third point at a new location re-derives the plane from it.
+func TestRedefineThreePointPlaneRepicksPoint(t *testing.T) {
+	g := NewWorkGeometry()
+	a := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 0) })
+	b := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 0, 0) })
+	c := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 0) })
+	wp := g.WorkPlanes().AddByThreePoints(a.Key(), b.Key(), c.Key())
+	if !wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Fatalf("initial three-point plane normal = %v, want +Z", wp.Plane().Normal())
+	}
+
+	slots := wp.RedefineSlots()
+	if len(slots) != 3 {
+		t.Fatalf("three-point plane RedefineSlots = %d, want 3", len(slots))
+	}
+	for i, s := range slots {
+		if s.Kind != WorkRefPoint {
+			t.Errorf("slot %d (%q) kind = %d, want WorkRefPoint", i, s.Label, s.Kind)
+		}
+	}
+
+	// Re-point the third corner above the XY plane so the plane tilts off +Z.
+	up := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 1) })
+	slots[2].Set(up.Key())
+	g.Recompute(nil)
+	if wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("after re-picking point 3, plane normal still +Z (%v) — redefine did not take", wp.Plane().Normal())
+	}
+}
+
+// TestRedefineOffsetPlaneScalar: an offset plane exposes its distance via EditableScalars, and
+// editing it moves the plane.
+func TestRedefineOffsetPlaneScalar(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 2 })
+
+	sc := wp.EditableScalars()
+	if len(sc) != 1 || sc[0].Label != "Offset" {
+		t.Fatalf("offset plane EditableScalars = %+v, want one Offset", sc)
+	}
+	if sc[0].Get() != 2 {
+		t.Errorf("offset Get = %v, want 2", sc[0].Get())
+	}
+	sc[0].Set(5)
+	g.Recompute(nil)
+	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) {
+		t.Errorf("after editing offset, origin = %v, want (0,0,5)", wp.Plane().Origin())
+	}
+	if len(wp.RedefineSlots()) != 1 || wp.RedefineSlots()[0].Kind != WorkRefPlane {
+		t.Errorf("offset plane should also expose its base plane as a WorkRefPlane slot")
+	}
+}
+
+// TestRedefineLineAngleScalar: a line-plane-angle plane exposes its angle, and editing it
+// re-angles the plane.
+func TestRedefineLineAngleScalar(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddByLinePlaneAndAngle(OriginXAxis, OriginXYPlane, func() float64 { return 0 })
+	n0 := wp.Plane().Normal().AsVector()
+
+	sc := wp.EditableScalars()
+	if len(sc) != 1 || sc[0].Label != "Angle" {
+		t.Fatalf("line-angle plane EditableScalars = %+v, want one Angle", sc)
+	}
+	sc[0].Set(stdmath.Pi / 4) // 45°
+	g.Recompute(nil)
+	if wp.Plane().Normal().AsVector().IsEqualTo(n0, wtol) {
+		t.Errorf("after editing the angle, the plane normal is unchanged (%v) — edit did not take", wp.Plane().Normal())
+	}
+}
+
+// TestTangentPlaneRedefineSlots: a plane-tangent plane exposes a parallel-plane slot and a
+// tangent-face slot of the right kinds (the face slot is what makes a tangent plane redefinable).
+func TestTangentPlaneRedefineSlots(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPlanes().AddByPlaneAndTangent(OriginXZPlane, FaceRef([]byte("cyl")))
+	slots := wp.RedefineSlots()
+	if len(slots) != 2 {
+		t.Fatalf("plane-tangent RedefineSlots = %d, want 2", len(slots))
+	}
+	if slots[0].Kind != WorkRefPlane || slots[1].Kind != WorkRefFace {
+		t.Errorf("plane-tangent slot kinds = [%d,%d], want [WorkRefPlane, WorkRefFace]", slots[0].Kind, slots[1].Kind)
+	}
+}
+
+// TestOriginPlaneNotRedefinable: the origin frame's planes have nothing to edit.
+func TestOriginPlaneNotRedefinable(t *testing.T) {
+	g := NewWorkGeometry()
+	origin := g.OriginPlanes()[0]
+	if origin.IsRedefinable() || len(origin.RedefineSlots()) != 0 || len(origin.EditableScalars()) != 0 {
+		t.Error("an origin plane must not be redefinable")
+	}
+}


### PR DESCRIPTION
Closes the last gap flagged in #132 / PR #133: **offset** work planes were editable on
double-click, but every other kind was a no-op. Now **every** user work plane is editable —
a reference-built plane (three points, plane-and-point, two planes, two lines, normal-to-curve,
and the four surface-tangent planes) is **redefined** by re-picking its references, and a
line-plane-angle plane edits its angle (Inventor's redefine).

## How
Mirrors the existing feature-edit flow (`model/feature/editable.go` + `app/feature_edit.go`):

- **Model** (`model/feature/work_plane_redefine.go`): `WorkPlane.RedefineSlots()` returns the
  plane's re-pickable references as typed `WorkRefSlot`s (each `Set` rebuilds the definition and
  swaps it back — no pointer plumbing of the value-typed defs), and `EditableScalars()` exposes
  offset/angle as the existing `feature.EditableParam`. `SnapshotDefinition()` backs Cancel.
- **App** (`app/work_plane_edit.go`): `WorkPlaneEditTool` now drives scalars **and** armed
  reference slots — `Arm` sets the pick filter for the slot's kind, `Pick` maps a viewport/
  browser pick to a `WorkRef` (work plane/axis/point or a B-rep face) and re-points the plane,
  recomputing live; Cancel restores the snapshot. `BeginEditWorkPlane` opens for any redefinable
  plane and keeps the PR-#133 edit-scope rollback.
- **Head** (`head/ui/work_plane_edit_dialog.go`): the dialog now shows scalar fields + a Select
  button per reference slot (same shape as the feature-edit dialog).

## Tests
- model: `RedefineSlots` arity/kinds per plane kind; re-pointing a three-point plane's 3rd point
  re-derives it; editing offset/angle re-derives; tangent plane exposes its face slot; origin
  planes are not redefinable.
- app: `BeginEditWorkPlane` opens a three-point redefine; arming a slot + feeding a point pick
  re-points and recomputes; Cancel restores; the offset edit still round-trips through the new
  scalar bridge; edit-scope still engages.
- Live: rebuilt head builds a part with exact volume and renders cleanly (the redefine
  interaction is mouse-driven and not bridge-reachable, so it's covered by the unit tests).

No `api/wire` change — work-plane editing is internal model/app/head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)