### PR TITLE
feat: document iProperties — attach, persist, serve (#156)

### DIFF
--- a/addin/router/document_properties.go
+++ b/addin/router/document_properties.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/attr"
+)
+
+// The document iProperties surface (#156): list, read, and write a document's metadata sets —
+// the standard Summary / Document Summary / Design Tracking sets plus user-defined custom
+// properties. A document's content (part or assembly) owns the sets through propertyHolder;
+// values cross the wire as the shared [types.Variant], converted to/from the model [attr.Value]
+// here.
+
+// propertyHolder is the content interface a document with iProperties satisfies — both the part
+// and assembly definitions do.
+type propertyHolder interface {
+	Properties() *attr.PropertySets
+}
+
+// registerDocumentPropertyHandlers wires the documents.*Property* methods.
+func (r *Router) registerDocumentPropertyHandlers() {
+	r.handlers[wire.MethodDocumentsListProperties] = listDocumentProperties
+	r.handlers[wire.MethodDocumentsGetProperty] = getDocumentProperty
+	r.handlers[wire.MethodDocumentsSetProperty] = setDocumentProperty
+}
+
+// documentProperties resolves the open document addressed by id to its property sets, erroring
+// when the document is not open or its content carries no properties (a bare reference stub).
+func documentProperties(s *app.Session, id uint64, method string) (*attr.PropertySets, error) {
+	d, err := documentByID(s, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	holder, ok := d.Content().(propertyHolder)
+	if !ok {
+		return nil, fmt.Errorf("%s: document %d (%s) has no properties", method, id, d.DisplayName())
+	}
+	return holder.Properties(), nil
+}
+
+// listDocumentProperties returns every property across the document's sets.
+func listDocumentProperties(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListPropertiesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ps, err := documentProperties(s, in.Document, wire.MethodDocumentsListProperties)
+	if err != nil {
+		return nil, err
+	}
+	var infos []wire.PropertyInfo
+	for _, set := range ps.Sets() {
+		for _, p := range set.Properties() {
+			infos = append(infos, propertyInfo(set.Name(), p))
+		}
+	}
+	return json.Marshal(wire.ListPropertiesResult{Properties: infos})
+}
+
+// getDocumentProperty returns one property addressed by its set and name.
+func getDocumentProperty(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.GetPropertyArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ps, err := documentProperties(s, in.Document, wire.MethodDocumentsGetProperty)
+	if err != nil {
+		return nil, err
+	}
+	set, ok := ps.Lookup(in.Set)
+	if !ok {
+		return nil, fmt.Errorf("%s: no property set %q", wire.MethodDocumentsGetProperty, in.Set)
+	}
+	p, ok := set.Property(in.Name)
+	if !ok {
+		return nil, fmt.Errorf("%s: no property %q in set %q", wire.MethodDocumentsGetProperty, in.Name, in.Set)
+	}
+	return json.Marshal(wire.PropertyResult{Property: propertyInfo(in.Set, p)})
+}
+
+// setDocumentProperty creates or replaces a property's value (creating a custom set on demand).
+func setDocumentProperty(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetPropertyArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ps, err := documentProperties(s, in.Document, wire.MethodDocumentsSetProperty)
+	if err != nil {
+		return nil, err
+	}
+	if in.Name == "" {
+		return nil, fmt.Errorf("%s: a property name is required", wire.MethodDocumentsSetProperty)
+	}
+	p := ps.Set(in.Set).Put(in.Name, valueFromVariant(in.Value))
+	return json.Marshal(wire.PropertyResult{Property: propertyInfo(in.Set, p)})
+}
+
+// propertyInfo renders a model property in set as a wire DTO.
+func propertyInfo(set string, p *attr.Property) wire.PropertyInfo {
+	from, _ := p.ExposedFromParameter()
+	return wire.PropertyInfo{Set: set, Name: p.Name(), Value: variantFromValue(p.Value()), FromParameter: from}
+}
+
+// variantFromValue converts a model [attr.Value] to the wire [types.Variant].
+func variantFromValue(v attr.Value) types.Variant {
+	switch v.Type() {
+	case attr.Boolean:
+		b, _ := v.Bool()
+		return types.BoolVariant(b)
+	case attr.Integer:
+		i, _ := v.Int()
+		return types.IntegerVariant(i)
+	case attr.Double:
+		f, _ := v.Float()
+		return types.DoubleVariant(f)
+	case attr.Bytes:
+		raw, _ := v.Raw()
+		return types.BytesVariant(raw)
+	default:
+		s, _ := v.Str()
+		return types.StringVariant(s)
+	}
+}
+
+// valueFromVariant converts a wire [types.Variant] to the model [attr.Value].
+func valueFromVariant(v types.Variant) attr.Value {
+	switch v.Type() {
+	case types.BooleanValue:
+		b, _ := v.Bool()
+		return attr.BoolValue(b)
+	case types.IntegerValue:
+		i, _ := v.Integer()
+		return attr.IntValue(i)
+	case types.DoubleValue:
+		f, _ := v.Double()
+		return attr.FloatValue(f)
+	case types.ByteArrayValue:
+		raw, _ := v.Bytes()
+		return attr.BytesValue(raw)
+	default:
+		s, _ := v.Str()
+		return attr.StringValue(s)
+	}
+}

--- a/addin/router/document_properties_test.go
+++ b/addin/router/document_properties_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestDocumentPropertiesOverWire sets a typed iProperty over the wire, reads it back, and finds it
+// in the document's property list — the #156 round trip a BOM/title-block client relies on.
+func TestDocumentPropertiesOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	id := uint64(s.ActiveDocument().ID())
+	const set = "Design Tracking Properties"
+
+	var setRes wire.PropertyResult
+	args := mustJSON(t, wire.SetPropertyArgs{Document: id, Set: set, Name: "Part Number", Value: types.StringVariant("BRK-001")})
+	call(t, r, s, "documents.setProperty", args, &setRes)
+	if v, ok := setRes.Property.Value.Str(); !ok || v != "BRK-001" {
+		t.Fatalf("set reply value = %v (ok=%v), want BRK-001", v, ok)
+	}
+
+	var getRes wire.PropertyResult
+	call(t, r, s, "documents.getProperty", fmt.Sprintf(`{"document":%d,"set":%q,"name":"Part Number"}`, id, set), &getRes)
+	if v, _ := getRes.Property.Value.Str(); v != "BRK-001" {
+		t.Errorf("get value = %q, want BRK-001", v)
+	}
+
+	var list wire.ListPropertiesResult
+	call(t, r, s, "documents.listProperties", fmt.Sprintf(`{"document":%d}`, id), &list)
+	if !hasProperty(list.Properties, set, "Part Number", "BRK-001") {
+		t.Errorf("listProperties missing the Part Number: %+v", list.Properties)
+	}
+}
+
+// TestGetUnknownDocumentPropertyFails: reading an absent property is a rejection, not an empty hit.
+func TestGetUnknownDocumentPropertyFails(t *testing.T) {
+	r, s := emptyPartSession(t)
+	id := uint64(s.ActiveDocument().ID())
+	if _, err := r.Handle(s, "documents.getProperty", []byte(fmt.Sprintf(`{"document":%d,"set":"Design Tracking Properties","name":"Nope"}`, id))); err == nil {
+		t.Error("getProperty of an unknown property should fail")
+	}
+}
+
+// hasProperty reports whether infos contains a string property with the given set/name/value.
+func hasProperty(infos []wire.PropertyInfo, set, name, value string) bool {
+	for _, p := range infos {
+		if p.Set == set && p.Name == name {
+			if v, ok := p.Value.Str(); ok && v == value {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -59,6 +59,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyOccurrenceHandlers()
 	r.registerAssemblyReplicationHandlers()
 	r.registerAssemblyBOMHandlers()
+	r.registerDocumentPropertyHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/attr"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
@@ -41,6 +42,8 @@ type AssemblyComponentDefinition struct {
 	// component definitions — ApplyRecipe has no workspace, so binding waits for
 	// ResolveReferences once the document is registered (#715). Empty outside a reopen.
 	pending []occurrenceRecipe
+	// props are the assembly document's iProperties (metadata sets), like a part's (#156).
+	props *attr.PropertySets
 }
 
 // NewAssemblyComponentDefinition returns an empty assembly content object: no
@@ -58,6 +61,7 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 		params:      param.NewParameters(),
 		work:        feature.NewWorkGeometry(),
 		sketches:    sketch.NewSketches(),
+		props:       attr.NewPropertySets(),
 	}
 	occ.SetListener(a.events)
 	a.features.SetBus(a.events.Bus()) // feature-program events ride the assembly's occurrence bus
@@ -183,6 +187,9 @@ func (a *AssemblyComponentDefinition) AddFeature(f feature.Feature) *AssemblyFea
 // Parameters returns the assembly's parameter DAG (shared with its sketches so
 // dimension expressions resolve against the same table).
 func (a *AssemblyComponentDefinition) Parameters() *param.Parameters { return a.params }
+
+// Properties returns the assembly's iProperties (document metadata sets), like a part's (#156).
+func (a *AssemblyComponentDefinition) Properties() *attr.PropertySets { return a.props }
 
 // WorkGeometry returns the assembly's origin coordinate frame and user work
 // planes/axes/points, expressed in assembly space — the planes a sketch is authored on.

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/attr"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/persistence/yamlcodec"
@@ -23,6 +24,7 @@ import (
 type assemblyRecipe struct {
 	Units       map[string]string  `yaml:"units,omitempty"`
 	Occurrences []occurrenceRecipe `yaml:"occurrences,omitempty"`
+	Properties  []propertyRecipe   `yaml:"properties,omitempty"` // document iProperties (#156)
 }
 
 // occurrenceRecipe is the persisted form of one placement: the component document it
@@ -43,6 +45,7 @@ func (a *AssemblyComponentDefinition) MarshalRecipe() ([]byte, error) {
 	return yamlcodec.Marshal(assemblyRecipe{
 		Units:       unitsRecipeFor(a.units),
 		Occurrences: a.occurrencesRecipe(),
+		Properties:  propertiesRecipeOf(a.props),
 	})
 }
 
@@ -83,6 +86,7 @@ func (a *AssemblyComponentDefinition) ApplyRecipe(model []byte) error {
 	if err := applyUnitsTo(a.units, r.Units); err != nil {
 		return err
 	}
+	applyPropertiesRecipe(a.props, r.Properties)
 	a.pending = r.Occurrences
 	return nil
 }
@@ -115,6 +119,7 @@ func (a *AssemblyComponentDefinition) RestoreRecipe(model []byte) error {
 func (a *AssemblyComponentDefinition) resetOccurrences() {
 	a.occurrences = occurrence.NewOccurrences()
 	a.occurrences.SetListener(a.events)
+	a.props = attr.NewPropertySets() // a restore re-applies the snapshot's properties onto a clean set (#156)
 	a.pending = nil
 }
 

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/attr"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/identity"
@@ -43,6 +44,9 @@ type PartComponentDefinition struct {
 	// per-import UUID that features cite, making the .obk self-contained (ADR-0031). Document-
 	// level input, NOT part of the recipe — it survives a recipe reset (undo/reopen).
 	resources map[string]doc.Resource
+	// props are the document's iProperties (metadata sets) — title/author/part number/custom,
+	// which feed BOMs and title blocks (#156).
+	props *attr.PropertySets
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature
@@ -63,6 +67,7 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		assignments: material.NewAssignmentStore(),
 		assets:      material.NewAssetSet(),
 		resources:   map[string]doc.Resource{},
+		props:       attr.NewPropertySets(),
 	}
 	d.features.SetResourceStore(d) // re-derive imported bodies from the resource table on open
 	d.features.SetFontResolver(d)  // resolve text/emboss fonts from embedded/app-provided resources
@@ -76,6 +81,10 @@ func (d *PartComponentDefinition) Assignments() *material.AssignmentStore { retu
 // Assets returns the part's embedded appearance/material set (the document-owned copies of
 // the non-built-in assets it uses).
 func (d *PartComponentDefinition) Assets() *material.AssetSet { return d.assets }
+
+// Properties returns the part's iProperties (document metadata sets) — the standard Summary /
+// Document Summary / Design Tracking sets plus user-defined custom properties (#156).
+func (d *PartComponentDefinition) Properties() *attr.PropertySets { return d.props }
 
 // AddPart creates a new part document in ws with a realized part component
 // definition installed (not the bare doc-package placeholder), makes it active, and

--- a/model/compdef/properties_recipe.go
+++ b/model/compdef/properties_recipe.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"oblikovati.org/model/attr"
+)
+
+// Persistence of document iProperties in the part/assembly recipe (#156): each set property is
+// stored as a small YAML record (set, name, typed value) so the .obk stays human-readable. The
+// four standard sets are recreated empty by attr.NewPropertySets on load; only authored
+// properties are persisted, then re-applied into their sets (a custom set name is recreated).
+
+// propertyRecipe is the persisted form of one document property: its set and name, the value's
+// type tag, and the value rendered to a string (base64 for bytes).
+type propertyRecipe struct {
+	Set   string `yaml:"set"`
+	Name  string `yaml:"name"`
+	Type  string `yaml:"type"`
+	Value string `yaml:"value"`
+}
+
+// propertiesRecipeOf captures every authored property across all the document's sets, in set then
+// insertion order. An empty document yields no records (the standard sets are implicit).
+func propertiesRecipeOf(ps *attr.PropertySets) []propertyRecipe {
+	var out []propertyRecipe
+	for _, set := range ps.Sets() {
+		for _, p := range set.Properties() {
+			typ, val := valueToRecipe(p.Value())
+			out = append(out, propertyRecipe{Set: set.Name(), Name: p.Name(), Type: typ, Value: val})
+		}
+	}
+	return out
+}
+
+// applyPropertiesRecipe re-creates the persisted properties on ps (Put into the named set,
+// creating a custom set if needed). An unparsable record is skipped rather than failing the load,
+// so one bad value never blocks reopening the document.
+func applyPropertiesRecipe(ps *attr.PropertySets, recs []propertyRecipe) {
+	for _, r := range recs {
+		v, err := valueFromRecipe(r.Type, r.Value)
+		if err != nil {
+			continue
+		}
+		ps.Set(r.Set).Put(r.Name, v)
+	}
+}
+
+// valueToRecipe renders a typed value to its (type tag, string) recipe form.
+func valueToRecipe(v attr.Value) (typ, val string) {
+	switch v.Type() {
+	case attr.Boolean:
+		b, _ := v.Bool()
+		return "boolean", strconv.FormatBool(b)
+	case attr.Integer:
+		i, _ := v.Int()
+		return "integer", strconv.FormatInt(i, 10)
+	case attr.Double:
+		f, _ := v.Float()
+		return "double", strconv.FormatFloat(f, 'g', -1, 64)
+	case attr.String:
+		s, _ := v.Str()
+		return "string", s
+	case attr.Bytes:
+		raw, _ := v.Raw()
+		return "bytes", base64.StdEncoding.EncodeToString(raw)
+	default:
+		return "string", ""
+	}
+}
+
+// valueFromRecipe reconstructs a typed value from its (type tag, string) recipe form, erroring on
+// an unknown tag or an unparsable value.
+func valueFromRecipe(typ, val string) (attr.Value, error) {
+	switch typ {
+	case "boolean":
+		b, err := strconv.ParseBool(val)
+		return attr.BoolValue(b), err
+	case "integer":
+		i, err := strconv.ParseInt(val, 10, 64)
+		return attr.IntValue(i), err
+	case "double":
+		f, err := strconv.ParseFloat(val, 64)
+		return attr.FloatValue(f), err
+	case "string":
+		return attr.StringValue(val), nil
+	case "bytes":
+		raw, err := base64.StdEncoding.DecodeString(val)
+		return attr.BytesValue(raw), err
+	default:
+		return attr.Value{}, fmt.Errorf("compdef: unknown property type %q", typ)
+	}
+}

--- a/model/compdef/properties_recipe_test.go
+++ b/model/compdef/properties_recipe_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/model/attr"
+)
+
+// TestPartPropertiesRoundTrip: a part's authored iProperties survive a recipe round-trip (save →
+// reopen), so a part number set on a document is there when it is read back (#156).
+func TestPartPropertiesRoundTrip(t *testing.T) {
+	d := NewPartComponentDefinition()
+	d.Properties().Set(attr.DesignTracking).Put("Part Number", attr.StringValue("BRK-001"))
+	d.Properties().Set(attr.UserDefined).Put("Vendor", attr.StringValue("Acme"))
+
+	data, err := d.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	got := NewPartComponentDefinition()
+	if err := got.ApplyRecipe(data); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if v := propertyString(t, got, attr.DesignTracking, "Part Number"); v != "BRK-001" {
+		t.Errorf("restored Part Number = %q, want BRK-001", v)
+	}
+	if v := propertyString(t, got, attr.UserDefined, "Vendor"); v != "Acme" {
+		t.Errorf("restored custom Vendor = %q, want Acme", v)
+	}
+}
+
+// TestAssemblyPropertiesRoundTrip: an assembly's iProperties round-trip through its recipe too.
+func TestAssemblyPropertiesRoundTrip(t *testing.T) {
+	a := NewAssemblyComponentDefinition()
+	a.Properties().Set(attr.SummaryInformation).Put("Title", attr.StringValue("Gearbox"))
+
+	data, err := a.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	got := NewAssemblyComponentDefinition()
+	if err := got.ApplyRecipe(data); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	set, ok := got.Properties().Lookup(attr.SummaryInformation)
+	if !ok {
+		t.Fatal("restored assembly has no Summary Information set")
+	}
+	p, ok := set.Property("Title")
+	if !ok {
+		t.Fatal("restored assembly has no Title property")
+	}
+	if v, _ := p.Value().Str(); v != "Gearbox" {
+		t.Errorf("restored Title = %q, want Gearbox", v)
+	}
+}
+
+// TestPropertyValueTypesRoundTrip: every value type survives the (type, string) recipe encoding.
+func TestPropertyValueTypesRoundTrip(t *testing.T) {
+	cases := []attr.Value{
+		attr.StringValue("hello"),
+		attr.IntValue(-42),
+		attr.FloatValue(3.5),
+		attr.BoolValue(true),
+		attr.BytesValue([]byte{1, 2, 3}),
+	}
+	for _, want := range cases {
+		typ, val := valueToRecipe(want)
+		got, err := valueFromRecipe(typ, val)
+		if err != nil {
+			t.Fatalf("valueFromRecipe(%q,%q): %v", typ, val, err)
+		}
+		if !got.Equal(want) {
+			t.Errorf("round-trip of %v via (%q,%q) = %v", want, typ, val, got)
+		}
+	}
+}
+
+// propertyString reads a string property from a part's set, failing if absent or not a string.
+func propertyString(t *testing.T, d *PartComponentDefinition, set, name string) string {
+	t.Helper()
+	s, ok := d.Properties().Lookup(set)
+	if !ok {
+		t.Fatalf("no property set %q", set)
+	}
+	p, ok := s.Property(name)
+	if !ok {
+		t.Fatalf("no property %q in set %q", name, set)
+	}
+	v, _ := p.Value().Str()
+	return v
+}

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -8,6 +8,7 @@ import (
 	"oblikovati.org/api/types"
 
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/attr"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/identity"
@@ -45,6 +46,7 @@ type partRecipe struct {
 	Sketches3D        []sketch.SketchData3D        `yaml:"sketches3D,omitempty"`
 	Features          []feature.FeatureData        `yaml:"features,omitempty"`
 	Materials         *material.RecipeData         `yaml:"materials,omitempty"`
+	Properties        []propertyRecipe             `yaml:"properties,omitempty"` // document iProperties (#156)
 }
 
 // sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
@@ -198,6 +200,7 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		Sketches3D:        sketches3D,
 		Features:          features,
 		Materials:         d.materialsRecipe(),
+		Properties:        propertiesRecipeOf(d.props),
 	}
 	if d.eop != endOfPartAtEnd {
 		eop := d.eop
@@ -235,6 +238,7 @@ func (d *PartComponentDefinition) resetRecipe() {
 	d.assignments = material.NewAssignmentStore()
 	d.assets = material.NewAssetSet()
 	d.bodies = topo.NewSurfaceBodies()
+	d.props = attr.NewPropertySets()
 }
 
 // ApplyRecipe restores the part from recipe YAML and recomputes (doc.RecipeContent).
@@ -246,6 +250,7 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 	if err := d.applyUnits(r.Units); err != nil {
 		return err
 	}
+	applyPropertiesRecipe(d.props, r.Properties)
 	if err := d.applyParameters(r.ParameterGroups, r.Parameters); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What
The source half of #156 (the API contract merged in Oblikovati.API#92). The iProperty *model* (`model/attr` `PropertySets`) already existed but was wired into **no document** — so a document had no metadata source, blocking the BOM's part numbers/descriptions (#718). This attaches it and serves the wire surface.

- **compdef**: the part and assembly definitions own an `attr.PropertySets` (the four standard sets — Summary / Document Summary / Design Tracking / User Defined — created on construction), exposed via `Properties()`.
- **persistence**: authored properties round-trip through the part/assembly recipe as small, human-readable YAML records (`set`, `name`, typed value). A reset (undo/reopen) re-applies the snapshot onto a clean set. Reuses the recipe channel — no new doc-level format.
- **router**: `documents.listProperties` / `getProperty` / `setProperty` resolve a document to its content's `PropertySets` and convert each value between the model `attr.Value` and the wire `types.Variant`.

## Tests
- `model/compdef`: part + assembly recipe round-trip (a part number / title survives save→reopen); every value type's `(type, string)` encoding round-trips.
- `addin/router`: the over-wire `setProperty → getProperty → listProperties` path; an unknown property read is rejected.

`go build ./...`, `go test ./model/compdef/... ./addin/router/... ./app/...`, `golangci-lint` all green.

## Notes
- Depends on **Oblikovati.API#92** (merged).
- The expression-engine bridge (parameters referencing properties) is left as a follow-up, per the issue.
- Unblocks **#718** (BOM component metadata from iProperties).

Closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)