### PR TITLE
M02-F06: implement derived parameter tables — cross-document parameter linking

### DIFF
--- a/addin/router/derived_tables.go
+++ b/addin/router/derived_tables.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/param"
+)
+
+// Derived parameter tables over the wire (M02-F06, Oblikovati#605):
+// parameters.derivedTables.list/add/setLinked/delete. Mutations go through
+// the session seams, which resolve the source document, keep the workspace
+// reference graph current, and record one undo step each.
+
+// derivedTableInfo marshals one table, resolving the live candidate list from
+// the source document (empty when the source is not reachable).
+func derivedTableInfo(s *app.Session, t *param.DerivedParameterTable) wire.DerivedParameterTableInfo {
+	info := wire.DerivedParameterTableInfo{
+		ID: t.ID(), SourceDocument: t.SourceDocument(), Linked: t.Linked(),
+		Health: t.Health().Reason,
+	}
+	if source, ok := s.LinkableSourceParameters(t.SourceDocument()); ok {
+		for _, sv := range source {
+			info.Available = append(info.Available, sv.Name)
+		}
+	} else if info.Health == "" {
+		info.Health = "source document " + t.SourceDocument() + " is unavailable"
+	}
+	return info
+}
+
+// listDerivedTables returns the active part's tables with live candidates.
+func listDerivedTables(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var out wire.ListDerivedParameterTablesResult
+	for _, t := range part.Parameters().DerivedTables() {
+		out.Tables = append(out.Tables, derivedTableInfo(s, t))
+	}
+	return json.Marshal(out)
+}
+
+// addDerivedTable links parameters from another open document into this one.
+func addDerivedTable(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.DerivedParameterTableAddArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	t, err := s.AddDerivedParameterTable(in.SourceDocument, in.Linked)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(derivedTableInfo(s, t))
+}
+
+// setDerivedTableLinked replaces a table's linked subset.
+func setDerivedTableLinked(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.DerivedParameterTableSetLinkedArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if err := s.SetDerivedTableLinked(in.ID, in.Linked); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	t, ok := part.Parameters().DerivedTableByID(in.ID)
+	if !ok {
+		return json.Marshal(struct{}{})
+	}
+	return json.Marshal(derivedTableInfo(s, t))
+}
+
+// deleteDerivedTable removes a table and its derived parameters.
+func deleteDerivedTable(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.DerivedParameterTableDeleteArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if err := s.DeleteDerivedParameterTable(in.ID); err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct{}{})
+}

