### PR TITLE
Let add-ins register and enter their own UI environments (M05-F16)

### DIFF
--- a/addin/router/ribbon.go
+++ b/addin/router/ribbon.go
@@ -82,13 +82,41 @@ func selectorInfo(sel *app.RibbonSelector) *wire.RibbonSelectorInfo {
 	return &wire.RibbonSelectorInfo{Options: options, SelectedIndex: sel.SelectedIndex}
 }
 
-// listEnvironments returns the UI environments the command framework scopes by,
-// flagging the active one (wire ui.listEnvironments; add-in environments: #667).
+// listEnvironments returns the UI environments the command framework scopes by —
+// the built-ins plus every registered add-in environment — flagging the active one
+// (wire ui.listEnvironments, M05-F12/F16).
 func listEnvironments(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	active := app.CurrentEnvironment(s)
 	envs := []wire.EnvironmentInfo{
 		{Environment: types.BaseEnvironment, Name: "Base", Active: active == types.BaseEnvironment},
 		{Environment: types.SketchEnvironment, Name: "Sketch", Active: active == types.SketchEnvironment},
 	}
+	for env, name := range s.AddInEnvironments() {
+		envs = append(envs, wire.EnvironmentInfo{Environment: env, Name: name, Active: active == env})
+	}
 	return json.Marshal(wire.ListEnvironmentsResult{Environments: envs})
+}
+
+// registerEnvironment declares an add-in environment (wire ui.registerEnvironment).
+func registerEnvironment(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.RegisterEnvironmentArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.RegisterEnvironment(req.Environment, req.Name); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// activateEnvironment enters/leaves an add-in environment (wire ui.activateEnvironment).
+func activateEnvironment(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ActivateEnvironmentArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.ActivateEnvironment(req.Environment); err != nil {
+		return nil, err
+	}
+	return ok()
 }

--- a/addin/router/ui_shell.go
+++ b/addin/router/ui_shell.go
@@ -18,6 +18,8 @@ func (r *Router) registerUIShellHandlers() {
 	r.handlers[wire.MethodUISetContextMenu] = setContextMenu
 	r.handlers[wire.MethodUIGetObjectVisibility] = getObjectVisibility
 	r.handlers[wire.MethodUISetObjectVisibility] = setObjectVisibility
+	r.handlers[wire.MethodUIRegisterEnvironment] = registerEnvironment
+	r.handlers[wire.MethodUIActivateEnvironment] = activateEnvironment
 }
 
 // searchCommands finds registered commands matching the query (wire ui.search).

--- a/addin/router/ui_shell_test.go
+++ b/addin/router/ui_shell_test.go
@@ -61,3 +61,26 @@ func TestUIContextMenuAndVisibilityOverWire(t *testing.T) {
 		t.Errorf("hidden planes still pickable (%d)", got)
 	}
 }
+
+func TestAddInEnvironmentsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "ui.registerEnvironment", `{"environment":7,"name":"Weldment"}`, nil)
+	call(t, r, s, "ui.activateEnvironment", `{"environment":7}`, nil)
+
+	var envs wire.ListEnvironmentsResult
+	call(t, r, s, "ui.listEnvironments", "{}", &envs)
+	foundActive := false
+	for _, e := range envs.Environments {
+		if e.Name == "Weldment" && e.Active {
+			foundActive = true
+		}
+	}
+	if !foundActive {
+		t.Fatalf("environments = %+v, want the active Weldment entry", envs.Environments)
+	}
+
+	call(t, r, s, "ui.activateEnvironment", `{"environment":0}`, nil)
+	if _, err := r.Handle(s, "ui.registerEnvironment", []byte(`{"environment":1,"name":"X"}`)); err == nil {
+		t.Error("the reserved sketch value must be rejected over the wire")
+	}
+}

