### PR TITLE
feature,router: assembly chamfer & fillet on placed component edges (M11-F08)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -13,6 +13,7 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -34,6 +35,8 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesAddHole] = assemblyFeaturesAddHole
 	r.handlers[wire.MethodAssemblyFeaturesAddExtrude] = assemblyFeaturesAddExtrude
 	r.handlers[wire.MethodAssemblyFeaturesAddRevolve] = assemblyFeaturesAddRevolve
+	r.handlers[wire.MethodAssemblyFeaturesAddChamfer] = assemblyFeaturesAddChamfer
+	r.handlers[wire.MethodAssemblyFeaturesAddFillet] = assemblyFeaturesAddFillet
 	r.handlers[wire.MethodAssemblyFeaturesEdit] = assemblyFeaturesEdit
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
@@ -169,6 +172,98 @@ func revolveAxisFromArgs(in wire.AddAssemblyRevolveArgs) (*feature.WorkAxis, err
 		return nil, fmt.Errorf("%s: angle %g must be in (0, 2π]", wire.MethodAssemblyFeaturesAddRevolve, in.Angle)
 	}
 	return feature.NewDatumAxis(math.P3(in.Origin[0], in.Origin[1], in.Origin[2]), dir), nil
+}
+
+// assemblyFeaturesAddChamfer chamfers picked component edges on every participant.
+func assemblyFeaturesAddChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyChamferArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Distance <= 0 {
+		return nil, fmt.Errorf("%s: distance %g must be positive", wire.MethodAssemblyFeaturesAddChamfer, in.Distance)
+	}
+	suffixes, err := assemblyEdgeSuffixes(asm, in.Edges, wire.MethodAssemblyFeaturesAddChamfer)
+	if err != nil {
+		return nil, err
+	}
+	dist := in.Distance
+	af := asm.AddFeature(feature.NewAssemblyChamferFeature(suffixes, func() float64 { return dist }))
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+}
+
+// assemblyFeaturesAddFillet rounds picked component edges on every participant.
+func assemblyFeaturesAddFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyFilletArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Radius <= 0 {
+		return nil, fmt.Errorf("%s: radius %g must be positive", wire.MethodAssemblyFeaturesAddFillet, in.Radius)
+	}
+	suffixes, err := assemblyEdgeSuffixes(asm, in.Edges, wire.MethodAssemblyFeaturesAddFillet)
+	if err != nil {
+		return nil, err
+	}
+	r := in.Radius
+	af := asm.AddFeature(feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }))
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+}
+
+// assemblyEdgeSuffixes resolves each edge ref to a component-local lineage suffix, after
+// validating the edge exists on its occurrence's component body. The suffix is what each
+// participant's placed body is matched against at recompute (#735).
+func assemblyEdgeSuffixes(asm *compdef.AssemblyComponentDefinition, refs []wire.AssemblyEdgeRef, method string) ([][]byte, error) {
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("%s: no edges given", method)
+	}
+	out := make([][]byte, 0, len(refs))
+	for _, ref := range refs {
+		occ, err := occurrenceByID(asm, ref.Occurrence, method)
+		if err != nil {
+			return nil, err
+		}
+		key := []byte(ref.Edge)
+		if !edgeOnComponent(componentBodies(occ), key) {
+			return nil, fmt.Errorf("%s: edge key not found on occurrence %d's component", method, ref.Occurrence)
+		}
+		out = append(out, topo.LineageSuffixOf(key))
+	}
+	return out, nil
+}
+
+// componentBodies returns the evaluated surface bodies of an occurrence's component
+// definition, or nil when it is not a body-bearing part.
+func componentBodies(occ *occurrence.Occurrence) []*topo.Body {
+	def, ok := occ.Definition().(interface {
+		SurfaceBodies() *topo.SurfaceBodies
+	})
+	if !ok {
+		return nil
+	}
+	return def.SurfaceBodies().All()
+}
+
+// edgeOnComponent reports whether any of the component's bodies carries the edge key.
+func edgeOnComponent(bodies []*topo.Body, key []byte) bool {
+	for _, b := range bodies {
+		if _, ok := b.FindEdgeByKey(key); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // assemblyFeaturesAddHole drills a parametric hole through the participants.

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -12,6 +12,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/occurrence"
@@ -385,5 +386,71 @@ func TestAssemblyHoleEditOverWire(t *testing.T) {
 	call(t, r, s, "assemblyFeatures.edit", fmt.Sprintf(`{"id":%d,"scalars":[{"index":0,"value":"0.6 cm"}]}`, added.Feature.ID), &edited)
 	if wide := featureResultVolume(asm, occs[0]); wide >= narrow {
 		t.Errorf("widening the bore should remove more material: narrow=%g wide=%g", narrow, wide)
+	}
+}
+
+// verticalBoxEdgeKey returns the reference key of a vertical edge (z-running) of the
+// occurrence's box component — a component-local key the assembly dress-up resolves per
+// placement.
+func verticalBoxEdgeKey(t *testing.T, occ *occurrence.Occurrence) string {
+	t.Helper()
+	def, ok := occ.Definition().(interface{ SurfaceBodies() *topo.SurfaceBodies })
+	if !ok || len(def.SurfaceBodies().All()) == 0 {
+		t.Fatal("occurrence component has no body")
+	}
+	for _, e := range def.SurfaceBodies().All()[0].Edges() {
+		if a, b := e.StartVertex().Point(), e.EndVertex().Point(); a.X == b.X && a.Y == b.Y {
+			return string(e.ReferenceKey())
+		}
+	}
+	t.Fatal("no vertical edge on the box component")
+	return ""
+}
+
+// TestAssemblyChamferOverWire chamfers a component edge and confirms EVERY placed instance
+// of that component is machined from the one feature — the occurrence-relative resolution
+// (#735). Two unit boxes share the component lineage, so both lose the chamfer wedge.
+func TestAssemblyChamferOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0, 5)
+	edge := verticalBoxEdgeKey(t, occs[0])
+
+	var added wire.AssemblyFeatureResult
+	args := mustJSON(t, wire.AddAssemblyChamferArgs{Edges: []wire.AssemblyEdgeRef{{Occurrence: occs[0].ID(), Edge: edge}}, Distance: 0.2})
+	call(t, r, s, "assemblyFeatures.addChamfer", args, &added)
+	if added.Feature.Kind != "assemblyChamfer" {
+		t.Fatalf("feature kind = %q, want assemblyChamfer", added.Feature.Kind)
+	}
+	// A 45° flat chamfer of setback 0.2 on a unit-length edge removes a 0.2²/2 prism ⇒ 0.98.
+	for i, occ := range occs {
+		if got := featureResultVolume(asm, occ); stdmath.Abs(got-0.98) > 1e-6 {
+			t.Errorf("participant %d chamfered volume = %g, want 0.98 (box minus a 0.2 chamfer wedge)", i, got)
+		}
+	}
+	// The chamfer advertises an editable Distance scalar.
+	if len(added.Feature.Scalars) != 1 || added.Feature.Scalars[0].Label != "Distance" {
+		t.Errorf("chamfer scalars = %+v, want one Distance scalar", added.Feature.Scalars)
+	}
+}
+
+// TestAssemblyFilletOverWire rounds a component edge on every participant, gated below the
+// box volume (a fillet removes the convex corner material).
+func TestAssemblyFilletOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+	edge := verticalBoxEdgeKey(t, occs[0])
+
+	var added wire.AssemblyFeatureResult
+	args := mustJSON(t, wire.AddAssemblyFilletArgs{Edges: []wire.AssemblyEdgeRef{{Occurrence: occs[0].ID(), Edge: edge}}, Radius: 0.2})
+	call(t, r, s, "assemblyFeatures.addFillet", args, &added)
+	if added.Feature.Kind != "assemblyFillet" {
+		t.Fatalf("feature kind = %q, want assemblyFillet", added.Feature.Kind)
+	}
+	got := featureResultVolume(asm, occs[0])
+	if got >= 1.0 || got < 0.9 {
+		t.Errorf("filleted volume = %g, want a unit box minus a small rounded corner (≈0.99)", got)
+	}
+
+	// An unknown edge key is rejected.
+	if _, err := r.Handle(s, "assemblyFeatures.addChamfer", []byte(fmt.Sprintf(`{"edges":[{"occurrence":%d,"edge":"bogus"}],"distance":0.1}`, occs[0].ID()))); err == nil {
+		t.Error("addChamfer with an unknown edge key should fail")
 	}
 }

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -466,6 +466,8 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyFeaturesAddProxyCut:         true,
 	wire.MethodAssemblyFeaturesAddHole:             true,
 	wire.MethodAssemblyFeaturesAddExtrude:          true,
