### PR TITLE
feat(addins): enforce API version compatibility at load + surface skips

### DIFF
--- a/addin/router/application.go
+++ b/addin/router/application.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerApplicationHandlers wires the host-application info methods an add-in can
+// query at runtime (the ThisApplication version surface).
+func (r *Router) registerApplicationHandlers() {
+	r.handlers[wire.MethodApplicationApiVersion] = applicationApiVersion
+}
+
+// applicationApiVersion reports the semantic version of the api contract this host
+// implements (wire.MethodApplicationApiVersion). It is sourced from api.Version, the
+// same constant the load-time ObkAddInApiMajor handshake gates on, so the runtime
+// answer can never disagree with the compatibility check.
+func applicationApiVersion(_ *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(wire.ApplicationApiVersionResult{
+		Version: api.Version,
+		Major:   api.Major(),
+		Minor:   api.Minor(),
+	})
+}

--- a/addin/router/application_test.go
+++ b/addin/router/application_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// TestApplicationApiVersionReportsHostContract proves the runtime query returns the
+// host's own api.Version/Major — the same source the load-time handshake gates on, so
+// an add-in can never see a version that disagrees with the compatibility check.
+func TestApplicationApiVersionReportsHostContract(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+
+	var got wire.ApplicationApiVersionResult
+	call(t, r, s, wire.MethodApplicationApiVersion, "{}", &got)
+
+	if got.Version != api.Version {
+		t.Errorf("version = %q, want host api.Version %q", got.Version, api.Version)
+	}
+	if got.Major != api.Major() {
+		t.Errorf("major = %d, want host api.Major() %d", got.Major, api.Major())
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -45,6 +45,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerExchangeHandlers()
 	r.registerFontHandlers()
 	r.registerAddInHandlers()
+	r.registerApplicationHandlers()
 	r.registerUISurfaceHandlers()
 	r.registerOptionHandlers()
 	r.registerMessagingHandlers()

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"oblikovati.org/addin/dispatch"
@@ -68,17 +69,7 @@ func startAddIns(session *app.Session) *addInHost {
 	h.script = newScriptController(rtr, session, d)
 	useBehaviorStore(session)
 	useDialogMemoryStore(session)
-	libs, err := addinhost.LoadDir(dir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "add-ins: %v\n", err)
-	}
-	for _, lib := range libs {
-		if err := registerAndMaybeActivate(session, lib); err != nil {
-			fmt.Fprintf(os.Stderr, "add-in %q: %v\n", lib.ID(), err)
-			continue
-		}
-		h.loaded = append(h.loaded, lib)
-	}
+	h.loadAndRegister(session, dir)
 	h.subs = events.Subscribe(session, func(ev []byte) { h.notifyActive(session, ev) })
 	// Under a supervisor (make run-watch sets OBK_ADDIN_AUTORESTART=1), watch the
 	// add-ins dir so a rebuilt library makes the app exit-and-relaunch — the safe way
@@ -88,6 +79,42 @@ func startAddIns(session *app.Session) *addInHost {
 		go h.watchAddIns()
 	}
 	return h
+}
+
+// loadAndRegister loads every shared-library add-in from dir, surfaces any refused on
+// API-version grounds in the status bar, and registers (and per stored behavior,
+// activates) the loadable ones. A bad add-in is logged and skipped — never fatal.
+func (h *addInHost) loadAndRegister(session *app.Session, dir string) {
+	libs, skipped, err := addinhost.LoadDir(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "add-ins: %v\n", err)
+	}
+	if notice := incompatibleNotice(skipped); notice != "" {
+		session.SetNotice(notice)
+	}
+	for _, lib := range libs {
+		if err := registerAndMaybeActivate(session, lib); err != nil {
+			fmt.Fprintf(os.Stderr, "add-in %q: %v\n", lib.ID(), err)
+			continue
+		}
+		h.loaded = append(h.loaded, lib)
+	}
+}
+
+// incompatibleNotice is the status-bar message for add-ins LoadDir refused on version
+// grounds — so a skipped add-in is never silent. Empty when nothing was skipped.
+func incompatibleNotice(skipped []addinhost.IncompatibleAddIn) string {
+	if len(skipped) == 0 {
+		return ""
+	}
+	if len(skipped) == 1 {
+		return fmt.Sprintf("Add-in %q skipped: incompatible API version (%s)", skipped[0].ID, skipped[0].Reason)
+	}
+	ids := make([]string, len(skipped))
+	for i, s := range skipped {
+		ids[i] = s.ID
+	}
+	return fmt.Sprintf("%d add-ins skipped: incompatible API version (%s)", len(skipped), strings.Join(ids, ", "))
 }
 
 // newScriptController builds the Script Console runtime: a gopher-lua engine whose host