--- a/app/ribbon_key.go
+++ b/app/ribbon_key.go
@@ -74,6 +74,9 @@ const (
 // the router can serve ui.listEnvironments from the same resolution the shell uses
 // (M05-F03, #247).
 func CurrentEnvironment(s *Session) Environment {
+	if s.activeAddInEnv != BaseEnvironment { // an entered add-in environment wins (M05-F16)
+		return s.activeAddInEnv
+	}
 	if s.InSketch() {
 		return SketchEnvironment
 	}

--- a/app/session.go
+++ b/app/session.go
@@ -74,6 +74,8 @@ type Session struct {
 	helpInterceptor      HelpInterceptor               // before-help veto hook (M05-F14)
 	documentSubTypes     map[string]DocumentSubType    // registered flavors (M05-F15)
 	documentSubTypeOrder []string
+	addinEnvironments    map[Environment]string                           // registered add-in environments (M05-F16)
+	activeAddInEnv       Environment                                      // the entered add-in environment (base when none)
 	markingMenus         map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
 	contextMenus         map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
 	objectVisibility     wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
@@ -173,6 +175,7 @@ func (s *Session) initShellSurfaces() {
 	}
 	s.helpSources = map[string]string{}
 	s.documentSubTypes = map[string]DocumentSubType{}
+	s.addinEnvironments = map[Environment]string{}
 }
 
 // AddIns returns the add-in registry (ApplicationAddIns).

--- a/app/ui_shell.go
+++ b/app/ui_shell.go
@@ -149,3 +149,52 @@ func (s *Session) ObjectVisibility() wire.ObjectVisibilityView { return s.object
 // SetObjectVisibility writes the toggles; hidden geometry also stops being
 // pickable (the accessors the overlays and pickers share consult these flags).
 func (s *Session) SetObjectVisibility(v wire.ObjectVisibilityView) { s.objectVisibility = v }
+
+// Add-in UI environments (M05-F16, #667): an add-in registers its own contextual
+// environment (values ≥ 2; the built-in base/sketch stay 0/1) and activates it;
+// commands registered with the value form its tabs, exactly like the sketch
+// environment. The active add-in environment overrides the sketch resolution.
+
+// RegisterEnvironment declares an add-in environment.
+func (s *Session) RegisterEnvironment(env Environment, name string) error {
+	if env <= SketchEnvironment {
+		return fmt.Errorf("app: environment %d is reserved (0 base, 1 sketch); add-in environments start at 2", env)
+	}
+	if name == "" {
+		return fmt.Errorf("app: environment %d needs a display name", env)
+	}
+	s.addinEnvironments[env] = name
+	return nil
+}
+
+// AddInEnvironments returns the registered add-in environments.
+func (s *Session) AddInEnvironments() map[Environment]string {
+	out := make(map[Environment]string, len(s.addinEnvironments))
+	for env, name := range s.addinEnvironments {
+		out[env] = name
+	}
+	return out
+}
+
+// ActivateEnvironment enters a registered add-in environment; BaseEnvironment
+// leaves it. The switch reaches observers as EnvironmentChanged.
+func (s *Session) ActivateEnvironment(env Environment) error {
+	if env == BaseEnvironment {
+		if s.activeAddInEnv != BaseEnvironment {
+			s.activeAddInEnv = BaseEnvironment
+			event.Emit(s.bus, event.After, EnvironmentChanged{Environment: CurrentEnvironment(s)})
+		}
+		return nil
+	}
+	if _, ok := s.addinEnvironments[env]; !ok {
+		return fmt.Errorf("app: environment %d is not registered", env)
+	}
+	if s.activeAddInEnv != env {
+		s.activeAddInEnv = env
+		event.Emit(s.bus, event.After, EnvironmentChanged{Environment: env})
+	}
+	return nil
+}
+
+// ActiveAddInEnvironment returns the active add-in environment (base when none).
+func (s *Session) ActiveAddInEnvironment() Environment { return s.activeAddInEnv }

--- a/app/ui_shell_test.go
+++ b/app/ui_shell_test.go
@@ -135,3 +135,46 @@ func TestEnterExitSketchEmitsEnvironmentChanged(t *testing.T) {
 		t.Fatalf("events = %+v, want sketch then base", got)
 	}
 }
+
+func TestAddInEnvironmentLifecycle(t *testing.T) {
+	s := NewSession()
+	var changes []EnvironmentChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e EnvironmentChanged) event.Outcome {
+		changes = append(changes, e)
+		return event.Continue()
+	})
+
+	if err := s.RegisterEnvironment(SketchEnvironment, "Bad"); err == nil {
+		t.Error("the reserved values must be rejected")
+	}
+	if err := s.RegisterEnvironment(7, "Weldment"); err != nil {
+		t.Fatalf("RegisterEnvironment: %v", err)
+	}
+	if err := s.ActivateEnvironment(9); err == nil {
+		t.Error("an unregistered environment must refuse activation")
+	}
+
+	noop := func(*Session) error { return nil }
+	_ = s.Commands().Add(NewCommand("Weld.Bead", "Weld Bead", "Weld", noop).
+		WithTab("Weldment").WithEnvironment(7).WithRibbons(ZeroDocRibbon))
+
+	if err := s.ActivateEnvironment(7); err != nil {
+		t.Fatalf("ActivateEnvironment: %v", err)
+	}
+	if CurrentEnvironment(s) != 7 {
+		t.Fatalf("CurrentEnvironment = %v, want the weldment environment", CurrentEnvironment(s))
+	}
+	if _, ok := BuildRibbon(s).Tab("Weldment"); !ok {
+		t.Error("the entered environment's contextual tab should appear on the ribbon")
+	}
+
+	if err := s.ActivateEnvironment(BaseEnvironment); err != nil {
+		t.Fatalf("ActivateEnvironment(base): %v", err)
+	}
+	if _, ok := BuildRibbon(s).Tab("Weldment"); ok {
+		t.Error("leaving the environment should remove its tab")
+	}
+	if len(changes) != 2 || changes[0].Environment != 7 || changes[1].Environment != BaseEnvironment {
+		t.Fatalf("events = %+v, want enter then leave", changes)
+	}
+}


### PR DESCRIPTION
## What

The GPL implementation half of M05-F16, closing #667 (contract: Oblikovati/Oblikovati.API#56):

- `ui.registerEnvironment` opens `types.Environment` values ≥ 2 as an add-in registry (reserved 0/1 rejected loudly); `ui.activateEnvironment` enters/leaves.
- `CurrentEnvironment` resolves an entered add-in environment ahead of the sketch state, so commands created with the value form contextual ribbon tabs **exactly like the Sketch tab** — proven by a test that watches a Weldment tab appear and disappear.
- Switches emit the existing `ui.environmentChanged`; `ui.listEnvironments` includes the registry.
- The audit's remaining items (CommandBarList, native-node overrides, browser drag-drop) are declined with rationale on the #160 won't-implement ADR issue.

Closes #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)