### PR TITLE
Add ModelTolerance GD&T carrier feature (M20-F13 #866)

### DIFF
--- a/addin/opregistry/feature_tolerance.go
+++ b/addin/opregistry/feature_tolerance.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Model GD&T tolerance carrier (M20-F13 #866): a metadata feature that annotates model
+// geometry with feature-control frames and datum labels. It changes no geometry — it carries
+// records that survive recompute and the .obk round trip.
+
+type toleranceFrameArgs struct {
+	Geometry       string   `json:"geometry"`
+	Characteristic string   `json:"characteristic"`
+	Value          string   `json:"value"`
+	Datums         []string `json:"datums"`
+}
+
+type datumLabelArgs struct {
+	Geometry string `json:"geometry"`
+	Label    string `json:"label"`
+}
+
+type modelToleranceArgs struct {
+	Frames []toleranceFrameArgs `json:"frames"`
+	Datums []datumLabelArgs     `json:"datums"`
+}
+
+const modelToleranceSchema = `{
+  "type": "object",
+  "properties": {
+    "frames": {
+      "type": "array",
+      "description": "Feature-control frames annotating model geometry.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "geometry": {"type": "string", "description": "Reference key of the face/edge the frame applies to (from get_reference_keys)."},
+          "characteristic": {"type": "string", "description": "Geometric characteristic symbol, e.g. flatness, position, perpendicularity, circularRunout."},
+          "value": {"type": "string", "description": "Tolerance zone size, e.g. \"0.05 mm\"."},
+          "datums": {"type": "array", "items": {"type": "string"}, "description": "Referenced datum labels, e.g. [\"A\",\"B\"]."}
+        },
+        "required": ["geometry", "characteristic", "value"]
+      }
+    },
+    "datums": {
+      "type": "array",
+      "description": "Datum features: model geometry tagged with a datum label.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "geometry": {"type": "string", "description": "Reference key of the datum face/edge (from get_reference_keys)."},
+          "label": {"type": "string", "description": "Datum label, e.g. \"A\"."}
+        },
+        "required": ["geometry", "label"]
+      }
+    }
+  }
+}`
+
+func modelToleranceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "modelTolerance", Summary: "Annotate model geometry with GD&T feature-control frames and datums (no geometry change).", Schema: json.RawMessage(modelToleranceSchema), Apply: applyModelTolerance}
+}
+
+func applyModelTolerance(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in modelToleranceArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.Frames) == 0 && len(in.Datums) == 0 {
+		return nil, fmt.Errorf("modelTolerance: nothing to annotate (no frames, no datums)")
+	}
+	def, err := toleranceDefFromArgs(part, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewToleranceFeatures(part.Features()).AddModelTolerance(def))
+}
+
+// toleranceDefFromArgs decodes the GD&T records, resolving characteristic spellings and value
+// expressions; an unknown characteristic is a precise error.
+func toleranceDefFromArgs(part *compdef.PartComponentDefinition, in modelToleranceArgs) (*feature.ModelToleranceDefinition, error) {
+	def := &feature.ModelToleranceDefinition{}
+	for i, fr := range in.Frames {
+		ch, ok := types.ParseGeometricCharacteristic(fr.Characteristic)
+		if !ok {
+			return nil, fmt.Errorf("modelTolerance: frames[%d] unknown characteristic %q", i, fr.Characteristic)
+		}
+		value, err := lengthClosure(part, fr.Value, fmt.Sprintf("modelTolerance: frames[%d].value", i))
+		if err != nil {
+			return nil, err
+		}
+		def.Frames = append(def.Frames, feature.ToleranceFrame{
+			GeometryKey:    []byte(fr.Geometry),
+			Characteristic: ch,
+			Value:          value(),
+			Datums:         append([]string(nil), fr.Datums...),
+		})
+	}
+	for _, dl := range in.Datums {
+		def.Datums = append(def.Datums, feature.DatumLabel{GeometryKey: []byte(dl.Geometry), Label: dl.Label})
+	}
+	return def, nil
+}

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -124,6 +124,7 @@ func Default() *Registry {
 		deleteFaceDescriptor(),
 		simplifyDescriptor(),
 		unwrapDescriptor(),
+		modelToleranceDescriptor(),
 		splitFaceDescriptor(),
 		replaceFaceDescriptor(),
 		moveBodyDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/router/model_tolerance_test.go
+++ b/addin/router/model_tolerance_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// The #866 acceptance over the wire: the modelTolerance op annotates a face with a GD&T frame
+// + datum through features.add without changing the body, and rejects an empty request.
+
+func TestModelToleranceOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	face := keys.Bodies[0].Faces[0].Key
+
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", mustJSON(t, map[string]any{
+		"kind": "modelTolerance",
+		"args": map[string]any{
+			"frames": []map[string]any{{"geometry": face, "characteristic": "flatness", "value": "0.05 mm", "datums": []string{"A"}}},
+			"datums": []map[string]any{{"geometry": face, "label": "A"}},
+		},
+	}), &res)
+	if res.Bodies != 1 {
+		t.Fatalf("modelTolerance changed body count to %d, want 1 (annotation passes the solid through)", res.Bodies)
+	}
+}
+
+func TestModelToleranceOverWireRejectsEmpty(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "features.add", []byte(`{"kind":"modelTolerance","args":{}}`)); err == nil {
+		t.Fatal("an empty modelTolerance (no frames, no datums) must error")
+	}
+}