+	wire.MethodAssemblyFeaturesAddChamfer:          true,
+	wire.MethodAssemblyFeaturesAddFillet:           true,
 	wire.MethodAssemblyFeaturesEdit:                true,
 	wire.MethodAssemblyFeaturesSetParticipants:     true,
 	wire.MethodAssemblyFeaturesSetParticipantPaths: true,

--- a/model/feature/assembly_dressup.go
+++ b/model/feature/assembly_dressup.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/param"
+)
+
+// Assembly edge dress-up features (M11-F08, #735): chamfer and fillet picked component
+// edges on every participating placement. The edges are stored as component-local lineage
+// SUFFIXES; at recompute each participant's placed body (transformed under a per-occurrence
+// lineage prefix) is matched by suffix to recover that placement's full edge keys, which the
+// existing exact-match part dress-up ops then operate on. A participant whose component does
+// not carry a picked edge passes through unchanged.
+
+// AssemblyChamferFeature flat-chamfers the picked component edges by a distance on every
+// participant.
+type AssemblyChamferFeature struct {
+	edgeSuffixes [][]byte
+	distance     func() float64
+	flatCorners  bool
+}
+
+// NewAssemblyChamferFeature returns a chamfer over the component edge suffixes, applying
+// distance (a closure, so an edit reflows it).
+func NewAssemblyChamferFeature(edgeSuffixes [][]byte, distance func() float64) *AssemblyChamferFeature {
+	return &AssemblyChamferFeature{edgeSuffixes: edgeSuffixes, distance: distance}
+}
+
+// Kind implements [Feature].
+func (f *AssemblyChamferFeature) Kind() string { return "assemblyChamfer" }
+
+// Recompute chamfers the matched edges of every participant body.
+func (f *AssemblyChamferFeature) Recompute(in Input) (Output, error) {
+	dist := f.distance()
+	bodies, err := dressParticipants(in.Bodies, f.edgeSuffixes, func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
+		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, "asmChamfer", f.flatCorners)
+		if err != nil {
+			return nil, err
+		}
+		return soleBody(out.Bodies, "assemblyChamfer")
+	})
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// EditableParams exposes the chamfer's setback distance (#752-style edit).
+func (f *AssemblyChamferFeature) EditableParams() []EditableParam {
+	return []EditableParam{scalarParam("Distance", param.Length, &f.distance)}
+}
+
+// AssemblyFilletFeature rounds the picked component edges to a constant radius on every
+// participant.
+type AssemblyFilletFeature struct {
+	edgeSuffixes [][]byte
+	radius       func() float64
+}
+
+// NewAssemblyFilletFeature returns a fillet over the component edge suffixes, applying
+// radius (a closure, so an edit reflows it).
+func NewAssemblyFilletFeature(edgeSuffixes [][]byte, radius func() float64) *AssemblyFilletFeature {
+	return &AssemblyFilletFeature{edgeSuffixes: edgeSuffixes, radius: radius}
+}
+
+// Kind implements [Feature].
+func (f *AssemblyFilletFeature) Kind() string { return "assemblyFillet" }
+
+// Recompute rounds the matched edges of every participant body.
+func (f *AssemblyFilletFeature) Recompute(in Input) (Output, error) {
+	r := f.radius()
+	bodies, err := dressParticipants(in.Bodies, f.edgeSuffixes, func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
+		return ops.FilletEdges(body, keys, r)
+	})
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// EditableParams exposes the fillet radius.
+func (f *AssemblyFilletFeature) EditableParams() []EditableParam {
+	return []EditableParam{scalarParam("Radius", param.Length, &f.radius)}
+}
+
+// dressParticipants applies an edge dress-up to every participant body, resolving the
+// component edge suffixes to that body's full edge keys first; a body with no matching edge
+// passes through unchanged. Shared by the assembly chamfer and fillet (#735).
+func dressParticipants(bodies []*topo.Body, suffixes [][]byte, dress func(body *topo.Body, keys [][]byte) (*topo.Body, error)) ([]*topo.Body, error) {
+	out := make([]*topo.Body, 0, len(bodies))
+	for _, body := range bodies {
+		keys := edgeKeysForSuffixes(body, suffixes)
+		if len(keys) == 0 {
+			out = append(out, body)
+			continue
+		}
+		dressed, err := dress(body, keys)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, dressed)
+	}
+	return out, nil
+}
+
+// edgeKeysForSuffixes resolves each component edge suffix to the participant body's full
+// reference keys (the occurrence-relative resolver from #735).
+func edgeKeysForSuffixes(body *topo.Body, suffixes [][]byte) [][]byte {
+	var keys [][]byte
+	for _, s := range suffixes {
+		keys = append(keys, body.EdgeReferenceKeysWithLineageSuffix(s)...)
+	}
+	return keys
+}
+
+// soleBody returns the single body of a dress-up result, erroring if the op did not yield
+// exactly one (a participant body chamfers to one body).
+func soleBody(bodies []*topo.Body, feat string) (*topo.Body, error) {
+	if len(bodies) != 1 {
+		return nil, fmt.Errorf("%s: dress-up produced %d bodies, want 1", feat, len(bodies))
+	}
+	return bodies[0], nil
+}


