### PR TITLE
feat: assembly Chamfer / Fillet commands (#766 — edge dress-up)

### DIFF
--- a/app/assembly_dressup_tools.go
+++ b/app/assembly_dressup_tools.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"bytes"
+	"errors"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Assembly edge dress-up tools (M11, #766): chamfer and fillet a component edge on every placed
+// instance of that component. The user picks an edge in the viewport (a world-space participant
+// body, surfaced by #769's edge picking); the tool resolves it to the COMPONENT-LOCAL edge suffix
+// and stores that, so the feature re-applies to every participant through the occurrence-relative
+// resolver (#735). The geometry lives in model/feature; these are interaction shells driven
+// headlessly here, with the distance/radius read from the generic tool-param dialog.
+
+// componentEdgeSuffix turns a picked world-body edge's reference key into the component-local
+// lineage suffix the assembly dress-up feature matches against each participant. A world edge's
+// key is [kindByte] + "occurrence:occ#i/<componentLineage>": strip the kind byte (LineageSuffixOf),
+// then drop the leading occurrence-prefix token (everything up to the first '/'), leaving
+// "<componentLineage>" — the same suffix the wire path stores from a component-local key (#735).
+func componentEdgeSuffix(referenceKey []byte) []byte {
+	lineage := topo.LineageSuffixOf(referenceKey)
+	if i := bytes.IndexByte(lineage, '/'); i >= 0 {
+		return lineage[i+1:]
+	}
+	return lineage
+}
+
+// assemblyEdgeSelectTool collects the participant edges a dress-up acts on, filtering picks to
+// edges and converting each to its component-local suffix on commit.
+type assemblyEdgeSelectTool struct {
+	edges []EdgeHandle
+}
+
+// Start restricts picking to edges, so a click selects a participant edge rather than the whole
+// occurrence (the SelectEdge filter bypasses occurrence selection — see #769).
+func (t *assemblyEdgeSelectTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+}
+
+// Pick appends a picked edge (ignoring a repeat, so a double-click does not duplicate it).
+func (t *assemblyEdgeSelectTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok && !t.hasEdge(e) {
+		t.edges = append(t.edges, e)
+	}
+}
+
+func (t *assemblyEdgeSelectTool) hasEdge(e EdgeHandle) bool {
+	for _, h := range t.edges {
+		if h == e {
+			return true
+		}
+	}
+	return false
+}
+
+// Cancel abandons the picks and clears the edge filter.
+func (t *assemblyEdgeSelectTool) Cancel(s *Session) {
+	t.edges = nil
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+
+// resolve returns the active assembly and the component-local suffix of each picked edge, erroring
+// when no assembly is active or nothing was picked.
+func (t *assemblyEdgeSelectTool) resolve(s *Session, op string) (*compdef.AssemblyComponentDefinition, [][]byte, error) {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(t.edges) == 0 {
+		return nil, nil, errors.New(op + ": pick a component edge first")
+	}
+	suffixes := make([][]byte, len(t.edges))
+	for i, e := range t.edges {
+		suffixes[i] = componentEdgeSuffix(e.Edge.ReferenceKey())
+	}
+	return asm, suffixes, nil
+}
+
+// finish names the new dress-up feature, recomputes the assembly so the participants re-machine,
+// and clears the edge filter.
+func (t *assemblyEdgeSelectTool) finish(s *Session, asm *compdef.AssemblyComponentDefinition, af *compdef.AssemblyFeature) {
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+
+// --- Chamfer --------------------------------------------------------------
+
+// AssemblyChamferTool bevels the picked component edges by a setback distance on every participant.
+type AssemblyChamferTool struct {
+	assemblyEdgeSelectTool
+	distance float64
+}
+
+// NewAssemblyChamferTool returns a chamfer tool with a default 1-unit setback.
+func NewAssemblyChamferTool() *AssemblyChamferTool { return &AssemblyChamferTool{distance: 1} }
+func (t *AssemblyChamferTool) Name() string        { return "Chamfer" }
+func (t *AssemblyChamferTool) Prompt(*Session) string {
+	return "Pick component edges, set the setback distance, then OK."
+}
+func (t *AssemblyChamferTool) CanCommit() bool { return len(t.edges) > 0 && t.distance > 0 }
+
+func (t *AssemblyChamferTool) Commit(s *Session) error {
+	asm, suffixes, err := t.resolve(s, "chamfer")
+	if err != nil {
+		return err
+	}
+	d := t.distance
+	af := asm.AddFeature(feature.NewAssemblyChamferFeature(suffixes, func() float64 { return d }))
+	t.finish(s, asm, af)
+	return nil
+}
+
+func (t *AssemblyChamferTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{"Distance", func() float64 { return t.distance }, func(v float64) { t.distance = v }},
+	}}
+}
+
+// --- Fillet ---------------------------------------------------------------
+
+// AssemblyFilletTool rounds the picked component edges to a radius on every participant.
+type AssemblyFilletTool struct {
+	assemblyEdgeSelectTool
+	radius float64
+}
+
+// NewAssemblyFilletTool returns a fillet tool with a default 1-unit radius.
+func NewAssemblyFilletTool() *AssemblyFilletTool { return &AssemblyFilletTool{radius: 1} }
+func (t *AssemblyFilletTool) Name() string       { return "Fillet" }
+func (t *AssemblyFilletTool) Prompt(*Session) string {
+	return "Pick component edges, set the radius, then OK."
+}
+func (t *AssemblyFilletTool) CanCommit() bool { return len(t.edges) > 0 && t.radius > 0 }
+
+func (t *AssemblyFilletTool) Commit(s *Session) error {
+	asm, suffixes, err := t.resolve(s, "fillet")
+	if err != nil {
+		return err
+	}
+	r := t.radius
+	af := asm.AddFeature(feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }))
+	t.finish(s, asm, af)
+	return nil
+}
+
+func (t *AssemblyFilletTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{"Radius", func() float64 { return t.radius }, func(v float64) { t.radius = v }},
+	}}
+}

