### PR TITLE
chore: require oblikovati.org/api v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.0.0
+	oblikovati.org/api v0.1.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.0.0
+	oblikovati.org/api v0.1.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What & why

The Apache-2.0 contract module is now released at **v0.1.0** (semver, auto-tagged from `Oblikovati.API`). This points both modules' `require` at that real tag instead of the `v0.0.0` placeholder:

- root `go.mod` (`oblikovati.org`)
- `head/go.mod` (`oblikovati.org/head`) — it depends on the root via `replace oblikovati.org => ../`, so it must record the same `api` version or MVS reports its go.mod as out of date (this is what the first push tripped: the `head` CI job failed with *"updates to go.mod needed"*).

**No build change.** Module resolution is unchanged in both paths:
- **local dev** uses the gitignored `go.work` (`replace oblikovati.org/api => ../Oblikovati.API`)
- **CI** injects `go mod edit -replace oblikovati.org/api=.../_api` (per module) after checking out the sibling

so the `require` version is overridden either way — a correctness/honesty bump. `go.sum` is unaffected (the module is always a local replace, never downloaded).

## Verification
- Root: `go build ./...` (workspace) and simulated CI (`GOWORK=off` + injected replace) → clean.
- Head: replicated the failing `head` job exactly (`GOWORK=off`, injected api replace, `CGO_ENABLED=1 go build ./...`) → clean after the head/go.mod bump.
- `go.sum` unchanged.

Note: the AddIns MCP bridge module also requires `oblikovati.org/api` and could be bumped similarly in its own repo (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)