### PR TITLE
Notify users of new GitHub releases (Help ▸ Check for Updates)

### DIFF
--- a/app/options/options.go
+++ b/app/options/options.go
@@ -47,6 +47,13 @@ type Save struct {
 	OldVersionsToKeep int                       `yaml:"oldVersionsToKeep,omitempty"`
 }
 
+// Updates is the software-update behavior (read by the head's startup auto-check and
+// the CLI): whether to check GitHub for a newer release on launch. The user toggles it
+// from the update notification or Help ▸ Check for Updates; a manual check ignores it.
+type Updates struct {
+	CheckOnStartup bool `yaml:"checkOnStartup"`
+}
+
 // All is every persisted option group. The ViewCube/display preferences live in
 // their own store (persistence/userprefs) and the color scheme in the theme store —
 // the options surface proxies those rather than duplicating their persistence.
@@ -55,6 +62,7 @@ type All struct {
 	Sketch  Sketch  `yaml:"sketch"`
 	Part    Part    `yaml:"part"`
 	Save    Save    `yaml:"save"`
+	Updates Updates `yaml:"updates"`
 }
 
 // Defaults returns the out-of-the-box options, mirroring the session's historical
@@ -66,6 +74,7 @@ func Defaults() All {
 		Sketch:  Sketch{GridSpacingCm: 1, GridVisible: true, GridMajorEvery: 5, SnapToPoints: true, SnapToGrid: true},
 		Part:    Part{ChamferFlatCorners: true},
 		Save:    Save{Thumbnail: types.ThumbnailNone},
+		Updates: Updates{CheckOnStartup: true},
 	}
 }
 

--- a/app/session.go
+++ b/app/session.go
@@ -24,6 +24,7 @@ import (
 	"oblikovati.org/renderer"
 	"oblikovati.org/scene"
 	"oblikovati.org/theme"
+	"oblikovati.org/update"
 )
 
 // Session is the running application state and the seam tests drive synthetically.
@@ -114,6 +115,8 @@ type Session struct {
 	asmBodies            assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
 	bomPanelOpen         bool                           // the Assemble ▸ Bill of Materials panel is open (#768)
 	bomViewKind          bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
+	updateCheckRequested bool                           // Help ▸ Check for Updates was clicked; the head runs the (network) check
+	pendingUpdate        *update.Result                 // last update-check outcome to show in the update window; nil = closed
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/app/update_notice.go
+++ b/app/update_notice.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/app/options"
+	"oblikovati.org/update"
+)
+
+// Software-update surface (Help ▸ Check for Updates). The session owns the user-visible
+// state — the "check on startup" preference and the result to display — but never does
+// the network I/O itself: the head runs the check ([oblikovati.org/update]) off the UI
+// thread and hands the outcome back through ShowUpdateResult, so the whole flow stays
+// unit-testable without a live GitHub (ADR-0014).
+
+// UpdateChecksEnabled reports whether the startup auto-check is on (the persisted
+// Updates.CheckOnStartup preference). A manual Help ▸ Check for Updates ignores it.
+func (s *Session) UpdateChecksEnabled() bool { return s.appOptions.Updates.CheckOnStartup }
+
+// SetUpdateChecksEnabled stores the startup-check preference (the update notification's
+// "don't check on startup" toggle), persisting it to the user's options file.
+func (s *Session) SetUpdateChecksEnabled(on bool) error {
+	s.appOptions.Updates = options.Updates{CheckOnStartup: on}
+	return s.saveOptions()
+}
+
+// RequestUpdateCheck flags a manual check; the head consumes it with
+// TakeUpdateCheckRequest, runs the network check, and reports back via ShowUpdateResult.
+func (s *Session) RequestUpdateCheck() { s.updateCheckRequested = true }
+
+// TakeUpdateCheckRequest returns and clears the pending manual-check request (one-shot,
+// so the head launches exactly one check per click).
+func (s *Session) TakeUpdateCheckRequest() bool {
+	req := s.updateCheckRequested
+	s.updateCheckRequested = false
+	return req
+}
+
+// ShowUpdateResult records a check's outcome for the update window to display, and when a
+// newer release exists also drops a status-bar notice so the user sees it even if the
+// window is dismissed. Called by the head after the check completes.
+func (s *Session) ShowUpdateResult(res update.Result) {
+	s.pendingUpdate = &res
+	if res.UpdateAvailable {
+		s.notice = fmt.Sprintf("Update available: %s — see Help ▸ Check for Updates", res.Latest.Version)
+	}
+}
+
+// PendingUpdate returns the update outcome to display, or nil when the window is closed.
+func (s *Session) PendingUpdate() *update.Result { return s.pendingUpdate }
+
+// DismissUpdate closes the update window.
+func (s *Session) DismissUpdate() { s.pendingUpdate = nil }
+
+// OpenLatestReleasePage opens the pending release's GitHub page through the platform URL
+// opener (the notification's download link). It errors if there is no release to open.
+func (s *Session) OpenLatestReleasePage() error {
+	if s.pendingUpdate == nil || s.pendingUpdate.Latest.HTMLURL == "" {
+		return fmt.Errorf("app: no release page to open (pending update: %v)", s.pendingUpdate)
+	}
+	return s.OpenURL(s.pendingUpdate.Latest.HTMLURL)
+}

