### PR TITLE
M11-F01: Assembly Component Definition

### DIFF
--- a/math/box.go
+++ b/math/box.go
@@ -123,3 +123,19 @@ func (b Box) Corners() [8]Point3 {
 	}
 	return c
 }
+
+// Transform returns the axis-aligned box bounding this box's eight corners after the
+// affine transform m — the AABB of a placed (rotated/translated) component, used to
+// accumulate an assembly's range box from its occurrences. A rotation enlarges the
+// AABB, which is correct (the tight box of a rotated box is not axis-aligned). The
+// empty box is returned unchanged: it has no corners to place.
+func (b Box) Transform(m Matrix4) Box {
+	if b.IsEmpty() {
+		return b
+	}
+	out := EmptyBox()
+	for _, c := range b.Corners() {
+		out = out.ExtendPoint(m.TransformPoint(c))
+	}
+	return out
+}

--- a/math/box_test.go
+++ b/math/box_test.go
@@ -69,6 +69,25 @@ func TestBoxUnionAndCorners(t *testing.T) {
 	}
 }
 
+func TestBoxTransform(t *testing.T) {
+	// Pure translation shifts both corners by the same vector.
+	moved := NewBox(P3(0, 0, 0), P3(1, 1, 1)).Transform(Translation4(V3(10, 20, 30)))
+	if moved.Min != (Point3{10, 20, 30}) || moved.Max != (Point3{11, 21, 31}) {
+		t.Errorf("translated = %v..%v, want {10 20 30}..{11 21 31}", moved.Min, moved.Max)
+	}
+	// A 90° rotation about Z maps (x,y)→(-y,x): the AABB of [0,2]×[0,1]×[0,1]
+	// grows to [-1,0]×[0,2]×[0,1] (a rotated box's tight AABB is larger).
+	rotZ := Matrix4FromCells([16]Scalar{0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1})
+	rotated := NewBox(P3(0, 0, 0), P3(2, 1, 1)).Transform(rotZ)
+	if rotated.Min != (Point3{-1, 0, 0}) || rotated.Max != (Point3{0, 2, 1}) {
+		t.Errorf("rotated = %v..%v, want {-1 0 0}..{0 2 1}", rotated.Min, rotated.Max)
+	}
+	// The empty box has no corners to place: it stays empty.
+	if got := EmptyBox().Transform(Translation4(V3(5, 5, 5))); !got.IsEmpty() {
+		t.Errorf("empty.Transform = %v..%v, want empty", got.Min, got.Max)
+	}
+}
+
 func TestBoxFarthestPoint(t *testing.T) {
 	b := NewBox(P3(-1, -2, -3), P3(4, 5, 6))
 	cases := []struct {

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"strconv"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/occurrence"
+	"oblikovati.org/model/param"
+)
+
+// AssemblyComponentDefinition is an assembly's modeling content — the assembly
+// analogue of [PartComponentDefinition]. Where a part owns bodies, an assembly owns
+// component occurrences (the placements of parts and sub-assemblies), its structure,
+// a range box unioned from those occurrences, and a change-detection version. It is
+// the reference API's AssemblyComponentDefinition (M11-F01, #345); constraints,
+// joints, and representations attach to it from M12.
+type AssemblyComponentDefinition struct {
+	occurrences *occurrence.Occurrences
+	units       param.UnitsOfMeasure // document display units (length/angle/…)
+}
+
+// NewAssemblyComponentDefinition returns an empty assembly content object: no
+// occurrences and default (metric) display units.
+func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
+	return &AssemblyComponentDefinition{
+		occurrences: occurrence.NewOccurrences(),
+		units:       param.DefaultUnitsOfMeasure(),
+	}
+}
+
+// An assembly definition is plain document content, not recipe-bearing content: it
+// has no recipe to persist until its occurrences reference documents (M11-F02), so
+// it intentionally does NOT implement doc.RecipeContent (contrast PartComponentDefinition).
+var _ doc.Content = (*AssemblyComponentDefinition)(nil)
+
+// init registers the real assembly content with the document layer so opening or
+// creating an assembly document yields a live AssemblyComponentDefinition, not the
+// identity-only stub (see doc.RegisterContentFactory). The assembly does not yet
+// implement doc.RecipeContent: its occurrences reference documents through the
+// reference graph that arrives in M11-F02, so there is nothing recipe-persistable
+// until then — today an assembly round-trips its identity (manifest) alone.
+func init() {
+	doc.RegisterContentFactory(doc.Assembly, func() doc.Content { return NewAssemblyComponentDefinition() })
+}
+
+// AddAssembly creates a new assembly document in ws with a realized assembly
+// component definition installed (not the bare doc-package placeholder), makes it
+// active, and returns it — the assembly counterpart of [AddPart], so the host's New
+// Assembly path and documents.create go through one place.
+func AddAssembly(ws *doc.Workspace, fullDocumentName string, visible bool) (*doc.Document, error) {
+	d, err := ws.Add(doc.Assembly, fullDocumentName, visible)
+	if err != nil {
+		return nil, err
+	}
+	d.SetContent(NewAssemblyComponentDefinition())
+	return d, nil
+}
+
+// DocumentType identifies this as assembly content, satisfying doc.Content.
+func (a *AssemblyComponentDefinition) DocumentType() doc.DocumentType { return doc.Assembly }
+
+// Occurrences returns the assembly's component occurrences — the parts and
+// sub-assemblies placed in it. Placement and editing operations land in M11-F02; this
+// is the live collection the assembly's structure and range box read from.
+func (a *AssemblyComponentDefinition) Occurrences() *occurrence.Occurrences {
+	return a.occurrences
+}
+
+// RangeBox returns the axis-aligned bounding box enclosing every unsuppressed
+// occurrence (empty when the assembly has none).
+func (a *AssemblyComponentDefinition) RangeBox() math.Box { return a.occurrences.RangeBox() }
+
+// PreciseRangeBox returns the tight bounding box. With axis-aligned occurrence boxes
+// it equals [RangeBox]; it tightens once occurrences expose curved-face evaluation
+// (kernel phase B), mirroring the part.
+func (a *AssemblyComponentDefinition) PreciseRangeBox() math.Box { return a.RangeBox() }
+
+// OrientedMinimumRangeBox returns an oriented bounding box. Phase A returns the
+// axis-aligned box as an oriented box; the true minimum-volume OBB is a later
+// optimization, as for the part.
+func (a *AssemblyComponentDefinition) OrientedMinimumRangeBox() math.OrientedBox {
+	box := a.RangeBox()
+	half := box.Diagonal().Scale(0.5)
+	x, _ := math.NewUnitVector3(1, 0, 0)
+	y, _ := math.NewUnitVector3(0, 1, 0)
+	z, _ := math.NewUnitVector3(0, 0, 1)
+	return math.NewOrientedBox(box.Center(), x, y, z, [3]math.Scalar{half.X, half.Y, half.Z})
+}
+
+// Units returns the document's display units (default metric — mm).
+func (a *AssemblyComponentDefinition) Units() param.UnitsOfMeasure { return a.units }
+
+// SetLengthUnit sets the assembly's preferred length unit (e.g. "mm", "in").
+func (a *AssemblyComponentDefinition) SetLengthUnit(name string) error {
+	return a.units.SetPreferred(param.Length, name)
+}
+
+// ModelGeometryVersion is a string that changes whenever the assembly's occurrences
+// change (add/remove/move/suppress), so consumers (drawings, parent assemblies) can
+// detect when they must update. It is derived from the occurrence collection's
+// revision, the assembly analogue of the part's edit counter.
+func (a *AssemblyComponentDefinition) ModelGeometryVersion() string {
+	return "v" + strconv.FormatUint(a.occurrences.Revision(), 10)
+}

