### PR TITLE
addin/router: implement workPlanes.redefine + self-describing list

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -74,6 +74,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
 	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes
 	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
+	r.handlers[wire.MethodWorkPlanesRedefine] = redefineWorkPlane
 	r.handlers[wire.MethodThemeActive] = themeActive
 	r.handlers[wire.MethodThemeList] = themeList
 	r.handlers[wire.MethodViewGetDisplayMode] = getDisplayMode
@@ -286,6 +287,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodParametersSet:          true,
 	wire.MethodFeaturesAdd:            true,
 	wire.MethodWorkPlanesCreate:       true,
+	wire.MethodWorkPlanesRedefine:     true,
 	wire.MethodModelAssignMaterial:    true,
 	wire.MethodModelAssignAppearance:  true,
 	wire.MethodSketchCreate:           true,

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -27,18 +27,129 @@ func listWorkPlanes(s *app.Session, _ json.RawMessage) (json.RawMessage, error) 
 	planes := part.WorkPlanes()
 	out := make([]wire.WorkPlaneInfo, planes.Count())
 	for i := 0; i < planes.Count(); i++ {
-		wp := planes.Item(i)
-		out[i] = wire.WorkPlaneInfo{
-			Index:    i,
-			Name:     wp.Name(),
-			Ref:      string(wp.Key()),
-			Origin:   point3Slice(wp.Plane().Origin()),
-			Normal:   vector3Slice(wp.Plane().Normal().AsVector()),
-			IsOrigin: wp.IsCoordinateSystemElement(),
-			Healthy:  wp.Health().OK(),
-		}
+		out[i] = workPlaneInfo(part, planes.Item(i), i)
 	}
 	return json.Marshal(wire.ListWorkPlanesResult{Planes: out})
