### PR TITLE
feat: persist + undo the assembly feature program (#785)

### DIFF
--- a/app/assembly_dressup_tools.go
+++ b/app/assembly_dressup_tools.go
@@ -83,10 +83,11 @@ func (t *assemblyEdgeSelectTool) resolve(s *Session, op string) (*compdef.Assemb
 }
 
 // finish names the new dress-up feature, recomputes the assembly so the participants re-machine,
-// and clears the edge filter.
+// records the undo step (the feature program now persists, #785), and clears the edge filter.
 func (t *assemblyEdgeSelectTool) finish(s *Session, asm *compdef.AssemblyComponentDefinition, af *compdef.AssemblyFeature) {
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
+	s.recordEdit(asm, af.Kind())
 	s.Selection().SetFilter(NewSelectionFilter())
 }
 

--- a/app/assembly_feature_undo_test.go
+++ b/app/assembly_feature_undo_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestAssemblyChamferIsUndoable: now that the assembly feature program serializes (#785), adding a
+// chamfer is one undo step — undo removes it (the recipe restores without it, then re-binds), redo
+// restores it. This exercises the full RestoreRecipe → ApplyRecipe → ResolveReferences path.
+func TestAssemblyChamferIsUndoable(t *testing.T) {
+	s, asm, _ := assemblyWithBoxComponent(t, 0)
+	trackFromHere(s) // baseline: the box placed, no features
+
+	tool := NewAssemblyChamferTool()
+	tool.Pick(s, worldVerticalEdge(t, s))
+	tool.distance = 0.2
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("chamfer: %v", err)
+	}
+	if asm.Features().Count() != 1 {
+		t.Fatalf("after chamfer: feature count = %d, want 1", asm.Features().Count())
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if asm.Features().Count() != 0 {
+		t.Errorf("undo should remove the chamfer: feature count = %d, want 0", asm.Features().Count())
+	}
+	if err := s.Redo(); err != nil {
+		t.Fatalf("redo: %v", err)
+	}
+	if asm.Features().Count() != 1 || asm.Features().Item(0).Kind() != "assemblyChamfer" {
+		t.Errorf("redo should restore the chamfer: features = %d", asm.Features().Count())
+	}
+}
+
+// TestAssemblyExtrudeIsUndoable: a sketch-based extrude undoes too — both the sketch and the
+// extrude round-trip through the recipe.
+func TestAssemblyExtrudeIsUndoable(t *testing.T) {
+	s, asm, occ := assemblyWithBoxComponent(t, 0)
+	trackFromHere(s) // baseline: the box, no sketch, no features
+
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	sk.AddRectangleByCorners(math.P2(0.5, 0.5), math.P2(1.5, 1.5))
+	if err := s.FinishSketch(); err != nil { // records the sketch step
+		t.Fatalf("FinishSketch: %v", err)
+	}
+	tool := NewAssemblyExtrudeTool()
+	tool.Pick(s, ProfileHandle{Sketch: sk, ProfileIndex: 0})
+	tool.distance = 4
+	if err := tool.Commit(s); err != nil { // records the extrude step
+		t.Fatalf("extrude: %v", err)
+	}
+	if got := participantMachinedVolume(asm, occ); got >= 16 {
+		t.Fatalf("the extrude did not machine the participant: volume %g", got)
+	}
+
+	if err := s.Undo(); err != nil { // undo the extrude
+		t.Fatalf("undo: %v", err)
+	}
+	if asm.Features().Count() != 0 {
+		t.Errorf("undo should remove the extrude: feature count = %d, want 0", asm.Features().Count())
+	}
+	// The sketch survives the extrude's undo (it was created in a prior step).
+	if asm.Sketches().Count() != 1 {
+		t.Errorf("the sketch should survive the extrude undo: sketch count = %d, want 1", asm.Sketches().Count())
+	}
+}

--- a/app/assembly_machining_tools.go
+++ b/app/assembly_machining_tools.go
@@ -87,6 +87,7 @@ func (t *AssemblyRevolveTool) Commit(s *Session) error {
 	af := asm.AddFeature(feature.NewAssemblyRevolveFeature(t.profile.Sketch, t.profile.ProfileIndex, axis, assemblyExtrudeOps[t.operation], func() float64 { return a }))
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Revolve") // the feature program persists + undoes (#785)
 	return nil
 }
 
@@ -138,6 +139,7 @@ func (t *AssemblyHoleTool) Commit(s *Session) error {
 	af := asm.AddFeature(hole)
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Hole") // the feature program persists + undoes (#785)
 	return nil
 }
 

--- a/app/assembly_sketch_features.go
+++ b/app/assembly_sketch_features.go
@@ -57,6 +57,7 @@ func (t *AssemblyExtrudeTool) Commit(s *Session) error {
 	af := asm.AddFeature(feature.NewAssemblyExtrudeFeature(t.profile.Sketch, t.profile.ProfileIndex, op, func() float64 { return d }))
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Extrude") // the feature program persists + undoes (#785)
 	return nil
 }
 

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -42,6 +42,10 @@ type AssemblyComponentDefinition struct {
 	// component definitions — ApplyRecipe has no workspace, so binding waits for
 	// ResolveReferences once the document is registered (#715). Empty outside a reopen.
 	pending []occurrenceRecipe
+	// pendingFeatures holds the machining program parsed by ApplyRecipe but not yet rebuilt —
+	// features bind after the occurrences resolve (they snapshot participation), so they wait
+	// for ResolveReferences like the occurrences do (#785). Empty outside a reopen/restore.
+	pendingFeatures []assemblyFeatureProgramRecipe
 	// props are the assembly document's iProperties (metadata sets), like a part's (#156).
 	props *attr.PropertySets
 }

--- a/model/compdef/assembly_feature_serialize_test.go
+++ b/model/compdef/assembly_feature_serialize_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// TestAssemblyFeatureProgramRoundTrips is the #785 save/load acceptance: an assembly's machining
+// program survives a save and reopen — the features are restored in order with their inputs, not
+// dropped (the gap this closes). Uses a parametric hole and a fillet (no geometry needed to record
+// them) plus a real placed component, so the reopen runs the full ResolveReferences path.
+func TestAssemblyFeatureProgramRoundTrips(t *testing.T) {
+	store, ws, asm, widget, asmDef := placedAssembly(t)
+	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+
+	down, err := math.NewUnitVector3(0, 0, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hole, err := feature.NewAssemblyHoleFeature(math.P3(1, 1, 1), down, 0.5, 1)
+	if err != nil {
+		t.Fatalf("hole: %v", err)
+	}
+	asmDef.AddFeature(hole)
+	asmDef.AddFeature(feature.NewAssemblyFilletFeature([][]byte{[]byte("e0")}, func() float64 { return 0.3 }))
+
+	def := reopenAssembly(t, store, ws, asm)
+	if def.Features().Count() != 2 {
+		t.Fatalf("reopened feature count = %d, want 2 (the program was dropped)", def.Features().Count())
+	}
+	if def.Features().Item(0).Kind() != "assemblyHole" || def.Features().Item(1).Kind() != "assemblyFillet" {
+		t.Errorf("reopened kinds = [%s %s], want [assemblyHole assemblyFillet]",
+			def.Features().Item(0).Kind(), def.Features().Item(1).Kind())
+	}
+
+	// Value fidelity: the reopened program re-marshals with the hole's diameter and the fillet's radius.
+	data, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	recipe := string(data)
+	for _, want := range []string{"assemblyHole", "diameter: 0.5", "assemblyFillet", "radius: 0.3"} {
+		if !strings.Contains(recipe, want) {
+			t.Errorf("reopened recipe is missing %q:\n%s", want, recipe)
+		}
+	}
+}

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -8,7 +8,9 @@ import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/attr"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
+	"oblikovati.org/model/sketch"
 	"oblikovati.org/persistence/yamlcodec"
 )
 
@@ -22,9 +24,20 @@ import (
 // assemblyRecipe is the persisted form of an AssemblyComponentDefinition: display units
 // plus the placed occurrences, in placement order.
 type assemblyRecipe struct {
-	Units       map[string]string  `yaml:"units,omitempty"`
-	Occurrences []occurrenceRecipe `yaml:"occurrences,omitempty"`
-	Properties  []propertyRecipe   `yaml:"properties,omitempty"` // document iProperties (#156)
+	Units         map[string]string              `yaml:"units,omitempty"`
+	Occurrences   []occurrenceRecipe             `yaml:"occurrences,omitempty"`
+	Properties    []propertyRecipe               `yaml:"properties,omitempty"` // document iProperties (#156)
+	Sketches      []sketch.SketchData            `yaml:"sketches,omitempty"`   // assembly-space sketches (#785)
+	Features      []assemblyFeatureProgramRecipe `yaml:"features,omitempty"`   // the machining program (#785)
+	EndOfFeatures *int                           `yaml:"endOfFeatures,omitempty"`
+}
+
+// assemblyFeatureProgramRecipe is the persisted form of one program entry: the feature's inputs
+// plus its name and suppression (the AssemblyFeature wrapper state).
+type assemblyFeatureProgramRecipe struct {
+	Name       string                      `yaml:"name,omitempty"`
+	Suppressed bool                        `yaml:"suppressed,omitempty"`
+	Feature    feature.AssemblyFeatureData `yaml:"feature"`
 }
 
 // occurrenceRecipe is the persisted form of one placement: the component document it
@@ -42,11 +55,60 @@ type occurrenceRecipe struct {
 
 // MarshalRecipe renders the assembly's recipe as YAML bytes (doc.RecipeContent).
 func (a *AssemblyComponentDefinition) MarshalRecipe() ([]byte, error) {
-	return yamlcodec.Marshal(assemblyRecipe{
+	sketches, err := a.sketches.MarshalRecipe()
+	if err != nil {
+		return nil, fmt.Errorf("compdef: marshal assembly sketches: %w", err)
+	}
+	r := assemblyRecipe{
 		Units:       unitsRecipeFor(a.units),
 		Occurrences: a.occurrencesRecipe(),
 		Properties:  propertiesRecipeOf(a.props),
-	})
+		Sketches:    sketches,
+		Features:    a.featuresRecipe(),
+	}
+	if eof := a.features.EndOfFeaturesPosition(); eof != endOfFeaturesAtEnd {
+		r.EndOfFeatures = &eof
+	}
+	return yamlcodec.Marshal(r)
+}
+
+// featuresRecipe captures the machining program in order — each feature whose state is
+// self-contained (a sketch-index/scalar/suffix feature). A kind not yet serializable (the box-cut's
+// transient tool body, the proxy-cut's occurrence reference) is skipped (#785).
+func (a *AssemblyComponentDefinition) featuresRecipe() []assemblyFeatureProgramRecipe {
+	sketchIndex := a.sketchIndexFunc()
+	var out []assemblyFeatureProgramRecipe
+	for i := 0; i < a.features.Count(); i++ {
+		af := a.features.Item(i)
+		m, ok := af.Definition().(feature.AssemblyFeatureMarshaler)
+		if !ok {
+			continue
+		}
+		out = append(out, assemblyFeatureProgramRecipe{
+			Name: af.Name(), Suppressed: af.Suppressed(), Feature: m.MarshalAssembly(sketchIndex),
+		})
+	}
+	return out
+}
+
+// sketchIndexFunc maps a sketch pointer to its index in the assembly's sketch collection, for a
+// feature to persist its sketch reference by index.
+func (a *AssemblyComponentDefinition) sketchIndexFunc() func(*sketch.Sketch) int {
+	idx := map[*sketch.Sketch]int{}
+	for i := 0; i < a.sketches.Count(); i++ {
+		idx[a.sketches.Item(i)] = i
+	}
+	return func(sk *sketch.Sketch) int { return idx[sk] }
+}
+
+// sketchSlice returns the assembly's sketches in order, for resolving feature sketch references on
+// restore.
+func (a *AssemblyComponentDefinition) sketchSlice() []*sketch.Sketch {
+	out := make([]*sketch.Sketch, a.sketches.Count())
+	for i := range out {
+		out[i] = a.sketches.Item(i)
+	}
+	return out
 }
 
 // occurrencesRecipe captures every restorable occurrence — those placed from a component
@@ -87,7 +149,17 @@ func (a *AssemblyComponentDefinition) ApplyRecipe(model []byte) error {
 		return err
 	}
 	applyPropertiesRecipe(a.props, r.Properties)
+	if err := a.sketches.ApplyRecipe(r.Sketches); err != nil {
+		return fmt.Errorf("compdef: restore assembly sketches: %w", err)
+	}
+	for i := 0; i < a.sketches.Count(); i++ {
+		a.sketches.Item(i).SetParameters(a.params) // share the param DAG so dimensions resolve
+	}
+	if r.EndOfFeatures != nil {
+		a.features.SetEndOfFeatures(*r.EndOfFeatures)
+	}
 	a.pending = r.Occurrences
+	a.pendingFeatures = r.Features // features bind after occurrences resolve (they snapshot participation)
 	return nil
 }
 
@@ -120,6 +192,10 @@ func (a *AssemblyComponentDefinition) resetOccurrences() {
 	a.occurrences = occurrence.NewOccurrences()
 	a.occurrences.SetListener(a.events)
 	a.props = attr.NewPropertySets() // a restore re-applies the snapshot's properties onto a clean set (#156)
+	a.sketches = sketch.NewSketches()
+	a.features = NewAssemblyFeatures() // the program rebuilds from the snapshot (#785)
+	a.features.SetBus(a.events.Bus())  // re-wire the recompute event bus the fresh program needs
+	a.pendingFeatures = nil
 	a.pending = nil
 }
 
@@ -143,6 +219,25 @@ func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) err
 		occ.SetAdaptive(rec.Adaptive)
 		occ.SetSubstitute(rec.Substitute)
 	}
+	return a.restoreFeatures()
+}
+
+// restoreFeatures reconstructs the machining program now that the occurrences are bound (each
+// feature snapshots the present occurrences as its participants via AddFeature) and recomputes.
+func (a *AssemblyComponentDefinition) restoreFeatures() error {
+	pending := a.pendingFeatures
+	a.pendingFeatures = nil
+	sketches := a.sketchSlice()
+	for _, fr := range pending {
+		f, err := feature.RestoreAssemblyFeature(fr.Feature, sketches)
+		if err != nil {
+			return fmt.Errorf("compdef: restore assembly feature: %w", err)
+		}
+		af := a.AddFeature(f)
+		af.SetName(fr.Name)
+		af.SetSuppressed(fr.Suppressed)
+	}
+	a.RecomputeFeatures()
 	return nil
 }
 

