### PR TITLE
Bind the kernel's transient geometry to the public contract (M01-F05)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -12,6 +12,7 @@ package events
 import (
 	"encoding/json"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/event"
@@ -139,7 +140,7 @@ func subscribeGizmos(bus *event.Bus, sink Sink) []event.Subscription {
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.TriadDragged) event.Outcome {
 			return relayJSON(sink, wire.TriadDragEvent{
 				Type: wire.EventTriadDrag, Phase: e.Phase, Segment: e.Segment,
-				MoveType: e.MoveType, Delta: e.Delta, Context: e.Context,
+				MoveType: e.MoveType, Delta: types.Matrix{Cells: e.Delta}, Context: e.Context,
 			})
 		}),
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.TriadSegmentChanged) event.Outcome {

--- a/addin/router/camera.go
+++ b/addin/router/camera.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	stdmath "math"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
@@ -43,9 +44,9 @@ func setCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	cam.Eye = math.P3(a.Eye[0], a.Eye[1], a.Eye[2])
-	cam.Target = math.P3(a.Target[0], a.Target[1], a.Target[2])
-	cam.Up = math.V3(a.Up[0], a.Up[1], a.Up[2])
+	cam.Eye = math.P3(a.Eye.X, a.Eye.Y, a.Eye.Z)
+	cam.Target = math.P3(a.Target.X, a.Target.Y, a.Target.Z)
+	cam.Up = math.V3(a.Up.X, a.Up.Y, a.Up.Z)
 	cam.FOV = a.FOV
 	if err := s.SetViewCamera(a.Document, cam); err != nil {
 		return nil, err
@@ -60,9 +61,9 @@ func setCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 // cameraView projects a scene.Camera onto the wire look-at DTO.
 func cameraView(c scene.Camera) wire.CameraView {
 	return wire.CameraView{
-		Eye:    [3]float64{c.Eye.X, c.Eye.Y, c.Eye.Z},
-		Target: [3]float64{c.Target.X, c.Target.Y, c.Target.Z},
-		Up:     [3]float64{c.Up.X, c.Up.Y, c.Up.Z},
+		Eye:    types.Point{X: c.Eye.X, Y: c.Eye.Y, Z: c.Eye.Z},
+		Target: types.Point{X: c.Target.X, Y: c.Target.Y, Z: c.Target.Z},
+		Up:     types.Vector{X: c.Up.X, Y: c.Up.Y, Z: c.Up.Z},
 		FOV:    c.FOV,
 	}
 }
@@ -71,7 +72,7 @@ func cameraView(c scene.Camera) wire.CameraView {
 // non-finite component, a non-positive or ≥π field of view, a zero eye→target distance,
 // a zero-length up vector, or an up parallel to the view direction.
 func validateCameraArgs(a wire.SetCameraArgs) error {
-	for _, v := range []float64{a.Eye[0], a.Eye[1], a.Eye[2], a.Target[0], a.Target[1], a.Target[2], a.Up[0], a.Up[1], a.Up[2], a.FOV} {
+	for _, v := range []float64{a.Eye.X, a.Eye.Y, a.Eye.Z, a.Target.X, a.Target.Y, a.Target.Z, a.Up.X, a.Up.Y, a.Up.Z, a.FOV} {
 		if stdmath.IsNaN(v) || stdmath.IsInf(v, 0) {
 			return fmt.Errorf("view.setCamera: non-finite camera component in %+v", a)
 		}
@@ -79,9 +80,9 @@ func validateCameraArgs(a wire.SetCameraArgs) error {
 	if a.FOV <= 0 || a.FOV >= stdmath.Pi {
 		return fmt.Errorf("view.setCamera: fov %v out of range (expected 0 < fov < π)", a.FOV)
 	}
-	eye := math.P3(a.Eye[0], a.Eye[1], a.Eye[2])
-	target := math.P3(a.Target[0], a.Target[1], a.Target[2])
-	up := math.V3(a.Up[0], a.Up[1], a.Up[2])
+	eye := math.P3(a.Eye.X, a.Eye.Y, a.Eye.Z)
+	target := math.P3(a.Target.X, a.Target.Y, a.Target.Z)
+	up := math.V3(a.Up.X, a.Up.Y, a.Up.Z)
 	const eps = 1e-9
 	if eye.DistanceTo(target) < eps {
 		return fmt.Errorf("view.setCamera: eye and target coincide at %v", a.Eye)

--- a/addin/router/camera_test.go
+++ b/addin/router/camera_test.go
@@ -5,6 +5,7 @@ package router
 import (
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 )
 
@@ -16,7 +17,7 @@ func TestCameraRoundTrips(t *testing.T) {
 
 	var set wire.CameraView
 	call(t, r, s, "view.setCamera", args, &set)
-	if set.Eye != [3]float64{10, 20, 30} || set.Target != [3]float64{1, 2, 3} || set.FOV != 0.8 {
+	if set.Eye != types.NewPoint(10, 20, 30) || set.Target != types.NewPoint(1, 2, 3) || set.FOV != 0.8 {
 		t.Fatalf("setCamera = %+v, want eye=[10 20 30] target=[1 2 3] fov=0.8", set)
 	}
 

--- a/addin/router/lighting.go
+++ b/addin/router/lighting.go
@@ -177,8 +177,8 @@ func lightInfo(index int, l renderer.SceneLight) wire.LightInfo {
 		On:                  l.On,
 		Color:               types.Rgba{R: l.Color[0], G: l.Color[1], B: l.Color[2], A: 1},
 		Intensity:           float64(l.Intensity),
-		Direction:           vec64(l.Direction),
-		Position:            vec64(l.Position),
+		Direction:           pointVec(l.Direction),
+		Position:            pointPos(l.Position),
 		SpotInnerAngle:      float64(l.SpotInner),
 		SpotOuterAngle:      float64(l.SpotOuter),
 		Attenuation:         vec64(l.Attenuation),
@@ -189,8 +189,8 @@ func lightInfo(index int, l renderer.SceneLight) wire.LightInfo {
 func sceneLight(in wire.LightInfo) renderer.SceneLight {
 	return renderer.SceneLight{
 		Kind:        app.LightKindForDefinition(in.LightDefinitionType),
-		Direction:   vec32(in.Direction),
-		Position:    vec32(in.Position),
+		Direction:   [3]float32{float32(in.Direction.X), float32(in.Direction.Y), float32(in.Direction.Z)},
+		Position:    [3]float32{float32(in.Position.X), float32(in.Position.Y), float32(in.Position.Z)},
 		Color:       [3]float32{in.Color.R, in.Color.G, in.Color.B},
 		Intensity:   float32(in.Intensity),
 		On:          in.On,
@@ -240,5 +240,15 @@ func environmentView(e renderer.Environment) wire.EnvironmentView {
 }
 
 func vec64(v [3]float32) [3]float64 { return [3]float64{float64(v[0]), float64(v[1]), float64(v[2])} }
+
+// pointVec / pointPos lift the renderer's float32 triples into the typed wire
+// geometry (M01-F05).
+func pointVec(v [3]float32) types.Vector {
+	return types.Vector{X: float64(v[0]), Y: float64(v[1]), Z: float64(v[2])}
+}
+
+func pointPos(v [3]float32) types.Point {
+	return types.Point{X: float64(v[0]), Y: float64(v[1]), Z: float64(v[2])}
+}
 
 func vec32(v [3]float64) [3]float32 { return [3]float32{float32(v[0]), float32(v[1]), float32(v[2])} }

--- a/addin/router/lighting_test.go
+++ b/addin/router/lighting_test.go
@@ -69,10 +69,10 @@ func TestLightRoundTrips(t *testing.T) {
 
 	added.Intensity = 2.5
 	added.Color = types.Rgba{R: 0.2, G: 0.4, B: 0.8, A: 1}
-	added.Position = [3]float64{1, 2, 3}
+	added.Position = types.NewPoint(1, 2, 3)
 	var set wire.LightInfo
 	call(t, r, s, "lighting.setLight", argJSON(t, wire.SetLightArgs{Index: added.Index, Light: added}), &set)
-	if set.Intensity != 2.5 || set.Color.B != 0.8 || set.Position != [3]float64{1, 2, 3} {
+	if set.Intensity != 2.5 || set.Color.B != 0.8 || set.Position != types.NewPoint(1, 2, 3) {
 		t.Errorf("setLight did not round-trip: %+v", set)
 	}
 

--- a/addin/router/minitoolbar_test.go
+++ b/addin/router/minitoolbar_test.go
@@ -15,7 +15,7 @@ func TestMiniToolbarOverWire(t *testing.T) {
 
 	var lst wire.ListMiniToolbarsResult
 	call(t, r, s, "miniToolbar.list", "{}", &lst)
-	if len(lst.Toolbars) != 1 || lst.Toolbars[0].Anchor == nil || lst.Toolbars[0].Anchor[2] != 3 {
+	if len(lst.Toolbars) != 1 || lst.Toolbars[0].Anchor == nil || lst.Toolbars[0].Anchor.Z != 3 {
 		t.Fatalf("list = %+v, want the anchored toolbar", lst.Toolbars)
 	}
 

--- a/addin/router/triad_test.go
+++ b/addin/router/triad_test.go
@@ -14,7 +14,7 @@ func TestTriadOverWire(t *testing.T) {
 	call(t, r, s, "triad.show", `{"triad":{"position":[1,2,3],"allowed":[1,9]}}`, nil)
 	var spec wire.TriadSpec
 	call(t, r, s, "triad.get", "{}", &spec)
-	if !spec.Visible || spec.Position[2] != 3 || len(spec.Allowed) != 2 {
+	if !spec.Visible || spec.Position.Z != 3 || len(spec.Allowed) != 2 {
 		t.Fatalf("triad = %+v, want visible at (1,2,3) with two allowed segments", spec)
 	}
 	if !s.TriadAllows(types.TriadXAxis) || s.TriadAllows(types.TriadYAxis) {

--- a/addin/router/views.go
+++ b/addin/router/views.go
@@ -5,6 +5,7 @@ package router
 import (
 	"encoding/json"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/doc"
@@ -137,9 +138,9 @@ func viewInfo(i int, v *doc.View, active bool) wire.ViewInfo {
 		Name:   v.Name,
 		Active: active,
 		Camera: wire.CameraView{
-			Eye:    [3]float64{v.Eye.X, v.Eye.Y, v.Eye.Z},
-			Target: [3]float64{v.Target.X, v.Target.Y, v.Target.Z},
-			Up:     [3]float64{v.Up.X, v.Up.Y, v.Up.Z},
+			Eye:    types.Point{X: v.Eye.X, Y: v.Eye.Y, Z: v.Eye.Z},
+			Target: types.Point{X: v.Target.X, Y: v.Target.Y, Z: v.Target.Z},
+			Up:     types.Vector{X: v.Up.X, Y: v.Up.Y, Z: v.Up.Z},
 			FOV:    v.FOV,
 		},
 	}

--- a/addin/router/views_test.go
+++ b/addin/router/views_test.go
@@ -71,7 +71,7 @@ func TestCameraReflectedInActiveViewListing(t *testing.T) {
 	var list wire.ListViewsResult
 	call(t, r, s, "views.list", "{}", &list)
 	got := list.Views[list.ActiveIndex].Camera
-	if got.Eye != [3]float64{9, 8, 7} || got.Target != [3]float64{1, 2, 3} {
+	if got.Eye != types.NewPoint(9, 8, 7) || got.Target != types.NewPoint(1, 2, 3) {
 		t.Fatalf("active view camera = %+v, want eye[9 8 7] target[1 2 3]", got)
 	}
 }

--- a/app/manipulators.go
+++ b/app/manipulators.go
@@ -21,7 +21,7 @@ type ManipulatorDragged struct {
 	Gizmo    string
 	Handle   string
 	Phase    string
-	Position [3]float64
+	Position types.Point
 	Context  wire.DragContext
 }
 
@@ -106,7 +106,7 @@ func (s *Session) BeginManipulatorDrag(gizmo, handle string, viewNormal math.Vec
 	if err != nil {
 		return err
 	}
-	start := math.P3(spec.Position[0], spec.Position[1], spec.Position[2])
+	start := math.P3(spec.Position.X, spec.Position.Y, spec.Position.Z)
 	s.manipulators.drag = &manipulatorDrag{
 		gizmo: gizmo, handle: handle, start: start,
 		normal: unitOrZero(viewNormal), snapTol: snapTol,
@@ -154,7 +154,7 @@ func (s *Session) EndManipulatorDrag(rayO math.Point3, rayD math.Vector3, shift,
 func (s *Session) ManipulatorDragging() bool { return s.manipulators.drag != nil }
 
 // manipulatorPosition resolves the dragged position with point inference.
-func (s *Session) manipulatorPosition(d *manipulatorDrag, rayO math.Point3, rayD math.Vector3) ([3]float64, types.PointInferenceKind) {
+func (s *Session) manipulatorPosition(d *manipulatorDrag, rayO math.Point3, rayD math.Vector3) (types.Point, types.PointInferenceKind) {
 	hit, ok := rayPlane(rayO, rayD, d.start, d.normal)
 	if !ok {
 		hit = d.start
@@ -165,7 +165,7 @@ func (s *Session) manipulatorPosition(d *manipulatorDrag, rayO math.Point3, rayD
 			hit, inference = snapped, types.InferencePoint
 		}
 	}
-	return [3]float64{float64(hit.X), float64(hit.Y), float64(hit.Z)}, inference
+	return types.Point{X: float64(hit.X), Y: float64(hit.Y), Z: float64(hit.Z)}, inference
 }
 
 // nearestWorkPoint finds a work point within tol of p.
@@ -199,7 +199,7 @@ func (s *Session) manipulatorHandle(gizmo, handle string) (wire.ManipulatorHandl
 }
 
 // bakeHandlePosition writes the dragged position back into the stored spec.
-func (s *Session) bakeHandlePosition(gizmo, handle string, pos [3]float64) {
+func (s *Session) bakeHandlePosition(gizmo, handle string, pos types.Point) {
 	g := s.manipulators.gizmos[gizmo]
 	for i := range g.handles {
 		if g.handles[i].ID == handle {

--- a/app/triad.go
+++ b/app/triad.go
@@ -112,13 +112,13 @@ func (s *Session) HoverTriadSegment(seg types.TriadSegment, hovered bool) {
 func (s *Session) triadAxes() (x, y, z math.Vector3) {
 	x, y, z = math.V3(1, 0, 0), math.V3(0, 1, 0), math.V3(0, 0, 1)
 	if a := s.triad.spec.AxisX; a != nil {
-		x = math.V3(a[0], a[1], a[2])
+		x = math.V3(a.X, a.Y, a.Z)
 	}
 	if a := s.triad.spec.AxisY; a != nil {
-		y = math.V3(a[0], a[1], a[2])
+		y = math.V3(a.X, a.Y, a.Z)
 	}
 	if a := s.triad.spec.AxisZ; a != nil {
-		z = math.V3(a[0], a[1], a[2])
+		z = math.V3(a.X, a.Y, a.Z)
 	}
 	return x, y, z
 }
@@ -126,7 +126,7 @@ func (s *Session) triadAxes() (x, y, z math.Vector3) {
 // TriadPosition returns the triad's position as a point.
 func (s *Session) TriadPosition() math.Point3 {
 	p := s.triad.spec.Position
-	return math.P3(p[0], p[1], p[2])
+	return math.P3(p.X, p.Y, p.Z)
 }
 
 // segmentConstraint resolves a segment to its motion constraint: the move type,
@@ -282,7 +282,7 @@ func (s *Session) EndTriadDrag(rayO math.Point3, rayD math.Vector3, shift, ctrl 
 	s.triad.drag = nil
 	if d.moveType != types.TriadRotate {
 		landed := d.origin.TranslateBy(math.V3(d.delta[3], d.delta[7], d.delta[11]))
-		s.triad.spec.Position = [3]float64{float64(landed.X), float64(landed.Y), float64(landed.Z)}
+		s.triad.spec.Position = types.Point{X: float64(landed.X), Y: float64(landed.Y), Z: float64(landed.Z)}
 	}
 	event.Emit(s.bus, event.After, TriadDragged{
 		Phase: DragEnd, Segment: d.segment, MoveType: d.moveType, Delta: d.delta,
@@ -298,9 +298,9 @@ func (s *Session) TriadDragging() bool { return s.triad.drag != nil }
 // dragContext assembles the wire context for an event.
 func dragContext(start math.Point3, rayO math.Point3, rayD math.Vector3, shift, ctrl bool, inf types.PointInferenceKind) wire.DragContext {
 	return wire.DragContext{
-		Start:     [3]float64{float64(start.X), float64(start.Y), float64(start.Z)},
-		RayOrigin: [3]float64{float64(rayO.X), float64(rayO.Y), float64(rayO.Z)},
-		RayDir:    [3]float64{float64(rayD.X), float64(rayD.Y), float64(rayD.Z)},
+		Start:     types.Point{X: float64(start.X), Y: float64(start.Y), Z: float64(start.Z)},
+		RayOrigin: types.Point{X: float64(rayO.X), Y: float64(rayO.Y), Z: float64(rayO.Z)},
+		RayDir:    types.Vector{X: float64(rayD.X), Y: float64(rayD.Y), Z: float64(rayD.Z)},
 		Shift:     shift, Ctrl: ctrl, Inference: inf,
 	}
 }

--- a/app/triad_test.go
+++ b/app/triad_test.go
@@ -24,7 +24,7 @@ func triadEventLog(s *Session) *[]TriadDragged {
 
 func TestTriadAxisDragTranslatesAlongX(t *testing.T) {
 	s := NewSession()
-	if err := s.ShowTriad(wire.TriadSpec{Position: [3]float64{0, 0, 0}, Visible: true}); err != nil {
+	if err := s.ShowTriad(wire.TriadSpec{Position: types.NewPoint(0, 0, 0), Visible: true}); err != nil {
 		t.Fatalf("ShowTriad: %v", err)
 	}
 	got := triadEventLog(s)
@@ -54,14 +54,14 @@ func TestTriadAxisDragTranslatesAlongX(t *testing.T) {
 	if dy, dz := move.Delta[7], move.Delta[11]; dy != 0 || dz != 0 {
 		t.Errorf("off-axis translation (%v, %v), want the X constraint to hold", dy, dz)
 	}
-	if pos := s.TriadSpec().Position; stdmath.Abs(pos[0]-3) > 1e-6 {
-		t.Errorf("triad landed at x=%v, want 3 (the delta baked in)", pos[0])
+	if pos := s.TriadSpec().Position; stdmath.Abs(pos.X-3) > 1e-6 {
+		t.Errorf("triad landed at x=%v, want 3 (the delta baked in)", pos.X)
 	}
 }
 
 func TestTriadRingDragRotatesAboutZ(t *testing.T) {
 	s := NewSession()
-	if err := s.ShowTriad(wire.TriadSpec{Position: [3]float64{0, 0, 0}, Visible: true}); err != nil {
+	if err := s.ShowTriad(wire.TriadSpec{Position: types.NewPoint(0, 0, 0), Visible: true}); err != nil {
 		t.Fatalf("ShowTriad: %v", err)
 	}
 	got := triadEventLog(s)
@@ -87,7 +87,7 @@ func TestTriadRingDragRotatesAboutZ(t *testing.T) {
 
 func TestTriadPlanarDragStaysInPlane(t *testing.T) {
 	s := NewSession()
-	if err := s.ShowTriad(wire.TriadSpec{Position: [3]float64{0, 0, 0}, Visible: true}); err != nil {
+	if err := s.ShowTriad(wire.TriadSpec{Position: types.NewPoint(0, 0, 0), Visible: true}); err != nil {
 		t.Fatalf("ShowTriad: %v", err)
 	}
 	got := triadEventLog(s)
@@ -143,7 +143,7 @@ func TestTriadSegmentHoverEmitsOnTransition(t *testing.T) {
 func TestManipulatorDragSlidesInViewPlane(t *testing.T) {
 	s := NewSession()
 	if err := s.SetManipulators("sim", []wire.ManipulatorHandleSpec{
-		{ID: "tip", Position: [3]float64{1, 1, 0}},
+		{ID: "tip", Position: types.NewPoint(1, 1, 0)},
 	}, ""); err != nil {
 		t.Fatalf("SetManipulators: %v", err)
 	}
@@ -164,11 +164,11 @@ func TestManipulatorDragSlidesInViewPlane(t *testing.T) {
 	if err := s.EndManipulatorDrag(math.P3(4, 2, 10), down, false, false); err != nil {
 		t.Fatalf("End: %v", err)
 	}
-	if len(got) != 3 || got[1].Position != [3]float64{4, 2, 0} {
+	if len(got) != 3 || got[1].Position != types.NewPoint(4, 2, 0) {
 		t.Fatalf("events = %+v, want the handle at (4,2,0)", got)
 	}
 	// The final position bakes into the spec.
-	if h := s.Manipulators().Handles()["sim"][0]; h.Position != [3]float64{4, 2, 0} {
+	if h := s.Manipulators().Handles()["sim"][0]; h.Position != types.NewPoint(4, 2, 0) {
 		t.Errorf("baked position = %v, want (4,2,0)", h.Position)
 	}
 }

--- a/architecture/decisions/ADR-0018-apache-api-contract-module.md
+++ b/architecture/decisions/ADR-0018-apache-api-contract-module.md
@@ -89,3 +89,31 @@ api/  (Apache-2.0, oblikovati.org/api)
 source/  (GPL-2.0)  requires + implements api; serves api/wire via addin/router
 add-in/  (vendor-licensed)  imports only api/{types,wire,client}
 ```
+
+## Addendum (2026-06): transient geometry — in-process values, wire DTO encoding
+
+M01-F05 (#602) put the transient-geometry vocabulary on the public surface. These
+values are ownerless, immutable, and created in huge volume (every point of every
+stroke of every preview), so round-tripping construction and evaluation over the
+C ABI would be the wrong transport. The split:
+
+- **Value types live IN `api/types`, with their math** (`Point`/`Point2d`,
+  `Vector`/`Vector2d`, `UnitVector`/`UnitVector2d`, `Matrix`/`Matrix2d`, the
+  boxes, the B-spline definition recipes). They are pure data + pure functions —
+  Apache-2.0, no host state — so an add-in computes locally at zero wire cost.
+  This is the one place the contract module carries *implementation*, justified
+  exactly because the implementation is closed-form math with no host coupling.
+- **Wire encoding is the same types.** Their JSON form is fixed-length arrays
+  (`[x,y,z]`, 9/16 matrix cells), byte-compatible with the ad-hoc
+  `[3]float64`/`[16]float64` fields that predated them; payloads that carry
+  geometry use them directly (camera, lighting, gizmos, anchors).
+- **Curves/surfaces are contracts, not values.** Construction validates and
+  evaluation runs against the kernel, so `api/contract` defines the interfaces
+  (umbrella `Curve`/`Curve2d`/`Surface`, per-kind interfaces, the single
+  `TransientGeometry` factory) and `/source/kernel/geomapi` implements them as
+  thin adapters over `kernel/geom` — the kernel itself stays free of API
+  conversions. Kind discriminators are frozen to the reference enum values.
+- The kernel keeps its own `math` package (`Scalar`-based) as the private
+  computation vocabulary; `geomapi` converts at the boundary. Aliasing the two
+  was rejected: it would couple every kernel file to the contract module for no
+  behavioral gain.

--- a/head/ui/extrude_panel_visual_test.go
+++ b/head/ui/extrude_panel_visual_test.go
@@ -111,9 +111,9 @@ func startVisualFeatureTool(s *app.Session, profile app.ProfileHandle) {
 		ext.Pick(s, profile)
 		ext.SetDistance(3)
 		_ = s.OK()
-		_ = s.ShowTriad(wire.TriadSpec{Position: [3]float64{2, 3, 1}, Visible: true})
+		_ = s.ShowTriad(wire.TriadSpec{Position: types.NewPoint(2, 3, 1), Visible: true})
 		_ = s.SetManipulators("demo", []wire.ManipulatorHandleSpec{
-			{ID: "tip", Position: [3]float64{0, 0, 2.5}, RadiusPx: 10},
+			{ID: "tip", Position: types.NewPoint(0, 0, 2.5), RadiusPx: 10},
 		}, "")
 	case "marking-menu": // M05-F12: the radial marking menu, opened as if right-clicked
 		ext := app.NewExtrudeTool()
@@ -198,7 +198,7 @@ func seedMessagingSurfaces(s *app.Session) {
 
 // seedMiniToolbar declares an anchored mini-toolbar the way a command would (M05-F07).
 func seedMiniToolbar(s *app.Session) {
-	anchor := [3]float64{2, 3, 2.5}
+	anchor := types.NewPoint(2, 3, 2.5)
 	_ = s.SetMiniToolbar(wire.MiniToolbarSpec{
 		ID: "demo.probe", Visible: true, HeadsUpText: "Probe depth", Anchor: &anchor,
 		ShowOK: true, ShowApply: true, ShowCancel: true,

--- a/head/ui/minitoolbar_view.go
+++ b/head/ui/minitoolbar_view.go
@@ -65,7 +65,7 @@ func miniToolbarScreenPos(cam scene.Camera, originX, originY float32, tb wire.Mi
 	if tb.Anchor == nil {
 		return originX + float32(tb.ScreenX), originY + float32(tb.ScreenY), true
 	}
-	p := gomath.P3(tb.Anchor[0], tb.Anchor[1], tb.Anchor[2])
+	p := gomath.P3(tb.Anchor.X, tb.Anchor.Y, tb.Anchor.Z)
 	sx, sy, ok := renderer.Project(cam, viewportNear, viewportFar, p)
 	if !ok {
 		return 0, 0, false

--- a/head/ui/triad_view.go
+++ b/head/ui/triad_view.go
@@ -52,9 +52,9 @@ func triadOverlay(s *app.Session, cam scene.Camera, list renderer.DrawList) rend
 func triadWorldAxes(s *app.Session) [3]math.Vector3 {
 	spec := s.TriadSpec()
 	axes := [3]math.Vector3{math.V3(1, 0, 0), math.V3(0, 1, 0), math.V3(0, 0, 1)}
-	for i, a := range []*[3]float64{spec.AxisX, spec.AxisY, spec.AxisZ} {
+	for i, a := range []*types.UnitVector{spec.AxisX, spec.AxisY, spec.AxisZ} {
 		if a != nil {
-			axes[i] = math.V3(a[0], a[1], a[2])
+			axes[i] = math.V3(a.X, a.Y, a.Z)
 		}
 	}
 	return axes
@@ -99,7 +99,7 @@ func manipulatorOverlay(s *app.Session, cam scene.Camera, list renderer.DrawList
 	size := 5 * cam.WorldPerPixel()
 	for _, handles := range s.Manipulators().Handles() {
 		for _, h := range handles {
-			p := math.P3(h.Position[0], h.Position[1], h.Position[2])
+			p := math.P3(h.Position.X, h.Position.Y, h.Position.Z)
 			list.Items = append(list.Items, gizmoMarker(p, cam, size))
 		}
 	}
@@ -224,7 +224,7 @@ func manipulatorHitTest(s *app.Session, cam scene.Camera, mx, my float64) (strin
 			if radius <= 0 {
 				radius = gizmoHitPx
 			}
-			p := math.P3(h.Position[0], h.Position[1], h.Position[2])
+			p := math.P3(h.Position.X, h.Position.Y, h.Position.Z)
 			if d, ok := screenDistance(cam, p, mx, my); ok && d <= radius {
 				return gizmo, h.ID, true
 			}

--- a/kernel/geomapi/convert.go
+++ b/kernel/geomapi/convert.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package geomapi binds the transient-geometry kernel (math + kernel/geom) to the
+// public contract (M01-F05, #602): the [Factory] implements
+// contract.TransientGeometry, and thin adapters give every kernel curve/surface
+// its contract interface — the kernel itself stays free of API conversions. The
+// in-proc vs over-the-wire split is recorded in ADR-0018's geometry addendum.
+package geomapi
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+)
+
+// Conversions between the kernel's math vocabulary and the contract's value
+// types. Both are plain float64 triples; only the spelling differs.
+
+func toPoint(p math.Point3) types.Point   { return types.Point{X: p.X, Y: p.Y, Z: p.Z} }
+func fromPoint(p types.Point) math.Point3 { return math.P3(p.X, p.Y, p.Z) }
+
+func toPoint2d(p math.Point2) types.Point2d   { return types.Point2d{X: p.X, Y: p.Y} }
+func fromPoint2d(p types.Point2d) math.Point2 { return math.P2(p.X, p.Y) }
+
+func toVector(v math.Vector3) types.Vector { return types.Vector{X: v.X, Y: v.Y, Z: v.Z} }
+
+func toVector2d(v math.Vector2) types.Vector2d { return types.Vector2d{X: v.X, Y: v.Y} }
+
+// toUnit converts a kernel unit direction; the invariant is already held, so the
+// fields copy straight across.
+func toUnit(u math.UnitVector3) types.UnitVector {
+	return types.UnitVector{X: u.X(), Y: u.Y(), Z: u.Z()}
+}
+
+func toUnit2d(u math.UnitVector2) types.UnitVector2d {
+	return types.UnitVector2d{X: u.X(), Y: u.Y()}
+}
+
+// fromUnit widens a contract unit direction to the kernel vector the geom
+// constructors take (they re-validate and normalize internally).
+func fromUnit(u types.UnitVector) math.Vector3 { return math.V3(u.X, u.Y, u.Z) }
+
+func fromUnit2d(u types.UnitVector2d) math.Vector2 { return math.V2(u.X, u.Y) }
+
+func toPoints(ps []math.Point3) []types.Point {
+	out := make([]types.Point, len(ps))
+	for i, p := range ps {
+		out[i] = toPoint(p)
+	}
+	return out
+}
+
+func fromPoints(ps []types.Point) []math.Point3 {
+	out := make([]math.Point3, len(ps))
+	for i, p := range ps {
+		out[i] = fromPoint(p)
+	}
+	return out
+}
+
+func toPoints2d(ps []math.Point2) []types.Point2d {
+	out := make([]types.Point2d, len(ps))
+	for i, p := range ps {
+		out[i] = toPoint2d(p)
+	}
+	return out
+}
+
+func fromPoints2d(ps []types.Point2d) []math.Point2 {
+	out := make([]math.Point2, len(ps))
+	for i, p := range ps {
+		out[i] = fromPoint2d(p)
+	}
+	return out
+}

--- a/kernel/geomapi/curves2.go
+++ b/kernel/geomapi/curves2.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geomapi
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+)
+
+// The 2D curve adapters, mirroring curves3.go in sketch space.
+
+// curve2 supplies the umbrella members from the embedded kernel curve.
+type curve2 struct {
+	kind  types.Curve2dType
+	form  types.CurveGeometryForm
+	inner geom.Curve2
+}
+
+func (c curve2) CurveType() types.Curve2dType          { return c.kind }
+func (c curve2) GeometryForm() types.CurveGeometryForm { return c.form }
+func (c curve2) Evaluate(t float64) types.Point2d      { return toPoint2d(c.inner.PointAt(t)) }
+func (c curve2) Tangent(t float64) types.Vector2d      { return toVector2d(c.inner.TangentAt(t)) }
+func (c curve2) Domain() (lo, hi float64)              { return c.inner.Domain() }
+
+func analytic2(kind types.Curve2dType, inner geom.Curve2) curve2 {
+	return curve2{kind: kind, form: types.CurveFormNotNURBS, inner: inner}
+}
+
+// line2dAdapter — contract.Line2d over geom.Line2d.
+type line2dAdapter struct {
+	curve2
+	g geom.Line2d
+}
+
+var _ contract.Line2d = line2dAdapter{}
+
+func newLine2d(g geom.Line2d) line2dAdapter {
+	return line2dAdapter{curve2: analytic2(types.LineCurve2d, g), g: g}
+}
+
+func (a line2dAdapter) RootPoint() types.Point2d      { return toPoint2d(a.g.Origin) }
+func (a line2dAdapter) Direction() types.UnitVector2d { return toUnit2d(a.g.Dir) }
+
+// segment2dAdapter — contract.LineSegment2d over geom.LineSegment2d.
+type segment2dAdapter struct {
+	curve2
+	g geom.LineSegment2d
+}
+
+var _ contract.LineSegment2d = segment2dAdapter{}
+
+func newSegment2d(g geom.LineSegment2d) segment2dAdapter {
+	return segment2dAdapter{curve2: analytic2(types.LineSegmentCurve2d, g), g: g}
+}
+
+func (a segment2dAdapter) StartPoint() types.Point2d { return toPoint2d(a.g.StartPoint) }
+func (a segment2dAdapter) EndPoint() types.Point2d   { return toPoint2d(a.g.EndPoint) }
+
+// circle2dAdapter — contract.Circle2d over geom.Circle2d.
+type circle2dAdapter struct {
+	curve2
+	g geom.Circle2d
+}
+
+var _ contract.Circle2d = circle2dAdapter{}
+
+func newCircle2d(g geom.Circle2d) circle2dAdapter {
+	return circle2dAdapter{curve2: analytic2(types.CircleCurve2d, g), g: g}
+}
+
+func (a circle2dAdapter) Center() types.Point2d { return toPoint2d(a.g.Center) }
+func (a circle2dAdapter) Radius() float64       { return a.g.Radius }
+
+// arc2dAdapter — contract.Arc2d over geom.Arc2d.
+type arc2dAdapter struct {
+	curve2
+	g geom.Arc2d
+}
+
+var _ contract.Arc2d = arc2dAdapter{}
+
+func newArc2d(g geom.Arc2d) arc2dAdapter {
+	return arc2dAdapter{curve2: analytic2(types.CircularArcCurve2d, g), g: g}
+}
+
+func (a arc2dAdapter) Center() types.Point2d { return toPoint2d(a.g.Center) }
+func (a arc2dAdapter) Radius() float64       { return a.g.Radius }
+func (a arc2dAdapter) StartAngle() float64   { return a.g.StartAngle }
+func (a arc2dAdapter) SweepAngle() float64   { return a.g.SweepAngle }
+
+// ellipse2dAdapter — contract.EllipseFull2d over geom.EllipseFull2d.
+type ellipse2dAdapter struct {
+	curve2
+	g geom.EllipseFull2d
+}
+
+var _ contract.EllipseFull2d = ellipse2dAdapter{}
+
+func newEllipse2d(g geom.EllipseFull2d) ellipse2dAdapter {
+	return ellipse2dAdapter{curve2: analytic2(types.EllipseFullCurve2d, g), g: g}
+}
+
+func (a ellipse2dAdapter) Center() types.Point2d         { return toPoint2d(a.g.Center) }
+func (a ellipse2dAdapter) MajorAxis() types.UnitVector2d { return toUnit2d(a.g.MajorAxis) }
+func (a ellipse2dAdapter) MajorRadius() float64          { return a.g.MajorRadius }
+func (a ellipse2dAdapter) MinorRadius() float64          { return a.g.MinorRadius }
+
+// ellipticalArc2dAdapter — contract.EllipticalArc2d over geom.EllipticalArc2d.
+type ellipticalArc2dAdapter struct {
+	curve2
+	g geom.EllipticalArc2d
+}
+
+var _ contract.EllipticalArc2d = ellipticalArc2dAdapter{}
+
+func newEllipticalArc2d(g geom.EllipticalArc2d) ellipticalArc2dAdapter {
+	return ellipticalArc2dAdapter{curve2: analytic2(types.EllipticalArcCurve2d, g), g: g}
+}
+
+func (a ellipticalArc2dAdapter) Center() types.Point2d         { return toPoint2d(a.g.Center) }
+func (a ellipticalArc2dAdapter) MajorAxis() types.UnitVector2d { return toUnit2d(a.g.MajorAxis) }
+func (a ellipticalArc2dAdapter) MajorRadius() float64          { return a.g.MajorRadius }
+func (a ellipticalArc2dAdapter) MinorRadius() float64          { return a.g.MinorRadius }
+func (a ellipticalArc2dAdapter) StartAngle() float64           { return a.g.StartAngle }
+func (a ellipticalArc2dAdapter) SweepAngle() float64           { return a.g.SweepAngle }
+
+// polyline2dAdapter — contract.Polyline2d over geom.Polyline2d.
+type polyline2dAdapter struct {
+	curve2
+	g geom.Polyline2d
+}
+
+var _ contract.Polyline2d = polyline2dAdapter{}
+
+func newPolyline2d(g geom.Polyline2d) polyline2dAdapter {
+	return polyline2dAdapter{curve2: analytic2(types.PolylineCurve2d, g), g: g}
+}
+
+func (a polyline2dAdapter) Points() []types.Point2d { return toPoints2d(a.g.Vertices) }
+
+// bspline2dAdapter — contract.BSplineCurve2d over geom.BSplineCurve2d.
+type bspline2dAdapter struct {
+	curve2
+	g geom.BSplineCurve2d
+}
+
+var _ contract.BSplineCurve2d = bspline2dAdapter{}
+
+func newBSpline2d(g geom.BSplineCurve2d) bspline2dAdapter {
+	return bspline2dAdapter{
+		curve2: curve2{kind: types.BSplineCurve2dKind, form: types.CurveFormNURBS, inner: g},
+		g:      g,
+	}
+}
+
+func (a bspline2dAdapter) Definition() types.BSplineCurve2dDef {
+	return types.BSplineCurve2dDef{
+		Degree:  a.g.Degree,
+		Poles:   toPoints2d(a.g.Ctrl),
+		Weights: append([]float64(nil), a.g.Weights...),
+		Knots:   append([]float64(nil), a.g.Knots...),
+	}
+}

--- a/kernel/geomapi/curves3.go
+++ b/kernel/geomapi/curves3.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geomapi
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+)
+
+// The 3D curve adapters: each wraps a kernel curve and speaks the contract's
+// value types. Evaluation delegates to the kernel; the adapters carry no state.
+
+// curve3 supplies the umbrella members from the embedded kernel curve.
+type curve3 struct {
+	kind  types.CurveType
+	form  types.CurveGeometryForm
+	inner geom.Curve3
+}
+
+func (c curve3) CurveType() types.CurveType            { return c.kind }
+func (c curve3) GeometryForm() types.CurveGeometryForm { return c.form }
+func (c curve3) Evaluate(t float64) types.Point        { return toPoint(c.inner.PointAt(t)) }
+func (c curve3) Tangent(t float64) types.Vector        { return toVector(c.inner.TangentAt(t)) }
+func (c curve3) Domain() (lo, hi float64)              { return c.inner.Domain() }
+
+// analytic3 / nurbs3 pick the geometry form for a kind.
+func analytic3(kind types.CurveType, inner geom.Curve3) curve3 {
+	return curve3{kind: kind, form: types.CurveFormNotNURBS, inner: inner}
+}
+
+// lineAdapter — contract.Line over geom.Line.
+type lineAdapter struct {
+	curve3
+	g geom.Line
+}
+
+var _ contract.Line = lineAdapter{}
+
+func newLine(g geom.Line) lineAdapter {
+	return lineAdapter{curve3: analytic3(types.LineCurve, g), g: g}
+}
+
+func (a lineAdapter) RootPoint() types.Point      { return toPoint(a.g.Origin) }
+func (a lineAdapter) Direction() types.UnitVector { return toUnit(a.g.Dir) }
+
+// segmentAdapter — contract.LineSegment over geom.LineSegment.
+type segmentAdapter struct {
+	curve3
+	g geom.LineSegment
+}
+
+var _ contract.LineSegment = segmentAdapter{}
+
+func newSegment(g geom.LineSegment) segmentAdapter {
+	return segmentAdapter{curve3: analytic3(types.LineSegmentCurve, g), g: g}
+}
+
+func (a segmentAdapter) StartPoint() types.Point { return toPoint(a.g.StartPoint) }
+func (a segmentAdapter) EndPoint() types.Point   { return toPoint(a.g.EndPoint) }
+
+// circleAdapter — contract.Circle over geom.Circle.
+type circleAdapter struct {
+	curve3
+	g geom.Circle
+}
+
+var _ contract.Circle = circleAdapter{}
+
+func newCircle(g geom.Circle) circleAdapter {
+	return circleAdapter{curve3: analytic3(types.CircleCurve, g), g: g}
+}
+
+func (a circleAdapter) Center() types.Point      { return toPoint(a.g.Center) }
+func (a circleAdapter) Normal() types.UnitVector { return toUnit(a.g.Normal) }
+func (a circleAdapter) Radius() float64          { return a.g.Radius }
+
+// arcAdapter — contract.Arc3d over geom.Arc3d.
+type arcAdapter struct {
+	curve3
+	g geom.Arc3d
+}
+
+var _ contract.Arc3d = arcAdapter{}
+
+func newArc(g geom.Arc3d) arcAdapter {
+	return arcAdapter{curve3: analytic3(types.CircularArcCurve, g), g: g}
+}
+
+func (a arcAdapter) Center() types.Point               { return toPoint(a.g.Center) }
+func (a arcAdapter) Normal() types.UnitVector          { return toUnit(a.g.Normal) }
+func (a arcAdapter) ReferenceVector() types.UnitVector { return toUnit(a.g.RefDir) }
+func (a arcAdapter) Radius() float64                   { return a.g.Radius }
+func (a arcAdapter) StartAngle() float64               { return a.g.StartAngle }
+func (a arcAdapter) SweepAngle() float64               { return a.g.SweepAngle }
+
+// ellipseAdapter — contract.EllipseFull over geom.EllipseFull.
+type ellipseAdapter struct {
+	curve3
+	g geom.EllipseFull
+}
+
+var _ contract.EllipseFull = ellipseAdapter{}
+
+func newEllipse(g geom.EllipseFull) ellipseAdapter {
+	return ellipseAdapter{curve3: analytic3(types.EllipseFullCurve, g), g: g}
+}
+
+func (a ellipseAdapter) Center() types.Point         { return toPoint(a.g.Center) }
+func (a ellipseAdapter) Normal() types.UnitVector    { return toUnit(a.g.Normal) }
+func (a ellipseAdapter) MajorAxis() types.UnitVector { return toUnit(a.g.MajorAxis) }
+func (a ellipseAdapter) MajorRadius() float64        { return a.g.MajorRadius }
+func (a ellipseAdapter) MinorRadius() float64        { return a.g.MinorRadius }
+
+// ellipticalArcAdapter — contract.EllipticalArc over geom.EllipticalArc.
+type ellipticalArcAdapter struct {
+	curve3
+	g geom.EllipticalArc
+}
+
+var _ contract.EllipticalArc = ellipticalArcAdapter{}
+
+func newEllipticalArc(g geom.EllipticalArc) ellipticalArcAdapter {
+	return ellipticalArcAdapter{curve3: analytic3(types.EllipticalArcCurve, g), g: g}
+}
+
+func (a ellipticalArcAdapter) Center() types.Point         { return toPoint(a.g.Center) }
+func (a ellipticalArcAdapter) Normal() types.UnitVector    { return toUnit(a.g.Normal) }
+func (a ellipticalArcAdapter) MajorAxis() types.UnitVector { return toUnit(a.g.MajorAxis) }
+func (a ellipticalArcAdapter) MajorRadius() float64        { return a.g.MajorRadius }
+func (a ellipticalArcAdapter) MinorRadius() float64        { return a.g.MinorRadius }
+func (a ellipticalArcAdapter) StartAngle() float64         { return a.g.StartAngle }
+func (a ellipticalArcAdapter) SweepAngle() float64         { return a.g.SweepAngle }
+
+// polylineAdapter — contract.Polyline3d over geom.Polyline.
+type polylineAdapter struct {
+	curve3
+	g geom.Polyline
+}
+
+var _ contract.Polyline3d = polylineAdapter{}
+
+func newPolyline(g geom.Polyline) polylineAdapter {
+	return polylineAdapter{curve3: analytic3(types.PolylineCurve, g), g: g}
+}
+
+func (a polylineAdapter) Points() []types.Point { return toPoints(a.g.Vertices) }
+
+// bsplineAdapter — contract.BSplineCurve over geom.BSplineCurve.
+type bsplineAdapter struct {
+	curve3
+	g geom.BSplineCurve
+}
+
+var _ contract.BSplineCurve = bsplineAdapter{}
+
+func newBSpline(g geom.BSplineCurve) bsplineAdapter {
+	return bsplineAdapter{
+		curve3: curve3{kind: types.BSplineCurveKind, form: types.CurveFormNURBS, inner: g},
+		g:      g,
+	}
+}
+
+func (a bsplineAdapter) Definition() types.BSplineCurveDef {
+	return types.BSplineCurveDef{
+		Degree:  a.g.Degree,
+		Poles:   toPoints(a.g.Ctrl),
+		Weights: append([]float64(nil), a.g.Weights...),
+		Knots:   append([]float64(nil), a.g.Knots...),
+	}
+}
+
+// helixAdapter — contract.Helix over geom.Helix3d (the Oblikovati extension).
+type helixAdapter struct {
+	curve3
+	g geom.Helix3d
+}
+
+var _ contract.Helix = helixAdapter{}
+
+func newHelix(g geom.Helix3d) helixAdapter {
+	return helixAdapter{curve3: analytic3(types.HelixCurve, g), g: g}
+}
+
+func (a helixAdapter) BasePoint() types.Point { return toPoint(a.g.Origin) }
+func (a helixAdapter) Axis() types.UnitVector { return toUnit(a.g.Axis) }
+func (a helixAdapter) StartRadius() float64   { return a.g.StartRadius }
+func (a helixAdapter) Pitch() float64         { return a.g.AxialPerTurn }
+func (a helixAdapter) TaperPerTurn() float64  { return a.g.RadialPerTurn }
+func (a helixAdapter) Turns() float64         { return a.g.Turns }

--- a/kernel/geomapi/factory.go
+++ b/kernel/geomapi/factory.go
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geomapi
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Factory is the host's contract.TransientGeometry: every constructor delegates
+// to the kernel's validated geom constructors and wraps the result in its
+// contract adapter. It is stateless — one shared instance serves every caller.
+type Factory struct{}
+
+var _ contract.TransientGeometry = Factory{}
+
+// New returns the transient-geometry factory.
+func New() Factory { return Factory{} }
+
+// positive guards the radii/extents the kernel constructors do not all validate
+// themselves, naming the offending value.
+func positive(name string, v float64) error {
+	if v <= 0 {
+		return fmt.Errorf("geomapi: %s %g is not positive", name, v)
+	}
+	return nil
+}
+
+func (Factory) CreateLine(root types.Point, direction types.UnitVector) (contract.Line, error) {
+	g, err := geom.NewLine(fromPoint(root), fromUnit(direction))
+	if err != nil {
+		return nil, err
+	}
+	return newLine(g), nil
+}
+
+func (Factory) CreateLineSegment(start, end types.Point) (contract.LineSegment, error) {
+	if start == end {
+		return nil, fmt.Errorf("geomapi: degenerate segment: start and end are both %+v", start)
+	}
+	return newSegment(geom.NewLineSegment(fromPoint(start), fromPoint(end))), nil
+}
+
+func (Factory) CreateCircle(center types.Point, normal types.UnitVector, radius float64) (contract.Circle, error) {
+	if err := positive("circle radius", radius); err != nil {
+		return nil, err
+	}
+	g, err := geom.NewCircle(fromPoint(center), fromUnit(normal), radius)
+	if err != nil {
+		return nil, err
+	}
+	return newCircle(g), nil
+}
+
+func (Factory) CreateCircleByThreePoints(a, b, c types.Point) (contract.Circle, error) {
+	g, err := geom.CircleByThreePoints(fromPoint(a), fromPoint(b), fromPoint(c))
+	if err != nil {
+		return nil, err
+	}
+	return newCircle(g), nil
+}
+
+func (Factory) CreateArc(center types.Point, normal, reference types.UnitVector, radius, startAngle, sweepAngle float64) (contract.Arc3d, error) {
+	if err := positive("arc radius", radius); err != nil {
+		return nil, err
+	}
+	g, err := geom.NewArc3d(fromPoint(center), fromUnit(normal), fromUnit(reference), radius, startAngle, sweepAngle)
+	if err != nil {
+		return nil, err
+	}
+	return newArc(g), nil
+}
+
+func (Factory) CreateArcByThreePoints(start, on, end types.Point) (contract.Arc3d, error) {
+	g, err := geom.Arc3dByThreePoints(fromPoint(start), fromPoint(on), fromPoint(end))
+	if err != nil {
+		return nil, err
+	}
+	return newArc(g), nil
+}
+
+func (Factory) CreateEllipseFull(center types.Point, normal, majorAxis types.UnitVector, majorRadius, minorRadius float64) (contract.EllipseFull, error) {
+	if err := positive("ellipse major radius", majorRadius); err != nil {
+		return nil, err
+	}
+	if err := positive("ellipse minor radius", minorRadius); err != nil {
+		return nil, err
+	}
+	g, err := geom.NewEllipseFull(fromPoint(center), fromUnit(normal), fromUnit(majorAxis), majorRadius, minorRadius)
+	if err != nil {
+		return nil, err
+	}
+	return newEllipse(g), nil
+}
+
+func (Factory) CreateEllipticalArc(center types.Point, normal, majorAxis types.UnitVector, majorRadius, minorRadius, startAngle, sweepAngle float64) (contract.EllipticalArc, error) {
+	g, err := geom.NewEllipticalArc(fromPoint(center), fromUnit(normal), fromUnit(majorAxis), majorRadius, minorRadius, startAngle, sweepAngle)
+	if err != nil {
+		return nil, err
+	}
+	return newEllipticalArc(g), nil
+}
+
+func (Factory) CreatePolyline(points []types.Point) (contract.Polyline3d, error) {
+	g, err := geom.NewPolyline(fromPoints(points))
+	if err != nil {
+		return nil, err
+	}
+	return newPolyline(g), nil
+}
+
+func (Factory) CreateBSplineCurve(def types.BSplineCurveDef) (contract.BSplineCurve, error) {
+	g, err := bsplineFromDef(def)
+	if err != nil {
+		return nil, err
+	}
+	return newBSpline(g), nil
+}
+
+// bsplineFromDef builds the kernel spline, defaulting nil weights to uniform.
+func bsplineFromDef(def types.BSplineCurveDef) (geom.BSplineCurve, error) {
+	if def.Weights == nil {
+		return geom.NewBSplineCurveUniformWeights(def.Degree, fromPoints(def.Poles), def.Knots)
+	}
+	return geom.NewBSplineCurve(def.Degree, fromPoints(def.Poles), def.Weights, def.Knots)
+}
+
+func (Factory) CreateFittedBSplineCurve(through []types.Point) (contract.BSplineCurve, error) {
+	g, err := geom.NewFittedBSplineCurve(fromPoints(through))
+	if err != nil {
+		return nil, err
+	}
+	return newBSpline(g), nil
+}
+
+func (Factory) CreateHelix(base types.Point, axis, reference types.UnitVector, startRadius, pitch, taperPerTurn, turns float64, clockwise bool) (contract.Helix, error) {
+	g, err := geom.NewHelix3d(fromPoint(base), fromUnit(axis), fromUnit(reference), startRadius, pitch, taperPerTurn, turns, clockwise)
+	if err != nil {
+		return nil, err
+	}
+	return newHelix(g), nil
+}
+
+func (Factory) CreateLine2d(root types.Point2d, direction types.UnitVector2d) (contract.Line2d, error) {
+	g, err := geom.NewLine2d(fromPoint2d(root), fromUnit2d(direction))
+	if err != nil {
+		return nil, err
+	}
+	return newLine2d(g), nil
+}
+
+func (Factory) CreateLineSegment2d(start, end types.Point2d) (contract.LineSegment2d, error) {
+	if start == end {
+		return nil, fmt.Errorf("geomapi: degenerate 2D segment: start and end are both %+v", start)
+	}
+	return newSegment2d(geom.NewLineSegment2d(fromPoint2d(start), fromPoint2d(end))), nil
+}
+
+func (Factory) CreateCircle2d(center types.Point2d, radius float64) (contract.Circle2d, error) {
+	if radius <= 0 {
+		return nil, fmt.Errorf("geomapi: circle radius %g is not positive", radius)
+	}
+	return newCircle2d(geom.NewCircle2d(fromPoint2d(center), radius)), nil
+}
+
+func (Factory) CreateArc2d(center types.Point2d, radius, startAngle, sweepAngle float64) (contract.Arc2d, error) {
+	if radius <= 0 {
+		return nil, fmt.Errorf("geomapi: arc radius %g is not positive", radius)
+	}
+	return newArc2d(geom.NewArc2d(fromPoint2d(center), radius, startAngle, sweepAngle)), nil
+}
+
+func (Factory) CreateEllipseFull2d(center types.Point2d, majorAxis types.UnitVector2d, majorRadius, minorRadius float64) (contract.EllipseFull2d, error) {
+	g, err := geom.NewEllipseFull2d(fromPoint2d(center), fromUnit2d(majorAxis), majorRadius, minorRadius)
+	if err != nil {
+		return nil, err
+	}
+	return newEllipse2d(g), nil
+}
+
+func (Factory) CreateEllipticalArc2d(center types.Point2d, majorAxis types.UnitVector2d, majorRadius, minorRadius, startAngle, sweepAngle float64) (contract.EllipticalArc2d, error) {
+	g, err := geom.NewEllipticalArc2d(fromPoint2d(center), fromUnit2d(majorAxis), majorRadius, minorRadius, startAngle, sweepAngle)
+	if err != nil {
+		return nil, err
+	}
+	return newEllipticalArc2d(g), nil
+}
+
+func (Factory) CreatePolyline2d(points []types.Point2d) (contract.Polyline2d, error) {
+	g, err := geom.NewPolyline2d(fromPoints2d(points))
+	if err != nil {
+		return nil, err
+	}
+	return newPolyline2d(g), nil
+}
+
+func (Factory) CreateBSplineCurve2d(def types.BSplineCurve2dDef) (contract.BSplineCurve2d, error) {
+	g, err := bspline2dFromDef(def)
+	if err != nil {
+		return nil, err
+	}
+	return newBSpline2d(g), nil
+}
+
+// bspline2dFromDef builds the kernel spline, defaulting nil weights to uniform.
+func bspline2dFromDef(def types.BSplineCurve2dDef) (geom.BSplineCurve2d, error) {
+	if def.Weights == nil {
+		return geom.NewBSplineCurve2dUniformWeights(def.Degree, fromPoints2d(def.Poles), def.Knots)
+	}
+	return geom.NewBSplineCurve2d(def.Degree, fromPoints2d(def.Poles), def.Weights, def.Knots)
+}
+
+func (Factory) CreateFittedBSplineCurve2d(through []types.Point2d) (contract.BSplineCurve2d, error) {
+	g, err := geom.NewFittedBSplineCurve2d(fromPoints2d(through))
+	if err != nil {
+		return nil, err
+	}
+	return newBSpline2d(g), nil
+}
+
+func (Factory) CreatePlane(root types.Point, normal types.UnitVector) (contract.Plane, error) {
+	g, err := geom.NewPlane(fromPoint(root), fromUnit(normal))
+	if err != nil {
+		return nil, err
+	}
+	return newPlane(g), nil
+}
+
+func (Factory) CreatePlaneByThreePoints(a, b, c types.Point) (contract.Plane, error) {
+	g, err := geom.PlaneByThreePoints(fromPoint(a), fromPoint(b), fromPoint(c))
+	if err != nil {
+		return nil, err
+	}
+	return newPlane(g), nil
+}
+
+func (Factory) CreateCylinder(base types.Point, axis types.UnitVector, radius float64) (contract.Cylinder, error) {
+	if err := positive("cylinder radius", radius); err != nil {
+		return nil, err
+	}
+	g, err := geom.NewCylinder(fromPoint(base), fromUnit(axis), radius)
+	if err != nil {
+		return nil, err
+	}
+	return newCylinder(g), nil
+}
+
+func (Factory) CreateCone(apex types.Point, axis types.UnitVector, halfAngle float64) (contract.Cone, error) {
+	g, err := geom.NewCone(fromPoint(apex), fromUnit(axis), halfAngle)
+	if err != nil {
+		return nil, err
+	}
+	return newCone(g), nil
+}
+
+func (Factory) CreateSphere(center types.Point, radius float64) (contract.Sphere, error) {
+	g, err := geom.NewSphere(fromPoint(center), radius)
+	if err != nil {
+		return nil, err
+	}
+	return newSphere(g), nil
+}
+
+func (Factory) CreateTorus(center types.Point, axis types.UnitVector, majorRadius, minorRadius float64) (contract.Torus, error) {
+	if err := positive("torus major radius", majorRadius); err != nil {
+		return nil, err
+	}
+	if err := positive("torus minor radius", minorRadius); err != nil {
+		return nil, err
+	}
+	g, err := geom.NewTorus(fromPoint(center), fromUnit(axis), majorRadius, minorRadius)
+	if err != nil {
+		return nil, err
+	}
+	return newTorus(g), nil
+}
+
+func (Factory) CreateEllipticalCylinder(base types.Point, axis, majorAxis types.UnitVector, majorRadius, minorRadius float64) (contract.EllipticalCylinder, error) {
+	g, err := geom.NewEllipticalCylinder(fromPoint(base), fromUnit(axis), fromUnit(majorAxis), majorRadius, minorRadius)
+	if err != nil {
+		return nil, err
+	}
+	return newEllipticalCylinder(g), nil
+}
+
+func (Factory) CreateEllipticalCone(apex types.Point, axis, majorAxis types.UnitVector, majorHalfAngle, minorHalfAngle float64) (contract.EllipticalCone, error) {
+	g, err := geom.NewEllipticalCone(fromPoint(apex), fromUnit(axis), fromUnit(majorAxis), majorHalfAngle, minorHalfAngle)
+	if err != nil {
+		return nil, err
+	}
+	return newEllipticalCone(g), nil
+}
+
+func (Factory) CreateBSplineSurface(def types.BSplineSurfaceDef) (contract.BSplineSurface, error) {
+	if def.PolesU <= 0 || def.PolesV <= 0 || len(def.Poles) != def.PolesU*def.PolesV {
+		return nil, fmt.Errorf("geomapi: surface poles %d do not fill the %d×%d net", len(def.Poles), def.PolesU, def.PolesV)
+	}
+	ctrl := make([][]math.Point3, def.PolesU)
+	for i := 0; i < def.PolesU; i++ {
+		ctrl[i] = fromPoints(def.Poles[i*def.PolesV : (i+1)*def.PolesV])
+	}
+	weights, err := surfaceWeightNet(def)
+	if err != nil {
+		return nil, err
+	}
+	g, err := geom.NewBSplineSurface(def.DegreeU, def.DegreeV, ctrl, weights, def.KnotsU, def.KnotsV)
+	if err != nil {
+		return nil, err
+	}
+	return newBSplineSurface(g), nil
+}
+
+// surfaceWeightNet shapes the flat weight list into the kernel's rectangular
+// net, defaulting an omitted list to uniform 1s.
+func surfaceWeightNet(def types.BSplineSurfaceDef) ([][]float64, error) {
+	weights := make([][]float64, def.PolesU)
+	if def.Weights == nil {
+		for i := range weights {
+			row := make([]float64, def.PolesV)
+			for j := range row {
+				row[j] = 1
+			}
+			weights[i] = row
+		}
+		return weights, nil
+	}
+	if len(def.Weights) != def.PolesU*def.PolesV {
+		return nil, fmt.Errorf("geomapi: surface weights %d do not fill the %d×%d net", len(def.Weights), def.PolesU, def.PolesV)
+	}
+	for i := 0; i < def.PolesU; i++ {
+		weights[i] = append([]float64(nil), def.Weights[i*def.PolesV:(i+1)*def.PolesV]...)
+	}
+	return weights, nil
+}

--- a/kernel/geomapi/geomapi_test.go
+++ b/kernel/geomapi/geomapi_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geomapi
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+)
+
+// unit is a test shorthand for a known-good unit vector.
+func unit(t *testing.T, x, y, z float64) types.UnitVector {
+	t.Helper()
+	u, err := types.NewUnitVector(x, y, z)
+	if err != nil {
+		t.Fatalf("unit(%g,%g,%g): %v", x, y, z, err)
+	}
+	return u
+}
+
+func TestFactoryCircleEvaluatesOnTheCircle(t *testing.T) {
+	tg := New()
+	circle, err := tg.CreateCircle(types.NewPoint(1, 2, 3), unit(t, 0, 0, 1), 2)
+	if err != nil {
+		t.Fatalf("CreateCircle: %v", err)
+	}
+	if circle.CurveType() != types.CircleCurve || circle.GeometryForm() != types.CurveFormNotNURBS {
+		t.Errorf("discriminators = %v/%v", circle.CurveType(), circle.GeometryForm())
+	}
+	if circle.Radius() != 2 || circle.Center() != types.NewPoint(1, 2, 3) {
+		t.Errorf("getters = r%v c%+v", circle.Radius(), circle.Center())
+	}
+	// Every sample sits at radius distance from the center, in the plane.
+	for _, s := range []float64{0, 0.25, 0.5, 0.9} {
+		p := circle.Evaluate(s)
+		if d := p.DistanceTo(circle.Center()); stdmath.Abs(d-2) > 1e-12 {
+			t.Errorf("|P(%v)-C| = %v, want 2", s, d)
+		}
+		if stdmath.Abs(p.Z-3) > 1e-12 {
+			t.Errorf("P(%v).Z = %v, want the circle plane z=3", s, p.Z)
+		}
+	}
+}
+
+func TestFactoryRejectsDegenerateInput(t *testing.T) {
+	tg := New()
+	if _, err := tg.CreateCircle(types.NewPoint(0, 0, 0), unit(t, 0, 0, 1), -1); err == nil {
+		t.Error("negative radius must be rejected")
+	}
+	if _, err := tg.CreateLineSegment(types.NewPoint(1, 1, 1), types.NewPoint(1, 1, 1)); err == nil {
+		t.Error("a zero-length segment must be rejected")
+	}
+	if _, err := tg.CreateCircle2d(types.NewPoint2d(0, 0), 0); err == nil {
+		t.Error("a zero 2D radius must be rejected")
+	}
+	if _, err := tg.CreatePolyline(nil); err == nil {
+		t.Error("an empty polyline must be rejected")
+	}
+	if _, err := tg.CreateBSplineSurface(types.BSplineSurfaceDef{PolesU: 2, PolesV: 2}); err == nil {
+		t.Error("a pole-less surface net must be rejected")
+	}
+}
+
+func TestFactoryArcGettersAndTangent(t *testing.T) {
+	tg := New()
+	arc, err := tg.CreateArc(types.NewPoint(0, 0, 0), unit(t, 0, 0, 1), unit(t, 1, 0, 0), 1, 0, stdmath.Pi/2)
+	if err != nil {
+		t.Fatalf("CreateArc: %v", err)
+	}
+	if arc.SweepAngle() != stdmath.Pi/2 || arc.Radius() != 1 {
+		t.Errorf("getters = sweep %v r %v", arc.SweepAngle(), arc.Radius())
+	}
+	start, end := arc.Evaluate(0), arc.Evaluate(1)
+	if !start.IsEqualTo(types.NewPoint(1, 0, 0), 1e-12) || !end.IsEqualTo(types.NewPoint(0, 1, 0), 1e-12) {
+		t.Errorf("arc span = %+v → %+v, want +X → +Y", start, end)
+	}
+	// The tangent at the start of a CCW quarter arc points along +Y.
+	tan := arc.Tangent(0)
+	if tan.X > 1e-9 || tan.Y <= 0 {
+		t.Errorf("tangent(0) = %+v, want +Y direction", tan)
+	}
+}
+
+func TestFactoryBSplineDefinitionRoundTrips(t *testing.T) {
+	tg := New()
+	def := types.BSplineCurveDef{
+		Degree: 2,
+		Poles:  []types.Point{{X: 0}, {X: 1, Y: 2}, {X: 2}, {X: 3, Y: -1}},
+		Knots:  []float64{0, 0, 0, 0.5, 1, 1, 1},
+	}
+	spline, err := tg.CreateBSplineCurve(def)
+	if err != nil {
+		t.Fatalf("CreateBSplineCurve: %v", err)
+	}
+	if spline.GeometryForm() != types.CurveFormNURBS {
+		t.Errorf("form = %v, want NURBS", spline.GeometryForm())
+	}
+	got := spline.Definition()
+	if got.Degree != 2 || len(got.Poles) != 4 || len(got.Knots) != 7 {
+		t.Fatalf("definition = %+v, want the input recipe back", got)
+	}
+	if got.Poles[1] != def.Poles[1] {
+		t.Errorf("pole[1] = %+v, want %+v", got.Poles[1], def.Poles[1])
+	}
+}
+
+func TestFactorySphereEvaluation(t *testing.T) {
+	tg := New()
+	sphere, err := tg.CreateSphere(types.NewPoint(0, 0, 0), 3)
+	if err != nil {
+		t.Fatalf("CreateSphere: %v", err)
+	}
+	if sphere.SurfaceType() != types.SphereSurface {
+		t.Errorf("kind = %v", sphere.SurfaceType())
+	}
+	p := sphere.Evaluate(0.3, -0.7)
+	if d := p.DistanceTo(types.NewPoint(0, 0, 0)); stdmath.Abs(d-3) > 1e-12 {
+		t.Errorf("|P| = %v, want 3", d)
+	}
+	// The unit normal of a centered sphere points along the position.
+	n := sphere.Normal(0.3, -0.7)
+	want := types.NewPoint(0, 0, 0).VectorTo(p).Scale(1.0 / 3.0)
+	if !n.IsEqualTo(want, 1e-9) {
+		t.Errorf("normal = %+v, want radial %+v", n, want)
+	}
+	// Parameter inverts Evaluate.
+	u, v := sphere.Parameter(p)
+	if q := sphere.Evaluate(u, v); !q.IsEqualTo(p, 1e-9) {
+		t.Errorf("Evaluate(Parameter(p)) = %+v, want %+v", q, p)
+	}
+}
+
+func TestFactoryEllipticalQuadricsAreFirstClass(t *testing.T) {
+	tg := New()
+	cyl, err := tg.CreateEllipticalCylinder(types.NewPoint(0, 0, 0), unit(t, 0, 0, 1), unit(t, 1, 0, 0), 3, 1)
+	if err != nil {
+		t.Fatalf("CreateEllipticalCylinder: %v", err)
+	}
+	if cyl.SurfaceType() != types.EllipticalCylinderSurface || cyl.MajorRadius() != 3 {
+		t.Errorf("cylinder = %v r %v", cyl.SurfaceType(), cyl.MajorRadius())
+	}
+	cone, err := tg.CreateEllipticalCone(types.NewPoint(0, 0, 0), unit(t, 0, 0, 1), unit(t, 1, 0, 0), 0.5, 0.3)
+	if err != nil {
+		t.Fatalf("CreateEllipticalCone: %v", err)
+	}
+	if cone.SurfaceType() != types.EllipticalConeSurface || cone.MajorHalfAngle() != 0.5 {
+		t.Errorf("cone = %v a %v", cone.SurfaceType(), cone.MajorHalfAngle())
+	}
+}
+
+func TestFactoryHelixIsTheHouseExtension(t *testing.T) {
+	tg := New()
+	helix, err := tg.CreateHelix(types.NewPoint(0, 0, 0), unit(t, 0, 0, 1), unit(t, 1, 0, 0), 2, 1, 0, 3, false)
+	if err != nil {
+		t.Fatalf("CreateHelix: %v", err)
+	}
+	if helix.CurveType() != types.HelixCurve || helix.Turns() != 3 || helix.Pitch() != 1 {
+		t.Errorf("helix = %v turns %v pitch %v", helix.CurveType(), helix.Turns(), helix.Pitch())
+	}
+	// After all turns the curve has climbed turns×pitch along the axis.
+	end := helix.Evaluate(1)
+	if stdmath.Abs(end.Z-3) > 1e-9 {
+		t.Errorf("end.Z = %v, want 3", end.Z)
+	}
+}
+
+// TestAdaptersSatisfyUmbrellas pins the assertion set: every adapter is usable
+// through the umbrella interfaces.
+func TestAdaptersSatisfyUmbrellas(t *testing.T) {
+	tg := New()
+	seg, _ := tg.CreateLineSegment(types.NewPoint(0, 0, 0), types.NewPoint(1, 0, 0))
+	var c contract.Curve = seg
+	if c.CurveType() != types.LineSegmentCurve {
+		t.Errorf("umbrella curve kind = %v", c.CurveType())
+	}
+	circle2d, _ := tg.CreateCircle2d(types.NewPoint2d(0, 0), 1)
+	var c2 contract.Curve2d = circle2d
+	if lo, hi := c2.Domain(); lo != 0 || hi != 1 {
+		t.Errorf("2D domain = [%v, %v]", lo, hi)
+	}
+	plane, _ := tg.CreatePlane(types.NewPoint(0, 0, 0), unit(t, 0, 0, 1))
+	var srf contract.Surface = plane
+	if srf.SurfaceType() != types.PlaneSurface {
+		t.Errorf("umbrella surface kind = %v", srf.SurfaceType())
+	}
+	if n := plane.PlaneNormal(); stdmath.Abs(n.Z) < 0.999 {
+		t.Errorf("plane normal = %+v, want ±Z", n)
+	}
+}

--- a/kernel/geomapi/surfaces.go
+++ b/kernel/geomapi/surfaces.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geomapi
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+)
+
+// The surface adapters: each wraps a kernel surface and speaks the contract's
+// value types.
+
+// surface supplies the umbrella members from the embedded kernel surface.
+type surface struct {
+	kind  types.SurfaceType
+	form  types.SurfaceGeometryForm
+	inner geom.Surface
+}
+
+func (s surface) SurfaceType() types.SurfaceType          { return s.kind }
+func (s surface) GeometryForm() types.SurfaceGeometryForm { return s.form }
+func (s surface) Evaluate(u, v float64) types.Point       { return toPoint(s.inner.PointAt(u, v)) }
+func (s surface) Normal(u, v float64) types.Vector        { return toVector(s.inner.NormalAt(u, v)) }
+
+func (s surface) Domains() (uLo, uHi, vLo, vHi float64) {
+	uLo, uHi = s.inner.UDomain()
+	vLo, vHi = s.inner.VDomain()
+	return uLo, uHi, vLo, vHi
+}
+
+func (s surface) Parameter(p types.Point) (u, v float64) {
+	return s.inner.ParamAt(fromPoint(p))
+}
+
+func analyticSurface(kind types.SurfaceType, inner geom.Surface) surface {
+	return surface{kind: kind, form: types.SurfaceFormNotNURBS, inner: inner}
+}
+
+// planeAdapter — contract.Plane over geom.Plane.
+type planeAdapter struct {
+	surface
+	g geom.Plane
+}
+
+var _ contract.Plane = planeAdapter{}
+
+func newPlane(g geom.Plane) planeAdapter {
+	return planeAdapter{surface: analyticSurface(types.PlaneSurface, g), g: g}
+}
+
+func (a planeAdapter) RootPoint() types.Point  { return toPoint(a.g.Origin) }
+func (a planeAdapter) UAxis() types.UnitVector { return toUnit(a.g.UAxis) }
+func (a planeAdapter) VAxis() types.UnitVector { return toUnit(a.g.VAxis) }
+
+func (a planeAdapter) PlaneNormal() types.UnitVector {
+	// The kernel derives the normal from the U/V basis (orthonormal), so the
+	// normalized cross product is exactly unit.
+	n := toUnit(a.g.UAxis).Cross(toUnit(a.g.VAxis))
+	return types.UnitVector(n)
+}
+
+// cylinderAdapter — contract.Cylinder over geom.Cylinder.
+type cylinderAdapter struct {
+	surface
+	g geom.Cylinder
+}
+
+var _ contract.Cylinder = cylinderAdapter{}
+
+func newCylinder(g geom.Cylinder) cylinderAdapter {
+	return cylinderAdapter{surface: analyticSurface(types.CylinderSurface, g), g: g}
+}
+
+func (a cylinderAdapter) BasePoint() types.Point { return toPoint(a.g.Origin) }
+func (a cylinderAdapter) Axis() types.UnitVector { return toUnit(a.g.AxisDir) }
+func (a cylinderAdapter) Radius() float64        { return a.g.Radius }
+
+// coneAdapter — contract.Cone over geom.Cone.
+type coneAdapter struct {
+	surface
+	g geom.Cone
+}
+
+var _ contract.Cone = coneAdapter{}
+
+func newCone(g geom.Cone) coneAdapter {
+	return coneAdapter{surface: analyticSurface(types.ConeSurface, g), g: g}
+}
+
+func (a coneAdapter) ApexPoint() types.Point { return toPoint(a.g.Apex) }
+func (a coneAdapter) Axis() types.UnitVector { return toUnit(a.g.AxisDir) }
+func (a coneAdapter) HalfAngle() float64     { return a.g.HalfAngle }
+
+// sphereAdapter — contract.Sphere over geom.Sphere.
+type sphereAdapter struct {
+	surface
+	g geom.Sphere
+}
+
+var _ contract.Sphere = sphereAdapter{}
+
+func newSphere(g geom.Sphere) sphereAdapter {
+	return sphereAdapter{surface: analyticSurface(types.SphereSurface, g), g: g}
+}
+
+func (a sphereAdapter) Center() types.Point { return toPoint(a.g.Center) }
+func (a sphereAdapter) Radius() float64     { return a.g.Radius }
+
+// torusAdapter — contract.Torus over geom.Torus.
+type torusAdapter struct {
+	surface
+	g geom.Torus
+}
+
+var _ contract.Torus = torusAdapter{}
+
+func newTorus(g geom.Torus) torusAdapter {
+	return torusAdapter{surface: analyticSurface(types.TorusSurface, g), g: g}
+}
+
+func (a torusAdapter) Center() types.Point    { return toPoint(a.g.Center) }
+func (a torusAdapter) Axis() types.UnitVector { return toUnit(a.g.AxisDir) }
+func (a torusAdapter) MajorRadius() float64   { return a.g.MajorRadius }
+func (a torusAdapter) MinorRadius() float64   { return a.g.MinorRadius }
+
+// ellipticalCylinderAdapter — contract.EllipticalCylinder over the kernel type.
+type ellipticalCylinderAdapter struct {
+	surface
+	g geom.EllipticalCylinder
+}
+
+var _ contract.EllipticalCylinder = ellipticalCylinderAdapter{}
+
+func newEllipticalCylinder(g geom.EllipticalCylinder) ellipticalCylinderAdapter {
+	return ellipticalCylinderAdapter{surface: analyticSurface(types.EllipticalCylinderSurface, g), g: g}
+}
+
+func (a ellipticalCylinderAdapter) BasePoint() types.Point      { return toPoint(a.g.Origin) }
+func (a ellipticalCylinderAdapter) Axis() types.UnitVector      { return toUnit(a.g.AxisDir) }
+func (a ellipticalCylinderAdapter) MajorAxis() types.UnitVector { return toUnit(a.g.Ref) }
+func (a ellipticalCylinderAdapter) MajorRadius() float64        { return a.g.MajorRadius }
+func (a ellipticalCylinderAdapter) MinorRadius() float64        { return a.g.MinorRadius }
+
+// ellipticalConeAdapter — contract.EllipticalCone over the kernel type.
+type ellipticalConeAdapter struct {
+	surface
+	g geom.EllipticalCone
+}
+
+var _ contract.EllipticalCone = ellipticalConeAdapter{}
+
+func newEllipticalCone(g geom.EllipticalCone) ellipticalConeAdapter {
+	return ellipticalConeAdapter{surface: analyticSurface(types.EllipticalConeSurface, g), g: g}
+}
+
+func (a ellipticalConeAdapter) ApexPoint() types.Point      { return toPoint(a.g.Apex) }
+func (a ellipticalConeAdapter) Axis() types.UnitVector      { return toUnit(a.g.AxisDir) }
+func (a ellipticalConeAdapter) MajorAxis() types.UnitVector { return toUnit(a.g.Ref) }
+func (a ellipticalConeAdapter) MajorHalfAngle() float64     { return a.g.MajorAngle }
+func (a ellipticalConeAdapter) MinorHalfAngle() float64     { return a.g.MinorAngle }
+
+// bsplineSurfaceAdapter — contract.BSplineSurface over geom.BSplineSurface.
+type bsplineSurfaceAdapter struct {
+	surface
+	g geom.BSplineSurface
+}
+
+var _ contract.BSplineSurface = bsplineSurfaceAdapter{}
+
+func newBSplineSurface(g geom.BSplineSurface) bsplineSurfaceAdapter {
+	return bsplineSurfaceAdapter{
+		surface: surface{kind: types.BSplineSurfaceKind, form: types.SurfaceFormNURBS, inner: g},
+		g:       g,
+	}
+}
+
+func (a bsplineSurfaceAdapter) Definition() types.BSplineSurfaceDef {
+	rows, cols := len(a.g.Ctrl), 0
+	if rows > 0 {
+		cols = len(a.g.Ctrl[0])
+	}
+	def := types.BSplineSurfaceDef{
+		DegreeU: a.g.UDegree, DegreeV: a.g.VDegree,
+		PolesU: rows, PolesV: cols,
+		KnotsU: append([]float64(nil), a.g.UKnots...),
+		KnotsV: append([]float64(nil), a.g.VKnots...),
+	}
+	for _, row := range a.g.Ctrl {
+		def.Poles = append(def.Poles, toPoints(row)...)
+	}
+	for _, row := range a.g.Weights {
+		def.Weights = append(def.Weights, row...)
+	}
+	return def
+}


### PR DESCRIPTION
## What

The GPL implementation half of M01-F05, closing #602 (contract: Oblikovati/Oblikovati.API#57):

- **`kernel/geomapi`**: `contract.TransientGeometry` implemented over the validated `kernel/geom` constructors (plus factory-side positive-radius guards where the kernel skips them); one thin adapter per curve/surface kind with compile-time assertions — the kernel stays free of API conversions. Elliptical cone/cylinder are first-class.
- **Wire ripple**: camera, lighting, views, triad, manipulators and mini-toolbar anchors now use the typed geometry; JSON stays byte-identical (the contract's array encoding).
- **ADR-0018 addendum**: records the in-process value types / contract curve interfaces split and the rejected kernel-math aliasing.

## Tests

Factory construction + degenerate-input rejection, circle/arc/sphere/helix evaluation sanity, B-spline definition round-trips, umbrella-interface coverage; the full existing suites pass over the migrated wire fields.

⚠️ CI needs Oblikovati/Oblikovati.API#57 — merged.

Closes #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)