### PR TITLE
feat(keymap): command alias & keyboard-shortcut customization (M05-F17, closes #831)

### DIFF
--- a/addin/router/keymap.go
+++ b/addin/router/keymap.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/app/keymap"
+)
+
+// registerKeymapHandlers wires command alias & keyboard-shortcut customization (M05-F17,
+// #831): list the catalog, rebind a shortcut, set an alias, reset one/all, import/export.
+func (r *Router) registerKeymapHandlers() {
+	r.handlers[wire.MethodKeymapList] = listKeymap
+	r.handlers[wire.MethodKeymapSetChord] = setKeymapChord
+	r.handlers[wire.MethodKeymapSetAlias] = setKeymapAlias
+	r.handlers[wire.MethodKeymapReset] = resetKeymapBinding
+	r.handlers[wire.MethodKeymapResetAll] = resetKeymapAll
+	r.handlers[wire.MethodKeymapExport] = exportKeymap
+	r.handlers[wire.MethodKeymapImport] = importKeymap
+}
+
+// listKeymap returns the full binding catalog (wire keymap.list).
+func listKeymap(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	cat := s.Bindings().Catalog()
+	out := make([]wire.BindingInfo, len(cat))
+	for i, b := range cat {
+		out[i] = wire.BindingInfo{
+			ActionID: b.ActionID, DisplayName: b.DisplayName, Kind: b.Kind,
+			Chord: b.Chord.String(), DefaultChord: b.DefaultChord.String(),
+			Alias: b.Alias, Customized: b.Customized,
+		}
+	}
+	return json.Marshal(wire.ListBindingsResult{Bindings: out})
+}
+
+// setKeymapChord rebinds one action's shortcut (wire keymap.setChord).
+func setKeymapChord(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetChordArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	chord, err := types.ParseChord(req.Chord)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.Bindings().SetChord(req.ActionID, chord); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// setKeymapAlias sets one action's typed alias (wire keymap.setAlias).
+func setKeymapAlias(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetAliasArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.Bindings().SetAlias(req.ActionID, req.Alias); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// resetKeymapBinding restores one action to its defaults (wire keymap.reset).
+func resetKeymapBinding(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.ResetBindingArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.Bindings().Reset(req.ActionID); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// resetKeymapAll discards every customization (wire keymap.resetAll).
+func resetKeymapAll(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	if err := s.Bindings().ResetAll(); err != nil {
+		return nil, err
+	}
+	return ok()
+}
+
+// exportKeymap returns the user's customization delta (wire keymap.export).
+func exportKeymap(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	c := s.Bindings().Export()
+	return json.Marshal(wire.KeymapExport{Chords: c.Chords, Aliases: c.Aliases})
+}
+
+// importKeymap replaces the customization with the imported delta (wire keymap.import).
+func importKeymap(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.KeymapExport
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	if err := s.Bindings().Import(keymap.Customization{Chords: req.Chords, Aliases: req.Aliases}); err != nil {
+		return nil, err
+	}
+	return ok()
+}

--- a/addin/router/keymap_test.go
+++ b/addin/router/keymap_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// addKeymapCommand registers a command so the catalog has a known command row.
+func addKeymapCommand(t *testing.T, s *app.Session, id, alias string) {
+	t.Helper()
+	cmd := app.NewCommand(id, id, "Test", func(*app.Session) error { return nil })
+	if alias != "" {
+		cmd = cmd.WithAlias(alias)
+	}
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("register %q: %v", id, err)
+	}
+}
+
+func TestKeymapListServesCatalog(t *testing.T) {
+	r, s := seededSession(t)
+	addKeymapCommand(t, s, "Test.Probe", "G")
+
+	var res wire.ListBindingsResult
+	call(t, r, s, "keymap.list", "{}", &res)
+
+	var extrude *wire.BindingInfo
+	var undo *wire.BindingInfo
+	for i := range res.Bindings {
+		switch res.Bindings[i].ActionID {
+		case "Test.Probe":
+			extrude = &res.Bindings[i]
+		case app.ActionUndo:
+			undo = &res.Bindings[i]
+		}
+	}
+	if extrude == nil || extrude.Chord != "G" || extrude.Kind != "command" {
+		t.Fatalf("Extrude row = %+v, want chord G / kind command", extrude)
+	}
+	if undo == nil || undo.Chord != "Ctrl+Z" || undo.Kind != "builtin" {
+		t.Fatalf("Undo row = %+v, want chord Ctrl+Z / kind builtin", undo)
+	}
+}
+
+func TestKeymapSetChordOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	addKeymapCommand(t, s, "Test.Probe", "G")
+
+	call(t, r, s, "keymap.setChord", `{"actionId":"Test.Probe","chord":"Ctrl+Shift+G"}`, nil)
+	if c, ok := s.Bindings().EffectiveChord("Test.Probe"); !ok || c.String() != "Ctrl+Shift+G" {
+		t.Fatalf("effective chord = (%q, %v), want Ctrl+Shift+E", c.String(), ok)
+	}
+}
+
+func TestKeymapSetChordConflictErrorsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	addKeymapCommand(t, s, "Test.Probe", "G")
+
+	if _, err := r.Handle(s, "keymap.setChord", []byte(`{"actionId":"Test.Probe","chord":"Ctrl+Z"}`)); err == nil {
+		t.Error("rebinding to Ctrl+Z (undo) should fail over the wire")
+	}
+}
+
+func TestKeymapResetOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	addKeymapCommand(t, s, "Test.Probe", "G")
+	call(t, r, s, "keymap.setChord", `{"actionId":"Test.Probe","chord":"Ctrl+Shift+G"}`, nil)
+
+	call(t, r, s, "keymap.reset", `{"actionId":"Test.Probe"}`, nil)
+	if c, ok := s.Bindings().EffectiveChord("Test.Probe"); !ok || c.String() != "G" {
+		t.Fatalf("after reset, chord = (%q, %v), want default G", c.String(), ok)
+	}
+}
+
+func TestKeymapExportImportRoundTripOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	addKeymapCommand(t, s, "Test.Probe", "G")
+	call(t, r, s, "keymap.setAlias", `{"actionId":"Test.Probe","alias":"EXT"}`, nil)
+
+	var exp wire.KeymapExport
+	call(t, r, s, "keymap.export", "{}", &exp)
+	if exp.Aliases["Test.Probe"] != "EXT" {
+		t.Fatalf("export = %+v, want the EXT alias", exp)
+	}
+
+	call(t, r, s, "keymap.resetAll", "{}", nil)
+	if s.Bindings().EffectiveAlias("Test.Probe") != "" {
+		t.Fatal("resetAll should have cleared the alias")
+	}
+
+	call(t, r, s, "keymap.import", `{"aliases":{"Test.Probe":"EXT"}}`, nil)
+	if s.Bindings().EffectiveAlias("Test.Probe") != "EXT" {
+		t.Error("import should restore the alias")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -47,6 +47,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAddInHandlers()
 	r.registerUISurfaceHandlers()
 	r.registerOptionHandlers()
+	r.registerKeymapHandlers()
 	r.registerMessagingHandlers()
 	r.registerMiniToolbarHandlers()
 	r.registerDialogHandlers()

--- a/app/bindings.go
+++ b/app/bindings.go
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app/keymap"
+)
+
+// The binding engine (M05-F17, #831). Every keyboard shortcut and typed command alias
+// resolves through here. A bindable target is identified by a flat action id: a
+// registered command id verbatim, or one of the reserved built-in ids below (session
+// actions — undo/redo/cancel/commit/visibility — that are not registry commands). The
+// hardcoded shortcuts of session_input.go migrate into the built-in table, so they are
+// rebindable like any command. Defaults are derived live from the command registry
+// (a command's WithAlias letter is its default chord) plus the built-in table; only the
+// user's deltas are stored (keymap.Customization).
+
+// Reserved built-in action ids — session actions that are not registry commands.
+const (
+	ActionUndo             = "edit.undo"
+	ActionRedo             = "edit.redo"
+	ActionCancel           = "tool.cancel"
+	ActionCommit           = "tool.commit"
+	ActionToggleVisibility = "workplane.toggleVisibility"
+)
+
+const (
+	bindingKindCommand = "command"
+	bindingKindBuiltin = "builtin"
+)
+
+// builtinAction is a bindable session action that is not a registered command. Its
+// dispatch closes over no state; it receives the Session at call time, and its guard
+// lives inside the dispatch so the pre-existing semantics are preserved exactly.
+type builtinAction struct {
+	id           string
+	displayName  string
+	defaultChord types.KeyChord
+	extraChords  []types.KeyChord // extra default chords that also resolve here (redo's Ctrl+Shift+Z)
+	dispatch     func(*Session) error
+}
+
+// builtinActions is the fixed table of session actions migrated out of PressKey.
+func builtinActions() []builtinAction {
+	return []builtinAction{
+		{id: ActionUndo, displayName: "Undo", defaultChord: mustChord("Ctrl+Z"), dispatch: dispatchUndo},
+		{id: ActionRedo, displayName: "Redo", defaultChord: mustChord("Ctrl+Y"),
+			extraChords: []types.KeyChord{mustChord("Ctrl+Shift+Z")}, dispatch: dispatchRedo},
+		{id: ActionCancel, displayName: "Cancel / Deselect", defaultChord: mustChord("Escape"), dispatch: dispatchCancel},
+		{id: ActionCommit, displayName: "Finish Command", defaultChord: mustChord("Enter"), dispatch: dispatchCommit},
+		{id: ActionToggleVisibility, displayName: "Toggle Visibility", defaultChord: mustChord("V"), dispatch: dispatchToggleVisibility},
+	}
+}
+
+// dispatchUndo runs undo only when no interactive tool is mid-operation — undo is
+// forbidden while a transaction is in progress, so the keystroke is a no-op otherwise.
+func dispatchUndo(s *Session) error {
+	if s.tool != nil {
+		return nil
+	}
+	return s.Undo()
+}
+
+func dispatchRedo(s *Session) error {
+	if s.tool != nil {
+		return nil
+	}
+	return s.Redo()
+}
+
+// dispatchCancel cancels the active tool, or with no tool clears the selection.
+func dispatchCancel(s *Session) error {
+	if s.tool != nil {
+		s.CancelTool()
+		return nil
+	}
+	s.Select(nil)
+	return nil
+}
+
+// dispatchCommit finishes the active tool; a no-op with no tool.
+func dispatchCommit(s *Session) error {
+	if s.tool != nil {
+		return s.OK()
+	}
+	return nil
+}
+
+func dispatchToggleVisibility(s *Session) error {
+	s.ToggleSelectedWorkPlaneVisibility()
+	return nil
+}
+
+// mustChord parses a constant chord literal from the built-in table, panicking on a
+// malformed one (a programming error, never reachable with the valid literals above).
+func mustChord(s string) types.KeyChord {
+	c, err := types.ParseChord(s)
+	if err != nil {
+		panic(fmt.Sprintf("app: invalid built-in chord literal %q: %v", s, err))
+	}
+	return c
+}
+
+// Bindings is the live resolver: the command registry, the built-in action table, and
+// the user's customization overlay, with the store to persist edits.
+type Bindings struct {
+	cmds     *CommandManager
+	builtins []builtinAction
+	custom   keymap.Customization
+	store    keymap.Store // nil ⇒ in-session only
+}
+
+// newBindings builds the engine over a command registry, with no customization yet.
+func newBindings(cmds *CommandManager) *Bindings {
+	return &Bindings{cmds: cmds, builtins: builtinActions(), custom: keymap.Defaults()}
+}
+
+// Bindings returns the session's binding engine, constructing it on first use over the
+// command registry. Lazy so the constructor stays small and commands registered after
+// NewSession are still seen (the engine reads the registry live).
+func (s *Session) Bindings() *Bindings {
+	if s.bindings == nil {
+		s.bindings = newBindings(s.commands)
+	}
+	return s.bindings
+}
+
+// bindable is the merged view of one action (command or built-in) the engine iterates.
+type bindable struct {
+	id           string
+	displayName  string
+	kind         string
+	defaultChord types.KeyChord
+	extraChords  []types.KeyChord
+}
+
+// bindables returns every bindable action: commands first (registration order), then
+// the built-ins. A command's default chord is its WithAlias letter (empty ⇒ unbound).
+func (b *Bindings) bindables() []bindable {
+	out := make([]bindable, 0, len(b.cmds.defs)+len(b.builtins))
+	for _, c := range b.cmds.All() {
+		dc, _ := types.ParseChord(c.Alias()) // single-letter alias; empty ⇒ unbound zero chord
+		out = append(out, bindable{id: c.ID(), displayName: c.DisplayName(), kind: bindingKindCommand, defaultChord: dc})
+	}
+	for _, ba := range b.builtins {
+		out = append(out, bindable{
+			id: ba.id, displayName: ba.displayName, kind: bindingKindBuiltin,
+			defaultChord: ba.defaultChord, extraChords: ba.extraChords,
+		})
+	}
+	return out
+}
+
+// findBindable locates one action by id.
+func (b *Bindings) findBindable(actionID string) (bindable, bool) {
+	for _, bd := range b.bindables() {
+		if bd.id == actionID {
+			return bd, true
+		}
+	}
+	return bindable{}, false
+}
+
+// EffectiveChord returns an action's current shortcut: the user override if present
+// (an empty override means explicitly unbound), else the derived default.
+func (b *Bindings) EffectiveChord(actionID string) (types.KeyChord, bool) {
+	if raw, ok := b.custom.Chords[actionID]; ok {
+		c, err := types.ParseChord(raw)
+		if err != nil || c.IsZero() {
+			return types.KeyChord{}, false
+		}
+		return c, true
+	}
+	bd, ok := b.findBindable(actionID)
+	if !ok || bd.defaultChord.IsZero() {
+		return types.KeyChord{}, false
+	}
+	return bd.defaultChord, true
+}
+
+// EffectiveAlias returns an action's typed command alias ("" if none). Aliases are
+// purely user-defined; there is no predefined alias.
+func (b *Bindings) EffectiveAlias(actionID string) string { return b.custom.Aliases[actionID] }
+
+// ResolveChord maps a pressed chord to the action it triggers. Effective bindings win;
+// an action's extra default chords resolve only while it keeps its default (not
+// overridden), preserving e.g. Ctrl+Shift+Z → redo.
+func (b *Bindings) ResolveChord(c types.KeyChord) (string, bool) {
+	if c.IsZero() {
+		return "", false
+	}
+	target := c.String()
+	for _, bd := range b.bindables() {
+		if ec, ok := b.EffectiveChord(bd.id); ok && ec.String() == target {
+			return bd.id, true
+		}
+	}
+	for _, bd := range b.bindables() {
+		if _, overridden := b.custom.Chords[bd.id]; overridden {
+			continue
+		}
+		for _, extra := range bd.extraChords {
+			if extra.String() == target {
+				return bd.id, true
+			}
+		}
+	}
+	return "", false
+}
+
+// ResolveAlias maps a typed alias (case-insensitive) to its action.
+func (b *Bindings) ResolveAlias(alias string) (string, bool) {
+	if alias == "" {
+		return "", false
+	}
+	for id, a := range b.custom.Aliases {
+		if strings.EqualFold(a, alias) {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// Dispatch runs an action by id: a built-in via its guarded session handler, else the
+// registered command via Session.Execute.
+func (b *Bindings) Dispatch(actionID string, s *Session) error {
+	for _, ba := range b.builtins {
+		if ba.id == actionID {
+			return ba.dispatch(s)
+		}
+	}
+	return s.Execute(actionID)
+}
+
+// SetChord rebinds an action's shortcut, rejecting a chord already bound elsewhere. A
+// zero chord clears the binding. Persists when a store is wired.
+func (b *Bindings) SetChord(actionID string, c types.KeyChord) error {
+	if _, ok := b.findBindable(actionID); !ok {
+		return fmt.Errorf("app: unknown action %q for SetChord; expected a command or built-in action id", actionID)
+	}
+	if !c.IsZero() {
+		if owner, ok := b.ResolveChord(c); ok && owner != actionID {
+			return fmt.Errorf("app: chord %q already bound to %q (%s)", c.String(), owner, b.displayName(owner))
+		}
+	}
+	if b.custom.Chords == nil {
+		b.custom.Chords = map[string]string{}
+	}
+	b.custom.Chords[actionID] = c.String()
+	return b.persist()
+}
+
+// SetAlias sets an action's typed alias, rejecting one already bound elsewhere. An
+// empty alias clears it.
+func (b *Bindings) SetAlias(actionID, alias string) error {
+	if _, ok := b.findBindable(actionID); !ok {
+		return fmt.Errorf("app: unknown action %q for SetAlias; expected a command or built-in action id", actionID)
+	}
+	if alias != "" {
+		if owner, ok := b.ResolveAlias(alias); ok && owner != actionID {
+			return fmt.Errorf("app: alias %q already bound to %q (%s)", alias, owner, b.displayName(owner))
+		}
+	}
+	if alias == "" {
+		delete(b.custom.Aliases, actionID)
+		return b.persist()
+	}
+	if b.custom.Aliases == nil {
+		b.custom.Aliases = map[string]string{}
+	}
+	b.custom.Aliases[actionID] = alias
+	return b.persist()
+}
+
+// Reset restores one action's shortcut and alias to their defaults.
+func (b *Bindings) Reset(actionID string) error {
+	delete(b.custom.Chords, actionID)
+	delete(b.custom.Aliases, actionID)
+	return b.persist()
+}
+
+// ResetAll discards every customization.
+func (b *Bindings) ResetAll() error {
+	b.custom = keymap.Defaults()
+	return b.persist()
+}
+
+// Export returns a copy of the user's customization delta (for keymap.export).
+func (b *Bindings) Export() keymap.Customization { return b.custom.Clone() }
+
+// Import replaces the customization with the given delta and persists it.
+func (b *Bindings) Import(c keymap.Customization) error {
+	b.custom = c.Clone()
+	return b.persist()
+}
+
+// Binding is one catalog row: an action with its effective and default shortcut, its
+// alias, and whether the user has customized it.
+type Binding struct {
+	ActionID     string
+	DisplayName  string
+	Kind         string
+	Chord        types.KeyChord
+	DefaultChord types.KeyChord
+	Alias        string
+	Customized   bool
+}
+
+// Catalog returns every bindable action with its effective + default binding, in a
+// stable display order (commands first, then built-ins).
+func (b *Bindings) Catalog() []Binding {
+	bindables := b.bindables()
+	out := make([]Binding, 0, len(bindables))
+	for _, bd := range bindables {
+		eff, _ := b.EffectiveChord(bd.id)
+		_, chordCustom := b.custom.Chords[bd.id]
+		_, aliasCustom := b.custom.Aliases[bd.id]
+		out = append(out, Binding{
+			ActionID: bd.id, DisplayName: bd.displayName, Kind: bd.kind,
+			Chord: eff, DefaultChord: bd.defaultChord, Alias: b.EffectiveAlias(bd.id),
+			Customized: chordCustom || aliasCustom,
+		})
+	}
+	return out
+}
+
+// CheckDefaults verifies the out-of-the-box bindings are self-consistent: no command id
+// reuses a reserved built-in id, and no two actions share a default chord. It is a
+// developer-error guard — call it after registering the standard commands.
+func (b *Bindings) CheckDefaults() error {
+	builtinID := map[string]bool{}
+	for _, ba := range b.builtins {
+		builtinID[ba.id] = true
+	}
+	for _, c := range b.cmds.All() {
+		if builtinID[c.ID()] {
+			return fmt.Errorf("app: command id %q collides with a reserved built-in action id", c.ID())
+		}
+	}
+	seen := map[string]string{}
+	for _, bd := range b.bindables() {
+		if bd.defaultChord.IsZero() {
+			continue
+		}
+		key := bd.defaultChord.String()
+		if other, dup := seen[key]; dup {
+			return fmt.Errorf("app: default chord %q bound to both %q and %q", key, other, bd.id)
+		}
+		seen[key] = bd.id
+	}
+	return nil
+}
+
+// displayName resolves an action id to its label for error messages.
+func (b *Bindings) displayName(actionID string) string {
+	if bd, ok := b.findBindable(actionID); ok {
+		return bd.displayName
+	}
+	return actionID
+}
+
+// persist saves the customization when a store is wired (in-session only otherwise).
+func (b *Bindings) persist() error {
+	if b.store == nil {
+		return nil
+	}
+	return b.store.Save(b.custom)
+}

--- a/app/bindings_test.go
+++ b/app/bindings_test.go
@@ -242,6 +242,41 @@ func TestDispatchCancelClearsToolThenSelection(t *testing.T) {
 	}
 }
 
+func TestPressKeyRunsCommandViaDefaultChord(t *testing.T) {
+	s := NewSession()
+	ran := false
+	cmd := NewCommand("Test.Line", "Line", "Test", func(*Session) error { ran = true; return nil }).WithAlias("L")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := s.PressKey(KeyEvent{Key: "l"}); err != nil { // lowercase canonicalizes to L
+		t.Fatalf("PressKey: %v", err)
+	}
+	if !ran {
+		t.Error("pressing a command's default chord should run it through the engine")
+	}
+}
+
+func TestPressKeyRebindTakesEffect(t *testing.T) {
+	s := NewSession()
+	ran := 0
+	cmd := NewCommand("Test.Line", "Line", "Test", func(*Session) error { ran++; return nil }).WithAlias("L")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := s.Bindings().SetChord("Test.Line", types.KeyChord{Key: "K"}); err != nil {
+		t.Fatalf("SetChord: %v", err)
+	}
+	_ = s.PressKey(KeyEvent{Key: "L"}) // the old default chord is no longer bound
+	if ran != 0 {
+		t.Error("the old chord should not trigger the command after a rebind")
+	}
+	_ = s.PressKey(KeyEvent{Key: "K"}) // the new chord
+	if ran != 1 {
+		t.Errorf("the rebound chord should trigger the command, ran=%d", ran)
+	}
+}
+
 func TestDispatchUndoGuardedWhileToolActive(t *testing.T) {
 	s, profile := newPartWithSquare(t, 2)
 	trackFromHere(s)

--- a/app/bindings_test.go
+++ b/app/bindings_test.go
@@ -185,6 +185,19 @@ func TestCheckDefaultsDuplicateChord(t *testing.T) {
 	}
 }
 
+// TestStandardCommandsPassCheckDefaults guards the shipped registry: no standard command
+// alias may collide with a built-in shortcut or another command's default chord. This is
+// the same check the head runs at startup (loadKeymap), here gated headlessly.
+func TestStandardCommandsPassCheckDefaults(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if err := s.Bindings().CheckDefaults(); err != nil {
+		t.Fatalf("the shipped command registry has a binding conflict: %v", err)
+	}
+}
+
 func TestCheckDefaultsCleanRegistry(t *testing.T) {
 	s := NewSession()
 	registerAlias(t, s, "Test.Extrude", "E")

--- a/app/bindings_test.go
+++ b/app/bindings_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app/keymap"
+)
+
+// bindingStubTool is a no-op Tool used to put a session into the "tool active" state so
+// the undo/redo dispatch guards can be exercised.
+type bindingStubTool struct{}
+
+func (bindingStubTool) Name() string              { return "Stub" }
+func (bindingStubTool) Start(*Session)            {}
+func (bindingStubTool) Pick(*Session, Selectable) {}
+func (bindingStubTool) CanCommit() bool           { return false }
+func (bindingStubTool) Commit(*Session) error     { return nil }
+func (bindingStubTool) Cancel(*Session)           {}
+
+// registerAlias adds a command with the given id/alias for binding tests.
+func registerAlias(t *testing.T, s *Session, id, alias string) {
+	t.Helper()
+	cmd := NewCommand(id, id, "Test", func(*Session) error { return nil })
+	if alias != "" {
+		cmd = cmd.WithAlias(alias)
+	}
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("register %q: %v", id, err)
+	}
+}
+
+func TestDefaultChordDerivesFromAlias(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	b := s.Bindings()
+
+	c, ok := b.EffectiveChord("Test.Extrude")
+	if !ok || c.String() != "E" {
+		t.Fatalf("EffectiveChord = (%q, %v), want E", c.String(), ok)
+	}
+	if id, ok := b.ResolveChord(types.KeyChord{Key: "E"}); !ok || id != "Test.Extrude" {
+		t.Errorf("ResolveChord(E) = (%q, %v), want Test.Extrude", id, ok)
+	}
+}
+
+func TestResolveChordBuiltinDefaults(t *testing.T) {
+	b := NewSession().Bindings()
+	cases := map[string]string{
+		"Ctrl+Z":       ActionUndo,
+		"Ctrl+Y":       ActionRedo,
+		"Ctrl+Shift+Z": ActionRedo, // extra default chord still resolves
+		"Escape":       ActionCancel,
+		"Enter":        ActionCommit,
+		"V":            ActionToggleVisibility,
+	}
+	for chordStr, want := range cases {
+		c, _ := types.ParseChord(chordStr)
+		if id, ok := b.ResolveChord(c); !ok || id != want {
+			t.Errorf("ResolveChord(%q) = (%q, %v), want %q", chordStr, id, ok, want)
+		}
+	}
+}
+
+func TestSetChordOverrideRebinds(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	b := s.Bindings()
+
+	if err := b.SetChord("Test.Extrude", types.KeyChord{Key: "E", Ctrl: true, Shift: true}); err != nil {
+		t.Fatalf("SetChord: %v", err)
+	}
+	if c, _ := b.EffectiveChord("Test.Extrude"); c.String() != "Ctrl+Shift+E" {
+		t.Errorf("effective chord = %q, want Ctrl+Shift+E", c.String())
+	}
+	if _, ok := b.ResolveChord(types.KeyChord{Key: "E"}); ok {
+		t.Error("old chord E should no longer resolve after rebind")
+	}
+	if id, ok := b.ResolveChord(types.KeyChord{Key: "E", Ctrl: true, Shift: true}); !ok || id != "Test.Extrude" {
+		t.Errorf("new chord should resolve to Test.Extrude, got (%q, %v)", id, ok)
+	}
+}
+
+func TestSetChordConflictIsRejected(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	err := s.Bindings().SetChord("Test.Extrude", types.KeyChord{Key: "Z", Ctrl: true})
+	if err == nil {
+		t.Fatal("rebinding to Ctrl+Z (undo) should conflict")
+	}
+	if !strings.Contains(err.Error(), "Ctrl+Z") || !strings.Contains(err.Error(), ActionUndo) {
+		t.Errorf("error %q should name the offending chord and the colliding action", err)
+	}
+}
+
+func TestSetChordClearThenReset(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	b := s.Bindings()
+
+	if err := b.SetChord("Test.Extrude", types.KeyChord{}); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if _, ok := b.EffectiveChord("Test.Extrude"); ok {
+		t.Error("cleared chord should be unbound, not fall back to default")
+	}
+	if err := b.Reset("Test.Extrude"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if c, ok := b.EffectiveChord("Test.Extrude"); !ok || c.String() != "E" {
+		t.Errorf("after reset, chord = (%q, %v), want default E", c.String(), ok)
+	}
+}
+
+func TestAliasSetResolveConflictCaseInsensitive(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	registerAlias(t, s, "Test.Hole", "H")
+	b := s.Bindings()
+
+	if err := b.SetAlias("Test.Extrude", "EXT"); err != nil {
+		t.Fatalf("SetAlias: %v", err)
+	}
+	if id, ok := b.ResolveAlias("ext"); !ok || id != "Test.Extrude" {
+		t.Errorf("ResolveAlias is case-insensitive: got (%q, %v)", id, ok)
+	}
+	if err := b.SetAlias("Test.Hole", "EXT"); err == nil {
+		t.Error("a duplicate alias should be rejected")
+	}
+}
+
+func TestAliasWithoutDefaultResetRemovesIt(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	b := s.Bindings()
+
+	if err := b.SetAlias("Test.Extrude", "X"); err != nil {
+		t.Fatalf("SetAlias: %v", err)
+	}
+	if b.EffectiveAlias("Test.Extrude") != "X" {
+		t.Errorf("alias = %q, want X", b.EffectiveAlias("Test.Extrude"))
+	}
+	if err := b.Reset("Test.Extrude"); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if b.EffectiveAlias("Test.Extrude") != "" {
+		t.Error("alias had no default; reset should remove it entirely")
+	}
+}
+
+func TestResetAllClearsEveryCustomization(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	b := s.Bindings()
+	_ = b.SetChord("Test.Extrude", types.KeyChord{Key: "E", Ctrl: true})
+	_ = b.SetAlias("Test.Extrude", "EXT")
+
+	if err := b.ResetAll(); err != nil {
+		t.Fatalf("ResetAll: %v", err)
+	}
+	for _, bd := range b.Catalog() {
+		if bd.Customized {
+			t.Errorf("action %q still customized after ResetAll", bd.ActionID)
+		}
+	}
+}
+
+func TestCheckDefaultsReservedIDCollision(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, ActionUndo, "") // a command id colliding with a built-in id
+	if err := s.Bindings().CheckDefaults(); err == nil {
+		t.Fatal("a command reusing a reserved built-in id should fail CheckDefaults")
+	}
+}
+
+func TestCheckDefaultsDuplicateChord(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Visibility", "V") // collides with built-in V (toggleVisibility)
+	err := s.Bindings().CheckDefaults()
+	if err == nil || !strings.Contains(err.Error(), "V") {
+		t.Fatalf("duplicate default chord V should fail CheckDefaults, got %v", err)
+	}
+}
+
+func TestCheckDefaultsCleanRegistry(t *testing.T) {
+	s := NewSession()
+	registerAlias(t, s, "Test.Extrude", "E")
+	if err := s.Bindings().CheckDefaults(); err != nil {
+		t.Errorf("a clean registry should pass CheckDefaults, got %v", err)
+	}
+}
+
+func TestKeymapStorePersistsAndReloads(t *testing.T) {
+	store := keymap.NewMemStore()
+	s1 := NewSession()
+	registerAlias(t, s1, "Test.Extrude", "E")
+	if err := s1.UseKeymapStore(store); err != nil {
+		t.Fatalf("UseKeymapStore: %v", err)
+	}
+	if err := s1.Bindings().SetChord("Test.Extrude", types.KeyChord{Key: "E", Ctrl: true}); err != nil {
+		t.Fatalf("SetChord: %v", err)
+	}
+	if store.Saved == 0 {
+		t.Error("SetChord should have persisted through the store")
+	}
+
+	s2 := NewSession()
+	if err := s2.UseKeymapStore(store); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if c, ok := s2.Bindings().EffectiveChord("Test.Extrude"); !ok || c.String() != "Ctrl+E" {
+		t.Errorf("reloaded chord = (%q, %v), want Ctrl+E", c.String(), ok)
+	}
+}
+
+func TestDispatchRunsCommand(t *testing.T) {
+	s := NewSession()
+	ran := false
+	cmd := NewCommand("Test.Run", "Run", "Test", func(*Session) error { ran = true; return nil })
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := s.Bindings().Dispatch("Test.Run", s); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !ran {
+		t.Error("Dispatch of a command id should run the command")
+	}
+}
+
+func TestDispatchCancelClearsToolThenSelection(t *testing.T) {
+	s := NewSession()
+	s.StartTool(bindingStubTool{})
+	if err := s.Bindings().Dispatch(ActionCancel, s); err != nil {
+		t.Fatalf("Dispatch cancel: %v", err)
+	}
+	if s.ActiveTool() != nil {
+		t.Error("cancel should clear the active tool")
+	}
+}
+
+func TestDispatchUndoGuardedWhileToolActive(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2)
+	trackFromHere(s)
+	s.SetPicker(stubPicker{sel: profile})
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	s.Click(120, 90)
+	ext.SetDistance(5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("extrude OK: %v", err)
+	}
+	if !s.CanUndo() {
+		t.Fatal("precondition: the extrude should be undoable")
+	}
+
+	s.StartTool(bindingStubTool{}) // a tool is now active
+	if err := s.Bindings().Dispatch(ActionUndo, s); err != nil {
+		t.Fatalf("Dispatch undo: %v", err)
+	}
+	if !s.CanUndo() {
+		t.Error("undo must be a no-op while a tool is active (guard preserved)")
+	}
+
+	s.CancelTool()
+	if err := s.Bindings().Dispatch(ActionUndo, s); err != nil {
+		t.Fatalf("Dispatch undo after cancel: %v", err)
+	}
+	if s.CanUndo() {
+		t.Error("with no tool, undo should consume the extrude transaction")
+	}
+}

