### PR TITLE
feature: parametric, editable assembly hole (M11-F08)

### DIFF
--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -366,3 +366,24 @@ func TestAssemblyFeaturesRejectsBadInput(t *testing.T) {
 		t.Error("assemblyFeatures.list on a part document should fail")
 	}
 }
+
+// TestAssemblyHoleEditOverWire checks a placed assembly hole advertises editable
+// Diameter/Depth scalars and that assemblyFeatures.edit re-dimensions it, re-drilling the
+// participant — a wider bore removes more material (#752).
+func TestAssemblyHoleEditOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	var added wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.addHole", `{"center":[0.5,0.5,0],"axis":[0,0,1],"diameter":0.3,"depth":1.5}`, &added)
+	if len(added.Feature.Scalars) != 2 || added.Feature.Scalars[0].Label != "Diameter" || added.Feature.Scalars[1].Label != "Depth" {
+		t.Fatalf("hole scalars = %+v, want editable Diameter and Depth", added.Feature.Scalars)
+	}
+	narrow := featureResultVolume(asm, occs[0])
+
+	// Widen the bore (scalar 0 = Diameter) and confirm more material is removed.
+	var edited wire.AssemblyFeatureResult
+	call(t, r, s, "assemblyFeatures.edit", fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"0.6 cm"}]}`, added.Feature.ID), &edited)
+	if wide := featureResultVolume(asm, occs[0]); wide >= narrow {
+		t.Errorf("widening the bore should remove more material: narrow=%g wide=%g", narrow, wide)
+	}
+}

--- a/model/feature/assembly_cut.go
+++ b/model/feature/assembly_cut.go
@@ -7,7 +7,6 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/math"
 )
 
 // AssemblyCutFeature is an assembly-machining feature: a tool body authored in the
@@ -36,19 +35,6 @@ type AssemblyCutFeature struct {
 // stock and [ops.Intersect] keeps the common volume.
 func NewAssemblyCutFeature(tool *topo.Body, op ops.PartFeatureOperation) *AssemblyCutFeature {
 	return &AssemblyCutFeature{kind: "assemblyCut", tool: tool, op: op}
-}
-
-// NewAssemblyHoleFeature returns an assembly hole: a drilled cylinder of the given
-// diameter and depth from center along axisInto, cut from each participant — a
-// parametric assembly-context feature kind that needs no sketch (M11-F08 kind set,
-// #735). The tool is faceted (the exact analytic cylinder is a NURBS-phase refinement),
-// fixed in assembly space; it reuses the cut machinery and reports kind "assemblyHole".
-func NewAssemblyHoleFeature(center math.Point3, axisInto math.UnitVector3, diameter, depth float64) (*AssemblyCutFeature, error) {
-	if diameter <= 0 || depth <= 0 {
-		return nil, fmt.Errorf("assemblyHole: diameter %g and depth %g must be positive", diameter, depth)
-	}
-	cyl := drillTool(center, axisInto, diameter/2, depth, "asmHole")
-	return &AssemblyCutFeature{kind: "assemblyHole", tool: cyl, op: ops.Cut}, nil
 }
 
 // Kind implements [Feature].

--- a/model/feature/assembly_hole.go
+++ b/model/feature/assembly_hole.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// AssemblyHoleFeature is a parametric assembly-machining hole: a drilled cylinder of the
+// given diameter and depth from center along axis, cut from each participating occurrence —
+// a parametric assembly-context feature kind that needs no sketch (M11-F08 kind set, #735).
+// Unlike the box [AssemblyCutFeature], it RETAINS its inputs and rebuilds the drill tool on
+// every recompute, so its diameter and depth are editable after placement via
+// assemblyFeatures.edit (#752). The tool is faceted (the exact analytic cylinder is a
+// NURBS-phase refinement).
+//
+// Example: drill a 0.5-wide, 1.5-deep hole down +z through every participant —
+//
+//	h, _ := feature.NewAssemblyHoleFeature(math.P3(0.5, 0.5, 0), zAxis, 0.5, 1.5)
+type AssemblyHoleFeature struct {
+	center   math.Point3
+	axis     math.UnitVector3
+	diameter float64
+	depth    float64
+}
+
+// NewAssemblyHoleFeature returns a parametric assembly hole. diameter and depth must be
+// positive; they can be re-dimensioned later through [AssemblyHoleFeature.EditableParams].
+func NewAssemblyHoleFeature(center math.Point3, axisInto math.UnitVector3, diameter, depth float64) (*AssemblyHoleFeature, error) {
+	if diameter <= 0 || depth <= 0 {
+		return nil, fmt.Errorf("assemblyHole: diameter %g and depth %g must be positive", diameter, depth)
+	}
+	return &AssemblyHoleFeature{center: center, axis: axisInto, diameter: diameter, depth: depth}, nil
+}
+
+// Kind implements [Feature].
+func (f *AssemblyHoleFeature) Kind() string { return "assemblyHole" }
+
+// Operation reports the boolean the feature applies, satisfying [OperationalFeature].
+func (f *AssemblyHoleFeature) Operation() ops.PartFeatureOperation { return ops.Cut }
+
+// ToolBody returns the assembly-space drill tool, satisfying [ToolFeature].
+func (f *AssemblyHoleFeature) ToolBody() *topo.Body { return f.tool() }
+
+// tool rebuilds the faceted drill cylinder from the current diameter/depth, so an edit
+// re-dimensions the bore on the next recompute.
+func (f *AssemblyHoleFeature) tool() *topo.Body {
+	return drillTool(f.center, f.axis, f.diameter/2, f.depth, "asmHole")
+}
+
+// Recompute drills the hole out of every running body. A non-positive diameter or depth —
+// possible after an edit — is a lost input the engine turns into feature health, not a
+// panic.
+func (f *AssemblyHoleFeature) Recompute(in Input) (Output, error) {
+	if f.diameter <= 0 || f.depth <= 0 {
+		return Output{}, fmt.Errorf("assemblyHole: diameter %g and depth %g must be positive", f.diameter, f.depth)
+	}
+	out, err := applyToolToAll(ops.Cut, in.Bodies, f.tool())
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: out}, nil
+}
+
+// EditableParams exposes the hole's diameter and depth, so assemblyFeatures.edit can
+// re-dimension a placed assembly hole (#752).
+func (f *AssemblyHoleFeature) EditableParams() []EditableParam {
+	return []EditableParam{
+		floatParam("Diameter", param.Length, &f.diameter),
+		floatParam("Depth", param.Length, &f.depth),
+	}
+}

--- a/model/feature/assembly_hole_test.go
+++ b/model/feature/assembly_hole_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// holedVolume recomputes f against a unit box and returns the remaining volume.
+func holedVolume(t *testing.T, f *AssemblyHoleFeature) float64 {
+	t.Helper()
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{unitBlock(t)}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 1 {
+		t.Fatalf("result = %d bodies, want 1", len(out.Bodies))
+	}
+	return bodyVolume(out.Bodies[0])
+}
+
+// TestAssemblyHoleExposesEditableDiameterDepth checks the parametric hole advertises its
+// Diameter and Depth as editable length scalars, and that widening the bore (the edit
+// path) re-drills a larger hole that removes more material (#752).
+func TestAssemblyHoleExposesEditableDiameterDepth(t *testing.T) {
+	axis, _ := gmath.NewUnitVector3(0, 0, 1)
+	f, err := NewAssemblyHoleFeature(gmath.P3(0.5, 0.5, 0), axis, 0.3, 1.5)
+	if err != nil {
+		t.Fatalf("NewAssemblyHoleFeature: %v", err)
+	}
+	ps := f.EditableParams()
+	if len(ps) != 2 || ps[0].Label != "Diameter" || ps[1].Label != "Depth" {
+		t.Fatalf("EditableParams = %+v, want a Diameter and a Depth scalar", ps)
+	}
+	if ps[0].Unit != param.Length || ps[1].Unit != param.Length {
+		t.Error("hole scalars should both be lengths")
+	}
+
+	narrow := holedVolume(t, f)
+	ps[0].Set(0.6) // widen the bore via the editable param
+	if wide := holedVolume(t, f); wide >= narrow {
+		t.Errorf("widening the hole should remove more material: narrow=%g wide=%g", narrow, wide)
+	}
+}


### PR DESCRIPTION
## What
Makes the assembly hole **parametric and editable** (**#752**). It baked its drill tool at construction (`NewAssemblyHoleFeature` returned an `*AssemblyCutFeature` with a fixed tool), retaining none of its inputs — so `assemblyFeatures.edit` rejected it as "no editable scalars."

- **feature**: a dedicated `AssemblyHoleFeature` retains `center`/`axis`/`diameter`/`depth` and rebuilds the drill tool from the current values on every recompute (mirroring the parametric part hole), so an edit re-dimensions the bore. It implements `EditableParams` exposing **Diameter** and **Depth** (both lengths), satisfying the `feature.Editable` path. A non-positive diameter/depth after an edit becomes feature health, not a panic.
- The `addHole` router path is unchanged (`AddFeature` takes the `Feature` interface); a placed hole now advertises its scalars on `list`/`add` and edits over the wire.

## Tests
- **feature**: the hole exposes Diameter + Depth length scalars; widening the bore via the editable param re-drills and removes more material.
- **router** (over-wire): `addHole` advertises both scalars; `assemblyFeatures.edit` widens the bore and the participant loses more material — volume-gated. (Existing `TestAssemblyHoleRemovesCylinder` analytic gate still passes with the parametric type.)

Full `go test ./...`, `go test -race`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only — no `api/` change.

Closes #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)