### PR TITLE
M11-F06: Derived Assembly Components (derive core)

### DIFF
--- a/model/compdef/assembly_derive.go
+++ b/model/compdef/assembly_derive.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
+)
+
+// An assembly definition is a body source a part can derive from: it flattens its
+// occurrence tree into placed bodies (M11-F06). It already reports its geometry
+// version, so a derived part re-derives when the assembly changes.
+var _ feature.AssemblyBodySource = (*AssemblyComponentDefinition)(nil)
+
+// PlacedBodies flattens the assembly's occurrence tree into the bodies of its leaf
+// parts, each paired with the world transform that places it (composed down the
+// occurrence path) and the occurrence it belongs to. Suppressed occurrences are
+// skipped. It is what a derived-assembly component pulls to build a base body — and
+// what shrinkwrap will simplify (M11-F06).
+func (a *AssemblyComponentDefinition) PlacedBodies() []feature.PlacedBody {
+	var out []feature.PlacedBody
+	collectPlacedBodies(a.occurrences, math.Identity4(), &out)
+	return out
+}
+
+// collectPlacedBodies walks one occurrence level, composing each occurrence's transform
+// with its parent's, emitting a leaf part's bodies and recursing into sub-assemblies.
+func collectPlacedBodies(occs *occurrence.Occurrences, parent math.Matrix4, out *[]feature.PlacedBody) {
+	for _, o := range occs.All() {
+		if o.Suppressed() {
+			continue
+		}
+		world := parent.Mul(o.Transform())
+		switch def := o.Definition().(type) {
+		case bodyDefinition: // a leaf part: emit its bodies placed in the assembly
+			for _, b := range def.SurfaceBodies().All() {
+				*out = append(*out, feature.PlacedBody{Body: b, Transform: world, Source: o})
+			}
+		case occurrence.Composite: // a sub-assembly: recurse with the composed transform
+			collectPlacedBodies(def.Occurrences(), world, out)
+		}
+	}
+}
+
+// bodyDefinition is a component definition that owns evaluated bodies — a part
+// definition. Matched structurally so the flatten works for any body-bearing leaf.
+type bodyDefinition interface {
+	SurfaceBodies() *topo.SurfaceBodies
+}

