### PR TITLE
model: persist assembly occurrences & resolve components on open (M11)

### DIFF
--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -124,12 +124,23 @@ func (a *AssemblyComponentDefinition) Place(name string, def occurrence.Definiti
 // component link. Use [PlaceComponentFromFile] to place an occurrence that survives a
 // save/reopen (it records the assembly→component reference and the document name).
 func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *doc.Document, transform math.Matrix4) (*occurrence.Occurrence, error) {
+	def, err := placeableDefinition(componentDoc)
+	if err != nil {
+		return nil, err
+	}
+	return a.Place(name, def, transform), nil
+}
+
+// placeableDefinition extracts the component definition a document holds, erroring when
+// its content is not placeable (a reference stub, a drawing). Shared by the in-memory and
+// file-backed place paths.
+func placeableDefinition(componentDoc *doc.Document) (occurrence.Definition, error) {
 	def, ok := componentDoc.Content().(occurrence.Definition)
 	if !ok {
 		return nil, fmt.Errorf("compdef: cannot place %q: its content %T is not a placeable component definition",
 			componentDoc.DisplayName(), componentDoc.Content())
 	}
-	return a.Place(name, def, transform), nil
+	return def, nil
 }
 
 // PlaceComponentFromFile places componentDoc into owner's assembly under name at
