### PR TITLE
M07: B-rep kernel completion — booleans proven, sewing, facet cache, shells/wires, body queries, transient factory

### DIFF
--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Body, shell and wire enumeration over the wire (M07-F06, #629), plus the
+// planar wire offset. Bodies are addressed by index in the active part.
+
+// resolveBody returns the active part's body at the given index.
+func resolveBody(s *app.Session, index int) (*topo.Body, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	all := part.SurfaceBodies().All()
+	if index < 0 || index >= len(all) {
+		return nil, fmt.Errorf("body index %d out of range (part has %d bodies)", index, len(all))
+	}
+	return all[index], nil
+}
+
+// bodyList serves wire.MethodBodyList.
+func bodyList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var out wire.BodyListResult
+	for i, b := range part.SurfaceBodies().All() {
+		out.Bodies = append(out.Bodies, wire.BodyInfo{
+			Index: i, Solid: b.IsSolid(),
+			Faces: len(b.Faces()), Edges: len(b.Edges()), Vertices: len(b.Vertices()),
+			Shells: len(b.Shells()), Wires: len(b.Wires()),
+		})
+	}
+	return json.Marshal(out)
+}
+
+// bodyShells serves wire.MethodBodyShells.
+func bodyShells(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodyIndexArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	q := ops.DefaultQuality()
+	var out wire.BodyShellsResult
+	for i, sh := range b.Shells() {
+		out.Shells = append(out.Shells, shellInfo(i, sh, q))
+	}
+	return json.Marshal(out)
+}
+
+func shellInfo(i int, sh *topo.Shell, q ops.Quality) wire.FaceShellInfo {
+	vol := ops.ShellSignedVolume(sh, q)
+	box := sh.RangeBox()
+	return wire.FaceShellInfo{
+		Index: i, Closed: sh.IsClosed(), Void: sh.IsClosed() && vol < 0,
+		Faces: len(sh.Faces()), Edges: len(sh.Edges()),
+		Volume:   absFloat(vol),
+		RangeBox: boxSpan(box),
+		Key:      string(sh.ReferenceKey()), TransientKey: sh.ID(),
+	}
+}
+
+func absFloat(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func boxSpan(b math.Box) []float64 {
+	return []float64{
+		float64(b.Min.X), float64(b.Min.Y), float64(b.Min.Z),
+		float64(b.Max.X), float64(b.Max.Y), float64(b.Max.Z),
+	}
+}
+
+// bodyWires serves wire.MethodBodyWires.
+func bodyWires(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodyIndexArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	var out wire.BodyWiresResult
+	for i, w := range b.Wires() {
+		out.Wires = append(out.Wires, wire.WireInfo{
+			Index: i, Closed: w.IsClosed(), Planar: w.IsPlanar(), Edges: len(w.Edges()),
+			Key: string(w.ReferenceKey()), TransientKey: w.ID(),
+		})
+	}
+	return json.Marshal(out)
+}
+
+// wireOffsetPlanar serves wire.MethodWireOffsetPlanar: the offset result is
+// registered as a transient body and returned sampled.
+func wireOffsetPlanar(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.OffsetPlanarWireArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	w, err := resolveWireRef(s, in)
+	if err != nil {
+		return nil, err
+	}
+	normal, err := xyz(in.Normal, "normal")
+	if err != nil {
+		return nil, err
+	}
+	corner, err := offsetCorner(in.CornerClosure)
+	if err != nil {
+		return nil, err
+	}
+	res, err := ops.OffsetPlanarWire(w, normal, in.Distance, corner)
+	if err != nil {
+		return nil, err
+	}
+	tb := s.TransientBodies().Adopt(res)
+	return json.Marshal(wire.OffsetPlanarWireResult{Handle: tb.Handle(), Wires: wirePolylines(res)})
+}
+
+// resolveWireRef finds the wire on a document body (BodyIndex) or a transient
+// body (Handle > 0 — sections and silhouettes land their wires there).
+func resolveWireRef(s *app.Session, in wire.OffsetPlanarWireArgs) (*topo.Wire, error) {
+	b, err := offsetSourceBody(s, in)
+	if err != nil {
+		return nil, err
+	}
+	wires := b.Wires()
+	if in.WireIndex < 0 || in.WireIndex >= len(wires) {
+		return nil, fmt.Errorf("wire index %d out of range (body has %d wires)", in.WireIndex, len(wires))
+	}
+	return wires[in.WireIndex], nil
+}
+
+func offsetSourceBody(s *app.Session, in wire.OffsetPlanarWireArgs) (*topo.Body, error) {
+	if in.Handle > 0 {
+		tb, ok := s.TransientBodies().ByHandle(in.Handle)
+		if !ok {
+			return nil, fmt.Errorf("no transient body with handle %d", in.Handle)
+		}
+		return tb.Topo(), nil
+	}
+	return resolveBody(s, in.BodyIndex)
+}
+
+// offsetCorner maps the wire spelling (empty ⇒ circular, the reference default).
+func offsetCorner(spelling string) (ops.WireOffsetCorner, error) {
+	if spelling == "" {
+		return ops.WireCornerCircular, nil
+	}
+	kind, ok := types.ParseOffsetCornerClosureType(spelling)
+	if !ok {
+		return 0, fmt.Errorf("unknown corner closure %q (want circular, linear or extend)", spelling)
+	}
+	switch kind {
+	case types.LinearCornerClosure:
+		return ops.WireCornerLinear, nil
+	case types.ExtendCornerClosure:
+		return ops.WireCornerExtend, nil
+	default:
+		return ops.WireCornerCircular, nil
+	}
+}
+
+// wirePolylines samples a body's wires for the reply payload.
+func wirePolylines(b *topo.Body) []wire.WirePolyline {
+	var out []wire.WirePolyline
+	for _, w := range b.Wires() {
+		var pts []float64
+		for _, u := range w.Uses() {
+			pts = appendUseSamples(pts, u)
+		}
+		out = append(out, wire.WirePolyline{Points: pts, Closed: w.IsClosed()})
+	}
+	return out
+}
+
+func appendUseSamples(pts []float64, u topo.Use) []float64 {
+	const per = 16
+	c := u.Edge.Geometry()
+	lo, hi := c.Domain()
+	for i := 0; i <= per; i++ {
+		t := float64(i) / per
+		if u.Reversed {
+			t = 1 - t
+		}
+		p := c.PointAt(lo + (hi-lo)*t)
+		pts = append(pts, float64(p.X), float64(p.Y), float64(p.Z))
+	}
+	return pts
+}
+
+// xyz decodes a [x, y, z] vector argument.
+func xyz(v []float64, label string) (math.Vector3, error) {
+	if len(v) != 3 {
+		return math.Vector3{}, fmt.Errorf("%s needs [x, y, z], got %d values", label, len(v))
+	}
+	return math.V3(math.Scalar(v[0]), math.Scalar(v[1]), math.Scalar(v[2])), nil
+}
+
+// xyzPoint decodes a [x, y, z] point argument.
+func xyzPoint(v []float64, label string) (math.Point3, error) {
+	w, err := xyz(v, label)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	return w.AsPoint(), nil
+}

--- a/addin/router/body_facets.go
+++ b/addin/router/body_facets.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Facet/stroke calculation and retrieval over the wire (M07-F03 remainder,
+// #293), backed by the session's tolerance-keyed facet store.
+
+// bodyCalculateFacets serves wire.MethodBodyCalculateFacets.
+func bodyCalculateFacets(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CalculateFacetsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	fs := s.FacetStore().CalculateFacets(b, in.Tolerance)
+	return json.Marshal(facetSetReply(fs, in.IncludeTextureMap))
+}
+
+// bodyExistingFacets serves wire.MethodBodyExistingFacets — retrieval only.
+func bodyExistingFacets(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CalculateFacetsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	fs, ok := s.FacetStore().ExistingFacets(b, in.Tolerance)
+	if !ok {
+		return nil, fmt.Errorf("no facet set exists at tolerance %g (calculate it first; cached: %v)",
+			in.Tolerance, s.FacetStore().FacetTolerances(b))
+	}
+	return json.Marshal(facetSetReply(fs, in.IncludeTextureMap))
+}
+
+func facetSetReply(fs *ops.BodyFacets, withUV bool) wire.FacetSetResult {
+	out := wire.FacetSetResult{
+		VertexCount: len(fs.Mesh.Positions), FacetCount: len(fs.Mesh.Indices) / 3,
+		VertexIndices: fs.Mesh.Indices, IndexCountPerFace: fs.IndexCountPerFace,
+	}
+	out.VertexCoordinates, out.NormalVectors = meshArrays(fs.Mesh)
+	if withUV {
+		out.TextureCoordinates = fs.TextureCoordinates()
+	}
+	return out
+}
+
+func meshArrays(m *ops.Mesh) ([]float64, []float64) {
+	coords := make([]float64, 0, 3*len(m.Positions))
+	normals := make([]float64, 0, 3*len(m.Normals))
+	for _, p := range m.Positions {
+		coords = append(coords, float64(p.X), float64(p.Y), float64(p.Z))
+	}
+	for _, n := range m.Normals {
+		normals = append(normals, float64(n.X), float64(n.Y), float64(n.Z))
+	}
+	return coords, normals
+}
+
+// bodyFacetTolerances serves wire.MethodBodyFacetTolerances.
+func bodyFacetTolerances(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	return toleranceReply(s, raw, func(b *topo.Body) []float64 { return s.FacetStore().FacetTolerances(b) })
+}
+
+// bodyStrokeTolerances serves wire.MethodBodyStrokeTolerances.
+func bodyStrokeTolerances(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	return toleranceReply(s, raw, func(b *topo.Body) []float64 { return s.FacetStore().StrokeTolerances(b) })
+}
+
+func toleranceReply(s *app.Session, raw json.RawMessage, list func(*topo.Body) []float64) (json.RawMessage, error) {
+	var in wire.BodyIndexArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.FacetTolerancesResult{Tolerances: list(b)})
+}
+
+// bodyCalculateStrokes serves wire.MethodBodyCalculateStrokes.
+func bodyCalculateStrokes(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CalculateStrokesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(strokeSetReply(s.FacetStore().CalculateStrokes(b, in.Tolerance).Polylines))
+}
+
+// bodyExistingStrokes serves wire.MethodBodyExistingStrokes — retrieval only.
+func bodyExistingStrokes(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CalculateStrokesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	ss, ok := s.FacetStore().ExistingStrokes(b, in.Tolerance)
+	if !ok {
+		return nil, fmt.Errorf("no stroke set exists at tolerance %g (calculate it first; cached: %v)",
+			in.Tolerance, s.FacetStore().StrokeTolerances(b))
+	}
+	return json.Marshal(strokeSetReply(ss.Polylines))
+}
+
+func strokeSetReply(polylines [][]math.Point3) wire.StrokeSetResult {
+	out := wire.StrokeSetResult{PolylineCount: len(polylines)}
+	for _, pl := range polylines {
+		out.PolylineLengths = append(out.PolylineLengths, len(pl))
+		for _, p := range pl {
+			out.VertexCoordinates = append(out.VertexCoordinates, float64(p.X), float64(p.Y), float64(p.Z))
+		}
+		out.VertexCount += len(pl)
+	}
+	return out
+}
+
+// faceCalculateFacets serves wire.MethodFaceCalculateFacets.
+func faceCalculateFacets(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	b, f, tol, err := resolveFaceArgs(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	mesh, ok := s.FacetStore().FaceFacets(b, f, tol)
+	if !ok {
+		return nil, fmt.Errorf("face not found in the body's facet set")
+	}
+	out := wire.FacetSetResult{
+		VertexCount: len(mesh.Positions), FacetCount: len(mesh.Indices) / 3,
+		VertexIndices: mesh.Indices, IndexCountPerFace: []int{len(mesh.Indices)},
+	}
+	out.VertexCoordinates, out.NormalVectors = meshArrays(mesh)
+	return json.Marshal(out)
+}
+
+// faceCalculateStrokes serves wire.MethodFaceCalculateStrokes.
+func faceCalculateStrokes(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	_, f, tol, err := resolveFaceArgs(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(strokeSetReply(s.FacetStore().FaceStrokes(f, tol)))
+}
+
+// resolveFaceArgs decodes the face-addressed facet args.
+func resolveFaceArgs(s *app.Session, raw json.RawMessage) (*topo.Body, *topo.Face, float64, error) {
+	var in wire.FaceFacetsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, nil, 0, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	f, ok := b.FindFaceByKey([]byte(in.FaceKey))
+	if !ok {
+		return nil, nil, 0, fmt.Errorf("no face with key %q on body %d", in.FaceKey, in.BodyIndex)
+	}
+	return b, f, in.Tolerance, nil
+}

--- a/addin/router/body_m07_test.go
+++ b/addin/router/body_m07_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// M07 router coverage (Oblikovati/Oblikovati#293/#629/#630): the body
+// topology/query/facet surface over a 40×30×50 mm extruded box.
+
+// boxPartSession is the canonical box part (4×3×5 cm) used across the suite.
+func boxPartSession(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct{}{})
+	return r, s
+}
+
+// TestBodyListAndShells: enumeration reports the box and its single closed,
+// non-void shell with keys.
+func TestBodyListAndShells(t *testing.T) {
+	r, s := boxPartSession(t)
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if len(list.Bodies) != 1 || list.Bodies[0].Faces != 6 || !list.Bodies[0].Solid || list.Bodies[0].Shells != 1 {
+		t.Fatalf("body list = %+v, want one solid 6-face single-shell box", list.Bodies)
+	}
+	var shells wire.BodyShellsResult
+	call(t, r, s, "body.shells", `{"bodyIndex":0}`, &shells)
+	if len(shells.Shells) != 1 {
+		t.Fatalf("shells = %d, want 1", len(shells.Shells))
+	}
+	sh := shells.Shells[0]
+	if !sh.Closed || sh.Void || sh.Key == "" || sh.TransientKey == 0 {
+		t.Errorf("shell = %+v, want closed non-void with keys", sh)
+	}
+	if stdmath.Abs(sh.Volume-60) > 0.01 { // 4×3×5 cm
+		t.Errorf("shell volume = %g, want 60", sh.Volume)
+	}
+}
+
+// TestBodyPointAndRayQueries: locate, ray, containment.
+func TestBodyPointAndRayQueries(t *testing.T) {
+	r, s := boxPartSession(t)
+	var loc wire.LocateUsingPointResult
+	call(t, r, s, "body.locateUsingPoint", `{"bodyIndex":0,"point":[2,1.5,5.05],"entityKind":"face","proximityTolerance":0.1}`, &loc)
+	if !loc.Found || loc.Entity.Kind != "face" {
+		t.Fatalf("locate = %+v, want the top face", loc)
+	}
+	var ray wire.FindUsingRayResult
+	call(t, r, s, "body.findUsingRay", `{"bodyIndex":0,"origin":[2,1.5,-5],"direction":[0,0,1]}`, &ray)
+	if len(ray.Hits) != 2 || ray.Hits[0].Distance >= ray.Hits[1].Distance {
+		t.Fatalf("ray hits = %+v, want entry+exit sorted", ray.Hits)
+	}
+	var inside wire.IsPointInsideResult
+	call(t, r, s, "body.isPointInside", `{"bodyIndex":0,"point":[2,1.5,2.5]}`, &inside)
+	if inside.Containment != "inside" {
+		t.Errorf("center containment = %q, want inside", inside.Containment)
+	}
+	call(t, r, s, "body.isPointInside", `{"bodyIndex":0,"point":[20,0,0]}`, &inside)
+	if inside.Containment != "outside" {
+		t.Errorf("far containment = %q, want outside", inside.Containment)
+	}
+}
+
+// TestBodyConvexityValidateRangeBoxBind: the remaining query handlers.
+func TestBodyConvexityValidateRangeBoxBind(t *testing.T) {
+	r, s := boxPartSession(t)
+	var conv wire.ConvexityEdgesResult
+	call(t, r, s, "body.convexityEdges", `{"bodyIndex":0,"collection":"allConvex"}`, &conv)
+	if len(conv.Edges) != 12 {
+		t.Errorf("convex edges = %d, want 12", len(conv.Edges))
+	}
+	var valid wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0,"checkLevel":2}`, &valid)
+	if !valid.Valid || len(valid.Problems) != 0 {
+		t.Errorf("validate = %+v, want clean", valid)
+	}
+	var box wire.BodyRangeBoxResult
+	call(t, r, s, "body.rangeBox", `{"bodyIndex":0,"precise":true}`, &box)
+	if len(box.Min) != 3 || len(box.Max) != 3 {
+		t.Fatalf("precise box = %+v", box)
+	}
+	var obb wire.BodyRangeBoxResult
+	call(t, r, s, "body.rangeBox", `{"bodyIndex":0,"oriented":true}`, &obb)
+	vol := vecLen(obb.DirectionOne) * vecLen(obb.DirectionTwo) * vecLen(obb.DirectionThree)
+	if stdmath.Abs(vol-60) > 0.01 {
+		t.Errorf("OBB volume = %g, want 60", vol)
+	}
+	var shells wire.BodyShellsResult
+	call(t, r, s, "body.shells", `{"bodyIndex":0}`, &shells)
+	var bind wire.BindTransientKeyResult
+	call(t, r, s, "body.bindTransientKey",
+		fmt.Sprintf(`{"bodyIndex":0,"transientKey":%d}`, shells.Shells[0].TransientKey), &bind)
+	if !bind.Found || bind.Kind != "shell" {
+		t.Errorf("bind = %+v, want the shell back", bind)
+	}
+}
+
+func vecLen(v []float64) float64 {
+	return stdmath.Sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2])
+}
+
+// TestFacetAndStrokeCacheFlow: calculate caches, existing retrieves, the
+// tolerance lists track, and the face-level calls work by key.
+func TestFacetAndStrokeCacheFlow(t *testing.T) {
+	r, s := boxPartSession(t)
+	var fs wire.FacetSetResult
+	call(t, r, s, "body.calculateFacets", `{"bodyIndex":0,"tolerance":0.01,"includeTextureMap":true}`, &fs)
+	if fs.FacetCount != 12 || len(fs.IndexCountPerFace) != 6 || len(fs.TextureCoordinates) != 2*fs.VertexCount {
+		t.Fatalf("facets = %d tris, %d faces, %d uv floats", fs.FacetCount, len(fs.IndexCountPerFace), len(fs.TextureCoordinates))
+	}
+	var existing wire.FacetSetResult
+	call(t, r, s, "body.existingFacets", `{"bodyIndex":0,"tolerance":0.01}`, &existing)
+	if existing.FacetCount != 12 {
+		t.Errorf("existing facets = %d tris, want 12", existing.FacetCount)
+	}
+	if _, err := r.Handle(s, "body.existingFacets", []byte(`{"bodyIndex":0,"tolerance":0.5}`)); err == nil {
+		t.Error("existingFacets at an uncached tolerance must error")
+	}
+	var tols wire.FacetTolerancesResult
+	call(t, r, s, "body.facetTolerances", `{"bodyIndex":0}`, &tols)
+	if len(tols.Tolerances) != 1 || tols.Tolerances[0] != 0.01 {
+		t.Errorf("facet tolerances = %v, want [0.01]", tols.Tolerances)
+	}
+	var ss wire.StrokeSetResult
+	call(t, r, s, "body.calculateStrokes", `{"bodyIndex":0,"tolerance":0.01}`, &ss)
+	if ss.PolylineCount != 12 {
+		t.Errorf("strokes = %d polylines, want 12 edges", ss.PolylineCount)
+	}
+	call(t, r, s, "body.existingStrokes", `{"bodyIndex":0,"tolerance":0.01}`, &ss)
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	// Reference keys carry a raw kind byte — marshal the args as real JSON.
+	faceArgs, err := json.Marshal(wire.FaceFacetsArgs{BodyIndex: 0, FaceKey: keys.Bodies[0].Faces[0].Key, Tolerance: 0.01})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var faceFs wire.FacetSetResult
+	call(t, r, s, "face.calculateFacets", string(faceArgs), &faceFs)
+	if faceFs.FacetCount != 2 {
+		t.Errorf("face facets = %d tris, want 2 (a planar quad)", faceFs.FacetCount)
+	}
+	var faceSs wire.StrokeSetResult
+	call(t, r, s, "face.calculateStrokes", string(faceArgs), &faceSs)
+	if faceSs.PolylineCount != 4 {
+		t.Errorf("face strokes = %d polylines, want 4", faceSs.PolylineCount)
+	}
+}
+
+// TestBodyValidateFlagsBadIndex: errors carry the offending value.
+func TestBodyValidateFlagsBadIndex(t *testing.T) {
+	r, s := boxPartSession(t)
+	_, err := r.Handle(s, "body.shells", []byte(`{"bodyIndex":5}`))
+	if err == nil || !strings.Contains(err.Error(), "5") {
+		t.Errorf("bad index error = %v, want it to name index 5", err)
+	}
+}

--- a/addin/router/body_query.go
+++ b/addin/router/body_query.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Body point/ray/validity queries over the wire (M07-F07, #630).
+
+// bodyLocateUsingPoint serves wire.MethodBodyLocateUsingPoint.
+func bodyLocateUsingPoint(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.LocateUsingPointArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	p, err := xyzPoint(in.Point, "point")
+	if err != nil {
+		return nil, err
+	}
+	kind, err := entityKindFilter(in.EntityKind)
+	if err != nil {
+		return nil, err
+	}
+	hit, found := ops.LocateUsingPoint(b, kind, p, in.ProximityTolerance, ops.DefaultQuality())
+	out := wire.LocateUsingPointResult{Found: found}
+	if found {
+		out.Entity = locatedInfo(hit)
+	}
+	return json.Marshal(out)
+}
+
+// entityKindFilter maps the wire spelling (empty = any).
+func entityKindFilter(spelling string) (topo.EntityKind, error) {
+	switch spelling {
+	case "":
+		return 0, nil
+	case "vertex":
+		return topo.KindVertex, nil
+	case "edge":
+		return topo.KindEdge, nil
+	case "face":
+		return topo.KindFace, nil
+	default:
+		return 0, fmt.Errorf("unknown entity kind %q (want vertex, edge or face)", spelling)
+	}
+}
+
+func locatedInfo(hit ops.LocatedEntity) wire.LocatedEntityInfo {
+	key, tkey := locatedKeys(hit)
+	return wire.LocatedEntityInfo{
+		Kind: hit.Kind.String(), Key: key, TransientKey: tkey,
+		Point:    []float64{float64(hit.Point.X), float64(hit.Point.Y), float64(hit.Point.Z)},
+		Distance: hit.Distance,
+	}
+}
+
+func locatedKeys(hit ops.LocatedEntity) (string, uint64) {
+	switch hit.Kind {
+	case topo.KindVertex:
+		return string(hit.Vertex.ReferenceKey()), hit.Vertex.ID()
+	case topo.KindEdge:
+		return string(hit.Edge.ReferenceKey()), hit.Edge.ID()
+	default:
+		return string(hit.Face.ReferenceKey()), hit.Face.ID()
+	}
+}
+
+// bodyFindUsingRay serves wire.MethodBodyFindUsingRay.
+func bodyFindUsingRay(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.FindUsingRayArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	origin, err := xyzPoint(in.Origin, "origin")
+	if err != nil {
+		return nil, err
+	}
+	dir, err := xyz(in.Direction, "direction")
+	if err != nil {
+		return nil, err
+	}
+	var out wire.FindUsingRayResult
+	for _, hit := range ops.FindUsingRay(b, origin, dir, in.Radius, ops.DefaultQuality(), in.FindFirstOnly) {
+		out.Hits = append(out.Hits, locatedInfo(hit))
+	}
+	return json.Marshal(out)
+}
+
+// bodyIsPointInside serves wire.MethodBodyIsPointInside.
+func bodyIsPointInside(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.IsPointInsideArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	p, err := xyzPoint(in.Point, "point")
+	if err != nil {
+		return nil, err
+	}
+	onTol := in.OnTolerance
+	if onTol <= 0 {
+		onTol = 1e-6
+	}
+	verdict, err := pointContainmentOf(b, in.ShellIndex, p, onTol)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.IsPointInsideResult{Containment: containmentSpelling(verdict)})
+}
+
+func pointContainmentOf(b *topo.Body, shellIndex *int, p math.Point3, onTol float64) (ops.PointContainment, error) {
+	q := ops.DefaultQuality()
+	if shellIndex == nil {
+		return ops.BodyContainment(b, p, q, onTol), nil
+	}
+	shells := b.Shells()
+	if *shellIndex < 0 || *shellIndex >= len(shells) {
+		return 0, fmt.Errorf("shell index %d out of range (body has %d shells)", *shellIndex, len(shells))
+	}
+	return ops.ShellContainment(shells[*shellIndex], p, q, onTol), nil
+}
+
+func containmentSpelling(c ops.PointContainment) string {
+	switch c {
+	case ops.ContainInside:
+		return types.InsideContainment.String()
+	case ops.ContainOn:
+		return types.OnContainment.String()
+	default:
+		return types.OutsideContainment.String()
+	}
+}
+
+// bodyConvexityEdges serves wire.MethodBodyConvexityEdges.
+func bodyConvexityEdges(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ConvexityEdgesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	class, err := convexityClass(in.Collection)
+	if err != nil {
+		return nil, err
+	}
+	var out wire.ConvexityEdgesResult
+	for _, e := range ops.BodyEdgeConvexity(b)[class] {
+		out.Edges = append(out.Edges, wire.TopologyRef{
+			Key:   string(e.ReferenceKey()),
+			Point: topoRefPoint(e.RangeBox().Center()),
+		})
+	}
+	return json.Marshal(out)
+}
+
+func convexityClass(spelling string) (ops.EdgeConvexity, error) {
+	kind, ok := types.ParseEdgeCollectionKind(spelling)
+	if !ok {
+		return 0, fmt.Errorf("unknown edge collection %q (want allConvex, allConcave or tangentiallyConnected)", spelling)
+	}
+	switch kind {
+	case types.AllConvexEdges:
+		return ops.EdgeConvex, nil
+	case types.AllConcaveEdges:
+		return ops.EdgeConcave, nil
+	case types.TangentiallyConnectedEdges:
+		return ops.EdgeTangent, nil
+	default:
+		return ops.EdgeConvexityUnknown, nil
+	}
+}
+
+// bodyValidate serves wire.MethodBodyValidate.
+func bodyValidate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ValidateBodyArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	level := ops.CheckTopology
+	if in.CheckLevel >= int(ops.CheckGeometry) {
+		level = ops.CheckGeometry
+	}
+	valid, problems := ops.ValidateBodyEntities(b, level, ops.DefaultQuality())
+	out := wire.ValidateBodyResult{Valid: valid}
+	for _, p := range problems {
+		out.Problems = append(out.Problems, wire.ProblemEntityInfo{
+			Kind: p.Kind.String(), Key: string(p.ReferenceKey), TransientKey: p.ID, Issue: p.Issue,
+		})
+	}
+	return json.Marshal(out)
+}
+
+// bodyRangeBox serves wire.MethodBodyRangeBox.
+func bodyRangeBox(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodyRangeBoxArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	if in.Oriented {
+		return orientedRangeBoxReply(b)
+	}
+	box := b.RangeBox()
+	if in.Precise {
+		box = ops.PreciseRangeBox(b, ops.DefaultQuality())
+	}
+	return json.Marshal(wire.BodyRangeBoxResult{
+		Min: []float64{float64(box.Min.X), float64(box.Min.Y), float64(box.Min.Z)},
+		Max: []float64{float64(box.Max.X), float64(box.Max.Y), float64(box.Max.Z)},
+	})
+}
+
+func orientedRangeBoxReply(b *topo.Body) (json.RawMessage, error) {
+	obb, err := ops.OrientedMinimumRangeBox(b)
+	if err != nil {
+		return nil, err
+	}
+	vec := func(v math.Vector3) []float64 { return []float64{float64(v.X), float64(v.Y), float64(v.Z)} }
+	return json.Marshal(wire.BodyRangeBoxResult{
+		Corner:       []float64{float64(obb.Corner.X), float64(obb.Corner.Y), float64(obb.Corner.Z)},
+		DirectionOne: vec(obb.DirectionOne), DirectionTwo: vec(obb.DirectionTwo), DirectionThree: vec(obb.DirectionThree),
+	})
+}
+
+// bodyBindTransientKey serves wire.MethodBodyBindTransientKey.
+func bodyBindTransientKey(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BindTransientKeyArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	ref, ok := b.BindTransientKey(in.TransientKey)
+	if !ok {
+		return json.Marshal(wire.BindTransientKeyResult{Found: false})
+	}
+	return json.Marshal(wire.BindTransientKeyResult{
+		Found: true, Kind: ref.Kind.String(), Key: string(transientRefReferenceKey(ref)),
+	})
+}
+
+func transientRefReferenceKey(ref topo.TransientRef) []byte {
+	switch ref.Kind {
+	case topo.KindVertex:
+		return ref.Vertex.ReferenceKey()
+	case topo.KindEdge:
+		return ref.Edge.ReferenceKey()
+	case topo.KindFace:
+		return ref.Face.ReferenceKey()
+	case topo.KindShell:
+		return ref.Shell.ReferenceKey()
+	default:
+		return ref.Wire.ReferenceKey()
+	}
+}

--- a/addin/router/brep.go
+++ b/addin/router/brep.go
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/bodyapi"
+)
+
+// The transient B-rep factory over the wire (M07-F05, #628): ownerless
+// bodies in the session registry, addressed by handle. Operations on a
+// document body always COPY it into transient space first.
+
+// brepSource resolves a BrepBodyRef onto a kernel body: a transient handle
+// directly, a document body as a fresh registry copy.
+func brepSource(s *app.Session, ref wire.BrepBodyRef) (*bodyapi.TransientBody, error) {
+	reg := s.TransientBodies()
+	if ref.Handle > 0 && ref.BodyIndex != nil {
+		return nil, fmt.Errorf("a body ref must set handle OR bodyIndex, got both")
+	}
+	if ref.Handle > 0 {
+		tb, ok := reg.ByHandle(ref.Handle)
+		if !ok {
+			return nil, fmt.Errorf("no transient body with handle %d", ref.Handle)
+		}
+		return tb, nil
+	}
+	if ref.BodyIndex == nil {
+		return nil, fmt.Errorf("a body ref must set handle or bodyIndex")
+	}
+	doc, err := resolveBody(s, *ref.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	clone, err := bodyapi.CopyTopoBody(doc, len(reg.Handles())+1)
+	if err != nil {
+		return nil, err
+	}
+	return reg.Adopt(clone), nil
+}
+
+// brepStats summarizes a transient body for the reply.
+func brepStats(tb *bodyapi.TransientBody) wire.BrepBodyStats {
+	return wire.BrepBodyStats{
+		Solid: tb.IsSolid(), Faces: tb.FaceCount(), Edges: tb.EdgeCount(),
+		Vertices: tb.VertexCount(), Shells: tb.ShellCount(), Wires: tb.WireCount(),
+		Volume: tb.Volume(),
+	}
+}
+
+func brepHandleReply(tb *bodyapi.TransientBody) (json.RawMessage, error) {
+	return json.Marshal(wire.BrepHandleResult{Handle: tb.Handle(), Stats: brepStats(tb)})
+}
+
+// brepCreatePrimitive serves wire.MethodBrepCreatePrimitive.
+func brepCreatePrimitive(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CreatePrimitiveArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	body, err := buildPrimitive(in)
+	if err != nil {
+		return nil, err
+	}
+	return brepHandleReply(s.TransientBodies().Adopt(body))
+}
+
+func buildPrimitive(in wire.CreatePrimitiveArgs) (*topo.Body, error) {
+	switch in.Kind {
+	case "block":
+		return primitiveBlock(in)
+	case "cylinderCone":
+		return primitiveCylinderCone(in)
+	case "sphere":
+		return primitiveSphere(in)
+	case "torus":
+		return primitiveTorus(in)
+	default:
+		return nil, fmt.Errorf("unknown primitive kind %q (want block, cylinderCone, sphere or torus)", in.Kind)
+	}
+}
+
+func primitiveBlock(in wire.CreatePrimitiveArgs) (*topo.Body, error) {
+	min, err := xyzPoint(in.Min, "min")
+	if err != nil {
+		return nil, err
+	}
+	max, err := xyzPoint(in.Max, "max")
+	if err != nil {
+		return nil, err
+	}
+	return brep.SolidBlock(min, max, "transient")
+}
+
+func primitiveCylinderCone(in wire.CreatePrimitiveArgs) (*topo.Body, error) {
+	bottom, err := xyzPoint(in.Bottom, "bottom")
+	if err != nil {
+		return nil, err
+	}
+	top, err := xyzPoint(in.Top, "top")
+	if err != nil {
+		return nil, err
+	}
+	return brep.SolidCylinderCone(bottom, top, in.BottomRadius, in.TopRadius, "transient")
+}
+
+func primitiveSphere(in wire.CreatePrimitiveArgs) (*topo.Body, error) {
+	center, err := xyzPoint(in.Center, "center")
+	if err != nil {
+		return nil, err
+	}
+	return brep.SolidSphere(center, in.Radius, "transient")
+}
+
+func primitiveTorus(in wire.CreatePrimitiveArgs) (*topo.Body, error) {
+	center, err := xyzPoint(in.Center, "center")
+	if err != nil {
+		return nil, err
+	}
+	axis, err := xyz(in.Axis, "axis")
+	if err != nil {
+		return nil, err
+	}
+	return brep.SolidTorus(center, axis, in.MajorRadius, in.MinorRadius, "transient")
+}
+
+// brepBoolean serves wire.MethodBrepBoolean: blank modified in place.
+func brepBoolean(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepBooleanArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	reg := s.TransientBodies()
+	blank, ok := reg.ByHandle(in.BlankHandle)
+	if !ok {
+		return nil, fmt.Errorf("no transient body with handle %d (the blank must be transient)", in.BlankHandle)
+	}
+	tool, err := brepSource(s, in.Tool)
+	if err != nil {
+		return nil, err
+	}
+	op, ok := types.ParseBooleanType(in.Operation)
+	if !ok {
+		return nil, fmt.Errorf("unknown boolean operation %q (want union, difference or intersect)", in.Operation)
+	}
+	if err := s.TransientBodies().DoBoolean(blank, tool, op); err != nil {
+		return nil, err
+	}
+	return brepHandleReply(blank)
+}
+
+// brepTransform serves wire.MethodBrepTransform (in place).
+func brepTransform(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepTransformArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	tb, ok := s.TransientBodies().ByHandle(in.Handle)
+	if !ok {
+		return nil, fmt.Errorf("no transient body with handle %d", in.Handle)
+	}
+	if len(in.Matrix) != 16 {
+		return nil, fmt.Errorf("transform needs 16 row-major cells, got %d", len(in.Matrix))
+	}
+	var m types.Matrix
+	copy(m.Cells[:], in.Matrix)
+	if err := s.TransientBodies().Transform(tb, m); err != nil {
+		return nil, err
+	}
+	return brepHandleReply(tb)
+}
+
+// brepCopy serves wire.MethodBrepCopy.
+func brepCopy(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepCopyArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	src, err := brepSource(s, in.Source)
+	if err != nil {
+		return nil, err
+	}
+	if in.Source.Handle > 0 {
+		copied, err := s.TransientBodies().Copy(src)
+		if err != nil {
+			return nil, err
+		}
+		return brepHandleReply(copied.(*bodyapi.TransientBody))
+	}
+	// A document source was already copied into the registry by brepSource.
+	return brepHandleReply(src)
+}
+
+// brepSectionWithPlane serves wire.MethodBrepSectionWithPlane.
+func brepSectionWithPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepSectionArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	src, err := brepSource(s, in.Source)
+	if err != nil {
+		return nil, err
+	}
+	origin, err := xyzPoint(in.PlaneOrigin, "planeOrigin")
+	if err != nil {
+		return nil, err
+	}
+	normal, err := xyz(in.PlaneNormal, "planeNormal")
+	if err != nil {
+		return nil, err
+	}
+	sec, err := ops.SectionWithPlane(src.Topo(), origin, normal, ops.DefaultQuality())
+	if err != nil {
+		return nil, err
+	}
+	tb := s.TransientBodies().Adopt(sec)
+	return json.Marshal(wire.BrepWiresResult{Handle: tb.Handle(), Wires: wirePolylines(sec)})
+}
+
+// brepDeleteFaces serves wire.MethodBrepDeleteFaces (no healing).
+func brepDeleteFaces(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepDeleteFacesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	tb, ok := s.TransientBodies().ByHandle(in.Handle)
+	if !ok {
+		return nil, fmt.Errorf("no transient body with handle %d", in.Handle)
+	}
+	keys := make([][]byte, len(in.FaceKeys))
+	for i, k := range in.FaceKeys {
+		keys[i] = []byte(k)
+	}
+	res, err := ops.DropFaces(tb.Topo(), keys, in.KeepInstead)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.TransientBodies().Replace(in.Handle, res); err != nil {
+		return nil, err
+	}
+	return brepHandleReply(tb)
+}
+
+// brepSilhouette serves wire.MethodBrepSilhouette.
+func brepSilhouette(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepSilhouetteArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	src, err := brepSource(s, in.Source)
+	if err != nil {
+		return nil, err
+	}
+	f, ok := src.Topo().FindFaceByKey([]byte(in.FaceKey))
+	if !ok {
+		return nil, fmt.Errorf("no face with key %q on the source body", in.FaceKey)
+	}
+	dir, err := xyz(in.ViewDirection, "viewDirection")
+	if err != nil {
+		return nil, err
+	}
+	sil, err := ops.FaceSilhouetteWires(f, dir, in.IncludeBoundary, ops.DefaultQuality())
+	if err != nil {
+		return nil, err
+	}
+	tb := s.TransientBodies().Adopt(sil)
+	return json.Marshal(wire.BrepWiresResult{Handle: tb.Handle(), Wires: wirePolylines(sil)})
+}
+
+// brepRuledSurface serves wire.MethodBrepRuledSurface.
+func brepRuledSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepRuledSurfaceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	w1, err := brepWireOf(s, in.SectionOne)
+	if err != nil {
+		return nil, err
+	}
+	w2, err := brepWireOf(s, in.SectionTwo)
+	if err != nil {
+		return nil, err
+	}
+	surf, err := ops.RuledSurfaceBetweenWires(w1, w2)
+	if err != nil {
+		return nil, err
+	}
+	return brepHandleReply(s.TransientBodies().Adopt(surf))
+}
+
+func brepWireOf(s *app.Session, ref wire.BrepWireRef) (*topo.Wire, error) {
+	src, err := brepSource(s, ref.Body)
+	if err != nil {
+		return nil, err
+	}
+	wires := src.Topo().Wires()
+	if ref.WireIndex < 0 || ref.WireIndex >= len(wires) {
+		return nil, fmt.Errorf("wire index %d out of range (body has %d wires)", ref.WireIndex, len(wires))
+	}
+	return wires[ref.WireIndex], nil
+}
+
+// brepImprint serves wire.MethodBrepImprint.
+func brepImprint(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepImprintArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	one, err := brepSource(s, in.BodyOne)
+	if err != nil {
+		return nil, err
+	}
+	two, err := brepSource(s, in.BodyTwo)
+	if err != nil {
+		return nil, err
+	}
+	ra, rb, err := brep.ImprintBodies(one.Topo(), two.Topo())
+	if err != nil {
+		return nil, err
+	}
+	reg := s.TransientBodies()
+	ta, tb := reg.Adopt(ra.Body), reg.Adopt(rb.Body)
+	return json.Marshal(wire.BrepImprintResult{
+		HandleOne: ta.Handle(), HandleTwo: tb.Handle(),
+		OneTouchedFaceKeys: faceKeys(ra.TouchedFaces), TwoTouchedFaceKeys: faceKeys(rb.TouchedFaces),
+		OneImprintedEdgeKeys: edgeKeys(ra.ImprintedEdge), TwoImprintedEdgeKeys: edgeKeys(rb.ImprintedEdge),
+	})
+}
+
+func faceKeys(faces []*topo.Face) []string {
+	out := make([]string, len(faces))
+	for i, f := range faces {
+		out[i] = string(f.ReferenceKey())
+	}
+	return out
+}
+
+func edgeKeys(edges []*topo.Edge) []string {
+	out := make([]string, len(edges))
+	for i, e := range edges {
+		out[i] = string(e.ReferenceKey())
+	}
+	return out
+}
+
+// brepIdenticalBodies serves wire.MethodBrepIdenticalBodies.
+func brepIdenticalBodies(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepIdenticalBodiesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	bodies := make([]*topo.Body, 0, len(in.Sources))
+	for _, ref := range in.Sources {
+		src, err := brepSource(s, ref)
+		if err != nil {
+			return nil, err
+		}
+		bodies = append(bodies, src.Topo())
+	}
+	opt := ops.IdenticalBodiesOptions{
+		Tolerance: in.Tolerance, MatchTopology: in.MatchTopology,
+		MatchReflection: in.MatchReflection == nil || *in.MatchReflection,
+	}
+	groups := ops.GroupIdenticalBodies(bodies, opt, ops.DefaultQuality())
+	return json.Marshal(wire.BrepIdenticalBodiesResult{Groups: groups})
+}
+
+// brepCreateFromDefinition serves wire.MethodBrepCreateFromDefinition.
+func brepCreateFromDefinition(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepCreateFromDefinitionArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	body, issues, err := s.TransientBodies().CreateFromDefinition(in.Definition)
+	if err != nil {
+		return nil, err
+	}
+	if len(issues) > 0 {
+		return json.Marshal(wire.BrepCreateFromDefinitionResult{Issues: issues})
+	}
+	tb := body.(*bodyapi.TransientBody)
+	return json.Marshal(wire.BrepCreateFromDefinitionResult{Handle: tb.Handle(), Stats: brepStats(tb)})
+}
+
+// brepDescribe serves wire.MethodBrepDescribe.
+func brepDescribe(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepHandleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	tb, ok := s.TransientBodies().ByHandle(in.Handle)
+	if !ok {
+		return nil, fmt.Errorf("no transient body with handle %d", in.Handle)
+	}
+	return brepHandleReply(tb)
+}
+
+// brepList serves wire.MethodBrepList.
+func brepList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.BrepListResult{Handles: s.TransientBodies().Handles()})
+}
+
+// brepDelete serves wire.MethodBrepDelete.
+func brepDelete(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepHandleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if !s.TransientBodies().Delete(in.Handle) {
+		return nil, fmt.Errorf("no transient body with handle %d", in.Handle)
+	}
+	return json.Marshal(wire.OKResult{OK: true})
+}

--- a/addin/router/brep_test.go
+++ b/addin/router/brep_test.go
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/geom"
+)
+
+// Transient B-rep factory over the wire (M07-F05, #628).
+
+// TestBrepPrimitivesAndLifecycle: create, describe, list, delete.
+func TestBrepPrimitivesAndLifecycle(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var block wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[3,2,5]}`, &block)
+	if block.Handle != 1 || !block.Stats.Solid || stdmath.Abs(block.Stats.Volume-30) > 1e-6 {
+		t.Fatalf("block = %+v, want handle 1 volume 30", block)
+	}
+	var sphere wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"sphere","center":[0,0,0],"radius":2}`, &sphere)
+	want := 4.0 / 3 * stdmath.Pi * 8
+	if stdmath.Abs(sphere.Stats.Volume-want)/want > 0.02 {
+		t.Errorf("sphere volume = %g, want ~%g", sphere.Stats.Volume, want)
+	}
+	var list wire.BrepListResult
+	call(t, r, s, "brep.list", `{}`, &list)
+	if len(list.Handles) != 2 {
+		t.Fatalf("handles = %v, want 2", list.Handles)
+	}
+	var desc wire.BrepHandleResult
+	call(t, r, s, "brep.describe", `{"handle":1}`, &desc)
+	if desc.Stats.Faces != 6 {
+		t.Errorf("described block faces = %d, want 6", desc.Stats.Faces)
+	}
+	call(t, r, s, "brep.delete", `{"handle":2}`, &wire.OKResult{})
+	call(t, r, s, "brep.list", `{}`, &list)
+	if len(list.Handles) != 1 {
+		t.Errorf("handles after delete = %v, want [1]", list.Handles)
+	}
+}
+
+// TestBrepBooleanTransformCopy: union grows the blank in place; transform
+// translates; copy mints an independent body.
+func TestBrepBooleanTransformCopy(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var a, b wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[1,1,1]}`, &a)
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[1,0,0],"max":[2,1,1]}`, &b)
+	var res wire.BrepHandleResult
+	call(t, r, s, "brep.boolean",
+		fmt.Sprintf(`{"blankHandle":%d,"tool":{"handle":%d},"operation":"union"}`, a.Handle, b.Handle), &res)
+	if res.Handle != a.Handle || stdmath.Abs(res.Stats.Volume-2) > 1e-6 {
+		t.Fatalf("union = %+v, want the blank at volume 2", res)
+	}
+	var moved wire.BrepHandleResult
+	call(t, r, s, "brep.transform",
+		fmt.Sprintf(`{"handle":%d,"matrix":[1,0,0,10, 0,1,0,0, 0,0,1,0, 0,0,0,1]}`, a.Handle), &moved)
+	if stdmath.Abs(moved.Stats.Volume-2) > 1e-6 {
+		t.Errorf("moved volume = %g, want 2", moved.Stats.Volume)
+	}
+	var copied wire.BrepHandleResult
+	call(t, r, s, "brep.copy", fmt.Sprintf(`{"source":{"handle":%d}}`, a.Handle), &copied)
+	if copied.Handle == a.Handle || stdmath.Abs(copied.Stats.Volume-2) > 1e-6 {
+		t.Errorf("copy = %+v, want a fresh handle at volume 2", copied)
+	}
+}
+
+// TestBrepCopiesDocumentBody: a document body referenced by index copies into
+// transient space (the document body itself is never mutated).
+func TestBrepCopiesDocumentBody(t *testing.T) {
+	r, s := boxPartSession(t)
+	var copied wire.BrepHandleResult
+	call(t, r, s, "brep.copy", `{"source":{"bodyIndex":0}}`, &copied)
+	if copied.Handle == 0 || stdmath.Abs(copied.Stats.Volume-60) > 0.01 {
+		t.Fatalf("document copy = %+v, want the 60 cm³ box", copied)
+	}
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if len(list.Bodies) != 1 {
+		t.Errorf("document still has %d bodies, want 1 (copy is transient)", len(list.Bodies))
+	}
+}
+
+// TestBrepSectionAndOffset: a plane section yields a closed wire; offsetting
+// it outward grows its length.
+func TestBrepSectionAndOffset(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var block wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[4,3,2]}`, &block)
+	var sec wire.BrepWiresResult
+	call(t, r, s, "brep.sectionWithPlane",
+		fmt.Sprintf(`{"source":{"handle":%d},"planeOrigin":[0,0,1],"planeNormal":[0,0,1]}`, block.Handle), &sec)
+	if len(sec.Wires) != 1 || !sec.Wires[0].Closed {
+		t.Fatalf("section = %+v, want one closed wire", sec.Wires)
+	}
+	var off wire.OffsetPlanarWireResult
+	call(t, r, s, "wire.offsetPlanar",
+		fmt.Sprintf(`{"handle":%d,"wireIndex":0,"normal":[0,0,1],"distance":-0.5,"cornerClosure":"linear"}`, sec.Handle), &off)
+	if off.Handle == 0 || len(off.Wires) != 1 {
+		t.Fatalf("offset = %+v, want one wire on a new handle", off)
+	}
+}
+
+// TestBrepDeleteFacesOpensBox: deleting one face leaves a 5-face surface body.
+func TestBrepDeleteFacesOpensBox(t *testing.T) {
+	r, s := boxPartSession(t)
+	var copied wire.BrepHandleResult
+	call(t, r, s, "brep.copy", `{"source":{"bodyIndex":0}}`, &copied)
+	// The transient copy's faces carry copy-derived keys; keep-instead with an
+	// unknown key keeps nothing — the removes-every-face guard must fire.
+	_, err := r.Handle(s, "brep.deleteFaces",
+		[]byte(fmt.Sprintf(`{"handle":%d,"faceKeys":["nope"],"keepInstead":true}`, copied.Handle)))
+	if err == nil || !strings.Contains(err.Error(), "every face") {
+		t.Fatalf("keep-none = %v, want the removes-every-face error", err)
+	}
+	// Plain delete with an unknown key keeps all 6 faces (a no-op delete).
+	var res wire.BrepHandleResult
+	call(t, r, s, "brep.deleteFaces",
+		fmt.Sprintf(`{"handle":%d,"faceKeys":["nope"]}`, copied.Handle), &res)
+	if res.Stats.Faces != 6 {
+		t.Errorf("no-op delete faces = %d, want 6", res.Stats.Faces)
+	}
+}
+
+// TestBrepImprintAndIdentical: stacked blocks imprint; congruent blocks group.
+func TestBrepImprintAndIdentical(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var big, small wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[4,4,1]}`, &big)
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[1,1,1],"max":[3,3,2]}`, &small)
+	var imp wire.BrepImprintResult
+	call(t, r, s, "brep.imprint",
+		fmt.Sprintf(`{"bodyOne":{"handle":%d},"bodyTwo":{"handle":%d}}`, big.Handle, small.Handle), &imp)
+	if imp.HandleOne == 0 || imp.HandleTwo == 0 || len(imp.OneTouchedFaceKeys) == 0 {
+		t.Fatalf("imprint = %+v, want new handles and touched faces", imp)
+	}
+	var a, b, c wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[1,2,3]}`, &a)
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[5,0,0],"max":[6,2,3]}`, &b)
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[1,2,4]}`, &c)
+	var groups wire.BrepIdenticalBodiesResult
+	call(t, r, s, "brep.identicalBodies",
+		fmt.Sprintf(`{"sources":[{"handle":%d},{"handle":%d},{"handle":%d}]}`, a.Handle, b.Handle, c.Handle), &groups)
+	if len(groups.Groups) != 2 || len(groups.Groups[0]) != 2 {
+		t.Errorf("identical groups = %v, want [[0 1] [2]]", groups.Groups)
+	}
+}
+
+// TestBrepCreateFromDefinition: a sound tetra graph compiles; a bad index is
+// reported by path with no handle.
+func TestBrepCreateFromDefinition(t *testing.T) {
+	r, s := emptyPartSession(t)
+	def := tetraWireDefinition()
+	args, err := json.Marshal(wire.BrepCreateFromDefinitionArgs{Definition: def})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res wire.BrepCreateFromDefinitionResult
+	call(t, r, s, "brep.createFromDefinition", string(args), &res)
+	if res.Handle == 0 || len(res.Issues) != 0 {
+		t.Fatalf("definition compile = %+v, want a handle", res)
+	}
+	if want := 1.0 / 6; stdmath.Abs(res.Stats.Volume-want) > 1e-6 {
+		t.Errorf("tetra volume = %g, want %g", res.Stats.Volume, want)
+	}
+	def.Edges[0].StartVertex = 42
+	args, _ = json.Marshal(wire.BrepCreateFromDefinitionArgs{Definition: def})
+	var bad wire.BrepCreateFromDefinitionResult
+	call(t, r, s, "brep.createFromDefinition", string(args), &bad)
+	if bad.Handle != 0 || len(bad.Issues) == 0 || bad.Issues[0].Path != "edges[0]" {
+		t.Errorf("bad graph = %+v, want edges[0] issue and no handle", bad)
+	}
+}
+
+// tetraWireDefinition is the unit tetrahedron as a wire definition graph
+// (the same windings as the kernel compiler's own test).
+func tetraWireDefinition() types.BrepBodyDefinition {
+	pts := [][]float64{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}}
+	var def types.BrepBodyDefinition
+	def.Solid = true
+	for _, p := range pts {
+		def.Vertices = append(def.Vertices, types.BrepVertexDef{Position: p})
+	}
+	pairs := [][2]int{{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}}
+	for _, pr := range pairs {
+		def.Edges = append(def.Edges, types.BrepEdgeDef{
+			Curve: types.BrepCurveDef{Kind: "lineSegment", Points: []float64{
+				pts[pr[0]][0], pts[pr[0]][1], pts[pr[0]][2],
+				pts[pr[1]][0], pts[pr[1]][1], pts[pr[1]][2],
+			}},
+			StartVertex: pr[0], EndVertex: pr[1],
+		})
+	}
+	use := func(e int, opp bool) types.BrepEdgeUseDef { return types.BrepEdgeUseDef{Edge: e, Opposed: opp} }
+	loops := [][]types.BrepEdgeUseDef{
+		{use(1, false), use(3, true), use(0, true)},
+		{use(0, false), use(4, false), use(2, true)},
+		{use(2, false), use(5, true), use(1, true)},
+		{use(3, false), use(5, false), use(4, true)},
+	}
+	normals := [][]float64{{0, 0, -1}, {0, -1, 0}, {-1, 0, 0}, {1, 1, 1}}
+	origins := [][]float64{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {1, 0, 0}}
+	for i := range loops {
+		def.Faces = append(def.Faces, types.BrepFaceDef{
+			Surface: types.BrepSurfaceDef{Kind: "plane", Origin: origins[i], Normal: normals[i]},
+			Loops:   []types.BrepLoopDef{{Uses: loops[i]}},
+		})
+	}
+	def.Lumps = []types.BrepLumpDef{{Shells: []types.BrepShellDef{{Faces: []int{0, 1, 2, 3}}}}}
+	return def
+}
+
+// TestBrepRuledSurfaceFromSections: rule between two parallel sections of a
+// block — a tube of area perimeter × gap.
+func TestBrepRuledSurfaceFromSections(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var block wire.BrepHandleResult
+	call(t, r, s, "brep.createPrimitive", `{"kind":"block","min":[0,0,0],"max":[2,1,4]}`, &block)
+	var s1, s2 wire.BrepWiresResult
+	call(t, r, s, "brep.sectionWithPlane",
+		fmt.Sprintf(`{"source":{"handle":%d},"planeOrigin":[0,0,1],"planeNormal":[0,0,1]}`, block.Handle), &s1)
+	call(t, r, s, "brep.sectionWithPlane",
+		fmt.Sprintf(`{"source":{"handle":%d},"planeOrigin":[0,0,3],"planeNormal":[0,0,1]}`, block.Handle), &s2)
+	var ruled wire.BrepHandleResult
+	call(t, r, s, "brep.ruledSurface",
+		fmt.Sprintf(`{"sectionOne":{"body":{"handle":%d},"wireIndex":0},"sectionTwo":{"body":{"handle":%d},"wireIndex":0}}`,
+			s1.Handle, s2.Handle), &ruled)
+	if ruled.Stats.Solid {
+		t.Error("a ruled surface is a surface body")
+	}
+	if ruled.Stats.Faces == 0 {
+		t.Error("ruled surface should carry faces")
+	}
+}
+
+// TestBrepSilhouetteOnDocumentCylinder: silhouette of a revolved cylinder's
+// side face from +X — two rulings.
+func TestBrepSilhouetteOnDocumentCylinder(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0]],"radius":"20 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct{}{})
+	var copied wire.BrepHandleResult
+	call(t, r, s, "brep.copy", `{"source":{"bodyIndex":0}}`, &copied)
+	// Find the cylindrical side face on the COPY via ray: fire from outside
+	// at mid-height toward the axis.
+	keyArgs, _ := json.Marshal(wire.BrepSilhouetteArgs{
+		Source: wire.BrepBodyRef{Handle: copied.Handle}, FaceKey: sideFaceKey(t, s, copied.Handle),
+		ViewDirection: []float64{1, 0, 0}, IncludeBoundary: true,
+	})
+	var sil wire.BrepWiresResult
+	call(t, r, s, "brep.silhouette", string(keyArgs), &sil)
+	if len(sil.Wires) != 2 {
+		t.Fatalf("cylinder silhouette = %d wires, want 2 rulings", len(sil.Wires))
+	}
+}
+
+// sideFaceKey returns the transient copy's curved (cylindrical) side face
+// key, probed directly on the registry — the wire surface addresses faces by
+// key but does not enumerate a transient body's faces (the document's
+// model.referenceKeys covers documents).
+func sideFaceKey(t *testing.T, s *app.Session, handle int) string {
+	t.Helper()
+	tb, ok := s.TransientBodies().ByHandle(handle)
+	if !ok {
+		t.Fatal("missing transient body")
+	}
+	for _, f := range tb.Topo().Faces() {
+		if _, planar := f.Geometry().(geom.Plane); !planar {
+			return string(f.ReferenceKey())
+		}
+	}
+	t.Fatal("no curved side face on the cylinder copy")
+	return ""
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -303,6 +303,44 @@ func (r *Router) registerMaterialHandlers() {
 	r.handlers[wire.MethodModelAssignMaterial] = assignMaterial
 	r.handlers[wire.MethodModelAssignAppearance] = assignAppearance
 	r.handlers[wire.MethodModelPhysicalProperties] = physicalProperties
+
+	// Body topology, queries and facet sets (M07 #293/#629/#630).
+	r.handlers[wire.MethodBodyList] = bodyList
+	r.handlers[wire.MethodBodyShells] = bodyShells
+	r.handlers[wire.MethodBodyWires] = bodyWires
+	r.handlers[wire.MethodWireOffsetPlanar] = wireOffsetPlanar
+	r.handlers[wire.MethodBodyLocateUsingPoint] = bodyLocateUsingPoint
+	r.handlers[wire.MethodBodyFindUsingRay] = bodyFindUsingRay
+	r.handlers[wire.MethodBodyIsPointInside] = bodyIsPointInside
+	r.handlers[wire.MethodBodyConvexityEdges] = bodyConvexityEdges
+	r.handlers[wire.MethodBodyValidate] = bodyValidate
+	r.handlers[wire.MethodBodyRangeBox] = bodyRangeBox
+	r.handlers[wire.MethodBodyBindTransientKey] = bodyBindTransientKey
+	r.handlers[wire.MethodBodyCalculateFacets] = bodyCalculateFacets
+	r.handlers[wire.MethodBodyExistingFacets] = bodyExistingFacets
+	r.handlers[wire.MethodBodyFacetTolerances] = bodyFacetTolerances
+	r.handlers[wire.MethodBodyCalculateStrokes] = bodyCalculateStrokes
+	r.handlers[wire.MethodBodyExistingStrokes] = bodyExistingStrokes
+	r.handlers[wire.MethodBodyStrokeTolerances] = bodyStrokeTolerances
+	r.handlers[wire.MethodFaceCalculateFacets] = faceCalculateFacets
+	r.handlers[wire.MethodFaceCalculateStrokes] = faceCalculateStrokes
+
+	// The transient B-rep factory (M07 #628) — session-scoped, no document
+	// mutation, so none of these are mutating methods.
+	r.handlers[wire.MethodBrepCreatePrimitive] = brepCreatePrimitive
+	r.handlers[wire.MethodBrepBoolean] = brepBoolean
+	r.handlers[wire.MethodBrepTransform] = brepTransform
+	r.handlers[wire.MethodBrepCopy] = brepCopy
+	r.handlers[wire.MethodBrepSectionWithPlane] = brepSectionWithPlane
+	r.handlers[wire.MethodBrepDeleteFaces] = brepDeleteFaces
+	r.handlers[wire.MethodBrepSilhouette] = brepSilhouette
+	r.handlers[wire.MethodBrepRuledSurface] = brepRuledSurface
+	r.handlers[wire.MethodBrepImprint] = brepImprint
+	r.handlers[wire.MethodBrepIdenticalBodies] = brepIdenticalBodies
+	r.handlers[wire.MethodBrepCreateFromDefinition] = brepCreateFromDefinition
+	r.handlers[wire.MethodBrepDescribe] = brepDescribe
+	r.handlers[wire.MethodBrepList] = brepList
+	r.handlers[wire.MethodBrepDelete] = brepDelete
 }
 
 // registerLightingHandlers wires the lighting-style, light, environment, and shadow methods

--- a/app/body_services.go
+++ b/app/body_services.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/bodyapi"
+	"oblikovati.org/model/facetstore"
+)
+
+// Session-owned body services (M07): the tolerance-keyed facet/stroke cache
+// (#293) and the transient B-rep registry (#628). Both are lazy — most
+// sessions never touch them.
+
+// FacetStore returns the session's facet/stroke cache.
+func (s *Session) FacetStore() *facetstore.FacetStore {
+	if s.facetStore == nil {
+		s.facetStore = facetstore.NewFacetStore()
+	}
+	return s.facetStore
+}
+
+// TransientBodies returns the session's transient B-rep factory/registry.
+func (s *Session) TransientBodies() *bodyapi.TransientBRep {
+	if s.transientBodies == nil {
+		s.transientBodies = bodyapi.NewTransientBRep(ops.DefaultQuality())
+	}
+	return s.transientBodies
+}

--- a/app/session.go
+++ b/app/session.go
@@ -10,9 +10,11 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app/options"
 	"oblikovati.org/event"
+	"oblikovati.org/model/bodyapi"
 	"oblikovati.org/model/clientgraphics"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/facetstore"
 	"oblikovati.org/model/material"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/persistence/dialogmemory"
@@ -32,6 +34,8 @@ type Session struct {
 	workspace            *doc.Workspace
 	store                doc.Store                // the workspace's persistence backend; nil for in-memory sessions
 	sketchInference      *sketch.InferenceOptions // session inference prefs (M06-F10; nil ⇒ defaults)
+	facetStore           *facetstore.FacetStore   // tolerance-keyed facet/stroke cache (M07 #293; lazy)
+	transientBodies      *bodyapi.TransientBRep   // transient B-rep registry (M07 #628; lazy)
 	commands             *CommandManager
 	histories            map[doc.ID]*docHistory // per-document transaction-event streams (undo/redo)
 	viewState            viewstate.Store        // per-user document view/camera persistence (nil ⇒ disabled)

--- a/kernel/brep/definition.go
+++ b/kernel/brep/definition.go
@@ -104,10 +104,7 @@ func CompileSurfaceBodyDefinition(def SurfaceBodyDefinition, feat string) (*topo
 	if len(issues) > 0 {
 		return nil, issues
 	}
-	issues = compileFaces(bld, def, edges, feat)
-	if len(issues) > 0 {
-		return nil, issues
-	}
+	compileFaces(bld, def, edges, feat)
 	body := bld.Build()
 	compileWires(body, def, edges, feat)
 	return body, nil
@@ -203,8 +200,9 @@ func compileEdges(bld *topo.Builder, def SurfaceBodyDefinition, verts []*topo.Ve
 	return out, issues
 }
 
-func compileFaces(bld *topo.Builder, def SurfaceBodyDefinition, edges []*topo.Edge, feat string) []DefinitionIssue {
-	var issues []DefinitionIssue
+// compileFaces builds the faces (index validity was established up front, so
+// this stage cannot fail).
+func compileFaces(bld *topo.Builder, def SurfaceBodyDefinition, edges []*topo.Edge, feat string) {
 	for i, f := range def.Faces {
 		specs := make([]topo.LoopSpec, len(f.Loops))
 		for j, l := range f.Loops {
@@ -225,7 +223,6 @@ func compileFaces(bld *topo.Builder, def SurfaceBodyDefinition, edges []*topo.Ed
 			bld.AddFace(f.Surface, lin, specs...)
 		}
 	}
-	return issues
 }
 
 func compileWires(body *topo.Body, def SurfaceBodyDefinition, edges []*topo.Edge, feat string) {

--- a/kernel/brep/definition.go
+++ b/kernel/brep/definition.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Bottom-up B-rep construction (M07-F05, Oblikovati/Oblikovati#628): the
+// reference SurfaceBodyDefinition graph — vertices, edges, faces with
+// edge-use loops, shells grouped into lumps, plus wire edges — compiled into
+// a topo.Body through the Builder. Construction problems are collected per
+// definition (the reference CreateTransientSurfaceBody errors map), not
+// aborted at the first.
+
+// VertexDefinition is one definition-graph vertex.
+type VertexDefinition struct {
+	Position      math.Point3
+	AssociativeID int
+}
+
+// EdgeDefinition is one edge: its model-space curve and endpoint vertex
+// indices (into the definition's Vertices).
+type EdgeDefinition struct {
+	Curve         geom.Curve3
+	StartVertex   int
+	EndVertex     int
+	AssociativeID int
+}
+
+// EdgeUseDefinition is one oriented edge use within a loop (Opposed =
+// traversed against the edge's natural direction).
+type EdgeUseDefinition struct {
+	Edge    int
+	Opposed bool
+}
+
+// EdgeLoopDefinition is one boundary loop; a face's FIRST loop is its outer.
+type EdgeLoopDefinition struct {
+	Uses []EdgeUseDefinition
+}
+
+// FaceDefinition is one face: surface geometry, loops, and whether the
+// material side opposes the surface normal.
+type FaceDefinition struct {
+	Surface       geom.Surface
+	ParamReversed bool
+	Loops         []EdgeLoopDefinition
+	AssociativeID int
+}
+
+// FaceShellDefinition groups face indices (into the definition's Faces).
+type FaceShellDefinition struct {
+	Faces []int
+}
+
+// WireDefinition is an ordered chain of edge indices carried without faces.
+type WireDefinition struct {
+	Edges []int
+}
+
+// LumpDefinition groups shells and wires (the body's connected regions).
+type LumpDefinition struct {
+	Shells []FaceShellDefinition
+	Wires  []WireDefinition
+}
+
+// SurfaceBodyDefinition is the whole graph.
+type SurfaceBodyDefinition struct {
+	Vertices []VertexDefinition
+	Edges    []EdgeDefinition
+	Faces    []FaceDefinition
+	Lumps    []LumpDefinition
+	Solid    bool
+}
+
+// DefinitionIssue is one construction problem, addressed by its graph path.
+type DefinitionIssue struct {
+	Path    string
+	Problem string
+}
+
+func issuef(issues []DefinitionIssue, path, format string, args ...interface{}) []DefinitionIssue {
+	return append(issues, DefinitionIssue{Path: path, Problem: fmt.Sprintf(format, args...)})
+}
+
+// CompileSurfaceBodyDefinition builds the body. A non-empty issue list means
+// the graph was rejected (no body); the topological validity of an
+// issue-free result is the caller's ops.Validate pass.
+//
+// Example: body, issues := brep.CompileSurfaceBodyDefinition(def, "addin")
+func CompileSurfaceBodyDefinition(def SurfaceBodyDefinition, feat string) (*topo.Body, []DefinitionIssue) {
+	issues := validateDefinitionIndices(def)
+	if len(issues) > 0 {
+		return nil, issues
+	}
+	bld := topo.NewBuilder(def.Solid, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	verts := compileVertices(bld, def, feat)
+	edges, issues := compileEdges(bld, def, verts, feat)
+	if len(issues) > 0 {
+		return nil, issues
+	}
+	issues = compileFaces(bld, def, edges, feat)
+	if len(issues) > 0 {
+		return nil, issues
+	}
+	body := bld.Build()
+	compileWires(body, def, edges, feat)
+	return body, nil
+}
+
+// validateDefinitionIndices checks every cross-reference before building.
+func validateDefinitionIndices(def SurfaceBodyDefinition) []DefinitionIssue {
+	var issues []DefinitionIssue
+	for i, e := range def.Edges {
+		if e.StartVertex < 0 || e.StartVertex >= len(def.Vertices) || e.EndVertex < 0 || e.EndVertex >= len(def.Vertices) {
+			issues = issuef(issues, fmt.Sprintf("edges[%d]", i),
+				"vertex indices (%d, %d) out of range (have %d vertices)", e.StartVertex, e.EndVertex, len(def.Vertices))
+		}
+		if e.Curve == nil {
+			issues = issuef(issues, fmt.Sprintf("edges[%d]", i), "edge has no curve")
+		}
+	}
+	issues = append(issues, validateFaceIndices(def)...)
+	issues = append(issues, validateLumpIndices(def)...)
+	return issues
+}
+
+func validateFaceIndices(def SurfaceBodyDefinition) []DefinitionIssue {
+	var issues []DefinitionIssue
+	for i, f := range def.Faces {
+		if f.Surface == nil {
+			issues = issuef(issues, fmt.Sprintf("faces[%d]", i), "face has no surface")
+		}
+		for j, l := range f.Loops {
+			if len(l.Uses) == 0 {
+				issues = issuef(issues, fmt.Sprintf("faces[%d].loops[%d]", i, j), "loop has no edge uses")
+			}
+			for k, u := range l.Uses {
+				if u.Edge < 0 || u.Edge >= len(def.Edges) {
+					issues = issuef(issues, fmt.Sprintf("faces[%d].loops[%d].uses[%d]", i, j, k),
+						"edge index %d out of range (have %d edges)", u.Edge, len(def.Edges))
+				}
+			}
+		}
+	}
+	return issues
+}
+
+func validateLumpIndices(def SurfaceBodyDefinition) []DefinitionIssue {
+	var issues []DefinitionIssue
+	for i, lump := range def.Lumps {
+		for j, sh := range lump.Shells {
+			for k, fi := range sh.Faces {
+				if fi < 0 || fi >= len(def.Faces) {
+					issues = issuef(issues, fmt.Sprintf("lumps[%d].shells[%d].faces[%d]", i, j, k),
+						"face index %d out of range (have %d faces)", fi, len(def.Faces))
+				}
+			}
+		}
+		for j, w := range lump.Wires {
+			for k, ei := range w.Edges {
+				if ei < 0 || ei >= len(def.Edges) {
+					issues = issuef(issues, fmt.Sprintf("lumps[%d].wires[%d].edges[%d]", i, j, k),
+						"edge index %d out of range (have %d edges)", ei, len(def.Edges))
+				}
+			}
+		}
+	}
+	return issues
+}
+
+func compileVertices(bld *topo.Builder, def SurfaceBodyDefinition, feat string) []*topo.Vertex {
+	out := make([]*topo.Vertex, len(def.Vertices))
+	for i, v := range def.Vertices {
+		out[i] = bld.AddVertex(v.Position, topo.NewLineage(topo.Tok(feat, "vertex", associativeOr(v.AssociativeID, i))))
+	}
+	return out
+}
+
+// compileEdges builds the edges, checking each curve's ends actually land on
+// its declared vertices (the classic hand-built-graph mistake).
+func compileEdges(bld *topo.Builder, def SurfaceBodyDefinition, verts []*topo.Vertex, feat string) ([]*topo.Edge, []DefinitionIssue) {
+	const endTol = 1e-6
+	var issues []DefinitionIssue
+	out := make([]*topo.Edge, len(def.Edges))
+	for i, e := range def.Edges {
+		lo, hi := e.Curve.Domain()
+		s, t := e.Curve.PointAt(lo), e.Curve.PointAt(hi)
+		sv, ev := verts[e.StartVertex].Point(), verts[e.EndVertex].Point()
+		if float64(s.DistanceTo(sv)) > endTol || float64(t.DistanceTo(ev)) > endTol {
+			issues = issuef(issues, fmt.Sprintf("edges[%d]", i),
+				"curve ends %v→%v do not meet vertices %v→%v (tolerance %g)", s, t, sv, ev, endTol)
+			continue
+		}
+		out[i] = bld.AddEdge(e.Curve, verts[e.StartVertex], verts[e.EndVertex],
+			topo.NewLineage(topo.Tok(feat, "edge", associativeOr(e.AssociativeID, i))))
+	}
+	return out, issues
+}
+
+func compileFaces(bld *topo.Builder, def SurfaceBodyDefinition, edges []*topo.Edge, feat string) []DefinitionIssue {
+	var issues []DefinitionIssue
+	for i, f := range def.Faces {
+		specs := make([]topo.LoopSpec, len(f.Loops))
+		for j, l := range f.Loops {
+			uses := make([]topo.Use, len(l.Uses))
+			for k, u := range l.Uses {
+				uses[k] = topo.Use{Edge: edges[u.Edge], Reversed: u.Opposed}
+			}
+			if j == 0 {
+				specs[j] = topo.OuterLoop(uses...)
+			} else {
+				specs[j] = topo.InnerLoop(uses...)
+			}
+		}
+		lin := topo.NewLineage(topo.Tok(feat, "face", associativeOr(f.AssociativeID, i)))
+		if f.ParamReversed {
+			bld.AddReversedFace(f.Surface, lin, specs...)
+		} else {
+			bld.AddFace(f.Surface, lin, specs...)
+		}
+	}
+	return issues
+}
+
+func compileWires(body *topo.Body, def SurfaceBodyDefinition, edges []*topo.Edge, feat string) {
+	wi := 0
+	for _, lump := range def.Lumps {
+		for _, w := range lump.Wires {
+			uses := make([]topo.Use, len(w.Edges))
+			for k, ei := range w.Edges {
+				uses[k] = topo.Fwd(edges[ei])
+			}
+			body.AttachWire(topo.NewLineage(topo.Tok(feat, "wire", wi)), uses)
+			wi++
+		}
+	}
+}
+
+// associativeOr prefers the caller's associative id, falling back to the
+// definition index, so reference keys are caller-stable when ids are given.
+func associativeOr(id, fallback int) int {
+	if id != 0 {
+		return id
+	}
+	return fallback
+}

--- a/kernel/brep/definition_test.go
+++ b/kernel/brep/definition_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// tetraDefinition is the unit tetrahedron as a bottom-up definition graph —
+// 4 vertices, 6 edges, 4 faces with consistently outward loops.
+func tetraDefinition() brep.SurfaceBodyDefinition {
+	p := []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(0, 0, 1)}
+	var def brep.SurfaceBodyDefinition
+	def.Solid = true
+	for i, pt := range p {
+		def.Vertices = append(def.Vertices, brep.VertexDefinition{Position: pt, AssociativeID: 100 + i})
+	}
+	pairs := [][2]int{{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}}
+	for _, pr := range pairs {
+		def.Edges = append(def.Edges, brep.EdgeDefinition{
+			Curve: geom.NewLineSegment(p[pr[0]], p[pr[1]]), StartVertex: pr[0], EndVertex: pr[1],
+		})
+	}
+	// Outward loops — the same windings as ops_test's proven tetra builder
+	// (each shared edge traversed once Fwd, once Opposed).
+	use := func(e int, opp bool) brep.EdgeUseDefinition { return brep.EdgeUseDefinition{Edge: e, Opposed: opp} }
+	loops := [][]brep.EdgeUseDefinition{
+		{use(1, false), use(3, true), use(0, true)},  // bottom (z=0), outward −Z
+		{use(0, false), use(4, false), use(2, true)}, // y=0 side, outward −Y
+		{use(2, false), use(5, true), use(1, true)},  // x=0 side, outward −X
+		{use(3, false), use(5, false), use(4, true)}, // slanted, outward (1,1,1)
+	}
+	normals := []math.Vector3{math.V3(0, 0, -1), math.V3(0, -1, 0), math.V3(-1, 0, 0), math.V3(1, 1, 1)}
+	origins := []math.Point3{p[0], p[0], p[0], p[1]}
+	for i := range loops {
+		surf, _ := geom.NewPlane(origins[i], normals[i])
+		def.Faces = append(def.Faces, brep.FaceDefinition{Surface: surf, Loops: []brep.EdgeLoopDefinition{{Uses: loops[i]}}})
+	}
+	def.Lumps = []brep.LumpDefinition{{Shells: []brep.FaceShellDefinition{{Faces: []int{0, 1, 2, 3}}}}}
+	return def
+}
+
+// TestCompileDefinitionTetra: the graph compiles into a valid solid of the
+// analytic volume 1/6, with caller-stable vertex keys.
+func TestCompileDefinitionTetra(t *testing.T) {
+	body, issues := brep.CompileSurfaceBodyDefinition(tetraDefinition(), "addin")
+	if len(issues) > 0 {
+		t.Fatalf("compile issues: %+v", issues)
+	}
+	if r := ops.Validate(body); !r.Valid || !r.Closed {
+		t.Fatalf("compiled tetra invalid: %+v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-1.0/6) > 1e-9 {
+		t.Errorf("compiled tetra volume = %g, want 1/6", v)
+	}
+	if len(body.Vertices()) != 4 || len(body.Edges()) != 6 || len(body.Faces()) != 4 {
+		t.Errorf("topology = %d/%d/%d, want 4/6/4", len(body.Vertices()), len(body.Edges()), len(body.Faces()))
+	}
+}
+
+// TestCompileDefinitionReportsProblems: bad indices and detached curves are
+// reported per definition with their graph path, and no body is built.
+func TestCompileDefinitionReportsProblems(t *testing.T) {
+	def := tetraDefinition()
+	def.Edges[2].EndVertex = 99 // out of range
+	body, issues := brep.CompileSurfaceBodyDefinition(def, "addin")
+	if body != nil || len(issues) == 0 {
+		t.Fatal("an out-of-range vertex index must reject the graph")
+	}
+	if issues[0].Path != "edges[2]" || !strings.Contains(issues[0].Problem, "99") {
+		t.Errorf("issue = %+v, want edges[2] naming index 99", issues[0])
+	}
+
+	def2 := tetraDefinition()
+	def2.Edges[0].Curve = geom.NewLineSegment(math.P3(5, 5, 5), math.P3(6, 6, 6)) // curve off its vertices
+	if body, issues := brep.CompileSurfaceBodyDefinition(def2, "addin"); body != nil || len(issues) == 0 {
+		t.Error("a curve detached from its vertices must reject the graph")
+	}
+}
+
+// TestCompileDefinitionWires: wire definitions land as body wires.
+func TestCompileDefinitionWires(t *testing.T) {
+	def := tetraDefinition()
+	def.Faces = nil
+	def.Solid = false
+	def.Lumps = []brep.LumpDefinition{{Wires: []brep.WireDefinition{{Edges: []int{0, 3}}}}}
+	body, issues := brep.CompileSurfaceBodyDefinition(def, "addin")
+	if len(issues) > 0 {
+		t.Fatalf("compile issues: %+v", issues)
+	}
+	if len(body.Wires()) != 1 || len(body.Wires()[0].Edges()) != 2 {
+		t.Errorf("wire body has %d wires, want 1 with 2 edges", len(body.Wires()))
+	}
+}
+
+// TestImprintBodiesSplitsContact: two stacked boxes imprint each other — the
+// big box's top face splits along the small box's footprint, both bodies keep
+// their volumes, and the touched faces/edges are reported.
+func TestImprintBodiesSplitsContact(t *testing.T) {
+	big, _ := brep.SolidBlock(math.P3(0, 0, 0), math.P3(4, 4, 1), "big")
+	small, _ := brep.SolidBlock(math.P3(1, 1, 1), math.P3(3, 3, 2), "small")
+	ra, rb, err := brep.ImprintBodies(big, small)
+	if err != nil {
+		t.Fatalf("ImprintBodies: %v", err)
+	}
+	if v := vol(ra.Body); stdmath.Abs(v-16) > 1e-6 {
+		t.Errorf("imprinted big volume = %g, want 16", v)
+	}
+	if v := vol(rb.Body); stdmath.Abs(v-4) > 1e-6 {
+		t.Errorf("imprinted small volume = %g, want 4", v)
+	}
+	if len(ra.Body.Faces()) <= 6 {
+		t.Errorf("big body has %d faces; the top should have split (>6)", len(ra.Body.Faces()))
+	}
+	if len(ra.TouchedFaces) == 0 || len(ra.ImprintedEdge) == 0 {
+		t.Errorf("imprint should report touched faces (%d) and imprinted edges (%d)",
+			len(ra.TouchedFaces), len(ra.ImprintedEdge))
+	}
+}

--- a/kernel/brep/imprint_public.go
+++ b/kernel/brep/imprint_public.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Public body imprinting (M07-F05, Oblikovati/Oblikovati#628): the reference
+// TransientBRep.ImprintBodies. Each body's faces split along its face–face
+// intersections with the other body, WITHOUT removing material — both results
+// keep their full skins, with new edges where the bodies touch. Planar-faced
+// bodies only (the same constraint as the exact boolean); curved operands
+// return ErrNonPlanar.
+
+// ImprintResult carries one imprinted copy plus the faces that were touched
+// (split or coincident with the other body).
+type ImprintResult struct {
+	Body          *topo.Body
+	TouchedFaces  []*topo.Face
+	ImprintedEdge []*topo.Edge
+}
+
+// ImprintBodies imprints a and b against each other, returning new bodies.
+//
+// Example: ra, rb, err := brep.ImprintBodies(a, b)
+func ImprintBodies(a, b *topo.Body) (ImprintResult, ImprintResult, error) {
+	fa, oka := facesOf(a)
+	fb, okb := facesOf(b)
+	if !oka || !okb {
+		return ImprintResult{}, ImprintResult{}, ErrNonPlanar
+	}
+	impA, impB := imprintAll(fa, fb)
+	ra, err := rebuildImprinted(fa, impA)
+	if err != nil {
+		return ImprintResult{}, ImprintResult{}, err
+	}
+	rb, err := rebuildImprinted(fb, impB)
+	if err != nil {
+		return ImprintResult{}, ImprintResult{}, err
+	}
+	return ra, rb, nil
+}
+
+// rebuildImprinted splits each face along its imprints and stitches ALL pieces
+// back (no classification — nothing is removed; the stitcher re-derives
+// solidity from edge pairing), tracking the touched faces and the new
+// imprint-lying edges.
+func rebuildImprinted(faces []planarFace, imprints [][][2]math.Point3) (ImprintResult, error) {
+	var kept []subFace
+	touched := map[string]bool{}
+	for i, f := range faces {
+		pieces := splitFace(f, imprints[i])
+		for k := range pieces {
+			if len(pieces) == 1 {
+				pieces[k].lineage = f.lineage
+			} else {
+				pieces[k].lineage = splitLineage(f.lineage, k)
+			}
+		}
+		if len(imprints[i]) > 0 {
+			touched[string(f.lineage.Key())] = true
+		}
+		kept = append(kept, pieces...)
+	}
+	body, err := stitch(kept)
+	if err != nil || body == nil {
+		return ImprintResult{}, err
+	}
+	return collectImprintTouches(body, touched, allImprints(imprints)), nil
+}
+
+// collectImprintTouches resolves the touched faces and imprint edges on the
+// rebuilt body: a face whose lineage starts with a touched source lineage, an
+// edge whose midpoint lies on an imprint segment.
+func collectImprintTouches(body *topo.Body, touched map[string]bool, segs [][2]math.Point3) ImprintResult {
+	out := ImprintResult{Body: body}
+	for _, f := range body.Faces() {
+		if lineagePrefixIn(f.Lineage(), touched) {
+			out.TouchedFaces = append(out.TouchedFaces, f)
+		}
+	}
+	for _, e := range body.Edges() {
+		if edgeOnSegments(e, segs) {
+			out.ImprintedEdge = append(out.ImprintedEdge, e)
+		}
+	}
+	return out
+}
+
+func allImprints(imprints [][][2]math.Point3) [][2]math.Point3 {
+	var out [][2]math.Point3
+	for _, per := range imprints {
+		out = append(out, per...)
+	}
+	return out
+}
+
+// lineagePrefixIn reports whether the lineage or any token-prefix of it is in
+// the touched set (split pieces carry the parent lineage + a split token).
+func lineagePrefixIn(l topo.Lineage, touched map[string]bool) bool {
+	tokens := l.Tokens()
+	for n := len(tokens); n > 0; n-- {
+		if touched[string(topo.NewLineage(tokens[:n]...).Key())] {
+			return true
+		}
+	}
+	return false
+}
+
+// edgeOnSegments reports whether the edge's midpoint lies on any imprint
+// segment (within the boolean weld tolerance).
+func edgeOnSegments(e *topo.Edge, segs [][2]math.Point3) bool {
+	c := e.Geometry()
+	lo, hi := c.Domain()
+	mid := c.PointAt((lo + hi) / 2)
+	for _, s := range segs {
+		if pointOnSegment3(mid, s[0], s[1], 1e-7) {
+			return true
+		}
+	}
+	return false
+}
+
+func pointOnSegment3(p, a, b math.Point3, tol float64) bool {
+	ab := a.VectorTo(b)
+	denom := float64(ab.LengthSquared())
+	if denom == 0 {
+		return float64(p.DistanceTo(a)) <= tol
+	}
+	t := float64(a.VectorTo(p).Dot(ab)) / denom
+	if t < 0 || t > 1 {
+		return false
+	}
+	on := a.TranslateBy(ab.Scale(math.Scalar(t)))
+	return float64(p.DistanceTo(on)) <= tol
+}

--- a/kernel/brep/primitives.go
+++ b/kernel/brep/primitives.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Analytic solid primitives for the transient B-rep factory (M07-F05,
+// Oblikovati/Oblikovati#628): block, cylinder/cone, sphere, torus. Sphere and
+// torus are CLOSED surfaces — one boundary-less face each; the tessellator's
+// closed-domain mesher wraps their seams and poles watertight (M25 PBI-330).
+
+// SolidBlock builds the axis-aligned box [min, max] as six planar faces.
+//
+// Example: b, err := brep.SolidBlock(math.P3(0,0,0), math.P3(4,2,1), "block")
+func SolidBlock(min, max math.Point3, feat string) (*topo.Body, error) {
+	sx, sy, sz := float64(max.X-min.X), float64(max.Y-min.Y), float64(max.Z-min.Z)
+	if sx <= 0 || sy <= 0 || sz <= 0 {
+		return nil, fmt.Errorf("brep.SolidBlock: box %v→%v has a non-positive extent (%g, %g, %g)",
+			min, max, sx, sy, sz)
+	}
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	v := blockVertices(bld, min, max, feat)
+	e := blockEdges(bld, v, feat)
+	blockFaces(bld, v, e, feat)
+	return bld.Build(), nil
+}
+
+// blockCorner index convention: bit 0 = +X, bit 1 = +Y, bit 2 = +Z.
+func blockVertices(bld *topo.Builder, min, max math.Point3, feat string) [8]*topo.Vertex {
+	var v [8]*topo.Vertex
+	for i := 0; i < 8; i++ {
+		p := math.P3(pick(i&1 != 0, max.X, min.X), pick(i&2 != 0, max.Y, min.Y), pick(i&4 != 0, max.Z, min.Z))
+		v[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(feat, "vertex", i)))
+	}
+	return v
+}
+
+func pick(hi bool, a, b math.Scalar) math.Scalar {
+	if hi {
+		return a
+	}
+	return b
+}
+
+// blockEdgePairs lists the cube's 12 edges by corner index.
+var blockEdgePairs = [12][2]int{
+	{0, 1}, {2, 3}, {4, 5}, {6, 7}, // along X
+	{0, 2}, {1, 3}, {4, 6}, {5, 7}, // along Y
+	{0, 4}, {1, 5}, {2, 6}, {3, 7}, // along Z
+}
+
+func blockEdges(bld *topo.Builder, v [8]*topo.Vertex, feat string) map[[2]int]*topo.Edge {
+	out := map[[2]int]*topo.Edge{}
+	for i, pair := range blockEdgePairs {
+		out[pair] = bld.AddEdge(geom.NewLineSegment(v[pair[0]].Point(), v[pair[1]].Point()),
+			v[pair[0]], v[pair[1]], topo.NewLineage(topo.Tok(feat, "edge", i)))
+	}
+	return out
+}
+
+// blockFaceCorners lists each face's corners wound CCW seen from OUTSIDE.
+var blockFaceCorners = [6][4]int{
+	{0, 2, 3, 1}, // -Z (bottom): outward −Z
+	{4, 5, 7, 6}, // +Z (top)
+	{0, 1, 5, 4}, // -Y (front)
+	{2, 6, 7, 3}, // +Y (back)
+	{0, 4, 6, 2}, // -X (left)
+	{1, 3, 7, 5}, // +X (right)
+}
+
+func blockFaces(bld *topo.Builder, v [8]*topo.Vertex, e map[[2]int]*topo.Edge, feat string) {
+	for fi, corners := range blockFaceCorners {
+		uses := make([]topo.Use, 4)
+		for k := 0; k < 4; k++ {
+			a, b := corners[k], corners[(k+1)%4]
+			if edge, ok := e[[2]int{a, b}]; ok {
+				uses[k] = topo.Fwd(edge)
+			} else {
+				uses[k] = topo.Rev(e[[2]int{b, a}])
+			}
+		}
+		n := v[corners[0]].Point().VectorTo(v[corners[1]].Point()).
+			Cross(v[corners[1]].Point().VectorTo(v[corners[2]].Point()))
+		surf, _ := geom.NewPlane(v[corners[0]].Point(), n)
+		bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "face", fi)), topo.OuterLoop(uses...))
+	}
+}
+
+// SolidCylinderCone builds the solid of revolution between two circular
+// sections: equal radii give a cylinder, differing radii a cone frustum, a
+// zero radius the full cone. Elliptical sections are not supported — the
+// kernel's surfaces of revolution are circular.
+//
+// Example: b, err := brep.SolidCylinderCone(math.P3(0,0,0), math.P3(0,0,5), 2, 2, "cyl")
+func SolidCylinderCone(bottom, top math.Point3, bottomRadius, topRadius float64, feat string) (*topo.Body, error) {
+	axis := bottom.VectorTo(top)
+	h := float64(axis.Length())
+	if h == 0 {
+		return nil, fmt.Errorf("brep.SolidCylinderCone: bottom and top coincide at %v", bottom)
+	}
+	if bottomRadius <= 0 && topRadius <= 0 {
+		return nil, fmt.Errorf("brep.SolidCylinderCone: radii (%g, %g) need at least one positive",
+			bottomRadius, topRadius)
+	}
+	if bottomRadius == topRadius {
+		return SolidCylinder(bottom, axis.Scale(math.Scalar(1/h)), bottomRadius, h)
+	}
+	return SolidOfRevolution(bottom, axis, coneMeridian(bottomRadius, topRadius, h), feat)
+}
+
+// coneMeridian is the CCW (radius, height) polygon of a cone/frustum.
+func coneMeridian(r0, r1, h float64) []math.Point2 {
+	if r1 <= 0 {
+		return []math.Point2{math.P2(0, 0), math.P2(math.Scalar(r0), 0), math.P2(0, math.Scalar(h))}
+	}
+	if r0 <= 0 {
+		return []math.Point2{math.P2(0, 0), math.P2(math.Scalar(r1), math.Scalar(h)), math.P2(0, math.Scalar(h))}
+	}
+	return []math.Point2{
+		math.P2(0, 0), math.P2(math.Scalar(r0), 0),
+		math.P2(math.Scalar(r1), math.Scalar(h)), math.P2(0, math.Scalar(h)),
+	}
+}
+
+// SolidSphere builds the full sphere as one boundary-less analytic face.
+//
+// Example: b, err := brep.SolidSphere(math.P3(0,0,0), 3, "sphere")
+func SolidSphere(center math.Point3, radius float64, feat string) (*topo.Body, error) {
+	surf, err := geom.NewSphere(center, radius)
+	if err != nil {
+		return nil, err
+	}
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "face", 0)))
+	return bld.Build(), nil
+}
+
+// SolidTorus builds the full torus (axis along axisDir) as one boundary-less
+// analytic face.
+//
+// Example: b, err := brep.SolidTorus(math.P3(0,0,0), math.V3(0,0,1), 5, 1, "torus")
+func SolidTorus(center math.Point3, axisDir math.Vector3, majorRadius, minorRadius float64, feat string) (*topo.Body, error) {
+	if minorRadius >= majorRadius {
+		return nil, fmt.Errorf("brep.SolidTorus: minor radius %g must be below major %g (self-intersecting otherwise)",
+			minorRadius, majorRadius)
+	}
+	surf, err := geom.NewTorus(center, axisDir, majorRadius, minorRadius)
+	if err != nil {
+		return nil, err
+	}
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "face", 0)))
+	return bld.Build(), nil
+}

--- a/kernel/brep/primitives_test.go
+++ b/kernel/brep/primitives_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+func TestPrimitiveVolumes(t *testing.T) {
+	q := ops.DefaultQuality()
+	block, err := brep.SolidBlock(math.P3(1, 1, 1), math.P3(3, 4, 6), "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := ops.BodyGeometryProperties(block, q).Volume; stdmath.Abs(v-30) > 1e-9 {
+		t.Errorf("block volume %g want 30", v)
+	}
+	cyl, err := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 4), 2, 2, "c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := ops.BodyGeometryProperties(cyl, q).Volume; stdmath.Abs(v-16*stdmath.Pi)/(16*stdmath.Pi) > 0.01 {
+		t.Errorf("cylinder volume %g want %g", v, 16*stdmath.Pi)
+	}
+	cone, err := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 3), 2, 0, "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := ops.BodyGeometryProperties(cone, q).Volume; stdmath.Abs(v-4*stdmath.Pi)/(4*stdmath.Pi) > 0.01 {
+		t.Errorf("cone volume %g want %g", v, 4*stdmath.Pi)
+	}
+	sph, err := brep.SolidSphere(math.P3(0, 0, 0), 2, "s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 4.0 / 3 * stdmath.Pi * 8
+	// The chord-tolerance mesh is inscribed: at 0.05 on r=2 the deficit is ~1.7%.
+	if v := ops.BodyGeometryProperties(sph, q).Volume; stdmath.Abs(v-want)/want > 0.02 {
+		t.Errorf("sphere volume %g want %g", v, want)
+	}
+	if !sph.IsSolid() || !sph.Shells()[0].IsClosed() {
+		t.Error("sphere must be a closed solid")
+	}
+	tor, err := brep.SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 1, "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantT := 2 * stdmath.Pi * stdmath.Pi * 5 * 1
+	if v := ops.BodyGeometryProperties(tor, q).Volume; stdmath.Abs(v-wantT)/wantT > 0.02 {
+		t.Errorf("torus volume %g want %g", v, wantT)
+	}
+}

--- a/kernel/geom/trace_surface_zero.go
+++ b/kernel/geom/trace_surface_zero.go
@@ -123,9 +123,24 @@ func appendCross(pts []math.Point3, s Surface, f scalarField, ua, va, fa, ub, vb
 // straddlesZero reports a sign change between two field samples, classifying an exact
 // zero with the negative side (a <= 0). This consistent tie-break is what lets the tracer
 // capture a contour that lies exactly on grid lines (e.g. an equator on a parameter row),
-// the classic marching-squares degeneracy, without double-counting it.
+// the classic marching-squares degeneracy, without double-counting it. Samples within
+// floating noise of zero snap to exact zero first: a node sitting ON the contour evaluates
+// to ±1e-16 with a sign that varies row to row (numerically-derived normals), and without
+// the snap adjacent columns alternate crossings, doubling the contour as a zigzag
+// (M07-F07 silhouette wires, Oblikovati/Oblikovati#630).
 func straddlesZero(a, b float64) bool {
-	return (a <= 0) != (b <= 0)
+	return (snapTinyToZero(a) <= 0) != (snapTinyToZero(b) <= 0)
+}
+
+// traceFieldEps is the field magnitude treated as exactly zero (fields here are
+// unit-vector dots, so 1e-12 is far below any genuine sample).
+const traceFieldEps = 1e-12
+
+func snapTinyToZero(v float64) float64 {
+	if stdmath.Abs(v) < traceFieldEps {
+		return 0
+	}
+	return v
 }
 
 // bisectEdge refines the zero crossing along a cell edge in parameter space and returns

--- a/kernel/ops/body_query.go
+++ b/kernel/ops/body_query.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Body locate/ray queries (M07-F07, Oblikovati/Oblikovati#630): find the
+// topology entity nearest a 3D point, and fire a ray (with a pick radius)
+// into the body. Distances are mesh-accurate at the given quality, matching
+// what picking and every other consumer sees.
+
+// LocatedEntity is one query answer: which entity, of which kind, how far.
+type LocatedEntity struct {
+	Kind     topo.EntityKind
+	Vertex   *topo.Vertex
+	Edge     *topo.Edge
+	Face     *topo.Face
+	Point    math.Point3 // the closest/hit point on the entity
+	Distance float64     // from the query point, or along the ray
+}
+
+// LocateUsingPoint returns the entity of the requested kind nearest p within
+// the proximity tolerance. kind 0 matches vertices, edges and faces, nearest
+// of any.
+//
+// Example: hit, ok := ops.LocateUsingPoint(b, 0, p, 1e-3, ops.DefaultQuality())
+func LocateUsingPoint(b *topo.Body, kind topo.EntityKind, p math.Point3, proximityTol float64, q Quality) (LocatedEntity, bool) {
+	best := LocatedEntity{Distance: stdmath.Inf(1)}
+	if kind == 0 || kind == topo.KindVertex {
+		closerVertex(&best, b, p)
+	}
+	if kind == 0 || kind == topo.KindEdge {
+		closerEdge(&best, b, p, q)
+	}
+	if kind == 0 || kind == topo.KindFace {
+		closerFace(&best, b, p, q)
+	}
+	return best, best.Distance <= proximityTol
+}
+
+func closerVertex(best *LocatedEntity, b *topo.Body, p math.Point3) {
+	for _, v := range b.Vertices() {
+		if d := float64(p.DistanceTo(v.Point())); d < best.Distance {
+			*best = LocatedEntity{Kind: topo.KindVertex, Vertex: v, Point: v.Point(), Distance: d}
+		}
+	}
+}
+
+func closerEdge(best *LocatedEntity, b *topo.Body, p math.Point3, q Quality) {
+	for _, e := range b.Edges() {
+		pl := discretizeEdge(e, q)
+		for i := 0; i+1 < len(pl); i++ {
+			cp := closestPointOnSegment(p, pl[i], pl[i+1])
+			if d := float64(p.DistanceTo(cp)); d < best.Distance {
+				*best = LocatedEntity{Kind: topo.KindEdge, Edge: e, Point: cp, Distance: d}
+			}
+		}
+	}
+}
+
+func closerFace(best *LocatedEntity, b *topo.Body, p math.Point3, q Quality) {
+	for _, f := range b.Faces() {
+		m := TessellateFace(f, q)
+		for t := 0; t+2 < len(m.Indices); t += 3 {
+			cp := closestPointOnTriangle(p,
+				m.Positions[m.Indices[t]], m.Positions[m.Indices[t+1]], m.Positions[m.Indices[t+2]])
+			if d := float64(p.DistanceTo(cp)); d < best.Distance {
+				*best = LocatedEntity{Kind: topo.KindFace, Face: f, Point: cp, Distance: d}
+			}
+		}
+	}
+}
+
+// closestPointOnSegment clamps p's projection onto segment ab.
+func closestPointOnSegment(p, a, b math.Point3) math.Point3 {
+	ab := a.VectorTo(b)
+	denom := float64(ab.LengthSquared())
+	if denom == 0 {
+		return a
+	}
+	t := float64(a.VectorTo(p).Dot(ab)) / denom
+	if t < 0 {
+		t = 0
+	}
+	if t > 1 {
+		t = 1
+	}
+	return a.TranslateBy(ab.Scale(math.Scalar(t)))
+}
+
+// FindUsingRay fires a ray into the body and returns every hit, nearest first:
+// faces where the ray crosses their mesh, plus edges and vertices passing
+// within radius of the ray. findFirstOnly truncates to the nearest hit.
+//
+// Example: hits := ops.FindUsingRay(b, origin, dir, 0.05, ops.DefaultQuality(), false)
+func FindUsingRay(b *topo.Body, origin math.Point3, dir math.Vector3, radius float64, q Quality, findFirstOnly bool) []LocatedEntity {
+	l := float64(dir.Length())
+	if l == 0 {
+		return nil
+	}
+	d := dir.Scale(math.Scalar(1 / l))
+	var hits []LocatedEntity
+	hits = append(hits, rayFaceHits(b, origin, d, q)...)
+	if radius > 0 {
+		hits = append(hits, rayEdgeHits(b, origin, d, radius, q)...)
+		hits = append(hits, rayVertexHits(b, origin, d, radius)...)
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].Distance < hits[j].Distance })
+	if findFirstOnly && len(hits) > 1 {
+		hits = hits[:1]
+	}
+	return hits
+}
+
+func rayFaceHits(b *topo.Body, origin math.Point3, dir math.Vector3, q Quality) []LocatedEntity {
+	var out []LocatedEntity
+	for _, f := range b.Faces() {
+		m := TessellateFace(f, q)
+		bestT, hit := stdmath.Inf(1), false
+		for t := 0; t+2 < len(m.Indices); t += 3 {
+			if dist, ok := rayTriangleDist(origin, dir,
+				m.Positions[m.Indices[t]], m.Positions[m.Indices[t+1]], m.Positions[m.Indices[t+2]]); ok && dist < bestT {
+				bestT, hit = dist, true
+			}
+		}
+		if hit {
+			p := origin.TranslateBy(dir.Scale(math.Scalar(bestT)))
+			out = append(out, LocatedEntity{Kind: topo.KindFace, Face: f, Point: p, Distance: bestT})
+		}
+	}
+	return out
+}
+
+func rayEdgeHits(b *topo.Body, origin math.Point3, dir math.Vector3, radius float64, q Quality) []LocatedEntity {
+	var out []LocatedEntity
+	for _, e := range b.Edges() {
+		if t, p, ok := rayPolylineApproach(origin, dir, discretizeEdge(e, q), radius); ok {
+			out = append(out, LocatedEntity{Kind: topo.KindEdge, Edge: e, Point: p, Distance: t})
+		}
+	}
+	return out
+}
+
+func rayVertexHits(b *topo.Body, origin math.Point3, dir math.Vector3, radius float64) []LocatedEntity {
+	var out []LocatedEntity
+	for _, v := range b.Vertices() {
+		t := float64(origin.VectorTo(v.Point()).Dot(dir))
+		if t < 0 {
+			continue
+		}
+		onRay := origin.TranslateBy(dir.Scale(math.Scalar(t)))
+		if float64(onRay.DistanceTo(v.Point())) <= radius {
+			out = append(out, LocatedEntity{Kind: topo.KindVertex, Vertex: v, Point: v.Point(), Distance: t})
+		}
+	}
+	return out
+}
+
+// rayPolylineApproach finds the polyline's nearest pass to the ray within
+// radius; returns the ray parameter and the polyline point.
+func rayPolylineApproach(origin math.Point3, dir math.Vector3, pl []math.Point3, radius float64) (float64, math.Point3, bool) {
+	bestT, bestP, found := stdmath.Inf(1), math.Point3{}, false
+	for i := 0; i+1 < len(pl); i++ {
+		t, p, d := raySegmentApproach(origin, dir, pl[i], pl[i+1])
+		if d <= radius && t >= 0 && t < bestT {
+			bestT, bestP, found = t, p, true
+		}
+	}
+	return bestT, bestP, found
+}
+
+// raySegmentApproach returns the ray parameter, segment point and distance of
+// the closest approach between the ray and segment ab (clamped to the segment).
+func raySegmentApproach(origin math.Point3, dir math.Vector3, a, b math.Point3) (float64, math.Point3, float64) {
+	// Closest point pair between infinite ray (origin + t·dir) and segment
+	// (a + s·ab): solve the 2×2 normal equations, clamp s to [0,1], re-derive t.
+	ab := a.VectorTo(b)
+	w := origin.VectorTo(a)
+	aDD := float64(dir.Dot(dir))
+	bDA := float64(dir.Dot(ab))
+	cAA := float64(ab.Dot(ab))
+	dDW := float64(dir.Dot(w))
+	eAW := float64(ab.Dot(w))
+	denom := aDD*cAA - bDA*bDA
+	s := 0.0
+	if denom > 1e-15 {
+		s = clamp01((bDA*dDW - aDD*eAW) / denom)
+	}
+	onSeg := a.TranslateBy(ab.Scale(math.Scalar(s)))
+	t := float64(origin.VectorTo(onSeg).Dot(dir)) / aDD
+	if t < 0 {
+		t = 0
+	}
+	onRay := origin.TranslateBy(dir.Scale(math.Scalar(t)))
+	return t, onSeg, float64(onRay.DistanceTo(onSeg))
+}
+

--- a/kernel/ops/body_query.go
+++ b/kernel/ops/body_query.go
@@ -200,4 +200,3 @@ func raySegmentApproach(origin math.Point3, dir math.Vector3, a, b math.Point3) 
 	onRay := origin.TranslateBy(dir.Scale(math.Scalar(t)))
 	return t, onSeg, float64(onRay.DistanceTo(onSeg))
 }
-

--- a/kernel/ops/body_query_test.go
+++ b/kernel/ops/body_query_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestLocateUsingPointFindsEachKind: a query near a corner finds the vertex,
+// near a mid-edge the edge, near a face center the face — and the kind filter
+// restricts the search.
+func TestLocateUsingPointFindsEachKind(t *testing.T) {
+	b := tetraBox(t, math.P3(0, 0, 0), 2)
+	q := DefaultQuality()
+	if hit, ok := LocateUsingPoint(b, 0, math.P3(-0.01, -0.01, -0.01), 0.1, q); !ok || hit.Kind != topo.KindVertex {
+		t.Errorf("corner query = (%v, %v), want a vertex", hit.Kind, ok)
+	}
+	if hit, ok := LocateUsingPoint(b, 0, math.P3(1, -0.01, -0.01), 0.1, q); !ok || hit.Kind != topo.KindEdge {
+		t.Errorf("mid-edge query = (%v, %v), want an edge", hit.Kind, ok)
+	}
+	if hit, ok := LocateUsingPoint(b, 0, math.P3(1, 1, 2.01), 0.1, q); !ok || hit.Kind != topo.KindFace {
+		t.Errorf("face-center query = (%v, %v), want a face", hit.Kind, ok)
+	}
+	if hit, ok := LocateUsingPoint(b, topo.KindFace, math.P3(-0.01, -0.01, -0.01), 0.1, q); !ok || hit.Kind != topo.KindFace {
+		t.Errorf("kind-filtered corner query = (%v, %v), want the nearest FACE", hit.Kind, ok)
+	}
+	if _, ok := LocateUsingPoint(b, 0, math.P3(5, 5, 5), 0.1, q); ok {
+		t.Error("a far point must not locate anything within tolerance")
+	}
+}
+
+// TestFindUsingRayOrdersHits: a ray through the box reports entry and exit
+// faces nearest-first; findFirstOnly truncates; radius picks up a grazed edge.
+func TestFindUsingRayOrdersHits(t *testing.T) {
+	b := tetraBox(t, math.P3(0, 0, 0), 2)
+	q := DefaultQuality()
+	hits := FindUsingRay(b, math.P3(1, 1, -5), math.V3(0, 0, 1), 0, q, false)
+	if len(hits) != 2 {
+		t.Fatalf("through-ray hit %d faces, want 2 (entry+exit)", len(hits))
+	}
+	if hits[0].Distance >= hits[1].Distance {
+		t.Error("hits must be sorted nearest first")
+	}
+	if first := FindUsingRay(b, math.P3(1, 1, -5), math.V3(0, 0, 1), 0, q, true); len(first) != 1 {
+		t.Errorf("findFirstOnly returned %d hits, want 1", len(first))
+	}
+	// A ray skimming 1e-3 outside the x=0,y=0 vertical edge only shows up
+	// with a radius.
+	if grazing := FindUsingRay(b, math.P3(-0.001, -0.001, -5), math.V3(0, 0, 1), 0, q, false); len(grazing) != 0 {
+		t.Errorf("zero-radius grazing ray hit %d entities, want 0", len(grazing))
+	}
+	grazed := FindUsingRay(b, math.P3(-0.001, -0.001, -5), math.V3(0, 0, 1), 0.01, q, false)
+	foundEdge := false
+	for _, h := range grazed {
+		if h.Kind == topo.KindEdge {
+			foundEdge = true
+		}
+	}
+	if !foundEdge {
+		t.Error("radius ray should pick up the grazed vertical edge")
+	}
+}
+
+// TestBodyEdgeConvexityCube: every cube edge is convex.
+func TestBodyEdgeConvexityCube(t *testing.T) {
+	byClass := BodyEdgeConvexity(tetraBox(t, math.P3(0, 0, 0), 2))
+	if n := len(byClass[EdgeConvex]); n != 12 {
+		t.Errorf("cube has %d convex edges, want 12 (got concave=%d tangent=%d unknown=%d)",
+			n, len(byClass[EdgeConcave]), len(byClass[EdgeTangent]), len(byClass[EdgeConvexityUnknown]))
+	}
+}
+
+// TestBodyEdgeConvexityCavity: the cavity's inner skin edges are concave from
+// the material's perspective (the material wraps 270° around them).
+func TestBodyEdgeConvexityCavity(t *testing.T) {
+	byClass := BodyEdgeConvexity(cavityBody(t))
+	if n := len(byClass[EdgeConcave]); n != 12 {
+		t.Errorf("cavity body has %d concave edges, want the 12 inner ones (convex=%d)",
+			n, len(byClass[EdgeConvex]))
+	}
+	if n := len(byClass[EdgeConvex]); n != 12 {
+		t.Errorf("cavity body has %d convex edges, want the 12 outer ones", n)
+	}
+}
+
+// TestOrientedMinimumRangeBoxRotatedBox: a box rotated 45° about Z still gets
+// a tight OBB of its true dimensions (an AABB would inflate by √2).
+func TestOrientedMinimumRangeBoxRotatedBox(t *testing.T) {
+	src := tetraBox(t, math.P3(0, 0, 0), 2)
+	axis, _ := math.UnitVector3FromVector(math.V3(0, 0, 1))
+	rot := math.Rotation4(stdmath.Pi/4, axis, math.P3(0, 0, 0))
+	rotated, err := TransformBody(src, rot, func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	obb, err := OrientedMinimumRangeBox(rotated)
+	if err != nil {
+		t.Fatalf("OrientedMinimumRangeBox: %v", err)
+	}
+	if v := obb.Volume(); stdmath.Abs(v-8) > 1e-6 {
+		t.Errorf("rotated-box OBB volume = %g, want 8 (tight)", v)
+	}
+	dims := []float64{
+		float64(obb.DirectionOne.Length()),
+		float64(obb.DirectionTwo.Length()),
+		float64(obb.DirectionThree.Length()),
+	}
+	for _, d := range dims {
+		if stdmath.Abs(d-2) > 1e-6 {
+			t.Errorf("OBB dimensions = %v, want all 2", dims)
+			break
+		}
+	}
+}
+
+// TestPreciseRangeBoxSeesFaceBulge is guarded by the analytic cylinder: the
+// topology RangeBox already samples edges, so both should agree on a box —
+// the point is PreciseRangeBox includes mesh interiors and wires.
+func TestPreciseRangeBoxCoversBody(t *testing.T) {
+	b := tetraBox(t, math.P3(1, 1, 1), 2)
+	box := PreciseRangeBox(b, DefaultQuality())
+	if box.Min.X > 1+1e-9 || box.Max.X < 3-1e-9 {
+		t.Errorf("precise box = %+v, want [1,3] on X", box)
+	}
+}
+
+// TestValidateBodyEntitiesLevels: a clean solid passes both levels; merged
+// interpenetrating shells pass topology but fail the geometry level with
+// face problems carrying keys.
+func TestValidateBodyEntitiesLevels(t *testing.T) {
+	clean := tetraBox(t, math.P3(0, 0, 0), 2)
+	if ok, problems := ValidateBodyEntities(clean, CheckGeometry, DefaultQuality()); !ok {
+		t.Errorf("clean box reports problems: %+v", problems)
+	}
+	a := tetra(1, math.V3(0, 0, 0))
+	bb := tetra(1, math.V3(0.2, 0.2, 0.2))
+	merged := topo.MergeBodies(topo.NewLineage(topo.Tok("imp", "body", 0)), true, a, bb)
+	if ok, _ := ValidateBodyEntities(merged, CheckTopology, DefaultQuality()); !ok {
+		t.Error("interpenetrating shells are still topologically valid")
+	}
+	ok, problems := ValidateBodyEntities(merged, CheckGeometry, DefaultQuality())
+	if ok || len(problems) == 0 {
+		t.Fatal("geometry-level check must flag the interpenetration")
+	}
+	if problems[0].Kind != topo.KindFace || len(problems[0].ReferenceKey) == 0 {
+		t.Errorf("problem entity = %+v, want a face with a reference key", problems[0])
+	}
+}
+
+// TestEntityLevelChecks: per-entity validity verdicts.
+func TestEntityLevelChecks(t *testing.T) {
+	b := tetraBox(t, math.P3(0, 0, 0), 2)
+	for _, e := range b.Edges() {
+		if !EdgeEntityValid(e) {
+			t.Fatalf("cube edge %d should be valid", e.ID())
+		}
+	}
+	for _, f := range b.Faces() {
+		if !FaceEntityValid(f) {
+			t.Fatalf("cube face %d should be valid", f.ID())
+		}
+	}
+}
+
+// TestBindTransientKey: each entity's session id binds back to it; an unknown
+// key reports false.
+func TestBindTransientKey(t *testing.T) {
+	b := tetraBox(t, math.P3(0, 0, 0), 2)
+	f := b.Faces()[2]
+	ref, ok := b.BindTransientKey(f.ID())
+	if !ok || ref.Kind != topo.KindFace || ref.Face != f {
+		t.Errorf("face key bound to %+v (ok=%v), want the face back", ref, ok)
+	}
+	sh := b.Shells()[0]
+	if ref, ok := b.BindTransientKey(sh.ID()); !ok || ref.Kind != topo.KindShell || ref.Shell != sh {
+		t.Error("shell key must bind to the shell")
+	}
+	if _, ok := b.BindTransientKey(0xFFFFFFFFFFFF); ok {
+		t.Error("an unknown transient key must not bind")
+	}
+}

--- a/kernel/ops/boolean_m07_acceptance_test.go
+++ b/kernel/ops/boolean_m07_acceptance_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// M07-F03 PBI-082 acceptance (Oblikovati/Oblikovati#298): the degenerate
+// arrangements a robust boolean must survive — operands sharing a coincident
+// (flush) face, identical operands, and sliver-thin overlaps — plus
+// reference-key continuity at the ops.Boolean level. Every result must be a
+// valid manifold solid with the analytically known volume.
+
+// opsBoxNamed is csgBox with a caller-chosen feature name, so two operands carry
+// distinct lineages (needed by the key-continuity cases).
+func opsBoxNamed(name string, p math.Point3, sx, sy, sz float64) *topo.Body {
+	m := subd.Box(sx, sy, sz)
+	for i := range m.Verts {
+		m.Verts[i] = m.Verts[i].TranslateBy(p.AsVector())
+	}
+	return subd.ToBody(m, name)
+}
+
+// requireSolid asserts the result is a valid, closed, manifold solid of the
+// expected volume.
+func requireSolid(t *testing.T, label string, b *topo.Body, wantVol float64) {
+	t.Helper()
+	r := ops.Validate(b)
+	if !r.Valid || !r.Closed || !r.Manifold {
+		t.Fatalf("%s: result not a valid solid: %+v", label, r.Issues)
+	}
+	if v := csgVolume(b); stdmath.Abs(v-wantVol) > 1e-4 {
+		t.Fatalf("%s: volume = %g, want %g", label, v, wantVol)
+	}
+}
+
+// Two boxes sharing a full coincident face: the join must dissolve the flush
+// pair into one solid (volume 2), not leave an internal double wall.
+func TestJoinCoincidentFullFace(t *testing.T) {
+	a := opsBoxNamed("a", math.P3(0, 0, 0), 1, 1, 1)
+	b := opsBoxNamed("b", math.P3(1, 0, 0), 1, 1, 1)
+	res, err := ops.Boolean(ops.Join, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireSolid(t, "flush join", res, 2)
+}
+
+// A smaller box flush against a larger face (partial coincidence): join must
+// imprint the contact region and stay manifold.
+func TestJoinCoincidentPartialFace(t *testing.T) {
+	a := opsBoxNamed("a", math.P3(0, 0, 0), 2, 2, 2)
+	b := opsBoxNamed("b", math.P3(2, 0.5, 0.5), 1, 1, 1)
+	res, err := ops.Boolean(ops.Join, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireSolid(t, "partial flush join", res, 9)
+}
+
+// Identical operands: union and intersection are the operand; difference is empty.
+func TestBooleanIdenticalOperands(t *testing.T) {
+	a := opsBoxNamed("a", math.P3(0, 0, 0), 1, 1, 1)
+	b := opsBoxNamed("b", math.P3(0, 0, 0), 1, 1, 1)
+	if res, err := ops.Boolean(ops.Join, a, b); err != nil {
+		t.Fatalf("identical join: %v", err)
+	} else {
+		requireSolid(t, "identical join", res, 1)
+	}
+	if res, err := ops.Boolean(ops.Intersect, a, b); err != nil {
+		t.Fatalf("identical intersect: %v", err)
+	} else {
+		requireSolid(t, "identical intersect", res, 1)
+	}
+	if res, err := ops.Boolean(ops.Cut, a, b); err != nil {
+		t.Fatalf("identical cut: %v", err)
+	} else if v := csgVolume(res); v > 1e-6 {
+		t.Fatalf("identical cut volume = %g, want 0", v)
+	}
+}
+
+// A cut whose tool stops a sliver short of the far wall: the remaining
+// sliver-thin wall must survive as valid material, not corrupt the topology.
+func TestCutLeavesSliverWall(t *testing.T) {
+	const sliver = 1e-4 // thin but above merge tolerance — must survive
+	a := opsBoxNamed("a", math.P3(0, 0, 0), 1, 1, 1)
+	b := opsBoxNamed("b", math.P3(-0.5, 0.25, 0.25), 0.5+(1-sliver), 0.5, 0.5)
+	res, err := ops.Boolean(ops.Cut, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireSolid(t, "sliver-wall cut", res, 1-0.5*0.5*(1-sliver))
+}
+
+// A sliver-wide overlap between the operands: the intersection is a slab of
+// near-zero width and must still come out valid (or exactly empty).
+func TestIntersectSliverOverlap(t *testing.T) {
+	const overlap = 1e-4
+	a := opsBoxNamed("a", math.P3(0, 0, 0), 1, 1, 1)
+	b := opsBoxNamed("b", math.P3(1-overlap, 0, 0), 1, 1, 1)
+	res, err := ops.Boolean(ops.Intersect, a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v := csgVolume(res); v > 1e-6 {
+		requireSolid(t, "sliver intersect", res, overlap)
+	}
+}
+
+// Key continuity at the ops.Boolean level (the feature engine's entry point):
+// a face untouched by the operation keeps a rebindable reference key, and the
+// result still resolves it after a SECOND edit (a follow-up cut elsewhere) —
+// the "rebindable after edits" clause of the acceptance criteria.
+func TestBooleanKeyContinuityThroughEdits(t *testing.T) {
+	a := opsBoxNamed("base", math.P3(0, 0, 0), 4, 4, 4)
+	bottom := faceByNormal(t, a, math.V3(0, 0, -1))
+	key := bottom.ReferenceKey()
+
+	joined, err := ops.Boolean(ops.Join, a, opsBoxNamed("boss", math.P3(1, 1, 4), 2, 2, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := joined.FindFaceByKey(key); !ok {
+		t.Fatal("bottom-face key lost after the join")
+	}
+	cutRes, err := ops.Boolean(ops.Cut, joined, opsBoxNamed("hole", math.P3(1.5, 1.5, 3), 1, 1, 3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cutRes.FindFaceByKey(key); !ok {
+		t.Fatal("bottom-face key lost after the follow-up cut")
+	}
+}
+
+// faceByNormal returns the face whose outward normal points along dir.
+func faceByNormal(t *testing.T, b *topo.Body, dir math.Vector3) *topo.Face {
+	t.Helper()
+	for _, f := range b.Faces() {
+		n := f.Geometry().NormalAt(0, 0)
+		if f.Reversed() {
+			n = n.Scale(-1)
+		}
+		if n.Dot(dir) > 0.9 {
+			return f
+		}
+	}
+	t.Fatalf("no face with normal %v", dir)
+	return nil
+}

--- a/kernel/ops/drop_faces.go
+++ b/kernel/ops/drop_faces.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"bytes"
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// DropFaces removes the selected faces (or with keepInstead, every face NOT
+// selected) without healing — the openings stay open and the result is a
+// surface body. This is the reference TransientBRep.DeleteFaces semantics;
+// the healing variant for solids is [DeleteFaces].
+//
+// Example: open, err := ops.DropFaces(b, [][]byte{face.ReferenceKey()}, false)
+func DropFaces(b *topo.Body, faceKeys [][]byte, keepInstead bool) (*topo.Body, error) {
+	selected := func(f *topo.Face) bool {
+		for _, k := range faceKeys {
+			if bytes.Equal(f.ReferenceKey(), k) {
+				return true
+			}
+		}
+		return false
+	}
+	// Keep a face when its selection state matches keepInstead: plain delete
+	// keeps the UNselected; keep-instead keeps the selected.
+	bld := topo.NewBuilder(false, b.Lineage())
+	kept := rebuildKeptFaces(bld, b, func(f *topo.Face) bool { return selected(f) == keepInstead })
+	if kept == 0 {
+		return nil, fmt.Errorf("ops.DropFaces: selection removes every face of body %d", b.ID())
+	}
+	return bld.Build(), nil
+}
+
+// rebuildKeptFaces clones the surviving faces (shared vertices/edges welded by
+// identity) into the builder, returning how many were kept.
+func rebuildKeptFaces(bld *topo.Builder, b *topo.Body, keep func(*topo.Face) bool) int {
+	verts := map[*topo.Vertex]*topo.Vertex{}
+	edges := map[*topo.Edge]*topo.Edge{}
+	kept := 0
+	for _, f := range b.Faces() {
+		if !keep(f) {
+			continue
+		}
+		kept++
+		specs := cloneLoopSpecs(bld, f, verts, edges)
+		if f.Reversed() {
+			bld.AddReversedFace(f.Geometry(), f.Lineage(), specs...)
+		} else {
+			bld.AddFace(f.Geometry(), f.Lineage(), specs...)
+		}
+	}
+	return kept
+}
+
+// cloneLoopSpecs rebuilds a face's loops against cloned (welded) topology.
+func cloneLoopSpecs(bld *topo.Builder, f *topo.Face, verts map[*topo.Vertex]*topo.Vertex, edges map[*topo.Edge]*topo.Edge) []topo.LoopSpec {
+	cloneV := func(v *topo.Vertex) *topo.Vertex {
+		if c, ok := verts[v]; ok {
+			return c
+		}
+		c := bld.AddVertex(v.Point(), v.Lineage())
+		verts[v] = c
+		return c
+	}
+	cloneE := func(e *topo.Edge) *topo.Edge {
+		if c, ok := edges[e]; ok {
+			return c
+		}
+		c := bld.AddEdge(e.Geometry(), cloneV(e.StartVertex()), cloneV(e.EndVertex()), e.Lineage())
+		edges[e] = c
+		return c
+	}
+	var specs []topo.LoopSpec
+	for _, l := range f.Loops() {
+		uses := make([]topo.Use, 0, len(l.EdgeUses()))
+		for _, u := range l.EdgeUses() {
+			uses = append(uses, topo.Use{Edge: cloneE(u.Edge()), Reversed: u.Reversed()})
+		}
+		if l.IsOuter() {
+			specs = append(specs, topo.OuterLoop(uses...))
+		} else {
+			specs = append(specs, topo.InnerLoop(uses...))
+		}
+	}
+	return specs
+}

--- a/kernel/ops/edge_convexity.go
+++ b/kernel/ops/edge_convexity.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Edge convexity classification (M07-F07, Oblikovati/Oblikovati#630): the
+// reference ConcaveEdges/ConvexEdges collections. At each manifold edge the
+// dihedral sign of the two material-outward face normals about the edge
+// tangent (as traversed by the first face) decides: positive triple product =
+// convex (material angle < π), negative = concave, near-parallel normals =
+// tangentially connected.
+
+// EdgeConvexity is one edge's dihedral class.
+type EdgeConvexity uint8
+
+const (
+	EdgeConvex EdgeConvexity = iota
+	EdgeConcave
+	EdgeTangent
+	EdgeConvexityUnknown // boundary or non-manifold edges have no dihedral
+)
+
+// String returns a stable name for diagnostics.
+func (c EdgeConvexity) String() string {
+	switch c {
+	case EdgeConvex:
+		return "convex"
+	case EdgeConcave:
+		return "concave"
+	case EdgeTangent:
+		return "tangent"
+	default:
+		return "unknown"
+	}
+}
+
+// tangentDihedralTol is the normal-angle band (radians) treated as
+// tangentially connected rather than convex/concave.
+const tangentDihedralTol = 1e-3
+
+// ClassifyEdgeConvexity returns one edge's dihedral class.
+func ClassifyEdgeConvexity(e *topo.Edge) EdgeConvexity {
+	uses := e.Uses()
+	if len(uses) != 2 {
+		return EdgeConvexityUnknown
+	}
+	mid := edgeMidpoint(e)
+	n1, ok1 := outwardFaceNormal(uses[0].Loop().Face(), mid)
+	n2, ok2 := outwardFaceNormal(uses[1].Loop().Face(), mid)
+	if !ok1 || !ok2 {
+		return EdgeConvexityUnknown
+	}
+	if float64(n1.AngleTo(n2)) < tangentDihedralTol {
+		return EdgeTangent
+	}
+	t := edgeUseTangent(uses[0])
+	triple := float64(n1.Cross(n2).Dot(t))
+	if triple > 0 {
+		return EdgeConvex
+	}
+	return EdgeConcave
+}
+
+// BodyEdgeConvexity classifies every edge, bucketed by class.
+//
+// Example: byClass := ops.BodyEdgeConvexity(b); concave := byClass[ops.EdgeConcave]
+func BodyEdgeConvexity(b *topo.Body) map[EdgeConvexity][]*topo.Edge {
+	out := map[EdgeConvexity][]*topo.Edge{}
+	for _, e := range b.Edges() {
+		c := ClassifyEdgeConvexity(e)
+		out[c] = append(out[c], e)
+	}
+	return out
+}
+
+// edgeMidpoint evaluates the edge curve at mid-parameter.
+func edgeMidpoint(e *topo.Edge) math.Point3 {
+	lo, hi := e.Geometry().Domain()
+	return e.Geometry().PointAt((lo + hi) / 2)
+}
+
+// outwardFaceNormal is the face's material-outward normal nearest p (surface
+// normal at the inverted parameters, negated for a reversed face).
+func outwardFaceNormal(f *topo.Face, p math.Point3) (math.Vector3, bool) {
+	u, v := f.Geometry().ParamAt(p)
+	n := f.Geometry().NormalAt(u, v)
+	l := float64(n.Length())
+	if l == 0 || stdmath.IsNaN(l) {
+		return math.Vector3{}, false
+	}
+	n = n.Scale(math.Scalar(1 / l))
+	if f.Reversed() {
+		n = n.Negate()
+	}
+	return n, true
+}
+
+// edgeUseTangent is the mid-edge curve tangent, oriented the way the use
+// traverses it.
+func edgeUseTangent(u *topo.EdgeUse) math.Vector3 {
+	c := u.Edge().Geometry()
+	lo, hi := c.Domain()
+	t := c.TangentAt((lo + hi) / 2)
+	if l := float64(t.Length()); l > 0 {
+		t = t.Scale(math.Scalar(1 / l))
+	}
+	if u.Reversed() {
+		t = t.Negate()
+	}
+	return t
+}
+
+// PreciseRangeBox is the tight axis-aligned box over the body's tessellation
+// at quality q — face interiors included, unlike the topology RangeBox, which
+// only samples vertices and edge curves (a sphere's equator bulge needs this).
+func PreciseRangeBox(b *topo.Body, q Quality) math.Box {
+	mesh, _ := TessellateBody(b, q)
+	box := math.EmptyBox()
+	for _, p := range mesh.Positions {
+		box = box.ExtendPoint(p)
+	}
+	for _, w := range b.Wires() {
+		box = wireExtend(box, w)
+	}
+	return box
+}
+
+func wireExtend(box math.Box, w *topo.Wire) math.Box {
+	for _, u := range w.Uses() {
+		c := u.Edge.Geometry()
+		lo, hi := c.Domain()
+		for i := 0; i <= 32; i++ {
+			box = box.ExtendPoint(c.PointAt(lo + (hi-lo)*float64(i)/32))
+		}
+	}
+	return box
+}

--- a/kernel/ops/entity_valid.go
+++ b/kernel/ops/entity_valid.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// Entity validity (M07-F07, Oblikovati/Oblikovati#630): the IsEntityValid
+// API face over Validate (PBI-084) plus, at the deeper check level, the
+// self-intersection scan. Problem entities are reported with their kind,
+// session id and reference key so a client can bind back to them.
+
+// EntityCheckLevel selects how deep ValidateEntity digs.
+type EntityCheckLevel int
+
+const (
+	// CheckTopology runs the manifold/orientation/closure checks (cheap).
+	CheckTopology EntityCheckLevel = 1
+	// CheckGeometry adds the face self-intersection scan (tessellates).
+	CheckGeometry EntityCheckLevel = 2
+)
+
+// ProblemEntity is one offending entity of a failed validity check.
+type ProblemEntity struct {
+	Kind         topo.EntityKind
+	ID           uint64
+	ReferenceKey []byte
+	Issue        string
+}
+
+// ValidateBodyEntities checks the whole body at the given level, returning
+// the verdict and each offending entity.
+//
+// Example: ok, problems := ops.ValidateBodyEntities(b, ops.CheckGeometry, ops.DefaultQuality())
+func ValidateBodyEntities(b *topo.Body, level EntityCheckLevel, q Quality) (bool, []ProblemEntity) {
+	problems := topologyProblems(b)
+	if level >= CheckGeometry {
+		for _, hit := range SelfIntersections(b, q) {
+			problems = append(problems,
+				faceProblem(hit.FaceA, fmt.Sprintf("self-intersects face %d near %v", hit.FaceB.ID(), hit.Witness)),
+				faceProblem(hit.FaceB, fmt.Sprintf("self-intersects face %d near %v", hit.FaceA.ID(), hit.Witness)))
+		}
+	}
+	return len(problems) == 0, problems
+}
+
+// topologyProblems maps Validate's per-edge findings onto problem entities.
+func topologyProblems(b *topo.Body) []ProblemEntity {
+	var out []ProblemEntity
+	for _, e := range b.Edges() {
+		switch uses := e.Uses(); {
+		case len(uses) < 2 && b.IsSolid():
+			out = append(out, edgeProblem(e, "boundary (open) edge on a solid"))
+		case len(uses) > 2:
+			out = append(out, edgeProblem(e, fmt.Sprintf("non-manifold: used by %d faces", len(uses))))
+		case len(uses) == 2 && uses[0].Reversed() == uses[1].Reversed():
+			out = append(out, edgeProblem(e, "inconsistent orientation between its two uses"))
+		}
+	}
+	return out
+}
+
+// EdgeEntityValid checks one edge: 1–2 uses, opposite orientation when manifold.
+func EdgeEntityValid(e *topo.Edge) bool {
+	uses := e.Uses()
+	if len(uses) == 0 || len(uses) > 2 {
+		return false
+	}
+	return len(uses) == 1 || uses[0].Reversed() != uses[1].Reversed()
+}
+
+// FaceEntityValid checks one face: an outer loop with edges, every use wired
+// back to this face.
+func FaceEntityValid(f *topo.Face) bool {
+	hasOuter := false
+	for _, l := range f.Loops() {
+		if len(l.EdgeUses()) == 0 {
+			return false
+		}
+		if l.IsOuter() {
+			hasOuter = true
+		}
+		for _, u := range l.EdgeUses() {
+			if u.Loop().Face() != f {
+				return false
+			}
+		}
+	}
+	return hasOuter
+}
+
+func edgeProblem(e *topo.Edge, issue string) ProblemEntity {
+	return ProblemEntity{Kind: topo.KindEdge, ID: e.ID(), ReferenceKey: e.ReferenceKey(), Issue: issue}
+}
+
+func faceProblem(f *topo.Face, issue string) ProblemEntity {
+	return ProblemEntity{Kind: topo.KindFace, ID: f.ID(), ReferenceKey: f.ReferenceKey(), Issue: issue}
+}

--- a/kernel/ops/facets.go
+++ b/kernel/ops/facets.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Queryable facet/stroke sets (M07-F03 remainder, Oblikovati/Oblikovati#293):
+// the reference API lets clients calculate facets at a tolerance and retrieve
+// them later without re-faceting. This file computes the snapshots; the
+// tolerance-keyed cache lives in model/facetstore.
+
+// BodyFacets is one body's facet set at one tolerance: the merged mesh, the
+// triangle-index count each face contributed (in body face order), and the
+// faces' own meshes for face-level retrieval.
+type BodyFacets struct {
+	Mesh              *Mesh
+	IndexCountPerFace []int
+	Faces             []*topo.Face
+	FaceMeshes        []*Mesh
+	uvs               []float64
+}
+
+// CalculateBodyFacets facets every face at the chordal tolerance through the
+// same pipeline the display tessellation uses (conformance repair + outward
+// orientation), tracking each face's contribution.
+//
+// Example: fs := ops.CalculateBodyFacets(body, ops.Quality{ChordTolerance: 0.01})
+func CalculateBodyFacets(b *topo.Body, q Quality) *BodyFacets {
+	faces, fm := tessellateBodyFaces(b, q)
+	out := &BodyFacets{Mesh: &Mesh{}, Faces: faces, FaceMeshes: fm}
+	for _, m := range fm {
+		out.IndexCountPerFace = append(out.IndexCountPerFace, len(m.Indices))
+		mergeMesh(out.Mesh, m)
+	}
+	return out
+}
+
+// TextureCoordinates returns one (u, v) pair per mesh vertex, taken from each
+// owning face's surface parameterization — the reference texture-map facet
+// variant. Computed on first call and memoized.
+func (bf *BodyFacets) TextureCoordinates() []float64 {
+	if bf.uvs != nil {
+		return bf.uvs
+	}
+	bf.uvs = make([]float64, 0, 2*len(bf.Mesh.Positions))
+	for i, m := range bf.FaceMeshes {
+		surf := bf.Faces[i].Geometry()
+		for _, p := range m.Positions {
+			u, v := surf.ParamAt(p)
+			bf.uvs = append(bf.uvs, u, v)
+		}
+	}
+	return bf.uvs
+}
+
+// BodyStrokes is one body's wireframe stroke set at one tolerance: each edge
+// sampled into a polyline (healed edges return their snapped seam exactly).
+type BodyStrokes struct {
+	Edges     []*topo.Edge
+	Polylines [][]math.Point3
+}
+
+// CalculateBodyStrokes samples every edge of the body at the chordal tolerance.
+//
+// Example: st := ops.CalculateBodyStrokes(body, ops.Quality{ChordTolerance: 0.01})
+func CalculateBodyStrokes(b *topo.Body, q Quality) *BodyStrokes {
+	return strokeEdges(b.Edges(), q)
+}
+
+// CalculateFaceStrokes samples one face's boundary edges at the tolerance.
+func CalculateFaceStrokes(f *topo.Face, q Quality) *BodyStrokes {
+	return strokeEdges(f.Edges(), q)
+}
+
+func strokeEdges(edges []*topo.Edge, q Quality) *BodyStrokes {
+	out := &BodyStrokes{Edges: edges, Polylines: make([][]math.Point3, len(edges))}
+	for i, e := range edges {
+		out.Polylines[i] = discretizeEdge(e, q)
+	}
+	return out
+}

--- a/kernel/ops/identical_bodies.go
+++ b/kernel/ops/identical_bodies.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"sort"
+
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Identical-body grouping (M07-F05, Oblikovati/Oblikovati#628): the reference
+// TransientBRep.GetIdenticalBodies. Bodies compare by their rigid-motion
+// INVARIANT signature — volume, surface area and the sorted principal moments
+// about the centroid — which a translation or rotation cannot change; a
+// reflection cannot either, so MatchReflection=false additionally compares the
+// signed moment skew (the centroidal third moment), which flips under
+// reflection. MatchTopology additionally requires equal face/edge/vertex
+// counts. Signature equality is necessary, not sufficient: two genuinely
+// different shapes with identical invariants (a measure-zero coincidence)
+// would group together; exact congruence testing is the M25 oracle's domain.
+
+// IdenticalBodiesOptions mirrors the reference NameValueMap options.
+type IdenticalBodiesOptions struct {
+	Tolerance       float64 // relative; 0 → 1e-6 (the reference default)
+	MatchTopology   bool
+	MatchReflection bool // default true in the reference: mirrored bodies match
+}
+
+// GroupIdenticalBodies partitions the bodies into groups of identical ones;
+// each group lists indices into the input slice.
+//
+// Example: groups := ops.GroupIdenticalBodies(bodies, ops.IdenticalBodiesOptions{MatchReflection: true}, ops.DefaultQuality())
+func GroupIdenticalBodies(bodies []*topo.Body, opt IdenticalBodiesOptions, q Quality) [][]int {
+	tol := opt.Tolerance
+	if tol <= 0 {
+		tol = 1e-6
+	}
+	sigs := make([]bodySignature, len(bodies))
+	for i, b := range bodies {
+		sigs[i] = signatureOf(b, q)
+	}
+	parent := make([]int, len(bodies))
+	for i := range parent {
+		parent[i] = i
+	}
+	for i := range bodies {
+		for j := i + 1; j < len(bodies); j++ {
+			if sigs[i].matches(sigs[j], tol, opt) {
+				union(parent, i, j)
+			}
+		}
+	}
+	return indexGroups(parent)
+}
+
+// bodySignature is the rigid-motion invariant fingerprint.
+type bodySignature struct {
+	volume, area           float64
+	moments                [3]float64 // sorted principal second moments about the centroid
+	skew                   float64    // signed third moment — flips under reflection
+	faces, edges, vertices int
+}
+
+// signatureOf computes the fingerprint from the body's tessellation.
+func signatureOf(b *topo.Body, q Quality) bodySignature {
+	mesh, _ := TessellateBody(b, q)
+	props := meshGeometryProperties(mesh)
+	moments, skew := centroidalMoments(mesh, props)
+	return bodySignature{
+		volume: props.Volume, area: props.Area, moments: moments, skew: skew,
+		faces: len(b.Faces()), edges: len(b.Edges()), vertices: len(b.Vertices()),
+	}
+}
+
+// centroidalMoments integrates the surface second moments (eigenvalues,
+// sorted) and a signed third moment about the centroid. Quadrature is EXACT
+// per polynomial degree — edge midpoints for the quadratics (degree-2 exact),
+// the Strang 4-point rule for the cubic skew — so the invariants do not
+// depend on how a planar face happened to triangulate (a rotated copy's
+// earcut may pick different diagonals).
+func centroidalMoments(mesh *Mesh, props GeometryProperties) ([3]float64, float64) {
+	var ixx, iyy, izz, ixy, ixz, iyz, skew float64
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		a := mesh.Positions[mesh.Indices[t]]
+		b := mesh.Positions[mesh.Indices[t+1]]
+		c := mesh.Positions[mesh.Indices[t+2]]
+		area := float64(a.VectorTo(b).Cross(a.VectorTo(c)).Length()) / 2
+		for _, qp := range midpointRule(a, b, c, props.Centroid) {
+			w := area / 3
+			ixx += w * (qp[1]*qp[1] + qp[2]*qp[2])
+			iyy += w * (qp[0]*qp[0] + qp[2]*qp[2])
+			izz += w * (qp[0]*qp[0] + qp[1]*qp[1])
+			ixy += w * qp[0] * qp[1]
+			ixz += w * qp[0] * qp[2]
+			iyz += w * qp[1] * qp[2]
+		}
+		skew += area * triangleSkew(a, b, c, props.Centroid)
+	}
+	eig := symmetricEigenvalues3(ixx, iyy, izz, -ixy, -ixz, -iyz)
+	sort.Float64s(eig[:])
+	return eig, skew
+}
+
+// midpointRule returns the three edge midpoints in centroid-relative
+// coordinates — the degree-2-exact triangle quadrature points (weight ⅓ each).
+func midpointRule(a, b, c math.Point3, centroid math.Point3) [3][3]float64 {
+	rel := func(p, q math.Point3) [3]float64 {
+		return [3]float64{
+			float64(p.X+q.X)/2 - float64(centroid.X),
+			float64(p.Y+q.Y)/2 - float64(centroid.Y),
+			float64(p.Z+q.Z)/2 - float64(centroid.Z),
+		}
+	}
+	return [3][3]float64{rel(a, b), rel(b, c), rel(c, a)}
+}
+
+// triangleSkew integrates xyz (centroid-relative) over the triangle with the
+// Strang degree-3 rule: centroid weight −27/48, the three (3/5, 1/5, 1/5)
+// points 25/48 each.
+func triangleSkew(a, b, c, centroid math.Point3) float64 {
+	at := func(wa, wb, wc float64) float64 {
+		x := wa*float64(a.X) + wb*float64(b.X) + wc*float64(c.X) - float64(centroid.X)
+		y := wa*float64(a.Y) + wb*float64(b.Y) + wc*float64(c.Y) - float64(centroid.Y)
+		z := wa*float64(a.Z) + wb*float64(b.Z) + wc*float64(c.Z) - float64(centroid.Z)
+		return x * y * z
+	}
+	const third = 1.0 / 3
+	sum := -27.0 / 48 * at(third, third, third)
+	sum += 25.0 / 48 * (at(0.6, 0.2, 0.2) + at(0.2, 0.6, 0.2) + at(0.2, 0.2, 0.6))
+	return sum
+}
+
+// matches compares two signatures under the options.
+func (s bodySignature) matches(o bodySignature, tol float64, opt IdenticalBodiesOptions) bool {
+	if opt.MatchTopology && (s.faces != o.faces || s.edges != o.edges || s.vertices != o.vertices) {
+		return false
+	}
+	if !relClose(s.volume, o.volume, tol) || !relClose(s.area, o.area, tol) {
+		return false
+	}
+	scale := s.moments[2]
+	for i := range s.moments {
+		if stdmath.Abs(s.moments[i]-o.moments[i]) > tol*stdmath.Max(scale, 1e-12) {
+			return false
+		}
+	}
+	if !opt.MatchReflection && !skewClose(s.skew, o.skew, tol, scale) {
+		return false
+	}
+	return true
+}
+
+func relClose(a, b, tol float64) bool {
+	scale := stdmath.Max(stdmath.Abs(a), stdmath.Abs(b))
+	if scale == 0 {
+		return true
+	}
+	return stdmath.Abs(a-b)/scale <= tol
+}
+
+// skewClose compares the signed skew (sign included — a mirror flips it).
+func skewClose(a, b, tol, scale float64) bool {
+	return stdmath.Abs(a-b) <= tol*stdmath.Max(scale, 1e-12)
+}
+
+// symmetricEigenvalues3 solves the symmetric 3×3 eigenvalue problem
+// (analytic trigonometric method; Smith 1961).
+func symmetricEigenvalues3(a11, a22, a33, a12, a13, a23 float64) [3]float64 {
+	p1 := a12*a12 + a13*a13 + a23*a23
+	q := (a11 + a22 + a33) / 3
+	if p1 == 0 {
+		return [3]float64{a11, a22, a33}
+	}
+	p2 := (a11-q)*(a11-q) + (a22-q)*(a22-q) + (a33-q)*(a33-q) + 2*p1
+	p := stdmath.Sqrt(p2 / 6)
+	det := (a11-q)*((a22-q)*(a33-q)-a23*a23) -
+		a12*(a12*(a33-q)-a23*a13) +
+		a13*(a12*a23-(a22-q)*a13)
+	r := det / (2 * p * p * p)
+	r = stdmath.Max(-1, stdmath.Min(1, r))
+	phi := stdmath.Acos(r) / 3
+	e1 := q + 2*p*stdmath.Cos(phi)
+	e3 := q + 2*p*stdmath.Cos(phi+2*stdmath.Pi/3)
+	return [3]float64{e1, 3*q - e1 - e3, e3}
+}
+
+// indexGroups buckets indices by union-find root, ordered by first member.
+func indexGroups(parent []int) [][]int {
+	order := []int{}
+	members := map[int][]int{}
+	for i := range parent {
+		r := find(parent, i)
+		if _, ok := members[r]; !ok {
+			order = append(order, r)
+		}
+		members[r] = append(members[r], i)
+	}
+	out := make([][]int, len(order))
+	for i, r := range order {
+		out[i] = members[r]
+	}
+	return out
+}

--- a/kernel/ops/ops_test.go
+++ b/kernel/ops/ops_test.go
@@ -185,9 +185,15 @@ func TestBooleanNewBodyAndStrings(t *testing.T) {
 	}
 }
 
-func TestSewNotYetImplemented(t *testing.T) {
-	if _, err := Sew(tetra(1, math.V3(0, 0, 0)), 1e-6); err == nil {
-		t.Error("Sew should report NotYetImplemented in phase A")
+// Sew is implemented as of M07 PBI-084 (#300) — gap behavior is covered by
+// sew_test.go; an already-closed body simply promotes to a solid.
+func TestSewClosedTetraSucceeds(t *testing.T) {
+	solid, err := Sew(tetra(1, math.V3(0, 0, 0)), 1e-6)
+	if err != nil {
+		t.Fatalf("Sew on a closed body: %v", err)
+	}
+	if !solid.IsSolid() {
+		t.Error("sewing a closed tetra should yield a solid")
 	}
 }
 

--- a/kernel/ops/oriented_box.go
+++ b/kernel/ops/oriented_box.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Oriented minimum range box (M07-F07, Oblikovati/Oblikovati#630). The classic
+// hull-flush approximation: for every convex-hull face normal, take that
+// normal as one box axis, run 2D rotating calipers on the projection for the
+// other two, and keep the smallest volume. Exact when the minimum box is flush
+// with a hull face (always true for polyhedra, per O'Rourke); curved bodies
+// are sampled at edge density, so the box is sample-accurate.
+
+// OrientedBox is a corner with three mutually perpendicular edge vectors —
+// the reference OrientedBox shape.
+type OrientedBox struct {
+	Corner                       math.Point3
+	DirectionOne                 math.Vector3
+	DirectionTwo, DirectionThree math.Vector3
+}
+
+// Volume returns the box volume.
+func (b OrientedBox) Volume() float64 {
+	return float64(b.DirectionOne.Length()) * float64(b.DirectionTwo.Length()) * float64(b.DirectionThree.Length())
+}
+
+// OrientedMinimumRangeBox computes the minimal oriented box over the body's
+// sampled geometry (vertices + 32 samples per curved edge).
+//
+// Example: obb := ops.OrientedMinimumRangeBox(body)
+func OrientedMinimumRangeBox(b *topo.Body) (OrientedBox, error) {
+	pts := bodySamplePoints(b)
+	hull, err := ConvexHull(pts, "obb")
+	if err != nil {
+		return OrientedBox{}, err
+	}
+	// Only hull vertices matter for extents — they dominate every interior
+	// sample, and there are far fewer of them than raw edge samples.
+	hullPts := make([]math.Point3, 0, len(hull.Vertices()))
+	for _, v := range hull.Vertices() {
+		hullPts = append(hullPts, v.Point())
+	}
+	best, bestVol := OrientedBox{}, stdmath.Inf(1)
+	for _, f := range hull.Faces() {
+		box, ok := boxFlushWithFace(f, hullPts)
+		if ok && box.Volume() < bestVol {
+			best, bestVol = box, box.Volume()
+		}
+	}
+	return best, nil
+}
+
+// bodySamplePoints collects vertices plus dense edge samples (curved
+// silhouettes bulge past their vertices).
+func bodySamplePoints(b *topo.Body) []math.Point3 {
+	var pts []math.Point3
+	for _, v := range b.Vertices() {
+		pts = append(pts, v.Point())
+	}
+	for _, e := range b.Edges() {
+		c := e.Geometry()
+		lo, hi := c.Domain()
+		for i := 0; i <= 32; i++ {
+			pts = append(pts, c.PointAt(lo+(hi-lo)*float64(i)/32))
+		}
+	}
+	for _, w := range b.Wires() {
+		for _, u := range w.Uses() {
+			c := u.Edge.Geometry()
+			lo, hi := c.Domain()
+			for i := 0; i <= 32; i++ {
+				pts = append(pts, c.PointAt(lo+(hi-lo)*float64(i)/32))
+			}
+		}
+	}
+	return pts
+}
+
+// boxFlushWithFace builds the best box whose base plane is flush with the hull
+// face: axis w = face normal, in-plane axes from 2D rotating calipers.
+func boxFlushWithFace(f *topo.Face, pts []math.Point3) (OrientedBox, bool) {
+	w := f.Geometry().NormalAt(0, 0)
+	l := float64(w.Length())
+	if l == 0 {
+		return OrientedBox{}, false
+	}
+	w = w.Scale(math.Scalar(1 / l))
+	u := perpUnit(w)
+	v := w.Cross(u)
+	proj := make([]math.Point2, len(pts))
+	wLo, wHi := stdmath.Inf(1), stdmath.Inf(-1)
+	for i, p := range pts {
+		d := p.AsVector()
+		proj[i] = math.P2(d.Dot(u), d.Dot(v))
+		h := float64(d.Dot(w))
+		wLo, wHi = minFloat(wLo, h), maxFloat(wHi, h)
+	}
+	rect, ok := minAreaRectangle(proj)
+	if !ok {
+		return OrientedBox{}, false
+	}
+	return liftRectangle(rect, u, v, w, wLo, wHi), true
+}
+
+// perpUnit returns a unit vector perpendicular to w.
+func perpUnit(w math.Vector3) math.Vector3 {
+	ref := math.V3(1, 0, 0)
+	if stdmath.Abs(float64(w.X)) > 0.9 {
+		ref = math.V3(0, 1, 0)
+	}
+	u := w.Cross(ref)
+	return u.Scale(math.Scalar(1 / float64(u.Length())))
+}
+
+// rect2 is a rotated 2D rectangle: corner + two perpendicular edge vectors.
+type rect2 struct {
+	corner math.Point2
+	e1, e2 math.Vector2
+}
+
+// liftRectangle assembles the 3D box from the in-plane rectangle and the
+// normal extent.
+func liftRectangle(r rect2, u, v, w math.Vector3, wLo, wHi float64) OrientedBox {
+	corner := math.P3(0, 0, 0).
+		TranslateBy(u.Scale(r.corner.X)).
+		TranslateBy(v.Scale(r.corner.Y)).
+		TranslateBy(w.Scale(math.Scalar(wLo)))
+	lift := func(e math.Vector2) math.Vector3 {
+		return u.Scale(e.X).Add(v.Scale(e.Y))
+	}
+	return OrientedBox{
+		Corner:       corner,
+		DirectionOne: lift(r.e1), DirectionTwo: lift(r.e2),
+		DirectionThree: w.Scale(math.Scalar(wHi - wLo)),
+	}
+}
+
+// minAreaRectangle runs rotating calipers over the 2D convex hull: the minimum
+// rectangle is flush with a hull edge.
+func minAreaRectangle(pts []math.Point2) (rect2, bool) {
+	hull := convexHull2D(pts)
+	if len(hull) < 3 {
+		return degenerateRect(hull)
+	}
+	best, bestArea := rect2{}, stdmath.Inf(1)
+	for i := 0; i < len(hull); i++ {
+		j := (i + 1) % len(hull)
+		dir := unit2(hull[i].VectorTo(hull[j]))
+		if float64(dir.Length()) == 0 {
+			continue
+		}
+		r := rectAlong(hull, dir)
+		if a := float64(r.e1.Length()) * float64(r.e2.Length()); a < bestArea {
+			best, bestArea = r, a
+		}
+	}
+	return best, bestArea < stdmath.Inf(1)
+}
+
+// rectAlong bounds the hull in the (dir, perp) frame.
+func rectAlong(hull []math.Point2, dir math.Vector2) rect2 {
+	perp := perpLeft(dir)
+	xLo, xHi := stdmath.Inf(1), stdmath.Inf(-1)
+	yLo, yHi := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, p := range hull {
+		x, y := float64(p.AsVector().Dot(dir)), float64(p.AsVector().Dot(perp))
+		xLo, xHi = minFloat(xLo, x), maxFloat(xHi, x)
+		yLo, yHi = minFloat(yLo, y), maxFloat(yHi, y)
+	}
+	corner := dir.Scale(math.Scalar(xLo)).Add(perp.Scale(math.Scalar(yLo))).AsPoint()
+	return rect2{
+		corner: corner,
+		e1:     dir.Scale(math.Scalar(xHi - xLo)),
+		e2:     perp.Scale(math.Scalar(yHi - yLo)),
+	}
+}
+
+// degenerateRect covers hulls of fewer than 3 points (a segment or point).
+func degenerateRect(hull []math.Point2) (rect2, bool) {
+	switch len(hull) {
+	case 2:
+		return rect2{corner: hull[0], e1: hull[0].VectorTo(hull[1]), e2: math.V2(0, 0)}, true
+	case 1:
+		return rect2{corner: hull[0]}, true
+	default:
+		return rect2{}, false
+	}
+}
+
+// convexHull2D is Andrew's monotone chain.
+func convexHull2D(pts []math.Point2) []math.Point2 {
+	sorted := append([]math.Point2(nil), pts...)
+	sortPoints2(sorted)
+	sorted = dedupePoints2(sorted)
+	if len(sorted) <= 2 {
+		return sorted
+	}
+	lower := halfHull(sorted)
+	upper := halfHull(reversed2(sorted))
+	return append(lower[:len(lower)-1], upper[:len(upper)-1]...)
+}
+
+func halfHull(pts []math.Point2) []math.Point2 {
+	var h []math.Point2
+	for _, p := range pts {
+		for len(h) >= 2 && float64(h[len(h)-2].VectorTo(h[len(h)-1]).Cross(h[len(h)-2].VectorTo(p))) <= 0 {
+			h = h[:len(h)-1]
+		}
+		h = append(h, p)
+	}
+	return h
+}
+
+func sortPoints2(pts []math.Point2) {
+	sort.Slice(pts, func(i, j int) bool { return lessPoint2(pts[i], pts[j]) })
+}
+
+func lessPoint2(a, b math.Point2) bool {
+	if a.X != b.X {
+		return a.X < b.X
+	}
+	return a.Y < b.Y
+}
+
+func dedupePoints2(pts []math.Point2) []math.Point2 {
+	out := pts[:0]
+	for i, p := range pts {
+		if i == 0 || float64(p.DistanceTo(out[len(out)-1])) > 1e-12 {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func reversed2(pts []math.Point2) []math.Point2 {
+	out := make([]math.Point2, len(pts))
+	for i, p := range pts {
+		out[len(pts)-1-i] = p
+	}
+	return out
+}

--- a/kernel/ops/ruled_surface.go
+++ b/kernel/ops/ruled_surface.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Ruled surfaces between wire sections (M07-F05, Oblikovati/Oblikovati#628):
+// the reference TransientBRep.CreateRuledSurface. Both wires sample at matched
+// parameters and the surface is built one ruled span at a time — a planar
+// face where the four span corners are coplanar (a wall between matching
+// polylines), a bilinear B-spline patch otherwise. Per-span faces keep the
+// rails' creases as real edges, so the tessellation follows the surface
+// exactly instead of cutting corners.
+
+// ruledSamples is the rail sampling density.
+const ruledSamples = 64
+
+// RuledSurfaceBetweenWires builds the ruled surface body between two wires.
+//
+// Example: surf, err := ops.RuledSurfaceBetweenWires(w1, w2)
+func RuledSurfaceBetweenWires(w1, w2 *topo.Wire) (*topo.Body, error) {
+	r1, r2 := wireRailPoints(w1, ruledSamples), wireRailPoints(w2, ruledSamples)
+	if len(r1) < 2 || len(r2) < 2 {
+		return nil, fmt.Errorf("ops.RuledSurfaceBetweenWires: wires sample to %d and %d points; need 2+ each",
+			len(r1), len(r2))
+	}
+	if w1.IsClosed() != w2.IsClosed() {
+		return nil, fmt.Errorf("ops.RuledSurfaceBetweenWires: one wire closed, the other open")
+	}
+	r2 = alignRail(r1, r2, w2.IsClosed())
+	if len(r2) != len(r1) {
+		r2 = resampleRail(r2, len(r1))
+	}
+	return ruledSpanBody(r1, r2, w1.IsClosed())
+}
+
+// wireRailPoints samples the wire chain at uniform per-edge parameters.
+func wireRailPoints(w *topo.Wire, n int) []math.Point3 {
+	uses := w.Uses()
+	if len(uses) == 0 {
+		return nil
+	}
+	per := n / len(uses)
+	if per < 2 {
+		per = 2
+	}
+	var pts []math.Point3
+	for _, u := range uses {
+		seg := sampleUse(u, per)
+		if len(pts) > 0 {
+			seg = seg[1:]
+		}
+		pts = append(pts, seg...)
+	}
+	return pts
+}
+
+func sampleUse(u topo.Use, per int) []math.Point3 {
+	c := u.Edge.Geometry()
+	lo, hi := c.Domain()
+	pts := make([]math.Point3, per+1)
+	for i := 0; i <= per; i++ {
+		t := float64(i) / float64(per)
+		if u.Reversed {
+			t = 1 - t
+		}
+		pts[i] = c.PointAt(lo + (hi-lo)*t)
+	}
+	return pts
+}
+
+// alignRail re-orients (and for closed rails re-phases) rail 2 to minimize
+// total ruling length, so the surface doesn't twist.
+func alignRail(r1, r2 []math.Point3, closed bool) []math.Point3 {
+	rev := reverse3(r2)
+	best, bestCost := r2, railCost(r1, r2)
+	if c := railCost(r1, rev); c < bestCost {
+		best, bestCost = rev, c
+	}
+	if closed {
+		best, bestCost = bestPhase(r1, best, bestCost)
+	}
+	return best
+}
+
+// bestPhase rotates a closed rail's start to the cheapest phase.
+func bestPhase(r1, r2 []math.Point3, cost float64) ([]math.Point3, float64) {
+	best, bestCost := r2, cost
+	n := len(r2) - 1 // last == first on a closed rail
+	for shift := 1; shift < n; shift++ {
+		rot := rotateRail(r2, shift)
+		if c := railCost(r1, rot); c < bestCost {
+			best, bestCost = rot, c
+		}
+	}
+	return best, bestCost
+}
+
+func rotateRail(r []math.Point3, shift int) []math.Point3 {
+	n := len(r) - 1
+	out := make([]math.Point3, len(r))
+	for i := 0; i <= n; i++ {
+		out[i] = r[(i+shift)%n]
+	}
+	out[n] = out[0]
+	return out
+}
+
+func railCost(a, b []math.Point3) float64 {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	sum := 0.0
+	for i := 0; i < n; i++ {
+		sum += float64(a[i].DistanceTo(b[i]))
+	}
+	return sum
+}
+
+// resampleRail re-samples a polyline rail to n points by arc length.
+func resampleRail(r []math.Point3, n int) []math.Point3 {
+	cum := make([]float64, len(r))
+	for i := 1; i < len(r); i++ {
+		cum[i] = cum[i-1] + float64(r[i-1].DistanceTo(r[i]))
+	}
+	total := cum[len(cum)-1]
+	out := make([]math.Point3, n)
+	for i := 0; i < n; i++ {
+		out[i] = railPointAt(r, cum, total*float64(i)/float64(n-1))
+	}
+	return out
+}
+
+func railPointAt(r []math.Point3, cum []float64, s float64) math.Point3 {
+	for i := 1; i < len(cum); i++ {
+		if s <= cum[i] {
+			span := cum[i] - cum[i-1]
+			if span == 0 {
+				return r[i]
+			}
+			f := math.Scalar((s - cum[i-1]) / span)
+			return r[i-1].TranslateBy(r[i-1].VectorTo(r[i]).Scale(f))
+		}
+	}
+	return r[len(r)-1]
+}
+
+// ruledSpanBody assembles the per-span faces with shared rail and ruling edges.
+func ruledSpanBody(r1, r2 []math.Point3, closed bool) (*topo.Body, error) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("ruled", "body", 0)))
+	n := len(r1)
+	m := n // distinct sample columns
+	if closed {
+		m = n - 1 // last == first
+	}
+	v1, v2 := railVertices(bld, r1, m, 0), railVertices(bld, r2, m, 1)
+	rulings := make([]*topo.Edge, m)
+	for i := 0; i < m; i++ {
+		rulings[i] = bld.AddEdge(geom.NewLineSegment(r1[i], r2[i]), v1[i], v2[i],
+			topo.NewLineage(topo.Tok("ruled", "ruling", i)))
+	}
+	for i := 0; i < n-1; i++ {
+		j := (i + 1) % m
+		addRuledSpanFace(bld, i, spanCorners{
+			a: r1[i], b: r1[(i+1)%m], c: r2[(i+1)%m], d: r2[i],
+			va: v1[i], vb: v1[j], vc: v2[j], vd: v2[i],
+			rulL: rulings[i], rulR: rulings[j],
+		})
+	}
+	return bld.Build(), nil
+}
+
+func railVertices(bld *topo.Builder, r []math.Point3, m, rail int) []*topo.Vertex {
+	out := make([]*topo.Vertex, m)
+	for i := 0; i < m; i++ {
+		out[i] = bld.AddVertex(r[i], topo.NewLineage(topo.Tok("ruled", fmt.Sprintf("rail%d-vertex", rail), i)))
+	}
+	return out
+}
+
+// spanCorners is one ruled span: corners a→b along rail 1, d→c along rail 2,
+// rulings a–d (left) and b–c (right).
+type spanCorners struct {
+	a, b, c, d     math.Point3
+	va, vb, vc, vd *topo.Vertex
+	rulL, rulR     *topo.Edge
+}
+
+// addRuledSpanFace adds one span as a planar face when its corners are
+// coplanar, else a 2×2 bilinear B-spline patch.
+func addRuledSpanFace(bld *topo.Builder, i int, sc spanCorners) {
+	e1 := bld.AddEdge(geom.NewLineSegment(sc.a, sc.b), sc.va, sc.vb, topo.NewLineage(topo.Tok("ruled", "rail1", i)))
+	e2 := bld.AddEdge(geom.NewLineSegment(sc.d, sc.c), sc.vd, sc.vc, topo.NewLineage(topo.Tok("ruled", "rail2", i)))
+	uses := []topo.Use{topo.Fwd(e1), topo.Fwd(sc.rulR), topo.Rev(e2), topo.Rev(sc.rulL)}
+	surf, err := spanSurface(sc)
+	if err != nil {
+		return // a fully degenerate span (both rails stalled) carries no area
+	}
+	bld.AddFace(surf, topo.NewLineage(topo.Tok("ruled", "face", i)), topo.OuterLoop(uses...))
+}
+
+// spanSurface picks the span's surface: plane for coplanar corners (the
+// dominant case between matching polylines), bilinear patch otherwise.
+func spanSurface(sc spanCorners) (geom.Surface, error) {
+	n := sc.a.VectorTo(sc.b).Cross(sc.a.VectorTo(sc.d))
+	if l := float64(n.Length()); l > 0 {
+		dev := stdmath.Abs(float64(sc.a.VectorTo(sc.c).Dot(n))) / l
+		if dev < 1e-9 {
+			return geom.NewPlane(sc.a, n)
+		}
+	}
+	ctrl := [][]math.Point3{{sc.a, sc.d}, {sc.b, sc.c}}
+	weights := [][]float64{{1, 1}, {1, 1}}
+	return geom.NewBSplineSurface(1, 1, ctrl, weights, []float64{0, 0, 1, 1}, []float64{0, 0, 1, 1})
+}

--- a/kernel/ops/ruled_surface.go
+++ b/kernel/ops/ruled_surface.go
@@ -85,7 +85,7 @@ func alignRail(r1, r2 []math.Point3, closed bool) []math.Point3 {
 		best, bestCost = rev, c
 	}
 	if closed {
-		best, bestCost = bestPhase(r1, best, bestCost)
+		best, _ = bestPhase(r1, best, bestCost)
 	}
 	return best
 }

--- a/kernel/ops/section_plane.go
+++ b/kernel/ops/section_plane.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Plane sections (M07-F05, Oblikovati/Oblikovati#628): intersect a body with
+// a plane and return the section curves as wires on a new wire-only body —
+// the reference CreateIntersectionWithPlane. Mesh-accurate: each face mesh's
+// triangle×plane segments chain into polylines.
+
+// SectionWithPlane sections the body with the plane (origin, normal).
+//
+// Example: sec, err := ops.SectionWithPlane(b, math.P3(0,0,1), math.V3(0,0,1), ops.DefaultQuality())
+func SectionWithPlane(b *topo.Body, origin math.Point3, normal math.Vector3, q Quality) (*topo.Body, error) {
+	l := float64(normal.Length())
+	if l == 0 {
+		return nil, fmt.Errorf("ops.SectionWithPlane: zero plane normal")
+	}
+	n := normal.Scale(math.Scalar(1 / l))
+	d := float64(origin.AsVector().Dot(n))
+	mesh, _ := TessellateBody(b, q)
+	segs := planeMeshSegments(mesh, n, d)
+	if len(segs) == 0 {
+		return nil, fmt.Errorf("ops.SectionWithPlane: the plane through %v misses the body", origin)
+	}
+	return wiresFromSegments(segs, "section")
+}
+
+// planeMeshSegments collects each triangle's crossing segment with the plane.
+func planeMeshSegments(mesh *Mesh, n math.Vector3, d float64) [][2]math.Point3 {
+	var segs [][2]math.Point3
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		tri := [3]math.Point3{
+			mesh.Positions[mesh.Indices[t]], mesh.Positions[mesh.Indices[t+1]], mesh.Positions[mesh.Indices[t+2]],
+		}
+		if seg, ok := trianglePlaneSegment(tri, n, d); ok {
+			segs = append(segs, seg)
+		}
+	}
+	return segs
+}
+
+// trianglePlaneSegment clips one triangle against the plane, returning the
+// crossing segment when the triangle genuinely straddles it.
+func trianglePlaneSegment(tri [3]math.Point3, n math.Vector3, d float64) ([2]math.Point3, bool) {
+	var s [3]float64
+	for i, p := range tri {
+		s[i] = float64(n.Dot(p.AsVector())) - d
+	}
+	var pts []math.Point3
+	for i := 0; i < 3; i++ {
+		j := (i + 1) % 3
+		if (s[i] > 0) == (s[j] > 0) || s[i] == s[j] {
+			continue
+		}
+		f := math.Scalar(s[i] / (s[i] - s[j]))
+		pts = append(pts, tri[i].TranslateBy(tri[i].VectorTo(tri[j]).Scale(f)))
+	}
+	if len(pts) != 2 || float64(pts[0].DistanceTo(pts[1])) < sectionWeldTol {
+		return [2]math.Point3{}, false
+	}
+	return [2]math.Point3{pts[0], pts[1]}, true
+}
+
+// sectionWeldTol welds section segment endpoints into chains.
+const sectionWeldTol = 1e-7
+
+// wiresFromSegments chains loose segments into polyline wires on a fresh
+// wire-only body (shared endpoints welded on a tolerance grid).
+func wiresFromSegments(segs [][2]math.Point3, feat string) (*topo.Body, error) {
+	chains := chainSegments(segs, sectionWeldTol)
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	body := bld.Build()
+	for i, chain := range chains {
+		curve, err := geom.NewPolyline(chain)
+		if err != nil {
+			continue // a degenerate (sub-tolerance) chain carries no geometry
+		}
+		v0 := bld.AddVertex(chain[0], topo.NewLineage(topo.Tok(feat, "vertex", 2*i)))
+		v1 := v0
+		if float64(chain[0].DistanceTo(chain[len(chain)-1])) > sectionWeldTol {
+			v1 = bld.AddVertex(chain[len(chain)-1], topo.NewLineage(topo.Tok(feat, "vertex", 2*i+1)))
+		}
+		e := bld.AddEdge(curve, v0, v1, topo.NewLineage(topo.Tok(feat, "edge", i)))
+		body.AttachWire(topo.NewLineage(topo.Tok(feat, "wire", i)), []topo.Use{topo.Fwd(e)})
+	}
+	if len(body.Wires()) == 0 {
+		return nil, fmt.Errorf("ops: section produced no usable chains from %d segments", len(segs))
+	}
+	return body, nil
+}
+
+// chainSegments greedily links segments end-to-end on a weld grid into
+// maximal polylines (closed chains end where they start).
+func chainSegments(segs [][2]math.Point3, tol float64) [][]math.Point3 {
+	used := make([]bool, len(segs))
+	var chains [][]math.Point3
+	for i := range segs {
+		if used[i] {
+			continue
+		}
+		used[i] = true
+		chain := []math.Point3{segs[i][0], segs[i][1]}
+		chain = extendChain(chain, segs, used, tol)
+		chains = append(chains, chain)
+	}
+	return chains
+}
+
+// extendChain grows the chain from both ends until no segment attaches.
+func extendChain(chain []math.Point3, segs [][2]math.Point3, used []bool, tol float64) []math.Point3 {
+	for grew := true; grew; {
+		grew = false
+		for j := range segs {
+			if used[j] {
+				continue
+			}
+			if next, ok := attachSegment(chain, segs[j], tol); ok {
+				chain, used[j], grew = next, true, true
+			}
+		}
+	}
+	return chain
+}
+
+// attachSegment tries to weld a segment onto either chain end.
+func attachSegment(chain []math.Point3, seg [2]math.Point3, tol float64) ([]math.Point3, bool) {
+	head, tail := chain[0], chain[len(chain)-1]
+	switch {
+	case float64(tail.DistanceTo(seg[0])) <= tol:
+		return append(chain, seg[1]), true
+	case float64(tail.DistanceTo(seg[1])) <= tol:
+		return append(chain, seg[0]), true
+	case float64(head.DistanceTo(seg[1])) <= tol:
+		return append([]math.Point3{seg[0]}, chain...), true
+	case float64(head.DistanceTo(seg[0])) <= tol:
+		return append([]math.Point3{seg[1]}, chain...), true
+	}
+	return chain, false
+}
+
+// FaceSilhouetteWires computes the silhouette curves of one face as viewed
+// from viewDir, clipped to the face's trim, as wires on a new body — the
+// reference TransientBRep.CreateSilhouetteCurve. includeBoundary keeps
+// silhouette runs that coincide with the face's own edges.
+//
+// Example: sil, err := ops.FaceSilhouetteWires(f, math.V3(0,0,1), true, ops.DefaultQuality())
+func FaceSilhouetteWires(f *topo.Face, viewDir math.Vector3, includeBoundary bool, q Quality) (*topo.Body, error) {
+	loops := geom.Silhouette(f.Geometry(), viewDir, faceParamWindow(f))
+	if len(loops) == 0 {
+		return nil, fmt.Errorf("ops: face %d has no silhouette from %v", f.ID(), viewDir)
+	}
+	mesh := TessellateFace(f, q)
+	onTol := stdmath.Max(q.tol(), 1e-6)
+	var segs [][2]math.Point3
+	for _, pl := range loops {
+		segs = append(segs, clipPolylineToFace(pl, mesh, f, onTol, includeBoundary)...)
+	}
+	if len(segs) == 0 {
+		return nil, fmt.Errorf("ops: face %d's silhouette lies outside its trim", f.ID())
+	}
+	return wiresFromSegments(segs, "silhouette")
+}
+
+// clipPolylineToFace keeps the polyline's segments whose midpoints lie on the
+// face (within onTol of its mesh), optionally dropping runs hugging the
+// face's boundary edges.
+func clipPolylineToFace(pl []math.Point3, mesh *Mesh, f *topo.Face, onTol float64, includeBoundary bool) [][2]math.Point3 {
+	var out [][2]math.Point3
+	for i := 0; i+1 < len(pl); i++ {
+		mid := pl[i].TranslateBy(pl[i].VectorTo(pl[i+1]).Scale(0.5))
+		if meshContainment(mesh, mid, onTol) != ContainOn {
+			continue
+		}
+		if !includeBoundary && pointNearFaceBoundary(mid, f, onTol) {
+			continue
+		}
+		out = append(out, [2]math.Point3{pl[i], pl[i+1]})
+	}
+	return out
+}
+
+// faceParamWindow derives the silhouette tracing window from the face's own
+// trim: every boundary sample inverted into (u, v). An unbounded surface
+// direction (a cylinder's axial v) gets no window from the surface domain, so
+// the trim is the only honest source.
+func faceParamWindow(f *topo.Face) geom.SurfaceGrid {
+	s := f.Geometry()
+	g := geom.SurfaceGrid{UMin: stdmath.Inf(1), UMax: stdmath.Inf(-1), VMin: stdmath.Inf(1), VMax: stdmath.Inf(-1)}
+	for _, e := range f.Edges() {
+		c := e.Geometry()
+		lo, hi := c.Domain()
+		for i := 0; i <= 16; i++ {
+			u, v := s.ParamAt(c.PointAt(lo + (hi-lo)*float64(i)/16))
+			g.UMin, g.UMax = stdmath.Min(g.UMin, u), stdmath.Max(g.UMax, u)
+			g.VMin, g.VMax = stdmath.Min(g.VMin, v), stdmath.Max(g.VMax, v)
+		}
+	}
+	if stdmath.IsInf(g.UMin, 1) {
+		g = geom.SurfaceGrid{UMin: stdmath.NaN()} // boundary-less face: fill from the domain below
+	}
+	g.USteps, g.VSteps = 97, 97
+	return shiftSeamWindows(s, g)
+}
+
+// shiftSeamWindows nudges a full-period tracing window half a cell off the
+// seam: a silhouette ruling lying exactly at u = 0 = 2π is invisible to
+// marching squares (the field is ~0 on the boundary nodes with no sign change
+// across them); shifted, the same ruling falls strictly inside a cell. The
+// window still spans one full period — periodic surfaces evaluate past their
+// nominal domain naturally.
+func shiftSeamWindows(s geom.Surface, g geom.SurfaceGrid) geom.SurfaceGrid {
+	uLo, uHi := s.UDomain()
+	vLo, vHi := s.VDomain()
+	if stdmath.IsNaN(g.UMin) {
+		g.UMin, g.UMax, g.VMin, g.VMax = uLo, uHi, vLo, vHi
+	}
+	if fullFiniteSpan(g.UMin, g.UMax, uLo, uHi) {
+		half := (g.UMax - g.UMin) / float64(2*g.USteps)
+		g.UMin, g.UMax = g.UMin+half, g.UMax+half
+	}
+	if fullFiniteSpan(g.VMin, g.VMax, vLo, vHi) {
+		half := (g.VMax - g.VMin) / float64(2*g.VSteps)
+		g.VMin, g.VMax = g.VMin+half, g.VMax+half
+	}
+	return g
+}
+
+// fullFiniteSpan reports whether [lo, hi] covers the whole finite surface
+// domain (the periodic full-turn case).
+func fullFiniteSpan(lo, hi, dLo, dHi float64) bool {
+	if stdmath.IsInf(dLo, 0) || stdmath.IsInf(dHi, 0) || dHi <= dLo {
+		return false
+	}
+	return lo <= dLo+1e-9 && hi >= dHi-1e-9
+}
+
+// pointNearFaceBoundary reports whether p hugs one of the face's edges.
+func pointNearFaceBoundary(p math.Point3, f *topo.Face, tol float64) bool {
+	for _, e := range f.Edges() {
+		c := e.Geometry()
+		lo, hi := c.Domain()
+		for i := 0; i <= 32; i++ {
+			if float64(p.DistanceTo(c.PointAt(lo+(hi-lo)*float64(i)/32))) <= tol {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/kernel/ops/self_intersect.go
+++ b/kernel/ops/self_intersect.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Self-intersection detection (M07 PBI-084, Oblikovati/Oblikovati#300): pairs
+// of faces of one body that pass through each other. Topologically adjacent
+// faces (sharing an edge or vertex) legitimately touch along that boundary and
+// are excluded; what remains crossing is real interpenetration — the classic
+// outcome of a bad import or an over-folded offset.
+
+// SelfIntersection is one interpenetrating, non-adjacent face pair, with a
+// witness point on the crossing.
+type SelfIntersection struct {
+	FaceA, FaceB *topo.Face
+	Witness      math.Point3
+}
+
+// SelfIntersections tessellates each face at q and reports every non-adjacent
+// face pair whose triangles cross. The check is mesh-accurate: crossings
+// thinner than the chord tolerance can escape it, which matches what every
+// downstream consumer (booleans, mass properties, export) would see anyway.
+//
+// Example: if hits := ops.SelfIntersections(body, ops.DefaultQuality()); len(hits) > 0 { reject(body) }
+func SelfIntersections(b *topo.Body, q Quality) []SelfIntersection {
+	faces := b.Faces()
+	meshes := make([]*Mesh, len(faces))
+	boxes := make([]math.Box, len(faces))
+	for i, f := range faces {
+		meshes[i] = TessellateFace(f, q)
+		boxes[i] = f.RangeBox()
+	}
+	var out []SelfIntersection
+	for i := range faces {
+		for j := i + 1; j < len(faces); j++ {
+			if !boxes[i].Intersects(boxes[j]) || facesAdjacent(faces[i], faces[j]) {
+				continue
+			}
+			if p, hit := meshesCross(meshes[i], meshes[j]); hit {
+				out = append(out, SelfIntersection{FaceA: faces[i], FaceB: faces[j], Witness: p})
+			}
+		}
+	}
+	return out
+}
+
+// facesAdjacent reports whether two faces share any vertex (which covers
+// sharing an edge) — contact along shared topology is legitimate.
+func facesAdjacent(a, b *topo.Face) bool {
+	verts := map[*topo.Vertex]bool{}
+	for _, e := range a.Edges() {
+		verts[e.StartVertex()] = true
+		verts[e.EndVertex()] = true
+	}
+	for _, e := range b.Edges() {
+		if verts[e.StartVertex()] || verts[e.EndVertex()] {
+			return true
+		}
+	}
+	return false
+}
+
+// meshesCross tests every triangle pair of the two face meshes.
+func meshesCross(a, b *Mesh) (math.Point3, bool) {
+	for i := 0; i+2 < len(a.Indices); i += 3 {
+		t1 := meshTriangle(a, i)
+		for j := 0; j+2 < len(b.Indices); j += 3 {
+			if p, hit := trianglesIntersect(t1, meshTriangle(b, j)); hit {
+				return p, true
+			}
+		}
+	}
+	return math.Point3{}, false
+}
+
+func meshTriangle(m *Mesh, i int) [3]math.Point3 {
+	return [3]math.Point3{
+		m.Positions[m.Indices[i]], m.Positions[m.Indices[i+1]], m.Positions[m.Indices[i+2]],
+	}
+}
+
+// selfIntersectEps keeps grazing contact (faces meeting within numerical noise
+// of each other) from reporting as interpenetration.
+const selfIntersectEps = 1e-9
+
+// trianglesIntersect is the Möller interval test: T1 must straddle T2's plane
+// and vice versa, and their intervals on the planes' intersection line must
+// overlap. Coplanar triangles are handled by 2D overlap on their shared plane.
+func trianglesIntersect(t1, t2 [3]math.Point3) (math.Point3, bool) {
+	n2, d2 := triPlaneEq(t2)
+	s1, straddles1 := signedDistances(t1, n2, d2)
+	if !straddles1 {
+		if triCoplanar(s1) {
+			return coplanarOverlap(t1, t2, n2)
+		}
+		return math.Point3{}, false
+	}
+	n1, d1 := triPlaneEq(t1)
+	s2, straddles2 := signedDistances(t2, n1, d1)
+	if !straddles2 {
+		return math.Point3{}, false
+	}
+	return intervalOverlap(t1, s1, t2, s2, n1.Cross(n2))
+}
+
+// triPlaneEq returns the triangle's (unnormalized) plane normal and offset.
+func triPlaneEq(t [3]math.Point3) (math.Vector3, float64) {
+	n := t[0].VectorTo(t[1]).Cross(t[0].VectorTo(t[2]))
+	return n, float64(n.Dot(t[0].AsVector()))
+}
+
+// signedDistances returns each vertex's signed distance to the plane and
+// whether the triangle genuinely straddles it (signs on both sides beyond eps).
+func signedDistances(t [3]math.Point3, n math.Vector3, d float64) ([3]float64, bool) {
+	var s [3]float64
+	pos, neg := false, false
+	for i, p := range t {
+		s[i] = float64(n.Dot(p.AsVector())) - d
+		if s[i] > selfIntersectEps {
+			pos = true
+		}
+		if s[i] < -selfIntersectEps {
+			neg = true
+		}
+	}
+	return s, pos && neg
+}
+
+func triCoplanar(s [3]float64) bool {
+	for _, v := range s {
+		if v > selfIntersectEps || v < -selfIntersectEps {
+			return false
+		}
+	}
+	return true
+}
+
+// intervalOverlap projects both triangles' plane crossings onto the planes'
+// intersection line and reports a witness point if the intervals overlap.
+func intervalOverlap(t1 [3]math.Point3, s1 [3]float64, t2 [3]math.Point3, s2 [3]float64, line math.Vector3) (math.Point3, bool) {
+	a0, a1, pa := crossingInterval(t1, s1, line)
+	b0, b1, _ := crossingInterval(t2, s2, line)
+	lo, hi := maxFloat(a0, b0), minFloat(a1, b1)
+	if lo+selfIntersectEps >= hi {
+		return math.Point3{}, false
+	}
+	return pa((lo + hi) / 2), true
+}
+
+// crossingInterval finds where the triangle's edges cross the other plane
+// (s changes sign), projected on the intersection line; pa maps a line
+// parameter back to a 3D witness point.
+func crossingInterval(t [3]math.Point3, s [3]float64, line math.Vector3) (float64, float64, func(float64) math.Point3) {
+	var pts []math.Point3
+	for i := 0; i < 3; i++ {
+		j := (i + 1) % 3
+		if (s[i] > 0) == (s[j] > 0) || s[i] == s[j] {
+			continue
+		}
+		f := math.Scalar(s[i] / (s[i] - s[j]))
+		pts = append(pts, t[i].TranslateBy(t[i].VectorTo(t[j]).Scale(f)))
+	}
+	if len(pts) < 2 {
+		pts = append(pts, t[0], t[0]) // degenerate grazing — empty interval
+	}
+	u0 := float64(line.Dot(pts[0].AsVector()))
+	u1 := float64(line.Dot(pts[1].AsVector()))
+	p0, p1 := pts[0], pts[1]
+	if u0 > u1 {
+		u0, u1, p0, p1 = u1, u0, p1, p0
+	}
+	at := func(u float64) math.Point3 {
+		if u1 == u0 {
+			return p0
+		}
+		f := math.Scalar((u - u0) / (u1 - u0))
+		return p0.TranslateBy(p0.VectorTo(p1).Scale(f))
+	}
+	return u0, u1, at
+}
+
+// coplanarOverlap projects both triangles onto their shared plane's dominant
+// axes and tests 2D overlap by separating axes over both triangles' edges.
+func coplanarOverlap(t1, t2 [3]math.Point3, n math.Vector3) (math.Point3, bool) {
+	u, v := planeAxes(n)
+	a := projectTriangle(t1, u, v)
+	b := projectTriangle(t2, u, v)
+	if separated(a, b) || separated(b, a) {
+		return math.Point3{}, false
+	}
+	c := triangleCenter(t1)
+	return c, true
+}
+
+// planeAxes picks two in-plane axes for the dominant-normal projection.
+func planeAxes(n math.Vector3) (math.Vector3, math.Vector3) {
+	ref := math.V3(1, 0, 0)
+	if abs(float64(n.X)) > abs(float64(n.Y)) && abs(float64(n.X)) > abs(float64(n.Z)) {
+		ref = math.V3(0, 1, 0)
+	}
+	u := n.Cross(ref)
+	return u, n.Cross(u)
+}
+
+func projectTriangle(t [3]math.Point3, u, v math.Vector3) [3][2]float64 {
+	var out [3][2]float64
+	for i, p := range t {
+		out[i] = [2]float64{float64(u.Dot(p.AsVector())), float64(v.Dot(p.AsVector()))}
+	}
+	return out
+}
+
+// separated reports whether any edge normal of a separates the projections of
+// a and b — disjoint intervals on the axis mean no overlap (plain SAT, winding
+// independent).
+func separated(a, b [3][2]float64) bool {
+	for i := 0; i < 3; i++ {
+		j := (i + 1) % 3
+		nx, ny := a[j][1]-a[i][1], a[i][0]-a[j][0] // edge normal
+		aMin, aMax := axisInterval(a, nx, ny)
+		bMin, bMax := axisInterval(b, nx, ny)
+		if aMax < bMin-selfIntersectEps || bMax < aMin-selfIntersectEps {
+			return true
+		}
+	}
+	return false
+}
+
+// axisInterval projects the triangle onto the (nx, ny) axis.
+func axisInterval(t [3][2]float64, nx, ny float64) (float64, float64) {
+	lo, hi := 1e308, -1e308
+	for _, p := range t {
+		v := nx*p[0] + ny*p[1]
+		lo, hi = minFloat(lo, v), maxFloat(hi, v)
+	}
+	return lo, hi
+}
+
+func triangleCenter(t [3]math.Point3) math.Point3 {
+	v := t[0].AsVector().Add(t[1].AsVector()).Add(t[2].AsVector())
+	return v.Scale(math.Scalar(1.0 / 3)).AsPoint()
+}
+
+func abs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/kernel/ops/self_intersect_test.go
+++ b/kernel/ops/self_intersect_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestSelfIntersectionsCleanSolid: a valid solid has none — adjacent faces
+// touching along shared edges must not count.
+func TestSelfIntersectionsCleanSolid(t *testing.T) {
+	body, err := Stitch(cubeFaces(), 0, false, "clean")
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	if hits := SelfIntersections(body, DefaultQuality()); len(hits) != 0 {
+		t.Errorf("clean cube reports %d self-intersections, want 0: %+v", len(hits), hits)
+	}
+}
+
+// TestSelfIntersectionsOverlappingShells: two interpenetrating tetra shells
+// merged into one body — the import failure mode PBI-084 targets — must be
+// caught with a witness inside the overlap region.
+func TestSelfIntersectionsOverlappingShells(t *testing.T) {
+	a := tetra(1, math.V3(0, 0, 0))
+	b := tetra(1, math.V3(0.2, 0.2, 0.2)) // shifted: shells pass through each other
+	merged := topo.MergeBodies(topo.NewLineage(topo.Tok("imp", "body", 0)), true, a, b)
+	hits := SelfIntersections(merged, DefaultQuality())
+	if len(hits) == 0 {
+		t.Fatal("interpenetrating shells must report self-intersections")
+	}
+	w := hits[0].Witness
+	if w.X < 0 || w.X > 1.2 || w.Y < 0 || w.Y > 1.2 || w.Z < 0 || w.Z > 1.2 {
+		t.Errorf("witness %v lies outside the bodies' overlap region", w)
+	}
+}
+
+// TestSelfIntersectionsDisjointShells: a two-shell body whose shells do not
+// touch (a legitimate multi-shell solid) is clean.
+func TestSelfIntersectionsDisjointShells(t *testing.T) {
+	a := tetra(1, math.V3(0, 0, 0))
+	b := tetra(1, math.V3(5, 0, 0))
+	merged := topo.MergeBodies(topo.NewLineage(topo.Tok("imp", "body", 0)), true, a, b)
+	if hits := SelfIntersections(merged, DefaultQuality()); len(hits) != 0 {
+		t.Errorf("disjoint shells report %d self-intersections, want 0", len(hits))
+	}
+}
+
+// TestSelfIntersectionsCoplanarOverlap: two coplanar overlapping faces (a
+// doubled wall from a bad import) are caught by the coplanar branch.
+func TestSelfIntersectionsCoplanarOverlap(t *testing.T) {
+	p := math.P3
+	q1 := quadBody("w1", p(0, 0, 0), p(2, 0, 0), p(2, 0, 2), p(0, 0, 2))
+	q2 := quadBody("w2", p(1, 0, 1), p(3, 0, 1), p(3, 0, 3), p(1, 0, 3)) // overlaps q1's corner
+	merged := topo.MergeBodies(topo.NewLineage(topo.Tok("imp", "body", 0)), false, q1, q2)
+	if hits := SelfIntersections(merged, DefaultQuality()); len(hits) == 0 {
+		t.Error("coplanar overlapping faces must report a self-intersection")
+	}
+}

--- a/kernel/ops/sew.go
+++ b/kernel/ops/sew.go
@@ -118,7 +118,7 @@ func clusterCentroids(pts []math.Point3, cluster []int) *boundaryClusters {
 	for i, p := range pts {
 		r := find(cluster, i)
 		sums[r] = sums[r].Add(p.AsVector())
-		counts[r] = counts[r] + 1
+		counts[r]++
 	}
 	bc := &boundaryClusters{grid: defaultStitchTolerance, centers: map[vKey]math.Point3{}}
 	for i, p := range pts {

--- a/kernel/ops/sew.go
+++ b/kernel/ops/sew.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+	"strings"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Tolerant sewing of open shells (M07 PBI-084, Oblikovati/Oblikovati#300):
+// boundary edges whose endpoints sit within the sew tolerance of each other —
+// a real gap, not an exact coincidence — are pulled onto shared positions and
+// welded into one edge. Edges that moved record the gap residual as a healed
+// polyline (the M25 SnappedCurve machinery), so both faces tessellate the seam
+// identically and the result stays watertight downstream.
+
+// defaultSewTolerance is the gap a Sew with tolerance 0 closes — generous next
+// to the exact-coincidence stitch grid, tight next to feature sizes (cm units).
+const defaultSewTolerance = 1e-4
+
+// Sew closes an open shell's near-coincident boundary gaps and promotes the
+// result to a solid. If gaps remain beyond the tolerance, it reports every
+// unsewable boundary edge precisely (id, endpoints, nearest opposite gap)
+// instead of returning a partially-sewn body.
+//
+// Example: quilt, _ := ops.Stitch(imported, 0, true, "import"); solid, err := ops.Sew(quilt, 1e-3)
+func Sew(b *topo.Body, tolerance float64) (*topo.Body, error) {
+	tol := tolerance
+	if tol <= 0 {
+		tol = defaultSewTolerance
+	}
+	open := BoundaryEdges(b)
+	if len(open) == 0 {
+		return Stitch([]*topo.Body{b}, 0, false, "sew") // already closed → promote to solid
+	}
+	body, w := sewWeld(b, boundarySnap(open, tol))
+	if remaining := BoundaryEdges(body); len(remaining) > 0 {
+		return nil, sewGapError(remaining, tol)
+	}
+	if r := Validate(body); !r.Valid {
+		return nil, fmt.Errorf("sew closed the shell but the result is invalid: %s", strings.Join(r.Issues, "; "))
+	}
+	sewStampResiduals(w)
+	return body, nil
+}
+
+// sewWeld re-welds every face of b with boundary endpoints snapped to their
+// cluster centers, returning the rebuilt body and the weld (for residuals).
+func sewWeld(b *topo.Body, snap *boundaryClusters) (*topo.Body, *weld) {
+	w := newWeld(defaultStitchTolerance)
+	w.snap = snap.apply
+	for _, f := range b.Faces() {
+		w.addFace(f)
+	}
+	return w.build(false, "sew"), w
+}
+
+// boundaryClusters maps boundary endpoint positions (keyed on the fine stitch
+// grid) to their cluster centroid; non-boundary positions pass through.
+type boundaryClusters struct {
+	grid    float64
+	centers map[vKey]math.Point3
+}
+
+// boundarySnap clusters the open edges' endpoints: endpoints within tol of each
+// other meld into one cluster whose centroid becomes the sewn position.
+func boundarySnap(open []*topo.Edge, tol float64) *boundaryClusters {
+	pts := boundaryEndpoints(open)
+	cluster := make([]int, len(pts))
+	for i := range cluster {
+		cluster[i] = i
+	}
+	for i := range pts {
+		for j := i + 1; j < len(pts); j++ {
+			if float64(pts[i].DistanceTo(pts[j])) <= tol {
+				union(cluster, i, j)
+			}
+		}
+	}
+	return clusterCentroids(pts, cluster)
+}
+
+// boundaryEndpoints collects each open edge's two endpoint positions.
+func boundaryEndpoints(open []*topo.Edge) []math.Point3 {
+	pts := make([]math.Point3, 0, 2*len(open))
+	for _, e := range open {
+		pts = append(pts, e.StartVertex().Point(), e.EndVertex().Point())
+	}
+	return pts
+}
+
+// union joins i's and j's clusters (plain union-find with path squash on find).
+func union(parent []int, i, j int) {
+	ri, rj := find(parent, i), find(parent, j)
+	if ri != rj {
+		parent[rj] = ri
+	}
+}
+
+func find(parent []int, i int) int {
+	for parent[i] != i {
+		parent[i] = parent[parent[i]]
+		i = parent[i]
+	}
+	return i
+}
+
+// clusterCentroids averages each cluster's members and indexes the centroid by
+// every member's fine-grid cell, so apply() can look any member up.
+func clusterCentroids(pts []math.Point3, cluster []int) *boundaryClusters {
+	sums := map[int]math.Vector3{}
+	counts := map[int]int{}
+	for i, p := range pts {
+		r := find(cluster, i)
+		sums[r] = sums[r].Add(p.AsVector())
+		counts[r] = counts[r] + 1
+	}
+	bc := &boundaryClusters{grid: defaultStitchTolerance, centers: map[vKey]math.Point3{}}
+	for i, p := range pts {
+		r := find(cluster, i)
+		c := sums[r].Scale(math.Scalar(1 / float64(counts[r]))).AsPoint()
+		bc.centers[bc.cell(p)] = c
+	}
+	return bc
+}
+
+func (bc *boundaryClusters) cell(p math.Point3) vKey {
+	w := weld{tol: bc.grid}
+	return w.vkey(p)
+}
+
+// apply snaps a boundary endpoint to its cluster centroid; any other position
+// passes through unchanged.
+func (bc *boundaryClusters) apply(p math.Point3) math.Point3 {
+	if c, ok := bc.centers[bc.cell(p)]; ok {
+		return c
+	}
+	return p
+}
+
+// sewStampResiduals records the gap each welded edge absorbed: an edge whose
+// endpoints moved gets a healed polyline (its curve samples, linearly tapered
+// onto the snapped endpoints) so both adjacent faces tessellate the seam from
+// the same points, plus the residual as its tolerance.
+func sewStampResiduals(w *weld) {
+	for key, e := range w.built {
+		curve := w.curves[key]
+		s0 := curve.PointAt(domainLo(curve))
+		s1 := curve.PointAt(domainHi(curve))
+		d0, d1 := alignSnapDeltas(e, s0, s1)
+		residual := maxFloat(float64(d0.Length()), float64(d1.Length()))
+		if residual <= w.tol {
+			continue
+		}
+		e.SetSnappedCurve(orientToEdge(taperedPolyline(curve, d0, d1), e), residual)
+	}
+}
+
+// orientToEdge flips a polyline running against the edge's start→end direction
+// — discretizeEdge hands SnappedCurve to every face verbatim, so it must run in
+// edge order even when the welded representative curve ran the other way.
+func orientToEdge(poly []math.Point3, e *topo.Edge) []math.Point3 {
+	first, last := poly[0], poly[len(poly)-1]
+	s := e.StartVertex().Point()
+	if first.DistanceTo(s) <= last.DistanceTo(s) {
+		return poly
+	}
+	return reverse3(poly)
+}
+
+// alignSnapDeltas matches the curve's natural ends to the welded edge's
+// vertices (the canonical edge key may run against the curve) and returns the
+// displacement each curve end absorbed.
+func alignSnapDeltas(e *topo.Edge, s0, s1 math.Point3) (math.Vector3, math.Vector3) {
+	a, b := e.StartVertex().Point(), e.EndVertex().Point()
+	if s0.DistanceTo(a)+s1.DistanceTo(b) <= s0.DistanceTo(b)+s1.DistanceTo(a) {
+		return s0.VectorTo(a), s1.VectorTo(b)
+	}
+	return s0.VectorTo(b), s1.VectorTo(a)
+}
+
+// sewSeamSamples is the healed-polyline density for a sewn edge.
+const sewSeamSamples = 32
+
+// taperedPolyline samples the curve and blends the endpoint displacements
+// linearly across it, landing exactly on the snapped endpoints. A straight
+// edge stays two points — its linear taper is still a straight line, so the
+// dense samples would only fragment the face tessellation.
+func taperedPolyline(c geom.Curve3, d0, d1 math.Vector3) []math.Point3 {
+	samples := sewSeamSamples
+	if _, straight := c.(geom.LineSegment); straight {
+		samples = 1
+	}
+	lo, hi := c.Domain()
+	out := make([]math.Point3, samples+1)
+	for i := 0; i <= samples; i++ {
+		t := float64(i) / float64(samples)
+		p := c.PointAt(lo + (hi-lo)*t)
+		shift := d0.Scale(math.Scalar(1 - t)).Add(d1.Scale(math.Scalar(t)))
+		out[i] = p.TranslateBy(shift)
+	}
+	return out
+}
+
+func domainLo(c geom.Curve3) float64 { lo, _ := c.Domain(); return lo }
+func domainHi(c geom.Curve3) float64 { _, hi := c.Domain(); return hi }
+
+// sewGapError reports every boundary edge that survived the sew, with its
+// endpoints and the nearest opposite boundary endpoint distance — the precise
+// "could not be stitched" report PBI-084 requires.
+func sewGapError(remaining []*topo.Edge, tol float64) error {
+	lines := make([]string, len(remaining))
+	for i, e := range remaining {
+		s, t := e.StartVertex().Point(), e.EndVertex().Point()
+		lines[i] = fmt.Sprintf("edge %d [%v → %v] gap %.3g", e.ID(), s, t, nearestGap(e, remaining))
+	}
+	return fmt.Errorf("sew: %d boundary edges exceed tolerance %g: %s",
+		len(remaining), tol, strings.Join(lines, "; "))
+}
+
+// nearestGap is the smallest endpoint distance from e to any OTHER boundary
+// edge — the gap a larger tolerance would have had to bridge.
+func nearestGap(e *topo.Edge, all []*topo.Edge) float64 {
+	best := stdmath.Inf(1)
+	for _, o := range all {
+		if o == e {
+			continue
+		}
+		for _, p := range []math.Point3{e.StartVertex().Point(), e.EndVertex().Point()} {
+			for _, q := range []math.Point3{o.StartVertex().Point(), o.EndVertex().Point()} {
+				best = minFloat(best, float64(p.DistanceTo(q)))
+			}
+		}
+	}
+	return best
+}

--- a/kernel/ops/sew_test.go
+++ b/kernel/ops/sew_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// gappedCubeQuilt is the open unit-cube quilt whose lid floats `gap` above the
+// walls — the canonical "imported shell with a real gap" PBI-084 targets. The
+// five lower faces stitch exactly; the lid's rim sits at z = 1+gap.
+func gappedCubeQuilt(t *testing.T, gap float64) *topo.Body {
+	t.Helper()
+	p := math.P3
+	z := math.Scalar(1 + gap)
+	faces := cubeFaces()[:1] // bottom
+	faces = append(faces,
+		quadBody("front", p(0, 0, 0), p(1, 0, 0), p(1, 0, 1), p(0, 0, 1)),
+		quadBody("back", p(0, 1, 0), p(0, 1, 1), p(1, 1, 1), p(1, 1, 0)),
+		quadBody("left", p(0, 0, 0), p(0, 0, 1), p(0, 1, 1), p(0, 1, 0)),
+		quadBody("right", p(1, 0, 0), p(1, 1, 0), p(1, 1, 1), p(1, 0, 1)),
+		quadBody("lid", p(0, 0, z), p(1, 0, z), p(1, 1, z), p(0, 1, z)),
+	)
+	quilt, err := Stitch(faces, 0, true, "import")
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	return quilt
+}
+
+// TestSewClosesGappedLid: a lid floating 5e-5 above the walls (within the
+// default sew tolerance) sews into a valid closed solid of ~unit volume.
+func TestSewClosesGappedLid(t *testing.T) {
+	quilt := gappedCubeQuilt(t, 5e-5)
+	if len(BoundaryEdges(quilt)) == 0 {
+		t.Fatal("premise: the gapped quilt must be open before sewing")
+	}
+	solid, err := Sew(quilt, 0)
+	if err != nil {
+		t.Fatalf("Sew: %v", err)
+	}
+	if !solid.IsSolid() {
+		t.Error("sewn body should be a solid")
+	}
+	if r := Validate(solid); !r.Valid || !r.Closed || !r.Manifold {
+		t.Errorf("sewn body validation = %+v, want fully valid", r)
+	}
+	if v := BodyGeometryProperties(solid, DefaultQuality()).Volume; stdmath.Abs(v-1) > 1e-3 {
+		t.Errorf("sewn cube volume = %g, want ~1", v)
+	}
+}
+
+// TestSewRecordsSeamResidual: the lid's rim edges record the absorbed gap as
+// their healing tolerance, the way M25 import healing does.
+func TestSewRecordsSeamResidual(t *testing.T) {
+	const gap = 5e-5
+	solid, err := Sew(gappedCubeQuilt(t, gap), 0)
+	if err != nil {
+		t.Fatalf("Sew: %v", err)
+	}
+	maxResidual := 0.0
+	for _, e := range solid.Edges() {
+		if e.Tolerance() > maxResidual {
+			maxResidual = e.Tolerance()
+		}
+	}
+	if maxResidual < gap/4 || maxResidual > gap*2 {
+		t.Errorf("max seam residual = %g, want about the %g gap", maxResidual, gap)
+	}
+}
+
+// TestSewReportsOversizedGapPrecisely: a gap beyond the tolerance fails with
+// every offending boundary edge and its measured gap in the error.
+func TestSewReportsOversizedGapPrecisely(t *testing.T) {
+	quilt := gappedCubeQuilt(t, 0.1)
+	_, err := Sew(quilt, 1e-3)
+	if err == nil {
+		t.Fatal("a 0.1 gap must not sew at tolerance 1e-3")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "boundary edges exceed tolerance") || !strings.Contains(msg, "gap") {
+		t.Errorf("error %q should report the boundary edges and their gaps", msg)
+	}
+}
+
+// TestSewAlreadyClosedPromotesToSolid: sewing a closed quilt is the
+// stitch-to-solid promotion, not an error.
+func TestSewAlreadyClosedPromotesToSolid(t *testing.T) {
+	quilt, err := Stitch(cubeFaces(), 0, true, "import")
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	solid, err := Sew(quilt, 0)
+	if err != nil {
+		t.Fatalf("Sew: %v", err)
+	}
+	if !solid.IsSolid() {
+		t.Error("sewing a closed quilt should promote it to a solid")
+	}
+}

--- a/kernel/ops/shell_query.go
+++ b/kernel/ops/shell_query.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Shell and body point queries (M07-F06/F07, Oblikovati/Oblikovati#629/#630):
+// signed shell volume (the void/solid classifier), and inside/on/outside
+// containment for shells and whole bodies.
+
+// PointContainment is the inside/on/outside verdict of a point query. The
+// api/types Containment enum is the wire spelling; this is the kernel value.
+type PointContainment uint8
+
+const (
+	ContainOutside PointContainment = iota
+	ContainInside
+	ContainOn
+)
+
+// String returns a stable name for diagnostics.
+func (c PointContainment) String() string {
+	switch c {
+	case ContainInside:
+		return "inside"
+	case ContainOn:
+		return "on"
+	default:
+		return "outside"
+	}
+}
+
+// shellMesh merges the shell's face tessellations (each face oriented to its
+// material-outward shading normals, Reversed honored).
+func shellMesh(s *topo.Shell, q Quality) *Mesh {
+	mesh := &Mesh{}
+	for _, f := range s.Faces() {
+		mergeMesh(mesh, TessellateFace(f, q))
+	}
+	return mesh
+}
+
+// ShellSignedVolume returns the divergence-theorem volume of the region the
+// shell bounds, signed by its material orientation: positive for an outer
+// (material-enclosing) shell, NEGATIVE for an inner void shell, whose
+// material-outward face normals point into the cavity.
+//
+// Example: if ops.ShellSignedVolume(sh, ops.DefaultQuality()) < 0 { /* cavity skin */ }
+func ShellSignedVolume(s *topo.Shell, q Quality) float64 {
+	mesh := shellMesh(s, q)
+	vol := 0.0
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		ia, ib, ic := mesh.Indices[t], mesh.Indices[t+1], mesh.Indices[t+2]
+		a, b, c := mesh.Positions[ia], mesh.Positions[ib], mesh.Positions[ic]
+		if outwardRef(mesh, ia, ib, ic).Dot(a.VectorTo(b).Cross(a.VectorTo(c))) < 0 {
+			b, c = c, b // align geometric winding to the outward shading normal
+		}
+		vol += float64(a.AsVector().Dot(b.AsVector().Cross(c.AsVector()))) / 6
+	}
+	return vol
+}
+
+// ShellIsVoid reports whether the shell is an inner void (cavity) skin.
+func ShellIsVoid(s *topo.Shell, q Quality) bool {
+	return s.IsClosed() && ShellSignedVolume(s, q) < 0
+}
+
+// ShellContainment classifies p against the region the shell bounds: ON within
+// onTol of the shell's mesh, else INSIDE by odd ray crossings.
+func ShellContainment(s *topo.Shell, p math.Point3, q Quality, onTol float64) PointContainment {
+	return meshContainment(shellMesh(s, q), p, onTol)
+}
+
+// BodyContainment classifies p against the solid body: ON within onTol of any
+// face, INSIDE by odd crossings over all faces (a point inside a cavity is
+// outside the material — the cavity skin's crossings cancel an outer hit pair).
+func BodyContainment(b *topo.Body, p math.Point3, q Quality, onTol float64) PointContainment {
+	mesh, _ := TessellateBody(b, q)
+	return meshContainment(mesh, p, onTol)
+}
+
+// meshContainment is the shared mesh-level classifier.
+func meshContainment(mesh *Mesh, p math.Point3, onTol float64) PointContainment {
+	dir := math.V3(0.5773, 0.5774, 0.5775) // same skewed ray as PointInsideBody
+	crossings := 0
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		a := mesh.Positions[mesh.Indices[t]]
+		b := mesh.Positions[mesh.Indices[t+1]]
+		c := mesh.Positions[mesh.Indices[t+2]]
+		if pointTriangleDistance(p, a, b, c) <= onTol {
+			return ContainOn
+		}
+		if rayHitsTriangle(p, dir, a, b, c) {
+			crossings++
+		}
+	}
+	if crossings%2 == 1 {
+		return ContainInside
+	}
+	return ContainOutside
+}
+
+// pointTriangleDistance is the exact distance from p to triangle abc
+// (Ericson, Real-Time Collision Detection §5.1.5 — region tests on the
+// barycentric Voronoi regions).
+func pointTriangleDistance(p, a, b, c math.Point3) float64 {
+	closest := closestPointOnTriangle(p, a, b, c)
+	return float64(p.DistanceTo(closest))
+}
+
+// triDots carries the six dot products and frame the Voronoi region tests share.
+type triDots struct {
+	a, b, c                math.Point3
+	ab, ac                 math.Vector3
+	d1, d2, d3, d4, d5, d6 float64
+}
+
+func newTriDots(p, a, b, c math.Point3) triDots {
+	ab, ac := a.VectorTo(b), a.VectorTo(c)
+	ap, bp, cp := a.VectorTo(p), b.VectorTo(p), c.VectorTo(p)
+	return triDots{
+		a: a, b: b, c: c, ab: ab, ac: ac,
+		d1: float64(ab.Dot(ap)), d2: float64(ac.Dot(ap)),
+		d3: float64(ab.Dot(bp)), d4: float64(ac.Dot(bp)),
+		d5: float64(ab.Dot(cp)), d6: float64(ac.Dot(cp)),
+	}
+}
+
+func closestPointOnTriangle(p, a, b, c math.Point3) math.Point3 {
+	d := newTriDots(p, a, b, c)
+	if v, hit := d.vertexRegion(); hit {
+		return v
+	}
+	if v, hit := d.edgeRegion(); hit {
+		return v
+	}
+	return d.faceRegion()
+}
+
+// vertexRegion returns the closest point when p projects beyond a corner.
+func (d triDots) vertexRegion() (math.Point3, bool) {
+	if d.d1 <= 0 && d.d2 <= 0 {
+		return d.a, true
+	}
+	if d.d3 >= 0 && d.d4 <= d.d3 {
+		return d.b, true
+	}
+	if d.d6 >= 0 && d.d5 <= d.d6 {
+		return d.c, true
+	}
+	return math.Point3{}, false
+}
+
+// edgeRegion returns the closest point when p projects onto an edge band.
+func (d triDots) edgeRegion() (math.Point3, bool) {
+	if vc := d.d1*d.d4 - d.d3*d.d2; vc <= 0 && d.d1 >= 0 && d.d3 <= 0 && d.d1-d.d3 > 0 {
+		t := math.Scalar(d.d1 / (d.d1 - d.d3))
+		return d.a.TranslateBy(d.ab.Scale(t)), true
+	}
+	if vb := d.d5*d.d2 - d.d1*d.d6; vb <= 0 && d.d2 >= 0 && d.d6 <= 0 && d.d2-d.d6 > 0 {
+		t := math.Scalar(d.d2 / (d.d2 - d.d6))
+		return d.a.TranslateBy(d.ac.Scale(t)), true
+	}
+	if va := d.d3*d.d6 - d.d5*d.d4; va <= 0 && d.d4-d.d3 >= 0 && d.d5-d.d6 >= 0 && (d.d4-d.d3)+(d.d5-d.d6) > 0 {
+		t := math.Scalar((d.d4 - d.d3) / ((d.d4 - d.d3) + (d.d5 - d.d6)))
+		return d.b.TranslateBy(d.b.VectorTo(d.c).Scale(t)), true
+	}
+	return math.Point3{}, false
+}
+
+// faceRegion projects into the triangle's interior barycentrically.
+func (d triDots) faceRegion() math.Point3 {
+	va := d.d3*d.d6 - d.d5*d.d4
+	vb := d.d5*d.d2 - d.d1*d.d6
+	vc := d.d1*d.d4 - d.d3*d.d2
+	denom := va + vb + vc
+	if denom == 0 {
+		return d.a // degenerate sliver triangle: any vertex is as close as it gets
+	}
+	v, w := math.Scalar(vb/denom), math.Scalar(vc/denom)
+	return d.a.TranslateBy(d.ab.Scale(v).Add(d.ac.Scale(w)))
+}

--- a/kernel/ops/shell_query.go
+++ b/kernel/ops/shell_query.go
@@ -156,14 +156,32 @@ func (d triDots) vertexRegion() (math.Point3, bool) {
 
 // edgeRegion returns the closest point when p projects onto an edge band.
 func (d triDots) edgeRegion() (math.Point3, bool) {
+	if v, hit := d.abRegion(); hit {
+		return v, true
+	}
+	if v, hit := d.acRegion(); hit {
+		return v, true
+	}
+	return d.bcRegion()
+}
+
+func (d triDots) abRegion() (math.Point3, bool) {
 	if vc := d.d1*d.d4 - d.d3*d.d2; vc <= 0 && d.d1 >= 0 && d.d3 <= 0 && d.d1-d.d3 > 0 {
 		t := math.Scalar(d.d1 / (d.d1 - d.d3))
 		return d.a.TranslateBy(d.ab.Scale(t)), true
 	}
+	return math.Point3{}, false
+}
+
+func (d triDots) acRegion() (math.Point3, bool) {
 	if vb := d.d5*d.d2 - d.d1*d.d6; vb <= 0 && d.d2 >= 0 && d.d6 <= 0 && d.d2-d.d6 > 0 {
 		t := math.Scalar(d.d2 / (d.d2 - d.d6))
 		return d.a.TranslateBy(d.ac.Scale(t)), true
 	}
+	return math.Point3{}, false
+}
+
+func (d triDots) bcRegion() (math.Point3, bool) {
 	if va := d.d3*d.d6 - d.d5*d.d4; va <= 0 && d.d4-d.d3 >= 0 && d.d5-d.d6 >= 0 && (d.d4-d.d3)+(d.d5-d.d6) > 0 {
 		t := math.Scalar((d.d4 - d.d3) / ((d.d4 - d.d3) + (d.d5 - d.d6)))
 		return d.b.TranslateBy(d.b.VectorTo(d.c).Scale(t)), true

--- a/kernel/ops/shell_wire_test.go
+++ b/kernel/ops/shell_wire_test.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"bytes"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// cavityBody is a 4×4×4 cube with a centered 2×2×2 cavity — the canonical
+// two-shell solid (#629): the outer skin plus the void skin.
+func cavityBody(t *testing.T) *topo.Body {
+	t.Helper()
+	big := tetraBox(t, math.P3(0, 0, 0), 4)
+	small := tetraBox(t, math.P3(1, 1, 1), 2)
+	res, err := Boolean(Cut, big, small)
+	if err != nil {
+		t.Fatalf("cavity cut: %v", err)
+	}
+	return res
+}
+
+func tetraBox(t *testing.T, p math.Point3, s float64) *topo.Body {
+	t.Helper()
+	m := subd.Box(s, s, s)
+	for i := range m.Verts {
+		m.Verts[i] = m.Verts[i].TranslateBy(p.AsVector())
+	}
+	return subd.ToBody(m, "box")
+}
+
+// TestCavityBodyHasVoidShell: the cut regroups into two closed shells; the
+// inner one classifies as a void with negative signed volume ≈ −8.
+func TestCavityBodyHasVoidShell(t *testing.T) {
+	body := cavityBody(t)
+	shells := body.Shells()
+	if len(shells) != 2 {
+		t.Fatalf("cavity body has %d shells, want 2 (outer + void)", len(shells))
+	}
+	voids := 0
+	for _, sh := range shells {
+		if !sh.IsClosed() {
+			t.Errorf("shell %d not closed", sh.Index())
+		}
+		if ShellIsVoid(sh, DefaultQuality()) {
+			voids++
+			if v := ShellSignedVolume(sh, DefaultQuality()); stdmath.Abs(v+8) > 0.05 {
+				t.Errorf("void shell signed volume = %g, want ~-8", v)
+			}
+		}
+	}
+	if voids != 1 {
+		t.Errorf("cavity body classifies %d void shells, want 1", voids)
+	}
+}
+
+// TestShellKeysAndRangeBoxes: shells carry distinct reference keys (kind-
+// prefixed) and connectivity-true range boxes.
+func TestShellKeysAndRangeBoxes(t *testing.T) {
+	body := cavityBody(t)
+	a, b := body.Shells()[0], body.Shells()[1]
+	if bytes.Equal(a.ReferenceKey(), b.ReferenceKey()) {
+		t.Error("the two shells must carry distinct reference keys")
+	}
+	if a.ReferenceKey()[0] != byte(topo.KindShell) {
+		t.Error("shell key must be kind-prefixed")
+	}
+	outer, void := a, b
+	if ShellIsVoid(a, DefaultQuality()) {
+		outer, void = b, a
+	}
+	vd := float64(void.RangeBox().Diagonal().Length())
+	od := float64(outer.RangeBox().Diagonal().Length())
+	if vd >= od {
+		t.Errorf("void shell box diagonal %g should be smaller than the outer %g", vd, od)
+	}
+	if len(outer.Edges()) == 0 || len(void.Edges()) == 0 {
+		t.Error("shells must report their edges")
+	}
+}
+
+// TestShellContainmentVerdicts: a point in the material is inside the outer
+// shell region but the body classifies cavity points as outside material.
+func TestShellContainmentVerdicts(t *testing.T) {
+	body := cavityBody(t)
+	q := DefaultQuality()
+	if c := BodyContainment(body, math.P3(0.5, 0.5, 0.5), q, 1e-6); c != ContainInside {
+		t.Errorf("material point = %v, want inside", c)
+	}
+	if c := BodyContainment(body, math.P3(2, 2, 2), q, 1e-6); c != ContainOutside {
+		t.Errorf("cavity center = %v, want outside (no material there)", c)
+	}
+	if c := BodyContainment(body, math.P3(0, 2, 2), q, 1e-6); c != ContainOn {
+		t.Errorf("outer wall point = %v, want on", c)
+	}
+	if c := BodyContainment(body, math.P3(10, 0, 0), q, 1e-6); c != ContainOutside {
+		t.Errorf("far point = %v, want outside", c)
+	}
+}
+
+// squareWireBody attaches a unit-square wire (CCW in the XY plane) to a body.
+func squareWireBody(side float64) (*topo.Body, *topo.Wire) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("w", "body", 0)))
+	p := []math.Point3{
+		math.P3(0, 0, 0), math.P3(math.Scalar(side), 0, 0),
+		math.P3(math.Scalar(side), math.Scalar(side), 0), math.P3(0, math.Scalar(side), 0),
+	}
+	v := make([]*topo.Vertex, 4)
+	for i := range p {
+		v[i] = bld.AddVertex(p[i], topo.NewLineage(topo.Tok("w", "vertex", i)))
+	}
+	uses := make([]topo.Use, 4)
+	for i := 0; i < 4; i++ {
+		j := (i + 1) % 4
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[j]), v[i], v[j], topo.NewLineage(topo.Tok("w", "edge", i)))
+		uses[i] = topo.Fwd(e)
+	}
+	body := bld.Build()
+	w := body.AttachWire(topo.NewLineage(topo.Tok("w", "wire", 0)), uses)
+	return body, w
+}
+
+// TestWireBasics: closure, planarity, plane frame, keys.
+func TestWireBasics(t *testing.T) {
+	body, w := squareWireBody(1)
+	if len(body.Wires()) != 1 {
+		t.Fatalf("body has %d wires, want 1", len(body.Wires()))
+	}
+	if !w.IsClosed() || !w.IsPlanar() {
+		t.Errorf("unit square wire: closed=%v planar=%v, want both true", w.IsClosed(), w.IsPlanar())
+	}
+	_, n, ok := w.PlaneFrame()
+	if !ok || stdmath.Abs(stdmath.Abs(float64(n.Z))-1) > 1e-9 {
+		t.Errorf("plane normal = %v (ok=%v), want ±Z", n, ok)
+	}
+	if w.ReferenceKey()[0] != byte(topo.KindWire) {
+		t.Error("wire key must be kind-prefixed")
+	}
+	if len(w.Edges()) != 4 {
+		t.Errorf("wire has %d edges, want 4", len(w.Edges()))
+	}
+}
+
+// TestWireNonPlanarDetected: lifting one vertex off the plane kills planarity.
+func TestWireNonPlanarDetected(t *testing.T) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("w", "body", 0)))
+	p := []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0.5), math.P3(0, 1, 0)}
+	v := make([]*topo.Vertex, 4)
+	for i := range p {
+		v[i] = bld.AddVertex(p[i], topo.NewLineage(topo.Tok("w", "vertex", i)))
+	}
+	uses := make([]topo.Use, 4)
+	for i := 0; i < 4; i++ {
+		j := (i + 1) % 4
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[j]), v[i], v[j], topo.NewLineage(topo.Tok("w", "edge", i)))
+		uses[i] = topo.Fwd(e)
+	}
+	w := bld.Build().AttachWire(topo.NewLineage(topo.Tok("w", "wire", 0)), uses)
+	if w.IsPlanar() {
+		t.Error("a twisted quad chain must not be planar")
+	}
+}
+
+// wireLength sums the wire's edge curve lengths by dense sampling.
+func wireLength(w *topo.Wire) float64 {
+	sum := 0.0
+	for _, u := range w.Uses() {
+		c := u.Edge.Geometry()
+		lo, hi := c.Domain()
+		prev := c.PointAt(lo)
+		for i := 1; i <= 64; i++ {
+			p := c.PointAt(lo + (hi-lo)*float64(i)/64)
+			sum += float64(prev.DistanceTo(p))
+			prev = p
+		}
+	}
+	return sum
+}
+
+// TestOffsetSquareInwardTrims: offsetting the CCW unit square LEFT (inward)
+// trims the corners — four lines, perimeter 4(1−2d).
+func TestOffsetSquareInwardTrims(t *testing.T) {
+	_, w := squareWireBody(1)
+	out, err := OffsetPlanarWire(w, math.V3(0, 0, 1), 0.1, WireCornerLinear)
+	if err != nil {
+		t.Fatalf("OffsetPlanarWire: %v", err)
+	}
+	ow := out.Wires()[0]
+	if len(ow.Edges()) != 4 {
+		t.Fatalf("inward offset has %d edges, want 4 (pure trim)", len(ow.Edges()))
+	}
+	if l := wireLength(ow); stdmath.Abs(l-4*0.8) > 1e-9 {
+		t.Errorf("inward offset perimeter = %g, want %g", l, 4*0.8)
+	}
+}
+
+// TestOffsetSquareOutwardCircular: offsetting RIGHT (outward) with circular
+// closure rounds each corner — 8 edges, perimeter 4 + 2π·d.
+func TestOffsetSquareOutwardCircular(t *testing.T) {
+	_, w := squareWireBody(1)
+	out, err := OffsetPlanarWire(w, math.V3(0, 0, 1), -0.25, WireCornerCircular)
+	if err != nil {
+		t.Fatalf("OffsetPlanarWire: %v", err)
+	}
+	ow := out.Wires()[0]
+	if len(ow.Edges()) != 8 {
+		t.Fatalf("outward circular offset has %d edges, want 8 (4 lines + 4 arcs)", len(ow.Edges()))
+	}
+	want := 4 + 2*stdmath.Pi*0.25
+	// wireLength samples 64 chords/edge; each arc reads ~2.5e-5 relative short.
+	if l := wireLength(ow); stdmath.Abs(l-want) > 1e-4 {
+		t.Errorf("outward offset perimeter = %g, want %g", l, want)
+	}
+}
+
+// TestOffsetSquareOutwardLinear: linear closure miters each corner — the
+// perimeter of the (1+2d) square.
+func TestOffsetSquareOutwardLinear(t *testing.T) {
+	_, w := squareWireBody(1)
+	out, err := OffsetPlanarWire(w, math.V3(0, 0, 1), -0.25, WireCornerLinear)
+	if err != nil {
+		t.Fatalf("OffsetPlanarWire: %v", err)
+	}
+	want := 4 * 1.5
+	if l := wireLength(out.Wires()[0]); stdmath.Abs(l-want) > 1e-9 {
+		t.Errorf("mitered outward perimeter = %g, want %g", l, want)
+	}
+}
+
+// circleWireBody is a single full-circle arc wire of radius r in XY.
+func circleWireBody(r float64) *topo.Wire {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("c", "body", 0)))
+	arc, _ := geom.NewArc3d(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), r, 0, 2*stdmath.Pi)
+	v := bld.AddVertex(math.P3(math.Scalar(r), 0, 0), topo.NewLineage(topo.Tok("c", "vertex", 0)))
+	e := bld.AddEdge(arc, v, v, topo.NewLineage(topo.Tok("c", "edge", 0)))
+	return bld.Build().AttachWire(topo.NewLineage(topo.Tok("c", "wire", 0)), []topo.Use{topo.Fwd(e)})
+}
+
+// TestOffsetCircleRadiusShift: a CCW circle offset left (toward center)
+// shrinks the radius; the collapse case errors with the offending values.
+func TestOffsetCircleRadiusShift(t *testing.T) {
+	w := circleWireBody(2)
+	out, err := OffsetPlanarWire(w, math.V3(0, 0, 1), 0.5, WireCornerCircular)
+	if err != nil {
+		t.Fatalf("OffsetPlanarWire: %v", err)
+	}
+	want := 2 * stdmath.Pi * 1.5
+	// chord sampling reads the circle ~2.4e-4 short at 64 segments.
+	if l := wireLength(out.Wires()[0]); stdmath.Abs(l-want) > 1e-2 {
+		t.Errorf("offset circle length = %g, want %g", l, want)
+	}
+	if _, err := OffsetPlanarWire(w, math.V3(0, 0, 1), 2.5, WireCornerCircular); err == nil {
+		t.Error("an offset past the radius must error (arc collapse)")
+	}
+}
+
+// TestOffsetRejectsOutOfPlane: a wire that leaves the stated plane errors
+// precisely rather than silently projecting.
+func TestOffsetRejectsOutOfPlane(t *testing.T) {
+	_, w := squareWireBody(1)
+	if _, err := OffsetPlanarWire(w, math.V3(1, 0, 0), 0.1, WireCornerLinear); err == nil {
+		t.Error("offsetting an XY wire in a YZ plane must error")
+	}
+}

--- a/kernel/ops/stitch.go
+++ b/kernel/ops/stitch.go
@@ -48,12 +48,18 @@ type (
 )
 
 // weld accumulates the coincidence-welded vertices, edges and faces to rebuild.
+// snap (identity for plain stitching) lets Sew pull near-coincident boundary
+// endpoints onto a shared position BEFORE quantization, so a real gap inside the
+// sew tolerance welds the way an exact coincidence does. built records the edges
+// the last build() created, so Sew can stamp gap residuals onto them.
 type weld struct {
 	tol    float64
+	snap   func(math.Point3) math.Point3
 	points map[vKey]math.Point3
 	curves map[eKey]geom.Curve3
 	uses   map[eKey]int
 	faces  []weldedFace
+	built  map[eKey]*topo.Edge
 }
 
 type weldedFace struct {
@@ -71,7 +77,10 @@ type weldedUse struct {
 }
 
 func newWeld(tol float64) *weld {
-	return &weld{tol: tol, points: map[vKey]math.Point3{}, curves: map[eKey]geom.Curve3{}, uses: map[eKey]int{}}
+	return &weld{
+		tol: tol, snap: func(p math.Point3) math.Point3 { return p },
+		points: map[vKey]math.Point3{}, curves: map[eKey]geom.Curve3{}, uses: map[eKey]int{},
+	}
 }
 
 // addFace captures a face (surface + lineage + welded loops) for rebuild.
@@ -105,12 +114,14 @@ func (w *weld) addUse(u *topo.EdgeUse) weldedUse {
 	return weldedUse{key: key, reversed: reversed}
 }
 
-// record welds an edge's endpoint positions and stores a representative curve.
+// record welds an edge's endpoint positions (after the snap hook) and stores a
+// representative curve.
 func (w *weld) record(e *topo.Edge) (vKey, vKey) {
-	sk := w.vkey(e.StartVertex().Point())
-	ek := w.vkey(e.EndVertex().Point())
-	w.points[sk] = e.StartVertex().Point()
-	w.points[ek] = e.EndVertex().Point()
+	s := w.snap(e.StartVertex().Point())
+	t := w.snap(e.EndVertex().Point())
+	sk, ek := w.vkey(s), w.vkey(t)
+	w.points[sk] = s
+	w.points[ek] = t
 	key, _ := canonical(sk, ek)
 	if _, ok := w.curves[key]; !ok {
 		w.curves[key] = e.Geometry()
@@ -173,6 +184,7 @@ func (w *weld) buildEdges(bld *topo.Builder, verts map[vKey]*topo.Vertex, feat s
 	for i, k := range keys {
 		out[k] = bld.AddEdge(w.curves[k], verts[k[0]], verts[k[1]], topo.NewLineage(topo.Tok(feat, "weld-edge", i)))
 	}
+	w.built = out
 	return out
 }
 

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -81,15 +81,7 @@ func TessellateEdge(e *topo.Edge, q Quality) []math.Point3 {
 // cyl/cone faces touching a crack so a trimmed wall conforms to its planar neighbour; a watertight body
 // has no cracks and is untouched.
 func TessellateBody(b *topo.Body, q Quality) (*Mesh, [][]math.Point3) {
-	faces := b.Faces()
-	fm := make([]*Mesh, len(faces))
-	idx := make(map[*topo.Face]int, len(faces))
-	for i, f := range faces {
-		fm[i] = TessellateFace(f, q)
-		idx[f] = i
-	}
-	conformCylConeFaces(faces, idx, fm, q)
-	orientFacesOutward(fm) // re-orient imported faces whose B-rep sense came in inverted (Normal-Debug red)
+	_, fm := tessellateBodyFaces(b, q)
 	mesh := &Mesh{}
 	for _, m := range fm {
 		mergeMesh(mesh, m)
@@ -99,6 +91,22 @@ func TessellateBody(b *topo.Body, q Quality) (*Mesh, [][]math.Point3) {
 		edges = append(edges, TessellateEdge(e, q))
 	}
 	return mesh, edges
+}
+
+// tessellateBodyFaces runs the per-face meshing pipeline (facet, cross-face
+// conformance repair, outward orientation) and returns the faces with their
+// repaired meshes — shared by [TessellateBody] and [CalculateBodyFacets].
+func tessellateBodyFaces(b *topo.Body, q Quality) ([]*topo.Face, []*Mesh) {
+	faces := b.Faces()
+	fm := make([]*Mesh, len(faces))
+	idx := make(map[*topo.Face]int, len(faces))
+	for i, f := range faces {
+		fm[i] = TessellateFace(f, q)
+		idx[f] = i
+	}
+	conformCylConeFaces(faces, idx, fm, q)
+	orientFacesOutward(fm) // re-orient imported faces whose B-rep sense came in inverted (Normal-Debug red)
+	return faces, fm
 }
 
 // TessellateFace facets a face. Planar faces are triangulated exactly from their

--- a/kernel/ops/transform.go
+++ b/kernel/ops/transform.go
@@ -28,9 +28,6 @@ import (
 //	    return prepend(topo.Tok("mirror", "copy", 0), l)
 //	})
 func TransformBody(b *topo.Body, m math.Matrix4, derive func(topo.Lineage) topo.Lineage) (*topo.Body, error) {
-	if n := len(b.Shells()); n != 1 {
-		return nil, fmt.Errorf("ops.TransformBody: %d shells; only single-shell bodies are supported", n)
-	}
 	reflected := m.Determinant() < 0
 	bld := topo.NewBuilder(b.IsSolid(), derive(b.Lineage()))
 
@@ -47,13 +44,73 @@ func TransformBody(b *topo.Body, m math.Matrix4, derive func(topo.Lineage) topo.
 		edges[e] = bld.AddEdge(curve, verts[e.StartVertex()], verts[e.EndVertex()], derive(e.Lineage()))
 	}
 	for _, f := range b.Faces() {
-		surface, err := geom.TransformSurface(f.Geometry(), m)
-		if err != nil {
-			return nil, fmt.Errorf("ops.TransformBody: face %d: %w", f.ID(), err)
+		if err := transformFaceInto(bld, f, m, edges, reflected, derive); err != nil {
+			return nil, err
 		}
-		bld.AddFace(surface, derive(f.Lineage()), loopSpecs(f, edges, reflected)...)
 	}
-	return bld.Build(), nil
+	out := bld.Build() // multi-shell sources regroup by connectivity here (#629)
+	transformWiresInto(out, b, m, edges, derive)
+	return out, nil
+}
+
+// transformFaceInto clones one face with its surface mapped, PRESERVING its
+// material sense — a reversed face (a cut/bore wall) must stay reversed or its
+// tessellation winds inward and the divergence-theorem volume flips on it.
+func transformFaceInto(bld *topo.Builder, f *topo.Face, m math.Matrix4, edges map[*topo.Edge]*topo.Edge, reflected bool, derive func(topo.Lineage) topo.Lineage) error {
+	surface, err := geom.TransformSurface(f.Geometry(), m)
+	if err != nil {
+		return fmt.Errorf("ops.TransformBody: face %d: %w", f.ID(), err)
+	}
+	if f.Reversed() {
+		bld.AddReversedFace(surface, derive(f.Lineage()), loopSpecs(f, edges, reflected)...)
+		return nil
+	}
+	bld.AddFace(surface, derive(f.Lineage()), loopSpecs(f, edges, reflected)...)
+	return nil
+}
+
+// transformWiresInto carries the source body's wires onto the transformed copy,
+// re-aiming each use at the cloned edges. Wire edges not shared with any face
+// are cloned here (they were absent from the face pass).
+func transformWiresInto(dst, src *topo.Body, m math.Matrix4, edges map[*topo.Edge]*topo.Edge, derive func(topo.Lineage) topo.Lineage) {
+	for _, w := range src.Wires() {
+		uses := make([]topo.Use, 0, len(w.Uses()))
+		for _, u := range w.Uses() {
+			clone, ok := edges[u.Edge]
+			if !ok {
+				clone = cloneWireEdge(u.Edge, m, derive)
+				edges[u.Edge] = clone
+			}
+			uses = append(uses, topo.Use{Edge: clone, Reversed: u.Reversed})
+		}
+		dst.AttachWire(derive(w.Lineage()), uses)
+	}
+}
+
+// cloneWireEdge maps a face-less wire edge (fresh vertices, transformed curve).
+// An untransformable curve keeps its polyline sampling — wires are sampled
+// consumers, so the seam stays faithful.
+func cloneWireEdge(e *topo.Edge, m math.Matrix4, derive func(topo.Lineage) topo.Lineage) *topo.Edge {
+	bld := topo.NewBuilder(false, derive(e.Lineage()))
+	curve, err := geom.TransformCurve(e.Geometry(), m)
+	if err != nil {
+		curve = transformSampledCurve(e.Geometry(), m)
+	}
+	s := bld.AddVertex(m.TransformPoint(e.StartVertex().Point()), derive(e.StartVertex().Lineage()))
+	t := bld.AddVertex(m.TransformPoint(e.EndVertex().Point()), derive(e.EndVertex().Lineage()))
+	return bld.AddEdge(curve, s, t, derive(e.Lineage()))
+}
+
+// transformSampledCurve maps a curve with no analytic transform as a polyline.
+func transformSampledCurve(c geom.Curve3, m math.Matrix4) geom.Curve3 {
+	const samples = 64
+	lo, hi := c.Domain()
+	pts := make([]math.Point3, samples+1)
+	for i := 0; i <= samples; i++ {
+		pts[i] = m.TransformPoint(c.PointAt(lo + (hi-lo)*float64(i)/samples))
+	}
+	poly, _ := geom.NewPolyline(pts)
+	return poly
 }
 
 // loopSpecs rebuilds a face's loop specs against the cloned edges, reversing the

--- a/kernel/ops/transform_multishell_test.go
+++ b/kernel/ops/transform_multishell_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TransformBody historically rejected multi-shell bodies and silently dropped
+// each face's material sense; both broke transformed cavity bodies (#629/#628
+// Copy rides on this). The cavity body is the regression vehicle: 4³ − 2³ = 56
+// of material in two shells with reversed cavity walls.
+
+func TestTransformBodyCavityPreservesShellsAndVolume(t *testing.T) {
+	body := cavityBody(t)
+	moved, err := TransformBody(body, math.Translation4(math.V3(10, 0, 0)), func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	if got := len(moved.Shells()); got != 2 {
+		t.Errorf("moved cavity body has %d shells, want 2", got)
+	}
+	if v := BodyGeometryProperties(moved, DefaultQuality()).Volume; stdmath.Abs(v-56) > 0.1 {
+		t.Errorf("moved cavity volume = %g, want 56 (face sense must survive)", v)
+	}
+	if r := Validate(moved); !r.Valid {
+		t.Errorf("moved cavity invalid: %v", r.Issues)
+	}
+}
+
+// TestTransformBodyCarriesWires: a wire-only body transforms with its wire.
+func TestTransformBodyCarriesWires(t *testing.T) {
+	_, w := squareWireBody(1)
+	src := w.Body()
+	moved, err := TransformBody(src, math.Translation4(math.V3(0, 0, 5)), func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	if len(moved.Wires()) != 1 {
+		t.Fatalf("moved body has %d wires, want 1", len(moved.Wires()))
+	}
+	p := moved.Wires()[0].Edges()[0].StartVertex().Point()
+	if stdmath.Abs(float64(p.Z)-5) > 1e-12 {
+		t.Errorf("moved wire start Z = %v, want 5", p.Z)
+	}
+}

--- a/kernel/ops/transient_brep_test.go
+++ b/kernel/ops/transient_brep_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestSectionWithPlaneBoxRectangle: a mid-height plane sections the box into
+// one closed rectangular chain of perimeter 2(sx+sy).
+func TestSectionWithPlaneBoxRectangle(t *testing.T) {
+	b := boxBody(math.P3(0, 0, 0), 3, 2, 4)
+	sec, err := SectionWithPlane(b, math.P3(0, 0, 2), math.V3(0, 0, 1), DefaultQuality())
+	if err != nil {
+		t.Fatalf("SectionWithPlane: %v", err)
+	}
+	wires := sec.Wires()
+	if len(wires) != 1 {
+		t.Fatalf("box section has %d wires, want 1", len(wires))
+	}
+	if !wires[0].IsClosed() {
+		t.Error("box section wire should be closed")
+	}
+	if l := wireLength(wires[0]); stdmath.Abs(l-10) > 1e-6 {
+		t.Errorf("section perimeter = %g, want 10", l)
+	}
+	if _, err := SectionWithPlane(b, math.P3(0, 0, 50), math.V3(0, 0, 1), DefaultQuality()); err == nil {
+		t.Error("a plane missing the body must error")
+	}
+}
+
+// boxBody stitches the six outward quads of a sx×sy×sz box at p — the
+// established cubeFaces idiom, scaled.
+func boxBody(p math.Point3, sx, sy, sz float64) *topo.Body {
+	s := func(x, y, z float64) math.Point3 {
+		return math.P3(p.X+math.Scalar(x*sx), p.Y+math.Scalar(y*sy), p.Z+math.Scalar(z*sz))
+	}
+	faces := []*topo.Body{
+		quadBody("bottom", s(0, 0, 0), s(0, 1, 0), s(1, 1, 0), s(1, 0, 0)),
+		quadBody("top", s(0, 0, 1), s(1, 0, 1), s(1, 1, 1), s(0, 1, 1)),
+		quadBody("front", s(0, 0, 0), s(1, 0, 0), s(1, 0, 1), s(0, 0, 1)),
+		quadBody("back", s(0, 1, 0), s(0, 1, 1), s(1, 1, 1), s(1, 1, 0)),
+		quadBody("left", s(0, 0, 0), s(0, 0, 1), s(0, 1, 1), s(0, 1, 0)),
+		quadBody("right", s(1, 0, 0), s(1, 1, 0), s(1, 1, 1), s(1, 0, 1)),
+	}
+	body, _ := Stitch(faces, 0, false, "box")
+	return body
+}
+
+// TestFaceSilhouetteCylinderRulings: a cylinder side face viewed from +X has
+// two vertical silhouette rulings (at y = ±r).
+func TestFaceSilhouetteCylinderRulings(t *testing.T) {
+	cyl := cylinderBody(t, 2, 5)
+	var side *topo.Face
+	for _, f := range cyl.Faces() {
+		if !isPlanarFace(f) {
+			side = f
+		}
+	}
+	if side == nil {
+		t.Fatal("cylinder has no curved side face")
+	}
+	sil, err := FaceSilhouetteWires(side, math.V3(1, 0, 0), true, DefaultQuality())
+	if err != nil {
+		t.Fatalf("FaceSilhouetteWires: %v", err)
+	}
+	if n := len(sil.Wires()); n != 2 {
+		t.Fatalf("cylinder silhouette has %d wires, want 2 rulings", n)
+	}
+	for _, w := range sil.Wires() {
+		if l := wireLength(w); stdmath.Abs(l-5) > 0.1 {
+			t.Errorf("silhouette ruling length = %g, want 5", l)
+		}
+	}
+}
+
+func cylinderBody(t *testing.T, r, h float64) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r, h)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	return b
+}
+
+func isPlanarFace(f *topo.Face) bool {
+	_, ok := f.Geometry().(geom.Plane)
+	return ok
+}
+
+// TestRuledSurfaceBetweenSquares: ruling two parallel unit squares 2 apart
+// gives a surface body of area ~8 (four 1×2 walls).
+func TestRuledSurfaceBetweenSquares(t *testing.T) {
+	_, w1 := squareWireBody(1)
+	_, w2raw := squareWireBody(1)
+	lifted, err := TransformBody(w2raw.Body(), math.Translation4(math.V3(0, 0, 2)), func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		t.Fatal(err)
+	}
+	w2 := lifted.Wires()[0]
+	surf, err := RuledSurfaceBetweenWires(w1, w2)
+	if err != nil {
+		t.Fatalf("RuledSurfaceBetweenWires: %v", err)
+	}
+	if surf.IsSolid() {
+		t.Error("a ruled surface is a surface body, not a solid")
+	}
+	props := BodyGeometryProperties(surf, DefaultQuality())
+	if stdmath.Abs(props.Area-8) > 0.1 {
+		t.Errorf("ruled surface area = %g, want ~8", props.Area)
+	}
+}
+
+// TestGroupIdenticalBodies: a box equals its translate and rotate, not a
+// different box; reflection matching is controllable.
+func TestGroupIdenticalBodies(t *testing.T) {
+	a := boxBody(math.P3(0, 0, 0), 1, 2, 3)
+	moved, _ := TransformBody(a, math.Translation4(math.V3(10, 0, 0)), func(l topo.Lineage) topo.Lineage { return l })
+	axis, _ := math.UnitVector3FromVector(math.V3(0, 0, 1))
+	rotated, _ := TransformBody(a, math.Rotation4(0.7, axis, math.P3(5, 5, 5)), func(l topo.Lineage) topo.Lineage { return l })
+	other := boxBody(math.P3(0, 0, 0), 1, 2, 4)
+	groups := GroupIdenticalBodies([]*topo.Body{a, moved, rotated, other},
+		IdenticalBodiesOptions{MatchReflection: true}, DefaultQuality())
+	if len(groups) != 2 {
+		t.Fatalf("grouping = %v, want 2 groups", groups)
+	}
+	if len(groups[0]) != 3 {
+		t.Errorf("identical group = %v, want the three congruent boxes", groups[0])
+	}
+}
+
+// TestDropFacesKeepsSelectionSemantics: deleting one face opens the body;
+// keep-instead retains only the selection.
+func TestDropFacesKeepsSelectionSemantics(t *testing.T) {
+	b := boxBody(math.P3(0, 0, 0), 1, 1, 1)
+	key := b.Faces()[0].ReferenceKey()
+	open, err := DropFaces(b, [][]byte{key}, false)
+	if err != nil {
+		t.Fatalf("DropFaces: %v", err)
+	}
+	if len(open.Faces()) != 5 || open.IsSolid() {
+		t.Errorf("drop-one result: %d faces solid=%v, want 5 faces surface body", len(open.Faces()), open.IsSolid())
+	}
+	if len(BoundaryEdges(open)) != 4 {
+		t.Errorf("opened box has %d boundary edges, want 4", len(BoundaryEdges(open)))
+	}
+	only, err := DropFaces(b, [][]byte{key}, true)
+	if err != nil {
+		t.Fatalf("DropFaces keep: %v", err)
+	}
+	if len(only.Faces()) != 1 {
+		t.Errorf("keep-instead result has %d faces, want 1", len(only.Faces()))
+	}
+	if _, err := DropFaces(only, [][]byte{only.Faces()[0].ReferenceKey()}, false); err == nil {
+		t.Error("removing every face must error")
+	}
+}

--- a/kernel/ops/validate.go
+++ b/kernel/ops/validate.go
@@ -56,4 +56,3 @@ func BoundaryEdges(b *topo.Body) []*topo.Edge {
 	}
 	return open
 }
-

--- a/kernel/ops/validate.go
+++ b/kernel/ops/validate.go
@@ -5,7 +5,6 @@ package ops
 import (
 	"fmt"
 
-	"oblikovati.org/build"
 	"oblikovati.org/kernel/topo"
 )
 
@@ -58,11 +57,3 @@ func BoundaryEdges(b *topo.Body) []*topo.Edge {
 	return open
 }
 
-// Sew stitches an open shell's coincident boundary edges into a closed, manifold
-// body. Tolerant stitching (matching near-coincident edges and rewiring uses)
-// needs the tolerant-topology machinery of kernel phase D; until then Validate +
-// BoundaryEdges report the open edges precisely, which is the documented
-// "or reported precisely" path (PBI-084).
-func Sew(_ *topo.Body, _ float64) (*topo.Body, error) {
-	return nil, build.NotYetImplemented("PBI-084-sew")
-}

--- a/kernel/ops/wire_offset.go
+++ b/kernel/ops/wire_offset.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Planar wire offsetting (M07-F06, Oblikovati/Oblikovati#629): offset a wire's
+// chain in its plane by a distance, joining the corners per the closure type.
+// Positive distance offsets toward normal × tangent (the LEFT of travel about
+// the given plane normal); negative offsets right. Line and arc edges offset
+// exactly (an arc's radius grows or shrinks); other curves offset as sampled
+// polylines. Corners where the offsets cross are trimmed at the support-curve
+// intersection; gap corners close per WireOffsetCorner. Global
+// self-intersection removal of the result (an offset larger than a concave
+// feature) is out of scope — the local result is returned as computed.
+
+// WireOffsetCorner selects how a gap corner closes (the reference
+// OffsetCornerClosureTypeEnum semantics).
+type WireOffsetCorner uint8
+
+const (
+	// WireCornerCircular rounds the gap with an arc about the original corner.
+	WireCornerCircular WireOffsetCorner = iota
+	// WireCornerLinear extends both sides tangentially to their intersection.
+	WireCornerLinear
+	// WireCornerExtend grows the actual curves (an arc stays an arc) to meet.
+	WireCornerExtend
+)
+
+// wireOffsetTol is the coincidence/degeneracy tolerance of the offset (cm).
+const wireOffsetTol = 1e-9
+
+// OffsetPlanarWire offsets w by distance in the plane with the given normal,
+// returning a new wire-only body. The wire must lie in that plane.
+//
+// Example: out, err := ops.OffsetPlanarWire(w, math.V3(0, 0, 1), 0.5, ops.WireCornerCircular)
+func OffsetPlanarWire(w *topo.Wire, normal math.Vector3, distance float64, corner WireOffsetCorner) (*topo.Body, error) {
+	if distance == 0 {
+		return nil, fmt.Errorf("ops.OffsetPlanarWire: distance must be non-zero")
+	}
+	pl, err := newWirePlane(w, normal)
+	if err != nil {
+		return nil, err
+	}
+	segs, err := wireSegments2D(w, pl)
+	if err != nil {
+		return nil, err
+	}
+	offs, err := offsetSegments(segs, distance)
+	if err != nil {
+		return nil, err
+	}
+	joined, err := joinOffsetCorners(segs, offs, distance, corner, w.IsClosed())
+	if err != nil {
+		return nil, err
+	}
+	return buildWireBody(joined, pl, w.IsClosed())
+}
+
+// wirePlane is the 2D frame the offset works in: x along u, y along v = n×u.
+type wirePlane struct {
+	origin  math.Point3
+	n, u, v math.Vector3
+}
+
+// newWirePlane frames the wire's plane from the caller's normal and verifies
+// the wire actually lies in it.
+func newWirePlane(w *topo.Wire, normal math.Vector3) (wirePlane, error) {
+	l := float64(normal.Length())
+	if l == 0 {
+		return wirePlane{}, fmt.Errorf("ops.OffsetPlanarWire: zero plane normal")
+	}
+	n := normal.Scale(math.Scalar(1 / l))
+	uses := w.Uses()
+	if len(uses) == 0 {
+		return wirePlane{}, fmt.Errorf("ops.OffsetPlanarWire: empty wire")
+	}
+	pl := frameAbout(uses[0].Edge.StartVertex().Point(), n)
+	if err := verifyWireInPlane(w, pl); err != nil {
+		return wirePlane{}, err
+	}
+	return pl, nil
+}
+
+// frameAbout picks in-plane axes for n through origin o.
+func frameAbout(o math.Point3, n math.Vector3) wirePlane {
+	ref := math.V3(1, 0, 0)
+	if stdmath.Abs(float64(n.X)) > 0.9 {
+		ref = math.V3(0, 1, 0)
+	}
+	u := n.Cross(ref)
+	u = u.Scale(math.Scalar(1 / float64(u.Length())))
+	return wirePlane{origin: o, n: n, u: u, v: n.Cross(u)}
+}
+
+// verifyWireInPlane samples the wire and rejects out-of-plane geometry with
+// the offending deviation.
+func verifyWireInPlane(w *topo.Wire, pl wirePlane) error {
+	for _, u := range w.Uses() {
+		c := u.Edge.Geometry()
+		lo, hi := c.Domain()
+		for i := 0; i <= 16; i++ {
+			p := c.PointAt(lo + (hi-lo)*float64(i)/16)
+			if dev := stdmath.Abs(float64(pl.origin.VectorTo(p).Dot(pl.n))); dev > 1e-7 {
+				return fmt.Errorf("ops.OffsetPlanarWire: edge %d leaves the plane by %g (max 1e-7)", u.Edge.ID(), dev)
+			}
+		}
+	}
+	return nil
+}
+
+func (pl wirePlane) to2(p math.Point3) math.Point2 {
+	d := pl.origin.VectorTo(p)
+	return math.P2(d.Dot(pl.u), d.Dot(pl.v))
+}
+
+func (pl wirePlane) to3(p math.Point2) math.Point3 {
+	return pl.origin.TranslateBy(pl.u.Scale(p.X).Add(pl.v.Scale(p.Y)))
+}
+
+// wireSeg kinds.
+const (
+	wsLine = iota
+	wsArc
+	wsPoly
+)
+
+// wireSeg is one oriented 2D primitive of the chain. Lines and polys are
+// ground-truthed by their points; arcs by center/radius/a0/sweep (a, b derived)
+// so trims and extensions stay exactly circular.
+type wireSeg struct {
+	kind      int
+	a, b      math.Point2
+	center    math.Point2
+	r         float64
+	a0, sweep float64 // arc: start angle and signed sweep (positive = CCW)
+	poly      []math.Point2
+}
+
+// arcPoint evaluates the arc seg at fraction f of its sweep.
+func (s *wireSeg) arcPoint(f float64) math.Point2 {
+	ang := s.a0 + s.sweep*f
+	return math.P2(s.center.X+math.Scalar(s.r*stdmath.Cos(ang)), s.center.Y+math.Scalar(s.r*stdmath.Sin(ang)))
+}
+
+// syncArcEnds refreshes the derived a/b endpoints from the arc parameters.
+func (s *wireSeg) syncArcEnds() {
+	s.a, s.b = s.arcPoint(0), s.arcPoint(1)
+}
+
+// startTangent and endTangent return unit travel directions at the seg ends.
+func (s *wireSeg) startTangent() math.Vector2 { return s.tangentAt(0) }
+func (s *wireSeg) endTangent() math.Vector2   { return s.tangentAt(1) }
+
+func (s *wireSeg) tangentAt(f float64) math.Vector2 {
+	switch s.kind {
+	case wsArc:
+		ang := s.a0 + s.sweep*f
+		t := math.V2(math.Scalar(-stdmath.Sin(ang)), math.Scalar(stdmath.Cos(ang)))
+		if s.sweep < 0 {
+			t = t.Negate()
+		}
+		return t
+	case wsPoly:
+		pts := s.poly
+		if f == 0 {
+			return unit2(pts[0].VectorTo(pts[1]))
+		}
+		return unit2(pts[len(pts)-2].VectorTo(pts[len(pts)-1]))
+	default:
+		return unit2(s.a.VectorTo(s.b))
+	}
+}
+
+func unit2(v math.Vector2) math.Vector2 {
+	l := float64(v.Length())
+	if l == 0 {
+		return v
+	}
+	return v.Scale(math.Scalar(1 / l))
+}
+
+// perpLeft rotates a direction 90° counterclockwise — the positive-offset side.
+func perpLeft(v math.Vector2) math.Vector2 { return math.V2(-v.Y, v.X) }
+
+// wireSegments2D converts the wire's oriented edges into 2D segs.
+func wireSegments2D(w *topo.Wire, pl wirePlane) ([]wireSeg, error) {
+	uses := w.Uses()
+	out := make([]wireSeg, len(uses))
+	for i, u := range uses {
+		seg, err := edgeSegment2D(u, pl)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = seg
+	}
+	return out, nil
+}
+
+// edgeSegment2D maps one oriented edge to a 2D seg: lines and arcs exactly,
+// anything else as a sampled polyline.
+func edgeSegment2D(u topo.Use, pl wirePlane) (wireSeg, error) {
+	switch c := u.Edge.Geometry().(type) {
+	case geom.LineSegment:
+		a, b := pl.to2(c.StartPoint), pl.to2(c.EndPoint)
+		if u.Reversed {
+			a, b = b, a
+		}
+		return wireSeg{kind: wsLine, a: a, b: b}, nil
+	case geom.Arc3d:
+		return arcSegment2D(c, u.Reversed, pl)
+	default:
+		return polySegment2D(u, pl), nil
+	}
+}
+
+// arcSegment2D projects an arc into the frame, flipping sweep sign when the
+// arc's own normal opposes the offset plane's.
+func arcSegment2D(c geom.Arc3d, reversed bool, pl wirePlane) (wireSeg, error) {
+	center := pl.to2(c.Center)
+	start3 := c.PointAt(0)
+	v0 := pl.to2(start3).AsVector().Sub(center.AsVector())
+	a0 := stdmath.Atan2(float64(v0.Y), float64(v0.X))
+	sweep := c.SweepAngle
+	if float64(c.Normal.AsVector().Dot(pl.n)) < 0 {
+		sweep = -sweep
+	}
+	if reversed {
+		a0, sweep = a0+sweep, -sweep
+	}
+	s := wireSeg{kind: wsArc, center: center, r: c.Radius, a0: a0, sweep: sweep}
+	s.syncArcEnds()
+	return s, nil
+}
+
+// polySegment2D samples any other curve at offset density, oriented.
+func polySegment2D(u topo.Use, pl wirePlane) wireSeg {
+	const samples = 64
+	c := u.Edge.Geometry()
+	lo, hi := c.Domain()
+	pts := make([]math.Point2, samples+1)
+	for i := 0; i <= samples; i++ {
+		pts[i] = pl.to2(c.PointAt(lo + (hi-lo)*float64(i)/samples))
+	}
+	if u.Reversed {
+		for l, r := 0, len(pts)-1; l < r; l, r = l+1, r-1 {
+			pts[l], pts[r] = pts[r], pts[l]
+		}
+	}
+	return wireSeg{kind: wsPoly, a: pts[0], b: pts[len(pts)-1], poly: pts}
+}
+
+// offsetSegments offsets each seg by d to its left (positive d).
+func offsetSegments(segs []wireSeg, d float64) ([]wireSeg, error) {
+	out := make([]wireSeg, len(segs))
+	for i := range segs {
+		off, err := offsetSegment(segs[i], d)
+		if err != nil {
+			return nil, fmt.Errorf("ops.OffsetPlanarWire: segment %d: %w", i, err)
+		}
+		out[i] = off
+	}
+	return out, nil
+}
+
+// offsetSegment offsets one seg: a line translates, an arc re-radiuses
+// (CCW: left is toward the center → r-d; CW: away → r+d), a polyline offsets
+// per segment with miter joints.
+func offsetSegment(s wireSeg, d float64) (wireSeg, error) {
+	switch s.kind {
+	case wsLine:
+		shift := perpLeft(unit2(s.a.VectorTo(s.b))).Scale(math.Scalar(d))
+		return wireSeg{kind: wsLine, a: s.a.TranslateBy(shift), b: s.b.TranslateBy(shift)}, nil
+	case wsArc:
+		r := s.r - d
+		if s.sweep < 0 {
+			r = s.r + d
+		}
+		if r <= wireOffsetTol {
+			return wireSeg{}, fmt.Errorf("offset %g collapses arc of radius %g", d, s.r)
+		}
+		off := wireSeg{kind: wsArc, center: s.center, r: r, a0: s.a0, sweep: s.sweep}
+		off.syncArcEnds()
+		return off, nil
+	default:
+		return offsetPolySeg(s, d), nil
+	}
+}
+
+// offsetPolySeg offsets a polyline with miter joints (bevel past the miter
+// limit, 4|d|).
+func offsetPolySeg(s wireSeg, d float64) wireSeg {
+	pts := s.poly
+	out := make([]math.Point2, 0, len(pts))
+	for i, p := range pts {
+		out = append(out, p.TranslateBy(polyOffsetDir(pts, i, d)))
+	}
+	return wireSeg{kind: wsPoly, a: out[0], b: out[len(out)-1], poly: out}
+}
+
+// polyOffsetDir is the offset displacement at polyline vertex i: the segment
+// normal at the ends, the (miter-limited) angle bisector normal inside.
+func polyOffsetDir(pts []math.Point2, i int, d float64) math.Vector2 {
+	last := len(pts) - 1
+	switch i {
+	case 0:
+		return perpLeft(unit2(pts[0].VectorTo(pts[1]))).Scale(math.Scalar(d))
+	case last:
+		return perpLeft(unit2(pts[last-1].VectorTo(pts[last]))).Scale(math.Scalar(d))
+	}
+	n1 := perpLeft(unit2(pts[i-1].VectorTo(pts[i])))
+	n2 := perpLeft(unit2(pts[i].VectorTo(pts[i+1])))
+	bis := n1.Add(n2)
+	denom := 1 + float64(n1.Dot(n2))
+	if denom < 1.0/8 { // miter longer than 4|d| → bevel via plain average
+		return bis.Scale(math.Scalar(d / 2))
+	}
+	return bis.Scale(math.Scalar(d / denom))
+}

--- a/kernel/ops/wire_offset_corners.go
+++ b/kernel/ops/wire_offset_corners.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Corner joining and 3D rebuild of the planar wire offset (wire_offset.go).
+// At each corner the offsets either CROSS (the chain turns toward the offset
+// side → trim both at their support intersection) or GAP (turns away → close
+// per the WireOffsetCorner mode).
+
+// joinOffsetCorners walks consecutive seg pairs (wrapping when closed),
+// trimming crossings and inserting gap closures.
+func joinOffsetCorners(src, offs []wireSeg, d float64, corner WireOffsetCorner, closed bool) ([]wireSeg, error) {
+	inserted := make([][]wireSeg, len(offs)) // closures appended after seg i
+	pairs := len(offs) - 1
+	if closed {
+		pairs = len(offs)
+	}
+	for k := 0; k < pairs; k++ {
+		i, j := k, (k+1)%len(offs)
+		fill, err := joinPair(&src[i], &offs[i], &offs[j], d, corner)
+		if err != nil {
+			return nil, err
+		}
+		inserted[i] = fill
+	}
+	var out []wireSeg
+	for i := range offs {
+		if segLength(&offs[i]) > wireOffsetTol {
+			out = append(out, offs[i])
+		}
+		out = append(out, inserted[i]...)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("ops.OffsetPlanarWire: offset %g consumed the whole wire", d)
+	}
+	return out, nil
+}
+
+// joinPair resolves one corner between prev and next: weld if snug, trim if
+// the offsets cross, close the gap otherwise. The original corner point comes
+// from the source chain (prev's end).
+func joinPair(srcPrev, prev, next *wireSeg, d float64, corner WireOffsetCorner) ([]wireSeg, error) {
+	if prev == next {
+		return nil, nil // single-seg closed chain (a full circle) — already joined
+	}
+	if float64(prev.b.DistanceTo(next.a)) <= wireOffsetTol {
+		setSegStart(next, prev.b)
+		return nil, nil
+	}
+	turn := float64(srcPrev.endTangent().Cross(next.startTangent()))
+	if d*turn > 0 {
+		if trimAtSupportIntersection(prev, next) {
+			return nil, nil
+		}
+		return []wireSeg{bevel(prev.b, next.a)}, nil // numerically parallel: bevel
+	}
+	return closeGap(srcPrev.b, prev, next, d, corner)
+}
+
+// closeGap inserts the closure for a gap corner about original corner P.
+func closeGap(p math.Point2, prev, next *wireSeg, d float64, corner WireOffsetCorner) ([]wireSeg, error) {
+	switch corner {
+	case WireCornerCircular:
+		return []wireSeg{closureArc(p, prev.b, next.a, d)}, nil
+	case WireCornerExtend:
+		if trimAtSupportIntersection(prev, next) {
+			return nil, nil
+		}
+		return closeLinear(prev, next)
+	default:
+		return closeLinear(prev, next)
+	}
+}
+
+// closeLinear extends both sides tangentially to their intersection (a miter);
+// near-parallel tangents bevel straight across.
+func closeLinear(prev, next *wireSeg) ([]wireSeg, error) {
+	m, ok := rayIntersection(prev.b, prev.endTangent(), next.a, next.startTangent().Negate())
+	if !ok {
+		return []wireSeg{bevel(prev.b, next.a)}, nil
+	}
+	out := make([]wireSeg, 0, 2)
+	if float64(prev.b.DistanceTo(m)) > wireOffsetTol {
+		out = append(out, bevel(prev.b, m))
+	}
+	if float64(m.DistanceTo(next.a)) > wireOffsetTol {
+		out = append(out, bevel(m, next.a))
+	}
+	return out, nil
+}
+
+// closureArc rounds the gap with an arc about p of radius |d|, swept the short
+// way from E to S.
+func closureArc(p, e, s math.Point2, d float64) wireSeg {
+	a0 := stdmath.Atan2(float64(e.Y-p.Y), float64(e.X-p.X))
+	a1 := stdmath.Atan2(float64(s.Y-p.Y), float64(s.X-p.X))
+	sweep := stdmath.Mod(a1-a0, 2*stdmath.Pi)
+	if sweep > stdmath.Pi {
+		sweep -= 2 * stdmath.Pi
+	}
+	if sweep < -stdmath.Pi {
+		sweep += 2 * stdmath.Pi
+	}
+	arc := wireSeg{kind: wsArc, center: p, r: stdmath.Abs(d), a0: a0, sweep: sweep}
+	arc.syncArcEnds()
+	return arc
+}
+
+func bevel(a, b math.Point2) wireSeg { return wireSeg{kind: wsLine, a: a, b: b} }
+
+// rayIntersection intersects two rays (origin + direction); ok is false when
+// near-parallel.
+func rayIntersection(p1 math.Point2, d1 math.Vector2, p2 math.Point2, d2 math.Vector2) (math.Point2, bool) {
+	denom := float64(d1.Cross(d2))
+	if stdmath.Abs(denom) < 1e-12 {
+		return math.Point2{}, false
+	}
+	w := p1.VectorTo(p2)
+	t := float64(w.Cross(d2)) / denom
+	return p1.TranslateBy(d1.Scale(math.Scalar(t))), true
+}
+
+// trimAtSupportIntersection moves prev's end and next's start onto the
+// intersection of their support curves nearest the current joint; false when
+// the supports do not intersect.
+func trimAtSupportIntersection(prev, next *wireSeg) bool {
+	cands := supportIntersections(prev, next)
+	if len(cands) == 0 {
+		return false
+	}
+	best, bestCost := cands[0], stdmath.Inf(1)
+	for _, c := range cands {
+		cost := float64(c.DistanceTo(prev.b)) + float64(c.DistanceTo(next.a))
+		if cost < bestCost {
+			best, bestCost = c, cost
+		}
+	}
+	setSegEnd(prev, best)
+	setSegStart(next, best)
+	return true
+}
+
+// supportIntersections intersects the two segs' unbounded support curves
+// (line↔line, line↔circle, circle↔circle; a polyline's corner end behaves as
+// its end segment's line).
+func supportIntersections(a, b *wireSeg) []math.Point2 {
+	if a.kind == wsArc && b.kind == wsArc {
+		return geom.Circle2dCircle2dIntersection(supportCircle(a), supportCircle(b), 0)
+	}
+	if a.kind == wsArc {
+		return circleLineCands(supportCircle(a), supportLine(b, false))
+	}
+	if b.kind == wsArc {
+		return circleLineCands(supportCircle(b), supportLine(a, true))
+	}
+	if p, ok := rayIntersection(segEndAnchor(a), a.endTangent(), segStartAnchor(b), b.startTangent()); ok {
+		return []math.Point2{p}
+	}
+	return nil
+}
+
+func circleLineCands(c geom.Circle2d, l geom.Line2d) []math.Point2 {
+	return geom.LineCircle2dIntersection(l, c, 0)
+}
+
+func supportCircle(s *wireSeg) geom.Circle2d { return geom.NewCircle2d(s.center, s.r) }
+
+// supportLine is the unbounded line through a line/poly seg's joint end.
+func supportLine(s *wireSeg, atEnd bool) geom.Line2d {
+	anchor, dir := segStartAnchor(s), s.startTangent()
+	if atEnd {
+		anchor, dir = segEndAnchor(s), s.endTangent()
+	}
+	l, _ := geom.NewLine2d(anchor, dir)
+	return l
+}
+
+func segStartAnchor(s *wireSeg) math.Point2 { return s.a }
+func segEndAnchor(s *wireSeg) math.Point2   { return s.b }
+
+// setSegEnd moves a seg's end to p (an arc re-aims its sweep; a poly replaces
+// its last vertex).
+func setSegEnd(s *wireSeg, p math.Point2) {
+	switch s.kind {
+	case wsArc:
+		end := stdmath.Atan2(float64(p.Y-s.center.Y), float64(p.X-s.center.X))
+		s.sweep = wrapTowards(end-s.a0, s.sweep)
+		s.syncArcEnds()
+	case wsPoly:
+		s.poly[len(s.poly)-1] = p
+		s.b = p
+	default:
+		s.b = p
+	}
+}
+
+// setSegStart moves a seg's start to p.
+func setSegStart(s *wireSeg, p math.Point2) {
+	switch s.kind {
+	case wsArc:
+		start := stdmath.Atan2(float64(p.Y-s.center.Y), float64(p.X-s.center.X))
+		end := s.a0 + s.sweep
+		s.a0 = start
+		s.sweep = wrapTowards(end-start, s.sweep)
+		s.syncArcEnds()
+	case wsPoly:
+		s.poly[0] = p
+		s.a = p
+	default:
+		s.a = p
+	}
+}
+
+// wrapTowards maps delta into the 2π band sharing reference's sign — a trim
+// shortens an arc, never flips its direction.
+func wrapTowards(delta, reference float64) float64 {
+	d := stdmath.Mod(delta, 2*stdmath.Pi)
+	if reference >= 0 && d < 0 {
+		d += 2 * stdmath.Pi
+	}
+	if reference < 0 && d > 0 {
+		d -= 2 * stdmath.Pi
+	}
+	return d
+}
+
+// segLength is the seg's approximate length (degeneracy filter).
+func segLength(s *wireSeg) float64 {
+	if s.kind == wsArc {
+		return stdmath.Abs(s.sweep) * s.r
+	}
+	if s.kind == wsPoly {
+		sum := 0.0
+		for i := 0; i+1 < len(s.poly); i++ {
+			sum += float64(s.poly[i].DistanceTo(s.poly[i+1]))
+		}
+		return sum
+	}
+	return float64(s.a.DistanceTo(s.b))
+}
+
+// buildWireBody lifts the joined 2D chain back to a 3D wire-only body.
+func buildWireBody(segs []wireSeg, pl wirePlane, closed bool) (*topo.Body, error) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("wireOffset", "body", 0)))
+	verts := wireChainVertices(bld, segs, pl, closed)
+	uses := make([]topo.Use, len(segs))
+	for i := range segs {
+		curve, err := segCurve3(&segs[i], pl)
+		if err != nil {
+			return nil, err
+		}
+		end := verts[(i+1)%len(verts)]
+		if !closed && i == len(segs)-1 {
+			end = verts[len(verts)-1]
+		}
+		e := bld.AddEdge(curve, verts[i], end, topo.NewLineage(topo.Tok("wireOffset", "edge", i)))
+		uses[i] = topo.Fwd(e)
+	}
+	body := bld.Build()
+	body.AttachWire(topo.NewLineage(topo.Tok("wireOffset", "wire", 0)), uses)
+	return body, nil
+}
+
+// wireChainVertices mints the chain's junction vertices (one per seg start,
+// plus the open end).
+func wireChainVertices(bld *topo.Builder, segs []wireSeg, pl wirePlane, closed bool) []*topo.Vertex {
+	var verts []*topo.Vertex
+	for i := range segs {
+		verts = append(verts, bld.AddVertex(pl.to3(segs[i].a), topo.NewLineage(topo.Tok("wireOffset", "vertex", i))))
+	}
+	if !closed {
+		last := &segs[len(segs)-1]
+		verts = append(verts, bld.AddVertex(pl.to3(last.b), topo.NewLineage(topo.Tok("wireOffset", "vertex", len(segs)))))
+	}
+	return verts
+}
+
+// segCurve3 lifts one 2D seg to its 3D curve.
+func segCurve3(s *wireSeg, pl wirePlane) (geom.Curve3, error) {
+	switch s.kind {
+	case wsArc:
+		return geom.NewArc3d(pl.to3(s.center), pl.n, pl.u, s.r, s.a0, s.sweep)
+	case wsPoly:
+		pts := make([]math.Point3, len(s.poly))
+		for i, p := range s.poly {
+			pts[i] = pl.to3(p)
+		}
+		return geom.NewPolyline(pts)
+	default:
+		return geom.NewLineSegment(pl.to3(s.a), pl.to3(s.b)), nil
+	}
+}

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -13,6 +13,7 @@ import (
 type Body struct {
 	id      uint64
 	shells  []*Shell
+	wires   []*Wire
 	solid   bool
 	lineage Lineage
 }

--- a/kernel/topo/builder.go
+++ b/kernel/topo/builder.go
@@ -90,5 +90,11 @@ func (bld *Builder) buildLoop(f *Face, spec LoopSpec) *Loop {
 	return loop
 }
 
-// Build returns the assembled body.
-func (bld *Builder) Build() *Body { return bld.body }
+// Build returns the assembled body, with its shells regrouped to true face
+// connectivity (M07-F06, #629) — a builder receives faces in arbitrary order,
+// so the single working shell may actually hold several disjoint groups (a
+// stitched pair of quilts, a cavity cut's inner skin).
+func (bld *Builder) Build() *Body {
+	RegroupShells(bld.body)
+	return bld.body
+}

--- a/kernel/topo/lineage.go
+++ b/kernel/topo/lineage.go
@@ -36,6 +36,8 @@ func (k EntityKind) String() string {
 		return "shell"
 	case KindBody:
 		return "body"
+	case KindWire:
+		return "wire"
 	default:
 		return "unknown"
 	}

--- a/kernel/topo/shell.go
+++ b/kernel/topo/shell.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import "oblikovati.org/math"
+
+// Shell queries and connectivity regrouping (M07-F06,
+// Oblikovati/Oblikovati#629): the FaceShell API object needs shells that mean
+// something — one per edge-connected face group — plus edges, range boxes and
+// stable reference keys.
+
+// Edges returns the shell's distinct edges (via its faces' loops).
+func (s *Shell) Edges() []*Edge {
+	seen := map[*Edge]bool{}
+	var out []*Edge
+	for _, f := range s.faces {
+		for _, e := range f.Edges() {
+			if !seen[e] {
+				seen[e] = true
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+// Index returns the shell's position among its body's shells (-1 if detached).
+func (s *Shell) Index() int {
+	for i, sh := range s.body.shells {
+		if sh == s {
+			return i
+		}
+	}
+	return -1
+}
+
+// Lineage derives the shell's lineage from its body's, extended by the shell
+// ordinal. Shells are connectivity groups, not modeled entities — they have no
+// generative path of their own, so the body's path plus a stable position is
+// the identity that survives a recompute (the regrouping walks faces in body
+// face order, which recompute reproduces).
+func (s *Shell) Lineage() Lineage {
+	return NewLineage(append(s.body.lineage.Tokens(), Tok("shell", "shell", s.Index()))...)
+}
+
+// ReferenceKey returns the shell's persistent reference key (M03 scheme).
+func (s *Shell) ReferenceKey() []byte {
+	return referenceKey(KindShell, s.Lineage())
+}
+
+// RangeBox returns the union of the shell's face range boxes.
+func (s *Shell) RangeBox() math.Box {
+	box := math.EmptyBox()
+	for _, f := range s.faces {
+		box = box.Union(f.RangeBox())
+	}
+	return box
+}
+
+// RegroupShells re-partitions a body's faces into true connectivity shells:
+// faces sharing an edge belong to one shell, and a shell is closed when every
+// edge it touches is used at least twice within the group. Builder.Build runs
+// this so a body's shells always reflect actual face connectivity (a stitched
+// pair of disjoint quilts is two shells, a cavity cut is the outer skin plus
+// the void skin).
+func RegroupShells(b *Body) {
+	faces := b.Faces()
+	if len(faces) == 0 {
+		return
+	}
+	groups := connectedFaceGroups(faces)
+	b.shells = make([]*Shell, len(groups))
+	for i, g := range groups {
+		sh := &Shell{id: nextID(), body: b, faces: g, closed: groupClosed(g)}
+		for _, f := range g {
+			f.shell = sh
+		}
+		b.shells[i] = sh
+	}
+}
+
+// connectedFaceGroups partitions faces into edge-connected groups, preserving
+// body face order within and across groups (stable shell identity).
+func connectedFaceGroups(faces []*Face) [][]*Face {
+	parent := make([]int, len(faces))
+	for i := range parent {
+		parent[i] = i
+	}
+	byEdge := map[*Edge]int{}
+	for i, f := range faces {
+		for _, e := range f.Edges() {
+			if first, ok := byEdge[e]; ok {
+				union(parent, first, i)
+			} else {
+				byEdge[e] = i
+			}
+		}
+	}
+	return groupByRoot(faces, parent)
+}
+
+// groupByRoot buckets faces by their union-find root, ordered by first member.
+func groupByRoot(faces []*Face, parent []int) [][]*Face {
+	order := []int{}
+	members := map[int][]*Face{}
+	for i, f := range faces {
+		r := find(parent, i)
+		if _, ok := members[r]; !ok {
+			order = append(order, r)
+		}
+		members[r] = append(members[r], f)
+	}
+	out := make([][]*Face, len(order))
+	for i, r := range order {
+		out[i] = members[r]
+	}
+	return out
+}
+
+// groupClosed reports whether every edge of the group is used at least twice by
+// the group's faces (no boundary edge → the shell bounds a region).
+func groupClosed(faces []*Face) bool {
+	uses := map[*Edge]int{}
+	for _, f := range faces {
+		for _, l := range f.Loops() {
+			for _, u := range l.EdgeUses() {
+				uses[u.Edge()]++
+			}
+		}
+	}
+	for _, n := range uses {
+		if n < 2 {
+			return false
+		}
+	}
+	return len(uses) > 0
+}
+
+// union and find are the package's shared union-find primitives.
+func union(parent []int, i, j int) {
+	ri, rj := find(parent, i), find(parent, j)
+	if ri != rj {
+		parent[rj] = ri
+	}
+}
+
+func find(parent []int, i int) int {
+	for parent[i] != i {
+		parent[i] = parent[parent[i]]
+		i = parent[i]
+	}
+	return i
+}

--- a/kernel/topo/shell.go
+++ b/kernel/topo/shell.go
@@ -133,7 +133,12 @@ func groupClosed(faces []*Face) bool {
 			return false
 		}
 	}
-	return len(uses) > 0
+	if len(uses) == 0 {
+		// No edges at all: a boundary-less face is a closed surface (a whole
+		// sphere or torus carried as one loop-less face) — closed by definition.
+		return len(faces) > 0
+	}
+	return true
 }
 
 // union and find are the package's shared union-find primitives.

--- a/kernel/topo/transient_key.go
+++ b/kernel/topo/transient_key.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+// Transient keys (M07-F07, Oblikovati/Oblikovati#630): every topology entity's
+// session id doubles as its transient key — stable within the session, NOT
+// persisted (reference keys are the persistent identity). BindTransientKey
+// resolves a key back to the entity, the reference
+// SurfaceBody.BindTransientKeyToObject.
+
+// TransientRef is the tagged result of a transient-key lookup: Kind says which
+// pointer is set.
+type TransientRef struct {
+	Kind   EntityKind
+	Vertex *Vertex
+	Edge   *Edge
+	Face   *Face
+	Shell  *Shell
+	Wire   *Wire
+}
+
+// BindTransientKey finds the entity with the given session id anywhere in the
+// body (vertices, edges, faces, shells, wires, the body itself is excluded —
+// the caller already holds it).
+//
+// Example: ref, ok := body.BindTransientKey(faceID)
+func (b *Body) BindTransientKey(key uint64) (TransientRef, bool) {
+	for _, f := range b.Faces() {
+		if f.ID() == key {
+			return TransientRef{Kind: KindFace, Face: f}, true
+		}
+	}
+	for _, e := range b.Edges() {
+		if e.ID() == key {
+			return TransientRef{Kind: KindEdge, Edge: e}, true
+		}
+	}
+	for _, v := range b.Vertices() {
+		if v.ID() == key {
+			return TransientRef{Kind: KindVertex, Vertex: v}, true
+		}
+	}
+	return b.bindStructural(key)
+}
+
+// bindStructural covers shells and wires.
+func (b *Body) bindStructural(key uint64) (TransientRef, bool) {
+	for _, s := range b.shells {
+		if s.ID() == key {
+			return TransientRef{Kind: KindShell, Shell: s}, true
+		}
+	}
+	for _, w := range b.wires {
+		if w.ID() == key {
+			return TransientRef{Kind: KindWire, Wire: w}, true
+		}
+	}
+	return TransientRef{}, false
+}

--- a/kernel/topo/wire.go
+++ b/kernel/topo/wire.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Wire topology (M07-F06, Oblikovati/Oblikovati#629): an ordered chain of
+// edges a body carries WITHOUT faces — the section/profile currency of ruled
+// surfaces, silhouette results and plane sections. Wires reuse [Use] for
+// orientation (a wire edge has no loop, so [EdgeUse] does not apply).
+
+// Wire is an ordered, oriented chain of edges owned by a body.
+type Wire struct {
+	id      uint64
+	body    *Body
+	uses    []Use
+	lineage Lineage
+}
+
+// KindWire continues the EntityKind block (values are persisted — never renumber).
+const KindWire EntityKind = 7
+
+func (w *Wire) ID() uint64       { return w.id }
+func (w *Wire) Kind() EntityKind { return KindWire }
+func (w *Wire) Body() *Body      { return w.body }
+func (w *Wire) Lineage() Lineage { return w.lineage }
+
+// ReferenceKey returns the wire's persistent reference key (M03 scheme).
+func (w *Wire) ReferenceKey() []byte { return referenceKey(KindWire, w.lineage) }
+
+// Uses returns the ordered, oriented edge uses of the chain.
+func (w *Wire) Uses() []Use { return append([]Use(nil), w.uses...) }
+
+// Edges returns the chain's edges in traversal order.
+func (w *Wire) Edges() []*Edge {
+	out := make([]*Edge, len(w.uses))
+	for i, u := range w.uses {
+		out[i] = u.Edge
+	}
+	return out
+}
+
+// IsClosed reports whether the chain returns to its start point.
+func (w *Wire) IsClosed() bool {
+	if len(w.uses) == 0 {
+		return false
+	}
+	first, _ := useEnds(w.uses[0])
+	_, last := useEnds(w.uses[len(w.uses)-1])
+	return first.Point().IsEqualTo(last.Point(), wirePlanarTol)
+}
+
+// useEnds returns a use's traversal start and end vertices.
+func useEnds(u Use) (*Vertex, *Vertex) {
+	if u.Reversed {
+		return u.Edge.EndVertex(), u.Edge.StartVertex()
+	}
+	return u.Edge.StartVertex(), u.Edge.EndVertex()
+}
+
+// wirePlanarTol is the deviation under which a wire counts as planar (and a
+// chain as closed) — model units (cm).
+const wirePlanarTol = 1e-7
+
+// wireSamplesPerEdge is how densely IsPlanar/PlaneFrame sample each curve.
+const wireSamplesPerEdge = 16
+
+// IsPlanar reports whether every edge curve lies in one plane. A collinear
+// chain (no unique plane) counts as planar — it lies in infinitely many.
+func (w *Wire) IsPlanar() bool {
+	if _, _, ok := w.PlaneFrame(); ok {
+		return true
+	}
+	return w.collinear()
+}
+
+// PlaneFrame returns the wire's UNIQUE plane (origin, unit normal) when the
+// sampled chain is planar within tolerance — the frame OffsetPlanarWire works
+// in. A collinear chain reports false (no unique plane; pass the normal
+// explicitly to the offset instead).
+func (w *Wire) PlaneFrame() (math.Point3, math.Vector3, bool) {
+	pts := w.samplePoints()
+	if len(pts) < 3 {
+		return math.Point3{}, math.Vector3{}, false
+	}
+	origin, normal, ok := newellPlane(pts)
+	if !ok {
+		return math.Point3{}, math.Vector3{}, false
+	}
+	for _, p := range pts {
+		if stdmath.Abs(float64(origin.VectorTo(p).Dot(normal))) > wirePlanarTol {
+			return math.Point3{}, math.Vector3{}, false
+		}
+	}
+	return origin, normal, true
+}
+
+// collinear reports whether every sampled point lies on one line. The line
+// direction comes from the FARTHEST sample (a closed chain ends where it
+// starts, so first→last would degenerate to zero).
+func (w *Wire) collinear() bool {
+	pts := w.samplePoints()
+	if len(pts) < 2 {
+		return true
+	}
+	dir := farthestDirection(pts)
+	if l := float64(dir.Length()); l == 0 {
+		return true // all samples coincide
+	} else {
+		dir = dir.Scale(math.Scalar(1 / l))
+	}
+	for _, p := range pts {
+		v := pts[0].VectorTo(p)
+		if float64(v.Cross(dir).Length()) > wirePlanarTol {
+			return false
+		}
+	}
+	return true
+}
+
+// farthestDirection is the vector from the first sample to its farthest peer.
+func farthestDirection(pts []math.Point3) math.Vector3 {
+	best, bestD := math.Vector3{}, math.Scalar(0)
+	for _, p := range pts {
+		if d := pts[0].DistanceSquaredTo(p); d > bestD {
+			best, bestD = pts[0].VectorTo(p), d
+		}
+	}
+	return best
+}
+
+// samplePoints samples each edge curve at wire density.
+func (w *Wire) samplePoints() []math.Point3 {
+	var pts []math.Point3
+	for _, u := range w.uses {
+		c := u.Edge.Geometry()
+		lo, hi := c.Domain()
+		for i := 0; i <= wireSamplesPerEdge; i++ {
+			pts = append(pts, c.PointAt(lo+(hi-lo)*float64(i)/wireSamplesPerEdge))
+		}
+	}
+	return pts
+}
+
+// newellPlane fits a plane through the points (Newell's method: robust normal
+// from the projected-area components, centroid as origin).
+func newellPlane(pts []math.Point3) (math.Point3, math.Vector3, bool) {
+	var n math.Vector3
+	var c math.Vector3
+	for i, p := range pts {
+		q := pts[(i+1)%len(pts)]
+		n.X += (p.Y - q.Y) * (p.Z + q.Z)
+		n.Y += (p.Z - q.Z) * (p.X + q.X)
+		n.Z += (p.X - q.X) * (p.Y + q.Y)
+		c = c.Add(p.AsVector())
+	}
+	l := float64(n.Length())
+	if l == 0 || l < 1e-12*spreadSquared(pts) {
+		// Vanishing projected area RELATIVE to the chain's size: the closed
+		// walk encloses nothing. A straight open chain lands here (collinear
+		// handles it); so does a degenerate back-and-forth chain — neither has
+		// a unique plane. The relative test keeps tiny-but-planar wires valid.
+		return math.Point3{}, math.Vector3{}, false
+	}
+	origin := c.Scale(math.Scalar(1 / float64(len(pts)))).AsPoint()
+	return origin, n.Scale(math.Scalar(1 / l)), true
+}
+
+// spreadSquared is the squared extent of the points about their first — the
+// size reference for the relative degenerate-area test.
+func spreadSquared(pts []math.Point3) float64 {
+	best := 0.0
+	for _, p := range pts {
+		if d := float64(pts[0].DistanceSquaredTo(p)); d > best {
+			best = d
+		}
+	}
+	return best
+}
+
+// AttachWire appends an ordered edge chain to the body's wires. The uses' edges
+// belong to the wire only (no faces); consecutive uses must chain end-to-start.
+func (b *Body) AttachWire(lineage Lineage, uses []Use) *Wire {
+	w := &Wire{id: nextID(), body: b, uses: append([]Use(nil), uses...), lineage: lineage}
+	b.wires = append(b.wires, w)
+	return w
+}
+
+// Wires returns the body's wires.
+func (b *Body) Wires() []*Wire { return append([]*Wire(nil), b.wires...) }

--- a/model/bodyapi/definition.go
+++ b/model/bodyapi/definition.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package bodyapi
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Decoding the wire definition graph (types.BrepBodyDefinition) into the
+// kernel's brep.SurfaceBodyDefinition: tagged analytic curve/surface
+// definitions become geom values; geometric problems are reported by graph
+// path like the compiler's own issues.
+
+// DecodeBodyDefinition maps the contract graph onto the kernel graph. A
+// non-empty issue list rejects the graph (no kernel definition is returned).
+func DecodeBodyDefinition(def types.BrepBodyDefinition) (brep.SurfaceBodyDefinition, []types.BrepDefinitionIssue) {
+	var out brep.SurfaceBodyDefinition
+	var issues []types.BrepDefinitionIssue
+	out.Solid = def.Solid
+	issues = decodeVertices(&out, def, issues)
+	issues = decodeEdges(&out, def, issues)
+	issues = decodeFaces(&out, def, issues)
+	decodeLumps(&out, def)
+	if len(issues) > 0 {
+		return brep.SurfaceBodyDefinition{}, issues
+	}
+	return out, nil
+}
+
+func decodeVertices(out *brep.SurfaceBodyDefinition, def types.BrepBodyDefinition, issues []types.BrepDefinitionIssue) []types.BrepDefinitionIssue {
+	for i, v := range def.Vertices {
+		p, ok := triplet(v.Position)
+		if !ok {
+			issues = append(issues, defIssue("vertices", i, "position needs [x, y, z], got %v", v.Position))
+			continue
+		}
+		out.Vertices = append(out.Vertices, brep.VertexDefinition{Position: p, AssociativeID: v.AssociativeID})
+	}
+	return issues
+}
+
+func decodeEdges(out *brep.SurfaceBodyDefinition, def types.BrepBodyDefinition, issues []types.BrepDefinitionIssue) []types.BrepDefinitionIssue {
+	for i, e := range def.Edges {
+		curve, err := decodeCurve(e.Curve)
+		if err != nil {
+			issues = append(issues, defIssue("edges", i, "%v", err))
+			continue
+		}
+		out.Edges = append(out.Edges, brep.EdgeDefinition{
+			Curve: curve, StartVertex: e.StartVertex, EndVertex: e.EndVertex, AssociativeID: e.AssociativeID,
+		})
+	}
+	return issues
+}
+
+func decodeFaces(out *brep.SurfaceBodyDefinition, def types.BrepBodyDefinition, issues []types.BrepDefinitionIssue) []types.BrepDefinitionIssue {
+	for i, f := range def.Faces {
+		surf, err := decodeSurface(f.Surface)
+		if err != nil {
+			issues = append(issues, defIssue("faces", i, "%v", err))
+			continue
+		}
+		kf := brep.FaceDefinition{Surface: surf, ParamReversed: f.ParamReversed, AssociativeID: f.AssociativeID}
+		for _, l := range f.Loops {
+			kl := brep.EdgeLoopDefinition{}
+			for _, u := range l.Uses {
+				kl.Uses = append(kl.Uses, brep.EdgeUseDefinition{Edge: u.Edge, Opposed: u.Opposed})
+			}
+			kf.Loops = append(kf.Loops, kl)
+		}
+		out.Faces = append(out.Faces, kf)
+	}
+	return issues
+}
+
+func decodeLumps(out *brep.SurfaceBodyDefinition, def types.BrepBodyDefinition) {
+	for _, lump := range def.Lumps {
+		kl := brep.LumpDefinition{}
+		for _, sh := range lump.Shells {
+			kl.Shells = append(kl.Shells, brep.FaceShellDefinition{Faces: sh.Faces})
+		}
+		for _, w := range lump.Wires {
+			kl.Wires = append(kl.Wires, brep.WireDefinition{Edges: w.Edges})
+		}
+		out.Lumps = append(out.Lumps, kl)
+	}
+}
+
+// decodeCurve builds the kernel curve from a tagged definition.
+func decodeCurve(c types.BrepCurveDef) (geom.Curve3, error) {
+	switch c.Kind {
+	case "lineSegment":
+		pts, ok := triplets(c.Points, 2)
+		if !ok {
+			return nil, fmt.Errorf("lineSegment needs 2 points (6 floats), got %d floats", len(c.Points))
+		}
+		return geom.NewLineSegment(pts[0], pts[1]), nil
+	case "arc":
+		return decodeArc(c)
+	case "polyline":
+		pts, ok := triplets(c.Points, -1)
+		if !ok || len(pts) < 2 {
+			return nil, fmt.Errorf("polyline needs 2+ xyz triplets, got %d floats", len(c.Points))
+		}
+		return geom.NewPolyline(pts)
+	default:
+		return nil, fmt.Errorf("unknown curve kind %q (want lineSegment, arc or polyline)", c.Kind)
+	}
+}
+
+func decodeArc(c types.BrepCurveDef) (geom.Curve3, error) {
+	center, okC := triplet(c.Center)
+	normal, okN := tripletV(c.Normal)
+	refDir, okR := tripletV(c.RefDir)
+	if !okC || !okN || !okR {
+		return nil, fmt.Errorf("arc needs center, normal and refDir as [x, y, z]")
+	}
+	return geom.NewArc3d(center, normal, refDir, c.Radius, c.StartAngle, c.SweepAngle)
+}
+
+// decodeSurface builds the kernel surface from a tagged definition.
+func decodeSurface(s types.BrepSurfaceDef) (geom.Surface, error) {
+	switch s.Kind {
+	case "plane":
+		return decodePlane(s)
+	case "cylinder":
+		return decodeAxial(s, func(o math.Point3, a math.Vector3) (geom.Surface, error) {
+			return geom.NewCylinder(o, a, s.Radius)
+		})
+	case "cone":
+		return decodeAxial(s, func(o math.Point3, a math.Vector3) (geom.Surface, error) {
+			return geom.NewCone(o, a, s.HalfAngle)
+		})
+	case "sphere":
+		o, ok := triplet(s.Origin)
+		if !ok {
+			return nil, fmt.Errorf("sphere needs origin as [x, y, z]")
+		}
+		return geom.NewSphere(o, s.Radius)
+	case "torus":
+		return decodeAxial(s, func(o math.Point3, a math.Vector3) (geom.Surface, error) {
+			return geom.NewTorus(o, a, s.MajorRadius, s.MinorRadius)
+		})
+	default:
+		return nil, fmt.Errorf("unknown surface kind %q (want plane, cylinder, cone, sphere or torus)", s.Kind)
+	}
+}
+
+func decodePlane(s types.BrepSurfaceDef) (geom.Surface, error) {
+	o, okO := triplet(s.Origin)
+	n, okN := tripletV(s.Normal)
+	if !okO || !okN {
+		return nil, fmt.Errorf("plane needs origin and normal as [x, y, z]")
+	}
+	return geom.NewPlane(o, n)
+}
+
+func decodeAxial(s types.BrepSurfaceDef, build func(math.Point3, math.Vector3) (geom.Surface, error)) (geom.Surface, error) {
+	o, okO := triplet(s.Origin)
+	a, okA := tripletV(s.Axis)
+	if !okO || !okA {
+		return nil, fmt.Errorf("%s needs origin and axis as [x, y, z]", s.Kind)
+	}
+	return build(o, a)
+}
+
+// definitionIssues maps kernel compiler issues onto the contract form.
+func definitionIssues(in []brep.DefinitionIssue) []types.BrepDefinitionIssue {
+	out := make([]types.BrepDefinitionIssue, len(in))
+	for i, di := range in {
+		out[i] = types.BrepDefinitionIssue{Path: di.Path, Problem: di.Problem}
+	}
+	return out
+}
+
+func defIssue(section string, index int, format string, args ...interface{}) types.BrepDefinitionIssue {
+	return types.BrepDefinitionIssue{
+		Path:    fmt.Sprintf("%s[%d]", section, index),
+		Problem: fmt.Sprintf(format, args...),
+	}
+}
+
+// triplet decodes one [x, y, z] point; tripletV one vector.
+func triplet(v []float64) (math.Point3, bool) {
+	if len(v) != 3 {
+		return math.Point3{}, false
+	}
+	return math.P3(math.Scalar(v[0]), math.Scalar(v[1]), math.Scalar(v[2])), true
+}
+
+func tripletV(v []float64) (math.Vector3, bool) {
+	if len(v) != 3 {
+		return math.Vector3{}, false
+	}
+	return math.V3(math.Scalar(v[0]), math.Scalar(v[1]), math.Scalar(v[2])), true
+}
+
+// triplets decodes a flattened xyz list; want -1 accepts any count.
+func triplets(v []float64, want int) ([]math.Point3, bool) {
+	if len(v)%3 != 0 {
+		return nil, false
+	}
+	n := len(v) / 3
+	if want >= 0 && n != want {
+		return nil, false
+	}
+	out := make([]math.Point3, n)
+	for i := 0; i < n; i++ {
+		out[i] = math.P3(math.Scalar(v[3*i]), math.Scalar(v[3*i+1]), math.Scalar(v[3*i+2]))
+	}
+	return out, true
+}

--- a/model/bodyapi/queries.go
+++ b/model/bodyapi/queries.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package bodyapi
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+var _ contract.BodyQueries = (*BodyQueriesAdapter)(nil)
+
+// BodyQueriesAdapter exposes one body's query surface (M07-F07, #630).
+type BodyQueriesAdapter struct {
+	body *topo.Body
+	q    ops.Quality
+}
+
+// NewBodyQueries wraps a body at the given quality.
+func NewBodyQueries(b *topo.Body, q ops.Quality) *BodyQueriesAdapter {
+	return &BodyQueriesAdapter{body: b, q: q}
+}
+
+// IsPointInside classifies a point against the body's material.
+func (a *BodyQueriesAdapter) IsPointInside(x, y, z float64) types.Containment {
+	c := ops.BodyContainment(a.body, math.P3(math.Scalar(x), math.Scalar(y), math.Scalar(z)), a.q, onTolDefault)
+	return containmentOf(c)
+}
+
+// ConvexEdgeCount and ConcaveEdgeCount report the dihedral classification.
+func (a *BodyQueriesAdapter) ConvexEdgeCount() int {
+	return len(ops.BodyEdgeConvexity(a.body)[ops.EdgeConvex])
+}
+
+func (a *BodyQueriesAdapter) ConcaveEdgeCount() int {
+	return len(ops.BodyEdgeConvexity(a.body)[ops.EdgeConcave])
+}
+
+// IsEntityValid checks the body at the given level (1 topology, 2 + the
+// self-intersection scan).
+func (a *BodyQueriesAdapter) IsEntityValid(checkLevel int) bool {
+	ok, _ := ops.ValidateBodyEntities(a.body, entityCheckLevel(checkLevel), a.q)
+	return ok
+}
+
+// entityCheckLevel maps the wire integer onto the kernel level (0 → topology).
+func entityCheckLevel(level int) ops.EntityCheckLevel {
+	if level >= int(ops.CheckGeometry) {
+		return ops.CheckGeometry
+	}
+	return ops.CheckTopology
+}
+
+// BindTransientKey resolves a session id to its entity kind and persistent key.
+func (a *BodyQueriesAdapter) BindTransientKey(key uint64) (string, []byte, bool) {
+	ref, ok := a.body.BindTransientKey(key)
+	if !ok {
+		return "", nil, false
+	}
+	return ref.Kind.String(), transientRefKey(ref), true
+}
+
+// transientRefKey returns the bound entity's persistent reference key.
+func transientRefKey(ref topo.TransientRef) []byte {
+	switch ref.Kind {
+	case topo.KindVertex:
+		return ref.Vertex.ReferenceKey()
+	case topo.KindEdge:
+		return ref.Edge.ReferenceKey()
+	case topo.KindFace:
+		return ref.Face.ReferenceKey()
+	case topo.KindShell:
+		return ref.Shell.ReferenceKey()
+	default:
+		return ref.Wire.ReferenceKey()
+	}
+}

--- a/model/bodyapi/shells.go
+++ b/model/bodyapi/shells.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package bodyapi adapts kernel topology onto the api/contract body surface
+// (M07-F05/F06/F07, Oblikovati/Oblikovati#628/#629/#630): face shells, wires,
+// body queries and the transient B-rep factory.
+package bodyapi
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Compile-time contract assertions (ADR-0018).
+var (
+	_ contract.FaceShell  = (*FaceShellAdapter)(nil)
+	_ contract.FaceShells = (*FaceShellsAdapter)(nil)
+	_ contract.Wire       = (*WireAdapter)(nil)
+	_ contract.Wires      = (*WiresAdapter)(nil)
+)
+
+// onTolDefault is the boundary band of point containment when callers pass 0.
+const onTolDefault = 1e-6
+
+// FaceShellAdapter exposes one kernel shell as a contract FaceShell.
+type FaceShellAdapter struct {
+	shell *topo.Shell
+	q     ops.Quality
+}
+
+// NewFaceShell wraps a kernel shell at the given quality.
+func NewFaceShell(s *topo.Shell, q ops.Quality) *FaceShellAdapter {
+	return &FaceShellAdapter{shell: s, q: q}
+}
+
+func (a *FaceShellAdapter) IsClosed() bool { return a.shell.IsClosed() }
+func (a *FaceShellAdapter) IsVoid() bool   { return ops.ShellIsVoid(a.shell, a.q) }
+
+// Volume is the magnitude of the shell region's volume (the API reports
+// sizes; the sign — void vs material — is IsVoid's job).
+func (a *FaceShellAdapter) Volume() float64 {
+	v := ops.ShellSignedVolume(a.shell, a.q)
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func (a *FaceShellAdapter) FaceCount() int { return len(a.shell.Faces()) }
+func (a *FaceShellAdapter) EdgeCount() int { return len(a.shell.Edges()) }
+
+// IsPointInside classifies a point against the shell's bounded region.
+func (a *FaceShellAdapter) IsPointInside(x, y, z float64) types.Containment {
+	c := ops.ShellContainment(a.shell, math.P3(math.Scalar(x), math.Scalar(y), math.Scalar(z)), a.q, onTolDefault)
+	return containmentOf(c)
+}
+
+func (a *FaceShellAdapter) ReferenceKey() []byte { return a.shell.ReferenceKey() }
+func (a *FaceShellAdapter) TransientKey() uint64 { return a.shell.ID() }
+
+// containmentOf maps the kernel verdict onto the frozen wire enum.
+func containmentOf(c ops.PointContainment) types.Containment {
+	switch c {
+	case ops.ContainInside:
+		return types.InsideContainment
+	case ops.ContainOn:
+		return types.OnContainment
+	default:
+		return types.OutsideContainment
+	}
+}
+
+// FaceShellsAdapter enumerates a body's shells.
+type FaceShellsAdapter struct {
+	body *topo.Body
+	q    ops.Quality
+}
+
+// NewFaceShells wraps a body's shell collection.
+func NewFaceShells(b *topo.Body, q ops.Quality) *FaceShellsAdapter {
+	return &FaceShellsAdapter{body: b, q: q}
+}
+
+func (a *FaceShellsAdapter) Count() int { return len(a.body.Shells()) }
+
+func (a *FaceShellsAdapter) Item(index int) contract.FaceShell {
+	return NewFaceShell(a.body.Shells()[index], a.q)
+}
+
+// WireAdapter exposes one kernel wire as a contract Wire.
+type WireAdapter struct{ wire *topo.Wire }
+
+// NewWire wraps a kernel wire.
+func NewWire(w *topo.Wire) *WireAdapter { return &WireAdapter{wire: w} }
+
+func (a *WireAdapter) IsClosed() bool       { return a.wire.IsClosed() }
+func (a *WireAdapter) IsPlanar() bool       { return a.wire.IsPlanar() }
+func (a *WireAdapter) EdgeCount() int       { return len(a.wire.Edges()) }
+func (a *WireAdapter) ReferenceKey() []byte { return a.wire.ReferenceKey() }
+func (a *WireAdapter) TransientKey() uint64 { return a.wire.ID() }
+
+// WiresAdapter enumerates a body's wires.
+type WiresAdapter struct{ body *topo.Body }
+
+// NewWires wraps a body's wire collection.
+func NewWires(b *topo.Body) *WiresAdapter { return &WiresAdapter{body: b} }
+
+func (a *WiresAdapter) Count() int { return len(a.body.Wires()) }
+
+func (a *WiresAdapter) Item(index int) contract.Wire {
+	return NewWire(a.body.Wires()[index])
+}

--- a/model/bodyapi/transient.go
+++ b/model/bodyapi/transient.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package bodyapi
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+var (
+	_ contract.TransientBRep = (*TransientBRep)(nil)
+	_ contract.TransientBody = (*TransientBody)(nil)
+)
+
+// TransientBody is one ownerless body in the session registry.
+type TransientBody struct {
+	handle int
+	body   *topo.Body
+	q      ops.Quality
+}
+
+// Handle returns the session handle; Topo the kernel body.
+func (t *TransientBody) Handle() int      { return t.handle }
+func (t *TransientBody) Topo() *topo.Body { return t.body }
+
+func (t *TransientBody) IsSolid() bool    { return t.body.IsSolid() }
+func (t *TransientBody) FaceCount() int   { return len(t.body.Faces()) }
+func (t *TransientBody) EdgeCount() int   { return len(t.body.Edges()) }
+func (t *TransientBody) VertexCount() int { return len(t.body.Vertices()) }
+func (t *TransientBody) ShellCount() int  { return len(t.body.Shells()) }
+func (t *TransientBody) WireCount() int   { return len(t.body.Wires()) }
+
+// Volume is the enclosed volume in cm³ (0 for an open surface body).
+func (t *TransientBody) Volume() float64 {
+	if !t.body.IsSolid() {
+		return 0
+	}
+	return ops.BodyGeometryProperties(t.body, t.q).Volume
+}
+
+// TransientBRep is the session's transient body factory and registry
+// (M07-F05, #628). Handles are positive and never reused within a session.
+type TransientBRep struct {
+	next   int
+	bodies map[int]*TransientBody
+	q      ops.Quality
+}
+
+// NewTransientBRep returns an empty registry at the given quality.
+//
+// Example: tb := bodyapi.NewTransientBRep(ops.DefaultQuality())
+func NewTransientBRep(q ops.Quality) *TransientBRep {
+	return &TransientBRep{next: 1, bodies: map[int]*TransientBody{}, q: q}
+}
+
+// register adopts a kernel body under a fresh handle.
+func (t *TransientBRep) register(b *topo.Body) *TransientBody {
+	tb := &TransientBody{handle: t.next, body: b, q: t.q}
+	t.bodies[t.next] = tb
+	t.next++
+	return tb
+}
+
+// Adopt registers an externally built kernel body (the wire layer's copies of
+// document bodies, offset results, sections).
+func (t *TransientBRep) Adopt(b *topo.Body) *TransientBody { return t.register(b) }
+
+// ByHandle resolves a handle.
+func (t *TransientBRep) ByHandle(h int) (*TransientBody, bool) {
+	tb, ok := t.bodies[h]
+	return tb, ok
+}
+
+// Handles lists the live handles, ascending.
+func (t *TransientBRep) Handles() []int {
+	out := make([]int, 0, len(t.bodies))
+	for h := 1; h < t.next; h++ {
+		if _, ok := t.bodies[h]; ok {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// Delete frees a handle; reports whether it existed.
+func (t *TransientBRep) Delete(h int) bool {
+	_, ok := t.bodies[h]
+	delete(t.bodies, h)
+	return ok
+}
+
+// Replace swaps a handle's body in place (the DoBoolean blank semantics).
+func (t *TransientBRep) Replace(h int, b *topo.Body) error {
+	tb, ok := t.bodies[h]
+	if !ok {
+		return fmt.Errorf("bodyapi: no transient body with handle %d", h)
+	}
+	tb.body = b
+	return nil
+}
+
+// CreateSolidBlock builds the box between two opposite corners.
+func (t *TransientBRep) CreateSolidBlock(min, max types.Point) (contract.TransientBody, error) {
+	b, err := brep.SolidBlock(p3(min), p3(max), "transient")
+	if err != nil {
+		return nil, err
+	}
+	return t.register(b), nil
+}
+
+// CreateSolidCylinderCone builds a cylinder/cone between two section centers.
+func (t *TransientBRep) CreateSolidCylinderCone(bottom, top types.Point, bottomRadius, topRadius float64) (contract.TransientBody, error) {
+	b, err := brep.SolidCylinderCone(p3(bottom), p3(top), bottomRadius, topRadius, "transient")
+	if err != nil {
+		return nil, err
+	}
+	return t.register(b), nil
+}
+
+// CreateSolidSphere builds a full sphere.
+func (t *TransientBRep) CreateSolidSphere(center types.Point, radius float64) (contract.TransientBody, error) {
+	b, err := brep.SolidSphere(p3(center), radius, "transient")
+	if err != nil {
+		return nil, err
+	}
+	return t.register(b), nil
+}
+
+// CreateSolidTorus builds a full torus about the axis.
+func (t *TransientBRep) CreateSolidTorus(center types.Point, axis types.Vector, majorRadius, minorRadius float64) (contract.TransientBody, error) {
+	b, err := brep.SolidTorus(p3(center), v3(axis), majorRadius, minorRadius, "transient")
+	if err != nil {
+		return nil, err
+	}
+	return t.register(b), nil
+}
+
+// Copy clones a body into a new handle (lineage derived so keys stay distinct).
+func (t *TransientBRep) Copy(body contract.TransientBody) (contract.TransientBody, error) {
+	src, err := t.topoOf(body)
+	if err != nil {
+		return nil, err
+	}
+	clone, err := CopyTopoBody(src, t.next)
+	if err != nil {
+		return nil, err
+	}
+	return t.register(clone), nil
+}
+
+// CopyTopoBody clones any kernel body with copy-distinct reference keys.
+func CopyTopoBody(src *topo.Body, copyIndex int) (*topo.Body, error) {
+	derive := func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append(l.Tokens(), topo.Tok("transient", "copy", copyIndex))...)
+	}
+	return ops.TransformBody(src, math.Identity4(), derive)
+}
+
+// Transform maps the body in place by a similarity matrix; scale/shear that
+// would break an analytic surface is rejected with the matrix in the error.
+func (t *TransientBRep) Transform(body contract.TransientBody, m types.Matrix) error {
+	tb, ok := body.(*TransientBody)
+	if !ok {
+		return fmt.Errorf("bodyapi: Transform needs a registry body, got %T", body)
+	}
+	moved, err := ops.TransformBody(tb.body, matrix4(m), func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		return err
+	}
+	tb.body = moved
+	return nil
+}
+
+// DoBoolean combines blank (modified in place) with tool.
+func (t *TransientBRep) DoBoolean(blank, tool contract.TransientBody, op types.BooleanType) error {
+	bb, ok := blank.(*TransientBody)
+	if !ok {
+		return fmt.Errorf("bodyapi: DoBoolean blank must be a registry body, got %T", blank)
+	}
+	toolBody, err := t.topoOf(tool)
+	if err != nil {
+		return err
+	}
+	res, err := ops.Boolean(booleanOp(op), bb.body, toolBody)
+	if err != nil {
+		return err
+	}
+	bb.body = res
+	return nil
+}
+
+// booleanOp maps the frozen wire enum onto the kernel operation.
+func booleanOp(op types.BooleanType) ops.PartFeatureOperation {
+	switch op {
+	case types.BooleanUnion:
+		return ops.Join
+	case types.BooleanIntersect:
+		return ops.Intersect
+	default:
+		return ops.Cut
+	}
+}
+
+// CreateIntersectionWithPlane sections a body; the curves come back as wires
+// on a new transient body.
+func (t *TransientBRep) CreateIntersectionWithPlane(body contract.TransientBody, planeOrigin types.Point, planeNormal types.Vector) (contract.TransientBody, error) {
+	src, err := t.topoOf(body)
+	if err != nil {
+		return nil, err
+	}
+	sec, err := ops.SectionWithPlane(src, p3(planeOrigin), v3(planeNormal), t.q)
+	if err != nil {
+		return nil, err
+	}
+	return t.register(sec), nil
+}
+
+// CreateFromDefinition compiles a bottom-up graph; issues reject the graph.
+func (t *TransientBRep) CreateFromDefinition(def types.BrepBodyDefinition) (contract.TransientBody, []types.BrepDefinitionIssue, error) {
+	kdef, issues := DecodeBodyDefinition(def)
+	if len(issues) > 0 {
+		return nil, issues, nil
+	}
+	body, compileIssues := brep.CompileSurfaceBodyDefinition(kdef, "definition")
+	if len(compileIssues) > 0 {
+		return nil, definitionIssues(compileIssues), nil
+	}
+	return t.register(body), nil, nil
+}
+
+// topoOf unwraps a contract body back to its kernel body.
+func (t *TransientBRep) topoOf(body contract.TransientBody) (*topo.Body, error) {
+	tb, ok := body.(*TransientBody)
+	if !ok {
+		return nil, fmt.Errorf("bodyapi: expected a registry body, got %T", body)
+	}
+	return tb.body, nil
+}
+
+func p3(p types.Point) math.Point3 {
+	return math.P3(math.Scalar(p.X), math.Scalar(p.Y), math.Scalar(p.Z))
+}
+
+func v3(v types.Vector) math.Vector3 {
+	return math.V3(math.Scalar(v.X), math.Scalar(v.Y), math.Scalar(v.Z))
+}
+
+// matrix4 maps the row-major contract matrix onto the kernel matrix (both
+// store 16 row-major cells).
+func matrix4(m types.Matrix) math.Matrix4 {
+	var cells [16]math.Scalar
+	for i, c := range m.Cells {
+		cells[i] = math.Scalar(c)
+	}
+	return math.Matrix4FromCells(cells)
+}

--- a/model/facetstore/facetstore.go
+++ b/model/facetstore/facetstore.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package facetstore caches facet and stroke sets per body and tolerance, so
+// API clients can retrieve a previously calculated set without re-faceting —
+// the reference API's GetExistingFacets / GetExistingStrokes semantics
+// (M07-F03 remainder, Oblikovati/Oblikovati#293).
+//
+// Entries are keyed by *topo.Body identity: a recompute mints new bodies, so
+// stale entries simply stop being reachable. DropBody evicts explicitly when a
+// caller replaces bodies in place.
+package facetstore
+
+import (
+	"sort"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// FacetStore is the per-session facet/stroke cache. Zero value is NOT ready —
+// use NewFacetStore.
+type FacetStore struct {
+	facets  map[*topo.Body]map[float64]*ops.BodyFacets
+	strokes map[*topo.Body]map[float64]*ops.BodyStrokes
+}
+
+// NewFacetStore returns an empty store.
+//
+// Example: st := facetstore.NewFacetStore(); fs := st.CalculateFacets(body, 0.01)
+func NewFacetStore() *FacetStore {
+	return &FacetStore{
+		facets:  map[*topo.Body]map[float64]*ops.BodyFacets{},
+		strokes: map[*topo.Body]map[float64]*ops.BodyStrokes{},
+	}
+}
+
+// quality maps a chordal tolerance onto the kernel quality (angle bound stays
+// the display default so round features keep their minimum segment count).
+func quality(tolerance float64) ops.Quality {
+	return ops.Quality{ChordTolerance: tolerance, AngleTolerance: ops.DefaultQuality().AngleTolerance}
+}
+
+// CalculateFacets facets the body at the tolerance and caches the set under
+// that tolerance; an already-cached set returns without re-faceting.
+func (st *FacetStore) CalculateFacets(b *topo.Body, tolerance float64) *ops.BodyFacets {
+	if fs, ok := st.ExistingFacets(b, tolerance); ok {
+		return fs
+	}
+	fs := ops.CalculateBodyFacets(b, quality(tolerance))
+	perBody, ok := st.facets[b]
+	if !ok {
+		perBody = map[float64]*ops.BodyFacets{}
+		st.facets[b] = perBody
+	}
+	perBody[tolerance] = fs
+	return fs
+}
+
+// ExistingFacets retrieves the facet set previously calculated at exactly this
+// tolerance, without faceting.
+func (st *FacetStore) ExistingFacets(b *topo.Body, tolerance float64) (*ops.BodyFacets, bool) {
+	fs, ok := st.facets[b][tolerance]
+	return fs, ok
+}
+
+// FacetTolerances lists the tolerances facet sets exist at for the body,
+// ascending.
+func (st *FacetStore) FacetTolerances(b *topo.Body) []float64 {
+	return sortedTolerances(keysOfFacets(st.facets[b]))
+}
+
+// CalculateStrokes samples the body's edges at the tolerance and caches the
+// stroke set; an already-cached set returns without re-sampling.
+func (st *FacetStore) CalculateStrokes(b *topo.Body, tolerance float64) *ops.BodyStrokes {
+	if ss, ok := st.ExistingStrokes(b, tolerance); ok {
+		return ss
+	}
+	ss := ops.CalculateBodyStrokes(b, quality(tolerance))
+	perBody, ok := st.strokes[b]
+	if !ok {
+		perBody = map[float64]*ops.BodyStrokes{}
+		st.strokes[b] = perBody
+	}
+	perBody[tolerance] = ss
+	return ss
+}
+
+// ExistingStrokes retrieves the stroke set previously calculated at exactly
+// this tolerance.
+func (st *FacetStore) ExistingStrokes(b *topo.Body, tolerance float64) (*ops.BodyStrokes, bool) {
+	ss, ok := st.strokes[b][tolerance]
+	return ss, ok
+}
+
+// StrokeTolerances lists the tolerances stroke sets exist at, ascending.
+func (st *FacetStore) StrokeTolerances(b *topo.Body) []float64 {
+	return sortedTolerances(keysOfStrokes(st.strokes[b]))
+}
+
+// FaceFacets returns one face's mesh from the body facet set at the tolerance,
+// calculating the body set if absent. The face-level reference calls ride the
+// body cache: a body set already carries every face's mesh.
+func (st *FacetStore) FaceFacets(b *topo.Body, f *topo.Face, tolerance float64) (*ops.Mesh, bool) {
+	fs := st.CalculateFacets(b, tolerance)
+	for i, face := range fs.Faces {
+		if face == f {
+			return fs.FaceMeshes[i], true
+		}
+	}
+	return nil, false
+}
+
+// FaceStrokes samples one face's boundary edges at the tolerance (uncached —
+// boundary sampling is cheap next to faceting).
+func (st *FacetStore) FaceStrokes(f *topo.Face, tolerance float64) [][]math.Point3 {
+	return ops.CalculateFaceStrokes(f, quality(tolerance)).Polylines
+}
+
+// DropBody evicts every cached set of a body (a caller replacing bodies in
+// place rather than minting new ones).
+func (st *FacetStore) DropBody(b *topo.Body) {
+	delete(st.facets, b)
+	delete(st.strokes, b)
+}
+
+func keysOfFacets(m map[float64]*ops.BodyFacets) []float64 {
+	out := make([]float64, 0, len(m))
+	for t := range m {
+		out = append(out, t)
+	}
+	return out
+}
+
+func keysOfStrokes(m map[float64]*ops.BodyStrokes) []float64 {
+	out := make([]float64, 0, len(m))
+	for t := range m {
+		out = append(out, t)
+	}
+	return out
+}
+
+func sortedTolerances(ts []float64) []float64 {
+	sort.Float64s(ts)
+	return ts
+}

--- a/model/facetstore/facetstore_test.go
+++ b/model/facetstore/facetstore_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package facetstore
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+)
+
+func storeBox(t *testing.T) *topo.Body {
+	t.Helper()
+	return subd.ToBody(subd.Box(2, 1, 1), "box")
+}
+
+// Calculate caches: the second call at the same tolerance returns the SAME set
+// (pointer identity — no re-faceting), and Existing sees it.
+func TestCalculateFacetsCachesPerTolerance(t *testing.T) {
+	st := NewFacetStore()
+	b := storeBox(t)
+	first := st.CalculateFacets(b, 0.01)
+	if again := st.CalculateFacets(b, 0.01); again != first {
+		t.Error("same tolerance must return the cached facet set, not re-facet")
+	}
+	if _, ok := st.ExistingFacets(b, 0.01); !ok {
+		t.Error("ExistingFacets should find the calculated set")
+	}
+	if _, ok := st.ExistingFacets(b, 0.05); ok {
+		t.Error("ExistingFacets must not invent a set for an uncalculated tolerance")
+	}
+}
+
+// Tolerances list every cached set ascending; strokes track independently.
+func TestToleranceListsAscending(t *testing.T) {
+	st := NewFacetStore()
+	b := storeBox(t)
+	st.CalculateFacets(b, 0.05)
+	st.CalculateFacets(b, 0.01)
+	got := st.FacetTolerances(b)
+	if len(got) != 2 || got[0] != 0.01 || got[1] != 0.05 {
+		t.Errorf("FacetTolerances = %v, want [0.01 0.05]", got)
+	}
+	if n := len(st.StrokeTolerances(b)); n != 0 {
+		t.Errorf("stroke tolerances = %d entries, want 0 (none calculated)", n)
+	}
+}
+
+// The facet set carries per-face index counts summing to the merged mesh, and
+// texture coordinates pair off 2-per-vertex.
+func TestFacetSetShape(t *testing.T) {
+	st := NewFacetStore()
+	b := storeBox(t)
+	fs := st.CalculateFacets(b, 0.01)
+	sum := 0
+	for _, c := range fs.IndexCountPerFace {
+		sum += c
+	}
+	if sum != len(fs.Mesh.Indices) {
+		t.Errorf("per-face index counts sum %d != merged indices %d", sum, len(fs.Mesh.Indices))
+	}
+	if uv := fs.TextureCoordinates(); len(uv) != 2*len(fs.Mesh.Positions) {
+		t.Errorf("texture coords = %d floats, want %d (2 per vertex)", len(uv), 2*len(fs.Mesh.Positions))
+	}
+}
+
+// Strokes cache like facets and cover every edge.
+func TestCalculateStrokesCaches(t *testing.T) {
+	st := NewFacetStore()
+	b := storeBox(t)
+	ss := st.CalculateStrokes(b, 0.01)
+	if len(ss.Polylines) != len(b.Edges()) {
+		t.Errorf("strokes cover %d edges, want %d", len(ss.Polylines), len(b.Edges()))
+	}
+	if again := st.CalculateStrokes(b, 0.01); again != ss {
+		t.Error("same tolerance must return the cached stroke set")
+	}
+}
+
+// Face-level retrieval rides the body cache; DropBody evicts everything.
+func TestFaceFacetsAndDrop(t *testing.T) {
+	st := NewFacetStore()
+	b := storeBox(t)
+	f := b.Faces()[0]
+	mesh, ok := st.FaceFacets(b, f, 0.01)
+	if !ok || len(mesh.Indices) == 0 {
+		t.Fatalf("FaceFacets = (%v, %v), want a non-empty mesh", mesh, ok)
+	}
+	if foreign := faceOfAnotherBody(t); func() bool { _, ok := st.FaceFacets(b, foreign, 0.01); return ok }() {
+		t.Error("a face of another body must not resolve")
+	}
+	st.DropBody(b)
+	if _, ok := st.ExistingFacets(b, 0.01); ok {
+		t.Error("DropBody should evict the facet sets")
+	}
+}
+
+func faceOfAnotherBody(t *testing.T) *topo.Face {
+	t.Helper()
+	return storeBox(t).Faces()[0]
+}
+
+// FaceStrokes samples the boundary without touching the cache.
+func TestFaceStrokesUncached(t *testing.T) {
+	st := NewFacetStore()
+	b := storeBox(t)
+	pl := st.FaceStrokes(b.Faces()[0], 0.01)
+	if len(pl) != len(b.Faces()[0].Edges()) {
+		t.Errorf("face strokes = %d polylines, want %d", len(pl), len(b.Faces()[0].Edges()))
+	}
+	if n := len(st.StrokeTolerances(b)); n != 0 {
+		t.Errorf("face strokes must not populate the body cache (got %d tolerances)", n)
+	}
+}
+
+// The default-quality angle bound carries into facet quality, so a coarse
+// chord tolerance still rounds small curves (the Quality contract).
+func TestQualityKeepsAngleBound(t *testing.T) {
+	q := quality(0.5)
+	if q.AngleTolerance != ops.DefaultQuality().AngleTolerance {
+		t.Errorf("angle tolerance = %g, want display default %g", q.AngleTolerance, ops.DefaultQuality().AngleTolerance)
+	}
+}


### PR DESCRIPTION
## What

Completes milestone M07 (B-Rep Modeling Kernel & Topology) — the six remaining issues, one commit each:

- **#298 boolean robustness**: the planar-exact + validated-CSG core already handled the degenerate arrangements; this lands the acceptance regression suite (coincident-face joins, identical operands, sliver walls/overlaps, reference-key rebinding through chained edits).
- **#300 healing & validation**: `Sew` (previously a stub) closes real boundary gaps by clustering near-coincident endpoints and re-welding, stamping each absorbed gap as an M25 healed polyline + residual; oversized gaps report every boundary edge with its measured gap. `SelfIntersections` adds the explicit interpenetration scan (Möller tri-tri + coplanar SAT) with witness points.
- **#293 facet/stroke query API**: `CalculateBodyFacets`/`Strokes` (per-face index counts, memoized surface-param UVs, healed-seam strokes) + `model/facetstore`'s tolerance-keyed cache, served as the `body.calculateFacets`/`existingFacets`/… wire family with face-level calls by reference key.
- **#629 shells & wires**: `Builder.Build` regroups shells by true face connectivity (a cavity cut is genuinely two shells); shells gain edges, range boxes, derived reference keys, signed volume / void classification and containment; wire topology (ordered face-less edge chains) lands in `kernel/topo` with planarity/closure/keys; `OffsetPlanarWire` offsets lines/arcs exactly with the three reference corner-closure modes. `TransformBody` drops its single-shell restriction, carries wires, and now preserves face sense (transformed cavity volumes previously corrupted).
- **#630 body queries**: `LocateUsingPoint`, `FindUsingRay` (pick radius, nearest-first), point containment, convex/concave/tangent edge classification, `ValidateBodyEntities` (topology + self-intersection levels with problem-entity reporting), transient keys + `BindTransientKey`, `PreciseRangeBox` and the hull-flush `OrientedMinimumRangeBox`. The zero tracer also gained a sub-epsilon snap fixing contour-on-node zigzag doubling. `AlternateBody` is recorded as won't-implement (no transacted/evaluated body split exists in this kernel — the evaluated body is the only body).
- **#628 transient B-rep factory**: solid primitives (block/cylinder-cone/sphere/torus — closed surfaces as boundary-less faces), boolean/transform/copy on session handles, plane sections and face silhouettes as wires, per-span ruled surfaces, public planar imprint with touched-face/edge reporting, invariant-signature identical-body grouping, and the bottom-up `SurfaceBodyDefinition` compiler with path-addressed issue reporting — all over the `brep.*` wire methods with `model/bodyapi` contract adapters.

Serves the contract merged as Oblikovati.API#67/#68 (ADR-0018 contract-first). Lint 0 issues; full suite green.

## Why

These were the open issues on milestone M07 — the body model's public face: queries, shells/wires, faceting retrieval and the add-in geometry toolkit, plus the two F03 PBIs that predate the api-parity audit.

Closes #293, closes #298, closes #300, closes #628, closes #629, closes #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)