### PR TITLE
feat: Pattern / Mirror / Copy component commands (#765)

### DIFF
--- a/addin/router/assembly_replication.go
+++ b/addin/router/assembly_replication.go
@@ -54,7 +54,7 @@ func assemblyPatternCreate(s *app.Session, raw json.RawMessage) (json.RawMessage
 		return nil, err
 	}
 	pat := occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr)
-	return newOccurrencesReply(patternOccurrences(asm, seed, pat))
+	return newOccurrencesReply(occurrence.PatternComponents(asm.Occurrences(), seed, pat))
 }
 
 // assemblyMirror adds a mirror of each source occurrence across the plane (origin, normal).
@@ -221,17 +221,6 @@ func assemblySubstitute(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 	}
 	sub := occurrence.Substitute(asm.Occurrences(), sources, in.Name, def, matrixFromWire(in.Transform))
 	return occurrenceReply(sub)
-}
-
-// patternOccurrences places a real occurrence for each pattern element beyond the seed
-// (element 0 is the seed, already placed), reusing the pattern's arrangement placements.
-func patternOccurrences(asm *compdef.AssemblyComponentDefinition, seed *occurrence.Occurrence, pat *occurrence.OccurrencePattern) []*occurrence.Occurrence {
-	created := make([]*occurrence.Occurrence, 0, pat.Count())
-	for i := 1; i < pat.Count(); i++ {
-		name := fmt.Sprintf("%s-p%d", seed.Name(), i+1)
-		created = append(created, asm.Place(name, seed.Definition(), pat.Element(i).Transform()))
-	}
-	return created
 }
 
 // arrangementFromArgs builds the pattern arrangement from the request's kind + parameters.

