### PR TITLE
feat: in-session edit of assembly machining features (#766)

### DIFF
--- a/app/assembly_feature_edit.go
+++ b/app/assembly_feature_edit.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Editing a committed assembly machining feature (#766): the browser's Edit re-opens the feature
+// as a tool whose Params() are its EditableParams (distance / radius / angle / depth …), shown in
+// the generic tool-param dialog. Each setter writes through to the feature's closure-backed scalar,
+// so OK recomputes the assembly with the new values and records an undo step; Cancel restores the
+// values captured when editing opened. Suppress and Delete round out the feature-node menu.
+
+// AssemblyFeatureEditTool edits one committed assembly feature's scalar parameters in place.
+type AssemblyFeatureEditTool struct {
+	feature *compdef.AssemblyFeature
+	params  []feature.EditableParam
+	orig    []float64 // values captured at open, restored on Cancel
+}
+
+// NewAssemblyFeatureEditTool opens af for editing, snapshotting its current parameter values.
+func NewAssemblyFeatureEditTool(af *compdef.AssemblyFeature) *AssemblyFeatureEditTool {
+	t := &AssemblyFeatureEditTool{feature: af}
+	if ed, ok := af.Definition().(feature.Editable); ok {
+		t.params = ed.EditableParams()
+	}
+	t.orig = make([]float64, len(t.params))
+	for i, p := range t.params {
+		t.orig[i] = p.Get()
+	}
+	return t
+}
+
+func (t *AssemblyFeatureEditTool) Name() string   { return "Edit " + t.feature.Name() }
+func (t *AssemblyFeatureEditTool) Start(*Session) {}
+
+// Pick is unused — an assembly feature edit changes scalar parameters, not geometric references
+// (re-picking participant edges/faces is a later refinement).
+func (t *AssemblyFeatureEditTool) Pick(*Session, Selectable) {}
+
+// CanCommit reports the feature has editable parameters to apply.
+func (t *AssemblyFeatureEditTool) CanCommit() bool { return len(t.params) > 0 }
+
+// Commit recomputes the assembly with the edited values (already written through by the dialog's
+// setters) and records the undo step.
+func (t *AssemblyFeatureEditTool) Commit(s *Session) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Edit "+t.feature.Kind())
+	return nil
+}
+
+// Cancel restores the parameter values captured at open and recomputes, so an abandoned edit
+// leaves no change.
+func (t *AssemblyFeatureEditTool) Cancel(s *Session) {
+	for i, p := range t.params {
+		p.Set(t.orig[i])
+	}
+	if asm, err := activeAssembly(s); err == nil {
+		asm.RecomputeFeatures()
+	}
+}
+
+// Params exposes the feature's editable scalars to the generic dialog.
+func (t *AssemblyFeatureEditTool) Params() ToolParams {
+	floats := make([]FloatParam, len(t.params))
+	for i, p := range t.params {
+		floats[i] = FloatParam{Label: p.Label, Get: p.Get, Set: p.Set}
+	}
+	return ToolParams{Floats: floats}
+}
+
+// BeginEditAssemblyFeature opens the feature edit tool for the browser-selected assembly feature
+// (the menu's Edit / a double-click). A feature with no editable parameters surfaces a notice
+// instead of opening an empty dialog.
+func (s *Session) BeginEditAssemblyFeature(h AssemblyFeatureHandle) {
+	if h.Feature == nil {
+		return
+	}
+	if !assemblyFeatureEditable(h.Feature) {
+		s.notice = h.Feature.Name() + " has no editable parameters"
+		return
+	}
+	s.StartTool(NewAssemblyFeatureEditTool(h.Feature))
+}
+
+// SuppressAssemblyFeature toggles a feature's suppression and recomputes (the program rebuilds with
+// or without its contribution), recording an undo step.
+func (s *Session) SuppressAssemblyFeature(af *compdef.AssemblyFeature, suppressed bool) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if af == nil {
+		return errors.New("app: SuppressAssemblyFeature with nil feature")
+	}
+	if af.Suppressed() == suppressed {
+		return nil
+	}
+	af.SetSuppressed(suppressed)
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Suppress Feature")
+	return nil
+}
+
+// ToggleAssemblyFeatureSuppressed flips a feature's suppression (the browser's Suppress/Unsuppress).
+func (s *Session) ToggleAssemblyFeatureSuppressed(af *compdef.AssemblyFeature) error {
+	if af == nil {
+		return errors.New("app: ToggleAssemblyFeatureSuppressed with nil feature")
+	}
+	return s.SuppressAssemblyFeature(af, !af.Suppressed())
+}
+
+// DeleteAssemblyFeature removes a feature from the program, clears the selection, recomputes, and
+// records an undo step.
+func (s *Session) DeleteAssemblyFeature(af *compdef.AssemblyFeature) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if af == nil {
+		return errors.New("app: DeleteAssemblyFeature with nil feature")
+	}
+	if !asm.Features().Remove(af.ID()) {
+		return errors.New("app: DeleteAssemblyFeature: feature not in this assembly")
+	}
+	s.selection.Clear()
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, "Delete Feature")
+	return nil
+}
+
+// assemblyFeatureEditable reports whether af exposes editable scalar parameters.
+func assemblyFeatureEditable(af *compdef.AssemblyFeature) bool {
+	ed, ok := af.Definition().(feature.Editable)
+	return ok && len(ed.EditableParams()) > 0
+}

