### PR TITLE
model,router: parametric assembly hole feature (M11-F08)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -30,6 +30,7 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesList] = assemblyFeaturesList
 	r.handlers[wire.MethodAssemblyFeaturesAdd] = assemblyFeaturesAdd
 	r.handlers[wire.MethodAssemblyFeaturesAddProxyCut] = assemblyFeaturesAddProxyCut
+	r.handlers[wire.MethodAssemblyFeaturesAddHole] = assemblyFeaturesAddHole
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
 	r.handlers[wire.MethodAssemblyFeaturesSetSuppressed] = assemblyFeaturesSetSuppressed
@@ -88,6 +89,30 @@ func assemblyFeaturesAddProxyCut(s *app.Session, raw json.RawMessage) (json.RawM
 	}
 	af := asm.AddFeature(feature.NewAssemblyProxyCutFeature(source, op))
 	af.RemoveParticipant(source)
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+}
+
+// assemblyFeaturesAddHole drills a parametric hole through the participants.
+func assemblyFeaturesAddHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyHoleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	axis, err := math.NewUnitVector3(in.Axis[0], in.Axis[1], in.Axis[2])
+	if err != nil {
+		return nil, fmt.Errorf("%s: axis %v is not a direction: %w", wire.MethodAssemblyFeaturesAddHole, in.Axis, err)
+	}
+	hole, err := feature.NewAssemblyHoleFeature(math.P3(in.Center[0], in.Center[1], in.Center[2]), axis, in.Diameter, in.Depth)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyFeaturesAddHole, err)
+	}
+	af := asm.AddFeature(hole)
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -105,6 +105,27 @@ func TestAssemblyProxyCutOverWire(t *testing.T) {
 	}
 }
 
+// TestAssemblyAddHoleOverWire drills a parametric hole through the participant and
+// checks it removed material (a faceted bore) without consuming the whole body.
+func TestAssemblyAddHoleOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	var added wire.AssemblyFeatureResult
+	args := `{"center":[0.5,0.5,0],"axis":[0,0,1],"diameter":0.5,"depth":1.5}`
+	call(t, r, s, "assemblyFeatures.addHole", args, &added)
+	if added.Feature.Kind != "assemblyHole" {
+		t.Fatalf("feature kind = %q, want assemblyHole", added.Feature.Kind)
+	}
+	got := featureResultVolume(asm, occs[0])
+	if got >= 1.0 || got < 0.7 {
+		t.Errorf("holed volume = %g, want a unit box minus a thin bore (≈0.8)", got)
+	}
+
+	if _, err := r.Handle(s, "assemblyFeatures.addHole", []byte(`{"center":[0,0,0],"axis":[0,0,0],"diameter":1,"depth":1}`)); err == nil {
+		t.Error("addHole with a zero axis should fail")
+	}
+}
+
 // TestAssemblySetParticipantsOverWire narrows participation to one occurrence; the
 // dropped one is left whole.
 func TestAssemblySetParticipantsOverWire(t *testing.T) {

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -461,6 +461,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyDeriveBreakLink:             true,
 	wire.MethodAssemblyFeaturesAdd:                 true,
 	wire.MethodAssemblyFeaturesAddProxyCut:         true,
+	wire.MethodAssemblyFeaturesAddHole:             true,
 	wire.MethodAssemblyFeaturesSetParticipants:     true,
 	wire.MethodAssemblyFeaturesSetParticipantPaths: true,
 	wire.MethodAssemblyFeaturesSetSuppressed:       true,

--- a/model/feature/assembly_cut.go
+++ b/model/feature/assembly_cut.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 )
 
 // AssemblyCutFeature is an assembly-machining feature: a tool body authored in the
