### PR TITLE
feat(head): M12-F05 contact-stop on drag + Contact panel/browser

### DIFF
--- a/addin/router/assembly_occurrences.go
+++ b/addin/router/assembly_occurrences.go
@@ -84,14 +84,20 @@ func assemblyPlaceByDefinition(s *app.Session, raw json.RawMessage) (json.RawMes
 	return occurrenceReply(o)
 }
 
-// assemblyTransform repositions an occurrence.
+// assemblyTransform repositions an occurrence. When the contact solver is on, a move that would
+// drive a contact-set member into one of its partners is rejected — the part stops at contact
+// (M12-F05); the occurrence keeps its current placement.
 func assemblyTransform(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	var in wire.TransformOccurrenceArgs
 	o, err := occurrenceFromArgs(s, raw, &in, &in.ID, wire.MethodAssemblyTransform)
 	if err != nil {
 		return nil, err
 	}
-	o.SetTransform(matrixFromWire(in.Transform))
+	target := matrixFromWire(in.Transform)
+	if asm, err := modelaccess.ActiveAssembly(s); err == nil && asm.WouldContactBlock(o.ID(), target) {
+		return occurrenceReply(o)
+	}
+	o.SetTransform(target)
 	return occurrenceReply(o)
 }
 

--- a/addin/router/contact_test.go
+++ b/addin/router/contact_test.go
@@ -6,7 +6,9 @@ import (
 	"math"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
+	math4 "oblikovati.org/math"
 )
 
 // TestInterferenceAnalysisOverWire checks the M12-F05 interference analysis: two unit boxes
@@ -63,5 +65,32 @@ func TestContactSetsOverWire(t *testing.T) {
 	call(t, r, s, "contactSets.delete", mustJSON(t, wire.ContactSetRef{ID: cs.ContactSet.ID}), &afterDel)
 	if len(afterDel.ContactSets) != 0 {
 		t.Errorf("after delete = %+v, want empty", afterDel.ContactSets)
+	}
+}
+
+// TestContactStopBlocksInterpenetratingMove checks the M12-F05 contact-stop: with the contact
+// solver on, moving a contact-set member into a partner is rejected (the part stops at
+// contact); with it off, the move applies.
+func TestContactStopBlocksInterpenetratingMove(t *testing.T) {
+	r, s, _, occs := assemblySessionWithBoxes(t, 0, 1) // adjacent unit boxes, touching at x=1
+
+	var cs wire.ContactSetResult
+	call(t, r, s, "contactSets.create", mustJSON(t, wire.CreateContactSetArgs{Name: "g"}), &cs)
+	call(t, r, s, "contactSets.addMember", mustJSON(t, wire.ContactMemberArgs{Set: cs.ContactSet.ID, Occurrence: occs[0].ID()}), &wire.ContactSetResult{})
+	call(t, r, s, "contactSets.addMember", mustJSON(t, wire.ContactMemberArgs{Set: cs.ContactSet.ID, Occurrence: occs[1].ID()}), &wire.ContactSetResult{})
+	call(t, r, s, "contactSolver.setEnabled", mustJSON(t, wire.ContactSolverEnableArgs{Enabled: true}), &wire.ContactSolverResult{})
+
+	before := occs[1].Transform()
+	intoPartner := types.Matrix{Cells: math4.Translation4(math4.V3(0.5, 0, 0)).Cells()} // overlaps box:1 [0,1]
+	var res wire.OccurrenceResult
+	call(t, r, s, "assembly.transform", mustJSON(t, wire.TransformOccurrenceArgs{ID: occs[1].ID(), Transform: intoPartner}), &res)
+	if !occs[1].Transform().IsEqualTo(before, 1e-9) {
+		t.Error("contact on: an interpenetrating move should be blocked (occurrence keeps its place)")
+	}
+
+	call(t, r, s, "contactSolver.setEnabled", mustJSON(t, wire.ContactSolverEnableArgs{Enabled: false}), &wire.ContactSolverResult{})
+	call(t, r, s, "assembly.transform", mustJSON(t, wire.TransformOccurrenceArgs{ID: occs[1].ID(), Transform: intoPartner}), &res)
+	if occs[1].Transform().IsEqualTo(before, 1e-9) {
+		t.Error("contact off: the move should apply")
 	}
 }