--- a/model/feature/assembly_feature_serialize.go
+++ b/model/feature/assembly_feature_serialize.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Serialization of the assembly feature program (#785): each machining feature renders its inputs
+// to an [AssemblyFeatureData] (a tagged union over Kind) and is reconstructed from one, so an
+// assembly's features round-trip through save/load and undo/redo. Sketch-bearing features
+// (extrude/revolve/sweep) reference the assembly's sketch by index; the closure-backed scalars
+// (distance/radius/angle) capture their current value and restore as a constant — editing a
+// restored feature is a separate concern. Features whose state is not self-contained (the box-cut's
+// transient tool body, the proxy-cut's source occurrence) do not implement the marshaler yet and
+// are skipped, to be added with their reference rebinding.
+
+// AssemblyFeatureData is the serializable form of one assembly machining feature: its kind and the
+// superset of inputs the kinds use (each populates only its own).
+type AssemblyFeatureData struct {
+	Kind         string       `yaml:"kind"`
+	SketchIndex  int          `yaml:"sketchIndex,omitempty"`  // extrude/revolve/sweep
+	ProfileIndex int          `yaml:"profileIndex,omitempty"` // extrude/revolve/sweep
+	Operation    int          `yaml:"operation,omitempty"`    // ops.PartFeatureOperation
+	Distance     float64      `yaml:"distance,omitempty"`     // extrude / chamfer
+	Radius       float64      `yaml:"radius,omitempty"`       // fillet
+	Angle        float64      `yaml:"angle,omitempty"`        // revolve
+	FlatCorners  bool         `yaml:"flatCorners,omitempty"`  // chamfer
+	EdgeSuffixes [][]byte     `yaml:"edgeSuffixes,omitempty"` // chamfer / fillet
+	FaceSuffixes [][]byte     `yaml:"faceSuffixes,omitempty"` // moveFace
+	Translation  [3]float64   `yaml:"translation,omitempty"`  // moveFace
+	Center       [3]float64   `yaml:"center,omitempty"`       // hole
+	Axis         [3]float64   `yaml:"axis,omitempty"`         // hole / revolve direction
+	AxisOrigin   [3]float64   `yaml:"axisOrigin,omitempty"`   // revolve datum-axis origin
+	HasAxis      bool         `yaml:"hasAxis,omitempty"`      // revolve: an explicit axis (else the sketch centerline)
+	Diameter     float64      `yaml:"diameter,omitempty"`     // hole
+	Depth        float64      `yaml:"depth,omitempty"`        // hole
+	Path         [][3]float64 `yaml:"path,omitempty"`         // sweep
+}
+
+// AssemblyFeatureMarshaler is implemented by the assembly features whose state is self-contained.
+// sketchIndex maps the feature's sketch to its index in the assembly's sketch collection.
+type AssemblyFeatureMarshaler interface {
+	MarshalAssembly(sketchIndex func(*sketch.Sketch) int) AssemblyFeatureData
+}
+
+// RestoreAssemblyFeature reconstructs a feature from its data, resolving sketch references against
+// sketches (by index). It errors on an unknown kind or an out-of-range sketch index.
+func RestoreAssemblyFeature(d AssemblyFeatureData, sketches []*sketch.Sketch) (Feature, error) {
+	switch d.Kind {
+	case "assemblyExtrude":
+		sk, err := sketchAt(sketches, d.SketchIndex, d.Kind)
+		if err != nil {
+			return nil, err
+		}
+		return NewAssemblyExtrudeFeature(sk, d.ProfileIndex, ops.PartFeatureOperation(d.Operation), constScalar(d.Distance)), nil
+	case "assemblyRevolve":
+		sk, err := sketchAt(sketches, d.SketchIndex, d.Kind)
+		if err != nil {
+			return nil, err
+		}
+		return NewAssemblyRevolveFeature(sk, d.ProfileIndex, restoreAxis(d), ops.PartFeatureOperation(d.Operation), constScalar(d.Angle)), nil
+	case "assemblySweep":
+		sk, err := sketchAt(sketches, d.SketchIndex, d.Kind)
+		if err != nil {
+			return nil, err
+		}
+		return NewAssemblySweepFeature(sk, d.ProfileIndex, ops.PartFeatureOperation(d.Operation), pointsFrom(d.Path)), nil
+	case "assemblyHole":
+		axis, err := math.NewUnitVector3(d.Axis[0], d.Axis[1], d.Axis[2])
+		if err != nil {
+			return nil, fmt.Errorf("feature: restore hole: axis %v is not a direction: %w", d.Axis, err)
+		}
+		return NewAssemblyHoleFeature(math.P3(d.Center[0], d.Center[1], d.Center[2]), axis, d.Diameter, d.Depth)
+	case "assemblyChamfer":
+		return NewAssemblyChamferFeature(d.EdgeSuffixes, constScalar(d.Distance)), nil
+	case "assemblyFillet":
+		return NewAssemblyFilletFeature(d.EdgeSuffixes, constScalar(d.Radius)), nil
+	case "assemblyMoveFace":
+		return NewAssemblyMoveFaceFeature(d.FaceSuffixes, math.V3(math.Scalar(d.Translation[0]), math.Scalar(d.Translation[1]), math.Scalar(d.Translation[2]))), nil
+	default:
+		return nil, fmt.Errorf("feature: cannot restore assembly feature kind %q", d.Kind)
+	}
+}
+
+// sketchAt resolves a sketch index, erroring when it is out of range (a corrupt recipe).
+func sketchAt(sketches []*sketch.Sketch, i int, kind string) (*sketch.Sketch, error) {
+	if i < 0 || i >= len(sketches) {
+		return nil, fmt.Errorf("feature: restore %s: sketch index %d out of range (%d sketches)", kind, i, len(sketches))
+	}
+	return sketches[i], nil
+}
+
+// restoreAxis rebuilds a revolve's explicit datum axis from data, or nil when none was stored (the
+// feature falls back to the sketch's single centerline).
+func restoreAxis(d AssemblyFeatureData) *WorkAxis {
+	if !d.HasAxis {
+		return nil
+	}
+	dir, err := math.NewUnitVector3(d.Axis[0], d.Axis[1], d.Axis[2])
+	if err != nil {
+		return nil
+	}
+	return NewDatumAxis(math.P3(d.AxisOrigin[0], d.AxisOrigin[1], d.AxisOrigin[2]), dir)
+}
+
+// constScalar returns a closure yielding a fixed value — the restored form of a closure-backed
+// scalar (editing a restored feature is out of scope here).
+func constScalar(v float64) func() float64 { return func() float64 { return v } }
+
+// pointsFrom / pathTo convert a sweep path between the flat-array recipe form and points.
+func pointsFrom(path [][3]float64) []math.Point3 {
+	out := make([]math.Point3, len(path))
+	for i, p := range path {
+		out[i] = math.P3(p[0], p[1], p[2])
+	}
+	return out
+}
+
+func pathTo(pts []math.Point3) [][3]float64 {
+	out := make([][3]float64, len(pts))
+	for i, p := range pts {
+		out[i] = [3]float64{float64(p.X), float64(p.Y), float64(p.Z)}
+	}
+	return out
+}
+
+// --- per-kind MarshalAssembly ---------------------------------------------
+
+func (f *AssemblyExtrudeFeature) MarshalAssembly(sketchIndex func(*sketch.Sketch) int) AssemblyFeatureData {
+	return AssemblyFeatureData{Kind: "assemblyExtrude", SketchIndex: sketchIndex(f.sketch), ProfileIndex: f.profileIndex, Operation: int(f.op), Distance: f.distance()}
+}
+
+func (f *AssemblyRevolveFeature) MarshalAssembly(sketchIndex func(*sketch.Sketch) int) AssemblyFeatureData {
+	d := AssemblyFeatureData{Kind: "assemblyRevolve", SketchIndex: sketchIndex(f.sketch), ProfileIndex: f.profileIndex, Operation: int(f.op), Angle: f.angle()}
+	if f.axis != nil {
+		d.HasAxis = true
+		o, dir := f.axis.Origin(), f.axis.Direction().AsVector()
+		d.AxisOrigin = [3]float64{float64(o.X), float64(o.Y), float64(o.Z)}
+		d.Axis = [3]float64{float64(dir.X), float64(dir.Y), float64(dir.Z)}
+	}
+	return d
+}
+
+func (f *AssemblySweepFeature) MarshalAssembly(sketchIndex func(*sketch.Sketch) int) AssemblyFeatureData {
+	return AssemblyFeatureData{Kind: "assemblySweep", SketchIndex: sketchIndex(f.sketch), ProfileIndex: f.profileIndex, Operation: int(f.op), Path: pathTo(f.path)}
+}
+
+func (f *AssemblyHoleFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
+	dir := f.axis.AsVector()
+	return AssemblyFeatureData{Kind: "assemblyHole",
+		Center:   [3]float64{float64(f.center.X), float64(f.center.Y), float64(f.center.Z)},
+		Axis:     [3]float64{float64(dir.X), float64(dir.Y), float64(dir.Z)},
+		Diameter: f.diameter, Depth: f.depth}
+}
+
+func (f *AssemblyChamferFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
+	return AssemblyFeatureData{Kind: "assemblyChamfer", EdgeSuffixes: f.edgeSuffixes, Distance: f.distance(), FlatCorners: f.flatCorners}
+}
+
+func (f *AssemblyFilletFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
+	return AssemblyFeatureData{Kind: "assemblyFillet", EdgeSuffixes: f.edgeSuffixes, Radius: f.radius()}
+}
+
+func (f *AssemblyMoveFaceFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
+	return AssemblyFeatureData{Kind: "assemblyMoveFace", FaceSuffixes: f.faceSuffixes,
+		Translation: [3]float64{float64(f.translation.X), float64(f.translation.Y), float64(f.translation.Z)}}
+}

--- a/model/feature/assembly_feature_serialize_test.go
+++ b/model/feature/assembly_feature_serialize_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"reflect"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// noSketchIndex is the sketch-index resolver for kinds that hold no sketch.
+func noSketchIndex(*sketch.Sketch) int { return 0 }
+
+// TestAssemblyFeatureDataRoundTrip pins every serializable assembly feature kind: its
+// MarshalAssembly → RestoreAssemblyFeature → MarshalAssembly is identity, so its inputs survive a
+// save/undo round-trip (#785). Sketch-bearing kinds resolve sketch index 0.
+func TestAssemblyFeatureDataRoundTrip(t *testing.T) {
+	sk := []*sketch.Sketch{{}} // index 0; the features only hold the pointer, not its contents
+	down, _ := math.NewUnitVector3(0, 0, -1)
+	yaw, _ := math.NewUnitVector3(0, 1, 0)
+
+	hole, _ := NewAssemblyHoleFeature(math.P3(1, 2, 3), down, 0.5, 4)
+	cases := map[string]Feature{
+		"extrude":  NewAssemblyExtrudeFeature(sk[0], 1, ops.Cut, func() float64 { return 2.5 }),
+		"revolve":  NewAssemblyRevolveFeature(sk[0], 0, NewDatumAxis(math.P3(0, 0, 0), yaw), ops.Join, func() float64 { return 1.5 }),
+		"sweep":    NewAssemblySweepFeature(sk[0], 0, ops.Cut, []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0)}),
+		"hole":     hole,
+		"chamfer":  NewAssemblyChamferFeature([][]byte{[]byte("e0")}, func() float64 { return 0.2 }),
+		"fillet":   NewAssemblyFilletFeature([][]byte{[]byte("e1")}, func() float64 { return 0.3 }),
+		"moveFace": NewAssemblyMoveFaceFeature([][]byte{[]byte("f0")}, math.V3(0, 0, 1)),
+	}
+	for name, f := range cases {
+		m, ok := f.(AssemblyFeatureMarshaler)
+		if !ok {
+			t.Errorf("%s: does not implement AssemblyFeatureMarshaler", name)
+			continue
+		}
+		data := m.MarshalAssembly(noSketchIndex)
+		restored, err := RestoreAssemblyFeature(data, sk)
+		if err != nil {
+			t.Errorf("%s: restore: %v", name, err)
+			continue
+		}
+		again := restored.(AssemblyFeatureMarshaler).MarshalAssembly(noSketchIndex)
+		if !reflect.DeepEqual(data, again) {
+			t.Errorf("%s: data did not round-trip:\n have %+v\n want %+v", name, again, data)
+		}
+	}
+}
+
+// TestRestoreAssemblyFeatureRejectsUnknownKind / out-of-range sketch are the corrupt-recipe guards.
+func TestRestoreAssemblyFeatureRejectsBadData(t *testing.T) {
+	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "nope"}, nil); err == nil {
+		t.Error("an unknown kind should be rejected")
+	}
+	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "assemblyExtrude", SketchIndex: 5}, nil); err == nil {
+		t.Error("an out-of-range sketch index should be rejected")
+	}
+}


