### PR TITLE
Build the UI shell: command search, radial marking menus, menu injection, visibility (M05-F12)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -47,8 +47,17 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentActivate) event.Outcome {
 			return relay(sink, wireEvent{Type: "document.activated", Document: e.Document.DisplayName(), ID: uint64(e.Document.ID())})
 		}),
+		event.Subscribe(bus, event.Before, func(_ event.Context, e app.CommandStarted) event.Outcome {
+			return relay(sink, wireEvent{Type: wire.EventCommandStarted, Command: e.ID})
+		}),
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.CommandEnded) event.Outcome {
 			return relay(sink, wireEvent{Type: "command.ended", Command: e.ID, Failed: e.Failed})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.SelectionChanged) event.Outcome {
+			return relayJSON(sink, wire.SelectionChangedEvent{Type: wire.EventSelectionChanged, Count: e.Count})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.EnvironmentChanged) event.Outcome {
+			return relayJSON(sink, wire.EnvironmentChangedEvent{Type: wire.EventEnvironmentChanged, Environment: e.Environment})
 		}),
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
 			return relayEdit(sink, e)
@@ -118,7 +127,8 @@ func subscribeMiniToolbars(bus *event.Bus, sink Sink) []event.Subscription {
 func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.ProgressCancelledEvent | wire.BalloonTipClickedEvent | wire.PromptAnsweredEvent |
 	wire.MiniToolbarChangedEvent | wire.MiniToolbarCommittedEvent |
-	wire.FileDialogChosenEvent | wire.WebDialogChangedEvent](sink Sink, ev E) event.Outcome {
+	wire.FileDialogChosenEvent | wire.WebDialogChangedEvent |
+	wire.SelectionChangedEvent | wire.EnvironmentChangedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -51,6 +51,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerMiniToolbarHandlers()
 	r.registerDialogHandlers()
 	r.registerWindowHandlers()
+	r.registerUIShellHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/addin/router/ui_shell.go
+++ b/addin/router/ui_shell.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerUIShellHandlers wires the M05-F12 shell methods: command search,
+// marking menus, context-menu injection, and object visibility (#619).
+func (r *Router) registerUIShellHandlers() {
+	r.handlers[wire.MethodUISearch] = searchCommands
+	r.handlers[wire.MethodUIGetMarkingMenu] = getMarkingMenu
+	r.handlers[wire.MethodUISetMarkingMenu] = setMarkingMenu
+	r.handlers[wire.MethodUISetContextMenu] = setContextMenu
+	r.handlers[wire.MethodUIGetObjectVisibility] = getObjectVisibility
+	r.handlers[wire.MethodUISetObjectVisibility] = setObjectVisibility
+}
+
+// searchCommands finds registered commands matching the query (wire ui.search).
+func searchCommands(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SearchCommandsArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	hits := s.SearchCommands(req.Query)
+	out := make([]wire.CommandInfo, len(hits))
+	for i, c := range hits {
+		out[i] = wire.CommandInfo{
+			ID: c.ID(), DisplayName: c.DisplayName(), Tab: c.Tab(), Category: c.Category(),
+			Alias: c.Alias(), Tooltip: c.Tooltip(), Icon: c.Icon(),
+			ButtonStyle: c.ButtonStyle(), Enabled: c.IsEnabled(s),
+		}
+	}
+	return json.Marshal(wire.SearchCommandsResult{Commands: out})
+}
+
+func getMarkingMenu(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.GetMarkingMenuArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	return json.Marshal(s.MarkingMenu(req.Environment))
+}
+
+func setMarkingMenu(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetMarkingMenuArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.SetMarkingMenu(req.Menu); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func setContextMenu(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetContextMenuArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.SetContextMenuItems(req.AddIn, req.Kind, req.Items); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func getObjectVisibility(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(s.ObjectVisibility())
+}
+
+func setObjectVisibility(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetObjectVisibilityArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	s.SetObjectVisibility(req.Visibility)
+	return ok()
+}

--- a/addin/router/ui_shell_test.go
+++ b/addin/router/ui_shell_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+func TestUISearchOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	var res wire.SearchCommandsResult
+	call(t, r, s, "ui.search", `{"query":"extrude"}`, &res)
+	if len(res.Commands) == 0 {
+		t.Fatal("ui.search(extrude) found nothing — the standard Extrude command should match")
+	}
+	call(t, r, s, "ui.search", `{"query":""}`, &res)
+	if len(res.Commands) != 0 {
+		t.Error("a blank query should return nothing")
+	}
+}
+
+func TestUIMarkingMenuOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	var menu wire.MarkingMenuView
+	call(t, r, s, "ui.getMarkingMenu", `{"environment":0}`, &menu)
+	if len(menu.Quadrants) == 0 {
+		t.Fatal("the base default radial menu should not be empty")
+	}
+
+	call(t, r, s, "ui.setMarkingMenu",
+		`{"menu":{"environment":1,"quadrants":[{"quadrant":0,"commandId":"Sketch.Line"}],"overflow":["Sketch.Finish"]}}`, nil)
+	call(t, r, s, "ui.getMarkingMenu", `{"environment":1}`, &menu)
+	if len(menu.Quadrants) != 1 || menu.Quadrants[0].CommandID != "Sketch.Line" {
+		t.Fatalf("customized menu = %+v, want the single Line slot", menu)
+	}
+	if _, err := r.Handle(s, "ui.setMarkingMenu",
+		[]byte(`{"menu":{"quadrants":[{"quadrant":11,"commandId":"X"}]}}`)); err == nil {
+		t.Error("an out-of-range quadrant should fail over the wire")
+	}
+}
+
+func TestUIContextMenuAndVisibilityOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "ui.setContextMenu",
+		`{"addin":"com.x.sim","kind":"feature","items":[{"label":"Analyze","commandId":"Sim.Analyze"}]}`, nil)
+	if _, err := r.Handle(s, "ui.setContextMenu",
+		[]byte(`{"kind":"feature","items":[]}`)); err == nil {
+		t.Error("an injection without the owning add-in should fail")
+	}
+
+	call(t, r, s, "ui.setObjectVisibility",
+		`{"visibility":{"workPlanes":false,"workAxes":true,"workPoints":true,"sketches":true}}`, nil)
+	var vis wire.ObjectVisibilityView
+	call(t, r, s, "ui.getObjectVisibility", "{}", &vis)
+	if vis.WorkPlanes || !vis.WorkAxes {
+		t.Fatalf("visibility = %+v, want planes hidden, axes shown", vis)
+	}
+	if got := len(s.PickableWorkPlanes()); got != 0 {
+		t.Errorf("hidden planes still pickable (%d)", got)
+	}
+}

