### PR TITLE
model,router: assembly revolve feature (M11-F08)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -5,6 +5,7 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	stdmath "math"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/types"
@@ -32,6 +33,7 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesAddProxyCut] = assemblyFeaturesAddProxyCut
 	r.handlers[wire.MethodAssemblyFeaturesAddHole] = assemblyFeaturesAddHole
 	r.handlers[wire.MethodAssemblyFeaturesAddExtrude] = assemblyFeaturesAddExtrude
+	r.handlers[wire.MethodAssemblyFeaturesAddRevolve] = assemblyFeaturesAddRevolve
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
 	r.handlers[wire.MethodAssemblyFeaturesSetSuppressed] = assemblyFeaturesSetSuppressed
@@ -122,6 +124,50 @@ func assemblyFeaturesAddExtrude(s *app.Session, raw json.RawMessage) (json.RawMe
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+}
+
+// assemblyFeaturesAddRevolve revolves a closed sketch profile (authored on an assembly
+// work plane) about the axis line (origin + direction in assembly space) into the
+// participants — a turned groove or boss.
+func assemblyFeaturesAddRevolve(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyRevolveArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	op, err := cutOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	sk, err := sketchAtIndex(asm, in.SketchIndex)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyFeaturesAddRevolve, err)
+	}
+	axis, err := revolveAxisFromArgs(in)
+	if err != nil {
+		return nil, err
+	}
+	angle := in.Angle
+	af := asm.AddFeature(feature.NewAssemblyRevolveFeature(sk, in.ProfileIndex, axis, op, func() float64 { return angle }))
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+}
+
+// revolveAxisFromArgs builds the assembly-space revolve axis from the request's origin and
+// direction, validating that the direction is non-zero and the angle is in (0,2π].
+func revolveAxisFromArgs(in wire.AddAssemblyRevolveArgs) (*feature.WorkAxis, error) {
+	dir, err := math.NewUnitVector3(in.Axis[0], in.Axis[1], in.Axis[2])
+	if err != nil {
+		return nil, fmt.Errorf("%s: axis %v is not a direction: %w", wire.MethodAssemblyFeaturesAddRevolve, in.Axis, err)
+	}
+	if in.Angle <= 0 || in.Angle > 2*stdmath.Pi+1e-9 {
+		return nil, fmt.Errorf("%s: angle %g must be in (0, 2π]", wire.MethodAssemblyFeaturesAddRevolve, in.Angle)
+	}
+	return feature.NewDatumAxis(math.P3(in.Origin[0], in.Origin[1], in.Origin[2]), dir), nil
 }
 
 // assemblyFeaturesAddHole drills a parametric hole through the participants.

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -101,6 +101,38 @@ func TestAssemblyExtrudeOverWire(t *testing.T) {
 	}
 }
 