--- a/model/compdef/assembly_derive_test.go
+++ b/model/compdef/assembly_derive_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// partWithBlock builds a part whose evaluated body is the box [min,max], via a base
+// feature, so PlacedBodies has real geometry to flatten.
+func partWithBlock(t *testing.T, min, max math.Point3) *PartComponentDefinition {
+	t.Helper()
+	block, err := brep.SolidBlock(min, max, "p")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	p := NewPartComponentDefinition()
+	feature.NewBaseFeatures(p.Features()).AddBase(block)
+	p.Recompute()
+	return p
+}
+
+// TestAssemblyPlacedBodiesFlattensTree checks the flatten: a part nested through a
+// sub-assembly is emitted once with the composed world transform, and a directly-placed
+// part once at its own transform.
+func TestAssemblyPlacedBodiesFlattensTree(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+
+	sub := NewAssemblyComponentDefinition()
+	sub.Place("p:1", part, math.Translation4(math.V3(5, 0, 0)))
+
+	top := NewAssemblyComponentDefinition()
+	top.Place("sub:1", sub, math.Translation4(math.V3(100, 0, 0)))
+	top.Place("p:loose", part, math.Identity4())
+
+	placed := top.PlacedBodies()
+	if len(placed) != 2 {
+		t.Fatalf("placed bodies = %d, want 2 (one nested, one loose)", len(placed))
+	}
+	var nestedX, looseX float64 = -1, -1
+	for _, pb := range placed {
+		x := float64(pb.Transform.TransformPoint(math.P3(0, 0, 0)).X)
+		if x > 50 {
+			nestedX = x
+		} else {
+			looseX = x
+		}
+	}
+	if nestedX != 105 { // top(+100) ∘ sub-occurrence(+5)
+		t.Errorf("nested part world X = %g, want 105 (100+5 composed)", nestedX)
+	}
+	if looseX != 0 {
+		t.Errorf("loose part world X = %g, want 0", looseX)
+	}
+}
+
+// TestAssemblyPlacedBodiesSkipsSuppressed checks suppressed occurrences contribute no
+// bodies.
+func TestAssemblyPlacedBodiesSkipsSuppressed(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	top := NewAssemblyComponentDefinition()
+	top.Place("keep:1", part, math.Identity4())
+	dropped := top.Place("drop:1", part, math.Translation4(math.V3(9, 0, 0)))
+	dropped.SetSuppressed(true)
+
+	if got := len(top.PlacedBodies()); got != 1 {
+		t.Errorf("placed bodies = %d, want 1 (suppressed occurrence skipped)", got)
+	}
+}

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// DeriveStyle controls how one source occurrence contributes to a derived assembly's
+// base body — the reference API's per-occurrence derive style. The zero value is
+// DeriveInclude, so an unstyled occurrence is merged in.
+type DeriveStyle int
+
+const (
+	// DeriveInclude merges the occurrence's bodies into the derived base.
+	DeriveInclude DeriveStyle = iota
+	// DeriveExclude omits the occurrence entirely.
+	DeriveExclude
+	// DeriveSubtract cuts the occurrence's bodies from the merged base.
+	DeriveSubtract
+)
+
+// String returns the lowercase name of the derive style.
+func (s DeriveStyle) String() string {
+	switch s {
+	case DeriveInclude:
+		return "include"
+	case DeriveExclude:
+		return "exclude"
+	case DeriveSubtract:
+		return "subtract"
+	default:
+		return "unknown"
+	}
+}
+
+// PlacedBody is one source body paired with the world transform of the occurrence that
+// places it (in the source assembly's space) and that occurrence, so a derived feature
+// can apply per-occurrence [DeriveStyle]. Flattening a source assembly's occurrence
+// tree yields these.
+type PlacedBody struct {
+	Body      *topo.Body
+	Transform math.Matrix4
+	Source    *occurrence.Occurrence
+}
+
+// AssemblyBodySource is the consumer-side view of a source assembly that a
+// derived-assembly feature pulls from: the placed bodies of its occurrence tree and a
+// geometry version to watch for associative update. Defined here so feature does not
+// import compdef (compdef.AssemblyComponentDefinition satisfies it structurally,
+// avoiding a cycle — compdef imports feature).
+type AssemblyBodySource interface {
+	PlacedBodies() []PlacedBody
+	ModelGeometryVersion() string
+}
+
+// DerivedAssemblyComponent derives a source assembly into this part as a base body:
+// each recompute pulls the source's placed bodies, transforms each into the part, and
+// merges the included ones — cutting the subtracted, skipping the excluded — into one
+// multi-lump base. It is the assembly-side counterpart of [DerivedPartComponent]
+// (M11-F06): a source edit bumps the source version so a re-derive flows it through,
+// and BreakLink freezes the current result and stops pulling.
+type DerivedAssemblyComponent struct {
+	source AssemblyBodySource
+	styles map[*occurrence.Occurrence]DeriveStyle
+	linked bool
+	frozen []*topo.Body
+}
+
+// Definition returns the derived recipe.
+func (d *DerivedAssemblyComponent) Definition() *DerivedAssemblyComponent { return d }
+
+// Kind implements [Feature].
+func (d *DerivedAssemblyComponent) Kind() string { return "derivedAssembly" }
+
+// SourceVersion returns the source assembly's current geometry version (change tracking).
+func (d *DerivedAssemblyComponent) SourceVersion() string { return d.source.ModelGeometryVersion() }
+
+// SetStyle sets the derive style for a source occurrence (default DeriveInclude).
+func (d *DerivedAssemblyComponent) SetStyle(o *occurrence.Occurrence, style DeriveStyle) {
+	d.styles[o] = style
+}
+
+// Linked reports whether the derive still pulls from its source.
+func (d *DerivedAssemblyComponent) Linked() bool { return d.linked }
+
+// BreakLink freezes the current derived bodies and severs the source link, so the part
+// keeps the derived geometry without further updates (the reference API's break link).
+func (d *DerivedAssemblyComponent) BreakLink() error {
+	bodies, err := d.derive()
+	if err != nil {
+		return err
+	}
+	d.frozen = bodies
+	d.linked = false
+	return nil
+}
+
+// Recompute appends the derived base body (or, after a broken link, the frozen bodies)
+// to the running state.
+func (d *DerivedAssemblyComponent) Recompute(in Input) (Output, error) {
+	out := append([]*topo.Body(nil), in.Bodies...)
+	if !d.linked {
+		return Output{Bodies: append(out, d.frozen...)}, nil
+	}
+	derived, err := d.derive()
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: append(out, derived...)}, nil
+}
+
+// derive flattens, transforms, and combines the source's placed bodies per style into
+// the derived base bodies (zero bodies when nothing is included, otherwise one).
+func (d *DerivedAssemblyComponent) derive() ([]*topo.Body, error) {
+	var joins, cuts []*topo.Body
+	for i, pb := range d.source.PlacedBodies() {
+		style := d.styles[pb.Source]
+		if style == DeriveExclude {
+			continue
+		}
+		placed, err := ops.TransformBody(pb.Body, pb.Transform, deriveLineage(i))
+		if err != nil {
+			return nil, fmt.Errorf("feature: derive-assembly transform of body %d: %w", i, err)
+		}
+		if style == DeriveSubtract {
+			cuts = append(cuts, placed)
+		} else {
+			joins = append(joins, placed)
+		}
+	}
+	if len(joins) == 0 {
+		return nil, nil
+	}
+	base := topo.MergeBodies(topo.NewLineage(topo.Tok("derivedAssembly", "body", 0)), true, joins...)
+	for _, tool := range cuts {
+		cut, err := ops.Boolean(ops.Cut, base, tool)
+		if err != nil {
+			return nil, fmt.Errorf("feature: derive-assembly subtract: %w", err)
+		}
+		base = cut
+	}
+	return []*topo.Body{base}, nil
+}
+
+// deriveLineage gives each placed copy a distinct lineage prefix, so the same source
+// part placed at several occurrences yields independent reference keys.
+func deriveLineage(index int) func(topo.Lineage) topo.Lineage {
+	prefix := topo.Tok("derivedAssembly", "occ", index)
+	return func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append([]topo.LineageToken{prefix}, l.Tokens()...)...)
+	}
+}
+
+// DerivedAssemblyComponents adds derived-assembly features into the engine.
+type DerivedAssemblyComponents struct{ engine *PartFeatures }
+
+// NewDerivedAssemblyComponents binds the collection to an engine.
+func NewDerivedAssemblyComponents(engine *PartFeatures) *DerivedAssemblyComponents {
+	return &DerivedAssemblyComponents{engine}
+}
+
+// AddDerived adds an associative derived-assembly component pulling from source.
+func (c *DerivedAssemblyComponents) AddDerived(source AssemblyBodySource) *PartFeature {
+	d := &DerivedAssemblyComponent{
+		source: source,
+		styles: map[*occurrence.Occurrence]DeriveStyle{},
+		linked: true,
+	}
+	return c.engine.Add(d)
+}

