### PR TITLE
M03: file identity & descriptors, attachments, save policy, interests, sub-types

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -185,7 +185,7 @@ func relayClientOperation(sink Sink, d *doc.Document, operation string) {
 	}
 	relayJSON(sink, wire.ClientOperationEvent{
 		Type: wire.EventClientOperation, Document: uint64(d.ID()),
-		SubType: d.SubType(), Operation: operation,
+		SubType: string(d.SubType()), Operation: operation,
 	})
 }
 

--- a/addin/router/attachments.go
+++ b/addin/router/attachments.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/doc"
+)
+
+// External-file attachments over the wire (M03-F08, #609).
+
+// attachmentInfo marshals one attachment record into the wire DTO.
+func attachmentInfo(a *doc.FileAttachment) wire.AttachmentInfo {
+	info := wire.AttachmentInfo{
+		Name: a.Name(), Kind: a.Kind(), FullFileName: a.FullFileName(),
+		ResolvedFileName: a.ResolvedFileName(), Resource: a.ResourceID(),
+		Status: a.Status(), BrowserVisible: a.BrowserVisible(),
+	}
+	if t := a.LastKnownFileTime(); !t.IsZero() {
+		info.LastKnownFileTime = t.UTC().Format(time.RFC3339Nano)
+	}
+	return info
+}
+
+// listAttachments returns a document's attachment records (wire
+// documents.listAttachments).
+func listAttachments(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListAttachmentsArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	all := d.Attachments().All()
+	out := make([]wire.AttachmentInfo, len(all))
+	for i, a := range all {
+		out[i] = attachmentInfo(a)
+	}
+	return json.Marshal(wire.ListAttachmentsResult{Attachments: out})
+}
+
+// addAttachment attaches an external file (wire documents.addAttachment).
+func addAttachment(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AddAttachmentArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := d.Attachments().Add(in.Name, in.Kind, in.FullFileName); err != nil {
+		return nil, err
+	}
+	return json.Marshal(attachmentInfo(d.Attachments().Record(in.Name)))
+}
+
+// removeAttachment deletes a named attachment record (wire
+// documents.removeAttachment).
+func removeAttachment(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.RemoveAttachmentArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	if !d.Attachments().Remove(in.Name) {
+		return nil, fmt.Errorf("router: document %d has no attachment named %q", in.Document, in.Name)
+	}
+	return ok()
+}

--- a/addin/router/attachments_test.go
+++ b/addin/router/attachments_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// fakeAddinFiles is a named ExternalFileProbe for the wire tests.
+type fakeAddinFiles struct {
+	files map[string][]byte
+	mod   time.Time
+}
+
+func (f *fakeAddinFiles) StatFile(name string) (time.Time, bool) {
+	_, ok := f.files[name]
+	return f.mod, ok
+}
+
+func (f *fakeAddinFiles) ReadFile(name string) ([]byte, error) {
+	b, ok := f.files[name]
+	if !ok {
+		return nil, fmt.Errorf("fake: no file %q", name)
+	}
+	return b, nil
+}
+
+// TestAttachmentsOverWire drives documents.addAttachment / listAttachments /
+// removeAttachment end to end (M03-F08, #609).
+func TestAttachmentsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	s.Workspace().SetExternalFileProbe(&fakeAddinFiles{
+		files: map[string][]byte{"/data/loads.csv": []byte("f1,f2\n")},
+		mod:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	})
+	id := uint64(s.ActiveDocument().ID())
+
+	var rec wire.AttachmentInfo
+	call(t, r, s, "documents.addAttachment",
+		fmt.Sprintf(`{"document":%d,"name":"loads","kind":3331,"fullFileName":"/data/loads.csv"}`, id), &rec)
+	if rec.Kind != types.AttachmentLinked || rec.Status != types.ReferenceUpToDate || rec.LastKnownFileTime == "" {
+		t.Fatalf("addAttachment = %+v, want a fresh linked record", rec)
+	}
+
+	var lst wire.ListAttachmentsResult
+	call(t, r, s, "documents.listAttachments", fmt.Sprintf(`{"document":%d}`, id), &lst)
+	if len(lst.Attachments) != 1 || lst.Attachments[0].Name != "loads" {
+		t.Fatalf("attachments = %+v, want [loads]", lst.Attachments)
+	}
+
+	if _, err := r.Handle(s, "documents.addAttachment",
+		[]byte(fmt.Sprintf(`{"document":%d,"name":"loads","kind":3329,"fullFileName":"/x"}`, id))); err == nil {
+		t.Error("a duplicate attachment name must fail over the wire")
+	}
+
+	call(t, r, s, "documents.removeAttachment", fmt.Sprintf(`{"document":%d,"name":"loads"}`, id), nil)
+	if _, err := r.Handle(s, "documents.removeAttachment",
+		[]byte(fmt.Sprintf(`{"document":%d,"name":"loads"}`, id))); err == nil {
+		t.Error("removing a missing attachment must fail")
+	}
+}

--- a/addin/router/documents.go
+++ b/addin/router/documents.go
@@ -18,7 +18,7 @@ import (
 func docInfo(d *doc.Document, active *doc.Document) wire.DocumentInfo {
 	return wire.DocumentInfo{
 		ID: uint64(d.ID()), Name: d.DisplayName(), Type: d.DocumentType().String(),
-		SubType: d.SubType(), Dirty: d.Dirty(), Visible: d.Visible(), Active: d == active,
+		SubType: string(d.SubType()), Dirty: d.Dirty(), Visible: d.Visible(), Active: d == active,
 	}
 }
 
@@ -55,7 +55,7 @@ func createDocument(s *app.Session, args json.RawMessage) (json.RawMessage, erro
 	}
 	// A requested flavor must be registered with a matching base type (M05-F15).
 	if in.SubType != "" {
-		if err := s.StampDocumentSubType(d, in.SubType); err != nil {
+		if err := s.StampDocumentSubType(d, doc.SubTypeID(in.SubType)); err != nil {
 			return nil, err
 		}
 	}
@@ -73,7 +73,7 @@ func registerDocumentSubType(s *app.Session, args json.RawMessage) (json.RawMess
 		return nil, err
 	}
 	if err := s.RegisterDocumentSubType(app.DocumentSubType{
-		ID: in.ID, BaseType: base, DisplayName: in.DisplayName,
+		ID: doc.SubTypeID(in.ID), BaseType: base, DisplayName: in.DisplayName,
 	}); err != nil {
 		return nil, err
 	}

--- a/addin/router/documents_subtype_test.go
+++ b/addin/router/documents_subtype_test.go
@@ -13,10 +13,15 @@ func TestDocumentSubTypesOverWire(t *testing.T) {
 	call(t, r, s, "documents.registerSubType",
 		`{"id":"com.x.sim.study","baseType":"part","displayName":"Simulation Study"}`, nil)
 
+	// The built-in sheet-metal flavor is seeded at session start (M03-F11),
+	// so the registry lists it ahead of the add-in's registration.
 	var lst wire.ListDocumentSubTypesResult
 	call(t, r, s, "documents.listSubTypes", "{}", &lst)
-	if len(lst.SubTypes) != 1 || lst.SubTypes[0].BaseType != "part" {
-		t.Fatalf("subtypes = %+v, want the part-based study", lst.SubTypes)
+	if len(lst.SubTypes) != 2 || lst.SubTypes[1].ID != "com.x.sim.study" || lst.SubTypes[1].BaseType != "part" {
+		t.Fatalf("subtypes = %+v, want the built-in sheet metal then the part-based study", lst.SubTypes)
+	}
+	if lst.SubTypes[0].ID != "org.oblikovati.part.sheetMetal" {
+		t.Fatalf("subtypes[0] = %+v, want the built-in sheet-metal flavor", lst.SubTypes[0])
 	}
 
 	var info wire.DocumentInfo
@@ -33,5 +38,17 @@ func TestDocumentSubTypesOverWire(t *testing.T) {
 	if _, err := r.Handle(s, "documents.registerSubType",
 		[]byte(`{"id":"bad","baseType":"spaceship"}`)); err == nil {
 		t.Error("an unknown base type should fail")
+	}
+	// Built-in ids are host-reserved: a client cannot claim the prefix, but
+	// creating a document with the seeded flavor works (M03-F11, #612).
+	if _, err := r.Handle(s, "documents.registerSubType",
+		[]byte(`{"id":"org.oblikovati.part.weldment","baseType":"part"}`)); err == nil {
+		t.Error("registering under the reserved org.oblikovati. prefix should fail")
+	}
+	var sheet wire.DocumentInfo
+	call(t, r, s, "documents.create",
+		`{"type":"part","name":"flange.obk","subType":"org.oblikovati.part.sheetMetal"}`, &sheet)
+	if sheet.SubType != "org.oblikovati.part.sheetMetal" {
+		t.Fatalf("created info = %+v, want the built-in sheet-metal flavor stamped", sheet)
 	}
 }

--- a/addin/router/files.go
+++ b/addin/router/files.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/doc"
+)
+
+// The file surface (M03-F07, #608): identity, the persisted file-to-file
+// reference records, and reference repair, served from the doc.File view.
+
+// fileInfo marshals a file view into the wire DTO.
+func fileInfo(f *doc.File) wire.FileInfo {
+	docs := f.Documents()
+	ids := make([]uint64, len(docs))
+	for i, d := range docs {
+		ids[i] = uint64(d.ID())
+	}
+	return wire.FileInfo{
+		FullFileName: f.FullFileName(), InternalName: f.InternalName(),
+		RevisionID: f.RevisionID(), DatabaseRevisionID: f.DatabaseRevisionID(),
+		SaveCounter: f.FileSaveCounter(), VersionCreated: f.VersionCreated(),
+		VersionSaved: f.VersionSaved(), Loaded: f.Loaded(), Referenced: f.Referenced(),
+		Documents: ids,
+	}
+}
+
+// fileReferenceInfo marshals one reference record into the file-side wire DTO.
+func fileReferenceInfo(r *doc.FileReference) wire.FileReferenceInfo {
+	return wire.FileReferenceInfo{
+		FullFileName: r.FullFileName(), RelativeFileName: r.RelativeFileName(),
+		LibraryName: r.LibraryName(), LocationType: r.LocationType(),
+		ResolvedFileName: r.ResolvedFileName(), ReferencedInternalName: r.ReferencedFileInternalName(),
+		SaveCounter: r.FileSaveCounter(), Status: r.Status(),
+		Missing: r.ReferenceMissing(), Replaced: r.ReferenceReplaced(),
+		LocationDifferent:     r.ReferenceLocationDifferent(),
+		InternalNameDifferent: r.ReferenceInternalNameDifferent(),
+	}
+}
+
+// documentByID resolves a wire document session id, shared by the document-
+// scoped M03 handlers (file references, attachments, interests, save).
+func documentByID(s *app.Session, id uint64) (*doc.Document, error) {
+	for _, d := range s.Workspace().Documents() {
+		if uint64(d.ID()) == id {
+			return d, nil
+		}
+	}
+	return nil, fmt.Errorf("router: no open document with id %d", id)
+}
+
+// openFile resolves the wire file name to the workspace's file view.
+func openFile(s *app.Session, fullFileName string) (*doc.File, error) {
+	f, ok := s.Workspace().FileByName(fullFileName)
+	if !ok {
+		return nil, fmt.Errorf("router: no open file named %q", fullFileName)
+	}
+	return f, nil
+}
+
+// getFile returns one open file's identity (wire files.get).
+func getFile(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.GetFileArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	f, err := openFile(s, in.FullFileName)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(fileInfo(f))
+}
+
+// listFileReferences returns a file's persisted reference records (wire
+// files.listReferences).
+func listFileReferences(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.GetFileArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	f, err := openFile(s, in.FullFileName)
+	if err != nil {
+		return nil, err
+	}
+	refs := f.References()
+	out := make([]wire.FileReferenceInfo, len(refs))
+	for i, r := range refs {
+		out[i] = fileReferenceInfo(r)
+	}
+	return json.Marshal(wire.ListFileReferencesResult{References: out})
+}
+
+// replaceFileReference re-points one reference record at a new target (wire
+// files.replaceReference) and returns the updated record.
+func replaceFileReference(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ReplaceFileReferenceArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	f, err := openFile(s, in.FullFileName)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range f.References() {
+		if r.FullFileName() != in.RequestedName {
+			continue
+		}
+		if err := r.ReplaceReference(in.NewFileName); err != nil {
+			return nil, err
+		}
+		return json.Marshal(fileReferenceInfo(r))
+	}
+	return nil, fmt.Errorf("router: file %q holds no reference named %q", in.FullFileName, in.RequestedName)
+}
+
+// listDocumentFileReferences returns the document-side reference views (wire
+// documents.listFileReferences).
+func listDocumentFileReferences(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListDocumentFileReferencesArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	refs := d.FileReferences()
+	out := make([]wire.DocumentFileReferenceInfo, len(refs))
+	for i, r := range refs {
+		out[i] = wire.DocumentFileReferenceInfo{
+			DisplayName: r.DisplayName(), FullFileName: r.FullFileName(),
+			Status: r.Status(), DocumentFound: r.DocumentFound(),
+			DifferentDocument: r.DifferentDocument(),
+		}
+	}
+	return json.Marshal(wire.ListDocumentFileReferencesResult{References: out})
+}

--- a/addin/router/files_test.go
+++ b/addin/router/files_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/model/doc"
+)
+
+// TestFileSurfaceOverWire covers files.get / files.listReferences against the
+// seeded session (M03-F07, #608).
+func TestFileSurfaceOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	d := s.ActiveDocument()
+
+	var info wire.FileInfo
+	call(t, r, s, "files.get", `{"fullFileName":"test.obk"}`, &info)
+	if info.InternalName == "" || !info.Loaded || len(info.Documents) != 1 {
+		t.Fatalf("files.get = %+v, want the loaded file's identity", info)
+	}
+	if info.Documents[0] != uint64(d.ID()) {
+		t.Errorf("contained documents = %v, want [%d]", info.Documents, d.ID())
+	}
+	if info.SaveCounter != 0 || info.RevisionID != "" {
+		t.Errorf("never-saved file reports %+v, want no revision stamps", info)
+	}
+
+	var refs wire.ListFileReferencesResult
+	call(t, r, s, "files.listReferences", `{"fullFileName":"test.obk"}`, &refs)
+	if len(refs.References) != 0 {
+		t.Errorf("references = %+v, want none on the standalone part", refs.References)
+	}
+
+	if _, err := r.Handle(s, "files.get", []byte(`{"fullFileName":"ghost.obk"}`)); err == nil {
+		t.Error("files.get must fail for a file that is not open")
+	}
+}
+
+// TestDocumentFileReferenceViewCarriesStatus: persisted records surface over
+// documents.listFileReferences with the derived status; an unresolvable record
+// reports missing (the broken-reference inspection path, M03-F07).
+func TestDocumentFileReferenceViewCarriesStatus(t *testing.T) {
+	r, s := seededSession(t)
+	d := s.ActiveDocument()
+	d.SetFileReferenceRecords([]doc.FileReferenceRecord{{
+		FullFileName: "/asm/parts/gone-pin.obk", RelativeFileName: "parts/gone-pin.obk",
+		LocationType: "ownerDirectory", SaveCounter: 3,
+	}})
+
+	var docRefs wire.ListDocumentFileReferencesResult
+	call(t, r, s, "documents.listFileReferences",
+		fmt.Sprintf(`{"document":%d}`, d.ID()), &docRefs)
+	if len(docRefs.References) != 1 {
+		t.Fatalf("references = %+v, want the seeded record", docRefs.References)
+	}
+	got := docRefs.References[0]
+	if got.Status != types.ReferenceMissing || got.DocumentFound {
+		t.Errorf("view = %+v, want a missing reference (no store can resolve it)", got)
+	}
+	if got.DisplayName != "gone-pin" {
+		t.Errorf("display name = %q, want gone-pin", got.DisplayName)
+	}
+
+	if _, err := r.Handle(s, "files.replaceReference",
+		[]byte(`{"fullFileName":"test.obk","requestedName":"/asm/parts/gone-pin.obk","newFileName":"/nope.obk"}`)); err == nil {
+		t.Error("repairing toward a nonexistent target must fail")
+	}
+}

--- a/addin/router/interests.go
+++ b/addin/router/interests.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// The add-in data registry over the wire (M03-F10, #611).
+
+// listDocumentInterests returns a document's interest records (wire
+// documents.listInterests).
+func listDocumentInterests(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListDocumentInterestsArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ListDocumentInterestsResult{Interests: d.InterestRecords()})
+}
+
+// addDocumentInterest registers (or updates) an interest record (wire
+// documents.addInterest).
+func addDocumentInterest(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.AddDocumentInterestArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	if err := d.Interests().Add(in.Interest); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// removeDocumentInterest deletes the (clientId, name) record (wire
+// documents.removeInterest).
+func removeDocumentInterest(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.RemoveDocumentInterestArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	if !d.Interests().Remove(in.ClientID, in.Name) {
+		return nil, fmt.Errorf("router: document %d has no interest (%q, %q)", in.Document, in.ClientID, in.Name)
+	}
+	return ok()
+}
+
+// hasDocumentInterest answers the discovery probe (wire documents.hasInterest).
+func hasDocumentInterest(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.HasDocumentInterestArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.HasDocumentInterestResult{HasInterest: d.Interests().HasInterest(in.Client)})
+}

--- a/addin/router/interests_test.go
+++ b/addin/router/interests_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestInterestRegistryOverWire drives documents.addInterest / listInterests /
+// hasInterest / removeInterest end to end (M03-F10, #611).
+func TestInterestRegistryOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	id := uint64(s.ActiveDocument().ID())
+
+	call(t, r, s, "documents.addInterest", fmt.Sprintf(
+		`{"document":%d,"interest":{"clientId":"com.x.toolpaths","name":"toolpath-recipes","interestType":68866,"dataVersion":2}}`, id), nil)
+
+	var lst wire.ListDocumentInterestsResult
+	call(t, r, s, "documents.listInterests", fmt.Sprintf(`{"document":%d}`, id), &lst)
+	if len(lst.Interests) != 1 || lst.Interests[0].InterestType != types.Interested || lst.Interests[0].DataVersion != 2 {
+		t.Fatalf("interests = %+v, want the migrating toolpath record", lst.Interests)
+	}
+
+	var has wire.HasDocumentInterestResult
+	call(t, r, s, "documents.hasInterest", fmt.Sprintf(`{"document":%d,"client":"toolpath-recipes"}`, id), &has)
+	if !has.HasInterest {
+		t.Error("hasInterest by name must report true")
+	}
+
+	if _, err := r.Handle(s, "documents.addInterest",
+		[]byte(fmt.Sprintf(`{"document":%d,"interest":{"clientId":"","name":"x"}}`, id))); err == nil {
+		t.Error("an interest without a client id must fail over the wire")
+	}
+
+	call(t, r, s, "documents.removeInterest",
+		fmt.Sprintf(`{"document":%d,"clientId":"com.x.toolpaths","name":"toolpath-recipes"}`, id), nil)
+	if _, err := r.Handle(s, "documents.removeInterest",
+		[]byte(fmt.Sprintf(`{"document":%d,"clientId":"com.x.toolpaths","name":"toolpath-recipes"}`, id))); err == nil {
+		t.Error("removing a missing interest must fail")
+	}
+}

--- a/addin/router/options.go
+++ b/addin/router/options.go
@@ -21,6 +21,7 @@ func (r *Router) registerOptionHandlers() {
 // optionGroupNames is the stable group order of options.listGroups.
 var optionGroupNames = []string{
 	wire.OptionGroupGeneral, wire.OptionGroupDisplay, wire.OptionGroupSketch, wire.OptionGroupPart,
+	wire.OptionGroupSave,
 }
 
 // listOptionGroups returns the available group names (wire options.listGroups).
@@ -49,16 +50,7 @@ func optionGroupView(s *app.Session, group string) (wire.OptionGroupView, error)
 	case wire.OptionGroupGeneral:
 		view.General = &wire.GeneralOptionsView{StartupAction: s.Options().General.StartupAction}
 	case wire.OptionGroupDisplay:
-		p := s.ViewCubePrefs()
-		view.Display = &wire.DisplayOptionsView{
-			ColorScheme:         s.Themes().ActiveName(),
-			ViewCubeHidden:      p.CubeHidden,
-			CompassHidden:       p.CompassHidden,
-			LockToSelection:     p.LockToSelection,
-			CubeInactiveOpacity: p.InactiveOpacity,
-			CubeSizePx:          p.CubeSizePx,
-			CubeCorner:          p.CubeCorner,
-		}
+		view.Display = displayOptionsView(s)
 	case wire.OptionGroupSketch:
 		o := s.Options().Sketch
 		view.Sketch = &wire.SketchOptionsView{
@@ -67,10 +59,29 @@ func optionGroupView(s *app.Session, group string) (wire.OptionGroupView, error)
 		}
 	case wire.OptionGroupPart:
 		view.Part = &wire.PartOptionsView{ChamferFlatCorners: s.Options().Part.ChamferFlatCorners}
+	case wire.OptionGroupSave:
+		o := s.Options().Save
+		view.Save = &wire.SaveOptionsView{
+			Thumbnail: o.Thumbnail, SaveDependents: o.SaveDependents, OldVersionsToKeep: o.OldVersionsToKeep,
+		}
 	default:
-		return view, fmt.Errorf("unknown option group %q (one of general/display/sketch/part)", group)
+		return view, fmt.Errorf("unknown option group %q (one of general/display/sketch/part/save)", group)
 	}
 	return view, nil
+}
+
+// displayOptionsView assembles the display group from its proxied stores.
+func displayOptionsView(s *app.Session) *wire.DisplayOptionsView {
+	p := s.ViewCubePrefs()
+	return &wire.DisplayOptionsView{
+		ColorScheme:         s.Themes().ActiveName(),
+		ViewCubeHidden:      p.CubeHidden,
+		CompassHidden:       p.CompassHidden,
+		LockToSelection:     p.LockToSelection,
+		CubeInactiveOpacity: p.InactiveOpacity,
+		CubeSizePx:          p.CubeSizePx,
+		CubeCorner:          p.CubeCorner,
+	}
 }
 
 // setOptionGroup writes one group (wire options.setGroup): the request names the
@@ -101,6 +112,12 @@ func applyOptionGroup(s *app.Session, req wire.OptionGroupView) error {
 		})
 	case req.Group == wire.OptionGroupPart && req.Part != nil:
 		return s.SetPartOptions(options.Part{ChamferFlatCorners: req.Part.ChamferFlatCorners})
+	case req.Group == wire.OptionGroupSave && req.Save != nil:
+		return s.SetSaveOptions(options.Save{
+			Thumbnail:         req.Save.Thumbnail,
+			SaveDependents:    req.Save.SaveDependents,
+			OldVersionsToKeep: req.Save.OldVersionsToKeep,
+		})
 	default:
 		return fmt.Errorf("option group %q carries no matching payload (set exactly the named group's field)", req.Group)
 	}

