### PR TITLE
model: assembly occurrence-lifecycle events (M11-F07)

### DIFF
--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -30,15 +30,21 @@ var (
 type AssemblyComponentDefinition struct {
 	occurrences *occurrence.Occurrences
 	units       param.UnitsOfMeasure // document display units (length/angle/…)
+	events      *AssemblyEvents      // occurrence-lifecycle event source (M11-F07)
 }
 
 // NewAssemblyComponentDefinition returns an empty assembly content object: no
-// occurrences and default (metric) display units.
+// occurrences, default (metric) display units, and a live event source wired to its
+// occurrence collection so placements/moves/suppression raise domain events (M11-F07).
 func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
-	return &AssemblyComponentDefinition{
-		occurrences: occurrence.NewOccurrences(),
+	occ := occurrence.NewOccurrences()
+	a := &AssemblyComponentDefinition{
+		occurrences: occ,
 		units:       param.DefaultUnitsOfMeasure(),
+		events:      newAssemblyEvents(),
 	}
+	occ.SetListener(a.events)
+	return a
 }
 
 // An assembly definition is plain document content, not recipe-bearing content: it
@@ -104,6 +110,42 @@ func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *
 			componentDoc.DisplayName(), componentDoc.Content())
 	}
 	return a.Place(name, def, transform), nil
+}
+
+// Events returns the assembly's occurrence-lifecycle event source — subscribe add-ins
+// and observers to its bus (M11-F07). Placements, moves, replacements and suppression
+// changes raise typed events; delete and suppress are also vetoable in the Before
+// phase via [AssemblyComponentDefinition.DeleteOccurrence] and SetOccurrenceSuppressed.
+func (a *AssemblyComponentDefinition) Events() *AssemblyEvents { return a.events }
+
+// DeleteOccurrence removes o from the assembly, first raising a vetoable OccurrenceDelete
+// in the Before phase; on commit the removal raises OccurrenceDelete After. It returns
+// an [AssemblyVetoError] if a Before handler cancelled the delete, or nil otherwise
+// (removing an occurrence not in this assembly is a silent no-op, as for the reference
+// API). M11-F07.
+func (a *AssemblyComponentDefinition) DeleteOccurrence(o *occurrence.Occurrence) error {
+	if err := raiseBefore(a.events.bus, "delete occurrence", OccurrenceDelete{Occurrence: o}); err != nil {
+		return err
+	}
+	a.occurrences.Remove(o)
+	return nil
+}
+
+// SetOccurrenceSuppressed toggles o's suppression, first raising a vetoable
+// OccurrenceSuppress in the Before phase; on commit the change raises OccurrenceSuppress
+// After. A Before handler may veto (e.g. to keep a required component active), in which
+// case it returns an [AssemblyVetoError] and o is unchanged. A no-op toggle (already in
+// the requested state) raises no event and returns nil. M11-F07.
+func (a *AssemblyComponentDefinition) SetOccurrenceSuppressed(o *occurrence.Occurrence, suppressed bool) error {
+	if o.Suppressed() == suppressed {
+		return nil
+	}
+	ev := OccurrenceSuppress{Occurrence: o, Suppressed: suppressed}
+	if err := raiseBefore(a.events.bus, "suppress occurrence", ev); err != nil {
+		return err
+	}
+	o.SetSuppressed(suppressed)
+	return nil
 }
 
 // RangeBox returns the axis-aligned bounding box enclosing every unsuppressed

