### PR TITLE
feat: BOM panel + CSV export (#768)

### DIFF
--- a/app/assembly_bom.go
+++ b/app/assembly_bom.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"os"
+
+	"oblikovati.org/model/bom"
+)
+
+// The Bill of Materials panel (#768): the Assemble ▸ Bill of Materials command opens a panel that
+// lists the active assembly's components in one of two standard views — Structured (the hierarchy,
+// sub-assemblies nested) or Parts Only (every unique part once with its total quantity) — and
+// exports the current view to CSV. The BOM itself (counting, grouping, CSV) is model/bom; this is
+// the head/app wiring around it.
+
+// OpenBOM / CloseBOM toggle the Bill of Materials panel; BOMPanelOpen reports its state (the head
+// draws the panel only when open).
+func (s *Session) OpenBOM()           { s.bomPanelOpen = true }
+func (s *Session) CloseBOM()          { s.bomPanelOpen = false }
+func (s *Session) BOMPanelOpen() bool { return s.bomPanelOpen }
+
+// BOMViewKind / SetBOMViewKind read and set which standard view the panel shows.
+func (s *Session) BOMViewKind() bom.ViewKind        { return s.bomViewKind }
+func (s *Session) SetBOMViewKind(kind bom.ViewKind) { s.bomViewKind = kind }
+
+// AssemblyBOM builds the active assembly's Bill of Materials in the currently selected view
+// (Structured or Parts Only), erroring when the active document is not an assembly.
+//
+//	view, err := session.AssemblyBOM()
+func (s *Session) AssemblyBOM() (*bom.View, error) {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	b := bom.New(asm.Occurrences())
+	if s.bomViewKind == bom.PartsOnlyView {
+		return b.PartsOnly(), nil
+	}
+	return b.Structured(), nil
+}
+
+// ExportBOMCSV writes the active assembly's BOM (current view, standard columns) to path as CSV —
+// the Export button on the panel. Returns the build/encode/write error so the head can report it.
+func (s *Session) ExportBOMCSV(path string) error {
+	view, err := s.AssemblyBOM()
+	if err != nil {
+		return err
+	}
+	csv, err := bom.ExportCSV(view, bom.StandardColumns())
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(csv), 0o644)
+}

--- a/app/assembly_bom_test.go
+++ b/app/assembly_bom_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"oblikovati.org/model/bom"
+)
+
+// TestAssemblyBOMCountsComponents: two instances of one component group into a single BOM row with
+// quantity 2 (the BOM counts identical components), proving the panel reads the live assembly.
+func TestAssemblyBOMCountsComponents(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	placedWidget(t, s, asm, "widget:2")
+
+	view, err := s.AssemblyBOM()
+	if err != nil {
+		t.Fatalf("AssemblyBOM: %v", err)
+	}
+	if len(view.Rows) != 1 {
+		t.Fatalf("BOM rows = %d, want 1 (two instances of one component group)", len(view.Rows))
+	}
+	if got := view.Rows[0].Quantity; got != 2 {
+		t.Errorf("row quantity = %d, want 2", got)
+	}
+}
+
+// TestBOMViewKindSelectsView: the panel's view toggle drives which view AssemblyBOM builds.
+func TestBOMViewKindSelectsView(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+
+	s.SetBOMViewKind(bom.PartsOnlyView)
+	view, err := s.AssemblyBOM()
+	if err != nil {
+		t.Fatalf("AssemblyBOM: %v", err)
+	}
+	if view.Kind != bom.PartsOnlyView {
+		t.Errorf("view kind = %v, want PartsOnlyView", view.Kind)
+	}
+}
+
+// TestExportBOMCSVWritesFile: Export writes a CSV with the standard header and a row per component,
+// at the chosen path.
+func TestExportBOMCSVWritesFile(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	placedWidget(t, s, asm, "widget:2")
+
+	path := filepath.Join(t.TempDir(), "bom.csv")
+	if err := s.ExportBOMCSV(path); err != nil {
+		t.Fatalf("ExportBOMCSV: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read CSV: %v", err)
+	}
+	csv := string(data)
+	if !strings.HasPrefix(csv, "Item,Part Number,Description,QTY,Structure") {
+		t.Errorf("CSV header = %q, want the standard columns", strings.SplitN(csv, "\n", 2)[0])
+	}
+	// The single grouped row carries quantity 2 — the last data cell before Structure.
+	if !strings.Contains(csv, ",2,") {
+		t.Errorf("CSV does not record the quantity-2 row:\n%s", csv)
+	}
+}
+
+// TestAssemblyBOMRequiresAssembly: building/exporting a BOM on a part errors rather than returning
+// an empty view.
+func TestAssemblyBOMRequiresAssembly(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if _, err := s.AssemblyBOM(); err == nil {
+		t.Error("AssemblyBOM on a part should error")
+	}
+	if err := s.ExportBOMCSV(filepath.Join(t.TempDir(), "x.csv")); err == nil {
+		t.Error("ExportBOMCSV on a part should error")
+	}
+}
+
+// TestBOMCommandOpensPanel: the Assemble ▸ Bill of Materials command opens the panel and is gated
+// to an active assembly.
+func TestBOMCommandOpensPanel(t *testing.T) {
+	s := assemblySession(t)
+	if s.BOMPanelOpen() {
+		t.Fatal("the BOM panel should start closed")
+	}
+	if err := s.Execute("Assembly.BOM"); err != nil {
+		t.Fatalf("execute Assembly.BOM: %v", err)
+	}
+	if !s.BOMPanelOpen() {
+		t.Error("executing Assembly.BOM should open the panel")
+	}
+	cmd, _ := s.Commands().ByID("Assembly.BOM")
+	if cmd.IsEnabled(registeredSession(t)) {
+		t.Error("Bill of Materials should be disabled on a part document")
+	}
+}

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -2,14 +2,11 @@
 
 package app
 
