### PR TITLE
feat: assembly joint drive & animation (M12-F03)

### DIFF
--- a/addin/router/assembly_drive.go
+++ b/addin/router/assembly_drive.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/assembly"
+)
+
+// The assembly drive surface (M12-F03, #366): sweep a joint's driven variable through a range
+// and return the per-step occurrence placements — the frames of a kinematic motion study.
+// Each step re-solves the active assembly with the variable pinned; with collision detection
+// the sweep halts at the first interfering frame. The drive is non-destructive (the engine
+// restores the assembly), so preview leaves the model unchanged.
+
+// registerAssemblyDriveHandlers wires the assemblyDrive.* methods.
+func (r *Router) registerAssemblyDriveHandlers() {
+	r.handlers[wire.MethodAssemblyDrivePreview] = assemblyDrivePreview
+}
+
+// assemblyDrivePreview drives the requested joint through the given settings and returns the
+// resulting frames.
+func assemblyDrivePreview(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.DriveJointArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	res, err := asm.DriveJoint(in.Joint, driveSettingsFromWire(in.Settings))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(driveResultToWire(res))
+}
+
+// driveSettingsFromWire builds the engine's drive settings from the wire DTO.
+func driveSettingsFromWire(d wire.DriveSettingsDTO) assembly.DriveSettings {
+	return assembly.NewDriveSettings(driveVariable(d.Variable), d.Start, d.End, d.Step,
+		d.RepetitionCount, d.RepetitionStartEndStart, d.CollisionDetection)
+}
+
+// driveVariable maps a wire variable string to the enum (empty/unknown ⇒ the joint's natural
+// variable).
+func driveVariable(v string) types.DriveVariable {
+	switch v {
+	case "angular":
+		return types.DriveAngular
+	case "linear":
+		return types.DriveLinear
+	default:
+		return types.DriveNatural
+	}
+}
+
+// driveResultToWire encodes the engine's drive frames into the wire result.
+func driveResultToWire(res assembly.DriveResult) wire.DriveResult {
+	frames := make([]wire.DriveFrame, 0, len(res.Frames))
+	for _, f := range res.Frames {
+		frames = append(frames, wire.DriveFrame{Value: f.Value, Collided: f.Collided, Placements: drivePlacements(f.Placements)})
+	}
+	return wire.DriveResult{Frames: frames, StoppedByCollision: res.StoppedByCollision, StoppedAtStep: res.StoppedAtStep}
+}
+
+// drivePlacements encodes one frame's occurrence transforms into the wire form.
+func drivePlacements(ps []assembly.OccurrencePlacement) []wire.DrivePlacement {
+	out := make([]wire.DrivePlacement, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, wire.DrivePlacement{Occurrence: p.Occurrence, Transform: types.Matrix{Cells: p.Transform.Cells()}})
+	}
+	return out
+}

--- a/addin/router/assembly_drive_test.go
+++ b/addin/router/assembly_drive_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestAssemblyDrivePreviewOverWire adds a rotational joint between two boxes' shared edge axis,
+// then drives it through a range over the wire and checks the frames advance the moved
+// component's rotation — the F03 acceptance over the router (#366).
+func TestAssemblyDrivePreviewOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 5)
+	occs[0].SetGrounded(true)
+	edge := boxEdgeKey(t, occs[0])
+
+	var added wire.AssemblyJointResult
+	call(t, r, s, "assemblyJoints.addRotational", mustJSON(t, wire.AddJointArgs{
+		A: wire.ConstraintGeomRef{Occurrence: occs[0].ID(), Entity: edge},
+		B: wire.ConstraintGeomRef{Occurrence: occs[1].ID(), Entity: edge},
+	}), &added)
+
+	span := math.Pi / 2
+	var res wire.DriveResult
+	call(t, r, s, "assemblyDrive.preview", mustJSON(t, wire.DriveJointArgs{
+		Joint: added.Joint.ID,
+		Settings: wire.DriveSettingsDTO{
+			Variable: "angular", Start: 0, End: span, Step: span / 4,
+		},
+	}), &res)
+
+	if len(res.Frames) != 5 {
+		t.Fatalf("frames = %d, want 5", len(res.Frames))
+	}
+	for _, f := range res.Frames {
+		if len(f.Placements) != 1 || f.Placements[0].Occurrence != occs[1].ID() {
+			t.Fatalf("frame placements = %+v, want the one moved occurrence", f.Placements)
+		}
+	}
+	// The moved frame's orientation sweeps through the driven span (measured axis-independently
+	// from the relative rotation between the first and last frame).
+	first := res.Frames[0].Placements[0].Transform
+	last := res.Frames[len(res.Frames)-1].Placements[0].Transform
+	if delta := rotationAngleBetween(first, last); math.Abs(delta-span) > 1e-3 {
+		t.Errorf("driven rotation = %.4f rad, want ≈ %.4f", delta, span)
+	}
+}
+
+// TestAssemblyDriveUndrivableJointRejected checks a rigid joint (0 DOF) is a clean error.
+func TestAssemblyDriveUndrivableJointRejected(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 5)
+	occs[0].SetGrounded(true)
+	edge := boxEdgeKey(t, occs[0])
+
+	var added wire.AssemblyJointResult
+	call(t, r, s, "assemblyJoints.addRigid", mustJSON(t, wire.AddJointArgs{
+		A: wire.ConstraintGeomRef{Occurrence: occs[0].ID(), Entity: edge},
+		B: wire.ConstraintGeomRef{Occurrence: occs[1].ID(), Entity: edge},
+	}), &added)
+
+	args := mustJSON(t, wire.DriveJointArgs{Joint: added.Joint.ID, Settings: wire.DriveSettingsDTO{End: 1, Step: 0.5}})
+	if _, err := r.Handle(s, "assemblyDrive.preview", []byte(args)); err == nil {
+		t.Error("driving a rigid joint should fail (not drivable)")
+	}
+}
+
+// rotationAngleBetween returns the angle of the relative rotation between two rigid frames,
+// independent of the (unknown) joint axis: acos((trace(Aᵀ·B)−1)/2) over their 3×3 rotation
+// parts.
+func rotationAngleBetween(a, b types.Matrix) float64 {
+	trace := 0.0
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			trace += a.At(i, j) * b.At(i, j) // Σ a[i][j]·b[i][j] = trace(A·Bᵀ)
+		}
+	}
+	c := (trace - 1) / 2
+	if c > 1 {
+		c = 1
+	} else if c < -1 {
+		c = -1
+	}
+	return math.Acos(c)
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -61,6 +61,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyOccurrenceHandlers()
 	r.registerAssemblyConstraintHandlers()
 	r.registerAssemblyJointHandlers()