+}
+
+// workPlaneInfo renders one plane as the wire DTO, including the editable inputs a redefine
+// accepts: its scalars (offset/angle, in the document's preferred unit) and its re-pickable
+// reference slots (each tagged plane|axis|point|face). Origin planes report neither.
+func workPlaneInfo(part *compdef.PartComponentDefinition, wp *feature.WorkPlane, index int) wire.WorkPlaneInfo {
+	return wire.WorkPlaneInfo{
+		Index:    index,
+		Name:     wp.Name(),
+		Ref:      string(wp.Key()),
+		Origin:   point3Slice(wp.Plane().Origin()),
+		Normal:   vector3Slice(wp.Plane().Normal().AsVector()),
+		IsOrigin: wp.IsCoordinateSystemElement(),
+		Healthy:  wp.Health().OK(),
+		Kind:     wp.Kind(),
+		Scalars:  workPlaneScalars(part, wp),
+		Slots:    workPlaneSlots(wp),
+	}
+}
+
+// workPlaneScalars renders the plane's editable scalars with their value in the document's
+// preferred unit (mm/deg), so a client reads the current value and can set a new one.
+func workPlaneScalars(part *compdef.PartComponentDefinition, wp *feature.WorkPlane) []wire.WorkPlaneScalar {
+	scalars := wp.EditableScalars()
+	if len(scalars) == 0 {
+		return nil
+	}
+	out := make([]wire.WorkPlaneScalar, len(scalars))
+	for i, sc := range scalars {
+		out[i] = wire.WorkPlaneScalar{
+			Index: i,
+			Label: sc.Label,
+			Unit:  part.Units().PreferredName(sc.Unit),
+			Value: part.Units().ToPreferred(param.Q(sc.Get(), sc.Unit)),
+		}
+	}
+	return out
+}
+
+// workPlaneSlots renders the plane's re-pickable reference slots (label + kind token).
+func workPlaneSlots(wp *feature.WorkPlane) []wire.WorkPlaneRefSlot {
+	slots := wp.RedefineSlots()
+	if len(slots) == 0 {
+		return nil
+	}
+	out := make([]wire.WorkPlaneRefSlot, len(slots))
+	for i, sl := range slots {
+		out[i] = wire.WorkPlaneRefSlot{Index: i, Label: sl.Label, Kind: sl.Kind.String()}
+	}
+	return out
+}
+
+// redefineWorkPlane edits a placed user work plane in place: it applies the requested scalar
+// edits (offset/angle, parsed in the document's units) and reference re-picks, then recomputes
+// and returns the plane's refreshed info. It fails on a bad index, an origin plane, or an
+// out-of-range scalar/slot; an unsatisfiable result is reported healthy=false, not an error.
+func redefineWorkPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.RedefineWorkPlaneArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	wp, err := userWorkPlane(part, in.Index)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyScalarEdits(part, wp, in.Scalars); err != nil {
+		return nil, err
+	}
+	if err := applyRepicks(wp, in.Repick); err != nil {
+		return nil, err
+	}
+	part.Recompute()
+	return json.Marshal(wire.RedefineWorkPlaneResult{Plane: workPlaneInfo(part, wp, in.Index)})
+}
+
+// userWorkPlane resolves a redefine index to a user (non-origin) work plane.
+func userWorkPlane(part *compdef.PartComponentDefinition, index int) (*feature.WorkPlane, error) {
+	planes := part.WorkPlanes()
+	if index < 0 || index >= planes.Count() {
+		return nil, fmt.Errorf("workPlanes.redefine: index %d out of range (%d planes)", index, planes.Count())
+	}
+	wp := planes.Item(index)
+	if wp.IsCoordinateSystemElement() {
+		return nil, fmt.Errorf("workPlanes.redefine: plane %d is an origin plane and cannot be redefined", index)
+	}
+	return wp, nil
+}
+
+// applyScalarEdits sets the plane's scalars from unit-bearing strings, parsed by each scalar's
+// quantity kind (length or angle) into the database units its Set expects.
+func applyScalarEdits(part *compdef.PartComponentDefinition, wp *feature.WorkPlane, edits []wire.ScalarEdit) error {
+	scalars := wp.EditableScalars()
+	for _, e := range edits {
+		if e.Index < 0 || e.Index >= len(scalars) {
+			return fmt.Errorf("workPlanes.redefine: scalar index %d out of range (%d scalars)", e.Index, len(scalars))
+		}
+		q, err := part.Units().Parse(e.Value, scalars[e.Index].Unit)
+		if err != nil {
+			return fmt.Errorf("workPlanes.redefine: scalar %d value %q: %w", e.Index, e.Value, err)
+		}
+		scalars[e.Index].Set(q.Value)
+	}
+	return nil
+}
+
+// applyRepicks re-points the plane's reference slots at the requested references (origin
+// constants / list refs / face keys, via toWorkRefs).
+func applyRepicks(wp *feature.WorkPlane, repicks []wire.SlotRepick) error {
+	slots := wp.RedefineSlots()
+	for _, rp := range repicks {
+		if rp.Slot < 0 || rp.Slot >= len(slots) {
+			return fmt.Errorf("workPlanes.redefine: slot %d out of range (%d slots)", rp.Slot, len(slots))
+		}
+		slots[rp.Slot].Set(toWorkRefs([]string{rp.Ref})[0])
+	}
+	return nil
 }
 
 // createWorkPlanes adds a datum plane of the requested kind to the active part and

--- a/addin/router/work_planes_test.go
+++ b/addin/router/work_planes_test.go
@@ -77,3 +77,65 @@ func TestWorkPlanesCreateBadOffsetExpression(t *testing.T) {
 		t.Error("expected error for an unparseable offset expression")
 	}
 }
