### PR TITLE
Implement viewport.captureWindow: whole-window PNG readback

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -107,6 +107,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodViewGetCamera] = getCamera
 	r.handlers[wire.MethodViewSetCamera] = setCamera
 	r.handlers[wire.MethodViewportCapture] = captureViewport
+	r.handlers[wire.MethodViewportCaptureWindow] = captureWindow
 	r.handlers[wire.MethodViewportSetNormalDebug] = setNormalDebug
 	r.handlers[wire.MethodViewportSetMeshColors] = setMeshColors
 	r.handlers[wire.MethodInteractionState] = interactionState

--- a/addin/router/viewport.go
+++ b/addin/router/viewport.go
@@ -14,6 +14,10 @@ import (
 // Tools ▸ Save Viewport PNG path so a programmatic capture never clobbers a manual one.
 var defaultCapturePath = filepath.Join("/tmp", "oblikovati-capture.png")
 
+// defaultWindowCapturePath is where viewport.captureWindow writes when no Path is given — distinct
+// from the viewport capture path so a window grab never clobbers a 3D-only one.
+var defaultWindowCapturePath = filepath.Join("/tmp", "oblikovati-window.png")
+
 // captureViewport requests a PNG of the active document's viewport framebuffer
 // (wire.MethodViewportCapture). It only FLAGS the request — the head writes the file after the next
 // frame renders, so the image is exactly what is on screen — and returns the path it will write plus
@@ -30,6 +34,25 @@ func captureViewport(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	s.RequestViewportCapture(path)
 	cam := s.Camera()
 	return json.Marshal(wire.CaptureViewportResult{Path: path, Width: cam.Width, Height: cam.Height})
+}
+
+// captureWindow requests a PNG of the WHOLE application window — the chrome (ribbon, browser, open
+// dialogs) composited with the 3D viewport (wire.MethodViewportCaptureWindow). Like captureViewport
+// it only FLAGS the request; the head reads back the swapchain after the frame composites, so the
+// image is exactly what is on screen, including UI state. Returns the path it will write and the
+// window pixel size so the caller can poll for completion.
+func captureWindow(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CaptureWindowArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	path := in.Path
+	if path == "" {
+		path = defaultWindowCapturePath
+	}
+	s.RequestWindowCapture(path)
+	frame := s.WindowFrameStatus()
+	return json.Marshal(wire.CaptureWindowResult{Path: path, Width: frame.Width, Height: frame.Height})
 }
 
 // setNormalDebug turns the viewport's normal-debug render on/off (wire.MethodViewportSetNormalDebug);

--- a/addin/router/viewport_test.go
+++ b/addin/router/viewport_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestCaptureWindowFlagsRequest checks viewport.captureWindow flags a whole-window capture (the head
+// services it after the swapchain composites) and returns the path it will write, so an MCP client
+// can poll for the file.
+func TestCaptureWindowFlagsRequest(t *testing.T) {
+	r, s := seededSession(t)
+	var res wire.CaptureWindowResult
+	call(t, r, s, "viewport.captureWindow", `{"path":"/tmp/w.png"}`, &res)
+	if res.Path != "/tmp/w.png" {
+		t.Errorf("result path = %q, want /tmp/w.png", res.Path)
+	}
+	if path, ok := s.TakeWindowCapture(); !ok || path != "/tmp/w.png" {
+		t.Errorf("captureWindow did not flag the request: (%q, %v)", path, ok)
+	}
+}
+
+// TestCaptureWindowDefaultPath checks an empty Path falls back to the default whole-window file,
+// distinct from the viewport-capture default so one never clobbers the other.
+func TestCaptureWindowDefaultPath(t *testing.T) {
+	r, s := seededSession(t)
+	var res wire.CaptureWindowResult
+	call(t, r, s, "viewport.captureWindow", `{}`, &res)
+	if res.Path == "" || res.Path == defaultCapturePath {
+		t.Errorf("default window path = %q, want a non-empty path distinct from the viewport default", res.Path)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -102,6 +102,7 @@ type Session struct {
 	meshImportRequested  bool                           // a "Place Mesh…" was requested; the head opens the file dialog (#700)
 	scriptConsoleOpen    bool                           // the Manage ▸ Scripts ▸ Script Console panel is open
 	capturePath          string                         // a requested viewport PNG capture path; the head writes it after render
+	captureWindowPath    string                         // a requested whole-window PNG capture path; the head writes it after the frame composites
 	normalDebug          bool                           // viewport normal-debug render (front green / back red); head reads each frame
 	meshColors           bool                           // viewport mesh-debug-colors render (each face/triangle a distinct color)
 	meshColorsPerTri     bool                           // when meshColors: color per TRIANGLE (else per B-rep face)

--- a/app/viewport_capture.go
+++ b/app/viewport_capture.go
@@ -19,6 +19,22 @@ func (s *Session) TakeViewportCapture() (path string, ok bool) {
 	return path, true
 }
 
+// RequestWindowCapture flags that the WHOLE application window (chrome + dialogs + viewport, the full
+// swapchain image) should be written to a PNG at path — the headless way to SEE the UI state, not
+// just the 3D render. Like [RequestViewportCapture] but the head reads back the swapchain after the
+// frame composites.
+func (s *Session) RequestWindowCapture(path string) { s.captureWindowPath = path }
+
+// TakeWindowCapture returns the pending whole-window capture path and clears it (ok=false when none
+// pending).
+func (s *Session) TakeWindowCapture() (path string, ok bool) {
+	if s.captureWindowPath == "" {
+		return "", false
+	}
+	path, s.captureWindowPath = s.captureWindowPath, ""
+	return path, true
+}
+
 // SetNormalDebug enables/disables the viewport's normal-debug render (front-facing GREEN, back-facing
 // RED) — the headless way to inspect winding/orientation. The head applies it on the next frame.
 func (s *Session) SetNormalDebug(on bool) { s.normalDebug = on }

--- a/app/window_capture_test.go
+++ b/app/window_capture_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestWindowCaptureRequestRoundTrip checks RequestWindowCapture flags a path that TakeWindowCapture
+// then consumes exactly once — the one-shot seam the head's frame loop drains to write the
+// whole-window PNG after the swapchain composites.
+func TestWindowCaptureRequestRoundTrip(t *testing.T) {
+	s := NewSession()
+	if _, ok := s.TakeWindowCapture(); ok {
+		t.Fatal("a fresh session should have no pending window capture")
+	}
+	s.RequestWindowCapture("/tmp/win.png")
+	path, ok := s.TakeWindowCapture()
+	if !ok || path != "/tmp/win.png" {
+		t.Fatalf("TakeWindowCapture = (%q, %v), want (/tmp/win.png, true)", path, ok)
+	}
+	if _, ok := s.TakeWindowCapture(); ok {
+		t.Error("the pending capture should be consumed after one Take")
+	}
+}
+
+// TestWindowAndViewportCapturesAreIndependent checks the whole-window and viewport-only capture
+// requests use separate slots, so requesting one never consumes or clobbers the other.
+func TestWindowAndViewportCapturesAreIndependent(t *testing.T) {
+	s := NewSession()
+	s.RequestViewportCapture("/tmp/vp.png")
+	s.RequestWindowCapture("/tmp/win.png")
+	if path, ok := s.TakeWindowCapture(); !ok || path != "/tmp/win.png" {
+		t.Errorf("TakeWindowCapture = (%q, %v), want the window path", path, ok)
+	}
+	if path, ok := s.TakeViewportCapture(); !ok || path != "/tmp/vp.png" {
+		t.Errorf("TakeViewportCapture = (%q, %v), want the viewport path still pending", path, ok)
+	}
+}

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -86,7 +86,8 @@ func pumpFrame(win *native.Window, session *app.Session, addins *addInHost) bool
 	}
 	addins.drain()
 	exit := ui.HandleClose(win, session)
-	win.EndFrame(ui.WindowClearColor()) // themed swapchain background (ADR-0021)
+	win.EndFrame(ui.WindowClearColor())   // themed swapchain background (ADR-0021)
+	ui.ServiceWindowCapture(win, session) // whole-window PNG: AFTER the swapchain composited this frame
 	return exit || addins.addInChanged()
 }
 

--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -101,6 +101,22 @@ func saveViewportPNG(w *Window, path string) error {
 	if !ok {
 		return fmt.Errorf("readback unavailable")
 	}
+	return encodeBGRAPNG(px, width, height, path)
+}
+
+// saveWindowPNG reads the full window swapchain image back and writes it as a PNG, so the whole UI
+// (chrome + open dialogs + the composited viewport) can be inspected headlessly.
+func saveWindowPNG(w *Window, path string) error {
+	px, width, height, ok := w.ReadbackWindow()
+	if !ok {
+		return fmt.Errorf("window readback unavailable")
+	}
+	return encodeBGRAPNG(px, width, height, path)
+}
+
+// encodeBGRAPNG writes BGRA8 pixels (Vulkan's surface byte order) as an RGBA PNG at path, swapping
+// the byte order and forcing opaque alpha. Shared by the viewport and whole-window captures.
+func encodeBGRAPNG(px []byte, width, height int, path string) error {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 	for i := 0; i+4 <= len(px); i += 4 {
 		img.Pix[i+0], img.Pix[i+1], img.Pix[i+2], img.Pix[i+3] = px[i+2], px[i+1], px[i+0], 255

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -1303,6 +1303,90 @@ int obk_viewport_readback(void* h, int slot, unsigned char* out, int cap, int* w
     return need;
 }
 
+// obk_window_capture copies the swapchain image for the current frame — the WHOLE window: the ImGui
+// chrome, open dialogs, and the composited 3D viewport — into out as 8-bit BGRA (the surface order),
+// row-major top to bottom. It returns the byte count written (0 if not ready or out is too small) and
+// reports the window pixel size. A self-contained synchronous transfer like obk_viewport_readback, but
+// it reads the backbuffer (the full composite) rather than the offscreen viewport target: it waits on
+// the frame's render fence so the composite is complete, copies the backbuffer through a transient
+// command pool (independent of the lazy viewport target), and restores the PRESENT_SRC layout so the
+// presented image is untouched. Call after the frame has rendered (obk_head_end_frame).
+int obk_window_capture(void* h, unsigned char* out, int cap, int* w, int* hh) {
+    HeadContext* c = (HeadContext*)h;
+    if (!c || c->device == VK_NULL_HANDLE) return 0;
+    ImGui_ImplVulkanH_Window* wd = &c->window_data;
+    if (wd->Width <= 0 || wd->Height <= 0 || (int)wd->FrameIndex >= wd->Frames.Size) return 0;
+    ImGui_ImplVulkanH_Frame* fd = &wd->Frames[wd->FrameIndex];
+    if (fd->Backbuffer == VK_NULL_HANDLE) return 0;
+    int need = wd->Width * wd->Height * 4;
+    if (w) *w = wd->Width;
+    if (hh) *hh = wd->Height;
+    if (!out || cap < need) return 0;
+
+    // The ImGui render into this backbuffer must be complete before we read it.
+    vkWaitForFences(c->device, 1, &fd->Fence, VK_TRUE, UINT64_MAX);
+
+    GpuBuffer staging{};
+    upload(c, &staging, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, (VkDeviceSize)need);
+
+    VkCommandPoolCreateInfo pci{};
+    pci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pci.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+    pci.queueFamilyIndex = c->queueFamily;
+    VkCommandPool pool = VK_NULL_HANDLE;
+    vkCreateCommandPool(c->device, &pci, nullptr, &pool);
+    VkCommandBufferAllocateInfo cba{};
+    cba.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    cba.commandPool = pool;
+    cba.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cba.commandBufferCount = 1;
+    VkCommandBuffer cmd = VK_NULL_HANDLE;
+    vkAllocateCommandBuffers(c->device, &cba, &cmd);
+
+    VkCommandBufferBeginInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd, &bi);
+    // The backbuffer is in PRESENT_SRC after the ImGui render pass; flip it to TRANSFER_SRC to copy,
+    // then restore PRESENT_SRC.
+    img_barrier(cmd, fd->Backbuffer, 1, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+                VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_ACCESS_MEMORY_READ_BIT,
+                VK_ACCESS_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT);
+    VkBufferImageCopy cp{};
+    cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    cp.imageExtent = {(uint32_t)wd->Width, (uint32_t)wd->Height, 1};
+    vkCmdCopyImageToBuffer(cmd, fd->Backbuffer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           staging.buffer, 1, &cp);
+    img_barrier(cmd, fd->Backbuffer, 1, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_ACCESS_TRANSFER_READ_BIT,
+                VK_ACCESS_MEMORY_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    vkEndCommandBuffer(cmd);
+
+    VkFenceCreateInfo fci{};
+    fci.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    VkFence fence = VK_NULL_HANDLE;
+    vkCreateFence(c->device, &fci, nullptr, &fence);
+    VkSubmitInfo submit{};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &cmd;
+    vkQueueSubmit(c->queue, 1, &submit, fence);
+    vkWaitForFences(c->device, 1, &fence, VK_TRUE, UINT64_MAX);
+
+    void* mapped = nullptr;
+    vkMapMemory(c->device, staging.memory, 0, need, 0, &mapped);
+    std::memcpy(out, mapped, need);
+    vkUnmapMemory(c->device, staging.memory);
+
+    vkDestroyFence(c->device, fence, nullptr);
+    vkDestroyCommandPool(c->device, pool, nullptr);
+    vkDestroyBuffer(c->device, staging.buffer, nullptr);
+    vkFreeMemory(c->device, staging.memory, nullptr);
+    return need;
+}
+
 // obk_viewport_texture returns the ImGui texture handle for the rendered color image
 // (0 before the first render), to be drawn with ImGui::Image.
 uint64_t obk_viewport_texture(void* h, int slot) {

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -27,6 +27,7 @@ void     obk_viewport_set_environment(void* h, const float* data, const int* dim
                                       float rotation, float intensity);
 uint64_t obk_viewport_texture(void* h, int slot);
 int      obk_viewport_readback(void* h, int slot, unsigned char* out, int cap, int* w, int* hh);
+int      obk_window_capture(void* h, unsigned char* out, int cap, int* w, int* hh);
 
 void obk_ig_image(unsigned long long tex, float w, float h);
 void obk_ig_content_region_avail(float* w, float* h);
@@ -100,6 +101,13 @@ func (w *Window) SaveViewportPNG(path string) error {
 	return saveViewportPNG(w, path)
 }
 
+// SaveWindowPNG reads back the current swapchain image and writes it as a PNG — a screenshot of the
+// WHOLE application window (chrome, open dialogs, and the composited viewport), for inspecting UI
+// state headlessly. Call after the frame has composited (EndFrame).
+func (w *Window) SaveWindowPNG(path string) error {
+	return saveWindowPNG(w, path)
+}
+
 // SetViewportNormalDebug toggles the normal-debug render: shaded triangles draw front-facing
 // green / back-facing red so inverted-winding / flipped-normal triangles stand out. Takes
 // effect on the next RenderViewport.
@@ -166,6 +174,23 @@ func (w *Window) ReadbackViewport(slot int) (pixels []byte, width, height int, o
 	buf := make([]byte, int(cw)*int(ch)*4)
 	n := C.obk_viewport_readback(w.handle, C.int(slot), (*C.uchar)(unsafe.Pointer(&buf[0])), C.int(len(buf)),
 		&cw, &ch)
+	if int(n) != len(buf) {
+		return nil, 0, 0, false
+	}
+	return buf, int(cw), int(ch), true
+}
+
+// ReadbackWindow copies the current swapchain image (the WHOLE window: chrome, dialogs, and the
+// composited viewport) to host memory, returning the raw 8-bit pixels (the surface's channel order,
+// typically BGRA), width and height, and ok=false if the swapchain is not ready. For headless
+// verification/screenshots; call after the frame has composited (EndFrame).
+func (w *Window) ReadbackWindow() (pixels []byte, width, height int, ok bool) {
+	var cw, ch C.int
+	if C.obk_window_capture(w.handle, nil, 0, &cw, &ch) != 0 || cw <= 0 || ch <= 0 {
+		return nil, 0, 0, false
+	}
+	buf := make([]byte, int(cw)*int(ch)*4)
+	n := C.obk_window_capture(w.handle, (*C.uchar)(unsafe.Pointer(&buf[0])), C.int(len(buf)), &cw, &ch)
 	if int(n) != len(buf) {
 		return nil, 0, 0, false
 	}

--- a/head/ui/viewport_screenshot.go
+++ b/head/ui/viewport_screenshot.go
@@ -41,3 +41,19 @@ func serviceScreenshot(win *native.Window, s *app.Session) {
 	}
 	fileNotice(s, "Saved viewport image to %s", screenshotPath)
 }
+
+// ServiceWindowCapture writes a pending whole-window capture (the viewport.captureWindow wire method
+// / MCP bridge) to its PNG. Unlike serviceScreenshot it must run AFTER EndFrame, when the swapchain
+// holds the fully composited frame (chrome + open dialogs + viewport), so the readback reflects the
+// whole window. Atomic temp+rename so a remote reader polling the path never sees a half-written file.
+func ServiceWindowCapture(win *native.Window, s *app.Session) {
+	path, ok := s.TakeWindowCapture()
+	if !ok {
+		return
+	}
+	if tmp := path + ".tmp"; win.SaveWindowPNG(tmp) != nil {
+		fileNotice(s, "viewport.captureWindow failed to render")
+	} else if err := os.Rename(tmp, path); err != nil {
+		fileNotice(s, "viewport.captureWindow failed: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Implements `viewport.captureWindow` (api/wire) — capture the **entire application window** (ImGui chrome: ribbon, browser, open dialogs, composited with the 3D viewport) to a PNG, not just the 3D framebuffer like `viewport.capture`. Lets an add-in / MCP client SEE the UI state headlessly.

- **app**: `RequestWindowCapture` / `TakeWindowCapture` — a one-shot path slot, independent of the viewport-capture slot.
- **router**: `viewport.captureWindow` flags the request and returns the path + window pixel size to poll.
- **head (cgo)**: `obk_window_capture` reads back the current swapchain image (the composited backbuffer) through a transient command pool and restores the `PRESENT_SRC` layout — mirrors `obk_viewport_readback` but for the whole window. Serviced in the frame loop **after `EndFrame`** (once the swapchain composited) and written atomically. The BGRA→RGBA + PNG encode is now shared between the viewport and window captures.

## Verification (live, over the MCP bridge)

Built a part with a solid, then captured both:
- `capture_window` → **2560×1425** — the full window: menu bar, the entire ribbon, model browser, the extruded block in the viewport, ViewCube, triad, status bar — rendered correctly.
- `capture_viewport` → **1980×1095** — the viewport panel alone.

The different sizes + the correct full-UI image confirm the swapchain readback and BGRA→RGBA conversion.

## Tests

- app: request/take round-trip + independence from the viewport-capture slot.
- router: `captureWindow` flags the request and returns the path; default-path fallback distinct from the viewport default.
- The cgo Vulkan readback is verified live (above), not unit-testable headlessly.

Stacked on API PR Oblikovati/Oblikovati.API#91 (the wire contract). Part of the assembly-UI verification surface (#763).

🤖 Generated with [Claude Code](https://claude.com/claude-code)