### PR TITLE
addin/router: sketch authoring on assemblies + assemblyFeatures.addExtrude (M11-F08)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -31,6 +31,7 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesAdd] = assemblyFeaturesAdd
 	r.handlers[wire.MethodAssemblyFeaturesAddProxyCut] = assemblyFeaturesAddProxyCut
 	r.handlers[wire.MethodAssemblyFeaturesAddHole] = assemblyFeaturesAddHole
+	r.handlers[wire.MethodAssemblyFeaturesAddExtrude] = assemblyFeaturesAddExtrude
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
 	r.handlers[wire.MethodAssemblyFeaturesSetSuppressed] = assemblyFeaturesSetSuppressed
@@ -89,6 +90,35 @@ func assemblyFeaturesAddProxyCut(s *app.Session, raw json.RawMessage) (json.RawM
 	}
 	af := asm.AddFeature(feature.NewAssemblyProxyCutFeature(source, op))
 	af.RemoveParticipant(source)
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+}
+
+// assemblyFeaturesAddExtrude extrudes a closed sketch profile (authored on an assembly
+// work plane) into the participants — a profiled pocket or boss.
+func assemblyFeaturesAddExtrude(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyExtrudeArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	op, err := cutOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	sk, err := sketchAtIndex(asm, in.SketchIndex)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyFeaturesAddExtrude, err)
+	}
+	if in.Distance <= 0 {
+		return nil, fmt.Errorf("%s: distance %g must be positive", wire.MethodAssemblyFeaturesAddExtrude, in.Distance)
+	}
+	distance := in.Distance
+	af := asm.AddFeature(feature.NewAssemblyExtrudeFeature(sk, in.ProfileIndex, op, func() float64 { return distance }))
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -74,6 +74,33 @@ func TestAssemblyFeaturesAddAndListOverWire(t *testing.T) {
 	}
 }
 
