### PR TITLE
feat: serialize the box-cut and proxy-cut assembly features (#785)

### DIFF
--- a/model/compdef/assembly_feature_serialize_test.go
+++ b/model/compdef/assembly_feature_serialize_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 )
@@ -48,5 +49,30 @@ func TestAssemblyFeatureProgramRoundTrips(t *testing.T) {
 		if !strings.Contains(recipe, want) {
 			t.Errorf("reopened recipe is missing %q:\n%s", want, recipe)
 		}
+	}
+}
+
+// TestAssemblyProxyCutRoundTrips: a proxy-cut's source occurrence reference rebinds on reopen — the
+// restored feature points at the live "tool:1" occurrence again, resolved by name after the
+// occurrences bind (the #785 follow-up for the reference-bearing kinds).
+func TestAssemblyProxyCutRoundTrips(t *testing.T) {
+	store, ws, asm, widget, asmDef := placedAssembly(t)
+	placeFromFile(t, asm, widget, asmDef, "target:1", math.Identity4())
+	src := placeFromFile(t, asm, widget, asmDef, "tool:1", math.Translation4(math.V3(0.5, 0, 0)))
+
+	af := asmDef.AddFeature(feature.NewAssemblyProxyCutFeature(src, ops.Cut))
+	af.RemoveParticipant(src) // a component never machines itself
+	af.SetName("proxy1")
+
+	def := reopenAssembly(t, store, ws, asm)
+	if def.Features().Count() != 1 {
+		t.Fatalf("reopened feature count = %d, want 1 (the proxy cut)", def.Features().Count())
+	}
+	pc, ok := def.Features().Item(0).Definition().(*feature.AssemblyProxyCutFeature)
+	if !ok {
+		t.Fatalf("restored feature is %T, want a proxy cut", def.Features().Item(0).Definition())
+	}
+	if pc.Source() == nil || pc.Source().Name() != "tool:1" {
+		t.Errorf("restored proxy-cut source = %v, want the rebound tool:1 occurrence", pc.Source())
 	}
 }

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -229,16 +229,31 @@ func (a *AssemblyComponentDefinition) restoreFeatures() error {
 	a.pendingFeatures = nil
 	sketches := a.sketchSlice()
 	for _, fr := range pending {
-		f, err := feature.RestoreAssemblyFeature(fr.Feature, sketches)
+		f, err := feature.RestoreAssemblyFeature(fr.Feature, sketches, a.occurrenceByName)
 		if err != nil {
 			return fmt.Errorf("compdef: restore assembly feature: %w", err)
 		}
 		af := a.AddFeature(f)
 		af.SetName(fr.Name)
 		af.SetSuppressed(fr.Suppressed)
+		// A proxy-cut never machines its own source component (the router excludes it on add),
+		// so drop the source from the participants AddFeature snapshotted.
+		if pc, ok := f.(*feature.AssemblyProxyCutFeature); ok {
+			af.RemoveParticipant(pc.Source())
+		}
 	}
 	a.RecomputeFeatures()
 	return nil
+}
+
+// occurrenceByName resolves a leaf occurrence by its instance name (the proxy-cut source rebind).
+func (a *AssemblyComponentDefinition) occurrenceByName(name string) (*occurrence.Occurrence, bool) {
+	for _, o := range a.occurrences.All() {
+		if o.Name() == name {
+			return o, true
+		}
+	}
+	return nil, false
 }
 
 // resolveComponent opens the component document named component as a reference of owner,

--- a/model/feature/assembly_feature_serialize.go
+++ b/model/feature/assembly_feature_serialize.go
@@ -5,8 +5,10 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
 )
 
