### PR TITLE
feat: F06 independent solve — per-placement flexible child positions

### DIFF
--- a/addin/router/assembly_occurrences.go
+++ b/addin/router/assembly_occurrences.go
@@ -29,6 +29,7 @@ func (r *Router) registerAssemblyOccurrenceHandlers() {
 	r.handlers[wire.MethodAssemblyTransform] = assemblyTransform
 	r.handlers[wire.MethodAssemblyGround] = assemblyGround
 	r.handlers[wire.MethodAssemblySetFlexible] = assemblySetFlexible
+	r.handlers[wire.MethodAssemblySetFlexibleChild] = assemblySetFlexibleChild
 	r.handlers[wire.MethodAssemblySuppress] = assemblySuppress
 	r.handlers[wire.MethodAssemblyReplace] = assemblyReplace
 	r.handlers[wire.MethodAssemblyRemove] = assemblyRemove
@@ -123,6 +124,39 @@ func assemblySetFlexible(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	}
 	o.SetFlexible(in.Flexible)
 	return occurrenceReply(o)
+}
+
+// assemblySetFlexibleChild positions a child component within a flexible sub-assembly
+// occurrence independently of the sub-assembly's other placements (M12-F06 independent solve).
+func assemblySetFlexibleChild(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetFlexibleChildArgs
+	o, err := occurrenceFromArgs(s, raw, &in, &in.Occurrence, wire.MethodAssemblySetFlexibleChild)
+	if err != nil {
+		return nil, err
+	}
+	if !o.Flexible() {
+		return nil, fmt.Errorf("%s: occurrence %d is not flexible", wire.MethodAssemblySetFlexibleChild, in.Occurrence)
+	}
+	if !subAssemblyHasChild(o, in.Child) {
+		return nil, fmt.Errorf("%s: flexible occurrence %d has no child named %q", wire.MethodAssemblySetFlexibleChild, in.Occurrence, in.Child)
+	}
+	o.SetChildTransform(in.Child, matrixFromWire(in.Transform))
+	return occurrenceReply(o)
+}
+
+// subAssemblyHasChild reports whether o's sub-assembly definition has a child instance named
+// childName.
+func subAssemblyHasChild(o *occurrence.Occurrence, childName string) bool {
+	sub, ok := o.Definition().(occurrence.Composite)
+	if !ok {
+		return false
+	}
+	for _, c := range sub.Occurrences().All() {
+		if c.Name() == childName {
+			return true
+		}
+	}
+	return false
 }
 
 // assemblySuppress excludes or restores an occurrence from the model (vetoable).

--- a/addin/router/flexible_child_test.go
+++ b/addin/router/flexible_child_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// TestSetFlexibleChildOverWire checks the M12-F06 independent solve over the wire: a flexible
+// sub-assembly occurrence positions its child independently, and a non-flexible occurrence is
+// rejected (#822).
+func TestSetFlexibleChildOverWire(t *testing.T) {
+	r, s, asm, _ := assemblySessionWithBoxes(t) // empty parent assembly
+
+	subDef := compdef.NewAssemblyComponentDefinition()
+	subDef.Place("p:1", blockPart(t, math.P3(0, 0, 0), math.P3(1, 1, 1)), math.Identity4())
+	flex := asm.Place("sub:1", subDef, math.Identity4())
+	flex.SetFlexible(true)
+
+	m := types.Matrix{Cells: math.Translation4(math.V3(0, 0, 7)).Cells()}
+	var res wire.OccurrenceResult
+	call(t, r, s, "assembly.setFlexibleChild", mustJSON(t, wire.SetFlexibleChildArgs{Occurrence: flex.ID(), Child: "p:1", Transform: m}), &res)
+	if got, ok := flex.ChildTransform("p:1"); !ok || got.Translation().Z != 7 {
+		t.Errorf("flexible child override = %v (ok=%v), want a z=7 placement", got, ok)
+	}
+
+	// A non-flexible occurrence is rejected.
+	rigid := asm.Place("sub:2", subDef, math.Identity4())
+	args := mustJSON(t, wire.SetFlexibleChildArgs{Occurrence: rigid.ID(), Child: "p:1", Transform: m})
+	if _, err := r.Handle(s, "assembly.setFlexibleChild", []byte(args)); err == nil {
+		t.Error("setFlexibleChild on a non-flexible occurrence should error")
+	}
+
+	// An unknown child name is rejected.
+	bad := mustJSON(t, wire.SetFlexibleChildArgs{Occurrence: flex.ID(), Child: "nope", Transform: m})
+	if _, err := r.Handle(s, "assembly.setFlexibleChild", []byte(bad)); err == nil {
+		t.Error("setFlexibleChild with an unknown child name should error")
+	}
+}

