### PR TITLE
router,feature: derive out-of-date status & update over the wire (M11)

### DIFF
--- a/addin/router/assembly_derive.go
+++ b/addin/router/assembly_derive.go
@@ -26,6 +26,78 @@ func (r *Router) registerAssemblyDeriveHandlers() {
 	r.handlers[wire.MethodAssemblyDeriveCreate] = assemblyDeriveCreate
 	r.handlers[wire.MethodAssemblyShrinkwrapCreate] = assemblyShrinkwrapCreate
 	r.handlers[wire.MethodAssemblyDeriveBreakLink] = assemblyDeriveBreakLink
+	r.handlers[wire.MethodAssemblyDeriveStatus] = assemblyDeriveStatus
+	r.handlers[wire.MethodAssemblyDeriveUpdate] = assemblyDeriveUpdate
+}
+
+// assemblyDeriveStatus reports the drive state of a derive-family feature: whether it is
+// out of date relative to its source, and the source's saved vs current revision (#751).
+func assemblyDeriveStatus(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	_, derive, err := resolveDeriveStatusFeature(s, raw, wire.MethodAssemblyDeriveStatus)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(deriveStatusResult(s, derive))
+}
+
+// assemblyDeriveUpdate re-syncs a derive to its source's current revision, clearing its
+// out-of-date state, and recomputes the part (#751).
+func assemblyDeriveUpdate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, derive, err := resolveDeriveStatusFeature(s, raw, wire.MethodAssemblyDeriveUpdate)
+	if err != nil {
+		return nil, err
+	}
+	derive.AcknowledgeSource(currentSourceRevision(s, derive.SourceLink().Document))
+	part.Recompute()
+	return json.Marshal(deriveStatusResult(s, derive))
+}
+
+// resolveDeriveStatusFeature resolves the active part and the derive-family feature
+// addressed by the DeriveStatusArgs id, erroring when the feature is not a derive.
+func resolveDeriveStatusFeature(s *app.Session, raw json.RawMessage, method string) (*compdef.PartComponentDefinition, feature.DeriveStatus, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	var in wire.DeriveStatusArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, nil, err
+	}
+	pf, _, err := partFeatureByID(part, in.ID, method)
+	if err != nil {
+		return nil, nil, err
+	}
+	derive, ok := pf.Definition().(feature.DeriveStatus)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s: feature %d is a %s, not a derived/shrinkwrap component", method, in.ID, pf.Kind())
+	}
+	return part, derive, nil
+}
+
+// deriveStatusResult renders a derive's drive state, resolving the source's current
+// revision through the workspace (empty when the source is not open/resolvable).
+func deriveStatusResult(s *app.Session, derive feature.DeriveStatus) wire.DeriveStatusResult {
+	link := derive.SourceLink()
+	return wire.DeriveStatusResult{
+		OutOfDate:       derive.OutOfDate(),
+		Linked:          derive.Linked(),
+		SourceDocument:  link.Document,
+		SavedRevision:   link.DatabaseRevisionID,
+		CurrentRevision: currentSourceRevision(s, link.Document),
+	}
+}
+
+// currentSourceRevision returns the source document's current recipe revision, or "" when
+// the document is not open in the workspace (so the drive state cannot be compared).
+func currentSourceRevision(s *app.Session, sourceName string) string {
+	if sourceName == "" {
+		return ""
+	}
+	d, ok := s.Workspace().ByName(sourceName)
+	if !ok {
+		return ""
+	}
+	return d.FileIdentity().DatabaseRevisionID
 }
 
 // assemblyDeriveCreate derives the source assembly document into the active part as a

--- a/addin/router/assembly_derive_test.go
+++ b/addin/router/assembly_derive_test.go
@@ -141,3 +141,38 @@ func TestAssemblyBreakLinkRejectsUnknownFeature(t *testing.T) {
 		t.Fatal("deriveBreakLink on an unknown feature returned nil error, want a rejection")
 	}
 }
