### PR TITLE
addin/router: assembly feature program methods (M11-F08)

### DIFF
--- a/addin/modelaccess/modelaccess.go
+++ b/addin/modelaccess/modelaccess.go
@@ -30,3 +30,18 @@ func ActivePart(s *app.Session) (*compdef.PartComponentDefinition, error) {
 	}
 	return part, nil
 }
+
+// ActiveAssembly returns the active document's assembly component definition, or an
+// error if there is no active document or it is not an assembly. The assembly-feature
+// and occurrence surfaces resolve their target through this.
+func ActiveAssembly(s *app.Session) (*compdef.AssemblyComponentDefinition, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, ErrNoActiveDocument
+	}
+	asm, ok := d.Content().(*compdef.AssemblyComponentDefinition)
+	if !ok {
+		return nil, fmt.Errorf("modelaccess: active document %q is not an assembly", d.DisplayName())
+	}
+	return asm, nil
+}

--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
+)
+
+// The assembly feature program surface (M11-F08, #633/#725): list the machining
+// features authored in the active assembly, add a box-tool cut, edit participation and
+// suppression, and move the end-of-features rollback marker. Features are addressed by
+// their stable id; participants by occurrence session id (the ids the occurrence push
+// events carry).
+
+// registerAssemblyFeatureHandlers wires the assemblyFeatures.* and assembly end-of-
+// features methods.
+func (r *Router) registerAssemblyFeatureHandlers() {
+	r.handlers[wire.MethodAssemblyFeaturesList] = assemblyFeaturesList
+	r.handlers[wire.MethodAssemblyFeaturesAdd] = assemblyFeaturesAdd
+	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
+	r.handlers[wire.MethodAssemblyFeaturesSetSuppressed] = assemblyFeaturesSetSuppressed
+	r.handlers[wire.MethodAssemblyGetEndOfFeatures] = assemblyGetEndOfFeatures
+	r.handlers[wire.MethodAssemblySetEndOfFeatures] = assemblySetEndOfFeatures
+}
+
+// assemblyFeaturesList returns the active assembly's feature program and marker state.
+func assemblyFeaturesList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(assemblyFeaturesResult(asm))
+}
+
+// assemblyFeaturesAdd adds a box-tool cut feature and returns its refreshed info.
+func assemblyFeaturesAdd(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyFeatureArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	cut, err := assemblyCutFromArgs(in)
+	if err != nil {
+		return nil, err
+	}
+	af := asm.AddFeature(cut)
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+}
+
+// assemblyFeaturesSetParticipants replaces a feature's participation set.
+func assemblyFeaturesSetParticipants(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetAssemblyParticipantsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	af, err := assemblyFeatureByID(asm, in.ID, wire.MethodAssemblyFeaturesSetParticipants)
+	if err != nil {
+		return nil, err
+	}
+	occs, err := occurrencesByID(asm, in.Participants, wire.MethodAssemblyFeaturesSetParticipants)
+	if err != nil {
+		return nil, err
+	}
+	af.SetParticipants(occs)
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+}
+
+// assemblyFeaturesSetSuppressed suppresses or unsuppresses the named features in batch.
+func assemblyFeaturesSetSuppressed(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetAssemblyFeaturesSuppressedArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Suppressed {
+		asm.Features().SuppressFeatures(in.IDs...)
+	} else {
+		asm.Features().UnsuppressFeatures(in.IDs...)
+	}
+	asm.RecomputeFeatures()
+	return json.Marshal(assemblyFeaturesResult(asm))
+}
+
+// assemblyGetEndOfFeatures returns the active assembly's rollback-marker state.
+func assemblyGetEndOfFeatures(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	feats := asm.Features()
+	return json.Marshal(wire.EndOfFeaturesResult{Position: feats.EndOfFeaturesPosition(), RolledBack: feats.IsRolledBack()})
+}
+
+// assemblySetEndOfFeatures moves the rollback marker and returns the refreshed program.
+func assemblySetEndOfFeatures(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetEndOfFeaturesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	asm.Features().SetEndOfFeatures(in.Position)
+	asm.RecomputeFeatures()
+	return json.Marshal(assemblyFeaturesResult(asm))
+}
+
+// assemblyCutFromArgs builds the assembly-space box-tool cut feature from the request.
+func assemblyCutFromArgs(in wire.AddAssemblyFeatureArgs) (feature.Feature, error) {
+	op, err := cutOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	min := math.P3(in.ToolMin[0], in.ToolMin[1], in.ToolMin[2])
+	max := math.P3(in.ToolMax[0], in.ToolMax[1], in.ToolMax[2])
+	tool, err := brep.SolidBlock(min, max, "asmCut")
+	if err != nil {
+		return nil, fmt.Errorf("%s: tool box %v..%v: %w", wire.MethodAssemblyFeaturesAdd, min, max, err)
+	}
+	return feature.NewAssemblyCutFeature(tool, op), nil
+}
+
+// cutOperation maps a BooleanType wire spelling to the model boolean operation.
+func cutOperation(spell string) (ops.PartFeatureOperation, error) {
+	bt, ok := types.ParseBooleanType(spell)
+	if !ok {
+		return 0, fmt.Errorf("%s: unknown operation %q (want difference/union/intersect)", wire.MethodAssemblyFeaturesAdd, spell)
+	}
+	switch bt {
+	case types.BooleanDifference:
+		return ops.Cut, nil
+	case types.BooleanUnion:
+		return ops.Join, nil
+	default: // BooleanIntersect
+		return ops.Intersect, nil
+	}
+}
+
+// assemblyFeatureByID resolves a wire feature id against the assembly's program.
+func assemblyFeatureByID(asm *compdef.AssemblyComponentDefinition, id uint64, method string) (*compdef.AssemblyFeature, error) {
+	af, ok := asm.Features().ByID(id)
+	if !ok {
+		return nil, fmt.Errorf("%s: no assembly feature with id %d (ids come from assemblyFeatures.list)", method, id)
+	}
+	return af, nil
+}
+
+// occurrencesByID resolves participant occurrence session ids against the assembly,
+// rejecting an unknown id.
+func occurrencesByID(asm *compdef.AssemblyComponentDefinition, ids []uint64, method string) ([]*occurrence.Occurrence, error) {
+	occs := make([]*occurrence.Occurrence, 0, len(ids))
+	for _, id := range ids {
+		o, ok := asm.Occurrences().ByID(id)
+		if !ok {
+			return nil, fmt.Errorf("%s: no occurrence with id %d in the assembly", method, id)
+		}
+		occs = append(occs, o)
+	}
+	return occs, nil
+}
+
+// assemblyFeaturesResult renders the whole program plus the rollback-marker state.
+func assemblyFeaturesResult(asm *compdef.AssemblyComponentDefinition) wire.AssemblyFeaturesResult {
+	feats := asm.Features()
+	out := make([]wire.AssemblyFeatureInfo, feats.Count())
+	for i := 0; i < feats.Count(); i++ {
+		out[i] = assemblyFeatureInfo(feats.Item(i))
+	}
+	return wire.AssemblyFeaturesResult{
+		Features:      out,
+		EndOfFeatures: feats.EndOfFeaturesPosition(),
+		RolledBack:    feats.IsRolledBack(),
+	}
+}
+
+// assemblyFeatureInfo renders one assembly feature as its wire DTO.
+func assemblyFeatureInfo(af *compdef.AssemblyFeature) wire.AssemblyFeatureInfo {
+	info := wire.AssemblyFeatureInfo{
+		ID:         af.ID(),
+		Kind:       af.Kind(),
+		Name:       af.Name(),
+		Suppressed: af.Suppressed(),
+	}
+	if h := af.Health(); !h.OK() {
+		info.Health = h.Reason
+	}
+	parts := af.Participants()
+	info.Participants = make([]uint64, len(parts))
+	for i, o := range parts {
+		info.Participants[i] = o.ID()
+	}
+	return info
+}

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// assemblySessionWithBoxes makes an assembly the active document, places one unit-box
+// part per X translation, and returns the router, session, assembly, and occurrences.
+func assemblySessionWithBoxes(t *testing.T, xs ...float64) (*Router, *app.Session, *compdef.AssemblyComponentDefinition, []*occurrence.Occurrence) {
+	t.Helper()
+	s := app.NewSession()
+	d, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(d); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	asm := d.Content().(*compdef.AssemblyComponentDefinition)
+	occs := make([]*occurrence.Occurrence, len(xs))
+	for i, x := range xs {
+		occs[i] = asm.Place(fmt.Sprintf("box:%d", i+1), blockPart(t, math.P3(0, 0, 0), math.P3(1, 1, 1)), math.Translation4(math.V3(x, 0, 0)))
+	}
+	return New(opregistry.Default()), s, asm, occs
+}
+
+// featureResultVolume sums an occurrence's machined assembly-feature result volume.
+func featureResultVolume(asm *compdef.AssemblyComponentDefinition, o *occurrence.Occurrence) float64 {
+	v := 0.0
+	for _, b := range asm.Features().Result(o) {
+		v += ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+	}
+	return v
+}
+
+// topHalfCut is the add request for a tool removing the top half (z>0.5) of unit boxes
+// across a wide X range.
+func topHalfCut() string {
+	return `{"toolMin":[-1,-1,0.5],"toolMax":[100,2,2],"operation":"difference"}`
+}
+
+// TestAssemblyFeaturesAddAndListOverWire adds a cut over the wire and checks it lists
+// with default participation, machining each participant to half volume.
+func TestAssemblyFeaturesAddAndListOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0, 5)
+
+	var added wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &added)
+	if added.Feature.Kind != "assemblyCut" || len(added.Feature.Participants) != 2 {
+		t.Fatalf("added feature = %+v, want assemblyCut with 2 participants", added.Feature)
+	}
+
+	var list wire.AssemblyFeaturesResult
+	call(t, r, s, "assemblyFeatures.list", `{}`, &list)
+	if len(list.Features) != 1 || list.Features[0].ID != added.Feature.ID {
+		t.Fatalf("list = %+v, want the one added feature", list.Features)
+	}
+	for _, o := range occs {
+		if got := featureResultVolume(asm, o); stdmath.Abs(got-0.5) > 1e-6 {
+			t.Errorf("participant machined volume = %g, want 0.5", got)
+		}
+	}
+}
+
+// TestAssemblySetParticipantsOverWire narrows participation to one occurrence; the
+// dropped one is left whole.
+func TestAssemblySetParticipantsOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0, 5)
+	var added wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &added)
+
+	args := fmt.Sprintf(`{"id":%d,"participants":[%d]}`, added.Feature.ID, occs[0].ID())
+	var setp wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.setParticipants", args, &setp)
+	if len(setp.Feature.Participants) != 1 || setp.Feature.Participants[0] != occs[0].ID() {
+		t.Fatalf("participants = %v, want just occurrence %d", setp.Feature.Participants, occs[0].ID())
+	}
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.5) > 1e-6 {
+		t.Errorf("kept participant volume = %g, want 0.5", got)
+	}
+	if got := featureResultVolume(asm, occs[1]); stdmath.Abs(got-1.0) > 1e-6 {
+		t.Errorf("dropped participant volume = %g, want 1.0 (untouched)", got)
+	}
+}
+
+// TestAssemblySetSuppressedOverWire suppresses then unsuppresses a feature in batch.
+func TestAssemblySetSuppressedOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+	var added wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &added)
+
+	var list wire.AssemblyFeaturesResult
+	call(t, r, s, "assemblyFeatures.setSuppressed", fmt.Sprintf(`{"ids":[%d],"suppressed":true}`, added.Feature.ID), &list)
+	if !list.Features[0].Suppressed {
+		t.Error("feature not reported suppressed")
+	}
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-1.0) > 1e-6 {
+		t.Errorf("suppressed-feature volume = %g, want 1.0 (passthrough)", got)
+	}
+
+	call(t, r, s, "assemblyFeatures.setSuppressed", fmt.Sprintf(`{"ids":[%d],"suppressed":false}`, added.Feature.ID), &list)
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.5) > 1e-6 {
+		t.Errorf("unsuppressed-feature volume = %g, want 0.5", got)
+	}
+}
+
+// TestAssemblyEndOfFeaturesOverWire rolls the program back and reads the marker.
+func TestAssemblyEndOfFeaturesOverWire(t *testing.T) {
+	r, s, _, _ := assemblySessionWithBoxes(t, 0)
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &wire.AssemblyFeatureResult{})
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &wire.AssemblyFeatureResult{})
+
+	var eof wire.EndOfFeaturesResult
+	call(t, r, s, "assembly.getEndOfFeatures", `{}`, &eof)
+	if eof.Position != -1 || eof.RolledBack {
+		t.Fatalf("initial marker = %+v, want position -1 not rolled back", eof)
+	}
+
+	var list wire.AssemblyFeaturesResult
+	call(t, r, s, "assembly.setEndOfFeatures", `{"position":1}`, &list)
+	if !list.RolledBack || list.EndOfFeatures != 1 {
+		t.Errorf("after rollback: result = %+v, want position 1 rolled back", list)
+	}
+	call(t, r, s, "assembly.getEndOfFeatures", `{}`, &eof)
+	if eof.Position != 1 || !eof.RolledBack {
+		t.Errorf("marker after rollback = %+v, want position 1 rolled back", eof)
+	}
+}
+
+// TestAssemblyFeaturesRejectsBadInput pins the error paths: a bad operation, an unknown
+// participant, and a non-assembly active document.
+func TestAssemblyFeaturesRejectsBadInput(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0)
+	if _, err := r.Handle(s, "assemblyFeatures.add", []byte(`{"toolMin":[0,0,0],"toolMax":[1,1,1],"operation":"bogus"}`)); err == nil {
+		t.Error("add with a bad operation should fail")
+	}
+	var added wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &added)
+	bad := fmt.Sprintf(`{"id":%d,"participants":[99999]}`, added.Feature.ID)
+	if _, err := r.Handle(s, "assemblyFeatures.setParticipants", []byte(bad)); err == nil {
+		t.Error("setParticipants with an unknown occurrence should fail")
+	}
+	_ = occs
+
+	rp, sp := emptyPartSession(t)
+	if _, err := rp.Handle(sp, "assemblyFeatures.list", []byte(`{}`)); err == nil {
+		t.Error("assemblyFeatures.list on a part document should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -55,6 +55,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerTriadHandlers()
 	r.registerHelpHandlers()
 	r.registerAssemblyDeriveHandlers()
+	r.registerAssemblyFeatureHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r
@@ -458,6 +459,10 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyDeriveCreate:             true,
 	wire.MethodAssemblyShrinkwrapCreate:         true,
 	wire.MethodAssemblyDeriveBreakLink:          true,
+	wire.MethodAssemblyFeaturesAdd:              true,
+	wire.MethodAssemblyFeaturesSetParticipants:  true,
+	wire.MethodAssemblyFeaturesSetSuppressed:    true,
+	wire.MethodAssemblySetEndOfFeatures:         true,
 	wire.MethodModelAssignMaterial:              true,
 	wire.MethodModelAssignAppearance:            true,
 	wire.MethodSketchCreate:                     true,

--- a/model/compdef/assembly_features.go
+++ b/model/compdef/assembly_features.go
@@ -79,6 +79,18 @@ func (f *AssemblyFeature) RemoveParticipant(o *occurrence.Occurrence) {
 	}
 }
 
+// SetParticipants replaces the feature's participation set with occs (in order),
+// dropping any current participant not in the new set. It is the "set participation"
+// edit the wire surface drives, distinct from incremental add/remove.
+func (f *AssemblyFeature) SetParticipants(occs []*occurrence.Occurrence) {
+	for _, o := range f.Participants() {
+		f.RemoveParticipant(o)
+	}
+	for _, o := range occs {
+		f.AddParticipant(o)
+	}
+}
+
 // Participates reports whether o is in this feature's participation set.
 func (f *AssemblyFeature) Participates(o *occurrence.Occurrence) bool { return f.participants[o] }
 

--- a/model/compdef/contract_assert.go
+++ b/model/compdef/contract_assert.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import "oblikovati.org/api/contract"
+
+// The assembly feature program satisfies the public assembly-features contract
+// (ADR-0018): the rollback marker and batch suppression the wire surface drives
+// (M11-F08, #633/#725).
+var (
+	_ contract.AssemblyFeatures = (*AssemblyFeatures)(nil)
+	_ contract.EndOfFeatures    = (*AssemblyFeatures)(nil)
+)


### PR DESCRIPTION
## What

Wires the assembly feature-program surface to the session — part 2 of ADR-0018 for #725. Contract merged in [Oblikovati.API#75](https://github.com/Oblikovati/Oblikovati.API/pull/75).

- **`assemblyFeatures.list`/`add`/`setParticipants`/`setSuppressed`** and **`assembly.getEndOfFeatures`/`setEndOfFeatures`** handlers over the active assembly.
- **`modelaccess.ActiveAssembly`** resolves the active assembly definition.
- **`compdef.AssemblyFeature.SetParticipants`** replaces a feature's participation set (the "set participation" edit); `compdef.AssemblyFeatures` asserts `contract.AssemblyFeatures`/`EndOfFeatures`.

## Verification

Router tests round-trip each method, **volume-gated** against analytic values: an added top-half cut machines each participant unit box to 0.5; narrowing participation leaves the dropped occurrence whole (1.0); batch suppress restores full volume then unsuppress re-cuts; rollback reports the marker. Plus bad-operation, unknown-participant, and non-assembly-document rejections. `go test ./...`, `-race`, vet, golangci-lint v2 green.

## Scope (this is the first of several PRs for #725)

This delivers the **request/response method group**. Still to come for #725: the curated push relay for feature-change events (needs new model event infra), and the richer inputs (proxy-based inputs, nested participation paths, the full feature kind set).

Refs #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)