--- a/app/assembly_dressup_tools_test.go
+++ b/app/assembly_dressup_tools_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// worldVerticalEdge returns an EdgeHandle for a vertical edge of the assembly's (single) placed
+// component body — the kind of pick the viewport produces under a SelectEdge filter (#769). The
+// edge carries the world body's occurrence-lineage prefix, which the chamfer tool must strip.
+func worldVerticalEdge(t *testing.T, s *Session) EdgeHandle {
+	t.Helper()
+	bodies := s.VisibleBodies()
+	if len(bodies) == 0 {
+		t.Fatal("assembly has no placed body to pick an edge on")
+	}
+	for _, e := range bodies[0].Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.X == b.X && a.Y == b.Y && a.Z != b.Z { // vertical: same XY, differing Z
+			return EdgeHandle{Edge: e}
+		}
+	}
+	t.Fatal("no vertical edge on the placed box")
+	return EdgeHandle{}
+}
+
+// participantMachinedVolume sums the assembly-feature machined result volume for an occurrence —
+// the volume the participant's body has AFTER the dress-up features run.
+func participantMachinedVolume(asm *compdef.AssemblyComponentDefinition, o *occurrence.Occurrence) float64 {
+	var v float64
+	for _, b := range asm.Features().Result(o) {
+		v += ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+	}
+	return v
+}
+
+// TestAssemblyChamferMachinesParticipant is the headline #766 test: picking a vertical edge of a
+// placed component (a world-space body carrying the occurrence-lineage prefix) and chamfering it
+// removes the analytic wedge from the participant — proving the picked world edge resolves to the
+// right component-local edge (a wrong suffix would no-op, leaving the volume unchanged).
+func TestAssemblyChamferMachinesParticipant(t *testing.T) {
+	s, asm, occ := assemblyWithBoxComponent(t, 0) // box [0,2]×[0,2]×[0,4], volume 16
+
+	tool := NewAssemblyChamferTool()
+	tool.Pick(s, worldVerticalEdge(t, s))
+	tool.distance = 0.2
+	if !tool.CanCommit() {
+		t.Fatal("a chamfer with an edge and a positive distance should be committable")
+	}
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if asm.Features().Count() != 1 || asm.Features().Item(0).Kind() != "assemblyChamfer" {
+		t.Fatalf("features = %d, want one assemblyChamfer", asm.Features().Count())
+	}
+	// A 45° flat chamfer of setback 0.2 on a length-4 vertical edge removes a 0.2²/2·4 = 0.08 wedge.
+	if got := participantMachinedVolume(asm, occ); stdmath.Abs(got-15.92) > 0.02 {
+		t.Errorf("chamfered participant volume = %g, want 15.92 (16 minus a 0.2 chamfer wedge)", got)
+	}
+}
+
+// TestAssemblyChamferAppliesToAllInstances is the occurrence-relative proof (#735/#766): picking
+// one edge on one placed instance chamfers that edge on EVERY instance of the component — a single
+// feature, resolved per participant by the component-local suffix.
+func TestAssemblyChamferAppliesToAllInstances(t *testing.T) {
+	s, asm, occ1 := assemblyWithBoxComponent(t, 0)
+	box := s.Workspace().Documents()[0] // the box component document
+	occ2, err := asm.PlaceComponentFromFile(s.ActiveDocument(), box, "box:2", math.Translation4(math.V3(20, 0, 0)))
+	if err != nil {
+		t.Fatalf("place second instance: %v", err)
+	}
+
+	tool := NewAssemblyChamferTool()
+	tool.Pick(s, worldVerticalEdge(t, s)) // one edge on the first instance
+	tool.distance = 0.2
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	for i, occ := range []*occurrence.Occurrence{occ1, occ2} {
+		if got := participantMachinedVolume(asm, occ); stdmath.Abs(got-15.92) > 0.02 {
+			t.Errorf("instance %d volume = %g, want 15.92 — both instances chamfered from one pick", i, got)
+		}
+	}
+}
+
+// TestAssemblyFilletMachinesParticipant: rounding a component edge removes the convex corner
+// material from the participant (volume drops below the box, by a small rounded amount).
+func TestAssemblyFilletMachinesParticipant(t *testing.T) {
+	s, asm, occ := assemblyWithBoxComponent(t, 0)
+
+	tool := NewAssemblyFilletTool()
+	tool.Pick(s, worldVerticalEdge(t, s))
+	tool.radius = 0.2
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if asm.Features().Item(0).Kind() != "assemblyFillet" {
+		t.Errorf("feature kind = %q, want assemblyFillet", asm.Features().Item(0).Kind())
+	}
+	// A radius-0.2 fillet on a length-4 edge removes (1 − π/4)·0.2²·4 ≈ 0.034 of corner material.
+	got := participantMachinedVolume(asm, occ)
+	if got >= 16 || got < 15.9 {
+		t.Errorf("filleted participant volume = %g, want a box minus a small rounded corner (≈15.97)", got)
+	}
+}
+
+// TestAssemblyDressupNeedsEdge: committing with nothing picked errors rather than adding an empty
+// feature.
+func TestAssemblyDressupNeedsEdge(t *testing.T) {
+	s, _, _ := assemblyWithBoxComponent(t, 0)
+	if NewAssemblyChamferTool().CanCommit() {
+		t.Error("a chamfer with no edge picked should not be committable")
+	}
+	if err := NewAssemblyChamferTool().Commit(s); err == nil {
+		t.Error("committing a chamfer with no edge should error")
+	}
+}
+
+// TestComponentEdgeSuffixStripsOccurrencePrefix pins the resolution helper: a world key
+// [kind]+"occurrence:occ#3/extrude:edge#2" yields the bare component suffix "extrude:edge#2".
+func TestComponentEdgeSuffixStripsOccurrencePrefix(t *testing.T) {
+	worldKey := append([]byte{byte(topo.KindEdge)}, []byte("occurrence:occ#3/extrude:edge#2")...)
+	if got := string(componentEdgeSuffix(worldKey)); got != "extrude:edge#2" {
+		t.Errorf("componentEdgeSuffix = %q, want extrude:edge#2", got)
+	}
+}

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -13,15 +13,21 @@ package app
 func assemblyTabCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		placeComponentCommand(),