--- a/app/assembly_feature_edit_test.go
+++ b/app/assembly_feature_edit_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// chamferedAssembly returns a session whose active assembly has a box placed and a 0.2 chamfer on a
+// vertical edge — the fixture the feature-edit tests start from.
+func chamferedAssembly(t *testing.T) (*Session, *compdef.AssemblyComponentDefinition, *occurrence.Occurrence) {
+	t.Helper()
+	s, asm, o := assemblyWithBoxComponent(t, 0)
+	tool := NewAssemblyChamferTool()
+	tool.Pick(s, worldVerticalEdge(t, s))
+	tool.distance = 0.2
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("chamfer: %v", err)
+	}
+	return s, asm, o
+}
+
+// setEditParam sets a named editable parameter on the edit tool, failing if it is absent.
+func setEditParam(t *testing.T, tool *AssemblyFeatureEditTool, label string, v float64) {
+	t.Helper()
+	for _, p := range tool.params {
+		if p.Label == label {
+			p.Set(v)
+			return
+		}
+	}
+	t.Fatalf("edit tool has no %q parameter", label)
+}
+
+// TestAssemblyBrowserListsFeatures: a committed machining feature appears in a Features folder as a
+// selectable AssemblyFeatureHandle row (#766).
+func TestAssemblyBrowserListsFeatures(t *testing.T) {
+	s, asm, _ := chamferedAssembly(t)
+	name := asm.Features().Item(0).Name()
+
+	node := findBrowserNode(BuildBrowser(s), "assemblyFeature", name)
+	if node == nil {
+		t.Fatalf("the assembly browser has no feature row for %q", name)
+	}
+	if _, ok := node.Select.(AssemblyFeatureHandle); !ok {
+		t.Errorf("feature node selects %T, want AssemblyFeatureHandle", node.Select)
+	}
+}
+
+// TestAssemblyFeatureEditChangesParameter: editing the chamfer's distance re-machines the
+// participant — a bigger setback removes more material (#766).
+func TestAssemblyFeatureEditChangesParameter(t *testing.T) {
+	s, asm, occ := chamferedAssembly(t)
+	before := participantMachinedVolume(asm, occ) // 16 − 0.2²/2·4 = 15.92
+
+	edit := NewAssemblyFeatureEditTool(asm.Features().Item(0))
+	setEditParam(t, edit, "Distance", 0.4)
+	if err := edit.Commit(s); err != nil {
+		t.Fatalf("edit commit: %v", err)
+	}
+	// A 0.4 setback removes 0.4²/2·4 = 0.32 ⇒ 15.68.
+	got := participantMachinedVolume(asm, occ)
+	if got >= before {
+		t.Errorf("a bigger chamfer should remove more: %g → %g", before, got)
+	}
+	if stdmath.Abs(got-15.68) > 0.02 {
+		t.Errorf("edited chamfered volume = %g, want 15.68 (a 0.4 setback)", got)
+	}
+}
+
+// TestAssemblyFeatureEditCancelRestores: cancelling an edit restores the parameter captured at open.
+func TestAssemblyFeatureEditCancelRestores(t *testing.T) {
+	s, asm, occ := chamferedAssembly(t)
+	original := participantMachinedVolume(asm, occ)
+
+	edit := NewAssemblyFeatureEditTool(asm.Features().Item(0))
+	setEditParam(t, edit, "Distance", 0.4)
+	edit.Cancel(s)
+	if got := participantMachinedVolume(asm, occ); stdmath.Abs(got-original) > 1e-9 {
+		t.Errorf("cancel should restore the volume: %g, want %g", got, original)
+	}
+}
+
+// TestAssemblyFeatureEditIsUndoable: a committed parameter edit is one undo step.
+func TestAssemblyFeatureEditIsUndoable(t *testing.T) {
+	s, asm, occ := chamferedAssembly(t)
+	original := participantMachinedVolume(asm, occ)
+	trackFromHere(s) // baseline: the 0.2 chamfer
+
+	edit := NewAssemblyFeatureEditTool(asm.Features().Item(0))
+	setEditParam(t, edit, "Distance", 0.4)
+	if err := edit.Commit(s); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	// Undo re-creates the occurrences (full-replace restore), so re-fetch the participant.
+	restored := asm.Occurrences().Item(0)
+	if got := participantMachinedVolume(asm, restored); stdmath.Abs(got-original) > 0.02 {
+		t.Errorf("undo should restore the 0.2 chamfer: volume %g, want %g", got, original)
+	}
+}
+
+// TestAssemblyFeatureMenuAndDelete: the feature menu offers Edit/Suppress/Delete, and Delete
+// removes the feature (undoably).
+func TestAssemblyFeatureMenuAndDelete(t *testing.T) {
+	s, asm, _ := chamferedAssembly(t)
+	af := asm.Features().Item(0)
+	node := findBrowserNode(BuildBrowser(s), "assemblyFeature", af.Name())
+
+	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Edit|Suppress|Delete" {
+		t.Errorf("feature menu = %q, want Edit|Suppress|Delete", labels)
+	}
+	trackFromHere(s)
+	if err := s.DeleteAssemblyFeature(af); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if asm.Features().Count() != 0 {
+		t.Fatalf("after delete: feature count = %d, want 0", asm.Features().Count())
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("undo: %v", err)
+	}
+	if asm.Features().Count() != 1 {
+		t.Errorf("undo should restore the feature: count = %d, want 1", asm.Features().Count())
+	}
+}

