### PR TITLE
M02-F07: implement parameter settings, tolerance sweeps & XML exchange

### DIFF
--- a/addin/router/parameter_settings.go
+++ b/addin/router/parameter_settings.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/param"
+)
+
+// Document-level parameter settings, tolerance sweeps, and parameter-set XML
+// exchange over the wire (M02-F07, Oblikovati#606): parameters.getSettings/
+// setSettings/setAllModelValueType/export/import.
+
+// parameterSettingsInfo marshals the live settings into their wire DTO.
+func parameterSettingsInfo(s *param.CollectionSettings) wire.ParameterSettingsInfo {
+	return wire.ParameterSettingsInfo{
+		LinearStandardTolerance:      s.LinearStandardTolerance,
+		AngularStandardTolerance:     s.AngularStandardTolerance,
+		UseStandardTolerances:        s.UseStandardTolerances,
+		ExportStandardTolerances:     s.ExportStandardTolerances,
+		LinearDimensionPrecision:     s.LinearDimensionPrecision,
+		AngularDimensionPrecision:    s.AngularDimensionPrecision,
+		DimensionDisplayType:         s.DimensionDisplayType.String(),
+		DisplayParameterAsExpression: s.DisplayParameterAsExpression,
+	}
+}
+
+// getParameterSettings returns the document's parameter settings.
+func getParameterSettings(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(parameterSettingsInfo(part.Parameters().Settings()))
+}
+
+// setParameterSettings applies the non-nil settings mutations, records one
+// undo step, and returns the updated settings.
+func setParameterSettings(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterSettingsUpdateArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	settings := part.Parameters().Settings()
+	if err := applySettingsUpdate(settings, in); err != nil {
+		return nil, err
+	}
+	s.RecordAddInEdit(part, "Edit Parameter Settings")
+	return json.Marshal(parameterSettingsInfo(settings))
+}
+
+// applySettingsUpdate copies the non-nil update fields onto the settings,
+// validating spellings and precision shape.
+func applySettingsUpdate(s *param.CollectionSettings, in wire.ParameterSettingsUpdateArgs) error {
+	setIfPresent(in.LinearStandardTolerance, &s.LinearStandardTolerance)
+	setIfPresent(in.AngularStandardTolerance, &s.AngularStandardTolerance)
+	setIfPresent(in.UseStandardTolerances, &s.UseStandardTolerances)
+	setIfPresent(in.ExportStandardTolerances, &s.ExportStandardTolerances)
+	setIfPresent(in.DisplayParameterAsExpression, &s.DisplayParameterAsExpression)
+	if err := applyPrecision(in.LinearDimensionPrecision, &s.LinearDimensionPrecision, "linear"); err != nil {
+		return err
+	}
+	if err := applyPrecision(in.AngularDimensionPrecision, &s.AngularDimensionPrecision, "angular"); err != nil {
+		return err
+	}
+	if in.DimensionDisplayType == nil {
+		return nil
+	}
+	display, ok := types.ParseDimensionDisplayType(*in.DimensionDisplayType)
+	if !ok {
+		return fmt.Errorf("parameters.setSettings: unknown dimension display type %q (want value|name|expression|tolerance|preciseValue)", *in.DimensionDisplayType)
+	}
+	s.DimensionDisplayType = display
+	return nil
+}
+
+// applyPrecision validates and applies one display precision (decimal places).
+func applyPrecision(in *int, dst *int, which string) error {
+	if in == nil {
+		return nil
+	}
+	if *in < 0 || *in > 8 {
+		return fmt.Errorf("parameters.setSettings: %s precision %d out of range; want 0–8 decimal places", which, *in)
+	}
+	*dst = *in
+	return nil
+}
+
+// sweepParameterModelValues drives every toleranced parameter's model-value
+// selection to one bound, recomputes (the consumed values move), and records
+// one undo step.
+func sweepParameterModelValues(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterSweepArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	m, ok := types.ParseModelValueType(in.ModelValueType)
+	if !ok {
+		return nil, fmt.Errorf("parameters.setAllModelValueType: unknown model value type %q (want nominal|lower|upper|median)", in.ModelValueType)
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	affected, err := part.Parameters().SetAllModelValueType(m)
+	if err != nil {
+		return nil, err
+	}
+	part.Features().MarkAllDirty()
+	part.Recompute()
+	s.RecordAddInEdit(part, "Sweep Tolerances")
+	return json.Marshal(wire.ParameterSweepResult{Affected: affected})
+}
+
+// exportParameters renders the user parameters as the exchange XML (read-only).
+func exportParameters(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	xml, err := part.Parameters().ExportXML()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ParameterExportResult{XML: xml})
+}
+
+// importParameters applies an exchange XML through the session's atomic
+// import seam (snapshot rollback on a bad set, one undo step on success).
+func importParameters(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ParameterImportArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	added, updated, err := s.ImportParameters(in.XML)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ParameterImportResult{Added: added, Updated: updated})
+}

