### PR TITLE
Cap surface-opening through-holes for shrinkwrap (#721)

### DIFF
--- a/addin/router/assembly_derive.go
+++ b/addin/router/assembly_derive.go
@@ -234,10 +234,11 @@ func shrinkwrapDefinition(in wire.ShrinkwrapCreateArgs) (feature.ShrinkwrapDefin
 		return feature.ShrinkwrapDefinition{}, err
 	}
 	return feature.ShrinkwrapDefinition{
-		RemoveStyle:   remove,
-		MinPartVolume: in.MinPartVolume,
-		EnvelopeStyle: envelope,
-		PatchHoles:    in.PatchHoles,
+		RemoveStyle:     remove,
+		MinPartVolume:   in.MinPartVolume,
+		EnvelopeStyle:   envelope,
+		PatchHoles:      in.PatchHoles,
+		MaxHoleDiameter: in.MaxHoleDiameter,
 	}, nil
 }
 

--- a/addin/router/assembly_derive_test.go
+++ b/addin/router/assembly_derive_test.go
@@ -99,6 +99,25 @@ func TestAssemblyShrinkwrapCreateOverWire(t *testing.T) {
 	}
 }
 
+// TestAssemblyShrinkwrapMaxHoleDiameterOverWire confirms the maxHoleDiameter option is accepted
+// and mapped over the wire (#721): solid boxes have no surface holes, so capping is a no-op and
+// the whole-envelope result is unchanged — the wire field flows through without error.
+func TestAssemblyShrinkwrapMaxHoleDiameterOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	src := addAssemblyDoc(t, s, "src.obk", 0, 10)
+
+	var detail wire.FeatureDetailResult
+	args := fmt.Sprintf(`{"source":%d,"envelopeStyle":%d,"maxHoleDiameter":5}`, src.ID(), int32(2))
+	call(t, r, s, "assembly.shrinkwrapCreate", args, &detail)
+
+	if detail.Feature.Kind != "shrinkwrap" {
+		t.Errorf("shrinkwrap feature kind = %q, want shrinkwrap", detail.Feature.Kind)
+	}
+	if got := activePartVolume(t, s); stdmath.Abs(got-11.0) > 1e-6 {
+		t.Errorf("shrinkwrap volume = %g, want 11.0 (capping is a no-op on solid boxes)", got)
+	}
+}
+
 // TestAssemblyDeriveBreakLinkOverWire creates a derive, then breaks its link and checks
 // the feature is no longer linked.
 func TestAssemblyDeriveBreakLinkOverWire(t *testing.T) {

--- a/kernel/ops/cap_holes.go
+++ b/kernel/ops/cap_holes.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// CapHoles eliminates through-holes / blind pockets that open to the surface (M20-F15-adjacent,
+// #721) — the complement of FillInternalVoids, which drops disconnected void shells. Given the
+// wall faces of a hole (its cylindrical/prism tube, plus a pocket's bottom), it removes them and
+// heals each opening flush by dropping the inner loop it left on the bordering face, whose own
+// plane caps the opening. The result keeps all real outer geometry but closes the holes.
+//
+// Each opening must be an inner loop of a surviving face whose edges are all shared with removed
+// faces (i.e. the opening lies in that face — a hole drilled normal to a planar face). It errors
+// when the result is not a closed solid, so a caller can fall back rather than ship an open body.
+//
+// Example: CapHoles(plateWithBore, boreWallKeys) → the solid plate (bore filled).
+func CapHoles(body *topo.Body, wallFaceKeys [][]byte) (*topo.Body, error) {
+	removed, err := resolveFaceSet(body, wallFaceKeys)
+	if err != nil {
+		return nil, err
+	}
+	if len(removed) == 0 {
+		return nil, fmt.Errorf("cap-holes: no wall faces selected")
+	}
+	result := buildSolidFromLoops(cappedLoops(body, removed))
+	if r := Validate(result); !r.Valid || !result.IsSolid() {
+		return nil, fmt.Errorf("cap-holes: result is not a closed solid (openings not coplanar with their faces?) %v", r.Issues)
+	}
+	return result, nil
+}
+
+// cappedLoops returns every surviving face as a point-ring loop set, dropping the inner loops
+// that bounded a removed hole (those heal flush against the face's own plane).
+func cappedLoops(body *topo.Body, removed map[uint64]bool) []ploop {
+	noMoves := map[uint64]math.Point3{}
+	var out []ploop
+	for _, f := range body.Faces() {
+		if removed[f.ID()] {
+			continue
+		}
+		pl := ploop{normal: f.Geometry().NormalAt(0, 0)}
+		for _, l := range f.Loops() {
+			if !l.IsOuter() && loopBordersRemoved(l, removed) {
+				continue // an opening into the capped hole ⇒ heal flush (drop the inner loop)
+			}
+			pl.rings = append(pl.rings, healedRing(l, noMoves))
+		}
+		out = append(out, pl)
+	}
+	return out
+}
+
+// loopBordersRemoved reports whether every edge of a loop is shared with a removed face — i.e.
+// the loop is an opening left by removing the hole walls.
+func loopBordersRemoved(l *topo.Loop, removed map[uint64]bool) bool {
+	for _, u := range l.EdgeUses() {
+		if !edgeBordersRemoved(u.Edge(), removed) {
+			return false
+		}
+	}
+	return true
+}
+
+func edgeBordersRemoved(e *topo.Edge, removed map[uint64]bool) bool {
+	for _, f := range e.Faces() {
+		if removed[f.ID()] {
+			return true
+		}
+	}
+	return false
+}
+
+// CapHolesByDiameter detects straight through-holes / pockets whose openings are no wider than
+// maxDiameter and caps them (#721). An opening is an inner loop; the hole's walls are the faces
+// adjacent to it. Returns the body unchanged when nothing qualifies.
+func CapHolesByDiameter(body *topo.Body, maxDiameter float64) (*topo.Body, error) {
+	walls := holeWallFaces(body, maxDiameter)
+	if len(walls) == 0 {
+		return body, nil
+	}
+	return CapHoles(body, walls)
+}
+
+// holeWallFaces returns the reference keys of faces that wall a hole whose opening (an inner
+// loop) spans at most maxDiameter — the faces adjacent across the opening's edges.
+func holeWallFaces(body *topo.Body, maxDiameter float64) [][]byte {
+	wallIDs := map[uint64]bool{}
+	var walls [][]byte
+	for _, f := range body.Faces() {
+		for _, l := range f.Loops() {
+			if l.IsOuter() || loopDiameter(l) > maxDiameter {
+				continue
+			}
+			for _, nb := range loopNeighbourFaces(l, f) {
+				if !wallIDs[nb.ID()] {
+					wallIDs[nb.ID()] = true
+					walls = append(walls, nb.ReferenceKey())
+				}
+			}
+		}
+	}
+	return walls
+}
+
+// loopNeighbourFaces returns the faces sharing an edge with loop l other than its owner.
+func loopNeighbourFaces(l *topo.Loop, owner *topo.Face) []*topo.Face {
+	var out []*topo.Face
+	seen := map[uint64]bool{owner.ID(): true}
+	for _, u := range l.EdgeUses() {
+		for _, nb := range u.Edge().Faces() {
+			if !seen[nb.ID()] {
+				seen[nb.ID()] = true
+				out = append(out, nb)
+			}
+		}
+	}
+	return out
+}
+
+// loopDiameter estimates an opening's width as the largest extent of its vertices' bounding box.
+func loopDiameter(l *topo.Loop) float64 {
+	lo := math.P3(stdmath.Inf(1), stdmath.Inf(1), stdmath.Inf(1))
+	hi := math.P3(stdmath.Inf(-1), stdmath.Inf(-1), stdmath.Inf(-1))
+	for _, u := range l.EdgeUses() {
+		p := u.Edge().StartVertex().Point()
+		lo = math.P3(stdmath.Min(lo.X, p.X), stdmath.Min(lo.Y, p.Y), stdmath.Min(lo.Z, p.Z))
+		hi = math.P3(stdmath.Max(hi.X, p.X), stdmath.Max(hi.Y, p.Y), stdmath.Max(hi.Z, p.Z))
+	}
+	return stdmath.Max(hi.X-lo.X, stdmath.Max(hi.Y-lo.Y, hi.Z-lo.Z))
+}

--- a/kernel/ops/cap_holes_test.go
+++ b/kernel/ops/cap_holes_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// boxWithThroughHole returns a 4×4×2 block (vol 32) with a 2×2 column through it in z (a
+// through-hole of volume 8, leaving 24), built by extruding a rectangle-with-rectangular-hole
+// profile so the faces are clean quads with real inner loops (not a triangle cage).
+func boxWithThroughHole(t *testing.T) *topo.Body {
+	t.Helper()
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	addSketchRect(sk, 0, 0, 4, 4) // outer boundary
+	addSketchRect(sk, 1, 1, 3, 3) // the hole
+	fs := feature.NewPartFeatures(nil, nil)
+	feature.NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 2 })
+	fs.Recompute()
+	holey := fs.Result()[0]
+	if v := csgVolume(holey); stdmath.Abs(v-24) > 1e-6 {
+		t.Fatalf("holey block volume = %g, want 24 (32 − 8 hole)", v)
+	}
+	return holey
+}
+
+// addSketchRect adds a closed axis-aligned rectangle [x0,x1]×[y0,y1] to a sketch.
+func addSketchRect(sk *sketch.Sketch, x0, y0, x1, y1 float64) {
+	c0 := sk.Points().Add(math.P2(x0, y0))
+	c1 := sk.Points().Add(math.P2(x1, y0))
+	c2 := sk.Points().Add(math.P2(x1, y1))
+	c3 := sk.Points().Add(math.P2(x0, y1))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}
+
+// TestCapHolesByDiameterFillsThroughHole detects and caps the through-hole, restoring the solid
+// 4×4×2 block (vol 32) — the #721 acceptance.
+func TestCapHolesByDiameterFillsThroughHole(t *testing.T) {
+	capped, err := ops.CapHolesByDiameter(boxWithThroughHole(t), 3)
+	if err != nil {
+		t.Fatalf("CapHolesByDiameter: %v", err)
+	}
+	if r := ops.Validate(capped); !r.Valid || !capped.IsSolid() {
+		t.Fatalf("capped body not a valid solid: %+v", r.Issues)
+	}
+	if v := csgVolume(capped); stdmath.Abs(v-32) > 1e-6 {
+		t.Errorf("capped volume = %g, want 32 (hole filled flush)", v)
+	}
+}
+
+// TestCapHolesExplicitSelection caps the same hole by selecting its four wall faces directly.
+func TestCapHolesExplicitSelection(t *testing.T) {
+	holey := boxWithThroughHole(t)
+	var walls [][]byte
+	for _, f := range holey.Faces() {
+		if n := f.Geometry().NormalAt(0, 0); stdmath.Abs(n.Z) < 0.1 && interiorXY(f) {
+			walls = append(walls, f.ReferenceKey())
+		}
+	}
+	if len(walls) != 4 {
+		t.Fatalf("selected %d wall faces, want 4", len(walls))
+	}
+	capped, err := ops.CapHoles(holey, walls)
+	if err != nil {
+		t.Fatalf("CapHoles: %v", err)
+	}
+	if v := csgVolume(capped); stdmath.Abs(v-32) > 1e-6 || !capped.IsSolid() {
+		t.Errorf("capped volume = %g solid=%v, want 32 solid", v, capped.IsSolid())
+	}
+}
+
+// TestCapHolesByDiameterIgnoresWideOpening leaves the hole when its opening exceeds the max
+// diameter (returns the body unchanged).
+func TestCapHolesByDiameterIgnoresWideOpening(t *testing.T) {
+	holey := boxWithThroughHole(t)
+	out, err := ops.CapHolesByDiameter(holey, 1) // the 2×2 opening is wider than 1
+	if err != nil {
+		t.Fatalf("CapHolesByDiameter: %v", err)
+	}
+	if v := csgVolume(out); stdmath.Abs(v-24) > 1e-6 {
+		t.Errorf("volume = %g, want 24 (hole left intact)", v)
+	}
+}
+
+// TestCapHolesEmptySelection rejects an empty wall set.
+func TestCapHolesEmptySelection(t *testing.T) {
+	if _, err := ops.CapHoles(csgBox(math.P3(0, 0, 0), 1, 1, 1), nil); err == nil {
+		t.Error("expected an error for an empty wall selection")
+	}
+}
+
+// interiorXY reports whether a face's vertices all lie within the bored column footprint
+// (x,y ∈ (0.5, 3.5)) — i.e. it is a hole wall, not an outer side.
+func interiorXY(f *topo.Face) bool {
+	for _, v := range f.Vertices() {
+		p := v.Point()
+		if p.X < 0.5 || p.X > 3.5 || p.Y < 0.5 || p.Y > 3.5 {
+			return false
+		}
+	}
+	return true
+}

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -48,9 +48,13 @@ type ShrinkwrapDefinition struct {
 	MinPartVolume float64 // threshold for RemoveSmallParts (units³)
 	EnvelopeStyle ShrinkwrapEnvelopeStyle
 	// PatchHoles fills each kept part's internal voids (cavities) so hollow parts
-	// become solid, before removal and enveloping. Through-holes open to the surface
-	// are unaffected (envelope replacement handles those).
+	// become solid, before removal and enveloping.
 	PatchHoles bool
+	// MaxHoleDiameter, when > 0, caps through-holes / pockets that open to the surface
+	// whose opening spans at most this width — closing them flush while keeping the real
+	// outer geometry (#721). Larger holes are left intact. Complements PatchHoles, which
+	// only fills disconnected internal voids.
+	MaxHoleDiameter float64
 }
 
 // BuildShrinkwrap flattens source's occurrence tree, drops parts per the removal
