### PR TITLE
M11-F03: Context Proxies

### DIFF
--- a/model/proxy/geometry.go
+++ b/model/proxy/geometry.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package proxy
+
+import "oblikovati.org/math"
+
+// The In*Context helpers report a proxied entity's geometry in assembly space. They
+// are free generic functions rather than methods because Go methods cannot add a type
+// constraint of their own: each is constrained to the capability the geometry needs
+// (a range box, a point, a direction), so it applies to exactly the native entities
+// that expose it — one transform path per geometry kind, shared by every entity that
+// has it.
+
+// Boxed is a definition-space entity that reports an axis-aligned range box. Topo
+// faces, edges, vertices, and bodies all satisfy it.
+type Boxed interface {
+	RangeBox() math.Box
+}
+
+// RangeBoxInContext returns the proxied entity's range box in assembly space: its
+// definition-space box transformed by the context. The native's own box is unchanged
+// (the proxy is a view, not a mutation).
+func RangeBoxInContext[E Boxed](p Proxy[E]) math.Box {
+	return p.native.RangeBox().Transform(p.context.transform)
+}
+
+// Pointed is a definition-space entity that reports a single point — a vertex or a
+// work point.
+type Pointed interface {
+	Point() math.Point3
+}
+
+// PointInContext returns the proxied entity's point in assembly space.
+func PointInContext[E Pointed](p Proxy[E]) math.Point3 {
+	return p.context.transform.TransformPoint(p.native.Point())
+}
+
+// Directed is a definition-space entity that reports a unit direction — a work axis.
+type Directed interface {
+	Direction() math.UnitVector3
+}
+
+// DirectionInContext returns the proxied entity's direction in assembly space, or
+// false if the context transform collapses it (only possible under a degenerate,
+// non-rigid transform; occurrence placements are rigid, so true in practice).
+func DirectionInContext[E Directed](p Proxy[E]) (math.UnitVector3, bool) {
+	d, err := p.context.transform.TransformUnitVector(p.native.Direction())
+	return d, err == nil
+}

