### PR TITLE
Serve feature editing through the same property panels

### DIFF
--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -12,10 +12,12 @@ import (
 // edges, set the setback distance in the property window, and OK to bevel them. Each
 // picked edge becomes a wedge cut on the active part.
 type ChamferTool struct {
-	edges       []EdgeHandle
-	distance    float64
-	flatCorners bool
-	added       *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed chamfer (see editChamferTool)
+	edges           []EdgeHandle
+	seededEdgeKeys  [][]byte // edit mode: the feature's existing edge keys (their edges are consumed, so no live handles exist)
+	distance        float64
+	flatCorners     bool
+	added           *feature.PartFeature
 }
 
 // NewChamferTool returns a chamfer tool with a default 1-unit setback and flat three-edge
@@ -63,22 +65,35 @@ func (t *ChamferTool) Distance() float64     { return t.distance }
 // Edges returns the picked edges (for the UI to list/highlight).
 func (t *ChamferTool) Edges() []EdgeHandle { return append([]EdgeHandle(nil), t.edges...) }
 
-// CanCommit reports whether at least one edge is picked and the distance is positive.
-func (t *ChamferTool) CanCommit() bool { return len(t.edges) > 0 && t.distance > 0 }
+// EdgeCount counts the selection the panel shows: edges picked this session plus, in
+// edit mode, the feature's retained edges.
+func (t *ChamferTool) EdgeCount() int { return len(t.seededEdgeKeys) + len(t.edges) }
+
+// selectedEdgeKeys is the reference-key set a commit writes: the retained keys plus
+// this session's picks.
+func (t *ChamferTool) selectedEdgeKeys() [][]byte {
+	keys := cloneKeys(t.seededEdgeKeys)
+	for _, e := range t.edges {
+		keys = append(keys, e.Edge.ReferenceKey())
+	}
+	return keys
+}
+
+// CanCommit reports whether at least one edge is selected and the distance is positive.
+func (t *ChamferTool) CanCommit() bool { return t.EdgeCount() > 0 && t.distance > 0 }
 
 // Commit bevels the picked edges on the active part and recomputes; a sick feature keeps
 // the tool open by returning an error.
 func (t *ChamferTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.edges))
-	for i, e := range t.edges {
-		keys[i] = e.Edge.ReferenceKey()
-	}
 	d := t.distance
