### PR TITLE
feat: assembly viewport rendering + occurrence picking (#769)

### DIFF
--- a/app/assembly_render.go
+++ b/app/assembly_render.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// Assembly viewport geometry (#769): an assembly renders its placed components by transforming
+// each occurrence's component body into assembly space. The same world-space bodies feed the
+// renderer, the ray-picker (face/edge/occurrence hit-test), and view-fitting — so wiring them
+// once through VisibleBodies lights up rendering AND picking for assemblies, which were
+// previously invisible (VisibleBodies was part-only).
+//
+// Transforming a body re-derives its geometry (ops.TransformBody), so the result is cached and
+// only rebuilt when the occurrence structure changes (placement, suppression, add/remove — all
+// bump occurrences.Revision). The cache returns STABLE *topo.Body pointers between rebuilds, so
+// the head's per-body tessellation cache keeps hitting.
+
+// assemblyBodyCache memoizes the active assembly's world-space bodies and the occurrence each
+// came from (for occurrence picking), keyed on the assembly and its occurrence revision.
+type assemblyBodyCache struct {
+	asm      *compdef.AssemblyComponentDefinition
+	revision uint64
+	bodies   []*topo.Body
+	owner    map[*topo.Body]*occurrence.Occurrence
+}
+
+// worldAssemblyBodies returns asm's unsuppressed placed bodies transformed into assembly space,
+// rebuilding the cache when the occurrence structure changed. A component placed at several
+// occurrences yields independent bodies (distinct lineage prefixes), so picking tells the
+// instances apart.
+func (s *Session) worldAssemblyBodies(asm *compdef.AssemblyComponentDefinition) []*topo.Body {
+	rev := asm.Occurrences().Revision()
+	if s.asmBodies.asm == asm && s.asmBodies.revision == rev && s.asmBodies.bodies != nil {
+		return s.asmBodies.bodies
+	}
+	placed := asm.PlacedBodies()
+	bodies := make([]*topo.Body, 0, len(placed))
+	owner := make(map[*topo.Body]*occurrence.Occurrence, len(placed))
+	for i, pb := range placed {
+		world, err := ops.TransformBody(pb.Body, pb.Transform, occurrenceBodyLineage(i))
+		if err != nil {
+			s.notice = "assembly render: " + err.Error()
+			continue
+		}
+		bodies = append(bodies, world)
+		owner[world] = pb.Source
+	}
+	s.asmBodies = assemblyBodyCache{asm: asm, revision: rev, bodies: bodies, owner: owner}
+	return bodies
+}
+
+// OccurrenceOfBody returns the occurrence a world-space assembly body was placed from, for the
+// ray-picker to resolve a body hit to its component (occurrence-level selection). It reads the
+// cache worldAssemblyBodies built, so it is only valid for bodies from the current frame's set.
+func (s *Session) OccurrenceOfBody(b *topo.Body) (*occurrence.Occurrence, bool) {
+	o, ok := s.asmBodies.owner[b]
+	return o, ok
+}
+
+// occurrenceBodyLineage gives each placed body a distinct lineage prefix by occurrence index, so
+// the same component placed at several occurrences yields independent reference keys (the
+// derived-assembly flatten uses the same scheme).
+func occurrenceBodyLineage(index int) func(topo.Lineage) topo.Lineage {
+	prefix := topo.Tok("occurrence", "occ", index)
+	return func(l topo.Lineage) topo.Lineage {
+		return topo.NewLineage(append([]topo.LineageToken{prefix}, l.Tokens()...)...)
+	}
+}

--- a/app/assembly_render_test.go
+++ b/app/assembly_render_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+	"oblikovati.org/scene"
+)
+
+// assemblyWithBoxComponent builds a box part [0,2]×[0,2]×[0,4] and places it into a fresh
+// assembly at +10 on X, returning the session (assembly active), the assembly definition, and the
+// placed occurrence — the fixture for the viewport rendering + picking tests (#769).
+func assemblyWithBoxComponent(t *testing.T, tx float64) (*Session, *compdef.AssemblyComponentDefinition, *occurrence.Occurrence) {
+	t.Helper()
+	s := extrudedBox(t, 2, 4) // active part = box [0,2]×[0,2]×[0,4]
+	boxDoc := s.ActiveDocument()
+	asmDoc, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(asmDoc); err != nil {
+		t.Fatalf("activate assembly: %v", err)
+	}
+	asm := asmDoc.Content().(*compdef.AssemblyComponentDefinition)
+	occ, err := asm.PlaceComponentFromFile(asmDoc, boxDoc, "box:1", math.Translation4(math.V3(math.Scalar(tx), 0, 0)))
+	if err != nil {
+		t.Fatalf("place box: %v", err)
+	}
+	return s, asm, occ
+}
+
+// TestVisibleBodiesTransformsPlacedComponents: an assembly's VisibleBodies are its components
+// transformed into assembly space — a box placed at +10 on X has its range box shifted there, so
+// the viewport (and picker) see the placed geometry, not the component at its own origin (#769).
+func TestVisibleBodiesTransformsPlacedComponents(t *testing.T) {
+	s, _, _ := assemblyWithBoxComponent(t, 10)
+
+	bodies := s.VisibleBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("assembly VisibleBodies = %d, want 1 placed component body", len(bodies))
+	}
+	rb := bodies[0].RangeBox()
+	if got := float64(rb.Min.X); got < 9.99 || got > 10.01 {
+		t.Errorf("placed body min X = %g, want 10 (box origin 0 + placement 10)", got)
+	}
+	if got := float64(rb.Max.X); got < 11.99 || got > 12.01 {
+		t.Errorf("placed body max X = %g, want 12 (10 + 2 side)", got)
+	}
+	if got := float64(rb.Max.Z); got < 3.99 || got > 4.01 {
+		t.Errorf("placed body max Z = %g, want 4 (the extrude height, unmoved on Z)", got)
+	}
+}
+
+// TestVisibleBodiesEmptyForUnplacedAssembly: an assembly with no components renders nothing.
+func TestVisibleBodiesEmptyForUnplacedAssembly(t *testing.T) {
+	s := NewSession()
+	asmDoc, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	_ = s.Workspace().SetActiveDocument(asmDoc)
+	if got := len(s.VisibleBodies()); got != 0 {
+		t.Errorf("empty assembly VisibleBodies = %d, want 0", got)
+	}
+}
+
+// TestOccurrenceOfBodyMapsBackToComponent: each world-space assembly body resolves to the
+// occurrence it was placed from, so a viewport click on a component selects that occurrence.
+func TestOccurrenceOfBodyMapsBackToComponent(t *testing.T) {
+	s, _, occ := assemblyWithBoxComponent(t, 10)
+	bodies := s.VisibleBodies()
+	got, ok := s.OccurrenceOfBody(bodies[0])
+	if !ok || got != occ {
+		t.Errorf("OccurrenceOfBody = (%v, %v), want the placed occurrence", got, ok)
+	}
+}
+
+// TestAssemblyBodyCacheIsStableUntilEdited: VisibleBodies returns the SAME body pointers between
+// calls (so the head's per-body tessellation cache keeps hitting), and rebuilds when the
+// occurrence structure changes.
+func TestAssemblyBodyCacheIsStableUntilEdited(t *testing.T) {
+	s, asm, _ := assemblyWithBoxComponent(t, 10)
+	first := s.VisibleBodies()
+	second := s.VisibleBodies()
+	if len(first) != 1 || first[0] != second[0] {
+		t.Fatal("VisibleBodies should return cached, stable body pointers between unedited calls")
+	}
+	// Placing another component bumps the occurrence revision → the cache rebuilds with more bodies.
+	box2 := s.Workspace().Documents()[0] // the box part document
+	if _, err := asm.PlaceComponentFromFile(s.ActiveDocument(), box2, "box:2", math.Translation4(math.V3(20, 0, 0))); err != nil {
+		t.Fatalf("place second: %v", err)
+	}
+	if got := len(s.VisibleBodies()); got != 2 {
+		t.Errorf("after a second placement VisibleBodies = %d, want 2 (cache rebuilt)", got)
+	}
+}
+
+// TestViewportClickSelectsOccurrence: a click on a placed component's body selects the OCCURRENCE
+// by default (component-level selection), and a face-filtered pick yields the face instead — the
+// occurrence vs face precedence the picker resolves (#769).
+func TestViewportClickSelectsOccurrence(t *testing.T) {
+	s, _, occ := assemblyWithBoxComponent(t, 10)
+
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(11, 1, 20) // above the placed box (x∈[10,12], y∈[0,2]), looking down
+	cam.Target = math.P3(11, 1, 0)
+	cam.Up = math.V3(0, 1, 0)
+	picker := NewRayPicker(cam, func() []*topo.Body { return s.VisibleBodies() }).
+		WithOccurrenceLookup(s.OccurrenceOfBody)
+
+	// Default (all-accepting) filter: the whole component is selected.
+	sel, ok := picker.Pick(200, 200, NewSelectionFilter())
+	if !ok {
+		t.Fatal("a center click should hit the placed component")
+	}
+	oh, ok := sel.(OccurrenceHandle)
+	if !ok || oh.Occurrence != occ {
+		t.Fatalf("default click selected %T, want the OccurrenceHandle for box:1", sel)
+	}
+
+	// A face filter (what a machining tool sets) bypasses occurrence selection and picks the face.
+	faceSel, ok := picker.Pick(200, 200, NewSelectionFilter(SelectFace))
+	if !ok {
+		t.Fatal("a face-filtered click should hit the top cap")
+	}
+	if _, ok := faceSel.(FaceHandle); !ok {
+		t.Errorf("face-filtered click selected %T, want FaceHandle", faceSel)
+	}
+}

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/scene"
 )