### PR DESCRIPTION
## What
The first **edge dress-up** assembly feature kinds (Phase 2 of #735), built on the occurrence-relative lineage-suffix resolver (#759).

- **feature**: `AssemblyChamferFeature` / `AssemblyFilletFeature` store the picked edges as **component-local lineage suffixes** + a closure-backed scalar (so they're editable via `assemblyFeatures.edit`). `Recompute` resolves each suffix to every participant's full edge keys (`Body.EdgeReferenceKeysWithLineageSuffix`) and applies the existing part dress-up ops (`chamferEdges` / `ops.FilletEdges`); a participant whose component lacks the edge passes through. The per-participant loop is shared by both kinds.
- **router**: `assemblyFeatures.addChamfer` / `addFillet` resolve each `AssemblyEdgeRef` to its occurrence's component, validate the edge exists, store its lineage suffix, and add the feature.

## Why
Chamfer/fillet pick edges by reference key, but the assembly recompute prefixes each participant body's lineage per occurrence — so a bare key never matches by exact key. The suffix resolver (#759) recovers each placement's full key from the component-local suffix.

## Tests
Over the wire: chamfering one component edge machines **every placed instance** of that component (two boxes both lose the chamfer wedge → 0.98, the analytic value); fillet rounds the corner; the chamfer advertises an editable Distance scalar; an unknown edge key is rejected.

Full `go test ./...` and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally.

## Depends on
- Foundation: #759 (merged) — lineage-suffix resolution.
- Contract: Oblikovati.API#88 (merged).

Part of #735. Follow-up: Phase 3 move-face (face dress-up); assembly sweep is a separate blocker (needs an assembly path input, not edge/face resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)