@@ -69,6 +73,9 @@ func BuildShrinkwrap(source AssemblyBodySource, def ShrinkwrapDefinition) ([]*to
 	if def.PatchHoles {
 		world = patchHoles(world)
 	}
+	if def.MaxHoleDiameter > 0 {
+		world = capThroughHoles(world, def.MaxHoleDiameter)
+	}
 	enveloped, err := applyEnvelope(keepAfterRemoval(world, def), def.EnvelopeStyle)
 	if err != nil {
 		return nil, err
@@ -83,6 +90,20 @@ func patchHoles(world []*topo.Body) []*topo.Body {
 	out := make([]*topo.Body, 0, len(world))
 	for _, b := range world {
 		out = append(out, ops.FillInternalVoids(b, q))
+	}
+	return out
+}
+
+// capThroughHoles caps each body's surface-opening holes no wider than maxDiameter, keeping the
+// holed body whenever the cap cannot close it (so a tricky part never fails the whole build).
+func capThroughHoles(world []*topo.Body, maxDiameter float64) []*topo.Body {
+	out := make([]*topo.Body, 0, len(world))
+	for _, b := range world {
+		if capped, err := ops.CapHolesByDiameter(b, maxDiameter); err == nil {
+			out = append(out, capped)
+			continue
+		}
+		out = append(out, b)
 	}
 	return out
 }

--- a/model/feature/shrinkwrap_test.go
+++ b/model/feature/shrinkwrap_test.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
 )
 
 // cavityBlock builds a 4³ block with a fully enclosed 2³ cavity (volume 56) by cutting
@@ -141,6 +142,49 @@ func TestShrinkwrapPatchHolesFillsCavity(t *testing.T) {
 	}
 	if got := volumeOf(bodies[0]); got < 63.9 || got > 64.1 {
 		t.Errorf("patched volume = %g, want ~64 (cavity filled)", got)
+	}
+}
+
+// holedPlate returns a 4×4×2 plate with a 2×2 through-hole (vol 24), built by extruding a
+// rectangle-with-rectangular-hole profile.
+func holedPlate(t *testing.T) *topo.Body {
+	t.Helper()
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(sk, 0, 0, 4, 4)
+	addRect(sk, 1, 1, 3, 3)
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 2 })
+	fs.Recompute()
+	return fs.Result()[0]
+}
+
+// TestShrinkwrapCapsThroughHole gates the through-hole patch (#721) through the feature: a
+// holed plate (vol 24) closes to its 32-volume solid block when MaxHoleDiameter covers the
+// opening, and is left intact when it does not.
+func TestShrinkwrapCapsThroughHole(t *testing.T) {
+	plate := holedPlate(t)
+	if v := volumeOf(plate); v < 23.9 || v > 24.1 {
+		t.Fatalf("holed-plate fixture volume = %g, want ~24", v)
+	}
+	src := &fakeAssemblySource{placed: []PlacedBody{
+		{Body: plate, Transform: math.Identity4(), Source: occFor("plate:1")},
+	}}
+
+	capped, err := BuildShrinkwrap(src, ShrinkwrapDefinition{MaxHoleDiameter: 3})
+	if err != nil {
+		t.Fatalf("BuildShrinkwrap: %v", err)
+	}
+	if got := volumeOf(capped[0]); got < 31.9 || got > 32.1 {
+		t.Errorf("capped volume = %g, want ~32 (hole closed flush)", got)
+	}
+
+	// PatchHoles alone must NOT fill a through-hole (it is not a disconnected internal void).
+	intact, err := BuildShrinkwrap(src, ShrinkwrapDefinition{PatchHoles: true})
+	if err != nil {
+		t.Fatalf("BuildShrinkwrap: %v", err)
+	}
+	if got := volumeOf(intact[0]); got < 23.9 || got > 24.1 {
+		t.Errorf("PatchHoles volume = %g, want ~24 (through-hole left intact)", got)
 	}
 }
 


