### PR TITLE
Add the Place Component tool: drop instances by ground-plane click

### DIFF
--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -7,19 +7,42 @@ import "fmt"
 // The Assemble ribbon tab (M11), shown for an assembly document (the AssemblyRibbon key,
 // switched in by ribbonKeyForDocument). This file establishes the tab's panel structure and
 // the active-assembly enable gate; each command's behavior lands in its own follow-up issue
-// (Place #763, Pattern/Mirror/Copy #765, BOM #768), which replaces the stub run below with a
-// real tool. The assembly model + wire surface already exist — these are head/app wiring.
+// (Pattern/Mirror/Copy #765, BOM #768), which replaces the stub run below with a real tool. The
+// assembly model + wire surface already exist — these are head/app wiring. Place (#763) is now
+// real: its command starts the Place Component tool.
 
 // assemblyTabCommands returns the Assemble tab commands in ribbon order, grouped into panels
 // by their category (Component / Pattern / BOM).
 func assemblyTabCommands() []*CommandDefinition {
 	return []*CommandDefinition{
-		assemblyStubCommand("Assembly.Place", "Place", "Component", 763),
+		placeComponentCommand(),
 		assemblyStubCommand("Assembly.Pattern", "Pattern", "Pattern", 765),
 		assemblyStubCommand("Assembly.Mirror", "Mirror", "Pattern", 765),
 		assemblyStubCommand("Assembly.Copy", "Copy", "Pattern", 765),
 		assemblyStubCommand("Assembly.BOM", "Bill of Materials", "BOM", 768),
 	}
+}
+
+// placeComponentCommand builds the Place command: it starts the modal Place Component tool on
+// the active assembly. The component file is chosen by the head's file dialog, which feeds the
+// running tool through SetPlaceComponentDocument; each ground-plane click then drops an
+// instance (#763).
+func placeComponentCommand() *CommandDefinition {
+	return NewCommand("Assembly.Place", "Place", "Component", runPlaceComponent).
+		WithTab("Assemble").
+		WithRibbons(AssemblyRibbon).
+		WithEnable(hasActiveAssembly).
+		WithTooltip("Place a component into the assembly.")
+}
+
+// runPlaceComponent starts the Place Component tool on the active assembly. The tool then waits
+// for a chosen component (the head's file dialog) and for ground-plane clicks to drop instances.
+func runPlaceComponent(s *Session) error {
+	if _, err := activeAssembly(s); err != nil {
+		return err
+	}
+	s.StartTool(NewPlaceComponentTool())
+	return nil
 }
 
 // assemblyStubCommand builds one Assemble-tab command on the AssemblyRibbon, enabled when an

--- a/app/place_component_session.go
+++ b/app/place_component_session.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/model/doc"
+
+// Session bridge for the Place Component tool's UI (#763): the head's file dialog feeds the
+// chosen component document to the running tool, and the viewport reads whether a component is
+// still awaited (the cue to open that dialog) — without touching the tool's internals, the same
+// shape as the Extrude and Offset Plane bridges.
+
+// ActivePlaceComponent returns the running Place Component tool, or nil when the active tool is
+// not a place-component (or there is none).
+func (s *Session) ActivePlaceComponent() *PlaceComponentTool {
+	if s.tool == nil {
+		return nil
+	}
+	t, _ := s.tool.tool.(*PlaceComponentTool)
+	return t
+}
+
+// SetPlaceComponentDocument hands the running Place tool the component the user chose in the
+// file dialog. A no-op when no Place tool is active, so a late dialog result is harmless.
+func (s *Session) SetPlaceComponentDocument(d *doc.Document) {
+	if t := s.ActivePlaceComponent(); t != nil {
+		t.SetComponentDocument(d)
+	}
+}
+
+// PlaceComponentAwaitingFile reports that a Place tool is active but has no component yet — the
+// cue for the head to open its file dialog.
+func (s *Session) PlaceComponentAwaitingFile() bool {
+	t := s.ActivePlaceComponent()
+	return t != nil && t.component == nil
+}

