### PR TITLE
feat: assembly contact sets + interference analysis (M12-F05)

### DIFF
--- a/addin/router/contact.go
+++ b/addin/router/contact.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/assembly"
+)
+
+// The assembly contact & interference surface (M12-F05, #362/#368): manage contact sets
+// (occurrences that resist interpenetration), toggle the contact solver, and run a static
+// interference analysis reporting the overlapping volumes between occurrences.
+
+// registerContactHandlers wires the contactSets.*/contactSolver.*/interference.* methods.
+func (r *Router) registerContactHandlers() {
+	r.handlers[wire.MethodContactSetsCreate] = contactSetsCreate
+	r.handlers[wire.MethodContactSetsList] = contactSetsList
+	r.handlers[wire.MethodContactSetsDelete] = contactSetsDelete
+	r.handlers[wire.MethodContactSetsAddMember] = contactSetsAddMember
+	r.handlers[wire.MethodContactSetsRemoveMember] = contactSetsRemoveMember
+	r.handlers[wire.MethodContactSolverSetEnabled] = contactSolverSetEnabled
+	r.handlers[wire.MethodContactSolverStatus] = contactSolverStatus
+	r.handlers[wire.MethodInterferenceAnalyze] = interferenceAnalyze
+}
+
+func contactSetsCreate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.CreateContactSetArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	cs := asm.ContactSolver().Create(in.Name)
+	return json.Marshal(wire.ContactSetResult{ContactSet: contactSetInfo(cs)})
+}
+
+func contactSetsList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]wire.ContactSetInfo, 0)
+	for _, cs := range asm.ContactSolver().All() {
+		out = append(out, contactSetInfo(cs))
+	}
+	return json.Marshal(wire.ContactSetsResult{ContactSets: out})
+}
+
+func contactSetsDelete(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ContactSetRef
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	asm.ContactSolver().Delete(in.ID)
+	return contactSetsList(s, nil)
+}
+
+func contactSetsAddMember(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	return contactMember(s, raw, (*assembly.ContactSolver).AddMember)
+}
+
+func contactSetsRemoveMember(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	return contactMember(s, raw, (*assembly.ContactSolver).RemoveMember)
+}
+
+// contactMember adds or removes a member via mutate and returns the updated set.
+func contactMember(s *app.Session, raw json.RawMessage, mutate func(*assembly.ContactSolver, uint64, uint64) error) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ContactMemberArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := mutate(asm.ContactSolver(), in.Set, in.Occurrence); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ContactSetResult{ContactSet: contactSetInfo(asm.ContactSolver().ByID(in.Set))})
+}
+
+func contactSolverSetEnabled(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ContactSolverEnableArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	asm.ContactSolver().SetEnabled(in.Enabled)
+	return contactSolverStatus(s, nil)
+}
+
+func contactSolverStatus(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	sv := asm.ContactSolver()
+	return json.Marshal(wire.ContactSolverResult{Solver: wire.ContactSolverInfo{Enabled: sv.Enabled(), SetCount: sv.SetCount()}})
+}
+
+func interferenceAnalyze(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	asm, err := modelaccess.ActiveAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AnalyzeInterferenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	res := asm.AnalyzeInterference(in.Occurrences)
+	out := make([]wire.InterferenceResultInfo, 0, len(res.Results))
+	for _, r := range res.Results {
+		out = append(out, interferenceResultInfo(r))
+	}
+	return json.Marshal(wire.InterferenceResultsResult{Results: out, TotalVolume: res.Total})
+}
+
+// contactSetInfo encodes a contact set.
+func contactSetInfo(cs assembly.ContactSetView) wire.ContactSetInfo {
+	return wire.ContactSetInfo{ID: cs.ID(), Name: cs.Name(), Members: cs.Members()}
+}
+
+// interferenceResultInfo encodes one interference result.
+func interferenceResultInfo(r assembly.InterferenceResult) wire.InterferenceResultInfo {
+	return wire.InterferenceResultInfo{
+		OccurrenceA: r.OccurrenceA(),
+		OccurrenceB: r.OccurrenceB(),
+		Volume:      r.Volume(),
+		Center:      types.Point{X: r.Center.X, Y: r.Center.Y, Z: r.Center.Z},
+	}
+}

