### PR TITLE
M20-F17: Bend Part feature

### DIFF
--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -385,6 +385,85 @@ func buildRotateAboutLineOp(part *compdef.PartComponentDefinition, a moveOpArg) 
 	return feature.RotateAboutLineOp(point, dir, angle), nil
 }
 
+// --- bend part -------------------------------------------------------------
+
+type bendPartArgs struct {
+	SketchIndex int    `json:"sketchIndex"`
+	LineIndex   int    `json:"lineIndex,omitempty"`
+	BendType    string `json:"bendType,omitempty"`
+	Radius      string `json:"radius,omitempty"`
+	Angle       string `json:"angle,omitempty"`
+	ArcLength   string `json:"arcLength,omitempty"`
+	Flip        bool   `json:"flip,omitempty"`
+}
+
+const bendPartSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the bend line."},
+    "lineIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Index of the bend line within the sketch's lines."},
+    "bendType": {"type": "string", "enum": ["radiusAndAngle", "radiusAndArcLength", "arcLengthAndAngle"], "default": "radiusAndAngle", "description": "Which two inputs drive the bend (the third is derived)."},
+    "radius": {"type": "string", "description": "Bend radius, e.g. \"5 mm\" (radiusAndAngle / radiusAndArcLength)."},
+    "angle": {"type": "string", "description": "Bend angle, e.g. \"90 deg\" (radiusAndAngle / arcLengthAndAngle)."},
+    "arcLength": {"type": "string", "description": "Bend arc length (radiusAndArcLength / arcLengthAndAngle)."},
+    "flip": {"type": "boolean", "default": false, "description": "Fold toward the opposite side of the sketch plane."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+func bendPartDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "bendPart", Summary: "Bend a solid body around a sketch bend line (radius/angle/arc-length controlled).", Schema: json.RawMessage(bendPartSchema), Apply: applyBendPart}
+}
+
+func applyBendPart(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in bendPartArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	def, err := bendDefinition(part, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewBendPartFeatures(part.Features()).Add(def))
+}
+
+// bendDefinition resolves the bend args (sketch, bend type, parametric scalars) into a model
+// bend definition.
+func bendDefinition(part *compdef.PartComponentDefinition, in bendPartArgs) (*feature.BendPartDefinition, error) {
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	bendType := types.RadiusAndAngleBend
+	if in.BendType != "" {
+		v, ok := types.ParseBendPartType(in.BendType)
+		if !ok {
+			return nil, fmt.Errorf("bendPart: unknown bendType %q", in.BendType)
+		}
+		bendType = v
+	}
+	radius, err := optionalLengthClosure(part, in.Radius, "bendPart: radius")
+	if err != nil {
+		return nil, err
+	}
+	angle, err := optionalAngleClosure(part, in.Angle, "bendPart: angle")
+	if err != nil {
+		return nil, err
+	}
+	arc, err := optionalLengthClosure(part, in.ArcLength, "bendPart: arcLength")
+	if err != nil {
+		return nil, err
+	}
+	return &feature.BendPartDefinition{
+		Sketch: sk, LineIndex: in.LineIndex, BendType: bendType,
+		Radius: radius, Angle: angle, ArcLength: arc, Flip: in.Flip,
+	}, nil
+}
+
 // --- replace face ----------------------------------------------------------
 
 type replaceFaceArgs struct {

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -124,6 +124,7 @@ func Default() *Registry {
 		splitFaceDescriptor(),
 		replaceFaceDescriptor(),
 		moveBodyDescriptor(),
+		bendPartDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "hole", "boss", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "moveBody", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/router/bend_part_test.go
+++ b/addin/router/bend_part_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestBendPartViaWireFoldsBody drives the full wire path for an M20-F17 bend — a bend line
+// across the extruded block, then features.add(bendPart) — and checks it recomputes healthy
+// into a single body (the fold-up geometry is asserted by the model-level test) (#651).
+func TestBendPartViaWireFoldsBody(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t) // block x∈[0,4] y∈[0,3] z∈[0,5] cm, Extrusion1
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"line","points":[[2,0],[2,3]]}`, &struct{}{})
+	call(t, r, s, "features.add",
+		`{"kind":"bendPart","args":{"sketchIndex":1,"lineIndex":0,"bendType":"radiusAndAngle","radius":"5 mm","angle":"90 deg"}}`,
+		&struct{}{})
+
+	tree := modelTreeOf(t, r, s)
+	if tree.Bodies != 1 {
+		t.Fatalf("after bend body count = %d, want 1 (bend replaces, not adds)", tree.Bodies)
+	}
+	bend := tree.Features[len(tree.Features)-1]
+	if bend.Kind != "bend-part" || bend.Health != "" {
+		t.Fatalf("bend feature = kind %q health %q, want bend-part / healthy", bend.Kind, bend.Health)
+	}
+}
+
+// TestBendPartScalarsEditable exposes the two driving scalars through features.edit.
+func TestBendPartScalarsEditable(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"line","points":[[2,0],[2,3]]}`, &struct{}{})
+	call(t, r, s, "features.add",
+		`{"kind":"bendPart","args":{"sketchIndex":1,"lineIndex":0,"radius":"5 mm","angle":"90 deg"}}`,
+		&struct{}{})
+	bendID := modelTreeOf(t, r, s).Features[1].ID
+
+	var detail wire.FeatureDetailResult
+	call(t, r, s, "features.get", fmt.Sprintf(`{"id":%d}`, bendID), &detail)
+	if len(detail.Feature.Scalars) != 2 || detail.Feature.Scalars[0].Label != "Radius" {
+		t.Fatalf("bend scalars = %+v, want [Radius, Angle]", detail.Feature.Scalars)
+	}
+}
+
+// TestBendPartUnknownTypeFails rejects an unknown bend type with a precise error.
+func TestBendPartUnknownTypeFails(t *testing.T) {
+	r, s, _ := extrudedPartViaAPI(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"line","points":[[2,0],[2,3]]}`, &struct{}{})
+	if _, err := r.Handle(s, "features.add",
+		[]byte(`{"kind":"bendPart","args":{"sketchIndex":1,"lineIndex":0,"bendType":"twist"}}`)); err == nil {
+		t.Error("expected an error for an unknown bendType")
+	}
+}

--- a/model/feature/bend_part.go
+++ b/model/feature/bend_part.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// Bend Part feature (M20-F17, #651): fold a solid part body around a sketch bend line, the
+// only solid-deformation feature in the part-modeling set (distinct from sheet-metal bends,
+// which need the sheet-metal environment). The geometry is the planar-faceted bend in
+// bend_part_geom.go; this is the Definition→Add→Feature triangle over it.
+
+// BendPartDefinition is the bend recipe: the sketch + the index of its bend line, the bend
+// type (which two of radius/angle/arc-length drive it), the three parametric scalars, and
+// Flip to fold toward the opposite side of the sketch plane.
+type BendPartDefinition struct {
+	Sketch    *sketch.Sketch
+	LineIndex int
+	BendType  types.BendPartType
+	Radius    func() float64
+	Angle     func() float64
+	ArcLength func() float64
+	Flip      bool
+}
+
+// BendPartFeature folds the running solid each recompute.
+type BendPartFeature struct {
+	def      *BendPartDefinition
+	featName string
+}
+
+// Definition returns the bend recipe.
+func (b *BendPartFeature) Definition() *BendPartDefinition { return b.def }
+
+// Kind implements [Feature].
+func (b *BendPartFeature) Kind() string { return "bend-part" }
+
+// Recompute folds the running body about the bend line and replaces it with the result.
+func (b *BendPartFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "bend-part")
+	if err != nil {
+		return Output{}, err
+	}
+	point, dir, up, err := b.bendLine()
+	if err != nil {
+		return Output{}, err
+	}
+	radius, angle, err := bendRadiusAngle(b.def)
+	if err != nil {
+		return Output{}, err
+	}
+	bent, err := bendSolid(body, point, dir, up, radius, angle, featOr(b.featName, "bend"))
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, bent)}, nil
+}
+
+// bendLine resolves the bend line's model-space point, direction, and the up-normal (the
+// sketch plane normal, flipped when Flip is set) the moving flange folds toward.
+func (b *BendPartFeature) bendLine() (point math.Point3, dir, up math.Vector3, err error) {
+	sk := b.def.Sketch
+	if sk == nil {
+		return point, dir, up, fmt.Errorf("bend-part: no sketch set")
+	}
+	lines := sk.Lines()
+	if b.def.LineIndex < 0 || b.def.LineIndex >= lines.Count() {
+		return point, dir, up, fmt.Errorf("bend-part: line index %d out of range (%d lines)", b.def.LineIndex, lines.Count())
+	}
+	l := lines.Item(b.def.LineIndex)
+	pl := sk.Plane()
+	p0, p1 := pl.ToModel(l.StartPoint().Position()), pl.ToModel(l.EndPoint().Position())
+	up = pl.Normal().AsVector()
+	if b.def.Flip {
+		up = up.Scale(-1)
+	}
+	return p0, p0.VectorTo(p1), up, nil
+}
+
+// bendRadiusAngle derives the bend radius and angle from the two driving inputs of the bend
+// type (the third is computed): angle = arcLength/radius, or radius = arcLength/angle.
+func bendRadiusAngle(def *BendPartDefinition) (radius, angle float64, err error) {
+	switch def.BendType {
+	case types.RadiusAndAngleBend:
+		radius, angle = callOrZero(def.Radius), callOrZero(def.Angle)
+	case types.RadiusAndArcLengthBend:
+		radius = callOrZero(def.Radius)
+		if radius <= 0 {
+			return 0, 0, fmt.Errorf("bend-part: radius %.4g must be > 0", radius)
+		}
+		angle = callOrZero(def.ArcLength) / radius
+	case types.ArcLengthAndAngleBend:
+		angle = callOrZero(def.Angle)
+		if angle <= 0 {
+			return 0, 0, fmt.Errorf("bend-part: angle %.4g must be > 0", angle)
+		}
+		radius = callOrZero(def.ArcLength) / angle
+	default:
+		return 0, 0, fmt.Errorf("bend-part: unknown bend type %v", def.BendType)
+	}
+	if radius <= 0 || angle <= 0 {
+		return 0, 0, fmt.Errorf("bend-part: radius %.4g and angle %.4g must both be > 0", radius, angle)
+	}
+	return radius, angle, nil
+}
+
+// EditableParams exposes the two scalars that drive the bend type for features.edit.
+func (b *BendPartFeature) EditableParams() []EditableParam {
+	switch b.def.BendType {
+	case types.RadiusAndArcLengthBend:
+		return []EditableParam{
+			scalarParam("Radius", param.Length, &b.def.Radius),
+			scalarParam("Arc Length", param.Length, &b.def.ArcLength),
+		}
+	case types.ArcLengthAndAngleBend:
+		return []EditableParam{
+			scalarParam("Arc Length", param.Length, &b.def.ArcLength),
+			scalarParam("Angle", param.Angle, &b.def.Angle),
+		}
+	default: // RadiusAndAngleBend
+		return []EditableParam{
+			scalarParam("Radius", param.Length, &b.def.Radius),
+			scalarParam("Angle", param.Angle, &b.def.Angle),
+		}
+	}
+}
+
+// BendPartFeatures adds bend features into the engine.
+type BendPartFeatures struct{ engine *PartFeatures }
+
+// NewBendPartFeatures binds the collection to a feature engine.
+func NewBendPartFeatures(engine *PartFeatures) *BendPartFeatures { return &BendPartFeatures{engine} }
+
+// Add places a bend feature, naming it Bend1, Bend2, ….
+func (c *BendPartFeatures) Add(def *BendPartDefinition) *PartFeature {
+	f := &BendPartFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Bend"))
+	f.featName = pf.Name()
+	return pf
+}

--- a/model/feature/bend_part_geom.go
+++ b/model/feature/bend_part_geom.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Bend Part geometry (M20-F17, #651). A bend folds the material on one side of a sketch
+// bend line up around a cylindrical bend region of the given radius through the bend angle.
+// This first cut is a planar-faceted approximation for a prismatic body: it splits the body
+// at the bend line, takes the cut cross-section, and rebuilds the part as ONE swept solid
+// along a straight→arc→straight path — the fixed flange, the faceted bend arc, and the
+// rotated moving flange — so the result is a single watertight solid (a sharp fold would be
+// non-manifold, hence the arc). A non-prismatic body bends as if it were the prism of its
+// cut section (documented approximation); a general free-form bend is a follow-up.
+
+// bendFacetStep caps the bend arc's facet size (~10°) so the cylindrical region is smooth
+// without exploding the face count.
+const bendFacetStep = stdmath.Pi / 18
+
+// bendSolid bends body about the bend line through (linePoint, lineDir) lying on the part,
+// folding the +across side up toward upNormal by angle over bend radius. radius and angle
+// are in database units / radians. It returns a single solid, erroring when the bend line
+// does not divide the body into two pieces.
+func bendSolid(body *topo.Body, linePoint math.Point3, lineDir, upNormal math.Vector3, radius, angle float64, feat string) (*topo.Body, error) {
+	frame, err := newBendFrame(linePoint, lineDir, upNormal, radius)
+	if err != nil {
+		return nil, err
+	}
+	section, err := bendCutSection(body, frame.cutPlane)
+	if err != nil {
+		return nil, err
+	}
+	lo, hi := acrossRange(body, frame.across, linePoint)
+	fixedLen, movingLen := frame.at-lo, hi-frame.at
+	if fixedLen <= bendTol || movingLen <= bendTol {
+		return nil, fmt.Errorf("bend line lies at the body edge (fixed %.4g, moving %.4g)", fixedLen, movingLen)
+	}
+	sections := bendSections(section, frame, fixedLen, movingLen, angle)
+	return sweptSolid(sections, false, feat)
+}
+
+// bendTol is the minimum flange length / section size below which a bend is degenerate.
+const bendTol = 1e-7
+
+// bendFrame is the resolved bend geometry: the orthonormal axes, the splitting plane, the
+// arc axis (parallel to the bend line, offset by the radius toward upNormal), and the bend
+// line's coordinate along the across direction.
+type bendFrame struct {
+	dir, up, across math.UnitVector3
+	cutPlane        geom.Plane
+	axisOrigin      math.Point3
+	at              float64 // linePoint projected onto across
+}
+
+// newBendFrame builds the bend frame, erroring on a degenerate (parallel) line/normal pair.
+func newBendFrame(linePoint math.Point3, lineDir, upNormal math.Vector3, radius float64) (bendFrame, error) {
+	d, err := math.UnitVector3FromVector(lineDir)
+	if err != nil {
+		return bendFrame{}, fmt.Errorf("bend line direction is degenerate: %v", lineDir)
+	}
+	n, err := math.UnitVector3FromVector(upNormal)
+	if err != nil {
+		return bendFrame{}, fmt.Errorf("bend up-normal is degenerate: %v", upNormal)
+	}
+	across, err := math.UnitVector3FromVector(d.AsVector().Cross(n.AsVector()))
+	if err != nil {
+		return bendFrame{}, fmt.Errorf("bend line direction %v is parallel to the up-normal %v", lineDir, upNormal)
+	}
+	plane, err := geom.NewPlane(linePoint, across.AsVector())
+	if err != nil {
+		return bendFrame{}, err
+	}
+	return bendFrame{
+		dir: d, up: n, across: across, cutPlane: plane,
+		axisOrigin: linePoint.TranslateBy(n.AsVector().Scale(radius)),
+		at:         across.AsVector().Dot(linePoint.AsVector()),
+	}, nil
+}
+
+// bendSections lays out the swept-path cross sections: the fixed flange (a straight prism
+// from the fixed end to the bend line), the faceted bend arc, and the moving flange (a
+// straight prism off the arc's end). The arc and the moving flange rotate about the bend
+// axis so the moving side folds up toward the up-normal.
+func bendSections(section []math.Point3, f bendFrame, fixedLen, movingLen, angle float64) [][]math.Point3 {
+	out := [][]math.Point3{translatedSection(section, f.across.AsVector().Scale(-fixedLen)), section}
+	steps := int(stdmath.Max(2, stdmath.Round(angle/bendFacetStep)))
+	step := angle / float64(steps)
+	var last []math.Point3
+	for k := 1; k <= steps; k++ {
+		rot := math.Rotation4(-step*float64(k), f.dir, f.axisOrigin) // negative folds toward +up
+		last = transformedSection(section, rot)
+		out = append(out, last)
+	}
+	movingDir := math.Rotation4(-angle, f.dir, f.axisOrigin).TransformVector(f.across.AsVector())
+	out = append(out, translatedSection(last, movingDir.Scale(movingLen)))
+	return out
+}
+
+// translatedSection / transformedSection copy a section under a translation / full transform.
+func translatedSection(section []math.Point3, by math.Vector3) []math.Point3 {
+	out := make([]math.Point3, len(section))
+	for i, p := range section {
+		out[i] = p.TranslateBy(by)
+	}
+	return out
+}
+
+func transformedSection(section []math.Point3, m math.Matrix4) []math.Point3 {
+	out := make([]math.Point3, len(section))
+	for i, p := range section {
+		out[i] = m.TransformPoint(p)
+	}
+	return out
+}
+
+// bendCutSection splits the body at the bend plane and returns the cut cross-section of the
+// moving (positive-across) piece as an ordered polygon.
+func bendCutSection(body *topo.Body, plane geom.Plane) ([]math.Point3, error) {
+	pieces, err := ops.SplitSolidByPlane(body, plane)
+	if err != nil {
+		return nil, err
+	}
+	if len(pieces) != 2 {
+		return nil, fmt.Errorf("bend line does not divide the body into two pieces (got %d)", len(pieces))
+	}
+	cap := coplanarCapFace(pieces[1], plane) // positive side is the moving flange
+	if cap == nil {
+		return nil, fmt.Errorf("bend: could not find the cut cross-section face")
+	}
+	poly := orderedFacePolygon(cap)
+	if len(poly) < 3 {
+		return nil, fmt.Errorf("bend: cut cross-section has %d vertices, want ≥3", len(poly))
+	}
+	return poly, nil
+}
+
+// coplanarCapFace returns the body's planar face lying in plane (its normal parallel to the
+// plane's and a vertex on it), or nil.
+func coplanarCapFace(body *topo.Body, plane geom.Plane) *topo.Face {
+	n := plane.Normal()
+	for _, f := range body.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok {
+			continue
+		}
+		if stdmath.Abs(pl.Normal().Cross(n).Length()) > 1e-6 {
+			continue
+		}
+		if stdmath.Abs(plane.Origin.VectorTo(pl.Origin).Dot(n)) < 1e-6 {
+			return f
+		}
+	}
+	return nil
+}
+
+// orderedFacePolygon walks a face's outer loop into an ordered list of model points.
+func orderedFacePolygon(f *topo.Face) []math.Point3 {
+	for _, l := range f.Loops() {
+		if !l.IsOuter() {
+			continue
+		}
+		uses := l.EdgeUses()
+		pts := make([]math.Point3, 0, len(uses))
+		for _, u := range uses {
+			v := u.Edge().StartVertex()
+			if u.Reversed() {
+				v = u.Edge().EndVertex()
+			}
+			pts = append(pts, v.Point())
+		}
+		return pts
+	}
+	return nil
+}
+
+// acrossRange returns the body's extent along the across direction, measured in the same
+// coordinate as the bend line's projection (so [lo,hi] brackets the bend position).
+func acrossRange(body *topo.Body, across math.UnitVector3, _ math.Point3) (lo, hi float64) {
+	a := across.AsVector()
+	lo, hi = stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range body.Vertices() {
+		t := a.Dot(v.Point().AsVector())
+		lo, hi = stdmath.Min(lo, t), stdmath.Max(hi, t)
+	}
+	return lo, hi
+}

--- a/model/feature/bend_part_geom_test.go
+++ b/model/feature/bend_part_geom_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/math"
+)
+
+// TestBendSolidBoxFoldsUpValid bends a long flat bar 90° at its middle and checks the
+// result is a single valid solid whose moving flange folded up (the +Z extent grew well
+// beyond the original thickness) while volume is conserved within the bend allowance.
+func TestBendSolidBoxFoldsUpValid(t *testing.T) {
+	bar := subd.ToBody(subd.Box(10, 2, 1), "bar") // L=10 (X), W=2 (Y), T=1 (Z), corner at origin
+	before := ops.BodyGeometryProperties(bar, ops.DefaultQuality()).Volume
+
+	// Bend line across the bar at x=5 on the top face, along +Y; fold the +X half up.
+	bent, err := bendSolid(bar, math.P3(5, 0, 1), math.V3(0, 1, 0), math.V3(0, 0, 1), 1.0, stdmath.Pi/2, "bend")
+	if err != nil {
+		t.Fatalf("bendSolid: %v", err)
+	}
+	if r := ops.Validate(bent); !r.Valid {
+		t.Fatalf("bent body invalid: %v", r.Issues)
+	}
+	props := ops.BodyGeometryProperties(bent, ops.DefaultQuality())
+	if props.Volume <= 0 {
+		t.Fatalf("bent volume = %g, want positive", props.Volume)
+	}
+	// Volume is roughly conserved (the arc adds/removes a little material vs. a sharp fold).
+	if rel := stdmath.Abs(props.Volume-before) / before; rel > 0.25 {
+		t.Errorf("bent volume %g vs original %g differ by %.0f%%, want <25%%", props.Volume, before, rel*100)
+	}
+	box := bent.RangeBox()
+	if box.Max.Z < 4 { // a 5-long flange folded 90° up should reach well above the 1.0 thickness
+		t.Errorf("bent top Z = %g, want the moving flange folded up (>4)", box.Max.Z)
+	}
+}

--- a/model/feature/bend_part_test.go
+++ b/model/feature/bend_part_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// bendBarFixture builds a part of a flat bar with a bend line across it at x=5, returning the
+// engine, the sketch (so a round-trip can re-supply it), and the placed bend feature.
+func bendBarFixture(t *testing.T) (*PartFeatures, *sketch.Sketch, *PartFeature) {
+	t.Helper()
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(5, 0), math.P2(5, 2)) // bend line along +Y at x=5
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(subd.ToBody(subd.Box(10, 2, 1), "bar"))
+	def := &BendPartDefinition{
+		Sketch: sk, LineIndex: 0, BendType: types.RadiusAndAngleBend,
+		Radius: constFloat(1), Angle: constFloat(stdmath.Pi / 2),
+	}
+	pf := NewBendPartFeatures(fs).Add(def)
+	return fs, sk, pf
+}
+
+// TestBendPartFeatureFoldsValidSolid recomputes a bend feature and checks it yields one
+// valid solid that folded up (M20-F17, #651).
+func TestBendPartFeatureFoldsValidSolid(t *testing.T) {
+	fs, _, pf := bendBarFixture(t)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("bend sick: %+v", pf.Health())
+	}
+	if len(fs.Result()) != 1 {
+		t.Fatalf("bend result = %d bodies, want 1", len(fs.Result()))
+	}
+	if r := ops.Validate(fs.Result()[0]); !r.Valid {
+		t.Fatalf("bent body invalid: %v", r.Issues)
+	}
+	if box := fs.Result()[0].RangeBox(); box.Max.Z < 4 {
+		t.Errorf("bent top Z = %g, want the flange folded up (>4)", box.Max.Z)
+	}
+}
+
+// TestBendPartDerivesAngleFromArcLength checks the arc-length+angle / radius+arc-length types
+// derive the missing input.
+func TestBendPartDerivesAngleFromArcLength(t *testing.T) {
+	def := &BendPartDefinition{BendType: types.RadiusAndArcLengthBend, Radius: constFloat(2), ArcLength: constFloat(stdmath.Pi)}
+	r, a, err := bendRadiusAngle(def)
+	if err != nil || r != 2 || stdmath.Abs(a-stdmath.Pi/2) > 1e-12 {
+		t.Errorf("radiusAndArcLength → (r=%g, a=%g, err=%v), want (2, pi/2, nil)", r, a, err)
+	}
+	def = &BendPartDefinition{BendType: types.ArcLengthAndAngleBend, ArcLength: constFloat(stdmath.Pi), Angle: constFloat(stdmath.Pi / 2)}
+	r, a, err = bendRadiusAngle(def)
+	if err != nil || stdmath.Abs(r-2) > 1e-12 || stdmath.Abs(a-stdmath.Pi/2) > 1e-12 {
+		t.Errorf("arcLengthAndAngle → (r=%g, a=%g, err=%v), want (2, pi/2, nil)", r, a, err)
+	}
+}
+
+// TestBendPartRoundTrip preserves the bend line, type, and scalars across an .obk round-trip
+// (extrude source + bend line in a second sketch, so the program serializes).
+func TestBendPartRoundTrip(t *testing.T) {
+	profile := sketch.NewSketches().Add(sketch.XYPlane())
+	bendSk := sketch.NewSketches().Add(sketch.XYPlane())
+	bendSk.Lines().AddByTwoPoints(math.P2(5, 0), math.P2(5, 2))
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(profile, 0, ops.NewBody, func() float64 { return 1 })
+	NewBendPartFeatures(fs).Add(&BendPartDefinition{
+		Sketch: bendSk, LineIndex: 0, BendType: types.RadiusAndAngleBend,
+		Radius: constFloat(1), Angle: constFloat(stdmath.Pi / 2),
+	})
+	idx := twoSketches{a: profile, b: bendSk}
+	data, err := fs.MarshalRecipe(idx)
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, idx, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(fresh.Count() - 1).Definition().(*BendPartFeature).Definition()
+	if def.BendType != types.RadiusAndAngleBend || def.LineIndex != 0 {
+		t.Errorf("restored bend = type %v line %d, want radiusAndAngle/0", def.BendType, def.LineIndex)
+	}
+	if got := def.Radius(); got != 1 {
+		t.Errorf("restored radius = %g, want 1", got)
+	}
+	if got := def.Angle(); stdmath.Abs(got-stdmath.Pi/2) > 1e-12 {
+		t.Errorf("restored angle = %g, want pi/2", got)
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -52,6 +52,7 @@ type FeatureData struct {
 	Sweep         *SweepData         `yaml:"sweep,omitempty"`
 	Loft          *LoftData          `yaml:"loft,omitempty"`
 	Move          *MoveData          `yaml:"move,omitempty"`
+	Bend          *BendData          `yaml:"bend,omitempty"`
 	Decal         *DecalData         `yaml:"decal,omitempty"`
 	Reference     *ReferenceData     `yaml:"reference,omitempty"`
 	Client        *ClientData        `yaml:"client,omitempty"`
@@ -228,6 +229,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Loft = lo
 	case *MoveFeature:
 		fd.Move = serializeMove(f.def)
+	case *BendPartFeature:
+		bd, err := serializeBend(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Bend = bd
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -385,6 +392,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSplitSolid(fs, fd.SplitSolid, work)
 	case "move":
 		return restoreMove(fs, fd.Move)
+	case "bend-part":
+		return restoreBend(fs, fd.Bend, sk)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_bend.go
+++ b/model/feature/serialize_bend.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// BendData is the serialized form of a BendPartFeature: the bend line (sketch index + line
+// index), the bend type, the three driving scalars (frozen to their current value), and the
+// fold-direction flip. Scalars not used by the bend type round-trip as 0.
+type BendData struct {
+	Sketch    int     `yaml:"sketch"`
+	Line      int     `yaml:"line"`
+	BendType  int32   `yaml:"bendType"`
+	Radius    float64 `yaml:"radius,omitempty"`
+	Angle     float64 `yaml:"angle,omitempty"`
+	ArcLength float64 `yaml:"arcLength,omitempty"`
+	Flip      bool    `yaml:"flip,omitempty"`
+}
+
+// serializeBend projects a bend recipe to its persisted form, erroring if its sketch is not
+// in the part (so the bend line cannot be lost silently).
+func serializeBend(def *BendPartDefinition, sk SketchIndexer) (*BendData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("bend-part references a sketch that is not in the part")
+	}
+	return &BendData{
+		Sketch: idx, Line: def.LineIndex, BendType: int32(def.BendType),
+		Radius: evalFloat(def.Radius), Angle: evalFloat(def.Angle), ArcLength: evalFloat(def.ArcLength),
+		Flip: def.Flip,
+	}, nil
+}
+
+// restoreBend rebuilds a BendPartFeature, erroring on a missing payload or unknown sketch.
+func restoreBend(fs *PartFeatures, d *BendData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("bend-part feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("bend-part references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &BendPartDefinition{
+		Sketch: s, LineIndex: d.Line, BendType: types.BendPartType(d.BendType),
+		Radius: constFloat(d.Radius), Angle: constFloat(d.Angle), ArcLength: constFloat(d.ArcLength),
+		Flip: d.Flip,
+	}
+	return NewBendPartFeatures(fs).Add(def), nil
+}


### PR DESCRIPTION
Closes #651.

## What
Adds the **Bend Part** feature — fold a solid body around a sketch bend line — the only solid-deformation feature in the part-modeling set (distinct from sheet-metal bends, which need the sheet-metal environment). It had no presence in the codebase.

### Geometry (`bend_part_geom.go`)
A **planar-faceted bend that yields a single valid solid**: split the body at the bend line, take the cut cross-section, and rebuild the part as **one swept solid** along a straight→arc→straight path — the fixed flange, the faceted cylindrical bend region, and the rotated moving flange. A sharp `R=0` fold would be non-manifold (the two flanges meet on an edge), so the arc region is what makes the result watertight. A non-prismatic body bends as the prism of its cut section (documented approximation).

### Triangle (`bend_part.go`)
`BendPartDefinition` (sketch bend line, `BendPartType`, radius/angle/arc-length parametric scalars, flip) → `BendPartFeatures.Add` → `BendPartFeature`. The bend type derives the missing input (`angle = arc/radius`, or `radius = arc/angle`). `features.edit` exposes the two driving scalars.

### Plumbing
- `.obk` round-trip (`serialize_bend.go`).
- opregistry **`bendPart`** kind (MCP / wire reachable), using `api/types.BendPartType` (landed in Oblikovati.API#107).

## Verification
- model: bends a bar 90° into a **valid manifold positive-volume** solid that folds up; bend-type derivations; feature recomputes healthy + `.obk` round-trip
- router (wire path): folds the body (1 healthy body), edits a driving scalar, rejects an unknown bend type
- `go build`, `go test`, `go vet`, `golangci-lint` (0 issues), spdx — all pass locally

## Follow-ups (not in this PR)
A ribbon button / interactive tool (head); a general free-form (non-prismatic) bend; bend side / bend-minimum options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)