### PR TITLE
Build the status, progress, notification and message-center surfaces (M05-F09)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -32,12 +32,12 @@ type wireEvent struct {
 	Failed   bool   `json:"failed,omitempty"`
 }
 
-// Subscribe wires the session's document and command events to sink and returns the
-// subscriptions so the caller can cancel them on shutdown.
+// Subscribe wires the session's document, command, and UI-surface events to sink
+// and returns the subscriptions so the caller can cancel them on shutdown.
 func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 	ws := s.Workspace().Events()
 	bus := s.Events()
-	return []event.Subscription{
+	subs := []event.Subscription{
 		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentCreated) event.Outcome {
 			return relay(sink, wireEvent{Type: "document.created", Document: e.Document.DisplayName(), ID: uint64(e.Document.ID())})
 		}),
@@ -53,6 +53,14 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
 			return relayEdit(sink, e)
 		}),
+	}
+	return append(subs, subscribeUISurfaces(bus, sink)...)
+}
+
+// subscribeUISurfaces wires the M05 UI-surface events: browser panes and dockable
+// windows (F03), progress/balloon/prompt feedback (F09).
+func subscribeUISurfaces(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.BrowserPaneNodeActivated) event.Outcome {
 			return relayJSON(sink, wire.BrowserNodeEvent{
 				Type: wire.EventBrowserNode, Pane: e.Pane, Node: e.Node, Gesture: e.Gesture,
@@ -63,12 +71,24 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 				Type: wire.EventDockableWindowChanged, ID: e.ID, Visible: e.Visible,
 			})
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.ProgressCancelled) event.Outcome {
+			return relayJSON(sink, wire.ProgressCancelledEvent{Type: wire.EventProgressCancelled, ID: e.ID})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.BalloonTipClicked) event.Outcome {
+			return relayJSON(sink, wire.BalloonTipClickedEvent{Type: wire.EventBalloonTipClicked, ID: e.ID})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.PromptAnswered) event.Outcome {
+			return relayJSON(sink, wire.PromptAnsweredEvent{
+				Type: wire.EventPromptAnswered, ID: e.ID, Answer: e.Answer, Remembered: e.Remembered,
+			})
+		}),
 	}
 }
 
 // relayJSON serializes a wire event DTO and hands it to sink (passive listener).
 // Generic so each call site stays statically typed (the house no-`any` rule).
