### PR TITLE
addin/events: relay assembly occurrence events to the wire (M11-F07)

### DIFF
--- a/addin/events/assembly_relay.go
+++ b/addin/events/assembly_relay.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"sync"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/occurrence"
+)
+
+// Assembly occurrence events fire on a bus owned by each assembly's component
+// definition (compdef.AssemblyEvents), not on the session or workspace bus — so the
+// relay cannot subscribe once at startup. subscribeAssemblies watches the workspace
+// for assembly documents and wires each one's bus to the sink, rewiring if a
+// document's content is swapped and unwiring when it closes (M11-F07, #723).
+
+// SubscribeAssembly wires one assembly definition's occurrence bus to sink, tagging
+// every relayed event with document so an add-in can attribute it. It returns the
+// five subscriptions (add/delete/replace/transform/suppress) so the caller can cancel
+// them. This is the pure relay — the host-facing wiring is [subscribeAssemblies].
+func SubscribeAssembly(bus *event.Bus, document doc.ID, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e compdef.OccurrenceAdd) event.Outcome {
+			return relayJSON(sink, occurrencePayload(wire.EventOccurrenceAdded, document, e.Occurrence))
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e compdef.OccurrenceDelete) event.Outcome {
+			return relayJSON(sink, occurrencePayload(wire.EventOccurrenceDeleted, document, e.Occurrence))
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e compdef.OccurrenceReplace) event.Outcome {
+			return relayJSON(sink, occurrencePayload(wire.EventOccurrenceReplaced, document, e.Occurrence))
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e compdef.OccurrenceTransform) event.Outcome {
+			return relayJSON(sink, transformPayload(document, e.Occurrence, e.Previous))
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e compdef.OccurrenceSuppress) event.Outcome {
+			p := occurrencePayload(wire.EventOccurrenceSuppressed, document, e.Occurrence)
+			p.Suppressed = e.Suppressed
+			return relayJSON(sink, p)
+		}),
+	}
+}
+
+// occurrencePayload renders an occurrence's identity (document, session id, instance
+// name) into the shared wire payload for the given event type.
+func occurrencePayload(eventType string, document doc.ID, o *occurrence.Occurrence) wire.OccurrenceEventPayload {
+	return wire.OccurrenceEventPayload{
+		Type:       eventType,
+		Document:   uint64(document),
+		Occurrence: o.ID(),
+		Name:       o.Name(),
+	}
+}
+
+// transformPayload renders an occurrence move, carrying its new placement and the
+// prior one (for a coalesced drag, previous is the pre-drag placement).
+func transformPayload(document doc.ID, o *occurrence.Occurrence, previous math.Matrix4) wire.OccurrenceEventPayload {
+	p := occurrencePayload(wire.EventOccurrenceTransformed, document, o)
+	cur := wireMatrix(o.Transform())
+	prev := wireMatrix(previous)
+	p.Transform, p.Previous = &cur, &prev
+	return p
+}
+
+// wireMatrix converts a model transform to the contract's matrix value type.
+func wireMatrix(m math.Matrix4) types.Matrix { return types.Matrix{Cells: m.Cells()} }
+
+// subscribeAssemblies watches the workspace document bus and keeps each open
+// assembly document's occurrence bus wired to sink. It wires on create and activate
+// (reading the live content, since AddAssembly installs the real definition after the
+// create event) and unwires on close, deduping by bus identity so a content swap
+// rewires exactly once.
+func subscribeAssemblies(ws *event.Bus, sink Sink) []event.Subscription {
+	w := &assemblyWatcher{sink: sink, wired: map[doc.ID]wiredAssembly{}}
+	return []event.Subscription{
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentCreated) event.Outcome {
+			w.wire(e.Document)
+			return event.Continue()
+		}),
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentActivate) event.Outcome {
+			w.wire(e.Document)
+			return event.Continue()
+		}),
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentClose) event.Outcome {
+			w.unwire(e.Document.ID())
+			return event.Continue()
+		}),
+	}
+}
+
+// wiredAssembly records which bus a document is wired to and the relay subscriptions,
+// so a content swap (different bus) can be detected and the old subscriptions cancelled.
+type wiredAssembly struct {
+	bus  *event.Bus
+	subs []event.Subscription
+}
+
+// assemblyWatcher tracks the per-document occurrence-bus relays. Its map is guarded
+// because document lifecycle events and occurrence events may fire from different
+// goroutines.
+type assemblyWatcher struct {
+	sink  Sink
+	mu    sync.Mutex
+	wired map[doc.ID]wiredAssembly
+}
+
+// wire subscribes d's assembly occurrence bus to the sink, if d holds assembly content
+// not already wired to that same bus. A document whose content was swapped to a new
+// assembly definition (a different bus) has its stale relay cancelled and replaced.
+func (w *assemblyWatcher) wire(d *doc.Document) {
+	asm, ok := d.Content().(*compdef.AssemblyComponentDefinition)
+	if !ok {
+		return
+	}
+	bus := asm.Events().Bus()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if cur, ok := w.wired[d.ID()]; ok {
+		if cur.bus == bus {
+			return
+		}
+		cancelAll(cur.subs)
+	}
+	w.wired[d.ID()] = wiredAssembly{bus: bus, subs: SubscribeAssembly(bus, d.ID(), w.sink)}
+}
+
+// unwire cancels and forgets a document's occurrence relay (on close).
+func (w *assemblyWatcher) unwire(id doc.ID) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if cur, ok := w.wired[id]; ok {
+		cancelAll(cur.subs)
+		delete(w.wired, id)
+	}
+}
+
+// cancelAll cancels every subscription in subs.
+func cancelAll(subs []event.Subscription) {
+	for _, s := range subs {
+		s.Cancel()
+	}
+}