+
+// TestAssemblyDeriveStatusAndUpdateOverWire reads a fresh derive's drive state over the
+// wire (linked, not out of date, naming its source), exercises update (idempotent for a
+// current derive), and checks break-link flips the reported linked state (#751).
+func TestAssemblyDeriveStatusAndUpdateOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	src := addAssemblyDoc(t, s, "src.obk", 0)
+
+	var detail wire.FeatureDetailResult
+	call(t, r, s, "assembly.deriveCreate", fmt.Sprintf(`{"source":%d}`, src.ID()), &detail)
+	id := detail.Feature.ID
+
+	var status wire.DeriveStatusResult
+	call(t, r, s, "assembly.deriveStatus", fmt.Sprintf(`{"id":%d}`, id), &status)
+	if status.OutOfDate || !status.Linked || status.SourceDocument != "src.obk" {
+		t.Fatalf("status = %+v, want linked, current, source src.obk", status)
+	}
+
+	var updated wire.DeriveStatusResult
+	call(t, r, s, "assembly.deriveUpdate", fmt.Sprintf(`{"id":%d}`, id), &updated)
+	if updated.OutOfDate {
+		t.Error("updating a current derive should leave it not out of date")
+	}
+
+	var broken wire.FeatureDetailResult
+	call(t, r, s, "assembly.deriveBreakLink", fmt.Sprintf(`{"id":%d}`, id), &broken)
+	call(t, r, s, "assembly.deriveStatus", fmt.Sprintf(`{"id":%d}`, id), &status)
+	if status.Linked {
+		t.Error("after break-link, status should report Linked=false")
+	}
+
+	if _, err := r.Handle(s, "assembly.deriveStatus", []byte(`{"id":99999}`)); err == nil {
+		t.Error("deriveStatus of an unknown feature id should fail")
+	}
+}

--- a/model/feature/derived.go
+++ b/model/feature/derived.go
@@ -54,6 +54,12 @@ func (d *DerivedPartComponent) SourceLink() DeriveSourceLink { return d.link }
 // OutOfDate reports whether the source has been edited since this derive was saved.
 func (d *DerivedPartComponent) OutOfDate() bool { return d.outOfDate }
 
+// AcknowledgeSource re-stamps the link's source revision and clears out-of-date (#751).
+func (d *DerivedPartComponent) AcknowledgeSource(currentDBRevID string) {
+	d.link.DatabaseRevisionID = currentDBRevID
+	d.outOfDate = false
+}
+
 // Transform returns the geometry transform the derive applies to its source bodies.
 func (d *DerivedPartComponent) Transform() math.Matrix4 { return d.transform }
 

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -111,6 +111,26 @@ type AssemblyDeriveBinder interface {
 	BindSource(source AssemblyBodySource, currentDBRevID string)
 }
 
+// DeriveStatus is the drive-state surface common to every derive-family feature
+// (derived-assembly, derived-part, shrinkwrap): the persisted source link, whether the
+// source is out of date, whether the link is still live, and acknowledging the source to
+// re-sync. It is what the public deriveStatus/deriveUpdate surface drives (#751).
+type DeriveStatus interface {
+	SourceLink() DeriveSourceLink
+	OutOfDate() bool
+	Linked() bool
+	// AcknowledgeSource re-stamps the link's source revision to currentDBRevID and clears
+	// the out-of-date flag, recording the source's current state as the new baseline.
+	AcknowledgeSource(currentDBRevID string)
+}
+
+// Every derive-family feature reports and re-syncs its drive state.
+var (
+	_ DeriveStatus = (*DerivedAssemblyComponent)(nil)
+	_ DeriveStatus = (*DerivedPartComponent)(nil)
+	_ DeriveStatus = (*ShrinkwrapComponent)(nil)
+)
+
 // DerivedAssemblyComponent derives a source assembly into this part as a base body:
 // each recompute pulls the source's placed bodies, transforms each into the part, and
 // merges the included ones — cutting the subtracted, skipping the excluded — into one
