### PR TITLE
feat: assembly sketching + Extrude (#766)

### DIFF
--- a/app/assembly_sketch_features.go
+++ b/app/assembly_sketch_features.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/feature"
+)
+
+// Assembly sketched features (#766): once a sketch is authored in assembly space (the sketch
+// environment is content-agnostic), an assembly Extrude runs its profile against every
+// participant body as a machining feature — adding or cutting material across the components. The
+// profile is picked in the viewport (a ProfileHandle); distance and operation come from the
+// generic tool-param dialog. The geometry is model/feature's AssemblyExtrudeFeature.
+
+// assemblyExtrudeOps maps the tool's operation choice index to the kernel operation. Cut is first
+// because an assembly extrude is most often a pocket cut across components.
+var assemblyExtrudeOps = []ops.PartFeatureOperation{ops.Cut, ops.Join, ops.Intersect, ops.NewBody}
+
+// AssemblyExtrudeTool extrudes a picked assembly-sketch profile into a machining feature applied to
+// every participant.
+type AssemblyExtrudeTool struct {
+	profile   *ProfileHandle
+	distance  float64
+	operation int // index into assemblyExtrudeOps
+}
+
+// NewAssemblyExtrudeTool returns an extrude tool with a 1-unit Cut default.
+func NewAssemblyExtrudeTool() *AssemblyExtrudeTool { return &AssemblyExtrudeTool{distance: 1} }
+func (t *AssemblyExtrudeTool) Name() string        { return "Extrude" }
+func (t *AssemblyExtrudeTool) Prompt(*Session) string {
+	return "Pick a sketch profile, set the distance and operation, then OK."
+}
+func (t *AssemblyExtrudeTool) Start(*Session) {}
+
+// Pick collects the profile region clicked in the viewport.
+func (t *AssemblyExtrudeTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(ProfileHandle); ok {
+		t.profile = &h
+	}
+}
+func (t *AssemblyExtrudeTool) Cancel(*Session) { t.profile = nil }
+func (t *AssemblyExtrudeTool) CanCommit() bool { return t.profile != nil && t.distance > 0 }
+
+func (t *AssemblyExtrudeTool) Commit(s *Session) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if t.profile == nil {
+		return errors.New("extrude: pick a sketch profile first")
+	}
+	d := t.distance
+	op := assemblyExtrudeOps[t.operation]
+	af := asm.AddFeature(feature.NewAssemblyExtrudeFeature(t.profile.Sketch, t.profile.ProfileIndex, op, func() float64 { return d }))
+	af.SetName(asm.Features().UniqueName(af.Kind()))
+	asm.RecomputeFeatures()
+	return nil
+}
+
+func (t *AssemblyExtrudeTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{
+			{"Distance", func() float64 { return t.distance }, func(v float64) { t.distance = v }},
+		},
+		Choices: []ChoiceParam{
+			{Label: "Operation", Options: []string{"Cut", "Join", "Intersect", "New body"},
+				Get: func() int { return t.operation }, Set: func(i int) { t.operation = i }},
+		},
+	}
+}

--- a/app/assembly_sketch_features_test.go
+++ b/app/assembly_sketch_features_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestCreateSketchOnAssembly: the sketch environment now opens on an assembly — CreateSketch adds
+// the sketch to the assembly and enters the editing environment (#766).
+func TestCreateSketchOnAssembly(t *testing.T) {
+	s := assemblySession(t)
+	asm := s.ActiveDocument().Content().(*compdef.AssemblyComponentDefinition)
+
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch on an assembly: %v", err)
+	}
+	if !s.InSketch() {
+		t.Error("CreateSketch should enter the sketch environment")
+	}
+	if asm.Sketches().Count() != 1 || asm.Sketches().Item(0) != sk {
+		t.Error("the sketch should be added to the assembly")
+	}
+}
+
+// TestAssemblySketchCommandsOnAssemblyRibbon: the Assemble tab offers Create 2D Sketch, and the
+// contextual Sketch tab's tools appear on the assembly ribbon while editing an assembly sketch.
+func TestAssemblySketchCommandsOnAssemblyRibbon(t *testing.T) {
+	s := assemblySession(t)
+	if cmd, ok := s.Commands().ByID("Assembly.CreateSketch"); !ok || !cmd.IsEnabled(s) {
+		t.Fatal("the Assemble tab should offer an enabled Create 2D Sketch")
+	}
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	tab, ok := BuildRibbon(s).Tab("Sketch")
+	if !ok {
+		t.Fatal("the contextual Sketch tab should appear on the assembly ribbon while sketching")
+	}
+	if _, ok := tab.Panel("Create"); !ok {
+		t.Error("the assembly Sketch tab has no Create panel (Line/Rectangle/…)")
+	}
+}
+
+// TestAssemblyExtrudeMachinesFromSketch is the end-to-end #766 sketch path: author a sketch on an
+// assembly, extrude-cut its profile across a placed component, and confirm an assemblyExtrude
+// feature machined the participant (its volume dropped).
+func TestAssemblyExtrudeMachinesFromSketch(t *testing.T) {
+	s, asm, occ := assemblyWithBoxComponent(t, 0) // box [0,2]×[0,2]×[0,4], assembly active
+
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	sk.AddRectangleByCorners(math.P2(0.5, 0.5), math.P2(1.5, 1.5)) // a 1×1 window inside the box footprint
+	if err := s.FinishSketch(); err != nil {
+		t.Fatalf("FinishSketch: %v", err)
+	}
+	if sk.Profiles().Count() == 0 {
+		t.Fatal("the finished assembly sketch has no profile to extrude")
+	}
+
+	tool := NewAssemblyExtrudeTool()
+	tool.Pick(s, ProfileHandle{Sketch: sk, ProfileIndex: 0})
+	tool.distance = 4  // through the box height
+	tool.operation = 0 // Cut
+	if !tool.CanCommit() {
+		t.Fatal("an extrude with a profile and a positive distance should be committable")
+	}
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if asm.Features().Count() != 1 || asm.Features().Item(0).Kind() != "assemblyExtrude" {
+		t.Fatalf("features = %d, want one assemblyExtrude", asm.Features().Count())
+	}
+	// A 1×1 cut through the 16-unit box removes 1×1×4 = 4 ⇒ 12.
+	if got := participantMachinedVolume(asm, occ); stdmath.Abs(got-12) > 0.1 {
+		t.Errorf("extrude-cut participant volume = %g, want 12 (16 minus a 1×1×4 pocket)", got)
+	}
+}

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -13,6 +13,19 @@ package app
 func assemblyTabCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		placeComponentCommand(),