--- a/model/compdef/assembly_events.go
+++ b/model/compdef/assembly_events.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// Assembly occurrence-lifecycle event type ids. The high byte 0x0B mirrors the
+// milestone (M11); ids are stable across versions because they cross the gRPC seam to
+// add-ins (never renumber). Constraint/joint (relationship) events join this family
+// once M12-F01 (#358) lands; they are intentionally absent here.
+const (
+	tidOccurrenceAdd       event.TypeID = 0x0B01
+	tidOccurrenceDelete    event.TypeID = 0x0B02
+	tidOccurrenceReplace   event.TypeID = 0x0B03
+	tidOccurrenceTransform event.TypeID = 0x0B04
+	tidOccurrenceSuppress  event.TypeID = 0x0B05
+)
+
+// OccurrenceAdd is raised (After) when an occurrence is placed in the assembly — the
+// reference API's AssemblyEvents.OnOccurrenceAdd.
+type OccurrenceAdd struct{ Occurrence *occurrence.Occurrence }
+
+// EventID implements event.Event.
+func (OccurrenceAdd) EventID() event.TypeID { return tidOccurrenceAdd }
+
+// OccurrenceDelete is raised around deleting an occurrence: vetoable in the Before
+// phase (driven by [AssemblyComponentDefinition.DeleteOccurrence]), then After once the
+// removal commits.
+type OccurrenceDelete struct{ Occurrence *occurrence.Occurrence }
+
+// EventID implements event.Event.
+func (OccurrenceDelete) EventID() event.TypeID { return tidOccurrenceDelete }
+
+// OccurrenceReplace is raised (After) when an occurrence's definition is swapped,
+// carrying the definition it held before.
+type OccurrenceReplace struct {
+	Occurrence *occurrence.Occurrence
+	Previous   occurrence.Definition
+}
+
+// EventID implements event.Event.
+func (OccurrenceReplace) EventID() event.TypeID { return tidOccurrenceReplace }
+
+// OccurrenceTransform is raised (After) when an occurrence is repositioned, carrying
+// its prior placement. During a drag batch it fires once per occurrence at resume (see
+// occurrence.Occurrences.SuspendNotifications), carrying the pre-batch placement.
+type OccurrenceTransform struct {
+	Occurrence *occurrence.Occurrence
+	Previous   math.Matrix4
+}
+
+// EventID implements event.Event.
+func (OccurrenceTransform) EventID() event.TypeID { return tidOccurrenceTransform }
+
+// OccurrenceSuppress is raised around toggling an occurrence's suppression: vetoable in
+// the Before phase (driven by [AssemblyComponentDefinition.SetOccurrenceSuppressed]),
+// then After once the change commits. Suppressed reports the requested/new state.
+type OccurrenceSuppress struct {
+	Occurrence *occurrence.Occurrence
+	Suppressed bool
+}
+
+// EventID implements event.Event.
+func (OccurrenceSuppress) EventID() event.TypeID { return tidOccurrenceSuppress }
+
+// AssemblyEvents is an assembly definition's occurrence-lifecycle event source — the
+// reference API's AssemblyEvents (M11-F07, #632). It bridges raw occurrence mutations
+// to a typed [event.Bus] that add-ins subscribe to: it implements
+// [occurrence.OccurrenceListener] so the assembly's occurrences notify it in the After
+// phase, and it raises the vetoable Before phase for operations a caller initiates
+// through the definition (delete, suppress).
+//
+// Example: subscribe to placements —
+//
+//	event.Subscribe(asm.Events().Bus(), event.After,
+//	    func(_ event.Context, e compdef.OccurrenceAdd) event.Outcome {
+//	        log.Printf("placed %s", e.Occurrence.Name())
+//	        return event.Continue()
+//	    })
+type AssemblyEvents struct{ bus *event.Bus }
+
+// AssemblyEvents is the sink the occurrence collection notifies.
+var _ occurrence.OccurrenceListener = (*AssemblyEvents)(nil)
+
+// newAssemblyEvents returns an event source on a fresh bus, installed by the assembly
+// definition constructor.
+func newAssemblyEvents() *AssemblyEvents { return &AssemblyEvents{bus: event.NewBus()} }
+
+// Bus returns the event bus to subscribe handlers on with [event.Subscribe].
+func (e *AssemblyEvents) Bus() *event.Bus { return e.bus }
+
+// OccurrenceAdded raises OccurrenceAdd (After). Implements occurrence.OccurrenceListener.
+func (e *AssemblyEvents) OccurrenceAdded(o *occurrence.Occurrence) {
+	event.Emit(e.bus, event.After, OccurrenceAdd{Occurrence: o})
+}
+
+// OccurrenceRemoved raises OccurrenceDelete (After).
+func (e *AssemblyEvents) OccurrenceRemoved(o *occurrence.Occurrence) {
+	event.Emit(e.bus, event.After, OccurrenceDelete{Occurrence: o})
+}
+
+// OccurrenceReplaced raises OccurrenceReplace (After) with the prior definition.
+func (e *AssemblyEvents) OccurrenceReplaced(o *occurrence.Occurrence, previous occurrence.Definition) {
+	event.Emit(e.bus, event.After, OccurrenceReplace{Occurrence: o, Previous: previous})
+}
+
+// OccurrenceTransformed raises OccurrenceTransform (After) with the prior placement.
+func (e *AssemblyEvents) OccurrenceTransformed(o *occurrence.Occurrence, previous math.Matrix4) {
+	event.Emit(e.bus, event.After, OccurrenceTransform{Occurrence: o, Previous: previous})
+}
+
+// OccurrenceSuppressionChanged raises OccurrenceSuppress (After) with the new state.
+func (e *AssemblyEvents) OccurrenceSuppressionChanged(o *occurrence.Occurrence) {
+	event.Emit(e.bus, event.After, OccurrenceSuppress{Occurrence: o, Suppressed: o.Suppressed()})
+}
+
+// AssemblyVetoError reports that a Before-phase handler cancelled an assembly
+// operation. Callers distinguish it from real failures via errors.As.
+type AssemblyVetoError struct {
+	Operation string
+	Reason    string
+}
+
+// Error implements error.
+func (e *AssemblyVetoError) Error() string {
+	return fmt.Sprintf("compdef: %s vetoed: %s", e.Operation, e.Reason)
+}
+
+// raiseBefore emits ev in the Before phase and returns an [AssemblyVetoError] if any
+// handler vetoed the operation, or nil to proceed. It mirrors doc.vetoed for the
+// assembly domain.
+func raiseBefore[E event.Event](bus *event.Bus, operation string, ev E) error {
+	if out := event.Emit(bus, event.Before, ev); out.Vetoed() {
+		return &AssemblyVetoError{Operation: operation, Reason: out.Reason}
+	}
+	return nil
+}

