### PR TITLE
M11-F06: Shrinkwrap hole patching (internal void fill)

### DIFF
--- a/kernel/ops/fill_voids.go
+++ b/kernel/ops/fill_voids.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import "oblikovati.org/kernel/topo"
+
+// FillInternalVoids returns b with its internal void (cavity) shells removed, so fully
+// enclosed cavities become solid material — the hole-patching path for shrinkwrap
+// simplification (M11-F06). A body with no voids is returned unchanged (same pointer).
+//
+// Only cavities disconnected from the boundary are filled: a through-hole's wall
+// belongs to the outer shell, so it is untouched here and is eliminated instead by
+// envelope replacement (or, later, by cap synthesis). Surface (open-shell) bodies pass
+// through unchanged.
+//
+// Example: solid := ops.FillInternalVoids(hollowCasting, ops.DefaultQuality())
+func FillInternalVoids(b *topo.Body, q Quality) *topo.Body {
+	shells := b.Shells()
+	kept := make([]*topo.Shell, 0, len(shells))
+	for _, sh := range shells {
+		if !ShellIsVoid(sh, q) {
+			kept = append(kept, sh)
+		}
+	}
+	if len(kept) == len(shells) {
+		return b // no void shells to drop
+	}
+	return topo.BodyFromShells(b.Lineage(), b.IsSolid(), kept...)
+}

--- a/kernel/ops/fill_voids_test.go
+++ b/kernel/ops/fill_voids_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/math"
+)
+
+// TestFillInternalVoidsRemovesCavity gates the hole-patch: the 4³−2³=56 cavity body
+// becomes the solid 4³=64 block once its void shell is dropped, and stays manifold.
+func TestFillInternalVoidsRemovesCavity(t *testing.T) {
+	body := cavityBody(t)
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; stdmath.Abs(v-56) > 0.1 {
+		t.Fatalf("fixture volume = %g, want 56 (4³ minus 2³ cavity)", v)
+	}
+	filled := FillInternalVoids(body, DefaultQuality())
+	if got := len(filled.Shells()); got != 1 {
+		t.Fatalf("filled body has %d shells, want 1 (void removed)", got)
+	}
+	if v := BodyGeometryProperties(filled, DefaultQuality()).Volume; stdmath.Abs(v-64) > 0.1 {
+		t.Errorf("filled volume = %g, want 64 (cavity filled to solid 4³)", v)
+	}
+	if r := Validate(filled); !r.Valid {
+		t.Errorf("filled body invalid: %v", r.Issues)
+	}
+}
+
+// TestFillInternalVoidsLeavesSolidUnchanged: a void-free body is returned as-is.
+func TestFillInternalVoidsLeavesSolidUnchanged(t *testing.T) {
+	block, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "b")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	if got := FillInternalVoids(block, DefaultQuality()); got != block {
+		t.Error("a void-free body should be returned unchanged (same pointer)")
+	}
+}

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -113,6 +113,21 @@ func (b *Body) FindVertexByKey(key []byte) (*Vertex, bool) {
 	return nil, false
 }
 
+// BodyFromShells builds a body owning exactly the given shells, re-parenting each. It
+// rebuilds a body from a subset of another body's shells — e.g. dropping the inner
+// void shells to fill internal cavities (ops.FillInternalVoids, M11-F06 shrinkwrap).
+// The donor shells must not be reused afterward, as their owning body is rewritten.
+//
+// Example: solid := BodyFromShells(b.Lineage(), b.IsSolid(), outerShellsOf(b)...)
+func BodyFromShells(lineage Lineage, solid bool, shells ...*Shell) *Body {
+	body := &Body{id: nextID(), solid: solid, lineage: lineage}
+	for _, sh := range shells {
+		sh.body = body
+		body.shells = append(body.shells, sh)
+	}
+	return body
+}
+
 // MergeBodies combines the shells of several bodies into one (a multi-lump body),
 // re-parenting each shell. Used by a boolean Join of non-touching bodies
 // (kernel/ops). The input bodies should not be used afterward.

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -47,6 +47,10 @@ type ShrinkwrapDefinition struct {
 	RemoveStyle   ShrinkwrapRemoveStyle
 	MinPartVolume float64 // threshold for RemoveSmallParts (units³)
 	EnvelopeStyle ShrinkwrapEnvelopeStyle
+	// PatchHoles fills each kept part's internal voids (cavities) so hollow parts
+	// become solid, before removal and enveloping. Through-holes open to the surface
+	// are unaffected (envelope replacement handles those).
+	PatchHoles bool
 }
 
 // BuildShrinkwrap flattens source's occurrence tree, drops parts per the removal
