### PR TITLE
M20-F16: WorkSurface construction surfaces

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -105,6 +105,11 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
 	r.handlers[wire.MethodWorkPlanesRedefine] = redefineWorkPlane
 	r.handlers[wire.MethodWorkPointsCreate] = createWorkPoint
+
+	r.handlers[wire.MethodWorkSurfacesList] = listWorkSurfaces
+	r.handlers[wire.MethodWorkSurfacesGet] = getWorkSurface
+	r.handlers[wire.MethodWorkSurfacesSetVisible] = setWorkSurfaceVisible
+	r.handlers[wire.MethodWorkSurfacesRename] = renameWorkSurface
 	r.handlers[wire.MethodThemeActive] = themeActive
 	r.handlers[wire.MethodThemeList] = themeList
 	r.handlers[wire.MethodViewGetDisplayMode] = getDisplayMode
@@ -467,6 +472,8 @@ var mutatingMethods = map[string]bool{
 	wire.MethodWorkPlanesCreate:                    true,
 	wire.MethodWorkPlanesRedefine:                  true,
 	wire.MethodWorkPointsCreate:                    true,
+	wire.MethodWorkSurfacesSetVisible:              true,
+	wire.MethodWorkSurfacesRename:                  true,
 	wire.MethodAssemblyDeriveCreate:                true,
 	wire.MethodAssemblyShrinkwrapCreate:            true,
 	wire.MethodAssemblyDeriveBreakLink:             true,

--- a/addin/router/work_surfaces.go
+++ b/addin/router/work_surfaces.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// The WorkSurface wire surface (M20-F16): enumerate the part's construction surfaces (the
+// result's sheet bodies, wrapped as named, visibility-controlled objects), get one, and
+// set its visibility or name. The collection is produced by surface features, so there is
+// no create method (it mirrors how datum surfaces appear in the reference API).
+
+// listWorkSurfaces serves wire.MethodWorkSurfacesList.
+func listWorkSurfaces(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	col := part.WorkSurfaces()
+	out := make([]wire.WorkSurfaceInfo, col.Count())
+	for i := 0; i < col.Count(); i++ {
+		out[i] = workSurfaceInfo(i, col.Item(i))
+	}
+	return json.Marshal(wire.ListWorkSurfacesResult{Surfaces: out})
+}
+
+// getWorkSurface serves wire.MethodWorkSurfacesGet.
+func getWorkSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.WorkSurfaceRefArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	w := part.WorkSurfaces().Item(in.Index)
+	if w == nil {
+		return nil, noSuchWorkSurface(part, in.Index)
+	}
+	return json.Marshal(wire.WorkSurfaceDetailResult{Surface: workSurfaceInfo(in.Index, w)})
+}
+
+// setWorkSurfaceVisible serves wire.MethodWorkSurfacesSetVisible.
+func setWorkSurfaceVisible(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetWorkSurfaceVisibleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	w := part.WorkSurfaces().Item(in.Index)
+	if w == nil {
+		return nil, noSuchWorkSurface(part, in.Index)
+	}
+	w.SetVisible(in.Visible)
+	part.MarkChanged() // bump the version so the viewport re-renders the surface's new state
+	return json.Marshal(wire.WorkSurfaceDetailResult{Surface: workSurfaceInfo(in.Index, w)})
+}
+
+// renameWorkSurface serves wire.MethodWorkSurfacesRename.
+func renameWorkSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.RenameWorkSurfaceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	col := part.WorkSurfaces()
+	w := col.Item(in.Index)
+	if w == nil {
+		return nil, noSuchWorkSurface(part, in.Index)
+	}
+	if col.HasName(in.Name, in.Index) {
+		return nil, fmt.Errorf("workSurfaces.rename: name %q is already used by another surface", in.Name)
+	}
+	if err := w.SetName(in.Name); err != nil {
+		return nil, fmt.Errorf("workSurfaces.rename: %w", err)
+	}
+	part.MarkChanged()
+	return json.Marshal(wire.WorkSurfaceDetailResult{Surface: workSurfaceInfo(in.Index, w)})
+}
+
+// noSuchWorkSurface is the shared "index out of range" error, naming the bound.
+func noSuchWorkSurface(part *compdef.PartComponentDefinition, index int) error {
+	return fmt.Errorf("workSurfaces: no surface at index %d (have %d)", index, part.WorkSurfaces().Count())
+}
+
+// workSurfaceInfo projects one surface to its wire row.
+func workSurfaceInfo(index int, w *feature.WorkSurface) wire.WorkSurfaceInfo {
+	bodies := 0
+	if w.Body() != nil {
+		bodies = 1
+	}
+	return wire.WorkSurfaceInfo{
+		Index:       index,
+		Name:        w.Name(),
+		Ref:         fmt.Sprintf("surface/%d", index),
+		Visible:     w.Visible(),
+		Translucent: w.Translucent(),
+		Bodies:      bodies,
+		Source:      w.Source(),
+	}
+}