--- a/model/compdef/assembly_events_test.go
+++ b/model/compdef/assembly_events_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// placeUnit places a unit-box part in asm and returns the occurrence.
+func placeUnit(asm *AssemblyComponentDefinition, name string) *occurrence.Occurrence {
+	part := NewPartComponentDefinition()
+	return asm.Place(name, part, math.Identity4())
+}
+
+// TestEventsRaiseOnPlaceMoveReplace covers the After-phase occurrence events reaching a
+// bus subscriber for the three programmatic mutations that have no veto (M11-F07).
+func TestEventsRaiseOnPlaceMoveReplace(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	var adds, transforms, replaces int
+	var lastPrev math.Matrix4
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceAdd) event.Outcome {
+		adds++
+		return event.Continue()
+	})
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceTransform) event.Outcome {
+		transforms++
+		lastPrev = e.Previous
+		return event.Continue()
+	})
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceReplace) event.Outcome {
+		replaces++
+		return event.Continue()
+	})
+
+	o := placeUnit(asm, "a:1")
+	o.SetTransform(math.Translation4(math.V3(4, 0, 0)))
+	asm.Occurrences().Replace(o, NewPartComponentDefinition())
+
+	if adds != 1 || transforms != 1 || replaces != 1 {
+		t.Fatalf("event counts: add=%d transform=%d replace=%d, want 1/1/1", adds, transforms, replaces)
+	}
+	if lastPrev != math.Identity4() {
+		t.Errorf("transform Previous = %v, want the prior identity placement", lastPrev)
+	}
+}
+
+// TestSuppressVetoKeepsOccurrenceActive: a Before handler vetoes the suppress, so the
+// definition op returns an AssemblyVetoError, the occurrence stays active, and no After
+// event fires.
+func TestSuppressVetoKeepsOccurrenceActive(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	o := placeUnit(asm, "a:1")
+
+	event.Subscribe(asm.Events().Bus(), event.Before, func(_ event.Context, e OccurrenceSuppress) event.Outcome {
+		return event.Veto("component is required")
+	})
+	afterFired := false
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceSuppress) event.Outcome {
+		afterFired = true
+		return event.Continue()
+	})
+
+	err := asm.SetOccurrenceSuppressed(o, true)
+	var veto *AssemblyVetoError
+	if !errors.As(err, &veto) {
+		t.Fatalf("SetOccurrenceSuppressed err = %v, want AssemblyVetoError", err)
+	}
+	if o.Suppressed() {
+		t.Error("occurrence was suppressed despite the veto")
+	}
+	if afterFired {
+		t.Error("After event fired despite the Before veto")
+	}
+}
+
+// TestSuppressCommitsWhenNotVetoed: with no veto the suppress applies and raises the
+// After event carrying the new state.
+func TestSuppressCommitsWhenNotVetoed(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	o := placeUnit(asm, "a:1")
+	var got *OccurrenceSuppress
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceSuppress) event.Outcome {
+		got = &e
+		return event.Continue()
+	})
+
+	if err := asm.SetOccurrenceSuppressed(o, true); err != nil {
+		t.Fatalf("SetOccurrenceSuppressed: %v", err)
+	}
+	if !o.Suppressed() {
+		t.Error("occurrence not suppressed after a non-vetoed call")
+	}
+	if got == nil || !got.Suppressed || got.Occurrence != o {
+		t.Errorf("After event = %+v, want one carrying Suppressed=true for the occurrence", got)
+	}
+}
+
+// TestDeleteVetoKeepsOccurrence: a Before handler vetoes the delete, so the occurrence
+// stays in the assembly.
+func TestDeleteVetoKeepsOccurrence(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	o := placeUnit(asm, "a:1")
+	event.Subscribe(asm.Events().Bus(), event.Before, func(_ event.Context, e OccurrenceDelete) event.Outcome {
+		return event.Veto("locked")
+	})
+
+	if err := asm.DeleteOccurrence(o); err == nil {
+		t.Fatal("DeleteOccurrence returned nil, want a veto error")
+	}
+	if asm.Occurrences().Count() != 1 {
+		t.Errorf("occurrence count = %d after vetoed delete, want 1", asm.Occurrences().Count())
+	}
+}
+
+// TestDeleteCommitsAndRaisesAfter: an unvetoed delete removes the occurrence and raises
+// the After event.
+func TestDeleteCommitsAndRaisesAfter(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	o := placeUnit(asm, "a:1")
+	deleted := false
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceDelete) event.Outcome {
+		deleted = e.Occurrence == o
+		return event.Continue()
+	})
+
+	if err := asm.DeleteOccurrence(o); err != nil {
+		t.Fatalf("DeleteOccurrence: %v", err)
+	}
+	if asm.Occurrences().Count() != 0 {
+		t.Errorf("occurrence count = %d after delete, want 0", asm.Occurrences().Count())
+	}
+	if !deleted {
+		t.Error("OccurrenceDelete After event did not fire for the deleted occurrence")
+	}
+}
+
+// TestDragBatchRaisesOneTransformEvent ties the occurrence-layer batch to the event
+// source: a suspended multi-step drag raises exactly one OccurrenceTransform on the bus.
+func TestDragBatchRaisesOneTransformEvent(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	o := placeUnit(asm, "a:1")
+	var transforms int
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e OccurrenceTransform) event.Outcome {
+		transforms++
+		return event.Continue()
+	})
+
+	asm.Occurrences().SuspendNotifications()
+	for i := 1; i <= 50; i++ {
+		o.SetTransform(math.Translation4(math.V3(float64(i), 0, 0)))
+	}
+	asm.Occurrences().ResumeNotifications()
+
+	if transforms != 1 {
+		t.Errorf("drag raised %d OccurrenceTransform events, want 1 (batched)", transforms)
+	}
+}

