### PR TITLE
router,bomapi: assembly BOM public surface (M11)

### DIFF
--- a/addin/router/assembly_bom.go
+++ b/addin/router/assembly_bom.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/bom"
+	"oblikovati.org/model/bomapi"
+	"oblikovati.org/model/compdef"
+)
+
+// The assembly bill-of-materials surface (M11-F05, #730): read a structured (nested) or
+// parts-only (flat) BOM view of the active assembly, and export a view to CSV with optional
+// custom property columns. The BOM derives live from the current occurrence tree.
+
+// registerAssemblyBOMHandlers wires the assembly.bom* methods.
+func (r *Router) registerAssemblyBOMHandlers() {
+	r.handlers[wire.MethodAssemblyBOMView] = assemblyBOMView
+	r.handlers[wire.MethodAssemblyBOMExport] = assemblyBOMExport
+}
+
+// assemblyBOMView returns the requested BOM view of the active assembly.
+func assemblyBOMView(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.BOMViewArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	view, err := bomViewByKind(asm, in.View)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.BOMViewResult{View: in.View, Rows: bomRowInfos(view.Rows)})
+}
+
+// assemblyBOMExport renders a BOM view of the active assembly to CSV with the standard
+// columns plus one per requested component property.
+func assemblyBOMExport(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.BOMExportArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	view, err := bomViewByKind(asm, in.View)
+	if err != nil {
+		return nil, err
+	}
+	csv, err := bom.ExportCSV(view, exportColumns(in.Columns))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyBOMExport, err)
+	}
+	return json.Marshal(wire.BOMExportResult{CSV: csv})
+}
+
+// bomViewByKind builds the active assembly's BOM and selects the requested view.
+func bomViewByKind(asm *compdef.AssemblyComponentDefinition, kind types.BOMViewKind) (*bom.View, error) {
+	b := bom.New(asm.Occurrences())
+	switch kind {
+	case types.BOMStructured:
+		return b.Structured(), nil
+	case types.BOMPartsOnly:
+		return b.PartsOnly(), nil
+	}
+	return nil, fmt.Errorf("%s: unknown view %q (want structured/partsOnly)", wire.MethodAssemblyBOMView, kind)
+}
+
+// exportColumns is the standard column set plus one property column per requested name.
+func exportColumns(extra []string) []bom.Column {
+	cols := bom.StandardColumns()
+	for _, name := range extra {
+		cols = append(cols, bom.PropertyColumn(name))
+	}
+	return cols
+}
+
+// bomRowInfos renders a slice of BOM rows (recursing into structured children) as DTOs.
+func bomRowInfos(rows []*bom.Row) []wire.BOMRowInfo {
+	out := make([]wire.BOMRowInfo, len(rows))
+	for i, r := range rows {
+		out[i] = bomRowInfo(r)
+	}
+	return out
+}
+
+// bomRowInfo renders one BOM row (and its children) as its wire DTO.
+func bomRowInfo(r *bom.Row) wire.BOMRowInfo {
+	return wire.BOMRowInfo{
+		ItemNumber:  r.ItemNumber,
+		PartNumber:  r.PartNumber,
+		Description: r.Description,
+		Structure:   bomapi.BOMStructure(r.Structure),
+		Quantity:    r.Quantity,
+		Properties:  r.Properties,
+		Children:    bomRowInfos(r.Children),
+	}
+}

