### PR TITLE
Redesign the Revolve, Sweep and Hole dialogs as property panels

### DIFF
--- a/app/feature_tool_clear_test.go
+++ b/app/feature_tool_clear_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// The property panels' selector chips clear one pick each (⊗). These lock the clears:
+// the pick empties, the tool stops being committable, and the breadcrumb name follows.
+
+func TestRevolveClearProfileEmptiesSelection(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2)
+	rv := NewRevolveTool()
+	s.StartTool(rv)
+	rv.Pick(s, profile)
+	if !rv.CanCommit() {
+		t.Fatal("a picked profile should make the revolve committable")
+	}
+	if rv.SourceSketchName() == "" {
+		t.Error("SourceSketchName() = \"\" with a picked profile, want the sketch's name")
+	}
+	rv.ClearProfile()
+	if _, ok := rv.PickedProfile(); ok || rv.CanCommit() {
+		t.Error("after ClearProfile the revolve must have no profile and not be committable")
+	}
+	if name := rv.SourceSketchName(); name != "" {
+		t.Errorf("SourceSketchName() = %q after clearing, want \"\"", name)
+	}
+}
+
+func TestSweepClearsProfileAndPathIndependently(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2)
+	sw := NewSweepTool()
+	s.StartTool(sw)
+	sw.Pick(s, profile)
+	sw.Pick(s, PathHandle{Sketch: profile.Sketch, PathIndex: 0})
+	if !sw.CanCommit() {
+		t.Fatal("profile + path should make the sweep committable")
+	}
+	sw.ClearPath()
+	if _, ok := sw.PickedPath(); ok {
+		t.Error("after ClearPath the sweep must have no path")
+	}
+	if _, ok := sw.PickedProfile(); !ok {
+		t.Error("ClearPath must not drop the profile pick")
+	}
+	sw.ClearProfile()
+	if _, ok := sw.PickedProfile(); ok || sw.SourceSketchName() != "" {
+		t.Error("after ClearProfile the sweep must have no profile and no source sketch name")
+	}
+}
+
+func TestHoleClearFaceEmptiesSelection(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	h := NewHoleTool()
+	s.StartTool(h)
+	h.Pick(s, FaceHandle{})
+	if _, ok := h.PickedFace(); !ok {
+		t.Fatal("picking a face handle should set the placement face")
+	}
+	h.ClearFace()
+	if _, ok := h.PickedFace(); ok || h.CanCommit() {
+		t.Error("after ClearFace the hole must have no face and not be committable")
+	}
+}

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -89,6 +89,10 @@ func (t *HoleTool) SinkAngle() float64     { return t.sinkAngle }
 func (t *HoleTool) SetPointAngle(a float64) { t.pointAngle = a }
 func (t *HoleTool) PointAngle() float64     { return t.pointAngle }
 