@@ -19,13 +20,14 @@ import (
 // [Picker], so a test "clicks on" a modeled solid or a datum plane — screen coordinate
 // → ray → face/plane — with no GPU.
 type RayPicker struct {
-	camera     scene.Camera
-	bodies     func() []*topo.Body
-	planes     func() []*feature.WorkPlane
-	points     func() []*feature.WorkPoint
-	axes       func() []*feature.WorkAxis
-	sketches   func() []*sketch.Sketch
-	sketches3D func() []*sketch.Sketch3D
+	camera       scene.Camera
+	bodies       func() []*topo.Body
+	planes       func() []*feature.WorkPlane
+	points       func() []*feature.WorkPoint
+	axes         func() []*feature.WorkAxis
+	sketches     func() []*sketch.Sketch
+	sketches3D   func() []*sketch.Sketch3D
+	occurrenceOf func(*topo.Body) (*occurrence.Occurrence, bool) // maps an assembly body hit to its component (#769)
 }
 
 // pickPixelRadius is how close (in pixels) the cursor must be to a datum point or axis to
@@ -73,6 +75,14 @@ func (p *RayPicker) WithAxes(axes func() []*feature.WorkAxis) *RayPicker {
 	return p
 }
 
+// WithOccurrenceLookup adds a body→occurrence map so a click on an assembly component's body
+// resolves to that occurrence (component-level selection). Provided only for assemblies; without
+// it the picker behaves as the part-only hit-test (#769).
+func (p *RayPicker) WithOccurrenceLookup(lookup func(*topo.Body) (*occurrence.Occurrence, bool)) *RayPicker {
+	p.occurrenceOf = lookup
+	return p
+}
+
 // SetCamera updates the view used for picking.
 func (p *RayPicker) SetCamera(c scene.Camera) { p.camera = c }
 
@@ -88,6 +98,13 @@ func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, boo
 	}
 	var cands []pickCandidate
 	if face, body, t := p.nearestFace(origin, dir); face != nil {
+		// In an assembly a click selects the whole component by default, so the occurrence
+		// candidate is appended BEFORE the face — it wins the depth tie under an all-accepting
+		// filter. A machining tool that sets a face/edge filter excludes SelectOccurrence and so
+		// gets the face instead.
+		if occ, ok := p.occurrenceForBody(body, filter); ok {
+			cands = append(cands, pickCandidate{t, OccurrenceHandle{Occurrence: occ}})
+		}
 		if sel, ok := facePick(face, body, filter); ok {
 			cands = append(cands, pickCandidate{t, sel})
 		}
@@ -384,6 +401,15 @@ func (p *RayPicker) nearestPlane(origin math.Point3, dir math.Vector3) (*feature
 		}
 	}
 	return hit, best