--- a/app/events.go
+++ b/app/events.go
@@ -23,6 +23,7 @@ const (
 	tidMiniToolbarCommitted event.TypeID = 0x050c // app/minitoolbar_store.go (M05-F07)
 	tidFileDialogChosen     event.TypeID = 0x050d // app/dialog_requests.go (M05-F08)
 	tidWebDialogChanged     event.TypeID = 0x050e // app/dialog_requests.go (M05-F08)
+	tidEnvironmentChanged   event.TypeID = 0x050f // app/ui_shell.go (M05-F12)
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's

--- a/app/session.go
+++ b/app/session.go
@@ -50,24 +50,27 @@ type Session struct {
 	hiddenBodyKeys     map[string]bool
 	graphics           *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins             *AddInManager
-	clientApps         *ClientApplicationRegistry    // external automation drivers (M05-F01)
-	browserPanes       *AddInBrowserPanes            // add-in browser panes (M05-F03)
-	dockableWindows    *AddInDockableWindows         // add-in dockable windows (M05-F03)
-	appOptions         options.All                   // typed per-user option groups (M05-F11)
-	optionsStore       options.Store                 // persists appOptions (nil ⇒ in-session only)
-	statusText         string                        // wire-set status-bar message (M05-F09)
-	messageCenter      *MessageCenter                // sectioned errors/warnings tree (M05-F09)
-	messageCenterOpen  bool                          // the Messages panel is open
-	progress           *ProgressLedger               // live progress bars (M05-F09)
-	balloonTips        *BalloonTipCenter             // notification balloons (M05-F09)
-	prompts            *PromptCenter                 // declarative prompts (M05-F09)
-	dialogMemoryStore  dialogmemory.Store            // persists suppressions + remembered answers
-	miniToolbars       *MiniToolbarRack              // in-canvas mini-toolbars (M05-F07)
-	fileDialogQueue    []FileDialogRequest           // pending add-in file-dialog asks (M05-F08)
-	webViews           map[string]wire.WebDialogSpec // presented web views (M05-F08)
-	webViewOrder       []string                      // web views in creation order
-	urlOpener          URLOpener                     // platform URL opener (head-injected)
-	windowFrame        WindowFrameStatus             // mirrored host-window state (M05-F10)
+	clientApps         *ClientApplicationRegistry                       // external automation drivers (M05-F01)
+	browserPanes       *AddInBrowserPanes                               // add-in browser panes (M05-F03)
+	dockableWindows    *AddInDockableWindows                            // add-in dockable windows (M05-F03)
+	appOptions         options.All                                      // typed per-user option groups (M05-F11)
+	optionsStore       options.Store                                    // persists appOptions (nil ⇒ in-session only)
+	statusText         string                                           // wire-set status-bar message (M05-F09)
+	messageCenter      *MessageCenter                                   // sectioned errors/warnings tree (M05-F09)
+	messageCenterOpen  bool                                             // the Messages panel is open
+	progress           *ProgressLedger                                  // live progress bars (M05-F09)
+	balloonTips        *BalloonTipCenter                                // notification balloons (M05-F09)
+	prompts            *PromptCenter                                    // declarative prompts (M05-F09)
+	dialogMemoryStore  dialogmemory.Store                               // persists suppressions + remembered answers
+	miniToolbars       *MiniToolbarRack                                 // in-canvas mini-toolbars (M05-F07)
+	fileDialogQueue    []FileDialogRequest                              // pending add-in file-dialog asks (M05-F08)
+	webViews           map[string]wire.WebDialogSpec                    // presented web views (M05-F08)
+	webViewOrder       []string                                         // web views in creation order
+	urlOpener          URLOpener                                        // platform URL opener (head-injected)
+	windowFrame        WindowFrameStatus                                // mirrored host-window state (M05-F10)
+	markingMenus       map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
+	contextMenus       map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
+	objectVisibility   wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
 	grid               *GridSettings
 	themes             *theme.Library
 	themeStore         *theme.Store
@@ -136,7 +139,6 @@ func newSession(store doc.Store) *Session {
 		balloonTips:     NewBalloonTipCenter(),
 		prompts:         NewPromptCenter(),
 		miniToolbars:    NewMiniToolbarRack(),
-		webViews:        map[string]wire.WebDialogSpec{},
 		visualStyle:     renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now
@@ -148,7 +150,20 @@ func newSession(store doc.Store) *Session {
 	// The embedded Sky map is the default environment for every visual style — IBL plus
 	// the sky as the viewport background (ADR-0026 §8).
 	s.lighting.Environment = renderer.DefaultEnvironment()
+	s.initShellSurfaces()
 	return s
+}
+
+// initShellSurfaces seeds the M05 add-in UI-shell state: web views, the default
+// radial marking menus, context-menu injections, and the object-visibility
+// toggles (everything toggleable starts shown).
+func (s *Session) initShellSurfaces() {
+	s.webViews = map[string]wire.WebDialogSpec{}
+	s.markingMenus = defaultMarkingMenus()
+	s.contextMenus = map[string]map[string][]wire.ContextMenuItemSpec{}
+	s.objectVisibility = wire.ObjectVisibilityView{
+		WorkPlanes: true, WorkAxes: true, WorkPoints: true, Sketches: true,
+	}
 }
 
 // AddIns returns the add-in registry (ApplicationAddIns).
@@ -201,6 +216,8 @@ func (s *Session) ActiveView() *doc.View {
 // it back — the head ticks these transitions (TickCameraAnimation).
 func (s *Session) EnterSketch(sk *sketch.Sketch) {
 	s.activeSketch = sk
+	// The contextual environment switched: add-ins re-aim their UI (M05-F12).
+	event.Emit(s.bus, event.After, EnvironmentChanged{Environment: SketchEnvironment})
 	sk.Edit()
 	s.beginEditScope(sk.Seq()) // hide features/datums created after this sketch while editing it
 	s.sketchReturnCam = s.camera
@@ -214,6 +231,7 @@ func (s *Session) ExitSketch() {
 	if s.activeSketch != nil {
 		s.activeSketch.ExitEdit()
 		s.activeSketch = nil
+		event.Emit(s.bus, event.After, EnvironmentChanged{Environment: BaseEnvironment})
 		s.pendingDim = nil // no dangling edit box after leaving the sketch
 		s.endEditScope()   // restore the rolled-back features (caller recomputes)
 		s.animateCameraTo(s.sketchReturnCam, sketchViewTweenSeconds)

--- a/app/ui_shell.go
+++ b/app/ui_shell.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+)
+
+// The UI shell surfaces of M05-F12 (#619): the per-environment radial marking
+// menu, add-in context-menu injection, the command search, and the View ▸
+// Object-visibility toggles.
+
+// EnvironmentChanged fires (After) when the UI environment switches (base ↔
+// sketch); the events relay forwards it as ui.environmentChanged.
+type EnvironmentChanged struct{ Environment Environment }
+
+// EventID implements event.Event.
+func (EnvironmentChanged) EventID() event.TypeID { return tidEnvironmentChanged }
+
+// defaultMarkingMenus is the out-of-the-box radial layout per environment: the
+// modeling staples around the cursor in base, the sketch staples in sketch.
+func defaultMarkingMenus() map[Environment]wire.MarkingMenuView {
+	return map[Environment]wire.MarkingMenuView{
+		BaseEnvironment: {
+			Environment: BaseEnvironment,
+			Quadrants: []wire.MarkingMenuItem{
+				{Quadrant: types.QuadrantNorth, CommandID: "Sketch.Create2D"},
+				{Quadrant: types.QuadrantEast, CommandID: "Create.Extrude"},
+				{Quadrant: types.QuadrantSouth, CommandID: "Modify.Hole"},
+				{Quadrant: types.QuadrantWest, CommandID: "Create.Revolve"},
+				{Quadrant: types.QuadrantNorthEast, CommandID: "Modify.Fillet"},
+				{Quadrant: types.QuadrantSouthEast, CommandID: "Modify.Chamfer"},
+			},
+		},
+		SketchEnvironment: {
+			Environment: SketchEnvironment,
+			Quadrants: []wire.MarkingMenuItem{
+				{Quadrant: types.QuadrantNorth, CommandID: "Sketch.Line"},
+				{Quadrant: types.QuadrantEast, CommandID: "Sketch.Circle"},
+				{Quadrant: types.QuadrantSouth, CommandID: "Sketch.Rectangle"},
+				{Quadrant: types.QuadrantWest, CommandID: "Sketch.Arc"},
+				{Quadrant: types.QuadrantNorthEast, CommandID: "Sketch.Dimension"},
+			},
+			Overflow: []string{"Sketch.Finish"},
+		},
+	}
+}
+
+// MarkingMenu returns the radial menu for an environment (the default until
+// customized).
+func (s *Session) MarkingMenu(env Environment) wire.MarkingMenuView {
+	if menu, ok := s.markingMenus[env]; ok {
+		return menu
+	}
+	return wire.MarkingMenuView{Environment: env}
+}
+
+// SetMarkingMenu replaces one environment's radial menu. Quadrants must be unique
+// and in range; unknown command ids are tolerated (skipped at render, like popup
+// items), so an add-in can declare before registering.
+func (s *Session) SetMarkingMenu(menu wire.MarkingMenuView) error {
+	seen := map[types.ScreenQuadrant]bool{}
+	for _, item := range menu.Quadrants {
+		if item.Quadrant > types.QuadrantNorthWest {
+			return fmt.Errorf("app: marking-menu quadrant %d out of range (0..7)", item.Quadrant)
+		}
+		if seen[item.Quadrant] {
+			return fmt.Errorf("app: marking-menu quadrant %v declared twice", item.Quadrant)
+		}
+		seen[item.Quadrant] = true
+	}
+	s.markingMenus[menu.Environment] = menu
+	return nil
+}
+
+// SetContextMenuItems replaces one add-in's injected entries for a browser node
+// kind ("" injects into every node's menu).
+func (s *Session) SetContextMenuItems(addin, kind string, items []wire.ContextMenuItemSpec) error {
+	if addin == "" {
+		return fmt.Errorf("app: context-menu injection needs the owning add-in id")
+	}
+	if s.contextMenus[addin] == nil {
+		s.contextMenus[addin] = map[string][]wire.ContextMenuItemSpec{}
+	}
+	if len(items) == 0 {
+		delete(s.contextMenus[addin], kind)
+		return nil
+	}
+	s.contextMenus[addin][kind] = items
+	return nil
+}
+
+// injectedMenuItems returns the add-in entries for a node kind, as runnable menu
+// items (clicking executes the named command).
+func (s *Session) injectedMenuItems(kind string) []BrowserMenuItem {
+	var out []BrowserMenuItem
+	for _, byKind := range s.contextMenus {
+		for _, scope := range []string{kind, ""} {
+			for _, item := range byKind[scope] {
+				out = append(out, runnableMenuItem(item))
+			}
+		}
+	}
+	return out
+}
+
+// runnableMenuItem adapts an injected spec into a browser menu entry.
+func runnableMenuItem(item wire.ContextMenuItemSpec) BrowserMenuItem {
+	id := item.CommandID
+	return BrowserMenuItem{
+		Label:   item.Label,
+		Enabled: true,
+		Invoke:  func(s *Session) error { return s.Execute(id) },
+	}
+}
+
+// BrowserMenuFor returns a node's context menu: the built-in entries plus any
+// add-in injections for its kind (M05-F12). The head renders this, not BrowserMenu.
+func BrowserMenuFor(s *Session, n BrowserNode) []BrowserMenuItem {
+	return append(BrowserMenu(n), s.injectedMenuItems(n.Kind)...)
+}
+
+// SearchCommands finds registered commands whose id, display name, or alias
+// contains the query (case-insensitive) — the search box's backing query.
+func (s *Session) SearchCommands(query string) []*CommandDefinition {
+	needle := strings.ToLower(strings.TrimSpace(query))
+	if needle == "" {
+		return nil
+	}
+	var out []*CommandDefinition
+	for _, c := range s.commands.All() {
+		if strings.Contains(strings.ToLower(c.ID()), needle) ||
+			strings.Contains(strings.ToLower(c.DisplayName()), needle) ||
+			strings.Contains(strings.ToLower(c.Alias()), needle) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ObjectVisibility returns the View ▸ Object-visibility toggles.
+func (s *Session) ObjectVisibility() wire.ObjectVisibilityView { return s.objectVisibility }
+
+// SetObjectVisibility writes the toggles; hidden geometry also stops being
+// pickable (the accessors the overlays and pickers share consult these flags).
+func (s *Session) SetObjectVisibility(v wire.ObjectVisibilityView) { s.objectVisibility = v }

--- a/app/ui_shell_test.go
+++ b/app/ui_shell_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+func TestMarkingMenuDefaultsAndCustomization(t *testing.T) {
+	s := NewSession()
+	base := s.MarkingMenu(BaseEnvironment)
+	if len(base.Quadrants) == 0 {
+		t.Fatal("the base environment should have a default radial menu")
+	}
+
+	custom := wire.MarkingMenuView{
+		Environment: SketchEnvironment,
+		Quadrants:   []wire.MarkingMenuItem{{Quadrant: types.QuadrantNorth, CommandID: "X.Top"}},
+		Overflow:    []string{"X.More"},
+	}
+	if err := s.SetMarkingMenu(custom); err != nil {
+		t.Fatalf("SetMarkingMenu: %v", err)
+	}
+	got := s.MarkingMenu(SketchEnvironment)
+	if len(got.Quadrants) != 1 || got.Quadrants[0].CommandID != "X.Top" || got.Overflow[0] != "X.More" {
+		t.Fatalf("customized menu = %+v, want the replacement", got)
+	}
+
+	if err := s.SetMarkingMenu(wire.MarkingMenuView{Quadrants: []wire.MarkingMenuItem{
+		{Quadrant: 9, CommandID: "X"},
+	}}); err == nil {
+		t.Error("an out-of-range quadrant should fail")
+	}
+	if err := s.SetMarkingMenu(wire.MarkingMenuView{Quadrants: []wire.MarkingMenuItem{
+		{Quadrant: types.QuadrantNorth, CommandID: "A"},
+		{Quadrant: types.QuadrantNorth, CommandID: "B"},
+	}}); err == nil {
+		t.Error("a duplicate quadrant should fail")
+	}
+}
+
+func TestContextMenuInjectionMergesIntoBrowserMenu(t *testing.T) {
+	s := NewSession()
+	if err := s.Commands().Add(NewCommand("Sim.Analyze", "Analyze stress", "Sim",
+		func(*Session) error { return nil })); err != nil {
+		t.Fatalf("add command: %v", err)
+	}
+	if err := s.SetContextMenuItems("com.x.sim", "feature", []wire.ContextMenuItemSpec{
+		{Label: "Analyze stress", CommandID: "Sim.Analyze"},
+	}); err != nil {
+		t.Fatalf("SetContextMenuItems: %v", err)
+	}
+
+	items := BrowserMenuFor(s, BrowserNode{Kind: "feature"})
+	found := false
+	for _, it := range items {
+		if it.Label == "Analyze stress" {
+			found = true
+			if err := it.Invoke(s); err != nil {
+				t.Fatalf("injected item Invoke: %v", err)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("injected item missing from feature menu: %+v", items)
+	}
+	if len(BrowserMenuFor(s, BrowserNode{Kind: "body"})) != 0 {
+		t.Error("a feature-kind injection must not leak into body menus")
+	}
+
+	// Clearing removes the injection.
+	if err := s.SetContextMenuItems("com.x.sim", "feature", nil); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	for _, it := range BrowserMenuFor(s, BrowserNode{Kind: "feature"}) {
+		if it.Label == "Analyze stress" {
+			t.Error("cleared injection still present")
+		}
+	}
+}
+
+func TestSearchCommandsMatchesIdNameAlias(t *testing.T) {
+	s := NewSession()
+	noop := func(*Session) error { return nil }
+	_ = s.Commands().Add(NewCommand("Model.Extrude", "Extrude", "Create", noop).WithAlias("E"))
+	_ = s.Commands().Add(NewCommand("Sketch.Line", "Line", "Draw", noop))
+
+	if hits := s.SearchCommands("extr"); len(hits) != 1 || hits[0].ID() != "Model.Extrude" {
+		t.Errorf("SearchCommands(extr) = %v, want the Extrude command", hits)
+	}
+	if hits := s.SearchCommands("e"); len(hits) < 2 {
+		t.Errorf("SearchCommands(e) = %d hits, want both (id/name/alias substrings)", len(hits))
+	}
+	if hits := s.SearchCommands("  "); hits != nil {
+		t.Error("a blank query should return nothing")
+	}
+}
+
+func TestObjectVisibilityGatesPickablePlanes(t *testing.T) {
+	s := sessionWithPart(t)
+	if !s.ObjectVisibility().WorkPlanes {
+		t.Fatal("planes should default visible")
+	}
+	before := len(s.PickableWorkPlanes())
+	if before == 0 {
+		t.Fatal("expected origin planes to be pickable")
+	}
+	vis := s.ObjectVisibility()
+	vis.WorkPlanes = false
+	s.SetObjectVisibility(vis)
+	if len(s.PickableWorkPlanes()) != 0 {
+		t.Error("hidden work planes must not be pickable")
+	}
+}
+
+func TestEnterExitSketchEmitsEnvironmentChanged(t *testing.T) {
+	s := sessionWithPart(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	var got []EnvironmentChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e EnvironmentChanged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+
+	sk := def.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	s.ExitSketch()
+	if len(got) != 2 || got[0].Environment != SketchEnvironment || got[1].Environment != BaseEnvironment {
+		t.Fatalf("events = %+v, want sketch then base", got)
+	}
+}

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -37,6 +37,9 @@ func (s *Session) SelectedWorkPlanes() []*feature.WorkPlane {
 // clicked as a new sketch's reference in the 3D view (issue #132); the head feeds this to
 // the RayPicker.
 func (s *Session) PickableWorkPlanes() []*feature.WorkPlane {
+	if !s.objectVisibility.WorkPlanes { // hidden kinds are not pickable (M05-F12)
+		return nil
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return nil

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -203,7 +203,12 @@ func installPicker(s *app.Session) {
 		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }).
 		WithPoints(func() []*feature.WorkPoint { return activeWorkPoints(s) }).
 		WithAxes(func() []*feature.WorkAxis { return activeWorkAxes(s) }).
-		WithSketches(func() []*sketch.Sketch { return activeSketches(s) }).
+		WithSketches(func() []*sketch.Sketch {
+			if !s.ObjectVisibility().Sketches {
+				return nil
+			}
+			return activeSketches(s)
+		}).
 		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }))
 }
 
@@ -230,6 +235,9 @@ func activeBodies(s *app.Session) []*topo.Body {
 // hidden by the active edit scope are excluded, matching the overlays — geometry the
 // viewport does not draw must not be clickable.
 func activeWorkPoints(s *app.Session) []*feature.WorkPoint {
+	if !s.ObjectVisibility().WorkPoints { // hidden kinds are not pickable (M05-F12)
+		return nil
+	}
 	p, err := modelaccess.ActivePart(s)
 	if err != nil {
 		return nil
@@ -245,6 +253,9 @@ func activeWorkPoints(s *app.Session) []*feature.WorkPoint {
 }
 
 func activeWorkAxes(s *app.Session) []*feature.WorkAxis {
+	if !s.ObjectVisibility().WorkAxes { // hidden kinds are not pickable (M05-F12)
+		return nil
+	}
 	p, err := modelaccess.ActivePart(s)
 	if err != nil {
 		return nil

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -45,6 +45,7 @@ float obk_ig_hover_seconds(void);
 int  obk_ig_begin_popup_context_item(const char* id);
 void obk_ig_open_popup(const char* id);
 int  obk_ig_begin_popup(const char* id);
+void obk_ig_close_current_popup(void);
 void obk_ig_end_popup(void);
 void obk_ig_set_scroll_here_y(void);
 int  obk_ig_input_float(const char* label, float* v);
@@ -584,6 +585,9 @@ func BeginPopup(id string) bool {
 // EndPopup closes a popup begun by BeginPopupContextItem/BeginPopup (call only when it
 // returned true).
 func EndPopup() { C.obk_ig_end_popup() }
+
+// CloseCurrentPopup closes the popup being drawn (a marking-menu pick).
+func CloseCurrentPopup() { C.obk_ig_close_current_popup() }
 
 // SetScrollHereY scrolls the current window to center the most recently drawn item — used
 // to reveal the browser node that just synced to the active selection.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -149,6 +149,7 @@ float obk_ig_hover_seconds(void) {
 int  obk_ig_begin_popup_context_item(const char* id) { return ImGui::BeginPopupContextItem(id) ? 1 : 0; }
 void obk_ig_open_popup(const char* id)       { ImGui::OpenPopup(id); }
 int  obk_ig_begin_popup(const char* id)      { return ImGui::BeginPopup(id) ? 1 : 0; }
+void obk_ig_close_current_popup(void)               { ImGui::CloseCurrentPopup(); }
 void obk_ig_end_popup(void)                  { ImGui::EndPopup(); }
 void obk_ig_set_scroll_here_y(void)          { ImGui::SetScrollHereY(0.5f); }
 

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -220,7 +220,7 @@ func drawBranchNode(s *app.Session, n app.BrowserNode) {
 // drawNodeMenu opens the node's right-click context menu (if it has any entries) and runs
 // the action behind a clicked item. Nodes whose kind has no menu draw nothing.
 func drawNodeMenu(s *app.Session, n app.BrowserNode) {
-	items := app.BrowserMenu(n)
+	items := app.BrowserMenuFor(s, n) // built-ins + add-in injections (M05-F12)
 	if len(items) == 0 {
 		return
 	}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -141,6 +141,7 @@ func drawChromeWindows(s *app.Session) {
 	drawAddInPanels(s)                  // add-in dockable windows (M05-F03)
 	drawMessagingSurfaces(s)            // toasts, prompt modal, message center (M05-F09)
 	drawWebViews(s)                     // web dialogs/views (M05-F08)
+	drawMarkingMenu(s)                  // radial marking menu popup (M05-F12)
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -18,6 +18,7 @@ func drawMenuBar(s *app.Session) {
 	drawFileMenu(s)
 	drawEditMenu(s)
 	drawToolsMenu()
+	drawCommandSearch(s) // the command search box (M05-F12)
 	native.EndMainMenuBar()
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -53,6 +53,9 @@ func drawSingleViewport(win *native.Window, s *app.Session) {
 	// Reserve the region with an input-capturing button, then read navigation from it.
 	cx, cy := native.GetCursorPos()
 	native.InvisibleButton("##viewport-nav", float32(pw), float32(ph))
+	if native.IsItemClicked(native.MouseRight) {
+		openMarkingMenu() // the radial marking menu (M05-F12)
+	}
 	bx, by := native.ItemRectMin()
 
 	cam := s.Camera()
@@ -365,12 +368,19 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 // the extrude / active-tool previews) to list.
 func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane, list renderer.DrawList) renderer.DrawList {
 	part := activePart(s)
-	hidden := s.EditScopeHides // hide datums created after the node being edited (issue #132)
-	list.Items = append(list.Items, planesOverlay(part, s.SelectedWorkPlane(), hovered, hidden)...)
-	list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s), hidden)...)
-	list.Items = append(list.Items, partSketchOverlays(s)...)
-	list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
-	list.Items = append(list.Items, sketch3DOverlays(s, pointMarkerPixels*cam.WorldPerPixel())...)
+	hidden := s.EditScopeHides  // hide datums created after the node being edited (issue #132)
+	vis := s.ObjectVisibility() // View ▸ Object visibility (M05-F12): hidden kinds neither draw nor pick
+	if vis.WorkPlanes {
+		list.Items = append(list.Items, planesOverlay(part, s.SelectedWorkPlane(), hovered, hidden)...)
+	}
+	if vis.WorkAxes {
+		list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s), hidden)...)
+	}
+	if vis.Sketches {
+		list.Items = append(list.Items, partSketchOverlays(s)...)
+		list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
+		list.Items = append(list.Items, sketch3DOverlays(s, pointMarkerPixels*cam.WorldPerPixel())...)
+	}
 	list.Items = append(list.Items, selectedEdgeOverlay(s)...)
 	list.Items = append(list.Items, threadOverlay(s)...)
 	list.Items = append(list.Items, toolHoverHighlight(s)...)

--- a/head/ui/command_search.go
+++ b/head/ui/command_search.go
@@ -1,0 +1,58 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The command search box (M05-F12): a query field in the menu bar; matches drop
+// down beneath it and a click runs the command. Backed by the same
+// session.SearchCommands the ui.search wire method serves.
+
+// commandSearchBuf is the box's edit buffer (UI state, head-owned).
+var commandSearchBuf [64]byte
+
+// drawCommandSearch renders the search field inside the main menu bar and its
+// results popup while a query is typed.
+func drawCommandSearch(s *app.Session) {
+	native.SetNextItemWidth(200)
+	native.InputText("##command-search", commandSearchBuf[:])
+	query := bufString(commandSearchBuf[:])
+	if query == "" {
+		return
+	}
+	hits := s.SearchCommands(query)
+	if len(hits) == 0 {
+		native.SetItemTooltip("No matching commands")
+		return
+	}
+	drawSearchResults(s, hits)
+}
+
+// drawSearchResults lists the matches right under the field; clicking one runs it
+// and clears the query.
+func drawSearchResults(s *app.Session, hits []*app.CommandDefinition) {
+	x, y := native.ItemRectMin()
+	_, h := native.ItemRectMax()
+	_ = h
+	native.SetNextWindowPos(x, y+native.FrameHeight())
+	if native.Begin("Search results###cmd-search-results") {
+		limit := len(hits)
+		if limit > 10 {
+			limit = 10
+		}
+		for _, cmd := range hits[:limit] {
+			native.BeginDisabled(!cmd.IsEnabled(s))
+			if native.Selectable(cmd.DisplayName()+"##sr-"+cmd.ID(), false) {
+				_ = s.Execute(cmd.ID())
+				commandSearchBuf = [64]byte{}
+			}
+			native.EndDisabled()
+		}
+	}
+	native.End()
+}

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -105,6 +105,13 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		showPreferences = true
 	case "messaging": // M05-F09 surfaces: progress bar, balloon toast, prompt, messages
 		seedMessagingSurfaces(s)
+	case "marking-menu": // M05-F12: the radial marking menu, opened as if right-clicked
+		ext := app.NewExtrudeTool()
+		s.StartTool(ext)
+		ext.Pick(s, profile)
+		ext.SetDistance(3)
+		_ = s.OK()
+		openMarkingMenuOnFirstFrame = true
 	case "dialogs": // M05-F08: an add-in file dialog + a docked web view
 		_ = s.ShowWebDialog(wire.WebDialogSpec{
 			ID: "docs", Title: "Documentation", URL: "https://docs.example.org/bracket",

--- a/head/ui/marking_menu_view.go
+++ b/head/ui/marking_menu_view.go
@@ -1,0 +1,98 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The radial marking menu (M05-F12): right-clicking the viewport opens the active
+// environment's eight-quadrant command ring (plus its linear overflow) as a popup
+// at the cursor. Picking a slot runs the command; clicking away dismisses — the
+// standard ImGui popup behavior.
+
+// markingMenuPopupID names the popup; the viewport's right-click opens it.
+const markingMenuPopupID = "##marking-menu"
+
+// markingMenuRadius is the ring's pixel radius around the popup center.
+const markingMenuRadius = 72
+
+// openMarkingMenu arms the popup (called on a viewport right-click).
+func openMarkingMenu() { native.OpenPopup(markingMenuPopupID) }
+
+// openMarkingMenuOnFirstFrame lets the visual harness show the menu without a
+// synthetic right-click; consumed on the first chrome frame.
+var openMarkingMenuOnFirstFrame bool
+
+// quadrantDirections maps each compass slot to its unit offset (screen y grows
+// downward, so north is -y).
+var quadrantDirections = map[types.ScreenQuadrant][2]float32{
+	types.QuadrantNorth: {0, -1}, types.QuadrantNorthEast: {0.7, -0.7},
+	types.QuadrantEast: {1, 0}, types.QuadrantSouthEast: {0.7, 0.7},
+	types.QuadrantSouth: {0, 1}, types.QuadrantSouthWest: {-0.7, 0.7},
+	types.QuadrantWest: {-1, 0}, types.QuadrantNorthWest: {-0.7, -0.7},
+}
+
+// drawMarkingMenu renders the popup when open: the ring for the active
+// environment, then the overflow rows. Unknown command ids are skipped, so a
+// customized menu can name commands before they register.
+func drawMarkingMenu(s *app.Session) {
+	if openMarkingMenuOnFirstFrame {
+		openMarkingMenuOnFirstFrame = false
+		openMarkingMenu()
+	}
+	if !native.BeginPopup(markingMenuPopupID) {
+		return
+	}
+	menu := s.MarkingMenu(app.CurrentEnvironment(s))
+	const size = 2*markingMenuRadius + 96 // ring + button width margin
+	centerX, centerY := float32(size)/2, float32(size)/2
+	native.InvisibleButton("##marking-area", size, size) // reserves the ring's space
+	for _, item := range menu.Quadrants {
+		drawMarkingSlot(s, centerX, centerY, item)
+	}
+	drawMarkingOverflow(s, menu.Overflow)
+	native.EndPopup()
+}
+
+// drawMarkingSlot places one quadrant's command button on the ring.
+func drawMarkingSlot(s *app.Session, centerX, centerY float32, item wire.MarkingMenuItem) {
+	cmd, ok := s.Commands().ByID(item.CommandID)
+	if !ok {
+		return
+	}
+	dir := quadrantDirections[item.Quadrant]
+	label := cmd.DisplayName()
+	w := native.CalcTextWidth(label) + 16
+	x := centerX + dir[0]*markingMenuRadius - w/2
+	y := centerY + dir[1]*markingMenuRadius - 12
+	native.SetCursorPos(x, y)
+	native.BeginDisabled(!cmd.IsEnabled(s))
+	if native.Button(label + "##mm-" + item.CommandID) {
+		_ = s.Execute(item.CommandID)
+		native.CloseCurrentPopup()
+	}
+	native.EndDisabled()
+}
+
+// drawMarkingOverflow renders the linear rows beneath the ring.
+func drawMarkingOverflow(s *app.Session, overflow []string) {
+	if len(overflow) == 0 {
+		return
+	}
+	native.Separator()
+	for _, id := range overflow {
+		cmd, ok := s.Commands().ByID(id)
+		if !ok {
+			continue
+		}
+		if native.Selectable(cmd.DisplayName()+"##mmo-"+id, false) {
+			_ = s.Execute(id)
+		}
+	}
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F12, closing #619 (contract: Oblikovati/Oblikovati.API#52):

- **Command search**: a menu-bar field backed by the same `SearchCommands` that serves `ui.search`; results drop down and a click executes.
- **Radial marking menu**: viewport right-click opens the active environment's eight-quadrant ring + linear overflow; `ui.get/setMarkingMenu` customize it per environment.
- **Context-menu injection**: `ui.setContextMenu` (declarative, per node kind); `BrowserMenuFor` merges add-in entries with the built-ins.
- **Object visibility**: `ui.get/setObjectVisibility` gates overlays **and** pickers — hidden geometry is never clickable.
- **Events**: `command.started`, `selection.changed`, `ui.environmentChanged` (sketch enter/exit). UI-reset events have no real trigger and are declined to the #160 ADR.

## Tests

Menu defaults/customization/validation, injection merge+clear+kind-scoping, search matching, visibility-gates-pickers, environment-change emission; wire round-trips for all six methods. Verified visually: the six-slot ring over the model.

Closes #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)