--- a/model/feature/derived_assembly_test.go
+++ b/model/feature/derived_assembly_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// fakeAssemblySource is a local AssemblyBodySource (compdef.AssemblyComponentDefinition
+// satisfies the real interface in production; importing compdef here would cycle).
+type fakeAssemblySource struct {
+	placed  []PlacedBody
+	version int
+}
+
+func (f *fakeAssemblySource) PlacedBodies() []PlacedBody   { return f.placed }
+func (f *fakeAssemblySource) ModelGeometryVersion() string { return fmt.Sprintf("v%d", f.version) }
+
+// fakeOccDef is a minimal occurrence.Definition so a Source occurrence (for derive-style
+// keying) can be minted; the derive transforms the PlacedBody, not this definition.
+type fakeOccDef struct{}
+
+func (fakeOccDef) RangeBox() math.Box { return math.EmptyBox() }
+
+func occFor(name string) *occurrence.Occurrence {
+	return occurrence.NewOccurrences().AddByComponentDefinition(name, fakeOccDef{}, math.Identity4())
+}
+
+func solidBlock(t *testing.T, min, max math.Point3) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(min, max, "src")
+	if err != nil {
+		t.Fatalf("SolidBlock(%v,%v): %v", min, max, err)
+	}
+	return b
+}
+
+func volumeOf(b *topo.Body) float64 {
+	return ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+}
+
+func approx(got, want float64) bool { d := got - want; return d < 1e-6 && d > -1e-6 }
+
+// TestDerivedAssemblyMergesIncludedBodies is the F06 core: two placed source bodies are
+// transformed into the part and merged into one base body (volume = sum).
+func TestDerivedAssemblyMergesIncludedBodies(t *testing.T) {
+	block := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2)) // volume 8
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
+		{Body: block, Transform: math.Translation4(math.V3(10, 0, 0)), Source: occFor("a:2")},
+	}}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	fs.Recompute()
+	if !pf.Health().OK() || len(fs.Result()) != 1 {
+		t.Fatalf("derive: health=%+v bodies=%d, want ok and one base body", pf.Health(), len(fs.Result()))
+	}
+	if got := volumeOf(fs.Result()[0]); !approx(got, 16) {
+		t.Errorf("derived volume = %g, want 16 (two 2³ blocks merged)", got)
+	}
+}
+
+// TestDerivedAssemblySubtractsStyledOccurrence cuts a subtracted occurrence's body from
+// the merged base — volume-gated against the analytic value.
+func TestDerivedAssemblySubtractsStyledOccurrence(t *testing.T) {
+	big := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))   // volume 8
+	small := solidBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1)) // a 1³ corner of big
+	cut := occFor("cut:1")
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: big, Transform: math.Identity4(), Source: occFor("keep:1")},
+		{Body: small, Transform: math.Identity4(), Source: cut},
+	}}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	pf.Definition().(*DerivedAssemblyComponent).SetStyle(cut, DeriveSubtract)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("derive health=%+v", pf.Health())
+	}
+	if got := volumeOf(fs.Result()[0]); !approx(got, 7) {
+		t.Errorf("derived volume = %g, want 7 (8 minus a 1³ corner)", got)
+	}
+}
+
+func TestDerivedAssemblyExcludesStyledOccurrence(t *testing.T) {
+	kept := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	dropped := solidBlock(t, math.P3(10, 10, 10), math.P3(12, 12, 12))
+	drop := occFor("drop:1")
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: kept, Transform: math.Identity4(), Source: occFor("keep:1")},
+		{Body: dropped, Transform: math.Identity4(), Source: drop},
+	}}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	pf.Definition().(*DerivedAssemblyComponent).SetStyle(drop, DeriveExclude)
+	fs.Recompute()
+	if got := volumeOf(fs.Result()[0]); !approx(got, 8) {
+		t.Errorf("derived volume = %g, want 8 (excluded block omitted)", got)
+	}
+}
+
+// TestDerivedAssemblyBreakLinkFreezesAndVersionTracks covers the associative pull (a
+// source edit re-derives) and the break-link (the result freezes).
+func TestDerivedAssemblyBreakLinkFreezesAndVersionTracks(t *testing.T) {
+	block := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
+	}}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	fs.Recompute()
+	d := pf.Definition().(*DerivedAssemblyComponent)
+	v0 := d.SourceVersion()
+
+	// Edit the source → associative re-derive reflects the added body.
+	src.placed = append(src.placed, PlacedBody{Body: block, Transform: math.Translation4(math.V3(10, 0, 0)), Source: occFor("a:2")})
+	src.version++
+	fs.MarkDirty(pf)
+	fs.Recompute()
+	if got := volumeOf(fs.Result()[0]); !approx(got, 16) {
+		t.Fatalf("after source edit, volume = %g, want 16 (re-derived)", got)
+	}
+	if d.SourceVersion() == v0 {
+		t.Error("source version did not advance on edit")
+	}
+
+	// Break the link and edit the source again → frozen, unchanged.
+	if err := d.BreakLink(); err != nil {
+		t.Fatalf("BreakLink: %v", err)
+	}
+	if d.Linked() {
+		t.Error("Linked() is true after BreakLink")
+	}
+	src.placed = append(src.placed, PlacedBody{Body: block, Transform: math.Translation4(math.V3(20, 0, 0)), Source: occFor("a:3")})
+	src.version++
+	fs.MarkDirty(pf)
+	fs.Recompute()
+	if got := volumeOf(fs.Result()[0]); !approx(got, 16) {
+		t.Errorf("after break-link, volume = %g, want frozen 16 (source change ignored)", got)
+	}
+}