+		NewCommand("Assembly.CreateSketch", "Create 2D Sketch", "Sketch", func(s *Session) error {
+			if s.SelectedWorkPlane() != nil {
+				_, err := s.CreateSketchOnSelectedPlane()
+				return err
+			}
+			s.StartTool(NewCreateSketchTool())
+			return nil
+		}).WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(canCreateSketch).
+			WithIcon("create-sketch").WithButtonStyle(LargeIconButton).
+			WithTooltip("Create 2D Sketch — author a sketch in assembly space (extrude/revolve machine the components)."),
+		assemblyToolCommand("Assembly.Extrude", "Extrude", "Modify", "extrude",
+			"Extrude — run a sketch profile across the components to add or cut material.",
+			func() Tool { return NewAssemblyExtrudeTool() }),
 		assemblyToolCommand("Assembly.RectangularPattern", "Rectangular Pattern", "Pattern", "rectangular-pattern",
 			"Rectangular Pattern — replicate the selected component on a grid (counts and spacing).",
 			func() Tool { return NewAssemblyRectPatternTool() }),

--- a/app/commands_sketch.go
+++ b/app/commands_sketch.go
@@ -45,11 +45,17 @@ func sketchTabCommands() []*CommandDefinition {
 	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
 		WithIcon("project-geometry").WithButtonStyle(LargeIconButton).
 		WithTooltip("Project Geometry — pick part edges/vertices to reference onto the sketch plane."))
-	return append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
+	cmds = append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
 		return s.FinishSketch()
 	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
 		WithIcon("finish-sketch").WithButtonStyle(LargeIconButton).
 		WithTooltip("Finish Sketch — leave the sketch environment and update the part."))
+	// The contextual Sketch tab serves a part AND an assembly sketch — the environment is now
+	// content-agnostic (#766) — so its tools appear on both ribbons.
+	for _, c := range cmds {
+		c.WithRibbons(PartRibbon, AssemblyRibbon)
+	}
+	return cmds
 }
 
 // sketchToolEntry is one tool-launching command (id/label/alias/tooltip + factory).

--- a/app/sketch_env.go
+++ b/app/sketch_env.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
 )
 