--- a/model/feature/model_tolerance.go
+++ b/model/feature/model_tolerance.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "oblikovati.org/api/types"
+
+// ModelTolerance (M20-F13 #866) is a GD&T carrier: a metadata feature that annotates model
+// geometry with feature-control frames and datum labels. Unlike the other F13 features it
+// changes no geometry — it passes the running body through and carries tolerance records that
+// survive recompute and the .obk round trip (mirrors the cosmetic/annotation features).
+
+// GeometricCharacteristic is the geometric-tolerance symbol of a feature-control frame; the
+// canonical definition lives in api/types (ADR-0018).
+type GeometricCharacteristic = types.GeometricCharacteristic
+
+// ToleranceFrame is one feature-control frame: a geometric characteristic over a tolerance
+// zone of size Value, applied to a model geometry reference, optionally relative to the named
+// datums (e.g. ["A","B"]).
+type ToleranceFrame struct {
+	GeometryKey    []byte
+	Characteristic GeometricCharacteristic
+	Value          float64
+	Datums         []string
+}
+
+// DatumLabel marks a model geometry reference as a datum feature (label "A", "B", …).
+type DatumLabel struct {
+	GeometryKey []byte
+	Label       string
+}
+
+// ModelToleranceDefinition is the GD&T record set carried by the feature.
+type ModelToleranceDefinition struct {
+	Frames []ToleranceFrame
+	Datums []DatumLabel
+}
+
+// ModelToleranceFeature annotates the model; it never alters the running body.
+type ModelToleranceFeature struct{ def *ModelToleranceDefinition }
+
+// Definition returns the GD&T record set.
+func (m *ModelToleranceFeature) Definition() *ModelToleranceDefinition { return m.def }
+
+// Kind implements [Feature].
+func (m *ModelToleranceFeature) Kind() string { return "modelTolerance" }
+
+// Recompute passes the running body state through unchanged — tolerances are metadata.
+func (m *ModelToleranceFeature) Recompute(in Input) (Output, error) {
+	return Output{Bodies: in.Bodies}, nil
+}
+
+// ToleranceFeatures adds GD&T model-tolerance carriers into the engine.
+type ToleranceFeatures struct{ engine *PartFeatures }
+
+// NewToleranceFeatures binds the collection to a feature engine.
+func NewToleranceFeatures(engine *PartFeatures) *ToleranceFeatures { return &ToleranceFeatures{engine} }
+
+// AddModelTolerance records a GD&T annotation set as a feature in history.
+func (c *ToleranceFeatures) AddModelTolerance(def *ModelToleranceDefinition) *PartFeature {
+	mt := &ModelToleranceFeature{def: def}
+	pf := c.engine.Add(mt)
+	pf.SetName(c.engine.UniqueName("Tolerance"))
+	return pf
+}