-func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent](sink Sink, ev E) event.Outcome {
+func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
+	wire.ProgressCancelledEvent | wire.BalloonTipClickedEvent | wire.PromptAnsweredEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/router/commands.go
+++ b/addin/router/commands.go
@@ -20,6 +20,7 @@ func listCommands(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 			ID: c.ID(), DisplayName: c.DisplayName(), Ribbon: c.Ribbons()[0],
 			Tab: c.Tab(), Category: c.Category(), Environment: c.Environment(),
 			Alias: c.Alias(), Tooltip: c.Tooltip(),
+			TooltipTitle: c.TooltipTitle(), TooltipExpanded: c.TooltipExpanded(),
 			Icon: c.Icon(), ButtonStyle: c.ButtonStyle(),
 			Enabled: c.IsEnabled(s),
 		}
@@ -44,7 +45,8 @@ func createCommand(s *app.Session, args json.RawMessage) (json.RawMessage, error
 	}
 	cmd := app.NewCommand(in.ID, in.DisplayName, in.Category, func(*app.Session) error { return nil }).
 		WithTab(in.Tab).WithEnvironment(in.Environment).WithAlias(in.Alias).WithTooltip(in.Tooltip).
-		WithIcon(in.Icon).WithButtonStyle(in.ButtonStyle).WithKind(in.Kind)
+		WithIcon(in.Icon).WithButtonStyle(in.ButtonStyle).WithKind(in.Kind).
+		WithTooltipDetail(in.TooltipTitle, in.TooltipExpanded)
 	if in.Ribbon != "" {
 		cmd.WithRibbons(in.Ribbon)
 	}

--- a/addin/router/messaging.go
+++ b/addin/router/messaging.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerMessagingHandlers wires the status / progress / balloon / prompt /
+// message-center methods (M05-F09, #616).
+func (r *Router) registerMessagingHandlers() {
+	r.handlers[wire.MethodStatusSetText] = setStatusText
+	r.handlers[wire.MethodStatusGetText] = getStatusText
+	r.handlers[wire.MethodProgressBegin] = beginProgress
+	r.handlers[wire.MethodProgressUpdate] = updateProgress
+	r.handlers[wire.MethodProgressEnd] = endProgress
+	r.handlers[wire.MethodBalloonTipRegister] = registerBalloonTip
+	r.handlers[wire.MethodBalloonTipShow] = showBalloonTip
+	r.handlers[wire.MethodPromptsShow] = showPrompt
+	r.handlers[wire.MethodErrorsAddMessage] = addErrorMessage
+	r.handlers[wire.MethodErrorsBeginSection] = beginMessageSection
+	r.handlers[wire.MethodErrorsEndSection] = endMessageSection
+	r.handlers[wire.MethodErrorsList] = listErrors
+	r.handlers[wire.MethodErrorsClear] = clearErrors
+	r.handlers[wire.MethodErrorsShow] = showErrors
+}
+
+func setStatusText(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetStatusTextArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	s.SetStatusText(req.Text)
+	return ok()
+}
+
+func getStatusText(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.StatusTextResult{Text: s.StatusText()})
+}
+
+func beginProgress(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.BeginProgressArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	id, err := s.Progress().Begin(req.Steps, req.Message)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.BeginProgressResult{ID: id})
+}
+
+func updateProgress(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.UpdateProgressArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	cancelled, err := s.Progress().Update(req.ID, req.Step, req.Message)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.UpdateProgressResult{OK: true, Cancelled: cancelled})
+}
+
+func endProgress(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.EndProgressArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.Progress().End(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func registerBalloonTip(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.RegisterBalloonTipArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	spec := app.BalloonTipSpec{ID: req.ID, Title: req.Title, Text: req.Text, Icon: req.Icon}
+	if err := s.BalloonTips().Register(spec); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func showBalloonTip(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ShowBalloonTipArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	shown, err := s.ShowBalloonTip(req.ID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ShowBalloonTipResult{Shown: shown})
+}
+
+func showPrompt(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ShowPromptArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	resolved, answer, err := s.ShowPrompt(app.PromptSpec{
+		ID: req.ID, Message: req.Message, Buttons: req.Buttons,
+		Default: req.Default, Restriction: req.Restriction,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ShowPromptResult{Resolved: resolved, Answer: answer})
+}
+
+func addErrorMessage(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.AddErrorMessageArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	s.Messages().AddMessage(req.Text, req.Severity)
+	return ok()
+}
+
+func beginMessageSection(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.BeginMessageSectionArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.BeginMessageSectionResult{Section: s.Messages().BeginSection(req.Title)})
+}
+
+func endMessageSection(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.EndMessageSectionArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.Messages().EndSection(req.Section); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func listErrors(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	m := s.Messages()
+	return json.Marshal(wire.ListErrorsResult{
+		Root: m.View(), HasErrors: m.HasErrors(), HasWarnings: m.HasWarnings(),
+		LastMessage: m.LastMessage(),
+	})
+}
+
+func clearErrors(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	s.Messages().Clear()
+	return ok()
+}
+
+func showErrors(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	s.SetMessageCenterOpen(true)
+	return ok()
+}

--- a/addin/router/messaging_test.go
+++ b/addin/router/messaging_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"strconv"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// itoaInt renders a plain int for the JSON one-liners (itoa in this package's
+// tests is the uint64 entity-id helper).
+func itoaInt(n int) string { return strconv.Itoa(n) }
+
+func TestStatusTextOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "status.setText", `{"text":"Meshing…"}`, nil)
+	var res wire.StatusTextResult
+	call(t, r, s, "status.getText", "{}", &res)
+	if res.Text != "Meshing…" {
+		t.Fatalf("text = %q, want Meshing…", res.Text)
+	}
+}
+
+func TestProgressOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	var bar wire.BeginProgressResult
+	call(t, r, s, "progress.begin", `{"steps":10,"message":"Meshing"}`, &bar)
+	if bar.ID == 0 {
+		t.Fatal("begin returned id 0")
+	}
+
+	var upd wire.UpdateProgressResult
+	call(t, r, s, "progress.update", `{"id":`+itoaInt(bar.ID)+`,"step":4}`, &upd)
+	if upd.Cancelled {
+		t.Fatal("not cancelled yet")
+	}
+	if err := s.CancelProgress(bar.ID); err != nil {
+		t.Fatalf("CancelProgress: %v", err)
+	}
+	call(t, r, s, "progress.update", `{"id":`+itoaInt(bar.ID)+`,"step":5}`, &upd)
+	if !upd.Cancelled {
+		t.Fatal("update should report the cancel")
+	}
+	call(t, r, s, "progress.end", `{"id":`+itoaInt(bar.ID)+`}`, nil)
+	if _, err := r.Handle(s, "progress.update", []byte(`{"id":`+itoaInt(bar.ID)+`,"step":6}`)); err == nil {
+		t.Error("updating an ended bar should fail")
+	}
+}
+
+func TestBalloonTipsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "balloonTip.register", `{"id":"sim.done","title":"Done","text":"Finished"}`, nil)
+	var shown wire.ShowBalloonTipResult
+	call(t, r, s, "balloonTip.show", `{"id":"sim.done"}`, &shown)
+	if !shown.Shown {
+		t.Fatal("first show should display")
+	}
+	s.DismissBalloonTip("sim.done", true)
+	call(t, r, s, "balloonTip.show", `{"id":"sim.done"}`, &shown)
+	if shown.Shown {
+		t.Fatal("a suppressed tip should report shown=false")
+	}
+	if _, err := r.Handle(s, "balloonTip.show", []byte(`{"id":"ghost"}`)); err == nil {
+		t.Error("showing an unregistered tip should fail")
+	}
+}
+
+func TestPromptsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	var res wire.ShowPromptResult
+	call(t, r, s, "prompts.show",
+		`{"id":"p","message":"Replace?","buttons":["Replace","Keep"],"restriction":1}`, &res)
+	if res.Resolved {
+		t.Fatal("first show should be pending")
+	}
+	if err := s.AnswerPrompt("p", "Keep", true); err != nil {
+		t.Fatalf("AnswerPrompt: %v", err)
+	}
+	call(t, r, s, "prompts.show",
+		`{"id":"p","message":"Replace?","buttons":["Replace","Keep"],"restriction":1}`, &res)
+	if !res.Resolved || res.Answer != "Keep" {
+		t.Fatalf("second show = %+v, want the remembered Keep", res)
+	}
+}
+
+func TestErrorsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	var sec wire.BeginMessageSectionResult
+	call(t, r, s, "errors.beginSection", `{"title":"Meshing"}`, &sec)
+	call(t, r, s, "errors.addMessage", `{"text":"degenerate face","severity":1}`, nil)
+	call(t, r, s, "errors.endSection", `{"section":`+itoaInt(sec.Section)+`}`, nil)
+	call(t, r, s, "errors.addMessage", `{"text":"boolean failed","severity":2}`, nil)
+
+	var lst wire.ListErrorsResult
+	call(t, r, s, "errors.list", "{}", &lst)
+	if !lst.HasErrors || !lst.HasWarnings || lst.LastMessage != "boolean failed" {
+		t.Fatalf("list = %+v, want both flags + last message", lst)
+	}
+	if len(lst.Root.Sections) != 1 || lst.Root.Sections[0].Messages[0].Text != "degenerate face" {
+		t.Fatalf("tree = %+v, want the Meshing section", lst.Root)
+	}
+
+	call(t, r, s, "errors.show", "{}", nil)
+	if !s.MessageCenterOpen() {
+		t.Error("errors.show should open the panel")
+	}
+	call(t, r, s, "errors.clear", "{}", nil)
+	var cleared wire.ListErrorsResult // fresh target: unmarshal keeps absent fields
+	call(t, r, s, "errors.list", "{}", &cleared)
+	if cleared.HasErrors || len(cleared.Root.Sections) != 0 {
+		t.Error("clear left state behind")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -47,6 +47,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAddInHandlers()
 	r.registerUISurfaceHandlers()
 	r.registerOptionHandlers()
+	r.registerMessagingHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/app/balloon_tips.go
+++ b/app/balloon_tips.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/event"
+	"oblikovati.org/persistence/dialogmemory"
+)
+
+// BalloonTipClicked fires (After) when the user clicks a balloon's body; the events
+// relay forwards it as a balloonTip.clicked push event (M05-F09).
+type BalloonTipClicked struct{ ID string }
+
+// EventID implements event.Event.
+func (BalloonTipClicked) EventID() event.TypeID { return tidBalloonClicked }
+
+// BalloonTipSpec is one registered notification balloon.
+type BalloonTipSpec struct {
+	ID    string
+	Title string
+	Text  string
+	Icon  string
+}
+
+// BalloonTipCenter registers named balloons and tracks the live (showing) ones —
+// the BalloonTip(s) equivalent. Suppression ("don't show again") persists per user
+// through the dialog-memory store.
+type BalloonTipCenter struct {
+	specs      map[string]BalloonTipSpec
+	active     []string
+	suppressed map[string]bool
+}
+
+// NewBalloonTipCenter returns an empty balloon registry.
+func NewBalloonTipCenter() *BalloonTipCenter {
+	return &BalloonTipCenter{specs: map[string]BalloonTipSpec{}, suppressed: map[string]bool{}}
+}
+
+// Register declares (or redeclares) a balloon under its stable id.
+func (b *BalloonTipCenter) Register(spec BalloonTipSpec) error {
+	if spec.ID == "" || spec.Title == "" {
+		return fmt.Errorf("app: balloon tip needs id and title, got id=%q title=%q", spec.ID, spec.Title)
+	}
+	b.specs[spec.ID] = spec
+	return nil
+}
+
+// Active returns the currently showing balloons in show order.
+func (b *BalloonTipCenter) Active() []BalloonTipSpec {
+	out := make([]BalloonTipSpec, len(b.active))
+	for i, id := range b.active {
+		out[i] = b.specs[id]
+	}
+	return out
+}
+
+// BalloonTips returns the session's balloon registry.
+func (s *Session) BalloonTips() *BalloonTipCenter { return s.balloonTips }
+
+// ShowBalloonTip displays a registered balloon; it reports false (without showing)
+// when the user suppressed it, mirroring the wire reply.
+func (s *Session) ShowBalloonTip(id string) (bool, error) {
+	b := s.balloonTips
+	if _, ok := b.specs[id]; !ok {
+		return false, fmt.Errorf("app: no balloon tip %q (register it first)", id)
+	}
+	if b.suppressed[id] {
+		return false, nil
+	}
+	for _, active := range b.active {
+		if active == id {
+			return true, nil // already showing
+		}
+	}
+	b.active = append(b.active, id)
+	return true, nil
+}
+
+// ClickBalloonTip reports the user clicked a showing balloon's body: it dismisses
+// the balloon and emits the event its owner observes.
+func (s *Session) ClickBalloonTip(id string) {
+	s.dismissBalloon(id)
+	event.Emit(s.bus, event.After, BalloonTipClicked{ID: id})
+}
+
+// DismissBalloonTip closes a showing balloon; dontShowAgain suppresses it for good
+// (persisted per user).
+func (s *Session) DismissBalloonTip(id string, dontShowAgain bool) {
+	s.dismissBalloon(id)
+	if dontShowAgain {
+		s.balloonTips.suppressed[id] = true
+		s.saveDialogMemory()
+	}
+}
+
+// dismissBalloon removes a balloon from the active list.
+func (s *Session) dismissBalloon(id string) {
+	b := s.balloonTips
+	for i, x := range b.active {
+		if x == id {
+			b.active = append(b.active[:i], b.active[i+1:]...)
+			return
+		}
+	}
+}
+
+// UseDialogMemoryStore installs the per-user remembered-choice store and loads it
+// into the balloon suppression set and the prompt answers.
+func (s *Session) UseDialogMemoryStore(store dialogmemory.Store) error {
+	mem, err := store.Load()
+	if err != nil {
+		return err
+	}
+	s.dialogMemoryStore = store
+	for _, id := range mem.SuppressedTips {
+		s.balloonTips.suppressed[id] = true
+	}
+	for id, answer := range mem.PromptAnswers {
+		s.prompts.remembered[id] = answer
+	}
+	return nil
+}
+
+// saveDialogMemory persists the suppression set and remembered prompt answers.
+func (s *Session) saveDialogMemory() {
+	if s.dialogMemoryStore == nil {
+		return
+	}
+	mem := dialogmemory.Memory{PromptAnswers: map[string]string{}}
+	for id := range s.balloonTips.suppressed {
+		mem.SuppressedTips = append(mem.SuppressedTips, id)
+	}
+	for id, answer := range s.prompts.remembered {
+		mem.PromptAnswers[id] = answer
+	}
+	_ = s.dialogMemoryStore.Save(mem)
+}