@@ -138,10 +149,9 @@ func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *
 // saved and restored across a reopen (#715). owner is the assembly's own document (the
 // one whose content is this definition); componentDoc is the component to instance.
 func (a *AssemblyComponentDefinition) PlaceComponentFromFile(owner, componentDoc *doc.Document, name string, transform math.Matrix4) (*occurrence.Occurrence, error) {
-	def, ok := componentDoc.Content().(occurrence.Definition)
-	if !ok {
-		return nil, fmt.Errorf("compdef: cannot place %q: its content %T is not a placeable component definition",
-			componentDoc.DisplayName(), componentDoc.Content())
+	def, err := placeableDefinition(componentDoc)
+	if err != nil {
+		return nil, err
 	}
 	componentName := componentDoc.FullDocumentName()
 	occ := a.occurrences.AddByComponentName(name, def, componentName, transform)

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -37,6 +37,10 @@ type AssemblyComponentDefinition struct {
 	params      *param.Parameters     // parameter DAG for assembly sketch dimensions
 	work        *feature.WorkGeometry // origin frame + user work planes, in assembly space
 	sketches    *sketch.Sketches      // sketches authored in the assembly (profile inputs)
+	// pending holds occurrence records parsed by ApplyRecipe but not yet bound to live
+	// component definitions — ApplyRecipe has no workspace, so binding waits for
+	// ResolveReferences once the document is registered (#715). Empty outside a reopen.
+	pending []occurrenceRecipe
 }
 
 // NewAssemblyComponentDefinition returns an empty assembly content object: no
@@ -60,17 +64,20 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 	return a
 }
 
-// An assembly definition is plain document content, not recipe-bearing content: it
-// has no recipe to persist until its occurrences reference documents (M11-F02), so
-// it intentionally does NOT implement doc.RecipeContent (contrast PartComponentDefinition).
-var _ doc.Content = (*AssemblyComponentDefinition)(nil)
+// An assembly persists its occurrence structure as a recipe and rebinds each occurrence
+// to its component document through the reference graph on reopen (#715), so it is both
+// recipe-bearing content and a reference resolver (the marshal/apply live in
+// assembly_serialize.go).
+var (
+	_ doc.RecipeContent     = (*AssemblyComponentDefinition)(nil)
+	_ doc.ReferenceResolver = (*AssemblyComponentDefinition)(nil)
+)
 
 // init registers the real assembly content with the document layer so opening or
 // creating an assembly document yields a live AssemblyComponentDefinition, not the
-// identity-only stub (see doc.RegisterContentFactory). The assembly does not yet
-// implement doc.RecipeContent: its occurrences reference documents through the
-// reference graph that arrives in M11-F02, so there is nothing recipe-persistable
-// until then — today an assembly round-trips its identity (manifest) alone.
+// identity-only stub (see doc.RegisterContentFactory). Its recipe (assembly_serialize.go)
+// restores the occurrence structure; the component documents those occurrences instance
+// are resolved through the reference graph after the assembly is registered (#715).
 func init() {
 	doc.RegisterContentFactory(doc.Assembly, func() doc.Content { return NewAssemblyComponentDefinition() })
 }
@@ -113,9 +120,9 @@ func (a *AssemblyComponentDefinition) Place(name string, def occurrence.Definiti
 // component. It errors if the content is not a placeable component definition (e.g. a
 // reference stub or a drawing).
 //
-// NOTE: this links the in-memory definitions only. Recording the assembly→component
-// document reference (the reference graph) and persisting placements arrive in a
-// follow-up — see the assembly-persistence note on the package factory.
+// NOTE: this links the in-memory definitions only — the occurrence carries no persistent
+// component link. Use [PlaceComponentFromFile] to place an occurrence that survives a
+// save/reopen (it records the assembly→component reference and the document name).
 func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *doc.Document, transform math.Matrix4) (*occurrence.Occurrence, error) {
 	def, ok := componentDoc.Content().(occurrence.Definition)
 	if !ok {
@@ -123,6 +130,24 @@ func (a *AssemblyComponentDefinition) PlaceComponent(name string, componentDoc *
 			componentDoc.DisplayName(), componentDoc.Content())
 	}
 	return a.Place(name, def, transform), nil
+}
+
+// PlaceComponentFromFile places componentDoc into owner's assembly under name at
+// transform AS A PERSISTENT placement: the occurrence records the component's document
+// name, and owner records the assembly→component reference (deduped) so the placement is
+// saved and restored across a reopen (#715). owner is the assembly's own document (the
+// one whose content is this definition); componentDoc is the component to instance.
+func (a *AssemblyComponentDefinition) PlaceComponentFromFile(owner, componentDoc *doc.Document, name string, transform math.Matrix4) (*occurrence.Occurrence, error) {
+	def, ok := componentDoc.Content().(occurrence.Definition)
+	if !ok {
+		return nil, fmt.Errorf("compdef: cannot place %q: its content %T is not a placeable component definition",
+			componentDoc.DisplayName(), componentDoc.Content())
+	}
+	componentName := componentDoc.FullDocumentName()
+	occ := a.occurrences.AddByComponentName(name, def, componentName, transform)
+	// Record (and resolve to the already-open) reference so save snapshots the edge.
+	owner.OpenReference(componentName)
+	return occ, nil
 }
 
 // Events returns the assembly's occurrence-lifecycle event source — subscribe add-ins

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/occurrence"
+	"oblikovati.org/persistence/yamlcodec"
+)
+
+// Assembly persistence (#715): the assembly recipe records its display units and its
+// occurrence structure — which component document each occurrence instances, where, and
+// in what state. Component documents themselves are NOT embedded; they are resolved
+// through the reference graph on reopen (ResolveReferences below), so one part edited on
+// disk updates every assembly that places it. A part-only assembly graph stays a tree of
+// .obk files referencing each other, exactly as the reference API models it.
+
+// assemblyRecipe is the persisted form of an AssemblyComponentDefinition: display units
+// plus the placed occurrences, in placement order.
+type assemblyRecipe struct {
+	Units       map[string]string  `yaml:"units,omitempty"`
+	Occurrences []occurrenceRecipe `yaml:"occurrences,omitempty"`
+}
+
+// occurrenceRecipe is the persisted form of one placement: the component document it
+// instances (full document name), its instance name and transform (16 row-major cells,
+// the same form the move feature persists), and its per-instance state flags.
+type occurrenceRecipe struct {
+	Name       string    `yaml:"name"`
+	Component  string    `yaml:"component"`
+	Transform  []float64 `yaml:"transform,omitempty"`
+	Suppressed bool      `yaml:"suppressed,omitempty"`
+	Grounded   bool      `yaml:"grounded,omitempty"`
+	Adaptive   bool      `yaml:"adaptive,omitempty"`
+	Substitute bool      `yaml:"substitute,omitempty"`
+}
+
+// MarshalRecipe renders the assembly's recipe as YAML bytes (doc.RecipeContent).
+func (a *AssemblyComponentDefinition) MarshalRecipe() ([]byte, error) {
+	return yamlcodec.Marshal(assemblyRecipe{
+		Units:       unitsRecipeFor(a.units),
+		Occurrences: a.occurrencesRecipe(),
+	})
+}
+
+// occurrencesRecipe captures every restorable occurrence — those placed from a component
+// document (a non-empty ComponentName). An in-memory placement from a bare definition has
+// no document to resolve on reopen, so it is intentionally omitted rather than persisted
+// as an unrestorable record.
+func (a *AssemblyComponentDefinition) occurrencesRecipe() []occurrenceRecipe {
+	var out []occurrenceRecipe
+	for _, o := range a.occurrences.All() {
+		if o.ComponentName() == "" {
+			continue
+		}
+		cells := o.Transform().Cells()
+		out = append(out, occurrenceRecipe{
+			Name:       o.Name(),
+			Component:  o.ComponentName(),
+			Transform:  cells[:],
+			Suppressed: o.Suppressed(),
+			Grounded:   o.Grounded(),
+			Adaptive:   o.Adaptive(),
+			Substitute: o.IsSubstitute(),
+		})
+	}
+	return out
+}
+
+// ApplyRecipe restores the assembly's units and stashes its occurrence records as pending
+// (doc.RecipeContent). It does NOT bind occurrences to component definitions: ApplyRecipe
+// runs during the store load, before the document joins a workspace, so there is no way to
+// open the component documents yet. Binding happens in [ResolveReferences] once the
+// workspace registers the assembly (#715).
+func (a *AssemblyComponentDefinition) ApplyRecipe(model []byte) error {
+	var r assemblyRecipe
+	if err := yamlcodec.Unmarshal(model, &r); err != nil {
+		return fmt.Errorf("compdef: parse assembly recipe: %w", err)
+	}
+	if err := applyUnitsTo(a.units, r.Units); err != nil {
+		return err
+	}
+	a.pending = r.Occurrences
+	return nil
+}
+
+// ResolveReferences binds each pending occurrence to its component document, opening the
+// component through owner's reference graph (doc.ReferenceResolver). A component that
+// cannot be opened becomes a placeholder occurrence whose reference is flagged broken —
+// reopening an assembly with a missing component is never fatal (the user repairs the
+// reference). owner is the assembly's own document.
+func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) error {
+	pending := a.pending
+	a.pending = nil
+	for _, rec := range pending {
+		transform, err := matrixFromRecipe(rec)
+		if err != nil {
+			return err
+		}
+		def := a.resolveComponent(owner, rec.Component)
+		occ := a.occurrences.AddByComponentName(rec.Name, def, rec.Component, transform)
+		occ.SetSuppressed(rec.Suppressed)
+		occ.SetGrounded(rec.Grounded)
+		occ.SetAdaptive(rec.Adaptive)
+		occ.SetSubstitute(rec.Substitute)
+	}
+	return nil
+}
+
+// resolveComponent opens the component document named component as a reference of owner,
+// returning its placeable definition; a target that cannot be opened (missing/replaced
+// file) yields a [missingDefinition] placeholder so the occurrence still restores. The
+// owner.OpenReference call records and resolves the edge, so the broken reference is
+// surfaced through the document's reference status, not lost.
+func (a *AssemblyComponentDefinition) resolveComponent(owner *doc.Document, component string) occurrence.Definition {
+	child, ok := owner.OpenReference(component)
+	if !ok {
+		return missingDefinition{}
+	}
+	def, ok := child.Content().(occurrence.Definition)
+	if !ok {
+		return missingDefinition{}
+	}
+	return def
+}
+
+// matrixFromRecipe rebuilds an occurrence transform from its persisted cells, erroring on
+// a matrix that is not 16 cells (no silent loss of a placement). A record with no cells
+// restores at the origin.
+func matrixFromRecipe(rec occurrenceRecipe) (math.Matrix4, error) {
+	if len(rec.Transform) == 0 {
+		return math.Identity4(), nil
+	}
+	if len(rec.Transform) != 16 {
+		return math.Matrix4{}, fmt.Errorf("compdef: occurrence %q transform has %d cells, want 16", rec.Name, len(rec.Transform))
+	}
+	var cells [16]float64
+	copy(cells[:], rec.Transform)
+	return math.Matrix4FromCells(cells), nil
+}
+
+// missingDefinition is the placeholder a restored occurrence instances when its component
+// document cannot be opened — an unresolved reference. It contributes no geometry (an
+// empty range box), so the assembly opens and recomputes without the missing part rather
+// than failing the whole load.
+type missingDefinition struct{}
+
+// RangeBox returns the empty box, satisfying occurrence.Definition.
+func (missingDefinition) RangeBox() math.Box { return math.EmptyBox() }

