### PR TITLE
feature,router: assembly sweep along an explicit path (M11-F08, closes #735)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -38,6 +38,7 @@ func (r *Router) registerAssemblyFeatureHandlers() {
 	r.handlers[wire.MethodAssemblyFeaturesAddChamfer] = assemblyFeaturesAddChamfer
 	r.handlers[wire.MethodAssemblyFeaturesAddFillet] = assemblyFeaturesAddFillet
 	r.handlers[wire.MethodAssemblyFeaturesAddMoveFace] = assemblyFeaturesAddMoveFace
+	r.handlers[wire.MethodAssemblyFeaturesAddSweep] = assemblyFeaturesAddSweep
 	r.handlers[wire.MethodAssemblyFeaturesEdit] = assemblyFeaturesEdit
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipants] = assemblyFeaturesSetParticipants
 	r.handlers[wire.MethodAssemblyFeaturesSetParticipantPaths] = assemblyFeaturesSetParticipantPaths
@@ -173,6 +174,48 @@ func revolveAxisFromArgs(in wire.AddAssemblyRevolveArgs) (*feature.WorkAxis, err
 		return nil, fmt.Errorf("%s: angle %g must be in (0, 2π]", wire.MethodAssemblyFeaturesAddRevolve, in.Angle)
 	}
 	return feature.NewDatumAxis(math.P3(in.Origin[0], in.Origin[1], in.Origin[2]), dir), nil
+}
+
+// assemblyFeaturesAddSweep sweeps an assembly sketch profile along an explicit polyline path
+// into the participants — a swept channel or rib.
+func assemblyFeaturesAddSweep(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddAssemblySweepArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	op, err := cutOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	sk, err := sketchAtIndex(asm, in.SketchIndex)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyFeaturesAddSweep, err)
+	}
+	path, err := assemblySweepPath(in.Path, wire.MethodAssemblyFeaturesAddSweep)
+	if err != nil {
+		return nil, err
+	}
+	af := asm.AddFeature(feature.NewAssemblySweepFeature(sk, in.ProfileIndex, op, path))
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+}
+
+// assemblySweepPath converts a wire path polyline to assembly-space points, requiring at
+// least two.
+func assemblySweepPath(points [][3]float64, method string) ([]math.Point3, error) {
+	if len(points) < 2 {
+		return nil, fmt.Errorf("%s: path needs at least two points, got %d", method, len(points))
+	}
+	path := make([]math.Point3, len(points))
+	for i, p := range points {
+		path[i] = math.P3(p[0], p[1], p[2])
+	}
+	return path, nil
 }
 
 // assemblyFeaturesAddChamfer chamfers picked component edges on every participant.

--- a/addin/router/assembly_features_test.go
+++ b/addin/router/assembly_features_test.go
@@ -491,3 +491,33 @@ func TestAssemblyMoveFaceOverWire(t *testing.T) {
 		t.Errorf("move-face scalars = %+v, want one editable Distance scalar", added.Feature.Scalars)
 	}
 }
