### PR TITLE
feat: assembly occurrence browser + selection (#764)

### DIFF
--- a/app/browser.go
+++ b/app/browser.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
 )
 
@@ -22,7 +23,7 @@ import (
 // clicking "XY Plane" selects the plane to sketch on).
 type BrowserNode struct {
 	Label    string
-	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "feature"
+	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "feature" | "occurrence"
 	Select   Selectable
 	Children []BrowserNode
 }
@@ -57,10 +58,53 @@ func BuildBrowser(s *Session) BrowserNode {
 		return BrowserNode{Label: "(no document)", Kind: "document"}
 	}
 	root := BrowserNode{Label: doc.DisplayName(), Kind: "document"}
-	if part, ok := doc.Content().(*compdef.PartComponentDefinition); ok {
-		addPartBranches(&root, part)
+	switch content := doc.Content().(type) {
+	case *compdef.PartComponentDefinition:
+		addPartBranches(&root, content)
+	case *compdef.AssemblyComponentDefinition:
+		addAssemblyBranches(&root, content)
 	}
 	return root
+}
+
+// addAssemblyBranches builds the assembly's browser tree: the Parameters folder, then the placed
+// component occurrences in placement order. Each occurrence node is selectable (its handle drives
+// ground/suppress/delete from the right-click menu and the replication commands), and a
+// sub-assembly occurrence nests its own occurrences so the structure is navigable (#764).
+func addAssemblyBranches(root *BrowserNode, asm *compdef.AssemblyComponentDefinition) {
+	params := root.child("Parameters", "parameters")
+	for _, p := range asm.Parameters().All() {
+		params.child(p.Name(), "parameter")
+	}
+	addOccurrenceNodes(root, asm.Occurrences())
+}
+
+// addOccurrenceNodes appends one selectable node per occurrence under parent, recursing into a
+// sub-assembly occurrence's own occurrences so nested structure is browsable. The node label
+// annotates the grounded / suppressed state (the head greys/badges later; the suffix keeps the
+// text tree self-describing).
+func addOccurrenceNodes(parent *BrowserNode, occs *occurrence.Occurrences) {
+	if occs == nil { // a leaf (part) occurrence has no sub-occurrence collection
+		return
+	}
+	for i := 0; i < occs.Count(); i++ {
+		o := occs.Item(i)
+		node := parent.selectableBranch(occurrenceLabel(o), "occurrence", OccurrenceHandle{Occurrence: o})
+		addOccurrenceNodes(node, o.SubOccurrences())
+	}
+}
+
+// occurrenceLabel is the occurrence's instance name with a state suffix when it is grounded or
+// suppressed, so the browser row reads its status without an icon.
+func occurrenceLabel(o *occurrence.Occurrence) string {
+	label := o.Name()
+	if o.Grounded() {
+		label += " (grounded)"
+	}
+	if o.Suppressed() {
+		label += " (suppressed)"
+	}
+	return label
 }
 
 // addPartBranches builds the part's browser tree: the static Origin and Parameters folders,

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -29,8 +29,32 @@ func BrowserMenu(n BrowserNode) []BrowserMenuItem {
 		return workAxisMenu(n.Select)
 	case "body":
 		return bodyMenu(n.Select)
+	case "occurrence":
+		return occurrenceMenu(n.Select)
 	default:
 		return nil
+	}
+}
+
+// occurrenceMenu offers a Ground/Unground toggle, a Suppress/Unsuppress toggle, and Delete for a
+// placed component occurrence (#764). Each label reflects the occurrence's current state.
+func occurrenceMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(OccurrenceHandle)
+	if !ok {
+		return nil
+	}
+	groundLabel := "Ground"
+	if h.Occurrence.Grounded() {
+		groundLabel = "Unground"
+	}
+	suppressLabel := "Suppress"
+	if h.Occurrence.Suppressed() {
+		suppressLabel = "Unsuppress"
+	}
+	return []BrowserMenuItem{
+		{Label: groundLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceGrounded(h.Occurrence) }},
+		{Label: suppressLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceSuppressed(h.Occurrence) }},
+		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteOccurrence(h.Occurrence) }},
 	}
 }
 

