### PR TITLE
M04-F05: TransactionEvents & file-access/file-UI event sets

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -55,6 +55,9 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 			return relayEdit(sink, e)
 		}),
 	)
+	subs = append(subs, subscribeTransactions(bus, sink)...)
+	subs = append(subs, subscribeFileAccess(s.Workspace().Events(), sink)...)
+	subs = append(subs, subscribeFileUIHooks(bus, sink)...)
 	return append(subs, subscribeUISurfaces(bus, sink)...)
 }
 
@@ -165,7 +168,9 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.FileDialogChosenEvent | wire.WebDialogChangedEvent |
 	wire.SelectionChangedEvent | wire.EnvironmentChangedEvent |
 	wire.TriadDragEvent | wire.TriadSegmentEvent | wire.ManipulatorDragEvent |
-	wire.ClientOperationEvent](sink Sink, ev E) event.Outcome {
+	wire.ClientOperationEvent | wire.TransactionEventPayload |
+	wire.FileResolutionEventPayload | wire.FileDirtyEventPayload |
+	wire.FileDialogHookPayload](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/events/lifecycle_relay.go
+++ b/addin/events/lifecycle_relay.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// The M04-F05 relays (Oblikovati#613): transaction lifecycle, file-access and
+// file-UI hook events forwarded to the add-in sink as their wire payloads. All
+// relays are After-phase observers — the vetoable/answerable Before phase is
+// in-proc only until the event transport (#148) carries answers back.
+
+// subscribeTransactions forwards the five transaction stream moves, each tagged
+// with the cursor point it acted on (commit=current, undo=previous, redo=next).
+func subscribeTransactions(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TransactionCommitted) event.Outcome {
+			return relayTransaction(sink, wire.EventTransactionCommitted, e.Document, e.Label, types.TransactionPointCurrent)
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TransactionUndone) event.Outcome {
+			return relayTransaction(sink, wire.EventTransactionUndone, e.Document, e.Label, types.TransactionPointPrevious)
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TransactionRedone) event.Outcome {
+			return relayTransaction(sink, wire.EventTransactionRedone, e.Document, e.Label, types.TransactionPointNext)
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TransactionAborted) event.Outcome {
+			return relayTransaction(sink, wire.EventTransactionAborted, e.Document, e.Label, types.TransactionPointCurrent)
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.TransactionDeleted) event.Outcome {
+			return relayTransaction(sink, wire.EventTransactionDeleted, e.Document, "", types.TransactionPointUnknown)
+		}),
+	}
+}
+
+// relayTransaction renders one stream move into the shared wire payload.
+func relayTransaction(sink Sink, eventType string, d doc.ID, label string, p types.TransactionPoint) event.Outcome {
+	return relayJSON(sink, wire.TransactionEventPayload{
+		Type: eventType, Document: uint64(d), Label: label, Point: p,
+	})
+}
+
+// subscribeFileAccess forwards the workspace-bus file events: resolution
+// outcomes and clean→dirty transitions.
+func subscribeFileAccess(ws *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.FileResolution) event.Outcome {
+			return relayJSON(sink, wire.FileResolutionEventPayload{
+				Type: wire.EventFileResolution, RequestedName: e.RequestedName, ResolvedName: e.Resolved(),
+			})
+		}),
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.FileDirty) event.Outcome {
+			return relayJSON(sink, wire.FileDirtyEventPayload{
+				Type: wire.EventFileDirty, Document: uint64(e.Document.ID()),
+				FullDocumentName: e.Document.FullDocumentName(),
+			})
+		}),
+	}
+}
+
+// subscribeFileUIHooks forwards the session-bus file-UI flow observations.
+func subscribeFileUIHooks(bus *event.Bus, sink Sink) []event.Subscription {
+	subs := []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FileNew) event.Outcome {
+			return relayJSON(sink, wire.FileDialogHookPayload{Type: wire.EventFileNew, DocumentType: e.DocumentType})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FileOpenFromMRU) event.Outcome {
+			return relayJSON(sink, wire.FileDialogHookPayload{Type: wire.EventFileOpenFromMRU, FileName: e.FullDocumentName})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.PopulateFileMetadata) event.Outcome {
+			return relayJSON(sink, wire.FileDialogHookPayload{
+				Type: wire.EventFilePopulateMetadata, Metadata: metadataEntries(e.Entries()),
+			})
+		}),
+	}
+	return append(subs, subscribeFileDialogHooks(bus, sink)...)
+}
+
+// subscribeFileDialogHooks forwards the three dialog-replacement hooks with
+// whatever path a handler supplied.
+func subscribeFileDialogHooks(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FileNewDialog) event.Outcome {
+			return relayJSON(sink, wire.FileDialogHookPayload{Type: wire.EventFileNewDialog, TemplateFile: e.Supplied()})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FileOpenDialog) event.Outcome {
+			return relayJSON(sink, wire.FileDialogHookPayload{Type: wire.EventFileOpenDialog, FileName: e.Supplied()})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FileSaveAsDialog) event.Outcome {
+			return relayJSON(sink, wire.FileDialogHookPayload{
+				Type: wire.EventFileSaveAsDialog, FileName: e.Supplied(), SaveCopyAs: e.SaveCopyAs,
+			})
+		}),
+	}
+}
+
+// metadataEntries maps the app's collected metadata into the wire shape.
+func metadataEntries(values []app.FileMetadataValue) []wire.FileMetadataEntry {
+	out := make([]wire.FileMetadataEntry, len(values))
+	for i, v := range values {
+		out[i] = wire.FileMetadataEntry{Name: v.Name, Value: v.Value}
+	}
+	return out
+}

