### PR TITLE
Fix the ribbon to the top of the window and adopt the reference layout

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -8,16 +8,17 @@ import (
 	"oblikovati.org/api/types"
 )
 
-// ButtonStyle is how a command renders in the ribbon (text, small icon, large icon).
-// The type and its values are defined once in the Apache-2.0 contract
-// ([types.ButtonStyle]); this alias keeps the app.ButtonStyle / app.LargeIconButton
-// spelling local to the implementation (ADR-0018).
+// ButtonStyle is how a command renders in the ribbon (text, small icon with label,
+// large icon, compact icon-only). The type and its values are defined once in the
+// Apache-2.0 contract ([types.ButtonStyle]); this alias keeps the app.ButtonStyle /
+// app.LargeIconButton spelling local to the implementation (ADR-0018).
 type ButtonStyle = types.ButtonStyle
 
 const (
-	TextOnlyButton  = types.TextOnlyButton
-	SmallIconButton = types.SmallIconButton
-	LargeIconButton = types.LargeIconButton
+	TextOnlyButton    = types.TextOnlyButton
+	SmallIconButton   = types.SmallIconButton
+	LargeIconButton   = types.LargeIconButton
+	CompactIconButton = types.CompactIconButton
 )
 
 // ControlKind is the UI control a command presents as — Inventor's ControlDefinition

--- a/app/commands_sketch.go
+++ b/app/commands_sketch.go
@@ -37,11 +37,13 @@ func sketchTabCommands() []*CommandDefinition {
 		WithIcon("auto-dimension").WithButtonStyle(SmallIconButton).
 		WithTooltip("Auto Dimension — fully constrain the sketch with dimensions and grounds."))
 	cmds = append(cmds, constrainCommands()...)
