### PR TITLE
model: assembly sketching subsystem + profile extrude (M11-F08)

### DIFF
--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
 )
 
 // An assembly definition is a composite component — a placeable definition that owns
@@ -30,14 +31,19 @@ var (
 // joints, and representations attach to it from M12.
 type AssemblyComponentDefinition struct {
 	occurrences *occurrence.Occurrences
-	units       param.UnitsOfMeasure // document display units (length/angle/…)
-	events      *AssemblyEvents      // occurrence-lifecycle event source (M11-F07)
-	features    *AssemblyFeatures    // assembly-authored machining features (M11-F08)
+	units       param.UnitsOfMeasure  // document display units (length/angle/…)
+	events      *AssemblyEvents       // occurrence-lifecycle event source (M11-F07)
+	features    *AssemblyFeatures     // assembly-authored machining features (M11-F08)
+	params      *param.Parameters     // parameter DAG for assembly sketch dimensions
+	work        *feature.WorkGeometry // origin frame + user work planes, in assembly space
+	sketches    *sketch.Sketches      // sketches authored in the assembly (profile inputs)
 }
 
 // NewAssemblyComponentDefinition returns an empty assembly content object: no
-// occurrences, default (metric) display units, and a live event source wired to its
-// occurrence collection so placements/moves/suppression raise domain events (M11-F07).
+// occurrences, default (metric) display units, a live event source wired to its
+// occurrence collection so placements/moves/suppression raise domain events (M11-F07),
+// and an empty sketch/work-geometry surface so assembly features can be authored from
+// profiles sketched in assembly space (the assembly sketching subsystem).
 func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 	occ := occurrence.NewOccurrences()
 	a := &AssemblyComponentDefinition{
@@ -45,6 +51,9 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 		units:       param.DefaultUnitsOfMeasure(),
 		events:      newAssemblyEvents(),
 		features:    NewAssemblyFeatures(),
+		params:      param.NewParameters(),
+		work:        feature.NewWorkGeometry(),
+		sketches:    sketch.NewSketches(),
 	}
 	occ.SetListener(a.events)
 	a.features.SetBus(a.events.Bus()) // feature-program events ride the assembly's occurrence bus
@@ -136,12 +145,56 @@ func (a *AssemblyComponentDefinition) AddFeature(f feature.Feature) *AssemblyFea
 	return a.features.Add(f, distinctSources(a.PlacedBodies()))
 }
 
