### PR TITLE
Make the Sonar exclusions reach automatic analysis; root-anchor SPDX writes

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,6 @@
-# SonarCloud automatic-analysis configuration.
+# SonarCloud automatic-analysis configuration (AutoScan reads .sonarcloud.properties;
+# a sonar-project.properties is only read by CI-based scanners, which this repo
+# does not run).
 #
 # Vendored third-party sources are excluded: Dear ImGui (head/third_party) is
 # upstream code we do not patch (the wrapper rule in CLAUDE.md), so its strlen/

--- a/scripts/add-spdx-headers.py
+++ b/scripts/add-spdx-headers.py
@@ -63,12 +63,12 @@ def go_files() -> list[Path]:
 
 
 def inside_root(path: Path) -> Path:
-    """Resolve path and refuse anything that escapes the repository root — a
-    symlinked .go file pointing outside the repo must never be rewritten."""
-    resolved = path.resolve()
-    if not resolved.is_relative_to(ROOT):
-        raise ValueError(f"refusing to touch {resolved}: outside the repository root {ROOT}")
-    return resolved
+    """Re-anchor path under the repository root, refusing anything that escapes
+    it — a symlinked .go file pointing outside the repo must never be rewritten.
+    The returned path is constructed from ROOT plus the validated relative part,
+    so every later read/write is provably root-anchored (S2083)."""
+    relative = path.resolve().relative_to(ROOT)  # raises ValueError outside ROOT
+    return ROOT.joinpath(relative)
 
 
 def main() -> int:


### PR DESCRIPTION
## What

Follow-up to #679 for the two findings that survived the develop re-analysis:

- **Vendored ImGui findings (6 hotspots + 1 blocker)**: the exclusion shipped in `sonar-project.properties`, which only CI-based scanners read. SonarCloud **automatic analysis reads `.sonarcloud.properties`** — renamed, same content.
- **`add-spdx-headers.py` path injection (S2083)**: the write target is now *constructed* from `ROOT / relative` after `relative_to` validation (which raises outside the root), not merely checked — the flow Sonar's taint engine recognizes as root-anchored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)