+// ClearFace empties the picked placement face — the property panel's selector clear
+// (⊗) — returning the tool to its pick-a-face step.
+func (t *HoleTool) ClearFace() { t.face = nil }
+
 // PickedFace returns the placement face (and true), or false when none picked yet.
 func (t *HoleTool) PickedFace() (FaceHandle, bool) {
 	if t.face == nil {

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -202,6 +202,24 @@ func (t *RevolveTool) PickedProfile() (ProfileHandle, bool) {
 // CanCommit reports whether a region has been picked (the axis has a default).
 func (t *RevolveTool) CanCommit() bool { return t.profile != nil }
 
+// ClearProfile empties the picked profile — the property panel's selector clear (⊗) —
+// dropping any centerline that was auto-selected from it, so the tool returns to its
+// select-a-region step.
+func (t *RevolveTool) ClearProfile() {
+	t.profile = nil
+	t.centerline = nil
+	t.centerlineSk = nil
+}
+
+// SourceSketchName returns the sketch the picked profile comes from, for the property
+// panel's breadcrumb; "" until a profile is picked.
+func (t *RevolveTool) SourceSketchName() string {
+	if t.profile == nil {
+		return ""
+	}
+	return t.profile.Sketch.Name()
+}
+
 // Commit adds the revolve feature to the active part and recomputes; a sick feature
 // (open profile, missing axis) keeps the tool open by returning an error.
 func (t *RevolveTool) Commit(s *Session) error {

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -73,6 +73,20 @@ func (t *SweepTool) PickedPath() (PathHandle, bool) {
 // CanCommit reports whether both a profile and a path have been picked.
 func (t *SweepTool) CanCommit() bool { return t.profile != nil && t.path != nil }
 
+// ClearProfile / ClearPath empty one pick each — the property panel's selector clear
+// (⊗) affordances on the Profiles and Path chips.
+func (t *SweepTool) ClearProfile() { t.profile = nil }
+func (t *SweepTool) ClearPath()    { t.path = nil }
+
+// SourceSketchName returns the sketch the picked profile comes from, for the property
+// panel's breadcrumb; "" until a profile is picked.
+func (t *SweepTool) SourceSketchName() string {
+	if t.profile == nil {
+		return ""
+	}
+	return t.profile.Sketch.Name()
+}
+
 // Commit resolves the path to a 3D rail, adds the sweep feature, and recomputes; a sick
 // feature keeps the tool open by returning an error.
 func (t *SweepTool) Commit(s *Session) error {

--- a/head/icon/assets/angle-full.svg
+++ b/head/icon/assets/angle-full.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M12 3 L12 21"/><path d="M5 12 A7 4 0 1 0 12 8 M9 5.5 L12 8 L9.5 10.5" stroke="#ff0000"/></svg>

--- a/head/icon/assets/drill-angle.svg
+++ b/head/icon/assets/drill-angle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M8 4 L8 15 L12 20 L16 15 L16 4"/><path d="M9.5 17 L12 14 L14.5 17" stroke="#ff0000"/></svg>

--- a/head/icon/assets/drill-flat.svg
+++ b/head/icon/assets/drill-flat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M8 4 L8 18 L16 18 L16 4"/></svg>

--- a/head/icon/assets/seat-counterbore.svg
+++ b/head/icon/assets/seat-counterbore.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 7 L7 7 M17 7 L21 7 M10 12 L10 18 L14 18 L14 12"/><path d="M7 7 L7 12 L10 12 M17 7 L17 12 L14 12" stroke="#ff0000"/></svg>

--- a/head/icon/assets/seat-countersink.svg
+++ b/head/icon/assets/seat-countersink.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 7 L7 7 M17 7 L21 7 M10 12 L10 18 L14 18 L14 12"/><path d="M7 7 L10 12 M17 7 L14 12" stroke="#ff0000"/></svg>

--- a/head/icon/assets/seat-none.svg
+++ b/head/icon/assets/seat-none.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 7 L9.5 7 M14.5 7 L21 7 M9.5 7 L9.5 18 L14.5 18 L14.5 7"/></svg>

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -64,12 +64,7 @@ func seedExtrudeFields(s *app.Session) {
 // drawExtrudeHeader renders the panel breadcrumb — the feature name and, once a profile
 // is picked, the sketch it extrudes (the reference panel's "Extrusion > Sketch" trail).
 func drawExtrudeHeader(ext *app.ExtrudeTool) {
-	native.Text("Extrusion")
-	if name := ext.SourceSketchName(); name != "" {
-		native.SameLine()
-		native.Text("> " + name)
-	}
-	native.Separator()
+	drawFeatureBreadcrumb("Extrusion", ext.SourceSketchName())
 }
 
 // drawExtrudeInputGeometry is the Input Geometry section: the Profiles selection chip
@@ -131,22 +126,6 @@ var extrudeExtentToggles = propertyToggleSet{
 		"To Next — extrude up to the next face",
 	},
 }
-
-var extrudeBooleanToggles = propertyToggleSet{
-	keys: []string{"bool-join", "bool-cut", "bool-intersect", "bool-new-solid"},
-	tips: []string{
-		"Join — merge the extrusion into the body",
-		"Cut — remove the extrusion from the body",
-		"Intersect — keep only the overlapping material",
-		"New Solid — create a separate body",
-	},
-}
-
-// propertyToggleSet bundles an icon-toggle row's glyph keys with their tooltips.
-type propertyToggleSet struct{ keys, tips []string }
-
-// extrudeBooleanOps lists the operations in the Boolean toggle row's order.
-var extrudeBooleanOps = []ops.PartFeatureOperation{ops.Join, ops.Cut, ops.Intersect, ops.NewBody}
 
 // extrudeExtentTypes lists the extents in the extent toggle row's order.
 var extrudeExtentTypes = []feature.ExtentType{feature.DistanceExtent, feature.ThroughAllExtent, feature.ToNextExtent}
@@ -236,26 +215,12 @@ func drawExtrudeSecondDistanceRow(s *app.Session) {
 	native.SetItemTooltip("Distance B (" + s.LengthUnitName() + ")")
 }
 
-// drawExtrudeOutput is the Output section: the Boolean toggle row.
+// drawExtrudeOutput is the Output section: the shared Boolean toggle row.
 func drawExtrudeOutput(ext *app.ExtrudeTool) {
 	if !propertySection("Output") {
 		return
 	}
-	propertyRow("Boolean")
-	b := extrudeBooleanToggles
-	if i := propertyIconToggles("extrude-boolean", b.keys, b.tips, extrudeBooleanIndex(ext)); i >= 0 {
-		ext.SetOperation(extrudeBooleanOps[i])
-	}
-}
-
-// extrudeBooleanIndex maps the tool's operation onto the Boolean toggle row.
-func extrudeBooleanIndex(ext *app.ExtrudeTool) int {
-	for i, op := range extrudeBooleanOps {
-		if op == ext.Operation() {
-			return i
-		}
-	}
-	return 3 // New Solid, the tool's default
+	drawBooleanPropertyRow("extrude-boolean", ext.Operation(), ext.SetOperation)
 }
 
 // drawExtrudeAdvanced is the Advanced Properties section: the Taper A draft angle.

--- a/head/ui/extrude_dialog_test.go
+++ b/head/ui/extrude_dialog_test.go
@@ -42,13 +42,11 @@ func TestExtrudeExtentIndexMapping(t *testing.T) {
 	}
 }
 
-// TestExtrudeBooleanIndexMapping locks the Boolean toggle order (Join, Cut, Intersect,
-// New Solid — the reference panel's order) against the tool's operation.
-func TestExtrudeBooleanIndexMapping(t *testing.T) {
-	ext := app.NewExtrudeTool()
-	for i, op := range extrudeBooleanOps {
-		ext.SetOperation(op)
-		if got := extrudeBooleanIndex(ext); got != i {
+// TestBooleanToggleIndexMapping locks the shared Boolean toggle order (Join, Cut,
+// Intersect, New Solid — the reference panel's order) against the feature operation.
+func TestBooleanToggleIndexMapping(t *testing.T) {
+	for i, op := range booleanToggleOps {
+		if got := booleanToggleIndex(op); got != i {
 			t.Errorf("operation %v maps to toggle %d, want %d", op, got, i)
 		}
 	}

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -32,15 +32,42 @@ func TestInWindowExtrudePanelVisualHold(t *testing.T) {
 	dockLaidOut = false
 	icons = nil
 	s, profile := extrudeReadySession(t)
-	ext := app.NewExtrudeTool()
-	s.StartTool(ext)
-	if os.Getenv("OBK_VISUAL_EMPTY") == "" { // EMPTY=1 shows the required/empty selector state
-		ext.Pick(s, profile)
-	}
+	startVisualFeatureTool(s, profile)
 	for i := 0; i < 6000; i++ { // long enough to screenshot even uncapped (~30s+)
 		win.BeginFrame()
 		DrawChrome(win, s)
 		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}
+
+// startVisualFeatureTool starts the tool OBK_VISUAL_TOOL names (extrude by default;
+// revolve / sweep / hole) and seeds its picks unless OBK_VISUAL_EMPTY=1, which leaves
+// every selector in its required/empty state instead.
+func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
+	pick := os.Getenv("OBK_VISUAL_EMPTY") == ""
+	switch os.Getenv("OBK_VISUAL_TOOL") {
+	case "revolve":
+		rv := app.NewRevolveTool()
+		s.StartTool(rv)
+		if pick {
+			rv.Pick(s, profile)
+		}
+	case "sweep":
+		sw := app.NewSweepTool()
+		s.StartTool(sw)
+		if pick {
+			sw.Pick(s, profile) // the path chip stays empty: its required state shows
+		}
+	case "hole":
+		h := app.NewHoleTool()
+		s.StartTool(h)
+		h.SetCounterbore(true) // show the seat dimension rows
+	default:
+		ext := app.NewExtrudeTool()
+		s.StartTool(ext)
+		if pick {
+			ext.Pick(s, profile)
+		}
 	}
 }
 

--- a/head/ui/feature_panels_test.go
+++ b/head/ui/feature_panels_test.go
@@ -1,0 +1,73 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestHoleSeatToggleRoundTrip locks the Seat row's mapping: applying toggle i reads
+// back as active index i, and the tool's seat flags stay mutually exclusive.
+func TestHoleSeatToggleRoundTrip(t *testing.T) {
+	h := app.NewHoleTool()
+	for i := 0; i < 3; i++ {
+		applyHoleSeat(h, i)
+		if got := holeSeatIndex(h); got != i {
+			t.Errorf("after applyHoleSeat(%d), index = %d, want %d", i, got, i)
+		}
+		if h.Counterbore() && h.Countersink() {
+			t.Errorf("after applyHoleSeat(%d), both seat flags are set", i)
+		}
+	}
+}
+
+// TestHoleDrillPointToggle locks the Drill Point mapping: flat zeroes the angle, angle
+// mode restores the panel's value and falls back to the 118° drill default.
+func TestHoleDrillPointToggle(t *testing.T) {
+	h := app.NewHoleTool()
+	holeUI.pointAngleDeg = 0 // simulate a cleared field: angle mode must restore 118
+	applyHoleDrillPoint(h, 1)
+	if got := h.PointAngle() * 180 / stdmath.Pi; got < 117.9 || got > 118.1 {
+		t.Errorf("angle mode with a zero field set %v°, want the 118° default", got)
+	}
+	applyHoleDrillPoint(h, 0)
+	if h.PointAngle() != 0 {
+		t.Errorf("flat mode left point angle %v, want 0", h.PointAngle())
+	}
+}
+
+// TestToggleRevolveFullRoundTrip locks the full-revolution toggle: entering full mode
+// zeroes the swept angle (the tool's full marker); leaving it restores the panel angle.
+func TestToggleRevolveFullRoundTrip(t *testing.T) {
+	rv := app.NewRevolveTool()
+	revolveUI.angleDeg = 180
+	if !rv.IsFullRevolution() {
+		rv.SetFullRevolution()
+	}
+	toggleRevolveFull(rv) // leave full mode → 180° from the panel field
+	if rv.IsFullRevolution() {
+		t.Fatal("toggling out of full mode left the tool in full revolution")
+	}
+	if got := rv.Angle() * 180 / stdmath.Pi; got < 179.9 || got > 180.1 {
+		t.Errorf("leaving full mode set angle %v°, want 180°", got)
+	}
+	toggleRevolveFull(rv) // back to full
+	if !rv.IsFullRevolution() {
+		t.Error("toggling into full mode did not set a full revolution")
+	}
+}
+
+// TestPickChipText locks the single-pick chip captions.
+func TestPickChipText(t *testing.T) {
+	if got := pickChipText(false, "1 Path", "Select Path"); got != "Select Path" {
+		t.Errorf("empty chip text = %q, want \"Select Path\"", got)
+	}
+	if got := pickChipText(true, "1 Path", "Select Path"); got != "1 Path" {
+		t.Errorf("picked chip text = %q, want \"1 Path\"", got)
+	}
+}

--- a/head/ui/hole_dialog.go
+++ b/head/ui/hole_dialog.go
@@ -11,9 +11,11 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// The Hole flow in the head: while the Hole tool runs, a modeless options window lets
-// the user set the diameter and depth (database units), then OK/Cancel. The placement
-// face is the one clicked in the viewport.
+// The Hole flow in the head: while the Hole tool runs, a modeless property panel (the
+// reference panel schema: Input Geometry / Type / Behavior sections) drives the tool —
+// the placement-face chip, the seat (none / counterbore / countersink) with its
+// dimensions, the termination, the hole size, and the drill point — then OK/Cancel.
+// Lengths are in the document's length unit, angles in degrees.
 var holeUI = struct {
 	diameter, depth          float32
 	through                  bool
@@ -24,7 +26,7 @@ var holeUI = struct {
 	open                     bool
 }{diameter: 1, depth: 2, cDiameter: 2, cDepth: 0.5, sinkAngleDeg: 90, pointAngleDeg: 118}
 
-// drawHoleDialog shows the hole options window while the Hole tool is active.
+// drawHoleDialog shows the Hole property panel while the Hole tool is active.
 func drawHoleDialog(s *app.Session) {
 	h := s.ActiveHole()
 	if h == nil {
@@ -32,11 +34,14 @@ func drawHoleDialog(s *app.Session) {
 		return
 	}
 	refreshHoleUI(h)
-	native.SetNextWindowSize(300, 390)
+	native.SetNextWindowSizeOnce(360, 460)
 	if native.Begin("Hole") {
-		drawHoleBody(s, h)
-		drawRecess(s, h)
-		drawHoleButtons(s, h)
+		drawFeatureBreadcrumb("Hole", "")
+		drawHoleInputGeometry(h)
+		drawHoleType(s, h)
+		drawHoleBehavior(s, h)
+		native.Separator()
+		drawCommitCancelButtons(s, h.CanCommit())
 	}
 	native.End()
 }
@@ -57,76 +62,173 @@ func refreshHoleUI(h *app.HoleTool) {
 	holeUI.open = true
 }
 
-func drawHoleBody(s *app.Session, h *app.HoleTool) {
-	if _, ok := h.PickedFace(); !ok {
-		native.Text("Click a planar face to place the hole on")
+// drawHoleInputGeometry is the Input Geometry section: the required placement-face chip.
+func drawHoleInputGeometry(h *app.HoleTool) {
+	if !propertySection("Input Geometry") {
+		return
 	}
-	drawHoleSize(s, h)
-	drawHoleDepth(s, h)
-	drawHolePointAngle(h)
+	propertyRow("Position")
+	_, picked := h.PickedFace()
+	if propertySelectorChip("hole-position", pickChipText(picked, "1 Face", "Select Face"), picked, true) {
+		h.ClearFace()
+	}
+	native.SetItemTooltip("Click a planar face in the viewport to place the hole on")
 }
 
-func drawHoleSize(s *app.Session, h *app.HoleTool) {
-	native.Text("Diameter (" + s.LengthUnitName() + ")")
-	native.InputFloat("##hole-diameter", &holeUI.diameter)
+// holeSeatToggles is the Type section's Seat row (the reference panel's seat shapes we
+// support: plain, counterbore, countersink).
+var holeSeatToggles = propertyToggleSet{
+	keys: []string{"seat-none", "seat-counterbore", "seat-countersink"},
+	tips: []string{
+		"None — a plain drilled hole",
+		"Counterbore — a flat-bottomed recess above the hole",
+		"Countersink — a conical recess above the hole",
+	},
+}
+
+// drawHoleType is the Type section: the Seat toggle row and the selected seat's
+// dimension rows.
+func drawHoleType(s *app.Session, h *app.HoleTool) {
+	if !propertySection("Type") {
+		return
+	}
+	propertyRow("Seat")
+	if i := propertyIconToggles("hole-seat", holeSeatToggles.keys, holeSeatToggles.tips, holeSeatIndex(h)); i >= 0 {
+		applyHoleSeat(h, i)
+	}
+	drawHoleSeatParams(s, h)
+}
+
+// holeSeatIndex maps the tool's mutually-exclusive seat flags onto the Seat row.
+func holeSeatIndex(h *app.HoleTool) int {
+	switch {
+	case h.Counterbore():
+		return 1
+	case h.Countersink():
+		return 2
+	default:
+		return 0
+	}
+}
+
+// applyHoleSeat writes one Seat toggle back to the tool (the tool keeps the two seat
+// profiles mutually exclusive) and re-syncs the panel's flags from it.
+func applyHoleSeat(h *app.HoleTool, index int) {
+	h.SetCounterbore(index == 1)
+	h.SetCountersink(index == 2)
+	holeUI.counterbore = h.Counterbore()
+	holeUI.countersink = h.Countersink()
+}
+
+// drawHoleSeatParams renders the selected seat's dimensions: a counterbore's recess
+// Ø + depth, or a countersink's sink Ø + included angle.
+func drawHoleSeatParams(s *app.Session, h *app.HoleTool) {
+	if h.Counterbore() {
+		propertyFloatRow("Seat Ø", "hole-cdia", s.LengthUnitName(), &holeUI.cDiameter)
+		propertyFloatRow("Seat Depth", "hole-cdepth", s.LengthUnitName(), &holeUI.cDepth)
+		h.SetCounterDiameter(float64(holeUI.cDiameter))
+		h.SetCounterDepth(float64(holeUI.cDepth))
+	}
+	if h.Countersink() {
+		propertyFloatRow("Seat Ø", "hole-sdia", s.LengthUnitName(), &holeUI.cDiameter)
+		propertyFloatRow("Seat Angle", "hole-sang", "deg", &holeUI.sinkAngleDeg)
+		h.SetCounterDiameter(float64(holeUI.cDiameter))
+		h.SetSinkAngle(float64(holeUI.sinkAngleDeg) * stdmath.Pi / 180)
+	}
+}
+
+// holeTerminationToggles / holeDrillPointToggles are the Behavior section's toggle rows.
+var holeTerminationToggles = propertyToggleSet{
+	keys: []string{"extent-distance", "extent-through-all"},
+	tips: []string{
+		"Distance — drill exactly Depth deep",
+		"Through All — drill through all existing material",
+	},
+}
+
+var holeDrillPointToggles = propertyToggleSet{
+	keys: []string{"drill-flat", "drill-angle"},
+	tips: []string{
+		"Flat — a flat-bottomed hole",
+		"Angle — a conical drill point of the given included angle",
+	},
+}
+
+// drawHoleBehavior is the Behavior section: termination, hole size, and drill point.
+func drawHoleBehavior(s *app.Session, h *app.HoleTool) {
+	if !propertySection("Behavior") {
+		return
+	}
+	drawHoleTerminationRow(h)
+	propertyFloatRow("Diameter", "hole-diameter", s.LengthUnitName(), &holeUI.diameter)
 	h.SetDiameter(float64(holeUI.diameter))
-	native.Checkbox("Through All", &holeUI.through)
-	h.SetThroughAll(holeUI.through)
+	drawHoleDepthRow(s, h)
+	drawHoleDrillPointRow(h)
 }
 
-func drawHoleDepth(s *app.Session, h *app.HoleTool) {
-	native.BeginDisabled(holeUI.through) // depth is ignored when drilling through
-	native.Text("Depth (" + s.LengthUnitName() + ")")
-	native.InputFloat("##hole-depth", &holeUI.depth)
+// drawHoleTerminationRow renders the Termination toggles (distance / through-all).
+func drawHoleTerminationRow(h *app.HoleTool) {
+	propertyRow("Termination")
+	active := 0
+	if h.ThroughAll() {
+		active = 1
+	}
+	tt := holeTerminationToggles
+	if i := propertyIconToggles("hole-termination", tt.keys, tt.tips, active); i >= 0 {
+		holeUI.through = i == 1
+		h.SetThroughAll(holeUI.through)
+	}
+}
+
+// drawHoleDepthRow renders the Depth field, greyed while drilling through everything.
+func drawHoleDepthRow(s *app.Session, h *app.HoleTool) {
+	native.BeginDisabled(holeUI.through)
+	propertyFloatRow("Depth", "hole-depth", s.LengthUnitName(), &holeUI.depth)
 	native.EndDisabled()
 	h.SetDepth(float64(holeUI.depth))
 }
 
-func drawHolePointAngle(h *app.HoleTool) {
+// drawHoleDrillPointRow renders the Drill Point toggles with the included-angle field
+// beside them in angle mode. The row greys out when the bottom shape is moot: a
+// through hole has no bottom, and a seated hole's recess owns the profile.
+func drawHoleDrillPointRow(h *app.HoleTool) {
 	native.BeginDisabled(holeUI.through || holeUI.counterbore || holeUI.countersink)
-	native.Text("Drill point angle (deg, 0 = flat)")
+	propertyRow("Drill Point")
+	active := 0
+	if h.PointAngle() > 0 {
+		active = 1
+	}
+	dt := holeDrillPointToggles
+	if i := propertyIconToggles("hole-drill", dt.keys, dt.tips, active); i >= 0 {
+		applyHoleDrillPoint(h, i)
+	}
+	drawHolePointAngleField(h)
+	native.EndDisabled()
+}
+
+// drawHolePointAngleField is the included-angle input shown beside the toggles while a
+// conical drill point is selected.
+func drawHolePointAngleField(h *app.HoleTool) {
+	if h.PointAngle() <= 0 {
+		return
+	}
+	native.SameLine()
+	native.SetNextItemWidth(60)
 	native.InputFloat("##hole-pang", &holeUI.pointAngleDeg)
+	native.SameLine()
+	native.Text("deg")
 	h.SetPointAngle(float64(holeUI.pointAngleDeg) * stdmath.Pi / 180)
-	native.EndDisabled()
 }
 
-// drawRecess renders the counterbore/countersink toggles (mutually exclusive) and their
-// parameters: a counterbore's recess Ø + depth, or a countersink's sink Ø + included angle.
-func drawRecess(s *app.Session, h *app.HoleTool) {
-	drawCounterbore(s, h)
-	drawCountersink(s, h)
-	h.SetCounterDiameter(float64(holeUI.cDiameter)) // shared recess/sink diameter
-}
-
-func drawCounterbore(s *app.Session, h *app.HoleTool) {
-	if native.Checkbox("Counterbore", &holeUI.counterbore) {
-		h.SetCounterbore(holeUI.counterbore)
-		holeUI.countersink = h.Countersink() // the tool clears the other profile
+// applyHoleDrillPoint writes one Drill Point toggle back to the tool: flat zeroes the
+// angle; angle mode restores the panel's angle (falling back to the 118° drill default).
+func applyHoleDrillPoint(h *app.HoleTool, index int) {
+	if index == 0 {
+		h.SetPointAngle(0)
+		return
 	}
-	native.BeginDisabled(!holeUI.counterbore)
-	native.Text("Counterbore Ø (" + s.LengthUnitName() + ")")
-	native.InputFloat("##hole-cdia", &holeUI.cDiameter)
-	native.Text("Counterbore depth (" + s.LengthUnitName() + ")")
-	native.InputFloat("##hole-cdepth", &holeUI.cDepth)
-	h.SetCounterDepth(float64(holeUI.cDepth))
-	native.EndDisabled()
-
-}
-
-func drawCountersink(s *app.Session, h *app.HoleTool) {
-	if native.Checkbox("Countersink", &holeUI.countersink) {
-		h.SetCountersink(holeUI.countersink)
-		holeUI.counterbore = h.Counterbore()
+	if holeUI.pointAngleDeg <= 0 {
+		holeUI.pointAngleDeg = 118
 	}
-	native.BeginDisabled(!holeUI.countersink)
-	native.Text("Countersink Ø (" + s.LengthUnitName() + ")")
-	native.InputFloat("##hole-sdia", &holeUI.cDiameter)
-	native.Text("Countersink angle (deg)")
-	native.InputFloat("##hole-sang", &holeUI.sinkAngleDeg)
-	h.SetSinkAngle(float64(holeUI.sinkAngleDeg) * stdmath.Pi / 180)
-	native.EndDisabled()
-}
-
-func drawHoleButtons(s *app.Session, h *app.HoleTool) {
-	drawCommitCancelButtons(s, h.CanCommit())
+	h.SetPointAngle(float64(holeUI.pointAngleDeg) * stdmath.Pi / 180)
 }

--- a/head/ui/property_panel.go
+++ b/head/ui/property_panel.go
@@ -4,7 +4,10 @@
 
 package ui
 
-import "oblikovati.org/head/internal/native"
+import (
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/kernel/ops"
+)
 
 // The feature property panels (the Extrusion panel first) share this widget kit: a
 // breadcrumb header, collapsible sections, label/control rows on a fixed column grid,
@@ -18,6 +21,26 @@ const (
 	propertyLabelWidth = 95
 	propertyFieldWidth = 110
 )
+
+// drawFeatureBreadcrumb renders a property panel's header trail: the feature name and,
+// once known, the sketch it consumes (the reference panel's "Feature > Sketch" line).
+func drawFeatureBreadcrumb(featureName, sketchName string) {
+	native.Text(featureName)
+	if sketchName != "" {
+		native.SameLine()
+		native.Text("> " + sketchName)
+	}
+	native.Separator()
+}
+
+// pickChipText is the chip caption for a single-pick selector: the filled text once
+// picked, the required prompt until then.
+func pickChipText(picked bool, filled, prompt string) string {
+	if picked {
+		return filled
+	}
+	return prompt
+}
 
 // propertySection draws a full-width collapsible section header, open by default the
 // first time it is shown. Draw the section's rows only when it returns true.
@@ -106,6 +129,42 @@ func drawPropertyToggle(group, key, tip string, selected bool) bool {
 	clicked := drawPropertyToggleControl(group, key, tip)
 	native.SetItemTooltip(tip)
 	return clicked
+}
+
+// propertyToggleSet bundles an icon-toggle row's glyph keys with their tooltips.
+type propertyToggleSet struct{ keys, tips []string }
+
+// booleanToggles / booleanToggleOps are the Output section's Boolean row, shared by the
+// volumetric feature panels (Extrude, Revolve, Sweep) in the reference panel's order.
+var booleanToggles = propertyToggleSet{
+	keys: []string{"bool-join", "bool-cut", "bool-intersect", "bool-new-solid"},
+	tips: []string{
+		"Join — merge the feature into the body",
+		"Cut — remove the feature from the body",
+		"Intersect — keep only the overlapping material",
+		"New Solid — create a separate body",
+	},
+}
+
+var booleanToggleOps = []ops.PartFeatureOperation{ops.Join, ops.Cut, ops.Intersect, ops.NewBody}
+
+// booleanToggleIndex maps a feature operation onto the Boolean toggle row.
+func booleanToggleIndex(op ops.PartFeatureOperation) int {
+	for i, o := range booleanToggleOps {
+		if o == op {
+			return i
+		}
+	}
+	return 3 // New Solid, the tools' default
+}
+
+// drawBooleanPropertyRow renders the Output section's Boolean toggle row, writing a
+// clicked operation through set.
+func drawBooleanPropertyRow(id string, current ops.PartFeatureOperation, set func(ops.PartFeatureOperation)) {
+	propertyRow("Boolean")
+	if i := propertyIconToggles(id, booleanToggles.keys, booleanToggles.tips, booleanToggleIndex(current)); i >= 0 {
+		set(booleanToggleOps[i])
+	}
 }
 
 // drawPropertyToggleControl draws the toggle's clickable control: the icon at the small

--- a/head/ui/property_panel_test.go
+++ b/head/ui/property_panel_test.go
@@ -14,7 +14,12 @@ import (
 // property panels names only bundled glyphs — a missing asset degrades the toggle to a
 // text button, so a typo'd key fails the build instead of shipping a mixed-looking row.
 func TestPropertyToggleIconsResolve(t *testing.T) {
-	for _, set := range []propertyToggleSet{extrudeDirectionToggles, extrudeExtentToggles, extrudeBooleanToggles} {
+	sets := []propertyToggleSet{
+		extrudeDirectionToggles, extrudeExtentToggles, booleanToggles,
+		holeSeatToggles, holeTerminationToggles, holeDrillPointToggles,
+		{keys: []string{"angle-full"}, tips: []string{"Full"}}, // the revolve full toggle's lone glyph
+	}
+	for _, set := range sets {
 		if len(set.keys) != len(set.tips) {
 			t.Errorf("toggle set %v: %d keys but %d tips", set.keys, len(set.keys), len(set.tips))
 		}

--- a/head/ui/revolve_dialog.go
+++ b/head/ui/revolve_dialog.go
@@ -12,11 +12,12 @@ import (
 	"oblikovati.org/model/feature"
 )
 
-// The Revolve flow in the head: while the Revolve tool runs, a modeless options window
-// (Inventor's Revolve property panel) lets the user choose the output operation, the
-// axis of revolution and the swept angle (or a full revolution), then OK/Cancel. The
-// picked region is outlined in the viewport by the tool's preview. The angle is shown
-// in degrees.
+// The Revolve flow in the head: while the Revolve tool runs, a modeless property panel
+// (the reference panel schema: Input Geometry / Behavior / Output sections over a
+// label/control grid) drives the tool — the profile chip, the axis of revolution, the
+// swept angle with its full-revolution toggle, and the boolean output — then OK/Cancel.
+// The picked region is outlined in the viewport by the tool's preview. The angle is
+// shown in degrees.
 var revolveUI = struct {
 	angleDeg   float32
 	centerline bool
@@ -29,8 +30,8 @@ var revolveAxes = []struct {
 	ref   feature.WorkRef
 }{{"X Axis", feature.OriginXAxis}, {"Y Axis", feature.OriginYAxis}, {"Z Axis", feature.OriginZAxis}}
 
-// drawRevolveDialog shows the revolve options window while the Revolve tool is active,
-// syncing each control with the tool every frame; OK commits, Cancel aborts.
+// drawRevolveDialog shows the Revolve property panel while the Revolve tool is active,
+// syncing every control with the tool each frame; OK commits, Cancel aborts.
 func drawRevolveDialog(s *app.Session) {
 	rv := s.ActiveRevolve()
 	if rv == nil {
@@ -42,22 +43,19 @@ func drawRevolveDialog(s *app.Session) {
 		revolveUI.centerline = rv.UseCenterline()
 		revolveUI.open = true
 	}
-	native.SetNextWindowSize(300, 270)
+	native.SetNextWindowSizeOnce(340, 360)
 	if native.Begin("Revolve") {
-		drawRevolveProfileText(rv)
-		revolveOperationCombo(rv)
-		native.Checkbox("About sketch centerline", &revolveUI.centerline)
-		rv.SetUseCenterline(revolveUI.centerline)
-		native.BeginDisabled(revolveUI.centerline) // the axis is the centerline now
-		revolveAxisCombo(rv)
-		native.EndDisabled()
-		drawRevolveAngle(rv)
-		drawRevolveButtons(s, rv)
+		drawFeatureBreadcrumb("Revolve", rv.SourceSketchName())
+		drawRevolveInputGeometry(rv)
+		drawRevolveBehavior(rv)
+		drawRevolveOutput(rv)
+		native.Separator()
+		drawCommitCancelButtons(s, rv.CanCommit())
 	}
 	native.End()
 }
 
-// seedRevolveAngle returns the dialog's initial angle in degrees from the tool (a full
+// seedRevolveAngle returns the panel's initial angle in degrees from the tool (a full
 // revolution shows 360).
 func seedRevolveAngle(rv *app.RevolveTool) float32 {
 	if rv.IsFullRevolution() {
@@ -66,27 +64,34 @@ func seedRevolveAngle(rv *app.RevolveTool) float32 {
 	return float32(rv.Angle() * 180 / stdmath.Pi)
 }
 
-func drawRevolveProfileText(rv *app.RevolveTool) {
-	if _, ok := rv.PickedProfile(); !ok {
-		native.Text("Click a region to revolve")
+// drawRevolveInputGeometry is the Input Geometry section: the required Profiles chip
+// and the Axis row (origin-axis combo, swapped for the sketch's centerline when that
+// toggle is on).
+func drawRevolveInputGeometry(rv *app.RevolveTool) {
+	if !propertySection("Input Geometry") {
+		return
 	}
+	propertyRow("Profiles")
+	_, picked := rv.PickedProfile()
+	if propertySelectorChip("revolve-profiles", pickChipText(picked, "1 Profile", "Select Profile"), picked, true) {
+		rv.ClearProfile()
+	}
+	native.SetItemTooltip("Click a region in the viewport")
+	propertyRow("Axis")
+	drawRevolveAxisControls(rv)
 }
 
-func revolveOperationCombo(rv *app.RevolveTool) {
-	preview := "New Solid"
-	for _, o := range extrudeOperations {
-		if o.op == rv.Operation() {
-			preview = o.label
-		}
-	}
-	if native.BeginCombo("Output", preview) {
-		for _, o := range extrudeOperations {
-			if native.Selectable(o.label, o.op == rv.Operation()) {
-				rv.SetOperation(o.op)
-			}
-		}
-		native.EndCombo()
-	}
+// drawRevolveAxisControls renders the axis combo (greyed while the centerline drives
+// the revolution) with the about-centerline toggle beneath it, aligned to the control
+// column.
+func drawRevolveAxisControls(rv *app.RevolveTool) {
+	native.BeginDisabled(revolveUI.centerline)
+	native.SetNextItemWidth(propertyFieldWidth)
+	revolveAxisCombo(rv)
+	native.EndDisabled()
+	propertyRow("")
+	native.Checkbox("About sketch centerline", &revolveUI.centerline)
+	rv.SetUseCenterline(revolveUI.centerline)
 }
 
 func revolveAxisCombo(rv *app.RevolveTool) {
@@ -96,7 +101,7 @@ func revolveAxisCombo(rv *app.RevolveTool) {
 			preview = a.label
 		}
 	}
-	if native.BeginCombo("Axis", preview) {
+	if native.BeginCombo("##revolve-axis", preview) {
 		for _, a := range revolveAxes {
 			if native.Selectable(a.label, a.ref == rv.Axis()) {
 				rv.SetAxis(a.ref)
@@ -106,33 +111,44 @@ func revolveAxisCombo(rv *app.RevolveTool) {
 	}
 }
 
-// drawRevolveAngle offers a full-revolution checkbox and, when unchecked, an angle field
-// in degrees written back to the tool as radians.
-func drawRevolveAngle(rv *app.RevolveTool) {
-	full := rv.IsFullRevolution()
-	if native.Checkbox("Full revolution", &full) {
-		if full {
-			rv.SetFullRevolution()
-		} else {
-			rv.SetAngle(float64(revolveUI.angleDeg) * stdmath.Pi / 180)
-		}
-	}
-	if full {
+// drawRevolveBehavior is the Behavior section: the Angle A field (greyed during a full
+// revolution) with the full-revolution toggle beside it.
+func drawRevolveBehavior(rv *app.RevolveTool) {
+	if !propertySection("Behavior") {
 		return
 	}
-	native.Text("Angle (deg)")
+	propertyRow("Angle A")
+	native.BeginDisabled(rv.IsFullRevolution())
+	native.SetNextItemWidth(propertyFieldWidth)
 	native.InputFloat("##revolve-angle", &revolveUI.angleDeg)
+	if !rv.IsFullRevolution() {
+		rv.SetAngle(float64(revolveUI.angleDeg) * stdmath.Pi / 180)
+	}
+	native.SetItemTooltip("Angle A (deg)")
+	native.EndDisabled()
+	native.SameLine()
+	if drawPropertyToggle("revolve-full", "angle-full", "Full — revolve the whole 360°", rv.IsFullRevolution()) {
+		toggleRevolveFull(rv)
+	}
+}
+
+// toggleRevolveFull flips the full-revolution mode: leaving it restores the swept angle
+// from the panel field (a non-positive field falls back to 360°).
+func toggleRevolveFull(rv *app.RevolveTool) {
+	if !rv.IsFullRevolution() {
+		rv.SetFullRevolution()
+		return
+	}
+	if revolveUI.angleDeg <= 0 {
+		revolveUI.angleDeg = 360
+	}
 	rv.SetAngle(float64(revolveUI.angleDeg) * stdmath.Pi / 180)
 }
 
-func drawRevolveButtons(s *app.Session, rv *app.RevolveTool) {
-	native.BeginDisabled(!rv.CanCommit())
-	if native.Button("OK") {
-		_ = s.OK() // a failed commit (e.g. open profile) keeps the tool open
+// drawRevolveOutput is the Output section: the shared Boolean toggle row.
+func drawRevolveOutput(rv *app.RevolveTool) {
+	if !propertySection("Output") {
+		return
 	}
-	native.EndDisabled()
-	native.SameLine()
-	if native.Button("Cancel") {
-		s.CancelTool()
-	}
+	drawBooleanPropertyRow("revolve-boolean", rv.Operation(), rv.SetOperation)
 }

--- a/head/ui/sweep_dialog.go
+++ b/head/ui/sweep_dialog.go
@@ -11,15 +11,17 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// The Sweep flow in the head: while the Sweep tool runs, a modeless options window shows
-// the profile/path pick state, the output operation and a twist field (degrees), then
-// OK/Cancel. The picked profile is outlined by the tool's preview.
+// The Sweep flow in the head: while the Sweep tool runs, a modeless property panel
+// (the reference panel schema) drives the tool — the Profiles and Path chips, the
+// twist, and the boolean output — then OK/Cancel. The picked profile is outlined by
+// the tool's preview.
 var sweepUI = struct {
 	twistDeg float32
 	open     bool
 }{}
 
-// drawSweepDialog shows the sweep options window while the Sweep tool is active.
+// drawSweepDialog shows the Sweep property panel while the Sweep tool is active,
+// syncing every control with the tool each frame; OK commits, Cancel aborts.
 func drawSweepDialog(s *app.Session) {
 	sw := s.ActiveSweep()
 	if sw == nil {
@@ -30,56 +32,51 @@ func drawSweepDialog(s *app.Session) {
 		sweepUI.twistDeg = float32(sw.Twist() * 180 / stdmath.Pi)
 		sweepUI.open = true
 	}
-	native.SetNextWindowSize(300, 220)
+	native.SetNextWindowSizeOnce(340, 320)
 	if native.Begin("Sweep") {
-		native.Text(sweepPickStatus(sw))
-		sweepOperationCombo(sw)
-		native.Text("Twist (deg)")
-		native.InputFloat("##sweep-twist", &sweepUI.twistDeg)
-		sw.SetTwist(float64(sweepUI.twistDeg) * stdmath.Pi / 180)
-		drawSweepButtons(s, sw)
+		drawFeatureBreadcrumb("Sweep", sw.SourceSketchName())
+		drawSweepInputGeometry(sw)
+		drawSweepBehavior(sw)
+		drawSweepOutput(sw)
+		native.Separator()
+		drawCommitCancelButtons(s, sw.CanCommit())
 	}
 	native.End()
 }
 
-func sweepPickStatus(sw *app.SweepTool) string {
+// drawSweepInputGeometry is the Input Geometry section: the required Profiles chip and
+// the required Path chip, each clearable on its own.
+func drawSweepInputGeometry(sw *app.SweepTool) {
+	if !propertySection("Input Geometry") {
+		return
+	}
+	propertyRow("Profiles")
 	_, hasProfile := sw.PickedProfile()
+	if propertySelectorChip("sweep-profiles", pickChipText(hasProfile, "1 Profile", "Select Profile"), hasProfile, true) {
+		sw.ClearProfile()
+	}
+	native.SetItemTooltip("Click a region in the viewport to sweep")
+	propertyRow("Path")
 	_, hasPath := sw.PickedPath()
-	switch {
-	case !hasProfile:
-		return "Click a region to sweep"
-	case !hasPath:
-		return "Click a path to sweep along"
-	default:
-		return "Profile and path selected"
+	if propertySelectorChip("sweep-path", pickChipText(hasPath, "1 Path", "Select Path"), hasPath, true) {
+		sw.ClearPath()
 	}
+	native.SetItemTooltip("Click the curve to sweep along")
 }
 
-func sweepOperationCombo(sw *app.SweepTool) {
-	preview := "New Solid"
-	for _, o := range extrudeOperations {
-		if o.op == sw.Operation() {
-			preview = o.label
-		}
+// drawSweepBehavior is the Behavior section: the twist spread along the path.
+func drawSweepBehavior(sw *app.SweepTool) {
+	if !propertySection("Behavior") {
+		return
 	}
-	if native.BeginCombo("Output", preview) {
-		for _, o := range extrudeOperations {
-			if native.Selectable(o.label, o.op == sw.Operation()) {
-				sw.SetOperation(o.op)
-			}
-		}
-		native.EndCombo()
-	}
+	propertyFloatRow("Twist", "sweep-twist", "deg", &sweepUI.twistDeg)
+	sw.SetTwist(float64(sweepUI.twistDeg) * stdmath.Pi / 180)
 }
 
-func drawSweepButtons(s *app.Session, sw *app.SweepTool) {
-	native.BeginDisabled(!sw.CanCommit())
-	if native.Button("OK") {
-		_ = s.OK()
+// drawSweepOutput is the Output section: the shared Boolean toggle row.
+func drawSweepOutput(sw *app.SweepTool) {
+	if !propertySection("Output") {
+		return
 	}
-	native.EndDisabled()
-	native.SameLine()
-	if native.Button("Cancel") {
-		s.CancelTool()
-	}
+	drawBooleanPropertyRow("sweep-boolean", sw.Operation(), sw.SetOperation)
 }


### PR DESCRIPTION
## What

Brings the remaining three feature dialogs onto the Extrusion panel's reference schema (per `inventor-revolution.png`, `inventor-sweep.png`, `inventor-hole.png`):

- **Revolve** — Input Geometry (Profiles chip; Axis combo with the about-centerline toggle), Behavior (Angle A with a full-revolution toggle beside it, greying the field at 360°), Output (Boolean row).
- **Sweep** — Input Geometry (Profiles and Path chips, each independently clearable and showing the red required state), Behavior (Twist), Output (Boolean row).
- **Hole** — Input Geometry (placement-face chip), Type (Seat toggle row: none / counterbore / countersink, plus the selected seat's dimension rows), Behavior (Termination toggles, Diameter, Depth greyed on through-all, Drill Point toggles with the included-angle field, greyed when the bottom shape is moot).
- The Boolean toggle row, breadcrumb, and single-pick chip captions move into the shared property-panel kit — Extrude now uses the same row instead of its own copy.
- `RevolveTool`/`SweepTool`/`HoleTool` gain the clear/name accessors the chips need; six new glyphs (seat ×3, drill point ×2, full revolution).

## Why

Same rationale as the Extrusion panel: one consistent editing surface across the volumetric features, matching the reference layout, with required/empty picks made visible instead of buried in prompt text.

Part of #247. Stacked on #659 (base branch); merge order #658 → #659 → this.

## Verification

- Root `go test ./...`, `make test` + `make smoke` in `head/` all green.
- New regressions: tool clears (`feature_tool_clear_test.go`), seat/drill-point/full-revolution toggle round-trips, chip captions, glyph resolution for every toggle row.
- Each panel screenshot-verified in the real window via the parametrized visual-hold test (`OBK_VISUAL_TOOL=revolve|sweep|hole`), including the mixed filled/required chip states and the greyed dependent fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)