### PR TITLE
Command Window: roll scrollback up from the bottom like a shell

### DIFF
--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -48,6 +48,7 @@ int  obk_ig_begin_popup(const char* id);
 void obk_ig_close_current_popup(void);
 void obk_ig_end_popup(void);
 void obk_ig_set_scroll_here_y(void);
+void obk_ig_scroll_to_bottom(void);
 int  obk_ig_input_float(const char* label, float* v);
 int  obk_ig_input_double(const char* label, double* v);
 int  obk_ig_input_int(const char* label, int* v);
@@ -658,6 +659,11 @@ func CloseCurrentPopup() { C.obk_ig_close_current_popup() }
 // SetScrollHereY scrolls the current window to center the most recently drawn item — used
 // to reveal the browser node that just synced to the active selection.
 func SetScrollHereY() { C.obk_ig_set_scroll_here_y() }
+
+// ScrollToBottom scrolls the current window so the most recently drawn item sits at the
+// bottom edge — the shell behaviour where new lines appear at the bottom and roll older
+// text up (the Command Window's scrollback).
+func ScrollToBottom() { C.obk_ig_scroll_to_bottom() }
 
 // BeginDisabled / EndDisabled gray out and disable the widgets between them.
 func BeginDisabled(disabled bool) {

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -153,6 +153,7 @@ int  obk_ig_begin_popup(const char* id)      { return ImGui::BeginPopup(id) ? 1 
 void obk_ig_close_current_popup(void)               { ImGui::CloseCurrentPopup(); }
 void obk_ig_end_popup(void)                  { ImGui::EndPopup(); }
 void obk_ig_set_scroll_here_y(void)          { ImGui::SetScrollHereY(0.5f); }
+void obk_ig_scroll_to_bottom(void)           { ImGui::SetScrollHereY(1.0f); }
 
 // Preference widgets: a float/int field and a checkbox. Each returns 1 when the value
 // changed this frame and writes the new value back through the pointer.

--- a/head/ui/command_window.go
+++ b/head/ui/command_window.go
@@ -185,7 +185,7 @@ func drawCommandScrollback(cl *app.CommandLine, reserve float32) {
 		native.PopStyleColor(1)
 	}
 	if len(lines) > commandLastLineCount {
-		native.SetScrollHereY()
+		native.ScrollToBottom() // new lines pin to the bottom and roll older text up (shell-style)
 	}
 	commandLastLineCount = len(lines)
 	native.EndChild()


### PR DESCRIPTION
## What

New message lines in the Command Window now pin to the bottom of the scrollback and
roll older text up, like a terminal.

## Why

The auto-tail called `SetScrollHereY(0.5)`, which **centred** the newest line in the
pane instead of putting it at the bottom — so new output appeared mid-panel rather than
rolling up from the bottom. This adds a `ScrollToBottom` native helper
(`SetScrollHereY(1.0)`) and uses it for the scrollback, so the latest line sits at the
bottom edge just above the input.

## Verification

- cgo head builds; `head/ui` tests pass.
- Live: drove the running app to emit many command-line lines (overflowing the pane) and
  confirmed the newest lines stay at the bottom with older text rolling up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)