### PR TITLE
M11-F04: Component Patterns, Mirror & Substitution

### DIFF
--- a/model/occurrence/arrangement.go
+++ b/model/occurrence/arrangement.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import "oblikovati.org/math"
+
+// Arrangement computes the per-element placements of an occurrence pattern: one
+// world-space offset transform per position, in order, applied to the seed's base
+// placement. Position 0 is always the identity — the seed itself. Circular,
+// rectangular, and feature-based arrangements implement it (M11-F04, PBI-121).
+type Arrangement interface {
+	// Placements returns one offset transform per pattern position, in order.
+	Placements() []math.Matrix4
+}
+
+// CircularArrangement places Count copies around an axis line (Origin, Axis) with
+// Step radians between adjacent elements (position i sits at i·Step). A full ring of
+// N uses Step = 2π/N; an arc uses a smaller span. Editing Count adds or drops trailing
+// positions at the same spacing.
+type CircularArrangement struct {
+	Origin math.Point3
+	Axis   math.UnitVector3
+	Step   math.Scalar
+	Count  int
+}
+
+// Placements returns Count rotations about the axis, the first being the identity.
+func (c CircularArrangement) Placements() []math.Matrix4 {
+	out := make([]math.Matrix4, max(c.Count, 1))
+	for i := range out {
+		out[i] = math.Rotation4(math.Scalar(i)*c.Step, c.Axis, c.Origin)
+	}
+	return out
+}
+
+// RectangularArrangement places a Count1×Count2 grid: Count1 columns spaced Spacing1
+// along Dir1 and Count2 rows spaced Spacing2 along Dir2. Positions run column-fastest,
+// so position 0 (column 0, row 0) is the identity.
+type RectangularArrangement struct {
+	Dir1     math.UnitVector3
+	Spacing1 math.Scalar
+	Count1   int
+	Dir2     math.UnitVector3
+	Spacing2 math.Scalar
+	Count2   int
+}
+
+// Placements returns Count1·Count2 translations on the grid, the first the identity.
+func (r RectangularArrangement) Placements() []math.Matrix4 {
+	c1, c2 := max(r.Count1, 1), max(r.Count2, 1)
+	out := make([]math.Matrix4, 0, c1*c2)
+	for row := 0; row < c2; row++ {
+		for col := 0; col < c1; col++ {
+			offset := r.Dir1.AsVector().Scale(math.Scalar(col) * r.Spacing1).
+				Add(r.Dir2.AsVector().Scale(math.Scalar(row) * r.Spacing2))
+			out = append(out, math.Translation4(offset))
+		}
+	}
+	return out
+}
+
+// FeatureArrangement follows a part feature pattern: its element placements are
+// supplied directly (the offsets of the driving feature pattern's elements, extracted
+// by the caller), so an assembly pattern tracks a part pattern without this package
+// depending on the feature engine. Offsets[0] should be the identity (the seed).
+type FeatureArrangement struct {
+	Offsets []math.Matrix4
+}
+
+// Placements returns the supplied feature-driven offsets.
+func (f FeatureArrangement) Placements() []math.Matrix4 {
+	out := make([]math.Matrix4, len(f.Offsets))
+	copy(out, f.Offsets)
+	return out
+}

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -45,6 +45,7 @@ type Occurrence struct {
 	suppressed bool
 	grounded   bool
 	adaptive   bool
+	substitute bool
 	definition Definition
 	owner      *Occurrences
 }
@@ -97,6 +98,12 @@ func (o *Occurrence) Adaptive() bool { return o.adaptive }
 
 // SetAdaptive marks the occurrence adaptive or rigid.
 func (o *Occurrence) SetAdaptive(adaptive bool) { o.adaptive = adaptive }
