### PR TITLE
Serve the ribbon object model and add-in browser panes, dockable windows (M05-F03)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -53,7 +53,26 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
 			return relayEdit(sink, e)
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.BrowserPaneNodeActivated) event.Outcome {
+			return relayJSON(sink, wire.BrowserNodeEvent{
+				Type: wire.EventBrowserNode, Pane: e.Pane, Node: e.Node, Gesture: e.Gesture,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.DockableWindowChanged) event.Outcome {
+			return relayJSON(sink, wire.DockableWindowChangedEvent{
+				Type: wire.EventDockableWindowChanged, ID: e.ID, Visible: e.Visible,
+			})
+		}),
 	}
+}
+
+// relayJSON serializes a wire event DTO and hands it to sink (passive listener).
+// Generic so each call site stays statically typed (the house no-`any` rule).
+func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent](sink Sink, ev E) event.Outcome {
+	if b, err := json.Marshal(ev); err == nil {
+		sink(b)
+	}
+	return event.Continue()
 }
 
 // relayEdit serializes a committed edit as the contract's [wire.EditCommittedEvent] (the

--- a/addin/events/events_test.go
+++ b/addin/events/events_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/doc"
 )
@@ -88,4 +89,68 @@ func has(s []string, v string) bool {
 		}
 	}
 	return false
