### PR TITLE
topo: occurrence-relative reference resolution by lineage suffix (M11, #735 pt1)

### DIFF
--- a/kernel/topo/lineage_suffix.go
+++ b/kernel/topo/lineage_suffix.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import "bytes"
+
+// Occurrence-relative reference resolution (Oblikovati/Oblikovati#735). An assembly
+// machining feature runs on placed component bodies, each transformed under a per-occurrence
+// lineage prefix (the recompute prepends an "assemblyFeature:occ#i" token to every entity's
+// lineage). A bare component-local reference key therefore never matches a placed edge/face
+// by exact key. But because the prefix is only PREPENDED, the component's lineage survives as
+// a SUFFIX of the placed entity's lineage — so a feature can store the component-local key and
+// recover each participant's full key by matching that suffix, then hand the full key to the
+// existing dress-up ops (chamfer/fillet/move-face), which resolve by exact key.
+
+// LineageSuffixOf strips the leading entity-kind byte from a reference key, yielding the bare
+// lineage key — the portion that survives as a suffix when the entity's body is transformed
+// under a lineage-prefixing derive. Use it to turn a component-local reference key into a
+// suffix to match against a placed body.
+func LineageSuffixOf(referenceKey []byte) []byte {
+	if len(referenceKey) == 0 {
+		return referenceKey
+	}
+	return referenceKey[1:]
+}
+
+// EdgeReferenceKeysWithLineageSuffix returns the full reference keys of every edge whose
+// lineage key ends with suffix at a token boundary — recovering, on a placed/transformed
+// body, the edges that descend from a component-local edge regardless of any prepended
+// lineage prefix (#735). An empty suffix matches nothing.
+func (b *Body) EdgeReferenceKeysWithLineageSuffix(suffix []byte) [][]byte {
+	if len(suffix) == 0 {
+		return nil
+	}
+	var out [][]byte
+	for _, e := range b.Edges() {
+		if lineageKeyHasSuffix(e.Lineage().Key(), suffix) {
+			out = append(out, e.ReferenceKey())
+		}
+	}
+	return out
+}
+
+// FaceReferenceKeysWithLineageSuffix is the face twin of
+// [Body.EdgeReferenceKeysWithLineageSuffix].
+func (b *Body) FaceReferenceKeysWithLineageSuffix(suffix []byte) [][]byte {
+	if len(suffix) == 0 {
+		return nil
+	}
+	var out [][]byte
+	for _, f := range b.Faces() {
+		if lineageKeyHasSuffix(f.Lineage().Key(), suffix) {
+			out = append(out, f.ReferenceKey())
+		}
+	}
+	return out
+}
+
+// lineageKeyHasSuffix reports whether full equals suffix or ends with "/" + suffix, so the
+// match always falls on a lineage-token boundary ("edge#1" never matches "edge#10").
+func lineageKeyHasSuffix(full, suffix []byte) bool {
+	if bytes.Equal(full, suffix) {
+		return true
+	}
+	return len(full) > len(suffix) && full[len(full)-len(suffix)-1] == '/' && bytes.HasSuffix(full, suffix)
+}

--- a/kernel/topo/lineage_suffix_test.go
+++ b/kernel/topo/lineage_suffix_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	"bytes"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// linedTetra builds the unit tetrahedron with every entity's lineage produced by lin —
+// used to build both a bare "component" body and an assembly-"placed" body whose lineages
+// carry an extra occurrence prefix.
+func linedTetra(lin func(role string, i int) Lineage) *Body {
+	bld := NewBuilder(true, lin("body", 0))
+	a := bld.AddVertex(math.P3(0, 0, 0), lin("vertex", 0))
+	b := bld.AddVertex(math.P3(1, 0, 0), lin("vertex", 1))
+	c := bld.AddVertex(math.P3(0, 1, 0), lin("vertex", 2))
+	d := bld.AddVertex(math.P3(0, 0, 1), lin("vertex", 3))
+	seg := func(p, q *Vertex) geom.LineSegment { return geom.NewLineSegment(p.Point(), q.Point()) }
+	edge := func(p, q *Vertex, i int) *Edge { return bld.AddEdge(seg(p, q), p, q, lin("edge", i)) }
+	ab, ac, ad := edge(a, b, 0), edge(a, c, 1), edge(a, d, 2)
+	bc, bd, cd := edge(b, c, 3), edge(b, d, 4), edge(c, d, 5)
+	plane := func(o, n math.Vector3) geom.Surface {
+		p, _ := geom.NewPlane(o.AsPoint(), n)
+		return p
+	}
+	bld.AddFace(plane(math.V3(0, 0, 0), math.V3(0, 0, 1)), lin("face", 0), OuterLoop(Fwd(ab), Fwd(bc), Rev(ac)))
+	bld.AddFace(plane(math.V3(0, 0, 0), math.V3(0, 1, 0)), lin("face", 1), OuterLoop(Fwd(ab), Fwd(bd), Rev(ad)))
+	bld.AddFace(plane(math.V3(0, 0, 0), math.V3(1, 0, 0)), lin("face", 2), OuterLoop(Fwd(ac), Fwd(cd), Rev(ad)))
+	bld.AddFace(plane(math.V3(1, 1, 1), math.V3(1, 1, 1)), lin("face", 3), OuterLoop(Fwd(bc), Fwd(cd), Rev(bd)))
+	return bld.Build()
+}
+
+func componentLineage(role string, i int) Lineage { return NewLineage(Tok("src", role, i)) }
+
+func placedLineage(occ int) func(string, int) Lineage {
+	return func(role string, i int) Lineage {
+		return NewLineage(Tok("assemblyFeature", "occ", occ), Tok("src", role, i))
+	}
+}
+
+// TestEdgeReferenceKeysWithLineageSuffix resolves a component-local edge key against a
+// placed body (its lineage prefixed by an occurrence token), recovering the placed edge's
+// full key regardless of the occurrence index — the occurrence-relative resolution the
+// assembly dress-up features rely on (#735).
+func TestEdgeReferenceKeysWithLineageSuffix(t *testing.T) {
+	component := linedTetra(componentLineage)
+	// The client picks an edge on the component; LineageSuffixOf yields the match suffix.
+	componentEdgeKey := edgeKeyForRole(t, component, 3)
+	suffix := LineageSuffixOf(componentEdgeKey)
+
+	for _, occ := range []int{0, 7} {
+		placed := linedTetra(placedLineage(occ))
+		keys := placed.EdgeReferenceKeysWithLineageSuffix(suffix)
+		if len(keys) != 1 {
+			t.Fatalf("occ %d: resolved %d edges, want 1", occ, len(keys))
+		}
+		want := edgeKeyForRole(t, placed, 3) // the placed edge#3's full (prefixed) key
+		if !bytes.Equal(keys[0], want) {
+			t.Errorf("occ %d: resolved key %q, want the placed edge's full key %q", occ, keys[0], want)
+		}
+	}
+
+	// A suffix for an edge index that does not exist resolves nothing.
+	missing := LineageSuffixOf(referenceKey(KindEdge, componentLineage("edge", 99)))
+	if got := linedTetra(placedLineage(0)).EdgeReferenceKeysWithLineageSuffix(missing); len(got) != 0 {
+		t.Errorf("non-existent edge suffix resolved %d keys, want 0", len(got))
+	}
+}
+
+// TestFaceReferenceKeysWithLineageSuffix is the face twin: a component face key resolves to
+// the placed body's prefixed face.
+func TestFaceReferenceKeysWithLineageSuffix(t *testing.T) {
+	suffix := LineageSuffixOf(referenceKey(KindFace, componentLineage("face", 2)))
+	placed := linedTetra(placedLineage(3))
+	keys := placed.FaceReferenceKeysWithLineageSuffix(suffix)
+	if len(keys) != 1 {
+		t.Fatalf("resolved %d faces, want 1", len(keys))
+	}
+	if _, ok := placed.FindFaceByKey(keys[0]); !ok {
+		t.Error("resolved face key does not bind back to a placed face")
+	}
+}
+
+// TestLineageSuffixBoundary checks a partial-token suffix never matches across a token
+// boundary: "edge#0" (no role/feature) must not match the full lineage "src:edge#0".
+func TestLineageSuffixBoundary(t *testing.T) {
+	placed := linedTetra(placedLineage(0))
+	if got := placed.EdgeReferenceKeysWithLineageSuffix([]byte("edge#0")); len(got) != 0 {
+		t.Errorf("partial-token suffix matched %d edges, want 0 (boundary guard)", len(got))
+	}
+	if got := placed.EdgeReferenceKeysWithLineageSuffix(nil); got != nil {
+		t.Error("empty suffix should match nothing")
+	}
+}
+
+// edgeKeyForRole returns the reference key of the body's edge whose lineage ends with
+// edge#i (the i-th source edge), failing if absent.
+func edgeKeyForRole(t *testing.T, b *Body, i int) []byte {
+	t.Helper()
+	suffix := LineageSuffixOf(referenceKey(KindEdge, componentLineage("edge", i)))
+	for _, e := range b.Edges() {
+		if lineageKeyHasSuffix(e.Lineage().Key(), suffix) {
+			return e.ReferenceKey()
+		}
+	}
+	t.Fatalf("no edge with source index %d", i)
+	return nil
+}


### PR DESCRIPTION
## What
The **foundation** (Phase 1 of #735) for assembly edge/face machining features — chamfer, fillet, move-face. Those kinds pick a component edge/face, but the assembly recompute transforms each participant body under a **per-occurrence lineage prefix** (`asmFeatureLineage`), so a bare component reference key never matches a placed entity by exact key (the part dress-up ops resolve by exact `FindEdgeByKey`).

Because the prefix is only **prepended**, the component lineage survives as a **suffix** of the placed entity's lineage. So a feature can store the component-local key and recover each participant's full key by suffix-match, then hand the full key to the existing exact-match ops.

- `Body.EdgeReferenceKeysWithLineageSuffix` / `FaceReferenceKeysWithLineageSuffix` — full reference keys of entities whose lineage key ends with the suffix at a **token boundary** (so `edge#1` never matches `edge#10`).
- `LineageSuffixOf` — strips a reference key's entity-kind byte to the bare lineage key used as the match suffix.

## Why
This is the missing infrastructure the issue calls out ("assembly/proxy-resolved inputs that do not exist yet"). With it, the edge/face dress-up kinds become implementable per-participant.

## Tests
A component edge key resolves to a placed body's prefixed edge **regardless of occurrence index** (occ 0 and occ 7 both resolve, to their own full keys); the face twin binds back; a partial-token suffix is rejected by the boundary guard; an empty/non-existent suffix matches nothing.

Full `go test ./...` and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only (kernel/topo).

## Follow-up (this branch / next PRs)
- Phase 2: assembly chamfer + fillet (edge dress-up) on this resolver + wire/router.
- Phase 3: assembly move-face (face dress-up).
- (Assembly sweep is a separate blocker — needs an assembly path input, not edge/face resolution.)

Part of #735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)