### PR TITLE
Serve the host file dialog to add-ins and present web views (M05-F08)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -100,6 +100,16 @@ func subscribeMiniToolbars(bus *event.Bus, sink Sink) []event.Subscription {
 				Type: wire.EventMiniToolbarCommitted, Toolbar: e.Toolbar, Gesture: e.Gesture,
 			})
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FileDialogChosen) event.Outcome {
+			return relayJSON(sink, wire.FileDialogChosenEvent{
+				Type: wire.EventFileDialogChosen, ID: e.ID, Paths: e.Paths, Cancelled: e.Cancelled,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.WebDialogChanged) event.Outcome {
+			return relayJSON(sink, wire.WebDialogChangedEvent{
+				Type: wire.EventWebDialogChanged, ID: e.ID, Visible: e.Visible,
+			})
+		}),
 	}
 }
 
@@ -107,7 +117,8 @@ func subscribeMiniToolbars(bus *event.Bus, sink Sink) []event.Subscription {
 // Generic so each call site stays statically typed (the house no-`any` rule).
 func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.ProgressCancelledEvent | wire.BalloonTipClickedEvent | wire.PromptAnsweredEvent |
-	wire.MiniToolbarChangedEvent | wire.MiniToolbarCommittedEvent](sink Sink, ev E) event.Outcome {
+	wire.MiniToolbarChangedEvent | wire.MiniToolbarCommittedEvent |
+	wire.FileDialogChosenEvent | wire.WebDialogChangedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/router/dialogs.go
+++ b/addin/router/dialogs.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerDialogHandlers wires the host-dialog methods (M05-F08, #615).
+func (r *Router) registerDialogHandlers() {
+	r.handlers[wire.MethodDialogsShowFileDialog] = showFileDialog
+	r.handlers[wire.MethodDialogsShowWebDialog] = showWebDialog
+	r.handlers[wire.MethodDialogsCloseWebDialog] = closeWebDialog
+	r.handlers[wire.MethodDialogsListWebViews] = listWebViews
+}
+
+// showFileDialog queues a file-dialog ask; the choice arrives as dialog.fileChosen.
+func showFileDialog(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ShowFileDialogArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	err := s.RequestFileDialog(app.FileDialogRequest{
+		ID: req.ID, Title: req.Title, Save: req.Save, Filter: req.Filter,
+		FilterIndex: req.FilterIndex, InitialDir: req.InitialDir, MultiSelect: req.MultiSelect,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func showWebDialog(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ShowWebDialogArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.ShowWebDialog(req.Dialog); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func closeWebDialog(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.CloseWebDialogArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.CloseWebDialog(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func listWebViews(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.ListWebViewsResult{Views: s.WebViews()})
+}

--- a/addin/router/dialogs_test.go
+++ b/addin/router/dialogs_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+func TestShowFileDialogQueuesRequest(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "dialogs.showFileDialog",
+		`{"id":"sim.report","title":"Save report","save":true,"filter":"HTML (*.html)|*.html"}`, nil)
+	pending, ok := s.PendingFileDialog()
+	if !ok || pending.ID != "sim.report" || !pending.Save || pending.Filter == "" {
+		t.Fatalf("pending = (%+v, %v), want the queued save ask", pending, ok)
+	}
+	if _, err := r.Handle(s, "dialogs.showFileDialog", []byte(`{"title":"no id"}`)); err == nil {
+		t.Error("a request without an id should fail")
+	}
+}
+
+func TestWebDialogsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "dialogs.showWebDialog",
+		`{"dialog":{"id":"docs","title":"Help","url":"https://example.org","dock":2,"visible":true}}`, nil)
+
+	var lst wire.ListWebViewsResult
+	call(t, r, s, "dialogs.listWebViews", "{}", &lst)
+	if len(lst.Views) != 1 || lst.Views[0].Dock != types.DockRight || !lst.Views[0].Visible {
+		t.Fatalf("views = %+v, want one visible dock-right view", lst.Views)
+	}
+
+	call(t, r, s, "dialogs.closeWebDialog", `{"id":"docs"}`, nil)
+	call(t, r, s, "dialogs.listWebViews", "{}", &lst)
+	if len(lst.Views) != 0 {
+		t.Fatalf("views after close = %+v, want none", lst.Views)
+	}
+	if _, err := r.Handle(s, "dialogs.closeWebDialog", []byte(`{"id":"docs"}`)); err == nil {
+		t.Error("closing an unknown view should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -49,6 +49,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerOptionHandlers()
 	r.registerMessagingHandlers()
 	r.registerMiniToolbarHandlers()
+	r.registerDialogHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/app/dialog_requests.go
+++ b/app/dialog_requests.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+// Host-provided dialogs for add-ins (M05-F08, #615): file open/save requests the
+// head's explorer answers asynchronously, and web views presented behind a thin
+// engine seam (the head shows the URL with an open-in-browser affordance until an
+// embedded engine lands).
+
+// FileDialogRequest is one queued file-dialog ask. ID keys the answer event.
+type FileDialogRequest struct {
+	ID          string
+	Title       string
+	Save        bool
+	Filter      string
+	FilterIndex int
+	InitialDir  string
+	MultiSelect bool
+}
+
+// FileDialogChosen fires (After) when the user answers a file dialog; the events
+// relay forwards it as a dialog.fileChosen push event.
+type FileDialogChosen struct {
+	ID        string
+	Paths     []string
+	Cancelled bool
+}
+
+// EventID implements event.Event.
+func (FileDialogChosen) EventID() event.TypeID { return tidFileDialogChosen }
+
+// WebDialogChanged fires (After) when a web view is shown or closed.
+type WebDialogChanged struct {
+	ID      string
+	Visible bool
+}
+
+// EventID implements event.Event.
+func (WebDialogChanged) EventID() event.TypeID { return tidWebDialogChanged }
+
+// URLOpener is the thin seam to the platform's URL opener (xdg-open & friends) —
+// injected by the head per the third-party-wrapper rule, faked in tests.
+type URLOpener interface {
+	OpenURL(url string) error
+}
+
+// SetURLOpener installs the platform URL opener.
+func (s *Session) SetURLOpener(opener URLOpener) { s.urlOpener = opener }
+
+// OpenURL opens a URL in the platform browser (the web-view fallback affordance).
+func (s *Session) OpenURL(url string) error {
+	if s.urlOpener == nil {
+		return fmt.Errorf("app: no URL opener configured to open %q", url)
+	}
+	return s.urlOpener.OpenURL(url)
+}
+
+// RequestFileDialog queues a file-dialog ask the head's explorer presents; the
+// user's answer arrives as a [FileDialogChosen] event keyed by the request's ID.
+func (s *Session) RequestFileDialog(req FileDialogRequest) error {
+	if req.ID == "" {
+		return fmt.Errorf("app: file dialog request needs an id, got %+v", req)
+	}
+	for _, queued := range s.fileDialogQueue {
+		if queued.ID == req.ID {
+			return nil // already pending; one answer serves both callers
+		}
+	}
+	s.fileDialogQueue = append(s.fileDialogQueue, req)
+	return nil
+}
+
+// PendingFileDialog returns the request the head should present (oldest first).
+func (s *Session) PendingFileDialog() (FileDialogRequest, bool) {
+	if len(s.fileDialogQueue) == 0 {
+		return FileDialogRequest{}, false
+	}
+	return s.fileDialogQueue[0], true
+}
+
+// ResolveFileDialog answers a pending request with the chosen paths (or a cancel)
+// and emits the event its owner observes.
+func (s *Session) ResolveFileDialog(id string, paths []string, cancelled bool) error {
+	for i, queued := range s.fileDialogQueue {
+		if queued.ID != id {
+			continue
+		}
+		s.fileDialogQueue = append(s.fileDialogQueue[:i], s.fileDialogQueue[i+1:]...)
+		event.Emit(s.bus, event.After, FileDialogChosen{ID: id, Paths: paths, Cancelled: cancelled})
+		return nil
+	}
+	return fmt.Errorf("app: no pending file dialog %q", id)
+}
+
+// WebViews returns the presented web views in creation order.
+func (s *Session) WebViews() []wire.WebDialogSpec {
+	out := make([]wire.WebDialogSpec, len(s.webViewOrder))
+	for i, id := range s.webViewOrder {
+		out[i] = s.webViews[id]
+	}
+	return out
+}
+
+// ShowWebDialog creates the web view or replaces its title/URL, emitting a
+// visibility event on transitions (a new visible view is a show).
+func (s *Session) ShowWebDialog(spec wire.WebDialogSpec) error {
+	if spec.ID == "" || spec.URL == "" {
+		return fmt.Errorf("app: web dialog needs id and url, got id=%q url=%q", spec.ID, spec.URL)
+	}
+	prev, existed := s.webViews[spec.ID]
+	if !existed {
+		s.webViewOrder = append(s.webViewOrder, spec.ID)
+	}
+	s.webViews[spec.ID] = spec
+	if !existed && spec.Visible || existed && prev.Visible != spec.Visible {
+		event.Emit(s.bus, event.After, WebDialogChanged{ID: spec.ID, Visible: spec.Visible})
+	}
+	return nil
+}
+
+// CloseWebDialog removes a web view, emitting a hide first when it was visible —
+// also the path the head takes when the user closes the window.
+func (s *Session) CloseWebDialog(id string) error {
+	spec, ok := s.webViews[id]
+	if !ok {
+		return fmt.Errorf("app: no web dialog %q", id)
+	}
+	if spec.Visible {
+		event.Emit(s.bus, event.After, WebDialogChanged{ID: id, Visible: false})
+	}
+	delete(s.webViews, id)
+	for i, x := range s.webViewOrder {
+		if x == id {
+			s.webViewOrder = append(s.webViewOrder[:i], s.webViewOrder[i+1:]...)
+			break
+		}
+	}
+	return nil
+}

--- a/app/dialog_requests_test.go
+++ b/app/dialog_requests_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+// FakeURLOpener is a named app.URLOpener recording what it was asked to open.
+type FakeURLOpener struct{ opened []string }
+
+func (f *FakeURLOpener) OpenURL(url string) error {
+	f.opened = append(f.opened, url)
+	return nil
+}
+
+func TestFileDialogRequestResolveRoundTrip(t *testing.T) {
+	s := NewSession()
+	var chosen []FileDialogChosen
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e FileDialogChosen) event.Outcome {
+		chosen = append(chosen, e)
+		return event.Continue()
+	})
+
+	req := FileDialogRequest{ID: "sim.report", Title: "Save report", Save: true}
+	if err := s.RequestFileDialog(req); err != nil {
+		t.Fatalf("RequestFileDialog: %v", err)
+	}
+	if err := s.RequestFileDialog(req); err != nil { // duplicate id: one answer serves both
+		t.Fatalf("RequestFileDialog(dup): %v", err)
+	}
+	pending, ok := s.PendingFileDialog()
+	if !ok || pending.ID != "sim.report" || !pending.Save {
+		t.Fatalf("Pending = (%+v, %v), want the save request", pending, ok)
+	}
+
+	if err := s.ResolveFileDialog("sim.report", []string{"/tmp/report.html"}, false); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(chosen) != 1 || chosen[0].Paths[0] != "/tmp/report.html" || chosen[0].Cancelled {
+		t.Fatalf("events = %+v, want the chosen path", chosen)
+	}
+	if _, ok := s.PendingFileDialog(); ok {
+		t.Error("queue should be empty after resolve")
+	}
+	if err := s.ResolveFileDialog("sim.report", nil, true); err == nil {
+		t.Error("resolving twice should fail")
+	}
+}
+
+func TestWebDialogLifecycleEmitsVisibility(t *testing.T) {
+	s := NewSession()
+	var changes []WebDialogChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e WebDialogChanged) event.Outcome {
+		changes = append(changes, e)
+		return event.Continue()
+	})
+
+	view := wire.WebDialogSpec{ID: "docs", Title: "Help", URL: "https://example.org", Visible: true}
+	if err := s.ShowWebDialog(view); err != nil {
+		t.Fatalf("ShowWebDialog: %v", err)
+	}
+	if err := s.ShowWebDialog(view); err != nil { // same visibility ⇒ silent
+		t.Fatalf("ShowWebDialog(re-show): %v", err)
+	}
+	if err := s.CloseWebDialog("docs"); err != nil {
+		t.Fatalf("CloseWebDialog: %v", err)
+	}
+	if len(s.WebViews()) != 0 {
+		t.Error("view survived Close")
+	}
+	want := []WebDialogChanged{{ID: "docs", Visible: true}, {ID: "docs", Visible: false}}
+	if len(changes) != 2 || changes[0] != want[0] || changes[1] != want[1] {
+		t.Fatalf("events = %+v, want shown then hidden", changes)
+	}
+	if err := s.ShowWebDialog(wire.WebDialogSpec{ID: "x"}); err == nil {
+		t.Error("a web dialog without a url should fail")
+	}
+}
+
+func TestOpenURLUsesInjectedOpener(t *testing.T) {
+	s := NewSession()
+	if err := s.OpenURL("https://example.org"); err == nil {
+		t.Fatal("OpenURL without an opener should fail")
+	}
+	opener := &FakeURLOpener{}
+	s.SetURLOpener(opener)
+	if err := s.OpenURL("https://example.org"); err != nil {
+		t.Fatalf("OpenURL: %v", err)
+	}
+	if len(opener.opened) != 1 || opener.opened[0] != "https://example.org" {
+		t.Errorf("opened = %v, want the url routed through the seam", opener.opened)
+	}
+}

--- a/app/events.go
+++ b/app/events.go
@@ -21,6 +21,8 @@ const (
 	tidPromptAnswered       event.TypeID = 0x050a // app/prompt_center.go (M05-F09)
 	tidMiniToolbarChanged   event.TypeID = 0x050b // app/minitoolbar_store.go (M05-F07)
 	tidMiniToolbarCommitted event.TypeID = 0x050c // app/minitoolbar_store.go (M05-F07)
+	tidFileDialogChosen     event.TypeID = 0x050d // app/dialog_requests.go (M05-F08)
+	tidWebDialogChanged     event.TypeID = 0x050e // app/dialog_requests.go (M05-F08)
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's

--- a/app/session.go
+++ b/app/session.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"oblikovati.org/api/wire"
 	"oblikovati.org/app/options"
 	"oblikovati.org/event"
 	"oblikovati.org/model/clientgraphics"
@@ -49,19 +50,23 @@ type Session struct {
 	hiddenBodyKeys     map[string]bool
 	graphics           *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins             *AddInManager
-	clientApps         *ClientApplicationRegistry // external automation drivers (M05-F01)
-	browserPanes       *AddInBrowserPanes         // add-in browser panes (M05-F03)
-	dockableWindows    *AddInDockableWindows      // add-in dockable windows (M05-F03)
-	appOptions         options.All                // typed per-user option groups (M05-F11)
-	optionsStore       options.Store              // persists appOptions (nil ⇒ in-session only)
-	statusText         string                     // wire-set status-bar message (M05-F09)
-	messageCenter      *MessageCenter             // sectioned errors/warnings tree (M05-F09)
-	messageCenterOpen  bool                       // the Messages panel is open
-	progress           *ProgressLedger            // live progress bars (M05-F09)
-	balloonTips        *BalloonTipCenter          // notification balloons (M05-F09)
-	prompts            *PromptCenter              // declarative prompts (M05-F09)
-	dialogMemoryStore  dialogmemory.Store         // persists suppressions + remembered answers
-	miniToolbars       *MiniToolbarRack           // in-canvas mini-toolbars (M05-F07)
+	clientApps         *ClientApplicationRegistry    // external automation drivers (M05-F01)
+	browserPanes       *AddInBrowserPanes            // add-in browser panes (M05-F03)
+	dockableWindows    *AddInDockableWindows         // add-in dockable windows (M05-F03)
+	appOptions         options.All                   // typed per-user option groups (M05-F11)
+	optionsStore       options.Store                 // persists appOptions (nil ⇒ in-session only)
+	statusText         string                        // wire-set status-bar message (M05-F09)
+	messageCenter      *MessageCenter                // sectioned errors/warnings tree (M05-F09)
+	messageCenterOpen  bool                          // the Messages panel is open
+	progress           *ProgressLedger               // live progress bars (M05-F09)
+	balloonTips        *BalloonTipCenter             // notification balloons (M05-F09)
+	prompts            *PromptCenter                 // declarative prompts (M05-F09)
+	dialogMemoryStore  dialogmemory.Store            // persists suppressions + remembered answers
+	miniToolbars       *MiniToolbarRack              // in-canvas mini-toolbars (M05-F07)
+	fileDialogQueue    []FileDialogRequest           // pending add-in file-dialog asks (M05-F08)
+	webViews           map[string]wire.WebDialogSpec // presented web views (M05-F08)
+	webViewOrder       []string                      // web views in creation order
+	urlOpener          URLOpener                     // platform URL opener (head-injected)
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store
@@ -130,6 +135,7 @@ func newSession(store doc.Store) *Session {
 		balloonTips:     NewBalloonTipCenter(),
 		prompts:         NewPromptCenter(),
 		miniToolbars:    NewMiniToolbarRack(),
+		webViews:        map[string]wire.WebDialogSpec{},
 		visualStyle:     renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -18,6 +18,7 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/app/options"
 	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/internal/sysopen"
 	"oblikovati.org/head/internal/windowstate"
 	"oblikovati.org/head/ui"
 	"oblikovati.org/kernel/ops"
@@ -132,6 +133,7 @@ func newDemoSession() *app.Session {
 		s.SetUserPrefsStore(userprefs.NewFileStore(path))
 	}
 	registerCommands(s)
+	s.SetURLOpener(sysopen.SystemOpener{}) // web-view fallback (M05-F08)
 	loadAppOptions(s)
 	// StartupAction (M05-F11): the historical default seeds a demo part; the user can
 	// opt into an empty workspace (the Get Started ribbon) in Preferences ▸ General.

--- a/head/internal/sysopen/sysopen.go
+++ b/head/internal/sysopen/sysopen.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package sysopen is the thin wrapper around the platform's URL opener (the
+// third-party-wrapper rule): xdg-open on Linux, open on macOS, rundll32 on
+// Windows. It satisfies app.URLOpener for the M05-F08 web-view fallback.
+package sysopen
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// SystemOpener opens URLs with the platform's default handler.
+type SystemOpener struct{}
+
+// OpenURL launches the platform opener for url (http/https only — a shell-escape
+// guard: the web-view fallback never opens arbitrary local schemes).
+func (SystemOpener) OpenURL(url string) error {
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("sysopen: refusing non-http(s) url %q", url)
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	default:
+		return exec.Command("xdg-open", url).Start()
+	}
+}

--- a/head/internal/sysopen/sysopen_test.go
+++ b/head/internal/sysopen/sysopen_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sysopen
+
+import "testing"
+
+// TestRejectsNonHTTPSchemes guards the shell-escape filter: only web URLs reach
+// the platform opener.
+func TestRejectsNonHTTPSchemes(t *testing.T) {
+	for _, url := range []string{"file:///etc/passwd", "javascript:alert(1)", "ftp://x", ""} {
+		if err := (SystemOpener{}).OpenURL(url); err == nil {
+			t.Errorf("OpenURL(%q) accepted a non-http(s) scheme", url)
+		}
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -122,6 +122,7 @@ func drawChromeWindows(s *app.Session) {
 	drawScriptConsole(s)
 	drawAddInPanels(s)                  // add-in dockable windows (M05-F03)
 	drawMessagingSurfaces(s)            // toasts, prompt modal, message center (M05-F09)
+	drawWebViews(s)                     // web dialogs/views (M05-F08)
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -105,6 +105,15 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		showPreferences = true
 	case "messaging": // M05-F09 surfaces: progress bar, balloon toast, prompt, messages
 		seedMessagingSurfaces(s)
+	case "dialogs": // M05-F08: an add-in file dialog + a docked web view
+		_ = s.ShowWebDialog(wire.WebDialogSpec{
+			ID: "docs", Title: "Documentation", URL: "https://docs.example.org/bracket",
+			Dock: types.DockRight, Visible: true,
+		})
+		_ = s.RequestFileDialog(app.FileDialogRequest{
+			ID: "sim.report", Title: "Save simulation report", Save: true,
+			Filter: "HTML (*.html)|*.html",
+		})
 	case "minitoolbar": // M05-F07: an anchored in-canvas mini-toolbar over a solid
 		ext := app.NewExtrudeTool()
 		s.StartTool(ext)

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
+	"oblikovati.org/app"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,6 +26,7 @@ const (
 	dialogLoadHDR                // View ▸ Load HDR (environment image)
 	dialogImport                 // File ▸ Import (STL/OBJ/3MF/STEP → imported body)
 	dialogExport                 // File ▸ Export (part bodies → STL/OBJ/3MF/STEP)
+	dialogAddIn                  // an add-in's dialogs.showFileDialog request (M05-F08)
 )
 
 // pathBufferLen bounds the path the user can type. ImGui edits the buffer in place,
@@ -55,7 +57,8 @@ type fileDialog struct {
 	entries    []fileEntry
 	roots      []string
 	errorText  string
-	resolution int // export mesh resolution: 0 low, 1 medium, 2 high
+	resolution int                   // export mesh resolution: 0 low, 1 medium, 2 high
+	request    app.FileDialogRequest // the add-in ask behind dialogAddIn mode
 }
 
 // fileAction is what a confirmed dialog asks the chrome to perform. Kind ==
@@ -80,6 +83,16 @@ func (d *fileDialog) openFor(mode fileDialogMode) {
 	d.openDir(initialExplorerDir())
 }
 
+// openForRequest arms the dialog for an add-in's ask (M05-F08): the request's
+// title heads the window and its initial directory seeds the browser.
+func (d *fileDialog) openForRequest(req app.FileDialogRequest) {
+	d.openFor(dialogAddIn)
+	d.request = req
+	if req.InitialDir != "" {
+		d.openDir(req.InitialDir)
+	}
+}
+
 // isOpen reports whether the modal should render this frame.
 func (d *fileDialog) isOpen() bool { return d.mode != dialogClosed }
 
@@ -94,6 +107,14 @@ func (d *fileDialog) title() string {
 		return "Import (.stl/.obj/.3mf/.step)"
 	case dialogExport:
 		return "Export (.stl/.obj/.3mf/.step)"
+	case dialogAddIn:
+		if d.request.Title != "" {
+			return d.request.Title
+		}
+		if d.request.Save {
+			return "Save As"
+		}
+		return "Open"
 	default:
 		return "Open"
 	}
@@ -222,9 +243,26 @@ func (d *fileDialog) allowedExts() []string {
 		return []string{".hdr"}
 	case dialogImport, dialogExport:
 		return []string{".stl", ".obj", ".3mf", ".step", ".stp"}
+	case dialogAddIn:
+		return filterExtensions(d.request.Filter)
 	default:
 		return nil
 	}
+}
+
+// filterExtensions pulls the extensions out of a display-name|pattern filter like
+// "Meshes (*.stl *.obj)|*.stl;*.obj" — the browser narrows to them; an empty or
+// pattern-less filter shows everything.
+func filterExtensions(filter string) []string {
+	parts := strings.Split(filter, "|")
+	patterns := parts[len(parts)-1]
+	var exts []string
+	for _, pattern := range strings.FieldsFunc(patterns, func(r rune) bool { return r == ';' || r == ' ' }) {
+		if ext := filepath.Ext(strings.TrimSpace(pattern)); ext != "" && ext != "." {
+			exts = append(exts, strings.ToLower(ext))
+		}
+	}
+	return exts
 }
 
 func (d *fileDialog) withDefaultExt(path string) string {

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -20,10 +20,17 @@ import (
 var fileModal fileDialog
 
 // drawFileDialog renders the file explorer and applies a confirmed file operation.
+// A pending add-in ask (dialogs.showFileDialog) arms the modal when it is free.
 func drawFileDialog(s *app.Session) {
 	if !fileModal.isOpen() {
-		return
+		if req, ok := s.PendingFileDialog(); ok {
+			fileModal.openForRequest(req)
+		} else {
+			return
+		}
 	}
+	wasAddIn := fileModal.mode == dialogAddIn
+	request := fileModal.request
 	var act fileAction
 	native.SetNextWindowSizeOnce(760, 520)
 	if native.Begin(fileModal.title()) {
@@ -34,6 +41,20 @@ func drawFileDialog(s *app.Session) {
 	}
 	native.End()
 	applyFileAction(s, act)
+	resolveAddInDialog(s, wasAddIn, request, act)
+}
+
+// resolveAddInDialog answers the add-in's ask: a confirmed path resolves it; the
+// modal closing any other way (Cancel, X, empty confirm) is a cancel.
+func resolveAddInDialog(s *app.Session, wasAddIn bool, request app.FileDialogRequest, act fileAction) {
+	if !wasAddIn || fileModal.isOpen() {
+		return
+	}
+	if act.Kind == dialogAddIn && act.Path != "" {
+		_ = s.ResolveFileDialog(request.ID, []string{act.Path}, false)
+		return
+	}
+	_ = s.ResolveFileDialog(request.ID, nil, true)
 }
 
 // drawExplorerHeader renders navigation, root selection, and search controls.
@@ -182,6 +203,11 @@ func drawExplorerActions(act fileAction) fileAction {
 
 func fileConfirmLabel() string {
 	switch fileModal.mode {
+	case dialogAddIn:
+		if fileModal.request.Save {
+			return "Save"
+		}
+		return "Open"
 	case dialogSaveAs:
 		return "Save"
 	case dialogImport:

--- a/head/ui/web_views.go
+++ b/head/ui/web_views.go
@@ -1,0 +1,43 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Web views (M05-F08): each visible web dialog renders as a window — docked when
+// its spec asks, floating otherwise. The head has no embedded web engine yet (the
+// engine sits behind the app's URLOpener seam), so the window shows the URL with an
+// open-in-browser affordance; when an engine lands, this file is the only render
+// site to change.
+
+// drawWebViews renders the visible web dialogs.
+func drawWebViews(s *app.Session) {
+	for _, view := range s.WebViews() {
+		if !view.Visible {
+			continue
+		}
+		applyInitialDock(view.Dock)
+		native.SetNextWindowSizeOnce(420, 180)
+		shown, open := native.BeginClosable(view.Title + "###webview-" + view.ID)
+		if shown {
+			native.Text(view.URL)
+			if native.Button("Open in Browser##" + view.ID) {
+				if err := s.OpenURL(view.URL); err != nil {
+					fmt.Fprintf(os.Stderr, "web view %q: %v\n", view.ID, err)
+				}
+			}
+		}
+		native.End()
+		if !open {
+			_ = s.CloseWebDialog(view.ID)
+		}
+	}
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F08, closing #615 (contract: Oblikovati/Oblikovati.API#50):

- **File dialog**: `dialogs.showFileDialog` queues an ask the head's existing explorer presents (new `dialogAddIn` mode — request title, `*.ext` filter narrowing, save semantics). Every outcome resolves as a `dialog.fileChosen` event — confirms and cancels alike. Async like prompts: wire calls must never block the session goroutine.
- **Web views**: `dialogs.showWebDialog/closeWebDialog/listWebViews`; views render docked (reusing the F03 initial-dock path) or floating. No embedded engine yet: the window shows the URL + **Open in Browser** through the new `app.URLOpener` seam (`head/internal/sysopen`, refusing non-http(s) schemes); the render site is the single place to change when an engine lands.

## Tests

Queue/resolve round-trip (duplicate-id coalescing, double-resolve rejection), web-view visibility events, the opener seam + scheme guard; wire round-trips. Verified visually: the add-in save dialog with its filter + the docked Documentation view.

Closes #615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)