--- a/app/update_notice_test.go
+++ b/app/update_notice_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/app/options"
+	"oblikovati.org/update"
+)
+
+func TestUpdateCheckRequestIsOneShot(t *testing.T) {
+	s := NewSession()
+	if s.TakeUpdateCheckRequest() {
+		t.Fatal("no request pending initially")
+	}
+	s.RequestUpdateCheck()
+	if !s.TakeUpdateCheckRequest() {
+		t.Fatal("the request should be taken once")
+	}
+	if s.TakeUpdateCheckRequest() {
+		t.Fatal("the request must clear after being taken")
+	}
+}
+
+func TestShowUpdateResultSetsNoticeWhenAvailable(t *testing.T) {
+	s := NewSession()
+	s.ShowUpdateResult(update.Result{
+		UpdateAvailable: true,
+		Latest:          update.Release{Version: "0.0.20260615030000", HTMLURL: "https://gh/r"},
+	})
+	if s.PendingUpdate() == nil {
+		t.Fatal("a result should be pending for the window")
+	}
+	if s.Notice() == "" {
+		t.Error("an available update should drop a status-bar notice")
+	}
+	s.DismissUpdate()
+	if s.PendingUpdate() != nil {
+		t.Error("DismissUpdate should clear the window")
+	}
+}
+
+func TestShowUpdateResultNoNoticeWhenUpToDate(t *testing.T) {
+	s := NewSession()
+	s.ShowUpdateResult(update.Result{UpdateAvailable: false})
+	if s.Notice() != "" {
+		t.Errorf("an up-to-date check must not nag the status bar, got %q", s.Notice())
+	}
+}
+
+func TestOpenLatestReleasePageUsesOpener(t *testing.T) {
+	s := NewSession()
+	opener := &FakeURLOpener{}
+	s.SetURLOpener(opener)
+	if err := s.OpenLatestReleasePage(); err == nil {
+		t.Fatal("opening with no pending release should fail")
+	}
+	s.ShowUpdateResult(update.Result{
+		UpdateAvailable: true,
+		Latest:          update.Release{HTMLURL: "https://gh/release"},
+	})
+	if err := s.OpenLatestReleasePage(); err != nil {
+		t.Fatalf("OpenLatestReleasePage: %v", err)
+	}
+	if len(opener.opened) != 1 || opener.opened[0] != "https://gh/release" {
+		t.Errorf("opened = %v, want the release URL", opener.opened)
+	}
+}
+
+func TestSetUpdateChecksEnabledPersists(t *testing.T) {
+	s := NewSession()
+	store := &FakeOptionsStore{stored: options.Defaults()}
+	if err := s.UseOptionsStore(store); err != nil {
+		t.Fatalf("UseOptionsStore: %v", err)
+	}
+	if !s.UpdateChecksEnabled() {
+		t.Fatal("default should be enabled")
+	}
+	if err := s.SetUpdateChecksEnabled(false); err != nil {
+		t.Fatalf("SetUpdateChecksEnabled: %v", err)
+	}
+	if s.UpdateChecksEnabled() {
+		t.Error("preference should be off after disabling")
+	}
+	if store.stored.Updates.CheckOnStartup {
+		t.Error("the disabled preference should have been persisted")
+	}
+}

--- a/cmd/oblikovati-cli/cmd_update.go
+++ b/cmd/oblikovati-cli/cmd_update.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"oblikovati.org/build"
+	"oblikovati.org/update"
+)
+
+// updateTimeout bounds the GitHub query so `check-updates` returns promptly on a slow or
+// missing network instead of hanging the headless tool.
+const updateTimeout = 8 * time.Second
+
+// cmdCheckUpdates queries GitHub for a newer release on this build's channel and prints a
+// plain-text result (CLAUDE.md: plain text for user-facing CLI output). An offline
+// machine or a dev build is reported as a graceful skip, not an error.
+//
+//	oblikovati-cli check-updates
+func cmdCheckUpdates(out io.Writer) error {
+	src := update.NewGitHubSource(update.DefaultOwner, update.DefaultRepo, &http.Client{Timeout: updateTimeout})
+	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
+	defer cancel()
+	res, err := update.NewChecker(src).Check(ctx, build.Version)
+	if err != nil {
+		return fmt.Errorf("oblikovati-cli: update check failed: %w", err)
+	}
+	fmt.Fprintln(out, updateMessage(res))
+	return nil
+}
+
+// updateMessage renders a check result as one line of user-facing text. Kept pure (no
+// I/O) so it is table-testable without a live GitHub.
+func updateMessage(res update.Result) string {
+	if res.Skipped {
+		return "Update check skipped: " + skipDetail(res.SkipReason, res.Channel) + "."
+	}
+	if res.UpdateAvailable {
+		return fmt.Sprintf("A new %s release is available: %s\nDownload: %s",
+			res.Channel, res.Latest.Version, res.Latest.HTMLURL)
+	}
+	return fmt.Sprintf("You are running the latest %s release (%s).", res.Channel, res.Current)
+}
+
+// skipDetail expands a skip reason into a full clause for the CLI message.
+func skipDetail(reason string, channel update.Channel) string {
+	switch reason {
+	case "offline":
+		return "no internet connection"
+	case "development build":
+		return "this is a development build"
+	case "no published release":
+		return "no release published on the " + channel.String() + " channel yet"
+	default:
+		return reason
+	}
+}

--- a/cmd/oblikovati-cli/cmd_update_test.go
+++ b/cmd/oblikovati-cli/cmd_update_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/update"
+)
+
+func TestUpdateMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		res  update.Result
+		want []string // substrings that must appear
+	}{
+		{
+			name: "available",
+			res: update.Result{
+				Channel: update.Stable, Current: "0.0.1",
+				UpdateAvailable: true,
+				Latest:          update.Release{Version: "0.0.2", HTMLURL: "https://gh/r"},
+			},
+			want: []string{"new stable release", "0.0.2", "https://gh/r"},
+		},
+		{
+			name: "up to date",
+			res:  update.Result{Channel: update.Stable, Current: "0.0.2"},
+			want: []string{"latest stable release", "0.0.2"},
+		},
+		{
+			name: "offline",
+			res:  update.Result{Channel: update.Stable, Skipped: true, SkipReason: "offline"},
+			want: []string{"skipped", "no internet connection"},
+		},
+		{
+			name: "dev build",
+			res:  update.Result{Channel: update.Dev, Skipped: true, SkipReason: "development build"},
+			want: []string{"skipped", "development build"},
+		},
+		{
+			name: "no release",
+			res:  update.Result{Channel: update.Nightly, Skipped: true, SkipReason: "no published release"},
+			want: []string{"skipped", "nightly channel"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := updateMessage(c.res)
+			for _, w := range c.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("updateMessage(%s) = %q, missing %q", c.name, got, w)
+				}
+			}
+		})
+	}
+}

