### PR TITLE
M20-F18: Pattern definition option parity

### DIFF
--- a/addin/opregistry/feature_pattern.go
+++ b/addin/opregistry/feature_pattern.go
@@ -5,8 +5,10 @@ package opregistry
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
@@ -18,17 +20,32 @@ import (
 // resolved to their ids; the layout is given numerically (counts, steps, axis, plane normal).
 
 type patternArgs struct {
-	SourceFeatures []string  `json:"sourceFeatures"`
-	CountX         int       `json:"countX,omitempty"`
-	CountY         int       `json:"countY,omitempty"`
-	StepX          []float64 `json:"stepX,omitempty"`
-	StepY          []float64 `json:"stepY,omitempty"`
-	Count          int       `json:"count,omitempty"`
-	Angle          string    `json:"angle,omitempty"`
-	AxisPoint      []float64 `json:"axisPoint,omitempty"`
-	AxisDir        []float64 `json:"axisDir,omitempty"`
-	Normal         []float64 `json:"normal,omitempty"`
-	Origin         []float64 `json:"origin,omitempty"`
+	SourceFeatures    []string     `json:"sourceFeatures"`
+	CountX            int          `json:"countX,omitempty"`
+	CountY            int          `json:"countY,omitempty"`
+	StepX             []float64    `json:"stepX,omitempty"`
+	StepY             []float64    `json:"stepY,omitempty"`
+	Count             int          `json:"count,omitempty"`
+	Angle             string       `json:"angle,omitempty"`
+	AxisPoint         []float64    `json:"axisPoint,omitempty"`
+	AxisDir           []float64    `json:"axisDir,omitempty"`
+	Normal            []float64    `json:"normal,omitempty"`
+	Origin            []float64    `json:"origin,omitempty"`
+	SpacingType       string       `json:"spacingType,omitempty"`
+	ComputeType       string       `json:"computeType,omitempty"`
+	Orientation       string       `json:"orientation,omitempty"`
+	PositioningMethod string       `json:"positioningMethod,omitempty"`
+	Boundary          *boundaryArg `json:"boundary,omitempty"`
+}
+
+// boundaryArg is the optional pattern-clipping boundary (M20-F18): a closed loop of 3D
+// points (cm) projected into the plane through planeOrigin with planeNormal; an occurrence
+// is dropped when its centre falls outside the loop.
+type boundaryArg struct {
+	PlaneOrigin []float64   `json:"planeOrigin,omitempty"`
+	PlaneNormal []float64   `json:"planeNormal"`
+	Polygon     [][]float64 `json:"polygon"`
+	Inclusion   string      `json:"inclusion,omitempty"`
 }
 
 const rectPatternSchema = `{
@@ -38,7 +55,17 @@ const rectPatternSchema = `{
     "countX": {"type": "integer", "minimum": 1, "default": 2},
     "countY": {"type": "integer", "minimum": 1, "default": 1},
     "stepX": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the first direction [x,y,z] in cm."},
-    "stepY": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the second direction [x,y,z] in cm."}
+    "stepY": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the second direction [x,y,z] in cm."},
+    "spacingType": {"type": "string", "enum": ["spacing", "fitted", "fitToPathLength"], "description": "How a step is read: 'spacing' = gap between occurrences (default); 'fitted' = total span divided across the count."},
+    "computeType": {"type": "string", "enum": ["identical", "adjustToModel", "optimized"], "description": "How each occurrence is computed."},
+    "orientation": {"type": "string", "enum": ["identical", "direction1", "direction2"], "description": "How each occurrence is oriented."},
+    "positioningMethod": {"type": "string", "enum": ["fitted", "incremental"], "description": "How occurrences are positioned along a direction."},
+    "boundary": {"type": "object", "description": "Clip the pattern: drop occurrences whose centre falls outside this loop.", "properties": {
+      "planeOrigin": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Boundary plane origin [x,y,z] (default origin)."},
+      "planeNormal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Boundary plane normal [x,y,z]."},
+      "polygon": {"type": "array", "items": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}, "description": "Closed loop of 3D points (cm) projected into the plane."},
+      "inclusion": {"type": "string", "enum": ["enclosed", "centroid", "basePoint"], "description": "Which occurrence point the boundary tests (default centroid)."}
+    }, "required": ["planeNormal", "polygon"]}
   },
   "required": ["sourceFeatures", "stepX"]
 }`
@@ -50,7 +77,17 @@ const circPatternSchema = `{
     "count": {"type": "integer", "minimum": 1, "default": 4},
     "angle": {"type": "string", "description": "Total sweep angle, e.g. \"360 deg\"."},
     "axisPoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "A point on the rotation axis [x,y,z] (default origin)."},
-    "axisDir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Rotation axis direction [x,y,z] (default +Z)."}
+    "axisDir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Rotation axis direction [x,y,z] (default +Z)."},
+    "spacingType": {"type": "string", "enum": ["spacing", "fitted", "fitToPathLength"], "description": "How 'angle' is read: 'spacing' = per-occurrence increment; 'fitted' = spread count across the angle inclusive; default = angle divided by count (full sweep)."},
+    "computeType": {"type": "string", "enum": ["identical", "adjustToModel", "optimized"], "description": "How each occurrence is computed."},
+    "orientation": {"type": "string", "enum": ["identical", "direction1", "direction2"], "description": "How each occurrence is oriented."},
+    "positioningMethod": {"type": "string", "enum": ["fitted", "incremental"], "description": "How occurrences are positioned."},
+    "boundary": {"type": "object", "description": "Clip the pattern: drop occurrences whose centre falls outside this loop.", "properties": {
+      "planeOrigin": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3},
+      "planeNormal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3},
+      "polygon": {"type": "array", "items": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}},
+      "inclusion": {"type": "string", "enum": ["enclosed", "centroid", "basePoint"]}
+    }, "required": ["planeNormal", "polygon"]}
   },
   "required": ["sourceFeatures", "count", "angle"]
 }`
@@ -111,7 +148,12 @@ func applyRectPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 		}
 	}
 	cx, cy := defaultInt(in.CountX, 2), defaultInt(in.CountY, 1)
-	feature.NewPatternFeatures(part.Features()).AddRectangular(ids, constIntFn(cx), constIntFn(cy), stepX, stepY)
+	opts, err := patternOptions(in)
+	if err != nil {
+		return nil, err
+	}
+	f := feature.NewPatternFeatures(part.Features()).AddRectangular(ids, constIntFn(cx), constIntFn(cy), stepX, stepY)
+	f.Definition().Options = opts
 	return lastFeatureResult(part)
 }
 
@@ -124,8 +166,78 @@ func applyCircPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	if err != nil {
 		return nil, err
 	}
-	feature.NewPatternFeatures(part.Features()).AddCircular(ids, constIntFn(defaultInt(in.Count, 4)), angle, originOr(in.AxisPoint), zAxisOr(in.AxisDir))
+	opts, err := patternOptions(in)
+	if err != nil {
+		return nil, err
+	}
+	f := feature.NewPatternFeatures(part.Features()).AddCircular(ids, constIntFn(defaultInt(in.Count, 4)), angle, originOr(in.AxisPoint), zAxisOr(in.AxisDir))
+	f.Definition().Options = opts
 	return lastFeatureResult(part)
+}
+
+// patternOptions resolves the M20-F18 option fields (spacing/compute/orientation/
+// positioning + boundary) from the request, defaulting to the legacy zero value.
+func patternOptions(in patternArgs) (feature.PatternOptions, error) {
+	o, err := patternEnumOptions(in)
+	if err != nil {
+		return o, err
+	}
+	if in.Boundary != nil {
+		o.Boundary, err = buildPatternBoundary(in.Boundary)
+	}
+	return o, err
+}
+
+// patternEnumOptions parses the four enum option fields, rejecting a non-empty unknown.
+func patternEnumOptions(in patternArgs) (feature.PatternOptions, error) {
+	var o feature.PatternOptions
+	var ok bool
+	if in.SpacingType != "" {
+		if o.Spacing, ok = types.ParsePatternSpacingType(in.SpacingType); !ok {
+			return o, fmt.Errorf("pattern: unknown spacingType %q", in.SpacingType)
+		}
+	}
+	if in.ComputeType != "" {
+		if o.Compute, ok = types.ParsePatternComputeType(in.ComputeType); !ok {
+			return o, fmt.Errorf("pattern: unknown computeType %q", in.ComputeType)
+		}
+	}
+	if in.Orientation != "" {
+		if o.Orientation, ok = types.ParsePatternOrientation(in.Orientation); !ok {
+			return o, fmt.Errorf("pattern: unknown orientation %q", in.Orientation)
+		}
+	}
+	if in.PositioningMethod != "" {
+		if o.Positioning, ok = types.ParsePatternPositioningMethod(in.PositioningMethod); !ok {
+			return o, fmt.Errorf("pattern: unknown positioningMethod %q", in.PositioningMethod)
+		}
+	}
+	return o, nil
+}
+
+// buildPatternBoundary turns the boundary request into a model clipping boundary.
+func buildPatternBoundary(b *boundaryArg) (*feature.PatternBoundary, error) {
+	if len(b.PlaneNormal) != 3 {
+		return nil, errors.New("pattern boundary: planeNormal needs 3 components [x,y,z]")
+	}
+	normal, _ := vec3(b.PlaneNormal, "pattern boundary normal")
+	poly := make([]math.Point3, len(b.Polygon))
+	for i, p := range b.Polygon {
+		q, err := point3(p, "pattern boundary polygon vertex")
+		if err != nil {
+			return nil, err
+		}
+		poly[i] = q
+	}
+	incl := types.IncludeByCentroid
+	if b.Inclusion != "" {
+		v, ok := types.ParsePatternBoundaryInclusion(b.Inclusion)
+		if !ok {
+			return nil, fmt.Errorf("pattern boundary: unknown inclusion %q", b.Inclusion)
+		}
+		incl = v
+	}
+	return feature.NewPatternBoundary(originOr(b.PlaneOrigin), normal, poly, incl)
 }
 
 func applyMirror(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/pattern_options_test.go
+++ b/addin/router/pattern_options_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestPatternRectangularAcceptsOptions drives the full wire path for an M20-F18 pattern
+// with a spacing type and a clipping boundary: three new-body occurrences 5 cm apart along
+// X, clipped to a box that excludes the third, leave the seed plus one copy (#652).
+func TestPatternRectangularAcceptsOptions(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t) // one 40×30 mm extrude (Extrusion1) → one solid body
+	if before := bodyCount(t, r, s); before != 1 {
+		t.Fatalf("fixture body count = %d, want 1", before)
+	}
+	call(t, r, s, "features.add", `{"kind":"patternRectangular","args":{
+		"sourceFeatures":["Extrusion1"],"countX":3,"countY":1,"stepX":[5,0,0],
+		"spacingType":"spacing",
+		"boundary":{"planeNormal":[0,0,1],"polygon":[[-5,-5,0],[8,-5,0],[8,5,0],[-5,5,0]],"inclusion":"centroid"}
+	}}`, &struct{}{})
+	if after := bodyCount(t, r, s); after != 2 {
+		t.Errorf("clipped pattern body count = %d, want 2 (seed + one in-bounds copy)", after)
+	}
+}
+
+// TestPatternRectangularRejectsUnknownSpacing surfaces a precise error for an unknown enum.
+func TestPatternRectangularRejectsUnknownSpacing(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	_, err := r.Handle(s, "features.add", []byte(`{"kind":"patternRectangular","args":{
+		"sourceFeatures":["Extrusion1"],"countX":2,"stepX":[5,0,0],"spacingType":"zigzag"}}`))
+	if err == nil {
+		t.Error("expected an error for an unknown spacingType")
+	}
+}
+
+func bodyCount(t *testing.T, r *Router, s *app.Session) int {
+	t.Helper()
+	return modelTreeOf(t, r, s).Bodies
+}

--- a/model/feature/pattern_options.go
+++ b/model/feature/pattern_options.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Pattern definition option surface (M20-F18, #652). Beyond a count and spacing, the
+// reference rectangular/circular pattern definitions carry: how a direction's spacing
+// value is interpreted, how each occurrence is computed and oriented, the positioning
+// method, and an optional boundary that clips the run. Compute/Orientation/Positioning
+// are carried here so they round-trip and are addressable; the spacing interpretation and
+// the boundary clip change the produced geometry today. The zero value of every field
+// reproduces the legacy behavior, so an existing pattern is unaffected.
+
+// PatternOptions is the shared option block both pattern definitions embed.
+type PatternOptions struct {
+	Spacing     types.PatternSpacingType
+	Compute     types.PatternComputeType
+	Orientation types.PatternOrientation
+	Positioning types.PatternPositioningMethod
+	Boundary    *PatternBoundary
+}
+
+// PatternBoundary clips a pattern to a closed loop: an occurrence is kept only when its
+// test point (the running body's centre, transformed into place) lies inside the polygon,
+// projected into the boundary plane. Inclusion records which point the reference tests by;
+// all three reduce to the same centre-point probe in this first implementation.
+type PatternBoundary struct {
+	Plane     geom.Plane
+	Polygon   []math.Point2
+	Inclusion types.PatternBoundaryInclusion
+}
+
+// rectStep returns the per-occurrence offset for a direction given its raw step vector and
+// the occurrence count: a "fitted" pattern treats the step as the TOTAL span and divides it
+// across the gaps, every other spacing keeps it as the gap itself.
+func (o PatternOptions) rectStep(step math.Vector3, count int) math.Vector3 {
+	if o.Spacing == types.SpacingFitted && count > 1 {
+		return step.Scale(1 / float64(count-1))
+	}
+	return step
+}
+
+// circIncrement returns the angle between adjacent circular occurrences: "between" treats
+// the angle as the per-occurrence increment, "fitted" spreads count occurrences across the
+// angle inclusive of both ends, and the unset default divides the angle by the count (the
+// legacy full-sweep behavior).
+func (o PatternOptions) circIncrement(angle float64, count int) float64 {
+	if count <= 1 {
+		return 0
+	}
+	switch o.Spacing {
+	case types.SpacingBetween:
+		return angle
+	case types.SpacingFitted:
+		return angle / float64(count-1)
+	default:
+		return angle / float64(count)
+	}
+}
+
+// clippedOccurrences returns the occurrence indices the boundary excludes. Occurrence 0
+// (the seed) is never clipped; a nil/degenerate boundary or a missing seed clips nothing.
+func (o PatternOptions) clippedOccurrences(transforms []math.Matrix4, seed math.Point3, hasSeed bool) map[int]bool {
+	clipped := map[int]bool{}
+	if !hasSeed || o.Boundary == nil || len(o.Boundary.Polygon) < 3 {
+		return clipped
+	}
+	for k := 1; k < len(transforms); k++ {
+		if !o.Boundary.contains(transforms[k].TransformPoint(seed)) {
+			clipped[k] = true
+		}
+	}
+	return clipped
+}
+
+// NewPatternBoundary builds a clipping boundary from a closed loop of 3D points and the
+// plane (origin + normal) they are projected into. The polygon is stored in the plane's
+// (u,v) frame; callers pass model-space points and need not know the basis.
+func NewPatternBoundary(origin math.Point3, normal math.Vector3, polygon []math.Point3, inclusion types.PatternBoundaryInclusion) (*PatternBoundary, error) {
+	plane, err := geom.NewPlane(origin, normal)
+	if err != nil {
+		return nil, err
+	}
+	poly := make([]math.Point2, len(polygon))
+	for i, p := range polygon {
+		poly[i] = planeProject2D(plane, p)
+	}
+	return &PatternBoundary{Plane: plane, Polygon: poly, Inclusion: inclusion}, nil
+}
+
+// contains reports whether p, projected into the boundary plane, is inside the polygon.
+func (b *PatternBoundary) contains(p math.Point3) bool {
+	return pointInsidePolygon2(planeProject2D(b.Plane, p), b.Polygon)
+}
+
+// planeProject2D drops a model point into a plane's (u,v) coordinates.
+func planeProject2D(pl geom.Plane, p math.Point3) math.Point2 {
+	d := pl.Origin.VectorTo(p)
+	return math.P2(d.Dot(pl.UAxis.AsVector()), d.Dot(pl.VAxis.AsVector()))
+}
+
+// pointInsidePolygon2 is an even–odd ray-cast point-in-polygon test.
+func pointInsidePolygon2(p math.Point2, poly []math.Point2) bool {
+	in := false
+	for i, n := 0, len(poly); i < n; i++ {
+		a, b := poly[i], poly[(i+1)%n]
+		if (a.Y > p.Y) != (b.Y > p.Y) {
+			x := a.X + (p.Y-a.Y)/(b.Y-a.Y)*(b.X-a.X)
+			if p.X < x {
+				in = !in
+			}
+		}
+	}
+	return in
+}
+
+// seedCentre returns the centre of the first running body's range box — the representative
+// point boundary clipping moves into each occurrence position. ok is false with no bodies.
+func seedCentre(bodies []*topo.Body) (math.Point3, bool) {
+	for _, b := range bodies {
+		if b != nil {
+			return b.RangeBox().Center(), true
+		}
+	}
+	return math.Point3{}, false
+}

--- a/model/feature/pattern_options_test.go
+++ b/model/feature/pattern_options_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestRectStepSpacing checks the fitted spacing divides the step across the gaps while the
+// default keeps it as the per-occurrence offset (M20-F18).
+func TestRectStepSpacing(t *testing.T) {
+	step := math.V3(6, 0, 0)
+	if got := (PatternOptions{}).rectStep(step, 3); got.X != 6 {
+		t.Errorf("default rectStep.X = %g, want 6 (step is the gap)", got.X)
+	}
+	if got := (PatternOptions{Spacing: types.SpacingFitted}).rectStep(step, 3); got.X != 3 {
+		t.Errorf("fitted rectStep.X = %g, want 3 (span 6 over 2 gaps)", got.X)
+	}
+}
+
+// TestCircIncrementSpacing checks the three circular spacing interpretations.
+func TestCircIncrementSpacing(t *testing.T) {
+	full := 2 * stdmath.Pi
+	if got := (PatternOptions{}).circIncrement(full, 4); stdmath.Abs(got-full/4) > 1e-12 {
+		t.Errorf("default circ inc = %g, want angle/count", got)
+	}
+	if got := (PatternOptions{Spacing: types.SpacingBetween}).circIncrement(0.5, 4); got != 0.5 {
+		t.Errorf("between circ inc = %g, want the angle itself (0.5)", got)
+	}
+	if got := (PatternOptions{Spacing: types.SpacingFitted}).circIncrement(full, 3); stdmath.Abs(got-stdmath.Pi) > 1e-12 {
+		t.Errorf("fitted circ inc = %g, want angle/(count-1) = pi", got)
+	}
+}
+
+// TestPatternBoundaryClipsOutsideOccurrences drops the occurrences whose centre falls
+// outside the boundary loop (M20-F18).
+func TestPatternBoundaryClipsOutsideOccurrences(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	src := NewBaseFeatures(fs).AddBase(prismBody()) // unit cube [0,1]^3, centre (0.5,0.5,0.5)
+	rect := NewPatternFeatures(fs).AddRectangular([]ID{src.ID()},
+		func() int { return 3 }, func() int { return 1 }, math.V3(2, 0, 0), math.Vector3{})
+	fs.Recompute()
+	if n := len(fs.Result()); n != 3 {
+		t.Fatalf("unclipped pattern = %d bodies, want 3", n)
+	}
+
+	// A boundary covering x∈[-1,3.5] keeps occurrences 0 (x=0.5) and 1 (x=2.5) but clips
+	// occurrence 2 (centre x=4.5).
+	boundary, err := NewPatternBoundary(math.P3(0, 0, 0), math.V3(0, 0, 1),
+		[]math.Point3{{X: -1, Y: -1}, {X: 3.5, Y: -1}, {X: 3.5, Y: 2}, {X: -1, Y: 2}}, types.IncludeByCentroid)
+	if err != nil {
+		t.Fatalf("NewPatternBoundary: %v", err)
+	}
+	rect.Definition().Options = PatternOptions{Boundary: boundary}
+	fs.MarkDirty(fs.Item(1)) // the pattern is feature 1 (base is 0)
+	fs.Recompute()
+	if n := len(fs.Result()); n != 2 {
+		t.Errorf("clipped pattern = %d bodies, want 2 (one occurrence outside the boundary)", n)
+	}
+}
+
+// TestPatternOptionsRoundTrip preserves the spacing type and boundary across an .obk
+// round-trip (M20-F18).
+func TestPatternOptionsRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	src := NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	rect := NewPatternFeatures(fs).AddRectangular([]ID{src.ID()},
+		func() int { return 2 }, func() int { return 1 }, math.V3(4, 0, 0), math.Vector3{})
+	boundary, _ := NewPatternBoundary(math.P3(0, 0, 0), math.V3(0, 0, 1),
+		[]math.Point3{{X: -1, Y: -1}, {X: 9, Y: -1}, {X: 9, Y: 2}, {X: -1, Y: 2}}, types.IncludeByCentroid)
+	rect.Definition().Options = PatternOptions{Spacing: types.SpacingFitted, Compute: types.ComputeOptimized, Boundary: boundary}
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	opts := fresh.Item(1).Definition().(*RectangularPatternFeature).Definition().Options
+	if opts.Spacing != types.SpacingFitted || opts.Compute != types.ComputeOptimized {
+		t.Errorf("restored options = spacing %v compute %v, want fitted/optimized", opts.Spacing, opts.Compute)
+	}
+	if opts.Boundary == nil || len(opts.Boundary.Polygon) != 4 {
+		t.Errorf("restored boundary = %+v, want a 4-vertex loop", opts.Boundary)
+	}
+}

--- a/model/feature/patterns.go
+++ b/model/feature/patterns.go
@@ -28,11 +28,17 @@ type PatternElement struct {
 }
 
 // patternBase holds the element list and the persistent per-index suppression set
-// shared by every pattern kind.
+// shared by every pattern kind. clipped is the transient set of occurrences a boundary
+// excludes this recompute (computed, not user-set; see [PatternOptions]).
 type patternBase struct {
 	suppressed map[int]bool
+	clipped    map[int]bool
 	elements   []PatternElement
 }
+
+// skip reports whether occurrence k is left out of the result — either suppressed by the
+// user or clipped by a pattern boundary.
+func (p *patternBase) skip(k int) bool { return p.suppressed[k] || p.clipped[k] }
 
 // rebuild regenerates the element list for count occurrences, preserving any
 // per-element suppression by index.
@@ -83,7 +89,7 @@ func (p *patternBase) SetElementSuppressed(i int, s bool) {
 func (p *patternBase) placeCopies(bodies []*topo.Body, transforms []math.Matrix4, feat string) ([]*topo.Body, error) {
 	var copies []*topo.Body
 	for k := 1; k < len(transforms); k++ {
-		if p.suppressed[k] {
+		if p.skip(k) {
 			continue
 		}
 		for bi, b := range bodies {
@@ -149,7 +155,7 @@ func (p *patternBase) replicateTool(bodies []*topo.Body, tool *topo.Body, op ops
 	last := len(running) - 1
 	running[last] = planarized(running[last], feat) // ditto for a curved running target
 	for k := 1; k < len(transforms); k++ {
-		if p.suppressed[k] {
+		if p.skip(k) {
 			continue
 		}
 		tk, err := ops.TransformBody(tool, transforms[k], copyLineage(feat, k, 0))
@@ -191,6 +197,7 @@ type RectangularPatternDefinition struct {
 	CountY         func() int
 	StepX          math.Vector3
 	StepY          math.Vector3
+	Options        PatternOptions // spacing/compute/orientation/positioning + boundary (M20-F18)
 }
 
 // RectangularPatternFeature is a 2D grid pattern.
@@ -205,7 +212,11 @@ func (r *RectangularPatternFeature) Kind() string                              {
 func (r *RectangularPatternFeature) Recompute(in Input) (Output, error) {
 	nx, ny := callOr1(r.def.CountX), callOr1(r.def.CountY)
 	r.rebuild(nx * ny)
-	transforms := rectTransforms(nx, ny, r.def.StepX, r.def.StepY)
+	stepX := r.def.Options.rectStep(r.def.StepX, nx)
+	stepY := r.def.Options.rectStep(r.def.StepY, ny)
+	transforms := rectTransforms(nx, ny, stepX, stepY)
+	seed, ok := seedCentre(in.Bodies)
+	r.clipped = r.def.Options.clippedOccurrences(transforms, seed, ok)
 	return r.replicate(in, r.def.SourceFeatures, transforms, "rect-pattern")
 }
 
@@ -230,6 +241,7 @@ type CircularPatternDefinition struct {
 	Angle          func() float64
 	AxisPoint      math.Point3
 	AxisDir        math.Vector3
+	Options        PatternOptions // spacing/compute/orientation/positioning + boundary (M20-F18)
 }
 
 // CircularPatternFeature is a circular pattern.
@@ -244,21 +256,24 @@ func (c *CircularPatternFeature) Kind() string                           { retur
 func (c *CircularPatternFeature) Recompute(in Input) (Output, error) {
 	count := callOr1(c.def.Count)
 	c.rebuild(count)
-	transforms, err := circTransforms(count, callOrZero(c.def.Angle), c.def.AxisPoint, c.def.AxisDir)
+	inc := c.def.Options.circIncrement(callOrZero(c.def.Angle), count)
+	transforms, err := circTransforms(count, inc, c.def.AxisPoint, c.def.AxisDir)
 	if err != nil {
 		return Output{}, err
 	}
+	seed, ok := seedCentre(in.Bodies)
+	c.clipped = c.def.Options.clippedOccurrences(transforms, seed, ok)
 	return c.replicate(in, c.def.SourceFeatures, transforms, "circ-pattern")
 }
 
-// circTransforms returns count occurrence rotations about the axis at angle/count
-// increments; element 0 is the identity.
-func circTransforms(count int, angle float64, axisPoint math.Point3, axisDir math.Vector3) ([]math.Matrix4, error) {
+// circTransforms returns count occurrence rotations about the axis stepping by inc radians
+// per occurrence; element 0 is the identity. The increment is chosen by the spacing type
+// ([PatternOptions.circIncrement]).
+func circTransforms(count int, inc float64, axisPoint math.Point3, axisDir math.Vector3) ([]math.Matrix4, error) {
 	dir, err := math.UnitVector3FromVector(axisDir)
 	if err != nil {
 		return nil, err
 	}
-	inc := angle / float64(count)
 	out := make([]math.Matrix4, count)
 	for k := 0; k < count; k++ {
 		out[k] = math.Rotation4(inc*float64(k), dir, axisPoint)

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -163,6 +163,7 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.RectPattern = &RectPatternData{
 			Source: src, CountX: evalInt(f.def.CountX), CountY: evalInt(f.def.CountY),
 			StepX: encodeVec3(f.def.StepX), StepY: encodeVec3(f.def.StepY),
+			Options: encodePatternOptions(f.def.Options),
 		}
 	case *CircularPatternFeature:
 		src, err := sourceIndices(f.def.SourceFeatures, idx)
@@ -172,6 +173,7 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.CircPattern = &CircPatternData{
 			Source: src, Count: evalInt(f.def.Count), Angle: evalFloat(f.def.Angle),
 			AxisPoint: encodePoint3(f.def.AxisPoint), AxisDir: encodeVec3(f.def.AxisDir),
+			Options: encodePatternOptions(f.def.Options),
 		}
 	case *SketchDrivenPatternFeature:
 		src, err := sourceIndices(f.def.SourceFeatures, idx)

--- a/model/feature/serialize_pattern.go
+++ b/model/feature/serialize_pattern.go
@@ -5,6 +5,8 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
 
@@ -16,20 +18,108 @@ import (
 
 // RectPatternData replicates source features in a 2D grid stepping by StepX/StepY.
 type RectPatternData struct {
-	Source []int     `yaml:"source"`
-	CountX int       `yaml:"countX"`
-	CountY int       `yaml:"countY"`
-	StepX  []float64 `yaml:"stepX"`
-	StepY  []float64 `yaml:"stepY"`
+	Source  []int               `yaml:"source"`
+	CountX  int                 `yaml:"countX"`
+	CountY  int                 `yaml:"countY"`
+	StepX   []float64           `yaml:"stepX"`
+	StepY   []float64           `yaml:"stepY"`
+	Options *PatternOptionsData `yaml:"options,omitempty"`
 }
 
 // CircPatternData replicates source features around an axis.
 type CircPatternData struct {
-	Source    []int     `yaml:"source"`
-	Count     int       `yaml:"count"`
-	Angle     float64   `yaml:"angle"`
-	AxisPoint []float64 `yaml:"axisPoint"`
-	AxisDir   []float64 `yaml:"axisDir"`
+	Source    []int               `yaml:"source"`
+	Count     int                 `yaml:"count"`
+	Angle     float64             `yaml:"angle"`
+	AxisPoint []float64           `yaml:"axisPoint"`
+	AxisDir   []float64           `yaml:"axisDir"`
+	Options   *PatternOptionsData `yaml:"options,omitempty"`
+}
+
+// PatternOptionsData is the serialized M20-F18 option block (omitted entirely when the
+// pattern uses only legacy defaults, so existing files round-trip unchanged).
+type PatternOptionsData struct {
+	Spacing     int32                `yaml:"spacing,omitempty"`
+	Compute     int32                `yaml:"compute,omitempty"`
+	Orientation int32                `yaml:"orientation,omitempty"`
+	Positioning int32                `yaml:"positioning,omitempty"`
+	Boundary    *PatternBoundaryData `yaml:"boundary,omitempty"`
+}
+
+// PatternBoundaryData is the serialized clipping boundary: the plane (origin + normal)
+// and the closed loop in the plane's (u,v) coordinates, plus the inclusion rule.
+type PatternBoundaryData struct {
+	PlaneOrigin []float64   `yaml:"planeOrigin"`
+	PlaneNormal []float64   `yaml:"planeNormal"`
+	Polygon     [][]float64 `yaml:"polygon"`
+	Inclusion   int32       `yaml:"inclusion,omitempty"`
+}
+
+// encodePatternOptions serializes the option block, returning nil when every field is the
+// legacy default so a plain pattern emits no options key.
+func encodePatternOptions(o PatternOptions) *PatternOptionsData {
+	if o.Spacing == 0 && o.Compute == 0 && o.Orientation == 0 && o.Positioning == 0 && o.Boundary == nil {
+		return nil
+	}
+	return &PatternOptionsData{
+		Spacing:     int32(o.Spacing),
+		Compute:     int32(o.Compute),
+		Orientation: int32(o.Orientation),
+		Positioning: int32(o.Positioning),
+		Boundary:    encodePatternBoundary(o.Boundary),
+	}
+}
+
+// decodePatternOptions rebuilds the option block (nil ⇒ the legacy default zero value).
+func decodePatternOptions(d *PatternOptionsData) (PatternOptions, error) {
+	if d == nil {
+		return PatternOptions{}, nil
+	}
+	boundary, err := decodePatternBoundary(d.Boundary)
+	if err != nil {
+		return PatternOptions{}, err
+	}
+	return PatternOptions{
+		Spacing:     types.PatternSpacingType(d.Spacing),
+		Compute:     types.PatternComputeType(d.Compute),
+		Orientation: types.PatternOrientation(d.Orientation),
+		Positioning: types.PatternPositioningMethod(d.Positioning),
+		Boundary:    boundary,
+	}, nil
+}
+
+func encodePatternBoundary(b *PatternBoundary) *PatternBoundaryData {
+	if b == nil {
+		return nil
+	}
+	poly := make([][]float64, len(b.Polygon))
+	for i, q := range b.Polygon {
+		poly[i] = []float64{q.X, q.Y}
+	}
+	return &PatternBoundaryData{
+		PlaneOrigin: encodePoint3(b.Plane.Origin),
+		PlaneNormal: encodeVec3(b.Plane.Normal()),
+		Polygon:     poly,
+		Inclusion:   int32(b.Inclusion),
+	}
+}
+
+func decodePatternBoundary(d *PatternBoundaryData) (*PatternBoundary, error) {
+	if d == nil {
+		return nil, nil
+	}
+	plane, err := geom.NewPlane(decodePoint3(d.PlaneOrigin), decodeVec3(d.PlaneNormal))
+	if err != nil {
+		return nil, fmt.Errorf("pattern boundary plane: %w", err)
+	}
+	poly := make([]math.Point2, len(d.Polygon))
+	for i, q := range d.Polygon {
+		if len(q) < 2 {
+			return nil, fmt.Errorf("pattern boundary polygon vertex %d has %d coords, want 2", i, len(q))
+		}
+		poly[i] = math.P2(q[0], q[1])
+	}
+	return &PatternBoundary{Plane: plane, Polygon: poly, Inclusion: types.PatternBoundaryInclusion(d.Inclusion)}, nil
 }
 
 // SketchDrivenPatternData places one occurrence of the source per sketch point.
@@ -89,7 +179,12 @@ func restoreRectPattern(fs *PartFeatures, d *RectPatternData, restored []*PartFe
 	if err != nil {
 		return nil, err
 	}
-	NewPatternFeatures(fs).AddRectangular(src, constInt(d.CountX), constInt(d.CountY), decodeVec3(d.StepX), decodeVec3(d.StepY))
+	f := NewPatternFeatures(fs).AddRectangular(src, constInt(d.CountX), constInt(d.CountY), decodeVec3(d.StepX), decodeVec3(d.StepY))
+	opts, err := decodePatternOptions(d.Options)
+	if err != nil {
+		return nil, err
+	}
+	f.Definition().Options = opts
 	return lastFeature(fs), nil
 }
 
@@ -101,7 +196,12 @@ func restoreCircPattern(fs *PartFeatures, d *CircPatternData, restored []*PartFe
 	if err != nil {
 		return nil, err
 	}
-	NewPatternFeatures(fs).AddCircular(src, constInt(d.Count), constFloat(d.Angle), decodePoint3(d.AxisPoint), decodeVec3(d.AxisDir))
+	f := NewPatternFeatures(fs).AddCircular(src, constInt(d.Count), constFloat(d.Angle), decodePoint3(d.AxisPoint), decodeVec3(d.AxisDir))
+	opts, err := decodePatternOptions(d.Options)
+	if err != nil {
+		return nil, err
+	}
+	f.Definition().Options = opts
 	return lastFeature(fs), nil
 }
 


### PR DESCRIPTION
Closes #652.

## What
Extends the rectangular and circular pattern definitions with the reference option surface beyond count + spacing.

**Concrete geometry**
- **Spacing type** — rectangular `fitted` treats the step as the *total span* divided across the gaps; circular `between` makes the angle the per-occurrence increment and `fitted` spreads the count across the angle inclusive. The unset default keeps the legacy `angle/count` full sweep / step-as-gap, so existing patterns are unchanged.
- **Boundary clipping** — an occurrence is dropped when its centre, projected into the boundary plane, falls outside the closed loop (`PatternBoundary`).

**Carried (round-trips, addressable; zero value = legacy behaviour)**
- compute type, orientation, positioning method — stored on the definition; behaviour is a noted follow-up so there is no regression today.

## Wiring
- `pattern_options.go`: `PatternOptions` + `PatternBoundary`; both pattern definitions embed it; the occurrence skip set is extended with boundary-clipped indices.
- `serialize_pattern.go` / `serialize.go`: `.obk` round-trip of every option (emitted only when non-default).
- `addin/opregistry`: `patternRectangular` / `patternCircular` gain `spacingType` / `computeType` / `orientation` / `positioningMethod` / `boundary`.

## Verification
- model: spacing math (rect + circ), boundary clips an out-of-range occurrence, options + boundary survive an `.obk` round-trip
- router (wire path): applies a spacing + boundary pattern (seed + one in-bounds copy) and rejects an unknown enum
- `go build`, `go test` (model/feature, addin/opregistry, addin/router incl. the schema-validity descriptor test), `go vet`, `golangci-lint` (0 issues) pass locally

## Follow-ups (not in this PR)
compute-type / orientation / positioning-method *behaviour*; a sketch-profile boundary reference (the boundary is given as explicit points here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)