### PR TITLE
feature,router: assembly move-face on placed component faces (M11-F08)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -37,6 +37,7 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesAddRevolve] = assemblyFeaturesAddRevolve
 	r.handlers[wire.MethodAssemblyFeaturesAddChamfer] = assemblyFeaturesAddChamfer
 	r.handlers[wire.MethodAssemblyFeaturesAddFillet] = assemblyFeaturesAddFillet
+	r.handlers[wire.MethodAssemblyFeaturesAddMoveFace] = assemblyFeaturesAddMoveFace
 	r.handlers[wire.MethodAssemblyFeaturesEdit] = assemblyFeaturesEdit
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
@@ -222,6 +223,27 @@ func assemblyFeaturesAddFillet(s *app.Session, raw json.RawMessage) (json.RawMes
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
+// assemblyFeaturesAddMoveFace translates picked component faces on every participant.
+func assemblyFeaturesAddMoveFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblyMoveFaceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	suffixes, err := assemblyFaceSuffixes(asm, in.Faces, wire.MethodAssemblyFeaturesAddMoveFace)
+	if err != nil {
+		return nil, err
+	}
+	delta := math.V3(in.Translation[0], in.Translation[1], in.Translation[2])
+	af := asm.AddFeature(feature.NewAssemblyMoveFaceFeature(suffixes, delta))
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+}
+
 // assemblyEdgeSuffixes resolves each edge ref to a component-local lineage suffix, after
 // validating the edge exists on its occurrence's component body. The suffix is what each
 // participant's placed body is matched against at recompute (#735).
@@ -231,17 +253,42 @@ func assemblyEdgeSuffixes(asm *compdef.AssemblyComponentDefinition, refs []wire.
 	}
 	out := make([][]byte, 0, len(refs))
 	for _, ref := range refs {
-		occ, err := occurrenceByID(asm, ref.Occurrence, method)
+		suffix, err := assemblyRefSuffix(asm, ref.Occurrence, []byte(ref.Edge), method, edgeOnComponent)
 		if err != nil {
 			return nil, err
 		}
-		key := []byte(ref.Edge)
-		if !edgeOnComponent(componentBodies(occ), key) {
-			return nil, fmt.Errorf("%s: edge key not found on occurrence %d's component", method, ref.Occurrence)
-		}
-		out = append(out, topo.LineageSuffixOf(key))
+		out = append(out, suffix)
 	}
 	return out, nil
+}
+
+// assemblyFaceSuffixes is the face twin of [assemblyEdgeSuffixes].
+func assemblyFaceSuffixes(asm *compdef.AssemblyComponentDefinition, refs []wire.AssemblyFaceRef, method string) ([][]byte, error) {
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("%s: no faces given", method)
+	}
+	out := make([][]byte, 0, len(refs))
+	for _, ref := range refs {
+		suffix, err := assemblyRefSuffix(asm, ref.Occurrence, []byte(ref.Face), method, faceOnComponent)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, suffix)
+	}
+	return out, nil
+}
+
+// assemblyRefSuffix validates that key names an entity on the occurrence's component body
+// (via present) and returns its component-local lineage suffix.
+func assemblyRefSuffix(asm *compdef.AssemblyComponentDefinition, occID uint64, key []byte, method string, present func([]*topo.Body, []byte) bool) ([]byte, error) {
+	occ, err := occurrenceByID(asm, occID, method)
+	if err != nil {
+		return nil, err
+	}
+	if !present(componentBodies(occ), key) {
+		return nil, fmt.Errorf("%s: reference key not found on occurrence %d's component", method, occID)
+	}
+	return topo.LineageSuffixOf(key), nil
 }
 
 // componentBodies returns the evaluated surface bodies of an occurrence's component
@@ -256,10 +303,19 @@ func componentBodies(occ *occurrence.Occurrence) []*topo.Body {
 	return def.SurfaceBodies().All()
 }
 