--- a/addin/router/parameter_settings_test.go
+++ b/addin/router/parameter_settings_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// Parameter settings, tolerance sweeps & XML exchange over the wire
+// (M02-F07, Oblikovati#606).
+
+func TestParameterSettingsRoundTripOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	var got wire.ParameterSettingsInfo
+	call(t, r, s, "parameters.getSettings", "{}", &got)
+	if got.LinearDimensionPrecision != 3 || got.AngularDimensionPrecision != 2 || got.DimensionDisplayType != "value" {
+		t.Fatalf("default settings = %+v, want 3/2 precision and value display", got)
+	}
+
+	call(t, r, s, "parameters.setSettings", `{
+		"linearStandardTolerance":"0.1 mm","useStandardTolerances":true,
+		"linearDimensionPrecision":4,"dimensionDisplayType":"expression"
+	}`, &got)
+	if got.LinearStandardTolerance != "0.1 mm" || !got.UseStandardTolerances {
+		t.Errorf("standard tolerance = %+v, want 0.1 mm enabled", got)
+	}
+	if got.LinearDimensionPrecision != 4 || got.DimensionDisplayType != "expression" {
+		t.Errorf("precision/display = %d/%q, want 4/expression", got.LinearDimensionPrecision, got.DimensionDisplayType)
+	}
+	// Unsent fields stay untouched.
+	if got.AngularDimensionPrecision != 2 {
+		t.Errorf("angular precision = %d, want the untouched 2", got.AngularDimensionPrecision)
+	}
+
+	for args, want := range map[string]string{
+		`{"dimensionDisplayType":"hex"}`:   "dimension display type",
+		`{"linearDimensionPrecision":12}`:  "out of range",
+		`{"angularDimensionPrecision":-1}`: "out of range",
+	} {
+		if _, err := r.Handle(s, "parameters.setSettings", []byte(args)); err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("setSettings(%s) err = %v, want it to mention %q", args, err, want)
+		}
+	}
+}
+
+func TestParameterSweepOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"od","expression":"4 cm"}`, nil)
+	call(t, r, s, "parameters.setTolerance", `{"name":"od","mode":"deviation","upper":"0.2 cm","lower":"-0.1 cm"}`, nil)
+	call(t, r, s, "parameters.setTolerance", `{"name":"width","mode":"symmetric","upper":"0.05 cm"}`, nil)
+
+	var res wire.ParameterSweepResult
+	call(t, r, s, "parameters.setAllModelValueType", `{"modelValueType":"upper"}`, &res)
+	if res.Affected != 2 {
+		t.Fatalf("sweep affected = %d, want both toleranced parameters", res.Affected)
+	}
+	if d := getDetail(t, r, s, "od"); d.ModelValueType != "upper" || !approx(d.ModelValue, 4.2) {
+		t.Errorf("od after sweep = %v (%s), want 4.2 upper", d.ModelValue, d.ModelValueType)
+	}
+
+	call(t, r, s, "parameters.setAllModelValueType", `{"modelValueType":"nominal"}`, &res)
+	if d := getDetail(t, r, s, "width"); d.ModelValueType != "nominal" || !approx(d.ModelValue, 4) {
+		t.Errorf("width after nominal sweep = %v (%s), want the nominal back", d.ModelValue, d.ModelValueType)
+	}
+
+	if _, err := r.Handle(s, "parameters.setAllModelValueType", []byte(`{"modelValueType":"sideways"}`)); err == nil {
+		t.Error("unknown sweep selection must be rejected")
+	}
+}
+
+func TestParameterXMLExchangeOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.update", `{"name":"width","comment":"outer width"}`, nil)
+
+	var exp wire.ParameterExportResult
+	call(t, r, s, "parameters.export", "{}", &exp)
+	if !strings.Contains(exp.XML, `name="width"`) || !strings.Contains(exp.XML, `comment="outer width"`) {
+		t.Fatalf("export = %s, want width with its comment", exp.XML)
+	}
+
+	// Re-import an edited set: width updates, a new parameter appears.
+	edited := strings.Replace(exp.XML, `expression="4 cm"`, `expression="5 cm"`, 1)
+	edited = strings.Replace(edited, "</parameters>",
+		`<parameter name="depth" expression="2 cm"/></parameters>`, 1)
+	var imp wire.ParameterImportResult
+	call(t, r, s, "parameters.import", `{"xml":`+jsonString(edited)+`}`, &imp)
+	if imp.Added != 1 || imp.Updated != 1 {
+		t.Fatalf("import counts = %+v, want 1 added / 1 updated", imp)
+	}
+	if d := getDetail(t, r, s, "width"); d.Expression != "5 cm" {
+		t.Errorf("width expression = %q, want the imported 5 cm", d.Expression)
+	}
+	if d := getDetail(t, r, s, "depth"); d.Expression != "2 cm" {
+		t.Errorf("depth = %+v, want the imported parameter", d)
+	}
+}
+
+// TestParameterImportRollsBackOnBadSet checks atomicity: a set whose late
+// entry fails must leave no trace of its earlier entries.
+func TestParameterImportRollsBackOnBadSet(t *testing.T) {
+	r, s := seededSession(t)
+	bad := `<parameters>
+		<parameter name="ok" expression="1 cm"/>
+		<parameter name="broken" expression="1 nonsenseunit"/>
+	</parameters>`
+	if _, err := r.Handle(s, "parameters.import", []byte(`{"xml":`+jsonString(bad)+`}`)); err == nil || !strings.Contains(err.Error(), "broken") {
+		t.Fatalf("import err = %v, want a rejection naming the broken entry", err)
+	}
+	if _, err := r.Handle(s, "parameters.getDetail", []byte(`{"name":"ok"}`)); err == nil {
+		t.Error("rolled-back import must not leave earlier entries behind")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -131,12 +131,29 @@ func (r *Router) registerParameterDetailHandlers() {
 	r.handlers[wire.MethodParametersDelete] = deleteParameter
 	r.handlers[wire.MethodParametersDrivenBy] = parameterDrivenBy
 	r.handlers[wire.MethodParametersDependents] = parameterDependents
+	r.registerParameterGroupHandlers()
+	r.registerParameterSettingsHandlers()
+}
+
+// registerParameterGroupHandlers wires the custom parameter groups (M02-F05,
+// Oblikovati#604).
+func (r *Router) registerParameterGroupHandlers() {
 	r.handlers[wire.MethodParametersGroupsList] = listParameterGroups
 	r.handlers[wire.MethodParametersGroupsAdd] = addParameterGroup
 	r.handlers[wire.MethodParametersGroupsDelete] = deleteParameterGroup
 	r.handlers[wire.MethodParametersGroupsSetDisplayName] = setParameterGroupDisplayName
 	r.handlers[wire.MethodParametersGroupsAddMember] = addParameterGroupMember
 	r.handlers[wire.MethodParametersGroupsRemoveMember] = removeParameterGroupMember
+}
+
+// registerParameterSettingsHandlers wires the document-level parameter
+// settings, the tolerance sweep, and the XML exchange (M02-F07, Oblikovati#606).
+func (r *Router) registerParameterSettingsHandlers() {
+	r.handlers[wire.MethodParametersGetSettings] = getParameterSettings
+	r.handlers[wire.MethodParametersSetSettings] = setParameterSettings
+	r.handlers[wire.MethodParametersSetAllModelValueType] = sweepParameterModelValues
+	r.handlers[wire.MethodParametersExport] = exportParameters
+	r.handlers[wire.MethodParametersImport] = importParameters
 }
 
 // registerSketchHandlers wires the 2D-sketch methods: the spine + enumeration here, and
@@ -328,6 +345,9 @@ var mutatingMethods = map[string]bool{
 	wire.MethodParametersGroupsSetDisplayName: true,
 	wire.MethodParametersGroupsAddMember:      true,
 	wire.MethodParametersGroupsRemoveMember:   true,
+	wire.MethodParametersSetSettings:          true,
+	wire.MethodParametersSetAllModelValueType: true,
+	wire.MethodParametersImport:               true,
 	wire.MethodFeaturesAdd:                    true,
 	wire.MethodFeaturesEdit:                   true,
 	wire.MethodFeaturesDelete:                 true,

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -144,6 +144,31 @@ func (s *Session) DeleteParameterGroup(name string) error {
 	return s.editParameters(func(ps *param.Parameters) error { return ps.DeleteGroup(name, true) })
 }
 
+// ImportParameters applies a parameter-set XML document atomically: the part
+// snapshots first, and any invalid entry restores it so a half-applied import
+// never survives (M02-F07, Oblikovati#606). On success it lands as one undo step.
+func (s *Session) ImportParameters(xml string) (added, updated int, err error) {
+	part, err := activePart(s)
+	if err != nil {
+		return 0, 0, err
+	}
+	snapshot, err := part.MarshalRecipe()
+	if err != nil {
+		return 0, 0, fmt.Errorf("app: snapshot before parameter import: %w", err)
+	}
+	added, updated, err = part.Parameters().ImportXML(xml)
+	if err != nil {
+		if restoreErr := part.RestoreRecipe(snapshot); restoreErr != nil {
+			return 0, 0, fmt.Errorf("app: parameter import failed (%w) and the rollback failed too: %v", err, restoreErr)
+		}
+		return 0, 0, err
+	}
+	part.Features().MarkAllDirty()
+	part.Recompute()
+	s.recordEdit(part, "Import Parameters")
+	return added, updated, nil
+}
+
 // editParam resolves the parameter by id and applies edit, then recomputes.
 func (s *Session) editParam(id param.ID, edit func(*param.Parameter) error) error {
 	return s.editParameters(func(ps *param.Parameters) error {

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -33,15 +33,16 @@ var _ doc.RecipeContent = (*PartComponentDefinition)(nil)
 // parameters. Sketches and features join it in later phases. The realized B-rep is
 // never stored — ApplyRecipe recomputes it.
 type partRecipe struct {
-	Units           map[string]string         `yaml:"units,omitempty"`
-	EndOfPart       *int                      `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
-	Parameters      []parameterRecipe         `yaml:"parameters,omitempty"`
-	ParameterGroups []parameterGroupRecipe    `yaml:"parameterGroups,omitempty"` // custom group records, in creation order
-	WorkFeatures    []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
-	Sketches        []sketch.SketchData       `yaml:"sketches,omitempty"`
-	Sketches3D      []sketch.SketchData3D     `yaml:"sketches3D,omitempty"`
-	Features        []feature.FeatureData     `yaml:"features,omitempty"`
-	Materials       *material.RecipeData      `yaml:"materials,omitempty"`
+	Units             map[string]string         `yaml:"units,omitempty"`
+	EndOfPart         *int                      `yaml:"endOfPart,omitempty"` // nil ⇒ evaluate the whole program
+	Parameters        []parameterRecipe         `yaml:"parameters,omitempty"`
+	ParameterGroups   []parameterGroupRecipe    `yaml:"parameterGroups,omitempty"` // custom group records, in creation order
+	ParameterSettings *parameterSettingsRecipe  `yaml:"parameterSettings,omitempty"`
+	WorkFeatures      []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
+	Sketches          []sketch.SketchData       `yaml:"sketches,omitempty"`
+	Sketches3D        []sketch.SketchData3D     `yaml:"sketches3D,omitempty"`
+	Features          []feature.FeatureData     `yaml:"features,omitempty"`
+	Materials         *material.RecipeData      `yaml:"materials,omitempty"`
 }
 
 // sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
