### PR TITLE
app/router: implement the features.* lifecycle methods

### DIFF
--- a/addin/router/feature_lifecycle.go
+++ b/addin/router/feature_lifecycle.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
+)
+
+// Handlers for the features.* lifecycle methods (issue #140): get, edit (scalar
+// inputs), delete, rename, setSuppressed, reorder. Features are addressed by the
+// stable id model.tree reports — never by index, which reorder/delete invalidate.
+// Mutations go through the app session so every change records an undo edit.
+
+// featureInfo renders one feature as the model-tree wire DTO (shared with modelTree).
+func featureInfo(f *feature.PartFeature) wire.FeatureInfo {
+	fi := wire.FeatureInfo{ID: uint64(f.ID()), Name: f.Name(), Kind: f.Kind(), Suppressed: f.Suppressed()}
+	if h := f.Health(); !h.OK() {
+		fi.Health = h.Reason
+	}
+	return fi
+}
+
+// partFeatureByID resolves a wire feature id against the active part, also returning
+// the feature's current history index, naming the wire method for errors.
+func partFeatureByID(part *compdef.PartComponentDefinition, id uint64, method string) (*feature.PartFeature, int, error) {
+	feats := part.Features()
+	for i := 0; i < feats.Count(); i++ {
+		if uint64(feats.Item(i).ID()) == id {
+			return feats.Item(i), i, nil
+		}
+	}
+	return nil, 0, fmt.Errorf("%s: no feature with id %d (ids come from model.tree)", method, id)
+}
+
+// featureDetail renders one feature with its history index and the editable scalars
+// features.edit accepts, mirroring workPlaneInfo for datum planes.
+func featureDetail(part *compdef.PartComponentDefinition, f *feature.PartFeature, index int) wire.FeatureDetail {
+	return wire.FeatureDetail{FeatureInfo: featureInfo(f), Index: index, Scalars: featureScalars(part, f)}
+}
+
+// featureScalars renders the feature's editable scalars with their value in the
+// document's preferred unit; nil when the definition exposes nothing editable.
+func featureScalars(part *compdef.PartComponentDefinition, f *feature.PartFeature) []wire.FeatureScalar {
+	ed, ok := f.Definition().(feature.Editable)
+	if !ok {
+		return nil
+	}
+	params := ed.EditableParams()
+	out := make([]wire.FeatureScalar, len(params))
+	for i, p := range params {
+		out[i] = wire.FeatureScalar{
+			Index:   i,
+			Label:   p.Label,
+			Unit:    part.Units().PreferredName(p.Unit),
+			Value:   part.Units().ToPreferred(param.Q(p.Get(), p.Unit)),
+			Integer: p.Integer,
+		}
+	}
+	return out
+}
+
+// featureDetailReply marshals the refreshed-feature response shared by the
+// get/edit/rename/setSuppressed/reorder handlers.
+func featureDetailReply(part *compdef.PartComponentDefinition, f *feature.PartFeature, index int) (json.RawMessage, error) {
+	return json.Marshal(wire.FeatureDetailResult{Feature: featureDetail(part, f, index)})
+}
+
+// getFeature returns one feature's state and editable scalars by id.
+func getFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, f, idx, err := resolveFeatureArgs(s, raw, wire.MethodFeaturesGet)
+	if err != nil {
+		return nil, err
+	}
+	return featureDetailReply(part, f, idx)
+}
+
+// resolveFeatureArgs decodes a FeatureRefArgs request and resolves its feature —
+// the shared front half of the get/delete handlers.
+func resolveFeatureArgs(s *app.Session, raw json.RawMessage, method string) (*compdef.PartComponentDefinition, *feature.PartFeature, int, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	var in wire.FeatureRefArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, nil, 0, err
+	}
+	f, idx, err := partFeatureByID(part, in.ID, method)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return part, f, idx, nil
+}
+
+// editFeature sets editable scalars of a placed feature in place. Every edit is
+// validated before any is applied — a bad value mid-batch must not leave the
+// definition half-edited — then the part recomputes once via CommitFeatureEdit.
+func editFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.EditFeatureArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	f, idx, err := partFeatureByID(part, in.ID, wire.MethodFeaturesEdit)
+	if err != nil {
+		return nil, err
+	}
+	apply, err := parseScalarEdits(part, f, in.Scalars)
+	if err != nil {
+		return nil, err
+	}
+	apply()
+	if err := s.CommitFeatureEdit(f); err != nil {
+		return nil, err
+	}
+	return featureDetailReply(part, f, idx)
+}
+
+// parseScalarEdits validates the whole batch — the feature must be editable, each
+// index in range, each value parseable in the scalar's unit — and returns a single
+// closure that applies every Set (Set itself cannot fail).
+func parseScalarEdits(part *compdef.PartComponentDefinition, f *feature.PartFeature, edits []wire.ScalarEdit) (func(), error) {
+	if len(edits) == 0 {
+		return nil, fmt.Errorf("features.edit: scalars is empty; expected at least one {index,value} edit")
+	}
+	ed, ok := f.Definition().(feature.Editable)
+	if !ok {
+		return nil, fmt.Errorf("features.edit: feature %d (%s) has no editable scalars", uint64(f.ID()), f.Kind())
+	}
+	params := ed.EditableParams()
+	sets := make([]func(), len(edits))
+	for i, e := range edits {
+		if e.Index < 0 || e.Index >= len(params) {
+			return nil, fmt.Errorf("features.edit: scalar index %d out of range (%d scalars, see features.get)", e.Index, len(params))
+		}
+		p := params[e.Index]
+		q, err := part.Units().Parse(e.Value, p.Unit)
+		if err != nil {
+			return nil, fmt.Errorf("features.edit: scalar %d value %q: %w", e.Index, e.Value, err)
+		}
+		set, v := p.Set, q.Value
+		sets[i] = func() { set(v) }
+	}
+	return func() {
+		for _, set := range sets {
+			set()
+		}
+	}, nil
+}
+
+// deleteFeature removes a feature from the history and recomputes.
+func deleteFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	_, f, _, err := resolveFeatureArgs(s, raw, wire.MethodFeaturesDelete)
+	if err != nil {
+		return nil, err
+	}
+	id := uint64(f.ID())
+	if err := s.DeleteFeature(f); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.DeleteFeatureResult{ID: id, Deleted: true})
+}
+
+// renameFeature sets a feature's display name (the id stays stable).
+func renameFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.RenameFeatureArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	f, idx, err := partFeatureByID(part, in.ID, wire.MethodFeaturesRename)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.RenameFeature(f, in.Name); err != nil {
+		return nil, err
+	}
+	return featureDetailReply(part, f, idx)
+}
+
+// setFeatureSuppressed sets explicit suppression (idempotent) and recomputes.
+func setFeatureSuppressed(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetFeatureSuppressedArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	f, idx, err := partFeatureByID(part, in.ID, wire.MethodFeaturesSetSuppressed)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.SetFeatureSuppressed(f, in.Suppressed); err != nil {
+		return nil, err
+	}
+	return featureDetailReply(part, f, idx)
+}
+
+// reorderFeature moves a feature to a new history index and recomputes. The detail
+// is re-resolved after the move so the reply carries the feature's new index.
+func reorderFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ReorderFeatureArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	f, _, err := partFeatureByID(part, in.ID, wire.MethodFeaturesReorder)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.ReorderFeature(f, in.NewIndex); err != nil {
+		return nil, err
+	}
+	_, idx, err := partFeatureByID(part, in.ID, wire.MethodFeaturesReorder)
+	if err != nil {
+		return nil, err
+	}
+	return featureDetailReply(part, f, idx)
+}
+
+// registerFeatureHandlers wires the features.* methods: creation (list/add, backed by
+// the operation registry) and the post-placement lifecycle (issue #140).
+func (r *Router) registerFeatureHandlers() {
+	r.handlers[wire.MethodFeaturesList] = r.listFeatureKinds
+	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
+	r.handlers[wire.MethodFeaturesGet] = getFeature
+	r.handlers[wire.MethodFeaturesEdit] = editFeature
+	r.handlers[wire.MethodFeaturesDelete] = deleteFeature
+	r.handlers[wire.MethodFeaturesRename] = renameFeature
+	r.handlers[wire.MethodFeaturesSetSuppressed] = setFeatureSuppressed
+	r.handlers[wire.MethodFeaturesReorder] = reorderFeature
+}

