### PR TITLE
feat: flexible subassembly occurrences (M12-F06)

### DIFF
--- a/addin/router/assembly_occurrences.go
+++ b/addin/router/assembly_occurrences.go
@@ -28,6 +28,7 @@ func (r *Router) registerAssemblyOccurrenceHandlers() {
 	r.handlers[wire.MethodAssemblyPlaceByDefinition] = assemblyPlaceByDefinition
 	r.handlers[wire.MethodAssemblyTransform] = assemblyTransform
 	r.handlers[wire.MethodAssemblyGround] = assemblyGround
+	r.handlers[wire.MethodAssemblySetFlexible] = assemblySetFlexible
 	r.handlers[wire.MethodAssemblySuppress] = assemblySuppress
 	r.handlers[wire.MethodAssemblyReplace] = assemblyReplace
 	r.handlers[wire.MethodAssemblyRemove] = assemblyRemove
@@ -103,6 +104,18 @@ func assemblyGround(s *app.Session, raw json.RawMessage) (json.RawMessage, error
 		return nil, err
 	}
 	o.SetGrounded(in.Grounded)
+	return occurrenceReply(o)
+}
+
+// assemblySetFlexible marks a sub-assembly occurrence flexible (independent per-placement solve)
+// or rigid — mutually exclusive with adaptive (M12-F06).
+func assemblySetFlexible(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetFlexibleOccurrenceArgs
+	o, err := occurrenceFromArgs(s, raw, &in, &in.ID, wire.MethodAssemblySetFlexible)
+	if err != nil {
+		return nil, err
+	}
+	o.SetFlexible(in.Flexible)
 	return occurrenceReply(o)
 }
 
@@ -234,6 +247,7 @@ func occurrenceInfo(o *occurrence.Occurrence) wire.OccurrenceInfo {
 		Suppressed: o.Suppressed(),
 		Grounded:   o.Grounded(),
 		Adaptive:   o.Adaptive(),
+		Flexible:   o.Flexible(),
 		Substitute: o.IsSubstitute(),
 	}
 	if subs := o.SubOccurrences(); subs != nil {

--- a/addin/router/flexible_test.go
+++ b/addin/router/flexible_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// TestSetFlexibleOverWire checks the M12-F06 flexible flag over the wire: a sub-assembly
+// occurrence becomes flexible (independent per-placement solve), a leaf part stays rigid (#822).
+func TestSetFlexibleOverWire(t *testing.T) {
+	r, s, asm, occs := assemblySessionWithBoxes(t, 0)
+
+	// A leaf part cannot be flexible — the flag stays off.
+	var leaf wire.OccurrenceResult
+	call(t, r, s, "assembly.setFlexible", mustJSON(t, wire.SetFlexibleOccurrenceArgs{ID: occs[0].ID(), Flexible: true}), &leaf)
+	if leaf.Occurrence.Flexible {
+		t.Error("a leaf part occurrence should not become flexible")
+	}
+
+	// A sub-assembly occurrence can.
+	sub := asm.Place("sub:1", compdef.NewAssemblyComponentDefinition(), math.Identity4())
+	var subRes wire.OccurrenceResult
+	call(t, r, s, "assembly.setFlexible", mustJSON(t, wire.SetFlexibleOccurrenceArgs{ID: sub.ID(), Flexible: true}), &subRes)
+	if !subRes.Occurrence.Flexible {
+		t.Error("a sub-assembly occurrence should become flexible over the wire")
+	}
+
+	// Turn it off again (fresh result var: Flexible is omitempty, so a false reply omits it and
+	// would otherwise leave a reused var's stale true in place).
+	var off wire.OccurrenceResult
+	call(t, r, s, "assembly.setFlexible", mustJSON(t, wire.SetFlexibleOccurrenceArgs{ID: sub.ID(), Flexible: false}), &off)
+	if off.Occurrence.Flexible || sub.Flexible() {
+		t.Error("setFlexible(false) should clear the flag")
+	}
+}

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -95,12 +95,21 @@ func occurrenceMenu(sel Selectable) []BrowserMenuItem {
 	if h.Occurrence.Suppressed() {
 		suppressLabel = "Unsuppress"
 	}
-	return []BrowserMenuItem{
+	items := []BrowserMenuItem{
 		{Label: "Edit", Enabled: h.Occurrence.ComponentName() != "", Invoke: func(s *Session) error { return s.OpenOccurrenceDocument(h.Occurrence) }},
 		{Label: groundLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceGrounded(h.Occurrence) }},
 		{Label: suppressLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceSuppressed(h.Occurrence) }},
-		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteOccurrence(h.Occurrence) }},
 	}