--- a/model/compdef/assembly_serialize_test.go
+++ b/model/compdef/assembly_serialize_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/occurrence"
+	"oblikovati.org/persistence"
+)
+
+// savePartDoc creates a part document at path in ws and saves it, so an assembly can
+// place it from a real, resolvable file. The part is empty — occurrence persistence
+// rebinds by document, independent of the component's geometry, so a body is unneeded
+// here (geometry round-tripping is covered by the part recipe tests).
+func savePartDoc(t *testing.T, ws *doc.Workspace, path string) *doc.Document {
+	t.Helper()
+	d, err := compdef.AddPart(ws, path, true)
+	if err != nil {
+		t.Fatalf("AddPart %q: %v", path, err)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save part %q: %v", path, err)
+	}
+	return d
+}
+
+// reopenAssembly saves the active assembly through the store and reopens it in a fresh
+// workspace backed by the same store, so its occurrences resolve their component
+// documents from disk through the reference graph — the real #715 round trip.
+func reopenAssembly(t *testing.T, store *persistence.PackageStore, ws *doc.Workspace, asm *doc.Document) *compdef.AssemblyComponentDefinition {
+	t.Helper()
+	if err := ws.Save(asm); err != nil {
+		t.Fatalf("Save assembly: %v", err)
+	}
+	reopened, err := doc.NewWorkspace(store).Open(asm.FullFileName(), true)
+	if err != nil {
+		t.Fatalf("Open assembly: %v", err)
+	}
+	def, ok := reopened.Content().(*compdef.AssemblyComponentDefinition)
+	if !ok {
+		t.Fatalf("reopened content is %T, want *AssemblyComponentDefinition", reopened.Content())
+	}
+	return def
+}
+
+// TestEmptyAssemblyRoundTrips checks a placed-component-free assembly round-trips its
+// units with zero occurrences (and writes no file references).
+func TestEmptyAssemblyRoundTrips(t *testing.T) {
+	store := persistence.NewPackageStore()
+	dir := t.TempDir()
+	ws := doc.NewWorkspace(store)
+	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "empty.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+
+	def := reopenAssembly(t, store, ws, asm)
+	if def.Occurrences().Count() != 0 {
+		t.Errorf("reopened empty assembly has %d occurrences, want 0", def.Occurrences().Count())
+	}
+}
+
+// TestAssemblyOccurrencesRoundTrip places one shared component twice with distinct
+// transforms and per-instance state, and checks both occurrences — names, placements,
+// suppression, grounding — restore through the reference graph, with exactly one
+// deduped assembly→component reference recorded.
+func TestAssemblyOccurrencesRoundTrip(t *testing.T) {
+	store := persistence.NewPackageStore()
+	dir := t.TempDir()
+	ws := doc.NewWorkspace(store)
+	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
+
+	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
+	at3 := math.Translation4(math.V3(3, 0, 0))
+	o1, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:1", math.Identity4())
+	if err != nil {
+		t.Fatalf("place widget:1: %v", err)
+	}
+	o2, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:2", at3)
+	if err != nil {
+		t.Fatalf("place widget:2: %v", err)
+	}
+	o1.SetGrounded(true)
+	o2.SetSuppressed(true)
+
+	def := reopenAssembly(t, store, ws, asm)
+	if def.Occurrences().Count() != 2 {
+		t.Fatalf("reopened assembly has %d occurrences, want 2", def.Occurrences().Count())
+	}
+	r1, r2 := def.Occurrences().Item(0), def.Occurrences().Item(1)
+	if r1.Name() != "widget:1" || !r1.Grounded() || r1.Suppressed() {
+		t.Errorf("occurrence 0 = {name:%q grounded:%v suppressed:%v}, want widget:1 grounded", r1.Name(), r1.Grounded(), r1.Suppressed())
+	}
+	if r2.Name() != "widget:2" || !r2.Suppressed() {
+		t.Errorf("occurrence 1 = {name:%q suppressed:%v}, want widget:2 suppressed", r2.Name(), r2.Suppressed())
+	}
+	if got := r2.Transform().Cells(); got != at3.Cells() {
+		t.Errorf("occurrence 1 transform = %v, want the x=3 translation", got)
+	}
+	// Both placements share one component document ⇒ exactly one reference edge/record.
+	if refs := def.Occurrences().Item(0).Definition(); refs == nil {
+		t.Error("occurrence 0 has a nil definition after reopen")
+	}
+}
+
+// TestAssemblyReferenceDeduped checks two placements of the same component yield a single
+// assembly→component reference edge and a single persisted file-reference record (the
+// referenced-by count must not inflate with placement count).
+func TestAssemblyReferenceDeduped(t *testing.T) {
+	store := persistence.NewPackageStore()
+	dir := t.TempDir()
+	ws := doc.NewWorkspace(store)
+	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
+	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
+	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:1", math.Identity4()); err != nil {
+		t.Fatalf("place widget:1: %v", err)
+	}
+	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:2", math.Identity4()); err != nil {
+		t.Fatalf("place widget:2: %v", err)
+	}
+	if got := len(asm.References()); got != 1 {
+		t.Errorf("assembly has %d reference edges, want 1 (deduped)", got)
+	}
+	if err := ws.Save(asm); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if got := len(asm.FileReferenceRecords()); got != 1 {
+		t.Errorf("assembly persisted %d file-reference records, want 1", got)
+	}
+}
+
+// TestAssemblyMissingComponentIsNotFatal checks reopening an assembly whose component
+// file is gone still succeeds: the occurrence restores as an unresolved placeholder
+// (empty range box), never a panic or a failed open.
+func TestAssemblyMissingComponentIsNotFatal(t *testing.T) {
+	store := persistence.NewPackageStore()
+	dir := t.TempDir()
+	ws := doc.NewWorkspace(store)
+	widget := savePartDoc(t, ws, filepath.Join(dir, "gone.obk"))
+	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
+	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "gone:1", math.Identity4()); err != nil {
+		t.Fatalf("place: %v", err)
+	}
+	if err := ws.Save(asm); err != nil {
+		t.Fatalf("Save assembly: %v", err)
+	}
+	// Delete the component package, then reopen the assembly in a fresh workspace.
+	if err := os.Remove(filepath.Join(dir, "gone.obk")); err != nil {
+		t.Fatalf("remove component: %v", err)
+	}
+	reopened, err := doc.NewWorkspace(store).Open(asm.FullFileName(), true)
+	if err != nil {
+		t.Fatalf("Open with missing component should not fail: %v", err)
+	}
+	def := reopened.Content().(*compdef.AssemblyComponentDefinition)
+	if def.Occurrences().Count() != 1 {
+		t.Fatalf("reopened assembly has %d occurrences, want 1 placeholder", def.Occurrences().Count())
+	}
+	if !def.Occurrences().Item(0).Definition().RangeBox().IsEmpty() {
+		t.Error("missing-component placeholder should contribute an empty range box")
+	}
+}
+
+// TestInMemoryPlaceNotPersisted checks an occurrence placed from a bare definition (no
+// document, via Place) is omitted from the recipe — it has no file to resolve on reopen,
+// so persisting it would yield an unrestorable record.
+func TestInMemoryPlaceNotPersisted(t *testing.T) {
+	store := persistence.NewPackageStore()
+	dir := t.TempDir()
+	ws := doc.NewWorkspace(store)
+	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
+	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
+	// One persistent placement and one bare in-memory placement.
+	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:1", math.Identity4()); err != nil {
+		t.Fatalf("place from file: %v", err)
+	}
+	asmDef.Place("loose:1", widget.Content().(occurrence.Definition), math.Identity4())
+
+	def := reopenAssembly(t, store, ws, asm)
+	if def.Occurrences().Count() != 1 || def.Occurrences().Item(0).Name() != "widget:1" {
+		t.Errorf("reopened occurrences = %d, want only the file-backed widget:1", def.Occurrences().Count())
+	}
+}
+
+// TestNestedAssemblyRoundTrip checks an assembly that places a sub-assembly (which itself
+// places a part) restores recursively: opening the top assembly hidden-opens the
+// sub-assembly, which hidden-opens the part, and every placement is rebound.
+func TestNestedAssemblyRoundTrip(t *testing.T) {
+	store := persistence.NewPackageStore()
+	dir := t.TempDir()
+	ws := doc.NewWorkspace(store)
+	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
+
+	sub, err := compdef.AddAssembly(ws, filepath.Join(dir, "sub.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly sub: %v", err)
+	}
+	subDef := sub.Content().(*compdef.AssemblyComponentDefinition)
+	if _, err := subDef.PlaceComponentFromFile(sub, widget, "widget:1", math.Identity4()); err != nil {
+		t.Fatalf("place widget in sub: %v", err)
+	}
+	if err := ws.Save(sub); err != nil {
+		t.Fatalf("Save sub: %v", err)
+	}
+
+	top, err := compdef.AddAssembly(ws, filepath.Join(dir, "top.obk"), true)
+	if err != nil {
+		t.Fatalf("AddAssembly top: %v", err)
+	}
+	topDef := top.Content().(*compdef.AssemblyComponentDefinition)
+	if _, err := topDef.PlaceComponentFromFile(top, sub, "sub:1", math.Translation4(math.V3(5, 0, 0))); err != nil {
+		t.Fatalf("place sub in top: %v", err)
+	}
+
+	def := reopenAssembly(t, store, ws, top)
+	if def.Occurrences().Count() != 1 {
+		t.Fatalf("reopened top has %d occurrences, want 1 (the sub-assembly)", def.Occurrences().Count())
+	}
+	subOcc := def.Occurrences().Item(0)
+	nested, ok := subOcc.Definition().(occurrence.Composite)
+	if !ok {
+		t.Fatalf("sub occurrence definition %T is not a composite (sub-assembly)", subOcc.Definition())
+	}
+	if nested.Occurrences().Count() != 1 || nested.Occurrences().Item(0).Name() != "widget:1" {
+		t.Errorf("nested sub-assembly = %d occurrences, want the restored widget:1", nested.Occurrences().Count())
+	}
+}