+
+// IsSubstitute reports whether this occurrence is a substitute — a simplified
+// representation that stands in for a set of detailed components (the reference API's
+// IsSubstituteOccurrence). Set by [Substitute]; the simplified geometry it references
+// is generated in M11-F06.
+func (o *Occurrence) IsSubstitute() bool { return o.substitute }
 
 // SubOccurrences returns the components nested inside this occurrence when it
 // instances an assembly (a [Composite] definition), or nil for a leaf part. They are

--- a/model/occurrence/ops.go
+++ b/model/occurrence/ops.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import "oblikovati.org/math"
+
+// Assembly-level replication ops (M11-F04, PBI-122): mirror, copy, and substitute
+// operate on an [Occurrences] collection, sharing the placed definitions (the
+// flyweight) and reusing the collection's id minting.
+
+// MirrorComponents adds a mirror of each source occurrence to dst, reflected across
+// the plane (origin, normal). Each mirror shares its source's definition but is placed
+// by reflection·sourceTransform, so it is correctly handed: the reflection's
+// determinant is -1, flipping the placement's orientation. Returns the new occurrences
+// in source order.
+//
+// A chiral component is handed here purely by its placement transform; deriving an
+// independent mirrored PART (a new, separately editable document) is M11-F06.
+func MirrorComponents(dst *Occurrences, sources []*Occurrence, origin math.Point3, normal math.UnitVector3) []*Occurrence {
+	reflect := math.Reflection4(origin, normal)
+	out := make([]*Occurrence, 0, len(sources))
+	for _, s := range sources {
+		mirrored := reflect.Mul(s.Transform())
+		out = append(out, dst.AddByComponentDefinition(s.name+"-mirror", s.definition, mirrored))
+	}
+	return out
+}
+
+// CopyComponents adds an independent copy of each source occurrence to dst — the same
+// definition and placement, but a new, unlinked instance (unlike a pattern element,
+// which tracks its seed). Returns the copies in source order.
+func CopyComponents(dst *Occurrences, sources []*Occurrence) []*Occurrence {
+	out := make([]*Occurrence, 0, len(sources))
+	for _, s := range sources {
+		out = append(out, dst.AddByComponentDefinition(s.name+"-copy", s.definition, s.transform))
+	}
+	return out
+}
+
+// Substitute swaps the source occurrences for a single substitute: it suppresses the
+// sources (so they leave the model but can be restored) and adds one occurrence,
+// flagged [Occurrence.IsSubstitute], that references simplified — a simplified
+// representation of them placed at transform. Returns the substitute.
+//
+// The simplified definition is the caller's (a shrinkwrap/derived part generated in
+// M11-F06); this is the substitution mechanism, not the geometry reduction.
+func Substitute(dst *Occurrences, sources []*Occurrence, name string, simplified Definition, transform math.Matrix4) *Occurrence {
+	for _, s := range sources {
+		s.SetSuppressed(true)
+	}
+	sub := dst.AddByComponentDefinition(name, simplified, transform)
+	sub.substitute = true
+	return sub
+}