--- a/app/command_input.go
+++ b/app/command_input.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati.org/api/types"
+)
+
+// The command-alias input box (M05-F17, #831): the user types a multi-character command
+// alias and commits with Enter to run it — the reference product's command-line input.
+// The buffer lives in the session so the flow is unit-testable without the head; the head
+// renders a status-bar text field bound to it (and forwards Enter/Escape). Resolution
+// goes through the binding engine: a typed alias first, then a single-character fallback
+// to that key's shortcut so the familiar one-letter access still works.
+
+// commandInput is the buffer state of the alias input box.
+type commandInput struct {
+	active bool
+	buf    string
+}
+
+// BeginCommandInput opens the alias input box with an empty buffer.
+func (s *Session) BeginCommandInput() {
+	s.cmdInput = commandInput{active: true}
+	s.notice = ""
+}
+
+// CommandInputActive reports whether the alias input box is open.
+func (s *Session) CommandInputActive() bool { return s.cmdInput.active }
+
+// CommandInputText returns the current buffer contents.
+func (s *Session) CommandInputText() string { return s.cmdInput.buf }
+
+// SetCommandInputText replaces the buffer — the head binds its text field to this so the
+// session stays the single source of truth.
+func (s *Session) SetCommandInputText(text string) {
+	if s.cmdInput.active {
+		s.cmdInput.buf = text
+	}
+}
+
+// AppendCommandInputRune appends one character (the headless typing path).
+func (s *Session) AppendCommandInputRune(r rune) {
+	if s.cmdInput.active {
+		s.cmdInput.buf += string(r)
+	}
+}
+
+// BackspaceCommandInput deletes the last character of the buffer.
+func (s *Session) BackspaceCommandInput() {
+	if !s.cmdInput.active || s.cmdInput.buf == "" {
+		return
+	}
+	runes := []rune(s.cmdInput.buf)
+	s.cmdInput.buf = string(runes[:len(runes)-1])
+}
+
+// CancelCommandInput closes the box, discarding the buffer.
+func (s *Session) CancelCommandInput() { s.cmdInput = commandInput{} }
+
+// CommandInputMatches returns "ALIAS — Command" hints for every action whose alias has
+// the current buffer as a case-insensitive prefix — the box's live match list.
+func (s *Session) CommandInputMatches() []string {
+	prefix := strings.ToLower(strings.TrimSpace(s.cmdInput.buf))
+	if prefix == "" {
+		return nil
+	}
+	var out []string
+	for _, bd := range s.Bindings().Catalog() {
+		if bd.Alias != "" && strings.HasPrefix(strings.ToLower(bd.Alias), prefix) {
+			out = append(out, bd.Alias+" — "+bd.DisplayName)
+		}
+	}
+	return out
+}
+
+// CommitCommandInput resolves the buffered alias and runs it: a typed alias first, then a
+// single-character fallback to that key's shortcut. On a hit the box closes and the action
+// dispatches; on a miss the box stays open and the reason is surfaced (a loud typo).
+func (s *Session) CommitCommandInput() error {
+	buf := strings.TrimSpace(s.cmdInput.buf)
+	b := s.Bindings()
+	actionID, ok := b.ResolveAlias(buf)
+	if !ok && len([]rune(buf)) == 1 {
+		actionID, ok = b.ResolveChord(types.KeyChord{Key: buf})
+	}
+	if !ok {
+		s.notice = fmt.Sprintf("no command for alias %q", buf)
+		return fmt.Errorf("app: no command for alias %q", buf)
+	}
+	s.cmdInput = commandInput{}
+	return b.Dispatch(actionID, s)
+}
+
+// routeKeyToCommandInput edits the buffer from a key event while the box is open: Enter
+// commits, Escape cancels, Backspace deletes, and a printable single character is appended.
+func (s *Session) routeKeyToCommandInput(e KeyEvent) error {
+	switch normalizeKey(e.Key) {
+	case "Enter":
+		return s.CommitCommandInput()
+	case "Escape":
+		s.CancelCommandInput()
+		return nil
+	case "Backspace":
+		s.BackspaceCommandInput()
+		return nil
+	default:
+		if rs := []rune(e.Key); len(rs) == 1 {
+			s.AppendCommandInputRune(rs[0])
+		}
+		return nil
+	}
+}

