### PR TITLE
kernel: stop the CSG-fallback boolean from hanging (#470 groundwork)

### DIFF
--- a/kernel/brep/partial_penetration_test.go
+++ b/kernel/brep/partial_penetration_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+)
+
+// TestPartialPenetrationBlindPocket is the minimal repro for M20-F01 PBI-199 (#470): a square
+// bar that pokes part-way into the top face of a box (its bottom cap lies INSIDE the box) cut
+// from the box must leave a watertight blind pocket with the right volume. The planar B-rep
+// boolean is exercised directly so the BSP-CSG fallback cannot mask the arrangement defect.
+func TestPartialPenetrationBlindPocket(t *testing.T) {
+	body := box(0, 0, 0, 10, 10, 10) // [0,10]^3, volume 1000
+	tool := box(3, 3, 5, 4, 4, 7)    // [3,7]x[3,7]x[5,12]; bottom z=5 is inside the box
+	res, err := brep.Boolean(brep.Difference, body, tool)
+	if err != nil {
+		t.Fatalf("Boolean: %v", err)
+	}
+	if open := ops.BoundaryEdges(res); len(open) != 0 {
+		t.Errorf("blind pocket left %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if r := ops.Validate(res); !r.Valid {
+		t.Errorf("blind pocket body invalid: manifold=%v closed=%v orient=%v", r.Manifold, r.Closed, r.OrientationOK)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := 1000.0 - 4*4*5 // overlap [3,7]x[3,7]x[5,10] = 80 removed
+	if stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("blind pocket volume = %g, want %g", got, want)
+	}
+}
+
+// TestBladeCrossesConcaveFacetedWall is the live PBI-199 defect (#470): a radial bar joined to
+// a tube crosses the tube's CONCAVE faceted inner wall, spanning several facets, and ends inside
+// the wall material (partial penetration of a re-entrant faceted surface). The fan blade hits
+// exactly this; the planar boolean must union it into a single valid manifold solid rather than
+// leaving a coincident shell.
+func TestBladeCrossesConcaveFacetedWall(t *testing.T) {
+	tube := annularPrism(t, 24, 20, 4, "tube") // z∈[0,4], inner 12-gon (concave wall), outer 64-gon
+	bar := box(16, -6, 1, 8, 12, 2)            // x∈[16,24] y∈[-6,6] z∈[1,3]; crosses the inner wall over several facets
+	joined, err := brep.Boolean(brep.Union, tube, bar)
+	if err != nil {
+		t.Fatalf("Boolean(Union): %v", err)
+	}
+	if open := ops.BoundaryEdges(joined); len(open) != 0 {
+		t.Errorf("blade∪tube left %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if r := ops.Validate(joined); !r.Valid {
+		t.Errorf("blade∪tube invalid: manifold=%v closed=%v orient=%v", r.Manifold, r.Closed, r.OrientationOK)
+	}
+}
+
+// TestBladeFlushAgainstFacetGrazes is the flush/grazing trigger: a blade whose outer end face
+// is COPLANAR with one facet of the tube's inner wall while its body crosses the neighbouring
+// facets (the "blade grazes the faceted wall" case the fan hits). The planar boolean must still
+// union it into a single valid manifold rather than welding a coincident shell.
+func TestBladeFlushAgainstFacetGrazes(t *testing.T) {
+	tube := annularPrism(t, 24, 20, 4, "tube") // inner 12-gon facet near +X is the vertical chord x≈19.32, y∈[-5.18,5.18]
+	// Bar outer face at x=19.32 (flush with that facet), crossing it; inner end inside the bore.
+	bar := box(12, -3, 1, 7.32, 6, 2) // x∈[12,19.32] y∈[-3,3] z∈[1,3]; +X face coplanar with the facet
+	joined, err := brep.Boolean(brep.Union, tube, bar)
+	if err != nil {
+		t.Fatalf("Boolean(Union): %v", err)
+	}
+	if open := ops.BoundaryEdges(joined); len(open) != 0 {
+		t.Errorf("flush blade left %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if r := ops.Validate(joined); !r.Valid {
+		t.Errorf("flush blade invalid: manifold=%v closed=%v orient=%v", r.Manifold, r.Closed, r.OrientationOK)
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -87,7 +87,11 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 	// modest operand size: triangle CSG on a large body is expensive and rarely recovers it,
 	// so above the limit we keep the (fast) planar result rather than pay a big CSG attempt.
 	if shouldFallbackBoolean(op, target, tool, body) && len(target.Faces())+len(tool.Faces()) <= csgFallbackFaceLimit {
-		if csg, cerr := booleanCSG(op, target, tool, lin); cerr == nil && csg != nil && Validate(csg).Valid {
+		// Adopt the CSG fallback only when it is a genuine closed manifold solid — NOT merely
+		// Validate().Valid, which does not require Closed: a high-facet mesh whose T-junction
+		// removal bailed (tjunctionFaceBudget) comes back non-watertight, and adopting that
+		// would replace a sound planar result with open garbage.
+		if csg, cerr := booleanCSG(op, target, tool, lin); cerr == nil && csg != nil && validBooleanSolid(csg) {
 			return csg, nil
 		}
 	}

--- a/kernel/ops/csg_body.go
+++ b/kernel/ops/csg_body.go
@@ -155,6 +155,16 @@ func quantize(v float64) int64 { return int64(stdmath.Round(v / weldGrid)) }
 // every undirected edge ends up shared by exactly two triangles (the prerequisite for a
 // closed solid). Capped to avoid pathological loops.
 func removeTJunctions(verts []math.Point3, faces [][3]int) [][3]int {
+	// The CSG fallback only matters for small degenerate cases (it is adopted only when its
+	// result validates). On a large tessellated mesh — a faceted curved wall the loft-blade
+	// boolean tessellates into thousands of triangles — the per-edge vertex scan below is
+	// O(faces·verts) per pass AND cascade-splitting grows faces each pass, so leaving it
+	// unbounded hangs the whole boolean (it never returns). Bail once the mesh exceeds the
+	// budget: the partly-split cage won't be watertight, so booleanGeneral discards this
+	// fallback and keeps the planar result — which is what such large cases get anyway.
+	if len(faces) > tjunctionFaceBudget {
+		return faces
+	}
 	for pass := 0; pass < 64; pass++ {
 		split := false
 		var next [][3]int
@@ -167,12 +177,18 @@ func removeTJunctions(verts []math.Point3, faces [][3]int) [][3]int {
 			}
 		}
 		faces = next
-		if !split {
+		if !split || len(faces) > tjunctionFaceBudget {
 			break
 		}
 	}
 	return faces
 }
+
+// tjunctionFaceBudget caps the triangle count the O(faces·verts) T-junction pass will chew
+// through, so the CSG fallback can never hang the boolean on a high-facet mesh. Small
+// degenerate cases (the V2 flush-bottom oblique penetration) are a few dozen triangles, far
+// under it; a tessellated faceted-wall boolean is thousands and bails immediately.
+const tjunctionFaceBudget = 4000
 
 // splitFaceAtTJunction finds a vertex lying on one of the triangle's edges and splits
 // the triangle across it into two triangles, reporting whether a split happened.

--- a/kernel/ops/csg_tjunction_test.go
+++ b/kernel/ops/csg_tjunction_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestRemoveTJunctionsBudget guards the CSG-fallback hang fix (M20-F01 #470): T-junction
+// removal splits a triangle whose edge carries another vertex when the mesh is small, but a
+// mesh larger than tjunctionFaceBudget must BAIL unchanged — rather than run the
+// O(faces·verts) cascade-splitting pass that used to hang the boolean on the thousands of
+// triangles a faceted curved wall tessellates into.
+func TestRemoveTJunctionsBudget(t *testing.T) {
+	// Vertex 3 sits on edge 0→1 of triangle (0,1,2): a T-junction that splits 1 tri into 2.
+	verts := []math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(0, 2, 0), math.P3(1, 0, 0)}
+
+	if got := removeTJunctions(verts, [][3]int{{0, 1, 2}}); len(got) != 2 {
+		t.Errorf("under budget: got %d faces, want 2 (the T-junction is split out)", len(got))
+	}
+
+	big := make([][3]int, tjunctionFaceBudget+1)
+	for i := range big {
+		big[i] = [3]int{0, 1, 2}
+	}
+	if got := removeTJunctions(verts, big); len(got) != len(big) {
+		t.Errorf("over budget: got %d faces, want %d (must bail unchanged, no scan)", len(got), len(big))
+	}
+}


### PR DESCRIPTION
Part of #470 (M20-F01 boolean robustness). **Does not close it** — the underlying arrangement defect remains; this removes a hang that blocked even *testing* it, plus regression guards.

## The hang (fixed)
The invalid-result CSG fallback in `booleanGeneral` could hang the whole boolean — and the app — on a high-facet mesh. `removeTJunctions` is O(faces·verts) per pass **and** cascade-splits (faces grow each pass); on the thousands of triangles a faceted curved wall tessellates into (the fan's loft-blade ∪ bored-body), it never returned. The fan e2e test that appeared to "hang at 600 s" was *this* (the boolean), not the MCP harness — the goroutine dump pins it to `removeTJunctions → splitFaceAtTJunction → onSegment`.

**Fixes:**
- Cap the T-junction pass at `tjunctionFaceBudget` (4000 tris); beyond it, bail unchanged. The CSG fallback only helps small degenerate cases (it's adopted only if its result validates), so a giant mesh gains nothing.
- Tighten the fallback adoption gate from `Validate().Valid` to `validBooleanSolid` (`Valid && Closed && Manifold && IsSolid`) — a bailed, non-watertight CSG cage must never replace a sound planar result with open garbage.

Result: the loft-blade∪bored-body boolean now returns in ~0.1 s with the planar result, so its real defect (a non-manifold coincident shell, euler=1) is **observable instead of hanging** — unblocking the fan acceptance tests so #470's actual arrangement fix can be iterated.

## Guards added
- `kernel/ops/csg_tjunction_test.go` — T-junction split happens under budget, bails over it.
- `kernel/brep/partial_penetration_test.go` — the partial-penetration subcases that already pass at the planar level (flat-face blind pocket w/ correct volume, clean concave-facet crossing, flush-at-facet), so they can't regress.

## Verification
`kernel/ops`, `kernel/brep`, `model/feature`, `addin/opregistry` suites green (incl. the V2 flush-bottom case that still adopts its valid CSG fallback); `go vet`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)