### PR TITLE
Move the sketch tool dialogs onto the property-panel schema

### DIFF
--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -76,6 +76,10 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		}
 	case "split":
 		s.StartTool(app.NewSplitTool())
+	case "sketch-text":
+		s.StartTool(app.NewSketchTextTool()) // a parameterized sketch tool: text + choices
+	case "sketch-polygon":
+		s.StartTool(app.NewPolygonTool(6)) // a parameterized sketch tool: int + float
 	case "fillet":
 		s.StartTool(app.NewFilletTool())
 	case "edit-extrude": // commit an extrude, then re-open it for editing (the unified flow)

--- a/head/ui/sketch3d_settings.go
+++ b/head/ui/sketch3d_settings.go
@@ -7,30 +7,44 @@ package ui
 import (
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/sketch"
 )
 
-// drawSketch3DSettings shows a small settings window while a 3D sketch is being edited
-// (Inventor's 3D Sketch settings): sketch visibility, dimension display, and deferred
-// updates. It edits the active sketch directly through its accessors (the same properties
-// the sketch3d.setProperty wire method toggles).
+// drawSketch3DSettings shows a small settings panel while a 3D sketch is being edited:
+// sketch visibility, dimension display, and deferred updates, on the property-panel
+// schema (a breadcrumb + a Behavior section of toggle rows). It edits the active sketch
+// directly through its accessors (the same properties the sketch3d.setProperty wire
+// method toggles); the settings are live, so there is no OK/Cancel.
 func drawSketch3DSettings(s *app.Session) {
 	sk := s.ActiveSketch3D()
 	if sk == nil {
 		return
 	}
+	native.SetNextWindowSizeOnce(300, 190)
 	if native.Begin("3D Sketch Settings") {
-		visible := sk.Visible()
-		if native.Checkbox("Visible", &visible) {
-			sk.SetVisible(visible)
-		}
-		dims := sk.DimensionsVisible()
-		if native.Checkbox("Show dimensions", &dims) {
-			sk.SetDimensionsVisible(dims)
-		}
-		defer3d := sk.DeferUpdates()
-		if native.Checkbox("Defer updates", &defer3d) {
-			sk.SetDeferUpdates(defer3d)
+		drawFeatureBreadcrumb("3D Sketch", sk.Name())
+		if propertySection("Behavior") {
+			drawSketch3DToggles(sk)
 		}
 	}
 	native.End()
+}
+
+// drawSketch3DToggles renders the three live setting rows.
+func drawSketch3DToggles(sk *sketch.Sketch3D) {
+	propertyRow("")
+	visible := sk.Visible()
+	if native.Checkbox("Visible", &visible) {
+		sk.SetVisible(visible)
+	}
+	propertyRow("")
+	dims := sk.DimensionsVisible()
+	if native.Checkbox("Show dimensions", &dims) {
+		sk.SetDimensionsVisible(dims)
+	}
+	propertyRow("")
+	defer3d := sk.DeferUpdates()
+	if native.Checkbox("Defer updates", &defer3d) {
+		sk.SetDeferUpdates(defer3d)
+	}
 }

--- a/head/ui/tool_params_dialog.go
+++ b/head/ui/tool_params_dialog.go
@@ -11,12 +11,13 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// One generic property dialog serves every tool that exposes parameters
+// One generic property panel serves every tool that exposes parameters
 // (app.ParameterizedTool) — the sketch Move/Copy/Rotate/Scale/Stretch, the rectangular/
-// circular patterns, Slot/Chamfer/Text/Fillet/Offset — instead of a bespoke cgo dialog per
-// tool (core/09 reflection-driven editing). It renders each parameter as a labelled input
-// bound to the tool's field; OK commits, Cancel aborts. Modeless: the user still picks
-// geometry in the viewport.
+// circular patterns, Slot/Chamfer/Text/Fillet/Offset, the feature pattern/modify tools —
+// instead of a bespoke cgo dialog per tool (core/09 reflection-driven editing). It
+// follows the property-panel schema: a breadcrumb naming the tool and a Behavior section
+// of label/control rows, one per parameter, with OK/Cancel beneath. Modeless: the user
+// still picks geometry in the viewport.
 
 // toolText is the persistent edit buffer for a tool's text parameter (Dear ImGui's
 // InputText needs a stable buffer across frames).
@@ -25,21 +26,25 @@ var toolText = struct {
 	open bool
 }{buf: make([]byte, 256)}
 
-// drawToolParamsDialog shows the generic parameter dialog while a parameterized tool runs.
+// drawToolParamsDialog shows the generic parameter panel while a parameterized tool runs.
 func drawToolParamsDialog(s *app.Session) {
 	title, params, ok := activeToolParams(s)
 	if !ok {
 		toolText.open = false
 		return
 	}
-	native.SetNextWindowSize(280, 240)
+	native.SetNextWindowSizeOnce(320, 280)
 	if native.Begin(title) {
-		drawToolFloatParams(params)
-		drawToolIntParams(params)
-		drawToolBoolParams(params)
-		drawToolChoiceParams(params)
-		drawToolTextParams(params)
-		drawToolParamButtons(s)
+		drawFeatureBreadcrumb(title, "")
+		if propertySection("Behavior") {
+			drawToolFloatParams(params)
+			drawToolIntParams(params)
+			drawToolBoolParams(params)
+			drawToolChoiceParams(params)
+			drawToolTextParams(params)
+		}
+		native.Separator()
+		drawCommitCancelButtons(s, s.ActiveTool().Tool().CanCommit())
 	}
 	native.End()
 }
@@ -64,6 +69,7 @@ func activeToolParams(s *app.Session) (string, app.ToolParams, bool) {
 
 func drawToolBoolParams(params app.ToolParams) {
 	for _, b := range params.Bools {
+		propertyRow("")
 		v := b.Get()
 		if native.Checkbox(b.Label, &v) {
 			b.Set(v)
@@ -72,7 +78,7 @@ func drawToolBoolParams(params app.ToolParams) {
 }
 
 // drawToolChoiceParams renders each one-of-N parameter (e.g. text alignment, font) as a
-// dropdown bound to the tool's selected index.
+// labelled dropdown row bound to the tool's selected index.
 func drawToolChoiceParams(params app.ToolParams) {
 	for _, c := range params.Choices {
 		drawToolChoice(c)
@@ -80,12 +86,14 @@ func drawToolChoiceParams(params app.ToolParams) {
 }
 
 func drawToolChoice(c app.ChoiceParam) {
+	propertyRow(c.Label)
+	native.SetNextItemWidth(propertyFieldWidth)
 	cur := c.Get()
 	preview := ""
 	if cur >= 0 && cur < len(c.Options) {
 		preview = c.Options[cur]
 	}
-	if !native.BeginCombo(c.Label, preview) {
+	if !native.BeginCombo("##tool-param-"+c.Label, preview) {
 		return
 	}
 	for i, opt := range c.Options {
@@ -98,8 +106,10 @@ func drawToolChoice(c app.ChoiceParam) {
 
 func drawToolFloatParams(params app.ToolParams) {
 	for _, f := range params.Floats {
+		propertyRow(f.Label)
+		native.SetNextItemWidth(propertyFieldWidth)
 		v := float32(f.Get())
-		if native.InputFloat(f.Label, &v) {
+		if native.InputFloat("##tool-param-"+f.Label, &v) {
 			f.Set(float64(v))
 		}
 	}
@@ -107,8 +117,10 @@ func drawToolFloatParams(params app.ToolParams) {
 
 func drawToolIntParams(params app.ToolParams) {
 	for _, n := range params.Ints {
+		propertyRow(n.Label)
+		native.SetNextItemWidth(propertyFieldWidth)
 		v := int32(n.Get())
-		if native.InputInt(n.Label, &v) {
+		if native.InputInt("##tool-param-"+n.Label, &v) {
 			n.Set(int(v))
 		}
 	}
@@ -126,21 +138,10 @@ func drawToolTextParams(params app.ToolParams) {
 		seedToolText(tp.Get())
 		toolText.open = true
 	}
-	if native.InputText(tp.Label, toolText.buf) {
+	propertyRow(tp.Label)
+	native.SetNextItemWidth(propertyComboWidth)
+	if native.InputText("##tool-param-"+tp.Label, toolText.buf) {
 		tp.Set(string(bytes.TrimRight(toolText.buf, "\x00")))
-	}
-}
-
-// drawToolParamButtons draws OK/Cancel; OK is disabled until the tool is ready.
-func drawToolParamButtons(s *app.Session) {
-	native.BeginDisabled(!s.ActiveTool().Tool().CanCommit())
-	if native.Button("OK") {
-		_ = s.OK()
-	}
-	native.EndDisabled()
-	native.SameLine()
-	if native.Button("Cancel") {
-		s.CancelTool()
 	}
 }
 


### PR DESCRIPTION
## What

- The generic parameterized-tool dialog (`tool_params_dialog.go`) — one dialog serving the sketch Move/Copy/Rotate/Scale/Stretch, the sketch patterns, Slot/Chamfer/Text/Fillet/Offset, and the feature pattern/modify tools — now renders on the property-panel schema: breadcrumb naming the tool, a Behavior section with one label/control row per parameter (float, int, checkbox, choice combo, text field at kit widths), shared OK/Cancel.
- The 3D Sketch settings window joins the schema (breadcrumb naming the sketch + a Behavior section of live toggle rows; no OK/Cancel since its settings apply immediately).

Because the dialog is reflection-driven, every parameterized tool gets the new layout from this single change — no per-tool dialogs were added.

## Why

Finishes the schema rollout: creation panels, edit panels, generic editors, and now the sketch/parameterized tool dialogs all share one visual language and one widget kit.

## Verification

- All suites green (root `go test ./...`, `make test` + `make smoke` in `head/`).
- Screenshot-verified in-window via the visual-hold harness (`OBK_VISUAL_TOOL=sketch-text`): the Text tool's mixed float/choice/text parameter set renders on the grid with the breadcrumb and gated OK.

Part of #247. Stacked on #662; merge order #658 → #659 → #660 → #661 → #662 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)