### PR TITLE
M20-F03: chamfer two-distance & distance-angle modes (#474)

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -22,10 +23,13 @@ import (
 // EdgeSets is fillet-only: the edge-set form (#323), taking precedence over the flat
 // edgeRefs+radius pair.
 type edgeDressArgs struct {
-	EdgeRefs []string        `json:"edgeRefs"`
-	Radius   string          `json:"radius,omitempty"`   // fillet
-	Distance string          `json:"distance,omitempty"` // chamfer
-	EdgeSets []filletSetArgs `json:"edgeSets,omitempty"` // fillet
+	EdgeRefs    []string        `json:"edgeRefs"`
+	Radius      string          `json:"radius,omitempty"`      // fillet
+	Distance    string          `json:"distance,omitempty"`    // chamfer
+	EdgeSets    []filletSetArgs `json:"edgeSets,omitempty"`    // fillet
+	ChamferType string          `json:"chamferType,omitempty"` // chamfer mode (default distance)
+	Distance2   string          `json:"distance2,omitempty"`   // chamfer twoDistances
+	Angle       string          `json:"angle,omitempty"`       // chamfer distanceAndAngle
 }
 
 // filletSetArgs is one fillet edge set over the wire: constant (radius) or variable
@@ -55,7 +59,10 @@ const chamferSchema = `{
   "type": "object",
   "properties": {
     "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to bevel (from get_reference_keys)."},
-    "distance": {"type": "string", "description": "Chamfer setback with units, e.g. \"2 mm\"."}
+    "distance": {"type": "string", "description": "Chamfer setback with units, e.g. \"2 mm\" (the first face for the asymmetric modes)."},
+    "chamferType": {"type": "string", "enum": ["distance", "distanceAndAngle", "twoDistances"], "default": "distance", "description": "Setback mode."},
+    "distance2": {"type": "string", "description": "twoDistances: setback on the second face, e.g. \"4 mm\"."},
+    "angle": {"type": "string", "description": "distanceAndAngle: chamfer-face angle, e.g. \"30 deg\"."}
   },
   "required": ["edgeRefs", "distance"]
 }`
@@ -147,8 +154,49 @@ func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewDressUpFeatures(part.Features()).AddChamfer(refKeys(in.EdgeRefs), d)
+	ct, err := chamferTypeOf(in.ChamferType)
+	if err != nil {
+		return nil, err
+	}
+	pf, err := applyChamferMode(part, refKeys(in.EdgeRefs), d, ct, in)
+	if err != nil {
+		return nil, err
+	}
 	return recomputeResult(part, pf)
+}
+
+// chamferTypeOf resolves the chamfer mode spelling, defaulting to equal-distance.
+func chamferTypeOf(spelling string) (types.ChamferType, error) {
+	if spelling == "" {
+		return types.ChamferDistance, nil
+	}
+	v, ok := types.ParseChamferType(spelling)
+	if !ok {
+		return 0, fmt.Errorf("chamfer: unknown chamferType %q", spelling)
+	}
+	return v, nil
+}
+
+// applyChamferMode places the chamfer feature for the resolved mode, resolving the second
+// input (distance2 or angle) for the asymmetric modes.
+func applyChamferMode(part *compdef.PartComponentDefinition, keys [][]byte, d func() float64, ct types.ChamferType, in edgeDressArgs) (*feature.PartFeature, error) {
+	du := feature.NewDressUpFeatures(part.Features())
+	switch ct {
+	case types.ChamferTwoDistances:
+		d2, err := lengthClosure(part, in.Distance2, "chamfer: distance2")
+		if err != nil {
+			return nil, err
+		}
+		return du.AddChamferTwoDistances(keys, d, d2), nil
+	case types.ChamferDistanceAndAngle:
+		a, err := angleClosure(part, in.Angle, "chamfer: angle")
+		if err != nil {
+			return nil, err
+		}
+		return du.AddChamferDistanceAngle(keys, d, a), nil
+	default:
+		return du.AddChamfer(keys, d), nil
+	}
 }
 
 // faceDressArgs is the shared shape of the face-referencing operations (shell, draft).

--- a/addin/router/chamfer_modes_test.go
+++ b/addin/router/chamfer_modes_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// chamferArgs builds a features.add(chamfer) request (edge keys carry binary bytes, so it
+// must be JSON-marshalled, not string-concatenated).
+func chamferArgs(t *testing.T, edge string, extra map[string]any) string {
+	t.Helper()
+	args := map[string]any{"edgeRefs": []string{edge}, "distance": "3 mm"}
+	for k, v := range extra {
+		args[k] = v
+	}
+	return mustJSON(t, map[string]any{"kind": "chamfer", "args": args})
+}
+
+// TestChamferTwoDistancesOverWire drives the full wire path for an asymmetric chamfer
+// (M20-F03 #474): features.add(chamfer, chamferType=twoDistances) on a box edge → valid solid.
+func TestChamferTwoDistancesOverWire(t *testing.T) {
+	r, s, verticals := filletBoxFixture(t)
+	call(t, r, s, "features.add", chamferArgs(t, verticals[0], map[string]any{"chamferType": "twoDistances", "distance2": "6 mm"}),
+		&struct {
+			Bodies int `json:"bodies"`
+		}{})
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("two-distance chamfered body invalid: %+v", v.Problems)
+	}
+}
+
+// TestChamferDistanceAngleOverWire drives the distance-and-angle mode over the wire.
+func TestChamferDistanceAngleOverWire(t *testing.T) {
+	r, s, verticals := filletBoxFixture(t)
+	call(t, r, s, "features.add", chamferArgs(t, verticals[0], map[string]any{"chamferType": "distanceAndAngle", "angle": "30 deg"}),
+		&struct {
+			Bodies int `json:"bodies"`
+		}{})
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("distance-angle chamfered body invalid: %+v", v.Problems)
+	}
+}
+
+// TestChamferUnknownTypeOverWire rejects an unknown chamfer mode with a precise error.
+func TestChamferUnknownTypeOverWire(t *testing.T) {
+	r, s, verticals := filletBoxFixture(t)
+	if _, err := r.Handle(s, "features.add", []byte(chamferArgs(t, verticals[0], map[string]any{"chamferType": "bevel"}))); err == nil {
+		t.Error("expected an error for an unknown chamferType")
+	}
+}

