### PR TITLE
feat: New Assembly document-creation flow (#762)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -43,8 +43,8 @@ func standardCommands() []*CommandDefinition {
 }
 
 // getStartedCommands are the ZeroDoc ribbon's Get Started tab — shown when no document is
-// open. New Part is the primary action; it creates a part, which switches the active ribbon
-// to the Part ribbon (RibbonUI_Overview's per-document-type ribbons).
+// open. New Part / New Assembly are the launch actions; each creates a document, which switches
+// the active ribbon to that type's ribbon (RibbonUI_Overview's per-document-type ribbons).
 func getStartedCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		NewCommand("GetStarted.NewPart", "New Part", "Launch", func(s *Session) error {
@@ -53,6 +53,12 @@ func getStartedCommands() []*CommandDefinition {
 		}).WithTab("Get Started").WithRibbons(ZeroDocRibbon).
 			WithIcon("new-part").WithButtonStyle(LargeIconButton).
 			WithTooltip("New Part — create a part document and open the part environment."),
+		NewCommand("GetStarted.NewAssembly", "New Assembly", "Launch", func(s *Session) error {
+			_, err := s.NewAssembly()
+			return err
+		}).WithTab("Get Started").WithRibbons(ZeroDocRibbon).
+			WithIcon("new-assembly").WithButtonStyle(LargeIconButton).
+			WithTooltip("New Assembly — create an assembly document and open the assembly environment, where you place and constrain components."),
 	}
 }
 

--- a/app/new_assembly_test.go
+++ b/app/new_assembly_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+// TestNewAssemblyCreatesActiveAssemblyDocument: Session.NewAssembly mints a realized assembly
+// document (assembly content installed, not the bare placeholder), makes it active, and names it
+// "Assembly1" — the assembly counterpart of NewPart (#762).
+func TestNewAssemblyCreatesActiveAssemblyDocument(t *testing.T) {
+	s := NewSession()
+	d, err := s.NewAssembly()
+	if err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	if s.ActiveDocument() != d {
+		t.Error("a new assembly should become the active document")
+	}
+	if d.DocumentType() != doc.Assembly {
+		t.Errorf("document type = %v, want Assembly", d.DocumentType())
+	}
+	if _, ok := d.Content().(*compdef.AssemblyComponentDefinition); !ok {
+		t.Errorf("content = %T, want *AssemblyComponentDefinition (realized, not placeholder)", d.Content())
+	}
+	if d.DisplayName() != "Assembly1" {
+		t.Errorf("name = %q, want Assembly1", d.DisplayName())
+	}
+}
+
+// TestNewAssemblyNamesAreUnique: two New Assembly commands in a row never clash — the second is
+// "Assembly2" — because uniqueDocumentName skips names already open.
+func TestNewAssemblyNamesAreUnique(t *testing.T) {
+	s := NewSession()
+	first, err := s.NewAssembly()
+	if err != nil {
+		t.Fatalf("first NewAssembly: %v", err)
+	}
+	second, err := s.NewAssembly()
+	if err != nil {
+		t.Fatalf("second NewAssembly: %v", err)
+	}
+	if first.DisplayName() == second.DisplayName() {
+		t.Errorf("both assemblies named %q; the second must be unique", first.DisplayName())
+	}
+	if second.DisplayName() != "Assembly2" {
+		t.Errorf("second assembly = %q, want Assembly2", second.DisplayName())
+	}
+}
+
+// TestNewAssemblyAndNewPartShareCounterSpace: the Part and Assembly counters are independent —
+// a New Part after a New Assembly is "Part1", not "Part2" (each prefix counts its own kind).
+func TestNewAssemblyAndNewPartShareCounterSpace(t *testing.T) {
+	s := NewSession()
+	if _, err := s.NewAssembly(); err != nil {
+		t.Fatalf("NewAssembly: %v", err)
+	}
+	part, err := s.NewPart()
+	if err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	if part.DisplayName() != "Part1" {
+		t.Errorf("first part after an assembly = %q, want Part1", part.DisplayName())
+	}
+}
+
+// TestGetStartedTabOffersNewAssembly: the ZeroDoc ribbon's Get Started ▸ Launch panel offers
+// New Assembly alongside New Part, so a user can start an assembly from an empty session (#762).
+func TestGetStartedTabOffersNewAssembly(t *testing.T) {
+	s := zeroDocSession(t)
+	cmd, ok := s.Commands().ByID("GetStarted.NewAssembly")
+	if !ok {
+		t.Fatal("GetStarted.NewAssembly command is not registered")
+	}
+	if !cmd.IsEnabled(s) {
+		t.Error("New Assembly should be enabled on the ZeroDoc ribbon")
+	}
+	r := BuildRibbon(s)
+	tab, ok := r.Tab("Get Started")
+	if !ok {
+		t.Fatal("ZeroDoc ribbon has no Get Started tab")
+	}
+	panel, ok := tab.Panel("Launch")
+	if !ok {
+		t.Fatal("Get Started tab has no Launch panel")
+	}
+	if !panelHasCommand(panel, "GetStarted.NewAssembly") {
+		t.Error("Launch panel does not offer New Assembly")
+	}
+}
+
+// TestExecuteNewAssemblyOpensAssemblyRibbon: executing the command by id creates the assembly and
+// switches the active ribbon to the Assemble environment (proves the command is wired end to end).
+func TestExecuteNewAssemblyOpensAssemblyRibbon(t *testing.T) {
+	s := zeroDocSession(t)
+	if err := s.Execute("GetStarted.NewAssembly"); err != nil {
+		t.Fatalf("execute GetStarted.NewAssembly: %v", err)
+	}
+	if BuildRibbon(s).Key != AssemblyRibbon {
+		t.Errorf("after New Assembly the ribbon is %q, want AssemblyRibbon", BuildRibbon(s).Key)
+	}
+}
+
+// panelHasCommand reports whether a ribbon panel carries a button for the command id.
+func panelHasCommand(p RibbonPanel, id string) bool {
+	for _, b := range p.Buttons {
+		if b.Command != nil && b.Command.ID() == id {
+			return true
+		}
+	}
+	return false
+}

