### PR TITLE
addin/router: implement workPoints.create + fix work-feature ref passthrough

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -75,6 +75,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes
 	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
 	r.handlers[wire.MethodWorkPlanesRedefine] = redefineWorkPlane
+	r.handlers[wire.MethodWorkPointsCreate] = createWorkPoint
 	r.handlers[wire.MethodThemeActive] = themeActive
 	r.handlers[wire.MethodThemeList] = themeList
 	r.handlers[wire.MethodViewGetDisplayMode] = getDisplayMode
@@ -288,6 +289,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodFeaturesAdd:            true,
 	wire.MethodWorkPlanesCreate:       true,
 	wire.MethodWorkPlanesRedefine:     true,
+	wire.MethodWorkPointsCreate:       true,
 	wire.MethodModelAssignMaterial:    true,
 	wire.MethodModelAssignAppearance:  true,
 	wire.MethodSketchCreate:           true,

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -177,6 +177,32 @@ func createWorkPlanes(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	})
 }
 
+// createWorkPoint adds a datum point fixed at the requested position to the active part and
+// recomputes, returning its index and reference (usable as a point input to a work plane or a
+// redefine re-pick).
+func createWorkPoint(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.CreateWorkPointArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	at, err := parseCoords(in.At, "at")
+	if err != nil {
+		return nil, err
+	}
+	p := math.P3(at[0], at[1], at[2])
+	wp := part.WorkPoints().AddByPosition(func() math.Point3 { return p })
+	part.Recompute()
+	return json.Marshal(wire.CreateWorkPointResult{
+		Index: part.WorkPoints().Count() - 1,
+		Ref:   string(wp.Key()),
+		Name:  wp.Name(),
+	})
+}
+
 // refPlaneCtor builds a work plane from exactly its references (no scalar parameters);
 // refPlaneCtors is the table of the kinds that need only references, keeping
 // buildWorkPlane's body to the kinds with extra inputs (offset, angle, fixed frame).
@@ -278,22 +304,39 @@ func addFixedWorkPlane(planes *feature.WorkPlanes, in wire.CreateWorkPlaneArgs) 
 	return planes.AddFixed(func() math.Point3 { return o }, x, y), nil
 }
 
