### PR TITLE
router,model: assembly replication public surface (M11)

### DIFF
--- a/addin/router/assembly_replication.go
+++ b/addin/router/assembly_replication.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// The assembly replication surface (M11-F04, #729): replicate placed components by
+// session id — pattern (circular/rectangular), mirror across a plane, independent copy,
+// and substitute a set with one simplified representation. Each op adds occurrences to
+// the active assembly; the additive ops reply with what they created, substitute with
+// the substitute occurrence. Occurrence resolution, info rendering, and the simplified-
+// definition lookup are shared with the occurrence surface (assembly_occurrences.go).
+
+// registerAssemblyReplicationHandlers wires the assembly.* replication methods.
+func (r *Router) registerAssemblyReplicationHandlers() {
+	r.handlers[wire.MethodAssemblyPatternCreate] = assemblyPatternCreate
+	r.handlers[wire.MethodAssemblyMirror] = assemblyMirror
+	r.handlers[wire.MethodAssemblyCopy] = assemblyCopy
+	r.handlers[wire.MethodAssemblySubstitute] = assemblySubstitute
+}
+
+// assemblyPatternCreate replicates the seed occurrence across an arrangement, adding one
+// occurrence per generated element beyond the seed.
+func assemblyPatternCreate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.CreatePatternArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	seed, err := occurrenceByID(asm, in.Seed, wire.MethodAssemblyPatternCreate)
+	if err != nil {
+		return nil, err
+	}
+	arr, err := arrangementFromArgs(in)
+	if err != nil {
+		return nil, err
+	}
+	pat := occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr)
+	return newOccurrencesReply(patternOccurrences(asm, seed, pat))
+}
+
+// assemblyMirror adds a mirror of each source occurrence across the plane (origin, normal).
+func assemblyMirror(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.MirrorComponentsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	sources, err := occurrencesByID(asm, in.Sources, wire.MethodAssemblyMirror)
+	if err != nil {
+		return nil, err
+	}
+	normal, err := math.NewUnitVector3(in.Normal[0], in.Normal[1], in.Normal[2])
+	if err != nil {
+		return nil, fmt.Errorf("%s: normal %v is not a direction: %w", wire.MethodAssemblyMirror, in.Normal, err)
+	}
+	origin := math.P3(in.Origin[0], in.Origin[1], in.Origin[2])
+	return newOccurrencesReply(occurrence.MirrorComponents(asm.Occurrences(), sources, origin, normal))
+}
+
+// assemblyCopy adds an independent copy of each source occurrence.
+func assemblyCopy(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.CopyComponentsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	sources, err := occurrencesByID(asm, in.Sources, wire.MethodAssemblyCopy)
+	if err != nil {
+		return nil, err
+	}
+	return newOccurrencesReply(occurrence.CopyComponents(asm.Occurrences(), sources))
+}
+
+// assemblySubstitute suppresses the source occurrences and adds one occurrence instancing
+// the simplified component held by an open document.
+func assemblySubstitute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SubstituteComponentsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	sources, err := occurrencesByID(asm, in.Sources, wire.MethodAssemblySubstitute)
+	if err != nil {
+		return nil, err
+	}
+	def, err := placeableDefinition(s, in.Document, wire.MethodAssemblySubstitute)
+	if err != nil {
+		return nil, err
+	}
+	sub := occurrence.Substitute(asm.Occurrences(), sources, in.Name, def, matrixFromWire(in.Transform))
+	return occurrenceReply(sub)
+}
+
+// patternOccurrences places a real occurrence for each pattern element beyond the seed
+// (element 0 is the seed, already placed), reusing the pattern's arrangement placements.
+func patternOccurrences(asm *compdef.AssemblyComponentDefinition, seed *occurrence.Occurrence, pat *occurrence.OccurrencePattern) []*occurrence.Occurrence {
+	created := make([]*occurrence.Occurrence, 0, pat.Count())
+	for i := 1; i < pat.Count(); i++ {
+		name := fmt.Sprintf("%s-p%d", seed.Name(), i+1)
+		created = append(created, asm.Place(name, seed.Definition(), pat.Element(i).Transform()))
+	}
+	return created
+}
+
+// arrangementFromArgs builds the pattern arrangement from the request's kind + parameters.
+func arrangementFromArgs(in wire.CreatePatternArgs) (occurrence.Arrangement, error) {
+	switch in.Kind {
+	case "circular":
+		return circularArrangement(in)
+	case "rectangular":
+		return rectangularArrangement(in)
+	}
+	return nil, fmt.Errorf("%s: unknown pattern kind %q (want circular/rectangular)", wire.MethodAssemblyPatternCreate, in.Kind)
+}
+
+// circularArrangement builds a circular arrangement (Angle radians between Count elements
+// about the axis through Origin).
+func circularArrangement(in wire.CreatePatternArgs) (occurrence.Arrangement, error) {
+	axis, err := math.NewUnitVector3(in.Axis[0], in.Axis[1], in.Axis[2])
+	if err != nil {
+		return nil, fmt.Errorf("%s: axis %v is not a direction: %w", wire.MethodAssemblyPatternCreate, in.Axis, err)
+	}
+	if in.Count < 1 {
+		return nil, fmt.Errorf("%s: count %d must be >= 1", wire.MethodAssemblyPatternCreate, in.Count)
+	}
+	return occurrence.CircularArrangement{
+		Origin: math.P3(in.Origin[0], in.Origin[1], in.Origin[2]), Axis: axis, Step: in.Angle, Count: in.Count,
+	}, nil
+}
+
+// rectangularArrangement builds a Count1×Count2 grid arrangement along two directions.
+func rectangularArrangement(in wire.CreatePatternArgs) (occurrence.Arrangement, error) {
+	d1, err := math.NewUnitVector3(in.Direction1[0], in.Direction1[1], in.Direction1[2])
+	if err != nil {
+		return nil, fmt.Errorf("%s: direction1 %v is not a direction: %w", wire.MethodAssemblyPatternCreate, in.Direction1, err)
+	}
+	d2, err := math.NewUnitVector3(in.Direction2[0], in.Direction2[1], in.Direction2[2])
+	if err != nil {
+		return nil, fmt.Errorf("%s: direction2 %v is not a direction: %w", wire.MethodAssemblyPatternCreate, in.Direction2, err)
+	}
+	if in.Count1 < 1 || in.Count2 < 1 {
+		return nil, fmt.Errorf("%s: counts %d×%d must be >= 1", wire.MethodAssemblyPatternCreate, in.Count1, in.Count2)
+	}
+	return occurrence.RectangularArrangement{
+		Dir1: d1, Spacing1: in.Spacing1, Count1: in.Count1, Dir2: d2, Spacing2: in.Spacing2, Count2: in.Count2,
+	}, nil
+}
+
+// newOccurrencesReply marshals the occurrences an additive replication op created.
+func newOccurrencesReply(created []*occurrence.Occurrence) (json.RawMessage, error) {
+	out := make([]wire.OccurrenceInfo, len(created))
+	for i, o := range created {
+		out[i] = occurrenceInfo(o)
+	}
+	return json.Marshal(wire.NewOccurrencesResult{Created: out})
+}