--- a/addin/router/derived_tables_test.go
+++ b/addin/router/derived_tables_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// Derived parameter tables over the wire (M02-F06, Oblikovati#605).
+
+// derivedWireSession is a seeded session plus a second, active part document
+// ready to derive from the seeded "test.obk" (which holds "width" = 4 cm).
+func derivedWireSession(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := seededSession(t)
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	return r, s
+}
+
+func TestDerivedTablesLifecycleOverWire(t *testing.T) {
+	r, s := derivedWireSession(t)
+
+	var info wire.DerivedParameterTableInfo
+	call(t, r, s, "parameters.derivedTables.add", `{"sourceDocument":"test.obk","linked":["width"]}`, &info)
+	if info.SourceDocument != "test.obk" || !slices.Equal(info.Linked, []string{"width"}) || info.Health != "" {
+		t.Fatalf("added table = %+v, want a healthy width link", info)
+	}
+	if !slices.Contains(info.Available, "width") {
+		t.Errorf("available = %v, want the source candidates listed", info.Available)
+	}
+	// The produced derived parameter answers member-level reads.
+	if d := getDetail(t, r, s, "width"); d.Kind != "derived" {
+		t.Errorf("derived parameter kind = %q, want derived", d.Kind)
+	}
+
+	var list wire.ListDerivedParameterTablesResult
+	call(t, r, s, "parameters.derivedTables.list", "{}", &list)
+	if len(list.Tables) != 1 || list.Tables[0].ID != info.ID {
+		t.Fatalf("tables = %+v, want the one added table", list.Tables)
+	}
+
+	var relinked wire.DerivedParameterTableInfo
+	call(t, r, s, "parameters.derivedTables.setLinked", `{"id":1}`, &relinked)
+	if len(relinked.Linked) != 0 {
+		t.Errorf("relinked = %+v, want an empty subset", relinked)
+	}
+	if _, err := r.Handle(s, "parameters.getDetail", []byte(`{"name":"width"}`)); err == nil {
+		t.Error("unlinking must delete the produced derived parameter")
+	}
+
+	call(t, r, s, "parameters.derivedTables.delete", `{"id":1}`, nil)
+	// A fresh var: an omitted "tables" would merge over a reused struct.
+	var after wire.ListDerivedParameterTablesResult
+	call(t, r, s, "parameters.derivedTables.list", "{}", &after)
+	if len(after.Tables) != 0 {
+		t.Errorf("tables after delete = %+v, want none", after.Tables)
+	}
+}
+
+func TestDerivedTablesRejectBadArgs(t *testing.T) {
+	r, s := derivedWireSession(t)
+	for method, args := range map[string]string{
+		"parameters.derivedTables.add":       `{"sourceDocument":"missing.obk"}`,
+		"parameters.derivedTables.setLinked": `{"id":99}`,
+		"parameters.derivedTables.delete":    `{"id":99}`,
+	} {
+		if _, err := r.Handle(s, method, []byte(args)); err == nil {
+			t.Errorf("%s(%s) must be rejected", method, args)
+		}
+	}
+}
+
+// TestDerivedTableMutationsBroadcast checks the mutations emit edit.committed
+// and the list read does not.
+func TestDerivedTableMutationsBroadcast(t *testing.T) {
+	r, s := derivedWireSession(t)
+	var methods []string
+	sub := event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
+		methods = append(methods, e.Method)
+		return event.Continue()
+	})
+	defer sub.Cancel()
+
+	call(t, r, s, "parameters.derivedTables.add", `{"sourceDocument":"test.obk","linked":["width"]}`, nil)
+	call(t, r, s, "parameters.derivedTables.list", "{}", nil)
+	call(t, r, s, "parameters.derivedTables.setLinked", `{"id":1,"linked":[]}`, nil)
+	call(t, r, s, "parameters.derivedTables.delete", `{"id":1}`, nil)
+
+	want := []string{
+		wire.MethodParametersDerivedTablesAdd,
+		wire.MethodParametersDerivedTablesSetLinked,
+		wire.MethodParametersDerivedTablesDelete,
+	}
+	if !slices.Equal(methods, want) {
+		t.Errorf("edit.committed methods = %v, want %v (and none for list)", methods, want)
+	}
+}
+
+// TestDerivedValueFollowsSourceOverWire drives the wire end of the
+// update-on-source-change behavior: editing the source parameter over the
+// wire pushes the new value into the deriving document.
+func TestDerivedValueFollowsSourceOverWire(t *testing.T) {
+	r, s := derivedWireSession(t)
+	call(t, r, s, "parameters.derivedTables.add", `{"sourceDocument":"test.obk","linked":["width"]}`, nil)
+	deriving := s.ActiveDocument()
+
+	// Activate the source and move width over the wire.
+	src, ok := s.Workspace().ByName("test.obk")
+	if !ok {
+		t.Fatal("seeded source document missing")
+	}
+	if err := s.Workspace().SetActiveDocument(src); err != nil {
+		t.Fatalf("activate source: %v", err)
+	}
+	call(t, r, s, "parameters.set", `{"name":"width","expression":"6 cm"}`, nil)
+
+	// Back on the deriving document, the derived value followed.
+	if err := s.Workspace().SetActiveDocument(deriving); err != nil {
+		t.Fatalf("re-activate deriving doc: %v", err)
+	}
+	if d := getDetail(t, r, s, "width"); !strings.Contains(d.Value, "6") {
+		t.Errorf("derived width after source edit = %q, want it at 6 cm", d.Value)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -133,6 +133,7 @@ func (r *Router) registerParameterDetailHandlers() {
 	r.handlers[wire.MethodParametersDependents] = parameterDependents
 	r.registerParameterGroupHandlers()
 	r.registerParameterSettingsHandlers()
+	r.registerDerivedTableHandlers()
 }
 
 // registerParameterGroupHandlers wires the custom parameter groups (M02-F05,
@@ -154,6 +155,15 @@ func (r *Router) registerParameterSettingsHandlers() {
 	r.handlers[wire.MethodParametersSetAllModelValueType] = sweepParameterModelValues
 	r.handlers[wire.MethodParametersExport] = exportParameters
 	r.handlers[wire.MethodParametersImport] = importParameters
+}
+
+// registerDerivedTableHandlers wires the derived parameter tables (M02-F06,
+// Oblikovati#605).
+func (r *Router) registerDerivedTableHandlers() {
+	r.handlers[wire.MethodParametersDerivedTablesList] = listDerivedTables
+	r.handlers[wire.MethodParametersDerivedTablesAdd] = addDerivedTable
+	r.handlers[wire.MethodParametersDerivedTablesSetLinked] = setDerivedTableLinked
+	r.handlers[wire.MethodParametersDerivedTablesDelete] = deleteDerivedTable
 }
 
 // registerSketchHandlers wires the 2D-sketch methods: the spine + enumeration here, and
@@ -323,6 +333,9 @@ func (r *Router) Handle(s *app.Session, method string, req []byte) (resp []byte,
 	// First cut: only router-path edits; local UI edits are not yet captured.
 	if mutatingMethods[method] {
 		s.EmitEditCommitted(method, req)
+		// The edit may have moved values other documents derive from
+		// (M02-F06); recordEdit covers session edits, this covers the wire.
+		s.ResyncDerivedFromActiveDocument()
 	}
 	return out, nil
 }
@@ -332,53 +345,56 @@ func (r *Router) Handle(s *app.Session, method string, req []byte) (resp []byte,
 // allowlist: a method missing here simply is not broadcast (a known first-cut gap,
 // failing safe), whereas a read-only method must never appear (it would broadcast noise).
 var mutatingMethods = map[string]bool{
-	wire.MethodDocumentsCreate:                true,
-	wire.MethodDocumentsImport:                true,
-	wire.MethodParametersAdd:                  true,
-	wire.MethodParametersSet:                  true,
-	wire.MethodParametersUpdate:               true,
-	wire.MethodParametersSetTolerance:         true,
-	wire.MethodParametersSetExpressionList:    true,
-	wire.MethodParametersDelete:               true,
-	wire.MethodParametersGroupsAdd:            true,
-	wire.MethodParametersGroupsDelete:         true,
-	wire.MethodParametersGroupsSetDisplayName: true,
-	wire.MethodParametersGroupsAddMember:      true,
-	wire.MethodParametersGroupsRemoveMember:   true,
-	wire.MethodParametersSetSettings:          true,
-	wire.MethodParametersSetAllModelValueType: true,
-	wire.MethodParametersImport:               true,
-	wire.MethodFeaturesAdd:                    true,
-	wire.MethodFeaturesEdit:                   true,
-	wire.MethodFeaturesDelete:                 true,
-	wire.MethodFeaturesRename:                 true,
-	wire.MethodFeaturesSetSuppressed:          true,
-	wire.MethodFeaturesReorder:                true,
-	wire.MethodWorkPlanesCreate:               true,
-	wire.MethodWorkPlanesRedefine:             true,
-	wire.MethodWorkPointsCreate:               true,
-	wire.MethodModelAssignMaterial:            true,
-	wire.MethodModelAssignAppearance:          true,
-	wire.MethodSketchCreate:                   true,
-	wire.MethodSketchRectangle:                true,
-	wire.MethodSketchDelete:                   true,
-	wire.MethodSketchEdit:                     true,
-	wire.MethodSketchExitEdit:                 true,
-	wire.MethodSketchSolve:                    true,
-	wire.MethodSketchAddEntity:                true,
-	wire.MethodSketchAddConstraint:            true,
-	wire.MethodSketchDeleteConstraint:         true,
-	wire.MethodSketchAddDimension:             true,
-	wire.MethodSketchDriveDimension:           true,
-	wire.MethodSketchSetProperty:              true,
-	wire.MethodSketchSetCustomLineType:        true,
-	wire.MethodSketchTransform:                true,
-	wire.MethodSketchAddPattern:               true,
-	wire.MethodSketchOffset:                   true,
-	wire.MethodSketchProject:                  true,
-	wire.MethodTransactionUndo:                true,
-	wire.MethodTransactionRedo:                true,
-	wire.MethodTransactionEnd:                 true,
+	wire.MethodDocumentsCreate:                  true,
+	wire.MethodDocumentsImport:                  true,
+	wire.MethodParametersAdd:                    true,
+	wire.MethodParametersSet:                    true,
+	wire.MethodParametersUpdate:                 true,
+	wire.MethodParametersSetTolerance:           true,
+	wire.MethodParametersSetExpressionList:      true,
+	wire.MethodParametersDelete:                 true,
+	wire.MethodParametersGroupsAdd:              true,
+	wire.MethodParametersGroupsDelete:           true,
+	wire.MethodParametersGroupsSetDisplayName:   true,
+	wire.MethodParametersGroupsAddMember:        true,
+	wire.MethodParametersGroupsRemoveMember:     true,
+	wire.MethodParametersSetSettings:            true,
+	wire.MethodParametersSetAllModelValueType:   true,
+	wire.MethodParametersImport:                 true,
+	wire.MethodParametersDerivedTablesAdd:       true,
+	wire.MethodParametersDerivedTablesSetLinked: true,
+	wire.MethodParametersDerivedTablesDelete:    true,
+	wire.MethodFeaturesAdd:                      true,
+	wire.MethodFeaturesEdit:                     true,
+	wire.MethodFeaturesDelete:                   true,
+	wire.MethodFeaturesRename:                   true,
+	wire.MethodFeaturesSetSuppressed:            true,
+	wire.MethodFeaturesReorder:                  true,
+	wire.MethodWorkPlanesCreate:                 true,
+	wire.MethodWorkPlanesRedefine:               true,
+	wire.MethodWorkPointsCreate:                 true,
+	wire.MethodModelAssignMaterial:              true,
+	wire.MethodModelAssignAppearance:            true,
+	wire.MethodSketchCreate:                     true,
+	wire.MethodSketchRectangle:                  true,
+	wire.MethodSketchDelete:                     true,
+	wire.MethodSketchEdit:                       true,
+	wire.MethodSketchExitEdit:                   true,
+	wire.MethodSketchSolve:                      true,
+	wire.MethodSketchAddEntity:                  true,
+	wire.MethodSketchAddConstraint:              true,
+	wire.MethodSketchDeleteConstraint:           true,
+	wire.MethodSketchAddDimension:               true,
+	wire.MethodSketchDriveDimension:             true,
+	wire.MethodSketchSetProperty:                true,
+	wire.MethodSketchSetCustomLineType:          true,
+	wire.MethodSketchTransform:                  true,
+	wire.MethodSketchAddPattern:                 true,
+	wire.MethodSketchOffset:                     true,
+	wire.MethodSketchProject:                    true,
+	wire.MethodTransactionUndo:                  true,
+	wire.MethodTransactionRedo:                  true,
+	wire.MethodTransactionEnd:                   true,
 }
 
 // record appends an operation entry to the trace, except for logs.tail itself (so polling the

--- a/app/derived_tables.go
+++ b/app/derived_tables.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/param"
+)
+
+// Derived parameter tables (M02-F06, Oblikovati#605): the session is the
+// resolution layer — it finds the source document through the workspace,
+// feeds its current values to the document-free model in model/param, records
+// the cross-document reference in the workspace graph, and re-syncs deriving
+// documents whenever a source finalizes an edit (the recordEdit seam).
+
+// LinkableSourceParameters returns the named document's numeric user
+// parameters — the candidates a derived table may link. ok=false means the
+// document is not open (or holds no part), which sync treats as a broken link.
+func (s *Session) LinkableSourceParameters(sourceDocument string) ([]param.SourceParameterValue, bool) {
+	d, ok := s.workspace.ByName(sourceDocument)
+	if !ok {
+		return nil, false
+	}
+	def, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return nil, false
+	}
+	var out []param.SourceParameterValue
+	for _, p := range def.Parameters().All() {
+		if p.Kind() == param.UserParam && p.IsNumeric() {
+			out = append(out, param.SourceParameterValue{Name: p.Name(), Value: p.Value()})
+		}
+	}
+	return out, true
+}
+
+// AddDerivedParameterTable links parameters from another open document into
+// the active part, recording the document reference so the link survives in
+// the workspace graph. One undo step.
+func (s *Session) AddDerivedParameterTable(sourceDocument string, linked []string) (*param.DerivedParameterTable, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if active := s.ActiveDocument(); active != nil && active.FullDocumentName() == sourceDocument {
+		return nil, fmt.Errorf("app: a document cannot derive parameters from itself (%q)", sourceDocument)
+	}
+	source, ok := s.LinkableSourceParameters(sourceDocument)
+	if !ok {
+		return nil, fmt.Errorf("app: no open part document named %q to derive from", sourceDocument)
+	}
+	t, err := part.Parameters().AddDerivedTable(sourceDocument, linked, source)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.ActiveDocument().AddReference(sourceDocument); err != nil {
+		return nil, err
+	}
+	part.Recompute()
+	s.recordEdit(part, "Derive Parameters")
+	return t, nil
+}
+
+// SetDerivedTableLinked replaces a table's linked subset on the active part.
+// One undo step.
+func (s *Session) SetDerivedTableLinked(id int, linked []string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t, ok := part.Parameters().DerivedTableByID(id)
+	if !ok {
+		return fmt.Errorf("app: no derived table with id %d", id)
+	}
+	source, ok := s.LinkableSourceParameters(t.SourceDocument())
+	if !ok {
+		return fmt.Errorf("app: source document %q is not open; cannot relink", t.SourceDocument())
+	}
+	if err := part.Parameters().SetDerivedTableLinked(id, linked, source); err != nil {
+		return err
+	}
+	part.Features().MarkAllDirty()
+	part.Recompute()
+	s.recordEdit(part, "Edit Derived Parameters")
+	return nil
+}
+
+// DeleteDerivedParameterTable removes a table and its derived parameters from
+// the active part (component-owned tables refuse). One undo step.
+func (s *Session) DeleteDerivedParameterTable(id int) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if err := part.Parameters().DeleteDerivedTable(id); err != nil {
+		return err
+	}
+	part.Features().MarkAllDirty()
+	part.Recompute()
+	s.recordEdit(part, "Delete Derived Parameters")
+	return nil
+}
+
+// ResyncDerivedFromActiveDocument pushes the active document's current values
+// into the documents deriving from it. The wire router calls this after every
+// mutating method — legacy wire edits (parameters.set/add) record no undo
+// step, so the recordEdit hook alone would miss them.
+func (s *Session) ResyncDerivedFromActiveDocument() {
+	if d := s.ActiveDocument(); d != nil {
+		s.resyncDerivedTables(d, map[string]bool{})
+	}
+}
+
+// resyncDerivedTables pushes a changed document's parameter values into every
+// open document deriving from it, then follows the chain (A→B→C) with a
+// visited guard against reference cycles. Syncs are computed consequences of
+// the source edit, not edits of their own — they record no undo step.
+func (s *Session) resyncDerivedTables(source *doc.Document, visited map[string]bool) {
+	name := source.FullDocumentName()
+	if visited[name] {
+		return
+	}
+	visited[name] = true
+	values, sourceOK := s.LinkableSourceParameters(name)
+	for _, d := range source.ReferencingDocuments() {
+		if s.resyncDocumentFrom(d, name, values, sourceOK) {
+			s.resyncDerivedTables(d, visited)
+		}
+	}
+}
+
+// resyncDocumentFrom refreshes one deriving document's tables that point at
+// sourceName, reporting whether anything was synced (and recomputing if so).
+func (s *Session) resyncDocumentFrom(d *doc.Document, sourceName string, values []param.SourceParameterValue, sourceOK bool) bool {
+	def, isPart := d.Content().(*compdef.PartComponentDefinition)
+	if !isPart {
+		return false
+	}
+	synced := false
+	for _, t := range def.Parameters().DerivedTables() {
+		if t.SourceDocument() != sourceName {
+			continue
+		}
+		_ = def.Parameters().SyncDerivedTable(t.ID(), values, sourceOK)
+		synced = true
+	}
+	if synced {
+		def.Features().MarkAllDirty()
+		def.Recompute()
+	}
+	return synced
+}