--- a/head/cmd/oblikovati-head/addins_test.go
+++ b/head/cmd/oblikovati-head/addins_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/head/internal/addinhost"
+)
+
+// TestIncompatibleNotice covers the status-bar message for version-skipped add-ins:
+// empty when none were skipped, the id + reason for one, and a count + ids for many.
+func TestIncompatibleNotice(t *testing.T) {
+	if got := incompatibleNotice(nil); got != "" {
+		t.Errorf("no skips: notice = %q, want empty", got)
+	}
+
+	one := []addinhost.IncompatibleAddIn{
+		{ID: "com.x.bridge", Reason: "add-in built against API 1.5, newer than host API 1.4"},
+	}
+	got := incompatibleNotice(one)
+	for _, want := range []string{"com.x.bridge", "incompatible API version", "newer than host API 1.4"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("single skip notice %q missing %q", got, want)
+		}
+	}
+
+	many := []addinhost.IncompatibleAddIn{
+		{ID: "com.x.a", Reason: "r1"},
+		{ID: "com.x.b", Reason: "r2"},
+	}
+	got = incompatibleNotice(many)
+	for _, want := range []string{"2 add-ins skipped", "com.x.a", "com.x.b"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("multi skip notice %q missing %q", got, want)
+		}
+	}
+}

--- a/head/internal/addinhost/dl_unix.go
+++ b/head/internal/addinhost/dl_unix.go
@@ -21,6 +21,7 @@ extern void ObkHostReleaseBuf(uint8_t* p);
 // Function-pointer trampolines: cgo cannot call a Go-held C pointer directly, so we
 // cast each dlsym result to its typedef and invoke it from C.
 typedef const char* (*strFn)(void);
+typedef int  (*intFn)(void);
 typedef int  (*activateFn)(ObkHostCall, ObkHostFree);
 typedef int  (*voidFn)(void);
 typedef int  (*notifyFn)(const uint8_t*, int);
@@ -28,6 +29,7 @@ typedef int  (*automationFn)(const char*, const uint8_t*, int, uint8_t**, int*);
 typedef void (*freeFn)(uint8_t*);
 
 static const char* call_str(void* fn)               { return ((strFn)fn)(); }
+static int  call_int(void* fn)                       { return ((intFn)fn)(); }
 static int  call_activate(void* fn)                  { return ((activateFn)fn)((ObkHostCall)ObkHostDispatch, (ObkHostFree)ObkHostReleaseBuf); }
 static int  call_void(void* fn)                      { return ((voidFn)fn)(); }
 static int  call_notify(void* fn, const uint8_t* ev, int n) { return ((notifyFn)fn)(ev, n); }
@@ -49,6 +51,8 @@ type unixLib struct {
 	handle   unsafe.Pointer
 	idSym    unsafe.Pointer
 	manSym   unsafe.Pointer
+	majorSym unsafe.Pointer
+	minorSym unsafe.Pointer
 	actSym   unsafe.Pointer
 	deactSym unsafe.Pointer
 	notifSym unsafe.Pointer
@@ -87,6 +91,11 @@ func openLibrary(path string) (addInLib, error) {
 	}
 	// Automation is an optional export: absence just means hasAutomation() is false.
 	l.autoSym = resolveOptional(h, "ObkAddInAutomation")
+	// The version exports are resolved leniently so a missing one does not abort the
+	// whole load; the compatibility gate (loader.go) turns their absence into a clear
+	// "cannot verify compatibility" skip rather than a dlsym error.
+	l.majorSym = resolveOptional(h, "ObkAddInApiMajor")
+	l.minorSym = resolveOptional(h, "ObkAddInApiMinor")
 	return l, nil
 }
 
