### PR TITLE
ci: bump actions to Node 24 majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,13 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -62,7 +62,7 @@ jobs:
             CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -ldflags "$LD" \
               -o "dist/oblikovati-cli-${VER}-${os}-${arch}${ext}" ./cmd/oblikovati-cli
           done
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: cli
           path: dist/*
@@ -73,13 +73,13 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: false
@@ -103,7 +103,7 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN: "1" # GitHub runners have no FUSE
           VER: ${{ inputs.version }}
         run: scripts/package-linux.sh dist/oblikovati-head "$VER" dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: head-linux
           path: dist/*.AppImage
@@ -117,8 +117,8 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
@@ -155,7 +155,7 @@ jobs:
           for dll in $(ldd oblikovati-head.exe | grep -i mingw64 | awk '{print $3}'); do cp "$dll" .; done
           cp /mingw64/bin/glfw3.dll . 2>/dev/null || true
           zip -j "oblikovati-head-${VER}-windows-amd64.zip" oblikovati-head.exe ./*.dll
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: head-windows
           path: dist/*.zip
@@ -204,13 +204,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: false
@@ -227,7 +227,7 @@ jobs:
           CGO_ENABLED=1 go build -ldflags "$LD" -o "$GITHUB_WORKSPACE/dist/oblikovati-head" ./cmd/oblikovati-head
       - name: Stage binary + dylibs
         run: scripts/macos-stage.sh dist/oblikovati-head "stage-${{ matrix.arch }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: head-macos-stage-${{ matrix.arch }}
           path: stage-${{ matrix.arch }}
@@ -242,8 +242,8 @@ jobs:
     if: needs.macos-preflight.outputs.enabled == 'true'
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v7
         with:
           pattern: head-macos-stage-*
           path: stage
@@ -289,7 +289,7 @@ jobs:
           AC_TEAM_ID: ${{ secrets.MACOS_AC_TEAM_ID }}
           VER: ${{ inputs.version }}
         run: scripts/macos-sign.sh dist/Oblikovati.app "$VER" dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: head-macos
           path: dist/*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # The Apache-2.0 contract is a sibling repo now; check it out and point the
       # `api` require at it (the committed go.mod has no replace — local dev uses
       # go.work, CI injects an equivalent replace).
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -39,7 +39,7 @@ jobs:
   docs-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16
         with:
           globs: |
@@ -49,7 +49,7 @@ jobs:
   docs-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: "--offline --no-progress architecture"
@@ -59,7 +59,7 @@ jobs:
   spdx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: python3 scripts/add-spdx-headers.py --check
 
   # Tier 1 — fast, cgo-free unit tests on every OS (architecture/testing/README).
@@ -72,13 +72,13 @@ jobs:
     env:
       CGO_ENABLED: "0"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -86,7 +86,7 @@ jobs:
       - run: go install gotest.tools/gotestsum@v1.12.0
       - name: Test
         run: gotestsum --junitfile test-results-${{ matrix.os }}.xml -- -coverprofile=coverage.out -covermode=count ./...
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results-${{ matrix.os }}
@@ -96,13 +96,13 @@ jobs:
   race:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -122,13 +122,13 @@ jobs:
   head:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           # Match build.yml's head-linux toolchain.
           go-version: "1.24"
@@ -158,13 +158,13 @@ jobs:
       matrix:
         target: [linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
           ref: develop
           path: _api
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       proceed: ${{ steps.check.outputs.proceed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0
@@ -60,11 +60,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
       - name: Assemble artifacts + checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: v
         run: echo "version=$(scripts/version.sh stable)" >> "$GITHUB_OUTPUT"
 
@@ -41,10 +41,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
       - name: Assemble artifacts + checksums


### PR DESCRIPTION
Bumps the GitHub-maintained actions to their first Node 24-based major, clearing the Node 20 deprecation warnings:

- `actions/checkout` v4 → **v5**
- `actions/setup-go` v5 → **v6**
- `actions/upload-artifact` v4 → **v6** (v5 is still Node 20)
- `actions/download-artifact` v4 → **v7** (v5/v6 are still Node 20)

Mechanical version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)