### PR TITLE
model: persist shrinkwrap source link & flag stale source on reopen (M11)

### DIFF
--- a/addin/router/assembly_derive.go
+++ b/addin/router/assembly_derive.go
@@ -65,7 +65,7 @@ func assemblyShrinkwrapCreate(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	source, _, err := assemblySource(s, in.Source, wire.MethodAssemblyShrinkwrapCreate)
+	source, sourceDoc, err := assemblySource(s, in.Source, wire.MethodAssemblyShrinkwrapCreate)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,9 @@ func assemblyShrinkwrapCreate(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewShrinkwrapComponents(part.Features()).AddShrinkwrap(source, def)
+	pf := feature.NewShrinkwrapComponents(part.Features()).AddShrinkwrap(source, def, deriveSourceLink(sourceDoc))
+	// Record the part→source edge so the first save snapshots the link (the source is open).
+	s.ActiveDocument().OpenReference(sourceDoc.FullDocumentName())
 	return commitNewDerive(part, pf)
 }
 

--- a/model/compdef/derived_part_persistence_test.go
+++ b/model/compdef/derived_part_persistence_test.go
@@ -23,14 +23,7 @@ func derivePartIntoPart(t *testing.T, ws *doc.Workspace, dir, name string, sourc
 	}
 	part := partDoc.Content().(*compdef.PartComponentDefinition)
 	source := sourceDoc.Content().(feature.BodySource)
-	id := sourceDoc.FileIdentity()
-	link := feature.DeriveSourceLink{
-		Document:           sourceDoc.FullDocumentName(),
-		InternalName:       id.InternalName,
-		DatabaseRevisionID: id.DatabaseRevisionID,
-	}
-	feature.NewDerivedComponents(part.Features()).AddDerived(source, transform, link)
-	partDoc.OpenReference(sourceDoc.FullDocumentName())
+	feature.NewDerivedComponents(part.Features()).AddDerived(source, transform, assemblySourceLink(partDoc, sourceDoc))
 	return partDoc
 }
 

--- a/model/compdef/derived_persistence_test.go
+++ b/model/compdef/derived_persistence_test.go
@@ -25,14 +25,7 @@ func deriveSourceIntoPart(t *testing.T, ws *doc.Workspace, dir, name string, sou
 	}
 	part := partDoc.Content().(*compdef.PartComponentDefinition)
 	source := sourceDoc.Content().(feature.AssemblyBodySource)
-	id := sourceDoc.FileIdentity()
-	link := feature.DeriveSourceLink{
-		Document:           sourceDoc.FullDocumentName(),
-		InternalName:       id.InternalName,
-		DatabaseRevisionID: id.DatabaseRevisionID,
-	}
-	feature.NewDerivedAssemblyComponents(part.Features()).AddDerived(source, link)
-	partDoc.OpenReference(sourceDoc.FullDocumentName())
+	feature.NewDerivedAssemblyComponents(part.Features()).AddDerived(source, assemblySourceLink(partDoc, sourceDoc))
 	return partDoc
 }
 

--- a/model/compdef/part_resolve.go
+++ b/model/compdef/part_resolve.go
@@ -22,27 +22,38 @@ var _ doc.ReferenceResolver = (*PartComponentDefinition)(nil)
 func (d *PartComponentDefinition) ResolveReferences(owner *doc.Document) error {
 	rebound := false
 	for i := 0; i < d.features.Count(); i++ {
-		switch derive := d.features.Item(i).Definition().(type) {
-		case *feature.DerivedAssemblyComponent:
-			if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
-				if source, ok := child.Content().(feature.AssemblyBodySource); ok {
-					derive.BindSource(source, rev)
-					rebound = true
-				}
-			}
-		case *feature.DerivedPartComponent:
-			if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
-				if source, ok := child.Content().(feature.BodySource); ok {
-					derive.BindSource(source, rev)
-					rebound = true
-				}
-			}
+		if bindDeriveFeature(owner, d.features.Item(i).Definition()) {
+			rebound = true
 		}
 	}
 	if rebound {
 		d.Recompute()
 	}
 	return nil