--- a/app/place_component_tool.go
+++ b/app/place_component_tool.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/scene"
+)
+
+// PlaceComponentTool instances a component document into the active assembly: each click on the
+// assembly ground plane drops one occurrence at that point and records it as its own undo step,
+// leaving the tool open to drop more — the multi-place behavior of the reference Place Component
+// command (M11, #763). The component document is chosen before placing begins (the head's file
+// dialog, or SetComponentDocument in tests), so the tool itself only turns clicks into
+// placements and its logic is testable without the UI.
+//
+// Example:
+//
+//	tool := NewPlaceComponentTool()
+//	tool.SetComponentDocument(widget) // chosen in the file dialog
+//	s.StartTool(tool)
+//	s.Click(px, py)                   // drops widget:1 on the ground plane
+type PlaceComponentTool struct {
+	component *doc.Document // the document to instance; nil until chosen
+	placed    int           // occurrences dropped so far, for unique instance names
+}
+
+var (
+	_ Tool           = (*PlaceComponentTool)(nil)
+	_ PlaneClickTool = (*PlaceComponentTool)(nil)
+)
+
+// NewPlaceComponentTool returns an idle Place tool. Its component must be set
+// (SetComponentDocument) before a click places anything.
+func NewPlaceComponentTool() *PlaceComponentTool { return &PlaceComponentTool{} }
+
+// Name implements [Tool].
+func (t *PlaceComponentTool) Name() string { return "Place Component" }
+
+// SetComponentDocument chooses the document the tool instances. The head calls this once the
+// user picks a file; tests inject an already-open component the same way.
+func (t *PlaceComponentTool) SetComponentDocument(d *doc.Document) { t.component = d }
+
+// Start implements [Tool]. Placement reads ground-plane clicks rather than entity picks, so the
+// tool clears the current selection and waits for ClickAt.
+func (t *PlaceComponentTool) Start(s *Session) { s.selection.Clear() }
+
+// Pick implements [Tool]. Placement is driven by ground-plane clicks (ClickAt), not entity
+// picks, so a pick is ignored — snapping a placement to existing geometry is a later refinement.
+func (t *PlaceComponentTool) Pick(_ *Session, _ Selectable) {}
+
+// ClickAt drops one instance of the component at the clicked point on the assembly ground plane
+// (Z = 0) and records it as an undo step, leaving the tool open for the next drop
+// ([PlaneClickTool]). A click before a component is chosen, off an active assembly, or on a
+// grazing ray that misses the plane is ignored with a notice rather than placing at a bogus
+// location.
+func (t *PlaceComponentTool) ClickAt(s *Session, px, py float64) {
+	if t.component == nil {
+		s.notice = "Place Component: choose a component first"
+		return
+	}
+	asm, err := activeAssembly(s)
+	if err != nil {
+		s.notice = err.Error()
+		return
+	}
+	at, ok := groundPoint(s.Camera(), px, py)
+	if !ok {
+		s.notice = "Place Component: click within the ground plane"
+		return
+	}
+	t.placed++
+	name := fmt.Sprintf("%s:%d", t.component.DisplayName(), t.placed)
+	if _, err := asm.PlaceComponentFromFile(s.ActiveDocument(), t.component, name, math.Translation4(at.AsVector())); err != nil {
+		t.placed-- // unwind the count so the next click reuses the name a failed placement skipped
+		s.notice = err.Error()
+		return
+	}
+	s.recordEdit(asm, "Place Component")
+}
+
+// CanCommit reports the tool has placed at least one instance, enabling OK to finish.
+func (t *PlaceComponentTool) CanCommit() bool { return t.placed > 0 }
+
+// Commit finishes the tool. Each placement was already applied and recorded on its click, so
+// finishing makes no further edit — it just closes the tool.
+func (t *PlaceComponentTool) Commit(_ *Session) error { return nil }
+
+// Cancel stops the tool. Instances dropped before cancelling remain (each is its own undo step),
+// matching the reference command where Esc keeps what was already placed.
+func (t *PlaceComponentTool) Cancel(_ *Session) {}
+
+// groundRayEpsilon is the |ray.Z| below which the view is treated as edge-on to the ground
+// plane, so no stable intersection exists.
+const groundRayEpsilon = 1e-9
+
+// groundPoint intersects the pixel ray with the assembly ground plane (Z = 0), the default
+// placement datum. It returns false for a ray parallel to the plane (a grazing, edge-on view)
+// or whose hit lies behind the camera, so a click that cannot resolve to a ground point is
+// dropped rather than placing at a bogus location.
+func groundPoint(cam scene.Camera, px, py float64) (math.Point3, bool) {
+	origin, dir := cam.RayThrough(px, py)
+	if dir.Z > -groundRayEpsilon && dir.Z < groundRayEpsilon {
+		return math.Point3{}, false
+	}
+	tHit := -origin.Z / dir.Z
+	if tHit < 0 {
+		return math.Point3{}, false
+	}
+	return origin.TranslateBy(dir.Scale(tHit)), true
+}

