### PR TITLE
Build the move/rotate triad and manipulator handles (M05-F13)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -95,9 +95,9 @@ func subscribeUISurfaces(bus *event.Bus, sink Sink) []event.Subscription {
 	return append(subs, subscribeMiniToolbars(bus, sink)...)
 }
 
-// subscribeMiniToolbars wires the mini-toolbar edit/commit events (M05-F07).
+// subscribeMiniToolbars wires the mini-toolbar and dialog events (M05-F07/F08).
 func subscribeMiniToolbars(bus *event.Bus, sink Sink) []event.Subscription {
-	return []event.Subscription{
+	subs := []event.Subscription{
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.MiniToolbarControlChanged) event.Outcome {
 			return relayJSON(sink, wire.MiniToolbarChangedEvent{
 				Type: wire.EventMiniToolbarChanged, Toolbar: e.Toolbar, Control: e.Control,
@@ -120,6 +120,30 @@ func subscribeMiniToolbars(bus *event.Bus, sink Sink) []event.Subscription {
 			})
 		}),
 	}
+	return append(subs, subscribeGizmos(bus, sink)...)
+}
+
+// subscribeGizmos wires the triad/manipulator events (M05-F13).
+func subscribeGizmos(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TriadDragged) event.Outcome {
+			return relayJSON(sink, wire.TriadDragEvent{
+				Type: wire.EventTriadDrag, Phase: e.Phase, Segment: e.Segment,
+				MoveType: e.MoveType, Delta: e.Delta, Context: e.Context,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TriadSegmentChanged) event.Outcome {
+			return relayJSON(sink, wire.TriadSegmentEvent{
+				Type: wire.EventTriadSegment, Segment: e.Segment, Hovered: e.Hovered,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.ManipulatorDragged) event.Outcome {
+			return relayJSON(sink, wire.ManipulatorDragEvent{
+				Type: wire.EventManipulatorDrag, Gizmo: e.Gizmo, Handle: e.Handle,
+				Phase: e.Phase, Position: e.Position, Context: e.Context,
+			})
+		}),
+	}
 }
 
 // relayJSON serializes a wire event DTO and hands it to sink (passive listener).
@@ -128,7 +152,8 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.ProgressCancelledEvent | wire.BalloonTipClickedEvent | wire.PromptAnsweredEvent |
 	wire.MiniToolbarChangedEvent | wire.MiniToolbarCommittedEvent |
 	wire.FileDialogChosenEvent | wire.WebDialogChangedEvent |
-	wire.SelectionChangedEvent | wire.EnvironmentChangedEvent](sink Sink, ev E) event.Outcome {
+	wire.SelectionChangedEvent | wire.EnvironmentChangedEvent |
+	wire.TriadDragEvent | wire.TriadSegmentEvent | wire.ManipulatorDragEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -52,6 +52,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerDialogHandlers()
 	r.registerWindowHandlers()
 	r.registerUIShellHandlers()
+	r.registerTriadHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/addin/router/triad.go
+++ b/addin/router/triad.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerTriadHandlers wires the gizmo methods (M05-F13, #620).
+func (r *Router) registerTriadHandlers() {
+	r.handlers[wire.MethodTriadShow] = showTriad
+	r.handlers[wire.MethodTriadUpdate] = updateTriad
+	r.handlers[wire.MethodTriadHide] = hideTriad
+	r.handlers[wire.MethodTriadGet] = getTriad
+	r.handlers[wire.MethodManipulatorsSet] = setManipulators
+	r.handlers[wire.MethodManipulatorsRemove] = removeManipulators
+}
+
+func showTriad(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ShowTriadArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	req.Triad.Visible = true
+	if err := s.ShowTriad(req.Triad); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func updateTriad(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ShowTriadArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.ShowTriad(req.Triad); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func hideTriad(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	s.HideTriad()
+	return ok()
+}
+
+func getTriad(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(s.TriadSpec())
+}
+
+func setManipulators(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetManipulatorsArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.SetManipulators(req.ID, req.Handles, req.Command); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func removeManipulators(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.RemoveManipulatorsArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.RemoveManipulators(req.ID); err != nil {
+		return nil, err
+	}
+	return ok()
+}

--- a/addin/router/triad_test.go
+++ b/addin/router/triad_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+func TestTriadOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "triad.show", `{"triad":{"position":[1,2,3],"allowed":[1,9]}}`, nil)
+	var spec wire.TriadSpec
+	call(t, r, s, "triad.get", "{}", &spec)
+	if !spec.Visible || spec.Position[2] != 3 || len(spec.Allowed) != 2 {
+		t.Fatalf("triad = %+v, want visible at (1,2,3) with two allowed segments", spec)
+	}
+	if !s.TriadAllows(types.TriadXAxis) || s.TriadAllows(types.TriadYAxis) {
+		t.Error("the allowed mask did not apply")
+	}
+
+	call(t, r, s, "triad.hide", "{}", nil)
+	call(t, r, s, "triad.get", "{}", &spec)
+	if spec.Visible {
+		t.Error("triad still visible after hide")
+	}
+	if _, err := r.Handle(s, "triad.show", []byte(`{"triad":{"allowed":[42]}}`)); err == nil {
+		t.Error("an out-of-range segment should fail over the wire")
+	}
+}
+
+func TestManipulatorsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "manipulators.set",
+		`{"id":"sim","handles":[{"id":"tip","position":[0,0,5],"radiusPx":10}]}`, nil)
+	if handles := s.Manipulators().Handles()["sim"]; len(handles) != 1 || handles[0].ID != "tip" {
+		t.Fatalf("handles = %+v, want the tip", handles)
+	}
+	call(t, r, s, "manipulators.remove", `{"id":"sim"}`, nil)
+	if len(s.Manipulators().Handles()) != 0 {
+		t.Error("gizmo survived remove")
+	}
+	if _, err := r.Handle(s, "manipulators.set", []byte(`{"id":"","handles":[]}`)); err == nil {
+		t.Error("a gizmo without an id should fail")
+	}
+}

--- a/app/events.go
+++ b/app/events.go
@@ -24,6 +24,9 @@ const (
 	tidFileDialogChosen     event.TypeID = 0x050d // app/dialog_requests.go (M05-F08)
 	tidWebDialogChanged     event.TypeID = 0x050e // app/dialog_requests.go (M05-F08)
 	tidEnvironmentChanged   event.TypeID = 0x050f // app/ui_shell.go (M05-F12)
+	tidTriadSegment         event.TypeID = 0x0510 // app/triad.go (M05-F13)
+	tidTriadDrag            event.TypeID = 0x0511 // app/triad.go (M05-F13)
+	tidManipulatorDrag      event.TypeID = 0x0512 // app/manipulators.go (M05-F13)
 )
 
 // CommandStarted fires (Before) when a command begins — Inventor's

--- a/app/manipulators.go
+++ b/app/manipulators.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+)
+
+// Add-in manipulator handles (M05-F13, #620): world-space hotspots an add-in
+// declares over its client graphics; dragging one streams manipulator.drag events
+// with the handle's view-plane position (snapped to work points within the snap
+// radius). The hit-testing lives in the head (it owns pixels); the drag math here.
+
+// ManipulatorDragged fires (After) on every handle drag phase.
+type ManipulatorDragged struct {
+	Gizmo    string
+	Handle   string
+	Phase    string
+	Position [3]float64
+	Context  wire.DragContext
+}
+
+// EventID implements event.Event.
+func (ManipulatorDragged) EventID() event.TypeID { return tidManipulatorDrag }
+
+// manipulatorGizmo is one declared handle set.
+type manipulatorGizmo struct {
+	handles []wire.ManipulatorHandleSpec
+	command string
+}
+
+// manipulatorDrag is one in-flight handle gesture.
+type manipulatorDrag struct {
+	gizmo, handle string
+	start         math.Point3
+	normal        math.Vector3 // the view plane the handle slides in
+	snapTol       float64
+}
+
+// ManipulatorBoard holds the declared gizmos in creation order.
+type ManipulatorBoard struct {
+	order  []string
+	gizmos map[string]manipulatorGizmo
+	drag   *manipulatorDrag
+}
+
+// NewManipulatorBoard returns an empty board.
+func NewManipulatorBoard() *ManipulatorBoard {
+	return &ManipulatorBoard{gizmos: map[string]manipulatorGizmo{}}
+}
+
+// Handles returns every declared gizmo's handles in creation order, flattened for
+// the head's hit-test (each spec keyed by its gizmo).
+func (b *ManipulatorBoard) Handles() map[string][]wire.ManipulatorHandleSpec {
+	out := map[string][]wire.ManipulatorHandleSpec{}
+	for _, id := range b.order {
+		out[id] = b.gizmos[id].handles
+	}
+	return out
+}
+
+// Manipulators returns the session's manipulator board.
+func (s *Session) Manipulators() *ManipulatorBoard { return s.manipulators }
+
+// SetManipulators replaces one gizmo's handle set.
+func (s *Session) SetManipulators(id string, handles []wire.ManipulatorHandleSpec, command string) error {
+	if id == "" {
+		return fmt.Errorf("app: manipulator gizmo needs an id")
+	}
+	for _, h := range handles {
+		if h.ID == "" {
+			return fmt.Errorf("app: manipulator handle of gizmo %q needs an id", id)
+		}
+	}
+	if _, exists := s.manipulators.gizmos[id]; !exists {
+		s.manipulators.order = append(s.manipulators.order, id)
+	}
+	s.manipulators.gizmos[id] = manipulatorGizmo{handles: handles, command: command}
+	return nil
+}
+
+// RemoveManipulators dismisses a gizmo's handles.
+func (s *Session) RemoveManipulators(id string) error {
+	if _, ok := s.manipulators.gizmos[id]; !ok {
+		return fmt.Errorf("app: no manipulator gizmo %q", id)
+	}
+	delete(s.manipulators.gizmos, id)
+	for i, x := range s.manipulators.order {
+		if x == id {
+			s.manipulators.order = append(s.manipulators.order[:i], s.manipulators.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// BeginManipulatorDrag starts a handle gesture: the handle slides in the view
+// plane through its position (viewNormal = the camera's forward at grab).
+func (s *Session) BeginManipulatorDrag(gizmo, handle string, viewNormal math.Vector3, rayO math.Point3, rayD math.Vector3, snapTol float64, shift, ctrl bool) error {
+	spec, err := s.manipulatorHandle(gizmo, handle)
+	if err != nil {
+		return err
+	}
+	start := math.P3(spec.Position[0], spec.Position[1], spec.Position[2])
+	s.manipulators.drag = &manipulatorDrag{
+		gizmo: gizmo, handle: handle, start: start,
+		normal: unitOrZero(viewNormal), snapTol: snapTol,
+	}
+	event.Emit(s.bus, event.After, ManipulatorDragged{
+		Gizmo: gizmo, Handle: handle, Phase: DragStart, Position: spec.Position,
+		Context: dragContext(start, rayO, rayD, shift, ctrl, types.InferenceNone),
+	})
+	return nil
+}
+
+// DragManipulator advances the gesture: the handle's position is the ray's
+// intersection with its view plane, snapped to a work point within the radius.
+func (s *Session) DragManipulator(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error {
+	d := s.manipulators.drag
+	if d == nil {
+		return fmt.Errorf("app: no manipulator drag in flight")
+	}
+	pos, inference := s.manipulatorPosition(d, rayO, rayD)
+	event.Emit(s.bus, event.After, ManipulatorDragged{
+		Gizmo: d.gizmo, Handle: d.handle, Phase: DragMove, Position: pos,
+		Context: dragContext(d.start, rayO, rayD, shift, ctrl, inference),
+	})
+	return nil
+}
+
+// EndManipulatorDrag finishes the gesture, baking the final position into the
+// handle spec so a re-list shows where it landed.
+func (s *Session) EndManipulatorDrag(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error {
+	d := s.manipulators.drag
+	if d == nil {
+		return fmt.Errorf("app: no manipulator drag in flight")
+	}
+	s.manipulators.drag = nil
+	pos, inference := s.manipulatorPosition(d, rayO, rayD)
+	s.bakeHandlePosition(d.gizmo, d.handle, pos)
+	event.Emit(s.bus, event.After, ManipulatorDragged{
+		Gizmo: d.gizmo, Handle: d.handle, Phase: DragEnd, Position: pos,
+		Context: dragContext(d.start, rayO, rayD, shift, ctrl, inference),
+	})
+	return nil
+}
+
+// ManipulatorDragging reports whether a handle gesture is in flight.
+func (s *Session) ManipulatorDragging() bool { return s.manipulators.drag != nil }
+
+// manipulatorPosition resolves the dragged position with point inference.
+func (s *Session) manipulatorPosition(d *manipulatorDrag, rayO math.Point3, rayD math.Vector3) ([3]float64, types.PointInferenceKind) {
+	hit, ok := rayPlane(rayO, rayD, d.start, d.normal)
+	if !ok {
+		hit = d.start
+	}
+	inference := types.InferenceNone
+	if d.snapTol > 0 {
+		if snapped, ok := s.nearestWorkPoint(hit, d.snapTol); ok {
+			hit, inference = snapped, types.InferencePoint
+		}
+	}
+	return [3]float64{float64(hit.X), float64(hit.Y), float64(hit.Z)}, inference
+}
+
+// nearestWorkPoint finds a work point within tol of p.
+func (s *Session) nearestWorkPoint(p math.Point3, tol float64) (math.Point3, bool) {
+	part, err := activePart(s)
+	if err != nil {
+		return math.Point3{}, false
+	}
+	points := part.WorkPoints()
+	for i := 0; i < points.Count(); i++ {
+		wp := points.Item(i)
+		if float64(p.DistanceTo(wp.Point())) <= tol {
+			return wp.Point(), true
+		}
+	}
+	return math.Point3{}, false
+}
+
+// manipulatorHandle finds one declared handle.
+func (s *Session) manipulatorHandle(gizmo, handle string) (wire.ManipulatorHandleSpec, error) {
+	g, ok := s.manipulators.gizmos[gizmo]
+	if !ok {
+		return wire.ManipulatorHandleSpec{}, fmt.Errorf("app: no manipulator gizmo %q", gizmo)
+	}
+	for _, h := range g.handles {
+		if h.ID == handle {
+			return h, nil
+		}
+	}
+	return wire.ManipulatorHandleSpec{}, fmt.Errorf("app: gizmo %q has no handle %q", gizmo, handle)
+}
+
+// bakeHandlePosition writes the dragged position back into the stored spec.
+func (s *Session) bakeHandlePosition(gizmo, handle string, pos [3]float64) {
+	g := s.manipulators.gizmos[gizmo]
+	for i := range g.handles {
+		if g.handles[i].ID == handle {
+			g.handles[i].Position = pos
+		}
+	}
+	s.manipulators.gizmos[gizmo] = g
+}
+
+// dropCommandGizmos removes the triad and manipulator gizmos tied to a command's
+// lifetime — the interaction-graphics lifecycle, like mini-toolbars.
+func (s *Session) dropCommandGizmos() {
+	if s.triad.spec.Command != "" {
+		s.HideTriad()
+	}
+	for _, id := range append([]string(nil), s.manipulators.order...) {
+		if s.manipulators.gizmos[id].command != "" {
+			_ = s.RemoveManipulators(id)
+		}
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -68,6 +68,8 @@ type Session struct {
 	webViewOrder       []string                                         // web views in creation order
 	urlOpener          URLOpener                                        // platform URL opener (head-injected)
 	windowFrame        WindowFrameStatus                                // mirrored host-window state (M05-F10)
+	triad              TriadGizmo                                       // the move/rotate triad (M05-F13)
+	manipulators       *ManipulatorBoard                                // add-in drag handles (M05-F13)
 	markingMenus       map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
 	contextMenus       map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
 	objectVisibility   wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
@@ -139,6 +141,7 @@ func newSession(store doc.Store) *Session {
 		balloonTips:     NewBalloonTipCenter(),
 		prompts:         NewPromptCenter(),
 		miniToolbars:    NewMiniToolbarRack(),
+		manipulators:    NewManipulatorBoard(),
 		visualStyle:     renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -21,6 +21,7 @@ func (s *Session) StartTool(t Tool) {
 		s.tool.tool.Cancel(s)
 		s.graphics.ClearInteraction() // drop the previous tool's preview/overlay graphics
 		s.dropCommandMiniToolbars()   // and its mini-toolbars (M05-F07)
+		s.dropCommandGizmos()         // and its triad/manipulators (M05-F13)
 	}
 	s.notice = ""
 	s.tool = &ToolInstance{tool: t}
@@ -56,6 +57,7 @@ func (s *Session) OK() error {
 	s.tool = nil
 	s.graphics.ClearInteraction() // a committed command's transient preview vanishes
 	s.dropCommandMiniToolbars()   // command-bound mini-toolbars die with the tool (M05-F07)
+	s.dropCommandGizmos()         // and the command-bound triad/manipulators (M05-F13)
 	return nil
 }
 
@@ -67,6 +69,7 @@ func (s *Session) CancelTool() {
 		s.tool = nil
 		s.graphics.ClearInteraction() // a cancelled command's transient preview vanishes
 		s.dropCommandMiniToolbars()   // command-bound mini-toolbars die with the tool (M05-F07)
+		s.dropCommandGizmos()         // and the command-bound triad/manipulators (M05-F13)
 	}
 }
 

--- a/app/triad.go
+++ b/app/triad.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+)
+
+// The move/rotate triad (M05-F13, #620): a session-owned gizmo the head renders
+// and drags; every gesture streams to the owner as events carrying the accumulated
+// delta transform. The drag math lives here, headless and unit-tested — the head
+// only routes rays.
+
+// The drag phases of triad/manipulator events.
+const (
+	DragStart = "start"
+	DragMove  = "move"
+	DragEnd   = "end"
+)
+
+// TriadSegmentChanged fires (After) when the hovered segment changes.
+type TriadSegmentChanged struct {
+	Segment types.TriadSegment
+	Hovered bool
+}
+
+// EventID implements event.Event.
+func (TriadSegmentChanged) EventID() event.TypeID { return tidTriadSegment }
+
+// TriadDragged fires (After) on every drag phase with the accumulated delta.
+type TriadDragged struct {
+	Phase    string
+	Segment  types.TriadSegment
+	MoveType types.TriadMoveType
+	Delta    [16]float64
+	Context  wire.DragContext
+}
+
+// EventID implements event.Event.
+func (TriadDragged) EventID() event.TypeID { return tidTriadDrag }
+
+// triadDrag is one in-flight gesture: the constraint resolved at grab time.
+type triadDrag struct {
+	segment  types.TriadSegment
+	moveType types.TriadMoveType
+	origin   math.Point3  // triad position at grab
+	axis     math.Vector3 // axial/ring constraint axis (unit)
+	normal   math.Vector3 // planar/free/ring working plane normal (unit)
+	grab     math.Point3  // grab point on the constraint
+	delta    [16]float64  // accumulated transform (row-major)
+	snapTol  float64      // world-units snap radius for point inference
+}
+
+// TriadGizmo is the session's triad state.
+type TriadGizmo struct {
+	spec     wire.TriadSpec
+	drag     *triadDrag
+	hovered  types.TriadSegment
+	hasHover bool
+}
+
+// TriadSpec returns the current triad declaration (Visible false when hidden).
+func (s *Session) TriadSpec() wire.TriadSpec { return s.triad.spec }
+
+// ShowTriad places (or re-places) the triad. Omitted axes default to identity.
+func (s *Session) ShowTriad(spec wire.TriadSpec) error {
+	for _, seg := range spec.Allowed {
+		if seg > types.TriadZRing {
+			return fmt.Errorf("app: triad segment %d out of range (0..9)", seg)
+		}
+	}
+	s.triad.spec = spec
+	return nil
+}
+
+// HideTriad dismisses the triad (ending any in-flight drag silently).
+func (s *Session) HideTriad() {
+	s.triad.spec.Visible = false
+	s.triad.drag = nil
+}
+
+// TriadAllows reports whether a segment is grabbable under the spec's mask.
+func (s *Session) TriadAllows(seg types.TriadSegment) bool {
+	if len(s.triad.spec.Allowed) == 0 {
+		return true
+	}
+	for _, allowed := range s.triad.spec.Allowed {
+		if allowed == seg {
+			return true
+		}
+	}
+	return false
+}
+
+// HoverTriadSegment reports the hovered segment (the head's hit-test); transitions
+// emit the segment-selection event.
+func (s *Session) HoverTriadSegment(seg types.TriadSegment, hovered bool) {
+	if s.triad.hasHover == hovered && (!hovered || s.triad.hovered == seg) {
+		return
+	}
+	s.triad.hasHover, s.triad.hovered = hovered, seg
+	event.Emit(s.bus, event.After, TriadSegmentChanged{Segment: seg, Hovered: hovered})
+}
+
+// triadAxes resolves the spec's orientation (identity when omitted).
+func (s *Session) triadAxes() (x, y, z math.Vector3) {
+	x, y, z = math.V3(1, 0, 0), math.V3(0, 1, 0), math.V3(0, 0, 1)
+	if a := s.triad.spec.AxisX; a != nil {
+		x = math.V3(a[0], a[1], a[2])
+	}
+	if a := s.triad.spec.AxisY; a != nil {
+		y = math.V3(a[0], a[1], a[2])
+	}
+	if a := s.triad.spec.AxisZ; a != nil {
+		z = math.V3(a[0], a[1], a[2])
+	}
+	return x, y, z
+}
+
+// TriadPosition returns the triad's position as a point.
+func (s *Session) TriadPosition() math.Point3 {
+	p := s.triad.spec.Position
+	return math.P3(p[0], p[1], p[2])
+}
+
+// segmentConstraint resolves a segment to its motion constraint: the move type,
+// the constraint axis (axial/ring moves), and the working-plane normal.
+func (s *Session) segmentConstraint(seg types.TriadSegment, rayDir math.Vector3) (types.TriadMoveType, math.Vector3, math.Vector3, error) {
+	axisOf, normalOf := s.segmentVectors()
+	switch {
+	case seg >= types.TriadXAxis && seg <= types.TriadZAxis:
+		return types.TriadTranslate, axisOf[seg], math.Vector3{}, nil
+	case seg >= types.TriadXYPlane && seg <= types.TriadXZPlane:
+		return types.TriadTranslatePlanar, math.Vector3{}, normalOf[seg], nil
+	case seg >= types.TriadXRing && seg <= types.TriadZRing:
+		return types.TriadRotate, axisOf[seg], axisOf[seg], nil
+	case seg == types.TriadOrigin:
+		return types.TriadFree, math.Vector3{}, rayDir.Scale(-1), nil
+	default:
+		return 0, math.Vector3{}, math.Vector3{}, fmt.Errorf("app: unknown triad segment %d", seg)
+	}
+}
+
+// segmentVectors maps segments to their constraint axis / working-plane normal.
+func (s *Session) segmentVectors() (map[types.TriadSegment]math.Vector3, map[types.TriadSegment]math.Vector3) {
+	x, y, z := s.triadAxes()
+	axisOf := map[types.TriadSegment]math.Vector3{
+		types.TriadXAxis: x, types.TriadYAxis: y, types.TriadZAxis: z,
+		types.TriadXRing: x, types.TriadYRing: y, types.TriadZRing: z,
+	}
+	normalOf := map[types.TriadSegment]math.Vector3{
+		types.TriadXYPlane: z, types.TriadYZPlane: x, types.TriadXZPlane: y,
+	}
+	return axisOf, normalOf
+}
+
+// BeginTriadDrag starts a gesture on a segment from the given pointer ray. snapTol
+// is the world-units radius for point inference (0 disables snapping).
+func (s *Session) BeginTriadDrag(seg types.TriadSegment, rayO math.Point3, rayD math.Vector3, snapTol float64, shift, ctrl bool) error {
+	if !s.triad.spec.Visible {
+		return fmt.Errorf("app: the triad is not visible")
+	}
+	if !s.TriadAllows(seg) {
+		return fmt.Errorf("app: triad segment %v is not in the allowed set", seg)
+	}
+	moveType, axis, normal, err := s.segmentConstraint(seg, rayD)
+	if err != nil {
+		return err
+	}
+	drag := &triadDrag{
+		segment: seg, moveType: moveType, origin: s.TriadPosition(),
+		axis: unitOrZero(axis), normal: unitOrZero(normal),
+		delta: identity4(), snapTol: snapTol,
+	}
+	drag.grab = drag.grabPoint(rayO, rayD)
+	s.triad.drag = drag
+	event.Emit(s.bus, event.After, TriadDragged{
+		Phase: DragStart, Segment: seg, MoveType: moveType, Delta: drag.delta,
+		Context: dragContext(drag.grab, rayO, rayD, shift, ctrl, types.InferenceNone),
+	})
+	return nil
+}
+
+// grabPoint resolves where on the constraint the pointer grabbed.
+func (d *triadDrag) grabPoint(rayO math.Point3, rayD math.Vector3) math.Point3 {
+	switch d.moveType {
+	case types.TriadTranslate:
+		t := closestParamOnAxis(d.origin, d.axis, rayO, rayD)
+		return d.origin.TranslateBy(d.axis.Scale(t))
+	default: // planar, free and ring grabs all live on the working plane
+		if hit, ok := rayPlane(rayO, rayD, d.origin, d.normal); ok {
+			return hit
+		}
+		return d.origin
+	}
+}
+
+// DragTriad advances the gesture to the current pointer ray, emitting the
+// accumulated delta. Translation moves snap to nearby work points (inference).
+func (s *Session) DragTriad(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error {
+	d := s.triad.drag
+	if d == nil {
+		return fmt.Errorf("app: no triad drag in flight")
+	}
+	inference := types.InferenceNone
+	switch d.moveType {
+	case types.TriadTranslate, types.TriadTranslatePlanar, types.TriadFree:
+		move := d.translationTo(rayO, rayD)
+		move, inference = s.snapTranslation(d, move)
+		d.delta = translation4(move)
+	case types.TriadRotate:
+		d.delta = d.rotationTo(rayO, rayD)
+	}
+	event.Emit(s.bus, event.After, TriadDragged{
+		Phase: DragMove, Segment: d.segment, MoveType: d.moveType, Delta: d.delta,
+		Context: dragContext(d.grab, rayO, rayD, shift, ctrl, inference),
+	})
+	return nil
+}
+
+// translationTo resolves the constrained translation from grab to the current ray.
+func (d *triadDrag) translationTo(rayO math.Point3, rayD math.Vector3) math.Vector3 {
+	if d.moveType == types.TriadTranslate {
+		t0 := closestParamOnAxis(d.origin, d.axis, rayO, rayD)
+		return d.axis.Scale(t0 - d.origin.VectorTo(d.grab).Dot(d.axis))
+	}
+	hit, ok := rayPlane(rayO, rayD, d.origin, d.normal)
+	if !ok {
+		return math.V3(0, 0, 0)
+	}
+	return d.grab.VectorTo(hit)
+}
+
+// rotationTo resolves the ring rotation (about the triad position) to the ray.
+func (d *triadDrag) rotationTo(rayO math.Point3, rayD math.Vector3) [16]float64 {
+	hit, ok := rayPlane(rayO, rayD, d.origin, d.normal)
+	if !ok {
+		return d.delta
+	}
+	v0, v1 := d.origin.VectorTo(d.grab), d.origin.VectorTo(hit)
+	if v0.Length() == 0 || v1.Length() == 0 {
+		return d.delta
+	}
+	angle := stdmath.Atan2(float64(v0.Cross(v1).Dot(d.axis)), float64(v0.Dot(v1)))
+	return rotationAbout4(d.origin, d.axis, angle)
+}
+
+// snapTranslation snaps the translated triad position to a nearby work point when
+// one sits within the drag's snap radius (the point-inference hook).
+func (s *Session) snapTranslation(d *triadDrag, move math.Vector3) (math.Vector3, types.PointInferenceKind) {
+	if d.snapTol <= 0 {
+		return move, types.InferenceNone
+	}
+	landed := d.origin.TranslateBy(move)
+	part, err := activePart(s)
+	if err != nil {
+		return move, types.InferenceNone
+	}
+	points := part.WorkPoints()
+	for i := 0; i < points.Count(); i++ {
+		wp := points.Item(i)
+		if float64(landed.DistanceTo(wp.Point())) <= d.snapTol {
+			return d.origin.VectorTo(wp.Point()), types.InferencePoint
+		}
+	}
+	return move, types.InferenceNone
+}
+
+// EndTriadDrag finishes the gesture, baking the final delta into the triad's
+// position (translations) so it stays where the user left it.
+func (s *Session) EndTriadDrag(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error {
+	d := s.triad.drag
+	if d == nil {
+		return fmt.Errorf("app: no triad drag in flight")
+	}
+	s.triad.drag = nil
+	if d.moveType != types.TriadRotate {
+		landed := d.origin.TranslateBy(math.V3(d.delta[3], d.delta[7], d.delta[11]))
+		s.triad.spec.Position = [3]float64{float64(landed.X), float64(landed.Y), float64(landed.Z)}
+	}
+	event.Emit(s.bus, event.After, TriadDragged{
+		Phase: DragEnd, Segment: d.segment, MoveType: d.moveType, Delta: d.delta,
+		Context: dragContext(d.grab, rayO, rayD, shift, ctrl, types.InferenceNone),
+	})
+	return nil
+}
+
+// TriadDragging reports whether a gesture is in flight (the head suppresses
+// navigation while it is).
+func (s *Session) TriadDragging() bool { return s.triad.drag != nil }
+
+// dragContext assembles the wire context for an event.
+func dragContext(start math.Point3, rayO math.Point3, rayD math.Vector3, shift, ctrl bool, inf types.PointInferenceKind) wire.DragContext {
+	return wire.DragContext{
+		Start:     [3]float64{float64(start.X), float64(start.Y), float64(start.Z)},
+		RayOrigin: [3]float64{float64(rayO.X), float64(rayO.Y), float64(rayO.Z)},
+		RayDir:    [3]float64{float64(rayD.X), float64(rayD.Y), float64(rayD.Z)},
+		Shift:     shift, Ctrl: ctrl, Inference: inf,
+	}
+}
+
+// closestParamOnAxis returns the parameter t (world units along the unit axis from
+// p0) of the point on the axis closest to the ray — the standard two-line closest
+// approach, degenerate (parallel) cases collapsing to 0.
+func closestParamOnAxis(p0 math.Point3, axis math.Vector3, rayO math.Point3, rayD math.Vector3) float64 {
+	w := rayO.VectorTo(p0) // rayO → p0 (the textbook w0 = p0 − ro)
+	b := float64(axis.Dot(rayD))
+	denom := 1 - b*b
+	if stdmath.Abs(denom) < 1e-9 {
+		return 0
+	}
+	d := float64(axis.Dot(w))
+	e := float64(rayD.Dot(w))
+	return (b*e - d) / denom
+}
+
+// rayPlane intersects a ray with the plane (origin, normal).
+func rayPlane(rayO math.Point3, rayD math.Vector3, origin math.Point3, normal math.Vector3) (math.Point3, bool) {
+	denom := float64(rayD.Dot(normal))
+	if stdmath.Abs(denom) < 1e-9 {
+		return math.Point3{}, false
+	}
+	t := float64(rayO.VectorTo(origin).Dot(normal)) / denom
+	if t < 0 {
+		return math.Point3{}, false
+	}
+	return rayO.TranslateBy(rayD.Scale(t)), true
+}
+
+// identity4 / translation4 / rotationAbout4 build row-major 4×4 transforms.
+func identity4() [16]float64 {
+	return [16]float64{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}
+}
+
+func translation4(v math.Vector3) [16]float64 {
+	m := identity4()
+	m[3], m[7], m[11] = float64(v.X), float64(v.Y), float64(v.Z)
+	return m
+}
+
+// rotationAbout4 rotates by angle around the unit axis through p (T·R·T⁻¹).
+func rotationAbout4(p math.Point3, axis math.Vector3, angle float64) [16]float64 {
+	c, s := stdmath.Cos(angle), stdmath.Sin(angle)
+	x, y, z := float64(axis.X), float64(axis.Y), float64(axis.Z)
+	t := 1 - c
+	r := [9]float64{
+		t*x*x + c, t*x*y - s*z, t*x*z + s*y,
+		t*x*y + s*z, t*y*y + c, t*y*z - s*x,
+		t*x*z - s*y, t*y*z + s*x, t*z*z + c,
+	}
+	px, py, pz := float64(p.X), float64(p.Y), float64(p.Z)
+	// translation column = p - R·p
+	tx := px - (r[0]*px + r[1]*py + r[2]*pz)
+	ty := py - (r[3]*px + r[4]*py + r[5]*pz)
+	tz := pz - (r[6]*px + r[7]*py + r[8]*pz)
+	return [16]float64{
+		r[0], r[1], r[2], tx,
+		r[3], r[4], r[5], ty,
+		r[6], r[7], r[8], tz,
+		0, 0, 0, 1,
+	}
+}
+
+// unitOrZero normalizes v, keeping the zero vector zero.
+func unitOrZero(v math.Vector3) math.Vector3 {
+	l := float64(v.Length())
+	if l == 0 {
+		return v
+	}
+	return v.Scale(1 / l)
+}

--- a/app/triad_test.go
+++ b/app/triad_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+)
+
+// triadEventLog subscribes to drag events.
+func triadEventLog(s *Session) *[]TriadDragged {
+	var got []TriadDragged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TriadDragged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+	return &got
+}
+
+func TestTriadAxisDragTranslatesAlongX(t *testing.T) {
+	s := NewSession()
+	if err := s.ShowTriad(wire.TriadSpec{Position: [3]float64{0, 0, 0}, Visible: true}); err != nil {
+		t.Fatalf("ShowTriad: %v", err)
+	}
+	got := triadEventLog(s)
+
+	// Looking straight down -Z from z=10: a ray through (2,0) grabs the X axis at x≈2.
+	down := math.V3(0, 0, -1)
+	if err := s.BeginTriadDrag(types.TriadXAxis, math.P3(2, 0, 10), down, 0, false, false); err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := s.DragTriad(math.P3(5, 0, 10), down, false, false); err != nil {
+		t.Fatalf("Drag: %v", err)
+	}
+	if err := s.EndTriadDrag(math.P3(5, 0, 10), down, false, false); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+
+	if len(*got) != 3 || (*got)[0].Phase != DragStart || (*got)[2].Phase != DragEnd {
+		t.Fatalf("phases = %+v, want start/move/end", *got)
+	}
+	move := (*got)[1]
+	if move.MoveType != types.TriadTranslate {
+		t.Errorf("moveType = %v, want translate", move.MoveType)
+	}
+	if dx := move.Delta[3]; stdmath.Abs(dx-3) > 1e-6 {
+		t.Errorf("delta.tx = %v, want 3 (grabbed at 2, dragged to 5)", dx)
+	}
+	if dy, dz := move.Delta[7], move.Delta[11]; dy != 0 || dz != 0 {
+		t.Errorf("off-axis translation (%v, %v), want the X constraint to hold", dy, dz)
+	}
+	if pos := s.TriadSpec().Position; stdmath.Abs(pos[0]-3) > 1e-6 {
+		t.Errorf("triad landed at x=%v, want 3 (the delta baked in)", pos[0])
+	}
+}
+
+func TestTriadRingDragRotatesAboutZ(t *testing.T) {
+	s := NewSession()
+	if err := s.ShowTriad(wire.TriadSpec{Position: [3]float64{0, 0, 0}, Visible: true}); err != nil {
+		t.Fatalf("ShowTriad: %v", err)
+	}
+	got := triadEventLog(s)
+
+	down := math.V3(0, 0, -1)
+	// Grab the Z ring at (1,0), drag to (0,1): a +90° rotation about Z.
+	if err := s.BeginTriadDrag(types.TriadZRing, math.P3(1, 0, 10), down, 0, false, false); err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := s.DragTriad(math.P3(0, 1, 10), down, false, false); err != nil {
+		t.Fatalf("Drag: %v", err)
+	}
+	move := (*got)[1]
+	if move.MoveType != types.TriadRotate {
+		t.Fatalf("moveType = %v, want rotate", move.MoveType)
+	}
+	// The delta must map (1,0,0) → (0,1,0).
+	x := [3]float64{move.Delta[0], move.Delta[4], move.Delta[8]}
+	if stdmath.Abs(x[0]) > 1e-6 || stdmath.Abs(x[1]-1) > 1e-6 {
+		t.Errorf("R·ex = %v, want (0,1,0) for a +90° Z rotation", x)
+	}
+}
+
+func TestTriadPlanarDragStaysInPlane(t *testing.T) {
+	s := NewSession()
+	if err := s.ShowTriad(wire.TriadSpec{Position: [3]float64{0, 0, 0}, Visible: true}); err != nil {
+		t.Fatalf("ShowTriad: %v", err)
+	}
+	got := triadEventLog(s)
+	down := math.V3(0, 0, -1)
+	if err := s.BeginTriadDrag(types.TriadXYPlane, math.P3(1, 1, 10), down, 0, false, false); err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := s.DragTriad(math.P3(4, -2, 10), down, false, false); err != nil {
+		t.Fatalf("Drag: %v", err)
+	}
+	move := (*got)[1]
+	if move.Delta[3] != 3 || move.Delta[7] != -3 || move.Delta[11] != 0 {
+		t.Errorf("planar delta = (%v,%v,%v), want (3,-3,0)", move.Delta[3], move.Delta[7], move.Delta[11])
+	}
+}
+
+func TestTriadRespectsAllowedMaskAndVisibility(t *testing.T) {
+	s := NewSession()
+	if err := s.ShowTriad(wire.TriadSpec{
+		Visible: true, Allowed: []types.TriadSegment{types.TriadXAxis},
+	}); err != nil {
+		t.Fatalf("ShowTriad: %v", err)
+	}
+	down := math.V3(0, 0, -1)
+	if err := s.BeginTriadDrag(types.TriadYAxis, math.P3(0, 2, 10), down, 0, false, false); err == nil {
+		t.Error("a segment outside the allowed mask must refuse to drag")
+	}
+	s.HideTriad()
+	if err := s.BeginTriadDrag(types.TriadXAxis, math.P3(2, 0, 10), down, 0, false, false); err == nil {
+		t.Error("a hidden triad must refuse to drag")
+	}
+	if err := s.ShowTriad(wire.TriadSpec{Allowed: []types.TriadSegment{99}}); err == nil {
+		t.Error("an out-of-range allowed segment must be rejected")
+	}
+}
+
+func TestTriadSegmentHoverEmitsOnTransition(t *testing.T) {
+	s := NewSession()
+	var got []TriadSegmentChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TriadSegmentChanged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+	s.HoverTriadSegment(types.TriadXAxis, true)
+	s.HoverTriadSegment(types.TriadXAxis, true) // repeat: silent
+	s.HoverTriadSegment(types.TriadZRing, true) // segment change
+	s.HoverTriadSegment(types.TriadZRing, false)
+	if len(got) != 3 || !got[0].Hovered || got[1].Segment != types.TriadZRing || got[2].Hovered {
+		t.Fatalf("events = %+v, want hover X, hover ZRing, unhover", got)
+	}
+}
+
+func TestManipulatorDragSlidesInViewPlane(t *testing.T) {
+	s := NewSession()
+	if err := s.SetManipulators("sim", []wire.ManipulatorHandleSpec{
+		{ID: "tip", Position: [3]float64{1, 1, 0}},
+	}, ""); err != nil {
+		t.Fatalf("SetManipulators: %v", err)
+	}
+	var got []ManipulatorDragged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e ManipulatorDragged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+
+	down := math.V3(0, 0, -1)
+	viewNormal := math.V3(0, 0, 1) // camera looking down -Z ⇒ plane normal +Z
+	if err := s.BeginManipulatorDrag("sim", "tip", viewNormal, math.P3(1, 1, 10), down, 0, false, false); err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := s.DragManipulator(math.P3(4, 2, 10), down, false, false); err != nil {
+		t.Fatalf("Drag: %v", err)
+	}
+	if err := s.EndManipulatorDrag(math.P3(4, 2, 10), down, false, false); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+	if len(got) != 3 || got[1].Position != [3]float64{4, 2, 0} {
+		t.Fatalf("events = %+v, want the handle at (4,2,0)", got)
+	}
+	// The final position bakes into the spec.
+	if h := s.Manipulators().Handles()["sim"][0]; h.Position != [3]float64{4, 2, 0} {
+		t.Errorf("baked position = %v, want (4,2,0)", h.Position)
+	}
+}
+
+func TestCommandBoundGizmosDieWithTool(t *testing.T) {
+	s := NewSession()
+	s.StartTool(FakeMiniToolbarTool{})
+	if err := s.ShowTriad(wire.TriadSpec{Visible: true, Command: "Sim.Move"}); err != nil {
+		t.Fatalf("ShowTriad: %v", err)
+	}
+	if err := s.SetManipulators("sim", []wire.ManipulatorHandleSpec{{ID: "tip"}}, "Sim.Move"); err != nil {
+		t.Fatalf("SetManipulators: %v", err)
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if s.TriadSpec().Visible {
+		t.Error("a command-bound triad must hide when the tool ends")
+	}
+	if len(s.Manipulators().Handles()) != 0 {
+		t.Error("command-bound manipulators must die with the tool")
+	}
+}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -69,6 +69,7 @@ func drawSingleViewport(win *native.Window, s *app.Session) {
 	cam, hovered := updateViewportCamera(s, pw, ph, hit.overCube)
 	list, sketchPlane, dims := viewportDrawList(s, cam, hovered)
 	list, gfxLabels := clientGraphicsOverlay(s, cam, list)
+	list = gizmoOverlays(s, cam, list)
 	renderViewportImage(win, s, 0, cam, list, pw, ph, cx, cy)
 	drawViewportOverlays(s, cam, sketchPlane, dims, gfxLabels, cx, cy, ph)
 	if s.ShowViewCube() {
@@ -304,9 +305,14 @@ func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Came
 	if overCube {
 		return cam, nil // the ViewCube owns the cursor this frame: no orbit, no pick
 	}
-	cam = ApplyNavigation(cam, readNavInput(isPlacingTool(s)))
+	gizmoActive := s.TriadDragging() || s.ManipulatorDragging()
+	cam = ApplyNavigation(cam, readNavInput(isPlacingTool(s) || gizmoActive))
 	s.SetCamera(cam)
-	handleViewportClick(s)
+	// The triad/manipulators own the pointer when hovered or mid-drag (M05-F13);
+	// picking and tool clicks stand down for the frame.
+	if !routeGizmoInput(s, cam) {
+		handleViewportClick(s)
+	}
 	return cam, hoveredPlane(s)
 }
 
@@ -388,6 +394,12 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	list.Items = append(list.Items, revolveCenterlineHighlight(s)...)
 	list.Items = append(list.Items, activeToolPreviewItems(s)...)
 	return list
+}
+
+// gizmoOverlays appends the triad and manipulator-handle geometry (M05-F13).
+func gizmoOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) renderer.DrawList {
+	list = triadOverlay(s, cam, list)
+	return manipulatorOverlay(s, cam, list)
 }
 
 // isPlacingTool reports whether the active tool consumes plane-point clicks (a sketch

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -105,6 +105,16 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		showPreferences = true
 	case "messaging": // M05-F09 surfaces: progress bar, balloon toast, prompt, messages
 		seedMessagingSurfaces(s)
+	case "triad": // M05-F13: the move/rotate triad over a solid, with a manipulator handle
+		ext := app.NewExtrudeTool()
+		s.StartTool(ext)
+		ext.Pick(s, profile)
+		ext.SetDistance(3)
+		_ = s.OK()
+		_ = s.ShowTriad(wire.TriadSpec{Position: [3]float64{2, 3, 1}, Visible: true})
+		_ = s.SetManipulators("demo", []wire.ManipulatorHandleSpec{
+			{ID: "tip", Position: [3]float64{0, 0, 2.5}, RadiusPx: 10},
+		}, "")
 	case "marking-menu": // M05-F12: the radial marking menu, opened as if right-clicked
 		ext := app.NewExtrudeTool()
 		s.StartTool(ext)

--- a/head/ui/triad_view.go
+++ b/head/ui/triad_view.go
@@ -1,0 +1,244 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/math"
+	"oblikovati.org/renderer"
+	"oblikovati.org/scene"
+)
+
+// The move/rotate triad and manipulator handles (M05-F13): the head renders the
+// session's gizmo state as on-top overlay geometry, hit-tests it in screen space,
+// and routes pointer rays to the session's drag math.
+
+// triadPixelLen is the axis length in pixels; rings sit at 3/4 of it, the plane
+// quads at ~1/3. gizmoHitPx is the screen-space grab radius.
+const (
+	triadPixelLen = 90
+	gizmoHitPx    = 9.0
+)
+
+// triadAxisColors is x/y/z in the conventional RGB.
+var triadAxisColors = [3][4]float32{{0.9, 0.2, 0.2, 1}, {0.2, 0.8, 0.2, 1}, {0.25, 0.45, 1, 1}}
+
+// triadOverlay appends the triad's geometry to the overlay list.
+func triadOverlay(s *app.Session, cam scene.Camera, list renderer.DrawList) renderer.DrawList {
+	spec := s.TriadSpec()
+	if !spec.Visible {
+		return list
+	}
+	worldLen := triadPixelLen * cam.WorldPerPixel()
+	pos := s.TriadPosition()
+	for i, axis := range triadWorldAxes(s) {
+		if seg := types.TriadSegment(uint8(types.TriadXAxis) + uint8(i)); s.TriadAllows(seg) {
+			list.Items = append(list.Items, gizmoLine(pos, pos.TranslateBy(axis.Scale(worldLen)), triadAxisColors[i]))
+		}
+		if seg := types.TriadSegment(uint8(types.TriadXRing) + uint8(i)); s.TriadAllows(seg) {
+			list.Items = append(list.Items, gizmoRing(pos, axis, worldLen*0.75, triadAxisColors[i]))
+		}
+	}
+	return list
+}
+
+// triadWorldAxes resolves the spec's axes as unit world vectors.
+func triadWorldAxes(s *app.Session) [3]math.Vector3 {
+	spec := s.TriadSpec()
+	axes := [3]math.Vector3{math.V3(1, 0, 0), math.V3(0, 1, 0), math.V3(0, 0, 1)}
+	for i, a := range []*[3]float64{spec.AxisX, spec.AxisY, spec.AxisZ} {
+		if a != nil {
+			axes[i] = math.V3(a[0], a[1], a[2])
+		}
+	}
+	return axes
+}
+
+// gizmoLine is one on-top axis line.
+func gizmoLine(a, b math.Point3, color [4]float32) renderer.DrawItem {
+	return renderer.DrawItem{
+		Primitive: renderer.Lines, Positions: []math.Point3{a, b},
+		Indices: []int{0, 1}, Color: color, OnTop: true,
+	}
+}
+
+// gizmoRing is a rotation ring: a 24-segment circle around axis at radius.
+func gizmoRing(center math.Point3, axis math.Vector3, radius float64, color [4]float32) renderer.DrawItem {
+	u, v := planeBasis(axis)
+	const segments = 24
+	pos := make([]math.Point3, segments)
+	idx := make([]int, 0, segments*2)
+	for i := 0; i < segments; i++ {
+		ang := 2 * stdmath.Pi * float64(i) / segments
+		offset := u.Scale(radius * stdmath.Cos(ang)).Add(v.Scale(radius * stdmath.Sin(ang)))
+		pos[i] = center.TranslateBy(offset)
+		idx = append(idx, i, (i+1)%segments)
+	}
+	return renderer.DrawItem{Primitive: renderer.Lines, Positions: pos, Indices: idx, Color: color, OnTop: true}
+}
+
+// planeBasis returns two unit vectors spanning the plane normal to axis.
+func planeBasis(axis math.Vector3) (math.Vector3, math.Vector3) {
+	ref := math.V3(0, 1, 0)
+	if stdmath.Abs(float64(axis.Dot(ref))) > 0.9 {
+		ref = math.V3(1, 0, 0)
+	}
+	u := axis.Cross(ref)
+	u = u.Scale(1 / float64(u.Length()))
+	return u, axis.Cross(u).Scale(-1)
+}
+
+// manipulatorOverlay appends every declared handle as a small on-top marker.
+func manipulatorOverlay(s *app.Session, cam scene.Camera, list renderer.DrawList) renderer.DrawList {
+	size := 5 * cam.WorldPerPixel()
+	for _, handles := range s.Manipulators().Handles() {
+		for _, h := range handles {
+			p := math.P3(h.Position[0], h.Position[1], h.Position[2])
+			list.Items = append(list.Items, gizmoMarker(p, cam, size))
+		}
+	}
+	return list
+}
+
+// gizmoMarker is a camera-facing quad outline marking a handle hotspot.
+func gizmoMarker(p math.Point3, cam scene.Camera, half float64) renderer.DrawItem {
+	forward := unitV(cam.Eye.VectorTo(cam.Target))
+	right := unitV(forward.Cross(cam.Up)).Scale(half)
+	up := unitV(right.Cross(forward)).Scale(half)
+	pos := []math.Point3{
+		p.TranslateBy(right.Add(up)), p.TranslateBy(right.Sub(up).Scale(1)),
+		p.TranslateBy(right.Scale(-1).Sub(up)), p.TranslateBy(up.Sub(right)),
+	}
+	return renderer.DrawItem{
+		Primitive: renderer.Lines, Positions: pos,
+		Indices: []int{0, 1, 1, 2, 2, 3, 3, 0}, Color: [4]float32{1, 0.8, 0.2, 1}, OnTop: true,
+	}
+}
+
+// unitV normalizes (zero-safe).
+func unitV(v math.Vector3) math.Vector3 {
+	l := float64(v.Length())
+	if l == 0 {
+		return v
+	}
+	return v.Scale(1 / l)
+}
+
+// routeGizmoInput drives the triad/manipulator gestures from the viewport pointer.
+// It reports whether the gizmo consumed the pointer this frame (the caller then
+// skips picking).
+func routeGizmoInput(s *app.Session, cam scene.Camera) bool {
+	if s.TriadDragging() || s.ManipulatorDragging() {
+		continueGizmoDrag(s, cam)
+		return true
+	}
+	if !native.IsItemHovered() {
+		return false
+	}
+	mx, my := viewportCursor()
+	if seg, hit := triadHitTest(s, cam, mx, my); hit {
+		s.HoverTriadSegment(seg, true)
+		if native.IsItemClicked(native.MouseLeft) {
+			rayO, rayD := cam.RayThrough(mx, my)
+			snapTol := gizmoHitPx * cam.WorldPerPixel()
+			_ = s.BeginTriadDrag(seg, rayO, rayD, snapTol, native.KeyShift(), native.KeyCtrl())
+		}
+		return true
+	}
+	s.HoverTriadSegment(types.TriadOrigin, false)
+	if gizmo, handle, hit := manipulatorHitTest(s, cam, mx, my); hit && native.IsItemClicked(native.MouseLeft) {
+		rayO, rayD := cam.RayThrough(mx, my)
+		forward := unitV(cam.Eye.VectorTo(cam.Target))
+		snapTol := gizmoHitPx * cam.WorldPerPixel()
+		_ = s.BeginManipulatorDrag(gizmo, handle, forward.Scale(-1), rayO, rayD, snapTol, native.KeyShift(), native.KeyCtrl())
+		return true
+	}
+	return false
+}
+
+// continueGizmoDrag advances or ends the in-flight gesture with the pointer ray.
+func continueGizmoDrag(s *app.Session, cam scene.Camera) {
+	mx, my := viewportCursor()
+	rayO, rayD := cam.RayThrough(mx, my)
+	shift, ctrl := native.KeyShift(), native.KeyCtrl()
+	if native.MouseDown(native.MouseLeft) {
+		if s.TriadDragging() {
+			_ = s.DragTriad(rayO, rayD, shift, ctrl)
+		} else {
+			_ = s.DragManipulator(rayO, rayD, shift, ctrl)
+		}
+		return
+	}
+	if s.TriadDragging() {
+		_ = s.EndTriadDrag(rayO, rayD, shift, ctrl)
+	} else {
+		_ = s.EndManipulatorDrag(rayO, rayD, shift, ctrl)
+	}
+}
+
+// triadHitTest finds the triad segment under the cursor in screen space.
+func triadHitTest(s *app.Session, cam scene.Camera, mx, my float64) (types.TriadSegment, bool) {
+	if !s.TriadSpec().Visible {
+		return 0, false
+	}
+	worldLen := triadPixelLen * cam.WorldPerPixel()
+	pos := s.TriadPosition()
+	axes := triadWorldAxes(s)
+	best, bestDist := types.TriadSegment(0), gizmoHitPx
+	found := false
+	probe := func(seg types.TriadSegment, p math.Point3) {
+		if !s.TriadAllows(seg) {
+			return
+		}
+		if d, ok := screenDistance(cam, p, mx, my); ok && d < bestDist {
+			best, bestDist, found = seg, d, true
+		}
+	}
+	for i, axis := range axes {
+		for _, t := range []float64{0.4, 0.7, 1.0} {
+			probe(types.TriadSegment(uint8(types.TriadXAxis)+uint8(i)), pos.TranslateBy(axis.Scale(worldLen*t)))
+		}
+		u, v := planeBasis(axis)
+		ringSeg := types.TriadSegment(uint8(types.TriadXRing) + uint8(i))
+		for k := 0; k < 16; k++ {
+			ang := 2 * stdmath.Pi * float64(k) / 16
+			offset := u.Scale(0.75 * worldLen * stdmath.Cos(ang)).Add(v.Scale(0.75 * worldLen * stdmath.Sin(ang)))
+			probe(ringSeg, pos.TranslateBy(offset))
+		}
+	}
+	probe(types.TriadOrigin, pos)
+	return best, found
+}
+
+// manipulatorHitTest finds the handle under the cursor.
+func manipulatorHitTest(s *app.Session, cam scene.Camera, mx, my float64) (string, string, bool) {
+	for gizmo, handles := range s.Manipulators().Handles() {
+		for _, h := range handles {
+			radius := h.RadiusPx
+			if radius <= 0 {
+				radius = gizmoHitPx
+			}
+			p := math.P3(h.Position[0], h.Position[1], h.Position[2])
+			if d, ok := screenDistance(cam, p, mx, my); ok && d <= radius {
+				return gizmo, h.ID, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// screenDistance projects p and returns its pixel distance to the cursor.
+func screenDistance(cam scene.Camera, p math.Point3, mx, my float64) (float64, bool) {
+	sx, sy, ok := renderer.Project(cam, viewportNear, viewportFar, p)
+	if !ok {
+		return 0, false
+	}
+	dx, dy := sx-mx, sy-my
+	return stdmath.Sqrt(dx*dx + dy*dy), true
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F13, closing #620 (contract: Oblikovati/Oblikovati.API#53):

- **Drag math in `app`, headless and unit-tested**: axis translation (two-line closest approach — the first test caught a sign regression), planar/free translation (ray–plane), ring rotation (atan2 about the axis, composed T·R·T⁻¹). Every phase emits the accumulated 4×4 delta + `DragContext`; translations snap to work points (point inference) and bake into the spec on end. Manipulator handles slide in their grab-time view plane with the same context.
- **Head**: on-top axis lines + rings (RGB), camera-facing handle markers; sampled screen-space hit-testing drives hover (`triad.segment`) and grabs; an in-flight gesture owns the pointer (navigation/picking stand down).
- **Router**: `triad.show/update/hide/get`, `manipulators.set/remove`; the relay forwards all three event streams. Command-bound gizmos die with the tool.

## Tests

Axis/planar/ring drag math, mask/visibility refusals, hover transitions, view-plane manipulator drags with baked positions, command-bound lifecycle; wire round-trips. Verified visually.

Closes #620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)