--- a/app/browser.go
+++ b/app/browser.go
@@ -23,7 +23,7 @@ import (
 // clicking "XY Plane" selects the plane to sketch on).
 type BrowserNode struct {
 	Label    string
-	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "feature" | "occurrence"
+	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "feature" | "occurrence" | "features" | "assemblyFeature"
 	Select   Selectable
 	Children []BrowserNode
 }
@@ -77,6 +77,29 @@ func addAssemblyBranches(root *BrowserNode, asm *compdef.AssemblyComponentDefini
 		params.child(p.Name(), "parameter")
 	}
 	addOccurrenceNodes(root, asm.Occurrences())
+	addAssemblyFeatureNodes(root, asm.Features())
+}
+
+// addAssemblyFeatureNodes appends a Features folder listing the assembly machining features in
+// program order, each a selectable row whose right-click menu edits / suppresses / deletes it
+// (#766). The folder is omitted when the assembly has no features yet.
+func addAssemblyFeatureNodes(root *BrowserNode, fs *compdef.AssemblyFeatures) {
+	if fs.Count() == 0 {
+		return
+	}
+	folder := root.child("Features", "features")
+	for i := 0; i < fs.Count(); i++ {
+		af := fs.Item(i)
+		folder.selectableChild(assemblyFeatureLabel(af), "assemblyFeature", AssemblyFeatureHandle{Feature: af})
+	}
+}
+
+// assemblyFeatureLabel is the feature row's label, suffixed when it is suppressed.
+func assemblyFeatureLabel(af *compdef.AssemblyFeature) string {
+	if af.Suppressed() {
+		return af.Name() + " (suppressed)"
+	}
+	return af.Name()
 }
 
 // addOccurrenceNodes appends one selectable node per occurrence under parent, recursing into a

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -33,8 +33,29 @@ func BrowserMenu(n BrowserNode) []BrowserMenuItem {
 		return bodyMenu(n.Select)
 	case "occurrence":
 		return occurrenceMenu(n.Select)
+	case "assemblyFeature":
+		return assemblyFeatureNodeMenu(n.Select)
 	default:
 		return nil
+	}
+}
+
+// assemblyFeatureNodeMenu offers Edit (its scalar parameters), a Suppress/Unsuppress toggle, and
+// Delete for a committed assembly machining feature (#766). Edit is greyed for a feature with no
+// editable parameters.
+func assemblyFeatureNodeMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(AssemblyFeatureHandle)
+	if !ok {
+		return nil
+	}
+	suppressLabel := "Suppress"
+	if h.Feature.Suppressed() {
+		suppressLabel = "Unsuppress"
+	}
+	return []BrowserMenuItem{
+		{Label: "Edit", Enabled: assemblyFeatureEditable(h.Feature), Invoke: func(s *Session) error { s.BeginEditAssemblyFeature(h); return nil }},
+		{Label: suppressLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleAssemblyFeatureSuppressed(h.Feature) }},
+		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteAssemblyFeature(h.Feature) }},
 	}
 }
 

