### PR TITLE
M11-F06: Shrinkwrap simplification & substitute-LOD path

### DIFF
--- a/model/compdef/shrinkwrap_lod.go
+++ b/model/compdef/shrinkwrap_lod.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
+)
+
+// ShrinkwrapToPart builds a simplified part definition from an assembly source: it runs
+// the shrinkwrap recipe over the source and wraps the resulting lightweight bodies as a
+// non-parametric base in a fresh part (M11-F06). The part is a placeable
+// occurrence.Definition, so it can stand in for the assembly as a substitute LOD.
+//
+// Example:
+//
+//	lod, _ := ShrinkwrapToPart(asm, feature.ShrinkwrapDefinition{EnvelopeStyle: feature.EnvelopeWhole})
+func ShrinkwrapToPart(source feature.AssemblyBodySource, def feature.ShrinkwrapDefinition) (*PartComponentDefinition, error) {
+	bodies, err := feature.BuildShrinkwrap(source, def)
+	if err != nil {
+		return nil, err
+	}
+	part := NewPartComponentDefinition()
+	feature.NewBaseFeatures(part.Features()).AddBase(bodies...)
+	part.Recompute()
+	return part, nil
+}
+
+// SubstituteWithShrinkwrap simplifies source into a lightweight part and substitutes it
+// for the given source occurrences in dst: the sources are suppressed and one
+// IsSubstitute occurrence referencing the shrinkwrap LOD is added at transform. This is
+// the substitute-representation (level-of-detail) path — a shrinkwrap result registered
+// as a substitute of the assembly it simplifies (M11-F06, feeds #348/#355, #361).
+func SubstituteWithShrinkwrap(dst *occurrence.Occurrences, sources []*occurrence.Occurrence, name string, source feature.AssemblyBodySource, def feature.ShrinkwrapDefinition, transform math.Matrix4) (*occurrence.Occurrence, error) {
+	lod, err := ShrinkwrapToPart(source, def)
+	if err != nil {
+		return nil, err
+	}
+	return occurrence.Substitute(dst, sources, name, lod, transform), nil
+}

