### PR TITLE
Mirror the host window into windows.listFrames and serve the tab strip (M05-F10)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -50,6 +50,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerMessagingHandlers()
 	r.registerMiniToolbarHandlers()
 	r.registerDialogHandlers()
+	r.registerWindowHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/addin/router/windows.go
+++ b/addin/router/windows.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerWindowHandlers wires the view-frame/tab methods (M05-F10, #617).
+func (r *Router) registerWindowHandlers() {
+	r.handlers[wire.MethodWindowsListFrames] = listViewFrames
+	r.handlers[wire.MethodWindowsListTabs] = listViewTabs
+	r.handlers[wire.MethodWindowsActivateTab] = activateViewTab
+	r.handlers[wire.MethodWindowsCloseTab] = closeViewTab
+}
+
+// listViewFrames reports the host's top-level frames — exactly one on the
+// single-frame head (wire windows.listFrames).
+func listViewFrames(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	f := s.WindowFrameStatus()
+	frame := wire.ViewFrameInfo{Caption: f.Caption, State: f.State, Width: f.Width, Height: f.Height}
+	return json.Marshal(wire.ListViewFramesResult{Frames: []wire.ViewFrameInfo{frame}})
+}
+
+// listViewTabs reports the document tab strip (wire windows.listTabs).
+func listViewTabs(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	ws := s.Workspace()
+	active := ws.ActiveDocument()
+	docs := ws.Documents()
+	tabs := make([]wire.ViewTabInfo, len(docs))
+	for i, d := range docs {
+		tabs[i] = wire.ViewTabInfo{
+			Document: uint64(d.ID()), Title: d.DisplayName(),
+			Active: d == active, Dirty: d.Dirty(),
+		}
+	}
+	return json.Marshal(wire.ListViewTabsResult{Tabs: tabs})
+}
+
+// activateViewTab brings a document tab to the front (wire windows.activateTab).
+func activateViewTab(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ActivateViewTabArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	for _, d := range s.Workspace().Documents() {
+		if uint64(d.ID()) == req.Document {
+			if err := s.Workspace().SetActiveDocument(d); err != nil {
+				return nil, err
+			}
+			return ok()
+		}
+	}
+	return nil, fmt.Errorf("no open document with id %d", req.Document)
+}
+
+// closeViewTab closes a document tab with documents.close's save-first/force
+// semantics (wire windows.closeTab).
+func closeViewTab(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.CloseViewTabArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	for _, d := range s.Workspace().Documents() {
+		if uint64(d.ID()) == req.Document {
+			if err := s.Workspace().Close(d, req.Force); err != nil {
+				return nil, err
+			}
+			return ok()
+		}
+	}
+	return nil, fmt.Errorf("no open document with id %d", req.Document)
+}

--- a/addin/router/windows_test.go
+++ b/addin/router/windows_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+func TestWindowsFramesReportMirroredState(t *testing.T) {
+	r, s := seededSession(t)
+	s.SetWindowFrameStatus(app.WindowFrameStatus{
+		Caption: "test.obk — Oblikovati", State: types.WindowMaximized, Width: 2560, Height: 1480,
+	})
+	var res wire.ListViewFramesResult
+	call(t, r, s, "windows.listFrames", "{}", &res)
+	if len(res.Frames) != 1 || res.Frames[0].State != types.WindowMaximized || res.Frames[0].Width != 2560 {
+		t.Fatalf("frames = %+v, want the mirrored maximized frame", res.Frames)
+	}
+}
+
+func TestWindowsTabsActivateAndClose(t *testing.T) {
+	r, s := seededSession(t)
+	var tabs wire.ListViewTabsResult
+	call(t, r, s, "windows.listTabs", "{}", &tabs)
+	if len(tabs.Tabs) != 1 || !tabs.Tabs[0].Active {
+		t.Fatalf("tabs = %+v, want the seeded active document", tabs.Tabs)
+	}
+	id := tabs.Tabs[0].Document
+
+	call(t, r, s, "windows.activateTab", `{"document":`+itoaInt(int(id))+`}`, nil)
+	if uint64(s.Workspace().ActiveDocument().ID()) != id {
+		t.Fatal("activateTab did not activate")
+	}
+
+	call(t, r, s, "windows.closeTab", `{"document":`+itoaInt(int(id))+`,"force":true}`, nil)
+	call(t, r, s, "windows.listTabs", "{}", &tabs)
+	if len(tabs.Tabs) != 0 {
+		t.Fatalf("tabs after close = %+v, want none", tabs.Tabs)
+	}
+	if _, err := r.Handle(s, "windows.activateTab", []byte(`{"document":999}`)); err == nil {
+		t.Error("activating an unknown tab should fail")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -67,6 +67,7 @@ type Session struct {
 	webViews           map[string]wire.WebDialogSpec // presented web views (M05-F08)
 	webViewOrder       []string                      // web views in creation order
 	urlOpener          URLOpener                     // platform URL opener (head-injected)
+	windowFrame        WindowFrameStatus             // mirrored host-window state (M05-F10)
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store

--- a/app/window_frame.go
+++ b/app/window_frame.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/api/types"
+
+// WindowFrameStatus is the host window's live state (M05-F10): the head reports it
+// each frame so windows.listFrames serves real geometry without the app touching
+// GLFW (the head owns the window; the session only mirrors it).
+type WindowFrameStatus struct {
+	Caption string
+	State   types.WindowState
+	Width   int
+	Height  int
+}
+
+// SetWindowFrameStatus mirrors the head window's current state into the session.
+func (s *Session) SetWindowFrameStatus(status WindowFrameStatus) { s.windowFrame = status }
+
+// WindowFrameStatus returns the mirrored host-window state. A headless session
+// (tests, CLI) reports a zero frame — callers present what exists.
+func (s *Session) WindowFrameStatus() WindowFrameStatus { return s.windowFrame }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -18,6 +18,7 @@
 package ui
 
 import (
+	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/kernel/topo"
@@ -53,6 +54,7 @@ func prepareChromeFrame(win *native.Window, s *app.Session) {
 	if icons == nil {
 		icons = newIconCache(win) // lazily bind the icon cache to this window
 	}
+	reportWindowFrame(win, s)
 	icons.beginFrame(s.ThemeRevision()) // free retired textures; flush composes on theme change
 	applyThemeIfChanged(win, s)         // restyle ImGui + overlays when the theme changed (live preview)
 	handleKeyboard(s)
@@ -74,6 +76,22 @@ func layoutDockedPanels() {
 // dockSideNodes remembers the default arrangement's node ids so add-in dockable
 // windows can be docked beside the built-in panels on first show (M05-F03).
 var dockSideNodes native.DockSideNodes
+
+// reportWindowFrame mirrors the GLFW window's live state into the session so
+// windows.listFrames serves real geometry (M05-F10). The caption follows the
+// active document, like a document-centric title bar.
+func reportWindowFrame(win *native.Window, s *app.Session) {
+	_, _, w, h, maximized := win.WindowState()
+	state := types.WindowNormal
+	if maximized {
+		state = types.WindowMaximized
+	}
+	caption := "Oblikovati"
+	if d := s.ActiveDocument(); d != nil {
+		caption = d.DisplayName() + " — Oblikovati"
+	}
+	s.SetWindowFrameStatus(app.WindowFrameStatus{Caption: caption, State: state, Width: w, Height: h})
+}
 
 func drawViewportIfPresent(win *native.Window, s *app.Session) {
 	if shouldDrawViewport(s) {


### PR DESCRIPTION
## What

The GPL implementation half of M05-F10, closing #617 (contract: Oblikovati/Oblikovati.API#51):

- The head mirrors its GLFW window (caption following the active document, `types.WindowState`, pixel size) into the session each frame; `windows.listFrames` serves it.
- `windows.listTabs/activateTab/closeTab` drive the document tab strip (close keeps documents.close's save-first/force semantics; active-tab changes already reach add-ins as `document.activated` events).
- View **tiling** deliberately stays with the existing `views.*` layout surface (`views.getLayout/setLayout`) rather than being duplicated here; tear-off frames and tab groups wait for a multi-window head (#160 ADR records the decline).

## Tests

Mirrored-frame and tab activate/close round-trips in `addin/router`.

Closes #617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)