--- a/addin/events/lifecycle_relay_test.go
+++ b/addin/events/lifecycle_relay_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// typedPayloadRecorder keeps the raw JSON per event type so each payload can be decoded
+// with its own wire DTO.
+type typedPayloadRecorder struct {
+	mu  sync.Mutex
+	raw map[string][][]byte
+}
+
+func newTypedPayloadRecorder() *typedPayloadRecorder {
+	return &typedPayloadRecorder{raw: map[string][][]byte{}}
+}
+
+func (r *typedPayloadRecorder) sink(b []byte) {
+	var tag struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(b, &tag); err != nil {
+		return
+	}
+	r.mu.Lock()
+	r.raw[tag.Type] = append(r.raw[tag.Type], append([]byte(nil), b...))
+	r.mu.Unlock()
+}
+
+// decodeSingle asserts eventType reached the sink exactly once and decodes it.
+// Generic over the wire payloads so each call site stays statically typed.
+func decodeSingle[P wire.TransactionEventPayload | wire.FileResolutionEventPayload |
+	wire.FileDirtyEventPayload | wire.FileDialogHookPayload](t *testing.T, r *typedPayloadRecorder, eventType string) P {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var payload P
+	got := r.raw[eventType]
+	if len(got) != 1 {
+		t.Fatalf("%s fired %d times, want 1", eventType, len(got))
+	}
+	if err := json.Unmarshal(got[0], &payload); err != nil {
+		t.Fatalf("decode %s: %v", eventType, err)
+	}
+	return payload
+}
+
+// TestForwardsTransactionLifecycle drives a commit, an undo, and a redo through
+// the session and checks each reaches the sink as the wire payload with the
+// cursor-relative point (M04-F05).
+func TestForwardsTransactionLifecycle(t *testing.T) {
+	s := app.NewSession()
+	rec := newTypedPayloadRecorder()
+	subs := Subscribe(s, rec.sink)
+	defer cancelAll(subs)
+
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	if err := s.AddNumericUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("add parameter: %v", err)
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if err := s.Redo(); err != nil {
+		t.Fatalf("Redo: %v", err)
+	}
+
+	committed := decodeSingle[wire.TransactionEventPayload](t, rec, wire.EventTransactionCommitted)
+	undone := decodeSingle[wire.TransactionEventPayload](t, rec, wire.EventTransactionUndone)
+	redone := decodeSingle[wire.TransactionEventPayload](t, rec, wire.EventTransactionRedone)
+	if committed.Label != "Edit Parameters" || committed.Point != types.TransactionPointCurrent {
+		t.Errorf("committed = %+v, want Edit Parameters at the current point", committed)
+	}
+	if undone.Point != types.TransactionPointPrevious || redone.Point != types.TransactionPointNext {
+		t.Errorf("undo/redo points = %v/%v, want previous/next", undone.Point, redone.Point)
+	}
+	if committed.Document == 0 {
+		t.Error("committed event must carry the document id")
+	}
+}
+
+// TestForwardsFileEvents covers the file-access and file-UI relays: a dirty
+// transition, a vetoed-free new-part flow, and a dialog hook answer.
+func TestForwardsFileEvents(t *testing.T) {
+	s := app.NewSession()
+	rec := newTypedPayloadRecorder()
+	subs := Subscribe(s, rec.sink)
+	defer cancelAll(subs)
+
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	created := decodeSingle[wire.FileDialogHookPayload](t, rec, wire.EventFileNew)
+	if created.DocumentType != types.DocumentPart {
+		t.Errorf("file.new payload = %+v, want a part", created)
+	}
+
+	// A new part is born dirty (no transition); clean it and dirty it again.
+	d := s.ActiveDocument()
+	d.ClearDirty()
+	d.MarkDirty()
+	dirty := decodeSingle[wire.FileDirtyEventPayload](t, rec, wire.EventFileDirty)
+	if dirty.Document != uint64(d.ID()) || dirty.FullDocumentName != d.FullDocumentName() {
+		t.Errorf("file.dirty payload = %+v, want document %d %q", dirty, d.ID(), d.FullDocumentName())
+	}
+
+	// An answered open-dialog hook relays the supplied path to observers.
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e app.FileOpenDialog) event.Outcome {
+		e.Supply("/vault/bracket.obk")
+		return event.Handle()
+	})
+	if path, ok := s.HookFileOpenDialog(); !ok || path != "/vault/bracket.obk" {
+		t.Fatalf("hook = (%q, %v), want the supplied path", path, ok)
+	}
+	hook := decodeSingle[wire.FileDialogHookPayload](t, rec, wire.EventFileOpenDialog)
+	if hook.FileName != "/vault/bracket.obk" {
+		t.Errorf("file.openDialog payload = %+v, want the supplied path", hook)
+	}
+}
+
+// cancelAll cancels every subscription (the shutdown path Subscribe documents).
+func cancelAll(subs []event.Subscription) {
+	for _, sub := range subs {
+		sub.Cancel()
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -111,13 +111,14 @@ func (r *Router) registerStandardHandlers() {
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query
 // the active document's transaction-event stream (transaction.undo/redo/state), plus the
-// bounded transaction.begin/end that coalesce a batch into one undo step.
+// bounded transaction.begin/end/abort that make a batch one undo step or discard it.
 func (r *Router) registerTransactionHandlers() {
 	r.handlers[wire.MethodTransactionUndo] = undoTransaction
 	r.handlers[wire.MethodTransactionRedo] = redoTransaction
 	r.handlers[wire.MethodTransactionState] = transactionState
 	r.handlers[wire.MethodTransactionBegin] = beginTransaction
 	r.handlers[wire.MethodTransactionEnd] = endTransaction
+	r.handlers[wire.MethodTransactionAbort] = abortTransaction
 }
 
 // registerParameterDetailHandlers wires the member-level parameter surface —
@@ -395,6 +396,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodTransactionUndo:                  true,
 	wire.MethodTransactionRedo:                  true,
 	wire.MethodTransactionEnd:                   true,
+	wire.MethodTransactionAbort:                 true,
 }
 
 // record appends an operation entry to the trace, except for logs.tail itself (so polling the

--- a/addin/router/transaction_bounds_test.go
+++ b/addin/router/transaction_bounds_test.go
@@ -58,3 +58,31 @@ func TestEndTransactionWithoutBeginErrors(t *testing.T) {
 		t.Fatal("expected an error ending with no open transaction")
 	}
 }
+
+// TestAbortTransactionDiscardsBatchOverWire: transaction.abort reverts the open
+// batch instead of committing it — the failed-batch escape hatch (M04-F05).
+func TestAbortTransactionDiscardsBatchOverWire(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+
+	call(t, r, s, "transaction.begin", `{"label":"batch"}`, nil)
+	if err := s.AddNumericUserParameter("h", "3 cm"); err != nil {
+		t.Fatalf("add h: %v", err)
+	}
+
+	var st wire.UndoState
+	call(t, r, s, "transaction.abort", "{}", &st)
+	if st.CanUndo {
+		t.Fatalf("an aborted batch must record nothing, got %+v", st)
+	}
+	if err := s.AddNumericUserParameter("h", "5 cm"); err != nil {
+		t.Fatalf("re-adding h after abort must work (the batch was reverted): %v", err)
+	}
+
+	if _, err := r.Handle(s, "transaction.abort", nil); err == nil {
+		t.Fatal("expected an error aborting with no open transaction")
+	}
+}

--- a/addin/router/transactions.go
+++ b/addin/router/transactions.go
@@ -53,6 +53,16 @@ func endTransaction(s *app.Session, _ json.RawMessage) (json.RawMessage, error) 
 	return marshalUndoState(s)
 }
 
