### PR TITLE
Assembly viewport parity: stable rendering, origin frame, and work-plane authoring

### DIFF
--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -17,17 +17,51 @@ import (
 	"oblikovati.org/model/param"
 )
 
-// listWorkPlanes enumerates the active part's datum planes (origin frame first, then
+// A part and an assembly both host work features over this wire surface.
+var (
+	_ workHost = (*compdef.PartComponentDefinition)(nil)
+	_ workHost = (*compdef.AssemblyComponentDefinition)(nil)
+)
+
+// workHost is the model surface the work-feature wire methods author against — a part OR an
+// assembly. Both own a work-geometry collection (origin frame + user datums), a parameter DAG,
+// document units, and a recompute, so workPlanes.* / workPoints.* serve an assembly exactly as a
+// part. (An assembly's offset / three-point / angle planes need no body; a tangent-to-face plane
+// needs a participant face and simply reports unhealthy on an assembly — it is not rejected here.)
+type workHost interface {
+	WorkPlanes() *feature.WorkPlanes
+	WorkPoints() *feature.WorkPoints
+	Units() param.UnitsOfMeasure
+	Parameters() *param.Parameters
+	Recompute()
+}
+
+// activeWorkHost resolves the active document's content to a work-feature host (part or assembly),
+// so the work-plane/point methods no longer reject an assembly. A document whose content is neither
+// (a drawing, a presentation, a reference stub) is an error.
+func activeWorkHost(s *app.Session) (workHost, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, modelaccess.ErrNoActiveDocument
+	}
+	host, ok := d.Content().(workHost)
+	if !ok {
+		return nil, fmt.Errorf("workPlanes: active document %q is not a part or assembly", d.DisplayName())
+	}
+	return host, nil
+}
+
+// listWorkPlanes enumerates the active model's datum planes (origin frame first, then
 // user planes) with their current geometry and health.
 func listWorkPlanes(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	host, err := activeWorkHost(s)
 	if err != nil {
 		return nil, err
 	}
-	planes := part.WorkPlanes()
+	planes := host.WorkPlanes()
 	out := make([]wire.WorkPlaneInfo, planes.Count())
 	for i := 0; i < planes.Count(); i++ {
-		out[i] = workPlaneInfo(part, planes.Item(i), i)
+		out[i] = workPlaneInfo(host, planes.Item(i), i)
 	}
 	return json.Marshal(wire.ListWorkPlanesResult{Planes: out})
 }
@@ -35,7 +69,7 @@ func listWorkPlanes(s *app.Session, _ json.RawMessage) (json.RawMessage, error) 
 // workPlaneInfo renders one plane as the wire DTO, including the editable inputs a redefine
 // accepts: its scalars (offset/angle, in the document's preferred unit) and its re-pickable
 // reference slots (each tagged plane|axis|point|face). Origin planes report neither.