--- a/app/assembly_replication_tools.go
+++ b/app/assembly_replication_tools.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// The assembly replication tools (M11, #765) replicate placed component occurrences picked in
+// the browser (OccurrenceHandle) into real placed copies: a rectangular/circular pattern of a
+// seed, a mirror across a plane, and an independent copy. They gather the source occurrence(s) +
+// parameters and apply the occurrence-level op on Commit; the geometry lives in
+// model/occurrence and is tested there, so these are interaction shells driven headlessly here.
+// Parameters are edited through the generic tool-param dialog (Params), so no head dialog is
+// needed — the same seam the part pattern tools use.
+
+// occurrenceSelectTool collects the source occurrences a replication op acts on. It seeds itself
+// from any pre-selected occurrences on Start (select-then-command), and accepts further picks
+// while active.
+type occurrenceSelectTool struct {
+	sources []*occurrence.Occurrence
+}
+
+// Start seeds the sources from the current selection so "select a component, click Pattern" works
+// without re-picking.
+func (t *occurrenceSelectTool) Start(s *Session) {
+	for _, it := range s.Selection().Items() {
+		if h, ok := it.(OccurrenceHandle); ok && h.Occurrence != nil {
+			t.sources = append(t.sources, h.Occurrence)
+		}
+	}
+}
+
+// Pick collects an occurrence pick (an OccurrenceHandle from the browser or, once #769 lands, the
+// viewport).
+func (t *occurrenceSelectTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(OccurrenceHandle); ok && h.Occurrence != nil {
+		t.sources = append(t.sources, h.Occurrence)
+	}
+}
+
+func (t *occurrenceSelectTool) Cancel(*Session) { t.sources = nil }
+
+// assembly resolves the active assembly and asserts a source was selected, erroring with op's
+// name otherwise.
+func (t *occurrenceSelectTool) assembly(s *Session, op string) (*compdef.AssemblyComponentDefinition, error) {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(t.sources) == 0 {
+		return nil, errors.New(op + ": select a component first")
+	}
+	return asm, nil
+}
+
+// --- Rectangular pattern --------------------------------------------------
+
+// AssemblyRectPatternTool patterns the seed occurrence on a grid: count1 columns along +X spaced
+// spacing1, count2 rows along +Y spaced spacing2.
+type AssemblyRectPatternTool struct {
+	occurrenceSelectTool
+	count1, count2     int
+	spacing1, spacing2 float64
+}
+
+// NewAssemblyRectPatternTool returns a 2×1 grid at 2 cm spacing, ready to edit.
+func NewAssemblyRectPatternTool() *AssemblyRectPatternTool {
+	return &AssemblyRectPatternTool{count1: 2, count2: 1, spacing1: 2, spacing2: 2}
+}
+func (t *AssemblyRectPatternTool) Name() string { return "Rectangular Pattern" }
+func (t *AssemblyRectPatternTool) Prompt(*Session) string {
+	return "Select a component, set the counts and spacing, then OK."
+}
+
+// CanCommit needs a seed and a grid that produces at least one copy beyond the seed.
+func (t *AssemblyRectPatternTool) CanCommit() bool {
+	return len(t.sources) > 0 && t.count1 >= 1 && t.count2 >= 1 && t.count1*t.count2 > 1
+}
+
+func (t *AssemblyRectPatternTool) Commit(s *Session) error {
+	asm, err := t.assembly(s, "rectangular pattern")
+	if err != nil {
+		return err
+	}
+	dir1, _ := math.NewUnitVector3(1, 0, 0) // axis literals are unit by construction; the error is unreachable
+	dir2, _ := math.NewUnitVector3(0, 1, 0)
+	seed := t.sources[0]
+	arr := occurrence.RectangularArrangement{
+		Dir1: dir1, Spacing1: math.Scalar(t.spacing1), Count1: t.count1,
+		Dir2: dir2, Spacing2: math.Scalar(t.spacing2), Count2: t.count2,
+	}
+	occurrence.PatternComponents(asm.Occurrences(), seed, occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr))
+	s.recordEdit(asm, "Rectangular Pattern")
+	return nil
+}
+
+func (t *AssemblyRectPatternTool) Params() ToolParams {
+	return ToolParams{
+		Ints: []IntParam{
+			{"Count X", func() int { return t.count1 }, func(n int) { t.count1 = n }},
+			{"Count Y", func() int { return t.count2 }, func(n int) { t.count2 = n }},
+		},
+		Floats: []FloatParam{
+			{"Spacing X", func() float64 { return t.spacing1 }, func(v float64) { t.spacing1 = v }},
+			{"Spacing Y", func() float64 { return t.spacing2 }, func(v float64) { t.spacing2 = v }},
+		},
+	}
+}
+
+// --- Circular pattern -----------------------------------------------------
+
+// AssemblyCircPatternTool patterns the seed occurrence around the Z axis: count copies evenly
+// spread over totalAngle (radians); a full ring uses 2π.
+type AssemblyCircPatternTool struct {
+	occurrenceSelectTool
+	count      int
+	totalAngle float64
+}
+
+// NewAssemblyCircPatternTool returns a 4-up full ring, ready to edit.
+func NewAssemblyCircPatternTool() *AssemblyCircPatternTool {
+	return &AssemblyCircPatternTool{count: 4, totalAngle: 2 * 3.141592653589793} // full ring (2π)
+}
+func (t *AssemblyCircPatternTool) Name() string { return "Circular Pattern" }
+func (t *AssemblyCircPatternTool) Prompt(*Session) string {
+	return "Select a component, set the count and angle, then OK."
+}
+func (t *AssemblyCircPatternTool) CanCommit() bool { return len(t.sources) > 0 && t.count >= 2 }
+
+func (t *AssemblyCircPatternTool) Commit(s *Session) error {
+	asm, err := t.assembly(s, "circular pattern")
+	if err != nil {
+		return err
+	}
+	axis, _ := math.NewUnitVector3(0, 0, 1)
+	seed := t.sources[0]
+	arr := occurrence.CircularArrangement{
+		Origin: math.P3(0, 0, 0), Axis: axis,
+		Step:  math.Scalar(t.totalAngle / float64(t.count)), // evenly distribute count over the sweep
+		Count: t.count,
+	}
+	occurrence.PatternComponents(asm.Occurrences(), seed, occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr))
+	s.recordEdit(asm, "Circular Pattern")
+	return nil
+}
+
+func (t *AssemblyCircPatternTool) Params() ToolParams {
+	return ToolParams{
+		Ints: []IntParam{{"Count", func() int { return t.count }, func(n int) { t.count = n }}},
+		Floats: []FloatParam{{
+			"Angle (deg)", func() float64 { return degFromRad(t.totalAngle) },
+			func(d float64) { t.totalAngle = radFromDeg(d) },
+		}},
+	}
+}
+
+// --- Mirror ---------------------------------------------------------------
+
+// AssemblyMirrorTool adds a mirror of each selected occurrence across the plane through the origin
+// with the given normal (default the YZ plane, normal +X). Each mirror shares its source's
+// component, handed by the reflection transform (an independent mirrored part is M11-F06).
+type AssemblyMirrorTool struct {
+	occurrenceSelectTool
+	normalX, normalY, normalZ float64
+}
+
+// NewAssemblyMirrorTool mirrors across the YZ plane by default.
+func NewAssemblyMirrorTool() *AssemblyMirrorTool {
+	return &AssemblyMirrorTool{normalX: 1}
+}
+func (t *AssemblyMirrorTool) Name() string { return "Mirror" }
+func (t *AssemblyMirrorTool) Prompt(*Session) string {
+	return "Select components, set the mirror-plane normal, then OK."
+}
+
+func (t *AssemblyMirrorTool) CanCommit() bool {
+	return len(t.sources) > 0 && (t.normalX != 0 || t.normalY != 0 || t.normalZ != 0)
+}
+
+func (t *AssemblyMirrorTool) Commit(s *Session) error {
+	asm, err := t.assembly(s, "mirror")
+	if err != nil {
+		return err
+	}
+	normal, err := math.NewUnitVector3(t.normalX, t.normalY, t.normalZ)
+	if err != nil {
+		return fmt.Errorf("mirror: normal (%g, %g, %g) is not a direction: %w", t.normalX, t.normalY, t.normalZ, err)
+	}
+	occurrence.MirrorComponents(asm.Occurrences(), t.sources, math.P3(0, 0, 0), normal)
+	s.recordEdit(asm, "Mirror Components")
+	return nil
+}
+
+func (t *AssemblyMirrorTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{"Normal X", func() float64 { return t.normalX }, func(v float64) { t.normalX = v }},
+		{"Normal Y", func() float64 { return t.normalY }, func(v float64) { t.normalY = v }},
+		{"Normal Z", func() float64 { return t.normalZ }, func(v float64) { t.normalZ = v }},
+	}}
+}
+
+// --- Copy -----------------------------------------------------------------
+
+// CopyComponents adds an independent copy of each currently-selected occurrence — same component
+// and placement, a new unlinked instance. Unlike Pattern/Mirror it needs no parameters, so it
+// runs immediately on the selection (Inventor's Copy), erroring when nothing is selected.
+func (s *Session) CopyComponents() error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	sources := selectedOccurrences(s)
+	if len(sources) == 0 {
+		return errors.New("copy: select a component to copy first")
+	}
+	occurrence.CopyComponents(asm.Occurrences(), sources)
+	s.recordEdit(asm, "Copy Components")
+	return nil
+}
+
+// selectedOccurrences returns the occurrences in the current selection set, in selection order.
+func selectedOccurrences(s *Session) []*occurrence.Occurrence {
+	var out []*occurrence.Occurrence
+	for _, it := range s.Selection().Items() {
+		if h, ok := it.(OccurrenceHandle); ok && h.Occurrence != nil {
+			out = append(out, h.Occurrence)
+		}
+	}
+	return out
+}