+// TestAssemblyRevolveOverWire drives the assembly revolve over the wire: a rectangle
+// profile authored on the assembly's XY sketch (x∈[0,0.5], y∈[0,1]) revolved a full turn
+// about the world Y axis is a cylinder (r=0.5) whose first quadrant cuts a quarter
+// cylinder (≈π/16) from the unit-box participant — so it removes material without
+// consuming the body. (The tight analytic gate is the model unit test; the boolean
+// re-facets the small-radius cylinder coarsely here.)
+func TestAssemblyRevolveOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &sk)
+	var rect wire.SketchRectangleResult
+	call(t, r, s, "sketch.rectangle", fmt.Sprintf(`{"sketchIndex":%d,"width":"0.5 cm","height":"1 cm"}`, sk.SketchIndex), &rect)
+
+	var added wire.AssemblyFeatureResult
+	args := fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"origin":[0,0,0],"axis":[0,1,0],"angle":%g,"operation":"difference"}`, sk.SketchIndex, 2*stdmath.Pi)
+	call(t, r, s, "assemblyFeatures.addRevolve", args, &added)
+	if added.Feature.Kind != "assemblyRevolve" {
+		t.Fatalf("feature kind = %q, want assemblyRevolve", added.Feature.Kind)
+	}
+	if got := featureResultVolume(asm, occs[0]); got >= 1.0 || got < 0.7 {
+		t.Errorf("revolve-cut volume = %g, want a unit box minus a quarter cylinder (≈0.8)", got)
+	}
+
+	if _, err := r.Handle(s, "assemblyFeatures.addRevolve", []byte(fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"origin":[0,0,0],"axis":[0,0,0],"angle":1,"operation":"difference"}`, sk.SketchIndex))); err == nil {
+		t.Error("addRevolve with a zero axis should fail")
+	}
+	if _, err := r.Handle(s, "assemblyFeatures.addRevolve", []byte(fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"origin":[0,0,0],"axis":[0,1,0],"angle":0,"operation":"difference"}`, sk.SketchIndex))); err == nil {
+		t.Error("addRevolve with a zero angle should fail")
+	}
+}
+
 // TestAssemblyProxyCutOverWire adds a proxy-input cut whose tool is another
 // occurrence's geometry, gated against the analytic value and shown to be associative:
 // moving the source component re-resolves the cut on the next recompute.

--- a/model/compdef/assembly_sketch_test.go
+++ b/model/compdef/assembly_sketch_test.go
@@ -87,6 +87,49 @@ func TestAssemblyExtrudeJoinsBoss(t *testing.T) {
 	}
 }
 
+// TestAssemblyRevolveBoresParticipant is the revolve subsystem end-to-end: a profile
+// sketched in assembly space (radius 0–0.25, height 0–1) is spun about its centerline into a
+// drilled cylinder and cut from a participant, gated against the analytic value — a unit box
+// minus a faceted r=0.25 through-bore ≈ 1 − π·0.25² (within facet tolerance).
+func TestAssemblyRevolveBoresParticipant(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	asm := NewAssemblyComponentDefinition()
+	occ := asm.Place("box:1", part, math.Identity4())
+
+	// Plane below the box whose local +x is world +x and local +y is world +z, so the profile's
+	// local (x,y) maps to (radius from the vertical centreline, height up the box). The profile
+	// runs z∈[-0.5,1.5] so the bore overshoots both box faces — no coplanar end caps, which would
+	// be a coincident-face boolean hazard — leaving a clean through-hole over the box's z∈[0,1].
+	bore, _ := sketch.NewPlane(math.P3(0.5, 0.5, -0.5), unitX(t), worldZ(t))
+	sk := asm.AddSketch(bore, nil)
+	squareProfileSketch(sk, 0.25, 2) // radius 0–0.25, height 0–2 (overshoots the box)
+	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	cl.SetCenterline(true) // the vertical bore axis
+
+	asm.AddFeature(feature.NewAssemblyRevolveFeature(sk, 0, nil, ops.Cut, func() float64 { return 2 * stdmath.Pi }))
+	asm.RecomputeFeatures()
+
+	// This asserts the assembly plumbing — sketch hosting, centreline axis, AddFeature,
+	// RecomputeFeatures, participant placement — drove a through-bore. The boolean re-facets
+	// the revolved cylinder coarsely at this radius (~an 8-gon), so it removes a bit less than
+	// the true circle; the tight analytic gate is the unit test TestAssemblyRevolveToolVolume.
+	removed := 1.0 - resultVolume(asm.Features(), occ)
+	trueBore := stdmath.Pi * 0.25 * 0.25 // π·r²·h, h=1
+	if removed < 0.85*trueBore || removed > 1.02*trueBore {
+		t.Errorf("revolve-bore removed = %g, want within [0.85,1.02]·%g of the analytic bore", removed, trueBore)
+	}
+}
+
+// worldZ returns the world Z unit vector for a sketch plane frame.
+func worldZ(t *testing.T) math.UnitVector3 {
+	t.Helper()
+	u, err := math.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("worldZ: %v", err)
+	}
+	return u
+}
+
 // unitX / unitY return the world X / Y unit vectors for a sketch plane frame.
 func unitX(t *testing.T) math.UnitVector3 {
 	t.Helper()

--- a/model/feature/assembly_revolve.go
+++ b/model/feature/assembly_revolve.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sketch"
+)
+
+// AssemblyRevolveFeature is the assembly-machining revolve (M11-F08 kind set, #735): a
+// sketch profile, authored on an assembly work plane so it already lives in assembly
+// space, spun about an axis into a solid of revolution and booleaned against each
+// participant body. It reuses [buildRevolveSolid] — the same revolution the part revolve
+// runs — so a profiled groove (Cut) or a turned boss (Join) machines every participant in
+// place without touching the shared part definitions.
+//
+// Example: turn a 90° groove profiled in sketch sk about its single centerline —
+//
+//	f := feature.NewAssemblyRevolveFeature(sk, 0, nil, ops.Cut, func() float64 { return math.Pi / 2 })
+type AssemblyRevolveFeature struct {
+	sketch       *sketch.Sketch
+	profileIndex int
+	axis         *WorkAxis // explicit assembly-space axis; nil ⇒ the sketch's single centerline
+	op           ops.PartFeatureOperation
+	angle        func() float64
+}
+
+// NewAssemblyRevolveFeature returns a revolve of the sketch's profileIndex-th closed region
+// about axis (nil ⇒ resolve the sketch's single centerline, like the part revolve), applying
+// op over angle radians (a closure, so a parameter edit reflows it). op is typically [ops.Cut]
+// (a turned groove) or [ops.Join] (a turned boss).
+func NewAssemblyRevolveFeature(skt *sketch.Sketch, profileIndex int, axis *WorkAxis, op ops.PartFeatureOperation, angle func() float64) *AssemblyRevolveFeature {
+	return &AssemblyRevolveFeature{sketch: skt, profileIndex: profileIndex, axis: axis, op: op, angle: angle}
+}
+
+// Kind implements [Feature].
+func (f *AssemblyRevolveFeature) Kind() string { return "assemblyRevolve" }
+
+// Operation reports the boolean the feature applies, satisfying [OperationalFeature].
+func (f *AssemblyRevolveFeature) Operation() ops.PartFeatureOperation { return f.op }
+
+// Recompute resolves the sketch's profile and axis, spins the profile into an assembly-space
+// solid of revolution by the current angle, and booleans it against every running body (an
+// emptied body is dropped). A missing/open profile, an unresolvable axis, or an out-of-range
+// angle is a lost input the engine turns into feature health, not a panic.
+func (f *AssemblyRevolveFeature) Recompute(in Input) (Output, error) {
+	tool, err := f.buildTool()
+	if err != nil {
+		return Output{}, err
+	}
+	out, err := applyToolToAll(f.op, in.Bodies, tool)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: out}, nil
+}
+
+// buildTool spins the resolved profile about the resolved axis into the assembly-space tool.
+func (f *AssemblyRevolveFeature) buildTool() (*topo.Body, error) {
+	prof, err := resolveSingleProfile(f.sketch, f.profileIndex, "assemblyRevolve")
+	if err != nil {
+		return nil, err
+	}
+	axis, err := f.resolveAxis()
+	if err != nil {
+		return nil, err
+	}
+	a := f.angle()
+	if a <= 0 || a > 2*stdmath.Pi+1e-9 {
+		return nil, fmt.Errorf("assemblyRevolve: angle %g must be in (0, 2π]", a)
+	}
+	return buildRevolveSolid(prof, f.sketch.Plane(), axis, a, 0, "asmRevolve")
+}
+
+// resolveAxis returns the explicit axis when set, otherwise the sketch's single centerline.
+func (f *AssemblyRevolveFeature) resolveAxis() (*WorkAxis, error) {
+	if f.axis != nil {
+		return f.axis, nil
+	}
+	return sketchCenterlineAxis(f.sketch, "assemblyRevolve")
+}

--- a/model/feature/assembly_revolve_test.go
+++ b/model/feature/assembly_revolve_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// fullTurn is the revolve-angle closure for a complete 360° revolution.
+func fullTurn() float64 { return 2 * stdmath.Pi }
+
+// TestAssemblyRevolveToolVolume gates the revolved tool against the analytic value: the
+// square x∈[2,4], y∈[0,2] spun a full turn about the Y axis is a washer of volume 24π.
+func TestAssemblyRevolveToolVolume(t *testing.T) {
+	f := NewAssemblyRevolveFeature(offsetSquareSketch(2, 2), 0, yAxis(), ops.Cut, fullTurn)
+	if f.Kind() != "assemblyRevolve" {
+		t.Errorf("kind = %q, want assemblyRevolve", f.Kind())
+	}
+	tool, err := f.buildTool()
+	if err != nil {
+		t.Fatalf("buildTool: %v", err)
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2 // 24π washer
+	if got := bodyVolume(tool); relErr(got, want) > 0.01 {
+		t.Errorf("revolved tool volume = %g, want ≈%g (24π)", got, want)
+	}
+}
+
+// enclosingBlock builds the box [-2,2]×[0,1]×[-2,2] (volume 16) that strictly contains the
+// unit cylinder turned in the cut test — no face tangency — so the boolean removes the tool's
+// whole volume cleanly.
+func enclosingBlock(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(-2, 0, -2), math.P3(2, 1, 2), "target")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// TestAssemblyRevolveCutsEveryBody is the assembly-context cut over several bodies: a
+// full-turn revolve of the square x∈[0,1], y∈[0,1] about the Y axis is a cylinder (r≈1,
+// y∈[0,1], volume ≈π by the analytic gate), strictly inside each enclosing block — so the
+// boolean removes exactly the tool volume from every participant (16 − toolVol).
+func TestAssemblyRevolveCutsEveryBody(t *testing.T) {
+	f := NewAssemblyRevolveFeature(offsetSquareSketch(0, 1), 0, yAxis(), ops.Cut, fullTurn)
+	tool, err := f.buildTool()
+	if err != nil {
+		t.Fatalf("buildTool: %v", err)
+	}
+	if toolVol := bodyVolume(tool); relErr(toolVol, stdmath.Pi) > 0.01 {
+		t.Fatalf("turned cylinder tool = %g, want ≈%g (π)", toolVol, stdmath.Pi)
+	}
+
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{enclosingBlock(t), enclosingBlock(t)}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 2 {
+		t.Fatalf("result bodies = %d, want 2", len(out.Bodies))
+	}
+	want := 16.0 - bodyVolume(tool) // each block keeps its volume minus the fully-contained tool
+	for i, b := range out.Bodies {
+		if got := bodyVolume(b); relErr(got, want) > 0.005 {
+			t.Errorf("body %d revolve-cut volume = %g, want ≈%g (block minus the turned cylinder)", i, got, want)
+		}
+	}
+}
+
+// TestAssemblyRevolveResolvesSketchCenterline: with no explicit axis the feature spins about
+// the sketch's single centerline (Inventor's common flow), producing the same washer.
+func TestAssemblyRevolveResolvesSketchCenterline(t *testing.T) {
+	sk := offsetSquareSketch(2, 2)
+	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2)) // vertical centerline = Y axis
+	cl.SetCenterline(true)
+
+	tool, err := NewAssemblyRevolveFeature(sk, 0, nil, ops.Cut, fullTurn).buildTool()
+	if err != nil {
+		t.Fatalf("buildTool about centerline: %v", err)
+	}
+	want := stdmath.Pi * (4*4 - 2*2) * 2
+	if got := bodyVolume(tool); relErr(got, want) > 0.01 {
+		t.Errorf("centerline-revolved tool = %g, want ≈%g (24π)", got, want)
+	}
+}
+
+// TestAssemblyRevolveRejectsBadAngle: a non-positive angle is a lost input reported as an
+// error rather than a degenerate solid.
+func TestAssemblyRevolveRejectsBadAngle(t *testing.T) {
+	f := NewAssemblyRevolveFeature(offsetSquareSketch(2, 2), 0, yAxis(), ops.Cut, func() float64 { return 0 })
+	if _, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}}); err == nil {
+		t.Error("zero angle should be rejected")
+	}
+}
+
+// TestAssemblyRevolveNoAxisNoCenterlineFails: no explicit axis and no sketch centerline is an
+// ambiguous input, reported as an error.
+func TestAssemblyRevolveNoAxisNoCenterlineFails(t *testing.T) {
+	f := NewAssemblyRevolveFeature(offsetSquareSketch(2, 2), 0, nil, ops.Cut, fullTurn)
+	if _, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}}); err == nil {
+		t.Error("revolve with no axis and no centerline should fail")
+	}
+}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -77,25 +77,32 @@ func (r *RevolveFeature) Recompute(in Input) (Output, error) {
 	return Output{Bodies: bodies}, nil
 }
 
-// buildRevolveTool spins the profile into the solid of revolution. Behind OBK_ANALYTIC_CURVES a
-// full 360° revolve of a rectilinear profile becomes a TRUE analytic solid (cylinder walls + disk/
-// annulus caps) so thread/chamfer/fillet attach to its revolved cylindrical faces (#129); every
-// other case (partial angle, an oblique/curved profile edge, or the gate off) keeps the faceted
-// swept solid. Booleans re-facet an analytic revolve body on demand (combine → planarized).
+// buildRevolveTool spins the profile into the solid of revolution, resolving the swept
+// span from the definition. The actual revolution is the shared [buildRevolveSolid] (the
+// assembly-context revolve, #735, reuses it on an assembly-space profile).
 func (r *RevolveFeature) buildRevolveTool(prof *sketch.Profile, axis *WorkAxis) (*topo.Body, error) {
 	angle, start := revolveSpan(r.def)
-	feat := featOr(r.featName, "revolve")
+	return buildRevolveSolid(prof, r.def.Sketch.Plane(), axis, angle, start, featOr(r.featName, "revolve"))
+}
+
+// buildRevolveSolid revolves a profile (already projected onto plane) about axis over the
+// swept angle starting at start. Behind OBK_ANALYTIC_CURVES a full 360° revolve of a
+// rectilinear profile becomes a TRUE analytic solid (cylinder walls + disk/annulus caps) so
+// thread/chamfer/fillet attach to its revolved cylindrical faces (#129); every other case
+// (partial angle, an oblique/curved profile edge, or the gate off) keeps the faceted swept
+// solid. Booleans re-facet an analytic revolve body on demand (combine → planarized).
+func buildRevolveSolid(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64, feat string) (*topo.Body, error) {
 	// Analytic only for a full revolve of a STRAIGHT-edged profile: those edges revolve to exact
 	// cylinder/cone/plane faces. A profile with an arc/spline (e.g. a sphere) would have its sampled
 	// chords turn into many tiny cone facets — worse than the faceted swept solid — so it stays
 	// faceted until curved meridian edges (torus, #129 follow-up) are supported.
 	if fullRevolution(angle) && isStraightLoop(prof.OuterLoop()) {
-		mer := meridianFromProfile(prof, r.def.Sketch.Plane(), axis)
+		mer := meridianFromProfile(prof, plane, axis)
 		if body, err := brep.SolidOfRevolution(axis.Origin(), axis.Direction().AsVector(), mer, feat); err == nil && body != nil {
 			return body, nil
 		}
 	}
-	sections, closed := revolveSectionsFrom(prof, r.def.Sketch.Plane(), axis, angle, start)
+	sections, closed := revolveSectionsFrom(prof, plane, axis, angle, start)
 	return sweptSolid(sections, closed, feat)
 }
 
@@ -157,14 +164,21 @@ func (r *RevolveFeature) revolveAxis() (*WorkAxis, error) {
 	if r.def.AxisCenterline != nil {
 		return centerlineAxis(r.def.AxisCenterline, r.def.AxisCenterlineSketch)
 	}
-	cls := r.def.Sketch.Centerlines()
+	return sketchCenterlineAxis(r.def.Sketch, "revolve")
+}
+
+// sketchCenterlineAxis resolves a sketch's single centerline into a revolve axis (Inventor's
+// "revolve about the sketch centerline"). No centerline, or more than one, is ambiguous and
+// reported as feature health — shared by the part and assembly-context revolves (#735).
+func sketchCenterlineAxis(sk *sketch.Sketch, feat string) (*WorkAxis, error) {
+	cls := sk.Centerlines()
 	if len(cls) == 0 {
-		return nil, errors.New("revolve: no axis of revolution (set an axis or add a sketch centerline)")
+		return nil, fmt.Errorf("%s: no axis of revolution (set an axis or add a sketch centerline)", feat)
 	}
 	if len(cls) > 1 {
-		return nil, errors.New("revolve: ambiguous axis — the sketch has multiple centerlines; pick one")
+		return nil, fmt.Errorf("%s: ambiguous axis — the sketch has multiple centerlines; pick one", feat)
 	}
-	return centerlineAxis(cls[0], r.def.Sketch)
+	return centerlineAxis(cls[0], sk)
 }
 
 // centerlineAxis turns a centerline line on its sketch into a transient axis of revolution.

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -114,6 +114,13 @@ type WorkAxes struct {
 	byKey map[WorkRef]*WorkAxis
 }
 
+// NewDatumAxis returns a transient datum axis (origin + unit direction) not tracked in any
+// WorkGeometry collection — for feature inputs resolved from caller coordinates, such as the
+// assembly-context revolve's axis supplied over the wire (#735).
+func NewDatumAxis(origin math.Point3, dir math.UnitVector3) *WorkAxis {
+	return &WorkAxis{origin: origin, dir: dir}
+}
+
 func newWorkAxes(g *WorkGeometry) *WorkAxes {
 	return &WorkAxes{g: g, byID: map[ID]*WorkAxis{}, byKey: map[WorkRef]*WorkAxis{}}
 }


### PR DESCRIPTION
## What
Implements the assembly-context **revolve** feature for the M11-F08 kind set (#735):
- `AssemblyRevolveFeature` (`model/feature/assembly_revolve.go`) — spins a sketch profile authored on an assembly work plane about an axis into a solid of revolution and booleans it against each participant body (turned groove via Cut, boss via Join).
- Refactor: `buildRevolveTool` now shares `buildRevolveSolid`, and centerline-axis resolution is extracted to `sketchCenterlineAxis`, both reused by the part and assembly revolves (no duplication).
- `feature.NewDatumAxis` — a transient origin+direction axis for inputs resolved from wire coordinates.
- Router `assemblyFeatures.addRevolve` keyed on the `api/wire` constant.

## Why
The assembly host already accepts any `feature.Feature`; this adds the revolve *kind*, unblocked by the assembly sketching subsystem (#738). Extrude and hole already shipped; revolve was the next tractable kind on that substrate.

## Tests (analytic gates)
- `model/feature`: revolved washer tool volume (24π); a full-turn cylinder cleanly cut from enclosing blocks across multiple participants; centerline-axis resolution; bad-angle / missing-axis rejection.
- `model/compdef`: end-to-end bore through a placed participant (sketch hosting → centerline axis → AddFeature → recompute → participant placement).
- `addin/router`: `addRevolve` over the wire removes material; zero-axis and zero-angle rejected.

## Depends on
Contract: Oblikovati/Oblikovati.API#81 (must merge first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)