--- a/model/proxy/proxy.go
+++ b/model/proxy/proxy.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package proxy views a definition-space entity (a part's face/edge/vertex or a work
+// feature) through an assembly occurrence context, so it reports assembly-space
+// geometry while still identifying the underlying native entity. It is the bridge
+// assembly features, mates, and measurement need (M11-F03, #347).
+//
+// The mechanism is implemented ONCE, generically: [Proxy] is parameterized over the
+// native entity type, so every entity kind gets a proxy for free and — crucially —
+// Proxy[E] is a DISTINCT type from the native E. A definition-space entity therefore
+// cannot be used where an assembly-space proxy is required (or vice versa); the
+// native≠proxy distinction is enforced by the compiler, not by convention. This is
+// the reference API's CreateGeometryProxy and its ~275 *Proxy types, without any
+// hand-authored per-entity proxy.
+package proxy
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// Context is the assembly-space context a definition-space entity is viewed through:
+// the transform from the entity's definition space to assembly space (composed along
+// the occurrence path) and the occurrence it is reached through, kept for identity —
+// the reference API's ContextDefinition role.
+type Context struct {
+	occurrence *occurrence.Occurrence
+	transform  math.Matrix4
+}
+
+// NewContext views entities through a single occurrence: the transform is the
+// occurrence's own placement in its assembly.
+func NewContext(o *occurrence.Occurrence) Context {
+	return Context{occurrence: o, transform: o.Transform()}
+}
+
+// NewPathContext views entities through a chain of nested occurrences — root first,
+// leaf last, as returned by [occurrence.Occurrences.ResolveChain]. The transform
+// composes each occurrence's placement (root·…·leaf) so an entity in the leaf's
+// definition space lands in the root assembly's space; the leaf occurrence is the
+// identifying context. An empty chain yields the identity context.
+func NewPathContext(chain []*occurrence.Occurrence) Context {
+	t := math.Identity4()
+	for _, o := range chain {
+		t = t.Mul(o.Transform())
+	}
+	var leaf *occurrence.Occurrence
+	if len(chain) > 0 {
+		leaf = chain[len(chain)-1]
+	}
+	return Context{occurrence: leaf, transform: t}
+}
+
+// Transform returns this context's definition→assembly-space transform.
+func (c Context) Transform() math.Matrix4 { return c.transform }
+
+// Occurrence returns the occurrence this context views entities through (the leaf of
+// the path), or nil for an empty path.
+func (c Context) Occurrence() *occurrence.Occurrence { return c.occurrence }
+
+// Proxy views a native definition-space entity E through a [Context], reporting
+// assembly-space geometry (via the In*Context helpers) while still identifying the
+// underlying native E (via [Proxy.Native]). Proxy[E] is a distinct type from E — see
+// the package doc on the native≠proxy distinction.
+type Proxy[E any] struct {
+	native  E
+	context Context
+}
+
+// CreateGeometryProxy views native through ctx — the reference API's
+// ComponentOccurrence.CreateGeometryProxy, generic over the entity so the proxy's type
+// matches the underlying entity.
+//
+//	p := proxy.CreateGeometryProxy(proxy.NewContext(occ), face) // Proxy[*topo.Face]
+func CreateGeometryProxy[E any](ctx Context, native E) Proxy[E] {
+	return Proxy[E]{native: native, context: ctx}
+}
+
+// Native returns the underlying definition-space entity this proxy views — the
+// reverse of [CreateGeometryProxy], recovering the native identity.
+func (p Proxy[E]) Native() E { return p.native }
+
+// Context returns the assembly-space context this proxy views its native through.
+func (p Proxy[E]) Context() Context { return p.context }

--- a/model/proxy/proxy_test.go
+++ b/model/proxy/proxy_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package proxy
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
+)
+
+// Real definition-space entities satisfy the proxy capability constraints, so the
+// generic mechanism proxies them with no per-entity code. These compile-time
+// assertions are the guarantee that a part's face/edge/vertex/body and the work
+// features can be proxied — proven without constructing any geometry.
+var (
+	_ Boxed    = (*topo.Face)(nil)
+	_ Boxed    = (*topo.Edge)(nil)
+	_ Boxed    = (*topo.Vertex)(nil)
+	_ Boxed    = (*topo.Body)(nil)
+	_ Pointed  = (*topo.Vertex)(nil)
+	_ Pointed  = (*feature.WorkPoint)(nil)
+	_ Directed = (*feature.WorkAxis)(nil)
+)
+
+// fakeDef is a minimal occurrence.Definition so tests can build occurrences with a
+// known transform; its box is irrelevant to the proxy (the proxy transforms the
+// proxied entity, not the occurrence's own definition).
+type fakeDef struct{}
+
+func (fakeDef) RangeBox() math.Box { return math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)) }
+
+// boxedEntity stands in for a topo face/edge/vertex (proven Boxed by the assertions
+// above), reporting a fixed definition-space range box.
+type boxedEntity struct{ box math.Box }
+
+func (b boxedEntity) RangeBox() math.Box { return b.box }
+
+// pointedEntity stands in for a vertex / work point; directedEntity for a work axis.
+type pointedEntity struct{ p math.Point3 }
+
+func (e pointedEntity) Point() math.Point3 { return e.p }
+
+type directedEntity struct{ d math.UnitVector3 }
+
+func (e directedEntity) Direction() math.UnitVector3 { return e.d }
+
+// occAt returns a single occurrence placed at translation t, for building contexts.
+func occAt(t math.Vector3) *occurrence.Occurrence {
+	return occurrence.NewOccurrences().AddByComponentDefinition("c:1", fakeDef{}, math.Translation4(t))
+}
+
+// TestProxyReportsAssemblySpaceBox is the F03 acceptance: an entity (here a face)
+// viewed via an occurrence reports its geometry in assembly space, not part space,
+// while Native recovers the unchanged underlying entity. (Proxy[E] is a distinct type
+// from E, so part-space geometry cannot be passed where an assembly-space proxy is
+// required — a compile-time guarantee, not exercised at runtime.)
+func TestProxyReportsAssemblySpaceBox(t *testing.T) {
+	face := boxedEntity{box: math.NewBox(math.P3(0, 0, 0), math.P3(2, 1, 1))}
+	ctx := NewContext(occAt(math.V3(10, 0, 0)))
+	p := CreateGeometryProxy(ctx, face)
+
+	got := RangeBoxInContext(p)
+	if got.Min != (math.P3(10, 0, 0)) || got.Max != (math.P3(12, 1, 1)) {
+		t.Errorf("assembly-space box = %v..%v, want {10 0 0}..{12 1 1}", got.Min, got.Max)
+	}
+	if p.Native().RangeBox().Max != (math.P3(2, 1, 1)) {
+		t.Errorf("native box = %v, want the unchanged part-space {2 1 1}", p.Native().RangeBox().Max)
+	}
+}
+
+func TestPointAndDirectionInContext(t *testing.T) {
+	ctx := NewContext(occAt(math.V3(5, 0, 0)))
+	pt := CreateGeometryProxy(ctx, pointedEntity{p: math.P3(1, 2, 3)})
+	if got := PointInContext(pt); got != (math.P3(6, 2, 3)) {
+		t.Errorf("point in context = %v, want {6 2 3}", got)
+	}
+	// A pure translation leaves directions unchanged.
+	xdir, _ := math.NewUnitVector3(1, 0, 0)
+	dir := CreateGeometryProxy(ctx, directedEntity{d: xdir})
+	got, ok := DirectionInContext(dir)
+	if !ok || got.Dot(xdir) < 0.999999 {
+		t.Errorf("direction in context = %v ok=%v, want unchanged +X", got, ok)
+	}
+}
+
+// TestPathContextComposesNestedTransforms proves nested occurrence paths compose: a
+// point in a pin's space, where the pin sits +1x inside a sub-assembly that sits +10x
+// in the top assembly, lands at +11x in the top.
+func TestPathContextComposesNestedTransforms(t *testing.T) {
+	g1 := occAt(math.V3(10, 0, 0))
+	pin := occAt(math.V3(1, 0, 0))
+	ctx := NewPathContext([]*occurrence.Occurrence{g1, pin})
+	if ctx.Occurrence() != pin {
+		t.Error("path context should identify the leaf occurrence")
+	}
+	p := CreateGeometryProxy(ctx, pointedEntity{p: math.P3(0, 0, 0)})
+	if got := PointInContext(p); got != (math.P3(11, 0, 0)) {
+		t.Errorf("nested point = %v, want {11 0 0} (10+1 composed)", got)
+	}
+}
+
+func TestEmptyPathContextIsIdentity(t *testing.T) {
+	ctx := NewPathContext(nil)
+	if ctx.Occurrence() != nil {
+		t.Error("empty path context should have no occurrence")
+	}
+	p := CreateGeometryProxy(ctx, pointedEntity{p: math.P3(7, 8, 9)})
+	if got := PointInContext(p); got != (math.P3(7, 8, 9)) {
+		t.Errorf("identity context moved the point to %v, want {7 8 9}", got)
+	}
+}