@@ -16,18 +17,44 @@ import (
 // the new/edited sketch. The geometry lives in model/sketch; the Session only tracks
 // which sketch is being edited (activeSketch).
 
-// CreateSketch adds a new sketch on the given plane to the active part and enters the
-// sketch environment to edit it. It errors when there is no active part or a sketch is
-// already being edited (Inventor forbids nesting sketch edits).
+// sketchHost is the active document's content a sketch is authored on — a part or an assembly.
+// Both own a sketch collection and the parameter DAG dimensions share, and both recompute, so the
+// sketch environment opens, finishes, and recomputes against either without knowing which (#766,
+// mirroring the content-agnostic router seam).
+type sketchHost interface {
+	Sketches() *sketch.Sketches
+	Parameters() *param.Parameters
+	Recompute()
+}
+
+// activeSketchHost resolves the active document's content as a sketch host, erroring when there is
+// no active document or its content hosts no sketches.
+func activeSketchHost(s *Session) (sketchHost, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, errors.New("app: no active document")
+	}
+	host, ok := d.Content().(sketchHost)
+	if !ok {
+		return nil, errors.New("app: the active document hosts no sketches")
+	}
+	return host, nil
+}
+
+// CreateSketch adds a new sketch on the given plane to the active document (part or assembly) and
+// enters the sketch environment to edit it. The sketch shares the host's parameter DAG so its
+// dimension expressions resolve against the host's parameters. It errors when there is no sketch
+// host active or a sketch is already being edited (Inventor forbids nesting sketch edits).
 func (s *Session) CreateSketch(plane sketch.Plane) (*sketch.Sketch, error) {
 	if s.activeSketch != nil {
 		return nil, errors.New("app: already editing a sketch (finish it first)")
 	}
-	part, err := activePart(s)
+	host, err := activeSketchHost(s)
 	if err != nil {
 		return nil, err
 	}
-	sk := part.Sketches().Add(plane)
+	sk := host.Sketches().Add(plane)
+	sk.SetParameters(host.Parameters()) // dimension expressions resolve in the host's table
 	s.EnterSketch(sk)
 	return sk, nil
 }
@@ -90,9 +117,11 @@ func (s *Session) FinishSketch() error {
 		s.CancelTool() // an in-progress geometry tool is abandoned on finish
 	}
 	s.ExitSketch()
-	if part, err := activePart(s); err == nil {
-		part.Recompute()
-		s.recordEdit(part, "Sketch")
+	if host, err := activeSketchHost(s); err == nil {
+		host.Recompute()
+		if rs, ok := host.(recipeStore); ok {
+			s.recordEdit(rs, "Sketch")
+		}
 	}
 	return nil
 }
@@ -107,6 +136,6 @@ func (s *Session) CanCreateSketch() bool {
 	if s.activeSketch != nil {
 		return false
 	}
-	_, err := activePart(s)
+	_, err := activeSketchHost(s)
 	return err == nil
 }

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -191,6 +191,11 @@ func (a *AssemblyComponentDefinition) Parameters() *param.Parameters { return a.
 // Properties returns the assembly's iProperties (document metadata sets), like a part's (#156).
 func (a *AssemblyComponentDefinition) Properties() *attr.PropertySets { return a.props }
 
+// Recompute re-solves the assembly (its sketches, work geometry, and feature program) — the
+// sketch-host-uniform name the sketch environment calls on Finish, aliasing RecomputeFeatures so
+// a part and an assembly present one recompute method (#766).
+func (a *AssemblyComponentDefinition) Recompute() { a.RecomputeFeatures() }
+
 // WorkGeometry returns the assembly's origin coordinate frame and user work
 // planes/axes/points, expressed in assembly space — the planes a sketch is authored on.
 func (a *AssemblyComponentDefinition) WorkGeometry() *feature.WorkGeometry { return a.work }


### PR DESCRIPTION
## What
Generalize the sketch environment from **part-only** to a content-agnostic **sketchHost** (part *or* assembly), and wire the assembly entry points — so a sketch can be authored in assembly space and **extruded across the components**. This is the sketch-based half of #766 (the dress-up half — chamfer/fillet — shipped earlier).

- **sketch env**: `CreateSketch` / `FinishSketch` / `CanCreateSketch` resolve the active document as a `sketchHost` (`Sketches` + `Parameters` + `Recompute`) instead of `activePart`; the sketch shares the host's parameter DAG so dimensions resolve. **The full part sketch suite is unchanged** (verified), so parts do not regress. `AssemblyComponentDefinition` gains a `Recompute` alias for the uniform interface.
- **ribbon**: the contextual Sketch tab's tools now appear on the assembly ribbon (the environment is content-agnostic), and the **Assemble tab offers Create 2D Sketch**.
- **assembly Extrude**: a tool that runs a picked sketch profile across the participants as a machining feature (Cut / Join / Intersect / New body) via the existing `AssemblyExtrudeFeature`.

## Tests
- `TestCreateSketchOnAssembly` — the environment opens on an assembly; the sketch lands in the assembly.
- `TestAssemblySketchCommandsOnAssemblyRibbon` — Create 2D Sketch on the Assemble tab; the Sketch tab's Create panel appears on the assembly ribbon while sketching.
- `TestAssemblyExtrudeMachinesFromSketch` — **end to end**: author a sketch → extrude-cut a 1×1 window through a placed 2×2×4 box → an `assemblyExtrude` feature machines the participant to exactly **12** (16 minus the 1×1×4 pocket).

`go test ./app/...` green (full suite, no part regression); `golangci-lint` 0 issues; head builds + icon-resolve passes.

## Remaining for #766 (follow-ups)
Revolve/Hole tools (same path) + the in-session feature edit. And assembly machining features still don't persist/undo (tracked in **#785**).

Advances #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)