--- a/addin/events/assembly_relay_test.go
+++ b/addin/events/assembly_relay_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+// occRecorder collects the occurrence push events the relay forwards (thread-safe;
+// occurrence events may fire from any goroutine).
+type occRecorder struct {
+	mu  sync.Mutex
+	got []wire.OccurrenceEventPayload
+}
+
+func (r *occRecorder) sink(b []byte) {
+	var p wire.OccurrenceEventPayload
+	if err := json.Unmarshal(b, &p); err != nil {
+		return
+	}
+	r.mu.Lock()
+	r.got = append(r.got, p)
+	r.mu.Unlock()
+}
+
+// ofType returns the recorded payloads whose Type matches.
+func (r *occRecorder) ofType(eventType string) []wire.OccurrenceEventPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []wire.OccurrenceEventPayload
+	for _, p := range r.got {
+		if p.Type == eventType {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func (r *occRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.got)
+}
+
+// TestSubscribeAssemblyRelaysLifecycle drives the curated occurrence events through
+// the pure relay and checks each reaches the sink as the right wire payload, tagged
+// with the document.
+func TestSubscribeAssemblyRelaysLifecycle(t *testing.T) {
+	asm := compdef.NewAssemblyComponentDefinition()
+	var rec occRecorder
+	subs := SubscribeAssembly(asm.Events().Bus(), doc.ID(4), rec.sink)
+	defer cancelAll(subs)
+
+	part := compdef.NewPartComponentDefinition()
+	o := asm.Place("box:1", part, math.Identity4())
+	o.SetTransform(math.Translation4(math.V3(5, 0, 0)))
+	if err := asm.SetOccurrenceSuppressed(o, true); err != nil {
+		t.Fatalf("suppress: %v", err)
+	}
+	if err := asm.DeleteOccurrence(o); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	added := rec.ofType(wire.EventOccurrenceAdded)
+	if len(added) != 1 || added[0].Document != 4 || added[0].Occurrence != o.ID() || added[0].Name != "box:1" {
+		t.Fatalf("added events = %+v, want one for box:1 on document 4", added)
+	}
+	moved := rec.ofType(wire.EventOccurrenceTransformed)
+	if len(moved) != 1 || moved[0].Transform == nil || moved[0].Previous == nil {
+		t.Fatalf("transformed events = %+v, want one carrying both placements", moved)
+	}
+	if moved[0].Transform.Cells[3] != 5 || moved[0].Previous.Cells[3] != 0 {
+		t.Errorf("transform placements new/prior X = %v/%v, want 5/0", moved[0].Transform.Cells[3], moved[0].Previous.Cells[3])
+	}
+	supp := rec.ofType(wire.EventOccurrenceSuppressed)
+	if len(supp) != 1 || !supp[0].Suppressed {
+		t.Errorf("suppressed events = %+v, want one with Suppressed=true", supp)
+	}
+	if del := rec.ofType(wire.EventOccurrenceDeleted); len(del) != 1 {
+		t.Errorf("deleted events = %+v, want one", del)
+	}
+}
+
+// TestSubscribeAssemblyReplaceRelays checks the replace event surfaces (it carries
+// identity only — the swapped-in definition is re-queried by the add-in).
+func TestSubscribeAssemblyReplaceRelays(t *testing.T) {
+	asm := compdef.NewAssemblyComponentDefinition()
+	var rec occRecorder
+	subs := SubscribeAssembly(asm.Events().Bus(), doc.ID(1), rec.sink)
+	defer cancelAll(subs)
+
+	o := asm.Place("pin:1", compdef.NewPartComponentDefinition(), math.Identity4())
+	asm.Occurrences().Replace(o, compdef.NewPartComponentDefinition())
+
+	if rep := rec.ofType(wire.EventOccurrenceReplaced); len(rep) != 1 || rep[0].Occurrence != o.ID() {
+		t.Errorf("replaced events = %+v, want one for the occurrence", rep)
+	}
+}
+
+// TestSubscribeAssemblyCoalescesDrag pins the batch contract over the wire: a
+// suspended multi-step drag relays exactly one transformed push carrying the net move
+// (pre-drag placement as Previous, final as Transform).
+func TestSubscribeAssemblyCoalescesDrag(t *testing.T) {
+	asm := compdef.NewAssemblyComponentDefinition()
+	var rec occRecorder
+	subs := SubscribeAssembly(asm.Events().Bus(), doc.ID(2), rec.sink)
+	defer cancelAll(subs)
+
+	o := asm.Place("slider:1", compdef.NewPartComponentDefinition(), math.Identity4())
+
+	asm.Occurrences().SuspendNotifications()
+	for i := 1; i <= 50; i++ {
+		o.SetTransform(math.Translation4(math.V3(float64(i), 0, 0)))
+	}
+	asm.Occurrences().ResumeNotifications()
+
+	moved := rec.ofType(wire.EventOccurrenceTransformed)
+	if len(moved) != 1 {
+		t.Fatalf("drag relayed %d transformed pushes, want 1 (coalesced)", len(moved))
+	}
+	if moved[0].Transform.Cells[3] != 50 || moved[0].Previous.Cells[3] != 0 {
+		t.Errorf("coalesced move new/prior X = %v/%v, want 50/0 (net move)", moved[0].Transform.Cells[3], moved[0].Previous.Cells[3])
+	}
+}
+
+// TestSubscribeAssembliesWiresActivatedDocument checks the workspace watcher wires an
+// assembly document's bus on activation (after AddAssembly installs the live content)
+// and relays its occurrence events, and stops once the document closes.
+func TestSubscribeAssembliesWiresActivatedDocument(t *testing.T) {
+	s := app.NewSession()
+	var rec occRecorder
+	subs := subscribeAssemblies(s.Workspace().Events(), rec.sink)
+	defer cancelAll(subs)
+
+	d, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(d); err != nil { // rewires to the live content's bus
+		t.Fatalf("activate: %v", err)
+	}
+	asm := d.Content().(*compdef.AssemblyComponentDefinition)
+	asm.Place("box:1", compdef.NewPartComponentDefinition(), math.Identity4())
+
+	added := rec.ofType(wire.EventOccurrenceAdded)
+	if len(added) != 1 || added[0].Document != uint64(d.ID()) {
+		t.Fatalf("after activate, added events = %+v, want one tagged with document %d", added, d.ID())
+	}
+
+	// After close, further mutation must not relay.
+	before := rec.count()
+	if err := s.Workspace().Close(d, true); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	asm.Place("box:2", compdef.NewPartComponentDefinition(), math.Identity4())
+	if rec.count() != before {
+		t.Errorf("relayed %d events after close, want %d (unwired)", rec.count()-before, 0)
+	}
+}

--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -57,6 +57,7 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 	)
 	subs = append(subs, subscribeTransactions(bus, sink)...)
 	subs = append(subs, subscribeFileAccess(s.Workspace().Events(), sink)...)
