### PR TITLE
Expose the add-in registry, lifecycle and automation over the API (M05-F01)

### DIFF
--- a/addin/router/addins.go
+++ b/addin/router/addins.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerAddInHandlers wires the add-in registry/lifecycle/automation methods and
+// the external client-application registry (M05-F01: #245, #251, #252).
+func (r *Router) registerAddInHandlers() {
+	r.handlers[wire.MethodAddInsList] = listAddIns
+	r.handlers[wire.MethodAddInsGet] = getAddIn
+	r.handlers[wire.MethodAddInsActivate] = activateAddIn
+	r.handlers[wire.MethodAddInsDeactivate] = deactivateAddIn
+	r.handlers[wire.MethodAddInsSetLoadBehavior] = setAddInLoadBehavior
+	r.handlers[wire.MethodAddInsCallAutomation] = callAddInAutomation
+	r.handlers[wire.MethodClientAppsRegister] = registerClientApp
+	r.handlers[wire.MethodClientAppsUnregister] = unregisterClientApp
+	r.handlers[wire.MethodClientAppsList] = listClientApps
+}
+
+// listAddIns returns every registered add-in in registration order
+// (wire.MethodAddInsList).
+func listAddIns(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	registry := s.AddIns()
+	ids := registry.Registered()
+	infos := make([]wire.AddInInfo, 0, len(ids))
+	for _, id := range ids {
+		info, err := registry.Describe(id)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, info)
+	}
+	return json.Marshal(wire.ListAddInsResult{AddIns: infos})
+}
+
+// getAddIn returns one registry entry by id (wire.MethodAddInsGet).
+func getAddIn(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var ref wire.AddInRefArgs
+	if err := decode(args, &ref); err != nil {
+		return nil, err
+	}
+	info, err := s.AddIns().Describe(ref.ID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(info)
+}
+
+// activateAddIn runs the add-in's activation (wire.MethodAddInsActivate).
+func activateAddIn(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var ref wire.AddInRefArgs
+	if err := decode(args, &ref); err != nil {
+		return nil, err
+	}
+	if err := s.AddIns().Activate(s, ref.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// deactivateAddIn runs the add-in's shutdown (wire.MethodAddInsDeactivate).
+func deactivateAddIn(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var ref wire.AddInRefArgs
+	if err := decode(args, &ref); err != nil {
+		return nil, err
+	}
+	if err := s.AddIns().Deactivate(s, ref.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// setAddInLoadBehavior persists when the host activates the add-in on startup
+// (wire.MethodAddInsSetLoadBehavior).
+func setAddInLoadBehavior(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetAddInLoadBehaviorArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.AddIns().SetLoadBehavior(req.ID, req.LoadBehavior); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// callAddInAutomation routes a call to another add-in's automation surface
+// (wire.MethodAddInsCallAutomation).
+func callAddInAutomation(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.CallAddInAutomationArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	out, err := s.AddIns().CallAutomation(req.ID, req.Method, req.Args)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.CallAddInAutomationResult{Result: out})
+}
+
+// registerClientApp announces an external client application
+// (wire.MethodClientAppsRegister).
+func registerClientApp(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.RegisterClientApplicationArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	id, err := s.ClientApps().Register(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.RegisterClientApplicationResult{ID: id})
+}
+
+// unregisterClientApp removes an external client application
+// (wire.MethodClientAppsUnregister).
+func unregisterClientApp(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.UnregisterClientApplicationArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.ClientApps().Unregister(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// listClientApps returns the registered external clients (wire.MethodClientAppsList).
+func listClientApps(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.ListClientApplicationsResult{Clients: s.ClientApps().List()})
+}

--- a/addin/router/addins_test.go
+++ b/addin/router/addins_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// FakeWireAddIn is a named in-memory add-in for wire-level registry tests: it
+// carries a manifest and an automation surface that doubles its numeric input.
+type FakeWireAddIn struct {
+	id     string
+	active bool
+}
+
+func (f *FakeWireAddIn) ID() string                  { return f.id }
+func (f *FakeWireAddIn) Activate(*app.Session) error { f.active = true; return nil }
+func (f *FakeWireAddIn) Deactivate(*app.Session) error {
+	f.active = false
+	return nil
+}
+func (f *FakeWireAddIn) Manifest() string {
+	return fmt.Sprintf(`{"id":%q,"displayName":"Wire Fake","version":"0.1.0"}`, f.id)
+}
+func (f *FakeWireAddIn) CallAutomation(method string, args []byte) ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"method":%q,"args":%s}`, method, string(args))), nil
+}
+
+// addInSession is a session with two fake add-ins registered, one activated.
+func addInSession(t *testing.T) (*Router, *app.Session, *FakeWireAddIn) {
+	t.Helper()
+	s := app.NewSession()
+	active := &FakeWireAddIn{id: "com.wire.active"}
+	idle := &FakeWireAddIn{id: "com.wire.idle"}
+	for _, a := range []*FakeWireAddIn{active, idle} {
+		if err := s.AddIns().Register(a); err != nil {
+			t.Fatalf("register %s: %v", a.id, err)
+		}
+	}
+	if err := s.AddIns().Activate(s, active.id); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	return New(opregistry.Default()), s, active
+}
+
+func TestAddInsListAndGet(t *testing.T) {
+	r, s, _ := addInSession(t)
+	var lst wire.ListAddInsResult
+	call(t, r, s, "addins.list", "{}", &lst)
+	if len(lst.AddIns) != 2 {
+		t.Fatalf("list has %d entries, want 2", len(lst.AddIns))
+	}
+	if lst.AddIns[0].ID != "com.wire.active" || !lst.AddIns[0].Activated {
+		t.Errorf("first entry = %+v, want activated com.wire.active", lst.AddIns[0])
+	}
+	if lst.AddIns[1].Activated {
+		t.Errorf("idle entry reports activated")
+	}
+
+	var info wire.AddInInfo
+	call(t, r, s, "addins.get", `{"id":"com.wire.idle"}`, &info)
+	if info.DisplayName != "Wire Fake" || !info.HasAutomation {
+		t.Errorf("get = %+v, want manifest identity and hasAutomation", info)
+	}
+}
+
+func TestAddInsLifecycleOverWire(t *testing.T) {
+	r, s, _ := addInSession(t)
+	call(t, r, s, "addins.activate", `{"id":"com.wire.idle"}`, nil)
+	if !s.AddIns().IsActive("com.wire.idle") {
+		t.Fatal("addins.activate did not activate")
+	}
+	call(t, r, s, "addins.deactivate", `{"id":"com.wire.idle"}`, nil)
+	if s.AddIns().IsActive("com.wire.idle") {
+		t.Fatal("addins.deactivate did not deactivate")
+	}
+}
+
+func TestAddInsSetLoadBehaviorOverWire(t *testing.T) {
+	r, s, _ := addInSession(t)
+	call(t, r, s, "addins.setLoadBehavior", `{"id":"com.wire.idle","loadBehavior":2}`, nil)
+	if got := s.AddIns().LoadBehavior("com.wire.idle"); got != types.LoadDisabled {
+		t.Fatalf("LoadBehavior = %v, want disabled", got)
+	}
+	if _, err := r.Handle(s, "addins.activate", []byte(`{"id":"com.wire.idle"}`)); err == nil {
+		t.Fatal("activating a disabled add-in over the wire should fail")
+	}
+}
+
+// TestAddInsCallAutomationOverWire is the #252 acceptance at the wire level: the
+// caller reaches another add-in's automation surface via addins.callAutomation.
+func TestAddInsCallAutomationOverWire(t *testing.T) {
+	r, s, _ := addInSession(t)
+	var res wire.CallAddInAutomationResult
+	call(t, r, s, "addins.callAutomation",
+		`{"id":"com.wire.active","method":"solve","args":{"n":3}}`, &res)
+	if string(res.Result) != `{"method":"solve","args":{"n":3}}` {
+		t.Errorf("result = %s, want the target's echo", res.Result)
+	}
+
+	if _, err := r.Handle(s, "addins.callAutomation",
+		[]byte(`{"id":"com.wire.idle","method":"solve"}`)); err == nil {
+		t.Error("automation on an inactive add-in should fail over the wire")
+	}
+}
+
+func TestClientAppsOverWire(t *testing.T) {
+	r, s, _ := addInSession(t)
+	var reg wire.RegisterClientApplicationResult
+	call(t, r, s, "clientApps.register", `{"name":"acme-pipeline"}`, &reg)
+	if reg.ID == 0 {
+		t.Fatal("register returned id 0")
+	}
+	var lst wire.ListClientApplicationsResult
+	call(t, r, s, "clientApps.list", "{}", &lst)
+	if len(lst.Clients) != 1 || lst.Clients[0].Name != "acme-pipeline" {
+		t.Fatalf("list = %+v, want one acme-pipeline", lst.Clients)
+	}
+	call(t, r, s, "clientApps.unregister", fmt.Sprintf(`{"id":%d}`, reg.ID), nil)
+	call(t, r, s, "clientApps.list", "{}", &lst)
+	if len(lst.Clients) != 0 {
+		t.Fatalf("list after unregister = %+v, want empty", lst.Clients)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -44,6 +44,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerGraphicsHandlers()
 	r.registerExchangeHandlers()
 	r.registerFontHandlers()
+	r.registerAddInHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/app/addin.go
+++ b/app/addin.go
@@ -15,17 +15,24 @@ type AddIn interface {
 	Deactivate(*Session) error
 }
 
-// AddInManager loads and tracks add-ins — Inventor's ApplicationAddIns. Activation
-// is idempotent per add-in.
+// AddInManager loads and tracks add-ins — the ApplicationAddIns registry.
+// Activation is idempotent per add-in. Load behaviors and the automation routing
+// live in addin_registry.go (M05-F01).
 type AddInManager struct {
-	addins map[string]AddIn
-	active map[string]bool
-	order  []string
+	addins        map[string]AddIn
+	active        map[string]bool
+	order         []string
+	behaviors     map[string]AddInLoadBehavior
+	behaviorStore AddInBehaviorStore
 }
 
 // NewAddInManager returns an empty add-in registry.
 func NewAddInManager() *AddInManager {
-	return &AddInManager{addins: map[string]AddIn{}, active: map[string]bool{}}
+	return &AddInManager{
+		addins:    map[string]AddIn{},
+		active:    map[string]bool{},
+		behaviors: map[string]AddInLoadBehavior{},
+	}
 }
 
 // Register makes an add-in known (not yet activated), erroring on a duplicate id.
@@ -38,11 +45,15 @@ func (m *AddInManager) Register(a AddIn) error {
 	return nil
 }
 
-// Activate runs an add-in's Activate (no-op if already active).
+// Activate runs an add-in's Activate (no-op if already active). A LoadDisabled
+// add-in refuses: it is listed but never runs until its behavior changes (#251).
 func (m *AddInManager) Activate(s *Session, id string) error {
 	a, ok := m.addins[id]
 	if !ok {
 		return fmt.Errorf("app: no add-in %q", id)
+	}
+	if m.behaviors[id] == LoadDisabled {
+		return fmt.Errorf("app: add-in %q is disabled; set its load behavior to startup or demand first", id)
 	}
 	if m.active[id] {
 		return nil

--- a/app/addin_registry.go
+++ b/app/addin_registry.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// AddInLoadBehavior aliases the canonical Apache-2.0 enum (ADR-0018) so call sites
+// here read naturally.
+type AddInLoadBehavior = types.AddInLoadBehavior
+
+const (
+	LoadOnStartup = types.LoadOnStartup
+	LoadOnDemand  = types.LoadOnDemand
+	LoadDisabled  = types.LoadDisabled
+)
+
+// The registry slice of ApplicationAddIns is part of the public in-process contract.
+var _ contract.AddInRegistry = (*AddInManager)(nil)
+
+// AddInManifested is the optional capability of an [AddIn] that carries the C-ABI
+// manifest JSON (a [wire.AddInManifest]) — every shared-library add-in does; a
+// first-party in-process add-in may skip it and list with its id only.
+type AddInManifested interface{ Manifest() string }
+
+// AddInLocated is the optional capability of an [AddIn] that knows the
+// shared-library file it was loaded from.
+type AddInLocated interface{ Path() string }
+
+// AddInAutomationProbe is the optional capability that reports whether an add-in's
+// automation surface is actually present. The shared-library wrapper always has the
+// CallAutomation method but may lack the ObkAddInAutomation export, so a plain
+// interface assertion would over-report.
+type AddInAutomationProbe interface{ HasAutomation() bool }
+
+// AddInBehaviorStore persists the per-user load behaviors across sessions. A missing
+// store file loads as an empty map (fresh install ⇒ everything LoadOnStartup).
+type AddInBehaviorStore interface {
+	Load() (map[string]types.AddInLoadBehavior, error)
+	Save(map[string]types.AddInLoadBehavior) error
+}
+
+// UseBehaviorStore loads the persisted load behaviors and keeps the store so
+// [AddInManager.SetLoadBehavior] writes through. Call before registering add-ins so
+// startup activation respects the stored behaviors.
+func (m *AddInManager) UseBehaviorStore(store AddInBehaviorStore) error {
+	loaded, err := store.Load()
+	if err != nil {
+		return fmt.Errorf("app: load add-in behaviors: %w", err)
+	}
+	for id, b := range loaded {
+		m.behaviors[id] = b
+	}
+	m.behaviorStore = store
+	return nil
+}
+
+// LoadBehavior returns when the host activates the add-in on startup (the zero
+// value, LoadOnStartup, for an id with no stored preference).
+func (m *AddInManager) LoadBehavior(id string) types.AddInLoadBehavior {
+	return m.behaviors[id]
+}
+
+// SetLoadBehavior records (and persists, when a store is wired) when the host should
+// activate the add-in on future startups. It does not deactivate a running add-in.
+func (m *AddInManager) SetLoadBehavior(id string, b types.AddInLoadBehavior) error {
+	if _, ok := m.addins[id]; !ok {
+		return fmt.Errorf("app: no add-in %q", id)
+	}
+	m.behaviors[id] = b
+	if m.behaviorStore == nil {
+		return nil
+	}
+	return m.behaviorStore.Save(m.behaviorSnapshot())
+}
+
+// behaviorSnapshot copies the non-default behaviors for persistence (storing the
+// default would freeze it; omitting it lets a future default change apply).
+func (m *AddInManager) behaviorSnapshot() map[string]types.AddInLoadBehavior {
+	out := map[string]types.AddInLoadBehavior{}
+	for id, b := range m.behaviors {
+		if b != types.LoadOnStartup {
+			out[id] = b
+		}
+	}
+	return out
+}
+
+// Describe returns the registry entry for one add-in: its manifest identity (when it
+// carries one) plus the host-side runtime state.
+func (m *AddInManager) Describe(id string) (wire.AddInInfo, error) {
+	a, ok := m.addins[id]
+	if !ok {
+		return wire.AddInInfo{}, fmt.Errorf("app: no add-in %q", id)
+	}
+	info := wire.AddInInfo{
+		ID:            id,
+		LoadBehavior:  m.behaviors[id],
+		Activated:     m.active[id],
+		HasAutomation: addInHasAutomation(a),
+	}
+	if located, ok := a.(AddInLocated); ok {
+		info.Location = located.Path()
+	}
+	if manifested, ok := a.(AddInManifested); ok {
+		fillFromManifest(&info, manifested.Manifest())
+	}
+	return info, nil
+}
+
+// fillFromManifest copies the manifest's identity fields into info. A malformed
+// manifest leaves them empty rather than failing the listing — the id (from
+// ObkAddInId) still identifies the entry.
+func fillFromManifest(info *wire.AddInInfo, manifest string) {
+	var man wire.AddInManifest
+	if json.Unmarshal([]byte(manifest), &man) != nil {
+		return
+	}
+	info.DisplayName, info.Version, info.Description = man.DisplayName, man.Version, man.Description
+	info.Kind, info.Capabilities = man.Kind, man.Capabilities
+}
+
+// addInHasAutomation reports whether automation can actually be routed to a — the
+// probe wins when present (shared-library wrappers), else the plain assertion.
+func addInHasAutomation(a AddIn) bool {
+	if probe, ok := a.(AddInAutomationProbe); ok {
+		return probe.HasAutomation()
+	}
+	_, ok := a.(contract.AddInAutomation)
+	return ok
+}
+
+// CallAutomation routes one automation request to the target add-in
+// (ApplicationAddIn.Automation). The target must be active — automation is a live
+// surface, not a manifest query — and must actually expose one.
+func (m *AddInManager) CallAutomation(id, method string, args []byte) ([]byte, error) {
+	a, ok := m.addins[id]
+	if !ok {
+		return nil, fmt.Errorf("app: no add-in %q", id)
+	}
+	if !m.active[id] {
+		return nil, fmt.Errorf("app: add-in %q is not active; automation needs an active add-in", id)
+	}
+	auto, ok := a.(contract.AddInAutomation)
+	if !ok || !addInHasAutomation(a) {
+		return nil, fmt.Errorf("app: add-in %q exposes no automation surface", id)
+	}
+	return auto.CallAutomation(method, args)
+}

--- a/app/addin_registry_test.go
+++ b/app/addin_registry_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// FakeManifestedAddIn is a named in-memory add-in with a manifest, a location, and
+// an optional automation surface — the test double for shared-library add-ins.
+type FakeManifestedAddIn struct {
+	id        string
+	manifest  string
+	path      string
+	automated bool
+	calls     []string
+}
+
+func (f *FakeManifestedAddIn) ID() string                { return f.id }
+func (f *FakeManifestedAddIn) Activate(*Session) error   { return nil }
+func (f *FakeManifestedAddIn) Deactivate(*Session) error { return nil }
+func (f *FakeManifestedAddIn) Manifest() string          { return f.manifest }
+func (f *FakeManifestedAddIn) Path() string              { return f.path }
+func (f *FakeManifestedAddIn) HasAutomation() bool       { return f.automated }
+
+// CallAutomation echoes the method plus the parsed argument, so tests can assert
+// the payload crossed intact.
+func (f *FakeManifestedAddIn) CallAutomation(method string, args []byte) ([]byte, error) {
+	f.calls = append(f.calls, method)
+	return []byte(fmt.Sprintf(`{"echo":%q,"got":%s}`, method, string(args))), nil
+}
+
+// FakeBehaviorStore is a named in-memory AddInBehaviorStore.
+type FakeBehaviorStore struct {
+	stored map[string]types.AddInLoadBehavior
+	saves  int
+}
+
+func (f *FakeBehaviorStore) Load() (map[string]types.AddInLoadBehavior, error) {
+	return f.stored, nil
+}
+
+func (f *FakeBehaviorStore) Save(m map[string]types.AddInLoadBehavior) error {
+	f.stored = m
+	f.saves++
+	return nil
+}
+
+func manifestedAddIn(id string) *FakeManifestedAddIn {
+	return &FakeManifestedAddIn{
+		id:   id,
+		path: "/addins/" + id + ".so",
+		manifest: fmt.Sprintf(
+			`{"id":%q,"displayName":"Fake %s","version":"1.2.3","description":"a fake","capabilities":["commands"]}`,
+			id, id),
+		automated: true,
+	}
+}
+
+func TestDescribeReadsManifestAndRuntimeState(t *testing.T) {
+	s := NewSession()
+	a := manifestedAddIn("com.x.a")
+	if err := s.AddIns().Register(a); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := s.AddIns().Activate(s, "com.x.a"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	info, err := s.AddIns().Describe("com.x.a")
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	if info.DisplayName != "Fake com.x.a" || info.Version != "1.2.3" {
+		t.Errorf("identity = %q/%q, want from manifest", info.DisplayName, info.Version)
+	}
+	if !info.Activated || !info.HasAutomation || info.Location != "/addins/com.x.a.so" {
+		t.Errorf("state = %+v, want activated, hasAutomation, located", info)
+	}
+	if len(info.Capabilities) != 1 || info.Capabilities[0] != "commands" {
+		t.Errorf("capabilities = %v, want [commands]", info.Capabilities)
+	}
+}
+
+func TestDescribeUnknownAddInFails(t *testing.T) {
+	if _, err := NewSession().AddIns().Describe("com.x.ghost"); err == nil {
+		t.Fatal("Describe(unknown) should fail")
+	}
+}
+
+func TestDescribeToleratesMalformedManifest(t *testing.T) {
+	s := NewSession()
+	a := &FakeManifestedAddIn{id: "com.x.bad", manifest: "{not json"}
+	if err := s.AddIns().Register(a); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	info, err := s.AddIns().Describe("com.x.bad")
+	if err != nil || info.ID != "com.x.bad" || info.DisplayName != "" {
+		t.Errorf("Describe = (%+v, %v), want bare id entry without identity fields", info, err)
+	}
+}
+
+func TestSetLoadBehaviorPersistsNonDefaultsOnly(t *testing.T) {
+	s := NewSession()
+	store := &FakeBehaviorStore{}
+	if err := s.AddIns().UseBehaviorStore(store); err != nil {
+		t.Fatalf("UseBehaviorStore: %v", err)
+	}
+	for _, id := range []string{"com.x.a", "com.x.b"} {
+		if err := s.AddIns().Register(manifestedAddIn(id)); err != nil {
+			t.Fatalf("Register %s: %v", id, err)
+		}
+	}
+
+	if err := s.AddIns().SetLoadBehavior("com.x.a", types.LoadOnDemand); err != nil {
+		t.Fatalf("SetLoadBehavior: %v", err)
+	}
+	if err := s.AddIns().SetLoadBehavior("com.x.b", types.LoadOnStartup); err != nil {
+		t.Fatalf("SetLoadBehavior default: %v", err)
+	}
+	if store.saves != 2 {
+		t.Errorf("saves = %d, want 2", store.saves)
+	}
+	if len(store.stored) != 1 || store.stored["com.x.a"] != types.LoadOnDemand {
+		t.Errorf("stored = %v, want only the non-default com.x.a=demand", store.stored)
+	}
+	if s.AddIns().LoadBehavior("com.x.b") != types.LoadOnStartup {
+		t.Error("default behavior should read back LoadOnStartup")
+	}
+}
+
+func TestSetLoadBehaviorUnknownAddInFails(t *testing.T) {
+	if err := NewSession().AddIns().SetLoadBehavior("com.x.ghost", types.LoadDisabled); err == nil {
+		t.Fatal("SetLoadBehavior(unknown) should fail")
+	}
+}
+
+func TestUseBehaviorStoreSeedsStoredBehaviors(t *testing.T) {
+	s := NewSession()
+	store := &FakeBehaviorStore{stored: map[string]types.AddInLoadBehavior{
+		"com.x.a": types.LoadDisabled,
+	}}
+	if err := s.AddIns().UseBehaviorStore(store); err != nil {
+		t.Fatalf("UseBehaviorStore: %v", err)
+	}
+	if got := s.AddIns().LoadBehavior("com.x.a"); got != types.LoadDisabled {
+		t.Errorf("LoadBehavior = %v, want disabled (seeded from store)", got)
+	}
+}
+
+func TestActivateRefusesDisabledAddIn(t *testing.T) {
+	s := NewSession()
+	if err := s.AddIns().Register(manifestedAddIn("com.x.a")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := s.AddIns().SetLoadBehavior("com.x.a", types.LoadDisabled); err != nil {
+		t.Fatalf("SetLoadBehavior: %v", err)
+	}
+	if err := s.AddIns().Activate(s, "com.x.a"); err == nil {
+		t.Fatal("Activate(disabled) should fail")
+	}
+	if s.AddIns().IsActive("com.x.a") {
+		t.Error("disabled add-in must not be active")
+	}
+}
+
+// TestCallAutomationRoutesBetweenAddIns is the #252 acceptance at the registry
+// level: one add-in reaches another's automation surface through the host.
+func TestCallAutomationRoutesBetweenAddIns(t *testing.T) {
+	s := NewSession()
+	target := manifestedAddIn("com.x.calc")
+	for _, a := range []AddIn{manifestedAddIn("com.x.caller"), target} {
+		if err := s.AddIns().Register(a); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+		if err := s.AddIns().Activate(s, a.ID()); err != nil {
+			t.Fatalf("Activate: %v", err)
+		}
+	}
+
+	out, err := s.AddIns().CallAutomation("com.x.calc", "add", []byte(`{"a":3}`))
+	if err != nil {
+		t.Fatalf("CallAutomation: %v", err)
+	}
+	var reply struct {
+		Echo string          `json:"echo"`
+		Got  json.RawMessage `json:"got"`
+	}
+	if err := json.Unmarshal(out, &reply); err != nil {
+		t.Fatalf("reply not JSON: %v", err)
+	}
+	if reply.Echo != "add" || string(reply.Got) != `{"a":3}` {
+		t.Errorf("reply = %+v, want method add with payload {\"a\":3}", reply)
+	}
+	if len(target.calls) != 1 {
+		t.Errorf("target saw %d calls, want 1", len(target.calls))
+	}
+}
+
+func TestCallAutomationRequiresActiveTarget(t *testing.T) {
+	s := NewSession()
+	if err := s.AddIns().Register(manifestedAddIn("com.x.calc")); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := s.AddIns().CallAutomation("com.x.calc", "add", nil); err == nil {
+		t.Fatal("CallAutomation on an inactive add-in should fail (mirrors ApplicationAddIn.Automation)")
+	}
+}
+
+func TestCallAutomationHonorsProbe(t *testing.T) {
+	s := NewSession()
+	a := manifestedAddIn("com.x.mute")
+	a.automated = false // the wrapper has the method but the export is absent
+	if err := s.AddIns().Register(a); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := s.AddIns().Activate(s, "com.x.mute"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if _, err := s.AddIns().CallAutomation("com.x.mute", "x", nil); err == nil {
+		t.Fatal("CallAutomation should fail when the probe reports no automation")
+	}
+	info, _ := s.AddIns().Describe("com.x.mute")
+	if info.HasAutomation {
+		t.Error("Describe should report hasAutomation=false from the probe")
+	}
+}

--- a/app/client_apps.go
+++ b/app/client_apps.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+)
+
+// ClientApplicationRegistry tracks external client applications driving the session
+// — out-of-process automation drivers (an MCP client, a test harness) that announce
+// themselves so the session can list who is connected. Distinct from in-process
+// add-ins ([AddInManager]); the ClientApplications equivalent (M05-F01, #245).
+type ClientApplicationRegistry struct {
+	nextID int
+	order  []int
+	names  map[int]string
+}
+
+// NewClientApplicationRegistry returns an empty external-client registry.
+func NewClientApplicationRegistry() *ClientApplicationRegistry {
+	return &ClientApplicationRegistry{nextID: 1, names: map[int]string{}}
+}
+
+// Register announces an external client and returns its session-unique id.
+func (r *ClientApplicationRegistry) Register(name string) (int, error) {
+	if name == "" {
+		return 0, fmt.Errorf("app: client application name is empty; expected a display name like \"acme-pipeline\"")
+	}
+	id := r.nextID
+	r.nextID++
+	r.names[id] = name
+	r.order = append(r.order, id)
+	return id, nil
+}
+
+// Unregister removes a previously registered external client by its id.
+func (r *ClientApplicationRegistry) Unregister(id int) error {
+	if _, ok := r.names[id]; !ok {
+		return fmt.Errorf("app: no client application %d", id)
+	}
+	delete(r.names, id)
+	for i, x := range r.order {
+		if x == id {
+			r.order = append(r.order[:i], r.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// List returns the registered external clients in registration order.
+func (r *ClientApplicationRegistry) List() []wire.ClientApplicationInfo {
+	out := make([]wire.ClientApplicationInfo, len(r.order))
+	for i, id := range r.order {
+		out[i] = wire.ClientApplicationInfo{ID: id, Name: r.names[id]}
+	}
+	return out
+}

--- a/app/client_apps_test.go
+++ b/app/client_apps_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+func TestClientAppsRegisterListUnregister(t *testing.T) {
+	reg := NewSession().ClientApps()
+	idA, err := reg.Register("acme-pipeline")
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	idB, err := reg.Register("qa-harness")
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if idA == idB {
+		t.Fatalf("ids collide: %d", idA)
+	}
+
+	lst := reg.List()
+	if len(lst) != 2 || lst[0].Name != "acme-pipeline" || lst[1].Name != "qa-harness" {
+		t.Fatalf("List = %+v, want registration order acme-pipeline, qa-harness", lst)
+	}
+
+	if err := reg.Unregister(idA); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if lst := reg.List(); len(lst) != 1 || lst[0].ID != idB {
+		t.Errorf("List after unregister = %+v, want only qa-harness", lst)
+	}
+}
+
+func TestClientAppsRejectEmptyNameAndUnknownID(t *testing.T) {
+	reg := NewClientApplicationRegistry()
+	if _, err := reg.Register(""); err == nil {
+		t.Error("Register(\"\") should fail")
+	}
+	if err := reg.Unregister(99); err == nil {
+		t.Error("Unregister(99) should fail for an unknown id")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -47,6 +47,7 @@ type Session struct {
 	hiddenBodyKeys     map[string]bool
 	graphics           *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins             *AddInManager
+	clientApps         *ClientApplicationRegistry // external automation drivers (M05-F01)
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store
@@ -106,6 +107,7 @@ func newSession(store doc.Store) *Session {
 		hiddenBodyKeys: map[string]bool{},
 		graphics:       clientgraphics.NewStore(),
 		addins:         NewAddInManager(),
+		clientApps:     NewClientApplicationRegistry(),
 		visualStyle:    renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now
@@ -122,6 +124,9 @@ func newSession(store doc.Store) *Session {
 
 // AddIns returns the add-in registry (ApplicationAddIns).
 func (s *Session) AddIns() *AddInManager { return s.addins }
+
+// ClientApps returns the external-client registry (ClientApplications).
+func (s *Session) ClientApps() *ClientApplicationRegistry { return s.clientApps }
 
 // Camera returns the active view's camera sized to the current viewport. Camera state is
 // per-view — a document owns a Views collection and each view owns a camera — so switching

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -17,6 +17,7 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/event"
 	"oblikovati.org/head/internal/addinhost"
+	"oblikovati.org/persistence/addinstate"
 	"oblikovati.org/script/bridge"
 	"oblikovati.org/script/console"
 	"oblikovati.org/script/gopherlua"
@@ -64,18 +65,19 @@ func startAddIns(session *app.Session) *addInHost {
 	// The Script Console runs Lua over the SAME router + dispatcher add-ins use, so its
 	// host calls serialize onto the session goroutine and never freeze the UI (ADR-0028 §5).
 	h.script = newScriptController(rtr, session, d)
+	useBehaviorStore(session)
 	libs, err := addinhost.LoadDir(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "add-ins: %v\n", err)
 	}
 	for _, lib := range libs {
-		if err := activate(session, lib); err != nil {
+		if err := registerAndMaybeActivate(session, lib); err != nil {
 			fmt.Fprintf(os.Stderr, "add-in %q: %v\n", lib.ID(), err)
 			continue
 		}
 		h.loaded = append(h.loaded, lib)
 	}
-	h.subs = events.Subscribe(session, h.notifyAll)
+	h.subs = events.Subscribe(session, func(ev []byte) { h.notifyActive(session, ev) })
 	// Under a supervisor (make run-watch sets OBK_ADDIN_AUTORESTART=1), watch the
 	// add-ins dir so a rebuilt library makes the app exit-and-relaunch — the safe way
 	// to pick up a new add-in (a Go c-shared cannot be hot-swapped in-process). Plain
@@ -96,18 +98,39 @@ func newScriptController(rtr *router.Router, session *app.Session, d *dispatch.D
 	return console.NewController(run, runner.DefaultGUILimits)
 }
 
-// activate registers and activates one loaded add-in.
-func activate(session *app.Session, lib *addinhost.LoadedAddIn) error {
+// useBehaviorStore wires the per-user load-behavior preferences into the registry,
+// so a demand/disabled add-in registers (it lists in addins.list) but is not
+// activated at startup (M05-F01, #251). A store failure costs only persistence —
+// the session still runs with the default behaviors.
+func useBehaviorStore(session *app.Session) {
+	path, err := addinstate.DefaultPath()
+	if err == nil {
+		err = session.AddIns().UseBehaviorStore(addinstate.NewFileStore(path))
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "add-in behaviors: %v\n", err)
+	}
+}
+
+// registerAndMaybeActivate registers one loaded add-in, activating it only when its
+// stored load behavior says so; demand/disabled entries wait for addins.activate.
+func registerAndMaybeActivate(session *app.Session, lib *addinhost.LoadedAddIn) error {
 	if err := session.AddIns().Register(lib); err != nil {
 		return err
+	}
+	if session.AddIns().LoadBehavior(lib.ID()) != app.LoadOnStartup {
+		return nil
 	}
 	return session.AddIns().Activate(session, lib.ID())
 }
 
-// notifyAll forwards a serialized event to every active add-in.
-func (h *addInHost) notifyAll(ev []byte) {
+// notifyActive forwards a serialized event to every ACTIVE add-in — a registered
+// but deactivated add-in must not keep observing the session.
+func (h *addInHost) notifyActive(session *app.Session, ev []byte) {
 	for _, lib := range h.loaded {
-		_ = lib.Notify(ev)
+		if session.AddIns().IsActive(lib.ID()) {
+			_ = lib.Notify(ev)
+		}
 	}
 }
 

--- a/head/internal/addinhost/automation_test.go
+++ b/head/internal/addinhost/automation_test.go
@@ -1,0 +1,58 @@
+//go:build linux || darwin
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addinhost
+
+import "testing"
+
+// TestAutomationExportRoundTrips loads the echo fixture and drives its OPTIONAL
+// ObkAddInAutomation export end-to-end: dlsym resolution, the C call, and the
+// cross-runtime buffer copy + ObkFree release (M05-F01 #252). No host callback is
+// involved — automation is a direct host→add-in call.
+func TestAutomationExportRoundTrips(t *testing.T) {
+	so := buildFixture(t, "echoaddin")
+	lib, err := Open(so)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := lib.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	if !lib.HasAutomation() {
+		t.Fatal("HasAutomation = false, want the fixture's ObkAddInAutomation resolved")
+	}
+	out, err := lib.CallAutomation("solve", []byte("abc"))
+	if err != nil {
+		t.Fatalf("CallAutomation: %v", err)
+	}
+	if string(out) != `{"method":"solve","payload":"abc"}` {
+		t.Errorf("automation reply = %s, want the fixture's echo", out)
+	}
+}
+
+// TestAutomationAbsentIsReported loads the UI fixture (which has no automation
+// export) and checks the probe reports false and the call fails with a clear error
+// — the lenient-resolution contract of the header.
+func TestAutomationAbsentIsReported(t *testing.T) {
+	so := buildFixture(t, "uiaddin")
+	lib, err := Open(so)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() {
+		if err := lib.Close(); err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	}()
+
+	if lib.HasAutomation() {
+		t.Fatal("HasAutomation = true for a fixture without the export")
+	}
+	if _, err := lib.CallAutomation("x", nil); err == nil {
+		t.Fatal("CallAutomation should fail when the export is absent")
+	}
+}

--- a/head/internal/addinhost/dl_unix.go
+++ b/head/internal/addinhost/dl_unix.go
@@ -24,11 +24,15 @@ typedef const char* (*strFn)(void);
 typedef int  (*activateFn)(ObkHostCall, ObkHostFree);
 typedef int  (*voidFn)(void);
 typedef int  (*notifyFn)(const uint8_t*, int);
+typedef int  (*automationFn)(const char*, const uint8_t*, int, uint8_t**, int*);
+typedef void (*freeFn)(uint8_t*);
 
 static const char* call_str(void* fn)               { return ((strFn)fn)(); }
 static int  call_activate(void* fn)                  { return ((activateFn)fn)((ObkHostCall)ObkHostDispatch, (ObkHostFree)ObkHostReleaseBuf); }
 static int  call_void(void* fn)                      { return ((voidFn)fn)(); }
 static int  call_notify(void* fn, const uint8_t* ev, int n) { return ((notifyFn)fn)(ev, n); }
+static int  call_automation(void* fn, const char* method, const uint8_t* req, int n, uint8_t** resp, int* respLen) { return ((automationFn)fn)(method, req, n, resp, respLen); }
+static void call_addin_free(void* fn, uint8_t* p)    { ((freeFn)fn)(p); }
 */
 import "C"
 
@@ -37,7 +41,10 @@ import (
 	"unsafe"
 )
 
-// unixLib is a dlopen'd add-in with its resolved C entry points.
+// unixLib is a dlopen'd add-in with its resolved C entry points. autoSym is the
+// OPTIONAL ObkAddInAutomation export (nil when the add-in has no automation
+// surface, M05-F01 #252); freeSym is the add-in's ObkFree, which releases the
+// buffers automation hands back across the runtime boundary.
 type unixLib struct {
 	handle   unsafe.Pointer
 	idSym    unsafe.Pointer
@@ -45,6 +52,8 @@ type unixLib struct {
 	actSym   unsafe.Pointer
 	deactSym unsafe.Pointer
 	notifSym unsafe.Pointer
+	freeSym  unsafe.Pointer
+	autoSym  unsafe.Pointer
 	path     string
 }
 
@@ -66,6 +75,7 @@ func openLibrary(path string) (addInLib, error) {
 		{"ObkAddInActivate", &l.actSym},
 		{"ObkAddInDeactivate", &l.deactSym},
 		{"ObkAddInNotify", &l.notifSym},
+		{"ObkFree", &l.freeSym},
 	}
 	for _, s := range syms {
 		p, err := resolve(h, s.name)
@@ -75,7 +85,16 @@ func openLibrary(path string) (addInLib, error) {
 		}
 		*s.dst = p
 	}
+	// Automation is an optional export: absence just means hasAutomation() is false.
+	l.autoSym = resolveOptional(h, "ObkAddInAutomation")
 	return l, nil
+}
+
+// resolveOptional looks up a symbol the contract marks optional; nil means absent.
+func resolveOptional(h unsafe.Pointer, name string) unsafe.Pointer {
+	cn := C.CString(name)
+	defer C.free(unsafe.Pointer(cn))
+	return C.dlsym(h, cn)
 }
 
 // resolve looks up a required symbol, returning a descriptive error if absent.
@@ -115,6 +134,35 @@ func (l *unixLib) notify(b []byte) error {
 		return fmt.Errorf("addinhost: ObkAddInNotify %q returned %d", l.path, int(rc))
 	}
 	return nil
+}
+
+func (l *unixLib) hasAutomation() bool { return l.autoSym != nil }
+
+// automation invokes the add-in's optional ObkAddInAutomation export. The reply
+// buffer is allocated by the add-in's runtime, so it is copied out and released
+// through the add-in's own ObkFree (the cross-runtime ownership rule of the header).
+func (l *unixLib) automation(method string, req []byte) ([]byte, error) {
+	if l.autoSym == nil {
+		return nil, fmt.Errorf("addinhost: add-in %q exports no ObkAddInAutomation", l.path)
+	}
+	cm := C.CString(method)
+	defer C.free(unsafe.Pointer(cm))
+	var reqPtr *C.uint8_t
+	if len(req) > 0 {
+		reqPtr = (*C.uint8_t)(unsafe.Pointer(&req[0]))
+	}
+	var resp *C.uint8_t
+	var respLen C.int
+	rc := C.call_automation(l.autoSym, cm, reqPtr, C.int(len(req)), &resp, &respLen) //nolint:gocritic // dupSubExpr false positive from cgo's generated call site
+	var out []byte
+	if resp != nil {
+		out = C.GoBytes(unsafe.Pointer(resp), respLen)
+		C.call_addin_free(l.freeSym, resp)
+	}
+	if rc != C.int(C.OBK_OK) {
+		return nil, fmt.Errorf("addinhost: automation %q on %q failed: %s", method, l.path, string(out))
+	}
+	return out, nil
 }
 
 func (l *unixLib) close() error {

--- a/head/internal/addinhost/include/oblikovati_addin.h
+++ b/head/internal/addinhost/include/oblikovati_addin.h
@@ -1,6 +1,11 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 /*
  * oblikovati_addin.h — the C ABI between the Oblikovati host and a shared-library
  * add-in (built with `go build -buildmode=c-shared`, producing .so/.dll).
+ *
+ * This header is part of the public, Apache-2.0 automation contract: it is the
+ * single source of truth for the host<->add-in boundary. Add-ins compile against
+ * it; the host vendors a copy of it. Keep it self-contained (C primitives only).
  *
  * WHY a C ABI and not Go types: a Go c-shared library loaded into the Go host runs
  * its OWN Go runtime (two heaps, two GCs in one process). Go pointers must not cross
@@ -69,6 +74,22 @@ extern int ObkAddInActivate(ObkHostCall call, ObkHostFree freeFn);
 extern int ObkAddInDeactivate(void);
 extern int ObkAddInNotify(const uint8_t *ev, int len);
 extern void ObkFree(uint8_t *p);
+
+/*
+ * OPTIONAL export: the add-in's automation surface (ApplicationAddIn.Automation,
+ * M05-F01 #252). The host resolves it leniently after load — an add-in without it
+ * simply reports hasAutomation:false in the registry. When present, the host routes
+ * addins.callAutomation requests here: `method` plus a JSON `req` chosen by THIS
+ * add-in's own contract (the host passes both through opaquely). On OBK_OK the
+ * add-in sets *resp/*respLen to a buffer it allocated, which the host copies and
+ * then releases via ObkFree; on OBK_ERR *resp is a UTF-8 error message (same
+ * ownership). Constraints: the call arrives on the host's session goroutine, so the
+ * handler must return promptly and must NOT call ObkHostCall synchronously — the
+ * dispatcher that would run it is the one waiting on this very call.
+ */
+extern int ObkAddInAutomation(const char *method,
+                              const uint8_t *req, int reqLen,
+                              uint8_t **resp, int *respLen);
 #endif /* OBK_BUILDING_ADDIN */
 
 #ifdef __cplusplus

--- a/head/internal/addinhost/loader.go
+++ b/head/internal/addinhost/loader.go
@@ -19,6 +19,8 @@ type addInLib interface {
 	activate() error
 	deactivate() error
 	notify(b []byte) error
+	hasAutomation() bool
+	automation(method string, req []byte) ([]byte, error)
 	close() error
 }
 
@@ -49,6 +51,16 @@ func (a *LoadedAddIn) Deactivate(*app.Session) error { return a.lib.deactivate()
 
 // Notify pushes a serialized host event to the add-in (ObkAddInNotify).
 func (a *LoadedAddIn) Notify(b []byte) error { return a.lib.notify(b) }
+
+// HasAutomation reports whether the add-in exports the optional ObkAddInAutomation
+// entry (app.AddInAutomationProbe), so the registry lists hasAutomation truthfully.
+func (a *LoadedAddIn) HasAutomation() bool { return a.lib.hasAutomation() }
+
+// CallAutomation routes an automation request to the add-in's optional
+// ObkAddInAutomation export (contract.AddInAutomation).
+func (a *LoadedAddIn) CallAutomation(method string, args []byte) ([]byte, error) {
+	return a.lib.automation(method, args)
+}
 
 // Close unloads the shared library (dlclose/FreeLibrary).
 func (a *LoadedAddIn) Close() error { return a.lib.close() }

--- a/head/internal/addinhost/testdata/echoaddin/main.go
+++ b/head/internal/addinhost/testdata/echoaddin/main.go
@@ -61,4 +61,21 @@ func ObkAddInNotify(ev *C.uint8_t, n C.int) C.int { return C.OBK_OK }
 //export ObkFree
 func ObkFree(p *C.uint8_t) { C.free(unsafe.Pointer(p)) }
 
+// ObkAddInAutomation is the OPTIONAL automation export (M05-F01 #252): it echoes
+// the method and payload back as JSON so the host-side automation round-trip test
+// can assert the buffer crossed both runtimes intact. Allocated with C.CBytes so
+// the host's release through ObkFree (C.free) matches.
+//
+//export ObkAddInAutomation
+func ObkAddInAutomation(method *C.char, req *C.uint8_t, n C.int, resp **C.uint8_t, respLen *C.int) C.int {
+	var payload []byte
+	if req != nil {
+		payload = C.GoBytes(unsafe.Pointer(req), n)
+	}
+	out := []byte(`{"method":"` + C.GoString(method) + `","payload":"` + string(payload) + `"}`)
+	*resp = (*C.uint8_t)(C.CBytes(out))
+	*respLen = C.int(len(out))
+	return C.OBK_OK
+}
+
 func main() {}

--- a/persistence/addinstate/addinstate.go
+++ b/persistence/addinstate/addinstate.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package addinstate persists the per-user add-in load behaviors (when each
+// installed add-in activates: startup / demand / disabled) to a single YAML file in
+// the OS config directory — the same per-user seam as themes and UI preferences
+// (M05-F01, #251). Only non-default behaviors are written, so a fresh install needs
+// no file and everything loads on startup.
+package addinstate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/persistence/yamlcodec"
+	"oblikovati.org/userconfig"
+)
+
+// behaviorsFile is the on-disk document: add-in id → stable behavior name
+// ("demand", "disabled"). Names, not numbers, so the file is hand-editable.
+type behaviorsFile struct {
+	Behaviors map[string]string `yaml:"behaviors"`
+}
+
+// FileStore persists the behaviors to a YAML file; it satisfies
+// app.AddInBehaviorStore.
+type FileStore struct{ path string }
+
+// DefaultPath is the per-user behaviors file in the shared config dir:
+// ~/.oblikovati/addin-behaviors.yaml on Linux/macOS.
+func DefaultPath() (string, error) {
+	return userconfig.File("addin-behaviors.yaml")
+}
+
+// NewFileStore returns a store backed by the file at path.
+func NewFileStore(path string) *FileStore { return &FileStore{path: path} }
+
+// Load reads the stored behaviors; a missing file is an empty map (fresh install).
+// An unknown behavior name is skipped rather than guessed, so a hand-edited typo
+// falls back to the default instead of disabling an add-in.
+func (s *FileStore) Load() (map[string]types.AddInLoadBehavior, error) {
+	raw, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return map[string]types.AddInLoadBehavior{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("addinstate: read %q: %w", s.path, err)
+	}
+	var f behaviorsFile
+	if err := yamlcodec.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("addinstate: parse %q: %w", s.path, err)
+	}
+	out := map[string]types.AddInLoadBehavior{}
+	for id, name := range f.Behaviors {
+		if b, ok := types.ParseAddInLoadBehavior(name); ok {
+			out[id] = b
+		}
+	}
+	return out, nil
+}
+
+// Save writes the behaviors, creating the config directory on first use.
+func (s *FileStore) Save(m map[string]types.AddInLoadBehavior) error {
+	f := behaviorsFile{Behaviors: map[string]string{}}
+	for id, b := range m {
+		f.Behaviors[id] = b.String()
+	}
+	data, err := yamlcodec.Marshal(f)
+	if err != nil {
+		return fmt.Errorf("addinstate: marshal behaviors: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("addinstate: create config dir for %q: %w", s.path, err)
+	}
+	return os.WriteFile(s.path, data, 0o644)
+}

--- a/persistence/addinstate/addinstate_test.go
+++ b/persistence/addinstate/addinstate_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addinstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+func TestLoadMissingFileIsEmpty(t *testing.T) {
+	s := NewFileStore(filepath.Join(t.TempDir(), "addin-behaviors.yaml"))
+	m, err := s.Load()
+	if err != nil || len(m) != 0 {
+		t.Fatalf("Load(missing) = (%v, %v), want empty map, nil", m, err)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "addin-behaviors.yaml")
+	s := NewFileStore(path)
+	in := map[string]types.AddInLoadBehavior{
+		"com.x.a": types.LoadOnDemand,
+		"com.x.b": types.LoadDisabled,
+	}
+	if err := s.Save(in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	out, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(out) != 2 || out["com.x.a"] != types.LoadOnDemand || out["com.x.b"] != types.LoadDisabled {
+		t.Errorf("round trip = %v, want %v", out, in)
+	}
+}
+
+func TestLoadSkipsUnknownBehaviorName(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "addin-behaviors.yaml")
+	yaml := "behaviors:\n  com.x.a: sometimes\n  com.x.b: demand\n"
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := NewFileStore(path).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, has := out["com.x.a"]; has {
+		t.Error("a typo'd behavior name should fall back to the default, not load")
+	}
+	if out["com.x.b"] != types.LoadOnDemand {
+		t.Errorf("com.x.b = %v, want demand", out["com.x.b"])
+	}
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F01, closing #251 and #252 and the registry/lifecycle scope of #245 (contract: Oblikovati/Oblikovati.API#45):

- **Registry**: `addins.list/get` serve manifest identity (displayName, version, kind, capabilities) + runtime state (activated, location, hasAutomation) from `AddInManager.Describe`.
- **Lifecycle**: `addins.activate/deactivate` over the wire; load behaviors (`startup`/`demand`/`disabled`) persist per user in `~/.oblikovati/addin-behaviors.yaml`; the head registers every discovered library but only activates LoadOnStartup entries, disabled add-ins refuse activation, and session events now reach only **active** add-ins.
- **Automation (#252)**: `addins.callAutomation` routes one add-in's call to another's automation surface. Shared-library add-ins expose it via the new optional `ObkAddInAutomation` export (resolved leniently by dlsym; reply buffers released through the add-in's own `ObkFree` — the cross-runtime ownership rule). Covered end-to-end through a real c-shared fixture.
- **Client applications**: `clientApps.register/unregister/list` track external automation drivers, distinct from in-process add-ins.

## Why

#251's acceptance ("the registry lists installed add-ins") and #252's ("one add-in obtains and calls another's automation object") had no public surface — the registry was host-internal. The api-parity audit on #245 additionally flagged load-behavior enums, add-in kind classification and the ClientApplication registry; all land here. Document subtypes + ClientOperationEvents were split to #665.

Closes #251. Closes #252.

## Tests

Registry/behavior/automation unit tests in `app`, wire round-trips in `addin/router`, YAML store round-trip in `persistence/addinstate`, and a real dlopen automation round-trip in `head/internal/addinhost` (echo fixture gained the optional export; the UI fixture proves absence is reported, not fatal). Full suite + lint green locally.

⚠️ CI needs Oblikovati/Oblikovati.API#45 merged first (checks out sibling develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)