--- a/app/derived_tables_test.go
+++ b/app/derived_tables_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+// derivedSession opens two part documents: gears.obk with a numeric user
+// parameter "module", and hub.obk (active) ready to derive from it.
+func derivedSession(t *testing.T) (*Session, *doc.Document, *doc.Document) {
+	t.Helper()
+	s := NewSession()
+	gears, err := s.NewPart()
+	if err != nil {
+		t.Fatalf("NewPart(gears): %v", err)
+	}
+	if err := s.AddNumericUserParameter("module", "2 mm"); err != nil {
+		t.Fatalf("add module: %v", err)
+	}
+	hub, err := s.NewPart()
+	if err != nil {
+		t.Fatalf("NewPart(hub): %v", err)
+	}
+	if s.ActiveDocument() != hub {
+		t.Fatal("hub must be the active document")
+	}
+	return s, gears, hub
+}
+
+// docPartOf unwraps a document's part definition.
+func docPartOf(t *testing.T, d *doc.Document) *compdef.PartComponentDefinition {
+	t.Helper()
+	def, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		t.Fatalf("document %q holds no part", d.FullDocumentName())
+	}
+	return def
+}
+
+func TestDeriveParametersAcrossDocuments(t *testing.T) {
+	s, gears, hub := derivedSession(t)
+
+	table, err := s.AddDerivedParameterTable(gears.FullDocumentName(), []string{"module"})
+	if err != nil {
+		t.Fatalf("AddDerivedParameterTable: %v", err)
+	}
+	p, ok := docPartOf(t, hub).Parameters().ByName("module")
+	if !ok || !approx3(p.Value().Value, 0.2) {
+		t.Fatalf("derived module = %+v, want 0.2 (2 mm in db units)", p)
+	}
+
+	// The document reference is in the workspace graph.
+	if refs := hub.ReferencedDocuments(); len(refs) != 1 || refs[0] != gears {
+		t.Errorf("hub references = %v, want [gears]", refs)
+	}
+
+	// Editing the source pushes the new value into the deriving document
+	// through the recordEdit seam — no manual sync.
+	if err := s.Workspace().SetActiveDocument(gears); err != nil {
+		t.Fatalf("activate gears: %v", err)
+	}
+	srcParam, _ := docPartOf(t, gears).Parameters().ByName("module")
+	if err := s.SetParameterEquation(srcParam.ID(), "3 mm"); err != nil {
+		t.Fatalf("edit source module: %v", err)
+	}
+	if !approx3(p.Value().Value, 0.3) {
+		t.Errorf("derived module after source edit = %v, want 0.3", p.Value().Value)
+	}
+
+	// Deleting the source parameter sickens the derived one on the next edit.
+	if err := s.DeleteParameter(srcParam.ID()); err != nil {
+		t.Fatalf("delete source module: %v", err)
+	}
+	if p.Health().OK() {
+		t.Error("derived parameter must go sick when its source is deleted")
+	}
+	if table.Health().OK() {
+		t.Errorf("table health = %+v, want failed", table.Health())
+	}
+}
+
+func TestDeriveRejectsSelfAndUnknownSource(t *testing.T) {
+	s, _, hub := derivedSession(t)
+	if _, err := s.AddDerivedParameterTable(hub.FullDocumentName(), nil); err == nil || !strings.Contains(err.Error(), "itself") {
+		t.Errorf("self-derive err = %v, want a self-link rejection", err)
+	}
+	if _, err := s.AddDerivedParameterTable("missing.obk", nil); err == nil {
+		t.Error("deriving from an unopened document must be rejected")
+	}
+}
+
+func TestDerivedTableLifecycleOnSession(t *testing.T) {
+	s, gears, hub := derivedSession(t)
+	table, err := s.AddDerivedParameterTable(gears.FullDocumentName(), nil)
+	if err != nil {
+		t.Fatalf("AddDerivedParameterTable: %v", err)
+	}
+
+	if err := s.SetDerivedTableLinked(table.ID(), []string{"module"}); err != nil {
+		t.Fatalf("SetDerivedTableLinked: %v", err)
+	}
+	if _, ok := docPartOf(t, hub).Parameters().ByName("module"); !ok {
+		t.Error("relinking must produce the derived parameter")
+	}
+
+	if err := s.DeleteDerivedParameterTable(table.ID()); err != nil {
+		t.Fatalf("DeleteDerivedParameterTable: %v", err)
+	}
+	if _, ok := docPartOf(t, hub).Parameters().ByName("module"); ok {
+		t.Error("deleting the table must delete its derived parameters")
+	}
+}
+
+// approx3 absorbs float noise at three decimals.
+func approx3(got, want float64) bool {
+	const eps = 1e-9
+	return got-want < eps && want-got < eps
+}