--- a/model/compdef/assembly_test.go
+++ b/model/compdef/assembly_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/occurrence"
+)
+
+// fakeComponentSource is a named stand-in for a placed component's definition,
+// reporting a fixed local box so the assembly's range box can be exercised without
+// building real child geometry (real placement arrives in M11-F02).
+type fakeComponentSource struct{ box math.Box }
+
+func (f fakeComponentSource) RangeBox() math.Box { return f.box }
+
+var _ occurrence.RangeBoxSource = fakeComponentSource{}
+
+// unitSource is a 1×1×1 component at its own origin.
+func unitSource() fakeComponentSource {
+	return fakeComponentSource{box: math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1))}
+}
+
+func TestNewAssemblyIsEmptyAssemblyContent(t *testing.T) {
+	a := NewAssemblyComponentDefinition()
+	if a.DocumentType() != doc.Assembly {
+		t.Errorf("DocumentType = %v, want assembly", a.DocumentType())
+	}
+	if a.Occurrences().Count() != 0 || !a.RangeBox().IsEmpty() {
+		t.Errorf("new assembly count=%d boxEmpty=%v, want 0 occurrences and an empty box",
+			a.Occurrences().Count(), a.RangeBox().IsEmpty())
+	}
+}
+
+func TestAssemblyRangeBoxUnionsOccurrencesAndVersionTracks(t *testing.T) {
+	a := NewAssemblyComponentDefinition()
+	v0 := a.ModelGeometryVersion()
+	a.Occurrences().Add("base", unitSource(), math.Identity4())
+	a.Occurrences().Add("offset", unitSource(), math.Translation4(math.V3(4, 0, 0)))
+	// [0,1]³ ∪ [4,5]×[0,1]×[0,1] = [0,5]×[0,1]×[0,1].
+	box := a.RangeBox()
+	if box.Min != (math.P3(0, 0, 0)) || box.Max != (math.P3(5, 1, 1)) {
+		t.Errorf("assembly box = %v..%v, want {0 0 0}..{5 1 1}", box.Min, box.Max)
+	}
+	if a.ModelGeometryVersion() == v0 {
+		t.Errorf("ModelGeometryVersion did not change after placing occurrences (still %s)", v0)
+	}
+}
+
+func TestAddAssemblyInstallsAssemblyContentAndActivates(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, err := AddAssembly(ws, "frame.oad", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if _, ok := d.Content().(*AssemblyComponentDefinition); !ok {
+		t.Fatalf("content is %T, want *AssemblyComponentDefinition", d.Content())
+	}
+	if ws.ActiveDocument() != d || d.DocumentType() != doc.Assembly {
+		t.Fatalf("AddAssembly active=%v type=%v, want active assembly", ws.ActiveDocument() == d, d.DocumentType())
+	}
+}
+
+// TestAssemblyFactoryRegisteredForWorkspaceAdd proves the init() registration: a
+// plain ws.Add(Assembly) (the path documents.create and the CLI use) yields the real
+// content, not the identity-only doc stub.
+func TestAssemblyFactoryRegisteredForWorkspaceAdd(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, err := ws.Add(doc.Assembly, "sub.oad", true)
+	if err != nil {
+		t.Fatalf("ws.Add(assembly): %v", err)
+	}
+	if _, ok := d.Content().(*AssemblyComponentDefinition); !ok {
+		t.Errorf("factory content = %T, want *AssemblyComponentDefinition", d.Content())
+	}
+}

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package occurrence models component occurrences — the placements of a component (a
+// part or a sub-assembly) inside an assembly. One referenced component can be placed
+// many times; each placement is an occurrence carrying its own transform and
+// suppression state. This is the assembly analogue of a body in a part: the unit the
+// assembly's structure, range box, and (from M12) constraints operate on. It is the
+// reference API's ComponentOccurrence / ComponentOccurrences (M11-F01, #345).
+package occurrence
+
+import "oblikovati.org/math"
+
+// RangeBoxSource is what an occurrence instances: anything that reports its local
+// (definition-space) range box. Both a part and an assembly component definition
+// satisfy it (model/compdef), so an occurrence's contribution to its owner's box
+// always reflects the current child geometry — and a sub-assembly can be placed in a
+// parent assembly (nesting). Kept narrow here so model/occurrence does not import
+// model/compdef, which imports this package.
+type RangeBoxSource interface {
+	// RangeBox returns the source's axis-aligned bounding box in its own space.
+	RangeBox() math.Box
+}
+
+// Occurrence is one placement of a component inside an assembly: its source
+// definition, a transform locating it in the assembly's space, and whether it is
+// suppressed (excluded from the model). Created and owned by an [Occurrences]
+// collection; mutating its transform or suppression bumps the owner's revision so the
+// assembly's geometry version advances.
+type Occurrence struct {
+	id         uint64
+	name       string
+	transform  math.Matrix4
+	suppressed bool
+	source     RangeBoxSource
+	owner      *Occurrences
+}
+
+// ID returns the occurrence's session id (unique within its owning collection).
+func (o *Occurrence) ID() uint64 { return o.id }
+
+// Name returns the occurrence's instance name (e.g. "pin:1").
+func (o *Occurrence) Name() string { return o.name }
+
+// Source returns the component definition this occurrence instances.
+func (o *Occurrence) Source() RangeBoxSource { return o.source }
+
+// Transform returns the occurrence's placement in its assembly's space.
+func (o *Occurrence) Transform() math.Matrix4 { return o.transform }
+
+// SetTransform repositions the occurrence and advances the owning assembly's version.
+func (o *Occurrence) SetTransform(m math.Matrix4) {
+	o.transform = m
+	o.owner.bump()
+}
+
+// Suppressed reports whether the occurrence is excluded from the model — it
+// contributes no geometry and is skipped by the range box (and, from M12, by
+// constraint solving).
+func (o *Occurrence) Suppressed() bool { return o.suppressed }
+
+// SetSuppressed sets the occurrence's suppression state, advancing the version only
+// when it actually changes.
+func (o *Occurrence) SetSuppressed(suppressed bool) {
+	if o.suppressed == suppressed {
+		return
+	}
+	o.suppressed = suppressed
+	o.owner.bump()
+}
+
+// RangeBox returns the occurrence's bounding box in its assembly's space: the
+// source's local box placed by the transform. A suppressed occurrence reports the
+// empty box, contributing nothing to the assembly.
+func (o *Occurrence) RangeBox() math.Box {
+	if o.suppressed {
+		return math.EmptyBox()
+	}
+	return o.source.RangeBox().Transform(o.transform)
+}

--- a/model/occurrence/occurrence_test.go
+++ b/model/occurrence/occurrence_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// fakeComponent is a named test double for a component definition: it reports a fixed
+// local range box, standing in for a real part/assembly definition (which the
+// reference graph supplies from M11-F02).
+type fakeComponent struct{ box math.Box }
+
+func (f fakeComponent) RangeBox() math.Box { return f.box }
+
+// unitComponent is a 1×1×1 box at the origin.
+func unitComponent() fakeComponent {
+	return fakeComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1))}
+}
+
+func TestOccurrencesAddAssignsIdsAndCounts(t *testing.T) {
+	occ := NewOccurrences()
+	a := occ.Add("a:1", unitComponent(), math.Identity4())
+	b := occ.Add("b:1", unitComponent(), math.Identity4())
+	if occ.Count() != 2 || a.ID() == b.ID() {
+		t.Fatalf("Count=%d ids=(%d,%d), want 2 distinct", occ.Count(), a.ID(), b.ID())
+	}
+	got, ok := occ.ByID(a.ID())
+	if !ok || got != a || occ.Item(0) != a {
+		t.Errorf("lookup mismatch: ByID ok=%v got=%p item0=%p a=%p", ok, got, occ.Item(0), a)
+	}
+}
+
+func TestOccurrenceRangeBoxPlacesByTransform(t *testing.T) {
+	occ := NewOccurrences()
+	occ.Add("origin", unitComponent(), math.Identity4())
+	occ.Add("moved", unitComponent(), math.Translation4(math.V3(10, 0, 0)))
+	// One unit box at [0,1]³ and another at [10,11]×[0,1]×[0,1] → union [0,11]×[0,1]×[0,1].
+	box := occ.RangeBox()
+	if box.Min != (math.P3(0, 0, 0)) || box.Max != (math.P3(11, 1, 1)) {
+		t.Errorf("assembly box = %v..%v, want {0 0 0}..{11 1 1}", box.Min, box.Max)
+	}
+}
+
+func TestSuppressedOccurrenceLeavesNoTraceInBox(t *testing.T) {
+	occ := NewOccurrences()
+	occ.Add("kept", unitComponent(), math.Identity4())
+	far := occ.Add("dropped", unitComponent(), math.Translation4(math.V3(100, 0, 0)))
+	far.SetSuppressed(true)
+	box := occ.RangeBox()
+	if box.Min != (math.P3(0, 0, 0)) || box.Max != (math.P3(1, 1, 1)) {
+		t.Errorf("box with suppressed occurrence = %v..%v, want just the kept unit box", box.Min, box.Max)
+	}
+}
+
+func TestMutationsAdvanceRevision(t *testing.T) {
+	occ := NewOccurrences()
+	r0 := occ.Revision()
+	o := occ.Add("x", unitComponent(), math.Identity4())
+	rAdd := occ.Revision()
+	o.SetTransform(math.Translation4(math.V3(1, 0, 0)))
+	rMove := occ.Revision()
+	o.SetSuppressed(true)
+	rSuppress := occ.Revision()
+	o.SetSuppressed(true) // no-op: state unchanged, must not advance
+	rNoop := occ.Revision()
+	if r0 >= rAdd || rAdd >= rMove || rMove >= rSuppress {
+		t.Errorf("revisions not strictly increasing: %d,%d,%d,%d", r0, rAdd, rMove, rSuppress)
+	}
+	if rNoop != rSuppress {
+		t.Errorf("no-op SetSuppressed advanced revision %d→%d", rSuppress, rNoop)
+	}
+	if !occ.Remove(o) || occ.Revision() <= rNoop {
+		t.Errorf("Remove should advance revision (was %d, now %d)", rNoop, occ.Revision())
+	}
+}
+
+func TestRemoveUnknownOccurrenceIsNoop(t *testing.T) {
+	occ := NewOccurrences()
+	other := NewOccurrences()
+	stray := other.Add("stray", unitComponent(), math.Identity4())
+	if occ.Remove(stray) {
+		t.Error("Remove of an occurrence from another collection returned true")
+	}
+}
+
+func TestEmptyAssemblyHasEmptyBox(t *testing.T) {
+	if box := NewOccurrences().RangeBox(); !box.IsEmpty() {
+		t.Errorf("empty assembly box = %v..%v, want empty", box.Min, box.Max)
+	}
+}

