### PR TITLE
doc,compdef: re-anchor relocated references on reopen (M11)

### DIFF
--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -100,8 +100,8 @@ func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) err
 		if err != nil {
 			return err
 		}
-		def := a.resolveComponent(owner, rec.Component)
-		occ := a.occurrences.AddByComponentName(rec.Name, def, rec.Component, transform)
+		def, component := a.resolveComponent(owner, rec.Component)
+		occ := a.occurrences.AddByComponentName(rec.Name, def, component, transform)
 		occ.SetSuppressed(rec.Suppressed)
 		occ.SetGrounded(rec.Grounded)
 		occ.SetAdaptive(rec.Adaptive)
@@ -111,20 +111,21 @@ func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) err
 }
 
 // resolveComponent opens the component document named component as a reference of owner,
-// returning its placeable definition; a target that cannot be opened (missing/replaced
-// file) yields a [missingDefinition] placeholder so the occurrence still restores. The
-// owner.OpenReference call records and resolves the edge, so the broken reference is
-// surfaced through the document's reference status, not lost.
-func (a *AssemblyComponentDefinition) resolveComponent(owner *doc.Document, component string) occurrence.Definition {
+// returning its placeable definition and the name it actually resolved to — the current
+// location, which differs from component when the project tree moved (#750), so the
+// occurrence re-binds to the live name and a re-save records it. A target that cannot be
+// opened yields a [missingDefinition] placeholder under the original name so the occurrence
+// still restores; the broken reference is surfaced through the document's reference status.
+func (a *AssemblyComponentDefinition) resolveComponent(owner *doc.Document, component string) (occurrence.Definition, string) {
 	child, ok := owner.OpenReference(component)
 	if !ok {
-		return missingDefinition{}
+		return missingDefinition{}, component
 	}
 	def, ok := child.Content().(occurrence.Definition)
 	if !ok {
-		return missingDefinition{}
+		return missingDefinition{}, component
 	}
-	return def
+	return def, child.FullDocumentName()
 }
 
 // matrixFromRecipe rebuilds an occurrence transform from its persisted cells, erroring on

--- a/model/compdef/part_resolve.go
+++ b/model/compdef/part_resolve.go
@@ -42,6 +42,7 @@ func bindDeriveFeature(owner *doc.Document, def feature.Feature) bool {
 		if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
 			if source, ok := child.Content().(feature.AssemblyBodySource); ok {
 				derive.BindSource(source, rev)
+				derive.RelinkSource(child.FullDocumentName())
 				return true
 			}
 		}
@@ -49,6 +50,7 @@ func bindDeriveFeature(owner *doc.Document, def feature.Feature) bool {
 		if child, rev, ok := openDeriveSource(owner, derive.SourceLink()); ok {
 			if source, ok := child.Content().(feature.BodySource); ok {
 				derive.BindSource(source, rev)
+				derive.RelinkSource(child.FullDocumentName())
 				return true
 			}
 		}

--- a/model/compdef/relocate_test.go
+++ b/model/compdef/relocate_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// moveFile relocates a saved .obk package from src to dst (creating dst's directory),
+// simulating a project tree moved as a whole on disk.
+func moveFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %q: %v", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", filepath.Dir(dst), err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %q: %v", dst, err)
+	}
+	if err := os.Remove(src); err != nil {
+		t.Fatalf("remove %q: %v", src, err)
+	}
+}
+
+// TestAssemblyReopensAfterTreeMove saves an assembly that references a component in a
+// subfolder, moves the whole tree (assembly + subfolder) to a new location, and reopens
+// the assembly there — its occurrence must re-resolve through the owner-relative reference
+// record, rebinding to the relocated component without manual repair (#750).
+func TestAssemblyReopensAfterTreeMove(t *testing.T) {
+	store := persistence.NewPackageStore()
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "parts"), 0o755); err != nil {
+		t.Fatalf("mkdir parts: %v", err)
+	}
+	ws := doc.NewWorkspace(store)
+	widget := savePartDoc(t, ws, filepath.Join(src, "parts"), "widget.obk")
+	asm, asmDef := newAssembly(t, ws, src, "asm.obk")
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+	if err := ws.Save(asm); err != nil {
+		t.Fatalf("Save assembly: %v", err)
+	}
+
+	// Move the assembly and its parts/ subfolder to a fresh location.
+	dst := t.TempDir()
+	moveFile(t, filepath.Join(src, "asm.obk"), filepath.Join(dst, "asm.obk"))
+	moveFile(t, filepath.Join(src, "parts", "widget.obk"), filepath.Join(dst, "parts", "widget.obk"))
+
+	def := openAssembly(t, store, filepath.Join(dst, "asm.obk"))
+	if def.Occurrences().Count() != 1 {
+		t.Fatalf("reopened assembly has %d occurrences, want 1", def.Occurrences().Count())
+	}
+	occ := def.Occurrences().Item(0)
+	if _, ok := occ.Definition().(*compdef.PartComponentDefinition); !ok {
+		t.Fatalf("occurrence definition = %T, want the relocated widget part (re-anchored, not a missing placeholder)", occ.Definition())
+	}
+	if want := filepath.Join(dst, "parts", "widget.obk"); occ.ComponentName() != want {
+		t.Errorf("occurrence component name = %q, want re-anchored %q", occ.ComponentName(), want)
+	}
+}

--- a/model/doc/resolve.go
+++ b/model/doc/resolve.go
@@ -2,6 +2,8 @@
 
 package doc
 