@@ -15,9 +17,9 @@ import (
 // assembly's features round-trip through save/load and undo/redo. Sketch-bearing features
 // (extrude/revolve/sweep) reference the assembly's sketch by index; the closure-backed scalars
 // (distance/radius/angle) capture their current value and restore as a constant — editing a
-// restored feature is a separate concern. Features whose state is not self-contained (the box-cut's
-// transient tool body, the proxy-cut's source occurrence) do not implement the marshaler yet and
-// are skipped, to be added with their reference rebinding.
+// restored feature is a separate concern. The box-cut persists its tool's axis-aligned corners
+// (every tool is a brep.SolidBlock) and the proxy-cut persists its source occurrence by name,
+// rebound through occByName once the occurrences are bound.
 
 // AssemblyFeatureData is the serializable form of one assembly machining feature: its kind and the
 // superset of inputs the kinds use (each populates only its own).
@@ -40,6 +42,9 @@ type AssemblyFeatureData struct {
 	Diameter     float64      `yaml:"diameter,omitempty"`     // hole
 	Depth        float64      `yaml:"depth,omitempty"`        // hole
 	Path         [][3]float64 `yaml:"path,omitempty"`         // sweep
+	ToolMin      [3]float64   `yaml:"toolMin,omitempty"`      // box-cut tool corners
+	ToolMax      [3]float64   `yaml:"toolMax,omitempty"`      // box-cut tool corners
+	SourceName   string       `yaml:"sourceName,omitempty"`   // proxy-cut source occurrence name
 }
 
 // AssemblyFeatureMarshaler is implemented by the assembly features whose state is self-contained.
@@ -49,8 +54,10 @@ type AssemblyFeatureMarshaler interface {
 }
 
 // RestoreAssemblyFeature reconstructs a feature from its data, resolving sketch references against
-// sketches (by index). It errors on an unknown kind or an out-of-range sketch index.
-func RestoreAssemblyFeature(d AssemblyFeatureData, sketches []*sketch.Sketch) (Feature, error) {
+// sketches (by index) and a proxy-cut's source occurrence through occByName (nil for the kinds that
+// hold no occurrence reference). It errors on an unknown kind, an out-of-range sketch index, or an
+// unresolvable source.
+func RestoreAssemblyFeature(d AssemblyFeatureData, sketches []*sketch.Sketch, occByName func(string) (*occurrence.Occurrence, bool)) (Feature, error) {
 	switch d.Kind {
 	case "assemblyExtrude":
 		sk, err := sketchAt(sketches, d.SketchIndex, d.Kind)
@@ -82,6 +89,21 @@ func RestoreAssemblyFeature(d AssemblyFeatureData, sketches []*sketch.Sketch) (F
 		return NewAssemblyFilletFeature(d.EdgeSuffixes, constScalar(d.Radius)), nil
 	case "assemblyMoveFace":
 		return NewAssemblyMoveFaceFeature(d.FaceSuffixes, math.V3(math.Scalar(d.Translation[0]), math.Scalar(d.Translation[1]), math.Scalar(d.Translation[2]))), nil
+	case "assemblyCut":
+		tool, err := brep.SolidBlock(math.P3(d.ToolMin[0], d.ToolMin[1], d.ToolMin[2]), math.P3(d.ToolMax[0], d.ToolMax[1], d.ToolMax[2]), "asmCut")
+		if err != nil {
+			return nil, fmt.Errorf("feature: restore box cut: %w", err)
+		}
+		return NewAssemblyCutFeature(tool, ops.PartFeatureOperation(d.Operation)), nil
+	case "assemblyProxyCut":
+		if occByName == nil {
+			return nil, fmt.Errorf("feature: restore proxy cut %q needs an occurrence resolver", d.SourceName)
+		}
+		src, ok := occByName(d.SourceName)
+		if !ok {
+			return nil, fmt.Errorf("feature: restore proxy cut: source occurrence %q not found", d.SourceName)
+		}
+		return NewAssemblyProxyCutFeature(src, ops.PartFeatureOperation(d.Operation)), nil
 	default:
 		return nil, fmt.Errorf("feature: cannot restore assembly feature kind %q", d.Kind)
 	}
@@ -169,4 +191,19 @@ func (f *AssemblyFilletFeature) MarshalAssembly(func(*sketch.Sketch) int) Assemb
 func (f *AssemblyMoveFaceFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
 	return AssemblyFeatureData{Kind: "assemblyMoveFace", FaceSuffixes: f.faceSuffixes,
 		Translation: [3]float64{float64(f.translation.X), float64(f.translation.Y), float64(f.translation.Z)}}
+}
+
+// MarshalAssembly captures the box-cut's tool as its axis-aligned corners (every tool is a
+// brep.SolidBlock; its range box recovers the corners), rebuilt on restore.
+func (f *AssemblyCutFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
+	box := f.tool.RangeBox()
+	return AssemblyFeatureData{Kind: "assemblyCut", Operation: int(f.op),
+		ToolMin: [3]float64{float64(box.Min.X), float64(box.Min.Y), float64(box.Min.Z)},
+		ToolMax: [3]float64{float64(box.Max.X), float64(box.Max.Y), float64(box.Max.Z)}}
+}
+
+// MarshalAssembly captures the proxy-cut's source occurrence by name; restore rebinds it to the
+// live occurrence (the assembly resolves it after the occurrences are bound).
+func (f *AssemblyProxyCutFeature) MarshalAssembly(func(*sketch.Sketch) int) AssemblyFeatureData {
+	return AssemblyFeatureData{Kind: "assemblyProxyCut", Operation: int(f.op), SourceName: f.source.Name()}
 }

--- a/model/feature/assembly_feature_serialize_test.go
+++ b/model/feature/assembly_feature_serialize_test.go
@@ -6,22 +6,43 @@ import (
 	"reflect"
 	"testing"
 
+	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
 )
 
 // noSketchIndex is the sketch-index resolver for kinds that hold no sketch.
 func noSketchIndex(*sketch.Sketch) int { return 0 }
 
+// serializeStubDef is a minimal occurrence definition (just a range box) for placing a proxy-cut
+// source occurrence in the serialization test.
+type serializeStubDef struct{}
+
+func (serializeStubDef) RangeBox() math.Box { return math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)) }
+
 // TestAssemblyFeatureDataRoundTrip pins every serializable assembly feature kind: its
 // MarshalAssembly → RestoreAssemblyFeature → MarshalAssembly is identity, so its inputs survive a
-// save/undo round-trip (#785). Sketch-bearing kinds resolve sketch index 0.
+// save/undo round-trip (#785). Sketch-bearing kinds resolve sketch index 0; the proxy-cut resolves
+// its source occurrence by name.
 func TestAssemblyFeatureDataRoundTrip(t *testing.T) {
 	sk := []*sketch.Sketch{{}} // index 0; the features only hold the pointer, not its contents
 	down, _ := math.NewUnitVector3(0, 0, -1)
 	yaw, _ := math.NewUnitVector3(0, 1, 0)
 
+	occs := occurrence.NewOccurrences()
+	src := occs.AddByComponentDefinition("box:1", serializeStubDef{}, math.Identity4())
+	occByName := func(name string) (*occurrence.Occurrence, bool) {
+		if name == src.Name() {
+			return src, true
+		}
+		return nil, false
+	}
+	boxTool, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(2, 3, 4), "t")
+	if err != nil {
+		t.Fatalf("box tool: %v", err)
+	}
 	hole, _ := NewAssemblyHoleFeature(math.P3(1, 2, 3), down, 0.5, 4)
 	cases := map[string]Feature{
 		"extrude":  NewAssemblyExtrudeFeature(sk[0], 1, ops.Cut, func() float64 { return 2.5 }),
@@ -31,6 +52,8 @@ func TestAssemblyFeatureDataRoundTrip(t *testing.T) {
 		"chamfer":  NewAssemblyChamferFeature([][]byte{[]byte("e0")}, func() float64 { return 0.2 }),
 		"fillet":   NewAssemblyFilletFeature([][]byte{[]byte("e1")}, func() float64 { return 0.3 }),
 		"moveFace": NewAssemblyMoveFaceFeature([][]byte{[]byte("f0")}, math.V3(0, 0, 1)),
+		"boxCut":   NewAssemblyCutFeature(boxTool, ops.Cut),
+		"proxyCut": NewAssemblyProxyCutFeature(src, ops.Cut),
 	}
 	for name, f := range cases {
 		m, ok := f.(AssemblyFeatureMarshaler)
@@ -39,7 +62,7 @@ func TestAssemblyFeatureDataRoundTrip(t *testing.T) {
 			continue
 		}
 		data := m.MarshalAssembly(noSketchIndex)
-		restored, err := RestoreAssemblyFeature(data, sk)
+		restored, err := RestoreAssemblyFeature(data, sk, occByName)
 		if err != nil {
 			t.Errorf("%s: restore: %v", name, err)
 			continue
@@ -51,12 +74,15 @@ func TestAssemblyFeatureDataRoundTrip(t *testing.T) {
 	}
 }
 
-// TestRestoreAssemblyFeatureRejectsUnknownKind / out-of-range sketch are the corrupt-recipe guards.
+// TestRestoreAssemblyFeatureRejectsBadData: the corrupt-recipe guards.
 func TestRestoreAssemblyFeatureRejectsBadData(t *testing.T) {
-	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "nope"}, nil); err == nil {
+	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "nope"}, nil, nil); err == nil {
 		t.Error("an unknown kind should be rejected")
 	}
-	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "assemblyExtrude", SketchIndex: 5}, nil); err == nil {
+	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "assemblyExtrude", SketchIndex: 5}, nil, nil); err == nil {
 		t.Error("an out-of-range sketch index should be rejected")
+	}
+	if _, err := RestoreAssemblyFeature(AssemblyFeatureData{Kind: "assemblyProxyCut", SourceName: "gone"}, nil, func(string) (*occurrence.Occurrence, bool) { return nil, false }); err == nil {
+		t.Error("an unresolvable proxy-cut source should be rejected")
 	}
 }


### PR DESCRIPTION
## What
The #785 feature-program persistence shipped earlier skipped the two reference/geometry-bearing kinds. This adds them, so **every** assembly machining kind now round-trips through save/load and undo:

- **box-cut** (`assemblyCut`): every tool body is a `brep.SolidBlock`, so its axis-aligned range box recovers the corners — persist `toolMin`/`toolMax` and rebuild the block on restore.
- **proxy-cut** (`assemblyProxyCut`): persist its source occurrence **by name**; `RestoreAssemblyFeature` takes an `occByName` resolver, and the assembly rebinds the source after the occurrences bind (then drops it from the participants, as the add path does — a component never machines itself).

## Tests
- `TestAssemblyFeatureDataRoundTrip` now covers **boxCut + proxyCut** (marshal→restore→marshal identity), and the corrupt-recipe guard rejects an **unresolvable proxy source**.
- `TestAssemblyProxyCutRoundTrips` — a real save→reopen rebinds the proxy-cut's source to the live `tool:1` occurrence.

`go test ./model/feature/... ./model/compdef/... ./app/... ./addin/router/...` green (no regression); `golangci-lint` 0 issues.

Completes **#785** for every assembly feature kind — the assembly machining program (UI *and* wire) is now fully durable across save and undo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)