--- a/addin/router/assembly_bom_test.go
+++ b/addin/router/assembly_bom_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/math"
+)
+
+// TestAssemblyBOMViewOverWire reads parts-only and structured BOM views of an assembly
+// holding two placements of one component: each view totals to a single row of quantity 2.
+func TestAssemblyBOMViewOverWire(t *testing.T) {
+	r, s, asm, _ := assemblySessionWithBoxes(t)
+	part := blockPart(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	asm.Place("box:1", part, math.Identity4())
+	asm.Place("box:2", part, math.Translation4(math.V3(2, 0, 0)))
+
+	var parts wire.BOMViewResult
+	call(t, r, s, "assembly.bomView", `{"view":"partsOnly"}`, &parts)
+	if parts.View != types.BOMPartsOnly || len(parts.Rows) != 1 || parts.Rows[0].Quantity != 2 {
+		t.Fatalf("parts-only = %+v, want one row of quantity 2", parts.Rows)
+	}
+	if parts.Rows[0].Structure != types.BOMNormal {
+		t.Errorf("structure = %q, want normal", parts.Rows[0].Structure)
+	}
+
+	var structured wire.BOMViewResult
+	call(t, r, s, "assembly.bomView", `{"view":"structured"}`, &structured)
+	if len(structured.Rows) != 1 || structured.Rows[0].Quantity != 2 {
+		t.Errorf("structured = %+v, want one row of quantity 2", structured.Rows)
+	}
+
+	if _, err := r.Handle(s, "assembly.bomView", []byte(`{"view":"bogus"}`)); err == nil {
+		t.Error("an unknown view should fail")
+	}
+}
+
+// TestAssemblyBOMExportOverWire exports a BOM to CSV with a custom property column and
+// checks the header carries the standard columns plus the requested one.
+func TestAssemblyBOMExportOverWire(t *testing.T) {
+	r, s, asm, _ := assemblySessionWithBoxes(t)
+	asm.Place("box:1", blockPart(t, math.P3(0, 0, 0), math.P3(1, 1, 1)), math.Identity4())
+
+	var res wire.BOMExportResult
+	call(t, r, s, "assembly.bomExport", `{"view":"partsOnly","columns":["Material"]}`, &res)
+	header, _, _ := strings.Cut(res.CSV, "\n")
+	for _, col := range []string{"Item", "Part Number", "Description", "QTY", "Structure", "Material"} {
+		if !strings.Contains(header, col) {
+			t.Errorf("CSV header %q missing column %q", header, col)
+		}
+	}
+
+	if _, err := r.Handle(s, "assembly.bomExport", []byte(`{"view":"bogus"}`)); err == nil {
+		t.Error("an unknown view should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -58,6 +58,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyFeatureHandlers()
 	r.registerAssemblyOccurrenceHandlers()
 	r.registerAssemblyReplicationHandlers()
+	r.registerAssemblyBOMHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/model/bomapi/bomapi.go
+++ b/model/bomapi/bomapi.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package bomapi adapts the model's bill-of-materials (model/bom) to the public scalar
+// contract surface (api/contract), the way bodyapi/geomapi adapt their kernels. The BOM
+// rows/views are data structs; these thin adapters expose them as the contract's getter
+// interfaces for an in-proc consumer (the head). The over-the-wire surface is served from
+// addin/router (M11-F05, #730).
+package bomapi
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/bom"
+	"oblikovati.org/model/occurrence"
+)
+
+// New returns the contract BOM read surface over the occurrences' live bill of materials.
+func New(root *occurrence.Occurrences) contract.BOM { return bomAdapter{bom.New(root)} }
+
+type bomAdapter struct{ b *bom.BOM }
+
+func (a bomAdapter) Structured() contract.BOMView { return viewAdapter{a.b.Structured()} }
+func (a bomAdapter) PartsOnly() contract.BOMView  { return viewAdapter{a.b.PartsOnly()} }
+
+type viewAdapter struct{ v *bom.View }
+
+func (a viewAdapter) Kind() types.BOMViewKind { return viewKind(a.v.Kind) }
+func (a viewAdapter) Rows() []contract.BOMRow { return wrapRows(a.v.Rows) }
+
+type rowAdapter struct{ r *bom.Row }
+
+func (a rowAdapter) ItemNumber() int               { return a.r.ItemNumber }
+func (a rowAdapter) PartNumber() string            { return a.r.PartNumber }
+func (a rowAdapter) Description() string           { return a.r.Description }
+func (a rowAdapter) Structure() types.BOMStructure { return BOMStructure(a.r.Structure) }
+func (a rowAdapter) Quantity() int                 { return a.r.Quantity }
+func (a rowAdapter) Children() []contract.BOMRow   { return wrapRows(a.r.Children) }
+
+// wrapRows adapts a slice of model rows to the contract row surface.
+func wrapRows(rows []*bom.Row) []contract.BOMRow {
+	out := make([]contract.BOMRow, len(rows))
+	for i, r := range rows {
+		out[i] = rowAdapter{r}
+	}
+	return out
+}
+
+// BOMStructure maps a model structure to its public wire spelling (the model's own
+// String()), shared by the contract adapter and the router.
+func BOMStructure(s bom.Structure) types.BOMStructure { return types.BOMStructure(s.String()) }
+
+// viewKind maps a model view kind to its public spelling.
+func viewKind(k bom.ViewKind) types.BOMViewKind {
+	if k == bom.PartsOnlyView {
+		return types.BOMPartsOnly
+	}
+	return types.BOMStructured
+}
+
+var (
+	_ contract.BOM     = bomAdapter{}
+	_ contract.BOMView = viewAdapter{}
+	_ contract.BOMRow  = rowAdapter{}
+)

--- a/model/bomapi/bomapi_test.go
+++ b/model/bomapi/bomapi_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package bomapi_test
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/bomapi"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// TestBOMAdapterPartsOnlyTotalsQuantity checks the contract adapter surfaces the model's
+// parts-only view: two placements of one definition total to a single row of quantity 2,
+// reported with the default ("normal") structure and the parts-only kind.
+func TestBOMAdapterPartsOnlyTotalsQuantity(t *testing.T) {
+	part := compdef.NewPartComponentDefinition()
+	occs := occurrence.NewOccurrences()
+	occs.AddByComponentDefinition("p:1", part, math.Identity4())
+	occs.AddByComponentDefinition("p:2", part, math.Translation4(math.V3(2, 0, 0)))
+
+	view := bomapi.New(occs).PartsOnly()
+	if view.Kind() != types.BOMPartsOnly {
+		t.Errorf("view kind = %q, want partsOnly", view.Kind())
+	}
+	rows := view.Rows()
+	if len(rows) != 1 || rows[0].Quantity() != 2 {
+		t.Fatalf("rows = %d, want one row of quantity 2", len(rows))
+	}
+	if rows[0].Structure() != types.BOMNormal || rows[0].ItemNumber() != 1 {
+		t.Errorf("row = {item %d, %q}, want {1, normal}", rows[0].ItemNumber(), rows[0].Structure())
+	}
+}


### PR DESCRIPTION
## What
Implements the assembly **bill of materials** public surface (#730) against the contract+wire from Oblikovati/Oblikovati.API#84:
- **model/bomapi** adapts the data-shaped `model/bom` (BOM/View/Row structs) to the scalar contract `BOM`/`BOMView`/`BOMRow` getter interfaces — the established `bodyapi`/`geomapi` adapter convention — with compile-time assertions.
- **addin/router** serves `assembly.bomView` (structured/parts-only, rows with nested children) and `assembly.bomExport` (CSV with the standard columns plus one per requested component property).

## Why
Exposure layer (ADR-0018) for the M11-F05 BOM model. The BOM derives live from the occurrence tree. Component metadata sourced from document iProperties is the separate #718.

## Tests
`bomapi` adapter (parts-only totals quantity, view kind, default structure); router over-wire (both views total a shared component to one row of quantity 2; export header carries standard + custom columns; unknown-view rejection).

## Depends on
Contract: Oblikovati/Oblikovati.API#84 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)