### PR TITLE
feat(head): forward keyboard shortcuts to the binding engine (M05-F17, #831)

### DIFF
--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -71,10 +71,12 @@ void obk_ig_item_rect_min(float* x, float* y);
 void obk_ig_mouse_pos(float* x, float* y);
 int  obk_ig_key_shift(void);
 int  obk_ig_key_ctrl(void);
+int  obk_ig_key_alt(void);
 int  obk_ig_escape_pressed(void);
 int  obk_ig_f1_pressed(void);
 int  obk_ig_undo_pressed(void);
 int  obk_ig_redo_pressed(void);
+int  obk_ig_pressed_keys(char* buf, int buf_size);
 int  obk_ig_want_text_input(void);
 float obk_ig_mouse_wheel(void);
 float obk_ig_delta_time(void);
@@ -141,7 +143,10 @@ void obk_inject_key_shift(int down);
 */
 import "C"
 
-import "unsafe"
+import (
+	"strings"
+	"unsafe"
+)
 
 // ImGui-widget wrappers in idiomatic Go. These are the verbs the chrome (head/ui)
 // composes each frame; the LAYOUT logic stays in Go. cstr converts once per call —
@@ -677,6 +682,20 @@ func KeyShift() bool { return C.obk_ig_key_shift() != 0 }
 
 // KeyCtrl reports whether a Ctrl key is held (multi-select modifier).
 func KeyCtrl() bool { return C.obk_ig_key_ctrl() != 0 }
+
+// KeyAlt reports whether an Alt key is held (a shortcut-chord modifier).
+func KeyAlt() bool { return C.obk_ig_key_alt() != 0 }
+
+// PressedKeys returns the names of the named keys pressed this frame (no auto-repeat,
+// modifier keys excluded) — e.g. ["E"] or ["F1"]. The names match the canonical KeyChord
+// key tokens, so the head forwards each as a chord to the binding engine (M05-F17).
+func PressedKeys() []string {
+	var buf [256]byte
+	if C.obk_ig_pressed_keys((*C.char)(unsafe.Pointer(&buf[0])), C.int(len(buf))) == 0 {
+		return nil
+	}
+	return strings.Split(C.GoString((*C.char)(unsafe.Pointer(&buf[0]))), "\n")
+}
 
 // EscapePressed reports whether Esc was pressed this frame (cancel the active tool).
 // F1Pressed fires once on the frame F1 is pressed — the host help shortcut (M05-F14).

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -4,6 +4,7 @@
 // Go-described tree in C++ — is what lets Go own the UI composition. Add wrappers as
 // the chrome grows; resist putting logic here.
 #include <cstring> // strcmp (theme color-name lookup)
+#include <cstdio>  // snprintf (bounds-safe key-name packing)
 #include "imgui.h"
 #include "imgui_internal.h" // SeparatorEx (vertical ribbon-panel divider)
 
@@ -322,6 +323,34 @@ int  obk_ig_f1_pressed(void)                 { return ImGui::IsKeyPressed(ImGuiK
 // Ctrl (and not WantTextInput) to form the global Ctrl+Z / Ctrl+Y shortcuts.
 int  obk_ig_undo_pressed(void)               { return ImGui::IsKeyPressed(ImGuiKey_Z) ? 1 : 0; }
 int  obk_ig_redo_pressed(void)               { return ImGui::IsKeyPressed(ImGuiKey_Y) ? 1 : 0; }
+int  obk_ig_key_alt(void)                    { return ImGui::GetIO().KeyAlt ? 1 : 0; }
+// pressed_keys writes the newline-separated names of every NAMED key pressed this frame (no
+// key repeat, modifier keys excluded) into buf, so the Go side can form a chord per key and
+// let the binding engine resolve rebindable shortcuts (M05-F17). Returns the count written.
+int  obk_ig_pressed_keys(char* buf, int buf_size) {
+    if (buf_size <= 0) return 0;
+    buf[0] = 0;
+    int count = 0, off = 0;
+    for (ImGuiKey key = ImGuiKey_NamedKey_BEGIN; key < ImGuiKey_NamedKey_END; key = (ImGuiKey)(key + 1)) {
+        if (!ImGui::IsKeyPressed(key, false)) continue; // false: ignore auto-repeat
+        switch (key) { // modifier keys travel as the chord's modifier flags, not as keys
+            case ImGuiKey_LeftCtrl:  case ImGuiKey_RightCtrl:
+            case ImGuiKey_LeftShift: case ImGuiKey_RightShift:
+            case ImGuiKey_LeftAlt:   case ImGuiKey_RightAlt:
+            case ImGuiKey_LeftSuper: case ImGuiKey_RightSuper: continue;
+            default: break;
+        }
+        const char* name = ImGui::GetKeyName(key);
+        if (name == NULL || name[0] == 0) continue;
+        const char* sep = (count > 0) ? "\n" : "";
+        // snprintf is bounds-safe: it never writes past buf_size and always NUL-terminates.
+        int n = snprintf(buf + off, (size_t)(buf_size - off), "%s%s", sep, name);
+        if (n < 0 || n >= buf_size - off) { buf[off] = 0; break; } // would truncate: keep complete entries
+        off += n;
+        count++;
+    }
+    return count;
+}
 // want_text_input is true while a text/number field is being edited, so global shortcuts
 // stand down and let the field keep the keystroke (incl. its own Ctrl+Z).
 int  obk_ig_want_text_input(void)            { return ImGui::GetIO().WantTextInput ? 1 : 0; }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -154,30 +154,49 @@ func drawChromeWindows(s *app.Session) {
 	}
 }
 
-// handleKeyboard routes global shortcuts to the session. Esc cancels the active tool at
-// any point (or clears the selection when idle) — Inventor's universal cancel. Ctrl+Z /
-// Ctrl+Y (Ctrl+Shift+Z) navigate the undo stream, but only when no text field has focus,
-// so a field's own editing keeps the keystroke.
+// handleKeyboard forwards keyboard input to the session's binding engine (M05-F17). Esc and
+// F1 are handled first so they work even from a focused field (Esc is the universal cancel;
+// F1 opens host help, not a bindable action). Otherwise, while no text widget owns the
+// keyboard, every non-modifier key pressed this frame is sent as a chord carrying the held
+// modifiers, so rebindable shortcuts (undo/redo, command shortcuts, …) resolve and fire.
 func handleKeyboard(s *app.Session) {
 	if native.EscapePressed() {
 		_ = s.PressKey(app.KeyEvent{Key: "Escape"})
 	}
-	if native.F1Pressed() { // F1 opens the host documentation (M05-F14)
+	if native.F1Pressed() {
 		_ = s.DisplayHelpTopic("", "")
 	}
-	if !native.KeyCtrl() || native.WantTextInput() {
+	if native.WantTextInput() { // a text widget owns the keyboard; stand down
 		return
 	}
-	mods := app.CtrlMod
+	dispatchPressedKeys(s, native.PressedKeys(), heldModifiers())
+}
+
+// dispatchPressedKeys sends each non-modifier key pressed this frame to the session as a
+// chord carrying the held modifiers. Escape is already handled in handleKeyboard, so it is
+// skipped here to avoid a double cancel. Kept pure (no native reads) so it is unit-testable.
+func dispatchPressedKeys(s *app.Session, keys []string, mods app.Modifier) {
+	for _, key := range keys {
+		if key == "Escape" {
+			continue
+		}
+		_ = s.PressKey(app.KeyEvent{Key: key, Mods: mods})
+	}
+}
+
+// heldModifiers reads the modifier keys currently down.
+func heldModifiers() app.Modifier {
+	var mods app.Modifier
+	if native.KeyCtrl() {
+		mods |= app.CtrlMod
+	}
 	if native.KeyShift() {
 		mods |= app.ShiftMod
 	}
-	switch {
-	case native.UndoPressed():
-		_ = s.PressKey(app.KeyEvent{Key: "z", Mods: mods})
-	case native.RedoPressed():
-		_ = s.PressKey(app.KeyEvent{Key: "y", Mods: mods})
+	if native.KeyAlt() {
+		mods |= app.AltMod
 	}
+	return mods
 }
 
 // dockLaidOut guards the one-time default panel arrangement (the dockspace persists

--- a/head/ui/keyboard_test.go
+++ b/head/ui/keyboard_test.go
@@ -1,0 +1,70 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+)
+
+// TestDispatchPressedKeysRunsShortcut proves the head's key-forwarding (M05-F17) drives the
+// binding engine: a forwarded letter resolves to its shortcut command and runs.
+func TestDispatchPressedKeysRunsShortcut(t *testing.T) {
+	s := app.NewSession()
+	ran := false
+	cmd := app.NewCommand("Test.Line", "Line", "Test", func(*app.Session) error { ran = true; return nil }).WithAlias("L")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	dispatchPressedKeys(s, []string{"L"}, 0)
+	if !ran {
+		t.Error("forwarding the L key should run the L-shortcut command")
+	}
+}
+
+// TestDispatchPressedKeysCarriesModifiers proves a modified chord (Ctrl+Z) forwards to the
+// built-in it is bound to — here undo, after an undoable edit.
+func TestDispatchPressedKeysCarriesModifiers(t *testing.T) {
+	s := app.NewSession()
+	ran := 0
+	cmd := app.NewCommand("Test.Probe", "Probe", "Test", func(*app.Session) error { ran++; return nil })
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	chord, err := types.ParseChord("Ctrl+K")
+	if err != nil {
+		t.Fatalf("ParseChord: %v", err)
+	}
+	if err := s.Bindings().SetChord("Test.Probe", chord); err != nil {
+		t.Fatalf("SetChord: %v", err)
+	}
+	dispatchPressedKeys(s, []string{"K"}, app.CtrlMod)
+	if ran != 1 {
+		t.Errorf("Ctrl+K should run the rebound command once, ran=%d", ran)
+	}
+}
+
+// TestDispatchPressedKeysSkipsEscape proves Escape is not double-handled here (handleKeyboard
+// forwards it separately).
+func TestDispatchPressedKeysSkipsEscape(t *testing.T) {
+	s := app.NewSession()
+	s.StartTool(stubKeyboardTool{})
+	dispatchPressedKeys(s, []string{"Escape"}, 0)
+	if s.ActiveTool() == nil {
+		t.Error("dispatchPressedKeys must skip Escape (handleKeyboard owns it), so the tool stays active")
+	}
+}
+
+// stubKeyboardTool is a no-op tool to observe that Escape was not dispatched here.
+type stubKeyboardTool struct{}
+
+func (stubKeyboardTool) Name() string                      { return "Stub" }
+func (stubKeyboardTool) Start(*app.Session)                {}
+func (stubKeyboardTool) Pick(*app.Session, app.Selectable) {}
+func (stubKeyboardTool) CanCommit() bool                   { return false }
+func (stubKeyboardTool) Commit(*app.Session) error         { return nil }
+func (stubKeyboardTool) Cancel(*app.Session)               {}


### PR DESCRIPTION
## What
Makes rebindable keyboard shortcuts actually fire from the keyboard in the head — the follow-up flagged in #839.

Before, `handleKeyboard` forwarded only Escape/Ctrl+Z/Ctrl+Y to `PressKey`, so a rebound letter shortcut (or any non-hardcoded one) never reached the binding engine. Now it enumerates **every non-modifier key pressed this frame** and sends each as a chord carrying the held modifiers:

- New native `PressedKeys()` — built on ImGui `IsKeyPressed(key, false)` + `GetKeyName`, over the named-key range, excluding modifier keys (no auto-repeat). New native `KeyAlt()` for the Alt modifier.
- `handleKeyboard` keeps Escape and F1 special (work even from a focused field), stands down while `WantTextInput()` (a text widget owns the keyboard), and otherwise forwards all pressed keys. Undo/redo now route through this same general path instead of bespoke `UndoPressed`/`RedoPressed` checks.

## Why
M05-F17 made shortcuts rebindable end-to-end, but the head's input layer only relayed three of them. This closes the gap so the customization panel's rebinds (and command shortcuts generally) take effect via the keyboard.

## Tests
The pure key→dispatch step is extracted as `dispatchPressedKeys` and unit-tested (`head/ui/keyboard_test.go`): a forwarded `L` runs its shortcut command, `Ctrl+K` runs a rebound command, and `Escape` is skipped here (owned by `handleKeyboard`). The cgo head builds, `ui`/`native` tests pass, lint clean, and it boots cleanly. (The native key enumeration itself reads real OS input, so it isn't headless-testable; it's standard ImGui API.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)