+// abortTransaction discards the open bounded transaction — the model reverts to the
+// group's pre-Begin state and no undo step is recorded (wire.MethodTransactionAbort,
+// M04-F05): an add-in whose batch failed partway does not leave the document half-edited.
+func abortTransaction(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	if err := s.AbortTransaction(); err != nil {
+		return nil, err
+	}
+	return marshalUndoState(s)
+}
+
 // marshalUndoState renders the active document's cursor state into the wire DTO.
 func marshalUndoState(s *app.Session) (json.RawMessage, error) {
 	return json.Marshal(wire.UndoState{

--- a/app/file_ui_events.go
+++ b/app/file_ui_events.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// The file-UI event set (M04-F05, Oblikovati#613) on the session bus: the
+// new/open/save-as flows and their dialogs, so an add-in can veto, observe, or
+// pre-seed them (a PDM add-in replaces the file dialogs with its vault picker).
+// Stable TypeIDs continue the session-bus block; never renumber.
+const (
+	tidFileNew              event.TypeID = 0x0518
+	tidFileNewDialog        event.TypeID = 0x0519
+	tidFileOpenDialog       event.TypeID = 0x051a
+	tidFileSaveAsDialog     event.TypeID = 0x051b
+	tidFileOpenFromMRU      event.TypeID = 0x051c
+	tidPopulateFileMetadata event.TypeID = 0x051d
+)
+
+// FileNew fires around creating a new document; a Before handler may veto
+// (e.g. enforce a vault checkout-first policy).
+type FileNew struct{ DocumentType doc.DocumentType }
+
+// EventID implements event.Event.
+func (FileNew) EventID() event.TypeID { return tidFileNew }
+
+// FileOpenDialog fires (Before) when the head is about to present File ▸ Open;
+// a handler that supplies a path replaces the dialog — the head opens the
+// supplied file directly. The After phase reports the outcome to observers.
+type FileOpenDialog struct{ answer *string }
+
+// EventID implements event.Event.
+func (FileOpenDialog) EventID() event.TypeID { return tidFileOpenDialog }
+
+// Supply answers the hook with the path to use instead of showing the dialog.
+// The first non-empty answer sticks (events travel by value; the slot is shared).
+func (e FileOpenDialog) Supply(path string) { supplyAnswer(e.answer, path) }
+
+// Supplied returns the path a handler supplied, "" when none did.
+func (e FileOpenDialog) Supplied() string { return *e.answer }
+
+// FileSaveAsDialog fires (Before) when the head is about to present File ▸
+// Save As; a handler that supplies a path replaces the dialog. SaveCopyAs
+// distinguishes the save-a-copy variant when it arrives.
+type FileSaveAsDialog struct {
+	SaveCopyAs bool
+	answer     *string
+}
+
+// EventID implements event.Event.
+func (FileSaveAsDialog) EventID() event.TypeID { return tidFileSaveAsDialog }
+
+// Supply answers the hook with the destination path to use instead of asking.
+func (e FileSaveAsDialog) Supply(path string) { supplyAnswer(e.answer, path) }
+
+// Supplied returns the path a handler supplied, "" when none did.
+func (e FileSaveAsDialog) Supplied() string { return *e.answer }
+
+// FileNewDialog fires (Before) when the head is about to present a new-document
+// template chooser; a handler may supply the template to use instead. The head
+// has no template dialog yet — the seam exists so add-ins written against it
+// keep working when one arrives, and wire observers see the flow today.
+type FileNewDialog struct{ answer *string }
+
+// EventID implements event.Event.
+func (FileNewDialog) EventID() event.TypeID { return tidFileNewDialog }
+
+// Supply answers the hook with the template file to use instead of asking.
+func (e FileNewDialog) Supply(templateFile string) { supplyAnswer(e.answer, templateFile) }
+
+// Supplied returns the template a handler supplied, "" when none did.
+func (e FileNewDialog) Supplied() string { return *e.answer }
+
+// FileOpenFromMRU fires around opening a document from the recent-files list;
+// a Before handler may veto (e.g. the vault knows the file moved).
+type FileOpenFromMRU struct{ FullDocumentName string }
+
+// EventID implements event.Event.
+func (FileOpenFromMRU) EventID() event.TypeID { return tidFileOpenFromMRU }
+
+// FileMetadataValue is one name/value pair collected around a save.
+type FileMetadataValue struct{ Name, Value string }
+
+// PopulateFileMetadata fires (Before) as a document is about to save, letting
+// handlers contribute file properties (author, revision, vault state…); the
+// collected entries are queryable via [Session.FileMetadata].
+type PopulateFileMetadata struct {
+	FullDocumentName string
+	entries          *[]FileMetadataValue
+}
+
+// EventID implements event.Event.
+func (PopulateFileMetadata) EventID() event.TypeID { return tidPopulateFileMetadata }
+
+// Add contributes one metadata entry (every handler's copy shares the slice).
+func (e PopulateFileMetadata) Add(name, value string) {
+	*e.entries = append(*e.entries, FileMetadataValue{Name: name, Value: value})
+}
+
+// Entries returns the collected metadata so far.
+func (e PopulateFileMetadata) Entries() []FileMetadataValue { return *e.entries }
+
+// supplyAnswer writes a hook's first non-empty answer; later calls are ignored.
+func supplyAnswer(slot *string, answer string) {
+	if *slot == "" {
+		*slot = answer
+	}
+}

--- a/app/file_ui_hooks.go
+++ b/app/file_ui_hooks.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// The session seams behind the file-UI event set (M04-F05, Oblikovati#613):
+// the head consults the Hook* methods before presenting its file dialogs, the
+// recent-files menu opens through OpenDocumentFromMRU, and the save paths
+// collect metadata. Each seam emits Before (handlers answer or veto) and After
+// (observers see the outcome) on the session bus.
+
+// maxRecentDocuments bounds the recent-files list (the File ▸ Open Recent menu).
+const maxRecentDocuments = 10
+
+// HookFileOpenDialog announces File ▸ Open is about to present. A handler that
+// supplies a path replaces the dialog: the head opens the returned path
+// directly instead of showing it.
+func (s *Session) HookFileOpenDialog() (string, bool) {
+	return runDialogHook(s, FileOpenDialog{answer: new(string)})
+}
+
+// HookFileSaveAsDialog announces File ▸ Save As is about to present; a supplied
+// path replaces the dialog.
+func (s *Session) HookFileSaveAsDialog(saveCopyAs bool) (string, bool) {
+	return runDialogHook(s, FileSaveAsDialog{SaveCopyAs: saveCopyAs, answer: new(string)})
+}
+
+// HookFileNewDialog announces a new-document template chooser is about to
+// present; a supplied template replaces the dialog.
+func (s *Session) HookFileNewDialog() (string, bool) {
+	return runDialogHook(s, FileNewDialog{answer: new(string)})
+}
+
+// dialogHook is the shape the three dialog hooks share: an answer slot readable
+// after emission.
+type dialogHook interface {
+	event.Event
+	Supplied() string
+}
+
+// runDialogHook emits one dialog hook in both phases and returns the answer.
+// Generic because the bus dispatches on the event's static type.
+func runDialogHook[E dialogHook](s *Session, ev E) (string, bool) {
+	event.Emit(s.bus, event.Before, ev)
+	event.Emit(s.bus, event.After, ev)
+	return ev.Supplied(), ev.Supplied() != ""
+}
+
+// RecentDocuments returns the recently opened/saved paths, most recent first —
+// the File ▸ Open Recent menu.
+func (s *Session) RecentDocuments() []string { return s.recentDocuments }
+
+// OpenDocumentFromMRU opens a path picked from the recent-files menu, behind
+// the vetoable FileOpenFromMRU hook (a vault add-in knows the file moved).
+func (s *Session) OpenDocumentFromMRU(path string) (*doc.Document, error) {
+	ev := FileOpenFromMRU{FullDocumentName: path}
+	if out := event.Emit(s.bus, event.Before, ev); out.Vetoed() {
+		s.notice = out.Reason
+		return nil, &doc.VetoError{Operation: "open recent", Reason: out.Reason}
+	}
+	d, err := s.OpenDocument(path)
+	if err != nil {
+		return nil, err
+	}
+	event.Emit(s.bus, event.After, ev)
+	return d, nil
+}
+
+// rememberRecentDocument moves path to the front of the recent list, bounded —
+// called by the open/save-as paths so the menu tracks real file activity.
+func (s *Session) rememberRecentDocument(path string) {
+	out := []string{path}
+	for _, p := range s.recentDocuments {
+		if p != path && len(out) < maxRecentDocuments {
+			out = append(out, p)
+		}
+	}
+	s.recentDocuments = out
+}
+
+// collectFileMetadata runs the PopulateFileMetadata hook for a document about
+// to save and remembers what handlers contributed.
+func (s *Session) collectFileMetadata(d *doc.Document) {
+	ev := PopulateFileMetadata{FullDocumentName: d.FullDocumentName(), entries: &[]FileMetadataValue{}}
+	event.Emit(s.bus, event.Before, ev)
+	event.Emit(s.bus, event.After, ev)
+	if s.fileMetadata == nil {
+		s.fileMetadata = map[doc.ID][]FileMetadataValue{}
+	}
+	s.fileMetadata[d.ID()] = ev.Entries()
+}
+
+// FileMetadata returns the entries the PopulateFileMetadata hook collected at
+// the document's last save (nil when it never saved this session).
+func (s *Session) FileMetadata(id doc.ID) []FileMetadataValue { return s.fileMetadata[id] }

--- a/app/file_ui_hooks_test.go
+++ b/app/file_ui_hooks_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// fakeDocStore is an in-memory doc.Store: enough persistence for the file-UI
+// hook tests to exercise real open/save flows without touching disk.
+type fakeDocStore struct{ saved map[string]doc.DocumentType }
+
+func newFakeDocStore() *fakeDocStore { return &fakeDocStore{saved: map[string]doc.DocumentType{}} }
+
+func (f *fakeDocStore) Save(d *doc.Document) error {
+	f.saved[d.FullDocumentName()] = d.DocumentType()
+	return nil
+}
+
+func (f *fakeDocStore) Load(name string) (*doc.Document, error) {
+	t, ok := f.saved[name]
+	if !ok {
+		return nil, errors.New("fakeDocStore: nothing at " + name)
+	}
+	return doc.Restore(t, name, "")
+}
+
+func (f *fakeDocStore) Exists(name string) bool { _, ok := f.saved[name]; return ok }
+
+// TestFileNewVetoBlocksNewPart: a Before FileNew handler vetoing (a vault's
+// checkout-first policy) stops the document from being created.
+func TestFileNewVetoBlocksNewPart(t *testing.T) {
+	s := NewSession()
+	var after []FileNew
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e FileNew) event.Outcome {
+		after = append(after, e)
+		return event.Continue()
+	})
+
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	if len(after) != 1 || after[0].DocumentType != doc.Part {
+		t.Fatalf("After events = %+v, want one part FileNew", after)
+	}
+
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e FileNew) event.Outcome {
+		return event.Veto("check out a project first")
+	})
+	if _, err := s.NewPart(); err == nil {
+		t.Fatal("a vetoed FileNew must block the create")
+	}
+	if n := len(s.Workspace().Documents()); n != 1 {
+		t.Errorf("documents after veto = %d, want still 1", n)
+	}
+	if len(after) != 1 {
+		t.Errorf("After events after veto = %d, want still 1", len(after))
+	}
+}
+
+// TestFileDialogHooksSupplyPaths: a handler answering a dialog hook replaces
+// the head's explorer — the seam returns the supplied path; unanswered hooks
+// report false so the head shows the dialog.
+func TestFileDialogHooksSupplyPaths(t *testing.T) {
+	s := NewSession()
+	if _, ok := s.HookFileOpenDialog(); ok {
+		t.Error("an unanswered open hook must report false")
+	}
+
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e FileOpenDialog) event.Outcome {
+		e.Supply("/vault/bracket.obk")
+		return event.Handle()
+	})
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e FileSaveAsDialog) event.Outcome {
+		if !e.SaveCopyAs {
+			e.Supply("/vault/out.obk")
+		}
+		return event.Handle()
+	})
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e FileNewDialog) event.Outcome {
+		e.Supply("/templates/steel-part.obk")
+		return event.Handle()
+	})
+
+	if path, ok := s.HookFileOpenDialog(); !ok || path != "/vault/bracket.obk" {
+		t.Errorf("open hook = (%q, %v), want the supplied vault path", path, ok)
+	}
+	if path, ok := s.HookFileSaveAsDialog(false); !ok || path != "/vault/out.obk" {
+		t.Errorf("save-as hook = (%q, %v), want the supplied destination", path, ok)
+	}
+	if _, ok := s.HookFileSaveAsDialog(true); ok {
+		t.Error("the save-copy-as variant was answered though the handler skips it")
+	}
+	if path, ok := s.HookFileNewDialog(); !ok || path != "/templates/steel-part.obk" {
+		t.Errorf("new hook = (%q, %v), want the supplied template", path, ok)
+	}
+}
+
+// TestOpenDocumentFromMRUHonorsVetoAndRecords: recent-files entries open behind
+// the vetoable hook, and open/save-as activity maintains the bounded MRU list.
+func TestOpenDocumentFromMRUHonorsVetoAndRecords(t *testing.T) {
+	store := newFakeDocStore()
+	s := NewSessionWithStore(store)
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	if err := s.SaveActiveDocumentAs("/models/a.obk"); err != nil {
+		t.Fatalf("SaveActiveDocumentAs: %v", err)
+	}
+	if got := s.RecentDocuments(); len(got) != 1 || got[0] != "/models/a.obk" {
+		t.Fatalf("RecentDocuments after save-as = %v, want [/models/a.obk]", got)
+	}
+	if err := s.Workspace().Close(s.ActiveDocument(), true); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := s.OpenDocumentFromMRU("/models/a.obk"); err != nil {
+		t.Fatalf("OpenDocumentFromMRU: %v", err)
+	}
+	if got := s.RecentDocuments(); len(got) != 1 || got[0] != "/models/a.obk" {
+		t.Errorf("RecentDocuments must dedupe re-opens, got %v", got)
+	}
+
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e FileOpenFromMRU) event.Outcome {
+		return event.Veto("the vault says this file moved")
+	})
+	_, err := s.OpenDocumentFromMRU("/models/a.obk")
+	var veto *doc.VetoError
+	if !errors.As(err, &veto) {
+		t.Fatalf("vetoed MRU open = %v, want a *doc.VetoError", err)
+	}
+}
+
+// TestPopulateFileMetadataCollectsAroundSave: handlers contribute entries when
+// a document saves, queryable afterwards per document.
+func TestPopulateFileMetadataCollectsAroundSave(t *testing.T) {
+	s := NewSessionWithStore(newFakeDocStore())
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e PopulateFileMetadata) event.Outcome {
+		e.Add("author", "vm")
+		e.Add("revision", "B")
+		return event.Handle()
+	})
+
+	if err := s.SaveActiveDocumentAs("/models/meta.obk"); err != nil {
+		t.Fatalf("SaveActiveDocumentAs: %v", err)
+	}
+	got := s.FileMetadata(s.ActiveDocument().ID())
+	if len(got) != 2 || got[0] != (FileMetadataValue{Name: "author", Value: "vm"}) {
+		t.Errorf("FileMetadata = %+v, want the two contributed entries", got)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -84,20 +84,22 @@ type Session struct {
 	themeStore           *theme.Store
 	materials            *material.Library
 	materialStore        *material.Store
-	notice               string                   // last user-facing notice (e.g. a failed-commit reason)
-	visualStyle          renderer.VisualStyle     // how the scene is drawn (View tab's Visual Style)
-	lightingStyle        renderer.LightingStyleID // active lighting preset (View tab's Lighting Style)
-	lighting             renderer.SceneLighting   // the live lighting rig (resolved from the style, then edited)
-	chamferFlatCorners   bool                     // default three-edge-corner treatment for new chamfers
-	paramsDialogOpen     bool                     // the Manage ▸ Parameters dialog is open
-	lightingPanelOpen    bool                     // the View ▸ Lighting settings panel is open
-	loadEnvRequested     bool                     // a "Load HDR…" was requested; the head opens the file dialog
-	scriptConsoleOpen    bool                     // the Manage ▸ Scripts ▸ Script Console panel is open
-	capturePath          string                   // a requested viewport PNG capture path; the head writes it after render
-	normalDebug          bool                     // viewport normal-debug render (front green / back red); head reads each frame
-	meshColors           bool                     // viewport mesh-debug-colors render (each face/triangle a distinct color)
-	meshColorsPerTri     bool                     // when meshColors: color per TRIANGLE (else per B-rep face)
-	editScope            editScope                // while editing a node, hide everything created after it (issue #132)
+	recentDocuments      []string                       // recently opened/saved paths, most recent first (M04-F05)
+	fileMetadata         map[doc.ID][]FileMetadataValue // last save's PopulateFileMetadata harvest (M04-F05)
+	notice               string                         // last user-facing notice (e.g. a failed-commit reason)
+	visualStyle          renderer.VisualStyle           // how the scene is drawn (View tab's Visual Style)
+	lightingStyle        renderer.LightingStyleID       // active lighting preset (View tab's Lighting Style)
+	lighting             renderer.SceneLighting         // the live lighting rig (resolved from the style, then edited)
+	chamferFlatCorners   bool                           // default three-edge-corner treatment for new chamfers
+	paramsDialogOpen     bool                           // the Manage ▸ Parameters dialog is open
+	lightingPanelOpen    bool                           // the View ▸ Lighting settings panel is open
+	loadEnvRequested     bool                           // a "Load HDR…" was requested; the head opens the file dialog
+	scriptConsoleOpen    bool                           // the Manage ▸ Scripts ▸ Script Console panel is open
+	capturePath          string                         // a requested viewport PNG capture path; the head writes it after render
+	normalDebug          bool                           // viewport normal-debug render (front green / back red); head reads each frame
+	meshColors           bool                           // viewport mesh-debug-colors render (each face/triangle a distinct color)
+	meshColorsPerTri     bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
+	editScope            editScope                      // while editing a node, hide everything created after it (issue #132)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in
@@ -308,6 +310,7 @@ func (s *Session) OpenDocument(path string) (*doc.Document, error) {
 	}
 	s.documentHistory(d) // open the event stream now so the first edit's before-snapshot is the open state
 	s.loadViewState(d)   // restore this user's saved camera/view layout (kept outside the .obk)
+	s.rememberRecentDocument(path)
 	return d, nil
 }
 
@@ -317,11 +320,17 @@ func (s *Session) OpenDocument(path string) (*doc.Document, error) {
 //
 //	d, err := session.NewPart()
 func (s *Session) NewPart() (*doc.Document, error) {
+	ev := FileNew{DocumentType: doc.Part}
+	if out := event.Emit(s.bus, event.Before, ev); out.Vetoed() {
+		s.notice = out.Reason
+		return nil, &doc.VetoError{Operation: "new part", Reason: out.Reason}
+	}
 	d, err := compdef.AddPart(s.workspace, s.uniquePartName(), true)
 	if err != nil {
 		return nil, err
 	}
 	s.documentHistory(d) // open the event stream now so the first edit is undoable to the empty part
+	event.Emit(s.bus, event.After, ev)
 	return d, nil
 }
 
@@ -350,6 +359,7 @@ func (s *Session) SaveActiveDocument() error {
 	if !strings.HasSuffix(d.FullFileName(), doc.PackageExtension) {
 		return ErrNeedsPath
 	}
+	s.collectFileMetadata(d) // the PopulateFileMetadata hook gathers file properties around the save
 	if err := s.workspace.Save(d); err != nil {
 		return err
 	}
@@ -364,9 +374,11 @@ func (s *Session) SaveActiveDocumentAs(path string) error {
 	if d == nil {
 		return ErrNoActiveDoc
 	}
+	s.collectFileMetadata(d) // the PopulateFileMetadata hook gathers file properties around the save
 	if err := s.workspace.SaveAs(d, path); err != nil {
 		return err
 	}
-	s.saveViewState(d) // persist under the new path (camera/view layout stays out of the .obk)
+	s.saveViewState(d)             // persist under the new path (camera/view layout stays out of the .obk)
+	s.rememberRecentDocument(path) // a save-as destination is recent file activity
 	return nil
 }

--- a/app/session.go
+++ b/app/session.go
@@ -160,6 +160,7 @@ func newSession(store doc.Store) *Session {
 	// the sky as the viewport background (ADR-0026 §8).
 	s.lighting.Environment = renderer.DefaultEnvironment()
 	s.initShellSurfaces()
+	s.watchDocumentCloses()
 	return s
 }
 

--- a/app/transaction_events.go
+++ b/app/transaction_events.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// The transaction lifecycle event set (M04-F05, Oblikovati#613): every move of a
+// document's transaction stream, on the session bus. Commit/undo/redo fire in the
+// Before phase (vetoable) and then, if not vetoed, the After phase; abort and
+// delete are observations only, matching the reference event set. Distinct from
+// the coalesced [TransactionChanged] (no payload, fires once per cursor move):
+// these carry which step moved and how, so an add-in can keep external state
+// (caches, overlays, exported data) consistent with undo/redo.
+//
+// Stable TypeIDs continue the session-bus block; never renumber.
+const (
+	tidTransactionCommitted event.TypeID = 0x0513
+	tidTransactionUndone    event.TypeID = 0x0514
+	tidTransactionRedone    event.TypeID = 0x0515
+	tidTransactionAborted   event.TypeID = 0x0516
+	tidTransactionDeleted   event.TypeID = 0x0517
+)
+
+// TransactionCommitted fires around one edit being recorded as an undo step.
+// A Before handler may veto, which reverts the model to the pre-edit snapshot
+// and turns the commit into an abort.
+type TransactionCommitted struct {
+	Document doc.ID
+	Label    string
+}
+
+// EventID implements event.Event.
+func (TransactionCommitted) EventID() event.TypeID { return tidTransactionCommitted }
+
+// TransactionUndone fires around undo. A Before handler may veto the move
+// (e.g. external state cannot roll back); Label names the step undone.
+type TransactionUndone struct {
+	Document doc.ID
+	Label    string
+}
+
+// EventID implements event.Event.
+func (TransactionUndone) EventID() event.TypeID { return tidTransactionUndone }
+
+// TransactionRedone fires around redo; a Before handler may veto the move.
+type TransactionRedone struct {
+	Document doc.ID
+	Label    string
+}
+
+// EventID implements event.Event.
+func (TransactionRedone) EventID() event.TypeID { return tidTransactionRedone }
+
+// TransactionAborted fires (After) when a transaction is discarded instead of
+// committed: an explicit [Session.AbortTransaction], or a commit a Before
+// handler vetoed. The model has already reverted to the pre-transaction state.
+type TransactionAborted struct {
+	Document doc.ID
+	Label    string
+}
+
+// EventID implements event.Event.
+func (TransactionAborted) EventID() event.TypeID { return tidTransactionAborted }
+
+// TransactionDeleted fires (After) when a document's whole transaction stream is
+// discarded — the document closed and its undo steps are gone.
+type TransactionDeleted struct{ Document doc.ID }
+
+// EventID implements event.Event.
+func (TransactionDeleted) EventID() event.TypeID { return tidTransactionDeleted }

--- a/app/transaction_events_test.go
+++ b/app/transaction_events_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/event"
+)
+
+// newPartSession is a session with one fresh part document — the smallest
+// vehicle for transaction-stream events (a parameter edit is one undo step).
+func newPartSession(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	return s
+}
+
+// TestCommitEmitsTransactionCommitted pins the happy path: one edit fires
+// Before then After with the step's label and document id (M04-F05).
+func TestCommitEmitsTransactionCommitted(t *testing.T) {
+	s := newPartSession(t)
+	var phases []event.Phase
+	var got TransactionCommitted
+	event.Subscribe(s.Events(), event.Before, func(c event.Context, e TransactionCommitted) event.Outcome {
+		phases = append(phases, c.Phase)
+		return event.Continue()
+	})
+	event.Subscribe(s.Events(), event.After, func(c event.Context, e TransactionCommitted) event.Outcome {
+		phases = append(phases, c.Phase)
+		got = e
+		return event.Continue()
+	})
+
+	if err := s.AddNumericUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter: %v", err)
+	}
+	if len(phases) != 2 || phases[0] != event.Before || phases[1] != event.After {
+		t.Fatalf("phases = %v, want [Before After]", phases)
+	}
+	if got.Label != "Edit Parameters" || got.Document != s.ActiveDocument().ID() {
+		t.Errorf("committed event = %+v, want the Edit Parameters step on the active document", got)
+	}
+}
+
+// TestVetoedCommitRevertsEditAndReportsAbort: a Before handler vetoing the
+// commit rolls the model back to the pre-edit snapshot, records no undo step,
+// and announces a TransactionAborted instead.
+func TestVetoedCommitRevertsEditAndReportsAbort(t *testing.T) {
+	s := newPartSession(t)
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e TransactionCommitted) event.Outcome {
+		return event.Veto("policy: parameters are locked")
+	})
+	var aborted []TransactionAborted
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TransactionAborted) event.Outcome {
+		aborted = append(aborted, e)
+		return event.Continue()
+	})
+
+	if err := s.AddNumericUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter itself must not fail: %v", err)
+	}
+	if _, ok := partOf(t, s).Parameters().ByName("w"); ok {
+		t.Error("the vetoed edit must be reverted, but parameter w survived")
+	}
+	if s.CanUndo() {
+		t.Error("a vetoed commit must not record an undo step")
+	}
+	if len(aborted) != 1 || aborted[0].Label != "Edit Parameters" {
+		t.Errorf("aborted events = %+v, want one for the Edit Parameters step", aborted)
+	}
+	if s.Notice() != "policy: parameters are locked" {
+		t.Errorf("notice = %q, want the veto reason surfaced", s.Notice())
+	}
+}
+
+// TestUndoRedoEmitEventsAndHonorVeto covers the navigation events: undo/redo
+// fire with the moved step's label, and a Before veto blocks the move.
+func TestUndoRedoEmitEventsAndHonorVeto(t *testing.T) {
+	s := newPartSession(t)
+	if err := s.AddNumericUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter: %v", err)
+	}
+	var undone []TransactionUndone
+	var redone []TransactionRedone
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TransactionUndone) event.Outcome {
+		undone = append(undone, e)
+		return event.Continue()
+	})
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TransactionRedone) event.Outcome {
+		redone = append(redone, e)
+		return event.Continue()
+	})
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if err := s.Redo(); err != nil {
+		t.Fatalf("Redo: %v", err)
+	}
+	if len(undone) != 1 || undone[0].Label != "Edit Parameters" {
+		t.Errorf("undone events = %+v, want one Edit Parameters", undone)
+	}
+	if len(redone) != 1 || redone[0].Label != "Edit Parameters" {
+		t.Errorf("redone events = %+v, want one Edit Parameters", redone)
+	}
+
+	// An external observer that cannot roll back vetoes the next undo: the
+	// cursor must not move and the parameter must survive.
+	event.Subscribe(s.Events(), event.Before, func(_ event.Context, e TransactionUndone) event.Outcome {
+		return event.Veto("exported state cannot roll back")
+	})
+	if err := s.Undo(); err == nil {
+		t.Fatal("a vetoed undo must return an error")
+	}
+	if _, ok := partOf(t, s).Parameters().ByName("w"); !ok {
+		t.Error("a vetoed undo must not move the cursor (parameter w vanished)")
+	}
+	if len(undone) != 1 {
+		t.Errorf("undone events after veto = %d, want still 1 (no After for a vetoed move)", len(undone))
+	}
+}
+
+// TestAbortTransactionDiscardsTheGroup: an aborted bounded transaction reverts
+// the whole batch, records nothing, and announces the abort with the group's
+// label — the seam behind wire transaction.abort.
+func TestAbortTransactionDiscardsTheGroup(t *testing.T) {
+	s := newPartSession(t)
+	if err := s.AbortTransaction(); err != ErrNoOpenTransaction {
+		t.Fatalf("abort with nothing open = %v, want ErrNoOpenTransaction", err)
+	}
+
+	var aborted []TransactionAborted
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TransactionAborted) event.Outcome {
+		aborted = append(aborted, e)
+		return event.Continue()
+	})
+	if err := s.BeginTransaction("remote batch"); err != nil {
+		t.Fatalf("BeginTransaction: %v", err)
+	}
+	if err := s.AddNumericUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter: %v", err)
+	}
+	if err := s.AbortTransaction(); err != nil {
+		t.Fatalf("AbortTransaction: %v", err)
+	}
+	if _, ok := partOf(t, s).Parameters().ByName("w"); ok {
+		t.Error("the aborted batch must be reverted, but parameter w survived")
+	}
+	if s.InTransaction() || s.CanUndo() {
+		t.Errorf("after abort: InTransaction=%v CanUndo=%v, want both false", s.InTransaction(), s.CanUndo())
+	}
+	if len(aborted) != 1 || aborted[0].Label != "remote batch" {
+		t.Errorf("aborted events = %+v, want one for the remote batch group", aborted)
+	}
+}
+
+// TestDocumentCloseDeletesTransactionStream: closing a document discards its
+// stream (no history leak) and announces TransactionDeleted.
+func TestDocumentCloseDeletesTransactionStream(t *testing.T) {
+	s := newPartSession(t)
+	if err := s.AddNumericUserParameter("w", "5 mm"); err != nil {
+		t.Fatalf("AddNumericUserParameter: %v", err)
+	}
+	var deleted []TransactionDeleted
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e TransactionDeleted) event.Outcome {
+		deleted = append(deleted, e)
+		return event.Continue()
+	})
+
+	d := s.ActiveDocument()
+	if err := s.Workspace().Close(d, true); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0].Document != d.ID() {
+		t.Fatalf("deleted events = %+v, want one for document %d", deleted, d.ID())
+	}
+	if _, ok := s.histories[d.ID()]; ok {
+		t.Error("the closed document's history must be dropped from the session")
+	}
+}