@@ -108,6 +109,20 @@ type toleranceRecipe struct {
 	Lower float64 `yaml:"lower,omitempty"`
 }
 
+// parameterSettingsRecipe persists the document-level parameter settings when
+// they differ from the defaults (M02-F07, Oblikovati#606). DimensionDisplayType
+// carries the wire spelling.
+type parameterSettingsRecipe struct {
+	LinearStandardTolerance      string `yaml:"linearStandardTolerance,omitempty"`
+	AngularStandardTolerance     string `yaml:"angularStandardTolerance,omitempty"`
+	UseStandardTolerances        bool   `yaml:"useStandardTolerances,omitempty"`
+	ExportStandardTolerances     bool   `yaml:"exportStandardTolerances,omitempty"`
+	LinearDimensionPrecision     int    `yaml:"linearDimensionPrecision"`
+	AngularDimensionPrecision    int    `yaml:"angularDimensionPrecision"`
+	DimensionDisplayType         string `yaml:"dimensionDisplayType,omitempty"`
+	DisplayParameterAsExpression bool   `yaml:"displayParameterAsExpression,omitempty"`
+}
+
 // parameterGroupRecipe persists one custom parameter group: the immutable
 // internal name, the display name when it differs, the owning client id, and
 // the member parameter names (M02-F05, Oblikovati#604).