--- a/addin/router/options_test.go
+++ b/addin/router/options_test.go
@@ -13,8 +13,8 @@ func TestOptionsListGroups(t *testing.T) {
 	r, s := seededSession(t)
 	var res wire.ListOptionGroupsResult
 	call(t, r, s, "options.listGroups", "{}", &res)
-	if len(res.Groups) != 4 || res.Groups[0] != "general" || res.Groups[3] != "part" {
-		t.Fatalf("groups = %v, want general/display/sketch/part", res.Groups)
+	if len(res.Groups) != 5 || res.Groups[0] != "general" || res.Groups[4] != "save" {
+		t.Fatalf("groups = %v, want general/display/sketch/part/save", res.Groups)
 	}
 }
 

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -74,6 +74,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodDocumentsCloseAll] = closeAllDocuments
 	r.handlers[wire.MethodDocumentsRegisterSubType] = registerDocumentSubType
 	r.handlers[wire.MethodDocumentsListSubTypes] = listDocumentSubTypes
+	r.registerFileHandlers()
 	r.handlers[wire.MethodParametersList] = listParameters
 	r.handlers[wire.MethodParametersGet] = getParameter
 	r.handlers[wire.MethodParametersAdd] = addParameter
@@ -107,6 +108,15 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewsRename] = renameView
 	r.handlers[wire.MethodViewsGetLayout] = getLayout
 	r.handlers[wire.MethodViewsSetLayout] = setLayout
+}
+
+// registerFileHandlers wires the file surface (M03-F07, #608): identity, the
+// persisted file-to-file reference records, and reference repair.
+func (r *Router) registerFileHandlers() {
+	r.handlers[wire.MethodFilesGet] = getFile
+	r.handlers[wire.MethodFilesListReferences] = listFileReferences
+	r.handlers[wire.MethodFilesReplaceReference] = replaceFileReference
+	r.handlers[wire.MethodDocumentsListFileReferences] = listDocumentFileReferences
 }
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query
@@ -397,6 +407,12 @@ var mutatingMethods = map[string]bool{
 	wire.MethodTransactionRedo:                  true,
 	wire.MethodTransactionEnd:                   true,
 	wire.MethodTransactionAbort:                 true,
+	wire.MethodFilesReplaceReference:            true,
+	wire.MethodDocumentsAddAttachment:           true,
+	wire.MethodDocumentsRemoveAttachment:        true,
+	wire.MethodDocumentsAddInterest:             true,
+	wire.MethodDocumentsRemoveInterest:          true,
+	wire.MethodDocumentsOpen:                    true,
 }
 
 // record appends an operation entry to the trace, except for logs.tail itself (so polling the

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -124,6 +124,11 @@ func (r *Router) registerFileHandlers() {
 	r.handlers[wire.MethodDocumentsAddInterest] = addDocumentInterest
 	r.handlers[wire.MethodDocumentsRemoveInterest] = removeDocumentInterest
 	r.handlers[wire.MethodDocumentsHasInterest] = hasDocumentInterest
+	r.handlers[wire.MethodDocumentsOpen] = openDocument
+	r.handlers[wire.MethodDocumentsSave] = saveDocument
+	r.handlers[wire.MethodDocumentsSaveAs] = saveDocumentAs
+	r.handlers[wire.MethodDocumentsSaveCopyAs] = saveDocumentCopyAs
+	r.handlers[wire.MethodDocumentsBatchSave] = batchSave
 }
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -117,6 +117,9 @@ func (r *Router) registerFileHandlers() {
 	r.handlers[wire.MethodFilesListReferences] = listFileReferences
 	r.handlers[wire.MethodFilesReplaceReference] = replaceFileReference
 	r.handlers[wire.MethodDocumentsListFileReferences] = listDocumentFileReferences
+	r.handlers[wire.MethodDocumentsListAttachments] = listAttachments
+	r.handlers[wire.MethodDocumentsAddAttachment] = addAttachment
+	r.handlers[wire.MethodDocumentsRemoveAttachment] = removeAttachment
 }
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -120,6 +120,10 @@ func (r *Router) registerFileHandlers() {
 	r.handlers[wire.MethodDocumentsListAttachments] = listAttachments
 	r.handlers[wire.MethodDocumentsAddAttachment] = addAttachment
 	r.handlers[wire.MethodDocumentsRemoveAttachment] = removeAttachment
+	r.handlers[wire.MethodDocumentsListInterests] = listDocumentInterests
+	r.handlers[wire.MethodDocumentsAddInterest] = addDocumentInterest
+	r.handlers[wire.MethodDocumentsRemoveInterest] = removeDocumentInterest
+	r.handlers[wire.MethodDocumentsHasInterest] = hasDocumentInterest
 }
 
 // registerTransactionHandlers wires the undo/redo control methods — navigate and query

--- a/addin/router/save.go
+++ b/addin/router/save.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/contract"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/doc"
+)
+
+// The document open/save lifecycle over the wire (#138) and the save policy
+// layer around it: SaveCopyAs and batch save (M03-F09, #610).
+
+// openDocument loads (or returns) the document at a full document name (wire
+// documents.open). DeferContent registers a reference stub without paging
+// content in.
+func openDocument(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.OpenDocumentArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if in.FullDocumentName == "" {
+		return nil, fmt.Errorf("router: documents.open needs a fullDocumentName")
+	}
+	d, err := openDocumentWithOptions(s, in)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(docInfo(d, s.Workspace().ActiveDocument()))
+}
+
+// openDocumentWithOptions picks the session's full open flow (history, view
+// state, recents) for ordinary opens, the raw workspace path for stubs.
+func openDocumentWithOptions(s *app.Session, in wire.OpenDocumentArgs) (*doc.Document, error) {
+	if in.DeferContent {
+		return s.Workspace().OpenWithOptions(in.FullDocumentName,
+			doc.OpenOptions{Visible: in.Visible, DeferContent: true})
+	}
+	d, err := s.OpenDocument(in.FullDocumentName)
+	if err != nil {
+		return nil, err
+	}
+	d.SetVisible(in.Visible)
+	return d, nil
+}
+
+// saveDocument writes a document at its current binding (wire documents.save).
+func saveDocument(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.SaveDocumentArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.SaveDocument(d); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SaveDocumentResult{FullDocumentName: d.FullDocumentName()})
+}
+
+// saveDocumentAs writes a document under a new identity (wire documents.saveAs).
+func saveDocumentAs(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.SaveDocumentAsArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.SaveDocumentAs(d, in.NewFullDocumentName); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SaveDocumentResult{FullDocumentName: d.FullDocumentName()})
+}
+
+// saveDocumentCopyAs writes a copy without retargeting (wire
+// documents.saveCopyAs).
+func saveDocumentCopyAs(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.SaveCopyAsArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, err
+	}
+	meta := doc.CopyMetadata{}
+	if in.Metadata != nil {
+		meta = doc.CopyMetadata{DisplayName: in.Metadata.DisplayName, SubType: doc.SubTypeID(in.Metadata.SubType)}
+	}
+	if err := s.SaveDocumentCopyAs(d, in.TargetFileName, meta); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SaveDocumentResult{FullDocumentName: in.TargetFileName})
+}
+
+// batchSave queues every item and executes one operation with per-file
+// outcomes (wire documents.batchSave).
+func batchSave(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.BatchSaveArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	queue := s.NewBatchSave()
+	for _, item := range in.Items {
+		d, err := documentByID(s, item.Document)
+		if err != nil {
+			return nil, err
+		}
+		if err := queue.AddFileToSave(d, item.TargetFileName); err != nil {
+			return nil, err
+		}
+	}
+	outcomes, err := executeBatch(queue, in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(batchResult(in.Items, outcomes))
+}
+
+// executeBatch dispatches the named operation.
+func executeBatch(queue *app.BatchSaveQueue, operation string) ([]contract.BatchSaveOutcome, error) {
+	switch operation {
+	case "save":
+		return queue.ExecuteSave(), nil
+	case "saveAs":
+		return queue.ExecuteSaveAs(), nil
+	case "saveCopyAs":
+		return queue.ExecuteSaveCopyAs(), nil
+	default:
+		return nil, fmt.Errorf("router: batch operation %q (want save|saveAs|saveCopyAs)", operation)
+	}
+}
+
+// batchResult maps the per-file outcomes onto the wire shape.
+func batchResult(items []wire.BatchSaveItem, outcomes []contract.BatchSaveOutcome) wire.BatchSaveResult {
+	out := wire.BatchSaveResult{Results: make([]wire.BatchSaveItemResult, len(outcomes))}
+	for i, o := range outcomes {
+		res := wire.BatchSaveItemResult{Document: items[i].Document, FullDocumentName: o.FullDocumentName, OK: o.Err == nil}
+		if o.Err != nil {
+			res.Error = o.Err.Error()
+		} else {
+			out.Saved++
+		}
+		out.Results[i] = res
+	}
+	return out
+}

--- a/addin/router/save_test.go
+++ b/addin/router/save_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// storedSession is a router session whose workspace persists real .obk files
+// under a temp dir — the open/save lifecycle needs a live store.
+func storedSession(t *testing.T) (*Router, *app.Session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	s := app.NewSessionWithStore(persistence.NewPackageStore())
+	d, err := s.Workspace().Add(doc.Part, filepath.Join(dir, "bracket.obk"), true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	d.SetContent(compdef.NewPartComponentDefinition())
+	return New(opregistry.Default()), s, dir
+}
+
+// TestSaveLifecycleOverWire drives documents.save / saveAs / open end to end
+// against real packages (#138, M03-F09).
+func TestSaveLifecycleOverWire(t *testing.T) {
+	r, s, dir := storedSession(t)
+	id := uint64(s.ActiveDocument().ID())
+
+	var saved wire.SaveDocumentResult
+	call(t, r, s, "documents.save", fmt.Sprintf(`{"document":%d}`, id), &saved)
+	if saved.FullDocumentName != filepath.Join(dir, "bracket.obk") {
+		t.Fatalf("save = %+v, want the document's path", saved)
+	}
+
+	moved := filepath.Join(dir, "bracket-v2.obk")
+	call(t, r, s, "documents.saveAs",
+		fmt.Sprintf(`{"document":%d,"newFullDocumentName":%q}`, id, moved), &saved)
+	if saved.FullDocumentName != moved || s.ActiveDocument().FullFileName() != moved {
+		t.Fatalf("saveAs = %+v, want the document retargeted to %s", saved, moved)
+	}
+
+	// Close, then reopen over the wire.
+	call(t, r, s, "documents.closeAll", `{"force":true}`, nil)
+	var info wire.DocumentInfo
+	call(t, r, s, "documents.open",
+		fmt.Sprintf(`{"fullDocumentName":%q,"visible":true}`, moved), &info)
+	if info.Name != "bracket-v2" || !info.Active {
+		t.Fatalf("open = %+v, want the reopened active document", info)
+	}
+}
+
+// TestSaveCopyAsAndBatchOverWire: a copy lands at the target without
+// retargeting; the batch reports per-file outcomes (M03-F09).
+func TestSaveCopyAsAndBatchOverWire(t *testing.T) {
+	r, s, dir := storedSession(t)
+	id := uint64(s.ActiveDocument().ID())
+	source := s.ActiveDocument().FullFileName()
+
+	target := filepath.Join(dir, "export", "bracket-rev3.obk")
+	if _, err := r.Handle(s, "documents.saveCopyAs",
+		[]byte(fmt.Sprintf(`{"document":%d,"targetFileName":%q}`, id, target))); err == nil {
+		t.Fatal("copying into a nonexistent directory must surface the store error")
+	}
+
+	target = filepath.Join(dir, "bracket-rev3.obk")
+	var saved wire.SaveDocumentResult
+	call(t, r, s, "documents.saveCopyAs",
+		fmt.Sprintf(`{"document":%d,"targetFileName":%q,"metadata":{"displayName":"Bracket rev3"}}`, id, target), &saved)
+	if saved.FullDocumentName != target || s.ActiveDocument().FullFileName() != source {
+		t.Fatalf("saveCopyAs = %+v, want the copy at the target and the source untouched", saved)
+	}
+
+	var batch wire.BatchSaveResult
+	call(t, r, s, "documents.batchSave", fmt.Sprintf(
+		`{"operation":"saveCopyAs","items":[{"document":%d,"targetFileName":%q},{"document":%d,"targetFileName":%q}]}`,
+		id, filepath.Join(dir, "a.obk"), id, source), &batch)
+	if batch.Saved != 1 || len(batch.Results) != 2 {
+		t.Fatalf("batch = %+v, want one success and one carried failure", batch)
+	}
+	if batch.Results[1].OK || batch.Results[1].Error == "" {
+		t.Errorf("results[1] = %+v, want the copy-onto-source failure carried", batch.Results[1])
+	}
+
+	if _, err := r.Handle(s, "documents.batchSave",
+		[]byte(`{"operation":"archive","items":[]}`)); err == nil {
+		t.Error("an unknown batch operation must fail")
+	}
+}
+
+// TestSaveOptionGroupOverWire: the save group reads and writes through
+// options.getGroup/setGroup, rejecting unimplemented thumbnail modes.
+func TestSaveOptionGroupOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	var groups wire.ListOptionGroupsResult
+	call(t, r, s, "options.listGroups", "{}", &groups)
+	if len(groups.Groups) != 5 || groups.Groups[4] != "save" {
+		t.Fatalf("groups = %v, want save listed", groups.Groups)
+	}
+
+	call(t, r, s, "options.setGroup",
+		`{"group":"save","save":{"thumbnail":79875,"saveDependents":true,"oldVersionsToKeep":2}}`, nil)
+	var view wire.OptionGroupView
+	call(t, r, s, "options.getGroup", `{"group":"save"}`, &view)
+	if view.Save == nil || view.Save.Thumbnail != types.ThumbnailActiveWindowOnSave ||
+		!view.Save.SaveDependents || view.Save.OldVersionsToKeep != 2 {
+		t.Fatalf("save view = %+v, want the written policy back", view.Save)
+	}
+
+	if _, err := r.Handle(s, "options.setGroup",
+		[]byte(`{"group":"save","save":{"thumbnail":79877}}`)); err == nil {
+		t.Error("an unimplemented thumbnail mode must be rejected over the wire")
+	}
+}

--- a/app/batch_save.go
+++ b/app/batch_save.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/model/doc"
+)
+
+// BatchSaveQueue is the FileSaveAs-style batch service (M03-F09, #610): queue
+// (document → target) pairs, then execute ONE operation over all of them with
+// per-file outcomes — execution continues past individual failures so one bad
+// path does not abort an export of fifty files. A queue is single-use:
+// executing drains it.
+type BatchSaveQueue struct {
+	s     *Session
+	items []batchSaveItem
+}
+
+type batchSaveItem struct {
+	d      *doc.Document
+	target string
+}
+
+var _ contract.BatchSave = (*BatchSaveQueue)(nil)
+
+// NewBatchSave returns an empty batch-save queue.
+func (s *Session) NewBatchSave() *BatchSaveQueue { return &BatchSaveQueue{s: s} }
+
+// AddFileToSave queues a document with its target file name (ignored by
+// ExecuteSave). Duplicate targets are rejected — two writes to one path is
+// always a caller bug.
+func (q *BatchSaveQueue) AddFileToSave(document contract.Document, targetFileName string) error {
+	d, ok := document.(*doc.Document)
+	if !ok || d == nil {
+		return fmt.Errorf("app: batch save needs an open workspace document, got %T", document)
+	}
+	for _, item := range q.items {
+		if item.target != "" && item.target == targetFileName {
+			return fmt.Errorf("app: batch already saves to %q", targetFileName)
+		}
+	}
+	q.items = append(q.items, batchSaveItem{d: d, target: targetFileName})
+	return nil
+}
+
+// Count returns the number of queued pairs.
+func (q *BatchSaveQueue) Count() int { return len(q.items) }
+
+// ExecuteSave saves every queued document at its current binding.
+func (q *BatchSaveQueue) ExecuteSave() []contract.BatchSaveOutcome {
+	return q.execute(func(item batchSaveItem) (string, error) {
+		return item.d.FullFileName(), q.s.SaveDocument(item.d)
+	})
+}
+
+// ExecuteSaveAs saves every queued document under its target name,
+// retargeting each document's identity.
+func (q *BatchSaveQueue) ExecuteSaveAs() []contract.BatchSaveOutcome {
+	return q.execute(func(item batchSaveItem) (string, error) {
+		return item.target, q.s.SaveDocumentAs(item.d, item.target)
+	})
+}
+
+// ExecuteSaveCopyAs writes a copy of every queued document to its target
+// without retargeting the in-memory documents.
+func (q *BatchSaveQueue) ExecuteSaveCopyAs() []contract.BatchSaveOutcome {
+	return q.execute(func(item batchSaveItem) (string, error) {
+		return item.target, q.s.SaveDocumentCopyAs(item.d, item.target, doc.CopyMetadata{})
+	})
+}
+
+// execute drains the queue through one per-item operation.
+func (q *BatchSaveQueue) execute(op func(batchSaveItem) (string, error)) []contract.BatchSaveOutcome {
+	out := make([]contract.BatchSaveOutcome, len(q.items))
+	for i, item := range q.items {
+		name, err := op(item)
+		out[i] = contract.BatchSaveOutcome{FullDocumentName: name, Err: err}
+	}
+	q.items = nil
+	return out
+}

--- a/app/document_subtypes.go
+++ b/app/document_subtypes.go
@@ -5,6 +5,7 @@ package app
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/model/doc"
 )