--- a/model/occurrence/ops_test.go
+++ b/model/occurrence/ops_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestMirrorComponentsAreCorrectlyHanded is the PBI-122 mirror acceptance: a mirror is
+// orientation-reversed (the reflection flips handedness), so a chiral component comes
+// out opposite-handed.
+func TestMirrorComponentsAreCorrectlyHanded(t *testing.T) {
+	asm := NewOccurrences()
+	src := asm.AddByComponentDefinition("part:1", unitComponent(), math.Translation4(math.V3(3, 0, 0)))
+	mirrors := MirrorComponents(asm, []*Occurrence{src}, math.P3(0, 0, 0), unitX(t)) // across the x=0 plane
+	if len(mirrors) != 1 {
+		t.Fatalf("mirrored %d, want 1", len(mirrors))
+	}
+	m := mirrors[0]
+	if det := m.Transform().Determinant(); det >= 0 {
+		t.Errorf("mirror placement determinant = %g, want < 0 (opposite hand)", det)
+	}
+	if got := m.Transform().TransformPoint(math.P3(0, 0, 0)); got != (math.P3(-3, 0, 0)) {
+		t.Errorf("mirrored placement = %v, want {-3 0 0}", got)
+	}
+	if m.Definition() != src.Definition() {
+		t.Error("mirror should share the source definition (handed by its transform)")
+	}
+	if asm.Count() != 2 {
+		t.Errorf("assembly count = %d, want 2 (source + mirror)", asm.Count())
+	}
+}
+
+func TestCopyComponentsAreIndependentInstances(t *testing.T) {
+	asm := NewOccurrences()
+	src := asm.AddByComponentDefinition("part:1", unitComponent(), math.Translation4(math.V3(2, 0, 0)))
+	copies := CopyComponents(asm, []*Occurrence{src})
+	if len(copies) != 1 || copies[0] == src || copies[0].ID() == src.ID() {
+		t.Fatalf("copy = %v, want one new instance with its own id", copies)
+	}
+	if c := copies[0]; c.Definition() != src.Definition() || c.Transform() != src.Transform() {
+		t.Error("copy should share the source's definition and placement")
+	}
+}
+
+// TestSubstituteSwapsInSimplifiedRep is the PBI-122 substitution acceptance: the
+// detailed sources are suppressed and a simplified representation stands in for them.
+func TestSubstituteSwapsInSimplifiedRep(t *testing.T) {
+	asm := NewOccurrences()
+	a := asm.AddByComponentDefinition("a:1", unitComponent(), math.Identity4())
+	b := asm.AddByComponentDefinition("b:1", unitComponent(), math.Translation4(math.V3(5, 0, 0)))
+	simplified := &mutableComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(6, 1, 1))}
+
+	sub := Substitute(asm, []*Occurrence{a, b}, "shrinkwrap:1", simplified, math.Identity4())
+	if !sub.IsSubstitute() {
+		t.Error("substitute occurrence should be flagged IsSubstitute")
+	}
+	if sub.Definition() != simplified {
+		t.Error("substitute should reference the simplified definition")
+	}
+	if !a.Suppressed() || !b.Suppressed() {
+		t.Error("substitution should suppress the detailed sources")
+	}
+	if got := asm.RangeBox().Max; got != (math.P3(6, 1, 1)) {
+		t.Errorf("assembly box = %v, want the simplified rep {6 1 1}", got)
+	}
+}