### PR DESCRIPTION
## What
Assembly machining features and sketches were **dropped on save** and **not undoable**: the assembly recipe held only units + occurrences (+ iProperties), so the whole feature/sketch program vanished on reopen — and the app machining tools deliberately skipped `recordEdit` because it would have been a no-op. This closes that systemic gap (the one I filed while shipping #766).

- **feature**: each self-contained machining feature renders its inputs to an `AssemblyFeatureData` (a tagged union over `Kind`) and is reconstructed from one (`RestoreAssemblyFeature`). Covers **extrude/revolve/sweep** (sketch by index), **hole/chamfer/fillet/move-face** (scalar + suffix). Closure-backed scalars capture their value and restore as a constant.
- **compdef**: the assembly recipe gains **sketches** (reusing the sketch recipe), the **feature program**, and the **end-of-features marker**. Sketches restore in `ApplyRecipe`; features wait for `ResolveReferences` (they snapshot the now-bound occurrences as participants), then recompute. The reset path clears sketches + the program so a restore yields exactly the snapshot.
- **app**: the assembly machining tools (chamfer/fillet/extrude/revolve/hole) now **record an undo step**, since the program persists.

## Tests (all three layers)
- `feature`: `TestAssemblyFeatureDataRoundTrip` — every serializable kind's marshal→restore→marshal is identity; `TestRestoreAssemblyFeatureRejectsBadData` — corrupt-recipe guards.
- `compdef`: `TestAssemblyFeatureProgramRoundTrips` — a real **save→reopen** restores the program in order with value fidelity (hole diameter, fillet radius).
- `app`: `TestAssemblyChamferIsUndoable` (undo removes / redo restores) and `TestAssemblyExtrudeIsUndoable` (the sketch + extrude undo; the sketch survives).

`go test ./model/feature/... ./model/compdef/... ./app/... ./addin/router/...` green (no regression); `golangci-lint` 0 issues.

## Scope
Closes #785 for the serializable kinds. The **box-cut** (transient tool body) and **proxy-cut** (occurrence reference) are not yet serializable — skipped on save, to be added with their reference rebinding (a small follow-up on this foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)