-import "fmt"
-
 // The Assemble ribbon tab (M11), shown for an assembly document (the AssemblyRibbon key,
-// switched in by ribbonKeyForDocument). This file establishes the tab's panel structure and
-// the active-assembly enable gate; each command's behavior lands in its own follow-up issue
-// (Pattern/Mirror/Copy #765, BOM #768), which replaces the stub run below with a real tool. The
-// assembly model + wire surface already exist — these are head/app wiring. Place (#763) is now
-// real: its command starts the Place Component tool.
+// switched in by ribbonKeyForDocument). It carries the Component panel (Place, #763), the Pattern
+// panel (Rectangular/Circular Pattern, Mirror, Copy, #765), and the BOM panel (Bill of Materials,
+// #768). The assembly model + wire surface already exist — these commands are the head/app wiring
+// that drives them.
 
 // assemblyTabCommands returns the Assemble tab commands in ribbon order, grouped into panels
 // by their category (Component / Pattern / BOM).
@@ -29,7 +26,15 @@ func assemblyTabCommands() []*CommandDefinition {
 			WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasActiveAssembly).
 			WithIcon("copy").WithButtonStyle(SmallIconButton).
 			WithTooltip("Copy — add an independent copy of each selected component."),
-		assemblyStubCommand("Assembly.BOM", "Bill of Materials", "BOM", 768),
+		NewCommand("Assembly.BOM", "Bill of Materials", "BOM", func(s *Session) error {
+			if _, err := activeAssembly(s); err != nil {
+				return err
+			}
+			s.OpenBOM()
+			return nil
+		}).WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasActiveAssembly).
+			WithIcon("bom").WithButtonStyle(LargeIconButton).
+			WithTooltip("Bill of Materials — list the assembly's components (structured or parts-only) and export to CSV."),
 	}
 }
 
@@ -67,22 +72,4 @@ func runPlaceComponent(s *Session) error {
 	}
 	s.StartTool(NewPlaceComponentTool())
 	return nil
-}
-
-// assemblyStubCommand builds one Assemble-tab command on the AssemblyRibbon, enabled when an
-// assembly is active. Its run is a placeholder until the named follow-up issue wires the
-// real tool — so the tab renders with the full panel structure now.
-func assemblyStubCommand(id, name, panel string, issue int) *CommandDefinition {
-	return NewCommand(id, name, panel, assemblyStubRun(name, issue)).
-		WithTab("Assemble").
-		WithRibbons(AssemblyRibbon).
-		WithEnable(hasActiveAssembly).
-		WithTooltip(fmt.Sprintf("%s — assembly command (implementation in #%d).", name, issue))
-}
-
-// assemblyStubRun reports that the command's behavior is not yet wired, naming its issue.
-func assemblyStubRun(name string, issue int) func(*Session) error {
-	return func(*Session) error {
-		return fmt.Errorf("%s is not yet implemented (#%d)", name, issue)
-	}
 }

--- a/app/session.go
+++ b/app/session.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/app/options"
 	"oblikovati.org/event"
 	"oblikovati.org/model/bodyapi"
+	"oblikovati.org/model/bom"
 	"oblikovati.org/model/clientgraphics"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
