### PR TITLE
M20-F20: Move feature operation-list parity

### DIFF
--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -247,21 +247,47 @@ func pathFromSketch(part *compdef.PartComponentDefinition, sketchIndex, pathInde
 // --- move body -------------------------------------------------------------
 
 type moveBodyArgs struct {
-	BodyIndex   int       `json:"bodyIndex"`
-	Translation []float64 `json:"translation"`
+	BodyIndex   int         `json:"bodyIndex"`
+	Translation []float64   `json:"translation,omitempty"`
+	Operations  []moveOpArg `json:"operations,omitempty"`
+}
+
+// moveOpArg is one entry of an ordered move operation list (M20-F20). Each is a typed,
+// independently parametric step (free-drag / along-ray / rotate-about-line); the fields a
+// given type reads are noted in the schema. The scalars are unit-bearing expressions so
+// they join the parameter graph.
+type moveOpArg struct {
+	Type  string    `json:"type"`
+	X     string    `json:"x,omitempty"`
+	Y     string    `json:"y,omitempty"`
+	Z     string    `json:"z,omitempty"`
+	Dir   []float64 `json:"dir,omitempty"`
+	Dist  string    `json:"dist,omitempty"`
+	Point []float64 `json:"point,omitempty"`
+	Angle string    `json:"angle,omitempty"`
 }
 
 const moveBodySchema = `{
   "type": "object",
   "properties": {
     "bodyIndex": {"type": "integer", "minimum": 0, "description": "Body to move (model.tree body order)."},
-    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Move vector [x,y,z] in cm."}
+    "translation": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Simple form: move vector [x,y,z] in cm. Ignored when operations is given."},
+    "operations": {"type": "array", "description": "Ordered move operations composed in list order (e.g. rotate then slide). Each is a separately parametric step.", "items": {"type": "object", "properties": {
+      "type": {"type": "string", "enum": ["freeDrag", "alongRay", "rotateAboutLine"], "description": "freeDrag: x/y/z offsets. alongRay: dir + dist. rotateAboutLine: point + dir + angle."},
+      "x": {"type": "string", "description": "freeDrag X offset, e.g. \"5 mm\"."},
+      "y": {"type": "string", "description": "freeDrag Y offset."},
+      "z": {"type": "string", "description": "freeDrag Z offset."},
+      "dir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Direction [x,y,z]: the ray for alongRay, the axis for rotateAboutLine."},
+      "dist": {"type": "string", "description": "alongRay distance, e.g. \"5 mm\"."},
+      "point": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "rotateAboutLine axis point [x,y,z] in cm."},
+      "angle": {"type": "string", "description": "rotateAboutLine angle, e.g. \"30 deg\"."}
+    }, "required": ["type"]}}
   },
-  "required": ["bodyIndex", "translation"]
+  "required": ["bodyIndex"]
 }`
 
 func moveBodyDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: "moveBody", Summary: "Move a solid body by a translation.", Schema: json.RawMessage(moveBodySchema), Apply: applyMoveBody}
+	return &OperationDescriptor{Name: "moveBody", Summary: "Move a solid body by a translation or an ordered list of parametric operations (free-drag / along-ray / rotate-about-line).", Schema: json.RawMessage(moveBodySchema), Apply: applyMoveBody}
 }
 
 func applyMoveBody(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -273,12 +299,90 @@ func applyMoveBody(s *app.Session, raw json.RawMessage) (json.RawMessage, error)
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, err
 	}
