### PR TITLE
Route add-in help through the host and report the locale (M05-F14)

### DIFF
--- a/addin/router/help.go
+++ b/addin/router/help.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerHelpHandlers wires the help-routing and language methods (M05-F14, #621).
+func (r *Router) registerHelpHandlers() {
+	r.handlers[wire.MethodHelpRegisterContext] = registerHelpContext
+	r.handlers[wire.MethodHelpDisplay] = displayHelp
+	r.handlers[wire.MethodHelpPath] = helpPath
+	r.handlers[wire.MethodLanguageInfo] = languageInfo
+}
+
+func registerHelpContext(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.RegisterHelpContextArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.RegisterHelpContext(req.Source, req.Base); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func displayHelp(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.DisplayHelpArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.DisplayHelpTopic(req.Source, req.Topic); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+func helpPath(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.DisplayHelpArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	base, err := s.HelpPath(req.Source)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.HelpPathResult{Source: req.Source, Base: base})
+}
+
+func languageInfo(_ *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.LanguageInfoResult{Locale: app.Locale()})
+}

--- a/addin/router/help_test.go
+++ b/addin/router/help_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+func TestHelpOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "help.registerContext",
+		`{"source":"com.x.sim","base":"https://docs.example.org/sim/"}`, nil)
+	var p wire.HelpPathResult
+	call(t, r, s, "help.path", `{"source":"com.x.sim"}`, &p)
+	if p.Base != "https://docs.example.org/sim/" {
+		t.Fatalf("path = %+v, want the registered base", p)
+	}
+	// Display fails cleanly without an opener (the headless session has none).
+	if _, err := r.Handle(s, "help.display", []byte(`{"source":"com.x.sim","topic":"x"}`)); err == nil {
+		t.Error("display without an opener should fail, not vanish")
+	}
+
+	var li wire.LanguageInfoResult
+	call(t, r, s, "language.info", "{}", &li)
+	if li.Locale == "" {
+		t.Fatal("locale should never be empty")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -53,6 +53,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerWindowHandlers()
 	r.registerUIShellHandlers()
 	r.registerTriadHandlers()
+	r.registerHelpHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/app/help_router.go
+++ b/app/help_router.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Help routing (M05-F14, #621): add-ins register help sources (URL prefixes or
+// local directories) and open topics through the host, so their help behaves like
+// product help. An in-process interceptor may handle a request first (the
+// HelpEvents veto seam for first-party code); everything else resolves against the
+// source's base and opens via the platform URL opener.
+
+// defaultHelpBase is the host's own documentation, the "" source.
+const defaultHelpBase = "https://github.com/Oblikovati/Oblikovati/tree/develop/architecture"
+
+// HelpInterceptor may handle a help request before the host routes it: return
+// true to consume it (the OnHelp veto/override hook for in-process code).
+type HelpInterceptor func(source, topic string) bool
+
+// SetHelpInterceptor installs the before-help hook (nil removes it).
+func (s *Session) SetHelpInterceptor(fn HelpInterceptor) { s.helpInterceptor = fn }
+
+// RegisterHelpContext declares a help source. Base must be an http(s) URL prefix
+// or an absolute local directory.
+func (s *Session) RegisterHelpContext(source, base string) error {
+	if source == "" || base == "" {
+		return fmt.Errorf("app: help context needs source and base, got source=%q base=%q", source, base)
+	}
+	if !isHelpBase(base) {
+		return fmt.Errorf("app: help base %q is neither an http(s) URL nor an absolute path", base)
+	}
+	s.helpSources[source] = base
+	return nil
+}
+
+// HelpPath returns a source's base ("" resolves to the host documentation).
+func (s *Session) HelpPath(source string) (string, error) {
+	if source == "" {
+		return defaultHelpBase, nil
+	}
+	base, ok := s.helpSources[source]
+	if !ok {
+		return "", fmt.Errorf("app: no help source %q (register it first)", source)
+	}
+	return base, nil
+}
+
+// DisplayHelpTopic opens a topic of a registered source: the interceptor first,
+// then the resolved target through the platform opener. A local-file base opens
+// as a file:// URL via the same seam.
+func (s *Session) DisplayHelpTopic(source, topic string) error {
+	if s.helpInterceptor != nil && s.helpInterceptor(source, topic) {
+		return nil
+	}
+	base, err := s.HelpPath(source)
+	if err != nil {
+		return err
+	}
+	return s.openHelpTarget(base, topic)
+}
+
+// openHelpTarget resolves base+topic and routes it through the URL opener.
+func (s *Session) openHelpTarget(base, topic string) error {
+	target := base
+	if topic != "" {
+		target = strings.TrimRight(base, "/") + "/" + strings.TrimLeft(topic, "/")
+	}
+	if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
+		target = "file://" + target
+	}
+	if s.urlOpener == nil {
+		return fmt.Errorf("app: no URL opener configured to show help %q", target)
+	}
+	return s.urlOpener.OpenURL(target)
+}
+
+// isHelpBase accepts http(s) URLs and absolute paths.
+func isHelpBase(base string) bool {
+	return strings.HasPrefix(base, "http://") || strings.HasPrefix(base, "https://") ||
+		strings.HasPrefix(base, "/")
+}
+
+// Locale returns the host locale as a BCP-47 tag, derived from the process
+// environment (LC_ALL/LANG), falling back to en-US.
+func Locale() string {
+	for _, name := range []string{"LC_ALL", "LANG"} {
+		if raw := os.Getenv(name); raw != "" && raw != "C" && raw != "POSIX" {
+			return normalizeLocale(raw)
+		}
+	}
+	return "en-US"
+}
+
+// normalizeLocale turns "en_US.UTF-8" into "en-US".
+func normalizeLocale(raw string) string {
+	if i := strings.IndexAny(raw, ".@"); i >= 0 {
+		raw = raw[:i]
+	}
+	return strings.ReplaceAll(raw, "_", "-")
+}

--- a/app/help_router_test.go
+++ b/app/help_router_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+func TestHelpTopicResolvesThroughOpener(t *testing.T) {
+	s := NewSession()
+	opener := &FakeURLOpener{}
+	s.SetURLOpener(opener)
+	if err := s.RegisterHelpContext("com.x.sim", "https://docs.example.org/sim/"); err != nil {
+		t.Fatalf("RegisterHelpContext: %v", err)
+	}
+
+	if err := s.DisplayHelpTopic("com.x.sim", "mesh-setup"); err != nil {
+		t.Fatalf("DisplayHelpTopic: %v", err)
+	}
+	if len(opener.opened) != 1 || opener.opened[0] != "https://docs.example.org/sim/mesh-setup" {
+		t.Fatalf("opened = %v, want the joined topic URL", opener.opened)
+	}
+
+	// "" routes to the host documentation.
+	if err := s.DisplayHelpTopic("", ""); err != nil {
+		t.Fatalf("DisplayHelpTopic(host): %v", err)
+	}
+	if base, _ := s.HelpPath(""); opener.opened[1] != base {
+		t.Errorf("host help opened %q, want %q", opener.opened[1], base)
+	}
+
+	if err := s.DisplayHelpTopic("ghost", "x"); err == nil {
+		t.Error("an unregistered source should fail")
+	}
+	if err := s.RegisterHelpContext("bad", "not-a-base"); err == nil {
+		t.Error("a relative non-URL base should be rejected")
+	}
+}
+
+func TestHelpInterceptorConsumesFirst(t *testing.T) {
+	s := NewSession()
+	opener := &FakeURLOpener{}
+	s.SetURLOpener(opener)
+	var seen []string
+	s.SetHelpInterceptor(func(source, topic string) bool {
+		seen = append(seen, source+"/"+topic)
+		return source == "mine"
+	})
+	_ = s.RegisterHelpContext("mine", "https://example.org/")
+
+	if err := s.DisplayHelpTopic("mine", "a"); err != nil {
+		t.Fatalf("DisplayHelpTopic: %v", err)
+	}
+	if len(opener.opened) != 0 {
+		t.Error("the interceptor consumed the request; nothing should open")
+	}
+	if err := s.DisplayHelpTopic("", "b"); err != nil {
+		t.Fatalf("DisplayHelpTopic(passthrough): %v", err)
+	}
+	if len(opener.opened) != 1 || len(seen) != 2 {
+		t.Errorf("opened=%v seen=%v, want one open and two interceptor calls", opener.opened, seen)
+	}
+}
+
+func TestLocaleNormalizes(t *testing.T) {
+	t.Setenv("LC_ALL", "pt_BR.UTF-8")
+	if got := Locale(); got != "pt-BR" {
+		t.Errorf("Locale = %q, want pt-BR", got)
+	}
+	t.Setenv("LC_ALL", "C")
+	t.Setenv("LANG", "")
+	if got := Locale(); got != "en-US" {
+		t.Errorf("Locale fallback = %q, want en-US", got)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -70,6 +70,8 @@ type Session struct {
 	windowFrame        WindowFrameStatus                                // mirrored host-window state (M05-F10)
 	triad              TriadGizmo                                       // the move/rotate triad (M05-F13)
 	manipulators       *ManipulatorBoard                                // add-in drag handles (M05-F13)
+	helpSources        map[string]string                                // add-in help bases by source (M05-F14)
+	helpInterceptor    HelpInterceptor                                  // before-help veto hook (M05-F14)
 	markingMenus       map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
 	contextMenus       map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
 	objectVisibility   wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
@@ -167,6 +169,7 @@ func (s *Session) initShellSurfaces() {
 	s.objectVisibility = wire.ObjectVisibilityView{
 		WorkPlanes: true, WorkAxes: true, WorkPoints: true, Sketches: true,
 	}
+	s.helpSources = map[string]string{}
 }
 
 // AddIns returns the add-in registry (ApplicationAddIns).

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -70,6 +70,7 @@ void obk_ig_mouse_pos(float* x, float* y);
 int  obk_ig_key_shift(void);
 int  obk_ig_key_ctrl(void);
 int  obk_ig_escape_pressed(void);
+int  obk_ig_f1_pressed(void);
 int  obk_ig_undo_pressed(void);
 int  obk_ig_redo_pressed(void);
 int  obk_ig_want_text_input(void);
@@ -661,6 +662,9 @@ func KeyShift() bool { return C.obk_ig_key_shift() != 0 }
 func KeyCtrl() bool { return C.obk_ig_key_ctrl() != 0 }
 
 // EscapePressed reports whether Esc was pressed this frame (cancel the active tool).
+// F1Pressed fires once on the frame F1 is pressed — the host help shortcut (M05-F14).
+func F1Pressed() bool { return C.obk_ig_f1_pressed() != 0 }
+
 func EscapePressed() bool { return C.obk_ig_escape_pressed() != 0 }
 
 // UndoPressed / RedoPressed report whether the Z / Y key was pressed this frame (the

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -315,6 +315,7 @@ int  obk_ig_key_shift(void)                  { return ImGui::GetIO().KeyShift ? 
 int  obk_ig_key_ctrl(void)                   { return ImGui::GetIO().KeyCtrl ? 1 : 0; }
 // escape_pressed fires once on the frame Esc is pressed (cancel the active tool).
 int  obk_ig_escape_pressed(void)             { return ImGui::IsKeyPressed(ImGuiKey_Escape) ? 1 : 0; }
+int  obk_ig_f1_pressed(void)                 { return ImGui::IsKeyPressed(ImGuiKey_F1) ? 1 : 0; }
 // undo/redo_pressed fire once on the frame Z / Y is pressed; the Go side gates them on
 // Ctrl (and not WantTextInput) to form the global Ctrl+Z / Ctrl+Y shortcuts.
 int  obk_ig_undo_pressed(void)               { return ImGui::IsKeyPressed(ImGuiKey_Z) ? 1 : 0; }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -155,6 +155,9 @@ func handleKeyboard(s *app.Session) {
 	if native.EscapePressed() {
 		_ = s.PressKey(app.KeyEvent{Key: "Escape"})
 	}
+	if native.F1Pressed() { // F1 opens the host documentation (M05-F14)
+		_ = s.DisplayHelpTopic("", "")
+	}
 	if !native.KeyCtrl() || native.WantTextInput() {
 		return
 	}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F14, closing #621 (contract: Oblikovati/Oblikovati.API#54):

- `help.registerContext` (URL prefixes or absolute directories; anything else rejected loudly), `help.display` resolving topics through the **URL-opener seam** (local bases become `file://`), `help.path`, and an in-process `HelpInterceptor` as the before-help veto/override hook.
- `""` targets the host's own documentation — now bound to **F1** in the head.
- `language.info` reports the locale normalized from `LC_ALL`/`LANG` to BCP-47 (`en-US` fallback).
- No live backing exists for translation catalogs, startup-help-focus or quit exit-types — declined to the #160 ADR (Deactivate is the add-in lifecycle signal).

## Tests

Topic resolution + base validation + interceptor consumption + locale normalization in `app`; wire round-trips incl. the no-opener failure mode.

Closes #621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)