### PR TITLE
fix(assembly): place a component without switching to its tab (#764)

### DIFF
--- a/app/assembly_open_component.go
+++ b/app/assembly_open_component.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/occurrence"
+)
+
+// OpenOccurrenceDocument brings a placed component's document forward into a visible, active
+// tab — the Edit/Open path (browser double-click or context menu) for an occurrence (#764).
+// Placement loads the component in the background with no tab ([OpenComponentForPlacement]);
+// this is how the user opens it to edit. The document is already in memory, so this just flips
+// it visible and active (or loads it from the store if the assembly was reopened). It errors
+// when the occurrence was placed from a bare in-memory definition (no document name).
+func (s *Session) OpenOccurrenceDocument(o *occurrence.Occurrence) error {
+	name := o.ComponentName()
+	if name == "" {
+		return fmt.Errorf("occurrence %q has no document to open", o.Name())
+	}
+	d, err := s.workspace.Open(name, true) // visible + active ⇒ a tab the viewport switches to
+	if err != nil {
+		return err
+	}
+	s.documentHistory(d)
+	s.loadViewState(d)
+	return nil
+}

--- a/app/assembly_open_component_test.go
+++ b/app/assembly_open_component_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestOccurrenceEditOpensComponentTab checks the placed-component Edit path (#764): the
+// occurrence context menu offers an enabled Edit that opens the component document in a
+// visible, active tab.
+func TestOccurrenceEditOpensComponentTab(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	occ := asm.Occurrences().Item(0)
+
+	menu := occurrenceMenu(OccurrenceHandle{Occurrence: occ})
+	edit, ok := findMenuItem(menu, "Edit")
+	if !ok || !edit.Enabled {
+		t.Fatalf("occurrence Edit item missing or disabled (ok=%v, %+v)", ok, edit)
+	}
+	if err := edit.Invoke(s); err != nil {
+		t.Fatalf("Edit invoke: %v", err)
+	}
+
+	widget, found := s.Workspace().ByName("widget.obk")
+	if !found {
+		t.Fatal("widget.obk not in the workspace")
+	}
+	if s.ActiveDocument() != widget {
+		t.Error("Edit did not open/activate the component document")
+	}
+	if !widget.Visible() {
+		t.Error("the opened component document is not visible (no tab would show)")
+	}
+}

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -75,6 +75,7 @@ func occurrenceMenu(sel Selectable) []BrowserMenuItem {
 		suppressLabel = "Unsuppress"
 	}
 	return []BrowserMenuItem{
+		{Label: "Edit", Enabled: h.Occurrence.ComponentName() != "", Invoke: func(s *Session) error { return s.OpenOccurrenceDocument(h.Occurrence) }},
 		{Label: groundLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceGrounded(h.Occurrence) }},
 		{Label: suppressLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceSuppressed(h.Occurrence) }},
 		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteOccurrence(h.Occurrence) }},

--- a/app/occurrence_browser_test.go
+++ b/app/occurrence_browser_test.go
@@ -66,13 +66,13 @@ func TestOccurrenceMenuTogglesLabels(t *testing.T) {
 	o := asm.Occurrences().Item(0)
 	node := findBrowserNode(BuildBrowser(s), "occurrence", "widget:1")
 
-	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Ground|Suppress|Delete" {
-		t.Errorf("fresh occurrence menu = %q, want Ground|Suppress|Delete", labels)
+	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Edit|Ground|Suppress|Delete" {
+		t.Errorf("fresh occurrence menu = %q, want Edit|Ground|Suppress|Delete", labels)
 	}
 	o.SetGrounded(true)
 	o.SetSuppressed(true)
-	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Unground|Unsuppress|Delete" {
-		t.Errorf("grounded+suppressed menu = %q, want Unground|Unsuppress|Delete", labels)
+	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Edit|Unground|Unsuppress|Delete" {
+		t.Errorf("grounded+suppressed menu = %q, want Edit|Unground|Unsuppress|Delete", labels)
 	}
 }
 

--- a/app/session.go
+++ b/app/session.go
@@ -341,6 +341,20 @@ func (s *Session) OpenDocument(path string) (*doc.Document, error) {
 	return d, nil
 }
 