+	mods := feature.NewModifyFeatures(part.Features())
+	if len(in.Operations) > 0 {
+		ops, err := buildMoveOps(part, in.Operations)
+		if err != nil {
+			return nil, err
+		}
+		return recomputeResult(part, mods.AddMoveOps(in.BodyIndex, ops))
+	}
 	t, err := vec3(in.Translation, "moveBody: translation")
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewModifyFeatures(part.Features()).AddMove(in.BodyIndex, math.Translation4(t))
-	return recomputeResult(part, pf)
+	return recomputeResult(part, mods.AddMove(in.BodyIndex, math.Translation4(t)))
+}
+
+// buildMoveOps resolves each operation arg into a parametric model move operation.
+func buildMoveOps(part *compdef.PartComponentDefinition, args []moveOpArg) ([]feature.MoveOperation, error) {
+	ops := make([]feature.MoveOperation, len(args))
+	for i, a := range args {
+		op, err := buildMoveOp(part, a)
+		if err != nil {
+			return nil, fmt.Errorf("moveBody operation %d: %w", i, err)
+		}
+		ops[i] = op
+	}
+	return ops, nil
+}
+
+// buildMoveOp dispatches on the operation type.
+func buildMoveOp(part *compdef.PartComponentDefinition, a moveOpArg) (feature.MoveOperation, error) {
+	switch types.MoveOperationType(a.Type) {
+	case types.MoveFreeDrag:
+		return buildFreeDragOp(part, a)
+	case types.MoveAlongRay:
+		return buildAlongRayOp(part, a)
+	case types.MoveRotateAboutLine:
+		return buildRotateAboutLineOp(part, a)
+	default:
+		return feature.MoveOperation{}, fmt.Errorf("unknown type %q (want freeDrag/alongRay/rotateAboutLine)", a.Type)
+	}
+}
+
+func buildFreeDragOp(part *compdef.PartComponentDefinition, a moveOpArg) (feature.MoveOperation, error) {
+	x, err := optionalLengthClosure(part, a.X, "moveBody freeDrag x")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	y, err := optionalLengthClosure(part, a.Y, "moveBody freeDrag y")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	z, err := optionalLengthClosure(part, a.Z, "moveBody freeDrag z")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	return feature.FreeDragOp(x, y, z), nil
+}
+
+func buildAlongRayOp(part *compdef.PartComponentDefinition, a moveOpArg) (feature.MoveOperation, error) {
+	dir, err := vec3(a.Dir, "moveBody alongRay dir")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	dist, err := lengthClosure(part, a.Dist, "moveBody alongRay dist")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	return feature.AlongRayOp(dir, dist), nil
+}
+
+func buildRotateAboutLineOp(part *compdef.PartComponentDefinition, a moveOpArg) (feature.MoveOperation, error) {
+	dir, err := vec3(a.Dir, "moveBody rotateAboutLine dir")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	point, err := point3(a.Point, "moveBody rotateAboutLine point")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	angle, err := angleClosure(part, a.Angle, "moveBody rotateAboutLine angle")
+	if err != nil {
+		return feature.MoveOperation{}, err
+	}
+	return feature.RotateAboutLineOp(point, dir, angle), nil
 }
 
 // --- replace face ----------------------------------------------------------

--- a/addin/opregistry/feature_refs.go
+++ b/addin/opregistry/feature_refs.go
@@ -67,6 +67,15 @@ func optionalAngleClosure(part *compdef.PartComponentDefinition, expr, field str
 	return angleClosure(part, expr, field)
 }
 
+// optionalLengthClosure is lengthClosure that yields a constant 0 for a blank argument
+// (an omitted offset/distance is a no-op move component).
+func optionalLengthClosure(part *compdef.PartComponentDefinition, expr, field string) (func() float64, error) {
+	if strings.TrimSpace(expr) == "" {
+		return func() float64 { return 0 }, nil
+	}
+	return lengthClosure(part, expr, field)
+}
+
 // valueClosure is the shared core of the *Closure helpers: a plain unit literal
 // ("10 mm") becomes a constant closure; any expression (a parameter reference like
 // "h", or "h+2 mm") is backed by an auto-named model parameter so the argument joins