### PR DESCRIPTION
## What

Implements **#721** (kernel geometry-parity): cap through-holes / blind pockets that open to the surface — the complement of `FillInternalVoids` (which only drops disconnected internal void shells).

- **`ops.CapHoles(body, wallFaceKeys)`** (kernel): removes a hole's wall faces and heals each opening flush by dropping the inner loop they left on the bordering face — whose own plane caps the opening — reusing the loop-welding infrastructure from `DeleteFaces`. A holed body becomes a solid block; outer geometry is preserved. Errors when the result is not a closed solid (so callers can fall back rather than ship an open body).
- **`ops.CapHolesByDiameter(body, maxDiameter)`**: detects straight through-holes/pockets by opening width (inner loops) and caps them; returns the body unchanged when nothing qualifies.
- **Shrinkwrap wire-up**: `ShrinkwrapDefinition.MaxHoleDiameter`, routed in `BuildShrinkwrap` after the internal-void fill, keeping the holed body whenever a cap can't close it (a tricky part never fails the whole build). Exposed on `wire.ShrinkwrapCreateArgs` (Oblikovati.API#112, merged).

## Why

Shrinkwrap could only eliminate surface holes via envelope replacement (replace the whole part with its bounding box). Capping keeps the real outer geometry while closing the openings — accurate lightweight simplification.

## Acceptance (#721)

- ✅ A 4×4×2 plate with a 2×2 through-hole (vol 24) caps to its **32-volume solid block**, validated manifold (kernel + model tests).
- ✅ Detection respects the diameter bound (wide opening left intact).
- ✅ `PatchHoles` alone leaves a through-hole intact (it is not a disconnected void).
- ✅ Routed through shrinkwrap end to end (model + wire tests).

## Validation

- `go build/vet ./...`, `go test ./kernel/ops ./model/feature ./addin/router` green; `golangci-lint` clean; SPDX present.
- **Live-confirmed**: rendered a holed plate beside its capped (solid) counterpart — hole closed flush, manifold; volumes 24 → 32.

Depends on Oblikovati.API#112 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)