--- a/app/command.go
+++ b/app/command.go
@@ -46,6 +46,8 @@ type CommandDefinition struct {
 	kind             ControlKind
 	alias            string // typed command alias (e.g. "E" → Extrude), Inventor-style
 	tooltip          string
+	tooltipTitle     string      // progressive tooltip title (M05-F09)
+	tooltipExpanded  string      // progressive tooltip long text, shown after a longer hover
 	iconKey          string      // icon asset key (e.g. "extrude"); empty ⇒ no icon
 	buttonStyle      ButtonStyle // ribbon render style; zero value ⇒ text-only
 	ribbons          []RibbonKey // ribbons this command appears on; empty ⇒ the Part ribbon
@@ -81,6 +83,17 @@ func (c *CommandDefinition) WithKind(k ControlKind) *CommandDefinition { c.kind 
 
 // WithTooltip sets the hover tooltip.
 func (c *CommandDefinition) WithTooltip(t string) *CommandDefinition { c.tooltip = t; return c }
+
+// WithTooltipDetail sets the progressive tooltip (M05-F09): title heads the hover
+// tip; expanded appears after a longer hover — the ProgressiveToolTip equivalent.
+func (c *CommandDefinition) WithTooltipDetail(title, expanded string) *CommandDefinition {
+	c.tooltipTitle, c.tooltipExpanded = title, expanded
+	return c
+}
+
+// TooltipTitle / TooltipExpanded are the progressive-tooltip parts ("" when unset).
+func (c *CommandDefinition) TooltipTitle() string    { return c.tooltipTitle }
+func (c *CommandDefinition) TooltipExpanded() string { return c.tooltipExpanded }
 
 // WithIcon sets the command's icon asset key (resolved by the head to an SVG glyph).
 // Pair it with WithButtonStyle to make the ribbon show the icon; a key with the

--- a/app/events.go
+++ b/app/events.go
@@ -15,7 +15,10 @@ const (
 	tidTransactionChange  event.TypeID = 0x0504
 	tidEditCommitted      event.TypeID = 0x0505
 	tidBrowserPaneNode    event.TypeID = 0x0506 // app/browser_panes.go (M05-F03)
-	tidDockableWinChanged event.TypeID = 0x0507 // app/dockable_windows.go (M05-F03)
+	tidDockableWinChanged event.TypeID = 0x0507 // app/dockwindow_store.go (M05-F03)
+	tidProgressCancelled  event.TypeID = 0x0508 // app/progress_ledger.go (M05-F09)
+	tidBalloonClicked     event.TypeID = 0x0509 // app/balloon_tips.go (M05-F09)
+	tidPromptAnswered     event.TypeID = 0x050a // app/prompt_center.go (M05-F09)
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's

--- a/app/message_center.go
+++ b/app/message_center.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"log/slog"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// MessageCenter aggregates errors/warnings/notices into a reviewable, sectioned tree
+// — the ErrorManager + MessageSection equivalent (M05-F09, #616). A command's
+// sub-operations report under one section (sections nest); the head shows the tree in
+// the Messages panel. Every entry is also slog'd (structured JSON per house rules),
+// so the operation trace carries the same record.
+type MessageCenter struct {
+	root        wire.MessageSectionView
+	openPath    []int // indexes into the nested Sections, innermost last
+	nextSection int
+	sectionIDs  map[int][]int // section id → its path, while open
+	hasErrors   bool
+	hasWarnings bool
+	lastMessage string
+}
+
+// NewMessageCenter returns an empty message center.
+func NewMessageCenter() *MessageCenter {
+	return &MessageCenter{nextSection: 1, sectionIDs: map[int][]int{}}
+}
+
+// BeginSection opens a titled section under the innermost open one; messages added
+// until EndSection land inside it. Returns the section's id.
+func (m *MessageCenter) BeginSection(title string) int {
+	parent := m.sectionAt(m.openPath)
+	parent.Sections = append(parent.Sections, wire.MessageSectionView{Title: title})
+	m.openPath = append(m.openPath, len(parent.Sections)-1)
+	id := m.nextSection
+	m.nextSection++
+	m.sectionIDs[id] = append([]int(nil), m.openPath...)
+	return id
+}
+
+// EndSection closes an open section; it must be the innermost one (sections nest
+// like brackets — closing an outer section with an inner one open is a bug).
+func (m *MessageCenter) EndSection(id int) error {
+	path, ok := m.sectionIDs[id]
+	if !ok {
+		return fmt.Errorf("app: no open message section %d", id)
+	}
+	if len(path) != len(m.openPath) {
+		return fmt.Errorf("app: message section %d is not the innermost open section", id)
+	}
+	delete(m.sectionIDs, id)
+	m.openPath = m.openPath[:len(m.openPath)-1]
+	return nil
+}
+
+// AddMessage reports one entry under the innermost open section, updates the
+// aggregate flags, and logs it (structured).
+func (m *MessageCenter) AddMessage(text string, severity types.MessageSeverity) {
+	section := m.sectionAt(m.openPath)
+	section.Messages = append(section.Messages, wire.MessageEntry{Text: text, Severity: severity})
+	m.lastMessage = text
+	switch severity {
+	case types.SeverityError:
+		m.hasErrors = true
+		slog.Error("message-center", "text", text)
+	case types.SeverityWarning:
+		m.hasWarnings = true
+		slog.Warn("message-center", "text", text)
+	default:
+		slog.Info("message-center", "text", text)
+	}
+}
+
+// HasErrors / HasWarnings / LastMessage are the aggregate ErrorManager reads.
+func (m *MessageCenter) HasErrors() bool     { return m.hasErrors }
+func (m *MessageCenter) HasWarnings() bool   { return m.hasWarnings }
+func (m *MessageCenter) LastMessage() string { return m.lastMessage }
+
+// Clear empties the tree and resets the flags (open sections are abandoned).
+func (m *MessageCenter) Clear() {
+	m.root = wire.MessageSectionView{}
+	m.openPath = nil
+	m.sectionIDs = map[int][]int{}
+	m.hasErrors, m.hasWarnings, m.lastMessage = false, false, ""
+}
+
+// View returns the current tree for serialization/rendering (a deep-shared copy is
+// unnecessary: callers render or marshal it immediately on the session goroutine).
+func (m *MessageCenter) View() wire.MessageSectionView { return m.root }
+
+// sectionAt walks the nested sections to the given path.
+func (m *MessageCenter) sectionAt(path []int) *wire.MessageSectionView {
+	section := &m.root
+	for _, i := range path {
+		section = &section.Sections[i]
+	}
+	return section
+}
+
+// Messages returns the session's message center.
+func (s *Session) Messages() *MessageCenter { return s.messageCenter }
+
+// MessageCenterOpen reports / SetMessageCenterOpen sets whether the head shows the
+// Messages panel (errors.show and the status-bar indicator toggle it).
+func (s *Session) MessageCenterOpen() bool        { return s.messageCenterOpen }
+func (s *Session) SetMessageCenterOpen(open bool) { s.messageCenterOpen = open }

--- a/app/messaging_test.go
+++ b/app/messaging_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+	"oblikovati.org/persistence/dialogmemory"
+)
+
+// FakeDialogMemoryStore is a named in-memory dialogmemory.Store.
+type FakeDialogMemoryStore struct {
+	stored dialogmemory.Memory
+	saves  int
+}
+
+func (f *FakeDialogMemoryStore) Load() (dialogmemory.Memory, error) { return f.stored, nil }
+func (f *FakeDialogMemoryStore) Save(m dialogmemory.Memory) error {
+	f.stored = m
+	f.saves++
+	return nil
+}
+
+func TestMessageCenterSectionsAndFlags(t *testing.T) {
+	m := NewMessageCenter()
+	outer := m.BeginSection("Meshing")
+	m.AddMessage("starting", types.SeverityInfo)
+	inner := m.BeginSection("Face 12")
+	m.AddMessage("degenerate face", types.SeverityWarning)
+	if err := m.EndSection(outer); err == nil {
+		t.Fatal("closing the outer section with the inner open should fail")
+	}
+	if err := m.EndSection(inner); err != nil {
+		t.Fatalf("EndSection(inner): %v", err)
+	}
+	if err := m.EndSection(outer); err != nil {
+		t.Fatalf("EndSection(outer): %v", err)
+	}
+	m.AddMessage("boolean failed", types.SeverityError)
+
+	if !m.HasErrors() || !m.HasWarnings() || m.LastMessage() != "boolean failed" {
+		t.Errorf("flags = errors %v warnings %v last %q, want both true + boolean failed",
+			m.HasErrors(), m.HasWarnings(), m.LastMessage())
+	}
+	root := m.View()
+	if len(root.Sections) != 1 || root.Sections[0].Title != "Meshing" ||
+		len(root.Sections[0].Sections) != 1 || root.Sections[0].Sections[0].Messages[0].Text != "degenerate face" {
+		t.Fatalf("tree = %+v, want Meshing ▸ Face 12 ▸ degenerate face", root)
+	}
+
+	m.Clear()
+	if m.HasErrors() || len(m.View().Sections) != 0 {
+		t.Error("Clear left state behind")
+	}
+}
+
+func TestProgressLedgerLifecycleAndCancel(t *testing.T) {
+	s := NewSession()
+	var cancelled []ProgressCancelled
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e ProgressCancelled) event.Outcome {
+		cancelled = append(cancelled, e)
+		return event.Continue()
+	})
+
+	outer, err := s.Progress().Begin(10, "outer")
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	inner, err := s.Progress().Begin(4, "inner")
+	if err != nil {
+		t.Fatalf("Begin inner: %v", err)
+	}
+	if bar, ok := s.Progress().Innermost(); !ok || bar.ID != inner {
+		t.Fatalf("Innermost = (%+v, %v), want the inner bar", bar, ok)
+	}
+
+	if err := s.CancelProgress(inner); err != nil {
+		t.Fatalf("CancelProgress: %v", err)
+	}
+	got, err := s.Progress().Update(inner, 99, "")
+	if err != nil || !got {
+		t.Fatalf("Update after cancel = (%v, %v), want cancelled true", got, err)
+	}
+	if bar, _ := s.Progress().Innermost(); bar.Step != bar.Steps {
+		t.Errorf("step = %d, want clamped to %d", bar.Step, bar.Steps)
+	}
+	if len(cancelled) != 1 || cancelled[0].ID != inner {
+		t.Fatalf("events = %+v, want one cancel of the inner bar", cancelled)
+	}
+
+	if err := s.Progress().End(inner); err != nil {
+		t.Fatalf("End inner: %v", err)
+	}
+	if bar, ok := s.Progress().Innermost(); !ok || bar.ID != outer {
+		t.Errorf("after ending inner, innermost = (%+v, %v), want the outer bar", bar, ok)
+	}
+	if _, err := s.Progress().Begin(0, "bad"); err == nil {
+		t.Error("Begin(0 steps) should fail")
+	}
+}
+
+func TestBalloonTipsSuppressionPersists(t *testing.T) {
+	store := &FakeDialogMemoryStore{}
+	s := NewSession()
+	if err := s.UseDialogMemoryStore(store); err != nil {
+		t.Fatalf("UseDialogMemoryStore: %v", err)
+	}
+	if err := s.BalloonTips().Register(BalloonTipSpec{ID: "sim.done", Title: "Done", Text: "Finished"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	shown, err := s.ShowBalloonTip("sim.done")
+	if err != nil || !shown {
+		t.Fatalf("Show = (%v, %v), want shown", shown, err)
+	}
+	s.DismissBalloonTip("sim.done", true) // "don't show again"
+	if shown, _ := s.ShowBalloonTip("sim.done"); shown {
+		t.Error("a suppressed tip should not show")
+	}
+	if len(store.stored.SuppressedTips) != 1 || store.stored.SuppressedTips[0] != "sim.done" {
+		t.Errorf("stored = %+v, want the suppression persisted", store.stored)
+	}
+
+	// A new session over the same store starts suppressed.
+	s2 := NewSession()
+	if err := s2.UseDialogMemoryStore(store); err != nil {
+		t.Fatalf("UseDialogMemoryStore(2): %v", err)
+	}
+	if err := s2.BalloonTips().Register(BalloonTipSpec{ID: "sim.done", Title: "Done", Text: "Finished"}); err != nil {
+		t.Fatalf("Register(2): %v", err)
+	}
+	if shown, _ := s2.ShowBalloonTip("sim.done"); shown {
+		t.Error("suppression did not survive the session boundary")
+	}
+}
+
+func TestBalloonTipClickEmitsAndDismisses(t *testing.T) {
+	s := NewSession()
+	var clicks []BalloonTipClicked
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e BalloonTipClicked) event.Outcome {
+		clicks = append(clicks, e)
+		return event.Continue()
+	})
+	_ = s.BalloonTips().Register(BalloonTipSpec{ID: "x", Title: "T", Text: "B"})
+	_, _ = s.ShowBalloonTip("x")
+	s.ClickBalloonTip("x")
+	if len(clicks) != 1 || clicks[0].ID != "x" {
+		t.Fatalf("clicks = %+v, want one on x", clicks)
+	}
+	if len(s.BalloonTips().Active()) != 0 {
+		t.Error("a clicked balloon should dismiss")
+	}
+}
+
+func TestPromptCenterRememberedAnswers(t *testing.T) {
+	store := &FakeDialogMemoryStore{}
+	s := NewSession()
+	if err := s.UseDialogMemoryStore(store); err != nil {
+		t.Fatalf("UseDialogMemoryStore: %v", err)
+	}
+	var answered []PromptAnswered
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e PromptAnswered) event.Outcome {
+		answered = append(answered, e)
+		return event.Continue()
+	})
+
+	spec := PromptSpec{
+		ID: "sim.replace", Message: "Replace results?", Buttons: []string{"Replace", "Keep"},
+		Restriction: types.PromptAllowRemember,
+	}
+	resolved, _, err := s.ShowPrompt(spec)
+	if err != nil || resolved {
+		t.Fatalf("ShowPrompt = (%v, %v), want pending", resolved, err)
+	}
+	if err := s.AnswerPrompt("sim.replace", "Banana", true); err == nil {
+		t.Fatal("an answer that is not a button should fail")
+	}
+	if err := s.AnswerPrompt("sim.replace", "Replace", true); err != nil {
+		t.Fatalf("AnswerPrompt: %v", err)
+	}
+	if len(answered) != 1 || answered[0].Answer != "Replace" || !answered[0].Remembered {
+		t.Fatalf("events = %+v, want remembered Replace", answered)
+	}
+
+	// The remembered answer now resolves instantly — and survives sessions.
+	resolved, answer, err := s.ShowPrompt(spec)
+	if err != nil || !resolved || answer != "Replace" {
+		t.Fatalf("ShowPrompt(again) = (%v, %q, %v), want instant Replace", resolved, answer, err)
+	}
+	s2 := NewSession()
+	if err := s2.UseDialogMemoryStore(store); err != nil {
+		t.Fatalf("UseDialogMemoryStore(2): %v", err)
+	}
+	if resolved, answer, _ := s2.ShowPrompt(spec); !resolved || answer != "Replace" {
+		t.Error("remembered answer did not survive the session boundary")
+	}
+}
+
+func TestPromptAlwaysAskNeverRemembers(t *testing.T) {
+	s := NewSession()
+	spec := PromptSpec{ID: "p", Message: "m", Buttons: []string{"OK"}}
+	if resolved, _, _ := s.ShowPrompt(spec); resolved {
+		t.Fatal("nothing remembered yet")
+	}
+	if err := s.AnswerPrompt("p", "OK", true); err != nil { // remember asked but not allowed
+		t.Fatalf("AnswerPrompt: %v", err)
+	}
+	if resolved, _, _ := s.ShowPrompt(spec); resolved {
+		t.Error("an always-ask prompt must not resolve from memory")
+	}
+}