+	// Only a sub-assembly occurrence can be flexible (solve its components independently per
+	// placement, M12-F06); the label reflects the current state.
+	if h.Occurrence.SubOccurrences() != nil {
+		flexLabel := "Flexible"
+		if h.Occurrence.Flexible() {
+			flexLabel = "Rigid"
+		}
+		items = append(items, BrowserMenuItem{Label: flexLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleOccurrenceFlexible(h.Occurrence) }})
+	}
+	return append(items, BrowserMenuItem{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteOccurrence(h.Occurrence) }})
 }
 
 // representationMenu offers Activate and Delete for a representation selected in the

--- a/app/flexible_ui_test.go
+++ b/app/flexible_ui_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// TestOccurrenceFlexibleMenu checks the M12-F06 Flexible toggle: only a sub-assembly
+// occurrence's menu offers it, invoking it sets the flag, and the label then reads Rigid (#822).
+func TestOccurrenceFlexibleMenu(t *testing.T) {
+	s, asm := assemblyWithComponent(t)
+	placedWidget(t, s, asm, "widget:1")
+	leaf := asm.Occurrences().Item(0)
+
+	if _, ok := findMenuItem(occurrenceMenu(OccurrenceHandle{Occurrence: leaf}), "Flexible"); ok {
+		t.Error("a leaf part occurrence's menu should not offer Flexible")
+	}
+
+	sub := asm.Place("sub:1", compdef.NewAssemblyComponentDefinition(), math.Identity4())
+	item, ok := findMenuItem(occurrenceMenu(OccurrenceHandle{Occurrence: sub}), "Flexible")
+	if !ok {
+		t.Fatal("a sub-assembly occurrence's menu should offer Flexible")
+	}
+	if err := item.Invoke(s); err != nil {
+		t.Fatalf("Flexible: %v", err)
+	}
+	if !sub.Flexible() {
+		t.Error("invoking Flexible did not set the flag")
+	}
+	if _, ok := findMenuItem(occurrenceMenu(OccurrenceHandle{Occurrence: sub}), "Rigid"); !ok {
+		t.Error("a flexible occurrence's menu should offer Rigid to turn it off")
+	}
+}

--- a/app/occurrence_actions.go
+++ b/app/occurrence_actions.go
@@ -72,6 +72,22 @@ func (s *Session) ToggleOccurrenceGrounded(o *occurrence.Occurrence) error {
 	return s.GroundOccurrence(o, !o.Grounded())
 }
 
+// ToggleOccurrenceFlexible flips a sub-assembly occurrence's flexible flag (the browser's
+// Flexible entry, M12-F06) — when flexible, the sub-assembly solves its components independently
+// per placement. Mutually exclusive with adaptive (the setter clears it).
+func (s *Session) ToggleOccurrenceFlexible(o *occurrence.Occurrence) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if o == nil {
+		return errors.New("app: ToggleOccurrenceFlexible with nil occurrence")
+	}
+	o.SetFlexible(!o.Flexible())
+	s.recordEdit(asm, "Flexible Component")
+	return nil
+}
+
 // DeleteOccurrence removes o from the active assembly, clears the selection (the deleted node no
 // longer exists at its old identity), recomputes, and records an undo step. Undo restores the
 // occurrence through the assembly recipe and rebinds its component reference.

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -50,6 +50,7 @@ type occurrenceRecipe struct {
 	Suppressed bool      `yaml:"suppressed,omitempty"`
 	Grounded   bool      `yaml:"grounded,omitempty"`
 	Adaptive   bool      `yaml:"adaptive,omitempty"`
+	Flexible   bool      `yaml:"flexible,omitempty"` // M12-F06
 	Substitute bool      `yaml:"substitute,omitempty"`
 }
 
@@ -129,6 +130,7 @@ func (a *AssemblyComponentDefinition) occurrencesRecipe() []occurrenceRecipe {
 			Suppressed: o.Suppressed(),
 			Grounded:   o.Grounded(),
 			Adaptive:   o.Adaptive(),
+			Flexible:   o.Flexible(),
 			Substitute: o.IsSubstitute(),
 		})
 	}
@@ -217,6 +219,7 @@ func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) err
 		occ.SetSuppressed(rec.Suppressed)
 		occ.SetGrounded(rec.Grounded)
 		occ.SetAdaptive(rec.Adaptive)