+	r.registerAssemblyDriveHandlers()
 	r.registerAssemblyReplicationHandlers()
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()

--- a/app/assembly_drive_ui_test.go
+++ b/app/assembly_drive_ui_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
+)
+
+// TestJointsPanelExposesDrive: the Joints panel carries the Drive command as a compact icon
+// button (M12-F03).
+func TestJointsPanelExposesDrive(t *testing.T) {
+	tab, ok := BuildRibbon(assemblySession(t)).Tab("Assemble")
+	if !ok {
+		t.Fatal("an active assembly should show the Assemble tab")
+	}
+	panel, ok := tab.Panel("Joints")
+	if !ok {
+		t.Fatal("Assemble tab has no Joints panel")
+	}
+	if !hasButton(panel, "Drive") {
+		t.Fatal("Joints panel is missing the Drive command")
+	}
+	if got, ok := styleOf(panel, "Drive"); !ok || got != CompactIconButton {
+		t.Errorf("Drive button style = %v, want CompactIconButton", got)
+	}
+}
+
+// TestDefaultDriveSettingsByKind: a rotational joint sweeps its angular range (a full turn
+// when unbounded), a slider its linear range.
+func TestDefaultDriveSettingsByKind(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	placedWidget(t, s, asm, "widget:2")
+	a, b := asm.Occurrences().Item(0), asm.Occurrences().Item(1)
+	z, _ := math.NewUnitVector3(0, 0, 1)
+	rot := asm.Joints().AddRotational(
+		assembly.Ref{Occurrence: a, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)},
+		assembly.Ref{Occurrence: b, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)})
+	slide := asm.Joints().AddSlider(
+		assembly.Ref{Occurrence: a, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)},
+		assembly.Ref{Occurrence: b, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)})
+
+	rs := defaultDriveSettings(rot)
+	if rs.Variable() != types.DriveAngular {
+		t.Errorf("rotational drive variable = %s, want angular", rs.Variable())
+	}
+	if _, end := rs.Range(); stdmath.Abs(end-2*stdmath.Pi) > 1e-9 {
+		t.Errorf("rotational drive end = %.4f, want 2π", end)
+	}
+	if ss := defaultDriveSettings(slide); ss.Variable() != types.DriveLinear {
+		t.Errorf("slider drive variable = %s, want linear", ss.Variable())
+	}
+}
+
+// TestSelectedDrivableJointGate: Drive enables only when a drivable joint is selected.
+func TestSelectedDrivableJointGate(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	placedWidget(t, s, asm, "widget:2")
+	a, b := asm.Occurrences().Item(0), asm.Occurrences().Item(1)
+	z, _ := math.NewUnitVector3(0, 0, 1)
+	rot := asm.Joints().AddRotational(
+		assembly.Ref{Occurrence: a, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)},
+		assembly.Ref{Occurrence: b, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)})
+
+	if hasSelectedDrivableJoint(s) {
+		t.Error("no selection: Drive should be disabled")
+	}
+	s.Selection().Add(AssemblyJointHandle{Joint: rot})
+	if !hasSelectedDrivableJoint(s) {
+		t.Error("rotational joint selected: Drive should be enabled")
+	}
+}
+
+// TestDrivePlaybackMovesThenRestores: starting playback and ticking moves the driven
+// component; stopping restores its pre-drive pose.
+func TestDrivePlaybackMovesThenRestores(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	placedWidget(t, s, asm, "widget:2")
+	a, b := asm.Occurrences().Item(0), asm.Occurrences().Item(1)
+	a.SetGrounded(true)
+	z, _ := math.NewUnitVector3(0, 0, 1)
+	rot := asm.Joints().AddRotational(
+		assembly.Ref{Occurrence: a, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)},
+		assembly.Ref{Occurrence: b, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), z)})
+
+	rest := b.Transform()
+	if err := s.StartDriveAnimation(rot.ID(), defaultDriveSettings(rot)); err != nil {
+		t.Fatalf("StartDriveAnimation: %v", err)
+	}
+	if !s.DriveAnimating() {
+		t.Fatal("DriveAnimating should be true after start")
+	}
+	s.TickDriveAnimation(driveFrameSeconds * 6) // advance to a rotated frame
+	if b.Transform().IsEqualTo(rest, 1e-9) {
+		t.Error("driven component did not move during playback")
+	}
+	s.StopDriveAnimation()
+	if s.DriveAnimating() {
+		t.Error("DriveAnimating should be false after stop")
+	}
+	if !b.Transform().IsEqualTo(rest, 1e-9) {
+		t.Error("stopping playback did not restore the rest pose")
+	}
+}

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -44,6 +44,7 @@ func jointCommands() []*CommandDefinition {
 			func(js *assembly.JointSet, r []assembly.Ref) assembly.Joint { return js.AddPlanar(r[0], r[1]) }),
 		jointCommand("Assembly.JointBall", "Ball", "joint-ball", "Ball joint — three rotations about a common point (3 DOF).",
 			func(js *assembly.JointSet, r []assembly.Ref) assembly.Joint { return js.AddBall(r[0], r[1]) }),
+		driveCommand(),
 	}
 }
 