@@ -155,14 +170,15 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		return nil, fmt.Errorf("compdef: marshal work features: %w", err)
 	}
 	r := partRecipe{
-		Units:           d.unitsRecipe(),
-		Parameters:      d.parametersRecipe(),
-		ParameterGroups: d.parameterGroupsRecipe(),
-		WorkFeatures:    work,
-		Sketches:        sketches,
-		Sketches3D:      sketches3D,
-		Features:        features,
-		Materials:       d.materialsRecipe(),
+		Units:             d.unitsRecipe(),
+		Parameters:        d.parametersRecipe(),
+		ParameterGroups:   d.parameterGroupsRecipe(),
+		ParameterSettings: d.parameterSettingsRecipe(),
+		WorkFeatures:      work,
+		Sketches:          sketches,
+		Sketches3D:        sketches3D,
+		Features:          features,
+		Materials:         d.materialsRecipe(),
 	}
 	if d.eop != endOfPartAtEnd {
 		eop := d.eop
@@ -212,6 +228,9 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 		return err
 	}
 	if err := d.applyParameters(r.ParameterGroups, r.Parameters); err != nil {
+		return err
+	}
+	if err := d.applyParameterSettings(r.ParameterSettings); err != nil {
 		return err
 	}
 	if err := feature.ApplyWork(d.work, r.WorkFeatures); err != nil {
@@ -345,6 +364,48 @@ func (d *PartComponentDefinition) applyParameters(groups []parameterGroupRecipe,
 		if err := d.applyParameterGroup(gr); err != nil {
 			return fmt.Errorf("compdef: restore parameter group %q: %w", gr.InternalName, err)
 		}
+	}
+	return nil
+}
+
+// parameterSettingsRecipe persists the parameter settings, nil when they are
+// the new-document defaults (the recipe omits zero state).
+func (d *PartComponentDefinition) parameterSettingsRecipe() *parameterSettingsRecipe {
+	s := *d.params.Settings()
+	if s == param.DefaultCollectionSettings() {
+		return nil
+	}
+	return &parameterSettingsRecipe{
+		LinearStandardTolerance:      s.LinearStandardTolerance,
+		AngularStandardTolerance:     s.AngularStandardTolerance,
+		UseStandardTolerances:        s.UseStandardTolerances,
+		ExportStandardTolerances:     s.ExportStandardTolerances,
+		LinearDimensionPrecision:     s.LinearDimensionPrecision,
+		AngularDimensionPrecision:    s.AngularDimensionPrecision,
+		DimensionDisplayType:         s.DimensionDisplayType.String(),
+		DisplayParameterAsExpression: s.DisplayParameterAsExpression,
+	}
+}
+
+// applyParameterSettings restores the persisted parameter settings (nil keeps
+// the defaults).
+func (d *PartComponentDefinition) applyParameterSettings(sr *parameterSettingsRecipe) error {
+	if sr == nil {
+		return nil
+	}
+	display, ok := types.ParseDimensionDisplayType(sr.DimensionDisplayType)
+	if !ok {
+		return fmt.Errorf("compdef: unknown dimension display type %q (want value|name|expression|tolerance|preciseValue)", sr.DimensionDisplayType)
+	}
+	*d.params.Settings() = param.CollectionSettings{
+		LinearStandardTolerance:      sr.LinearStandardTolerance,
+		AngularStandardTolerance:     sr.AngularStandardTolerance,
+		UseStandardTolerances:        sr.UseStandardTolerances,
+		ExportStandardTolerances:     sr.ExportStandardTolerances,
+		LinearDimensionPrecision:     sr.LinearDimensionPrecision,
+		AngularDimensionPrecision:    sr.AngularDimensionPrecision,
+		DimensionDisplayType:         display,
+		DisplayParameterAsExpression: sr.DisplayParameterAsExpression,
 	}
 	return nil
 }

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -189,6 +189,9 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 	_, _ = ps.AddGroup("com.example:frame", "Frame", "com.example")
 	_ = ps.AddToGroup(num.ID(), "com.example:frame")
 	_ = ps.AddToGroup(txt.ID(), "com.example:frame")
