### PR TITLE
router: assembly.mirrorIntoPart — mirror into a handed part document (M11)

### DIFF
--- a/addin/router/assembly_occurrences.go
+++ b/addin/router/assembly_occurrences.go
@@ -56,7 +56,10 @@ func assemblyPlace(s *app.Session, raw json.RawMessage) (json.RawMessage, error)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyPlace, err)
 	}
-	o, err := asm.PlaceComponent(in.Name, d, matrixFromWire(in.Transform))
+	// Place persistently: record the assembly→component reference and the occurrence's
+	// document name, so the placement survives a save/reopen (#715) and the occurrence is
+	// file-backed (e.g. for mirror-into-part, #717).
+	o, err := asm.PlaceComponentFromFile(s.ActiveDocument(), d, in.Name, matrixFromWire(in.Transform))
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyPlace, err)
 	}

--- a/addin/router/assembly_replication.go
+++ b/addin/router/assembly_replication.go
@@ -5,12 +5,16 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
 )
 
@@ -25,6 +29,7 @@ import (
 func (r *Router) registerAssemblyReplicationHandlers() {
 	r.handlers[wire.MethodAssemblyPatternCreate] = assemblyPatternCreate
 	r.handlers[wire.MethodAssemblyMirror] = assemblyMirror
+	r.handlers[wire.MethodAssemblyMirrorIntoPart] = assemblyMirrorIntoPart
 	r.handlers[wire.MethodAssemblyCopy] = assemblyCopy
 	r.handlers[wire.MethodAssemblySubstitute] = assemblySubstitute
 }
@@ -72,6 +77,110 @@ func assemblyMirror(s *app.Session, raw json.RawMessage) (json.RawMessage, error
 	}
 	origin := math.P3(in.Origin[0], in.Origin[1], in.Origin[2])
 	return newOccurrencesReply(occurrence.MirrorComponents(asm.Occurrences(), sources, origin, normal))
+}
+
+// assemblyMirrorIntoPart mirrors each source occurrence into a NEW opposite-hand part
+// document and places that as the mirrored occurrence (#717) — the document-producing
+// counterpart of assemblyMirror.
+func assemblyMirrorIntoPart(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	sources, reflect, err := parseMirrorIntoPart(asm, raw)
+	if err != nil {
+		return nil, err
+	}
+	asmDoc := s.ActiveDocument()
+	created := make([]*occurrence.Occurrence, 0, len(sources))
+	for _, src := range sources {
+		occ, err := mirrorOccurrenceIntoPart(s, asm, asmDoc, src, reflect)
+		if err != nil {
+			return nil, err
+		}
+		created = append(created, occ)
+	}
+	// AddPart activated each new mirror part; leave the assembly active, as assemblyMirror does.
+	if err := s.Workspace().SetActiveDocument(asmDoc); err != nil {
+		return nil, err
+	}
+	return newOccurrencesReply(created)
+}
+
+// parseMirrorIntoPart resolves the source occurrences and the mirror-plane reflection from
+// the request.
+func parseMirrorIntoPart(asm *compdef.AssemblyComponentDefinition, raw json.RawMessage) ([]*occurrence.Occurrence, math.Matrix4, error) {
+	var in wire.MirrorIntoPartArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, math.Matrix4{}, err
+	}
+	sources, err := occurrencesByID(asm, in.Sources, wire.MethodAssemblyMirrorIntoPart)
+	if err != nil {
+		return nil, math.Matrix4{}, err
+	}
+	normal, err := math.NewUnitVector3(in.Normal[0], in.Normal[1], in.Normal[2])
+	if err != nil {
+		return nil, math.Matrix4{}, fmt.Errorf("%s: normal %v is not a direction: %w", wire.MethodAssemblyMirrorIntoPart, in.Normal, err)
+	}
+	return sources, math.Reflection4(math.P3(in.Origin[0], in.Origin[1], in.Origin[2]), normal), nil
+}
+
+// mirrorOccurrenceIntoPart derives src's component into a new opposite-hand part and places
+// it so the occurrence's WORLD geometry equals the plane-mirror of the source. The new
+// part's local geometry is the source reflected about its own YZ plane (M), and the
+// occurrence sits at T = reflect·S·M — which has positive determinant, so the handedness
+// lives in the part, not the placement (a real opposite-hand part, not a reflected instance).
+func mirrorOccurrenceIntoPart(s *app.Session, asm *compdef.AssemblyComponentDefinition, asmDoc *doc.Document, src *occurrence.Occurrence, reflect math.Matrix4) (*occurrence.Occurrence, error) {
+	sourceName := src.ComponentName()
+	if sourceName == "" {
+		return nil, fmt.Errorf("%s: occurrence %q is not file-backed; mirror-into-part needs a source document", wire.MethodAssemblyMirrorIntoPart, src.Name())
+	}
+	sourceDoc, ok := s.Workspace().ByName(sourceName)
+	if !ok {
+		return nil, fmt.Errorf("%s: source document %q is not open", wire.MethodAssemblyMirrorIntoPart, sourceName)
+	}
+	local := localMirror()
+	mirroredDoc, err := deriveMirrorPart(s, sourceDoc, sourceName, local)
+	if err != nil {
+		return nil, err
+	}
+	placement := reflect.Mul(src.Transform()).Mul(local) // T = reflect·S·M
+	return asm.PlaceComponentFromFile(asmDoc, mirroredDoc, src.Name()+"-mirror", placement)
+}
+
+// deriveMirrorPart creates a new part document whose geometry is sourceDoc's body reflected
+// by local (the opposite-hand part), linked to the source for re-derive on open, and
+// returns it. The part→source reference is recorded so a save snapshots the link.
+func deriveMirrorPart(s *app.Session, sourceDoc *doc.Document, sourceName string, local math.Matrix4) (*doc.Document, error) {
+	source, ok := sourceDoc.Content().(feature.BodySource)
+	if !ok {
+		return nil, fmt.Errorf("%s: source %q is not a part", wire.MethodAssemblyMirrorIntoPart, sourceName)
+	}
+	mirroredDoc, err := compdef.AddPart(s.Workspace(), mirrorPartName(sourceName), false)
+	if err != nil {
+		return nil, fmt.Errorf("%s: create mirror part: %w", wire.MethodAssemblyMirrorIntoPart, err)
+	}
+	mirroredPart := mirroredDoc.Content().(*compdef.PartComponentDefinition)
+	id := sourceDoc.FileIdentity()
+	link := feature.DeriveSourceLink{Document: sourceName, InternalName: id.InternalName, DatabaseRevisionID: id.DatabaseRevisionID}
+	feature.NewDerivedComponents(mirroredPart.Features()).AddDerived(source, local, link)
+	mirroredDoc.OpenReference(sourceName) // mirror-part → source edge, for save + re-derive on open
+	mirroredPart.Recompute()
+	return mirroredDoc, nil
+}
+
+// localMirror is the reflection about a part's local YZ plane — the opposite-hand baking
+// transform. The unit X is always valid, so the construction cannot fail.
+func localMirror() math.Matrix4 {
+	normal, _ := math.NewUnitVector3(1, 0, 0)
+	return math.Reflection4(math.P3(0, 0, 0), normal)
+}
+
+// mirrorPartName derives the mirror part's document name from the source's:
+// "<base>-mirror<ext>" (e.g. widget.obk → widget-mirror.obk).
+func mirrorPartName(sourceName string) string {
+	ext := filepath.Ext(sourceName)
+	return strings.TrimSuffix(sourceName, ext) + "-mirror" + ext
 }
 
 // assemblyCopy adds an independent copy of each source occurrence.