--- a/app/occurrence_actions.go
+++ b/app/occurrence_actions.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/occurrence"
+)
+
+// Session actions invoked from the assembly browser's right-click menu (#764): ground, suppress,
+// and delete a placed component occurrence. Each mutates the active assembly through the model's
+// vetoable operations (so an add-in can refuse one), recomputes when the change affects geometry,
+// and records an undo step — the occurrence counterpart of the part browser actions in
+// app/browser_actions.go. A vetoed change surfaces its reason as the returned error, leaving the
+// occurrence unchanged.
+
+// SuppressOccurrence sets o's suppression and recomputes so an unsuppressed feature drops the
+// occurrence's body from its participants and the range box updates. A no-op toggle records
+// nothing.
+func (s *Session) SuppressOccurrence(o *occurrence.Occurrence, suppressed bool) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if o == nil {
+		return errors.New("app: SuppressOccurrence with nil occurrence")
+	}
+	if o.Suppressed() == suppressed {
+		return nil
+	}
+	if err := asm.SetOccurrenceSuppressed(o, suppressed); err != nil {
+		return err
+	}
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Suppress Component")
+	return nil
+}
+
+// ToggleOccurrenceSuppressed flips o's suppression (the browser's Suppress/Unsuppress entry).
+func (s *Session) ToggleOccurrenceSuppressed(o *occurrence.Occurrence) error {
+	if o == nil {
+		return errors.New("app: ToggleOccurrenceSuppressed with nil occurrence")
+	}
+	return s.SuppressOccurrence(o, !o.Suppressed())
+}
+
+// GroundOccurrence fixes (grounded=true) or releases o in assembly space. Grounding is a
+// constraint flag with no geometry effect on its own (the solver consumes it in M12), so it
+// records an undo step without recomputing. A no-op toggle records nothing.
+func (s *Session) GroundOccurrence(o *occurrence.Occurrence, grounded bool) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if o == nil {
+		return errors.New("app: GroundOccurrence with nil occurrence")
+	}
+	if o.Grounded() == grounded {
+		return nil
+	}
+	o.SetGrounded(grounded)
+	s.recordEdit(asm, "Ground Component")
+	return nil
+}
+
+// ToggleOccurrenceGrounded flips o's grounded flag (the browser's Ground/Unground entry).
+func (s *Session) ToggleOccurrenceGrounded(o *occurrence.Occurrence) error {
+	if o == nil {
+		return errors.New("app: ToggleOccurrenceGrounded with nil occurrence")
+	}
+	return s.GroundOccurrence(o, !o.Grounded())
+}
+
+// DeleteOccurrence removes o from the active assembly, clears the selection (the deleted node no
+// longer exists at its old identity), recomputes, and records an undo step. Undo restores the
+// occurrence through the assembly recipe and rebinds its component reference.
+func (s *Session) DeleteOccurrence(o *occurrence.Occurrence) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if o == nil {
+		return errors.New("app: DeleteOccurrence with nil occurrence")
+	}
+	if err := asm.DeleteOccurrence(o); err != nil {
+		return err
+	}
+	s.selection.Clear()
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Delete Component")
+	return nil
+}