--- a/app/browser.go
+++ b/app/browser.go
@@ -86,7 +86,20 @@ func addAssemblyBranches(root *BrowserNode, asm *compdef.AssemblyComponentDefini
 	addOccurrenceNodes(root, asm.Occurrences())
 	addAssemblyConstraintNodes(root, asm.Constraints())
 	addAssemblyJointNodes(root, asm.Joints())
+	addContactSetNodes(root, asm.ContactSolver())
 	addAssemblyFeatureNodes(root, asm.Features())
+}
+
+// addContactSetNodes appends a Contact Sets folder listing the assembly's contact sets (each
+// with its member count), omitted when there are none (M12-F05).
+func addContactSetNodes(root *BrowserNode, solver *assembly.ContactSolver) {
+	if solver.Count() == 0 {
+		return
+	}
+	folder := root.child("Contact Sets", "contactSets")
+	for _, cs := range solver.All() {
+		folder.child(fmt.Sprintf("%s (%d)", cs.Name(), cs.MemberCount()), "contactSet")
+	}
 }
 
 // addRepresentationNodes appends a Representations folder (View / Position / Level of Detail

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -25,6 +25,7 @@ func assemblyTabCommands() []*CommandDefinition {
 	cmds = append(cmds, relationshipCommands()...)
 	cmds = append(cmds, jointCommands()...)
 	cmds = append(cmds, representationCommands()...)
+	cmds = append(cmds, contactCommands()...)
 	return append(cmds, assemblyModelingCommands()...)
 }
 

--- a/app/contact_commands.go
+++ b/app/contact_commands.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "fmt"
+
+// The Contact panel (M12-F05, Oblikovati/Oblikovati#362/#368) on the Assemble tab: group the
+// selected components into a contact set (they resist interpenetration when dragged), toggle
+// the contact solver, and analyze interference (the overlapping volumes between components).
+
+// contactCommands returns the Contact-panel commands.
+func contactCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		contactCommand("Assembly.ContactSet", "Contact Set", "contact-set",
+			"Group the selected components into a contact set — they resist interpenetration when the contact solver is on.", (*Session).CreateContactSet),
+		contactCommand("Assembly.ContactEnable", "Enable Contact", "contact-enable",
+			"Toggle the contact solver — whether moving a contact-set member stops at contact with another.", (*Session).ToggleContactSolver),
+		contactCommand("Assembly.Interference", "Interference", "interference",
+			"Analyze interference — report the overlapping volumes between the assembly's components.", (*Session).AnalyzeInterference),
+	}
+}
+
+// contactCommand builds a Contact-panel command that runs run on an active assembly.
+func contactCommand(id, name, icon, tooltip string, run func(*Session) error) *CommandDefinition {
+	return NewCommand(id, name, "Contact", run).
+		WithTab("Assemble").WithRibbons(AssemblyRibbon).WithEnable(hasActiveAssembly).
+		WithIcon(icon).WithButtonStyle(CompactIconButton).WithTooltip(tooltip)
+}
+
+// CreateContactSet groups the currently-selected component occurrences into a new contact set.
+func (s *Session) CreateContactSet() error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	cs := asm.ContactSolver().Create("")
+	members := 0
+	for _, it := range s.Selection().Items() {
+		if h, ok := it.(OccurrenceHandle); ok {
+			_ = asm.ContactSolver().AddMember(cs.ID(), h.Occurrence.ID())
+			members++
+		}
+	}
+	s.notice = fmt.Sprintf("Created %s with %d component(s)", cs.Name(), members)
+	return nil
+}
+
+// ToggleContactSolver flips contact enforcement on or off.
+func (s *Session) ToggleContactSolver() error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	solver := asm.ContactSolver()
+	solver.SetEnabled(!solver.Enabled())
+	state := "disabled"
+	if solver.Enabled() {
+		state = "enabled"
+	}
+	s.notice = "Contact solver " + state
+	return nil
+}
+
+// AnalyzeInterference reports the overlapping volumes between the assembly's components as a
+// status notice.
+func (s *Session) AnalyzeInterference() error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	res := asm.AnalyzeInterference(nil)
+	if len(res.Results) == 0 {
+		s.notice = "No interference detected"
+		return nil
+	}
+	s.notice = fmt.Sprintf("%d interference(s), total volume %.3f cm³", len(res.Results), res.Total)
+	return nil
+}

