### PR TITLE
Render in-canvas mini-toolbars and stream their edits back (M05-F07)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -58,9 +58,9 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 }
 
 // subscribeUISurfaces wires the M05 UI-surface events: browser panes and dockable
-// windows (F03), progress/balloon/prompt feedback (F09).
+// windows (F03), progress/balloon/prompt feedback (F09), mini-toolbars (F07).
 func subscribeUISurfaces(bus *event.Bus, sink Sink) []event.Subscription {
-	return []event.Subscription{
+	subs := []event.Subscription{
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.BrowserPaneNodeActivated) event.Outcome {
 			return relayJSON(sink, wire.BrowserNodeEvent{
 				Type: wire.EventBrowserNode, Pane: e.Pane, Node: e.Node, Gesture: e.Gesture,
@@ -83,12 +83,31 @@ func subscribeUISurfaces(bus *event.Bus, sink Sink) []event.Subscription {
 			})
 		}),
 	}
+	return append(subs, subscribeMiniToolbars(bus, sink)...)
+}
+
+// subscribeMiniToolbars wires the mini-toolbar edit/commit events (M05-F07).
+func subscribeMiniToolbars(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.MiniToolbarControlChanged) event.Outcome {
+			return relayJSON(sink, wire.MiniToolbarChangedEvent{
+				Type: wire.EventMiniToolbarChanged, Toolbar: e.Toolbar, Control: e.Control,
+				Value: e.Value, Checked: e.Checked, Number: e.Number, Selected: e.Selected,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.MiniToolbarCommitted) event.Outcome {
+			return relayJSON(sink, wire.MiniToolbarCommittedEvent{
+				Type: wire.EventMiniToolbarCommitted, Toolbar: e.Toolbar, Gesture: e.Gesture,
+			})
+		}),
+	}
 }
 
 // relayJSON serializes a wire event DTO and hands it to sink (passive listener).
 // Generic so each call site stays statically typed (the house no-`any` rule).
 func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