--- a/model/compdef/assembly_derive.go
+++ b/model/compdef/assembly_derive.go
@@ -21,28 +21,41 @@ var _ feature.AssemblyBodySource = (*AssemblyComponentDefinition)(nil)
 // what shrinkwrap will simplify (M11-F06).
 func (a *AssemblyComponentDefinition) PlacedBodies() []feature.PlacedBody {
 	var out []feature.PlacedBody
-	collectPlacedBodies(a.occurrences, math.Identity4(), nil, &out)
+	collectPlacedBodies(a.occurrences, math.Identity4(), nil, &out, nil)
 	return out
 }
 
 // collectPlacedBodies walks one occurrence level, composing each occurrence's transform
 // with its parent's and extending the instance-name path, emitting a leaf part's bodies
 // and recursing into sub-assemblies. The path disambiguates a shared flyweight reached
-// through several placements (M11-F08 nested participation).
-func collectPlacedBodies(occs *occurrence.Occurrences, parent math.Matrix4, path occurrence.OccurrencePath, out *[]feature.PlacedBody) {
+// through several placements (M11-F08 nested participation). flexParent, when non-nil, is the
+// flexible sub-assembly occurrence whose children we are walking: each child uses that
+// placement's independent override transform when one is set, so two placements of one flexible
+// sub-assembly show their components in different positions (M12-F06).
+func collectPlacedBodies(occs *occurrence.Occurrences, parent math.Matrix4, path occurrence.OccurrencePath, out *[]feature.PlacedBody, flexParent *occurrence.Occurrence) {
 	for _, o := range occs.All() {
 		if o.Suppressed() {
 			continue
 		}
-		world := parent.Mul(o.Transform())
+		local := o.Transform()
+		if flexParent != nil {
+			if override, ok := flexParent.ChildTransform(o.Name()); ok {
+				local = override
+			}
+		}
+		world := parent.Mul(local)
 		here := append(append(occurrence.OccurrencePath(nil), path...), o.Name())
 		switch def := o.Definition().(type) {
 		case bodyDefinition: // a leaf part: emit its bodies placed in the assembly
 			for _, b := range def.SurfaceBodies().All() {
 				*out = append(*out, feature.PlacedBody{Body: b, Transform: world, Source: o, Path: here})
 			}
-		case occurrence.Composite: // a sub-assembly: recurse with the composed transform
-			collectPlacedBodies(def.Occurrences(), world, here, out)
+		case occurrence.Composite: // a sub-assembly: recurse, carrying flexible-child overrides
+			var nextFlex *occurrence.Occurrence
+			if o.Flexible() {
+				nextFlex = o
+			}
+			collectPlacedBodies(def.Occurrences(), world, here, out, nextFlex)
 		}
 	}
 }

--- a/model/compdef/assembly_derive_test.go
+++ b/model/compdef/assembly_derive_test.go
@@ -71,3 +71,40 @@ func TestAssemblyPlacedBodiesSkipsSuppressed(t *testing.T) {
 		t.Errorf("placed bodies = %d, want 1 (suppressed occurrence skipped)", got)
 	}
 }