+import "path/filepath"
+
 // ReferenceResolver is the optional interface content implements when reopening it must
 // resolve references to other documents — an assembly binding its occurrences to the
 // component documents they instance (#715). The workspace calls ResolveReferences once,
@@ -29,5 +31,31 @@ func (d *Document) OpenReference(fullDocumentName string) (*Document, bool) {
 		return nil, false
 	}
 	desc := d.graph.addReferenceUnique(d, fullDocumentName)
+	if target, ok := d.graph.resolve(desc); ok {
+		return target, true
+	}
+	// The stored (absolute) name no longer resolves — the project tree may have moved.
+	// Re-anchor this reference's owner-relative spelling to the owner's CURRENT directory
+	// and retry, repointing the edge so a re-save records the new location (#750).
+	relocated, ok := d.relocatedReferenceTarget(fullDocumentName)
+	if !ok || relocated == fullDocumentName {
+		return nil, false
+	}
+	d.graph.repointReference(d, fullDocumentName, relocated)
 	return d.graph.resolve(desc)
+}
+
+// relocatedReferenceTarget re-anchors a moved reference: when the owner holds a persisted
+// file-reference record for name carrying an owner-directory-relative spelling, it re-joins
+// that spelling to the owner's CURRENT directory, so a project tree moved as a whole still
+// resolves on reopen (#750). It reports false when no relative record covers name (e.g. a
+// library or absolute reference), leaving absolute resolution as the last resort.
+func (d *Document) relocatedReferenceTarget(name string) (string, bool) {
+	for _, r := range d.fileReferences {
+		if r.fullFileName != name || r.relativeFileName == "" {
+			continue
+		}
+		return filepath.Join(filepath.Dir(d.fullDocumentName), filepath.FromSlash(r.relativeFileName)), true
+	}
+	return "", false
 }

--- a/model/feature/derived.go
+++ b/model/feature/derived.go
@@ -60,6 +60,9 @@ func (d *DerivedPartComponent) AcknowledgeSource(currentDBRevID string) {
 	d.outOfDate = false
 }
 
+// RelinkSource updates the link's source document name (#750).
+func (d *DerivedPartComponent) RelinkSource(document string) { d.link.Document = document }
+
 // Transform returns the geometry transform the derive applies to its source bodies.
 func (d *DerivedPartComponent) Transform() math.Matrix4 { return d.transform }
 

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -109,6 +109,9 @@ type AssemblyBodySource interface {
 type AssemblyDeriveBinder interface {
 	SourceLink() DeriveSourceLink
 	BindSource(source AssemblyBodySource, currentDBRevID string)
+	// RelinkSource updates the link's source document name to where it actually resolved,
+	// so a reference relocated with a moved project tree re-binds and re-saves clean (#750).
+	RelinkSource(document string)
 }
 
 // DeriveStatus is the drive-state surface common to every derive-family feature
@@ -181,6 +184,9 @@ func (d *DerivedAssemblyComponent) AcknowledgeSource(currentDBRevID string) {
 	d.link.DatabaseRevisionID = currentDBRevID
 	d.outOfDate = false
 }
+
+// RelinkSource updates the link's source document name (#750).
+func (d *DerivedAssemblyComponent) RelinkSource(document string) { d.link.Document = document }
 
 // BindSource (re)binds the live source assembly after a restore and recomputes staleness:
 // the derive is out of date when currentDBRevID (the source's revision now) differs from

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -276,6 +276,9 @@ func (s *ShrinkwrapComponent) AcknowledgeSource(currentDBRevID string) {
 	s.outOfDate = false
 }
 
+// RelinkSource updates the link's source document name (#750).
+func (s *ShrinkwrapComponent) RelinkSource(document string) { s.link.Document = document }
+
 // BindSource (re)binds the live source assembly after a restore and recomputes staleness:
 // out of date when currentDBRevID differs from the revision captured in the link (#715).
 func (s *ShrinkwrapComponent) BindSource(source AssemblyBodySource, currentDBRevID string) {


### PR DESCRIPTION
## What
Makes assembly/derive document references **portable across a project-tree move** (**#750**). Occurrences and derive source links persist their target by **absolute** document name and resolved it as-is, so moving or renaming a project directory broke every reference on reopen — even though the files moved together.

- **doc**: `Document.OpenReference`, when the stored absolute name no longer resolves, re-joins the reference's **owner-directory-relative** spelling (from the persisted `FileReference` record the document layer already records via `relateToOwner`) to the owner's **current** directory and retries, repointing the graph edge. Absolute resolution stays the last resort for library/out-of-tree references.
- **compdef**: the assembly and part resolvers re-bind to the document that actually resolved — occurrence `componentName` / derive `link.Document` updated via a new `RelinkSource` — so the recipe **self-heals**: a save after a move records the relocated, portable path rather than the stale one. (Avoids the degradation where a re-save would otherwise lose the relative spelling.)

## Why
The relative spelling + `FileResolution` repair machinery already existed; the persistence path just wasn't wired to use it for occurrence/derive rebind.

## Tests
`TestAssemblyReopensAfterTreeMove`: save an assembly referencing a component in a `parts/` subfolder, **move the whole tree** (assembly + subfolder) to a new directory, reopen there → the occurrence re-resolves to the relocated component (its definition is the real part, not a missing placeholder) and its `componentName` is re-anchored to the new path — no manual repair. The same `OpenReference` re-anchoring + `RelinkSource` covers the derive (derived-assembly/part/shrinkwrap) source links.

Full `go test ./...`, `go test -race ./model/...`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only — no `api/` change.

Closes #750.

🤖 Generated with [Claude Code](https://claude.com/claude-code)