### PR TITLE
model: assembly machining features in occurrence context (M11-F08)

### DIFF
--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/param"
 )
@@ -31,6 +32,7 @@ type AssemblyComponentDefinition struct {
 	occurrences *occurrence.Occurrences
 	units       param.UnitsOfMeasure // document display units (length/angle/…)
 	events      *AssemblyEvents      // occurrence-lifecycle event source (M11-F07)
+	features    *AssemblyFeatures    // assembly-authored machining features (M11-F08)
 }
 
 // NewAssemblyComponentDefinition returns an empty assembly content object: no
@@ -42,6 +44,7 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 		occurrences: occ,
 		units:       param.DefaultUnitsOfMeasure(),
 		events:      newAssemblyEvents(),
+		features:    NewAssemblyFeatures(),
 	}
 	occ.SetListener(a.events)
 	return a
@@ -117,6 +120,28 @@ func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *
 // changes raise typed events; delete and suppress are also vetoable in the Before
 // phase via [AssemblyComponentDefinition.DeleteOccurrence] and SetOccurrenceSuppressed.
 func (a *AssemblyComponentDefinition) Events() *AssemblyEvents { return a.events }
+
+// Features returns the assembly's machining-feature program — the features authored in
+// the assembly that cut/modify placed component geometry in place (M11-F08). Add a
+// feature with [AssemblyComponentDefinition.AddFeature] so it picks up default
+// participation; evaluate the program with [AssemblyComponentDefinition.RecomputeFeatures].
+func (a *AssemblyComponentDefinition) Features() *AssemblyFeatures { return a.features }
+
+// AddFeature appends an assembly machining feature wrapping f, defaulting its
+// participation to every component currently present (the reference API's behavior:
+// components added later do not participate unless added to the feature). It returns
+// the hosted feature so the caller can adjust participation or suppression.
+func (a *AssemblyComponentDefinition) AddFeature(f feature.Feature) *AssemblyFeature {
+	return a.features.Add(f, distinctSources(a.PlacedBodies()))
+}
+
+// RecomputeFeatures evaluates the assembly feature program against the current placed
+// geometry, machining each unsuppressed feature into its participants' assembly-space
+// bodies (not the shared part definitions) up to the end-of-features marker. Read the
+// per-occurrence results with [AssemblyFeatures.Result].
+func (a *AssemblyComponentDefinition) RecomputeFeatures() {
+	a.features.Recompute(a.PlacedBodies())
+}
 
 // DeleteOccurrence removes o from the assembly, first raising a vetoable OccurrenceDelete
 // in the Before phase; on commit the removal raises OccurrenceDelete After. It returns