--- a/app/drive_anim.go
+++ b/app/drive_anim.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
+	"oblikovati.org/model/occurrence"
+)
+
+// Joint drive playback (M12-F03, Oblikovati/Oblikovati#366): the Drive command precomputes a
+// joint's motion frames (assembly.DriveJoint) and the head plays them back, applying each
+// frame's occurrence placements so the assembly animates through the joint's range of motion.
+// Playback loops while active; stopping restores the pre-drive rest pose (the drive itself is
+// non-destructive). The cadence/looping logic is pure so it is unit-testable.
+
+// driveFrameSeconds is how long each motion frame is shown — the playback cadence.
+const driveFrameSeconds = 0.04
+
+// driveAnimation is an in-progress drive playback: the motion frames, the occurrences they
+// move, the rest pose to restore on stop, and the playback cursor.
+type driveAnimation struct {
+	frames    []assembly.DriveFrame
+	container *occurrence.Occurrences
+	occs      map[uint64]*occurrence.Occurrence
+	rest      map[uint64]math.Matrix4
+	elapsed   float64
+	active    bool
+}
+
+// StartDriveAnimation computes the joint's motion frames and begins playback. It errors when
+// there is no active assembly or the joint is not drivable; a drive with no frames is a no-op.
+func (s *Session) StartDriveAnimation(jointID uint64, settings assembly.DriveSettings) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	res, err := asm.DriveJoint(jointID, settings)
+	if err != nil {
+		return err
+	}
+	if len(res.Frames) == 0 {
+		return nil
+	}
+	occs, rest := map[uint64]*occurrence.Occurrence{}, map[uint64]math.Matrix4{}
+	for _, o := range asm.Occurrences().All() {
+		occs[o.ID()], rest[o.ID()] = o, o.Transform()
+	}
+	s.driveAnim = driveAnimation{frames: res.Frames, container: asm.Occurrences(), occs: occs, rest: rest, active: true}
+	return nil
+}
+
+// DriveAnimating reports whether a drive is playing, so the head ticks it each frame.
+func (s *Session) DriveAnimating() bool { return s.driveAnim.active }
+
+// TickDriveAnimation advances playback by dt seconds, applying the current motion frame
+// (looping through the frames). It is a no-op when no drive is active.
+func (s *Session) TickDriveAnimation(dt float64) {
+	if !s.driveAnim.active || dt < 0 {
+		return
+	}
+	s.driveAnim.elapsed += dt
+	idx := int(s.driveAnim.elapsed/driveFrameSeconds) % len(s.driveAnim.frames)
+	s.applyDrivePlacements(s.driveAnim.frames[idx].Placements)
+}
+
+// StopDriveAnimation ends playback and restores the assembly's pre-drive rest pose.
+func (s *Session) StopDriveAnimation() {
+	if !s.driveAnim.active {
+		return
+	}
+	s.driveAnim.active = false
+	s.driveAnim.container.SuspendNotifications()
+	defer s.driveAnim.container.ResumeNotifications()
+	for id, m := range s.driveAnim.rest {
+		if o := s.driveAnim.occs[id]; o != nil {
+			o.SetTransform(m)
+		}
+	}
+}
+
+// applyDrivePlacements writes one frame's occurrence transforms in a single notification batch.
+func (s *Session) applyDrivePlacements(placements []assembly.OccurrencePlacement) {
+	s.driveAnim.container.SuspendNotifications()
+	defer s.driveAnim.container.ResumeNotifications()
+	for _, p := range placements {
+		if o := s.driveAnim.occs[p.Occurrence]; o != nil {
+			o.SetTransform(p.Transform)
+		}
+	}
+}

--- a/app/drive_command.go
+++ b/app/drive_command.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"math"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/assembly"
+)
+
+// The Drive command (M12-F03, Oblikovati/Oblikovati#366) animates a selected joint through its
+// range of motion: it precomputes the motion frames and plays them back (drive_anim.go). It
+// lives on the Joints panel and enables only when a drivable joint (rotational/slider/
+// cylindrical) is selected in the browser's Joints folder.
+
+// driveFrameCount is how many steps a default sweep is divided into.
+const driveFrameCount = 36
+
+// defaultSlideCm is the default linear sweep length (cm) for a slider with no limits.
+const defaultSlideCm = 5.0
+
+// driveCommand builds the Joints-panel Drive command.
+func driveCommand() *CommandDefinition {
+	return NewCommand("Assembly.Drive", "Drive", "Joints", func(s *Session) error {
+		joint, ok := selectedDrivableJoint(s)
+		if !ok {
+			return fmt.Errorf("select a drivable joint (rotational, slider, or cylindrical) in the browser to drive")
+		}
+		return s.StartDriveAnimation(joint.ID(), defaultDriveSettings(joint))
+	}).WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasSelectedDrivableJoint).
+		WithIcon("joint-drive").WithButtonStyle(CompactIconButton).
+		WithTooltip("Drive — animate a joint through its range of motion.")
+}
+
+// hasSelectedDrivableJoint enables Drive only when a drivable joint is selected.
+func hasSelectedDrivableJoint(s *Session) bool {
+	_, ok := selectedDrivableJoint(s)
+	return ok
+}
+
+// selectedDrivableJoint returns the selected joint when it is one whose motion can be driven.
+func selectedDrivableJoint(s *Session) (assembly.Joint, bool) {
+	h, ok := s.Selection().First().(AssemblyJointHandle)
+	if !ok || !isDrivableKind(h.Joint.Type()) {
+		return nil, false
+	}
+	return h.Joint, true
+}
+
+// isDrivableKind reports whether a joint kind has a single driven variable to sweep.
+func isDrivableKind(k types.AssemblyJointType) bool {
+	return k == types.JointRotational || k == types.JointSlider || k == types.JointCylindrical
+}
+
+// defaultDriveSettings builds a sensible sweep for a joint: a slider sweeps its linear range,
+// every other drivable kind its angular range. The sweep oscillates (there-and-back) so the
+// looped playback reads as smooth motion.
+func defaultDriveSettings(j assembly.Joint) assembly.DriveSettings {
+	if j.Type() == types.JointSlider {
+		start, end := linearRange(j)
+		return assembly.NewDriveSettings(types.DriveLinear, start, end, stepFor(start, end), 2, true, false)
+	}
+	start, end := angularRange(j)
+	return assembly.NewDriveSettings(types.DriveAngular, start, end, stepFor(start, end), 2, true, false)
+}
+
+// angularRange is the joint's angular limits, or a full turn when unbounded.
+func angularRange(j assembly.Joint) (start, end float64) {
+	if lim := j.Limits(); lim != nil {
+		if lo, hasLo := lim.AngularMinimum(); hasLo {
+			if hi, hasHi := lim.AngularMaximum(); hasHi {
+				return lo, hi
+			}
+		}
+		if hi, hasHi := lim.AngularMaximum(); hasHi {
+			return 0, hi
+		}
+	}
+	return 0, 2 * math.Pi
+}
+
+// linearRange is the joint's linear limits, or a default slide when unbounded.
+func linearRange(j assembly.Joint) (start, end float64) {
+	if lim := j.Limits(); lim != nil {
+		if lo, hasLo := lim.LinearMinimum(); hasLo {
+			if hi, hasHi := lim.LinearMaximum(); hasHi {
+				return lo, hi
+			}
+		}
+		if hi, hasHi := lim.LinearMaximum(); hasHi {
+			return 0, hi
+		}
+	}
+	return 0, defaultSlideCm
+}
+
+// stepFor divides a span into driveFrameCount steps (always positive; a zero span degenerates
+// to a unit step so the sweep still has its endpoints).
+func stepFor(start, end float64) float64 {
+	span := math.Abs(end - start)
+	if span == 0 {
+		return 1
+	}
+	return span / driveFrameCount
+}