--- a/app/undo.go
+++ b/app/undo.go
@@ -86,15 +86,34 @@ func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string
 
 // commitRecipeDelta records the part's recipe delta as one undo event and
 // pushes values other documents derive from through the reference graph
-// (M02-F06). A no-op delta (before == after) records nothing.
+// (M02-F06). A no-op delta (before == after) records nothing. A Before
+// TransactionCommitted handler may veto, which reverts the part to the
+// pre-edit snapshot and reports the commit as an abort (M04-F05).
 func (s *Session) commitRecipeDelta(d *doc.Document, dh *docHistory, part *compdef.PartComponentDefinition, label string) {
 	after, err := part.MarshalRecipe()
 	if err != nil || bytes.Equal(after, dh.snapshot) {
 		return
 	}
+	if out := event.Emit(s.bus, event.Before, TransactionCommitted{Document: d.ID(), Label: label}); out.Vetoed() {
+		s.revertVetoedCommit(d, dh, part, label, out.Reason)
+		return
+	}
 	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
 	dh.snapshot = after
 	s.resyncDerivedTables(d, map[string]bool{})
+	event.Emit(s.bus, event.After, TransactionCommitted{Document: d.ID(), Label: label})
+}
+
+// revertVetoedCommit rolls the part back to the stream's snapshot after a Before
+// handler vetoed the commit, surfacing the veto reason in the status bar.
+func (s *Session) revertVetoedCommit(d *doc.Document, dh *docHistory, part *compdef.PartComponentDefinition, label, reason string) {
+	if err := part.RestoreRecipe(dh.snapshot); err != nil {
+		s.notice = err.Error()
+		return
+	}
+	s.notice = reason
+	s.resyncDerivedTables(d, map[string]bool{})
+	event.Emit(s.bus, event.After, TransactionAborted{Document: d.ID(), Label: label})
 }
 
 // RecordAddInEdit finalizes a router-applied mutation as one undo step: the
