### PR TITLE
Convert presentation meshes to faceted B-rep solids (M20-F15 #492)

### DIFF
--- a/addin/opregistry/feature_mesh.go
+++ b/addin/opregistry/feature_mesh.go
@@ -17,13 +17,15 @@ import (
 // documents.import, which converts a mesh file into B-rep bodies.
 
 type meshArgs struct {
-	Path string `json:"path"`
+	Path  string `json:"path"`
+	Solid bool   `json:"solid"`
 }
 
 const meshSchema = `{
   "type": "object",
   "properties": {
-    "path": {"type": "string", "description": "Host-local path of an ASCII STL file to place as mesh reference geometry."}
+    "path": {"type": "string", "description": "Host-local path of an ASCII STL file to place as mesh reference geometry."},
+    "solid": {"type": "boolean", "description": "When true, convert the mesh to a faceted B-rep solid body (one planar face per facet) instead of placing it as reference geometry."}
   },
   "required": ["path"]
 }`
@@ -50,6 +52,16 @@ func applyMesh(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mesh: parse %q: %w", in.Path, err)
 	}
-	pf := feature.NewMeshFeatures(part.Features()).Add(g)
-	return recomputeResult(part, pf)
+	return recomputeResult(part, addMeshFeature(part.Features(), g, in.Solid))
+}
+
+// addMeshFeature places the mesh as a single feature: a faceted B-rep solid when solid is set
+// (#492), otherwise a presentation mesh (reference geometry that passes the running solid
+// through). The two modes are mutually exclusive.
+func addMeshFeature(fs *feature.PartFeatures, g *feature.MeshGeometry, solid bool) *feature.PartFeature {
+	meshes := feature.NewMeshFeatures(fs)
+	if solid {
+		return meshes.AddSolid(g)
+	}
+	return meshes.Add(g)
 }

--- a/addin/router/mesh_test.go
+++ b/addin/router/mesh_test.go
@@ -60,6 +60,30 @@ func TestMeshFeatureOverWire(t *testing.T) {
 	}
 }
 