+	subs = append(subs, subscribeAssemblies(s.Workspace().Events(), sink)...)
 	subs = append(subs, subscribeFileUIHooks(bus, sink)...)
 	return append(subs, subscribeUISurfaces(bus, sink)...)
 }
@@ -170,7 +171,7 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.TriadDragEvent | wire.TriadSegmentEvent | wire.ManipulatorDragEvent |
 	wire.ClientOperationEvent | wire.TransactionEventPayload |
 	wire.FileResolutionEventPayload | wire.FileDirtyEventPayload |
-	wire.FileDialogHookPayload](sink Sink, ev E) event.Outcome {
+	wire.FileDialogHookPayload | wire.OccurrenceEventPayload](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/events/lifecycle_relay_test.go
+++ b/addin/events/lifecycle_relay_test.go
@@ -128,10 +128,3 @@ func TestForwardsFileEvents(t *testing.T) {
 		t.Errorf("file.openDialog payload = %+v, want the supplied path", hook)
 	}
 }
-
-// cancelAll cancels every subscription (the shutdown path Subscribe documents).
-func cancelAll(subs []event.Subscription) {
-	for _, sub := range subs {
-		sub.Cancel()
-	}
-}


### PR DESCRIPTION
## What

Completes the M11-F07 public push surface (#723) — part 2 of ADR-0018. The wire/client contract merged in [Oblikovati.API#73](https://github.com/Oblikovati/Oblikovati.API/pull/73); this is the GPL relay that bridges the internal assembly event bus to it.

- **`SubscribeAssembly(bus, document, sink)`** — the pure relay. Wires one assembly's occurrence bus to the add-in `Sink`: add/delete/replace/transform/suppress are forwarded as `wire.OccurrenceEventPayload`, tagged with the document id. A drag-coalesced transform (the model's `Suspend`/`ResumeNotifications`) relays **one** net-move push.
- **`subscribeAssemblies(ws, sink)`** — watches the workspace document bus and keeps each open assembly's occurrence bus wired to the sink, deduping by bus identity (so `AddAssembly`'s post-create content swap rewires exactly once) and unwiring on close. Wired into `events.Subscribe`.

## Why

Occurrence events fire on a bus owned by each assembly's component definition, not the session/workspace bus — so add-ins previously could not subscribe and would have to poll occurrence state.

## Verification

Relay tests round-trip the curated set: place/move/suppress/delete → exactly the right `occurrence.*` payloads with identity + placements decoded; **drag → one coalesced transform push** carrying the net move; the workspace watcher wires an activated assembly document and stops relaying after it closes. `go test ./...`, `-race`, `go vet`, golangci-lint v2 all green.

## Notes / scope

- **Constraint/joint (relationship) events** depend on M12-F01 (#358) and join this surface once relationships exist.
- A `contract.AssemblyEvents` Go interface is intentionally omitted: like every other event family (transaction/file/UI), occurrence events cross the boundary as JSON over the C-ABI Notify, not as an in-proc Go interface.
- Occurrence request/response **methods** (place/move/etc. over the wire) are the separate model→API surface tracked by #716.

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)