-// RecomputeFeatures evaluates the assembly feature program against the current placed
-// geometry, machining each unsuppressed feature into its participants' assembly-space
-// bodies (not the shared part definitions) up to the end-of-features marker. Read the
-// per-occurrence results with [AssemblyFeatures.Result].
+// Parameters returns the assembly's parameter DAG (shared with its sketches so
+// dimension expressions resolve against the same table).
+func (a *AssemblyComponentDefinition) Parameters() *param.Parameters { return a.params }
+
+// WorkGeometry returns the assembly's origin coordinate frame and user work
+// planes/axes/points, expressed in assembly space — the planes a sketch is authored on.
+func (a *AssemblyComponentDefinition) WorkGeometry() *feature.WorkGeometry { return a.work }
+
+// Sketches returns the assembly's planar sketches — the profile inputs an assembly
+// feature (e.g. an extrude) is authored from, sketched in assembly space.
+func (a *AssemblyComponentDefinition) Sketches() *sketch.Sketches { return a.sketches }
+
+// AddSketch creates a sketch on plane and shares the assembly's parameter DAG so its
+// dimensions resolve against the same table (mirroring the part). Pass a host closure
+// (non-nil) to track a moving work plane so the sketch follows it.
+func (a *AssemblyComponentDefinition) AddSketch(plane sketch.Plane, host func() sketch.Plane) *sketch.Sketch {
+	sk := a.sketches.Add(plane)
+	sk.SetParameters(a.params)
+	if host != nil {
+		sk.SetPlaneHost(host)
+	}
+	return sk
+}
+
+// RecomputeFeatures re-solves the assembly's sketches and work geometry, then evaluates
+// the feature program against the current placed geometry — machining each unsuppressed
+// feature into its participants' assembly-space bodies (not the shared part definitions)
+// up to the end-of-features marker. Solving first means a profile-based feature (an
+// extrude) reads an up-to-date profile. Read per-occurrence results with [AssemblyFeatures.Result].
 func (a *AssemblyComponentDefinition) RecomputeFeatures() {
+	a.solveSketches()
+	a.work.Recompute(nil) // origin + offset planes need no body; tangent-to-face planes are part-only
+	a.refreshSketchPlanes()
 	a.features.Recompute(a.PlacedBodies())
+}
+
+// solveSketches re-solves every assembly sketch so parameter-driven dimensions move the
+// geometry before a profile is read.
+func (a *AssemblyComponentDefinition) solveSketches() {
+	for i := 0; i < a.sketches.Count(); i++ {
+		a.sketches.Item(i).Solve()
+	}
+}
+
+// refreshSketchPlanes re-reads each sketch's host work plane so sketches on datum planes
+// follow them when they move.
+func (a *AssemblyComponentDefinition) refreshSketchPlanes() {
+	for i := 0; i < a.sketches.Count(); i++ {
+		a.sketches.Item(i).RefreshPlane()
+	}
 }
 
 // DeleteOccurrence removes o from the assembly, first raising a vetoable OccurrenceDelete

--- a/model/compdef/assembly_sketch_test.go
+++ b/model/compdef/assembly_sketch_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// squareProfileSketch adds a closed rectangle [0,w]×[0,h] to sk (assembly coords).
+func squareProfileSketch(sk *sketch.Sketch, w, h float64) {
+	p0 := sk.Points().Add(math.P2(0, 0))
+	p1 := sk.Points().Add(math.P2(w, 0))
+	p2 := sk.Points().Add(math.P2(w, h))
+	p3 := sk.Points().Add(math.P2(0, h))
+	sk.Lines().Add(p0, p1)
+	sk.Lines().Add(p1, p2)
+	sk.Lines().Add(p2, p3)
+	sk.Lines().Add(p3, p0)
+}
+
+// TestAssemblySketchHostsClosedProfile checks the assembly hosts a sketch on a work
+// plane, shares its parameter DAG, and yields a closed profile after solving.
+func TestAssemblySketchHostsClosedProfile(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	sk := asm.AddSketch(sketch.XYPlane(), nil)
+	if asm.Sketches().Count() != 1 {
+		t.Fatalf("assembly sketch count = %d, want 1", asm.Sketches().Count())
+	}
+	if sk.Parameters() != asm.Parameters() {
+		t.Error("sketch does not share the assembly's parameter DAG")
+	}
+	squareProfileSketch(sk, 0.5, 1)
+	sk.Solve()
+
+	profiles := sk.Profiles()
+	if profiles.Count() != 1 || !profiles.Item(0).IsClosed() {
+		t.Fatalf("profiles = %d, want one closed region", profiles.Count())
+	}
+	if got := profiles.Item(0).Area(); stdmath.Abs(got-0.5) > 1e-9 {
+		t.Errorf("profile area = %g, want 0.5", got)
+	}
+}
+
+// TestAssemblySketchExtrudeCutsParticipant is the subsystem end-to-end: a profile
+// sketched in assembly space is extruded into a prism and cut from a participant,
+// gated against the analytic value (unit box minus a 0.5×1×0.6 pocket = 0.7).
+func TestAssemblySketchExtrudeCutsParticipant(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	asm := NewAssemblyComponentDefinition()
+	occ := asm.Place("box:1", part, math.Identity4())
+
+	sk := asm.AddSketch(sketch.XYPlane(), nil)
+	squareProfileSketch(sk, 0.5, 1)
+
+	asm.AddFeature(feature.NewAssemblyExtrudeFeature(sk, 0, ops.Cut, func() float64 { return 0.6 }))
+	asm.RecomputeFeatures()
+
+	if got := resultVolume(asm.Features(), occ); stdmath.Abs(got-0.7) > 1e-6 {
+		t.Errorf("extrude-cut volume = %g, want 0.7 (unit box minus a 0.5×1×0.6 pocket)", got)
+	}
+}
+
+// TestAssemblyExtrudeJoinsBoss checks the join variant adds a profiled boss to each
+// participant (unit box plus a 0.25×0.25×0.5 stud standing on its top face).
+func TestAssemblyExtrudeJoinsBoss(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	asm := NewAssemblyComponentDefinition()
+	occ := asm.Place("box:1", part, math.Identity4())
+
+	// Sketch the stud footprint on the box's top face (z=1) and extrude up by 0.5.
+	top, _ := sketch.NewPlane(math.P3(0, 0, 1), unitX(t), unitY(t))
+	sk := asm.AddSketch(top, nil)
+	squareProfileSketch(sk, 0.25, 0.25)
+
+	asm.AddFeature(feature.NewAssemblyExtrudeFeature(sk, 0, ops.Join, func() float64 { return 0.5 }))
+	asm.RecomputeFeatures()
+
+	want := 1.0 + 0.25*0.25*0.5
+	if got := resultVolume(asm.Features(), occ); stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("extrude-join volume = %g, want %g (box plus a 0.25×0.25×0.5 stud)", got, want)
+	}
+}
+
+// unitX / unitY return the world X / Y unit vectors for a sketch plane frame.
+func unitX(t *testing.T) math.UnitVector3 {
+	t.Helper()
+	u, err := math.NewUnitVector3(1, 0, 0)
+	if err != nil {
+		t.Fatalf("unitX: %v", err)
+	}
+	return u
+}
+func unitY(t *testing.T) math.UnitVector3 {
+	t.Helper()
+	u, err := math.NewUnitVector3(0, 1, 0)
+	if err != nil {
+		t.Fatalf("unitY: %v", err)
+	}
+	return u
+}

