### PR TITLE
fix(head): continuous edge lines on coincident faces (edge depth bias)

### DIFF
--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -1129,11 +1129,19 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
                 vkCmdSetDepthBias(v->cmd, 0.0f, 0.0f, 0.0f);
             }
         }
-        // 3) solid edges — depth-tested, so only the visible portions appear.
+        // 3) solid edges — depth-tested, so only the visible portions appear. A small negative
+        //    depth bias pulls the edge fragments slightly toward the camera so they win the
+        //    z-fight against the faces they lie on. Without it, an edge co-located with a face at
+        //    the same depth flickers in and out of the depth test and renders broken — worst
+        //    where two mated parts' coincident faces sit at the edge's exact depth. The bias is
+        //    small enough that edges genuinely behind solid geometry still fail the test (the
+        //    hidden-edge pass below handles those).
         if (lineIC > 0) {
             pushLit(0.0f);
+            vkCmdSetDepthBias(v->cmd, -1.0f, 0.0f, -1.0f);
             vkCmdBindPipeline(v->cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->linePipeline);
             vkCmdDrawIndexed(v->cmd, (uint32_t)lineIC, 1, (uint32_t)lineFirst, lineBase, 0);
+            vkCmdSetDepthBias(v->cmd, 0.0f, 0.0f, 0.0f);
         }
         // 4) hidden edges — reversed depth test, drawn only where occluded (dashed geometry).
         if (hidIC > 0) {


### PR DESCRIPTION
## Problem

Edge (wireframe) lines rendered **broken / discontinuous** on mated parts — where two components' faces are coincident. It's a z-depth problem, not tessellation.

## Cause

The solid-edge pass drew at **depth-bias 0**, i.e. the same depth as the faces the edges lie on. An edge co-located with a face z-fights with it, so only the fragments that happen to win the depth test appear → the line breaks up. Two mated parts make it worse: their coincident faces sit exactly at the shared edge's depth.

## Fix

Apply a small **negative depth bias** (`vkCmdSetDepthBias(-1, 0, -1)`) for the edge pass only, pulling edge fragments slightly toward the camera so they consistently beat coplanar faces. The bias is small enough that edges genuinely *behind* solid geometry still fail the depth test — the hidden-edge pass keeps drawing those dashed.

## Verified

Live in the running head: the shared edge of two mated 40 mm blocks is now clean and continuous, with no hidden edges bleeding through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)