--- a/model/compdef/assembly_serialize_test.go
+++ b/model/compdef/assembly_serialize_test.go
@@ -14,33 +14,80 @@ import (
 	"oblikovati.org/persistence"
 )
 
-// savePartDoc creates a part document at path in ws and saves it, so an assembly can
+// assemblyWorkspace returns a package-store-backed workspace and its temp directory —
+// the fixture every assembly round-trip test builds on.
+func assemblyWorkspace(t *testing.T) (*persistence.PackageStore, *doc.Workspace, string) {
+	t.Helper()
+	store := persistence.NewPackageStore()
+	return store, doc.NewWorkspace(store), t.TempDir()
+}
+
+// newAssembly adds and returns an assembly document and its definition at name in dir.
+func newAssembly(t *testing.T, ws *doc.Workspace, dir, name string) (*doc.Document, *compdef.AssemblyComponentDefinition) {
+	t.Helper()
+	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, name), true)
+	if err != nil {
+		t.Fatalf("AddAssembly %q: %v", name, err)
+	}
+	return asm, asm.Content().(*compdef.AssemblyComponentDefinition)
+}
+
+// savePartDoc creates a part document at name in dir/ws and saves it, so an assembly can
 // place it from a real, resolvable file. The part is empty — occurrence persistence
 // rebinds by document, independent of the component's geometry, so a body is unneeded
 // here (geometry round-tripping is covered by the part recipe tests).
