### PR TITLE
M09: dress-up & pattern features — fillet sets, thread tables, boss, split, face edits, direct edit

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -5,9 +5,11 @@ package opregistry
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
 
@@ -17,19 +19,36 @@ import (
 // recomputes. They are how an MCP driver exercises the subtractive kernel end to end.
 
 // edgeDressArgs is the shared shape of the edge-referencing operations (fillet, chamfer).
+// EdgeSets is fillet-only: the edge-set form (#323), taking precedence over the flat
+// edgeRefs+radius pair.
 type edgeDressArgs struct {
-	EdgeRefs []string `json:"edgeRefs"`
-	Radius   string   `json:"radius,omitempty"`   // fillet
-	Distance string   `json:"distance,omitempty"` // chamfer
+	EdgeRefs []string        `json:"edgeRefs"`
+	Radius   string          `json:"radius,omitempty"`   // fillet
+	Distance string          `json:"distance,omitempty"` // chamfer
+	EdgeSets []filletSetArgs `json:"edgeSets,omitempty"` // fillet
+}
+
+// filletSetArgs is one fillet edge set over the wire: constant (radius) or variable
+// (startRadius+endRadius over exactly one edge).
+type filletSetArgs struct {
+	EdgeRefs    []string `json:"edgeRefs"`
+	Radius      string   `json:"radius,omitempty"`
+	StartRadius string   `json:"startRadius,omitempty"`
+	EndRadius   string   `json:"endRadius,omitempty"`
 }
 
 const filletSchema = `{
   "type": "object",
   "properties": {
-    "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to round (from get_reference_keys)."},
-    "radius": {"type": "string", "description": "Fillet radius with units, e.g. \"3 mm\"."}
-  },
-  "required": ["edgeRefs", "radius"]
+    "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to round (from get_reference_keys). Flat form: one constant radius over these edges."},
+    "radius": {"type": "string", "description": "Fillet radius with units, e.g. \"3 mm\" (flat form)."},
+    "edgeSets": {"type": "array", "minItems": 1, "description": "Edge-set form (takes precedence over edgeRefs): any mix of constant and variable radius sets.", "items": {"type": "object", "properties": {
+      "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+      "radius": {"type": "string", "description": "Constant radius for this set, e.g. \"3 mm\"."},
+      "startRadius": {"type": "string", "description": "Variable set: radius at the edge's start vertex (the set holds exactly one edge)."},
+      "endRadius": {"type": "string", "description": "Variable set: radius at the edge's end vertex."}
+    }, "required": ["edgeRefs"]}}
+  }
 }`
 
 const chamferSchema = `{
@@ -58,8 +77,15 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, err
 	}
+	if len(in.EdgeSets) > 0 {
+		sets, err := filletSetsFromArgs(part, in.EdgeSets)
+		if err != nil {
+			return nil, err
+		}
+		return recomputeResult(part, feature.NewDressUpFeatures(part.Features()).AddFilletSets(sets))
+	}
 	if len(in.EdgeRefs) == 0 {
-		return nil, errors.New("fillet: edgeRefs is empty")
+		return nil, errors.New("fillet: edgeRefs is empty (give edgeRefs+radius or edgeSets)")
 	}
 	r, err := lengthClosure(part, in.Radius, "fillet: radius")
 	if err != nil {
@@ -67,6 +93,42 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	}
 	pf := feature.NewDressUpFeatures(part.Features()).AddFillet(refKeys(in.EdgeRefs), r)
 	return recomputeResult(part, pf)
+}
+
+// filletSetsFromArgs decodes the edge-set form: each set is constant (radius) or variable
+// (startRadius+endRadius); giving both or neither is a precise error.
+func filletSetsFromArgs(part *compdef.PartComponentDefinition, args []filletSetArgs) ([]feature.FilletEdgeSet, error) {
+	out := make([]feature.FilletEdgeSet, len(args))
+	for i, a := range args {
+		if len(a.EdgeRefs) == 0 {
+			return nil, fmt.Errorf("fillet: edgeSets[%d].edgeRefs is empty", i)
+		}
+		radii, err := filletSetRadii(part, a, i)
+		if err != nil {
+			return nil, err
+		}
+		radii.EdgeKeys = refKeys(a.EdgeRefs)
+		out[i] = radii
+	}
+	return out, nil
+}
+
+// filletSetRadii resolves one set's radius closures from its constant or variable spelling.
+func filletSetRadii(part *compdef.PartComponentDefinition, a filletSetArgs, i int) (feature.FilletEdgeSet, error) {
+	hasConst, hasVar := a.Radius != "", a.StartRadius != "" || a.EndRadius != ""
+	if hasConst == hasVar {
+		return feature.FilletEdgeSet{}, fmt.Errorf("fillet: edgeSets[%d] needs radius OR startRadius+endRadius (got radius=%q start=%q end=%q)", i, a.Radius, a.StartRadius, a.EndRadius)
+	}
+	if hasConst {
+		r, err := lengthClosure(part, a.Radius, "fillet: radius")
+		return feature.FilletEdgeSet{Radius: r}, err
+	}
+	r0, err := lengthClosure(part, a.StartRadius, "fillet: startRadius")
+	if err != nil {
+		return feature.FilletEdgeSet{}, err
+	}
+	r1, err := lengthClosure(part, a.EndRadius, "fillet: endRadius")
+	return feature.FilletEdgeSet{StartRadius: r0, EndRadius: r1}, err
 }
 
 func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -372,19 +372,21 @@ func partingAxis(name string) feature.PartingAxis {
 type splitSolidArgs struct {
 	WorkPlaneIndex int    `json:"workPlaneIndex"`
 	Keep           string `json:"keep,omitempty"`
+	Type           string `json:"type,omitempty"` // frozen types.SplitType spelling (#330)
 }
 
 const splitSolidSchema = `{
   "type": "object",
   "properties": {
     "workPlaneIndex": {"type": "integer", "minimum": 0, "description": "Index of the work plane to split along (see list_work_planes)."},
-    "keep": {"type": "string", "enum": ["both", "positive", "negative"], "default": "both", "description": "Which side(s) of the plane to keep."}
+    "keep": {"type": "string", "enum": ["both", "positive", "negative"], "default": "both", "description": "Which side(s) of the plane to keep (trim modes)."},
+    "type": {"type": "string", "enum": ["trimSolid", "splitFaces", "splitBody"], "description": "Split kind: trimSolid keeps one side (per keep, default positive); splitFaces imprints the plane onto the faces without removing material; splitBody keeps both pieces as separate solids. Absent: derived from keep."}
   },
   "required": ["workPlaneIndex"]
 }`
 
 func splitSolidDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: "splitSolid", Summary: "Split the solid along a work plane, keeping one or both halves.", Schema: json.RawMessage(splitSolidSchema), Apply: applySplitSolid}
+	return &OperationDescriptor{Name: "splitSolid", Summary: "Split the solid along a work plane: trim one side, split into bodies, or split faces only.", Schema: json.RawMessage(splitSolidSchema), Apply: applySplitSolid}
 }
 
 func applySplitSolid(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -400,8 +402,36 @@ func applySplitSolid(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	if in.WorkPlaneIndex < 0 || in.WorkPlaneIndex >= planes.Count() {
 		return nil, fmt.Errorf("splitSolid: work plane %d out of range (part has %d)", in.WorkPlaneIndex, planes.Count())
 	}
-	pf := feature.NewModifyFeatures(part.Features()).AddSplitSolid(planes.Item(in.WorkPlaneIndex), splitSide(in.Keep))
+	pf, err := addSplitOfType(part, planes.Item(in.WorkPlaneIndex), in)
+	if err != nil {
+		return nil, err
+	}
 	return recomputeResult(part, pf)
+}
+
+// addSplitOfType dispatches on the frozen split-type spelling; absent keeps the original
+// keep-driven behavior (both sides by default).
+func addSplitOfType(part *compdef.PartComponentDefinition, wp *feature.WorkPlane, in splitSolidArgs) (*feature.PartFeature, error) {
+	mods := feature.NewModifyFeatures(part.Features())
+	if in.Type == "" {
+		return mods.AddSplitSolid(wp, splitSide(in.Keep)), nil
+	}
+	st, ok := types.ParseSplitType(in.Type)
+	if !ok {
+		return nil, fmt.Errorf("splitSolid: unknown type %q (want trimSolid/splitFaces/splitBody)", in.Type)
+	}
+	switch st {
+	case types.SplitFacesSplit:
+		return mods.AddSplitFaces(wp), nil
+	case types.SplitBodySplit:
+		return mods.AddSplitSolid(wp, feature.SplitBoth), nil
+	default: // trimSolid keeps one side; "both" makes no sense here, default positive
+		side := splitSide(in.Keep)
+		if side == feature.SplitBoth {
+			side = feature.SplitPositive
+		}
+		return mods.AddSplitSolid(wp, side), nil
+	}
 }
 
 func splitSide(name string) feature.SplitSide {

--- a/addin/opregistry/feature_directedit.go
+++ b/addin/opregistry/feature_directedit.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// The consolidated direct-edit operation (M09-F04 PBI-108, #332): one descriptor
+// discriminated by the frozen DirectEditOperationType spellings.
+
+type directEditArgs struct {
+	Operation   string    `json:"operation"`
+	FaceRefs    []string  `json:"faceRefs,omitempty"`
+	Translation []float64 `json:"translation,omitempty"`
+	Direction   []float64 `json:"direction,omitempty"`
+	Distance    string    `json:"distance,omitempty"`
+	AxisPoint   []float64 `json:"axisPoint,omitempty"`
+	AxisDir     []float64 `json:"axisDir,omitempty"`
+	Angle       string    `json:"angle,omitempty"`
+	Scale       float64   `json:"scale,omitempty"`
+	Base        []float64 `json:"base,omitempty"`
+}
+
+const directEditSchema = `{
+  "type": "object",
+  "properties": {
+    "operation": {"type": "string", "enum": ["move", "size", "rotate", "delete", "scale"], "description": "Direct-edit operation (frozen DirectEditOperationType spellings)."},
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "description": "Picked faces (move/size/rotate/delete; get_reference_keys)."},
+    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "move: displacement [x,y,z] in cm."},
+    "direction": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "size: push/pull direction [x,y,z]."},
+    "distance": {"type": "string", "description": "size: push distance with units, e.g. \"3 mm\"."},
+    "axisPoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "rotate: a point on the axis [x,y,z] in cm."},
+    "axisDir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "rotate: the axis direction."},
+    "angle": {"type": "string", "description": "rotate: angle with units, e.g. \"10 deg\"."},
+    "scale": {"type": "number", "exclusiveMinimum": 0, "description": "scale: uniform factor applied to the running body."},
+    "base": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "scale: fixed base point [x,y,z] in cm (default origin)."}
+  },
+  "required": ["operation"]
+}`
+
+func directEditDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "directEdit", Summary: "Direct edit: move/size/rotate/delete picked faces, or scale the body uniformly.", Schema: json.RawMessage(directEditSchema), Apply: applyDirectEdit}
+}
+
+func applyDirectEdit(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in directEditArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	op, ok := types.ParseDirectEditOperationType(in.Operation)
+	if !ok {
+		return nil, fmt.Errorf("directEdit: unknown operation %q (want move/size/rotate/delete/scale)", in.Operation)
+	}
+	def, err := directEditDefinition(part, op, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewModifyFeatures(part.Features()).AddDirectEdit(def))
+}
+
+// directEditDefinition builds the definition for the operation, validating the
+// fields it needs.
+func directEditDefinition(part *compdef.PartComponentDefinition, op types.DirectEditOperationType, in directEditArgs) (*feature.DirectEditDefinition, error) {
+	def := &feature.DirectEditDefinition{Operation: op, FaceKeys: refKeys(in.FaceRefs)}
+	if op != types.DirectEditScaleOperation && len(in.FaceRefs) == 0 {
+		return nil, errors.New("directEdit: faceRefs is empty")
+	}
+	switch op {
+	case types.DirectEditMoveOperation:
+		t, err := vec3(in.Translation, "directEdit: translation")
+		if err != nil {
+			return nil, err
+		}
+		def.Translation = t
+	case types.DirectEditSizeOperation:
+		return directEditSize(part, def, in)
+	case types.DirectEditRotateOperation:
+		return directEditRotate(part, def, in)
+	case types.DirectEditScaleOperation:
+		if in.Scale <= 0 {
+			return nil, fmt.Errorf("directEdit: scale %g must be > 0", in.Scale)
+		}
+		def.ScaleFactor = constScale(in.Scale)
+		def.BasePoint = optionalPoint(in.Base)
+	}
+	return def, nil
+}
+
+func directEditSize(part *compdef.PartComponentDefinition, def *feature.DirectEditDefinition, in directEditArgs) (*feature.DirectEditDefinition, error) {
+	dir, err := vec3(in.Direction, "directEdit: direction")
+	if err != nil {
+		return nil, err
+	}
+	dist, err := lengthClosure(part, in.Distance, "directEdit: distance")
+	if err != nil {
+		return nil, err
+	}
+	def.Direction, def.Distance = dir, dist
+	return def, nil
+}
+
+func directEditRotate(part *compdef.PartComponentDefinition, def *feature.DirectEditDefinition, in directEditArgs) (*feature.DirectEditDefinition, error) {
+	p, err := point3(in.AxisPoint, "directEdit: axisPoint")
+	if err != nil {
+		return nil, err
+	}
+	dir, err := vec3(in.AxisDir, "directEdit: axisDir")
+	if err != nil {
+		return nil, err
+	}
+	angle, err := angleClosure(part, in.Angle, "directEdit: angle")
+	if err != nil {
+		return nil, err
+	}
+	def.AxisPoint, def.AxisDir, def.Angle = p, dir, angle
+	return def, nil
+}
+
+func constScale(v float64) func() float64 { return func() float64 { return v } }
+
+// optionalPoint reads a 3-coord point, defaulting to the origin when absent.
+func optionalPoint(s []float64) math.Point3 {
+	if len(s) != 3 {
+		return math.P3(0, 0, 0)
+	}
+	return math.P3(s[0], s[1], s[2])
+}

--- a/addin/opregistry/feature_extras.go
+++ b/addin/opregistry/feature_extras.go
@@ -5,8 +5,10 @@ package opregistry
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/model/feature"
 )
@@ -59,17 +61,23 @@ func applyBoss(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 }
 
 type threadArgs struct {
-	FaceRef     string `json:"faceRef"`
-	Designation string `json:"designation"`
-	Cut         bool   `json:"cut,omitempty"`
+	FaceRef       string `json:"faceRef"`
+	Designation   string `json:"designation"`
+	Cut           bool   `json:"cut,omitempty"`
+	Class         string `json:"class,omitempty"`
+	Tapered       bool   `json:"tapered,omitempty"`
+	ModelDiameter string `json:"modelDiameter,omitempty"`
 }
 
 const threadSchema = `{
   "type": "object",
   "properties": {
     "faceRef": {"type": "string", "description": "Reference key of the cylindrical face to thread (get_reference_keys)."},
-    "designation": {"type": "string", "description": "Thread designation, e.g. \"M8x1.25\"."},
-    "cut": {"type": "boolean", "default": false, "description": "false = cosmetic thread (display only); true = model a real cut thread (the face becomes a threaded surface)."}
+    "designation": {"type": "string", "description": "Thread designation, e.g. \"M8x1.25\" (enumerable via threads.tableQuery)."},
+    "cut": {"type": "boolean", "default": false, "description": "false = cosmetic thread (display only); true = model a real cut thread (the face becomes a threaded surface)."},
+    "class": {"type": "string", "description": "Tolerance class recorded on the spec, e.g. \"6H\" (enumerable via threads.tableQuery)."},
+    "tapered": {"type": "boolean", "default": false, "description": "Pipe-thread (tapered) data; a cut tapered thread is rejected — model it cosmetic."},
+    "modelDiameter": {"type": "string", "enum": ["major", "minor", "pitch", "tapDrill"], "description": "Which thread diameter the modeled face represents (default major)."}
   },
   "required": ["faceRef", "designation"]
 }`
@@ -90,6 +98,16 @@ func applyThread(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if in.FaceRef == "" || in.Designation == "" {
 		return nil, errors.New("thread: faceRef and designation are required")
 	}
-	pf := feature.NewDressUpFeatures(part.Features()).AddThread([]byte(in.FaceRef), in.Designation, in.Cut)
+	md := types.ModelDiameterFromThread(0)
+	if in.ModelDiameter != "" {
+		var ok bool
+		if md, ok = types.ParseModelDiameterFromThread(in.ModelDiameter); !ok {
+			return nil, fmt.Errorf("thread: unknown modelDiameter %q (want major/minor/pitch/tapDrill)", in.ModelDiameter)
+		}
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddThreadDef(&feature.ThreadDefinition{
+		FaceKey: []byte(in.FaceRef), Designation: in.Designation, Cut: in.Cut,
+		Class: in.Class, Tapered: in.Tapered, ModelDiameter: md,
+	})
 	return recomputeResult(part, pf)
 }

--- a/addin/opregistry/feature_modify.go
+++ b/addin/opregistry/feature_modify.go
@@ -5,8 +5,10 @@ package opregistry
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -58,12 +60,16 @@ func applyCombine(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 // --- thicken ---------------------------------------------------------------
 
 type thickenArgs struct {
-	Thickness string `json:"thickness"`
+	Thickness     string `json:"thickness"`
+	Approximation string `json:"approximation,omitempty"`
 }
 
 const thickenSchema = `{
   "type": "object",
-  "properties": {"thickness": {"type": "string", "description": "Wall thickness to add to the surface body, e.g. \"2 mm\"."}},
+  "properties": {
+    "thickness": {"type": "string", "description": "Wall thickness to add to the surface body, e.g. \"2 mm\"."},
+    "approximation": {"type": "string", "enum": ["none", "mean", "neverTooThick", "neverTooThin"], "description": "Accepted approximation (#331 parity); the kernel computes the exact offset, which satisfies every bound."}
+  },
   "required": ["thickness"]
 }`
 
@@ -84,8 +90,25 @@ func applyThicken(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
+	approx, err := approximationArg(in.Approximation, "thicken")
+	if err != nil {
+		return nil, err
+	}
 	pf := feature.NewModifyFeatures(part.Features()).AddThickenFn(th)
+	pf.Definition().(*feature.ThickenFeature).SetApproximation(approx)
 	return recomputeResult(part, pf)
+}
+
+// approximationArg parses the optional #331 approximation spelling (empty = none/exact).
+func approximationArg(s, op string) (types.FeatureApproximationType, error) {
+	if s == "" {
+		return 0, nil
+	}
+	a, ok := types.ParseFeatureApproximationType(s)
+	if !ok {
+		return 0, fmt.Errorf("%s: unknown approximation %q (want none/mean/neverTooThick/neverTooThin)", op, s)
+	}
+	return a, nil
 }
 
 // --- trim ------------------------------------------------------------------
@@ -134,25 +157,33 @@ func applyTrim(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 // --- face direct edits (move / offset / delete / split) --------------------
 
 type faceEditArgs struct {
-	FaceRefs    []string  `json:"faceRefs"`
-	Translation []float64 `json:"translation,omitempty"` // moveFace
-	Distance    string    `json:"distance,omitempty"`    // faceOffset
+	FaceRefs      []string  `json:"faceRefs"`
+	Translation   []float64 `json:"translation,omitempty"`   // moveFace translate
+	AxisPoint     []float64 `json:"axisPoint,omitempty"`     // moveFace rotate (#331)
+	AxisDir       []float64 `json:"axisDir,omitempty"`       // moveFace rotate
+	Angle         string    `json:"angle,omitempty"`         // moveFace rotate
+	Distance      string    `json:"distance,omitempty"`      // faceOffset
+	Approximation string    `json:"approximation,omitempty"` // faceOffset (#331)
 }
 
 const moveFaceSchema = `{
   "type": "object",
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to move (get_reference_keys)."},
-    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Move vector [x,y,z] in cm."}
+    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Translate mode: move vector [x,y,z] in cm."},
+    "axisPoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Rotate mode: a point on the rotation axis [x,y,z] in cm."},
+    "axisDir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Rotate mode: the rotation axis direction [x,y,z]."},
+    "angle": {"type": "string", "description": "Rotate mode: rotation angle with units, e.g. \"10 deg\"."}
   },