+	ps.Settings().LinearStandardTolerance = "0.1 mm"
+	ps.Settings().UseStandardTolerances = true
+	ps.Settings().DimensionDisplayType = types.DimensionDisplayExpression
 
 	r := reopenThroughStore(t, d).Parameters()
 
@@ -232,6 +235,10 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 	}
 	if got := r.GroupsOf(rt.ID()); len(got) != 1 || got[0] != "com.example:frame" {
 		t.Errorf("material groups = %v, want [com.example:frame]", got)
+	}
+	rs := r.Settings()
+	if rs.LinearStandardTolerance != "0.1 mm" || !rs.UseStandardTolerances || rs.DimensionDisplayType != types.DimensionDisplayExpression {
+		t.Errorf("parameter settings = %+v, want the saved standard tolerance/display restored", rs)
 	}
 	_ = flag
 }

--- a/model/param/exchange.go
+++ b/model/param/exchange.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// Parameter-set XML exchange (M02-F07, Oblikovati#606): user parameters
+// round-trip as a flat, documented XML so spreadsheet/PDM tooling can edit
+// them outside the application. Model/reference parameters never export —
+// they are owned by features and have no life outside the document.
+//
+// The format, one element per parameter:
+//
+//	<parameters>
+//	  <parameter name="len" expression="10 mm" comment="the length" isKey="true" exposedAsProperty="true"/>
+//	  <parameter name="material" valueType="text" text="steel"/>
+//	  <parameter name="vented" valueType="boolean" bool="true"/>
+//	</parameters>
+
+// parameterSetXML is the document element of the exchange format.
+type parameterSetXML struct {
+	XMLName    xml.Name            `xml:"parameters"`
+	Parameters []parameterEntryXML `xml:"parameter"`
+}
+
+// parameterEntryXML is one exchanged parameter. ValueType is empty for
+// numeric, "text" or "boolean" otherwise (the parameterRecipe spellings).
+type parameterEntryXML struct {
+	Name              string `xml:"name,attr"`
+	ValueType         string `xml:"valueType,attr,omitempty"`
+	Expression        string `xml:"expression,attr,omitempty"`
+	Text              string `xml:"text,attr,omitempty"`
+	Bool              bool   `xml:"bool,attr,omitempty"`
+	Comment           string `xml:"comment,attr,omitempty"`
+	IsKey             bool   `xml:"isKey,attr,omitempty"`
+	ExposedAsProperty bool   `xml:"exposedAsProperty,attr,omitempty"`
+}
+
+// ExportXML renders the user parameters as the exchange XML.
+func (ps *Parameters) ExportXML() (string, error) {
+	var set parameterSetXML
+	for _, p := range ps.All() {
+		if p.Kind() != UserParam {
+			continue
+		}
+		set.Parameters = append(set.Parameters, exportEntry(p))
+	}
+	out, err := xml.MarshalIndent(set, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("param: marshal parameter set: %w", err)
+	}
+	return string(out), nil
+}
+
+// exportEntry projects one user parameter into its exchange element.
+func exportEntry(p *Parameter) parameterEntryXML {
+	e := parameterEntryXML{
+		Name: p.Name(), Comment: p.Comment,
+		IsKey: p.IsKey, ExposedAsProperty: p.ExposedAsProperty,
+	}
+	switch {
+	case p.IsText():
+		e.ValueType, e.Text = "text", p.Text()
+	case p.IsBoolean():
+		e.ValueType, e.Bool = "boolean", p.Bool()
+	default:
+		e.Expression = p.Expression()
+	}
+	return e
+}
+
+// ImportXML applies an exchange document: unknown names are created as user
+// parameters, known names updated in place. The set is structurally validated
+// first; the first invalid entry rejects the import naming the offending
+// value. Expression errors surface as they apply — run the import against a
+// snapshot the caller can restore (app.Session.ImportParameters does).
+func (ps *Parameters) ImportXML(doc string) (added, updated int, err error) {
+	var set parameterSetXML
+	if err := xml.Unmarshal([]byte(doc), &set); err != nil {
+		return 0, 0, fmt.Errorf("param: parameter set is not valid XML: %w", err)
+	}
+	if err := validateEntries(set.Parameters); err != nil {
+		return 0, 0, err
+	}
+	for _, e := range set.Parameters {
+		wasNew, err := ps.importEntry(e)
+		if err != nil {
+			return added, updated, fmt.Errorf("param: import %q: %w", e.Name, err)
+		}
+		if wasNew {
+			added++
+		} else {
+			updated++
+		}
+	}
+	return added, updated, nil
+}
+
+// validateEntries rejects structurally bad entries before anything mutates.
+func validateEntries(entries []parameterEntryXML) error {
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if err := validateEntry(e); err != nil {
+			return err
+		}
+		if seen[e.Name] {
+			return fmt.Errorf("param: parameter %q appears twice in the import set", e.Name)
+		}
+		seen[e.Name] = true
+	}
+	return nil
+}
+
+// validateEntry checks one entry's shape: a name, a known value type, and a
+// value matching that type.
+func validateEntry(e parameterEntryXML) error {
+	if e.Name == "" {
+		return fmt.Errorf("param: import entry without a name (expression %q)", e.Expression)
+	}
+	switch e.ValueType {
+	case "":
+		if e.Expression == "" {
+			return fmt.Errorf("param: numeric import entry %q needs an expression", e.Name)
+		}
+	case "text", "boolean":
+	default:
+		return fmt.Errorf("param: import entry %q has unknown value type %q (want text|boolean or empty for numeric)", e.Name, e.ValueType)
+	}
+	return nil
+}
+
+// importEntry creates or updates one parameter from its exchange element,
+// reporting whether it was newly created.
+func (ps *Parameters) importEntry(e parameterEntryXML) (wasNew bool, err error) {
+	p, exists := ps.ByName(e.Name)
+	if !exists {
+		if p, err = ps.addImported(e); err != nil {
+			return false, err
+		}
+	} else if err = applyImportedValue(p, e); err != nil {
+		return false, err
+	}
+	p.Comment, p.IsKey, p.ExposedAsProperty = e.Comment, e.IsKey, e.ExposedAsProperty
+	return !exists, nil
+}
+
+// addImported creates the user parameter for one entry, routed by value type.
+func (ps *Parameters) addImported(e parameterEntryXML) (*Parameter, error) {
+	switch e.ValueType {
+	case "text":
+		return ps.AddTextUserParameter(e.Name, e.Text)
+	case "boolean":
+		return ps.AddBooleanUserParameter(e.Name, e.Bool)
+	default:
+		return ps.AddUserParameter(e.Name, e.Expression)
+	}
+}
+
+// applyImportedValue updates an existing parameter's value from one entry; the
+// entry's flavor must match the parameter's.
+func applyImportedValue(p *Parameter, e parameterEntryXML) error {
+	switch e.ValueType {
+	case "text":
+		return p.SetText(e.Text)
+	case "boolean":
+		return p.SetBool(e.Bool)
+	default:
+		return p.SetExpression(e.Expression)
+	}
+}

