### PR TITLE
model: derived-part applies a transform, persists & rebinds on open (M11)

### DIFF
--- a/model/compdef/derived_part_persistence_test.go
+++ b/model/compdef/derived_part_persistence_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// derivePartIntoPart creates a part that derives sourceDoc (another part) with transform,
+// capturing the source identity link and recording the part→source reference — the model
+// equivalent of a mirror-into-part (#717). Returns the deriving part document.
+func derivePartIntoPart(t *testing.T, ws *doc.Workspace, dir, name string, sourceDoc *doc.Document, transform math.Matrix4) *doc.Document {
+	t.Helper()
+	partDoc, err := compdef.AddPart(ws, filepath.Join(dir, name), true)
+	if err != nil {
+		t.Fatalf("AddPart %q: %v", name, err)
+	}
+	part := partDoc.Content().(*compdef.PartComponentDefinition)
+	source := sourceDoc.Content().(feature.BodySource)
+	id := sourceDoc.FileIdentity()
+	link := feature.DeriveSourceLink{
+		Document:           sourceDoc.FullDocumentName(),
+		InternalName:       id.InternalName,
+		DatabaseRevisionID: id.DatabaseRevisionID,
+	}
+	feature.NewDerivedComponents(part.Features()).AddDerived(source, transform, link)
+	partDoc.OpenReference(sourceDoc.FullDocumentName())
+	return partDoc
+}
+
+// derivedPartComponentOf returns the single derived-part component of a part.
+func derivedPartComponentOf(t *testing.T, part *compdef.PartComponentDefinition) *feature.DerivedPartComponent {
+	t.Helper()
+	for i := 0; i < part.Features().Count(); i++ {
+		if d, ok := part.Features().Item(i).Definition().(*feature.DerivedPartComponent); ok {
+			return d
+		}
+	}
+	t.Fatal("part has no derived-part component")
+	return nil
+}
+
+// TestDerivedFromPartRebindsOnReopen derives one part into another with a reflection
+// transform (the mirror-into-part shape), saves and reopens the deriving part, and checks
+// the derive re-resolves its source through the part's reference graph — rebound, not
+// stale, transform preserved — so a handed part survives a session (#717 foundation).
+func TestDerivedFromPartRebindsOnReopen(t *testing.T) {
+	store, ws, dir := assemblyWorkspace(t)
+	srcDoc := savePartDoc(t, ws, dir, "source.obk")
+	x, err := math.NewUnitVector3(1, 0, 0)
+	if err != nil {
+		t.Fatalf("NewUnitVector3: %v", err)
+	}
+	reflect := math.Reflection4(math.P3(0, 0, 0), x)
+	partDoc := derivePartIntoPart(t, ws, dir, "derived.obk", srcDoc, reflect)
+	if err := ws.Save(partDoc); err != nil {
+		t.Fatalf("Save derived part: %v", err)
+	}
+
+	d := derivedPartComponentOf(t, openPart(t, store, partDoc.FullFileName()))
+	if d.SourceVersion() == "" {
+		t.Error("reopened derived-part should have rebound its source")
+	}
+	if d.OutOfDate() {
+		t.Error("derive against an unchanged source should not be out of date")
+	}
+	if got := d.SourceLink().Document; got != srcDoc.FullFileName() {
+		t.Errorf("restored source link document = %q, want %q", got, srcDoc.FullFileName())
+	}
+	if d.Transform().Cells() != reflect.Cells() {
+		t.Error("restored derive transform does not match the saved reflection")
+	}
+}

