### PR TITLE
feat: BOM component metadata from iProperties (#718)

### DIFF
--- a/model/bom/bom.go
+++ b/model/bom/bom.go
@@ -141,7 +141,7 @@ func newRow(comp Component, def occurrence.Definition, quantity int) *Row {
 		Description: comp.Description(),
 		Structure:   comp.BOMStructure(),
 		Quantity:    quantity,
-		Properties:  comp.Properties(),
+		Properties:  comp.CustomProperties(),
 		Definition:  def,
 	}
 }

--- a/model/bom/bom_test.go
+++ b/model/bom/bom_test.go
@@ -18,11 +18,11 @@ type fakePart struct {
 	props     map[string]string
 }
 
-func (p *fakePart) RangeBox() math.Box            { return math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)) }
-func (p *fakePart) PartNumber() string            { return p.num }
-func (p *fakePart) Description() string           { return p.desc }
-func (p *fakePart) BOMStructure() Structure       { return p.structure }
-func (p *fakePart) Properties() map[string]string { return p.props }
+func (p *fakePart) RangeBox() math.Box                  { return math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)) }
+func (p *fakePart) PartNumber() string                  { return p.num }
+func (p *fakePart) Description() string                 { return p.desc }
+func (p *fakePart) BOMStructure() Structure             { return p.structure }
+func (p *fakePart) CustomProperties() map[string]string { return p.props }
 
 // fakeAssembly is a named sub-assembly component: a Composite (owns occurrences) that
 // is also a bom.Component.

--- a/model/bom/structure.go
+++ b/model/bom/structure.go
@@ -44,6 +44,17 @@ func (s Structure) String() string {
 	}
 }
 
+// ParseStructure resolves a structure's lowercase name back to its value, reporting false on an
+// unknown name (so a stored "BOM Structure" property maps to the enum; #718).
+func ParseStructure(s string) (Structure, bool) {
+	for _, v := range []Structure{Normal, Phantom, Reference, Purchased, Inseparable} {
+		if v.String() == s {
+			return v, true
+		}
+	}
+	return Normal, false
+}
+
 // expands reports whether a sub-assembly of this structure is traversed into its
 // children (Normal/Phantom) rather than counted as one opaque line
 // (Purchased/Inseparable). Reference is neither — it is dropped from counts entirely.
@@ -62,16 +73,16 @@ type Component interface {
 	Description() string
 	// BOMStructure is how the component participates in the BOM.
 	BOMStructure() Structure
-	// Properties are the component's custom properties (iProperties), keyed by name,
+	// CustomProperties are the component's properties (iProperties), keyed by name,
 	// available as export columns.
-	Properties() map[string]string
+	CustomProperties() map[string]string
 }
 
 // defaultComponent is the metadata used for a placed definition that does not
 // implement [Component]: a normal, unnamed line.
 type defaultComponent struct{}
 
-func (defaultComponent) PartNumber() string            { return "" }
-func (defaultComponent) Description() string           { return "" }
-func (defaultComponent) BOMStructure() Structure       { return Normal }
-func (defaultComponent) Properties() map[string]string { return nil }
+func (defaultComponent) PartNumber() string                  { return "" }
+func (defaultComponent) Description() string                 { return "" }
+func (defaultComponent) BOMStructure() Structure             { return Normal }
+func (defaultComponent) CustomProperties() map[string]string { return nil }