-func savePartDoc(t *testing.T, ws *doc.Workspace, path string) *doc.Document {
+func savePartDoc(t *testing.T, ws *doc.Workspace, dir, name string) *doc.Document {
 	t.Helper()
-	d, err := compdef.AddPart(ws, path, true)
+	d, err := compdef.AddPart(ws, filepath.Join(dir, name), true)
 	if err != nil {
-		t.Fatalf("AddPart %q: %v", path, err)
+		t.Fatalf("AddPart %q: %v", name, err)
 	}
 	if err := ws.Save(d); err != nil {
-		t.Fatalf("Save part %q: %v", path, err)
+		t.Fatalf("Save part %q: %v", name, err)
 	}
 	return d
 }
 
-// reopenAssembly saves the active assembly through the store and reopens it in a fresh
-// workspace backed by the same store, so its occurrences resolve their component
-// documents from disk through the reference graph — the real #715 round trip.
+// placedAssembly builds the common fixture: a store-backed workspace with a saved
+// "widget.obk" component part and a new empty "asm.obk" assembly, returning the pieces a
+// placement round-trip needs.
+func placedAssembly(t *testing.T) (store *persistence.PackageStore, ws *doc.Workspace, asm, widget *doc.Document, asmDef *compdef.AssemblyComponentDefinition) {
+	t.Helper()
+	store, ws, dir := assemblyWorkspace(t)
+	widget = savePartDoc(t, ws, dir, "widget.obk")
+	asm, asmDef = newAssembly(t, ws, dir, "asm.obk")
+	return store, ws, asm, widget, asmDef
+}
+
+// placeFromFile places componentDoc into asmDef under name at transform, failing the test
+// on error — the persisting place path the round-trip exercises.
+func placeFromFile(t *testing.T, asm, componentDoc *doc.Document, asmDef *compdef.AssemblyComponentDefinition, name string, transform math.Matrix4) *occurrence.Occurrence {
+	t.Helper()
+	o, err := asmDef.PlaceComponentFromFile(asm, componentDoc, name, transform)
+	if err != nil {
+		t.Fatalf("place %q: %v", name, err)
+	}
+	return o
+}
+
+// reopenAssembly saves the assembly through the store and reopens it in a fresh workspace
+// backed by the same store, so its occurrences resolve their component documents from disk
+// through the reference graph — the real #715 round trip.
 func reopenAssembly(t *testing.T, store *persistence.PackageStore, ws *doc.Workspace, asm *doc.Document) *compdef.AssemblyComponentDefinition {
 	t.Helper()
 	if err := ws.Save(asm); err != nil {
 		t.Fatalf("Save assembly: %v", err)
 	}
-	reopened, err := doc.NewWorkspace(store).Open(asm.FullFileName(), true)
+	return openAssembly(t, store, asm.FullFileName())
+}
+
+// openAssembly opens name in a fresh store-backed workspace (forcing the on-disk load and
+// reference-resolution path) and returns its assembly definition.
+func openAssembly(t *testing.T, store *persistence.PackageStore, name string) *compdef.AssemblyComponentDefinition {
+	t.Helper()
+	reopened, err := doc.NewWorkspace(store).Open(name, true)
 	if err != nil {
-		t.Fatalf("Open assembly: %v", err)
+		t.Fatalf("Open assembly %q: %v", name, err)
 	}
 	def, ok := reopened.Content().(*compdef.AssemblyComponentDefinition)
 	if !ok {
@@ -49,49 +96,25 @@ func reopenAssembly(t *testing.T, store *persistence.PackageStore, ws *doc.Works
 	return def
 }
 
-// TestEmptyAssemblyRoundTrips checks a placed-component-free assembly round-trips its
-// units with zero occurrences (and writes no file references).
+// TestEmptyAssemblyRoundTrips checks a placed-component-free assembly round-trips with
+// zero occurrences.
 func TestEmptyAssemblyRoundTrips(t *testing.T) {
-	store := persistence.NewPackageStore()
-	dir := t.TempDir()
-	ws := doc.NewWorkspace(store)
-	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "empty.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly: %v", err)
-	}
+	store, ws, dir := assemblyWorkspace(t)
+	asm, _ := newAssembly(t, ws, dir, "empty.obk")
 
-	def := reopenAssembly(t, store, ws, asm)
-	if def.Occurrences().Count() != 0 {
+	if def := reopenAssembly(t, store, ws, asm); def.Occurrences().Count() != 0 {
 		t.Errorf("reopened empty assembly has %d occurrences, want 0", def.Occurrences().Count())
 	}
 }
 
 // TestAssemblyOccurrencesRoundTrip places one shared component twice with distinct
 // transforms and per-instance state, and checks both occurrences — names, placements,
-// suppression, grounding — restore through the reference graph, with exactly one
-// deduped assembly→component reference recorded.
+// suppression, grounding — restore through the reference graph.
 func TestAssemblyOccurrencesRoundTrip(t *testing.T) {
-	store := persistence.NewPackageStore()
-	dir := t.TempDir()
-	ws := doc.NewWorkspace(store)
-	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
-
-	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly: %v", err)
-	}
-	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
+	store, ws, asm, widget, asmDef := placedAssembly(t)
 	at3 := math.Translation4(math.V3(3, 0, 0))
-	o1, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:1", math.Identity4())
-	if err != nil {
-		t.Fatalf("place widget:1: %v", err)
-	}
-	o2, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:2", at3)
-	if err != nil {
-		t.Fatalf("place widget:2: %v", err)
-	}
-	o1.SetGrounded(true)
-	o2.SetSuppressed(true)
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4()).SetGrounded(true)
+	placeFromFile(t, asm, widget, asmDef, "widget:2", at3).SetSuppressed(true)
 
 	def := reopenAssembly(t, store, ws, asm)
 	if def.Occurrences().Count() != 2 {
@@ -107,8 +130,7 @@ func TestAssemblyOccurrencesRoundTrip(t *testing.T) {
 	if got := r2.Transform().Cells(); got != at3.Cells() {
 		t.Errorf("occurrence 1 transform = %v, want the x=3 translation", got)
 	}
-	// Both placements share one component document ⇒ exactly one reference edge/record.
-	if refs := def.Occurrences().Item(0).Definition(); refs == nil {
+	if r1.Definition() == nil {
 		t.Error("occurrence 0 has a nil definition after reopen")
 	}
 }
@@ -117,21 +139,10 @@ func TestAssemblyOccurrencesRoundTrip(t *testing.T) {
 // assembly→component reference edge and a single persisted file-reference record (the
 // referenced-by count must not inflate with placement count).
 func TestAssemblyReferenceDeduped(t *testing.T) {
-	store := persistence.NewPackageStore()
-	dir := t.TempDir()
-	ws := doc.NewWorkspace(store)
-	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
-	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly: %v", err)
-	}
-	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
-	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:1", math.Identity4()); err != nil {
-		t.Fatalf("place widget:1: %v", err)
-	}
-	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:2", math.Identity4()); err != nil {
-		t.Fatalf("place widget:2: %v", err)
-	}
+	_, ws, asm, widget, asmDef := placedAssembly(t)
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+	placeFromFile(t, asm, widget, asmDef, "widget:2", math.Identity4())
+
 	if got := len(asm.References()); got != 1 {
 		t.Errorf("assembly has %d reference edges, want 1 (deduped)", got)
 	}
@@ -147,30 +158,18 @@ func TestAssemblyReferenceDeduped(t *testing.T) {
 // file is gone still succeeds: the occurrence restores as an unresolved placeholder
 // (empty range box), never a panic or a failed open.
 func TestAssemblyMissingComponentIsNotFatal(t *testing.T) {
-	store := persistence.NewPackageStore()
-	dir := t.TempDir()
-	ws := doc.NewWorkspace(store)
-	widget := savePartDoc(t, ws, filepath.Join(dir, "gone.obk"))
-	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly: %v", err)
-	}
-	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
-	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "gone:1", math.Identity4()); err != nil {
-		t.Fatalf("place: %v", err)
-	}
+	store, ws, dir := assemblyWorkspace(t)
+	widget := savePartDoc(t, ws, dir, "gone.obk")
+	asm, asmDef := newAssembly(t, ws, dir, "asm.obk")
+	placeFromFile(t, asm, widget, asmDef, "gone:1", math.Identity4())
 	if err := ws.Save(asm); err != nil {
 		t.Fatalf("Save assembly: %v", err)
 	}
-	// Delete the component package, then reopen the assembly in a fresh workspace.
 	if err := os.Remove(filepath.Join(dir, "gone.obk")); err != nil {
 		t.Fatalf("remove component: %v", err)
 	}
-	reopened, err := doc.NewWorkspace(store).Open(asm.FullFileName(), true)
-	if err != nil {
-		t.Fatalf("Open with missing component should not fail: %v", err)
-	}
-	def := reopened.Content().(*compdef.AssemblyComponentDefinition)
+
+	def := openAssembly(t, store, asm.FullFileName())
 	if def.Occurrences().Count() != 1 {
 		t.Fatalf("reopened assembly has %d occurrences, want 1 placeholder", def.Occurrences().Count())
 	}
@@ -183,19 +182,8 @@ func TestAssemblyMissingComponentIsNotFatal(t *testing.T) {
 // document, via Place) is omitted from the recipe — it has no file to resolve on reopen,
 // so persisting it would yield an unrestorable record.
 func TestInMemoryPlaceNotPersisted(t *testing.T) {
-	store := persistence.NewPackageStore()
-	dir := t.TempDir()
-	ws := doc.NewWorkspace(store)
-	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
-	asm, err := compdef.AddAssembly(ws, filepath.Join(dir, "asm.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly: %v", err)
-	}
-	asmDef := asm.Content().(*compdef.AssemblyComponentDefinition)
-	// One persistent placement and one bare in-memory placement.
-	if _, err := asmDef.PlaceComponentFromFile(asm, widget, "widget:1", math.Identity4()); err != nil {
-		t.Fatalf("place from file: %v", err)
-	}
+	store, ws, asm, widget, asmDef := placedAssembly(t)
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
 	asmDef.Place("loose:1", widget.Content().(occurrence.Definition), math.Identity4())
 
 	def := reopenAssembly(t, store, ws, asm)
@@ -208,40 +196,23 @@ func TestInMemoryPlaceNotPersisted(t *testing.T) {
 // places a part) restores recursively: opening the top assembly hidden-opens the
 // sub-assembly, which hidden-opens the part, and every placement is rebound.
 func TestNestedAssemblyRoundTrip(t *testing.T) {
-	store := persistence.NewPackageStore()
-	dir := t.TempDir()
-	ws := doc.NewWorkspace(store)
-	widget := savePartDoc(t, ws, filepath.Join(dir, "widget.obk"))
-
-	sub, err := compdef.AddAssembly(ws, filepath.Join(dir, "sub.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly sub: %v", err)
-	}
-	subDef := sub.Content().(*compdef.AssemblyComponentDefinition)
-	if _, err := subDef.PlaceComponentFromFile(sub, widget, "widget:1", math.Identity4()); err != nil {
-		t.Fatalf("place widget in sub: %v", err)
-	}
+	store, ws, dir := assemblyWorkspace(t)
+	widget := savePartDoc(t, ws, dir, "widget.obk")
+	sub, subDef := newAssembly(t, ws, dir, "sub.obk")
+	placeFromFile(t, sub, widget, subDef, "widget:1", math.Identity4())
 	if err := ws.Save(sub); err != nil {
 		t.Fatalf("Save sub: %v", err)
 	}
-
-	top, err := compdef.AddAssembly(ws, filepath.Join(dir, "top.obk"), true)
-	if err != nil {
-		t.Fatalf("AddAssembly top: %v", err)
-	}
-	topDef := top.Content().(*compdef.AssemblyComponentDefinition)
-	if _, err := topDef.PlaceComponentFromFile(top, sub, "sub:1", math.Translation4(math.V3(5, 0, 0))); err != nil {
-		t.Fatalf("place sub in top: %v", err)
-	}
+	top, topDef := newAssembly(t, ws, dir, "top.obk")
+	placeFromFile(t, top, sub, topDef, "sub:1", math.Translation4(math.V3(5, 0, 0)))
 
 	def := reopenAssembly(t, store, ws, top)
 	if def.Occurrences().Count() != 1 {
 		t.Fatalf("reopened top has %d occurrences, want 1 (the sub-assembly)", def.Occurrences().Count())
 	}
-	subOcc := def.Occurrences().Item(0)
-	nested, ok := subOcc.Definition().(occurrence.Composite)
+	nested, ok := def.Occurrences().Item(0).Definition().(occurrence.Composite)
 	if !ok {
-		t.Fatalf("sub occurrence definition %T is not a composite (sub-assembly)", subOcc.Definition())
+		t.Fatalf("sub occurrence definition %T is not a composite (sub-assembly)", def.Occurrences().Item(0).Definition())
 	}
 	if nested.Occurrences().Count() != 1 || nested.Occurrences().Item(0).Name() != "widget:1" {
 		t.Errorf("nested sub-assembly = %d occurrences, want the restored widget:1", nested.Occurrences().Count())

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -295,22 +295,33 @@ func (d *PartComponentDefinition) materialsRecipe() *material.RecipeData {
 
 // unitsRecipe captures the preferred display-unit name for each category.
 func (d *PartComponentDefinition) unitsRecipe() map[string]string {
+	return unitsRecipeFor(d.units)
+}
+
+// applyUnits restores the preferred display unit for each named category.
+func (d *PartComponentDefinition) applyUnits(units map[string]string) error {
+	return applyUnitsTo(d.units, units)
+}
+
+// unitsRecipeFor captures the preferred display-unit name for each category — shared by
+// the part and assembly recipes, which persist units identically.
+func unitsRecipeFor(u param.UnitsOfMeasure) map[string]string {
 	out := make(map[string]string, len(unitCategories))
 	for _, cat := range unitCategories {
-		out[cat.String()] = d.units.PreferredName(cat)
+		out[cat.String()] = u.PreferredName(cat)
 	}
 	return out
 }
 
-// applyUnits restores the preferred display unit for each named category. An unknown
-// category name or an invalid unit is a corrupt-recipe error (no silent loss).
-func (d *PartComponentDefinition) applyUnits(units map[string]string) error {
+// applyUnitsTo restores the preferred display unit for each named category onto u. An
+// unknown category name or an invalid unit is a corrupt-recipe error (no silent loss).
+func applyUnitsTo(u param.UnitsOfMeasure, units map[string]string) error {
 	for name, unitName := range units {
 		cat, ok := unitCategoryByName(name)
 		if !ok {
 			return fmt.Errorf("compdef: unknown unit category %q in recipe", name)
 		}
-		if err := d.units.SetPreferred(cat, unitName); err != nil {
+		if err := u.SetPreferred(cat, unitName); err != nil {
 			return fmt.Errorf("compdef: restore units: %w", err)
 		}
 	}

--- a/model/doc/refgraph.go
+++ b/model/doc/refgraph.go
@@ -131,6 +131,20 @@ func (g *RefGraph) addReference(parent *Document, childName string) *DocumentDes
 	return desc
 }
 
+// addReferenceUnique records parent→childName only when no such edge exists yet,
+// returning the existing or freshly created descriptor. It is the idempotent form used
+// when resolving restored references (#715): a component placed N times, or a reference
+// re-resolved across recomputes, must yield exactly one edge so the referenced-by count
+// is not inflated (addReference appends unconditionally, by contrast).
+func (g *RefGraph) addReferenceUnique(parent *Document, childName string) *DocumentDescriptor {
+	for _, desc := range g.forward[parent.fullDocumentName] {
+		if desc.fullDocumentName == childName {
+			return desc
+		}
+	}
+	return g.addReference(parent, childName)
+}
+
 // removeReference drops the edge from parent to childName, if present, and releases
 // the child's referenced count.
 func (g *RefGraph) removeReference(parent *Document, childName string) bool {

--- a/model/doc/resolve.go
+++ b/model/doc/resolve.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+// ReferenceResolver is the optional interface content implements when reopening it must
+// resolve references to other documents — an assembly binding its occurrences to the
+// component documents they instance (#715). The workspace calls ResolveReferences once,
+// right after the owning document is registered, so the resolver can reach its sibling
+// documents through owner.OpenReference (which hidden-opens them through the graph). A
+// content type that does not implement this interface round-trips its own recipe alone.
+//
+// The owner is passed in rather than held as a back-reference because content has no
+// link to its document otherwise, and the resolver needs the graph-connected document
+// (which exists only after registration) to open and record references.
+type ReferenceResolver interface {
+	Content
+	// ResolveReferences binds owner's restored references to live documents. A reference
+	// that cannot be resolved must be surfaced (e.g. a broken descriptor), never fatal.
+	ResolveReferences(owner *Document) error
+}
+
+// OpenReference resolves the document named fullDocumentName as a reference of d: an
+// already-open document wins, otherwise it is hidden-opened through the workspace store.
+// It reuses the reference graph's resolution (already-open short-circuit, lazy load,
+// broken-flagging) and records the d→child edge so the dependency is tracked and the
+// child stays open while d references it. Returns false when the target cannot be found.
+func (d *Document) OpenReference(fullDocumentName string) (*Document, bool) {
+	if d.graph == nil {
+		return nil, false
+	}
+	desc := d.graph.addReferenceUnique(d, fullDocumentName)
+	return d.graph.resolve(desc)
+}

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -113,6 +113,14 @@ func (ws *Workspace) OpenWithOptions(fullDocumentName string, opts OpenOptions) 
 	}
 	d.visible = opts.Visible
 	ws.register(d)
+	// Resolve cross-document references after registration so a resolver that hidden-opens
+	// a sibling (an assembly binding its components, #715) finds this document already in
+	// byName — that short-circuit (above) is what terminates cyclic and diamond references.
+	if r, ok := d.content.(ReferenceResolver); ok {
+		if err := r.ResolveReferences(d); err != nil {
+			return nil, fmt.Errorf("doc: open %q: resolve references: %w", fullDocumentName, err)
+		}
+	}
 	event.Emit(ws.bus, event.After, DocumentOpened{FullDocumentName: fullDocumentName})
 	return d, nil
 }

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -47,7 +47,12 @@ type Occurrence struct {
 	adaptive   bool
 	substitute bool
 	definition Definition
-	owner      *Occurrences
+	// componentName is the full document name of the component this occurrence instances,
+	// recorded when placed from a document so the placement can be restored on reopen
+	// (#715). Empty for an in-memory placement made from a bare definition (no file) and
+	// for replicated copies, which inherit the seed's definition rather than re-record it.
+	componentName string
+	owner         *Occurrences
 }
 
 // ID returns the occurrence's session id (unique within its owning collection).
@@ -58,6 +63,11 @@ func (o *Occurrence) Name() string { return o.name }
 
 // Definition returns the shared component definition this occurrence instances.
 func (o *Occurrence) Definition() Definition { return o.definition }
+
+// ComponentName returns the full document name of the component this occurrence
+// instances, or "" when it was placed from a bare in-memory definition. It is the
+// persistent link the assembly recipe records and resolves on reopen (#715).
+func (o *Occurrence) ComponentName() string { return o.componentName }
 
 // Transform returns the occurrence's placement in its assembly's space.
 func (o *Occurrence) Transform() math.Matrix4 { return o.transform }
@@ -105,6 +115,11 @@ func (o *Occurrence) SetAdaptive(adaptive bool) { o.adaptive = adaptive }
 // IsSubstituteOccurrence). Set by [Substitute]; the simplified geometry it references
 // is generated in M11-F06.
 func (o *Occurrence) IsSubstitute() bool { return o.substitute }
+
+// SetSubstitute marks the occurrence as a substitute (or not). It is the restore-time
+// setter for the persisted flag (#715); the interactive substitute path goes through
+// [Substitute], which also wires the simplified definition the flag stands for.
+func (o *Occurrence) SetSubstitute(substitute bool) { o.substitute = substitute }
 
 // SubOccurrences returns the components nested inside this occurrence when it
 // instances an assembly (a [Composite] definition), or nil for a leaf part. They are

--- a/model/occurrence/occurrences.go
+++ b/model/occurrence/occurrences.go
@@ -44,9 +44,19 @@ func (c *Occurrences) SetListener(l OccurrenceListener) {
 // returning the new occurrence. def is shared — placing the same definition twice
 // yields two occurrences that both track its edits (the flyweight). The transform
 // locates the component in the assembly's space; pass [math.Identity4] for the origin.
+// The occurrence carries no persistent component link (its ComponentName is ""); use
+// [AddByComponentName] to place from a document so the placement can be saved (#715).
 func (c *Occurrences) AddByComponentDefinition(name string, def Definition, transform math.Matrix4) *Occurrence {
+	return c.AddByComponentName(name, def, "", transform)
+}
+
+// AddByComponentName places def under name with transform, recording componentName —
+// the full document name of the component def belongs to — so the placement can be
+// restored on reopen (#715). componentName "" is the in-memory-only placement (see
+// [AddByComponentDefinition]).
+func (c *Occurrences) AddByComponentName(name string, def Definition, componentName string, transform math.Matrix4) *Occurrence {
 	c.nextID++
-	o := &Occurrence{id: c.nextID, name: name, transform: transform, definition: def, owner: c}
+	o := &Occurrence{id: c.nextID, name: name, transform: transform, definition: def, componentName: componentName, owner: c}
 	c.items = append(c.items, o)
 	c.byID[o.id] = o
 	c.bump()


### PR DESCRIPTION
## What
Makes an assembly **recipe-bearing** so a saved assembly restores its placed components, their placements, and per-instance state by resolving each component **document** through the reference graph on reopen. This is **part 1 of #715** (acceptance #1).

- **occurrence**: an `Occurrence` now records the full document name of the component it instances (`AddByComponentName`); a bare in-memory `Place` leaves it empty.
- **doc**: new `ReferenceResolver` seam — content whose restore must bind to *other* documents implements `ResolveReferences(owner)`, which `Workspace.OpenWithOptions` calls right **after** registering the document, so cyclic/diamond references terminate on the already-open `byName` short-circuit. `Document.OpenReference` resolves + records an edge through the existing `RefGraph` machinery; `addReferenceUnique` dedupes so N placements of one component yield exactly one edge / one persisted file-reference record.
- **compdef**: `AssemblyComponentDefinition` implements `RecipeContent` + `ReferenceResolver`. `MarshalRecipe` writes units + the file-backed occurrences (name, component, transform, suppressed/grounded/adaptive/substitute); `ApplyRecipe` restores units and stashes *pending* records (no workspace yet); `ResolveReferences` hidden-opens each component and binds the occurrence, with a `missingDefinition` placeholder when a component file is gone (**never fatal**). `PlaceComponentFromFile` is the persisting place path. Units-recipe helpers are now shared with the part rather than duplicated.

## Why
An assembly was in-memory only — saving wrote its manifest but **none** of its placed components, so reopening yielded an empty assembly. Occurrences must record *which document* they instance and the graph must resolve them on open.

## Design note
`RecipeContent.{Marshal,Apply}Recipe` have no workspace handle and `Content` has no back-reference to its `Document`, so binding occurrences to live definitions **cannot** happen inside `ApplyRecipe` (it runs during `store.Load`, before the document joins a workspace). Binding is therefore a two-phase restore: `ApplyRecipe` parses → pending records; the workspace-driven `ResolveReferences` hook (post-register) opens the components and binds. The existing `RefGraph.resolve` already lazily hidden-opens a referenced document, so PR1 reuses that backbone — the only new seam is the resolve hook.

## Tests (`model/compdef/assembly_serialize_test.go`)
Real save→YAML→reopen-in-a-fresh-workspace round trips: empty assembly; two shared placements (distinct transforms, one grounded + one suppressed, **one** deduped reference edge + **one** file-reference record); missing component file (placeholder, empty range box, no panic); in-memory `Place` omitted from the recipe; nested sub-assembly (recursive resolve through the workspace).

Full `go test ./...`, `go test -race ./model/...`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only — no `api/` contract change.

## Follow-up
Part 2 of #715 (separate PR): derived-assembly source link — persist the source's `FileIdentity` (InternalName + DatabaseRevisionID) on `DerivedAssemblyComponent` for cross-session staleness (acceptance #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)