--- a/addin/router/feature_lifecycle_test.go
+++ b/addin/router/feature_lifecycle_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// extrudedPartViaAPI drives the wire surface end-to-end — sketch.create,
+// sketch.rectangle, features.add(extrude 50mm) — and returns the extrude's stable id
+// from model.tree, the fixture every features.* lifecycle test starts from.
+func extrudedPartViaAPI(t *testing.T) (*Router, *app.Session, uint64) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"distance":"50 mm"}}`, &struct{}{})
+	tree := modelTreeOf(t, r, s)
+	if len(tree.Features) != 1 {
+		t.Fatalf("fixture: model.tree reports %d features, want 1", len(tree.Features))
+	}
+	return r, s, tree.Features[0].ID
+}
+
+func modelTreeOf(t *testing.T, r *Router, s *app.Session) wire.ModelTreeResult {
+	t.Helper()
+	var tree wire.ModelTreeResult
+	call(t, r, s, "model.tree", `{}`, &tree)
+	return tree
+}
+
+func TestFeaturesGetReportsEditableScalars(t *testing.T) {
+	r, s, id := extrudedPartViaAPI(t)
+	var got wire.FeatureDetailResult
+	call(t, r, s, "features.get", fmt.Sprintf(`{"id":%d}`, id), &got)
+	f := got.Feature
+	if f.Kind != "extrude" || f.Index != 0 || f.Suppressed {
+		t.Errorf("detail = kind %q index %d suppressed %v, want extrude/0/false", f.Kind, f.Index, f.Suppressed)
+	}
+	if len(f.Scalars) == 0 {
+		t.Fatal("extrude detail reports no editable scalars")
+	}
+	if sc := f.Scalars[0]; sc.Label != "Distance" || sc.Value != 50 || sc.Unit != "mm" {
+		t.Errorf("scalar 0 = %q %v %s, want Distance 50 mm", sc.Label, sc.Value, sc.Unit)
+	}
+}
+
+func TestFeaturesGetUnknownIDFails(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	if _, err := r.Handle(s, "features.get", []byte(`{"id":999999}`)); err == nil {
+		t.Error("expected an error for an unknown feature id")
+	}
+}
+
+func TestFeaturesEditChangesScalarAndRecomputes(t *testing.T) {
+	r, s, id := extrudedPartViaAPI(t)
+	var got wire.FeatureDetailResult
+	call(t, r, s, "features.edit",
+		fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"60 mm"}]}`, id), &got)
+	if v := got.Feature.Scalars[0].Value; v != 60 {
+		t.Errorf("distance after edit = %v mm, want 60", v)
+	}
+	if tree := modelTreeOf(t, r, s); tree.Bodies != 1 {
+		t.Errorf("bodies after edit = %d, want 1", tree.Bodies)
+	}
+}
+
+func TestFeaturesEditValidatesBeforeApplying(t *testing.T) {
+	r, s, id := extrudedPartViaAPI(t)
+	// Batch with a valid first edit and a broken second one: nothing may be applied.
+	_, err := r.Handle(s, "features.edit",
+		[]byte(fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"60 mm"},{"index":9,"value":"1 mm"}]}`, id)))
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("expected an out-of-range error, got %v", err)
+	}
+	var got wire.FeatureDetailResult
+	call(t, r, s, "features.get", fmt.Sprintf(`{"id":%d}`, id), &got)
+	if v := got.Feature.Scalars[0].Value; v != 50 {
+		t.Errorf("distance after failed batch = %v mm, want 50 (untouched)", v)
+	}
+	if _, err := r.Handle(s, "features.edit",
+		[]byte(fmt.Sprintf(`{"id":%d,"scalars":[]}`, id))); err == nil {
+		t.Error("expected an error for an empty scalars batch")
+	}
+	if _, err := r.Handle(s, "features.edit",
+		[]byte(fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"bogus"}]}`, id))); err == nil {
+		t.Error("expected an error for an unparseable value")
+	}
+}
+
+func TestFeaturesRenameViaAPI(t *testing.T) {
+	r, s, id := extrudedPartViaAPI(t)
+	var got wire.FeatureDetailResult
+	call(t, r, s, "features.rename", fmt.Sprintf(`{"id":%d,"name":"Base Boss"}`, id), &got)
+	if got.Feature.Name != "Base Boss" || got.Feature.ID != id {
+		t.Errorf("rename reply = %q id %d, want \"Base Boss\" id %d", got.Feature.Name, got.Feature.ID, id)
+	}
+	if tree := modelTreeOf(t, r, s); tree.Features[0].Name != "Base Boss" {
+		t.Errorf("model.tree name = %q, want \"Base Boss\"", tree.Features[0].Name)
+	}
+	if _, err := r.Handle(s, "features.rename", []byte(fmt.Sprintf(`{"id":%d,"name":""}`, id))); err == nil {
+		t.Error("expected an error renaming to the empty name")
+	}
+}
+
+func TestFeaturesSetSuppressedViaAPI(t *testing.T) {
+	r, s, id := extrudedPartViaAPI(t)
+	var got wire.FeatureDetailResult
+	call(t, r, s, "features.setSuppressed", fmt.Sprintf(`{"id":%d,"suppressed":true}`, id), &got)
+	if !got.Feature.Suppressed {
+		t.Error("reply does not report the feature suppressed")
+	}
+	if tree := modelTreeOf(t, r, s); tree.Bodies != 0 {
+		t.Errorf("bodies with the only extrude suppressed = %d, want 0", tree.Bodies)
+	}
+	call(t, r, s, "features.setSuppressed", fmt.Sprintf(`{"id":%d,"suppressed":false}`, id), &got)
+	if tree := modelTreeOf(t, r, s); tree.Bodies != 1 {
+		t.Errorf("bodies after unsuppress = %d, want 1", tree.Bodies)
+	}
+}
+
+func TestFeaturesDeleteViaAPI(t *testing.T) {
+	r, s, id := extrudedPartViaAPI(t)
+	var got wire.DeleteFeatureResult
+	call(t, r, s, "features.delete", fmt.Sprintf(`{"id":%d}`, id), &got)
+	if !got.Deleted || got.ID != id {
+		t.Errorf("delete reply = %+v, want deleted id %d", got, id)
+	}
+	tree := modelTreeOf(t, r, s)
+	if len(tree.Features) != 0 || tree.Bodies != 0 {
+		t.Errorf("after delete: %d features, %d bodies; want 0/0", len(tree.Features), tree.Bodies)
+	}
+	if _, err := r.Handle(s, "features.delete", []byte(fmt.Sprintf(`{"id":%d}`, id))); err == nil {
+		t.Error("expected an error deleting an already-deleted id")
+	}
+}
+
+func TestFeaturesReorderViaAPI(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	// A second, independent extrude on its own sketch; it lands at history index 1.
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":1,"width":"10 mm","height":"10 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":1,"distance":"5 mm","op":"newBody"}}`, &struct{}{})
+	tree := modelTreeOf(t, r, s)
+	if len(tree.Features) != 2 {
+		t.Fatalf("fixture: %d features, want 2", len(tree.Features))
+	}
+	second := tree.Features[1].ID
+
+	var got wire.FeatureDetailResult
+	call(t, r, s, "features.reorder", fmt.Sprintf(`{"id":%d,"newIndex":0}`, second), &got)
+	if got.Feature.Index != 0 {
+		t.Errorf("reorder reply index = %d, want 0", got.Feature.Index)
+	}
+	if tree := modelTreeOf(t, r, s); tree.Features[0].ID != second {
+		t.Errorf("model.tree first feature id = %d, want %d", tree.Features[0].ID, second)
+	}
+	if _, err := r.Handle(s, "features.reorder", []byte(fmt.Sprintf(`{"id":%d,"newIndex":42}`, second))); err == nil {
+		t.Error("expected an error for an out-of-range index")
+	}
+}