--- a/app/session.go
+++ b/app/session.go
@@ -50,6 +50,7 @@ type Session struct {
 	picker               Picker
 	camera               scene.Camera
 	camTween             cameraTween
+	driveAnim            driveAnimation
 	sketchReturnCam      scene.Camera
 	activeSketch         *sketch.Sketch
 	activeSketch3D       *sketch.Sketch3D

--- a/head/icon/assets/joint-drive.svg
+++ b/head/icon/assets/joint-drive.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M5 13 A8 8 0 0 1 13 5"/><path d="M10 13 L17 17 L10 21 Z" fill="#000" stroke="none"/></svg>

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -296,6 +296,9 @@ func drawViewportOverlays(s *app.Session, cam scene.Camera, sketchPlane sketch.P
 func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Camera, *feature.WorkPlane) {
 	cam := s.Camera()
 	cam.Width, cam.Height = pw, ph
+	if s.DriveAnimating() {
+		s.TickDriveAnimation(float64(native.DeltaTime())) // advance a running joint-drive playback (M12-F03)
+	}
 	if s.CameraAnimating() {
 		s.SetCamera(cam)
 		s.TickCameraAnimation(float64(native.DeltaTime()))

--- a/model/assembly/contract_assert.go
+++ b/model/assembly/contract_assert.go
@@ -33,4 +33,7 @@ var (
 	_ contract.DSJoints                 = (*DSJointSet)(nil)
 	_ contract.DSJointDefinition        = dsJointDefinition{}
 	_ contract.DSDegreesOfFreedom       = (*dsDOF)(nil)
+
+	// Drive (M12-F03).
+	_ contract.DriveSettings = DriveSettings{}
 )

--- a/model/assembly/drive.go
+++ b/model/assembly/drive.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// Drive (M12-F03, Oblikovati/Oblikovati#366) sweeps a joint's driven variable through a value
+// range, re-solving the assembly (constraints and joints together, ADR-0011) with the
+// variable pinned at each step, and returns the resulting per-step occurrence placements —
+// the frames of a kinematic motion study. With collision detection the sweep halts at the
+// first frame where a moved component interferes with another. The drive is non-destructive:
+// the assembly is restored to its pre-drive placements before returning.
+
+// OccurrencePlacement is one occurrence's transform at a drive frame.
+type OccurrencePlacement struct {
+	Occurrence uint64
+	Transform  math.Matrix4
+}
+
+// DriveFrame is one step of a drive: the driven value, the resulting placements of the moved
+// occurrences, and whether interference was detected at this frame.
+type DriveFrame struct {
+	Value      float64
+	Placements []OccurrencePlacement
+	Collided   bool
+}
+
+// DriveResult is a drive's frames in play order, plus — when collision detection halted the
+// sweep — the flag and the index of the last (collided) frame.
+type DriveResult struct {
+	Frames             []DriveFrame
+	StoppedByCollision bool
+	StoppedAtStep      int
+}
+
+// DriveJoint sweeps the joint with jointID through s and returns the frames. It errors when
+// the joint is unknown or its kind/variable pairing is not drivable.
+func DriveJoint(occs *occurrence.Occurrences, cs *ConstraintSet, js *JointSet, jointID uint64, s DriveSettings) (DriveResult, error) {
+	joint, ok := js.ByID(jointID).(*assemblyJoint)
+	if !ok {
+		return DriveResult{}, fmt.Errorf("assembly: no joint with id %d to drive", jointID)
+	}
+	resolved, ok := drivableVariable(joint.kind, s.variable)
+	if !ok {
+		return DriveResult{}, fmt.Errorf("assembly: joint %d (%s) is not drivable for variable %s", jointID, joint.kind, s.variable)
+	}
+	return sweep(occs, combinedRelationships(cs, js), joint, resolved, s), nil
+}
+
+// sweep runs the value sequence, restoring the assembly afterwards. base is the assembly's
+// constraints+joints; each step appends a fresh pin so base is never mutated.
+func sweep(occs *occurrence.Occurrences, base []relationship, joint *assemblyJoint, resolved types.DriveVariable, s DriveSettings) DriveResult {
+	saved := snapshotPlacements(occs)
+	defer restorePlacements(occs, saved)
+
+	var res DriveResult
+	for i, v := range driveValues(s) {
+		pin := &drivenPin{joint: joint, resolved: resolved, value: v}
+		solveOver(occs, append(append([]relationship{}, base...), pin), true)
+		frame := DriveFrame{Value: v, Placements: capturePlacements(occs)}
+		if s.collision && occurrencesInterfere(occs) {
+			frame.Collided = true
+			res.Frames = append(res.Frames, frame)
+			res.StoppedByCollision, res.StoppedAtStep = true, i
+			return res
+		}
+		res.Frames = append(res.Frames, frame)
+	}
+	return res
+}
+
+// driveValues expands the settings into the ordered value sequence: a start→end ramp by step,
+// repeated RepetitionCount times, each odd pass reversed when ping-pong is set.
+func driveValues(s DriveSettings) []float64 {
+	forward := rampValues(s.start, s.end, s.step)
+	reps := s.reps
+	if reps < 1 {
+		reps = 1
+	}
+	var out []float64
+	for r := 0; r < reps; r++ {
+		if s.pingPong && r%2 == 1 {
+			out = append(out, reversed(forward)...)
+		} else {
+			out = append(out, forward...)
+		}
+	}
+	return out
+}
+
+// rampValues returns start, start±step, … up to end (inclusive), stepping toward end. A
+// non-positive step degenerates to the two endpoints so a drive always has frames.
+func rampValues(start, end, step float64) []float64 {
+	if step <= 0 {
+		return []float64{start, end}
+	}
+	dir := 1.0
+	if end < start {
+		dir = -1.0
+	}
+	out := []float64{}
+	for v := start; (v-end)*dir < step*0.5; v += step * dir {
+		out = append(out, v)
+	}
+	if len(out) == 0 || out[len(out)-1] != end {
+		out = append(out, end)
+	}
+	return out
+}
+
+// reversed returns a new slice with vs in reverse order.
+func reversed(vs []float64) []float64 {
+	out := make([]float64, len(vs))
+	for i, v := range vs {
+		out[len(vs)-1-i] = v
+	}
+	return out
+}
+
+// snapshotPlacements records every non-suppressed occurrence's transform so the drive can be
+// undone.
+func snapshotPlacements(occs *occurrence.Occurrences) map[uint64]math.Matrix4 {
+	saved := map[uint64]math.Matrix4{}
+	for _, o := range occs.All() {
+		if !o.Suppressed() {
+			saved[o.ID()] = o.Transform()
+		}
+	}
+	return saved
+}
+
+// restorePlacements writes the saved transforms back in one notification batch.
+func restorePlacements(occs *occurrence.Occurrences, saved map[uint64]math.Matrix4) {
+	occs.SuspendNotifications()
+	defer occs.ResumeNotifications()
+	for _, o := range occs.All() {
+		if m, ok := saved[o.ID()]; ok {
+			o.SetTransform(m)
+		}
+	}
+}
+
+// capturePlacements records the transforms of the occurrences a drive can move (non-grounded,
+// non-suppressed) — the per-frame delta a consumer animates over the static grounded set.
+func capturePlacements(occs *occurrence.Occurrences) []OccurrencePlacement {
+	var out []OccurrencePlacement
+	for _, o := range occs.All() {
+		if o.Suppressed() || o.Grounded() {
+			continue
+		}
+		out = append(out, OccurrencePlacement{Occurrence: o.ID(), Transform: o.Transform()})
+	}
+	return out
+}

--- a/model/assembly/drive_collision.go
+++ b/model/assembly/drive_collision.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import "oblikovati.org/model/occurrence"
+
+// Collision-stop (M12-F03) halts a drive when a moved component interferes with another. For
+// V1 this is a broad-phase proxy: an overlap of world axis-aligned bounding boxes
+// (Occurrence.RangeBox), a *query* between solve steps — not the contact solver (M12-F05) and
+// not a true B-rep clash (a tighter narrow phase is a later refinement). It is intentionally
+// conservative: a coarse box overlap is reported as interference.
+
+// occurrencesInterfere reports whether any non-grounded occurrence's world bounding box
+// overlaps another occurrence's box — the moved-component-hits-something test.
+func occurrencesInterfere(occs *occurrence.Occurrences) bool {
+	placed := placedOccurrences(occs)
+	for i, moved := range placed {
+		if moved.Grounded() {
+			continue
+		}
+		box := moved.RangeBox()
+		for j, other := range placed {
+			if i == j {
+				continue
+			}
+			if box.Intersects(other.RangeBox()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// placedOccurrences returns the non-suppressed occurrences (those with a real placement).
+func placedOccurrences(occs *occurrence.Occurrences) []*occurrence.Occurrence {
+	var out []*occurrence.Occurrence
+	for _, o := range occs.All() {
+		if !o.Suppressed() {
+			out = append(out, o)
+		}
+	}
+	return out
+}

--- a/model/assembly/drive_residual.go
+++ b/model/assembly/drive_residual.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+	"oblikovati.org/solve"
+)
+
+// Driving a joint (M12-F03) reuses the ONE solver (ADR-0011): a drive step adds a single
+// extra residual that pins the joint's otherwise-free driven variable to the step value, so
+// the assembly re-solves to that pose. The joint residual bundle already leaves exactly the
+// driven DOF (F02); the pin removes it. A drivenPin is therefore a relationship that solves
+// together with the constraints and joints over the same placement set.
+
+// drivenPin pins a joint's resolved driven variable (angular or linear) to value — the extra
+// residual a drive step adds on top of the assembly's constraints and joints.
+type drivenPin struct {
+	joint    *assemblyJoint
+	resolved types.DriveVariable // already angular or linear (never natural)
+	value    float64
+}
+
+// Suppressed is always false: a pin only exists for the duration of one drive step.
+func (p *drivenPin) Suppressed() bool { return false }
+
+// anchors are the driven joint's two anchors, so the pin resolves exactly when the joint does.
+func (p *drivenPin) anchors() []anchor { return p.joint.anchors() }
+
+// setHealth is a no-op: the pin is transient and carries no reportable health.
+func (p *drivenPin) setHealth(health.Status) {}
+
+// bind emits the single pin residual over the joint's two origin placements.
+func (p *drivenPin) bind(b binder) []solve.Residual {
+	return single(func() []float64 {
+		pa, pb := p.joint.boundPlacements(b)
+		r, ok := drivenResidual(p.resolved, p.joint.a.prim, p.joint.b.prim, pa.matrix(), pb.matrix(), p.value)
+		if !ok {
+			return nil
+		}
+		return []float64{r}
+	})
+}
+
+// drivableVariable resolves a requested drive variable against a joint kind: it maps
+// DriveNatural to the kind's natural variable and validates an explicit choice, returning the
+// concrete (angular|linear) variable and whether the pairing is drivable. Rigid (0 DOF) and
+// the multi-DOF planar/ball joints have no single natural driven scalar and are not drivable.
+func drivableVariable(kind types.AssemblyJointType, requested types.DriveVariable) (types.DriveVariable, bool) {
+	switch kind {
+	case types.JointRotational:
+		return resolveAgainst(requested, types.DriveAngular, false)
+	case types.JointSlider:
+		return resolveAgainst(requested, types.DriveLinear, false)
+	case types.JointCylindrical:
+		return resolveAgainst(requested, types.DriveAngular, true) // both variables allowed
+	default:
+		return types.DriveNatural, false
+	}
+}
+
+// resolveAgainst maps natural→preferred and accepts an explicit variable when it is the
+// preferred one (or, when bothAllowed, the other concrete one).
+func resolveAgainst(requested, preferred types.DriveVariable, bothAllowed bool) (types.DriveVariable, bool) {
+	switch requested {
+	case types.DriveNatural:
+		return preferred, true
+	case types.DriveAngular, types.DriveLinear:
+		if requested == preferred || bothAllowed {
+			return requested, true
+		}
+	}
+	return types.DriveNatural, false
+}
+
+// drivenResidual returns the single residual that pins the resolved variable to value: for an
+// angular drive the relative roll about the joint axis equals value; for a linear drive the
+// axial position equals value. ok is false when the geometry lacks what the pin needs.
+func drivenResidual(resolved types.DriveVariable, a, b Primitive, ma, mb math.Matrix4, value float64) (float64, bool) {
+	switch resolved {
+	case types.DriveAngular:
+		return angularPinResidual(a, b, ma, mb, value)
+	case types.DriveLinear:
+		return gapResidual(worldPoint(ma, a), worldPoint(mb, b), worldDir(mb, b), value), true
+	default:
+		return 0, false
+	}
+}
+
+// angularPinResidual pins B's roll about the joint axis to angle radians from A's roll
+// reference: rotate A's part-tied reference by angle about the axis, then measure the signed
+// roll to B's reference (zero when B sits at angle). ok is false only when the axis degenerates.
+func angularPinResidual(a, b Primitive, ma, mb math.Matrix4, angle float64) (float64, bool) {
+	axisV := worldDir(mb, b)
+	axis, err := math.UnitVector3FromVector(axisV)
+	if err != nil {
+		return 0, false
+	}
+	target := math.QuaternionFromAxisAngle(axis, angle).Matrix4().TransformVector(worldRollRef(ma, a))
+	return target.Cross(worldRollRef(mb, b)).Dot(axisV), true
+}
+
+// worldRollRef returns a part-tied direction perpendicular to the joint axis, used to measure
+// the relative roll: the primitive's secondary axis when it carries one (consistent with
+// rollLockResidual), else a deterministic perpendicular derived from the axis. Both are mapped
+// through the occurrence frame m, so the reference rotates with the part.
+func worldRollRef(m math.Matrix4, prim Primitive) math.Vector3 {
+	if prim.hasSecondary {
+		return worldSecondary(m, prim)
+	}
+	u, _ := tangentFrame(prim.dir.AsVector())
+	return m.TransformVector(u)
+}

--- a/model/assembly/drive_settings.go
+++ b/model/assembly/drive_settings.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import "oblikovati.org/api/types"
+
+// DriveSettings describes a joint drive (M12-F03, Oblikovati/Oblikovati#366): which driven
+// variable to sweep, the value range and (positive) step, how many times to repeat, whether
+// to ping-pong (end→start on alternate passes), and whether a collision halts the sweep.
+// Values are in the variable's units (radians for angular, centimetres for linear). It is a
+// value object built by the router from the wire DTO and implements contract.DriveSettings.
+type DriveSettings struct {
+	variable   types.DriveVariable
+	start, end float64
+	step       float64
+	reps       int
+	pingPong   bool
+	collision  bool
+}
+
+// NewDriveSettings builds drive settings from plain values (the router's bridge from the wire
+// DTO), e.g. NewDriveSettings(types.DriveAngular, 0, math.Pi, math.Pi/18, 1, false, true).
+func NewDriveSettings(variable types.DriveVariable, start, end, step float64, reps int, pingPong, collision bool) DriveSettings {
+	return DriveSettings{variable: variable, start: start, end: end, step: step, reps: reps, pingPong: pingPong, collision: collision}
+}
+
+// Variable selects which driven variable the drive sweeps.
+func (s DriveSettings) Variable() types.DriveVariable { return s.variable }
+
+// Range returns the start and end values of the sweep.
+func (s DriveSettings) Range() (start, end float64) { return s.start, s.end }
+
+// Step returns the increment between consecutive frames (always reported positive).
+func (s DriveSettings) Step() float64 { return s.step }
+
+// RepetitionCount returns how many times the sweep repeats (1 = a single pass).
+func (s DriveSettings) RepetitionCount() int { return s.reps }
+
+// RepetitionStartEndStart reports whether each repetition also plays back end→start.
+func (s DriveSettings) RepetitionStartEndStart() bool { return s.pingPong }
+
+// CollisionDetection reports whether the drive halts on interference.
+func (s DriveSettings) CollisionDetection() bool { return s.collision }

--- a/model/assembly/drive_test.go
+++ b/model/assembly/drive_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// boxComponent is a named fake occurrence definition with a real bounding box, so its
+// occurrences have a non-empty RangeBox for the collision-stop test.
+type boxComponent struct{ box math.Box }
+
+func (c boxComponent) RangeBox() math.Box { return c.box }
+
+// placeBox adds an occurrence backed by a box-bearing definition.
+func placeBox(occs *occurrence.Occurrences, name string, m math.Matrix4, box math.Box) *occurrence.Occurrence {
+	return occs.AddByComponentDefinition(name, boxComponent{box}, m)
+}
+
+// rollAboutZ is the moving frame's roll about +Z: the angle of its mapped local X axis in the
+// XY plane. The drive advances this as it pins the rotational variable.
+func rollAboutZ(m math.Matrix4) float64 {
+	x := m.TransformVector(math.V3(1, 0, 0))
+	return stdmath.Atan2(x.Y, x.X)
+}
+
+// TestDriveRotationalJointAnimates is the F03 acceptance: driving a rotational joint advances
+// the free component's rotation through the swept range, one step at a time, and restores the
+// assembly afterwards.
+func TestDriveRotationalJointAnimates(t *testing.T) {
+	occs := occurrence.NewOccurrences()
+	base := place(occs, "base:1", math.Identity4())
+	base.SetGrounded(true)
+	moving := place(occs, "moving:1", math.Translation4(math.V3(0, 0, 6)))
+	before := moving.Transform()
+
+	cs := NewConstraintSet(occs, nil)
+	js := NewJointSet(occs, nil)
+	axis := func(o *occurrence.Occurrence) Ref {
+		return Ref{Occurrence: o, Primitive: LinePrimitive(math.P3(0, 0, 0), unit(t, 0, 0, 1))}
+	}
+	joint := js.AddRotational(axis(base), axis(moving))
+
+	span := stdmath.Pi / 2
+	settings := NewDriveSettings(types.DriveAngular, 0, span, span/4, 1, false, false)
+	res, err := DriveJoint(occs, cs, js, joint.ID(), settings)
+	if err != nil {
+		t.Fatalf("DriveJoint: %v", err)
+	}
+	if len(res.Frames) != 5 {
+		t.Fatalf("frames = %d, want 5 (0, π/8, π/4, 3π/8, π/2)", len(res.Frames))
+	}
+
+	first := rollAboutZ(res.Frames[0].Placements[0].Transform)
+	last := rollAboutZ(res.Frames[len(res.Frames)-1].Placements[0].Transform)
+	if delta := stdmath.Abs(last - first); stdmath.Abs(delta-span) > 1e-3 {
+		t.Errorf("rotation swept = %.4f rad, want ≈ %.4f", delta, span)
+	}
+	if got := moving.Transform(); !got.IsEqualTo(before, 1e-9) {
+		t.Errorf("assembly not restored after drive: %v, want %v", got, before)
+	}
+}
+
+// TestDriveStopsOnCollision drives an arm (its body offset from the joint axis) toward a fixed
+// wall; collision detection must halt the sweep at the frame the arm's box first overlaps the
+// wall.
+func TestDriveStopsOnCollision(t *testing.T) {
+	occs := occurrence.NewOccurrences()
+	wall := placeBox(occs, "wall:1", math.Identity4(), math.NewBox(math.P3(-5, -1, -2), math.P3(-1, 1, 8)))
+	wall.SetGrounded(true)
+	arm := placeBox(occs, "arm:1", math.Identity4(), math.NewBox(math.P3(1, -0.5, -0.5), math.P3(3, 0.5, 0.5)))
+
+	cs := NewConstraintSet(occs, nil)
+	js := NewJointSet(occs, nil)
+	axis := func(o *occurrence.Occurrence) Ref {
+		return Ref{Occurrence: o, Primitive: LinePrimitive(math.P3(0, 0, 0), unit(t, 0, 0, 1))}
+	}
+	joint := js.AddRotational(axis(wall), axis(arm))
+
+	// Sweep the arm from +X (clear) toward -X (into the wall) with collision detection on.
+	settings := NewDriveSettings(types.DriveAngular, 0, stdmath.Pi, stdmath.Pi/8, 1, false, true)
+	res, err := DriveJoint(occs, cs, js, joint.ID(), settings)
+	if err != nil {
+		t.Fatalf("DriveJoint: %v", err)
+	}
+	if !res.StoppedByCollision {
+		t.Fatalf("drive did not stop on collision: %+v", res)
+	}
+	if res.StoppedAtStep == 0 || res.StoppedAtStep >= 8 {
+		t.Errorf("stopped at step %d, want a mid-sweep frame (arm clear at 0, in the wall near π)", res.StoppedAtStep)
+	}
+	if last := res.Frames[len(res.Frames)-1]; !last.Collided {
+		t.Errorf("final frame not marked collided: %+v", last)
+	}
+}
+
+// TestDriveValuesSequence checks the value expansion: a ramp, repetitions, and a ping-pong
+// that plays alternate passes in reverse.
+func TestDriveValuesSequence(t *testing.T) {
+	ramp := driveValues(NewDriveSettings(types.DriveLinear, 0, 1, 0.5, 1, false, false))
+	if want := []float64{0, 0.5, 1}; !floatsEqual(ramp, want) {
+		t.Errorf("ramp = %v, want %v", ramp, want)
+	}
+	pong := driveValues(NewDriveSettings(types.DriveLinear, 0, 1, 0.5, 2, true, false))
+	if want := []float64{0, 0.5, 1, 1, 0.5, 0}; !floatsEqual(pong, want) {
+		t.Errorf("ping-pong = %v, want %v", pong, want)
+	}
+	twice := driveValues(NewDriveSettings(types.DriveLinear, 0, 1, 0.5, 2, false, false))
+	if want := []float64{0, 0.5, 1, 0, 0.5, 1}; !floatsEqual(twice, want) {
+		t.Errorf("repeat = %v, want %v", twice, want)
+	}
+}
+
+// TestDrivableVariable checks which joint-kind/variable pairings are drivable and how natural
+// resolves.
+func TestDrivableVariable(t *testing.T) {
+	cases := []struct {
+		kind      types.AssemblyJointType
+		requested types.DriveVariable
+		want      types.DriveVariable
+		ok        bool
+	}{
+		{types.JointRotational, types.DriveNatural, types.DriveAngular, true},
+		{types.JointRotational, types.DriveLinear, types.DriveNatural, false},
+		{types.JointSlider, types.DriveNatural, types.DriveLinear, true},
+		{types.JointCylindrical, types.DriveNatural, types.DriveAngular, true},
+		{types.JointCylindrical, types.DriveLinear, types.DriveLinear, true},
+		{types.JointRigid, types.DriveNatural, types.DriveNatural, false},
+		{types.JointPlanar, types.DriveNatural, types.DriveNatural, false},
+		{types.JointBall, types.DriveAngular, types.DriveNatural, false},
+	}
+	for _, c := range cases {
+		got, ok := drivableVariable(c.kind, c.requested)
+		if got != c.want || ok != c.ok {
+			t.Errorf("drivableVariable(%s, %s) = (%s, %v), want (%s, %v)", c.kind, c.requested, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestDriveJointErrors checks the engine rejects an unknown joint and an undrivable kind.
+func TestDriveJointErrors(t *testing.T) {
+	occs := occurrence.NewOccurrences()
+	base := place(occs, "base:1", math.Identity4())
+	base.SetGrounded(true)
+	moving := place(occs, "moving:1", math.Identity4())
+	cs := NewConstraintSet(occs, nil)
+	js := NewJointSet(occs, nil)
+	frame := func(o *occurrence.Occurrence) Ref {
+		return Ref{Occurrence: o, Primitive: FramePrimitive(math.P3(0, 0, 0), unit(t, 0, 0, 1), unit(t, 1, 0, 0))}
+	}
+	rigid := js.AddRigid(frame(base), frame(moving))
+
+	if _, err := DriveJoint(occs, cs, js, 999, NewDriveSettings(types.DriveAngular, 0, 1, 0.5, 1, false, false)); err == nil {
+		t.Error("DriveJoint(unknown id) = nil error, want failure")
+	}
+	if _, err := DriveJoint(occs, cs, js, rigid.ID(), NewDriveSettings(types.DriveNatural, 0, 1, 0.5, 1, false, false)); err == nil {
+		t.Error("DriveJoint(rigid) = nil error, want not-drivable failure")
+	}
+}
+
+// floatsEqual compares two float slices within a tolerance.
+func floatsEqual(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if stdmath.Abs(a[i]-b[i]) > 1e-9 {
+			return false
+		}
+	}
+	return true
+}

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -214,6 +214,14 @@ func (a *AssemblyComponentDefinition) AssemblyHealth() assembly.SolveReport {
 	return assembly.AssemblyHealth(a.constraints, a.joints)
 }
 
+// DriveJoint sweeps the joint with the given id through settings — re-solving the assembly at
+// each step with the driven variable pinned — and returns the resulting motion frames
+// (M12-F03, Oblikovati/Oblikovati#366). It is non-destructive: the assembly is left in its
+// pre-drive pose. Errors when the joint is unknown or its kind/variable is not drivable.
+func (a *AssemblyComponentDefinition) DriveJoint(jointID uint64, settings assembly.DriveSettings) (assembly.DriveResult, error) {
+	return assembly.DriveJoint(a.occurrences, a.constraints, a.joints, jointID, settings)
+}
+
 // AddFeature appends an assembly machining feature wrapping f, defaulting its
 // participation to every component currently present (the reference API's behavior:
 // components added later do not participate unless added to the feature). It returns

--- a/model/compdef/assembly_drive_test.go
+++ b/model/compdef/assembly_drive_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
+)
+
+// TestDriveJointThroughAssembly checks the assembly definition drives one of its joints —
+// sweeping the rotational variable and returning motion frames — and leaves the assembly in
+// its pre-drive pose (M12-F03).
+func TestDriveJointThroughAssembly(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	base := asm.Place("base:1", NewPartComponentDefinition(), math.Identity4())
+	base.SetGrounded(true)
+	moving := asm.Place("moving:1", NewPartComponentDefinition(), math.Translation4(math.V3(0, 0, 6)))
+
+	zAxis, _ := math.NewUnitVector3(0, 0, 1)
+	j := asm.Joints().AddRotational(
+		assembly.Ref{Occurrence: base, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), zAxis)},
+		assembly.Ref{Occurrence: moving, Primitive: assembly.LinePrimitive(math.P3(0, 0, 0), zAxis)})
+
+	before := moving.Transform()
+	span := stdmath.Pi / 2
+	res, err := asm.DriveJoint(j.ID(), assembly.NewDriveSettings(types.DriveAngular, 0, span, span/4, 1, false, false))
+	if err != nil {
+		t.Fatalf("DriveJoint: %v", err)
+	}
+	if len(res.Frames) != 5 {
+		t.Fatalf("frames = %d, want 5", len(res.Frames))
+	}
+	if !moving.Transform().IsEqualTo(before, 1e-9) {
+		t.Errorf("assembly not restored after drive")
+	}
+
+	if _, err := asm.DriveJoint(404, assembly.NewDriveSettings(types.DriveAngular, 0, 1, 0.5, 1, false, false)); err == nil {
+		t.Error("DriveJoint(unknown id) = nil error, want failure")
+	}
+}


### PR DESCRIPTION
## What

Implements **M12-F03 — constraint/joint drive & animation** (Oblikovati/Oblikovati#366): driving a joint through a value range with steps, repeats, ping-pong, and an optional collision-stop — a kinematic motion study.

- **Engine** (`model/assembly`): a drive sweeps a joint's driven variable, re-solving the assembly (constraints + joints together, ADR-0011) at each step with the variable **pinned** by a single extra residual on the same solver — angular drive pins the relative roll about the joint axis, linear drive pins the axial position. Drivable kinds: rotational (angular), slider (linear), cylindrical (either). Non-destructive (restores the pre-drive pose); returns the per-step occurrence placements.
- **Collision-stop**: halts the sweep at the first frame a moved component's world bounding box overlaps another's (a broad-phase proxy; a true B-rep clash and the contact solver are later milestone steps).
- **Host** (`model/compdef`): `AssemblyComponentDefinition.DriveJoint(jointID, settings)`.
- **Router**: `assemblyDrive.preview` over the wire.
- **Head**: a **Drive** command on the Assemble tab's Joints panel that animates a selected joint through its range of motion (the viewport ticks the playback each frame), with a `joint-drive` icon.

## Acceptance

Driving a rotational joint animates assembly motion; collision halts the drive. Verified by unit, router, and head-UI tests.

## Notes

- Stacked on **Oblikovati.API#105** (the contract); CI is red until that merges to `api` develop.
- `head/demo.opd` intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)