--- a/model/compdef/part_resolve.go
+++ b/model/compdef/part_resolve.go
@@ -12,22 +12,31 @@ import (
 // whether it has since changed — is only knowable once the workspace can open it.
 var _ doc.ReferenceResolver = (*PartComponentDefinition)(nil)
 
-// ResolveReferences rebinds the part's derived-assembly features to their source documents
-// after a reopen (doc.ReferenceResolver): each derive re-resolves its source through
-// owner's reference graph, rebinds the live source for associative re-derive, and
-// recomputes whether the source is out of date (its recipe revision now differs from the
-// one captured when the derive was saved). A source that cannot be opened leaves the
-// derive unbound — it contributes no geometry — and is never fatal. owner is the part's
-// own document.
+// ResolveReferences rebinds the part's derive features (derived-assembly and derived-part)
+// to their source documents after a reopen (doc.ReferenceResolver): each derive re-resolves
+// its source through owner's reference graph, rebinds the live source for associative
+// re-derive, and recomputes whether the source is out of date (its recipe revision now
+// differs from the one captured when the derive was saved). A source that cannot be opened
+// leaves the derive unbound — it contributes no geometry — and is never fatal. owner is the
+// part's own document.
 func (d *PartComponentDefinition) ResolveReferences(owner *doc.Document) error {
 	rebound := false
 	for i := 0; i < d.features.Count(); i++ {
-		derive, ok := d.features.Item(i).Definition().(*feature.DerivedAssemblyComponent)
-		if !ok {
-			continue
-		}
-		if d.bindDeriveSource(owner, derive) {
-			rebound = true
+		switch derive := d.features.Item(i).Definition().(type) {
+		case *feature.DerivedAssemblyComponent:
+			if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
+				if source, ok := child.Content().(feature.AssemblyBodySource); ok {
+					derive.BindSource(source, rev)
+					rebound = true
+				}
+			}
+		case *feature.DerivedPartComponent:
+			if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
+				if source, ok := child.Content().(feature.BodySource); ok {
+					derive.BindSource(source, rev)
+					rebound = true
+				}
+			}
 		}
 	}
 	if rebound {
@@ -36,22 +45,16 @@ func (d *PartComponentDefinition) ResolveReferences(owner *doc.Document) error {
 	return nil
 }
 
-// bindDeriveSource opens a derive's source document through owner's reference graph and
-// rebinds it, reporting whether a live source was bound. An empty link (a derive built
-// without a document, e.g. in tests) or an unopenable/ non-assembly source is skipped.
-func (d *PartComponentDefinition) bindDeriveSource(owner *doc.Document, derive *feature.DerivedAssemblyComponent) bool {
-	link := derive.SourceLink()
+// openDeriveSource opens a derive's source document through owner's reference graph,
+// returning it with its current recipe revision. An empty link (a derive built without a
+// document, e.g. in tests) or an unopenable source reports false.
+func openDeriveSource(owner *doc.Document, link feature.DeriveSourceLink) (*doc.Document, string, bool) {
 	if link.Document == "" {
-		return false
+		return nil, "", false
 	}
 	child, ok := owner.OpenReference(link.Document)
 	if !ok {
-		return false
+		return nil, "", false
 	}
-	source, ok := child.Content().(feature.AssemblyBodySource)
-	if !ok {
-		return false
-	}
-	derive.BindSource(source, child.FileIdentity().DatabaseRevisionID)
-	return true
+	return child, child.FileIdentity().DatabaseRevisionID, true
 }

--- a/model/feature/derived.go
+++ b/model/feature/derived.go
@@ -2,7 +2,13 @@
 
 package feature
 
-import "oblikovati.org/kernel/topo"
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
 
 // BodySource is the consumer-side view of a part's evaluated content that a derived
 // feature pulls from — defined here so feature does not import compdef (avoiding a
@@ -15,30 +21,107 @@ type BodySource interface {
 }
 
 // DerivedPartComponent pulls geometry associatively from another part document
-// (PBI-097): each recompute re-reads the source's bodies, so a source edit flows
-// through. Scale/Mirror are recorded; applying the geometric transform needs a
-// kernel body-transform op (it arrives with assembly occurrence transforms, M11),
-// so for now the geometry is pulled as-is.
+// (PBI-097): each recompute re-reads the source's bodies and applies the derive
+// transform, so a source edit flows through. The transform is a general affine — the
+// identity pulls the source as-is; a reflection (negative determinant) produces an
+// opposite-hand copy, the basis of mirror-into-a-handed-part (#717). Like the derived
+// assembly, it carries the source's identity link to detect a stale source across
+// sessions (#715) and a break-link freeze.
 type DerivedPartComponent struct {
-	source BodySource
-	Scale  float64
-	Mirror bool
+	source    BodySource   // nil after restore until BindSource rebinds it
+	transform math.Matrix4 // applied to each pulled body; a reflection (det<0) mirrors it
+	link      DeriveSourceLink
+	linked    bool
+	frozen    []*topo.Body
+	outOfDate bool
 }
 
 // Definition returns the derived recipe.
 func (d *DerivedPartComponent) Definition() *DerivedPartComponent { return d }
 
-// SourceVersion returns the source's current geometry version (for change tracking).
-func (d *DerivedPartComponent) SourceVersion() string { return d.source.ModelGeometryVersion() }
+// SourceVersion returns the source's current geometry version, or "" when the source is
+// not bound (after restore, before [BindSource]).
+func (d *DerivedPartComponent) SourceVersion() string {
+	if d.source == nil {
+		return ""
+	}
+	return d.source.ModelGeometryVersion()
+}
+
+// SourceLink returns the persisted identity of the derive's source document (#715).
+func (d *DerivedPartComponent) SourceLink() DeriveSourceLink { return d.link }
+
+// OutOfDate reports whether the source has been edited since this derive was saved.
+func (d *DerivedPartComponent) OutOfDate() bool { return d.outOfDate }
+
+// Transform returns the geometry transform the derive applies to its source bodies.
+func (d *DerivedPartComponent) Transform() math.Matrix4 { return d.transform }
+
+// Linked reports whether the derive still pulls from its source.
+func (d *DerivedPartComponent) Linked() bool { return d.linked }
+
+// BindSource (re)binds the live source after a restore and recomputes staleness: the
+// derive is out of date when currentDBRevID differs from the revision in the link.
+func (d *DerivedPartComponent) BindSource(source BodySource, currentDBRevID string) {
+	d.source = source
+	d.outOfDate = d.link.DatabaseRevisionID != "" && currentDBRevID != "" && currentDBRevID != d.link.DatabaseRevisionID
+}
 
 // Kind implements [Feature].
 func (d *DerivedPartComponent) Kind() string { return "derived" }
 
-// Recompute appends the source's bodies to the running state.
+// BreakLink freezes the current derived bodies and severs the source link.
+func (d *DerivedPartComponent) BreakLink() error {
+	bodies, err := d.build()
+	if err != nil {
+		return err
+	}
+	d.frozen = bodies
+	d.linked = false
+	return nil
+}
+
+// Recompute appends the derived bodies (or, after a broken link, the frozen bodies) to
+// the running state, sharing the associative-or-frozen path with the derived assembly.
 func (d *DerivedPartComponent) Recompute(in Input) (Output, error) {
-	out := append([]*topo.Body(nil), in.Bodies...)
-	out = append(out, d.source.SurfaceBodies().All()...)
-	return Output{Bodies: out}, nil
+	return recomputeLinked(in, d.linked, d.frozen, d.build)
+}
+
+// build transforms each source body by the derive transform. An unbound source — a
+// restored derive not yet resolved (or missing) — yields no bodies, so a recompute
+// before/without binding is safe.
+func (d *DerivedPartComponent) build() ([]*topo.Body, error) {
+	if d.source == nil {
+		return nil, nil
+	}
+	var out []*topo.Body
+	for i, b := range d.source.SurfaceBodies().All() {
+		placed, err := d.placeBody(b, i)
+		if err != nil {
+			return nil, fmt.Errorf("feature: derived-part transform of body %d: %w", i, err)
+		}
+		out = append(out, placed)
+	}
+	return out, nil
+}
+
+// placeBody applies the derive transform to one source body. The identity short-circuits
+// to the source body unchanged; otherwise [ops.TransformBody] transforms it (flipping
+// winding for a reflection) under a distinct lineage so the copy gets independent keys.
+func (d *DerivedPartComponent) placeBody(b *topo.Body, index int) (*topo.Body, error) {
+	if d.transform.Cells() == math.Identity4().Cells() {
+		return b, nil
+	}
+	return ops.TransformBody(b, d.transform, derivedPartLineage(index))
+}
+
+// derivedPartLineage gives each transformed copy a distinct lineage prefix, so the
+// derived bodies get reference keys independent of the source's.
+func derivedPartLineage(index int) func(topo.Lineage) topo.Lineage {
+	prefix := topo.Tok("derivedPart", "body", index)
+	return func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append([]topo.LineageToken{prefix}, l.Tokens()...)...)
+	}
 }
 
 // NonParametricBaseFeature wraps imported/base bodies (from translation, M17) as a
@@ -71,9 +154,21 @@ type (
 func NewDerivedComponents(engine *PartFeatures) *DerivedComponents { return &DerivedComponents{engine} }
 func NewBaseFeatures(engine *PartFeatures) *BaseFeatures           { return &BaseFeatures{engine} }
 
-// AddDerived adds an associative derived component pulling from source.
-func (c *DerivedComponents) AddDerived(source BodySource, scale float64, mirror bool) *PartFeature {
-	return c.engine.Add(&DerivedPartComponent{source: source, Scale: scale, Mirror: mirror})
+// AddDerived adds an associative derived component pulling from source and applying
+// transform to its bodies (identity = pull as-is; a reflection mirrors them). link
+// records the source document's identity so the derive survives a save and detects a
+// stale source on reopen (#715).
+func (c *DerivedComponents) AddDerived(source BodySource, transform math.Matrix4, link DeriveSourceLink) *PartFeature {
+	return c.engine.Add(&DerivedPartComponent{source: source, transform: transform, link: link, linked: true})
+}
+
+// RestoreDerivedPart rebuilds a derived-part component from its persisted recipe — the
+// source identity link, the geometry transform, and the linked flag — all UNBOUND. The
+// live source is rebound later by [DerivedPartComponent.BindSource] once the part's
+// reference graph resolves the source document (#715). Until then it contributes no
+// geometry.
+func RestoreDerivedPart(link DeriveSourceLink, transform math.Matrix4, linked bool) *DerivedPartComponent {
+	return &DerivedPartComponent{transform: transform, link: link, linked: linked}
 }
 
 // AddBase adds a non-parametric base feature wrapping imported bodies.

--- a/model/feature/derived_part_test.go
+++ b/model/feature/derived_part_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// offsetBlockSource is a fake part source holding a unit block offset to +x (centroid
+// x=1.5), so a reflection about x=0 visibly relocates it to -x while preserving volume.
+func offsetBlockSource(t *testing.T) *fakeBodySource {
+	t.Helper()
+	src := newFakeBodySource()
+	src.SurfaceBodies().Add(solidBlock(t, math.P3(1, 0, 0), math.P3(2, 1, 1)))
+	return src
+}
+
+// TestDerivedPartAppliesReflection checks a reflection (negative-determinant) derive
+// transform mirrors the source body — the volume is preserved (the winding flip keeps it
+// a valid outward solid, not an inside-out negative one) and the centroid crosses to -x.
+func TestDerivedPartAppliesReflection(t *testing.T) {
+	src := offsetBlockSource(t)
+	reflect := math.Reflection4(math.P3(0, 0, 0), mustX()) // mirror across the x=0 plane
+
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedComponents(fs).AddDerived(src, reflect, DeriveSourceLink{})
+	fs.Recompute()
+	if !pf.Health().OK() || len(fs.Result()) != 1 {
+		t.Fatalf("derived reflection: health=%+v bodies=%d, want ok and one body", pf.Health(), len(fs.Result()))
+	}
+	props := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality())
+	if !approx(props.Volume, 1) {
+		t.Errorf("mirrored volume = %g, want 1 (reflection preserves volume; winding stays outward)", props.Volume)
+	}
+	if props.Centroid.X > -1 {
+		t.Errorf("mirrored centroid x = %g, want ≈ -1.5 (reflected across x=0)", props.Centroid.X)
+	}
+}
+
+// TestDerivedPartRoundTripAndRebind round-trips a reflecting derive through the feature
+// codec (link + transform + linked), restores it UNBOUND, rebinds a newer-revision source,
+// and checks it flags out of date and re-derives the mirrored body.
+func TestDerivedPartRoundTripAndRebind(t *testing.T) {
+	src := offsetBlockSource(t)
+	reflect := math.Reflection4(math.P3(0, 0, 0), mustX())
+	link := DeriveSourceLink{Document: "src.obk", InternalName: "GUID-1", DatabaseRevisionID: "rev-1"}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedComponents(fs).AddDerived(src, reflect, link)
+
+	fd, err := serializeFeature(pf, nil, nil)
+	if err != nil {
+		t.Fatalf("serialize derived part: %v", err)
+	}
+	fs2 := NewPartFeatures(nil, nil)
+	restored, err := buildFeature(fs2, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("restore derived part: %v", err)
+	}
+	d := restored.Definition().(*DerivedPartComponent)
+	if d.SourceLink() != link {
+		t.Errorf("restored link = %+v, want %+v", d.SourceLink(), link)
+	}
+	if d.Transform().Cells() != reflect.Cells() {
+		t.Error("restored transform does not match the saved reflection")
+	}
+	if d.SourceVersion() != "" {
+		t.Errorf("restored derive should be unbound, got source version %q", d.SourceVersion())
+	}
+
+	d.BindSource(offsetBlockSource(t), "rev-2")
+	if !d.OutOfDate() {
+		t.Error("rebinding a newer-revision source should flag out of date")
+	}
+	fs2.Recompute()
+	if len(fs2.Result()) != 1 || !approx(volumeOf(fs2.Result()[0]), 1) {
+		t.Fatalf("rebound derive = %v, want one mirrored body of volume 1", fs2.Result())
+	}
+}

--- a/model/feature/derived_test.go
+++ b/model/feature/derived_test.go
@@ -39,7 +39,7 @@ func TestDerivedComponentPullsSourceAssociatively(t *testing.T) {
 	source.SurfaceBodies().Add(oneBody())
 
 	fs := NewPartFeatures(nil, nil)
-	pf := NewDerivedComponents(fs).AddDerived(source, 1, false)
+	pf := NewDerivedComponents(fs).AddDerived(source, math.Identity4(), DeriveSourceLink{})
 	fs.Recompute()
 	if !pf.Health().OK() || len(fs.Result()) != 1 {
 		t.Fatalf("derived pull: health=%+v bodies=%d, want ok/1", pf.Health(), len(fs.Result()))
@@ -65,7 +65,7 @@ func TestNonParametricBaseFeatureIsDownstreamEditable(t *testing.T) {
 	// A downstream derived/extrude feature consumes the base body's running state.
 	source := newFakeBodySource()
 	source.SurfaceBodies().Add(oneBody())
-	NewDerivedComponents(fs).AddDerived(source, 1, false)
+	NewDerivedComponents(fs).AddDerived(source, math.Identity4(), DeriveSourceLink{})
 
 	fs.Recompute()
 	if !base.Health().OK() {

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -60,6 +60,7 @@ type FeatureData struct {
 	Import        *ImportData        `yaml:"import,omitempty"`
 
 	DerivedAssembly *DerivedAssemblyData `yaml:"derivedAssembly,omitempty"`
+	DerivedPart     *DerivedPartData     `yaml:"derivedPart,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -251,6 +252,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.FaceKeys())}
 	case *DerivedAssemblyComponent:
 		fd.DerivedAssembly = serializeDerivedAssembly(f)
+	case *DerivedPartComponent:
+		fd.DerivedPart = serializeDerivedPart(f)
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -383,6 +386,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreCosmetic(fs, fd)
 	case "derivedAssembly":
 		return restoreDerivedAssembly(fs, fd.DerivedAssembly)
+	case "derived":
+		return restoreDerivedPart(fs, fd.DerivedPart)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize_derived.go
+++ b/model/feature/serialize_derived.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/math"
 	"oblikovati.org/model/occurrence"
 )
 
@@ -64,4 +65,62 @@ func restoreDerivedAssembly(fs *PartFeatures, data *DerivedAssemblyData) (*PartF
 		styles = append(styles, DeriveStyleAtPath{Path: occurrence.OccurrencePath(e.Path), Style: style})
 	}
 	return fs.Add(RestoreDerivedAssembly(link, data.Linked, styles)), nil
+}
+
+// DerivedPartData is the serialized form of a derived-part feature (#715/#717): the
+// source document's identity link, the geometry transform applied to the pulled bodies
+// (16 row-major cells — a reflection makes an opposite-hand part), and the linked flag.
+// The source geometry is pulled from the resolved source on open, never embedded.
+type DerivedPartData struct {
+	SourceDocument           string    `yaml:"sourceDocument"`
+	SourceInternalName       string    `yaml:"sourceInternalName,omitempty"`
+	SourceDatabaseRevisionID string    `yaml:"sourceRevision,omitempty"`
+	Transform                []float64 `yaml:"transform,omitempty"`
+	Linked                   bool      `yaml:"linked"`
+}
+
+// serializeDerivedPart projects a derived-part feature to its persisted form.
+func serializeDerivedPart(d *DerivedPartComponent) *DerivedPartData {
+	link := d.SourceLink()
+	cells := d.Transform().Cells()
+	return &DerivedPartData{
+		SourceDocument:           link.Document,
+		SourceInternalName:       link.InternalName,
+		SourceDatabaseRevisionID: link.DatabaseRevisionID,
+		Transform:                cells[:],
+		Linked:                   d.Linked(),
+	}
+}
+
+// restoreDerivedPart rebuilds an UNBOUND derived-part feature from its payload and adds it
+// to the engine. The source is rebound — and staleness computed — later, when the part's
+// reference graph resolves the source document.
+func restoreDerivedPart(fs *PartFeatures, data *DerivedPartData) (*PartFeature, error) {
+	if data == nil {
+		return nil, fmt.Errorf("derived feature is missing its payload")
+	}
+	link := DeriveSourceLink{
+		Document:           data.SourceDocument,
+		InternalName:       data.SourceInternalName,
+		DatabaseRevisionID: data.SourceDatabaseRevisionID,
+	}
+	transform, err := matrixFromCells(data.Transform)
+	if err != nil {
+		return nil, fmt.Errorf("derived feature: %w", err)
+	}
+	return fs.Add(RestoreDerivedPart(link, transform, data.Linked)), nil
+}
+
+// matrixFromCells rebuilds a transform from its persisted 16 row-major cells; an empty
+// slice restores the identity (the pull-as-is derive).
+func matrixFromCells(cells []float64) (math.Matrix4, error) {
+	if len(cells) == 0 {
+		return math.Identity4(), nil
+	}
+	if len(cells) != 16 {
+		return math.Matrix4{}, fmt.Errorf("transform has %d cells, want 16", len(cells))
+	}
+	var c [16]float64
+	copy(c[:], cells)
+	return math.Matrix4FromCells(c), nil
 }


### PR DESCRIPTION
## What
Brings `feature.DerivedPartComponent` (part→part derive) to full parity with the derived-**assembly** component (#715/#748). It was a stub: it **ignored** its `Scale`/`Mirror` fields ("pulled as-is"), had **no serialization codec**, and **no source link** — so a part carrying one could not even save.

- **feature**: replace the unused `Scale`/`Mirror` with a single geometry **`transform math.Matrix4`** applied to each pulled source body via `kernel/ops.TransformBody` — identity pulls as-is; a **reflection** (negative determinant) makes an opposite-hand copy, flipping winding so the solid stays outward, under a distinct lineage so the copy gets independent reference keys. It now carries a `DeriveSourceLink`, rebinds via `BindSource` (computing out-of-date by recipe revision), and supports `BreakLink` — sharing the associative-or-frozen recompute path with the assembly derive.
- **feature serialization**: a `derivedPart` codec carrying the source link, the transform (16 cells), and the linked flag; geometry is pulled from the resolved source on open, never embedded (ADR-0020).
- **compdef**: `PartComponentDefinition.ResolveReferences` now rebinds **both** derive kinds (derived-assembly and derived-part) through one shared `openDeriveSource`.

## Why
This is the **foundation for #717** (mirror components into independent handed part documents): the handed part is a `DerivedPartComponent` pulling the source geometry with a reflection transform. It can't exist until the derived-part can apply a transform and persist. It also closes the `DerivedPartComponent` portion of the follow-up **#749**.

## Tests
- **feature**: a reflection derive mirrors the body — volume preserved + centroid crosses the plane (proving the winding flip keeps it a valid outward solid, not inside-out); source-link + transform codec round-trip → restore unbound → rebind newer-revision source → flags out-of-date and re-derives.
- **compdef**: one part derives another with a reflection, saves, reopens in a fresh workspace → the derive re-resolves its source through the part's reference graph, rebinds, transform preserved.

Full `go test ./...`, `go test -race ./model/...`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only — no `api/` change.

## Follow-up
PR 2 (#717): the `assembly.mirrorIntoPart` wire/router flow that creates the handed part and places it (`T = R·S·M`). Closes the `DerivedPartComponent` half of #749; shrinkwrap parity remains in #749.