### PR DESCRIPTION
Partial for #631 — the derived-assembly **geometry core** (the model-side producer). Shrinkwrap, LOD, and the formal API surface are deferred (see Scope).

## What

The assembly-side counterpart of the derived **part** component (M08-F04): derive a source assembly into a part as a base body.

- **`model/feature` `DerivedAssemblyComponent`** — each recompute pulls the source's placed bodies, transforms each into the part (distinct lineage per placement), and merges the included ones into one multi-lump base, **cutting** per-occurrence subtracted bodies and **skipping** excluded ones (`DeriveStyle`: include/exclude/subtract). Associative: a source edit bumps `ModelGeometryVersion` so a re-derive flows it through; **`BreakLink`** freezes the current result and stops pulling. The source is consumed through the `AssemblyBodySource` interface (so `feature` doesn't import `compdef`).
- **`model/compdef` `AssemblyComponentDefinition.PlacedBodies`** — flattens the occurrence tree into its leaf parts' bodies, each with the world transform composed down the occurrence path (suppressed occurrences skipped). This makes the assembly an `AssemblyBodySource`.

## Acceptance / correctness

Per the tessellation-correctness rule, the boolean geometry is **volume-gated against analytic values**:
- merge of two 2³ blocks → **16**;
- an 8-volume block minus a 1³ corner (subtract) → **7**;
- an excluded block is omitted → **8**;
- break-link freezes the result across a later source edit → **16**.
Plus the flatten composes nested transforms (`100 ∘ 5 = 105`) and skips suppressed occurrences.

## Scope notes

Consistent with F01–F05, this is GPL model work; the formal **`api/types`/`wire`/`client`/`contract`** surface (`assembly.deriveCreate`/`deriveBreakLink`, derive-style enum) is deferred until a head/add-in consumer exists. Also deferred, as the issue anticipates:
- **Shrinkwrap** (visibility-based removal, hole patching, envelope replacement) — needs advanced kernel ops; `PlacedBodies` is the producer it will simplify.
- **Substitute-LOD** registration (feeds #348/#355) and the persistent **source-document GUID/revision** link (rides with assembly persistence) — the in-session associative pull + break-link are in place.

These follow-ups are noted in the code. This PR delivers the derive engine + the flatten, fully tested.

## Tests

`model/feature` (merge/subtract/exclude/break-link/version, all volume-gated) and `model/compdef` (nested-transform flatten, suppressed skip). Full suite green (core + head), `golangci-lint` v2.1.0 clean, SPDX present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)