--- a/model/occurrence/pattern.go
+++ b/model/occurrence/pattern.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import "oblikovati.org/math"
+
+// OccurrencePatternElement is one replicated instance of an occurrence pattern: its
+// computed placement plus per-element state — a suppression flag and an optional
+// reposition override that wins over the pattern-computed placement. The reference
+// API's OccurrencePatternElement (M11-F04).
+type OccurrencePatternElement struct {
+	placement  math.Matrix4 // arrangement offset · seed base
+	suppressed bool
+	override   *math.Matrix4 // reposition override; nil ⇒ use placement
+}
+
+// Transform returns the element's effective placement: the reposition override if
+// set, otherwise the pattern-computed placement.
+func (e *OccurrencePatternElement) Transform() math.Matrix4 {
+	if e.override != nil {
+		return *e.override
+	}
+	return e.placement
+}
+
+// Suppressed reports whether this element is omitted from the pattern.
+func (e *OccurrencePatternElement) Suppressed() bool { return e.suppressed }
+
+// SetSuppressed includes or omits this element.
+func (e *OccurrencePatternElement) SetSuppressed(suppressed bool) { e.suppressed = suppressed }
+
+// Reposition overrides this element's placement (e.g. nudging one patterned instance
+// off the regular grid); the override survives regeneration by index.
+func (e *OccurrencePatternElement) Reposition(m math.Matrix4) { e.override = &m }
+
+// ClearReposition drops the override so the element returns to its pattern placement.
+func (e *OccurrencePatternElement) ClearReposition() { e.override = nil }
+
+// Repositioned reports whether the element carries a reposition override.
+func (e *OccurrencePatternElement) Repositioned() bool { return e.override != nil }
+
+// OccurrencePattern replicates a seed component across an [Arrangement]. Each position
+// becomes an [OccurrencePatternElement] placed at the arrangement offset composed with
+// the seed's base placement. Editing the arrangement (e.g. a new count) regenerates
+// the elements, preserving each surviving element's suppression and reposition
+// override by index — the reference API's *OccurrencePattern.
+type OccurrencePattern struct {
+	seed        Definition
+	base        math.Matrix4
+	arrangement Arrangement
+	elements    []*OccurrencePatternElement
+}
+
+// NewOccurrencePattern builds a pattern of seed (placed at base) over arrangement and
+// generates its elements.
+func NewOccurrencePattern(seed Definition, base math.Matrix4, arrangement Arrangement) *OccurrencePattern {
+	p := &OccurrencePattern{seed: seed, base: base, arrangement: arrangement}
+	p.Regenerate()
+	return p
+}
+
+// SetArrangement swaps the arrangement (e.g. to change count or spacing) and
+// regenerates the elements, keeping surviving elements' state by index.
+func (p *OccurrencePattern) SetArrangement(a Arrangement) {
+	p.arrangement = a
+	p.Regenerate()
+}
+
+// Regenerate rebuilds the elements from the current arrangement. Each surviving
+// position (by index) keeps its suppression and reposition override, so a count edit
+// leaves the state of the elements that remain untouched.
+func (p *OccurrencePattern) Regenerate() {
+	placements := p.arrangement.Placements()
+	next := make([]*OccurrencePatternElement, len(placements))
+	for i, offset := range placements {
+		e := &OccurrencePatternElement{placement: offset.Mul(p.base)}
+		if i < len(p.elements) {
+			e.suppressed = p.elements[i].suppressed
+			e.override = p.elements[i].override
+		}
+		next[i] = e
+	}
+	p.elements = next
+}
+
+// Seed returns the component this pattern replicates.
+func (p *OccurrencePattern) Seed() Definition { return p.seed }
+
+// Count returns the number of pattern elements (including suppressed ones).
+func (p *OccurrencePattern) Count() int { return len(p.elements) }
+
+// Element returns the i-th pattern element in arrangement order.
+func (p *OccurrencePattern) Element(i int) *OccurrencePatternElement { return p.elements[i] }
+
+// Elements returns a snapshot of the pattern's elements in arrangement order.
+func (p *OccurrencePattern) Elements() []*OccurrencePatternElement {
+	out := make([]*OccurrencePatternElement, len(p.elements))
+	copy(out, p.elements)
+	return out
+}
+
+// RangeBox returns the axis-aligned box enclosing the seed placed at every
+// unsuppressed element (empty when all are suppressed). Empty placements are skipped,
+// as in [Occurrences.RangeBox].
+func (p *OccurrencePattern) RangeBox() math.Box {
+	box := math.EmptyBox()
+	for _, e := range p.elements {
+		if e.suppressed {
+			continue
+		}
+		eb := p.seed.RangeBox().Transform(e.Transform())
+		if eb.IsEmpty() {
+			continue
+		}
+		box = box.Union(eb)
+	}
+	return box
+}