--- a/model/param/exchange_test.go
+++ b/model/param/exchange_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExportXMLCoversUserParametersOnly(t *testing.T) {
+	ps := NewParameters()
+	num, _ := ps.AddUserParameter("len", "10 mm")
+	num.Comment, num.IsKey = "the length", true
+	_, _ = ps.AddTextUserParameter("material", "steel")
+	_, _ = ps.AddBooleanUserParameter("vented", true)
+	_, _ = ps.AddModelParameter("d0", "2 mm")
+
+	xml, err := ps.ExportXML()
+	if err != nil {
+		t.Fatalf("ExportXML: %v", err)
+	}
+	for _, want := range []string{
+		`name="len"`, `expression="10 mm"`, `comment="the length"`, `isKey="true"`,
+		`name="material"`, `valueType="text"`, `text="steel"`,
+		`name="vented"`, `valueType="boolean"`, `bool="true"`,
+	} {
+		if !strings.Contains(xml, want) {
+			t.Errorf("export missing %s:\n%s", want, xml)
+		}
+	}
+	if strings.Contains(xml, "d0") {
+		t.Error("model parameters must not export — they are feature-owned")
+	}
+}
+
+func TestImportXMLRoundTripAddsAndUpdates(t *testing.T) {
+	src := NewParameters()
+	num, _ := src.AddUserParameter("len", "10 mm")
+	num.ExposedAsProperty = true
+	_, _ = src.AddTextUserParameter("material", "steel")
+	xml, _ := src.ExportXML()
+
+	// A fresh collection imports everything as new.
+	dst := NewParameters()
+	added, updated, err := dst.ImportXML(xml)
+	if err != nil {
+		t.Fatalf("ImportXML: %v", err)
+	}
+	if added != 2 || updated != 0 {
+		t.Errorf("import counts = %d/%d, want 2 added", added, updated)
+	}
+	rl, _ := dst.ByName("len")
+	if rl == nil || rl.Expression() != "10 mm" || !rl.ExposedAsProperty {
+		t.Errorf("len not round-tripped: %+v", rl)
+	}
+	rt, _ := dst.ByName("material")
+	if rt == nil || !rt.IsText() || rt.Text() != "steel" {
+		t.Errorf("material not round-tripped: %+v", rt)
+	}
+
+	// A second import of an edited set updates in place.
+	edited := strings.Replace(xml, "10 mm", "12 mm", 1)
+	added, updated, err = dst.ImportXML(edited)
+	if err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	if added != 0 || updated != 2 {
+		t.Errorf("re-import counts = %d/%d, want 2 updated", added, updated)
+	}
+	if rl.Expression() != "12 mm" {
+		t.Errorf("len expression = %q, want the imported 12 mm", rl.Expression())
+	}
+}
+
+func TestImportXMLRejectsBadSets(t *testing.T) {
+	for name, doc := range map[string]string{
+		"not xml":                    `{"name":"len"}`,
+		"missing name":               `<parameters><parameter expression="10 mm"/></parameters>`,
+		"unknown value type":         `<parameters><parameter name="x" valueType="blob"/></parameters>`,
+		"numeric without expression": `<parameters><parameter name="x"/></parameters>`,
+		"duplicate name":             `<parameters><parameter name="x" expression="1 mm"/><parameter name="x" expression="2 mm"/></parameters>`,
+	} {
+		ps := NewParameters()
+		if _, _, err := ps.ImportXML(doc); err == nil {
+			t.Errorf("%s: import must be rejected", name)
+		}
+		if ps.Count() != 0 {
+			t.Errorf("%s: structural rejection must not create parameters", name)
+		}
+	}
+}
+
+func TestImportXMLFlavorMismatchErrors(t *testing.T) {
+	ps := NewParameters()
+	_, _ = ps.AddUserParameter("len", "10 mm")
+	doc := `<parameters><parameter name="len" valueType="text" text="oops"/></parameters>`
+	if _, _, err := ps.ImportXML(doc); err == nil || !strings.Contains(err.Error(), "len") {
+		t.Errorf("flavor mismatch err = %v, want a rejection naming len", err)
+	}
+}

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -23,6 +23,9 @@ type Parameters struct {
 	// group-key memberships (a parameter may sit in several groups). See group.go.
 	groups      []*ParameterGroup
 	memberships map[ID]map[string]bool
+
+	// settings are the document-level parameter settings (M02-F07); see settings.go.
+	settings CollectionSettings
 }
 
 // idSet is a set of parameter ids.