-		assemblyToolCommand("Assembly.RectangularPattern", "Rectangular Pattern", "rectangular-pattern",
+		assemblyToolCommand("Assembly.RectangularPattern", "Rectangular Pattern", "Pattern", "rectangular-pattern",
 			"Rectangular Pattern — replicate the selected component on a grid (counts and spacing).",
 			func() Tool { return NewAssemblyRectPatternTool() }),
-		assemblyToolCommand("Assembly.CircularPattern", "Circular Pattern", "circular-pattern",
+		assemblyToolCommand("Assembly.CircularPattern", "Circular Pattern", "Pattern", "circular-pattern",
 			"Circular Pattern — replicate the selected component around the Z axis (count and angle).",
 			func() Tool { return NewAssemblyCircPatternTool() }),
-		assemblyToolCommand("Assembly.Mirror", "Mirror", "mirror",
+		assemblyToolCommand("Assembly.Mirror", "Mirror", "Pattern", "mirror",
 			"Mirror — add a mirror of the selected components across a plane.",
 			func() Tool { return NewAssemblyMirrorTool() }),
+		assemblyToolCommand("Assembly.Chamfer", "Chamfer", "Modify", "chamfer",
+			"Chamfer — bevel a picked component edge on every instance of that component.",
+			func() Tool { return NewAssemblyChamferTool() }),
+		assemblyToolCommand("Assembly.Fillet", "Fillet", "Modify", "fillet",
+			"Fillet — round a picked component edge on every instance of that component.",
+			func() Tool { return NewAssemblyFilletTool() }),
 		NewCommand("Assembly.Copy", "Copy", "Pattern", func(s *Session) error { return s.CopyComponents() }).
 			WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasActiveAssembly).
 			WithIcon("copy").WithButtonStyle(SmallIconButton).
@@ -41,8 +47,8 @@ func assemblyTabCommands() []*CommandDefinition {
 // assemblyToolCommand builds an Assemble-tab command that starts a replication tool on the active
 // assembly. The tool seeds its sources from the current selection and reads the rest from the
 // generic tool-param dialog (#765).
-func assemblyToolCommand(id, name, icon, tooltip string, newTool func() Tool) *CommandDefinition {
-	return NewCommand(id, name, "Pattern", func(s *Session) error {
+func assemblyToolCommand(id, name, panel, icon, tooltip string, newTool func() Tool) *CommandDefinition {
+	return NewCommand(id, name, panel, func(s *Session) error {
 		if _, err := activeAssembly(s); err != nil {
 			return err
 		}


### PR DESCRIPTION
## What
Wire the assembly **edge dress-up** — Chamfer and Fillet of a participant edge — onto the **Assemble ▸ Modify** panel. The user picks an edge of a placed component in the viewport (a world-space participant body, surfaced by #769's edge picking); the tool resolves it to the **component-local edge suffix** and stores that, so the feature re-applies to **every instance** of that component via the occurrence-relative resolver (#735).

### The resolution (the crux)
A picked world edge's reference key carries the `occurrence:occ#i/` lineage prefix. `componentEdgeSuffix` strips the kind byte and that prefix to recover the bare component lineage suffix — the same form the wire path stores from a component-local key. Verified by a dedicated unit test plus volume gates.

## Tests (analytic gates)
- `TestAssemblyChamferMachinesParticipant` — chamfering a length-4 edge by 0.2 removes the analytic **0.08 wedge** (volume 16 → **15.92**); a wrong suffix would no-op (16).
- `TestAssemblyChamferAppliesToAllInstances` — one pick chamfers **both** placed instances to 15.92 (the occurrence-relative proof).
- `TestAssemblyFilletMachinesParticipant`, `TestAssemblyDressupNeedsEdge`, `TestComponentEdgeSuffixStripsOccurrencePrefix`.

`go test ./app/...` green (incl. `-race`); `golangci-lint` 0 issues; head builds + icon-resolve passes (reuses the part chamfer/fillet glyphs).

## Scope & a backend gap I found
This delivers the **edge dress-up** (chamfer/fillet) of #766 — the part #769 + #735 directly enable. **Remaining for #766:** the sketch-based kinds (extrude/revolve/hole) need assembly-sketch authoring enabled in the UI, plus the in-session feature edit — follow-ups.

**Note (not introduced here):** like the existing, merged wire path, these run **in-session only** — assembly machining features are **not serialized in the assembly recipe** (`assemblyRecipe` = units + occurrences), an **M11-F08 backend gap**, so they don't yet persist across save or undo. Worth a dedicated follow-up issue (assembly feature-program persistence), which would make the whole assembly machining family — wire + UI — durable.

Part of M11 (Assembly Modeling & Instancing); advances #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)