+
+// TestFlexibleIndependentChildPositions checks the M12-F06 independent solve: a flexible
+// sub-assembly occurrence positions its child independently of another placement of the same
+// (shared) sub-assembly definition.
+func TestFlexibleIndependentChildPositions(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	sub := NewAssemblyComponentDefinition()
+	sub.Place("p:1", part, math.Identity4()) // shared default: child at the origin
+
+	top := NewAssemblyComponentDefinition()
+	flex := top.Place("sub:1", sub, math.Identity4())             // placement 1, at x=0
+	top.Place("sub:2", sub, math.Translation4(math.V3(10, 0, 0))) // placement 2, at x=10
+
+	// Make placement 1 flexible and lift its child by +20 in Z — only this placement changes.
+	flex.SetFlexible(true)
+	flex.SetChildTransform("p:1", math.Translation4(math.V3(0, 0, 20)))
+
+	placed := top.PlacedBodies()
+	if len(placed) != 2 {
+		t.Fatalf("placed bodies = %d, want 2", len(placed))
+	}
+	var flexZ, rigidZ float64 = -1, -1
+	for _, pb := range placed {
+		p0 := pb.Transform.TransformPoint(math.P3(0, 0, 0))
+		if float64(p0.X) > 5 {
+			rigidZ = float64(p0.Z) // placement 2 (x=10) — the shared default
+		} else {
+			flexZ = float64(p0.Z) // placement 1 (x=0) — the flexible override
+		}
+	}
+	if flexZ != 20 {
+		t.Errorf("flexible placement child Z = %g, want 20 (independent override)", flexZ)
+	}
+	if rigidZ != 0 {
+		t.Errorf("other placement child Z = %g, want 0 (shared default, unaffected)", rigidZ)
+	}
+}

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -51,7 +51,10 @@ type occurrenceRecipe struct {
 	Grounded   bool      `yaml:"grounded,omitempty"`
 	Adaptive   bool      `yaml:"adaptive,omitempty"`
 	Flexible   bool      `yaml:"flexible,omitempty"` // M12-F06
-	Substitute bool      `yaml:"substitute,omitempty"`
+	// ChildTransforms is a flexible occurrence's per-child independent placement (child name →
+	// 16-cell row-major transform), persisting the M12-F06 independent solution per placement.
+	ChildTransforms map[string][]float64 `yaml:"childTransforms,omitempty"`
+	Substitute      bool                 `yaml:"substitute,omitempty"`
 }
 
 // MarshalRecipe renders the assembly's recipe as YAML bytes (doc.RecipeContent).
@@ -124,14 +127,15 @@ func (a *AssemblyComponentDefinition) occurrencesRecipe() []occurrenceRecipe {
 		}
 		cells := o.Transform().Cells()
 		out = append(out, occurrenceRecipe{
-			Name:       o.Name(),
-			Component:  o.ComponentName(),
-			Transform:  cells[:],
-			Suppressed: o.Suppressed(),
-			Grounded:   o.Grounded(),
-			Adaptive:   o.Adaptive(),
-			Flexible:   o.Flexible(),
-			Substitute: o.IsSubstitute(),
+			Name:            o.Name(),
+			Component:       o.ComponentName(),
+			Transform:       cells[:],
+			Suppressed:      o.Suppressed(),
+			Grounded:        o.Grounded(),
+			Adaptive:        o.Adaptive(),
+			Flexible:        o.Flexible(),
+			ChildTransforms: marshalChildOverrides(o.ChildOverrides()),
+			Substitute:      o.IsSubstitute(),
 		})
 	}
 	return out
@@ -220,6 +224,7 @@ func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) err
 		occ.SetGrounded(rec.Grounded)
 		occ.SetAdaptive(rec.Adaptive)
 		occ.SetFlexible(rec.Flexible)
+		occ.SetChildOverrides(parseChildOverrides(rec.ChildTransforms))
 		occ.SetSubstitute(rec.Substitute)
 	}
 	return a.restoreFeatures()
@@ -300,3 +305,34 @@ type missingDefinition struct{}
 
 // RangeBox returns the empty box, satisfying occurrence.Definition.
 func (missingDefinition) RangeBox() math.Box { return math.EmptyBox() }
+
+// marshalChildOverrides flattens a flexible occurrence's per-child transforms (M12-F06) to the
+// recipe form (child instance name → 16-cell row-major transform).
+func marshalChildOverrides(overrides map[string]math.Matrix4) map[string][]float64 {
+	if len(overrides) == 0 {
+		return nil
+	}
+	out := make(map[string][]float64, len(overrides))
+	for name, m := range overrides {
+		cells := m.Cells()
+		out[name] = cells[:]
+	}
+	return out
+}
+
+// parseChildOverrides reverses marshalChildOverrides on reopen, skipping malformed entries.
+func parseChildOverrides(recorded map[string][]float64) map[string]math.Matrix4 {
+	if len(recorded) == 0 {
+		return nil
+	}
+	out := make(map[string]math.Matrix4, len(recorded))
+	for name, c := range recorded {
+		if len(c) != 16 {
+			continue
+		}
+		var cells [16]float64
+		copy(cells[:], c)
+		out[name] = math.Matrix4FromCells(cells)
+	}
+	return out
+}