@@ -16,22 +17,41 @@ import (
 
 // DocumentSubType is one registered flavor.
 type DocumentSubType struct {
-	ID          string
+	ID          doc.SubTypeID
 	BaseType    doc.DocumentType
 	DisplayName string
 }
 
 // RegisterDocumentSubType declares a flavor; re-registering the same id replaces
-// its declaration (an add-in updating its display name on reload).
+// its declaration (an add-in updating its display name on reload). Ids under the
+// reserved built-in prefix cannot be claimed by clients (M03-F11, #612).
 func (s *Session) RegisterDocumentSubType(st DocumentSubType) error {
 	if st.ID == "" {
 		return fmt.Errorf("app: document subtype needs an id")
 	}
+	if st.ID.BuiltIn() {
+		return fmt.Errorf("app: subtype id %q is under the reserved %q prefix", st.ID, types.ReservedSubTypePrefix)
+	}
+	s.recordDocumentSubType(st)
+	return nil
+}
+
+// recordDocumentSubType writes the registry entry; the built-in flavors use it
+// directly to bypass the reserved-prefix guard.
+func (s *Session) recordDocumentSubType(st DocumentSubType) {
 	if _, exists := s.documentSubTypes[st.ID]; !exists {
 		s.documentSubTypeOrder = append(s.documentSubTypeOrder, st.ID)
 	}
 	s.documentSubTypes[st.ID] = st
-	return nil
+}
+
+// registerBuiltInSubTypes seeds the host-reserved flavors at session start:
+// the sheet-metal part discriminator is persisted from the first .obk files so
+// it never needs retrofitting; its environment lands with M20 (M03-F11, #612).
+func (s *Session) registerBuiltInSubTypes() {
+	s.recordDocumentSubType(DocumentSubType{
+		ID: types.SubTypeSheetMetalPart, BaseType: doc.Part, DisplayName: "Sheet Metal Part",
+	})
 }
 
 // DocumentSubTypes returns the registered flavors in registration order.
@@ -45,7 +65,7 @@ func (s *Session) DocumentSubTypes() []DocumentSubType {
 
 // StampDocumentSubType marks a document with a REGISTERED flavor whose base type
 // matches — the documents.create path calls it for a requested subType.
-func (s *Session) StampDocumentSubType(d *doc.Document, subType string) error {
+func (s *Session) StampDocumentSubType(d *doc.Document, subType doc.SubTypeID) error {
 	st, ok := s.documentSubTypes[subType]
 	if !ok {
 		return fmt.Errorf("app: document subtype %q is not registered", subType)
@@ -63,7 +83,7 @@ func (s *Session) SubTypeInfos() []wire.DocumentSubTypeInfo {
 	out := make([]wire.DocumentSubTypeInfo, len(flavors))
 	for i, st := range flavors {
 		out[i] = wire.DocumentSubTypeInfo{
-			ID: st.ID, BaseType: docTypeName(st.BaseType), DisplayName: st.DisplayName,
+			ID: string(st.ID), BaseType: docTypeName(st.BaseType), DisplayName: st.DisplayName,
 		}
 	}
 	return out

--- a/app/document_subtypes_test.go
+++ b/app/document_subtypes_test.go
@@ -36,3 +36,19 @@ func TestRegisterDocumentSubTypeNeedsID(t *testing.T) {
 		t.Error("a subtype without an id must fail")
 	}
 }
+
+// TestBuiltInSubTypesSeededAndReserved pins the M03-F11 invariants: the
+// sheet-metal flavor exists from session start (so .obk files persist the
+// discriminator before M20 ships its environment), and clients cannot claim
+// ids under the reserved prefix.
+func TestBuiltInSubTypesSeededAndReserved(t *testing.T) {
+	s := NewSession()
+	flavors := s.DocumentSubTypes()
+	if len(flavors) == 0 || flavors[0].ID != "org.oblikovati.part.sheetMetal" {
+		t.Fatalf("flavors = %+v, want the built-in sheet-metal flavor seeded first", flavors)
+	}
+	err := s.RegisterDocumentSubType(DocumentSubType{ID: "org.oblikovati.part.weldment", BaseType: doc.Part})
+	if err == nil {
+		t.Error("registering under the reserved org.oblikovati. prefix must fail")
+	}
+}

--- a/app/file_ui_hooks_test.go
+++ b/app/file_ui_hooks_test.go
@@ -21,6 +21,11 @@ func (f *fakeDocStore) Save(d *doc.Document) error {
 	return nil
 }
 
+func (f *fakeDocStore) SaveCopy(d *doc.Document, target string, _ doc.CopyMetadata) error {
+	f.saved[target] = d.DocumentType()
+	return nil
+}
+
 func (f *fakeDocStore) Load(name string) (*doc.Document, error) {
 	t, ok := f.saved[name]
 	if !ok {

--- a/app/interest_watch.go
+++ b/app/interest_watch.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// The host behavior hook of the interest registry (M03-F10, #611): when a
+// document opens carrying interests from clients that are not present this
+// session, the user is warned — their add-in data is in the file but nothing
+// loaded can service it. A warning in the status bar, never fatal.
+
+// watchDocumentInterests subscribes the open-time absent-client check.
+func (s *Session) watchDocumentInterests() {
+	event.Subscribe(s.workspace.Events(), event.After, func(_ event.Context, e doc.DocumentOpened) event.Outcome {
+		if d, ok := s.workspace.ByName(e.FullDocumentName); ok {
+			if notice := s.absentInterestNotice(d); notice != "" {
+				s.notice = notice
+			}
+		}
+		return event.Continue()
+	})
+}
+
+// absentInterestNotice names the interested clients missing from this
+// session, "" when everyone is present.
+func (s *Session) absentInterestNotice(d *doc.Document) string {
+	var absent []string
+	for _, rec := range d.InterestRecords() {
+		if rec.InterestType != types.Interested {
+			continue
+		}
+		if !s.interestClientPresent(rec.ClientID) {
+			absent = append(absent, rec.ClientID)
+		}
+	}
+	if len(absent) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s has add-in data from unavailable client(s): %s",
+		d.DisplayName(), strings.Join(absent, ", "))
+}
+
+// interestClientPresent reports whether clientID matches a registered add-in
+// or a connected client application.
+func (s *Session) interestClientPresent(clientID string) bool {
+	for _, id := range s.addins.Registered() {
+		if id == clientID {
+			return true
+		}
+	}
+	for _, info := range s.clientApps.List() {
+		if info.Name == clientID {
+			return true
+		}
+	}
+	return false
+}

--- a/app/interest_watch_test.go
+++ b/app/interest_watch_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// TestOpenWarnsOnInterestsFromAbsentClients: a document carrying interests
+// from a client not present this session surfaces a status-bar warning on
+// open — never an error (M03-F10, #611).
+func TestOpenWarnsOnInterestsFromAbsentClients(t *testing.T) {
+	s := NewSession()
+	d, err := s.Workspace().Add(doc.Part, "augmented.obk", true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := d.Interests().Add(types.DocumentInterestRecord{
+		ClientID: "com.x.toolpaths", Name: "toolpath-recipes", InterestType: types.Interested,
+	}); err != nil {
+		t.Fatalf("Add interest: %v", err)
+	}
+
+	// The open hook fires on the workspace event; emit it as ws.Open would.
+	event.Emit(s.Workspace().Events(), event.After, doc.DocumentOpened{FullDocumentName: "augmented.obk"})
+	if !strings.Contains(s.Notice(), "com.x.toolpaths") {
+		t.Fatalf("notice = %q, want the absent client named", s.Notice())
+	}
+
+	// With the client present (registered as a client app) there is no warning.
+	if _, err := s.ClientApps().Register("com.x.toolpaths"); err != nil {
+		t.Fatalf("Register client app: %v", err)
+	}
+	s.SetNotice("")
+	event.Emit(s.Workspace().Events(), event.After, doc.DocumentOpened{FullDocumentName: "augmented.obk"})
+	if s.Notice() != "" {
+		t.Errorf("notice = %q, want none when the client is present", s.Notice())
+	}
+}

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -38,6 +38,15 @@ type Part struct {
 	ChamferFlatCorners bool `yaml:"chamferFlatCorners"`
 }
 
+// Save is the save policy (M03-F09, #610): thumbnail capture on save (read by
+// the head's save path), dependent saving (read by the session's save flow),
+// and old-version retention (read by the package store).
+type Save struct {
+	Thumbnail         types.ThumbnailSaveOption `yaml:"thumbnail,omitempty"`
+	SaveDependents    bool                      `yaml:"saveDependents,omitempty"`
+	OldVersionsToKeep int                       `yaml:"oldVersionsToKeep,omitempty"`
+}
+
 // All is every persisted option group. The ViewCube/display preferences live in
 // their own store (persistence/userprefs) and the color scheme in the theme store —
 // the options surface proxies those rather than duplicating their persistence.
@@ -45,6 +54,7 @@ type All struct {
 	General General `yaml:"general"`
 	Sketch  Sketch  `yaml:"sketch"`
 	Part    Part    `yaml:"part"`
+	Save    Save    `yaml:"save"`
 }
 
 // Defaults returns the out-of-the-box options, mirroring the session's historical
@@ -55,6 +65,7 @@ func Defaults() All {
 		General: General{StartupAction: types.StartupNewPart},
 		Sketch:  Sketch{GridSpacingCm: 1, GridVisible: true, GridMajorEvery: 5, SnapToPoints: true, SnapToGrid: true},
 		Part:    Part{ChamferFlatCorners: true},
+		Save:    Save{Thumbnail: types.ThumbnailNone},
 	}
 }
 

--- a/app/save_ops.go
+++ b/app/save_ops.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati.org/model/doc"
+)
+
+// Document-scoped save operations (M03-F09, #610): the generalized save flow
+// behind File ▸ Save, the documents.save/saveAs/saveCopyAs wire methods and
+// batch save. The active-document wrappers in session.go delegate here.
+
+// SaveDocument writes any open document back to its path, honoring the save
+// policy: with SaveDependents on, its dirty referenced documents save first.
+func (s *Session) SaveDocument(d *doc.Document) error {
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	if !strings.HasSuffix(d.FullFileName(), doc.PackageExtension) {
+		return ErrNeedsPath
+	}
+	if s.appOptions.Save.SaveDependents {
+		if err := s.saveDirtyDependents(d); err != nil {
+			return err
+		}
+	}
+	s.collectFileMetadata(d) // the PopulateFileMetadata hook gathers file properties around the save
+	if err := s.workspace.Save(d); err != nil {
+		return err
+	}
+	s.saveViewState(d) // persist this user's camera/view layout alongside (not inside) the document
+	return nil
+}
+
+// saveDirtyDependents saves d's dirty referenced documents before d itself, so
+// one Save leaves the whole tree consistent (the SaveDependents policy).
+func (s *Session) saveDirtyDependents(d *doc.Document) error {
+	for _, dep := range d.AllReferencedDocuments() {
+		if !dep.Dirty() || !strings.HasSuffix(dep.FullFileName(), doc.PackageExtension) {
+			continue
+		}
+		if err := s.workspace.Save(dep); err != nil {
+			return fmt.Errorf("app: save dependent %q: %w", dep.FullFileName(), err)
+		}
+	}
+	return nil
+}
+
+// SaveDocumentAs writes any open document under a new full document name,
+// which becomes its identity.
+func (s *Session) SaveDocumentAs(d *doc.Document, path string) error {
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	s.collectFileMetadata(d)
+	if err := s.workspace.SaveAs(d, path); err != nil {
+		return err
+	}
+	s.saveViewState(d)
+	s.rememberRecentDocument(path)
+	return nil
+}
+
+// SaveDocumentCopyAs writes a copy of any open document to targetFileName
+// without retargeting it — the document keeps its binding and dirty state.
+func (s *Session) SaveDocumentCopyAs(d *doc.Document, targetFileName string, meta doc.CopyMetadata) error {
+	if d == nil {
+		return ErrNoActiveDoc
+	}
+	return s.workspace.SaveCopy(d, targetFileName, meta)
+}

--- a/app/save_ops_test.go
+++ b/app/save_ops_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app/options"
+	"oblikovati.org/model/doc"
+)
+
+// savedSession is a session over the in-memory fakeDocStore with one saved
+// part at parts/pin.obk referenced by an assembly at frame.obk.
+func savedSession(t *testing.T) (*Session, *fakeDocStore, *doc.Document, *doc.Document) {
+	t.Helper()
+	store := newFakeDocStore()
+	s := NewSessionWithStore(store)
+	part, err := s.Workspace().Add(doc.Part, "parts/pin.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	if err := s.Workspace().Save(part); err != nil {
+		t.Fatalf("Save part: %v", err)
+	}
+	owner, err := s.Workspace().Add(doc.Assembly, "frame.obk", true)
+	if err != nil {
+		t.Fatalf("Add owner: %v", err)
+	}
+	if _, err := owner.AddReference(part.FullDocumentName()); err != nil {
+		t.Fatalf("AddReference: %v", err)
+	}
+	return s, store, owner, part
+}
+
+// TestSaveDependentsPolicySavesDirtyReferences: with the policy on, saving the
+// owner first saves its dirty referenced documents (M03-F09).
+func TestSaveDependentsPolicySavesDirtyReferences(t *testing.T) {
+	s, _, owner, part := savedSession(t)
+	part.MarkDirty()
+
+	if err := s.SaveDocument(owner); err != nil {
+		t.Fatalf("SaveDocument without the policy: %v", err)
+	}
+	if !part.Dirty() {
+		t.Fatal("without the policy the dependent must stay dirty")
+	}
+
+	if err := s.SetSaveOptions(options.Save{Thumbnail: types.ThumbnailNone, SaveDependents: true}); err != nil {
+		t.Fatalf("SetSaveOptions: %v", err)
+	}
+	if err := s.SaveDocument(owner); err != nil {
+		t.Fatalf("SaveDocument with the policy: %v", err)
+	}
+	if part.Dirty() {
+		t.Error("the dirty dependent must be saved before the owner")
+	}
+}
+
+// TestSetSaveOptionsRejectsDeadSettings: unsupported thumbnail modes and
+// negative retention are rejected, never persisted (the no-dead-settings rule).
+func TestSetSaveOptionsRejectsDeadSettings(t *testing.T) {
+	s := NewSession()
+	if err := s.SetSaveOptions(options.Save{Thumbnail: types.ThumbnailIsoViewOnSave}); err == nil {
+		t.Error("an unimplemented thumbnail mode must be rejected")
+	}
+	if err := s.SetSaveOptions(options.Save{Thumbnail: types.ThumbnailNone, OldVersionsToKeep: -1}); err == nil {
+		t.Error("negative retention must be rejected")
+	}
+	if err := s.SetSaveOptions(options.Save{Thumbnail: types.ThumbnailActiveWindowOnSave, OldVersionsToKeep: 3}); err != nil {
+		t.Fatalf("a supported policy must be accepted: %v", err)
+	}
+	if got := s.Options().Save; got.Thumbnail != types.ThumbnailActiveWindowOnSave || got.OldVersionsToKeep != 3 {
+		t.Errorf("save options = %+v, want the accepted policy applied", got)
+	}
+}
+
+// TestSavePolicyControlContract: the contract.SaveOptions view reads and
+// writes the same group.
+func TestSavePolicyControlContract(t *testing.T) {
+	s := NewSession()
+	c := s.SavePolicy()
+	if c.Thumbnail() != types.ThumbnailNone || c.SaveDependents() || c.OldVersionsToKeep() != 0 {
+		t.Fatalf("defaults = (%v, %v, %d), want none/false/0", c.Thumbnail(), c.SaveDependents(), c.OldVersionsToKeep())
+	}
+	c.SetSaveDependents(true)
+	if !c.SaveDependents() {
+		t.Error("SetSaveDependents must apply to the running session")
+	}
+	if err := c.SetThumbnail(types.ThumbnailImportFromFile); err == nil {
+		t.Error("SetThumbnail must reject unimplemented modes")
+	}
+	if err := c.SetOldVersionsToKeep(5); err != nil || c.OldVersionsToKeep() != 5 {
+		t.Errorf("SetOldVersionsToKeep = (%v, %d), want 5 applied", err, c.OldVersionsToKeep())
+	}
+}
+
+// TestBatchSavePerFileOutcomes: one bad item does not abort the batch; the
+// queue drains on execute (M03-F09).
+func TestBatchSavePerFileOutcomes(t *testing.T) {
+	s, store, owner, part := savedSession(t)
+	q := s.NewBatchSave()
+	if err := q.AddFileToSave(part, "exports/pin-copy.obk"); err != nil {
+		t.Fatalf("AddFileToSave: %v", err)
+	}
+	if err := q.AddFileToSave(owner, "exports/pin-copy.obk"); err == nil {
+		t.Fatal("a duplicate target must be rejected at queue time")
+	}
+	if err := q.AddFileToSave(owner, "parts/pin.obk"); err != nil {
+		t.Fatalf("AddFileToSave owner: %v", err)
+	}
+	if q.Count() != 2 {
+		t.Fatalf("count = %d, want 2", q.Count())
+	}
+
+	// saveCopyAs: the part copies fine; the owner targets an OPEN file name,
+	// which the workspace rejects — the batch must carry that per-file error.
+	outcomes := q.ExecuteSaveCopyAs()
+	if len(outcomes) != 2 || q.Count() != 0 {
+		t.Fatalf("outcomes = %d (queued %d), want 2 outcomes and a drained queue", len(outcomes), q.Count())
+	}
+	if outcomes[0].Err != nil || !store.Exists("exports/pin-copy.obk") {
+		t.Errorf("outcome[0] = %+v, want the pin copied", outcomes[0])
+	}
+	if outcomes[1].Err == nil || !strings.Contains(outcomes[1].Err.Error(), "open in this workspace") {
+		t.Errorf("outcome[1] = %+v, want the open-target failure carried", outcomes[1])
+	}
+}

--- a/app/save_policy.go
+++ b/app/save_policy.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/app/options"
+)
+
+// The save policy half of M03-F09 (#610): the "save" option group bound to its
+// live readers — the head's thumbnail capture, the session's dependent-save
+// flow, and the package store's old-version retention. Setters reject what
+// this host cannot perform (no dead settings, the M05-F11 rule).
+
+// supportedThumbnailModes are the capture modes this host implements: none,
+// and capturing the active viewport when a save completes (the head's
+// framebuffer readback). The iso-view and import-from-file modes await a
+// headless render path.
+var supportedThumbnailModes = map[types.ThumbnailSaveOption]bool{
+	types.ThumbnailNone:               true,
+	types.ThumbnailActiveWindowOnSave: true,
+}
+
+// SetSaveOptions validates, applies and stores the save group.
+func (s *Session) SetSaveOptions(o options.Save) error {
+	if !supportedThumbnailModes[o.Thumbnail] {
+		return fmt.Errorf("app: thumbnail mode %q is not implemented by this host (none|activeWindowOnSave)", o.Thumbnail)
+	}
+	if o.OldVersionsToKeep < 0 {
+		return fmt.Errorf("app: oldVersionsToKeep %d is negative (0 disables retention)", o.OldVersionsToKeep)
+	}
+	s.appOptions.Save = o
+	s.applyOldVersionRetention(o.OldVersionsToKeep)
+	return s.saveOptions()
+}
+
+// oldVersionRetainer is what the package store implements; the session only
+// knows the doc.Store seam, so retention forwards through this assertion.
+type oldVersionRetainer interface {
+	SetOldVersionsToKeep(count int)
+}
+
+// applyOldVersionRetention forwards the retention count to a store that
+// supports it (a memory-only session has nothing to retain).
+func (s *Session) applyOldVersionRetention(count int) {
+	if r, ok := s.store.(oldVersionRetainer); ok {
+		r.SetOldVersionsToKeep(count)
+	}
+}
+
+// SavePolicyControl is the [contract.SaveOptions] view over the session's
+// save group.
+type SavePolicyControl struct{ s *Session }
+
+var _ contract.SaveOptions = SavePolicyControl{}
+
+// SavePolicy returns the in-process save-options control.
+func (s *Session) SavePolicy() SavePolicyControl { return SavePolicyControl{s: s} }
+
+// Thumbnail returns how a preview thumbnail is captured on save.
+func (c SavePolicyControl) Thumbnail() types.ThumbnailSaveOption {
+	return c.s.appOptions.Save.Thumbnail
+}
+
+// SetThumbnail selects the capture mode, erroring on unimplemented modes.
+func (c SavePolicyControl) SetThumbnail(option types.ThumbnailSaveOption) error {
+	o := c.s.appOptions.Save
+	o.Thumbnail = option
+	return c.s.SetSaveOptions(o)
+}
+
+// SaveDependents reports whether saving also saves dirty referenced documents.
+func (c SavePolicyControl) SaveDependents() bool { return c.s.appOptions.Save.SaveDependents }
+
+// SetSaveDependents toggles dependent saving. The toggle always applies to the
+// running session; persisting it is best-effort (a read-only config dir must
+// not break an in-memory policy change — the contract setter carries no error).
+func (c SavePolicyControl) SetSaveDependents(save bool) {
+	c.s.appOptions.Save.SaveDependents = save
+	_ = c.s.saveOptions()
+}
+
+// OldVersionsToKeep returns the save-time retention count, 0 when off.
+func (c SavePolicyControl) OldVersionsToKeep() int { return c.s.appOptions.Save.OldVersionsToKeep }
+
+// SetOldVersionsToKeep sets the retention count, erroring on negatives.
+func (c SavePolicyControl) SetOldVersionsToKeep(count int) error {
+	o := c.s.appOptions.Save
+	o.OldVersionsToKeep = count
+	return c.s.SetSaveOptions(o)
+}

--- a/app/session.go
+++ b/app/session.go
@@ -50,28 +50,28 @@ type Session struct {
 	hiddenBodyKeys       map[string]bool
 	graphics             *clientgraphics.Store // add-in client/interaction graphics (M05-F05)
 	addins               *AddInManager
-	clientApps           *ClientApplicationRegistry    // external automation drivers (M05-F01)
-	browserPanes         *AddInBrowserPanes            // add-in browser panes (M05-F03)
-	dockableWindows      *AddInDockableWindows         // add-in dockable windows (M05-F03)
-	appOptions           options.All                   // typed per-user option groups (M05-F11)
-	optionsStore         options.Store                 // persists appOptions (nil ⇒ in-session only)
-	statusText           string                        // wire-set status-bar message (M05-F09)
-	messageCenter        *MessageCenter                // sectioned errors/warnings tree (M05-F09)
-	messageCenterOpen    bool                          // the Messages panel is open
-	progress             *ProgressLedger               // live progress bars (M05-F09)
-	balloonTips          *BalloonTipCenter             // notification balloons (M05-F09)
-	prompts              *PromptCenter                 // declarative prompts (M05-F09)
-	dialogMemoryStore    dialogmemory.Store            // persists suppressions + remembered answers
-	miniToolbars         *MiniToolbarRack              // in-canvas mini-toolbars (M05-F07)
-	fileDialogQueue      []FileDialogRequest           // pending add-in file-dialog asks (M05-F08)
-	webViews             map[string]wire.WebDialogSpec // presented web views (M05-F08)
-	webViewOrder         []string                      // web views in creation order
-	urlOpener            URLOpener                     // platform URL opener (head-injected)
-	windowFrame          WindowFrameStatus             // mirrored host-window state (M05-F10)
-	triad                TriadGizmo                    // the move/rotate triad (M05-F13)
-	manipulators         *ManipulatorBoard             // add-in drag handles (M05-F13)
-	helpSources          map[string]string             // add-in help bases by source (M05-F14)
-	helpInterceptor      HelpInterceptor               // before-help veto hook (M05-F14)
+	clientApps           *ClientApplicationRegistry        // external automation drivers (M05-F01)
+	browserPanes         *AddInBrowserPanes                // add-in browser panes (M05-F03)
+	dockableWindows      *AddInDockableWindows             // add-in dockable windows (M05-F03)
+	appOptions           options.All                       // typed per-user option groups (M05-F11)
+	optionsStore         options.Store                     // persists appOptions (nil ⇒ in-session only)
+	statusText           string                            // wire-set status-bar message (M05-F09)
+	messageCenter        *MessageCenter                    // sectioned errors/warnings tree (M05-F09)
+	messageCenterOpen    bool                              // the Messages panel is open
+	progress             *ProgressLedger                   // live progress bars (M05-F09)
+	balloonTips          *BalloonTipCenter                 // notification balloons (M05-F09)
+	prompts              *PromptCenter                     // declarative prompts (M05-F09)
+	dialogMemoryStore    dialogmemory.Store                // persists suppressions + remembered answers
+	miniToolbars         *MiniToolbarRack                  // in-canvas mini-toolbars (M05-F07)
+	fileDialogQueue      []FileDialogRequest               // pending add-in file-dialog asks (M05-F08)
+	webViews             map[string]wire.WebDialogSpec     // presented web views (M05-F08)
+	webViewOrder         []string                          // web views in creation order
+	urlOpener            URLOpener                         // platform URL opener (head-injected)
+	windowFrame          WindowFrameStatus                 // mirrored host-window state (M05-F10)
+	triad                TriadGizmo                        // the move/rotate triad (M05-F13)
+	manipulators         *ManipulatorBoard                 // add-in drag handles (M05-F13)
+	helpSources          map[string]string                 // add-in help bases by source (M05-F14)
+	helpInterceptor      HelpInterceptor                   // before-help veto hook (M05-F14)
 	documentSubTypes     map[doc.SubTypeID]DocumentSubType // registered flavors (M05-F15)
 	documentSubTypeOrder []doc.SubTypeID
 	addinEnvironments    map[Environment]string                           // registered add-in environments (M05-F16)

--- a/app/session.go
+++ b/app/session.go
@@ -163,6 +163,7 @@ func newSession(store doc.Store) *Session {
 	s.lighting.Environment = renderer.DefaultEnvironment()
 	s.initShellSurfaces()
 	s.watchDocumentCloses()
+	s.watchDocumentInterests()
 	return s
 }
 

--- a/app/session.go
+++ b/app/session.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app/options"
@@ -31,6 +30,7 @@ import (
 // window involved, so "operating the UI" is fully unit-testable (ADR-0014/0004).
 type Session struct {
 	workspace            *doc.Workspace
+	store                doc.Store // the workspace's persistence backend; nil for in-memory sessions
 	commands             *CommandManager
 	histories            map[doc.ID]*docHistory // per-document transaction-event streams (undo/redo)
 	viewState            viewstate.Store        // per-user document view/camera persistence (nil ⇒ disabled)
@@ -131,6 +131,7 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 
 func newSession(store doc.Store) *Session {
 	s := &Session{
+		store:           store,
 		workspace:       doc.NewWorkspace(store),
 		commands:        NewCommandManager(),
 		histories:       map[doc.ID]*docHistory{},
@@ -354,33 +355,11 @@ func (s *Session) uniquePartName() string {
 // the [doc.PackageExtension] suffix, since new documents are minted with bare names
 // like "Part1" — and return [ErrNeedsPath] so the UI can prompt via Save As.
 func (s *Session) SaveActiveDocument() error {
-	d := s.workspace.ActiveDocument()
-	if d == nil {
-		return ErrNoActiveDoc
-	}
-	if !strings.HasSuffix(d.FullFileName(), doc.PackageExtension) {
-		return ErrNeedsPath
-	}
-	s.collectFileMetadata(d) // the PopulateFileMetadata hook gathers file properties around the save
-	if err := s.workspace.Save(d); err != nil {
-		return err
-	}
-	s.saveViewState(d) // persist this user's camera/view layout alongside (not inside) the document
-	return nil
+	return s.SaveDocument(s.workspace.ActiveDocument())
 }
 
 // SaveActiveDocumentAs writes the active document to path, which becomes its new
 // identity. It is the core of File ▸ Save As and the CLI save-as command.
 func (s *Session) SaveActiveDocumentAs(path string) error {
-	d := s.workspace.ActiveDocument()
-	if d == nil {
-		return ErrNoActiveDoc
-	}
-	s.collectFileMetadata(d) // the PopulateFileMetadata hook gathers file properties around the save
-	if err := s.workspace.SaveAs(d, path); err != nil {
-		return err
-	}
-	s.saveViewState(d)             // persist under the new path (camera/view layout stays out of the .obk)
-	s.rememberRecentDocument(path) // a save-as destination is recent file activity
-	return nil
+	return s.SaveDocumentAs(s.workspace.ActiveDocument(), path)
 }

--- a/app/session.go
+++ b/app/session.go
@@ -72,8 +72,8 @@ type Session struct {
 	manipulators         *ManipulatorBoard             // add-in drag handles (M05-F13)
 	helpSources          map[string]string             // add-in help bases by source (M05-F14)
 	helpInterceptor      HelpInterceptor               // before-help veto hook (M05-F14)
-	documentSubTypes     map[string]DocumentSubType    // registered flavors (M05-F15)
-	documentSubTypeOrder []string
+	documentSubTypes     map[doc.SubTypeID]DocumentSubType // registered flavors (M05-F15)
+	documentSubTypeOrder []doc.SubTypeID
 	addinEnvironments    map[Environment]string                           // registered add-in environments (M05-F16)
 	activeAddInEnv       Environment                                      // the entered add-in environment (base when none)
 	markingMenus         map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
@@ -177,7 +177,8 @@ func (s *Session) initShellSurfaces() {
 		WorkPlanes: true, WorkAxes: true, WorkPoints: true, Sketches: true,
 	}
 	s.helpSources = map[string]string{}
-	s.documentSubTypes = map[string]DocumentSubType{}
+	s.documentSubTypes = map[doc.SubTypeID]DocumentSubType{}
+	s.registerBuiltInSubTypes()
 	s.addinEnvironments = map[Environment]string{}
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -37,9 +37,10 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 		} else {
 			drawSingleViewport(win, s)
 		}
-		viewCubeContextMenu(s)    // the ViewCube right-click menu (opened from a tile/single path)
-		drawViewCubeOptions(s)    // the ViewCube Options window (toggled from that menu)
-		serviceScreenshot(win, s) // Tools ▸ Save Viewport PNG, after the viewport rendered
+		viewCubeContextMenu(s)       // the ViewCube right-click menu (opened from a tile/single path)
+		drawViewCubeOptions(s)       // the ViewCube Options window (toggled from that menu)
+		serviceScreenshot(win, s)    // Tools ▸ Save Viewport PNG, after the viewport rendered
+		serviceSaveThumbnail(win, s) // the save policy's sidecar capture (M03-F09)
 	}
 	native.End()
 }

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -249,6 +249,7 @@ func applyFileAction(s *app.Session, act fileAction) {
 			fileNotice(s, "Save failed: %v", err)
 		} else {
 			fileNotice(s, "Saved %s", name)
+			queueSaveThumbnail(s, act.Path)
 		}
 	case dialogLoadHDR:
 		s.LoadEnvironmentFile(act.Path) // the decode happens lazily on the next viewport frame
@@ -297,4 +298,7 @@ func saveActive(s *app.Session) {
 		return
 	}
 	fileNotice(s, "Saved")
+	if d := s.Workspace().ActiveDocument(); d != nil {
+		queueSaveThumbnail(s, d.FullFileName())
+	}
 }

--- a/head/ui/save_thumbnail.go
+++ b/head/ui/save_thumbnail.go
@@ -1,0 +1,46 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Save-time thumbnail capture (M03-F09, #610): with the save policy set to
+// activeWindowOnSave, a successful save arms a capture of the viewport into a
+// git-ignored sidecar image next to the document (<file>.obk.png — thumbnails
+// are never document content, ADR-0020). The capture is serviced AFTER the
+// viewport has rendered the frame, like the screenshot service, so the image
+// reflects what is on screen.
+
+// pendingThumbnailPath is the armed sidecar destination, "" when idle.
+var pendingThumbnailPath string
+
+// queueSaveThumbnail arms a capture for the document just saved at savedPath,
+// when the save policy asks for one.
+func queueSaveThumbnail(s *app.Session, savedPath string) {
+	if savedPath == "" {
+		return
+	}
+	if s.SavePolicy().Thumbnail() == types.ThumbnailActiveWindowOnSave {
+		pendingThumbnailPath = savedPath + ".png"
+	}
+}
+
+// serviceSaveThumbnail writes the armed sidecar after the viewport rendered.
+// Success is silent (a sidecar, not a user action); failure lands in the
+// status bar.
+func serviceSaveThumbnail(win *native.Window, s *app.Session) {
+	if pendingThumbnailPath == "" {
+		return
+	}
+	path := pendingThumbnailPath
+	pendingThumbnailPath = ""
+	if err := win.SaveViewportPNG(path); err != nil {
+		fileNotice(s, "Thumbnail capture failed: %v", err)
+	}
+}

--- a/model/doc/attachments.go
+++ b/model/doc/attachments.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+)
+
+// Linked external-file attachments (M03-F08, #609): a document's named
+// references to foreign (non-.obk) files — linked spreadsheets, sketch images,
+// design-data side files. Linked attachments track the path and its last-known
+// modification time for out-of-date detection; embedded attachments carry the
+// file's bytes inside the document. These are the persistence backbone for
+// spreadsheet-linked parameter tables (M15) and sketch images (M21).
+
+// ExternalFileProbe is the filesystem seam attachments resolve through —
+// foreign files live outside the document [Store], so the workspace carries
+// its own probe (injected; tests use a named fake).
+type ExternalFileProbe interface {
+	// StatFile returns the file's modification time, exists=false when absent.
+	StatFile(fullFileName string) (modTime time.Time, exists bool)
+	// ReadFile returns the file's bytes (the embed path).
+	ReadFile(fullFileName string) ([]byte, error)
+}
+
+// FileAttachment is one attachment record on a document.
+type FileAttachment struct {
+	owner             *Document
+	name              string
+	kind              types.AttachmentKind
+	fullFileName      string
+	payload           []byte // embedded bytes; nil for linked/generic
+	resourceID        string // minted id addressing an embedded payload
+	lastKnownFileTime time.Time
+	browserVisible    bool
+}
+
+// Name returns the unique name other objects bind to.
+func (a *FileAttachment) Name() string { return a.name }
+
+// Kind returns whether the foreign file is linked, embedded or generic.
+func (a *FileAttachment) Kind() types.AttachmentKind { return a.kind }
+
+// FullFileName returns the as-recorded path (the origin file for embedded).
+func (a *FileAttachment) FullFileName() string { return a.fullFileName }
+
+// ResourceID returns the id addressing an embedded payload, "" otherwise.
+func (a *FileAttachment) ResourceID() string { return a.resourceID }
+
+// Payload returns a copy of an embedded attachment's bytes, nil otherwise.
+func (a *FileAttachment) Payload() []byte {
+	out := make([]byte, len(a.payload))
+	copy(out, a.payload)
+	return out
+}
+
+// LastKnownFileTime returns the target's modification time as recorded at
+// attach time; the zero time when unknown or embedded.
+func (a *FileAttachment) LastKnownFileTime() time.Time { return a.lastKnownFileTime }
+
+// BrowserVisible reports whether the attachment shows in the model browser.
+func (a *FileAttachment) BrowserVisible() bool { return a.browserVisible }
+
+// SetBrowserVisible toggles the attachment's browser visibility.
+func (a *FileAttachment) SetBrowserVisible(visible bool) { a.browserVisible = visible }
+
+// probe returns the owning workspace's external-file probe, nil for a
+// standalone document (status is then unknown).
+func (a *FileAttachment) probe() ExternalFileProbe {
+	if a.owner == nil || a.owner.graph == nil {
+		return nil
+	}
+	return a.owner.graph.ws.externalFiles
+}
+
+// ResolvedFileName returns where the linked path resolves right now, "" while
+// missing. Embedded payloads travel with the document and resolve to nothing.
+func (a *FileAttachment) ResolvedFileName() string {
+	if a.kind == types.AttachmentEmbedded {
+		return ""
+	}
+	p := a.probe()
+	if p == nil {
+		return ""
+	}
+	if _, exists := p.StatFile(a.fullFileName); exists {
+		return a.fullFileName
+	}
+	return ""
+}
+
+// Status derives the attachment's freshness: embedded payloads are always up
+// to date; a linked file that vanished is missing; a linked file modified
+// after the recorded time is out of date.
+func (a *FileAttachment) Status() types.ReferenceStatus {
+	if a.kind == types.AttachmentEmbedded {
+		return types.ReferenceUpToDate
+	}
+	p := a.probe()
+	if p == nil {
+		return types.ReferenceUnknown
+	}
+	mod, exists := p.StatFile(a.fullFileName)
+	switch {
+	case !exists:
+		return types.ReferenceMissing
+	case a.kind == types.AttachmentLinked && !a.lastKnownFileTime.IsZero() && mod.After(a.lastKnownFileTime):
+		return types.ReferenceOutOfDate
+	default:
+		return types.ReferenceUpToDate
+	}
+}
+
+// FileAttachments is a document's attachment collection (lazily seeded).
+type FileAttachments struct {
+	d      *Document
+	byName map[string]*FileAttachment
+	order  []string
+}
+
+// Attachments returns the document's attachment collection.
+func (d *Document) Attachments() *FileAttachments {
+	if d.attachments == nil {
+		d.attachments = &FileAttachments{d: d, byName: map[string]*FileAttachment{}}
+	}
+	return d.attachments
+}
+
+// Count returns the number of attachment records.
+func (c *FileAttachments) Count() int { return len(c.order) }
+
+// Names returns the attachment names in insertion order.
+func (c *FileAttachments) Names() []string {
+	out := make([]string, len(c.order))
+	copy(out, c.order)
+	return out
+}
+
+// ByName returns the named attachment, ok=false when absent. It returns the
+// contract view (interface returns keep the collection assignable to
+// [contract.FileAttachments]); in-package callers use [FileAttachments.Record].
+func (c *FileAttachments) ByName(name string) (contract.FileAttachment, bool) {
+	a, ok := c.byName[name]
+	if !ok {
+		return nil, false
+	}
+	return a, true
+}
+
+// Record returns the named concrete attachment, nil when absent.
+func (c *FileAttachments) Record(name string) *FileAttachment { return c.byName[name] }
+
+// Add attaches the file at fullFileName under the unique name. A linked
+// attachment records the file's current modification time; an embedded one
+// reads and carries its bytes. The document is marked dirty.
+func (c *FileAttachments) Add(name string, kind types.AttachmentKind, fullFileName string) (contract.FileAttachment, error) {
+	if name == "" || fullFileName == "" {
+		return nil, fmt.Errorf("doc: attachment needs a name and a file (got %q, %q)", name, fullFileName)
+	}
+	if _, taken := c.byName[name]; taken {
+		return nil, fmt.Errorf("doc: attachment %q already exists", name)
+	}
+	a := &FileAttachment{owner: c.d, name: name, kind: kind, fullFileName: fullFileName, browserVisible: true}
+	if err := c.captureSource(a); err != nil {
+		return nil, err
+	}
+	c.byName[name] = a
+	c.order = append(c.order, name)
+	c.d.MarkDirty()
+	return a, nil
+}
+
+// captureSource records what Add needs from the foreign file: bytes for an
+// embedded attachment, the modification time for a linked one.
+func (c *FileAttachments) captureSource(a *FileAttachment) error {
+	p := a.probe()
+	switch {
+	case a.kind == types.AttachmentEmbedded:
+		if p == nil {
+			return fmt.Errorf("doc: cannot embed %q: document has no workspace", a.fullFileName)
+		}
+		payload, err := p.ReadFile(a.fullFileName)
+		if err != nil {
+			return fmt.Errorf("doc: embed %q: %w", a.fullFileName, err)
+		}
+		a.payload, a.resourceID = payload, mintFileGUID()
+	case a.kind == types.AttachmentLinked && p != nil:
+		if mod, exists := p.StatFile(a.fullFileName); exists {
+			a.lastKnownFileTime = mod
+		}
+	}
+	return nil
+}
+
+// Remove deletes the named record (and an embedded payload with it),
+// reporting whether it existed.
+func (c *FileAttachments) Remove(name string) bool {
+	if _, ok := c.byName[name]; !ok {
+		return false
+	}
+	delete(c.byName, name)
+	for i, n := range c.order {
+		if n == name {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			break
+		}
+	}
+	c.d.MarkDirty()
+	return true
+}
+
+// All returns the attachment records in insertion order.
+func (c *FileAttachments) All() []*FileAttachment {
+	out := make([]*FileAttachment, len(c.order))
+	for i, name := range c.order {
+		out[i] = c.byName[name]
+	}
+	return out
+}
+
+// osFileProbe is the default [ExternalFileProbe]: the real filesystem.
+type osFileProbe struct{}
+
+func (osFileProbe) StatFile(fullFileName string) (time.Time, bool) {
+	info, err := os.Stat(fullFileName)
+	if err != nil || info.IsDir() {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
+}
+
+func (osFileProbe) ReadFile(fullFileName string) ([]byte, error) {
+	return os.ReadFile(fullFileName)
+}
+
+// FileAttachmentRecord is the persistence shape of one attachment — plain data
+// the store round-trips (the doc/persistence bridge, like [Resource]).
+type FileAttachmentRecord struct {
+	Name              string
+	Kind              string // wire spelling; readable in the YAML file
+	FullFileName      string
+	ResourceID        string
+	Payload           []byte // embedded bytes; nil for linked/generic
+	LastKnownFileTime string // RFC 3339; "" when unknown
+	BrowserVisible    bool
+}
+
+// AttachmentRecords renders the collection for persistence.
+func (d *Document) AttachmentRecords() []FileAttachmentRecord {
+	all := d.Attachments().All()
+	out := make([]FileAttachmentRecord, len(all))
+	for i, a := range all {
+		out[i] = FileAttachmentRecord{
+			Name: a.name, Kind: a.kind.String(), FullFileName: a.fullFileName,
+			ResourceID: a.resourceID, Payload: a.payload,
+			LastKnownFileTime: formatFileTime(a.lastKnownFileTime),
+			BrowserVisible:    a.browserVisible,
+		}
+	}
+	return out
+}
+
+// SetAttachmentRecords restores persisted attachment records (the load path).
+func (d *Document) SetAttachmentRecords(records []FileAttachmentRecord) {
+	c := &FileAttachments{d: d, byName: map[string]*FileAttachment{}}
+	for _, rec := range records {
+		kind, ok := types.ParseAttachmentKind(rec.Kind)
+		if !ok {
+			kind = types.AttachmentGeneric
+		}
+		c.byName[rec.Name] = &FileAttachment{
+			owner: d, name: rec.Name, kind: kind, fullFileName: rec.FullFileName,
+			resourceID: rec.ResourceID, payload: rec.Payload,
+			lastKnownFileTime: parseFileTime(rec.LastKnownFileTime),
+			browserVisible:    rec.BrowserVisible,
+		}
+		c.order = append(c.order, rec.Name)
+	}
+	d.attachments = c
+}
+
+// formatFileTime / parseFileTime are the RFC 3339 round-trip for the
+// last-known file time; the zero time persists as "".
+func formatFileTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func parseFileTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/model/doc/attachments_test.go
+++ b/model/doc/attachments_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"oblikovati.org/api/types"
+)
+
+// fakeExternalFiles is a named in-memory ExternalFileProbe: foreign files with
+// controllable bytes and modification times.
+type fakeExternalFiles struct {
+	files map[string]fakeExternalFile
+}
+
+type fakeExternalFile struct {
+	bytes []byte
+	mod   time.Time
+}
+
+func newFakeExternalFiles() *fakeExternalFiles {
+	return &fakeExternalFiles{files: map[string]fakeExternalFile{}}
+}
+
+func (f *fakeExternalFiles) put(name string, bytes []byte, mod time.Time) {
+	f.files[name] = fakeExternalFile{bytes: bytes, mod: mod}
+}
+
+func (f *fakeExternalFiles) StatFile(name string) (time.Time, bool) {
+	file, ok := f.files[name]
+	return file.mod, ok
+}
+
+func (f *fakeExternalFiles) ReadFile(name string) ([]byte, error) {
+	file, ok := f.files[name]
+	if !ok {
+		return nil, fmt.Errorf("fake: no file %q", name)
+	}
+	return file.bytes, nil
+}
+
+// attachmentFixture is a part document in a workspace with a fake foreign
+// filesystem holding loads.csv.
+func attachmentFixture(t *testing.T) (*Document, *fakeExternalFiles, time.Time) {
+	t.Helper()
+	ws := NewWorkspace(newFakeStore())
+	ext := newFakeExternalFiles()
+	ws.SetExternalFileProbe(ext)
+	attached := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	ext.put("/data/loads.csv", []byte("f1,f2\n1,2\n"), attached)
+	d, err := ws.Add(Part, "bracket.obk", true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	return d, ext, attached
+}
+
+// TestLinkedAttachmentTracksFreshness: a linked attachment records the mod
+// time at attach and reports outOfDate / missing as the foreign file changes
+// or vanishes (M03-F08).
+func TestLinkedAttachmentTracksFreshness(t *testing.T) {
+	d, ext, attached := attachmentFixture(t)
+	if _, err := d.Attachments().Add("loads", types.AttachmentLinked, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	a := d.Attachments().Record("loads")
+	if !a.LastKnownFileTime().Equal(attached) || a.Status() != types.ReferenceUpToDate {
+		t.Fatalf("fresh link = (%v, %v), want upToDate at the attach time", a.LastKnownFileTime(), a.Status())
+	}
+	if a.ResolvedFileName() != "/data/loads.csv" {
+		t.Errorf("resolved = %q, want the linked path", a.ResolvedFileName())
+	}
+
+	ext.put("/data/loads.csv", []byte("changed"), attached.Add(time.Hour))
+	if a.Status() != types.ReferenceOutOfDate {
+		t.Errorf("status after foreign edit = %v, want outOfDate", a.Status())
+	}
+	delete(ext.files, "/data/loads.csv")
+	if a.Status() != types.ReferenceMissing || a.ResolvedFileName() != "" {
+		t.Errorf("status after deletion = %v, want missing", a.Status())
+	}
+}
+
+// TestEmbeddedAttachmentCarriesPayload: an embedded attachment reads the file
+// once and stays upToDate even when the origin vanishes.
+func TestEmbeddedAttachmentCarriesPayload(t *testing.T) {
+	d, ext, _ := attachmentFixture(t)
+	if _, err := d.Attachments().Add("loads", types.AttachmentEmbedded, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	a := d.Attachments().Record("loads")
+	if string(a.Payload()) != "f1,f2\n1,2\n" || a.ResourceID() == "" {
+		t.Fatalf("payload = %q (resource %q), want the embedded bytes addressable", a.Payload(), a.ResourceID())
+	}
+	delete(ext.files, "/data/loads.csv")
+	if a.Status() != types.ReferenceUpToDate {
+		t.Errorf("embedded status = %v, want upToDate regardless of the origin", a.Status())
+	}
+	if _, err := d.Attachments().Add("ghost", types.AttachmentEmbedded, "/data/ghost.bin"); err == nil {
+		t.Error("embedding an unreadable file must fail")
+	}
+}
+
+// TestAttachmentCollectionRules: unique names, dirty marking, removal.
+func TestAttachmentCollectionRules(t *testing.T) {
+	d, _, _ := attachmentFixture(t)
+	d.ClearDirty()
+	if _, err := d.Attachments().Add("loads", types.AttachmentGeneric, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !d.Dirty() {
+		t.Error("attaching must mark the document dirty")
+	}
+	if _, err := d.Attachments().Add("loads", types.AttachmentLinked, "/data/other.csv"); err == nil {
+		t.Error("a duplicate attachment name must fail")
+	}
+	if _, err := d.Attachments().Add("", types.AttachmentLinked, "/x"); err == nil {
+		t.Error("an empty attachment name must fail")
+	}
+	if got := d.Attachments().Names(); len(got) != 1 || got[0] != "loads" {
+		t.Errorf("names = %v, want [loads]", got)
+	}
+	if !d.Attachments().Remove("loads") || d.Attachments().Remove("loads") {
+		t.Error("Remove must report existence exactly once")
+	}
+	if d.Attachments().Count() != 0 {
+		t.Errorf("count after removal = %d, want 0", d.Attachments().Count())
+	}
+}
+
+// TestAttachmentRecordsRoundTrip: the persistence bridge keeps payloads,
+// times and flags across SetAttachmentRecords(AttachmentRecords()).
+func TestAttachmentRecordsRoundTrip(t *testing.T) {
+	d, _, attached := attachmentFixture(t)
+	if _, err := d.Attachments().Add("loads", types.AttachmentLinked, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add linked: %v", err)
+	}
+	if _, err := d.Attachments().Add("table", types.AttachmentEmbedded, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add embedded: %v", err)
+	}
+	d.Attachments().Record("table").SetBrowserVisible(false)
+
+	recs := d.AttachmentRecords()
+	d.SetAttachmentRecords(recs)
+
+	linked := d.Attachments().Record("loads")
+	if !linked.LastKnownFileTime().Equal(attached) || linked.Kind() != types.AttachmentLinked {
+		t.Errorf("linked after round-trip = (%v, %v), want the recorded time kept",
+			linked.LastKnownFileTime(), linked.Kind())
+	}
+	embedded := d.Attachments().Record("table")
+	if string(embedded.Payload()) != "f1,f2\n1,2\n" || embedded.BrowserVisible() {
+		t.Errorf("embedded after round-trip = (%q, visible=%v), want payload kept and hidden",
+			embedded.Payload(), embedded.BrowserVisible())
+	}
+}

--- a/model/doc/contract_assert.go
+++ b/model/doc/contract_assert.go
@@ -24,3 +24,9 @@ var (
 	_ contract.FileAttachment  = (*FileAttachment)(nil)
 	_ contract.FileAttachments = (*FileAttachments)(nil)
 )
+
+// The add-in data registry (M03-F10, #611).
+var (
+	_ contract.DocumentInterest  = InterestRecordView{}
+	_ contract.DocumentInterests = (*DocumentInterests)(nil)
+)

--- a/model/doc/contract_assert.go
+++ b/model/doc/contract_assert.go
@@ -9,3 +9,12 @@ import "oblikovati.org/api/contract"
 // a method's signature drifts from [contract.Document], the build breaks here rather
 // than silently diverging the public surface from what /source actually does.
 var _ contract.Document = (*Document)(nil)
+
+// The file surface (M03-F07, #608): the file object and the two descriptor
+// views — one FileReference satisfies both the file-side flags contract and
+// the document-side status/bridge contract.
+var (
+	_ contract.File                     = (*File)(nil)
+	_ contract.FileDescriptor           = (*FileReference)(nil)
+	_ contract.ReferencedFileDescriptor = (*FileReference)(nil)
+)

--- a/model/doc/contract_assert.go
+++ b/model/doc/contract_assert.go
@@ -18,3 +18,9 @@ var (
 	_ contract.FileDescriptor           = (*FileReference)(nil)
 	_ contract.ReferencedFileDescriptor = (*FileReference)(nil)
 )
+
+// External-file attachments (M03-F08, #609).
+var (
+	_ contract.FileAttachment  = (*FileAttachment)(nil)
+	_ contract.FileAttachments = (*FileAttachments)(nil)
+)

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -44,6 +44,8 @@ type Document struct {
 	subType          SubTypeID      // flavored document subtype id, "" for plain (M05-F15, M03-F11)
 	referencedBy     int            // how many open documents reference this one (maintained by the graph, M03-F04)
 	views            *DocumentViews // per-document view collection (cameras); lazily seeded by Views()
+	identity         FileIdentity   // the file's persisted identity block (M03-F07, #159)
+	fileReferences   []*FileReference
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;
@@ -57,6 +59,7 @@ func newDocument(t DocumentType, fullDocumentName string, content Content, open 
 		content:          content,
 		open:             open,
 		visible:          open,
+		identity:         newFileIdentity(),
 	}
 }
 

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -41,7 +41,7 @@ type Document struct {
 	open             bool
 	visible          bool
 	compacted        bool
-	subType          string         // add-in flavored document subtype id, "" for plain (M05-F15)
+	subType          SubTypeID      // flavored document subtype id, "" for plain (M05-F15, M03-F11)
 	referencedBy     int            // how many open documents reference this one (maintained by the graph, M03-F04)
 	views            *DocumentViews // per-document view collection (cameras); lazily seeded by Views()
 }
@@ -73,12 +73,13 @@ func (d *Document) ID() ID { return d.id }
 // DocumentType returns the kind discriminator.
 func (d *Document) DocumentType() DocumentType { return d.docType }
 
-// SubType returns the add-in flavored subtype id ("" for a plain document) — the
-// DocumentSubType discriminator (M05-F15); persisted in the manifest.
-func (d *Document) SubType() string { return d.subType }
+// SubType returns the flavored subtype id ("" for a plain document) — the
+// DocumentSubType discriminator (M05-F15, typed in M03-F11); persisted in the
+// manifest.
+func (d *Document) SubType() SubTypeID { return d.subType }
 
 // SetSubType stamps the flavored subtype id.
-func (d *Document) SetSubType(id string) { d.subType = id }
+func (d *Document) SetSubType(id SubTypeID) { d.subType = id }
 
 // Content returns the modeling payload, or nil if this is an unopened reference
 // stub. Callers needing a typed view use the specialization accessors

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -46,6 +46,7 @@ type Document struct {
 	views            *DocumentViews // per-document view collection (cameras); lazily seeded by Views()
 	identity         FileIdentity   // the file's persisted identity block (M03-F07, #159)
 	fileReferences   []*FileReference
+	attachments      *FileAttachments // external-file attachment records (M03-F08); lazily seeded
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -46,7 +46,8 @@ type Document struct {
 	views            *DocumentViews // per-document view collection (cameras); lazily seeded by Views()
 	identity         FileIdentity   // the file's persisted identity block (M03-F07, #159)
 	fileReferences   []*FileReference
-	attachments      *FileAttachments // external-file attachment records (M03-F08); lazily seeded
+	attachments      *FileAttachments   // external-file attachment records (M03-F08); lazily seeded
+	interests        *DocumentInterests // add-in data registry (M03-F10); lazily seeded
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;

--- a/model/doc/document_type.go
+++ b/model/doc/document_type.go
@@ -12,6 +12,12 @@ import "oblikovati.org/api/types"
 // reference graph and must never be renumbered — see [types.DocumentType].
 type DocumentType = types.DocumentType
 
+// SubTypeID refines the base DocumentType with a flavored sub-type — the
+// persisted discriminator behind sheet-metal parts and add-in flavors
+// (M03-F11, #612). Defined once in the contract ([types.DocumentSubTypeID]);
+// this alias keeps doc-layer spellings short.
+type SubTypeID = types.DocumentSubTypeID
+
 const (
 	// Unknown is the zero value: a document whose kind has not been resolved
 	// (e.g. an unresolved reference stub before its manifest is read).

--- a/model/doc/file.go
+++ b/model/doc/file.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+// The file as an object distinct from the documents it contains (M03-F07,
+// #608). Today one .obk hosts exactly one document, so a File is a view over
+// that document's identity and reference records; the shape already allows
+// several contained documents (model states and library members later).
+
+// File is one document file: identity, load state, and its reference records.
+type File struct {
+	d *Document
+}
+
+// FileByName returns the file view of an open (or stub-registered) document
+// file, ok=false when no document with that file name is in the workspace.
+func (ws *Workspace) FileByName(fullFileName string) (*File, bool) {
+	d, ok := ws.byName[fullFileName]
+	if !ok {
+		return nil, false
+	}
+	return &File{d: d}, true
+}
+
+// File returns the file hosting this document.
+func (d *Document) File() *File { return &File{d: d} }
+
+// FullFileName returns the file's on-disk name.
+func (f *File) FullFileName() string { return f.d.FullFileName() }
+
+// InternalName returns the stable identity GUID minted at creation.
+func (f *File) InternalName() string { return f.d.identity.InternalName }
+
+// RevisionID returns the GUID stamping the content as of the last save.
+func (f *File) RevisionID() string { return f.d.identity.RevisionID }
+
+// DatabaseRevisionID returns the GUID stamping only the model content.
+func (f *File) DatabaseRevisionID() string { return f.d.identity.DatabaseRevisionID }
+
+// FileSaveCounter returns how many times the file has been saved.
+func (f *File) FileSaveCounter() int { return f.d.identity.SaveCounter }
+
+// VersionCreated returns the software version that created the file.
+func (f *File) VersionCreated() string { return f.d.identity.VersionCreated }
+
+// VersionSaved returns the software version that last saved the file, "" for
+// a never-saved file.
+func (f *File) VersionSaved() string { return f.d.identity.VersionSaved }
+
+// Loaded reports whether any document within this file is paged in.
+func (f *File) Loaded() bool { return f.d.Open() }
+
+// Referenced reports whether any other in-memory file references this one.
+func (f *File) Referenced() bool { return f.d.Referenced() }
+
+// Documents returns the contained documents that are available — today the
+// hosting document alone; model states and members widen this later.
+func (f *File) Documents() []*Document { return []*Document{f.d} }
+
+// References returns the file's persisted file-to-file reference records.
+func (f *File) References() []*FileReference { return f.d.FileReferences() }

--- a/model/doc/file_identity.go
+++ b/model/doc/file_identity.go
@@ -90,6 +90,23 @@ func recipeDigest(d *Document) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// CopyIdentity mints the identity of a fresh copy of a file (SaveCopyAs,
+// M03-F09): a copy is a NEW file — two files must never share an internal
+// name — but its model content is the source's, so the database revision and
+// digest carry over (a derived part keyed on them still matches).
+func CopyIdentity(src FileIdentity) FileIdentity {
+	id := newFileIdentity()
+	id.RevisionID = mintFileGUID()
+	id.SaveCounter = 1
+	id.VersionSaved = build.Version
+	id.DatabaseRevisionID = src.DatabaseRevisionID
+	id.ModelDigest = src.ModelDigest
+	if id.DatabaseRevisionID == "" {
+		id.DatabaseRevisionID = mintFileGUID()
+	}
+	return id
+}
+
 // FileIdentity returns the document file's identity block.
 func (d *Document) FileIdentity() FileIdentity { return d.identity }
 

--- a/model/doc/file_identity.go
+++ b/model/doc/file_identity.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"oblikovati.org/build"
+)
+
+// File identity (M03-F07 #608, #159): every document file carries a stable
+// GUID minted at creation plus revision stamps maintained on save, so a
+// referencing file can detect that its target changed. Retrofitting identity
+// onto files in the wild is painful, so it is persisted from the first .obk.
+
+// FileIdentity is the persisted identity block of one document file.
+type FileIdentity struct {
+	// InternalName is the stable GUID minted at creation; it survives renames
+	// and every ordinary save. A save-copy mints a fresh one (two files must
+	// never share an identity).
+	InternalName string
+	// RevisionID stamps the file content as of the last save; every save
+	// mints a new one.
+	RevisionID string
+	// DatabaseRevisionID stamps only the model (recipe) content: it is
+	// re-minted on save only when the recipe changed, so property-only saves
+	// keep it (#159 — derived parts and assemblies key on it).
+	DatabaseRevisionID string
+	// SaveCounter counts how many times the file has been saved.
+	SaveCounter int
+	// VersionCreated / VersionSaved record the software versions that created
+	// and last saved the file.
+	VersionCreated string
+	VersionSaved   string
+	// ModelDigest is the recipe digest as of the last save — the comparison
+	// basis that decides whether DatabaseRevisionID re-mints.
+	ModelDigest string
+}
+
+// mintFileGUID returns a fresh RFC 4122 version-4 UUID string.
+func mintFileGUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand never fails on supported platforms; failing loud beats
+		// silently minting duplicate identities.
+		panic(fmt.Sprintf("doc: minting file guid: %v", err))
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// newFileIdentity mints the identity of a freshly created (never saved) file.
+func newFileIdentity() FileIdentity {
+	return FileIdentity{InternalName: mintFileGUID(), VersionCreated: build.Version}
+}
+
+// nextForSave returns the identity as it will be after a save that persists
+// modelDigest: counter bumped, content revision re-minted, and the database
+// revision re-minted only when the recipe actually changed.
+func (id FileIdentity) nextForSave(modelDigest string) FileIdentity {
+	next := id
+	next.SaveCounter++
+	next.RevisionID = mintFileGUID()
+	next.VersionSaved = build.Version
+	if next.DatabaseRevisionID == "" || modelDigest != id.ModelDigest {
+		next.DatabaseRevisionID = mintFileGUID()
+		next.ModelDigest = modelDigest
+	}
+	return next
+}
+
+// recipeDigest fingerprints the document's recipe so a save can tell whether
+// the model actually changed (DatabaseRevisionID re-mints only then). A
+// recipe-less or unmarshalable content digests empty, which conservatively
+// re-mints.
+func recipeDigest(d *Document) string {
+	rc, ok := d.Content().(RecipeContent)
+	if !ok {
+		return ""
+	}
+	b, err := rc.MarshalRecipe()
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// FileIdentity returns the document file's identity block.
+func (d *Document) FileIdentity() FileIdentity { return d.identity }
+
+// SetFileIdentity restores a persisted identity (the load path). A zero
+// identity (a pre-identity .obk) keeps the minted one, so old files gain an
+// identity on first load and persist it on their next save.
+func (d *Document) SetFileIdentity(id FileIdentity) {
+	if id.InternalName == "" {
+		return
+	}
+	d.identity = id
+}

--- a/model/doc/file_identity_test.go
+++ b/model/doc/file_identity_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import "testing"
+
+// TestFileIdentityMintedAtCreation: every document file gets a unique GUID and
+// the creating software version from the moment it exists (M03-F07, #159).
+func TestFileIdentityMintedAtCreation(t *testing.T) {
+	ws := NewWorkspace(newFakeStore())
+	a, _ := ws.Add(Part, "a.obk", true)
+	b, _ := ws.Add(Part, "b.obk", true)
+	idA, idB := a.FileIdentity(), b.FileIdentity()
+	if idA.InternalName == "" || idA.InternalName == idB.InternalName {
+		t.Fatalf("internal names = (%q, %q), want unique non-empty GUIDs", idA.InternalName, idB.InternalName)
+	}
+	if idA.VersionCreated == "" {
+		t.Error("VersionCreated must carry the creating software version")
+	}
+	if idA.SaveCounter != 0 || idA.RevisionID != "" {
+		t.Errorf("identity before first save = %+v, want no revision stamps yet", idA)
+	}
+}
+
+// TestSaveBumpsIdentity: a save advances the counter and re-mints the content
+// revision; the database revision re-mints only when the recipe changed.
+func TestSaveBumpsIdentity(t *testing.T) {
+	ws := NewWorkspace(newFakeStore())
+	d, _ := ws.Add(Part, "a.obk", true)
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	first := d.FileIdentity()
+	if first.SaveCounter != 1 || first.RevisionID == "" || first.DatabaseRevisionID == "" {
+		t.Fatalf("identity after first save = %+v, want counter 1 and minted revisions", first)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	second := d.FileIdentity()
+	if second.SaveCounter != 2 || second.RevisionID == first.RevisionID {
+		t.Errorf("second save = %+v, want counter 2 and a fresh content revision", second)
+	}
+	if second.DatabaseRevisionID != first.DatabaseRevisionID {
+		t.Errorf("database revision re-minted on an unchanged model: %q → %q",
+			first.DatabaseRevisionID, second.DatabaseRevisionID)
+	}
+	if second.InternalName != first.InternalName {
+		t.Error("the internal name must survive every save")
+	}
+}
+
+// TestFailedSaveRollsIdentityBack: identity must never drift ahead of the
+// bytes on disk.
+func TestFailedSaveRollsIdentityBack(t *testing.T) {
+	ws := NewWorkspace(&failingStore{})
+	d, _ := ws.Add(Part, "a.obk", true)
+	before := d.FileIdentity()
+	if err := ws.Save(d); err == nil {
+		t.Fatal("a failing store must surface the save error")
+	}
+	if got := d.FileIdentity(); got != before {
+		t.Errorf("identity after failed save = %+v, want untouched %+v", got, before)
+	}
+}
+
+// failingStore is a Store whose writes always fail.
+type failingStore struct{}
+
+func (s *failingStore) Save(*Document) error { return errNotStored{"write failed"} }
+func (s *failingStore) Load(name string) (*Document, error) {
+	return nil, errNotStored{name}
+}
+func (s *failingStore) Exists(string) bool { return false }

--- a/model/doc/file_identity_test.go
+++ b/model/doc/file_identity_test.go
@@ -68,6 +68,9 @@ func TestFailedSaveRollsIdentityBack(t *testing.T) {
 type failingStore struct{}
 
 func (s *failingStore) Save(*Document) error { return errNotStored{"write failed"} }
+func (s *failingStore) SaveCopy(*Document, string, CopyMetadata) error {
+	return errNotStored{"write failed"}
+}
 func (s *failingStore) Load(name string) (*Document, error) {
 	return nil, errNotStored{name}
 }

--- a/model/doc/file_reference.go
+++ b/model/doc/file_reference.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"oblikovati.org/api/types"
+)
+
+// File-level reference descriptors (M03-F07, #608): the persisted "as-saved"
+// record of one file-to-file reference. The live [RefGraph] drives resolution
+// this session; these records make the reference inspectable when the target
+// is gone — an unresolved file still reports what it tried to reference, why
+// it failed, and offers [FileReference.ReplaceReference] as the repair.
+
+// FileReference is one persisted file-to-file reference record. Its methods
+// satisfy both descriptor contracts: the file-side flags view and the
+// document-side status/bridge view.
+type FileReference struct {
+	owner                  *Document
+	fullFileName           string // the as-saved target
+	relativeFileName       string
+	libraryName            string
+	locationType           types.FileLocationType
+	referencedInternalName string
+	saveCounter            int
+	replacement            string // a repair target; "" until ReplaceReference
+}
+
+// FullFileName returns the reference's as-saved full file name.
+func (r *FileReference) FullFileName() string { return r.fullFileName }
+
+// RelativeFileName returns the owner-relative spelling, "" when the target
+// lies outside the owner's directory tree.
+func (r *FileReference) RelativeFileName() string { return r.relativeFileName }
+
+// LibraryName returns the owning library's name — "" until project libraries
+// participate in resolution (the M03-F04 project layer records workspaces
+// only today).
+func (r *FileReference) LibraryName() string { return r.libraryName }
+
+// LocationType classifies where the as-saved name points.
+func (r *FileReference) LocationType() types.FileLocationType { return r.locationType }
+
+// ReferencedFileInternalName returns the target's identity GUID as saved, ""
+// when the target was never loaded while the owner saved.
+func (r *FileReference) ReferencedFileInternalName() string { return r.referencedInternalName }
+
+// FileSaveCounter returns the target's save counter as saved, the comparison
+// basis for out-of-date detection.
+func (r *FileReference) FileSaveCounter() int { return r.saveCounter }
+
+// effectiveTarget is the name resolution acts on: the repair target once
+// re-pointed, the as-saved name otherwise.
+func (r *FileReference) effectiveTarget() string {
+	if r.replacement != "" {
+		return r.replacement
+	}
+	return r.fullFileName
+}
+
+// liveTarget returns the open document the reference resolves to, if any.
+func (r *FileReference) liveTarget() (*Document, bool) {
+	if r.owner == nil || r.owner.graph == nil {
+		return nil, false
+	}
+	d, ok := r.owner.graph.ws.byName[r.effectiveTarget()]
+	return d, ok && d.open
+}
+
+// ResolvedFileName returns where the reference resolves right now: the open
+// target's name, an existing file on disk, or "" while missing.
+func (r *FileReference) ResolvedFileName() string {
+	if _, ok := r.liveTarget(); ok {
+		return r.effectiveTarget()
+	}
+	if r.owner != nil && r.owner.graph != nil {
+		if store := r.owner.graph.ws.store; store != nil && store.Exists(r.effectiveTarget()) {
+			return r.effectiveTarget()
+		}
+	}
+	return ""
+}
+
+// ReferenceMissing reports that the target cannot be found anywhere.
+func (r *FileReference) ReferenceMissing() bool { return r.ResolvedFileName() == "" }
+
+// ReferenceReplaced reports the reference was re-pointed and the owner has not
+// been saved since (saving makes the repair the as-saved truth).
+func (r *FileReference) ReferenceReplaced() bool { return r.replacement != "" }
+
+// ReferenceLocationDifferent reports the reference resolves somewhere other
+// than the as-saved location.
+func (r *FileReference) ReferenceLocationDifferent() bool {
+	resolved := r.ResolvedFileName()
+	return resolved != "" && resolved != r.fullFileName
+}
+
+// ReferenceInternalNameDifferent reports the resolved file carries a different
+// identity GUID than the one saved against (a swapped-in file).
+func (r *FileReference) ReferenceInternalNameDifferent() bool {
+	target, ok := r.liveTarget()
+	if !ok || r.referencedInternalName == "" {
+		return false
+	}
+	return target.identity.InternalName != r.referencedInternalName
+}
+
+// referenceOutOfDate reports the target has been saved since the owner
+// recorded it (only assessable while the target is open).
+func (r *FileReference) referenceOutOfDate() bool {
+	target, ok := r.liveTarget()
+	if !ok || r.saveCounter == 0 {
+		return false
+	}
+	return target.identity.SaveCounter > r.saveCounter
+}
+
+// Status derives the single status vocabulary from the resolution state.
+func (r *FileReference) Status() types.ReferenceStatus {
+	switch {
+	case r.ReferenceReplaced():
+		return types.ReferenceReplaced
+	case r.ReferenceMissing():
+		return types.ReferenceMissing
+	case r.ReferenceInternalNameDifferent() || r.referenceOutOfDate():
+		return types.ReferenceOutOfDate
+	default:
+		return types.ReferenceUpToDate
+	}
+}
+
+// DisplayName returns the reference's human-readable name (document-side view).
+func (r *FileReference) DisplayName() string { return derivedDisplayName(r.fullFileName) }
+
+// DocumentFound reports whether a document resolves for this reference.
+func (r *FileReference) DocumentFound() bool { return !r.ReferenceMissing() }
+
+// DifferentDocument reports the resolved document is not the one saved
+// against — a repair or a swapped-in file.
+func (r *FileReference) DifferentDocument() bool {
+	return r.ReferenceReplaced() || r.ReferenceInternalNameDifferent() || r.ReferenceLocationDifferent()
+}
+
+// ReplaceReference re-points this record at fullFileName (the broken-reference
+// repair). The replacement must exist; the matching live graph edge is
+// re-pointed too, so resolution this session follows the repair, and the next
+// save persists it as the as-saved truth.
+func (r *FileReference) ReplaceReference(fullFileName string) error {
+	if r.owner == nil || r.owner.graph == nil {
+		return fmt.Errorf("doc: reference %q has no workspace; cannot replace", r.fullFileName)
+	}
+	ws := r.owner.graph.ws
+	if ws.store == nil || !ws.store.Exists(fullFileName) {
+		return fmt.Errorf("doc: replacement %q does not exist", fullFileName)
+	}
+	old := r.effectiveTarget()
+	r.replacement = fullFileName
+	ws.graph.repointReference(r.owner, old, fullFileName)
+	return nil
+}
+
+// FileReferences returns the document's persisted file-to-file reference
+// records, in order.
+func (d *Document) FileReferences() []*FileReference {
+	out := make([]*FileReference, len(d.fileReferences))
+	copy(out, d.fileReferences)
+	return out
+}
+
+// FileReferenceRecord is the persistence shape of one record — plain data the
+// store round-trips (the doc/persistence bridge, like [Resource]).
+type FileReferenceRecord struct {
+	FullFileName           string
+	RelativeFileName       string
+	LibraryName            string
+	LocationType           string // wire spelling; readable in the YAML file
+	ReferencedInternalName string
+	SaveCounter            int
+}
+
+// FileReferenceRecords renders the as-saved snapshot for persistence.
+func (d *Document) FileReferenceRecords() []FileReferenceRecord {
+	out := make([]FileReferenceRecord, len(d.fileReferences))
+	for i, r := range d.fileReferences {
+		out[i] = FileReferenceRecord{
+			FullFileName: r.fullFileName, RelativeFileName: r.relativeFileName,
+			LibraryName: r.libraryName, LocationType: r.locationType.String(),
+			ReferencedInternalName: r.referencedInternalName, SaveCounter: r.saveCounter,
+		}
+	}
+	return out
+}
+
+// SetFileReferenceRecords restores persisted records (the load path).
+func (d *Document) SetFileReferenceRecords(records []FileReferenceRecord) {
+	d.fileReferences = make([]*FileReference, len(records))
+	for i, rec := range records {
+		loc, ok := types.ParseFileLocationType(rec.LocationType)
+		if !ok {
+			loc = types.LocationUnknown
+		}
+		d.fileReferences[i] = &FileReference{
+			owner: d, fullFileName: rec.FullFileName, relativeFileName: rec.RelativeFileName,
+			libraryName: rec.LibraryName, locationType: loc,
+			referencedInternalName: rec.ReferencedInternalName, saveCounter: rec.SaveCounter,
+		}
+	}
+}
+
+// snapshotFileReferences rebuilds the records from the live reference graph at
+// save time: every graph edge becomes a record carrying where the target is
+// and what identity it had; a pending repair becomes the as-saved truth.
+// Identity details of an unloaded target survive from the prior record.
+func (d *Document) snapshotFileReferences() {
+	if d.graph == nil {
+		return
+	}
+	descs := d.graph.descriptors(d.fullDocumentName)
+	if len(descs) == 0 && len(d.fileReferences) > 0 {
+		// The graph is rebuilt lazily after load (a reopened document's edges
+		// only reappear as features re-touch their sources), so an empty graph
+		// must not wipe the persisted records — they may be the only memory of
+		// what this file references.
+		return
+	}
+	prior := d.fileReferences
+	d.fileReferences = make([]*FileReference, len(descs))
+	for i, desc := range descs {
+		d.fileReferences[i] = d.snapshotOneReference(desc.fullDocumentName, prior)
+	}
+}
+
+// snapshotOneReference builds the as-saved record for one graph edge.
+func (d *Document) snapshotOneReference(target string, prior []*FileReference) *FileReference {
+	rec := &FileReference{owner: d, fullFileName: target}
+	rec.relativeFileName, rec.locationType = relateToOwner(d.fullDocumentName, target)
+	if t, ok := d.graph.ws.byName[target]; ok && t.open {
+		rec.referencedInternalName = t.identity.InternalName
+		rec.saveCounter = t.identity.SaveCounter
+		return rec
+	}
+	for _, p := range prior {
+		if p.effectiveTarget() == target {
+			rec.referencedInternalName, rec.saveCounter = p.referencedInternalName, p.saveCounter
+		}
+	}
+	return rec
+}
+
+// relateToOwner expresses target relative to the owner file's directory. A
+// sibling-tree target is an ownerDirectory reference (portable across moves of
+// the whole tree); anything else is recorded absolute with unknown location
+// until project search roots join resolution.
+func relateToOwner(ownerName, target string) (string, types.FileLocationType) {
+	rel, err := filepath.Rel(filepath.Dir(ownerName), target)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", types.LocationUnknown
+	}
+	return rel, types.LocationOwnerDirectory
+}

--- a/model/doc/file_reference.go
+++ b/model/doc/file_reference.go
@@ -254,11 +254,13 @@ func (d *Document) snapshotOneReference(target string, prior []*FileReference) *
 // relateToOwner expresses target relative to the owner file's directory. A
 // sibling-tree target is an ownerDirectory reference (portable across moves of
 // the whole tree); anything else is recorded absolute with unknown location
-// until project search roots join resolution.
+// until project search roots join resolution. The relative spelling is
+// normalized to forward slashes — a .obk saved on one OS must resolve on
+// another (ADR-0020 portability).
 func relateToOwner(ownerName, target string) (string, types.FileLocationType) {
 	rel, err := filepath.Rel(filepath.Dir(ownerName), target)
 	if err != nil || strings.HasPrefix(rel, "..") {
 		return "", types.LocationUnknown
 	}
-	return rel, types.LocationOwnerDirectory
+	return filepath.ToSlash(rel), types.LocationOwnerDirectory
 }

--- a/model/doc/file_reference_test.go
+++ b/model/doc/file_reference_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// referencingWorkspace is one assembly-like owner in /asm referencing a part
+// in the same tree — the canonical descriptor fixture.
+func referencingWorkspace(t *testing.T) (*Workspace, *Document, *Document) {
+	t.Helper()
+	ws := NewWorkspace(newFakeStore())
+	part, _ := ws.Add(Part, "/asm/parts/pin.obk", true)
+	if err := ws.Save(part); err != nil {
+		t.Fatalf("Save part: %v", err)
+	}
+	owner, _ := ws.Add(Assembly, "/asm/frame.obk", true)
+	if _, err := owner.AddReference(part.FullDocumentName()); err != nil {
+		t.Fatalf("AddReference: %v", err)
+	}
+	if err := ws.Save(owner); err != nil {
+		t.Fatalf("Save owner: %v", err)
+	}
+	return ws, owner, part
+}
+
+// TestSaveSnapshotsFileReferences: saving records the as-saved descriptor with
+// the target's identity, the owner-relative spelling, and upToDate status.
+func TestSaveSnapshotsFileReferences(t *testing.T) {
+	_, owner, part := referencingWorkspace(t)
+	refs := owner.FileReferences()
+	if len(refs) != 1 {
+		t.Fatalf("references = %d, want the one part reference", len(refs))
+	}
+	r := refs[0]
+	if r.FullFileName() != "/asm/parts/pin.obk" || r.RelativeFileName() != "parts/pin.obk" {
+		t.Errorf("names = (%q, %q), want the absolute and owner-relative spellings",
+			r.FullFileName(), r.RelativeFileName())
+	}
+	if r.LocationType() != types.LocationOwnerDirectory {
+		t.Errorf("location = %v, want ownerDirectory", r.LocationType())
+	}
+	if r.ReferencedFileInternalName() != part.FileIdentity().InternalName || r.FileSaveCounter() != 1 {
+		t.Errorf("recorded identity = (%q, %d), want the part's GUID at save counter 1",
+			r.ReferencedFileInternalName(), r.FileSaveCounter())
+	}
+	if r.Status() != types.ReferenceUpToDate || !r.DocumentFound() || r.DifferentDocument() {
+		t.Errorf("status = %v (found=%v different=%v), want a clean upToDate reference",
+			r.Status(), r.DocumentFound(), r.DifferentDocument())
+	}
+}
+
+// TestReferenceGoesOutOfDateWhenTargetSaves: the target saving again after the
+// owner recorded it reports outOfDate on the owner's record.
+func TestReferenceGoesOutOfDateWhenTargetSaves(t *testing.T) {
+	ws, owner, part := referencingWorkspace(t)
+	if err := ws.Save(part); err != nil {
+		t.Fatalf("Save part again: %v", err)
+	}
+	if got := owner.FileReferences()[0].Status(); got != types.ReferenceOutOfDate {
+		t.Errorf("status after target re-save = %v, want outOfDate", got)
+	}
+}
+
+// TestMissingReferenceReportsAndRepairs: a vanished target reports missing
+// with full detail, and ReplaceReference re-points record and graph edge.
+func TestMissingReferenceReportsAndRepairs(t *testing.T) {
+	ws, owner, part := referencingWorkspace(t)
+	store := ws.store.(*fakeStore)
+	delete(store.saved, part.FullDocumentName())
+	if err := ws.Close(part, true); err != nil {
+		t.Fatalf("Close part: %v", err)
+	}
+
+	r := owner.FileReferences()[0]
+	if r.Status() != types.ReferenceMissing || !r.ReferenceMissing() || r.DocumentFound() {
+		t.Fatalf("status = %v, want a missing reference", r.Status())
+	}
+
+	moved, _ := ws.Add(Part, "/asm/parts/pin-v2.obk", true)
+	if err := ws.Save(moved); err != nil {
+		t.Fatalf("Save moved part: %v", err)
+	}
+	if err := r.ReplaceReference("/no/such/file.obk"); err == nil {
+		t.Error("replacing with a nonexistent target must fail")
+	}
+	if err := r.ReplaceReference("/asm/parts/pin-v2.obk"); err != nil {
+		t.Fatalf("ReplaceReference: %v", err)
+	}
+	if r.Status() != types.ReferenceReplaced || r.ResolvedFileName() != "/asm/parts/pin-v2.obk" {
+		t.Errorf("after repair status = %v resolved = %q, want replaced → pin-v2",
+			r.Status(), r.ResolvedFileName())
+	}
+	if !r.DifferentDocument() || !r.ReferenceLocationDifferent() {
+		t.Error("a repaired reference must report it resolves to a different document")
+	}
+	if docs := owner.ReferencedDocuments(); len(docs) != 1 || docs[0].FullDocumentName() != "/asm/parts/pin-v2.obk" {
+		t.Errorf("graph resolution after repair = %v, want the replacement", docs)
+	}
+
+	// Saving makes the repair the as-saved truth.
+	if err := ws.Save(owner); err != nil {
+		t.Fatalf("Save owner: %v", err)
+	}
+	r = owner.FileReferences()[0]
+	if r.FullFileName() != "/asm/parts/pin-v2.obk" || r.Status() != types.ReferenceUpToDate {
+		t.Errorf("after save = (%q, %v), want the replacement persisted upToDate", r.FullFileName(), r.Status())
+	}
+}
+
+// TestFileViewExposesIdentityAndReferences: the File object bridges identity,
+// load state and the reference records (M03-F07).
+func TestFileViewExposesIdentityAndReferences(t *testing.T) {
+	ws, owner, _ := referencingWorkspace(t)
+	f, ok := ws.FileByName(owner.FullFileName())
+	if !ok {
+		t.Fatal("FileByName must find the open owner")
+	}
+	if f.InternalName() != owner.FileIdentity().InternalName || f.FileSaveCounter() != 1 {
+		t.Errorf("file identity = (%q, %d), want the owner's", f.InternalName(), f.FileSaveCounter())
+	}
+	if !f.Loaded() || len(f.Documents()) != 1 || len(f.References()) != 1 {
+		t.Errorf("file view = (loaded=%v docs=%d refs=%d), want the loaded single-document file",
+			f.Loaded(), len(f.Documents()), len(f.References()))
+	}
+	if _, ok := ws.FileByName("/nowhere.obk"); ok {
+		t.Error("FileByName must miss unknown names")
+	}
+}

--- a/model/doc/interests.go
+++ b/model/doc/interests.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// The add-in data registry on documents (M03-F10, #611): an interest declares
+// "client X has data in / depends on this document", carries a client-managed
+// data version for migration, and is readable without loading the add-in —
+// the discovery layer over the attribute-set payload layer. Interests persist
+// with the document so the host can warn when a document opens and the
+// responsible add-in is absent.
+
+// InterestRecordView is one registered interest, read through the contract's
+// scalar accessors.
+type InterestRecordView struct {
+	rec types.DocumentInterestRecord
+}
+
+// ClientID returns the owning client's id.
+func (v InterestRecordView) ClientID() string { return v.rec.ClientID }
+
+// Name returns the interest's name; (ClientID, Name) is its identity.
+func (v InterestRecordView) Name() string { return v.rec.Name }
+
+// InterestType returns the interest's strength.
+func (v InterestRecordView) InterestType() types.DocumentInterestType { return v.rec.InterestType }
+
+// DataVersion returns the client-managed migration version, 0 non-migrating.
+func (v InterestRecordView) DataVersion() int { return v.rec.DataVersion }
+
+// ClientData returns the uninterpreted client payload.
+func (v InterestRecordView) ClientData() string { return v.rec.ClientData }
+
+// DocumentInterests is a document's interest registry (lazily seeded).
+type DocumentInterests struct {
+	d       *Document
+	records []types.DocumentInterestRecord
+}
+
+// Interests returns the document's interest registry.
+func (d *Document) Interests() *DocumentInterests {
+	if d.interests == nil {
+		d.interests = &DocumentInterests{d: d}
+	}
+	return d.interests
+}
+
+// Count returns the number of interest records.
+func (c *DocumentInterests) Count() int { return len(c.records) }
+
+// Records returns the interest records in insertion order.
+func (c *DocumentInterests) Records() []types.DocumentInterestRecord {
+	out := make([]types.DocumentInterestRecord, len(c.records))
+	copy(out, c.records)
+	return out
+}
+
+// At returns the record at index as the contract's scalar view.
+func (c *DocumentInterests) At(index int) (InterestRecordView, error) {
+	if index < 0 || index >= len(c.records) {
+		return InterestRecordView{}, fmt.Errorf("doc: interest index %d out of range [0,%d)", index, len(c.records))
+	}
+	return InterestRecordView{rec: c.records[index]}, nil
+}
+
+// HasInterest reports whether any record's ClientID or Name matches
+// clientIDOrName — the cheap "does anyone hold data here?" probe.
+func (c *DocumentInterests) HasInterest(clientIDOrName string) bool {
+	for _, rec := range c.records {
+		if rec.ClientID == clientIDOrName || rec.Name == clientIDOrName {
+			return true
+		}
+	}
+	return false
+}
+
+// Add registers the record, updating an existing (ClientID, Name) entry in
+// place. An unset InterestType registers as Interested. The document is
+// marked dirty.
+func (c *DocumentInterests) Add(record types.DocumentInterestRecord) error {
+	if record.ClientID == "" || record.Name == "" {
+		return fmt.Errorf("doc: interest needs a client id and a name (got %q, %q)", record.ClientID, record.Name)
+	}
+	if record.InterestType == 0 {
+		record.InterestType = types.Interested
+	}
+	defer c.d.MarkDirty()
+	for i, rec := range c.records {
+		if rec.ClientID == record.ClientID && rec.Name == record.Name {
+			c.records[i] = record
+			return nil
+		}
+	}
+	c.records = append(c.records, record)
+	return nil
+}
+
+// Remove deletes the (clientID, name) record, reporting whether it existed.
+func (c *DocumentInterests) Remove(clientID, name string) bool {
+	for i, rec := range c.records {
+		if rec.ClientID == clientID && rec.Name == name {
+			c.records = append(c.records[:i], c.records[i+1:]...)
+			c.d.MarkDirty()
+			return true
+		}
+	}
+	return false
+}
+
+// InterestRecords renders the registry for persistence.
+func (d *Document) InterestRecords() []types.DocumentInterestRecord {
+	return d.Interests().Records()
+}
+
+// SetInterestRecords restores persisted interest records (the load path).
+func (d *Document) SetInterestRecords(records []types.DocumentInterestRecord) {
+	d.interests = &DocumentInterests{d: d, records: records}
+}

--- a/model/doc/interests_test.go
+++ b/model/doc/interests_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// TestInterestRegistryRules: identity is (ClientID, Name); re-adding updates
+// in place; HasInterest matches either id or name; removal reports existence.
+func TestInterestRegistryRules(t *testing.T) {
+	ws := NewWorkspace(newFakeStore())
+	d, _ := ws.Add(Part, "bracket.obk", true)
+	d.ClearDirty()
+
+	if err := d.Interests().Add(types.DocumentInterestRecord{ClientID: "", Name: "x"}); err == nil {
+		t.Error("an interest without a client id must fail")
+	}
+	rec := types.DocumentInterestRecord{
+		ClientID: "com.x.toolpaths", Name: "toolpath-recipes", DataVersion: 1, ClientData: "v1",
+	}
+	if err := d.Interests().Add(rec); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !d.Dirty() {
+		t.Error("registering an interest must mark the document dirty")
+	}
+	got := d.Interests().Records()
+	if len(got) != 1 || got[0].InterestType != types.Interested {
+		t.Fatalf("records = %+v, want one defaulted to interested", got)
+	}
+
+	rec.DataVersion = 2
+	if err := d.Interests().Add(rec); err != nil {
+		t.Fatalf("re-Add: %v", err)
+	}
+	if got := d.Interests().Records(); len(got) != 1 || got[0].DataVersion != 2 {
+		t.Errorf("records after update = %+v, want the version-2 record in place", got)
+	}
+
+	if !d.Interests().HasInterest("com.x.toolpaths") || !d.Interests().HasInterest("toolpath-recipes") {
+		t.Error("HasInterest must match the client id and the interest name")
+	}
+	if d.Interests().HasInterest("com.x.ghost") {
+		t.Error("HasInterest must miss unknown clients")
+	}
+
+	view, err := d.Interests().At(0)
+	if err != nil || view.ClientID() != "com.x.toolpaths" || view.DataVersion() != 2 {
+		t.Errorf("At(0) = (%+v, %v), want the scalar view of the record", view, err)
+	}
+	if _, err := d.Interests().At(5); err == nil {
+		t.Error("At must reject an out-of-range index")
+	}
+
+	if !d.Interests().Remove("com.x.toolpaths", "toolpath-recipes") {
+		t.Error("Remove must report the record existed")
+	}
+	if d.Interests().Remove("com.x.toolpaths", "toolpath-recipes") {
+		t.Error("Remove must miss an already-removed record")
+	}
+}

--- a/model/doc/refgraph.go
+++ b/model/doc/refgraph.go
@@ -149,6 +149,37 @@ func (g *RefGraph) removeReference(parent *Document, childName string) bool {
 	return false
 }
 
+// repointReference updates the edge parent→oldName to point at newName, fixing
+// the reverse index and reference counts — the ReplaceReference repair
+// (M03-F07, #608). A missing edge is a no-op: the persisted record is then the
+// only thing repaired, which is still correct for a reference whose graph edge
+// has not been rebuilt this session.
+func (g *RefGraph) repointReference(parent *Document, oldName, newName string) {
+	for _, desc := range g.forward[parent.fullDocumentName] {
+		if desc.fullDocumentName != oldName {
+			continue
+		}
+		desc.fullDocumentName, desc.resolved, desc.broken = newName, nil, false
+		delete(g.reverse[oldName], parent.fullDocumentName)
+		if g.reverse[newName] == nil {
+			g.reverse[newName] = map[string]bool{}
+		}
+		g.reverse[newName][parent.fullDocumentName] = true
+		g.shiftRefCount(oldName, newName)
+		return
+	}
+}
+
+// shiftRefCount moves one referenced-by count from the old target to the new.
+func (g *RefGraph) shiftRefCount(oldName, newName string) {
+	if child, ok := g.ws.byName[oldName]; ok && child.open {
+		child.releaseRef()
+	}
+	if child, ok := g.ws.byName[newName]; ok && child.open {
+		child.acquireRef()
+	}
+}
+
 // descriptors returns the reference descriptors of the named parent, in order.
 func (g *RefGraph) descriptors(parentName string) []*DocumentDescriptor {
 	src := g.forward[parentName]

--- a/model/doc/store.go
+++ b/model/doc/store.go
@@ -16,11 +16,24 @@ type Store interface {
 	// Save writes the document's current state, overwriting any prior version at
 	// its full document name. It must be atomic from a reader's point of view.
 	Save(d *Document) error
+	// SaveCopy writes a copy of the document at targetFullFileName without
+	// touching the document's binding or dirty state (M03-F09). The copy is a
+	// NEW file: the implementation mints it a fresh identity ([CopyIdentity]).
+	SaveCopy(d *Document, targetFullFileName string, meta CopyMetadata) error
 	// Load reads the document at the given full document name and returns it open
 	// (content paged in). It returns an error if nothing is stored there.
 	Load(fullDocumentName string) (*Document, error)
 	// Exists reports whether a document is stored at the given full document name.
 	Exists(fullDocumentName string) bool
+}
+
+// CopyMetadata customizes the file a SaveCopy mints (the typed "new file"
+// descriptor of M03-F09); zero-value fields inherit from the source document.
+type CopyMetadata struct {
+	// DisplayName overrides the copy's display name.
+	DisplayName string
+	// SubType re-stamps the copy's flavored subtype id.
+	SubType SubTypeID
 }
 
 // newContent builds the content object for a document kind. It prefers a real content

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -139,7 +139,10 @@ func (ws *Workspace) openStub(fullDocumentName string) (*Document, error) {
 	return d, nil
 }
 
-// Save writes the document through the store and clears its dirty flag.
+// Save writes the document through the store and clears its dirty flag. The
+// save stamps the file identity (counter, revision GUIDs — M03-F07) and
+// snapshots the as-saved file reference records; a failed store write rolls
+// the identity back so it never drifts ahead of the bytes on disk.
 func (ws *Workspace) Save(d *Document) error {
 	if ws.store == nil {
 		return fmt.Errorf("doc: cannot save %q: no store configured", d.fullDocumentName)
@@ -147,7 +150,11 @@ func (ws *Workspace) Save(d *Document) error {
 	if err := vetoed(ws.bus, "save", DocumentSave{Document: d}); err != nil {
 		return err
 	}
+	d.snapshotFileReferences()
+	prior := d.identity
+	d.identity = prior.nextForSave(recipeDigest(d))
 	if err := ws.store.Save(d); err != nil {
+		d.identity = prior
 		return fmt.Errorf("doc: save %q: %w", d.fullDocumentName, err)
 	}
 	d.ClearDirty()

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -168,6 +168,27 @@ func (ws *Workspace) Save(d *Document) error {
 	return nil
 }
 
+// SaveCopy writes a copy of the document to targetFullFileName without
+// retargeting the in-memory document (M03-F09, #610) — the export/archival
+// workhorse: the document keeps its binding, dirty state and identity; the
+// copy on disk gets a fresh one. The target must differ from the source and
+// must not be open in this workspace.
+func (ws *Workspace) SaveCopy(d *Document, targetFullFileName string, meta CopyMetadata) error {
+	if ws.store == nil {
+		return fmt.Errorf("doc: cannot save a copy of %q: no store configured", d.fullDocumentName)
+	}
+	if targetFullFileName == "" || targetFullFileName == d.fullDocumentName {
+		return fmt.Errorf("doc: copy target %q must name a different file", targetFullFileName)
+	}
+	if _, open := ws.byName[targetFullFileName]; open {
+		return fmt.Errorf("doc: cannot copy over %q: it is open in this workspace", targetFullFileName)
+	}
+	if err := ws.store.SaveCopy(d, targetFullFileName, meta); err != nil {
+		return fmt.Errorf("doc: save copy %q: %w", targetFullFileName, err)
+	}
+	return nil
+}
+
 // SaveAs writes the document under a new full document name, which becomes its
 // identity. The new name must not collide with another open document.
 func (ws *Workspace) SaveAs(d *Document, newFullDocumentName string) error {

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -18,27 +18,33 @@ import (
 // this is the seam that enforces identity and (later) the reference graph and
 // transactions (parametric-cad §13).
 type Workspace struct {
-	store   Store
-	ordered []*Document          // insertion order, for stable enumeration
-	byID    map[ID]*Document     // session-id lookup
-	byName  map[string]*Document // full-document-name lookup (ItemByName)
-	graph   *RefGraph            // shared document reference graph (M03-F04)
-	bus     *event.Bus           // application/document/modeling events (M04-F04)
-	active  *Document
+	store         Store
+	ordered       []*Document          // insertion order, for stable enumeration
+	byID          map[ID]*Document     // session-id lookup
+	byName        map[string]*Document // full-document-name lookup (ItemByName)
+	graph         *RefGraph            // shared document reference graph (M03-F04)
+	bus           *event.Bus           // application/document/modeling events (M04-F04)
+	externalFiles ExternalFileProbe    // foreign-file access for attachments (M03-F08)
+	active        *Document
 }
 
 // NewWorkspace creates an empty workspace backed by store. A nil store is allowed
 // for purely in-memory sessions; Save/Open then return an error.
 func NewWorkspace(store Store) *Workspace {
 	ws := &Workspace{
-		store:  store,
-		byID:   map[ID]*Document{},
-		byName: map[string]*Document{},
-		bus:    event.NewBus(),
+		store:         store,
+		byID:          map[ID]*Document{},
+		byName:        map[string]*Document{},
+		bus:           event.NewBus(),
+		externalFiles: osFileProbe{},
 	}
 	ws.graph = newRefGraph(ws)
 	return ws
 }
+
+// SetExternalFileProbe replaces the foreign-file access seam — tests inject a
+// named fake; the default probes the real filesystem.
+func (ws *Workspace) SetExternalFileProbe(p ExternalFileProbe) { ws.externalFiles = p }
 
 // References returns the workspace's document reference graph.
 func (ws *Workspace) References() *RefGraph { return ws.graph }

--- a/model/doc/workspace_test.go
+++ b/model/doc/workspace_test.go
@@ -25,6 +25,15 @@ func (s *fakeStore) Save(d *Document) error {
 	return nil
 }
 
+func (s *fakeStore) SaveCopy(d *Document, target string, meta CopyMetadata) error {
+	displayName := d.DisplayName()
+	if meta.DisplayName != "" {
+		displayName = meta.DisplayName
+	}
+	s.saved[target] = storedDoc{docType: d.DocumentType(), displayName: displayName}
+	return nil
+}
+
 func (s *fakeStore) Load(fullDocumentName string) (*Document, error) {
 	rec, ok := s.saved[fullDocumentName]
 	if !ok {

--- a/persistence/attachments_test.go
+++ b/persistence/attachments_test.go
@@ -81,3 +81,36 @@ func TestAttachmentsRoundTripThroughPackage(t *testing.T) {
 			embedded.Payload(), embedded.ResourceID())
 	}
 }
+
+// TestInterestsRoundTripThroughPackage: the registry persists in a readable
+// 'interests' section and reloads with the document (M03-F10).
+func TestInterestsRoundTripThroughPackage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bracket.obk")
+	store := NewPackageStore()
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, path, true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := d.Interests().Add(types.DocumentInterestRecord{
+		ClientID: "com.x.toolpaths", Name: "toolpath-recipes", DataVersion: 3, ClientData: "k",
+	}); err != nil {
+		t.Fatalf("Add interest: %v", err)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got := reopened.Interests().Records()
+	if len(got) != 1 || got[0].DataVersion != 3 || got[0].InterestType != types.Interested {
+		t.Fatalf("reloaded interests = %+v, want the persisted record", got)
+	}
+	if !reopened.Interests().HasInterest("com.x.toolpaths") {
+		t.Error("the reloaded registry must answer the discovery probe")
+	}
+}

--- a/persistence/attachments_test.go
+++ b/persistence/attachments_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/doc"
+)
+
+// fakeForeignFiles is a named ExternalFileProbe over in-memory foreign files.
+type fakeForeignFiles struct {
+	files map[string][]byte
+	mod   time.Time
+}
+
+func (f *fakeForeignFiles) StatFile(name string) (time.Time, bool) {
+	_, ok := f.files[name]
+	return f.mod, ok
+}
+
+func (f *fakeForeignFiles) ReadFile(name string) ([]byte, error) {
+	b, ok := f.files[name]
+	if !ok {
+		return nil, fmt.Errorf("fake: no file %q", name)
+	}
+	return b, nil
+}
+
+// TestAttachmentsRoundTripThroughPackage: linked and embedded attachments
+// persist in the .obk (payload base64) and reload intact in a fresh
+// workspace (M03-F08).
+func TestAttachmentsRoundTripThroughPackage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bracket.obk")
+	store := NewPackageStore()
+	ext := &fakeForeignFiles{
+		files: map[string][]byte{"/data/loads.csv": []byte("f1,f2\n1,2\n")},
+		mod:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	ws := doc.NewWorkspace(store)
+	ws.SetExternalFileProbe(ext)
+	d, err := ws.Add(doc.Part, path, true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := d.Attachments().Add("loads", types.AttachmentLinked, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add linked: %v", err)
+	}
+	if _, err := d.Attachments().Add("table", types.AttachmentEmbedded, "/data/loads.csv"); err != nil {
+		t.Fatalf("Add embedded: %v", err)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	ws2 := doc.NewWorkspace(store)
+	ws2.SetExternalFileProbe(ext)
+	reopened, err := ws2.Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got := reopened.Attachments().Names(); len(got) != 2 || got[0] != "loads" || got[1] != "table" {
+		t.Fatalf("reloaded names = %v, want [loads table] in order", got)
+	}
+	linked := reopened.Attachments().Record("loads")
+	if linked.Kind() != types.AttachmentLinked || !linked.LastKnownFileTime().Equal(ext.mod) {
+		t.Errorf("linked = (%v, %v), want the recorded link", linked.Kind(), linked.LastKnownFileTime())
+	}
+	if linked.Status() != types.ReferenceUpToDate {
+		t.Errorf("linked status = %v, want upToDate against the unchanged foreign file", linked.Status())
+	}
+	embedded := reopened.Attachments().Record("table")
+	if string(embedded.Payload()) != "f1,f2\n1,2\n" || embedded.ResourceID() == "" {
+		t.Errorf("embedded payload = %q (resource %q), want the bytes carried in the .obk",
+			embedded.Payload(), embedded.ResourceID())
+	}
+}

--- a/persistence/file_identity_test.go
+++ b/persistence/file_identity_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"oblikovati.org/model/doc"
+)
+
+// TestFileIdentityRoundTripsThroughPackage: the identity block persists in the
+// .obk and survives a reload in a fresh workspace; a further save continues
+// the counter instead of restarting it (M03-F07, #159).
+func TestFileIdentityRoundTripsThroughPackage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bracket.obk")
+	store := NewPackageStore()
+
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, path, true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	saved := d.FileIdentity()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(raw), "internalName: "+saved.InternalName) {
+		t.Errorf("the .obk must carry the identity block; got:\n%s", raw)
+	}
+
+	ws2 := doc.NewWorkspace(store)
+	reopened, err := ws2.Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got := reopened.FileIdentity()
+	if got.InternalName != saved.InternalName || got.SaveCounter != 1 {
+		t.Fatalf("reloaded identity = %+v, want the persisted %+v", got, saved)
+	}
+	if err := ws2.Save(reopened); err != nil {
+		t.Fatalf("Save after reload: %v", err)
+	}
+	if next := reopened.FileIdentity(); next.SaveCounter != 2 || next.InternalName != saved.InternalName {
+		t.Errorf("identity after reload+save = %+v, want counter 2 under the same GUID", next)
+	}
+}
+
+// TestFileReferencesRoundTripThroughPackage: as-saved reference records reload
+// with the owner so a file whose targets vanished still reports what it tried
+// to reference (M03-F07).
+func TestFileReferencesRoundTripThroughPackage(t *testing.T) {
+	dir := t.TempDir()
+	store := NewPackageStore()
+	ws := doc.NewWorkspace(store)
+	part, err := ws.Add(doc.Part, filepath.Join(dir, "pin.obk"), true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	if err := ws.Save(part); err != nil {
+		t.Fatalf("Save part: %v", err)
+	}
+	owner, err := ws.Add(doc.Assembly, filepath.Join(dir, "frame.obk"), true)
+	if err != nil {
+		t.Fatalf("Add owner: %v", err)
+	}
+	if _, err := owner.AddReference(part.FullDocumentName()); err != nil {
+		t.Fatalf("AddReference: %v", err)
+	}
+	if err := ws.Save(owner); err != nil {
+		t.Fatalf("Save owner: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(owner.FullFileName(), true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	refs := reopened.FileReferences()
+	if len(refs) != 1 || refs[0].FullFileName() != part.FullFileName() {
+		t.Fatalf("reloaded references = %+v, want the pin record", refs)
+	}
+	if refs[0].RelativeFileName() != "pin.obk" {
+		t.Errorf("relative name = %q, want pin.obk", refs[0].RelativeFileName())
+	}
+	if refs[0].ReferencedFileInternalName() != part.FileIdentity().InternalName {
+		t.Errorf("recorded target GUID = %q, want %q",
+			refs[0].ReferencedFileInternalName(), part.FileIdentity().InternalName)
+	}
+
+}
+
+// TestResaveWithoutLiveEdgesKeepsReferenceRecords: the reference graph is
+// rebuilt lazily after a load, so saving a freshly reopened owner must keep
+// the persisted records rather than wiping them.
+func TestResaveWithoutLiveEdgesKeepsReferenceRecords(t *testing.T) {
+	dir := t.TempDir()
+	store := NewPackageStore()
+	ws := doc.NewWorkspace(store)
+	part, _ := ws.Add(doc.Part, filepath.Join(dir, "pin.obk"), true)
+	if err := ws.Save(part); err != nil {
+		t.Fatalf("Save part: %v", err)
+	}
+	owner, _ := ws.Add(doc.Assembly, filepath.Join(dir, "frame.obk"), true)
+	if _, err := owner.AddReference(part.FullDocumentName()); err != nil {
+		t.Fatalf("AddReference: %v", err)
+	}
+	if err := ws.Save(owner); err != nil {
+		t.Fatalf("Save owner: %v", err)
+	}
+
+	ws2 := doc.NewWorkspace(store)
+	reopened, err := ws2.Open(owner.FullFileName(), true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := ws2.Save(reopened); err != nil {
+		t.Fatalf("re-Save: %v", err)
+	}
+	if refs := reopened.FileReferences(); len(refs) != 1 {
+		t.Fatalf("references after edge-less re-save = %d, want the record kept", len(refs))
+	}
+}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -50,6 +50,8 @@ func (p *Package) marshal() ([]byte, error) {
 		DocumentType:  p.manifest.DocumentType,
 		SubType:       p.manifest.SubType,
 		DisplayName:   p.manifest.DisplayName,
+		Identity:      p.identity,
+		References:    p.references,
 		Model:         p.model,
 		Data:          p.streams,
 		Resources:     p.resources,
@@ -73,6 +75,8 @@ func decode(raw []byte) (*Package, error) {
 	}
 	p.model = doc.Model
 	p.resources = doc.Resources
+	p.identity = doc.Identity
+	p.references = doc.References
 	for name, data := range doc.Data {
 		p.WriteStream(name, data)
 	}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -52,6 +52,8 @@ func (p *Package) marshal() ([]byte, error) {
 		DisplayName:   p.manifest.DisplayName,
 		Identity:      p.identity,
 		References:    p.references,
+		Attachments:   p.attachments,
+		Interests:     p.interests,
 		Model:         p.model,
 		Data:          p.streams,
 		Resources:     p.resources,
@@ -77,6 +79,8 @@ func decode(raw []byte) (*Package, error) {
 	p.resources = doc.Resources
 	p.identity = doc.Identity
 	p.references = doc.References
+	p.attachments = doc.Attachments
+	p.interests = doc.Interests
 	for name, data := range doc.Data {
 		p.WriteStream(name, data)
 	}

--- a/persistence/old_versions.go
+++ b/persistence/old_versions.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Old-version retention (M03-F09, #610): when enabled, every save first copies
+// the prior file into an OldVersions sibling directory — <name>.<n>.obk with
+// .1 the most recent — pruned to the configured count. The prior file is
+// COPIED, never moved, so an interrupted save still leaves the original
+// untouched (the atomic-save guarantee is preserved).
+
+// retainOldVersion archives the current file at path before it is overwritten,
+// keeping at most keep prior versions. keep<=0 disables retention; a missing
+// prior file (first save) is a no-op.
+func retainOldVersion(path string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	prior, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	dir := filepath.Join(filepath.Dir(path), "OldVersions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if err := rotateOldVersions(dir, filepath.Base(path), keep); err != nil {
+		return err
+	}
+	return os.WriteFile(oldVersionPath(dir, filepath.Base(path), 1), prior, 0o644)
+}
+
+// rotateOldVersions shifts <name>.<n>.obk up by one and prunes beyond keep.
+func rotateOldVersions(dir, base string, keep int) error {
+	_ = os.Remove(oldVersionPath(dir, base, keep)) // the oldest retained slot falls off
+	for n := keep - 1; n >= 1; n-- {
+		from, to := oldVersionPath(dir, base, n), oldVersionPath(dir, base, n+1)
+		if _, err := os.Stat(from); err != nil {
+			continue
+		}
+		if err := os.Rename(from, to); err != nil {
+			return fmt.Errorf("rotate %q: %w", from, err)
+		}
+	}
+	return nil
+}
+
+// oldVersionPath names one retained version: <dir>/<stem>.<n>.obk.
+func oldVersionPath(dir, base string, n int) string {
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	return filepath.Join(dir, fmt.Sprintf("%s.%d%s", stem, n, filepath.Ext(base)))
+}

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -25,17 +25,31 @@ type StreamStat struct {
 // file (ADR-0020). Stream bytes are copied in and out so a Package never shares
 // backing arrays with its callers.
 type Package struct {
-	manifest  Manifest                      // identity; the zero value means "no manifest"
-	model     []byte                        // recipe YAML bytes; nil ⇒ no model
-	streams   map[string][]byte             // named binary data sections
-	order     []string                      // data-section insertion order, for stable enumeration
-	resources map[string]yamlcodec.Resource // embedded imported files, keyed by UUID (ADR-0031)
+	manifest   Manifest                      // identity; the zero value means "no manifest"
+	model      []byte                        // recipe YAML bytes; nil ⇒ no model
+	streams    map[string][]byte             // named binary data sections
+	order      []string                      // data-section insertion order, for stable enumeration
+	resources  map[string]yamlcodec.Resource // embedded imported files, keyed by UUID (ADR-0031)
+	identity   *yamlcodec.FileIdentityRecord // file identity block (M03-F07, #159); nil pre-identity
+	references []yamlcodec.FileReferenceRecord
 }
 
 // NewPackage returns an empty package.
 func NewPackage() *Package {
 	return &Package{streams: map[string][]byte{}}
 }
+
+// SetIdentity stores the file identity block (M03-F07, #159).
+func (p *Package) SetIdentity(id *yamlcodec.FileIdentityRecord) { p.identity = id }
+
+// Identity returns the file identity block, nil for a pre-identity file.
+func (p *Package) Identity() *yamlcodec.FileIdentityRecord { return p.identity }
+
+// SetFileReferences stores the as-saved file-to-file reference records (M03-F07).
+func (p *Package) SetFileReferences(refs []yamlcodec.FileReferenceRecord) { p.references = refs }
+
+// FileReferences returns the as-saved file-to-file reference records.
+func (p *Package) FileReferences() []yamlcodec.FileReferenceRecord { return p.references }
 
 // SetResources stores the document's embedded resource table (ADR-0031), keyed by UUID.
 func (p *Package) SetResources(r map[string]yamlcodec.Resource) { p.resources = r }

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -25,13 +25,15 @@ type StreamStat struct {
 // file (ADR-0020). Stream bytes are copied in and out so a Package never shares
 // backing arrays with its callers.
 type Package struct {
-	manifest   Manifest                      // identity; the zero value means "no manifest"
-	model      []byte                        // recipe YAML bytes; nil ⇒ no model
-	streams    map[string][]byte             // named binary data sections
-	order      []string                      // data-section insertion order, for stable enumeration
-	resources  map[string]yamlcodec.Resource // embedded imported files, keyed by UUID (ADR-0031)
-	identity   *yamlcodec.FileIdentityRecord // file identity block (M03-F07, #159); nil pre-identity
-	references []yamlcodec.FileReferenceRecord
+	manifest    Manifest                      // identity; the zero value means "no manifest"
+	model       []byte                        // recipe YAML bytes; nil ⇒ no model
+	streams     map[string][]byte             // named binary data sections
+	order       []string                      // data-section insertion order, for stable enumeration
+	resources   map[string]yamlcodec.Resource // embedded imported files, keyed by UUID (ADR-0031)
+	identity    *yamlcodec.FileIdentityRecord // file identity block (M03-F07, #159); nil pre-identity
+	references  []yamlcodec.FileReferenceRecord
+	attachments []yamlcodec.AttachmentRecord // external-file attachments (M03-F08)
+	interests   []yamlcodec.InterestRecord   // add-in data registry (M03-F10)
 }
 
 // NewPackage returns an empty package.
@@ -50,6 +52,18 @@ func (p *Package) SetFileReferences(refs []yamlcodec.FileReferenceRecord) { p.re
 
 // FileReferences returns the as-saved file-to-file reference records.
 func (p *Package) FileReferences() []yamlcodec.FileReferenceRecord { return p.references }
+
+// SetAttachments stores the external-file attachment records (M03-F08).
+func (p *Package) SetAttachments(a []yamlcodec.AttachmentRecord) { p.attachments = a }
+
+// Attachments returns the external-file attachment records.
+func (p *Package) Attachments() []yamlcodec.AttachmentRecord { return p.attachments }
+
+// SetInterests stores the add-in data-registry records (M03-F10).
+func (p *Package) SetInterests(i []yamlcodec.InterestRecord) { p.interests = i }
+
+// Interests returns the add-in data-registry records.
+func (p *Package) Interests() []yamlcodec.InterestRecord { return p.interests }
 
 // SetResources stores the document's embedded resource table (ADR-0031), keyed by UUID.
 func (p *Package) SetResources(r map[string]yamlcodec.Resource) { p.resources = r }

--- a/persistence/save_copy_test.go
+++ b/persistence/save_copy_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/model/doc"
+)
+
+// TestSaveCopyMintsAFreshFile: the copy carries the source content under a NEW
+// identity, while the source keeps its binding, dirty state and identity
+// (M03-F09, #610).
+func TestSaveCopyMintsAFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	store := NewPackageStore()
+	ws := doc.NewWorkspace(store)
+	src, err := ws.Add(doc.Part, filepath.Join(dir, "bracket.obk"), true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := ws.Save(src); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	src.MarkDirty()
+
+	target := filepath.Join(dir, "bracket-rev3.obk")
+	if err := ws.SaveCopy(src, target, doc.CopyMetadata{DisplayName: "Bracket rev3"}); err != nil {
+		t.Fatalf("SaveCopy: %v", err)
+	}
+	if src.FullFileName() != filepath.Join(dir, "bracket.obk") || !src.Dirty() {
+		t.Error("the source must keep its binding and dirty state")
+	}
+
+	copyDoc, err := doc.NewWorkspace(store).Open(target, true)
+	if err != nil {
+		t.Fatalf("Open copy: %v", err)
+	}
+	if copyDoc.DisplayName() != "Bracket rev3" {
+		t.Errorf("copy display name = %q, want the override", copyDoc.DisplayName())
+	}
+	srcID, copyID := src.FileIdentity(), copyDoc.FileIdentity()
+	if copyID.InternalName == srcID.InternalName || copyID.InternalName == "" {
+		t.Errorf("copy internal name = %q, want a fresh GUID (source %q)", copyID.InternalName, srcID.InternalName)
+	}
+	if copyID.DatabaseRevisionID != srcID.DatabaseRevisionID {
+		t.Errorf("copy database revision = %q, want the source's %q (same model)",
+			copyID.DatabaseRevisionID, srcID.DatabaseRevisionID)
+	}
+
+	if err := ws.SaveCopy(src, src.FullFileName(), doc.CopyMetadata{}); err == nil {
+		t.Error("copying onto the source path must fail")
+	}
+}
+
+// TestSaveRetainsOldVersions: with retention on, each save archives the prior
+// file as OldVersions/<name>.<n>.obk (.1 newest), pruned to the count.
+func TestSaveRetainsOldVersions(t *testing.T) {
+	dir := t.TempDir()
+	store := NewPackageStore()
+	store.SetOldVersionsToKeep(2)
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, filepath.Join(dir, "bracket.obk"), true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	for range [4]int{} {
+		if err := ws.Save(d); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	old := filepath.Join(dir, "OldVersions")
+	entries, err := os.ReadDir(old)
+	if err != nil {
+		t.Fatalf("ReadDir(OldVersions): %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("retained %d versions, want pruned to 2: %v", len(entries), entries)
+	}
+	for _, name := range []string{"bracket.1.obk", "bracket.2.obk"} {
+		if _, err := os.Stat(filepath.Join(old, name)); err != nil {
+			t.Errorf("missing retained version %s: %v", name, err)
+		}
+	}
+	// .1 must be the most recent prior version: it carries save counter 3 (the
+	// state just before the 4th save).
+	pkg, err := OpenPackage(filepath.Join(old, "bracket.1.obk"))
+	if err != nil {
+		t.Fatalf("open retained version: %v", err)
+	}
+	if id := pkg.Identity(); id == nil || id.SaveCounter != 3 {
+		t.Errorf("OldVersions/.1 identity = %+v, want save counter 3", pkg.Identity())
+	}
+}

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -32,7 +32,7 @@ func (s *PackageStore) Save(d *doc.Document) error {
 	manifest := Manifest{
 		SchemaVersion: CurrentSchemaVersion,
 		DocumentType:  uint32(d.DocumentType()),
-		SubType:       d.SubType(),
+		SubType:       string(d.SubType()),
 		DisplayName:   d.DisplayName(),
 	}
 	if err := pkg.SetManifest(manifest); err != nil {
@@ -66,7 +66,7 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.SetSubType(manifest.SubType) // restore the add-in flavor (M05-F15)
+	d.SetSubType(doc.SubTypeID(manifest.SubType)) // restore the flavor (M05-F15)
 	// Resources must be restored BEFORE the recipe is applied, so a feature that re-derives
 	// geometry from an embedded resource (e.g. an imported body) can read its bytes (ADR-0031).
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -17,7 +17,9 @@ import (
 // package whose manifest carries the document kind and display name. The richer
 // model streams (parameters, features, sketches) join the manifest once that data
 // exists on the content objects (M07+); today the manifest is the persisted recipe.
-type PackageStore struct{}
+type PackageStore struct {
+	oldVersionsToKeep int // prior versions retained in OldVersions/ on save; 0 = off (M03-F09)
+}
 
 // NewPackageStore returns a store that reads and writes .obk packages.
 func NewPackageStore() *PackageStore {
@@ -26,35 +28,73 @@ func NewPackageStore() *PackageStore {
 
 var _ doc.Store = (*PackageStore)(nil)
 
+// SetOldVersionsToKeep configures save-time retention: the prior file moves
+// into an OldVersions sibling directory, pruned to count (M03-F09, #610).
+func (s *PackageStore) SetOldVersionsToKeep(count int) { s.oldVersionsToKeep = count }
+
+// OldVersionsToKeep returns the retention count, 0 when retention is off.
+func (s *PackageStore) OldVersionsToKeep() int { return s.oldVersionsToKeep }
+
 // Save writes the document's manifest and — when its content carries a recipe — the
 // model recipe into a fresh package, and saves it atomically at the document's file
 // name. The realized geometry is never written; it is recomputed on open (ADR-0020).
 func (s *PackageStore) Save(d *doc.Document) error {
+	pkg, err := s.buildPackage(d, d.DisplayName(), string(d.SubType()), d.FileIdentity())
+	if err != nil {
+		return err
+	}
+	if err := retainOldVersion(d.FullFileName(), s.oldVersionsToKeep); err != nil {
+		return fmt.Errorf("persistence: retain old version of %q: %w", d.FullFileName(), err)
+	}
+	return pkg.Save(d.FullFileName())
+}
+
+// SaveCopy writes a copy of the document at targetFullFileName: same content,
+// fresh file identity (two files must never share an internal name), with
+// optional display-name/subtype overrides (M03-F09).
+func (s *PackageStore) SaveCopy(d *doc.Document, targetFullFileName string, meta doc.CopyMetadata) error {
+	displayName, subType := d.DisplayName(), string(d.SubType())
+	if meta.DisplayName != "" {
+		displayName = meta.DisplayName
+	}
+	if meta.SubType != "" {
+		subType = string(meta.SubType)
+	}
+	pkg, err := s.buildPackage(d, displayName, subType, doc.CopyIdentity(d.FileIdentity()))
+	if err != nil {
+		return err
+	}
+	return pkg.Save(targetFullFileName)
+}
+
+// buildPackage renders the document into a fresh package under the given
+// manifest fields and identity.
+func (s *PackageStore) buildPackage(d *doc.Document, displayName, subType string, identity doc.FileIdentity) (*Package, error) {
 	pkg := NewPackage()
 	manifest := Manifest{
 		SchemaVersion: CurrentSchemaVersion,
 		DocumentType:  uint32(d.DocumentType()),
-		SubType:       string(d.SubType()),
-		DisplayName:   d.DisplayName(),
+		SubType:       subType,
+		DisplayName:   displayName,
 	}
 	if err := pkg.SetManifest(manifest); err != nil {
-		return err
+		return nil, err
 	}
-	pkg.SetIdentity(toCodecIdentity(d.FileIdentity()))
+	pkg.SetIdentity(toCodecIdentity(identity))
 	pkg.SetFileReferences(toCodecFileReferences(d.FileReferenceRecords()))
 	pkg.SetAttachments(toCodecAttachments(d.AttachmentRecords()))
 	pkg.SetInterests(toCodecInterests(d.InterestRecords()))
 	if rc, ok := d.Content().(doc.RecipeContent); ok {
 		model, err := rc.MarshalRecipe()
 		if err != nil {
-			return fmt.Errorf("persistence: save %q: marshal recipe: %w", d.FullFileName(), err)
+			return nil, fmt.Errorf("persistence: save %q: marshal recipe: %w", d.FullFileName(), err)
 		}
 		pkg.SetModelYAML(model)
 	}
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {
 		pkg.SetResources(toCodecResources(rb.Resources()))
 	}
-	return pkg.Save(d.FullFileName())
+	return pkg, nil
 }
 
 // Load opens the package at fullDocumentName, migrates it, and reconstructs the
@@ -81,16 +121,27 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {
 		rb.SetResources(fromCodecResources(pkg.Resources()))
 	}
-	if model, ok := pkg.ModelYAML(); ok {
-		rc, ok := d.Content().(doc.RecipeContent)
-		if !ok {
-			return nil, fmt.Errorf("persistence: load %q: file has a model recipe but %v content cannot restore it (is its package imported?)", fullDocumentName, d.DocumentType())
-		}
-		if err := rc.ApplyRecipe(model); err != nil {
-			return nil, fmt.Errorf("persistence: load %q: %w", fullDocumentName, err)
-		}
+	if err := applyModelRecipe(d, pkg, fullDocumentName); err != nil {
+		return nil, err
 	}
 	return d, nil
+}
+
+// applyModelRecipe replays the persisted recipe into the document's content,
+// failing loud when the content kind cannot restore one.
+func applyModelRecipe(d *doc.Document, pkg *Package, fullDocumentName string) error {
+	model, ok := pkg.ModelYAML()
+	if !ok {
+		return nil
+	}
+	rc, ok := d.Content().(doc.RecipeContent)
+	if !ok {
+		return fmt.Errorf("persistence: load %q: file has a model recipe but %v content cannot restore it (is its package imported?)", fullDocumentName, d.DocumentType())
+	}
+	if err := rc.ApplyRecipe(model); err != nil {
+		return fmt.Errorf("persistence: load %q: %w", fullDocumentName, err)
+	}
+	return nil
 }
 
 // restoreIdentity puts the persisted identity block, reference records and

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -38,6 +38,8 @@ func (s *PackageStore) Save(d *doc.Document) error {
 	if err := pkg.SetManifest(manifest); err != nil {
 		return err
 	}
+	pkg.SetIdentity(toCodecIdentity(d.FileIdentity()))
+	pkg.SetFileReferences(toCodecFileReferences(d.FileReferenceRecords()))
 	if rc, ok := d.Content().(doc.RecipeContent); ok {
 		model, err := rc.MarshalRecipe()
 		if err != nil {
@@ -67,6 +69,7 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 		return nil, err
 	}
 	d.SetSubType(doc.SubTypeID(manifest.SubType)) // restore the flavor (M05-F15)
+	restoreIdentity(d, pkg)
 	// Resources must be restored BEFORE the recipe is applied, so a feature that re-derives
 	// geometry from an embedded resource (e.g. an imported body) can read its bytes (ADR-0031).
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {
@@ -82,6 +85,57 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 		}
 	}
 	return d, nil
+}
+
+// restoreIdentity puts the persisted identity block and reference records back
+// on the document (M03-F07). A pre-identity file keeps the freshly minted
+// identity, persisting it on its next save.
+func restoreIdentity(d *doc.Document, pkg *Package) {
+	if id := pkg.Identity(); id != nil {
+		d.SetFileIdentity(doc.FileIdentity{
+			InternalName: id.InternalName, RevisionID: id.RevisionID,
+			DatabaseRevisionID: id.DatabaseRevisionID, SaveCounter: id.SaveCounter,
+			VersionCreated: id.VersionCreated, VersionSaved: id.VersionSaved,
+			ModelDigest: id.ModelDigest,
+		})
+	}
+	d.SetFileReferenceRecords(fromCodecFileReferences(pkg.FileReferences()))
+}
+
+// toCodecIdentity renders the document identity for the on-disk shape.
+func toCodecIdentity(id doc.FileIdentity) *yamlcodec.FileIdentityRecord {
+	return &yamlcodec.FileIdentityRecord{
+		InternalName: id.InternalName, RevisionID: id.RevisionID,
+		DatabaseRevisionID: id.DatabaseRevisionID, SaveCounter: id.SaveCounter,
+		VersionCreated: id.VersionCreated, VersionSaved: id.VersionSaved,
+		ModelDigest: id.ModelDigest,
+	}
+}
+
+// toCodecFileReferences / fromCodecFileReferences bridge the reference records
+// across the doc/persistence seam (fields identical, layers decoupled).
+func toCodecFileReferences(in []doc.FileReferenceRecord) []yamlcodec.FileReferenceRecord {
+	out := make([]yamlcodec.FileReferenceRecord, len(in))
+	for i, r := range in {
+		out[i] = yamlcodec.FileReferenceRecord{
+			FullFileName: r.FullFileName, RelativeFileName: r.RelativeFileName,
+			LibraryName: r.LibraryName, LocationType: r.LocationType,
+			ReferencedInternalName: r.ReferencedInternalName, SaveCounter: r.SaveCounter,
+		}
+	}
+	return out
+}
+
+func fromCodecFileReferences(in []yamlcodec.FileReferenceRecord) []doc.FileReferenceRecord {
+	out := make([]doc.FileReferenceRecord, len(in))
+	for i, r := range in {
+		out[i] = doc.FileReferenceRecord{
+			FullFileName: r.FullFileName, RelativeFileName: r.RelativeFileName,
+			LibraryName: r.LibraryName, LocationType: r.LocationType,
+			ReferencedInternalName: r.ReferencedInternalName, SaveCounter: r.SaveCounter,
+		}
+	}
+	return out
 }
 
 // toCodecResources / fromCodecResources bridge the document-layer resource table (doc.Resource)

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence/yamlcodec"
 )
@@ -42,6 +43,7 @@ func (s *PackageStore) Save(d *doc.Document) error {
 	pkg.SetIdentity(toCodecIdentity(d.FileIdentity()))
 	pkg.SetFileReferences(toCodecFileReferences(d.FileReferenceRecords()))
 	pkg.SetAttachments(toCodecAttachments(d.AttachmentRecords()))
+	pkg.SetInterests(toCodecInterests(d.InterestRecords()))
 	if rc, ok := d.Content().(doc.RecipeContent); ok {
 		model, err := rc.MarshalRecipe()
 		if err != nil {
@@ -109,7 +111,36 @@ func restoreIdentity(d *doc.Document, pkg *Package) error {
 		return err
 	}
 	d.SetAttachmentRecords(recs)
+	d.SetInterestRecords(fromCodecInterests(pkg.Interests()))
 	return nil
+}
+
+// toCodecInterests / fromCodecInterests bridge the interest registry across
+// the doc/persistence seam; the interest type persists as its wire spelling.
+func toCodecInterests(in []types.DocumentInterestRecord) []yamlcodec.InterestRecord {
+	out := make([]yamlcodec.InterestRecord, len(in))
+	for i, r := range in {
+		out[i] = yamlcodec.InterestRecord{
+			ClientID: r.ClientID, Name: r.Name, InterestType: r.InterestType.String(),
+			DataVersion: r.DataVersion, ClientData: r.ClientData,
+		}
+	}
+	return out
+}
+
+func fromCodecInterests(in []yamlcodec.InterestRecord) []types.DocumentInterestRecord {
+	out := make([]types.DocumentInterestRecord, len(in))
+	for i, r := range in {
+		t, ok := types.ParseDocumentInterestType(r.InterestType)
+		if !ok {
+			t = types.Interested
+		}
+		out[i] = types.DocumentInterestRecord{
+			ClientID: r.ClientID, Name: r.Name, InterestType: t,
+			DataVersion: r.DataVersion, ClientData: r.ClientData,
+		}
+	}
+	return out
 }
 
 // toCodecAttachments / fromCodecAttachments bridge attachment records across

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -3,6 +3,7 @@
 package persistence
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 
@@ -40,6 +41,7 @@ func (s *PackageStore) Save(d *doc.Document) error {
 	}
 	pkg.SetIdentity(toCodecIdentity(d.FileIdentity()))
 	pkg.SetFileReferences(toCodecFileReferences(d.FileReferenceRecords()))
+	pkg.SetAttachments(toCodecAttachments(d.AttachmentRecords()))
 	if rc, ok := d.Content().(doc.RecipeContent); ok {
 		model, err := rc.MarshalRecipe()
 		if err != nil {
@@ -69,7 +71,9 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 		return nil, err
 	}
 	d.SetSubType(doc.SubTypeID(manifest.SubType)) // restore the flavor (M05-F15)
-	restoreIdentity(d, pkg)
+	if err := restoreIdentity(d, pkg); err != nil {
+		return nil, fmt.Errorf("persistence: load %q: %w", fullDocumentName, err)
+	}
 	// Resources must be restored BEFORE the recipe is applied, so a feature that re-derives
 	// geometry from an embedded resource (e.g. an imported body) can read its bytes (ADR-0031).
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {
@@ -87,10 +91,10 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	return d, nil
 }
 
-// restoreIdentity puts the persisted identity block and reference records back
-// on the document (M03-F07). A pre-identity file keeps the freshly minted
-// identity, persisting it on its next save.
-func restoreIdentity(d *doc.Document, pkg *Package) {
+// restoreIdentity puts the persisted identity block, reference records and
+// attachments back on the document (M03-F07/F08). A pre-identity file keeps
+// the freshly minted identity, persisting it on its next save.
+func restoreIdentity(d *doc.Document, pkg *Package) error {
 	if id := pkg.Identity(); id != nil {
 		d.SetFileIdentity(doc.FileIdentity{
 			InternalName: id.InternalName, RevisionID: id.RevisionID,
@@ -100,6 +104,43 @@ func restoreIdentity(d *doc.Document, pkg *Package) {
 		})
 	}
 	d.SetFileReferenceRecords(fromCodecFileReferences(pkg.FileReferences()))
+	recs, err := fromCodecAttachments(pkg.Attachments())
+	if err != nil {
+		return err
+	}
+	d.SetAttachmentRecords(recs)
+	return nil
+}
+
+// toCodecAttachments / fromCodecAttachments bridge attachment records across
+// the doc/persistence seam; the embedded payload travels base64 on disk (the
+// same concession as data sections, ADR-0020).
+func toCodecAttachments(in []doc.FileAttachmentRecord) []yamlcodec.AttachmentRecord {
+	out := make([]yamlcodec.AttachmentRecord, len(in))
+	for i, a := range in {
+		out[i] = yamlcodec.AttachmentRecord{
+			Name: a.Name, Kind: a.Kind, FullFileName: a.FullFileName,
+			ResourceID: a.ResourceID, Payload: base64.StdEncoding.EncodeToString(a.Payload),
+			LastKnownFileTime: a.LastKnownFileTime, BrowserVisible: a.BrowserVisible,
+		}
+	}
+	return out
+}
+
+func fromCodecAttachments(in []yamlcodec.AttachmentRecord) ([]doc.FileAttachmentRecord, error) {
+	out := make([]doc.FileAttachmentRecord, len(in))
+	for i, a := range in {
+		payload, err := base64.StdEncoding.DecodeString(a.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("persistence: attachment %q payload is not valid base64: %w", a.Name, err)
+		}
+		out[i] = doc.FileAttachmentRecord{
+			Name: a.Name, Kind: a.Kind, FullFileName: a.FullFileName,
+			ResourceID: a.ResourceID, Payload: payload,
+			LastKnownFileTime: a.LastKnownFileTime, BrowserVisible: a.BrowserVisible,
+		}
+	}
+	return out, nil
 }
 
 // toCodecIdentity renders the document identity for the on-disk shape.

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -40,18 +40,48 @@ type Document struct {
 	// Resources is the root resource table (ADR-0031): imported files embedded in the
 	// document, keyed by a per-import UUID and referenced from the recipe by that key.
 	Resources map[string]Resource
+	// Identity is the file identity block (M03-F07, #159); nil for pre-identity files.
+	Identity *FileIdentityRecord
+	// References are the as-saved file-to-file reference records (M03-F07).
+	References []FileReferenceRecord
+}
+
+// FileIdentityRecord is the on-disk file identity block: the stable GUID plus
+// the revision stamps a referencing file compares against (M03-F07, #159).
+type FileIdentityRecord struct {
+	InternalName       string `yaml:"internalName,omitempty"`
+	RevisionID         string `yaml:"revisionId,omitempty"`
+	DatabaseRevisionID string `yaml:"databaseRevisionId,omitempty"`
+	SaveCounter        int    `yaml:"saveCounter,omitempty"`
+	VersionCreated     string `yaml:"versionCreated,omitempty"`
+	VersionSaved       string `yaml:"versionSaved,omitempty"`
+	ModelDigest        string `yaml:"modelDigest,omitempty"`
+}
+
+// FileReferenceRecord is one as-saved file-to-file reference: the logical
+// names, the location class (a wire spelling, readable in the file), and the
+// referenced file's identity at save time (M03-F07).
+type FileReferenceRecord struct {
+	FullFileName           string `yaml:"fullFileName"`
+	RelativeFileName       string `yaml:"relativeFileName,omitempty"`
+	LibraryName            string `yaml:"libraryName,omitempty"`
+	LocationType           string `yaml:"locationType,omitempty"`
+	ReferencedInternalName string `yaml:"referencedInternalName,omitempty"`
+	SaveCounter            int    `yaml:"saveCounter,omitempty"`
 }
 
 // onDisk is the YAML projection of a Document: manifest at top level, recipe as a
 // native node, data sections base64-encoded. omitempty keeps a minimal file readable.
 type onDisk struct {
-	SchemaVersion int               `yaml:"schemaVersion,omitempty"`
-	DocumentType  uint32            `yaml:"documentType,omitempty"`
-	SubType       string            `yaml:"subType,omitempty"`
-	DisplayName   string            `yaml:"displayName,omitempty"`
-	Resources     yaml.Node         `yaml:"resources,omitempty"`
-	Model         yaml.Node         `yaml:"model,omitempty"`
-	Data          map[string]string `yaml:"data,omitempty"`
+	SchemaVersion int                   `yaml:"schemaVersion,omitempty"`
+	DocumentType  uint32                `yaml:"documentType,omitempty"`
+	SubType       string                `yaml:"subType,omitempty"`
+	DisplayName   string                `yaml:"displayName,omitempty"`
+	Identity      *FileIdentityRecord   `yaml:"identity,omitempty"`
+	References    []FileReferenceRecord `yaml:"references,omitempty"`
+	Resources     yaml.Node             `yaml:"resources,omitempty"`
+	Model         yaml.Node             `yaml:"model,omitempty"`
+	Data          map[string]string     `yaml:"data,omitempty"`
 }
 
 // MarshalDocument renders d as the on-disk YAML file. The recipe bytes are parsed and
@@ -62,6 +92,8 @@ func MarshalDocument(d Document) ([]byte, error) {
 		DocumentType:  d.DocumentType,
 		SubType:       d.SubType,
 		DisplayName:   d.DisplayName,
+		Identity:      d.Identity,
+		References:    d.References,
 	}
 	if len(d.Resources) > 0 {
 		node, err := resourcesNode(d.Resources)
@@ -124,6 +156,8 @@ func documentHeader(od onDisk) Document {
 		DocumentType:  od.DocumentType,
 		SubType:       od.SubType,
 		DisplayName:   od.DisplayName,
+		Identity:      od.Identity,
+		References:    od.References,
 	}
 }
 

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -126,19 +126,8 @@ func MarshalDocument(d Document) ([]byte, error) {
 		Attachments:   d.Attachments,
 		Interests:     d.Interests,
 	}
-	if len(d.Resources) > 0 {
-		node, err := resourcesNode(d.Resources)
-		if err != nil {
-			return nil, err
-		}
-		od.Resources = *node
-	}
-	if len(d.Model) > 0 {
-		node, err := modelNode(d.Model)
-		if err != nil {
-			return nil, err
-		}
-		od.Model = *node
+	if err := embedNativeNodes(&od, d); err != nil {
+		return nil, err
 	}
 	if len(d.Data) > 0 {
 		od.Data = make(map[string]string, len(d.Data))
@@ -147,6 +136,26 @@ func MarshalDocument(d Document) ([]byte, error) {
 		}
 	}
 	return yaml.Marshal(od)
+}
+
+// embedNativeNodes parses the resource table and the recipe into native YAML
+// nodes so both read as real nested YAML on disk, not escaped strings.
+func embedNativeNodes(od *onDisk, d Document) error {
+	if len(d.Resources) > 0 {
+		node, err := resourcesNode(d.Resources)
+		if err != nil {
+			return err
+		}
+		od.Resources = *node
+	}
+	if len(d.Model) > 0 {
+		node, err := modelNode(d.Model)
+		if err != nil {
+			return err
+		}
+		od.Model = *node
+	}
+	return nil
 }
 
 // UnmarshalDocument decodes a .obk file's bytes. It rejects a legacy ZIP package with

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -44,6 +44,10 @@ type Document struct {
 	Identity *FileIdentityRecord
 	// References are the as-saved file-to-file reference records (M03-F07).
 	References []FileReferenceRecord
+	// Attachments are the external-file attachment records (M03-F08).
+	Attachments []AttachmentRecord
+	// Interests are the add-in data registry records (M03-F10).
+	Interests []InterestRecord
 }
 
 // FileIdentityRecord is the on-disk file identity block: the stable GUID plus
@@ -70,6 +74,29 @@ type FileReferenceRecord struct {
 	SaveCounter            int    `yaml:"saveCounter,omitempty"`
 }
 
+// AttachmentRecord is one external-file attachment (M03-F08): a named link to
+// a foreign file, with an embedded payload carried base64 (the same concession
+// as data sections, ADR-0020).
+type AttachmentRecord struct {
+	Name              string `yaml:"name"`
+	Kind              string `yaml:"kind"`
+	FullFileName      string `yaml:"fullFileName,omitempty"`
+	ResourceID        string `yaml:"resourceId,omitempty"`
+	Payload           string `yaml:"payload,omitempty"` // base64
+	LastKnownFileTime string `yaml:"lastKnownFileTime,omitempty"`
+	BrowserVisible    bool   `yaml:"browserVisible,omitempty"`
+}
+
+// InterestRecord is one add-in data-registry entry (M03-F10): client X has
+// data in / depends on this document, readable without loading the add-in.
+type InterestRecord struct {
+	ClientID     string `yaml:"clientId"`
+	Name         string `yaml:"name"`
+	InterestType string `yaml:"interestType,omitempty"`
+	DataVersion  int    `yaml:"dataVersion,omitempty"`
+	ClientData   string `yaml:"clientData,omitempty"`
+}
+
 // onDisk is the YAML projection of a Document: manifest at top level, recipe as a
 // native node, data sections base64-encoded. omitempty keeps a minimal file readable.
 type onDisk struct {
@@ -79,6 +106,8 @@ type onDisk struct {
 	DisplayName   string                `yaml:"displayName,omitempty"`
 	Identity      *FileIdentityRecord   `yaml:"identity,omitempty"`
 	References    []FileReferenceRecord `yaml:"references,omitempty"`
+	Attachments   []AttachmentRecord    `yaml:"attachments,omitempty"`
+	Interests     []InterestRecord      `yaml:"interests,omitempty"`
 	Resources     yaml.Node             `yaml:"resources,omitempty"`
 	Model         yaml.Node             `yaml:"model,omitempty"`
 	Data          map[string]string     `yaml:"data,omitempty"`
@@ -94,6 +123,8 @@ func MarshalDocument(d Document) ([]byte, error) {
 		DisplayName:   d.DisplayName,
 		Identity:      d.Identity,
 		References:    d.References,
+		Attachments:   d.Attachments,
+		Interests:     d.Interests,
 	}
 	if len(d.Resources) > 0 {
 		node, err := resourcesNode(d.Resources)
@@ -158,6 +189,8 @@ func documentHeader(od onDisk) Document {
 		DisplayName:   od.DisplayName,
 		Identity:      od.Identity,
 		References:    od.References,
+		Attachments:   od.Attachments,
+		Interests:     od.Interests,
 	}
 }
 


### PR DESCRIPTION
## What

Implements the five features that complete the M03 milestone (Documents, Persistence & Identity), against the contracts merged in Oblikovati.API#65:

- **Document sub-types** (closes #612): the discriminator is the contract's typed `DocumentSubTypeID` end to end; the built-in sheet-metal part flavor is seeded at session start so .obk files persist it long before M20, and client registration under the reserved `org.oblikovati.` prefix is rejected.
- **File identity & file-level reference descriptors** (closes #608, closes #159): every file carries a persisted identity block — stable GUID, content revision re-minted each save, database revision re-minted only when the recipe digest changed, save counter, software versions — stamped by `Workspace.Save` with rollback on a failed write. Saves snapshot the live graph edges into as-saved reference records (owner-relative spelling, location class, target GUID/save counter) so an unresolved file still reports what it tried to reference; `ReplaceReference` repairs a broken record and re-points the matching graph edge. Served over `files.get/listReferences/replaceReference` + `documents.listFileReferences`.
- **External-file attachments** (closes #609): linked (path + last-known mtime, timestamp-based outOfDate/missing), embedded (bytes travel base64 in the .obk, addressable by a minted resource id) and generic records, resolved through a new injectable `ExternalFileProbe` seam. `documents.listAttachments/addAttachment/removeAttachment`.
- **Save policy, SaveCopyAs & batch save** (closes #610, closes #138): `documents.open/save/saveAs` close the lifecycle gap; `documents.saveCopyAs` writes a fresh-identity copy without retargeting; `documents.batchSave` executes one operation with per-file outcomes. The new `save` option group carries thumbnail capture (the head writes a `<file>.obk.png` sidecar from the viewport readback; unimplemented modes are rejected — no dead settings), SaveDependents (dirty referenced documents save first) and OldVersionsToKeep (prior file archived under `OldVersions/`, copied not moved, pruned).
- **Document interests** (closes #611): persisted `(clientId, name, interestType, dataVersion, clientData)` records with in-place updates and the `hasInterest` discovery probe; opening a document whose interested clients are absent surfaces a status-bar warning, never an error. `documents.listInterests/addInterest/removeInterest/hasInterest`.

## Why

These are the last five open issues of M03. Identity and the persisted descriptor/attachment/interest sections are minted from the first .obk files precisely because retrofitting them onto files in the wild is painful — that constraint drove landing them now rather than with their consuming milestones (M11 assemblies, M15 tables, M20 sheet metal).

All new behavior is covered by model, persistence and wire-level tests; `go test ./...`, `go vet` and golangci-lint v2.1.0 are clean locally, and the head module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)