-func workPlaneInfo(part *compdef.PartComponentDefinition, wp *feature.WorkPlane, index int) wire.WorkPlaneInfo {
+func workPlaneInfo(host workHost, wp *feature.WorkPlane, index int) wire.WorkPlaneInfo {
 	return wire.WorkPlaneInfo{
 		Index:    index,
 		Name:     wp.Name(),
@@ -46,14 +80,14 @@ func workPlaneInfo(part *compdef.PartComponentDefinition, wp *feature.WorkPlane,
 		Healthy:  wp.Health().OK(),
 		Reason:   wp.Health().Reason, // empty when healthy
 		Kind:     wp.Kind(),
-		Scalars:  workPlaneScalars(part, wp),
+		Scalars:  workPlaneScalars(host, wp),
 		Slots:    workPlaneSlots(wp),
 	}
 }
 
 // workPlaneScalars renders the plane's editable scalars with their value in the document's
 // preferred unit (mm/deg), so a client reads the current value and can set a new one.
-func workPlaneScalars(part *compdef.PartComponentDefinition, wp *feature.WorkPlane) []wire.WorkPlaneScalar {
+func workPlaneScalars(host workHost, wp *feature.WorkPlane) []wire.WorkPlaneScalar {
 	scalars := wp.EditableScalars()
 	if len(scalars) == 0 {
 		return nil
@@ -63,8 +97,8 @@ func workPlaneScalars(part *compdef.PartComponentDefinition, wp *feature.WorkPla
 		out[i] = wire.WorkPlaneScalar{
 			Index: i,
 			Label: sc.Label,
-			Unit:  part.Units().PreferredName(sc.Unit),
-			Value: part.Units().ToPreferred(param.Q(sc.Get(), sc.Unit)),
+			Unit:  host.Units().PreferredName(sc.Unit),
+			Value: host.Units().ToPreferred(param.Q(sc.Get(), sc.Unit)),
 		}
 	}
 	return out
@@ -88,7 +122,7 @@ func workPlaneSlots(wp *feature.WorkPlane) []wire.WorkPlaneRefSlot {
 // and returns the plane's refreshed info. It fails on a bad index, an origin plane, or an
 // out-of-range scalar/slot; an unsatisfiable result is reported healthy=false, not an error.
 func redefineWorkPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	host, err := activeWorkHost(s)
 	if err != nil {
 		return nil, err
 	}
@@ -96,12 +130,12 @@ func redefineWorkPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	wp, err := userWorkPlane(part, in.Index)
+	wp, err := userWorkPlane(host, in.Index)
 	if err != nil {
 		return nil, err
 	}
 	restore := wp.SnapshotDefinition() // an error mid-batch must not leave earlier edits applied
-	if err := applyScalarEdits(part, wp, in.Scalars); err != nil {
+	if err := applyScalarEdits(host, wp, in.Scalars); err != nil {
 		restore()
 		return nil, err
 	}
@@ -109,13 +143,13 @@ func redefineWorkPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 		restore()
 		return nil, err
 	}
-	part.Recompute()
-	return json.Marshal(wire.RedefineWorkPlaneResult{Plane: workPlaneInfo(part, wp, in.Index)})
+	host.Recompute()
+	return json.Marshal(wire.RedefineWorkPlaneResult{Plane: workPlaneInfo(host, wp, in.Index)})
 }
 
 // userWorkPlane resolves a redefine index to a user (non-origin) work plane.
-func userWorkPlane(part *compdef.PartComponentDefinition, index int) (*feature.WorkPlane, error) {
-	planes := part.WorkPlanes()
+func userWorkPlane(host workHost, index int) (*feature.WorkPlane, error) {
+	planes := host.WorkPlanes()
 	if index < 0 || index >= planes.Count() {
 		return nil, fmt.Errorf("workPlanes.redefine: index %d out of range (%d planes)", index, planes.Count())
 	}
@@ -128,13 +162,13 @@ func userWorkPlane(part *compdef.PartComponentDefinition, index int) (*feature.W
 
 // applyScalarEdits sets the plane's scalars from unit-bearing strings, parsed by each scalar's
 // quantity kind (length or angle) into the database units its Set expects.
-func applyScalarEdits(part *compdef.PartComponentDefinition, wp *feature.WorkPlane, edits []wire.ScalarEdit) error {
+func applyScalarEdits(host workHost, wp *feature.WorkPlane, edits []wire.ScalarEdit) error {
 	scalars := wp.EditableScalars()
 	for _, e := range edits {
 		if e.Index < 0 || e.Index >= len(scalars) {
 			return fmt.Errorf("workPlanes.redefine: scalar index %d out of range (%d scalars)", e.Index, len(scalars))
 		}
-		q, err := part.Units().Parse(e.Value, scalars[e.Index].Unit)
+		q, err := host.Units().Parse(e.Value, scalars[e.Index].Unit)
 		if err != nil {
 			return fmt.Errorf("workPlanes.redefine: scalar %d value %q: %w", e.Index, e.Value, err)
 		}
@@ -159,11 +193,11 @@ func applyRepicks(wp *feature.WorkPlane, repicks []wire.SlotRepick) error {
 	return nil
 }
 
-// createWorkPlanes adds a datum plane of the requested kind to the active part and
+// createWorkPlanes adds a datum plane of the requested kind to the active model and
 // recomputes. An unsatisfiable definition still creates the plane (reported healthy=false)
 // — the call only fails on bad arguments (unknown kind, wrong reference count, …).
 func createWorkPlanes(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	host, err := activeWorkHost(s)
 	if err != nil {
 		return nil, err
 	}
@@ -171,24 +205,24 @@ func createWorkPlanes(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	wp, err := buildWorkPlane(part, in)
+	wp, err := buildWorkPlane(host, in)
 	if err != nil {
 		return nil, err
 	}
-	part.Recompute()
+	host.Recompute()
 	return json.Marshal(wire.CreateWorkPlaneResult{
-		Index:   part.WorkPlanes().Count() - 1,
+		Index:   host.WorkPlanes().Count() - 1,
 		Ref:     string(wp.Key()),
 		Name:    wp.Name(),
 		Healthy: wp.Health().OK(),
 	})
 }
 
-// createWorkPoint adds a datum point fixed at the requested position to the active part and
+// createWorkPoint adds a datum point fixed at the requested position to the active model and
 // recomputes, returning its index and reference (usable as a point input to a work plane or a
 // redefine re-pick).
 func createWorkPoint(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	host, err := activeWorkHost(s)
 	if err != nil {
 		return nil, err
 	}
@@ -201,10 +235,10 @@ func createWorkPoint(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 		return nil, err
 	}
 	p := math.P3(at[0], at[1], at[2])
-	wp := part.WorkPoints().AddByPosition(func() math.Point3 { return p })
-	part.Recompute()
+	wp := host.WorkPoints().AddByPosition(func() math.Point3 { return p })
+	host.Recompute()
 	return json.Marshal(wire.CreateWorkPointResult{
-		Index: part.WorkPoints().Count() - 1,
+		Index: host.WorkPoints().Count() - 1,
 		Ref:   string(wp.Key()),
 		Name:  wp.Name(),
 	})
@@ -247,8 +281,8 @@ var refPlaneCtors = map[types.WorkPlaneKind]refPlaneCtor{
 }
 
 // buildWorkPlane dispatches a create request to the matching model constructor.
-func buildWorkPlane(part *compdef.PartComponentDefinition, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
-	planes := part.WorkPlanes()
+func buildWorkPlane(host workHost, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+	planes := host.WorkPlanes()
 	refs := toWorkRefs(in.Refs)
 	kind := types.WorkPlaneKind(in.Kind)
 	if c, ok := refPlaneCtors[kind]; ok {
@@ -259,38 +293,38 @@ func buildWorkPlane(part *compdef.PartComponentDefinition, in wire.CreateWorkPla
 	}
 	switch kind {
 	case types.WorkPlaneOffset:
-		return addOffsetPlane(part, refs, in)
+		return addOffsetPlane(host, refs, in)
 	case types.WorkPlaneLinePlaneAngle:
-		return addAnglePlane(part, refs, in)
+		return addAnglePlane(host, refs, in)
 	case types.WorkPlaneFixed:
-		return addFixedWorkPlane(part.WorkPlanes(), in)
+		return addFixedWorkPlane(host.WorkPlanes(), in)
 	default:
 		return nil, fmt.Errorf("workPlanes.create: unknown kind %q (see api/types WorkPlane*)", in.Kind)
 	}
 }
 
 // addOffsetPlane builds the plane-offset kind: one base plane reference + a distance.
-func addOffsetPlane(part *compdef.PartComponentDefinition, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+func addOffsetPlane(host workHost, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
 	if len(refs) != 1 {
 		return nil, fmt.Errorf("workPlanes.create: %s needs 1 reference, got %d", in.Kind, len(refs))
 	}
-	off, err := modelLengthClosure(part, in.Offset)
+	off, err := modelLengthClosure(host, in.Offset)
 	if err != nil {
 		return nil, err
 	}
-	return part.WorkPlanes().AddByPlaneAndOffset(refs[0], off), nil
+	return host.WorkPlanes().AddByPlaneAndOffset(refs[0], off), nil
 }
 
 // addAnglePlane builds the line-plane-angle kind: a line + a plane reference + an angle.
-func addAnglePlane(part *compdef.PartComponentDefinition, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
+func addAnglePlane(host workHost, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, error) {
 	if len(refs) != 2 {
 		return nil, fmt.Errorf("workPlanes.create: %s needs 2 references, got %d", in.Kind, len(refs))
 	}
-	a, err := modelAngle(part, in.Angle)
+	a, err := modelAngle(host, in.Angle)
 	if err != nil {
 		return nil, err
 	}
-	return part.WorkPlanes().AddByLinePlaneAndAngle(refs[0], refs[1], func() float64 { return a }), nil
+	return host.WorkPlanes().AddByLinePlaneAndAngle(refs[0], refs[1], func() float64 { return a }), nil
 }
 
 // addFixedWorkPlane builds an AddFixed plane from its origin point and two axis vectors.
@@ -353,14 +387,14 @@ func isWorkFeatureRef(r string) bool {
 // modelLengthClosure turns a distance argument into a live, parameter-aware value: a
 // plain literal is constant; an expression ("h", "h/2") is backed by an auto model
 // parameter, so editing the parameter and recomputing re-reads it (a work plane is
-// re-evaluated by part.Recompute). Mirrors opregistry's lengthClosure for the router
+// re-evaluated by the host's Recompute). Mirrors opregistry's lengthClosure for the router
 // args that feed func() float64 (work-plane offset).
-func modelLengthClosure(part *compdef.PartComponentDefinition, expr string) (func() float64, error) {
-	if q, err := part.Units().Parse(expr, param.Length); err == nil {
+func modelLengthClosure(host workHost, expr string) (func() float64, error) {
+	if q, err := host.Units().Parse(expr, param.Length); err == nil {
 		v := q.Value
 		return func() float64 { return v }, nil
 	}
-	p, err := part.Parameters().AddAutoModelParameter(expr)
+	p, err := host.Parameters().AddAutoModelParameter(expr)
 	if err != nil {
 		return nil, fmt.Errorf("workPlanes.create: offset %q: %w", expr, err)
 	}
@@ -371,8 +405,8 @@ func modelLengthClosure(part *compdef.PartComponentDefinition, expr string) (fun
 }
 
 // modelAngle parses a unit-bearing angle ("45 deg") into a model value (radians).
-func modelAngle(part *compdef.PartComponentDefinition, expr string) (float64, error) {
-	q, err := part.Units().Parse(expr, param.Angle)
+func modelAngle(host workHost, expr string) (float64, error) {
+	q, err := host.Units().Parse(expr, param.Angle)
 	if err != nil {
 		return 0, fmt.Errorf("workPlanes.create: angle %q: %w", expr, err)
 	}

--- a/addin/router/work_planes_assembly_test.go
+++ b/addin/router/work_planes_assembly_test.go
@@ -43,28 +43,11 @@ func TestWorkPlanesListServesAssembly(t *testing.T) {
 }
 
 // TestWorkPlanesCreateOffsetInAssembly: an offset plane built on the assembly's origin XY plane is
-// created, healthy, and lands at the expected position — the same flow a part supports, now served
-// for an assembly (its offset plane needs no body).
+// created, healthy, and lands at the expected position — the same flow a part supports (its offset
+// plane needs no body), now served for an assembly. Shares the assertion with the part test.
 func TestWorkPlanesCreateOffsetInAssembly(t *testing.T) {
 	r, s := emptyAssemblySession(t)
-	var res wire.CreateWorkPlaneResult
-	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
-	if !res.Healthy {
-		t.Fatalf("offset plane not healthy: %+v", res)
-	}
-	if res.Index != 3 { // after the 3 origin planes
-		t.Errorf("new plane index = %d, want 3", res.Index)
-	}
-	var list wire.ListWorkPlanesResult
-	call(t, r, s, "workPlanes.list", "{}", &list)
-	if len(list.Planes) != 4 {
-		t.Fatalf("after create, %d planes, want 4", len(list.Planes))
-	}
-	created := list.Planes[3]
-	// "10 mm" is 1.0 cm in model units; the XY plane offset +Z lands at z=1.
-	if created.IsOrigin || len(created.Origin) != 3 || created.Origin[2] != 1 {
-		t.Errorf("created plane = %+v, want a user plane at z=1", created)
-	}
+	assertOffsetPlaneOnXY(t, r, s)
 }
 
 // TestWorkPlanesCreateThreePointsInAssembly: a three-point plane through the assembly's origin

--- a/addin/router/work_planes_assembly_test.go
+++ b/addin/router/work_planes_assembly_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+)
+
+// emptyAssemblySession returns a router and a session with a fresh assembly active — its origin
+// frame is seeded, the fixture for the assembly work-feature wire tests.
+func emptyAssemblySession(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	s := app.NewSession()
+	d, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(d); err != nil {
+		t.Fatalf("activate assembly: %v", err)
+	}
+	return New(opregistry.Default()), s
+}
+
+// TestWorkPlanesListServesAssembly: an assembly answers workPlanes.list with its three origin
+// planes — before, the handler rejected an assembly ("not a part").
+func TestWorkPlanesListServesAssembly(t *testing.T) {
+	r, s := emptyAssemblySession(t)
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if len(list.Planes) != 3 {
+		t.Fatalf("fresh assembly has %d work planes, want 3 origin planes", len(list.Planes))
+	}
+	for _, p := range list.Planes {
+		if !p.IsOrigin || !p.Healthy {
+			t.Errorf("origin plane %q: isOrigin=%v healthy=%v, want both true", p.Name, p.IsOrigin, p.Healthy)
+		}
+	}
+}
+
+// TestWorkPlanesCreateOffsetInAssembly: an offset plane built on the assembly's origin XY plane is
+// created, healthy, and lands at the expected position — the same flow a part supports, now served
+// for an assembly (its offset plane needs no body).
+func TestWorkPlanesCreateOffsetInAssembly(t *testing.T) {
+	r, s := emptyAssemblySession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
+	if !res.Healthy {
+		t.Fatalf("offset plane not healthy: %+v", res)
+	}
+	if res.Index != 3 { // after the 3 origin planes
+		t.Errorf("new plane index = %d, want 3", res.Index)
+	}
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if len(list.Planes) != 4 {
+		t.Fatalf("after create, %d planes, want 4", len(list.Planes))
+	}
+	created := list.Planes[3]
+	// "10 mm" is 1.0 cm in model units; the XY plane offset +Z lands at z=1.
+	if created.IsOrigin || len(created.Origin) != 3 || created.Origin[2] != 1 {
+		t.Errorf("created plane = %+v, want a user plane at z=1", created)
+	}
+}
+
+// TestWorkPlanesCreateThreePointsInAssembly: a three-point plane through the assembly's origin
+// datums is created and healthy — exercising a reference-only constructor against an assembly.
+func TestWorkPlanesCreateThreePointsInAssembly(t *testing.T) {
+	r, s := emptyAssemblySession(t)
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"two-planes","refs":["origin/plane/xy","origin/plane/xz"]}`, &res)
+	if !res.Healthy {
+		t.Errorf("assembly midplane not healthy: %+v", res)
+	}
+}
+
+// TestWorkPointCreateInAssembly: a datum point fixed at a position is added to an assembly and
+// returns a usable reference.
+func TestWorkPointCreateInAssembly(t *testing.T) {
+	r, s := emptyAssemblySession(t)
+	var res wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[1,2,3]}`, &res)
+	if res.Ref == "" {
+		t.Errorf("workPoints.create in assembly returned no ref: %+v", res)
+	}
+}

--- a/addin/router/work_planes_test.go
+++ b/addin/router/work_planes_test.go
@@ -7,7 +7,32 @@ import (
 	"testing"
 
 	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
 )
+
+// assertOffsetPlaneOnXY creates a +Z offset plane on the origin XY plane and asserts it is the
+// healthy 4th plane landing at z=1 (10 mm = 1 cm in model units). Shared by the part and the
+// assembly create tests so the same create+list+geometry check serves both document kinds.
+func assertOffsetPlaneOnXY(t *testing.T, r *Router, s *app.Session) {
+	t.Helper()
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
+	if !res.Healthy {
+		t.Fatalf("offset plane not healthy: %+v", res)
+	}
+	if res.Index != 3 { // after the 3 origin planes
+		t.Errorf("new plane index = %d, want 3", res.Index)
+	}
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if len(list.Planes) != 4 {
+		t.Fatalf("after create, %d planes, want 4", len(list.Planes))
+	}
+	created := list.Planes[3]
+	if created.IsOrigin || len(created.Origin) != 3 || created.Origin[2] != 1 {
+		t.Errorf("created plane = %+v, want a user plane at z=1", created)
+	}
+}
 
 func TestWorkPlanesListIncludesOriginFrame(t *testing.T) {
 	r, s := emptyPartSession(t)
@@ -25,24 +50,7 @@ func TestWorkPlanesListIncludesOriginFrame(t *testing.T) {
 
 func TestWorkPlanesCreateOffsetThenList(t *testing.T) {
 	r, s := emptyPartSession(t)
-	var res wire.CreateWorkPlaneResult
-	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &res)
-	if !res.Healthy {
-		t.Fatalf("offset plane not healthy: %+v", res)
-	}
-	if res.Index != 3 { // after the 3 origin planes
-		t.Errorf("new plane index = %d, want 3", res.Index)
-	}
-	var list wire.ListWorkPlanesResult
-	call(t, r, s, "workPlanes.list", "{}", &list)
-	if len(list.Planes) != 4 {
-		t.Fatalf("after create, %d planes, want 4", len(list.Planes))
-	}
-	created := list.Planes[3]
-	// "10 mm" is 1.0 cm in model units; the XY plane offset +Z lands at z=1.
-	if created.IsOrigin || len(created.Origin) != 3 || created.Origin[2] != 1 {
-		t.Errorf("created plane = %+v, want a user plane at z=1", created)
-	}
+	assertOffsetPlaneOnXY(t, r, s)
 }
 
 func TestWorkPlanesCreateMidplane(t *testing.T) {

--- a/app/browser.go
+++ b/app/browser.go
@@ -67,11 +67,13 @@ func BuildBrowser(s *Session) BrowserNode {
 	return root
 }
 
-// addAssemblyBranches builds the assembly's browser tree: the Parameters folder, then the placed
-// component occurrences in placement order. Each occurrence node is selectable (its handle drives
-// ground/suppress/delete from the right-click menu and the replication commands), and a
-// sub-assembly occurrence nests its own occurrences so the structure is navigable (#764).
+// addAssemblyBranches builds the assembly's browser tree: the Origin folder (origin planes/axes/
+// point, like a part's), the Parameters folder, then the placed component occurrences in placement
+// order. Each occurrence node is selectable (its handle drives ground/suppress/delete from the
+// right-click menu and the replication commands), and a sub-assembly occurrence nests its own
+// occurrences so the structure is navigable (#764).
 func addAssemblyBranches(root *BrowserNode, asm *compdef.AssemblyComponentDefinition) {
+	addOriginBranch(root, asm.WorkGeometry()) // the Origin folder (planes/axes/point), like a part's
 	params := root.child("Parameters", "parameters")
 	for _, p := range asm.Parameters().All() {
 		params.child(p.Name(), "parameter")
@@ -137,7 +139,7 @@ func occurrenceLabel(o *occurrence.Occurrence) string {
 // Sketches branch, so a sketch's dependency on an earlier work plane/feature is visible
 // (issue #132). Sketch/feature/datum nodes are selectable so clicking one syncs the 3D view.
 func addPartBranches(root *BrowserNode, part *compdef.PartComponentDefinition) {
-	addOriginBranch(root, part)
+	addOriginBranch(root, part.WorkGeometry())
 	params := root.child("Parameters", "parameters")
 	for _, p := range part.Parameters().All() {
 		params.child(p.Name(), "parameter")
@@ -278,19 +280,20 @@ func featureLabel(f *feature.PartFeature) string {
 
 // addOriginBranch fills the Origin folder with the seven coordinate-system elements (three
 // planes, three axes, the center point), all selectable — the reference inputs for
-// axis/point-driven work planes (Inventor's Origin folder).
-func addOriginBranch(root *BrowserNode, part *compdef.PartComponentDefinition) {
+// axis/point-driven work planes (the Origin folder). It takes the work geometry (not a part) so a
+// part AND an assembly both get the folder — both seed the same origin frame.
+func addOriginBranch(root *BrowserNode, wg *feature.WorkGeometry) {
 	origin := root.child("Origin", "origin")
-	for _, wp := range part.OriginPlanes() {
+	for _, wp := range wg.OriginPlanes() {
 		origin.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
 	}
-	axes := part.WorkAxes()
+	axes := wg.WorkAxes()
 	for i := 0; i < axes.Count(); i++ {
 		if a := axes.Item(i); a.IsCoordinateSystemElement() {
 			origin.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
 		}
 	}
-	points := part.WorkPoints()
+	points := wg.WorkPoints()
 	for i := 0; i < points.Count(); i++ {
 		if p := points.Item(i); p.IsCoordinateSystemElement() {
 			origin.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})

--- a/app/work_geometry_assembly_test.go
+++ b/app/work_geometry_assembly_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// activeAssemblySession returns a session with a fresh, empty assembly active — its origin frame
+// (origin planes/axes/point) is seeded on creation, the fixture for the assembly work-geometry tests.
+func activeAssemblySession(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	asmDoc, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(asmDoc); err != nil {
+		t.Fatalf("activate assembly: %v", err)
+	}
+	return s
+}
+
+// TestActiveWorkGeometryResolvesAssembly: the active-work-geometry accessor resolves an assembly's
+// origin frame, not only a part's — both own a feature.WorkGeometry, so datum rendering and picking
+// can source from it model-agnostically.
+func TestActiveWorkGeometryResolvesAssembly(t *testing.T) {
+	s := activeAssemblySession(t)
+	wg, ok := s.ActiveWorkGeometry()
+	if !ok || wg == nil {
+		t.Fatalf("ActiveWorkGeometry(assembly) = (%v, %v), want the assembly's seeded work geometry", wg, ok)
+	}
+	if got := wg.WorkPlanes().Count(); got < 3 {
+		t.Errorf("assembly origin planes = %d, want >= 3 (XY/XZ/YZ)", got)
+	}
+}
+
+// TestPickableWorkPlanesIncludesAssemblyOrigin: an assembly's three origin planes are pickable (so
+// they can host a sketch in the assembly), where before they were absent — PickableWorkPlanes was
+// part-gated and returned nil for an assembly.
+func TestPickableWorkPlanesIncludesAssemblyOrigin(t *testing.T) {
+	s := activeAssemblySession(t)
+	if got := len(s.PickableWorkPlanes()); got != 3 {
+		t.Errorf("assembly PickableWorkPlanes = %d, want 3 origin planes (XY/XZ/YZ)", got)
+	}
+}
+
+// TestPickableWorkAxesFollowsVisibilityInAssembly: an assembly's origin axes (X/Y/Z), like a
+// part's, are hidden by default (the Origin folder) and become pickable AND drawn once made
+// visible. Before, an assembly's axes were never offered (the source was part-gated); now toggling
+// them on shows them in the assembly exactly as in a part.
+func TestPickableWorkAxesFollowsVisibilityInAssembly(t *testing.T) {
+	s := activeAssemblySession(t)
+	if got := len(s.PickableWorkAxes()); got != 0 {
+		t.Fatalf("assembly PickableWorkAxes (default) = %d, want 0 (origin axes hidden until shown, as in a part)", got)
+	}
+	wg, _ := s.ActiveWorkGeometry()
+	axes := wg.WorkAxes()
+	for i := 0; i < axes.Count(); i++ {
+		axes.Item(i).SetVisible(true) // the user shows the Origin folder's axes
+	}
+	if got := len(s.PickableWorkAxes()); got != 3 {
+		t.Errorf("assembly PickableWorkAxes (shown) = %d, want 3 origin axes (X/Y/Z)", got)
+	}
+}
+
+// TestPickableWorkPointsIncludesAssemblyOrigin: an assembly's origin centre point is a snap target.
+func TestPickableWorkPointsIncludesAssemblyOrigin(t *testing.T) {
+	s := activeAssemblySession(t)
+	if got := len(s.PickableWorkPoints()); got != 1 {
+		t.Errorf("assembly PickableWorkPoints = %d, want 1 origin centre point", got)
+	}
+}
+
+// TestAssemblyBrowserHasOriginFolder: the assembly browser shows an Origin folder with the seven
+// coordinate-system elements (3 planes + 3 axes + 1 point), like a part's — before, an assembly's
+// tree had Parameters and occurrences but no Origin folder at all.
+func TestAssemblyBrowserHasOriginFolder(t *testing.T) {
+	s := activeAssemblySession(t)
+	root := BuildBrowser(s)
+	if !hasTopLevelKind(root, "origin") {
+		t.Fatal("assembly browser has no Origin folder; a part's does")
+	}
+	var origin BrowserNode
+	for _, c := range root.Children {
+		if c.Kind == "origin" {
+			origin = c
+		}
+	}
+	if got := len(origin.Children); got != 7 {
+		t.Errorf("assembly Origin folder has %d entries, want 7 (3 planes + 3 axes + 1 point)", got)
+	}
+}

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -29,27 +29,89 @@ func (s *Session) SelectedWorkPlanes() []*feature.WorkPlane {
 	return planes
 }
 
+// ActiveWorkGeometry returns the active document's work geometry — its origin coordinate frame
+// (origin planes/axes/point) and user-created datums — whether the active document is a part or an
+// assembly, since both own a [feature.WorkGeometry]. The second result is false when no such
+// document is active. The viewport's datum rendering and picking source from this so an assembly's
+// origin axes and work planes are shown and clickable exactly like a part's.
+func (s *Session) ActiveWorkGeometry() (*feature.WorkGeometry, bool) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, false
+	}
+	provider, ok := d.Content().(interface {
+		WorkGeometry() *feature.WorkGeometry
+	})
+	if !ok {
+		return nil, false
+	}
+	return provider.WorkGeometry(), true
+}
+
 // PickableWorkPlanes returns the work planes the viewport hit-test should offer: every
-// origin plane (always pickable as a sketch host — Inventor's Origin folder — even though
+// origin plane (always pickable as a sketch host — the Origin folder — even though
 // origin planes default to hidden) plus every VISIBLE user-created datum not hidden by the
 // active edit scope (a plane the overlays don't draw must not be clickable either). User
 // planes were previously absent from the picker, so a ribbon-created plane could not be
 // clicked as a new sketch's reference in the 3D view (issue #132); the head feeds this to
-// the RayPicker.
+// the RayPicker. Works for an assembly too (its origin planes are sketch hosts as well).
 func (s *Session) PickableWorkPlanes() []*feature.WorkPlane {
 	if !s.objectVisibility.WorkPlanes { // hidden kinds are not pickable (M05-F12)
 		return nil
 	}
-	part, err := activePart(s)
-	if err != nil {
+	wg, ok := s.ActiveWorkGeometry()
+	if !ok {
 		return nil
 	}
-	planes := part.WorkPlanes()
+	planes := wg.WorkPlanes()
 	out := make([]*feature.WorkPlane, 0, planes.Count())
 	for i := 0; i < planes.Count(); i++ {
 		wp := planes.Item(i)
 		if wp.IsCoordinateSystemElement() || (wp.Visible() && !s.EditScopeHides(wp.Seq())) {
 			out = append(out, wp)
+		}
+	}
+	return out
+}
+
+// PickableWorkAxes returns the datum axes (origin X/Y/Z and user) the viewport hit-test should
+// offer — every visible axis not hidden by the active edit scope, for a part or an assembly. The
+// picker snaps a click to one as a work-plane / sketch reference; geometry the overlays do not draw
+// must not be clickable, so this mirrors the axesOverlay filter.
+func (s *Session) PickableWorkAxes() []*feature.WorkAxis {
+	if !s.objectVisibility.WorkAxes { // hidden kinds are not pickable (M05-F12)
+		return nil
+	}
+	wg, ok := s.ActiveWorkGeometry()
+	if !ok {
+		return nil
+	}
+	axes := wg.WorkAxes()
+	out := make([]*feature.WorkAxis, 0, axes.Count())
+	for i := 0; i < axes.Count(); i++ {
+		if ax := axes.Item(i); ax.Visible() && !s.EditScopeHides(ax.Seq()) {
+			out = append(out, ax)
+		}
+	}
+	return out
+}
+
+// PickableWorkPoints returns the datum points (origin center and user) the viewport hit-test should
+// snap to, for a part or an assembly. Points have no overlay symbol but are snap targets; scope-
+// hidden ones are excluded to match the other datums.
+func (s *Session) PickableWorkPoints() []*feature.WorkPoint {
+	if !s.objectVisibility.WorkPoints { // hidden kinds are not pickable (M05-F12)
+		return nil
+	}
+	wg, ok := s.ActiveWorkGeometry()
+	if !ok {
+		return nil
+	}
+	points := wg.WorkPoints()
+	out := make([]*feature.WorkPoint, 0, points.Count())
+	for i := 0; i < points.Count(); i++ {
+		if pt := points.Item(i); !s.EditScopeHides(pt.Seq()) {
+			out = append(out, pt)
 		}
 	}
 	return out

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -202,8 +202,8 @@ func installPicker(s *app.Session) {
 	s.SetPicker(app.NewRayPicker(s.Camera(),
 		func() []*topo.Body { return activeBodies(s) }).
 		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }).
-		WithPoints(func() []*feature.WorkPoint { return activeWorkPoints(s) }).
-		WithAxes(func() []*feature.WorkAxis { return activeWorkAxes(s) }).
+		WithPoints(func() []*feature.WorkPoint { return s.PickableWorkPoints() }).
+		WithAxes(func() []*feature.WorkAxis { return s.PickableWorkAxes() }).
 		WithSketches(func() []*sketch.Sketch {
 			if !s.ObjectVisibility().Sketches {
 				return nil
@@ -230,46 +230,6 @@ func loadAppOptions(s *app.Session) {
 // the picker's hit-test so it follows the current document.
 func activeBodies(s *app.Session) []*topo.Body {
 	return s.VisibleBodies()
-}
-
-// activeWorkPoints / activeWorkAxes return the active part's datum points/axes (origin
-// and user), so the picker can snap a click to them as work-plane reference inputs. Nodes
-// hidden by the active edit scope are excluded, matching the overlays — geometry the
-// viewport does not draw must not be clickable.
-func activeWorkPoints(s *app.Session) []*feature.WorkPoint {
-	if !s.ObjectVisibility().WorkPoints { // hidden kinds are not pickable (M05-F12)
-		return nil
-	}
-	p, err := modelaccess.ActivePart(s)
-	if err != nil {
-		return nil
-	}
-	points := p.WorkPoints()
-	out := make([]*feature.WorkPoint, 0, points.Count())
-	for i := 0; i < points.Count(); i++ {
-		if pt := points.Item(i); !s.EditScopeHides(pt.Seq()) {
-			out = append(out, pt)
-		}
-	}
-	return out
-}
-
-func activeWorkAxes(s *app.Session) []*feature.WorkAxis {
-	if !s.ObjectVisibility().WorkAxes { // hidden kinds are not pickable (M05-F12)
-		return nil
-	}
-	p, err := modelaccess.ActivePart(s)
-	if err != nil {
-		return nil
-	}
-	axes := p.WorkAxes()
-	out := make([]*feature.WorkAxis, 0, axes.Count())
-	for i := 0; i < axes.Count(); i++ {
-		if ax := axes.Item(i); ax.Visible() && !s.EditScopeHides(ax.Seq()) {
-			out = append(out, ax)
-		}
-	}
-	return out
 }
 
 // activeSketches returns the active part's visible sketches (nil if none), so the picker

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -191,12 +191,11 @@ func clampDim(v float32) int {
 	return int(v)
 }
 
-// activeBodies returns the surface bodies of the active part, or nil.
+// activeBodies returns the bodies the viewport draws for the active document — a part's own bodies
+// or an assembly's placed components (Session.VisibleBodies resolves both, #769). It is nil only
+// when no renderable document is active, so an assembly's components render and cache like a part's
+// (a part-only gate here left the assembly viewport blank).
 func activeBodies(s *app.Session) []*topo.Body {
-	part := activePart(s)
-	if part == nil {
-		return nil
-	}
 	return s.VisibleBodies()
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -377,14 +377,14 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 // modelOverlays appends the 3D-model overlays (work planes, part sketches, selected edges, and
 // the extrude / active-tool previews) to list.
 func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane, list renderer.DrawList) renderer.DrawList {
-	part := activePart(s)
-	hidden := s.EditScopeHides  // hide datums created after the node being edited (issue #132)
-	vis := s.ObjectVisibility() // View ▸ Object visibility (M05-F12): hidden kinds neither draw nor pick
-	if vis.WorkPlanes {
-		list.Items = append(list.Items, planesOverlay(part, s.SelectedWorkPlane(), hovered, hidden)...)
+	wg, hasWG := s.ActiveWorkGeometry() // a part OR an assembly's origin frame + datums (#769 parity)
+	hidden := s.EditScopeHides          // hide datums created after the node being edited (issue #132)
+	vis := s.ObjectVisibility()         // View ▸ Object visibility (M05-F12): hidden kinds neither draw nor pick
+	if hasWG && vis.WorkPlanes {
+		list.Items = append(list.Items, planesOverlay(wg.WorkPlanes(), s.SelectedWorkPlane(), hovered, hidden)...)
 	}
-	if vis.WorkAxes {
-		list.Items = append(list.Items, axesOverlay(part, selectedWorkAxis(s), hidden)...)
+	if hasWG && vis.WorkAxes {
+		list.Items = append(list.Items, axesOverlay(wg.WorkAxes(), selectedWorkAxis(s), hidden)...)
 	}
 	if vis.Sketches {
 		list.Items = append(list.Items, partSketchOverlays(s)...)

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -6,22 +6,21 @@ package ui
 
 import (
 	"oblikovati.org/math"
-	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/renderer"
 )
 
-// planesOverlay draws the part's work planes — the origin frame AND user-created datums —
-// each as a translucent filled square with a solid square border (Inventor's datum-plane
-// look), so a created work plane is visible and can be clicked. Hidden planes (Visibility
-// toggled off) are skipped. The selected plane's border is highlighted; the plane under
-// the cursor uses the hover color. Shown outside the sketch environment.
-func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *feature.WorkPlane, hidden scopeFilter) []renderer.DrawItem {
-	if part == nil {
+// planesOverlay draws a model's work planes — the origin frame AND user-created datums — each as a
+// translucent filled square with a solid square border (the datum-plane look), so a created work
+// plane is visible and can be clicked. Hidden planes (Visibility toggled off) are skipped. The
+// selected plane's border is highlighted; the plane under the cursor uses the hover color. Shown
+// outside the sketch environment. Takes the plane collection (not a part) so it serves a part or an
+// assembly — both expose WorkPlanes() through their work geometry.
+func planesOverlay(planes *feature.WorkPlanes, selected, hovered *feature.WorkPlane, hidden scopeFilter) []renderer.DrawItem {
+	if planes == nil {
 		return nil
 	}
 	var items []renderer.DrawItem
-	planes := part.WorkPlanes()
 	for i := 0; i < planes.Count(); i++ {
 		wp := planes.Item(i)
 		if !wp.Visible() || hidden(wp.Seq()) {
@@ -32,11 +31,10 @@ func planesOverlay(part *compdef.PartComponentDefinition, selected, hovered *fea
 	return items
 }
 
-func axesOverlay(part *compdef.PartComponentDefinition, selected *feature.WorkAxis, hidden scopeFilter) []renderer.DrawItem {
-	if part == nil {
+func axesOverlay(axes *feature.WorkAxes, selected *feature.WorkAxis, hidden scopeFilter) []renderer.DrawItem {
+	if axes == nil {
 		return nil
 	}
-	axes := part.WorkAxes()
 	items := make([]renderer.DrawItem, 0, axes.Count())
 	for i := 0; i < axes.Count(); i++ {
 		axis := axes.Item(i)

--- a/head/ui/plane_overlay_test.go
+++ b/head/ui/plane_overlay_test.go
@@ -1,0 +1,53 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// showAllDatums makes every origin plane and axis visible — the Origin-folder toggle a user flips to
+// see the coordinate frame (they default hidden in a part and an assembly alike).
+func showAllDatums(wg *feature.WorkGeometry) {
+	planes := wg.WorkPlanes()
+	for i := 0; i < planes.Count(); i++ {
+		planes.Item(i).SetVisible(true)
+	}
+	axes := wg.WorkAxes()
+	for i := 0; i < axes.Count(); i++ {
+		axes.Item(i).SetVisible(true)
+	}
+}
+
+// TestAssemblyOriginDatumsDrawWhenShown: the datum overlays draw an ASSEMBLY's origin planes and
+// axes once shown — the viewport sources them through ActiveWorkGeometry, so an assembly gets the
+// origin frame a part has (before, the overlays were part-gated and an assembly drew none).
+func TestAssemblyOriginDatumsDrawWhenShown(t *testing.T) {
+	s := app.NewSession()
+	asmDoc, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(asmDoc); err != nil {
+		t.Fatalf("activate assembly: %v", err)
+	}
+	wg, ok := s.ActiveWorkGeometry()
+	if !ok {
+		t.Fatal("ActiveWorkGeometry returned false for an active assembly")
+	}
+	showAllDatums(wg)
+	noHide := func(uint64) bool { return false }
+
+	if got := len(planesOverlay(wg.WorkPlanes(), nil, nil, noHide)); got == 0 {
+		t.Error("planesOverlay drew nothing for an assembly's visible origin planes")
+	}
+	if got := len(axesOverlay(wg.WorkAxes(), nil, noHide)); got == 0 {
+		t.Error("axesOverlay drew nothing for an assembly's visible origin axes")
+	}
+}

--- a/head/ui/viewport_cache.go
+++ b/head/ui/viewport_cache.go
@@ -49,15 +49,18 @@ func cachedBodyDrawList(s *app.Session, cam scene.Camera) renderer.DrawList {
 	return renderer.DrawList{Items: append([]renderer.DrawItem(nil), bodyGeometryCache.list.Items...)}
 }
 
-// bodyGeometryKey identifies the cached geometry: the part's geometry version (bumped on any
-// geometry/appearance edit and on recompute) + the visual style + the visible body ids.
+// bodyGeometryKey identifies the cached geometry: the active model's geometry version + the visual
+// style + the visible body ids. A part AND an assembly both report a geometry version (bumped on any
+// geometry/appearance edit, recompute, or — for an assembly — occurrence change), so the cache holds
+// for assemblies too; a part-only version here returned "" for an assembly, defeating the cache and
+// re-tessellating every placed body every frame (the unstable-viewport bug when a component is placed).
 func bodyGeometryKey(s *app.Session) string {
-	part := activePart(s)
-	if part == nil {
+	version, ok := activeModelGeometryVersion(s)
+	if !ok {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString(part.ModelGeometryVersion())
+	b.WriteString(version)
 	b.WriteByte('|')
 	b.WriteString(strconv.Itoa(int(s.VisualStyle())))
 	if on, perTri := s.MeshColors(); on { // mesh-debug-colors uses a different builder; key it apart
@@ -72,4 +75,23 @@ func bodyGeometryKey(s *app.Session) string {
 		b.WriteString(strconv.FormatUint(body.ID(), 10))
 	}
 	return b.String()
+}
+
+// modelGeometryVersioned is the active document content that reports a geometry version — a part or
+// an assembly (compdef.PartComponentDefinition / AssemblyComponentDefinition). Matched structurally
+// so the cache keys on either without importing or switching on the concrete type.
+type modelGeometryVersioned interface{ ModelGeometryVersion() string }
+
+// activeModelGeometryVersion returns the active document's geometry version, or false when no
+// renderable model (part or assembly) is active — in which case there is nothing to cache.
+func activeModelGeometryVersion(s *app.Session) (string, bool) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return "", false
+	}
+	m, ok := d.Content().(modelGeometryVersioned)
+	if !ok {
+		return "", false
+	}
+	return m.ModelGeometryVersion(), true
 }

--- a/head/ui/viewport_cache_test.go
+++ b/head/ui/viewport_cache_test.go
@@ -27,14 +27,14 @@ func assemblyWithPlacedBox(t *testing.T) *app.Session {
 	}
 	def := partDoc.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
-	c0 := sk.Points().Add(math.P2(-2, -2))
-	c1 := sk.Points().Add(math.P2(2, -2))
-	c2 := sk.Points().Add(math.P2(2, 2))
-	c3 := sk.Points().Add(math.P2(-2, 2))
-	sk.Lines().Add(c0, c1)
-	sk.Lines().Add(c1, c2)
-	sk.Lines().Add(c2, c3)
-	sk.Lines().Add(c3, c0)
+	corners := []math.Point2{math.P2(-2, -2), math.P2(2, -2), math.P2(2, 2), math.P2(-2, 2)}
+	pts := make([]*sketch.Point, len(corners))
+	for i, c := range corners {
+		pts[i] = sk.Points().Add(c)
+	}
+	for i := range pts {
+		sk.Lines().Add(pts[i], pts[(i+1)%len(pts)]) // close the loop back to the first corner
+	}
 	feature.NewExtrudeFeatures(def.Features()).
 		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
 	def.Recompute()

--- a/head/ui/viewport_cache_test.go
+++ b/head/ui/viewport_cache_test.go
@@ -1,0 +1,104 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// assemblyWithPlacedBox builds a box part and places it into a fresh assembly (assembly active),
+// the fixture for the viewport-cache tests: the head must render AND cache an assembly's placed
+// component geometry, not just a part's.
+func assemblyWithPlacedBox(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	partDoc, err := compdef.AddPart(s.Workspace(), "box.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := partDoc.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(-2, -2))
+	c1 := sk.Points().Add(math.P2(2, -2))
+	c2 := sk.Points().Add(math.P2(2, 2))
+	c3 := sk.Points().Add(math.P2(-2, 2))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+
+	asmDoc, err := compdef.AddAssembly(s.Workspace(), "asm.obk", true)
+	if err != nil {
+		t.Fatalf("AddAssembly: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(asmDoc); err != nil {
+		t.Fatalf("activate assembly: %v", err)
+	}
+	asm := asmDoc.Content().(*compdef.AssemblyComponentDefinition)
+	if _, err := asm.PlaceComponentFromFile(asmDoc, partDoc, "box:1", math.Translation4(math.V3(10, 0, 0))); err != nil {
+		t.Fatalf("place box: %v", err)
+	}
+	return s
+}
+
+// TestActiveBodiesRendersAssemblyComponents: the viewport's body source must surface an assembly's
+// placed components, not just a part's bodies — otherwise a placed component renders nothing
+// (the #769 render gap, regressed in the cached draw path). activeBodies feeds build() in
+// cachedBodyDrawList, so a nil here is a blank assembly viewport.
+func TestActiveBodiesRendersAssemblyComponents(t *testing.T) {
+	s := assemblyWithPlacedBox(t)
+	if got := len(activeBodies(s)); got != 1 {
+		t.Fatalf("activeBodies(assembly) = %d bodies, want 1 placed component (else the assembly viewport is blank)", got)
+	}
+}
+
+// TestBodyGeometryKeyCachesAssemblies: the tessellation cache key must be NON-EMPTY and STABLE for
+// an assembly. An empty key takes cachedBodyDrawList's no-cache branch, which re-tessellates every
+// placed body EVERY frame — the runaway repaint that makes the assembly viewport unstable. The key
+// must also be stable between unedited frames so the cache actually holds (VisibleBodies returns
+// stable body ids, so the key can).
+func TestBodyGeometryKeyCachesAssemblies(t *testing.T) {
+	s := assemblyWithPlacedBox(t)
+	key := bodyGeometryKey(s)
+	if key == "" {
+		t.Fatal("bodyGeometryKey(assembly) = \"\", which disables the cache and re-tessellates every frame")
+	}
+	if again := bodyGeometryKey(s); again != key {
+		t.Errorf("bodyGeometryKey is unstable between frames: %q then %q (the cache would rebuild every frame)", key, again)
+	}
+}
+
+// TestViewportRendersMultipleComponents: several placements — copies of one component plus a
+// second, distinct part — all render, and the cache key reflects every placed body (distinct ids)
+// while staying stable. Guards the multi-component assembly case (each copy is an independent body
+// via its own lineage prefix, so the viewport shows N bodies, not one).
+func TestViewportRendersMultipleComponents(t *testing.T) {
+	s := assemblyWithPlacedBox(t)
+	asm := s.ActiveDocument().Content().(*compdef.AssemblyComponentDefinition)
+	boxDoc := s.Workspace().Documents()[0] // the box part document, placed again as a second copy
+	if _, err := asm.PlaceComponentFromFile(s.ActiveDocument(), boxDoc, "box:2", math.Translation4(math.V3(20, 0, 0))); err != nil {
+		t.Fatalf("place second copy: %v", err)
+	}
+	if got := len(activeBodies(s)); got != 2 {
+		t.Fatalf("activeBodies after a second placement = %d, want 2 independent component bodies", got)
+	}
+	key := bodyGeometryKey(s)
+	if key == "" {
+		t.Fatal("bodyGeometryKey = \"\" with two components placed (cache disabled)")
+	}
+	if again := bodyGeometryKey(s); again != key {
+		t.Errorf("bodyGeometryKey unstable across frames with multiple components: %q then %q", key, again)
+	}
+}

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -208,6 +208,14 @@ func (a *AssemblyComponentDefinition) WorkGeometry() *feature.WorkGeometry { ret
 // surface can resolve "sketch on work plane N" the same way it does for a part.
 func (a *AssemblyComponentDefinition) WorkPlanes() *feature.WorkPlanes { return a.work.WorkPlanes() }
 
+// WorkAxes returns the assembly's datum axes (origin + user), mirroring the part so the work-
+// feature wire surface can author and list them against an assembly.
+func (a *AssemblyComponentDefinition) WorkAxes() *feature.WorkAxes { return a.work.WorkAxes() }
+
+// WorkPoints returns the assembly's datum points (origin + user), mirroring the part so the work-
+// feature wire surface (e.g. workPoints.create) can author them against an assembly.
+func (a *AssemblyComponentDefinition) WorkPoints() *feature.WorkPoints { return a.work.WorkPoints() }
+
 // Sketches returns the assembly's planar sketches — the profile inputs an assembly
 // feature (e.g. an extrude) is authored from, sketched in assembly space.
 func (a *AssemblyComponentDefinition) Sketches() *sketch.Sketches { return a.sketches }


### PR DESCRIPTION
## What & why

Three related fixes that bring an **assembly document's viewport to parity with a part's**. All started from one report: placing a part into an assembly made the 3D viewport unstable (looked like an infinite loop). Investigating that surfaced a cluster of part-only gates in the head/app/router.

### 1. Stable assembly rendering (the reported bug)
The viewport tessellation cache keyed on `activePart`, which is nil for an assembly, so `bodyGeometryKey` returned `""` and `cachedBodyDrawList` rebuilt the full styled draw list (tessellate + smooth-shade + edge-extract) **every frame**. With a component placed, there are bodies to re-tessellate each frame → a pegged CPU core → the unstable viewport. `activeBodies` was likewise part-gated, so an assembly also drew nothing.

Fix: key the cache on the **active model's** geometry version (part or assembly both report one) and source bodies from `VisibleBodies` (already assembly-aware, returns stable body ids across frames so the cache holds).

### 2. Origin frame parity
An assembly already seeds an origin coordinate frame, but every head/app seam that surfaced work geometry was part-gated — no origin axes/planes in the viewport, no Origin folder in the browser. Routed datum rendering, picking, and the browser Origin folder through a new model-agnostic `Session.ActiveWorkGeometry`. Origin datums stay hidden-by-default, matching a part exactly.

### 3. Work-plane authoring in assemblies
`workPlanes.create/list/redefine` and `workPoints.create` resolved the active model via `modelaccess.ActivePart`, rejecting an assembly. Generalized them over a `workHost` interface (`WorkPlanes/WorkPoints/Units/Parameters/Recompute`) satisfied by both definitions; added the assembly's `WorkAxes/WorkPoints` accessors. **No wire change** — the methods already exist; this only broadens the implementation to a new document type.

## Verification
- New tests in `head/ui`, `app`, and `addin/router` pinning each fix (cache key stable/non-empty for assemblies; multi-component placement; origin datums pickable + drawn + in the browser; work-plane/point create/list in an assembly). Full `app` / `model` / `router` / `head/ui` suites green; the part path is unregressed.
- Verified **live on the running head over the MCP bridge**: placing 3 copies of one part + 2 of a distinct part all render; the assembly browser shows an Origin folder; an offset plane and an angled plane created in an assembly are healthy and render in the viewport.
- gofmt clean; `golangci-lint` adds zero new issues.

## Commits (not squashed — granular context)
1. `fix(head)`: cache assembly geometry so placing a part doesn't peg the viewport
2. `feat(assembly)`: surface the origin frame (axes/planes/point) like a part
3. `feat(router)`: author work planes/points in an assembly, not just a part

🤖 Generated with [Claude Code](https://claude.com/claude-code)