@@ -106,6 +125,19 @@ func (s *Session) RecordAddInEdit(part *compdef.PartComponentDefinition, label s
 
 // ErrNoOpenTransaction is returned by EndTransaction when no bounded transaction is open.
 var ErrNoOpenTransaction = errors.New("app: no open transaction to end")
+
+// watchDocumentCloses discards a closed document's transaction stream and
+// announces the deletion (M04-F05): the undo steps die with the document, and
+// dropping the map entry keeps closed documents from leaking histories.
+func (s *Session) watchDocumentCloses() {
+	event.Subscribe(s.workspace.Events(), event.After, func(_ event.Context, e doc.DocumentClose) event.Outcome {
+		if _, ok := s.histories[e.Document.ID()]; ok {
+			delete(s.histories, e.Document.ID())
+			event.Emit(s.bus, event.After, TransactionDeleted{Document: e.Document.ID()})
+		}
+		return event.Continue()
+	})
+}
 
 // BeginTransaction opens a bounded transaction on the active document: every edit
 // recorded until the matching EndTransaction is coalesced into a single undo step named
@@ -151,6 +183,32 @@ func (s *Session) EndTransaction() error {
 	return nil
 }
 
+// AbortTransaction discards the open bounded transaction instead of committing
+// it: the part reverts to the group's pre-Begin snapshot (whatever the nesting
+// depth — an abort cancels the whole group, there is no partial abort) and no
+// undo step is recorded. The seam behind wire transaction.abort, so an add-in
+// whose batch fails partway does not leave the document half-edited (M04-F05).
+func (s *Session) AbortTransaction() error {
+	d := s.ActiveDocument()
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	dh := s.documentHistory(d)
+	if dh.groupDepth == 0 {
+		return ErrNoOpenTransaction
+	}
+	label := dh.groupLabel
+	dh.groupDepth, dh.groupLabel = 0, ""
+	if part, ok := d.Content().(*compdef.PartComponentDefinition); ok {
+		if err := part.RestoreRecipe(dh.snapshot); err != nil {
+			return err
+		}
+		s.resyncDerivedTables(d, map[string]bool{})
+	}
+	event.Emit(s.bus, event.After, TransactionAborted{Document: d.ID(), Label: label})
+	return nil
+}
+
 // InTransaction reports whether a bounded transaction is open on the active document.
 func (s *Session) InTransaction() bool {
 	st := s.activeStream()
@@ -168,12 +226,11 @@ func (s *Session) Undo() error {
 		return ErrNoActiveDoc
 	}
 	dh := s.documentHistory(d)
-	if err := dh.hist.Undo(); err != nil {
-		s.notice = err.Error()
+	ev := TransactionUndone{Document: d.ID(), Label: s.UndoLabel()}
+	if err := cursorMove(s, d, dh, ev, dh.hist.Undo); err != nil {
 		return err
 	}
-	dh.resync(d)
-	s.notice = ""
+	event.Emit(s.bus, event.After, ev)
 	return nil
 }
 
@@ -185,7 +242,25 @@ func (s *Session) Redo() error {
 		return ErrNoActiveDoc
 	}
 	dh := s.documentHistory(d)
-	if err := dh.hist.Redo(); err != nil {
+	ev := TransactionRedone{Document: d.ID(), Label: s.RedoLabel()}
+	if err := cursorMove(s, d, dh, ev, dh.hist.Redo); err != nil {
+		return err
+	}
+	event.Emit(s.bus, event.After, ev)
+	return nil
+}
+
+// cursorMove runs one undo/redo navigation behind its Before event: a handler may
+// veto the move (e.g. external state cannot roll back, M04-F05), and a failed
+// move surfaces in the status bar. The caller emits the matching After event.
+// Generic (and free, since methods cannot be) because the bus dispatches on the
+// event's static type — an interface-typed emit would reach no subscriber.
+func cursorMove[E event.Event](s *Session, d *doc.Document, dh *docHistory, ev E, move func() error) error {
+	if out := event.Emit(s.bus, event.Before, ev); out.Vetoed() {
+		s.notice = out.Reason
+		return &doc.VetoError{Operation: "transaction", Reason: out.Reason}
+	}
+	if err := move(); err != nil {
 		s.notice = err.Error()
 		return err
 	}

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -28,13 +28,14 @@ func drawFileMenu(s *app.Session) {
 			_, _ = s.NewPart()
 		}
 		if native.MenuItem("Open") {
-			fileModal.openFor(dialogOpen)
+			openViaHookOrDialog(s)
 		}
+		drawOpenRecentMenu(s)
 		if native.MenuItem("Save") {
 			saveActive(s)
 		}
 		if native.MenuItem("Save As") {
-			fileModal.openFor(dialogSaveAs)
+			saveAsViaHookOrDialog(s)
 		}
 		native.Separator()
 		if native.MenuItem("Import") { // STL / OBJ / 3MF / STEP → an imported body
@@ -45,6 +46,44 @@ func drawFileMenu(s *app.Session) {
 		}
 		native.EndMenu()
 	}
+}
+
+// openViaHookOrDialog consults the FileOpenDialog hook before presenting the
+// explorer (M04-F05): an add-in that supplies a path replaces the dialog.
+func openViaHookOrDialog(s *app.Session) {
+	if path, ok := s.HookFileOpenDialog(); ok {
+		applyFileAction(s, fileAction{Kind: dialogOpen, Path: path})
+		return
+	}
+	fileModal.openFor(dialogOpen)
+}
+
+// saveAsViaHookOrDialog consults the FileSaveAsDialog hook before presenting
+// the explorer; a supplied destination saves directly.
+func saveAsViaHookOrDialog(s *app.Session) {
+	if path, ok := s.HookFileSaveAsDialog(false); ok {
+		applyFileAction(s, fileAction{Kind: dialogSaveAs, Path: path})
+		return
+	}
+	fileModal.openFor(dialogSaveAs)
+}
+
+// drawOpenRecentMenu lists the session's recent documents (File ▸ Open Recent);
+// each entry opens behind the vetoable FileOpenFromMRU hook.
+func drawOpenRecentMenu(s *app.Session) {
+	recent := s.RecentDocuments()
+	if len(recent) == 0 {
+		return
+	}
+	if !native.BeginMenu("Open Recent") {
+		return
+	}
+	for _, path := range recent {
+		if native.MenuItem(path) {
+			_, _ = s.OpenDocumentFromMRU(path)
+		}
+	}
+	native.EndMenu()
 }
 
 func drawEditMenu(s *app.Session) {

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+
+	"oblikovati.org/event"
 )
 
 // ID is a document's session-stable handle. Like entity ids (core/02), it is a
@@ -123,8 +125,16 @@ func (d *Document) SetDisplayName(name string) { d.displayName = name }
 func (d *Document) Dirty() bool { return d.dirty }
 
 // MarkDirty flags the document as having unsaved changes. Editing operations
-// call this; saving clears it via [Document.ClearDirty].
-func (d *Document) MarkDirty() { d.dirty = true }
+// call this; saving clears it via [Document.ClearDirty]. The clean→dirty
+// transition announces a [FileDirty] event (M04-F05); re-marking an already
+// dirty document is silent.
+func (d *Document) MarkDirty() {
+	wasDirty := d.dirty
+	d.dirty = true
+	if !wasDirty && d.graph != nil {
+		event.Emit(d.graph.ws.bus, event.After, FileDirty{Document: d})
+	}
+}
 
 // ClearDirty records that the document's on-disk state matches memory, e.g.
 // right after a successful save.

--- a/model/doc/file_events.go
+++ b/model/doc/file_events.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import "oblikovati.org/event"
+
+// The file-access event set (M04-F05, Oblikovati#613) on the workspace bus:
+// reference resolution and dirty transitions. TypeIDs continue the document
+// block; never renumber.
+const (
+	tidFileResolution event.TypeID = 0x0406
+	tidFileDirty      event.TypeID = 0x0407
+)
+
+// FileResolution fires (Before) when a full document name fails to load — the
+// hook that lets a subscriber supply a substitute path for a moved or renamed
+// reference. The first handler to call [FileResolution.Resolve] wins; the
+// workspace retries the load with the supplied name. After the open concludes
+// the event fires again (After) carrying the outcome, for passive observers.
+type FileResolution struct {
+	RequestedName string
+	// resolved is shared by every handler's copy of the event, so a handler's
+	// Resolve is visible to the emitting workspace (events travel by value).
+	resolved *string
+}
+
+// newFileResolution builds the event with its answer slot allocated.
+func newFileResolution(requestedName string) FileResolution {
+	return FileResolution{RequestedName: requestedName, resolved: new(string)}
+}
+
+// Resolve supplies the substitute full document name to load instead. The first
+// non-empty answer sticks; later calls are ignored.
+func (e FileResolution) Resolve(fullDocumentName string) {
+	if *e.resolved == "" {
+		*e.resolved = fullDocumentName
+	}
+}
+
+// Resolved returns the substitute a handler supplied, "" when unanswered.
+func (e FileResolution) Resolved() string { return *e.resolved }
+
+// EventID implements event.Event.
+func (FileResolution) EventID() event.TypeID { return tidFileResolution }
+
+// FileDirty fires (After only) on a document's clean→dirty transition — the
+// first unsaved change since open/save; further edits while already dirty do
+// not re-fire. Subscribers use it to track which open files need attention
+// (e.g. an autosave or session-recovery add-in).
+type FileDirty struct{ Document *Document }
+
+// EventID implements event.Event.
+func (FileDirty) EventID() event.TypeID { return tidFileDirty }

--- a/model/doc/file_events_test.go
+++ b/model/doc/file_events_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"testing"
+
+	"oblikovati.org/event"
+)
+
+// TestFileResolutionSuppliesSubstitutePath: a Before handler answering the
+// resolution hook redirects a failed open to the supplied name (the moved-file
+// case, M04-F05); the After phase reports the outcome to observers.
+func TestFileResolutionSuppliesSubstitutePath(t *testing.T) {
+	store := newFakeStore()
+	ws := NewWorkspace(store)
+	moved, _ := ws.Add(Part, "/new/home/bracket.obk", true)
+	if err := ws.Save(moved); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := ws.Close(moved, true); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	event.Subscribe(ws.Events(), event.Before, func(_ event.Context, e FileResolution) event.Outcome {
+		if e.RequestedName == "/old/home/bracket.obk" {
+			e.Resolve("/new/home/bracket.obk")
+		}
+		return event.Handle()
+	})
+	var observed []FileResolution
+	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e FileResolution) event.Outcome {
+		observed = append(observed, e)
+		return event.Continue()
+	})
+
+	d, err := ws.Open("/old/home/bracket.obk", true)
+	if err != nil {
+		t.Fatalf("Open with a resolving handler: %v", err)
+	}
+	if d.FullDocumentName() != "/new/home/bracket.obk" {
+		t.Errorf("opened %q, want the substitute /new/home/bracket.obk", d.FullDocumentName())
+	}
+	if len(observed) != 1 || observed[0].Resolved() != "/new/home/bracket.obk" {
+		t.Errorf("After observations = %+v, want one carrying the substitute", observed)
+	}
+}
+
+// TestFileResolutionUnansweredStillFails: with no handler (or no answer) the
+// open fails with the original error and the After event reports no substitute.
+func TestFileResolutionUnansweredStillFails(t *testing.T) {
+	ws := NewWorkspace(newFakeStore())
+	var observed []FileResolution
+	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e FileResolution) event.Outcome {
+		observed = append(observed, e)
+		return event.Continue()
+	})
+
+	if _, err := ws.Open("/nowhere/gone.obk", true); err == nil {
+		t.Fatal("an unresolved open must fail")
+	}
+	if len(observed) != 1 || observed[0].Resolved() != "" {
+		t.Errorf("After observations = %+v, want one with no substitute", observed)
+	}
+}
+
+// TestFileResolutionFirstAnswerSticks: a second handler cannot overwrite the
+// first handler's substitute.
+func TestFileResolutionFirstAnswerSticks(t *testing.T) {
+	e := newFileResolution("a.obk")
+	e.Resolve("first.obk")
+	e.Resolve("second.obk")
+	if e.Resolved() != "first.obk" {
+		t.Errorf("Resolved() = %q, want the first answer to stick", e.Resolved())
+	}
+}
+
+// TestFileDirtyFiresOnCleanToDirtyTransition: only the first MarkDirty after
+// open/save announces; re-marking an already dirty document is silent.
+func TestFileDirtyFiresOnCleanToDirtyTransition(t *testing.T) {
+	store := newFakeStore()
+	ws := NewWorkspace(store)
+	d, err := ws.Add(Part, "Part1", true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	var dirtied []FileDirty
+	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e FileDirty) event.Outcome {
+		dirtied = append(dirtied, e)
+		return event.Continue()
+	})
+
+	d.MarkDirty() // already dirty from Add: no transition, no event
+	if len(dirtied) != 0 {
+		t.Fatalf("marking an already-dirty document fired %d events, want 0", len(dirtied))
+	}
+	if err := ws.Save(d); err != nil { // save cleans
+		t.Fatalf("Save: %v", err)
+	}
+	d.MarkDirty()
+	d.MarkDirty()
+	if len(dirtied) != 1 || dirtied[0].Document != d {
+		t.Fatalf("dirty events = %d, want exactly 1 for the clean→dirty transition", len(dirtied))
+	}
+}

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -101,14 +101,34 @@ func (ws *Workspace) OpenWithOptions(fullDocumentName string, opts OpenOptions) 
 	if err := vetoed(ws.bus, "open", DocumentOpened{FullDocumentName: fullDocumentName}); err != nil {
 		return nil, err
 	}