@@ -62,11 +66,25 @@ func BuildShrinkwrap(source AssemblyBodySource, def ShrinkwrapDefinition) ([]*to
 	if err != nil {
 		return nil, err
 	}
+	if def.PatchHoles {
+		world = patchHoles(world)
+	}
 	enveloped, err := applyEnvelope(keepAfterRemoval(world, def), def.EnvelopeStyle)
 	if err != nil {
 		return nil, err
 	}
 	return mergeIntoBase(enveloped), nil
+}
+
+// patchHoles fills each body's internal voids so hollow parts become solid before the
+// rest of the simplification runs.
+func patchHoles(world []*topo.Body) []*topo.Body {
+	q := ops.DefaultQuality()
+	out := make([]*topo.Body, 0, len(world))
+	for _, b := range world {
+		out = append(out, ops.FillInternalVoids(b, q))
+	}
+	return out
 }
 
 // worldBodies transforms each placed source body into assembly space, giving each a

--- a/model/feature/shrinkwrap_test.go
+++ b/model/feature/shrinkwrap_test.go
@@ -6,8 +6,23 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
+
+// cavityBlock builds a 4³ block with a fully enclosed 2³ cavity (volume 56) by cutting
+// an inner block from a bigger one — a hollow part for the hole-patch gate.
+func cavityBlock(t *testing.T) *topo.Body {
+	t.Helper()
+	big := solidBlock(t, math.P3(0, 0, 0), math.P3(4, 4, 4))
+	small := solidBlock(t, math.P3(1, 1, 1), math.P3(3, 3, 3))
+	res, err := ops.Boolean(ops.Cut, big, small)
+	if err != nil {
+		t.Fatalf("cavity cut: %v", err)
+	}
+	return res
+}
 
 // rotZ45 is a 45° rotation about the Z axis through the origin — used to make a block's
 // world AABB strictly larger than the block, so an envelope volume is a meaningful gate.
@@ -106,6 +121,26 @@ func TestShrinkwrapWholeEnvelope(t *testing.T) {
 	}
 	if got := volumeOf(bodies[0]); !approx(got, 4) {
 		t.Errorf("whole envelope volume = %g, want 4 (4×1×1 bounding box)", got)
+	}
+}
+
+// TestShrinkwrapPatchHolesFillsCavity gates the hole-patch through the feature: a
+// hollow 56-volume part is solidified to its 64-volume outer block when PatchHoles is
+// set (the internal void is dropped before merge).
+func TestShrinkwrapPatchHolesFillsCavity(t *testing.T) {
+	cav := cavityBlock(t)
+	if v := volumeOf(cav); v < 55.9 || v > 56.1 {
+		t.Fatalf("cavity fixture volume = %g, want ~56", v)
+	}
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: cav, Transform: math.Identity4(), Source: occFor("hollow:1")},
+	}}
+	bodies, err := BuildShrinkwrap(src, ShrinkwrapDefinition{PatchHoles: true})
+	if err != nil {
+		t.Fatalf("BuildShrinkwrap: %v", err)
+	}
+	if got := volumeOf(bodies[0]); got < 63.9 || got > 64.1 {
+		t.Errorf("patched volume = %g, want ~64 (cavity filled)", got)
 	}
 }
 


### PR DESCRIPTION
## What

Completes the **model-side** shrinkwrap capability for **M11-F06** (#631) by adding hole patching, the last simplification beyond removal/envelope/merge.

**`kernel`**
- `ops.FillInternalVoids(b, q)` — rebuilds a body keeping only its non-void shells, so a fully enclosed cavity becomes solid. Void shells are identified by negative signed volume (`ShellIsVoid`). A void-free body is returned unchanged (same pointer).
- `topo.BodyFromShells(lineage, solid, shells...)` — the small constructor that rebuilds a body from a subset of another's shells (re-parenting), counterpart of `MergeBodies`.

**`model/feature`**
- `ShrinkwrapDefinition.PatchHoles` — fills each kept part's internal voids before removal/enveloping, so hollow parts contribute solid material to the lightweight result.

## Why

Envelope replacement already eliminates holes by *replacing* a part with its box; `PatchHoles` is the complementary path that keeps real geometry but solidifies internal cavities. Together they cover the shrinkwrap simplification set in the model.

## Verification

- Volume-gated against analytic values: the canonical 4³−2³ = **56** cavity body fills to a manifold **64** (kernel), and end-to-end a hollow 56-volume part is solidified to 64 through the feature.
- `Validate` confirms the filled body stays manifold/closed.
- `go build ./...`, `go vet ./kernel/... ./model/...`, full `kernel/ops` + `kernel/topo` + `model/feature` tests green; golangci-lint v2 clean; SPDX headers present.

## Scope — closes the model gap; one kernel item split out

This makes the shrinkwrap model surface of #631 complete (removal ✓, envelopes ✓, hole patching ✓, substitute-LOD ✓). The remaining flavor — capping cylindrical **through-holes** open to the surface — needs cap-surface synthesis and trimming, a standalone kernel B-rep op I'll file separately rather than fold into M11. Public API surface (#716) and source-document persistence (#715) stay tracked separately per the M11 cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)