### PR TITLE
M02-F08: implement the member-level parameter surface (tolerance, dependencies, expression list, lifecycle)

### DIFF
--- a/addin/router/parameters_detail.go
+++ b/addin/router/parameters_detail.go
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/param"
+)
+
+// The member-level parameter surface (M02-F08, Oblikovati#607): detail reads,
+// presentation/tolerance/value-list mutations, dependency queries and delete.
+// Mutations finalize through Session.RecordAddInEdit so they are undoable, and
+// the router broadcasts them as edit.committed (mutatingMethods).
+
+// paramDetail marshals the full member-level view of one parameter.
+func paramDetail(part *compdef.PartComponentDefinition, p *param.Parameter) wire.ParameterDetail {
+	ps := part.Parameters()
+	d := wire.ParameterDetail{
+		ParameterInfo: paramInfo(part, p),
+		Units:         paramUnitName(part, p),
+		Comment:       p.Comment, IsKey: p.IsKey, Visible: p.Visible,
+		InUse: ps.InUse(p.ID()), Precision: p.Precision,
+		DisplayFormat: p.DisplayFormat.String(), ExposedAsProperty: p.ExposedAsProperty,
+		ModelValueType:       p.ModelValueType().String(),
+		CustomPropertyFormat: customPropertyInfo(p.CustomProperty),
+		DrivenBy:             paramNames(ps, ps.DrivenBy(p.ID())),
+		Dependents:           paramNames(ps, ps.Dependents(p.ID())),
+	}
+	if p.IsNumeric() {
+		tol := p.Tolerance()
+		d.ModelValue = p.ModelValue()
+		d.Tolerance = &wire.ToleranceInfo{Type: tol.Kind().String(), Upper: tol.Upper, Lower: tol.Lower}
+	}
+	if p.IsMultiValue() {
+		d.ExpressionList = &wire.ExpressionListInfo{
+			Expressions: p.ExpressionList(), AllowCustomValues: p.AllowsCustomValue(),
+			CustomOrder: p.CustomOrder(),
+		}
+	}
+	return d
+}
+
+// paramUnitName names the parameter's unit for the wire: the document's display
+// unit for dimensioned categories, the category name (text/boolean/unitless)
+// otherwise.
+func paramUnitName(part *compdef.PartComponentDefinition, p *param.Parameter) string {
+	if name := part.Units().PreferredName(p.Unit()); name != "" {
+		return name
+	}
+	return p.Unit().String()
+}
+
+// customPropertyInfo marshals a custom-property format into its wire DTO.
+func customPropertyInfo(cp param.CustomPropertyFormat) *wire.CustomPropertyFormatInfo {
+	return &wire.CustomPropertyFormatInfo{
+		PropertyType: cp.PropertyType.String(), Units: cp.Units, Precision: cp.Precision.String(),
+		ShowLeadingZeros: cp.ShowLeadingZeros, ShowTrailingZeros: cp.ShowTrailingZeros,
+		ShowUnitsString: cp.ShowUnitsString,
+	}
+}
+
+// paramNames maps graph ids onto display names (deleted ids are skipped).
+func paramNames(ps *param.Parameters, ids []param.ID) []string {
+	names := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if p, ok := ps.ByID(id); ok {
+			names = append(names, p.Name())
+		}
+	}
+	return names
+}
+
+// paramByName resolves one parameter on the active part, naming the method in
+// the not-found error.
+func paramByName(s *app.Session, method, name string) (*compdef.PartComponentDefinition, *param.Parameter, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	p, ok := part.Parameters().ByName(name)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s: no parameter named %q", method, name)
+	}
+	return part, p, nil
+}
+
+// getParameterDetail returns the member-level view of one parameter.
+func getParameterDetail(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterNameArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, p, err := paramByName(s, "parameters.getDetail", in.Name)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(paramDetail(part, p))
+}
+
+// updateParameter applies the non-nil presentation/exposure mutations, records
+// one undo step, and returns the updated detail.
+func updateParameter(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterUpdateArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, p, err := paramByName(s, "parameters.update", in.Name)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyParameterUpdate(p, in); err != nil {
+		return nil, err
+	}
+	// A model-value selection change moves the value features consume.
+	if in.ModelValueType != nil {
+		part.Features().MarkAllDirty()
+		part.Recompute()
+	}
+	s.RecordAddInEdit(part, "Edit Parameter")
+	return json.Marshal(paramDetail(part, p))
+}
+
+// applyParameterUpdate copies the non-nil update fields onto the parameter.
+func applyParameterUpdate(p *param.Parameter, in wire.ParameterUpdateArgs) error {
+	setIfPresent(in.Comment, &p.Comment)
+	setIfPresent(in.IsKey, &p.IsKey)
+	setIfPresent(in.Visible, &p.Visible)
+	setIfPresent(in.Precision, &p.Precision)
+	setIfPresent(in.ExposedAsProperty, &p.ExposedAsProperty)
+	if in.DisplayFormat != nil {
+		f, ok := types.ParseParameterDisplayFormat(*in.DisplayFormat)
+		if !ok {
+			return fmt.Errorf("parameters.update: unknown display format %q (want decimal|fractional|architectural)", *in.DisplayFormat)
+		}
+		p.DisplayFormat = f
+	}
+	if in.ModelValueType != nil {
+		m, ok := types.ParseModelValueType(*in.ModelValueType)
+		if !ok {
+			return fmt.Errorf("parameters.update: unknown model value type %q (want nominal|lower|upper|median)", *in.ModelValueType)
+		}
+		if err := p.SetModelValueType(m); err != nil {
+			return err
+		}
+	}
+	return applyCustomPropertyUpdate(p, in.CustomPropertyFormat)
+}
+
+// setIfPresent copies a pointer-optional update field when it was sent.
+func setIfPresent[V any](src *V, dst *V) {
+	if src != nil {
+		*dst = *src
+	}
+}
+
+// applyCustomPropertyUpdate replaces the parameter's custom-property format
+// from its wire DTO, validating the enum spellings.
+func applyCustomPropertyUpdate(p *param.Parameter, in *wire.CustomPropertyFormatInfo) error {
+	if in == nil {
+		return nil
+	}
+	t, ok := types.ParseCustomPropertyType(in.PropertyType)
+	if !ok {
+		return fmt.Errorf("parameters.update: unknown custom property type %q (want text|number)", in.PropertyType)
+	}
+	prec, ok := types.ParseCustomPropertyPrecision(in.Precision)
+	if !ok {
+		return fmt.Errorf("parameters.update: unknown custom property precision %q", in.Precision)
+	}
+	p.CustomProperty = param.CustomPropertyFormat{
+		PropertyType: t, Units: in.Units, Precision: prec,
+		ShowLeadingZeros: in.ShowLeadingZeros, ShowTrailingZeros: in.ShowTrailingZeros,
+		ShowUnitsString: in.ShowUnitsString,
+	}
+	return nil
+}
+
+// setParameterTolerance applies one tolerance mode, recomputes (the model value
+// may move), records one undo step, and returns the updated detail.
+func setParameterTolerance(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterToleranceArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, p, err := paramByName(s, "parameters.setTolerance", in.Name)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyToleranceMode(part, p, in); err != nil {
+		return nil, err
+	}
+	part.Features().MarkAllDirty()
+	part.Recompute()
+	s.RecordAddInEdit(part, "Edit Tolerance")
+	return json.Marshal(paramDetail(part, p))
+}
+
+// applyToleranceMode dispatches one wire tolerance mode onto the model setters.
+func applyToleranceMode(part *compdef.PartComponentDefinition, p *param.Parameter, in wire.ParameterToleranceArgs) error {
+	switch in.Mode {
+	case "default":
+		return p.SetToleranceDefault()
+	case "min":
+		return p.SetToleranceMinMax(types.ToleranceMin)
+	case "max":
+		return p.SetToleranceMinMax(types.ToleranceMax)
+	case "symmetric":
+		band, err := toleranceOperand(part, p, in.Upper, "upper")
+		if err != nil {
+			return err
+		}
+		return p.SetToleranceSymmetric(band)
+	case "deviation", "limits":
+		return applyToleranceBand(part, p, in)
+	default:
+		return fmt.Errorf("parameters.setTolerance: unknown mode %q (want default|deviation|symmetric|limits|min|max)", in.Mode)
+	}
+}
+
+// applyToleranceBand parses both operands and applies a deviation or limits band.
+func applyToleranceBand(part *compdef.PartComponentDefinition, p *param.Parameter, in wire.ParameterToleranceArgs) error {
+	upper, err := toleranceOperand(part, p, in.Upper, "upper")
+	if err != nil {
+		return err
+	}
+	lower, err := toleranceOperand(part, p, in.Lower, "lower")
+	if err != nil {
+		return err
+	}
+	if in.Mode == "limits" {
+		return p.SetToleranceLimits(upper, lower)
+	}
+	return p.SetToleranceDeviation(upper, lower)
+}
+
+// toleranceOperand parses one unit-bearing tolerance expression in the
+// parameter's unit category, returning the database-unit value.
+func toleranceOperand(part *compdef.PartComponentDefinition, p *param.Parameter, expr, field string) (float64, error) {
+	if expr == "" {
+		return 0, fmt.Errorf("parameters.setTolerance: %s value is required for this mode", field)
+	}
+	q, err := part.Units().Parse(expr, p.Unit())
+	if err != nil {
+		return 0, fmt.Errorf("parameters.setTolerance: %s %q: %w", field, expr, err)
+	}
+	return q.Value, nil
+}
+
+// setParameterExpressionList replaces the multi-value choices (empty clears),
+// records one undo step, and returns the updated detail.
+func setParameterExpressionList(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterExpressionListArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, p, err := paramByName(s, "parameters.setExpressionList", in.Name)
+	if err != nil {
+		return nil, err
+	}
+	if len(in.Expressions) == 0 {
+		p.ClearExpressionList()
+	} else if err := replaceExpressionList(p, in); err != nil {
+		return nil, err
+	}
+	s.RecordAddInEdit(part, "Edit Value List")
+	return json.Marshal(paramDetail(part, p))
+}
+
+// replaceExpressionList sets the choices and the ordering flag.
+func replaceExpressionList(p *param.Parameter, in wire.ParameterExpressionListArgs) error {
+	if err := p.SetExpressionList(in.Expressions, in.AllowCustomValues); err != nil {
+		return err
+	}
+	if !in.CustomOrder {
+		p.SetCustomOrder(false)
+	}
+	return nil
+}
+
+// deleteParameter removes an unused parameter; an in-use one is rejected with
+// the offending dependents so the caller can resolve them first.
+func deleteParameter(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterNameArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, p, err := paramByName(s, "parameters.delete", in.Name)
+	if err != nil {
+		return nil, err
+	}
+	ps := part.Parameters()
+	if ps.InUse(p.ID()) {
+		return nil, fmt.Errorf("parameters.delete: %q is in use by [%s]; remove those references first",
+			in.Name, strings.Join(deleteBlockers(ps, p), ", "))
+	}
+	if err := ps.Delete(p.ID()); err != nil {
+		return nil, err
+	}
+	part.Features().MarkAllDirty()
+	part.Recompute()
+	s.RecordAddInEdit(part, "Delete Parameter")
+	return json.Marshal(struct{}{})
+}
+
+// deleteBlockers names what keeps a parameter alive: its dependents, or its
+// owning feature dimension for model parameters.
+func deleteBlockers(ps *param.Parameters, p *param.Parameter) []string {
+	if names := paramNames(ps, ps.Dependents(p.ID())); len(names) > 0 {
+		return names
+	}
+	return []string{"its feature dimension"}
+}
+
+// parameterDrivenBy / parameterDependents answer the dependency queries.
+func parameterDrivenBy(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	return parameterNeighbors(s, "parameters.drivenBy", args, (*param.Parameters).DrivenBy)
+}
+
+func parameterDependents(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	return parameterNeighbors(s, "parameters.dependents", args, (*param.Parameters).Dependents)
+}
+
+// parameterNeighbors resolves one side of the dependency graph to names.
+func parameterNeighbors(s *app.Session, method string, args json.RawMessage, side func(*param.Parameters, param.ID) []param.ID) (json.RawMessage, error) {
+	var in wire.ParameterNameArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, p, err := paramByName(s, method, in.Name)
+	if err != nil {
+		return nil, err
+	}
+	ps := part.Parameters()
+	return json.Marshal(wire.ParameterNamesResult{Names: paramNames(ps, side(ps, p.ID()))})
+}

