### PR TITLE
model: derived-assembly source link & cross-session staleness (M11, #715 pt2)

### DIFF
--- a/addin/router/assembly_derive.go
+++ b/addin/router/assembly_derive.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 )
 
@@ -28,14 +29,29 @@ func (r *Router) registerAssemblyDeriveHandlers() {
 }
 
 // assemblyDeriveCreate derives the source assembly document into the active part as a
-// base body (include-all) and returns the new feature's detail.
+// base body (include-all) and returns the new feature's detail. The source's identity is
+// captured on the derive and recorded as a reference of the active part, so the link
+// survives a save and a stale source is detected on reopen (#715).
 func assemblyDeriveCreate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, source, err := resolveDeriveSource(s, raw, wire.MethodAssemblyDeriveCreate)
+	part, source, sourceDoc, err := resolveDeriveSource(s, raw, wire.MethodAssemblyDeriveCreate)
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewDerivedAssemblyComponents(part.Features()).AddDerived(source)
+	pf := feature.NewDerivedAssemblyComponents(part.Features()).AddDerived(source, deriveSourceLink(sourceDoc))
+	// Record the part→source edge now so the first save snapshots it (mirrors
+	// PlaceComponentFromFile); the source is already open, so this just resolves it.
+	s.ActiveDocument().OpenReference(sourceDoc.FullDocumentName())
 	return commitNewDerive(part, pf)
+}
+
+// deriveSourceLink captures the source assembly document's identity for a derive link.
+func deriveSourceLink(sourceDoc *doc.Document) feature.DeriveSourceLink {
+	id := sourceDoc.FileIdentity()
+	return feature.DeriveSourceLink{
+		Document:           sourceDoc.FullDocumentName(),
+		InternalName:       id.InternalName,
+		DatabaseRevisionID: id.DatabaseRevisionID,
+	}
 }
 
 // assemblyShrinkwrapCreate derives the source assembly into the active part as a