-	cmds = append(cmds, NewCommand("Sketch.Project", "Project Geometry", "Draw", func(s *Session) error {
+	// Project Geometry lives in Create as a large button (the canonical ribbon has no
+	// "Draw" panel — see architecture/mapping/inventor-ribbon-structure.md).
+	cmds = append(cmds, NewCommand("Sketch.Project", "Project Geometry", "Create", func(s *Session) error {
 		s.StartTool(NewProjectGeometryTool())
 		return nil
 	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
-		WithIcon("project-geometry").WithButtonStyle(SmallIconButton).
+		WithIcon("project-geometry").WithButtonStyle(LargeIconButton).
 		WithTooltip("Project Geometry — pick part edges/vertices to reference onto the sketch plane."))
 	return append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
 		return s.FinishSketch()
@@ -53,10 +55,13 @@ func sketchTabCommands() []*CommandDefinition {
 // sketchToolEntry is one tool-launching command (id/label/alias/tooltip + factory).
 // variants, when present, become the entry's split-button dropdown (Inventor's variant
 // flyout): sibling tools reachable from the head's arrow, not their own panel buttons.
+// large marks the panel's headline tools (Line, Circle, …) that render as large
+// captioned buttons; the rest stack as small labeled rows.
 type sketchToolEntry struct {
 	id, name, alias, tip string
 	start                func() Tool
 	variants             []sketchToolEntry
+	large                bool
 }
 
 // newToolCommand builds one tool-launching command (no alias/icon for variants, which only
@@ -74,8 +79,12 @@ func newToolCommand(panel string, e sketchToolEntry) *CommandDefinition {
 func buildToolCommands(panel string, entries []sketchToolEntry) []*CommandDefinition {
 	cmds := make([]*CommandDefinition, len(entries))
 	for i, e := range entries {
+		style := SmallIconButton
+		if e.large {
+			style = LargeIconButton
+		}
 		cmd := newToolCommand(panel, e).WithAlias(e.alias).
-			WithIcon(strings.ToLower(e.name)).WithButtonStyle(SmallIconButton)
+			WithIcon(strings.ToLower(e.name)).WithButtonStyle(style)
 		if len(e.variants) > 0 {
 			variants := make([]*CommandDefinition, len(e.variants))
 			for j, v := range e.variants {
@@ -118,15 +127,15 @@ func sketchPatternCommands() []*CommandDefinition {
 // which Inventor places in Create, not Modify).
 func createCommands() []*CommandDefinition {
 	return buildToolCommands("Create", []sketchToolEntry{
-		{id: "Sketch.Line", name: "Line", alias: "L", tip: "Line — draw a line between two points.", start: func() Tool { return NewLineTool() }},
-		{id: "Sketch.Rectangle", name: "Rectangle", alias: "REC", tip: "Rectangle — draw a two-corner rectangle.", start: func() Tool { return NewRectangleTool() }, variants: []sketchToolEntry{
+		{id: "Sketch.Line", name: "Line", alias: "L", large: true, tip: "Line — draw a line between two points.", start: func() Tool { return NewLineTool() }},
+		{id: "Sketch.Rectangle", name: "Rectangle", alias: "REC", large: true, tip: "Rectangle — draw a two-corner rectangle.", start: func() Tool { return NewRectangleTool() }, variants: []sketchToolEntry{
 			{id: "Sketch.Rectangle.ThreePoint", name: "Three Point Rectangle", tip: "Three Point Rectangle — base edge then width.", start: func() Tool { return NewThreePointRectangleTool() }},
 			{id: "Sketch.Rectangle.Center", name: "Two Point Center Rectangle", tip: "Two Point Center Rectangle — center then a corner.", start: func() Tool { return NewCenterRectangleTool() }},
 		}},
-		{id: "Sketch.Circle", name: "Circle", alias: "C", tip: "Circle — draw a circle from its center and radius.", start: func() Tool { return NewCircleTool() }, variants: []sketchToolEntry{
+		{id: "Sketch.Circle", name: "Circle", alias: "C", large: true, tip: "Circle — draw a circle from its center and radius.", start: func() Tool { return NewCircleTool() }, variants: []sketchToolEntry{
 			{id: "Sketch.Circle.ThreePoint", name: "Three Point Circle", tip: "Three Point Circle — the circle through three points.", start: func() Tool { return NewThreePointCircleTool() }},
 		}},
-		{id: "Sketch.Arc", name: "Arc", alias: "A", tip: "Arc — draw a three-point arc.", start: func() Tool { return NewArcTool() }, variants: []sketchToolEntry{
+		{id: "Sketch.Arc", name: "Arc", alias: "A", large: true, tip: "Arc — draw a three-point arc.", start: func() Tool { return NewArcTool() }, variants: []sketchToolEntry{
 			{id: "Sketch.Arc.CenterPoint", name: "Center Point Arc", tip: "Center Point Arc — center, start, then end.", start: func() Tool { return NewCenterPointArcTool() }},
 		}},
 		{id: "Sketch.Slot", name: "Slot", tip: "Slot — click two centre points for a straight slot.", start: func() Tool { return NewSketchSlotTool(1) }, variants: []sketchToolEntry{
@@ -155,7 +164,7 @@ func constrainCommands() []*CommandDefinition {
 			s.StartTool(newTool())
 			return nil
 		}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).WithTooltip(d.tooltip).
-			WithIcon(strings.ToLower(d.name)).WithButtonStyle(SmallIconButton)
+			WithIcon(strings.ToLower(d.name)).WithButtonStyle(CompactIconButton)
 	}
 	return cmds
 }

--- a/app/commands_standard_test.go
+++ b/app/commands_standard_test.go
@@ -26,9 +26,10 @@ func TestStandardRibbonHasSketchCreatePanel(t *testing.T) {
 	if !ok {
 		t.Fatal("Sketch tab has no Create panel")
 	}
-	// Line, Rectangle, Circle, Arc, Slot, Spline, Ellipse, Polygon, Fillet, Chamfer, Text, Point.
-	if len(panel.Buttons) != 12 {
-		t.Errorf("Sketch Create panel has %d tools, want 12", len(panel.Buttons))
+	// Line, Rectangle, Circle, Arc, Slot, Spline, Ellipse, Polygon, Fillet, Chamfer, Text,
+	// Point, plus Project Geometry (merged from the non-canonical Draw panel 2026-06-11).
+	if len(panel.Buttons) != 13 {
+		t.Errorf("Sketch Create panel has %d tools, want 13", len(panel.Buttons))
 	}
 }
 
@@ -46,9 +47,11 @@ func TestIconCommandsCarryIconAndStyle(t *testing.T) {
 		icon  string
 		style ButtonStyle
 	}{
-		"Create.Extrude": {"extrude", LargeIconButton},
-		"Sketch.Line":    {"line", SmallIconButton},
-		"Sketch.Finish":  {"finish-sketch", LargeIconButton},
+		"Create.Extrude":    {"extrude", LargeIconButton},
+		"Sketch.Line":       {"line", LargeIconButton}, // headline Create tool (2020 ribbon look)
+		"Sketch.Fillet":     {"fillet", SmallIconButton},
+		"Sketch.Coincident": {"coincident", CompactIconButton},
+		"Sketch.Finish":     {"finish-sketch", LargeIconButton},
 	}
 	for id, w := range want {
 		c, ok := s.Commands().ByID(id)

--- a/app/ribbon_alignment_test.go
+++ b/app/ribbon_alignment_test.go
@@ -61,4 +61,49 @@ func TestSketchTabPanelsMatchInventor(t *testing.T) {
 	if _, exists := tab.Panel("Dimension"); exists {
 		t.Error("there must be no standalone 'Dimension' panel (Inventor has none)")
 	}
+
+	if !hasButton(create, "Project Geometry") {
+		t.Error("Create panel should contain Project Geometry")
+	}
+	if _, exists := tab.Panel("Draw"); exists {
+		t.Error("there must be no 'Draw' panel (Project Geometry lives in Create)")
+	}
+}
+
+// styleOf returns the ribbon button style of the named command on the panel, or false.
+func styleOf(p RibbonPanel, name string) (ButtonStyle, bool) {
+	for _, b := range p.Buttons {
+		if b.Command.DisplayName() == name {
+			return b.Command.ButtonStyle(), true
+		}
+	}
+	return 0, false
+}
+
+// TestSketchTabButtonStyles locks the canonical ribbon's button sizing: the Create
+// panel's headline tools and Project Geometry render large with a caption, the stacked
+// rows render small with a side label, and the constraint grid is compact icon-only.
+func TestSketchTabButtonStyles(t *testing.T) {
+	s := registeredSession(t)
+	enterSketchEnv(t, s)
+	tab, ok := BuildRibbon(s).Tab("Sketch")
+	if !ok {
+		t.Fatal("no Sketch tab")
+	}
+	create, _ := tab.Panel("Create")
+	for _, name := range []string{"Line", "Circle", "Arc", "Rectangle", "Project Geometry"} {
+		if got, ok := styleOf(create, name); !ok || got != LargeIconButton {
+			t.Errorf("Create %q style = %v, want LargeIconButton", name, got)
+		}
+	}
+	if got, ok := styleOf(create, "Fillet"); !ok || got != SmallIconButton {
+		t.Errorf("Create \"Fillet\" style = %v, want SmallIconButton", got)
+	}
+	constrain, _ := tab.Panel("Constrain")
+	if got, ok := styleOf(constrain, "Coincident"); !ok || got != CompactIconButton {
+		t.Errorf("Constrain \"Coincident\" style = %v, want CompactIconButton", got)
+	}
+	if got, ok := styleOf(constrain, "Dimension"); !ok || got != SmallIconButton {
+		t.Errorf("Constrain \"Dimension\" style = %v, want SmallIconButton", got)
+	}
 }

--- a/architecture/mapping/inventor-ribbon-structure.md
+++ b/architecture/mapping/inventor-ribbon-structure.md
@@ -210,11 +210,11 @@ fix as the affected features are touched (the commands work; they're in the wron
 | Sketch `Auto Dimension` | `Dimension` | **`Constrain`** | ✅ fixed 2026-06-04 |
 | Sketch `Mirror` | `Modify` | **`Pattern`** | ✅ fixed 2026-06-04 |
 | Sketch `Fillet` | `Modify` | **`Create`** | ✅ fixed 2026-06-04 |
-| Sketch `Project Geometry` | `Draw` | (not in this tree's Sketch tab; verify) | review |
+| Sketch `Project Geometry` | `Draw` | **`Create`** (large button, per the 2020 Sketch-tab screenshot) | ✅ fixed 2026-06-11 |
 | Part `Offset Face`/`Thicken` | `Modify` | `Modify` has **`Thicken/Offset`** (combined) | ok-ish |
 
 The Sketch tab now matches the tree (panels: Create, Modify, Pattern, Constrain, Exit;
-plus a non-canonical `Draw` panel holding Project Geometry — under review). Locked by
+the former non-canonical `Draw` panel was merged into Create 2026-06-11). Locked by
 `app.TestSketchTabPanelsMatchInventor`. **Modify** = Move/Copy/Rotate/Scale/Stretch/Trim/
 Extend/Split/Offset; **Pattern** = Rectangular/Circular/Mirror; **Create** = the full
 canonical set incl. Slot/Fillet/Chamfer/Text (plus Ellipse/Polygon extras); **Constrain** =

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -341,21 +341,20 @@ extern "C" unsigned int obk_ig_dockspace_over_main(void) {
     return ImGui::DockSpaceOverViewport(0, NULL, ImGuiDockNodeFlags_PassthruCentralNode);
 }
 
-// obk_ig_dock_default_layout builds the initial panel arrangement once: ribbon docked
-// across the top, the model browser left, the status bar bottom, and the 3D viewport
-// filling the central node. The window names come from Go (it owns panel identity); the
-// split structure is the default layout. Without this the panels float and auto-size to
-// nothing, so the viewport collapses to a sliver.
-extern "C" void obk_ig_dock_default_layout(unsigned int dockId, const char* ribbon,
-        const char* model, const char* viewport, const char* status) {
+// obk_ig_dock_default_layout builds the initial panel arrangement once: the model
+// browser left, the status bar bottom, and the 3D viewport filling the central node.
+// The ribbon is no longer part of the dockspace — it is a fixed band pinned above it
+// (obk_ig_begin_ribbon_band). The window names come from Go (it owns panel identity);
+// the split structure is the default layout. Without this the panels float and
+// auto-size to nothing, so the viewport collapses to a sliver.
+extern "C" void obk_ig_dock_default_layout(unsigned int dockId, const char* model,
+        const char* viewport, const char* status) {
     ImGui::DockBuilderRemoveNode(dockId);
     ImGui::DockBuilderAddNode(dockId, ImGuiDockNodeFlags_DockSpace);
     ImGui::DockBuilderSetNodeSize(dockId, ImGui::GetMainViewport()->Size);
     ImGuiID center = dockId;
-    ImGuiID top = ImGui::DockBuilderSplitNode(center, ImGuiDir_Up, 0.18f, NULL, &center);
     ImGuiID left = ImGui::DockBuilderSplitNode(center, ImGuiDir_Left, 0.22f, NULL, &center);
     ImGuiID bottom = ImGui::DockBuilderSplitNode(center, ImGuiDir_Down, 0.07f, NULL, &center);
-    ImGui::DockBuilderDockWindow(ribbon, top);
     ImGui::DockBuilderDockWindow(model, left);
     ImGui::DockBuilderDockWindow(status, bottom);
     ImGui::DockBuilderDockWindow(viewport, center);

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -73,6 +73,14 @@ float obk_ig_delta_time(void);
 void obk_ig_mouse_delta(float* dx, float* dy);
 void obk_ig_get_cursor_pos(float* x, float* y);
 void obk_ig_set_cursor_pos(float x, float y);
+int  obk_ig_begin_ribbon_band(const char* name, float height);
+void obk_ig_get_cursor_screen_pos(float* x, float* y);
+void obk_ig_set_cursor_screen_pos(float x, float y);
+void obk_ig_item_rect_max(float* x, float* y);
+float obk_ig_calc_text_width(const char* s);
+float obk_ig_frame_height(void);
+float obk_ig_text_line_height(void);
+void obk_ig_style_metrics(float* fpx, float* fpy, float* isx, float* isy, float* wpx, float* wpy);
 void obk_ig_set_next_window_pos(float x, float y);
 void obk_ig_set_next_window_size(float w, float h);
 void obk_ig_set_next_window_size_first_use(float w, float h);
@@ -111,7 +119,7 @@ int  obk_ig_begin_combo(const char* label, const char* preview);
 void obk_ig_end_combo(void);
 
 unsigned int obk_ig_dockspace_over_main(void);
-void obk_ig_dock_default_layout(unsigned int dockId, const char* ribbon, const char* model, const char* viewport, const char* status);
+void obk_ig_dock_default_layout(unsigned int dockId, const char* model, const char* viewport, const char* status);
 
 // Synthetic-input injection for in-window UI tests (defined in app.cpp).
 void obk_inject_mouse_pos(float x, float y);
@@ -642,23 +650,85 @@ func SetNextWindowSizeOnce(w, h float32) {
 	C.obk_ig_set_next_window_size_first_use(C.float(w), C.float(h))
 }
 
-// DockSpaceOverMain hosts a full-window dockspace each frame and returns its stable id.
-// Call it once per frame before the panels; the panels then dock into it.
+// DockSpaceOverMain hosts a dockspace over the main viewport's work area each frame and
+// returns its stable id. The work area excludes the menu bar and the ribbon band (both
+// claim their slice via the viewport side-bar mechanism), so the docked panels lay out
+// below the fixed chrome. Call it once per frame before the panels.
 func DockSpaceOverMain() uint32 { return uint32(C.obk_ig_dockspace_over_main()) }
 
-// DockDefaultLayout arranges the named panels once: ribbon top, model left, status
-// bottom, viewport filling the center. Call it a single time after the first
-// DockSpaceOverMain (the names must match the panels' Begin() titles).
-func DockDefaultLayout(dockID uint32, ribbon, model, viewport, status string) {
-	cr, fr := cstr(ribbon)
-	defer fr()
+// DockDefaultLayout arranges the named panels once: model left, status bottom, viewport
+// filling the center. Call it a single time after the first DockSpaceOverMain (the
+// names must match the panels' Begin() titles). The ribbon is not docked — it is a
+// fixed band drawn with BeginRibbonBand.
+func DockDefaultLayout(dockID uint32, model, viewport, status string) {
 	cm, fm := cstr(model)
 	defer fm()
 	cv, fv := cstr(viewport)
 	defer fv()
 	cs, fs := cstr(status)
 	defer fs()
-	C.obk_ig_dock_default_layout(C.uint(dockID), cr, cm, cv, cs)
+	C.obk_ig_dock_default_layout(C.uint(dockID), cm, cv, cs)
+}
+
+// BeginRibbonBand pins a full-width band of the given height across the top of the main
+// viewport, under the menu bar. The band is fixed chrome: not movable, resizable, or
+// dockable, and the dockspace lays out beneath it. Reports whether the content is
+// visible; pair with End regardless.
+func BeginRibbonBand(name string, height float32) bool {
+	c, free := cstr(name)
+	defer free()
+	return C.obk_ig_begin_ribbon_band(c, C.float(height)) != 0
+}
+
+// GetCursorScreenPos / SetCursorScreenPos read and write the layout cursor in screen
+// space — for pinning the ribbon's panel-name strip at a fixed band Y.
+func GetCursorScreenPos() (float32, float32) {
+	var x, y C.float
+	C.obk_ig_get_cursor_screen_pos(&x, &y)
+	return float32(x), float32(y)
+}
+func SetCursorScreenPos(x, y float32) { C.obk_ig_set_cursor_screen_pos(C.float(x), C.float(y)) }
+
+// ItemRectMax returns the screen-space bottom-right of the last item (pairs with
+// ItemRectMin to measure a just-drawn group, e.g. a ribbon panel's button block).
+func ItemRectMax() (float32, float32) {
+	var x, y C.float
+	C.obk_ig_item_rect_max(&x, &y)
+	return float32(x), float32(y)
+}
+
+// CalcTextWidth returns the rendered width of s in the current font (for centering
+// ribbon captions and panel names).
+func CalcTextWidth(s string) float32 {
+	c, free := cstr(s)
+	defer free()
+	return float32(C.obk_ig_calc_text_width(c))
+}
+
+// FrameHeight is the height of a framed widget row (font size + frame padding) — the
+// tab-strip height the ribbon band budget builds on.
+func FrameHeight() float32 { return float32(C.obk_ig_frame_height()) }
+
+// TextLineHeight is the height of one line of text in the current font.
+func TextLineHeight() float32 { return float32(C.obk_ig_text_line_height()) }
+
+// StyleMetrics are the live ImGui style paddings/spacings, so Go layout math (the
+// ribbon band height, caption centering) tracks the style instead of hardcoding pixels.
+type StyleMetrics struct {
+	FramePadX, FramePadY       float32
+	ItemSpacingX, ItemSpacingY float32
+	WindowPadX, WindowPadY     float32
+}
+
+// Metrics reads the current style's paddings and spacings.
+func Metrics() StyleMetrics {
+	var fpx, fpy, isx, isy, wpx, wpy C.float
+	C.obk_ig_style_metrics(&fpx, &fpy, &isx, &isy, &wpx, &wpy)
+	return StyleMetrics{
+		FramePadX: float32(fpx), FramePadY: float32(fpy),
+		ItemSpacingX: float32(isx), ItemSpacingY: float32(isy),
+		WindowPadX: float32(wpx), WindowPadY: float32(wpy),
+	}
 }
 
 // Inject* feed synthetic pointer/keyboard input into the next frame's ImGui IO, winning

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -39,6 +39,41 @@ void obk_ig_begin_group(void)                { ImGui::BeginGroup(); }
 void obk_ig_end_group(void)                  { ImGui::EndGroup(); }
 // separator_vertical draws a vertical divider between two horizontally-laid panels.
 void obk_ig_separator_vertical(void)         { ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical); }
+
+// begin_ribbon_band pins a full-width, fixed-height band to the top of the main
+// viewport (under the menu bar) via BeginViewportSideBar — the side-bar claims its
+// slice of the viewport work area, so the dockspace created afterwards lays out below
+// it. The band cannot be moved, resized, collapsed, or docked: the ribbon is window
+// chrome, not a palette. Pair with obk_ig_end regardless of the return value.
+int  obk_ig_begin_ribbon_band(const char* name, float height) {
+    ImGuiWindowFlags flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings;
+    return ImGui::BeginViewportSideBar(name, ImGui::GetMainViewport(), ImGuiDir_Up,
+        height, flags) ? 1 : 0;
+}
+
+// Cursor/layout probes for the ribbon's manual placement (screen space): the panel
+// name strip is pinned at a fixed band Y and centered under its button block, which
+// needs the block's rect, the text width, and a screen-space cursor write.
+void obk_ig_get_cursor_screen_pos(float* x, float* y) {
+    ImVec2 p = ImGui::GetCursorScreenPos();
+    *x = p.x; *y = p.y;
+}
+void obk_ig_set_cursor_screen_pos(float x, float y) { ImGui::SetCursorScreenPos(ImVec2(x, y)); }
+void obk_ig_item_rect_max(float* x, float* y) {
+    ImVec2 p = ImGui::GetItemRectMax();
+    *x = p.x; *y = p.y;
+}
+float obk_ig_calc_text_width(const char* s)  { return ImGui::CalcTextSize(s).x; }
+float obk_ig_frame_height(void)              { return ImGui::GetFrameHeight(); }
+float obk_ig_text_line_height(void)          { return ImGui::GetTextLineHeight(); }
+// style_metrics reports the paddings/spacings the Go layout math needs (frame padding,
+// item spacing, window padding) so pixel constants in Go stay in sync with the style.
+void obk_ig_style_metrics(float* fpx, float* fpy, float* isx, float* isy, float* wpx, float* wpy) {
+    const ImGuiStyle& st = ImGui::GetStyle();
+    *fpx = st.FramePadding.x; *fpy = st.FramePadding.y;
+    *isx = st.ItemSpacing.x;  *isy = st.ItemSpacing.y;
+    *wpx = st.WindowPadding.x; *wpy = st.WindowPadding.y;
+}
 // mouse_double_clicked reports a double-click of the given button this frame (used to
 // re-open a dimension for editing).
 int  obk_ig_mouse_double_clicked(int button) { return ImGui::IsMouseDoubleClicked(button) ? 1 : 0; }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -33,9 +33,12 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	prepareChromeFrame(win, s)
 	drawMenuBar(s)
 	activated := ""
+	// The ribbon band must be drawn after the menu bar (it stacks beneath it in the
+	// viewport work area) and before the dockspace (which fills what remains).
 	if id := drawRibbon(s); id != "" {
 		activated = id
 	}
+	layoutDockedPanels()
 	drawBrowser(s)
 	drawViewportIfPresent(win, s)
 	drawChromeDialogs(s)
@@ -53,12 +56,18 @@ func prepareChromeFrame(win *native.Window, s *app.Session) {
 	icons.beginFrame(s.ThemeRevision()) // free retired textures; flush composes on theme change
 	applyThemeIfChanged(win, s)         // restyle ImGui + overlays when the theme changed (live preview)
 	handleKeyboard(s)
+	followActiveDocument(s)
+}
+
+// layoutDockedPanels hosts the dockspace under the fixed chrome (menu bar + ribbon
+// band) and builds the one-time default arrangement of the dockable panels. The ribbon
+// is intentionally absent: it is fixed chrome, not a dockable panel.
+func layoutDockedPanels() {
 	dockID := native.DockSpaceOverMain()
 	if !dockLaidOut {
-		native.DockDefaultLayout(dockID, "Ribbon", "Model", "Viewport", "Status")
+		native.DockDefaultLayout(dockID, "Model", "Viewport", "Status")
 		dockLaidOut = true
 	}
-	followActiveDocument(s)
 }
 
 func drawViewportIfPresent(win *native.Window, s *app.Session) {

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -14,15 +14,16 @@ import (
 // only on the transition frame, so the user can still pick tabs by hand afterwards.
 var prevInSketch bool
 
-// drawRibbon renders the ribbon as Inventor's two-level layout: a tab bar of command
-// tabs, each tab holding its panels of command buttons. A disabled command renders a
-// disabled button (its predicate is re-evaluated every frame). The contextual Sketch
-// tab is auto-selected when entering the sketch environment. Returns the id of a
-// clicked command, or "".
+// drawRibbon renders the ribbon as a fixed band pinned across the top of the window,
+// directly under the menu bar — classic CAD ribbons are window chrome, not dockable
+// palettes, so the band claims its slice of the work area each frame and the dockspace
+// lays out beneath it. Inside the band: a tab strip, then each tab's panels of command
+// buttons. A disabled command renders a disabled button (its predicate is re-evaluated
+// every frame). Returns the id of a clicked command, or "".
 func drawRibbon(s *app.Session) string {
 	force := contextualTab(s)
 	var activated string
-	if native.Begin("Ribbon") && native.BeginTabBar("##ribbon-tabs") {
+	if native.BeginRibbonBand("##ribbon", ribbonBandHeight()) && native.BeginTabBar("##ribbon-tabs") {
 		for _, tab := range app.BuildRibbon(s).Tabs {
 			if native.BeginTabItemSelected(tab.Name, tab.Name == force) {
 				if id := drawTabPanels(tab.Panels); id != "" {
@@ -37,10 +38,34 @@ func drawRibbon(s *app.Session) string {
 	return activated
 }
 
+// ribbonMaxRows is how many small buttons stack in one panel column before the next
+// column starts (the classic ribbon stacks its small buttons three deep).
+const ribbonMaxRows = 3
+
+// ribbonGridHeight is the height of the band's button-grid area: the tallest column
+// shape, ribbonMaxRows rows of small icon buttons.
+func ribbonGridHeight(m native.StyleMetrics) float32 {
+	row := smallIconPx + 2*m.FramePadY
+	return ribbonMaxRows*row + (ribbonMaxRows-1)*m.ItemSpacingY
+}
+
+// ribbonBandHeight is the fixed height of the ribbon band: the tab strip, the button
+// grid, and the panel-name strip, plus the paddings between them. Computed from the
+// live style so a font or padding change can never clip the band's content.
+func ribbonBandHeight() float32 {
+	m := native.Metrics()
+	content := ribbonGridHeight(m) + m.ItemSpacingY + native.TextLineHeight()
+	return 2*m.WindowPadY + native.FrameHeight() + m.ItemSpacingY + content
+}
+
 // drawTabPanels lays the tab's panels out horizontally — each panel is a layout group
-// (button row + title) and panels sit SameLine with a vertical divider between them, so
-// no panel is pushed off-screen the way a vertical stack hid the Sketch tab's Exit panel.
+// (button columns + name strip) separated by a full-height vertical divider. Every
+// panel pins its name at the same band-bottom Y (labelY), which both matches the
+// reference ribbon's footer strip and makes the dividers span the full band.
 func drawTabPanels(panels []app.RibbonPanel) string {
+	m := native.Metrics()
+	_, gridTop := native.GetCursorScreenPos()
+	labelY := gridTop + ribbonGridHeight(m) + m.ItemSpacingY
 	var activated string
 	for i, panel := range panels {
 		if i > 0 {
@@ -48,7 +73,7 @@ func drawTabPanels(panels []app.RibbonPanel) string {
 			native.SeparatorVertical()
 			native.SameLine()
 		}
-		if id := drawPanel(panel); id != "" {
+		if id := drawPanel(panel, labelY); id != "" {
 			activated = id
 		}
 	}
@@ -69,54 +94,94 @@ func contextualTab(s *app.Session) string {
 	return "3D Model"
 }
 
-// ribbonMaxRows caps how many button rows a panel uses (Inventor stacks small buttons a
-// few rows deep); the column count grows to fit, keeping each panel narrow so panels sit
-// side-by-side without running off the ribbon.
-const ribbonMaxRows = 3
-
-// panelCols returns how many columns to wrap a panel's n buttons into, bounded so the
-// panel is at most ribbonMaxRows tall.
-func panelCols(n int) int {
-	if n <= ribbonMaxRows {
-		return 1
+// packPanelColumns lays a panel's buttons into the ribbon's column-major flow: a large
+// button stands alone as its own full-height column, while small/compact/text buttons
+// stack up to ribbonMaxRows deep before the next column starts — so a registration
+// order of Move, Copy, Rotate, Trim, … reads down each column like the reference ribbon.
+func packPanelColumns(buttons []app.RibbonButton) [][]app.RibbonButton {
+	var cols [][]app.RibbonButton
+	var stack []app.RibbonButton
+	flush := func() {
+		if len(stack) > 0 {
+			cols = append(cols, stack)
+			stack = nil
+		}
 	}
-	return (n + ribbonMaxRows - 1) / ribbonMaxRows
+	for _, b := range buttons {
+		if b.Command.ButtonStyle() == app.LargeIconButton {
+			flush()
+			cols = append(cols, []app.RibbonButton{b})
+			continue
+		}
+		stack = append(stack, b)
+		if len(stack) == ribbonMaxRows {
+			flush()
+		}
+	}
+	flush()
+	return cols
 }
 
-// drawPanel renders one ribbon panel as a self-contained layout group: a compact grid of
-// command buttons with the panel title beneath them (Inventor's panel layout), so the
-// whole panel is one narrow, horizontally-placeable unit. The title uses plain Text (not
-// SeparatorText, which would stretch the group to the full window width and hide every
-// panel to its right). Returns the id of a clicked command, or "".
-func drawPanel(panel app.RibbonPanel) string {
+// drawPanel renders one ribbon panel as a self-contained layout group — its button
+// columns with the panel name centered beneath in the band's footer strip — so the
+// whole panel is one narrow, horizontally-placeable unit. Returns the id of a clicked
+// command, or "".
+func drawPanel(panel app.RibbonPanel, labelY float32) string {
 	if panel.Selector != nil {
-		return drawSelectorPanel(panel)
+		return drawSelectorPanel(panel, labelY)
 	}
-	var activated string
-	cols := panelCols(len(panel.Buttons))
 	native.BeginGroup()
-	for i, btn := range panel.Buttons {
-		if i > 0 && i%cols != 0 {
-			native.SameLine() // continue the current row; a new row starts at each multiple of cols
-		}
-		if id := drawRibbonButton(btn); id != "" {
-			activated = id
-		}
-	}
-	native.Text(panel.Name) // panel title under its buttons
+	activated := drawPanelColumns(packPanelColumns(panel.Buttons))
+	drawPanelName(panel.Name, labelY)
 	native.EndGroup()
 	return activated
+}
+
+// drawPanelColumns draws the packed columns side by side, each column a vertical group
+// of its buttons, and leaves the whole block as the last item so the caller can measure
+// it (ItemRectMin/Max) to center the panel name.
+func drawPanelColumns(cols [][]app.RibbonButton) string {
+	var activated string
+	native.BeginGroup()
+	for i, col := range cols {
+		if i > 0 {
+			native.SameLine()
+		}
+		native.BeginGroup()
+		for _, btn := range col {
+			if id := drawRibbonButton(btn); id != "" {
+				activated = id
+			}
+		}
+		native.EndGroup()
+	}
+	native.EndGroup()
+	return activated
+}
+
+// drawPanelName centers the panel name under the button block just drawn, pinned at
+// the shared band-bottom labelY — the reference ribbon's panel-name footer strip.
+func drawPanelName(name string, labelY float32) {
+	x0, _ := native.ItemRectMin()
+	x1, _ := native.ItemRectMax()
+	off := ((x1 - x0) - native.CalcTextWidth(name)) / 2
+	if off < 0 {
+		off = 0
+	}
+	native.SetCursorScreenPos(x0+off, labelY)
+	native.Text(name)
 }
 
 // selectorWidth is the pixel width of a ribbon selection-box (the Visual Style drop-down) —
 // wide enough for the longest label ("Wireframe with Visible Edges Only").
 const selectorWidth = 230
 
-// drawSelectorPanel renders a panel as a labelled selection box (Inventor's combo control):
-// a drop-down previewing the current choice with the panel title beneath, matching the button
-// panels' layout. Choosing an option returns its command id so the caller runs it (which sets
-// the new selection); the box reflects the session state on the next frame.
-func drawSelectorPanel(panel app.RibbonPanel) string {
+// drawSelectorPanel renders a panel as a labelled selection box (a ribbon combo
+// control): a drop-down previewing the current choice with the panel name beneath,
+// matching the button panels' layout. Choosing an option returns its command id so the
+// caller runs it (which sets the new selection); the box reflects the session state on
+// the next frame.
+func drawSelectorPanel(panel app.RibbonPanel, labelY float32) string {
 	sel := panel.Selector
 	preview := ""
 	if sel.SelectedIndex >= 0 && sel.SelectedIndex < len(sel.Options) {
@@ -136,15 +201,15 @@ func drawSelectorPanel(panel app.RibbonPanel) string {
 		}
 		native.EndCombo()
 	}
-	native.Text(panel.Name) // panel title under the selection box
+	drawPanelName(panel.Name, labelY)
 	native.EndGroup()
 	return activated
 }
 
-// drawRibbonButton renders one command in its configured style (text, small icon, or
-// large icon), greyed when its predicate is false, with the command tooltip on hover.
+// drawRibbonButton renders one command in its configured style (text, small, large, or
+// compact icon), greyed when its predicate is false, with the command tooltip on hover.
 // A command with variants renders as a split button: the head control plus a dropdown
-// arrow listing the variant tools (Inventor's variant flyout). It returns the id of the
+// arrow listing the variant tools (the variant flyout). It returns the id of the
 // command (head or chosen variant) clicked this frame, else "".
 func drawRibbonButton(btn app.RibbonButton) string {
 	native.BeginDisabled(!btn.Enabled)
@@ -212,7 +277,7 @@ func drawButtonControl(btn app.RibbonButton) bool {
 // text-only command.
 func iconSizeFor(s app.ButtonStyle) (int, bool) {
 	switch s {
-	case app.SmallIconButton:
+	case app.SmallIconButton, app.CompactIconButton:
 		return smallIconPx, true
 	case app.LargeIconButton:
 		return largeIconPx, true
@@ -225,18 +290,55 @@ func iconSizeFor(s app.ButtonStyle) (int, bool) {
 // baked in by iconCache.compose from the icon.* tokens, so no per-draw tinting.
 var identityTint = [4]float32{1, 1, 1, 1}
 
-// drawIconButton renders an icon button: small ones are icon-only (dense tool grids),
-// large ones place the name as a caption beneath the icon (the classic two CAD ribbon
-// button sizes). The icon is the click target either way.
+// drawIconButton renders an icon button in its style: large is a captioned panel
+// heading, small is an icon with its name beside it, and compact is the bare icon for
+// dense grids like the constraint palette. The icon is the click target in every style.
 func drawIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
-	if btn.Command.ButtonStyle() != app.LargeIconButton {
+	switch btn.Command.ButtonStyle() {
+	case app.LargeIconButton:
+		return drawLargeIconButton(btn, tex, px)
+	case app.SmallIconButton:
+		return drawLabeledIconButton(btn, tex, px)
+	default: // CompactIconButton
 		clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
 		native.SetItemTooltip(btn.Command.Tooltip())
 		return clicked
 	}
+}
+
+// drawLabeledIconButton renders a small button as icon + name side by side, the label
+// vertically centered on the icon row — the stacked rows of a ribbon panel column.
+func drawLabeledIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
+	m := native.Metrics()
 	native.BeginGroup()
 	clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
 	native.SetItemTooltip(btn.Command.Tooltip())
+	native.SameLine()
+	x, y := native.GetCursorScreenPos()
+	native.SetCursorScreenPos(x, y+(px+2*m.FramePadY-native.TextLineHeight())/2)
+	native.Text(btn.Command.DisplayName())
+	native.EndGroup()
+	return clicked
+}
+
+// drawLargeIconButton renders a large button as a panel heading: the icon centered over
+// its caption, the cell as wide as the wider of the two — so "Start 2D Sketch" doesn't
+// hang off a 40px icon.
+func drawLargeIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
+	m := native.Metrics()
+	frameW := px + 2*m.FramePadX // ImageButton draws its frame padding around the glyph
+	textW := native.CalcTextWidth(btn.Command.DisplayName())
+	cellW := frameW
+	if textW > cellW {
+		cellW = textW
+	}
+	native.BeginGroup()
+	x, y := native.GetCursorScreenPos()
+	native.SetCursorScreenPos(x+(cellW-frameW)/2, y)
+	clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
+	native.SetItemTooltip(btn.Command.Tooltip())
+	_, captionY := native.GetCursorScreenPos()
+	native.SetCursorScreenPos(x+(cellW-textW)/2, captionY)
 	native.Text(btn.Command.DisplayName())
 	native.EndGroup()
 	return clicked

--- a/head/ui/icon_cache.go
+++ b/head/ui/icon_cache.go
@@ -9,11 +9,14 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// Rasterization sizes per button style. Small icons fill the dense sketch tool grids;
-// large icons head a panel (two button sizes). Glyphs are size-normalized at raster
-// time (see icon.RasterizeRoles), so these are the on-screen icon sizes directly.
+// Rasterization sizes per button style. Small icons sit beside their label in a panel
+// column's stacked rows (and alone in compact grids); large icons head a panel over a
+// caption. Glyphs are size-normalized at raster time (see icon.RasterizeRoles), so
+// these are the on-screen icon sizes directly. Small dropped from 30 when small
+// buttons gained side labels: three 18px rows + labels match a large captioned button,
+// the classic two ribbon button sizes.
 const (
-	smallIconPx = 30
+	smallIconPx = 18
 	largeIconPx = 40
 )
 

--- a/head/ui/ribbon_columns_test.go
+++ b/head/ui/ribbon_columns_test.go
@@ -1,0 +1,53 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// styledRibbonButton builds a minimal ribbon button of the given style for layout tests.
+func styledRibbonButton(id string, style app.ButtonStyle) app.RibbonButton {
+	cmd := app.NewCommand(id, id, "Test", func(*app.Session) error { return nil }).
+		WithButtonStyle(style)
+	return app.RibbonButton{Command: cmd, Enabled: true}
+}
+
+// TestPackPanelColumns locks the ribbon's column-major flow: small/compact buttons
+// stack ribbonMaxRows deep, and a large button always stands alone as its own column —
+// even when it interrupts a partially filled stack.
+func TestPackPanelColumns(t *testing.T) {
+	buttons := []app.RibbonButton{
+		styledRibbonButton("s1", app.SmallIconButton),
+		styledRibbonButton("s2", app.SmallIconButton),
+		styledRibbonButton("L1", app.LargeIconButton), // interrupts the 2-deep stack
+		styledRibbonButton("c1", app.CompactIconButton),
+		styledRibbonButton("c2", app.CompactIconButton),
+		styledRibbonButton("c3", app.CompactIconButton),
+		styledRibbonButton("s3", app.SmallIconButton), // overflow starts a new column
+	}
+	cols := packPanelColumns(buttons)
+	wantLens := []int{2, 1, 3, 1}
+	if len(cols) != len(wantLens) {
+		t.Fatalf("packPanelColumns returned %d columns, want %d", len(cols), len(wantLens))
+	}
+	for i, want := range wantLens {
+		if len(cols[i]) != want {
+			t.Errorf("column %d has %d buttons, want %d", i, len(cols[i]), want)
+		}
+	}
+	if got := cols[1][0].Command.ID(); got != "L1" {
+		t.Errorf("column 1 holds %q, want the large button \"L1\" alone", got)
+	}
+}
+
+// TestPackPanelColumnsEmpty guards the degenerate panel (no buttons → no columns).
+func TestPackPanelColumnsEmpty(t *testing.T) {
+	if cols := packPanelColumns(nil); len(cols) != 0 {
+		t.Errorf("packPanelColumns(nil) = %d columns, want 0", len(cols))
+	}
+}

--- a/head/ui/sketch_ribbon_visual_test.go
+++ b/head/ui/sketch_ribbon_visual_test.go
@@ -1,0 +1,68 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/compdef"
+)
+
+// TestInWindowSketchRibbonVisualHold is a manual visual check: it opens the real window
+// in the sketch environment and holds it for ~15s so a human (or a screenshot tool) can
+// inspect the contextual Sketch ribbon. Skipped unless OBK_VISUAL_HOLD=1 — it renders
+// nothing assertable and exists only for eyeballing layout work.
+func TestInWindowSketchRibbonVisualHold(t *testing.T) {
+	if os.Getenv("OBK_VISUAL_HOLD") == "" {
+		t.Skip("manual visual check only (set OBK_VISUAL_HOLD=1)")
+	}
+	win, err := native.CreateWindow(1800, 600, "obk-sketch-ribbon-visual")
+	if err != nil {
+		t.Skipf("no window/Vulkan available: %v", err)
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	dockLaidOut = false
+	icons = nil
+	s := sketchEnvSession(t)
+	for i := 0; i < 6000; i++ { // long enough to screenshot even uncapped (~30s+)
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}
+
+// sketchEnvSession builds a part session with the standard commands registered and the
+// sketch environment entered via the pre-selected-XY-plane path (no interactive pick).
+func sketchEnvSession(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "sketch-ribbon-visual.obk", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	var origin app.BrowserNode
+	for _, c := range app.BuildBrowser(s).Children {
+		if c.Kind == "origin" {
+			origin = c
+		}
+	}
+	if len(origin.Children) == 0 {
+		t.Fatal("browser tree has no Origin folder with planes")
+	}
+	s.SelectBrowserNode(origin.Children[0]) // XY Plane
+	if err := s.Execute("Sketch.Create2D"); err != nil {
+		t.Fatalf("Create 2D Sketch: %v", err)
+	}
+	if !s.InSketch() {
+		t.Fatal("session did not enter the sketch environment")
+	}
+	return s
+}

--- a/theme/blendermap.go
+++ b/theme/blendermap.go
@@ -58,6 +58,9 @@ var directBindings = map[Token]directBinding{
 	types.TokenChromeButtonActive: {wcol("wcol_tool"), "inner_sel", false},
 	types.TokenChromeAccent:       {wcol("wcol_regular"), "inner_sel", true},
 	types.TokenChromeScrollbar:    {wcol("wcol_scroll"), "item", false},
+	// Danger reads the console's error-line red — the only legible per-theme red the
+	// Blender document authors (wcol_state's `error` is a dark fill, not a text/outline).
+	types.TokenChromeDanger: {[]string{"Theme", "console", "ThemeConsole"}, "line_error", true},
 	// Viewport 2D ← view_3d editor slots (sketch == Blender edit-mode geometry).
 	types.TokenViewportBg:           {append(append([]string(nil), pathV3Space...), "gradients", "ThemeGradientColors"), "high_gradient", true},
 	types.TokenGridMinor:            {pathView3D, "grid", false},

--- a/theme/token.go
+++ b/theme/token.go
@@ -69,6 +69,7 @@ var tokenInfos = map[Token]TokenInfo{
 	types.TokenChromeButtonActive:   {types.TokenChromeButtonActive, "Button (active)", GroupChrome},
 	types.TokenChromeAccent:         {types.TokenChromeAccent, "Accent", GroupChrome},
 	types.TokenChromeScrollbar:      {types.TokenChromeScrollbar, "Scrollbar", GroupChrome},
+	types.TokenChromeDanger:         {types.TokenChromeDanger, "Danger / required", GroupChrome},
 	types.TokenViewportBg:           {types.TokenViewportBg, "Background", GroupViewport},
 	types.TokenGridMinor:            {types.TokenGridMinor, "Grid (minor)", GroupViewport},
 	types.TokenGridMajor:            {types.TokenGridMajor, "Grid (major)", GroupViewport},


### PR DESCRIPTION
## What

- The ribbon is no longer a dockable panel: it is a fixed band pinned across the top of the window under the menu bar (viewport side-bar mechanism), with no title bar and no move/resize/float/dock affordances. The dockspace now lays out Model / Viewport / Status beneath it.
- The band's layout matches the reference ribbon extracted from the 2020 Sketch-tab screenshot:
  - column-major panel flow — a large captioned button is its own full-height column; small buttons stack three deep with their names beside 18px icons; compact buttons are icon-only for dense grids (the constraint palette);
  - panel names are centered in a shared footer strip at the bottom of the band; inter-panel dividers span the full band height;
  - band height derives from live style metrics, so font/padding changes can't clip the content.
- Sketch command styles align with the reference: Line / Rectangle / Circle / Arc / Project Geometry are large; the constraint grid is compact; Project Geometry moves from the non-canonical `Draw` panel into `Create` (mapping doc updated).

## Why

The ribbon is window chrome, not a palette — docking/floating it (or losing it behind another panel) breaks the command surface the whole app hangs off. The layout work brings the panels to visual parity with the canonical ribbon structure already mapped in `architecture/mapping/inventor-ribbon-structure.md`.

Part of #247. **Depends on Oblikovati/Oblikovati.API#42** (`types.CompactIconButton`) — merge that first.

## Verification

- `go test ./...` green in the root module, `make test` + `make smoke` green in `head/`, API types tests green.
- New regression tests: `TestSketchTabButtonStyles`, extended `TestSketchTabPanelsMatchInventor`, `TestPackPanelColumns(+Empty)`.
- Verified visually in the real window (3D Model and contextual Sketch tabs), via the new env-gated `TestInWindowSketchRibbonVisualHold` harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)