@@ -108,6 +109,8 @@ type Session struct {
 	meshColorsPerTri     bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
 	editScope            editScope                      // while editing a node, hide everything created after it (issue #132)
 	asmBodies            assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
+	bomPanelOpen         bool                           // the Assemble ▸ Bill of Materials panel is open (#768)
+	bomViewKind          bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/head/icon/assets/bom.svg
+++ b/head/icon/assets/bom.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="4" y="4" width="16" height="16"/><path d="M4 9 H20 M4 14 H20 M10 4 V20"/></svg>

--- a/head/ui/bom_panel.go
+++ b/head/ui/bom_panel.go
@@ -1,0 +1,105 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+	"strings"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/bom"
+)
+
+// The Bill of Materials panel (Assemble ▸ Bill of Materials, #768): a window listing the active
+// assembly's components in the chosen view (Structured / Parts Only) with an Export-to-CSV button.
+// The BOM itself — counting, grouping, the CSV — is model/bom, surfaced through Session.AssemblyBOM
+// / ExportBOMCSV; this only renders it. Part numbers/descriptions are blank until a component's
+// iProperties feed the BOM (#718); the structure and quantities are correct regardless.
+
+// bomViewNames index by bom.ViewKind, for the view chooser.
+var bomViewNames = []string{"Structured", "Parts Only"}
+
+// drawBOMWindow renders the BOM panel when it is open. It rebuilds the view each frame from the
+// live assembly, so placing or deleting a component updates the list immediately.
+func drawBOMWindow(s *app.Session) {
+	if !s.BOMPanelOpen() {
+		return
+	}
+	native.SetNextWindowSizeOnce(720, 480)
+	if native.Begin("Bill of Materials") {
+		drawBOMControls(s)
+		native.Separator()
+		if view, err := s.AssemblyBOM(); err != nil {
+			native.Text(err.Error())
+		} else {
+			drawBOMTable(view)
+		}
+		native.Separator()
+		if native.Button("Done") {
+			s.CloseBOM()
+		}
+	}
+	native.End()
+}
+
+// drawBOMControls renders the view chooser (Structured / Parts Only) and the Export CSV button,
+// which arms the file dialog to write the current view.
+func drawBOMControls(s *app.Session) {
+	cur := int(s.BOMViewKind())
+	native.SetNextItemWidth(160)
+	if native.BeginCombo("View##bom-view", bomViewNames[cur]) {
+		for i, name := range bomViewNames {
+			if native.Selectable(name, i == cur) {
+				s.SetBOMViewKind(bom.ViewKind(i))
+			}
+		}
+		native.EndCombo()
+	}
+	native.SameLine()
+	if native.Button("Export CSV") {
+		fileModal.openFor(dialogExportBOM)
+	}
+}
+
+// drawBOMTable renders the rows as a five-column table (Item, Part Number, Description, QTY,
+// Structure). A structured view nests sub-assembly children, indented under their parent.
+func drawBOMTable(view *bom.View) {
+	if len(view.Rows) == 0 {
+		native.Text("  (no components)")
+		return
+	}
+	if !native.BeginTable("##bom-table", 5, 0, 0) {
+		return
+	}
+	for _, c := range []string{"Item", "Part Number", "Description", "QTY", "Structure"} {
+		native.TableSetupColumn(c)
+	}
+	native.TableSetupScrollFreeze(0, 1)
+	native.TableHeadersRow()
+	for _, r := range view.Rows {
+		drawBOMRow(r, 0)
+	}
+	native.EndTable()
+}
+
+// drawBOMRow draws one row and recurses into its children, indenting the part-number cell by depth
+// so the structured hierarchy reads as a tree.
+func drawBOMRow(r *bom.Row, depth int) {
+	native.TableNextRow()
+	native.TableNextColumn()
+	native.Text(strconv.Itoa(r.ItemNumber))
+	native.TableNextColumn()
+	native.Text(strings.Repeat("  ", depth) + r.PartNumber)
+	native.TableNextColumn()
+	native.Text(r.Description)
+	native.TableNextColumn()
+	native.Text(strconv.Itoa(r.Quantity))
+	native.TableNextColumn()
+	native.Text(r.Structure.String())
+	for _, child := range r.Children {
+		drawBOMRow(child, depth+1)
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -134,6 +134,7 @@ func drawSurfaceFeatureDialogs(s *app.Session) {
 }
 
 func drawChromeWindows(s *app.Session) {
+	drawBOMWindow(s) // Assemble ▸ Bill of Materials (#768)
 	drawParametersWindow(s)
 	drawPreferencesWindow(s)
 	drawMaterialsWindow(s)

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -31,6 +31,7 @@ const (
 	dialogAddIn                         // an add-in's dialogs.showFileDialog request (M05-F08)
 	dialogMeshRef                       // Mesh ▸ Place Mesh (ASCII STL → mesh reference geometry, #700)
 	dialogPlaceComponent                // Assemble ▸ Place: choose the component document to instance (#763)
+	dialogExportBOM                     // Assemble ▸ Bill of Materials ▸ Export CSV (#768)
 )
 
 // pathBufferLen bounds the path the user can type. ImGui edits the buffer in place,
@@ -129,6 +130,8 @@ func (d *fileDialog) title() string {
 		return "Import (.stl/.obj/.3mf/.step)"
 	case dialogExport:
 		return "Export (.stl/.obj/.3mf/.step)"
+	case dialogExportBOM:
+		return "Export BOM (.csv)"
 	case dialogAddIn:
 		return d.addInTitle()
 	default:
@@ -273,6 +276,8 @@ func (d *fileDialog) allowedExts() []string {
 		return []string{".stl"}
 	case dialogImport, dialogExport:
 		return []string{".stl", ".obj", ".3mf", ".step", ".stp"}
+	case dialogExportBOM:
+		return []string{".csv"}
 	case dialogAddIn:
 		return filterExtensions(d.request.Filter)
 	default:

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -212,7 +212,7 @@ func fileConfirmLabel() string {
 		return "Save"
 	case dialogImport:
 		return "Import"
-	case dialogExport:
+	case dialogExport, dialogExportBOM:
 		return "Export"
 	default:
 		return "Open"
@@ -252,6 +252,8 @@ func applyFileAction(s *app.Session, act fileAction) {
 		importBodyFromFile(s, act.Path, name)
 	case dialogExport:
 		exportToFile(s, act, name)
+	case dialogExportBOM:
+		exportBOMToFile(s, act.Path, name)
 	}
 }
 
@@ -292,6 +294,16 @@ func exportToFile(s *app.Session, act fileAction, name string) {
 		return
 	}
 	fileNotice(s, "Exported %s", name)
+}
+
+// exportBOMToFile writes the active assembly's current BOM view to a CSV file (Assemble ▸ Bill of
+// Materials ▸ Export CSV, #768).
+func exportBOMToFile(s *app.Session, path, name string) {
+	if err := s.ExportBOMCSV(path); err != nil {
+		fileNotice(s, "Export BOM failed: %v", err)
+		return
+	}
+	fileNotice(s, "Exported BOM %s", name)
 }
 
 // openDocumentFromFile opens the chosen document and reports the outcome (File ▸ Open).


### PR DESCRIPTION
## What
Replace the Assemble-tab **Bill of Materials** stub with a real panel that lists the active assembly's components in either standard view — **Structured** (the hierarchy, sub-assemblies nested) or **Parts Only** (every unique part once with its total quantity) — and **exports the current view to CSV** via the file dialog.

The BOM itself (counting, grouping, CSV encoding) already existed in `model/bom` and backs the wire surface; this is the head/app wiring around it:
- `Session.AssemblyBOM()` builds the live view in the selected kind; `ExportBOMCSV(path)` writes it (standard columns); `OpenBOM`/`BOMPanelOpen`/`BOMViewKind`/`SetBOMViewKind` hold the panel state.
- `head/ui/bom_panel.go` rebuilds the table each frame from the live assembly (placing/deleting a component updates it immediately) and indents structured sub-assembly rows under their parent.
- a `dialogExportBOM` file-dialog mode (`.csv`) writes the export.
- `bom` ribbon icon (a table glyph); the now-unused assembly stub-command helpers are removed (BOM was the last stub).

## Why
M11 feature-completeness — the BOM is a core deliverable of an assembly. Part numbers/descriptions are blank until a component's iProperties feed the BOM (**#718**, the follow-up); the structure and quantities are correct regardless.

## Tests
- `TestAssemblyBOMCountsComponents` — two instances of one component group into one row, quantity 2.
- `TestBOMViewKindSelectsView` — the toggle drives which view is built.
- `TestExportBOMCSVWritesFile` — writes the standard header + a quantity-2 row to the chosen path.
- `TestAssemblyBOMRequiresAssembly` — errors on a part.
- `TestBOMCommandOpensPanel` — the command opens the panel and is gated to an assembly.

`go test ./app/...` green; `golangci-lint run ./app/...` 0 issues; head builds + `bom.svg` passes the icon role-conformance + resolve tests.

Part of M11 (Assembly Modeling & Instancing). Closes #768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)