### PR TITLE
model,addin/events: relay assembly feature-program changes (M11-F08)

### DIFF
--- a/addin/events/assembly_relay.go
+++ b/addin/events/assembly_relay.go
@@ -43,6 +43,23 @@ func SubscribeAssembly(bus *event.Bus, document doc.ID, sink Sink) []event.Subsc
 			p.Suppressed = e.Suppressed
 			return relayJSON(sink, p)
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e compdef.AssemblyFeaturesRecomputed) event.Outcome {
+			return relayJSON(sink, assemblyFeaturesPayload(document, e))
+		}),
+	}
+}
+
+// assemblyFeaturesPayload renders a feature-program recompute as the wire change event,
+// mapping each feature's model health snapshot to its wire shape.
+func assemblyFeaturesPayload(document doc.ID, e compdef.AssemblyFeaturesRecomputed) wire.AssemblyFeaturesChangedEvent {
+	feats := make([]wire.AssemblyFeatureHealth, len(e.Features))
+	for i, f := range e.Features {
+		feats[i] = wire.AssemblyFeatureHealth{ID: f.ID, Suppressed: f.Suppressed, Health: f.Health}
+	}
+	return wire.AssemblyFeaturesChangedEvent{
+		Type:     wire.EventAssemblyFeaturesChanged,
+		Document: uint64(document),
+		Features: feats,
 	}
 }
 

--- a/addin/events/assembly_relay_test.go
+++ b/addin/events/assembly_relay_test.go
@@ -9,16 +9,48 @@ import (
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
 )
 
 // occRecorder collects the occurrence push events the relay forwards (thread-safe;
 // occurrence events may fire from any goroutine).
 type occRecorder struct {
-	mu  sync.Mutex
-	got []wire.OccurrenceEventPayload
+	mu               sync.Mutex
+	got              []wire.OccurrenceEventPayload
+	rawFeatureEvents []wire.AssemblyFeaturesChangedEvent
+}
+
+// featureSink records only assemblyFeatures.changed pushes (the relay forwards both
+// occurrence and feature events to one sink, so it filters by type).
+func (r *occRecorder) featureSink(b []byte) {
+	var tag struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(b, &tag) != nil || tag.Type != wire.EventAssemblyFeaturesChanged {
+		return
+	}
+	var p wire.AssemblyFeaturesChangedEvent
+	if json.Unmarshal(b, &p) != nil {
+		return
+	}
+	r.mu.Lock()
+	r.rawFeatureEvents = append(r.rawFeatureEvents, p)
+	r.mu.Unlock()
+}
+
+// assemblyTool builds an assembly-space box-cut feature for the feature-program tests.
+func assemblyTool(t *testing.T) feature.Feature {
+	t.Helper()
+	tool, err := brep.SolidBlock(math.P3(-1, -1, 0.5), math.P3(2, 2, 2), "tool")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return feature.NewAssemblyCutFeature(tool, ops.Cut)
 }
 
 func (r *occRecorder) sink(b []byte) {
@@ -128,6 +160,35 @@ func TestSubscribeAssemblyCoalescesDrag(t *testing.T) {
 	}
 	if moved[0].Transform.Cells[3] != 50 || moved[0].Previous.Cells[3] != 0 {
 		t.Errorf("coalesced move new/prior X = %v/%v, want 50/0 (net move)", moved[0].Transform.Cells[3], moved[0].Previous.Cells[3])
+	}
+}
+
+// featuresChanged returns the recorded assemblyFeatures.changed payloads.
+func (r *occRecorder) featuresChanged() []wire.AssemblyFeaturesChangedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]wire.AssemblyFeaturesChangedEvent(nil), r.rawFeatureEvents...)
+}
+
+// TestSubscribeAssemblyRelaysFeatureProgram checks a feature-program recompute relays
+// one assemblyFeatures.changed push carrying each feature's health, tagged with the
+// document.
+func TestSubscribeAssemblyRelaysFeatureProgram(t *testing.T) {
+	asm := compdef.NewAssemblyComponentDefinition()
+	var rec occRecorder
+	subs := SubscribeAssembly(asm.Events().Bus(), doc.ID(9), rec.featureSink)
+	defer cancelAll(subs)
+
+	asm.Place("box:1", compdef.NewPartComponentDefinition(), math.Identity4())
+	af := asm.AddFeature(assemblyTool(t))
+	asm.RecomputeFeatures()
+
+	got := rec.featuresChanged()
+	if len(got) != 1 {
+		t.Fatalf("relayed %d feature-change pushes, want 1", len(got))
+	}
+	if got[0].Document != 9 || len(got[0].Features) != 1 || got[0].Features[0].ID != af.ID() {
+		t.Errorf("feature-change payload = %+v, want one feature %d on document 9", got[0], af.ID())
 	}
 }
 