@@ -155,6 +175,12 @@ func (d *DerivedAssemblyComponent) SourceLink() DeriveSourceLink { return d.link
 // source resolved on reopen carries a different recipe revision than [DeriveSourceLink]
 // captured. Always false for an in-session derive (the link matches the live source).
 func (d *DerivedAssemblyComponent) OutOfDate() bool { return d.outOfDate }
+
+// AcknowledgeSource re-stamps the link's source revision and clears out-of-date (#751).
+func (d *DerivedAssemblyComponent) AcknowledgeSource(currentDBRevID string) {
+	d.link.DatabaseRevisionID = currentDBRevID
+	d.outOfDate = false
+}
 
 // BindSource (re)binds the live source assembly after a restore and recomputes staleness:
 // the derive is out of date when currentDBRevID (the source's revision now) differs from

--- a/model/feature/serialize_derived_test.go
+++ b/model/feature/serialize_derived_test.go
@@ -77,6 +77,26 @@ func TestDerivedAssemblyStyleSurvivesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDeriveAcknowledgeSourceClearsOutOfDate checks AcknowledgeSource re-stamps the link's
+// source revision and clears the out-of-date flag — the model side of deriveUpdate (#751).
+func TestDeriveAcknowledgeSourceClearsOutOfDate(t *testing.T) {
+	src, _, _ := sourceWithTwoBlocks(t)
+	fs := NewPartFeatures(nil, nil)
+	pf := NewDerivedAssemblyComponents(fs).AddDerived(src, DeriveSourceLink{DatabaseRevisionID: "rev-1"})
+	d := pf.Definition().(*DerivedAssemblyComponent)
+	d.BindSource(src, "rev-2")
+	if !d.OutOfDate() {
+		t.Fatal("binding a newer-revision source should flag out of date")
+	}
+	d.AcknowledgeSource("rev-2")
+	if d.OutOfDate() {
+		t.Error("AcknowledgeSource should clear out-of-date")
+	}
+	if got := d.SourceLink().DatabaseRevisionID; got != "rev-2" {
+		t.Errorf("acknowledged link revision = %q, want rev-2", got)
+	}
+}
+
 // TestDerivedAssemblyOutOfDateByRevision checks BindSource flags out-of-date exactly when
 // the source's current revision differs from the one captured in the link.
 func TestDerivedAssemblyOutOfDateByRevision(t *testing.T) {

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -270,6 +270,12 @@ func (s *ShrinkwrapComponent) SourceLink() DeriveSourceLink { return s.link }
 // saved — the source resolved on reopen carries a different recipe revision than captured.
 func (s *ShrinkwrapComponent) OutOfDate() bool { return s.outOfDate }
 
+// AcknowledgeSource re-stamps the link's source revision and clears out-of-date (#751).
+func (s *ShrinkwrapComponent) AcknowledgeSource(currentDBRevID string) {
+	s.link.DatabaseRevisionID = currentDBRevID
+	s.outOfDate = false
+}
+
 // BindSource (re)binds the live source assembly after a restore and recomputes staleness:
 // out of date when currentDBRevID differs from the revision captured in the link (#715).
 func (s *ShrinkwrapComponent) BindSource(source AssemblyBodySource, currentDBRevID string) {


### PR DESCRIPTION
## What
Exposes the derive-family **drive state** over the public API (**#751**). Out-of-date detection landed model-only across #715/#748/#753/#755, so the head and add-ins couldn't see or act on it. Now a client can read whether a derived component is stale relative to its source and re-sync it (the reference API's drive-state badge + "Update").

- **feature**: a `DeriveStatus` interface (`SourceLink`/`OutOfDate`/`Linked`/`AcknowledgeSource`) satisfied by all three derive-family features (derived-assembly, derived-part, shrinkwrap, with a compile-time assertion). `AcknowledgeSource` re-stamps the link's source revision and clears out-of-date — the model side of update.
- **addin/router**: `assembly.deriveStatus` reports `outOfDate`/`linked`/`sourceDocument` and the source's **saved-vs-current** recipe revision (current resolved through the workspace, empty when the source isn't open); `assembly.deriveUpdate` re-syncs to the current revision, clears out-of-date, and recomputes the part. Both address a derive by its `model.tree` id; a non-derive id is rejected.

## Why
The `outOfDate` flag is only meaningful after a reopen (it's computed at source rebind). Exposing `savedRevision` vs `currentRevision` alongside it also lets a client detect live drift in-session, not just the persisted verdict.

## Tests
- **feature**: `AcknowledgeSource` clears out-of-date and re-stamps the link revision.
- **router** (over-wire): a fresh derive reports linked / not-out-of-date / source document; update is idempotent for a current derive; break-link flips the reported `Linked`; unknown-feature-id rejection.

Full `go test ./...`, `go test -race ./model/... ./addin/...`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally.

## Depends on
Contract: Oblikovati.API#87 (merged).

Closes #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)