@@ -49,7 +65,7 @@ func assemblyShrinkwrapCreate(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	source, err := assemblySource(s, in.Source, wire.MethodAssemblyShrinkwrapCreate)
+	source, _, err := assemblySource(s, in.Source, wire.MethodAssemblyShrinkwrapCreate)
 	if err != nil {
 		return nil, err
 	}
@@ -88,36 +104,37 @@ func assemblyDeriveBreakLink(s *app.Session, raw json.RawMessage) (json.RawMessa
 	return featureDetailReply(part, pf, idx)
 }
 
-// resolveDeriveSource resolves the active part and the DeriveCreateArgs source
-// assembly, shared by the derive create handler.
-func resolveDeriveSource(s *app.Session, raw json.RawMessage, method string) (*compdef.PartComponentDefinition, feature.AssemblyBodySource, error) {
+// resolveDeriveSource resolves the active part and the DeriveCreateArgs source assembly
+// document, shared by the derive create handler. The source document is returned so the
+// caller can capture its identity for the derive link (#715).
+func resolveDeriveSource(s *app.Session, raw json.RawMessage, method string) (*compdef.PartComponentDefinition, feature.AssemblyBodySource, *doc.Document, error) {
 	part, err := modelaccess.ActivePart(s)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	var in wire.DeriveCreateArgs
 	if err := decode(raw, &in); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	source, err := assemblySource(s, in.Source, method)
+	source, sourceDoc, err := assemblySource(s, in.Source, method)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return part, source, nil
+	return part, source, sourceDoc, nil
 }
 
-// assemblySource resolves an open document id to its assembly body source, rejecting a
-// non-assembly document (a part has no occurrence tree to derive).
-func assemblySource(s *app.Session, id uint64, method string) (feature.AssemblyBodySource, error) {
+// assemblySource resolves an open document id to its assembly body source and document,
+// rejecting a non-assembly document (a part has no occurrence tree to derive).
+func assemblySource(s *app.Session, id uint64, method string) (feature.AssemblyBodySource, *doc.Document, error) {
 	d, err := documentByID(s, id)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", method, err)
+		return nil, nil, fmt.Errorf("%s: %w", method, err)
 	}
 	source, ok := d.Content().(feature.AssemblyBodySource)
 	if !ok {
-		return nil, fmt.Errorf("%s: document %d (%s) is not an assembly", method, id, d.DisplayName())
+		return nil, nil, fmt.Errorf("%s: document %d (%s) is not an assembly", method, id, d.DisplayName())
 	}
-	return source, nil
+	return source, d, nil
 }
 
 // commitNewDerive gives the new derive/shrinkwrap feature a unique name, recomputes the

--- a/model/compdef/derived_persistence_test.go
+++ b/model/compdef/derived_persistence_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/persistence"
+)
+
+// deriveSourceIntoPart creates a part document deriving sourceDoc — capturing the source's
+// identity link and recording the part→source reference exactly as the derive router does —
+// and returns the part document (now active).
+func deriveSourceIntoPart(t *testing.T, ws *doc.Workspace, dir, name string, sourceDoc *doc.Document) *doc.Document {
+	t.Helper()
+	partDoc, err := compdef.AddPart(ws, filepath.Join(dir, name), true)
+	if err != nil {
+		t.Fatalf("AddPart %q: %v", name, err)
+	}
+	part := partDoc.Content().(*compdef.PartComponentDefinition)
+	source := sourceDoc.Content().(feature.AssemblyBodySource)
+	id := sourceDoc.FileIdentity()
+	link := feature.DeriveSourceLink{
+		Document:           sourceDoc.FullDocumentName(),
+		InternalName:       id.InternalName,
+		DatabaseRevisionID: id.DatabaseRevisionID,
+	}
+	feature.NewDerivedAssemblyComponents(part.Features()).AddDerived(source, link)
+	partDoc.OpenReference(sourceDoc.FullDocumentName())
+	return partDoc
+}
+
+// openPart opens name in a fresh store-backed workspace (forcing the on-disk load and
+// reference-resolution path) and returns its part definition.
+func openPart(t *testing.T, store *persistence.PackageStore, name string) *compdef.PartComponentDefinition {
+	t.Helper()
+	reopened, err := doc.NewWorkspace(store).Open(name, true)
+	if err != nil {
+		t.Fatalf("Open part %q: %v", name, err)
+	}
+	return reopened.Content().(*compdef.PartComponentDefinition)
+}
+
+// derivedComponentOf returns the single derived-assembly component of a part.
+func derivedComponentOf(t *testing.T, part *compdef.PartComponentDefinition) *feature.DerivedAssemblyComponent {
+	t.Helper()
+	for i := 0; i < part.Features().Count(); i++ {
+		if d, ok := part.Features().Item(i).Definition().(*feature.DerivedAssemblyComponent); ok {
+			return d
+		}
+	}
+	t.Fatal("part has no derived-assembly component")
+	return nil
+}
+
+// savedDerivedPart builds and saves a source assembly and a part that derives it (both in
+// the same store), returning the store, workspace, dir, and the two saved documents — the
+// fixture the derived-part reopen tests start from.
+func savedDerivedPart(t *testing.T) (store *persistence.PackageStore, ws *doc.Workspace, dir string, srcDoc, partDoc *doc.Document) {
+	t.Helper()
+	store, ws, dir = assemblyWorkspace(t)
+	srcDoc, _ = newAssembly(t, ws, dir, "src.obk")
+	if err := ws.Save(srcDoc); err != nil {
+		t.Fatalf("Save source: %v", err)
+	}
+	partDoc = deriveSourceIntoPart(t, ws, dir, "derived.obk", srcDoc)
+	if err := ws.Save(partDoc); err != nil {
+		t.Fatalf("Save derived part: %v", err)
+	}
+	return store, ws, dir, srcDoc, partDoc
+}
+
+// TestDerivedPartRebindsAndIsCurrent derives a saved source assembly into a part, saves and
+// reopens the part, and checks the derive re-resolves its source through the reference graph
+// (rebound, non-empty source version) and is not flagged out of date (source unchanged).
+func TestDerivedPartRebindsAndIsCurrent(t *testing.T) {
+	store, _, _, srcDoc, partDoc := savedDerivedPart(t)
+
+	d := derivedComponentOf(t, openPart(t, store, partDoc.FullFileName()))
+	if d.SourceVersion() == "" {
+		t.Error("reopened derive should have rebound its source (empty source version)")
+	}
+	if d.OutOfDate() {
+		t.Error("derive against an unchanged source should not be out of date")
+	}
+	if got := d.SourceLink().Document; got != srcDoc.FullFileName() {
+		t.Errorf("restored source link document = %q, want %q", got, srcDoc.FullFileName())
+	}
+}
+
+// TestDerivedPartFlagsStaleSourceAcrossSessions saves a derived part, then edits and re-saves
+// the source assembly (re-minting its recipe revision), and checks the part reopened in a
+// fresh session flags the derive out of date by the revision mismatch — #715 acceptance 2.
+func TestDerivedPartFlagsStaleSourceAcrossSessions(t *testing.T) {
+	store, ws, dir := assemblyWorkspace(t)
+	widget := savePartDoc(t, ws, dir, "widget.obk")
+	srcDoc, srcDef := newAssembly(t, ws, dir, "src.obk")
+	if err := ws.Save(srcDoc); err != nil { // revision 1
+		t.Fatalf("Save source: %v", err)
+	}
+	partDoc := deriveSourceIntoPart(t, ws, dir, "derived.obk", srcDoc)
+	if err := ws.Save(partDoc); err != nil {
+		t.Fatalf("Save derived part: %v", err)
+	}
+
+	// Edit the source after the derive was saved and re-save it — re-minting its revision.
+	placeFromFile(t, srcDoc, widget, srcDef, "widget:1", math.Identity4())
+	if err := ws.Save(srcDoc); err != nil { // revision 2
+		t.Fatalf("Re-save edited source: %v", err)
+	}
+
+	d := derivedComponentOf(t, openPart(t, store, partDoc.FullFileName()))
+	if !d.OutOfDate() {
+		t.Error("source edited and saved after the derive ⇒ reopened derive should be out of date")
+	}
+}
+
+// TestDerivedPartMissingSourceIsNotFatal checks reopening a derived part whose source file
+// is gone still succeeds, leaving the derive unbound (no source) rather than panicking.
+func TestDerivedPartMissingSourceIsNotFatal(t *testing.T) {
+	store, _, dir, _, partDoc := savedDerivedPart(t)
+	if err := os.Remove(filepath.Join(dir, "src.obk")); err != nil {
+		t.Fatalf("remove source: %v", err)
+	}
+
+	d := derivedComponentOf(t, openPart(t, store, partDoc.FullFileName()))
+	if d.SourceVersion() != "" {
+		t.Error("a missing source should leave the derive unbound (empty source version)")
+	}
+}

--- a/model/compdef/part_resolve.go
+++ b/model/compdef/part_resolve.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// A part resolves the source documents of its derived-assembly features on reopen (#715):
+// the derive recipe carries the source's identity, but the live source assembly — and
+// whether it has since changed — is only knowable once the workspace can open it.
+var _ doc.ReferenceResolver = (*PartComponentDefinition)(nil)
+
+// ResolveReferences rebinds the part's derived-assembly features to their source documents
+// after a reopen (doc.ReferenceResolver): each derive re-resolves its source through
+// owner's reference graph, rebinds the live source for associative re-derive, and
+// recomputes whether the source is out of date (its recipe revision now differs from the
+// one captured when the derive was saved). A source that cannot be opened leaves the
+// derive unbound — it contributes no geometry — and is never fatal. owner is the part's
+// own document.
+func (d *PartComponentDefinition) ResolveReferences(owner *doc.Document) error {
+	rebound := false
+	for i := 0; i < d.features.Count(); i++ {
+		derive, ok := d.features.Item(i).Definition().(*feature.DerivedAssemblyComponent)
+		if !ok {
+			continue
+		}
+		if d.bindDeriveSource(owner, derive) {
+			rebound = true
+		}
+	}
+	if rebound {
+		d.Recompute()
+	}
+	return nil
+}
+
+// bindDeriveSource opens a derive's source document through owner's reference graph and
+// rebinds it, reporting whether a live source was bound. An empty link (a derive built
+// without a document, e.g. in tests) or an unopenable/ non-assembly source is skipped.
+func (d *PartComponentDefinition) bindDeriveSource(owner *doc.Document, derive *feature.DerivedAssemblyComponent) bool {
+	link := derive.SourceLink()
+	if link.Document == "" {
+		return false
+	}
+	child, ok := owner.OpenReference(link.Document)
+	if !ok {
+		return false
+	}
+	source, ok := child.Content().(feature.AssemblyBodySource)
+	if !ok {
+		return false
+	}
+	derive.BindSource(source, child.FileIdentity().DatabaseRevisionID)
+	return true
+}

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -39,6 +39,40 @@ func (s DeriveStyle) String() string {
 	}
 }
 
