### PR TITLE
router,feature: assemblyFeatures.edit scalar edits in place (M11-F08)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -34,6 +34,7 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesAddHole] = assemblyFeaturesAddHole
 	r.handlers[wire.MethodAssemblyFeaturesAddExtrude] = assemblyFeaturesAddExtrude
 	r.handlers[wire.MethodAssemblyFeaturesAddRevolve] = assemblyFeaturesAddRevolve
+	r.handlers[wire.MethodAssemblyFeaturesEdit] = assemblyFeaturesEdit
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
 	r.handlers[wire.MethodAssemblyFeaturesSetSuppressed] = assemblyFeaturesSetSuppressed
@@ -67,7 +68,7 @@ func assemblyFeaturesAdd(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	af := asm.AddFeature(cut)
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesAddProxyCut adds a feature whose tool is the proxied geometry of the
@@ -94,7 +95,7 @@ func assemblyFeaturesAddProxyCut(s *app.Session, raw json.RawMessage) (json.RawM
 	af.RemoveParticipant(source)
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesAddExtrude extrudes a closed sketch profile (authored on an assembly
@@ -123,7 +124,7 @@ func assemblyFeaturesAddExtrude(s *app.Session, raw json.RawMessage) (json.RawMe
 	af := asm.AddFeature(feature.NewAssemblyExtrudeFeature(sk, in.ProfileIndex, op, func() float64 { return distance }))
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesAddRevolve revolves a closed sketch profile (authored on an assembly
@@ -154,7 +155,7 @@ func assemblyFeaturesAddRevolve(s *app.Session, raw json.RawMessage) (json.RawMe
 	af := asm.AddFeature(feature.NewAssemblyRevolveFeature(sk, in.ProfileIndex, axis, op, func() float64 { return angle }))
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // revolveAxisFromArgs builds the assembly-space revolve axis from the request's origin and
@@ -191,7 +192,7 @@ func assemblyFeaturesAddHole(s *app.Session, raw json.RawMessage) (json.RawMessa
 	af := asm.AddFeature(hole)
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesSetParticipants replaces a feature's participation set.
@@ -214,7 +215,7 @@ func assemblyFeaturesSetParticipants(s *app.Session, raw json.RawMessage) (json.
 	}
 	af.SetParticipants(occs)
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesSetParticipantPaths restricts a feature to specific nested occurrence
@@ -238,7 +239,7 @@ func assemblyFeaturesSetParticipantPaths(s *app.Session, raw json.RawMessage) (j
 	}
 	af.SetParticipantPaths(paths)
 	asm.RecomputeFeatures()
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(af)})
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // resolveParticipantPaths validates each instance-name path resolves to an occurrence
@@ -257,6 +258,35 @@ func resolveParticipantPaths(asm *compdef.AssemblyComponentDefinition, paths [][
 		out = append(out, path)
 	}
 	return out, nil
+}
+
+// assemblyFeaturesEdit sets editable scalars of an assembly feature in place — the
+// assembly-context Edit Feature (#725), mirroring the part features.edit. The batch is
+// validated before any value is applied, then the feature program recomputes once.
+func assemblyFeaturesEdit(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.EditAssemblyFeatureArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	af, err := assemblyFeatureByID(asm, in.ID, wire.MethodAssemblyFeaturesEdit)
+	if err != nil {
+		return nil, err
+	}
+	ed, ok := af.Definition().(feature.Editable)
+	if !ok {
+		return nil, fmt.Errorf("%s: feature %d (%s) has no editable scalars", wire.MethodAssemblyFeaturesEdit, af.ID(), af.Kind())
+	}
+	apply, err := planScalarEdits(asm.Units(), ed, in.Scalars, wire.MethodAssemblyFeaturesEdit)
+	if err != nil {
+		return nil, err
+	}
+	apply()
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesSetSuppressed suppresses or unsuppresses the named features in batch.
@@ -362,7 +392,7 @@ func assemblyFeaturesResult(asm *compdef.AssemblyComponentDefinition) wire.Assem
 	feats := asm.Features()
 	out := make([]wire.AssemblyFeatureInfo, feats.Count())
 	for i := 0; i < feats.Count(); i++ {
-		out[i] = assemblyFeatureInfo(feats.Item(i))
+		out[i] = assemblyFeatureInfo(asm, feats.Item(i))
 	}
 	return wire.AssemblyFeaturesResult{
 		Features:      out,
@@ -372,12 +402,13 @@ func assemblyFeaturesResult(asm *compdef.AssemblyComponentDefinition) wire.Assem
 }
 
 // assemblyFeatureInfo renders one assembly feature as its wire DTO.
-func assemblyFeatureInfo(af *compdef.AssemblyFeature) wire.AssemblyFeatureInfo {
+func assemblyFeatureInfo(asm *compdef.AssemblyComponentDefinition, af *compdef.AssemblyFeature) wire.AssemblyFeatureInfo {
 	info := wire.AssemblyFeatureInfo{
 		ID:         af.ID(),
 		Kind:       af.Kind(),
 		Name:       af.Name(),
 		Suppressed: af.Suppressed(),
+		Scalars:    editableScalars(asm.Units(), af.Definition()),
 	}
 	if h := af.Health(); !h.OK() {
 		info.Health = h.Reason

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -5,6 +5,7 @@ package router
 import (
 	"fmt"
 	stdmath "math"
+	"strings"
 	"testing"
 
 	"oblikovati.org/addin/opregistry"
@@ -98,6 +99,53 @@ func TestAssemblyExtrudeOverWire(t *testing.T) {
 	}
 	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.7) > 1e-6 {
 		t.Errorf("extrude-cut volume = %g, want 0.7 (unit box minus a 0.5×1×0.6 pocket)", got)
+	}
+}
+
+// TestAssemblyFeatureEditOverWire authors a profiled extrude-cut, then edits its depth in
+// place over the wire — the assembly-context Edit Feature (#725). The deeper pocket
+// removes more material (gated against the analytic value), while the box cut exposes no
+// editable scalars (its tool is fixed at construction) so editing it is rejected.
+func TestAssemblyFeatureEditOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &sk)
+	var rect wire.SketchRectangleResult
+	call(t, r, s, "sketch.rectangle", fmt.Sprintf(`{"sketchIndex":%d,"width":"0.5 cm","height":"1 cm"}`, sk.SketchIndex), &rect)
+
+	var added wire.AssemblyFeatureResult
+	addArgs := fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"distance":0.6,"operation":"difference"}`, sk.SketchIndex)
+	call(t, r, s, "assemblyFeatures.addExtrude", addArgs, &added)
+	if len(added.Feature.Scalars) != 1 || added.Feature.Scalars[0].Label != "Distance" {
+		t.Fatalf("addExtrude scalars = %+v, want one editable Distance scalar", added.Feature.Scalars)
+	}
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.7) > 1e-6 {
+		t.Fatalf("pre-edit volume = %g, want 0.7 (0.5×1×0.6 pocket)", got)
+	}
+
+	// Deepen the pocket from 0.6 to 0.8: the participant loses more material.
+	var edited wire.AssemblyFeatureResult
+	editArgs := fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"0.8 cm"}]}`, added.Feature.ID)
+	call(t, r, s, "assemblyFeatures.edit", editArgs, &edited)
+	if edited.Feature.ID != added.Feature.ID {
+		t.Fatalf("edit returned feature %d, want %d", edited.Feature.ID, added.Feature.ID)
+	}
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.6) > 1e-6 {
+		t.Errorf("post-edit volume = %g, want 0.6 (deeper 0.5×1×0.8 pocket)", got)
+	}
+
+	// The box cut bakes its tool at construction, so it exposes nothing editable.
+	var cut wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.add", topHalfCut(), &cut)
+	if len(cut.Feature.Scalars) != 0 {
+		t.Errorf("box cut scalars = %+v, want none", cut.Feature.Scalars)
+	}
+	if _, err := r.Handle(s, "assemblyFeatures.edit", []byte(fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"1 cm"}]}`, cut.Feature.ID))); err == nil {
+		t.Error("editing a box cut (no editable scalars) should fail")
+	}
+	if _, err := r.Handle(s, "assemblyFeatures.edit", []byte(fmt.Sprintf(`{"id":%d,"scalars":[{"index":5,"value":"1 cm"}]}`, added.Feature.ID))); err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("out-of-range scalar index err = %v, want 'out of range'", err)
 	}
 }
 

--- a/addin/router/feature_lifecycle.go
+++ b/addin/router/feature_lifecycle.go
@@ -11,7 +11,6 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
-	"oblikovati.org/model/param"
 )
 
 // Handlers for the features.* lifecycle methods (issue #140): get, edit (scalar
@@ -49,22 +48,7 @@ func featureDetail(part *compdef.PartComponentDefinition, f *feature.PartFeature
 // featureScalars renders the feature's editable scalars with their value in the
 // document's preferred unit; nil when the definition exposes nothing editable.
 func featureScalars(part *compdef.PartComponentDefinition, f *feature.PartFeature) []wire.FeatureScalar {
-	ed, ok := f.Definition().(feature.Editable)
-	if !ok {
-		return nil
-	}
-	params := ed.EditableParams()
-	out := make([]wire.FeatureScalar, len(params))
-	for i, p := range params {
-		out[i] = wire.FeatureScalar{
-			Index:   i,
-			Label:   p.Label,
-			Unit:    part.Units().PreferredName(p.Unit),
-			Value:   part.Units().ToPreferred(param.Q(p.Get(), p.Unit)),
-			Integer: p.Integer,
-		}
-	}
-	return out
+	return editableScalars(part.Units(), f.Definition())
 }
 
 // featureDetailReply marshals the refreshed-feature response shared by the
@@ -131,32 +115,11 @@ func editFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 // index in range, each value parseable in the scalar's unit — and returns a single
 // closure that applies every Set (Set itself cannot fail).
 func parseScalarEdits(part *compdef.PartComponentDefinition, f *feature.PartFeature, edits []wire.ScalarEdit) (func(), error) {
-	if len(edits) == 0 {
-		return nil, fmt.Errorf("features.edit: scalars is empty; expected at least one {index,value} edit")
-	}
 	ed, ok := f.Definition().(feature.Editable)
 	if !ok {
 		return nil, fmt.Errorf("features.edit: feature %d (%s) has no editable scalars", uint64(f.ID()), f.Kind())
 	}
-	params := ed.EditableParams()
-	sets := make([]func(), len(edits))
-	for i, e := range edits {
-		if e.Index < 0 || e.Index >= len(params) {
-			return nil, fmt.Errorf("features.edit: scalar index %d out of range (%d scalars, see features.get)", e.Index, len(params))
-		}
-		p := params[e.Index]
-		q, err := part.Units().Parse(e.Value, p.Unit)
-		if err != nil {
-			return nil, fmt.Errorf("features.edit: scalar %d value %q: %w", e.Index, e.Value, err)
-		}
-		set, v := p.Set, q.Value
-		sets[i] = func() { set(v) }
-	}
-	return func() {
-		for _, set := range sets {
-			set()
-		}
-	}, nil
+	return planScalarEdits(part.Units(), ed, edits, wire.MethodFeaturesEdit)
 }
 
 // deleteFeature removes a feature from the history and recomputes.

--- a/addin/router/feature_scalars.go
+++ b/addin/router/feature_scalars.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
+)
+
+// Shared scalar render/validate logic for the two Edit Feature surfaces — the part
+// features.edit and the assembly assemblyFeatures.edit (Oblikovati/Oblikovati#725) —
+// so both expose and apply scalar edits identically against any feature.Editable
+// definition.
+
+// editableScalars renders f's editable scalars in units's preferred unit, or nil when
+// the definition exposes nothing editable. The index is the scalar's slot for an edit.
+func editableScalars(units param.UnitsOfMeasure, f feature.Feature) []wire.FeatureScalar {
+	ed, ok := f.(feature.Editable)
+	if !ok {
+		return nil
+	}
+	params := ed.EditableParams()
+	out := make([]wire.FeatureScalar, len(params))
+	for i, p := range params {
+		out[i] = wire.FeatureScalar{
+			Index:   i,
+			Label:   p.Label,
+			Unit:    units.PreferredName(p.Unit),
+			Value:   units.ToPreferred(param.Q(p.Get(), p.Unit)),
+			Integer: p.Integer,
+		}
+	}
+	return out
+}
+
+// planScalarEdits validates a whole batch against ed — non-empty, each index in range,
+// each value parseable in its scalar's unit — and returns one closure applying every Set
+// (Set itself cannot fail), so a bad value mid-batch never leaves a definition
+// half-edited. method names the wire method for errors.
+func planScalarEdits(units param.UnitsOfMeasure, ed feature.Editable, edits []wire.ScalarEdit, method string) (func(), error) {
+	if len(edits) == 0 {
+		return nil, fmt.Errorf("%s: scalars is empty; expected at least one {index,value} edit", method)
+	}
+	params := ed.EditableParams()
+	sets := make([]func(), len(edits))
+	for i, e := range edits {
+		if e.Index < 0 || e.Index >= len(params) {
+			return nil, fmt.Errorf("%s: scalar index %d out of range (%d scalars)", method, e.Index, len(params))
+		}
+		p := params[e.Index]
+		q, err := units.Parse(e.Value, p.Unit)
+		if err != nil {
+			return nil, fmt.Errorf("%s: scalar %d value %q: %w", method, e.Index, e.Value, err)
+		}
+		set, v := p.Set, q.Value
+		sets[i] = func() { set(v) }
+	}
+	return func() {
+		for _, set := range sets {
+			set()
+		}
+	}, nil
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -466,6 +466,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyFeaturesAddProxyCut:         true,
 	wire.MethodAssemblyFeaturesAddHole:             true,
 	wire.MethodAssemblyFeaturesAddExtrude:          true,
+	wire.MethodAssemblyFeaturesEdit:                true,
 	wire.MethodAssemblyFeaturesSetParticipants:     true,
 	wire.MethodAssemblyFeaturesSetParticipantPaths: true,
 	wire.MethodAssemblyFeaturesSetSuppressed:       true,

--- a/model/feature/assembly_editable.go
+++ b/model/feature/assembly_editable.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "oblikovati.org/model/param"
+
+// Edit Feature scalar coverage for the assembly-context machining features (M11-F08,
+// Oblikovati/Oblikovati#725): the assemblyFeatures.edit wire surface renders whatever
+// EditableParams exposes, so a kind without an implementation cannot be edited after
+// placement. The sketch-profiled kinds drive their scalar through a closure
+// ([scalarParam]) so an edit reflows the next recompute; the box cut and the drilled
+// hole bake a fixed tool at construction and so expose nothing editable here.
+
+var (
+	_ Editable = (*AssemblyExtrudeFeature)(nil)
+	_ Editable = (*AssemblyRevolveFeature)(nil)
+)
+
+// EditableParams exposes the assembly extrude's depth.
+func (f *AssemblyExtrudeFeature) EditableParams() []EditableParam {
+	return []EditableParam{scalarParam("Distance", param.Length, &f.distance)}
+}
+
+// EditableParams exposes the assembly revolve's sweep angle.
+func (f *AssemblyRevolveFeature) EditableParams() []EditableParam {
+	return []EditableParam{scalarParam("Angle", param.Angle, &f.angle)}
+}

--- a/model/feature/assembly_editable_test.go
+++ b/model/feature/assembly_editable_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/param"
+)
+
+// TestAssemblyExtrudeEditableDistance checks the extrude exposes its depth as a single
+// editable length scalar whose Set reflows the closure the next recompute reads (#725).
+func TestAssemblyExtrudeEditableDistance(t *testing.T) {
+	f := NewAssemblyExtrudeFeature(nil, 0, ops.Cut, func() float64 { return 3 })
+	ps := f.EditableParams()
+	if len(ps) != 1 || ps[0].Label != "Distance" || ps[0].Unit != param.Length {
+		t.Fatalf("EditableParams = %+v, want one Distance length scalar", ps)
+	}
+	if got := ps[0].Get(); got != 3 {
+		t.Errorf("Get = %g, want 3", got)
+	}
+	ps[0].Set(8)
+	if got := f.EditableParams()[0].Get(); got != 8 {
+		t.Errorf("after Set(8) the distance closure should reflow to 8, got %g", got)
+	}
+}
+
+// TestAssemblyRevolveEditableAngle checks the revolve exposes its sweep as a single
+// editable angle scalar whose Set reflows the closure the next recompute reads (#725).
+func TestAssemblyRevolveEditableAngle(t *testing.T) {
+	f := NewAssemblyRevolveFeature(nil, 0, nil, ops.Cut, func() float64 { return stdmath.Pi })
+	ps := f.EditableParams()
+	if len(ps) != 1 || ps[0].Label != "Angle" || ps[0].Unit != param.Angle {
+		t.Fatalf("EditableParams = %+v, want one Angle scalar", ps)
+	}
+	if got := ps[0].Get(); got != stdmath.Pi {
+		t.Errorf("Get = %g, want π", got)
+	}
+	ps[0].Set(stdmath.Pi / 2)
+	if got := f.EditableParams()[0].Get(); got != stdmath.Pi/2 {
+		t.Errorf("after Set(π/2) the angle closure should reflow, got %g", got)
+	}
+}


### PR DESCRIPTION
## What
Completes the assembly feature public push surface (#725) with its last missing method: **editing a placed assembly machining feature's scalar inputs in place** — the assembly-context Edit Feature, mirroring the part `features.edit`.

- **model/feature**: the sketch-profiled kinds expose their scalar via `EditableParams` so an edit reflows the next recompute — `assemblyExtrude` its depth (length), `assemblyRevolve` its sweep angle. The box cut and drilled hole bake a fixed tool at construction and so expose nothing editable (like a cosmetic part feature).
- **addin/router**: `assemblyFeaturesEdit` validates the whole batch before applying any value (a bad value mid-batch must not half-edit the definition), then recomputes the feature program once. `AssemblyFeatureInfo` now advertises its editable scalars, so `list`/`add` replies tell a client exactly what `edit` accepts.
- Shares the scalar render/validate logic between the part `features.edit` and this assembly surface (new `feature_scalars.go`) instead of duplicating it.

## Why
`add`/`list`/`setParticipants`/`setSuppressed`/end-of-features were exposed for assembly features, but `edit` (explicitly in #725's wire scope) was missing — a placed assembly extrude/revolve could not be re-dimensioned over the wire.

## Tests
- `model/feature`: extrude exposes one editable Distance (length) scalar, revolve one Angle scalar, and `Set` reflows the backing closure.
- `addin/router` (over-wire, volume-gated): authoring a 0.6-deep extrude pocket then editing it to 0.8 removes the expected extra material (0.7 → 0.6); a box cut advertises no scalars and editing it (or an out-of-range index) is rejected.

Full root-module `go test ./...` and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally.

## Depends on
Contract: Oblikovati/Oblikovati.API#85 (merged).

Closes #725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)