--- a/model/compdef/shrinkwrap_lod_test.go
+++ b/model/compdef/shrinkwrap_lod_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
+)
+
+// boxVolume reports the volume of an occurrence's placed range box (the LOD's extent).
+func boxVolume(o *occurrence.Occurrence) float64 { return float64(o.RangeBox().Volume()) }
+
+// findSubstitute returns the single IsSubstitute occurrence in the collection.
+func findSubstitute(t *testing.T, occs *occurrence.Occurrences) *occurrence.Occurrence {
+	t.Helper()
+	var found *occurrence.Occurrence
+	for _, o := range occs.All() {
+		if o.IsSubstitute() {
+			if found != nil {
+				t.Fatalf("expected one substitute occurrence, found a second %q", o.Name())
+			}
+			found = o
+		}
+	}
+	if found == nil {
+		t.Fatal("no substitute occurrence found")
+	}
+	return found
+}
+
+// TestShrinkwrapToPartWholeEnvelope builds a single bounding-box LOD from a two-part
+// assembly: parts at [0,1]³ and [3,4]×[0,1]² give an envelope box of [0,4]×[0,1]² = 4.
+func TestShrinkwrapToPartWholeEnvelope(t *testing.T) {
+	sub := NewAssemblyComponentDefinition()
+	sub.Place("a:1", partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1)), math.Identity4())
+	sub.Place("b:1", partWithBlock(t, math.P3(3, 0, 0), math.P3(4, 1, 1)), math.Identity4())
+
+	lod, err := ShrinkwrapToPart(sub, feature.ShrinkwrapDefinition{EnvelopeStyle: feature.EnvelopeWhole})
+	if err != nil {
+		t.Fatalf("ShrinkwrapToPart: %v", err)
+	}
+	if got := float64(lod.RangeBox().Volume()); got < 3.999999 || got > 4.000001 {
+		t.Errorf("LOD range-box volume = %g, want 4 (whole bounding box)", got)
+	}
+}
+
+// TestSubstituteWithShrinkwrapRegistersLOD is the substitute-representation path: the
+// source assembly occurrence is suppressed and a single IsSubstitute LOD occurrence
+// takes its place, carrying the shrinkwrap envelope's extent.
+func TestSubstituteWithShrinkwrapRegistersLOD(t *testing.T) {
+	sub := NewAssemblyComponentDefinition()
+	sub.Place("a:1", partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1)), math.Identity4())
+	sub.Place("b:1", partWithBlock(t, math.P3(3, 0, 0), math.P3(4, 1, 1)), math.Identity4())
+
+	top := NewAssemblyComponentDefinition()
+	subOcc := top.Place("sub:1", sub, math.Identity4())
+
+	lodOcc, err := SubstituteWithShrinkwrap(top.Occurrences(), []*occurrence.Occurrence{subOcc},
+		"sub-lod", sub, feature.ShrinkwrapDefinition{EnvelopeStyle: feature.EnvelopeWhole}, math.Identity4())
+	if err != nil {
+		t.Fatalf("SubstituteWithShrinkwrap: %v", err)
+	}
+	if !subOcc.Suppressed() {
+		t.Error("source occurrence was not suppressed by substitution")
+	}
+	if !lodOcc.IsSubstitute() {
+		t.Error("LOD occurrence is not flagged IsSubstitute")
+	}
+	if got := boxVolume(findSubstitute(t, top.Occurrences())); got < 3.999999 || got > 4.000001 {
+		t.Errorf("substitute LOD extent volume = %g, want 4 (whole envelope)", got)
+	}
+}

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -104,15 +104,23 @@ func (d *DerivedAssemblyComponent) BreakLink() error {
 // Recompute appends the derived base body (or, after a broken link, the frozen bodies)
 // to the running state.
 func (d *DerivedAssemblyComponent) Recompute(in Input) (Output, error) {
+	return recomputeLinked(in, d.linked, d.frozen, d.derive)
+}
+
+// recomputeLinked is the shared associative-or-frozen recompute for the derive-family
+// features (derived-assembly, shrinkwrap): while linked it rebuilds from source via
+// build and appends the result; once the link is broken it appends the frozen bodies
+// captured at BreakLink instead. Keeps the two features' update semantics identical.
+func recomputeLinked(in Input, linked bool, frozen []*topo.Body, build func() ([]*topo.Body, error)) (Output, error) {
 	out := append([]*topo.Body(nil), in.Bodies...)
-	if !d.linked {
-		return Output{Bodies: append(out, d.frozen...)}, nil
+	if !linked {
+		return Output{Bodies: append(out, frozen...)}, nil
 	}
-	derived, err := d.derive()
+	built, err := build()
 	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: append(out, derived...)}, nil
+	return Output{Bodies: append(out, built...)}, nil
 }
 
 // derive flattens, transforms, and combines the source's placed bodies per style into

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// ShrinkwrapRemoveStyle selects which source parts a shrinkwrap drops before merging —
+// the reference API's shrinkwrap remove style. Removal makes the result lighter by
+// discarding parts a viewer never sees or that are too small to matter.
+type ShrinkwrapRemoveStyle int
+
+const (
+	// RemoveNone keeps every part (the full, unsimplified set).
+	RemoveNone ShrinkwrapRemoveStyle = iota
+	// RemoveSmallParts drops parts whose body volume is below MinPartVolume.
+	RemoveSmallParts
+	// RemoveInternalParts drops parts fully enclosed by other parts (never visible
+	// from outside the assembly).
+	RemoveInternalParts
+)
+
+// ShrinkwrapEnvelopeStyle selects how kept parts are replaced by simpler proxy
+// geometry — the reference API's envelopes-replace style. Envelopes erase internal
+// detail (and, by construction, holes) so the result is a lightweight closed solid.
+type ShrinkwrapEnvelopeStyle int
+
+const (
+	// EnvelopeNone keeps each kept part's real geometry.
+	EnvelopeNone ShrinkwrapEnvelopeStyle = iota
+	// EnvelopePerPart replaces each kept part with its axis-aligned bounding box.
+	EnvelopePerPart
+	// EnvelopeWhole replaces the entire kept set with one axis-aligned bounding box.
+	EnvelopeWhole
+)
+
+// ShrinkwrapDefinition is the recipe for simplifying a source assembly into a
+// lightweight base body: which parts to remove and how to envelope the rest. The zero
+// value (RemoveNone + EnvelopeNone) reduces to a plain include-everything derive.
+type ShrinkwrapDefinition struct {
+	RemoveStyle   ShrinkwrapRemoveStyle
+	MinPartVolume float64 // threshold for RemoveSmallParts (units³)
+	EnvelopeStyle ShrinkwrapEnvelopeStyle
+}
+
+// BuildShrinkwrap flattens source's occurrence tree, drops parts per the removal
+// style, replaces the rest with envelopes per the envelope style, and merges the
+// result into a single lightweight solid base body (M11-F06). It returns no body when
+// nothing survives removal — the model-side producer of a shrinkwrap substitute
+// (#348/#355) and LOD representation (#361).
+//
+// Example: BuildShrinkwrap(asm, ShrinkwrapDefinition{EnvelopeStyle: EnvelopeWhole})
+// yields one box enclosing the whole assembly.
+func BuildShrinkwrap(source AssemblyBodySource, def ShrinkwrapDefinition) ([]*topo.Body, error) {
+	world, err := worldBodies(source.PlacedBodies())
+	if err != nil {
+		return nil, err
+	}
+	enveloped, err := applyEnvelope(keepAfterRemoval(world, def), def.EnvelopeStyle)
+	if err != nil {
+		return nil, err
+	}
+	return mergeIntoBase(enveloped), nil
+}
+
+// worldBodies transforms each placed source body into assembly space, giving each a
+// distinct lineage prefix so repeated placements of one part keep independent keys
+// (reusing the derive-family lineage prefixer).
+func worldBodies(placed []PlacedBody) ([]*topo.Body, error) {
+	out := make([]*topo.Body, 0, len(placed))
+	for i, pb := range placed {
+		b, err := ops.TransformBody(pb.Body, pb.Transform, deriveLineage(i))
+		if err != nil {
+			return nil, fmt.Errorf("feature: shrinkwrap transform of body %d: %w", i, err)
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// keepAfterRemoval returns the world bodies that survive the removal style.
+func keepAfterRemoval(world []*topo.Body, def ShrinkwrapDefinition) []*topo.Body {
+	switch def.RemoveStyle {
+	case RemoveSmallParts:
+		return keepLargerThan(world, def.MinPartVolume)
+	case RemoveInternalParts:
+		return keepVisible(world)
+	default:
+		return world
+	}
+}
+
+// keepLargerThan keeps bodies whose volume is at least minVolume.
+func keepLargerThan(world []*topo.Body, minVolume float64) []*topo.Body {
+	q := ops.DefaultQuality()
+	kept := make([]*topo.Body, 0, len(world))
+	for _, b := range world {
+		if ops.BodyGeometryProperties(b, q).Volume >= minVolume {
+			kept = append(kept, b)
+		}
+	}
+	return kept
+}
+
+// keepVisible drops internal parts: a body whose every vertex lies inside one of the
+// other bodies is fully enclosed (never seen from outside) and is removed.
+func keepVisible(world []*topo.Body) []*topo.Body {
+	kept := make([]*topo.Body, 0, len(world))
+	for i, b := range world {
+		if !enclosedByOthers(b, world, i) {
+			kept = append(kept, b)
+		}
+	}
+	return kept
+}
+
+// enclosedByOthers reports whether every vertex of world[i] lies inside some other
+// body, i.e. the part is internal to the assembly. A body with no vertices is never
+// treated as enclosed.
+func enclosedByOthers(b *topo.Body, world []*topo.Body, i int) bool {
+	verts := b.Vertices()
+	if len(verts) == 0 {
+		return false
+	}
+	for _, v := range verts {
+		if !insideAnyExcept(v.Point(), world, i) {
+			return false
+		}
+	}
+	return true
+}
+
+// insideAnyExcept reports whether p lies inside any body other than world[skip].
+func insideAnyExcept(p math.Point3, world []*topo.Body, skip int) bool {
+	for j, other := range world {
+		if j != skip && ops.PointInsideBody(other, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// applyEnvelope replaces kept bodies with bounding-box proxies per style.
+func applyEnvelope(kept []*topo.Body, style ShrinkwrapEnvelopeStyle) ([]*topo.Body, error) {
+	switch style {
+	case EnvelopePerPart:
+		return perPartEnvelopes(kept)
+	case EnvelopeWhole:
+		return wholeEnvelope(kept)
+	default:
+		return kept, nil
+	}
+}
+
+// perPartEnvelopes replaces each body with its own axis-aligned bounding box solid.
+func perPartEnvelopes(kept []*topo.Body) ([]*topo.Body, error) {
+	out := make([]*topo.Body, 0, len(kept))
+	for i, b := range kept {
+		box, err := envelopeSolid(b.RangeBox(), fmt.Sprintf("shrinkwrapEnvelope%d", i))
+		if err != nil {
+			return nil, err
+		}
+		if box != nil {
+			out = append(out, box)
+		}
+	}
+	return out, nil
+}
+
+// wholeEnvelope replaces the whole kept set with one bounding box enclosing them all.
+func wholeEnvelope(kept []*topo.Body) ([]*topo.Body, error) {
+	if len(kept) == 0 {
+		return nil, nil
+	}
+	box := kept[0].RangeBox()
+	for _, b := range kept[1:] {
+		box = box.Union(b.RangeBox())
+	}
+	solid, err := envelopeSolid(box, "shrinkwrapEnvelope")
+	if err != nil || solid == nil {
+		return nil, err
+	}
+	return []*topo.Body{solid}, nil
+}
+
+// envelopeSolid builds the axis-aligned box solid for box, or no body for an empty box.
+func envelopeSolid(box math.Box, feat string) (*topo.Body, error) {
+	if box.IsEmpty() {
+		return nil, nil
+	}
+	b, err := brep.SolidBlock(box.Min, box.Max, feat)
+	if err != nil {
+		return nil, fmt.Errorf("feature: shrinkwrap envelope %q for box %v: %w", feat, box, err)
+	}
+	return b, nil
+}
+
+// mergeIntoBase combines the proxy/real bodies into one multi-lump solid base body
+// (matching the derived-assembly merge), or returns nothing when the set is empty.
+func mergeIntoBase(bodies []*topo.Body) []*topo.Body {
+	solids := make([]*topo.Body, 0, len(bodies))
+	for _, b := range bodies {
+		if b != nil {
+			solids = append(solids, b)
+		}
+	}
+	if len(solids) == 0 {
+		return nil
+	}
+	lineage := topo.NewLineage(topo.Tok("shrinkwrap", "body", 0))
+	return []*topo.Body{topo.MergeBodies(lineage, true, solids...)}
+}
+
+// ShrinkwrapComponent derives a source assembly into this part as a simplified,
+// lightweight base body (M11-F06): each recompute runs [BuildShrinkwrap] over the
+// source, so a source edit re-simplifies; BreakLink freezes the current result. It is
+// the simplified-derive flavor of [DerivedAssemblyComponent].
+type ShrinkwrapComponent struct {
+	source AssemblyBodySource
+	def    ShrinkwrapDefinition
+	linked bool
+	frozen []*topo.Body
+}
+
+// Definition returns the shrinkwrap recipe holder.
+func (s *ShrinkwrapComponent) Definition() *ShrinkwrapComponent { return s }
+
+// Kind implements [Feature].
+func (s *ShrinkwrapComponent) Kind() string { return "shrinkwrap" }
+
+// SourceVersion returns the source assembly's geometry version (change tracking).
+func (s *ShrinkwrapComponent) SourceVersion() string { return s.source.ModelGeometryVersion() }
+
+// Linked reports whether the shrinkwrap still pulls from its source.
+func (s *ShrinkwrapComponent) Linked() bool { return s.linked }
+
+// Options returns the shrinkwrap recipe (removal + envelope styles).
+func (s *ShrinkwrapComponent) Options() ShrinkwrapDefinition { return s.def }
+
+// SetOptions replaces the shrinkwrap recipe; the next recompute re-simplifies.
+func (s *ShrinkwrapComponent) SetOptions(def ShrinkwrapDefinition) { s.def = def }
+
+// BreakLink freezes the current shrinkwrap result and severs the source link, so the
+// part keeps the simplified geometry without further updates.
+func (s *ShrinkwrapComponent) BreakLink() error {
+	bodies, err := BuildShrinkwrap(s.source, s.def)
+	if err != nil {
+		return err
+	}
+	s.frozen = bodies
+	s.linked = false
+	return nil
+}
+
+// Recompute appends the shrinkwrap base body (or, after a broken link, the frozen
+// bodies) to the running state.
+func (s *ShrinkwrapComponent) Recompute(in Input) (Output, error) {
+	return recomputeLinked(in, s.linked, s.frozen, func() ([]*topo.Body, error) {
+		return BuildShrinkwrap(s.source, s.def)
+	})
+}
+
+// ShrinkwrapComponents adds shrinkwrap features into the engine.
+type ShrinkwrapComponents struct{ engine *PartFeatures }
+
+// NewShrinkwrapComponents binds the collection to an engine.
+func NewShrinkwrapComponents(engine *PartFeatures) *ShrinkwrapComponents {
+	return &ShrinkwrapComponents{engine}
+}
+
+// AddShrinkwrap adds an associative shrinkwrap component simplifying source per def.
+func (c *ShrinkwrapComponents) AddShrinkwrap(source AssemblyBodySource, def ShrinkwrapDefinition) *PartFeature {
+	return c.engine.Add(&ShrinkwrapComponent{source: source, def: def, linked: true})
+}

--- a/model/feature/shrinkwrap_test.go
+++ b/model/feature/shrinkwrap_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// rotZ45 is a 45° rotation about the Z axis through the origin — used to make a block's
+// world AABB strictly larger than the block, so an envelope volume is a meaningful gate.
+func rotZ45(t *testing.T) math.Matrix4 {
+	t.Helper()
+	z, err := math.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("NewUnitVector3: %v", err)
+	}
+	return math.Rotation4(stdmath.Pi/4, z, math.P3(0, 0, 0))
+}
+
+// TestShrinkwrapMergesAllPartsByDefault: the zero-value recipe (keep all, no envelope)
+// merges every placed body into one base, volume = sum (two disjoint 2³ blocks → 16).
+func TestShrinkwrapMergesAllPartsByDefault(t *testing.T) {
+	block := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
+		{Body: block, Transform: math.Translation4(math.V3(10, 0, 0)), Source: occFor("a:2")},
+	}}
+	bodies, err := BuildShrinkwrap(src, ShrinkwrapDefinition{})
+	if err != nil || len(bodies) != 1 {
+		t.Fatalf("BuildShrinkwrap: err=%v bodies=%d, want one base body", err, len(bodies))
+	}
+	if got := volumeOf(bodies[0]); !approx(got, 16) {
+		t.Errorf("shrinkwrap volume = %g, want 16 (two 2³ blocks merged)", got)
+	}
+}
+
+// TestShrinkwrapRemovesSmallParts drops a tiny part below the size threshold, keeping
+// only the large one (volume-gated against the kept block's analytic volume).
+func TestShrinkwrapRemovesSmallParts(t *testing.T) {
+	big := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))              // volume 8
+	tiny := solidBlock(t, math.P3(10, 10, 10), math.P3(10.5, 10.5, 10.5)) // volume 0.125
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: big, Transform: math.Identity4(), Source: occFor("big:1")},
+		{Body: tiny, Transform: math.Identity4(), Source: occFor("tiny:1")},
+	}}
+	bodies, err := BuildShrinkwrap(src, ShrinkwrapDefinition{RemoveStyle: RemoveSmallParts, MinPartVolume: 1})
+	if err != nil {
+		t.Fatalf("BuildShrinkwrap: %v", err)
+	}
+	if got := volumeOf(bodies[0]); !approx(got, 8) {
+		t.Errorf("shrinkwrap volume = %g, want 8 (0.125³ part removed by size)", got)
+	}
+}
+
+// TestShrinkwrapRemovesInternalParts drops a part fully enclosed by another. The small
+// block sits entirely inside the big one; without removal a multi-lump merge would
+// double-count it (65), so the analytic 64 proves it was dropped.
+func TestShrinkwrapRemovesInternalParts(t *testing.T) {
+	big := solidBlock(t, math.P3(0, 0, 0), math.P3(4, 4, 4))   // volume 64
+	inner := solidBlock(t, math.P3(1, 1, 1), math.P3(2, 2, 2)) // volume 1, inside big
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: big, Transform: math.Identity4(), Source: occFor("shell:1")},
+		{Body: inner, Transform: math.Identity4(), Source: occFor("core:1")},
+	}}
+	bodies, err := BuildShrinkwrap(src, ShrinkwrapDefinition{RemoveStyle: RemoveInternalParts})
+	if err != nil {
+		t.Fatalf("BuildShrinkwrap: %v", err)
+	}
+	if got := volumeOf(bodies[0]); !approx(got, 64) {
+		t.Errorf("shrinkwrap volume = %g, want 64 (enclosed inner part removed)", got)
+	}
+}
+
+// TestShrinkwrapPerPartEnvelope replaces a part with its bounding box. A 2³ block
+// rotated 45° about Z has an axis-aligned envelope of (2√2)²·2 = 16 — twice the block's
+// volume — so the envelope clearly changed the geometry.
+func TestShrinkwrapPerPartEnvelope(t *testing.T) {
+	block := solidBlock(t, math.P3(-1, -1, -1), math.P3(1, 1, 1)) // volume 8
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: rotZ45(t), Source: occFor("a:1")},
+	}}
+	bodies, err := BuildShrinkwrap(src, ShrinkwrapDefinition{EnvelopeStyle: EnvelopePerPart})
+	if err != nil {
+		t.Fatalf("BuildShrinkwrap: %v", err)
+	}
+	if got := volumeOf(bodies[0]); !approx(got, 16) {
+		t.Errorf("per-part envelope volume = %g, want 16 (AABB of the rotated 2³ block)", got)
+	}
+}
+
+// TestShrinkwrapWholeEnvelope replaces the entire assembly with one bounding box: two
+// unit blocks 3 apart give an envelope of [0,4]×[0,1]×[0,1] = 4.
+func TestShrinkwrapWholeEnvelope(t *testing.T) {
+	near := solidBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	far := solidBlock(t, math.P3(3, 0, 0), math.P3(4, 1, 1))
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: near, Transform: math.Identity4(), Source: occFor("a:1")},
+		{Body: far, Transform: math.Identity4(), Source: occFor("a:2")},
+	}}
+	bodies, err := BuildShrinkwrap(src, ShrinkwrapDefinition{EnvelopeStyle: EnvelopeWhole})
+	if err != nil || len(bodies) != 1 {
+		t.Fatalf("BuildShrinkwrap: err=%v bodies=%d, want one envelope", err, len(bodies))
+	}
+	if got := volumeOf(bodies[0]); !approx(got, 4) {
+		t.Errorf("whole envelope volume = %g, want 4 (4×1×1 bounding box)", got)
+	}
+}
+
+// TestShrinkwrapBreakLinkFreezesAndVersionTracks covers the associative pull (a source
+// edit re-simplifies) and break-link (the result freezes).
+func TestShrinkwrapBreakLinkFreezesAndVersionTracks(t *testing.T) {
+	block := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
+	}}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewShrinkwrapComponents(fs).AddShrinkwrap(src, ShrinkwrapDefinition{})
+	fs.Recompute()
+	s := pf.Definition().(*ShrinkwrapComponent)
+	v0 := s.SourceVersion()
+
+	// Edit the source → associative re-simplify reflects the added body.
+	src.placed = append(src.placed, PlacedBody{Body: block, Transform: math.Translation4(math.V3(10, 0, 0)), Source: occFor("a:2")})
+	src.version++
+	fs.MarkDirty(pf)
+	fs.Recompute()
+	if got := volumeOf(fs.Result()[0]); !approx(got, 16) {
+		t.Fatalf("after source edit, volume = %g, want 16 (re-simplified)", got)
+	}
+	if s.SourceVersion() == v0 {
+		t.Error("source version did not advance on edit")
+	}
+
+	// Break the link and edit again → frozen, unchanged.
+	if err := s.BreakLink(); err != nil {
+		t.Fatalf("BreakLink: %v", err)
+	}
+	if s.Linked() {
+		t.Error("Linked() is true after BreakLink")
+	}
+	src.placed = append(src.placed, PlacedBody{Body: block, Transform: math.Translation4(math.V3(20, 0, 0)), Source: occFor("a:3")})
+	src.version++
+	fs.MarkDirty(pf)
+	fs.Recompute()
+	if got := volumeOf(fs.Result()[0]); !approx(got, 16) {
+		t.Errorf("after break-link, volume = %g, want frozen 16 (source change ignored)", got)
+	}
+}