+
+func TestWorkPlanesListReportsScalarsAndSlots(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"20 mm"}`, &res)
+
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	p := list.Planes[res.Index]
+	if p.Kind != "plane-offset" {
+		t.Errorf("kind = %q, want plane-offset", p.Kind)
+	}
+	if len(p.Scalars) != 1 || p.Scalars[0].Label != "Offset" || p.Scalars[0].Unit != "mm" || p.Scalars[0].Value != 20 {
+		t.Errorf("scalars = %+v, want one Offset = 20 mm", p.Scalars)
+	}
+	if len(p.Slots) != 1 || p.Slots[0].Kind != "plane" {
+		t.Errorf("slots = %+v, want one plane slot", p.Slots)
+	}
+}
+
+func TestWorkPlanesRedefineScalarMovesPlane(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
+
+	var rd wire.RedefineWorkPlaneResult
+	call(t, r, s, "workPlanes.redefine", `{"index":3,"scalars":[{"index":0,"value":"50 mm"}]}`, &rd)
+	// 50 mm = 5 cm; the XY-offset plane lands at z=5.
+	if !rd.Plane.Healthy || rd.Plane.Origin[2] != 5 {
+		t.Errorf("after scalar redefine, plane = %+v, want healthy at z=5", rd.Plane)
+	}
+	if rd.Plane.Scalars[0].Value != 50 {
+		t.Errorf("redefined offset reads back %v mm, want 50", rd.Plane.Scalars[0].Value)
+	}
+}
+
+func TestWorkPlanesRedefineRepickReorientsPlane(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
+
+	// Re-point the base from XY (+Z normal) to XZ (+Y normal): the plane reorients.
+	var rd wire.RedefineWorkPlaneResult
+	call(t, r, s, "workPlanes.redefine", `{"index":3,"repick":[{"slot":0,"ref":"origin/plane/xz"}]}`, &rd)
+	if !rd.Plane.Healthy {
+		t.Fatalf("repick produced an unhealthy plane: %+v", rd.Plane)
+	}
+	// XZ plane's normal is +Y, so the offset plane's normal is now ±Y, not ±Z.
+	if rd.Plane.Normal[2] != 0 {
+		t.Errorf("after re-picking base to XZ, normal = %v, want no Z component", rd.Plane.Normal)
+	}
+}
+
+func TestWorkPlanesRedefineRejectsOriginAndBadIndex(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPlanes.redefine", []byte(`{"index":0}`)); err == nil {
+		t.Error("redefining an origin plane (index 0) should error")
+	}
+	if _, err := r.Handle(s, "workPlanes.redefine", []byte(`{"index":99}`)); err == nil {
+		t.Error("redefining an out-of-range index should error")
+	}
+}

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -117,6 +117,11 @@ func (w *WorkPlane) Plane() sketch.Plane { return w.plane }
 // DisplaySize is the half-edge length of the square the plane is drawn/picked as.
 func (w *WorkPlane) DisplaySize() float64 { return w.displaySize }
 
+// Kind returns the plane's constructor name (its definition's kind: "plane-offset",
+// "three-points", "plane-tangent", …) — the same vocabulary as the api/types WorkPlane*
+// constants, for read-back over the wire.
+func (w *WorkPlane) Kind() string { return w.def.kindName() }
+
 // IsCoordinateSystemElement reports whether this is one of the origin frame's planes;
 // Grounded reports whether its geometry is fixed (the absolute document frame).
 func (w *WorkPlane) IsCoordinateSystemElement() bool { return w.coordinateSystem }

--- a/model/feature/work_plane_redefine.go
+++ b/model/feature/work_plane_redefine.go
@@ -27,6 +27,22 @@ const (
 	WorkRefFace
 )
 
+// String renders the slot kind as the stable wire token ("plane"|"axis"|"point"|"face").
+func (k WorkRefKind) String() string {
+	switch k {
+	case WorkRefPlane:
+		return "plane"
+	case WorkRefAxis:
+		return "axis"
+	case WorkRefPoint:
+		return "point"
+	case WorkRefFace:
+		return "face"
+	default:
+		return "unknown"
+	}
+}
+
 // WorkRefSlot is one re-pickable reference of a placed work plane. Set rebinds the slot to a
 // new reference: it mutates the definition and swaps it back into the plane, so the next
 // recompute re-derives the plane from the chosen geometry. The editor arms a slot, resolves a


### PR DESCRIPTION
Implements the `workPlanes.redefine` wire method added in Oblikovati.API#31, and makes
`workPlanes.list` self-describing so a client knows what each plane's redefine accepts.

- `redefineWorkPlane` handler: resolves a user plane by index, applies scalar edits
  (offset/angle, parsed in the document's units) and reference re-picks (origin constants /
  list refs / face keys), recomputes, returns the refreshed plane info. Errors on a bad index
  or an origin plane; an unsatisfiable result is `healthy:false`, not an error.
- `workPlanes.list` now reports `Kind`, `Scalars` (label/unit/value in the preferred unit), and
  `Slots` (label + plane|axis|point|face) — read from the model's `EditableScalars`/`RedefineSlots`.
- Model: `WorkPlane.Kind()` and `WorkRefKind.String()` for the read-back.

Tests cover scalar redefine (plane moves), reference re-pick (plane reorients), the
self-describing fields, and the origin/out-of-range guards.

Requires Oblikovati.API#31 on `develop` (merged). The mcp-bridge `redefine_work_plane` tool
lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)