-	d, err := ws.store.Load(fullDocumentName)
+	d, err := ws.loadResolving(fullDocumentName)
 	if err != nil {
-		return nil, fmt.Errorf("doc: open %q: %w", fullDocumentName, err)
+		return nil, err
 	}
 	d.visible = opts.Visible
 	ws.register(d)
 	event.Emit(ws.bus, event.After, DocumentOpened{FullDocumentName: fullDocumentName})
 	return d, nil
+}
+
+// loadResolving loads a document from the store, giving [FileResolution]
+// subscribers one chance to supply a substitute path when the name fails to
+// load (a moved or renamed reference, M04-F05). The After phase reports the
+// outcome to passive observers whether or not anything resolved it.
+func (ws *Workspace) loadResolving(fullDocumentName string) (*Document, error) {
+	d, err := ws.store.Load(fullDocumentName)
+	if err == nil {
+		return d, nil
+	}
+	resolution := newFileResolution(fullDocumentName)
+	event.Emit(ws.bus, event.Before, resolution)
+	defer event.Emit(ws.bus, event.After, resolution)
+	if substitute := resolution.Resolved(); substitute != "" {
+		if d, retryErr := ws.store.Load(substitute); retryErr == nil {
+			return d, nil
+		}
+	}
+	return nil, fmt.Errorf("doc: open %q: %w", fullDocumentName, err)
 }
 
 // openStub registers an unopened reference stub. The kind is unknown until the