-	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferCorners(keys, func() float64 { return d }, t.flatCorners)
+	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferCorners(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners)
 	part.Recompute()
 	s.recordEdit(part, "Chamfer")
 	if !t.added.Health().OK() {
@@ -99,9 +114,27 @@ func (t *ChamferTool) Prompt(*Session) string {
 	return "Set the distance, then click OK"
 }
 
-// Cancel restores the default selection filter.
-func (t *ChamferTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+// Cancel restores the default selection filter (or, in edit mode, the definition).
+func (t *ChamferTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
-// ClearEdges empties the picked edges — the property panel's selector clear (⊗) —
-// returning the tool to its pick-edges step.
-func (t *ChamferTool) ClearEdges() { t.edges = nil }
+// commitEdit writes the panel state back into the committed chamfer's definition.
+func (t *ChamferTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.ChamferFeature).Definition()
+	def.EdgeKeys = t.selectedEdgeKeys()
+	def.Distance = konst(t.distance)
+	def.FlatCorners = t.flatCorners
+	return commitFeatureEdit(s, t.target)
+}
+
+// ClearEdges empties the edge selection — the picks and, in edit mode, the feature's
+// retained keys — returning the tool to its pick-edges step.
+func (t *ChamferTool) ClearEdges() {
+	t.edges = nil
+	t.seededEdgeKeys = nil
+}

--- a/app/coil_tool.go
+++ b/app/coil_tool.go
@@ -15,12 +15,13 @@ import (
 // the helix axis, pitch, number of revolutions and operation in the property window,
 // and OK to add a coil feature to the active part. It mirrors [RevolveTool].
 type CoilTool struct {
-	profile     *ProfileHandle
-	axis        feature.WorkRef
-	pitch       float64
-	revolutions float64
-	operation   ops.PartFeatureOperation
-	added       *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed coil (see editCoilTool)
+	profile         *ProfileHandle
+	axis            feature.WorkRef
+	pitch           float64
+	revolutions     float64
+	operation       ops.PartFeatureOperation
+	added           *feature.PartFeature
 }
 
 // NewCoilTool returns a coil tool defaulting to a single-pitch, 3-revolution helix about
@@ -67,6 +68,9 @@ func (t *CoilTool) CanCommit() bool { return t.profile != nil && t.revolutions >
 // Commit adds the coil feature to the active part and recomputes; a sick feature keeps
 // the tool open by returning an error.
 func (t *CoilTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
@@ -85,6 +89,24 @@ func (t *CoilTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// commitEdit writes the panel state back into the committed coil's definition — the
+// same properties the create path passes to Add.
+func (t *CoilTool) commitEdit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	axis, ok := part.WorkGeometry().AxisByRef(t.axis)
+	if !ok {
+		return errors.New("coil edit: axis " + string(t.axis) + " not found")
+	}
+	def := t.target.Definition().(*feature.CoilFeature).Definition()
+	def.Sketch, def.ProfileIndex, def.Axis = t.profile.Sketch, t.profile.ProfileIndex, axis
+	def.Pitch, def.Revolutions = konst(t.pitch), konst(t.revolutions)
+	def.Operation = t.operation
+	return commitFeatureEdit(s, t.target)
 }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
@@ -115,7 +137,13 @@ func (t *CoilTool) Preview(*Session) []renderer.DrawItem {
 }
 
 // Cancel restores the default selection filter.
-func (t *CoilTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *CoilTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
 // ClearProfile empties the picked profile — the property panel's selector clear (⊗) —
 // returning the tool to its select-a-region step.

--- a/app/draft_tool.go
+++ b/app/draft_tool.go
@@ -16,9 +16,11 @@ const degToRad = stdmath.Pi / 180
 // draft angle (degrees) in the property window, and OK to taper them about the +Z pull
 // direction (the mould-pull default). Negative angle leans the face in, positive out.
 type DraftTool struct {
-	faces    []FaceHandle
-	angleDeg float64
-	added    *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed draft (see editDraftTool)
+	faces           []FaceHandle
+	seededFaceKeys  [][]byte // edit mode: the feature's existing face keys
+	angleDeg        float64
+	added           *feature.PartFeature
 }
 
 // NewDraftTool returns a draft tool with a default 3° angle.
@@ -55,22 +57,35 @@ func (t *DraftTool) AngleDegrees() float64     { return t.angleDeg }
 // Faces returns the picked faces (for the UI to list/highlight).
 func (t *DraftTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
 
-// CanCommit reports whether at least one face is picked and the angle is non-zero.
-func (t *DraftTool) CanCommit() bool { return len(t.faces) > 0 && t.angleDeg != 0 }
+// FaceCount counts the selection the panel shows: faces picked this session plus, in
+// edit mode, the feature's retained faces.
+func (t *DraftTool) FaceCount() int { return len(t.seededFaceKeys) + len(t.faces) }
+
+// selectedFaceKeys is the reference-key set a commit writes: the retained keys plus
+// this session's picks.
+func (t *DraftTool) selectedFaceKeys() [][]byte {
+	keys := cloneKeys(t.seededFaceKeys)
+	for _, f := range t.faces {
+		keys = append(keys, f.Face.ReferenceKey())
+	}
+	return keys
+}
+
+// CanCommit reports whether at least one face is selected and the angle is non-zero.
+func (t *DraftTool) CanCommit() bool { return t.FaceCount() > 0 && t.angleDeg != 0 }
 
 // Commit tapers the picked faces on the active part and recomputes; a sick feature keeps
 // the tool open by returning an error.
 func (t *DraftTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.faces))
-	for i, f := range t.faces {
-		keys[i] = f.Face.ReferenceKey()
-	}
 	rad := t.angleDeg * degToRad
-	t.added = feature.NewDressUpFeatures(part.Features()).AddDraft(keys, func() float64 { return rad })
+	t.added = feature.NewDressUpFeatures(part.Features()).AddDraft(t.selectedFaceKeys(), func() float64 { return rad })
 	part.Recompute()
 	s.recordEdit(part, "Draft")
 	if !t.added.Health().OK() {
@@ -92,8 +107,25 @@ func (t *DraftTool) Prompt(*Session) string {
 }
 
 // Cancel restores the default selection filter.
-func (t *DraftTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *DraftTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
-// ClearFaces empties the picked faces — the property panel's selector clear (⊗) —
-// returning the tool to its pick-faces step.
-func (t *DraftTool) ClearFaces() { t.faces = nil }
+// commitEdit writes the panel state back into the committed draft's definition.
+func (t *DraftTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.FaceDraftFeature).Definition()
+	def.FaceKeys = t.selectedFaceKeys()
+	def.Angle = konst(t.angleDeg * degToRad)
+	return commitFeatureEdit(s, t.target)
+}
+
+// ClearFaces empties the face selection — the picks and, in edit mode, the feature's
+// retained keys — returning the tool to its pick-faces step.
+func (t *DraftTool) ClearFaces() {
+	t.faces = nil
+	t.seededFaceKeys = nil
+}

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -19,15 +19,16 @@ import (
 // Inventor extrude flow, driven entirely by session input so a test exercises it with
 // synthetic clicks. It is the worked example proving geometry flows end to end.
 type ExtrudeTool struct {
-	profiles   []ProfileHandle
-	distance   float64 // primary depth, model units
-	distance2  float64 // asymmetric second-direction depth, model units
-	taper      float64 // draft angle, radians
-	extent     feature.ExtentType
-	direction  feature.ExtentDirection
-	asymmetric bool
-	operation  ops.PartFeatureOperation
-	added      *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed extrude (see editExtrudeTool)
+	profiles        []ProfileHandle
+	distance        float64 // primary depth, model units
+	distance2       float64 // asymmetric second-direction depth, model units
+	taper           float64 // draft angle, radians
+	extent          feature.ExtentType
+	direction       feature.ExtentDirection
+	asymmetric      bool
+	operation       ops.PartFeatureOperation
+	added           *feature.PartFeature
 }
 
 // NewExtrudeTool returns an extrude tool defaulting to a positive distance extrusion that
@@ -163,6 +164,9 @@ func (t *ExtrudeTool) CanCommit() bool {
 // must lie on one sketch (a single extrude consumes one sketch's regions); picks on
 // other sketches are ignored.
 func (t *ExtrudeTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
@@ -178,6 +182,16 @@ func (t *ExtrudeTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// commitEdit writes the panel state back into the committed extrude's definition —
+// the same properties the create path passes to AddExtrude.
+func (t *ExtrudeTool) commitEdit(s *Session) error {
+	skt := t.profiles[0].Sketch
+	def := t.target.Definition().(*feature.ExtrudeFeature).Definition()
+	def.Sketch, def.ProfileIndices = skt, profileIndicesOn(t.profiles, skt)
+	def.Operation, def.Extent, def.Taper = t.operation, t.buildExtent(), t.taper
+	return commitFeatureEdit(s, t.target)
 }
 
 // profileIndicesOn returns the region indices among handles that belong to sketch skt.
@@ -250,7 +264,13 @@ func prismWireframe(plane sketch.Plane, poly []math.Point2, dist float64) render
 }
 
 // Cancel restores the default selection filter.
-func (t *ExtrudeTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *ExtrudeTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
 // activePart returns the active document's part component definition, or an error.
 func activePart(s *Session) (*compdef.PartComponentDefinition, error) {

--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -3,8 +3,6 @@
 package app
 
 import (
-	"errors"
-
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/model/feature"
 )
@@ -83,37 +81,21 @@ func (t *FeatureEditTool) CanCommit() bool { return true }
 // Commit recomputes with the edited parameters/references and records the edit. A sick result
 // returns an error so the dialog stays open for correction.
 func (t *FeatureEditTool) Commit(s *Session) error {
-	part, err := activePart(s)
-	if err != nil {
-		return err
-	}
-	s.endEditScope() // restore full evaluation before the final rebuild
-	part.Features().MarkDirty(t.feature)
-	part.Recompute()
-	s.recordEdit(part, "Edit "+t.feature.Name())
-	s.Selection().SetFilter(NewSelectionFilter())
-	if !t.feature.Health().OK() {
-		return errors.New("feature edit: " + t.feature.Health().Reason)
-	}
-	return nil
+	return commitFeatureEdit(s, t.feature)
 }
 
 // Cancel restores the snapshotted parameters and references, recomputes, and clears the filter.
 func (t *FeatureEditTool) Cancel(s *Session) {
-	for i, p := range t.params {
-		p.Set(t.origP[i])
-	}
-	for _, restore := range t.restore {
-		if restore != nil {
-			restore()
+	cancelFeatureEdit(s, t.feature, func() {
+		for i, p := range t.params {
+			p.Set(t.origP[i])
 		}
-	}
-	s.endEditScope() // restore full evaluation before rebuilding with the reverted values
-	if part, err := activePart(s); err == nil {
-		part.Features().MarkDirty(t.feature)
-		part.Recompute()
-	}
-	s.Selection().SetFilter(NewSelectionFilter())
+		for _, restore := range t.restore {
+			if restore != nil {
+				restore()
+			}
+		}
+	})
 }
 
 // Arm puts the i-th reference slot into pick mode (its kind's filter); ClearSlot empties it.
@@ -163,17 +145,24 @@ func (t *FeatureEditTool) recompute(s *Session) {
 	}
 }
 
-// BeginEditFeature opens a feature for editing (browser double-click / Edit menu). A feature
-// with no editable parameters or references is a no-op.
+// BeginEditFeature opens a feature for editing (browser double-click / Edit menu). A
+// feature whose creation tool can round-trip its definition re-opens that tool — the
+// SAME property panel serves creation and editing, with every creation property
+// available (editToolFor). Other editable features open the generic parameter/
+// reference editor; a feature with neither is a no-op.
 func (s *Session) BeginEditFeature(h FeatureHandle) {
-	t := newFeatureEditTool(h.Feature)
-	if !t.editable() {
-		return
+	tool, ok := editToolFor(s, h.Feature)
+	if !ok {
+		t := newFeatureEditTool(h.Feature)
+		if !t.editable() {
+			return
+		}
+		tool = t
 	}
 	// StartTool first: it cancels any previous edit tool, whose Cancel restores that edit's
 	// scope — beginning our scope before that would capture the rolled-back marker and then
 	// have it cleared out from under us (the part would stay stuck mid-history after commit).
-	s.StartTool(t)
+	s.StartTool(tool)
 	s.beginEditScope(h.Feature.Seq()) // roll back to this feature: hide everything after it
 }
 

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// Edit mode for the creation tools: double-clicking a feature whose tool can round-trip
+// its definition re-opens the SAME tool (and therefore the same property panel) seeded
+// from the committed feature — every property available at creation is available while
+// editing. The tool's Commit then writes the state back into the definition instead of
+// adding a new feature; Cancel restores a definition snapshot. Features whose panel
+// cannot round-trip the definition (patterns, mirror, rib, emboss) keep the generic
+// FeatureEditTool parameter/reference editor.
+
+// featureEditMode binds a creation tool to the committed feature it re-edits. The zero
+// value means the tool is creating a new feature. Embedded by the edit-capable tools.
+type featureEditMode struct {
+	target     *feature.PartFeature
+	restoreDef func() // definition snapshot, applied on Cancel
+}
+
+// bindEdit puts the tool into edit mode over f, with restore capturing the definition
+// state to reinstate on Cancel.
+func (m *featureEditMode) bindEdit(f *feature.PartFeature, restore func()) {
+	m.target = f
+	m.restoreDef = restore
+}
+
+// IsEditing reports whether the tool re-edits a committed feature (vs creating one).
+func (m *featureEditMode) IsEditing() bool { return m.target != nil }
+
+// EditingName returns the edited feature's name for the panel breadcrumb, or "".
+func (m *featureEditMode) EditingName() string {
+	if m.target == nil {
+		return ""
+	}
+	return m.target.Name()
+}
+
+// commitFeatureEdit finishes an in-place edit after the caller mutated the definition:
+// it restores full history evaluation, recomputes with the new recipe, records the
+// transaction, and surfaces a sick feature as an error so the panel stays open.
+func commitFeatureEdit(s *Session, f *feature.PartFeature) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	s.endEditScope() // restore full evaluation before the final rebuild
+	part.Features().MarkDirty(f)
+	part.Recompute()
+	s.recordEdit(part, "Edit "+f.Name())
+	s.Selection().SetFilter(NewSelectionFilter())
+	if !f.Health().OK() {
+		return errors.New("feature edit: " + f.Health().Reason)
+	}
+	return nil
+}
+
+// cancelFeatureEdit reverts an in-place edit: the caller-provided restore reinstates the
+// definition snapshot, the edit scope ends, and the part rebuilds at the original recipe.
+func cancelFeatureEdit(s *Session, f *feature.PartFeature, restore func()) {
+	if restore != nil {
+		restore()
+	}
+	s.endEditScope()
+	if part, err := activePart(s); err == nil {
+		part.Features().MarkDirty(f)
+		part.Recompute()
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+
+// editToolFor builds the creation tool re-opened over a committed feature, or false for
+// feature kinds the generic editor still serves.
+func editToolFor(s *Session, f *feature.PartFeature) (Tool, bool) {
+	switch d := f.Definition().(type) {
+	case *feature.ExtrudeFeature:
+		return editExtrudeTool(f, d), true
+	case *feature.RevolveFeature:
+		return editRevolveTool(s, f, d), true
+	case *feature.CoilFeature:
+		return editCoilTool(s, f, d), true
+	case *feature.HoleFeature:
+		return editHoleTool(f, d), true
+	case *feature.FilletFeature:
+		return editFilletTool(f, d), true
+	case *feature.ChamferFeature:
+		return editChamferTool(f, d), true
+	case *feature.ShellFeature:
+		return editShellTool(f, d), true
+	case *feature.FaceDraftFeature:
+		return editDraftTool(f, d), true
+	default:
+		return nil, false
+	}
+}
+
+// editExtrudeTool seeds an ExtrudeTool from a committed extrude: profiles, operation,
+// extent (type, direction, distances, asymmetry) and taper — the full creation surface.
+func editExtrudeTool(f *feature.PartFeature, ext *feature.ExtrudeFeature) *ExtrudeTool {
+	def := ext.Definition()
+	t := NewExtrudeTool()
+	for _, idx := range def.ProfileIndices {
+		t.profiles = append(t.profiles, ProfileHandle{Sketch: def.Sketch, ProfileIndex: idx})
+	}
+	t.operation = def.Operation
+	t.taper = def.Taper
+	seedExtrudeExtent(t, def.Extent)
+	t.bindEdit(f, snapshotExtrudeDef(def))
+	return t
+}
+
+// seedExtrudeExtent copies a committed extent into the tool's option state.
+func seedExtrudeExtent(t *ExtrudeTool, ext feature.Extent) {
+	t.extent = ext.Type
+	t.direction = ext.Direction
+	if ext.Distance != nil {
+		t.distance = ext.Distance()
+	}
+	if ext.Distance2 != nil {
+		t.asymmetric = true
+		t.distance2 = ext.Distance2()
+	}
+}
+
+func snapshotExtrudeDef(def *feature.ExtrudeDefinition) func() {
+	orig := *def
+	orig.ProfileIndices = append([]int(nil), def.ProfileIndices...)
+	return func() { *def = orig }
+}
+
+// editRevolveTool seeds a RevolveTool from a committed revolve: profile, axis (work
+// axis, specific centerline, or the sketch's own), angle and operation.
+func editRevolveTool(s *Session, f *feature.PartFeature, rv *feature.RevolveFeature) *RevolveTool {
+	def := rv.Definition()
+	t := NewRevolveTool()
+	t.profile = &ProfileHandle{Sketch: def.Sketch, ProfileIndex: def.ProfileIndex}
+	t.angle = callOrZeroFn(def.Angle)
+	t.operation = def.Operation
+	seedRevolveAxis(s, t, def)
+	t.bindEdit(f, snapshotRevolveDef(def))
+	return t
+}
+
+// seedRevolveAxis maps the definition's axis precedence back onto the tool: a specific
+// centerline, an origin work axis (matched by identity), or the sketch's own centerline.
+func seedRevolveAxis(s *Session, t *RevolveTool, def *feature.RevolveDefinition) {
+	if def.AxisCenterline != nil {
+		t.centerline, t.centerlineSk = def.AxisCenterline, def.AxisCenterlineSketch
+		return
+	}
+	if def.Axis == nil {
+		t.useCenterln = true
+		return
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return
+	}
+	for _, ref := range []feature.WorkRef{feature.OriginXAxis, feature.OriginYAxis, feature.OriginZAxis} {
+		if a, ok := part.WorkGeometry().AxisByRef(ref); ok && a == def.Axis {
+			t.axis = ref
+			return
+		}
+	}
+}
+
+func snapshotRevolveDef(def *feature.RevolveDefinition) func() {
+	orig := *def
+	return func() { *def = orig }
+}
+
+// editCoilTool seeds a CoilTool from a committed coil: profile, axis, pitch,
+// revolutions and operation.
+func editCoilTool(s *Session, f *feature.PartFeature, c *feature.CoilFeature) *CoilTool {
+	def := c.Definition()
+	t := NewCoilTool()
+	t.profile = &ProfileHandle{Sketch: def.Sketch, ProfileIndex: def.ProfileIndex}
+	t.pitch = callOrZeroFn(def.Pitch)
+	t.revolutions = callOrZeroFn(def.Revolutions)
+	t.operation = def.Operation
+	seedCoilAxis(s, t, def.Axis)
+	t.bindEdit(f, snapshotCoilDef(def))
+	return t
+}
+
+// seedCoilAxis matches the definition's work axis back to its origin reference.
+func seedCoilAxis(s *Session, t *CoilTool, axis *feature.WorkAxis) {
+	part, err := activePart(s)
+	if err != nil || axis == nil {
+		return
+	}
+	for _, ref := range []feature.WorkRef{feature.OriginXAxis, feature.OriginYAxis, feature.OriginZAxis} {
+		if a, ok := part.WorkGeometry().AxisByRef(ref); ok && a == axis {
+			t.axis = ref
+			return
+		}
+	}
+}
+
+func snapshotCoilDef(def *feature.CoilDefinition) func() {
+	orig := *def
+	return func() { *def = orig }
+}
+
+// editHoleTool seeds a HoleTool from a committed hole: the placement-face key, the bore
+// size/termination, the seat type with its dimensions, and the drill point.
+func editHoleTool(f *feature.PartFeature, h *feature.HoleFeature) *HoleTool {
+	def := h.Definition()
+	t := NewHoleTool()
+	t.seededFaceKey = append([]byte(nil), def.PlacementFaceKey...)
+	t.diameter = callOrZeroFn(def.Diameter)
+	t.depth = callOrZeroFn(def.Depth)
+	t.through = def.ThroughAll
+	t.pointAngle = callOrZeroFn(def.PointAngle)
+	seedHoleSeat(t, def)
+	t.bindEdit(f, snapshotHoleDef(def))
+	return t
+}
+
+// seedHoleSeat copies the hole's seat profile (counterbore/countersink) into the tool.
+func seedHoleSeat(t *HoleTool, def *feature.HoleDefinition) {
+	t.counterbore = def.Type == feature.CounterboreHole
+	t.countersink = def.Type == feature.CountersinkHole
+	t.cDiameter = callOrZeroFn(def.CounterDiameter)
+	t.cDepth = callOrZeroFn(def.CounterDepth)
+	t.sinkAngle = callOrZeroFn(def.CounterAngle)
+}
+
+func snapshotHoleDef(def *feature.HoleDefinition) func() {
+	orig := *def
+	orig.PlacementFaceKey = append([]byte(nil), def.PlacementFaceKey...)
+	return func() { *def = orig }
+}
+
+// editFilletTool / editChamferTool / editShellTool / editDraftTool seed the dress-up
+// tools: the definition's reference keys are retained as the seeded selection (live
+// handles cannot exist — the feature consumed that geometry), so the panel shows the
+// count, the clear empties it, and new viewport picks extend it.
+func editFilletTool(f *feature.PartFeature, fl *feature.FilletFeature) *FilletTool {
+	def := fl.Definition()
+	t := NewFilletTool()
+	t.seededEdgeKeys = cloneKeys(def.EdgeKeys)
+	t.radius = callOrZeroFn(def.Radius)
+	t.bindEdit(f, snapshotFilletDef(def))
+	return t
+}
+
+func snapshotFilletDef(def *feature.FilletDefinition) func() {
+	orig := *def
+	orig.EdgeKeys = cloneKeys(def.EdgeKeys)
+	return func() { *def = orig }
+}
+
+func editChamferTool(f *feature.PartFeature, c *feature.ChamferFeature) *ChamferTool {
+	def := c.Definition()
+	t := NewChamferTool()
+	t.seededEdgeKeys = cloneKeys(def.EdgeKeys)
+	t.distance = callOrZeroFn(def.Distance)
+	t.flatCorners = def.FlatCorners
+	t.bindEdit(f, snapshotChamferDef(def))
+	return t
+}
+
+func snapshotChamferDef(def *feature.ChamferDefinition) func() {
+	orig := *def
+	orig.EdgeKeys = cloneKeys(def.EdgeKeys)
+	return func() { *def = orig }
+}
+
+func editShellTool(f *feature.PartFeature, sh *feature.ShellFeature) *ShellTool {
+	def := sh.Definition()
+	t := NewShellTool()
+	t.seededFaceKeys = cloneKeys(def.RemovedFaceKeys)
+	t.thickness = callOrZeroFn(def.Thickness)
+	t.bindEdit(f, snapshotShellDef(def))
+	return t
+}
+
+func snapshotShellDef(def *feature.ShellDefinition) func() {
+	orig := *def
+	orig.RemovedFaceKeys = cloneKeys(def.RemovedFaceKeys)
+	return func() { *def = orig }
+}
+
+func editDraftTool(f *feature.PartFeature, d *feature.FaceDraftFeature) *DraftTool {
+	def := d.Definition()
+	t := NewDraftTool()
+	t.seededFaceKeys = cloneKeys(def.FaceKeys)
+	t.angleDeg = callOrZeroFn(def.Angle) / degToRad
+	t.bindEdit(f, snapshotDraftDef(def))
+	return t
+}
+
+func snapshotDraftDef(def *feature.FaceDraftDefinition) func() {
+	orig := *def
+	orig.FaceKeys = cloneKeys(def.FaceKeys)
+	return func() { *def = orig }
+}
+
+// cloneKeys deep-copies a reference-key list so a snapshot survives later mutation.
+func cloneKeys(keys [][]byte) [][]byte {
+	out := make([][]byte, len(keys))
+	for i, k := range keys {
+		out[i] = append([]byte(nil), k...)
+	}
+	return out
+}
+
+// callOrZeroFn evaluates a parameter closure, treating nil as zero.
+func callOrZeroFn(f func() float64) float64 {
+	if f == nil {
+		return 0
+	}
+	return f()
+}

--- a/app/feature_edit_test.go
+++ b/app/feature_edit_test.go
@@ -2,7 +2,11 @@
 
 package app
 
-import "testing"
+import (
+	"testing"
+
+	"oblikovati.org/model/feature"
+)
 
 // extrudedFeatureSession returns a session with one committed extrude (5 cm tall, 2×2
 // base) and a handle to that feature — the starting point for the edit-on-double-click
@@ -20,23 +24,27 @@ func extrudedFeatureSession(t *testing.T) (*Session, FeatureHandle) {
 	return s, FeatureHandle{Feature: ext.AddedFeature()}
 }
 
-func TestBeginEditFeatureOpensExtrudeAtItsDistance(t *testing.T) {
+// TestBeginEditFeatureReopensExtrudePanel locks the unified edit flow: double-clicking
+// a committed extrude re-opens the Extrude property panel (the creation tool in edit
+// mode) seeded with the feature's full creation state — not the generic param editor.
+func TestBeginEditFeatureReopensExtrudePanel(t *testing.T) {
 	s, h := extrudedFeatureSession(t)
 	s.BeginEditFeature(h)
-	if !s.IsEditingFeature() {
-		t.Fatal("BeginEditFeature should open an edit for an extrude")
+	ext := s.ActiveExtrude()
+	if ext == nil {
+		t.Fatal("BeginEditFeature should re-open the Extrude tool for an extrude")
 	}
-	if s.EditingFeatureName() != h.Feature.Name() {
-		t.Errorf("editing name = %q, want %q", s.EditingFeatureName(), h.Feature.Name())
+	if !ext.IsEditing() || ext.EditingName() != h.Feature.Name() {
+		t.Errorf("edit binding = (%v, %q), want (true, %q)", ext.IsEditing(), ext.EditingName(), h.Feature.Name())
 	}
-	if n := s.EditFeatureParamCount(); n != 1 {
-		t.Fatalf("extrude editable param count = %d, want 1 (Distance)", n)
+	if s.IsEditingFeature() {
+		t.Error("the generic feature editor must not be open for an extrude")
 	}
-	if l := s.EditFeatureParamLabel(0); l != "Distance" {
-		t.Errorf("param 0 label = %q, want %q", l, "Distance")
+	if n := len(ext.PickedProfiles()); n != 1 {
+		t.Errorf("seeded profile count = %d, want 1", n)
 	}
-	// Database 5 cm shows as 50 mm in the document's display unit.
-	if d := s.EditFeatureParamValue(0); d < 49.99 || d > 50.01 {
+	// Database 5 cm shows as 50 mm in the document's display unit (the panel field).
+	if d := s.ExtrudeDistanceDisplay(); d < 49.99 || d > 50.01 {
 		t.Errorf("edit distance display = %v, want ~50 mm", d)
 	}
 }
@@ -44,12 +52,12 @@ func TestBeginEditFeatureOpensExtrudeAtItsDistance(t *testing.T) {
 func TestCommitFeatureEditRecomputesTheBody(t *testing.T) {
 	s, h := extrudedFeatureSession(t)
 	s.BeginEditFeature(h)
-	s.SetEditFeatureParamValue(0, 80) // 80 mm = 8 cm
-	if err := s.OK(); err != nil {    // OK commits the active feature-edit tool
+	s.SetExtrudeDistanceDisplay(80) // 80 mm = 8 cm, via the panel path
+	if err := s.OK(); err != nil {  // OK commits the edit-mode tool
 		t.Fatalf("commit feature edit: %v", err)
 	}
-	if s.IsEditingFeature() {
-		t.Error("a successful commit should close the edit")
+	if s.ActiveExtrude() != nil {
+		t.Error("a successful commit should close the edit panel")
 	}
 	if z := partBodies(s)()[0].RangeBox().Diagonal().Z; z < 7.99 || z > 8.01 {
 		t.Errorf("body height after edit = %v, want ~8 cm", z)
@@ -59,13 +67,42 @@ func TestCommitFeatureEditRecomputesTheBody(t *testing.T) {
 func TestCancelFeatureEditRestoresTheDistance(t *testing.T) {
 	s, h := extrudedFeatureSession(t)
 	s.BeginEditFeature(h)
-	s.SetEditFeatureParamValue(0, 80) // change it, then back out
+	s.SetExtrudeDistanceDisplay(80) // change it, then back out
 	s.CancelTool()
-	if s.IsEditingFeature() {
-		t.Error("cancel should close the edit")
+	if s.ActiveExtrude() != nil {
+		t.Error("cancel should close the edit panel")
 	}
 	if z := partBodies(s)()[0].RangeBox().Diagonal().Z; z < 4.99 || z > 5.01 {
 		t.Errorf("body height after cancel = %v, want ~5 cm (unchanged)", z)
+	}
+}
+
+// TestExtrudeEditRoundTripsFullCreationSurface locks "every creation property is
+// editable": operation, taper, extent direction and asymmetry survive a commit and land
+// in the definition.
+func TestExtrudeEditRoundTripsFullCreationSurface(t *testing.T) {
+	s, h := extrudedFeatureSession(t)
+	s.BeginEditFeature(h)
+	ext := s.ActiveExtrude()
+	ext.SetTaper(0.1)
+	ext.SetAsymmetric(true)
+	ext.SetSecondDistance(2)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit full-surface edit: %v", err)
+	}
+	def := h.Feature.Definition().(*feature.ExtrudeFeature)
+	if got := def.Taper(); got < 0.099 || got > 0.101 {
+		t.Errorf("taper after edit = %v, want 0.1", got)
+	}
+	if def.Extent().Distance2 == nil {
+		t.Fatal("asymmetric second distance did not reach the definition")
+	}
+	if d2 := def.Extent().Distance2(); d2 < 1.99 || d2 > 2.01 {
+		t.Errorf("second distance after edit = %v, want 2", d2)
+	}
+	// The body now spans -2..+5 along Z: 7 cm tall.
+	if z := partBodies(s)()[0].RangeBox().Diagonal().Z; z < 6.99 || z > 7.01 {
+		t.Errorf("body height after asymmetric edit = %v, want ~7 cm", z)
 	}
 }
 
@@ -87,5 +124,81 @@ func TestFeatureEditIsEditableReflectsCapability(t *testing.T) {
 	_ = s
 	if !FeatureIsEditable(h.Feature) {
 		t.Error("an extrude should be editable")
+	}
+}
+
+// TestFilletEditSeedsKeysAndRoundTrips locks the dress-up edit flow: editing a fillet
+// re-opens the Fillet panel with the feature's edges retained as the seeded selection
+// (their topology was consumed, so only keys survive), and a radius change written
+// through the panel lands in the definition on commit.
+func TestFilletEditSeedsKeysAndRoundTrips(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	edge := verticalEdgeOf(t, block)
+	s.SetPicker(stubPicker{sel: edge})
+	create := NewFilletTool()
+	s.StartTool(create)
+	s.Click(50, 50)
+	create.SetRadius(0.5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("seed fillet: %v", err)
+	}
+
+	s.BeginEditFeature(FeatureHandle{Feature: create.AddedFeature()})
+	f := s.ActiveFillet()
+	if f == nil {
+		t.Fatal("BeginEditFeature should re-open the Fillet panel for a fillet")
+	}
+	if !f.IsEditing() || f.EdgeCount() != 1 {
+		t.Fatalf("edit binding = (%v, %d edges), want (true, 1 seeded edge)", f.IsEditing(), f.EdgeCount())
+	}
+	f.SetRadius(0.25)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit fillet edit: %v", err)
+	}
+	def := create.AddedFeature().Definition().(*feature.FilletFeature).Definition()
+	if r := def.Radius(); r < 0.249 || r > 0.251 {
+		t.Errorf("radius after edit = %v, want 0.25", r)
+	}
+	if len(def.EdgeKeys) != 1 {
+		t.Errorf("edge keys after edit = %d, want the retained 1", len(def.EdgeKeys))
+	}
+}
+
+// TestHoleEditSwitchesSeatType locks that the Hole panel's full creation surface is
+// editable: a drilled hole becomes a counterbore on edit-commit, with the seat
+// dimensions written into the definition.
+func TestHoleEditSwitchesSeatType(t *testing.T) {
+	s, block := newPartWithBlock(t, 4)
+	top := topFaceOf(t, block)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+	create := NewHoleTool()
+	s.StartTool(create)
+	s.Click(50, 50)
+	create.SetDiameter(0.6)
+	create.SetDepth(1.5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("seed hole: %v", err)
+	}
+
+	s.BeginEditFeature(FeatureHandle{Feature: create.AddedFeature()})
+	h := s.ActiveHole()
+	if h == nil {
+		t.Fatal("BeginEditFeature should re-open the Hole panel for a hole")
+	}
+	if !h.HasPlacement() {
+		t.Fatal("the placement face must be retained from the definition")
+	}
+	h.SetCounterbore(true)
+	h.SetCounterDiameter(1.0)
+	h.SetCounterDepth(0.4)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit hole edit: %v", err)
+	}
+	def := create.AddedFeature().Definition().(*feature.HoleFeature).Definition()
+	if def.Type != feature.CounterboreHole {
+		t.Errorf("hole type after edit = %v, want CounterboreHole", def.Type)
+	}
+	if d := def.CounterDiameter(); d < 0.99 || d > 1.01 {
+		t.Errorf("counter diameter after edit = %v, want 1.0", d)
 	}
 }

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -12,9 +12,11 @@ import (
 // set the radius in the property window, and OK to round them. Each picked edge becomes a
 // rolling-ball cylinder blend on the active part.
 type FilletTool struct {
-	edges  []EdgeHandle
-	radius float64
-	added  *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed fillet (see editFilletTool)
+	edges           []EdgeHandle
+	seededEdgeKeys  [][]byte // edit mode: the feature's existing edge keys (their edges are consumed, so no live handles exist)
+	radius          float64
+	added           *feature.PartFeature
 }
 
 // NewFilletTool returns a fillet tool with a default 1-unit radius.
@@ -51,22 +53,35 @@ func (t *FilletTool) Radius() float64     { return t.radius }
 // Edges returns the picked edges (for the UI to list/highlight).
 func (t *FilletTool) Edges() []EdgeHandle { return append([]EdgeHandle(nil), t.edges...) }
 
-// CanCommit reports whether at least one edge is picked and the radius is positive.
-func (t *FilletTool) CanCommit() bool { return len(t.edges) > 0 && t.radius > 0 }
+// EdgeCount counts the selection the panel shows: edges picked this session plus, in
+// edit mode, the feature's retained edges.
+func (t *FilletTool) EdgeCount() int { return len(t.seededEdgeKeys) + len(t.edges) }
+
+// selectedEdgeKeys is the reference-key set a commit writes: the retained keys plus
+// this session's picks.
+func (t *FilletTool) selectedEdgeKeys() [][]byte {
+	keys := cloneKeys(t.seededEdgeKeys)
+	for _, e := range t.edges {
+		keys = append(keys, e.Edge.ReferenceKey())
+	}
+	return keys
+}
+
+// CanCommit reports whether at least one edge is selected and the radius is positive.
+func (t *FilletTool) CanCommit() bool { return t.EdgeCount() > 0 && t.radius > 0 }
 
 // Commit rounds the picked edges on the active part and recomputes; a sick feature (a
 // non-convex edge or a radius that overruns the geometry) keeps the tool open via an error.
 func (t *FilletTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.edges))
-	for i, e := range t.edges {
-		keys[i] = e.Edge.ReferenceKey()
-	}
 	r := t.radius
-	t.added = feature.NewDressUpFeatures(part.Features()).AddFillet(keys, func() float64 { return r })
+	t.added = feature.NewDressUpFeatures(part.Features()).AddFillet(t.selectedEdgeKeys(), func() float64 { return r })
 	part.Recompute()
 	s.recordEdit(part, "Fillet")
 	if !t.added.Health().OK() {
@@ -88,8 +103,25 @@ func (t *FilletTool) Prompt(*Session) string {
 }
 
 // Cancel restores the default selection filter.
-func (t *FilletTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *FilletTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
-// ClearEdges empties the picked edges — the property panel's selector clear (⊗) —
-// returning the tool to its pick-edges step.
-func (t *FilletTool) ClearEdges() { t.edges = nil }
+// commitEdit writes the panel state back into the committed fillet's definition.
+func (t *FilletTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.FilletFeature).Definition()
+	def.EdgeKeys = t.selectedEdgeKeys()
+	def.Radius = konst(t.radius)
+	return commitFeatureEdit(s, t.target)
+}
+
+// ClearEdges empties the edge selection — the picks and, in edit mode, the feature's
+// retained keys — returning the tool to its pick-edges step.
+func (t *FilletTool) ClearEdges() {
+	t.edges = nil
+	t.seededEdgeKeys = nil
+}

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -14,17 +14,19 @@ import (
 // the face centroid along the inward normal) into the active part. Diameter and depth are
 // in database units; the property window converts to the document's display unit.
 type HoleTool struct {
-	face        *FaceHandle
-	diameter    float64
-	depth       float64
-	through     bool // Through All: drill through the part with a true cylinder wall
-	counterbore bool // counterbore: a flat recess above the bore
-	countersink bool // countersink: a conical recess above the bore
-	cDiameter   float64
-	cDepth      float64
-	sinkAngle   float64 // countersink included angle (radians)
-	pointAngle  float64 // drilled blind-hole drill point: included angle (radians; 0 = flat)
-	added       *feature.PartFeature
+	featureEditMode             // set ⇒ this panel re-edits a committed hole (see editHoleTool)
+	face            *FaceHandle // placement face picked this session
+	seededFaceKey   []byte      // edit mode: the feature's existing placement-face key
+	diameter        float64
+	depth           float64
+	through         bool // Through All: drill through the part with a true cylinder wall
+	counterbore     bool // counterbore: a flat recess above the bore
+	countersink     bool // countersink: a conical recess above the bore
+	cDiameter       float64
+	cDepth          float64
+	sinkAngle       float64 // countersink included angle (radians)
+	pointAngle      float64 // drilled blind-hole drill point: included angle (radians; 0 = flat)
+	added           *feature.PartFeature
 }
 
 // NewHoleTool returns a hole tool with a default Ø1 × 2 drilled hole and a 118° drill point
@@ -89,9 +91,25 @@ func (t *HoleTool) SinkAngle() float64     { return t.sinkAngle }
 func (t *HoleTool) SetPointAngle(a float64) { t.pointAngle = a }
 func (t *HoleTool) PointAngle() float64     { return t.pointAngle }
 
-// ClearFace empties the picked placement face — the property panel's selector clear
-// (⊗) — returning the tool to its pick-a-face step.
-func (t *HoleTool) ClearFace() { t.face = nil }
+// ClearFace empties the placement face — the picked one and, in edit mode, the
+// feature's retained key — returning the tool to its pick-a-face step.
+func (t *HoleTool) ClearFace() {
+	t.face = nil
+	t.seededFaceKey = nil
+}
+
+// HasPlacement reports whether a placement face is set: picked this session or, in
+// edit mode, retained from the feature's definition. The property panel's chip state.
+func (t *HoleTool) HasPlacement() bool { return t.face != nil || len(t.seededFaceKey) > 0 }
+
+// placementKey is the reference key the commit writes: a fresh pick wins over the
+// retained one.
+func (t *HoleTool) placementKey() []byte {
+	if t.face != nil {
+		return t.face.Face.ReferenceKey()
+	}
+	return t.seededFaceKey
+}
 
 // PickedFace returns the placement face (and true), or false when none picked yet.
 func (t *HoleTool) PickedFace() (FaceHandle, bool) {
@@ -105,7 +123,7 @@ func (t *HoleTool) PickedFace() (FaceHandle, bool) {
 // (unless Through All), and — for a counterbore — the recess is larger than the bore and shallow
 // enough to leave bore below it.
 func (t *HoleTool) CanCommit() bool {
-	if t.face == nil || t.diameter <= 0 || (!t.through && t.depth <= 0) {
+	if !t.HasPlacement() || t.diameter <= 0 || (!t.through && t.depth <= 0) {
 		return false
 	}
 	if t.counterbore && !t.counterboreValid() {
@@ -132,6 +150,9 @@ func (t *HoleTool) countersinkValid() bool {
 // Commit drills the hole into the active part and recomputes; a sick feature (lost face,
 // boolean failure) keeps the tool open by returning an error.
 func (t *HoleTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
@@ -169,6 +190,31 @@ func (t *HoleTool) addFeature(holes *feature.HoleFeatures) *feature.PartFeature 
 	}
 }
 
+// commitEdit writes the panel state back into the committed hole's definition — the
+// same properties the create path captures, including a seat-type change.
+func (t *HoleTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.HoleFeature).Definition()
+	def.PlacementFaceKey = t.placementKey()
+	def.Diameter, def.Depth = konst(t.diameter), konst(t.depth)
+	def.ThroughAll = t.through
+	def.PointAngle = konst(t.pointAngle)
+	def.CounterDiameter, def.CounterDepth, def.CounterAngle = konst(t.cDiameter), konst(t.cDepth), konst(t.sinkAngle)
+	def.Type = t.holeType()
+	return commitFeatureEdit(s, t.target)
+}
+
+// holeType maps the tool's mutually-exclusive seat flags onto the definition's type.
+func (t *HoleTool) holeType() feature.HoleType {
+	switch {
+	case t.counterbore:
+		return feature.CounterboreHole
+	case t.countersink:
+		return feature.CountersinkHole
+	default:
+		return feature.DrilledHole
+	}
+}
+
 // konst wraps a captured value as a parameter closure.
 func konst(v float64) func() float64 { return func() float64 { return v } }
 
@@ -184,4 +230,10 @@ func (t *HoleTool) Prompt(*Session) string {
 }
 
 // Cancel restores the default selection filter.
-func (t *HoleTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *HoleTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -49,14 +49,15 @@ func preselectCenterline(profileSketch *sketch.Sketch, sketches []*sketch.Sketch
 // add a revolve feature to the active part. It mirrors [ExtrudeTool] and is driven
 // entirely by session input so a test exercises the full flow with synthetic clicks.
 type RevolveTool struct {
-	profile      *ProfileHandle
-	axis         feature.WorkRef // origin axis (X/Y/Z) or a user work axis (fallback)
-	useCenterln  bool            // revolve about the sketch's own (single) centerline
-	centerline   *sketch.Line    // a specific centerline picked/pre-selected as the axis
-	centerlineSk *sketch.Sketch  // the centerline's sketch
-	angle        float64         // swept angle in radians; 0 ⇒ full revolution
-	operation    ops.PartFeatureOperation
-	added        *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed revolve (see editRevolveTool)
+	profile         *ProfileHandle
+	axis            feature.WorkRef // origin axis (X/Y/Z) or a user work axis (fallback)
+	useCenterln     bool            // revolve about the sketch's own (single) centerline
+	centerline      *sketch.Line    // a specific centerline picked/pre-selected as the axis
+	centerlineSk    *sketch.Sketch  // the centerline's sketch
+	angle           float64         // swept angle in radians; 0 ⇒ full revolution
+	operation       ops.PartFeatureOperation
+	added           *feature.PartFeature
 }
 
 // NewRevolveTool returns a revolve tool defaulting to a full revolution about the Y
@@ -223,6 +224,9 @@ func (t *RevolveTool) SourceSketchName() string {
 // Commit adds the revolve feature to the active part and recomputes; a sick feature
 // (open profile, missing axis) keeps the tool open by returning an error.
 func (t *RevolveTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
@@ -236,6 +240,42 @@ func (t *RevolveTool) Commit(s *Session) error {
 		return errors.New("revolve: " + t.added.Health().Reason)
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// commitEdit writes the panel state back into the committed revolve's definition,
+// mirroring the create path's axis precedence (explicit axis / picked centerline / the
+// sketch's own centerline).
+func (t *RevolveTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.RevolveFeature).Definition()
+	def.Sketch, def.ProfileIndex = t.profile.Sketch, t.profile.ProfileIndex
+	angle := t.angle
+	def.Angle = func() float64 { return angle }
+	def.Operation = t.operation
+	if err := t.writeEditAxis(s, def); err != nil {
+		return err
+	}
+	return commitFeatureEdit(s, t.target)
+}
+
+// writeEditAxis maps the tool's axis choice back onto the definition's precedence trio.
+func (t *RevolveTool) writeEditAxis(s *Session, def *feature.RevolveDefinition) error {
+	def.Axis, def.AxisCenterline, def.AxisCenterlineSketch = nil, nil, nil
+	switch {
+	case t.centerline != nil:
+		def.AxisCenterline, def.AxisCenterlineSketch = t.centerline, t.centerlineSk
+	case t.useCenterln: // the definition's auto case: all three axis fields nil
+	default:
+		part, err := activePart(s)
+		if err != nil {
+			return err
+		}
+		axis, ok := part.WorkGeometry().AxisByRef(t.axis)
+		if !ok {
+			return errors.New("revolve edit: axis " + string(t.axis) + " not found")
+		}
+		def.Axis = axis
+	}
 	return nil
 }
 
@@ -287,7 +327,13 @@ func (t *RevolveTool) Preview(*Session) []renderer.DrawItem {
 }
 
 // Cancel restores the default selection filter.
-func (t *RevolveTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *RevolveTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
 // FullTurn is the swept angle of a complete revolution, for the property window's
 // "Full" button to set an explicit angle when the user switches to a partial angle.

--- a/app/shell_tool.go
+++ b/app/shell_tool.go
@@ -12,9 +12,11 @@ import (
 // (the openings), set the wall thickness in the property window, and OK to hollow the
 // active part to that thickness.
 type ShellTool struct {
-	faces     []FaceHandle
-	thickness float64
-	added     *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed shell (see editShellTool)
+	faces           []FaceHandle
+	seededFaceKeys  [][]byte // edit mode: the feature's existing removed-face keys
+	thickness       float64
+	added           *feature.PartFeature
 }
 
 // NewShellTool returns a shell tool with a default 1-unit wall thickness.
@@ -55,21 +57,34 @@ func (t *ShellTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.fa
 // CanCommit reports whether at least one face is picked and the thickness is positive.
 // (A shell with no removed faces hollows to a closed void, which our planar engine does
 // not yet build, so we require at least one opening.)
-func (t *ShellTool) CanCommit() bool { return len(t.faces) > 0 && t.thickness > 0 }
+func (t *ShellTool) CanCommit() bool { return t.FaceCount() > 0 && t.thickness > 0 }
+
+// FaceCount counts the selection the panel shows: faces picked this session plus, in
+// edit mode, the feature's retained faces.
+func (t *ShellTool) FaceCount() int { return len(t.seededFaceKeys) + len(t.faces) }
+
+// selectedFaceKeys is the reference-key set a commit writes: the retained keys plus
+// this session's picks.
+func (t *ShellTool) selectedFaceKeys() [][]byte {
+	keys := cloneKeys(t.seededFaceKeys)
+	for _, f := range t.faces {
+		keys = append(keys, f.Face.ReferenceKey())
+	}
+	return keys
+}
 
 // Commit hollows the active part to the wall thickness, opening the picked faces, and
 // recomputes; a sick feature keeps the tool open by returning an error.
 func (t *ShellTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.faces))
-	for i, f := range t.faces {
-		keys[i] = f.Face.ReferenceKey()
-	}
 	th := t.thickness
-	t.added = feature.NewDressUpFeatures(part.Features()).AddShell(keys, func() float64 { return th })
+	t.added = feature.NewDressUpFeatures(part.Features()).AddShell(t.selectedFaceKeys(), func() float64 { return th })
 	part.Recompute()
 	s.recordEdit(part, "Shell")
 	if !t.added.Health().OK() {
@@ -91,8 +106,25 @@ func (t *ShellTool) Prompt(*Session) string {
 }
 
 // Cancel restores the default selection filter.
-func (t *ShellTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *ShellTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}
 
-// ClearFaces empties the picked faces — the property panel's selector clear (⊗) —
-// returning the tool to its pick-faces step.
-func (t *ShellTool) ClearFaces() { t.faces = nil }
+// commitEdit writes the panel state back into the committed shell's definition.
+func (t *ShellTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.ShellFeature).Definition()
+	def.RemovedFaceKeys = t.selectedFaceKeys()
+	def.Thickness = konst(t.thickness)
+	return commitFeatureEdit(s, t.target)
+}
+
+// ClearFaces empties the face selection — the picks and, in edit mode, the feature's
+// retained keys — returning the tool to its pick-faces step.
+func (t *ShellTool) ClearFaces() {
+	t.faces = nil
+	t.seededFaceKeys = nil
+}

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -15,27 +15,32 @@ import (
 var chamferUI = struct {
 	distance    float32
 	flatCorners bool
-	open        bool
+	seeded      *app.ChamferTool // the tool the fields were seeded from (nil = none)
 }{distance: 1, flatCorners: true}
 
-// drawChamferDialog shows the Chamfer property panel while the Chamfer tool is active.
+// drawChamferDialog shows the Chamfer property panel while the Chamfer tool is active —
+// creating a chamfer or re-editing a committed one (the same panel serves both).
 func drawChamferDialog(s *app.Session) {
 	c := s.ActiveChamfer()
 	if c == nil {
-		chamferUI.open = false
+		chamferUI.seeded = nil
 		return
 	}
-	if !chamferUI.open {
+	if chamferUI.seeded != c {
 		chamferUI.distance = float32(c.Distance())
 		chamferUI.flatCorners = c.FlatCorners()
-		chamferUI.open = true
+		chamferUI.seeded = c
 	}
 	native.SetNextWindowSizeOnce(340, 250)
 	if native.Begin("Chamfer") {
-		drawFeatureBreadcrumb("Chamfer", "")
+		title := "Chamfer"
+		if name := c.EditingName(); name != "" {
+			title = name // re-editing a committed chamfer: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
 		if propertySection("Input Geometry") {
-			drawPickChipRow("Edges", "chamfer-edges", countChipText(len(c.Edges()), "Edge", "Select Edges"),
-				len(c.Edges()) > 0, "Click edges in the viewport to bevel", c.ClearEdges)
+			drawPickChipRow("Edges", "chamfer-edges", countChipText(c.EdgeCount(), "Edge", "Select Edges"),
+				c.EdgeCount() > 0, "Click edges in the viewport to bevel", c.ClearEdges)
 		}
 		if propertySection("Behavior") {
 			drawChamferBehaviorRows(s, c)

--- a/head/ui/coil_dialog.go
+++ b/head/ui/coil_dialog.go
@@ -15,7 +15,7 @@ import (
 // outlined by the tool's preview.
 var coilUI = struct {
 	pitch, revolutions float32
-	open               bool
+	seeded             *app.CoilTool // the tool the fields were seeded from (nil = none)
 }{pitch: 1, revolutions: 3}
 
 // drawCoilDialog shows the Coil property panel while the Coil tool is active, syncing
@@ -23,13 +23,17 @@ var coilUI = struct {
 func drawCoilDialog(s *app.Session) {
 	c := s.ActiveCoil()
 	if c == nil {
-		coilUI.open = false
+		coilUI.seeded = nil
 		return
 	}
 	refreshCoilUI(c)
 	native.SetNextWindowSizeOnce(340, 340)
 	if native.Begin("Coil") {
-		drawFeatureBreadcrumb("Coil", c.SourceSketchName())
+		title := "Coil"
+		if name := c.EditingName(); name != "" {
+			title = name // re-editing a committed coil: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, c.SourceSketchName())
 		drawCoilInputGeometry(c)
 		drawCoilBehavior(s, c)
 		drawCoilOutput(c)
@@ -40,12 +44,12 @@ func drawCoilDialog(s *app.Session) {
 }
 
 func refreshCoilUI(c *app.CoilTool) {
-	if coilUI.open {
+	if coilUI.seeded == c {
 		return
 	}
 	coilUI.pitch = float32(c.Pitch())
 	coilUI.revolutions = float32(c.Revolutions())
-	coilUI.open = true
+	coilUI.seeded = c
 }
 
 // drawCoilInputGeometry is the Input Geometry section: the required Profiles chip and

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -13,27 +13,32 @@ import (
 // (the reference panel schema) shows the picked-faces chip and the signed draft angle,
 // then OK/Cancel.
 var draftUI = struct {
-	angle float32
-	open  bool
+	angle  float32
+	seeded *app.DraftTool // the tool the fields were seeded from (nil = none)
 }{angle: 3}
 
-// drawDraftDialog shows the Draft property panel while the Draft tool is active.
+// drawDraftDialog shows the Draft property panel while the Draft tool is active —
+// creating a draft or re-editing a committed one (the same panel serves both).
 func drawDraftDialog(s *app.Session) {
 	d := s.ActiveDraft()
 	if d == nil {
-		draftUI.open = false
+		draftUI.seeded = nil
 		return
 	}
-	if !draftUI.open {
+	if draftUI.seeded != d {
 		draftUI.angle = float32(d.AngleDegrees())
-		draftUI.open = true
+		draftUI.seeded = d
 	}
 	native.SetNextWindowSizeOnce(340, 230)
 	if native.Begin("Draft") {
-		drawFeatureBreadcrumb("Draft", "")
+		title := "Draft"
+		if name := d.EditingName(); name != "" {
+			title = name // re-editing a committed draft: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
 		if propertySection("Input Geometry") {
-			drawPickChipRow("Faces", "draft-faces", countChipText(len(d.Faces()), "Face", "Select Faces"),
-				len(d.Faces()) > 0, "Click faces in the viewport to draft", d.ClearFaces)
+			drawPickChipRow("Faces", "draft-faces", countChipText(d.FaceCount(), "Face", "Select Faces"),
+				d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
 		}
 		if propertySection("Behavior") {
 			propertyFloatRow("Angle", "draft-angle", "deg (+out / −in)", &draftUI.angle)

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -18,24 +18,26 @@ import (
 // picked profile is highlighted in the viewport with a live prism preview. Distances
 // are in the document's length unit (e.g. mm), the taper in its angle unit (e.g. deg).
 
-// extrudeUI holds the panel's editable fields across frames and whether the panel was
-// open last frame (so it seeds the fields once when the tool opens).
+// extrudeUI holds the panel's editable fields across frames, keyed by the tool they
+// were seeded from — so switching straight from one extrude (or one feature edit) to
+// another reseeds instead of carrying stale values into the new tool.
 var extrudeUI = struct {
 	distance, second, taper float32
-	open                    bool
+	seeded                  *app.ExtrudeTool
 }{distance: 10}
 
 // drawExtrudeDialog shows the Extrusion property panel while the Extrude tool is
-// active, syncing every control with the tool each frame; OK commits, Cancel aborts.
+// active — creating a feature or re-editing a committed one (the same panel serves
+// both) — syncing every control with the tool each frame; OK commits, Cancel aborts.
 func drawExtrudeDialog(s *app.Session) {
 	ext := s.ActiveExtrude()
 	if ext == nil {
-		extrudeUI.open = false
+		extrudeUI.seeded = nil
 		return
 	}
-	if !extrudeUI.open { // tool just opened — seed the fields from its current state
+	if extrudeUI.seeded != ext { // tool just opened — seed the fields from its state
 		seedExtrudeFields(s)
-		extrudeUI.open = true
+		extrudeUI.seeded = ext
 	}
 	native.SetNextWindowSizeOnce(340, 430)
 	if native.Begin("Extrusion") {
@@ -61,8 +63,13 @@ func seedExtrudeFields(s *app.Session) {
 
 // drawExtrudeHeader renders the panel breadcrumb — the feature name and, once a profile
 // is picked, the sketch it extrudes (the reference panel's "Extrusion > Sketch" trail).
+// Re-editing a committed extrude names that feature instead.
 func drawExtrudeHeader(ext *app.ExtrudeTool) {
-	drawFeatureBreadcrumb("Extrusion", ext.SourceSketchName())
+	title := "Extrusion"
+	if name := ext.EditingName(); name != "" {
+		title = name
+	}
+	drawFeatureBreadcrumb(title, ext.SourceSketchName())
 }
 
 // drawExtrudeInputGeometry is the Input Geometry section: the Profiles selection chip

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -78,6 +78,14 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		s.StartTool(app.NewSplitTool())
 	case "fillet":
 		s.StartTool(app.NewFilletTool())
+	case "edit-extrude": // commit an extrude, then re-open it for editing (the unified flow)
+		ext := app.NewExtrudeTool()
+		s.StartTool(ext)
+		ext.Pick(s, profile)
+		ext.SetDistance(3)
+		if err := s.OK(); err == nil {
+			s.BeginEditFeature(app.FeatureHandle{Feature: ext.AddedFeature()})
+		}
 	default:
 		ext := app.NewExtrudeTool()
 		s.StartTool(ext)

--- a/head/ui/feature_edit_dialog.go
+++ b/head/ui/feature_edit_dialog.go
@@ -6,17 +6,18 @@ package ui
 
 import (
 	"fmt"
+	"strconv"
 
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
 
-// The feature-edit flow in the head: double-clicking a feature in the model browser (or its
-// "Edit" context-menu entry) opens this dialog. It shows one field per editable scalar
-// parameter (distance, radius, angle, diameter …) AND a row per geometric reference slot
-// (the fillet's edges, a hole's placement face …) with Select (re-pick in the viewport) and
-// Clear buttons. Editing is an interactive tool, so OK = s.OK() (commit), Cancel =
-// s.CancelTool() (restore). Each field shows the document's unit for that quantity.
+// The generic feature editor: features whose creation panel can round-trip their
+// definition re-open that panel instead (app.BeginEditFeature dispatch); this dialog
+// serves the rest (patterns, mirror, rib, emboss). It follows the same property-panel
+// schema — an Input Geometry section of armable reference-slot chips and a Behavior
+// section of scalar rows — so editing looks the same everywhere. OK = s.OK() (commit),
+// Cancel = s.CancelTool() (restore). Each field shows the document's unit.
 
 // featureEditUI holds the dialog's per-parameter field values across frames, keyed by the
 // feature being edited — so switching directly from one feature's edit to another's reseeds
@@ -26,7 +27,8 @@ var featureEditUI struct {
 	editing string // EditingFeatureName of the feature the fields were seeded from ("" = none)
 }
 
-// drawFeatureEditDialog shows the parameter + reference editor while a feature edit is open.
+// drawFeatureEditDialog shows the parameter + reference editor while a generic feature
+// edit is open.
 func drawFeatureEditDialog(s *app.Session) {
 	if !s.IsEditingFeature() {
 		featureEditUI.editing = ""
@@ -35,11 +37,12 @@ func drawFeatureEditDialog(s *app.Session) {
 	nParams := s.EditFeatureParamCount()
 	nRefs := s.EditFeatureRefSlotCount()
 	refreshFeatureEditUI(s, nParams)
-	native.SetNextWindowSize(320, float32(108+nParams*30+nRefs*30))
+	native.SetNextWindowSizeOnce(340, float32(150+nParams*28+nRefs*28))
 	if native.Begin("Edit Feature") {
-		native.Text(s.EditingFeatureName())
-		drawEditParams(s, nParams)
+		drawFeatureBreadcrumb(s.EditingFeatureName(), "")
 		drawEditRefSlots(s, nRefs)
+		drawEditParams(s, nParams)
+		native.Separator()
 		drawFeatureEditButtons(s)
 	}
 	native.End()
@@ -69,44 +72,61 @@ func drawFeatureEditButtons(s *app.Session) {
 	}
 }
 
-// drawEditParams renders one field per editable scalar (an integer field for whole-number
-// inputs like a pattern count), syncing it to the feature.
+// drawEditRefSlots is the Input Geometry section: one armable chip per reference slot.
+// Clicking a chip arms its slot for viewport picking; × clears a clearable slot.
+func drawEditRefSlots(s *app.Session, n int) {
+	if n == 0 || !propertySection("Input Geometry") {
+		return
+	}
+	for i := 0; i < n; i++ {
+		label := s.EditFeatureRefSlotLabel(i)
+		propertyRow(label)
+		text := editSlotChipText(s.EditFeatureRefSlotRefCount(i), label)
+		arm, clear := propertyArmableSlotChip(fmt.Sprintf("edit-ref-%d", i), text,
+			s.EditFeatureRefSlotRefCount(i) > 0, s.EditFeatureRefSlotArmed(i), s.EditFeatureRefSlotClearable(i))
+		if arm {
+			s.EditFeatureArmRefSlot(i)
+		}
+		if clear {
+			s.EditFeatureClearRefSlot(i)
+		}
+	}
+}
+
+// editSlotChipText is the slot chip caption: the reference panel's generic "N Selected"
+// once filled, the slot's own prompt while empty.
+func editSlotChipText(count int, label string) string {
+	if count == 0 {
+		return "Select " + label
+	}
+	return strconv.Itoa(count) + " Selected"
+}
+
+// drawEditParams is the Behavior section: one row per editable scalar (an integer field
+// for whole-number inputs like a pattern count), synced to the feature each frame.
 func drawEditParams(s *app.Session, n int) {
+	if n == 0 || !propertySection("Behavior") {
+		return
+	}
 	for i := 0; i < n && i < len(featureEditUI.values); i++ {
-		label := s.EditFeatureParamLabel(i)
-		if u := s.EditFeatureParamUnitName(i); u != "" {
-			label += " (" + u + ")"
-		}
-		native.Text(label)
-		if s.EditFeatureParamIsInteger(i) {
-			iv := int32(featureEditUI.values[i] + 0.5)
-			native.InputInt(fmt.Sprintf("##edit-feature-param-%d", i), &iv)
-			featureEditUI.values[i] = float32(iv)
-		} else {
-			native.InputFloat(fmt.Sprintf("##edit-feature-param-%d", i), &featureEditUI.values[i])
-		}
+		drawEditParamRow(s, i)
 		s.SetEditFeatureParamValue(i, float64(featureEditUI.values[i])) // keep the feature in sync
 	}
 }
 
-// drawEditRefSlots renders one row per reference slot: a count, a Select button that arms the
-// slot for viewport picking (highlighted while armed), and a Clear button.
-func drawEditRefSlots(s *app.Session, n int) {
-	for i := 0; i < n; i++ {
-		native.Text(fmt.Sprintf("%s: %d selected", s.EditFeatureRefSlotLabel(i), s.EditFeatureRefSlotRefCount(i)))
+// drawEditParamRow renders one scalar row: label, value field, unit suffix.
+func drawEditParamRow(s *app.Session, i int) {
+	propertyRow(s.EditFeatureParamLabel(i))
+	native.SetNextItemWidth(propertyFieldWidth)
+	if s.EditFeatureParamIsInteger(i) {
+		iv := int32(featureEditUI.values[i] + 0.5)
+		native.InputInt(fmt.Sprintf("##edit-feature-param-%d", i), &iv)
+		featureEditUI.values[i] = float32(iv)
+	} else {
+		native.InputFloat(fmt.Sprintf("##edit-feature-param-%d", i), &featureEditUI.values[i])
+	}
+	if u := s.EditFeatureParamUnitName(i); u != "" {
 		native.SameLine()
-		selectLabel := "Select"
-		if s.EditFeatureRefSlotArmed(i) {
-			selectLabel = "Selecting… (click geometry)"
-		}
-		if native.Button(fmt.Sprintf("%s##edit-ref-select-%d", selectLabel, i)) {
-			s.EditFeatureArmRefSlot(i)
-		}
-		if s.EditFeatureRefSlotClearable(i) {
-			native.SameLine()
-			if native.Button(fmt.Sprintf("Clear##edit-ref-clear-%d", i)) {
-				s.EditFeatureClearRefSlot(i)
-			}
-		}
+		native.Text(u)
 	}
 }

--- a/head/ui/feature_panels_test.go
+++ b/head/ui/feature_panels_test.go
@@ -108,3 +108,14 @@ func TestLoftGuideChipState(t *testing.T) {
 		t.Errorf("empty centerline chip = (%q, %v), want (\"Select Path\", false)", text, filled)
 	}
 }
+
+// TestEditSlotChipText locks the generic editor's slot chip captions: the reference
+// sheet's "N Selected" once filled, the slot's prompt while empty.
+func TestEditSlotChipText(t *testing.T) {
+	if got := editSlotChipText(0, "Edges"); got != "Select Edges" {
+		t.Errorf("empty slot chip = %q, want \"Select Edges\"", got)
+	}
+	if got := editSlotChipText(2, "Edges"); got != "2 Selected" {
+		t.Errorf("filled slot chip = %q, want \"2 Selected\"", got)
+	}
+}

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -14,26 +14,31 @@ import (
 // OK/Cancel.
 var filletUI = struct {
 	radius float32
-	open   bool
+	seeded *app.FilletTool // the tool the fields were seeded from (nil = none)
 }{radius: 1}
 
-// drawFilletDialog shows the Fillet property panel while the Fillet tool is active.
+// drawFilletDialog shows the Fillet property panel while the Fillet tool is active —
+// creating a fillet or re-editing a committed one (the same panel serves both).
 func drawFilletDialog(s *app.Session) {
 	f := s.ActiveFillet()
 	if f == nil {
-		filletUI.open = false
+		filletUI.seeded = nil
 		return
 	}
-	if !filletUI.open {
+	if filletUI.seeded != f {
 		filletUI.radius = float32(f.Radius())
-		filletUI.open = true
+		filletUI.seeded = f
 	}
 	native.SetNextWindowSizeOnce(340, 230)
 	if native.Begin("Fillet") {
-		drawFeatureBreadcrumb("Fillet", "")
+		title := "Fillet"
+		if name := f.EditingName(); name != "" {
+			title = name // re-editing a committed fillet: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
 		if propertySection("Input Geometry") {
-			drawPickChipRow("Edges", "fillet-edges", countChipText(len(f.Edges()), "Edge", "Select Edges"),
-				len(f.Edges()) > 0, "Click convex edges in the viewport to round", f.ClearEdges)
+			drawPickChipRow("Edges", "fillet-edges", countChipText(f.EdgeCount(), "Edge", "Select Edges"),
+				f.EdgeCount() > 0, "Click convex edges in the viewport to round", f.ClearEdges)
 		}
 		if propertySection("Behavior") {
 			propertyFloatRow("Radius", "fillet-radius", s.LengthUnitName(), &filletUI.radius)

--- a/head/ui/hole_dialog.go
+++ b/head/ui/hole_dialog.go
@@ -23,20 +23,24 @@ var holeUI = struct {
 	cDiameter, cDepth        float32
 	sinkAngleDeg             float32
 	pointAngleDeg            float32
-	open                     bool
+	seeded                   *app.HoleTool // the tool the fields were seeded from (nil = none)
 }{diameter: 1, depth: 2, cDiameter: 2, cDepth: 0.5, sinkAngleDeg: 90, pointAngleDeg: 118}
 
 // drawHoleDialog shows the Hole property panel while the Hole tool is active.
 func drawHoleDialog(s *app.Session) {
 	h := s.ActiveHole()
 	if h == nil {
-		holeUI.open = false
+		holeUI.seeded = nil
 		return
 	}
 	refreshHoleUI(h)
 	native.SetNextWindowSizeOnce(360, 460)
 	if native.Begin("Hole") {
-		drawFeatureBreadcrumb("Hole", "")
+		title := "Hole"
+		if name := h.EditingName(); name != "" {
+			title = name // re-editing a committed hole: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
 		drawHoleInputGeometry(h)
 		drawHoleType(s, h)
 		drawHoleBehavior(s, h)
@@ -47,7 +51,7 @@ func drawHoleDialog(s *app.Session) {
 }
 
 func refreshHoleUI(h *app.HoleTool) {
-	if holeUI.open {
+	if holeUI.seeded == h {
 		return
 	}
 	holeUI.diameter = float32(h.Diameter())
@@ -59,7 +63,7 @@ func refreshHoleUI(h *app.HoleTool) {
 	holeUI.cDepth = float32(h.CounterDepth())
 	holeUI.sinkAngleDeg = float32(h.SinkAngle() * 180 / stdmath.Pi)
 	holeUI.pointAngleDeg = float32(h.PointAngle() * 180 / stdmath.Pi)
-	holeUI.open = true
+	holeUI.seeded = h
 }
 
 // drawHoleInputGeometry is the Input Geometry section: the required placement-face chip.
@@ -68,7 +72,7 @@ func drawHoleInputGeometry(h *app.HoleTool) {
 		return
 	}
 	propertyRow("Position")
-	_, picked := h.PickedFace()
+	picked := h.HasPlacement() // a fresh pick, or the edited feature's retained face
 	if propertySelectorChip("hole-position", pickChipText(picked, "1 Face", "Select Face"), picked, true) {
 		h.ClearFace()
 	}

--- a/head/ui/property_panel.go
+++ b/head/ui/property_panel.go
@@ -128,6 +128,37 @@ func drawEmptySelectorChip(id, text string, required bool) {
 	native.Button(text + "##" + id)
 }
 
+// propertyArmableSlotChip draws the generic editors' reference-slot chip: clicking the
+// chip arms the slot for viewport picking (the reference panel's Active selector state —
+// it reads "Selecting…" while armed), and the clear (×) empties it when clearable.
+// Returns (armClicked, clearClicked).
+func propertyArmableSlotChip(id, text string, filled, armed, clearable bool) (bool, bool) {
+	if armed {
+		text = "Selecting…"
+	}
+	armClicked := drawArmableChipButton(id, text, filled, armed)
+	if !clearable {
+		return armClicked, false
+	}
+	native.SameLine()
+	return armClicked, native.Button("×##" + id + "-clear")
+}
+
+// drawArmableChipButton renders the chip body: accent while armed or filled, the danger
+// prompt while empty (a slot always names required geometry).
+func drawArmableChipButton(id, text string, filled, armed bool) bool {
+	if armed || filled {
+		native.PushStyleColor("Button", accentColor)
+		native.PushStyleColor("ButtonHovered", accentColor)
+		native.PushStyleColor("ButtonActive", accentColor)
+		defer native.PopStyleColor(3)
+	} else {
+		native.PushStyleColor("Text", dangerColor)
+		defer native.PopStyleColor(1)
+	}
+	return native.Button(text + "##" + id)
+}
+
 // propertyIconToggles draws a row of icon toggle buttons (the reference panel's
 // Direction and Boolean rows), highlighting the active index in the accent color.
 // Each option is an icon key + tooltip; a missing glyph falls back to its tooltip's

--- a/head/ui/revolve_dialog.go
+++ b/head/ui/revolve_dialog.go
@@ -21,7 +21,7 @@ import (
 var revolveUI = struct {
 	angleDeg   float32
 	centerline bool
-	open       bool
+	seeded     *app.RevolveTool // the tool the fields were seeded from (nil = none)
 }{angleDeg: 360}
 
 // revolveAxes names each origin axis for the axis combo, paired with its work reference.
@@ -35,17 +35,21 @@ var revolveAxes = []struct {
 func drawRevolveDialog(s *app.Session) {
 	rv := s.ActiveRevolve()
 	if rv == nil {
-		revolveUI.open = false
+		revolveUI.seeded = nil
 		return
 	}
-	if !revolveUI.open {
+	if revolveUI.seeded != rv {
 		revolveUI.angleDeg = seedRevolveAngle(rv)
 		revolveUI.centerline = rv.UseCenterline()
-		revolveUI.open = true
+		revolveUI.seeded = rv
 	}
 	native.SetNextWindowSizeOnce(340, 360)
 	if native.Begin("Revolve") {
-		drawFeatureBreadcrumb("Revolve", rv.SourceSketchName())
+		title := "Revolve"
+		if name := rv.EditingName(); name != "" {
+			title = name // re-editing a committed revolve: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, rv.SourceSketchName())
 		drawRevolveInputGeometry(rv)
 		drawRevolveBehavior(rv)
 		drawRevolveOutput(rv)

--- a/head/ui/shell_dialog.go
+++ b/head/ui/shell_dialog.go
@@ -14,26 +14,31 @@ import (
 // then OK/Cancel.
 var shellUI = struct {
 	thickness float32
-	open      bool
+	seeded    *app.ShellTool // the tool the fields were seeded from (nil = none)
 }{thickness: 1}
 
-// drawShellDialog shows the Shell property panel while the Shell tool is active.
+// drawShellDialog shows the Shell property panel while the Shell tool is active —
+// creating a shell or re-editing a committed one (the same panel serves both).
 func drawShellDialog(s *app.Session) {
 	sh := s.ActiveShell()
 	if sh == nil {
-		shellUI.open = false
+		shellUI.seeded = nil
 		return
 	}
-	if !shellUI.open {
+	if shellUI.seeded != sh {
 		shellUI.thickness = float32(sh.Thickness())
-		shellUI.open = true
+		shellUI.seeded = sh
 	}
 	native.SetNextWindowSizeOnce(340, 230)
 	if native.Begin("Shell") {
-		drawFeatureBreadcrumb("Shell", "")
+		title := "Shell"
+		if name := sh.EditingName(); name != "" {
+			title = name // re-editing a committed shell: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
 		if propertySection("Input Geometry") {
-			drawPickChipRow("Remove", "shell-faces", countChipText(len(sh.Faces()), "Face", "Select Faces"),
-				len(sh.Faces()) > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
+			drawPickChipRow("Remove", "shell-faces", countChipText(sh.FaceCount(), "Face", "Select Faces"),
+				sh.FaceCount() > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
 		}
 		if propertySection("Behavior") {
 			propertyFloatRow("Thickness", "shell-thickness", s.LengthUnitName(), &shellUI.thickness)

--- a/head/ui/work_plane_edit_dialog.go
+++ b/head/ui/work_plane_edit_dialog.go
@@ -11,12 +11,13 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// Editing / redefining a placed work plane (browser double-click): an offset plane edits its
-// distance, a line-plane-angle plane edits its angle, and a reference-built plane (three
-// points, two planes, a tangent face, …) re-picks its references. The dialog mirrors the
-// feature-edit dialog — one field per editable scalar, one row per reference slot with a
-// Select button that arms it for viewport/browser picking. While it is open the model is
-// rolled back to the plane (edit-scope, issue #132). Scalars are in the document's unit.
+// Editing / redefining a placed work plane (browser double-click): an offset plane edits
+// its distance, a line-plane-angle plane edits its angle, and a reference-built plane
+// (three points, two planes, a tangent face, …) re-picks its references. The dialog
+// follows the property-panel schema like the feature editors — an Input Geometry section
+// of armable reference-slot chips and a Behavior section of scalar rows. While it is
+// open the model is rolled back to the plane (edit-scope, issue #132). Scalars are in
+// the document's unit.
 
 // workPlaneEditUI holds the dialog's per-scalar field values across frames, keyed by the
 // plane being edited — so switching directly from one plane's edit to another's reseeds the
@@ -35,11 +36,12 @@ func drawWorkPlaneEditDialog(s *app.Session) {
 	nScalars := s.EditPlaneScalarCount()
 	nRefs := s.EditPlaneRefSlotCount()
 	refreshWorkPlaneEditUI(s, nScalars)
-	native.SetNextWindowSize(320, float32(104+nScalars*30+nRefs*30))
+	native.SetNextWindowSizeOnce(340, float32(150+nScalars*28+nRefs*28))
 	if native.Begin("Edit Work Plane") {
-		native.Text(s.EditPlaneName())
-		drawWorkPlaneScalars(s, nScalars)
+		drawFeatureBreadcrumb(s.EditPlaneName(), "")
 		drawWorkPlaneRefSlots(s, nRefs)
+		drawWorkPlaneScalars(s, nScalars)
+		native.Separator()
 		drawWorkPlaneEditButtons(s)
 	}
 	native.End()
@@ -56,31 +58,37 @@ func refreshWorkPlaneEditUI(s *app.Session, nScalars int) {
 	workPlaneEditUI.editing = s.EditPlaneName()
 }
 
-// drawWorkPlaneScalars renders one field per editable scalar (offset/angle), syncing it to the
-// plane each frame.
+// drawWorkPlaneScalars is the Behavior section: one row per editable scalar
+// (offset/angle), synced to the plane each frame.
 func drawWorkPlaneScalars(s *app.Session, n int) {
+	if n == 0 || !propertySection("Behavior") {
+		return
+	}
 	for i := 0; i < n && i < len(workPlaneEditUI.values); i++ {
-		label := s.EditPlaneScalarLabel(i)
-		if u := s.EditPlaneScalarUnitName(i); u != "" {
-			label += " (" + u + ")"
-		}
-		native.Text(label)
+		propertyRow(s.EditPlaneScalarLabel(i))
+		native.SetNextItemWidth(propertyFieldWidth)
 		native.InputFloat(fmt.Sprintf("##edit-plane-scalar-%d", i), &workPlaneEditUI.values[i])
+		if u := s.EditPlaneScalarUnitName(i); u != "" {
+			native.SameLine()
+			native.Text(u)
+		}
 		s.SetEditPlaneScalarValue(i, float64(workPlaneEditUI.values[i])) // keep the plane in sync
 	}
 }
 
-// drawWorkPlaneRefSlots renders one row per reference slot: a label and a Select button that
-// arms the slot for viewport/browser picking (highlighted while armed).
+// drawWorkPlaneRefSlots is the Input Geometry section: one armable chip per reference
+// slot — clicking it arms the slot for viewport/browser picking (plane slots have no
+// clear: a plane always needs its references).
 func drawWorkPlaneRefSlots(s *app.Session, n int) {
+	if n == 0 || !propertySection("Input Geometry") {
+		return
+	}
 	for i := 0; i < n; i++ {
-		native.Text(s.EditPlaneRefSlotLabel(i))
-		native.SameLine()
-		selectLabel := "Select"
-		if s.EditPlaneRefSlotArmed(i) {
-			selectLabel = "Selecting… (click geometry)"
-		}
-		if native.Button(fmt.Sprintf("%s##edit-plane-ref-%d", selectLabel, i)) {
+		label := s.EditPlaneRefSlotLabel(i)
+		propertyRow(label)
+		arm, _ := propertyArmableSlotChip(fmt.Sprintf("edit-plane-ref-%d", i), label,
+			true, s.EditPlaneRefSlotArmed(i), false)
+		if arm {
 			s.EditPlaneArmRefSlot(i)
 		}
 	}


### PR DESCRIPTION
## What

Editing a feature now offers **exactly the same properties as creating it**, through **the same dialog** — no duplicated edit UI.

- `BeginEditFeature` re-opens the creation tool itself for the eight features whose tool round-trips its definition (Extrude, Revolve, Coil, Hole, Fillet, Chamfer, Shell, Draft): the tool is seeded from the committed definition, the existing property panel opens automatically, the panel's OK writes the state back into the definition (shared edit-commit/cancel helpers, extracted from the generic editor), and Cancel restores a snapshot.
- Full creation surface is editable: extrude boolean/direction/extent/taper, hole seat-type switches, revolve axis modes (work axis / picked centerline / auto centerline), etc.
- Dress-up tools retain the feature's reference keys as a seeded selection (the feature consumed that topology, so no live handles exist): chips show the combined count, clear empties both, new picks extend.
- Panels seed per tool identity, so jumping straight from one feature's edit to another's reseeds instead of leaking stale values; breadcrumbs name the edited feature (`Extrusion1 > Sketch1`).
- The two remaining generic editors (features without a panel — patterns, mirror, rib, emboss — and work planes) are restyled onto the property-panel schema with armable slot chips (accent "Selecting…" while armed, "N Selected" when filled per the reference sheet, danger prompt when empty).

## Why

The generic param/refslot editor exposed a fraction of each feature's options (an extrude edit offered only Distance). Re-using the creation tools as the edit surface gives parity by construction and keeps one dialog per feature.

## Verification

- All suites green (root `go test ./...`, `make test` + `make smoke` in `head/`).
- Rewritten + new app tests: panel re-open assertions, commit/cancel geometry round-trips, full-surface extrude edit (taper + asymmetric distances land in the definition and the body), fillet seeded-keys edit, hole drilled→counterbore switch.
- Verified in-window (visual-hold `OBK_VISUAL_TOOL=edit-extrude`): the committed extrude re-opens with the complete creation panel seeded (30 mm distance, profile chip filled, feature-name breadcrumb).

Part of #247. Stacked on #661; merge order #658 → #659 → #660 → #661 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)