--- a/addin/router/assembly_replication_test.go
+++ b/addin/router/assembly_replication_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"oblikovati.org/api/wire"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
 )
 
 // TestAssemblyPatternCircularOverWire replicates a seed component four-up around the Z
@@ -88,5 +91,49 @@ func TestAssemblySubstituteOverWire(t *testing.T) {
 
 	if _, err := r.Handle(s, "assembly.substitute", []byte(`{"sources":[99999],"document":1,"name":"x","transform":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}`)); err == nil {
 		t.Error("substitute of an unknown source id should fail")
+	}
+}
+
+// TestAssemblyMirrorIntoPartOverWire mirrors a file-backed component into a new opposite-
+// hand part document (#717): the created occurrence is placed by a proper (det>0)
+// transform — handedness lives in the part — and a new separately-openable "*-mirror.obk"
+// part holds the source geometry reflected across the local plane (volume preserved,
+// centroid crossed to -x).
+func TestAssemblyMirrorIntoPartOverWire(t *testing.T) {
+	r, s, _, _ := assemblySessionWithBoxes(t)
+	widget := partDocWithBox(t, s, "widget.obk") // a unit box [0,1]³ at the part origin
+
+	// Place the widget (file-backed, so the occurrence records a component document).
+	var placed wire.OccurrenceResult
+	call(t, r, s, "assembly.place", fmt.Sprintf(`{"document":%d,"name":"widget:1","transform":%s}`, uint64(widget.ID()), transformJSON(2, 0, 0)), &placed)
+
+	var mirrored wire.NewOccurrencesResult
+	call(t, r, s, "assembly.mirrorIntoPart", fmt.Sprintf(`{"sources":[%d],"origin":[0,0,0],"normal":[1,0,0]}`, placed.Occurrence.ID), &mirrored)
+	if len(mirrored.Created) != 1 {
+		t.Fatalf("mirror-into-part created %d occurrences, want 1", len(mirrored.Created))
+	}
+	if placement := math.Matrix4FromCells(mirrored.Created[0].Transform.Cells); placement.Determinant() <= 0 {
+		t.Errorf("placement determinant = %g, want > 0 (a real opposite-hand part, not a reflected instance)", placement.Determinant())
+	}
+
+	mirrorDoc, ok := s.Workspace().ByName("widget-mirror.obk")
+	if !ok {
+		t.Fatal("mirror-into-part should create a new widget-mirror.obk part document")
+	}
+	bodies := mirrorDoc.Content().(*compdef.PartComponentDefinition).SurfaceBodies().All()
+	if len(bodies) != 1 {
+		t.Fatalf("mirror part has %d bodies, want 1 (the reflected source)", len(bodies))
+	}
+	props := ops.BodyGeometryProperties(bodies[0], ops.DefaultQuality())
+	if stdmath.Abs(props.Volume-1) > 1e-6 {
+		t.Errorf("mirror part volume = %g, want 1 (reflection preserves the unit box)", props.Volume)
+	}
+	if props.Centroid.X > 0 {
+		t.Errorf("mirror part centroid x = %g, want < 0 (geometry reflected about the local YZ plane)", props.Centroid.X)
+	}
+
+	// The source occurrence remains; the assembly now has the original plus the mirror.
+	if _, err := r.Handle(s, "assembly.mirrorIntoPart", []byte(`{"sources":[999],"origin":[0,0,0],"normal":[1,0,0]}`)); err == nil {
+		t.Error("mirror-into-part of an unknown occurrence id should fail")
 	}
 }