--- a/model/occurrence/pattern_test.go
+++ b/model/occurrence/pattern_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+func unitX(t *testing.T) math.UnitVector3 { return mustUnit(t, 1, 0, 0) }
+func unitY(t *testing.T) math.UnitVector3 { return mustUnit(t, 0, 1, 0) }
+func unitZ(t *testing.T) math.UnitVector3 { return mustUnit(t, 0, 0, 1) }
+
+func mustUnit(t *testing.T, x, y, z math.Scalar) math.UnitVector3 {
+	t.Helper()
+	u, err := math.NewUnitVector3(x, y, z)
+	if err != nil {
+		t.Fatalf("NewUnitVector3(%g,%g,%g): %v", x, y, z, err)
+	}
+	return u
+}
+
+func TestRectangularPatternGrid(t *testing.T) {
+	arr := RectangularArrangement{Dir1: unitX(t), Spacing1: 1, Count1: 3, Dir2: unitY(t), Spacing2: 1, Count2: 2}
+	p := NewOccurrencePattern(unitComponent(), math.Identity4(), arr)
+	if p.Count() != 6 {
+		t.Fatalf("count = %d, want 6 (3×2)", p.Count())
+	}
+	// Positions run column-fastest: element 0 at origin, element 2 at +2x, element 3 (row 1) at +1y.
+	for _, c := range []struct {
+		i    int
+		want math.Point3
+	}{{0, math.P3(0, 0, 0)}, {2, math.P3(2, 0, 0)}, {3, math.P3(0, 1, 0)}} {
+		if got := p.Element(c.i).Transform().TransformPoint(math.P3(0, 0, 0)); got != c.want {
+			t.Errorf("element %d at %v, want %v", c.i, got, c.want)
+		}
+	}
+}
+
+// TestPatternTracksCountEditsPreservingState is the PBI-121 acceptance: a count edit
+// updates the element set while surviving elements keep their suppression/reposition.
+func TestPatternTracksCountEditsPreservingState(t *testing.T) {
+	x, y := unitX(t), unitY(t)
+	p := NewOccurrencePattern(unitComponent(), math.Identity4(),
+		RectangularArrangement{Dir1: x, Spacing1: 1, Count1: 3, Dir2: y, Spacing2: 1, Count2: 1})
+	if p.Count() != 3 {
+		t.Fatalf("count = %d, want 3", p.Count())
+	}
+	p.Element(1).SetSuppressed(true)
+	off := math.Translation4(math.V3(0, 0, 9))
+	p.Element(2).Reposition(off)
+
+	p.SetArrangement(RectangularArrangement{Dir1: x, Spacing1: 1, Count1: 5, Dir2: y, Spacing2: 1, Count2: 1})
+	if p.Count() != 5 {
+		t.Fatalf("count after edit = %d, want 5", p.Count())
+	}
+	if !p.Element(1).Suppressed() {
+		t.Error("element 1 lost its suppression across the count edit")
+	}
+	if !p.Element(2).Repositioned() || p.Element(2).Transform() != off {
+		t.Error("element 2 lost its reposition override across the count edit")
+	}
+	if p.Element(4).Suppressed() || p.Element(4).Repositioned() {
+		t.Error("new trailing element 4 should be fresh (unsuppressed, not repositioned)")
+	}
+}
+
+func TestCircularPatternPlacesAroundAxis(t *testing.T) {
+	p := NewOccurrencePattern(unitComponent(), math.Translation4(math.V3(1, 0, 0)),
+		CircularArrangement{Origin: math.P3(0, 0, 0), Axis: unitZ(t), Step: stdmath.Pi / 2, Count: 4})
+	if p.Count() != 4 {
+		t.Fatalf("count = %d, want 4", p.Count())
+	}
+	// The seed sits at (1,0,0); a quarter turn about Z carries element 1 to ≈(0,1,0).
+	got := p.Element(1).Transform().TransformPoint(math.P3(0, 0, 0))
+	if !got.IsEqualTo(math.P3(0, 1, 0), 1e-9) {
+		t.Errorf("element 1 ≈ %v, want ≈{0 1 0}", got)
+	}
+}
+
+func TestSuppressedPatternElementLeavesNoBox(t *testing.T) {
+	p := NewOccurrencePattern(unitComponent(), math.Identity4(),
+		RectangularArrangement{Dir1: unitX(t), Spacing1: 100, Count1: 2, Dir2: unitY(t), Spacing2: 1, Count2: 1})
+	if got := p.RangeBox().Max.X; got != 101 { // unit boxes at x∈[0,1] and x∈[100,101]
+		t.Fatalf("full pattern box maxX = %g, want 101", got)
+	}
+	p.Element(1).SetSuppressed(true)
+	if got := p.RangeBox().Max.X; got != 1 {
+		t.Errorf("box maxX after suppressing the far element = %g, want 1", got)
+	}
+}
+
+func TestFeatureArrangementFollowsSuppliedOffsets(t *testing.T) {
+	offsets := []math.Matrix4{math.Identity4(), math.Translation4(math.V3(7, 0, 0))}
+	p := NewOccurrencePattern(unitComponent(), math.Identity4(), FeatureArrangement{Offsets: offsets})
+	if p.Count() != 2 {
+		t.Fatalf("count = %d, want 2", p.Count())
+	}
+	if got := p.Element(1).Transform().TransformPoint(math.P3(0, 0, 0)); got != (math.P3(7, 0, 0)) {
+		t.Errorf("feature-driven element 1 = %v, want {7 0 0}", got)
+	}
+}