--- a/addin/router/assembly_replication_test.go
+++ b/addin/router/assembly_replication_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestAssemblyPatternCircularOverWire replicates a seed component four-up around the Z
+// axis: the pattern adds three new occurrences (elements 1–3 beyond the seed), so the
+// tree grows from one to four.
+func TestAssemblyPatternCircularOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0)
+
+	var created wire.NewOccurrencesResult
+	args := fmt.Sprintf(`{"seed":%d,"kind":"circular","origin":[0,0,0],"axis":[0,0,1],"angle":%g,"count":4}`, occs[0].ID(), stdmath.Pi/2)
+	call(t, r, s, "assembly.patternCreate", args, &created)
+	if len(created.Created) != 3 {
+		t.Fatalf("circular pattern created %d occurrences, want 3 (4 total minus the seed)", len(created.Created))
+	}
+
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.occurrences", `{}`, &tree)
+	if len(tree.Occurrences) != 4 {
+		t.Errorf("tree = %d occurrences, want 4 after the 4-up pattern", len(tree.Occurrences))
+	}
+
+	if _, err := r.Handle(s, "assembly.patternCreate", []byte(fmt.Sprintf(`{"seed":%d,"kind":"helical","count":2}`, occs[0].ID()))); err == nil {
+		t.Error("an unknown pattern kind should fail")
+	}
+}
+
+// TestAssemblyMirrorOverWire mirrors a component (placed at x=2) across the YZ plane
+// through the origin: the new occurrence sits at x=-2.
+func TestAssemblyMirrorOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 2)
+
+	var mirrored wire.NewOccurrencesResult
+	args := fmt.Sprintf(`{"sources":[%d],"origin":[0,0,0],"normal":[1,0,0]}`, occs[0].ID())
+	call(t, r, s, "assembly.mirror", args, &mirrored)
+	if len(mirrored.Created) != 1 {
+		t.Fatalf("mirror created %d occurrences, want 1", len(mirrored.Created))
+	}
+	if got := mirrored.Created[0].Transform.Cells[3]; got != -2 {
+		t.Errorf("mirror x-translation = %g, want -2 (reflected across x=0)", got)
+	}
+
+	if _, err := r.Handle(s, "assembly.mirror", []byte(`{"sources":[99999],"origin":[0,0,0],"normal":[1,0,0]}`)); err == nil {
+		t.Error("mirror of an unknown occurrence id should fail")
+	}
+}
+
+// TestAssemblyCopyOverWire copies a component, producing an independent occurrence at the
+// same placement.
+func TestAssemblyCopyOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 3)
+
+	var copied wire.NewOccurrencesResult
+	call(t, r, s, "assembly.copy", fmt.Sprintf(`{"sources":[%d]}`, occs[0].ID()), &copied)
+	if len(copied.Created) != 1 {
+		t.Fatalf("copy created %d occurrences, want 1", len(copied.Created))
+	}
+	if copied.Created[0].ID == occs[0].ID() || copied.Created[0].Transform.Cells[3] != 3 {
+		t.Errorf("copy = %+v, want a new occurrence at the source's placement (x=3)", copied.Created[0])
+	}
+}
+
+// TestAssemblySubstituteOverWire substitutes two components with one simplified part: the
+// substitute occurrence is flagged, and the sources are suppressed.
+func TestAssemblySubstituteOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 5)
+	lod := openPartDoc(t, s, "lod.obk")
+
+	var sub wire.OccurrenceResult
+	args := fmt.Sprintf(`{"sources":[%d,%d],"document":%d,"name":"lod:1","transform":%s}`,
+		occs[0].ID(), occs[1].ID(), uint64(lod.ID()), transformJSON(0, 0, 0))
+	call(t, r, s, "assembly.substitute", args, &sub)
+	if sub.Occurrence.Name != "lod:1" || !sub.Occurrence.Substitute {
+		t.Fatalf("substitute = %+v, want a substitute occurrence named lod:1", sub.Occurrence)
+	}
+	if !occs[0].Suppressed() || !occs[1].Suppressed() {
+		t.Error("substituted sources should be suppressed")
+	}
+
+	if _, err := r.Handle(s, "assembly.substitute", []byte(`{"sources":[99999],"document":1,"name":"x","transform":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}`)); err == nil {
+		t.Error("substitute of an unknown source id should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -57,6 +57,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyDeriveHandlers()
 	r.registerAssemblyFeatureHandlers()
 	r.registerAssemblyOccurrenceHandlers()
+	r.registerAssemblyReplicationHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/model/occurrence/contract_assert.go
+++ b/model/occurrence/contract_assert.go
@@ -10,3 +10,10 @@ var (
 	_ contract.ComponentOccurrence  = (*Occurrence)(nil)
 	_ contract.ComponentOccurrences = (*Occurrences)(nil)
 )
+
+// The pattern model satisfies the public contract's scalar pattern read surfaces (#729);
+// pattern elements are created/read as occurrences over api/wire (assembly.patternCreate).
+var (
+	_ contract.OccurrencePattern        = (*OccurrencePattern)(nil)
+	_ contract.OccurrencePatternElement = (*OccurrencePatternElement)(nil)
+)


### PR DESCRIPTION
## What
Implements the **assembly component replication** surface (#729) against the contract+wire from Oblikovati/Oblikovati.API#83:
- **addin/router** serves `assembly.patternCreate` (circular/rectangular — places a real occurrence per generated element beyond the seed, reusing the tested arrangement model), `mirror`/`copy` (via the model's `MirrorComponents`/`CopyComponents`), and `substitute` (suppress the sources, add one occurrence instancing a simplified part resolved from an open document). Seed/sources are addressed by occurrence session id.
- **contract assertions**: `occurrence.OccurrencePattern`/`.OccurrencePatternElement` satisfy the public scalar interfaces.

## Why
Exposure layer (ADR-0018) for the M11-F04 replication model so add-ins/head can pattern, mirror, copy, and substitute placed components.

## Notes
`patternCreate` materializes the seed's replicated elements as independent occurrences (they appear in `assembly.occurrences`), reusing the tested `OccurrencePattern`/arrangement math. The editable persistent-pattern object (per-element suppress/reposition, live arrangement edits) needs an assembly-level pattern collection — a model follow-up beyond this exposure layer.

## Tests (router, over the wire)
4-up circular pattern; mirror across a plane (reflected placement); independent copy; substitute (flagged occurrence + suppressed sources); unknown-id and unknown-kind rejection.

## Depends on
Contract: Oblikovati/Oblikovati.API#83 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)