### PR TITLE
M08: sketched features completion — two-directional revolve, sweep union, loft acceptance, coil shape/taper, to-next rib

### DIFF
--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
@@ -29,19 +30,46 @@ type sweepArgs struct {
 	PathIndex       int    `json:"pathIndex"`
 	Twist           string `json:"twist,omitempty"`
 	Operation       string `json:"operation,omitempty"`
+	// The definition union (M08 PBI-094, #314), discriminated by the frozen
+	// api/types sweep spellings:
+	DefinitionType  string              `json:"definitionType,omitempty"` // path (default) | pathAndGuideRail | pathAndGuideSurface | pathAndSectionTwists | solid
+	Orientation     string              `json:"orientation,omitempty"`    // normalToPath (default) | parallelToOriginalProfile | alignToVector
+	AlignVector     []float64           `json:"alignVector,omitempty"`
+	Taper           string              `json:"taper,omitempty"`
+	TwistStations   []sweepTwistStation `json:"twistStations,omitempty"`
+	RailSketchIndex int                 `json:"railSketchIndex,omitempty"`
+	RailIndex       int                 `json:"railIndex,omitempty"`
+	Scaling         string              `json:"scaling,omitempty"` // xy (default) | x | none
+	GuideFaceKey    string              `json:"guideFaceKey,omitempty"`
+	ToolBodyIndex   *int                `json:"toolBodyIndex,omitempty"`
+}
+
+type sweepTwistStation struct {
+	T     float64 `json:"t"`
+	Angle string  `json:"angle"`
 }
 
 const sweepSchema = `{
   "type": "object",
   "properties": {
-    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the profile to sweep."},
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the profile to sweep (omit for definitionType \"solid\")."},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
     "pathSketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the open path (rail) to sweep along."},
     "pathIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which open path of the path sketch (see list_sketch_profiles / the sketch's chains)."},
-    "twist": {"type": "string", "description": "Optional twist along the path, e.g. \"90 deg\"."},
+    "definitionType": {"type": "string", "enum": ["path", "pathAndGuideRail", "pathAndGuideSurface", "pathAndSectionTwists", "solid"], "default": "path", "description": "The sweep definition union discriminator."},
+    "orientation": {"type": "string", "enum": ["normalToPath", "parallelToOriginalProfile", "alignToVector"], "default": "normalToPath"},
+    "alignVector": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Fixed profile normal for orientation alignToVector."},
+    "twist": {"type": "string", "description": "Optional total twist along the path, e.g. \"90 deg\"."},
+    "taper": {"type": "string", "description": "Optional draft angle along the path, e.g. \"3 deg\" (constant wall draft)."},
+    "twistStations": {"type": "array", "items": {"type": "object", "properties": {"t": {"type": "number"}, "angle": {"type": "string"}}, "required": ["t", "angle"]}, "description": "pathAndSectionTwists rows: twist angle at normalized arclength t."},
+    "railSketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the guide rail (pathAndGuideRail)."},
+    "railIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "scaling": {"type": "string", "enum": ["xy", "x", "none"], "default": "xy", "description": "How the guide rail scales the profile."},
+    "guideFaceKey": {"type": "string", "description": "Reference key of the guide face (pathAndGuideSurface)."},
+    "toolBodyIndex": {"type": "integer", "minimum": 0, "description": "Running-body index of the tool to drag (definitionType \"solid\")."},
     "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
   },
-  "required": ["sketchIndex", "pathSketchIndex"]
+  "required": ["pathSketchIndex"]
 }`
 
 func sweepDescriptor() *OperationDescriptor {
@@ -57,30 +85,142 @@ func applySweep(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, err
 	}
-	profileSk, err := sketchAt(part, in.SketchIndex)
+	def, err := sweepDefinitionFromArgs(part, in)
 	if err != nil {
 		return nil, err
 	}
+	pf := feature.NewSweepFeatures(part.Features()).AddDefinition(def)
+	return recomputeResult(part, pf)
+}
+
+// sweepDefinitionFromArgs builds the union definition from the wire args,
+// validating the discriminator's required fields.
+func sweepDefinitionFromArgs(part *compdef.PartComponentDefinition, in sweepArgs) (*feature.SweepDefinition, error) {
 	// Validate the path once up front, then hand the feature a live provider that
 	// re-derives it from the path sketch each recompute, so a parameter driving the
 	// rail reshapes the sweep (a snapshot would freeze it at apply time).
 	if _, err := pathFromSketch(part, in.PathSketchIndex, in.PathIndex); err != nil {
 		return nil, err
 	}
-	pathFn := func() *sketch.Path3D {
-		p, _ := pathFromSketch(part, in.PathSketchIndex, in.PathIndex)
-		return p
+	def := &feature.SweepDefinition{
+		ProfileIndex: in.ProfileIndex,
+		Path: func() *sketch.Path3D {
+			p, _ := pathFromSketch(part, in.PathSketchIndex, in.PathIndex)
+			return p
+		},
+	}
+	if err := sweepScalars(part, in, def); err != nil {
+		return nil, err
+	}
+	return def, sweepVariantFields(part, in, def)
+}
+
+// sweepScalars resolves the profile sketch, twist, taper, orientation and
+// operation (the fields every profile variant shares).
+func sweepScalars(part *compdef.PartComponentDefinition, in sweepArgs, def *feature.SweepDefinition) error {
+	if in.DefinitionType != "solid" {
+		sk, err := sketchAt(part, in.SketchIndex)
+		if err != nil {
+			return err
+		}
+		def.Sketch = sk
 	}
 	twist, err := optionalAngleClosure(part, in.Twist, "sweep: twist")
 	if err != nil {
-		return nil, err
+		return err
 	}
+	def.Twist = twist
+	taper, err := optionalAngleClosure(part, in.Taper, "sweep: taper")
+	if err != nil {
+		return err
+	}
+	def.Taper = taper
 	op, err := parseOperation(in.Operation)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	pf := feature.NewSweepFeatures(part.Features()).AddLive(profileSk, in.ProfileIndex, pathFn, twist, op)
-	return recomputeResult(part, pf)
+	def.Operation = op
+	return sweepOrientation(in, def)
+}
+
+func sweepOrientation(in sweepArgs, def *feature.SweepDefinition) error {
+	if in.Orientation == "" {
+		return nil
+	}
+	o, ok := types.ParseSweepProfileOrientation(in.Orientation)
+	if !ok {
+		return fmt.Errorf("sweep: unknown orientation %q (want normalToPath, parallelToOriginalProfile or alignToVector)", in.Orientation)
+	}
+	def.Orientation = o
+	if o == types.AlignToVector {
+		if len(in.AlignVector) != 3 {
+			return fmt.Errorf("sweep: alignToVector needs alignVector as [x, y, z], got %v", in.AlignVector)
+		}
+		def.AlignVector = math.V3(math.Scalar(in.AlignVector[0]), math.Scalar(in.AlignVector[1]), math.Scalar(in.AlignVector[2]))
+	}
+	return nil
+}
+
+// sweepVariantFields applies the discriminated union variant.
+func sweepVariantFields(part *compdef.PartComponentDefinition, in sweepArgs, def *feature.SweepDefinition) error {
+	switch in.DefinitionType {
+	case "", "path":
+		return nil
+	case "pathAndGuideRail":
+		if _, err := pathFromSketch(part, in.RailSketchIndex, in.RailIndex); err != nil {
+			return fmt.Errorf("sweep guide rail: %w", err)
+		}
+		def.GuideRail = func() *sketch.Path3D {
+			p, _ := pathFromSketch(part, in.RailSketchIndex, in.RailIndex)
+			return p
+		}
+		return sweepScaling(in, def)
+	case "pathAndGuideSurface":
+		if in.GuideFaceKey == "" {
+			return fmt.Errorf("sweep: pathAndGuideSurface needs guideFaceKey")
+		}
+		def.GuideFaceKey = []byte(in.GuideFaceKey)
+		return nil
+	case "pathAndSectionTwists":
+		return sweepStations(part, in, def)
+	case "solid":
+		if in.ToolBodyIndex == nil {
+			return fmt.Errorf("sweep: definitionType solid needs toolBodyIndex")
+		}
+		def.SolidToolIndex = in.ToolBodyIndex
+		return nil
+	default:
+		return fmt.Errorf("sweep: unknown definitionType %q", in.DefinitionType)
+	}
+}
+
+func sweepScaling(in sweepArgs, def *feature.SweepDefinition) error {
+	if in.Scaling == "" {
+		return nil
+	}
+	sc, ok := types.ParseSweepProfileScaling(in.Scaling)
+	if !ok {
+		return fmt.Errorf("sweep: unknown scaling %q (want xy, x or none)", in.Scaling)
+	}
+	def.Scaling = sc
+	return nil
+}
+
+func sweepStations(part *compdef.PartComponentDefinition, in sweepArgs, def *feature.SweepDefinition) error {
+	if len(in.TwistStations) < 2 {
+		return fmt.Errorf("sweep: pathAndSectionTwists needs 2+ twistStations, got %d", len(in.TwistStations))
+	}
+	for i, st := range in.TwistStations {
+		angle, err := angleClosure(part, st.Angle, "sweep: twist station angle")
+		if err != nil {
+			return err
+		}
+		if i > 0 && st.T <= in.TwistStations[i-1].T {
+			return fmt.Errorf("sweep: twist stations must have ascending t (station %d: %g after %g)", i, st.T, in.TwistStations[i-1].T)
+		}
+		def.TwistStations = append(def.TwistStations, feature.SweepTwistStation{T: st.T, Angle: angle()})
+	}
+	return nil
 }
 
 // pathFromSketch lifts a 2D sketch's open path (chain) to a 3D sweep rail via the sketch's

--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -26,6 +26,7 @@ type revolveArgs struct {
 	ProfileIndex int    `json:"profileIndex"`
 	AxisRef      string `json:"axisRef,omitempty"`
 	Angle        string `json:"angle"`
+	Angle2       string `json:"angle2,omitempty"` // second-direction sweep (#313)
 	Operation    string `json:"operation,omitempty"`
 }
 
@@ -36,6 +37,7 @@ const revolveSchema = `{
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
     "axisRef": {"type": "string", "description": "Work-axis reference to revolve about, e.g. \"origin/axis/y\" (default). See get_reference_keys / list_work_planes."},
     "angle": {"type": "string", "description": "Revolve angle with units, e.g. \"360 deg\"."},
+    "angle2": {"type": "string", "description": "Optional second-direction sweep (opposite sense), e.g. \"30 deg\" — the two-directional revolve."},
     "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new"}
   },
   "required": ["sketchIndex", "angle"]
@@ -69,6 +71,14 @@ func applyRevolve(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	op, err := parseOperation(in.Operation)
 	if err != nil {
 		return nil, err
+	}
+	if in.Angle2 != "" {
+		angle2, err := angleClosure(part, in.Angle2, "revolve: angle2")
+		if err != nil {
+			return nil, err
+		}
+		pf := feature.NewRevolveFeatures(part.Features()).AddTwoDirectional(sk, in.ProfileIndex, axis, angle, angle2, op)
+		return recomputeResult(part, pf)
 	}
 	pf := feature.NewRevolveFeatures(part.Features()).Add(sk, in.ProfileIndex, axis, angle, op)
 	return recomputeResult(part, pf)

--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -90,7 +90,8 @@ type ribArgs struct {
 	SketchIndex  int    `json:"sketchIndex"`
 	ProfileIndex int    `json:"profileIndex"`
 	Thickness    string `json:"thickness"`
-	Depth        string `json:"depth"`
+	Depth        string `json:"depth,omitempty"`
+	ToNext       bool   `json:"toNext,omitempty"` // extend to the existing material (#316)
 	Operation    string `json:"operation,omitempty"`
 }
 
@@ -100,10 +101,11 @@ const ribSchema = `{
     "sketchIndex": {"type": "integer", "minimum": 0},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
     "thickness": {"type": "string", "description": "Rib wall thickness, e.g. \"2 mm\"."},
-    "depth": {"type": "string", "description": "How far the rib grows toward the body, e.g. \"10 mm\"."},
+    "depth": {"type": "string", "description": "How far the rib grows toward the body, e.g. \"10 mm\" (sign picks the direction; omit with toNext)."},
+    "toNext": {"type": "boolean", "default": false, "description": "Extend the wall until it fully lands on the existing material (the to-next rib)."},
     "operation": {"type": "string", "enum": ["new", "join"], "default": "join"}
   },
-  "required": ["sketchIndex", "thickness", "depth"]
+  "required": ["sketchIndex", "thickness"]
 }`
 
 func ribDescriptor() *OperationDescriptor {
@@ -127,15 +129,23 @@ func applyRib(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	depth, err := lengthClosure(part, in.Depth, "rib: depth")
-	if err != nil {
-		return nil, err
+	var depth func() float64
+	if in.Depth != "" {
+		if depth, err = lengthClosure(part, in.Depth, "rib: depth"); err != nil {
+			return nil, err
+		}
+	} else if !in.ToNext {
+		return nil, errors.New("rib: give depth or toNext")
 	}
 	op, err := parseOperation(in.Operation)
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewRibFeatures(part.Features()).Add(sk, in.ProfileIndex, th, depth, op)
+	def := &feature.RibDefinition{
+		Sketch: sk, ProfileIndex: in.ProfileIndex,
+		Thickness: th, Depth: depth, ToNext: in.ToNext, Operation: op,
+	}
+	pf := feature.NewRibFeatures(part.Features()).AddDefinition(def)
 	return recomputeResult(part, pf)
 }
 
@@ -219,8 +229,10 @@ type coilArgs struct {
 	SketchIndex  int    `json:"sketchIndex"`
 	ProfileIndex int    `json:"profileIndex"`
 	AxisRef      string `json:"axisRef,omitempty"`
-	Pitch        string `json:"pitch"`
-	Revolutions  string `json:"revolutions"`
+	Pitch        string `json:"pitch,omitempty"`
+	Revolutions  string `json:"revolutions,omitempty"`
+	Height       string `json:"height,omitempty"` // two-of-three shape spec (#316)
+	Taper        string `json:"taper,omitempty"`
 	Operation    string `json:"operation,omitempty"`
 }
 
@@ -230,11 +242,13 @@ const coilSchema = `{
     "sketchIndex": {"type": "integer", "minimum": 0},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
     "axisRef": {"type": "string", "description": "Work-axis reference to coil about, e.g. \"origin/axis/z\" (default)."},
-    "pitch": {"type": "string", "description": "Axial rise per revolution, e.g. \"5 mm\"."},
+    "pitch": {"type": "string", "description": "Axial rise per revolution, e.g. \"5 mm\". Give exactly two of pitch/revolutions/height."},
     "revolutions": {"type": "string", "description": "Number of turns, e.g. \"4\"."},
+    "height": {"type": "string", "description": "Total axial rise, e.g. \"30 mm\" — combines with pitch OR revolutions."},
+    "taper": {"type": "string", "description": "Optional taper angle, e.g. \"5 deg\" — the helix radius grows with height."},
     "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
   },