--- a/model/compdef/assembly_features.go
+++ b/model/compdef/assembly_features.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"strconv"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/occurrence"
+)
+
+// endOfFeaturesAtEnd is the assembly EOF marker value meaning "evaluate every feature".
+const endOfFeaturesAtEnd = -1
+
+// AssemblyFeature is one machining feature authored in the assembly: a reused part
+// feature triangle ([feature.Feature]) plus the assembly-context state the part
+// engine has no notion of — which occurrences it participates on, its suppression,
+// and its evaluation health. Authored in the assembly, it cuts/modifies the placed
+// geometry of its participant occurrences in place, never the shared part definitions
+// (M11-F08, #633).
+type AssemblyFeature struct {
+	id           uint64
+	name         string
+	feature      feature.Feature
+	participants map[*occurrence.Occurrence]bool
+	order        []*occurrence.Occurrence // first-added participant order, for determinism
+	suppress     bool
+	health       health.Health
+}
+
+// ID returns the feature's stable handle within its collection (unchanged by rename).
+func (f *AssemblyFeature) ID() uint64 { return f.id }
+
+// Name/SetName get and set the display name; the id is stable across renames.
+func (f *AssemblyFeature) Name() string     { return f.name }
+func (f *AssemblyFeature) SetName(n string) { f.name = n }
+
+// Kind returns the wrapped feature's type name.
+func (f *AssemblyFeature) Kind() string { return f.feature.Kind() }
+
+// Definition returns the wrapped feature recipe (the reused part triangle).
+func (f *AssemblyFeature) Definition() feature.Feature { return f.feature }
+
+// Health returns the feature's current evaluation health.
+func (f *AssemblyFeature) Health() health.Health { return f.health }
+
+// Suppressed reports whether the feature is explicitly suppressed.
+func (f *AssemblyFeature) Suppressed() bool { return f.suppress }
+
+// SetSuppressed toggles explicit suppression. A suppressed assembly feature passes its
+// participants' geometry through unchanged on the next recompute.
+func (f *AssemblyFeature) SetSuppressed(s bool) { f.suppress = s }
+
+// AddParticipant adds o to the occurrences this feature machines (idempotent). Later-
+// added components do not participate until added here — matching the reference API,
+// where only components present when the feature is created participate by default.
+func (f *AssemblyFeature) AddParticipant(o *occurrence.Occurrence) {
+	if f.participants[o] {
+		return
+	}
+	f.participants[o] = true
+	f.order = append(f.order, o)
+}
+
+// RemoveParticipant drops o from participation (idempotent), so the feature no longer
+// affects that occurrence.
+func (f *AssemblyFeature) RemoveParticipant(o *occurrence.Occurrence) {
+	if !f.participants[o] {
+		return
+	}
+	delete(f.participants, o)
+	for i, p := range f.order {
+		if p == o {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+}
+
+// Participates reports whether o is in this feature's participation set.
+func (f *AssemblyFeature) Participates(o *occurrence.Occurrence) bool { return f.participants[o] }
+
+// Participants returns the participant occurrences in first-added order.
+func (f *AssemblyFeature) Participants() []*occurrence.Occurrence {
+	return append([]*occurrence.Occurrence(nil), f.order...)
+}
+
+// AssemblyFeatures is the assembly's ordered feature program and its participation
+// state — the assembly analogue of [feature.PartFeatures]. It hosts reused part
+// feature triangles in assembly context: it tracks an end-of-features rollback marker,
+// supports batch suppression, and on [AssemblyFeatures.Recompute] threads each
+// unsuppressed feature through the assembly-space bodies of its participant
+// occurrences, recording per-occurrence results without touching the shared part
+// definitions (M11-F08, #633).
+type AssemblyFeatures struct {
+	items  []*AssemblyFeature
+	byID   map[uint64]*AssemblyFeature
+	nextID uint64
+	eof    int // end-of-features feature index; endOfFeaturesAtEnd ⇒ full program
+	// result holds each participant occurrence's machined assembly-space bodies after
+	// the last recompute; see assembly_features_recompute.go.
+	result map[*occurrence.Occurrence][]*topo.Body
+}
+
+// NewAssemblyFeatures returns an empty assembly feature program with the EOF marker at
+// the end (every feature evaluated).
+func NewAssemblyFeatures() *AssemblyFeatures {
+	return &AssemblyFeatures{byID: map[uint64]*AssemblyFeature{}, eof: endOfFeaturesAtEnd}
+}
+
+// Add appends an assembly feature wrapping f, participating on the given occurrences
+// (the default participation the assembly snapshots from the components present). The
+// feature starts unsuppressed and healthy.
+func (fs *AssemblyFeatures) Add(f feature.Feature, participants []*occurrence.Occurrence) *AssemblyFeature {
+	fs.nextID++
+	af := &AssemblyFeature{
+		id:           fs.nextID,
+		name:         f.Kind(),
+		feature:      f,
+		participants: map[*occurrence.Occurrence]bool{},
+		health:       health.Healthy,
+	}
+	for _, o := range participants {
+		af.AddParticipant(o)
+	}
+	fs.items = append(fs.items, af)
+	fs.byID[af.id] = af
+	return af
+}
+
+// Remove deletes the feature with the given id, reporting whether it was present.
+func (fs *AssemblyFeatures) Remove(id uint64) bool {
+	if _, ok := fs.byID[id]; !ok {
+		return false
+	}
+	delete(fs.byID, id)
+	for i, af := range fs.items {
+		if af.id == id {
+			fs.items = append(fs.items[:i], fs.items[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+// Count returns the number of features; Item returns the i-th in history order.
+func (fs *AssemblyFeatures) Count() int                  { return len(fs.items) }
+func (fs *AssemblyFeatures) Item(i int) *AssemblyFeature { return fs.items[i] }
+
+// ByID returns the feature with the given id.
+func (fs *AssemblyFeatures) ByID(id uint64) (*AssemblyFeature, bool) {
+	f, ok := fs.byID[id]
+	return f, ok
+}
+
+// ByName returns the first feature with the given name.
+func (fs *AssemblyFeatures) ByName(name string) (*AssemblyFeature, bool) {
+	for _, f := range fs.items {
+		if f.name == name {
+			return f, true
+		}
+	}
+	return nil, false
+}
+
+// UniqueName returns base suffixed with the smallest positive integer not already a
+// feature name, so the browser shows distinct rows (mirrors PartFeatures.UniqueName).
+func (fs *AssemblyFeatures) UniqueName(base string) string {
+	for n := 1; ; n++ {
+		name := base + strconv.Itoa(n)
+		if _, taken := fs.ByName(name); !taken {
+			return name
+		}
+	}
+}
+
+// EndOfFeaturesPosition returns the feature index the program evaluates up to, or -1
+// when every feature is evaluated (the marker is at the end).
+func (fs *AssemblyFeatures) EndOfFeaturesPosition() int { return fs.eof }
+
+// IsRolledBack reports whether the EOF marker sits before the end of the program, so
+// some trailing features are currently rolled back (not evaluated).
+func (fs *AssemblyFeatures) IsRolledBack() bool { return fs.eof != endOfFeaturesAtEnd }
+
+// SetEndOfFeatures moves the EOF marker to position, rolling the assembly back to that
+// point; features at or after it are skipped on the next recompute. A negative
+// position restores the marker to the end (see [AssemblyFeatures.RollToEnd]).
+func (fs *AssemblyFeatures) SetEndOfFeatures(position int) {
+	if position < 0 {
+		position = endOfFeaturesAtEnd
+	}
+	fs.eof = position
+}
+
+// RollToEnd moves the EOF marker back to the end, re-including every feature.
+func (fs *AssemblyFeatures) RollToEnd() { fs.SetEndOfFeatures(endOfFeaturesAtEnd) }
+
+// SuppressFeatures suppresses every named feature in one batch — the reference API's
+// SuppressFeatures. Unknown ids are ignored.
+func (fs *AssemblyFeatures) SuppressFeatures(ids ...uint64) { fs.setSuppressed(ids, true) }
+
+// UnsuppressFeatures clears suppression on every named feature in one batch — the
+// reference API's UnsuppressFeatures. Unknown ids are ignored.
+func (fs *AssemblyFeatures) UnsuppressFeatures(ids ...uint64) { fs.setSuppressed(ids, false) }
+
+// setSuppressed applies a suppression state to each named feature that exists.
+func (fs *AssemblyFeatures) setSuppressed(ids []uint64, suppressed bool) {
+	for _, id := range ids {
+		if af, ok := fs.byID[id]; ok {
+			af.suppress = suppressed
+		}
+	}
+}
+
+// effectiveEnd returns the evaluation cutoff (the EOF marker, clamped to the length).
+func (fs *AssemblyFeatures) effectiveEnd() int {
+	if fs.eof == endOfFeaturesAtEnd || fs.eof > len(fs.items) {
+		return len(fs.items)
+	}
+	return fs.eof
+}

--- a/model/compdef/assembly_features_recompute.go
+++ b/model/compdef/assembly_features_recompute.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"errors"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/occurrence"
+)
+
+// Recompute evaluates the assembly feature program against placed (the assembly's
+// flattened, occurrence-attributed bodies). It machines each unsuppressed feature, up
+// to the end-of-features marker, into the assembly-space copy of each participant
+// occurrence's bodies — never the shared part definitions — and records the per-
+// occurrence result. Each feature's health reflects how its participants evaluated.
+//
+// The shared definitions stay untouched because the running bodies are assembly-space
+// COPIES (each placed body is transformed into assembly space first), so a boolean
+// rewrites the copy, not the part's own B-rep.
+func (fs *AssemblyFeatures) Recompute(placed []feature.PlacedBody) {
+	groups := groupPlacedBodies(placed)
+	end := fs.effectiveEnd()
+	for i := 0; i < end; i++ {
+		fs.evaluate(fs.items[i], groups)
+	}
+	fs.result = groups
+}
+
+// Result returns o's machined assembly-space bodies after the last recompute, or nil
+// if o did not participate (or no recompute has run). The returned slice is the live
+// result, so callers that mutate it must copy first.
+func (fs *AssemblyFeatures) Result(o *occurrence.Occurrence) []*topo.Body {
+	return fs.result[o]
+}
+
+// evaluate machines one feature into its participants' running bodies, aggregating the
+// outcome into its health. A suppressed feature passes every participant through
+// unchanged (the reference behavior: a suppressed assembly feature contributes no
+// machining), mirroring the part engine's suppressed-passthrough.
+func (fs *AssemblyFeatures) evaluate(af *AssemblyFeature, groups map[*occurrence.Occurrence][]*topo.Body) {
+	if af.suppress {
+		af.health = health.Health{Status: health.Suppressed}
+		return
+	}
+	deferred, sick := false, false
+	for _, o := range af.order {
+		bodies, present := groups[o]
+		if !present {
+			continue // a participant with no current geometry (e.g. suppressed occurrence)
+		}
+		out, err := af.feature.Recompute(feature.Input{Bodies: bodies})
+		switch {
+		case err == nil:
+			groups[o] = out.Bodies
+		case isDeferred(err):
+			deferred = true
+		default:
+			sick = true // a failed participant keeps its pre-feature geometry (passthrough)
+		}
+	}
+	af.health = featureHealth(deferred, sick)
+}
+
+// featureHealth maps a feature's aggregated participant outcomes to a single health,
+// mirroring the part engine's classify policy: any hard failure sickens the feature,
+// otherwise a deferred participant warns, otherwise it is healthy.
+func featureHealth(deferred, sick bool) health.Health {
+	switch {
+	case sick:
+		return health.Sicken("assembly feature failed on a participant occurrence")
+	case deferred:
+		return health.Health{Status: health.Warning, Reason: feature.ErrDeferred.Error()}
+	default:
+		return health.Healthy
+	}
+}
+
+// isDeferred reports whether err is (or wraps) the engine's deferred-geometry signal,
+// so a participant whose feature only deferred warns rather than sickens — matching the
+// part engine's errors.Is classification.
+func isDeferred(err error) bool { return errors.Is(err, feature.ErrDeferred) }
+
+// groupPlacedBodies transforms each placed body into its assembly-space copy and groups
+// the copies by the occurrence that places them. A body whose transform is degenerate
+// is skipped (it cannot be placed); such cases do not occur for rigid occurrence
+// placements but are handled rather than panicking.
+func groupPlacedBodies(placed []feature.PlacedBody) map[*occurrence.Occurrence][]*topo.Body {
+	groups := map[*occurrence.Occurrence][]*topo.Body{}
+	for i, pb := range placed {
+		copyBody, err := ops.TransformBody(pb.Body, pb.Transform, asmFeatureLineage(i))
+		if err != nil {
+			continue
+		}
+		groups[pb.Source] = append(groups[pb.Source], copyBody)
+	}
+	return groups
+}
+
+// asmFeatureLineage gives each placed copy a distinct lineage prefix, so the same part
+// placed at several occurrences yields independent reference keys in the machined
+// result (mirrors the derived-assembly flatten's per-occurrence lineage).
+func asmFeatureLineage(index int) func(topo.Lineage) topo.Lineage {
+	prefix := topo.Tok("assemblyFeature", "occ", index)
+	return func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append([]topo.LineageToken{prefix}, l.Tokens()...)...)
+	}
+}
+
+// distinctSources returns the occurrences that contribute geometry to placed, in
+// first-seen order — the default participation an assembly feature snapshots (every
+// component present participates). It does not transform bodies; it only lists the
+// source occurrences.
+func distinctSources(placed []feature.PlacedBody) []*occurrence.Occurrence {
+	seen := map[*occurrence.Occurrence]bool{}
+	var order []*occurrence.Occurrence
+	for _, pb := range placed {
+		if seen[pb.Source] {
+			continue
+		}
+		seen[pb.Source] = true
+		order = append(order, pb.Source)
+	}
+	return order
+}

--- a/model/compdef/assembly_features_test.go
+++ b/model/compdef/assembly_features_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	stdmath "math"
+	"strconv"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/occurrence"
+)
+
+// topHalfCutter builds an assembly-space tool box spanning a wide X range that, cut
+// from a unit box, removes its top half (z ∈ [0.5,1]) — half the volume.
+func topHalfCutter(t *testing.T) *topo.Body {
+	t.Helper()
+	tool, err := brep.SolidBlock(math.P3(-1, -1, 0.5), math.P3(100, 2, 2), "asmTool")
+	if err != nil {
+		t.Fatalf("SolidBlock cutter: %v", err)
+	}
+	return tool
+}
+
+// resultVolume sums o's machined assembly-space result bodies' volumes, for analytic
+// gating of the assembly feature program.
+func resultVolume(fs *AssemblyFeatures, o *occurrence.Occurrence) float64 {
+	v := 0.0
+	for _, b := range fs.Result(o) {
+		v += ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+	}
+	return v
+}
+
+// assemblyOfUnitBoxes places one unit-box part at each given X translation and returns
+// the assembly and the occurrences in order.
+func assemblyOfUnitBoxes(t *testing.T, xs ...float64) (*AssemblyComponentDefinition, []*occurrence.Occurrence) {
+	t.Helper()
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	asm := NewAssemblyComponentDefinition()
+	occs := make([]*occurrence.Occurrence, len(xs))
+	for i, x := range xs {
+		occs[i] = asm.Place("box:"+strconv.Itoa(i+1), part, math.Translation4(math.V3(x, 0, 0)))
+	}
+	return asm, occs
+}
+
+// TestAddFeatureDefaultsParticipationToPresentComponents: an added feature participates
+// on every component present at add time, and not on components added later (the
+// reference API's default-participation rule).
+func TestAddFeatureDefaultsParticipationToPresentComponents(t *testing.T) {
+	asm, occs := assemblyOfUnitBoxes(t, 0, 5)
+	af := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+
+	if !af.Participates(occs[0]) || !af.Participates(occs[1]) {
+		t.Error("present components should participate by default")
+	}
+	if got := len(af.Participants()); got != 2 {
+		t.Fatalf("default participants = %d, want 2", got)
+	}
+
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	late := asm.Place("late:1", part, math.Translation4(math.V3(20, 0, 0)))
+	if af.Participates(late) {
+		t.Error("a component added after the feature should not participate by default")
+	}
+}
+
+// TestAssemblyFeatureMachinesParticipantsGated gates the whole host against analytic
+// volume: a top-half cut machines each participant to 0.5 and leaves a removed
+// participant (and the shared part definition) untouched at 1.0.
+func TestAssemblyFeatureMachinesParticipantsGated(t *testing.T) {
+	asm, occs := assemblyOfUnitBoxes(t, 0, 5, 20)
+	af := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	af.RemoveParticipant(occs[2]) // box 3 opts out
+
+	asm.RecomputeFeatures()
+
+	for i := 0; i < 2; i++ {
+		if got := resultVolume(asm.Features(), occs[i]); stdmath.Abs(got-0.5) > 1e-6 {
+			t.Errorf("participant %d machined volume = %g, want 0.5", i, got)
+		}
+	}
+	if got := resultVolume(asm.Features(), occs[2]); stdmath.Abs(got-1.0) > 1e-6 {
+		t.Errorf("non-participant machined volume = %g, want 1.0 (untouched)", got)
+	}
+	// The shared part definition is unchanged — its own body is still a full unit box.
+	shared := occs[0].Definition().(*PartComponentDefinition)
+	sharedVol := ops.BodyGeometryProperties(shared.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+	if stdmath.Abs(sharedVol-1.0) > 1e-6 {
+		t.Errorf("shared part definition volume = %g, want 1.0 (assembly cut must not edit it)", sharedVol)
+	}
+}
+
+// TestSuppressedFeaturePassesGeometryThrough: a suppressed assembly feature machines
+// nothing (participants keep full volume) and reports Suppressed health; unsuppressing
+// re-applies it.
+func TestSuppressedFeaturePassesGeometryThrough(t *testing.T) {
+	asm, occs := assemblyOfUnitBoxes(t, 0)
+	af := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+
+	asm.Features().SuppressFeatures(af.ID())
+	asm.RecomputeFeatures()
+	if got := resultVolume(asm.Features(), occs[0]); stdmath.Abs(got-1.0) > 1e-6 {
+		t.Errorf("suppressed feature machined volume = %g, want 1.0 (passthrough)", got)
+	}
+	if af.Health().Status != health.Suppressed {
+		t.Errorf("suppressed feature health = %v, want Suppressed", af.Health().Status)
+	}
+
+	asm.Features().UnsuppressFeatures(af.ID())
+	asm.RecomputeFeatures()
+	if got := resultVolume(asm.Features(), occs[0]); stdmath.Abs(got-0.5) > 1e-6 {
+		t.Errorf("unsuppressed feature machined volume = %g, want 0.5", got)
+	}
+	if af.Health().Status != health.OK {
+		t.Errorf("recomputed feature health = %v, want OK", af.Health().Status)
+	}
+}
+
+// TestEndOfFeaturesRollsBackTrailingFeatures: the EOF marker bounds how far the program
+// evaluates, so rolling back drops trailing features' machining.
+func TestEndOfFeaturesRollsBackTrailingFeatures(t *testing.T) {
+	asm, occs := assemblyOfUnitBoxes(t, 0)
+	// F1 removes the top half (→0.5); F2 removes everything above z=0.25 of F1's result (→0.25).
+	asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	lower, _ := brep.SolidBlock(math.P3(-1, -1, 0.25), math.P3(100, 2, 2), "asmTool2")
+	asm.AddFeature(feature.NewAssemblyCutFeature(lower, ops.Cut))
+
+	asm.RecomputeFeatures()
+	if got := resultVolume(asm.Features(), occs[0]); stdmath.Abs(got-0.25) > 1e-6 {
+		t.Errorf("full program volume = %g, want 0.25 (both cuts)", got)
+	}
+
+	asm.Features().SetEndOfFeatures(1) // evaluate only F1
+	if !asm.Features().IsRolledBack() {
+		t.Error("IsRolledBack = false after SetEndOfFeatures(1), want true")
+	}
+	asm.RecomputeFeatures()
+	if got := resultVolume(asm.Features(), occs[0]); stdmath.Abs(got-0.5) > 1e-6 {
+		t.Errorf("rolled-back volume = %g, want 0.5 (only F1)", got)
+	}
+
+	asm.Features().RollToEnd()
+	asm.RecomputeFeatures()
+	if got := resultVolume(asm.Features(), occs[0]); stdmath.Abs(got-0.25) > 1e-6 {
+		t.Errorf("rolled-to-end volume = %g, want 0.25 (both cuts again)", got)
+	}
+}
+
+// TestAssemblyFeaturesLookupsAndRemove covers the collection bookkeeping: unique
+// naming, id/name lookup, removal, and count.
+func TestAssemblyFeaturesLookupsAndRemove(t *testing.T) {
+	asm, _ := assemblyOfUnitBoxes(t, 0)
+	fs := asm.Features()
+	a := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	a.SetName(fs.UniqueName("assemblyCut"))
+	b := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	b.SetName(fs.UniqueName("assemblyCut"))
+
+	if a.Name() == b.Name() {
+		t.Errorf("UniqueName returned duplicate %q", a.Name())
+	}
+	if got, ok := fs.ByID(a.ID()); !ok || got != a {
+		t.Error("ByID did not return the feature")
+	}
+	if got, ok := fs.ByName(b.Name()); !ok || got != b {
+		t.Error("ByName did not return the feature")
+	}
+	if !fs.Remove(a.ID()) || fs.Count() != 1 {
+		t.Errorf("after Remove: count = %d, want 1", fs.Count())
+	}
+	if _, ok := fs.ByID(a.ID()); ok {
+		t.Error("removed feature still resolves by id")
+	}
+}

--- a/model/feature/assembly_cut.go
+++ b/model/feature/assembly_cut.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// AssemblyCutFeature is an assembly-machining feature: a tool body authored in the
+// assembly's space, booleaned against each running body it is applied to. It is the
+// V1 representative of the part feature triangle reused in assembly context (M11-F08,
+// #633) — like [CombineFeature] it is a thin wrapper over [ops.Boolean], but its tool
+// is fixed in assembly space rather than picked from the running bodies, because an
+// assembly feature cuts placed component geometry, not a single part's bodies.
+//
+// The assembly host applies it once per participating occurrence, threading that
+// occurrence's assembly-space bodies through Recompute, so the same tool machines
+// every participant in place without touching the shared part definitions.
+//
+// Example: a slot milled through every bracket in an assembly —
+//
+//	tool, _ := brep.SolidBlock(min, max, "asmCut")
+//	f := feature.NewAssemblyCutFeature(tool, ops.Cut)
+type AssemblyCutFeature struct {
+	tool *topo.Body
+	op   ops.PartFeatureOperation
+}
+
+// NewAssemblyCutFeature returns an assembly feature that applies op with tool. op is
+// typically [ops.Cut] (machining away material); [ops.Join] adds the tool as shared
+// stock and [ops.Intersect] keeps the common volume.
+func NewAssemblyCutFeature(tool *topo.Body, op ops.PartFeatureOperation) *AssemblyCutFeature {
+	return &AssemblyCutFeature{tool: tool, op: op}
+}
+
+// Kind implements [Feature].
+func (f *AssemblyCutFeature) Kind() string { return "assemblyCut" }
+
+// Operation reports the boolean the feature applies, satisfying [OperationalFeature].
+func (f *AssemblyCutFeature) Operation() ops.PartFeatureOperation { return f.op }
+
+// ToolBody returns the assembly-space tool, satisfying [ToolFeature].
+func (f *AssemblyCutFeature) ToolBody() *topo.Body { return f.tool }
+
+// Recompute booleans the tool against every running body, replacing each with its
+// result (an empty result — the tool consumed the whole body — drops it). A missing
+// tool is a lost-input failure the engine turns into feature health, not a panic.
+func (f *AssemblyCutFeature) Recompute(in Input) (Output, error) {
+	if f.tool == nil {
+		return Output{}, fmt.Errorf("assemblyCut: nil tool body")
+	}
+	out := make([]*topo.Body, 0, len(in.Bodies))
+	for i, target := range in.Bodies {
+		res, err := ops.Boolean(f.op, target, f.tool)
+		if err != nil {
+			return Output{}, fmt.Errorf("assemblyCut: boolean on body %d: %w", i, err)
+		}
+		if res != nil && len(res.Faces()) > 0 {
+			out = append(out, res)
+		}
+	}
+	return Output{Bodies: out}, nil
+}

--- a/model/feature/assembly_cut_test.go
+++ b/model/feature/assembly_cut_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+)
+
+// unitBlock builds the solid box [0,1]³ (volume 1) used as an assembly-cut target.
+func unitBlock(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(1, 1, 1), "target")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// TestAssemblyCutRemovesToolVolume gates the cut against the analytic value: a tool
+// covering the top half of a unit box removes exactly 0.5 of its volume.
+func TestAssemblyCutRemovesToolVolume(t *testing.T) {
+	tool, err := brep.SolidBlock(gmath.P3(-1, -1, 0.5), gmath.P3(2, 2, 2), "tool")
+	if err != nil {
+		t.Fatalf("SolidBlock tool: %v", err)
+	}
+	f := NewAssemblyCutFeature(tool, ops.Cut)
+
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 1 {
+		t.Fatalf("result bodies = %d, want 1", len(out.Bodies))
+	}
+	if got := bodyVolume(out.Bodies[0]); math.Abs(got-0.5) > 1e-6 {
+		t.Errorf("cut volume = %g, want 0.5 (top half removed)", got)
+	}
+}
+
+// TestAssemblyCutAppliesToEveryBody confirms the tool machines each running body, so
+// applying it across N targets cuts all N (the assembly host relies on this to machine
+// a participant's several bodies in one Recompute).
+func TestAssemblyCutAppliesToEveryBody(t *testing.T) {
+	tool, _ := brep.SolidBlock(gmath.P3(-1, -1, 0.5), gmath.P3(2, 2, 2), "tool")
+	f := NewAssemblyCutFeature(tool, ops.Cut)
+
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t), unitBlock(t)}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 2 {
+		t.Fatalf("result bodies = %d, want 2", len(out.Bodies))
+	}
+	for i, b := range out.Bodies {
+		if got := bodyVolume(b); math.Abs(got-0.5) > 1e-6 {
+			t.Errorf("body %d cut volume = %g, want 0.5", i, got)
+		}
+	}
+}
+
+// TestAssemblyCutDropsFullyConsumedBody: a tool that fully encloses the target removes
+// the whole body, so the result drops it rather than carrying an empty body.
+func TestAssemblyCutDropsFullyConsumedBody(t *testing.T) {
+	tool, _ := brep.SolidBlock(gmath.P3(-1, -1, -1), gmath.P3(2, 2, 2), "tool")
+	f := NewAssemblyCutFeature(tool, ops.Cut)
+
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 0 {
+		t.Errorf("result bodies = %d, want 0 (target fully consumed)", len(out.Bodies))
+	}
+}
+
+// TestAssemblyCutNilToolFails: a missing tool is a lost input the engine can turn into
+// feature health, reported as an error rather than a panic.
+func TestAssemblyCutNilToolFails(t *testing.T) {
+	f := NewAssemblyCutFeature(nil, ops.Cut)
+	if _, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}}); err == nil {
+		t.Fatal("Recompute with nil tool returned nil error, want a failure")
+	}
+}