--- a/model/occurrence/listener.go
+++ b/model/occurrence/listener.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import "oblikovati.org/math"
+
+// OccurrenceListener observes occurrence mutations after they apply, so an owner — the
+// assembly definition's event source — can raise domain events without this package
+// depending on it (the dependency points inward; model/occurrence must not import
+// model/compdef). Every method reports an After-phase fact: the change has already
+// happened, so a listener never vetoes here. It is the sink behind the reference API's
+// AssemblyEvents occurrence notifications (M11-F07, #632).
+//
+// Install one with [Occurrences.SetListener]; mutations on the collection and on its
+// occurrences then call the matching method.
+type OccurrenceListener interface {
+	// OccurrenceAdded fires after o is placed in the collection.
+	OccurrenceAdded(o *Occurrence)
+	// OccurrenceRemoved fires after o is deleted from the collection.
+	OccurrenceRemoved(o *Occurrence)
+	// OccurrenceReplaced fires after o's definition is swapped, carrying the prior one.
+	OccurrenceReplaced(o *Occurrence, previous Definition)
+	// OccurrenceTransformed fires after o is repositioned, carrying its prior placement.
+	// Inside a drag batch ([Occurrences.SuspendNotifications]) it is coalesced to one
+	// call per occurrence at resume, carrying the placement held when the batch began.
+	OccurrenceTransformed(o *Occurrence, previous math.Matrix4)
+	// OccurrenceSuppressionChanged fires after o's suppression flag actually changes.
+	OccurrenceSuppressionChanged(o *Occurrence)
+}
+
+// silentListener is the null-object default so the collection never nil-checks a
+// listener. SetListener(nil) restores it.
+type silentListener struct{}
+
+func (silentListener) OccurrenceAdded(*Occurrence)                     {}
+func (silentListener) OccurrenceRemoved(*Occurrence)                   {}
+func (silentListener) OccurrenceReplaced(*Occurrence, Definition)      {}
+func (silentListener) OccurrenceTransformed(*Occurrence, math.Matrix4) {}
+func (silentListener) OccurrenceSuppressionChanged(*Occurrence)        {}