@@ -34,6 +37,7 @@ func NewParameters() *Parameters {
 		byID: map[ID]*Parameter{}, byName: map[string]ID{}, nextID: 1,
 		drivenBy: map[ID]idSet{}, dependents: map[ID]idSet{},
 		memberships: map[ID]map[string]bool{},
+		settings:    DefaultCollectionSettings(),
 	}
 }
 

--- a/model/param/settings.go
+++ b/model/param/settings.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// Document-level parameter settings and whole-model tolerance sweeps
+// (M02-F07, Oblikovati#606). In the reference API the Parameters collection
+// doubles as the document's parameter-settings object, so the settings live
+// here rather than on a separate document options type.
+
+// DimensionDisplayType is how dimensions tied to parameters render in
+// sketches. Aliased from the contract (ADR-0018).
+type DimensionDisplayType = types.DimensionDisplayType
+
+// CollectionSettings are the document-level parameter settings: the standard
+// tolerance expressions applied to dimensions without an explicit tolerance
+// (when UseStandardTolerances is on), the default display precisions, and how
+// dimensions render. They affect presentation and defaulting only — never an
+// evaluated or model value.
+type CollectionSettings struct {
+	LinearStandardTolerance      string
+	AngularStandardTolerance     string
+	UseStandardTolerances        bool
+	ExportStandardTolerances     bool
+	LinearDimensionPrecision     int
+	AngularDimensionPrecision    int
+	DimensionDisplayType         DimensionDisplayType
+	DisplayParameterAsExpression bool
+}
+
+// DefaultCollectionSettings is what every new document starts with: three
+// linear / two angular display decimals, dimensions rendered as values.
+func DefaultCollectionSettings() CollectionSettings {
+	return CollectionSettings{
+		LinearDimensionPrecision:  3,
+		AngularDimensionPrecision: 2,
+		DimensionDisplayType:      types.DimensionDisplayValue,
+	}
+}
+
+// Settings returns the document-level parameter settings for reading and
+// editing in place.
+func (ps *Parameters) Settings() *CollectionSettings { return &ps.settings }
+
+// SetAllModelValueType drives every toleranced parameter's model-value
+// selection to one band bound — the reference SetAllToMax/Min/Nominal/Median
+// sweeps for limit-stack studies. Parameters without an explicit tolerance
+// band are left alone. It returns how many parameters it moved.
+func (ps *Parameters) SetAllModelValueType(m ModelValueType) (int, error) {
+	switch m {
+	case Nominal, Upper, Lower, Median:
+	default:
+		return 0, fmt.Errorf("param: unknown sweep model value type %d; want nominal/lower/upper/median", int32(m))
+	}
+	affected := 0
+	for _, id := range ps.order {
+		p := ps.byID[id]
+		if p.Tolerance() == (Tolerance{}) {
+			continue
+		}
+		if err := p.SetModelValueType(m); err != nil {
+			return affected, err
+		}
+		affected++
+	}
+	return affected, nil
+}