@@ -110,6 +119,16 @@ func resolve(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
 
 func (l *unixLib) id() string       { return C.GoString(C.call_str(l.idSym)) }
 func (l *unixLib) manifest() string { return C.GoString(C.call_str(l.manSym)) }
+
+// apiVersion reports the oblikovati.org/api major/minor the add-in was compiled
+// against (ObkAddInApiMajor/ObkAddInApiMinor). present is false when the add-in omits
+// either export, which the loader's gate treats as incompatible.
+func (l *unixLib) apiVersion() (major, minor int, present bool) {
+	if l.majorSym == nil || l.minorSym == nil {
+		return 0, 0, false
+	}
+	return int(C.call_int(l.majorSym)), int(C.call_int(l.minorSym)), true
+}
 
 func (l *unixLib) activate() error {
 	if rc := C.call_activate(l.actSym); rc != C.int(C.OBK_OK) {

--- a/head/internal/addinhost/gate_test.go
+++ b/head/internal/addinhost/gate_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addinhost
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api"
+)
+
+// fixtureAPIMajor is the api major hardcoded in testdata/*/main.go's ObkAddInApiMajor
+// (they cannot import oblikovati.org/api — testdata is excluded from the module).
+const fixtureAPIMajor = 0
+
+// TestFixturesTrackAPIMajor fails the day the API majors, pointing the maintainer at
+// the hardcoded fixture exports so the loader integration tests don't silently start
+// exercising the incompatible path instead of the happy path.
+func TestFixturesTrackAPIMajor(t *testing.T) {
+	if api.Major() != fixtureAPIMajor {
+		t.Fatalf("api.Major() = %d but testdata fixtures hardcode %d; update ObkAddInApiMajor in "+
+			"testdata/echoaddin & testdata/uiaddin and this constant", api.Major(), fixtureAPIMajor)
+	}
+}
+
+// TestCheckCompatibility covers the load-time gate: a present, matching-major add-in
+// whose minor is not newer than the host loads; a different major, a newer minor, or
+// a missing version export is refused with a message naming both versions.
+func TestCheckCompatibility(t *testing.T) {
+	cases := []struct {
+		name                   string
+		addinMajor, addinMinor int
+		present                bool
+		hostMajor, hostMinor   int
+		wantErr                string // substring; "" means compatible
+	}{
+		{"same version loads", 1, 4, true, 1, 4, ""},
+		{"older minor loads", 1, 2, true, 1, 4, ""},
+		{"zero version loads", 0, 0, true, 0, 1, ""},
+		{"different major refused", 1, 0, true, 2, 0, "API major 1, host is API major 2"},
+		{"newer minor refused", 1, 5, true, 1, 4, "API 1.5, newer than host API 1.4"},
+		{"missing export refused", 0, 0, false, 3, 2, "does not report its API version"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkCompatibility(tc.addinMajor, tc.addinMinor, tc.present, tc.hostMajor, tc.hostMinor)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkCompatibility(%d.%d,%v,%d.%d) = %v, want nil",
+						tc.addinMajor, tc.addinMinor, tc.present, tc.hostMajor, tc.hostMinor, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("checkCompatibility(%d.%d,%v,%d.%d) = %v, want error containing %q",
+					tc.addinMajor, tc.addinMinor, tc.present, tc.hostMajor, tc.hostMinor, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/head/internal/addinhost/include/oblikovati_addin.h
+++ b/head/internal/addinhost/include/oblikovati_addin.h
@@ -54,6 +54,20 @@ typedef void (*ObkHostFree)(uint8_t *p);
  *
  *   ObkAddInId        stable add-in id (e.g. "com.oblikovati.mcp-bridge").
  *   ObkAddInManifest  JSON: {id, displayName, version, capabilities:[...]}.
+ *   ObkAddInApiMajor  the MAJOR version of the oblikovati.org/api contract the add-in
+ *                     was COMPILED against (== api.Major()). The host reads this right
+ *                     after loading the library and BEFORE activating it: if the value
+ *                     differs from the host's own API major, the add-in is incompatible
+ *                     (a major bump is the breaking-change boundary, semver §8) and is
+ *                     NOT loaded.
+ *   ObkAddInApiMinor  the MINOR version the add-in was COMPILED against (== api.Minor()).
+ *                     Within a matching major, the host loads an add-in built against the
+ *                     same or an OLDER minor (minor bumps are additive/backward-compatible,
+ *                     semver §7); an add-in built against a NEWER minor than the host needs
+ *                     API the host lacks and is NOT loaded. An add-in that omits either
+ *                     version export cannot prove compatibility and is likewise not loaded.
+ *                     The full host version is readable at runtime via the
+ *                     "application.apiVersion" host call.
  *   ObkAddInActivate  store the host callbacks and start the add-in (e.g. its MCP
  *                     server). Returns OBK_OK on success.
  *   ObkAddInDeactivate stop the add-in and join its goroutines. Returns OBK_OK.
@@ -70,6 +84,8 @@ typedef void (*ObkHostFree)(uint8_t *p);
 #ifndef OBK_BUILDING_ADDIN
 extern const char *ObkAddInId(void);
 extern const char *ObkAddInManifest(void);
+extern int ObkAddInApiMajor(void);
+extern int ObkAddInApiMinor(void);
 extern int ObkAddInActivate(ObkHostCall call, ObkHostFree freeFn);
 extern int ObkAddInDeactivate(void);
 extern int ObkAddInNotify(const uint8_t *ev, int len);

--- a/head/internal/addinhost/loader.go
+++ b/head/internal/addinhost/loader.go
@@ -4,10 +4,12 @@ package addinhost
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"oblikovati.org/api"
 	"oblikovati.org/app"
 )
 
@@ -16,6 +18,7 @@ import (
 type addInLib interface {
 	id() string
 	manifest() string
+	apiVersion() (major, minor int, present bool)
 	activate() error
 	deactivate() error
 	notify(b []byte) error
@@ -65,31 +68,91 @@ func (a *LoadedAddIn) CallAutomation(method string, args []byte) ([]byte, error)
 // Close unloads the shared library (dlclose/FreeLibrary).
 func (a *LoadedAddIn) Close() error { return a.lib.close() }
 
-// LoadDir opens every shared-library add-in in dir and returns wrappers ready to
-// register with session.AddIns(). A missing dir means "no add-ins installed" and
-// yields (nil, nil). On the first failed load it returns what loaded so far plus
-// the error, so the caller can decide whether a bad add-in is fatal.
-func LoadDir(dir string) ([]*LoadedAddIn, error) {
+// IncompatibleAddIn records an add-in [LoadDir] refused to load because its
+// compiled-against api version is incompatible with the host (a different major, or a
+// minor newer than the host's). The caller surfaces Reason to the user (status bar).
+type IncompatibleAddIn struct {
+	ID     string // the add-in's id (best effort; its ObkAddInId still resolves)
+	Path   string // the shared-library file
+	Reason string // why it was refused, naming both versions
+}
+
+// LoadDir opens every shared-library add-in in dir and returns the loadable ones
+// (ready to register with session.AddIns()) plus any it refused on version grounds.
+// A missing dir means "no add-ins installed" and yields (nil, nil, nil). On the first
+// hard load failure it returns what loaded so far plus the error, so the caller can
+// decide whether a bad add-in is fatal; a version-incompatible add-in is NOT a hard
+// failure — it is skipped, logged, and reported in the second return value.
+func LoadDir(dir string) ([]*LoadedAddIn, []IncompatibleAddIn, error) {
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("addinhost: read add-in dir %q: %w", dir, err)
+		return nil, nil, fmt.Errorf("addinhost: read add-in dir %q: %w", dir, err)
 	}
 	var out []*LoadedAddIn
+	var skipped []IncompatibleAddIn
 	for _, e := range entries {
 		if e.IsDir() || !isSharedLib(e.Name()) {
 			continue
 		}
-		path := filepath.Join(dir, e.Name())
-		l, err := openLibrary(path)
-		if err != nil {
-			return out, err
+		loaded, skip, err := loadOne(filepath.Join(dir, e.Name()))
+		switch {
+		case err != nil:
+			return out, skipped, err
+		case skip != nil:
+			skipped = append(skipped, *skip)
+		default:
+			out = append(out, loaded)
 		}
-		out = append(out, &LoadedAddIn{lib: l, id: l.id(), path: path})
 	}
-	return out, nil
+	return out, skipped, nil
+}
+
+// loadOne opens one shared library and either returns a loadable add-in or, when its
+// api version is incompatible, a skip record naming why (the library is closed). A
+// hard open failure is returned as an error the caller may treat as fatal.
+func loadOne(path string) (*LoadedAddIn, *IncompatibleAddIn, error) {
+	l, err := openLibrary(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if reason := compatibilityError(l); reason != nil {
+		// Read the id before close: dlclose unmaps the library, so calling any
+		// resolved export afterwards is use-after-unmap.
+		id := l.id()
+		slog.Warn("addinhost: not loading incompatible add-in", "id", id, "path", path, "reason", reason.Error())
+		_ = l.close()
+		return nil, &IncompatibleAddIn{ID: id, Path: path, Reason: reason.Error()}, nil
+	}
+	return &LoadedAddIn{lib: l, id: l.id(), path: path}, nil, nil
+}
+
+// compatibilityError refuses an add-in whose compiled-against api version is
+// incompatible with this host's (ObkAddInApiMajor/ObkAddInApiMinor, see
+// include/oblikovati_addin.h); nil means compatible.
+func compatibilityError(l addInLib) error {
+	major, minor, present := l.apiVersion()
+	return checkCompatibility(major, minor, present, api.Major(), api.Minor())
+}
+
+// checkCompatibility is the pure version comparison behind compatibilityError, split
+// out so it is unit testable without building a real c-shared add-in. The rule: a
+// missing version export cannot be verified (refused); a different major is breaking
+// (refused); a minor NEWER than the host needs API the host lacks (refused). An
+// older-or-equal minor is fine — minor bumps are additive/backward-compatible.
+func checkCompatibility(addinMajor, addinMinor int, present bool, hostMajor, hostMinor int) error {
+	if !present {
+		return fmt.Errorf("add-in does not report its API version (no ObkAddInApiMajor/Minor); cannot verify compatibility with host API %d.%d", hostMajor, hostMinor)
+	}
+	if addinMajor != hostMajor {
+		return fmt.Errorf("add-in built against API major %d, host is API major %d", addinMajor, hostMajor)
+	}
+	if addinMinor > hostMinor {
+		return fmt.Errorf("add-in built against API %d.%d, newer than host API %d.%d", addinMajor, addinMinor, hostMajor, hostMinor)
+	}
+	return nil
 }
 
 // Open loads a single shared-library add-in from path and wraps it for
@@ -99,6 +162,10 @@ func Open(path string) (*LoadedAddIn, error) {
 	l, err := openLibrary(path)
 	if err != nil {
 		return nil, err
+	}
+	if reason := compatibilityError(l); reason != nil {
+		_ = l.close()
+		return nil, fmt.Errorf("addinhost: %s: %w", path, reason)
 	}
 	return &LoadedAddIn{lib: l, id: l.id(), path: path}, nil
 }

--- a/head/internal/addinhost/loader_test.go
+++ b/head/internal/addinhost/loader_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,7 +57,7 @@ func TestLoadDirRoundTripsHostCall(t *testing.T) {
 		return req, nil
 	}, 2*time.Second)
 
-	libs, err := LoadDir(dir)
+	libs, _, err := LoadDir(dir)
 	if err != nil {
 		t.Fatalf("LoadDir: %v", err)
 	}
@@ -92,13 +93,55 @@ func TestLoadDirRoundTripsHostCall(t *testing.T) {
 	}
 }
 
+// TestLoadDirSkipsIncompatibleAddIn proves the load-time gate end to end: a real
+// c-shared add-in reporting a mismatched ObkAddInApiMajor is left unloaded while a
+// compatible one in the same directory still loads.
+func TestLoadDirSkipsIncompatibleAddIn(t *testing.T) {
+	dir := t.TempDir()
+	placeFixture(t, "echoaddin", dir)
+	placeFixture(t, "incompataddin", dir)
+
+	libs, skipped, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(libs) != 1 {
+		t.Fatalf("loaded %d add-ins, want 1 (the incompatible one must be skipped)", len(libs))
+	}
+	if got := libs[0].ID(); got != "com.oblikovati.echo-fixture" {
+		t.Fatalf("loaded %q, want the compatible com.oblikovati.echo-fixture", got)
+	}
+	defer func() { _ = libs[0].Close() }()
+
+	if len(skipped) != 1 {
+		t.Fatalf("skipped %d add-ins, want 1 (reported for the status bar)", len(skipped))
+	}
+	if skipped[0].ID != "com.oblikovati.incompat-fixture" {
+		t.Errorf("skipped ID = %q, want com.oblikovati.incompat-fixture", skipped[0].ID)
+	}
+	if !strings.Contains(skipped[0].Reason, "API major") {
+		t.Errorf("skipped reason = %q, want it to name the API major mismatch", skipped[0].Reason)
+	}
+}
+
+// placeFixture builds a fixture and moves the library into dir, so several fixtures
+// can share one add-ins directory (buildFixture isolates each in its own temp dir).
+func placeFixture(t *testing.T, dirName, dir string) {
+	t.Helper()
+	so := buildFixture(t, dirName)
+	dst := filepath.Join(dir, filepath.Base(so))
+	if err := os.Rename(so, dst); err != nil {
+		t.Fatalf("place fixture %q: %v", dirName, err)
+	}
+}
+
 // TestLoadDirMissingDir treats an absent add-in folder as "none installed".
 func TestLoadDirMissingDir(t *testing.T) {
-	libs, err := LoadDir(filepath.Join(t.TempDir(), "does-not-exist"))
+	libs, skipped, err := LoadDir(filepath.Join(t.TempDir(), "does-not-exist"))
 	if err != nil {
 		t.Fatalf("LoadDir(missing) err = %v, want nil", err)
 	}
-	if libs != nil {
-		t.Fatalf("LoadDir(missing) = %v, want nil", libs)
+	if libs != nil || skipped != nil {
+		t.Fatalf("LoadDir(missing) = (%v, %v), want (nil, nil)", libs, skipped)
 	}
 }

--- a/head/internal/addinhost/testdata/echoaddin/main.go
+++ b/head/internal/addinhost/testdata/echoaddin/main.go
@@ -33,6 +33,18 @@ func ObkAddInId() *C.char { return idStr }
 //export ObkAddInManifest
 func ObkAddInManifest() *C.char { return manStr }
 
+// ObkAddInApiMajor/ObkAddInApiMinor report the api version this fixture is "built
+// against". testdata dirs are excluded from the module, so the fixture cannot import
+// oblikovati.org/api; the major is hardcoded and pinned to api.Major() by
+// TestFixturesTrackAPIMajor. Minor 0 is always <= any host minor, so it stays
+// loadable as the host's minor advances.
+//
+//export ObkAddInApiMajor
+func ObkAddInApiMajor() C.int { return 0 }
+
+//export ObkAddInApiMinor
+func ObkAddInApiMinor() C.int { return 0 }
+
 //export ObkAddInActivate
 func ObkAddInActivate(call C.HostCall, free C.HostFree) C.int {
 	method := C.CString("echo")

--- a/head/internal/addinhost/testdata/incompataddin/main.go
+++ b/head/internal/addinhost/testdata/incompataddin/main.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// incompatfixture is a minimal c-shared add-in whose ObkAddInApiMajor reports a major
+// (99) deliberately different from any real host's, so the loader's compatibility gate
+// must refuse to load it. It implements just enough of the C ABI to be a loadable
+// library; it is never activated.
+package main
+
+/*
+#include <stdlib.h>
+#include <stdint.h>
+
+#define OBK_OK 0
+
+typedef int  (*HostCall)(const char* method, const uint8_t* req, int reqLen, uint8_t** resp, int* respLen);
+typedef void (*HostFree)(uint8_t* p);
+*/
+import "C"
+
+var (
+	idStr  = C.CString("com.oblikovati.incompat-fixture")
+	manStr = C.CString(`{"id":"com.oblikovati.incompat-fixture","displayName":"Incompat Fixture","version":"0.0.0"}`)
+)
+
+//export ObkAddInId
+func ObkAddInId() *C.char { return idStr }
+
+//export ObkAddInManifest
+func ObkAddInManifest() *C.char { return manStr }
+
+// ObkAddInApiMajor reports an impossible major so the host's gate refuses the add-in;
+// ObkAddInApiMinor is present (both version exports required) but irrelevant here.
+//
+//export ObkAddInApiMajor
+func ObkAddInApiMajor() C.int { return 99 }
+
+//export ObkAddInApiMinor
+func ObkAddInApiMinor() C.int { return 0 }
+
+//export ObkAddInActivate
+func ObkAddInActivate(call C.HostCall, free C.HostFree) C.int { return C.OBK_OK }
+
+//export ObkAddInDeactivate
+func ObkAddInDeactivate() C.int { return C.OBK_OK }
+
+//export ObkAddInNotify
+func ObkAddInNotify(ev *C.uint8_t, n C.int) C.int { return C.OBK_OK }
+
+//export ObkFree
+func ObkFree(p *C.uint8_t) {}
+
+func main() {}

--- a/head/internal/addinhost/testdata/uiaddin/main.go
+++ b/head/internal/addinhost/testdata/uiaddin/main.go
@@ -51,6 +51,17 @@ func ObkAddInId() *C.char { return idStr }
 //export ObkAddInManifest
 func ObkAddInManifest() *C.char { return manStr }
 
+// ObkAddInApiMajor/ObkAddInApiMinor report the api version this fixture is "built
+// against" — hardcoded because testdata dirs are excluded from the module (cannot
+// import oblikovati.org/api). The major is pinned to api.Major() by
+// TestFixturesTrackAPIMajor; minor 0 stays <= any host minor.
+//
+//export ObkAddInApiMajor
+func ObkAddInApiMajor() C.int { return 0 }
+
+//export ObkAddInApiMinor
+func ObkAddInApiMinor() C.int { return 0 }
+
 //export ObkAddInActivate
 func ObkAddInActivate(call C.HostCall, free C.HostFree) C.int {
 	mu.Lock()

--- a/head/internal/addinhost/uiaddin_test.go
+++ b/head/internal/addinhost/uiaddin_test.go
@@ -47,7 +47,7 @@ func TestAddInExtendsRibbonAndActsOnClick(t *testing.T) {
 		return rtr.Handle(s, method, req)
 	}, 2*time.Second)
 
-	libs, err := LoadDir(filepath.Dir(so))
+	libs, _, err := LoadDir(filepath.Dir(so))
 	if err != nil || len(libs) != 1 {
 		t.Fatalf("LoadDir: libs=%d err=%v", len(libs), err)
 	}


### PR DESCRIPTION
## What & why

Host side of the add-in/host API version handshake (contract: Oblikovati.API#99 — **merge that first**).

- The loader reads each add-in's `ObkAddInApiMajor`/`ObkAddInApiMinor` right after `dlopen` and **before** activation. It refuses an add-in whose API **major differs**, whose **minor is newer** than the host's (older/equal is fine — minor bumps are additive), or that omits the version exports. Gated on `api.Major()`/`api.Minor()`.
- `LoadDir` now reports the refused add-ins (id + reason); `startAddIns` shows a **status-bar notice** naming the skipped add-in(s) and why, so an incompatible add-in is never silently absent.
- Serves `application.apiVersion` from the router (`version` + `major` + `minor`) for runtime queries.

## Tests
- Pure compatibility table: major mismatch / newer minor / missing export / older-minor-OK.
- **End-to-end:** `LoadDir` skips a real incompatible c-shared fixture (reports the skip) while a compatible one loads.
- Router version query; status-bar message builder; drift guard pinning testdata fixtures' major to `api.Major()`.
- C ABI header re-vendored from the api source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)