--- a/app/contact_ui_test.go
+++ b/app/contact_ui_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestContactPanelAndActions: the Contact panel exposes its commands, creating a contact set
+// from the selection groups them, the solver toggles, and Analyze Interference reports the
+// overlap (M12-F05).
+func TestContactPanelAndActions(t *testing.T) {
+	tab, ok := BuildRibbon(assemblySession(t)).Tab("Assemble")
+	if !ok {
+		t.Fatal("assembly should show the Assemble tab")
+	}
+	panel, ok := tab.Panel("Contact")
+	if !ok {
+		t.Fatal("Assemble tab has no Contact panel")
+	}
+	for _, name := range []string{"Contact Set", "Enable Contact", "Interference"} {
+		if !hasButton(panel, name) {
+			t.Errorf("Contact panel missing %q", name)
+		}
+	}
+
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	placedWidget(t, s, asm, "widget:2")
+	a, b := asm.Occurrences().Item(0), asm.Occurrences().Item(1)
+	s.Selection().Add(OccurrenceHandle{Occurrence: a})
+	s.Selection().Add(OccurrenceHandle{Occurrence: b})
+
+	if err := s.CreateContactSet(); err != nil {
+		t.Fatalf("CreateContactSet: %v", err)
+	}
+	if asm.ContactSolver().Count() != 1 || asm.ContactSolver().All()[0].MemberCount() != 2 {
+		t.Errorf("contact set = %d sets / %d members, want 1/2", asm.ContactSolver().Count(), len(asm.ContactSolver().All()))
+	}
+	if folder := findBrowserNode(BuildBrowser(s), "contactSets", "Contact Sets"); folder == nil || len(folder.Children) != 1 {
+		t.Errorf("Contact Sets browser folder = %v, want one row", folder)
+	}
+
+	if err := s.ToggleContactSolver(); err != nil || !asm.ContactSolver().Enabled() {
+		t.Errorf("ToggleContactSolver: err=%v enabled=%v", err, asm.ContactSolver().Enabled())
+	}
+
+	// Overlap the two widgets, then Analyze Interference reports a positive volume.
+	b.SetTransform(math.Identity4()) // coincident with a → full overlap
+	if err := s.AnalyzeInterference(); err != nil {
+		t.Fatalf("AnalyzeInterference: %v", err)
+	}
+	if !strings.Contains(s.Notice(), "interference") {
+		t.Errorf("interference notice = %q, want an interference report", s.Notice())
+	}
+}

--- a/head/icon/assets/contact-enable.svg
+++ b/head/icon/assets/contact-enable.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="3" y="7" width="8" height="10"/><rect x="13" y="7" width="8" height="10"/><circle cx="12" cy="12" r="1.5" fill="#000" stroke="none"/></svg>

--- a/head/icon/assets/contact-set.svg
+++ b/head/icon/assets/contact-set.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="4" y="6" width="10" height="10"/><rect x="10" y="10" width="10" height="8"/></svg>

--- a/head/icon/assets/interference.svg
+++ b/head/icon/assets/interference.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><circle cx="9" cy="12" r="6"/><circle cx="15" cy="12" r="6"/><path d="M12 7 A6 6 0 0 1 12 17 A6 6 0 0 1 12 7 Z" fill="#000" stroke="none"/></svg>

--- a/model/assembly/contact.go
+++ b/model/assembly/contact.go
@@ -151,6 +151,25 @@ func (s *ContactSolver) Item(i int) contract.ContactSet {
 	return s.sets[i]
 }
 
