### PR TITLE
Make assembly edits undoable through the transaction stream

### DIFF
--- a/app/assembly_undo_test.go
+++ b/app/assembly_undo_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// assemblyWithComponent returns a session whose active document is an empty assembly, plus a
+// component part open in the same workspace ready to place. The component is registered (open),
+// so a restore's re-bind resolves it through the reference graph with no disk round trip — the
+// fixture the assembly-undo tests build on (#763).
+func assemblyWithComponent(t *testing.T) (*Session, *compdef.AssemblyComponentDefinition) {
+	t.Helper()
+	s := NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "widget.obk", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	asm, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(asm); err != nil {
+		t.Fatalf("activate assembly: %v", err)
+	}
+	return s, asm.Content().(*compdef.AssemblyComponentDefinition)
+}
+
+// placedWidget places the workspace's widget component into the active assembly under name,
+// failing the test on error. It opens the component by name through the assembly's reference
+// graph so the placement persists like a real Place would.
+func placedWidget(t *testing.T, s *Session, asm *compdef.AssemblyComponentDefinition, name string) {
+	t.Helper()
+	owner := s.ActiveDocument()
+	widget, ok := owner.OpenReference("widget.obk")
+	if !ok {
+		t.Fatal("widget.obk should resolve as a reference of the active assembly")
+	}
+	if _, err := asm.PlaceComponentFromFile(owner, widget, name, math.Identity4()); err != nil {
+		t.Fatalf("place %q: %v", name, err)
+	}
+}
+
+// TestAssemblyPlaceIsUndoable is the headline assembly-undo test (#763): placing a component is
+// one transaction event, navigated through the same generalized recipe-store stream a part edit
+// uses. Undo removes the occurrence (restore the prior recipe, then re-bind), redo restores it.
+func TestAssemblyPlaceIsUndoable(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	trackFromHere(s) // baseline = empty assembly, the state undo returns to
+
+	placedWidget(t, s, asm, "widget:1")
+	s.recordEdit(asm, "Place Component")
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Fatalf("after place: occurrence count = %d, want 1", got)
+	}
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 0 {
+		t.Errorf("after undo: occurrence count = %d, want 0", got)
+	}
+
+	if err := s.Redo(); err != nil {
+		t.Fatalf("redo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Fatalf("after redo: occurrence count = %d, want 1", got)
+	}
+	if name := asm.Occurrences().Item(0).Name(); name != "widget:1" {
+		t.Errorf("redo re-bound occurrence name = %q, want %q", name, "widget:1")
+	}
+}
+
+// TestAssemblyEditUndoIsOneStep checks two placements coalesced under a bounded transaction
+// undo as a single step — the assembly path through Begin/EndTransaction now that the
+// transaction guards accept any recipe store, not only parts (#763).
+func TestAssemblyEditUndoIsOneStep(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	trackFromHere(s)
+
+	if err := s.BeginTransaction("Place Two"); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	placedWidget(t, s, asm, "widget:1")
+	s.recordEdit(asm, "Place Component")
+	placedWidget(t, s, asm, "widget:2")
+	s.recordEdit(asm, "Place Component")
+	if err := s.EndTransaction(); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 2 {
+		t.Fatalf("after grouped place: occurrence count = %d, want 2", got)
+	}
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 0 {
+		t.Errorf("one undo should remove the whole group: occurrence count = %d, want 0", got)
+	}
+}

--- a/app/undo.go
+++ b/app/undo.go
@@ -12,8 +12,20 @@ import (
 	"oblikovati.org/model/doc"
 )
 
-// The part definition is the concrete RecipeStore a snapshot event navigates.
-var _ command.RecipeStore = (*compdef.PartComponentDefinition)(nil)
+// recipeStore is the document content the app's undo stream records: content whose entire
+// recipe can be captured (MarshalRecipe) and restored (command.RecipeStore.RestoreRecipe). Part
+// and assembly definitions both satisfy it, so an assembly edit — placing a component (#763) —
+// is one undo step exactly like a part edit, recorded through the same chokepoint.
+type recipeStore interface {
+	command.RecipeStore
+	MarshalRecipe() ([]byte, error)
+}
+
+// Part and assembly definitions are the concrete recipe stores a snapshot event navigates.
+var (
+	_ recipeStore = (*compdef.PartComponentDefinition)(nil)
+	_ recipeStore = (*compdef.AssemblyComponentDefinition)(nil)
+)
 
 // docHistory is one document's transaction-event stream: the [command.History] (the
 // cursor over the events) plus snapshot — the recipe the model holds at the current