--- a/app/command_input_test.go
+++ b/app/command_input_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+// addAliased registers a flag-setting command and gives it the custom alias.
+func addAliased(t *testing.T, s *Session, id, alias string, ran *bool) {
+	t.Helper()
+	cmd := NewCommand(id, id, "Test", func(*Session) error { *ran = true; return nil })
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add %q: %v", id, err)
+	}
+	if alias != "" {
+		if err := s.Bindings().SetAlias(id, alias); err != nil {
+			t.Fatalf("SetAlias %q: %v", id, err)
+		}
+	}
+}
+
+func TestCommandInputCommitsCustomAlias(t *testing.T) {
+	s := NewSession()
+	ran := false
+	addAliased(t, s, "Test.Extrude", "EXT", &ran)
+
+	s.BeginCommandInput()
+	for _, r := range "ext" { // case-insensitive
+		s.AppendCommandInputRune(r)
+	}
+	if err := s.CommitCommandInput(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if !ran {
+		t.Error("commit should dispatch the aliased command")
+	}
+	if s.CommandInputActive() {
+		t.Error("commit should close the box")
+	}
+}
+
+func TestCommandInputSingleLetterFallback(t *testing.T) {
+	s := NewSession()
+	ran := false
+	cmd := NewCommand("Test.Line", "Line", "Test", func(*Session) error { ran = true; return nil }).WithAlias("L")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.BeginCommandInput()
+	s.SetCommandInputText("L")
+	if err := s.CommitCommandInput(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if !ran {
+		t.Error("a single letter should fall back to that shortcut's command")
+	}
+}
+
+func TestCommandInputMatchesPrefix(t *testing.T) {
+	s := NewSession()
+	ran := false
+	addAliased(t, s, "Test.Extrude", "EXT", &ran)
+	s.BeginCommandInput()
+	s.SetCommandInputText("ex")
+
+	m := s.CommandInputMatches()
+	if len(m) != 1 || !strings.Contains(m[0], "EXT") {
+		t.Errorf("matches = %v, want one EXT hint", m)
+	}
+}
+
+func TestCommandInputCommitMissStaysOpen(t *testing.T) {
+	s := NewSession()
+	s.BeginCommandInput()
+	s.SetCommandInputText("nope")
+	if err := s.CommitCommandInput(); err == nil {
+		t.Fatal("an unknown alias should error")
+	}
+	if !s.CommandInputActive() {
+		t.Error("a miss should keep the box open")
+	}
+	if !strings.Contains(s.Notice(), "nope") {
+		t.Errorf("notice %q should name the bad alias", s.Notice())
+	}
+}
+
+func TestCommandInputBufferEditingViaPressKey(t *testing.T) {
+	s := NewSession()
+	ran := false
+	addAliased(t, s, "Test.Extrude", "EXT", &ran)
+
+	s.BeginCommandInput()
+	for _, k := range []string{"e", "x", "q"} {
+		_ = s.PressKey(KeyEvent{Key: k})
+	}
+	_ = s.PressKey(KeyEvent{Key: "Backspace"}) // delete the stray q
+	_ = s.PressKey(KeyEvent{Key: "t"})
+	if s.CommandInputText() != "ext" {
+		t.Fatalf("buffer = %q, want ext", s.CommandInputText())
+	}
+	if err := s.PressKey(KeyEvent{Key: "Enter"}); err != nil {
+		t.Fatalf("Enter: %v", err)
+	}
+	if !ran || s.CommandInputActive() {
+		t.Errorf("Enter should commit and close: ran=%v active=%v", ran, s.CommandInputActive())
+	}
+}
+
+func TestCommandInputEscapeCancels(t *testing.T) {
+	s := NewSession()
+	s.BeginCommandInput()
+	s.SetCommandInputText("ex")
+	if err := s.PressKey(KeyEvent{Key: "Escape"}); err != nil {
+		t.Fatalf("Escape: %v", err)
+	}
+	if s.CommandInputActive() {
+		t.Error("Escape should cancel the box")
+	}
+}
+
+// While the box is open, a chord must NOT trigger its global shortcut — the keystroke is
+// captured by the buffer instead (the head additionally gates this on text focus).
+func TestCommandInputCapturesKeysFromShortcuts(t *testing.T) {
+	s := NewSession()
+	ran := false
+	cmd := NewCommand("Test.Line", "Line", "Test", func(*Session) error { ran = true; return nil }).WithAlias("L")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.BeginCommandInput()
+	_ = s.PressKey(KeyEvent{Key: "L"}) // would run the command if it were a shortcut
+	if ran {
+		t.Error("a key typed into the open box must not fire its shortcut")
+	}
+	if s.CommandInputText() != "L" {
+		t.Errorf("the key should land in the buffer, got %q", s.CommandInputText())
+	}
+}

--- a/app/keymap/keymap.go
+++ b/app/keymap/keymap.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package keymap holds the user's command alias & keyboard-shortcut customization
+// (M05-F17, #831) and its YAML persistence. It stores only the user's DELTAS from the
+// defaults — the effective bindings are derived live by the app's binding engine from
+// the command registry plus this overlay, so the registry stays the single source of
+// truth for predefined shortcuts. Chords are kept as their canonical string form
+// ([oblikovati.org/api/types.KeyChord.String]), matching the keymap.* wire surface.
+package keymap
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"oblikovati.org/persistence/yamlcodec"
+	"oblikovati.org/userconfig"
+)
+
+// Customization is the user's binding overlay: only entries that differ from the
+// derived defaults. Keys are action ids (a command id or a built-in action id); chord
+// values are canonical chord strings, alias values are the typed command aliases. The
+// zero value (empty maps) means "every binding at its default".
+type Customization struct {
+	Chords  map[string]string `yaml:"chords,omitempty"`
+	Aliases map[string]string `yaml:"aliases,omitempty"`
+}
+
+// Defaults returns the empty overlay: with no customization every binding takes its
+// derived default. Unlike app/options, the effective defaults are NOT stored here —
+// they are computed by the binding engine from the registry — so this is bare on
+// purpose.
+func Defaults() Customization { return Customization{} }
+
+// Clone returns a deep copy so callers mutate without aliasing the stored maps.
+func (c Customization) Clone() Customization {
+	return Customization{Chords: cloneMap(c.Chords), Aliases: cloneMap(c.Aliases)}
+}
+
+// cloneMap copies a string map, returning nil for an empty source (so omitempty holds).
+func cloneMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// Store persists the customization across sessions.
+type Store interface {
+	Load() (Customization, error)
+	Save(Customization) error
+}
+
+// FileStore persists the customization to one YAML file in the user config directory.
+type FileStore struct{ path string }
+
+// DefaultPath is the per-user keymap file: ~/.oblikovati/keymap.yaml on Linux/macOS.
+func DefaultPath() (string, error) { return userconfig.File("keymap.yaml") }
+
+// NewFileStore returns a store backed by the file at path.
+func NewFileStore(path string) *FileStore { return &FileStore{path: path} }
+
+// Load reads the stored customization; a missing file (fresh install) is the empty
+// overlay, so a clean install runs entirely on derived defaults.
+func (s *FileStore) Load() (Customization, error) {
+	c := Defaults()
+	raw, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return c, nil
+	}
+	if err != nil {
+		return c, fmt.Errorf("keymap: read %q: %w", s.path, err)
+	}
+	if err := yamlcodec.Unmarshal(raw, &c); err != nil {
+		return Defaults(), fmt.Errorf("keymap: parse %q: %w", s.path, err)
+	}
+	return c, nil
+}
+
+// Save writes the customization, creating the config directory on first use.
+func (s *FileStore) Save(c Customization) error {
+	data, err := yamlcodec.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("keymap: marshal: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("keymap: create config dir for %q: %w", s.path, err)
+	}
+	return os.WriteFile(s.path, data, 0o644)
+}
+
+// MemStore is an in-memory Store for tests.
+type MemStore struct {
+	stored Customization
+	Saved  int // number of Save calls, for assertions
+}
+
+// NewMemStore returns an empty in-memory store.
+func NewMemStore() *MemStore { return &MemStore{} }
+
+// Load returns the last saved customization (empty if none).
+func (s *MemStore) Load() (Customization, error) { return s.stored, nil }
+
+// Save records a copy of the customization and counts the call.
+func (s *MemStore) Save(c Customization) error {
+	s.stored = c.Clone()
+	s.Saved++
+	return nil
+}

