### PR TITLE
M20-F13: Simplify & Unwrap features (#490)

### DIFF
--- a/addin/opregistry/feature_modify.go
+++ b/addin/opregistry/feature_modify.go
@@ -301,3 +301,70 @@ func decodeFaceEdit(s *app.Session, raw json.RawMessage, op string) (*compdef.Pa
 	}
 	return part, in, nil
 }
+
+// --- simplify & unwrap (M20-F13) -------------------------------------------
+
+type simplifyArgs struct {
+	FaceRefs  []string `json:"faceRefs,omitempty"`
+	FillVoids bool     `json:"fillVoids,omitempty"`
+}
+
+const simplifySchema = `{
+  "type": "object",
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "description": "Reference keys of faces to remove and heal (from get_reference_keys)."},
+    "fillVoids": {"type": "boolean", "default": false, "description": "Also fill internal voids (cavities)."}
+  }
+}`
+
+func simplifyDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "simplify", Summary: "Reduce a model: remove and heal selected faces and/or fill internal voids.", Schema: json.RawMessage(simplifySchema), Apply: applySimplify}
+}
+
+func applySimplify(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in simplifyArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.FaceRefs) == 0 && !in.FillVoids {
+		return nil, errors.New("simplify: nothing to do (faceRefs empty and fillVoids off)")
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddSimplify(refKeys(in.FaceRefs), in.FillVoids)
+	return recomputeResult(part, pf)
+}
+
+type unwrapArgs struct {
+	FaceRef string `json:"faceRef"`
+}
+
+const unwrapSchema = `{
+  "type": "object",
+  "properties": {
+    "faceRef": {"type": "string", "description": "Reference key of the cylindrical face to flatten (from get_reference_keys)."}
+  },
+  "required": ["faceRef"]
+}`
+
+func unwrapDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "unwrap", Summary: "Flatten a cylindrical face into a flat sheet patch (circumference × height).", Schema: json.RawMessage(unwrapSchema), Apply: applyUnwrap}
+}
+
+func applyUnwrap(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in unwrapArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.FaceRef == "" {
+		return nil, errors.New("unwrap: faceRef is required")
+	}
+	pf := feature.NewModifyFeatures(part.Features()).AddUnwrap([]byte(in.FaceRef))
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -122,6 +122,8 @@ func Default() *Registry {
 		moveFaceDescriptor(),
 		faceOffsetDescriptor(),
 		deleteFaceDescriptor(),
+		simplifyDescriptor(),
+		unwrapDescriptor(),
 		splitFaceDescriptor(),
 		replaceFaceDescriptor(),
 		moveBodyDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/router/simplify_unwrap_test.go
+++ b/addin/router/simplify_unwrap_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSimplifyFillVoidsOverWire runs simplify(fillVoids) on a box (a no-op fill that must keep
+// a valid solid) and rejects an empty request (M20-F13 #490).
+func TestSimplifyFillVoidsOverWire(t *testing.T) {
+	r, s, _ := filletBoxFixture(t)
+	call(t, r, s, "features.add", `{"kind":"simplify","args":{"fillVoids":true}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("simplified body invalid: %+v", v.Problems)
+	}
+	if _, err := r.Handle(s, "features.add", []byte(`{"kind":"simplify","args":{}}`)); err == nil {
+		t.Error("expected an error for an empty simplify (no faces, no fillVoids)")
+	}
+}
+
+// TestUnwrapOverWire extrudes a cylinder, unwraps its side face, and checks a second (sheet)
+// body appears — the flattened patch (M20-F13 #490).
+func TestUnwrapOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0]],"radius":"20 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"30 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	var side string
+	for _, f := range keys.Bodies[0].Faces {
+		if len(f.Point) == 3 && f.Point[2] > 0.1 && f.Point[2] < 2.9 { // mid-height ⇒ the cylindrical side
+			side = f.Key
+		}
+	}
+	if side == "" {
+		t.Fatal("no cylindrical side face found")
+	}
+	call(t, r, s, "features.add", mustJSON(t, map[string]any{"kind": "unwrap", "args": map[string]any{"faceRef": side}}), &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	if n := modelTreeOf(t, r, s).Bodies; n != 2 {
+		t.Errorf("after unwrap body count = %d, want 2 (cylinder + flat patch)", n)
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -31,6 +31,8 @@ type FeatureData struct {
 	Shell      *FaceDressData  `yaml:"shell,omitempty"`
 	Draft      *FaceDressData  `yaml:"draft,omitempty"`
 	Lip        *LipData        `yaml:"lip,omitempty"`
+	Simplify   *SimplifyData   `yaml:"simplify,omitempty"`
+	Unwrap     *UnwrapData     `yaml:"unwrap,omitempty"`
 	Thread     *ThreadData     `yaml:"thread,omitempty"`
 	Hole       *HoleData       `yaml:"hole,omitempty"`
 	Boss       *BossData       `yaml:"boss,omitempty"`
@@ -128,6 +130,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle), Pull: []float64{p.X, p.Y, p.Z}}
 	case *LipFeature:
 		fd.Lip = &LipData{Edges: encodeKeys(f.def.EdgeKeys), Width: evalFloat(f.def.Width), Height: evalFloat(f.def.Height), Groove: f.def.Groove}
+	case *SimplifyFeature:
+		fd.Simplify = &SimplifyData{RemoveFaces: encodeKeys(f.def.RemoveFaceKeys), FillVoids: f.def.FillVoids}
+	case *UnwrapFeature:
+		fd.Unwrap = &UnwrapData{Face: encodeKey(f.def.FaceKey)}
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut,
 			Class: f.def.Class, Tapered: f.def.Tapered, ModelDiameter: threadModelDiameterName(f.def.ModelDiameter)}
@@ -333,6 +339,10 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		}
 	case "lip":
 		return restoreLip(fs, fd.Lip)
+	case "simplify":
+		return restoreSimplify(fs, fd.Simplify)
+	case "unwrap":
+		return restoreUnwrap(fs, fd.Unwrap)
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_simplify.go
+++ b/model/feature/serialize_simplify.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SimplifyData is the serialized form of a SimplifyFeature (M20-F13): the faces removed and
+// whether internal voids were filled.
+type SimplifyData struct {
+	RemoveFaces []string `yaml:"removeFaces,omitempty"`
+	FillVoids   bool     `yaml:"fillVoids,omitempty"`
+}
+
+// UnwrapData is the serialized form of an UnwrapFeature: the cylindrical face flattened.
+type UnwrapData struct {
+	Face string `yaml:"face"`
+}
+
+// restoreSimplify rebuilds a SimplifyFeature.
+func restoreSimplify(fs *PartFeatures, d *SimplifyData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("simplify feature is missing its payload")
+	}
+	keys, err := decodeKeys(d.RemoveFaces)
+	if err != nil {
+		return nil, err
+	}
+	return NewModifyFeatures(fs).AddSimplify(keys, d.FillVoids), nil
+}
+
+// restoreUnwrap rebuilds an UnwrapFeature.
+func restoreUnwrap(fs *PartFeatures, d *UnwrapData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("unwrap feature is missing its payload")
+	}
+	key, err := decodeKey(d.Face)
+	if err != nil {
+		return nil, err
+	}
+	return NewModifyFeatures(fs).AddUnwrap(key), nil
+}

--- a/model/feature/simplify.go
+++ b/model/feature/simplify.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// Simplify is a model-reduction feature (M20-F13): it removes a selected set of faces (healing
+// the openings, like Delete Face) and/or fills internal voids, producing a lighter body for
+// downstream use (display, drawings, analysis). It bundles the two reductions into one history
+// step distinct from the single Delete Face edit.
+
+// SimplifyDefinition is the reduction recipe: faces to remove and whether to fill voids.
+type SimplifyDefinition struct {
+	RemoveFaceKeys [][]byte
+	FillVoids      bool
+}
+
+// SimplifyFeature reduces the running body.
+type SimplifyFeature struct{ def *SimplifyDefinition }
+
+// Definition returns the simplify recipe.
+func (s *SimplifyFeature) Definition() *SimplifyDefinition { return s.def }
+
+// Kind implements [Feature].
+func (s *SimplifyFeature) Kind() string { return "simplify" }
+
+// Recompute removes the selected faces (healing the openings) then fills internal voids.
+func (s *SimplifyFeature) Recompute(in Input) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	if len(s.def.RemoveFaceKeys) == 0 && !s.def.FillVoids {
+		return Output{}, fmt.Errorf("simplify: nothing to do (no faces to remove and fillVoids off)")
+	}
+	result := body
+	if len(s.def.RemoveFaceKeys) > 0 {
+		if result, err = ops.DeleteFaces(result, s.def.RemoveFaceKeys); err != nil {
+			return Output{}, fmt.Errorf("simplify: %w", err)
+		}
+	}
+	if s.def.FillVoids {
+		result = ops.FillInternalVoids(result, ops.DefaultQuality())
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// AddSimplify reduces the running body by removing faceKeys (healing) and optionally filling
+// internal voids.
+func (c *ModifyFeatures) AddSimplify(faceKeys [][]byte, fillVoids bool) *PartFeature {
+	return c.engine.Add(&SimplifyFeature{def: &SimplifyDefinition{RemoveFaceKeys: faceKeys, FillVoids: fillVoids}})
+}

--- a/model/feature/simplify_unwrap_test.go
+++ b/model/feature/simplify_unwrap_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// axisAligned reports whether a normal points (nearly) along ±X/±Y/±Z.
+func axisAligned(n math.Vector3) bool {
+	return stdmath.Abs(n.X) > 0.99 || stdmath.Abs(n.Y) > 0.99 || stdmath.Abs(n.Z) > 0.99
+}
+
+// TestSimplifyRemovesChamferLighter chamfers a box edge then simplifies away the chamfer face,
+// healing back to a sharp box with fewer faces — a validated lighter body (M20-F13 #490).
+func TestSimplifyRemovesChamferLighter(t *testing.T) {
+	box, edge := box2(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	NewDressUpFeatures(fs).AddChamfer([][]byte{edge}, func() float64 { return 0.5 })
+	fs.Recompute()
+	chamfered := fs.Result()[0]
+	before := len(chamfered.Faces())
+	var chamferFace []byte
+	for _, f := range chamfered.Faces() {
+		if !axisAligned(f.Geometry().NormalAt(0, 0)) {
+			chamferFace = f.ReferenceKey()
+			break
+		}
+	}
+	if chamferFace == nil {
+		t.Fatal("no chamfer (non-axis) face found")
+	}
+
+	simp := NewModifyFeatures(fs).AddSimplify([][]byte{chamferFace}, false)
+	fs.Recompute()
+	if !simp.Health().OK() {
+		t.Fatalf("simplify sick: %+v", simp.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("simplified body not a valid solid: %+v", r)
+	}
+	if got := len(res.Faces()); got >= before {
+		t.Errorf("simplified face count = %d, want < %d (lighter)", got, before)
+	}
+}
+
+// TestUnwrapFlattensCylinder unwraps a cylinder's side face into a flat sheet of circumference
+// × height (M20-F13 #490).
+func TestUnwrapFlattensCylinder(t *testing.T) {
+	const r, h = 5.0, 10.0
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), r)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return h })
+	fs.Recompute()
+	var cylFace []byte
+	for _, f := range fs.Result()[0].Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cylFace = f.ReferenceKey()
+			break
+		}
+	}
+	if cylFace == nil {
+		t.Fatal("no cylinder face on the extruded circle")
+	}
+
+	uw := NewModifyFeatures(fs).AddUnwrap(cylFace)
+	fs.Recompute()
+	if !uw.Health().OK() {
+		t.Fatalf("unwrap sick: %+v", uw.Health())
+	}
+	bodies := fs.Result()
+	if len(bodies) != 2 {
+		t.Fatalf("unwrap result = %d bodies, want 2 (cylinder + flat patch)", len(bodies))
+	}
+	patch := bodies[1]
+	if patch.IsSolid() {
+		t.Error("unwrapped patch is solid, want an open sheet")
+	}
+	box := patch.RangeBox()
+	if w := box.Max.X - box.Min.X; stdmath.Abs(w-2*stdmath.Pi*r) > 1e-3 {
+		t.Errorf("patch width = %g, want circumference 2πr = %g", w, 2*stdmath.Pi*r)
+	}
+	if ht := box.Max.Y - box.Min.Y; stdmath.Abs(ht-h) > 1e-3 {
+		t.Errorf("patch height = %g, want %g", ht, h)
+	}
+}
+
+// TestSimplifyUnwrapRoundTrip checks both features survive an .obk round trip.
+func TestSimplifyUnwrapRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 1 })
+	NewModifyFeatures(fs).AddSimplify([][]byte{[]byte("f0")}, true)
+	NewModifyFeatures(fs).AddUnwrap([]byte("f1"))
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	sd := fresh.Item(1).Definition().(*SimplifyFeature).Definition()
+	if len(sd.RemoveFaceKeys) != 1 || !sd.FillVoids {
+		t.Errorf("restored simplify = %d faces, fillVoids %v; want 1, true", len(sd.RemoveFaceKeys), sd.FillVoids)
+	}
+	ud := fresh.Item(2).Definition().(*UnwrapFeature).Definition()
+	if string(ud.FaceKey) != "f1" {
+		t.Errorf("restored unwrap face = %q, want f1", ud.FaceKey)
+	}
+}

--- a/model/feature/unwrap.go
+++ b/model/feature/unwrap.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Unwrap is a model feature (M20-F13): it flattens a cylindrical face into a planar patch — the
+// developable surface unrolled to a flat rectangle (arc length × axial height). The flattened
+// patch is appended as a sheet body (an open surface), leaving the source solid in place; it
+// lands in the part's WorkSurfaces collection.
+
+// UnwrapDefinition names the cylindrical face to flatten.
+type UnwrapDefinition struct {
+	FaceKey []byte
+}
+
+// UnwrapFeature appends the flattened patch of its cylindrical face.
+type UnwrapFeature struct {
+	def      *UnwrapDefinition
+	featName string
+}
+
+// Definition returns the unwrap recipe.
+func (u *UnwrapFeature) Definition() *UnwrapDefinition { return u.def }
+
+// Kind implements [Feature].
+func (u *UnwrapFeature) Kind() string { return "unwrap" }
+
+// Recompute flattens the named cylindrical face and appends the flat sheet to the result.
+func (u *UnwrapFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "unwrap")
+	if err != nil {
+		return Output{}, err
+	}
+	face, ok := body.FindFaceByKey(u.def.FaceKey)
+	if !ok {
+		return Output{}, fmt.Errorf("unwrap: face reference lost")
+	}
+	patch, err := unwrapCylindricalFace(face, featOr(u.featName, "unwrap"))
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: append(append([]*topo.Body(nil), in.Bodies...), patch)}, nil
+}
+
+// unwrapCylindricalFace unrolls a cylindrical face into a flat rectangle sheet of arc-length ×
+// axial-height, where arc length = radius × the face's angular span (a full/periodic face
+// unrolls the whole circumference).
+func unwrapCylindricalFace(face *topo.Face, feat string) (*topo.Body, error) {
+	cyl, ok := face.Geometry().(geom.Cylinder)
+	if !ok {
+		return nil, fmt.Errorf("unwrap: face is %T, want a cylinder", face.Geometry())
+	}
+	height, span := cylindricalFaceExtent(cyl, face.Vertices())
+	if height <= 1e-9 {
+		return nil, fmt.Errorf("unwrap: degenerate axial height %g", height)
+	}
+	arc := cyl.Radius * span
+	return flatSheet(arc, height, feat), nil
+}
+
+// cylindricalFaceExtent returns the face's axial height and angular span (radians) from its
+// vertices. A periodic/full face (vertices clustered at a seam, or spanning the full turn)
+// unrolls the whole circumference (2π).
+func cylindricalFaceExtent(cyl geom.Cylinder, verts []*topo.Vertex) (height, span float64) {
+	axis := cyl.AxisDir.AsVector()
+	ref := cyl.Ref.AsVector()
+	bi := axis.Cross(ref)
+	loAx, hiAx := stdmath.Inf(1), stdmath.Inf(-1)
+	loAng, hiAng := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range verts {
+		d := cyl.Origin.VectorTo(v.Point())
+		ax := d.Dot(axis)
+		radial := d.Sub(axis.Scale(ax))
+		ang := stdmath.Atan2(radial.Dot(bi), radial.Dot(ref))
+		loAx, hiAx = stdmath.Min(loAx, ax), stdmath.Max(hiAx, ax)
+		loAng, hiAng = stdmath.Min(loAng, ang), stdmath.Max(hiAng, ang)
+	}
+	angSpan := hiAng - loAng
+	if angSpan < 0.5 || angSpan > 2*stdmath.Pi-0.5 { // seam-only or near-full ⇒ a periodic full turn
+		angSpan = 2 * stdmath.Pi
+	}
+	return hiAx - loAx, angSpan
+}
+
+// flatSheet builds a flat [0,w]×[0,h] rectangle as an open (sheet) surface body on the XY plane.
+func flatSheet(w, h float64, feat string) *topo.Body {
+	lin := topo.NewLineage(topo.Tok(feat, "patch", 0))
+	bld := topo.NewBuilder(false, lin) // false ⇒ an open surface body
+	corners := []math.Point3{math.P3(0, 0, 0), math.P3(w, 0, 0), math.P3(w, h, 0), math.P3(0, h, 0)}
+	vs := make([]*topo.Vertex, 4)
+	for i, c := range corners {
+		vs[i] = bld.AddVertex(c, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := range corners {
+		e := bld.AddEdge(geom.NewLineSegment(corners[i], corners[(i+1)%4]), vs[i], vs[(i+1)%4], lin)
+		uses[i] = topo.Use{Edge: e}
+	}
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, lin, topo.OuterLoop(uses...))
+	return bld.Build()
+}
+
+// AddUnwrap appends the flattened patch of the cylindrical face referenced by faceKey.
+func (c *ModifyFeatures) AddUnwrap(faceKey []byte) *PartFeature {
+	uf := &UnwrapFeature{def: &UnwrapDefinition{FaceKey: faceKey}}
+	pf := c.engine.Add(uf)
+	pf.SetName(c.engine.UniqueName("Unwrap"))
+	uf.featName = pf.name
+	return pf
+}


### PR DESCRIPTION
Part of #490 (Direct-Edit & Simplify). Adds the two missing model-reduction features. **DirectEdit** (move/size/rotate/delete/scale) already exists, satisfying the rest of F13's acceptance.

## Status of #490's scope
- **DirectEdit** — already shipped ✓ (a move dispatches to the F04 move-face op)
- **Simplify** — **this PR** ✓
- **Unwrap** — **this PR** ✓
- **ModelTolerance** (GD&T metadata carrier) — follow-up (not in acceptance)

**Acceptance met:** direct-edit move → F04 op (existing), simplify removes a face set producing a validated lighter body, unwrap flattens a cylindrical face, round-trip.

## Simplify
Remove a selected face set (healing the openings, like Delete Face) and/or fill internal voids → a lighter validated body, bundled into one history step (`ops.DeleteFaces` + `ops.FillInternalVoids`).

## Unwrap
Flatten a cylindrical face into a flat sheet patch (circumference × axial height), appended as an open surface body (lands in WorkSurfaces). A periodic/full face unrolls the whole circumference.

Plumbing: `AddSimplify` / `AddUnwrap` on `ModifyFeatures`; `.obk` round-trip; opregistry `simplify` / `unwrap` kinds.

## Verification
- **model**: simplify removes a chamfer face → fewer faces, valid solid; unwrap → sheet of width 2πr × height h; `.obk` round-trip.
- **router (wire path)**: simplify(fillVoids) keeps a valid solid + rejects empty; unwrap of a cylinder side face adds the flat patch body.
- **live-confirmed**: cylinder + flat unrolled patch; chamfer healed back to a plain box.
- `go build`, `go test`, `go vet`, `golangci-lint` (0 issues) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)