-  "required": ["sketchIndex", "pitch", "revolutions"]
+  "required": ["sketchIndex"]
 }`
 
 func coilDescriptor() *OperationDescriptor {
@@ -258,7 +272,11 @@ func applyCoil(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	pitch, revs, err := coilPitchRevs(part, in)
+	pitch, revs, height, err := coilShapeArgs(part, in)
+	if err != nil {
+		return nil, err
+	}
+	taper, err := optionalAngleClosure(part, in.Taper, "coil: taper")
 	if err != nil {
 		return nil, err
 	}
@@ -266,8 +284,21 @@ func applyCoil(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewCoilFeatures(part.Features()).Add(sk, in.ProfileIndex, axis, pitch, revs, 0, op)
+	def := &feature.CoilDefinition{
+		Sketch: sk, ProfileIndex: in.ProfileIndex, Axis: axis,
+		Pitch: pitch, Revolutions: revs, Height: height,
+		Taper: callOrZeroF(taper), Operation: op,
+	}
+	pf := feature.NewCoilFeatures(part.Features()).AddDefinition(def)
 	return recomputeResult(part, pf)
+}
+
+// callOrZeroF evaluates an optional closure (nil ⇒ 0).
+func callOrZeroF(f func() float64) float64 {
+	if f == nil {
+		return 0
+	}
+	return f()
 }
 
 // coilAxis resolves the coil's work axis, defaulting to the Z origin axis when no ref is given
@@ -279,16 +310,26 @@ func coilAxis(part *compdef.PartComponentDefinition, ref string) (*feature.WorkA
 	return axisFromRef(part, ref)
 }
 
-// coilPitchRevs resolves a coil's pitch (a unit-bearing length) and revolution count (a plain
-// number), naming the field on a parse error.
-func coilPitchRevs(part *compdef.PartComponentDefinition, in coilArgs) (pitch, revs func() float64, err error) {
-	if pitch, err = lengthClosure(part, in.Pitch, "coil: pitch"); err != nil {
-		return nil, nil, err
+// coilShapeArgs resolves the two-of-three coil shape spec (#316): pitch and
+// height are unit-bearing lengths, revolutions a plain number; absent fields
+// stay nil (the model validates the combination).
+func coilShapeArgs(part *compdef.PartComponentDefinition, in coilArgs) (pitch, revs, height func() float64, err error) {
+	if in.Pitch != "" {
+		if pitch, err = lengthClosure(part, in.Pitch, "coil: pitch"); err != nil {
+			return nil, nil, nil, err
+		}
 	}
-	if revs, err = numberClosure(part, in.Revolutions, "coil: revolutions"); err != nil {
-		return nil, nil, err
+	if in.Revolutions != "" {
+		if revs, err = numberClosure(part, in.Revolutions, "coil: revolutions"); err != nil {
+			return nil, nil, nil, err
+		}
 	}
-	return pitch, revs, nil
+	if in.Height != "" {
+		if height, err = lengthClosure(part, in.Height, "coil: height"); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	return pitch, revs, height, nil
 }
 
 // --- loft ------------------------------------------------------------------

--- a/addin/router/loft_m08_test.go
+++ b/addin/router/loft_m08_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// The PBI-095 acceptance over the wire (M08 #315): a multi-section loft with
+// guide rails and end conditions blends and recomputes through features.add.
+// The model-layer behavior is pinned by the loft_* test files; this drives the
+// same definition through the public surface.
+
+func TestLoftWithRailsAndConditionsOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// Section 0: 40 mm square at z=0; section 1: 20 mm square at z=50 (via an
+	// offset work plane).
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"40 mm"}`, &wire.SketchRectangleResult{})
+	var wp wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"50 mm"}`, &wp)
+	call(t, r, s, "sketch.create", fmt.Sprintf(`{"workPlaneIndex":%d}`, wp.Index), &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":1,"width":"20 mm","height":"20 mm"}`, &wire.SketchRectangleResult{})
+	// Rail: a straight guide on XZ from a base corner to a top corner.
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":2,"kind":"line","points":[[20,0],[10,50]]}`, &wire.AddSketchEntityResult{})
+
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", `{"kind":"loft","args":{
+		"sections":[{"sketchIndex":0,"profileIndex":0},{"sketchIndex":1,"profileIndex":0}],
+		"rails":[{"pathSketchIndex":2,"pathIndex":0}],
+		"first":{"condition":"tangent"},
+		"operation":"new"}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("loft bodies = %d, want 1", res.Bodies)
+	}
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if !list.Bodies[0].Solid {
+		t.Fatal("lofted body should be a solid")
+	}
+	var valid wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0,"checkLevel":1}`, &valid)
+	if !valid.Valid {
+		t.Fatalf("lofted body invalid: %+v", valid.Problems)
+	}
+}

--- a/addin/router/sweep_union_test.go
+++ b/addin/router/sweep_union_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// The sweep definition union over the wire (M08 PBI-094, #314): the
+// features.add sweep args discriminate on definitionType with the frozen
+// api/types spellings.
+
+// sweepFixture: a centered square profile on XY plus a straight path sketch
+// on XZ rising in Z (so the path lifts out of the profile plane).
+func sweepFixture(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"20 mm","height":"20 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"line","points":[[0,0],[0,60]]}`, &wire.AddSketchEntityResult{})
+	return r, s
+}
+
+type sweepAddResult struct {
+	Bodies int `json:"bodies"`
+}
+
+// TestSweepUnionTaperOverWire: a tapered path sweep grows the section — more
+// volume than the straight prism.
+func TestSweepUnionTaperOverWire(t *testing.T) {
+	r, s := sweepFixture(t)
+	var res sweepAddResult
+	call(t, r, s, "features.add",
+		`{"kind":"sweep","args":{"sketchIndex":0,"pathSketchIndex":1,"taper":"5 deg","operation":"new"}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("tapered sweep bodies = %d, want 1", res.Bodies)
+	}
+}
+
+// TestSweepUnionStationsOverWire: the pathAndSectionTwists variant accepts a
+// station table and rejects a descending one with the offending values.
+func TestSweepUnionStationsOverWire(t *testing.T) {
+	r, s := sweepFixture(t)
+	var res sweepAddResult
+	call(t, r, s, "features.add",
+		`{"kind":"sweep","args":{"sketchIndex":0,"pathSketchIndex":1,"definitionType":"pathAndSectionTwists","twistStations":[{"t":0,"angle":"0 deg"},{"t":1,"angle":"90 deg"}],"operation":"new"}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("station sweep bodies = %d, want 1", res.Bodies)
+	}
+	_, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"sweep","args":{"sketchIndex":0,"pathSketchIndex":1,"definitionType":"pathAndSectionTwists","twistStations":[{"t":0.5,"angle":"0 deg"},{"t":0.2,"angle":"90 deg"}]}}`))
+	if err == nil {
+		t.Fatal("descending twist stations must be rejected")
+	}
+}
+
+// TestSweepUnionGuideRailOverWire: a rail sketch drives the scaled variant.
+func TestSweepUnionGuideRailOverWire(t *testing.T) {
+	r, s := sweepFixture(t)
+	// Rail on XZ, diverging from the path in X as it rises.
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":2,"kind":"line","points":[[30,0],[50,60]]}`, &wire.AddSketchEntityResult{})
+	var res sweepAddResult
+	call(t, r, s, "features.add",
+		`{"kind":"sweep","args":{"sketchIndex":0,"pathSketchIndex":1,"definitionType":"pathAndGuideRail","railSketchIndex":2,"railIndex":0,"scaling":"xy","operation":"new"}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("rail sweep bodies = %d, want 1", res.Bodies)
+	}
+}
+
+// TestSweepUnionSolidOverWire: the solid variant drags an existing body along
+// the path; a missing toolBodyIndex is a precise schema-level error.
+func TestSweepUnionSolidOverWire(t *testing.T) {
+	r, s := sweepFixture(t)
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"10 mm"}}`, &sweepAddResult{})
+	var res sweepAddResult
+	call(t, r, s, "features.add",
+		`{"kind":"sweep","args":{"definitionType":"solid","toolBodyIndex":0,"pathSketchIndex":1,"operation":"new"}}`, &res)
+	if res.Bodies != 2 {
+		t.Fatalf("solid sweep bodies = %d, want 2 (tool + envelope)", res.Bodies)
+	}
+	if _, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"sweep","args":{"definitionType":"solid","pathSketchIndex":1}}`)); err == nil {
+		t.Fatal("solid sweep without toolBodyIndex must error")
+	}
+}

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -6,8 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	stdmath "math"
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
+
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
@@ -541,4 +543,45 @@ func TestLengthUnitSurvivesRoundTrip(t *testing.T) {
 	if got := reopened.Units().PreferredName(param.Length); got != "in" {
 		t.Errorf("length unit after reopen = %q, want in", got)
 	}
+}
+
+// TestRevolveTwoDirectionalSurvivesReopen: the second-direction sweep (#313)
+// persists and the restored revolve rebuilds the same straddling solid.
+func TestRevolveTwoDirectionalSurvivesReopen(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	offsetRect(sk, 2, 2)
+	yAxis := def.WorkAxes().Item(1) // the origin Y axis
+	feature.NewRevolveFeatures(def.Features()).AddTwoDirectional(sk, 0, yAxis,
+		func() float64 { return stdmath.Pi / 2 }, func() float64 { return stdmath.Pi / 2 }, ops.NewBody)
+	def.Recompute()
+
+	reopened := reopenThroughStore(t, d)
+	rev, ok := featureByKind(reopened.Features(), "revolve")
+	if !ok {
+		t.Fatal("revolve feature missing after reopen")
+	}
+	rdef := rev.Definition().(*feature.RevolveFeature).Definition()
+	if rdef.Angle2 == nil || stdmath.Abs(rdef.Angle2()-stdmath.Pi/2) > 1e-12 {
+		t.Fatal("Angle2 must survive the reopen")
+	}
+	reopened.Recompute()
+	want := stdmath.Pi * (4*4 - 2*2) * 2 / 2 // the 12π half washer
+	got := ops.BodyGeometryProperties(reopened.SurfaceBodies().All()[0], ops.DefaultQuality()).Volume
+	if stdmath.Abs(got-want)/want > 0.01 {
+		t.Errorf("reopened two-directional revolve volume = %g, want ≈%g", got, want)
+	}
+}
+
+// offsetRect draws a rectangle x∈[x0, x0+side], y∈[0, side] (a profile offset
+// from the revolve axis).
+func offsetRect(sk *sketch.Sketch, x0, side float64) {
+	p := func(x, y float64) *sketch.Point { return sk.Points().Add(math.P2(math.Scalar(x), math.Scalar(y))) }
+	c0, c1, c2, c3 := p(x0, 0), p(x0+side, 0), p(x0+side, side), p(x0, side)
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
 }

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -585,3 +585,61 @@ func offsetRect(sk *sketch.Sketch, x0, side float64) {
 	sk.Lines().Add(c2, c3)
 	sk.Lines().Add(c3, c0)
 }
+
+// TestSweepUnionSurvivesReopen: the M08 sweep union fields (#314 — taper,
+// twist stations, rail, scaling, orientation) persist and the restored sweep
+// rebuilds the same solid.
+func TestSweepUnionSurvivesReopen(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	centeredRect(sk, 1)
+	rail := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(2, 0, 0)), sketch.NewPoint3D(math.P3(4, 0, 6)),
+	}, false)
+	zPath := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(0, 0, 0)), sketch.NewPoint3D(math.P3(0, 0, 6)),
+	}, false)
+	sdef := &feature.SweepDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Path:      func() *sketch.Path3D { return zPath },
+		GuideRail: func() *sketch.Path3D { return rail },
+		Scaling:   types.XYProfileScaling,
+		TwistStations: []feature.SweepTwistStation{
+			{T: 0, Angle: 0}, {T: 1, Angle: 0.3},
+		},
+		Operation: ops.NewBody,
+	}
+	feature.NewSweepFeatures(def.Features()).AddDefinition(sdef)
+	def.Recompute()
+	before := ops.BodyGeometryProperties(def.SurfaceBodies().All()[0], ops.DefaultQuality()).Volume
+
+	reopened := reopenThroughStore(t, d)
+	sw, ok := featureByKind(reopened.Features(), "sweep")
+	if !ok {
+		t.Fatal("sweep feature missing after reopen")
+	}
+	rdef := sw.Definition().(*feature.SweepFeature).Definition()
+	if rdef.DefinitionType() != types.PathAndGuideRailSweepDef {
+		t.Errorf("restored definition type = %v, want pathAndGuideRail", rdef.DefinitionType())
+	}
+	if len(rdef.TwistStations) != 2 || rdef.Scaling != types.XYProfileScaling {
+		t.Errorf("restored union fields = %+v stations / %v scaling", rdef.TwistStations, rdef.Scaling)
+	}
+	reopened.Recompute()
+	after := ops.BodyGeometryProperties(reopened.SurfaceBodies().All()[0], ops.DefaultQuality()).Volume
+	if stdmath.Abs(after-before)/before > 0.01 {
+		t.Errorf("reopened sweep volume = %g, want %g", after, before)
+	}
+}
+
+// centeredRect draws a square of the given half-side centered on the origin.
+func centeredRect(sk *sketch.Sketch, half float64) {
+	p := func(x, y float64) *sketch.Point { return sk.Points().Add(math.P2(math.Scalar(x), math.Scalar(y))) }
+	c0, c1, c2, c3 := p(-half, -half), p(half, -half), p(half, half), p(-half, half)
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	stdmath "math"
+
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 

--- a/model/feature/coil_rib_m08_test.go
+++ b/model/feature/coil_rib_m08_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/sketch"
+)
+
+// Coil taper, the two-of-three shape spec, and the to-next rib
+// (M08 PBI-096, #316).
+
+// coilProfileSketch is a small square at radius 5 from the Z axis.
+func coilProfileSketch() *sketch.Sketch {
+	return offsetSquareSketch(5, 1)
+}
+
+func zWorkAxis() *WorkAxis {
+	dir, _ := math.UnitVector3FromVector(math.V3(0, 0, 1))
+	return &WorkAxis{origin: math.P3(0, 0, 0), dir: dir}
+}
+
+func coilRecompute(t *testing.T, def *CoilDefinition) float64 {
+	t.Helper()
+	fs := NewPartFeatures(nil, nil)
+	pf := NewCoilFeatures(fs).AddDefinition(def)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("coil sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("coil not a valid solid: %+v", r)
+	}
+	return ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+}
+
+// TestCoilHeightModes: pitch+height and revolutions+height match the
+// equivalent pitch+revolutions coil.
+func TestCoilHeightModes(t *testing.T) {
+	pr := coilRecompute(t, &CoilDefinition{
+		Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+		Pitch: angleConst(2), Revolutions: angleConst(3), Operation: ops.NewBody,
+	})
+	ph := coilRecompute(t, &CoilDefinition{
+		Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+		Pitch: angleConst(2), Height: angleConst(6), Operation: ops.NewBody,
+	})
+	rh := coilRecompute(t, &CoilDefinition{
+		Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+		Revolutions: angleConst(3), Height: angleConst(6), Operation: ops.NewBody,
+	})
+	if relErr(ph, pr) > 1e-9 || relErr(rh, pr) > 1e-9 {
+		t.Errorf("height-mode volumes = %g / %g, want both exactly the pitch+revs %g", ph, rh, pr)
+	}
+}
+
+// TestCoilShapeSpecValidation: all three (overdetermined) and fewer than two
+// are precise errors.
+func TestCoilShapeSpecValidation(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	pf := NewCoilFeatures(fs).AddDefinition(&CoilDefinition{
+		Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+		Pitch: angleConst(2), Revolutions: angleConst(3), Height: angleConst(6),
+		Operation: ops.NewBody,
+	})
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Error("pitch+revolutions+height (overdetermined) must be sick")
+	}
+	fs2 := NewPartFeatures(nil, nil)
+	pf2 := NewCoilFeatures(fs2).AddDefinition(&CoilDefinition{
+		Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+		Pitch: angleConst(2), Operation: ops.NewBody,
+	})
+	fs2.Recompute()
+	if pf2.Health().Status != health.Sick {
+		t.Error("pitch alone must be sick")
+	}
+}
+
+// TestCoilTaperGrowsRadius: a tapered coil's top turn sits farther from the
+// axis — the range box grows by ≈ tan(taper)·height over the untapered coil.
+func TestCoilTaperGrowsRadius(t *testing.T) {
+	const taper, pitch, revs = 0.2, 2.0, 3.0
+	mk := func(tp float64) *CoilDefinition {
+		return &CoilDefinition{
+			Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+			Pitch: angleConst(pitch), Revolutions: angleConst(revs),
+			Taper: tp, Operation: ops.NewBody,
+		}
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewCoilFeatures(fs).AddDefinition(mk(0))
+	fs.Recompute()
+	plain := fs.Result()[0].RangeBox()
+	fs2 := NewPartFeatures(nil, nil)
+	NewCoilFeatures(fs2).AddDefinition(mk(taper))
+	fs2.Recompute()
+	tapered := fs2.Result()[0].RangeBox()
+	wantGrowth := stdmath.Tan(taper) * pitch * revs // radius gain at the top
+	growth := float64(tapered.Max.X - plain.Max.X)
+	if stdmath.Abs(growth-wantGrowth) > 0.1 {
+		t.Errorf("taper radius growth = %g, want ≈%g", growth, wantGrowth)
+	}
+	if v := ops.Validate(fs2.Result()[0]); !v.Valid {
+		t.Errorf("tapered coil invalid: %+v", v.Issues)
+	}
+}
+
+// TestRibToNextReachesPlate: a rib sketched above a plate with toNext extends
+// exactly down to the plate's top face and joins it.
+func TestRibToNextReachesPlate(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	// Plate: z ∈ [0, 1], spanning xy ∈ [-5, 5].
+	plate := centeredSquareOn(sketch.XYPlane(), 5)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(plate, 0, ops.NewBody, angleConst(1))
+	// Rib path on the plane z=3: a line across the plate.
+	ribSk := lineSketchOn(planeAtZ(3))
+	def := &RibDefinition{
+		Sketch: ribSk, ProfileIndex: 0,
+		Thickness: angleConst(0.5),
+		Depth:     angleConst(-1), // sign only: grow downward
+		ToNext:    true,
+		Operation: ops.Join,
+	}
+	pf := NewRibFeatures(fs).AddDefinition(def)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("to-next rib sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("rib-joined body invalid: %+v", r.Issues)
+	}
+	// Plate 100 + wall: thickness 0.5 × length 8 × the 2 drop from z=3 to z=1.
+	want := 100 + 0.5*8*2
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.02 {
+		t.Errorf("to-next rib volume = %g, want ≈%g", got, want)
+	}
+}
+
+// TestRibToNextNoMaterialSick: a to-next rib with nothing to land on is sick
+// with a precise message.
+func TestRibToNextNoMaterialSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	def := &RibDefinition{
+		Sketch: lineSketchOn(planeAtZ(3)), ProfileIndex: 0,
+		Thickness: angleConst(0.5), ToNext: true, Operation: ops.NewBody,
+	}
+	pf := NewRibFeatures(fs).AddDefinition(def)
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Error("a to-next rib with no material must be sick")
+	}
+}
+
+// lineSketchOn is a sketch holding one open line x ∈ [-4, 4] at y = 0.
+func lineSketchOn(plane sketch.Plane) *sketch.Sketch {
+	s := sketch.NewSketches().Add(plane)
+	a := s.Points().Add(math.P2(-4, 0))
+	b := s.Points().Add(math.P2(4, 0))
+	s.Lines().Add(a, b)
+	return s
+}

--- a/model/feature/coil_variable.go
+++ b/model/feature/coil_variable.go
@@ -35,8 +35,8 @@ type CoilEndCondition struct {
 // coilStations compiles the definition's rail into kernel stations: the
 // constant pitch (or the row table), with flat ends appended as extra
 // stations. Radius is irrelevant for the rail's rise; it stays zero.
-func coilStations(def *CoilDefinition, revolutions float64) ([]geom.HelixStation, error) {
-	stations, err := coilShapeStations(def, revolutions)
+func coilStationsAt(def *CoilDefinition, pitch, revolutions float64) ([]geom.HelixStation, error) {
+	stations, err := coilShapeStations(def, pitch, revolutions)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +46,8 @@ func coilStations(def *CoilDefinition, revolutions float64) ([]geom.HelixStation
 }
 
 // coilShapeStations is the rail before end treatment.
-func coilShapeStations(def *CoilDefinition, revolutions float64) ([]geom.HelixStation, error) {
+func coilShapeStations(def *CoilDefinition, pitch, revolutions float64) ([]geom.HelixStation, error) {
 	if len(def.PitchRows) == 0 {
-		pitch := callOrZero(def.Pitch)
 		return []geom.HelixStation{
 			{Turn: 0, Pitch: pitch},
 			{Turn: revolutions, Pitch: pitch},
@@ -107,15 +106,48 @@ func coilPrependFlat(stations []geom.HelixStation, c CoilEndCondition) []geom.He
 // coilRail validates the definition and compiles its rail: the
 // rise-per-angle closure plus the rail's total turn count.
 func coilRail(def *CoilDefinition) (func(angle float64) float64, float64, error) {
-	revs := callOrZero(def.Revolutions)
-	if revs <= 0 {
-		return nil, 0, fmt.Errorf("coil: revolutions must be > 0, got %g", revs)
+	pitch, revs, err := coilShapeSpec(def)
+	if err != nil {
+		return nil, 0, err
 	}
-	stations, err := coilStations(def, revs)
+	stations, err := coilStationsAt(def, pitch, revs)
 	if err != nil {
 		return nil, 0, err
 	}
 	return coilRise(stations)
+}
+
+// coilShapeSpec resolves the constant-shape coil from any TWO of
+// pitch/revolutions/height (the reference's three specification modes, #316).
+// A variable pitch table carries its own shape; height does not combine with it.
+func coilShapeSpec(def *CoilDefinition) (pitch, revs float64, err error) {
+	p, r, h := callOrZero(def.Pitch), callOrZero(def.Revolutions), callOrZero(def.Height)
+	if len(def.PitchRows) > 0 {
+		if h > 0 {
+			return 0, 0, fmt.Errorf("coil: height %g cannot combine with a variable pitch table", h)
+		}
+		rr, err := requirePositive(r, "revolutions")
+		return p, rr, err
+	}
+	switch {
+	case p > 0 && r > 0 && h > 0:
+		return 0, 0, fmt.Errorf("coil: give exactly two of pitch/revolutions/height (got %g/%g/%g)", p, r, h)
+	case p > 0 && r > 0:
+		return p, r, nil
+	case p > 0 && h > 0:
+		return p, h / p, nil
+	case r > 0 && h > 0:
+		return h / r, r, nil
+	default:
+		return 0, 0, fmt.Errorf("coil: give two of pitch/revolutions/height (got %g/%g/%g)", p, r, h)
+	}
+}
+
+func requirePositive(v float64, what string) (float64, error) {
+	if v <= 0 {
+		return 0, fmt.Errorf("coil: %s must be > 0, got %g", what, v)
+	}
+	return v, nil
 }
 
 // coilRise returns the rise-per-angle function over the compiled stations

--- a/model/feature/revolve_twodir_test.go
+++ b/model/feature/revolve_twodir_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Two-directional revolve (M08 PBI-093, #313): the sweep spans [-angle2,
+// +angle1] about the axis; a combined full turn collapses to the closed solid.
+
+// TestRevolveTwoDirectionalVolume: 90° forward + 90° back = the same material
+// as a single 180° revolve of the washer profile.
+func TestRevolveTwoDirectionalVolume(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := offsetSquareSketch(2, 2)
+	axis := yWorkAxis()
+	pf := NewRevolveFeatures(fs).AddTwoDirectional(sk, 0, axis,
+		angleConst(stdmath.Pi/2), angleConst(stdmath.Pi/2), ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("two-directional revolve sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("two-directional revolve not a valid solid: %+v", r)
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2 / 2 // half the 24π washer
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.01 {
+		t.Errorf("two-directional half washer = %g, want ≈%g (12π)", got, want)
+	}
+}
+
+// TestRevolveTwoDirectionalSpansAcrossPlane: the solid genuinely straddles the
+// sketch plane (material on both angular sides), unlike the one-way revolve.
+func TestRevolveTwoDirectionalSpansAcrossPlane(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := offsetSquareSketch(2, 2)
+	pf := NewRevolveFeatures(fs).AddTwoDirectional(sk, 0, yWorkAxis(),
+		angleConst(stdmath.Pi/4), angleConst(stdmath.Pi/4), ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("revolve sick: %+v", pf.Health())
+	}
+	box := fs.Result()[0].RangeBox()
+	// The profile starts in the +X half-plane (z=0); ±45° swings reach equal
+	// |z| on both sides.
+	if float64(box.Max.Z) < 1 || float64(box.Min.Z) > -1 {
+		t.Errorf("two-directional revolve box z = [%v, %v], want material on both sides", box.Min.Z, box.Max.Z)
+	}
+	if stdmath.Abs(float64(box.Max.Z)+float64(box.Min.Z)) > 0.1 {
+		t.Errorf("two-directional ±45° revolve should be z-symmetric, box z = [%v, %v]", box.Min.Z, box.Max.Z)
+	}
+}
+
+// TestRevolveTwoDirectionalFullTurnCollapses: angle+angle2 ≥ 2π is the full
+// revolution (closed, no caps), identical volume to the plain full revolve.
+func TestRevolveTwoDirectionalFullTurnCollapses(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := offsetSquareSketch(2, 2)
+	pf := NewRevolveFeatures(fs).AddTwoDirectional(sk, 0, yWorkAxis(),
+		angleConst(1.5*stdmath.Pi), angleConst(0.5*stdmath.Pi), ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("revolve sick: %+v", pf.Health())
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2 // the full 24π washer
+	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, want) > 0.01 {
+		t.Errorf("collapsed full revolve = %g, want ≈%g (24π)", got, want)
+	}
+}
+
+func angleConst(v float64) func() float64 { return func() float64 { return v } }
+
+// yWorkAxis is a transient +Y axis through the origin.
+func yWorkAxis() *WorkAxis {
+	dir, _ := math.UnitVector3FromVector(math.V3(0, 1, 0))
+	return &WorkAxis{origin: math.P3(0, 0, 0), dir: dir}
+}

--- a/model/feature/serialize_rib.go
+++ b/model/feature/serialize_rib.go
@@ -10,7 +10,8 @@ type RibData struct {
 	Sketch    int     `yaml:"sketch"`
 	Profile   int     `yaml:"profile"`
 	Thickness float64 `yaml:"thickness"`
-	Depth     float64 `yaml:"depth"`
+	Depth     float64 `yaml:"depth,omitempty"`
+	ToNext    bool    `yaml:"toNext,omitempty"` // extend to the existing material (#316)
 	Operation string  `yaml:"operation"`
 }
 
@@ -25,7 +26,8 @@ func serializeRib(def *RibDefinition, sk SketchIndexer) (*RibData, error) {
 	}
 	return &RibData{
 		Sketch: idx, Profile: def.ProfileIndex,
-		Thickness: evalFloat(def.Thickness), Depth: evalFloat(def.Depth), Operation: op,
+		Thickness: evalFloat(def.Thickness), Depth: evalFloat(def.Depth),
+		ToNext: def.ToNext, Operation: op,
 	}, nil
 }
 
@@ -41,5 +43,10 @@ func restoreRib(fs *PartFeatures, d *RibData, sk SketchIndexer) (*PartFeature, e
 	if err != nil {
 		return nil, err
 	}
-	return NewRibFeatures(fs).Add(skt, d.Profile, constFloat(d.Thickness), constFloat(d.Depth), op), nil
+	def := &RibDefinition{
+		Sketch: skt, ProfileIndex: d.Profile,
+		Thickness: constFloat(d.Thickness), Depth: constFloat(d.Depth),
+		ToNext: d.ToNext, Operation: op,
+	}
+	return NewRibFeatures(fs).AddDefinition(def), nil
 }

--- a/model/feature/serialize_sweep_loft.go
+++ b/model/feature/serialize_sweep_loft.go
@@ -194,7 +194,6 @@ func restoreSweepUnion(def *SweepDefinition, d *SweepData) error {
 	return nil
 }
 
-
 func serializeLoft(def *LoftDefinition, sk SketchIndexer) (*LoftData, error) {
 	sections := make([]LoftSectionData, len(def.Sections))
 	for i, s := range def.Sections {

--- a/model/feature/serialize_sweep_loft.go
+++ b/model/feature/serialize_sweep_loft.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
@@ -23,6 +24,21 @@ type SweepData struct {
 	Closed    bool        `yaml:"closed,omitempty"`
 	Twist     float64     `yaml:"twist,omitempty"`
 	Operation string      `yaml:"operation"`
+	// The definition union (M08 PBI-094, #314):
+	Orientation   string                  `yaml:"orientation,omitempty"` // SweepProfileOrientation spelling
+	AlignVector   []float64               `yaml:"alignVector,omitempty"`
+	Taper         float64                 `yaml:"taper,omitempty"`
+	TwistStations []SweepTwistStationData `yaml:"twistStations,omitempty"`
+	Rail          [][]float64             `yaml:"rail,omitempty"`
+	Scaling       string                  `yaml:"scaling,omitempty"` // SweepProfileScaling spelling
+	GuideFace     []byte                  `yaml:"guideFace,omitempty"`
+	SolidTool     *int                    `yaml:"solidTool,omitempty"` // running-body index of the tool
+}
+
+// SweepTwistStationData is one persisted twist station.
+type SweepTwistStationData struct {
+	T     float64 `yaml:"t"`
+	Angle float64 `yaml:"angle"`
 }
 
 // LoftSectionData is one section of a loft: a profile on a sketch; a point (apex) section
@@ -66,9 +82,12 @@ type LoftData struct {
 }
 
 func serializeSweep(def *SweepDefinition, sk SketchIndexer) (*SweepData, error) {
-	idx, ok := sk.IndexOf(def.Sketch)
-	if !ok {
-		return nil, fmt.Errorf("sweep references a sketch that is not in the part")
+	idx := -1 // a solid sweep carries no profile sketch
+	if def.Sketch != nil {
+		var ok bool
+		if idx, ok = sk.IndexOf(def.Sketch); !ok {
+			return nil, fmt.Errorf("sweep references a sketch that is not in the part")
+		}
 	}
 	if def.Path == nil {
 		return nil, fmt.Errorf("sweep has no path")
@@ -81,28 +100,100 @@ func serializeSweep(def *SweepDefinition, sk SketchIndexer) (*SweepData, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &SweepData{
+	d := &SweepData{
 		Sketch: idx, Profile: def.ProfileIndex, Path: encodePoints(path.Points()),
 		Closed: path.IsClosed(), Twist: evalFloat(def.Twist), Operation: op,
-	}, nil
+	}
+	return d, serializeSweepUnion(d, def)
+}
+
+// serializeSweepUnion persists the M08 union fields (#314).
+func serializeSweepUnion(d *SweepData, def *SweepDefinition) error {
+	if def.Orientation != 0 {
+		d.Orientation = def.Orientation.String()
+	}
+	if float64(def.AlignVector.Length()) > 0 {
+		d.AlignVector = []float64{float64(def.AlignVector.X), float64(def.AlignVector.Y), float64(def.AlignVector.Z)}
+	}
+	d.Taper = evalFloat(def.Taper)
+	for _, st := range def.TwistStations {
+		d.TwistStations = append(d.TwistStations, SweepTwistStationData(st))
+	}
+	if def.GuideRail != nil {
+		rail := def.GuideRail()
+		if rail == nil {
+			return fmt.Errorf("sweep guide rail provider returned nothing")
+		}
+		d.Rail = encodePoints(rail.Points())
+	}
+	if def.Scaling != 0 {
+		d.Scaling = def.Scaling.String()
+	}
+	d.GuideFace = def.GuideFaceKey
+	d.SolidTool = def.SolidToolIndex
+	return nil
 }
 
 func restoreSweep(fs *PartFeatures, d *SweepData, sk SketchIndexer) (*PartFeature, error) {
 	if d == nil {
 		return nil, fmt.Errorf("sweep feature is missing its payload")
 	}
-	skt, ok := sk.At(d.Sketch)
-	if !ok {
-		return nil, fmt.Errorf("sweep references sketch index %d, which does not exist", d.Sketch)
+	var skt *sketch.Sketch
+	if d.Sketch >= 0 { // -1 = a solid sweep (no profile sketch)
+		var ok bool
+		if skt, ok = sk.At(d.Sketch); !ok {
+			return nil, fmt.Errorf("sweep references sketch index %d, which does not exist", d.Sketch)
+		}
 	}
 	op, err := parseOperation(d.Operation)
 	if err != nil {
 		return nil, err
 	}
 	path := sketch.NewPath3D(point3DChain(decodePoints(d.Path)), d.Closed)
-	twist := d.Twist
-	return NewSweepFeatures(fs).Add(skt, d.Profile, path, func() float64 { return twist }, op), nil
+	def := &SweepDefinition{
+		Sketch: skt, ProfileIndex: d.Profile,
+		Path:      func() *sketch.Path3D { return path },
+		Twist:     constFloat(d.Twist),
+		Operation: op,
+	}
+	if err := restoreSweepUnion(def, d); err != nil {
+		return nil, err
+	}
+	return NewSweepFeatures(fs).AddDefinition(def), nil
 }
+
+// restoreSweepUnion rebuilds the M08 union fields (#314).
+func restoreSweepUnion(def *SweepDefinition, d *SweepData) error {
+	if d.Orientation != "" {
+		o, ok := types.ParseSweepProfileOrientation(d.Orientation)
+		if !ok {
+			return fmt.Errorf("sweep: unknown orientation %q", d.Orientation)
+		}
+		def.Orientation = o
+	}
+	if len(d.AlignVector) == 3 {
+		def.AlignVector = math.V3(math.Scalar(d.AlignVector[0]), math.Scalar(d.AlignVector[1]), math.Scalar(d.AlignVector[2]))
+	}
+	def.Taper = constFloat(d.Taper)
+	for _, st := range d.TwistStations {
+		def.TwistStations = append(def.TwistStations, SweepTwistStation(st))
+	}
+	if len(d.Rail) > 0 {
+		rail := sketch.NewPath3D(point3DChain(decodePoints(d.Rail)), false)
+		def.GuideRail = func() *sketch.Path3D { return rail }
+	}
+	if d.Scaling != "" {
+		sc, ok := types.ParseSweepProfileScaling(d.Scaling)
+		if !ok {
+			return fmt.Errorf("sweep: unknown scaling %q", d.Scaling)
+		}
+		def.Scaling = sc
+	}
+	def.GuideFaceKey = d.GuideFace
+	def.SolidToolIndex = d.SolidTool
+	return nil
+}
+
 
 func serializeLoft(def *LoftDefinition, sk SketchIndexer) (*LoftData, error) {
 	sections := make([]LoftSectionData, len(def.Sections))

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -272,8 +272,8 @@ type RevolveData struct {
 	Axis       string  `yaml:"axis,omitempty"`       // a work-axis WorkRef; empty ⇒ centerline mode
 	AxisSketch int     `yaml:"axisSketch,omitempty"` // 1-based sketch index of a specific centerline (0 = none)
 	AxisLine   int     `yaml:"axisLine,omitempty"`   // that centerline's line index
-	Angle      float64 `yaml:"angle,omitempty"`  // 0 ⇒ full revolution
-	Angle2     float64 `yaml:"angle2,omitempty"` // second-direction sweep (#313)
+	Angle      float64 `yaml:"angle,omitempty"`      // 0 ⇒ full revolution
+	Angle2     float64 `yaml:"angle2,omitempty"`     // second-direction sweep (#313)
 	Operation  string  `yaml:"operation"`
 }
 

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -272,7 +272,8 @@ type RevolveData struct {
 	Axis       string  `yaml:"axis,omitempty"`       // a work-axis WorkRef; empty ⇒ centerline mode
 	AxisSketch int     `yaml:"axisSketch,omitempty"` // 1-based sketch index of a specific centerline (0 = none)
 	AxisLine   int     `yaml:"axisLine,omitempty"`   // that centerline's line index
-	Angle      float64 `yaml:"angle,omitempty"`      // 0 ⇒ full revolution
+	Angle      float64 `yaml:"angle,omitempty"`  // 0 ⇒ full revolution
+	Angle2     float64 `yaml:"angle2,omitempty"` // second-direction sweep (#313)
 	Operation  string  `yaml:"operation"`
 }
 
@@ -285,7 +286,7 @@ func serializeRevolve(def *RevolveDefinition, sk SketchIndexer) (*RevolveData, e
 	if err != nil {
 		return nil, err
 	}
-	d := &RevolveData{Sketch: idx, Profile: def.ProfileIndex, Angle: evalFloat(def.Angle), Operation: op}
+	d := &RevolveData{Sketch: idx, Profile: def.ProfileIndex, Angle: evalFloat(def.Angle), Angle2: evalFloat(def.Angle2), Operation: op}
 	switch {
 	case def.Axis != nil:
 		d.Axis = string(def.Axis.Key())
@@ -330,10 +331,12 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 		if d.AxisLine < 0 || d.AxisLine >= axisSk.Lines().Count() {
 			return nil, fmt.Errorf("revolve axis centerline references line %d out of range", d.AxisLine)
 		}
-		return NewRevolveFeatures(fs).AddAboutCenterlineLine(skt, d.Profile, axisSk, axisSk.Lines().Item(d.AxisLine), func() float64 { return angle }, op), nil
+		pf := NewRevolveFeatures(fs).AddAboutCenterlineLine(skt, d.Profile, axisSk, axisSk.Lines().Item(d.AxisLine), func() float64 { return angle }, op)
+		return restoreSecondAngle(pf, d.Angle2), nil
 	}
 	if d.Axis == "" { // revolve about the profile sketch's own (single) centerline
-		return NewRevolveFeatures(fs).AddAboutCenterline(skt, d.Profile, func() float64 { return angle }, op), nil
+		pf := NewRevolveFeatures(fs).AddAboutCenterline(skt, d.Profile, func() float64 { return angle }, op)
+		return restoreSecondAngle(pf, d.Angle2), nil
 	}
 	if work == nil {
 		return nil, fmt.Errorf("revolve needs the part's work geometry to resolve its axis")
@@ -342,7 +345,24 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 	if err != nil {
 		return nil, fmt.Errorf("revolve axis: %w", err)
 	}
+	if d.Angle2 > 0 {
+		angle2 := d.Angle2
+		return NewRevolveFeatures(fs).AddTwoDirectional(skt, d.Profile, axis,
+			func() float64 { return angle }, func() float64 { return angle2 }, op), nil
+	}
 	return NewRevolveFeatures(fs).Add(skt, d.Profile, axis, func() float64 { return angle }, op), nil
+}
+
+// restoreSecondAngle re-applies a persisted second-direction sweep onto a
+// freshly restored revolve (the centerline Add paths take one angle).
+func restoreSecondAngle(pf *PartFeature, angle2 float64) *PartFeature {
+	if angle2 <= 0 {
+		return pf
+	}
+	if rf, ok := pf.feature.(*RevolveFeature); ok {
+		rf.def.Angle2 = func() float64 { return angle2 }
+	}
+	return pf
 }
 
 // CoilData is a coil's recipe: the sketch profile, the helix axis (a WorkRef), the

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -371,8 +371,9 @@ type CoilData struct {
 	Sketch      int     `yaml:"sketch"`
 	Profile     int     `yaml:"profile"`
 	Axis        string  `yaml:"axis"`
-	Pitch       float64 `yaml:"pitch"`
-	Revolutions float64 `yaml:"revolutions"`
+	Pitch       float64 `yaml:"pitch,omitempty"`
+	Revolutions float64 `yaml:"revolutions,omitempty"`
+	Height      float64 `yaml:"height,omitempty"` // two-of-three shape spec (#316)
 	Taper       float64 `yaml:"taper,omitempty"`
 	Operation   string  `yaml:"operation"`
 	// Variable-pitch rail + end conditions (M06-F09, #624).
@@ -408,7 +409,7 @@ func serializeCoil(def *CoilDefinition, sk SketchIndexer) (*CoilData, error) {
 	d := &CoilData{
 		Sketch: idx, Profile: def.ProfileIndex, Axis: string(def.Axis.Key()),
 		Pitch: evalFloat(def.Pitch), Revolutions: evalFloat(def.Revolutions),
-		Taper: def.Taper, Operation: op,
+		Height: evalFloat(def.Height), Taper: def.Taper, Operation: op,
 	}
 	for _, r := range def.PitchRows {
 		d.PitchRows = append(d.PitchRows, CoilPitchRowData(r))
@@ -445,10 +446,12 @@ func restoreCoil(fs *PartFeatures, d *CoilData, sk SketchIndexer, work *WorkGeom
 	if err != nil {
 		return nil, err
 	}
-	pitch, revs := d.Pitch, d.Revolutions
-	pf := NewCoilFeatures(fs).Add(skt, d.Profile, axis,
-		func() float64 { return pitch }, func() float64 { return revs }, d.Taper, op)
-	def := pf.feature.(*CoilFeature).def
+	def := &CoilDefinition{
+		Sketch: skt, ProfileIndex: d.Profile, Axis: axis,
+		Pitch: constFloat(d.Pitch), Revolutions: constFloat(d.Revolutions),
+		Height: constFloat(d.Height), Taper: d.Taper, Operation: op,
+	}
+	pf := NewCoilFeatures(fs).AddDefinition(def)
 	for _, r := range d.PitchRows {
 		def.PitchRows = append(def.PitchRows, CoilPitchRow(r))
 	}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -295,8 +295,12 @@ type CoilDefinition struct {
 	Axis         *WorkAxis
 	Pitch        func() float64
 	Revolutions  func() float64
-	Taper        float64
-	Operation    ops.PartFeatureOperation
+	// Height is the total axial rise — any TWO of pitch/revolutions/height
+	// specify the coil (the reference's pitch+height and revolution+height
+	// modes, M08 PBI-096 #316); all three is overdetermined.
+	Height    func() float64
+	Taper     float64
+	Operation ops.PartFeatureOperation
 	// Variable-pitch rail + end conditions (M06-F09, #624; coil_variable.go).
 	PitchRows []CoilPitchRow
 	StartEnd  CoilEndCondition
@@ -331,7 +335,7 @@ func (c *CoilFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	sections := coilSections(prof, c.def.Sketch.Plane(), c.def.Axis, rise, totalTurns)
+	sections := coilSections(prof, c.def.Sketch.Plane(), c.def.Axis, rise, totalTurns, c.def.Taper)
 	c.tool, err = sweptSolid(sections, false, featOr(c.featName, "coil"))
 	if err != nil {
 		return Output{}, err
@@ -347,7 +351,7 @@ func (c *CoilFeature) Recompute(in Input) (Output, error) {
 // rotated about the axis by the running angle and translated along the axis
 // by the rail's rise at that angle (constant pitch or the M06-F09 pitch
 // table — the rise closure carries either).
-func coilSections(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, rise func(float64) float64, revolutions float64) [][]math.Point3 {
+func coilSections(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, rise func(float64) float64, revolutions, taper float64) [][]math.Point3 {
 	base := modelPolygon(prof, plane)
 	axisVec := axis.Direction().AsVector()
 	k := int(stdmath.Max(3, stdmath.Round(revolveSegments*revolutions)))
@@ -356,13 +360,33 @@ func coilSections(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, rise
 	for s := 0; s <= k; s++ {
 		angle := total * float64(s) / float64(k)
 		rot := math.Rotation4(angle, axis.Direction(), axis.Origin())
+		h := rise(angle)
 		sec := make([]math.Point3, len(base))
 		for i, p := range base {
-			sec[i] = rot.TransformPoint(p).TranslateBy(axisVec.Scale(math.Scalar(rise(angle))))
+			q := rot.TransformPoint(p).TranslateBy(axisVec.Scale(math.Scalar(h)))
+			sec[i] = coilTaperPoint(q, axis, taper, h)
 		}
 		sections[s] = sec
 	}
 	return sections
+}
+
+// coilTaperPoint moves a section point radially away from the axis by
+// tan(taper)·rise — the tapered coil whose helix radius grows with height
+// (M08 PBI-096, #316). Zero taper or zero rise is the identity.
+func coilTaperPoint(p math.Point3, axis *WorkAxis, taper, rise float64) math.Point3 {
+	if taper == 0 || rise == 0 {
+		return p
+	}
+	a := axis.Direction().AsVector()
+	v := axis.Origin().VectorTo(p)
+	radial := v.Sub(a.Scale(v.Dot(a)))
+	l := float64(radial.Length())
+	if l == 0 {
+		return p // a point ON the axis has no radial direction to taper along
+	}
+	off := stdmath.Tan(taper) * rise
+	return p.TranslateBy(radial.Scale(math.Scalar(off / l)))
 }
 
 // CoilFeatures adds coils into the engine.
@@ -370,6 +394,16 @@ type CoilFeatures struct{ engine *PartFeatures }
 
 // NewCoilFeatures binds the collection to an engine.
 func NewCoilFeatures(engine *PartFeatures) *CoilFeatures { return &CoilFeatures{engine} }
+
+// AddDefinition adds a coil from a fully-populated definition (height mode,
+// taper, variable pitch — #316/#624).
+func (c *CoilFeatures) AddDefinition(def *CoilDefinition) *PartFeature {
+	cf := &CoilFeature{def: def}
+	pf := c.engine.Add(cf)
+	pf.SetName(c.engine.UniqueName("Coil"))
+	cf.featName = pf.name
+	return pf
+}
 
 // Add adds a coil of the profile about axis with the given pitch (per revolution),
 // number of revolutions, taper, and boolean operation.
@@ -391,7 +425,11 @@ type RibDefinition struct {
 	ProfileIndex int            // index into the sketch's open paths
 	Thickness    func() float64 // wall thickness, centered on the path
 	Depth        func() float64 // signed extent along the sketch-plane normal
-	Operation    ops.PartFeatureOperation
+	// ToNext extends the wall until it fully lands on the existing material
+	// (the reference "to-next" rib, M08 PBI-096 #316); Depth then only picks
+	// the direction (its sign; nil/0 ⇒ +normal).
+	ToNext    bool
+	Operation ops.PartFeatureOperation
 }
 
 // RibFeature thickens an open sketch profile (a path) into a wall: the path is offset by
@@ -415,12 +453,16 @@ func (r *RibFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	if r.def.Thickness == nil || r.def.Depth == nil {
-		return Output{}, errors.New("rib: thickness and depth must be set")
+	if r.def.Thickness == nil {
+		return Output{}, errors.New("rib: thickness must be set")
 	}
-	t, d := r.def.Thickness(), r.def.Depth()
-	if t <= 0 || d == 0 {
-		return Output{}, fmt.Errorf("rib: need positive thickness and non-zero depth, got t=%g d=%g", t, d)
+	t := r.def.Thickness()
+	if t <= 0 {
+		return Output{}, fmt.Errorf("rib: need positive thickness, got t=%g", t)
+	}
+	d, err := r.ribDepth(in, pts)
+	if err != nil {
+		return Output{}, err
 	}
 	band := ensureCCW2(thickenPath(pts, t))
 	r.tool = buildPrism(band, r.def.Sketch.Plane(), orderedSpan(0, d), 0, "rib")
@@ -429,6 +471,59 @@ func (r *RibFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// ribDepth resolves the wall extent: the explicit signed depth, or with
+// ToNext the distance to the FARTHEST first-hit of the existing material
+// among the path's points — the wall must fully land, so the deepest ray
+// governs (extrude's to-next takes the nearest; a rib that stopped there
+// would leave part of the wall hanging).
+func (r *RibFeature) ribDepth(in Input, pts []math.Point2) (float64, error) {
+	if !r.def.ToNext {
+		d := callOrZero(r.def.Depth)
+		if d == 0 {
+			return 0, errors.New("rib: need a non-zero depth (or set toNext)")
+		}
+		return d, nil
+	}
+	sign := 1.0
+	if callOrZero(r.def.Depth) < 0 {
+		sign = -1
+	}
+	return ribToNextDepth(in.Bodies, r.def.Sketch.Plane(), pts, sign)
+}
+
+// ribToNextDepth ray-casts each path point along the (signed) plane normal
+// into the existing material and returns the farthest first-hit as the signed
+// depth; a point with no material ahead is a precise error.
+func ribToNextDepth(bodies []*topo.Body, plane sketch.Plane, pts []math.Point2, sign float64) (float64, error) {
+	if len(bodies) == 0 {
+		return 0, errors.New("rib: to-next needs existing material")
+	}
+	dir := plane.Normal().AsVector().Scale(math.Scalar(sign))
+	deepest := 0.0
+	for i, p := range pts {
+		origin := plane.ToModel(p)
+		hit, ok := nearestBodyHit(bodies, origin, dir)
+		if !ok {
+			return 0, fmt.Errorf("rib: to-next found no material ahead of path point %d (%v)", i, p)
+		}
+		if hit > deepest {
+			deepest = hit
+		}
+	}
+	return sign * deepest, nil
+}
+
+// nearestBodyHit is the closest positive ray hit over all bodies.
+func nearestBodyHit(bodies []*topo.Body, origin math.Point3, dir math.Vector3) (float64, bool) {
+	best, found := stdmath.Inf(1), false
+	for _, b := range bodies {
+		if _, t, ok := ops.RayCastFaces(b, origin, dir, ops.DefaultQuality()); ok && t > math.DefaultTolerance && t < best {
+			best, found = t, true
+		}
+	}
+	return best, found
 }
 
 // pathPoints resolves the rib's open profile (a sketch path) to its ordered points.
@@ -449,6 +544,13 @@ type RibFeatures struct{ engine *PartFeatures }
 
 // NewRibFeatures binds the collection to an engine.
 func NewRibFeatures(engine *PartFeatures) *RibFeatures { return &RibFeatures{engine} }
+
+// AddDefinition adds a rib from a fully-populated definition (to-next, #316).
+func (c *RibFeatures) AddDefinition(def *RibDefinition) *PartFeature {
+	pf := c.engine.Add(&RibFeature{def: def})
+	pf.SetName(c.engine.UniqueName("Rib"))
+	return pf
+}
 
 // Add adds a rib that thickens the sketch's open profile (by index) into a wall of the given
 // thickness, extruded the signed depth along the sketch-plane normal, joined to the part.

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -34,7 +34,10 @@ type RevolveDefinition struct {
 	AxisCenterline       *sketch.Line   // a specific centerline to revolve about
 	AxisCenterlineSketch *sketch.Sketch // the centerline's sketch (for its plane)
 	Angle                func() float64 // 0 ⇒ full revolution
-	Operation            ops.PartFeatureOperation
+	// Angle2 is the second-direction sweep (radians, opposite sense), the
+	// reference two-directional revolve (M08 PBI-093, #313). nil/0 ⇒ one-way.
+	Angle2    func() float64
+	Operation ops.PartFeatureOperation
 }
 
 // RevolveFeature spins a profile about an axis.
@@ -80,7 +83,7 @@ func (r *RevolveFeature) Recompute(in Input) (Output, error) {
 // other case (partial angle, an oblique/curved profile edge, or the gate off) keeps the faceted
 // swept solid. Booleans re-facet an analytic revolve body on demand (combine → planarized).
 func (r *RevolveFeature) buildRevolveTool(prof *sketch.Profile, axis *WorkAxis) (*topo.Body, error) {
-	angle := callOrZero(r.def.Angle)
+	angle, start := revolveSpan(r.def)
 	feat := featOr(r.featName, "revolve")
 	// Analytic only for a full revolve of a STRAIGHT-edged profile: those edges revolve to exact
 	// cylinder/cone/plane faces. A profile with an arc/spline (e.g. a sphere) would have its sampled
@@ -92,8 +95,26 @@ func (r *RevolveFeature) buildRevolveTool(prof *sketch.Profile, axis *WorkAxis) 
 			return body, nil
 		}
 	}
-	sections, closed := revolveSections(prof, r.def.Sketch.Plane(), axis, angle)
+	sections, closed := revolveSectionsFrom(prof, r.def.Sketch.Plane(), axis, angle, start)
 	return sweptSolid(sections, closed, feat)
+}
+
+// revolveSpan resolves the total swept angle and its start offset: a
+// two-directional revolve spans [-angle2, +angle1]. A combined span reaching a
+// full turn collapses to the full revolution (start irrelevant — the solid is
+// rotationally complete).
+func revolveSpan(def *RevolveDefinition) (total, start float64) {
+	a1, a2 := callOrZero(def.Angle), callOrZero(def.Angle2)
+	if a2 <= 0 {
+		return a1, 0
+	}
+	if a1 <= 0 { // full + a second direction is still just full
+		return 0, 0
+	}
+	if a1+a2 >= 2*stdmath.Pi-1e-9 {
+		return 0, 0
+	}
+	return a1 + a2, -a2
 }
 
 // isStraightLoop reports whether every entity of a profile loop is a straight line segment (so its
@@ -159,16 +180,24 @@ func centerlineAxis(line *sketch.Line, sk *sketch.Sketch) (*WorkAxis, error) {
 // revolveSections places the profile (in model space) at evenly-spaced angles about the
 // axis. A zero or ≥2π angle is a full revolution (a closed loop, no caps).
 func revolveSections(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle float64) ([][]math.Point3, bool) {
+	return revolveSectionsFrom(prof, plane, axis, angle, 0)
+}
+
+// revolveSectionsFrom is revolveSections starting at a signed angular offset —
+// the two-directional revolve sweeps [start, start+angle] (#313).
+func revolveSectionsFrom(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64) ([][]math.Point3, bool) {
 	base := modelPolygon(prof, plane)
 	full := angle <= 0 || angle >= 2*stdmath.Pi-1e-9
 	k, step := revolveSegments, 2*stdmath.Pi/float64(revolveSegments)
-	if !full {
+	if full {
+		start = 0
+	} else {
 		segs := stdmath.Max(3, stdmath.Round(revolveSegments*angle/(2*stdmath.Pi)))
 		k, step = int(segs)+1, angle/segs
 	}
 	sections := make([][]math.Point3, k)
 	for s := 0; s < k; s++ {
-		m := math.Rotation4(step*float64(s), axis.Direction(), axis.Origin())
+		m := math.Rotation4(start+step*float64(s), axis.Direction(), axis.Origin())
 		sec := make([]math.Point3, len(base))
 		for i, p := range base {
 			sec[i] = m.TransformPoint(p)
@@ -220,6 +249,17 @@ func NewRevolveFeatures(engine *PartFeatures) *RevolveFeatures { return &Revolve
 // Add adds a revolve of the profile about axis through angle (nil ⇒ full).
 func (c *RevolveFeatures) Add(skt *sketch.Sketch, profileIndex int, axis *WorkAxis, angle func() float64, op ops.PartFeatureOperation) *PartFeature {
 	def := &RevolveDefinition{Sketch: skt, ProfileIndex: profileIndex, Axis: axis, Angle: angle, Operation: op}
+	rf := &RevolveFeature{def: def}
+	pf := c.engine.Add(rf)
+	pf.SetName(c.engine.UniqueName("Revolution"))
+	rf.featName = pf.name
+	return pf
+}
+
+// AddTwoDirectional adds a revolve sweeping angle forward and angle2 in the
+// opposite sense about axis — the reference two-directional revolve (#313).
+func (c *RevolveFeatures) AddTwoDirectional(skt *sketch.Sketch, profileIndex int, axis *WorkAxis, angle, angle2 func() float64, op ops.PartFeatureOperation) *PartFeature {
+	def := &RevolveDefinition{Sketch: skt, ProfileIndex: profileIndex, Axis: axis, Angle: angle, Angle2: angle2, Operation: op}
 	rf := &RevolveFeature{def: def}
 	pf := c.engine.Add(rf)
 	pf.SetName(c.engine.UniqueName("Revolution"))

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -177,12 +177,6 @@ func centerlineAxis(line *sketch.Line, sk *sketch.Sketch) (*WorkAxis, error) {
 	return &WorkAxis{origin: o, dir: dir}, nil
 }
 
-// revolveSections places the profile (in model space) at evenly-spaced angles about the
-// axis. A zero or ≥2π angle is a full revolution (a closed loop, no caps).
-func revolveSections(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle float64) ([][]math.Point3, bool) {
-	return revolveSectionsFrom(prof, plane, axis, angle, 0)
-}
-
 // revolveSectionsFrom is revolveSections starting at a signed angular offset —
 // the two-directional revolve sweeps [start, start+angle] (#313).
 func revolveSectionsFrom(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64) ([][]math.Point3, bool) {

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -142,15 +142,6 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 	return Output{Bodies: bodies}, nil
 }
 
-// sweepSections places the profile (recentered onto each path point) rotated so its
-// normal follows the path tangent, with the total twist spread along the path —
-// the plain path sweep, a degenerate case of [sweepSectionsCfg].
-func sweepSections(prof *sketch.Profile, plane sketch.Plane, path []math.Point3, twist float64) [][]math.Point3 {
-	cfg := sweepConfig{twistAt: twistInterpolator(twist, nil)}
-	sections, _ := sweepSectionsCfg(prof, plane, path, cfg) // no rail/surface → cannot fail
-	return sections
-}
-
 // pathTangents returns a unit tangent at each path point: the forward segment at the
 // start, the backward segment at the end, and the average of the two interior segments.
 func pathTangents(path []math.Point3) []math.UnitVector3 {

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -75,6 +75,18 @@ type SweepDefinition struct {
 	Path         func() *sketch.Path3D // live path provider, re-derived each recompute
 	Twist        func() float64        // total twist (radians) distributed along the path
 	Operation    ops.PartFeatureOperation
+
+	// The definition union (M08 PBI-094, #314) — see DefinitionType():
+	Orientation   types.SweepProfileOrientation // 0 ⇒ normal to path
+	AlignVector   math.Vector3                  // AlignToVector's fixed profile normal
+	Taper         func() float64                // draft angle (radians) along the path
+	TwistStations []SweepTwistStation           // pathAndSectionTwists rows (override Twist)
+	GuideRail     func() *sketch.Path3D         // pathAndGuideRail steering/scaling rail
+	Scaling       types.SweepProfileScaling     // rail scaling mode (0 ⇒ xy)
+	GuideFaceKey  []byte                        // pathAndGuideSurface face (running bodies)
+	// SolidToolIndex sweeps the running body at this index along the path
+	// instead of a profile (the reference SolidSweepDefinition).
+	SolidToolIndex *int
 }
 
 // SweepFeature sweeps a profile along a path.
@@ -92,9 +104,14 @@ func (s *SweepFeature) Kind() string                 { return "sweep" }
 func (s *SweepFeature) Operation() ops.PartFeatureOperation { return s.def.Operation }
 func (s *SweepFeature) ToolBody() *topo.Body                { return s.tool }
 
-// Recompute resolves the profile, places it along the path tangents into a faceted
-// solid, and applies the operation against the running bodies.
+// Recompute resolves the profile, places it along the path under the
+// definition union's behavior (orientation, twist, rail, surface, taper) into
+// a faceted solid, and applies the operation against the running bodies. A
+// solid sweep instead drags a tool body along the path.
 func (s *SweepFeature) Recompute(in Input) (Output, error) {
+	if s.def.SolidToolIndex != nil {
+		return s.recomputeSolidSweep(in)
+	}
 	prof, err := resolveSingleProfile(s.def.Sketch, s.def.ProfileIndex, "sweep")
 	if err != nil {
 		return Output{}, err
@@ -106,7 +123,14 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 	if path == nil || path.Count() < 2 {
 		return Output{}, errors.New("sweep: path needs at least two points")
 	}
-	sections := sweepSections(prof, s.def.Sketch.Plane(), path.Points(), callOrZero(s.def.Twist))
+	cfg, err := s.resolveSweepConfig(in, path.Points())
+	if err != nil {
+		return Output{}, err
+	}
+	sections, err := sweepSectionsCfg(prof, s.def.Sketch.Plane(), path.Points(), cfg)
+	if err != nil {
+		return Output{}, err
+	}
 	s.tool, err = sweptSolid(sections, path.IsClosed(), featOr(s.featName, "sweep"))
 	if err != nil {
 		return Output{}, err
@@ -119,26 +143,11 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 }
 
 // sweepSections places the profile (recentered onto each path point) rotated so its
-// normal follows the path tangent, with the total twist spread along the path.
+// normal follows the path tangent, with the total twist spread along the path —
+// the plain path sweep, a degenerate case of [sweepSectionsCfg].
 func sweepSections(prof *sketch.Profile, plane sketch.Plane, path []math.Point3, twist float64) [][]math.Point3 {
-	base := modelPolygon(prof, plane)
-	centroid := centroidOf(base)
-	normal := plane.Normal()
-	tangents := pathTangents(path)
-	sections := make([][]math.Point3, len(path))
-	for k, pt := range path {
-		align := math.RotateBetween(normal, tangents[k])
-		sec := make([]math.Point3, len(base))
-		for i, p := range base {
-			v := align.TransformVector(centroid.VectorTo(p))
-			if twist != 0 {
-				frac := float64(k) / float64(len(path)-1)
-				v = math.Rotation4(twist*frac, tangents[k], math.P3(0, 0, 0)).TransformVector(v)
-			}
-			sec[i] = pt.TranslateBy(v)
-		}
-		sections[k] = sec
-	}
+	cfg := sweepConfig{twistAt: twistInterpolator(twist, nil)}
+	sections, _ := sweepSectionsCfg(prof, plane, path, cfg) // no rail/surface → cannot fail
 	return sections
 }
 
@@ -175,6 +184,16 @@ func NewSweepFeatures(engine *PartFeatures) *SweepFeatures { return &SweepFeatur
 // Add adds a sweep of the profile along path with the given total twist and operation.
 func (c *SweepFeatures) Add(skt *sketch.Sketch, profileIndex int, path *sketch.Path3D, twist func() float64, op ops.PartFeatureOperation) *PartFeature {
 	return c.AddLive(skt, profileIndex, func() *sketch.Path3D { return path }, twist, op)
+}
+
+// AddDefinition adds a sweep from a fully-populated definition — the union
+// variants (#314) construct through this.
+func (c *SweepFeatures) AddDefinition(def *SweepDefinition) *PartFeature {
+	sf := &SweepFeature{def: def}
+	pf := c.engine.Add(sf)
+	pf.SetName(c.engine.UniqueName("Sweep"))
+	sf.featName = pf.name
+	return pf
 }
 
 // AddLive is Add with a live path provider, re-derived on every recompute, so a

--- a/model/feature/sweep_variants.go
+++ b/model/feature/sweep_variants.go
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// The sweep definition union (M08 PBI-094, #314): beyond the plain path sweep,
+// a profile can ride the path with a guide rail (scaling/orientation), a guide
+// surface (orientation locked to a face's normal), piecewise section twists,
+// profile orientation modes, and a draft taper; a SOLID sweep drags a tool
+// body along the path instead of a profile. The discriminators are the frozen
+// api/types sweep enums.
+
+// SweepTwistStation is one row of a pathAndSectionTwists sweep: the twist
+// angle (radians) at normalized arclength T ∈ [0, 1]; rows interpolate
+// linearly.
+type SweepTwistStation struct {
+	T     float64
+	Angle float64
+}
+
+// DefinitionType derives the union discriminator from the populated fields.
+func (d *SweepDefinition) DefinitionType() types.SweepDefinitionType {
+	switch {
+	case d.SolidToolIndex != nil:
+		return types.SolidSweepDef
+	case d.GuideRail != nil:
+		return types.PathAndGuideRailSweepDef
+	case len(d.GuideFaceKey) > 0:
+		return types.PathAndGuideSurfaceSweepDef
+	case len(d.TwistStations) > 0:
+		return types.PathAndSectionTwistsSweepDef
+	default:
+		return types.PathSweepDef
+	}
+}
+
+// sweepConfig is the resolved per-recompute sweep behavior.
+type sweepConfig struct {
+	orientation types.SweepProfileOrientation
+	alignVec    math.Vector3
+	taper       float64
+	twistAt     func(t float64) float64
+	rail        []math.Point3 // resampled to the path's count; nil ⇒ none
+	scaling     types.SweepProfileScaling
+	upAt        func(k int) (math.Vector3, bool) // guide-surface up; nil ⇒ none
+}
+
+// resolveSweepConfig validates and resolves the union fields against the
+// running bodies (the guide face) and the path.
+func (s *SweepFeature) resolveSweepConfig(in Input, path []math.Point3) (sweepConfig, error) {
+	d := s.def
+	cfg := sweepConfig{
+		orientation: d.Orientation, alignVec: d.AlignVector,
+		taper:   callOrZero(d.Taper),
+		twistAt: twistInterpolator(callOrZero(d.Twist), d.TwistStations),
+		scaling: d.Scaling,
+	}
+	if d.GuideRail != nil {
+		rail := d.GuideRail()
+		if rail == nil || rail.Count() < 2 {
+			return cfg, errors.New("sweep: the guide rail needs at least two points")
+		}
+		cfg.rail = resamplePolyline(rail.Points(), len(path))
+	}
+	if len(d.GuideFaceKey) > 0 {
+		up, err := guideSurfaceUp(in.Bodies, d.GuideFaceKey, path)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.upAt = up
+	}
+	if cfg.orientation == types.AlignToVector && float64(cfg.alignVec.Length()) == 0 {
+		return cfg, errors.New("sweep: alignToVector orientation needs a non-zero align vector")
+	}
+	return cfg, nil
+}
+
+// twistInterpolator builds θ(t): the station table when present (piecewise
+// linear, clamped), else the simple linear total twist.
+func twistInterpolator(total float64, stations []SweepTwistStation) func(float64) float64 {
+	if len(stations) == 0 {
+		return func(t float64) float64 { return total * t }
+	}
+	return func(t float64) float64 { return stationAngleAt(stations, t) }
+}
+
+// stationAngleAt evaluates the twist station table at t (stations are in
+// ascending T order; outside the table the end values hold).
+func stationAngleAt(st []SweepTwistStation, t float64) float64 {
+	if t <= st[0].T {
+		return st[0].Angle
+	}
+	for i := 0; i+1 < len(st); i++ {
+		if t <= st[i+1].T {
+			span := st[i+1].T - st[i].T
+			if span <= 0 {
+				return st[i+1].Angle
+			}
+			f := (t - st[i].T) / span
+			return st[i].Angle + f*(st[i+1].Angle-st[i].Angle)
+		}
+	}
+	return st[len(st)-1].Angle
+}
+
+// guideSurfaceUp resolves the guide face and returns the per-station up
+// direction: the face's surface normal nearest each path point.
+func guideSurfaceUp(bodies []*topo.Body, key []byte, path []math.Point3) (func(int) (math.Vector3, bool), error) {
+	face, ok := findFace(bodies, key)
+	if !ok {
+		return nil, fmt.Errorf("sweep: guide-surface face %q not found on the running bodies", key)
+	}
+	surf := face.Geometry()
+	return func(k int) (math.Vector3, bool) {
+		u, v := surf.ParamAt(path[k])
+		n := surf.NormalAt(u, v)
+		if l := float64(n.Length()); l > 0 {
+			return n.Scale(math.Scalar(1 / l)), true
+		}
+		return math.Vector3{}, false
+	}, nil
+}
+
+// resamplePolyline re-samples a polyline to n points by arc length.
+func resamplePolyline(pts []math.Point3, n int) []math.Point3 {
+	cum := make([]float64, len(pts))
+	for i := 1; i < len(pts); i++ {
+		cum[i] = cum[i-1] + float64(pts[i-1].DistanceTo(pts[i]))
+	}
+	total := cum[len(cum)-1]
+	out := make([]math.Point3, n)
+	for i := 0; i < n; i++ {
+		out[i] = polylinePointAt(pts, cum, total*float64(i)/float64(n-1))
+	}
+	return out
+}
+
+func polylinePointAt(pts []math.Point3, cum []float64, s float64) math.Point3 {
+	for i := 1; i < len(cum); i++ {
+		if s <= cum[i] {
+			span := cum[i] - cum[i-1]
+			if span == 0 {
+				return pts[i]
+			}
+			f := math.Scalar((s - cum[i-1]) / span)
+			return pts[i-1].TranslateBy(pts[i-1].VectorTo(pts[i]).Scale(f))
+		}
+	}
+	return pts[len(pts)-1]
+}
+
+// sweepSectionsCfg places the profile along the path under the resolved
+// config: orientation mode, twist, rail scaling/steering, guide-surface
+// steering, and the draft taper.
+func sweepSectionsCfg(prof *sketch.Profile, plane sketch.Plane, path []math.Point3, cfg sweepConfig) ([][]math.Point3, error) {
+	base := modelPolygon(prof, plane)
+	centroid := centroidOf(base)
+	normal := plane.Normal()
+	tangents := pathTangents(path)
+	arc := cumulativeArclength(path)
+	steer, err := newSweepSteering(cfg, path, tangents)
+	if err != nil {
+		return nil, err
+	}
+	miters := miterDirections(base, centroid, normal)
+	sections := make([][]math.Point3, len(path))
+	for k := range path {
+		sections[k] = sweepSectionAt(base, centroid, normal, miters, path, tangents, arc, cfg, steer, k)
+	}
+	return sections, nil
+}
+
+// sweepSectionAt builds one section: taper offset in profile space (so the
+// draft rides the section's rotation), base orientation, steering
+// (rail/surface), scaling, twist.
+func sweepSectionAt(base []math.Point3, centroid math.Point3, normal math.UnitVector3,
+	miters []math.Vector3, path []math.Point3, tangents []math.UnitVector3, arc []float64,
+	cfg sweepConfig, steer *sweepSteering, k int) []math.Point3 {
+	align := sectionAlign(cfg, normal, tangents, k)
+	axis := sectionAxis(cfg, normal, tangents, k)
+	t := arc[k] / arc[len(arc)-1]
+	twist := cfg.twistAt(t)
+	draft := stdmath.Tan(cfg.taper) * arc[k]
+	sec := make([]math.Point3, len(base))
+	for i, p := range base {
+		rel := centroid.VectorTo(p)
+		if draft != 0 {
+			rel = rel.Add(miters[i].Scale(math.Scalar(draft)))
+		}
+		v := align.TransformVector(rel)
+		v = steer.apply(v, k, axis)
+		if twist != 0 {
+			v = math.Rotation4(twist, axis, math.P3(0, 0, 0)).TransformVector(v)
+		}
+		sec[i] = path[k].TranslateBy(v)
+	}
+	return sec
+}
+
+// miterDirections precomputes, per profile vertex, the outward offset
+// direction scaled so a unit move offsets every WALL by exactly one unit —
+// the constant-draft taper semantics (a plain radial offset would move a
+// square's corners √2 farther than its walls, overstating the draft on flats
+// and understating it at corners).
+func miterDirections(base []math.Point3, centroid math.Point3, normal math.UnitVector3) []math.Vector3 {
+	n := len(base)
+	out := make([]math.Vector3, n)
+	for i := range base {
+		prev, next := base[(i-1+n)%n], base[(i+1)%n]
+		n1 := edgeOutNormal(prev, base[i], centroid, normal)
+		n2 := edgeOutNormal(base[i], next, centroid, normal)
+		bis := n1.Add(n2)
+		l := float64(bis.Length())
+		if l == 0 { // straight-through vertex: either normal works
+			out[i] = n1
+			continue
+		}
+		bis = bis.Scale(math.Scalar(1 / l))
+		cosHalf := float64(bis.Dot(n1))
+		if cosHalf < 0.1 {
+			cosHalf = 0.1 // cap the miter at very sharp corners (≈84°+ half-angle)
+		}
+		out[i] = bis.Scale(math.Scalar(1 / cosHalf))
+	}
+	return out
+}
+
+// edgeOutNormal is the in-plane unit normal of edge a→b pointing away from
+// the centroid.
+func edgeOutNormal(a, b, centroid math.Point3, normal math.UnitVector3) math.Vector3 {
+	e := a.VectorTo(b)
+	nrm := e.Cross(normal.AsVector())
+	if l := float64(nrm.Length()); l > 0 {
+		nrm = nrm.Scale(math.Scalar(1 / l))
+	}
+	mid := a.TranslateBy(e.Scale(0.5))
+	if float64(centroid.VectorTo(mid).Dot(nrm)) < 0 {
+		nrm = nrm.Scale(-1)
+	}
+	return nrm
+}
+
+// sectionAlign is the base profile rotation for the orientation mode.
+func sectionAlign(cfg sweepConfig, normal math.UnitVector3, tangents []math.UnitVector3, k int) math.Matrix4 {
+	switch cfg.orientation {
+	case types.ParallelToOriginalProfile:
+		return math.Identity4()
+	case types.AlignToVector:
+		u, err := math.UnitVector3FromVector(cfg.alignVec)
+		if err != nil {
+			return math.Identity4()
+		}
+		return math.RotateBetween(normal, u)
+	default: // NormalToPath
+		return math.RotateBetween(normal, tangents[k])
+	}
+}
+
+// sectionAxis is the twist/steering axis: the path tangent for normal-to-path
+// sweeps, the (fixed) section normal otherwise.
+func sectionAxis(cfg sweepConfig, normal math.UnitVector3, tangents []math.UnitVector3, k int) math.UnitVector3 {
+	switch cfg.orientation {
+	case types.ParallelToOriginalProfile:
+		return normal
+	case types.AlignToVector:
+		if u, err := math.UnitVector3FromVector(cfg.alignVec); err == nil {
+			return u
+		}
+		return normal
+	default:
+		return tangents[k]
+	}
+}
+
+// cumulativeArclength returns the running arclength at each path point.
+func cumulativeArclength(path []math.Point3) []float64 {
+	out := make([]float64, len(path))
+	for i := 1; i < len(path); i++ {
+		out[i] = out[i-1] + float64(path[i-1].DistanceTo(path[i]))
+	}
+	if out[len(out)-1] == 0 {
+		out[len(out)-1] = 1 // degenerate single-point guard for the t division
+	}
+	return out
+}
+
+// sweepSteering tracks a reference direction (rail vector or surface normal)
+// about the section axis: each section rotates so its local reference axis
+// follows the guide, and rail sweeps scale with the rail distance.
+type sweepSteering struct {
+	refs   []math.Vector3 // per-station target direction ⊥ axis (zero ⇒ none)
+	dists  []float64      // rail distance per station (scaling)
+	scale  types.SweepProfileScaling
+	hasRef bool
+}
+
+// newSweepSteering precomputes the per-station steering targets.
+func newSweepSteering(cfg sweepConfig, path []math.Point3, tangents []math.UnitVector3) (*sweepSteering, error) {
+	st := &sweepSteering{scale: cfg.scaling}
+	switch {
+	case cfg.rail != nil:
+		if err := st.fromRail(cfg, path, tangents); err != nil {
+			return nil, err
+		}
+	case cfg.upAt != nil:
+		st.fromSurface(cfg, path, tangents)
+	}
+	return st, nil
+}
+
+func (st *sweepSteering) fromRail(cfg sweepConfig, path []math.Point3, tangents []math.UnitVector3) error {
+	st.refs = make([]math.Vector3, len(path))
+	st.dists = make([]float64, len(path))
+	for k := range path {
+		ref := perpComponent(path[k].VectorTo(cfg.rail[k]), tangents[k])
+		d := float64(ref.Length())
+		if d < 1e-12 {
+			return fmt.Errorf("sweep: guide rail touches the path at station %d — rail and path must stay apart", k)
+		}
+		st.refs[k], st.dists[k] = ref, d
+	}
+	st.hasRef = true
+	return nil
+}
+
+func (st *sweepSteering) fromSurface(cfg sweepConfig, path []math.Point3, tangents []math.UnitVector3) {
+	st.refs = make([]math.Vector3, len(path))
+	for k := range path {
+		if n, ok := cfg.upAt(k); ok {
+			st.refs[k] = perpComponent(n, tangents[k])
+		}
+	}
+	st.scale = types.NoProfileScaling
+	st.hasRef = true
+}
+
+// apply steers one displacement vector at station k: rotate the section so the
+// station-0 reference direction tracks the station-k one, then scale per the
+// rail mode.
+func (st *sweepSteering) apply(v math.Vector3, k int, axis math.UnitVector3) math.Vector3 {
+	if !st.hasRef || float64(st.refs[0].Length()) == 0 || float64(st.refs[k].Length()) == 0 {
+		return v
+	}
+	phi := signedAngleAbout(st.refs[0], st.refs[k], axis)
+	if phi != 0 {
+		v = math.Rotation4(phi, axis, math.P3(0, 0, 0)).TransformVector(v)
+	}
+	return st.scaleBy(v, k)
+}
+
+// scaleBy applies the rail scaling: XY scales the whole section with the rail
+// distance, X only the component along the rail direction, none leaves size.
+func (st *sweepSteering) scaleBy(v math.Vector3, k int) math.Vector3 {
+	if st.dists == nil || st.scale == types.NoProfileScaling {
+		return v
+	}
+	f := st.dists[k] / st.dists[0]
+	if st.scale == types.XProfileScaling {
+		dir := st.refs[k].Scale(math.Scalar(1 / st.refs[k].Length()))
+		along := dir.Scale(v.Dot(dir))
+		return v.Sub(along).Add(along.Scale(math.Scalar(f)))
+	}
+	return v.Scale(math.Scalar(f)) // XY (the default)
+}
+
+// perpComponent removes the axis-parallel part of v.
+func perpComponent(v math.Vector3, axis math.UnitVector3) math.Vector3 {
+	a := axis.AsVector()
+	return v.Sub(a.Scale(v.Dot(a)))
+}
+
+// signedAngleAbout is the signed rotation from a to b about axis (both ⊥ axis).
+func signedAngleAbout(a, b math.Vector3, axis math.UnitVector3) float64 {
+	la, lb := float64(a.Length()), float64(b.Length())
+	if la == 0 || lb == 0 {
+		return 0
+	}
+	cos := float64(a.Dot(b)) / (la * lb)
+	cos = stdmath.Max(-1, stdmath.Min(1, cos))
+	angle := stdmath.Acos(cos)
+	if float64(a.Cross(b).Dot(axis.AsVector())) < 0 {
+		angle = -angle
+	}
+	return angle
+}
+
+// --- solid sweep -------------------------------------------------------------
+
+// recomputeSolidSweep drags the tool BODY along the path: the swept volume is
+// the union of tool stamps at path samples dense enough that consecutive
+// stamps overlap (step ≤ half the tool's smallest extent), translation only —
+// the discrete swept-envelope construction.
+func (s *SweepFeature) recomputeSolidSweep(in Input) (Output, error) {
+	idx := *s.def.SolidToolIndex
+	if idx < 0 || idx >= len(in.Bodies) {
+		return Output{}, fmt.Errorf("sweep: solid tool body %d out of range (%d bodies)", idx, len(in.Bodies))
+	}
+	toolSrc := in.Bodies[idx]
+	path, err := s.resolvePathPoints()
+	if err != nil {
+		return Output{}, err
+	}
+	swept, err := sweptToolEnvelope(toolSrc, path, featOr(s.featName, "sweep"))
+	if err != nil {
+		return Output{}, err
+	}
+	s.tool = swept
+	bodies, err := combine(in.Bodies, swept, s.def.Operation)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// resolvePathPoints resolves and validates the definition's path.
+func (s *SweepFeature) resolvePathPoints() ([]math.Point3, error) {
+	if s.def.Path == nil {
+		return nil, errors.New("sweep: path needs at least two points")
+	}
+	path := s.def.Path()
+	if path == nil || path.Count() < 2 {
+		return nil, errors.New("sweep: path needs at least two points")
+	}
+	return path.Points(), nil
+}
+
+// sweptToolEnvelope unions translated tool stamps along the path.
+func sweptToolEnvelope(tool *topo.Body, path []math.Point3, feat string) (*topo.Body, error) {
+	samples := stampStations(tool, path)
+	origin := samples[0]
+	swept, err := stampAt(tool, origin, origin, feat, 0)
+	if err != nil {
+		return nil, err
+	}
+	for i := 1; i < len(samples); i++ {
+		stamp, err := stampAt(tool, origin, samples[i], feat, i)
+		if err != nil {
+			return nil, err
+		}
+		if swept, err = ops.Boolean(ops.Join, swept, stamp); err != nil {
+			return nil, fmt.Errorf("sweep: stamp %d union failed: %w", i, err)
+		}
+	}
+	return swept, nil
+}
+
+// stampStations resamples the path so consecutive stamps overlap: the step is
+// half the tool's smallest range-box extent.
+func stampStations(tool *topo.Body, path []math.Point3) []math.Point3 {
+	d := tool.RangeBox().Diagonal()
+	minExtent := stdmath.Min(stdmath.Min(stdmath.Abs(float64(d.X)), stdmath.Abs(float64(d.Y))), stdmath.Abs(float64(d.Z)))
+	cum := cumulativeArclength(path)
+	total := cum[len(cum)-1]
+	step := minExtent / 2
+	if step <= 0 {
+		step = total / 8
+	}
+	n := int(stdmath.Ceil(total/step)) + 1
+	if n < len(path) {
+		n = len(path)
+	}
+	return resamplePolyline(path, n)
+}
+
+// stampAt translates the tool from the path origin to a station (identity
+// lineage at station 0 so the first stamp IS the tool's footprint there).
+func stampAt(tool *topo.Body, origin, at math.Point3, feat string, i int) (*topo.Body, error) {
+	m := math.Translation4(origin.VectorTo(at))
+	return ops.TransformBody(tool, m, func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append(l.Tokens(), topo.Tok(feat, "stamp", i))...)
+	})
+}

--- a/model/feature/sweep_variants_test.go
+++ b/model/feature/sweep_variants_test.go
@@ -253,4 +253,3 @@ func TestSolidSweepExtendsBox(t *testing.T) {
 		t.Errorf("definition type = %v, want solid", def.DefinitionType())
 	}
 }
-

--- a/model/feature/sweep_variants_test.go
+++ b/model/feature/sweep_variants_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// The sweep definition union (M08 PBI-094, #314): taper, orientation modes,
+// section twists, guide rail scaling, guide surface, solid sweep.
+
+// straightZPath is a straight path up Z of the given length, sampled densely
+// enough for the per-section machinery.
+func straightZPath(length float64, samples int) *sketch.Path3D {
+	pts := make([]*sketch.Point3D, samples+1)
+	for i := 0; i <= samples; i++ {
+		z := length * float64(i) / float64(samples)
+		pts[i] = sketch.NewPoint3D(math.P3(0, 0, math.Scalar(z)))
+	}
+	return sketch.NewPath3D(pts, false)
+}
+
+func sweepDefRecompute(t *testing.T, fs *PartFeatures, def *SweepDefinition) *topo.Body {
+	t.Helper()
+	sf := &SweepFeature{def: def}
+	pf := fs.Add(sf)
+	pf.SetName(fs.UniqueName("Sweep"))
+	sf.featName = pf.name
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("sweep sick: %+v", pf.Health())
+	}
+	body := fs.Result()[len(fs.Result())-1]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("swept body not a valid solid: %+v", r)
+	}
+	return body
+}
+
+// bodyVolume is the tessellated volume at display quality.
+func bodyVolume(b *topo.Body) float64 {
+	return ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+}
+
+// TestSweepTaperFrustum: a tapered straight sweep of a square is the analytic
+// draft solid — side(s) = a + 2·tan(τ)·s, V = ∫ side² ds.
+func TestSweepTaperFrustum(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	const a, L, taper = 2.0, 5.0, 0.1
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(sketch.XYPlane(), a/2), ProfileIndex: 0,
+		Path:      func() *sketch.Path3D { return straightZPath(L, 16) },
+		Taper:     func() float64 { return taper },
+		Operation: ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	tt := stdmath.Tan(taper)
+	want := a*a*L + 2*a*tt*L*L + 4.0/3*tt*tt*L*L*L // ∫(a+2τs)² ds
+	if got := bodyVolume(body); relErr(got, want) > 0.01 {
+		t.Errorf("tapered sweep volume = %g, want ≈%g", got, want)
+	}
+}
+
+// TestSweepParallelOrientationShears: sweeping parallel-to-profile along a
+// diagonal path SHEARS the prism (sections stay horizontal), so its volume is
+// base area × HEIGHT, not base area × path length.
+func TestSweepParallelOrientationShears(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	diag := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(0, 0, 0)),
+		sketch.NewPoint3D(math.P3(3, 0, 4)), // length 5, height 4
+	}, false)
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(sketch.XYPlane(), 1), ProfileIndex: 0,
+		Path:        func() *sketch.Path3D { return diag },
+		Orientation: types.ParallelToOriginalProfile,
+		Operation:   ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	if got := bodyVolume(body); relErr(got, 4*4) > 0.02 { // area 4 × height 4
+		t.Errorf("sheared parallel sweep volume = %g, want ≈16 (area×height)", got)
+	}
+}
+
+// TestSweepSectionTwistsHold: a station table that twists to 90° by mid-path
+// and holds keeps the prism volume (rigid sections) and stays valid.
+func TestSweepSectionTwistsHold(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(sketch.XYPlane(), 1), ProfileIndex: 0,
+		Path: func() *sketch.Path3D { return straightZPath(6, 24) },
+		TwistStations: []SweepTwistStation{
+			{T: 0, Angle: 0}, {T: 0.5, Angle: stdmath.Pi / 2}, {T: 1, Angle: stdmath.Pi / 2},
+		},
+		Operation: ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	if got := bodyVolume(body); relErr(got, 4*6) > 0.03 {
+		t.Errorf("section-twist sweep volume = %g, want ≈24", got)
+	}
+	if def.DefinitionType() != types.PathAndSectionTwistsSweepDef {
+		t.Errorf("definition type = %v, want pathAndSectionTwists", def.DefinitionType())
+	}
+}
+
+// TestSweepGuideRailScalesXY: a rail diverging linearly from the path scales
+// the section linearly — the analytic square frustum.
+func TestSweepGuideRailScalesXY(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	const a, L = 2.0, 6.0
+	rail := func() *sketch.Path3D { // x = 2 at s=0 → x = 4 at s=L: scale 1 → 2
+		return sketch.NewPath3D([]*sketch.Point3D{
+			sketch.NewPoint3D(math.P3(2, 0, 0)),
+			sketch.NewPoint3D(math.P3(4, 0, L)),
+		}, false)
+	}
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(sketch.XYPlane(), a/2), ProfileIndex: 0,
+		Path:      func() *sketch.Path3D { return straightZPath(L, 16) },
+		GuideRail: rail,
+		Scaling:   types.XYProfileScaling,
+		Operation: ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	// Square side a at the base, 2a at the top: the frustum V = L/3·(A1+A2+√(A1·A2)).
+	a1, a2 := a*a, 4*a*a
+	want := L / 3 * (a1 + a2 + stdmath.Sqrt(a1*a2))
+	if got := bodyVolume(body); relErr(got, want) > 0.02 {
+		t.Errorf("rail-scaled sweep volume = %g, want ≈%g (frustum)", got, want)
+	}
+	if def.DefinitionType() != types.PathAndGuideRailSweepDef {
+		t.Errorf("definition type = %v, want pathAndGuideRail", def.DefinitionType())
+	}
+}
+
+// TestSweepGuideRailNoScaling: the same diverging rail with scaling "none"
+// keeps the prism size (the rail steers orientation only).
+func TestSweepGuideRailNoScaling(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	rail := func() *sketch.Path3D {
+		return sketch.NewPath3D([]*sketch.Point3D{
+			sketch.NewPoint3D(math.P3(2, 0, 0)),
+			sketch.NewPoint3D(math.P3(4, 0, 6)),
+		}, false)
+	}
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(sketch.XYPlane(), 1), ProfileIndex: 0,
+		Path:      func() *sketch.Path3D { return straightZPath(6, 16) },
+		GuideRail: rail,
+		Scaling:   types.NoProfileScaling,
+		Operation: ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	if got := bodyVolume(body); relErr(got, 4*6) > 0.02 {
+		t.Errorf("unscaled rail sweep volume = %g, want ≈24", got)
+	}
+}
+
+// TestSweepGuideRailTouchingPathSick: a rail crossing the path is a precise error.
+func TestSweepGuideRailTouchingPathSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	rail := func() *sketch.Path3D {
+		return sketch.NewPath3D([]*sketch.Point3D{
+			sketch.NewPoint3D(math.P3(0, 0, 0)), // ON the path at s=0
+			sketch.NewPoint3D(math.P3(2, 0, 6)),
+		}, false)
+	}
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(sketch.XYPlane(), 1), ProfileIndex: 0,
+		Path:      func() *sketch.Path3D { return straightZPath(6, 8) },
+		GuideRail: rail,
+		Operation: ops.NewBody,
+	}
+	sf := &SweepFeature{def: def}
+	pf := fs.Add(sf)
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Fatal("a rail touching the path must go sick")
+	}
+}
+
+// TestSweepGuideSurfaceConstantNormal: a planar guide face (constant normal)
+// steers without distorting — prism volume preserved, type discriminated.
+func TestSweepGuideSurfaceConstantNormal(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	// Base body whose +X face guides the sweep.
+	base := centeredSquareOn(sketch.XYPlane(), 4)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(base, 0, ops.NewBody, func() float64 { return 1 })
+	fs.Recompute()
+	var guideKey []byte
+	for _, f := range fs.Result()[0].Faces() {
+		n := f.Geometry().NormalAt(0, 0)
+		if float64(n.X) > 0.9 {
+			guideKey = f.ReferenceKey()
+		}
+	}
+	if guideKey == nil {
+		t.Fatal("no +X face on the base body")
+	}
+	def := &SweepDefinition{
+		Sketch: centeredSquareOn(planeAtZ(2), 1), ProfileIndex: 0,
+		Path:         func() *sketch.Path3D { return straightZPathFrom(2, 6, 12) },
+		GuideFaceKey: guideKey,
+		Operation:    ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	if got := bodyVolume(body); relErr(got, 4*6) > 0.03 {
+		t.Errorf("guide-surface sweep volume = %g, want ≈24", got)
+	}
+	if def.DefinitionType() != types.PathAndGuideSurfaceSweepDef {
+		t.Errorf("definition type = %v, want pathAndGuideSurface", def.DefinitionType())
+	}
+}
+
+// straightZPathFrom is a straight path from z0 up Z.
+func straightZPathFrom(z0, length float64, samples int) *sketch.Path3D {
+	pts := make([]*sketch.Point3D, samples+1)
+	for i := 0; i <= samples; i++ {
+		z := z0 + length*float64(i)/float64(samples)
+		pts[i] = sketch.NewPoint3D(math.P3(0, 0, math.Scalar(z)))
+	}
+	return sketch.NewPath3D(pts, false)
+}
+
+// TestSolidSweepExtendsBox: dragging a unit-cube tool body along a straight
+// 4-long X path sweeps the exact 5×1×1 envelope.
+func TestSolidSweepExtendsBox(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(centeredSquareOn(sketch.XYPlane(), 0.5), 0, ops.NewBody, func() float64 { return 1 })
+	fs.Recompute()
+	toolIdx := 0
+	xPath := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(0, 0, 0)),
+		sketch.NewPoint3D(math.P3(4, 0, 0)),
+	}, false)
+	def := &SweepDefinition{
+		Path:           func() *sketch.Path3D { return xPath },
+		SolidToolIndex: &toolIdx,
+		Operation:      ops.NewBody,
+	}
+	body := sweepDefRecompute(t, fs, def)
+	if got := bodyVolume(body); relErr(got, 5*1*1) > 0.01 {
+		t.Errorf("solid sweep envelope = %g, want 5 (1×1 cube dragged 4)", got)
+	}
+	if def.DefinitionType() != types.SolidSweepDef {
+		t.Errorf("definition type = %v, want solid", def.DefinitionType())
+	}
+}
+


### PR DESCRIPTION
## What

Completes milestone M08 (Part Modeling: Sketched & Work Features) — the five open issues, one commit per PBI:

- **#313 revolve**: the two-directional revolve — `Angle2` sweeps the opposite sense, spanning `[-angle2, +angle1]` and collapsing to the closed full revolution at a combined turn. Wired through the collection API, all three restore paths, the registry args, with half-washer/z-symmetry/full-turn-collapse/reopen tests. (Full vs angular and serialization already shipped; this was the open scope item.)
- **#314 sweep**: the discriminated definition union the api-parity audit scoped, keyed by the frozen enums merged in Oblikovati.API: orientation modes (normal-to-path / parallel / align-to-vector), constant-draft taper (mitered polygon offset — a radial offset overstates the draft on flats by √2), piecewise twist stations, guide rails with xy/x/none scaling (precise error when the rail touches the path), guide surfaces locking the section's up vector to a face normal, and solid sweeps dragging a tool body as a union of overlapping stamps. Full persistence + registry union args + analytic model tests (draft volume integral, shear, rail frustum, dragged-cube envelope) + router tests per variant.
- **#315 loft**: the model layer (rails, centerline, area graph, map curves, conditions, closed, point/face sections) shipped previously with eight test files; this adds the missing public-surface pin — a two-section loft with a guide rail and tangent end condition through `features.add`, validated over `body.validate`.
- **#316 coil & rib**: the coil accepts any two of pitch/revolutions/height (overdetermined and underdetermined are precise errors) and its taper — persisted since M06 but never applied — now grows the helix radius by tan(taper)·rise (pinned by range-box growth). The rib gains to-next: each path point ray-casts along the signed normal and the farthest first-hit governs so the wall fully lands; no material ahead is a per-point error.
- **#305** is the F03 parent — all five PBIs (092 was already closed) are now delivered.

Serves the contract merged as Oblikovati.API#69 (frozen sweep vocabulary). Lint 0 issues; full suite green.

Closes #305, closes #313, closes #314, closes #315, closes #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)