--- a/app/session.go
+++ b/app/session.go
@@ -335,7 +335,7 @@ func (s *Session) NewPart() (*doc.Document, error) {
 		s.notice = out.Reason
 		return nil, &doc.VetoError{Operation: "new part", Reason: out.Reason}
 	}
-	d, err := compdef.AddPart(s.workspace, s.uniquePartName(), true)
+	d, err := compdef.AddPart(s.workspace, s.uniqueDocumentName("Part"), true)
 	if err != nil {
 		return nil, err
 	}
@@ -344,14 +344,36 @@ func (s *Session) NewPart() (*doc.Document, error) {
 	return d, nil
 }
 
-// uniquePartName returns the first "PartN" name not currently open, so New Part never clashes.
-func (s *Session) uniquePartName() string {
+// NewAssembly creates a realized assembly document with a unique "AssemblyN" name and makes it
+// active (the workspace activates a newly added document), so the viewport and ribbon switch to
+// the assembly environment. It backs the New Assembly command on the ZeroDoc ribbon (#762) — the
+// counterpart of [Session.NewPart].
+//
+//	d, err := session.NewAssembly()
+func (s *Session) NewAssembly() (*doc.Document, error) {
+	ev := FileNew{DocumentType: doc.Assembly}
+	if out := event.Emit(s.bus, event.Before, ev); out.Vetoed() {
+		s.notice = out.Reason
+		return nil, &doc.VetoError{Operation: "new assembly", Reason: out.Reason}
+	}
+	d, err := compdef.AddAssembly(s.workspace, s.uniqueDocumentName("Assembly"), true)
+	if err != nil {
+		return nil, err
+	}
+	s.documentHistory(d) // open the event stream now so the first placement is undoable to the empty assembly
+	event.Emit(s.bus, event.After, ev)
+	return d, nil
+}
+
+// uniqueDocumentName returns the first "<prefix>N" name not currently open, so New Part / New
+// Assembly never clash with an open document.
+func (s *Session) uniqueDocumentName(prefix string) string {
 	taken := map[string]bool{}
 	for _, d := range s.workspace.Documents() {
 		taken[d.DisplayName()] = true
 	}
 	for n := 1; ; n++ {
-		if name := "Part" + strconv.Itoa(n); !taken[name] {
+		if name := prefix + strconv.Itoa(n); !taken[name] {
 			return name
 		}
 	}

--- a/head/icon/assets/new-assembly.svg
+++ b/head/icon/assets/new-assembly.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="4" y="9" width="9" height="9"/><rect x="11" y="4" width="9" height="9"/><path d="M16 16 H22 M19 13 V19" stroke="#ff0000"/></svg>

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -27,6 +27,9 @@ func drawFileMenu(s *app.Session) {
 		if native.MenuItem("New Part") {
 			_, _ = s.NewPart()
 		}
+		if native.MenuItem("New Assembly") { // #762 — start an assembly to place and constrain components
+			_, _ = s.NewAssembly()
+		}
 		if native.MenuItem("Open") {
 			openViaHookOrDialog(s)
 		}


### PR DESCRIPTION
## What
Wire **New Assembly** into the UI so a user can create an assembly document — until now only Part was reachable from the UI, leaving the whole assembly environment (Place Component, the Assemble ribbon) accessible only over the wire.

- `Session.NewAssembly()` — the counterpart of `NewPart()`: mints a *realized* assembly document (assembly content installed, not the bare placeholder), names it uniquely `AssemblyN`, and activates it so the ribbon/viewport switch to the assembly environment.
- New Assembly button on the ZeroDoc **Get Started ▸ Launch** panel (with a `new-assembly` glyph) and a **File ▸ New Assembly** menu item, mirroring New Part.
- `uniquePartName` generalized to `uniqueDocumentName(prefix)` so Part and Assembly share one collision-free namer (no duplication).

## Why
M11 feature-completeness: you can place components into an assembly, but there was no UI path to *create* one. Closes the entry-point gap.

## Tests
- `TestNewAssemblyCreatesActiveAssemblyDocument` — realized content, active, named `Assembly1`.
- `TestNewAssemblyNamesAreUnique` — second is `Assembly2`.
- `TestNewAssemblyAndNewPartShareCounterSpace` — independent Part/Assembly counters.
- `TestGetStartedTabOffersNewAssembly` / `TestExecuteNewAssemblyOpensAssemblyRibbon` — command registered, enabled, and switches to the AssemblyRibbon end to end.
- Existing `TestRibbonCommandIconsResolve` now guards the new `new-assembly.svg` asset.

`go test ./app/...` green; `golangci-lint run ./app/...` 0 issues; head builds with cgo.

Part of M11 (Assembly Modeling & Instancing). Closes #762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)