### PR DESCRIPTION
Implements #613 on top of the contract PR Oblikovati/Oblikovati.API#64 (merged).

## What
**Transaction lifecycle events** (session bus, M04-F03 infrastructure):
- `TransactionCommitted` / `TransactionUndone` / `TransactionRedone` fire Before (vetoable) and After. A vetoed commit reverts the part to the pre-edit snapshot and reports `TransactionAborted`; a vetoed undo/redo leaves the cursor in place.
- New `Session.AbortTransaction` + wire `transaction.abort`: discards an open bounded transaction (the model reverts to the pre-Begin state). Previously an add-in had no way to bail out of a failed batch over the wire.
- Closing a document now drops its history entry and fires `TransactionDeleted` — this also fixes a leak where the histories map kept closed documents' streams forever.

**File-access events** (workspace bus):
- `FileResolution`: when a full document name fails to load, a Before handler may supply a substitute path and the workspace retries with it (the moved-reference case). After-phase reports the outcome.
- `FileDirty`: fires on the clean→dirty transition only.

**File-UI events** (session bus) + head wiring:
- `FileNew` (vetoable) wraps `NewPart`.
- `FileOpenDialog` / `FileSaveAsDialog` / `FileNewDialog`: a subscriber that supplies a path replaces the head's explorer — the File menu consults the hooks before presenting.
- `FileOpenFromMRU` (vetoable) guards the new **File ▸ Open Recent** menu, fed by a session-bounded MRU list.
- `PopulateFileMetadata` collects file properties around every save, queryable per document.

**Add-in bridge**: all new events relay to the add-in sink as their `api/wire` payloads (transaction moves tagged with the `TransactionPoint` they acted on). Before-phase answering stays in-proc until the event transport (#148).

## Why
Add-ins need transaction events to keep external state (caches, overlays, exports) consistent with undo/redo, and file events to participate in reference resolution and the new/open/save-as flows — the two platform event families M04 left unpicked.

## Tests
Per-layer: `app/transaction_events_test.go`, `app/file_ui_hooks_test.go`, `model/doc/file_events_test.go`, `addin/events/lifecycle_relay_test.go`, plus router coverage for `transaction.abort`. Full suite, vet, and golangci-lint v2.1.0 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)