### PR TITLE
3D sketch: implement tangent/smooth/splineFitPoints/helical constraints, wire them to the UI, and guard declared kinds

### DIFF
--- a/addin/router/sketch3d_constraints.go
+++ b/addin/router/sketch3d_constraints.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
 
@@ -43,8 +44,127 @@ func buildSketch3DConstraint(sk *sketch.Sketch3D, kind types.Geometric3DConstrai
 		return midpointConstraint3D(sk, refs)
 	case types.Geo3DGround:
 		return groundConstraint3D(sk, refs)
+	case types.Geo3DTangent, types.Geo3DSmooth:
+		return smoothJoinConstraint3D(sk, kind, refs)
+	case types.Geo3DSplineFitPoints:
+		return splineFitConstraint3D(sk, refs)
+	case types.Geo3DHelical:
+		return helicalConstraint3D(sk, refs)
+	case types.Geo3DEqual:
+		return equalConstraint3D(sk, refs)
 	default:
 		return orientationConstraint3D(sk, kind, refs)
+	}
+}
+
+// smoothJoinConstraint3D builds the tangent (G1) / smooth (G2) join between two curves
+// (line/arc/spline), joining at their nearest endpoints — the same choice the 2D Smooth
+// tool makes. Smooth requires at least one spline: two analytic curves can only be G2
+// when cocircular, so anything else would over-constrain unsolvably.
+func smoothJoinConstraint3D(sk *sketch.Sketch3D, kind types.Geometric3DConstraintKind, refs []uint64) (sketch.Constraint, error) {
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("sketch3d.addConstraint: %s needs 2 curve refs (line/arc/spline), got %d", kind, len(refs))
+	}
+	c1, err := smoothCurveRef3D(sk, refs[0])
+	if err != nil {
+		return nil, err
+	}
+	c2, err := smoothCurveRef3D(sk, refs[1])
+	if err != nil {
+		return nil, err
+	}
+	p1, p2, ok := sketch.NearestEndpointPair3D(c1, c2)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d.addConstraint: %s: a picked curve has no free endpoint (closed spline?)", kind)
+	}
+	if kind == types.Geo3DTangent {
+		return sketch.NewTangent3D(c1, c2, p1, p2), nil
+	}
+	if !isSpline3D(c1) && !isSpline3D(c2) {
+		return nil, fmt.Errorf("sketch3d.addConstraint: smooth needs at least one spline (got %T and %T)", c1, c2)
+	}
+	return sketch.NewSmooth3D(c1, c2, p1, p2), nil
+}
+
+// splineFitConstraint3D attaches a point to the nearest fit point of a fit spline.
+func splineFitConstraint3D(sk *sketch.Sketch3D, refs []uint64) (sketch.Constraint, error) {
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("sketch3d.addConstraint: splineFitPoints needs a spline + point, got %d refs", len(refs))
+	}
+	sp, err := splineRef3D(sk, refs[0])
+	if err != nil {
+		return nil, err
+	}
+	p, err := pointRef3D(sk, refs[1])
+	if err != nil {
+		return nil, err
+	}
+	c, err := sketch.NewSplineFitPoints3D(sp, p)
+	if err != nil {
+		return nil, fmt.Errorf("sketch3d.addConstraint: %w", err)
+	}
+	return c, nil
+}
+
+// helicalConstraint3D ties a helix to the circle it starts on (coincident origin/center,
+// equal start radius/circle radius).
+func helicalConstraint3D(sk *sketch.Sketch3D, refs []uint64) (sketch.Constraint, error) {
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("sketch3d.addConstraint: helical needs a helix + circle, got %d refs", len(refs))
+	}
+	h, err := helixRef3D(sk, refs[0])
+	if err != nil {
+		return nil, err
+	}
+	circle, err := circleRef3D(sk, refs[1])
+	if err != nil {
+		return nil, err
+	}
+	c, err := sketch.NewHelical3D(h, circle)
+	if err != nil {
+		return nil, fmt.Errorf("sketch3d.addConstraint: %w", err)
+	}
+	return c, nil
+}
+
+// isSpline3D reports whether a smooth-capable curve is a spline (the side whose end
+// curvature the solver can adjust for a G2 join).
+func isSpline3D(c sketch.SmoothCurve3D) bool {
+	_, ok := c.(*sketch.Spline3D)
+	return ok
+}
+
+// equalConstraint3D forces two radius DOFs equal — the operands are circle (radius) or
+// helix (start radius) entities. Surfaced by the issue-#142 kind-coverage guard:
+// Geo3DEqual was declared and Equal3D implemented, but no router case existed.
+func equalConstraint3D(sk *sketch.Sketch3D, refs []uint64) (sketch.Constraint, error) {
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("sketch3d.addConstraint: equal needs 2 circle/helix refs, got %d", len(refs))
+	}
+	a, err := radiusScalar3D(sk, refs[0])
+	if err != nil {
+		return nil, err
+	}
+	b, err := radiusScalar3D(sk, refs[1])
+	if err != nil {
+		return nil, err
+	}
+	return sketch.NewEqual3D(a, b), nil
+}
+
+// radiusScalar3D resolves an entity id to its radius solver DOF.
+func radiusScalar3D(sk *sketch.Sketch3D, id uint64) (*math.Scalar, error) {
+	e, ok := sk.EntityByID(sketch.ID(id))
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: no entity with id %d", id)
+	}
+	switch v := e.(type) {
+	case *sketch.Circle3D:
+		return &v.Radius, nil
+	case *sketch.HelicalCurve3D:
+		return &v.StartRadius, nil
+	default:
+		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a circle or helix (radius DOF)", id, e)
 	}
 }
 
@@ -202,4 +322,57 @@ func lineRef3D(sk *sketch.Sketch3D, id uint64) (*sketch.Line3D, error) {
 		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a 3D line", id, e)
 	}
 	return l, nil
+}
+
+// smoothCurveRef3D resolves a session id to a tangent/smooth-capable curve
+// (line/arc/spline).
+func smoothCurveRef3D(sk *sketch.Sketch3D, id uint64) (sketch.SmoothCurve3D, error) {
+	e, ok := sk.EntityByID(sketch.ID(id))
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: no entity with id %d", id)
+	}
+	c, ok := e.(sketch.SmoothCurve3D)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a line/arc/spline", id, e)
+	}
+	return c, nil
+}
+
+// splineRef3D resolves a session id to a 3D spline entity.
+func splineRef3D(sk *sketch.Sketch3D, id uint64) (*sketch.Spline3D, error) {
+	e, ok := sk.EntityByID(sketch.ID(id))
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: no entity with id %d", id)
+	}
+	sp, ok := e.(*sketch.Spline3D)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a 3D spline", id, e)
+	}
+	return sp, nil
+}
+
+// helixRef3D resolves a session id to a helical curve entity.
+func helixRef3D(sk *sketch.Sketch3D, id uint64) (*sketch.HelicalCurve3D, error) {
+	e, ok := sk.EntityByID(sketch.ID(id))
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: no entity with id %d", id)
+	}
+	h, ok := e.(*sketch.HelicalCurve3D)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a helical curve", id, e)
+	}
+	return h, nil
+}
+
+// circleRef3D resolves a session id to a 3D circle entity.
+func circleRef3D(sk *sketch.Sketch3D, id uint64) (*sketch.Circle3D, error) {
+	e, ok := sk.EntityByID(sketch.ID(id))
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: no entity with id %d", id)
+	}
+	c, ok := e.(*sketch.Circle3D)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a 3D circle", id, e)
+	}
+	return c, nil
 }