--- a/addin/router/work_surfaces_test.go
+++ b/addin/router/work_surfaces_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// patchedSurfacePartViaAPI drives the wire surface to a part with one boundary-patch
+// surface body (a closed rectangle filled with a sheet), the fixture the WorkSurface
+// methods read (M20-F16).
+func patchedSurfacePartViaAPI(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"boundaryPatch","args":{"sketchIndex":0}}`, &struct{}{})
+	return r, s
+}
+
+func TestWorkSurfacesListReportsPatchSurface(t *testing.T) {
+	r, s := patchedSurfacePartViaAPI(t)
+	var got wire.ListWorkSurfacesResult
+	call(t, r, s, "workSurfaces.list", `{}`, &got)
+	if len(got.Surfaces) != 1 {
+		t.Fatalf("workSurfaces.list = %d surfaces, want 1", len(got.Surfaces))
+	}
+	su := got.Surfaces[0]
+	if su.Name != "Surface1" || su.Ref != "surface/0" || !su.Visible || su.Bodies != 1 {
+		t.Errorf("surface = %+v, want Surface1/surface/0/visible/1 body", su)
+	}
+}
+
+func TestWorkSurfacesSetVisibleAndRename(t *testing.T) {
+	r, s := patchedSurfacePartViaAPI(t)
+
+	var hidden wire.WorkSurfaceDetailResult
+	call(t, r, s, "workSurfaces.setVisible", mustJSON(t, wire.SetWorkSurfaceVisibleArgs{Index: 0, Visible: false}), &hidden)
+	if hidden.Surface.Visible {
+		t.Errorf("after setVisible(false) surface is still visible: %+v", hidden.Surface)
+	}
+
+	var renamed wire.WorkSurfaceDetailResult
+	call(t, r, s, "workSurfaces.rename", mustJSON(t, wire.RenameWorkSurfaceArgs{Index: 0, Name: "Parting"}), &renamed)
+	if renamed.Surface.Name != "Parting" {
+		t.Errorf("after rename, name = %q, want Parting", renamed.Surface.Name)
+	}
+
+	// The change is observable via get and survives (state held in the collection).
+	var got wire.WorkSurfaceDetailResult
+	call(t, r, s, "workSurfaces.get", mustJSON(t, wire.WorkSurfaceRefArgs{Index: 0}), &got)
+	if got.Surface.Name != "Parting" || got.Surface.Visible {
+		t.Errorf("get = %+v, want hidden surface named Parting", got.Surface)
+	}
+}
+
+func TestWorkSurfacesRenameRejectsEmpty(t *testing.T) {
+	r, s := patchedSurfacePartViaAPI(t)
+	if _, err := r.Handle(s, "workSurfaces.rename", []byte(mustJSON(t, wire.RenameWorkSurfaceArgs{Index: 0, Name: ""}))); err == nil {
+		t.Error("empty rename must be rejected")
+	}
+}
+
+func TestWorkSurfacesGetOutOfRangeFails(t *testing.T) {
+	r, s := patchedSurfacePartViaAPI(t)
+	if _, err := r.Handle(s, "workSurfaces.get", []byte(mustJSON(t, wire.WorkSurfaceRefArgs{Index: 9}))); err == nil {
+		t.Error("get with an out-of-range index must fail")
+	}
+}

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -31,6 +31,7 @@ type PartComponentDefinition struct {
 	features   *feature.PartFeatures
 	keys       *identity.KeyManager
 	work       *feature.WorkGeometry // origin coordinate frame + user work planes/axes/points
+	surfaces   *feature.WorkSurfaces // construction surfaces wrapping the result's sheet bodies (M20-F16)
 	units      param.UnitsOfMeasure  // document display units (length/angle/…)
 	version    uint64
 	eop        int // end-of-part feature index; endOfPartAtEnd ⇒ full program
@@ -62,6 +63,7 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		features:    feature.NewPartFeatures(params, keys),
 		keys:        keys,
 		work:        feature.NewWorkGeometry(),
+		surfaces:    feature.NewWorkSurfaces(),
 		units:       param.DefaultUnitsOfMeasure(),
 		eop:         endOfPartAtEnd,
 		assignments: material.NewAssignmentStore(),
@@ -128,6 +130,7 @@ func (d *PartComponentDefinition) Recompute() {
 	for _, b := range d.features.Result() {
 		d.bodies.Add(b)
 	}
+	d.surfaces.Sync(d.features.Result()) // gather the result's sheet bodies as work surfaces (M20-F16)
 	d.refreshSketchReferences()
 	d.MarkChanged()
 }

--- a/model/compdef/workplane.go
+++ b/model/compdef/workplane.go
@@ -21,6 +21,10 @@ func (d *PartComponentDefinition) UserCoordinateSystems() *feature.UserCoordinat
 	return d.work.UserCoordinateSystems()
 }
 
+// WorkSurfaces exposes the part's construction surfaces (the result's sheet bodies wrapped
+// as named, visibility-controlled objects), kept in sync by Recompute (M20-F16).
+func (d *PartComponentDefinition) WorkSurfaces() *feature.WorkSurfaces { return d.surfaces }
+
 // OriginPlanes returns the part's origin datum planes (XY/XZ/YZ), the Origin folder's
 // contents in the browser and the default sketch hosts.
 func (d *PartComponentDefinition) OriginPlanes() []*feature.WorkPlane {

--- a/model/feature/work_surface.go
+++ b/model/feature/work_surface.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// WorkSurface construction surfaces (M20-F16, #654… see #650). A surface-output feature
+// (a surface extrude/revolve/loft/sweep, a boundary patch, a knit/stitch, a ruled or
+// trim/extend result) emits an open sheet body rather than a solid. Those sheet bodies are
+// gathered here as named, visibility-controlled WorkSurfaces, so they can be addressed,
+// hidden, renamed, and (later) consumed by reference — mirroring how WorkPlanes wraps datum
+// planes. WorkSurfaces is a work-feature-like collection (produced by features, no Add of
+// its own), not a feature triangle.
+
+// WorkSurface is one named construction surface wrapping a surface (sheet) body.
+type WorkSurface struct {
+	name        string
+	visible     bool
+	translucent bool
+	body        *topo.Body // current geometry, refreshed each Sync (body identity is not stable)
+	source      string     // best-effort name of the producing feature (may be empty)
+}
+
+// Name / Visible / Translucent / Body / Source expose the surface's state.
+func (w *WorkSurface) Name() string          { return w.name }
+func (w *WorkSurface) Visible() bool         { return w.visible }
+func (w *WorkSurface) Translucent() bool     { return w.translucent }
+func (w *WorkSurface) Body() *topo.Body      { return w.body }
+func (w *WorkSurface) Source() string        { return w.source }
+func (w *WorkSurface) SetVisible(v bool)     { w.visible = v }
+func (w *WorkSurface) SetTranslucent(v bool) { w.translucent = v }
+
+// SetName renames the surface; an empty name is rejected so the browser always has a label.
+func (w *WorkSurface) SetName(name string) error {
+	if name == "" {
+		return fmt.Errorf("work surface name must not be empty")
+	}
+	w.name = name
+	return nil
+}
+
+// WorkSurfaces is the part's ordered collection of construction surfaces. It is kept in
+// sync with the model's surface bodies; display state (name/visibility/translucency) is
+// keyed by position, so it survives a recompute that rebuilds the underlying body objects.
+type WorkSurfaces struct {
+	items []*WorkSurface
+}
+
+// NewWorkSurfaces returns an empty collection.
+func NewWorkSurfaces() *WorkSurfaces { return &WorkSurfaces{} }
+
+// Count / All / Item read the collection. Item returns nil for an out-of-range index.
+func (c *WorkSurfaces) Count() int          { return len(c.items) }
+func (c *WorkSurfaces) All() []*WorkSurface { return c.items }
+func (c *WorkSurfaces) Item(i int) *WorkSurface {
+	if i < 0 || i >= len(c.items) {
+		return nil
+	}
+	return c.items[i]
+}
+
+// Sync reconciles the collection with the part's current result bodies: the surface
+// (non-solid) bodies, in result order, become the work surfaces. A surviving position
+// keeps its display state and just refreshes its body; a new position is auto-named
+// "Surfacei"; trailing positions whose surfaces are gone are dropped.
+func (c *WorkSurfaces) Sync(bodies []*topo.Body) {
+	surfaces := surfaceBodiesOf(bodies)
+	for i, b := range surfaces {
+		if i < len(c.items) {
+			c.items[i].body = b
+			continue
+		}
+		c.items = append(c.items, &WorkSurface{name: fmt.Sprintf("Surface%d", i+1), visible: true, body: b})
+	}
+	if len(surfaces) < len(c.items) {
+		c.items = c.items[:len(surfaces)]
+	}
+}
+
+// HasName reports whether another surface (not the one at exclude) already uses name —
+// the uniqueness guard a rename consults.
+func (c *WorkSurfaces) HasName(name string, exclude int) bool {
+	for i, w := range c.items {
+		if i != exclude && w.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// surfaceBodiesOf returns the open (non-solid) sheet bodies of a result body list.
+func surfaceBodiesOf(bodies []*topo.Body) []*topo.Body {
+	var out []*topo.Body
+	for _, b := range bodies {
+		if b != nil && !b.IsSolid() {
+			out = append(out, b)
+		}
+	}
+	return out
+}

--- a/model/feature/work_surface_test.go
+++ b/model/feature/work_surface_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// TestWorkSurfacesSyncGathersSheetBodies keeps only the open (non-solid) bodies of a
+// result and auto-names them in order (M20-F16).
+func TestWorkSurfacesSyncGathersSheetBodies(t *testing.T) {
+	c := NewWorkSurfaces()
+	c.Sync([]*topo.Body{prismBody(), patchSurfaceBody(2, 3), prismBody(), patchSurfaceBody(1, 1)})
+
+	if c.Count() != 2 {
+		t.Fatalf("work surface count = %d, want 2 (only the sheet bodies)", c.Count())
+	}
+	if c.Item(0).Name() != "Surface1" || c.Item(1).Name() != "Surface2" {
+		t.Errorf("names = %q,%q, want Surface1,Surface2", c.Item(0).Name(), c.Item(1).Name())
+	}
+	if !c.Item(0).Visible() || c.Item(0).Translucent() {
+		t.Errorf("new surface defaults = visible %v translucent %v, want true/false", c.Item(0).Visible(), c.Item(0).Translucent())
+	}
+}
+
+// TestWorkSurfacesSyncPreservesDisplayState keeps a renamed/hidden surface's state across
+// a resync that rebuilds the underlying body objects, and drops a surface that disappears.
+func TestWorkSurfacesSyncPreservesDisplayState(t *testing.T) {
+	c := NewWorkSurfaces()
+	c.Sync([]*topo.Body{patchSurfaceBody(2, 3), patchSurfaceBody(1, 1)})
+	if err := c.Item(0).SetName("Parting"); err != nil {
+		t.Fatalf("SetName: %v", err)
+	}
+	c.Item(0).SetVisible(false)
+	c.Item(0).SetTranslucent(true)
+
+	// A fresh recompute hands back new body objects for the same surfaces.
+	fresh := patchSurfaceBody(2, 3)
+	c.Sync([]*topo.Body{fresh, patchSurfaceBody(1, 1)})
+	if got := c.Item(0); got.Name() != "Parting" || got.Visible() || !got.Translucent() {
+		t.Errorf("display state lost on resync: name %q visible %v translucent %v", got.Name(), got.Visible(), got.Translucent())
+	}
+	if c.Item(0).Body() != fresh {
+		t.Error("surface body not refreshed to the new object on resync")
+	}
+
+	// Dropping the second surface trims the collection.
+	c.Sync([]*topo.Body{patchSurfaceBody(2, 3)})
+	if c.Count() != 1 {
+		t.Errorf("count after a surface disappears = %d, want 1", c.Count())
+	}
+}
+
+// TestWorkSurfacesRenameGuards rejects an empty name and reports a duplicate (excluding self).
+func TestWorkSurfacesRenameGuards(t *testing.T) {
+	c := NewWorkSurfaces()
+	c.Sync([]*topo.Body{patchSurfaceBody(2, 3), patchSurfaceBody(1, 1)})
+	if err := c.Item(0).SetName(""); err == nil {
+		t.Error("empty name must be rejected")
+	}
+	if c.HasName("Surface1", 0) {
+		t.Error("HasName must exclude the surface at the excluded index")
+	}
+	if !c.HasName("Surface2", 0) {
+		t.Error("HasName must report a name used by another surface")
+	}
+}
+
+// TestWorkSurfacesItemOutOfRange returns nil rather than panicking.
+func TestWorkSurfacesItemOutOfRange(t *testing.T) {
+	c := NewWorkSurfaces()
+	if c.Item(0) != nil || c.Item(-1) != nil {
+		t.Error("Item out of range must be nil")
+	}
+}


### PR DESCRIPTION
Closes #650.

## What
Surface-output features emit open **sheet bodies** that, until now, could not be addressed, named, or hidden. This gathers them as a **WorkSurfaces** collection on the part — named, visibility-controlled construction surfaces — mirroring how WorkPlanes wraps datum planes.

- **model** (`work_surface.go`): `WorkSurface` (name / visible / translucent / body / source) + `WorkSurfaces` collection whose `Sync` reconciles against the result's sheet bodies (`IsSolid()==false`), **preserving display state by position** across recomputes (body identity is not stable) and auto-naming new ones `Surface1…`.
- **compdef** (`part.go`, `workplane.go`): `PartComponentDefinition` owns the collection, syncs it each `Recompute`, and exposes `WorkSurfaces()` alongside `WorkPlanes()`/`WorkPoints()`.
- **router** (`work_surfaces.go`): `workSurfaces.list / get / setVisible / rename` handlers (the API contract landed in Oblikovati.API#107); `setVisible`/`rename` join the collaboration-broadcast allowlist.

## Why
The reference API surfaces these sheet bodies as a `WorkSurfaces` collection of named, visibility-controlled `WorkSurface` objects so they can be hidden, renamed, and consumed by reference. Modeled like a work feature (produced by features, no `Add`), not a feature triangle.

## Verification
- model: `Sync` keeps only sheet bodies, preserves a renamed/hidden surface across a resync that rebuilds bodies, drops a removed surface
- router (wire path): lists a boundary-patch surface; set/get visibility + name; rejects empty rename and out-of-range index
- `go build`, `go test` (model/feature, model/compdef, addin/router), `go vet`, `golangci-lint` (0 issues) pass locally

## Follow-ups (not in this PR)
Honoring visibility in the head renderer; accepting a WorkSurface as a feature input (split tool / to-face extent); the assembly `WorkSurfaceProxy`; `.obk` persistence of names/visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)