--- a/model/occurrence/listener_test.go
+++ b/model/occurrence/listener_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// recordingListener is a named fake OccurrenceListener that logs every notification in
+// order, so a test can assert exactly which mutations fired and with what payload.
+type recordingListener struct {
+	added       []*Occurrence
+	removed     []*Occurrence
+	replaced    []replaceCall
+	transformed []transformCall
+	suppressed  []*Occurrence
+}
+
+type replaceCall struct {
+	occ      *Occurrence
+	previous Definition
+}
+
+type transformCall struct {
+	occ      *Occurrence
+	previous math.Matrix4
+}
+
+func (r *recordingListener) OccurrenceAdded(o *Occurrence)   { r.added = append(r.added, o) }
+func (r *recordingListener) OccurrenceRemoved(o *Occurrence) { r.removed = append(r.removed, o) }
+func (r *recordingListener) OccurrenceReplaced(o *Occurrence, previous Definition) {
+	r.replaced = append(r.replaced, replaceCall{o, previous})
+}
+func (r *recordingListener) OccurrenceTransformed(o *Occurrence, previous math.Matrix4) {
+	r.transformed = append(r.transformed, transformCall{o, previous})
+}
+func (r *recordingListener) OccurrenceSuppressionChanged(o *Occurrence) {
+	r.suppressed = append(r.suppressed, o)
+}
+
+// listenIn returns a fresh collection with a recording listener installed.
+func listenIn() (*Occurrences, *recordingListener) {
+	occ := NewOccurrences()
+	rec := &recordingListener{}
+	occ.SetListener(rec)
+	return occ, rec
+}
+
+func unitBox() fakeComponent {
+	return fakeComponent{box: math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1))}
+}
+
+// TestListenerSeesStructuralMutations covers add/remove/replace notifications and their
+// payloads — the After-phase facts the assembly turns into domain events (M11-F07).
+func TestListenerSeesStructuralMutations(t *testing.T) {
+	occ, rec := listenIn()
+	first := unitBox()
+	o := occ.AddByComponentDefinition("a:1", first, math.Identity4())
+	if len(rec.added) != 1 || rec.added[0] != o {
+		t.Fatalf("OccurrenceAdded = %v, want one call for the placed occurrence", rec.added)
+	}
+
+	second := unitBox()
+	if !occ.Replace(o, second) {
+		t.Fatal("Replace reported the occurrence as foreign")
+	}
+	if len(rec.replaced) != 1 || rec.replaced[0].occ != o || rec.replaced[0].previous != Definition(first) {
+		t.Fatalf("OccurrenceReplaced = %+v, want one call carrying the prior definition", rec.replaced)
+	}
+
+	if !occ.Remove(o) {
+		t.Fatal("Remove reported the occurrence as foreign")
+	}
+	if len(rec.removed) != 1 || rec.removed[0] != o {
+		t.Fatalf("OccurrenceRemoved = %v, want one call for the removed occurrence", rec.removed)
+	}
+}
+
+// TestListenerSeesTransformAndSuppression covers the per-occurrence placement and
+// suppression notifications, including that a no-op suppression toggle stays silent.
+func TestListenerSeesTransformAndSuppression(t *testing.T) {
+	occ, rec := listenIn()
+	o := occ.AddByComponentDefinition("a:1", unitBox(), math.Identity4())
+
+	moved := math.Translation4(math.V3(5, 0, 0))
+	o.SetTransform(moved)
+	if len(rec.transformed) != 1 || rec.transformed[0].previous != math.Identity4() {
+		t.Fatalf("OccurrenceTransformed = %+v, want one call carrying the prior (identity) placement", rec.transformed)
+	}
+
+	o.SetSuppressed(true)
+	o.SetSuppressed(true) // no-op: already suppressed, must not re-fire
+	if len(rec.suppressed) != 1 || rec.suppressed[0] != o {
+		t.Fatalf("OccurrenceSuppressionChanged = %v, want exactly one call (no-op toggle stays silent)", rec.suppressed)
+	}
+}
+
+// TestDragBatchCoalescesTransforms proves the solver-drag batch: many per-step moves of
+// one occurrence collapse to a single notification carrying the pre-batch placement,
+// while a second moved occurrence flushes once in first-moved order (M11-F07).
+func TestDragBatchCoalescesTransforms(t *testing.T) {
+	occ, rec := listenIn()
+	a := occ.AddByComponentDefinition("a:1", unitBox(), math.Identity4())
+	b := occ.AddByComponentDefinition("b:1", unitBox(), math.Identity4())
+	rec.transformed = nil // ignore the adds
+
+	occ.SuspendNotifications()
+	for i := 1; i <= 100; i++ {
+		a.SetTransform(math.Translation4(math.V3(float64(i), 0, 0)))
+	}
+	b.SetTransform(math.Translation4(math.V3(0, 7, 0)))
+	if len(rec.transformed) != 0 {
+		t.Fatalf("got %d notifications during the batch, want 0 (coalesced)", len(rec.transformed))
+	}
+	occ.ResumeNotifications()
+
+	if len(rec.transformed) != 2 {
+		t.Fatalf("after resume got %d notifications, want 2 (one per moved occurrence)", len(rec.transformed))
+	}
+	if rec.transformed[0].occ != a || rec.transformed[0].previous != math.Identity4() {
+		t.Errorf("first flush = %+v, want occurrence a with its pre-batch (identity) placement", rec.transformed[0])
+	}
+	if rec.transformed[1].occ != b {
+		t.Errorf("second flush occurrence = %v, want b (first-moved order)", rec.transformed[1].occ)
+	}
+	// Revision still advanced per step (geometry version is not batched).
+	if occ.Revision() == 0 {
+		t.Error("revision did not advance during the batch")
+	}
+}
+
+// TestDragBatchSkipsNetZeroMove: an occurrence dragged out and back to its starting
+// placement emits no event at resume (nothing net changed).
+func TestDragBatchSkipsNetZeroMove(t *testing.T) {
+	occ, rec := listenIn()
+	o := occ.AddByComponentDefinition("a:1", unitBox(), math.Identity4())
+	rec.transformed = nil
+
+	occ.SuspendNotifications()
+	o.SetTransform(math.Translation4(math.V3(9, 0, 0)))
+	o.SetTransform(math.Identity4()) // back to start
+	occ.ResumeNotifications()
+
+	if len(rec.transformed) != 0 {
+		t.Fatalf("net-zero drag emitted %d notifications, want 0", len(rec.transformed))
+	}
+}
+
+// TestNestedBatchFlushesAtOutermostResume: only the outermost ResumeNotifications ends
+// the batch; an inner resume must not flush early.
+func TestNestedBatchFlushesAtOutermostResume(t *testing.T) {
+	occ, rec := listenIn()
+	o := occ.AddByComponentDefinition("a:1", unitBox(), math.Identity4())
+	rec.transformed = nil
+
+	occ.SuspendNotifications()
+	occ.SuspendNotifications()
+	o.SetTransform(math.Translation4(math.V3(3, 0, 0)))
+	occ.ResumeNotifications() // inner — still batched
+	if len(rec.transformed) != 0 {
+		t.Fatalf("inner resume flushed %d notifications, want 0 (batch still open)", len(rec.transformed))
+	}
+	occ.ResumeNotifications() // outer — flush now
+	if len(rec.transformed) != 1 {
+		t.Fatalf("outer resume flushed %d notifications, want 1", len(rec.transformed))
+	}
+}
+
+// TestSetListenerNilDetaches: passing nil restores the silent listener so later
+// mutations don't panic and nothing is recorded.
+func TestSetListenerNilDetaches(t *testing.T) {
+	occ, rec := listenIn()
+	occ.SetListener(nil)
+	o := occ.AddByComponentDefinition("a:1", unitBox(), math.Identity4())
+	o.SetTransform(math.Translation4(math.V3(1, 0, 0)))
+	if len(rec.added) != 0 || len(rec.transformed) != 0 {
+		t.Errorf("detached listener still received calls: added=%d transformed=%d", len(rec.added), len(rec.transformed))
+	}
+}

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -66,8 +66,9 @@ func (o *Occurrence) Transform() math.Matrix4 { return o.transform }
 // It is the reference API's Transformation set / SetTransformWithoutConstraints:
 // constraint adjustment after a move is the solver's job (M12), not this call's.
 func (o *Occurrence) SetTransform(m math.Matrix4) {
+	previous := o.transform
 	o.transform = m
-	o.owner.bump()
+	o.owner.transformed(o, previous)
 }
 
 // Suppressed reports whether the occurrence is excluded from the model — it
