### PR TITLE
app: Assembly ribbon tab + active-assembly scaffolding (M11)

### DIFF
--- a/app/assembly_access.go
+++ b/app/assembly_access.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/compdef"
+)
+
+// activeAssembly returns the active document's assembly content, erroring when there is no
+// active document or it is not an assembly — the assembly counterpart of [activePart], used
+// by the Assemble ribbon commands and assembly tools (M11).
+func activeAssembly(s *Session) (*compdef.AssemblyComponentDefinition, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, errors.New("app: no active document")
+	}
+	asm, ok := d.Content().(*compdef.AssemblyComponentDefinition)
+	if !ok {
+		return nil, errors.New("app: active document is not an assembly")
+	}
+	return asm, nil
+}
+
+// hasActiveAssembly reports whether the active document is an assembly — the enable
+// predicate for the Assemble ribbon commands (mirrors [hasActivePart]).
+func hasActiveAssembly(s *Session) bool {
+	asm, _ := activeAssembly(s)
+	return asm != nil
+}

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "fmt"
+
+// The Assemble ribbon tab (M11), shown for an assembly document (the AssemblyRibbon key,
+// switched in by ribbonKeyForDocument). This file establishes the tab's panel structure and
+// the active-assembly enable gate; each command's behavior lands in its own follow-up issue
+// (Place #763, Pattern/Mirror/Copy #765, BOM #768), which replaces the stub run below with a
+// real tool. The assembly model + wire surface already exist — these are head/app wiring.
+
+// assemblyTabCommands returns the Assemble tab commands in ribbon order, grouped into panels
+// by their category (Component / Pattern / BOM).
+func assemblyTabCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		assemblyStubCommand("Assembly.Place", "Place", "Component", 763),
+		assemblyStubCommand("Assembly.Pattern", "Pattern", "Pattern", 765),
+		assemblyStubCommand("Assembly.Mirror", "Mirror", "Pattern", 765),
+		assemblyStubCommand("Assembly.Copy", "Copy", "Pattern", 765),
+		assemblyStubCommand("Assembly.BOM", "Bill of Materials", "BOM", 768),
+	}
+}
+
+// assemblyStubCommand builds one Assemble-tab command on the AssemblyRibbon, enabled when an
+// assembly is active. Its run is a placeholder until the named follow-up issue wires the
+// real tool — so the tab renders with the full panel structure now.
+func assemblyStubCommand(id, name, panel string, issue int) *CommandDefinition {
+	return NewCommand(id, name, panel, assemblyStubRun(name, issue)).
+		WithTab("Assemble").
+		WithRibbons(AssemblyRibbon).
+		WithEnable(hasActiveAssembly).
+		WithTooltip(fmt.Sprintf("%s — assembly command (implementation in #%d).", name, issue))
+}
+
+// assemblyStubRun reports that the command's behavior is not yet wired, naming its issue.
+func assemblyStubRun(name string, issue int) func(*Session) error {
+	return func(*Session) error {
+		return fmt.Errorf("%s is not yet implemented (#%d)", name, issue)
+	}
+}

--- a/app/commands_assembly_test.go
+++ b/app/commands_assembly_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// assemblySession returns a session with an active assembly document and the standard
+// ribbon commands wired — so BuildRibbon resolves the AssemblyRibbon.
+func assemblySession(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	d, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(d); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	return s
+}
+
+// TestAssembleRibbonTabAndPanels checks an active assembly shows the Assemble tab with its
+// Component/Pattern/BOM panels (the M11 scaffolding, #761).
+func TestAssembleRibbonTabAndPanels(t *testing.T) {
+	tab, ok := BuildRibbon(assemblySession(t)).Tab("Assemble")
+	if !ok {
+		t.Fatal("an active assembly should show the Assemble ribbon tab")
+	}
+	for _, panel := range []string{"Component", "Pattern", "BOM"} {
+		if _, ok := tab.Panel(panel); !ok {
+			t.Errorf("Assemble tab has no %s panel", panel)
+		}
+	}
+}
+
+// TestAssembleTabAbsentForPart checks the Assemble tab is contextual to an assembly: a part
+// document must not show it.
+func TestAssembleTabAbsentForPart(t *testing.T) {
+	if _, ok := BuildRibbon(registeredSession(t)).Tab("Assemble"); ok {
+		t.Error("a part ribbon should not show the Assemble tab")
+	}
+}
+
+// TestActiveAssemblyGate checks the active-assembly enable predicate and accessor.
+func TestActiveAssemblyGate(t *testing.T) {
+	if !hasActiveAssembly(assemblySession(t)) {
+		t.Error("hasActiveAssembly should be true with an assembly active")
+	}
+	if hasActiveAssembly(registeredSession(t)) {
+		t.Error("hasActiveAssembly should be false with a part active")
+	}
+	if _, err := activeAssembly(assemblySession(t)); err != nil {
+		t.Errorf("activeAssembly should resolve the active assembly: %v", err)
+	}
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -37,6 +37,7 @@ func standardCommands() []*CommandDefinition {
 	cmds = append(cmds, workFeatureCommands()...)
 	cmds = append(cmds, manageTabCommands()...)
 	cmds = append(cmds, sketchTabCommands()...)
+	cmds = append(cmds, assemblyTabCommands()...)
 	cmds = append(cmds, viewTabCommands()...)
 	return cmds
 }


### PR DESCRIPTION
## What
The **foundation for the assembly head UI** (#761). The ribbon is data-driven (`BuildRibbon` walks the command registry; `AssemblyRibbon` + `ribbonKeyForDocument` already switch by document type), but **no command targeted the AssemblyRibbon**, so the assembly tab rendered empty.

- **`app/assembly_access.go`**: `activeAssembly` / `hasActiveAssembly` — the assembly counterparts of `activePart` / `hasActivePart`; the accessor + enable gate the Assemble commands and forthcoming assembly tools use.
- **`app/commands_assembly.go`**: `assemblyTabCommands` registers the **Assemble** tab with its **Component / Pattern / BOM** panels, each command gated on an active assembly. Behaviors land in their own issues (Place #763, Pattern/Mirror/Copy #765, BOM #768), which replace the stub run with a real tool — this PR establishes the structure + gate.
- Registered into `standardCommands` so `RegisterStandardCommands` wires the tab.

## Why
Establishes the assembly ribbon scaffolding the rest of the assembly UI backlog (#761–#770) builds on. No new wire methods (the ribbon is internal); no head-rendering changes (data-driven).

## Tests
A ribbon-registry test asserts the Assemble tab + Component/Pattern/BOM panels appear for an assembly document and are **absent for a part**, and that the active-assembly gate resolves correctly (true for assembly, false for part).

Full `go test ./...`, `go test -race ./app/`, and `golangci-lint v2.1.0 run ./...` (0 issues) pass locally. Source-repo only.

Part of #761 (the foundation of the assembly UI backlog #761–#770).

🤖 Generated with [Claude Code](https://claude.com/claude-code)