--- a/cmd/oblikovati-cli/main.go
+++ b/cmd/oblikovati-cli/main.go
@@ -49,11 +49,13 @@ func run(args []string, out io.Writer) error {
 		return cmdScript(args[1:], out)
 	case "version":
 		return cmdVersion(out)
+	case "check-updates":
+		return cmdCheckUpdates(out)
 	case "help", "-h", "--help":
 		fmt.Fprintln(out, usage)
 		return nil
 	default:
-		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|import|export|script|version)", args[0])
+		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|import|export|script|version|check-updates)", args[0])
 	}
 }
 
@@ -68,4 +70,5 @@ usage:
   oblikovati-cli import <mesh-file.stl|.obj|.3mf> <dst.opd>
   oblikovati-cli export <src.opd> <mesh-file.stl|.obj|.3mf> [low|medium|high]
   oblikovati-cli script run <file.lua> [--doc in.opd] [--save out.opd]
-  oblikovati-cli version`
+  oblikovati-cli version
+  oblikovati-cli check-updates`

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -63,11 +63,14 @@ func run(session *app.Session, maxFrames int) error {
 	defer addins.stop(session)
 	ui.SetScriptController(addins.script) // the Manage ▸ Script Console panel drives this runtime
 
+	updates := newUpdatePoller()
+	startupUpdateCheck(session, updates) // silent check on launch (honors the user's preference)
+
 	for frame := 0; ; frame++ {
 		if maxFrames > 0 && frame >= maxFrames {
 			break
 		}
-		if pumpFrame(win, session, addins) {
+		if pumpFrame(win, session, addins, updates) {
 			break
 		}
 	}
@@ -78,13 +81,14 @@ func run(session *app.Session, maxFrames int) error {
 // calls, and the close prompt. It returns true when the loop should exit — the user closed
 // the window, or a rebuilt add-in on disk needs the supervisor to relaunch (a Go c-shared
 // cannot be hot-swapped in-process).
-func pumpFrame(win *native.Window, session *app.Session, addins *addInHost) bool {
+func pumpFrame(win *native.Window, session *app.Session, addins *addInHost, updates *updatePoller) bool {
 	win.BeginFrame()
 	if id := ui.DrawChrome(win, session); id != "" {
 		if execErr := session.Execute(id); execErr != nil {
 			fmt.Fprintf(os.Stderr, "command %q: %v\n", id, execErr)
 		}
 	}
+	serviceUpdates(session, updates) // publish a finished update check; start a manual one
 	addins.drain()
 	exit := ui.HandleClose(win, session)
 	win.EndFrame(ui.WindowClearColor())   // themed swapchain background (ADR-0021)

--- a/head/cmd/oblikovati-head/updates.go
+++ b/head/cmd/oblikovati-head/updates.go
@@ -1,0 +1,94 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"oblikovati.org/app"
+	"oblikovati.org/build"
+	"oblikovati.org/update"
+)
+
+// updateHTTPTimeout bounds the GitHub query so a slow or missing network never blocks the
+// frame loop (the check runs off-thread, but the timeout also frees that goroutine).
+const updateHTTPTimeout = 8 * time.Second
+
+// updateOutcome pairs a check result with whether it came from a manual Help ▸ Check for
+// Updates: a manual check always opens the window (even "you're up to date"), while the
+// silent startup check only surfaces when there is actually a newer release to offer.
+type updateOutcome struct {
+	res    update.Result
+	manual bool
+}
+
+// updatePoller runs the GitHub update check off the UI thread and hands the result back
+// to the (single-threaded) session through an atomic pointer the frame loop drains — the
+// session is never touched from the network goroutine.
+type updatePoller struct {
+	checker *update.Checker
+	version string
+	outcome atomic.Pointer[updateOutcome]
+	busy    atomic.Bool // one in-flight check at a time
+}
+
+// newUpdatePoller builds a poller querying the published GitHub repository.
+func newUpdatePoller() *updatePoller {
+	src := update.NewGitHubSource(update.DefaultOwner, update.DefaultRepo, &http.Client{Timeout: updateHTTPTimeout})
+	return &updatePoller{checker: update.NewChecker(src), version: build.Version}
+}
+
+// launch starts a check unless one is already running. manual marks a user-triggered
+// check (vs. the startup auto-check) so serviceUpdates knows whether to pop the window.
+func (p *updatePoller) launch(manual bool) {
+	if !p.busy.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer p.busy.Store(false)
+		ctx, cancel := context.WithTimeout(context.Background(), updateHTTPTimeout)
+		defer cancel()
+		res, err := p.checker.Check(ctx, p.version)
+		if err != nil {
+			res = update.Result{
+				Channel: update.DetectChannel(p.version), Current: p.version,
+				Skipped: true, SkipReason: "check failed",
+			}
+		}
+		p.outcome.Store(&updateOutcome{res: res, manual: manual})
+	}()
+}
+
+// take returns and clears a completed check's outcome, if any.
+func (p *updatePoller) take() (*updateOutcome, bool) {
+	o := p.outcome.Swap(nil)
+	return o, o != nil
+}
+
+// startupUpdateCheck launches the silent auto-check when the user has it enabled.
+func startupUpdateCheck(s *app.Session, p *updatePoller) {
+	if s.UpdateChecksEnabled() {
+		p.launch(false)
+	}
+}
+
+// serviceUpdates is called each frame: it starts a manual check when Help ▸ Check for
+// Updates was clicked, and publishes any completed outcome into the session — always for
+// a manual check, but only on a real update for the silent startup check.
+func serviceUpdates(s *app.Session, p *updatePoller) {
+	if s.TakeUpdateCheckRequest() {
+		p.launch(true)
+	}
+	o, ok := p.take()
+	if !ok {
+		return
+	}
+	if o.manual || o.res.UpdateAvailable {
+		s.ShowUpdateResult(o.res)
+	}
+}

--- a/head/cmd/oblikovati-head/updates_test.go
+++ b/head/cmd/oblikovati-head/updates_test.go
@@ -1,0 +1,61 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/update"
+)
+
+// upToDate / available are canned results for the service-gating tests.
+func upToDate() update.Result {
+	return update.Result{Channel: update.Stable, Current: "0.0.1"}
+}
+func available() update.Result {
+	return update.Result{
+		Channel: update.Stable, Current: "0.0.1", UpdateAvailable: true,
+		Latest: update.Release{Version: "0.0.2", HTMLURL: "https://gh/r"},
+	}
+}
+
+func TestServiceUpdatesManualAlwaysShows(t *testing.T) {
+	s := app.NewSession()
+	p := &updatePoller{}
+	p.outcome.Store(&updateOutcome{res: upToDate(), manual: true})
+	serviceUpdates(s, p)
+	if s.PendingUpdate() == nil {
+		t.Fatal("a manual check must open the window even when up to date")
+	}
+}
+
+func TestServiceUpdatesAutoSuppressesUpToDate(t *testing.T) {
+	s := app.NewSession()
+	p := &updatePoller{}
+	p.outcome.Store(&updateOutcome{res: upToDate(), manual: false})
+	serviceUpdates(s, p)
+	if s.PendingUpdate() != nil {
+		t.Fatal("the silent startup check must not nag when up to date")
+	}
+}
+
+func TestServiceUpdatesAutoShowsAvailable(t *testing.T) {
+	s := app.NewSession()
+	p := &updatePoller{}
+	p.outcome.Store(&updateOutcome{res: available(), manual: false})
+	serviceUpdates(s, p)
+	if s.PendingUpdate() == nil || !s.PendingUpdate().UpdateAvailable {
+		t.Fatal("the startup check must surface a real update")
+	}
+}
+
+func TestServiceUpdatesNoOutcomeIsNoop(t *testing.T) {
+	s := app.NewSession()
+	serviceUpdates(s, &updatePoller{})
+	if s.PendingUpdate() != nil {
+		t.Fatal("no completed check should leave the window closed")
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -142,6 +142,7 @@ func drawChromeWindows(s *app.Session) {
 	drawScriptConsole(s)
 	drawKeymapEditor(s)                 // Tools ▸ Customize Keyboard (M05-F17)
 	drawCommandInput(s)                 // command-alias input box (M05-F17)
+	drawUpdateWindow(s)                 // Help ▸ Check for Updates notification
 	drawAddInPanels(s)                  // add-in dockable windows (M05-F03)
 	drawMessagingSurfaces(s)            // toasts, prompt modal, message center (M05-F09)
 	drawWebViews(s)                     // web dialogs/views (M05-F08)

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -18,8 +18,26 @@ func drawMenuBar(s *app.Session) {
 	drawFileMenu(s)
 	drawEditMenu(s)
 	drawToolsMenu(s)
+	drawHelpMenu(s)
 	drawCommandSearch(s) // the command search box (M05-F12)
 	native.EndMainMenuBar()
+}
+
+// drawHelpMenu is the Help menu: product documentation (F1) and a manual update check.
+// "Check for Updates" requests the (network) check, which the head runs off-thread and
+// reports back through the Software Update window — so it works even while the
+// application is running, per the manual-check requirement.
+func drawHelpMenu(s *app.Session) {
+	if native.BeginMenu("Help") {
+		if native.MenuItem("Documentation") {
+			_ = s.DisplayHelpTopic("", "")
+		}
+		native.Separator()
+		if native.MenuItem("Check for Updates") {
+			s.RequestUpdateCheck()
+		}
+		native.EndMenu()
+	}
 }
 
 func drawFileMenu(s *app.Session) {

--- a/head/ui/update_text.go
+++ b/head/ui/update_text.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+
+	"oblikovati.org/update"
+)
+
+// updateHeadline is the one-line status shown at the top of the Software Update window.
+// It is the pure text half of the window (no native calls) so it stays unit-testable
+// without the cgo/Vulkan head.
+func updateHeadline(res *update.Result) string {
+	if res.Skipped {
+		return "Update check skipped: " + skipHeadline(res)
+	}
+	if res.UpdateAvailable {
+		return fmt.Sprintf("A new %s release is available: %s", res.Channel, res.Latest.Version)
+	}
+	return fmt.Sprintf("You are up to date (%s %s).", res.Channel, res.Current)
+}
+
+// skipHeadline expands a skip reason into a sentence for the window.
+func skipHeadline(res *update.Result) string {
+	switch res.SkipReason {
+	case "offline":
+		return "no internet connection."
+	case "development build":
+		return "this is a development build."
+	case "no published release":
+		return "no release published on the " + res.Channel.String() + " channel yet."
+	case "check failed":
+		return "could not reach the update server."
+	default:
+		return res.SkipReason + "."
+	}
+}

--- a/head/ui/update_text_test.go
+++ b/head/ui/update_text_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/update"
+)
+
+func TestUpdateHeadline(t *testing.T) {
+	cases := []struct {
+		name string
+		res  update.Result
+		want string
+	}{
+		{
+			name: "available",
+			res: update.Result{
+				Channel: update.Nightly, UpdateAvailable: true,
+				Latest: update.Release{Version: "0.0.20260615030000-nightly"},
+			},
+			want: "new nightly release is available: 0.0.20260615030000-nightly",
+		},
+		{
+			name: "up to date",
+			res:  update.Result{Channel: update.Stable, Current: "0.0.1"},
+			want: "up to date (stable 0.0.1)",
+		},
+		{name: "offline", res: skipResult("offline", update.Stable), want: "no internet connection"},
+		{name: "dev", res: skipResult("development build", update.Dev), want: "development build"},
+		{name: "no release", res: skipResult("no published release", update.Nightly), want: "nightly channel yet"},
+		{name: "failed", res: skipResult("check failed", update.Stable), want: "could not reach the update server"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := updateHeadline(&c.res); !strings.Contains(got, c.want) {
+				t.Errorf("updateHeadline(%s) = %q, missing %q", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+func skipResult(reason string, ch update.Channel) update.Result {
+	return update.Result{Channel: ch, Skipped: true, SkipReason: reason}
+}

--- a/head/ui/update_window.go
+++ b/head/ui/update_window.go
@@ -1,0 +1,59 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/update"
+)
+
+// drawUpdateWindow renders the software-update notification when a check result is
+// pending ([app.Session.PendingUpdate]). It shows whether a newer release exists, offers
+// a direct link to the GitHub release page, and lets the user turn off the startup check
+// — the toggle persists to the user's options (Updates.CheckOnStartup).
+func drawUpdateWindow(s *app.Session) {
+	res := s.PendingUpdate()
+	if res == nil {
+		return
+	}
+	native.SetNextWindowSizeOnce(420, 200)
+	if native.Begin("Software Update") {
+		drawUpdateBody(s, res)
+	}
+	native.End()
+}
+
+// drawUpdateBody renders the window contents for a pending result.
+func drawUpdateBody(s *app.Session, res *update.Result) {
+	native.Text(updateHeadline(res))
+	native.Separator()
+	if res.UpdateAvailable {
+		drawReleaseLink(s, res)
+	}
+	drawStartupToggle(s)
+	native.Separator()
+	if native.Button("Close") {
+		s.DismissUpdate()
+	}
+}
+
+// drawReleaseLink renders the button that opens the release's GitHub page via the
+// platform URL opener.
+func drawReleaseLink(s *app.Session, res *update.Result) {
+	native.Text("Current: " + res.Current)
+	if native.Button("Open Release Page") {
+		_ = s.OpenLatestReleasePage()
+	}
+	native.Separator()
+}
+
+// drawStartupToggle renders the "check on startup" checkbox, persisting changes.
+func drawStartupToggle(s *app.Session) {
+	check := s.UpdateChecksEnabled()
+	if native.Checkbox("Check for updates on startup", &check) {
+		_ = s.SetUpdateChecksEnabled(check)
+	}
+}

--- a/update/channel.go
+++ b/update/channel.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package update checks GitHub for a newer Oblikovati release on the running
+// build's channel. The host (GUI head) and the CLI both consult it; it owns only
+// the version comparison and the GitHub query (behind the [ReleaseSource] seam) —
+// callers own how the result is surfaced (a status-bar notice, a window, a line of
+// CLI text) and whether to honor the user's "check on startup" preference.
+//
+// A build's channel is derived from its linker-stamped version
+// ([oblikovati.org/build.Version]): a "-nightly" prerelease comes from the rolling
+// nightly prerelease, a plain MAJOR.MINOR.PATCH from a stable release, and "dev"
+// (a local build) from no channel at all — so a developer's build never nags.
+package update
+
+import "strings"
+
+// Channel is the release stream a build belongs to. The host only ever compares a
+// build against the latest release on its OWN channel (a nightly user is offered the
+// next nightly, not a far-older stable), mirroring how nightly.yml and release.yml
+// publish (see those workflows).
+type Channel int
+
+const (
+	// Dev is a local build (build.Version "dev" or empty): there is nothing to
+	// compare against, so the checker reports a skip and never touches the network.
+	Dev Channel = iota
+	// Stable is a tagged release from the `release` branch (release.yml).
+	Stable
+	// Nightly is the rolling prerelease from `develop` (nightly.yml).
+	Nightly
+)
+
+// nightlySuffix is the semver prerelease tag scripts/version.sh appends to a nightly
+// build's version (e.g. "0.0.20260614120000-nightly").
+const nightlySuffix = "-nightly"
+
+// String renders the channel for user-facing text and logs.
+func (c Channel) String() string {
+	switch c {
+	case Stable:
+		return "stable"
+	case Nightly:
+		return "nightly"
+	default:
+		return "dev"
+	}
+}
+
+// DetectChannel classifies a linker-stamped build version into its release channel.
+// An empty or "dev" version is a local build (Dev); a "-nightly" prerelease suffix is
+// Nightly; anything else is a Stable release.
+func DetectChannel(version string) Channel {
+	switch {
+	case version == "" || version == "dev":
+		return Dev
+	case strings.HasSuffix(version, nightlySuffix):
+		return Nightly
+	default:
+		return Stable
+	}
+}

--- a/update/channel_test.go
+++ b/update/channel_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import "testing"
+
+func TestDetectChannel(t *testing.T) {
+	cases := []struct {
+		version string
+		want    Channel
+	}{
+		{"", Dev},
+		{"dev", Dev},
+		{"0.0.20260614120000", Stable},
+		{"v0.0.20260614120000", Stable}, // a leading v is still a stable release
+		{"0.0.20260614120000-nightly", Nightly},
+		{"1.4.20260614120000-nightly", Nightly},
+	}
+	for _, c := range cases {
+		if got := DetectChannel(c.version); got != c.want {
+			t.Errorf("DetectChannel(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+func TestChannelString(t *testing.T) {
+	cases := map[Channel]string{Dev: "dev", Stable: "stable", Nightly: "nightly"}
+	for ch, want := range cases {
+		if got := ch.String(); got != want {
+			t.Errorf("Channel(%d).String() = %q, want %q", ch, got, want)
+		}
+	}
+}

--- a/update/checker.go
+++ b/update/checker.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import (
+	"context"
+	"errors"
+)
+
+// Checker compares the running build against the latest release on its channel through
+// an injected [ReleaseSource]. Construct it once and reuse it for both the startup
+// auto-check and the manual "Check for Updates" command.
+type Checker struct{ source ReleaseSource }
+
+// NewChecker returns a checker that queries source.
+func NewChecker(source ReleaseSource) *Checker { return &Checker{source: source} }
+
+// Check reports whether a newer release than current exists on current's channel.
+//
+// It never returns an error for the expected "nothing to offer" cases — a dev build, an
+// offline machine, or a channel with no release — those come back as Skipped with a
+// reason, so the GUI can show "you're up to date / offline" and the CLI can stay quiet.
+// Only an unexpected failure (bad response, HTTP 5xx) is returned as an error.
+//
+//	res, err := chk.Check(ctx, build.Version)
+//	if err == nil && res.UpdateAvailable { notify(res.Latest.HTMLURL) }
+func (c *Checker) Check(ctx context.Context, current string) (Result, error) {
+	res := Result{Channel: DetectChannel(current), Current: current}
+	if res.Channel == Dev {
+		return skip(res, "development build"), nil
+	}
+	latest, err := c.source.Latest(ctx, res.Channel)
+	if errors.Is(err, ErrOffline) {
+		return skip(res, "offline"), nil
+	}
+	if errors.Is(err, ErrNoRelease) {
+		return skip(res, "no published release"), nil
+	}
+	if err != nil {
+		return res, err
+	}
+	res.Latest = latest
+	res.UpdateAvailable = IsNewer(latest.Version, current)
+	return res, nil
+}
+
+// skip marks a result as a graceful no-op with the given reason.
+func skip(res Result, reason string) Result {
+	res.Skipped = true
+	res.SkipReason = reason
+	return res
+}

--- a/update/checker_test.go
+++ b/update/checker_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeSource is a named ReleaseSource returning a canned release or error per channel.
+type fakeSource struct {
+	rel    Release
+	err    error
+	gotCh  Channel
+	called bool
+}
+
+func (f *fakeSource) Latest(_ context.Context, ch Channel) (Release, error) {
+	f.called, f.gotCh = true, ch
+	return f.rel, f.err
+}
+
+func TestCheckDevBuildNeverQueries(t *testing.T) {
+	src := &fakeSource{}
+	res, err := NewChecker(src).Check(context.Background(), "dev")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if src.called {
+		t.Error("a dev build must not touch the network")
+	}
+	if !res.Skipped || res.SkipReason != "development build" {
+		t.Errorf("got %+v, want skipped development build", res)
+	}
+}
+
+func TestCheckOfflineIsGracefulSkip(t *testing.T) {
+	src := &fakeSource{err: ErrOffline}
+	res, err := NewChecker(src).Check(context.Background(), "0.0.20260614120000")
+	if err != nil {
+		t.Fatalf("offline must not be an error, got %v", err)
+	}
+	if !res.Skipped || res.SkipReason != "offline" {
+		t.Errorf("got %+v, want skipped offline", res)
+	}
+}
+
+func TestCheckNoReleaseIsGracefulSkip(t *testing.T) {
+	src := &fakeSource{err: ErrNoRelease}
+	res, _ := NewChecker(src).Check(context.Background(), "0.0.20260614120000")
+	if !res.Skipped || res.SkipReason != "no published release" {
+		t.Errorf("got %+v, want skipped no published release", res)
+	}
+}
+
+func TestCheckUnexpectedErrorPropagates(t *testing.T) {
+	boom := errors.New("github 503")
+	src := &fakeSource{err: boom}
+	if _, err := NewChecker(src).Check(context.Background(), "0.0.20260614120000"); !errors.Is(err, boom) {
+		t.Fatalf("want the underlying error, got %v", err)
+	}
+}
+
+func TestCheckUpdateAvailableUsesChannel(t *testing.T) {
+	src := &fakeSource{rel: Release{Version: "0.0.20260615030000-nightly", HTMLURL: "https://x/r"}}
+	res, err := NewChecker(src).Check(context.Background(), "0.0.20260614120000-nightly")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if src.gotCh != Nightly {
+		t.Errorf("queried channel %v, want Nightly", src.gotCh)
+	}
+	if !res.UpdateAvailable || res.Latest.HTMLURL != "https://x/r" {
+		t.Errorf("got %+v, want update available with the release URL", res)
+	}
+}
+
+func TestCheckUpToDate(t *testing.T) {
+	src := &fakeSource{rel: Release{Version: "0.0.20260614120000"}}
+	res, _ := NewChecker(src).Check(context.Background(), "0.0.20260614120000")
+	if res.UpdateAvailable || res.Skipped {
+		t.Errorf("got %+v, want no update and not skipped", res)
+	}
+}

--- a/update/github.go
+++ b/update/github.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// httpDoer is the one method of *http.Client this package needs, named so tests can fake
+// the transport without a live server (CLAUDE.md: wrap external I/O behind a thin seam).
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// GitHubSource reads releases from the GitHub REST API. It maps a [Channel] to the right
+// endpoint — stable to the repo's "latest" release, nightly to the rolling `nightly`
+// tag — mirroring how release.yml and nightly.yml publish them.
+type GitHubSource struct {
+	owner, repo string
+	apiBase     string // overridable for tests; defaults to the public API host
+	http        httpDoer
+}
+
+// DefaultOwner/DefaultRepo are the published Oblikovati repository on GitHub.
+const (
+	DefaultOwner = "Oblikovati"
+	DefaultRepo  = "Oblikovati"
+)
+
+// defaultAPIBase is the public GitHub REST API host.
+const defaultAPIBase = "https://api.github.com"
+
+// maxReleaseBody caps the JSON we read from GitHub (a release object is a few KiB); it
+// bounds memory if the endpoint ever misbehaves.
+const maxReleaseBody = 1 << 20
+
+// NewGitHubSource returns a source for owner/repo over doer (typically an *http.Client
+// with a short timeout so a slow network never blocks startup).
+func NewGitHubSource(owner, repo string, doer httpDoer) *GitHubSource {
+	return &GitHubSource{owner: owner, repo: repo, apiBase: defaultAPIBase, http: doer}
+}
+
+// Latest fetches the newest release on channel, translating connectivity failures to
+// [ErrOffline] and a missing release to [ErrNoRelease] so the checker can skip them.
+func (g *GitHubSource) Latest(ctx context.Context, channel Channel) (Release, error) {
+	raw, err := g.get(ctx, g.endpoint(channel))
+	if err != nil {
+		return Release{}, err
+	}
+	return parseRelease(raw, channel)
+}
+
+// endpoint is the releases API URL for channel: the moving `nightly` tag for nightly, the
+// "latest" (newest non-prerelease) for stable.
+func (g *GitHubSource) endpoint(channel Channel) string {
+	if channel == Nightly {
+		return fmt.Sprintf("%s/repos/%s/%s/releases/tags/nightly", g.apiBase, g.owner, g.repo)
+	}
+	return fmt.Sprintf("%s/repos/%s/%s/releases/latest", g.apiBase, g.owner, g.repo)
+}
+
+// get performs the request and returns the body, mapping transport errors to ErrOffline
+// and a 404 to ErrNoRelease.
+func (g *GitHubSource) get(ctx context.Context, endpoint string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("update: build request for %q: %w", endpoint, err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := g.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOffline, err) // no network / DNS / timeout
+	}
+	defer resp.Body.Close()
+	return readReleaseBody(resp, endpoint)
+}
+
+// readReleaseBody validates the status and returns the capped body.
+func readReleaseBody(resp *http.Response, endpoint string) ([]byte, error) {
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNoRelease
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("update: GET %q: %s", endpoint, resp.Status)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, maxReleaseBody))
+}
+
+// ghRelease is the subset of GitHub's release object we use.
+type ghRelease struct {
+	TagName string `json:"tag_name"`
+	Name    string `json:"name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// parseRelease turns a GitHub release JSON into a [Release], deriving the comparable
+// version from the right field for the channel.
+func parseRelease(raw []byte, channel Channel) (Release, error) {
+	var gr ghRelease
+	if err := json.Unmarshal(raw, &gr); err != nil {
+		return Release{}, fmt.Errorf("update: parse release JSON: %w", err)
+	}
+	ver := releaseVersion(gr, channel)
+	if ver == "" {
+		return Release{}, fmt.Errorf("update: release has no version (tag=%q name=%q)", gr.TagName, gr.Name)
+	}
+	return Release{Version: ver, HTMLURL: gr.HTMLURL, Channel: channel}, nil
+}
+
+// releaseVersion reads the comparable version: a stable release carries it in the
+// "v<version>" tag, but the nightly tag is the fixed string "nightly", so its version
+// lives in the title ("Nightly <version>"), set by nightly.yml.
+func releaseVersion(gr ghRelease, channel Channel) string {
+	if channel == Nightly {
+		return lastField(gr.Name)
+	}
+	return strings.TrimPrefix(gr.TagName, "v")
+}
+
+// lastField returns the final whitespace-separated token of s (the version in a
+// "Nightly <version>" title), or "" when s has none.
+func lastField(s string) string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}

--- a/update/github_test.go
+++ b/update/github_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// fakeDoer is a named httpDoer returning a canned response/error and recording the URL.
+type fakeDoer struct {
+	status int
+	body   string
+	err    error
+	gotURL string
+	gotHdr string
+}
+
+func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	f.gotURL = req.URL.String()
+	f.gotHdr = req.Header.Get("Accept")
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &http.Response{
+		StatusCode: f.status,
+		Status:     http.StatusText(f.status),
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+	}, nil
+}
+
+func newSource(d *fakeDoer) *GitHubSource {
+	s := NewGitHubSource(DefaultOwner, DefaultRepo, d)
+	s.apiBase = "https://api.test"
+	return s
+}
+
+func TestLatestStableParsesTag(t *testing.T) {
+	d := &fakeDoer{status: 200, body: `{"tag_name":"v0.0.20260614120000","html_url":"https://gh/r1"}`}
+	rel, err := newSource(d).Latest(context.Background(), Stable)
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	if rel.Version != "0.0.20260614120000" || rel.HTMLURL != "https://gh/r1" || rel.Channel != Stable {
+		t.Errorf("got %+v", rel)
+	}
+	if !strings.HasSuffix(d.gotURL, "/releases/latest") {
+		t.Errorf("stable hit %q, want /releases/latest", d.gotURL)
+	}
+	if d.gotHdr != "application/vnd.github+json" {
+		t.Errorf("Accept header = %q", d.gotHdr)
+	}
+}
+
+func TestLatestNightlyParsesTitle(t *testing.T) {
+	d := &fakeDoer{status: 200, body: `{"tag_name":"nightly","name":"Nightly 0.0.20260615030000-nightly","html_url":"https://gh/n"}`}
+	rel, err := newSource(d).Latest(context.Background(), Nightly)
+	if err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+	if rel.Version != "0.0.20260615030000-nightly" {
+		t.Errorf("nightly version = %q", rel.Version)
+	}
+	if !strings.HasSuffix(d.gotURL, "/releases/tags/nightly") {
+		t.Errorf("nightly hit %q, want /releases/tags/nightly", d.gotURL)
+	}
+}
+
+func TestLatestTransportErrorIsOffline(t *testing.T) {
+	d := &fakeDoer{err: errors.New("dial tcp: no route to host")}
+	_, err := newSource(d).Latest(context.Background(), Stable)
+	if !errors.Is(err, ErrOffline) {
+		t.Fatalf("want ErrOffline, got %v", err)
+	}
+}
+
+func TestLatest404IsNoRelease(t *testing.T) {
+	d := &fakeDoer{status: 404, body: `{"message":"Not Found"}`}
+	_, err := newSource(d).Latest(context.Background(), Nightly)
+	if !errors.Is(err, ErrNoRelease) {
+		t.Fatalf("want ErrNoRelease, got %v", err)
+	}
+}
+
+func TestLatest500IsError(t *testing.T) {
+	d := &fakeDoer{status: 500, body: ``}
+	_, err := newSource(d).Latest(context.Background(), Stable)
+	if err == nil || errors.Is(err, ErrOffline) || errors.Is(err, ErrNoRelease) {
+		t.Fatalf("a 5xx must be a hard error, got %v", err)
+	}
+}
+
+func TestLatestMissingVersionIsError(t *testing.T) {
+	d := &fakeDoer{status: 200, body: `{"tag_name":"nightly","name":""}`}
+	if _, err := newSource(d).Latest(context.Background(), Nightly); err == nil {
+		t.Fatal("a release with no parseable version must error")
+	}
+}

--- a/update/release.go
+++ b/update/release.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import (
+	"context"
+	"errors"
+)
+
+// Release is a published release on a channel: the version to compare against and the
+// URL of its GitHub page (where the user downloads it).
+type Release struct {
+	Version string
+	HTMLURL string
+	Channel Channel
+}
+
+// Result is the outcome of a check, designed so a caller never has to interpret an
+// error to render the common cases: an offline machine, a dev build, or a channel with
+// no published release all come back as a graceful Skipped result, not an error. Only an
+// unexpected failure (a malformed response, an HTTP 5xx) is returned as an error.
+type Result struct {
+	Channel         Channel
+	Current         string  // the running build's version
+	Latest          Release // the newest release on the channel; zero when Skipped
+	UpdateAvailable bool
+	Skipped         bool
+	SkipReason      string // human-readable: "development build", "offline", "no published release"
+}
+
+// ErrOffline marks a transport-level failure (no network, DNS failure, timeout): the
+// checker converts it into a Skipped result so the auto-check stays silent offline, per
+// the requirement to skip the verification when there is no internet.
+var ErrOffline = errors.New("update: release server unreachable")
+
+// ErrNoRelease marks a channel that has no published release yet (GitHub 404): also a
+// graceful skip, not a failure the user should see.
+var ErrNoRelease = errors.New("update: no release published on channel")
+
+// ReleaseSource fetches the latest release on a channel. It is the seam tests fake and
+// [GitHubSource] implements, keeping the network I/O out of the comparison logic.
+type ReleaseSource interface {
+	Latest(ctx context.Context, channel Channel) (Release, error)
+}

--- a/update/version.go
+++ b/update/version.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import (
+	"strconv"
+	"strings"
+)
+
+// IsNewer reports whether latest is a strictly greater release than current. Both are
+// the project's MAJOR.MINOR.PATCH[-prerelease] strings (see scripts/version.sh): the
+// PATCH is a UTC build timestamp, so within a channel the comparison is monotonic. The
+// prerelease suffix is ignored — a nightly is only ever compared to other nightlies,
+// which all carry the same "-nightly" tag, so the numeric core is what differs.
+//
+//	IsNewer("0.0.20260615030000", "0.0.20260614120000") // => true
+func IsNewer(latest, current string) bool { return compareCore(latest, current) > 0 }
+
+// compareCore compares the numeric MAJOR.MINOR.PATCH cores of two versions, returning
+// -1, 0, or 1. A leading "v" and any "-prerelease" suffix are stripped first.
+func compareCore(a, b string) int {
+	ax, bx := coreParts(a), coreParts(b)
+	for i := 0; i < 3; i++ {
+		switch {
+		case ax[i] > bx[i]:
+			return 1
+		case ax[i] < bx[i]:
+			return -1
+		}
+	}
+	return 0
+}
+
+// coreParts extracts [MAJOR, MINOR, PATCH] as int64 (PATCH is a 14-digit timestamp, too
+// large for a 32-bit int). A missing or non-numeric component is treated as 0, so a
+// malformed version sorts low rather than panicking the caller.
+func coreParts(v string) [3]int64 {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		v = v[:i]
+	}
+	var out [3]int64
+	for i, p := range strings.SplitN(v, ".", 3) {
+		out[i], _ = strconv.ParseInt(strings.TrimSpace(p), 10, 64)
+	}
+	return out
+}

--- a/update/version_test.go
+++ b/update/version_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package update
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"0.0.20260615030000", "0.0.20260614120000", true},                 // later nightly timestamp
+		{"0.0.20260614120000", "0.0.20260615030000", false},                // older
+		{"0.0.20260614120000", "0.0.20260614120000", false},                // equal
+		{"0.1.20260101000000", "0.0.20260615030000", true},                 // minor bump beats a newer timestamp
+		{"1.0.20260101000000", "0.9.20260615030000", true},                 // major bump
+		{"v0.0.20260615030000", "0.0.20260614120000", true},                // leading v on latest
+		{"0.0.20260615030000-nightly", "0.0.20260614120000-nightly", true}, // prerelease ignored
+		{"0.0.20260615030000-nightly", "0.0.20260615030000-nightly", false},
+	}
+	for _, c := range cases {
+		if got := IsNewer(c.latest, c.current); got != c.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+// TestPatchTimestampExceedsInt32 guards the int64 parse: a 14-digit timestamp PATCH
+// overflows a 32-bit int, which would corrupt the comparison on a 32-bit build.
+func TestPatchTimestampExceedsInt32(t *testing.T) {
+	if !IsNewer("0.0.20260101000001", "0.0.20260101000000") {
+		t.Fatal("timestamp PATCH must compare as int64, not overflow")
+	}
+}


### PR DESCRIPTION
## What

Adds software-update notifications to the application:

- **GUI head:** a new **Help** menu (Documentation + **Check for Updates**) and a **Software Update** window. On launch the head silently checks GitHub for a newer release; when one exists it opens the window with a **direct link to the GitHub release page**. The window has a **"Check for updates on startup"** toggle that persists. Manual **Help ▸ Check for Updates** works while the app is running and always shows the result.
- **CLI:** `oblikovati-cli check-updates` prints a plain-text result with the download link.
- **Preference:** a per-user `Updates.CheckOnStartup` option (default on), saved in the user options file; the notification's toggle writes it.

## Why / behavior

- **Channel-aware:** the check compares against the latest release on the running build's *own* channel — a nightly build is offered the next nightly, a stable build the next stable — derived from the linker-stamped `build.Version` (`-nightly` prerelease vs plain semver), mirroring how `nightly.yml`/`release.yml` publish.
- **Dev builds never check** (`build.Version == "dev"`), so local development is never nagged.
- **Skips when offline:** a transport failure (no internet/DNS/timeout) is a graceful skip, not an error; likewise a channel with no published release (HTTP 404).
- **Off the UI thread:** the GUI check runs on a goroutine and hands its result back through an atomic pointer the frame loop drains, so the single-threaded session is never touched concurrently and a slow network never stalls a frame.

## Design

The new `oblikovati.org/update` package owns only the version comparison and the GitHub query (behind a `ReleaseSource`/`httpDoer` seam); the session owns the user-visible state (window, notice, persisted toggle); the head owns the network + threading. This keeps the whole flow unit-testable without a live GitHub or a window (ADR-0014).

## Tests

- `update`: channel detection, version comparison (incl. int64 timestamp PATCH), checker skip/available/error paths, GitHub parsing for both channels + 404/transport/5xx mapping (named `fakeDoer`/`fakeSource`).
- `app`: preference persistence, one-shot manual-check request, notice-on-available, release-page open.
- CLI: message formatter table.
- head: window headline text + service-gating (manual always shows, silent startup only on a real update).

## Live verification

Built the CLI with stamped versions against the real `Oblikovati/Oblikovati` repo (which currently has a nightly prerelease and no stable):

- old nightly → `A new nightly release is available: 0.0.20260614071613-nightly` + release URL
- newer nightly → `You are running the latest nightly release`
- stable → `skipped: no release published on the stable channel yet` (404)
- dev → `skipped: this is a development build`
- transient network failure → `skipped: no internet connection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)