@@ -82,7 +83,7 @@ func (o *Occurrence) SetSuppressed(suppressed bool) {
 		return
 	}
 	o.suppressed = suppressed
-	o.owner.bump()
+	o.owner.suppressed(o)
 }
 
 // Grounded reports whether the occurrence is fixed in space (the solver may not move

--- a/model/occurrence/occurrences.go
+++ b/model/occurrence/occurrences.go
@@ -7,17 +7,37 @@ import "oblikovati.org/math"
 // Occurrences is the collection of component occurrences an assembly owns — the
 // reference API's ComponentOccurrences (M11-F01/F02). It mints occurrence ids, tracks
 // a revision that advances on every structural or placement change (so the assembly's
-// geometry version derives from it), and unions its members' boxes.
+// geometry version derives from it), unions its members' boxes, and notifies a
+// [OccurrenceListener] of each mutation so the assembly raises domain events (M11-F07).
 type Occurrences struct {
 	items    []*Occurrence
 	byID     map[uint64]*Occurrence
 	nextID   uint64
 	revision uint64
+
+	listener OccurrenceListener
+	// Drag-batch state: while suspend > 0, per-occurrence transform notifications are
+	// withheld and coalesced. dragStart holds each moved occurrence's placement when the
+	// batch began; dragOrder preserves first-moved order so the resume flush is
+	// deterministic.
+	suspend   int
+	dragStart map[*Occurrence]math.Matrix4
+	dragOrder []*Occurrence
 }
 