### PR DESCRIPTION
## What

Lands the shrinkwrap remainder of **M11-F06** (#631): turn a source assembly into a single lightweight base body, and register that result as a substitute level-of-detail of the assembly.

**`model/feature` — shrinkwrap feature**
- `ShrinkwrapDefinition`: a **removal style** (`RemoveNone` / `RemoveSmallParts` with a `MinPartVolume` threshold / `RemoveInternalParts` — parts fully enclosed by others) and an **envelope style** (`EnvelopeNone` / `EnvelopePerPart` / `EnvelopeWhole` — replace each kept part, or the whole set, with its bounding box).
- `ShrinkwrapComponent`: the simplified-derive flavor of `DerivedAssemblyComponent` — pulls the source's placed bodies, removes/envelopes/merges into one solid, re-simplifies on source change, and `BreakLink` freezes.
- `BuildShrinkwrap` is the standalone producer reused by the LOD path.
- The frozen/linked recompute is now shared with `DerivedAssemblyComponent` via `recomputeLinked` (no duplication).

**`model/compdef` — substitute-LOD path**
- `ShrinkwrapToPart` wraps the lightweight bodies as a non-parametric base part (a placeable `occurrence.Definition`).
- `SubstituteWithShrinkwrap` suppresses the source occurrences and adds one `IsSubstitute` LOD occurrence in their place — the entry point that feeds occurrence substitution (#348/#355) and LOD representations (#361).

## Why

Shrinkwrap is the lightweight-substitute producer the rest of M11/M17 builds on. Envelope replacement is the hole-elimination mechanism (a box is closed by construction), so the result is always a clean solid.

## Verification

- Every path is **volume-gated against analytic values**: merged sum (16), size removal (8), internal-part removal (64, proving the enclosed part was dropped vs. a 65 double-count), rotated-2³-block per-part envelope (16 = the AABB), whole-assembly envelope (4), and break-link freeze.
- LOD path asserts the source occurrence is suppressed and a single `IsSubstitute` occurrence carries the envelope extent.
- `go build ./...`, `go vet ./model/...`, `go test ./model/...` green; golangci-lint v2 clean; SPDX headers present.

## Scope / still open under #631

Per-part true hole-patching of *real* geometry (inner-loop fill) and substitute-LOD on real (non-enveloped) geometry remain — they need new kernel B-rep surgery ops. The public API surface (`assembly.shrinkwrapCreate` wire/client/contract) and source-document GUID/revision persistence are tracked separately (#716, #715), consistent with the rest of M11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)