### PR TITLE
M11-F02: Component Occurrences

### DIFF
--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -3,12 +3,22 @@
 package compdef
 
 import (
+	"fmt"
 	"strconv"
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/param"
+)
+
+// An assembly definition is a composite component — a placeable definition that owns
+// its own occurrences — so it can nest inside a parent assembly; a part definition is
+// a plain (leaf) placeable definition. These assertions pin both, the flyweight
+// vocabulary the occurrence model places against (M11-F02).
+var (
+	_ occurrence.Composite  = (*AssemblyComponentDefinition)(nil)
+	_ occurrence.Definition = (*PartComponentDefinition)(nil)
 )
 
 // AssemblyComponentDefinition is an assembly's modeling content — the assembly
@@ -63,10 +73,37 @@ func AddAssembly(ws *doc.Workspace, fullDocumentName string, visible bool) (*doc
 func (a *AssemblyComponentDefinition) DocumentType() doc.DocumentType { return doc.Assembly }
 
 // Occurrences returns the assembly's component occurrences — the parts and
-// sub-assemblies placed in it. Placement and editing operations land in M11-F02; this
-// is the live collection the assembly's structure and range box read from.
+// sub-assemblies placed in it. This is the live collection the assembly's structure
+// and range box read from, and the one a parent assembly navigates into when this
+// assembly is itself placed (nesting). It also makes the definition a Composite.
 func (a *AssemblyComponentDefinition) Occurrences() *occurrence.Occurrences {
 	return a.occurrences
+}
+
+// Place adds an occurrence of def to the assembly under name at transform, returning
+// it — the assembly-level entry behind "place component". def is shared: place the
+// same definition twice and both occurrences track its edits (the flyweight). To
+// place an open document's component, use [PlaceComponent].
+func (a *AssemblyComponentDefinition) Place(name string, def occurrence.Definition, transform math.Matrix4) *occurrence.Occurrence {
+	return a.occurrences.AddByComponentDefinition(name, def, transform)
+}
+
+// PlaceComponent places the component held by componentDoc — an open part or assembly
+// document — into the assembly under name at transform. The document's content
+// definition is shared (the flyweight), so every placement tracks edits to that
+// component. It errors if the content is not a placeable component definition (e.g. a
+// reference stub or a drawing).
+//
+// NOTE: this links the in-memory definitions only. Recording the assembly→component
+// document reference (the reference graph) and persisting placements arrive in a
+// follow-up — see the assembly-persistence note on the package factory.
+func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *doc.Document, transform math.Matrix4) (*occurrence.Occurrence, error) {
+	def, ok := componentDoc.Content().(occurrence.Definition)
+	if !ok {
+		return nil, fmt.Errorf("compdef: cannot place %q: its content %T is not a placeable component definition",
+			componentDoc.DisplayName(), componentDoc.Content())
+	}
+	return a.Place(name, def, transform), nil
 }
 
 // RangeBox returns the axis-aligned bounding box enclosing every unsuppressed

--- a/model/compdef/assembly_test.go
+++ b/model/compdef/assembly_test.go
@@ -17,7 +17,7 @@ type fakeComponentSource struct{ box math.Box }
 
 func (f fakeComponentSource) RangeBox() math.Box { return f.box }
 