### PR DESCRIPTION
## What
Implements the document-producing mirror (**#717**): for each chiral source occurrence, derive a **new opposite-hand PART document** — the source geometry reflected, baked into its own editable, separately-openable part — and place THAT as the mirrored occurrence, rather than `assembly.mirror`'s shared definition handed only by the placement.

- **`assemblyMirrorIntoPart`**: resolves each file-backed source, creates a `<base>-mirror.obk` part deriving the source with a **local reflection** (the derived-part foundation from #753), records the mirror→source reference, recomputes, and places it at **`T = reflect·S·M`** so the occurrence's world geometry equals the plane-mirror of the source while the placement stays **proper (det > 0)** — the handedness lives in the *part*, not the transform.
- **`assembly.place` fix**: now places **persistently** (`PlaceComponentFromFile`) so a wire-placed occurrence is file-backed and survives a save/reopen (#715). Without this the placement carried no component reference — a latent gap from the #715 work — so mirror-into-part had no source document to derive from.

## Why
The reference API's mirror creates a real opposite-hand part for a chiral component that must be separately editable; today's mirror only reflects the placement. "Mirror vs reuse" starts conservative — this method always derives; symmetry-detection reuse is a later refinement.

## Transform algebra (verified)
World result must equal the plane-mirror `R·S·G` (R reflection, S source placement, G source local geometry). Baking the part as `M·G` (M a local reflection) and placing at `T = R·S·M` gives `T·M·G = R·S·G`, and `det(T) = det(S) > 0`.

## Tests
Over-wire: place a file-backed unit box, `assembly.mirrorIntoPart` across x=0 → one created occurrence with **det > 0** placement; a new `widget-mirror.obk` part exists, separately openable, holding **one body of volume 1** (reflection-preserving) whose **centroid crossed to −x** (proving the reflection + winding flip); unknown-source rejection.

Full `go test ./...`, `go test -race`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally.

## Depends on
- Foundation: #753 (merged) — derived-part transform + persistence.
- Contract: Oblikovati.API#86 (merged).

Closes #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)