--- a/app/assembly_replication_tools_test.go
+++ b/app/assembly_replication_tools_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestCopyComponentsAddsIndependentCopy: with one component selected, Copy adds a second
+// occurrence (same component, "-copy" suffix) and the add is one undo step (#765).
+func TestCopyComponentsAddsIndependentCopy(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	s.selection.Add(OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+	trackFromHere(s)
+
+	if err := s.CopyComponents(); err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 2 {
+		t.Fatalf("after Copy: occurrence count = %d, want 2", got)
+	}
+	if name := asm.Occurrences().Item(1).Name(); name != "widget:1-copy" {
+		t.Errorf("copy name = %q, want widget:1-copy", name)
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Errorf("undo should remove the copy: count = %d, want 1", got)
+	}
+}
+
+// TestCopyComponentsRequiresSelection: Copy with nothing selected errors rather than no-op.
+func TestCopyComponentsRequiresSelection(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	if err := s.CopyComponents(); err == nil {
+		t.Error("Copy with no occurrence selected should error")
+	}
+}
+
+// TestRectPatternPlacesGrid: a 2×2 rectangular pattern of the seed adds 3 occurrences (the seed
+// is element 0,0), for 4 total, in one undo step.
+func TestRectPatternPlacesGrid(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	trackFromHere(s)
+
+	tool := NewAssemblyRectPatternTool()
+	tool.Pick(s, OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+	tool.count1, tool.count2 = 2, 2
+	tool.spacing1, tool.spacing2 = 3, 3
+	if !tool.CanCommit() {
+		t.Fatal("a 2×2 pattern with a seed should be committable")
+	}
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 4 {
+		t.Fatalf("2×2 pattern: occurrence count = %d, want 4", got)
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 1 {
+		t.Errorf("one undo should remove all pattern copies: count = %d, want 1", got)
+	}
+}
+
+// TestCircPatternPlacesRing: a count-4 circular pattern adds 3 occurrences (the seed is element
+// 0), for 4 total.
+func TestCircPatternPlacesRing(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+
+	tool := NewAssemblyCircPatternTool() // count 4 default
+	tool.Pick(s, OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+	if !tool.CanCommit() {
+		t.Fatal("a 4-up ring with a seed should be committable")
+	}
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 4 {
+		t.Errorf("4-up ring: occurrence count = %d, want 4", got)
+	}
+}
+
+// TestMirrorComponentsAddsMirror: Mirror adds one mirrored occurrence (the "-mirror" suffix) per
+// source.
+func TestMirrorComponentsAddsMirror(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+
+	tool := NewAssemblyMirrorTool() // normal +X
+	tool.Pick(s, OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+	if !tool.CanCommit() {
+		t.Fatal("a mirror with a source and a nonzero normal should be committable")
+	}
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if got := asm.Occurrences().Count(); got != 2 {
+		t.Fatalf("mirror: occurrence count = %d, want 2", got)
+	}
+	if name := asm.Occurrences().Item(1).Name(); name != "widget:1-mirror" {
+		t.Errorf("mirror name = %q, want widget:1-mirror", name)
+	}
+}
+
+// TestMirrorRejectsZeroNormal: a degenerate (zero) mirror-plane normal is not committable and
+// errors on commit rather than placing a bogus reflection.
+func TestMirrorRejectsZeroNormal(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	tool := NewAssemblyMirrorTool()
+	tool.Pick(s, OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+	tool.normalX, tool.normalY, tool.normalZ = 0, 0, 0
+	if tool.CanCommit() {
+		t.Error("a zero normal should block commit")
+	}
+	if err := tool.Commit(s); err == nil {
+		t.Error("commit with a zero normal should error")
+	}
+}
+
+// TestReplicationToolSeedsFromSelection: starting a tool with a component pre-selected adopts it
+// as the source, so "select then Pattern" needs no re-pick.
+func TestReplicationToolSeedsFromSelection(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	s.selection.Add(OccurrenceHandle{Occurrence: asm.Occurrences().Item(0)})
+
+	tool := NewAssemblyRectPatternTool()
+	tool.Start(s)
+	if len(tool.sources) != 1 {
+		t.Fatalf("Start adopted %d sources from the selection, want 1", len(tool.sources))
+	}
+}
+
+// TestReplicationToolsRequireSeed: a pattern with no source errors on commit (the active-assembly
+// + non-empty-source gate).
+func TestReplicationToolsRequireSeed(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	tool := NewAssemblyCircPatternTool() // no Pick, no selection
+	if err := tool.Commit(s); err == nil {
+		t.Error("a pattern with no selected component should error on commit")
+	}
+}

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -16,11 +16,35 @@ import "fmt"
 func assemblyTabCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		placeComponentCommand(),
-		assemblyStubCommand("Assembly.Pattern", "Pattern", "Pattern", 765),
-		assemblyStubCommand("Assembly.Mirror", "Mirror", "Pattern", 765),
-		assemblyStubCommand("Assembly.Copy", "Copy", "Pattern", 765),
+		assemblyToolCommand("Assembly.RectangularPattern", "Rectangular Pattern", "rectangular-pattern",
+			"Rectangular Pattern — replicate the selected component on a grid (counts and spacing).",
+			func() Tool { return NewAssemblyRectPatternTool() }),
+		assemblyToolCommand("Assembly.CircularPattern", "Circular Pattern", "circular-pattern",
+			"Circular Pattern — replicate the selected component around the Z axis (count and angle).",
+			func() Tool { return NewAssemblyCircPatternTool() }),
+		assemblyToolCommand("Assembly.Mirror", "Mirror", "mirror",
+			"Mirror — add a mirror of the selected components across a plane.",
+			func() Tool { return NewAssemblyMirrorTool() }),
+		NewCommand("Assembly.Copy", "Copy", "Pattern", func(s *Session) error { return s.CopyComponents() }).
+			WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasActiveAssembly).
+			WithIcon("copy").WithButtonStyle(SmallIconButton).
+			WithTooltip("Copy — add an independent copy of each selected component."),
 		assemblyStubCommand("Assembly.BOM", "Bill of Materials", "BOM", 768),
 	}
+}
+
+// assemblyToolCommand builds an Assemble-tab command that starts a replication tool on the active
+// assembly. The tool seeds its sources from the current selection and reads the rest from the
+// generic tool-param dialog (#765).
+func assemblyToolCommand(id, name, icon, tooltip string, newTool func() Tool) *CommandDefinition {
+	return NewCommand(id, name, "Pattern", func(s *Session) error {
+		if _, err := activeAssembly(s); err != nil {
+			return err
+		}
+		s.StartTool(newTool())
+		return nil
+	}).WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasActiveAssembly).
+		WithIcon(icon).WithButtonStyle(SmallIconButton).WithTooltip(tooltip)
 }
 
 // placeComponentCommand builds the Place command: it starts the modal Place Component tool on

--- a/model/occurrence/ops.go
+++ b/model/occurrence/ops.go
@@ -2,11 +2,20 @@
 
 package occurrence
 
-import "oblikovati.org/math"
+import (
+	"fmt"
 
-// Assembly-level replication ops (M11-F04, PBI-122): mirror, copy, and substitute
+	"oblikovati.org/math"
+)
+
+// Assembly-level replication ops (M11-F04, PBI-122): mirror, copy, pattern, and substitute
 // operate on an [Occurrences] collection, sharing the placed definitions (the
 // flyweight) and reusing the collection's id minting.
+//
+// The additive ops (mirror, copy, pattern) carry the source's componentName onto each new
+// occurrence: a replica references the SAME component document as its source, so it persists
+// and re-binds on reopen exactly like the source (and an undo records it). Without that name
+// the replica would be an in-memory-only placement the recipe drops (#765).
 
 // MirrorComponents adds a mirror of each source occurrence to dst, reflected across
 // the plane (origin, normal). Each mirror shares its source's definition but is placed
@@ -21,7 +30,7 @@ func MirrorComponents(dst *Occurrences, sources []*Occurrence, origin math.Point
 	out := make([]*Occurrence, 0, len(sources))
 	for _, s := range sources {
 		mirrored := reflect.Mul(s.Transform())
-		out = append(out, dst.AddByComponentDefinition(s.name+"-mirror", s.definition, mirrored))
+		out = append(out, dst.AddByComponentName(s.name+"-mirror", s.definition, s.componentName, mirrored))
 	}
 	return out
 }
@@ -32,7 +41,20 @@ func MirrorComponents(dst *Occurrences, sources []*Occurrence, origin math.Point
 func CopyComponents(dst *Occurrences, sources []*Occurrence) []*Occurrence {
 	out := make([]*Occurrence, 0, len(sources))
 	for _, s := range sources {
-		out = append(out, dst.AddByComponentDefinition(s.name+"-copy", s.definition, s.transform))
+		out = append(out, dst.AddByComponentName(s.name+"-copy", s.definition, s.componentName, s.transform))
+	}
+	return out
+}
+
+// PatternComponents places a real occurrence for each pattern element beyond the seed (element 0
+// is the seed, already in dst), naming them "<seed>-pN" and sharing the seed's component. Returns
+// the placed occurrences in element order. It is the shared placement step behind the assembly
+// pattern command and the wire pattern method, so both produce persistable occurrences.
+func PatternComponents(dst *Occurrences, seed *Occurrence, pat *OccurrencePattern) []*Occurrence {
+	out := make([]*Occurrence, 0, pat.Count())
+	for i := 1; i < pat.Count(); i++ {
+		name := fmt.Sprintf("%s-p%d", seed.name, i+1)
+		out = append(out, dst.AddByComponentName(name, seed.definition, seed.componentName, pat.Element(i).Transform()))
 	}
 	return out
 }

--- a/model/occurrence/ops_test.go
+++ b/model/occurrence/ops_test.go
@@ -45,6 +45,34 @@ func TestCopyComponentsAreIndependentInstances(t *testing.T) {
 	}
 }
 
+// TestReplicasInheritComponentName is the #765 regression: a copy/mirror/pattern element must
+// carry the source's componentName, so it persists and re-binds on reopen exactly like the source
+// (the assembly recipe drops a nameless, in-memory-only placement, which also made replicas
+// un-undoable). Source placed with a component name; every replica must keep it.
+func TestReplicasInheritComponentName(t *testing.T) {
+	asm := NewOccurrences()
+	src := asm.AddByComponentName("widget:1", unitComponent(), "widget.obk", math.Identity4())
+
+	copies := CopyComponents(asm, []*Occurrence{src})
+	if got := copies[0].ComponentName(); got != "widget.obk" {
+		t.Errorf("copy componentName = %q, want widget.obk", got)
+	}
+	mirrors := MirrorComponents(asm, []*Occurrence{src}, math.P3(0, 0, 0), unitX(t))
+	if got := mirrors[0].ComponentName(); got != "widget.obk" {
+		t.Errorf("mirror componentName = %q, want widget.obk", got)
+	}
+	pat := NewOccurrencePattern(src.Definition(), src.Transform(), RectangularArrangement{
+		Dir1: unitX(t), Spacing1: 2, Count1: 2, Dir2: unitX(t), Spacing2: 0, Count2: 1,
+	})
+	elems := PatternComponents(asm, src, pat)
+	if len(elems) != 1 {
+		t.Fatalf("2×1 pattern placed %d occurrences beyond the seed, want 1", len(elems))
+	}
+	if got := elems[0].ComponentName(); got != "widget.obk" {
+		t.Errorf("pattern element componentName = %q, want widget.obk", got)
+	}
+}
+
 // TestSubstituteSwapsInSimplifiedRep is the PBI-122 substitution acceptance: the
 // detailed sources are suppressed and a simplified representation stands in for them.
 func TestSubstituteSwapsInSimplifiedRep(t *testing.T) {


### PR DESCRIPTION
## What
Replace the Assemble-tab **Pattern / Mirror / Copy** stubs (which errored) with real occurrence-replication commands:

- **Rectangular Pattern** / **Circular Pattern** / **Mirror** — interactive tools that seed their source from the selected component (or further picks) and read their arrangement (counts/spacing, count/angle, plane normal) from the **generic tool-param dialog** — so no head dialog is needed, the same seam the part pattern tools use.
- **Copy** — runs immediately on the selection (Inventor's Copy), adding an independent instance of each selected component.

Each replicates through the `model/occurrence` ops and records **one undo step**.

## Latent persistence/undo bug fixed
While wiring these I found the replication ops created occurrences with an **empty component name** (`AddByComponentDefinition`), so `occurrencesRecipe` dropped them — the replicas **neither survived save/load nor undo**. They now carry the source's component name (a replica references the *same* component document), so they persist, re-bind on reopen, and undo as one step. This also fixes the **wire path** (`assembly.copy` / `assembly.mirror` / `assembly.patternCreate`), which shares the same ops.

The pattern-placement loop, previously duplicated between the app tool and the router, is extracted into `occurrence.PatternComponents` so both call one place.

## Tests
- app: `TestCopyComponentsAddsIndependentCopy` (+ undo), `TestRectPatternPlacesGrid` (2×2 → 4, one undo removes all), `TestCircPatternPlacesRing`, `TestMirrorComponentsAddsMirror`, `TestMirrorRejectsZeroNormal`, `TestReplicationToolSeedsFromSelection`, `TestReplicationToolsRequireSeed`, `TestCopyComponentsRequiresSelection`.
- model: `TestReplicasInheritComponentName` — copy/mirror/pattern element each keep the source's component name (the regression guard).

`go test ./app/... ./model/occurrence/... ./addin/router/...` green (incl. `-race`); `golangci-lint` 0 issues; head builds + icon-resolve test passes (reuses existing pattern/mirror/copy glyphs).

Part of M11 (Assembly Modeling & Instancing). Closes #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)