### PR TITLE
Add the Place Component file picker to the head

### DIFF
--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -108,6 +108,7 @@ func drawChromeDialogs(s *app.Session) {
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawWorkPlaneEditDialog(s)
+	drawPlaceComponentDialog(s) // Assemble ▸ Place: arms the component file picker (#763)
 }
 
 func drawSolidFeatureDialogs(s *app.Session) {

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -22,14 +22,15 @@ import (
 type fileDialogMode int
 
 const (
-	dialogClosed  fileDialogMode = iota
-	dialogOpen                   // File ▸ Open
-	dialogSaveAs                 // File ▸ Save As
-	dialogLoadHDR                // View ▸ Load HDR (environment image)
-	dialogImport                 // File ▸ Import (STL/OBJ/3MF/STEP → imported body)
-	dialogExport                 // File ▸ Export (part bodies → STL/OBJ/3MF/STEP)
-	dialogAddIn                  // an add-in's dialogs.showFileDialog request (M05-F08)
-	dialogMeshRef                // Mesh ▸ Place Mesh (ASCII STL → mesh reference geometry, #700)
+	dialogClosed         fileDialogMode = iota
+	dialogOpen                          // File ▸ Open
+	dialogSaveAs                        // File ▸ Save As
+	dialogLoadHDR                       // View ▸ Load HDR (environment image)
+	dialogImport                        // File ▸ Import (STL/OBJ/3MF/STEP → imported body)
+	dialogExport                        // File ▸ Export (part bodies → STL/OBJ/3MF/STEP)
+	dialogAddIn                         // an add-in's dialogs.showFileDialog request (M05-F08)
+	dialogMeshRef                       // Mesh ▸ Place Mesh (ASCII STL → mesh reference geometry, #700)
+	dialogPlaceComponent                // Assemble ▸ Place: choose the component document to instance (#763)
 )
 
 // pathBufferLen bounds the path the user can type. ImGui edits the buffer in place,
@@ -122,21 +123,29 @@ func (d *fileDialog) title() string {
 		return "Load HDR"
 	case dialogMeshRef:
 		return "Place Mesh (.stl)"
+	case dialogPlaceComponent:
+		return "Place Component"
 	case dialogImport:
 		return "Import (.stl/.obj/.3mf/.step)"
 	case dialogExport:
 		return "Export (.stl/.obj/.3mf/.step)"
 	case dialogAddIn:
-		if d.request.Title != "" {
-			return d.request.Title
-		}
-		if d.request.Save {
-			return "Save As"
-		}
-		return "Open"
+		return d.addInTitle()
 	default:
 		return "Open"
 	}
+}
+
+// addInTitle is the window heading for an add-in's file dialog request: its custom title when
+// set, otherwise Save As / Open by the request's direction.
+func (d *fileDialog) addInTitle() string {
+	if d.request.Title != "" {
+		return d.request.Title
+	}
+	if d.request.Save {
+		return "Save As"
+	}
+	return "Open"
 }
 
 // filterHint names the file family surfaced by the browser for this operation.
@@ -256,8 +265,8 @@ func (d *fileDialog) allowsFile(name string) bool {
 
 func (d *fileDialog) allowedExts() []string {
 	switch d.mode {
-	case dialogOpen, dialogSaveAs:
-		return doc.DocumentExtensions()
+	case dialogOpen, dialogSaveAs, dialogPlaceComponent:
+		return doc.DocumentExtensions() // a component is another .obk document (part or sub-assembly)
 	case dialogLoadHDR:
 		return []string{".hdr"}
 	case dialogMeshRef:

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -239,39 +239,81 @@ func applyFileAction(s *app.Session, act fileAction) {
 	name := filepath.Base(act.Path)
 	switch act.Kind {
 	case dialogOpen:
-		if _, err := s.OpenDocument(act.Path); err != nil {
-			fileNotice(s, "Open failed: %v", err)
-		} else {
-			fileNotice(s, "Opened %s", name)
-		}
+		openDocumentFromFile(s, act.Path, name)
+	case dialogPlaceComponent:
+		placeComponentFromFile(s, act.Path, name)
 	case dialogSaveAs:
-		if err := s.SaveActiveDocumentAs(act.Path); err != nil {
-			fileNotice(s, "Save failed: %v", err)
-		} else {
-			fileNotice(s, "Saved %s", name)
-			queueSaveThumbnail(s, act.Path)
-		}
+		saveActiveDocumentAs(s, act.Path, name)
 	case dialogLoadHDR:
 		s.LoadEnvironmentFile(act.Path) // the decode happens lazily on the next viewport frame
 	case dialogMeshRef:
-		if _, err := s.ImportMeshFile(act.Path); err != nil {
-			fileNotice(s, "Place Mesh failed: %v", err)
-		} else {
-			fileNotice(s, "Placed mesh %s", name)
-		}
+		placeMeshFromFile(s, act.Path, name)
 	case dialogImport:
-		if res, err := s.ImportFile(act.Path); err != nil {
-			fileNotice(s, "Import failed: %v", err)
-		} else {
-			fileNotice(s, "Imported %s (%d %s)", name, res.BodyCount, plural(res.BodyCount, "body", "bodies"))
-		}
+		importBodyFromFile(s, act.Path, name)
 	case dialogExport:
-		if _, err := s.ExportFile(act.Path, types.MeshResolution(act.Resolution)); err != nil {
-			fileNotice(s, "Export failed: %v", err)
-		} else {
-			fileNotice(s, "Exported %s", name)
-		}
+		exportToFile(s, act, name)
 	}
+}
+
+// saveActiveDocumentAs writes the active document to path and, on success, queues its thumbnail
+// and remembers the path so a later File ▸ Save writes straight through (File ▸ Save As).
+func saveActiveDocumentAs(s *app.Session, path, name string) {
+	if err := s.SaveActiveDocumentAs(path); err != nil {
+		fileNotice(s, "Save failed: %v", err)
+		return
+	}
+	fileNotice(s, "Saved %s", name)
+	queueSaveThumbnail(s, path)
+}
+
+// placeMeshFromFile imports an ASCII STL as mesh reference geometry (Mesh ▸ Place Mesh).
+func placeMeshFromFile(s *app.Session, path, name string) {
+	if _, err := s.ImportMeshFile(path); err != nil {
+		fileNotice(s, "Place Mesh failed: %v", err)
+		return
+	}
+	fileNotice(s, "Placed mesh %s", name)
+}
+
+// importBodyFromFile imports a CAD file into the active part as an imported body (File ▸ Import).
+func importBodyFromFile(s *app.Session, path, name string) {
+	res, err := s.ImportFile(path)
+	if err != nil {
+		fileNotice(s, "Import failed: %v", err)
+		return
+	}
+	fileNotice(s, "Imported %s (%d %s)", name, res.BodyCount, plural(res.BodyCount, "body", "bodies"))
+}
+
+// exportToFile writes the active part's bodies to a mesh file at the chosen resolution (File ▸ Export).
+func exportToFile(s *app.Session, act fileAction, name string) {
+	if _, err := s.ExportFile(act.Path, types.MeshResolution(act.Resolution)); err != nil {
+		fileNotice(s, "Export failed: %v", err)
+		return
+	}
+	fileNotice(s, "Exported %s", name)
+}
+
+// openDocumentFromFile opens the chosen document and reports the outcome (File ▸ Open).
+func openDocumentFromFile(s *app.Session, path, name string) {
+	if _, err := s.OpenDocument(path); err != nil {
+		fileNotice(s, "Open failed: %v", err)
+		return
+	}
+	fileNotice(s, "Opened %s", name)
+}
+
+// placeComponentFromFile opens the chosen component and hands it to the running Place tool (#763);
+// the tool then drops instances on ground-plane clicks. Opening (not just naming) the document
+// shares the live content, so edits to the component propagate to every placement.
+func placeComponentFromFile(s *app.Session, path, name string) {
+	d, err := s.OpenDocument(path)
+	if err != nil {
+		fileNotice(s, "Place Component failed: %v", err)
+		return
+	}
+	s.SetPlaceComponentDocument(d)
+	fileNotice(s, "Placing %s — click to drop instances", name)
 }
 
 // fileNotice shows a file-operation outcome in the status bar (s.Notice) and mirrors it to

--- a/head/ui/file_dialog_test.go
+++ b/head/ui/file_dialog_test.go
@@ -5,6 +5,7 @@ package ui
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -35,6 +36,28 @@ func TestFileDialogConfirmReturnsActionForMode(t *testing.T) {
 	}
 	if d.isOpen() {
 		t.Error("dialog should be closed after confirm")
+	}
+}
+
+// TestFileDialogPlaceComponentMode checks the Place Component picker (#763): its title, that it
+// filters to the same .obk document family as Open (a component is a part or sub-assembly), and
+// that confirming yields a dialogPlaceComponent action — the one the chrome routes to
+// SetPlaceComponentDocument.
+func TestFileDialogPlaceComponentMode(t *testing.T) {
+	var d fileDialog
+	d.openFor(dialogPlaceComponent)
+	if !d.isOpen() || d.title() != "Place Component" {
+		t.Fatalf("openFor(PlaceComponent): isOpen=%v title=%q", d.isOpen(), d.title())
+	}
+	var open fileDialog
+	open.openFor(dialogOpen)
+	if !slices.Equal(d.allowedExts(), open.allowedExts()) {
+		t.Errorf("place-component exts = %v, want the document family %v", d.allowedExts(), open.allowedExts())
+	}
+	path := filepath.Join(t.TempDir(), "widget.obk")
+	d.typePath(path)
+	if act := d.confirm(); act.Kind != dialogPlaceComponent || act.Path != path {
+		t.Errorf("confirm() = %+v, want PlaceComponent %q", act, path)
 	}
 }
 

--- a/head/ui/place_component_dialog.go
+++ b/head/ui/place_component_dialog.go
@@ -1,0 +1,41 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "oblikovati.org/app"
+
+// placeUI tracks which Place Component tool instance the file picker has been opened for, so the
+// picker opens exactly once when a Place tool starts awaiting a component — not every frame — and
+// the tool is abandoned if the user dismisses the picker without choosing a file. Keyed on the
+// tool pointer (like the extrude dialog's seeded field) so a fresh Place invocation re-arms.
+var placeUI struct {
+	armedFor *app.PlaceComponentTool
+}
+
+// drawPlaceComponentDialog drives the Place Component tool's one piece of chrome: choosing the
+// component document to instance (#763). When a Place tool is active and has no component yet it
+// opens the file picker (in dialogPlaceComponent mode, which feeds the choice to the tool via
+// SetPlaceComponentDocument); if the user cancels the picker without choosing, the tool is
+// abandoned so it does not sit waiting forever. Placement itself is ground-plane clicks in the
+// viewport (the app PlaceComponentTool), so there is no per-frame property panel here.
+func drawPlaceComponentDialog(s *app.Session) {
+	tool := s.ActivePlaceComponent()
+	if tool == nil {
+		placeUI.armedFor = nil // tool committed or cancelled; re-arm for the next invocation
+		return
+	}
+	if !s.PlaceComponentAwaitingFile() {
+		return // a component is chosen; the tool now drops instances on viewport clicks
+	}
+	if placeUI.armedFor != tool {
+		fileModal.openFor(dialogPlaceComponent) // open the picker once for this tool
+		placeUI.armedFor = tool
+		return
+	}
+	if !fileModal.isOpen() {
+		s.CancelTool() // the picker was dismissed without a choice — abandon the Place tool
+		placeUI.armedFor = nil
+	}
+}


### PR DESCRIPTION
## What

Completes **#763 Place Component** end to end: the Assemble-tab Place command starts the `PlaceComponentTool` (merged in #775), which needs a component document — this wires the head's file picker to supply it.

- A new `dialogPlaceComponent` file-dialog mode (filtered to the `.obk` document family — a component is a part or sub-assembly), opened when an active Place tool is awaiting a component.
- The chosen file is opened and handed to the tool via `SetPlaceComponentDocument`; the tool then drops instances on ground-plane clicks. If the user dismisses the picker without choosing, the tool is cancelled so it doesn't hang. Arming is keyed on the tool instance, so the picker opens once per Place invocation.
- `applyFileAction` grew a seventh branch, so each file operation moves to its own small handler and `applyFileAction` becomes a thin dispatcher (and the add-in title case splits out of `title()`) — keeping the functions within the size/complexity limits.

## Testing

- Non-cgo file-dialog logic: the new mode's title, its `.obk` filter, and that confirm yields a `dialogPlaceComponent` action.
- The cgo arming/draw glue is build-verified and was **verified live**: executing `Assembly.Place` in the running app opened the Place Component file picker (confirmed by a full-window screenshot showing the modal over the Oblikovati window).

Builds on the assembly-undo (#774) and Place tool (#775). Closes #763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)