--- a/model/occurrence/occurrences.go
+++ b/model/occurrence/occurrences.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import "oblikovati.org/math"
+
+// Occurrences is the collection of component occurrences an assembly owns — the
+// reference API's ComponentOccurrences (M11-F01). It mints occurrence ids, tracks a
+// revision that advances on every structural or placement change (so the assembly's
+// geometry version derives from it), and unions its members' boxes.
+type Occurrences struct {
+	items    []*Occurrence
+	byID     map[uint64]*Occurrence
+	nextID   uint64
+	revision uint64
+}
+
+// NewOccurrences returns an empty occurrence collection.
+func NewOccurrences() *Occurrences {
+	return &Occurrences{byID: map[uint64]*Occurrence{}}
+}
+
+// Add places source in the assembly under name with transform, returning the new
+// occurrence. The transform locates the component in the assembly's space; pass
+// [math.Identity4] to place it at the origin.
+func (c *Occurrences) Add(name string, source RangeBoxSource, transform math.Matrix4) *Occurrence {
+	c.nextID++
+	o := &Occurrence{id: c.nextID, name: name, transform: transform, source: source, owner: c}
+	c.items = append(c.items, o)
+	c.byID[o.id] = o
+	c.bump()
+	return o
+}
+
+// Count returns the number of occurrences; Item returns the i-th in placement order.
+func (c *Occurrences) Count() int             { return len(c.items) }
+func (c *Occurrences) Item(i int) *Occurrence { return c.items[i] }
+
+// ByID returns the occurrence with the given session id.
+func (c *Occurrences) ByID(id uint64) (*Occurrence, bool) {
+	o, ok := c.byID[id]
+	return o, ok
+}
+
+// All returns a snapshot of the occurrences in placement order.
+func (c *Occurrences) All() []*Occurrence {
+	out := make([]*Occurrence, len(c.items))
+	copy(out, c.items)
+	return out
+}
+
+// Remove deletes an occurrence, reporting whether it was present and advancing the
+// revision when it was.
+func (c *Occurrences) Remove(o *Occurrence) bool {
+	if _, ok := c.byID[o.id]; !ok {
+		return false
+	}
+	delete(c.byID, o.id)
+	for i, existing := range c.items {
+		if existing == o {
+			c.items = append(c.items[:i], c.items[i+1:]...)
+			c.bump()
+			return true
+		}
+	}
+	return false
+}
+
+// RangeBox returns the axis-aligned box enclosing every unsuppressed occurrence,
+// empty when the assembly has none. Empty contributions (suppressed occurrences, or
+// a source with no geometry) are skipped — unioning the empty box would blow the
+// result out to infinite extents, since the empty box has ±inf corners.
+func (c *Occurrences) RangeBox() math.Box {
+	box := math.EmptyBox()
+	for _, o := range c.items {
+		ob := o.RangeBox()
+		if ob.IsEmpty() {
+			continue
+		}
+		box = box.Union(ob)
+	}
+	return box
+}
+
+// Revision returns a counter that advances on every structural change (add/remove)
+// and every placement/suppression change, so consumers can detect when the assembly
+// geometry changed (the basis for the assembly's ModelGeometryVersion).
+func (c *Occurrences) Revision() uint64 { return c.revision }
+
+// bump advances the revision after a mutation.
+func (c *Occurrences) bump() { c.revision++ }