-// NewOccurrences returns an empty occurrence collection.
+// NewOccurrences returns an empty occurrence collection with a silent (no-op) listener.
 func NewOccurrences() *Occurrences {
-	return &Occurrences{byID: map[uint64]*Occurrence{}}
+	return &Occurrences{byID: map[uint64]*Occurrence{}, listener: silentListener{}}
+}
+
+// SetListener installs the observer notified after each occurrence mutation, replacing
+// any previous one; pass nil to detach. The assembly definition installs its event
+// source here so occurrence changes raise domain events (M11-F07).
+func (c *Occurrences) SetListener(l OccurrenceListener) {
+	if l == nil {
+		l = silentListener{}
+	}
+	c.listener = l
 }
 
 // AddByComponentDefinition places def in the assembly under name with transform,
@@ -30,6 +50,7 @@ func (c *Occurrences) AddByComponentDefinition(name string, def Definition, tran
 	c.items = append(c.items, o)
 	c.byID[o.id] = o
 	c.bump()
+	c.listener.OccurrenceAdded(o)
 	return o
 }
 
@@ -43,8 +64,10 @@ func (c *Occurrences) Replace(o *Occurrence, def Definition) bool {
 	if c.byID[o.id] != o {
 		return false
 	}
+	previous := o.definition
 	o.definition = def
 	c.bump()
+	c.listener.OccurrenceReplaced(o, previous)
 	return true
 }
 
@@ -90,6 +113,7 @@ func (c *Occurrences) Remove(o *Occurrence) bool {
 		if existing == o {
 			c.items = append(c.items[:i], c.items[i+1:]...)
 			c.bump()
+			c.listener.OccurrenceRemoved(o)
 			return true
 		}
 	}
@@ -119,3 +143,60 @@ func (c *Occurrences) Revision() uint64 { return c.revision }
 
 // bump advances the revision after a mutation.
 func (c *Occurrences) bump() { c.revision++ }