--- a/addin/router/sketch3d_constraints_coverage_test.go
+++ b/addin/router/sketch3d_constraints_coverage_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// The declared-kind coverage guard of issue #142: every Geometric3DConstraintKind
+// declared in api/types must be accepted end-to-end by sketch3d.addConstraint, so the
+// contract can never again advertise constraint kinds the solver cannot build. A new
+// kind added to api/types without a fixture here fails the completeness check below.
+
+// constraint3DFixture builds the minimal geometry for one kind and returns the
+// addConstraint entity refs.
+type constraint3DFixture func(t *testing.T, r *Router, s *app.Session) []uint64
+
+// twoLines3D builds two non-parallel lines and returns their entity ids.
+func twoLines3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	var l1, l2 wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0,0],[1,0,0]]}`, &l1)
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,1,0],[1,1,1]]}`, &l2)
+	return []uint64{l1.EntityID, l2.EntityID}
+}
+
+// oneLine3D builds a single line and returns its entity id.
+func oneLine3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	return twoLines3D(t, r, s)[:1]
+}
+
+// nPoints3D builds n standalone points and returns their ids.
+func nPoints3D(n int) constraint3DFixture {
+	return func(t *testing.T, r *Router, s *app.Session) []uint64 {
+		t.Helper()
+		out := make([]uint64, n)
+		for i := range out {
+			var p wire.AddSketch3DEntityResult
+			call(t, r, s, "sketch3d.addEntity",
+				fmt.Sprintf(`{"sketchIndex":0,"kind":"point","points":[[%d,%d,0]]}`, i, i*2), &p)
+			out[i] = p.EntityID
+		}
+		return out
+	}
+}
+
+// lineAndArc3D builds a line meeting an arc at (1,0,0) and returns their ids.
+func lineAndArc3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	var l, a wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0,0],[1,0,0]]}`, &l)
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"arc","points":[[1,1,0],[1,0,0],[2,1,0]],"ccw":false}`, &a)
+	return []uint64{l.EntityID, a.EntityID}
+}
+
+// lineAndSpline3D builds a line and a fit spline starting near the line's end.
+func lineAndSpline3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	var l, sp wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[-1,0,0],[0,0,0]]}`, &l)
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"spline","points":[[0.2,0.1,0],[1,1,0],[2,0,1]]}`, &sp)
+	return []uint64{l.EntityID, sp.EntityID}
+}
+
+// splineAndPoint3D builds a fit spline and a standalone point near a fit point.
+func splineAndPoint3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	var sp, p wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"spline","points":[[0,0,0],[1,1,0],[2,0,1]]}`, &sp)
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"point","points":[[1.1,0.9,0]]}`, &p)
+	return []uint64{sp.EntityID, p.EntityID}
+}
+
+// twoCircles3D builds two circles of different radii and returns their ids.
+func twoCircles3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	var c1, c2 wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0,0]],"radius":"10 mm"}`, &c1)
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0,5]],"radius":"7 mm"}`, &c2)
+	return []uint64{c1.EntityID, c2.EntityID}
+}
+
+// helixAndCircle3D builds a coaxial (Z) helix and circle and returns their ids.
+func helixAndCircle3D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	var h, c wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity",
+		`{"sketchIndex":0,"kind":"helical","points":[[0,0,1]],"radius":"4 mm","mode":"pitchRevolution","pitch":"10 mm","revolutions":3}`, &h)
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0,0]],"radius":"5 mm"}`, &c)
+	return []uint64{h.EntityID, c.EntityID}
+}
+
+// declared3DConstraintFixtures maps EVERY declared kind to its minimal fixture.
+// Geo3DBend is the one tracked exception: entity + constraint are unimplemented and
+// tracked by issue #143 — remove the exclusion when it lands.
+var declared3DConstraintFixtures = map[types.Geometric3DConstraintKind]constraint3DFixture{
+	types.Geo3DCoincident:    nPoints3D(2),
+	types.Geo3DCollinear:     nPoints3D(3),
+	types.Geo3DConcentric:    nPoints3D(2),
+	types.Geo3DParallel:      twoLines3D,
+	types.Geo3DPerpendicular: twoLines3D,
+	types.Geo3DTangent:       lineAndArc3D,
+	types.Geo3DSmooth:        lineAndSpline3D,
+	types.Geo3DMidpoint: func(t *testing.T, r *Router, s *app.Session) []uint64 {
+		pts := nPoints3D(1)(t, r, s)
+		return append(pts, oneLine3D(t, r, s)...)
+	},
+	types.Geo3DGround:            nPoints3D(1),
+	types.Geo3DParallelToXAxis:   oneLine3D,
+	types.Geo3DParallelToYAxis:   oneLine3D,
+	types.Geo3DParallelToZAxis:   oneLine3D,
+	types.Geo3DParallelToXYPlane: oneLine3D,
+	types.Geo3DParallelToXZPlane: oneLine3D,
+	types.Geo3DParallelToYZPlane: oneLine3D,
+	types.Geo3DSplineFitPoints:   splineAndPoint3D,
+	types.Geo3DHelical:           helixAndCircle3D,
+	types.Geo3DEqual:             twoCircles3D,
+}
+
+// trackedUnimplemented3DKinds are declared kinds knowingly absent from the solver,
+// each requiring an open issue. The completeness check fails when a kind is neither
+// covered nor tracked here.
+var trackedUnimplemented3DKinds = map[types.Geometric3DConstraintKind]string{
+	types.Geo3DBend: "issue #143 (bend entity + constraint)",
+}
+
+// allDeclared3DConstraintKinds mirrors the const block in api/types/sketch3d.go
+// (Go cannot enumerate constants); keep in sync when the API grows.
+var allDeclared3DConstraintKinds = []types.Geometric3DConstraintKind{
+	types.Geo3DCoincident, types.Geo3DCollinear, types.Geo3DConcentric, types.Geo3DEqual,
+	types.Geo3DParallel, types.Geo3DPerpendicular, types.Geo3DTangent, types.Geo3DSmooth,
+	types.Geo3DMidpoint, types.Geo3DGround,
+	types.Geo3DParallelToXAxis, types.Geo3DParallelToYAxis, types.Geo3DParallelToZAxis,
+	types.Geo3DParallelToXYPlane, types.Geo3DParallelToXZPlane, types.Geo3DParallelToYZPlane,
+	types.Geo3DSplineFitPoints, types.Geo3DBend, types.Geo3DHelical,
+}
+
+// TestEvery3DConstraintKindAccepted drives sketch3d.addConstraint for every declared
+// kind with a fixture and asserts the constraint lands with the same kind reported
+// back by sketch3d.constraints.
+func TestEvery3DConstraintKindAccepted(t *testing.T) {
+	for kind, fixture := range declared3DConstraintFixtures {
+		t.Run(string(kind), func(t *testing.T) {
+			r, s := emptyPartSession(t)
+			call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+			refs := fixture(t, r, s)
+			var res wire.AddSketch3DConstraintResult
+			call(t, r, s, "sketch3d.addConstraint",
+				fmt.Sprintf(`{"sketchIndex":0,"kind":"%s","entities":%s}`, kind, jsonUints(refs)), &res)
+			if res.Kind != string(kind) {
+				t.Errorf("addConstraint kind = %q, want %q", res.Kind, kind)
+			}
+			var cons wire.ListConstraints3DResult
+			call(t, r, s, "sketch3d.constraints", `{"sketchIndex":0}`, &cons)
+			if len(cons.Constraints) != 1 || cons.Constraints[0].Kind != string(kind) {
+				t.Errorf("enumerated constraints = %+v, want one of kind %q", cons.Constraints, kind)
+			}
+		})
+	}
+}
+
+// TestDeclared3DConstraintKindsComplete fails when a declared kind is neither covered
+// by a fixture (incl. the equal special case) nor in the tracked-unimplemented list —
+// the guard that api/types can never ship ahead of the solver again (issue #142).
+func TestDeclared3DConstraintKindsComplete(t *testing.T) {
+	for _, kind := range allDeclared3DConstraintKinds {
+		_, covered := declared3DConstraintFixtures[kind]
+		issue, tracked := trackedUnimplemented3DKinds[kind]
+		switch {
+		case covered && tracked:
+			t.Errorf("kind %q is both covered and tracked-unimplemented (%s) — remove one", kind, issue)
+		case !covered && !tracked:
+			t.Errorf("kind %q is declared in api/types but has no fixture and no tracking issue", kind)
+		}
+	}
+}
+
+// jsonUints renders ids as a JSON array.
+func jsonUints(ids []uint64) string {
+	out := "["
+	for i, id := range ids {
+		if i > 0 {
+			out += ","
+		}
+		out += fmt.Sprintf("%d", id)
+	}
+	return out + "]"
+}

--- a/addin/router/sketch3d_enumerate.go
+++ b/addin/router/sketch3d_enumerate.go
@@ -220,6 +220,22 @@ func lineConstraint3DKind(c sketch.Constraint) (types.Geometric3DConstraintKind,
 	case *sketch.ParallelToPlane3D:
 		return planeConstraintKind(v), []uint64{uint64(v.L.EntityID())}
 	default:
+		return curveConstraint3DKind(c)
+	}
+}
+
+// curveConstraint3DKind maps the curve-join constraints (issue #142) to their kind.
+func curveConstraint3DKind(c sketch.Constraint) (types.Geometric3DConstraintKind, []uint64) {
+	switch v := c.(type) {
+	case *sketch.Tangent3D:
+		return types.Geo3DTangent, []uint64{uint64(v.C1.EntityID()), uint64(v.C2.EntityID())}
+	case *sketch.Smooth3D:
+		return types.Geo3DSmooth, []uint64{uint64(v.C1.EntityID()), uint64(v.C2.EntityID())}
+	case *sketch.SplineFitPoints3D:
+		return types.Geo3DSplineFitPoints, []uint64{uint64(v.Spline.EntityID()), uint64(v.P.EntityID())}
+	case *sketch.Helical3D:
+		return types.Geo3DHelical, []uint64{uint64(v.H.EntityID()), uint64(v.C.EntityID())}
+	default:
 		return types.Geo3DUnknown, nil
 	}
 }

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -200,14 +200,31 @@ func patternFeatureCommands() []*CommandDefinition {
 }
 
 // sketch3DToolCommands are the contextual 3D-sketch tools, enabled only while a 3D sketch
-// is being edited (M22-F12): the geometry tools plus Finish.
+// is being edited (M22-F12): the geometry tools, the Constrain panel, plus Finish.
 func sketch3DToolCommands() []*CommandDefinition {
 	finish := NewCommand("Sketch3D.Finish", "Finish 3D Sketch", "Sketch3D", func(s *Session) error {
 		return s.FinishSketch3D()
 	}).WithTab(tab3DSketch).WithEnable(inSketch3D).WithIcon("finish-sketch").
 		WithButtonStyle(LargeIconButton).
 		WithTooltip("Finish the 3D sketch and return to the model.")
-	return append(sketch3DDrawCommands(), finish)
+	cmds := append(sketch3DDrawCommands(), sketch3DConstrainCommands()...)
+	return append(cmds, finish)
+}
+
+// sketch3DConstrainCommands are the 3D Sketch tab's Constrain panel (issue #142) —
+// each starts an interactive constraint tool the user then feeds 3D geometry, the
+// same tool-first flow as the 2D Constrain panel.
+func sketch3DConstrainCommands() []*CommandDefinition {
+	cmds := make([]*CommandDefinition, len(sketch3DConstraintToolDefs))
+	for i, d := range sketch3DConstraintToolDefs {
+		newTool := d.new
+		cmds[i] = NewCommand(d.id, d.name, "Constrain", func(s *Session) error {
+			s.StartTool(newTool())
+			return nil
+		}).WithTab(tab3DSketch).WithEnable(inSketch3D).WithTooltip(d.tooltip).
+			WithIcon(d.icon).WithButtonStyle(SmallIconButton)
+	}
+	return cmds
 }
 
 // sketch3DDrawCommands are the 3D-sketch geometry-placement tools (line/point/circle/arc/

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -19,12 +19,13 @@ import (
 // [Picker], so a test "clicks on" a modeled solid or a datum plane — screen coordinate
 // → ray → face/plane — with no GPU.
 type RayPicker struct {
-	camera   scene.Camera
-	bodies   func() []*topo.Body
-	planes   func() []*feature.WorkPlane
-	points   func() []*feature.WorkPoint
-	axes     func() []*feature.WorkAxis
-	sketches func() []*sketch.Sketch
+	camera     scene.Camera
+	bodies     func() []*topo.Body
+	planes     func() []*feature.WorkPlane
+	points     func() []*feature.WorkPoint
+	axes       func() []*feature.WorkAxis
+	sketches   func() []*sketch.Sketch
+	sketches3D func() []*sketch.Sketch3D
 }
 
 // pickPixelRadius is how close (in pixels) the cursor must be to a datum point or axis to
@@ -49,6 +50,14 @@ func (p *RayPicker) WithPlanes(planes func() []*feature.WorkPlane) *RayPicker {
 // resolve a click inside a sketch profile region — what an extrude/revolve consumes.
 func (p *RayPicker) WithSketches(sketches func() []*sketch.Sketch) *RayPicker {
 	p.sketches = sketches
+	return p
+}
+
+// WithSketches3D adds a provider of the part's (visible) 3D sketches, so the picker can
+// resolve a click on a 3D-sketch curve or point — what the 3D constraint tools consume
+// (issue #142).
+func (p *RayPicker) WithSketches3D(sketches3D func() []*sketch.Sketch3D) *RayPicker {
+	p.sketches3D = sketches3D
 	return p
 }
 
@@ -92,8 +101,65 @@ func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, boo
 	if sel, t, ok := p.nearestSketchCurve(origin, dir, filter); ok {
 		cands = append(cands, pickCandidate{t, sel})
 	}
+	if sel, t, ok := p.nearestSketch3DEntity(origin, dir, filter); ok {
+		cands = append(cands, pickCandidate{t, sel})
+	}
 	return nearestCandidate(cands)
 }
+
+// nearestSketch3DEntity returns the 3D-sketch entity (curve or standalone point) the
+// ray passes nearest within the pick radius, in any visible 3D sketch, when the
+// filter accepts sketch entities — how the 3D constraint tools receive their picks
+// (issue #142). Curves test against the same sampled polyline the overlay draws.
+func (p *RayPicker) nearestSketch3DEntity(origin math.Point3, dir math.Vector3, filter *SelectionFilter) (Selectable, float64, bool) {
+	if p.sketches3D == nil || !filter.Accepts(SelectSketchEntity) {
+		return nil, stdmath.Inf(1), false
+	}
+	tol := pickPixelRadius * p.camera.WorldPerPixel()
+	var hit Selectable
+	best := stdmath.Inf(1)
+	for _, sk := range p.sketches3D() {
+		for _, e := range sk.Entities() {
+			if d, t, ok := raySketch3DEntityDistance(origin, dir, e); ok && d <= tol && t < best {
+				best, hit = t, SketchEntityHandle{Entity: e}
+			}
+		}
+	}
+	return hit, best, hit != nil
+}
+
+// raySketch3DEntityDistance returns the closest approach between the ray and an
+// entity's sampled polyline (a standalone point is its single sample).
+func raySketch3DEntityDistance(origin math.Point3, dir math.Vector3, e sketch.Entity) (dist, t float64, ok bool) {
+	pts := sketch.SamplePolyline3D(e, pick3DCurveSegments)
+	if len(pts) == 0 {
+		return 0, 0, false
+	}
+	if len(pts) == 1 {
+		return rayPointDistance(origin, dir, pts[0])
+	}
+	dist, t = stdmath.Inf(1), stdmath.Inf(1)
+	for i := 0; i+1 < len(pts); i++ {
+		if d, s, segOK := raySegmentDistance(origin, dir, pts[i], pts[i+1]); segOK && d < dist {
+			dist, t, ok = d, s, true
+		}
+	}
+	return dist, t, ok
+}
+
+// rayPointDistance returns the distance from the forward ray to a point and the ray
+// parameter of the closest approach; ok is false behind the ray origin.
+func rayPointDistance(origin math.Point3, dir math.Vector3, pt math.Point3) (dist, t float64, ok bool) {
+	t = float64(origin.VectorTo(pt).Dot(dir))
+	if t <= 0 {
+		return 0, 0, false
+	}
+	return float64(origin.TranslateBy(dir.Scale(math.Scalar(t))).DistanceTo(pt)), t, true
+}
+
+// pick3DCurveSegments is the sample budget for picking curved 3D entities — matches
+// the overlay's draw sampling so what you see is what you pick.
+const pick3DCurveSegments = 48
 
 // nearestSketchCurve returns the sketch line the ray passes nearest (within the pick radius, in
 // any visible sketch), when the filter accepts sketch entities — so a sketch line/centerline can

--- a/app/raypicker_sketch3d_test.go
+++ b/app/raypicker_sketch3d_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+// sketch3DPicker builds a session whose picker sees one 3D sketch, with the camera
+// looking straight down the Z axis at the given target.
+func sketch3DPicker(t *testing.T, target math.Point3) (*Session, *sketch.Sketch3D) {
+	t.Helper()
+	s, _ := emptyPartSession(t)
+	sk3, err := s.CreateSketch3D()
+	if err != nil {
+		t.Fatalf("create 3D sketch: %v", err)
+	}
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(target.X, target.Y, 20)
+	cam.Target = target
+	cam.Up = math.V3(0, 1, 0)
+	s.SetPicker(NewRayPicker(cam, partBodies(s)).
+		WithSketches3D(func() []*sketch.Sketch3D { return []*sketch.Sketch3D{sk3} }))
+	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+	return s, sk3
+}
+
+// TestRayPickerSelectsSketch3DLine checks a viewport click lands on a 3D-sketch line —
+// what feeds the 3D constraint tools their picks (issue #142).
+func TestRayPickerSelectsSketch3DLine(t *testing.T) {
+	s, sk3 := sketch3DPicker(t, math.P3(1, 1, 0))
+	l := sk3.AddLine3D(math.P3(0, 1, 0), math.P3(2, 1, 0)) // passes under the centre pixel
+
+	s.Click(200, 200)
+	if s.Selection().Count() != 1 {
+		t.Fatalf("3D line pick selected %d, want 1", s.Selection().Count())
+	}
+	h, ok := s.Selection().First().(SketchEntityHandle)
+	if !ok || h.Entity != l {
+		t.Fatalf("selected %T (%v), want the 3D line", s.Selection().First(), ok)
+	}
+}
+
+// TestRayPickerSelectsSketch3DCurveAndPoint checks sampled-curve picking (a helix seen
+// down its axis) and standalone-point picking.
+func TestRayPickerSelectsSketch3DCurveAndPoint(t *testing.T) {
+	zAxis, err := math.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("axis: %v", err)
+	}
+	// The helix winds around (0,0,z) with radius 1 — looking down at (1,0,0) hits its
+	// start-side flank.
+	s, sk3 := sketch3DPicker(t, math.P3(1, 0, 0))
+	h := sk3.AddHelix3D(math.P3(0, 0, 0), zAxis, 1, 0.5, 0, 4, false)
+	s.Click(200, 200)
+	if got := s.Selection().First(); s.Selection().Count() != 1 || got.(SketchEntityHandle).Entity != h {
+		t.Fatalf("helix pick selected %v (count %d), want the helix", got, s.Selection().Count())
+	}
+
+	s2, sk2 := sketch3DPicker(t, math.P3(5, 5, 2))
+	p := sk2.AddPoint3D(math.P3(5, 5, 2))
+	s2.Click(200, 200)
+	if got := s2.Selection().First(); s2.Selection().Count() != 1 || got.(SketchEntityHandle).Entity != p {
+		t.Fatalf("point pick selected %v (count %d), want the standalone point", got, s2.Selection().Count())
+	}
+}
+
+// TestRayPickerSketch3DRespectsFilter: with a face-only filter, a 3D-sketch entity
+// under the cursor must not be picked.
+func TestRayPickerSketch3DRespectsFilter(t *testing.T) {
+	s, sk3 := sketch3DPicker(t, math.P3(1, 1, 0))
+	sk3.AddLine3D(math.P3(0, 1, 0), math.P3(2, 1, 0))
+	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
+	s.Click(200, 200)
+	if s.Selection().Count() != 0 {
+		t.Fatalf("filtered pick selected %d, want 0", s.Selection().Count())
+	}
+}

--- a/app/sketch3d_constraint_tools.go
+++ b/app/sketch3d_constraint_tools.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"oblikovati.org/model/sketch"
+)
+
+// 3D-sketch constraint tools (issue #142): tangent, smooth, helical, and spline-fit
+// reach the user the same tool-first way as the 2D Constrain panel. They reuse the
+// generic pick-driven [ConstraintTool] — 3D entities implement sketch.Entity and
+// arrive as SketchEntityHandle picks from the viewport's 3D-sketch picking — and
+// apply against the active 3D sketch's constraint collection.
+
+// geom3D returns the active 3D sketch's geometric-constraint collection (the same
+// collection type 2D sketches use; the entities differ).
+func (s *Session) geom3D() *sketch.GeometricConstraints {
+	return s.activeSketch3D.GeometricConstraints3D()
+}
+
+// afterConstraint3D re-solves the active 3D sketch and clears the selection — the 3D
+// counterpart of afterConstraint.
+func (s *Session) afterConstraint3D() error {
+	if s.activeSketch3D == nil {
+		return errors.New("no active 3D sketch")
+	}
+	s.activeSketch3D.Solve()
+	s.Select(nil)
+	return nil
+}
+
+// sketch3DConstraintToolDefs is the 3D Sketch tab's Constrain panel, in display
+// order. Icons reuse the 2D constraint glyphs (tangent/smooth) and the entity glyphs
+// (helix/spline) so the panel needs no new assets.
+var sketch3DConstraintToolDefs = []struct {
+	id, name, icon, tooltip, prompt string
+	new                             func() *ConstraintTool
+}{
+	{
+		"Sketch3D.Tangent", "Tangent", "tangent",
+		"Tangent — pick two connected curves (line/arc/spline) to join tangentially (G1).",
+		"Select two curves to join tangentially",
+		func() *ConstraintTool {
+			return &ConstraintTool{name: "Tangent (3D)", prompt: "Select two curves to join tangentially",
+				accepts: acceptSmoothCurve3D, ready: ready2SmoothCurves3D, apply: entityApply(applyTangent3D)}
+		},
+	},
+	{
+		"Sketch3D.Smooth", "Smooth", "smooth",
+		"Smooth (G2) — pick a spline and an adjacent curve to join curvature-continuously.",
+		"Select a spline and an adjacent curve to join smoothly (G2)",
+		func() *ConstraintTool {
+			return &ConstraintTool{name: "Smooth (3D)", prompt: "Select a spline and an adjacent curve to join smoothly (G2)",
+				accepts: acceptSmoothCurve3D, ready: readySmooth3D, apply: entityApply(applySmooth3D)}
+		},
+	},
+	{
+		"Sketch3D.Helical", "Helical", "helix",
+		"Helical — pick a helix and the circle it starts on (coincident origin, equal radius).",
+		"Select a helix and a circle",
+		func() *ConstraintTool {
+			return &ConstraintTool{name: "Helical", prompt: "Select a helix and a circle",
+				accepts: acceptHelixOrCircle3D, ready: readyHelical3D, apply: entityApply(applyHelical3D)}
+		},
+	},
+	{
+		"Sketch3D.SplineFit", "Spline Fit", "spline",
+		"Spline Fit — attach a point to the nearest fit point of a fit spline.",
+		"Select a fit spline and a point",
+		func() *ConstraintTool {
+			return &ConstraintTool{name: "Spline Fit", prompt: "Select a fit spline and a point",
+				accepts: acceptSplineOrPoint3D, ready: readySplineFit3D, apply: entityApply(applySplineFit3D)}
+		},
+	},
+}
+
+// --- accepts / ready predicates ---------------------------------------------------------
+
+func acceptSmoothCurve3D(e sketch.Entity) bool {
+	_, ok := e.(sketch.SmoothCurve3D)
+	return ok
+}
+
+func ready2SmoothCurves3D(ents []sketch.Entity) bool { return len(smoothCurves3DOf(ents)) >= 2 }
+
+// readySmooth3D needs two curves, at least one being a spline (G2 needs an end the
+// solver can bend — mirrors the 2D Smooth tool).
+func readySmooth3D(ents []sketch.Entity) bool {
+	curves := smoothCurves3DOf(ents)
+	return len(curves) >= 2 && hasSpline3D(curves)
+}
+
+func acceptHelixOrCircle3D(e sketch.Entity) bool {
+	switch e.(type) {
+	case *sketch.HelicalCurve3D, *sketch.Circle3D:
+		return true
+	default:
+		return false
+	}
+}
+
+func readyHelical3D(ents []sketch.Entity) bool {
+	h, c := helixAndCircleOf(ents)
+	return h != nil && c != nil
+}
+
+func acceptSplineOrPoint3D(e sketch.Entity) bool {
+	switch v := e.(type) {
+	case *sketch.Spline3D:
+		return v.IsFitType()
+	case *sketch.Point3D:
+		return true
+	default:
+		return false
+	}
+}
+
+func readySplineFit3D(ents []sketch.Entity) bool {
+	sp, p := splineAndPointOf(ents)
+	return sp != nil && p != nil
+}
+
+// --- apply functions ----------------------------------------------------------------------
+
+// applyTangent3D joins two curves with a tangent (G1) constraint at their nearest
+// endpoints.
+func applyTangent3D(s *Session, ents []sketch.Entity) error {
+	curves := smoothCurves3DOf(ents)
+	if len(curves) >= 2 {
+		if p1, p2, ok := sketch.NearestEndpointPair3D(curves[0], curves[1]); ok {
+			s.geom3D().Add(sketch.NewTangent3D(curves[0], curves[1], p1, p2))
+			return s.afterConstraint3D()
+		}
+	}
+	return errNeed("tangent", "two curves with free endpoints (line/arc/spline)")
+}
+
+// applySmooth3D joins two curves with a smooth (G2) constraint at their nearest
+// endpoints — at least one side must be a spline.
+func applySmooth3D(s *Session, ents []sketch.Entity) error {
+	curves := smoothCurves3DOf(ents)
+	if len(curves) >= 2 && hasSpline3D(curves) {
+		if p1, p2, ok := sketch.NearestEndpointPair3D(curves[0], curves[1]); ok {
+			s.geom3D().Add(sketch.NewSmooth3D(curves[0], curves[1], p1, p2))
+			return s.afterConstraint3D()
+		}
+	}
+	return errNeed("smooth", "a spline and an adjacent curve with free endpoints")
+}
+
+// applyHelical3D ties the picked helix to the picked circle.
+func applyHelical3D(s *Session, ents []sketch.Entity) error {
+	h, circle := helixAndCircleOf(ents)
+	if h == nil || circle == nil {
+		return errNeed("helical", "a helix and a circle")
+	}
+	c, err := sketch.NewHelical3D(h, circle)
+	if err != nil {
+		return fmt.Errorf("helical: %w", err)
+	}
+	s.geom3D().Add(c)
+	return s.afterConstraint3D()
+}
+
+// applySplineFit3D attaches the picked point to the picked fit spline.
+func applySplineFit3D(s *Session, ents []sketch.Entity) error {
+	sp, p := splineAndPointOf(ents)
+	if sp == nil || p == nil {
+		return errNeed("spline fit", "a fit spline and a point")
+	}
+	c, err := sketch.NewSplineFitPoints3D(sp, p)
+	if err != nil {
+		return fmt.Errorf("spline fit: %w", err)
+	}
+	s.geom3D().Add(c)
+	return s.afterConstraint3D()
+}
+
+// --- pick filtering helpers -----------------------------------------------------------------
+
+// smoothCurves3DOf extracts the tangent/smooth-capable curves from the picks.
+func smoothCurves3DOf(ents []sketch.Entity) []sketch.SmoothCurve3D {
+	var out []sketch.SmoothCurve3D
+	for _, e := range ents {
+		if c, ok := e.(sketch.SmoothCurve3D); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func hasSpline3D(curves []sketch.SmoothCurve3D) bool {
+	for _, c := range curves {
+		if _, ok := c.(*sketch.Spline3D); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// helixAndCircleOf extracts the first helix and first circle from the picks.
+func helixAndCircleOf(ents []sketch.Entity) (*sketch.HelicalCurve3D, *sketch.Circle3D) {
+	var h *sketch.HelicalCurve3D
+	var c *sketch.Circle3D
+	for _, e := range ents {
+		switch v := e.(type) {
+		case *sketch.HelicalCurve3D:
+			if h == nil {
+				h = v
+			}
+		case *sketch.Circle3D:
+			if c == nil {
+				c = v
+			}
+		}
+	}
+	return h, c
+}
+
+// splineAndPointOf extracts the first fit spline and first point from the picks.
+func splineAndPointOf(ents []sketch.Entity) (*sketch.Spline3D, *sketch.Point3D) {
+	var sp *sketch.Spline3D
+	var p *sketch.Point3D
+	for _, e := range ents {
+		switch v := e.(type) {
+		case *sketch.Spline3D:
+			if sp == nil && v.IsFitType() {
+				sp = v
+			}
+		case *sketch.Point3D:
+			if p == nil {
+				p = v
+			}
+		}
+	}
+	return sp, p
+}

--- a/app/sketch3d_constraint_tools_test.go
+++ b/app/sketch3d_constraint_tools_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// sketch3DSession builds a session editing a fresh 3D sketch with the standard
+// commands registered — the fixture every 3D constraint-tool test starts from.
+func sketch3DSession(t *testing.T) (*Session, *sketch.Sketch3D) {
+	t.Helper()
+	s, _ := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	sk, err := s.CreateSketch3D()
+	if err != nil {
+		t.Fatalf("create 3D sketch: %v", err)
+	}
+	return s, sk
+}
+
+// TestSketch3DTangentToolAppliesViaPicks drives the ribbon command + pick flow end to
+// end: activate Sketch3D.Tangent, pick a line and an arc, and the constraint applies
+// and re-solves the sketch into a tangent join.
+func TestSketch3DTangentToolAppliesViaPicks(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	l := sk.AddLine3D(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	a := sk.AddArc3D(math.P3(1, 1, 0), math.P3(1.3, 0.2, 0), math.P3(2, 1, 0), false)
+
+	if err := s.Execute("Sketch3D.Tangent"); err != nil {
+		t.Fatalf("Sketch3D.Tangent: %v", err)
+	}
+	s.feedPick(SketchEntityHandle{Entity: l})
+	if s.ActiveTool() == nil {
+		t.Fatal("tool should stay active after one pick")
+	}
+	s.feedPick(SketchEntityHandle{Entity: a}) // second pick → auto-applies + deactivates
+	if s.ActiveTool() != nil {
+		t.Error("tool should deactivate after applying the constraint")
+	}
+	if sk.GeometricConstraints3D().Count() != 1 {
+		t.Fatalf("constraints = %d, want 1", sk.GeometricConstraints3D().Count())
+	}
+	if d := float64(l.B.Position().DistanceTo(a.Start.Position())); d > 1e-6 {
+		t.Errorf("join endpoints %g apart after tool applied, want coincident", d)
+	}
+}
+
+// TestSketch3DSmoothToolNeedsSpline keeps gathering picks for two analytic curves
+// (not ready) and applies once a spline is picked.
+func TestSketch3DSmoothToolNeedsSpline(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	l1 := sk.AddLine3D(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	l2 := sk.AddLine3D(math.P3(1.2, 0, 0), math.P3(2, 1, 0))
+	sp := sk.AddSpline3D([]math.Point3{{X: 1.1, Y: 0.1, Z: 0}, {X: 2, Y: 1, Z: 0.5}, {X: 3, Y: 0, Z: 1}}, false, true)
+
+	if err := s.Execute("Sketch3D.Smooth"); err != nil {
+		t.Fatalf("Sketch3D.Smooth: %v", err)
+	}
+	s.feedPick(SketchEntityHandle{Entity: l1})
+	s.feedPick(SketchEntityHandle{Entity: l2})
+	if s.ActiveTool() == nil {
+		t.Fatal("two analytic curves must not satisfy Smooth (needs a spline)")
+	}
+	s.feedPick(SketchEntityHandle{Entity: sp})
+	if s.ActiveTool() != nil {
+		t.Error("tool should deactivate after the spline pick completes the constraint")
+	}
+	if sk.GeometricConstraints3D().Count() != 1 {
+		t.Fatalf("constraints = %d, want 1", sk.GeometricConstraints3D().Count())
+	}
+	if _, ok := sk.GeometricConstraints3D().Item(0).(*sketch.Smooth3D); !ok {
+		t.Errorf("applied constraint = %T, want *Smooth3D", sk.GeometricConstraints3D().Item(0))
+	}
+}
+
+// TestSketch3DHelicalToolApplies picks a helix and a circle (any order) and ties them.
+func TestSketch3DHelicalToolApplies(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	zAxis, err := math.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("axis: %v", err)
+	}
+	circle := sk.AddCircle3D(math.P3(0, 0, 0), zAxis, 5)
+	helix := sk.AddHelix3D(math.P3(0.4, 0.1, 0), zAxis, 4, 1, 0, 6, false)
+
+	if err := s.Execute("Sketch3D.Helical"); err != nil {
+		t.Fatalf("Sketch3D.Helical: %v", err)
+	}
+	s.feedPick(SketchEntityHandle{Entity: circle}) // circle first: order must not matter
+	s.feedPick(SketchEntityHandle{Entity: helix})
+	if s.ActiveTool() != nil {
+		t.Error("tool should deactivate after applying the constraint")
+	}
+	if sk.GeometricConstraints3D().Count() != 1 {
+		t.Fatalf("constraints = %d, want 1", sk.GeometricConstraints3D().Count())
+	}
+	if d := float64(helix.Origin.Position().DistanceTo(circle.Center.Position())); d > 1e-6 {
+		t.Errorf("helix origin %g from circle center after solve, want coincident", d)
+	}
+	if dr := stdmath.Abs(float64(helix.StartRadius - circle.Radius)); dr > 1e-6 {
+		t.Errorf("start radius differs from circle radius by %g after solve", dr)
+	}
+}
+
+// TestSketch3DSplineFitToolApplies attaches a point to a fit spline via picks.
+func TestSketch3DSplineFitToolApplies(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	sp := sk.AddSpline3D([]math.Point3{{X: 0, Y: 0, Z: 0}, {X: 1, Y: 1, Z: 0}, {X: 2, Y: 0, Z: 1}}, false, true)
+	p := sk.AddPoint3D(math.P3(1.1, 0.9, 0.1))
+
+	if err := s.Execute("Sketch3D.SplineFit"); err != nil {
+		t.Fatalf("Sketch3D.SplineFit: %v", err)
+	}
+	s.feedPick(SketchEntityHandle{Entity: sp})
+	s.feedPick(SketchEntityHandle{Entity: p})
+	if s.ActiveTool() != nil {
+		t.Error("tool should deactivate after applying the constraint")
+	}
+	if d := float64(sp.Points[1].Position().DistanceTo(p.Position())); d > 1e-6 {
+		t.Errorf("point %g from its fit point after solve, want attached", d)
+	}
+}
+
+// TestSketch3DConstrainToolRejectsWrongType guards the hover/accept filter: the
+// helical tool must not record a line pick.
+func TestSketch3DConstrainToolRejectsWrongType(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	l := sk.AddLine3D(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	if err := s.Execute("Sketch3D.Helical"); err != nil {
+		t.Fatalf("Sketch3D.Helical: %v", err)
+	}
+	tool, ok := s.ActiveTool().Tool().(*ConstraintTool)
+	if !ok {
+		t.Fatalf("active tool = %T, want *ConstraintTool", s.ActiveTool().Tool())
+	}
+	if tool.Accepts(l) {
+		t.Error("the helical tool should not accept a line")
+	}
+	s.feedPick(SketchEntityHandle{Entity: l})
+	if len(tool.Picked()) != 0 {
+		t.Errorf("rejected pick was recorded: %d picks", len(tool.Picked()))
+	}
+}
+
+// TestSketch3DConstrainCommandsDisabledOutsideSketch guards the enable predicate: the
+// Constrain commands are contextual to the 3D-sketch environment.
+func TestSketch3DConstrainCommandsDisabledOutsideSketch(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	for _, id := range []string{"Sketch3D.Tangent", "Sketch3D.Smooth", "Sketch3D.Helical", "Sketch3D.SplineFit"} {
+		cmd, ok := s.Commands().ByID(id)
+		if !ok {
+			t.Fatalf("command %s is not registered", id)
+		}
+		if cmd.IsEnabled(s) {
+			t.Errorf("%s enabled outside the 3D-sketch environment", id)
+		}
+	}
+}

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -182,7 +182,8 @@ func seedPart(s *app.Session) {
 		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }).
 		WithPoints(func() []*feature.WorkPoint { return activeWorkPoints(s) }).
 		WithAxes(func() []*feature.WorkAxis { return activeWorkAxes(s) }).
-		WithSketches(func() []*sketch.Sketch { return activeSketches(s) }))
+		WithSketches(func() []*sketch.Sketch { return activeSketches(s) }).
+		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }))
 
 	// Frame the box (centered ~(2,1.5,2.5)) from a three-quarter view.
 	cam := s.Camera()
@@ -243,6 +244,23 @@ func activeSketches(s *app.Session) []*sketch.Sketch {
 	var out []*sketch.Sketch
 	for i := 0; i < p.Sketches().Count(); i++ {
 		if sk := p.Sketches().Item(i); sk.Visible() && !s.EditScopeHides(sk.Seq()) {
+			out = append(out, sk)
+		}
+	}
+	return out
+}
+
+// activeSketches3D returns the active part's visible 3D sketches (nil if none), so the
+// picker can resolve a click on a 3D-sketch curve or point for the 3D constraint
+// tools (issue #142).
+func activeSketches3D(s *app.Session) []*sketch.Sketch3D {
+	p, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil
+	}
+	var out []*sketch.Sketch3D
+	for i := 0; i < p.Sketches3D().Count(); i++ {
+		if sk := p.Sketches3D().Item(i); sk.Visible() {
 			out = append(out, sk)
 		}
 	}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -369,6 +369,7 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s), hidden)...)
 	list.Items = append(list.Items, partSketchOverlays(s)...)
 	list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
+	list.Items = append(list.Items, sketch3DOverlays(s, pointMarkerPixels*cam.WorldPerPixel())...)
 	list.Items = append(list.Items, selectedEdgeOverlay(s)...)
 	list.Items = append(list.Items, threadOverlay(s)...)
 	list.Items = append(list.Items, toolHoverHighlight(s)...)

--- a/head/ui/sketch3d_overlay.go
+++ b/head/ui/sketch3d_overlay.go
@@ -1,0 +1,86 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+)
+
+// sketch3DOverlays renders the active part's 3D sketches in the viewport — curves as
+// sampled polylines (the same sampling the ray picker tests against), standalone
+// points as screen-constant crosses — so 3D-sketch geometry is visible and pickable
+// for the constraint tools (issue #142). Entities picked by the active pick-driven
+// tool draw highlighted, mirroring the 2D sketch overlay's cue.
+func sketch3DOverlays(s *app.Session, hPoint float64) []renderer.DrawItem {
+	part := activePart(s)
+	if part == nil {
+		return nil
+	}
+	picked := pickedSketchEntities(s)
+	normal, sel := &segAccum{}, &segAccum{}
+	for i := 0; i < part.Sketches3D().Count(); i++ {
+		sk := part.Sketches3D().Item(i)
+		if !sk.Visible() {
+			continue
+		}
+		accumSketch3D(sk, picked, normal, sel, hPoint)
+	}
+	var items []renderer.DrawItem
+	items = appendGrid(items, normal, sketchColor)
+	items = appendGrid(items, sel, sketchSelectedColor)
+	return items
+}
+
+// pickedSketchEntities returns the entities the active pick-driven tool has gathered
+// (so they highlight), or nil when no such tool is active.
+func pickedSketchEntities(s *app.Session) map[sketch.Entity]bool {
+	at := s.ActiveTool()
+	if at == nil {
+		return nil
+	}
+	et, ok := at.Tool().(app.SketchEntityTool)
+	if !ok {
+		return nil
+	}
+	picked := et.Picked()
+	if len(picked) == 0 {
+		return nil
+	}
+	set := make(map[sketch.Entity]bool, len(picked))
+	for _, e := range picked {
+		set[e] = true
+	}
+	return set
+}
+
+// accumSketch3D accumulates one 3D sketch's entities as model-space segments: curves
+// by their sampled polyline, single points as a three-axis cross of half-size h.
+func accumSketch3D(sk *sketch.Sketch3D, picked map[sketch.Entity]bool, normal, sel *segAccum, h float64) {
+	for _, e := range sk.Entities() {
+		acc := normal
+		if picked[e] {
+			acc = sel
+		}
+		pts := sketch.SamplePolyline3D(e, sketchSegments)
+		if len(pts) == 1 {
+			accumPointCross3D(acc, pts[0], h)
+			continue
+		}
+		for i := 0; i+1 < len(pts); i++ {
+			acc.addSegment(pts[i], pts[i+1])
+		}
+	}
+}
+
+// accumPointCross3D draws a standalone 3D point as a small axis-aligned cross.
+func accumPointCross3D(acc *segAccum, p math.Point3, h float64) {
+	d := math.Scalar(h)
+	acc.addSegment(math.P3(p.X-d, p.Y, p.Z), math.P3(p.X+d, p.Y, p.Z))
+	acc.addSegment(math.P3(p.X, p.Y-d, p.Z), math.P3(p.X, p.Y+d, p.Z))
+	acc.addSegment(math.P3(p.X, p.Y, p.Z-d), math.P3(p.X, p.Y, p.Z+d))
+}

--- a/model/sketch/constraints_3d_curves.go
+++ b/model/sketch/constraints_3d_curves.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// The curve-attachment 3D constraints of issue #142 (M22 F04/F05): SplineFitPoints3D
+// ties external geometry to a fit spline's interpolation points, and Helical3D ties a
+// helix to the circle it starts on. Both express intent the solver and the browser
+// can name (like Concentric3D vs a plain coincidence).
+
+// SplineFitPoints3D ties a 3D point to one fit point of a fit-type spline, so geometry
+// chained to the spline stays attached when the spline re-solves — Inventor's
+// spline-fit-point coincidence. The fit-point index is chosen at creation (nearest to
+// the attached point) and is stable thereafter.
+type SplineFitPoints3D struct {
+	constraintBase
+	Spline   *Spline3D
+	P        *Point3D
+	FitIndex int
+}
+
+// NewSplineFitPoints3D attaches p to the nearest fit point of sp. It rejects control
+// splines (their points are not on the curve) and splines without points.
+func NewSplineFitPoints3D(sp *Spline3D, p *Point3D) (*SplineFitPoints3D, error) {
+	if !sp.IsFitType() {
+		return nil, fmt.Errorf("sketch: splineFitPoints needs a fit (interpolating) spline, entity %d is a control spline", sp.EntityID())
+	}
+	if len(sp.Points) == 0 {
+		return nil, fmt.Errorf("sketch: splineFitPoints: spline %d has no fit points", sp.EntityID())
+	}
+	return &SplineFitPoints3D{
+		constraintBase: newConstraint(), Spline: sp, P: p, FitIndex: nearestFitIndex(sp, p),
+	}, nil
+}
+
+// NewSplineFitPoints3DAt attaches p to the fit point at the given index — the
+// deserializer's constructor, which must rebind the saved index, not re-derive it.
+func NewSplineFitPoints3DAt(sp *Spline3D, p *Point3D, index int) (*SplineFitPoints3D, error) {
+	if !sp.IsFitType() {
+		return nil, fmt.Errorf("sketch: splineFitPoints needs a fit (interpolating) spline, entity %d is a control spline", sp.EntityID())
+	}
+	if index < 0 || index >= len(sp.Points) {
+		return nil, fmt.Errorf("sketch: splineFitPoints index %d out of range (%d fit points)", index, len(sp.Points))
+	}
+	return &SplineFitPoints3D{constraintBase: newConstraint(), Spline: sp, P: p, FitIndex: index}, nil
+}
+
+// nearestFitIndex returns the index of the spline fit point closest to p.
+func nearestFitIndex(sp *Spline3D, p *Point3D) int {
+	best, bestD := 0, stdmath.Inf(1)
+	for i, fp := range sp.Points {
+		if d := float64(fp.Position().DistanceTo(p.Position())); d < bestD {
+			best, bestD = i, d
+		}
+	}
+	return best
+}
+
+func (c *SplineFitPoints3D) Residuals() []float64 {
+	fp := c.Spline.Points[c.FitIndex]
+	return []float64{float64(fp.X - c.P.X), float64(fp.Y - c.P.Y), float64(fp.Z - c.P.Z)}
+}
+
+func (c *SplineFitPoints3D) Variables() []*math.Scalar {
+	fp := c.Spline.Points[c.FitIndex]
+	return []*math.Scalar{&fp.X, &fp.Y, &fp.Z, &c.P.X, &c.P.Y, &c.P.Z}
+}
+
+// Helical3D ties a helix to the circle it starts on: the helix origin coincides with
+// the circle's center and the start radius equals the circle's radius — the
+// thread-on-cylinder-rim relation a coil path needs (M22-F04). The circle's axis is
+// definitional on both sides (neither is a solver DOF), so orientation is not a
+// residual; the constructor is where an axis mismatch surfaces.
+type Helical3D struct {
+	constraintBase
+	H *HelicalCurve3D
+	C *Circle3D
+}
+
+// NewHelical3D constrains h to start on circle c. It rejects a helix whose winding
+// axis is not parallel to the circle's plane normal — the relation would be
+// unsatisfiable by solving (neither axis is a DOF).
+func NewHelical3D(h *HelicalCurve3D, c *Circle3D) (*Helical3D, error) {
+	if !h.Axis.AsVector().IsParallelTo(c.Axis.AsVector(), 0) {
+		return nil, fmt.Errorf("sketch: helical: helix axis %v is not parallel to circle axis %v", h.Axis, c.Axis)
+	}
+	return &Helical3D{constraintBase: newConstraint(), H: h, C: c}, nil
+}
+
+func (c *Helical3D) Residuals() []float64 {
+	return []float64{
+		float64(c.H.Origin.X - c.C.Center.X),
+		float64(c.H.Origin.Y - c.C.Center.Y),
+		float64(c.H.Origin.Z - c.C.Center.Z),
+		float64(c.H.StartRadius - c.C.Radius),
+	}
+}
+
+func (c *Helical3D) Variables() []*math.Scalar {
+	return []*math.Scalar{
+		&c.H.Origin.X, &c.H.Origin.Y, &c.H.Origin.Z, &c.H.StartRadius,
+		&c.C.Center.X, &c.C.Center.Y, &c.C.Center.Z, &c.C.Radius,
+	}
+}

--- a/model/sketch/constraints_3d_curves_test.go
+++ b/model/sketch/constraints_3d_curves_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+func TestSplineFitPoints3DBindsNearestAndSolves(t *testing.T) {
+	s := NewSketches3D().Add()
+	sp := s.AddSpline3D([]gmath.Point3{
+		{X: 0, Y: 0, Z: 0}, {X: 1, Y: 1, Z: 0}, {X: 2, Y: 0, Z: 1},
+	}, false, true)
+	p := s.AddPoint3D(gmath.P3(1.1, 0.9, 0.1)) // nearest fit point: index 1
+	c, err := NewSplineFitPoints3D(sp, p)
+	if err != nil {
+		t.Fatalf("NewSplineFitPoints3D: %v", err)
+	}
+	if c.FitIndex != 1 {
+		t.Fatalf("FitIndex = %d, want 1 (nearest)", c.FitIndex)
+	}
+	s.GeometricConstraints3D().add(c)
+	solved3D(t, s)
+	if d := float64(sp.Points[1].Position().DistanceTo(p.Position())); d > 1e-6 {
+		t.Errorf("point %g from fit point after solve, want attached", d)
+	}
+}
+
+func TestSplineFitPoints3DRejectsControlSpline(t *testing.T) {
+	s := NewSketches3D().Add()
+	control := s.AddSpline3D([]gmath.Point3{
+		{X: 0, Y: 0, Z: 0}, {X: 1, Y: 1, Z: 0}, {X: 2, Y: 0, Z: 0},
+	}, false, false)
+	p := s.AddPoint3D(gmath.P3(0, 0, 0))
+	if _, err := NewSplineFitPoints3D(control, p); err == nil {
+		t.Error("expected an error for a control (non-interpolating) spline")
+	}
+}
+
+func TestHelical3DTiesHelixToCircleAndSolves(t *testing.T) {
+	s := NewSketches3D().Add()
+	axis, err := gmath.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("axis: %v", err)
+	}
+	circle := s.AddCircle3D(gmath.P3(0, 0, 0), axis, 5)
+	helix := s.AddHelix3D(gmath.P3(0.5, -0.2, 0.3), axis, 4.2, 1, 0, 8, false)
+	c, err := NewHelical3D(helix, circle)
+	if err != nil {
+		t.Fatalf("NewHelical3D: %v", err)
+	}
+	s.GeometricConstraints3D().add(c)
+	solved3D(t, s)
+	if d := float64(helix.Origin.Position().DistanceTo(circle.Center.Position())); d > 1e-6 {
+		t.Errorf("helix origin %g from circle center after solve, want coincident", d)
+	}
+	if dr := float64(helix.StartRadius - circle.Radius); dr > 1e-6 || dr < -1e-6 {
+		t.Errorf("start radius differs from circle radius by %g after solve", dr)
+	}
+}
+
+func TestHelical3DRejectsSkewAxes(t *testing.T) {
+	s := NewSketches3D().Add()
+	zAxis, _ := gmath.NewUnitVector3(0, 0, 1)
+	xAxis, _ := gmath.NewUnitVector3(1, 0, 0)
+	circle := s.AddCircle3D(gmath.P3(0, 0, 0), zAxis, 5)
+	helix := s.AddHelix3D(gmath.P3(0, 0, 0), xAxis, 5, 1, 0, 3, false)
+	if _, err := NewHelical3D(helix, circle); err == nil {
+		t.Error("expected an error for a helix axis not parallel to the circle axis")
+	}
+}
+
+// TestCurveConstraints3DRoundTrip checks splineFitPoints (with its fit index) and
+// helical survive marshal→apply.
+func TestCurveConstraints3DRoundTrip(t *testing.T) {
+	src := NewSketches3D()
+	s := src.Add()
+	axis, _ := gmath.NewUnitVector3(0, 0, 1)
+	sp := s.AddSpline3D([]gmath.Point3{
+		{X: 0, Y: 0, Z: 0}, {X: 1, Y: 1, Z: 0}, {X: 2, Y: 0, Z: 1},
+	}, false, true)
+	p := s.AddPoint3D(gmath.P3(2, 0, 1))
+	fit, err := NewSplineFitPoints3D(sp, p)
+	if err != nil {
+		t.Fatalf("fit: %v", err)
+	}
+	circle := s.AddCircle3D(gmath.P3(0, 0, 4), axis, 3)
+	helix := s.AddHelix3D(gmath.P3(0, 0, 4), axis, 3, 1, 0, 5, false)
+	hel, err := NewHelical3D(helix, circle)
+	if err != nil {
+		t.Fatalf("helical: %v", err)
+	}
+	s.GeometricConstraints3D().add(fit)
+	s.GeometricConstraints3D().add(hel)
+
+	data, err := src.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dst := NewSketches3D()
+	if err := dst.ApplyRecipe3D(data); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got := dst.Item(0).GeometricConstraints3D()
+	if got.Count() != 2 {
+		t.Fatalf("restored constraints = %d, want 2", got.Count())
+	}
+	rfit, ok := got.Item(0).(*SplineFitPoints3D)
+	if !ok || rfit.FitIndex != 2 {
+		t.Fatalf("restored[0] = %T (index %v), want *SplineFitPoints3D at fit index 2", got.Item(0), ok)
+	}
+	if _, ok := got.Item(1).(*Helical3D); !ok {
+		t.Fatalf("restored[1] = %T, want *Helical3D", got.Item(1))
+	}
+}

--- a/model/sketch/constraints_3d_smooth.go
+++ b/model/sketch/constraints_3d_smooth.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Tangent (G1) and Smooth (G2) constraints for 3D curves — the 3D counterparts of
+// constraints_smooth.go, closing the types-declared-but-unimplemented gap of issue
+// #142 (M22-F05 / PBI-236). Both join two curves at endpoints: Tangent drives the
+// join coincident (G0) with collinear tangents (G1); Smooth additionally matches the
+// orientation-free curvature vector (G2). As in 2D, two analytic curves can only be
+// G2 when cocircular, so Smooth is meaningful when at least one side is a spline —
+// the app tool and the router enforce that.
+
+// SmoothCurve3D is a 3D curve that can report its tangent and curvature at one of its
+// endpoints — a Line3D, Arc3D, or Spline3D. The interface is sealed (the methods are
+// unexported) so only those types satisfy it.
+type SmoothCurve3D interface {
+	Entity
+	// smoothFrame3D returns the tangent direction and the curvature vector at endpoint
+	// p (the curvature vector points toward the centre of curvature, |v| = curvature).
+	// ok is false when p is not one of the curve's endpoints (or the curve is
+	// degenerate there).
+	smoothFrame3D(p *Point3D) (tangent, curvature math.Vector3, ok bool)
+	// smoothVars3D returns the scalar DOFs of the curve's defining points.
+	smoothVars3D() []*math.Scalar
+	// smoothEnds3D returns the curve's free endpoints (empty for a closed curve).
+	smoothEnds3D() []*Point3D
+}
+
+// Tangent3D joins curves C1 and C2 with collinear tangents (G1) at endpoints P1 and
+// P2, which it also drives coincident (G0). Residuals: position match (3, G0),
+// tangent cross product (3, G1 — rank 2; the solver's rank analysis absorbs the
+// redundant component, as with Parallel3D).
+type Tangent3D struct {
+	constraintBase
+	C1, C2 SmoothCurve3D
+	P1, P2 *Point3D
+}
+
+// NewTangent3D constrains c1 (at endpoint p1) and c2 (at endpoint p2) to a tangent
+// (G1) join.
+func NewTangent3D(c1, c2 SmoothCurve3D, p1, p2 *Point3D) *Tangent3D {
+	return &Tangent3D{constraintBase: newConstraint(), C1: c1, C2: c2, P1: p1, P2: p2}
+}
+
+func (c *Tangent3D) Residuals() []float64 {
+	t1, _, ok1 := c.C1.smoothFrame3D(c.P1)
+	t2, _, ok2 := c.C2.smoothFrame3D(c.P2)
+	if !ok1 || !ok2 {
+		return []float64{1, 1, 1, 1, 1, 1} // p1/p2 not endpoints: cannot be satisfied
+	}
+	cr := t1.Cross(t2)
+	return []float64{
+		float64(c.P1.X - c.P2.X), float64(c.P1.Y - c.P2.Y), float64(c.P1.Z - c.P2.Z), // G0
+		float64(cr.X), float64(cr.Y), float64(cr.Z), // G1
+	}
+}
+
+func (c *Tangent3D) Variables() []*math.Scalar {
+	return append(c.C1.smoothVars3D(), c.C2.smoothVars3D()...)
+}
+
+// Smooth3D joins curves C1 and C2 curvature-continuously (G2) at endpoints P1 and P2:
+// the Tangent3D residuals plus the curvature-vector match.
+type Smooth3D struct {
+	constraintBase
+	C1, C2 SmoothCurve3D
+	P1, P2 *Point3D
+}
+
+// NewSmooth3D constrains c1 (at endpoint p1) and c2 (at endpoint p2) to a smooth (G2)
+// join.
+func NewSmooth3D(c1, c2 SmoothCurve3D, p1, p2 *Point3D) *Smooth3D {
+	return &Smooth3D{constraintBase: newConstraint(), C1: c1, C2: c2, P1: p1, P2: p2}
+}
+
+func (c *Smooth3D) Residuals() []float64 {
+	t1, k1, ok1 := c.C1.smoothFrame3D(c.P1)
+	t2, k2, ok2 := c.C2.smoothFrame3D(c.P2)
+	if !ok1 || !ok2 {
+		return []float64{1, 1, 1, 1, 1, 1, 1, 1, 1}
+	}
+	cr := t1.Cross(t2)
+	return []float64{
+		float64(c.P1.X - c.P2.X), float64(c.P1.Y - c.P2.Y), float64(c.P1.Z - c.P2.Z), // G0
+		float64(cr.X), float64(cr.Y), float64(cr.Z), // G1
+		float64(k1.X - k2.X), float64(k1.Y - k2.Y), float64(k1.Z - k2.Z), // G2
+	}
+}
+
+func (c *Smooth3D) Variables() []*math.Scalar {
+	return append(c.C1.smoothVars3D(), c.C2.smoothVars3D()...)
+}
+
+// NearestEndpointPair3D returns the endpoint of c1 and the endpoint of c2 that lie
+// closest to each other — how the tangent/smooth tools and the wire API choose the
+// join when the caller picks only the two curves (mirrors the 2D Smooth tool's
+// nearest-endpoint behaviour). ok is false when either curve has no free endpoint
+// (e.g. a closed spline).
+func NearestEndpointPair3D(c1, c2 SmoothCurve3D) (p1, p2 *Point3D, ok bool) {
+	ends1, ends2 := c1.smoothEnds3D(), c2.smoothEnds3D()
+	best := stdmath.Inf(1)
+	for _, p := range ends1 {
+		for _, q := range ends2 {
+			if d := float64(p.Position().DistanceTo(q.Position())); d < best {
+				p1, p2, best = p, q, d
+			}
+		}
+	}
+	return p1, p2, p1 != nil && p2 != nil
+}
+
+// --- per-curve smooth frames ----------------------------------------------------------
+
+// smoothFrame3D for a line: the tangent points from p toward the other endpoint; a
+// line is straight, so its curvature vector is zero.
+func (l *Line3D) smoothFrame3D(p *Point3D) (math.Vector3, math.Vector3, bool) {
+	switch p {
+	case l.A:
+		return unit3(l.A.Position().VectorTo(l.B.Position())), math.Vector3{}, true
+	case l.B:
+		return unit3(l.B.Position().VectorTo(l.A.Position())), math.Vector3{}, true
+	default:
+		return math.Vector3{}, math.Vector3{}, false
+	}
+}
+
+func (l *Line3D) smoothVars3D() []*math.Scalar { return line3DVars(l) }
+func (l *Line3D) smoothEnds3D() []*Point3D     { return []*Point3D{l.A, l.B} }
+
+// smoothFrame3D for an arc: the tangent is perpendicular to the radius at p within
+// the arc's plane (normal from center/start/end); the curvature vector points from p
+// to the centre with magnitude 1/r. The tangent's sign along the arc is irrelevant —
+// both G1 residual forms (cross product) are sign-free.
+func (a *Arc3D) smoothFrame3D(p *Point3D) (math.Vector3, math.Vector3, bool) {
+	if p != a.Start && p != a.End {
+		return math.Vector3{}, math.Vector3{}, false
+	}
+	center := a.Center.Position()
+	normal := center.VectorTo(a.Start.Position()).Cross(center.VectorTo(a.End.Position()))
+	radial := center.VectorTo(p.Position())
+	r := radial.Length()
+	if r < math.DefaultTolerance || normal.Length() < math.DefaultTolerance {
+		return math.Vector3{}, math.Vector3{}, false // degenerate arc (collinear or zero radius)
+	}
+	tangent := unit3(normal.Cross(radial))
+	curvature := p.Position().VectorTo(center).Scale(1 / (r * r)) // toward centre, |.|=1/r
+	return tangent, curvature, true
+}
+
+func (a *Arc3D) smoothVars3D() []*math.Scalar {
+	return []*math.Scalar{
+		&a.Center.X, &a.Center.Y, &a.Center.Z,
+		&a.Start.X, &a.Start.Y, &a.Start.Z,
+		&a.End.X, &a.End.Y, &a.End.Z,
+	}
+}
+
+func (a *Arc3D) smoothEnds3D() []*Point3D { return []*Point3D{a.Start, a.End} }
+
+// smoothFrame3D for a spline: the tangent points from the endpoint toward its
+// adjacent defining point; the curvature vector is that of the circle through the
+// three terminal points (zero when collinear) — the same representative-polyline
+// convention as the 2D spline and the Catmull–Rom sampler.
+func (s *Spline3D) smoothFrame3D(p *Point3D) (math.Vector3, math.Vector3, bool) {
+	n := len(s.Points)
+	if n < 2 || s.Closed {
+		return math.Vector3{}, math.Vector3{}, false
+	}
+	var adjacent, second *Point3D
+	switch p {
+	case s.Points[0]:
+		adjacent = s.Points[1]
+		if n >= 3 {
+			second = s.Points[2]
+		}
+	case s.Points[n-1]:
+		adjacent = s.Points[n-2]
+		if n >= 3 {
+			second = s.Points[n-3]
+		}
+	default:
+		return math.Vector3{}, math.Vector3{}, false
+	}
+	tangent := unit3(p.Position().VectorTo(adjacent.Position()))
+	if second == nil {
+		return tangent, math.Vector3{}, true
+	}
+	return tangent, curvatureVector3(second.Position(), adjacent.Position(), p.Position()), true
+}
+
+func (s *Spline3D) smoothVars3D() []*math.Scalar {
+	vars := make([]*math.Scalar, 0, len(s.Points)*3)
+	for _, p := range s.Points {
+		vars = append(vars, &p.X, &p.Y, &p.Z)
+	}
+	return vars
+}
+
+func (s *Spline3D) smoothEnds3D() []*Point3D {
+	if len(s.Points) < 2 || s.Closed {
+		return nil
+	}
+	return []*Point3D{s.Points[0], s.Points[len(s.Points)-1]}
+}
+
+// --- geometry helpers -------------------------------------------------------------------
+
+// unit3 returns v scaled to unit length, or the zero vector when v is (near) zero.
+func unit3(v math.Vector3) math.Vector3 {
+	l := v.Length()
+	if l < math.DefaultTolerance {
+		return math.Vector3{}
+	}
+	return v.Scale(1 / l)
+}
+
+// curvatureVector3 returns the curvature vector at p of the circle through a, b, p —
+// it points from p toward the circle's centre with magnitude 1/R, and is zero when
+// the three points are collinear (infinite radius).
+func curvatureVector3(a, b, p math.Point3) math.Vector3 {
+	center, ok := circumcenter3(a, b, p)
+	if !ok {
+		return math.Vector3{}
+	}
+	toCenter := p.VectorTo(center)
+	r := toCenter.Length()
+	if r < math.DefaultTolerance {
+		return math.Vector3{}
+	}
+	return toCenter.Scale(1 / (r * r))
+}
+
+// circumcenter3 returns the centre of the circle through a, b, c in 3D, and false
+// when they are (near) collinear. Standard construction: with u = b−a, v = c−a and
+// n = u×v, the centre is a + (|u|²(v×n) + |v|²(n×u)) / (2|n|²).
+func circumcenter3(a, b, c math.Point3) (math.Point3, bool) {
+	u := a.VectorTo(b)
+	v := a.VectorTo(c)
+	n := u.Cross(v)
+	n2 := n.LengthSquared()
+	if n2 < math.DefaultTolerance*math.DefaultTolerance {
+		return math.Point3{}, false
+	}
+	offset := v.Cross(n).Scale(u.LengthSquared()).Add(n.Cross(u).Scale(v.LengthSquared())).Scale(1 / (2 * n2))
+	return a.TranslateBy(offset), true
+}

--- a/model/sketch/constraints_3d_smooth_test.go
+++ b/model/sketch/constraints_3d_smooth_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// residualsNear asserts every residual component is within tol of zero.
+func residualsNear(t *testing.T, c Constraint, tol float64) {
+	t.Helper()
+	for i, r := range c.Residuals() {
+		if stdmath.Abs(r) > tol {
+			t.Errorf("residual[%d] = %g, want |r| <= %g", i, r, tol)
+		}
+	}
+}
+
+// TestTangent3DLineArcResidualZeroWhenSatisfied builds a line meeting an arc
+// tangentially in the XY plane: line along +X ending at (1,0,0), arc centered at
+// (1,1,0) through (1,0,0) — the radius is ⟂ the line there, so they are tangent.
+func TestTangent3DLineArcResidualZeroWhenSatisfied(t *testing.T) {
+	s := NewSketches3D().Add()
+	l := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0))
+	a := s.AddArc3D(gmath.P3(1, 1, 0), gmath.P3(1, 0, 0), gmath.P3(2, 1, 0), false)
+	c := NewTangent3D(l, a, l.B, a.Start)
+	residualsNear(t, c, 1e-12)
+}
+
+// TestTangent3DSolvesPerturbedJoin perturbs the arc start away from the line end and
+// checks the solver restores a coincident, tangent join.
+func TestTangent3DSolvesPerturbedJoin(t *testing.T) {
+	s := NewSketches3D().Add()
+	l := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0))
+	a := s.AddArc3D(gmath.P3(1, 1, 0), gmath.P3(1.2, 0.1, 0.05), gmath.P3(2, 1, 0), false)
+	c := NewTangent3D(l, a, l.B, a.Start)
+	s.GeometricConstraints3D().add(c)
+	solved3D(t, s)
+	residualsNear(t, c, 1e-6)
+	if d := float64(l.B.Position().DistanceTo(a.Start.Position())); d > 1e-6 {
+		t.Errorf("join endpoints %g apart after solve, want coincident", d)
+	}
+}
+
+// TestTangent3DRejectsNonEndpoint reports unsatisfiable (constant penalty) when the
+// given point is not an endpoint of the curve.
+func TestTangent3DRejectsNonEndpoint(t *testing.T) {
+	s := NewSketches3D().Add()
+	l1 := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0))
+	l2 := s.AddLine3D(gmath.P3(1, 0, 0), gmath.P3(2, 1, 0))
+	stray := s.AddPoint3D(gmath.P3(9, 9, 9))
+	c := NewTangent3D(l1, l2, stray, l2.A)
+	for i, r := range c.Residuals() {
+		if r != 1 {
+			t.Fatalf("residual[%d] = %g, want the constant penalty 1", i, r)
+		}
+	}
+}
+
+// TestSmooth3DSplineLineSolvesG2 joins a line to a spline with G2 continuity: after
+// solving, the spline's terminal points must be collinear with the line direction
+// (zero curvature matches the straight line).
+func TestSmooth3DSplineLineSolvesG2(t *testing.T) {
+	s := NewSketches3D().Add()
+	l := s.AddLine3D(gmath.P3(-2, 0, 0), gmath.P3(0, 0, 0))
+	sp := s.AddSpline3D([]gmath.Point3{
+		{X: 0.2, Y: 0.3, Z: 0}, {X: 1, Y: 0.8, Z: 0.4}, {X: 2, Y: 0.2, Z: 0.9},
+	}, false, true)
+	c := NewSmooth3D(l, sp, l.B, sp.Points[0])
+	s.GeometricConstraints3D().add(c)
+	solved3D(t, s)
+	residualsNear(t, c, 1e-6)
+	if d := float64(l.B.Position().DistanceTo(sp.Points[0].Position())); d > 1e-6 {
+		t.Errorf("join endpoints %g apart after solve, want coincident", d)
+	}
+}
+
+// TestSmooth3DArcArcResidualZeroWhenCocircular checks two arcs of one circle meeting
+// at a point are already G2 (equal curvature vectors, collinear tangents).
+func TestSmooth3DArcArcResidualZeroWhenCocircular(t *testing.T) {
+	s := NewSketches3D().Add()
+	// Unit circle around the origin in XY: arc1 from (1,0) to (0,1), arc2 from (0,1)
+	// to (-1,0); they meet at (0,1) sharing center and radius.
+	a1 := s.AddArc3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0), gmath.P3(0, 1, 0), true)
+	a2 := s.AddArc3D(gmath.P3(0, 0, 0), gmath.P3(0, 1, 0), gmath.P3(-1, 0, 0), true)
+	c := NewSmooth3D(a1, a2, a1.End, a2.Start)
+	residualsNear(t, c, 1e-9)
+}
+
+// TestNearestEndpointPair3D picks the closest endpoints of two separated lines and
+// reports no pair for a closed spline (no free endpoints).
+func TestNearestEndpointPair3D(t *testing.T) {
+	s := NewSketches3D().Add()
+	l1 := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0))
+	l2 := s.AddLine3D(gmath.P3(1.1, 0, 0), gmath.P3(5, 5, 5))
+	p1, p2, ok := NearestEndpointPair3D(l1, l2)
+	if !ok || p1 != l1.B || p2 != l2.A {
+		t.Errorf("nearest pair = (%v,%v,%v), want l1.B/l2.A", p1, p2, ok)
+	}
+	closed := s.AddSpline3D([]gmath.Point3{{X: 0, Y: 0, Z: 0}, {X: 1, Y: 0, Z: 0}, {X: 0, Y: 1, Z: 0}}, true, true)
+	if _, _, ok := NearestEndpointPair3D(l1, closed); ok {
+		t.Error("a closed spline must report no free endpoints")
+	}
+}
+
+// TestSmoothJoin3DRoundTrip checks tangent + smooth survive marshal→apply, re-binding
+// to the restored curves and endpoints.
+func TestSmoothJoin3DRoundTrip(t *testing.T) {
+	src := NewSketches3D()
+	s := src.Add()
+	l := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0))
+	a := s.AddArc3D(gmath.P3(1, 1, 0), gmath.P3(1, 0, 0), gmath.P3(2, 1, 0), false)
+	sp := s.AddSpline3D([]gmath.Point3{{X: 2, Y: 1, Z: 0}, {X: 3, Y: 2, Z: 1}, {X: 4, Y: 1, Z: 0}}, false, true)
+	s.GeometricConstraints3D().add(NewTangent3D(l, a, l.B, a.Start))
+	s.GeometricConstraints3D().add(NewSmooth3D(a, sp, a.End, sp.Points[0]))
+
+	data, err := src.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dst := NewSketches3D()
+	if err := dst.ApplyRecipe3D(data); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got := dst.Item(0).GeometricConstraints3D()
+	if got.Count() != 2 {
+		t.Fatalf("restored constraints = %d, want 2", got.Count())
+	}
+	tan, ok := got.Item(0).(*Tangent3D)
+	if !ok {
+		t.Fatalf("restored[0] = %T, want *Tangent3D", got.Item(0))
+	}
+	residualsNear(t, tan, 1e-9) // satisfied layout must restore satisfied
+	if _, ok := got.Item(1).(*Smooth3D); !ok {
+		t.Fatalf("restored[1] = %T, want *Smooth3D", got.Item(1))
+	}
+}

--- a/model/sketch/sample_entity_3d.go
+++ b/model/sketch/sample_entity_3d.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// SamplePolyline3D returns a model-space polyline approximating a 3D sketch entity —
+// the shared shape the viewport overlay draws and the ray picker tests clicks
+// against (issue #142: 3D sketch geometry must be visible and pickable for the
+// constraint tools). segments bounds the sample count of curved entities; a point
+// returns its single position, a line its two endpoints, and an unknown or
+// degenerate entity nil.
+//
+//	pts := sketch.SamplePolyline3D(entity, 64)
+func SamplePolyline3D(e Entity, segments int) []math.Point3 {
+	if segments < 2 {
+		segments = 2
+	}
+	switch v := e.(type) {
+	case *Point3D:
+		return []math.Point3{v.Position()}
+	case *Line3D:
+		return []math.Point3{v.A.Position(), v.B.Position()}
+	case *Spline3D:
+		return v.Sample()
+	case *FixedSpline3D:
+		return v.Sample()
+	case *EquationCurve3D:
+		return v.Sample(segments)
+	default:
+		return sampleCurve3D(e, segments)
+	}
+}
+
+// curve3At is the kernel-curve evaluation shape shared by circle/arc/helix/conics.
+type curve3At interface{ PointAt(t float64) math.Point3 }
+
+// sampleCurve3D samples the analytic kernel curve of a circle/arc/helix/conic entity
+// uniformly over t ∈ [0,1]; a helix gets segments per turn so a long spring stays
+// round. Returns nil when the entity has no curve (unknown kind or degenerate).
+func sampleCurve3D(e Entity, segments int) []math.Point3 {
+	cu, n := analyticCurve3D(e, segments)
+	if cu == nil {
+		return nil
+	}
+	pts := make([]math.Point3, n+1)
+	for i := 0; i <= n; i++ {
+		pts[i] = cu.PointAt(float64(i) / float64(n))
+	}
+	return pts
+}
+
+// analyticCurve3D resolves an entity's kernel curve and its sample count.
+func analyticCurve3D(e Entity, segments int) (curve3At, int) {
+	switch v := e.(type) {
+	case *Circle3D:
+		if cu, err := v.Curve(); err == nil {
+			return cu, segments
+		}
+	case *Arc3D:
+		if cu, err := v.Curve(); err == nil {
+			return cu, segments
+		}
+	case *HelicalCurve3D:
+		if cu, err := v.Curve(); err == nil {
+			return cu, helixSampleCount(v.Turns, segments)
+		}
+	case *Ellipse3D:
+		if cu, err := v.Curve(); err == nil {
+			return cu, segments
+		}
+	case *EllipticalArc3D:
+		if cu, err := v.Curve(); err == nil {
+			return cu, segments
+		}
+	}
+	return nil, 0
+}
+
+// helixSampleCount scales the sample budget with the turn count (min one segment
+// budget per turn, capped at 16 turns so a pathological helix stays bounded).
+func helixSampleCount(turns float64, segments int) int {
+	n := int(turns)
+	if n < 1 {
+		n = 1
+	}
+	if n > 16 {
+		n = 16
+	}
+	return n * segments
+}

--- a/model/sketch/sample_entity_3d_test.go
+++ b/model/sketch/sample_entity_3d_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+func TestSamplePolyline3DShapes(t *testing.T) {
+	s := NewSketches3D().Add()
+	zAxis, err := gmath.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("axis: %v", err)
+	}
+
+	p := s.AddPoint3D(gmath.P3(1, 2, 3))
+	if pts := SamplePolyline3D(p, 16); len(pts) != 1 || pts[0] != gmath.P3(1, 2, 3) {
+		t.Errorf("point sample = %v, want its single position", pts)
+	}
+
+	l := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(1, 0, 0))
+	if pts := SamplePolyline3D(l, 16); len(pts) != 2 || pts[0] != gmath.P3(0, 0, 0) || pts[1] != gmath.P3(1, 0, 0) {
+		t.Errorf("line sample = %v, want its two endpoints", pts)
+	}
+
+	c := s.AddCircle3D(gmath.P3(0, 0, 0), zAxis, 2)
+	pts := SamplePolyline3D(c, 32)
+	if len(pts) != 33 {
+		t.Fatalf("circle sample count = %d, want segments+1 = 33", len(pts))
+	}
+	for i, q := range pts {
+		r := float64(gmath.P3(0, 0, 0).DistanceTo(q))
+		if stdmath.Abs(r-2) > 1e-9 {
+			t.Fatalf("circle sample %d at radius %g, want 2", i, r)
+		}
+	}
+
+	h := s.AddHelix3D(gmath.P3(0, 0, 0), zAxis, 1, 0.5, 0, 4, false)
+	hp := SamplePolyline3D(h, 16)
+	if len(hp) != 4*16+1 {
+		t.Errorf("helix sample count = %d, want turns*segments+1 = 65", len(hp))
+	}
+	if rise := float64(hp[len(hp)-1].Z - hp[0].Z); stdmath.Abs(rise-2) > 1e-9 {
+		t.Errorf("helix rise = %g, want pitch*turns = 2", rise)
+	}
+}
+
+func TestSamplePolyline3DUnknownKindIsNil(t *testing.T) {
+	s := NewSketches3D().Add()
+	// An included reference curve has no analytic kernel curve of its own — the
+	// sampler must report nil rather than guessing.
+	inc := s.IncludeCurve3D(&fakeCurveSource{id: "e", pts: []gmath.Point3{{X: 0}, {X: 1}}})
+	if pts := SamplePolyline3D(inc, 8); pts != nil {
+		t.Errorf("unsupported entity sampled to %v, want nil", pts)
+	}
+}

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -94,11 +94,13 @@ type Entity3DData struct {
 
 // Constraint3DRow is one geometric 3D constraint: its kind plus operand ids split into
 // Points (point operands) and Curves (line/curve entity operands), in the order the
-// constraint's factory expects.
+// constraint's factory expects. Index is the splineFitPoints fit-point index (the
+// constraint binds a specific fit point, not a re-derived nearest one).
 type Constraint3DRow struct {
 	Kind   string `yaml:"kind"`
 	Points []int  `yaml:"points,omitempty"`
 	Curves []int  `yaml:"curves,omitempty"`
+	Index  int    `yaml:"index,omitempty"`
 }
 
 // MarshalRecipe3D projects every 3D sketch into its serializable form, in order.
@@ -305,10 +307,21 @@ func serializeConstraint3D(c Constraint) (Constraint3DRow, error) {
 		return Constraint3DRow{Kind: axisRowKind(v.Axis), Curves: []int{int(v.L.id)}}, nil
 	case *ParallelToPlane3D:
 		return Constraint3DRow{Kind: planeRowKind(v.Normal), Curves: []int{int(v.L.id)}}, nil
+	case *Tangent3D:
+		return Constraint3DRow{Kind: "tangent", Curves: entity3DIDPair(v.C1, v.C2), Points: []int{int(v.P1.id), int(v.P2.id)}}, nil
+	case *Smooth3D:
+		return Constraint3DRow{Kind: "smooth", Curves: entity3DIDPair(v.C1, v.C2), Points: []int{int(v.P1.id), int(v.P2.id)}}, nil
+	case *SplineFitPoints3D:
+		return Constraint3DRow{Kind: "splineFitPoints", Curves: []int{int(v.Spline.id)}, Points: []int{int(v.P.id)}, Index: v.FitIndex}, nil
+	case *Helical3D:
+		return Constraint3DRow{Kind: "helical", Curves: []int{int(v.H.id), int(v.C.id)}}, nil
 	default:
 		return Constraint3DRow{}, fmt.Errorf("cannot serialize 3D constraint of type %T (no codec yet)", c)
 	}
 }
+
+// entity3DIDPair returns two curve entities' ids in order.
+func entity3DIDPair(a, b Entity) []int { return []int{int(a.EntityID()), int(b.EntityID())} }
 
 // axisRowKind names a parallel-to-axis constraint for serialization by its axis vector.
 func axisRowKind(axis math.Vector3) string {
@@ -514,11 +527,20 @@ func restoreEntity3D(s *Sketch3D, ed Entity3DData, idmap map[int]*Point3D) (Enti
 }
 
 // restoreConstraint3D re-adds one geometric 3D constraint, binding its point operands
-// through idmap and its line operands through entmap.
+// through idmap and its line operands through entmap. The curve-join kinds (tangent/
+// smooth/splineFitPoints/helical, issue #142) dispatch first — their Curves are not
+// necessarily lines, so they resolve against the full entity map.
 func restoreConstraint3D(s *Sketch3D, cd Constraint3DRow, idmap map[int]*Point3D, entmap map[int]Entity) error {
 	pts, err := lookupPoints3D(cd.Points, idmap)
 	if err != nil {
 		return fmt.Errorf("%s constraint: %w", cd.Kind, err)
+	}
+	if c, handled, err := curveConstraint3DFromRow(cd, pts, entmap); handled {
+		if err != nil {
+			return fmt.Errorf("%s constraint: %w", cd.Kind, err)
+		}
+		s.geomCons.add(c)
+		return nil
 	}
 	lines, err := lookupLines3D(cd.Curves, entmap)
 	if err != nil {
@@ -530,6 +552,89 @@ func restoreConstraint3D(s *Sketch3D, cd Constraint3DRow, idmap map[int]*Point3D
 	}
 	s.geomCons.add(c)
 	return nil
+}
+
+// curveConstraint3DFromRow rebuilds the curve-join constraint kinds; handled is false
+// for every other kind (which restoreConstraint3D resolves over line operands).
+func curveConstraint3DFromRow(cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) (Constraint, bool, error) {
+	switch cd.Kind {
+	case "tangent", "smooth":
+		c, err := restoreSmoothJoin3D(cd, pts, entmap)
+		return c, true, err
+	case "splineFitPoints":
+		sp, err := lookupSpline3D(cd.Curves, entmap)
+		if err != nil {
+			return nil, true, err
+		}
+		c, err := NewSplineFitPoints3DAt(sp, pts[0], cd.Index)
+		return c, true, err
+	case "helical":
+		c, err := restoreHelical3D(cd, entmap)
+		return c, true, err
+	default:
+		return nil, false, nil
+	}
+}
+
+// restoreSmoothJoin3D rebuilds a tangent or smooth join from its two curves and their
+// serialized join endpoints.
+func restoreSmoothJoin3D(cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) (Constraint, error) {
+	if len(cd.Curves) != 2 || len(pts) != 2 {
+		return nil, fmt.Errorf("needs 2 curves + 2 points, got %d/%d", len(cd.Curves), len(pts))
+	}
+	c1, err := lookupSmoothCurve3D(cd.Curves[0], entmap)
+	if err != nil {
+		return nil, err
+	}
+	c2, err := lookupSmoothCurve3D(cd.Curves[1], entmap)
+	if err != nil {
+		return nil, err
+	}
+	if cd.Kind == "tangent" {
+		return NewTangent3D(c1, c2, pts[0], pts[1]), nil
+	}
+	return NewSmooth3D(c1, c2, pts[0], pts[1]), nil
+}
+
+// restoreHelical3D rebuilds a helix-on-circle constraint from its two curve operands.
+func restoreHelical3D(cd Constraint3DRow, entmap map[int]Entity) (Constraint, error) {
+	if len(cd.Curves) != 2 {
+		return nil, fmt.Errorf("needs a helix + circle, got %d curves", len(cd.Curves))
+	}
+	h, ok := entmap[cd.Curves[0]].(*HelicalCurve3D)
+	if !ok {
+		return nil, fmt.Errorf("entity id %d is %T, want a helical curve", cd.Curves[0], entmap[cd.Curves[0]])
+	}
+	circle, ok := entmap[cd.Curves[1]].(*Circle3D)
+	if !ok {
+		return nil, fmt.Errorf("entity id %d is %T, want a 3D circle", cd.Curves[1], entmap[cd.Curves[1]])
+	}
+	return NewHelical3D(h, circle)
+}
+
+// lookupSmoothCurve3D resolves a saved entity id to a tangent/smooth-capable curve.
+func lookupSmoothCurve3D(id int, entmap map[int]Entity) (SmoothCurve3D, error) {
+	e, ok := entmap[id]
+	if !ok {
+		return nil, fmt.Errorf("references unknown entity id %d", id)
+	}
+	c, ok := e.(SmoothCurve3D)
+	if !ok {
+		return nil, fmt.Errorf("entity id %d is %T, want a line/arc/spline", id, e)
+	}
+	return c, nil
+}
+
+// lookupSpline3D resolves a single saved entity id to a live 3D spline.
+func lookupSpline3D(ids []int, entmap map[int]Entity) (*Spline3D, error) {
+	if len(ids) != 1 {
+		return nil, fmt.Errorf("needs 1 spline operand, got %d", len(ids))
+	}
+	sp, ok := entmap[ids[0]].(*Spline3D)
+	if !ok {
+		return nil, fmt.Errorf("entity id %d is %T, want a 3D spline", ids[0], entmap[ids[0]])
+	}
+	return sp, nil
 }
 
 // constraint3DFromRow builds the constraint for a serialized kind from its resolved


### PR DESCRIPTION
## What

Closes #142. Three layers, one per commit:

**Kernel** (`model/sketch`): `Tangent3D` (G0+G1) and `Smooth3D` (G0+G1+G2) join two curves at endpoints through a sealed `SmoothCurve3D` frame interface (line/arc/spline), mirroring the 2D `constraints_smooth.go` design with a 3D circumcenter for curvature. `SplineFitPoints3D` ties a point to a specific fit point of a fit spline. `Helical3D` ties a helix to the circle it starts on (coincident origin/center + equal start radius; non-parallel axes rejected at construction since axes are definitional, not DOFs). All four serialize through the `.obk` YAML projection.

**Router** (`addin/router`): `sketch3d.addConstraint` cases for the four kinds — plus **`equal`, which the new coverage guard immediately exposed as declared and kernel-implemented but never routed**. The guard is the issue's lasting fix: `TestDeclared3DConstraintKindsComplete` fails when any kind declared in `api/types` has neither a passing end-to-end fixture nor a tracking issue (`bend` → #143). The contract can no longer ship ahead of the solver silently.

**UI** (`app` + `head`): PBI-236/237 promised constraint tools + ribbon buttons and none existed for ANY 3D constraint. The 3D Sketch tab gains a Constrain panel (Tangent, Smooth, Helical, Spline Fit) reusing the generic pick-driven `ConstraintTool`; the ray picker gains 3D-sketch entity hit testing (`WithSketches3D`, sampled polylines + points) and the head a 3D-sketch viewport overlay — both built on one shared `SamplePolyline3D`, so what is drawn is exactly what picks. Until now 3D sketch geometry was neither visible nor pickable in the viewport at all.

## Why

`api/types` declared 19 geometric 3D constraint kinds while the solver implemented 10 — add-ins discovered unsolvable kinds only at runtime, and users had no interactive way to apply any 3D constraint (issue #142).

## Tests

12 kernel tests (residual-zero-when-satisfied, solver convergence from perturbed joins, degenerate rejections, round-trips), the router kind-coverage suite (every declared kind end-to-end + completeness guard), 6 app tool tests (command → pick → apply flow, spline requirement for Smooth, accept filters, enablement), 3 ray-picker tests, sampler tests. Full suite + bridge e2e (live router) green; head builds and `ui` tests pass (ribbon icons resolve). golangci-lint clean on new code (remaining funlen findings are pre-existing in untouched functions).

Companion PRs: Oblikovati.API (wire operand-order docs), Oblikovati.AddIns (bridge tool description) — same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)