+		occ.SetFlexible(rec.Flexible)
 		occ.SetSubstitute(rec.Substitute)
 	}
 	return a.restoreFeatures()

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -46,6 +46,7 @@ type Occurrence struct {
 	hidden     bool // inverse of visibility (M12-F04 design-view reps); zero ⇒ visible
 	grounded   bool
 	adaptive   bool
+	flexible   bool // sub-assembly solves independently per placement (M12-F06); excl. adaptive
 	substitute bool
 	definition Definition
 	// componentName is the full document name of the component this occurrence instances,
@@ -117,8 +118,32 @@ func (o *Occurrence) SetVisible(visible bool) { o.hidden = !visible }
 // satisfy assembly constraints (resolved by the solver from M12).
 func (o *Occurrence) Adaptive() bool { return o.adaptive }
 
-// SetAdaptive marks the occurrence adaptive or rigid.
-func (o *Occurrence) SetAdaptive(adaptive bool) { o.adaptive = adaptive }
+// SetAdaptive marks the occurrence adaptive or rigid. Adaptive and flexible are mutually
+// exclusive (M12-F06), so enabling adaptive clears flexible.
+func (o *Occurrence) SetAdaptive(adaptive bool) {
+	if adaptive {
+		o.flexible = false
+	}
+	o.adaptive = adaptive
+}
+
+// Flexible reports whether this sub-assembly occurrence solves its components independently per
+// placement — so two placements of the same sub-assembly can show their components in different
+// positions (M12-F06, the reference API's flexible component). Mutually exclusive with adaptive.
+func (o *Occurrence) Flexible() bool { return o.flexible }
+
+// SetFlexible marks a sub-assembly occurrence flexible (or rigid). Only an occurrence that
+// instances a sub-assembly (a [Composite] definition) can be flexible — for a leaf part it is a
+// no-op. Enabling flexible clears adaptive (the two states are mutually exclusive).
+func (o *Occurrence) SetFlexible(flexible bool) {
+	if flexible {
+		if _, ok := o.definition.(Composite); !ok {
+			return
+		}
+		o.adaptive = false
+	}
+	o.flexible = flexible
+}
 
 // IsSubstitute reports whether this occurrence is a substitute — a simplified
 // representation that stands in for a set of detailed components (the reference API's

--- a/model/occurrence/occurrence_test.go
+++ b/model/occurrence/occurrence_test.go
@@ -232,3 +232,33 @@ func TestVisibilityFlagDefaultsVisible(t *testing.T) {
 		t.Error("after SetVisible(true) the occurrence should be visible again")
 	}
 }
+
+// TestFlexibleFlag checks the M12-F06 flexible flag: only a sub-assembly occurrence can be
+// flexible, and flexible is mutually exclusive with adaptive.
+func TestFlexibleFlag(t *testing.T) {
+	occs := NewOccurrences()
+
+	// A leaf part cannot be flexible.
+	leaf := occs.AddByComponentDefinition("part:1", unitComponent(), math.Identity4())
+	leaf.SetFlexible(true)
+	if leaf.Flexible() {
+		t.Error("a leaf part occurrence should not become flexible")
+	}
+
+	// A sub-assembly occurrence can.
+	sub := occs.AddByComponentDefinition("sub:1", &fakeAssembly{children: NewOccurrences()}, math.Identity4())
+	sub.SetFlexible(true)
+	if !sub.Flexible() {
+		t.Error("a sub-assembly occurrence should become flexible")
+	}
+
+	// Flexible and adaptive are mutually exclusive.
+	sub.SetAdaptive(true)
+	if sub.Flexible() || !sub.Adaptive() {
+		t.Errorf("after SetAdaptive: flexible=%v adaptive=%v, want false/true", sub.Flexible(), sub.Adaptive())
+	}
+	sub.SetFlexible(true)
+	if !sub.Flexible() || sub.Adaptive() {
+		t.Errorf("after SetFlexible: flexible=%v adaptive=%v, want true/false", sub.Flexible(), sub.Adaptive())
+	}
+}


### PR DESCRIPTION
## What

Implements **M12-F06 — flexible assemblies** (Oblikovati/Oblikovati#822): mark a subassembly occurrence *flexible* so each placement of the shared definition can show its components in independent positions.

- **occurrence:** `Flexible()`/`SetFlexible()` — only a sub-assembly (`Composite`) occurrence can be flexible, and flexible is **mutually exclusive with adaptive** (each setter clears the other). Persisted in the assembly recipe (round-trips like grounded/adaptive).
- **router:** `assembly.setFlexible` + `Flexible` on `OccurrenceInfo` (the contract was merged in Oblikovati.API#106).
- **head:** a **Flexible/Rigid** toggle on a sub-assembly occurrence's browser menu (one undo step).

## Tested

Occurrence flag (sub-assembly-only + mutual exclusivity with adaptive), `set_flexible` over the wire (a sub-assembly becomes flexible, a leaf stays rigid), and the browser menu (offers Flexible only for sub-assemblies, toggles to Rigid). Full `go test ./...` clean, lint 0, head cgo build green.

## Scope note

This delivers the flag + its semantics + persistence + surface. The per-placement **independent constraint solution** (separate sub-assembly solver state per occurrence) builds on this flag and is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)