+
+// transformed records a placement change for o (whose prior placement was previous):
+// it advances the revision and notifies the listener immediately, unless a drag batch
+// is active, in which case the notification is deferred and coalesced to a single call
+// at [Occurrences.ResumeNotifications]. Called by [Occurrence.SetTransform].
+func (c *Occurrences) transformed(o *Occurrence, previous math.Matrix4) {
+	c.bump()
+	if c.suspend == 0 {
+		c.listener.OccurrenceTransformed(o, previous)
+		return
+	}
+	if _, seen := c.dragStart[o]; !seen {
+		c.dragStart[o] = previous
+		c.dragOrder = append(c.dragOrder, o)
+	}
+}
+
+// suppressed records a suppression toggle for o and notifies the listener. Suppression
+// is a low-frequency, meaningful change, so it is never coalesced — it fires even
+// inside a drag batch. Called by [Occurrence.SetSuppressed].
+func (c *Occurrences) suppressed(o *Occurrence) {
+	c.bump()
+	c.listener.OccurrenceSuppressionChanged(o)
+}
+
+// SuspendNotifications begins a batch that coalesces per-occurrence transform
+// notifications until the matching [Occurrences.ResumeNotifications], so a solver drag
+// or drive animation raises one OccurrenceTransformed per moved occurrence instead of
+// one per step (M11-F07). Calls nest; the batch ends only when the outermost resumes.
+// The revision still advances per step — only the event stream is batched.
+func (c *Occurrences) SuspendNotifications() {
+	if c.suspend == 0 {
+		c.dragStart = map[*Occurrence]math.Matrix4{}
+		c.dragOrder = nil
+	}
+	c.suspend++
+}
+
+// ResumeNotifications ends a batch started by [Occurrences.SuspendNotifications],
+// flushing one OccurrenceTransformed per occurrence that ended the batch at a
+// different placement than it began (a net no-op move emits nothing), in first-moved
+// order. An unbalanced resume (no batch active) is ignored.
+func (c *Occurrences) ResumeNotifications() {
+	if c.suspend == 0 {
+		return
+	}
+	c.suspend--
+	if c.suspend > 0 {
+		return
+	}
+	for _, o := range c.dragOrder {
+		if start := c.dragStart[o]; o.transform != start {
+			c.listener.OccurrenceTransformed(o, start)
+		}
+	}
+	c.dragStart, c.dragOrder = nil, nil
+}


### PR DESCRIPTION
## What

Adds the `AssemblyEvents` source the reference API hangs off an assembly definition (M11-F07, #632), so add-ins **observe** occurrence lifecycle instead of polling occurrence state.

- **`occurrence.OccurrenceListener`** — an injected observer the `Occurrences` collection notifies after every mutation: add, remove, replace, transform, suppression. Null-object default (no nil checks); `SetListener(nil)` detaches.
- **`compdef.AssemblyEvents`** — implements the listener and raises typed events (`OccurrenceAdd/Delete/Replace/Transform/Suppress`) on an `event.Bus` subscribers attach to via `asm.Events().Bus()`. TypeIDs `0x0B0x` (high byte mirrors M11).
- **Veto (Before phase)** — `DeleteOccurrence` and `SetOccurrenceSuppressed` on the definition raise a vetoable Before event; a handler can cancel the change (`AssemblyVetoError`). The other mutations are After-only facts (they also cover programmatic edits).
- **Drag batching** — `SuspendNotifications`/`ResumeNotifications` coalesce a solver drag's per-step transforms into one event per moved occurrence (carrying its pre-batch placement, skipping net-zero moves), so animation doesn't flood subscribers. The geometry revision still advances per step.

## Why

M04 defers domain events to their owning milestones; M11 shipped no assembly event surface, so add-ins had to poll. This is the occurrence-lifecycle half of that surface.

## Scope / follow-ups

- **Constraint/joint (relationship) events** are intentionally absent — they depend on M12-F01 (#358).
- The **api/wire + client bridge** and the **addin relay** (curated push events) are the public-surface follow-up, matching the F06 cadence (model core first, public API split out).

## Tests

Volume-free, deterministic unit tests at both layers (occurrence listener/batching, and the event source end-to-end over the bus): structural events + payloads, transform/suppression, no-op silence, veto keeps state + suppresses After, drag coalescing (incl. net-zero and nested batches). Full suite + `-race` + `vet` + golangci-lint v2 all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)