-  "required": ["faceRefs", "translation"]
+  "required": ["faceRefs"]
 }`
 
 const faceOffsetSchema = `{
   "type": "object",
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to offset (get_reference_keys)."},
-    "distance": {"type": "string", "description": "Offset distance with units, e.g. \"2 mm\"."}
+    "distance": {"type": "string", "description": "Offset distance with units, e.g. \"2 mm\"."},
+    "approximation": {"type": "string", "enum": ["none", "mean", "neverTooThick", "neverTooThin"], "description": "Accepted approximation (#331 parity); the kernel computes the exact offset, which satisfies every bound."}
   },
   "required": ["faceRefs", "distance"]
 }`
@@ -190,11 +221,32 @@ func applyMoveFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error)
 	if err != nil {
 		return nil, err
 	}
+	if in.Angle != "" || len(in.AxisDir) > 0 {
+		return applyMoveFaceRotate(part, in)
+	}
 	t, err := vec3(in.Translation, "moveFace: translation")
 	if err != nil {
 		return nil, err
 	}
 	pf := feature.NewModifyFeatures(part.Features()).AddMoveFace(refKeys(in.FaceRefs), t)
+	return recomputeResult(part, pf)
+}
+
+// applyMoveFaceRotate is the rotate arm (#331): axisPoint + axisDir + angle.
+func applyMoveFaceRotate(part *compdef.PartComponentDefinition, in faceEditArgs) (json.RawMessage, error) {
+	p, err := point3(in.AxisPoint, "moveFace: axisPoint")
+	if err != nil {
+		return nil, err
+	}
+	dir, err := vec3(in.AxisDir, "moveFace: axisDir")
+	if err != nil {
+		return nil, err
+	}
+	angle, err := angleClosure(part, in.Angle, "moveFace: angle")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddMoveFaceRotate(refKeys(in.FaceRefs), p, dir, angle)
 	return recomputeResult(part, pf)
 }
 
@@ -207,7 +259,11 @@ func applyFaceOffset(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewModifyFeatures(part.Features()).AddFaceOffsetFn(refKeys(in.FaceRefs), d)
+	approx, err := approximationArg(in.Approximation, "faceOffset")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddFaceOffsetApprox(refKeys(in.FaceRefs), d, approx)
 	return recomputeResult(part, pf)
 }
 

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -117,6 +117,7 @@ func Default() *Registry {
 		combineDescriptor(),
 		thickenDescriptor(),
 		trimDescriptor(),
+		directEditDescriptor(),
 		moveFaceDescriptor(),
 		faceOffsetDescriptor(),
 		deleteFaceDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -17,7 +17,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "hole", "boss", "thread",
-		"combine", "thicken", "trim", "moveFace", "faceOffset", "deleteFace", "split",
+		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "moveBody", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",

--- a/addin/router/direct_edit_test.go
+++ b/addin/router/direct_edit_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// The consolidated direct edit over the wire (M09-F04 PBI-108, #332).
+
+func TestDirectEditScaleOverWire(t *testing.T) {
+	r, s, _ := filletBoxFixture(t)
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", `{"kind":"directEdit","args":{"operation":"scale","scale":2,"base":[0,0,0]}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("scale bodies = %d, want 1", res.Bodies)
+	}
+	var box wire.BodyRangeBoxResult
+	call(t, r, s, "body.rangeBox", `{"bodyIndex":0}`, &box)
+	// 40×30×50 mm doubled about the origin → max corner (8, 6, 10) cm.
+	if box.Max[2] < 9.9 || box.Max[2] > 10.1 {
+		t.Errorf("scaled box max z = %g, want 10", box.Max[2])
+	}
+}
+
+func TestDirectEditSizeOverWire(t *testing.T) {
+	r, s, _ := filletBoxFixture(t)
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	var top string
+	for _, f := range keys.Bodies[0].Faces {
+		if len(f.Point) == 3 && f.Point[2] > 4.9 {
+			top = f.Key
+		}
+	}
+	args, _ := json.Marshal(map[string]interface{}{
+		"kind": "directEdit",
+		"args": map[string]interface{}{
+			"operation": "size", "faceRefs": []string{top},
+			"direction": []float64{0, 0, 1}, "distance": "10 mm",
+		},
+	})
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", string(args), &res)
+	if res.Bodies != 1 {
+		t.Fatalf("size bodies = %d, want 1", res.Bodies)
+	}
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("sized body invalid: %+v", v.Problems)
+	}
+
+	if _, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"directEdit","args":{"operation":"shrinkwrap"}}`)); err == nil {
+		t.Fatal("an unknown direct-edit operation must be rejected")
+	}
+}

--- a/addin/router/face_edit_m09_test.go
+++ b/addin/router/face_edit_m09_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// The #331 face-edit extensions over the wire: the moveFace rotate arm and the
+// faceOffset approximation input.
+
+func TestMoveFaceRotateOverWire(t *testing.T) {
+	r, s, _ := filletBoxFixture(t)
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	var top string
+	for _, f := range keys.Bodies[0].Faces {
+		if len(f.Point) == 3 && f.Point[2] > 4.9 {
+			top = f.Key
+		}
+	}
+	if top == "" {
+		t.Fatal("no top face found")
+	}
+	args, _ := json.Marshal(map[string]interface{}{
+		"kind": "moveFace",
+		"args": map[string]interface{}{
+			"faceRefs":  []string{top},
+			"axisPoint": []float64{0, 0, 5},
+			"axisDir":   []float64{0, 1, 0},
+			"angle":     "5 deg",
+		},
+	})
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", string(args), &res)
+	if res.Bodies != 1 {
+		t.Fatalf("rotate-face bodies = %d, want 1", res.Bodies)
+	}
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("rotated body invalid: %+v", v.Problems)
+	}
+}
+
+func TestFaceOffsetApproximationOverWire(t *testing.T) {
+	r, s, _ := filletBoxFixture(t)
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	face := keys.Bodies[0].Faces[0].Key
+	args, _ := json.Marshal(map[string]interface{}{
+		"kind": "faceOffset",
+		"args": map[string]interface{}{
+			"faceRefs": []string{face}, "distance": "2 mm", "approximation": "neverTooThick",
+		},
+	})
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", string(args), &res)
+	if res.Bodies != 1 {
+		t.Fatalf("faceOffset bodies = %d, want 1", res.Bodies)
+	}
+
+	bad, _ := json.Marshal(map[string]interface{}{
+		"kind": "faceOffset",
+		"args": map[string]interface{}{"faceRefs": []string{face}, "distance": "2 mm", "approximation": "sloppy"},
+	})
+	if _, err := r.Handle(s, "features.add", bad); err == nil {
+		t.Fatal("an unknown approximation must be rejected")
+	}
+}

--- a/addin/router/fillet_sets_test.go
+++ b/addin/router/fillet_sets_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// The fillet edge-set form over the wire (M09-F01 PBI-099, #323): features.add
+// fillet accepts edgeSets mixing constant and variable radius sets.
+
+// filletBoxFixture extrudes a 40×30×50 mm box and returns the reference keys
+// of its vertical edges (midpoint z = 2.5 cm).
+func filletBoxFixture(t *testing.T) (*Router, *app.Session, []string) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	var vertical []string
+	for _, e := range keys.Bodies[0].Edges {
+		if len(e.Point) == 3 && e.Point[2] > 2.4 && e.Point[2] < 2.6 {
+			vertical = append(vertical, e.Key)
+		}
+	}
+	if len(vertical) != 4 {
+		t.Fatalf("vertical edges = %d, want 4", len(vertical))
+	}
+	return r, s, vertical
+}
+
+type filletSetsAddResult struct {
+	Bodies int `json:"bodies"`
+}
+
+// TestFilletEdgeSetsOverWire adds a constant + variable edge-set fillet via
+// features.add (keys carry raw bytes, so the args are marshalled, not quoted).
+func TestFilletEdgeSetsOverWire(t *testing.T) {
+	r, s, vertical := filletBoxFixture(t)
+	args, _ := json.Marshal(map[string]interface{}{
+		"kind": "fillet",
+		"args": map[string]interface{}{
+			"edgeSets": []map[string]interface{}{
+				{"edgeRefs": []string{vertical[0]}, "radius": "4 mm"},
+				{"edgeRefs": []string{vertical[1]}, "startRadius": "2 mm", "endRadius": "7 mm"},
+			},
+		},
+	})
+	var res filletSetsAddResult
+	call(t, r, s, "features.add", string(args), &res)
+	if res.Bodies != 1 {
+		t.Fatalf("edge-set fillet bodies = %d, want 1", res.Bodies)
+	}
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("edge-set filleted body invalid: %+v", v.Problems)
+	}
+}
+
+// TestFilletEdgeSetRejectsMixedSpelling: a set giving both a constant radius
+// and a variable pair is a precise error.
+func TestFilletEdgeSetRejectsMixedSpelling(t *testing.T) {
+	r, s, vertical := filletBoxFixture(t)
+	args, _ := json.Marshal(map[string]interface{}{
+		"kind": "fillet",
+		"args": map[string]interface{}{
+			"edgeSets": []map[string]interface{}{
+				{"edgeRefs": []string{vertical[0]}, "radius": "4 mm", "startRadius": "2 mm", "endRadius": "7 mm"},
+			},
+		},
+	})
+	if _, err := r.Handle(s, "features.add", args); err == nil {
+		t.Fatal("a set with both radius and startRadius/endRadius must be rejected")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -83,6 +83,8 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodModelTree] = modelTree
 	r.handlers[wire.MethodModelSelection] = modelSelection
 	r.handlers[wire.MethodModelReferenceKeys] = referenceKeys
+	r.handlers[wire.MethodThreadsTableQuery] = threadsTableQuery
+	r.handlers[wire.MethodThreadsResolve] = threadsResolve
 	r.registerSketchHandlers()
 	r.registerFeatureHandlers()
 	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes

--- a/addin/router/split_combine_m09_test.go
+++ b/addin/router/split_combine_m09_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// The #330 acceptance over the wire: a body splits into multiple solids
+// (typed with the frozen SplitType spellings) and two bodies combine.
+
+// splitFixture extrudes a 40×30×50 mm box and adds a z=25 mm offset work plane.
+func splitFixture(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"25 mm"}`, &wire.CreateWorkPlaneResult{})
+	return r, s
+}
+
+type splitAddResult struct {
+	Bodies int `json:"bodies"`
+}
+
+// TestSplitBodyThenCombineOverWire: type splitBody yields two solids; combine
+// joins them back into one.
+func TestSplitBodyThenCombineOverWire(t *testing.T) {
+	r, s := splitFixture(t)
+	var res splitAddResult
+	call(t, r, s, "features.add", `{"kind":"splitSolid","args":{"workPlaneIndex":3,"type":"splitBody"}}`, &res)
+	if res.Bodies != 2 {
+		t.Fatalf("splitBody bodies = %d, want 2", res.Bodies)
+	}
+	var joined splitAddResult
+	call(t, r, s, "features.add", `{"kind":"combine","args":{"targetIndex":0,"toolIndex":1,"operation":"join"}}`, &joined)
+	if joined.Bodies != 1 {
+		t.Fatalf("combine bodies = %d, want 1", joined.Bodies)
+	}
+}
+
+// TestSplitFacesOverWire: type splitFaces keeps one body (volume untouched)
+// but the box gains the imprint faces.
+func TestSplitFacesOverWire(t *testing.T) {
+	r, s := splitFixture(t)
+	var res splitAddResult
+	call(t, r, s, "features.add", `{"kind":"splitSolid","args":{"workPlaneIndex":3,"type":"splitFaces"}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("splitFaces bodies = %d, want 1", res.Bodies)
+	}
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	if n := len(keys.Bodies[0].Faces); n != 10 {
+		t.Errorf("imprinted box faces = %d, want 10", n)
+	}
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("imprinted body invalid: %+v", v.Problems)
+	}
+}
+
+// TestSplitTrimSolidOverWire: type trimSolid keeps one side (default positive).
+func TestSplitTrimSolidOverWire(t *testing.T) {
+	r, s := splitFixture(t)
+	var res splitAddResult
+	call(t, r, s, "features.add", `{"kind":"splitSolid","args":{"workPlaneIndex":3,"type":"trimSolid"}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("trimSolid bodies = %d, want 1", res.Bodies)
+	}
+	if _, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"splitSolid","args":{"workPlaneIndex":3,"type":"halve"}}`)); err == nil {
+		t.Fatal("an unknown split type must be rejected")
+	}
+}

--- a/addin/router/threads.go
+++ b/addin/router/threads.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"errors"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// The thread table wire surface (M09-F01 PBI-101, #325): threads.tableQuery
+// enumerates the thread tables progressively and threads.resolve turns a
+// designation into the thread data the thread feature, hole tapping (#326),
+// and drawings (M14) consume — one source of truth, served from the same
+// tables [feature.ParseThreadDesignation] resolves against.
+
+// threadsTableQuery lists thread types always; a type's nominal sizes, a
+// size's designations, and a designation's classes as each filter is given.
+func threadsTableQuery(_ *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ThreadTableQueryArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &in); err != nil {
+			return nil, err
+		}
+	}
+	out := wire.ThreadTableQueryResult{ThreadTypes: feature.ThreadTypes()}
+	if err := fillThreadLevels(&out, in); err != nil {
+		return nil, err
+	}
+	return json.Marshal(out)
+}
+
+// fillThreadLevels resolves the size/designation/class levels the filters unlock. The
+// class level derives its table from the designation itself, so it works without
+// threadType.
+func fillThreadLevels(out *wire.ThreadTableQueryResult, in wire.ThreadTableQueryArgs) error {
+	var err error
+	if in.ThreadType != "" {
+		if out.NominalSizes, err = feature.ThreadNominalSizes(in.ThreadType); err != nil {
+			return err
+		}
+		if in.NominalSize != "" {
+			if out.Designations, err = feature.ThreadDesignationsOf(in.ThreadType, in.NominalSize); err != nil {
+				return err
+			}
+		}
+	}
+	if in.Designation == "" {
+		return nil
+	}
+	tt, err := feature.ThreadTypeOfDesignation(in.Designation)
+	if err != nil {
+		return err
+	}
+	out.Classes, err = feature.ThreadClasses(tt, in.Internal)
+	return err
+}
+
+// threadsResolve resolves a designation (+class/handedness/tapered) to its thread data.
+func threadsResolve(_ *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ResolveThreadArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Designation == "" {
+		return nil, errors.New("threads.resolve: designation is required")
+	}
+	spec, err := feature.ParseThreadDesignation(in.Designation)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ThreadInfoResult{
+		Designation: spec.Designation, ThreadType: spec.ThreadType, NominalSize: spec.NominalSize,
+		Class: in.Class, Metric: spec.Metric, Internal: in.Internal,
+		RightHanded: spec.RightHanded && !in.LeftHanded, Tapered: in.Tapered,
+		Pitch: spec.Pitch, MajorDiameter: spec.MajorDiameter, MinorDiameter: spec.MinorDiameter,
+		PitchDiameter: spec.PitchDiameter, TapDrillDiameter: spec.TapDrillDiameter,
+	})
+}

--- a/addin/router/threads_test.go
+++ b/addin/router/threads_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// The thread table wire surface (M09-F01 PBI-101, #325).
+
+// TestThreadsTableQueryProgressive: types always; sizes with a type;
+// designations with a size; classes with a designation (side-aware).
+func TestThreadsTableQueryProgressive(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var bare wire.ThreadTableQueryResult
+	call(t, r, s, "threads.tableQuery", `{}`, &bare)
+	if len(bare.ThreadTypes) < 2 || bare.NominalSizes != nil {
+		t.Fatalf("bare query = %+v, want types only", bare)
+	}
+
+	var sized wire.ThreadTableQueryResult
+	call(t, r, s, "threads.tableQuery", `{"threadType":"ISO"}`, &sized)
+	if len(sized.NominalSizes) == 0 {
+		t.Fatal("ISO query listed no nominal sizes")
+	}
+
+	var full wire.ThreadTableQueryResult
+	call(t, r, s, "threads.tableQuery", `{"threadType":"ISO","nominalSize":"M8","designation":"M8x1.25","internal":true}`, &full)
+	if len(full.Designations) == 0 || len(full.Classes) == 0 {
+		t.Fatalf("full query = %+v, want designations and classes", full)
+	}
+	if full.Classes[0] != "6H" {
+		t.Errorf("internal ISO class = %q, want 6H", full.Classes[0])
+	}
+
+	if _, err := r.Handle(s, "threads.tableQuery", []byte(`{"threadType":"BSW"}`)); err == nil {
+		t.Fatal("an unknown thread type must error")
+	}
+}
+
+// TestThreadsResolveCarriesParityFields: the resolved DTO carries class /
+// tapered / handedness alongside the derived diameters.
+func TestThreadsResolveCarriesParityFields(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var info wire.ThreadInfoResult
+	call(t, r, s, "threads.resolve", `{"designation":"M8x1.25","class":"6H","internal":true,"tapered":false}`, &info)
+	if !info.Metric || info.ThreadType != "ISO" || info.NominalSize != "M8" {
+		t.Errorf("resolved = %+v, want metric ISO M8", info)
+	}
+	if info.Class != "6H" || !info.Internal || !info.RightHanded {
+		t.Errorf("parity fields = class %q internal %v rh %v", info.Class, info.Internal, info.RightHanded)
+	}
+	if info.TapDrillDiameter != 8-1.25 || info.PitchDiameter != 8-0.6495*1.25 {
+		t.Errorf("derived diameters = %g / %g", info.TapDrillDiameter, info.PitchDiameter)
+	}
+
+	var lh wire.ThreadInfoResult
+	call(t, r, s, "threads.resolve", `{"designation":"1/4-20","leftHanded":true}`, &lh)
+	if lh.RightHanded || lh.Metric || lh.ThreadType != "ANSI" {
+		t.Errorf("left-handed inch resolve = %+v", lh)
+	}
+
+	if _, err := r.Handle(s, "threads.resolve", []byte(`{}`)); err == nil {
+		t.Fatal("resolve without a designation must error")
+	}
+}

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -4,11 +4,20 @@ package ops
 
 import (
 	"fmt"
+	stdmath "math"
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
+
+// EdgeFilletRadii is one picked edge with its blend radius at each end: R0 at the edge's
+// start vertex, R1 at its end vertex. Equal radii give a constant fillet; differing radii a
+// variable fillet whose radius runs linearly along the edge (#323).
+type EdgeFilletRadii struct {
+	Key    []byte
+	R0, R1 float64
+}
 
 // FilletEdges rounds the selected convex straight edges of a planar solid with a constant-
 // radius rolling-ball blend: each edge between two planar faces is replaced by a cylinder
@@ -19,20 +28,30 @@ import (
 // straight edges with one extra face at each end (box/prism edges); chains, corners where
 // fillets meet, and concave edges are follow-ups.
 func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, error) {
-	if r <= 0 {
-		return nil, fmt.Errorf("fillet: radius %g must be > 0", r)
+	picks := make([]EdgeFilletRadii, len(edgeKeys))
+	for i, k := range edgeKeys {
+		picks[i] = EdgeFilletRadii{Key: k, R0: r, R1: r}
 	}
-	edges, err := resolveFilletEdges(body, edgeKeys)
+	return FilletEdgesVarying(body, picks)
+}
+
+// FilletEdgesVarying is FilletEdges with a per-end radius for each edge. A variable edge's
+// blend is a generalized cone (the rolling ball grows linearly along the edge), built as
+// planar trapezoids between successive rulings: adjacent rulings meet at the cone's apex on
+// the edge line, so each strip face is EXACTLY planar — the only approximation is the end
+// arcs as chords, the same density convention as a hole's faceted cylinder.
+func FilletEdgesVarying(body *topo.Body, picks []EdgeFilletRadii) (*topo.Body, error) {
+	edges, err := resolveFilletPicks(body, picks)
 	if err != nil {
 		return nil, err
 	}
-	blends, err := computeBlends(edges, r)
+	blends, err := computeBlends(edges)
 	if err != nil {
 		return nil, err
 	}
 	fils := make([]edgeFillet, 0, len(edges))
-	for _, e := range edges {
-		ef, err := computeEdgeFillet(body, e, r, blends)
+	for _, p := range edges {
+		ef, err := computeEdgeFillet(body, p, blends)
 		if err != nil {
 			return nil, err
 		}
@@ -45,29 +64,45 @@ func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, err
 	return res, nil
 }
 
-// resolveFilletEdges resolves the edge reference keys against the body, erroring on a lost key.
-func resolveFilletEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, error) {
-	edges := make([]*topo.Edge, 0, len(keys))
-	for _, k := range keys {
-		e, ok := body.FindEdgeByKey(k)
-		if !ok {
-			return nil, fmt.Errorf("fillet: edge reference lost: %x", k)
+// filletPick is one resolved fillet input: the edge and its per-end radii.
+type filletPick struct {
+	edge   *topo.Edge
+	r0, r1 float64
+}
+
+// varying reports whether the pick's radius changes along the edge.
+func (p filletPick) varying() bool { return p.r0 != p.r1 }
+
+// resolveFilletPicks resolves the edge reference keys against the body, erroring on a lost
+// key or a non-positive radius.
+func resolveFilletPicks(body *topo.Body, picks []EdgeFilletRadii) ([]filletPick, error) {
+	out := make([]filletPick, 0, len(picks))
+	for _, p := range picks {
+		if p.R0 <= 0 || p.R1 <= 0 {
+			return nil, fmt.Errorf("fillet: radii %g/%g must be > 0", p.R0, p.R1)
 		}
-		edges = append(edges, e)
+		e, ok := body.FindEdgeByKey(p.Key)
+		if !ok {
+			return nil, fmt.Errorf("fillet: edge reference lost: %x", p.Key)
+		}
+		out = append(out, filletPick{edge: e, r0: p.R0, r1: p.R1})
 	}
-	return edges, nil
+	return out, nil
 }
 
 // corner is one rounded end of a filleted edge: the cylinder centre at that end, the tangent
 // points on faces a/b, and the arc midpoint (the cylinder point nearest the sharp corner).
 // At a blend corner the centre is the corner sphere's centre and the tangent points are the
-// sphere's tangents (the cylinder ends there and its arc joins the sphere patch).
+// sphere's tangents (the cylinder ends there and its arc joins the sphere patch). A variable
+// fillet's corner additionally carries the arc sampled as chords (ta…tb), shared between the
+// blend's ruling strips and the end face so they stay watertight.
 type corner struct {
 	a, b    *topo.Face
 	cen     math.Point3 // cylinder centre at this end (sphere centre when blended)
 	ta, tb  math.Point3
 	mid     math.Point3
-	endFace *topo.Face // the flat end cap to arc (nil at a blend corner)
+	chords  []math.Point3 // variable fillet only: the end arc as chord samples ta…tb
+	endFace *topo.Face    // the flat end cap to arc (nil at a blend corner)
 	vertex  *topo.Vertex
 	blend   bool
 }
@@ -80,18 +115,21 @@ func (c corner) tOf(f *topo.Face) math.Point3 {
 	return c.tb
 }
 
-// edgeFillet is a fully solved fillet of one edge: its two faces, the cylinder, and the two
-// rounded corners.
+// edgeFillet is a fully solved fillet of one edge: its two faces, the cylinder (constant
+// radius only), the two rounded corners, and whether the radius varies along the edge.
 type edgeFillet struct {
-	a, b   *topo.Face
-	cyl    geom.Cylinder
-	c0, c1 corner
-	edge   *topo.Edge
+	a, b    *topo.Face
+	cyl     geom.Cylinder
+	c0, c1  corner
+	edge    *topo.Edge
+	varying bool
 }
 
 // computeEdgeFillet solves the rolling-ball geometry for one convex straight edge, using a
-// corner blend at either endpoint that is a shared corner.
-func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64, blends map[uint64]*cornerBlend) (edgeFillet, error) {
+// corner blend at either endpoint that is a shared corner. A varying pick gets its end arcs
+// sampled as chords (shared by the ruling strips and the end faces).
+func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend) (edgeFillet, error) {
+	e := p.edge
 	a, b, nA, nB, err := edgePlanarFaces(e)
 	if err != nil {
 		return edgeFillet{}, err
@@ -100,16 +138,21 @@ func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64, blends map[uint
 	if err != nil {
 		return edgeFillet{}, fmt.Errorf("fillet: degenerate edge")
 	}
-	off := nA.Add(nB).Scale(-r / (1 + nA.Dot(nB))) // centre offset from the edge into the solid
-	if mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point()); !PointInsideBody(body, mid.TranslateBy(off)) {
+	offDir := nA.Add(nB).Scale(-1 / (1 + nA.Dot(nB))) // per-unit-radius centre offset into the solid
+	rMid := (p.r0 + p.r1) / 2
+	if mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point()); !PointInsideBody(body, mid.TranslateBy(offDir.Scale(rMid))) {
 		return edgeFillet{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
 	}
-	in := cornerInputs{a: a, b: b, nA: nA, nB: nB, off: off, r: r, axis: axis.AsVector()}
-	c0, c1, err := edgeCorners(e, in, blends)
+	in := cornerInputs{a: a, b: b, nA: nA, nB: nB, offDir: offDir, axis: axis.AsVector()}
+	c0, c1, err := edgeCorners(e, p, in, blends)
 	if err != nil {
 		return edgeFillet{}, err
 	}
-	cyl, err := geom.NewCylinder(c0.cen, axis.AsVector(), r)
+	if p.varying() {
+		sampleCornerChords(&c0, &c1, in)
+		return edgeFillet{a: a, b: b, c0: c0, c1: c1, edge: e, varying: true}, nil
+	}
+	cyl, err := geom.NewCylinder(c0.cen, axis.AsVector(), p.r0)
 	if err != nil {
 		return edgeFillet{}, err
 	}
@@ -117,13 +160,45 @@ func computeEdgeFillet(body *topo.Body, e *topo.Edge, r float64, blends map[uint
 }
 
 // edgeCorners solves the rounded corners at both endpoints of an edge (each blended when its
-// vertex is a shared corner).
-func edgeCorners(e *topo.Edge, in cornerInputs, blends map[uint64]*cornerBlend) (c0, c1 corner, err error) {
-	if c0, err = cornerAt(e.StartVertex(), in, blends[e.StartVertex().ID()]); err != nil {
+// vertex is a shared corner), with the pick's per-end radius.
+func edgeCorners(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend) (c0, c1 corner, err error) {
+	if c0, err = cornerAt(e.StartVertex(), in, p.r0, blends[e.StartVertex().ID()]); err != nil {
 		return corner{}, corner{}, err
 	}
-	c1, err = cornerAt(e.EndVertex(), in, blends[e.EndVertex().ID()])
+	c1, err = cornerAt(e.EndVertex(), in, p.r1, blends[e.EndVertex().ID()])
 	return c0, c1, err
+}
+
+// filletChordsPerTurn matches holeFacets' density: chords are sized as if the full circle
+// had this many sides, so a 90° wedge gets 8.
+const filletChordsPerTurn = 32
+
+// sampleCornerChords samples both corners' arcs at the same angular stations, so chord j of
+// one corner pairs with chord j of the other as a straight ruling of the blend cone.
+func sampleCornerChords(c0, c1 *corner, in cornerInputs) {
+	wedge := stdmath.Acos(float64(in.nA.Dot(in.nB)))
+	k := int(stdmath.Ceil(wedge / (2 * stdmath.Pi / filletChordsPerTurn)))
+	if k < 4 {
+		k = 4
+	}
+	c0.chords = arcChords(*c0, in, k)
+	c1.chords = arcChords(*c1, in, k)
+}
+
+// arcChords samples a corner's arc ta…tb as k+1 points: cen + r·slerp(nA→nB), the exact
+// rolling-ball contact directions at evenly spaced stations.
+func arcChords(c corner, in cornerInputs, k int) []math.Point3 {
+	r := c.cen.DistanceTo(c.ta)
+	wedge := stdmath.Acos(float64(in.nA.Dot(in.nB)))
+	sinW := stdmath.Sin(wedge)
+	out := make([]math.Point3, k+1)
+	for j := 0; j <= k; j++ {
+		s := float64(j) / float64(k)
+		dir := in.nA.Scale(stdmath.Sin((1-s)*wedge) / sinW).
+			Add(in.nB.Scale(stdmath.Sin(s*wedge) / sinW))
+		out[j] = c.cen.TranslateBy(dir.Scale(r))
+	}
+	return out
 }
 
 // edgePlanarFaces returns the edge's two faces and their outward normals, erroring unless
@@ -141,31 +216,32 @@ func edgePlanarFaces(e *topo.Edge) (a, b *topo.Face, nA, nB math.Vector3, err er
 	return faces[0], faces[1], pa.Normal(), pb.Normal(), nil
 }
 
-// cornerInputs bundles the per-edge data a corner needs.
+// cornerInputs bundles the per-edge data a corner needs. offDir is the centre offset from
+// the edge into the solid PER UNIT RADIUS (a variable fillet's centre line follows offDir
+// scaled by the local radius).
 type cornerInputs struct {
 	a, b   *topo.Face
 	nA, nB math.Vector3
-	off    math.Vector3
+	offDir math.Vector3
 	axis   math.Vector3
-	r      float64
 }
 
-// cornerAt solves a fillet corner at vertex v. Without a blend it is a simple end: centre
-// v+off, tangent points r along each face normal, an arc on the end face. With a blend (v is
-// a shared corner) the centre is the blend sphere's centre and the tangent points are the
-// sphere's tangents on the two faces; the corner-end arc joins the sphere patch (no end
-// face), and the arc is registered on the blend.
-func cornerAt(v *topo.Vertex, in cornerInputs, blend *cornerBlend) (corner, error) {
-	cen := v.Point().TranslateBy(in.off)
-	ta := cen.TranslateBy(in.nA.Scale(in.r))
-	tb := cen.TranslateBy(in.nB.Scale(in.r))
+// cornerAt solves a fillet corner at vertex v with the local radius r. Without a blend it is
+// a simple end: centre v+offDir·r, tangent points r along each face normal, an arc on the end
+// face. With a blend (v is a shared corner) the centre is the blend sphere's centre and the
+// tangent points are the sphere's tangents on the two faces; the corner-end arc joins the
+// sphere patch (no end face), and the arc is registered on the blend.
+func cornerAt(v *topo.Vertex, in cornerInputs, r float64, blend *cornerBlend) (corner, error) {
+	cen := v.Point().TranslateBy(in.offDir.Scale(r))
+	ta := cen.TranslateBy(in.nA.Scale(r))
+	tb := cen.TranslateBy(in.nB.Scale(r))
 	var end *topo.Face
 	if blend != nil {
 		cen, ta, tb = blend.center, blend.tan[in.a.ID()], blend.tan[in.b.ID()]
 	} else if end = endFaceAt(v, in.a, in.b); end == nil {
 		return corner{}, fmt.Errorf("fillet: edge endpoint has no end face to round")
 	}
-	mid := cen.TranslateBy(perpToward(cen, v.Point(), in.axis).Scale(in.r))
+	mid := cen.TranslateBy(perpToward(cen, v.Point(), in.axis).Scale(r))
 	c := corner{a: in.a, b: in.b, endFace: end, vertex: v, cen: cen, ta: ta, tb: tb, mid: mid, blend: blend != nil}
 	if blend != nil {
 		blend.arcs = append(blend.arcs, blendArc{ta: ta, tb: tb, mid: mid})
@@ -215,23 +291,28 @@ type cornerBlend struct {
 
 // computeBlends finds the shared corners of the filleted edge set and solves a sphere patch
 // for each. A vertex where ≥2 filleted edges meet must be a fully-filleted trihedral corner
-// (exactly 3 of the selected edges, 3 faces) — the supported case (e.g. a box corner);
-// anything else errors clearly. Returns a map keyed by corner vertex id.
-func computeBlends(edges []*topo.Edge, r float64) (map[uint64]*cornerBlend, error) {
-	groups := map[uint64][]*topo.Edge{}
-	for _, e := range edges {
-		groups[e.StartVertex().ID()] = append(groups[e.StartVertex().ID()], e)
-		groups[e.EndVertex().ID()] = append(groups[e.EndVertex().ID()], e)
+// (exactly 3 of the selected edges, 3 faces) at ONE constant radius — a variable edge's
+// faceted end chords cannot meet a sphere patch's true arcs watertight, and a sphere blend
+// has a single radius, so both cases error clearly. Returns a map keyed by corner vertex id.
+func computeBlends(picks []filletPick) (map[uint64]*cornerBlend, error) {
+	groups := map[uint64][]filletPick{}
+	for _, p := range picks {
+		groups[p.edge.StartVertex().ID()] = append(groups[p.edge.StartVertex().ID()], p)
+		groups[p.edge.EndVertex().ID()] = append(groups[p.edge.EndVertex().ID()], p)
 	}
 	out := map[uint64]*cornerBlend{}
-	for vid, es := range groups {
-		if len(es) < 2 {
+	for vid, ps := range groups {
+		if len(ps) < 2 {
 			continue
 		}
-		v := vertexByID(es, vid)
+		r, err := blendRadius(ps)
+		if err != nil {
+			return nil, err
+		}
+		v := vertexByID(edgesOf(ps), vid)
 		faces := facesAtVertex(v)
-		if len(es) != 3 || len(faces) != 3 {
-			return nil, fmt.Errorf("fillet: corner blend needs exactly 3 mutually filleted edges at a 3-face vertex (got %d edges, %d faces); other corner configs are not yet supported", len(es), len(faces))
+		if len(ps) != 3 || len(faces) != 3 {
+			return nil, fmt.Errorf("fillet: corner blend needs exactly 3 mutually filleted edges at a 3-face vertex (got %d edges, %d faces); other corner configs are not yet supported", len(ps), len(faces))
 		}
 		cb, err := solveBlend(v, faces, r)
 		if err != nil {
@@ -240,6 +321,30 @@ func computeBlends(edges []*topo.Edge, r float64) (map[uint64]*cornerBlend, erro
 		out[vid] = cb
 	}
 	return out, nil
+}
+
+// blendRadius returns the single constant radius shared by every pick meeting at the corner,
+// erroring on a variable pick or on differing radii (with the offending values).
+func blendRadius(ps []filletPick) (float64, error) {
+	r := ps[0].r0
+	for _, p := range ps {
+		if p.varying() {
+			return 0, fmt.Errorf("fillet: a variable-radius edge (radii %g→%g) cannot share a filleted corner with another filleted edge", p.r0, p.r1)
+		}
+		if p.r0 != r {
+			return 0, fmt.Errorf("fillet: edges meeting at a shared corner must use one radius (got %g and %g)", r, p.r0)
+		}
+	}
+	return r, nil
+}
+
+// edgesOf projects the picks' edges.
+func edgesOf(ps []filletPick) []*topo.Edge {
+	out := make([]*topo.Edge, len(ps))
+	for i, p := range ps {
+		out[i] = p.edge
+	}
+	return out
 }
 
 // solveBlend builds the corner sphere from the three planar faces meeting at v (the point

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -144,19 +144,25 @@ func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerB
 		return edgeFillet{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
 	}
 	in := cornerInputs{a: a, b: b, nA: nA, nB: nB, offDir: offDir, axis: axis.AsVector()}
+	return solvedEdgeFillet(e, p, in, blends)
+}
+
+// solvedEdgeFillet assembles the edgeFillet once the edge's frame is known: corners per end
+// radius, then either the chord-sampled varying blend or the constant cylinder.
+func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend) (edgeFillet, error) {
 	c0, c1, err := edgeCorners(e, p, in, blends)
 	if err != nil {
 		return edgeFillet{}, err
 	}
 	if p.varying() {
 		sampleCornerChords(&c0, &c1, in)
-		return edgeFillet{a: a, b: b, c0: c0, c1: c1, edge: e, varying: true}, nil
+		return edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, edge: e, varying: true}, nil
 	}
-	cyl, err := geom.NewCylinder(c0.cen, axis.AsVector(), p.r0)
+	cyl, err := geom.NewCylinder(c0.cen, in.axis, p.r0)
 	if err != nil {
 		return edgeFillet{}, err
 	}
-	return edgeFillet{a: a, b: b, cyl: cyl, c0: c0, c1: c1, edge: e}, nil
+	return edgeFillet{a: in.a, b: in.b, cyl: cyl, c0: c0, c1: c1, edge: e}, nil
 }
 
 // edgeCorners solves the rounded corners at both endpoints of an edge (each blended when its

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -10,8 +10,8 @@ import (
 
 // filletResultFaces builds the faces of the filleted body: every original face transformed
 // for the fillets touching it (its A/B corners pulled back to the tangent points, its simple
-// end corners replaced by an arc), one cylinder face per filleted edge, and one sphere patch
-// per corner blend.
+// end corners replaced by an arc or chord fan), one cylinder face per constant filleted edge
+// (or a planar ruling strip per variable one), and one sphere patch per corner blend.
 func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*cornerBlend) []filletFace {
 	abSubst, endCorner := filletMaps(fils)
 	var out []filletFace
@@ -19,12 +19,47 @@ func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*co
 		out = append(out, transformFace(f, abSubst[f], endCorner[f]))
 	}
 	for _, ef := range fils {
+		if ef.varying {
+			out = append(out, rulingStripFaces(ef)...)
+			continue
+		}
 		out = append(out, cylinderFace(ef))
 	}
 	for _, cb := range blends {
 		out = append(out, spherePatchFace(cb))
 	}
 	return out
+}
+
+// rulingStripFaces builds a variable fillet's blend as planar trapezoids between successive
+// rulings: chord j of corner 0 pairs with chord j of corner 1 (the corners are sampled at the
+// same angular stations). Adjacent rulings of the blend meet at its cone apex on the edge
+// line, so each strip face is exactly planar; winding is fixed outward (away from the centre
+// line) per quad.
+func rulingStripFaces(ef edgeFillet) []filletFace {
+	cmid := ef.c0.cen.Midpoint(ef.c1.cen)
+	out := make([]filletFace, 0, len(ef.c0.chords)-1)
+	for j := 0; j+1 < len(ef.c0.chords); j++ {
+		quad := [4]math.Point3{ef.c0.chords[j], ef.c1.chords[j], ef.c1.chords[j+1], ef.c0.chords[j+1]}
+		out = append(out, planarQuadFace(quad, cmid))
+	}
+	return out
+}
+
+// planarQuadFace builds one planar face over the quad, wound so its normal points away from
+// the blend centre line (approximated by cmid — the wedge spans < π, so the sign is robust).
+func planarQuadFace(quad [4]math.Point3, cmid math.Point3) filletFace {
+	n := quad[0].VectorTo(quad[1]).Cross(quad[0].VectorTo(quad[3]))
+	qc := centroidPts(quad[:])
+	if n.Dot(cmid.VectorTo(qc)) < 0 {
+		quad = [4]math.Point3{quad[0], quad[3], quad[2], quad[1]}
+		n = n.Scale(-1)
+	}
+	pl, _ := geom.NewPlane(quad[0], n)
+	return filletFace{surface: pl, loops: []filletLoop{{
+		pts:    quad[:],
+		curves: make([]geom.Curve3, 4),
+	}}}
 }
 
 // filletMaps indexes, per face: the corner-vertex → tangent-point pullbacks (where the face
@@ -79,9 +114,7 @@ func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends
 			c := ends[v.ID()]
 			tIn := c.tOf(otherFace(uses[(i-1+n)%n].Edge(), f))
 			tOut := c.tOf(otherFace(u.Edge(), f))
-			arc, _ := geom.Arc3dByThreePoints(tIn, c.mid, tOut)
-			fl.add(tIn, arc)
-			fl.add(tOut, nil)
+			addCornerRound(&fl, c, tIn, tOut)
 		case subs != nil && hasSubst(subs, v):
 			fl.add(subs[v.ID()], nil)
 		default:
@@ -89,6 +122,33 @@ func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends
 		}
 	}
 	return fl
+}
+
+// addCornerRound expands a simple end corner into its rounded boundary: one true arc for a
+// constant fillet, or the chord fan (shared with the ruling strips) for a variable one.
+func addCornerRound(fl *filletLoop, c corner, tIn, tOut math.Point3) {
+	if len(c.chords) == 0 {
+		arc, _ := geom.Arc3dByThreePoints(tIn, c.mid, tOut)
+		fl.add(tIn, arc)
+		fl.add(tOut, nil)
+		return
+	}
+	for _, p := range orientedChords(c.chords, tIn) {
+		fl.add(p, nil)
+	}
+}
+
+// orientedChords returns the corner's chord samples starting from tIn (the chords run ta→tb;
+// a loop entering from the b side walks them reversed).
+func orientedChords(chords []math.Point3, tIn math.Point3) []math.Point3 {
+	if chords[0].DistanceTo(tIn) < 1e-9 {
+		return chords
+	}
+	out := make([]math.Point3, len(chords))
+	for i, p := range chords {
+		out[len(chords)-1-i] = p
+	}
+	return out
 }
 
 func hasCorner(ends map[uint64]corner, v *topo.Vertex) bool { _, ok := ends[v.ID()]; return ok }

--- a/kernel/ops/fillet_varying_test.go
+++ b/kernel/ops/fillet_varying_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+)
+
+// The variable-radius fillet (M09-F01 PBI-099, #323): the blend is a generalized
+// cone built as exactly planar trapezoids between rulings, so the result's
+// tessellated volume is closed-form in the chord count.
+
+// varyingNotchFactor is the cross-section fraction of r² a chorded 90° fillet
+// removes: the square corner r² minus the K-chord fan (K·r²/2·sin(π/2/K)),
+// with K = filletChordsPerTurn/4 chords over the quarter turn.
+func varyingNotchFactor(k int) float64 {
+	return 1 - float64(k)/2*stdmath.Sin(stdmath.Pi/2/float64(k))
+}
+
+// TestFilletVaryingRadiusVolume rounds one vertical edge of a 2×2×2 box from
+// r=0.3 at one end to r=0.6 at the other. The removed volume is the exact
+// chord-geometry integral c·∫r(z)²dz = c·L·(r0²+r0·r1+r1²)/3 — the strip faces
+// and chorded end fans are all planar, so the tessellation adds no error.
+func TestFilletVaryingRadiusVolume(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	pick := ops.EdgeFilletRadii{Key: verticalEdgeKey(t, box), R0: 0.3, R1: 0.6}
+	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{pick})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("variable-filleted box not a valid solid: %+v", r)
+	}
+	if n := hasCylinderFaces(res); n != 0 {
+		t.Errorf("variable fillet produced %d cylinder faces, want 0 (planar ruling strips)", n)
+	}
+	const k = 8 // ceil((π/2) / (2π/32)) chords across the 90° wedge
+	removed := varyingNotchFactor(k) * 2 * (0.3*0.3 + 0.3*0.6 + 0.6*0.6) / 3
+	want := 8 - removed
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("variable fillet volume = %g, want %g (exact chord geometry)", got, want)
+	}
+}
+
+// TestFilletVaryingCollapsesToConstant: equal end radii through the varying API
+// must reproduce the constant cylinder fillet exactly.
+func TestFilletVaryingCollapsesToConstant(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	key := verticalEdgeKey(t, box)
+	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{{Key: key, R0: 0.5, R1: 0.5}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := hasCylinderFaces(res); n != 1 {
+		t.Errorf("equal-radii fillet has %d cylinder faces, want 1 (constant path)", n)
+	}
+}
+
+// TestFilletVaryingAtSharedCornerRejected: a variable edge meeting another
+// filleted edge at a corner has no watertight blend — a precise error, not a
+// broken body.
+func TestFilletVaryingAtSharedCornerRejected(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	vert := verticalEdgeKey(t, box)
+	v, _ := box.FindEdgeByKey(vert)
+	ends := map[uint64]bool{v.StartVertex().ID(): true, v.EndVertex().ID(): true}
+	var neighbour []byte
+	for _, e := range box.Edges() {
+		if e != v && (ends[e.StartVertex().ID()] || ends[e.EndVertex().ID()]) {
+			neighbour = e.ReferenceKey()
+			break
+		}
+	}
+	_, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{
+		{Key: vert, R0: 0.2, R1: 0.5},
+		{Key: neighbour, R0: 0.2, R1: 0.2},
+	})
+	if err == nil || !strings.Contains(err.Error(), "variable-radius edge") {
+		t.Fatalf("err = %v, want the variable-at-shared-corner rejection", err)
+	}
+}
+
+// TestFilletVaryingStripsAreTrulyPlanar: every blend face's vertices lie on its
+// reported plane (the exactness claim the volume test builds on).
+func TestFilletVaryingStripsAreTrulyPlanar(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	pick := ops.EdgeFilletRadii{Key: verticalEdgeKey(t, box), R0: 0.2, R1: 0.7}
+	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{pick})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range res.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok {
+			t.Fatalf("non-planar face %T in a variable fillet result", f.Geometry())
+		}
+		for _, v := range f.Vertices() {
+			if d := stdmath.Abs(float64(pl.Origin.VectorTo(v.Point()).Dot(pl.Normal()))); d > 1e-9 {
+				t.Fatalf("face vertex %.12g off its plane by %g", v.Point(), d)
+			}
+		}
+	}
+}

--- a/kernel/ops/move_face.go
+++ b/kernel/ops/move_face.go
@@ -43,8 +43,34 @@ func OffsetFaces(solid *topo.Body, faceKeys [][]byte, dist float64) (*topo.Body,
 	}), nil
 }
 
+// RotateFaces rotates the selected faces' planes by angle about an axis (point + unit
+// direction), retrimming the neighbours — the rotate arm of the move-face direct edit
+// (#331). Same contract as [MoveFaces]: topology is preserved, so a rotation large enough
+// to collapse or invert a face is a follow-up needing retopology.
+func RotateFaces(solid *topo.Body, faceKeys [][]byte, axisPoint math.Point3, axisDir math.UnitVector3, angle float64) (*topo.Body, error) {
+	sel, err := resolveFaceSet(solid, faceKeys)
+	if err != nil {
+		return nil, err
+	}
+	rot := math.Rotation4(angle, axisDir, axisPoint)
+	return rebuildWithPlanes(solid, "rotate-face", func(f *topo.Face) geom.Plane {
+		pl := f.Geometry().(geom.Plane)
+		if !sel[f.ID()] {
+			return pl
+		}
+		return rotatePlane(pl, rot)
+	}), nil
+}
+
 // shiftPlane returns the plane translated by delta (origin moved, basis/normal unchanged).
 func shiftPlane(pl geom.Plane, delta math.Vector3) geom.Plane {
 	moved, _ := geom.NewPlaneFromAxes(pl.Origin.TranslateBy(delta), pl.UAxis.AsVector(), pl.VAxis.AsVector())
+	return moved
+}
+
+// rotatePlane returns the plane mapped through the rotation (origin and basis rotated).
+func rotatePlane(pl geom.Plane, rot math.Matrix4) geom.Plane {
+	moved, _ := geom.NewPlaneFromAxes(rot.TransformPoint(pl.Origin),
+		rot.TransformVector(pl.UAxis.AsVector()), rot.TransformVector(pl.VAxis.AsVector()))
 	return moved
 }

--- a/kernel/ops/rotate_face_test.go
+++ b/kernel/ops/rotate_face_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// The rotate arm of the move-face direct edit (M09-F04 PBI-107, #331).
+
+// faceWithNormal returns a face whose outward plane normal matches dir.
+func faceWithNormal(t *testing.T, b *topo.Body, dir math.Vector3) *topo.Face {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if pl, ok := f.Geometry().(geom.Plane); ok && float64(pl.Normal().Dot(dir)) > 0.9 {
+			return f
+		}
+	}
+	t.Fatal("no face with the requested normal")
+	return nil
+}
+
+// TestRotateFacesTiltsTopIntoWedge rotates a 2×2×2 box's top face by θ about
+// the y-axis line along its x=0 top edge: the top plane becomes z = 2 − x·tanθ
+// and the volume the analytic wedge 8 − 4·tanθ.
+func TestRotateFacesTiltsTopIntoWedge(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	top := faceWithNormal(t, box, math.V3(0, 0, 1))
+	const theta = 0.15
+	axisDir, _ := math.UnitVector3FromVector(math.V3(0, 1, 0))
+	res, err := ops.RotateFaces(box, [][]byte{top.ReferenceKey()}, math.P3(0, 0, 2), axisDir, theta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("rotated-face box not a valid solid: %+v", r)
+	}
+	want := 8 - 4*stdmath.Tan(theta)
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("wedge volume = %g, want %g", got, want)
+	}
+}
+
+// TestRotateFacesLostKey: a missing face key errors with the key.
+func TestRotateFacesLostKey(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	axisDir, _ := math.UnitVector3FromVector(math.V3(0, 1, 0))
+	if _, err := ops.RotateFaces(box, [][]byte{[]byte("gone")}, math.P3(0, 0, 2), axisDir, 0.1); err == nil {
+		t.Fatal("a lost face key must error")
+	}
+}

--- a/kernel/ops/split.go
+++ b/kernel/ops/split.go
@@ -3,6 +3,9 @@
 package ops
 
 import (
+	"fmt"
+
+	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -26,6 +29,19 @@ func SplitSolidByPlane(body *topo.Body, plane geom.Plane) ([]*topo.Body, error) 
 		}
 	}
 	return pieces, nil
+}
+
+// SplitFacesByPlane imprints the plane's section curves onto the body's faces (the
+// reference's Split Faces mode, #330): faces crossing the plane split along it, NO material
+// is removed, and the volume is unchanged. Built on the body imprint (M07) against a
+// half-space box whose near face lies exactly on the plane.
+func SplitFacesByPlane(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
+	tool := halfSpaceBox(plane, splitExtent(body, plane.Origin), true)
+	ra, _, err := brep.ImprintBodies(body, tool)
+	if err != nil {
+		return nil, fmt.Errorf("split faces: %w", err)
+	}
+	return ra.Body, nil
 }
 
 // splitExtent returns a half-width large enough for a cutting half-space anchored at the plane

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -644,3 +644,52 @@ func centeredRect(sk *sketch.Sketch, half float64) {
 	sk.Lines().Add(c2, c3)
 	sk.Lines().Add(c3, c0)
 }
+
+// TestFilletEdgeSetsSurviveReopen: a mixed constant + variable edge-set fillet
+// (#323) reopens with its sets intact — same health, same volume.
+func TestFilletEdgeSetsSurviveReopen(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	rectangle(sk, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+
+	var vertical [][]byte
+	for _, e := range def.SurfaceBodies().All()[0].Edges() {
+		if a, b := e.StartVertex().Point(), e.EndVertex().Point(); a.X == b.X && a.Y == b.Y {
+			vertical = append(vertical, e.ReferenceKey())
+		}
+	}
+	if len(vertical) < 2 {
+		t.Fatalf("found %d vertical edges, want ≥2", len(vertical))
+	}
+	pf := feature.NewDressUpFeatures(def.Features()).AddFilletSets([]feature.FilletEdgeSet{
+		{EdgeKeys: [][]byte{vertical[0]}, Radius: func() float64 { return 0.4 }},
+		{EdgeKeys: [][]byte{vertical[1]}, StartRadius: func() float64 { return 0.2 }, EndRadius: func() float64 { return 0.7 }},
+	})
+	def.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("edge-set fillet before save = %v, want OK", pf.Health())
+	}
+	before := ops.BodyGeometryProperties(def.SurfaceBodies().All()[0], ops.DefaultQuality()).Volume
+
+	reopened := reopenThroughStore(t, d)
+	got, ok := featureByKind(reopened.Features(), "fillet")
+	if !ok {
+		t.Fatal("fillet feature missing after reopen")
+	}
+	if !got.Health().OK() {
+		t.Fatalf("edge-set fillet after reopen = %v, want OK", got.Health())
+	}
+	rdef := got.Definition().(*feature.FilletFeature).Definition()
+	if len(rdef.EdgeSets) != 2 || rdef.EdgeSets[1].Radius != nil || rdef.EdgeSets[1].EndRadius() != 0.7 {
+		t.Errorf("restored edge sets = %d sets, want the constant+variable pair back", len(rdef.EdgeSets))
+	}
+	after := ops.BodyGeometryProperties(reopened.SurfaceBodies().All()[0], ops.DefaultQuality()).Volume
+	if stdmath.Abs(after-before) > 1e-9 {
+		t.Errorf("reopened fillet volume = %g, want %g", after, before)
+	}
+}

--- a/model/feature/direct_edit.go
+++ b/model/feature/direct_edit.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// The consolidated direct-edit feature (M09-F04 PBI-108, #332): one feature whose
+// operation — move / size / rotate / delete on picked faces, or a uniform scale of the
+// running body — is discriminated by the frozen DirectEditOperationType. The face
+// operations reuse the same plane-rebuild kernel ops as the standalone face edits; scale
+// is a similarity TransformBody about a base point with identity lineage (an in-place
+// edit, so downstream picks survive).
+
+// DirectEditDefinition is the direct-edit recipe. Per operation:
+// move (FaceKeys+Translation), size (FaceKeys+Direction+Distance — push/pull along the
+// direction), rotate (FaceKeys+AxisPoint/AxisDir/Angle), delete (FaceKeys),
+// scale (ScaleFactor about BasePoint, whole body).
+type DirectEditDefinition struct {
+	Operation   types.DirectEditOperationType
+	FaceKeys    [][]byte
+	Translation math.Vector3
+	Direction   math.Vector3
+	Distance    func() float64
+	AxisPoint   math.Point3
+	AxisDir     math.Vector3
+	Angle       func() float64
+	ScaleFactor func() float64
+	BasePoint   math.Point3
+}
+
+// DirectEditFeature applies one direct-edit operation to the running body.
+type DirectEditFeature struct{ def *DirectEditDefinition }
+
+// Definition returns the direct-edit recipe.
+func (f *DirectEditFeature) Definition() *DirectEditDefinition { return f.def }
+
+// Kind implements [Feature].
+func (f *DirectEditFeature) Kind() string { return "directEdit" }
+
+// Recompute dispatches on the operation; an unknown operation is a precise error.
+func (f *DirectEditFeature) Recompute(in Input) (Output, error) {
+	switch f.def.Operation {
+	case types.DirectEditMoveOperation:
+		return retopoFacesBody(in, f.def.FaceKeys, "directEdit move", func(b *topo.Body, keys [][]byte) (*topo.Body, error) {
+			return ops.MoveFaces(b, keys, f.def.Translation)
+		})
+	case types.DirectEditSizeOperation:
+		return f.recomputeSize(in)
+	case types.DirectEditRotateOperation:
+		return f.recomputeRotate(in)
+	case types.DirectEditDeleteOperation:
+		return retopoFacesBody(in, f.def.FaceKeys, "directEdit delete", ops.DeleteFaces)
+	case types.DirectEditScaleOperation:
+		return f.recomputeScale(in)
+	default:
+		return Output{}, fmt.Errorf("directEdit: unsupported operation %v (want move/size/rotate/delete/scale)", f.def.Operation)
+	}
+}
+
+// recomputeSize pushes the picked faces along the direction by distance (the push/pull
+// size edit — MoveFaces with the vector direction·distance).
+func (f *DirectEditFeature) recomputeSize(in Input) (Output, error) {
+	dir, err := math.UnitVector3FromVector(f.def.Direction)
+	if err != nil {
+		return Output{}, fmt.Errorf("directEdit size: direction %v is degenerate", f.def.Direction)
+	}
+	delta := dir.AsVector().Scale(callOrZero(f.def.Distance))
+	return retopoFacesBody(in, f.def.FaceKeys, "directEdit size", func(b *topo.Body, keys [][]byte) (*topo.Body, error) {
+		return ops.MoveFaces(b, keys, delta)
+	})
+}
+
+// recomputeRotate rotates the picked faces about the axis.
+func (f *DirectEditFeature) recomputeRotate(in Input) (Output, error) {
+	dir, err := math.UnitVector3FromVector(f.def.AxisDir)
+	if err != nil {
+		return Output{}, fmt.Errorf("directEdit rotate: axis %v is degenerate", f.def.AxisDir)
+	}
+	return retopoFacesBody(in, f.def.FaceKeys, "directEdit rotate", func(b *topo.Body, keys [][]byte) (*topo.Body, error) {
+		return ops.RotateFaces(b, keys, f.def.AxisPoint, dir, callOrZero(f.def.Angle))
+	})
+}
+
+// recomputeScale scales the running body uniformly about the base point. Identity lineage
+// derive keeps every reference key, so downstream picks survive the edit.
+func (f *DirectEditFeature) recomputeScale(in Input) (Output, error) {
+	k := callOrZero(f.def.ScaleFactor)
+	if k <= 0 {
+		return Output{}, fmt.Errorf("directEdit scale: factor %g must be > 0", k)
+	}
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	m := scaleAbout(f.def.BasePoint, k)
+	scaled, err := ops.TransformBody(body, m, func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		return Output{}, fmt.Errorf("directEdit scale: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, scaled)}, nil
+}
+
+// scaleAbout is the uniform similarity T(p)·S(k)·T(−p).
+func scaleAbout(p math.Point3, k float64) math.Matrix4 {
+	toOrigin := math.Translation4(p.AsVector().Scale(-1))
+	back := math.Translation4(p.AsVector())
+	return back.Mul(math.Scale4(k, k, k)).Mul(toOrigin)
+}
+
+// AddDirectEdit adds a consolidated direct-edit operation (#332).
+func (c *ModifyFeatures) AddDirectEdit(def *DirectEditDefinition) *PartFeature {
+	pf := c.engine.Add(&DirectEditFeature{def: def})
+	pf.SetName(c.engine.UniqueName("DirectEdit"))
+	return pf
+}

--- a/model/feature/direct_edit_test.go
+++ b/model/feature/direct_edit_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+)
+
+// The consolidated direct edit (M09-F04 PBI-108, #332): one feature, five
+// operations, each pinned by an analytic volume.
+
+// directEditBox builds a 4×4×4 box engine and returns the face key whose
+// outward normal matches dir.
+func directEditBox(t *testing.T, dir math.Vector3) (*PartFeatures, []byte) {
+	t.Helper()
+	box := boxBody()
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	for _, f := range box.Faces() {
+		if pl, ok := f.Geometry().(geom.Plane); ok && float64(pl.Normal().Dot(dir)) > 0.9 {
+			return fs, f.ReferenceKey()
+		}
+	}
+	t.Fatal("no face with the requested normal")
+	return nil, nil
+}
+
+func directEditVolume(t *testing.T, fs *PartFeatures, def *DirectEditDefinition) float64 {
+	t.Helper()
+	pf := NewModifyFeatures(fs).AddDirectEdit(def)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("directEdit %v sick: %+v", def.Operation, pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("directEdit %v result not a valid solid: %+v", def.Operation, r)
+	}
+	return ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+}
+
+func TestDirectEditMovePushesFace(t *testing.T) {
+	fs, top := directEditBox(t, math.V3(0, 0, 1))
+	got := directEditVolume(t, fs, &DirectEditDefinition{
+		Operation: types.DirectEditMoveOperation, FaceKeys: [][]byte{top}, Translation: math.V3(0, 0, 1),
+	})
+	if stdmath.Abs(got-80) > 1e-9 { // 4×4×5
+		t.Errorf("move volume = %g, want 80", got)
+	}
+}
+
+func TestDirectEditSizePushesAlongDirection(t *testing.T) {
+	fs, side := directEditBox(t, math.V3(1, 0, 0))
+	got := directEditVolume(t, fs, &DirectEditDefinition{
+		Operation: types.DirectEditSizeOperation, FaceKeys: [][]byte{side},
+		Direction: math.V3(2, 0, 0), Distance: constFloat(0.5), // direction normalizes
+	})
+	if stdmath.Abs(got-72) > 1e-9 { // 4.5×4×4
+		t.Errorf("size volume = %g, want 72", got)
+	}
+}
+
+func TestDirectEditRotateTiltsFace(t *testing.T) {
+	fs, top := directEditBox(t, math.V3(0, 0, 1))
+	const theta = 0.1
+	got := directEditVolume(t, fs, &DirectEditDefinition{
+		Operation: types.DirectEditRotateOperation, FaceKeys: [][]byte{top},
+		AxisPoint: math.P3(0, 0, 4), AxisDir: math.V3(0, 1, 0), Angle: constFloat(theta),
+	})
+	// Top plane tilts to z = 4 − x·tanθ over x,y ∈ [0,4]: removed = ∫∫ x·tanθ = 32·tanθ.
+	want := 64 - 32*stdmath.Tan(theta)
+	if stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("rotate volume = %g, want %g", got, want)
+	}
+}
+
+func TestDirectEditScaleAboutPoint(t *testing.T) {
+	fs, _ := directEditBox(t, math.V3(0, 0, 1))
+	got := directEditVolume(t, fs, &DirectEditDefinition{
+		Operation: types.DirectEditScaleOperation, ScaleFactor: constFloat(1.5), BasePoint: math.P3(2, 2, 2),
+	})
+	if stdmath.Abs(got-64*1.5*1.5*1.5) > 1e-9 {
+		t.Errorf("scale volume = %g, want %g", got, 64*1.5*1.5*1.5)
+	}
+}
+
+func TestDirectEditDeleteDispatches(t *testing.T) {
+	// Delete reuses the same kernel op the standalone delete-face feature pins
+	// (healable cases live in its tests); here the dispatch path must go Sick
+	// on an unhealable pick — a box cap has nowhere to heal to — instead of
+	// corrupting the body.
+	fs, top := directEditBox(t, math.V3(0, 0, 1))
+	pf := NewModifyFeatures(fs).AddDirectEdit(&DirectEditDefinition{
+		Operation: types.DirectEditDeleteOperation, FaceKeys: [][]byte{top},
+	})
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Errorf("deleting a box cap = %v, want Sick (no healable neighbours)", pf.Health().Status)
+	}
+}
+
+func TestDirectEditUnknownOperationSick(t *testing.T) {
+	fs, top := directEditBox(t, math.V3(0, 0, 1))
+	pf := NewModifyFeatures(fs).AddDirectEdit(&DirectEditDefinition{
+		Operation: types.DirectEditUnknownOperation, FaceKeys: [][]byte{top},
+	})
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Errorf("unknown operation = %v, want Sick", pf.Health().Status)
+	}
+}
+
+func TestDirectEditRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewModifyFeatures(fs).AddDirectEdit(&DirectEditDefinition{
+		Operation: types.DirectEditRotateOperation, FaceKeys: [][]byte{[]byte("f")},
+		AxisPoint: math.P3(0, 0, 4), AxisDir: math.V3(0, 1, 0), Angle: constFloat(0.1),
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if data[0].DirectEdit == nil || data[0].DirectEdit.Operation != "rotate" {
+		t.Fatalf("serialized = %+v, want a rotate directEdit", data[0].DirectEdit)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*DirectEditFeature).Definition()
+	if def.Operation != types.DirectEditRotateOperation || def.Angle() != 0.1 || def.AxisDir.Y != 1 {
+		t.Errorf("restored = %+v, want the rotate definition back", def)
+	}
+}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -132,10 +132,17 @@ func (d *FaceDraftFeature) Recompute(in Input) (Output, error) {
 
 // ThreadDefinition applies thread data to a cylindrical face. Cut=false is a cosmetic thread
 // (data + display, solid unchanged); Cut=true models a real thread (a helical groove cut).
+// Class, Tapered, and ModelDiameter are the #325 parity fields: the tolerance class recorded
+// on the spec, the pipe-thread flag (the reference's TaperedThreadInfo split — data-only, a
+// cut tapered thread needs a conical face and errors), and which thread diameter the modeled
+// cylindrical face represents (zero value = major, the common case).
 type ThreadDefinition struct {
-	FaceKey     []byte
-	Designation string
-	Cut         bool
+	FaceKey       []byte
+	Designation   string
+	Cut           bool
+	Class         string
+	Tapered       bool
+	ModelDiameter types.ModelDiameterFromThread
 }
 
 // ThreadFeature tags a cylindrical face with a cosmetic thread (Inventor's ThreadFeature): it
@@ -154,11 +161,20 @@ func (t *ThreadFeature) Spec() *ThreadSpec { return t.spec }
 
 // Recompute parses the designation, binds the cylindrical face, records the thread spec, and
 // passes the (unchanged) solid through. A bad designation, a lost face, or a non-cylindrical
-// face makes the feature Sick.
+// face makes the feature Sick — as does cutting a tapered (pipe) thread, which would need a
+// conical face the feature doesn't model yet.
 func (t *ThreadFeature) Recompute(in Input) (Output, error) {
 	spec, err := ParseThreadDesignation(t.def.Designation)
 	if err != nil {
 		return Output{}, err
+	}
+	spec.Class, spec.Tapered = t.def.Class, t.def.Tapered
+	spec.ModelDiameter = t.def.ModelDiameter
+	if spec.ModelDiameter == 0 {
+		spec.ModelDiameter = types.ThreadMajorDiameter
+	}
+	if t.def.Tapered && t.def.Cut {
+		return Output{}, fmt.Errorf("thread %q: a cut tapered (pipe) thread needs a conical face; model it cosmetic", t.def.Designation)
 	}
 	body, err := runningBody(in)
 	if err != nil {
@@ -274,5 +290,10 @@ func (c *DressUpFeatures) AddDraftPull(faceKeys [][]byte, pull math.Vector3, ang
 // AddThread tags a cylindrical face with thread data; cut=true models a real (cut) thread,
 // cut=false a cosmetic one.
 func (c *DressUpFeatures) AddThread(faceKey []byte, designation string, cut bool) *PartFeature {
-	return c.engine.Add(&ThreadFeature{def: &ThreadDefinition{FaceKey: faceKey, Designation: designation, Cut: cut}})
+	return c.AddThreadDef(&ThreadDefinition{FaceKey: faceKey, Designation: designation, Cut: cut})
+}
+
+// AddThreadDef adds a thread from a full definition (class / tapered / model diameter, #325).
+func (c *DressUpFeatures) AddThreadDef(def *ThreadDefinition) *PartFeature {
+	return c.engine.Add(&ThreadFeature{def: def})
 }

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -21,13 +22,34 @@ import (
 // (rolling-ball fillets), so once inputs resolve these features report
 // [ErrDeferred] (→ health.Warning) and pass the body through unchanged.
 
-// FilletDefinition rounds selected edges to a radius.
+// FilletEdgeSet is one edge set of a fillet definition (the reference's
+// FilletConstantRadiusEdgeSet / FilletVariableRadiusEdgeSet): a constant Radius over the
+// whole set, or — when Radius is nil — a variable StartRadius→EndRadius over a single edge
+// (radius runs linearly from the edge's start vertex to its end vertex).
+type FilletEdgeSet struct {
+	EdgeKeys    [][]byte
+	Radius      func() float64
+	StartRadius func() float64
+	EndRadius   func() float64
+}
+
+// variable reports whether the set carries a start→end radius instead of a constant one.
+func (s FilletEdgeSet) variable() bool { return s.Radius == nil }
+
+// FilletDefinition rounds selected edges. EdgeKeys+Radius is the original single
+// constant-radius form; EdgeSets (when non-empty) takes precedence and carries any mix of
+// constant and variable sets (#323).
 type FilletDefinition struct {
 	EdgeKeys [][]byte
 	Radius   func() float64
+	EdgeSets []FilletEdgeSet
 }
 
-// FilletFeature is a constant-radius edge fillet.
+// FilletType reports the definition's discriminator: always an edge fillet for now (the
+// reference's face and full-round fillets are follow-ups tracked on #323).
+func (d *FilletDefinition) FilletType() types.FilletType { return types.EdgeFillet }
+
+// FilletFeature is an edge fillet over one or more constant/variable radius edge sets.
 type FilletFeature struct{ def *FilletDefinition }
 
 // Definition returns the fillet recipe.
@@ -37,8 +59,11 @@ func (f *FilletFeature) Definition() *FilletDefinition { return f.def }
 func (f *FilletFeature) Kind() string { return "fillet" }
 
 // Recompute rounds the picked convex edges on the running body with a real rolling-ball
-// blend (cylinder faces). See fillet.go.
+// blend (cylinder faces; planar ruling strips for variable sets). See fillet.go.
 func (f *FilletFeature) Recompute(in Input) (Output, error) {
+	if len(f.def.EdgeSets) > 0 {
+		return filletBodySets(in, f.def.EdgeSets, "fillet")
+	}
 	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), "fillet")
 }
 
@@ -203,6 +228,12 @@ func NewDressUpFeatures(engine *PartFeatures) *DressUpFeatures { return &DressUp
 // AddFillet rounds the given edges (by reference key) to radius.
 func (c *DressUpFeatures) AddFillet(edgeKeys [][]byte, radius func() float64) *PartFeature {
 	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius}})
+}
+
+// AddFilletSets rounds any mix of constant and variable radius edge sets in one feature
+// (the reference's FilletDefinition edge-set model, #323).
+func (c *DressUpFeatures) AddFilletSets(sets []FilletEdgeSet) *PartFeature {
+	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeSets: sets}})
 }
 
 // AddChamfer bevels the given edges by distance, blending three-edge corners flat (the

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 )
 
 // filletBody rounds the selected convex edges of the running body to the given radius via
@@ -46,4 +47,70 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, feat string) (Outpu
 		return Output{}, err
 	}
 	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// filletBodySets rounds the definition's edge sets in one kernel pass: each constant set
+// contributes its edges at one radius, each variable set one edge with a start→end radius.
+// A single constant set routes through filletBody to keep the analytic cylinder-rim path.
+func filletBodySets(in Input, sets []FilletEdgeSet, feat string) (Output, error) {
+	if len(sets) == 1 && !sets[0].variable() {
+		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), feat)
+	}
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	picks, err := filletPicksOf(sets, feat)
+	if err != nil {
+		return Output{}, err
+	}
+	work := planarizeFilletPicks(body, picks, feat)
+	result, err := ops.FilletEdgesVarying(work, picks)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// filletPicksOf flattens the edge sets into per-edge radius picks, rejecting a variable set
+// that holds more than one edge (a variable radius runs along ONE edge; tangent chains are a
+// follow-up).
+func filletPicksOf(sets []FilletEdgeSet, feat string) ([]ops.EdgeFilletRadii, error) {
+	var out []ops.EdgeFilletRadii
+	for _, s := range sets {
+		if !s.variable() {
+			r := callOrZero(s.Radius)
+			for _, k := range s.EdgeKeys {
+				out = append(out, ops.EdgeFilletRadii{Key: k, R0: r, R1: r})
+			}
+			continue
+		}
+		if len(s.EdgeKeys) != 1 {
+			return nil, fmt.Errorf("%s: a variable-radius set must hold exactly 1 edge, got %d (tangent chains are a follow-up)", feat, len(s.EdgeKeys))
+		}
+		out = append(out, ops.EdgeFilletRadii{Key: s.EdgeKeys[0], R0: callOrZero(s.StartRadius), R1: callOrZero(s.EndRadius)})
+	}
+	return out, nil
+}
+
+// planarizeFilletPicks re-facets a curved body for the picks' edges (remapping each pick's
+// key to the faceted segment, see planarizeForEdges); a planar body — or an unresolvable
+// key, surfaced later by the kernel — passes through unchanged.
+func planarizeFilletPicks(body *topo.Body, picks []ops.EdgeFilletRadii, feat string) *topo.Body {
+	keys := make([][]byte, len(picks))
+	for i, p := range picks {
+		keys[i] = p.Key
+	}
+	origEdges, err := resolveEdges(body, keys)
+	if err != nil {
+		return body
+	}
+	pb, mapped := planarizeForEdges(body, origEdges, feat)
+	if pb == body {
+		return body
+	}
+	for i, me := range mapped {
+		picks[i].Key = me.ReferenceKey()
+	}
+	return pb
 }

--- a/model/feature/fillet_sets_test.go
+++ b/model/feature/fillet_sets_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/sketch"
+)
+
+// Fillet edge sets (M09-F01 PBI-099, #323): mixed constant sets and the
+// variable start→end radius set through the feature engine.
+
+// boxAndVerticalEdges builds a 2×2×2 box and returns it with the reference
+// keys of its four vertical edges (no two of which share a vertex).
+func boxAndVerticalEdges(t *testing.T) (*PartFeatures, [][]byte) {
+	t.Helper()
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var keys [][]byte
+	for _, e := range box.Edges() {
+		if a, b := e.StartVertex().Point(), e.EndVertex().Point(); a.X == b.X && a.Y == b.Y {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	if len(keys) != 4 {
+		t.Fatalf("found %d vertical edges, want 4", len(keys))
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	return fs, keys
+}
+
+// TestFilletSetsMixedConstantRadii rounds two vertical edges at different
+// radii via two constant sets in one feature — the cylinder-exact volume.
+func TestFilletSetsMixedConstantRadii(t *testing.T) {
+	fs, keys := boxAndVerticalEdges(t)
+	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{
+		{EdgeKeys: [][]byte{keys[0]}, Radius: angleConst(0.3)},
+		{EdgeKeys: [][]byte{keys[1]}, Radius: angleConst(0.6)},
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("mixed-set fillet sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("mixed-set fillet not a valid solid: %+v", r)
+	}
+	notch := func(r float64) float64 { return r*r - stdmath.Pi*r*r/4 }
+	want := 8 - notch(0.3)*2 - notch(0.6)*2
+	if got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume; relErr(got, want) > 1e-3 {
+		t.Errorf("mixed-set fillet volume = %g, want ≈ %g", got, want)
+	}
+}
+
+// TestFilletVariableSetThroughEngine rounds one vertical edge 0.3→0.6 through
+// the feature engine — the exact chord-geometry volume (planar strips).
+func TestFilletVariableSetThroughEngine(t *testing.T) {
+	fs, keys := boxAndVerticalEdges(t)
+	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{
+		{EdgeKeys: [][]byte{keys[0]}, StartRadius: angleConst(0.3), EndRadius: angleConst(0.6)},
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("variable fillet sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	const k = 8 // chords across the 90° wedge at the holeFacets density
+	c := 1 - float64(k)/2*stdmath.Sin(stdmath.Pi/2/float64(k))
+	want := 8 - c*2*(0.3*0.3+0.3*0.6+0.6*0.6)/3
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("variable fillet volume = %g, want %g", got, want)
+	}
+	if pf.Definition().(*FilletFeature).Definition().FilletType() != 61697 {
+		t.Error("fillet type discriminator != edge fillet")
+	}
+}
+
+// TestFilletVariableSetNeedsOneEdge: a variable set over two edges is a
+// precise Sick, not a broken body.
+func TestFilletVariableSetNeedsOneEdge(t *testing.T) {
+	fs, keys := boxAndVerticalEdges(t)
+	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{
+		{EdgeKeys: [][]byte{keys[0], keys[1]}, StartRadius: angleConst(0.2), EndRadius: angleConst(0.4)},
+	})
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Errorf("two-edge variable set = %v, want Sick", pf.Health().Status)
+	}
+}
+
+// TestFilletSetsLostEdgeSick: any lost key in any set makes the feature Sick.
+func TestFilletSetsLostEdgeSick(t *testing.T) {
+	fs, keys := boxAndVerticalEdges(t)
+	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{
+		{EdgeKeys: [][]byte{keys[0]}, Radius: angleConst(0.3)},
+		{EdgeKeys: [][]byte{[]byte("gone")}, Radius: angleConst(0.2)},
+	})
+	fs.Recompute()
+	if pf.Health().Status != health.Sick {
+		t.Errorf("lost-edge set = %v, want Sick", pf.Health().Status)
+	}
+}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -18,8 +18,9 @@ import (
 // planar slab via brep.CutCylindricalHole, a blind hole via brep.CutBlindCylindricalHole
 // (flat bottom, or a conical drill point when PointAngle is set). A counterbore adds a flat
 // recess + shoulder; a countersink a true cone recess (exact-only). Unsupported drilled/
-// counterbore shapes fall back to the faceted boolean. Boss geometry still defers (ErrDeferred →
-// Warning). A lost placement face → Sick. Point placement (vs. the face centroid) is a follow-up.
+// counterbore shapes fall back to the faceted boolean. A boss is the join-side mirror of the
+// drilled hole: the same tool cylinder grown OUT of the face and unioned (#327). A lost
+// placement face → Sick. Point placement (vs. the face centroid) is a follow-up.
 
 // HoleTapInfo carries thread data for a tapped hole, consumed by hole tables (M14).
 type HoleTapInfo struct {
@@ -224,19 +225,51 @@ type BossDefinition struct {
 }
 
 // BossFeature adds a cylindrical boss to the running solid.
-type BossFeature struct{ def *BossDefinition }
+type BossFeature struct {
+	def      *BossDefinition
+	featName string
+	tool     *topo.Body // the boss cylinder of the last recompute, for pattern replication
+}
 
 func (b *BossFeature) Definition() *BossDefinition { return b.def }
 func (b *BossFeature) Kind() string                { return "boss" }
+
+// Recompute resolves the placement face and raises the boss cylinder from its centroid along
+// the outward normal, joining it to the running body. The tool's small entry overhang sits
+// INSIDE the body (drillTool's near span), so the union always overlaps cleanly.
 func (b *BossFeature) Recompute(in Input) (Output, error) {
-	return resolveFacesThenDefer(in, [][]byte{b.def.PlacementFaceKey}, "boss")
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	face, ok := body.FindFaceByKey(b.def.PlacementFaceKey)
+	if !ok {
+		return Output{}, fmt.Errorf("boss: placement face reference lost")
+	}
+	r, h := callOrZero(b.def.Diameter)/2, callOrZero(b.def.Height)
+	if r <= 0 || h <= 0 {
+		return Output{}, fmt.Errorf("boss: diameter %g and height %g must be > 0", 2*r, h)
+	}
+	out, err := math.UnitVector3FromVector(face.Geometry().NormalAt(0, 0))
+	if err != nil {
+		return Output{}, fmt.Errorf("boss: placement face has no normal")
+	}
+	b.tool = drillTool(centroidOf(faceVertexPoints(face)), out, r, h, featOr(b.featName, "boss"))
+	res, err := ops.Boolean(ops.Join, body, b.tool)
+	if err != nil {
+		return Output{}, fmt.Errorf("boss: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
 }
 
-// Operation reports that a boss adds material, so once boss geometry lands a pattern of a boss
-// unions its raised cylinder at each occurrence. Until then its geometry defers (it builds no
-// body), so a pattern of a boss replicates nothing rather than copying the whole solid — the
-// empty-delta path in [sourceDelta]/[patternBase.replicate]. Implements [OperationalFeature].
+// Operation reports that a boss adds material, so a pattern of a boss unions its raised
+// cylinder at each occurrence (one body with N studs) instead of copying the whole solid.
+// Implements [OperationalFeature].
 func (b *BossFeature) Operation() ops.PartFeatureOperation { return ops.Join }
+
+// ToolBody returns the boss cylinder the last recompute joined, so a pattern replicates a
+// clean stud at each occurrence. Implements [ToolFeature].
+func (b *BossFeature) ToolBody() *topo.Body { return b.tool }
 
 // HoleFeatures and BossFeatures add hole/boss features into the engine.
 type (
@@ -293,7 +326,12 @@ func (c *HoleFeatures) addHole(def *HoleDefinition) *PartFeature {
 	return pf
 }
 
-// Add adds a cylindrical boss on the placement face.
+// Add adds a cylindrical boss on the placement face, naming it (Boss1, Boss2, …) so its
+// generated topology has a stable, distinct lineage.
 func (c *BossFeatures) Add(faceKey []byte, diameter, height func() float64) *PartFeature {
-	return c.engine.Add(&BossFeature{def: &BossDefinition{PlacementFaceKey: faceKey, Diameter: diameter, Height: height}})
+	bf := &BossFeature{def: &BossDefinition{PlacementFaceKey: faceKey, Diameter: diameter, Height: height}}
+	pf := c.engine.Add(bf)
+	pf.SetName(c.engine.UniqueName("Boss"))
+	bf.featName = pf.name
+	return pf
 }

--- a/model/feature/hole_boss_test.go
+++ b/model/feature/hole_boss_test.go
@@ -13,10 +13,10 @@ import (
 	"oblikovati.org/model/sketch"
 )
 
-func TestHoleGeneratesRealGeometryBossDefers(t *testing.T) {
-	// A drilled hole now generates real geometry (healthy). Each feature is tested on its
-	// own body: a boolean rebuilds the topology with new lineage, so a reference to a
-	// pre-cut face does not survive (chaining across a boolean is a follow-up).
+func TestHoleAndBossGenerateRealGeometry(t *testing.T) {
+	// A drilled hole and a boss both generate real geometry (healthy). Each feature is
+	// tested on its own body: a boolean rebuilds the topology with new lineage, so a
+	// reference to a pre-cut face does not survive (chaining across a boolean is a follow-up).
 	hb := prismBody()
 	fsHole := NewPartFeatures(nil, nil)
 	NewBaseFeatures(fsHole).AddBase(hb)
@@ -31,13 +31,75 @@ func TestHoleGeneratesRealGeometryBossDefers(t *testing.T) {
 	NewBaseFeatures(fsBoss).AddBase(bb)
 	boss := NewBossFeatures(fsBoss).Add(bb.Faces()[0].ReferenceKey(), func() float64 { return 0.5 }, func() float64 { return 1 })
 	fsBoss.Recompute()
-	if boss.Health().Status != health.Warning {
-		t.Errorf("boss health = %v, want warning (geometry deferred)", boss.Health().Status)
+	if !boss.Health().OK() {
+		t.Errorf("boss health = %v, want OK (real stud, #327)", boss.Health())
 	}
 
 	tapped := NewHoleFeatures(NewPartFeatures(nil, nil)).AddTapped([]byte("f"), func() float64 { return 0.2 }, func() float64 { return 0.4 }, "M5x0.8")
 	if tap := tapped.Definition().(*HoleFeature).Definition().Tap; !tap.Tapped || tap.Designation != "M5x0.8" {
 		t.Errorf("tap info = %+v, want tapped M5x0.8", tap)
+	}
+}
+
+// TestBossRaisesStudOfExactVolume: a boss on a block's top adds exactly the stud's prism
+// volume (the entry overhang overlaps the block, so it adds nothing) — #327.
+func TestBossRaisesStudOfExactVolume(t *testing.T) {
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=2 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	boss := NewBossFeatures(fs).Add(top, func() float64 { return 1 }, func() float64 { return 1.5 })
+	fs.Recompute()
+	if !boss.Health().OK() {
+		t.Fatalf("boss sick: %+v", boss.Health())
+	}
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("boss result = %d bodies, want 1 (joined)", len(res))
+	}
+	if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+		t.Fatalf("bossed body not a valid solid: %+v", r)
+	}
+	want := 32 + regularPolygonArea(0.5, holeFacets)*1.5
+	if got := ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("bossed volume = %g, want %g (block + Ø1×1.5 stud)", got, want)
+	}
+}
+
+// TestBossLostFaceSick: a boss whose placement face vanished goes Sick.
+func TestBossLostFaceSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(prismBody())
+	boss := NewBossFeatures(fs).Add([]byte("gone"), func() float64 { return 1 }, func() float64 { return 1 })
+	fs.Recompute()
+	if boss.Health().Status != health.Sick {
+		t.Errorf("boss health = %v, want Sick (lost placement face)", boss.Health().Status)
+	}
+}
+
+// TestPatternOfBossReplicatesStuds: a rectangular pattern of a boss re-joins the clean stud
+// (ToolBody) at each occurrence — one body whose volume grows by N−1 extra studs.
+func TestPatternOfBossReplicatesStuds(t *testing.T) {
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey()
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	boss := NewBossFeatures(fs).Add(top, func() float64 { return 1 }, func() float64 { return 1.5 })
+	// Step 1.2 keeps the copy fully on the block (a step to the rim would leave half the
+	// entry overhang unsupported and add half a sliver of volume).
+	NewPatternFeatures(fs).AddRectangular([]ID{boss.ID()},
+		func() int { return 2 }, func() int { return 1 }, math.V3(1.2, 0, 0), noStep)
+	fs.Recompute()
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("pattern of a boss → %d bodies, want 1", len(res))
+	}
+	stud := regularPolygonArea(0.5, holeFacets) * 1.5
+	want := 32 + 2*stud
+	if got := ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("patterned-boss volume = %g, want %g (block + 2 studs)", got, want)
 	}
 }
 

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -82,13 +83,23 @@ func (f *faceEditFeature) FaceKeys() [][]byte { return f.faceKeys }
 type SplitFeature struct{ faceEditFeature }
 
 // ThickenFeature turns the running surface (sheet) body into a solid of a wall thickness.
-type ThickenFeature struct{ thickness func() float64 }
+// Approximation mirrors FaceOffsetFeature's (#331): carried, exact path computed.
+type ThickenFeature struct {
+	thickness     func() float64
+	approximation types.FeatureApproximationType
+}
 
 // Kind implements [Feature].
 func (f *ThickenFeature) Kind() string { return "thicken" }
 
 // Thickness returns the wall thickness (for the UI / serialization).
 func (f *ThickenFeature) Thickness() float64 { return f.thickness() }
+
+// Approximation returns the requested approximation (zero value = none/exact).
+func (f *ThickenFeature) Approximation() types.FeatureApproximationType { return f.approximation }
+
+// SetApproximation records the approximation request (the kernel still computes exact).
+func (f *ThickenFeature) SetApproximation(a types.FeatureApproximationType) { f.approximation = a }
 
 // Recompute thickens the running surface body into a solid (see kernel/ops/thicken.go); a
 // non-surface or non-thickenable body makes the feature go Sick.
@@ -134,30 +145,57 @@ func (f *DeleteFaceFeature) Recompute(in Input) (Output, error) {
 	return retopoFacesBody(in, f.faceKeys, f.kind, ops.DeleteFaces)
 }
 
-// MoveFaceFeature translates the picked faces by a vector, retrimming the neighbours.
+// MoveFaceFeature translates the picked faces by a vector — or, in rotate mode (#331),
+// rotates them about an axis — retrimming the neighbours.
 type MoveFaceFeature struct {
 	faceEditFeature
 	translation math.Vector3
+	axisPoint   math.Point3
+	axisDir     math.Vector3 // zero = translate mode
+	angle       func() float64
 }
 
 // Translation returns the move-face displacement (for the UI / serialization).
 func (f *MoveFaceFeature) Translation() math.Vector3 { return f.translation }
 
-// Recompute moves the picked faces on the running body (see kernel/ops/move_face.go).
+// Rotation returns the rotate-mode axis and angle; rotating reports false in translate mode.
+func (f *MoveFaceFeature) Rotation() (point math.Point3, dir math.Vector3, angle float64, rotating bool) {
+	if f.angle == nil {
+		return math.Point3{}, math.Vector3{}, 0, false
+	}
+	return f.axisPoint, f.axisDir, f.angle(), true
+}
+
+// Recompute moves (or rotates) the picked faces on the running body (see
+// kernel/ops/move_face.go).
 func (f *MoveFaceFeature) Recompute(in Input) (Output, error) {
 	return retopoFacesBody(in, f.faceKeys, f.kind, func(b *topo.Body, keys [][]byte) (*topo.Body, error) {
-		return ops.MoveFaces(b, keys, f.translation)
+		if f.angle == nil {
+			return ops.MoveFaces(b, keys, f.translation)
+		}
+		dir, err := math.UnitVector3FromVector(f.axisDir)
+		if err != nil {
+			return nil, fmt.Errorf("rotate axis %v is degenerate", f.axisDir)
+		}
+		return ops.RotateFaces(b, keys, f.axisPoint, dir, f.angle())
 	})
 }
 
 // FaceOffsetFeature moves the picked faces along their own normals by a distance.
+// Approximation is the #331 parity input: the kernel computes the EXACT offset, which
+// satisfies every approximation bound, so the choice is carried for the API/UI without
+// changing geometry.
 type FaceOffsetFeature struct {
 	faceEditFeature
-	distance func() float64
+	distance      func() float64
+	approximation types.FeatureApproximationType
 }
 
 // Distance returns the face-offset distance (for the UI / serialization).
 func (f *FaceOffsetFeature) Distance() float64 { return f.distance() }
+
+// Approximation returns the requested approximation (zero value = none/exact).
+func (f *FaceOffsetFeature) Approximation() types.FeatureApproximationType { return f.approximation }
 
 // Recompute offsets the picked faces on the running body (see kernel/ops/move_face.go).
 func (f *FaceOffsetFeature) Recompute(in Input) (Output, error) {
@@ -201,6 +239,15 @@ func (c *ModifyFeatures) AddMoveFace(faceKeys [][]byte, translation math.Vector3
 	return c.engine.Add(&MoveFaceFeature{faceEditFeature: faceEditFeature{kind: "move-face", faceKeys: faceKeys}, translation: translation})
 }
 
+// AddMoveFaceRotate is the rotate arm of move-face (#331): the picked faces rotate by angle
+// about the axis (point + direction).
+func (c *ModifyFeatures) AddMoveFaceRotate(faceKeys [][]byte, axisPoint math.Point3, axisDir math.Vector3, angle func() float64) *PartFeature {
+	return c.engine.Add(&MoveFaceFeature{
+		faceEditFeature: faceEditFeature{kind: "move-face", faceKeys: faceKeys},
+		axisPoint:       axisPoint, axisDir: axisDir, angle: angle,
+	})
+}
+
 func (c *ModifyFeatures) AddFaceOffset(faceKeys [][]byte, distance float64) *PartFeature {
 	return c.AddFaceOffsetFn(faceKeys, constFloat(distance))
 }
@@ -208,6 +255,15 @@ func (c *ModifyFeatures) AddFaceOffset(faceKeys [][]byte, distance float64) *Par
 // AddFaceOffsetFn is AddFaceOffset with a live (parameter-driven) distance.
 func (c *ModifyFeatures) AddFaceOffsetFn(faceKeys [][]byte, distance func() float64) *PartFeature {
 	return c.engine.Add(&FaceOffsetFeature{faceEditFeature: faceEditFeature{kind: "face-offset", faceKeys: faceKeys}, distance: distance})
+}
+
+// AddFaceOffsetApprox is AddFaceOffsetFn carrying the #331 approximation request (the kernel
+// computes the exact offset, which satisfies every approximation bound).
+func (c *ModifyFeatures) AddFaceOffsetApprox(faceKeys [][]byte, distance func() float64, approx types.FeatureApproximationType) *PartFeature {
+	return c.engine.Add(&FaceOffsetFeature{
+		faceEditFeature: faceEditFeature{kind: "face-offset", faceKeys: faceKeys},
+		distance:        distance, approximation: approx,
+	})
 }
 
 func (c *ModifyFeatures) AddDeleteFace(faceKeys [][]byte) *PartFeature {

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -215,5 +216,57 @@ func TestCombineDefinitionAccessible(t *testing.T) {
 	c := NewModifyFeatures(fs).AddCombine(0, 1, ops.Cut)
 	if c.Definition().(*CombineFeature).Definition().Operation != ops.Cut {
 		t.Error("combine definition not accessible")
+	}
+}
+
+// The #331 face-edit extensions: move-face rotate mode and the approximation
+// request, both surviving the recipe codec.
+func TestMoveFaceRotateAndApproximationRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewModifyFeatures(fs).AddMoveFaceRotate([][]byte{[]byte("f1")},
+		math.P3(0, 0, 2), math.V3(0, 1, 0), constFloat(0.15))
+	NewModifyFeatures(fs).AddFaceOffsetApprox([][]byte{[]byte("f2")},
+		constFloat(0.3), types.NeverTooThinApproximation)
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if d := data[0].FaceEdit; len(d.AxisDir) != 3 || d.Angle != 0.15 || d.Translation != nil {
+		t.Fatalf("serialized rotate = %+v, want axis+angle and no translation", d)
+	}
+	if data[1].FaceEdit.Approximation != "neverTooThin" {
+		t.Fatalf("serialized approximation = %q", data[1].FaceEdit.Approximation)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if _, dir, angle, rotating := fresh.Item(0).Definition().(*MoveFaceFeature).Rotation(); !rotating || dir.Y != 1 || angle != 0.15 {
+		t.Errorf("restored rotate = dir %v angle %v rotating %v", dir, angle, rotating)
+	}
+	if got := fresh.Item(1).Definition().(*FaceOffsetFeature).Approximation(); got != types.NeverTooThinApproximation {
+		t.Errorf("restored approximation = %v, want neverTooThin", got)
+	}
+}
+
+// TestThickenApproximationRoundTrip: thicken carries its approximation too.
+func TestThickenApproximationRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	pf := NewModifyFeatures(fs).AddThicken(0.2)
+	pf.Definition().(*ThickenFeature).SetApproximation(types.MeanApproximation)
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if data[0].Thicken.Approximation != "mean" {
+		t.Fatalf("serialized thicken = %+v", data[0].Thicken)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if got := fresh.Item(0).Definition().(*ThickenFeature).Approximation(); got != types.MeanApproximation {
+		t.Errorf("restored thicken approximation = %v, want mean", got)
 	}
 }

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -116,7 +116,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		p := f.def.PullDir
 		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle), Pull: []float64{p.X, p.Y, p.Z}}
 	case *ThreadFeature:
-		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut}
+		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut,
+			Class: f.def.Class, Tapered: f.def.Tapered, ModelDiameter: threadModelDiameterName(f.def.ModelDiameter)}
 	case *HoleFeature:
 		h, err := serializeHole(f.def)
 		if err != nil {
@@ -314,7 +315,12 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if err != nil {
 			return nil, err
 		}
-		return du.AddThread(key, fd.Thread.Designation, fd.Thread.Cut), nil
+		md, err := threadModelDiameterOf(fd.Thread.ModelDiameter)
+		if err != nil {
+			return nil, err
+		}
+		return du.AddThreadDef(&ThreadDefinition{FaceKey: key, Designation: fd.Thread.Designation,
+			Cut: fd.Thread.Cut, Class: fd.Thread.Class, Tapered: fd.Thread.Tapered, ModelDiameter: md}), nil
 	case "hole":
 		return restoreHole(fs, fd.Hole)
 	case "boss":

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -102,6 +102,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		}
 		fd.Extrude = ed
 	case *FilletFeature:
+		if len(f.def.EdgeSets) > 0 {
+			fd.Fillet = &EdgeDressData{Sets: serializeFilletSets(f.def.EdgeSets)}
+			break
+		}
 		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius)}
 	case *ChamferFeature:
 		flat := f.def.FlatCorners
@@ -272,6 +276,13 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 	case "extrude":
 		return requireExtrude(fs, fd.Extrude, sk, work)
 	case "fillet":
+		if fd.Fillet != nil && len(fd.Fillet.Sets) > 0 {
+			sets, err := restoreFilletSets(fd.Fillet.Sets)
+			if err != nil {
+				return nil, err
+			}
+			return du.AddFilletSets(sets), nil
+		}
 		d, err := requireEdgeDress(fd.Fillet, "fillet")
 		if err != nil {
 			return nil, err

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -36,6 +36,7 @@ type FeatureData struct {
 	Emboss     *EmbossData     `yaml:"emboss,omitempty"`
 	Combine    *CombineData    `yaml:"combine,omitempty"`
 	SplitSolid *SplitSolidData `yaml:"splitSolid,omitempty"`
+	DirectEdit *DirectEditData `yaml:"directEdit,omitempty"`
 
 	RectPattern   *RectPatternData         `yaml:"rectangularPattern,omitempty"`
 	CircPattern   *CircPatternData         `yaml:"circularPattern,omitempty"`
@@ -233,6 +234,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Finish = &FinishData{Faces: encodeKeys(f.def.FaceKeys), Spec: f.def.Spec}
 	case *ImportedBodyFeature:
 		fd.Import = serializeImportedBody(f)
+	case *DirectEditFeature:
+		fd.DirectEdit = serializeDirectEdit(f.def)
 	case *MoveFaceFeature:
 		fd.FaceEdit = serializeMoveFace(f)
 	case *FaceOffsetFeature:
@@ -327,6 +330,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreBoss(fs, fd.Boss)
 	case "combine":
 		return restoreCombine(fs, fd.Combine)
+	case "directEdit":
+		return restoreDirectEdit(fs, fd.DirectEdit)
 	case "rectangular-pattern":
 		return restoreRectPattern(fs, fd.RectPattern, restored)
 	case "circular-pattern":

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -234,14 +234,14 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 	case *ImportedBodyFeature:
 		fd.Import = serializeImportedBody(f)
 	case *MoveFaceFeature:
-		t := f.Translation()
-		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Translation: []float64{t.X, t.Y, t.Z}}
+		fd.FaceEdit = serializeMoveFace(f)
 	case *FaceOffsetFeature:
-		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Distance: f.Distance()}
+		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Distance: f.Distance(),
+			Approximation: approximationName(f.Approximation())}
 	case *ReplaceFaceFeature:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Target: encodeKey(f.TargetKey())}
 	case *ThickenFeature:
-		fd.Thicken = &ThickenData{Value: f.Thickness()}
+		fd.Thicken = &ThickenData{Value: f.Thickness(), Approximation: approximationName(f.Approximation())}
 	case faceEditor:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	default:
@@ -345,7 +345,13 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if fd.Thicken == nil {
 			return nil, fmt.Errorf("thicken feature is missing its payload")
 		}
-		return NewModifyFeatures(fs).AddThicken(fd.Thicken.Value), nil
+		approx, err := approximationOf(fd.Thicken.Approximation)
+		if err != nil {
+			return nil, err
+		}
+		pf := NewModifyFeatures(fs).AddThicken(fd.Thicken.Value)
+		pf.Definition().(*ThickenFeature).SetApproximation(approx)
+		return pf, nil
 	case "revolve":
 		return restoreRevolve(fs, fd.Revolve, sk, work)
 	case "coil":

--- a/model/feature/serialize_directedit.go
+++ b/model/feature/serialize_directedit.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// YAML codec for the consolidated direct edit (#332). The operation is stored by its
+// frozen wire spelling; only the fields its operation uses are emitted.
+
+// DirectEditData is a direct edit's recipe.
+type DirectEditData struct {
+	Operation   string    `yaml:"operation"`
+	Faces       []string  `yaml:"faces,omitempty"`
+	Translation []float64 `yaml:"translation,omitempty"`
+	Direction   []float64 `yaml:"direction,omitempty"`
+	Distance    float64   `yaml:"distance,omitempty"`
+	AxisPoint   []float64 `yaml:"axisPoint,omitempty"`
+	AxisDir     []float64 `yaml:"axisDir,omitempty"`
+	Angle       float64   `yaml:"angle,omitempty"`
+	Scale       float64   `yaml:"scale,omitempty"`
+	Base        []float64 `yaml:"base,omitempty"`
+}
+
+func serializeDirectEdit(def *DirectEditDefinition) *DirectEditData {
+	return &DirectEditData{
+		Operation:   def.Operation.String(),
+		Faces:       encodeKeys(def.FaceKeys),
+		Translation: encodeVec3(def.Translation),
+		Direction:   encodeVec3(def.Direction),
+		Distance:    evalFloat(def.Distance),
+		AxisPoint:   encodePoint3(def.AxisPoint),
+		AxisDir:     encodeVec3(def.AxisDir),
+		Angle:       evalFloat(def.Angle),
+		Scale:       evalFloat(def.ScaleFactor),
+		Base:        encodePoint3(def.BasePoint),
+	}
+}
+
+func restoreDirectEdit(fs *PartFeatures, d *DirectEditData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("directEdit feature is missing its payload")
+	}
+	op, ok := types.ParseDirectEditOperationType(d.Operation)
+	if !ok {
+		return nil, fmt.Errorf("directEdit: unknown operation %q (want move/size/rotate/delete/scale)", d.Operation)
+	}
+	keys, err := decodeKeys(d.Faces)
+	if err != nil {
+		return nil, err
+	}
+	return NewModifyFeatures(fs).AddDirectEdit(&DirectEditDefinition{
+		Operation: op, FaceKeys: keys,
+		Translation: decodeVec3(d.Translation),
+		Direction:   decodeVec3(d.Direction), Distance: constFloat(d.Distance),
+		AxisPoint: decodePoint3(d.AxisPoint), AxisDir: decodeVec3(d.AxisDir), Angle: constFloat(d.Angle),
+		ScaleFactor: constFloat(d.Scale), BasePoint: decodePoint3(d.Base),
+	}), nil
+}

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 )
 
@@ -85,11 +86,16 @@ type FaceDressData struct {
 	Pull  []float64 `yaml:"pull,omitempty"` // draft pull direction (dx,dy,dz); absent ⇒ +Z
 }
 
-// ThreadData tags a single cylindrical face (reference key) with a thread designation.
+// ThreadData tags a single cylindrical face (reference key) with a thread designation, plus
+// the #325 parity fields: the tolerance class, the tapered (pipe) flag, and which thread
+// diameter the modeled face represents (wire spelling; absent = major).
 type ThreadData struct {
-	Face        string `yaml:"face"`
-	Designation string `yaml:"designation"`
-	Cut         bool   `yaml:"cut,omitempty"`
+	Face          string `yaml:"face"`
+	Designation   string `yaml:"designation"`
+	Cut           bool   `yaml:"cut,omitempty"`
+	Class         string `yaml:"class,omitempty"`
+	Tapered       bool   `yaml:"tapered,omitempty"`
+	ModelDiameter string `yaml:"modelDiameter,omitempty"`
 }
 
 // dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups.
@@ -171,4 +177,25 @@ func chamferFlatCornersOr(p *bool) bool {
 		return true
 	}
 	return *p
+}
+
+// threadModelDiameterName encodes a thread's model-diameter choice as its wire spelling
+// (empty for the zero value, so older recipes stay byte-identical).
+func threadModelDiameterName(md types.ModelDiameterFromThread) string {
+	if md == 0 {
+		return ""
+	}
+	return md.String()
+}
+
+// threadModelDiameterOf decodes the wire spelling back (absent = zero value, meaning major).
+func threadModelDiameterOf(s string) (types.ModelDiameterFromThread, error) {
+	if s == "" {
+		return 0, nil
+	}
+	md, ok := types.ParseModelDiameterFromThread(s)
+	if !ok {
+		return 0, fmt.Errorf("thread: unknown modelDiameter %q (want major/minor/pitch/tapDrill)", s)
+	}
+	return md, nil
 }

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -27,10 +27,54 @@ func draftPull(p []float64) math.Vector3 {
 // picked edges as reference keys plus the scalar value. FlatCorners is chamfer-only and a
 // pointer so an absent value (older recipes, or a fillet) is distinguishable from an
 // explicit false; absent restores as the flat-corner default (see chamferFlatCornersOr).
+// Sets is fillet-only: the edge-set form (#323) — when present it carries the whole recipe
+// and Edges/Value stay empty.
 type EdgeDressData struct {
+	Edges       []string        `yaml:"edges,omitempty"`
+	Value       float64         `yaml:"value,omitempty"`
+	FlatCorners *bool           `yaml:"flatCorners,omitempty"`
+	Sets        []FilletSetData `yaml:"sets,omitempty"`
+}
+
+// FilletSetData is one serialized fillet edge set: constant (Radius) or variable
+// (StartRadius/EndRadius over one edge).
+type FilletSetData struct {
 	Edges       []string `yaml:"edges"`
-	Value       float64  `yaml:"value"`
-	FlatCorners *bool    `yaml:"flatCorners,omitempty"`
+	Radius      float64  `yaml:"radius,omitempty"`
+	StartRadius float64  `yaml:"startRadius,omitempty"`
+	EndRadius   float64  `yaml:"endRadius,omitempty"`
+}
+
+// serializeFilletSets encodes a fillet's edge sets (nil for the legacy single-set form).
+func serializeFilletSets(sets []FilletEdgeSet) []FilletSetData {
+	out := make([]FilletSetData, len(sets))
+	for i, s := range sets {
+		out[i] = FilletSetData{Edges: encodeKeys(s.EdgeKeys)}
+		if s.variable() {
+			out[i].StartRadius, out[i].EndRadius = evalFloat(s.StartRadius), evalFloat(s.EndRadius)
+			continue
+		}
+		out[i].Radius = evalFloat(s.Radius)
+	}
+	return out
+}
+
+// restoreFilletSets decodes the edge-set form back into definition sets.
+func restoreFilletSets(sets []FilletSetData) ([]FilletEdgeSet, error) {
+	out := make([]FilletEdgeSet, len(sets))
+	for i, s := range sets {
+		keys, err := decodeKeys(s.Edges)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = FilletEdgeSet{EdgeKeys: keys}
+		if s.Radius > 0 {
+			out[i].Radius = constFloat(s.Radius)
+			continue
+		}
+		out[i].StartRadius, out[i].EndRadius = constFloat(s.StartRadius), constFloat(s.EndRadius)
+	}
+	return out, nil
 }
 
 // FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -2,26 +2,67 @@
 
 package feature
 
-import "fmt"
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
 
 // This file holds the YAML codec for the direct face-edit features — split, move-face,
 // face-offset, delete-face, replace-face and thicken. They share one shape (a set of
 // picked faces by reference key) plus, for the geometric edits, a parameter: move-face
-// carries a translation vector, face-offset a distance. The keys re-bind to the
-// regenerated faces on recompute.
+// carries a translation vector or a rotation, face-offset a distance. The keys re-bind to
+// the regenerated faces on recompute.
 
 // FaceEditData is a direct face edit: the picked faces as reference keys, plus the optional
-// parameter of the geometric edits (move-face translation, face-offset distance).
+// parameter of the geometric edits (move-face translation or rotation, face-offset
+// distance + approximation).
 type FaceEditData struct {
-	Faces       []string  `yaml:"faces"`
-	Translation []float64 `yaml:"translation,omitempty"` // move-face: dx, dy, dz
-	Distance    float64   `yaml:"distance,omitempty"`    // face-offset
-	Target      string    `yaml:"target,omitempty"`      // replace-face: source face key
+	Faces         []string  `yaml:"faces"`
+	Translation   []float64 `yaml:"translation,omitempty"`   // move-face: dx, dy, dz
+	AxisPoint     []float64 `yaml:"axisPoint,omitempty"`     // move-face rotate (#331)
+	AxisDir       []float64 `yaml:"axisDir,omitempty"`       // move-face rotate
+	Angle         float64   `yaml:"angle,omitempty"`         // move-face rotate, radians
+	Distance      float64   `yaml:"distance,omitempty"`      // face-offset
+	Approximation string    `yaml:"approximation,omitempty"` // face-offset (#331), wire spelling
+	Target        string    `yaml:"target,omitempty"`        // replace-face: source face key
 }
 
-// ThickenData is a thicken feature: the wall thickness applied to the running surface body.
+// ThickenData is a thicken feature: the wall thickness applied to the running surface body,
+// plus the #331 approximation request (wire spelling; absent = none/exact).
 type ThickenData struct {
-	Value float64 `yaml:"value"`
+	Value         float64 `yaml:"value"`
+	Approximation string  `yaml:"approximation,omitempty"`
+}
+
+// approximationName / approximationOf map the enum to its wire spelling (empty for the zero
+// value so older recipes stay byte-identical).
+func approximationName(a types.FeatureApproximationType) string {
+	if a == 0 {
+		return ""
+	}
+	return a.String()
+}
+
+func approximationOf(s string) (types.FeatureApproximationType, error) {
+	if s == "" {
+		return 0, nil
+	}
+	a, ok := types.ParseFeatureApproximationType(s)
+	if !ok {
+		return 0, fmt.Errorf("unknown approximation %q (want none/mean/neverTooThick/neverTooThin)", s)
+	}
+	return a, nil
+}
+
+// serializeMoveFace encodes a move-face in whichever mode it carries.
+func serializeMoveFace(f *MoveFaceFeature) *FaceEditData {
+	if p, dir, angle, rotating := f.Rotation(); rotating {
+		return &FaceEditData{Faces: encodeKeys(f.FaceKeys()),
+			AxisPoint: []float64{p.X, p.Y, p.Z}, AxisDir: []float64{dir.X, dir.Y, dir.Z}, Angle: angle}
+	}
+	t := f.Translation()
+	return &FaceEditData{Faces: encodeKeys(f.FaceKeys()), Translation: []float64{t.X, t.Y, t.Z}}
 }
 
 // faceEditor is satisfied by every direct face-edit feature (they embed faceEditFeature),
@@ -45,9 +86,16 @@ func restoreFaceEdit(fs *PartFeatures, kind string, d *FaceEditData) (*PartFeatu
 	case "split":
 		return m.AddSplit(keys), nil
 	case "move-face":
+		if len(d.AxisDir) == 3 {
+			return m.AddMoveFaceRotate(keys, decodePoint3(d.AxisPoint), decodeVec3(d.AxisDir), constFloat(d.Angle)), nil
+		}
 		return m.AddMoveFace(keys, decodeVec3(d.Translation)), nil
 	case "face-offset":
-		return m.AddFaceOffset(keys, d.Distance), nil
+		approx, err := approximationOf(d.Approximation)
+		if err != nil {
+			return nil, err
+		}
+		return m.AddFaceOffsetApprox(keys, constFloat(d.Distance), approx), nil
 	case "delete-face":
 		return m.AddDeleteFace(keys), nil
 	case "replace-face":

--- a/model/feature/serialize_split.go
+++ b/model/feature/serialize_split.go
@@ -4,11 +4,12 @@ package feature
 
 import "fmt"
 
-// SplitSolidData is a solid split's recipe: the cutting work plane (by WorkRef) and which
-// side(s) to keep.
+// SplitSolidData is a solid split's recipe: the cutting work plane (by WorkRef), which
+// side(s) to keep, and the faces-only flag (the Split Faces mode, #330).
 type SplitSolidData struct {
-	Plane string `yaml:"plane"`
-	Keep  string `yaml:"keep,omitempty"`
+	Plane     string `yaml:"plane"`
+	Keep      string `yaml:"keep,omitempty"`
+	FacesOnly bool   `yaml:"facesOnly,omitempty"`
 }
 
 // splitSideNames map the kept-side enum to/from a stable name.
@@ -37,7 +38,7 @@ func serializeSplitSolid(def *SplitSolidDefinition) (*SplitSolidData, error) {
 	if def.Plane == nil {
 		return nil, fmt.Errorf("split references no cutting plane")
 	}
-	return &SplitSolidData{Plane: string(def.Plane.Key()), Keep: splitSideName(def.Keep)}, nil
+	return &SplitSolidData{Plane: string(def.Plane.Key()), Keep: splitSideName(def.Keep), FacesOnly: def.FacesOnly}, nil
 }
 
 func restoreSplitSolid(fs *PartFeatures, d *SplitSolidData, work *WorkGeometry) (*PartFeature, error) {
@@ -47,6 +48,9 @@ func restoreSplitSolid(fs *PartFeatures, d *SplitSolidData, work *WorkGeometry) 
 	wp, err := resolvePlaneRef(work, d.Plane)
 	if err != nil {
 		return nil, err
+	}
+	if d.FacesOnly {
+		return NewModifyFeatures(fs).AddSplitFaces(wp), nil
 	}
 	keep, err := parseSplitSide(d.Keep)
 	if err != nil {

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
@@ -411,5 +412,40 @@ func TestUncodedFeatureErrorsRatherThanDrops(t *testing.T) {
 	fs.Add(fakeFeature{})
 	if _, err := fs.MarshalRecipe(oneSketch{}); err == nil {
 		t.Error("MarshalRecipe silently accepted a feature with no codec; it must error")
+	}
+}
+
+// TestThreadParityFieldsRoundTrip: the #325 thread fields (class / tapered /
+// modelDiameter) survive the recipe codec, and a legacy thread without them
+// restores with the defaults.
+func TestThreadParityFieldsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewDressUpFeatures(fs).AddThreadDef(&ThreadDefinition{
+		FaceKey: []byte("face-1"), Designation: "M8x1.25", Cut: false,
+		Class: "6H", Tapered: true, ModelDiameter: types.ThreadTapDrillDiameter,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if d := data[0].Thread; d.Class != "6H" || !d.Tapered || d.ModelDiameter != "tapDrill" {
+		t.Fatalf("serialized thread = %+v, want class/tapered/modelDiameter carried", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*ThreadFeature).Definition()
+	if def.Class != "6H" || !def.Tapered || def.ModelDiameter != types.ThreadTapDrillDiameter {
+		t.Errorf("restored thread = %+v, want the parity fields back", def)
+	}
+
+	legacy := []FeatureData{{Kind: "thread", Thread: &ThreadData{Face: "ZmFjZQ==", Designation: "M6x1"}}}
+	old := NewPartFeatures(nil, nil)
+	if err := old.ApplyRecipe(legacy, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe(legacy): %v", err)
+	}
+	if d := old.Item(0).Definition().(*ThreadFeature).Definition(); d.Class != "" || d.Tapered || d.ModelDiameter != 0 {
+		t.Errorf("legacy thread restored with non-defaults: %+v", d)
 	}
 }

--- a/model/feature/split_solid.go
+++ b/model/feature/split_solid.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -21,15 +22,18 @@ const (
 	SplitNegative                  // keep the opposite side (trim)
 )
 
-// SplitSolidDefinition is the recipe for a solid split: a cutting work plane and which side(s)
-// to keep, re-resolved each recompute.
+// SplitSolidDefinition is the recipe for a solid split: a cutting work plane, which side(s)
+// to keep, and FacesOnly — the reference's Split Faces mode, which imprints the plane onto
+// the body's faces without removing material (#330). Re-resolved each recompute.
 type SplitSolidDefinition struct {
-	Plane *WorkPlane
-	Keep  SplitSide
+	Plane     *WorkPlane
+	Keep      SplitSide
+	FacesOnly bool
 }
 
-// SplitSolidFeature divides the running solid bodies by a plane (Inventor's Split Solid / Trim
-// Solid): each solid is cut into the pieces on each side of the plane, and Keep filters them.
+// SplitSolidFeature divides the running solid bodies by a plane (the reference's Split
+// feature): each solid is cut into the pieces on each side of the plane and Keep filters
+// them — or, FacesOnly, each solid keeps its volume and only its faces split.
 type SplitSolidFeature struct{ def *SplitSolidDefinition }
 
 // Definition returns the split recipe.
@@ -38,8 +42,21 @@ func (f *SplitSolidFeature) Definition() *SplitSolidDefinition { return f.def }
 // Kind implements [Feature].
 func (f *SplitSolidFeature) Kind() string { return "splitSolid" }
 
+// SplitType reports the frozen discriminator of what this split does (api/types, #330).
+func (f *SplitSolidFeature) SplitType() types.SplitType {
+	switch {
+	case f.def.FacesOnly:
+		return types.SplitFacesSplit
+	case f.def.Keep == SplitBoth:
+		return types.SplitBodySplit
+	default:
+		return types.TrimSolidSplit
+	}
+}
+
 // Recompute resolves the cutting plane and splits every running solid body by it, keeping the
-// requested side(s). A lost plane → Sick; surface (non-solid) bodies pass through unchanged.
+// requested side(s) — or imprinting faces only. A lost plane → Sick; surface (non-solid)
+// bodies pass through unchanged.
 func (f *SplitSolidFeature) Recompute(in Input) (Output, error) {
 	if f.def.Plane == nil {
 		return Output{}, errors.New("split: no cutting plane")
@@ -54,13 +71,30 @@ func (f *SplitSolidFeature) Recompute(in Input) (Output, error) {
 			out = append(out, b)
 			continue
 		}
-		pieces, err := ops.SplitSolidByPlane(b, plane)
+		pieces, err := f.splitOne(b, plane)
 		if err != nil {
 			return Output{}, err
 		}
-		out = append(out, keepSplitSides(pieces, plane, f.def.Keep)...)
+		out = append(out, pieces...)
 	}
 	return Output{Bodies: out}, nil
+}
+
+// splitOne applies the definition's mode to one solid: a faces-only imprint, or the
+// side-filtered body split.
+func (f *SplitSolidFeature) splitOne(b *topo.Body, plane geom.Plane) ([]*topo.Body, error) {
+	if f.def.FacesOnly {
+		imprinted, err := ops.SplitFacesByPlane(b, plane)
+		if err != nil {
+			return nil, err
+		}
+		return []*topo.Body{imprinted}, nil
+	}
+	pieces, err := ops.SplitSolidByPlane(b, plane)
+	if err != nil {
+		return nil, err
+	}
+	return keepSplitSides(pieces, plane, f.def.Keep), nil
 }
 
 // geomPlaneOf converts a work plane's sketch plane to a kernel plane for the split.
@@ -94,6 +128,14 @@ func keepSplitSides(pieces []*topo.Body, plane geom.Plane, keep SplitSide) []*to
 // requested side(s).
 func (c *ModifyFeatures) AddSplitSolid(plane *WorkPlane, keep SplitSide) *PartFeature {
 	pf := c.engine.Add(&SplitSolidFeature{def: &SplitSolidDefinition{Plane: plane, Keep: keep}})
+	pf.SetName(c.engine.UniqueName("Split"))
+	return pf
+}
+
+// AddSplitFaces adds a faces-only split: the plane imprints onto every running solid's
+// faces without removing material (#330).
+func (c *ModifyFeatures) AddSplitFaces(plane *WorkPlane) *PartFeature {
+	pf := c.engine.Add(&SplitSolidFeature{def: &SplitSolidDefinition{Plane: plane, FacesOnly: true}})
 	pf.SetName(c.engine.UniqueName("Split"))
 	return pf
 }

--- a/model/feature/split_solid_test.go
+++ b/model/feature/split_solid_test.go
@@ -80,3 +80,54 @@ func TestSplitSolidRoundTrip(t *testing.T) {
 		t.Errorf("restored split = keep %d plane %v, want positive + the z=2 plane", def.Keep, def.Plane)
 	}
 }
+
+// The Split Faces mode (#330): the plane imprints onto the box's faces — same
+// volume, same single body, four more faces (each crossing side wall splits in
+// two), and the discriminator reports splitFaces.
+func TestSplitFacesImprintsWithoutRemovingMaterial(t *testing.T) {
+	_, wp := midPlaneAt(2)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(boxBody())
+	split := NewModifyFeatures(fs).AddSplitFaces(wp)
+	fs.Recompute()
+
+	if !split.Health().OK() {
+		t.Fatalf("split-faces went sick: %+v", split.Health())
+	}
+	pieces := fs.Result()
+	if len(pieces) != 1 {
+		t.Fatalf("split-faces result = %d bodies, want 1 (no material removed)", len(pieces))
+	}
+	if r := ops.Validate(pieces[0]); !r.Valid || !pieces[0].IsSolid() {
+		t.Fatalf("imprinted body not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(pieces[0], ops.DefaultQuality()).Volume; stdmath.Abs(v-64) > 1e-9 {
+		t.Errorf("imprinted volume = %g, want 64 (unchanged)", v)
+	}
+	if n := len(pieces[0].Faces()); n != 10 {
+		t.Errorf("imprinted box has %d faces, want 10 (4 side walls split)", n)
+	}
+	if split.Definition().(*SplitSolidFeature).SplitType() != 32770 {
+		t.Error("split type discriminator != splitFaces")
+	}
+}
+
+// The faces-only flag round-trips through the recipe.
+func TestSplitFacesRoundTrip(t *testing.T) {
+	g, wp := midPlaneAt(2)
+	fs := NewPartFeatures(nil, nil)
+	NewModifyFeatures(fs).AddSplitFaces(wp)
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, g); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*SplitSolidFeature).Definition()
+	if !def.FacesOnly || def.Plane == nil {
+		t.Errorf("restored split = %+v, want facesOnly with its plane", def)
+	}
+}

--- a/model/feature/thread_spec.go
+++ b/model/feature/thread_spec.go
@@ -6,19 +6,40 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"oblikovati.org/api/types"
 )
 
-// ThreadSpec is the resolved geometry of a thread designation (the cosmetic-thread data
-// Inventor records on a face): pitch and the major/minor diameters, handedness, and whether it
-// is an internal (hole) or external (shaft) thread. A cosmetic thread does not cut the solid;
-// this is the data that drives the thread display and downstream fit checks.
+// ThreadSpec is the resolved geometry of a thread designation (the cosmetic-thread data the
+// reference records on a face): pitch and the basic-profile diameters, handedness, the
+// tolerance class, and whether it is an internal (hole) or external (shaft) thread. A
+// cosmetic thread does not cut the solid; this is the data that drives the thread display,
+// hole tables (M14), and downstream fit checks — one source of truth per the #325 audit.
 type ThreadSpec struct {
-	Designation   string
-	Pitch         float64 // mm between crests
-	MajorDiameter float64 // mm (nominal)
-	MinorDiameter float64 // mm (root)
-	Internal      bool
-	RightHanded   bool
+	Designation      string
+	ThreadType       string  // catalog standard ("ISO" for metric, "ANSI" for Unified inch)
+	NominalSize      string  // "M8", "1/4", "#8"
+	Class            string  // tolerance class ("6H", "2A", …); empty = unspecified
+	Pitch            float64 // mm between crests
+	MajorDiameter    float64 // mm (nominal)
+	MinorDiameter    float64 // mm (root, ISO basic d − 1.0825·P)
+	PitchDiameter    float64 // mm (ISO basic d − 0.6495·P)
+	TapDrillDiameter float64 // mm (standard tap drill, d − P)
+	Metric           bool
+	Internal         bool
+	RightHanded      bool
+	Tapered          bool // pipe thread (the reference's TaperedThreadInfo split)
+	// ModelDiameter declares which thread diameter the modeled cylindrical face
+	// represents (major when unset) — consumed by drawings/hole tables, not geometry.
+	ModelDiameter types.ModelDiameterFromThread
+}
+
+// fillDerivedDiameters computes the ISO-basic pitch diameter and the standard tap drill from
+// the major diameter and pitch (shared by the metric and Unified parsers — the Unified basic
+// profile uses the same 60° relations, in mm).
+func (s *ThreadSpec) fillDerivedDiameters() {
+	s.PitchDiameter = s.MajorDiameter - 0.6495*s.Pitch
+	s.TapDrillDiameter = s.MajorDiameter - s.Pitch
 }
 
 // coarsePitch is the ISO metric coarse-pitch table for common nominal diameters (mm).
@@ -78,6 +99,8 @@ func parseImperial(body string, spec ThreadSpec) (ThreadSpec, error) {
 	if spec.MinorDiameter <= 0 {
 		return ThreadSpec{}, fmt.Errorf("thread: %s too coarse (minor diameter ≤ 0)", spec.Designation)
 	}
+	spec.ThreadType, spec.NominalSize = string(StandardANSI), sizeStr
+	spec.fillDerivedDiameters()
 	return spec, nil
 }
 
@@ -95,6 +118,8 @@ func parseMetric(body string, spec ThreadSpec) (ThreadSpec, error) {
 	if spec.MinorDiameter <= 0 {
 		return ThreadSpec{}, fmt.Errorf("thread: pitch %g too coarse for M%g (minor diameter ≤ 0)", spec.Pitch, major)
 	}
+	spec.Metric, spec.ThreadType, spec.NominalSize = true, string(StandardISO), fmt.Sprintf("M%g", major)
+	spec.fillDerivedDiameters()
 	return spec, nil
 }
 

--- a/model/feature/thread_tables.go
+++ b/model/feature/thread_tables.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// The thread table query surface (M09-F01 PBI-101, #325): the wire-facing view
+// over the thread catalog (thread_catalog.go) behind threads.tableQuery —
+// thread types, each type's nominal sizes, the standard designations per size,
+// and the tolerance classes per side. The thread feature, hole tapping (#326),
+// and drawings (M14) all resolve designations through [ParseThreadDesignation]
+// against these same tables.
+
+// ThreadTypes lists the thread table names — the catalog standards.
+func ThreadTypes() []string {
+	stds := ThreadStandards()
+	out := make([]string, len(stds))
+	for i, s := range stds {
+		out[i] = string(s)
+	}
+	return out
+}
+
+// threadStandardOf resolves a wire thread-type spelling to its catalog
+// standard, erroring with the known names.
+func threadStandardOf(threadType string) (ThreadStandard, error) {
+	for _, s := range ThreadStandards() {
+		if string(s) == threadType {
+			return s, nil
+		}
+	}
+	return "", fmt.Errorf("thread: unknown thread type %q (want one of %v)", threadType, ThreadTypes())
+}
+
+// ThreadNominalSizes lists a thread type's nominal sizes (catalog order,
+// ascending diameter).
+func ThreadNominalSizes(threadType string) ([]string, error) {
+	std, err := threadStandardOf(threadType)
+	if err != nil {
+		return nil, err
+	}
+	sizes := ThreadSizes(std)
+	out := make([]string, len(sizes))
+	for i, s := range sizes {
+		out[i] = s.Name
+	}
+	return out, nil
+}
+
+// ThreadDesignationsOf lists one nominal size's parseable designations (coarse
+// pitch first, then fines), built by the same [ThreadDesignation] the thread
+// tool uses.
+func ThreadDesignationsOf(threadType, nominalSize string) ([]string, error) {
+	std, err := threadStandardOf(threadType)
+	if err != nil {
+		return nil, err
+	}
+	size, ok := findSize(std, nominalSize)
+	if !ok {
+		return nil, fmt.Errorf("thread: %s has no size %q", std, nominalSize)
+	}
+	out := make([]string, len(size.Pitches))
+	for i, p := range size.Pitches {
+		if out[i], err = ThreadDesignation(std, nominalSize, p); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// ThreadClasses lists the tolerance classes for one side of a thread type:
+// internal (nut) or external (bolt). The classes are per-system, not
+// per-designation, in these tables.
+func ThreadClasses(threadType string, internal bool) ([]string, error) {
+	std, err := threadStandardOf(threadType)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case StandardSystem(std) == SystemMetric && internal:
+		return []string{"6H"}, nil
+	case StandardSystem(std) == SystemMetric:
+		return []string{"6g"}, nil
+	case internal:
+		return []string{"2B", "3B"}, nil
+	default:
+		return []string{"2A", "3A"}, nil
+	}
+}
+
+// ThreadTypeOfDesignation reports which table a designation resolves against
+// (for classifying a parsed spec back to its type name).
+func ThreadTypeOfDesignation(designation string) (string, error) {
+	spec, err := ParseThreadDesignation(designation)
+	if err != nil {
+		return "", err
+	}
+	return spec.ThreadType, nil
+}

--- a/model/feature/thread_tables_test.go
+++ b/model/feature/thread_tables_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// The thread table query surface (#325): every listed designation must parse
+// back through the same tables, and the parsed spec carries the derived
+// diameters the drawings/hole tables consume.
+
+func TestThreadTablesRoundTripThroughParser(t *testing.T) {
+	for _, tt := range ThreadTypes() {
+		sizes, err := ThreadNominalSizes(tt)
+		if err != nil || len(sizes) == 0 {
+			t.Fatalf("ThreadNominalSizes(%s): %v / %d sizes", tt, err, len(sizes))
+		}
+		for _, size := range sizes {
+			designations, err := ThreadDesignationsOf(tt, size)
+			if err != nil || len(designations) == 0 {
+				t.Fatalf("ThreadDesignationsOf(%s, %s): %v", tt, size, err)
+			}
+			for _, d := range designations {
+				spec, err := ParseThreadDesignation(d)
+				if err != nil {
+					t.Errorf("table designation %q does not parse: %v", d, err)
+					continue
+				}
+				if spec.NominalSize != size {
+					t.Errorf("designation %q parses to size %q, want %q", d, spec.NominalSize, size)
+				}
+			}
+		}
+	}
+}
+
+func TestThreadSpecDerivedDiameters(t *testing.T) {
+	spec, err := ParseThreadDesignation("M8x1.25")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ISO basic: d2 = d − 0.6495·P, tap drill = d − P.
+	if d2 := 8 - 0.6495*1.25; spec.PitchDiameter != d2 {
+		t.Errorf("pitch diameter = %g, want %g", spec.PitchDiameter, d2)
+	}
+	if spec.TapDrillDiameter != 8-1.25 {
+		t.Errorf("tap drill = %g, want 6.75", spec.TapDrillDiameter)
+	}
+	if spec.ThreadType != "ISO" || spec.NominalSize != "M8" || !spec.Metric {
+		t.Errorf("spec classification = %q/%q metric=%v, want ISO/M8/true", spec.ThreadType, spec.NominalSize, spec.Metric)
+	}
+}
+
+func TestThreadClassesPerSide(t *testing.T) {
+	internal, _ := ThreadClasses("ISO", true)
+	external, _ := ThreadClasses("ISO", false)
+	if len(internal) == 0 || len(external) == 0 || internal[0] == external[0] {
+		t.Errorf("ISO classes = %v / %v, want distinct internal/external", internal, external)
+	}
+	if _, err := ThreadClasses("BSW", true); err == nil {
+		t.Error("an unknown thread type must error")
+	}
+}
+
+func TestThreadDefinitionParityFields(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(prismBody())
+	// A cut tapered thread is rejected with a precise error (conical faces are a follow-up).
+	pf := NewDressUpFeatures(fs).AddThreadDef(&ThreadDefinition{
+		FaceKey: []byte("x"), Designation: "M8x1.25", Cut: true, Tapered: true,
+	})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("a cut tapered thread must be sick")
+	}
+	// The model-diameter choice defaults to major on the resolved spec.
+	def := pf.Definition().(*ThreadFeature).Definition()
+	if def.ModelDiameter != 0 {
+		t.Errorf("unset modelDiameter = %v, want zero (defaults to major at recompute)", def.ModelDiameter)
+	}
+	if types.ThreadMajorDiameter.String() != "major" {
+		t.Error("frozen spelling drifted")
+	}
+}


### PR DESCRIPTION
## What

Feature-completes **M09: Part Modeling: Dress-up & Pattern Features** (the six open PBIs; F03 patterns/mirror and chamfer/hole were already done). Contract half merged first as Oblikovati.API#70 (frozen FilletType / FeatureApproximationType / ModelDiameterFromThread / DirectEditOperationType / SplitType + the threads.tableQuery/threads.resolve wire surface).

One commit per issue:

- **#323 fillet edge sets** — the reference's edge-set model: any mix of constant-radius sets and variable (start→end radius) sets in one feature. The variable blend is a generalized cone built as **exactly planar** trapezoids between rulings (adjacent rulings meet at the cone apex on the edge line), so the tessellated volume is closed-form in the chord count — pinned at 1e-9 in kernel and engine tests. End faces share the chord samples (watertight); variable edges at shared corners and mixed-radius corner blends are rejected with the offending values. Face/full-round fillets and setbacks are documented follow-ups (#694, #695).
- **#325 thread parity** — the thread catalog goes public: `threads.tableQuery` (progressive types → sizes → designations → classes) and `threads.resolve` (designation + class/handedness/tapered → pitch + ISO-basic major/minor/pitch/tap-drill diameters), one source of truth for tapping (#326) and drawings (M14). The thread definition carries class, the tapered (pipe) flag (cut form rejected — needs a conical face), and ModelDiameterFromThread; every listed designation is pinned to parse back. Shell + draft acceptance was already met.
- **#327 boss** — real geometry at last: the join-side mirror of the drilled hole (tool cylinder grown out of the face, entry overhang inside the body), with ToolBody pattern replication (one body with N studs) and exact-volume pins.
- **#330 split** — the Split Faces mode: the plane imprints its section curves onto the faces via the M07 body imprint against the existing half-space box — volume bit-identical, faces split. splitSolid args gain the frozen `type` union (trimSolid/splitFaces/splitBody); acceptance pinned over the wire (splitBody → two solids → combine joins them back).
- **#331 face edits** — move-face gains its rotate arm (axis + angle through the same plane-rebuild machinery, analytic wedge pin); FaceOffset/Thicken carry `FeatureApproximationType` per the audit — recorded and round-tripped while the kernel computes the exact offset, which satisfies every approximation bound.
- **#332 direct edit** — the consolidated feature: move/size/rotate/delete on picked faces + uniform body scale about a base point (TransformBody similarity with identity lineage, so reference keys survive). Each arm pinned by an analytic volume; unknown operations go Sick with precise errors.

## Why

These are the features that lean hardest on persistent topological identity (M03): every input is a reference key that re-binds across recompute and reopen, and every new mode (variable fillet, faces-only split, rotate, scale) keeps that contract — lost references go Sick, never corrupt.

Closes #319, closes #320, closes #322, closes #323, closes #325, closes #327, closes #330, closes #331, closes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)