--- a/model/feature/assembly_dressup.go
+++ b/model/feature/assembly_dressup.go
@@ -38,7 +38,7 @@ func (f *AssemblyChamferFeature) Kind() string { return kindAssemblyChamfer }
 func (f *AssemblyChamferFeature) Recompute(in Input) (Output, error) {
 	dist := f.distance()
 	bodies, err := dressParticipants(in.Bodies, edgeSuffixKeys(f.edgeSuffixes), func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
-		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, "asmChamfer", f.flatCorners)
+		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, dist, "asmChamfer", f.flatCorners)
 		if err != nil {
 			return nil, err
 		}

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 	"sort"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -30,32 +31,42 @@ const singularDetTol = 1e-12
 // a tetrahedron cut that trims the pointy three-plane intersection into one flat
 // triangular face — the way Inventor blends such a corner by default. With it clear the
 // three chamfer planes are left to meet at a point.
-func chamferEdges(in Input, keys [][]byte, dist float64, feat string, flatCorners bool) (Output, error) {
+func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorners bool) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
 	}
-	if dist <= 0 {
-		return Output{}, fmt.Errorf("chamfer: distance %g must be > 0", dist)
+	if d1 <= 0 || d2 <= 0 {
+		return Output{}, fmt.Errorf("chamfer: setbacks (%g, %g) must both be > 0", d1, d2)
 	}
 	edges, err := resolveEdges(body, keys)
 	if err != nil {
 		return Output{}, err
 	}
-	// A rim of a simple analytic cylinder gets a TRUE conical chamfer (one geom.Cone face) by
-	// rebuilding the body as a surface of revolution (#127). Anything else falls through.
-	if res, ok := analyticCylinderChamfer(body, edges, dist, feat); ok {
-		return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+	// The analytic conical chamfer (#127) and the flat-corner blend assume a SYMMETRIC setback;
+	// an asymmetric (two-distance / distance-angle) chamfer takes the plain faceted-wedge path.
+	if d1 == d2 {
+		// A rim of a simple analytic cylinder gets a TRUE conical chamfer (one geom.Cone face) by
+		// rebuilding the body as a surface of revolution (#127). Anything else falls through.
+		if res, ok := analyticCylinderChamfer(body, edges, d1, feat); ok {
+			return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+		}
 	}
+	return chamferByWedges(in, body, edges, d1, d2, feat, flatCorners)
+}
+
+// chamferByWedges bevels the edges by cutting a wedge tool per edge (plus the flat-corner
+// blend cuts when requested) — the general faceted path used for every non-analytic chamfer.
+func chamferByWedges(in Input, body *topo.Body, edges []*topo.Edge, d1, d2 float64, feat string, flatCorners bool) (Output, error) {
 	// A curved body (analytic cylinder) is re-faceted and the selected edges remapped to its faceted
 	// segments, so the wedge cut works instead of hitting a degenerate closed edge (#129/#127).
 	work, edges := planarizeForEdges(body, edges, feat)
-	tools, err := chamferWedges(edges, dist, feat)
+	tools, err := chamferWedges(edges, d1, d2, feat)
 	if err != nil {
 		return Output{}, err
 	}
 	if flatCorners {
-		tools = append(tools, cornerCutTools(edges, dist, feat)...)
+		tools = append(tools, cornerCutTools(edges, d1, feat)...)
 	}
 	result, err := cutAll(work, tools)
 	if err != nil {
@@ -91,11 +102,31 @@ func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, error) {
 	return edges, nil
 }
 
-// chamferWedges builds the bevel wedge for each resolved edge.
-func chamferWedges(edges []*topo.Edge, dist float64, feat string) ([]*topo.Body, error) {
+// chamferSetbacks resolves a chamfer definition's mode into the two face setbacks (d1 along
+// the first adjacent face, d2 along the second): equal distance, two distances, or a distance
+// plus the chamfer-face angle (d2 = d1·tan θ, exact for perpendicular faces, the box case).
+func chamferSetbacks(def *ChamferDefinition) (d1, d2 float64, err error) {
+	d1 = callOrZero(def.Distance)
+	switch def.Type {
+	case types.ChamferTwoDistances:
+		d2 = callOrZero(def.Distance2)
+	case types.ChamferDistanceAndAngle:
+		a := callOrZero(def.Angle)
+		if a <= 0 || a >= stdmath.Pi/2 {
+			return 0, 0, fmt.Errorf("chamfer: angle %g rad must be in (0, π/2)", a)
+		}
+		d2 = d1 * stdmath.Tan(a)
+	default: // ChamferDistance (and the zero value): symmetric
+		d2 = d1
+	}
+	return d1, d2, nil
+}
+
+// chamferWedges builds the bevel wedge for each resolved edge (setbacks d1, d2).
+func chamferWedges(edges []*topo.Edge, d1, d2 float64, feat string) ([]*topo.Body, error) {
 	tools := make([]*topo.Body, 0, len(edges))
 	for i, edge := range edges {
-		tool, err := chamferWedge(edge, dist, fmt.Sprintf("%s/w%d", feat, i))
+		tool, err := chamferWedge(edge, d1, d2, fmt.Sprintf("%s/w%d", feat, i))
 		if err != nil {
 			return nil, err
 		}
@@ -104,10 +135,11 @@ func chamferWedges(edges []*topo.Edge, dist float64, feat string) ([]*topo.Body,
 	return tools, nil
 }
 
-// chamferWedge builds the triangular prism removed to bevel an edge: a right-triangle
-// cross-section with legs `dist` along each adjacent face's interior, swept along the
-// edge (with a small overhang past each end so the boolean is clean).
-func chamferWedge(edge *topo.Edge, dist float64, feat string) (*topo.Body, error) {
+// chamferWedge builds the triangular prism removed to bevel an edge: a triangle cross-section
+// with leg d1 along the first adjacent face's interior and d2 along the second's, swept along
+// the edge (with a small overhang past each end so the boolean is clean). Equal d1==d2 is the
+// symmetric chamfer; d1≠d2 is the asymmetric two-distance / distance-angle chamfer.
+func chamferWedge(edge *topo.Edge, d1, d2 float64, feat string) (*topo.Body, error) {
 	faces := edge.Faces()
 	if len(faces) != 2 {
 		return nil, fmt.Errorf("chamfer: edge bounds %d faces, need 2", len(faces))
@@ -126,7 +158,7 @@ func chamferWedge(edge *topo.Edge, dist float64, feat string) (*topo.Body, error
 	plane := planePerp(v0, e)
 	u, v := plane.XAxis().AsVector(), plane.YAxis().AsVector()
 	proj := func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) }
-	poly := []math.Point2{{X: 0, Y: 0}, proj(t1.Scale(dist)), proj(t2.Scale(dist))}
+	poly := []math.Point2{{X: 0, Y: 0}, proj(t1.Scale(d1)), proj(t2.Scale(d2))}
 	return buildPrism(poly, plane, span{near: -cutterOverhang, far: v0.DistanceTo(v1) + cutterOverhang}, 0, feat), nil
 }
 

--- a/model/feature/chamfer_modes_test.go
+++ b/model/feature/chamfer_modes_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"sort"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// box2 builds a 2×2×2 box on the XY plane and returns it with the reference key of its
+// vertical edge at the +X+Y corner (2,2).
+func box2(t *testing.T) (*topo.Body, []byte) {
+	t.Helper()
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	for _, e := range box.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.X == b.X && a.Y == b.Y && stdmath.Abs(a.X-2) < 1e-9 && stdmath.Abs(a.Y-2) < 1e-9 {
+			return box, e.ReferenceKey()
+		}
+	}
+	t.Fatal("no vertical edge at corner (2,2)")
+	return nil, nil
+}
+
+// cornerSetbacks returns the distances from the chamfered corner (2,2,0) to the chamfer
+// face's setback vertices on the bottom (z=0), sorted — for an asymmetric chamfer these are
+// the two different face setbacks.
+func cornerSetbacks(body *topo.Body) []float64 {
+	var ds []float64
+	for _, v := range body.Vertices() {
+		p := v.Point()
+		if stdmath.Abs(p.Z) > 1e-6 {
+			continue
+		}
+		if d := p.DistanceTo(math.P3(2, 2, 0)); d > 0.05 && d < 1.5 {
+			ds = append(ds, d)
+		}
+	}
+	sort.Float64s(ds)
+	return ds
+}
+
+// TestChamferTwoDistancesAsymmetric chamfers a box edge with unequal setbacks and verifies
+// the volume (½·d1·d2·L wedge) and that the two face setbacks are actually d1 and d2 (M20-F03).
+func TestChamferTwoDistancesAsymmetric(t *testing.T) {
+	box, edge := box2(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	ch := NewDressUpFeatures(fs).AddChamferTwoDistances([][]byte{edge}, func() float64 { return 0.3 }, func() float64 { return 0.6 })
+	fs.Recompute()
+
+	if !ch.Health().OK() {
+		t.Fatalf("two-distance chamfer sick: %+v", ch.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("two-distance chamfer not a valid solid: %+v", r)
+	}
+	want := 8 - 0.5*0.3*0.6*2 // box 8 − asymmetric wedge ½·d1·d2·length
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, want) > 1e-6 {
+		t.Errorf("two-distance chamfer volume = %g, want %g", got, want)
+	}
+	ds := cornerSetbacks(res)
+	if len(ds) != 2 || stdmath.Abs(ds[0]-0.3) > 1e-6 || stdmath.Abs(ds[1]-0.6) > 1e-6 {
+		t.Errorf("corner setbacks = %v, want [0.3 0.6] (asymmetric)", ds)
+	}
+}
+
+// TestChamferDistanceAngle chamfers with a distance + angle; the second setback is derived as
+// d·tanθ, so the removed wedge volume reflects the angle (M20-F03).
+func TestChamferDistanceAngle(t *testing.T) {
+	box, edge := box2(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	const d, angle = 0.4, stdmath.Pi / 6 // 30° ⇒ d2 = 0.4·tan30°
+	ch := NewDressUpFeatures(fs).AddChamferDistanceAngle([][]byte{edge}, func() float64 { return d }, func() float64 { return angle })
+	fs.Recompute()
+
+	if !ch.Health().OK() {
+		t.Fatalf("distance-angle chamfer sick: %+v", ch.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("distance-angle chamfer not a valid solid: %+v", r)
+	}
+	d2 := d * stdmath.Tan(angle)
+	want := 8 - 0.5*d*d2*2
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, want) > 1e-6 {
+		t.Errorf("distance-angle chamfer volume = %g, want %g (d2=%g)", got, want, d2)
+	}
+}
+
+// TestChamferTwoDistancesRoundTrip checks the mode + second distance survive an .obk round
+// trip (extrude source so the program serializes).
+func TestChamferTwoDistancesRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 1 })
+	NewDressUpFeatures(fs).AddChamferTwoDistances([][]byte{[]byte("e0")}, func() float64 { return 0.3 }, func() float64 { return 0.6 })
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(1).Definition().(*ChamferFeature).Definition()
+	if def.Type != types.ChamferTwoDistances {
+		t.Errorf("restored chamfer type = %v, want twoDistances", def.Type)
+	}
+	if def.Distance() != 0.3 || def.Distance2() != 0.6 {
+		t.Errorf("restored setbacks = (%g, %g), want (0.3, 0.6)", def.Distance(), def.Distance2())
+	}
+}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -67,16 +67,24 @@ func (f *FilletFeature) Recompute(in Input) (Output, error) {
 	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), "fillet")
 }
 
-// ChamferDefinition bevels selected edges by a distance. FlatCorners blends a vertex
-// where three selected edges meet into a flat triangular face (the Inventor default);
-// when false the three chamfer planes are left to meet at a point.
+// ChamferType aliases the public chamfer-mode discriminator (ADR-0018).
+type ChamferType = types.ChamferType
+
+// ChamferDefinition bevels selected edges. Type (M20-F03) selects the setback mode: equal
+// Distance on both faces (the default / zero value), two independent distances (Distance +
+// Distance2, asymmetric), or a Distance plus the chamfer-face Angle. FlatCorners blends a
+// vertex where three selected edges meet into a flat triangular face — only for the
+// equal-distance mode; an asymmetric chamfer leaves the corner planes to meet at a point.
 type ChamferDefinition struct {
 	EdgeKeys    [][]byte
 	Distance    func() float64
+	Distance2   func() float64 // twoDistances: setback on the second face
+	Angle       func() float64 // distanceAndAngle: chamfer-face angle (radians)
+	Type        ChamferType    // zero value ⇒ equal-distance
 	FlatCorners bool
 }
 
-// ChamferFeature is an equal-distance edge chamfer.
+// ChamferFeature bevels selected edges (equal-distance, two-distance, or distance-and-angle).
 type ChamferFeature struct {
 	def      *ChamferDefinition
 	featName string
@@ -86,9 +94,14 @@ func (c *ChamferFeature) Definition() *ChamferDefinition { return c.def }
 func (c *ChamferFeature) Kind() string                   { return "chamfer" }
 
 // Recompute bevels each selected (convex) edge by cutting a wedge tool along it via the
-// boolean. See chamfer.go.
+// boolean; the two setbacks come from the mode (see chamferSetbacks). Flat-corner blending
+// applies only to the symmetric equal-distance case. See chamfer.go.
 func (c *ChamferFeature) Recompute(in Input) (Output, error) {
-	return chamferEdges(in, c.def.EdgeKeys, callOrZero(c.def.Distance), featOr(c.featName, "chamfer"), c.def.FlatCorners)
+	d1, d2, err := chamferSetbacks(c.def)
+	if err != nil {
+		return Output{}, err
+	}
+	return chamferEdges(in, c.def.EdgeKeys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners && d1 == d2)
 }
 
 // ShellDefinition hollows a body, removing the selected faces, to a wall thickness.
@@ -261,7 +274,24 @@ func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64)
 // AddChamferCorners bevels the given edges by distance; flatCorners selects whether a
 // three-edge corner is blended into a flat triangular face (true) or left pointy (false).
 func (c *DressUpFeatures) AddChamferCorners(edgeKeys [][]byte, distance func() float64, flatCorners bool) *PartFeature {
-	cf := &ChamferFeature{def: &ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, FlatCorners: flatCorners}}
+	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners})
+}
+
+// AddChamferTwoDistances bevels the given edges with independent setbacks on the two adjacent
+// faces (an asymmetric chamfer, M20-F03).
+func (c *DressUpFeatures) AddChamferTwoDistances(edgeKeys [][]byte, distance, distance2 func() float64) *PartFeature {
+	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Distance2: distance2, Type: types.ChamferTwoDistances})
+}
+
+// AddChamferDistanceAngle bevels the given edges by a setback on the first face and the
+// chamfer-face angle (radians), M20-F03.
+func (c *DressUpFeatures) AddChamferDistanceAngle(edgeKeys [][]byte, distance, angle func() float64) *PartFeature {
+	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Angle: angle, Type: types.ChamferDistanceAndAngle})
+}
+
+// addChamfer registers a chamfer feature with the given definition.
+func (c *DressUpFeatures) addChamfer(def *ChamferDefinition) *PartFeature {
+	cf := &ChamferFeature{def: def}
 	pf := c.engine.Add(cf)
 	pf.SetName(c.engine.UniqueName("Chamfer"))
 	cf.featName = pf.name

--- a/model/feature/editable.go
+++ b/model/feature/editable.go
@@ -416,7 +416,14 @@ func (f *FilletFeature) EditableParams() []EditableParam {
 
 // EditableParams exposes the chamfer distance.
 func (c *ChamferFeature) EditableParams() []EditableParam {
-	return []EditableParam{scalarParam("Distance", param.Length, &c.def.Distance)}
+	ps := []EditableParam{scalarParam("Distance", param.Length, &c.def.Distance)}
+	switch c.def.Type {
+	case types.ChamferTwoDistances:
+		ps = append(ps, scalarParam("Distance 2", param.Length, &c.def.Distance2))
+	case types.ChamferDistanceAndAngle:
+		ps = append(ps, scalarParam("Angle", param.Angle, &c.def.Angle))
+	}
+	return ps
 }
 
 // EditableParams exposes the shell wall thickness.

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/model/seq"
 	"oblikovati.org/model/sketch"
@@ -115,7 +116,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius)}
 	case *ChamferFeature:
 		flat := f.def.FlatCorners