### PR DESCRIPTION
## What

Adds **assembly features** — features authored *in the assembly* that machine the placed geometry of their participant occurrences in place, never editing the shared part definitions. This is the reference API's `AssemblyFeatures` (M11-F08, #633), the assembly-context hosting the part feature engine has no notion of.

- **`feature.AssemblyCutFeature`** — a reused part feature triangle whose tool is fixed in the assembly's space (vs picked from running bodies), booleaned against each body it is applied to. The V1 representative machining feature.
- **`compdef.AssemblyFeatures`** — the assembly's ordered feature program:
  - **per-feature occurrence participation** — default participation is every component present at add time; components added later do not participate unless added (`AddParticipant`/`RemoveParticipant`/`Participates`), matching the reference behavior.
  - **end-of-features rollback marker** — `SetEndOfFeatures`/`RollToEnd`/`IsRolledBack`.
  - **batch suppression** — `SuppressFeatures`/`UnsuppressFeatures`.
  - **`Recompute`** threads each unsuppressed feature, up to the EOF marker, through the assembly-space **copies** of its participants' bodies (so shared part defs stay untouched), recording per-occurrence results; feature health mirrors the part engine's classify policy.
- **`AssemblyComponentDefinition.AddFeature`/`Features`/`RecomputeFeatures`** wire it onto the assembly, defaulting participation from `PlacedBodies`.

## Why

M20 excludes assembly features and points at M11/M12, but no issue covered them. This delivers the model core so machining-after-placement works end to end on flat assemblies of parts.

## Verification

- **Volume-gated** against analytic values: a top-half cut machines each participant unit box to exactly 0.5; a removed participant and the shared part definition stay at 1.0.
- Tests cover default participation, late-added non-participation, suppression passthrough + health, EOF rollback, and collection bookkeeping.
- `go test ./model/...`, `-race`, `go vet`, golangci-lint v2 all green.

## Deferred (per the M11 model-first cadence)

- Public push surface (`api/types`·`wire`·`client`·`contract` + addin relay) — follow-up issue.
- Proxy-sketch feature inputs from occurrence geometry (#347) and nested sub-assembly participation paths.

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)