--- a/model/feature/model_tolerance_test.go
+++ b/model/feature/model_tolerance_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/sketch"
+)
+
+// sampleToleranceDef builds a GD&T record set: a flatness frame on faceKey relative to datum A,
+// and a datum label A on the same geometry.
+func sampleToleranceDef(faceKey []byte) *ModelToleranceDefinition {
+	return &ModelToleranceDefinition{
+		Frames: []ToleranceFrame{{
+			GeometryKey:    faceKey,
+			Characteristic: types.CharacteristicFlatness,
+			Value:          0.005, // 0.05 mm in cm
+			Datums:         []string{"A"},
+		}},
+		Datums: []DatumLabel{{GeometryKey: faceKey, Label: "A"}},
+	}
+}
+
+// TestModelTolerancePassesBodyThrough: the carrier annotates without changing the running body
+// (#866 — metadata feature).
+func TestModelTolerancePassesBodyThrough(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(sk, 0, 0, 2, 2)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 2 })
+	fs.Recompute()
+	before := fs.Result()[0]
+	faceKey := before.Faces()[0].ReferenceKey()
+
+	mt := NewToleranceFeatures(fs).AddModelTolerance(sampleToleranceDef(faceKey))
+	fs.Recompute()
+	if !mt.Health().OK() {
+		t.Fatalf("model tolerance sick: %+v", mt.Health())
+	}
+	after := fs.Result()
+	if len(after) != 1 || after[0] != before {
+		t.Errorf("model tolerance altered the running body: %d bodies (want 1, same pointer)", len(after))
+	}
+}
+
+// TestModelToleranceRoundTrip: frames + datums survive the recipe codec (characteristic, value,
+// datum labels, geometry keys).
+func TestModelToleranceRoundTrip(t *testing.T) {
+	faceKey := []byte("face-7")
+	fs := NewPartFeatures(nil, nil)
+	NewToleranceFeatures(fs).AddModelTolerance(sampleToleranceDef(faceKey))
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*ModelToleranceFeature).Definition()
+	if len(def.Frames) != 1 || len(def.Datums) != 1 {
+		t.Fatalf("restored = %d frames, %d datums; want 1, 1", len(def.Frames), len(def.Datums))
+	}
+	fr := def.Frames[0]
+	if fr.Characteristic != types.CharacteristicFlatness || fr.Value != 0.005 ||
+		len(fr.Datums) != 1 || fr.Datums[0] != "A" || string(fr.GeometryKey) != "face-7" {
+		t.Errorf("restored frame = %+v, want flatness 0.005 datum A on face-7", fr)
+	}
+	if dl := def.Datums[0]; dl.Label != "A" || string(dl.GeometryKey) != "face-7" {
+		t.Errorf("restored datum = %+v, want label A on face-7", dl)
+	}
+}
+
+// TestModelToleranceUnknownCharacteristicRejected: a bad characteristic spelling errors on
+// restore (no silent loss).
+func TestModelToleranceUnknownCharacteristicRejected(t *testing.T) {
+	d := &ModelToleranceData{Frames: []ToleranceFrameData{{Geometry: encodeKey([]byte("f0")), Characteristic: "bogus", Value: 1}}}
+	if _, err := restoreModelTolerance(NewPartFeatures(nil, nil), d); err == nil {
+		t.Error("expected an error for an unknown characteristic spelling")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -21,27 +21,28 @@ import (
 // FeatureData is the serializable form of one history feature. Exactly one payload
 // pointer is set, matching Kind.
 type FeatureData struct {
-	Kind       string          `yaml:"kind"`
-	Name       string          `yaml:"name,omitempty"`
-	Suppressed bool            `yaml:"suppressed,omitempty"`
-	Seq        uint64          `yaml:"seq,omitempty"` // global creation stamp; see model/seq
-	Extrude    *ExtrudeData    `yaml:"extrude,omitempty"`
-	Fillet     *EdgeDressData  `yaml:"fillet,omitempty"`
-	Chamfer    *EdgeDressData  `yaml:"chamfer,omitempty"`
-	Shell      *FaceDressData  `yaml:"shell,omitempty"`
-	Draft      *FaceDressData  `yaml:"draft,omitempty"`
-	Lip        *LipData        `yaml:"lip,omitempty"`
-	Simplify   *SimplifyData   `yaml:"simplify,omitempty"`
-	Unwrap     *UnwrapData     `yaml:"unwrap,omitempty"`
-	MeshSolid  *MeshSolidData  `yaml:"meshSolid,omitempty"`
-	Thread     *ThreadData     `yaml:"thread,omitempty"`
-	Hole       *HoleData       `yaml:"hole,omitempty"`
-	Boss       *BossData       `yaml:"boss,omitempty"`
-	Rib        *RibData        `yaml:"rib,omitempty"`
-	Emboss     *EmbossData     `yaml:"emboss,omitempty"`
-	Combine    *CombineData    `yaml:"combine,omitempty"`
-	SplitSolid *SplitSolidData `yaml:"splitSolid,omitempty"`
-	DirectEdit *DirectEditData `yaml:"directEdit,omitempty"`
+	Kind           string              `yaml:"kind"`
+	Name           string              `yaml:"name,omitempty"`
+	Suppressed     bool                `yaml:"suppressed,omitempty"`
+	Seq            uint64              `yaml:"seq,omitempty"` // global creation stamp; see model/seq
+	Extrude        *ExtrudeData        `yaml:"extrude,omitempty"`
+	Fillet         *EdgeDressData      `yaml:"fillet,omitempty"`
+	Chamfer        *EdgeDressData      `yaml:"chamfer,omitempty"`
+	Shell          *FaceDressData      `yaml:"shell,omitempty"`
+	Draft          *FaceDressData      `yaml:"draft,omitempty"`
+	Lip            *LipData            `yaml:"lip,omitempty"`
+	Simplify       *SimplifyData       `yaml:"simplify,omitempty"`
+	Unwrap         *UnwrapData         `yaml:"unwrap,omitempty"`
+	MeshSolid      *MeshSolidData      `yaml:"meshSolid,omitempty"`
+	ModelTolerance *ModelToleranceData `yaml:"modelTolerance,omitempty"`
+	Thread         *ThreadData         `yaml:"thread,omitempty"`
+	Hole           *HoleData           `yaml:"hole,omitempty"`
+	Boss           *BossData           `yaml:"boss,omitempty"`
+	Rib            *RibData            `yaml:"rib,omitempty"`
+	Emboss         *EmbossData         `yaml:"emboss,omitempty"`
+	Combine        *CombineData        `yaml:"combine,omitempty"`
+	SplitSolid     *SplitSolidData     `yaml:"splitSolid,omitempty"`
+	DirectEdit     *DirectEditData     `yaml:"directEdit,omitempty"`
 
 	RectPattern   *RectPatternData         `yaml:"rectangularPattern,omitempty"`
 	CircPattern   *CircPatternData         `yaml:"circularPattern,omitempty"`
@@ -137,6 +138,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Unwrap = &UnwrapData{Face: encodeKey(f.def.FaceKey)}
 	case *MeshSolidFeature:
 		fd.MeshSolid = serializeMeshSolid(f.geom)
+	case *ModelToleranceFeature:
+		fd.ModelTolerance = serializeModelTolerance(f.def)
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut,
 			Class: f.def.Class, Tapered: f.def.Tapered, ModelDiameter: threadModelDiameterName(f.def.ModelDiameter)}
@@ -348,6 +351,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreUnwrap(fs, fd.Unwrap)
 	case "mesh-solid":
 		return restoreMeshSolid(fs, fd.MeshSolid)
+	case "modelTolerance":
+		return restoreModelTolerance(fs, fd.ModelTolerance)
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_tolerance.go
+++ b/model/feature/serialize_tolerance.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// ModelToleranceData is the serialized form of a ModelToleranceFeature (#866): the GD&T
+// feature-control frames and datum labels, with geometry references as encoded keys and the
+// characteristic as its wire spelling.
+type ModelToleranceData struct {
+	Frames []ToleranceFrameData `yaml:"frames,omitempty"`
+	Datums []DatumLabelData     `yaml:"datums,omitempty"`
+}
+
+// ToleranceFrameData is one serialized feature-control frame.
+type ToleranceFrameData struct {
+	Geometry       string   `yaml:"geometry"`
+	Characteristic string   `yaml:"characteristic"`
+	Value          float64  `yaml:"value"`
+	Datums         []string `yaml:"datums,omitempty"`
+}
+
+// DatumLabelData is one serialized datum label.
+type DatumLabelData struct {
+	Geometry string `yaml:"geometry"`
+	Label    string `yaml:"label"`
+}
+
+// serializeModelTolerance captures the GD&T record set.
+func serializeModelTolerance(def *ModelToleranceDefinition) *ModelToleranceData {
+	d := &ModelToleranceData{}
+	for _, f := range def.Frames {
+		d.Frames = append(d.Frames, ToleranceFrameData{
+			Geometry:       encodeKey(f.GeometryKey),
+			Characteristic: f.Characteristic.String(),
+			Value:          f.Value,
+			Datums:         append([]string(nil), f.Datums...),
+		})
+	}
+	for _, dl := range def.Datums {
+		d.Datums = append(d.Datums, DatumLabelData{Geometry: encodeKey(dl.GeometryKey), Label: dl.Label})
+	}
+	return d
+}
+
+// restoreModelTolerance rebuilds a ModelToleranceFeature from its records, erroring on an
+// unknown characteristic spelling (no silent loss).
+func restoreModelTolerance(fs *PartFeatures, d *ModelToleranceData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("modelTolerance feature is missing its payload")
+	}
+	def := &ModelToleranceDefinition{}
+	for _, fr := range d.Frames {
+		key, err := decodeKey(fr.Geometry)
+		if err != nil {
+			return nil, err
+		}
+		ch, ok := types.ParseGeometricCharacteristic(fr.Characteristic)
+		if !ok {
+			return nil, fmt.Errorf("modelTolerance: unknown characteristic %q", fr.Characteristic)
+		}
+		def.Frames = append(def.Frames, ToleranceFrame{GeometryKey: key, Characteristic: ch, Value: fr.Value, Datums: append([]string(nil), fr.Datums...)})
+	}
+	for _, dl := range d.Datums {
+		key, err := decodeKey(dl.Geometry)
+		if err != nil {
+			return nil, err
+		}
+		def.Datums = append(def.Datums, DatumLabel{GeometryKey: key, Label: dl.Label})
+	}
+	return NewToleranceFeatures(fs).AddModelTolerance(def), nil
+}


### PR DESCRIPTION
## What

Completes the last **M20-F13** scope item (#866, split from #490): a **ModelTolerance** feature — a GD&T carrier that annotates model geometry with feature-control frames and datum labels.

- **model** (`model_tolerance.go`): `ModelToleranceFeature`/`ModelToleranceDefinition` holding feature-control frames (a `GeometricCharacteristic` over a tolerance zone value, optionally relative to named datums) and datum labels, each keyed by a geometry reference. On a `ToleranceFeatures` collection. Recompute **passes the running body through unchanged** — it carries metadata, like the cosmetic/annotation features.
- **serialize** (`serialize_tolerance.go`): inline `.obk` codec (geometry as encoded key, characteristic as its wire spelling), erroring on an unknown characteristic (no silent loss).
- **opregistry** (`feature_tolerance.go`): `modelTolerance` kind + JSON schema; rejects an empty annotation.
- uses `types.GeometricCharacteristic` (added in Oblikovati.API#111, ADR-0018).

## Why

GD&T tolerances are model metadata that downstream drawings/inspection consume. F13's other features (DirectEdit, Simplify, Unwrap) shipped in #490/#865; this carries data rather than mutating geometry, so it closes the feature.

## Acceptance (#866)

- ✅ Holds frames + datums referencing model geometry.
- ✅ Produces no body change (pass-through).
- ✅ Survives recompute and the `.obk` round trip (model + wire tests).

## Validation

- `go build/vet ./...`, `go test ./model/feature ./addin/...` green; `golangci-lint` clean; SPDX present.
- **Live-confirmed**: applied through the real opregistry `modelTolerance` path against a running session — 2 features, 1 body, last = `modelTolerance`; the part renders intact (GD&T glyph rendering is drawing scope, M14).

Depends on Oblikovati.API#111 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)