+// TestMeshSolidOverWire imports the same STL with solid:true and confirms the mesh is
+// converted to a validated solid body (M20-F15 #492).
+func TestMeshSolidOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := filepath.Join(t.TempDir(), "tetra.stl")
+	if err := os.WriteFile(path, []byte(routerTetraSTL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", fmt.Sprintf(`{"kind":"mesh","args":{"path":%q,"solid":true}}`, path), &res)
+	if res.Bodies != 1 {
+		t.Fatalf("mesh-solid body count = %d, want 1 (converted solid)", res.Bodies)
+	}
+	var v struct {
+		Valid bool `json:"valid"`
+	}
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatal("converted mesh-solid body is not valid")
+	}
+}
+
 func TestMeshFeatureOverWireRejectsMissingFile(t *testing.T) {
 	r, s := emptyPartSession(t)
 	if _, err := r.Handle(s, "features.add", []byte(`{"kind":"mesh","args":{"path":"/nonexistent/x.stl"}}`)); err == nil {

--- a/kernel/ops/mesh_brep.go
+++ b/kernel/ops/mesh_brep.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// MeshToBRep converts a closed welded mesh — shared vertices and facets given as ordered
+// vertex-index loops (each typically a triangle) — into a faceted B-rep solid: one planar face
+// per facet, with shared edges and vertices. Facets with more than three vertices are
+// fan-triangulated. The cage is re-oriented to positive volume so an inward-wound (but
+// consistent) input still yields an outward solid. Returns nil for an empty mesh.
+//
+// Example: tetra := MeshToBRep(verts, [][]int{{0,1,2},{0,2,3},{0,3,1},{1,3,2}}, "mesh") — a
+// validated 4-face solid.
+func MeshToBRep(verts []math.Point3, facets [][]int, feat string) *topo.Body {
+	tris := facetTriangles(verts, facets)
+	if len(tris) == 0 {
+		return nil
+	}
+	body := trianglesToBody(tris, feat)
+	if body == nil {
+		return nil
+	}
+	// cageToBody trusts the facet winding for face normals; if the mesh was wound inward
+	// (negative volume) flip every facet so the result is a proper outward solid.
+	if BodyGeometryProperties(body, DefaultQuality()).Volume < 0 {
+		body = trianglesToBody(reversedTris(tris), feat)
+	}
+	return body
+}
+
+// facetTriangles fan-triangulates each facet loop into CSG triangles, dropping degenerate ones
+// and any facet whose indices are out of range.
+func facetTriangles(verts []math.Point3, facets [][]int) []tri {
+	var tris []tri
+	for _, f := range facets {
+		if len(f) < 3 || !facetInRange(f, len(verts)) {
+			continue
+		}
+		for i := 1; i+1 < len(f); i++ {
+			if t, ok := newTri(verts[f[0]], verts[f[i]], verts[f[i+1]]); ok {
+				tris = append(tris, t)
+			}
+		}
+	}
+	return tris
+}
+
+func facetInRange(f []int, n int) bool {
+	for _, idx := range f {
+		if idx < 0 || idx >= n {
+			return false
+		}
+	}
+	return true
+}
+
+// reversedTris flips each triangle's winding (swapping two corners).
+func reversedTris(tris []tri) []tri {
+	out := make([]tri, 0, len(tris))
+	for _, t := range tris {
+		if rt, ok := newTri(t.a, t.c, t.b); ok {
+			out = append(out, rt)
+		}
+	}
+	return out
+}

--- a/kernel/ops/mesh_brep_test.go
+++ b/kernel/ops/mesh_brep_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// unitTetraMesh returns the four corner vertices of a unit tetrahedron and outward-wound
+// triangular facets (acceptance fixture for #492).
+func unitTetraMesh() ([]math.Point3, [][]int) {
+	verts := []math.Point3{
+		math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(0, 0, 1),
+	}
+	facets := [][]int{{0, 2, 1}, {0, 1, 3}, {0, 3, 2}, {1, 2, 3}}
+	return verts, facets
+}
+
+// TestMeshToBRepTetraSolid is the #492 acceptance: a tetra mesh converts to a validated
+// 4-face solid with the analytic volume 1/6.
+func TestMeshToBRepTetraSolid(t *testing.T) {
+	verts, facets := unitTetraMesh()
+	body := MeshToBRep(verts, facets, "mesh")
+	if body == nil {
+		t.Fatal("MeshToBRep returned nil for a tetra mesh")
+	}
+	if r := Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("tetra B-rep not a valid solid: valid=%v solid=%v problems=%v", r.Valid, body.IsSolid(), r.Issues)
+	}
+	if n := len(body.Faces()); n != 4 {
+		t.Errorf("face count = %d, want 4", n)
+	}
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; stdmath.Abs(v-1.0/6) > 1e-9 {
+		t.Errorf("volume = %v, want %v", v, 1.0/6)
+	}
+}
+
+// TestMeshToBRepReorientsInwardMesh: an inward-wound (negative-volume) but consistent mesh
+// is re-oriented to a positive-volume outward solid rather than rejected.
+func TestMeshToBRepReorientsInwardMesh(t *testing.T) {
+	verts, facets := unitTetraMesh()
+	for _, f := range facets { // flip every facet ⇒ inward winding
+		f[1], f[2] = f[2], f[1]
+	}
+	body := MeshToBRep(verts, facets, "mesh")
+	if body == nil {
+		t.Fatal("MeshToBRep returned nil for an inward-wound tetra")
+	}
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; v <= 0 {
+		t.Errorf("volume = %v, want positive after re-orientation", v)
+	}
+}
+
+// TestMeshToBRepEmpty: no facets ⇒ nil (nothing to build).
+func TestMeshToBRepEmpty(t *testing.T) {
+	if b := MeshToBRep(nil, nil, "mesh"); b != nil {
+		t.Errorf("MeshToBRep(empty) = %v, want nil", b)
+	}
+}
+
+// TestMeshToBRepQuadFacet: a quad facet fan-triangulates; a unit cube (6 quad facets)
+// becomes a valid solid of volume 1.
+func TestMeshToBRepQuadFacet(t *testing.T) {
+	verts := []math.Point3{
+		math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0),
+		math.P3(0, 0, 1), math.P3(1, 0, 1), math.P3(1, 1, 1), math.P3(0, 1, 1),
+	}
+	facets := [][]int{
+		{0, 3, 2, 1}, {4, 5, 6, 7}, {0, 1, 5, 4}, {2, 3, 7, 6}, {1, 2, 6, 5}, {0, 4, 7, 3},
+	}
+	body := MeshToBRep(verts, facets, "mesh")
+	if body == nil {
+		t.Fatal("MeshToBRep returned nil for a cube mesh")
+	}
+	if r := Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("cube B-rep not a valid solid: %v", r.Issues)
+	}
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; stdmath.Abs(v-1.0) > 1e-9 {
+		t.Errorf("volume = %v, want 1", v)
+	}
+}