--- a/model/compdef/bom_metadata.go
+++ b/model/compdef/bom_metadata.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"strconv"
+
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/bom"
+)
+
+// Document BOM metadata (#718): the part and assembly definitions satisfy [bom.Component] by
+// reading their iProperties (#156), so a BOM over a real assembly shows each component's part
+// number, description, and custom property columns — instead of the blank default a definition
+// without metadata falls back to. The BOM structure rides a Design Tracking property, so it
+// persists through the same recipe channel as the rest of the iProperties.
+//
+// A per-OCCURRENCE structure override (the reference API allows one) is a follow-up: occurrence
+// cannot return a bom.Structure without an import cycle (bom imports occurrence).
+
+var (
+	_ bom.Component = (*PartComponentDefinition)(nil)
+	_ bom.Component = (*AssemblyComponentDefinition)(nil)
+)
+
+// The Design Tracking property names the BOM reads.
+const (
+	propPartNumber   = "Part Number"
+	propDescription  = "Description"
+	propBOMStructure = "BOM Structure"
+)
+
+// PartNumber / Description / BOMStructure / CustomProperties implement [bom.Component] for a part
+// from its iProperties.
+func (d *PartComponentDefinition) PartNumber() string {
+	return designTrackingProperty(d.props, propPartNumber)
+}
+func (d *PartComponentDefinition) Description() string {
+	return designTrackingProperty(d.props, propDescription)
+}
+func (d *PartComponentDefinition) BOMStructure() bom.Structure { return bomStructureOf(d.props) }
+func (d *PartComponentDefinition) CustomProperties() map[string]string {
+	return customPropertiesOf(d.props)
+}
+
+// PartNumber / Description / BOMStructure / CustomProperties implement [bom.Component] for an
+// assembly (a sub-assembly carries metadata too) from its iProperties.
+func (a *AssemblyComponentDefinition) PartNumber() string {
+	return designTrackingProperty(a.props, propPartNumber)
+}
+func (a *AssemblyComponentDefinition) Description() string {
+	return designTrackingProperty(a.props, propDescription)
+}
+func (a *AssemblyComponentDefinition) BOMStructure() bom.Structure { return bomStructureOf(a.props) }
+func (a *AssemblyComponentDefinition) CustomProperties() map[string]string {
+	return customPropertiesOf(a.props)
+}
+
+// designTrackingProperty reads a string-valued property from the Design Tracking set, returning ""
+// when the set or property is absent or not a string.
+func designTrackingProperty(ps *attr.PropertySets, name string) string {
+	s, ok := ps.Lookup(attr.DesignTracking)
+	if !ok {
+		return ""
+	}
+	p, ok := s.Property(name)
+	if !ok {
+		return ""
+	}
+	v, _ := p.Value().Str()
+	return v
+}
+
+// bomStructureOf maps the "BOM Structure" Design Tracking property to a [bom.Structure], defaulting
+// to Normal when it is unset or unrecognized.
+func bomStructureOf(ps *attr.PropertySets) bom.Structure {
+	if st, ok := bom.ParseStructure(designTrackingProperty(ps, propBOMStructure)); ok {
+		return st
+	}
+	return bom.Normal
+}
+
+// customPropertiesOf flattens every property across the document's sets into a name→display-string
+// map, the source for a BOM's custom export columns. Returns nil when there are no properties.
+func customPropertiesOf(ps *attr.PropertySets) map[string]string {
+	out := map[string]string{}
+	for _, set := range ps.Sets() {
+		for _, p := range set.Properties() {
+			out[p.Name()] = propertyDisplayString(p.Value())
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// propertyDisplayString renders a typed value for a BOM column (a string property is verbatim;
+// numbers/booleans format; bytes are not column data and render empty).
+func propertyDisplayString(v attr.Value) string {
+	switch v.Type() {
+	case attr.Integer:
+		i, _ := v.Int()
+		return strconv.FormatInt(i, 10)
+	case attr.Double:
+		f, _ := v.Float()
+		return strconv.FormatFloat(f, 'g', -1, 64)
+	case attr.Boolean:
+		b, _ := v.Bool()
+		return strconv.FormatBool(b)
+	case attr.Bytes:
+		return ""
+	default:
+		s, _ := v.Str()
+		return s
+	}
+}

--- a/model/compdef/bom_metadata_test.go
+++ b/model/compdef/bom_metadata_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/bom"
+)
+
+// TestBOMReadsComponentIProperties is the #718 payoff: a BOM over an assembly shows each
+// component's part number, description, and custom property columns, sourced from the component
+// document's iProperties — not the blank default.
+func TestBOMReadsComponentIProperties(t *testing.T) {
+	part := NewPartComponentDefinition()
+	part.Properties().Set(attr.DesignTracking).Put(propPartNumber, attr.StringValue("BRK-001"))
+	part.Properties().Set(attr.DesignTracking).Put(propDescription, attr.StringValue("Bracket"))
+	part.Properties().Set(attr.UserDefined).Put("Material", attr.StringValue("Steel"))
+
+	asm := NewAssemblyComponentDefinition()
+	asm.Occurrences().AddByComponentDefinition("p:1", part, math.Identity4())
+
+	rows := bom.New(asm.Occurrences()).PartsOnly().Rows
+	if len(rows) != 1 {
+		t.Fatalf("BOM rows = %d, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.PartNumber != "BRK-001" {
+		t.Errorf("row PartNumber = %q, want BRK-001", r.PartNumber)
+	}
+	if r.Description != "Bracket" {
+		t.Errorf("row Description = %q, want Bracket", r.Description)
+	}
+	if r.Properties["Material"] != "Steel" {
+		t.Errorf("custom column Material = %q, want Steel", r.Properties["Material"])
+	}
+}
+
+// TestBOMStructureFromProperty: a component's BOM structure is read from its "BOM Structure"
+// Design Tracking property (default Normal when unset).
+func TestBOMStructureFromProperty(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if got := d.BOMStructure(); got != bom.Normal {
+		t.Errorf("default BOMStructure = %v, want Normal", got)
+	}
+	d.Properties().Set(attr.DesignTracking).Put(propBOMStructure, attr.StringValue("purchased"))
+	if got := d.BOMStructure(); got != bom.Purchased {
+		t.Errorf("BOMStructure after setting the property = %v, want Purchased", got)
+	}
+}
+
+// TestEmptyDocumentBOMMetadataIsBlank: a document with no iProperties reports blank metadata (the
+// BOM falls back to a normal, unnamed line), so the default is unchanged.
+func TestEmptyDocumentBOMMetadataIsBlank(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if d.PartNumber() != "" || d.Description() != "" || d.CustomProperties() != nil {
+		t.Errorf("empty document metadata = (%q, %q, %v), want blank", d.PartNumber(), d.Description(), d.CustomProperties())
+	}
+}


### PR DESCRIPTION
## What
The BOM read a **blank default** for every component (no part number, description, or custom columns) because no `compdef` definition implemented `bom.Component`. Now they source that metadata from their iProperties (#156):

- The part and assembly definitions implement `bom.Component` — **PartNumber** and **Description** from the Design Tracking set, **CustomProperties** flattened from every set (the source of custom export columns), and **BOMStructure** from a `"BOM Structure"` Design Tracking property (default `Normal`), which persists through the same recipe channel as the rest of the iProperties.
- `bom.Component.Properties()` is renamed `CustomProperties()` so the `Properties()` name is free for the document's `attr.PropertySets` accessor (#156). `bom.ParseStructure` maps the stored structure name back to the enum.

So a BOM (the panel or CSV from #768) over a real assembly now shows each component's **number, description, and custom columns** instead of blank cells.

## Tests
- `TestBOMReadsComponentIProperties` — a placed part with Part Number / Description / a custom `Material` property → the BOM row shows all three.
- `TestBOMStructureFromProperty` — default `Normal`; set `"BOM Structure" = "purchased"` → `Purchased`.
- `TestEmptyDocumentBOMMetadataIsBlank` — a document with no iProperties is blank (the default is unchanged).

`go build ./...`, `go test ./model/bom/... ./model/compdef/...`, `golangci-lint` all green.

## Notes
- Depends on **#156** (merged).
- A per-**occurrence** BOM-structure override is a follow-up (it would require `occurrence` to import `bom` — a cycle).

Closes #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)