--- a/app/place_component_tool_test.go
+++ b/app/place_component_tool_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/scene"
+)
+
+// placeReady sets up an assembly session with a top-down camera and a started Place tool armed
+// with the widget component — the fixture the placement tests click into. The default camera
+// looks down −Z from (0,0,10) at the ground plane (Z=0), so a centre click maps to the origin.
+func placeReady(t *testing.T) (*Session, *compdef.AssemblyComponentDefinition, *PlaceComponentTool) {
+	t.Helper()
+	s, asm := assemblyWithComponent(t)
+	trackFromHere(s) // baseline = empty assembly, the state the first placement undoes to
+	s.SetCamera(scene.NewCamera(800, 600))
+	widget, ok := s.ActiveDocument().OpenReference("widget.obk")
+	if !ok {
+		t.Fatal("widget.obk should resolve as a reference of the active assembly")
+	}
+	tool := NewPlaceComponentTool()
+	tool.SetComponentDocument(widget)
+	s.StartTool(tool)
+	return s, asm, tool
+}
+
+// translationOf returns the (x,y,z) translation cells of the occurrence's placement transform.
+func translationOf(asm *compdef.AssemblyComponentDefinition, i int) (x, y, z float64) {
+	cells := asm.Occurrences().Item(i).Transform().Cells()
+	return cells[3], cells[7], cells[11]
+}
+
+// TestPlaceComponentDropsAtGroundClick is the headline placement test (#763): a click on the
+// viewport drops one occurrence at the ground-plane point under the cursor. A centre click on
+// the top-down camera resolves to the world origin.
+func TestPlaceComponentDropsAtGroundClick(t *testing.T) {
+	s, asm, _ := placeReady(t)
+
+	s.Click(400, 300) // viewport centre → ground origin
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Fatalf("after click: occurrence count = %d, want 1", got)
+	}
+	x, y, z := translationOf(asm, 0)
+	if stdmath.Abs(x) > 1e-6 || stdmath.Abs(y) > 1e-6 || stdmath.Abs(z) > 1e-6 {
+		t.Errorf("placement at (%g,%g,%g), want the ground origin (0,0,0)", x, y, z)
+	}
+	if name := asm.Occurrences().Item(0).Name(); name != "widget:1" {
+		t.Errorf("instance name = %q, want %q", name, "widget:1")
+	}
+}
+
+// TestPlaceComponentProjectsOffCentreClick checks the placement follows the cursor: a top-centre
+// click resolves to a point offset along +Y on the ground plane, not trivially the origin. With
+// the default 45° FOV camera at depth 10, the top edge projects to Y = 10·tan(π/8).
+func TestPlaceComponentProjectsOffCentreClick(t *testing.T) {
+	s, asm, _ := placeReady(t)
+
+	s.Click(400, 0) // top-centre (screen y-down) → ground +Y
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Fatalf("after click: occurrence count = %d, want 1", got)
+	}
+	x, y, z := translationOf(asm, 0)
+	wantY := 10 * stdmath.Tan(stdmath.Pi/8)
+	if stdmath.Abs(x) > 1e-6 || stdmath.Abs(z) > 1e-6 || stdmath.Abs(y-wantY) > 1e-6 {
+		t.Errorf("placement at (%g,%g,%g), want (0,%g,0)", x, y, z, wantY)
+	}
+}
+
+// TestPlaceComponentMultiDropEachUndoable checks the tool stays open across clicks (multi-place)
+// and that each drop is its own undo step: two clicks place two occurrences, and undo removes
+// them one at a time back to the empty assembly.
+func TestPlaceComponentMultiDropEachUndoable(t *testing.T) {
+	s, asm, _ := placeReady(t)
+
+	s.Click(400, 300)
+	s.Click(400, 0)
+	if got := asm.Occurrences().Count(); got != 2 {
+		t.Fatalf("after two clicks: occurrence count = %d, want 2", got)
+	}
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Errorf("after one undo: occurrence count = %d, want 1 (each drop is its own step)", got)
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 0 {
+		t.Errorf("after two undos: occurrence count = %d, want 0", got)
+	}
+}
+
+// TestPlaceComponentCanCommitAfterFirstDrop checks OK is disabled until at least one instance is
+// placed, then enabled — the tool finishes only once it has done something.
+func TestPlaceComponentCanCommitAfterFirstDrop(t *testing.T) {
+	s, _, tool := placeReady(t)
+
+	if tool.CanCommit() {
+		t.Error("CanCommit should be false before any placement")
+	}
+	s.Click(400, 300)
+	if !tool.CanCommit() {
+		t.Error("CanCommit should be true after a placement")
+	}
+}
+
+// TestPlaceComponentIgnoresClickWithoutComponent checks a click before a component is chosen
+// places nothing and explains why, rather than panicking on a nil component.
+func TestPlaceComponentIgnoresClickWithoutComponent(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	trackFromHere(s)
+	s.SetCamera(scene.NewCamera(800, 600))
+	s.StartTool(NewPlaceComponentTool()) // armed with no component
+
+	s.Click(400, 300)
+	if got := asm.Occurrences().Count(); got != 0 {
+		t.Fatalf("a click without a component placed %d occurrences, want 0", got)
+	}
+	if s.notice == "" {
+		t.Error("a click without a component should report why nothing was placed")
+	}
+}
+
+// TestPlaceComponentBridgeFeedsFile checks the head's session bridge: the tool reports it is
+// awaiting a file, and SetPlaceComponentDocument arms it so a subsequent click can place.
+func TestPlaceComponentBridgeFeedsFile(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	trackFromHere(s)
+	s.SetCamera(scene.NewCamera(800, 600))
+	s.StartTool(NewPlaceComponentTool())
+
+	if !s.PlaceComponentAwaitingFile() {
+		t.Fatal("a fresh Place tool should await a component file")
+	}
+	widget, _ := s.ActiveDocument().OpenReference("widget.obk")
+	s.SetPlaceComponentDocument(widget)
+	if s.PlaceComponentAwaitingFile() {
+		t.Error("the tool should not await a file once SetPlaceComponentDocument is called")
+	}
+
+	s.Click(400, 300)
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Errorf("after arming and clicking: occurrence count = %d, want 1", got)
+	}
+}
+
+// TestPlaceCommandStartsTool checks the Assemble-tab Place button starts the Place Component
+// tool (replacing the former stub), so the head can then drive its file dialog (#763).
+func TestPlaceCommandStartsTool(t *testing.T) {
+	s := assemblySession(t)
+	if err := s.Execute("Assembly.Place"); err != nil {
+		t.Fatalf("Execute Assembly.Place: %v", err)
+	}
+	if s.ActivePlaceComponent() == nil {
+		t.Error("Assembly.Place should start the Place Component tool")
+	}
+}