--- a/app/undo.go
+++ b/app/undo.go
@@ -81,12 +81,20 @@ func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string
 		// undo step at EndTransaction. snapshot is intentionally left untouched.
 		return
 	}
+	s.commitRecipeDelta(d, dh, part, label)
+}
+
+// commitRecipeDelta records the part's recipe delta as one undo event and
+// pushes values other documents derive from through the reference graph
+// (M02-F06). A no-op delta (before == after) records nothing.
+func (s *Session) commitRecipeDelta(d *doc.Document, dh *docHistory, part *compdef.PartComponentDefinition, label string) {
 	after, err := part.MarshalRecipe()
 	if err != nil || bytes.Equal(after, dh.snapshot) {
 		return
 	}
 	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
 	dh.snapshot = after
+	s.resyncDerivedTables(d, map[string]bool{})
 }
 
 // RecordAddInEdit finalizes a router-applied mutation as one undo step: the
@@ -139,12 +147,7 @@ func (s *Session) EndTransaction() error {
 	if !ok {
 		return nil
 	}
-	after, err := part.MarshalRecipe()
-	if err != nil || bytes.Equal(after, dh.snapshot) {
-		return nil
-	}
-	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
-	dh.snapshot = after
+	s.commitRecipeDelta(d, dh, part, label)
 	return nil
 }
 

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -38,6 +38,7 @@ type partRecipe struct {
 	Parameters        []parameterRecipe         `yaml:"parameters,omitempty"`
 	ParameterGroups   []parameterGroupRecipe    `yaml:"parameterGroups,omitempty"` // custom group records, in creation order
 	ParameterSettings *parameterSettingsRecipe  `yaml:"parameterSettings,omitempty"`
+	DerivedTables     []derivedTableRecipe      `yaml:"derivedParameterTables,omitempty"`
 	WorkFeatures      []feature.WorkFeatureData `yaml:"workFeatures,omitempty"`
 	Sketches          []sketch.SketchData       `yaml:"sketches,omitempty"`
 	Sketches3D        []sketch.SketchData3D     `yaml:"sketches3D,omitempty"`
@@ -123,6 +124,17 @@ type parameterSettingsRecipe struct {
 	DisplayParameterAsExpression bool   `yaml:"displayParameterAsExpression,omitempty"`
 }
 
+// derivedTableRecipe persists one derived parameter table: its stable id (so
+// undo restores keep wire handles valid), the source document, and the linked
+// names. The produced derived parameters persist in the parameters list and
+// reconnect by name on restore (M02-F06, Oblikovati#605).
+type derivedTableRecipe struct {
+	ID             int      `yaml:"id"`
+	SourceDocument string   `yaml:"sourceDocument"`
+	Linked         []string `yaml:"linked,omitempty"`
+	OwnedByFeature bool     `yaml:"ownedByFeature,omitempty"`
+}
+
 // parameterGroupRecipe persists one custom parameter group: the immutable
 // internal name, the display name when it differs, the owning client id, and
 // the member parameter names (M02-F05, Oblikovati#604).
@@ -174,6 +186,7 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		Parameters:        d.parametersRecipe(),
 		ParameterGroups:   d.parameterGroupsRecipe(),
 		ParameterSettings: d.parameterSettingsRecipe(),
+		DerivedTables:     d.derivedTablesRecipe(),
 		WorkFeatures:      work,
 		Sketches:          sketches,
 		Sketches3D:        sketches3D,
@@ -231,6 +244,9 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 		return err
 	}
 	if err := d.applyParameterSettings(r.ParameterSettings); err != nil {
+		return err
+	}
+	if err := d.applyDerivedTables(r.DerivedTables); err != nil {
 		return err
 	}
 	if err := feature.ApplyWork(d.work, r.WorkFeatures); err != nil {
@@ -363,6 +379,29 @@ func (d *PartComponentDefinition) applyParameters(groups []parameterGroupRecipe,
 	for _, gr := range groups {
 		if err := d.applyParameterGroup(gr); err != nil {
 			return fmt.Errorf("compdef: restore parameter group %q: %w", gr.InternalName, err)
+		}
+	}
+	return nil
+}
+
+// derivedTablesRecipe renders the derived parameter tables in creation order.
+func (d *PartComponentDefinition) derivedTablesRecipe() []derivedTableRecipe {
+	var out []derivedTableRecipe
+	for _, t := range d.params.DerivedTables() {
+		out = append(out, derivedTableRecipe{
+			ID: t.ID(), SourceDocument: t.SourceDocument(),
+			Linked: t.Linked(), OwnedByFeature: t.OwnedByFeature(),
+		})
+	}
+	return out
+}
+
+// applyDerivedTables re-creates the persisted tables after the parameters
+// they reconnect to.
+func (d *PartComponentDefinition) applyDerivedTables(tables []derivedTableRecipe) error {
+	for _, tr := range tables {
+		if err := d.params.RestoreDerivedTable(tr.ID, tr.SourceDocument, tr.Linked, tr.OwnedByFeature); err != nil {
+			return fmt.Errorf("compdef: restore derived table %d: %w", tr.ID, err)
 		}
 	}
 	return nil

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -243,6 +243,37 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 	_ = flag
 }
 
+// TestDerivedTableSurvivesRoundTrip checks a derived parameter table restores
+// with its id, source link, and produced parameters reconnected by name.
+func TestDerivedTableSurvivesRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	ps := d.Content().(*compdef.PartComponentDefinition).Parameters()
+	src := []param.SourceParameterValue{{Name: "module", Value: param.Quantity{Value: 0.2, Unit: param.Length}}}
+	table, err := ps.AddDerivedTable("gears.obk", []string{"module"}, src)
+	if err != nil {
+		t.Fatalf("AddDerivedTable: %v", err)
+	}
+
+	r := reopenThroughStore(t, d).Parameters()
+	rt, ok := r.DerivedTableByID(table.ID())
+	if !ok || rt.SourceDocument() != "gears.obk" || len(rt.Linked()) != 1 {
+		t.Fatalf("restored table = %+v, want gears.obk linking module under id %d", rt, table.ID())
+	}
+	p, ok := r.ByName("module")
+	if !ok || p.Kind() != param.DerivedParam {
+		t.Fatalf("restored derived parameter = %+v, want read-only module", p)
+	}
+	// The reconnected link must sync — proof the produced map rebuilt by name.
+	changed := []param.SourceParameterValue{{Name: "module", Value: param.Quantity{Value: 0.4, Unit: param.Length}}}
+	if err := r.SyncDerivedTable(rt.ID(), changed, true); err != nil {
+		t.Fatalf("sync after reload: %v", err)
+	}
+	if p.Value().Value != 0.4 {
+		t.Errorf("synced reloaded value = %v, want 0.4", p.Value().Value)
+	}
+}
+
 func TestSketchGeometrySurvivesRoundTrip(t *testing.T) {
 	ws := doc.NewWorkspace(nil)
 	d, _ := compdef.AddPart(ws, "Part1", true)

--- a/model/param/derived_table.go
+++ b/model/param/derived_table.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"fmt"
+	"slices"
+)
+
+// Derived parameter tables (the reference API's DerivedParameterTable,
+// M02-F06, Oblikovati#605): the connection objects that link parameters from
+// another document into this one. A table records the source document and the
+// chosen linked subset, and owns the resulting read-only [DerivedParam]
+// parameters. The collection knows nothing about documents — callers resolve
+// the source into [SourceParameterValue]s (app.Session does, through the
+// workspace reference graph) and feed them to the sync methods, so the model
+// stays document-free and headless-testable.
+
+// SourceParameterValue is one linkable source parameter as the resolver sees
+// it: its name and its current evaluated quantity (database units). Only
+// numeric parameters link — a derived parameter is a value, not a text.
+type SourceParameterValue struct {
+	Name  string
+	Value Quantity
+}
+
+// DerivedParameterTable is one cross-document link. The id is stable for the
+// document's life (persisted, so undo restores keep wire handles valid).
+type DerivedParameterTable struct {
+	id             int
+	sourceDocument string
+	linked         []string
+	produced       map[string]ID // linked source name → derived parameter id
+	health         Health
+	ownedByFeature bool
+}
+
+// ID returns the table's stable identity.
+func (t *DerivedParameterTable) ID() int { return t.id }
+
+// SourceDocument returns the linked document's full document name.
+func (t *DerivedParameterTable) SourceDocument() string { return t.sourceDocument }
+
+// Linked returns the linked source-parameter names, in link order.
+func (t *DerivedParameterTable) Linked() []string { return append([]string(nil), t.linked...) }
+
+// Health returns the table's link health: healthy when every link resolves.
+func (t *DerivedParameterTable) Health() Health { return t.health }
+
+// OwnedByFeature reports whether a derived component owns this table — such a
+// table dies with its component, never through DeleteDerivedTable.
+func (t *DerivedParameterTable) OwnedByFeature() bool { return t.ownedByFeature }
+
+// MarkOwnedByFeature hands the table to a derived component (M08-F04).
+func (t *DerivedParameterTable) MarkOwnedByFeature() { t.ownedByFeature = true }
+
+// DerivedTables returns the tables in creation order.
+func (ps *Parameters) DerivedTables() []*DerivedParameterTable {
+	return append([]*DerivedParameterTable(nil), ps.derivedTables...)
+}
+
+// DerivedTableByID returns the table with the given id.
+func (ps *Parameters) DerivedTableByID(id int) (*DerivedParameterTable, bool) {
+	for _, t := range ps.derivedTables {
+		if t.id == id {
+			return t, true
+		}
+	}
+	return nil, false
+}
+
+// AddDerivedTable links the named source parameters into this collection,
+// creating one read-only derived parameter per linked name. Every linked name
+// must exist in source; a clash with an existing local parameter rejects the
+// add.
+func (ps *Parameters) AddDerivedTable(sourceDocument string, linked []string, source []SourceParameterValue) (*DerivedParameterTable, error) {
+	if sourceDocument == "" {
+		return nil, fmt.Errorf("param: derived table needs a source document")
+	}
+	t := &DerivedParameterTable{
+		id: ps.nextTableID, sourceDocument: sourceDocument, produced: map[string]ID{},
+	}
+	if err := ps.linkDerived(t, linked, source); err != nil {
+		return nil, err
+	}
+	ps.nextTableID++
+	ps.derivedTables = append(ps.derivedTables, t)
+	return t, nil
+}
+
+// SetDerivedTableLinked replaces the table's linked subset: newly linked
+// names gain derived parameters, unlinked ones lose theirs, kept ones update.
+func (ps *Parameters) SetDerivedTableLinked(id int, linked []string, source []SourceParameterValue) error {
+	t, ok := ps.DerivedTableByID(id)
+	if !ok {
+		return fmt.Errorf("param: no derived table with id %d", id)
+	}
+	for name, pid := range t.produced {
+		if slices.Contains(linked, name) {
+			continue
+		}
+		if p, exists := ps.byID[pid]; exists {
+			ps.remove(p)
+		}
+		delete(t.produced, name)
+	}
+	return ps.linkDerived(t, linked, source)
+}
+
+// linkDerived points the table at the given subset, creating missing derived
+// parameters and refreshing the values of kept ones.
+func (ps *Parameters) linkDerived(t *DerivedParameterTable, linked []string, source []SourceParameterValue) error {
+	values := sourceByName(source)
+	for _, name := range linked {
+		q, ok := values[name]
+		if !ok {
+			return fmt.Errorf("param: source document %q has no linkable parameter %q", t.sourceDocument, name)
+		}
+		if err := ps.produceDerived(t, name, q); err != nil {
+			return err
+		}
+	}
+	t.linked = append([]string(nil), linked...)
+	t.health = Health{Status: Healthy}
+	return nil
+}
+
+// produceDerived creates or refreshes the derived parameter for one link.
+func (ps *Parameters) produceDerived(t *DerivedParameterTable, name string, q Quantity) error {
+	if pid, exists := t.produced[name]; exists {
+		ps.refreshDerivedValue(pid, q)
+		return nil
+	}
+	p, err := ps.AddDerivedParameter(name, q)
+	if err != nil {
+		return fmt.Errorf("param: link %q: %w", name, err)
+	}
+	t.produced[name] = p.ID()
+	return nil
+}
+
+// SyncDerivedTable refreshes the table from the source's current parameters.
+// sourceOK=false means the source document itself is unreachable; a missing
+// linked name turns its derived parameter sick instead of deleting it, so the
+// model keeps computing on the last known value.
+func (ps *Parameters) SyncDerivedTable(id int, source []SourceParameterValue, sourceOK bool) error {
+	t, ok := ps.DerivedTableByID(id)
+	if !ok {
+		return fmt.Errorf("param: no derived table with id %d", id)
+	}
+	if !sourceOK {
+		ps.sickenTable(t, "source document "+t.sourceDocument+" is unavailable")
+		return nil
+	}
+	values := sourceByName(source)
+	broken := ps.syncLinks(t, values)
+	if len(broken) > 0 {
+		t.health = Health{Status: Failed, Reason: fmt.Sprintf("removed at source: %v", broken)}
+		return nil
+	}
+	t.health = Health{Status: Healthy}
+	return nil
+}
+
+// syncLinks refreshes every link, returning the names no longer at the source.
+func (ps *Parameters) syncLinks(t *DerivedParameterTable, values map[string]Quantity) []string {
+	var broken []string
+	for _, name := range t.linked {
+		pid, produced := t.produced[name]
+		if !produced {
+			continue
+		}
+		q, ok := values[name]
+		if !ok {
+			broken = append(broken, name)
+			ps.sickenDerived(pid, "removed at source document "+t.sourceDocument)
+			continue
+		}
+		ps.refreshDerivedValue(pid, q)
+	}
+	return broken
+}
+
+// RestoreDerivedTable re-creates a persisted table, reconnecting its produced
+// derived parameters by name (they restore with the parameter list itself).
+// A linked name without a matching derived parameter stays unproduced until
+// the next sync re-links it.
+func (ps *Parameters) RestoreDerivedTable(id int, sourceDocument string, linked []string, ownedByFeature bool) error {
+	if _, exists := ps.DerivedTableByID(id); exists {
+		return fmt.Errorf("param: a derived table with id %d already exists", id)
+	}
+	t := &DerivedParameterTable{
+		id: id, sourceDocument: sourceDocument, linked: append([]string(nil), linked...),
+		produced: map[string]ID{}, ownedByFeature: ownedByFeature,
+		health: Health{Status: Healthy},
+	}
+	for _, name := range linked {
+		if p, ok := ps.ByName(name); ok && p.Kind() == DerivedParam {
+			t.produced[name] = p.ID()
+		}
+	}
+	if id >= ps.nextTableID {
+		ps.nextTableID = id + 1
+	}
+	ps.derivedTables = append(ps.derivedTables, t)
+	return nil
+}
+
+// DeleteDerivedTable removes a table and its derived parameters. A table
+// owned by a derived component is deleted through its component, never here.
+func (ps *Parameters) DeleteDerivedTable(id int) error {
+	t, ok := ps.DerivedTableByID(id)
+	if !ok {
+		return fmt.Errorf("param: no derived table with id %d", id)
+	}
+	if t.ownedByFeature {
+		return fmt.Errorf("param: derived table %d is owned by a derived component; delete the component instead", id)
+	}
+	for _, pid := range t.produced {
+		if p, exists := ps.byID[pid]; exists {
+			ps.remove(p)
+		}
+	}
+	for i, other := range ps.derivedTables {
+		if other.id == id {
+			ps.derivedTables = append(ps.derivedTables[:i], ps.derivedTables[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// refreshDerivedValue updates one read-only derived parameter in place and
+// recomputes whatever reads it.
+func (ps *Parameters) refreshDerivedValue(id ID, q Quantity) {
+	p, ok := ps.byID[id]
+	if !ok {
+		return
+	}
+	p.expr, p.value, p.health = constantExpr(q), q, Health{Status: Healthy}
+	ps.recomputeFrom(id)
+}
+
+// sickenDerived fails one derived parameter, keeping its last value so the
+// geometry it drives stays computable.
+func (ps *Parameters) sickenDerived(id ID, reason string) {
+	if p, ok := ps.byID[id]; ok {
+		p.health = Health{Status: Failed, Reason: reason}
+	}
+}
+
+// sickenTable fails the table and every parameter it produced.
+func (ps *Parameters) sickenTable(t *DerivedParameterTable, reason string) {
+	t.health = Health{Status: Failed, Reason: reason}
+	for _, pid := range t.produced {
+		ps.sickenDerived(pid, reason)
+	}
+}
+
+// sourceByName indexes the resolver's view for link lookups.
+func sourceByName(source []SourceParameterValue) map[string]Quantity {
+	out := make(map[string]Quantity, len(source))
+	for _, s := range source {
+		out[s.Name] = s.Value
+	}
+	return out
+}

--- a/model/param/derived_table_test.go
+++ b/model/param/derived_table_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// gearSource is the resolver's view of a source document with two linkable
+// numeric parameters.
+func gearSource() []SourceParameterValue {
+	return []SourceParameterValue{
+		{Name: "module", Value: Quantity{Value: 0.2, Unit: Length}},
+		{Name: "teeth", Value: Quantity{Value: 24, Unit: Unitless}},
+	}
+}
+
+func TestAddDerivedTableProducesReadOnlyParameters(t *testing.T) {
+	ps := NewParameters()
+	table, err := ps.AddDerivedTable("gears.obk", []string{"module"}, gearSource())
+	if err != nil {
+		t.Fatalf("AddDerivedTable: %v", err)
+	}
+	if table.SourceDocument() != "gears.obk" || !slices.Equal(table.Linked(), []string{"module"}) {
+		t.Errorf("table = %+v, want gears.obk linking module", table)
+	}
+	p, ok := ps.ByName("module")
+	if !ok || p.Kind() != DerivedParam || !approxScalar(p.Value().Value, 0.2) {
+		t.Fatalf("derived parameter = %+v, want read-only module = 0.2", p)
+	}
+	if err := p.SetExpression("1 mm"); err == nil {
+		t.Error("a derived parameter must be read-only")
+	}
+
+	if _, err := ps.AddDerivedTable("gears.obk", []string{"bogus"}, gearSource()); err == nil || !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("unknown link err = %v, want a rejection naming bogus", err)
+	}
+	if _, err := ps.AddDerivedTable("", nil, nil); err == nil {
+		t.Error("empty source document must be rejected")
+	}
+	// A second table linking the same name clashes with the produced parameter.
+	if _, err := ps.AddDerivedTable("other.obk", []string{"module"}, gearSource()); err == nil {
+		t.Error("a link clashing with an existing parameter must be rejected")
+	}
+}
+
+func TestSetDerivedTableLinkedDiffsTheSubset(t *testing.T) {
+	ps := NewParameters()
+	table, _ := ps.AddDerivedTable("gears.obk", []string{"module"}, gearSource())
+
+	if err := ps.SetDerivedTableLinked(table.ID(), []string{"teeth"}, gearSource()); err != nil {
+		t.Fatalf("SetDerivedTableLinked: %v", err)
+	}
+	if _, ok := ps.ByName("module"); ok {
+		t.Error("unlinking must delete the produced derived parameter")
+	}
+	if p, ok := ps.ByName("teeth"); !ok || p.Kind() != DerivedParam {
+		t.Error("newly linked name must gain a derived parameter")
+	}
+}
+
+func TestSyncDerivedTablePropagatesAndSickens(t *testing.T) {
+	ps := NewParameters()
+	table, _ := ps.AddDerivedTable("gears.obk", []string{"module"}, gearSource())
+	// A local parameter computing on the derived value.
+	dependent, _ := ps.AddUserParameter("pitch", "module * 24")
+	if !approxScalar(dependent.Value().Value, 4.8) {
+		t.Fatalf("dependent = %v, want 4.8 (0.2 * 24)", dependent.Value().Value)
+	}
+
+	// A source value change flows through to dependents.
+	changed := []SourceParameterValue{{Name: "module", Value: Quantity{Value: 0.25, Unit: Length}}}
+	if err := ps.SyncDerivedTable(table.ID(), changed, true); err != nil {
+		t.Fatalf("SyncDerivedTable: %v", err)
+	}
+	if !approxScalar(dependent.Value().Value, 6) {
+		t.Errorf("dependent after sync = %v, want 6 (0.25 * 24)", dependent.Value().Value)
+	}
+
+	// A removed source parameter sickens its derived counterpart but keeps the
+	// last value so the model still computes.
+	if err := ps.SyncDerivedTable(table.ID(), nil, true); err != nil {
+		t.Fatalf("sync with removed source: %v", err)
+	}
+	module, _ := ps.ByName("module")
+	if module.Health().OK() || !approxScalar(module.Value().Value, 0.25) {
+		t.Errorf("after removal: health=%+v value=%v, want sick at last value 0.25", module.Health(), module.Value().Value)
+	}
+	if table.Health().OK() || !strings.Contains(table.Health().Reason, "module") {
+		t.Errorf("table health = %+v, want failed naming module", table.Health())
+	}
+
+	// The source coming back restores health.
+	if err := ps.SyncDerivedTable(table.ID(), gearSource(), true); err != nil {
+		t.Fatalf("recovery sync: %v", err)
+	}
+	if !module.Health().OK() || !table.Health().OK() {
+		t.Errorf("after recovery: param=%+v table=%+v, want both healthy", module.Health(), table.Health())
+	}
+
+	// An unreachable source document sickens the whole table.
+	_ = ps.SyncDerivedTable(table.ID(), nil, false)
+	if table.Health().OK() || module.Health().OK() {
+		t.Error("unreachable source must sicken the table and its parameters")
+	}
+}
+
+func TestDeleteDerivedTableRules(t *testing.T) {
+	ps := NewParameters()
+	table, _ := ps.AddDerivedTable("gears.obk", []string{"module", "teeth"}, gearSource())
+
+	owned, _ := ps.AddDerivedTable("hub.obk", nil, []SourceParameterValue{})
+	owned.MarkOwnedByFeature()
+	if err := ps.DeleteDerivedTable(owned.ID()); err == nil || !strings.Contains(err.Error(), "component") {
+		t.Errorf("component-owned delete err = %v, want a refusal pointing at the component", err)
+	}
+
+	if err := ps.DeleteDerivedTable(table.ID()); err != nil {
+		t.Fatalf("DeleteDerivedTable: %v", err)
+	}
+	if _, ok := ps.ByName("module"); ok {
+		t.Error("deleting a table must delete its derived parameters")
+	}
+	if err := ps.DeleteDerivedTable(table.ID()); err == nil {
+		t.Error("deleting an unknown table must error")
+	}
+}
+
+func TestRestoreDerivedTableReconnectsByName(t *testing.T) {
+	ps := NewParameters()
+	// The parameter list restores first (as ApplyRecipe does), then the table.
+	_, _ = ps.AddDerivedParameter("module", Quantity{Value: 0.2, Unit: Length})
+	if err := ps.RestoreDerivedTable(7, "gears.obk", []string{"module"}, true); err != nil {
+		t.Fatalf("RestoreDerivedTable: %v", err)
+	}
+	table, ok := ps.DerivedTableByID(7)
+	if !ok || !table.OwnedByFeature() {
+		t.Fatalf("restored table = %+v, want id 7 owned by feature", table)
+	}
+	// The reconnected link syncs like a created one.
+	changed := []SourceParameterValue{{Name: "module", Value: Quantity{Value: 0.3, Unit: Length}}}
+	_ = ps.SyncDerivedTable(7, changed, true)
+	p, _ := ps.ByName("module")
+	if !approxScalar(p.Value().Value, 0.3) {
+		t.Errorf("synced reconnected value = %v, want 0.3", p.Value().Value)
+	}
+	// The persistent counter never reissues a restored id.
+	next, _ := ps.AddDerivedTable("other.obk", nil, nil)
+	if next.ID() <= 7 {
+		t.Errorf("next table id = %d, want above the restored 7", next.ID())
+	}
+}

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -26,6 +26,11 @@ type Parameters struct {
 
 	// settings are the document-level parameter settings (M02-F07); see settings.go.
 	settings CollectionSettings
+
+	// Derived parameter tables (M02-F06): cross-document links in creation
+	// order, with their persistent id counter. See derived_table.go.
+	derivedTables []*DerivedParameterTable
+	nextTableID   int
 }
 
 // idSet is a set of parameter ids.
@@ -38,6 +43,7 @@ func NewParameters() *Parameters {
 		drivenBy: map[ID]idSet{}, dependents: map[ID]idSet{},
 		memberships: map[ID]map[string]bool{},
 		settings:    DefaultCollectionSettings(),
+		nextTableID: 1,
 	}
 }
 


### PR DESCRIPTION
## What

Implements the /source half of #605 (contract merged as Oblikovati/api#63): `DerivedParameterTable` — the connection object linking parameters from another document into this one — served over `addin/router`.

- **Table records** hold the source document, the chosen linked subset, and own one read-only `DerivedParam` per link. `model/param` stays document-free: the session resolves the source through the workspace and feeds `SourceParameterValue`s to the sync.
- **Update-on-source-change**: every finalized edit (the `commitRecipeDelta` seam shared by `recordEdit` and `EndTransaction`, plus the router's mutating-method hook for legacy wire edits that record no undo step) pushes new values into deriving documents transitively (A→B→C, cycle-guarded). Value changes flow through the dependency DAG into local expressions and features.
- **Broken links degrade, never explode**: a removed source parameter sickens its derived counterpart at its last value so the model keeps computing, and fails the table naming the loss; an unreachable source document sickens the whole table; a recovered source heals both.
- **Lifecycle**: `setLinked` diffs the subset (new names gain derived parameters, unlinked ones lose theirs); delete refuses component-owned tables (M08-F04 owns those); the document reference lands in the workspace reference graph.
- **Persistence**: tables persist in `.obk` with their stable ids (undo restores keep wire handles valid) and reconnect their produced parameters by name on restore.

## Tests

- `model/param`: produce/read-only invariants, link validation and clashes, subset diffing, sync propagation through dependents, sicken/heal cycles, delete rules, restore reconnection and id-counter survival.
- `app`: two-document derive with automatic propagation on source edit, source-delete sickening, self/unknown-source rejection, session lifecycle.
- `model/compdef`: `.obk` round-trip with post-reload sync proof.
- `addin/router`: wire lifecycle with live candidates, bad-args rejections, `edit.committed` broadcasts, and end-to-end source-edit propagation over the wire.

Full suite, `go vet`, and golangci-lint v2.1.0 (the CI pin) are green locally.

Closes #605. With it, all four open M02 issues (#604–#607) are delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)