### PR TITLE
router,model: assembly occurrences public surface (M11)

### DIFF
--- a/addin/router/assembly_occurrences.go
+++ b/addin/router/assembly_occurrences.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// The assembly occurrence surface (M11-F01/F02, #728): read the active assembly's
+// occurrence tree and place/transform/ground/suppress/replace/remove components.
+// Occurrences are addressed by session id (the ids the occurrence push events carry);
+// each single-occurrence mutator replies with the affected occurrence's refreshed info,
+// and remove replies with the refreshed tree.
+
+// registerAssemblyOccurrenceHandlers wires the assembly.* occurrence methods.
+func (r *Router) registerAssemblyOccurrenceHandlers() {
+	r.handlers[wire.MethodAssemblyOccurrences] = assemblyOccurrences
+	r.handlers[wire.MethodAssemblyPlace] = assemblyPlace
+	r.handlers[wire.MethodAssemblyPlaceByDefinition] = assemblyPlaceByDefinition
+	r.handlers[wire.MethodAssemblyTransform] = assemblyTransform
+	r.handlers[wire.MethodAssemblyGround] = assemblyGround
+	r.handlers[wire.MethodAssemblySuppress] = assemblySuppress
+	r.handlers[wire.MethodAssemblyReplace] = assemblyReplace
+	r.handlers[wire.MethodAssemblyRemove] = assemblyRemove
+}
+
+// assemblyOccurrences returns the active assembly's occurrence tree.
+func assemblyOccurrences(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(occurrenceTreeResult(asm))
+}
+
+// assemblyPlace places the component held by an open document into the active assembly.
+func assemblyPlace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.PlaceOccurrenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	d, err := documentByID(s, in.Document)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyPlace, err)
+	}
+	o, err := asm.PlaceComponent(in.Name, d, matrixFromWire(in.Transform))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyPlace, err)
+	}
+	return occurrenceReply(o)
+}
+
+// assemblyPlaceByDefinition places another instance of an existing occurrence's component.
+func assemblyPlaceByDefinition(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.PlaceByDefinitionArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	src, err := occurrenceByID(asm, in.Source, wire.MethodAssemblyPlaceByDefinition)
+	if err != nil {
+		return nil, err
+	}
+	o := asm.Place(in.Name, src.Definition(), matrixFromWire(in.Transform))
+	return occurrenceReply(o)
+}
+
+// assemblyTransform repositions an occurrence.
+func assemblyTransform(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.TransformOccurrenceArgs
+	o, err := occurrenceFromArgs(s, raw, &in, &in.ID, wire.MethodAssemblyTransform)
+	if err != nil {
+		return nil, err
+	}
+	o.SetTransform(matrixFromWire(in.Transform))
+	return occurrenceReply(o)
+}
+
+// assemblyGround fixes or releases an occurrence in space.
+func assemblyGround(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.GroundOccurrenceArgs
+	o, err := occurrenceFromArgs(s, raw, &in, &in.ID, wire.MethodAssemblyGround)
+	if err != nil {
+		return nil, err
+	}
+	o.SetGrounded(in.Grounded)
+	return occurrenceReply(o)
+}
+
+// assemblySuppress excludes or restores an occurrence from the model (vetoable).
+func assemblySuppress(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SuppressOccurrenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	o, err := occurrenceByID(asm, in.ID, wire.MethodAssemblySuppress)
+	if err != nil {
+		return nil, err
+	}
+	if err := asm.SetOccurrenceSuppressed(o, in.Suppressed); err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblySuppress, err)
+	}
+	return occurrenceReply(o)
+}
+
+// assemblyReplace swaps an occurrence's component for another open document's, keeping the
+// occurrence's id, name, transform, and state.
+func assemblyReplace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ReplaceOccurrenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	o, err := occurrenceByID(asm, in.ID, wire.MethodAssemblyReplace)
+	if err != nil {
+		return nil, err
+	}
+	def, err := placeableDefinition(s, in.Document, wire.MethodAssemblyReplace)
+	if err != nil {
+		return nil, err
+	}
+	asm.Occurrences().Replace(o, def)
+	return occurrenceReply(o)
+}
+
+// assemblyRemove deletes an occurrence and returns the refreshed tree (vetoable).
+func assemblyRemove(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.RemoveOccurrenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	o, err := occurrenceByID(asm, in.ID, wire.MethodAssemblyRemove)
+	if err != nil {
+		return nil, err
+	}
+	if err := asm.DeleteOccurrence(o); err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyRemove, err)
+	}
+	return json.Marshal(occurrenceTreeResult(asm))
+}
+
+// occurrenceFromArgs decodes an id-bearing request and resolves its occurrence — shared by
+// the simple by-id mutators (transform, ground). id points into the decoded struct.
+func occurrenceFromArgs(s *app.Session, raw json.RawMessage, in any, id *uint64, method string) (*occurrence.Occurrence, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	if err := decode(raw, in); err != nil {
+		return nil, err
+	}
+	return occurrenceByID(asm, *id, method)
+}
+
+// occurrenceByID resolves an occurrence session id against the assembly, rejecting unknown.
+func occurrenceByID(asm *compdef.AssemblyComponentDefinition, id uint64, method string) (*occurrence.Occurrence, error) {
+	o, ok := asm.Occurrences().ByID(id)
+	if !ok {
+		return nil, fmt.Errorf("%s: no occurrence with id %d in the assembly (ids come from assembly.occurrences)", method, id)
+	}
+	return o, nil
+}
+
+// placeableDefinition resolves an open document id to its placeable component definition.
+func placeableDefinition(s *app.Session, id uint64, method string) (occurrence.Definition, error) {
+	d, err := documentByID(s, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	def, ok := d.Content().(occurrence.Definition)
+	if !ok {
+		return nil, fmt.Errorf("%s: document %d (%s) is not a placeable component", method, id, d.DisplayName())
+	}
+	return def, nil
+}
+
+// occurrenceReply marshals one occurrence as the single-occurrence result.
+func occurrenceReply(o *occurrence.Occurrence) (json.RawMessage, error) {
+	return json.Marshal(wire.OccurrenceResult{Occurrence: occurrenceInfo(o)})
+}
+
+// occurrenceTreeResult renders the assembly's top-level occurrences as the tree result.
+func occurrenceTreeResult(asm *compdef.AssemblyComponentDefinition) wire.OccurrencesResult {
+	return wire.OccurrencesResult{Occurrences: occurrenceNodes(asm.Occurrences())}
+}
+
+// occurrenceNodes renders a collection's occurrences in placement order, recursing into
+// each composite's sub-occurrences.
+func occurrenceNodes(occs *occurrence.Occurrences) []wire.OccurrenceInfo {
+	all := occs.All()
+	out := make([]wire.OccurrenceInfo, len(all))
+	for i, o := range all {
+		out[i] = occurrenceInfo(o)
+	}
+	return out
+}
+
+// occurrenceInfo renders one occurrence (and its nested children) as its wire DTO.
+func occurrenceInfo(o *occurrence.Occurrence) wire.OccurrenceInfo {
+	info := wire.OccurrenceInfo{
+		ID:         o.ID(),
+		Name:       o.Name(),
+		Transform:  types.Matrix{Cells: o.Transform().Cells()},
+		Suppressed: o.Suppressed(),
+		Grounded:   o.Grounded(),
+		Adaptive:   o.Adaptive(),
+		Substitute: o.IsSubstitute(),
+	}
+	if subs := o.SubOccurrences(); subs != nil {
+		info.Children = occurrenceNodes(subs)
+	}
+	return info
+}
+
+// matrixFromWire converts the contract matrix value to a model transform.
+func matrixFromWire(m types.Matrix) math.Matrix4 { return math.Matrix4FromCells(m.Cells) }

--- a/addin/router/assembly_occurrences_test.go
+++ b/addin/router/assembly_occurrences_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+// openPartDoc adds a part document to the workspace (keeping the active document
+// unchanged) and returns it, so a test can place it into the active assembly by id.
+func openPartDoc(t *testing.T, s *app.Session, name string) *doc.Document {
+	t.Helper()
+	active := s.ActiveDocument()
+	d, err := compdef.AddPart(s.Workspace(), name, true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(active); err != nil {
+		t.Fatalf("restore active: %v", err)
+	}
+	return d
+}
+
+// transformJSON renders a row-major translation matrix (tx,ty,tz in cells 3/7/11) as the
+// flat 16-cell array the wire matrix expects.
+func transformJSON(tx, ty, tz float64) string {
+	return fmt.Sprintf("[1,0,0,%g, 0,1,0,%g, 0,0,1,%g, 0,0,0,1]", tx, ty, tz)
+}
+
+// TestAssemblyOccurrencesTreeOverWire reads the occurrence tree of an assembly with two
+// placed components and checks ids, names, and placements round-trip.
+func TestAssemblyOccurrencesTreeOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 5)
+
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.occurrences", `{}`, &tree)
+	if len(tree.Occurrences) != 2 {
+		t.Fatalf("tree = %d occurrences, want 2", len(tree.Occurrences))
+	}
+	if tree.Occurrences[0].ID != occs[0].ID() || tree.Occurrences[0].Name != occs[0].Name() {
+		t.Errorf("node[0] = {%d,%q}, want {%d,%q}", tree.Occurrences[0].ID, tree.Occurrences[0].Name, occs[0].ID(), occs[0].Name())
+	}
+	// occs[1] was placed at x=5 (cells[3]).
+	if got := tree.Occurrences[1].Transform.Cells[3]; got != 5 {
+		t.Errorf("node[1] x-translation = %g, want 5", got)
+	}
+}
+
+// TestAssemblyPlaceOverWire places an open part document into the active assembly and
+// checks the new occurrence carries the requested name/transform and joins the tree.
+func TestAssemblyPlaceOverWire(t *testing.T) {
+	r, s, _, _ := assemblySessionWithBoxes(t)
+	pin := openPartDoc(t, s, "pin.obk")
+
+	var placed wire.OccurrenceResult
+	args := fmt.Sprintf(`{"document":%d,"name":"pin:1","transform":%s}`, uint64(pin.ID()), transformJSON(2, 0, 0))
+	call(t, r, s, "assembly.place", args, &placed)
+	if placed.Occurrence.Name != "pin:1" || placed.Occurrence.Transform.Cells[3] != 2 {
+		t.Fatalf("placed = %+v, want pin:1 at x=2", placed.Occurrence)
+	}
+
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.occurrences", `{}`, &tree)
+	if len(tree.Occurrences) != 1 || tree.Occurrences[0].ID != placed.Occurrence.ID {
+		t.Fatalf("tree = %+v, want the one placed occurrence", tree.Occurrences)
+	}
+
+	if _, err := r.Handle(s, "assembly.place", []byte(`{"document":99999,"name":"x","transform":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}`)); err == nil {
+		t.Error("place with an unknown document id should fail")
+	}
+}
+
+// TestAssemblyPlaceByDefinitionOverWire places a second instance reusing an existing
+// occurrence's definition.
+func TestAssemblyPlaceByDefinitionOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0)
+
+	var placed wire.OccurrenceResult
+	args := fmt.Sprintf(`{"source":%d,"name":"box:2","transform":%s}`, occs[0].ID(), transformJSON(3, 0, 0))
+	call(t, r, s, "assembly.placeByDefinition", args, &placed)
+	if placed.Occurrence.Name != "box:2" || placed.Occurrence.ID == occs[0].ID() {
+		t.Fatalf("placed = %+v, want a new occurrence named box:2", placed.Occurrence)
+	}
+
+	if _, err := r.Handle(s, "assembly.placeByDefinition", []byte(`{"source":99999,"name":"x","transform":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}`)); err == nil {
+		t.Error("placeByDefinition with an unknown source id should fail")
+	}
+}
+
+// TestAssemblyTransformGroundSuppressOverWire drives the per-occurrence state mutators and
+// checks each is reflected on the occurrence.
+func TestAssemblyTransformGroundSuppressOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0)
+	id := occs[0].ID()
+
+	var moved wire.OccurrenceResult
+	call(t, r, s, "assembly.transform", fmt.Sprintf(`{"id":%d,"transform":%s}`, id, transformJSON(7, 0, 0)), &moved)
+	if moved.Occurrence.Transform.Cells[3] != 7 || occs[0].Transform().Cells()[3] != 7 {
+		t.Errorf("after transform: wire=%g model=%g, want 7", moved.Occurrence.Transform.Cells[3], occs[0].Transform().Cells()[3])
+	}
+
+	var grounded wire.OccurrenceResult
+	call(t, r, s, "assembly.ground", fmt.Sprintf(`{"id":%d,"grounded":true}`, id), &grounded)
+	if !grounded.Occurrence.Grounded || !occs[0].Grounded() {
+		t.Error("after ground: occurrence should be grounded")
+	}
+
+	var suppressed wire.OccurrenceResult
+	call(t, r, s, "assembly.suppress", fmt.Sprintf(`{"id":%d,"suppressed":true}`, id), &suppressed)
+	if !suppressed.Occurrence.Suppressed || !occs[0].Suppressed() {
+		t.Error("after suppress: occurrence should be suppressed")
+	}
+
+	if _, err := r.Handle(s, "assembly.transform", []byte(`{"id":99999,"transform":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}`)); err == nil {
+		t.Error("transform of an unknown occurrence id should fail")
+	}
+}
+
+// TestAssemblyReplaceOverWire swaps an occurrence's component for another document's,
+// keeping the occurrence's id, name, and placement.
+func TestAssemblyReplaceOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 4)
+	id, name := occs[0].ID(), occs[0].Name()
+	pin := openPartDoc(t, s, "pin.obk")
+
+	var replaced wire.OccurrenceResult
+	call(t, r, s, "assembly.replace", fmt.Sprintf(`{"id":%d,"document":%d}`, id, uint64(pin.ID())), &replaced)
+	if replaced.Occurrence.ID != id || replaced.Occurrence.Name != name || replaced.Occurrence.Transform.Cells[3] != 4 {
+		t.Errorf("replaced = %+v, want id/name/placement kept (id=%d name=%q x=4)", replaced.Occurrence, id, name)
+	}
+}
+
+// TestAssemblyRemoveOverWire deletes an occurrence and checks the tree shrinks.
+func TestAssemblyRemoveOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 5)
+
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.remove", fmt.Sprintf(`{"id":%d}`, occs[0].ID()), &tree)
+	if len(tree.Occurrences) != 1 || tree.Occurrences[0].ID != occs[1].ID() {
+		t.Fatalf("after remove: tree = %+v, want only occurrence %d", tree.Occurrences, occs[1].ID())
+	}
+
+	if _, err := r.Handle(s, "assembly.remove", []byte(`{"id":99999}`)); err == nil {
+		t.Error("remove of an unknown occurrence id should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -56,6 +56,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerHelpHandlers()
 	r.registerAssemblyDeriveHandlers()
 	r.registerAssemblyFeatureHandlers()
+	r.registerAssemblyOccurrenceHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/model/compdef/contract_assert.go
+++ b/model/compdef/contract_assert.go
@@ -11,3 +11,7 @@ var (
 	_ contract.AssemblyFeatures = (*AssemblyFeatures)(nil)
 	_ contract.EndOfFeatures    = (*AssemblyFeatures)(nil)
 )
+
+// The assembly definition satisfies the public contract's scalar assembly read surface
+// (#728); the occurrence tree and mutators travel over api/wire (assembly.*).
+var _ contract.AssemblyComponentDefinition = (*AssemblyComponentDefinition)(nil)

--- a/model/occurrence/contract_assert.go
+++ b/model/occurrence/contract_assert.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+import "oblikovati.org/api/contract"
+
+// The occurrence model satisfies the scalar read surfaces the public contract exposes for
+// assembly occurrences (ADR-0018, #728); the mutators travel over api/wire.
+var (
+	_ contract.ComponentOccurrence  = (*Occurrence)(nil)
+	_ contract.ComponentOccurrences = (*Occurrences)(nil)
+)


### PR DESCRIPTION
## What
Implements the **assembly occurrences** public surface (#728) against the contract+wire from Oblikovati/Oblikovati.API#82:
- **addin/router** serves `assembly.occurrences` (the occurrence tree, recursing into nested sub-assemblies) and `place`/`placeByDefinition`/`transform`/`ground`/`suppress`/`replace`/`remove`. Occurrences are addressed by session id; `place`/`replace` resolve an open document by id; `suppress`/`remove` go through the vetoable `AssemblyComponentDefinition` paths.
- **compile-time contract assertions**: `occurrence.Occurrence`/`.Occurrences` satisfy `ComponentOccurrence`/`ComponentOccurrences`; `compdef.AssemblyComponentDefinition` satisfies the contract `AssemblyComponentDefinition`.

## Why
The occurrence model (M11-F01/F02) was GPL-only; this is the exposure layer (ADR-0018) so add-ins and the head can drive assembly occurrence editing. Model is already built and tested; this wraps it.

## Tests (router, over the wire)
Tree read; place by document and by definition; transform/ground/suppress reflected on the occurrence; replace keeps id/name/placement; remove shrinks the tree; unknown occurrence-id and unknown-document rejection.

## Depends on
Contract: Oblikovati/Oblikovati.API#82 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)