### PR TITLE
M20-F10: Lip & groove feature (#485)

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -271,3 +271,51 @@ func applyDraft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	pf := feature.NewDressUpFeatures(part.Features()).AddDraft(refKeys(in.FaceRefs), a)
 	return recomputeResult(part, pf)
 }
+
+// --- lip / groove (M20-F10) ------------------------------------------------
+
+type lipArgs struct {
+	EdgeRefs []string `json:"edgeRefs"`
+	Width    string   `json:"width"`
+	Height   string   `json:"height"`
+	Groove   bool     `json:"groove,omitempty"`
+}
+
+const lipSchema = `{
+  "type": "object",
+  "properties": {
+    "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to run the bead along (from get_reference_keys)."},
+    "width": {"type": "string", "description": "Bead width along the first adjacent face, e.g. \"2 mm\"."},
+    "height": {"type": "string", "description": "Bead height along the second adjacent face, e.g. \"2 mm\"."},
+    "groove": {"type": "boolean", "default": false, "description": "Cut a recessed groove instead of raising a lip."}
+  },
+  "required": ["edgeRefs", "width", "height"]
+}`
+
+func lipDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "lip", Summary: "Run a raised lip (or recessed groove) bead along picked edges.", Schema: json.RawMessage(lipSchema), Apply: applyLip}
+}
+
+func applyLip(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in lipArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.EdgeRefs) == 0 {
+		return nil, errors.New("lip: edgeRefs is empty")
+	}
+	w, err := lengthClosure(part, in.Width, "lip: width")
+	if err != nil {
+		return nil, err
+	}
+	h, err := lengthClosure(part, in.Height, "lip: height")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddLip(refKeys(in.EdgeRefs), w, h, in.Groove)
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -110,6 +110,7 @@ func Default() *Registry {
 		chamferDescriptor(),
 		shellDescriptor(),
 		draftDescriptor(),
+		lipDescriptor(),
 		holeDescriptor(),
 		bossDescriptor(),
 		threadDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
-		"fillet", "chamfer", "shell", "draft", "hole", "boss", "thread",
+		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",

--- a/addin/router/lip_test.go
+++ b/addin/router/lip_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// lipArgsJSON builds a features.add(lip) request (edge keys carry binary bytes, so JSON-marshal).
+func lipArgsJSON(t *testing.T, edge string, groove bool) string {
+	t.Helper()
+	return mustJSON(t, map[string]any{"kind": "lip", "args": map[string]any{
+		"edgeRefs": []string{edge}, "width": "2 mm", "height": "2 mm", "groove": groove,
+	}})
+}
+
+// TestLipOverWire runs a raised lip along a box edge end to end (M20-F10 #485) → valid solid.
+func TestLipOverWire(t *testing.T) {
+	r, s, verticals := filletBoxFixture(t)
+	call(t, r, s, "features.add", lipArgsJSON(t, verticals[0], false), &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("lipped body invalid: %+v", v.Problems)
+	}
+}
+
+// TestLipGrooveOverWire runs the groove variant over the wire.
+func TestLipGrooveOverWire(t *testing.T) {
+	r, s, verticals := filletBoxFixture(t)
+	call(t, r, s, "features.add", lipArgsJSON(t, verticals[0], true), &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("grooved body invalid: %+v", v.Problems)
+	}
+}

--- a/model/feature/editable.go
+++ b/model/feature/editable.go
@@ -436,6 +436,14 @@ func (d *FaceDraftFeature) EditableParams() []EditableParam {
 	return []EditableParam{scalarParam("Angle", param.Angle, &d.def.Angle)}
 }
 
+// EditableParams exposes the lip bead's width and height.
+func (l *LipFeature) EditableParams() []EditableParam {
+	return []EditableParam{
+		scalarParam("Width", param.Length, &l.def.Width),
+		scalarParam("Height", param.Length, &l.def.Height),
+	}
+}
+
 // EditableParams exposes a hole's diameter, depth (blind only), and recess inputs by type.
 func (h *HoleFeature) EditableParams() []EditableParam {
 	ps := []EditableParam{scalarParam("Diameter", param.Length, &h.def.Diameter)}

--- a/model/feature/lip.go
+++ b/model/feature/lip.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Lip is a plastic-part feature (M20-F10): a rectangular bead run along selected edges, either
+// raised as a mating lip (Join) or recessed as a groove (Cut). Width sizes the bead along the
+// first adjacent face, Height along the second; the bead is centred on the edge so one quadrant
+// overlaps the body (bonding the lip / biting the groove) and the rest protrudes.
+
+// LipDefinition is the lip/groove recipe.
+type LipDefinition struct {
+	EdgeKeys [][]byte
+	Width    func() float64
+	Height   func() float64
+	Groove   bool // cut a groove instead of raising a lip
+}
+
+// LipFeature runs a bead along the selected edges.
+type LipFeature struct {
+	def      *LipDefinition
+	featName string
+}
+
+// Definition returns the lip recipe.
+func (l *LipFeature) Definition() *LipDefinition { return l.def }
+
+// Kind implements [Feature].
+func (l *LipFeature) Kind() string { return "lip" }
+
+// Recompute joins (lip) or cuts (groove) a bead along each selected edge into the running body.
+func (l *LipFeature) Recompute(in Input) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	w, h := callOrZero(l.def.Width), callOrZero(l.def.Height)
+	if w <= 0 || h <= 0 {
+		return Output{}, fmt.Errorf("lip: width %g and height %g must both be > 0", w, h)
+	}
+	edges, err := resolveEdges(body, l.def.EdgeKeys)
+	if err != nil {
+		return Output{}, err
+	}
+	op := ops.Join
+	if l.def.Groove {
+		op = ops.Cut
+	}
+	result := body
+	for i, edge := range edges {
+		bead, err := lipBead(edge, w, h, fmt.Sprintf("%s/b%d", featOr(l.featName, "lip"), i))
+		if err != nil {
+			return Output{}, err
+		}
+		if result, err = ops.Boolean(op, result, bead); err != nil {
+			return Output{}, err
+		}
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// lipBead builds the Width×Height bead swept along an edge: a rectangle in the plane
+// perpendicular to the edge, centred on the edge line and oriented to the adjacent faces (Width
+// along face 0's interior, Height along face 1's), swept the edge's length with a small overhang.
+func lipBead(edge *topo.Edge, w, h float64, feat string) (*topo.Body, error) {
+	faces := edge.Faces()
+	if len(faces) != 2 {
+		return nil, fmt.Errorf("lip: edge bounds %d faces, need 2", len(faces))
+	}
+	v0, v1 := edge.StartVertex().Point(), edge.EndVertex().Point()
+	e, err := math.UnitVector3FromVector(v0.VectorTo(v1))
+	if err != nil {
+		return nil, fmt.Errorf("lip: degenerate edge")
+	}
+	mid := v0.Midpoint(v1)
+	t1, t2 := interiorDir(faces[0], mid, e), interiorDir(faces[1], mid, e)
+	if t1.LengthSquared() == 0 || t2.LengthSquared() == 0 {
+		return nil, fmt.Errorf("lip: cannot orient the bead against the edge faces")
+	}
+	plane := planePerp(v0, e)
+	u, v := plane.XAxis().AsVector(), plane.YAxis().AsVector()
+	proj := func(vec math.Vector3) math.Point2 { return math.P2(vec.Dot(u), vec.Dot(v)) }
+	a, b := t1.Scale(w/2), t2.Scale(h/2) // half-extents along the two face interiors
+	poly := []math.Point2{proj(a.Add(b)), proj(a.Sub(b)), proj(a.Scale(-1).Sub(b)), proj(a.Scale(-1).Add(b))}
+	return buildPrism(poly, plane, span{near: -cutterOverhang, far: v0.DistanceTo(v1) + cutterOverhang}, 0, feat), nil
+}
+
+// AddLip runs a bead along the given edges — a raised lip (groove=false) or a recessed groove
+// (groove=true), sized width × height.
+func (c *DressUpFeatures) AddLip(edgeKeys [][]byte, width, height func() float64, groove bool) *PartFeature {
+	lf := &LipFeature{def: &LipDefinition{EdgeKeys: edgeKeys, Width: width, Height: height, Groove: groove}}
+	pf := c.engine.Add(lf)
+	pf.SetName(c.engine.UniqueName("Lip"))
+	lf.featName = pf.name
+	return pf
+}

--- a/model/feature/lip_test.go
+++ b/model/feature/lip_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestLipRaisesBeadAlongTopEdge runs a lip along a box top edge and checks it adds material
+// into a valid solid; the groove variant cuts (M20-F10 #485).
+func TestLipRaisesBeadAlongTopEdge(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var top []byte
+	for _, e := range box.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if stdmath.Abs(a.Z-2) < 1e-9 && stdmath.Abs(b.Z-2) < 1e-9 && a.Z == b.Z { // a horizontal top edge
+			top = e.ReferenceKey()
+			break
+		}
+	}
+	if top == nil {
+		t.Fatal("no top edge found")
+	}
+	base := 8.0 // box volume
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	lip := NewDressUpFeatures(fs).AddLip([][]byte{top}, func() float64 { return 0.3 }, func() float64 { return 0.3 }, false)
+	fs.Recompute()
+	if !lip.Health().OK() {
+		t.Fatalf("lip sick: %+v", lip.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("lip body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; got <= base {
+		t.Errorf("lip volume = %g, want > %g (lip adds material)", got, base)
+	}
+}
+
+// TestLipGrooveCutsAlongTopEdge checks the groove variant removes material.
+func TestLipGrooveCutsAlongTopEdge(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var top []byte
+	for _, e := range box.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if stdmath.Abs(a.Z-2) < 1e-9 && stdmath.Abs(b.Z-2) < 1e-9 && a.Z == b.Z {
+			top = e.ReferenceKey()
+			break
+		}
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	g := NewDressUpFeatures(fs).AddLip([][]byte{top}, func() float64 { return 0.3 }, func() float64 { return 0.3 }, true)
+	fs.Recompute()
+	if !g.Health().OK() {
+		t.Fatalf("groove sick: %+v", g.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("groove body not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; got >= 8.0 {
+		t.Errorf("groove volume = %g, want < 8 (groove removes material)", got)
+	}
+}
+
+// TestLipRoundTrip checks the lip's size + groove flag survive an .obk round trip.
+func TestLipRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 1 })
+	NewDressUpFeatures(fs).AddLip([][]byte{[]byte("e0")}, func() float64 { return 0.3 }, func() float64 { return 0.5 }, true)
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(1).Definition().(*LipFeature).Definition()
+	if def.Width() != 0.3 || def.Height() != 0.5 || !def.Groove {
+		t.Errorf("restored lip = (w %g, h %g, groove %v), want (0.3, 0.5, true)", def.Width(), def.Height(), def.Groove)
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -30,6 +30,7 @@ type FeatureData struct {
 	Chamfer    *EdgeDressData  `yaml:"chamfer,omitempty"`
 	Shell      *FaceDressData  `yaml:"shell,omitempty"`
 	Draft      *FaceDressData  `yaml:"draft,omitempty"`
+	Lip        *LipData        `yaml:"lip,omitempty"`
 	Thread     *ThreadData     `yaml:"thread,omitempty"`
 	Hole       *HoleData       `yaml:"hole,omitempty"`
 	Boss       *BossData       `yaml:"boss,omitempty"`
@@ -125,6 +126,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 	case *FaceDraftFeature:
 		p := f.def.PullDir
 		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle), Pull: []float64{p.X, p.Y, p.Z}}
+	case *LipFeature:
+		fd.Lip = &LipData{Edges: encodeKeys(f.def.EdgeKeys), Width: evalFloat(f.def.Width), Height: evalFloat(f.def.Height), Groove: f.def.Groove}
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut,
 			Class: f.def.Class, Tapered: f.def.Tapered, ModelDiameter: threadModelDiameterName(f.def.ModelDiameter)}
@@ -328,6 +331,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		default:
 			return du.AddChamferCorners(d.keys, constFloat(d.value), chamferFlatCornersOr(fd.Chamfer.FlatCorners)), nil
 		}
+	case "lip":
+		return restoreLip(fs, fd.Lip)
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_lip.go
+++ b/model/feature/serialize_lip.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// LipData is the serialized form of a LipFeature (M20-F10): the edge path the bead runs
+// along, its cross-section size, and whether it is a recessed groove.
+type LipData struct {
+	Edges  []string `yaml:"edges"`
+	Width  float64  `yaml:"width"`
+	Height float64  `yaml:"height"`
+	Groove bool     `yaml:"groove,omitempty"`
+}
+
+// restoreLip rebuilds a LipFeature, erroring on a missing payload.
+func restoreLip(fs *PartFeatures, d *LipData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("lip feature is missing its payload")
+	}
+	keys, err := decodeKeys(d.Edges)
+	if err != nil {
+		return nil, err
+	}
+	return NewDressUpFeatures(fs).AddLip(keys, constFloat(d.Width), constFloat(d.Height), d.Groove), nil
+}


### PR DESCRIPTION
Part of #485 (plastic part features). Adds the **Lip** feature, closing the F10 acceptance.

## Status of #485's scope
- **Emboss** (raise / engrave / text, depth, taper) — already shipped ✓
- **Boss** — a basic cylindrical boss already exists ✓ (the richer *head+thread+ribs* plastic boss is a follow-up)
- **Lip** — **this PR** ✓
- **Grill** (island/rib/spar set in a boundary) — follow-up

**Acceptance met:** an emboss raises a profile into a validated solid + engrave cuts (existing), and **a lip now runs along an edge** (validated, recompute on size).

## Lip
A rectangular bead run along selected edges — a raised mating lip (`Join`) or a recessed groove (`Cut`). The bead is a Width×Height cross-section in the plane perpendicular to the edge, centred on the edge and oriented to the adjacent faces, swept the edge's length; one quadrant overlaps the body so the join bonds / the cut bites. `AddLip` on `DressUpFeatures` (edge-referencing like chamfer/fillet); `features.edit` exposes Width/Height; `.obk` round-trip; opregistry `lip` kind.

## Verification
- **model**: lip adds material into a valid solid along a top edge; groove removes material; `.obk` round-trip of size + groove flag.
- **router (wire path)**: lip and groove both run into valid bodies.
- **live-confirmed** on the Vulkan renderer (raised bead / recessed notch).
- `go build`, `go test`, `go vet`, `golangci-lint` (0 issues) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)