@@ -25,6 +26,7 @@ import (
 //	tool, _ := brep.SolidBlock(min, max, "asmCut")
 //	f := feature.NewAssemblyCutFeature(tool, ops.Cut)
 type AssemblyCutFeature struct {
+	kind string
 	tool *topo.Body
 	op   ops.PartFeatureOperation
 }
@@ -33,11 +35,24 @@ type AssemblyCutFeature struct {
 // typically [ops.Cut] (machining away material); [ops.Join] adds the tool as shared
 // stock and [ops.Intersect] keeps the common volume.
 func NewAssemblyCutFeature(tool *topo.Body, op ops.PartFeatureOperation) *AssemblyCutFeature {
-	return &AssemblyCutFeature{tool: tool, op: op}
+	return &AssemblyCutFeature{kind: "assemblyCut", tool: tool, op: op}
+}
+
+// NewAssemblyHoleFeature returns an assembly hole: a drilled cylinder of the given
+// diameter and depth from center along axisInto, cut from each participant — a
+// parametric assembly-context feature kind that needs no sketch (M11-F08 kind set,
+// #735). The tool is faceted (the exact analytic cylinder is a NURBS-phase refinement),
+// fixed in assembly space; it reuses the cut machinery and reports kind "assemblyHole".
+func NewAssemblyHoleFeature(center math.Point3, axisInto math.UnitVector3, diameter, depth float64) (*AssemblyCutFeature, error) {
+	if diameter <= 0 || depth <= 0 {
+		return nil, fmt.Errorf("assemblyHole: diameter %g and depth %g must be positive", diameter, depth)
+	}
+	cyl := drillTool(center, axisInto, diameter/2, depth, "asmHole")
+	return &AssemblyCutFeature{kind: "assemblyHole", tool: cyl, op: ops.Cut}, nil
 }
 
 // Kind implements [Feature].
-func (f *AssemblyCutFeature) Kind() string { return "assemblyCut" }
+func (f *AssemblyCutFeature) Kind() string { return f.kind }
 
 // Operation reports the boolean the feature applies, satisfying [OperationalFeature].
 func (f *AssemblyCutFeature) Operation() ops.PartFeatureOperation { return f.op }

--- a/model/feature/assembly_cut_test.go
+++ b/model/feature/assembly_cut_test.go
@@ -79,6 +79,42 @@ func TestAssemblyCutDropsFullyConsumedBody(t *testing.T) {
 	}
 }
 
+// TestAssemblyHoleRemovesCylinder gates the parametric assembly hole against the
+// analytic value: a through-hole of radius 0.25 drilled along +z removes a faceted
+// cylinder (its 32-gon cross-section × the unit box's height) from the box.
+func TestAssemblyHoleRemovesCylinder(t *testing.T) {
+	axis, _ := gmath.NewUnitVector3(0, 0, 1)
+	f, err := NewAssemblyHoleFeature(gmath.P3(0.5, 0.5, 0), axis, 0.5, 1.5)
+	if err != nil {
+		t.Fatalf("NewAssemblyHoleFeature: %v", err)
+	}
+	if f.Kind() != "assemblyHole" {
+		t.Errorf("kind = %q, want assemblyHole", f.Kind())
+	}
+
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 1 {
+		t.Fatalf("result bodies = %d, want 1", len(out.Bodies))
+	}
+	// Expected: unit box minus the faceted bore (its 32-gon cross-section × box height 1).
+	boreArea := 0.5 * float64(holeFacets) * 0.25 * 0.25 * math.Sin(2*math.Pi/float64(holeFacets))
+	want := 1.0 - boreArea*1.0
+	if got := bodyVolume(out.Bodies[0]); math.Abs(got-want) > 1e-6 {
+		t.Errorf("holed volume = %g, want %g (box minus the faceted bore)", got, want)
+	}
+}
+
+// TestAssemblyHoleRejectsBadDimensions: non-positive diameter or depth is an error.
+func TestAssemblyHoleRejectsBadDimensions(t *testing.T) {
+	axis, _ := gmath.NewUnitVector3(0, 0, 1)
+	if _, err := NewAssemblyHoleFeature(gmath.P3(0, 0, 0), axis, 0, 1); err == nil {
+		t.Error("zero diameter should be rejected")
+	}
+}
+
 // TestAssemblyCutNilToolFails: a missing tool is a lost input the engine can turn into
 // feature health, reported as an error rather than a panic.
 func TestAssemblyCutNilToolFails(t *testing.T) {


### PR DESCRIPTION
## What

Broadens the assembly feature kind set beyond the cut with a **parametric hole** — a drilled cylinder placed by point/axis/diameter/depth, needing no sketch (#735). Contract merged in [Oblikovati.API#79](https://github.com/Oblikovati/Oblikovati.API/pull/79).

- **`feature.NewAssemblyHoleFeature`** builds a faceted drill cylinder (reusing the hole/boss `drillTool`) and reuses the proven cut machinery, reporting kind `"assemblyHole"` (`AssemblyCutFeature` gains a `kind` field; existing callers unchanged).
- **`assemblyFeatures.addHole`** routes it, resolving the axis to a unit direction and rejecting non-positive diameter/depth or a zero axis.

## Verification

The hole removes the analytic faceted-bore volume (model layer) and reduces the participant volume without consuming it (over the wire); bad-dimension and zero-axis rejections. `go test ./...`, `-race`, vet, golangci-lint v2 green.

## Scope of #735 (the full kind set)

This adds the one kind that is **parametric** and so deliverable today. The remaining kinds remain blocked on infrastructure that does not exist yet:
- **extrude-from-profile / revolve / sweep** need a sketch profile authored in **assembly-context sketching/work-planes**;
- **chamfer / fillet / move-face** need **proxy-resolved edge/face picking** against the assembly-space participant bodies.

Rectangular pocket/boss is already expressible via `assemblyFeatures.add` (box tool + operation), and an associative occurrence-geometry tool via `addProxyCut` (#734). I'll leave #735 open tracking the profile/edge-pick kinds, which build on the assembly-sketching subsystem (#734's sketch branch).

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)