+// DeriveStyleFromName parses a derive style spelling (the inverse of [DeriveStyle.String]),
+// reporting whether it is a known style. Used to restore a persisted per-occurrence style.
+func DeriveStyleFromName(name string) (DeriveStyle, bool) {
+	switch name {
+	case "include":
+		return DeriveInclude, true
+	case "exclude":
+		return DeriveExclude, true
+	case "subtract":
+		return DeriveSubtract, true
+	default:
+		return DeriveInclude, false
+	}
+}
+
+// DeriveSourceLink identifies the source assembly document a derived component pulls from,
+// captured when the derive is created so the link survives a save (#715). Document is the
+// full document name to re-resolve on reopen; InternalName is the source's identity GUID;
+// DatabaseRevisionID is the source's recipe revision at derive time — a different revision
+// on reopen means the source changed since, i.e. the derive is out of date.
+type DeriveSourceLink struct {
+	Document           string
+	InternalName       string
+	DatabaseRevisionID string
+}
+
+// DeriveStyleAtPath pairs a non-default derive style with the occurrence path it applies
+// to — the persistable, pointer-free form of the per-occurrence styles map. Path is the
+// root-first instance-name path of the styled source placement ([PlacedBody.Path]).
+type DeriveStyleAtPath struct {
+	Path  occurrence.OccurrencePath
+	Style DeriveStyle
+}
+
 // PlacedBody is one source body paired with the world transform of the occurrence that
 // places it (in the source assembly's space) and that occurrence, so a derived feature
 // can apply per-occurrence [DeriveStyle]. Flattening a source assembly's occurrence