+// OpenComponentForPlacement loads a component document into memory so the active assembly can
+// instance it, WITHOUT making it visible or active — placing a part must never switch the tab
+// away from the assembly (Inventor's invisible Documents.Open). The document is reachable but
+// shows no tab; the user opens it in a tab later via Edit/Open on the occurrence
+// ([OpenOccurrenceDocument]).
+func (s *Session) OpenComponentForPlacement(path string) (*doc.Document, error) {
+	d, err := s.workspace.OpenWithOptions(path, doc.OpenOptions{Visible: false, Background: true})
+	if err != nil {
+		return nil, err
+	}
+	s.documentHistory(d) // track its edit stream so an Edit-in-tab later has a clean before-state
+	return d, nil
+}
+
 // NewPart creates a realized part document with a unique "PartN" name and makes it active
 // (the workspace activates a newly added document), so the viewport and ribbon switch to the
 // part environment. It backs the New Part command on the ZeroDoc ribbon and the File menu.

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -199,6 +199,8 @@ func openEditOnDoubleClick(s *app.Session, n app.BrowserNode) {
 		s.BeginEditSketch(h)
 	case app.WorkPlaneHandle:
 		s.BeginEditWorkPlane(h)
+	case app.OccurrenceHandle:
+		_ = s.OpenOccurrenceDocument(h.Occurrence) // open the placed component in a tab (#764)
 	}
 }
 