+
+// TestAssemblySweepOverWire sweeps an assembly sketch profile along an explicit polyline
+// path into the participant (#735). A difference-sweep removes a channel (volume drops
+// below the box and stays a valid solid); the assembly-sketch profile + path wiring is what
+// this gates (the swept-solid geometry itself is covered by the part sweep tests).
+func TestAssemblySweepOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &sk)
+	var rect wire.SketchRectangleResult
+	call(t, r, s, "sketch.rectangle", fmt.Sprintf(`{"sketchIndex":%d,"width":"0.5 cm","height":"1 cm"}`, sk.SketchIndex), &rect)
+
+	var added wire.AssemblyFeatureResult
+	args := fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"path":[[0.25,0.5,0],[0.25,0.5,0.6]],"operation":"difference"}`, sk.SketchIndex)
+	call(t, r, s, "assemblyFeatures.addSweep", args, &added)
+	if added.Feature.Kind != "assemblySweep" {
+		t.Fatalf("feature kind = %q, want assemblySweep", added.Feature.Kind)
+	}
+	// The path starts at the profile centroid (0.25,0.5,0) and runs +0.6z, so the swept
+	// channel is the 0.5×1 profile dragged straight down — the same 0.3 cut an extrude makes.
+	if got := featureResultVolume(asm, occs[0]); stdmath.Abs(got-0.7) > 1e-6 {
+		t.Errorf("swept-cut volume = %g, want 0.7 (unit box minus a 0.5×1×0.6 channel)", got)
+	}
+
+	// A single-point path is rejected.
+	if _, err := r.Handle(s, "assemblyFeatures.addSweep", []byte(fmt.Sprintf(`{"sketchIndex":%d,"profileIndex":0,"path":[[0,0,0]],"operation":"difference"}`, sk.SketchIndex))); err == nil {
+		t.Error("addSweep with a single-point path should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -466,6 +466,7 @@ var mutatingMethods = map[string]bool{
 	wire.MethodAssemblyFeaturesAddProxyCut:         true,
 	wire.MethodAssemblyFeaturesAddHole:             true,
 	wire.MethodAssemblyFeaturesAddExtrude:          true,
+	wire.MethodAssemblyFeaturesAddSweep:            true,
 	wire.MethodAssemblyFeaturesAddChamfer:          true,
 	wire.MethodAssemblyFeaturesAddFillet:           true,
 	wire.MethodAssemblyFeaturesAddMoveFace:         true,

--- a/model/feature/assembly_sweep.go
+++ b/model/feature/assembly_sweep.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// AssemblySweepFeature is the assembly-machining sweep (M11-F08 kind set, #735): a sketch
+// profile authored on an assembly work plane, swept along an explicit polyline path in the
+// assembly's space, and booleaned against each participant body. It reuses the part sweep
+// geometry (sweepSectionsCfg/sweptSolid) so a profiled channel (Cut) or rib (Join) machines
+// every participant in place. The path is supplied directly — the assembly analogue of the
+// revolve's explicit axis — since assembly-context 3D sketch paths are a later subsystem.
+//
+// Example: cut a channel of profile sk along a vertical path through every participant —
+//
+//	f := feature.NewAssemblySweepFeature(sk, 0, ops.Cut, []math.Point3{p0, p1})
+type AssemblySweepFeature struct {
+	sketch       *sketch.Sketch
+	profileIndex int
+	op           ops.PartFeatureOperation
+	path         []math.Point3
+}
+
+// NewAssemblySweepFeature returns a sweep of the sketch's profileIndex-th closed region
+// along path, applying op. op is typically [ops.Cut] (a swept channel) or [ops.Join] (a
+// swept rib). path must have at least two points.
+func NewAssemblySweepFeature(skt *sketch.Sketch, profileIndex int, op ops.PartFeatureOperation, path []math.Point3) *AssemblySweepFeature {
+	return &AssemblySweepFeature{sketch: skt, profileIndex: profileIndex, op: op, path: path}
+}
+
+// Kind implements [Feature].
+func (f *AssemblySweepFeature) Kind() string { return "assemblySweep" }
+
+// Operation reports the boolean the feature applies, satisfying [OperationalFeature].
+func (f *AssemblySweepFeature) Operation() ops.PartFeatureOperation { return f.op }
+
+// Recompute sweeps the profile along the path into an assembly-space tool and booleans it
+// against every running body. A missing/open profile or a degenerate path is a lost input
+// the engine turns into feature health, not a panic.
+func (f *AssemblySweepFeature) Recompute(in Input) (Output, error) {
+	tool, err := f.buildTool()
+	if err != nil {
+		return Output{}, err
+	}
+	out, err := applyToolToAll(f.op, in.Bodies, tool)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: out}, nil
+}
+
+// buildTool sweeps the resolved profile along the path into the assembly-space tool, using
+// the default normal-to-path orientation with no twist.
+func (f *AssemblySweepFeature) buildTool() (*topo.Body, error) {
+	if len(f.path) < 2 {
+		return nil, fmt.Errorf("assemblySweep: path needs at least two points, got %d", len(f.path))
+	}
+	prof, err := resolveSingleProfile(f.sketch, f.profileIndex, "assemblySweep")
+	if err != nil {
+		return nil, err
+	}
+	cfg := sweepConfig{orientation: types.NormalToPath, twistAt: func(float64) float64 { return 0 }}
+	sections, err := sweepSectionsCfg(prof, f.sketch.Plane(), f.path, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("assemblySweep: %w", err)
+	}
+	return sweptSolid(sections, false, "asmSweep")
+}


### PR DESCRIPTION
## What
The assembly **sweep** kind — the **last** of the M11-F08 feature set (**#735**). It sweeps a profile from the assembly sketch along an **explicit polyline path** in assembly space (the assembly analogue of the revolve's explicit axis, since assembly-context 3D sketch paths are a later subsystem) and booleans the swept tool against each participant.

- **feature**: `AssemblySweepFeature` reuses the part sweep geometry (`sweepSectionsCfg` + `sweptSolid`, normal-to-path orientation, no twist) to build the tool once in assembly space, then `applyToolToAll` over the participants — structurally the extrude/revolve sibling.
- **router**: `assemblyFeatures.addSweep` resolves the assembly sketch profile + the path polyline and adds the feature.

## Tests
Over the wire: a profile swept straight down from its centroid cuts the same 0.5×1×0.6 channel an extrude would (volume **0.7**, the analytic value); a single-point path is rejected.

Full `go test ./...`, `go test -race`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally.

## #735 complete
The full M11-F08 assembly feature kind set is now in: **extrude, revolve, hole, chamfer, fillet, move-face, sweep** (plus box/proxy cut). The edge/face kinds (chamfer/fillet/move-face) rest on the occurrence-relative lineage-suffix foundation (#759).

## Depends on
Contract: Oblikovati.API#90 (merged).

Closes #735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)