--- a/model/feature/mesh_solid.go
+++ b/model/feature/mesh_solid.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// MeshSolid (M20-F15 #492) converts an imported presentation mesh into a faceted B-rep solid:
+// one planar face per facet, with shared edges/vertices. Distinct from MeshFeature, which keeps
+// the mesh as reference geometry; this feature produces a real solid body usable downstream.
+
+// MeshSolidFeature converts its mesh to a B-rep solid appended as a new body.
+type MeshSolidFeature struct {
+	geom     *MeshGeometry
+	featName string
+}
+
+// Geometry returns the source mesh.
+func (m *MeshSolidFeature) Geometry() *MeshGeometry { return m.geom }
+
+// Kind implements [Feature].
+func (m *MeshSolidFeature) Kind() string { return "mesh-solid" }
+
+// Recompute converts the mesh to a faceted solid and appends it to the running bodies.
+func (m *MeshSolidFeature) Recompute(in Input) (Output, error) {
+	body := ops.MeshToBRep(m.geom.Vertices, m.geom.Facets, featOr(m.featName, "mesh-solid"))
+	if body == nil {
+		return Output{}, fmt.Errorf("mesh-solid: mesh has no facets (%d verts, %d facets)", len(m.geom.Vertices), len(m.geom.Facets))
+	}
+	return Output{Bodies: append(append([]*topo.Body(nil), in.Bodies...), body)}, nil
+}
+
+// AddSolid converts mesh geometry to a B-rep solid feature.
+func (c *MeshFeatures) AddSolid(g *MeshGeometry) *PartFeature {
+	mf := &MeshSolidFeature{geom: g, featName: "MeshSolid"}
+	pf := c.engine.Add(mf)
+	pf.SetName(c.engine.UniqueName("MeshSolid"))
+	mf.featName = pf.name
+	return pf
+}