+// TestAssemblyExtrudeOverWire drives the assembly sketching subsystem over the wire:
+// create a sketch on the active assembly, rectangle a profile, and extrude-cut it into
+// the participant — gated against the analytic value (unit box minus a 0.5×1×0.6
+// pocket = 0.7; the database unit is the centimetre, so a 1 cm profile is 1 unit).
+func TestAssemblyExtrudeOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &sk)
+
+	var rect wire.SketchRectangleResult
+	call(t, r, s, "sketch.rectangle", fmt.Sprintf(`{"sketchIndex":%d,"width":"0.5 cm","height":"1 cm"}`, sk.SketchIndex), &rect)
+	if rect.Profiles != 1 {
+		t.Fatalf("rectangle profiles = %d, want 1", rect.Profiles)
+	}
+
+	var added wire.AssemblyFeatureResult
+	args := fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"distance":0.6,"operation":"difference"}`, sk.SketchIndex)
+	call(t, r, s, "assemblyFeatures.addExtrude", args, &added)
+	if added.Feature.Kind != "assemblyExtrude" {
+		t.Fatalf("feature kind = %q, want assemblyExtrude", added.Feature.Kind)
+	}
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.7) > 1e-6 {
+		t.Errorf("extrude-cut volume = %g, want 0.7 (unit box minus a 0.5×1×0.6 pocket)", got)
+	}
+}
+
 // TestAssemblyProxyCutOverWire adds a proxy-input cut whose tool is another
 // occurrence's geometry, gated against the analytic value and shown to be associative:
 // moving the source component re-resolves the cut on the next recompute.

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -462,6 +462,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyFeaturesAdd:                 true,
 	wire.MethodAssemblyFeaturesAddProxyCut:         true,
 	wire.MethodAssemblyFeaturesAddHole:             true,
+	wire.MethodAssemblyFeaturesAddExtrude:          true,
 	wire.MethodAssemblyFeaturesSetParticipants:     true,
 	wire.MethodAssemblyFeaturesSetParticipantPaths: true,
 	wire.MethodAssemblyFeaturesSetSuppressed:       true,

--- a/addin/router/sketch.go
+++ b/addin/router/sketch.go
@@ -11,15 +11,40 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
-	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
 )
 
-// createSketch adds a sketch on an origin plane of the active part and returns its
-// index (for sketch.rectangle / features.add).
+// activeSketchHost resolves the active document's content as a sketch host (a part or
+// an assembly), erroring if there is no active document or its content hosts no sketches.
+func activeSketchHost(s *app.Session) (sketchHost, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, modelaccess.ErrNoActiveDocument
+	}
+	host, ok := d.Content().(sketchHost)
+	if !ok {
+		return nil, fmt.Errorf("router: active document %q does not host sketches", d.DisplayName())
+	}
+	return host, nil
+}
+
+// sketchHost is the active-document content a sketch is authored on — a part or an
+// assembly. Both own a sketch collection, the parameter DAG dimensions share, display
+// units, and datum planes, so the sketch-authoring methods (create/rectangle) work
+// against either without knowing which (#739).
+type sketchHost interface {
+	Sketches() *sketch.Sketches
+	Parameters() *param.Parameters
+	Units() param.UnitsOfMeasure
+	WorkPlanes() *feature.WorkPlanes
+}
+
+// createSketch adds a sketch on an origin or work plane of the active sketch host (part
+// or assembly) and returns its index (for sketch.rectangle / features.add).
 func createSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	host, err := activeSketchHost(s)
 	if err != nil {
 		return nil, err
 	}
@@ -27,36 +52,36 @@ func createSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	plane, name, host, err := sketchCreatePlane(part, in)
+	plane, name, planeHost, err := sketchCreatePlane(host, in)
 	if err != nil {
 		return nil, err
 	}
-	sk := part.Sketches().Add(plane)
-	// Share the part's parameter DAG so dimension expressions can reference user
+	sk := host.Sketches().Add(plane)
+	// Share the host's parameter DAG so dimension expressions can reference user
 	// parameters (e.g. "od/2") and the dimension's own d0,d1… parameters live in
-	// the part's table — the way Inventor sketch dimensions work. Without this the
+	// the host's table — the way Inventor sketch dimensions work. Without this the
 	// sketch keeps an isolated param store and "od/2" resolves to 0, collapsing
 	// the geometry.
-	sk.SetParameters(part.Parameters())
+	sk.SetParameters(host.Parameters())
 	// On a work plane, track it so the sketch follows when the plane moves.
-	if host != nil {
-		sk.SetPlaneHost(host)
+	if planeHost != nil {
+		sk.SetPlaneHost(planeHost)
 	}
-	return json.Marshal(wire.CreateSketchResult{SketchIndex: part.Sketches().Count() - 1, Plane: name})
+	return json.Marshal(wire.CreateSketchResult{SketchIndex: host.Sketches().Count() - 1, Plane: name})
 }
 
 // sketchCreatePlane resolves the plane a new sketch starts on: a user work plane (when
 // WorkPlaneIndex is set — the way to sketch on a plane built on a feature-created face) or an
 // origin plane otherwise.
-func sketchCreatePlane(part *compdef.PartComponentDefinition, in wire.CreateSketchArgs) (sketch.Plane, string, func() sketch.Plane, error) {
+func sketchCreatePlane(host sketchHost, in wire.CreateSketchArgs) (sketch.Plane, string, func() sketch.Plane, error) {
 	if in.WorkPlaneIndex == nil {
 		plane, name, err := parsePlane(in.Plane)
 		return plane, name, nil, err // origin planes are fixed, no host to track
 	}
-	planes := part.WorkPlanes()
+	planes := host.WorkPlanes()
 	i := *in.WorkPlaneIndex
 	if i < 0 || i >= planes.Count() {
-		return sketch.Plane{}, "", nil, fmt.Errorf("sketch.create: work plane %d out of range (part has %d)", i, planes.Count())
+		return sketch.Plane{}, "", nil, fmt.Errorf("sketch.create: work plane %d out of range (have %d)", i, planes.Count())
 	}
 	wp := planes.Item(i)
 	// The host re-reads the work plane (recomputed in place) so the sketch tracks it.
@@ -65,7 +90,7 @@ func sketchCreatePlane(part *compdef.PartComponentDefinition, in wire.CreateSket
 
 // sketchRectangle adds a closed rectangle (one profile) to a sketch, ready to extrude.
 func sketchRectangle(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	host, err := activeSketchHost(s)
 	if err != nil {
 		return nil, err
 	}
@@ -73,15 +98,15 @@ func sketchRectangle(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	sk, err := sketchAtIndex(part, in.SketchIndex)
+	sk, err := sketchAtIndex(host, in.SketchIndex)
 	if err != nil {
 		return nil, err
 	}
-	w, err := part.Units().Parse(in.Width, param.Length)
+	w, err := host.Units().Parse(in.Width, param.Length)
 	if err != nil {
 		return nil, fmt.Errorf("sketch.rectangle: width %q: %w", in.Width, err)
 	}
-	h, err := part.Units().Parse(in.Height, param.Length)
+	h, err := host.Units().Parse(in.Height, param.Length)
 	if err != nil {
 		return nil, fmt.Errorf("sketch.rectangle: height %q: %w", in.Height, err)
 	}
@@ -115,10 +140,10 @@ func parsePlane(name string) (sketch.Plane, string, error) {
 	}
 }
 
-// sketchAtIndex returns the active part's sketch at i, bounds-checked.
-func sketchAtIndex(part *compdef.PartComponentDefinition, i int) (*sketch.Sketch, error) {
-	if i < 0 || i >= part.Sketches().Count() {
-		return nil, fmt.Errorf("sketch index %d out of range (part has %d sketches)", i, part.Sketches().Count())
+// sketchAtIndex returns the host's sketch at i, bounds-checked.
+func sketchAtIndex(host sketchHost, i int) (*sketch.Sketch, error) {
+	if i < 0 || i >= host.Sketches().Count() {
+		return nil, fmt.Errorf("sketch index %d out of range (have %d sketches)", i, host.Sketches().Count())
 	}
-	return part.Sketches().Item(i), nil
+	return host.Sketches().Item(i), nil
 }

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -153,6 +153,10 @@ func (a *AssemblyComponentDefinition) Parameters() *param.Parameters { return a.
 // planes/axes/points, expressed in assembly space — the planes a sketch is authored on.
 func (a *AssemblyComponentDefinition) WorkGeometry() *feature.WorkGeometry { return a.work }
 
+// WorkPlanes returns the assembly's datum planes (origin + user), so the shared sketch
+// surface can resolve "sketch on work plane N" the same way it does for a part.
+func (a *AssemblyComponentDefinition) WorkPlanes() *feature.WorkPlanes { return a.work.WorkPlanes() }
+
 // Sketches returns the assembly's planar sketches — the profile inputs an assembly
 // feature (e.g. an extrude) is authored from, sketched in assembly space.
 func (a *AssemblyComponentDefinition) Sketches() *sketch.Sketches { return a.sketches }


### PR DESCRIPTION
## What

Exposes the assembly sketching subsystem over the wire — part 2 of ADR-0018 for #739. Contract merged in [Oblikovati.API#80](https://github.com/Oblikovati/Oblikovati.API/pull/80). An add-in can now author a profile on an assembly and extrude it.

- The **`sketch.create` / `sketch.rectangle`** handlers now resolve a content-agnostic **`sketchHost`** (the active part *or* assembly) instead of only the active part, so the same authoring methods work on either. Both `PartComponentDefinition` and `AssemblyComponentDefinition` satisfy `sketchHost`; the assembly gains `WorkPlanes()` to match.
- **`assemblyFeatures.addExtrude`** builds `feature.AssemblyExtrudeFeature` from a sketch index + profile index + distance + `types.BooleanType` operation.

## Verification

Router test, **volume-gated end-to-end over the wire**: create a sketch on the active assembly, rectangle a 0.5×1 profile, extrude-cut by 0.6 → a unit-box participant at **0.7**. The existing part `sketch.*` and `freeform.*` tests stay green, confirming the host refactor is backward-compatible. `go test ./...`, `-race`, vet, golangci-lint v2 green.

## Scope

Delivers the core of #739: profile authoring (create + rectangle) on assemblies + extrude. Richer sketch-entity/constraint authoring on assemblies (the remaining `sketch.*` handlers) extends the same `sketchHost` path and can follow incrementally.

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)