--- a/app/keymap/keymap_test.go
+++ b/app/keymap/keymap_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package keymap
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestFileStoreMissingFileIsEmpty(t *testing.T) {
+	s := NewFileStore(filepath.Join(t.TempDir(), "absent.yaml"))
+	c, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load of a missing file: %v", err)
+	}
+	if len(c.Chords) != 0 || len(c.Aliases) != 0 {
+		t.Errorf("missing file should load the empty overlay, got %+v", c)
+	}
+}
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keymap.yaml")
+	s := NewFileStore(path)
+	want := Customization{
+		Chords:  map[string]string{"Feature.Extrude": "Ctrl+E", "edit.undo": "Ctrl+Z"},
+		Aliases: map[string]string{"Feature.Hole": "HOL"},
+	}
+	if err := s.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Chords["Feature.Extrude"] != "Ctrl+E" || got.Chords["edit.undo"] != "Ctrl+Z" || got.Aliases["Feature.Hole"] != "HOL" {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", got, want)
+	}
+}
+
+func TestMemStoreSavesACopy(t *testing.T) {
+	s := NewMemStore()
+	c := Customization{Chords: map[string]string{"a": "A"}}
+	if err := s.Save(c); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	c.Chords["a"] = "MUTATED" // mutating the caller's map must not affect the store
+	got, _ := s.Load()
+	if got.Chords["a"] != "A" {
+		t.Errorf("MemStore should hold a copy, got %q after caller mutation", got.Chords["a"])
+	}
+	if s.Saved != 1 {
+		t.Errorf("Saved = %d, want 1", s.Saved)
+	}
+}
+
+func TestCloneIsIndependent(t *testing.T) {
+	c := Customization{Chords: map[string]string{"a": "A"}, Aliases: map[string]string{"b": "B"}}
+	clone := c.Clone()
+	clone.Chords["a"] = "X"
+	clone.Aliases["b"] = "Y"
+	if c.Chords["a"] != "A" || c.Aliases["b"] != "B" {
+		t.Error("Clone should not alias the source maps")
+	}
+}
+
+func TestCloneOfEmptyIsNil(t *testing.T) {
+	clone := Defaults().Clone()
+	if clone.Chords != nil || clone.Aliases != nil {
+		t.Errorf("clone of empty should keep nil maps (omitempty), got %+v", clone)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -86,6 +86,7 @@ type Session struct {
 	markingMenus         map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
 	contextMenus         map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
 	objectVisibility     wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
+	cmdInput             commandInput                                     // command-alias input box state (M05-F17)
 	grid                 *GridSettings
 	themes               *theme.Library
 	themeStore           *theme.Store

--- a/app/session.go
+++ b/app/session.go
@@ -38,6 +38,7 @@ type Session struct {
 	facetStore           *facetstore.FacetStore   // tolerance-keyed facet/stroke cache (M07 #293; lazy)
 	transientBodies      *bodyapi.TransientBRep   // transient B-rep registry (M07 #628; lazy)
 	commands             *CommandManager
+	bindings             *Bindings              // keyboard shortcut + alias resolver (M05-F17)
 	histories            map[doc.ID]*docHistory // per-document transaction-event streams (undo/redo)
 	viewState            viewstate.Store        // per-user document view/camera persistence (nil ⇒ disabled)
 	prefs                userprefs.Prefs        // global user preferences (ViewCube show/lock/compass/size/…)

--- a/app/session.go
+++ b/app/session.go
@@ -100,6 +100,7 @@ type Session struct {
 	lighting             renderer.SceneLighting         // the live lighting rig (resolved from the style, then edited)
 	chamferFlatCorners   bool                           // default three-edge-corner treatment for new chamfers
 	paramsDialogOpen     bool                           // the Manage ▸ Parameters dialog is open
+	keymapEditorOpen     bool                           // the Tools ▸ Customize Keyboard panel is open (M05-F17)
 	lightingPanelOpen    bool                           // the View ▸ Lighting settings panel is open
 	loadEnvRequested     bool                           // a "Load HDR…" was requested; the head opens the file dialog
 	meshImportRequested  bool                           // a "Place Mesh…" was requested; the head opens the file dialog (#700)

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/event"
 )
 
@@ -178,58 +179,36 @@ func (s *Session) Pointer(e PointerEvent) {
 	}
 }
 
-// undoRedoShortcut handles the Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z navigators over the active
-// document's transaction stream, returning handled=true when the keystroke was one of
-// them. It is a no-op while an interactive tool is mid-operation — Inventor forbids undo
-// while a transaction is in progress; the head additionally gates it on no text field
-// having keyboard focus.
-func (s *Session) undoRedoShortcut(e KeyEvent) (bool, error) {
-	if !e.Mods.Has(CtrlMod) || s.tool != nil {
-		return false, nil
+// keyEventToChord converts a device key event into a canonical [types.KeyChord],
+// normalizing key synonyms (Return → Enter) so a binding matches however the platform
+// spells the key.
+func keyEventToChord(e KeyEvent) types.KeyChord {
+	return types.KeyChord{
+		Key:   normalizeKey(e.Key),
+		Ctrl:  e.Mods.Has(CtrlMod),
+		Alt:   e.Mods.Has(AltMod),
+		Shift: e.Mods.Has(ShiftMod),
 	}
-	switch e.Key {
-	case "z", "Z":
-		if e.Mods.Has(ShiftMod) {
-			return true, s.Redo()
-		}
-		return true, s.Undo()
-	case "y", "Y":
-		return true, s.Redo()
-	}
-	return false, nil
 }
 
-// PressKey routes a key press: Escape cancels the active tool, Enter commits it, and
-// otherwise a registered command alias runs (Inventor command aliases).
+// normalizeKey maps platform key synonyms onto the canonical token the binding table
+// uses, then canonicalizes case so "z" and "Z" are one chord.
+func normalizeKey(key string) string {
+	if key == "Return" {
+		return "Enter"
+	}
+	return types.CanonicalKey(key)
+}
+
+// PressKey routes a key press through the binding engine (M05-F17, #831): the chord the
+// event forms is resolved to an action — a registered command or a built-in (undo/redo/
+// cancel/commit/visibility) — and dispatched. With no matching binding it is a no-op. The
+// built-in guards (e.g. undo is suppressed mid-tool) live in the dispatch, so behavior
+// matches the formerly hardcoded shortcuts.
 func (s *Session) PressKey(e KeyEvent) error {
-	if handled, err := s.undoRedoShortcut(e); handled {
-		return err
+	b := s.Bindings()
+	if actionID, ok := b.ResolveChord(keyEventToChord(e)); ok {
+		return b.Dispatch(actionID, s)
 	}
-	switch e.Key {
-	case "Escape":
-		// Esc cancels the active tool at any point in its operation; with no tool it
-		// clears the selection (Inventor's behavior).
-		if s.tool != nil {
-			s.CancelTool()
-		} else {
-			s.Select(nil)
-		}
-		return nil
-	case "Enter", "Return":
-		if s.tool != nil {
-			return s.OK()
-		}
-		return nil
-	case "v", "V":
-		// Toggle visibility of the selected work plane(s) (Autodesk Fusion's V binding;
-		// Inventor has no default visibility hotkey). No-op when nothing applicable is
-		// selected, so V stays free for other contexts.
-		s.ToggleSelectedWorkPlaneVisibility()
-		return nil
-	default:
-		if _, ok := s.commands.ByAlias(e.Key); ok {
-			return s.Invoke(e.Key)
-		}
-		return nil
-	}
+	return nil
 }

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -200,12 +200,16 @@ func normalizeKey(key string) string {
 	return types.CanonicalKey(key)
 }
 
-// PressKey routes a key press through the binding engine (M05-F17, #831): the chord the
+// PressKey routes a key press through the binding engine (M05-F17, #831). While the
+// command-alias input box is open the keystroke edits its buffer; otherwise the chord the
 // event forms is resolved to an action — a registered command or a built-in (undo/redo/
 // cancel/commit/visibility) — and dispatched. With no matching binding it is a no-op. The
 // built-in guards (e.g. undo is suppressed mid-tool) live in the dispatch, so behavior
 // matches the formerly hardcoded shortcuts.
 func (s *Session) PressKey(e KeyEvent) error {
+	if s.CommandInputActive() {
+		return s.routeKeyToCommandInput(e)
+	}
 	b := s.Bindings()
 	if actionID, ok := b.ResolveChord(keyEventToChord(e)); ok {
 		return b.Dispatch(actionID, s)

--- a/app/session_keymap.go
+++ b/app/session_keymap.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/app/keymap"
+
+// The session half of M05-F17 (#831): the binding engine lives in [Bindings]; this file
+// wires its persistence, mirroring UseOptionsStore. The head installs a FileStore at
+// startup so rebinds and custom aliases survive across runs.
+
+// UseKeymapStore installs persistence for the keyboard customization and loads the
+// stored overlay into the binding engine.
+func (s *Session) UseKeymapStore(store keymap.Store) error {
+	loaded, err := store.Load()
+	if err != nil {
+		return err
+	}
+	b := s.Bindings()
+	b.store = store
+	b.custom = loaded
+	return nil
+}

--- a/app/session_keymap.go
+++ b/app/session_keymap.go
@@ -20,3 +20,9 @@ func (s *Session) UseKeymapStore(store keymap.Store) error {
 	b.custom = loaded
 	return nil
 }
+
+// OpenKeymapEditor / CloseKeymapEditor / KeymapEditorOpen drive the Tools ▸ Customize
+// Keyboard panel's visibility (the catalog and edit verbs live on [Bindings]).
+func (s *Session) OpenKeymapEditor()      { s.keymapEditorOpen = true }
+func (s *Session) CloseKeymapEditor()     { s.keymapEditorOpen = false }
+func (s *Session) KeymapEditorOpen() bool { return s.keymapEditorOpen }

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -16,6 +16,7 @@ import (
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/types"
 	"oblikovati.org/app"
+	"oblikovati.org/app/keymap"
 	"oblikovati.org/app/options"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/head/internal/sysopen"
@@ -134,6 +135,7 @@ func newDemoSession() *app.Session {
 		s.SetUserPrefsStore(userprefs.NewFileStore(path))
 	}
 	registerCommands(s)
+	loadKeymap(s)                          // after registerCommands: CheckDefaults validates the registered shortcuts
 	s.SetURLOpener(sysopen.SystemOpener{}) // web-view fallback (M05-F08)
 	loadAppOptions(s)
 	// StartupAction (M05-F11): the historical default seeds a demo part; the user can
@@ -212,6 +214,23 @@ func installPicker(s *app.Session) {
 		}).
 		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }).
 		WithOccurrenceLookup(s.OccurrenceOfBody))
+}
+
+// loadKeymap wires the per-user keyboard-customization file (M05-F17) and verifies the
+// default bindings are self-consistent. A store failure costs only persistence (defaults
+// still apply); a CheckDefaults failure is a programming error in the command registry
+// (an alias colliding with a built-in shortcut) and is fatal.
+func loadKeymap(s *app.Session) {
+	if err := s.Bindings().CheckDefaults(); err != nil {
+		panic(err)
+	}
+	path, err := keymap.DefaultPath()
+	if err == nil {
+		err = s.UseKeymapStore(keymap.NewFileStore(path))
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "keymap: %v\n", err)
+	}
 }
 
 // loadAppOptions wires the per-user options file (M05-F11) and applies the stored

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -52,6 +52,8 @@ int  obk_ig_input_float(const char* label, float* v);
 int  obk_ig_input_double(const char* label, double* v);
 int  obk_ig_input_int(const char* label, int* v);
 int  obk_ig_input_text(const char* label, char* buf, int buf_size);
+int  obk_ig_input_text_submit(const char* label, char* buf, int buf_size);
+void obk_ig_set_keyboard_focus_here(void);
 int  obk_ig_input_text_multiline(const char* label, char* buf, int buf_size, float w, float h);
 int  obk_ig_begin_child(const char* id, float w, float h, int border);
 void obk_ig_end_child(void);
@@ -262,6 +264,21 @@ func InputText(label string, buf []byte) bool {
 	defer free()
 	return C.obk_ig_input_text(c, (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))) != 0
 }
+
+// InputTextSubmit is InputText that returns true only on the frame the user presses Enter
+// (ImGuiInputTextFlags_EnterReturnsTrue) — the commit signal for the command-alias box.
+func InputTextSubmit(label string, buf []byte) bool {
+	if len(buf) == 0 {
+		return false
+	}
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_input_text_submit(c, (*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))) != 0
+}
+
+// SetKeyboardFocusHere focuses the next widget on the coming frame — used to put the caret
+// in the command-alias box the moment it opens.
+func SetKeyboardFocusHere() { C.obk_ig_set_keyboard_focus_here() }
 
 // InputTextMultiline draws a multi-line text editor over buf (NUL-terminated, edited in
 // place up to len(buf)-1 bytes) sized w×h logical pixels (0 ⇒ fill the available content

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -159,6 +159,8 @@ int  obk_ig_input_float(const char* label, float* v) { return ImGui::InputFloat(
 int  obk_ig_input_double(const char* label, double* v) { return ImGui::InputDouble(label, v) ? 1 : 0; }
 int  obk_ig_input_int(const char* label, int* v)     { return ImGui::InputInt(label, v) ? 1 : 0; }
 int  obk_ig_input_text(const char* label, char* buf, int buf_size) { return ImGui::InputText(label, buf, (size_t)buf_size) ? 1 : 0; }
+int  obk_ig_input_text_submit(const char* label, char* buf, int buf_size) { return ImGui::InputText(label, buf, (size_t)buf_size, ImGuiInputTextFlags_EnterReturnsTrue) ? 1 : 0; }
+void obk_ig_set_keyboard_focus_here(void) { ImGui::SetKeyboardFocusHere(); }
 int  obk_ig_input_text_multiline(const char* label, char* buf, int buf_size, float w, float h) {
     return ImGui::InputTextMultiline(label, buf, (size_t)buf_size, ImVec2(w, h)) ? 1 : 0;
 }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -140,6 +140,8 @@ func drawChromeWindows(s *app.Session) {
 	drawMaterialsWindow(s)
 	drawLightingWindow(s)
 	drawScriptConsole(s)
+	drawKeymapEditor(s)                 // Tools ▸ Customize Keyboard (M05-F17)
+	drawCommandInput(s)                 // command-alias input box (M05-F17)
 	drawAddInPanels(s)                  // add-in dockable windows (M05-F03)
 	drawMessagingSurfaces(s)            // toasts, prompt modal, message center (M05-F09)
 	drawWebViews(s)                     // web dialogs/views (M05-F08)

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -17,7 +17,7 @@ func drawMenuBar(s *app.Session) {
 	}
 	drawFileMenu(s)
 	drawEditMenu(s)
-	drawToolsMenu()
+	drawToolsMenu(s)
 	drawCommandSearch(s) // the command search box (M05-F12)
 	native.EndMainMenuBar()
 }
@@ -107,13 +107,19 @@ func drawEditMenu(s *app.Session) {
 	}
 }
 
-func drawToolsMenu() {
+func drawToolsMenu(s *app.Session) {
 	if native.BeginMenu("Tools") {
 		if native.MenuItem("Materials") {
 			showMaterials = !showMaterials
 		}
 		if native.MenuItem("Preferences") {
 			showPreferences = !showPreferences
+		}
+		if native.MenuItem("Customize Keyboard") { // M05-F17: rebind shortcuts / aliases
+			s.OpenKeymapEditor()
+		}
+		if native.MenuItem("Command Input") { // M05-F17: type an alias to run a command
+			s.BeginCommandInput()
 		}
 		native.Separator()
 		if native.MenuItem(checkLabel("Normal Debug (front green / back red)", normalDebugOn)) {

--- a/head/ui/command_input_box.go
+++ b/head/ui/command_input_box.go
@@ -1,0 +1,78 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The command-alias input box (M05-F17, #831): a focused text field where the user types
+// a command alias and presses Enter to run it, with a live list of matches. The session
+// owns the buffer and the resolve/dispatch; this file is the ImGui surface bound to it.
+// Because the field holds keyboard focus, native.WantTextInput suppresses global Ctrl
+// shortcuts while typing (head/ui/chrome.go), so e.g. Ctrl+Z in the box never undoes.
+
+const commandInputBufLen = 64
+
+// commandInputUI is the box's cross-frame widget state.
+var commandInputUI = struct {
+	buf    [commandInputBufLen]byte
+	primed bool // caret focused + buffer seeded for the current open session
+}{}
+
+// drawCommandInput renders the command-alias input box while it is open.
+func drawCommandInput(s *app.Session) {
+	if !s.CommandInputActive() {
+		commandInputUI.primed = false
+		return
+	}
+	native.SetNextWindowSizeOnce(360, 0)
+	if native.Begin("Command Input") {
+		drawCommandInputBody(s)
+	}
+	native.End()
+}
+
+// drawCommandInputBody draws the box's contents: a focused field, the live matches, and
+// the Run/Cancel buttons. The buffer is seeded and focused once per open session.
+func drawCommandInputBody(s *app.Session) {
+	if !commandInputUI.primed {
+		copyText(commandInputUI.buf[:], s.CommandInputText())
+		native.SetKeyboardFocusHere()
+		commandInputUI.primed = true
+	}
+	native.SetNextItemWidth(-1)
+	submitted := native.InputTextSubmit("##command-alias", commandInputUI.buf[:])
+	s.SetCommandInputText(bufString(commandInputUI.buf[:]))
+	drawCommandInputMatches(s)
+	if native.Button("Run") || submitted {
+		runCommandInput(s)
+	}
+	native.SameLine()
+	if native.Button("Cancel") {
+		s.CancelCommandInput()
+	}
+	if note := s.Notice(); note != "" {
+		native.Text(note)
+	}
+}
+
+// runCommandInput commits the typed alias. A miss keeps the box open with the reason in
+// the session notice (shown above); a hit closes it and re-primes for next time.
+func runCommandInput(s *app.Session) {
+	s.SetCommandInputText(bufString(commandInputUI.buf[:]))
+	if err := s.CommitCommandInput(); err != nil {
+		return
+	}
+	commandInputUI.primed = false
+}
+
+// drawCommandInputMatches lists the alias hints for the current buffer.
+func drawCommandInputMatches(s *app.Session) {
+	for _, m := range s.CommandInputMatches() {
+		native.BulletText(m)
+	}
+}

--- a/head/ui/keymap_window.go
+++ b/head/ui/keymap_window.go
@@ -1,0 +1,135 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The Tools ▸ Customize Keyboard panel (M05-F17, #831): the predefined catalog of every
+// bindable action with its editable shortcut and alias, per-row reset, and reset-all. The
+// binding engine owns resolution, conflict checks and persistence; this file is the ImGui
+// surface that reads the catalog each frame and calls the edit verbs on Enter.
+
+const keymapBufLen = 48
+
+// keymapUI is the panel's cross-frame state: per-action edit buffers (seeded lazily, then
+// dropped after an apply so the canonical value re-seeds) and the last apply error.
+var keymapUI = struct {
+	chord   map[string][]byte
+	alias   map[string][]byte
+	lastErr string
+}{}
+
+// drawKeymapEditor renders the customization panel while it is open.
+func drawKeymapEditor(s *app.Session) {
+	if !s.KeymapEditorOpen() {
+		return
+	}
+	if keymapUI.chord == nil {
+		dropKeymapBuffers()
+	}
+	native.SetNextWindowSizeOnce(720, 560)
+	if native.Begin("Customize Keyboard") {
+		native.Text("Type a shortcut (e.g. Ctrl+Shift+E) or an alias, then Enter. Empty clears it.")
+		if keymapUI.lastErr != "" {
+			native.Text("! " + keymapUI.lastErr)
+		}
+		native.Separator()
+		drawKeymapTable(s)
+		native.Separator()
+		if native.Button("Reset All") {
+			recordKeymapResult(s.Bindings().ResetAll())
+			dropKeymapBuffers()
+		}
+		native.SameLine()
+		if native.Button("Done") {
+			s.CloseKeymapEditor()
+		}
+	}
+	native.End()
+}
+
+// drawKeymapTable renders the catalog as an editable four-column table.
+func drawKeymapTable(s *app.Session) {
+	if !native.BeginTable("##keymap", 4, 0, 0) {
+		return
+	}
+	native.TableSetupColumn("Command")
+	native.TableSetupColumn("Shortcut")
+	native.TableSetupColumn("Alias")
+	native.TableSetupColumn("")
+	native.TableSetupScrollFreeze(0, 1)
+	native.TableHeadersRow()
+	for _, b := range s.Bindings().Catalog() {
+		drawKeymapRow(s, b)
+	}
+	native.EndTable()
+}
+
+// drawKeymapRow renders one action: its name, editable shortcut/alias fields, and a reset.
+func drawKeymapRow(s *app.Session, b app.Binding) {
+	native.TableNextRow()
+	native.TableNextColumn()
+	native.Text(b.DisplayName)
+
+	native.TableNextColumn()
+	if editKeymapField(b.ActionID, keymapUI.chord, b.Chord.String(), "##chord-") {
+		applyChord(s, b.ActionID, bufString(keymapUI.chord[b.ActionID]))
+	}
+
+	native.TableNextColumn()
+	if editKeymapField(b.ActionID, keymapUI.alias, b.Alias, "##alias-") {
+		recordKeymapResult(s.Bindings().SetAlias(b.ActionID, bufString(keymapUI.alias[b.ActionID])))
+		delete(keymapUI.alias, b.ActionID)
+	}
+
+	native.TableNextColumn()
+	if b.Customized && native.Button("Reset##"+b.ActionID) {
+		recordKeymapResult(s.Bindings().Reset(b.ActionID))
+		delete(keymapUI.chord, b.ActionID)
+		delete(keymapUI.alias, b.ActionID)
+	}
+}
+
+// editKeymapField draws a per-action InputText seeded lazily from current, returning true
+// on Enter.
+func editKeymapField(id string, buffers map[string][]byte, current, idPrefix string) bool {
+	buf, ok := buffers[id]
+	if !ok {
+		buf = make([]byte, keymapBufLen)
+		copyText(buf, current)
+		buffers[id] = buf
+	}
+	native.SetNextItemWidth(-1)
+	return native.InputTextSubmit(idPrefix+id, buf)
+}
+
+// applyChord parses a typed chord and rebinds the action, recording any error.
+func applyChord(s *app.Session, actionID, text string) {
+	chord, err := types.ParseChord(text)
+	if err == nil {
+		err = s.Bindings().SetChord(actionID, chord)
+	}
+	recordKeymapResult(err)
+	delete(keymapUI.chord, actionID)
+}
+
+// recordKeymapResult clears the panel error on success, else shows the reason.
+func recordKeymapResult(err error) {
+	if err != nil {
+		keymapUI.lastErr = err.Error()
+		return
+	}
+	keymapUI.lastErr = ""
+}
+
+// dropKeymapBuffers forces every field to re-seed from the model (after a reset-all).
+func dropKeymapBuffers() {
+	keymapUI.chord = map[string][]byte{}
+	keymapUI.alias = map[string][]byte{}
+}


### PR DESCRIPTION
## What
Implements **M05-F17** — user customization of command aliases and keyboard shortcuts (#831): a rebindable shortcut engine, per-user persistence, a multi-character command-alias input box, and a head customization panel + predefined catalog.

Depends on the contract in **Oblikovati.API#100** (must merge first; CI here is red until then).

## Why
The issue assumed the backend existed — it didn't. Aliases were static (`WithAlias`, no override/persistence) and shortcuts were hardcoded in `PressKey` (Escape/Enter/V/Ctrl+Z/Y). This builds the whole customization layer while preserving every existing behavior.

## How it's structured (commit-per-PBI)
1. **`app/keymap`** — serializable `Customization` overlay + YAML store (`~/.oblikovati/keymap.yaml`), mirroring `app/options`. Stores only user deltas.
2. **`app.Bindings`** — the live engine: derives default chords from each command's `WithAlias` letter, holds a built-in action table (undo/redo/cancel/commit/visibility — the former hardcoded shortcuts), resolves chords/aliases to action ids, dispatches to a command or a guarded built-in, and conflict-checks every rebind (errors name the offending value + colliding action). Reset/reset-all/export/import + a startup `CheckDefaults` self-check.
3. **`PressKey` rerouted** through the engine — chord resolution replaces the hardcoded cases; behavior preserved (verified by the unchanged undo/redo/V/Enter/Escape regression tests + new rebind-then-press coverage).
4. **Command-alias input box** — a session-held buffer: type a multi-char alias, Enter to run; resolves via the engine (alias, then single-letter fallback), loud miss.
5. **Router** — serves `keymap.*` (list/setChord/setAlias/reset/resetAll/export/import), driving `app.Bindings`.
6. **Head UI** — Tools ▸ **Customize Keyboard** (editable catalog table with rebind/reset/reset-all, inline conflict errors) and **Command Input** (focused alias field, live matches). Startup installs the keymap store and runs `CheckDefaults`. Adds native `InputTextSubmit` + `SetKeyboardFocusHere`.

## Tests
Unit-tested at every layer: KeyChord round-trip, store persistence, engine (conflict/reset/dispatch-guards/default derivation), `PressKey` regression + rebind, command-input flow, router over-wire (incl. conflict rejection + export/import round-trip), and a guard test that the **shipped command registry passes `CheckDefaults`**. `go test ./...` + `golangci-lint` clean on both modules; the cgo head builds, its `ui` tests pass, and it boots cleanly through the new startup path.

## Follow-ups (noted, out of scope here)
- The head forwards only Escape/Ctrl+Z/Ctrl+Y to `PressKey` today; general letter-key shortcut forwarding (so a rebound `E` fires from the keyboard) needs native key enumeration. The command-input box is the alias-entry path meanwhile.
- The MCP bridge (separate repo) needs a tools regenerate to expose the 7 `keymap_*` tools (verified the generator emits them from the new client annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)