--- a/model/occurrence/occurrence.go
+++ b/model/occurrence/occurrence.go
@@ -49,6 +49,10 @@ type Occurrence struct {
 	flexible   bool // sub-assembly solves independently per placement (M12-F06); excl. adaptive
 	substitute bool
 	definition Definition
+	// childOverrides is a flexible occurrence's independent child placement: keyed by child
+	// instance name, it overrides the shared sub-assembly definition's default transform so THIS
+	// placement positions its components independently (M12-F06). Nil for a rigid occurrence.
+	childOverrides map[string]math.Matrix4
 	// componentName is the full document name of the component this occurrence instances,
 	// recorded when placed from a document so the placement can be restored on reopen
 	// (#715). Empty for an in-memory placement made from a bare definition (no file) and
@@ -143,6 +147,50 @@ func (o *Occurrence) SetFlexible(flexible bool) {
 		o.adaptive = false
 	}
 	o.flexible = flexible
+}
+
+// ChildTransform returns the independent transform this flexible occurrence assigns to the
+// named child of its sub-assembly definition, and whether one is set (M12-F06). A caller falls
+// back to the child's shared default transform when ok is false.
+func (o *Occurrence) ChildTransform(childName string) (math.Matrix4, bool) {
+	m, ok := o.childOverrides[childName]
+	return m, ok
+}
+
+// SetChildTransform positions the named child of this flexible occurrence's sub-assembly
+// independently of the other placements, bumping the owning assembly's version so the render
+// refreshes. It is the per-placement degree of freedom that makes a sub-assembly flexible.
+func (o *Occurrence) SetChildTransform(childName string, m math.Matrix4) {
+	if o.childOverrides == nil {
+		o.childOverrides = map[string]math.Matrix4{}
+	}
+	o.childOverrides[childName] = m
+	o.owner.transformed(o, o.transform) // bump the version (the placement moved a child)
+}
+
+// ChildOverrides returns a copy of this occurrence's per-child transform overrides — what the
+// recipe persists for a flexible placement (M12-F06).
+func (o *Occurrence) ChildOverrides() map[string]math.Matrix4 {
+	if len(o.childOverrides) == 0 {
+		return nil
+	}
+	out := make(map[string]math.Matrix4, len(o.childOverrides))
+	for k, v := range o.childOverrides {
+		out[k] = v
+	}
+	return out
+}
+
+// SetChildOverrides restores the per-child overrides (the recipe-apply path on reopen).
+func (o *Occurrence) SetChildOverrides(overrides map[string]math.Matrix4) {
+	if len(overrides) == 0 {
+		o.childOverrides = nil
+		return
+	}
+	o.childOverrides = make(map[string]math.Matrix4, len(overrides))
+	for k, v := range overrides {
+		o.childOverrides[k] = v
+	}
 }
 
 // IsSubstitute reports whether this occurrence is a substitute — a simplified


### PR DESCRIPTION
## What

Makes a flexible subassembly occurrence solve its components **independently** of the shared definition's other placements (Oblikovati/Oblikovati#822) — the deeper half of M12-F06 (the flag landed in #857).

The flyweight keeps **shared geometry**, but each flexible placement carries its own **per-child transform overrides**:

- **occurrence:** `ChildTransform`/`SetChildTransform`/`ChildOverrides`, keyed by child instance name; a set bumps the assembly version so the render refreshes.
- **compdef:** `collectPlacedBodies` carries the flexible occurrence, so each child uses *that placement's* override (else the shared default) — two placements of one flexible subassembly render their components in different positions.
- **persistence:** the per-child overrides round-trip in the assembly recipe.
- **router:** `assembly.setFlexibleChild` (the **Oblikovati.API#109** contract).

## Tested

`PlacedBodies` shows independent child positions for a flexible placement while another placement of the same definition is unaffected; the override over the wire; rejection of a non-flexible occurrence / unknown child. Full `go test ./...` clean, lint 0.

## Note

Stacked on **Oblikovati.API#109** (the `set_flexible_child` contract); CI is red until that merges to `api` develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)