--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -171,7 +171,8 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.TriadDragEvent | wire.TriadSegmentEvent | wire.ManipulatorDragEvent |
 	wire.ClientOperationEvent | wire.TransactionEventPayload |
 	wire.FileResolutionEventPayload | wire.FileDirtyEventPayload |
-	wire.FileDialogHookPayload | wire.OccurrenceEventPayload](sink Sink, ev E) event.Outcome {
+	wire.FileDialogHookPayload | wire.OccurrenceEventPayload |
+	wire.AssemblyFeaturesChangedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -47,6 +47,7 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 		features:    NewAssemblyFeatures(),
 	}
 	occ.SetListener(a.events)
+	a.features.SetBus(a.events.Bus()) // feature-program events ride the assembly's occurrence bus
 	return a
 }
 

--- a/model/compdef/assembly_features.go
+++ b/model/compdef/assembly_features.go
@@ -5,6 +5,7 @@ package compdef
 import (
 	"strconv"
 
+	"oblikovati.org/event"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/health"
@@ -114,6 +115,9 @@ type AssemblyFeatures struct {
 	// result holds each participant occurrence's machined assembly-space bodies after
 	// the last recompute; see assembly_features_recompute.go.
 	result map[*occurrence.Occurrence][]*topo.Body
+	// bus, when set by the assembly definition, is where the program raises
+	// AssemblyFeaturesRecomputed after each recompute (see assembly_features_events.go).
+	bus *event.Bus
 }
 
 // NewAssemblyFeatures returns an empty assembly feature program with the EOF marker at

--- a/model/compdef/assembly_features_events.go
+++ b/model/compdef/assembly_features_events.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import "oblikovati.org/event"
+
+// Assembly feature-program event type id. It continues the assembly event block
+// (occurrence events are 0x0B01–0x0B05; the feature program is 0x0B06) and rides the
+// same per-assembly bus, so an add-in subscribing to an assembly receives both its
+// occurrence and its feature-program changes (M11-F08, #725). Ids are stable across
+// versions (they cross the gRPC seam); never renumber.
+const tidAssemblyFeaturesRecomputed event.TypeID = 0x0B06
+
+// FeatureHealth is one feature's post-recompute state in an
+// [AssemblyFeaturesRecomputed] event: its id, whether it is suppressed, and its health
+// reason ("" when healthy). It carries enough for a consumer to react to health/result
+// changes without re-reading the whole program.
+type FeatureHealth struct {
+	ID         uint64
+	Suppressed bool
+	Health     string
+}
+
+// AssemblyFeaturesRecomputed is raised (After) when the assembly feature program is
+// re-evaluated — after every add, participation/suppression edit, or rollback-marker
+// move, since each triggers a recompute. It carries each feature's resulting health so
+// the push relay can forward a curated feature-change event (M11-F08, #725).
+type AssemblyFeaturesRecomputed struct {
+	Features []FeatureHealth
+}
+
+// EventID implements event.Event.
+func (AssemblyFeaturesRecomputed) EventID() event.TypeID { return tidAssemblyFeaturesRecomputed }
+
+// SetBus installs the bus the feature program raises [AssemblyFeaturesRecomputed] on.
+// The assembly definition wires this to its shared occurrence/feature bus; a program
+// with no bus (a bare collection in a unit test) raises nothing.
+func (fs *AssemblyFeatures) SetBus(bus *event.Bus) { fs.bus = bus }
+
+// raiseRecomputed emits the post-recompute health snapshot, if a bus is installed.
+func (fs *AssemblyFeatures) raiseRecomputed() {
+	if fs.bus == nil {
+		return
+	}
+	snap := make([]FeatureHealth, len(fs.items))
+	for i, af := range fs.items {
+		snap[i] = FeatureHealth{ID: af.id, Suppressed: af.suppress, Health: af.health.Reason}
+	}
+	event.Emit(fs.bus, event.After, AssemblyFeaturesRecomputed{Features: snap})
+}

--- a/model/compdef/assembly_features_recompute.go
+++ b/model/compdef/assembly_features_recompute.go
@@ -28,6 +28,7 @@ func (fs *AssemblyFeatures) Recompute(placed []feature.PlacedBody) {
 		fs.evaluate(fs.items[i], groups)
 	}
 	fs.result = groups
+	fs.raiseRecomputed()
 }
 
 // Result returns o's machined assembly-space bodies after the last recompute, or nil