--- a/model/feature/mesh_solid_test.go
+++ b/model/feature/mesh_solid_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// tetraMeshGeometry is a unit tetrahedron with outward-wound triangular facets.
+func tetraMeshGeometry() *MeshGeometry {
+	return &MeshGeometry{
+		Vertices: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(0, 0, 1)},
+		Facets:   [][]int{{0, 2, 1}, {0, 1, 3}, {0, 3, 2}, {1, 2, 3}},
+	}
+}
+
+// TestMeshSolidConvertsTetra is the #492 acceptance: a tetra mesh converts to a validated
+// 4-face solid body.
+func TestMeshSolidConvertsTetra(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ms := NewMeshFeatures(fs).AddSolid(tetraMeshGeometry())
+	fs.Recompute()
+	if !ms.Health().OK() {
+		t.Fatalf("mesh-solid sick: %+v", ms.Health())
+	}
+	bodies := fs.Result()
+	if len(bodies) != 1 {
+		t.Fatalf("mesh-solid result = %d bodies, want 1", len(bodies))
+	}
+	solid := bodies[0]
+	if r := ops.Validate(solid); !r.Valid || !solid.IsSolid() {
+		t.Fatalf("converted body not a valid solid: %+v", r)
+	}
+	if n := len(solid.Faces()); n != 4 {
+		t.Errorf("face count = %d, want 4", n)
+	}
+	if v := ops.BodyGeometryProperties(solid, ops.DefaultQuality()).Volume; stdmath.Abs(v-1.0/6) > 1e-9 {
+		t.Errorf("volume = %v, want %v", v, 1.0/6)
+	}
+}
+
+// TestPresentationMeshPassesBodyThrough: the presentation MeshFeature carries the mesh without
+// altering the running body (#492 acceptance bullet 2).
+func TestPresentationMeshPassesBodyThrough(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), 5)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 10 })
+	fs.Recompute()
+	before := fs.Result()[0]
+
+	mf := NewMeshFeatures(fs).Add(tetraMeshGeometry())
+	fs.Recompute()
+	if !mf.Health().OK() {
+		t.Fatalf("presentation mesh sick: %+v", mf.Health())
+	}
+	after := fs.Result()
+	if len(after) != 1 || after[0] != before {
+		t.Errorf("presentation mesh altered the running body: %d bodies (want 1, same pointer)", len(after))
+	}
+	if mf.Definition().(*MeshFeature).Geometry().Facets == nil {
+		t.Error("presentation mesh dropped its geometry")
+	}
+}
+
+// TestMeshSolidRoundTrip checks the mesh-solid feature (with its inline mesh) survives an
+// .obk round trip and rebuilds the same solid (#492 acceptance: round-trip).
+func TestMeshSolidRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewMeshFeatures(fs).AddSolid(tetraMeshGeometry())
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	g := fresh.Item(0).Definition().(*MeshSolidFeature).Geometry()
+	if len(g.Vertices) != 4 || len(g.Facets) != 4 {
+		t.Fatalf("restored mesh = %d verts, %d facets; want 4, 4", len(g.Vertices), len(g.Facets))
+	}
+	fresh.Recompute()
+	solid := fresh.Result()[0]
+	if r := ops.Validate(solid); !r.Valid || !solid.IsSolid() {
+		t.Fatalf("restored body not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(solid, ops.DefaultQuality()).Volume; stdmath.Abs(v-1.0/6) > 1e-9 {
+		t.Errorf("restored volume = %v, want %v", v, 1.0/6)
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -33,6 +33,7 @@ type FeatureData struct {
 	Lip        *LipData        `yaml:"lip,omitempty"`
 	Simplify   *SimplifyData   `yaml:"simplify,omitempty"`
 	Unwrap     *UnwrapData     `yaml:"unwrap,omitempty"`
+	MeshSolid  *MeshSolidData  `yaml:"meshSolid,omitempty"`
 	Thread     *ThreadData     `yaml:"thread,omitempty"`
 	Hole       *HoleData       `yaml:"hole,omitempty"`
 	Boss       *BossData       `yaml:"boss,omitempty"`
@@ -134,6 +135,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Simplify = &SimplifyData{RemoveFaces: encodeKeys(f.def.RemoveFaceKeys), FillVoids: f.def.FillVoids}
 	case *UnwrapFeature:
 		fd.Unwrap = &UnwrapData{Face: encodeKey(f.def.FaceKey)}
+	case *MeshSolidFeature:
+		fd.MeshSolid = serializeMeshSolid(f.geom)
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut,
 			Class: f.def.Class, Tapered: f.def.Tapered, ModelDiameter: threadModelDiameterName(f.def.ModelDiameter)}
@@ -343,6 +346,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSimplify(fs, fd.Simplify)
 	case "unwrap":
 		return restoreUnwrap(fs, fd.Unwrap)
+	case "mesh-solid":
+		return restoreMeshSolid(fs, fd.MeshSolid)
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_mesh_solid.go
+++ b/model/feature/serialize_mesh_solid.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// MeshSolidData is the serialized form of a MeshSolidFeature (M20-F15 #492): the source mesh
+// stored inline as welded vertices plus facet index loops, so the conversion round-trips
+// without depending on the original import file.
+type MeshSolidData struct {
+	Vertices [][]float64 `yaml:"vertices"`
+	Facets   [][]int     `yaml:"facets"`
+}
+
+// serializeMeshSolid captures the source mesh inline.
+func serializeMeshSolid(g *MeshGeometry) *MeshSolidData {
+	return &MeshSolidData{Vertices: encodePoints(g.Vertices), Facets: copyFacets(g.Facets)}
+}
+
+// restoreMeshSolid rebuilds a MeshSolidFeature from its inline mesh.
+func restoreMeshSolid(fs *PartFeatures, d *MeshSolidData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("mesh-solid feature is missing its payload")
+	}
+	g := &MeshGeometry{Vertices: decodePoints(d.Vertices), Facets: copyFacets(d.Facets)}
+	return NewMeshFeatures(fs).AddSolid(g), nil
+}
+
+// copyFacets deep-copies facet index loops so the serialized and live forms never alias.
+func copyFacets(facets [][]int) [][]int {
+	out := make([][]int, len(facets))
+	for i, f := range facets {
+		out[i] = append([]int(nil), f...)
+	}
+	return out
+}


### PR DESCRIPTION
## What

Implements **M20-F15 / #492**: turn an imported presentation mesh into a real B-rep solid.

- **`ops.MeshToBRep`** (kernel) — builds a faceted solid from a closed welded mesh: one planar face per facet, shared edges/vertices, fan-triangulating non-triangular facets and re-orienting to positive volume so a consistently inward-wound mesh still yields an outward solid.
- **`MeshSolidFeature`** (model) — converts a `MeshGeometry` to a solid body and appends it; round-trips its source mesh **inline** in the `.obk` recipe, so the conversion survives a save/open independent of the original import file. `MeshFeature` stays the pass-through *presentation* mesh (reference geometry).
- **`mesh` operation** gains a `solid` flag selecting conversion over reference placement (mutually exclusive).

## Why

A presentation mesh was reference-only — selectable but inert. Converting it to a B-rep makes the geometry usable by the rest of the kernel: validation, mass properties, boolean input, export.

## Acceptance (#492)

- ✅ A tetra mesh converts to a **validated 4-face solid** (`ops`/model/wire tests; volume = 1/6).
- ✅ The presentation mesh **carries its geometry without altering the running body** (pointer-identity test).
- ✅ The mesh-solid feature **survives an `.obk` round trip** (inline mesh re-builds the same solid).

## Validation

- `go build/vet ./...`, `go test ./kernel/ops ./model/feature ./addin/...` green.
- `golangci-lint` clean; SPDX headers present.
- **Live-confirmed**: rendered an octahedron mesh converted to a solid — clean facets, sharp edges, correct shading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)