+}
+
+// rawRecorder collects the raw JSON the sink receives, for events whose shapes are
+// wire DTOs rather than the package's own wireEvent (M05-F03 push events).
+type rawRecorder struct {
+	mu  sync.Mutex
+	got []string
+}
+
+func (r *rawRecorder) sink(b []byte) {
+	r.mu.Lock()
+	r.got = append(r.got, string(b))
+	r.mu.Unlock()
+}
+
+// TestForwardsBrowserPaneAndDockableWindowEvents checks the M05-F03 UI events reach
+// the sink as their wire DTOs: a pane-node gesture as browser.node and a window
+// visibility change as dockableWindow.changed.
+func TestForwardsBrowserPaneAndDockableWindowEvents(t *testing.T) {
+	s := app.NewSession()
+	var rec rawRecorder
+	subs := Subscribe(s, rec.sink)
+	defer func() {
+		for _, sub := range subs {
+			sub.Cancel()
+		}
+	}()
+
+	if err := s.BrowserPanes().Set(wire.BrowserPaneSpec{
+		ID: "sim", Title: "Simulation",
+		Nodes: []wire.BrowserNodeSpec{{ID: "f1", Label: "Force"}},
+	}); err != nil {
+		t.Fatalf("Set pane: %v", err)
+	}
+	if err := s.ActivateBrowserPaneNode("sim", "f1", app.BrowserGestureSelect); err != nil {
+		t.Fatalf("ActivateBrowserPaneNode: %v", err)
+	}
+	if err := s.SetDockableWindow(wire.DockableWindowSpec{ID: "w", Title: "W", Visible: true}); err != nil {
+		t.Fatalf("SetDockableWindow: %v", err)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	var node wire.BrowserNodeEvent
+	var win wire.DockableWindowChangedEvent
+	for _, raw := range rec.got {
+		_ = json.Unmarshal([]byte(raw), &node)
+		if node.Type == wire.EventBrowserNode {
+			break
+		}
+	}
+	if node.Pane != "sim" || node.Node != "f1" || node.Gesture != "select" {
+		t.Errorf("browser.node = %+v, want sim/f1/select", node)
+	}
+	found := false
+	for _, raw := range rec.got {
+		if json.Unmarshal([]byte(raw), &win) == nil && win.Type == wire.EventDockableWindowChanged {
+			found = true
+			break
+		}
+	}
+	if !found || win.ID != "w" || !win.Visible {
+		t.Errorf("dockableWindow.changed = %+v (found=%v), want visible w", win, found)
+	}
 }

--- a/addin/router/commands.go
+++ b/addin/router/commands.go
@@ -44,9 +44,14 @@ func createCommand(s *app.Session, args json.RawMessage) (json.RawMessage, error
 	}
 	cmd := app.NewCommand(in.ID, in.DisplayName, in.Category, func(*app.Session) error { return nil }).
 		WithTab(in.Tab).WithEnvironment(in.Environment).WithAlias(in.Alias).WithTooltip(in.Tooltip).
-		WithIcon(in.Icon).WithButtonStyle(in.ButtonStyle)
+		WithIcon(in.Icon).WithButtonStyle(in.ButtonStyle).WithKind(in.Kind)
 	if in.Ribbon != "" {
 		cmd.WithRibbons(in.Ribbon)
+	}
+	// A PopupControl lists other registered commands by id (the CommandBarPopUp
+	// equivalent, M05-F03); unknown ids are skipped at ribbon-build time.
+	if in.Kind == app.PopupControl || len(in.Items) > 0 {
+		cmd.WithPopupItems(in.Items...)
 	}
 	if err := s.Commands().Add(cmd); err != nil {
 		return nil, err

--- a/addin/router/ribbon.go
+++ b/addin/router/ribbon.go
@@ -5,15 +5,17 @@ package router
 import (
 	"encoding/json"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 )
 
-// ribbonList returns the ribbon currently shown for the active document (wire ribbon.list /
-// Inventor's "list the contents of the ribbon"), so an add-in can discover the tab and panel
-// internal names to insert its controls into. It mirrors exactly what the shell renders — the
-// ribbon for the active document's type (ZeroDoc when none is open), with contextual tabs
-// present only when their environment is active.
+// ribbonList returns the ribbon currently shown for the active document (wire ribbon.list):
+// the typed ribbon object model of M05-F03 — tabs, panels (with their selector when they
+// render as a selection box), and each control's kind, look, live state and dropdown items.
+// It mirrors exactly what the shell renders — the ribbon for the active document's type
+// (ZeroDoc when none is open), with contextual tabs present only when their environment is
+// active.
 func ribbonList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	r := app.BuildRibbon(s)
 	tabs := make([]wire.RibbonTabInfo, len(r.Tabs))
@@ -23,18 +25,70 @@ func ribbonList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	return json.Marshal(wire.ListRibbonResult{Key: r.Key, Tabs: tabs})
 }
 
-// panelInfos maps a tab's panels (and their buttons) to the wire shape.
+// panelInfos maps a tab's panels (and their buttons or selector) to the wire shape.
 func panelInfos(panels []app.RibbonPanel) []wire.RibbonPanelInfo {
 	out := make([]wire.RibbonPanelInfo, len(panels))
 	for i, p := range panels {
-		controls := make([]wire.RibbonControlInfo, len(p.Buttons))
-		for j, b := range p.Buttons {
-			controls[j] = wire.RibbonControlInfo{
-				CommandID:   b.Command.ID(),
-				DisplayName: b.Command.DisplayName(),
-			}
+		info := wire.RibbonPanelInfo{Name: p.Name}
+		if p.Selector != nil {
+			info.Selector = selectorInfo(p.Selector)
+		} else {
+			info.Controls = controlInfos(p.Buttons)
 		}
-		out[i] = wire.RibbonPanelInfo{Name: p.Name, Controls: controls}
+		out[i] = info
 	}
 	return out
+}
+
+// controlInfos maps a panel's buttons to the wire control shape.
+func controlInfos(buttons []app.RibbonButton) []wire.RibbonControlInfo {
+	out := make([]wire.RibbonControlInfo, len(buttons))
+	for i, b := range buttons {
+		out[i] = wire.RibbonControlInfo{
+			CommandID:   b.Command.ID(),
+			DisplayName: b.Command.DisplayName(),
+			Kind:        b.Command.Kind(),
+			ButtonStyle: b.Command.ButtonStyle(),
+			Icon:        b.Command.Icon(),
+			Tooltip:     b.Command.Tooltip(),
+			Alias:       b.Command.Alias(),
+			Enabled:     b.Enabled,
+			Active:      b.Active,
+			Items:       itemInfos(b.Variants),
+		}
+	}
+	return out
+}
+
+// itemInfos maps a button's resolved dropdown entries (split-button variants or popup
+// items) to the wire shape.
+func itemInfos(variants []app.RibbonVariant) []wire.RibbonItemInfo {
+	if len(variants) == 0 {
+		return nil
+	}
+	out := make([]wire.RibbonItemInfo, len(variants))
+	for i, v := range variants {
+		out[i] = wire.RibbonItemInfo{CommandID: v.CommandID, Label: v.Label, Tooltip: v.Tooltip, Enabled: v.Enabled}
+	}
+	return out
+}
+
+// selectorInfo maps a selection-box panel to the wire shape.
+func selectorInfo(sel *app.RibbonSelector) *wire.RibbonSelectorInfo {
+	options := make([]wire.RibbonItemInfo, len(sel.Options))
+	for i, o := range sel.Options {
+		options[i] = wire.RibbonItemInfo{CommandID: o.CommandID, Label: o.Label, Tooltip: o.Tooltip, Enabled: true}
+	}
+	return &wire.RibbonSelectorInfo{Options: options, SelectedIndex: sel.SelectedIndex}
+}
+
+// listEnvironments returns the UI environments the command framework scopes by,
+// flagging the active one (wire ui.listEnvironments; add-in environments: #667).
+func listEnvironments(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	active := app.CurrentEnvironment(s)
+	envs := []wire.EnvironmentInfo{
+		{Environment: types.BaseEnvironment, Name: "Base", Active: active == types.BaseEnvironment},
+		{Environment: types.SketchEnvironment, Name: "Sketch", Active: active == types.SketchEnvironment},
+	}
+	return json.Marshal(wire.ListEnvironmentsResult{Environments: envs})
 }

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -45,6 +45,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerExchangeHandlers()
 	r.registerFontHandlers()
 	r.registerAddInHandlers()
+	r.registerUISurfaceHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/addin/router/ui_surfaces.go
+++ b/addin/router/ui_surfaces.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerUISurfaceHandlers wires the add-in UI surfaces of M05-F03: browser panes
+// (#256), dockable windows and the environment listing (#247).
+func (r *Router) registerUISurfaceHandlers() {
+	r.handlers[wire.MethodBrowserSetPane] = setBrowserPane
+	r.handlers[wire.MethodBrowserDeletePane] = deleteBrowserPane
+	r.handlers[wire.MethodBrowserListPanes] = listBrowserPanes
+	r.handlers[wire.MethodDockableWindowsSet] = setDockableWindow
+	r.handlers[wire.MethodDockableWindowsSetVisible] = setDockableWindowVisible
+	r.handlers[wire.MethodDockableWindowsDelete] = deleteDockableWindow
+	r.handlers[wire.MethodDockableWindowsList] = listDockableWindows
+	r.handlers[wire.MethodUIListEnvironments] = listEnvironments
+}
+
+// setBrowserPane creates or replaces an add-in browser pane (wire browser.setPane).
+func setBrowserPane(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetBrowserPaneArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.BrowserPanes().Set(req.Pane); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// deleteBrowserPane removes an add-in browser pane (wire browser.deletePane).
+func deleteBrowserPane(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.DeleteBrowserPaneArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.BrowserPanes().Delete(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// listBrowserPanes returns the add-in panes in creation order (wire browser.listPanes).
+func listBrowserPanes(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.ListBrowserPanesResult{Panes: s.BrowserPanes().List()})
+}
+
+// setDockableWindow creates or replaces an add-in dockable window
+// (wire dockableWindows.set).
+func setDockableWindow(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetDockableWindowArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.SetDockableWindow(req.Window); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// setDockableWindowVisible shows/hides an add-in window (wire dockableWindows.setVisible).
+func setDockableWindowVisible(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetDockableWindowVisibleArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.SetDockableWindowVisible(req.ID, req.Visible); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// deleteDockableWindow removes an add-in window (wire dockableWindows.delete).
+func deleteDockableWindow(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.DeleteDockableWindowArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.DeleteDockableWindow(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// listDockableWindows returns the add-in windows in creation order
+// (wire dockableWindows.list).
+func listDockableWindows(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.ListDockableWindowsResult{Windows: s.DockableWindows().List()})
+}

--- a/addin/router/ui_surfaces_test.go
+++ b/addin/router/ui_surfaces_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+func TestBrowserPanesOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "browser.setPane",
+		`{"pane":{"id":"sim","title":"Simulation","nodes":[{"id":"loads","label":"Loads","children":[{"id":"f1","label":"Force 10N"}]}]}}`, nil)
+
+	var lst wire.ListBrowserPanesResult
+	call(t, r, s, "browser.listPanes", "{}", &lst)
+	if len(lst.Panes) != 1 || lst.Panes[0].Nodes[0].Children[0].ID != "f1" {
+		t.Fatalf("listPanes = %+v, want the declared tree intact", lst.Panes)
+	}
+
+	call(t, r, s, "browser.deletePane", `{"id":"sim"}`, nil)
+	call(t, r, s, "browser.listPanes", "{}", &lst)
+	if len(lst.Panes) != 0 {
+		t.Fatalf("panes after delete = %+v, want none", lst.Panes)
+	}
+	if _, err := r.Handle(s, "browser.deletePane", []byte(`{"id":"sim"}`)); err == nil {
+		t.Error("deleting an unknown pane should fail")
+	}
+}
+
+func TestDockableWindowsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "dockableWindows.set",
+		`{"window":{"id":"sim.panel","title":"Simulation","dock":2,"visible":true,"controls":[{"kind":1,"text":"Run","commandId":"Sim.Run"}]}}`, nil)
+
+	var lst wire.ListDockableWindowsResult
+	call(t, r, s, "dockableWindows.list", "{}", &lst)
+	if len(lst.Windows) != 1 || lst.Windows[0].Dock != types.DockRight || !lst.Windows[0].Visible {
+		t.Fatalf("list = %+v, want one visible dock-right window", lst.Windows)
+	}
+	if lst.Windows[0].Controls[0].Kind != types.PanelButton {
+		t.Errorf("control kind = %v, want button", lst.Windows[0].Controls[0].Kind)
+	}
+
+	call(t, r, s, "dockableWindows.setVisible", `{"id":"sim.panel","visible":false}`, nil)
+	call(t, r, s, "dockableWindows.list", "{}", &lst)
+	if lst.Windows[0].Visible {
+		t.Error("window still visible after setVisible(false)")
+	}
+
+	call(t, r, s, "dockableWindows.delete", `{"id":"sim.panel"}`, nil)
+	call(t, r, s, "dockableWindows.list", "{}", &lst)
+	if len(lst.Windows) != 0 {
+		t.Fatalf("windows after delete = %+v, want none", lst.Windows)
+	}
+}
+
+func TestListEnvironmentsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	var res wire.ListEnvironmentsResult
+	call(t, r, s, "ui.listEnvironments", "{}", &res)
+	if len(res.Environments) != 2 {
+		t.Fatalf("environments = %+v, want Base and Sketch", res.Environments)
+	}
+	if !res.Environments[0].Active || res.Environments[0].Name != "Base" {
+		t.Errorf("first = %+v, want active Base (no sketch open)", res.Environments[0])
+	}
+}
+
+// TestRibbonListCarriesTypedControlModel checks ribbon.list serves the M05-F03 typed
+// model: control kind/style/state, popup items, and the selector of a combo panel.
+func TestRibbonListCarriesTypedControlModel(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "commands.create",
+		`{"id":"x.a","displayName":"Alpha","category":"Demo"}`, nil)
+	call(t, r, s, "commands.create",
+		`{"id":"x.menu","displayName":"Menu","category":"Demo","kind":4,"items":["x.a"]}`, nil)
+
+	var res wire.ListRibbonResult
+	call(t, r, s, "ribbon.list", "{}", &res)
+
+	menu := findControl(t, res, "x.menu")
+	if menu.Kind != types.PopupControl {
+		t.Errorf("menu kind = %v, want popup", menu.Kind)
+	}
+	if len(menu.Items) != 1 || menu.Items[0].CommandID != "x.a" || menu.Items[0].Label != "Alpha" {
+		t.Errorf("menu items = %+v, want the resolved x.a entry", menu.Items)
+	}
+
+	if !hasSelectorPanel(res) {
+		t.Error("no panel serialized as a selector — the Visual Style combo panel should")
+	}
+}
+
+// findControl locates a control by command id across the ribbon.
+func findControl(t *testing.T, res wire.ListRibbonResult, id string) wire.RibbonControlInfo {
+	t.Helper()
+	for _, tab := range res.Tabs {
+		for _, p := range tab.Panels {
+			for _, c := range p.Controls {
+				if c.CommandID == id {
+					return c
+				}
+			}
+		}
+	}
+	t.Fatalf("control %q not found in ribbon", id)
+	return wire.RibbonControlInfo{}
+}
+
+// hasSelectorPanel reports whether any panel rendered as a selection box.
+func hasSelectorPanel(res wire.ListRibbonResult) bool {
+	for _, tab := range res.Tabs {
+		for _, p := range tab.Panels {
+			if p.Selector != nil && len(p.Selector.Options) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/app/browser_panes.go
+++ b/app/browser_panes.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+// Add-in browser panes (M05-F03, #256): named trees an add-in declares through
+// browser.setPane, shown by the head beside the built-in Model pane. The pane spec
+// is declared bulk state ([wire.BrowserPaneSpec] is already pure data, so it IS the
+// model — re-declaring it here would only duplicate the shape).
+
+// BrowserPaneNodeActivated fires (After) when the user interacts with an add-in
+// pane node; the events relay forwards it as a wire browser.node push event.
+// Gesture is one of the BrowserGesture* constants.
+type BrowserPaneNodeActivated struct {
+	Pane    string
+	Node    string
+	Gesture string
+}
+
+// EventID implements event.Event.
+func (BrowserPaneNodeActivated) EventID() event.TypeID { return tidBrowserPaneNode }
+
+// The gestures a browser pane node reports.
+const (
+	BrowserGestureSelect   = "select"
+	BrowserGestureDouble   = "double"
+	BrowserGestureExpand   = "expand"
+	BrowserGestureCollapse = "collapse"
+)
+
+// AddInBrowserPanes stores the declared panes in creation order.
+type AddInBrowserPanes struct {
+	order []string
+	panes map[string]wire.BrowserPaneSpec
+}
+
+// NewAddInBrowserPanes returns an empty pane store.
+func NewAddInBrowserPanes() *AddInBrowserPanes {
+	return &AddInBrowserPanes{panes: map[string]wire.BrowserPaneSpec{}}
+}
+
+// Set creates the pane or replaces its whole tree.
+func (p *AddInBrowserPanes) Set(spec wire.BrowserPaneSpec) error {
+	if spec.ID == "" || spec.Title == "" {
+		return fmt.Errorf("app: browser pane needs id and title, got id=%q title=%q", spec.ID, spec.Title)
+	}
+	if _, exists := p.panes[spec.ID]; !exists {
+		p.order = append(p.order, spec.ID)
+	}
+	p.panes[spec.ID] = spec
+	return nil
+}
+
+// Delete removes a pane.
+func (p *AddInBrowserPanes) Delete(id string) error {
+	if _, ok := p.panes[id]; !ok {
+		return fmt.Errorf("app: no browser pane %q", id)
+	}
+	delete(p.panes, id)
+	for i, x := range p.order {
+		if x == id {
+			p.order = append(p.order[:i], p.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// List returns the panes in creation order.
+func (p *AddInBrowserPanes) List() []wire.BrowserPaneSpec {
+	out := make([]wire.BrowserPaneSpec, len(p.order))
+	for i, id := range p.order {
+		out[i] = p.panes[id]
+	}
+	return out
+}
+
+// BrowserPanes returns the add-in browser-pane store.
+func (s *Session) BrowserPanes() *AddInBrowserPanes { return s.browserPanes }
+
+// ActivateBrowserPaneNode reports a user gesture on an add-in pane node — the head
+// calls it from the browser UI; the event reaches the owning add-in through the
+// events relay. Unknown panes error so a stale head click is loud, not silent.
+func (s *Session) ActivateBrowserPaneNode(pane, node, gesture string) error {
+	if _, ok := s.browserPanes.panes[pane]; !ok {
+		return fmt.Errorf("app: no browser pane %q", pane)
+	}
+	switch gesture {
+	case BrowserGestureSelect, BrowserGestureDouble, BrowserGestureExpand, BrowserGestureCollapse:
+	default:
+		return fmt.Errorf("app: unknown browser gesture %q (select/double/expand/collapse)", gesture)
+	}
+	event.Emit(s.bus, event.After, BrowserPaneNodeActivated{Pane: pane, Node: node, Gesture: gesture})
+	return nil
+}

--- a/app/browser_panes_test.go
+++ b/app/browser_panes_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+func simPane() wire.BrowserPaneSpec {
+	return wire.BrowserPaneSpec{
+		ID: "sim", Title: "Simulation",
+		Nodes: []wire.BrowserNodeSpec{{
+			ID: "loads", Label: "Loads", Expanded: true,
+			Children: []wire.BrowserNodeSpec{{ID: "f1", Label: "Force 10N"}},
+		}},
+	}
+}
+
+func TestBrowserPanesSetReplaceDeleteList(t *testing.T) {
+	panes := NewAddInBrowserPanes()
+	if err := panes.Set(simPane()); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	replaced := simPane()
+	replaced.Nodes = nil
+	if err := panes.Set(replaced); err != nil {
+		t.Fatalf("Set(replace): %v", err)
+	}
+	lst := panes.List()
+	if len(lst) != 1 || len(lst[0].Nodes) != 0 {
+		t.Fatalf("List = %+v, want one pane with the replaced (empty) tree", lst)
+	}
+	if err := panes.Delete("sim"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(panes.List()) != 0 {
+		t.Error("pane survived Delete")
+	}
+	if err := panes.Delete("sim"); err == nil {
+		t.Error("Delete(unknown) should fail")
+	}
+}
+
+func TestBrowserPaneRejectsMissingIdentity(t *testing.T) {
+	if err := NewAddInBrowserPanes().Set(wire.BrowserPaneSpec{ID: "x"}); err == nil {
+		t.Error("Set without title should fail")
+	}
+}
+
+func TestActivateBrowserPaneNodeEmitsEvent(t *testing.T) {
+	s := NewSession()
+	if err := s.BrowserPanes().Set(simPane()); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	var got []BrowserPaneNodeActivated
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e BrowserPaneNodeActivated) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+
+	if err := s.ActivateBrowserPaneNode("sim", "f1", BrowserGestureDouble); err != nil {
+		t.Fatalf("ActivateBrowserPaneNode: %v", err)
+	}
+	if len(got) != 1 || got[0].Node != "f1" || got[0].Gesture != "double" {
+		t.Fatalf("events = %+v, want one double-gesture on f1", got)
+	}
+
+	if err := s.ActivateBrowserPaneNode("ghost", "f1", BrowserGestureSelect); err == nil {
+		t.Error("unknown pane should error")
+	}
+	if err := s.ActivateBrowserPaneNode("sim", "f1", "hover"); err == nil {
+		t.Error("unknown gesture should error")
+	}
+}

--- a/app/command.go
+++ b/app/command.go
@@ -21,19 +21,18 @@ const (
 	CompactIconButton = types.CompactIconButton
 )
 
-// ControlKind is the UI control a command presents as — Inventor's ControlDefinition
-// kinds. The ribbon (ImGui) renders the right widget per kind; the logic is identical.
-type ControlKind uint8
+// ControlKind is the UI control a command presents as — the ControlDefinition
+// kinds. Defined once in the Apache-2.0 contract ([types.ControlKind], M05-F03);
+// this alias keeps the app.ButtonControl spelling local to the implementation
+// (ADR-0018). The ribbon (ImGui) renders the right widget per kind.
+type ControlKind = types.ControlKind
 
 const (
-	// ButtonControl: a one-shot command button (the default).
-	ButtonControl ControlKind = iota
-	// ToggleControl: a checkbox/toggle button.
-	ToggleControl
-	// ComboControl: a drop-down list.
-	ComboControl
-	// SpinnerControl: a numeric spinner.
-	SpinnerControl
+	ButtonControl  = types.ButtonControl
+	ToggleControl  = types.ToggleControl
+	ComboControl   = types.ComboControl
+	SpinnerControl = types.SpinnerControl
+	PopupControl   = types.PopupControl
 )
 
 // CommandDefinition is a registered command — Inventor's ControlDefinition plus its
@@ -60,6 +59,7 @@ type CommandDefinition struct {
 	run              func(*Session) error
 	variants         []*CommandDefinition // split-button dropdown entries (Inventor's variant flyout)
 	isVariant        bool                 // true ⇒ reachable only via a head command's dropdown, never its own panel button
+	popupItems       []string             // for PopupControl: ids of the registered commands its menu lists (M05-F03)
 }
 
 // NewCommand starts a command definition with the required fields. Use the With*
@@ -133,6 +133,20 @@ func (c *CommandDefinition) WithVariants(variants ...*CommandDefinition) *Comman
 // Variants returns this command's split-button dropdown entries (nil if it is a plain
 // button). The slice is the live backing array; callers must not mutate it.
 func (c *CommandDefinition) Variants() []*CommandDefinition { return c.variants }
+
+// WithPopupItems makes this command a PopupControl listing other REGISTERED commands
+// by id — the CommandBarPopUp equivalent (M05-F03, #247). Unlike WithVariants, the
+// items are ordinary commands resolved from the registry at ribbon-build time, so an
+// add-in can group its existing buttons under one menu without re-declaring them.
+// Unknown ids are skipped at build time (the menu shows what exists).
+func (c *CommandDefinition) WithPopupItems(ids ...string) *CommandDefinition {
+	c.kind = PopupControl
+	c.popupItems = ids
+	return c
+}
+
+// PopupItems returns the command ids a PopupControl lists (nil otherwise).
+func (c *CommandDefinition) PopupItems() []string { return c.popupItems }
 
 // WithActive sets the predicate that reports whether this command is the *current* selection
 // of its combo group — used to drive the highlighted item of a ribbon selection box (a panel

--- a/app/dockwindow_store.go
+++ b/app/dockwindow_store.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+// Add-in dockable windows (M05-F03, #247): titled panels an add-in declares through
+// dockableWindows.set; the head renders their declarative content and docks them.
+// Like browser panes, the wire spec is the model (pure declared data).
+
+// DockableWindowChanged fires (After) when a window's visibility changes — by the
+// add-in, or by the user closing it in the head. The events relay forwards it as a
+// wire dockableWindow.changed push event (DockableWindowsEvents OnShow/OnHide).
+type DockableWindowChanged struct {
+	ID      string
+	Visible bool
+}
+
+// EventID implements event.Event.
+func (DockableWindowChanged) EventID() event.TypeID { return tidDockableWinChanged }
+
+// AddInDockableWindows stores the declared windows in creation order.
+type AddInDockableWindows struct {
+	order   []string
+	windows map[string]wire.DockableWindowSpec
+}
+
+// NewAddInDockableWindows returns an empty window store.
+func NewAddInDockableWindows() *AddInDockableWindows {
+	return &AddInDockableWindows{windows: map[string]wire.DockableWindowSpec{}}
+}
+
+// List returns the windows in creation order.
+func (w *AddInDockableWindows) List() []wire.DockableWindowSpec {
+	out := make([]wire.DockableWindowSpec, len(w.order))
+	for i, id := range w.order {
+		out[i] = w.windows[id]
+	}
+	return out
+}
+
+// Get returns one window by id.
+func (w *AddInDockableWindows) Get(id string) (wire.DockableWindowSpec, bool) {
+	spec, ok := w.windows[id]
+	return spec, ok
+}
+
+// DockableWindows returns the add-in dockable-window store.
+func (s *Session) DockableWindows() *AddInDockableWindows { return s.dockableWindows }
+
+// SetDockableWindow creates the window or replaces its title/content, emitting a
+// visibility event when the effective visibility changed (a new visible window is a
+// show; re-declaring with Visible:false hides).
+func (s *Session) SetDockableWindow(spec wire.DockableWindowSpec) error {
+	if spec.ID == "" || spec.Title == "" {
+		return fmt.Errorf("app: dockable window needs id and title, got id=%q title=%q", spec.ID, spec.Title)
+	}
+	prev, existed := s.dockableWindows.windows[spec.ID]
+	if !existed {
+		s.dockableWindows.order = append(s.dockableWindows.order, spec.ID)
+	}
+	s.dockableWindows.windows[spec.ID] = spec
+	if !existed && spec.Visible || existed && prev.Visible != spec.Visible {
+		event.Emit(s.bus, event.After, DockableWindowChanged{ID: spec.ID, Visible: spec.Visible})
+	}
+	return nil
+}
+
+// SetDockableWindowVisible shows or hides a window without touching its content —
+// also the path the head takes when the user closes the window, so the owning
+// add-in always observes the change.
+func (s *Session) SetDockableWindowVisible(id string, visible bool) error {
+	spec, ok := s.dockableWindows.windows[id]
+	if !ok {
+		return fmt.Errorf("app: no dockable window %q", id)
+	}
+	if spec.Visible == visible {
+		return nil
+	}
+	spec.Visible = visible
+	s.dockableWindows.windows[id] = spec
+	event.Emit(s.bus, event.After, DockableWindowChanged{ID: id, Visible: visible})
+	return nil
+}
+
+// DeleteDockableWindow removes a window, emitting a hide first when it was visible
+// (the add-in sees a consistent shown→hidden→gone sequence).
+func (s *Session) DeleteDockableWindow(id string) error {
+	spec, ok := s.dockableWindows.windows[id]
+	if !ok {
+		return fmt.Errorf("app: no dockable window %q", id)
+	}
+	if spec.Visible {
+		event.Emit(s.bus, event.After, DockableWindowChanged{ID: id, Visible: false})
+	}
+	delete(s.dockableWindows.windows, id)
+	for i, x := range s.dockableWindows.order {
+		if x == id {
+			s.dockableWindows.order = append(s.dockableWindows.order[:i], s.dockableWindows.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}

--- a/app/dockwindow_store_test.go
+++ b/app/dockwindow_store_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+func simWindow(visible bool) wire.DockableWindowSpec {
+	return wire.DockableWindowSpec{
+		ID: "sim.panel", Title: "Simulation", Dock: types.DockRight, Visible: visible,
+		Controls: []wire.PanelControlSpec{
+			{Kind: types.PanelLabel, Text: "Mesh: 12k"},
+			{Kind: types.PanelButton, Text: "Run", CommandID: "Sim.Run"},
+		},
+	}
+}
+
+// dockEventLog subscribes to visibility events and records them.
+func dockEventLog(s *Session) *[]DockableWindowChanged {
+	var got []DockableWindowChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e DockableWindowChanged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+	return &got
+}
+
+func TestSetDockableWindowEmitsOnVisibilityTransitions(t *testing.T) {
+	s := NewSession()
+	got := dockEventLog(s)
+
+	if err := s.SetDockableWindow(simWindow(true)); err != nil { // new visible ⇒ shown
+		t.Fatalf("SetDockableWindow: %v", err)
+	}
+	if err := s.SetDockableWindow(simWindow(true)); err != nil { // same visibility ⇒ silent
+		t.Fatalf("SetDockableWindow(re-set): %v", err)
+	}
+	if err := s.SetDockableWindow(simWindow(false)); err != nil { // hide
+		t.Fatalf("SetDockableWindow(hide): %v", err)
+	}
+	want := []DockableWindowChanged{{ID: "sim.panel", Visible: true}, {ID: "sim.panel", Visible: false}}
+	if len(*got) != 2 || (*got)[0] != want[0] || (*got)[1] != want[1] {
+		t.Fatalf("events = %+v, want shown then hidden", *got)
+	}
+}
+
+func TestSetDockableWindowVisibleRoundTrip(t *testing.T) {
+	s := NewSession()
+	if err := s.SetDockableWindow(simWindow(false)); err != nil {
+		t.Fatalf("SetDockableWindow: %v", err)
+	}
+	got := dockEventLog(s)
+
+	if err := s.SetDockableWindowVisible("sim.panel", true); err != nil {
+		t.Fatalf("SetVisible(true): %v", err)
+	}
+	if err := s.SetDockableWindowVisible("sim.panel", true); err != nil { // no-op
+		t.Fatalf("SetVisible(repeat): %v", err)
+	}
+	spec, ok := s.DockableWindows().Get("sim.panel")
+	if !ok || !spec.Visible {
+		t.Fatalf("Get = (%+v, %v), want visible window", spec, ok)
+	}
+	if len(*got) != 1 || !(*got)[0].Visible {
+		t.Fatalf("events = %+v, want exactly one show", *got)
+	}
+	if err := s.SetDockableWindowVisible("ghost", true); err == nil {
+		t.Error("SetVisible(unknown) should fail")
+	}
+}
+
+func TestDeleteDockableWindowEmitsHideFirst(t *testing.T) {
+	s := NewSession()
+	if err := s.SetDockableWindow(simWindow(true)); err != nil {
+		t.Fatalf("SetDockableWindow: %v", err)
+	}
+	got := dockEventLog(s)
+
+	if err := s.DeleteDockableWindow("sim.panel"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].Visible {
+		t.Fatalf("events = %+v, want one hide before removal", *got)
+	}
+	if len(s.DockableWindows().List()) != 0 {
+		t.Error("window survived Delete")
+	}
+	if err := s.DeleteDockableWindow("sim.panel"); err == nil {
+		t.Error("Delete(unknown) should fail")
+	}
+}
+
+func TestSetDockableWindowRejectsMissingIdentity(t *testing.T) {
+	if err := NewSession().SetDockableWindow(wire.DockableWindowSpec{Title: "x"}); err == nil {
+		t.Error("Set without id should fail")
+	}
+}

--- a/app/events.go
+++ b/app/events.go
@@ -9,11 +9,13 @@ import (
 
 // Application UI events on the session bus. Stable TypeIDs (0x05xx = M05 UI).
 const (
-	tidCommandStarted    event.TypeID = 0x0501
-	tidCommandEnded      event.TypeID = 0x0502
-	tidSelectionChanged  event.TypeID = 0x0503
-	tidTransactionChange event.TypeID = 0x0504
-	tidEditCommitted     event.TypeID = 0x0505
+	tidCommandStarted     event.TypeID = 0x0501
+	tidCommandEnded       event.TypeID = 0x0502
+	tidSelectionChanged   event.TypeID = 0x0503
+	tidTransactionChange  event.TypeID = 0x0504
+	tidEditCommitted      event.TypeID = 0x0505
+	tidBrowserPaneNode    event.TypeID = 0x0506 // app/browser_panes.go (M05-F03)
+	tidDockableWinChanged event.TypeID = 0x0507 // app/dockable_windows.go (M05-F03)
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's

--- a/app/ribbon.go
+++ b/app/ribbon.go
@@ -104,8 +104,13 @@ func BuildRibbon(s *Session) Ribbon {
 }
 
 // resolveVariants turns a head command's variant definitions into dropdown entries with
-// each variant's enabled state resolved against the session this frame.
+// each variant's enabled state resolved against the session this frame. A PopupControl's
+// entries come from the registry instead — its menu lists other registered commands by id
+// (M05-F03, #247).
 func resolveVariants(c *CommandDefinition, s *Session) []RibbonVariant {
+	if c.kind == PopupControl {
+		return resolvePopupItems(c, s)
+	}
 	if len(c.variants) == 0 {
 		return nil
 	}
@@ -117,6 +122,25 @@ func resolveVariants(c *CommandDefinition, s *Session) []RibbonVariant {
 			Tooltip:   v.Tooltip(),
 			Enabled:   v.IsEnabled(s),
 		}
+	}
+	return out
+}
+
+// resolvePopupItems looks a popup's item ids up in the registry, skipping unknown ids so
+// the menu shows what exists (an add-in may declare items before registering them all).
+func resolvePopupItems(c *CommandDefinition, s *Session) []RibbonVariant {
+	var out []RibbonVariant
+	for _, id := range c.popupItems {
+		item, ok := s.commands.ByID(id)
+		if !ok {
+			continue
+		}
+		out = append(out, RibbonVariant{
+			CommandID: item.ID(),
+			Label:     item.DisplayName(),
+			Tooltip:   item.Tooltip(),
+			Enabled:   item.IsEnabled(s),
+		})
 	}
 	return out
 }

--- a/app/ribbon_key.go
+++ b/app/ribbon_key.go
@@ -70,13 +70,18 @@ const (
 	SketchEnvironment = types.SketchEnvironment
 )
 
-// currentEnvironment reports the session's active ribbon environment.
-func currentEnvironment(s *Session) Environment {
+// CurrentEnvironment reports the session's active ribbon environment — exported so
+// the router can serve ui.listEnvironments from the same resolution the shell uses
+// (M05-F03, #247).
+func CurrentEnvironment(s *Session) Environment {
 	if s.InSketch() {
 		return SketchEnvironment
 	}
 	return BaseEnvironment
 }
+
+// currentEnvironment keeps the historical package-internal spelling.
+func currentEnvironment(s *Session) Environment { return CurrentEnvironment(s) }
 
 // environmentShows reports whether a command scoped to cmdEnv appears in the current
 // environment: base-environment commands always show; a contextual command shows only in its

--- a/app/ribbon_popup_test.go
+++ b/app/ribbon_popup_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestPopupControlResolvesRegistryItems checks a PopupControl's ribbon button lists
+// its item commands (resolved live from the registry), skipping ids that don't exist
+// — the CommandBarPopUp behavior of M05-F03.
+func TestPopupControlResolvesRegistryItems(t *testing.T) {
+	s := NewSession() // no document open ⇒ the ZeroDoc ribbon, so commands target it
+	noop := func(*Session) error { return nil }
+	if err := s.Commands().Add(NewCommand("x.a", "Alpha", "Demo", noop).WithTooltip("first").WithRibbons(ZeroDocRibbon)); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := s.Commands().Add(NewCommand("x.b", "Beta", "Demo", noop).WithRibbons(ZeroDocRibbon)); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	popup := NewCommand("x.menu", "Tools Menu", "Demo", noop).WithRibbons(ZeroDocRibbon).
+		WithPopupItems("x.a", "x.ghost", "x.b")
+	if err := s.Commands().Add(popup); err != nil {
+		t.Fatalf("add popup: %v", err)
+	}
+	if popup.Kind() != PopupControl {
+		t.Fatalf("WithPopupItems should set PopupControl, got %v", popup.Kind())
+	}
+
+	panel, ok := BuildRibbon(s).Panel("Demo")
+	if !ok {
+		t.Fatal("Demo panel missing from ribbon")
+	}
+	var menu *RibbonButton
+	for i := range panel.Buttons {
+		if panel.Buttons[i].Command.ID() == "x.menu" {
+			menu = &panel.Buttons[i]
+		}
+	}
+	if menu == nil {
+		t.Fatal("popup button missing from panel")
+	}
+	if len(menu.Variants) != 2 || menu.Variants[0].CommandID != "x.a" || menu.Variants[1].CommandID != "x.b" {
+		t.Fatalf("popup items = %+v, want x.a and x.b (ghost skipped)", menu.Variants)
+	}
+	if menu.Variants[0].Tooltip != "first" || !menu.Variants[0].Enabled {
+		t.Errorf("item[0] = %+v, want tooltip and live enabled state carried", menu.Variants[0])
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -48,6 +48,8 @@ type Session struct {
 	graphics           *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins             *AddInManager
 	clientApps         *ClientApplicationRegistry // external automation drivers (M05-F01)
+	browserPanes       *AddInBrowserPanes         // add-in browser panes (M05-F03)
+	dockableWindows    *AddInDockableWindows      // add-in dockable windows (M05-F03)
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store
@@ -98,17 +100,19 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 
 func newSession(store doc.Store) *Session {
 	s := &Session{
-		workspace:      doc.NewWorkspace(store),
-		commands:       NewCommandManager(),
-		histories:      map[doc.ID]*docHistory{},
-		bus:            event.NewBus(),
-		selection:      NewSelection(),
-		camera:         scene.NewCamera(800, 600),
-		hiddenBodyKeys: map[string]bool{},
-		graphics:       clientgraphics.NewStore(),
-		addins:         NewAddInManager(),
-		clientApps:     NewClientApplicationRegistry(),
-		visualStyle:    renderer.ShadedWithEdges,
+		workspace:       doc.NewWorkspace(store),
+		commands:        NewCommandManager(),
+		histories:       map[doc.ID]*docHistory{},
+		bus:             event.NewBus(),
+		selection:       NewSelection(),
+		camera:          scene.NewCamera(800, 600),
+		hiddenBodyKeys:  map[string]bool{},
+		graphics:        clientgraphics.NewStore(),
+		addins:          NewAddInManager(),
+		clientApps:      NewClientApplicationRegistry(),
+		browserPanes:    NewAddInBrowserPanes(),
+		dockableWindows: NewAddInDockableWindows(),
+		visualStyle:     renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now
 		// that the whole rig lights every shaded mode (ADR-0026 §8).

--- a/head/internal/addinhost/testdata/uiaddin/main.go
+++ b/head/internal/addinhost/testdata/uiaddin/main.go
@@ -68,6 +68,17 @@ func ObkAddInActivate(call C.HostCall, free C.HostFree) C.int {
 	if _, ok := callHost("commands.create", req); !ok {
 		return C.OBK_ERR
 	}
+	// Extend the browser: declare a pane with one clickable node (M05-F03 #256).
+	pane, _ := json.Marshal(map[string]any{
+		"pane": map[string]any{
+			"id":    "fixture-pane",
+			"title": "Fixture",
+			"nodes": []map[string]any{{"id": "ping-node", "label": "Ping Node"}},
+		},
+	})
+	if _, ok := callHost("browser.setPane", pane); !ok {
+		return C.OBK_ERR
+	}
 	return C.OBK_OK
 }
 
@@ -78,6 +89,9 @@ func ObkAddInDeactivate() C.int { return C.OBK_OK }
 type hostEvent struct {
 	Type    string `json:"type"`
 	Command string `json:"command"`
+	Pane    string `json:"pane"`
+	Node    string `json:"node"`
+	Gesture string `json:"gesture"`
 }
 
 //export ObkAddInNotify
@@ -89,7 +103,17 @@ func ObkAddInNotify(ev *C.uint8_t, n C.int) C.int {
 	if e.Type == "command.ended" && e.Command == buttonID {
 		go runButtonAction() // off the session goroutine — see the package comment
 	}
+	if e.Type == "browser.node" && e.Node == "ping-node" && e.Gesture == "select" {
+		go runPaneNodeAction() // the #256 acceptance: a custom node responding to clicks
+	}
 	return C.OBK_OK
+}
+
+// runPaneNodeAction is the pane node's click behavior: create a document so the test
+// can observe the round trip pane-click → browser.node event → host call.
+func runPaneNodeAction() {
+	req, _ := json.Marshal(map[string]any{"type": "part", "name": "FromPaneClick"})
+	callHost("documents.create", req)
 }
 
 // runButtonAction is the button's behavior: create a part document through the host

--- a/head/internal/addinhost/uiaddin_test.go
+++ b/head/internal/addinhost/uiaddin_test.go
@@ -83,6 +83,20 @@ func TestAddInExtendsRibbonAndActsOnClick(t *testing.T) {
 	if !drainUntilDocument(t, d, s, "FromAddIn") {
 		t.Fatal("add-in did not create its document in response to the button click")
 	}
+
+	// (3) The browser is extended (M05-F03 #256): the add-in's pane was declared on
+	// Activate, and "clicking" its node (what the head's browser does) routes the
+	// browser.node event to the add-in, which reacts with another host call.
+	panes := s.BrowserPanes().List()
+	if len(panes) != 1 || panes[0].ID != "fixture-pane" || panes[0].Nodes[0].ID != "ping-node" {
+		t.Fatalf("add-in did not declare its browser pane: %+v", panes)
+	}
+	if err := s.ActivateBrowserPaneNode("fixture-pane", "ping-node", app.BrowserGestureSelect); err != nil {
+		t.Fatalf("activate pane node: %v", err)
+	}
+	if !drainUntilDocument(t, d, s, "FromPaneClick") {
+		t.Fatal("add-in did not react to its browser pane node click")
+	}
 }
 
 // drainUntil drains d on this goroutine until done yields (returning its value) or a

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -348,7 +348,8 @@ extern "C" unsigned int obk_ig_dockspace_over_main(void) {
 // the split structure is the default layout. Without this the panels float and
 // auto-size to nothing, so the viewport collapses to a sliver.
 extern "C" void obk_ig_dock_default_layout(unsigned int dockId, const char* model,
-        const char* viewport, const char* status) {
+        const char* viewport, const char* status,
+        unsigned int* outLeft, unsigned int* outBottom, unsigned int* outCenter) {
     ImGui::DockBuilderRemoveNode(dockId);
     ImGui::DockBuilderAddNode(dockId, ImGuiDockNodeFlags_DockSpace);
     ImGui::DockBuilderSetNodeSize(dockId, ImGui::GetMainViewport()->Size);
@@ -359,6 +360,26 @@ extern "C" void obk_ig_dock_default_layout(unsigned int dockId, const char* mode
     ImGui::DockBuilderDockWindow(status, bottom);
     ImGui::DockBuilderDockWindow(viewport, center);
     ImGui::DockBuilderFinish(dockId);
+    // Report the side node ids so late-created windows (add-in dockable windows,
+    // M05-F03) can be docked into the arrangement with SetNextWindowDockID.
+    *outLeft = left; *outBottom = bottom; *outCenter = center;
+}
+
+// obk_ig_dock_split carves a new node off an existing one at runtime (e.g. a right
+// band for an add-in window when none exists yet), returning the new node id and
+// updating *nodeId to the remainder.
+extern "C" unsigned int obk_ig_dock_split(unsigned int* nodeId, int dir, float ratio) {
+    ImGuiID remain = *nodeId;
+    ImGuiID fresh = ImGui::DockBuilderSplitNode(remain, (ImGuiDir)dir, ratio, NULL, &remain);
+    ImGui::DockBuilderFinish(remain);
+    *nodeId = remain;
+    return fresh;
+}
+
+// obk_ig_set_next_window_dock docks the NEXT Begin'd window into the given node the
+// first time it appears; afterwards the user's own re-docking wins (FirstUseEver).
+extern "C" void obk_ig_set_next_window_dock(unsigned int nodeId) {
+    ImGui::SetNextWindowDockID(nodeId, ImGuiCond_FirstUseEver);
 }
 
 void obk_head_begin_frame(void* h) {

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -14,6 +14,7 @@ void obk_ig_end_menu(void);
 int  obk_ig_menu_item(const char* label);
 int  obk_ig_menu_item_ex(const char* label, const char* shortcut, int enabled);
 int  obk_ig_begin(const char* name);
+int  obk_ig_begin_closable(const char* name, int* open);
 void obk_ig_end(void);
 void obk_ig_text(const char* s);
 int  obk_ig_button(const char* label);
@@ -99,6 +100,8 @@ int  obk_ig_table_next_column(void);
 void obk_ig_end_table(void);
 void obk_ig_set_next_item_width(float w);
 void obk_ig_push_id_int(int id);
+void obk_ig_push_id_str(const char* id);
+int  obk_ig_is_item_toggled_open(void);
 void obk_ig_pop_id(void);
 int  obk_ig_is_item_deactivated_after_edit(void);
 
@@ -119,7 +122,9 @@ int  obk_ig_begin_combo(const char* label, const char* preview);
 void obk_ig_end_combo(void);
 
 unsigned int obk_ig_dockspace_over_main(void);
-void obk_ig_dock_default_layout(unsigned int dockId, const char* model, const char* viewport, const char* status);
+void obk_ig_dock_default_layout(unsigned int dockId, const char* model, const char* viewport, const char* status, unsigned int* outLeft, unsigned int* outBottom, unsigned int* outCenter);
+unsigned int obk_ig_dock_split(unsigned int* nodeId, int dir, float ratio);
+void obk_ig_set_next_window_dock(unsigned int nodeId);
 
 // Synthetic-input injection for in-window UI tests (defined in app.cpp).
 void obk_inject_mouse_pos(float x, float y);
@@ -179,6 +184,18 @@ func Begin(name string) bool {
 	return C.obk_ig_begin(c) != 0
 }
 func End() { C.obk_ig_end() }
+
+// BeginClosable is Begin with ImGui's title-bar close button: it reports whether
+// the content is visible and whether the window is still open (false the frame the
+// user clicks the X) — used by add-in dockable windows so closing reaches the
+// owning add-in as a visibility event (M05-F03). Pair with End like Begin.
+func BeginClosable(name string) (visible, open bool) {
+	c, free := cstr(name)
+	defer free()
+	cOpen := C.int(1)
+	v := C.obk_ig_begin_closable(c, &cOpen)
+	return v != 0, cOpen != 0
+}
 
 // Text draws a line of unformatted text.
 func Text(s string) {
@@ -396,7 +413,20 @@ func SetNextItemWidth(w float32) { C.obk_ig_set_next_item_width(C.float(w)) }
 // PushIDInt / PopID scope an integer id (a parameter's id) so identical cell-widget
 // labels across rows do not collide. Pair every PushIDInt with a PopID.
 func PushIDInt(id int) { C.obk_ig_push_id_int(C.int(id)) }
-func PopID()           { C.obk_ig_pop_id() }
+
+// PushID pushes a string id onto ImGui's id stack — for rows whose ids come from
+// declared data (add-in pane nodes) rather than a frame-local counter.
+func PushID(id string) {
+	c, free := cstr(id)
+	defer free()
+	C.obk_ig_push_id_str(c)
+}
+
+// IsItemToggledOpen reports whether the last tree node was opened or closed by this
+// frame's interaction — how the browser detects an expand/collapse gesture to report
+// to the owning add-in (M05-F03).
+func IsItemToggledOpen() bool { return C.obk_ig_is_item_toggled_open() != 0 }
+func PopID()                  { C.obk_ig_pop_id() }
 
 // IsItemDeactivatedAfterEdit reports whether the most recent item was edited and then
 // committed this frame (Enter or focus loss) — so a text cell commits once the user is
@@ -656,19 +686,39 @@ func SetNextWindowSizeOnce(w, h float32) {
 // below the fixed chrome. Call it once per frame before the panels.
 func DockSpaceOverMain() uint32 { return uint32(C.obk_ig_dockspace_over_main()) }
 
+// DockSideNodes are the dock-node ids of the default arrangement, so late-created
+// windows (add-in dockable windows, M05-F03) can be docked beside the built-ins.
+type DockSideNodes struct{ Left, Bottom, Center uint32 }
+
 // DockDefaultLayout arranges the named panels once: model left, status bottom, viewport
-// filling the center. Call it a single time after the first DockSpaceOverMain (the
-// names must match the panels' Begin() titles). The ribbon is not docked — it is a
-// fixed band drawn with BeginRibbonBand.
-func DockDefaultLayout(dockID uint32, model, viewport, status string) {
+// filling the center, returning the side node ids. Call it a single time after the
+// first DockSpaceOverMain (the names must match the panels' Begin() titles). The
+// ribbon is not docked — it is a fixed band drawn with BeginRibbonBand.
+func DockDefaultLayout(dockID uint32, model, viewport, status string) DockSideNodes {
 	cm, fm := cstr(model)
 	defer fm()
 	cv, fv := cstr(viewport)
 	defer fv()
 	cs, fs := cstr(status)
 	defer fs()
-	C.obk_ig_dock_default_layout(C.uint(dockID), cm, cv, cs)
+	var left, bottom, center C.uint
+	C.obk_ig_dock_default_layout(C.uint(dockID), cm, cv, cs, &left, &bottom, &center)
+	return DockSideNodes{Left: uint32(left), Bottom: uint32(bottom), Center: uint32(center)}
 }
+
+// DockSplit carves a new node off *node (ImGuiDir: 0=left, 1=right, 2=up, 3=down)
+// at the given ratio, returning the new node's id; *node becomes the remainder.
+// Used to create a band on demand for an add-in window.
+func DockSplit(node *uint32, dir int, ratio float32) uint32 {
+	cNode := C.uint(*node)
+	fresh := C.obk_ig_dock_split(&cNode, C.int(dir), C.float(ratio))
+	*node = uint32(cNode)
+	return uint32(fresh)
+}
+
+// SetNextWindowDock docks the next Begin'd window into the given node on its first
+// appearance; the user's later re-docking wins.
+func SetNextWindowDock(nodeID uint32) { C.obk_ig_set_next_window_dock(C.uint(nodeID)) }
 
 // BeginRibbonBand pins a full-width band of the given height across the top of the main
 // viewport, under the menu bar. The band is fixed chrome: not movable, resizable, or

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -27,6 +27,12 @@ void obk_ig_set_next_window_size_first_use(float w, float h) {
     ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_FirstUseEver);
 }
 int  obk_ig_begin(const char* name)          { return ImGui::Begin(name) ? 1 : 0; }
+int  obk_ig_begin_closable(const char* name, int* open) {
+    bool p_open = (*open != 0);
+    int visible = ImGui::Begin(name, &p_open) ? 1 : 0;
+    *open = p_open ? 1 : 0;
+    return visible;
+}
 void obk_ig_end(void)                        { ImGui::End(); }
 void obk_ig_text(const char* s)              { ImGui::TextUnformatted(s); }
 int  obk_ig_button(const char* label)        { return ImGui::Button(label) ? 1 : 0; }
@@ -255,6 +261,8 @@ int  obk_ig_table_next_column(void)                    { return ImGui::TableNext
 void obk_ig_end_table(void)                            { ImGui::EndTable(); }
 void obk_ig_set_next_item_width(float w)               { ImGui::SetNextItemWidth(w); }
 void obk_ig_push_id_int(int id)                        { ImGui::PushID(id); }
+void obk_ig_push_id_str(const char* id)                { ImGui::PushID(id); }
+int  obk_ig_is_item_toggled_open(void)                 { return ImGui::IsItemToggledOpen() ? 1 : 0; }
 void obk_ig_pop_id(void)                               { ImGui::PopID(); }
 int  obk_ig_is_item_deactivated_after_edit(void)       { return ImGui::IsItemDeactivatedAfterEdit() ? 1 : 0; }
 

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -1,0 +1,95 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Add-in dockable windows (M05-F03, #247): each visible declared window renders as a
+// real ImGui window — closable, and dockable into the chrome's dockspace by the user
+// like any panel. Content is the declared control list; a button executes the command
+// it names, so the owning add-in observes clicks through command.ended.
+
+// addInPanelDefaultSize is a sane first-show size for a declared window; afterwards
+// ImGui's saved settings keep whatever the user made of it.
+const addInPanelDefaultW, addInPanelDefaultH = 280, 200
+
+// drawAddInPanels renders every visible add-in dockable window. Closing one via its
+// title-bar X routes through the session so the owning add-in receives the
+// visibility event (DockableWindowsEvents OnHide).
+func drawAddInPanels(s *app.Session) {
+	for _, spec := range s.DockableWindows().List() {
+		if !spec.Visible {
+			continue
+		}
+		drawAddInPanel(s, spec)
+	}
+}
+
+// addInDockRightNode is the lazily created right band: the default layout has no
+// right node (it would be empty and ImGui collapses empty nodes), so the first
+// DockRight window splits one off the central node.
+var addInDockRightNode uint32
+
+// applyInitialDock docks the next window into the band its spec asks for, on first
+// appearance only (FirstUseEver — the user's re-docking wins afterwards).
+func applyInitialDock(dock types.DockingState) {
+	switch dock {
+	case types.DockLeft:
+		native.SetNextWindowDock(dockSideNodes.Left)
+	case types.DockBottom:
+		native.SetNextWindowDock(dockSideNodes.Bottom)
+	case types.DockRight:
+		if addInDockRightNode == 0 && dockSideNodes.Center != 0 {
+			addInDockRightNode = native.DockSplit(&dockSideNodes.Center, 1, 0.25)
+		}
+		native.SetNextWindowDock(addInDockRightNode)
+	default: // DockFloating: leave it free
+	}
+}
+
+// drawAddInPanel renders one declared window and its controls.
+func drawAddInPanel(s *app.Session, spec wire.DockableWindowSpec) {
+	native.SetNextWindowSizeOnce(addInPanelDefaultW, addInPanelDefaultH)
+	applyInitialDock(spec.Dock)
+	visible, open := native.BeginClosable(spec.Title + "###addin-" + spec.ID)
+	if visible {
+		for i, control := range spec.Controls {
+			drawAddInPanelControl(s, spec.ID, i, control)
+		}
+	}
+	native.End()
+	if !open {
+		if err := s.SetDockableWindowVisible(spec.ID, false); err != nil {
+			fmt.Fprintf(os.Stderr, "add-in window %q: %v\n", spec.ID, err)
+		}
+	}
+}
+
+// drawAddInPanelControl renders one declared control by kind. The index joins the id
+// stack so two unnamed controls never collide.
+func drawAddInPanelControl(s *app.Session, windowID string, index int, control wire.PanelControlSpec) {
+	native.PushIDInt(index)
+	defer native.PopID()
+	switch control.Kind {
+	case types.PanelButton:
+		if native.Button(control.Text) && control.CommandID != "" {
+			if err := s.Execute(control.CommandID); err != nil {
+				fmt.Fprintf(os.Stderr, "add-in window %q button %q: %v\n", windowID, control.CommandID, err)
+			}
+		}
+	case types.PanelSeparator:
+		native.Separator()
+	default: // PanelLabel (and any future kind degrades to its text)
+		native.Text(control.Text)
+	}
+}

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
@@ -29,14 +30,96 @@ var browserSync browserSelectionSync
 var browserNodeSeq int
 
 // drawBrowser renders the model browser tree from the active document, then records the
-// selection so the next frame can detect a change for scroll-sync.
+// selection so the next frame can detect a change for scroll-sync. When add-ins have
+// declared browser panes (M05-F03 #256), the window becomes a tab bar: the Model tree
+// first, then one tab per add-in pane.
 func drawBrowser(s *app.Session) {
 	if native.Begin("Model") {
-		browserNodeSeq = 0
-		drawNode(s, app.BuildBrowser(s))
-		browserSync.last = s.Selection().First()
+		if panes := s.BrowserPanes().List(); len(panes) > 0 {
+			drawBrowserPaneTabs(s, panes)
+		} else {
+			drawModelTree(s)
+		}
 	}
 	native.End()
+}
+
+// drawModelTree renders the built-in document tree (the Model pane's content).
+func drawModelTree(s *app.Session) {
+	browserNodeSeq = 0
+	drawNode(s, app.BuildBrowser(s))
+	browserSync.last = s.Selection().First()
+}
+
+// drawBrowserPaneTabs renders the Model tree and the add-in panes as tabs.
+func drawBrowserPaneTabs(s *app.Session, panes []wire.BrowserPaneSpec) {
+	if !native.BeginTabBar("##browser-panes") {
+		return
+	}
+	if native.BeginTabItem("Model") {
+		drawModelTree(s)
+		native.EndTabItem()
+	}
+	for _, pane := range panes {
+		if native.BeginTabItem(pane.Title + "##" + pane.ID) {
+			for _, n := range pane.Nodes {
+				drawAddInPaneNode(s, pane.ID, n)
+			}
+			native.EndTabItem()
+		}
+	}
+	native.EndTabBar()
+}
+
+// drawAddInPaneNode renders one declared node: a leaf as a clickable row, a parent as a
+// tree node. Every gesture (select, double-click, expand, collapse) is reported to the
+// session so the owning add-in receives it as a browser.node event — the #256 acceptance:
+// an add-in node that responds to clicks.
+func drawAddInPaneNode(s *app.Session, paneID string, n wire.BrowserNodeSpec) {
+	native.PushID("addin-node-" + n.ID)
+	defer native.PopID()
+	if len(n.Children) == 0 {
+		if native.Selectable(n.Label, false) {
+			_ = s.ActivateBrowserPaneNode(paneID, n.ID, app.BrowserGestureSelect)
+		}
+		reportDoubleClick(s, paneID, n.ID)
+		return
+	}
+	drawAddInPaneBranch(s, paneID, n)
+}
+
+// drawAddInPaneBranch renders a parent node, reporting expand/collapse and select
+// gestures, and recurses into its children while open.
+func drawAddInPaneBranch(s *app.Session, paneID string, n wire.BrowserNodeSpec) {
+	if n.Expanded {
+		native.SetNextItemOpen(true, true)
+	}
+	open := native.TreeNode(n.Label)
+	if native.IsItemToggledOpen() {
+		gesture := app.BrowserGestureCollapse
+		if open {
+			gesture = app.BrowserGestureExpand
+		}
+		_ = s.ActivateBrowserPaneNode(paneID, n.ID, gesture)
+	}
+	if native.IsItemClicked(native.MouseLeft) {
+		_ = s.ActivateBrowserPaneNode(paneID, n.ID, app.BrowserGestureSelect)
+	}
+	reportDoubleClick(s, paneID, n.ID)
+	if !open {
+		return
+	}
+	for _, child := range n.Children {
+		drawAddInPaneNode(s, paneID, child)
+	}
+	native.TreePop()
+}
+
+// reportDoubleClick reports a double-click gesture on the last item.
+func reportDoubleClick(s *app.Session, paneID, nodeID string) {
+	if native.IsItemHovered() && native.IsMouseDoubleClicked(native.MouseLeft) {
+		_ = s.ActivateBrowserPaneNode(paneID, nodeID, app.BrowserGestureDouble)
+	}
 }
 
 // drawNode renders a browser node and its children: a selectable node as a clickable,

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -65,10 +65,15 @@ func prepareChromeFrame(win *native.Window, s *app.Session) {
 func layoutDockedPanels() {
 	dockID := native.DockSpaceOverMain()
 	if !dockLaidOut {
-		native.DockDefaultLayout(dockID, "Model", "Viewport", "Status")
+		dockSideNodes = native.DockDefaultLayout(dockID, "Model", "Viewport", "Status")
+		addInDockRightNode = 0 // any lazily split right band died with the old layout
 		dockLaidOut = true
 	}
 }
+
+// dockSideNodes remembers the default arrangement's node ids so add-in dockable
+// windows can be docked beside the built-in panels on first show (M05-F03).
+var dockSideNodes native.DockSideNodes
 
 func drawViewportIfPresent(win *native.Window, s *app.Session) {
 	if shouldDrawViewport(s) {
@@ -115,6 +120,7 @@ func drawChromeWindows(s *app.Session) {
 	drawMaterialsWindow(s)
 	drawLightingWindow(s)
 	drawScriptConsole(s)
+	drawAddInPanels(s)                  // add-in dockable windows (M05-F03)
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -212,6 +212,9 @@ func drawSelectorPanel(panel app.RibbonPanel, labelY float32) string {
 // arrow listing the variant tools (the variant flyout). It returns the id of the
 // command (head or chosen variant) clicked this frame, else "".
 func drawRibbonButton(btn app.RibbonButton) string {
+	if btn.Command.Kind() == app.PopupControl {
+		return drawPopupMenuButton(btn)
+	}
 	native.BeginDisabled(!btn.Enabled)
 	clicked := drawButtonControl(btn)
 	native.EndDisabled()
@@ -222,6 +225,33 @@ func drawRibbonButton(btn app.RibbonButton) string {
 		return drawVariantDropdown(btn)
 	}
 	return ""
+}
+
+// drawPopupMenuButton renders a PopupControl (M05-F03): the button itself runs nothing —
+// it opens a menu of the control's resolved items, and choosing one returns that item's
+// command id. Unlike a split button there is no head action, so the whole face is the
+// menu trigger.
+func drawPopupMenuButton(btn app.RibbonButton) string {
+	native.BeginDisabled(!btn.Enabled)
+	if drawButtonControl(btn) {
+		native.OpenPopup(btn.Command.ID() + "##popup")
+	}
+	native.EndDisabled()
+	var chosen string
+	if native.BeginPopup(btn.Command.ID() + "##popup") {
+		for _, v := range btn.Variants {
+			native.BeginDisabled(!v.Enabled)
+			if native.Selectable(v.Label, false) {
+				chosen = v.CommandID
+			}
+			native.EndDisabled()
+			if v.Tooltip != "" {
+				native.SetItemTooltip(v.Tooltip)
+			}
+		}
+		native.EndPopup()
+	}
+	return chosen
 }
 
 // variantArrowWidth is the pixel width of a split button's dropdown arrow box — just wide

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/math"
@@ -97,6 +99,8 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		ext.Pick(s, profile)
 		ext.SetDistance(3)
 		_ = s.OK()
+	case "addin-ui": // M05-F03 surfaces: browser pane tab, dockable window, popup button
+		seedAddInSurfaces(s)
 	default:
 		ext := app.NewExtrudeTool()
 		s.StartTool(ext)
@@ -104,6 +108,32 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 			ext.Pick(s, profile)
 		}
 	}
+}
+
+// seedAddInSurfaces declares the M05-F03 add-in UI surfaces the way an add-in would
+// over the wire: a popup ribbon control, a browser pane, and a visible dockable
+// window — so a screenshot shows all three rendered by the head.
+func seedAddInSurfaces(s *app.Session) {
+	noop := func(*app.Session) error { return nil }
+	_ = s.Commands().Add(app.NewCommand("demo.alpha", "Alpha", "Add-In Demo", noop))
+	_ = s.Commands().Add(app.NewCommand("demo.beta", "Beta", "Add-In Demo", noop))
+	_ = s.Commands().Add(app.NewCommand("demo.menu", "Demo Menu", "Add-In Demo", noop).
+		WithTab("Tools").WithPopupItems("demo.alpha", "demo.beta"))
+	_ = s.BrowserPanes().Set(wire.BrowserPaneSpec{
+		ID: "sim", Title: "Simulation",
+		Nodes: []wire.BrowserNodeSpec{{
+			ID: "loads", Label: "Loads", Expanded: true,
+			Children: []wire.BrowserNodeSpec{{ID: "f1", Label: "Force 10N"}, {ID: "f2", Label: "Pressure 2bar"}},
+		}, {ID: "mesh", Label: "Mesh"}},
+	})
+	_ = s.SetDockableWindow(wire.DockableWindowSpec{
+		ID: "sim.panel", Title: "Simulation", Dock: types.DockRight, Visible: true,
+		Controls: []wire.PanelControlSpec{
+			{Kind: types.PanelLabel, Text: "Mesh: 12,480 elements"},
+			{Kind: types.PanelSeparator},
+			{Kind: types.PanelButton, Text: "Run Study", CommandID: "demo.alpha"},
+		},
+	})
 }
 
 // applyVisualOverrides applies the OBK_VISUAL_* renderer knobs through the View-tab


### PR DESCRIPTION
## What

The GPL implementation half of M05-F03, closing #256 and the ribbon/browser/docking scope of #247 (contract: Oblikovati/Oblikovati.API#46):

- **Typed ribbon model**: `ribbon.list` now serves control kind/style/icon/live state, split-button and popup items, and combo-panel selectors. `commands.create` accepts `kind`+`items`, so an add-in registers a **PopupControl** — a ribbon menu of its other commands, resolved live from the registry.
- **Browser panes (#256)**: `browser.setPane/deletePane/listPanes`; the head shows add-in panes as tabs beside the Model tree, and every node gesture comes back as a `browser.node` push event. The acceptance ("an add-in adds a custom node that responds to clicks") is proven **end-to-end through a real c-shared fixture**.
- **Dockable windows**: `dockableWindows.set/setVisible/delete/list` declare docked panels of label/button/separator controls. The head honors the initial `DockingState` (left/bottom join existing bands; right lazily splits a band off the central node; floating stays free), the user's re-docking wins afterwards, and closing the window's X reaches the add-in as `dockableWindow.changed`. Button clicks surface as ordinary command-ended events — no extra plumbing.
- **Environments**: `ui.listEnvironments` (read-only; add-in environments split to #667).

## Why

The shell's host surfaces were head-internal: ribbon discovery was id+name only, and add-ins had no browser or docking presence at all — the core of #247/#256. Remaining audit items live in #667; ribbon docking/appearance enums are declined (fixed chrome by design, PR #658).

## Tests

Popup resolution, pane store + gesture events, window store + visibility events in `app`; wire round-trips (incl. the enriched ribbon model) in `addin/router`; relay coverage in `addin/events`; the extended `uiaddin` C-ABI fixture proves pane declaration + node-click reaction end-to-end. Visually verified (screenshot): Simulation window docked right with its controls, Model|Simulation browser tabs.

⚠️ CI needs Oblikovati/Oblikovati.API#46 — merged.

Closes #256. Closes #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)