--- a/model/compdef/assembly_features_test.go
+++ b/model/compdef/assembly_features_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"oblikovati.org/event"
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -150,6 +151,27 @@ func TestEndOfFeaturesRollsBackTrailingFeatures(t *testing.T) {
 	asm.RecomputeFeatures()
 	if got := resultVolume(asm.Features(), occs[0]); stdmath.Abs(got-0.25) > 1e-6 {
 		t.Errorf("rolled-to-end volume = %g, want 0.25 (both cuts again)", got)
+	}
+}
+
+// TestRecomputeRaisesFeaturesEvent checks that recomputing the feature program raises
+// AssemblyFeaturesRecomputed on the assembly bus, carrying each feature's health.
+func TestRecomputeRaisesFeaturesEvent(t *testing.T) {
+	asm, _ := assemblyOfUnitBoxes(t, 0)
+	var got *AssemblyFeaturesRecomputed
+	event.Subscribe(asm.Events().Bus(), event.After, func(_ event.Context, e AssemblyFeaturesRecomputed) event.Outcome {
+		got = &e
+		return event.Continue()
+	})
+
+	af := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	asm.RecomputeFeatures()
+
+	if got == nil || len(got.Features) != 1 || got.Features[0].ID != af.ID() {
+		t.Fatalf("recompute event = %+v, want one feature snapshot for %d", got, af.ID())
+	}
+	if got.Features[0].Suppressed || got.Features[0].Health != "" {
+		t.Errorf("feature snapshot = %+v, want unsuppressed + healthy", got.Features[0])
 	}
 }
 


### PR DESCRIPTION
## What

The **push half** of the F08 surface (#725), part 2 of ADR-0018. Contract merged in [Oblikovati.API#76](https://github.com/Oblikovati/Oblikovati.API/pull/76). An add-in subscribed to an assembly now receives a curated push whenever its machining-feature program changes.

- **`compdef.AssemblyFeatures`** raises `AssemblyFeaturesRecomputed` (After) on every recompute — which every add / participation / suppression edit and rollback-marker move triggers — carrying each feature's health. It rides the **same per-assembly bus** as the F07 occurrence events (type id `0x0B06`), wired by the definition; a bare collection with no bus raises nothing (unit-test friendly).
- **`addin/events.SubscribeAssembly`** forwards it as `wire.AssemblyFeaturesChangedEvent`, so the existing workspace watcher (`subscribeAssemblies`) already delivers it alongside the occurrence events.

## Verification

The model raises the event with the per-feature health snapshot; the relay forwards exactly **one** push per recompute, tagged with the document. `go test ./...`, `-race`, vet, golangci-lint v2 green.

## Scope (#725 progress)

Method group ✅ (#731) · **push relay ✅ (this PR)** · still to come: richer inputs — proxy-based feature inputs (#347), nested sub-assembly participation paths, and the full feature kind set.

Refs #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)