@@ -74,10 +108,19 @@ type AssemblyBodySource interface {
 // (M11-F06): a source edit bumps the source version so a re-derive flows it through,
 // and BreakLink freezes the current result and stops pulling.
 type DerivedAssemblyComponent struct {
-	source AssemblyBodySource
+	source AssemblyBodySource // nil after restore until BindSource rebinds it
 	styles map[*occurrence.Occurrence]DeriveStyle
 	linked bool
 	frozen []*topo.Body
+	// link is the persisted identity of the source document (#715); zero for a derive
+	// built without one (e.g. a pure in-memory test source).
+	link DeriveSourceLink
+	// pendingStyles holds path-keyed styles parsed from the recipe but not yet rebound to
+	// live occurrences — applied in BindSource once the source's PlacedBodies exist.
+	pendingStyles []DeriveStyleAtPath
+	// outOfDate records, after a rebind, that the source's current recipe revision differs
+	// from the one captured in link (the source was edited since this derive was saved).
+	outOfDate bool
 }
 
 // Definition returns the derived recipe.
@@ -86,12 +129,75 @@ func (d *DerivedAssemblyComponent) Definition() *DerivedAssemblyComponent { retu
 // Kind implements [Feature].
 func (d *DerivedAssemblyComponent) Kind() string { return "derivedAssembly" }
 
-// SourceVersion returns the source assembly's current geometry version (change tracking).
-func (d *DerivedAssemblyComponent) SourceVersion() string { return d.source.ModelGeometryVersion() }
+// SourceVersion returns the source assembly's current geometry version (change tracking),
+// or "" when the source is not bound (after restore, before [BindSource]).
+func (d *DerivedAssemblyComponent) SourceVersion() string {
+	if d.source == nil {
+		return ""
+	}
+	return d.source.ModelGeometryVersion()
+}
+
+// SourceLink returns the persisted identity of the derive's source document (#715).
+func (d *DerivedAssemblyComponent) SourceLink() DeriveSourceLink { return d.link }
+
+// OutOfDate reports whether the source has been edited since this derive was saved — the
+// source resolved on reopen carries a different recipe revision than [DeriveSourceLink]
+// captured. Always false for an in-session derive (the link matches the live source).
+func (d *DerivedAssemblyComponent) OutOfDate() bool { return d.outOfDate }
+
+// BindSource (re)binds the live source assembly after a restore and recomputes staleness:
+// the derive is out of date when currentDBRevID (the source's revision now) differs from
+// the revision captured in the link. It also rebinds the path-keyed pending styles to the
+// now-live occurrences. Both revisions must be non-empty for a meaningful comparison.
+func (d *DerivedAssemblyComponent) BindSource(source AssemblyBodySource, currentDBRevID string) {
+	d.source = source
+	d.outOfDate = d.link.DatabaseRevisionID != "" && currentDBRevID != "" && currentDBRevID != d.link.DatabaseRevisionID
+	d.rebindStyles()
+}
+
+// rebindStyles re-keys pendingStyles (path → style) onto the live source occurrences by
+// matching each placement's path, then clears them. A path no longer present in the source
+// is dropped (the placement was removed upstream).
+func (d *DerivedAssemblyComponent) rebindStyles() {
+	if len(d.pendingStyles) == 0 {
+		return
+	}
+	byPath := make(map[string]DeriveStyle, len(d.pendingStyles))
+	for _, e := range d.pendingStyles {
+		byPath[e.Path.Key()] = e.Style
+	}
+	for _, pb := range d.source.PlacedBodies() {
+		if style, ok := byPath[pb.Path.Key()]; ok {
+			d.styles[pb.Source] = style
+		}
+	}
+	d.pendingStyles = nil
+}
 
 // SetStyle sets the derive style for a source occurrence (default DeriveInclude).
 func (d *DerivedAssemblyComponent) SetStyle(o *occurrence.Occurrence, style DeriveStyle) {
 	d.styles[o] = style
+}
+
+// StylesByPath renders the non-default per-occurrence styles in their persistable,
+// pointer-free form, keyed by each styled placement's path. Returns nil when every
+// occurrence uses the default (include), keeping the recipe minimal.
+func (d *DerivedAssemblyComponent) StylesByPath() []DeriveStyleAtPath {
+	if d.source == nil || len(d.styles) == 0 {
+		return nil
+	}
+	var out []DeriveStyleAtPath
+	seen := map[string]bool{} // an occurrence with several bodies repeats its path; record once
+	for _, pb := range d.source.PlacedBodies() {
+		style, ok := d.styles[pb.Source]
+		if !ok || style == DeriveInclude || seen[pb.Path.Key()] {
+			continue
+		}
+		seen[pb.Path.Key()] = true
+		out = append(out, DeriveStyleAtPath{Path: pb.Path, Style: style})
+	}
+	return out
 }
 
 // Linked reports whether the derive still pulls from its source.
@@ -132,8 +238,13 @@ func recomputeLinked(in Input, linked bool, frozen []*topo.Body, build func() ([
 }
 
 // derive flattens, transforms, and combines the source's placed bodies per style into
-// the derived base bodies (zero bodies when nothing is included, otherwise one).
+// the derived base bodies (zero bodies when nothing is included, otherwise one). An
+// unbound source — a restored derive whose source has not been resolved yet (or is
+// missing) — yields no bodies, so a recompute before/without binding is safe.
 func (d *DerivedAssemblyComponent) derive() ([]*topo.Body, error) {
+	if d.source == nil {
+		return nil, nil
+	}
 	var joins, cuts []*topo.Body
 	for i, pb := range d.source.PlacedBodies() {
 		style := d.styles[pb.Source]
@@ -150,6 +261,12 @@ func (d *DerivedAssemblyComponent) derive() ([]*topo.Body, error) {
 			joins = append(joins, placed)
 		}
 	}
+	return combineDerived(joins, cuts)
+}
+
+// combineDerived merges the included bodies into one base and cuts the subtracted tools
+// from it, yielding zero bodies when nothing is included or the single merged base.
+func combineDerived(joins, cuts []*topo.Body) ([]*topo.Body, error) {
 	if len(joins) == 0 {
 		return nil, nil
 	}
@@ -181,12 +298,29 @@ func NewDerivedAssemblyComponents(engine *PartFeatures) *DerivedAssemblyComponen
 	return &DerivedAssemblyComponents{engine}
 }
 
-// AddDerived adds an associative derived-assembly component pulling from source.
-func (c *DerivedAssemblyComponents) AddDerived(source AssemblyBodySource) *PartFeature {
+// AddDerived adds an associative derived-assembly component pulling from source, recording
+// link — the source document's identity — so the derive survives a save and can detect a
+// stale source on reopen (#715).
+func (c *DerivedAssemblyComponents) AddDerived(source AssemblyBodySource, link DeriveSourceLink) *PartFeature {
 	d := &DerivedAssemblyComponent{
 		source: source,
 		styles: map[*occurrence.Occurrence]DeriveStyle{},
 		linked: true,
+		link:   link,
 	}
 	return c.engine.Add(d)
+}
+
+// RestoreDerivedAssembly rebuilds a derived-assembly component from its persisted recipe:
+// the source identity link, the linked flag, and the path-keyed styles — all UNBOUND. The
+// live source is rebound later by [DerivedAssemblyComponent.BindSource] once the part's
+// reference graph resolves the source document (#715), at which point styles re-key and
+// staleness is computed. Until then the derive contributes no geometry.
+func RestoreDerivedAssembly(link DeriveSourceLink, linked bool, styles []DeriveStyleAtPath) *DerivedAssemblyComponent {
+	return &DerivedAssemblyComponent{
+		styles:        map[*occurrence.Occurrence]DeriveStyle{},
+		linked:        linked,
+		link:          link,
+		pendingStyles: styles,
+	}
 }

--- a/model/feature/derived_assembly_test.go
+++ b/model/feature/derived_assembly_test.go
@@ -57,7 +57,7 @@ func TestDerivedAssemblyMergesIncludedBodies(t *testing.T) {
 		{Body: block, Transform: math.Translation4(math.V3(10, 0, 0)), Source: occFor("a:2")},
 	}}
 	fs := NewPartFeatures(nil, nil)
-	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{})
 	fs.Recompute()
 	if !pf.Health().OK() || len(fs.Result()) != 1 {
 		t.Fatalf("derive: health=%+v bodies=%d, want ok and one base body", pf.Health(), len(fs.Result()))
@@ -78,7 +78,7 @@ func TestDerivedAssemblySubtractsStyledOccurrence(t *testing.T) {
 		{Body: small, Transform: math.Identity4(), Source: cut},
 	}}
 	fs := NewPartFeatures(nil, nil)
-	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{})
 	pf.Definition().(*DerivedAssemblyComponent).SetStyle(cut, DeriveSubtract)
 	fs.Recompute()
 	if !pf.Health().OK() {
@@ -98,7 +98,7 @@ func TestDerivedAssemblyExcludesStyledOccurrence(t *testing.T) {
 		{Body: dropped, Transform: math.Identity4(), Source: drop},
 	}}
 	fs := NewPartFeatures(nil, nil)
-	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{})
 	pf.Definition().(*DerivedAssemblyComponent).SetStyle(drop, DeriveExclude)
 	fs.Recompute()
 	if got := volumeOf(fs.Result()[0]); !approx(got, 8) {
@@ -114,7 +114,7 @@ func TestDerivedAssemblyBreakLinkFreezesAndVersionTracks(t *testing.T) {
 		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
 	}}
 	fs := NewPartFeatures(nil, nil)
-	pf := NewDerivedAssemblyComponents(fs).AddDerived(src)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{})
 	fs.Recompute()
 	d := pf.Definition().(*DerivedAssemblyComponent)
 	v0 := d.SourceVersion()

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -58,6 +58,8 @@ type FeatureData struct {
 	Mark          *MarkData          `yaml:"mark,omitempty"`
 	Finish        *FinishData        `yaml:"finish,omitempty"`
 	Import        *ImportData        `yaml:"import,omitempty"`
+
+	DerivedAssembly *DerivedAssemblyData `yaml:"derivedAssembly,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -247,6 +249,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Thicken = &ThickenData{Value: f.Thickness(), Approximation: approximationName(f.Approximation())}
 	case faceEditor:
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
+	case *DerivedAssemblyComponent:
+		fd.DerivedAssembly = serializeDerivedAssembly(f)
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -377,6 +381,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":
 		return restoreCosmetic(fs, fd)
+	case "derivedAssembly":
+		return restoreDerivedAssembly(fs, fd.DerivedAssembly)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize_derived.go
+++ b/model/feature/serialize_derived.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/occurrence"
+)
+
+// DerivedAssemblyData is the serialized form of a derived-assembly feature (#715): the
+// source document's identity link (so the derive can re-resolve its source and detect a
+// stale one on reopen), whether the link is live, and the non-default per-occurrence
+// styles keyed by occurrence path. The source geometry is NOT embedded — it is pulled
+// from the resolved source document on open (ADR-0020).
+type DerivedAssemblyData struct {
+	SourceDocument           string             `yaml:"sourceDocument"`
+	SourceInternalName       string             `yaml:"sourceInternalName,omitempty"`
+	SourceDatabaseRevisionID string             `yaml:"sourceRevision,omitempty"`
+	Linked                   bool               `yaml:"linked"`
+	Styles                   []deriveStyleEntry `yaml:"styles,omitempty"`
+}
+
+// deriveStyleEntry persists one non-default derive style by the occurrence path it
+// applies to (the pointer-free key, valid across save/load).
+type deriveStyleEntry struct {
+	Path  []string `yaml:"path"`
+	Style string   `yaml:"style"`
+}
+
+// serializeDerivedAssembly projects a derived-assembly feature to its persisted form.
+func serializeDerivedAssembly(d *DerivedAssemblyComponent) *DerivedAssemblyData {
+	link := d.SourceLink()
+	data := &DerivedAssemblyData{
+		SourceDocument:           link.Document,
+		SourceInternalName:       link.InternalName,
+		SourceDatabaseRevisionID: link.DatabaseRevisionID,
+		Linked:                   d.linked,
+	}
+	for _, s := range d.StylesByPath() {
+		data.Styles = append(data.Styles, deriveStyleEntry{Path: []string(s.Path), Style: s.Style.String()})
+	}
+	return data
+}
+
+// restoreDerivedAssembly rebuilds an UNBOUND derived-assembly feature from its payload and
+// adds it to the engine. The source is rebound — and staleness computed — later, when the
+// part's reference graph resolves the source document (see compdef part ResolveReferences).
+func restoreDerivedAssembly(fs *PartFeatures, data *DerivedAssemblyData) (*PartFeature, error) {
+	if data == nil {
+		return nil, fmt.Errorf("derivedAssembly feature is missing its payload")
+	}
+	link := DeriveSourceLink{
+		Document:           data.SourceDocument,
+		InternalName:       data.SourceInternalName,
+		DatabaseRevisionID: data.SourceDatabaseRevisionID,
+	}
+	styles := make([]DeriveStyleAtPath, 0, len(data.Styles))
+	for _, e := range data.Styles {
+		style, ok := DeriveStyleFromName(e.Style)
+		if !ok {
+			return nil, fmt.Errorf("derivedAssembly: unknown derive style %q (want include/exclude/subtract)", e.Style)
+		}
+		styles = append(styles, DeriveStyleAtPath{Path: occurrence.OccurrencePath(e.Path), Style: style})
+	}
+	return fs.Add(RestoreDerivedAssembly(link, data.Linked, styles)), nil
+}

--- a/model/feature/serialize_derived_test.go
+++ b/model/feature/serialize_derived_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// sourceWithTwoBlocks builds a fake source of two disjoint unit blocks placed at a:1 (the
+// origin) and a:2 (x=10), each carrying its occurrence path so derive styles can key on it.
+func sourceWithTwoBlocks(t *testing.T) (*fakeAssemblySource, *occurrence.Occurrence, *occurrence.Occurrence) {
+	t.Helper()
+	block := solidBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	a, b := occFor("a:1"), occFor("a:2")
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: math.Identity4(), Source: a, Path: occurrence.OccurrencePath{"a:1"}},
+		{Body: block, Transform: math.Translation4(math.V3(10, 0, 0)), Source: b, Path: occurrence.OccurrencePath{"a:2"}},
+	}}
+	return src, a, b
+}
+
+// roundTripDerive serializes pf's derived-assembly feature and rebuilds it into a fresh
+// engine, returning the restored (still unbound) component and its engine.
+func roundTripDerive(t *testing.T, pf *PartFeature) (*DerivedAssemblyComponent, *PartFeatures) {
+	t.Helper()
+	fd, err := serializeFeature(pf, nil, nil)
+	if err != nil {
+		t.Fatalf("serialize derive: %v", err)
+	}
+	fs := NewPartFeatures(nil, nil)
+	restored, err := buildFeature(fs, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("restore derive: %v", err)
+	}
+	return restored.Definition().(*DerivedAssemblyComponent), fs
+}
+
+// TestDerivedAssemblySourceLinkSurvivesRoundTrip checks the source identity link round-trips
+// through the feature codec, restoring UNBOUND (no source) until a later BindSource.
+func TestDerivedAssemblySourceLinkSurvivesRoundTrip(t *testing.T) {
+	src, _, _ := sourceWithTwoBlocks(t)
+	link := DeriveSourceLink{Document: "src.obk", InternalName: "GUID-1", DatabaseRevisionID: "rev-1"}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, link)
+
+	restored, _ := roundTripDerive(t, pf)
+	if restored.SourceLink() != link {
+		t.Errorf("restored link = %+v, want %+v", restored.SourceLink(), link)
+	}
+	if restored.SourceVersion() != "" {
+		t.Errorf("restored derive should be unbound (empty source version), got %q", restored.SourceVersion())
+	}
+}
+
+// TestDerivedAssemblyStyleSurvivesRoundTrip excludes one source occurrence, round-trips the
+// derive, rebinds an equivalent source, and checks the excluded occurrence is still omitted
+// — the base body is the single included block (volume 1, not 2).
+func TestDerivedAssemblyStyleSurvivesRoundTrip(t *testing.T) {
+	src, _, b := sourceWithTwoBlocks(t)
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{DatabaseRevisionID: "rev-1"})
+	pf.Definition().(*DerivedAssemblyComponent).SetStyle(b, DeriveExclude)
+
+	restored, fs2 := roundTripDerive(t, pf)
+	// Rebind an equivalent source (same paths, fresh occurrence pointers) at the same revision.
+	src2, _, _ := sourceWithTwoBlocks(t)
+	restored.BindSource(src2, "rev-1")
+	if restored.OutOfDate() {
+		t.Error("same revision on rebind should not be out of date")
+	}
+	fs2.Recompute()
+	if len(fs2.Result()) != 1 || !approx(volumeOf(fs2.Result()[0]), 1) {
+		t.Fatalf("restored derive volume = %v bodies, want one body of volume 1 (a:2 excluded)", fs2.Result())
+	}
+}
+
+// TestDerivedAssemblyOutOfDateByRevision checks BindSource flags out-of-date exactly when
+// the source's current revision differs from the one captured in the link.
+func TestDerivedAssemblyOutOfDateByRevision(t *testing.T) {
+	src, _, _ := sourceWithTwoBlocks(t)
+	cases := []struct {
+		name         string
+		linkRev      string
+		currentRev   string
+		wantOutdated bool
+	}{
+		{"unchanged", "rev-1", "rev-1", false},
+		{"edited", "rev-1", "rev-2", true},
+		{"no link revision", "", "rev-2", false},
+		{"no current revision", "rev-1", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fs := NewPartFeatures(nil, nil)
+			pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{DatabaseRevisionID: c.linkRev})
+			d := pf.Definition().(*DerivedAssemblyComponent)
+			d.BindSource(src, c.currentRev)
+			if d.OutOfDate() != c.wantOutdated {
+				t.Errorf("OutOfDate(link=%q,current=%q) = %v, want %v", c.linkRev, c.currentRev, d.OutOfDate(), c.wantOutdated)
+			}
+		})
+	}
+}

--- a/model/occurrence/path.go
+++ b/model/occurrence/path.go
@@ -2,6 +2,8 @@
 
 package occurrence
 
+import "strings"
+
 // OccurrencePath addresses a (possibly nested) occurrence from a root assembly: the
 // sequence of occurrence instance names from the top down, e.g.
 // ["gearbox:1", "shaft:2"]. Because sub-occurrences are shared flyweights, the same
@@ -9,6 +11,12 @@ package occurrence
 // path is what disambiguates the *context* it is reached through — the reference API's
 // ComponentOccurrence.OccurrencePath. The empty path resolves to nothing.
 type OccurrencePath []string
+
+// Key returns a stable string key for the path, for use as a map key when associating
+// data with a placement (e.g. per-occurrence derive styles, #715). It is an in-memory
+// key, not a persisted form — the NUL separator cannot occur in an instance name, so
+// distinct paths never collide.
+func (p OccurrencePath) Key() string { return strings.Join(p, "\x00") }
 
 // Resolve walks the path from this collection down through nested sub-assemblies,
 // returning the addressed occurrence. It fails (false) on an empty path, a segment


### PR DESCRIPTION
## What
Completes **#715** (acceptance #2): a derived part reopened against an edited source **flags out-of-date by GUID+revision**. Builds on part 1 (#747), reusing its resolve-on-open seam — now extended to parts.

- **feature**: `DerivedAssemblyComponent` records a `DeriveSourceLink` (source document name + `InternalName` + `DatabaseRevisionID`) captured at derive time. A restored derive is **unbound** (contributes no geometry, recompute-safe) until `BindSource` rebinds the live source and computes out-of-date by comparing the source's current recipe revision against the captured one. Per-occurrence derive styles persist by occurrence **path** (`OccurrencePath.Key`) and re-key onto the live occurrences on rebind — a full-fidelity round trip.
- **feature serialization**: a `derivedAssembly` codec (`serialize_derived.go`) carries the link, linked flag, and non-default styles; the source geometry is pulled from the resolved source on open, never embedded (ADR-0020).
- **compdef**: `PartComponentDefinition` now implements `doc.ReferenceResolver`, re-resolving each derive's source through the part's reference graph on reopen (the PR1 seam), rebinding and recomputing staleness. A missing source leaves the derive unbound — never fatal.
- **router**: derive-create captures the source link and records the part→source reference so the link is snapshotted on save (mirrors PR1's `PlaceComponentFromFile`).

## Why
The derive held its source purely in memory and tracked change only via the live geometry version — in-session only. Derived features did not serialize at all, so a derived part never survived a reopen, let alone noticed an edited source.

## Design note
Same two-phase constraint as PR1: `ApplyRecipe` has no workspace, so a restored derive is unbound and binds in the workspace-driven `ResolveReferences` after registration. `DatabaseRevisionID` re-mints on save only when the recipe changed (#159) — exactly the staleness basis. Stable style key: `collectPlacedBodies` always sets the full root-first `PlacedBody.Path`.

## Tests
- **feature** (`serialize_derived_test.go`): source-link + linked + styles codec round-trip (rebind → excluded occurrence omitted, volume-gated 2→1); `OutOfDate` table over revision (un/changed, empty link/current).
- **compdef** (`derived_persistence_test.go`, reusing PR1 helpers): derive a saved source into a part, save+reopen → rebound & not stale; **edit + re-save the source (re-mints revision) → reopened derive flags out-of-date**; missing source → unbound, not fatal.

Full `go test ./...`, `go test -race ./model/...`, `golangci-lint v2.1.0 run ./...` (0 issues) pass locally; test scaffolding shared with PR1 to keep the SonarCloud duplication gate green. Source-repo only — no `api/` contract change.

## Scope / follow-up
`DerivedAssemblyComponent` only (the issue's named target). `DerivedPartComponent` and `ShrinkwrapComponent` share the same derive-family mechanism and are a parallel follow-up.

Closes #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)