### PR TITLE
addin/router: assembly derive/shrinkwrap methods (M11-F06)

### DIFF
--- a/addin/router/assembly_derive.go
+++ b/addin/router/assembly_derive.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// The assembly derive/shrinkwrap surface (M11-F06, #631/#716): derive a source
+// assembly into the active part as a base body — optionally simplified into a
+// lightweight shrinkwrap — and break the link to freeze the result. Each create adds a
+// feature to the active part and returns its refreshed detail; break-link addresses
+// the feature by its stable id.
+
+// registerAssemblyDeriveHandlers wires the assembly.* derive/shrinkwrap methods.
+func (r *Router) registerAssemblyDeriveHandlers() {
+	r.handlers[wire.MethodAssemblyDeriveCreate] = assemblyDeriveCreate
+	r.handlers[wire.MethodAssemblyShrinkwrapCreate] = assemblyShrinkwrapCreate
+	r.handlers[wire.MethodAssemblyDeriveBreakLink] = assemblyDeriveBreakLink
+}
+
+// assemblyDeriveCreate derives the source assembly document into the active part as a
+// base body (include-all) and returns the new feature's detail.
+func assemblyDeriveCreate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, source, err := resolveDeriveSource(s, raw, wire.MethodAssemblyDeriveCreate)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDerivedAssemblyComponents(part.Features()).AddDerived(source)
+	return commitNewDerive(part, pf)
+}
+
+// assemblyShrinkwrapCreate derives the source assembly into the active part as a
+// simplified, lightweight base body per the removal/envelope options.
+func assemblyShrinkwrapCreate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ShrinkwrapCreateArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	source, err := assemblySource(s, in.Source, wire.MethodAssemblyShrinkwrapCreate)
+	if err != nil {
+		return nil, err
+	}
+	def, err := shrinkwrapDefinition(in)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewShrinkwrapComponents(part.Features()).AddShrinkwrap(source, def)
+	return commitNewDerive(part, pf)
+}
+
+// assemblyDeriveBreakLink freezes and severs a derived-assembly or shrinkwrap feature's
+// source link, addressed by its stable id.
+func assemblyDeriveBreakLink(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.DeriveBreakLinkArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pf, idx, err := partFeatureByID(part, in.ID, wire.MethodAssemblyDeriveBreakLink)
+	if err != nil {
+		return nil, err
+	}
+	linked, ok := pf.Definition().(interface{ BreakLink() error })
+	if !ok {
+		return nil, fmt.Errorf("%s: feature %d is a %s, not a derived/shrinkwrap component",
+			wire.MethodAssemblyDeriveBreakLink, in.ID, pf.Kind())
+	}
+	if err := linked.BreakLink(); err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyDeriveBreakLink, err)
+	}
+	part.Recompute()
+	return featureDetailReply(part, pf, idx)
+}
+
+// resolveDeriveSource resolves the active part and the DeriveCreateArgs source
+// assembly, shared by the derive create handler.
+func resolveDeriveSource(s *app.Session, raw json.RawMessage, method string) (*compdef.PartComponentDefinition, feature.AssemblyBodySource, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	var in wire.DeriveCreateArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, nil, err
+	}
+	source, err := assemblySource(s, in.Source, method)
+	if err != nil {
+		return nil, nil, err
+	}
+	return part, source, nil
+}
+
+// assemblySource resolves an open document id to its assembly body source, rejecting a
+// non-assembly document (a part has no occurrence tree to derive).
+func assemblySource(s *app.Session, id uint64, method string) (feature.AssemblyBodySource, error) {
+	d, err := documentByID(s, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	source, ok := d.Content().(feature.AssemblyBodySource)
+	if !ok {
+		return nil, fmt.Errorf("%s: document %d (%s) is not an assembly", method, id, d.DisplayName())
+	}
+	return source, nil
+}
+
+// commitNewDerive gives the new derive/shrinkwrap feature a unique name, recomputes the
+// part, and replies with its detail.
+func commitNewDerive(part *compdef.PartComponentDefinition, pf *feature.PartFeature) (json.RawMessage, error) {
+	pf.SetName(part.Features().UniqueName(pf.Kind()))
+	part.Recompute()
+	_, idx, err := partFeatureByID(part, uint64(pf.ID()), "assembly.derive")
+	if err != nil {
+		return nil, err
+	}
+	return featureDetailReply(part, pf, idx)
+}
+
+// shrinkwrapDefinition maps the wire options to the model shrinkwrap recipe.
+func shrinkwrapDefinition(in wire.ShrinkwrapCreateArgs) (feature.ShrinkwrapDefinition, error) {
+	remove, err := removeStyle(in.RemoveStyle)
+	if err != nil {
+		return feature.ShrinkwrapDefinition{}, err
+	}
+	envelope, err := envelopeStyle(in.EnvelopeStyle)
+	if err != nil {
+		return feature.ShrinkwrapDefinition{}, err
+	}
+	return feature.ShrinkwrapDefinition{
+		RemoveStyle:   remove,
+		MinPartVolume: in.MinPartVolume,
+		EnvelopeStyle: envelope,
+		PatchHoles:    in.PatchHoles,
+	}, nil
+}
+
+// removeStyle maps the public remove style to the model one.
+func removeStyle(s types.ShrinkwrapRemoveStyle) (feature.ShrinkwrapRemoveStyle, error) {
+	switch s {
+	case types.RemoveNone:
+		return feature.RemoveNone, nil
+	case types.RemoveSmallParts:
+		return feature.RemoveSmallParts, nil
+	case types.RemoveInternalParts:
+		return feature.RemoveInternalParts, nil
+	}
+	return 0, fmt.Errorf("%s: unknown shrinkwrap remove style %d", wire.MethodAssemblyShrinkwrapCreate, int32(s))
+}
+
+// envelopeStyle maps the public envelope style to the model one.
+func envelopeStyle(s types.ShrinkwrapEnvelopeStyle) (feature.ShrinkwrapEnvelopeStyle, error) {
+	switch s {
+	case types.EnvelopeNone:
+		return feature.EnvelopeNone, nil
+	case types.EnvelopePerPart:
+		return feature.EnvelopePerPart, nil
+	case types.EnvelopeWhole:
+		return feature.EnvelopeWhole, nil
+	}
+	return 0, fmt.Errorf("%s: unknown shrinkwrap envelope style %d", wire.MethodAssemblyShrinkwrapCreate, int32(s))
+}

--- a/addin/router/assembly_derive_test.go
+++ b/addin/router/assembly_derive_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// blockPart builds a part whose evaluated body is the box [min,max], so a source
+// assembly placing it has real geometry to derive.
+func blockPart(t *testing.T, min, max math.Point3) *compdef.PartComponentDefinition {
+	t.Helper()
+	block, err := brep.SolidBlock(min, max, "p")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	p := compdef.NewPartComponentDefinition()
+	feature.NewBaseFeatures(p.Features()).AddBase(block)
+	p.Recompute()
+	return p
+}
+
+// addAssemblyDoc adds a source assembly document to the workspace, placing one unit-box
+// part per given X translation, and keeps the active document unchanged so the derive
+// target stays the active part.
+func addAssemblyDoc(t *testing.T, s *app.Session, name string, xs ...float64) *doc.Document {
+	t.Helper()
+	active := s.ActiveDocument()
+	d, err := compdef.AddAssembly(s.Workspace(), name, true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	asm := d.Content().(*compdef.AssemblyComponentDefinition)
+	for i, x := range xs {
+		asm.Place(fmt.Sprintf("box:%d", i+1), blockPart(t, math.P3(0, 0, 0), math.P3(1, 1, 1)), math.Translation4(math.V3(x, 0, 0)))
+	}
+	if active != nil {
+		if err := s.Workspace().SetActiveDocument(active); err != nil {
+			t.Fatalf("restore active: %v", err)
+		}
+	}
+	return d
+}
+
+// activePartVolume sums the active part's body volumes (the derived result).
+func activePartVolume(t *testing.T, s *app.Session) float64 {
+	t.Helper()
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	v := 0.0
+	for _, b := range def.SurfaceBodies().All() {
+		v += ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+	}
+	return v
+}
+
+// TestAssemblyDeriveCreateOverWire derives a one-box assembly into the active part and
+// gates the result against the analytic volume (the box, 1.0).
+func TestAssemblyDeriveCreateOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	src := addAssemblyDoc(t, s, "src.obk", 0)
+
+	var detail wire.FeatureDetailResult
+	call(t, r, s, "assembly.deriveCreate", fmt.Sprintf(`{"source":%d}`, src.ID()), &detail)
+
+	if detail.Feature.Kind != "derivedAssembly" {
+		t.Errorf("derived feature kind = %q, want derivedAssembly", detail.Feature.Kind)
+	}
+	if got := activePartVolume(t, s); stdmath.Abs(got-1.0) > 1e-6 {
+		t.Errorf("derived part volume = %g, want 1.0 (the source box)", got)
+	}
+}
+
+// TestAssemblyShrinkwrapCreateOverWire shrinkwraps a two-box assembly with a whole
+// envelope: the result is one box enclosing both unit boxes (X spanning 0..11 → 11).
+func TestAssemblyShrinkwrapCreateOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	src := addAssemblyDoc(t, s, "src.obk", 0, 10)
+
+	var detail wire.FeatureDetailResult
+	args := fmt.Sprintf(`{"source":%d,"envelopeStyle":%d}`, src.ID(), int32(2)) // EnvelopeWhole
+	call(t, r, s, "assembly.shrinkwrapCreate", args, &detail)
+
+	if detail.Feature.Kind != "shrinkwrap" {
+		t.Errorf("shrinkwrap feature kind = %q, want shrinkwrap", detail.Feature.Kind)
+	}
+	if got := activePartVolume(t, s); stdmath.Abs(got-11.0) > 1e-6 {
+		t.Errorf("whole-envelope shrinkwrap volume = %g, want 11.0 (box enclosing both)", got)
+	}
+}
+
+// TestAssemblyDeriveBreakLinkOverWire creates a derive, then breaks its link and checks
+// the feature is no longer linked.
+func TestAssemblyDeriveBreakLinkOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	src := addAssemblyDoc(t, s, "src.obk", 0)
+
+	var created wire.FeatureDetailResult
+	call(t, r, s, "assembly.deriveCreate", fmt.Sprintf(`{"source":%d}`, src.ID()), &created)
+
+	var broken wire.FeatureDetailResult
+	call(t, r, s, "assembly.deriveBreakLink", fmt.Sprintf(`{"id":%d}`, created.Feature.ID), &broken)
+
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	f, ok := def.Features().ByID(feature.ID(created.Feature.ID))
+	if !ok {
+		t.Fatalf("feature %d not found after break link", created.Feature.ID)
+	}
+	derived := f.Definition().(*feature.DerivedAssemblyComponent)
+	if derived.Linked() {
+		t.Error("derived feature still linked after assembly.deriveBreakLink")
+	}
+}
+
+// TestAssemblyDeriveRejectsNonAssemblySource: deriving from a part document (no
+// occurrence tree) is an error naming the offending document.
+func TestAssemblyDeriveRejectsNonAssemblySource(t *testing.T) {
+	r, s := emptyPartSession(t)
+	partID := uint64(s.ActiveDocument().ID()) // the active part itself
+
+	_, err := r.Handle(s, "assembly.deriveCreate", []byte(fmt.Sprintf(`{"source":%d}`, partID)))
+	if err == nil {
+		t.Fatal("deriveCreate from a part source returned nil error, want a rejection")
+	}
+}
+
+// TestAssemblyBreakLinkRejectsUnknownFeature: break-link on a missing id is an error.
+func TestAssemblyBreakLinkRejectsUnknownFeature(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "assembly.deriveBreakLink", []byte(`{"id":9999}`)); err == nil {
+		t.Fatal("deriveBreakLink on an unknown feature returned nil error, want a rejection")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -54,6 +54,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerUIShellHandlers()
 	r.registerTriadHandlers()
 	r.registerHelpHandlers()
+	r.registerAssemblyDeriveHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r
@@ -454,6 +455,9 @@ var mutatingMethods = map[string]bool{
 	wire.MethodWorkPlanesCreate:                 true,
 	wire.MethodWorkPlanesRedefine:               true,
 	wire.MethodWorkPointsCreate:                 true,
+	wire.MethodAssemblyDeriveCreate:             true,
+	wire.MethodAssemblyShrinkwrapCreate:         true,
+	wire.MethodAssemblyDeriveBreakLink:          true,
 	wire.MethodModelAssignMaterial:              true,
 	wire.MethodModelAssignAppearance:            true,
 	wire.MethodSketchCreate:                     true,

--- a/model/feature/contract_assert.go
+++ b/model/feature/contract_assert.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "oblikovati.org/api/contract"
+
+// The derived-assembly and shrinkwrap features satisfy the public derive contract
+// (ADR-0018): both pull a source assembly into the part and expose the same scalar
+// surface (kind, link state, source version, break-link). Shrinkwrap is the simplified
+// flavor of the same contract (M11-F06, #631/#716).
+var (
+	_ contract.DerivedAssemblyComponent = (*DerivedAssemblyComponent)(nil)
+	_ contract.DerivedAssemblyComponent = (*ShrinkwrapComponent)(nil)
+)


### PR DESCRIPTION
## What

Wires the **F06 derive/shrinkwrap** surface to the session — part 2 of ADR-0018, the F06 slice of #716. The `types`/`contract`/`wire`/`client` contract merged in [Oblikovati.API#74](https://github.com/Oblikovati/Oblikovati.API/pull/74).

- **`assembly.deriveCreate`** — derive an open assembly document into the active part as a base body (include-all), via `feature.NewDerivedAssemblyComponents().AddDerived`.
- **`assembly.shrinkwrapCreate`** — the simplified derive, mapping the wire removal/envelope options to the model `ShrinkwrapDefinition`.
- **`assembly.deriveBreakLink`** — freeze + sever a derived/shrinkwrap feature's source link by id.
- **`model/feature`** — compile-time assertions that both `DerivedAssemblyComponent` and `ShrinkwrapComponent` satisfy `contract.DerivedAssemblyComponent`.

## Verification

Router tests round-trip each method over the wire, **volume-gated** against analytic values: deriving a unit-box assembly → part volume 1.0; a whole-envelope shrinkwrap of two boxes 10 apart → the enclosing box (11.0); break-link leaves the feature unlinked. Plus non-assembly-source and unknown-id rejections. `go test ./...`, `-race`, `go vet`, golangci-lint v2 all green.

## Scope

This is the **F06 slice** of #716 only (derive/shrinkwrap). The rest of the umbrella — occurrences (place/transform/ground/suppress/replace/remove), patterns/mirror/copy/substitute, and BOM — remain open under #716 and will be filed as follow-ups. #716 stays open.

Refs #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)