--- a/model/param/settings_test.go
+++ b/model/param/settings_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+func TestCollectionSettingsDefaults(t *testing.T) {
+	ps := NewParameters()
+	s := ps.Settings()
+	if s.LinearDimensionPrecision != 3 || s.AngularDimensionPrecision != 2 {
+		t.Errorf("default precisions = %d/%d, want 3/2", s.LinearDimensionPrecision, s.AngularDimensionPrecision)
+	}
+	if s.DimensionDisplayType != types.DimensionDisplayValue || s.UseStandardTolerances {
+		t.Errorf("defaults = %+v, want value display and standard tolerances off", s)
+	}
+	// Settings edit in place through the accessor.
+	s.UseStandardTolerances = true
+	if !ps.Settings().UseStandardTolerances {
+		t.Error("Settings() must expose the live settings, not a copy")
+	}
+}
+
+func TestSetAllModelValueTypeSweepsTolerancedOnly(t *testing.T) {
+	ps := NewParameters()
+	plain, _ := ps.AddUserParameter("plain", "10 mm")
+	tolA, _ := ps.AddUserParameter("a", "10 mm")
+	tolB, _ := ps.AddUserParameter("b", "20 mm")
+	txt, _ := ps.AddTextUserParameter("label", "lid")
+	_ = tolA.SetToleranceDeviation(0.02, -0.01)
+	_ = tolB.SetToleranceSymmetric(0.05)
+
+	affected, err := ps.SetAllModelValueType(Upper)
+	if err != nil {
+		t.Fatalf("SetAllModelValueType: %v", err)
+	}
+	if affected != 2 {
+		t.Errorf("affected = %d, want the 2 toleranced parameters", affected)
+	}
+	if tolA.ModelValueType() != Upper || tolB.ModelValueType() != Upper {
+		t.Errorf("sweep missed a toleranced parameter: %s/%s", tolA.ModelValueType(), tolB.ModelValueType())
+	}
+	if !approxScalar(tolA.ModelValue(), 1.02) || !approxScalar(tolB.ModelValue(), 2.05) {
+		t.Errorf("model values = %v/%v, want 1.02/2.05 (nominal + upper)", tolA.ModelValue(), tolB.ModelValue())
+	}
+	// Untoleranced and non-numeric parameters are left alone.
+	if plain.ModelValueType() != Nominal || txt.ModelValueType() != Nominal {
+		t.Error("sweep must not touch untoleranced parameters")
+	}
+
+	if _, err := ps.SetAllModelValueType(ModelValueType(9)); err == nil {
+		t.Error("unknown sweep selection must be rejected")
+	}
+}


### PR DESCRIPTION
## What

Implements the /source half of #606 (contract merged as Oblikovati/api#62).

- **Collection settings**: `CollectionSettings` lives on the `Parameters` collection (mirroring the reference API, where `Parameters` doubles as the document's parameter-settings object) — linear/angular standard tolerance expressions with use/export flags, display precisions (defaults 3/2), dimension display mode, `DisplayParameterAsExpression`. Persisted in `.obk` only when off-default; settings edits land as one undo step.
- **Tolerance sweeps**: `parameters.setAllModelValueType` drives every explicitly toleranced parameter to one band bound (nominal/lower/upper/median — the reference `SetAllToMax/Min/Nominal/Median`) in a single undo step, recomputing since consumed model values move; untoleranced parameters are untouched and the affected count is reported.
- **XML exchange**: `parameters.export` renders user parameters as a flat documented XML (model parameters are feature-owned and never export); `parameters.import` creates unknown names and updates known ones. Import is atomic: the set validates structurally before any mutation, and `Session.ImportParameters` snapshots the part so a bad expression in a late entry rolls the whole set back, naming the offending entry.

## Tests

- `model/param`: settings defaults/live accessor, sweep selectivity + counts + bad-selection rejection, XML export shape, import round-trip (add + update counts), structural rejections (missing name, unknown value type, duplicates, numeric without expression), flavor-mismatch errors.
- `model/compdef`: settings `.obk` round-trip.
- `addin/router`: settings round-trip with unsent-field semantics + spelling/precision rejections, sweep over the wire with model-value verification, export→edit→import cycle, and the rollback-on-bad-set atomicity check.

Full suite, `go vet`, and golangci-lint v2.1.0 (the CI pin) are green locally.

Closes #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)