### PR TITLE
fix(brep): robust planar boolean for partial penetration of faceted curved walls (#860)

### DIFF
--- a/kernel/brep/arrange2d.go
+++ b/kernel/brep/arrange2d.go
@@ -57,6 +57,7 @@ func planarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
 			}
 		}
 	}
+	splitTJunctions(weld.points, edges)
 	out := make([][2]int, 0, len(edges))
 	for e := range edges {
 		out = append(out, e)
@@ -70,6 +71,63 @@ func planarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
 		return out[i][1] < out[j][1]
 	})
 	return weld.points, out
+}
+
+// tjTol bounds the perpendicular distance at which a welded vertex counts as lying ON an
+// edge — a T-junction. It matches the welder's coincidence grid (1e-7): any point that would
+// weld onto the line is at most that far off it, while genuine features sit orders of
+// magnitude further (≥1e-2), so this never splits a near-miss.
+const tjTol = 1e-7
+
+// splitTJunctions subdivides every edge at any welded vertex lying strictly on its interior,
+// repeating until stable. splitOne only cuts at proper interior crossings of two segments;
+// when one segment merely ENDS on another's interior (a T-junction — e.g. a coplanar imprint
+// chain clipped to land exactly on a hole-loop edge, #860), the touch point welds as a vertex
+// but the host edge is left whole, so the chain dangles and the face never partitions. This
+// pass welds such chains shut, the crux of robust planar arrangement under faceted-curve cuts.
+func splitTJunctions(pts []math.Point2, edges map[[2]int]bool) {
+	for changed := true; changed; {
+		changed = false
+		for e := range edges {
+			c := vertexOnEdgeInterior(pts, e[0], e[1])
+			if c < 0 {
+				continue
+			}
+			delete(edges, e)
+			edges[canonEdge(e[0], c)] = true
+			edges[canonEdge(c, e[1])] = true
+			changed = true
+		}
+	}
+}
+
+// vertexOnEdgeInterior returns a vertex index lying strictly inside segment a→b (within
+// [tjTol] of it, parameter away from both ends), or −1 if none. The lowest such index is
+// returned for determinism.
+func vertexOnEdgeInterior(pts []math.Point2, a, b int) int {
+	pa, pb := pts[a], pts[b]
+	ab := pa.VectorTo(pb)
+	lenSq := ab.LengthSquared()
+	if lenSq < tjTol*tjTol {
+		return -1
+	}
+	best := -1
+	for c := range pts {
+		if c == a || c == b {
+			continue
+		}
+		t := pa.VectorTo(pts[c]).Dot(ab) / lenSq
+		if t <= tjTol || t >= 1-tjTol {
+			continue
+		}
+		if pa.TranslateBy(ab.Scale(t)).DistanceTo(pts[c]) > tjTol {
+			continue
+		}
+		if best < 0 || c < best {
+			best = c
+		}
+	}
+	return best
 }
 
 // splitOne returns segment i's elementary edges: the chain of welded vertex indices along

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -65,8 +65,8 @@ func imprintAll(fa, fb []planarFace) (impA, impB [][][2]math.Point3) {
 	for i := range fa {
 		for j := range fb {
 			if coplanar(fa[i], fb[j]) {
-				impA[i] = append(impA[i], interiorSegments(fa[i], faceEdges3D(fb[j]))...)
-				impB[j] = append(impB[j], interiorSegments(fb[j], faceEdges3D(fa[i]))...)
+				impA[i] = append(impA[i], coplanarOverlapSegments(fa[i], faceEdges3D(fb[j]))...)
+				impB[j] = append(impB[j], coplanarOverlapSegments(fb[j], faceEdges3D(fa[i]))...)
 				continue
 			}
 			segs := imprint(fa[i], fb[j])
@@ -134,6 +134,7 @@ func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Bo
 				fromFace = append(fromFace, out)
 			}
 		}
+		fromFace = mergeFilledHoles(fromFace)
 		// A face that survives as a single piece carries its source lineage unchanged, so
 		// its reference key is identical after the boolean (K1a). A face split into several
 		// kept pieces gives each a distinct child lineage (parent + split#k).

--- a/kernel/brep/boolean_coplanar.go
+++ b/kernel/brep/boolean_coplanar.go
@@ -4,7 +4,9 @@ package brep
 
 import (
 	stdmath "math"
+	"sort"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
 
@@ -35,6 +37,61 @@ func faceEdges3D(f planarFace) [][2]math.Point3 {
 		}
 	}
 	return segs
+}
+
+// coplanarOverlapSegments clips the other coplanar face's boundary edges to THIS face's
+// material region, keeping only the in-material portions (and dropping any lying on f's own
+// boundary). A coplanar union/cut only interacts over the shared overlap; imprinting the
+// other outline WHOLE injects segments that fall inside f's holes or beyond its outer loop —
+// e.g. a bar whose footprint sits inside a bored face's hole — which corrupt the 2D
+// arrangement into spurious sub-faces and a doubled coincident membrane (#860). Clipping each
+// edge to f's material (like the non-coplanar imprint already does via faceLineIntervals)
+// keeps only the segments that actually split f.
+func coplanarOverlapSegments(f planarFace, segs [][2]math.Point3) [][2]math.Point3 {
+	var out [][2]math.Point3
+	for _, s := range segs {
+		out = append(out, clipSegmentToMaterial(f, s)...)
+	}
+	return interiorSegments(f, out)
+}
+
+// clipSegmentToMaterial splits a segment (coplanar with f) at its crossings with f's loops and
+// returns the sub-segments whose midpoint lies in f's material (inside the outer loop, outside
+// every hole).
+func clipSegmentToMaterial(f planarFace, s [2]math.Point3) [][2]math.Point3 {
+	a2, b2 := to2D(f.plane, s[0]), to2D(f.plane, s[1])
+	ab := a2.VectorTo(b2)
+	ts := loopCrossingParams(f, geom.NewLineSegment2d(a2, b2))
+	var out [][2]math.Point3
+	for i := 0; i+1 < len(ts); i++ {
+		if ts[i+1]-ts[i] < arrTol {
+			continue
+		}
+		if !pointInFace2D(a2.TranslateBy(ab.Scale((ts[i]+ts[i+1])/2)), f) {
+			continue
+		}
+		p := to3D(f.plane, a2.TranslateBy(ab.Scale(ts[i])))
+		q := to3D(f.plane, a2.TranslateBy(ab.Scale(ts[i+1])))
+		out = append(out, [2]math.Point3{p, q})
+	}
+	return out
+}
+
+// loopCrossingParams returns the sorted parameters along seg (0 and 1 included) where it
+// crosses any of f's loop edges — the cut points that split seg into material/non-material runs.
+func loopCrossingParams(f planarFace, seg geom.LineSegment2d) []float64 {
+	ts := []float64{0, 1}
+	for _, ring := range f.loops {
+		n := len(ring)
+		for i := 0; i < n; i++ {
+			c, d := to2D(f.plane, ring[i]), to2D(f.plane, ring[(i+1)%n])
+			if _, sp, _, ok := geom.Segment2dIntersection(seg, geom.NewLineSegment2d(c, d), arrTol); ok {
+				ts = append(ts, sp)
+			}
+		}
+	}
+	sort.Float64s(ts)
+	return ts
 }
 
 // coplanarCover reports whether sub-face point ip is covered by a coplanar face of the other