### PR DESCRIPTION
Closes #345. Closes #350 (PBI-117).

## What

Replaces the identity-only assembly content stub with the real **`AssemblyComponentDefinition`** — the assembly analogue of `PartComponentDefinition`. An assembly document now exposes its component occurrences and bounding box (the PBI's acceptance criterion).

Three layers:

- **`math.Box.Transform(Matrix4)`** — the AABB of a box's eight transformed corners; the primitive for placing a component's box by an occurrence transform.
- **`model/occurrence`** — `Occurrence` (a placement: source definition + transform + suppression) and the `Occurrences` collection (mint ids, `Add`/`Remove`/`Count`/`Item`/`ByID`/`All`, a `Revision` that advances on every structural/placement change, and a `RangeBox` that unions members' transformed boxes). A narrow `RangeBoxSource` interface lets both part and sub-assembly definitions be placed without a `compdef` import cycle (nesting-ready).
- **`model/compdef/assembly.go`** — `AssemblyComponentDefinition` owning the occurrences, exposing `RangeBox`/`PreciseRangeBox`/`OrientedMinimumRangeBox` (parity with the part), display units, and a `ModelGeometryVersion` derived from the occurrence revision. `AddAssembly` mirrors `AddPart`, and an `init()` registers the content factory so `ws.Add(Assembly)` / `documents.create` / the CLI yield the real definition instead of the doc-layer placeholder.

## Why

M11 introduces the assembly as a second real document kind; F01 builds the container the rest of the milestone fills. The occurrence *placement* operations (placing referenced documents, ground/transform/pattern/nesting) are F02 — this PR delivers the in-memory model and the bounding box those operations will read and write.

## Scope notes

- Consistent with the M07 part definition, the assembly definition is a GPL model type — no `api/contract` interface is added (the part has none yet either; public wire/contract exposure follows when a head/add-in consumer needs it). So this is a single source-repo PR, no API change.
- The assembly intentionally does **not** implement `doc.RecipeContent` yet: its occurrences reference documents via the reference graph that arrives in F02, so there is nothing recipe-persistable until then — today an assembly round-trips its identity (manifest). Marked with a `TODO`/explained in the factory comment.

## Tests

- `math`: `Box.Transform` — translation, a 90° Z-rotation enlarging the AABB, empty-box passthrough.
- `model/occurrence`: id assignment, transform-placed union box, suppressed occurrences leaving no trace, revision strictly advancing on add/move/suppress/remove (and a no-op suppress not advancing), cross-collection `Remove` no-op, empty-assembly empty box.
- `model/compdef`: new assembly is empty content of the right kind; range box unions placed occurrences and the version tracks; `AddAssembly` installs+activates real content; the `init()` factory is registered for `ws.Add(Assembly)`.
- Full suite green (core + head), `golangci-lint` v2.1.0 clean, SPDX headers present. Verified the factory registration breaks no existing assembly/persistence test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)