-	wire.ProgressCancelledEvent | wire.BalloonTipClickedEvent | wire.PromptAnsweredEvent](sink Sink, ev E) event.Outcome {
+	wire.ProgressCancelledEvent | wire.BalloonTipClickedEvent | wire.PromptAnsweredEvent |
+	wire.MiniToolbarChangedEvent | wire.MiniToolbarCommittedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/router/minitoolbar.go
+++ b/addin/router/minitoolbar.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerMiniToolbarHandlers wires the in-canvas mini-toolbar methods (M05-F07, #614).
+func (r *Router) registerMiniToolbarHandlers() {
+	r.handlers[wire.MethodMiniToolbarSet] = setMiniToolbar
+	r.handlers[wire.MethodMiniToolbarUpdate] = updateMiniToolbar
+	r.handlers[wire.MethodMiniToolbarRemove] = removeMiniToolbar
+	r.handlers[wire.MethodMiniToolbarList] = listMiniToolbars
+}
+
+func setMiniToolbar(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetMiniToolbarArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.SetMiniToolbar(req.Toolbar); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func updateMiniToolbar(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.UpdateMiniToolbarArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.UpdateMiniToolbarControls(req.ID, req.Controls); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func removeMiniToolbar(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.RemoveMiniToolbarArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.RemoveMiniToolbar(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func listMiniToolbars(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.ListMiniToolbarsResult{Toolbars: s.MiniToolbars().List()})
+}

--- a/addin/router/minitoolbar_test.go
+++ b/addin/router/minitoolbar_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+func TestMiniToolbarOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "miniToolbar.set",
+		`{"toolbar":{"id":"sim.probe","visible":true,"headsUpText":"Probe","anchor":[1,2,3],"showOK":true,"controls":[{"kind":5,"id":"depth","label":"Depth","value":"10 mm"}]}}`, nil)
+
+	var lst wire.ListMiniToolbarsResult
+	call(t, r, s, "miniToolbar.list", "{}", &lst)
+	if len(lst.Toolbars) != 1 || lst.Toolbars[0].Anchor == nil || lst.Toolbars[0].Anchor[2] != 3 {
+		t.Fatalf("list = %+v, want the anchored toolbar", lst.Toolbars)
+	}
+
+	call(t, r, s, "miniToolbar.update",
+		`{"id":"sim.probe","controls":[{"id":"depth","value":"12 mm"}]}`, nil)
+	call(t, r, s, "miniToolbar.list", "{}", &lst)
+	if lst.Toolbars[0].Controls[0].Value != "12 mm" {
+		t.Fatalf("update did not merge: %+v", lst.Toolbars[0].Controls)
+	}
+
+	call(t, r, s, "miniToolbar.remove", `{"id":"sim.probe"}`, nil)
+	call(t, r, s, "miniToolbar.list", "{}", &lst)
+	if len(lst.Toolbars) != 0 {
+		t.Fatalf("toolbars after remove = %+v, want none", lst.Toolbars)
+	}
+	if _, err := r.Handle(s, "miniToolbar.update",
+		[]byte(`{"id":"sim.probe","controls":[]}`)); err == nil {
+		t.Error("updating a removed toolbar should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -48,6 +48,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerUISurfaceHandlers()
 	r.registerOptionHandlers()
 	r.registerMessagingHandlers()
+	r.registerMiniToolbarHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/app/events.go
+++ b/app/events.go
@@ -9,16 +9,18 @@ import (
 
 // Application UI events on the session bus. Stable TypeIDs (0x05xx = M05 UI).
 const (
-	tidCommandStarted     event.TypeID = 0x0501
-	tidCommandEnded       event.TypeID = 0x0502
-	tidSelectionChanged   event.TypeID = 0x0503
-	tidTransactionChange  event.TypeID = 0x0504
-	tidEditCommitted      event.TypeID = 0x0505
-	tidBrowserPaneNode    event.TypeID = 0x0506 // app/browser_panes.go (M05-F03)
-	tidDockableWinChanged event.TypeID = 0x0507 // app/dockwindow_store.go (M05-F03)
-	tidProgressCancelled  event.TypeID = 0x0508 // app/progress_ledger.go (M05-F09)
-	tidBalloonClicked     event.TypeID = 0x0509 // app/balloon_tips.go (M05-F09)
-	tidPromptAnswered     event.TypeID = 0x050a // app/prompt_center.go (M05-F09)
+	tidCommandStarted       event.TypeID = 0x0501
+	tidCommandEnded         event.TypeID = 0x0502
+	tidSelectionChanged     event.TypeID = 0x0503
+	tidTransactionChange    event.TypeID = 0x0504
+	tidEditCommitted        event.TypeID = 0x0505
+	tidBrowserPaneNode      event.TypeID = 0x0506 // app/browser_panes.go (M05-F03)
+	tidDockableWinChanged   event.TypeID = 0x0507 // app/dockwindow_store.go (M05-F03)
+	tidProgressCancelled    event.TypeID = 0x0508 // app/progress_ledger.go (M05-F09)
+	tidBalloonClicked       event.TypeID = 0x0509 // app/balloon_tips.go (M05-F09)
+	tidPromptAnswered       event.TypeID = 0x050a // app/prompt_center.go (M05-F09)
+	tidMiniToolbarChanged   event.TypeID = 0x050b // app/minitoolbar_store.go (M05-F07)
+	tidMiniToolbarCommitted event.TypeID = 0x050c // app/minitoolbar_store.go (M05-F07)
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's

--- a/app/minitoolbar_store.go
+++ b/app/minitoolbar_store.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+// In-canvas mini-toolbars (M05-F07, #614): floating toolbars an interactive command
+// or add-in declares; the head renders them in the viewport and reports the user's
+// edits back as events. Like the other declared UI surfaces, the wire spec is the
+// model.
+
+// MiniToolbarControlChanged fires (After) when the user edits one control; the
+// events relay forwards it as a miniToolbar.changed push event.
+type MiniToolbarControlChanged struct {
+	Toolbar  string
+	Control  string
+	Value    string
+	Checked  bool
+	Number   float64
+	Selected int
+}
+
+// EventID implements event.Event.
+func (MiniToolbarControlChanged) EventID() event.TypeID { return tidMiniToolbarChanged }
+
+// MiniToolbarCommitted fires (After) on the toolbar's OK/Apply/Cancel.
+type MiniToolbarCommitted struct {
+	Toolbar string
+	Gesture string // "ok", "apply" or "cancel"
+}
+
+// EventID implements event.Event.
+func (MiniToolbarCommitted) EventID() event.TypeID { return tidMiniToolbarCommitted }
+
+// The commit gestures of a mini-toolbar.
+const (
+	MiniToolbarOK     = "ok"
+	MiniToolbarApply  = "apply"
+	MiniToolbarCancel = "cancel"
+)
+
+// MiniToolbarRack holds the declared toolbars in creation order.
+type MiniToolbarRack struct {
+	order    []string
+	toolbars map[string]wire.MiniToolbarSpec
+}
+
+// NewMiniToolbarRack returns an empty rack.
+func NewMiniToolbarRack() *MiniToolbarRack {
+	return &MiniToolbarRack{toolbars: map[string]wire.MiniToolbarSpec{}}
+}
+
+// List returns the toolbars in creation order.
+func (r *MiniToolbarRack) List() []wire.MiniToolbarSpec {
+	out := make([]wire.MiniToolbarSpec, len(r.order))
+	for i, id := range r.order {
+		out[i] = r.toolbars[id]
+	}
+	return out
+}
+
+// Get returns one toolbar by id.
+func (r *MiniToolbarRack) Get(id string) (wire.MiniToolbarSpec, bool) {
+	spec, ok := r.toolbars[id]
+	return spec, ok
+}
+
+// MiniToolbars returns the session's mini-toolbar rack.
+func (s *Session) MiniToolbars() *MiniToolbarRack { return s.miniToolbars }
+
+// SetMiniToolbar creates or wholly replaces a toolbar.
+func (s *Session) SetMiniToolbar(spec wire.MiniToolbarSpec) error {
+	if spec.ID == "" {
+		return fmt.Errorf("app: mini-toolbar needs an id, got %+v", spec)
+	}
+	if _, exists := s.miniToolbars.toolbars[spec.ID]; !exists {
+		s.miniToolbars.order = append(s.miniToolbars.order, spec.ID)
+	}
+	s.miniToolbars.toolbars[spec.ID] = spec
+	return nil
+}
+
+// UpdateMiniToolbarControls merges control values by control id.
+func (s *Session) UpdateMiniToolbarControls(id string, controls []wire.MiniToolbarControlSpec) error {
+	spec, ok := s.miniToolbars.toolbars[id]
+	if !ok {
+		return fmt.Errorf("app: no mini-toolbar %q", id)
+	}
+	for _, incoming := range controls {
+		if !mergeMiniToolbarControl(&spec, incoming) {
+			return fmt.Errorf("app: mini-toolbar %q has no control %q", id, incoming.ID)
+		}
+	}
+	s.miniToolbars.toolbars[id] = spec
+	return nil
+}
+
+// mergeMiniToolbarControl writes incoming's value fields over the matching control.
+func mergeMiniToolbarControl(spec *wire.MiniToolbarSpec, incoming wire.MiniToolbarControlSpec) bool {
+	for i := range spec.Controls {
+		if spec.Controls[i].ID != incoming.ID {
+			continue
+		}
+		c := &spec.Controls[i]
+		c.Value, c.Checked, c.Number, c.Selected = incoming.Value, incoming.Checked, incoming.Number, incoming.Selected
+		return true
+	}
+	return false
+}
+
+// RemoveMiniToolbar dismisses a toolbar.
+func (s *Session) RemoveMiniToolbar(id string) error {
+	if _, ok := s.miniToolbars.toolbars[id]; !ok {
+		return fmt.Errorf("app: no mini-toolbar %q", id)
+	}
+	delete(s.miniToolbars.toolbars, id)
+	for i, x := range s.miniToolbars.order {
+		if x == id {
+			s.miniToolbars.order = append(s.miniToolbars.order[:i], s.miniToolbars.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// ChangeMiniToolbarControl records a user edit (the head's widgets call it),
+// keeping the stored spec current and emitting the change for the owner.
+func (s *Session) ChangeMiniToolbarControl(toolbarID string, control wire.MiniToolbarControlSpec) error {
+	if err := s.UpdateMiniToolbarControls(toolbarID, []wire.MiniToolbarControlSpec{control}); err != nil {
+		return err
+	}
+	event.Emit(s.bus, event.After, MiniToolbarControlChanged{
+		Toolbar: toolbarID, Control: control.ID,
+		Value: control.Value, Checked: control.Checked, Number: control.Number, Selected: control.Selected,
+	})
+	return nil
+}
+
+// CommitMiniToolbar reports the toolbar's OK/Apply/Cancel; ok and cancel also
+// dismiss it (apply keeps it for further edits).
+func (s *Session) CommitMiniToolbar(id, gesture string) error {
+	if _, ok := s.miniToolbars.toolbars[id]; !ok {
+		return fmt.Errorf("app: no mini-toolbar %q", id)
+	}
+	switch gesture {
+	case MiniToolbarOK, MiniToolbarApply, MiniToolbarCancel:
+	default:
+		return fmt.Errorf("app: unknown mini-toolbar gesture %q (ok/apply/cancel)", gesture)
+	}
+	event.Emit(s.bus, event.After, MiniToolbarCommitted{Toolbar: id, Gesture: gesture})
+	if gesture != MiniToolbarApply {
+		return s.RemoveMiniToolbar(id)
+	}
+	return nil
+}
+
+// dropCommandMiniToolbars removes the toolbars tied to a command's lifetime — the
+// interaction-graphics lifecycle: the tool ended, its toolbar goes with it.
+func (s *Session) dropCommandMiniToolbars() {
+	for _, id := range append([]string(nil), s.miniToolbars.order...) {
+		if s.miniToolbars.toolbars[id].Command != "" {
+			_ = s.RemoveMiniToolbar(id)
+		}
+	}
+}

--- a/app/minitoolbar_store_test.go
+++ b/app/minitoolbar_store_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+func probeToolbar(command string) wire.MiniToolbarSpec {
+	return wire.MiniToolbarSpec{
+		ID: "sim.probe", Command: command, Visible: true, HeadsUpText: "Probe",
+		ShowOK: true, ShowCancel: true,
+		Controls: []wire.MiniToolbarControlSpec{
+			{Kind: types.MiniToolbarValueEditor, ID: "depth", Label: "Depth", Value: "10 mm"},
+			{Kind: types.MiniToolbarSlider, ID: "blend", Number: 0.5, Min: 0, Max: 1},
+		},
+	}
+}
+
+func TestMiniToolbarSetUpdateRemove(t *testing.T) {
+	s := NewSession()
+	if err := s.SetMiniToolbar(probeToolbar("")); err != nil {
+		t.Fatalf("SetMiniToolbar: %v", err)
+	}
+	if err := s.UpdateMiniToolbarControls("sim.probe", []wire.MiniToolbarControlSpec{
+		{ID: "depth", Value: "12 mm"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	tb, ok := s.MiniToolbars().Get("sim.probe")
+	if !ok || tb.Controls[0].Value != "12 mm" {
+		t.Fatalf("toolbar = %+v, want depth merged to 12 mm", tb)
+	}
+	if err := s.UpdateMiniToolbarControls("sim.probe", []wire.MiniToolbarControlSpec{{ID: "ghost"}}); err == nil {
+		t.Error("updating an unknown control should fail")
+	}
+	if err := s.RemoveMiniToolbar("sim.probe"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if len(s.MiniToolbars().List()) != 0 {
+		t.Error("toolbar survived Remove")
+	}
+}
+
+func TestMiniToolbarChangeAndCommitEvents(t *testing.T) {
+	s := NewSession()
+	var changes []MiniToolbarControlChanged
+	var commits []MiniToolbarCommitted
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e MiniToolbarControlChanged) event.Outcome {
+		changes = append(changes, e)
+		return event.Continue()
+	})
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e MiniToolbarCommitted) event.Outcome {
+		commits = append(commits, e)
+		return event.Continue()
+	})
+	if err := s.SetMiniToolbar(probeToolbar("")); err != nil {
+		t.Fatalf("SetMiniToolbar: %v", err)
+	}
+
+	if err := s.ChangeMiniToolbarControl("sim.probe", wire.MiniToolbarControlSpec{
+		ID: "blend", Number: 0.75,
+	}); err != nil {
+		t.Fatalf("Change: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Control != "blend" || changes[0].Number != 0.75 {
+		t.Fatalf("changes = %+v, want blend 0.75", changes)
+	}
+	if tb, _ := s.MiniToolbars().Get("sim.probe"); tb.Controls[1].Number != 0.75 {
+		t.Error("the change did not land in the stored spec")
+	}
+
+	if err := s.CommitMiniToolbar("sim.probe", MiniToolbarApply); err != nil {
+		t.Fatalf("Commit apply: %v", err)
+	}
+	if len(s.MiniToolbars().List()) != 1 {
+		t.Error("apply must keep the toolbar")
+	}
+	if err := s.CommitMiniToolbar("sim.probe", MiniToolbarOK); err != nil {
+		t.Fatalf("Commit ok: %v", err)
+	}
+	if len(s.MiniToolbars().List()) != 0 {
+		t.Error("ok must dismiss the toolbar")
+	}
+	if len(commits) != 2 || commits[0].Gesture != "apply" || commits[1].Gesture != "ok" {
+		t.Fatalf("commits = %+v, want apply then ok", commits)
+	}
+}
+
+// FakeMiniToolbarTool is a named minimal tool for the lifecycle test.
+type FakeMiniToolbarTool struct{}
+
+func (FakeMiniToolbarTool) Name() string              { return "fake" }
+func (FakeMiniToolbarTool) Start(*Session)            {}
+func (FakeMiniToolbarTool) Pick(*Session, Selectable) {}
+func (FakeMiniToolbarTool) CanCommit() bool           { return true }
+func (FakeMiniToolbarTool) Commit(*Session) error     { return nil }
+func (FakeMiniToolbarTool) Cancel(*Session)           {}
+
+func TestCommandBoundMiniToolbarDiesWithTool(t *testing.T) {
+	s := NewSession()
+	s.StartTool(FakeMiniToolbarTool{})
+	if err := s.SetMiniToolbar(probeToolbar("Sim.Probe")); err != nil {
+		t.Fatalf("SetMiniToolbar: %v", err)
+	}
+	free := probeToolbar("")
+	free.ID = "sim.free"
+	if err := s.SetMiniToolbar(free); err != nil {
+		t.Fatalf("SetMiniToolbar(free): %v", err)
+	}
+
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	left := s.MiniToolbars().List()
+	if len(left) != 1 || left[0].ID != "sim.free" {
+		t.Fatalf("toolbars after commit = %+v, want only the unbound one", left)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -61,6 +61,7 @@ type Session struct {
 	balloonTips        *BalloonTipCenter          // notification balloons (M05-F09)
 	prompts            *PromptCenter              // declarative prompts (M05-F09)
 	dialogMemoryStore  dialogmemory.Store         // persists suppressions + remembered answers
+	miniToolbars       *MiniToolbarRack           // in-canvas mini-toolbars (M05-F07)
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store
@@ -128,6 +129,7 @@ func newSession(store doc.Store) *Session {
 		progress:        NewProgressLedger(),
 		balloonTips:     NewBalloonTipCenter(),
 		prompts:         NewPromptCenter(),
+		miniToolbars:    NewMiniToolbarRack(),
 		visualStyle:     renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -20,6 +20,7 @@ func (s *Session) StartTool(t Tool) {
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
 		s.graphics.ClearInteraction() // drop the previous tool's preview/overlay graphics
+		s.dropCommandMiniToolbars()   // and its mini-toolbars (M05-F07)
 	}
 	s.notice = ""
 	s.tool = &ToolInstance{tool: t}
@@ -54,6 +55,7 @@ func (s *Session) OK() error {
 	s.notice = ""
 	s.tool = nil
 	s.graphics.ClearInteraction() // a committed command's transient preview vanishes
+	s.dropCommandMiniToolbars()   // command-bound mini-toolbars die with the tool (M05-F07)
 	return nil
 }
 
@@ -64,6 +66,7 @@ func (s *Session) CancelTool() {
 		s.tool.tool.Cancel(s)
 		s.tool = nil
 		s.graphics.ClearInteraction() // a cancelled command's transient preview vanishes
+		s.dropCommandMiniToolbars()   // command-bound mini-toolbars die with the tool (M05-F07)
 	}
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -276,6 +276,7 @@ func drawViewportOverlays(s *app.Session, cam scene.Camera, sketchPlane sketch.P
 	ox, oy := native.ItemRectMin()
 	drawAxisGizmo(cam, ox, oy, ph)
 	drawClientGraphicsLabels(cx, cy, cam, labels)
+	drawMiniToolbars(s, cam, ox, oy) // in-canvas mini-toolbars (M05-F07)
 	if s.InSketch() && len(dims) > 0 {
 		if d := drawDimensionLabels(cx, cy, cam, sketchPlane, dims); d != nil {
 			s.BeginEditDimension(d) // double-clicked a dimension's value

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -105,6 +105,13 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		showPreferences = true
 	case "messaging": // M05-F09 surfaces: progress bar, balloon toast, prompt, messages
 		seedMessagingSurfaces(s)
+	case "minitoolbar": // M05-F07: an anchored in-canvas mini-toolbar over a solid
+		ext := app.NewExtrudeTool()
+		s.StartTool(ext)
+		ext.Pick(s, profile)
+		ext.SetDistance(3)
+		_ = s.OK()
+		seedMiniToolbar(s)
 	default:
 		ext := app.NewExtrudeTool()
 		s.StartTool(ext)
@@ -161,6 +168,21 @@ func seedMessagingSurfaces(s *app.Session) {
 	s.Messages().AddMessage("degenerate face at fillet F7", types.SeverityWarning)
 	_ = s.Messages().EndSection(sec)
 	s.SetMessageCenterOpen(true)
+}
+
+// seedMiniToolbar declares an anchored mini-toolbar the way a command would (M05-F07).
+func seedMiniToolbar(s *app.Session) {
+	anchor := [3]float64{2, 3, 2.5}
+	_ = s.SetMiniToolbar(wire.MiniToolbarSpec{
+		ID: "demo.probe", Visible: true, HeadsUpText: "Probe depth", Anchor: &anchor,
+		ShowOK: true, ShowApply: true, ShowCancel: true,
+		Controls: []wire.MiniToolbarControlSpec{
+			{Kind: types.MiniToolbarValueEditor, ID: "depth", Label: "Depth", Value: "10 mm"},
+			{Kind: types.MiniToolbarSlider, ID: "blend", Label: "Blend", Number: 0.4, Min: 0, Max: 1},
+			{Kind: types.MiniToolbarCombo, ID: "dir", Label: "Direction", Options: []string{"Normal", "Reversed"}},
+			{Kind: types.MiniToolbarCheckbox, ID: "sym", Label: "Symmetric", Checked: true},
+		},
+	})
 }
 
 // applyVisualOverrides applies the OBK_VISUAL_* renderer knobs through the View-tab

--- a/head/ui/minitoolbar_view.go
+++ b/head/ui/minitoolbar_view.go
@@ -1,0 +1,178 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"math"
+	"strconv"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	gomath "oblikovati.org/math"
+	"oblikovati.org/renderer"
+	"oblikovati.org/scene"
+)
+
+// In-canvas mini-toolbars (M05-F07): each visible declared toolbar renders as a
+// small floating window over the viewport — at its projected model anchor, or at
+// viewport-relative pixels — with its declared controls and OK/Apply/Cancel row.
+// User edits flow back through the session, so the owner receives the
+// miniToolbar.changed / .committed events.
+
+// drawMiniToolbars renders the visible toolbars; originX/Y is the viewport image's
+// screen origin (anchors project relative to it).
+func drawMiniToolbars(s *app.Session, cam scene.Camera, originX, originY float32) {
+	for _, tb := range s.MiniToolbars().List() {
+		if tb.Visible {
+			drawMiniToolbar(s, cam, originX, originY, tb)
+		}
+	}
+}
+
+// drawMiniToolbar renders one toolbar. Closing the window's X is a cancel.
+func drawMiniToolbar(s *app.Session, cam scene.Camera, originX, originY float32, tb wire.MiniToolbarSpec) {
+	x, y, visible := miniToolbarScreenPos(cam, originX, originY, tb)
+	if !visible {
+		return // anchored behind the camera: nothing sensible to show
+	}
+	native.SetNextWindowPos(x, y)
+	title := tb.HeadsUpText
+	if title == "" {
+		title = tb.ID
+	}
+	shown, open := native.BeginClosable(title + "###minitoolbar-" + tb.ID)
+	if shown {
+		for i, control := range tb.Controls {
+			native.PushIDInt(i)
+			drawMiniToolbarControl(s, tb.ID, control)
+			native.PopID()
+		}
+		drawMiniToolbarCommitRow(s, tb)
+	}
+	native.End()
+	if !open {
+		_ = s.CommitMiniToolbar(tb.ID, app.MiniToolbarCancel)
+	}
+}
+
+// miniToolbarScreenPos resolves the toolbar's screen position: the projected model
+// anchor when one is declared, else the viewport-relative pixel offset.
+func miniToolbarScreenPos(cam scene.Camera, originX, originY float32, tb wire.MiniToolbarSpec) (float32, float32, bool) {
+	if tb.Anchor == nil {
+		return originX + float32(tb.ScreenX), originY + float32(tb.ScreenY), true
+	}
+	p := gomath.P3(tb.Anchor[0], tb.Anchor[1], tb.Anchor[2])
+	sx, sy, ok := renderer.Project(cam, viewportNear, viewportFar, p)
+	if !ok {
+		return 0, 0, false
+	}
+	return originX + float32(sx), originY + float32(sy), true
+}
+
+// drawMiniToolbarControl renders one control by kind, reporting edits through the
+// session so the owner sees miniToolbar.changed.
+func drawMiniToolbarControl(s *app.Session, toolbarID string, control wire.MiniToolbarControlSpec) {
+	changed := false
+	switch control.Kind {
+	case types.MiniToolbarCheckbox:
+		changed = native.Checkbox(control.Label, &control.Checked)
+	case types.MiniToolbarCombo:
+		changed = drawMiniToolbarCombo(&control)
+	case types.MiniToolbarSlider:
+		v := float32(control.Number)
+		if native.SliderFloat(control.Label, &v, float32(control.Min), float32(control.Max)) {
+			control.Number = roundSlider(float64(v))
+			changed = true
+		}
+	case types.MiniToolbarTextBox, types.MiniToolbarValueEditor:
+		changed = drawMiniToolbarText(&control, false)
+	case types.MiniToolbarTextEditor:
+		changed = drawMiniToolbarText(&control, true)
+	default: // MiniToolbarButton
+		changed = native.Button(control.Label)
+	}
+	if control.Tooltip != "" {
+		native.SetItemTooltip(control.Tooltip)
+	}
+	if changed {
+		_ = s.ChangeMiniToolbarControl(toolbarID, control)
+	}
+}
+
+// drawMiniToolbarCombo renders the pick-one dropdown, writing the selection back.
+func drawMiniToolbarCombo(control *wire.MiniToolbarControlSpec) bool {
+	preview := ""
+	if control.Selected >= 0 && control.Selected < len(control.Options) {
+		preview = control.Options[control.Selected]
+	}
+	changed := false
+	if native.BeginCombo(control.Label, preview) {
+		for i, option := range control.Options {
+			if native.Selectable(option+"##opt-"+strconv.Itoa(i), i == control.Selected) {
+				control.Selected = i
+				changed = true
+			}
+		}
+		native.EndCombo()
+	}
+	return changed
+}
+
+// drawMiniToolbarText renders a single- or multi-line text input over the control's
+// value, reporting the edit when the field is left (deactivated after edit), so a
+// keystroke storm does not flood the owner.
+func drawMiniToolbarText(control *wire.MiniToolbarControlSpec, multiline bool) bool {
+	buf := make([]byte, 256)
+	copy(buf, control.Value)
+	if multiline {
+		native.InputTextMultiline(control.Label, buf, 0, 60)
+	} else {
+		native.InputText(control.Label, buf)
+	}
+	if !native.IsItemDeactivatedAfterEdit() {
+		return false
+	}
+	control.Value = cString(buf)
+	return true
+}
+
+// drawMiniToolbarCommitRow renders the OK/Apply/Cancel row per the spec's flags.
+func drawMiniToolbarCommitRow(s *app.Session, tb wire.MiniToolbarSpec) {
+	if !tb.ShowOK && !tb.ShowApply && !tb.ShowCancel {
+		return
+	}
+	native.Separator()
+	drawCommitButton(s, tb.ID, tb.ShowOK, "OK", app.MiniToolbarOK, false)
+	drawCommitButton(s, tb.ID, tb.ShowApply, "Apply", app.MiniToolbarApply, tb.ShowOK)
+	drawCommitButton(s, tb.ID, tb.ShowCancel, "Cancel", app.MiniToolbarCancel, tb.ShowOK || tb.ShowApply)
+}
+
+// drawCommitButton renders one gesture button when shown.
+func drawCommitButton(s *app.Session, toolbarID string, show bool, label, gesture string, sameLine bool) {
+	if !show {
+		return
+	}
+	if sameLine {
+		native.SameLine()
+	}
+	if native.Button(label + "##commit-" + toolbarID) {
+		_ = s.CommitMiniToolbar(toolbarID, gesture)
+	}
+}
+
+// roundSlider trims slider noise to 4 decimals so change events carry stable values.
+func roundSlider(v float64) float64 { return math.Round(v*10000) / 10000 }
+
+// cString returns the NUL-terminated prefix of buf as a Go string.
+func cString(buf []byte) string {
+	for i, b := range buf {
+		if b == 0 {
+			return string(buf[:i])
+		}
+	}
+	return string(buf)
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F07, closing #614 (contract: Oblikovati/Oblikovati.API#49):

- **App**: `MiniToolbarRack` + session verbs — `miniToolbar.set` replaces whole, `.update` merges by control id; user edits emit `miniToolbar.changed` (and land in the stored spec); OK/Apply/Cancel emit `miniToolbar.committed` (ok/cancel dismiss). A toolbar bound to its owning command **dies with the tool**, hooked at the same three points interaction graphics already clear.
- **Head**: toolbars float at their projected model anchor (same projection as client-graphics labels) or viewport-relative pixels; controls render by kind (button/checkbox/combo/slider/textbox/value-editor/text-editor); text fields report on deactivate-after-edit; the title-bar X cancels.
- **Router**: `miniToolbar.set/update/remove/list`.

## Tests

Store/merge/commit/lifecycle unit tests (incl. the command-bound auto-dismiss through a real tool), wire round-trips, relay coverage. Verified visually: an anchored toolbar with all four interactive control kinds floating beside an extruded solid.

Closes #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)