### PR DESCRIPTION
## What

Makes the Assemble-tab **Place** command real at the app layer (it was a stub that errored). A modal `PlaceComponentTool` instances a chosen component document into the active assembly — **one occurrence per click on the ground plane (Z=0)**, each recorded as its own undo step, so multi-place and per-instance undo behave like the reference command.

- `app/place_component_tool.go`: the tool (Tool + PlaneClickTool). Each `ClickAt` projects the pixel ray to the ground plane (`groundPoint`) and places an instance there via `PlaceComponentFromFile`, then records the edit. Stays open for the next drop.
- `app/place_component_session.go`: session bridge — `ActivePlaceComponent` / `SetPlaceComponentDocument` / `PlaceComponentAwaitingFile`, so the head feeds the file the user picks to the running tool and learns when to prompt.
- `app/commands_assembly.go`: `Assembly.Place` now starts the tool instead of erroring.

Placement reuses the existing `PlaneClickTool` routing seam, so **no viewport/`Pointer` change was needed** — the prerequisite I expected turned out already covered.

## Why

First functional command on the Assemble tab. Builds directly on the assembly-undo stream (#774) — placing/undoing a component is one step like any part edit.

## Testing

App-level, headless:
- a click drops an instance at the ground point under the cursor (centre → world origin; off-centre top click → `Y = 10·tan(π/8)`, proving real ray–plane projection rather than a trivial origin);
- the tool stays open for multi-place, each drop independently undoable back to the empty assembly;
- OK gates until a placement is made; a click with no chosen component is a no-op with a notice (no nil panic);
- the bridge arms the tool from a chosen file; the command starts the tool.

Full `go test ./...`, `go test -race ./app`, `golangci-lint run ./...` (0 issues) green.

## Follow-up

The head ImGui file dialog that calls `SetPlaceComponentDocument` (and opens on `PlaceComponentAwaitingFile`) is the remaining glue for end-to-end UI use — next phase of #763. No public API surface changes here.

Part of M11. #763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)