--- a/model/feature/assembly_extrude.go
+++ b/model/feature/assembly_extrude.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sketch"
+)
+
+// AssemblyExtrudeFeature is an assembly-machining feature authored from a sketch profile
+// rather than a fixed tool box — the assembly-context extrude (M11-F08 kind set, #735).
+// Its sketch is drawn on an assembly work plane, so the profile already lives in
+// assembly space; at recompute it extrudes that profile into a prism by the given
+// distance and booleans it against each participant body. The same buildPrism path the
+// part extrude uses produces the tool, so a profiled pocket/boss machines every
+// participant in place without touching the shared part definitions.
+//
+// Example: cut a slot profiled in sketch sk through every participant —
+//
+//	f := feature.NewAssemblyExtrudeFeature(sk, 0, ops.Cut, func() float64 { return 10 })
+type AssemblyExtrudeFeature struct {
+	sketch       *sketch.Sketch
+	profileIndex int
+	op           ops.PartFeatureOperation
+	distance     func() float64
+}
+
+// NewAssemblyExtrudeFeature returns an extrude of the sketch's profileIndex-th closed
+// region, applying op over distance (a closure, so a parameter edit reflows it). op is
+// typically [ops.Cut] (a profiled pocket) or [ops.Join] (a profiled boss).
+func NewAssemblyExtrudeFeature(skt *sketch.Sketch, profileIndex int, op ops.PartFeatureOperation, distance func() float64) *AssemblyExtrudeFeature {
+	return &AssemblyExtrudeFeature{sketch: skt, profileIndex: profileIndex, op: op, distance: distance}
+}
+
+// Kind implements [Feature].
+func (f *AssemblyExtrudeFeature) Kind() string { return "assemblyExtrude" }
+
+// Operation reports the boolean the feature applies, satisfying [OperationalFeature].
+func (f *AssemblyExtrudeFeature) Operation() ops.PartFeatureOperation { return f.op }
+
+// Recompute resolves the sketch's profile, extrudes it into an assembly-space prism by
+// the current distance, and booleans the prism against every running body (an emptied
+// body is dropped). A missing/open profile or a non-positive distance is a lost input
+// the engine turns into feature health, not a panic.
+func (f *AssemblyExtrudeFeature) Recompute(in Input) (Output, error) {
+	tool, err := f.buildTool()
+	if err != nil {
+		return Output{}, err
+	}
+	out, err := applyToolToAll(f.op, in.Bodies, tool)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: out}, nil
+}
+
+// buildTool extrudes the resolved profile into the assembly-space prism tool.
+func (f *AssemblyExtrudeFeature) buildTool() (*topo.Body, error) {
+	profiles := f.sketch.Profiles()
+	if f.profileIndex < 0 || f.profileIndex >= profiles.Count() {
+		return nil, fmt.Errorf("assemblyExtrude: profile %d out of range (sketch has %d)", f.profileIndex, profiles.Count())
+	}
+	p := profiles.Item(f.profileIndex)
+	if !p.IsClosed() {
+		return nil, fmt.Errorf("assemblyExtrude: profile %d is open; an extrude needs a closed region", f.profileIndex)
+	}
+	d := f.distance()
+	if d <= 0 {
+		return nil, fmt.Errorf("assemblyExtrude: distance %g must be positive", d)
+	}
+	return buildPrismWithHoles(p, f.sketch.Plane(), span{near: 0, far: d}, 0, "asmExtrude"), nil
+}