--- a/addin/router/move_operations_test.go
+++ b/addin/router/move_operations_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// TestMoveBodyOperationListShiftsBody drives the full wire path for an M20-F20 move
+// operation list — features.add(moveBody, operations:[freeDrag]) — and checks the body's
+// range box shifts by the requested offsets, proving the opregistry args resolve into a
+// composed, recomputed move (#654).
+func TestMoveBodyOperationListShiftsBody(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+
+	before := rangeBoxOf(t, r, s)
+	call(t, r, s, "features.add",
+		`{"kind":"moveBody","args":{"bodyIndex":0,"operations":[{"type":"freeDrag","x":"10 mm","z":"5 mm"}]}}`,
+		&struct{}{})
+	after := rangeBoxOf(t, r, s)
+
+	if got := after.Min[0] - before.Min[0]; math.Abs(got-1) > 1e-6 { // 10 mm = 1 cm
+		t.Errorf("range box min X moved by %g cm, want 1", got)
+	}
+	if got := after.Min[2] - before.Min[2]; math.Abs(got-0.5) > 1e-6 { // 5 mm = 0.5 cm
+		t.Errorf("range box min Z moved by %g cm, want 0.5", got)
+	}
+	if got := after.Min[1] - before.Min[1]; math.Abs(got) > 1e-6 {
+		t.Errorf("range box min Y moved by %g cm, want 0 (no Y offset)", got)
+	}
+}
+
+// TestMoveBodyOperationUnknownTypeFails rejects an unknown operation type with a precise
+// error rather than silently producing a no-op move.
+func TestMoveBodyOperationUnknownTypeFails(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	if _, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"moveBody","args":{"bodyIndex":0,"operations":[{"type":"warp"}]}}`)); err == nil {
+		t.Error("expected an error for an unknown move operation type")
+	}
+}
+
+// TestMoveBodyOperationScalarIsEditable proves a composed move exposes each operation's
+// scalar through features.edit: editing the along-ray distance re-shifts the body (#654).
+func TestMoveBodyOperationScalarIsEditable(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	call(t, r, s, "features.add",
+		`{"kind":"moveBody","args":{"bodyIndex":0,"operations":[{"type":"alongRay","dir":[1,0,0],"dist":"10 mm"}]}}`,
+		&struct{}{})
+	tree := modelTreeOf(t, r, s)
+	moveID := tree.Features[len(tree.Features)-1].ID
+
+	var detail wire.FeatureDetailResult
+	call(t, r, s, "features.get", mustJSON(t, wire.FeatureRefArgs{ID: moveID}), &detail)
+	if len(detail.Feature.Scalars) != 1 || detail.Feature.Scalars[0].Label != "Move 1 Distance" {
+		t.Fatalf("move scalars = %+v, want one 'Move 1 Distance'", detail.Feature.Scalars)
+	}
+
+	before := rangeBoxOf(t, r, s)
+	call(t, r, s, "features.edit",
+		mustJSON(t, wire.EditFeatureArgs{ID: moveID, Scalars: []wire.ScalarEdit{{Index: 0, Value: "30 mm"}}}),
+		&wire.FeatureDetailResult{})
+	after := rangeBoxOf(t, r, s)
+	if got := after.Min[0] - before.Min[0]; math.Abs(got-2) > 1e-6 { // 30 mm − 10 mm = 2 cm
+		t.Errorf("editing distance to 30 mm shifted X by %g cm, want 2", got)
+	}
+}
+
+func rangeBoxOf(t *testing.T, r *Router, s *app.Session) wire.BodyRangeBoxResult {
+	t.Helper()
+	var box wire.BodyRangeBoxResult
+	call(t, r, s, "body.rangeBox", `{"bodyIndex":0}`, &box)
+	return box
+}

--- a/model/feature/editable.go
+++ b/model/feature/editable.go
@@ -4,7 +4,9 @@ package feature
 
 import (
 	"bytes"
+	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
@@ -355,6 +357,35 @@ func (e *ExtrudeFeature) EditableParams() []EditableParam {
 // EditableParams exposes the revolve angle (0 ⇒ a full revolution).
 func (r *RevolveFeature) EditableParams() []EditableParam {
 	return []EditableParam{scalarParam("Angle", param.Angle, &r.def.Angle)}
+}
+
+// EditableParams exposes each move operation's own scalars in list order, so a composed
+// move ("rotate then slide") is edited per operation (M20-F20). A baked single-transform
+// move (no operation list) exposes nothing — its matrix is not a scalar surface.
+func (m *MoveFeature) EditableParams() []EditableParam {
+	var ps []EditableParam
+	for i := range m.def.Ops {
+		ps = append(ps, moveOpParams(i+1, &m.def.Ops[i])...)
+	}
+	return ps
+}
+
+// moveOpParams returns the editable scalars of the n-th move operation (1-based label).
+func moveOpParams(n int, op *MoveOperation) []EditableParam {
+	switch op.Kind {
+	case types.MoveFreeDrag:
+		return []EditableParam{
+			scalarParam(fmt.Sprintf("Move %d X", n), param.Length, &op.X),
+			scalarParam(fmt.Sprintf("Move %d Y", n), param.Length, &op.Y),
+			scalarParam(fmt.Sprintf("Move %d Z", n), param.Length, &op.Z),
+		}
+	case types.MoveAlongRay:
+		return []EditableParam{scalarParam(fmt.Sprintf("Move %d Distance", n), param.Length, &op.Dist)}
+	case types.MoveRotateAboutLine:
+		return []EditableParam{scalarParam(fmt.Sprintf("Move %d Angle", n), param.Angle, &op.Angle)}
+	default:
+		return nil
+	}
 }
 
 // EditableParams exposes the coil's pitch and revolution count.

--- a/model/feature/move.go
+++ b/model/feature/move.go
@@ -15,10 +15,23 @@ import (
 // in place, so its reference keys are preserved (the identity lineage map) and picks
 // against it survive the move (Inventor's MoveFeature / direct-edit move-body).
 
-// MoveDefinition is the recipe: which running body (by index) and the transform.
+// MoveDefinition is the recipe: which running body (by index) and how it moves. A move
+// is either a single baked Transform (the legacy form) or an ordered, separately
+// parametric operation list (Ops, M20-F20); when Ops is non-empty it is the source of
+// truth and Transform is ignored.
 type MoveDefinition struct {
 	BodyIndex int
 	Transform math.Matrix4
+	Ops       []MoveOperation
+}
+
+// transform returns the move's effective transform: the composition of the operation
+// list when present, else the baked Transform.
+func (d *MoveDefinition) transform() math.Matrix4 {
+	if len(d.Ops) == 0 {
+		return d.Transform
+	}
+	return composeMoveOps(d.Ops)
 }
 
 // MoveFeature applies the definition's transform to the target body each recompute.
@@ -35,7 +48,7 @@ func (m *MoveFeature) Recompute(in Input) (Output, error) {
 	if !validIndex(m.def.BodyIndex, in.Bodies) {
 		return Output{}, fmt.Errorf("move: invalid body index %d (have %d)", m.def.BodyIndex, len(in.Bodies))
 	}
-	moved, err := ops.TransformBody(in.Bodies[m.def.BodyIndex], m.def.Transform, keepLineage)
+	moved, err := ops.TransformBody(in.Bodies[m.def.BodyIndex], m.def.transform(), keepLineage)
 	if err != nil {
 		return Output{}, err
 	}
@@ -48,7 +61,13 @@ func (m *MoveFeature) Recompute(in Input) (Output, error) {
 // downstream features that picked the moved body's faces still resolve.
 func keepLineage(l topo.Lineage) topo.Lineage { return l }
 
-// AddMove relocates the running body at bodyIndex by transform.
+// AddMove relocates the running body at bodyIndex by a single baked transform.
 func (c *ModifyFeatures) AddMove(bodyIndex int, transform math.Matrix4) *PartFeature {
 	return c.engine.Add(&MoveFeature{def: &MoveDefinition{BodyIndex: bodyIndex, Transform: transform}})
+}
+
+// AddMoveOps relocates the running body at bodyIndex by an ordered list of parametric
+// move operations (free-drag / along-ray / rotate-about-line), composed in list order.
+func (c *ModifyFeatures) AddMoveOps(bodyIndex int, operations []MoveOperation) *PartFeature {
+	return c.engine.Add(&MoveFeature{def: &MoveDefinition{BodyIndex: bodyIndex, Ops: operations}})
 }

--- a/model/feature/move_operation.go
+++ b/model/feature/move_operation.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+)
+
+// Move operation list (M20-F20, #654). A MoveDefinition composes an ordered sequence of
+// independently parametric operations rather than a single baked matrix, so a move like
+// "rotate 30° about this edge, then slide 5 mm along it" round-trips as two separately
+// driven operations and each one's scalar can be edited on its own.
+
+// MoveOperationType aliases the public discriminator so existing call sites keep one
+// spelling (ADR-0018: the canonical definition lives in api/types).
+type MoveOperationType = types.MoveOperationType
+
+// MoveOperation is one entry in a MoveDefinition's operation list. The active fields
+// depend on Kind:
+//   - MoveFreeDrag:        X, Y, Z translation offsets (length closures).
+//   - MoveAlongRay:        Dir direction + Dist distance along it (length closure).
+//   - MoveRotateAboutLine: AxisPoint/AxisDir axis + Angle rotation (angle closure, radians).
+//
+// The scalars are func() float64 so a parameter edit is re-read on the next recompute.
+type MoveOperation struct {
+	Kind      MoveOperationType
+	X, Y, Z   func() float64
+	Dir       math.Vector3
+	Dist      func() float64
+	AxisPoint math.Point3
+	AxisDir   math.Vector3
+	Angle     func() float64
+}
+
+// Matrix returns the operation's current transform, reading its parametric closures live.
+// A degenerate ray/axis or an unknown kind yields the identity (a no-op) so composing the
+// list is always total — a sick operation never corrupts the others.
+func (o MoveOperation) Matrix() math.Matrix4 {
+	switch o.Kind {
+	case types.MoveFreeDrag:
+		return math.Translation4(math.V3(callOrZero(o.X), callOrZero(o.Y), callOrZero(o.Z)))
+	case types.MoveAlongRay:
+		dir, err := math.UnitVector3FromVector(o.Dir)
+		if err != nil {
+			return math.Identity4()
+		}
+		return math.Translation4(dir.AsVector().Scale(callOrZero(o.Dist)))
+	case types.MoveRotateAboutLine:
+		axis, err := math.UnitVector3FromVector(o.AxisDir)
+		if err != nil {
+			return math.Identity4()
+		}
+		return math.Rotation4(callOrZero(o.Angle), axis, o.AxisPoint)
+	default:
+		return math.Identity4()
+	}
+}
+
+// composeMoveOps multiplies the operations into a single transform applied in list order
+// (operation 0 first): each step left-multiplies, so the result is opₙ·…·op₀.
+func composeMoveOps(operations []MoveOperation) math.Matrix4 {
+	m := math.Identity4()
+	for _, op := range operations {
+		m = op.Matrix().Mul(m)
+	}
+	return m
+}
+
+// FreeDragOp builds a free-drag operation from X/Y/Z offset closures.
+func FreeDragOp(x, y, z func() float64) MoveOperation {
+	return MoveOperation{Kind: types.MoveFreeDrag, X: x, Y: y, Z: z}
+}
+
+// AlongRayOp builds a move-along-ray operation from a direction and a distance closure.
+func AlongRayOp(dir math.Vector3, dist func() float64) MoveOperation {
+	return MoveOperation{Kind: types.MoveAlongRay, Dir: dir, Dist: dist}
+}
+
+// RotateAboutLineOp builds a rotate-about-line operation from an axis and an angle closure.
+func RotateAboutLineOp(axisPoint math.Point3, axisDir math.Vector3, angle func() float64) MoveOperation {
+	return MoveOperation{Kind: types.MoveRotateAboutLine, AxisPoint: axisPoint, AxisDir: axisDir, Angle: angle}
+}

--- a/model/feature/move_test.go
+++ b/model/feature/move_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
@@ -64,5 +65,87 @@ func TestMoveFeatureRoundTrip(t *testing.T) {
 	}
 	if !def.Transform.IsEqualTo(tx, 1e-12) {
 		t.Errorf("transform not preserved:\n%v\n%v", def.Transform.Cells(), tx.Cells())
+	}
+}
+
+// TestMoveOpsComposeInOrder drives the unit prism with "rotate 90° about Z, then slide
+// +X 5": the rotation maps x∈[0,1] to x∈[-1,0], and the later slide carries it to [4,5],
+// proving the operations compose in list order (M20-F20, #654).
+func TestMoveOpsComposeInOrder(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(prismBody())
+	ops := []MoveOperation{
+		RotateAboutLineOp(math.P3(0, 0, 0), math.V3(0, 0, 1), constFloat(stdmath.Pi/2)),
+		AlongRayOp(math.V3(1, 0, 0), constFloat(5)),
+	}
+	move := NewModifyFeatures(fs).AddMoveOps(0, ops)
+	fs.Recompute()
+
+	if !move.Health().OK() {
+		t.Fatalf("move sick: %+v", move.Health())
+	}
+	box := fs.Result()[0].RangeBox()
+	if stdmath.Abs(box.Min.X-4) > 1e-9 || stdmath.Abs(box.Max.X-5) > 1e-9 {
+		t.Errorf("composed range box X = [%g,%g], want [4,5]", box.Min.X, box.Max.X)
+	}
+	if stdmath.Abs(box.Min.Y-0) > 1e-9 || stdmath.Abs(box.Max.Y-1) > 1e-9 {
+		t.Errorf("composed range box Y = [%g,%g], want [0,1]", box.Min.Y, box.Max.Y)
+	}
+}
+
+// TestMoveOpsRecomputeOnParamChange proves an operation's scalar is re-read live: moving
+// the closure's backing value and recomputing relocates the body to the new distance.
+func TestMoveOpsRecomputeOnParamChange(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(prismBody())
+	dist := 2.0
+	move := NewModifyFeatures(fs).AddMoveOps(0, []MoveOperation{
+		AlongRayOp(math.V3(1, 0, 0), func() float64 { return dist }),
+	})
+	fs.Recompute()
+	if box := fs.Result()[0].RangeBox(); stdmath.Abs(box.Min.X-2) > 1e-9 {
+		t.Fatalf("range box X min = %g, want 2 before edit", box.Min.X)
+	}
+	// A parameter edit marks dependent features dirty; here we change the backing value
+	// and mark the move so the next recompute re-reads the operation's live closure.
+	dist = 7
+	fs.MarkDirty(move)
+	fs.Recompute()
+	if box := fs.Result()[0].RangeBox(); stdmath.Abs(box.Min.X-7) > 1e-9 {
+		t.Errorf("range box X min = %g, want 7 after param change", box.Min.X)
+	}
+}
+
+// TestMoveOpsRoundTrip serializes and restores an operation list and checks the operation
+// kinds and the composed transform survive (M20-F20).
+func TestMoveOpsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	orig := []MoveOperation{
+		RotateAboutLineOp(math.P3(1, 0, 0), math.V3(0, 0, 1), constFloat(0.4)),
+		AlongRayOp(math.V3(0, 1, 0), constFloat(3)),
+		FreeDragOp(constFloat(1), constFloat(-2), constFloat(0.5)),
+	}
+	NewModifyFeatures(fs).AddMoveOps(2, orig)
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*MoveFeature).Definition()
+	if def.BodyIndex != 2 || len(def.Ops) != 3 {
+		t.Fatalf("restored move = body %d, %d ops; want body 2, 3 ops", def.BodyIndex, len(def.Ops))
+	}
+	wantKinds := []types.MoveOperationType{types.MoveRotateAboutLine, types.MoveAlongRay, types.MoveFreeDrag}
+	for i, want := range wantKinds {
+		if def.Ops[i].Kind != want {
+			t.Errorf("op %d kind = %q, want %q", i, def.Ops[i].Kind, want)
+		}
+	}
+	if want := composeMoveOps(orig); !def.transform().IsEqualTo(want, 1e-9) {
+		t.Errorf("composed transform not preserved:\n%v\n%v", def.transform().Cells(), want.Cells())
 	}
 }

--- a/model/feature/serialize_move.go
+++ b/model/feature/serialize_move.go
@@ -5,34 +5,127 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 )
 
-// MoveData is the serialized form of a MoveFeature: the target body index and the
-// transform as its 16 row-major cells (Inventor's GetMatrixData form). The cells are
-// the general affine form so any rigid move / mirror / uniform scale round-trips.
+// MoveData is the serialized form of a MoveFeature: the target body index and either a
+// single transform (the 16 row-major cells, the legacy form) or an ordered operation
+// list (M20-F20). Exactly one of Matrix/Ops is populated; an op list takes precedence
+// when present so the separately driven operations survive the round trip.
 type MoveData struct {
-	Body   int       `yaml:"body"`
-	Matrix []float64 `yaml:"matrix"`
+	Body   int          `yaml:"body"`
+	Matrix []float64    `yaml:"matrix,omitempty"`
+	Ops    []MoveOpData `yaml:"ops,omitempty"`
 }
 
-// serializeMove projects a move recipe to its persisted form.
+// MoveOpData is one serialized move operation. Only the fields its kind uses are written.
+type MoveOpData struct {
+	Kind   string    `yaml:"kind"`
+	Offset []float64 `yaml:"offset,omitempty"` // freeDrag [x,y,z]
+	Dir    []float64 `yaml:"dir,omitempty"`    // alongRay / rotate direction [x,y,z]
+	Dist   float64   `yaml:"dist,omitempty"`   // alongRay distance
+	Point  []float64 `yaml:"point,omitempty"`  // rotate axis point [x,y,z]
+	Angle  float64   `yaml:"angle,omitempty"`  // rotate angle (radians)
+}
+
+// serializeMove projects a move recipe to its persisted form (op list when present,
+// else the baked transform).
 func serializeMove(def *MoveDefinition) *MoveData {
+	if len(def.Ops) > 0 {
+		return &MoveData{Body: def.BodyIndex, Ops: encodeMoveOps(def.Ops)}
+	}
 	cells := def.Transform.Cells()
 	return &MoveData{Body: def.BodyIndex, Matrix: cells[:]}
 }
 
-// restoreMove rebuilds a MoveFeature, erroring on a missing payload or a matrix that
-// is not 16 cells (no silent loss of the transform).
+// encodeMoveOps freezes each operation's parametric scalars to their current value.
+func encodeMoveOps(operations []MoveOperation) []MoveOpData {
+	out := make([]MoveOpData, len(operations))
+	for i, op := range operations {
+		out[i] = encodeMoveOp(op)
+	}
+	return out
+}
+
+// encodeMoveOp serializes the fields the operation's kind uses.
+func encodeMoveOp(op MoveOperation) MoveOpData {
+	switch op.Kind {
+	case types.MoveFreeDrag:
+		return MoveOpData{Kind: string(op.Kind), Offset: []float64{evalFloat(op.X), evalFloat(op.Y), evalFloat(op.Z)}}
+	case types.MoveAlongRay:
+		return MoveOpData{Kind: string(op.Kind), Dir: moveVec3Cells(op.Dir), Dist: evalFloat(op.Dist)}
+	default: // MoveRotateAboutLine
+		return MoveOpData{Kind: string(op.Kind), Dir: moveVec3Cells(op.AxisDir), Point: movePoint3Cells(op.AxisPoint), Angle: evalFloat(op.Angle)}
+	}
+}
+
+// restoreMove rebuilds a MoveFeature, erroring on a missing payload or a malformed move.
 func restoreMove(fs *PartFeatures, d *MoveData) (*PartFeature, error) {
 	if d == nil {
 		return nil, fmt.Errorf("move feature is missing its payload")
+	}
+	m := NewModifyFeatures(fs)
+	if len(d.Ops) > 0 {
+		operations, err := decodeMoveOps(d.Ops)
+		if err != nil {
+			return nil, err
+		}
+		return m.AddMoveOps(d.Body, operations), nil
 	}
 	if len(d.Matrix) != 16 {
 		return nil, fmt.Errorf("move feature matrix has %d cells, want 16", len(d.Matrix))
 	}
 	var cells [16]float64
 	copy(cells[:], d.Matrix)
-	m := NewModifyFeatures(fs)
 	return m.AddMove(d.Body, math.Matrix4FromCells(cells)), nil
+}
+
+// decodeMoveOps rebuilds the operation list with constant closures (a reloaded file's
+// scalars are frozen values; an in-session edit re-parametrizes them).
+func decodeMoveOps(data []MoveOpData) ([]MoveOperation, error) {
+	out := make([]MoveOperation, len(data))
+	for i, od := range data {
+		op, err := decodeMoveOp(od)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = op
+	}
+	return out, nil
+}
+
+// decodeMoveOp rebuilds one operation, erroring on an unknown kind.
+func decodeMoveOp(od MoveOpData) (MoveOperation, error) {
+	kind := types.MoveOperationType(od.Kind)
+	switch kind {
+	case types.MoveFreeDrag:
+		o := moveVec3(od.Offset)
+		return FreeDragOp(constFloat(o.X), constFloat(o.Y), constFloat(o.Z)), nil
+	case types.MoveAlongRay:
+		return AlongRayOp(moveVec3(od.Dir), constFloat(od.Dist)), nil
+	case types.MoveRotateAboutLine:
+		return RotateAboutLineOp(movePoint3(od.Point), moveVec3(od.Dir), constFloat(od.Angle)), nil
+	default:
+		return MoveOperation{}, fmt.Errorf("move operation has unknown kind %q (want freeDrag/alongRay/rotateAboutLine)", od.Kind)
+	}
+}
+
+// moveVec3Cells / movePoint3Cells flatten a vector/point to [x,y,z]; moveVec3 /
+// movePoint3 are their inverses, tolerating a short/nil slice as the zero vector/point.
+func moveVec3Cells(v math.Vector3) []float64  { return []float64{v.X, v.Y, v.Z} }
+func movePoint3Cells(p math.Point3) []float64 { return []float64{p.X, p.Y, p.Z} }
+
+func moveVec3(a []float64) math.Vector3 {
+	if len(a) < 3 {
+		return math.Vector3{}
+	}
+	return math.V3(a[0], a[1], a[2])
+}
+
+func movePoint3(a []float64) math.Point3 {
+	if len(a) < 3 {
+		return math.Point3{}
+	}
+	return math.P3(a[0], a[1], a[2])
 }


### PR DESCRIPTION
Closes #654.

## What
`MoveDefinition` becomes an ordered list of typed, independently parametric **operations** instead of one baked matrix, so a composed move — *"rotate 30° about this edge, then slide 5 mm along it"* — round-trips and is edited as two separately driven operations.

- **model** (`move.go`, `move_operation.go`): `MoveOperation` with the three subtypes — free-drag (X/Y/Z), along-ray (dir + distance), rotate-about-line (axis + angle) — each with live `func() float64` scalars; `MoveDefinition.Ops` composed in list order; `AddMoveOps`. The legacy single-transform `AddMove` path is untouched (composition falls back to the baked `Transform` when there is no op list).
- **serialize** (`serialize_move.go`): `MoveData` gains an `ops` list (matrix retained for the baked form); `.obk` restores operation kinds + composed transform.
- **features.edit** (`editable.go`): `MoveFeature` exposes each operation's own scalars (`Move N X/Y/Z`, `Move N Distance`, `Move N Angle`).
- **opregistry** (`feature_advanced.go`): `moveBody` accepts an `operations[]` array with parameter-aware closures; the legacy `translation` form still works.

## Why
A single composed matrix cannot round-trip two separately driven parameters; the operation list makes each step independently parametric and editable, matching the reference `MoveDefinition`. This extends the Definition leg of the existing Move triangle only.

## Verification
- model: composition order, recompute on a scalar change, `.obk` round-trip
- router (wire path): operation list shifts the body, unknown op type errors, per-operation scalar edit re-shifts the body
- `go build`, `go test` (model/feature, addin/opregistry, addin/router), `go vet`, `golangci-lint` (0 issues) all pass locally

Depends on the M20 API parity contracts (Oblikovati.API#107, merged) for `types.MoveOperationType`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)