-// edgeOnComponent reports whether any of the component's bodies carries the edge key.
+// edgeOnComponent / faceOnComponent report whether any component body carries the key.
 func edgeOnComponent(bodies []*topo.Body, key []byte) bool {
 	for _, b := range bodies {
 		if _, ok := b.FindEdgeByKey(key); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func faceOnComponent(bodies []*topo.Body, key []byte) bool {
+	for _, b := range bodies {
+		if _, ok := b.FindFaceByKey(key); ok {
 			return true
 		}
 	}

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -454,3 +454,40 @@ func TestAssemblyFilletOverWire(t *testing.T) {
 		t.Error("addChamfer with an unknown edge key should fail")
 	}
 }
+
+// topBoxFaceKey returns the reference key of the box component's top face (highest z),
+// whose +z normal makes a +z move-face grow the box.
+func topBoxFaceKey(t *testing.T, occ *occurrence.Occurrence) string {
+	t.Helper()
+	def := occ.Definition().(interface{ SurfaceBodies() *topo.SurfaceBodies })
+	var top *topo.Face
+	for _, f := range def.SurfaceBodies().All()[0].Faces() {
+		if top == nil || f.RangeBox().Center().Z > top.RangeBox().Center().Z {
+			top = f
+		}
+	}
+	return string(top.ReferenceKey())
+}
+
+// TestAssemblyMoveFaceOverWire translates a component's top face on every participant and
+// gates the grown volume (#735): pushing the unit box's top face +0.5z makes a 1.5 box, on
+// both placed instances from one feature.
+func TestAssemblyMoveFaceOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0, 5)
+	face := topBoxFaceKey(t, occs[0])
+
+	var added wire.AssemblyFeatureResult
+	args := mustJSON(t, wire.AddAssemblyMoveFaceArgs{Faces: []wire.AssemblyFaceRef{{Occurrence: occs[0].ID(), Face: face}}, Translation: [3]float64{0, 0, 0.5}})
+	call(t, r, s, "assemblyFeatures.addMoveFace", args, &added)
+	if added.Feature.Kind != "assemblyMoveFace" {
+		t.Fatalf("feature kind = %q, want assemblyMoveFace", added.Feature.Kind)
+	}
+	for i, occ := range occs {
+		if got := featureResultVolume(asm, occ); stdmath.Abs(got-1.5) > 1e-6 {
+			t.Errorf("participant %d moved-face volume = %g, want 1.5 (top face pushed +0.5z)", i, got)
+		}
+	}
+	if len(added.Feature.Scalars) != 1 || added.Feature.Scalars[0].Label != "Distance" {
+		t.Errorf("move-face scalars = %+v, want one editable Distance scalar", added.Feature.Scalars)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -468,6 +468,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyFeaturesAddExtrude:          true,
 	wire.MethodAssemblyFeaturesAddChamfer:          true,
 	wire.MethodAssemblyFeaturesAddFillet:           true,
+	wire.MethodAssemblyFeaturesAddMoveFace:         true,
 	wire.MethodAssemblyFeaturesEdit:                true,
 	wire.MethodAssemblyFeaturesSetParticipants:     true,
 	wire.MethodAssemblyFeaturesSetParticipantPaths: true,

--- a/model/feature/assembly_dressup.go
+++ b/model/feature/assembly_dressup.go
@@ -37,7 +37,7 @@ func (f *AssemblyChamferFeature) Kind() string { return "assemblyChamfer" }
 // Recompute chamfers the matched edges of every participant body.
 func (f *AssemblyChamferFeature) Recompute(in Input) (Output, error) {
 	dist := f.distance()
-	bodies, err := dressParticipants(in.Bodies, f.edgeSuffixes, func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
+	bodies, err := dressParticipants(in.Bodies, edgeSuffixKeys(f.edgeSuffixes), func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
 		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, "asmChamfer", f.flatCorners)
 		if err != nil {
 			return nil, err
@@ -74,7 +74,7 @@ func (f *AssemblyFilletFeature) Kind() string { return "assemblyFillet" }
 // Recompute rounds the matched edges of every participant body.
 func (f *AssemblyFilletFeature) Recompute(in Input) (Output, error) {
 	r := f.radius()
-	bodies, err := dressParticipants(in.Bodies, f.edgeSuffixes, func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
+	bodies, err := dressParticipants(in.Bodies, edgeSuffixKeys(f.edgeSuffixes), func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
 		return ops.FilletEdges(body, keys, r)
 	})
 	if err != nil {
@@ -88,13 +88,14 @@ func (f *AssemblyFilletFeature) EditableParams() []EditableParam {
 	return []EditableParam{scalarParam("Radius", param.Length, &f.radius)}
 }
 
-// dressParticipants applies an edge dress-up to every participant body, resolving the
-// component edge suffixes to that body's full edge keys first; a body with no matching edge
-// passes through unchanged. Shared by the assembly chamfer and fillet (#735).
-func dressParticipants(bodies []*topo.Body, suffixes [][]byte, dress func(body *topo.Body, keys [][]byte) (*topo.Body, error)) ([]*topo.Body, error) {
+// dressParticipants applies a face-edit/dress-up to every participant body, resolving the
+// component reference suffixes to that body's full keys via keysFor first; a body with no
+// matching entity passes through unchanged. Shared by the assembly chamfer, fillet, and
+// move-face (#735).
+func dressParticipants(bodies []*topo.Body, keysFor func(*topo.Body) [][]byte, dress func(body *topo.Body, keys [][]byte) (*topo.Body, error)) ([]*topo.Body, error) {
 	out := make([]*topo.Body, 0, len(bodies))
 	for _, body := range bodies {
-		keys := edgeKeysForSuffixes(body, suffixes)
+		keys := keysFor(body)
 		if len(keys) == 0 {
 			out = append(out, body)
 			continue
@@ -108,14 +109,27 @@ func dressParticipants(bodies []*topo.Body, suffixes [][]byte, dress func(body *
 	return out, nil
 }
 
-// edgeKeysForSuffixes resolves each component edge suffix to the participant body's full
-// reference keys (the occurrence-relative resolver from #735).
-func edgeKeysForSuffixes(body *topo.Body, suffixes [][]byte) [][]byte {
-	var keys [][]byte
-	for _, s := range suffixes {
-		keys = append(keys, body.EdgeReferenceKeysWithLineageSuffix(s)...)
+// edgeSuffixKeys / faceSuffixKeys return a resolver that maps each component suffix to a
+// participant body's full edge / face reference keys (the occurrence-relative resolver
+// from #735).
+func edgeSuffixKeys(suffixes [][]byte) func(*topo.Body) [][]byte {
+	return func(body *topo.Body) [][]byte {
+		var keys [][]byte
+		for _, s := range suffixes {
+			keys = append(keys, body.EdgeReferenceKeysWithLineageSuffix(s)...)
+		}
+		return keys
 	}
-	return keys
+}
+
+func faceSuffixKeys(suffixes [][]byte) func(*topo.Body) [][]byte {
+	return func(body *topo.Body) [][]byte {
+		var keys [][]byte
+		for _, s := range suffixes {
+			keys = append(keys, body.FaceReferenceKeysWithLineageSuffix(s)...)
+		}
+		return keys
+	}
 }
 
 // soleBody returns the single body of a dress-up result, erroring if the op did not yield

--- a/model/feature/assembly_move_face.go
+++ b/model/feature/assembly_move_face.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// AssemblyMoveFaceFeature translates picked component faces by a vector (in assembly space)
+// on every participating placement — the assembly-context Move Face (M11-F08, #735). The
+// faces are stored as component-local lineage suffixes and resolved per participant through
+// the occurrence-relative resolver, then moved by the existing [ops.MoveFaces]. A participant
+// whose component does not carry a picked face passes through unchanged.
+type AssemblyMoveFaceFeature struct {
+	faceSuffixes [][]byte
+	translation  math.Vector3
+}
+
+// NewAssemblyMoveFaceFeature returns a move-face over the component face suffixes,
+// translating them by delta.
+func NewAssemblyMoveFaceFeature(faceSuffixes [][]byte, delta math.Vector3) *AssemblyMoveFaceFeature {
+	return &AssemblyMoveFaceFeature{faceSuffixes: faceSuffixes, translation: delta}
+}
+
+// Kind implements [Feature].
+func (f *AssemblyMoveFaceFeature) Kind() string { return "assemblyMoveFace" }
+
+// Recompute moves the matched faces of every participant body by the translation.
+func (f *AssemblyMoveFaceFeature) Recompute(in Input) (Output, error) {
+	bodies, err := dressParticipants(in.Bodies, faceSuffixKeys(f.faceSuffixes), func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
+		return ops.MoveFaces(body, keys, f.translation)
+	})
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// EditableParams exposes the move's displacement magnitude (the part move-face's edit
+// scalar), so assemblyFeatures.edit can re-dimension it.
+func (f *AssemblyMoveFaceFeature) EditableParams() []EditableParam {
+	return []EditableParam{spacingParam("Distance", &f.translation, math.V3(0, 0, 1))}
+}


### PR DESCRIPTION
## What
The assembly **move-face** kind (Phase 3 of #735), completing the edge/face dress-up set (chamfer/fillet/move-face) on the occurrence-relative lineage-suffix resolver (#759).

- **feature**: `AssemblyMoveFaceFeature` stores picked faces as component-local lineage suffixes + a translation; `Recompute` resolves each suffix to every participant's full face keys (`Body.FaceReferenceKeysWithLineageSuffix`) and moves them with the existing `ops.MoveFaces`; a participant whose component lacks the face passes through. The displacement magnitude is editable (`spacingParam`), like the part move-face.
- The per-participant dress-up loop now takes a **key-resolver**, shared by chamfer/fillet (edges) and move-face (faces) — no duplication. Edge/face suffix resolution is factored into one `assemblyRefSuffix` path.
- **router**: `assemblyFeatures.addMoveFace` resolves each `AssemblyFaceRef` to its occurrence's component, validates the face, stores its suffix.

## Tests
Over the wire: pushing a box component's top face **+0.5z** grows **every** placed instance to volume **1.5** (the analytic value) from one feature; the move advertises an editable Distance scalar.

Full `go test ./...`, `go test -race`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally.

## Depends on
- Foundation: #759 (merged). Contract: Oblikovati.API#89 (merged).

## #735 status
Phase 1 (foundation) + Phase 2 (chamfer/fillet) + Phase 3 (move-face) now complete. The only remaining kind is **sweep** — a separate blocker that needs an assembly *path* input (3D sketch / explicit polyline), not edge/face resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)