### PR DESCRIPTION
## What

Gives an assembly definition its own **sketching surface in assembly space**, so machining features can be authored from sketch profiles rather than fixed tool geometry — the foundation the profile-based feature kinds need (#735; the assembly-sketching subsystem behind #734's sketch branch).

- **`AssemblyComponentDefinition`** now hosts a `param.Parameters` DAG, a `feature.WorkGeometry` (origin frame + user work planes, in assembly space), and a `sketch.Sketches` collection — reusing the **part-agnostic** `sketch.Sketches` / `feature.WorkGeometry` constructors. `AddSketch` creates a sketch sharing the assembly's parameters (and optionally tracking a moving work plane); `RecomputeFeatures` now solves the sketches + work geometry **before** evaluating the feature program, so a profile-based feature reads an up-to-date profile.
- **`feature.AssemblyExtrudeFeature`** extrudes a sketch profile (already in assembly space) into a prism via the **same `buildPrism` path the part extrude uses**, and booleans it against each participant — a profiled pocket (`Cut`) or boss (`Join`).

## Why

This is the subsystem that #734/#735 were blocked on. With it, the assembly feature hosting (participation, suppression, rollback, push events) can now be driven by real sketch profiles — unblocking extrude-from-profile, and providing the work-plane/sketch substrate revolve/sweep will build on.

## Verification (volume-gated against analytic values)

- the assembly hosts a sketch that shares its parameter DAG and yields one closed profile (area 0.5) after solving;
- an **extrude-cut** of a 0.5×1 profile by 0.6 leaves a unit-box participant at **0.7**;
- an **extrude-join** adds a 0.25×0.25×0.5 boss → **1.03125**.

`go test ./...`, `-race`, `go vet`, golangci-lint v2 green.

## Scope

GPL **model** subsystem, delivered model-first (as F01–F08 were). The public wire surface — sketch authoring on assemblies (reusing the part `sketch.*` router against `ActiveAssembly`) and an `assemblyFeatures.addExtrude` method — is deferred to a follow-up. Revolve/sweep (other profile kinds) and proxy edge/face picking for chamfer/fillet build on this substrate.

Refs #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)