+// PartnersOf returns the occurrences that share a contact set with occID — the components its
+// motion must not interpenetrate.
+func (s *ContactSolver) PartnersOf(occID uint64) []uint64 {
+	seen := map[uint64]bool{}
+	var out []uint64
+	for _, cs := range s.sets {
+		if !contains(cs.members, occID) {
+			continue
+		}
+		for _, m := range cs.members {
+			if m != occID && !seen[m] {
+				seen[m] = true
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
 // Contacts reports whether the two occurrences share a contact set — the pairs the contact
 // solver keeps from interpenetrating.
 func (s *ContactSolver) Contacts(a, b uint64) bool {

--- a/model/assembly/contact_test.go
+++ b/model/assembly/contact_test.go
@@ -31,6 +31,9 @@ func TestContactSolverMembership(t *testing.T) {
 	if s.Contacts(1, 3) {
 		t.Error("occurrence 3 is in no set — it should not contact")
 	}
+	if p := s.PartnersOf(1); len(p) != 1 || p[0] != 2 {
+		t.Errorf("PartnersOf(1) = %v, want [2]", p)
+	}
 
 	_ = s.RemoveMember(cs.ID(), 2)
 	if s.Contacts(1, 2) {

--- a/model/compdef/interference.go
+++ b/model/compdef/interference.go
@@ -45,6 +45,36 @@ func (a *AssemblyComponentDefinition) AnalyzeInterference(subset []uint64) assem
 	return out
 }
 
+// WouldContactBlock reports whether moving the occurrence with occID to newTransform would make
+// it interpenetrate one of its contact-set partners (M12-F05) — the contact solver's
+// stop-at-contact test for a candidate move. It is false (no block) when the solver is
+// disabled or the occurrence shares no contact set. The probe is non-destructive: the
+// occurrence's transform is restored before returning.
+func (a *AssemblyComponentDefinition) WouldContactBlock(occID uint64, newTransform math.Matrix4) bool {
+	if !a.contacts.Enabled() {
+		return false
+	}
+	partners := a.contacts.PartnersOf(occID)
+	o, ok := a.occurrences.ByID(occID)
+	if len(partners) == 0 || !ok {
+		return false
+	}
+	saved := o.Transform()
+	o.SetTransform(newTransform)
+	defer o.SetTransform(saved)
+	moved := occurrenceWorldBodies(o)
+	for _, pid := range partners {
+		p, ok := a.occurrences.ByID(pid)
+		if !ok {
+			continue
+		}
+		if vol, _, found := bodiesOverlapVolume(moved, occurrenceWorldBodies(p)); found && vol > interferenceVolumeEps {
+			return true
+		}
+	}
+	return false
+}
+
 // placedLeafOccurrences returns the non-suppressed occurrences that instance a part with
 // bodies (sub-assembly interference is a later refinement).
 func placedLeafOccurrences(occs *occurrence.Occurrences) []*occurrence.Occurrence {


### PR DESCRIPTION
## What

Completes **M12-F05's interactive half** (Oblikovati/Oblikovati#362/#368), on top of the merged interference analysis (#854):

- **Contact-stop:** `ContactSolver.PartnersOf` + `compdef.WouldContactBlock` non-destructively probe a candidate move against the moving occurrence's contact-set partners. `assembly.transform` now **rejects a move that would interpenetrate a partner while the solver is on** — the part stops at contact; with the solver off, the move applies as before (no behavior change by default).
- **Head UI:** a **Contact** panel on the Assemble tab — *Contact Set* (group the selected components), *Enable Contact* (toggle), *Interference* (analyze, reports the overlapping volume as a status notice) — with icons, and a **Contact Sets** browser folder.

## Acceptance

Closes F05: *dragging a contacting part stops at contact; interference reports overlapping volumes.* Tested: `PartnersOf`, contact-stop over the wire (interpenetrating move blocked with the solver on, applies with it off), and the Contact panel + actions. Full `go test ./...` clean, lint 0, head cgo build + ribbon-icon test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)