--- a/addin/router/model.go
+++ b/addin/router/model.go
@@ -25,12 +25,7 @@ func modelTree(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	feats := part.Features()
 	fis := make([]wire.FeatureInfo, feats.Count())
 	for i := 0; i < feats.Count(); i++ {
-		f := feats.Item(i)
-		fi := wire.FeatureInfo{ID: uint64(f.ID()), Name: f.Name(), Kind: f.Kind(), Suppressed: f.Suppressed()}
-		if h := f.Health(); !h.OK() {
-			fi.Health = h.Reason
-		}
-		fis[i] = fi
+		fis[i] = featureInfo(feats.Item(i))
 	}
 	return json.Marshal(wire.ModelTreeResult{
 		Document:   s.ActiveDocument().DisplayName(),

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -70,8 +70,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodModelSelection] = modelSelection
 	r.handlers[wire.MethodModelReferenceKeys] = referenceKeys
 	r.registerSketchHandlers()
-	r.handlers[wire.MethodFeaturesList] = r.listFeatureKinds
-	r.handlers[wire.MethodFeaturesAdd] = r.addFeature
+	r.registerFeatureHandlers()
 	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes
 	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
 	r.handlers[wire.MethodWorkPlanesRedefine] = redefineWorkPlane
@@ -287,6 +286,11 @@ var mutatingMethods = map[string]bool{
 	wire.MethodParametersAdd:          true,
 	wire.MethodParametersSet:          true,
 	wire.MethodFeaturesAdd:            true,
+	wire.MethodFeaturesEdit:           true,
+	wire.MethodFeaturesDelete:         true,
+	wire.MethodFeaturesRename:         true,
+	wire.MethodFeaturesSetSuppressed:  true,
+	wire.MethodFeaturesReorder:        true,
 	wire.MethodWorkPlanesCreate:       true,
 	wire.MethodWorkPlanesRedefine:     true,
 	wire.MethodWorkPointsCreate:       true,

--- a/app/browser_actions.go
+++ b/app/browser_actions.go
@@ -105,15 +105,8 @@ func (s *Session) ToggleSketchShared(sk *sketch.Sketch) error {
 // ToggleFeatureSuppressed flips a feature's explicit suppression and recomputes, so the
 // part rebuilds with or without that feature's contribution.
 func (s *Session) ToggleFeatureSuppressed(f *feature.PartFeature) error {
-	part, err := activePart(s)
-	if err != nil {
-		return err
-	}
 	if f == nil {
 		return errors.New("app: ToggleFeatureSuppressed with nil feature")
 	}
-	f.SetSuppressed(!f.Suppressed())
-	part.Recompute()
-	s.recordEdit(part, "Suppress Feature")
-	return nil
+	return s.SetFeatureSuppressed(f, !f.Suppressed())
 }

--- a/app/feature_lifecycle.go
+++ b/app/feature_lifecycle.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Session actions for the lifecycle of a placed feature (issue #140): rename,
+// explicit suppression, history reorder, and committing an in-place definition
+// edit. Like the browser actions (app/browser_actions.go) each records an undo
+// edit and recomputes when the change affects geometry; they are the seam the
+// addin router's features.* methods call into.
+
+// activePartFeature resolves the active part and guards that f belongs to it, naming
+// the action for errors (e.g. "RenameFeature").
+func activePartFeature(s *Session, f *feature.PartFeature, action string) (*compdef.PartComponentDefinition, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if f == nil {
+		return nil, fmt.Errorf("app: %s with nil feature", action)
+	}
+	if got, ok := part.Features().ByID(f.ID()); !ok || got != f {
+		return nil, fmt.Errorf("app: %s: feature %q not in active part", action, f.Name())
+	}
+	return part, nil
+}
+
+// RenameFeature sets a feature's display name (the id stays stable). The name must
+// be non-empty and not already used by another feature — Inventor enforces unique
+// browser names, and ByName lookups would otherwise turn ambiguous.
+func (s *Session) RenameFeature(f *feature.PartFeature, name string) error {
+	part, err := activePartFeature(s, f, "RenameFeature")
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		return errors.New("app: RenameFeature: name must be non-empty")
+	}
+	if other, ok := part.Features().ByName(name); ok && other != f {
+		return fmt.Errorf("app: RenameFeature: name %q is already used by another feature", name)
+	}
+	f.SetName(name)
+	s.recordEdit(part, "Rename Feature")
+	return nil
+}
+
+// SetFeatureSuppressed sets (not toggles) explicit suppression and recomputes.
+// Setting the current state is a no-op, so a replicated or retried call is
+// idempotent and records no spurious undo edit.
+func (s *Session) SetFeatureSuppressed(f *feature.PartFeature, suppressed bool) error {
+	part, err := activePartFeature(s, f, "SetFeatureSuppressed")
+	if err != nil {
+		return err
+	}
+	if f.Suppressed() == suppressed {
+		return nil
+	}
+	f.SetSuppressed(suppressed)
+	part.Recompute()
+	s.recordEdit(part, suppressLabel(suppressed))
+	return nil
+}
+
+func suppressLabel(suppressed bool) string {
+	if suppressed {
+		return "Suppress Feature"
+	}
+	return "Unsuppress Feature"
+}
+
+// ReorderFeature moves a feature to a new history index and recomputes. The model
+// rejects a move that would place the feature before one it depends on.
+func (s *Session) ReorderFeature(f *feature.PartFeature, newIndex int) error {
+	part, err := activePartFeature(s, f, "ReorderFeature")
+	if err != nil {
+		return err
+	}
+	if err := part.Features().Reorder(f, newIndex); err != nil {
+		return err
+	}
+	part.Recompute()
+	s.recordEdit(part, "Reorder Feature")
+	return nil
+}
+
+// CommitFeatureEdit recomputes after the caller mutated f's definition through its
+// [feature.Editable] / [feature.ReferenceEditable] surface, and records the undo
+// edit — the commit seam model/feature/editable.go points feature editors at.
+func (s *Session) CommitFeatureEdit(f *feature.PartFeature) error {
+	part, err := activePartFeature(s, f, "CommitFeatureEdit")
+	if err != nil {
+		return err
+	}
+	part.Features().MarkDirty(f)
+	part.Recompute()
+	s.recordEdit(part, "Edit Feature")
+	return nil
+}

--- a/app/feature_lifecycle_test.go
+++ b/app/feature_lifecycle_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/feature"
+)
+
+func TestRenameFeatureSetsNameAndKeepsID(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	id := f.ID()
+	if err := s.RenameFeature(f, "Base Boss"); err != nil {
+		t.Fatalf("RenameFeature: %v", err)
+	}
+	if f.Name() != "Base Boss" {
+		t.Errorf("name after rename = %q, want %q", f.Name(), "Base Boss")
+	}
+	if f.ID() != id {
+		t.Errorf("id changed across rename: %d -> %d", id, f.ID())
+	}
+}
+
+func TestRenameFeatureRejectsEmptyAndDuplicate(t *testing.T) {
+	s, _, first, second := twoExtrudePart(t)
+	if err := s.RenameFeature(first, ""); err == nil {
+		t.Error("expected an error for an empty name")
+	}
+	if err := s.RenameFeature(second, first.Name()); err == nil {
+		t.Errorf("expected an error renaming to the duplicate name %q", first.Name())
+	}
+	// Renaming a feature to its own current name is a no-op, not a duplicate.
+	if err := s.RenameFeature(first, first.Name()); err != nil {
+		t.Errorf("rename to own name: %v", err)
+	}
+}
+
+func TestSetFeatureSuppressedRebuildsAndIsIdempotent(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	if err := s.SetFeatureSuppressed(f, true); err != nil {
+		t.Fatalf("SetFeatureSuppressed(true): %v", err)
+	}
+	if n := len(def.SurfaceBodies().All()); n != 0 {
+		t.Errorf("bodies with the only extrude suppressed = %d, want 0", n)
+	}
+	if err := s.SetFeatureSuppressed(f, true); err != nil {
+		t.Fatalf("repeated SetFeatureSuppressed(true): %v", err)
+	}
+	if err := s.SetFeatureSuppressed(f, false); err != nil {
+		t.Fatalf("SetFeatureSuppressed(false): %v", err)
+	}
+	if n := len(def.SurfaceBodies().All()); n != 1 {
+		t.Errorf("bodies after unsuppress = %d, want 1", n)
+	}
+}
+
+func TestReorderFeatureMovesHistoryPosition(t *testing.T) {
+	s, part, _, second := twoExtrudePart(t)
+	if err := s.ReorderFeature(second, 0); err != nil {
+		t.Fatalf("ReorderFeature: %v", err)
+	}
+	if got := part.Features().Item(0); got != second {
+		t.Errorf("feature at index 0 after reorder = %q, want %q", got.Name(), second.Name())
+	}
+	if err := s.ReorderFeature(second, 99); err == nil {
+		t.Error("expected an error for an out-of-range index")
+	}
+}
+
+func TestCommitFeatureEditAppliesScalarChange(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	ed, ok := f.Definition().(feature.Editable)
+	if !ok {
+		t.Fatal("extrude definition does not implement Editable")
+	}
+	ed.EditableParams()[0].Set(8) // distance, database units (cm)
+	if err := s.CommitFeatureEdit(f); err != nil {
+		t.Fatalf("CommitFeatureEdit: %v", err)
+	}
+	if got := ed.EditableParams()[0].Get(); got != 8 {
+		t.Errorf("distance after edit = %v, want 8", got)
+	}
+	if n := len(def.SurfaceBodies().All()); n != 1 {
+		t.Errorf("bodies after committed edit = %d, want 1", n)
+	}
+}
+
+func TestFeatureLifecycleRejectsForeignFeature(t *testing.T) {
+	s, _ := extrudedBoxPart(t)
+	_, otherDef := extrudedBoxPart(t) // a second, unrelated session's part
+	foreign := otherDef.Features().Item(0)
+	if err := s.RenameFeature(foreign, "x"); err == nil {
+		t.Error("expected an error renaming a feature from another part")
+	}
+	if err := s.SetFeatureSuppressed(foreign, true); err == nil {
+		t.Error("expected an error suppressing a feature from another part")
+	}
+	if err := s.CommitFeatureEdit(foreign); err == nil {
+		t.Error("expected an error committing an edit on a feature from another part")
+	}
+}

--- a/model/feature/work_plane_redefine.go
+++ b/model/feature/work_plane_redefine.go
@@ -191,6 +191,8 @@ func (w *WorkPlane) IsRedefinable() bool {
 // restores it — an edit's Cancel calls it to undo any re-picked references and scalar changes
 // in one step. Every user definition is held behind a pointer (slots and scalar edits mutate
 // one shared instance), so the snapshot copies the pointee and the restore copies it back.
+//
+//nolint:funlen // one-case-per-definition-kind dispatch; each case only names the concrete type snapshotPointee needs.
 func (w *WorkPlane) SnapshotDefinition() func() {
 	switch d := w.def.(type) {
 	case *offsetPlaneDef:

--- a/model/feature/work_plane_redefine_test.go
+++ b/model/feature/work_plane_redefine_test.go
@@ -33,7 +33,9 @@ func TestRedefineThreePointPlaneRepicksPoint(t *testing.T) {
 
 	// Re-point the third corner above the XY plane so the plane tilts off +Z.
 	up := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 1, 1) })
-	slots[2].Set(up.Key())
+	if err := slots[2].Set(up.Key()); err != nil {
+		t.Fatalf("re-pick point 3: %v", err)
+	}
 	g.Recompute(nil)
 	if wp.Plane().Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
 		t.Errorf("after re-picking point 3, plane normal still +Z (%v) — redefine did not take", wp.Plane().Normal())


### PR DESCRIPTION
## What

Implements the feature-lifecycle wire methods (`features.get/edit/delete/rename/setSuppressed/reorder`) declared in Oblikovati/Oblikovati.API#33. Closes #140.

- **app**: `RenameFeature` (non-empty, unique name), `SetFeatureSuppressed` (set-not-toggle, idempotent), `ReorderFeature`, and `CommitFeatureEdit` — the commit seam `model/feature/editable.go` anticipated. Each guards the feature belongs to the active part, records an undo edit, and recomputes when geometry is affected. `ToggleFeatureSuppressed` now delegates to the setter.
- **addin/router**: the six handlers. Features resolve by stable id (indices die on reorder/delete). Scalar batches are validated wholesale — feature editable, index in range, value parseable in the scalar's unit — before any `Set` applies, so a mid-batch error cannot leave a definition half-edited. The reorder reply re-resolves the feature so it reports the new index.
- The five mutating methods join the `edit.committed` allowlist (ADR-0004 replication).
- `registerFeatureHandlers` extracted alongside `registerSketchHandlers` (funlen).

## Why

The model layer already had the mechanics (`PartFeatures.Reorder`, suppression, the `Editable` scalar surface) but nothing exposed them to add-ins — parametric editing was impossible over the API (issue #140). With this PR an add-in can read an extrude's distance, deepen it, suppress it, rename it, reorder history, and delete it, each as one undoable, replicated edit.

## Tests

- `app/feature_lifecycle_test.go`: rename rules (empty/duplicate/own-name), suppress rebuild + idempotency, reorder bounds, commit-edit recompute, foreign-feature rejection.
- `addin/router/feature_lifecycle_test.go`: all six methods end-to-end over wire JSON, including validate-before-apply (a bad batch leaves the distance untouched) and body-count assertions through `model.tree`.
- Full suite + `golangci-lint` clean on touched packages.

Out of scope (follow-up per the issue discussion): re-picking geometric references (`EditableRefSlot` — profiles, edges, faces), which deserves its own ref-resolution design mirroring work-plane `repick`.

Refs Oblikovati/Oblikovati.API#33 (contract; must merge with or before this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)