--- a/head/ui/chrome_doctabs.go
+++ b/head/ui/chrome_doctabs.go
@@ -62,7 +62,9 @@ var prevActiveDoc uint64
 // tab is selected so the strip follows. The tabs read the workspace each frame, so
 // opening/closing/activating documents is reflected automatically.
 func drawDocumentTabs(s *app.Session) {
-	docs := s.Workspace().Documents()
+	// Only visible documents get a tab: a component loaded in the background for placement is
+	// referenced in memory but shows no tab until the user opens it via Edit (#764).
+	docs := s.Workspace().VisibleDocuments()
 	if len(docs) == 0 {
 		return
 	}

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -315,11 +315,13 @@ func openDocumentFromFile(s *app.Session, path, name string) {
 	fileNotice(s, "Opened %s", name)
 }
 
-// placeComponentFromFile opens the chosen component and hands it to the running Place tool (#763);
-// the tool then drops instances on ground-plane clicks. Opening (not just naming) the document
-// shares the live content, so edits to the component propagate to every placement.
+// placeComponentFromFile loads the chosen component in the background and hands it to the
+// running Place tool (#763); the tool then drops instances on ground-plane clicks. The
+// component is loaded (not just named) so the live content is shared and edits propagate to
+// every placement — but it is NOT made visible or active, so placing a part never switches the
+// tab away from the assembly. The user opens the part in a tab later via Edit on the occurrence.
 func placeComponentFromFile(s *app.Session, path, name string) {
-	d, err := s.OpenDocument(path)
+	d, err := s.OpenComponentForPlacement(path)
 	if err != nil {
 		fileNotice(s, "Place Component failed: %v", err)
 		return

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -61,6 +61,11 @@ type OpenOptions struct {
 	// DeferContent opens the document as a reference stub — identity registered,
 	// content not paged in — for callers that only need to record a dependency.
 	DeferContent bool
+	// Background loads the document without making it the active document (and without
+	// changing the current one) — the placement path, where instancing a component into the
+	// active assembly must reference its document in memory but never switch focus to it
+	// (Inventor's invisible Documents.Open). The user opens it in a tab later via Edit/Open.
+	Background bool
 }
 
 // Add creates a new document of kind t from the built-in template and registers
@@ -94,25 +99,44 @@ func (ws *Workspace) Open(fullDocumentName string, visible bool) (*Document, err
 // without touching the store.
 func (ws *Workspace) OpenWithOptions(fullDocumentName string, opts OpenOptions) (*Document, error) {
 	if existing, ok := ws.byName[fullDocumentName]; ok {
-		existing.SetVisible(opts.Visible)
-		ws.active = existing
-		return existing, nil
+		return ws.reopenExisting(existing, opts), nil
 	}
 	if opts.DeferContent {
 		return ws.openStub(fullDocumentName)
 	}
+	return ws.loadNew(fullDocumentName, opts)
+}
+
+// reopenExisting hands back an already-open document, applying the open's visibility and
+// making it active — UNLESS Background, which references it in place without changing its
+// visibility or stealing focus (re-placing a part the user has open must not hide it).
+func (ws *Workspace) reopenExisting(existing *Document, opts OpenOptions) *Document {
+	if !opts.Background {
+		existing.SetVisible(opts.Visible)
+		ws.active = existing
+	}
+	return existing
+}
+
+// loadNew loads, registers, and resolves a not-yet-open document. A Background load references
+// it in memory without switching the active document (the placement path).
+func (ws *Workspace) loadNew(fullDocumentName string, opts OpenOptions) (*Document, error) {
 	if ws.store == nil {
 		return nil, fmt.Errorf("doc: cannot open %q: no store configured", fullDocumentName)
 	}
 	if err := vetoed(ws.bus, "open", DocumentOpened{FullDocumentName: fullDocumentName}); err != nil {
 		return nil, err
 	}
+	prevActive := ws.active
 	d, err := ws.loadResolving(fullDocumentName)
 	if err != nil {
 		return nil, err
 	}
 	d.visible = opts.Visible
 	ws.register(d)
+	if opts.Background {
+		ws.active = prevActive // register() activated d; a background load must not switch focus
+	}
 	// Resolve cross-document references after registration so a resolver that hidden-opens
 	// a sibling (an assembly binding its components, #715) finds this document already in
 	// byName — that short-circuit (above) is what terminates cyclic and diamond references.

--- a/model/doc/workspace_test.go
+++ b/model/doc/workspace_test.go
@@ -265,3 +265,54 @@ func TestAddRejectsDuplicateNameAndBadType(t *testing.T) {
 		t.Error("Add accepted an invalid document type")
 	}
 }
+
+// TestBackgroundOpenKeepsActiveAndHidden pins the place-component fix (#764): loading a
+// component in the background must reference it in memory without making it visible or
+// stealing the active document, so placing a part never switches the tab away from the
+// assembly.
+func TestBackgroundOpenKeepsActiveAndHidden(t *testing.T) {
+	ws := NewWorkspace(newFakeStore())
+	asm, _ := ws.Add(Assembly, "asm.obk", true)
+	part, _ := ws.Add(Part, "part.obk", true) // stage in the store
+	if err := ws.Save(part); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := ws.Close(part, false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := ws.SetActiveDocument(asm); err != nil {
+		t.Fatalf("SetActiveDocument: %v", err)
+	}
+
+	got, err := ws.OpenWithOptions("part.obk", OpenOptions{Visible: false, Background: true})
+	if err != nil {
+		t.Fatalf("background open: %v", err)
+	}
+	if ws.ActiveDocument() != asm {
+		t.Error("background open stole the active document; the assembly must stay active")
+	}
+	if got.Visible() {
+		t.Error("background-opened component reports Visible() = true")
+	}
+	if vis := ws.VisibleDocuments(); len(vis) != 1 || vis[0] != asm {
+		t.Errorf("visible documents = %d (want only the assembly); a background component must show no tab", len(vis))
+	}
+}
+
+// TestBackgroundOpenOfOpenDocPreservesIt checks that re-placing a part the user already has
+// open in a tab does not hide it or steal focus.
+func TestBackgroundOpenOfOpenDocPreservesIt(t *testing.T) {
+	ws := NewWorkspace(newFakeStore())
+	asm, _ := ws.Add(Assembly, "asm.obk", true)
+	part, _ := ws.Add(Part, "part.obk", true) // user has it open, visible, active
+	if _, err := ws.OpenWithOptions("part.obk", OpenOptions{Visible: false, Background: true}); err != nil {
+		t.Fatalf("background re-open: %v", err)
+	}
+	if !part.Visible() {
+		t.Error("re-placing a part the user has open in a tab hid it")
+	}
+	if ws.ActiveDocument() != part {
+		t.Error("background re-open changed the active document")
+	}
+	_ = asm
+}


### PR DESCRIPTION
## Problem

Placing a part into an assembly opened the referenced part document as a **visible, active tab** and switched the viewport to it — forcing the user to navigate back to the assembly to keep placing. A placed component should be **in memory but not visible**: referenced so the assembly can instance it, with no tab and no focus change. The part opens in a tab only on demand (Edit / double-click) — Inventor's invisible `Documents.Open`.

## Fix

- **`model/doc`** — `OpenOptions` gains `Background`: load a document without making it active (and without changing the current active document). `OpenWithOptions` honours it (split into `reopenExisting`/`loadNew`). A background re-open of a document the user already has open is a no-op on its visibility/focus.
- **`app`** — `OpenComponentForPlacement` loads the component **hidden + background**; the head's Place-from-file path now uses it instead of `OpenDocument`. `OpenOccurrenceDocument` brings a placed component forward into a **visible, active** tab — the Edit path.
- **`head`** — the document tab strip renders `VisibleDocuments()` (a background component shows no tab); the occurrence context menu gains **Edit**, and a browser double-click on an occurrence opens its component.

## Tests

- `doc`: a background open keeps the assembly active and the component hidden (no tab); re-placing a part the user has open does not hide it or steal focus.
- `app`: the occurrence Edit item opens/activates the component document.
- Updated the existing occurrence-menu expectation to include Edit.

Full `go test ./...` clean, root golangci-lint 0, head cgo build + UI tests green. `head/demo.opd` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)