--- a/addin/router/contact_test.go
+++ b/addin/router/contact_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestInterferenceAnalysisOverWire checks the M12-F05 interference analysis: two unit boxes
+// overlapping by 0.5 cm in X report one interfering pair with the right overlap volume; boxes
+// that do not overlap report none (#362/#368).
+func TestInterferenceAnalysisOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 0.5) // unit boxes, overlap x in [0.5,1]
+
+	var res wire.InterferenceResultsResult
+	call(t, r, s, "interference.analyze", `{}`, &res)
+	if len(res.Results) != 1 {
+		t.Fatalf("interference results = %d, want 1 overlapping pair", len(res.Results))
+	}
+	got := res.Results[0]
+	if got.OccurrenceA != occs[0].ID() && got.OccurrenceB != occs[0].ID() {
+		t.Errorf("pair = %d/%d, want box:1 (%d) involved", got.OccurrenceA, got.OccurrenceB, occs[0].ID())
+	}
+	if math.Abs(got.Volume-0.5) > 0.05 { // 0.5 x 1 x 1 cm overlap
+		t.Errorf("overlap volume = %.4f, want ~0.5", got.Volume)
+	}
+	if math.Abs(res.TotalVolume-0.5) > 0.05 {
+		t.Errorf("total volume = %.4f, want ~0.5", res.TotalVolume)
+	}
+
+	// Disjoint boxes: no interference.
+	r2, s2, _, _ := assemblySessionWithBoxes(t, 0, 2)
+	var none wire.InterferenceResultsResult
+	call(t, r2, s2, "interference.analyze", `{}`, &none)
+	if len(none.Results) != 0 {
+		t.Errorf("disjoint boxes reported %d interferences, want 0", len(none.Results))
+	}
+}
+
+// TestContactSetsOverWire drives the contact-set management + solver toggle over the wire.
+func TestContactSetsOverWire(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 2)
+
+	var cs wire.ContactSetResult
+	call(t, r, s, "contactSets.create", mustJSON(t, wire.CreateContactSetArgs{Name: "group"}), &cs)
+	call(t, r, s, "contactSets.addMember", mustJSON(t, wire.ContactMemberArgs{Set: cs.ContactSet.ID, Occurrence: occs[0].ID()}), &wire.ContactSetResult{})
+	var added wire.ContactSetResult
+	call(t, r, s, "contactSets.addMember", mustJSON(t, wire.ContactMemberArgs{Set: cs.ContactSet.ID, Occurrence: occs[1].ID()}), &added)
+	if len(added.ContactSet.Members) != 2 {
+		t.Fatalf("members = %v, want 2", added.ContactSet.Members)
+	}
+
+	var sv wire.ContactSolverResult
+	call(t, r, s, "contactSolver.setEnabled", mustJSON(t, wire.ContactSolverEnableArgs{Enabled: true}), &sv)
+	if !sv.Solver.Enabled || sv.Solver.SetCount != 1 {
+		t.Errorf("solver state = %+v, want enabled with 1 set", sv.Solver)
+	}
+
+	var afterDel wire.ContactSetsResult
+	call(t, r, s, "contactSets.delete", mustJSON(t, wire.ContactSetRef{ID: cs.ContactSet.ID}), &afterDel)
+	if len(afterDel.ContactSets) != 0 {
+		t.Errorf("after delete = %+v, want empty", afterDel.ContactSets)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -63,6 +63,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyJointHandlers()
 	r.registerAssemblyDriveHandlers()
 	r.registerRepresentationHandlers()
+	r.registerContactHandlers()
 	r.registerAssemblyReplicationHandlers()
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()

--- a/model/assembly/contact.go
+++ b/model/assembly/contact.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/contract"
+)
+
+// Contact (M12-F05, Oblikovati/Oblikovati#362/#368): a contact set is a named group of
+// occurrences that resist interpenetration when one is dragged, and the contact solver toggles
+// whether that resistance is enforced. Membership is pure bookkeeping (ids); the geometric
+// contact-stop and interference analysis read the occurrence bodies (compdef). These satisfy
+// contract.ContactSet(s)/ContactSolver.
+
+// ContactSetView is a contact set's host-read surface (so the router encodes it without naming
+// the unexported concrete type).
+type ContactSetView interface {
+	contract.ContactSet
+	Members() []uint64
+}
+
+// contactSet is a named group of occurrence ids that resist interpenetration.
+type contactSet struct {
+	id      uint64
+	name    string
+	members []uint64
+}
+
+// ID returns the contact set's session id.
+func (c *contactSet) ID() uint64 { return c.id }
+
+// Name returns the contact set's display name.
+func (c *contactSet) Name() string { return c.name }
+
+// MemberCount returns the number of occurrences in the set.
+func (c *contactSet) MemberCount() int { return len(c.members) }
+
+// Members returns the member occurrence ids (a copy).
+func (c *contactSet) Members() []uint64 {
+	out := make([]uint64, len(c.members))
+	copy(out, c.members)
+	return out
+}
+
+// ContactSolver owns an assembly's contact sets and the enforce-on-drag toggle.
+type ContactSolver struct {
+	enabled bool
+	sets    []*contactSet
+	nextID  uint64
+}
+
+// NewContactSolver builds an empty, disabled contact solver.
+func NewContactSolver() *ContactSolver { return &ContactSolver{} }
+
+// Enabled reports whether contact is enforced during a drag.
+func (s *ContactSolver) Enabled() bool { return s.enabled }
+
+// SetEnabled turns contact enforcement on or off.
+func (s *ContactSolver) SetEnabled(on bool) { s.enabled = on }
+
+// SetCount returns the number of contact sets.
+func (s *ContactSolver) SetCount() int { return len(s.sets) }
+
+// Create adds a new contact set named name and returns its host-read view.
+func (s *ContactSolver) Create(name string) ContactSetView {
+	s.nextID++
+	if name == "" {
+		name = fmt.Sprintf("Contact:%d", len(s.sets)+1)
+	}
+	cs := &contactSet{id: s.nextID, name: name}
+	s.sets = append(s.sets, cs)
+	return cs
+}
+
+// ByID returns the contact set with the given id (host-read view), or nil.
+func (s *ContactSolver) ByID(id uint64) ContactSetView {
+	if cs := s.setByID(id); cs != nil {
+		return cs
+	}
+	return nil
+}
+
+// setByID returns the concrete contact set for internal mutation, or nil.
+func (s *ContactSolver) setByID(id uint64) *contactSet {
+	for _, cs := range s.sets {
+		if cs.id == id {
+			return cs
+		}
+	}
+	return nil
+}
+
+// All returns the contact sets in creation order (host-read views).
+func (s *ContactSolver) All() []ContactSetView {
+	out := make([]ContactSetView, len(s.sets))
+	for i, cs := range s.sets {
+		out[i] = cs
+	}
+	return out
+}
+
+// AddMember adds an occurrence to a contact set (idempotent), erroring on an unknown set.
+func (s *ContactSolver) AddMember(setID, occurrence uint64) error {
+	cs := s.setByID(setID)
+	if cs == nil {
+		return fmt.Errorf("assembly: no contact set with id %d", setID)
+	}
+	for _, m := range cs.members {
+		if m == occurrence {
+			return nil
+		}
+	}
+	cs.members = append(cs.members, occurrence)
+	return nil
+}
+
+// RemoveMember removes an occurrence from a contact set, erroring on an unknown set.
+func (s *ContactSolver) RemoveMember(setID, occurrence uint64) error {
+	cs := s.setByID(setID)
+	if cs == nil {
+		return fmt.Errorf("assembly: no contact set with id %d", setID)
+	}
+	for i, m := range cs.members {
+		if m == occurrence {
+			cs.members = append(cs.members[:i], cs.members[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// Delete removes a contact set by id, reporting whether it was found.
+func (s *ContactSolver) Delete(id uint64) bool {
+	for i, cs := range s.sets {
+		if cs.id == id {
+			s.sets = append(s.sets[:i], s.sets[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// Count / Item give the contract.ContactSets read surface.
+func (s *ContactSolver) Count() int { return len(s.sets) }
+func (s *ContactSolver) Item(i int) contract.ContactSet {
+	if i < 0 || i >= len(s.sets) {
+		return nil
+	}
+	return s.sets[i]
+}
+
+// Contacts reports whether the two occurrences share a contact set — the pairs the contact
+// solver keeps from interpenetrating.
+func (s *ContactSolver) Contacts(a, b uint64) bool {
+	for _, cs := range s.sets {
+		if contains(cs.members, a) && contains(cs.members, b) {
+			return true
+		}
+	}
+	return false
+}
+
+// contains reports whether ids holds v.
+func contains(ids []uint64, v uint64) bool {
+	for _, id := range ids {
+		if id == v {
+			return true
+		}
+	}
+	return false
+}

--- a/model/assembly/contact_test.go
+++ b/model/assembly/contact_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import "testing"
+
+// TestContactSolverMembership checks contact-set creation, idempotent membership, the
+// shared-set contact query, removal, and delete (M12-F05).
+func TestContactSolverMembership(t *testing.T) {
+	s := NewContactSolver()
+	if s.Enabled() {
+		t.Error("a new contact solver should be disabled")
+	}
+	s.SetEnabled(true)
+	if !s.Enabled() {
+		t.Error("SetEnabled(true) did not enable the solver")
+	}
+
+	cs := s.Create("group")
+	if err := s.AddMember(cs.ID(), 1); err != nil {
+		t.Fatalf("AddMember: %v", err)
+	}
+	_ = s.AddMember(cs.ID(), 2)
+	_ = s.AddMember(cs.ID(), 2) // idempotent
+	if cs.MemberCount() != 2 {
+		t.Errorf("member count = %d, want 2", cs.MemberCount())
+	}
+	if !s.Contacts(1, 2) {
+		t.Error("occurrences 1 and 2 share a set — they should contact")
+	}
+	if s.Contacts(1, 3) {
+		t.Error("occurrence 3 is in no set — it should not contact")
+	}
+
+	_ = s.RemoveMember(cs.ID(), 2)
+	if s.Contacts(1, 2) {
+		t.Error("after removing 2, the pair should no longer contact")
+	}
+	if !s.Delete(cs.ID()) || s.Count() != 0 {
+		t.Errorf("delete failed: count = %d", s.Count())
+	}
+	if err := s.AddMember(404, 1); err == nil {
+		t.Error("AddMember to an unknown set should error")
+	}
+}

--- a/model/assembly/contract_assert.go
+++ b/model/assembly/contract_assert.go
@@ -43,4 +43,11 @@ var (
 	_ contract.LevelOfDetailRepresentation = (*lodRep)(nil)
 	_ contract.ModelState                  = (*modelState)(nil)
 	_ contract.RepresentationsManager      = (*Representations)(nil)
+
+	// Contact & interference (M12-F05).
+	_ contract.ContactSet          = (*contactSet)(nil)
+	_ contract.ContactSets         = (*ContactSolver)(nil)
+	_ contract.ContactSolver       = (*ContactSolver)(nil)
+	_ contract.InterferenceResult  = InterferenceResult{}
+	_ contract.InterferenceResults = InterferenceResults{}
 )

--- a/model/assembly/interference.go
+++ b/model/assembly/interference.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import (
+	"oblikovati.org/api/contract"
+	"oblikovati.org/math"
+)
+
+// Interference analysis (M12-F05, Oblikovati/Oblikovati#362/#368) reports the overlapping
+// volumes between occurrences — where two placed components occupy the same space. These are
+// the result data types (satisfying contract.InterferenceResult(s)); the geometric computation
+// (transform bodies to world, boolean-intersect, measure volume) lives in the host (compdef),
+// which owns the body geometry.
+
+// InterferenceResult is one overlapping pair: the two occurrence ids, the overlap volume, and a
+// representative point inside the overlap.
+type InterferenceResult struct {
+	A, B   uint64
+	Vol    float64
+	Center math.Point3
+}
+
+// OccurrenceA / OccurrenceB are the interfering occurrences' session ids.
+func (r InterferenceResult) OccurrenceA() uint64 { return r.A }
+func (r InterferenceResult) OccurrenceB() uint64 { return r.B }
+
+// Volume is the overlap volume (cubic centimetres).
+func (r InterferenceResult) Volume() float64 { return r.Vol }
+
+// InterferenceResults is an interference analysis outcome: the interfering pairs and the total
+// overlap volume.
+type InterferenceResults struct {
+	Results []InterferenceResult
+	Total   float64
+}
+
+// Count returns the number of interfering pairs.
+func (rs InterferenceResults) Count() int { return len(rs.Results) }
+
+// Item returns the i-th interference result, or nil when out of range.
+func (rs InterferenceResults) Item(i int) contract.InterferenceResult {
+	if i < 0 || i >= len(rs.Results) {
+		return nil
+	}
+	return rs.Results[i]
+}
+
+// TotalVolume is the sum of every pair's overlap volume.
+func (rs InterferenceResults) TotalVolume() float64 { return rs.Total }

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -40,6 +40,7 @@ type AssemblyComponentDefinition struct {
 	dsJoints    *assembly.DSJointSet    // DS-joint (DOF/imposed-motion) view (M12-F02)
 
 	representations *assembly.Representations // design-view/positional/LOD override layers + model states (M12-F04)
+	contacts        *assembly.ContactSolver   // contact sets + interpenetration toggle (M12-F05)
 	features        *AssemblyFeatures         // assembly-authored machining features (M11-F08)
 	params          *param.Parameters         // parameter DAG for assembly sketch dimensions
 	work            *feature.WorkGeometry     // origin frame + user work planes, in assembly space
@@ -79,6 +80,7 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 	a.joints = assembly.NewJointSet(occ, a.events)
 	a.dsJoints = assembly.NewDSJointSet()
 	a.representations = assembly.NewRepresentations(occ, a.constraints, a.joints)
+	a.contacts = assembly.NewContactSolver()
 	return a
 }
 
@@ -207,6 +209,12 @@ func (a *AssemblyComponentDefinition) DSJoints() *assembly.DSJointSet { return a
 // level-of-detail override layers plus model states (M12-F04).
 func (a *AssemblyComponentDefinition) Representations() *assembly.Representations {
 	return a.representations
+}
+
+// ContactSolver returns the assembly's contact solver — the contact sets and the
+// interpenetration-on-drag toggle (M12-F05).
+func (a *AssemblyComponentDefinition) ContactSolver() *assembly.ContactSolver {
+	return a.contacts
 }
 
 // SolveConstraints positions the assembly's occurrences to satisfy BOTH its constraints and

--- a/model/compdef/interference.go
+++ b/model/compdef/interference.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
+	"oblikovati.org/model/occurrence"
+)
+
+// Interference analysis (M12-F05, Oblikovati/Oblikovati#362/#368): where two placed components
+// occupy the same space. The host owns the body geometry, so the computation lives here — each
+// occurrence's bodies are transformed to world, broad-phased by bounding box, and (for
+// overlapping pairs) boolean-intersected to measure the real overlap volume.
+
+// interferenceVolumeEps ignores negligible overlaps (touching faces, numerical noise).
+const interferenceVolumeEps = 1e-6
+
+// AnalyzeInterference reports the overlapping volumes between the assembly's occurrences.
+// subset (occurrence ids) restricts the analysis to pairs both within it; empty analyzes every
+// pair.
+func (a *AssemblyComponentDefinition) AnalyzeInterference(subset []uint64) assembly.InterferenceResults {
+	occs := placedLeafOccurrences(a.occurrences)
+	world := make(map[uint64][]*topo.Body, len(occs))
+	boxes := make(map[uint64]math.Box, len(occs))
+	for _, o := range occs {
+		world[o.ID()] = occurrenceWorldBodies(o)
+		boxes[o.ID()] = o.RangeBox()
+	}
+	var out assembly.InterferenceResults
+	for i := 0; i < len(occs); i++ {
+		for j := i + 1; j < len(occs); j++ {
+			oa, ob := occs[i], occs[j]
+			if !pairInSubset(subset, oa.ID(), ob.ID()) || !boxes[oa.ID()].Intersects(boxes[ob.ID()]) {
+				continue
+			}
+			if vol, center, ok := bodiesOverlapVolume(world[oa.ID()], world[ob.ID()]); ok {
+				out.Results = append(out.Results, assembly.InterferenceResult{A: oa.ID(), B: ob.ID(), Vol: vol, Center: center})
+				out.Total += vol
+			}
+		}
+	}
+	return out
+}
+
+// placedLeafOccurrences returns the non-suppressed occurrences that instance a part with
+// bodies (sub-assembly interference is a later refinement).
+func placedLeafOccurrences(occs *occurrence.Occurrences) []*occurrence.Occurrence {
+	var out []*occurrence.Occurrence
+	for _, o := range occs.All() {
+		if o.Suppressed() {
+			continue
+		}
+		if _, ok := o.Definition().(interface {
+			SurfaceBodies() *topo.SurfaceBodies
+		}); ok {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+// occurrenceWorldBodies transforms an occurrence's part bodies into assembly space.
+func occurrenceWorldBodies(o *occurrence.Occurrence) []*topo.Body {
+	part, ok := o.Definition().(interface {
+		SurfaceBodies() *topo.SurfaceBodies
+	})
+	if !ok {
+		return nil
+	}
+	var out []*topo.Body
+	for _, b := range part.SurfaceBodies().All() {
+		world, err := ops.TransformBody(b, o.Transform(), func(l topo.Lineage) topo.Lineage { return l })
+		if err == nil && world != nil {
+			out = append(out, world)
+		}
+	}
+	return out
+}
+
+// bodiesOverlapVolume boolean-intersects every body pair and returns the total overlap volume
+// (cm³) and a representative point, or ok=false when the overlap is negligible.
+func bodiesOverlapVolume(as, bs []*topo.Body) (float64, math.Point3, bool) {
+	total := 0.0
+	var center math.Point3
+	found := false
+	for _, ba := range as {
+		for _, bb := range bs {
+			inter, err := ops.Boolean(ops.Intersect, ba, bb)
+			if err != nil || inter == nil {
+				continue
+			}
+			v := bodyVolume(inter)
+			if v <= interferenceVolumeEps {
+				continue
+			}
+			total += v
+			if !found {
+				center = inter.RangeBox().Center()
+				found = true
+			}
+		}
+	}
+	return total, center, found
+}
+
+// bodyVolume is the absolute enclosed volume of a body (sum of its shells' signed volumes).
+func bodyVolume(b *topo.Body) float64 {
+	v := 0.0
+	for _, sh := range b.Shells() {
+		v += ops.ShellSignedVolume(sh, ops.DefaultQuality())
+	}
+	if v < 0 {
+		v = -v
+	}
+	return v
+}
+
+// pairInSubset reports whether the pair is in scope: both ids in subset, or subset empty.
+func pairInSubset(subset []uint64, a, b uint64) bool {
+	if len(subset) == 0 {
+		return true
+	}
+	return idInSet(subset, a) && idInSet(subset, b)
+}
+
+func idInSet(ids []uint64, v uint64) bool {
+	for _, id := range ids {
+		if id == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

First half of **M12-F05 — contact & interference** (Oblikovati/Oblikovati#362/#368):

- **`model/assembly`** — `ContactSolver`: named contact sets (occurrences that resist interpenetration) with membership + an enforce-on-drag toggle, plus the `InterferenceResult(s)` data types.
- **`model/compdef`** — `AnalyzeInterference`: transforms each occurrence's bodies to world, broad-phases by bounding box, and **boolean-intersects** overlapping pairs to measure the **real overlap volume** (`ops.Boolean(Intersect)` + `ShellSignedVolume`), reporting each pair's volume + a representative point and the total.
- **`addin/router`** — `contactSets.*` / `contactSolver.*` / `interference.analyze`.

## Tested + live-verified
Unit: contact-set membership/toggle. Router: interference over the wire — two unit boxes overlapping 0.5 cm report a 0.5 cm³ overlap; disjoint boxes report none. **Live (running head over MCP):** two 40 mm cubes overlapping 2 cm reported **32.000 cm³** (exact) via real boolean intersection.

Builds on the merged M12 API contract (Oblikovati.API#106).

## Still to come
The interactive **contact-stop during drag** (a moving contact-set member stops at contact) + head UI, and the bridge integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)