+}
+
+// bindDeriveFeature rebinds one feature's derive source if it is a derive-family feature,
+// reporting whether a live source was bound. The assembly-sourced derives (derived-assembly
+// and shrinkwrap) share the AssemblyBodySource path; the derived-part binds a part
+// BodySource.
+func bindDeriveFeature(owner *doc.Document, def feature.Feature) bool {
+	switch derive := def.(type) {
+	case feature.AssemblyDeriveBinder:
+		if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
+			if source, ok := child.Content().(feature.AssemblyBodySource); ok {
+				derive.BindSource(source, rev)
+				return true
+			}
+		}
+	case *feature.DerivedPartComponent:
+		if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
+			if source, ok := child.Content().(feature.BodySource); ok {
+				derive.BindSource(source, rev)
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // openDeriveSource opens a derive's source document through owner's reference graph,

--- a/model/compdef/shrinkwrap_persistence_test.go
+++ b/model/compdef/shrinkwrap_persistence_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// assemblySourceLink records partDoc's reference to sourceDoc and returns the source's
+// identity link — the shared front half of the derive/shrinkwrap-from-document test
+// helpers, exactly as the router does at create time.
+func assemblySourceLink(partDoc, sourceDoc *doc.Document) feature.DeriveSourceLink {
+	partDoc.OpenReference(sourceDoc.FullDocumentName())
+	id := sourceDoc.FileIdentity()
+	return feature.DeriveSourceLink{
+		Document:           sourceDoc.FullDocumentName(),
+		InternalName:       id.InternalName,
+		DatabaseRevisionID: id.DatabaseRevisionID,
+	}
+}
+
+// shrinkwrapSourceIntoPart creates a part that shrinkwraps sourceDoc (an assembly),
+// recording the source link and reference, and returns the part document.
+func shrinkwrapSourceIntoPart(t *testing.T, ws *doc.Workspace, dir, name string, sourceDoc *doc.Document) *doc.Document {
+	t.Helper()
+	partDoc, err := compdef.AddPart(ws, filepath.Join(dir, name), true)
+	if err != nil {
+		t.Fatalf("AddPart %q: %v", name, err)
+	}
+	part := partDoc.Content().(*compdef.PartComponentDefinition)
+	source := sourceDoc.Content().(feature.AssemblyBodySource)
+	feature.NewShrinkwrapComponents(part.Features()).AddShrinkwrap(source, feature.ShrinkwrapDefinition{}, assemblySourceLink(partDoc, sourceDoc))
+	return partDoc
+}
+
+// shrinkwrapComponentOf returns the single shrinkwrap component of a part.
+func shrinkwrapComponentOf(t *testing.T, part *compdef.PartComponentDefinition) *feature.ShrinkwrapComponent {
+	t.Helper()
+	for i := 0; i < part.Features().Count(); i++ {
+		if sw, ok := part.Features().Item(i).Definition().(*feature.ShrinkwrapComponent); ok {
+			return sw
+		}
+	}
+	t.Fatal("part has no shrinkwrap component")
+	return nil
+}
+
+// TestShrinkwrapPartRebindsOnReopen shrinkwraps a saved source assembly into a part, saves
+// and reopens the part, and checks the shrinkwrap re-resolves its source through the part's
+// reference graph — rebound and not stale (#715/#749 acceptance).
+func TestShrinkwrapPartRebindsOnReopen(t *testing.T) {
+	store, ws, dir := assemblyWorkspace(t)
+	srcDoc, _ := newAssembly(t, ws, dir, "src.obk")
+	if err := ws.Save(srcDoc); err != nil {
+		t.Fatalf("Save source: %v", err)
+	}
+	partDoc := shrinkwrapSourceIntoPart(t, ws, dir, "wrap.obk", srcDoc)
+	if err := ws.Save(partDoc); err != nil {
+		t.Fatalf("Save shrinkwrap part: %v", err)
+	}
+
+	sw := shrinkwrapComponentOf(t, openPart(t, store, partDoc.FullFileName()))
+	if sw.SourceVersion() == "" {
+		t.Error("reopened shrinkwrap should have rebound its source")
+	}
+	if sw.OutOfDate() {
+		t.Error("shrinkwrap against an unchanged source should not be out of date")
+	}
+	if got := sw.SourceLink().Document; got != srcDoc.FullFileName() {
+		t.Errorf("restored source link document = %q, want %q", got, srcDoc.FullFileName())
+	}
+}

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -101,6 +101,16 @@ type AssemblyBodySource interface {
 	ModelGeometryVersion() string
 }
 
+// AssemblyDeriveBinder is the derive-family feature that pulls from an assembly source —
+// the derived-assembly and the shrinkwrap. It exposes the persisted source link and
+// rebinds the live assembly source on reopen, so the part resolver can rebind both kinds
+// uniformly (#715). The derived-PART feature is NOT one of these — it binds a part
+// [BodySource], a different interface.
+type AssemblyDeriveBinder interface {
+	SourceLink() DeriveSourceLink
+	BindSource(source AssemblyBodySource, currentDBRevID string)
+}
+
 // DerivedAssemblyComponent derives a source assembly into this part as a base body:
 // each recompute pulls the source's placed bodies, transforms each into the part, and
 // merges the included ones — cutting the subtracted, skipping the excluded — into one

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -61,6 +61,7 @@ type FeatureData struct {
 
 	DerivedAssembly *DerivedAssemblyData `yaml:"derivedAssembly,omitempty"`
 	DerivedPart     *DerivedPartData     `yaml:"derivedPart,omitempty"`
+	Shrinkwrap      *ShrinkwrapData      `yaml:"shrinkwrap,omitempty"`
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -254,6 +255,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.DerivedAssembly = serializeDerivedAssembly(f)
 	case *DerivedPartComponent:
 		fd.DerivedPart = serializeDerivedPart(f)
+	case *ShrinkwrapComponent:
+		fd.Shrinkwrap = serializeShrinkwrap(f)
 	default:
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -388,6 +391,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreDerivedAssembly(fs, fd.DerivedAssembly)
 	case "derived":
 		return restoreDerivedPart(fs, fd.DerivedPart)
+	case "shrinkwrap":
+		return restoreShrinkwrap(fs, fd.Shrinkwrap)
 	default:
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize_derived.go
+++ b/model/feature/serialize_derived.go
@@ -111,6 +111,57 @@ func restoreDerivedPart(fs *PartFeatures, data *DerivedPartData) (*PartFeature, 
 	return fs.Add(RestoreDerivedPart(link, transform, data.Linked)), nil
 }
 
+// ShrinkwrapData is the serialized form of a shrinkwrap feature (#715/#749): the source
+// assembly document's identity link, the linked flag, and the simplification options. The
+// simplified geometry is rebuilt from the resolved source on open, never embedded.
+type ShrinkwrapData struct {
+	SourceDocument           string  `yaml:"sourceDocument"`
+	SourceInternalName       string  `yaml:"sourceInternalName,omitempty"`
+	SourceDatabaseRevisionID string  `yaml:"sourceRevision,omitempty"`
+	Linked                   bool    `yaml:"linked"`
+	RemoveStyle              int     `yaml:"removeStyle,omitempty"`
+	MinPartVolume            float64 `yaml:"minPartVolume,omitempty"`
+	EnvelopeStyle            int     `yaml:"envelopeStyle,omitempty"`
+	PatchHoles               bool    `yaml:"patchHoles,omitempty"`
+}
+
+// serializeShrinkwrap projects a shrinkwrap feature to its persisted form.
+func serializeShrinkwrap(s *ShrinkwrapComponent) *ShrinkwrapData {
+	link := s.SourceLink()
+	opt := s.Options()
+	return &ShrinkwrapData{
+		SourceDocument:           link.Document,
+		SourceInternalName:       link.InternalName,
+		SourceDatabaseRevisionID: link.DatabaseRevisionID,
+		Linked:                   s.Linked(),
+		RemoveStyle:              int(opt.RemoveStyle),
+		MinPartVolume:            opt.MinPartVolume,
+		EnvelopeStyle:            int(opt.EnvelopeStyle),
+		PatchHoles:               opt.PatchHoles,
+	}
+}
+
+// restoreShrinkwrap rebuilds an UNBOUND shrinkwrap feature from its payload and adds it to
+// the engine. The source is rebound — and staleness computed — later, when the part's
+// reference graph resolves the source document.
+func restoreShrinkwrap(fs *PartFeatures, data *ShrinkwrapData) (*PartFeature, error) {
+	if data == nil {
+		return nil, fmt.Errorf("shrinkwrap feature is missing its payload")
+	}
+	link := DeriveSourceLink{
+		Document:           data.SourceDocument,
+		InternalName:       data.SourceInternalName,
+		DatabaseRevisionID: data.SourceDatabaseRevisionID,
+	}
+	def := ShrinkwrapDefinition{
+		RemoveStyle:   ShrinkwrapRemoveStyle(data.RemoveStyle),
+		MinPartVolume: data.MinPartVolume,
+		EnvelopeStyle: ShrinkwrapEnvelopeStyle(data.EnvelopeStyle),
+		PatchHoles:    data.PatchHoles,
+	}
+	return fs.Add(RestoreShrinkwrap(link, def, data.Linked)), nil
+}
+
 // matrixFromCells rebuilds a transform from its persisted 16 row-major cells; an empty
 // slice restores the identity (the pull-as-is derive).
 func matrixFromCells(cells []float64) (math.Matrix4, error) {

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -240,10 +240,12 @@ func mergeIntoBase(bodies []*topo.Body) []*topo.Body {
 // source, so a source edit re-simplifies; BreakLink freezes the current result. It is
 // the simplified-derive flavor of [DerivedAssemblyComponent].
 type ShrinkwrapComponent struct {
-	source AssemblyBodySource
-	def    ShrinkwrapDefinition
-	linked bool
-	frozen []*topo.Body
+	source    AssemblyBodySource // nil after restore until BindSource rebinds it
+	def       ShrinkwrapDefinition
+	linked    bool
+	frozen    []*topo.Body
+	link      DeriveSourceLink
+	outOfDate bool
 }
 
 // Definition returns the shrinkwrap recipe holder.
@@ -252,8 +254,28 @@ func (s *ShrinkwrapComponent) Definition() *ShrinkwrapComponent { return s }
 // Kind implements [Feature].
 func (s *ShrinkwrapComponent) Kind() string { return "shrinkwrap" }
 
-// SourceVersion returns the source assembly's geometry version (change tracking).
-func (s *ShrinkwrapComponent) SourceVersion() string { return s.source.ModelGeometryVersion() }
+// SourceVersion returns the source assembly's geometry version, or "" when the source is
+// not bound (after restore, before [BindSource]).
+func (s *ShrinkwrapComponent) SourceVersion() string {
+	if s.source == nil {
+		return ""
+	}
+	return s.source.ModelGeometryVersion()
+}
+
+// SourceLink returns the persisted identity of the shrinkwrap's source document (#715).
+func (s *ShrinkwrapComponent) SourceLink() DeriveSourceLink { return s.link }
+
+// OutOfDate reports whether the source assembly has been edited since this shrinkwrap was
+// saved — the source resolved on reopen carries a different recipe revision than captured.
+func (s *ShrinkwrapComponent) OutOfDate() bool { return s.outOfDate }
+
+// BindSource (re)binds the live source assembly after a restore and recomputes staleness:
+// out of date when currentDBRevID differs from the revision captured in the link (#715).
+func (s *ShrinkwrapComponent) BindSource(source AssemblyBodySource, currentDBRevID string) {
+	s.source = source
+	s.outOfDate = s.link.DatabaseRevisionID != "" && currentDBRevID != "" && currentDBRevID != s.link.DatabaseRevisionID
+}
 
 // Linked reports whether the shrinkwrap still pulls from its source.
 func (s *ShrinkwrapComponent) Linked() bool { return s.linked }
@@ -267,7 +289,7 @@ func (s *ShrinkwrapComponent) SetOptions(def ShrinkwrapDefinition) { s.def = def
 // BreakLink freezes the current shrinkwrap result and severs the source link, so the
 // part keeps the simplified geometry without further updates.
 func (s *ShrinkwrapComponent) BreakLink() error {
-	bodies, err := BuildShrinkwrap(s.source, s.def)
+	bodies, err := s.build()
 	if err != nil {
 		return err
 	}
@@ -276,12 +298,19 @@ func (s *ShrinkwrapComponent) BreakLink() error {
 	return nil
 }
 
+// build simplifies the bound source; an unbound source (a restored shrinkwrap not yet
+// resolved, or missing) yields no bodies, so a recompute before/without binding is safe.
+func (s *ShrinkwrapComponent) build() ([]*topo.Body, error) {
+	if s.source == nil {
+		return nil, nil
+	}
+	return BuildShrinkwrap(s.source, s.def)
+}
+
 // Recompute appends the shrinkwrap base body (or, after a broken link, the frozen
 // bodies) to the running state.
 func (s *ShrinkwrapComponent) Recompute(in Input) (Output, error) {
-	return recomputeLinked(in, s.linked, s.frozen, func() ([]*topo.Body, error) {
-		return BuildShrinkwrap(s.source, s.def)
-	})
+	return recomputeLinked(in, s.linked, s.frozen, s.build)
 }
 
 // ShrinkwrapComponents adds shrinkwrap features into the engine.
@@ -292,7 +321,17 @@ func NewShrinkwrapComponents(engine *PartFeatures) *ShrinkwrapComponents {
 	return &ShrinkwrapComponents{engine}
 }
 
-// AddShrinkwrap adds an associative shrinkwrap component simplifying source per def.
-func (c *ShrinkwrapComponents) AddShrinkwrap(source AssemblyBodySource, def ShrinkwrapDefinition) *PartFeature {
-	return c.engine.Add(&ShrinkwrapComponent{source: source, def: def, linked: true})
+// AddShrinkwrap adds an associative shrinkwrap component simplifying source per def,
+// recording link — the source assembly document's identity — so the shrinkwrap survives a
+// save and detects a stale source on reopen (#715).
+func (c *ShrinkwrapComponents) AddShrinkwrap(source AssemblyBodySource, def ShrinkwrapDefinition, link DeriveSourceLink) *PartFeature {
+	return c.engine.Add(&ShrinkwrapComponent{source: source, def: def, linked: true, link: link})
+}
+
+// RestoreShrinkwrap rebuilds a shrinkwrap component from its persisted recipe — the source
+// identity link, the simplification options, and the linked flag — all UNBOUND. The live
+// source is rebound later by [ShrinkwrapComponent.BindSource] once the part's reference
+// graph resolves the source document (#715); until then it contributes no geometry.
+func RestoreShrinkwrap(link DeriveSourceLink, def ShrinkwrapDefinition, linked bool) *ShrinkwrapComponent {
+	return &ShrinkwrapComponent{def: def, linked: linked, link: link}
 }

--- a/model/feature/shrinkwrap_serialize_test.go
+++ b/model/feature/shrinkwrap_serialize_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestShrinkwrapSourceLinkAndOptionsRoundTrip round-trips a shrinkwrap through the feature
+// codec — source identity link, linked flag, and every simplification option — restores it
+// UNBOUND, rebinds a newer-revision source, and checks it flags out of date and
+// re-simplifies the source into one enveloped body.
+func TestShrinkwrapSourceLinkAndOptionsRoundTrip(t *testing.T) {
+	block := solidBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2)) // volume 8
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
+	}}
+	link := DeriveSourceLink{Document: "asm.obk", InternalName: "GUID-1", DatabaseRevisionID: "rev-1"}
+	def := ShrinkwrapDefinition{RemoveStyle: RemoveSmallParts, MinPartVolume: 0.5, EnvelopeStyle: EnvelopeWhole, PatchHoles: true}
+	fs := NewPartFeatures(nil, nil)
+	pf := NewShrinkwrapComponents(fs).AddShrinkwrap(src, def, link)
+
+	fd, err := serializeFeature(pf, nil, nil)
+	if err != nil {
+		t.Fatalf("serialize shrinkwrap: %v", err)
+	}
+	fs2 := NewPartFeatures(nil, nil)
+	restored, err := buildFeature(fs2, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("restore shrinkwrap: %v", err)
+	}
+	sw := restored.Definition().(*ShrinkwrapComponent)
+	if sw.SourceLink() != link {
+		t.Errorf("restored link = %+v, want %+v", sw.SourceLink(), link)
+	}
+	if sw.Options() != def {
+		t.Errorf("restored options = %+v, want %+v", sw.Options(), def)
+	}
+	if sw.SourceVersion() != "" {
+		t.Errorf("restored shrinkwrap should be unbound, got source version %q", sw.SourceVersion())
+	}
+
+	sw.BindSource(src, "rev-2")
+	if !sw.OutOfDate() {
+		t.Error("rebinding a newer-revision source should flag out of date")
+	}
+	fs2.Recompute()
+	if len(fs2.Result()) != 1 {
+		t.Fatalf("rebound shrinkwrap = %d bodies, want one enveloped body", len(fs2.Result()))
+	}
+}

--- a/model/feature/shrinkwrap_test.go
+++ b/model/feature/shrinkwrap_test.go
@@ -152,7 +152,7 @@ func TestShrinkwrapBreakLinkFreezesAndVersionTracks(t *testing.T) {
 		{Body: block, Transform: math.Identity4(), Source: occFor("a:1")},
 	}}
 	fs := NewPartFeatures(nil, nil)
-	pf := NewShrinkwrapComponents(fs).AddShrinkwrap(src, ShrinkwrapDefinition{})
+	pf := NewShrinkwrapComponents(fs).AddShrinkwrap(src, ShrinkwrapDefinition{}, DeriveSourceLink{})
 	fs.Recompute()
 	s := pf.Definition().(*ShrinkwrapComponent)
 	v0 := s.SourceVersion()


### PR DESCRIPTION
## What
Completes **#749**: brings `feature.ShrinkwrapComponent` (the simplified assembly derive) to the same persistence + cross-session staleness as the derived-assembly (#748) and derived-part (#753) components. It held its source assembly **in memory only**, had **no serialization codec**, and **no source link** — so a shrinkwrap didn't survive a reopen or notice an edited source.

- **feature**: `ShrinkwrapComponent` records a `DeriveSourceLink` captured at create time, rebinds via `BindSource` (computing out-of-date by recipe revision), and contributes no geometry while unbound (recompute-safe). A new `shrinkwrap` codec carries the source link, linked flag, and simplification options (remove/envelope style, min volume, patch-holes); geometry is rebuilt from the resolved source on open, never embedded (ADR-0020).
- **compdef**: `PartComponentDefinition.ResolveReferences` rebinds it too. The two assembly-sourced derives (derived-assembly + shrinkwrap) now bind through one **`feature.AssemblyDeriveBinder`** interface, so the resolver handles all three derive kinds without per-kind duplication.
- **router**: `assembly.shrinkwrapCreate` captures the source link and records the part→source reference so the link is snapshotted on save.

## Why
The follow-up #749 (narrowed after #753 closed its derived-part half). With this, all three derive-family features — derived-assembly, derived-part, shrinkwrap — persist their source and detect a stale source across sessions, uniformly.

## Tests
- **feature**: shrinkwrap codec round-trip (source link + linked + **all four options**) → restore unbound → rebind newer-revision source → flags out-of-date and re-simplifies to one enveloped body.
- **compdef**: shrinkwrap a saved source assembly into a part, save, reopen in a fresh workspace → the shrinkwrap re-resolves its source through the part's reference graph, rebinds, not stale. (Shared test scaffolding (`assemblySourceLink`) extracted across the three derive persistence tests to keep the SonarCloud duplication gate green.)

Full `go test ./...`, `go test -race ./model/...`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only — no `api/` change.

Closes #749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)