--- a/app/selection.go
+++ b/app/selection.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
@@ -86,6 +87,13 @@ func (SketchEntityHandle) SelectionKind() SelectionKind { return SelectSketchEnt
 type OccurrenceHandle struct{ Occurrence *occurrence.Occurrence }
 
 func (OccurrenceHandle) SelectionKind() SelectionKind { return SelectOccurrence }
+
+// AssemblyFeatureHandle wraps a committed assembly machining feature (selected in the assembly
+// browser), the input the edit/suppress/delete actions consume (#766). It wraps the program
+// wrapper, not the bare feature, so those actions reach the suppression/name/id state.
+type AssemblyFeatureHandle struct{ Feature *compdef.AssemblyFeature }
+
+func (AssemblyFeatureHandle) SelectionKind() SelectionKind { return SelectFeature }
 
 // SketchHandle wraps a whole sketch (selected in the browser), as opposed to one of its
 // entities — the input for Edit Sketch and for highlighting the sketch in the view.

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -193,6 +193,8 @@ func openEditOnDoubleClick(s *app.Session, n app.BrowserNode) {
 	switch h := n.Select.(type) {
 	case app.FeatureHandle:
 		s.BeginEditFeature(h)
+	case app.AssemblyFeatureHandle:
+		s.BeginEditAssemblyFeature(h) // edit a committed assembly machining feature (#766)
 	case app.SketchHandle:
 		s.BeginEditSketch(h)
 	case app.WorkPlaneHandle:


### PR DESCRIPTION
## What
Committed assembly machining features were invisible in the browser and couldn't be re-edited. Surface and edit them — the **last piece of #766**.

- The assembly browser gains a **Features** folder listing each machining feature in program order (selectable `AssemblyFeatureHandle` rows; suppressed ones annotated).
- **Edit** (the browser right-click menu *and* a double-click) re-opens a feature as a tool whose `Params()` are its `EditableParams` (distance / radius / angle / …), shown in the generic tool-param dialog. The dialog's setters write through to the feature's closure-backed scalars, so **OK** recomputes with the new values and records an undo step, and **Cancel** restores the values captured at open.
- **Suppress/Unsuppress** and **Delete** round out the menu (both undoable).

Because the feature program now persists (#785), an edit is one undo step and survives save.

## Tests
- `TestAssemblyBrowserListsFeatures` — the feature appears as a selectable row.
- `TestAssemblyFeatureEditChangesParameter` — editing a chamfer's setback 0.2→0.4 re-machines the participant to the new analytic volume (15.92→15.68).
- `TestAssemblyFeatureEditCancelRestores` — Cancel restores the original.
- `TestAssemblyFeatureEditIsUndoable` — the edit undoes as one step.
- `TestAssemblyFeatureMenuAndDelete` — Edit|Suppress|Delete; Delete removes the feature, undo restores it.

`go test ./app/...` green (full suite); `golangci-lint` 0 issues; head builds.

Closes #766 — the assembly machining set is now fully wired: create (chamfer/fillet/extrude/revolve/hole), persist/undo (#785), and **edit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)