-		fd.Chamfer = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Distance), FlatCorners: &flat}
+		fd.Chamfer = &EdgeDressData{
+			Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Distance), FlatCorners: &flat,
+			ChamferType: int32(f.def.Type), Value2: evalFloat(f.def.Distance2), Angle: evalFloat(f.def.Angle),
+		}
 	case *ShellFeature:
 		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness)}
 	case *FaceDraftFeature:
@@ -316,7 +320,14 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if err != nil {
 			return nil, err
 		}
-		return du.AddChamferCorners(d.keys, constFloat(d.value), chamferFlatCornersOr(fd.Chamfer.FlatCorners)), nil
+		switch types.ChamferType(fd.Chamfer.ChamferType) {
+		case types.ChamferTwoDistances:
+			return du.AddChamferTwoDistances(d.keys, constFloat(d.value), constFloat(fd.Chamfer.Value2)), nil
+		case types.ChamferDistanceAndAngle:
+			return du.AddChamferDistanceAngle(d.keys, constFloat(d.value), constFloat(fd.Chamfer.Angle)), nil
+		default:
+			return du.AddChamferCorners(d.keys, constFloat(d.value), chamferFlatCornersOr(fd.Chamfer.FlatCorners)), nil
+		}
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -35,6 +35,12 @@ type EdgeDressData struct {
 	Value       float64         `yaml:"value,omitempty"`
 	FlatCorners *bool           `yaml:"flatCorners,omitempty"`
 	Sets        []FilletSetData `yaml:"sets,omitempty"`
+	// Chamfer-only mode (M20-F03): the setback mode and its second input. ChamferType 0 (or
+	// absent, in older recipes) ⇒ the equal-distance default; Value2 is the second distance
+	// (twoDistances); Angle is the chamfer-face angle in radians (distanceAndAngle).
+	ChamferType int32   `yaml:"chamferType,omitempty"`
+	Value2      float64 `yaml:"value2,omitempty"`
+	Angle       float64 `yaml:"angle,omitempty"`
 }
 
 // FilletSetData is one serialized fillet edge set: constant (Radius) or variable