### PR DESCRIPTION
Closes #348. Closes #354 (PBI-121). Closes #355 (PBI-122).

## What

Assembly-level replication, in `model/occurrence`.

### Patterns (PBI-121)
- **`Arrangement`** computes per-element placements; three implementations: **`CircularArrangement`** (rotations about an axis via `math.Rotation4`), **`RectangularArrangement`** (a grid along two directions), **`FeatureArrangement`** (offsets supplied from a driving part pattern — so an assembly pattern follows a part pattern without this package depending on the feature engine).
- **`OccurrencePattern`** composes each arrangement offset with the seed's base placement into an **`OccurrencePatternElement`**. `SetArrangement`/`Regenerate` rebuild the elements on a count/spacing edit, **preserving each surviving element's suppression and reposition override by index**. Each element can be suppressed (omitted) or repositioned (placement overridden).

### Mirror / Copy / Substitute (PBI-122)
- **`MirrorComponents`** reflects each source across a plane (`math.Reflection4`); the mirror shares its source's definition but is placed by `reflection·sourceTransform`, so it is **correctly handed** (the reflection's determinant is −1).
- **`CopyComponents`** adds independent, unlinked instances (same definition + placement, fresh ids).
- **`Substitute`** suppresses the detailed sources and adds one occurrence — flagged **`IsSubstitute`** (new on `Occurrence`) — referencing a simplified representation of them (a level-of-detail swap).

## Acceptance

- **PBI-121**: `TestPatternTracksCountEditsPreservingState` — a count edit grows/shrinks the element set while a suppressed and a repositioned element keep their state by index; circular/rectangular/feature placements verified; suppressed elements drop out of the pattern's range box.
- **PBI-122**: `TestMirrorComponentsAreCorrectlyHanded` — the mirrored placement is orientation-reversed (det < 0) and reflects correctly; `TestSubstituteSwapsInSimplifiedRep` — sources are suppressed and the flagged substitute's simplified rep drives the assembly box.

## Scope notes

GPL model work (no API change), consistent with F01–F03. Deferred to **M11-F06** (Derived Assembly Components & Shrinkwrap), as noted in the code: deriving an independent mirrored **part** (a new editable document) and **generating** the simplified substitute geometry. This PR delivers the placement-level handedness and the substitution swap the acceptance requires; the simplified definition is the caller's.

## Tests

Full `model/occurrence` coverage for patterns (grid, count-edit state preservation, circular placement, feature-driven offsets, suppressed-element box) and ops (mirror handedness + reflection, independent copies, substitution swap). Full suite green (core + head), `golangci-lint` v2.1.0 clean, SPDX present. `math.Reflection4`/`Rotation4` already existed and are reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)