@@ -38,8 +50,8 @@ type docHistory struct {
 // resync sets snapshot to the recipe the document now holds — called after undo/redo
 // so the next new edit captures the correct before-snapshot for its event.
 func (dh *docHistory) resync(d *doc.Document) {
-	if part, ok := d.Content().(*compdef.PartComponentDefinition); ok {
-		dh.snapshot, _ = part.MarshalRecipe()
+	if c, ok := d.Content().(recipeStore); ok {
+		dh.snapshot, _ = c.MarshalRecipe()
 	}
 }
 
@@ -70,7 +82,7 @@ func (s *Session) documentHistory(d *doc.Document) *docHistory {
 // of the geometry recompute the caller already ran, so recordEdit does not recompute.
 // An edit that changed nothing (e.g. exiting a sketch untouched) leaves before==after
 // and records no event, so the stream holds only real changes.
-func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string) {
+func (s *Session) recordEdit(content recipeStore, label string) {
 	d := s.ActiveDocument()
 	if d == nil {
 		return
@@ -81,7 +93,7 @@ func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string
 		// undo step at EndTransaction. snapshot is intentionally left untouched.
 		return
 	}
-	s.commitRecipeDelta(d, dh, part, label)
+	s.commitRecipeDelta(d, dh, content, label)
 }
 
 // commitRecipeDelta records the part's recipe delta as one undo event and
@@ -89,16 +101,16 @@ func (s *Session) recordEdit(part *compdef.PartComponentDefinition, label string
 // (M02-F06). A no-op delta (before == after) records nothing. A Before
 // TransactionCommitted handler may veto, which reverts the part to the
 // pre-edit snapshot and reports the commit as an abort (M04-F05).
-func (s *Session) commitRecipeDelta(d *doc.Document, dh *docHistory, part *compdef.PartComponentDefinition, label string) {
-	after, err := part.MarshalRecipe()
+func (s *Session) commitRecipeDelta(d *doc.Document, dh *docHistory, content recipeStore, label string) {
+	after, err := content.MarshalRecipe()
 	if err != nil || bytes.Equal(after, dh.snapshot) {
 		return
 	}
 	if out := event.Emit(s.bus, event.Before, TransactionCommitted{Document: d.ID(), Label: label}); out.Vetoed() {
-		s.revertVetoedCommit(d, dh, part, label, out.Reason)
+		s.revertVetoedCommit(d, dh, content, label, out.Reason)
 		return
 	}
-	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, part))
+	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, content))
 	dh.snapshot = after
 	s.resyncDerivedTables(d, map[string]bool{})
 	event.Emit(s.bus, event.After, TransactionCommitted{Document: d.ID(), Label: label})
@@ -106,14 +118,29 @@ func (s *Session) commitRecipeDelta(d *doc.Document, dh *docHistory, part *compd
 
 // revertVetoedCommit rolls the part back to the stream's snapshot after a Before
 // handler vetoed the commit, surfacing the veto reason in the status bar.
-func (s *Session) revertVetoedCommit(d *doc.Document, dh *docHistory, part *compdef.PartComponentDefinition, label, reason string) {
-	if err := part.RestoreRecipe(dh.snapshot); err != nil {
+func (s *Session) revertVetoedCommit(d *doc.Document, dh *docHistory, content recipeStore, label, reason string) {
+	if err := content.RestoreRecipe(dh.snapshot); err != nil {
 		s.notice = err.Error()
 		return
 	}
+	s.rebindReferences(d)
 	s.notice = reason
 	s.resyncDerivedTables(d, map[string]bool{})
 	event.Emit(s.bus, event.After, TransactionAborted{Document: d.ID(), Label: label})
+}
+
+// rebindReferences re-binds cross-document references after a recipe restore (#763). An
+// assembly's RestoreRecipe leaves its occurrences pending — binding each to its component
+// document needs the workspace to open the component, which only an owner-aware caller has — so
+// every app-layer restore (undo, redo, abort, veto-revert) pairs with this to re-bind. It also
+// re-binds a derived part's source after a part restore. Content that restores fully in place
+// implements no resolver and is a silent no-op.
+func (s *Session) rebindReferences(d *doc.Document) {
+	if r, ok := d.Content().(doc.ReferenceResolver); ok {
+		if err := r.ResolveReferences(d); err != nil {
+			s.notice = err.Error()
+		}
+	}
 }
 
 // RecordAddInEdit finalizes a router-applied mutation as one undo step: the
@@ -175,11 +202,11 @@ func (s *Session) EndTransaction() error {
 	}
 	label := dh.groupLabel
 	dh.groupLabel = ""
-	part, ok := d.Content().(*compdef.PartComponentDefinition)
+	content, ok := d.Content().(recipeStore)
 	if !ok {
 		return nil
 	}
-	s.commitRecipeDelta(d, dh, part, label)
+	s.commitRecipeDelta(d, dh, content, label)
 	return nil
 }
 
@@ -199,10 +226,11 @@ func (s *Session) AbortTransaction() error {
 	}
 	label := dh.groupLabel
 	dh.groupDepth, dh.groupLabel = 0, ""
-	if part, ok := d.Content().(*compdef.PartComponentDefinition); ok {
-		if err := part.RestoreRecipe(dh.snapshot); err != nil {
+	if content, ok := d.Content().(recipeStore); ok {
+		if err := content.RestoreRecipe(dh.snapshot); err != nil {
 			return err
 		}
+		s.rebindReferences(d)
 		s.resyncDerivedTables(d, map[string]bool{})
 	}
 	event.Emit(s.bus, event.After, TransactionAborted{Document: d.ID(), Label: label})
@@ -264,6 +292,7 @@ func cursorMove[E event.Event](s *Session, d *doc.Document, dh *docHistory, ev E
 		s.notice = err.Error()
 		return err
 	}
+	s.rebindReferences(d) // an assembly restore leaves occurrences pending; re-bind before resync (#763)
 	dh.resync(d)
 	s.notice = ""
 	return nil

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -87,6 +87,37 @@ func (a *AssemblyComponentDefinition) ApplyRecipe(model []byte) error {
 	return nil
 }
 
+// RestoreRecipe replaces the assembly's entire occurrence structure with the snapshot — the
+// undo/redo restore path (command.RecipeStore, #763). Unlike a part's RestoreRecipe it cannot
+// finish in place: each occurrence must be re-bound to its component document, which needs the
+// workspace to open the component (the same reason ApplyRecipe defers binding). So it resets
+// the occurrences and re-stashes the snapshot as pending; the owner-aware caller pairs every
+// restore with [ResolveReferences] to re-bind (app/undo.go's rebindReferences does this for
+// every restore). Resetting in place preserves the definition pointer, so the document Content
+// and any held reference to the assembly stay valid, and applying a snapshot to an
+// already-populated assembly yields exactly that snapshot rather than a union.
+//
+// Example:
+//
+//	before, _ := asm.MarshalRecipe()
+//	asm.PlaceComponentFromFile(owner, widget, "widget:1", math.Identity4())
+//	asm.RestoreRecipe(before)            // occurrences back to pending
+//	asm.ResolveReferences(owner)         // re-bound: the placement is gone
+func (a *AssemblyComponentDefinition) RestoreRecipe(model []byte) error {
+	a.resetOccurrences()
+	return a.ApplyRecipe(model)
+}
+
+// resetOccurrences clears the occurrence structure in place, re-wiring the fresh collection to
+// the assembly's event source (the listener NewAssemblyComponentDefinition installs) so
+// placements after a restore keep raising occurrence-lifecycle events. The definition pointer
+// is preserved so external references to the assembly stay valid.
+func (a *AssemblyComponentDefinition) resetOccurrences() {
+	a.occurrences = occurrence.NewOccurrences()
+	a.occurrences.SetListener(a.events)
+	a.pending = nil
+}
+
 // ResolveReferences binds each pending occurrence to its component document, opening the
 // component through owner's reference graph (doc.ReferenceResolver). A component that
 // cannot be opened becomes a placeholder occurrence whose reference is flagged broken —

--- a/model/compdef/assembly_undo_test.go
+++ b/model/compdef/assembly_undo_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/event"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// TestAssemblyRestoreRecipeResetsToSnapshot checks RestoreRecipe is a full replace, not a
+// union: restoring an earlier snapshot onto an assembly that has since gained occurrences
+// yields exactly the snapshot's occurrences after re-binding — the undo invariant the
+// transaction stream depends on (#763). The reset would silently union (showing both
+// placements) if RestoreRecipe merged like ApplyRecipe instead of clearing first.
+func TestAssemblyRestoreRecipeResetsToSnapshot(t *testing.T) {
+	_, _, asm, widget, asmDef := placedAssembly(t)
+
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+	oneOccurrence, err := asmDef.MarshalRecipe() // snapshot with exactly one occurrence
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	placeFromFile(t, asm, widget, asmDef, "widget:2", math.Identity4())
+	if got := asmDef.Occurrences().Count(); got != 2 {
+		t.Fatalf("after second place: occurrence count = %d, want 2", got)
+	}
+
+	if err := asmDef.RestoreRecipe(oneOccurrence); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := asmDef.Occurrences().Count(); got != 0 {
+		t.Fatalf("restore stashes occurrences as pending until re-bind: count = %d, want 0", got)
+	}
+	if err := asmDef.ResolveReferences(asm); err != nil {
+		t.Fatalf("resolve references: %v", err)
+	}
+	if got := asmDef.Occurrences().Count(); got != 1 {
+		t.Errorf("after re-bind: occurrence count = %d, want 1 (the snapshot, not a union)", got)
+	}
+	if name := asmDef.Occurrences().Item(0).Name(); name != "widget:1" {
+		t.Errorf("re-bound occurrence name = %q, want %q", name, "widget:1")
+	}
+	if cn := asmDef.Occurrences().Item(0).ComponentName(); cn != widget.FullDocumentName() {
+		t.Errorf("re-bound occurrence component = %q, want %q", cn, widget.FullDocumentName())
+	}
+}
+
+// TestAssemblyRestoreRecipeToEmptyRemovesOccurrences checks restoring the empty baseline
+// clears every occurrence — undo of the very first placement back to a bare assembly (#763).
+func TestAssemblyRestoreRecipeToEmptyRemovesOccurrences(t *testing.T) {
+	_, _, asm, widget, asmDef := placedAssembly(t)
+	empty, err := asmDef.MarshalRecipe() // baseline: no occurrences yet
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+
+	if err := asmDef.RestoreRecipe(empty); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if err := asmDef.ResolveReferences(asm); err != nil {
+		t.Fatalf("resolve references: %v", err)
+	}
+	if got := asmDef.Occurrences().Count(); got != 0 {
+		t.Errorf("after restore to empty baseline: occurrence count = %d, want 0", got)
+	}
+}
+
+// TestRestoreRewiresOccurrenceEvents guards the SetListener re-wire in resetOccurrences: a
+// restore swaps in a fresh occurrence collection, and a subsequent placement must still raise
+// an OccurrenceAdd event. A dropped listener would pass every count assertion yet silently stop
+// the browser and event surface from updating after an undo (#763).
+func TestRestoreRewiresOccurrenceEvents(t *testing.T) {
+	_, _, asm, widget, asmDef := placedAssembly(t)
+	empty, err := asmDef.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+	if err := asmDef.RestoreRecipe(empty); err != nil { // swaps the occurrence collection
+		t.Fatalf("restore: %v", err)
+	}
+
+	added := 0
+	event.Subscribe(asmDef.Events().Bus(), event.After, func(_ event.Context, _ compdef.OccurrenceAdd) event.Outcome {
+		added++
+		return event.Continue()
+	})
+	placeFromFile(t, asm, widget, asmDef, "widget:2", math.Identity4())
+	if added != 1 {
+		t.Errorf("placement after restore raised %d OccurrenceAdd events, want 1 (the listener must survive the reset)", added)
+	}
+}


### PR DESCRIPTION
## What

Generalizes the app's undo chokepoint so an **assembly edit is one undo step**, navigated through the same transaction stream a part edit uses. Prerequisite for the Assemble-tab head tools (Place Component #763 and the rest).

- `app/undo.go`: introduce an app-level `recipeStore` interface (`MarshalRecipe` + `command.RecipeStore.RestoreRecipe`) that both part and assembly definitions satisfy; retype `recordEdit`, `commitRecipeDelta`, `revertVetoedCommit`, `resync`, `EndTransaction`, `AbortTransaction` to it. The `command.RecipeEvent` engine was already generic — only the app layer was part-bound.
- `model/compdef`: add `AssemblyComponentDefinition.RestoreRecipe` (full replace: reset the occurrence structure in place, re-wiring the event listener, then re-stash the snapshot as pending).
- A new `rebindReferences` step pairs with **every** app-layer restore (undo, redo, abort, veto-revert): an assembly restore leaves occurrences pending because re-binding needs the workspace to open each component, so it re-binds via the existing `ResolveReferences` resolver. This also re-binds a derived part's source after a part restore, closing the same latent gap there.

## Why

The undo chokepoint was typed to `*PartComponentDefinition`, so assembly edits recorded nothing and could not be undone/redone. Placing or removing a component has to be undoable like any other edit.

## Testing

- `model/compdef`: `RestoreRecipe` is a full replace not a union (restoring an N-occurrence snapshot over an N+1 state yields exactly N after re-bind); restore-to-empty clears all; **occurrence events still fire after the collection swap** (guards the `SetListener` re-wire).
- `app`: placing a component is undoable/redoable (occurrence removed on undo, re-bound to the real component on redo); two placements coalesced under a bounded transaction undo as one step.
- Full `go test ./...`, `go test -race ./app ./model/compdef ./command`, and `golangci-lint run ./...` (0 issues) all green. Part undo (including derive features) unaffected.

No public API surface changes — reuses the existing `command.RecipeStore`.

Part of M11. Unblocks #763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)