### PR DESCRIPTION
Closes #474.

## What
The edge chamfer was **equal-distance only**. Adds the reference's three setback modes via `ChamferDefinition.Type` (`types.ChamferType`, landed in Oblikovati.API#110):
- **distance** — equal setback on both faces (unchanged default; the zero value stays this, so existing chamfers are untouched)
- **twoDistances** — independent setbacks d1/d2 (**asymmetric**)
- **distanceAndAngle** — a distance plus the chamfer-face angle (`d2 = d1·tanθ`, exact for perpendicular faces — the box case)

## How
The wedge cross-section now takes a leg per face (d1 along the first adjacent face's interior, d2 along the second), so `d1≠d2` cuts an asymmetric bevel. The analytic conical chamfer (#127) and the flat-corner blend assume a symmetric setback, so the asymmetric modes take the plain faceted-wedge path.

Plumbing: `AddChamferTwoDistances` / `AddChamferDistanceAngle` constructors; `features.edit` exposes the second input per mode; `.obk` round-trip of the mode + second input (older recipes restore as equal-distance); opregistry `chamfer` gains `chamferType` / `distance2` / `angle`.

## Verification
- **model**: two-distance asymmetric — volume `½·d1·d2·L` **and** the two face setbacks measured at 0.3/0.6 (genuinely asymmetric); distance-angle — `d2=d·tanθ` volume; `.obk` round-trip of mode + second distance.
- **router (wire path)**: applies both modes to a box edge → valid solid; rejects an unknown `chamferType`.
- `go build`, `go test` (model/feature, addin/opregistry incl. schema-validity, addin/router), `go vet`, `golangci-lint` (0 issues) pass locally.

## Follow-up (not in this PR, not in #474's acceptance)
Corner-round at vertices (curved geometry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)