--- a/addin/router/parameters_detail_test.go
+++ b/addin/router/parameters_detail_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// The member-level parameter surface over the wire (M02-F08, Oblikovati#607):
+// parameters.getDetail/update/setTolerance/setExpressionList/delete/drivenBy/
+// dependents against a live session.
+
+// getDetail fetches one parameter's member-level view, failing the test on error.
+func getDetail(t *testing.T, r *Router, s *app.Session, name string) wire.ParameterDetail {
+	t.Helper()
+	var d wire.ParameterDetail
+	call(t, r, s, "parameters.getDetail", `{"name":"`+name+`"}`, &d)
+	return d
+}
+
+func TestParameterGetDetailDefaults(t *testing.T) {
+	r, s := seededSession(t)
+	d := getDetail(t, r, s, "width")
+	if d.Name != "width" || d.Expression != "4 cm" {
+		t.Fatalf("detail identity = %+v, want width / 4 cm", d.ParameterInfo)
+	}
+	if !d.Visible || d.DisplayFormat != "decimal" || d.ModelValueType != "nominal" {
+		t.Errorf("presentation defaults = visible=%v format=%q mvt=%q, want true/decimal/nominal",
+			d.Visible, d.DisplayFormat, d.ModelValueType)
+	}
+	if d.Tolerance == nil || d.Tolerance.Type != "default" || d.Tolerance.Upper != 0 {
+		t.Errorf("tolerance = %+v, want bandless default", d.Tolerance)
+	}
+	if d.ModelValue != 4 {
+		t.Errorf("model value = %v, want the 4 cm nominal", d.ModelValue)
+	}
+	if d.InUse || d.ExpressionList != nil || len(d.DrivenBy)+len(d.Dependents) != 0 {
+		t.Errorf("fresh parameter not standalone: %+v", d)
+	}
+	if d.CustomPropertyFormat == nil || d.CustomPropertyFormat.PropertyType != "text" {
+		t.Errorf("custom property format = %+v, want the text default", d.CustomPropertyFormat)
+	}
+}
+
+func TestParameterDetailDependencyNeighborhood(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"half","expression":"width / 2"}`, nil)
+
+	if d := getDetail(t, r, s, "width"); !d.InUse || !slices.Equal(d.Dependents, []string{"half"}) {
+		t.Errorf("width detail = inUse=%v dependents=%v, want in use by [half]", d.InUse, d.Dependents)
+	}
+	if d := getDetail(t, r, s, "half"); !slices.Equal(d.DrivenBy, []string{"width"}) {
+		t.Errorf("half drivenBy = %v, want [width]", d.DrivenBy)
+	}
+
+	var names wire.ParameterNamesResult
+	call(t, r, s, "parameters.dependents", `{"name":"width"}`, &names)
+	if !slices.Equal(names.Names, []string{"half"}) {
+		t.Errorf("parameters.dependents(width) = %v, want [half]", names.Names)
+	}
+	call(t, r, s, "parameters.drivenBy", `{"name":"half"}`, &names)
+	if !slices.Equal(names.Names, []string{"width"}) {
+		t.Errorf("parameters.drivenBy(half) = %v, want [width]", names.Names)
+	}
+}
+
+func TestParameterUpdatePresentation(t *testing.T) {
+	r, s := seededSession(t)
+	var d wire.ParameterDetail
+	call(t, r, s, "parameters.update", `{
+		"name":"width","comment":"outer width","isKey":true,"visible":false,
+		"precision":2,"displayFormat":"fractional","exposedAsProperty":true,
+		"customPropertyFormat":{"propertyType":"number","precision":"twoDecimalPlaces","showTrailingZeros":true}
+	}`, &d)
+	if d.Comment != "outer width" || !d.IsKey || d.Visible || d.Precision != 2 {
+		t.Errorf("updated detail = %+v, want comment/key/hidden/precision applied", d)
+	}
+	if d.DisplayFormat != "fractional" || !d.ExposedAsProperty {
+		t.Errorf("format/exposure = %q/%v, want fractional/true", d.DisplayFormat, d.ExposedAsProperty)
+	}
+	cp := d.CustomPropertyFormat
+	if cp == nil || cp.PropertyType != "number" || cp.Precision != "twoDecimalPlaces" || !cp.ShowTrailingZeros {
+		t.Errorf("custom property format = %+v, want number/twoDecimalPlaces/trailing zeros", cp)
+	}
+	// Unsent fields stay untouched: a second update changing only the comment
+	// must not reset the rest.
+	call(t, r, s, "parameters.update", `{"name":"width","comment":"narrower"}`, &d)
+	if d.Comment != "narrower" || !d.IsKey || d.DisplayFormat != "fractional" {
+		t.Errorf("partial update clobbered other fields: %+v", d)
+	}
+}
+
+func TestParameterUpdateRejectsUnknownSpellings(t *testing.T) {
+	r, s := seededSession(t)
+	for args, want := range map[string]string{
+		`{"name":"width","displayFormat":"roman"}`:                                                       "display format",
+		`{"name":"width","modelValueType":"midpoint"}`:                                                   "model value type",
+		`{"name":"width","customPropertyFormat":{"propertyType":"blob","precision":"twoDecimalPlaces"}}`: "custom property type",
+		`{"name":"nope","comment":"x"}`:                                                                  "no parameter named",
+	} {
+		if _, err := r.Handle(s, "parameters.update", []byte(args)); err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("update(%s) err = %v, want it to mention %q", args, err, want)
+		}
+	}
+}
+
+func TestParameterToleranceModesOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	// Each mutation's response is checked through a fresh getDetail: omitempty
+	// fields would otherwise merge stale values when reusing one struct.
+	call(t, r, s, "parameters.setTolerance", `{"name":"width","mode":"symmetric","upper":"0.1 cm"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Tolerance.Type != "symmetric" || d.Tolerance.Upper != 0.1 || d.Tolerance.Lower != -0.1 {
+		t.Errorf("symmetric tolerance = %+v, want ±0.1", d.Tolerance)
+	}
+
+	// Limits are absolute values, stored as deviations from the 4 cm nominal.
+	call(t, r, s, "parameters.setTolerance", `{"name":"width","mode":"limits","upper":"4.3 cm","lower":"3.8 cm"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Tolerance.Type != "limitsStacked" || !approx(d.Tolerance.Upper, 0.3) || !approx(d.Tolerance.Lower, -0.2) {
+		t.Errorf("limits tolerance = %+v, want +0.3/-0.2", d.Tolerance)
+	}
+
+	// The model-value selection picks a value inside the band; features consume it.
+	call(t, r, s, "parameters.update", `{"name":"width","modelValueType":"upper"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.ModelValueType != "upper" || !approx(d.ModelValue, 4.3) {
+		t.Errorf("model value after upper selection = %v (%s), want 4.3", d.ModelValue, d.ModelValueType)
+	}
+
+	call(t, r, s, "parameters.setTolerance", `{"name":"width","mode":"max"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Tolerance.Type != "max" || d.Tolerance.Upper != 0 || d.Tolerance.Lower != 0 {
+		t.Errorf("max tolerance = %+v, want bandless max", d.Tolerance)
+	}
+
+	call(t, r, s, "parameters.setTolerance", `{"name":"width","mode":"default"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Tolerance.Type != "default" || !approx(d.ModelValue, 4) {
+		t.Errorf("default tolerance = %+v model=%v, want default band and the nominal back", d.Tolerance, d.ModelValue)
+	}
+}
+
+func TestParameterToleranceRejectsBadInput(t *testing.T) {
+	r, s := seededSession(t)
+	for args, want := range map[string]string{
+		`{"name":"width","mode":"wobbly"}`:                                       "unknown mode",
+		`{"name":"width","mode":"symmetric"}`:                                    "upper value is required",
+		`{"name":"width","mode":"deviation","upper":"0.1 cm"}`:                   "lower value is required",
+		`{"name":"width","mode":"symmetric","upper":"banana"}`:                   "banana",
+		`{"name":"width","mode":"deviation","upper":"-0.1 cm","lower":"0.1 cm"}`: "upper",
+	} {
+		if _, err := r.Handle(s, "parameters.setTolerance", []byte(args)); err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("setTolerance(%s) err = %v, want it to mention %q", args, err, want)
+		}
+	}
+}
+
+func TestParameterExpressionListOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	call(t, r, s, "parameters.setExpressionList",
+		`{"name":"width","expressions":["6 cm","4 cm"],"allowCustomValues":true,"customOrder":true}`, nil)
+	if el := getDetail(t, r, s, "width").ExpressionList; el == nil || !slices.Equal(el.Expressions, []string{"6 cm", "4 cm"}) || !el.AllowCustomValues || !el.CustomOrder {
+		t.Fatalf("expression list = %+v, want authored order [6 cm, 4 cm] with custom values", el)
+	}
+
+	// customOrder=false sorts the choices (the reference CustomOrder=False).
+	call(t, r, s, "parameters.setExpressionList",
+		`{"name":"width","expressions":["6 cm","4 cm"],"customOrder":false}`, nil)
+	if el := getDetail(t, r, s, "width").ExpressionList; el == nil || !slices.Equal(el.Expressions, []string{"4 cm", "6 cm"}) || el.CustomOrder {
+		t.Errorf("sorted expression list = %+v, want [4 cm, 6 cm]", el)
+	}
+
+	// An empty list returns the parameter to single-valued.
+	call(t, r, s, "parameters.setExpressionList", `{"name":"width"}`, nil)
+	if el := getDetail(t, r, s, "width").ExpressionList; el != nil {
+		t.Errorf("cleared expression list = %+v, want single-valued", el)
+	}
+}
+
+func TestParameterDeleteRejectsInUse(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"half","expression":"width / 2"}`, nil)
+
+	// width drives half, so deleting it must name the blocker.
+	if _, err := r.Handle(s, "parameters.delete", []byte(`{"name":"width"}`)); err == nil || !strings.Contains(err.Error(), "half") {
+		t.Fatalf("delete(width) err = %v, want in-use rejection naming half", err)
+	}
+
+	call(t, r, s, "parameters.delete", `{"name":"half"}`, nil)
+	call(t, r, s, "parameters.delete", `{"name":"width"}`, nil)
+	if _, err := r.Handle(s, "parameters.getDetail", []byte(`{"name":"width"}`)); err == nil {
+		t.Fatal("width still resolvable after delete")
+	}
+}
+
+// TestParameterDetailMutationsAreUndoable drives a wire mutation against a
+// recording session and checks RecordAddInEdit lands it as one undo step.
+func TestParameterDetailMutationsAreUndoable(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	// Add through the recording Session seam (wire parameters.add does not record
+	// its own undo step yet) so the undo baseline holds the parameter.
+	if err := s.AddNumericUserParameter("h", "3 cm"); err != nil {
+		t.Fatalf("add param: %v", err)
+	}
+	call(t, r, s, "parameters.update", `{"name":"h","comment":"the height"}`, nil)
+
+	var st wire.UndoState
+	call(t, r, s, "transaction.state", "{}", &st)
+	if !st.CanUndo || st.NextUndo != "Edit Parameter" {
+		t.Fatalf("state after update = %+v, want one Edit Parameter undo step", st)
+	}
+	call(t, r, s, "transaction.undo", "{}", &st)
+	if d := getDetail(t, r, s, "h"); d.Comment != "" {
+		t.Errorf("comment after undo = %q, want it reverted", d.Comment)
+	}
+}
+
+// TestParameterDetailMutationsBroadcast checks the new mutation methods emit
+// edit.committed (the replication seam) and the detail read does not.
+func TestParameterDetailMutationsBroadcast(t *testing.T) {
+	r, s := seededSession(t)
+	var methods []string
+	sub := event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
+		methods = append(methods, e.Method)
+		return event.Continue()
+	})
+	defer sub.Cancel()
+
+	call(t, r, s, "parameters.getDetail", `{"name":"width"}`, nil)
+	call(t, r, s, "parameters.update", `{"name":"width","comment":"c"}`, nil)
+	call(t, r, s, "parameters.setTolerance", `{"name":"width","mode":"symmetric","upper":"0.1 cm"}`, nil)
+	call(t, r, s, "parameters.setExpressionList", `{"name":"width","expressions":["4 cm","6 cm"]}`, nil)
+	call(t, r, s, "parameters.delete", `{"name":"width"}`, nil)
+
+	want := []string{
+		wire.MethodParametersUpdate, wire.MethodParametersSetTolerance,
+		wire.MethodParametersSetExpressionList, wire.MethodParametersDelete,
+	}
+	if !slices.Equal(methods, want) {
+		t.Errorf("edit.committed methods = %v, want %v (and none for getDetail)", methods, want)
+	}
+}
+
+// approx absorbs float noise from unit conversion round-trips.
+func approx(got, want float64) bool {
+	const eps = 1e-9
+	return got-want < eps && want-got < eps
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -78,6 +78,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodParametersGet] = getParameter
 	r.handlers[wire.MethodParametersAdd] = addParameter
 	r.handlers[wire.MethodParametersSet] = setParameter
+	r.registerParameterDetailHandlers()
 	r.handlers[wire.MethodModelTree] = modelTree
 	r.handlers[wire.MethodModelSelection] = modelSelection
 	r.handlers[wire.MethodModelReferenceKeys] = referenceKeys
@@ -117,6 +118,19 @@ func (r *Router) registerTransactionHandlers() {
 	r.handlers[wire.MethodTransactionState] = transactionState
 	r.handlers[wire.MethodTransactionBegin] = beginTransaction
 	r.handlers[wire.MethodTransactionEnd] = endTransaction
+}
+
+// registerParameterDetailHandlers wires the member-level parameter surface —
+// detail reads, presentation/tolerance/value-list mutations, dependency queries
+// and delete (M02-F08, Oblikovati#607).
+func (r *Router) registerParameterDetailHandlers() {
+	r.handlers[wire.MethodParametersGetDetail] = getParameterDetail
+	r.handlers[wire.MethodParametersUpdate] = updateParameter
+	r.handlers[wire.MethodParametersSetTolerance] = setParameterTolerance
+	r.handlers[wire.MethodParametersSetExpressionList] = setParameterExpressionList
+	r.handlers[wire.MethodParametersDelete] = deleteParameter
+	r.handlers[wire.MethodParametersDrivenBy] = parameterDrivenBy
+	r.handlers[wire.MethodParametersDependents] = parameterDependents
 }
 
 // registerSketchHandlers wires the 2D-sketch methods: the spine + enumeration here, and
@@ -295,41 +309,45 @@ func (r *Router) Handle(s *app.Session, method string, req []byte) (resp []byte,
 // allowlist: a method missing here simply is not broadcast (a known first-cut gap,
 // failing safe), whereas a read-only method must never appear (it would broadcast noise).
 var mutatingMethods = map[string]bool{
-	wire.MethodDocumentsCreate:         true,
-	wire.MethodDocumentsImport:         true,
-	wire.MethodParametersAdd:           true,
-	wire.MethodParametersSet:           true,
-	wire.MethodFeaturesAdd:             true,
-	wire.MethodFeaturesEdit:            true,
-	wire.MethodFeaturesDelete:          true,
-	wire.MethodFeaturesRename:          true,
-	wire.MethodFeaturesSetSuppressed:   true,
-	wire.MethodFeaturesReorder:         true,
-	wire.MethodWorkPlanesCreate:        true,
-	wire.MethodWorkPlanesRedefine:      true,
-	wire.MethodWorkPointsCreate:        true,
-	wire.MethodModelAssignMaterial:     true,
-	wire.MethodModelAssignAppearance:   true,
-	wire.MethodSketchCreate:            true,
-	wire.MethodSketchRectangle:         true,
-	wire.MethodSketchDelete:            true,
-	wire.MethodSketchEdit:              true,
-	wire.MethodSketchExitEdit:          true,
-	wire.MethodSketchSolve:             true,
-	wire.MethodSketchAddEntity:         true,
-	wire.MethodSketchAddConstraint:     true,
-	wire.MethodSketchDeleteConstraint:  true,
-	wire.MethodSketchAddDimension:      true,
-	wire.MethodSketchDriveDimension:    true,
-	wire.MethodSketchSetProperty:       true,
-	wire.MethodSketchSetCustomLineType: true,
-	wire.MethodSketchTransform:         true,
-	wire.MethodSketchAddPattern:        true,
-	wire.MethodSketchOffset:            true,
-	wire.MethodSketchProject:           true,
-	wire.MethodTransactionUndo:         true,
-	wire.MethodTransactionRedo:         true,
-	wire.MethodTransactionEnd:          true,
+	wire.MethodDocumentsCreate:             true,
+	wire.MethodDocumentsImport:             true,
+	wire.MethodParametersAdd:               true,
+	wire.MethodParametersSet:               true,
+	wire.MethodParametersUpdate:            true,
+	wire.MethodParametersSetTolerance:      true,
+	wire.MethodParametersSetExpressionList: true,
+	wire.MethodParametersDelete:            true,
+	wire.MethodFeaturesAdd:                 true,
+	wire.MethodFeaturesEdit:                true,
+	wire.MethodFeaturesDelete:              true,
+	wire.MethodFeaturesRename:              true,
+	wire.MethodFeaturesSetSuppressed:       true,
+	wire.MethodFeaturesReorder:             true,
+	wire.MethodWorkPlanesCreate:            true,
+	wire.MethodWorkPlanesRedefine:          true,
+	wire.MethodWorkPointsCreate:            true,
+	wire.MethodModelAssignMaterial:         true,
+	wire.MethodModelAssignAppearance:       true,
+	wire.MethodSketchCreate:                true,
+	wire.MethodSketchRectangle:             true,
+	wire.MethodSketchDelete:                true,
+	wire.MethodSketchEdit:                  true,
+	wire.MethodSketchExitEdit:              true,
+	wire.MethodSketchSolve:                 true,
+	wire.MethodSketchAddEntity:             true,
+	wire.MethodSketchAddConstraint:         true,
+	wire.MethodSketchDeleteConstraint:      true,
+	wire.MethodSketchAddDimension:          true,
+	wire.MethodSketchDriveDimension:        true,
+	wire.MethodSketchSetProperty:           true,
+	wire.MethodSketchSetCustomLineType:     true,
+	wire.MethodSketchTransform:             true,
+	wire.MethodSketchAddPattern:            true,
+	wire.MethodSketchOffset:                true,
+	wire.MethodSketchProject:               true,
+	wire.MethodTransactionUndo:             true,
+	wire.MethodTransactionRedo:             true,
+	wire.MethodTransactionEnd:              true,
 }
 
 // record appends an operation entry to the trace, except for logs.tail itself (so polling the

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -74,11 +74,14 @@ func (s *Session) SetParameterExport(id param.ID, export bool) error {
 	return s.editParam(id, func(p *param.Parameter) error { p.ExposedAsProperty = export; return nil })
 }
 
-// SetParameterTolerance sets a numeric parameter's engineering tolerance band.
+// SetParameterTolerance sets a numeric parameter's engineering tolerance band
+// (stored as a deviation tolerance) and which value within it the model uses.
 func (s *Session) SetParameterTolerance(id param.ID, upper, lower float64, kind param.ModelValueType) error {
 	return s.editParam(id, func(p *param.Parameter) error {
-		p.SetTolerance(param.Tolerance{Upper: upper, Lower: lower, Type: kind})
-		return nil
+		if err := p.SetToleranceDeviation(upper, lower); err != nil {
+			return err
+		}
+		return p.SetModelValueType(kind)
 	})
 }
 

--- a/app/undo.go
+++ b/app/undo.go
@@ -89,6 +89,13 @@ func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string
 	dh.snapshot = after
 }
 
+// RecordAddInEdit finalizes a router-applied mutation as one undo step: the
+// add-in wire path has no interactive tool to call recordEdit, so its handlers
+// call this exported seam after their recompute (M02-F08, Oblikovati#607).
+func (s *Session) RecordAddInEdit(part *compdef.PartComponentDefinition, label string) {
+	s.recordEdit(part, label)
+}
+
 // ErrNoOpenTransaction is returned by EndTransaction when no bounded transaction is open.
 var ErrNoOpenTransaction = errors.New("app: no open transaction to end")
 

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -5,6 +5,8 @@ package compdef
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
+
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
@@ -68,29 +70,55 @@ func (si sketchIndex) At(i int) (*sketch.Sketch, bool) {
 // the shared presentation/behavior state (comment, key, export, precision, tolerance,
 // multi-value list, group membership).
 type parameterRecipe struct {
-	Name        string           `yaml:"name"`
-	Kind        string           `yaml:"kind"`
-	ValueType   string           `yaml:"valueType,omitempty"` // "text" | "boolean"; numeric when empty
-	Expression  string           `yaml:"expression,omitempty"`
-	Text        string           `yaml:"text,omitempty"`
-	Bool        bool             `yaml:"bool,omitempty"`
-	Value       float64          `yaml:"value,omitempty"`
-	Unit        string           `yaml:"unit,omitempty"`
-	Comment     string           `yaml:"comment,omitempty"`
-	Key         bool             `yaml:"key,omitempty"`
-	Export      bool             `yaml:"export,omitempty"`
-	Precision   int              `yaml:"precision,omitempty"`
-	Tolerance   *toleranceRecipe `yaml:"tolerance,omitempty"`
-	ExprList    []string         `yaml:"expressionList,omitempty"`
-	AllowCustom bool             `yaml:"allowCustomValue,omitempty"`
-	Group       string           `yaml:"group,omitempty"`
+	Name       string           `yaml:"name"`
+	Kind       string           `yaml:"kind"`
+	ValueType  string           `yaml:"valueType,omitempty"` // "text" | "boolean"; numeric when empty
+	Expression string           `yaml:"expression,omitempty"`
+	Text       string           `yaml:"text,omitempty"`
+	Bool       bool             `yaml:"bool,omitempty"`
+	Value      float64          `yaml:"value,omitempty"`
+	Unit       string           `yaml:"unit,omitempty"`
+	Comment    string           `yaml:"comment,omitempty"`
+	Key        bool             `yaml:"key,omitempty"`
+	Export     bool             `yaml:"export,omitempty"`
+	Precision  int              `yaml:"precision,omitempty"`
+	Tolerance  *toleranceRecipe `yaml:"tolerance,omitempty"`
+	// ModelValueType is the tolerance-band selection's wire spelling; empty
+	// means nominal (Oblikovati#607).
+	ModelValueType string   `yaml:"modelValueType,omitempty"`
+	ExprList       []string `yaml:"expressionList,omitempty"`
+	AllowCustom    bool     `yaml:"allowCustomValue,omitempty"`
+	// SortedValueList is the inverse of the in-memory CustomOrder flag: a saved
+	// multi-value list is authored-order by default, so only auto-sorted lists
+	// persist a marker.
+	SortedValueList bool   `yaml:"sortedValueList,omitempty"`
+	Group           string `yaml:"group,omitempty"`
+	// Hidden is the inverse of Visible (parameters default to visible, and the
+	// recipe omits zero values).
+	Hidden bool `yaml:"hidden,omitempty"`
+	// DisplayFormat is the wire spelling; empty means decimal.
+	DisplayFormat  string                `yaml:"displayFormat,omitempty"`
+	CustomProperty *customPropertyRecipe `yaml:"customProperty,omitempty"`
 }
 
-// toleranceRecipe is the persisted form of a non-zero engineering tolerance.
+// toleranceRecipe is the persisted form of a non-zero engineering tolerance:
+// the flavor's wire spelling plus the deviation band in database units.
 type toleranceRecipe struct {
+	Type  string  `yaml:"type,omitempty"`
 	Upper float64 `yaml:"upper,omitempty"`
 	Lower float64 `yaml:"lower,omitempty"`
-	Type  uint8   `yaml:"type,omitempty"`
+}
+
+// customPropertyRecipe persists a non-default custom-property format (the
+// formatting of a parameter exposed as a document property). Enum fields carry
+// wire spellings.
+type customPropertyRecipe struct {
+	PropertyType      string `yaml:"propertyType,omitempty"`
+	Units             string `yaml:"units,omitempty"`
+	Precision         string `yaml:"precision,omitempty"`
+	ShowLeadingZeros  bool   `yaml:"showLeadingZeros,omitempty"`
+	ShowTrailingZeros bool   `yaml:"showTrailingZeros,omitempty"`
+	ShowUnitsString   bool   `yaml:"showUnitsString,omitempty"`
 }
 
 // unitCategories are the display-unit categories a document persists, in a stable
@@ -267,13 +295,28 @@ func (d *PartComponentDefinition) parameterRecipeOf(p *param.Parameter) paramete
 		pr.Value, pr.Unit = p.Value().Value, p.Value().Unit.String()
 	}
 	if t := p.Tolerance(); t != (param.Tolerance{}) {
-		pr.Tolerance = &toleranceRecipe{Upper: t.Upper, Lower: t.Lower, Type: uint8(t.Type)}
+		pr.Tolerance = &toleranceRecipe{Type: t.Kind().String(), Upper: t.Upper, Lower: t.Lower}
+	}
+	if m := p.ModelValueType(); m != param.Nominal {
+		pr.ModelValueType = m.String()
 	}
 	if p.IsMultiValue() {
 		pr.ExprList, pr.AllowCustom = p.ExpressionList(), p.AllowsCustomValue()
+		pr.SortedValueList = !p.CustomOrder()
 	}
 	if g, ok := d.params.GroupOf(p.ID()); ok {
 		pr.Group = g
+	}
+	pr.Hidden = !p.Visible
+	if p.DisplayFormat != param.DisplayFormatDecimal {
+		pr.DisplayFormat = p.DisplayFormat.String()
+	}
+	if cp := p.CustomProperty; cp != param.DefaultCustomPropertyFormat() {
+		pr.CustomProperty = &customPropertyRecipe{
+			PropertyType: cp.PropertyType.String(), Units: cp.Units, Precision: cp.Precision.String(),
+			ShowLeadingZeros: cp.ShowLeadingZeros, ShowTrailingZeros: cp.ShowTrailingZeros,
+			ShowUnitsString: cp.ShowUnitsString,
+		}
 	}
 	return pr
 }
@@ -325,19 +368,101 @@ func (d *PartComponentDefinition) addParameter(pr parameterRecipe) (*param.Param
 }
 
 // applyParameterState restores the shared presentation/behavior fields onto a freshly
-// re-added parameter: comment, key, export, precision, tolerance, multi-value list, group.
+// re-added parameter: comment, key, export, precision, visibility, display format,
+// tolerance, multi-value list, custom-property format, group.
 func (d *PartComponentDefinition) applyParameterState(p *param.Parameter, pr parameterRecipe) error {
 	p.Comment, p.IsKey, p.ExposedAsProperty, p.Precision = pr.Comment, pr.Key, pr.Export, pr.Precision
-	if pr.Tolerance != nil {
-		p.SetTolerance(param.Tolerance{Upper: pr.Tolerance.Upper, Lower: pr.Tolerance.Lower, Type: param.ModelValueType(pr.Tolerance.Type)})
+	p.Visible = !pr.Hidden
+	if err := applyParameterFormats(p, pr); err != nil {
+		return err
 	}
-	if len(pr.ExprList) > 0 {
-		if err := p.SetExpressionList(pr.ExprList, pr.AllowCustom); err != nil {
-			return err
-		}
+	if err := applyParameterTolerance(p, pr); err != nil {
+		return err
+	}
+	if err := applyParameterValueList(p, pr); err != nil {
+		return err
 	}
 	if pr.Group != "" {
 		return d.params.AddToGroup(p.ID(), pr.Group)
+	}
+	return nil
+}
+
+// applyParameterFormats restores the display format and custom-property format
+// from their persisted wire spellings.
+func applyParameterFormats(p *param.Parameter, pr parameterRecipe) error {
+	if pr.DisplayFormat != "" {
+		f, ok := types.ParseParameterDisplayFormat(pr.DisplayFormat)
+		if !ok {
+			return fmt.Errorf("unknown display format %q (want decimal|fractional|architectural)", pr.DisplayFormat)
+		}
+		p.DisplayFormat = f
+	}
+	if pr.CustomProperty == nil {
+		return nil
+	}
+	cp, err := customPropertyFromRecipe(*pr.CustomProperty)
+	if err != nil {
+		return err
+	}
+	p.CustomProperty = cp
+	return nil
+}
+
+// customPropertyFromRecipe parses one persisted custom-property format,
+// defaulting absent enum spellings to the new-parameter defaults.
+func customPropertyFromRecipe(cr customPropertyRecipe) (param.CustomPropertyFormat, error) {
+	cp := param.DefaultCustomPropertyFormat()
+	cp.Units, cp.ShowLeadingZeros, cp.ShowTrailingZeros, cp.ShowUnitsString =
+		cr.Units, cr.ShowLeadingZeros, cr.ShowTrailingZeros, cr.ShowUnitsString
+	if cr.PropertyType != "" {
+		t, ok := types.ParseCustomPropertyType(cr.PropertyType)
+		if !ok {
+			return cp, fmt.Errorf("unknown custom property type %q (want text|number)", cr.PropertyType)
+		}
+		cp.PropertyType = t
+	}
+	if cr.Precision != "" {
+		prec, ok := types.ParseCustomPropertyPrecision(cr.Precision)
+		if !ok {
+			return cp, fmt.Errorf("unknown custom property precision %q", cr.Precision)
+		}
+		cp.Precision = prec
+	}
+	return cp, nil
+}
+
+// applyParameterTolerance restores the tolerance band and the model-value
+// selection from their persisted wire spellings.
+func applyParameterTolerance(p *param.Parameter, pr parameterRecipe) error {
+	if pr.Tolerance != nil {
+		t, ok := types.ParseToleranceType(pr.Tolerance.Type)
+		if !ok {
+			return fmt.Errorf("unknown tolerance type %q", pr.Tolerance.Type)
+		}
+		p.SetTolerance(param.Tolerance{Type: t, Upper: pr.Tolerance.Upper, Lower: pr.Tolerance.Lower})
+	}
+	if pr.ModelValueType == "" {
+		return nil
+	}
+	m, ok := types.ParseModelValueType(pr.ModelValueType)
+	if !ok {
+		return fmt.Errorf("unknown model value type %q (want nominal|lower|upper|median)", pr.ModelValueType)
+	}
+	return p.SetModelValueType(m)
+}
+
+// applyParameterValueList restores the multi-value choices, re-sorting when the
+// list was saved as auto-sorted.
+func applyParameterValueList(p *param.Parameter, pr parameterRecipe) error {
+	if len(pr.ExprList) == 0 {
+		return nil
+	}
+	if err := p.SetExpressionList(pr.ExprList, pr.AllowCustom); err != nil {
+		return err
+	}
+	if pr.SortedValueList {
+		p.SetCustomOrder(false)
 	}
 	return nil
 }

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
@@ -177,7 +178,11 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 
 	num, _ := ps.AddUserParameter("len", "10 mm")
 	num.Comment, num.IsKey, num.ExposedAsProperty = "the length", true, true
-	num.SetTolerance(param.Tolerance{Upper: 0.01, Lower: -0.02, Type: param.Median})
+	_ = num.SetToleranceDeviation(0.01, -0.02)
+	_ = num.SetModelValueType(param.Median)
+	num.DisplayFormat = param.DisplayFormatFractional
+	num.Visible = false
+	num.CustomProperty.PropertyType, num.CustomProperty.ShowTrailingZeros = types.CustomPropertyNumber, true
 	_ = num.SetExpressionList([]string{"10 mm", "20 mm"}, true)
 	txt, _ := ps.AddTextUserParameter("material", "steel")
 	flag, _ := ps.AddBooleanUserParameter("vented", true)
@@ -190,8 +195,20 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 	if rl.Comment != "the length" || !rl.IsKey || !rl.ExposedAsProperty {
 		t.Errorf("len comment/key/export not restored: %+v", rl)
 	}
-	if tol := rl.Tolerance(); tol.Upper != 0.01 || tol.Lower != -0.02 || tol.Type != param.Median {
-		t.Errorf("tolerance = %+v, want {0.01 -0.02 Median}", tol)
+	if tol := rl.Tolerance(); tol.Upper != 0.01 || tol.Lower != -0.02 || tol.Type != types.ToleranceDeviation {
+		t.Errorf("tolerance = %+v, want deviation {0.01 -0.02}", tol)
+	}
+	if rl.ModelValueType() != param.Median {
+		t.Errorf("model value type = %s, want median", rl.ModelValueType())
+	}
+	if rl.DisplayFormat != param.DisplayFormatFractional || rl.Visible {
+		t.Errorf("display format/visibility not restored: %s visible=%v", rl.DisplayFormat, rl.Visible)
+	}
+	if cp := rl.CustomProperty; cp.PropertyType != types.CustomPropertyNumber || !cp.ShowTrailingZeros || !cp.ShowLeadingZeros {
+		t.Errorf("custom property format not restored: %+v", cp)
+	}
+	if !rl.CustomOrder() {
+		t.Error("multi-value list must restore as authored-order")
 	}
 	if !rl.IsMultiValue() || !rl.AllowsCustomValue() || len(rl.ExpressionList()) != 2 {
 		t.Errorf("multi-value not restored: %v custom=%v", rl.ExpressionList(), rl.AllowsCustomValue())

--- a/model/param/custom_property.go
+++ b/model/param/custom_property.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "oblikovati.org/api/types"
+
+// CustomPropertyFormat controls how a parameter's value is formatted when it is
+// exposed as a custom document property (Parameter.ExposedAsProperty): text vs
+// number, the display unit (empty means the document's display unit), the
+// precision, and zero/unit-string rendering. Mirrors the reference API's
+// CustomPropertyFormat object (Oblikovati#607).
+type CustomPropertyFormat struct {
+	PropertyType      types.CustomPropertyType
+	Units             string
+	Precision         types.CustomPropertyPrecision
+	ShowLeadingZeros  bool
+	ShowTrailingZeros bool
+	ShowUnitsString   bool
+}
+
+// DefaultCustomPropertyFormat is the format every new parameter starts with:
+// a text property in the document display unit, three decimal places, leading
+// zeros and the unit string shown.
+func DefaultCustomPropertyFormat() CustomPropertyFormat {
+	return CustomPropertyFormat{
+		PropertyType:     types.CustomPropertyText,
+		Precision:        types.PrecisionThreeDecimalPlaces,
+		ShowLeadingZeros: true,
+		ShowUnitsString:  true,
+	}
+}

--- a/model/param/expression_list.go
+++ b/model/param/expression_list.go
@@ -2,9 +2,12 @@
 
 package param
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
-// Multi-value parameters (Inventor's ExpressionList): a parameter can offer a fixed list
+// Multi-value parameters (the reference API's ExpressionList): a parameter can offer a fixed list
 // of allowed expressions chosen from a dropdown, optionally accepting one custom value
 // outside the list. The current selection is just the parameter's expression — the
 // dropdown the UI shows is the list plus the current value when it is a custom one, so
@@ -12,20 +15,35 @@ import "fmt"
 
 // SetExpressionList makes the parameter multi-value with the given choices. allowCustom
 // permits selecting a value outside the list. An empty list clears the multi-value state.
-// It does not change the current value.
+// It does not change the current value. The authored order is kept (CustomOrder becomes
+// true, per the reference ExpressionList); SetCustomOrder(false) re-enables sorting.
 func (p *Parameter) SetExpressionList(list []string, allowCustom bool) error {
 	if !p.kind.Editable() {
 		return fmt.Errorf("param: %s parameter %q is read-only", p.kind, p.name)
 	}
 	p.exprList = append([]string(nil), list...)
 	p.allowCustom = allowCustom && len(list) > 0
+	p.customOrder = len(list) > 0
 	return nil
 }
 
 // ClearExpressionList drops the multi-value choices, returning the parameter to a plain
 // single value (its current value is kept).
 func (p *Parameter) ClearExpressionList() {
-	p.exprList, p.allowCustom = nil, false
+	p.exprList, p.allowCustom, p.customOrder = nil, false, false
+}
+
+// CustomOrder reports whether the multi-value choices stay in authored order
+// (true) instead of being kept sorted (false).
+func (p *Parameter) CustomOrder() bool { return p.customOrder }
+
+// SetCustomOrder toggles authored-order presentation; turning it off sorts the
+// current choices alphabetically (the reference behavior of CustomOrder=False).
+func (p *Parameter) SetCustomOrder(custom bool) {
+	p.customOrder = custom && p.IsMultiValue()
+	if !custom {
+		sort.Strings(p.exprList)
+	}
 }
 
 // ExpressionList returns the multi-value choices (empty when single-valued).

--- a/model/param/expression_list_test.go
+++ b/model/param/expression_list_test.go
@@ -66,3 +66,20 @@ func TestClearExpressionList(t *testing.T) {
 		t.Error("ClearExpressionList should make the parameter single-valued")
 	}
 }
+
+func TestCustomOrderKeepsAuthoredOrderUntilDisabled(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 mm")
+	_ = p.SetExpressionList([]string{"20 mm", "10 mm"}, false)
+	if !p.CustomOrder() {
+		t.Fatal("SetExpressionList must keep authored order (CustomOrder=true)")
+	}
+	if l := p.ExpressionList(); l[0] != "20 mm" {
+		t.Errorf("list = %v, want authored order [20 mm, 10 mm]", l)
+	}
+	// Turning custom order off sorts the choices (the reference CustomOrder=False).
+	p.SetCustomOrder(false)
+	if l := p.ExpressionList(); l[0] != "10 mm" || p.CustomOrder() {
+		t.Errorf("after SetCustomOrder(false): list = %v custom=%v, want sorted/false", l, p.CustomOrder())
+	}
+}

--- a/model/param/graph.go
+++ b/model/param/graph.go
@@ -59,6 +59,17 @@ func (ps *Parameters) DrivenBy(id ID) []ID { return ps.orderedSet(ps.drivenBy[id
 // Dependents returns the parameters that read this one, in insertion order.
 func (ps *Parameters) Dependents(id ID) []ID { return ps.orderedSet(ps.dependents[id]) }
 
+// InUse reports whether the parameter currently drives anything: another
+// parameter reads it, or it is a model parameter (owned by a feature/dimension,
+// which consumes its model value by construction).
+func (ps *Parameters) InUse(id ID) bool {
+	if len(ps.dependents[id]) > 0 {
+		return true
+	}
+	p, ok := ps.byID[id]
+	return ok && p.kind == ModelParam
+}
+
 // rebind resolves the parameter's references to ids, rejects a resulting cycle,
 // rewires its edges, and recomputes it together with its dependents.
 func (ps *Parameters) rebind(id ID) error {

--- a/model/param/graph_test.go
+++ b/model/param/graph_test.go
@@ -150,3 +150,25 @@ func TestDeleteDriverSickensDependents(t *testing.T) {
 		t.Errorf("dependent health after driver delete = %+v, want Failed", h.Health())
 	}
 }
+
+func TestInUseFollowsDependentsAndModelKind(t *testing.T) {
+	ps := NewParameters()
+	free, _ := ps.AddUserParameter("free", "1 mm")
+	driver, _ := ps.AddUserParameter("od", "10 mm")
+	dependent, _ := ps.AddUserParameter("wall", "od / 5")
+	dim, _ := ps.AddModelParameter("d0", "2 mm")
+
+	if ps.InUse(free.ID()) {
+		t.Error("an unreferenced user parameter is not in use")
+	}
+	if !ps.InUse(driver.ID()) {
+		t.Error("a parameter read by another is in use")
+	}
+	if ps.InUse(dependent.ID()) {
+		t.Error("a leaf dependent is not in use")
+	}
+	// Model parameters belong to a feature dimension, so they are always in use.
+	if !ps.InUse(dim.ID()) {
+		t.Error("a model parameter is in use by construction")
+	}
+}

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -61,6 +61,11 @@ type Parameter struct {
 
 	exprList    []string // multi-value choices (empty ⇒ single-valued); see expression_list.go
 	allowCustom bool     // a value outside exprList is accepted (the one custom value)
+	customOrder bool     // keep exprList in authored order instead of sorting it
+
+	// modelValueType selects which value within the tolerance band the model
+	// consumes; the zero value reads as Nominal (see ModelValueType).
+	modelValueType ModelValueType
 
 	Comment           string
 	IsKey             bool
@@ -68,6 +73,7 @@ type Parameter struct {
 	Precision         int
 	DisplayFormat     ParameterDisplayFormat
 	ExposedAsProperty bool
+	CustomProperty    CustomPropertyFormat
 }
 
 // ID returns the parameter's stable identity.
@@ -98,9 +104,44 @@ func (p *Parameter) Bool() bool { return p.IsBoolean() && p.value.Value != 0 }
 // Value returns the evaluated quantity (database units).
 func (p *Parameter) Value() Quantity { return p.value }
 
-// ModelValue returns the value the model consumes after the tolerance is
-// applied (database units).
-func (p *Parameter) ModelValue() float64 { return p.tol.ModelValue(p.value.Value) }
+// ModelValue returns the value the model consumes after the tolerance band and
+// the parameter's model-value selection are applied (database units).
+func (p *Parameter) ModelValue() float64 {
+	switch p.ModelValueType() {
+	case Upper:
+		return p.value.Value + p.tol.Upper
+	case Lower:
+		return p.value.Value + p.tol.Lower
+	case Median:
+		return p.value.Value + (p.tol.Upper+p.tol.Lower)/2
+	default:
+		return p.value.Value
+	}
+}
+
+// ModelValueType returns which value within the tolerance band the model
+// consumes; the zero value reads as Nominal.
+func (p *Parameter) ModelValueType() ModelValueType {
+	if p.modelValueType == 0 {
+		return Nominal
+	}
+	return p.modelValueType
+}
+
+// SetModelValueType selects which value within the tolerance band the model
+// consumes. It errors for non-numeric parameters and unknown selections.
+func (p *Parameter) SetModelValueType(m ModelValueType) error {
+	if err := p.requireNumericTolerance(); err != nil {
+		return err
+	}
+	switch m {
+	case Nominal, Upper, Lower, Median:
+		p.modelValueType = m
+		return nil
+	default:
+		return fmt.Errorf("param: unknown model value type %d for %q; want nominal/lower/upper/median", int32(m), p.name)
+	}
+}
 
 // Expression returns the authored expression source.
 func (p *Parameter) Expression() string { return p.expr.Source() }

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -183,7 +183,11 @@ func (ps *Parameters) add(name string, kind ParameterKind) (*Parameter, error) {
 	if _, exists := ps.byName[name]; exists {
 		return nil, fmt.Errorf("param: a parameter named %q already exists", name)
 	}
-	p := &Parameter{id: ps.nextID, name: name, kind: kind, Visible: true}
+	p := &Parameter{
+		id: ps.nextID, name: name, kind: kind, Visible: true,
+		DisplayFormat: DisplayFormatDecimal, modelValueType: Nominal,
+		CustomProperty: DefaultCustomPropertyFormat(),
+	}
 	ps.nextID++
 	ps.byID[p.id] = p
 	ps.byName[name] = p.id

--- a/model/param/tolerance.go
+++ b/model/param/tolerance.go
@@ -2,56 +2,127 @@
 
 package param
 
-// ModelValueType selects which value within an engineering tolerance band the
-// model actually consumes (contract: ModelValueTypeEnum). Stable explicit ids.
-type ModelValueType uint8
+import (
+	"fmt"
 
-const (
-	// Nominal uses the authored value, ignoring the tolerance band.
-	Nominal ModelValueType = 0
-	// Upper uses nominal + the upper deviation.
-	Upper ModelValueType = 1
-	// Lower uses nominal + the lower deviation.
-	Lower ModelValueType = 2
-	// Median uses nominal + the midpoint of the deviation band.
-	Median ModelValueType = 3
+	"oblikovati.org/api/types"
 )
 
-// Tolerance is an engineering tolerance: a deviation band (Upper, Lower, in
-// database units) plus the [ModelValueType] that decides which value the model
-// uses. The zero Tolerance is symmetric-zero with type Nominal — i.e. model
-// value equals nominal.
+// ToleranceType is the engineering-tolerance flavor. The type, its frozen ids,
+// String, and ParseToleranceType live in the Apache-2.0 contract
+// ([types.ToleranceType]); this alias keeps param spellings working (ADR-0018).
+type ToleranceType = types.ToleranceType
+
+// ModelValueType selects which value within the tolerance band the model
+// consumes. Aliased from the contract; the historical param.Nominal /
+// param.Upper / param.Lower / param.Median spellings are preserved below.
+type ModelValueType = types.ModelValueType
+
+const (
+	Nominal = types.ModelValueNominal
+	Upper   = types.ModelValueUpper
+	Lower   = types.ModelValueLower
+	Median  = types.ModelValueMedian
+)
+
+// ParameterDisplayFormat is how a parameter's numeric value is rendered
+// (decimal, fractional, architectural). Aliased from the contract.
+type ParameterDisplayFormat = types.ParameterDisplayFormat
+
+const (
+	DisplayFormatDecimal       = types.DisplayFormatDecimal
+	DisplayFormatFractional    = types.DisplayFormatFractional
+	DisplayFormatArchitectural = types.DisplayFormatArchitectural
+)
+
+// Tolerance is an engineering tolerance: a flavor plus the deviation band from
+// the nominal value (Upper, Lower, database units). The zero Tolerance means
+// "standard/default tolerance, no explicit band" — [Tolerance.Kind] maps the
+// zero Type onto [types.ToleranceDefault] so existing `t != Tolerance{}`
+// has-explicit-tolerance checks keep working. Which value within the band the
+// model consumes is the parameter's [Parameter.ModelValueType], per the
+// reference API's split between Tolerance.ToleranceType and
+// Parameter.ModelValueType (Oblikovati#607).
 type Tolerance struct {
+	Type  ToleranceType
 	Upper float64
 	Lower float64
-	Type  ModelValueType
 }
 
-// ModelValue applies the tolerance to a nominal value, returning the value the
-// model consumes (all in database units).
-func (t Tolerance) ModelValue(nominal float64) float64 {
-	switch t.Type {
-	case Upper:
-		return nominal + t.Upper
-	case Lower:
-		return nominal + t.Lower
-	case Median:
-		return nominal + (t.Upper+t.Lower)/2
-	default:
-		return nominal
+// Kind returns the tolerance flavor, mapping the zero value to ToleranceDefault.
+func (t Tolerance) Kind() ToleranceType {
+	if t.Type == 0 {
+		return types.ToleranceDefault
 	}
+	return t.Type
 }
 
-// ParameterDisplayFormat controls how a parameter is presented (contract:
-// ParameterDisplayFormatEnum). It affects display only, never the stored or
-// model value.
-type ParameterDisplayFormat uint8
+// SetToleranceDefault reverts the parameter to the standard/default tolerance
+// (no explicit band; the model value follows the nominal).
+func (p *Parameter) SetToleranceDefault() error {
+	if err := p.requireNumericTolerance(); err != nil {
+		return err
+	}
+	p.tol = Tolerance{}
+	return nil
+}
 
-const (
-	// ShowExpression displays the authored expression text.
-	ShowExpression ParameterDisplayFormat = 0
-	// ShowValue displays the evaluated value in the preferred unit.
-	ShowValue ParameterDisplayFormat = 1
-	// ShowTolerance displays the value with its tolerance band.
-	ShowTolerance ParameterDisplayFormat = 2
-)
+// SetToleranceDeviation sets an asymmetric deviation band: upper and lower are
+// deviations from nominal in database units, upper ≥ lower.
+func (p *Parameter) SetToleranceDeviation(upper, lower float64) error {
+	if err := p.requireNumericTolerance(); err != nil {
+		return err
+	}
+	if upper < lower {
+		return fmt.Errorf("param: deviation upper %g < lower %g for %q; want upper ≥ lower", upper, lower, p.name)
+	}
+	p.tol = Tolerance{Type: types.ToleranceDeviation, Upper: upper, Lower: lower}
+	return nil
+}
+
+// SetToleranceSymmetric sets a symmetric ± band: band ≥ 0, in database units.
+func (p *Parameter) SetToleranceSymmetric(band float64) error {
+	if err := p.requireNumericTolerance(); err != nil {
+		return err
+	}
+	if band < 0 {
+		return fmt.Errorf("param: symmetric tolerance band %g for %q must be ≥ 0", band, p.name)
+	}
+	p.tol = Tolerance{Type: types.ToleranceSymmetric, Upper: band, Lower: -band}
+	return nil
+}
+
+// SetToleranceLimits sets a limits tolerance from absolute limit values (in
+// database units): the band is stored as deviations from the current nominal.
+func (p *Parameter) SetToleranceLimits(upperLimit, lowerLimit float64) error {
+	if err := p.requireNumericTolerance(); err != nil {
+		return err
+	}
+	if upperLimit < lowerLimit {
+		return fmt.Errorf("param: limits upper %g < lower %g for %q; want upper ≥ lower", upperLimit, lowerLimit, p.name)
+	}
+	nominal := p.value.Value
+	p.tol = Tolerance{Type: types.ToleranceLimitsStacked, Upper: upperLimit - nominal, Lower: lowerLimit - nominal}
+	return nil
+}
+
+// SetToleranceMinMax marks the value as a MIN or MAX tolerance (no band).
+func (p *Parameter) SetToleranceMinMax(t ToleranceType) error {
+	if err := p.requireNumericTolerance(); err != nil {
+		return err
+	}
+	if t != types.ToleranceMin && t != types.ToleranceMax {
+		return fmt.Errorf("param: SetToleranceMinMax(%s) for %q; want min or max", t, p.name)
+	}
+	p.tol = Tolerance{Type: t}
+	return nil
+}
+
+// requireNumericTolerance rejects tolerance edits on text and true/false
+// parameters, which carry no tolerance.
+func (p *Parameter) requireNumericTolerance() error {
+	if !p.IsNumeric() {
+		return fmt.Errorf("param: %q is a %s parameter; only numeric parameters carry a tolerance", p.name, p.value.Unit)
+	}
+	return nil
+}

--- a/model/param/tolerance_test.go
+++ b/model/param/tolerance_test.go
@@ -2,10 +2,13 @@
 
 package param
 
-import "testing"
+import (
+	"testing"
 
-func TestToleranceModelValue(t *testing.T) {
-	nominal := 10.0
+	"oblikovati.org/api/types"
+)
+
+func TestModelValueFollowsModelValueType(t *testing.T) {
 	cases := []struct {
 		typ  ModelValueType
 		want float64
@@ -16,9 +19,16 @@ func TestToleranceModelValue(t *testing.T) {
 		{Median, 10.05}, // 10 + (0.2 + -0.1)/2
 	}
 	for _, c := range cases {
-		tol := Tolerance{Upper: 0.2, Lower: -0.1, Type: c.typ}
-		if got := tol.ModelValue(nominal); !approxScalar(got, c.want) {
-			t.Errorf("ModelValue(type=%d) = %v, want %v", c.typ, got, c.want)
+		ps := NewParameters()
+		p, _ := ps.AddUserParameter("d", "10 cm")
+		if err := p.SetToleranceDeviation(0.2, -0.1); err != nil {
+			t.Fatalf("SetToleranceDeviation: %v", err)
+		}
+		if err := p.SetModelValueType(c.typ); err != nil {
+			t.Fatalf("SetModelValueType(%s): %v", c.typ, err)
+		}
+		if got := p.ModelValue(); !approxScalar(got, c.want) {
+			t.Errorf("ModelValue(type=%s) = %v, want %v", c.typ, got, c.want)
 		}
 	}
 }
@@ -26,7 +36,12 @@ func TestToleranceModelValue(t *testing.T) {
 func TestToleranceAffectsModelValueNotNominal(t *testing.T) {
 	ps := NewParameters()
 	p, _ := ps.AddUserParameter("d", "10 cm")
-	p.SetTolerance(Tolerance{Upper: 0.2, Lower: -0.2, Type: Upper})
+	if err := p.SetToleranceDeviation(0.2, -0.2); err != nil {
+		t.Fatalf("SetToleranceDeviation: %v", err)
+	}
+	if err := p.SetModelValueType(Upper); err != nil {
+		t.Fatalf("SetModelValueType: %v", err)
+	}
 	if !approxScalar(p.Value().Value, 10) {
 		t.Errorf("nominal Value changed to %v, want 10", p.Value().Value)
 	}
@@ -35,12 +50,67 @@ func TestToleranceAffectsModelValueNotNominal(t *testing.T) {
 	}
 }
 
+func TestToleranceSetOperations(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 cm")
+
+	if err := p.SetToleranceSymmetric(0.05); err != nil {
+		t.Fatalf("SetToleranceSymmetric: %v", err)
+	}
+	if tol := p.Tolerance(); tol.Type != types.ToleranceSymmetric || tol.Upper != 0.05 || tol.Lower != -0.05 {
+		t.Errorf("symmetric tolerance = %+v, want ±0.05", tol)
+	}
+	// Limits are absolute values, stored as deviations from the 10 cm nominal.
+	if err := p.SetToleranceLimits(10.3, 9.8); err != nil {
+		t.Fatalf("SetToleranceLimits: %v", err)
+	}
+	if tol := p.Tolerance(); tol.Type != types.ToleranceLimitsStacked || !approxScalar(tol.Upper, 0.3) || !approxScalar(tol.Lower, -0.2) {
+		t.Errorf("limits tolerance = %+v, want +0.3/-0.2", tol)
+	}
+	if err := p.SetToleranceMinMax(types.ToleranceMax); err != nil {
+		t.Fatalf("SetToleranceMinMax: %v", err)
+	}
+	if tol := p.Tolerance(); tol.Type != types.ToleranceMax || tol.Upper != 0 {
+		t.Errorf("max tolerance = %+v, want bandless max", tol)
+	}
+	if err := p.SetToleranceDefault(); err != nil {
+		t.Fatalf("SetToleranceDefault: %v", err)
+	}
+	if tol := p.Tolerance(); tol != (Tolerance{}) || tol.Kind() != types.ToleranceDefault {
+		t.Errorf("default tolerance = %+v (kind %s), want zero/default", tol, tol.Kind())
+	}
+}
+
+func TestToleranceSetOperationsRejectBadInput(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d", "10 cm")
+	if err := p.SetToleranceDeviation(-0.1, 0.1); err == nil {
+		t.Error("deviation with upper < lower must be rejected")
+	}
+	if err := p.SetToleranceSymmetric(-0.1); err == nil {
+		t.Error("negative symmetric band must be rejected")
+	}
+	if err := p.SetToleranceMinMax(types.ToleranceSymmetric); err == nil {
+		t.Error("SetToleranceMinMax with a non-min/max type must be rejected")
+	}
+	if err := p.SetModelValueType(ModelValueType(7)); err == nil {
+		t.Error("unknown model value type must be rejected")
+	}
+	txt, _ := ps.AddTextUserParameter("label", "lid")
+	if err := txt.SetToleranceSymmetric(0.1); err == nil {
+		t.Error("tolerance on a text parameter must be rejected")
+	}
+	if err := txt.SetModelValueType(Upper); err == nil {
+		t.Error("model value type on a text parameter must be rejected")
+	}
+}
+
 func TestPrecisionIsDisplayOnly(t *testing.T) {
 	ps := NewParameters()
 	p, _ := ps.AddUserParameter("d", "10 cm")
 	before := p.Value()
 	p.Precision = 2
-	p.DisplayFormat = ShowValue
+	p.DisplayFormat = DisplayFormatFractional
 	// Changing precision/format must not touch the stored value or model value.
 	if p.Value() != before || !approxScalar(p.ModelValue(), 10) {
 		t.Errorf("precision changed numeric state: value=%v modelValue=%v", p.Value(), p.ModelValue())


### PR DESCRIPTION
## What

Implements the /source half of #607 (the contract half merged as Oblikovati/api#60): the full member-level parameter surface, served over `addin/router` from the `api/wire` constants.

- **Tolerance**: mode-specific setters (default / deviation / symmetric / limits / min / max) with a `ToleranceType` flavor aliased from `api/types`; the model-value selection (`nominal|lower|upper|median`) moves onto the parameter, matching the reference API's split, and shifts the value features consume.
- **Dependency graph**: `parameters.drivenBy` / `parameters.dependents` answer by name; `Parameters.InUse` guards deletion.
- **Expression list**: authored-order vs sorted choices (`CustomOrder`), custom-value allowance, clearing returns the parameter to single-valued.
- **Lifecycle**: `parameters.delete` rejects an in-use parameter naming its blockers; deletions, like every mutation here, land as one undo step through the new `Session.RecordAddInEdit` seam and broadcast `edit.committed` for replication.
- **Presentation/exposure**: comment, key, visibility, precision, display format, and the custom-property format (`text|number`, precision, zero/unit rendering) behind `parameters.update` with unsent-field semantics (pointer args).
- **Persistence**: all new state round-trips through `.obk` by wire spellings, not raw enum ints.

## Why

Add-ins could only read `{name, kind, expression, value, health}` — no tolerance, no value dropdown, no way to discover what drives a dimension or to delete a parameter safely. This closes the M02 gap against the reference parameter API.

## Tests

- `model/param`: tolerance mode setters + rejection cases, model-value selection, custom-order semantics, `InUse` across kinds.
- `model/compdef`: round-trip of every new persisted field.
- `addin/router`: detail defaults, dependency neighborhood, update (partial-update semantics + unknown-spelling rejections), every tolerance mode over the wire, expression-list ordering, in-use delete rejection, undo integration, `edit.committed` broadcast coverage.

Full suite, `go vet`, and golangci-lint v2.1.0 (the CI pin) are green locally.

Closes #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)