--- a/app/progress_ledger.go
+++ b/app/progress_ledger.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/event"
+)
+
+// ProgressCancelled fires (After) when the user cancels a progress bar; the events
+// relay forwards it as a progress.cancelled push event (M05-F09).
+type ProgressCancelled struct{ ID int }
+
+// EventID implements event.Event.
+func (ProgressCancelled) EventID() event.TypeID { return tidProgressCancelled }
+
+// ProgressView is one live bar for the status bar's rendering: the innermost (most
+// recently begun) is the one shown.
+type ProgressView struct {
+	ID        int
+	Steps     int
+	Step      int
+	Message   string
+	Cancelled bool
+}
+
+// ProgressLedger tracks the live progress bars — nesting-safe: each Begin gets its
+// own id and bars end independently (a sub-operation's bar inside an outer one).
+type ProgressLedger struct {
+	nextID int
+	order  []int
+	bars   map[int]*ProgressView
+}
+
+// NewProgressLedger returns an empty ledger.
+func NewProgressLedger() *ProgressLedger {
+	return &ProgressLedger{nextID: 1, bars: map[int]*ProgressView{}}
+}
+
+// Begin starts a bar of steps steps (≥1) and returns its id.
+func (l *ProgressLedger) Begin(steps int, message string) (int, error) {
+	if steps < 1 {
+		return 0, fmt.Errorf("app: progress needs at least 1 step, got %d", steps)
+	}
+	id := l.nextID
+	l.nextID++
+	l.bars[id] = &ProgressView{ID: id, Steps: steps, Message: message}
+	l.order = append(l.order, id)
+	return id, nil
+}
+
+// Update advances a bar (clamped to its step count), optionally replacing its
+// message, and reports whether the user cancelled it.
+func (l *ProgressLedger) Update(id, step int, message string) (cancelled bool, err error) {
+	bar, ok := l.bars[id]
+	if !ok {
+		return false, fmt.Errorf("app: no progress bar %d", id)
+	}
+	if step > bar.Steps {
+		step = bar.Steps
+	}
+	bar.Step = step
+	if message != "" {
+		bar.Message = message
+	}
+	return bar.Cancelled, nil
+}
+
+// End removes a bar.
+func (l *ProgressLedger) End(id int) error {
+	if _, ok := l.bars[id]; !ok {
+		return fmt.Errorf("app: no progress bar %d", id)
+	}
+	delete(l.bars, id)
+	for i, x := range l.order {
+		if x == id {
+			l.order = append(l.order[:i], l.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// Innermost returns the most recently begun live bar (what the status bar shows).
+func (l *ProgressLedger) Innermost() (ProgressView, bool) {
+	if len(l.order) == 0 {
+		return ProgressView{}, false
+	}
+	return *l.bars[l.order[len(l.order)-1]], true
+}
+
+// Progress returns the session's progress ledger.
+func (s *Session) Progress() *ProgressLedger { return s.progress }
+
+// CancelProgress marks a bar cancelled (the status bar's cancel control) and emits
+// the event the owning add-in observes.
+func (s *Session) CancelProgress(id int) error {
+	bar, ok := s.progress.bars[id]
+	if !ok {
+		return fmt.Errorf("app: no progress bar %d", id)
+	}
+	if bar.Cancelled {
+		return nil
+	}
+	bar.Cancelled = true
+	event.Emit(s.bus, event.After, ProgressCancelled{ID: id})
+	return nil
+}

--- a/app/prompt_center.go
+++ b/app/prompt_center.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+)
+
+// PromptAnswered fires (After) when the user answers a pending prompt; the events
+// relay forwards it as a prompt.answered push event (M05-F09).
+type PromptAnswered struct {
+	ID         string
+	Answer     string
+	Remembered bool
+}
+
+// EventID implements event.Event.
+func (PromptAnswered) EventID() event.TypeID { return tidPromptAnswered }
+
+// PromptSpec is one declarative prompt: the message, the answer buttons in display
+// order, the default button index, and whether the user may remember their answer.
+type PromptSpec struct {
+	ID          string
+	Message     string
+	Buttons     []string
+	Default     int
+	Restriction types.PromptRestriction
+}
+
+// PromptCenter queues prompts for the head's modal and keeps the per-user
+// remembered answers — the PromptMessage(s)/PromptsOptions equivalent. A wire call
+// must never block the session goroutine on user input, so showing is asynchronous:
+// remembered prompts resolve instantly, the rest resolve through [Session.AnswerPrompt].
+type PromptCenter struct {
+	pending    []PromptSpec
+	remembered map[string]string
+}
+
+// NewPromptCenter returns an empty prompt queue.
+func NewPromptCenter() *PromptCenter {
+	return &PromptCenter{remembered: map[string]string{}}
+}
+
+// Pending returns the prompt the head should display (the oldest queued one).
+func (p *PromptCenter) Pending() (PromptSpec, bool) {
+	if len(p.pending) == 0 {
+		return PromptSpec{}, false
+	}
+	return p.pending[0], true
+}
+
+// Prompts returns the session's prompt center.
+func (s *Session) Prompts() *PromptCenter { return s.prompts }
+
+// ShowPrompt queues a prompt. A remembered answer resolves instantly (resolved true
+// + the answer); otherwise the head shows the modal and the answer arrives through
+// [Session.AnswerPrompt] as a [PromptAnswered] event.
+func (s *Session) ShowPrompt(spec PromptSpec) (resolved bool, answer string, err error) {
+	if spec.ID == "" || spec.Message == "" || len(spec.Buttons) == 0 {
+		return false, "", fmt.Errorf("app: prompt needs id, message and buttons, got id=%q message=%q buttons=%v",
+			spec.ID, spec.Message, spec.Buttons)
+	}
+	if spec.Default < 0 || spec.Default >= len(spec.Buttons) {
+		return false, "", fmt.Errorf("app: prompt default %d out of range of %d buttons", spec.Default, len(spec.Buttons))
+	}
+	if remembered, ok := s.prompts.remembered[spec.ID]; ok && spec.Restriction == types.PromptAllowRemember {
+		return true, remembered, nil
+	}
+	for _, queued := range s.prompts.pending {
+		if queued.ID == spec.ID {
+			return false, "", nil // already pending; one modal will answer both callers
+		}
+	}
+	s.prompts.pending = append(s.prompts.pending, spec)
+	return false, "", nil
+}
+
+// AnswerPrompt resolves the oldest pending prompt with one of its button labels —
+// the head's modal calls it. remember keeps the answer (when the prompt allows it)
+// so the next ShowPrompt resolves instantly.
+func (s *Session) AnswerPrompt(id, answer string, remember bool) error {
+	spec, ok := s.peekPendingPrompt(id)
+	if !ok {
+		return fmt.Errorf("app: no pending prompt %q", id)
+	}
+	// Validate BEFORE removing: a rejected answer must leave the prompt pending
+	// (removing first would silently swallow it — caught by the regression test).
+	if !promptHasButton(spec, answer) {
+		return fmt.Errorf("app: prompt %q has no button %q (one of %v)", id, answer, spec.Buttons)
+	}
+	s.removePendingPrompt(id)
+	remembered := remember && spec.Restriction == types.PromptAllowRemember
+	if remembered {
+		s.prompts.remembered[id] = answer
+		s.saveDialogMemory()
+	}
+	event.Emit(s.bus, event.After, PromptAnswered{ID: id, Answer: answer, Remembered: remembered})
+	return nil
+}
+
+// peekPendingPrompt returns the pending prompt with the given id without removing it.
+func (s *Session) peekPendingPrompt(id string) (PromptSpec, bool) {
+	for _, spec := range s.prompts.pending {
+		if spec.ID == id {
+			return spec, true
+		}
+	}
+	return PromptSpec{}, false
+}
+
+// removePendingPrompt drops the pending prompt with the given id.
+func (s *Session) removePendingPrompt(id string) {
+	for i, spec := range s.prompts.pending {
+		if spec.ID == id {
+			s.prompts.pending = append(s.prompts.pending[:i], s.prompts.pending[i+1:]...)
+			return
+		}
+	}
+}
+
+// promptHasButton reports whether answer is one of the prompt's buttons.
+func promptHasButton(spec PromptSpec, answer string) bool {
+	for _, b := range spec.Buttons {
+		if b == answer {
+			return true
+		}
+	}
+	return false
+}

--- a/app/session.go
+++ b/app/session.go
@@ -15,6 +15,7 @@ import (
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/material"
 	"oblikovati.org/model/sketch"
+	"oblikovati.org/persistence/dialogmemory"
 	"oblikovati.org/persistence/userprefs"
 	"oblikovati.org/persistence/viewstate"
 	"oblikovati.org/renderer"
@@ -53,6 +54,13 @@ type Session struct {
 	dockableWindows    *AddInDockableWindows      // add-in dockable windows (M05-F03)
 	appOptions         options.All                // typed per-user option groups (M05-F11)
 	optionsStore       options.Store              // persists appOptions (nil ⇒ in-session only)
+	statusText         string                     // wire-set status-bar message (M05-F09)
+	messageCenter      *MessageCenter             // sectioned errors/warnings tree (M05-F09)
+	messageCenterOpen  bool                       // the Messages panel is open
+	progress           *ProgressLedger            // live progress bars (M05-F09)
+	balloonTips        *BalloonTipCenter          // notification balloons (M05-F09)
+	prompts            *PromptCenter              // declarative prompts (M05-F09)
+	dialogMemoryStore  dialogmemory.Store         // persists suppressions + remembered answers
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store
@@ -116,6 +124,10 @@ func newSession(store doc.Store) *Session {
 		browserPanes:    NewAddInBrowserPanes(),
 		dockableWindows: NewAddInDockableWindows(),
 		appOptions:      options.Defaults(),
+		messageCenter:   NewMessageCenter(),
+		progress:        NewProgressLedger(),
+		balloonTips:     NewBalloonTipCenter(),
+		prompts:         NewPromptCenter(),
 		visualStyle:     renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now

--- a/app/statusbar.go
+++ b/app/statusbar.go
@@ -16,18 +16,25 @@ type Prompted interface {
 
 // StatusBar is the status-bar model for a frame.
 type StatusBar struct {
-	Prompt         string // guidance text shown to the user
-	ToolName       string // active tool's name, or "" when idle
-	ToolActive     bool   // whether a tool is running (so OK/Cancel show)
-	CanCommit      bool   // whether OK should be enabled
-	SelectionCount int    // size of the current selection set
-	Notice         string // last user-facing notice (a failed-commit reason), or ""
+	Prompt         string       // guidance text shown to the user
+	ToolName       string       // active tool's name, or "" when idle
+	ToolActive     bool         // whether a tool is running (so OK/Cancel show)
+	CanCommit      bool         // whether OK should be enabled
+	SelectionCount int          // size of the current selection set
+	Notice         string       // last user-facing notice (a failed-commit reason), or ""
+	StatusText     string       // wire-set status message (status.setText, M05-F09), or ""
+	Progress       ProgressView // the innermost live progress bar (M05-F09)
+	HasProgress    bool         // whether Progress is live (so the bar renders)
+	MessageBadge   bool         // the message center holds errors/warnings (panel indicator)
 }
 
 // BuildStatus assembles the status bar from the session: the active tool's prompt and
 // commit-readiness, or "Ready" when idle, plus the selection count and any notice.
 func BuildStatus(s *Session) StatusBar {
 	sb := StatusBar{Prompt: "Ready", SelectionCount: s.Selection().Count(), Notice: s.Notice()}
+	sb.StatusText = s.StatusText()
+	sb.Progress, sb.HasProgress = s.Progress().Innermost()
+	sb.MessageBadge = s.Messages().HasErrors() || s.Messages().HasWarnings()
 	ti := s.ActiveTool()
 	if ti == nil {
 		return sb
@@ -50,3 +57,10 @@ func toolPrompt(s *Session, t Tool) string {
 	}
 	return "Select or specify input for " + t.Name()
 }
+
+// StatusText returns the wire-set status message (status.getText).
+func (s *Session) StatusText() string { return s.statusText }
+
+// SetStatusText puts (or, with "", clears) a status-bar message — the status.setText
+// surface an add-in narrates long operations with (M05-F09).
+func (s *Session) SetStatusText(text string) { s.statusText = text }

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -18,6 +18,7 @@ import (
 	"oblikovati.org/event"
 	"oblikovati.org/head/internal/addinhost"
 	"oblikovati.org/persistence/addinstate"
+	"oblikovati.org/persistence/dialogmemory"
 	"oblikovati.org/script/bridge"
 	"oblikovati.org/script/console"
 	"oblikovati.org/script/gopherlua"
@@ -66,6 +67,7 @@ func startAddIns(session *app.Session) *addInHost {
 	// host calls serialize onto the session goroutine and never freeze the UI (ADR-0028 §5).
 	h.script = newScriptController(rtr, session, d)
 	useBehaviorStore(session)
+	useDialogMemoryStore(session)
 	libs, err := addinhost.LoadDir(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "add-ins: %v\n", err)
@@ -109,6 +111,19 @@ func useBehaviorStore(session *app.Session) {
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "add-in behaviors: %v\n", err)
+	}
+}
+
+// useDialogMemoryStore wires the per-user remembered dialog choices (suppressed
+// balloon tips, remembered prompt answers — M05-F09). A failure costs only
+// persistence.
+func useDialogMemoryStore(session *app.Session) {
+	path, err := dialogmemory.DefaultPath()
+	if err == nil {
+		err = session.UseDialogMemoryStore(dialogmemory.NewFileStore(path))
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dialog memory: %v\n", err)
 	}
 }
 

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -39,6 +39,9 @@ int  obk_ig_tree_node_selectable(const char* label, int selected);
 void obk_ig_tree_pop(void);
 void obk_ig_bullet_text(const char* s);
 void obk_ig_set_item_tooltip(const char* s);
+void obk_ig_progress_bar(float fraction, float w, const char* overlay);
+void obk_ig_main_viewport_size(float* w, float* h);
+float obk_ig_hover_seconds(void);
 int  obk_ig_begin_popup_context_item(const char* id);
 void obk_ig_open_popup(const char* id);
 int  obk_ig_begin_popup(const char* id);
@@ -523,6 +526,26 @@ func BulletText(s string) {
 
 // SetItemTooltip shows a hover tooltip for the most recently drawn item (the ribbon
 // button), matching Inventor's on-hover command tooltips. No-op if the text is empty.
+// ProgressBar draws a determinate progress bar of the given pixel width with an
+// optional overlay text (M05-F09 status-bar progress).
+func ProgressBar(fraction, width float32, overlay string) {
+	c, free := cstr(overlay)
+	defer free()
+	C.obk_ig_progress_bar(C.float(fraction), C.float(width), c)
+}
+
+// MainViewportSize reports the main viewport's pixel size — used to anchor the
+// balloon toasts and the prompt modal (M05-F09).
+func MainViewportSize() (w, h float32) {
+	var cw, ch C.float
+	C.obk_ig_main_viewport_size(&cw, &ch)
+	return float32(cw), float32(ch)
+}
+
+// HoverSeconds reports how long the last item has been hovered — drives the
+// progressive tooltip's expanded text (M05-F09).
+func HoverSeconds() float32 { return float32(C.obk_ig_hover_seconds()) }
+
 func SetItemTooltip(s string) {
 	if s == "" {
 		return

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -125,6 +125,22 @@ int  obk_ig_tree_node_selectable(const char* label, int selected) {
 void obk_ig_tree_pop(void)                   { ImGui::TreePop(); }
 void obk_ig_bullet_text(const char* s)       { ImGui::BulletText("%s", s); }
 void obk_ig_set_item_tooltip(const char* s)  { ImGui::SetItemTooltip("%s", s); }
+// progress_bar draws a determinate bar of the given pixel width; overlay text ("")
+// falls back to ImGui's percentage.
+void obk_ig_progress_bar(float fraction, float w, const char* overlay) {
+    const char* ov = (overlay && overlay[0]) ? overlay : NULL;
+    ImGui::ProgressBar(fraction, ImVec2(w, 0.0f), ov);
+}
+// main_viewport_size reports the main viewport's size (toast/modal placement).
+void obk_ig_main_viewport_size(float* w, float* h) {
+    ImVec2 sz = ImGui::GetMainViewport()->Size;
+    *w = sz.x; *h = sz.y;
+}
+// hover_seconds reports how long the last item has been hovered (the progressive
+// tooltip's expand timer).
+float obk_ig_hover_seconds(void) {
+    return ImGui::IsItemHovered() ? ImGui::GetCurrentContext()->HoveredIdTimer : 0.0f;
+}
 
 // begin_popup_context_item opens (on right-click of the just-drawn item) and begins a
 // context-menu popup keyed by id; returns 1 while the popup is open so the caller fills

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -121,6 +121,7 @@ func drawChromeWindows(s *app.Session) {
 	drawLightingWindow(s)
 	drawScriptConsole(s)
 	drawAddInPanels(s)                  // add-in dockable windows (M05-F03)
+	drawMessagingSurfaces(s)            // toasts, prompt modal, message center (M05-F09)
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -299,7 +299,7 @@ func drawButtonControl(btn app.RibbonButton) bool {
 		}
 	}
 	clicked := native.Button(btn.Command.DisplayName())
-	native.SetItemTooltip(btn.Command.Tooltip())
+	setCommandTooltip(btn.Command)
 	return clicked
 }
 
@@ -331,7 +331,7 @@ func drawIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
 		return drawLabeledIconButton(btn, tex, px)
 	default: // CompactIconButton
 		clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
-		native.SetItemTooltip(btn.Command.Tooltip())
+		setCommandTooltip(btn.Command)
 		return clicked
 	}
 }
@@ -342,7 +342,7 @@ func drawLabeledIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
 	m := native.Metrics()
 	native.BeginGroup()
 	clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
-	native.SetItemTooltip(btn.Command.Tooltip())
+	setCommandTooltip(btn.Command)
 	native.SameLine()
 	x, y := native.GetCursorScreenPos()
 	native.SetCursorScreenPos(x, y+(px+2*m.FramePadY-native.TextLineHeight())/2)
@@ -366,10 +366,34 @@ func drawLargeIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
 	x, y := native.GetCursorScreenPos()
 	native.SetCursorScreenPos(x+(cellW-frameW)/2, y)
 	clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
-	native.SetItemTooltip(btn.Command.Tooltip())
+	setCommandTooltip(btn.Command)
 	_, captionY := native.GetCursorScreenPos()
 	native.SetCursorScreenPos(x+(cellW-textW)/2, captionY)
 	native.Text(btn.Command.DisplayName())
 	native.EndGroup()
 	return clicked
+}
+
+// progressiveHoverDelay is how long a hover lasts (seconds) before the expanded
+// text joins the tooltip — the ProgressiveToolTip behavior (M05-F09).
+const progressiveHoverDelay = 1.2
+
+// setCommandTooltip renders the command's tooltip for the last item: the optional
+// title heads it, and the expanded text appears after a longer hover.
+func setCommandTooltip(c *app.CommandDefinition) {
+	text := c.Tooltip()
+	if title := c.TooltipTitle(); title != "" {
+		if text == "" {
+			text = title
+		} else {
+			text = title + "\n" + text
+		}
+	}
+	if expanded := c.TooltipExpanded(); expanded != "" && native.HoverSeconds() > progressiveHoverDelay {
+		if text != "" {
+			text += "\n\n"
+		}
+		text += expanded
+	}
+	native.SetItemTooltip(text)
 }

--- a/head/ui/chrome_statusbar.go
+++ b/head/ui/chrome_statusbar.go
@@ -36,8 +36,47 @@ func drawStatusBar(s *app.Session) {
 			native.SameLine()
 			native.Text("— " + sb.Notice)
 		}
+		if sb.StatusText != "" {
+			native.SameLine()
+			native.Text("· " + sb.StatusText)
+		}
+		drawStatusProgress(s, sb)
+		drawMessagesBadge(s, sb)
 	}
 	native.End()
+}
+
+// drawStatusProgress renders the innermost live progress bar with its cancel
+// control (M05-F09). Cancel marks the bar; the owner observes it in its next
+// update reply and as a progress.cancelled event.
+func drawStatusProgress(s *app.Session, sb app.StatusBar) {
+	if !sb.HasProgress {
+		return
+	}
+	native.SameLine()
+	fraction := float32(0)
+	if sb.Progress.Steps > 0 {
+		fraction = float32(sb.Progress.Step) / float32(sb.Progress.Steps)
+	}
+	native.ProgressBar(fraction, 160, sb.Progress.Message)
+	if !sb.Progress.Cancelled {
+		native.SameLine()
+		if native.Button("Cancel##progress") {
+			_ = s.CancelProgress(sb.Progress.ID)
+		}
+	}
+}
+
+// drawMessagesBadge renders the message-center indicator when it holds
+// errors/warnings; clicking opens the Messages panel.
+func drawMessagesBadge(s *app.Session, sb app.StatusBar) {
+	if !sb.MessageBadge {
+		return
+	}
+	native.SameLine()
+	if native.Button("Messages…") {
+		s.SetMessageCenterOpen(true)
+	}
 }
 
 // selectionText renders the selection count as a short status (e.g. "1 selected").

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -103,6 +103,8 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		seedAddInSurfaces(s)
 	case "preferences": // the Preferences window (General/Sketch Grid/Modeling/Theme tabs)
 		showPreferences = true
+	case "messaging": // M05-F09 surfaces: progress bar, balloon toast, prompt, messages
+		seedMessagingSurfaces(s)
 	default:
 		ext := app.NewExtrudeTool()
 		s.StartTool(ext)
@@ -136,6 +138,29 @@ func seedAddInSurfaces(s *app.Session) {
 			{Kind: types.PanelButton, Text: "Run Study", CommandID: "demo.alpha"},
 		},
 	})
+}
+
+// seedMessagingSurfaces stages every M05-F09 feedback surface the way an add-in
+// would over the wire: a half-done progress bar, a status text, a balloon toast, a
+// pending prompt, and message-center content (so the badge shows).
+func seedMessagingSurfaces(s *app.Session) {
+	s.SetStatusText("Solving load case 2 of 5")
+	if id, err := s.Progress().Begin(10, "Meshing bracket…"); err == nil {
+		_, _ = s.Progress().Update(id, 6, "")
+	}
+	_ = s.BalloonTips().Register(app.BalloonTipSpec{
+		ID: "sim.done", Title: "Simulation finished", Text: "Study 'Bracket' converged in 42 s.",
+	})
+	_, _ = s.ShowBalloonTip("sim.done")
+	_, _, _ = s.ShowPrompt(app.PromptSpec{
+		ID: "sim.replace", Message: "Replace the existing results?",
+		Buttons: []string{"Replace", "Keep both"}, Restriction: types.PromptAllowRemember,
+	})
+	sec := s.Messages().BeginSection("Meshing")
+	s.Messages().AddMessage("12 thin faces refined", types.SeverityInfo)
+	s.Messages().AddMessage("degenerate face at fillet F7", types.SeverityWarning)
+	_ = s.Messages().EndSection(sec)
+	s.SetMessageCenterOpen(true)
 }
 
 // applyVisualOverrides applies the OBK_VISUAL_* renderer knobs through the View-tab

--- a/head/ui/messaging_surfaces.go
+++ b/head/ui/messaging_surfaces.go
@@ -1,0 +1,134 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The M05-F09 feedback surfaces: balloon-tip toasts, the prompt modal, and the
+// message-center panel. All three read session state each frame and write user
+// gestures back through the session, so their owners observe the push events.
+
+// drawMessagingSurfaces renders the active balloons, a pending prompt, and the
+// Messages panel when open.
+func drawMessagingSurfaces(s *app.Session) {
+	drawBalloonToasts(s)
+	drawPromptModal(s)
+	drawMessageCenter(s)
+}
+
+// drawBalloonToasts renders each showing balloon as a small fixed window stacked
+// up the bottom-right corner. Clicking the body reports the click; the X closes;
+// the checkbox suppresses the tip for good.
+func drawBalloonToasts(s *app.Session) {
+	const toastW, toastH, margin = 320, 110, 16
+	screenW, screenH := native.MainViewportSize()
+	for i, tip := range s.BalloonTips().Active() {
+		x := screenW - toastW - margin
+		y := screenH - float32(i+1)*(toastH+margin)
+		native.SetNextWindowPos(x, y)
+		native.SetNextWindowSize(toastW, toastH)
+		visible, open := native.BeginClosable(tip.Title + "###balloon-" + tip.ID)
+		if visible {
+			if native.Selectable(tip.Text, false) {
+				s.ClickBalloonTip(tip.ID)
+			}
+			dontShow := false
+			if native.Checkbox("Don't show again##"+tip.ID, &dontShow) && dontShow {
+				s.DismissBalloonTip(tip.ID, true)
+			}
+		}
+		native.End()
+		if !open {
+			s.DismissBalloonTip(tip.ID, false)
+		}
+	}
+}
+
+// drawPromptModal renders the oldest pending prompt as a centered modal: the
+// message, one button per answer, and the remember checkbox when allowed.
+func drawPromptModal(s *app.Session) {
+	spec, ok := s.Prompts().Pending()
+	if !ok {
+		return
+	}
+	screenW, screenH := native.MainViewportSize()
+	native.SetNextWindowPos(screenW/2-220, screenH/2-80)
+	native.SetNextWindowSize(440, 0)
+	if native.Begin("Prompt###prompt-modal") {
+		native.Text(spec.Message)
+		native.Separator()
+		if spec.Restriction == types.PromptAllowRemember {
+			native.Checkbox("Remember my answer", &promptRemember)
+		}
+		for i, label := range spec.Buttons {
+			if i > 0 {
+				native.SameLine()
+			}
+			if native.Button(label + "##prompt-" + strconv.Itoa(i)) {
+				_ = s.AnswerPrompt(spec.ID, label, promptRemember)
+				promptRemember = false
+			}
+		}
+	}
+	native.End()
+}
+
+// promptRemember is the modal's "remember my answer" checkbox state (UI state, so
+// it lives in the head; reset after each answer).
+var promptRemember bool
+
+// drawMessageCenter renders the sectioned message tree (errors.show / the status
+// badge open it).
+func drawMessageCenter(s *app.Session) {
+	if !s.MessageCenterOpen() {
+		return
+	}
+	native.SetNextWindowSizeOnce(420, 320)
+	visible, open := native.BeginClosable("Messages###message-center")
+	if visible {
+		if native.Button("Clear") {
+			s.Messages().Clear()
+		}
+		native.Separator()
+		drawMessageSection(s.Messages().View())
+	}
+	native.End()
+	if !open {
+		s.SetMessageCenterOpen(false)
+	}
+}
+
+// drawMessageSection renders one section's messages and nested sections.
+func drawMessageSection(section wire.MessageSectionView) {
+	for _, msg := range section.Messages {
+		native.BulletText(severityPrefix(msg.Severity) + msg.Text)
+	}
+	for _, sub := range section.Sections {
+		native.SetNextItemOpen(true, true)
+		if native.TreeNode(sub.Title) {
+			drawMessageSection(sub)
+			native.TreePop()
+		}
+	}
+}
+
+// severityPrefix tags a message row by its severity.
+func severityPrefix(sev types.MessageSeverity) string {
+	switch sev {
+	case types.SeverityError:
+		return "[error] "
+	case types.SeverityWarning:
+		return "[warning] "
+	default:
+		return ""
+	}
+}

--- a/persistence/dialogmemory/dialogmemory.go
+++ b/persistence/dialogmemory/dialogmemory.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package dialogmemory persists the user's remembered dialog choices (M05-F09,
+// #616): which balloon tips they suppressed ("don't show again") and which prompt
+// answers they chose to keep — one YAML file in the OS config directory, beside the
+// other per-user stores.
+package dialogmemory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"oblikovati.org/persistence/yamlcodec"
+	"oblikovati.org/userconfig"
+)
+
+// Memory is the remembered choices: suppressed balloon-tip ids and prompt answers
+// keyed by prompt id.
+type Memory struct {
+	SuppressedTips []string          `yaml:"suppressedTips,omitempty"`
+	PromptAnswers  map[string]string `yaml:"promptAnswers,omitempty"`
+}
+
+// Store loads and saves the remembered choices.
+type Store interface {
+	Load() (Memory, error)
+	Save(Memory) error
+}
+
+// FileStore persists the memory to a YAML file.
+type FileStore struct{ path string }
+
+// DefaultPath is the per-user file: ~/.oblikovati/dialog-memory.yaml on Linux/macOS.
+func DefaultPath() (string, error) {
+	return userconfig.File("dialog-memory.yaml")
+}
+
+// NewFileStore returns a store backed by the file at path.
+func NewFileStore(path string) *FileStore { return &FileStore{path: path} }
+
+// Load reads the remembered choices; a missing file is an empty memory.
+func (s *FileStore) Load() (Memory, error) {
+	raw, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return Memory{}, nil
+	}
+	if err != nil {
+		return Memory{}, fmt.Errorf("dialogmemory: read %q: %w", s.path, err)
+	}
+	var m Memory
+	if err := yamlcodec.Unmarshal(raw, &m); err != nil {
+		return Memory{}, fmt.Errorf("dialogmemory: parse %q: %w", s.path, err)
+	}
+	return m, nil
+}
+
+// Save writes the remembered choices, creating the config directory on first use.
+func (s *FileStore) Save(m Memory) error {
+	data, err := yamlcodec.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("dialogmemory: marshal: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("dialogmemory: create config dir for %q: %w", s.path, err)
+	}
+	return os.WriteFile(s.path, data, 0o644)
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F09, closing #616 (contract: Oblikovati/Oblikovati.API#48):

- **Status bar**: `status.setText/getText`; renders the innermost live **progress bar** (nesting-safe `ProgressLedger`; cancel button → `cancelled` in the next update reply **and** a `progress.cancelled` event) and a **Messages…** badge.
- **Balloon tips**: bottom-right toasts; body click → `balloonTip.clicked`; *don't show again* persists in `~/.oblikovati/dialog-memory.yaml`.
- **Prompts**: declarative and non-blocking — remembered answers resolve in the `prompts.show` reply; live ones render as a modal firing `prompt.answered`. A rejected answer leaves the prompt pending (regression-tested).
- **Message center**: sectioned tree with bracket-style nesting, aggregate flags, structured slog per entry, a panel with Clear; `errors.show` opens it.
- **Progressive tooltips**: `WithTooltipDetail(title, expanded)` — ribbon shows the title at once, the expanded text after a 1.2 s hover.

## Tests

Section nesting/flags, progress lifecycle + cancel event, suppression and remembered answers surviving session boundaries (fake stores), prompt validation regression; wire round-trips for all five method groups; relay coverage. All surfaces verified visually in one staged screenshot (progress bar + toast + prompt modal + Messages panel + status text).

Closes #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)