--- a/app/occurrence_browser_test.go
+++ b/app/occurrence_browser_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+// findBrowserNode returns the first node of the given kind whose label matches, searched
+// depth-first — so a test can locate an occurrence row in the assembly tree.
+func findBrowserNode(n BrowserNode, kind, label string) *BrowserNode {
+	if n.Kind == kind && n.Label == label {
+		return &n
+	}
+	for i := range n.Children {
+		if found := findBrowserNode(n.Children[i], kind, label); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// TestAssemblyBrowserListsOccurrences: an assembly with a placed component shows that occurrence
+// as a selectable browser row carrying an OccurrenceHandle, so clicking it selects the occurrence
+// (#764). A part document's browser never grew an occurrence row, so this is the assembly path.
+func TestAssemblyBrowserListsOccurrences(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+
+	node := findBrowserNode(BuildBrowser(s), "occurrence", "widget:1")
+	if node == nil {
+		t.Fatal("assembly browser has no occurrence row for widget:1")
+	}
+	h, ok := node.Select.(OccurrenceHandle)
+	if !ok {
+		t.Fatalf("occurrence node selects %T, want OccurrenceHandle", node.Select)
+	}
+	if h.Occurrence != asm.Occurrences().Item(0) {
+		t.Error("occurrence handle does not point at the placed occurrence")
+	}
+}
+
+// TestOccurrenceLabelReflectsState: the browser row annotates grounded and suppressed state in
+// its label so the text tree is self-describing.
+func TestOccurrenceLabelReflectsState(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	o := asm.Occurrences().Item(0)
+
+	if got := occurrenceLabel(o); got != "widget:1" {
+		t.Errorf("plain label = %q, want widget:1", got)
+	}
+	o.SetGrounded(true)
+	o.SetSuppressed(true)
+	if got := occurrenceLabel(o); got != "widget:1 (grounded) (suppressed)" {
+		t.Errorf("annotated label = %q, want \"widget:1 (grounded) (suppressed)\"", got)
+	}
+}
+
+// TestOccurrenceMenuTogglesLabels: the right-click menu offers Ground/Suppress/Delete, and the
+// toggle labels reflect the occurrence's current state (Ground→Unground, Suppress→Unsuppress).
+func TestOccurrenceMenuTogglesLabels(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	o := asm.Occurrences().Item(0)
+	node := findBrowserNode(BuildBrowser(s), "occurrence", "widget:1")
+
+	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Ground|Suppress|Delete" {
+		t.Errorf("fresh occurrence menu = %q, want Ground|Suppress|Delete", labels)
+	}
+	o.SetGrounded(true)
+	o.SetSuppressed(true)
+	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Unground|Unsuppress|Delete" {
+		t.Errorf("grounded+suppressed menu = %q, want Unground|Unsuppress|Delete", labels)
+	}
+}
+
+// TestSuppressOccurrenceIsUndoable: suppressing a component is one undo step — undo unsuppresses,
+// redo re-suppresses — proving the change records a recipe delta (#764).
+func TestSuppressOccurrenceIsUndoable(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	trackFromHere(s) // baseline: placed, unsuppressed
+
+	if err := s.ToggleOccurrenceSuppressed(asm.Occurrences().Item(0)); err != nil {
+		t.Fatalf("suppress: %v", err)
+	}
+	if !asm.Occurrences().Item(0).Suppressed() {
+		t.Fatal("toggle did not suppress the occurrence")
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if asm.Occurrences().Item(0).Suppressed() {
+		t.Error("undo should restore the unsuppressed state")
+	}
+	if err := s.Redo(); err != nil {
+		t.Fatalf("redo: %v", err)
+	}
+	if !asm.Occurrences().Item(0).Suppressed() {
+		t.Error("redo should re-suppress the occurrence")
+	}
+}
+
+// TestGroundOccurrenceIsUndoable: grounding a component is one undo step (the grounded flag
+// round-trips through the recipe).
+func TestGroundOccurrenceIsUndoable(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	trackFromHere(s) // baseline: placed, not grounded
+
+	if err := s.ToggleOccurrenceGrounded(asm.Occurrences().Item(0)); err != nil {
+		t.Fatalf("ground: %v", err)
+	}
+	if !asm.Occurrences().Item(0).Grounded() {
+		t.Fatal("toggle did not ground the occurrence")
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if asm.Occurrences().Item(0).Grounded() {
+		t.Error("undo should release the occurrence")
+	}
+}
+
+// TestDeleteOccurrenceIsUndoable: deleting a component removes it and clears the selection; undo
+// restores it through the assembly recipe (#764).
+func TestDeleteOccurrenceIsUndoable(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	s.selection.Add(OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+	trackFromHere(s) // baseline: one occurrence placed
+
+	if err := s.DeleteOccurrence(asm.Occurrences().Item(0)); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 0 {
+		t.Fatalf("after delete: occurrence count = %d, want 0", got)
+	}
+	if s.Selection().Count() != 0 {
+		t.Error("delete should clear the selection (the node is gone)")
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Errorf("undo should restore the occurrence: count = %d, want 1", got)
+	}
+}
+
+// TestOccurrenceActionsRejectNonAssembly: the occurrence actions error on a part document (no
+// active assembly), rather than mutating the wrong content.
+func TestOccurrenceActionsRejectNonAssembly(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if err := s.SuppressOccurrence(nil, true); err == nil {
+		t.Error("SuppressOccurrence on a part should error")
+	}
+	if err := s.DeleteOccurrence(nil); err == nil {
+		t.Error("DeleteOccurrence on a part should error")
+	}
+}
+
+// TestOccurrenceHandleSelectionKind pins the new selection kind.
+func TestOccurrenceHandleSelectionKind(t *testing.T) {
+	if got := (OccurrenceHandle{}).SelectionKind(); got != SelectOccurrence {
+		t.Errorf("OccurrenceHandle kind = %d, want SelectOccurrence", got)
+	}
+}

--- a/app/selection.go
+++ b/app/selection.go
@@ -5,6 +5,7 @@ package app
 import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
 )
 
@@ -25,6 +26,7 @@ const (
 	SelectWorkPoint
 	SelectWorkAxis
 	SelectPath
+	SelectOccurrence
 )
 
 // Selectable is anything the selection set can hold. Concrete handles wrap the
@@ -77,6 +79,13 @@ func (PathHandle) SelectionKind() SelectionKind { return SelectPath }
 type SketchEntityHandle struct{ Entity sketch.Entity }
 
 func (SketchEntityHandle) SelectionKind() SelectionKind { return SelectSketchEntity }
+
+// OccurrenceHandle wraps a placed component occurrence (selected in the assembly browser or, once
+// viewport occurrence picking lands in #769, by clicking its body). It is the input the assembly
+// occurrence operations (ground/suppress/delete, and the replication commands in #765) consume.
+type OccurrenceHandle struct{ Occurrence *occurrence.Occurrence }
+
+func (OccurrenceHandle) SelectionKind() SelectionKind { return SelectOccurrence }
 
 // SketchHandle wraps a whole sketch (selected in the browser), as opposed to one of its
 // entities — the input for Edit Sketch and for highlighting the sketch in the view.


### PR DESCRIPTION
## What
Make placed components visible and manageable in the model browser, and give the selection set an occurrence kind.

- **selection**: `OccurrenceHandle` / `SelectOccurrence` — a placed occurrence can now enter the selection set (the input the replication commands #765 and viewport occurrence picking #769 consume).
- **browser**: `BuildBrowser` now handles an assembly document — a Parameters folder plus one selectable row per occurrence (sub-assembly occurrences nest their own), the row label annotating grounded / suppressed state so the text tree is self-describing.
- **occurrence actions** (undoable): `Session.SuppressOccurrence` / `GroundOccurrence` / `DeleteOccurrence` (+ `Toggle*` for the menu), routed through the model's vetoable operations and recorded as recipe deltas, so undo/redo round-trip the state.
- **browser menu**: an occurrence row offers Ground/Unground, Suppress/Unsuppress, Delete — labels reflect current state.

The head renders all of this through its existing generic selectable-node + right-click-menu path, so there is **no head change**.

## Why
M11 feature-completeness: until now an assembly's browser was empty and there was no UI to ground/suppress/delete a component. This is also the keystone that unblocks Pattern/Mirror/Copy (#765) and viewport occurrence picking (#769), both of which need an occurrence in the selection set.

## Tests
- `TestAssemblyBrowserListsOccurrences` — a placed component shows as a selectable `OccurrenceHandle` row.
- `TestOccurrenceLabelReflectsState` — label suffixes for grounded/suppressed.
- `TestOccurrenceMenuTogglesLabels` — Ground/Suppress/Delete, labels flip with state.
- `TestSuppressOccurrenceIsUndoable` / `TestGroundOccurrenceIsUndoable` / `TestDeleteOccurrenceIsUndoable` — each is one undo step round-tripping through the assembly recipe.
- `TestOccurrenceActionsRejectNonAssembly`, `TestOccurrenceHandleSelectionKind`.

`go test ./app/...` green (incl. `-race`); `golangci-lint run ./app/...` 0 issues; head builds with cgo.

Part of M11 (Assembly Modeling & Instancing). Closes #764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)