### PR DESCRIPTION
Closes #347. Closes #353 (PBI-120).

## What

Adds `model/proxy` — the mechanism that views a part-definition entity (face/edge/vertex, work feature) through an assembly occurrence so it reports **assembly-space** geometry while still identifying the underlying **native** entity. This is the bridge assembly features, mates, and measurement need.

Per the PBI's explicit guidance — *"implement proxying once generically; do not hand-author 275 proxy types; the architectural win is the explicit native≠proxy type distinction"* — it is built with **Go generics**:

- **`Proxy[E]`** is parameterized over the native entity, so every entity kind gets a proxy for free, and `Proxy[E]` is a **distinct type** from `E`. A definition-space entity therefore cannot be passed where an assembly-space proxy is required (or vice versa) — enforced by the compiler, not convention.
- **`Context`** carries the definition→assembly transform — composed along an occurrence path via `NewPathContext` (using F02's nesting) — and the occurrence reached through (the reference API's `ContextDefinition` role).
- **`CreateGeometryProxy(ctx, native)`** wraps a native; **`Native()`** recovers it.
- The **`In*Context`** helpers (`RangeBoxInContext`/`PointInContext`/`DirectionInContext`), each constrained to the capability its geometry needs (`Boxed`/`Pointed`/`Directed`), report the entity transformed into assembly space — one transform path per geometry kind, shared by every entity that exposes it.

## Acceptance

- **A part face viewed via an occurrence reports assembly-space geometry** — `TestProxyReportsAssemblySpaceBox`: a face's box reports in assembly space, `Native()` recovers the unchanged part-space entity. Path composition verified in `TestPathContextComposesNestedTransforms`.
- **Proxy and native are type-distinct** — `Proxy[E]` ≠ `E` is a compile-time property (documented; a mismatch fails to compile rather than at runtime).

The "works for real part faces" guarantee is pinned by **compile-time assertions** that `topo.Face`/`Edge`/`Vertex`/`Body` (Boxed), `topo.Vertex`/`feature.WorkPoint` (Pointed), and `feature.WorkAxis` (Directed) satisfy the constraints — proven without constructing geometry.

## Scope notes

GPL model work (no API change), consistent with F01/F02. The proxy is a read-only view over in-memory entities; surfacing proxies over the wire and using them to drive assembly features arrive with their consumers (assembly features, mates) in later features/milestones.

## Tests

`model/proxy`: assembly-space box/point/direction via a single occurrence, nested-path transform composition, identity/empty-path context, native-identity preservation, plus the real-entity capability assertions. Full suite green (core + head), `golangci-lint` v2.1.0 clean, SPDX present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)