+}
+
+// occurrenceForBody resolves a body hit to its component occurrence, when the picker has a
+// lookup (an assembly) and the filter accepts occurrence selection.
+func (p *RayPicker) occurrenceForBody(body *topo.Body, filter *SelectionFilter) (*occurrence.Occurrence, bool) {
+	if p.occurrenceOf == nil || !filter.Accepts(SelectOccurrence) {
+		return nil, false
+	}
+	return p.occurrenceOf(body)
 }
 
 // facePick wraps a face hit as the handle the filter wants (face or owning body),

--- a/app/render.go
+++ b/app/render.go
@@ -61,8 +61,15 @@ func (s *Session) RenderFrame(backend renderer.Backend) {
 // sceneBodies returns the bodies to draw — the active part's, if any.
 func (s *Session) sceneBodies() []*topo.Body { return s.VisibleBodies() }
 
-// VisibleBodies returns active-part bodies not hidden by browser visibility state.
+// VisibleBodies returns the bodies the viewport renders and the picker hit-tests for the active
+// document: a part's own bodies (minus those hidden by browser visibility state), or — for an
+// assembly — its placed components transformed into assembly space (#769). An assembly's
+// per-occurrence visibility is suppression, already applied when collecting placed bodies, so the
+// part hidden-body filter does not apply to it.
 func (s *Session) VisibleBodies() []*topo.Body {
+	if asm, err := activeAssembly(s); err == nil {
+		return s.worldAssemblyBodies(asm)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return nil

--- a/app/session.go
+++ b/app/session.go
@@ -107,6 +107,7 @@ type Session struct {
 	meshColors           bool                           // viewport mesh-debug-colors render (each face/triangle a distinct color)
 	meshColorsPerTri     bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
 	editScope            editScope                      // while editing a node, hide everything created after it (issue #132)
+	asmBodies            assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -210,7 +210,8 @@ func installPicker(s *app.Session) {
 			}
 			return activeSketches(s)
 		}).
-		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }))
+		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }).
+		WithOccurrenceLookup(s.OccurrenceOfBody))
 }
 
 // loadAppOptions wires the per-user options file (M05-F11) and applies the stored