--- a/kernel/brep/boolean_geom.go
+++ b/kernel/brep/boolean_geom.go
@@ -116,7 +116,42 @@ func faceLineIntervals(f planarFace, p0 math.Point3, dir math.Vector3) [][2]floa
 			out = append(out, [2]float64{ts[i], ts[i+1]})
 		}
 	}
+	// A line that runs exactly ALONG a boundary edge grazes the face: the even–odd midpoint
+	// test above lands on the boundary and rejects it non-deterministically (a float tie-break
+	// that drops one wall of a boundary-straddle cut, #860). Add the span of every collinear
+	// boundary edge explicitly so such an imprint is captured on whichever face owns the edge
+	// — for that face interiorSegments later drops it as on-boundary; for the other face (where
+	// the same line is interior) the overlap keeps it.
+	return append(out, collinearEdgeSpans(o2, d2, f)...)
+}
+
+// collinearEdgeSpans returns the line parameters spanned by each boundary edge of f that lies
+// along the line (o2 + t·d2) — both endpoints within [arrTol] of the line. The span is the
+// edge endpoints projected onto the line; an edge meeting the line at a single point is not
+// collinear and is excluded.
+func collinearEdgeSpans(o2 math.Point2, d2 math.Vector2, f planarFace) [][2]float64 {
+	lenSq := d2.LengthSquared()
+	var out [][2]float64
+	for _, ring := range f.loops {
+		n := len(ring)
+		for i := 0; i < n; i++ {
+			a, b := to2D(f.plane, ring[i]), to2D(f.plane, ring[(i+1)%n])
+			if distPointLine2D(a, o2, d2) > arrTol || distPointLine2D(b, o2, d2) > arrTol {
+				continue
+			}
+			ta := o2.VectorTo(a).Dot(d2) / lenSq
+			tb := o2.VectorTo(b).Dot(d2) / lenSq
+			out = append(out, [2]float64{minf(ta, tb), maxf(ta, tb)})
+		}
+	}
 	return out
+}
+
+// distPointLine2D is the perpendicular distance from p to the line through o with direction d.
+func distPointLine2D(p, o math.Point2, d math.Vector2) float64 {
+	op := o.VectorTo(p)
+	cross := op.Cross(d)
+	return stdmath.Abs(cross) / stdmath.Sqrt(d.LengthSquared())
 }
 
 func to2Dvec(pl geom.Plane, v math.Vector3) math.Vector2 {

--- a/kernel/brep/boolean_penetration_test.go
+++ b/kernel/brep/boolean_penetration_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// TestBarThroughBoredWallUnion is the kernel regression for #860 (the parametric-fan blade
+// defect, distilled): a thin bar whose bottom is COPLANAR with a bored body's bottom is unioned
+// on so it crosses the faceted bore wall — a partial penetration of a concave faceted surface.
+// Before the arrangement-robustness fixes (collinear-edge imprint capture, coplanar imprint
+// material-clip, T-junction welding, and filled-hole merge) the union welded the bar bottom as a
+// coincident non-manifold membrane along the bore wall. It must come back a clean manifold solid
+// whether the bar stops short of, exactly touches, or pokes through the bore wall.
+func TestBarThroughBoredWallUnion(t *testing.T) {
+	// Body: 5×5×1.5 box, bored (r=2.35) with a re-entrant hub (r=0.675) joined in the centre —
+	// so the bar's outer end crosses the CONCAVE bored wall, the hard case.
+	body := box(-2.5, -2.5, 0, 5, 5, 1.5)
+	body = cutOrFatal(t, body, cylinderZAt(0, 0, -0.5, 2.0, 2.35, "bore"), "bore")
+	body = joinOrFatal(t, body, cylinderZAt(0, 0, 0, 1.5, 0.675, "hub"), "hub")
+
+	// The bar inner end is over the hub; the outer end (x) sweeps from inside the bore void, to
+	// exactly the bore radius, to past it into the frame material.
+	for _, tip := range []float64{2.30, 2.34, 2.35, 2.36, 2.40} {
+		bar := box(0.6, -0.08, 0, tip-0.6, 0.16, 0.6)
+		joined, err := brep.Boolean(brep.Union, body, bar)
+		if err != nil {
+			t.Fatalf("tip=%.2f: union: %v", tip, err)
+		}
+		assertCleanSolid(t, joined, tip)
+	}
+}
+
+// assertCleanSolid fails if the body has any boundary (1-face) or non-manifold (>2-face) edge.
+func assertCleanSolid(t *testing.T, b *topo.Body, tip float64) {
+	t.Helper()
+	if b == nil {
+		t.Fatalf("tip=%.2f: nil result", tip)
+	}
+	open, nonManifold := 0, 0
+	for _, e := range b.Edges() {
+		switch n := len(e.Faces()); {
+		case n < 2:
+			open++
+		case n > 2:
+			nonManifold++
+		}
+	}
+	if r := ops.Validate(b); !r.Valid || open != 0 || nonManifold != 0 {
+		t.Errorf("tip=%.2f: not a clean manifold solid: valid=%v open=%d nonManifold=%d issues=%v",
+			tip, r.Valid, open, nonManifold, r.Issues)
+	}
+}

--- a/kernel/brep/boolean_split.go
+++ b/kernel/brep/boolean_split.go
@@ -3,6 +3,11 @@
 package brep
 
 import (
+	stdmath "math"
+	"sort"
+	"strconv"
+	"strings"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -28,6 +33,68 @@ func splitFace(f planarFace, imprints [][2]math.Point3) []subFace {
 		out = append(out, sf)
 	}
 	return out
+}
+
+// mergeFilledHoles dissolves the artificial split where one kept sub-face exactly FILLS a hole
+// of another kept sub-face of the same source face. Both are coincident, same-normal fragments
+// of one planar surface, so the hole boundary between them is not a real edge — leaving it in
+// makes the shared loop a third user of edges that also bound the neighbour solid's face,
+// producing a non-manifold seam at a partial penetration (#860, the blade footprint over a
+// bored wall). Removing the filled hole and dropping the filler merges them into the single
+// face the surface should be.
+func mergeFilledHoles(faces []subFace) []subFace {
+	drop := make([]bool, len(faces))
+	for i := range faces {
+		for h := 0; h < len(faces[i].holes); {
+			if j := fillerOf(faces, faces[i].holes[h], drop, i); j >= 0 {
+				drop[j] = true
+				faces[i].holes = append(faces[i].holes[:h], faces[i].holes[h+1:]...)
+				continue
+			}
+			h++
+		}
+	}
+	out := faces[:0]
+	for i := range faces {
+		if !drop[i] {
+			out = append(out, faces[i])
+		}
+	}
+	return out
+}
+
+// fillerOf returns the index of a not-yet-dropped face (other than self) whose outer loop is
+// the same ring as hole, or −1. A face filling a hole is identified by loop coincidence.
+func fillerOf(faces []subFace, hole []math.Point3, drop []bool, self int) int {
+	want := ringSignature(hole)
+	for j := range faces {
+		if j == self || drop[j] || len(faces[j].holes) > 0 {
+			continue
+		}
+		if ringSignature(faces[j].outer) == want {
+			return j
+		}
+	}
+	return -1
+}
+
+// ringSignature is an order/winding-independent key for a 3D loop: its vertices rounded to the
+// stitch weld grid and concatenated in sorted order, so the same ring compares equal however
+// it is traversed.
+func ringSignature(ring []math.Point3) string {
+	keys := make([]string, len(ring))
+	for i, p := range ring {
+		keys[i] = roundKey(p)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "|")
+}
+
+func roundKey(p math.Point3) string {
+	const grid = 1e-6
+	return strconv.FormatInt(int64(stdmath.Round(p.X/grid)), 36) + "," +
+		strconv.FormatInt(int64(stdmath.Round(p.Y/grid)), 36) + "," +
+		strconv.FormatInt(int64(stdmath.Round(p.Z/grid)), 36)
 }
 
 // faceBoundarySegments returns a face's loop edges as 2D segments in its plane.

--- a/kernel/brep/nopscad_dip_test.go
+++ b/kernel/brep/nopscad_dip_test.go
@@ -82,8 +82,6 @@ func TestNopDipCSG(t *testing.T) {
 //
 // Repro distilled from NopSCADlib dip()'s pin-1 index notch (circle d=3 at y=size.x/2).
 func TestBlindStraddleCurvedCutWatertight(t *testing.T) {
-	t.Skip("open spec: blind boundary-straddle cut — cross-face vertex disagreement leaves an unpaired sliver (not watertight)")
-
 	body := prismBodyAlongY(dipOctagon(), -dipHalfLen, dipHalfLen, "bar")
 	body = cutOrFatal(t, body, cylinderZAt(0, dipHalfLen, 0, 0.16, 0.15, "notch"), "index notch")
 	if open := ops.BoundaryEdges(body); len(open) != 0 {


### PR DESCRIPTION
## What & why

The planar B-rep boolean welded a **coincident non-manifold membrane** whenever a face's bottom is coplanar with another solid's bottom and an edge/wall crossed a **faceted curved wall** — the parametric-fan blade ∪ bored-hub defect (#860, the follow-up to the parked #470; the *hang* was already fixed in #858).

Reproduced at the kernel level, it was **four distinct failures** on the path from a clean cut to a clean partial-penetration union. Each is fixed in `kernel/brep`:

1. **`faceLineIntervals`** now captures an imprint running exactly *along* a tool facet's boundary edge. The even-odd midpoint test lands on the boundary and dropped one wall of a boundary-straddle cut non-deterministically (a float tie-break), leaving an open footprint. Collinear boundary-edge spans are added explicitly.
2. **Coplanar (ON/ON) imprint** clips the other face's outline to *this* face's material instead of injecting it whole. A bar whose footprint sits inside a bored face's hole was imprinting segments into the void, corrupting the 2D arrangement into spurious sub-faces.
3. **The 2D arrangement welds T-junctions**: an imprint chain that merely *ends on* a boundary edge (rather than crossing it) now splits that edge, so the chain closes and the face partitions.
4. **Kept sub-faces where one fills another's hole are merged.** Two coincident, same-normal fragments of one surface left the hole loop as a third user of edges that also bound the neighbour solid's face — the non-manifold seam.

No public API change — implementation only.

## Tests

- Unskips the kernel acceptance **`TestBlindStraddleCurvedCutWatertight`**.
- Adds **`TestBarThroughBoredWallUnion`** — a bar across a bored + hubbed wall, outer tip short of / exactly at / past the wall.
- `kernel/brep` + `kernel/ops` pass, including `-race`; full `kernel/… model/… app/… addin/…` sweep green; golangci-lint v2.1.0 clean.
- The bridge fan/blade acceptance tests (`TestFanBodyStaysManifold`, `TestBladeJoinBooleanIsTheDefect`) now pass against this branch — unskipped in a follow-up bridge PR.

Closes #860. Refs #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)