-var _ occurrence.RangeBoxSource = fakeComponentSource{}
+var _ occurrence.Definition = fakeComponentSource{}
 
 // unitSource is a 1×1×1 component at its own origin.
 func unitSource() fakeComponentSource {
@@ -38,8 +38,8 @@ func TestNewAssemblyIsEmptyAssemblyContent(t *testing.T) {
 func TestAssemblyRangeBoxUnionsOccurrencesAndVersionTracks(t *testing.T) {
 	a := NewAssemblyComponentDefinition()
 	v0 := a.ModelGeometryVersion()
-	a.Occurrences().Add("base", unitSource(), math.Identity4())
-	a.Occurrences().Add("offset", unitSource(), math.Translation4(math.V3(4, 0, 0)))
+	a.Place("base", unitSource(), math.Identity4())
+	a.Place("offset", unitSource(), math.Translation4(math.V3(4, 0, 0)))
 	// [0,1]³ ∪ [4,5]×[0,1]×[0,1] = [0,5]×[0,1]×[0,1].
 	box := a.RangeBox()
 	if box.Min != (math.P3(0, 0, 0)) || box.Max != (math.P3(5, 1, 1)) {
@@ -75,5 +75,63 @@ func TestAssemblyFactoryRegisteredForWorkspaceAdd(t *testing.T) {
 	}
 	if _, ok := d.Content().(*AssemblyComponentDefinition); !ok {
 		t.Errorf("factory content = %T, want *AssemblyComponentDefinition", d.Content())
+	}
+}
+
+// TestPlaceComponentSharesDefinitionAcrossPlacements is the PBI-118 acceptance at the
+// document level: two placements of one part document share its definition (the
+// flyweight), so editing the part would update both.
+func TestPlaceComponentSharesDefinitionAcrossPlacements(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	partDoc, err := AddPart(ws, "pin.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	asm := NewAssemblyComponentDefinition()
+	o1, err := asm.PlaceComponent("pin:1", partDoc, math.Identity4())
+	if err != nil {
+		t.Fatalf("PlaceComponent pin:1: %v", err)
+	}
+	o2, err := asm.PlaceComponent("pin:2", partDoc, math.Translation4(math.V3(5, 0, 0)))
+	if err != nil {
+		t.Fatalf("PlaceComponent pin:2: %v", err)
+	}
+	if asm.Occurrences().Count() != 2 {
+		t.Fatalf("occurrence count = %d, want 2", asm.Occurrences().Count())
+	}
+	if o1.Definition() != o2.Definition() {
+		t.Error("two placements of one part document should share its definition (flyweight)")
+	}
+}
+
+func TestPlaceComponentRejectsNonComponentDocument(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	drawingDoc, err := ws.Add(doc.Drawing, "sheet.odd", true) // drawing content has no range box
+	if err != nil {
+		t.Fatalf("ws.Add(drawing): %v", err)
+	}
+	if _, err := NewAssemblyComponentDefinition().PlaceComponent("x", drawingDoc, math.Identity4()); err == nil {
+		t.Error("PlaceComponent of a drawing document should error (not a component definition)")
+	}
+}
+
+// TestNestedAssemblyResolvableByPath is the PBI-119 acceptance with real definitions:
+// a sub-assembly placed in a parent assembly has its nested part addressable by path.
+func TestNestedAssemblyResolvableByPath(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	pinDoc, err := AddPart(ws, "pin.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	sub := NewAssemblyComponentDefinition()
+	if _, err := sub.PlaceComponent("pin:1", pinDoc, math.Identity4()); err != nil {
+		t.Fatalf("place pin in sub-assembly: %v", err)
+	}
+	top := NewAssemblyComponentDefinition()
+	top.Place("gearbox:1", sub, math.Identity4())
+
+	got, ok := top.Occurrences().Resolve(occurrence.OccurrencePath{"gearbox:1", "pin:1"})
+	if !ok || got.Name() != "pin:1" {
+		t.Errorf("Resolve([gearbox:1 pin:1]) ok=%v got=%v, want the nested pin:1", ok, got)
 	}
 }

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -1,37 +1,51 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 // Package occurrence models component occurrences — the placements of a component (a
-// part or a sub-assembly) inside an assembly. One referenced component can be placed
-// many times; each placement is an occurrence carrying its own transform and
-// suppression state. This is the assembly analogue of a body in a part: the unit the
-// assembly's structure, range box, and (from M12) constraints operate on. It is the
-// reference API's ComponentOccurrence / ComponentOccurrences (M11-F01, #345).
+// part or a sub-assembly) inside an assembly. One shared component definition can be
+// placed many times; each placement is an occurrence carrying its own transform and
+// per-instance state. This is the flyweight at the heart of assemblies: memory scales
+// with unique components, not with placements, and editing a definition updates every
+// occurrence of it. It is the reference API's ComponentOccurrence /
+// ComponentOccurrences (M11-F01/F02, #345/#346).
 package occurrence
 
 import "oblikovati.org/math"
 
-// RangeBoxSource is what an occurrence instances: anything that reports its local
-// (definition-space) range box. Both a part and an assembly component definition
-// satisfy it (model/compdef), so an occurrence's contribution to its owner's box
-// always reflects the current child geometry — and a sub-assembly can be placed in a
-// parent assembly (nesting). Kept narrow here so model/occurrence does not import
-// model/compdef, which imports this package.
-type RangeBoxSource interface {
-	// RangeBox returns the source's axis-aligned bounding box in its own space.
+// Definition is the component definition an occurrence instances — a part or an
+// assembly definition (model/compdef). Many occurrences can share one Definition (the
+// flyweight): placing a part twice yields two occurrences pointing at the same
+// Definition, so editing it updates every instance. The occurrence needs the
+// definition's range box to place it; an assembly definition additionally satisfies
+// [Composite] so its instances can be navigated into. Kept narrow here so
+// model/occurrence does not import model/compdef, which imports this package.
+type Definition interface {
+	// RangeBox returns the definition's axis-aligned bounding box in its own space.
 	RangeBox() math.Box
 }
 
-// Occurrence is one placement of a component inside an assembly: its source
-// definition, a transform locating it in the assembly's space, and whether it is
-// suppressed (excluded from the model). Created and owned by an [Occurrences]
-// collection; mutating its transform or suppression bumps the owner's revision so the
-// assembly's geometry version advances.
+// Composite is a [Definition] that owns its own occurrences — an assembly. An
+// occurrence of a Composite has sub-occurrences (the components nested inside it), the
+// basis of the assembly nesting model. A part definition is not a Composite. The
+// assembly definition satisfies this through its existing Occurrences accessor.
+type Composite interface {
+	Definition
+	// Occurrences returns the components placed inside this composite definition.
+	Occurrences() *Occurrences
+}
+
+// Occurrence is one placement of a component inside an assembly: the shared
+// definition it instances, a transform locating it in the assembly's space, and its
+// per-instance state. Created and owned by an [Occurrences] collection; mutating its
+// transform or suppression bumps the owner's revision so the assembly's geometry
+// version advances (grounding/adaptivity are non-geometric and do not).
 type Occurrence struct {
 	id         uint64
 	name       string
 	transform  math.Matrix4
 	suppressed bool
-	source     RangeBoxSource
+	grounded   bool
+	adaptive   bool
+	definition Definition
 	owner      *Occurrences
 }
 
@@ -41,13 +55,15 @@ func (o *Occurrence) ID() uint64 { return o.id }
 // Name returns the occurrence's instance name (e.g. "pin:1").
 func (o *Occurrence) Name() string { return o.name }
 
-// Source returns the component definition this occurrence instances.
-func (o *Occurrence) Source() RangeBoxSource { return o.source }
+// Definition returns the shared component definition this occurrence instances.
+func (o *Occurrence) Definition() Definition { return o.definition }
 
 // Transform returns the occurrence's placement in its assembly's space.
 func (o *Occurrence) Transform() math.Matrix4 { return o.transform }
 
 // SetTransform repositions the occurrence and advances the owning assembly's version.
+// It is the reference API's Transformation set / SetTransformWithoutConstraints:
+// constraint adjustment after a move is the solver's job (M12), not this call's.
 func (o *Occurrence) SetTransform(m math.Matrix4) {
 	o.transform = m
 	o.owner.bump()
@@ -59,7 +75,7 @@ func (o *Occurrence) SetTransform(m math.Matrix4) {
 func (o *Occurrence) Suppressed() bool { return o.suppressed }
 
 // SetSuppressed sets the occurrence's suppression state, advancing the version only
-// when it actually changes.
+// when it actually changes (suppression adds/removes geometry).
 func (o *Occurrence) SetSuppressed(suppressed bool) {
 	if o.suppressed == suppressed {
 		return
@@ -68,12 +84,37 @@ func (o *Occurrence) SetSuppressed(suppressed bool) {
 	o.owner.bump()
 }
 
+// Grounded reports whether the occurrence is fixed in space (the solver may not move
+// it). Grounding is a constraint hint, not geometry, so it does not bump the version.
+func (o *Occurrence) Grounded() bool { return o.grounded }
+
+// SetGrounded fixes or releases the occurrence in space.
+func (o *Occurrence) SetGrounded(grounded bool) { o.grounded = grounded }
+
+// Adaptive reports whether the occurrence's underdimensioned geometry may flex to
+// satisfy assembly constraints (resolved by the solver from M12).
+func (o *Occurrence) Adaptive() bool { return o.adaptive }
+
+// SetAdaptive marks the occurrence adaptive or rigid.
+func (o *Occurrence) SetAdaptive(adaptive bool) { o.adaptive = adaptive }
+
+// SubOccurrences returns the components nested inside this occurrence when it
+// instances an assembly (a [Composite] definition), or nil for a leaf part. They are
+// the shared definition's occurrences — the flyweight: every placement of one
+// sub-assembly navigates into the same children, disambiguated by occurrence path.
+func (o *Occurrence) SubOccurrences() *Occurrences {
+	if c, ok := o.definition.(Composite); ok {
+		return c.Occurrences()
+	}
+	return nil
+}
+
 // RangeBox returns the occurrence's bounding box in its assembly's space: the
-// source's local box placed by the transform. A suppressed occurrence reports the
+// definition's local box placed by the transform. A suppressed occurrence reports the
 // empty box, contributing nothing to the assembly.
 func (o *Occurrence) RangeBox() math.Box {
 	if o.suppressed {
 		return math.EmptyBox()
 	}
-	return o.source.RangeBox().Transform(o.transform)
+	return o.definition.RangeBox().Transform(o.transform)
 }

--- a/model/occurrence/occurrence_test.go
+++ b/model/occurrence/occurrence_test.go
@@ -8,22 +8,41 @@ import (
 	"oblikovati.org/math"
 )
 
-// fakeComponent is a named test double for a component definition: it reports a fixed
-// local range box, standing in for a real part/assembly definition (which the
-// reference graph supplies from M11-F02).
+// fakeComponent is a named test double for a leaf component definition (a part): it
+// reports a fixed local range box and is not a Composite, so its occurrences have no
+// sub-occurrences.
 type fakeComponent struct{ box math.Box }
 
 func (f fakeComponent) RangeBox() math.Box { return f.box }
 
-// unitComponent is a 1×1×1 box at the origin.
+// unitComponent is a 1×1×1 leaf component at the origin.
 func unitComponent() fakeComponent {
 	return fakeComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1))}
 }
 
+// mutableComponent is a named Definition with a pointer identity and a changeable box,
+// to prove the flyweight: editing one shared definition updates every occurrence of it.
+type mutableComponent struct{ box math.Box }
+
+func (m *mutableComponent) RangeBox() math.Box { return m.box }
+
+// fakeAssembly is a named Composite test double: a definition that owns a nested
+// occurrence collection, standing in for an assembly definition so nesting can be
+// exercised without model/compdef.
+type fakeAssembly struct {
+	box      math.Box
+	children *Occurrences
+}
+
+func (f *fakeAssembly) RangeBox() math.Box        { return f.box }
+func (f *fakeAssembly) Occurrences() *Occurrences { return f.children }
+
+var _ Composite = (*fakeAssembly)(nil)
+
 func TestOccurrencesAddAssignsIdsAndCounts(t *testing.T) {
 	occ := NewOccurrences()
-	a := occ.Add("a:1", unitComponent(), math.Identity4())
-	b := occ.Add("b:1", unitComponent(), math.Identity4())
+	a := occ.AddByComponentDefinition("a:1", unitComponent(), math.Identity4())
+	b := occ.AddByComponentDefinition("b:1", unitComponent(), math.Identity4())
 	if occ.Count() != 2 || a.ID() == b.ID() {
 		t.Fatalf("Count=%d ids=(%d,%d), want 2 distinct", occ.Count(), a.ID(), b.ID())
 	}
@@ -35,8 +54,8 @@ func TestOccurrencesAddAssignsIdsAndCounts(t *testing.T) {
 
 func TestOccurrenceRangeBoxPlacesByTransform(t *testing.T) {
 	occ := NewOccurrences()
-	occ.Add("origin", unitComponent(), math.Identity4())
-	occ.Add("moved", unitComponent(), math.Translation4(math.V3(10, 0, 0)))
+	occ.AddByComponentDefinition("origin", unitComponent(), math.Identity4())
+	occ.AddByComponentDefinition("moved", unitComponent(), math.Translation4(math.V3(10, 0, 0)))
 	// One unit box at [0,1]³ and another at [10,11]×[0,1]×[0,1] → union [0,11]×[0,1]×[0,1].
 	box := occ.RangeBox()
 	if box.Min != (math.P3(0, 0, 0)) || box.Max != (math.P3(11, 1, 1)) {
@@ -46,8 +65,8 @@ func TestOccurrenceRangeBoxPlacesByTransform(t *testing.T) {
 
 func TestSuppressedOccurrenceLeavesNoTraceInBox(t *testing.T) {
 	occ := NewOccurrences()
-	occ.Add("kept", unitComponent(), math.Identity4())
-	far := occ.Add("dropped", unitComponent(), math.Translation4(math.V3(100, 0, 0)))
+	occ.AddByComponentDefinition("kept", unitComponent(), math.Identity4())
+	far := occ.AddByComponentDefinition("dropped", unitComponent(), math.Translation4(math.V3(100, 0, 0)))
 	far.SetSuppressed(true)
 	box := occ.RangeBox()
 	if box.Min != (math.P3(0, 0, 0)) || box.Max != (math.P3(1, 1, 1)) {
@@ -58,7 +77,7 @@ func TestSuppressedOccurrenceLeavesNoTraceInBox(t *testing.T) {
 func TestMutationsAdvanceRevision(t *testing.T) {
 	occ := NewOccurrences()
 	r0 := occ.Revision()
-	o := occ.Add("x", unitComponent(), math.Identity4())
+	o := occ.AddByComponentDefinition("x", unitComponent(), math.Identity4())
 	rAdd := occ.Revision()
 	o.SetTransform(math.Translation4(math.V3(1, 0, 0)))
 	rMove := occ.Revision()
@@ -80,7 +99,7 @@ func TestMutationsAdvanceRevision(t *testing.T) {
 func TestRemoveUnknownOccurrenceIsNoop(t *testing.T) {
 	occ := NewOccurrences()
 	other := NewOccurrences()
-	stray := other.Add("stray", unitComponent(), math.Identity4())
+	stray := other.AddByComponentDefinition("stray", unitComponent(), math.Identity4())
 	if occ.Remove(stray) {
 		t.Error("Remove of an occurrence from another collection returned true")
 	}
@@ -89,5 +108,109 @@ func TestRemoveUnknownOccurrenceIsNoop(t *testing.T) {
 func TestEmptyAssemblyHasEmptyBox(t *testing.T) {
 	if box := NewOccurrences().RangeBox(); !box.IsEmpty() {
 		t.Errorf("empty assembly box = %v..%v, want empty", box.Min, box.Max)
+	}
+}
+
+// TestEditingSharedDefinitionUpdatesAllOccurrences is the PBI-118 flyweight: two
+// placements of one definition share it, and editing the definition updates both
+// without re-placing.
+func TestEditingSharedDefinitionUpdatesAllOccurrences(t *testing.T) {
+	occ := NewOccurrences()
+	def := &mutableComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1))}
+	a := occ.AddByComponentDefinition("u:1", def, math.Identity4())
+	b := occ.AddByComponentDefinition("u:2", def, math.Translation4(math.V3(10, 0, 0)))
+	if a.Definition() != b.Definition() {
+		t.Fatal("placements should share the same definition pointer (flyweight)")
+	}
+	def.box = math.NewBox(math.P3(0, 0, 0), math.P3(2, 2, 2)) // edit the shared definition
+	if a.RangeBox().Max != (math.P3(2, 2, 2)) {
+		t.Errorf("occurrence a box max = %v, want grown to {2 2 2}", a.RangeBox().Max)
+	}
+	if b.RangeBox().Min != (math.P3(10, 0, 0)) || b.RangeBox().Max != (math.P3(12, 2, 2)) {
+		t.Errorf("occurrence b box = %v..%v, want {10 0 0}..{12 2 2}", b.RangeBox().Min, b.RangeBox().Max)
+	}
+}
+
+func TestOccurrenceStateFlags(t *testing.T) {
+	occ := NewOccurrences()
+	o := occ.AddByComponentDefinition("u:1", unitComponent(), math.Identity4())
+	if o.Grounded() || o.Adaptive() || o.Suppressed() {
+		t.Error("new occurrence should be ungrounded, non-adaptive, unsuppressed")
+	}
+	rev := occ.Revision()
+	o.SetGrounded(true)
+	o.SetAdaptive(true)
+	if !o.Grounded() || !o.Adaptive() {
+		t.Error("grounded/adaptive flags did not stick")
+	}
+	if occ.Revision() != rev {
+		t.Errorf("grounding/adaptivity bumped the geometry revision %d→%d (non-geometric, should not)", rev, occ.Revision())
+	}
+}
+
+func TestReplaceSwapsDefinitionKeepingPlacement(t *testing.T) {
+	occ := NewOccurrences()
+	small := &mutableComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1))}
+	big := &mutableComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(3, 3, 3))}
+	o := occ.AddByComponentDefinition("u:1", small, math.Translation4(math.V3(5, 0, 0)))
+	id, name, tf := o.ID(), o.Name(), o.Transform()
+	if !occ.Replace(o, big) {
+		t.Fatal("Replace returned false for an owned occurrence")
+	}
+	if o.Definition() != Definition(big) || o.ID() != id || o.Name() != name || o.Transform() != tf {
+		t.Error("Replace should swap the definition but keep id/name/transform")
+	}
+	if o.RangeBox().Max != (math.P3(8, 3, 3)) { // big [0,3]³ placed at +5x
+		t.Errorf("replaced box max = %v, want {8 3 3}", o.RangeBox().Max)
+	}
+	if occ.Replace(NewOccurrences().AddByComponentDefinition("x", small, math.Identity4()), big) {
+		t.Error("Replace of a foreign occurrence returned true")
+	}
+}
+
+// TestNestedOccurrencesResolveByPath is the PBI-119 nesting acceptance: a
+// sub-assembly's instances are addressable by occurrence path, and the parent is a
+// property of the path (the shared child has no single parent).
+func TestNestedOccurrencesResolveByPath(t *testing.T) {
+	// Sub-assembly B holding one pin.
+	bChildren := NewOccurrences()
+	pin := bChildren.AddByComponentDefinition("pin:1", unitComponent(), math.Identity4())
+	b := &fakeAssembly{box: math.NewBox(math.P3(0, 0, 0), math.P3(2, 2, 2)), children: bChildren}
+
+	// Top assembly A places B twice.
+	a := NewOccurrences()
+	g1 := a.AddByComponentDefinition("gearbox:1", b, math.Identity4())
+	a.AddByComponentDefinition("gearbox:2", b, math.Translation4(math.V3(10, 0, 0)))
+
+	if g1.SubOccurrences() != bChildren {
+		t.Error("SubOccurrences should be the shared sub-assembly children (flyweight)")
+	}
+	got, ok := a.Resolve(OccurrencePath{"gearbox:1", "pin:1"})
+	if !ok || got != pin {
+		t.Errorf("Resolve([gearbox:1 pin:1]) ok=%v got=%p, want the pin %p", ok, got, pin)
+	}
+	// The same shared pin is reachable under gearbox:2, with gearbox:2 as its parent.
+	parent, ok := a.ParentInPath(OccurrencePath{"gearbox:2", "pin:1"})
+	if !ok || parent == nil || parent.Name() != "gearbox:2" {
+		t.Errorf("ParentInPath([gearbox:2 pin:1]) = %v ok=%v, want gearbox:2", parent, ok)
+	}
+	// A top-level target resolves but has no parent.
+	if p, ok := a.ParentInPath(OccurrencePath{"gearbox:1"}); !ok || p != nil {
+		t.Errorf("ParentInPath([gearbox:1]) = %v ok=%v, want nil parent (top-level)", p, ok)
+	}
+}
+
+func TestResolveRejectsBadPaths(t *testing.T) {
+	a := NewOccurrences()
+	a.AddByComponentDefinition("bolt:1", unitComponent(), math.Identity4()) // a leaf part
+	cases := []OccurrencePath{
+		{},                 // empty
+		{"missing:1"},      // unknown name
+		{"bolt:1", "deep"}, // descending into a leaf part
+	}
+	for _, p := range cases {
+		if _, ok := a.Resolve(p); ok {
+			t.Errorf("Resolve(%v) = ok, want failure", p)
+		}
 	}
 }

--- a/model/occurrence/occurrences.go
+++ b/model/occurrence/occurrences.go
@@ -5,8 +5,8 @@ package occurrence
 import "oblikovati.org/math"
 
 // Occurrences is the collection of component occurrences an assembly owns — the
-// reference API's ComponentOccurrences (M11-F01). It mints occurrence ids, tracks a
-// revision that advances on every structural or placement change (so the assembly's
+// reference API's ComponentOccurrences (M11-F01/F02). It mints occurrence ids, tracks
+// a revision that advances on every structural or placement change (so the assembly's
 // geometry version derives from it), and unions its members' boxes.
 type Occurrences struct {
 	items    []*Occurrence
@@ -20,16 +20,32 @@ func NewOccurrences() *Occurrences {
 	return &Occurrences{byID: map[uint64]*Occurrence{}}
 }
 
-// Add places source in the assembly under name with transform, returning the new
-// occurrence. The transform locates the component in the assembly's space; pass
-// [math.Identity4] to place it at the origin.
-func (c *Occurrences) Add(name string, source RangeBoxSource, transform math.Matrix4) *Occurrence {
+// AddByComponentDefinition places def in the assembly under name with transform,
+// returning the new occurrence. def is shared — placing the same definition twice
+// yields two occurrences that both track its edits (the flyweight). The transform
+// locates the component in the assembly's space; pass [math.Identity4] for the origin.
+func (c *Occurrences) AddByComponentDefinition(name string, def Definition, transform math.Matrix4) *Occurrence {
 	c.nextID++
-	o := &Occurrence{id: c.nextID, name: name, transform: transform, source: source, owner: c}
+	o := &Occurrence{id: c.nextID, name: name, transform: transform, definition: def, owner: c}
 	c.items = append(c.items, o)
 	c.byID[o.id] = o
 	c.bump()
 	return o
+}
+
+// Replace swaps an occurrence's definition in place — the "replace component"
+// operation: a different component at the same placement, keeping the occurrence's id,
+// name, transform, and state. Reports whether the occurrence belongs to this
+// collection.
+func (c *Occurrences) Replace(o *Occurrence, def Definition) bool {
+	// Verify identity, not just id presence: ids are per-collection, so a foreign
+	// occurrence can share an id with one of ours.
+	if c.byID[o.id] != o {
+		return false
+	}
+	o.definition = def
+	c.bump()
+	return true
 }
 
 // Count returns the number of occurrences; Item returns the i-th in placement order.
@@ -42,6 +58,18 @@ func (c *Occurrences) ByID(id uint64) (*Occurrence, bool) {
 	return o, ok
 }
 
+// byName returns the first occurrence with the given instance name, or nil. Instance
+// names are expected unique within a collection (the placement layer auto-numbers
+// them, e.g. "pin:1"/"pin:2"); path resolution relies on that.
+func (c *Occurrences) byName(name string) *Occurrence {
+	for _, o := range c.items {
+		if o.name == name {
+			return o
+		}
+	}
+	return nil
+}
+
 // All returns a snapshot of the occurrences in placement order.
 func (c *Occurrences) All() []*Occurrence {
 	out := make([]*Occurrence, len(c.items))
@@ -52,7 +80,9 @@ func (c *Occurrences) All() []*Occurrence {
 // Remove deletes an occurrence, reporting whether it was present and advancing the
 // revision when it was.
 func (c *Occurrences) Remove(o *Occurrence) bool {
-	if _, ok := c.byID[o.id]; !ok {
+	// Verify identity, not just id presence: a foreign occurrence may share an id
+	// with one of ours, and deleting on a bare id match would evict the real entry.
+	if c.byID[o.id] != o {
 		return false
 	}
 	delete(c.byID, o.id)
@@ -67,8 +97,8 @@ func (c *Occurrences) Remove(o *Occurrence) bool {
 }
 
 // RangeBox returns the axis-aligned box enclosing every unsuppressed occurrence,
-// empty when the assembly has none. Empty contributions (suppressed occurrences, or
-// a source with no geometry) are skipped — unioning the empty box would blow the
+// empty when the assembly has none. Empty contributions (suppressed occurrences, or a
+// definition with no geometry) are skipped — unioning the empty box would blow the
 // result out to infinite extents, since the empty box has ±inf corners.
 func (c *Occurrences) RangeBox() math.Box {
 	box := math.EmptyBox()
@@ -82,9 +112,9 @@ func (c *Occurrences) RangeBox() math.Box {
 	return box
 }
 
-// Revision returns a counter that advances on every structural change (add/remove)
-// and every placement/suppression change, so consumers can detect when the assembly
-// geometry changed (the basis for the assembly's ModelGeometryVersion).
+// Revision returns a counter that advances on every structural change (add/remove/
+// replace) and every placement/suppression change, so consumers can detect when the
+// assembly geometry changed (the basis for the assembly's ModelGeometryVersion).
 func (c *Occurrences) Revision() uint64 { return c.revision }
 
 // bump advances the revision after a mutation.

--- a/model/occurrence/path.go
+++ b/model/occurrence/path.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+// OccurrencePath addresses a (possibly nested) occurrence from a root assembly: the
+// sequence of occurrence instance names from the top down, e.g.
+// ["gearbox:1", "shaft:2"]. Because sub-occurrences are shared flyweights, the same
+// nested occurrence object is reached through every placement of its sub-assembly; the
+// path is what disambiguates the *context* it is reached through — the reference API's
+// ComponentOccurrence.OccurrencePath. The empty path resolves to nothing.
+type OccurrencePath []string
+
+// Resolve walks the path from this collection down through nested sub-assemblies,
+// returning the addressed occurrence. It fails (false) on an empty path, a segment
+// naming no occurrence, or a non-final segment whose occurrence is a leaf part (no
+// sub-occurrences to descend into).
+func (c *Occurrences) Resolve(path OccurrencePath) (*Occurrence, bool) {
+	chain, ok := c.ResolveChain(path)
+	if !ok {
+		return nil, false
+	}
+	return chain[len(chain)-1], true
+}
+
+// ResolveChain walks the path and returns every occurrence along it — the root
+// segment first, the addressed occurrence last — so the caller has each occurrence's
+// parent context (chain[len-2] is the addressed occurrence's parent occurrence). It
+// fails identically to [Occurrences.Resolve].
+func (c *Occurrences) ResolveChain(path OccurrencePath) ([]*Occurrence, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+	chain := make([]*Occurrence, 0, len(path))
+	level := c
+	for i, name := range path {
+		if level == nil {
+			return nil, false // a leaf part has no sub-occurrences to descend into
+		}
+		o := level.byName(name)
+		if o == nil {
+			return nil, false
+		}
+		chain = append(chain, o)
+		if i < len(path)-1 {
+			level = o.SubOccurrences()
+		}
+	}
+	return chain, true
+}
+
+// ParentInPath returns the occurrence that contains the path's target — its parent in
+// this navigation context — or nil when the target is top-level (a single-segment
+// path). Because a shared sub-occurrence has no single parent, the parent is a
+// property of the path, not of the occurrence.
+func (c *Occurrences) ParentInPath(path OccurrencePath) (*Occurrence, bool) {
+	chain, ok := c.ResolveChain(path)
+	if !ok {
+		return nil, false
+	}
+	if len(chain) < 2 {
+		return nil, true // resolved, but the target is top-level: no parent
+	}
+	return chain[len(chain)-2], true
+}


### PR DESCRIPTION
Closes #346. Closes #351 (PBI-118). Closes #352 (PBI-119).

## What

Turns the F01 occurrence container into the assembly **flyweight** — a shared component definition placed many times, each placement carrying its own transform and per-instance state, nestable to any depth.

**`model/occurrence`**
- **`Definition`** (the component an occurrence instances) replaces the bare `RangeBoxSource`; **`Composite`** extends it for assembly definitions that own their own occurrences. Many occurrences share one `Definition`, so editing a component updates every placement.
- **`AddByComponentDefinition`** places a shared definition; **`Replace`** swaps an occurrence's definition in place (keeping id/name/transform/state).
- **Per-instance state**: `grounded` and `adaptive` join `suppressed`. Suppression is geometric (bumps the geometry revision); grounding/adaptivity are not.
- **Nesting**: an occurrence of a `Composite` exposes the sub-assembly's occurrences (`SubOccurrences`); **`OccurrencePath`** resolves a nested instance from a root assembly. Because a shared sub-occurrence has no single parent, the parent is a property of the *path* (`ResolveChain`/`ParentInPath`), not a field.

**`model/compdef`** — the assembly definition gains `Place(name, def, transform)` and `PlaceComponent(name, doc, transform)` (resolving an open document's content to a placeable definition, erroring on non-component content). Compile-time assertions pin that an assembly definition is a `Composite` and a part is a plain `Definition`.

## Acceptance

- **PBI-118**: two placements of one part document share its definition (`TestPlaceComponentSharesDefinitionAcrossPlacements`); editing a shared definition updates both placements' boxes (`TestEditingSharedDefinitionUpdatesAllOccurrences`).
- **PBI-119**: an occurrence moves via `SetTransform`; a sub-assembly's nested instances are addressable by path (`TestNestedAssemblyResolvableByPath`, `TestNestedOccurrencesResolveByPath`), with the parent resolved per-path.

## Bug fixed

The new `Replace` test surfaced a latent identity bug shared with `Remove`: both matched on bare id *presence*, but ids are per-collection, so a foreign occurrence with a colliding id passed — and `Remove` would even evict the real map entry. Both now verify pointer identity (`byID[o.id] != o`).

## Scope notes

Consistent with F01, this is GPL model work (no API change) and links the **in-memory** definitions. Recording the assembly→component document reference (the reference graph) and **persisting placements** remain the natural next increment — noted at the placement call and the assembly-persistence TODO. The acceptance criteria are all met at the model level.

## Tests

Full `model/occurrence` + `model/compdef` coverage (flyweight sharing, edit propagation, state flags + revision semantics, replace, nesting/path resolution, bad-path rejection, foreign-occurrence guards). Full suite green (core + head), `golangci-lint` v2.1.0 clean, SPDX present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)