### PR DESCRIPTION
## What
Make assemblies **visible and pickable** in the viewport. Until now an assembly rendered *nothing*: `Session.VisibleBodies()` — which feeds the renderer (`render.go`), the ray-picker (`installPicker`), and view-fitting — was **part-only** and returned `nil` for an assembly, so placed components were invisible and unpickable.

- `VisibleBodies()` is now assembly-aware: it returns the assembly's components transformed into assembly space (`ops.TransformBody` per placed body — the `worldBodies` pattern), which lights up **rendering AND face/edge picking** through the existing draw-list and hit-test paths with no new render code.
- The transformed bodies are **memoized** (`assemblyBodyCache`, keyed on the assembly + its occurrence revision), so they rebuild only when the structure changes and the head's per-body tessellation cache keeps hitting. Stable `*topo.Body` pointers between rebuilds. A component placed at several occurrences gets distinct lineage prefixes, so instances stay separable.
- **Occurrence-level selection**: the picker maps a body hit back to its occurrence (`OccurrenceOfBody`) and, under an all-accepting filter, selects the whole component (the occurrence wins the depth tie over its face) — Inventor's single-click-selects-component. A tool that sets a face/edge filter (assembly machining, #766) excludes occurrence selection and gets the face instead.

## Why
M11 feature-completeness keystone: an assembly you can't *see* is unusable, and this unblocks viewport interaction + assembly machining (#766).

## Tests (analytic gates)
- `TestVisibleBodiesTransformsPlacedComponents` — a box `[0,2]³…[0,4]` placed at +10 X has its range box at X∈[10,12], Z unchanged (the transform is correct, not the component at its own origin).
- `TestVisibleBodiesEmptyForUnplacedAssembly`, `TestOccurrenceOfBodyMapsBackToComponent`.
- `TestAssemblyBodyCacheIsStableUntilEdited` — same body pointers between calls; rebuilds (+1 body) after a second placement.
- `TestViewportClickSelectsOccurrence` — a center click selects the `OccurrenceHandle`; a face-filtered click yields the `FaceHandle` (the precedence).

`go test ./app/...` green; `golangci-lint` 0 issues; head builds + `head/ui` tests pass. Transformed-body tessellation is the same `TransformBody` path the volume-gated derive/shrinkwrap tests already cover.

Part of M11 (Assembly Modeling & Instancing). Closes #769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)