-// toWorkRefs converts the request's reference strings to model work references.
-// toWorkRefs wraps reference strings as work refs. An origin reference ("origin/plane/xy",
-// "origin/axis/z", …) and a user work plane/axis name are plain plane/axis refs; any other
-// string is a B-rep topology reference key (from model.referenceKeys) and is tagged as a
-// FaceRef so the resolver builds the plane on that body face — the way a work plane lands on a
-// surface a feature created. (Edge/vertex-based kinds over the wire are a known limitation.)
+// toWorkRefs converts the request's reference strings to model work references. A work-feature
+// reference — an origin constant ("origin/plane/xy", "origin/axis/z", …), a user plane/axis/
+// point/ucs ref ("plane/3", "point/0", from a create/list result), or an encoded vertex ref
+// ("vertex/…") — is passed through verbatim; any other string is a B-rep topology reference key
+// (from model.referenceKeys) and is tagged as a FaceRef so the resolver builds the plane on that
+// body face. This lets a user work point/plane/axis feed another work feature over the wire
+// (e.g. a three-point plane through three created points, or a redefine re-pick).
 func toWorkRefs(refs []string) []feature.WorkRef {
 	out := make([]feature.WorkRef, len(refs))
 	for i, r := range refs {
-		if strings.HasPrefix(r, "origin/") {
+		if isWorkFeatureRef(r) {
 			out[i] = feature.WorkRef(r)
 		} else {
 			out[i] = feature.FaceRef([]byte(r))
 		}
 	}
 	return out
+}
+
+// workFeatureRefPrefixes are the reference-string prefixes that name a work feature (an origin
+// element, a user plane/axis/point/coordinate-system, or an encoded vertex) rather than a raw
+// B-rep face key.
+var workFeatureRefPrefixes = []string{"origin/", "plane/", "axis/", "point/", "ucs/", "vertex/"}
+
+// isWorkFeatureRef reports whether r names a work feature (so it is passed through as a plane/
+// axis/point ref) rather than a raw face key.
+func isWorkFeatureRef(r string) bool {
+	for _, p := range workFeatureRefPrefixes {
+		if strings.HasPrefix(r, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // modelLengthClosure turns a distance argument into a live, parameter-aware value: a

--- a/addin/router/work_planes_test.go
+++ b/addin/router/work_planes_test.go
@@ -3,6 +3,7 @@
 package router
 
 import (
+	"fmt"
 	"testing"
 
 	"oblikovati.org/api/wire"
@@ -137,5 +138,65 @@ func TestWorkPlanesRedefineRejectsOriginAndBadIndex(t *testing.T) {
 	}
 	if _, err := r.Handle(s, "workPlanes.redefine", []byte(`{"index":99}`)); err == nil {
 		t.Error("redefining an out-of-range index should error")
+	}
+}
+
+func TestWorkPointsCreateAndThreePointPlane(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// Three created points define a plane tilted off the principal planes.
+	var p0, p1, p2 wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,0,0]}`, &p0)
+	call(t, r, s, "workPoints.create", `{"at":[4,0,0]}`, &p1)
+	call(t, r, s, "workPoints.create", `{"at":[0,4,2]}`, &p2)
+	// The origin center point occupies index 0, so user points start at point/1.
+	if p0.Ref != "point/1" || p1.Ref != "point/2" || p2.Ref != "point/3" {
+		t.Fatalf("point refs = %q,%q,%q, want point/1..3", p0.Ref, p1.Ref, p2.Ref)
+	}
+
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"three-points","refs":["`+p0.Ref+`","`+p1.Ref+`","`+p2.Ref+`"]}`, &res)
+	if !res.Healthy {
+		t.Fatalf("three-point plane not healthy (user point refs must resolve): %+v", res)
+	}
+
+	// Its three slots are point slots.
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	p := list.Planes[res.Index]
+	if p.Kind != "three-points" || len(p.Slots) != 3 || p.Slots[2].Kind != "point" {
+		t.Errorf("three-point plane slots = %+v (kind %q), want 3 point slots", p.Slots, p.Kind)
+	}
+}
+
+func TestWorkPlanesRedefineThreePointRepick(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var a, b, c wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,0,0]}`, &a)
+	call(t, r, s, "workPoints.create", `{"at":[4,0,0]}`, &b)
+	call(t, r, s, "workPoints.create", `{"at":[0,4,0]}`, &c) // all in the XY plane → ±Z normal
+	var plane wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"three-points","refs":["`+a.Ref+`","`+b.Ref+`","`+c.Ref+`"]}`, &plane)
+	if !plane.Healthy {
+		t.Fatalf("three-point plane from user points should be healthy: %+v", plane)
+	}
+	// The fresh plane lies in XY, so its normal is vertical (±Z).
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if z := list.Planes[plane.Index].Normal[2]; z != 1 && z != -1 {
+		t.Fatalf("initial three-point plane normal = %v, want vertical ±Z", list.Planes[plane.Index].Normal)
+	}
+
+	// A fourth point above the XY plane; re-point slot 2 at it → the plane tilts off ±Z.
+	var d wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,4,3]}`, &d)
+	var rd wire.RedefineWorkPlaneResult
+	call(t, r, s, "workPlanes.redefine", fmt.Sprintf(`{"index":%d,"repick":[{"slot":2,"ref":%q}]}`, plane.Index, d.Ref), &rd)
+	if !rd.Plane.Healthy {
+		t.Fatalf("redefined three-point plane not healthy: %+v", rd.Plane)
+	}
+	if z := rd.Plane.Normal[2]; z == 1 || z == -1 {
+		t.Errorf("after re-picking point 3 above the plane, normal = %v, want tilted off ±Z", rd.Plane.Normal)
 	}
 }


### PR DESCRIPTION
Implements `workPoints.create` (Oblikovati.API#32, on `develop`) and fixes a reference-passthrough
bug so point-based work-plane construction/redefine works over the wire.

- `createWorkPoint` handler: adds a datum point at `[x,y,z]`, returns its index/ref.
- **`toWorkRefs` fix**: a work-feature reference — origin constants AND user `plane/N` `axis/N`
  `point/N` `ucs/N` `vertex/…` refs — is now passed through verbatim; only a genuinely unknown
  string is treated as a B-rep face key. Previously any non-`origin/` ref (including `point/1`
  from a create result) was silently wrapped as a face key, so user-feature references never
  resolved — a three-point plane through created points came back unhealthy.

Tests: create 3 points → a healthy three-point plane with 3 point slots; re-pick a point slot
at a 4th point → the plane tilts off vertical.

The mcp-bridge `create_work_point` tool lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)