### PR TITLE
kernel/brep: resolve tangent-contact unions into manifold solids (M20-F01)

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -5,6 +5,7 @@ package brep
 import (
 	"errors"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -31,6 +32,7 @@ type subFace struct {
 	normal  math.Vector3
 	point   math.Point3
 	lineage topo.Lineage
+	fromB   bool // which operand this came from (false=A, true=B); fuses tangent contacts
 }
 
 // Boolean computes A op B as a clean planar B-rep: it imprints the face–face intersection
@@ -45,11 +47,79 @@ func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
 	if !oka || !okb {
 		return nil, ErrNonPlanar
 	}
+	res, away, err := booleanOnce(op, fa, fb, a, b)
+	if err != nil || away.LengthSquared() == 0 {
+		return res, err
+	}
+	return retryNudged(op, fa, fb, a, res, away)
+}
+
+// booleanOnce runs one pass: imprint, split, classify, keep, stitch. The vector is a non-zero
+// "away" direction when the pass hit a tangent/grazing contact (operand B nudged along it
+// opens a clean clearance), else the zero vector.
+func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.Vector3, error) {
 	impA, impB := imprintAll(fa, fb)
 	var kept []subFace
 	kept = append(kept, selectFaces(fa, impA, b, fb, op, false)...)
 	kept = append(kept, selectFaces(fb, impB, a, fa, op, true)...)
 	return stitch(kept)
+}
+
+// nudgeEps is the magnitude (cm) of the clearance opened at a tangent contact: above the weld
+// grid (1e-6) so it survives, far below any modelled feature so it is geometrically
+// irrelevant. A line tangency carries no material, so replacing it with a ~0.1 µm gap loses
+// nothing and — unlike the exact tangent — leaves no coincident edge for a re-weld to collapse.
+const nudgeEps = 1e-5
+
+// retryNudged re-runs the boolean with operand B nudged a hair along `away` (out of the
+// tangent contact) so the degenerate touch becomes a clean clearance. It keeps the nudged
+// result only when it is a proper solid, so a nudge that would disconnect the part falls back
+// to the original (topologically resolved) result.
+func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.Vector3) (*topo.Body, error) {
+	fbp := translateFaces(fb, away.Scale(nudgeEps))
+	bp, _, err := stitch(planarToSubFaces(fbp))
+	if err != nil || bp == nil {
+		return original, nil
+	}
+	res, _, err := booleanOnce(op, fa, fbp, a, bp)
+	if err != nil || res == nil || !res.IsSolid() {
+		return original, nil
+	}
+	return res, nil
+}
+
+// translateFaces returns a copy of the planar faces rigidly displaced by d (a rigid move keeps
+// every face planar, so the result is still a valid planar-faceted operand).
+func translateFaces(faces []planarFace, d math.Vector3) []planarFace {
+	out := make([]planarFace, len(faces))
+	for i, f := range faces {
+		loops := make([][]math.Point3, len(f.loops))
+		for li, ring := range f.loops {
+			moved := make([]math.Point3, len(ring))
+			for vi, p := range ring {
+				moved[vi] = p.TranslateBy(d)
+			}
+			loops[li] = moved
+		}
+		pl, _ := geom.NewPlane(centroid3(loops[0]), f.normal)
+		out[i] = planarFace{plane: pl, normal: f.normal, loops: loops, lineage: f.lineage}
+	}
+	return out
+}
+
+// planarToSubFaces adapts whole planar faces to sub-faces (outer ring first, the rest holes)
+// so stitch can rebuild a body from them — used to materialise the nudged operand B.
+func planarToSubFaces(faces []planarFace) []subFace {
+	out := make([]subFace, 0, len(faces))
+	for _, f := range faces {
+		if len(f.loops) == 0 {
+			continue
+		}
+		sf := subFace{outer: f.loops[0], normal: f.normal, point: centroid3(f.loops[0]), lineage: f.lineage, fromB: true}
+		sf.holes = append(sf.holes, f.loops[1:]...)
+		out = append(out, sf)
+	}
+	return out
 }
 
 // imprintAll computes, for every crossing face pair, the shared intersection segment and
@@ -139,6 +209,7 @@ func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Bo
 		// its reference key is identical after the boolean (K1a). A face split into several
 		// kept pieces gives each a distinct child lineage (parent + split#k).
 		for k := range fromFace {
+			fromFace[k].fromB = isB // operand tag, so the stitch can fuse tangent contacts
 			if len(fromFace) == 1 {
 				fromFace[k].lineage = f.lineage
 			} else {

--- a/kernel/brep/boolean_nonmanifold.go
+++ b/kernel/brep/boolean_nonmanifold.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// loopEdgeUse is one directed use of an undirected vertex pair by a face loop: the face/ring/pos
+// that locate it, and whether the ring traverses the pair high→low (reversed, vs the canonical
+// low→high orientation used to key the edge).
+type loopEdgeUse struct {
+	face, ring, pos int
+	reversed        bool
+	fromB           bool // operand of the using face, for cross-operand fusion of tangent contacts
+}
+
+// collectEdgeUses groups every directed loop edge by its canonical (low,high) vertex pair, so
+// the stitch can resolve each pair's uses into shared topo edges.
+func collectEdgeUses(faces []builtFace) map[[2]int][]loopEdgeUse {
+	uses := map[[2]int][]loopEdgeUse{}
+	for fi, f := range faces {
+		for ri, r := range f.rings {
+			n := len(r)
+			for i := 0; i < n; i++ {
+				a, b := r[i], r[(i+1)%n]
+				key := canonEdge(a, b)
+				uses[key] = append(uses[key], loopEdgeUse{face: fi, ring: ri, pos: i, reversed: a > b, fromB: f.fromB})
+			}
+		}
+	}
+	return uses
+}
+
+// allUsesPaired reports whether every vertex pair is used an even, non-zero number of times —
+// the combinatorial closed-shell test. Exactly two is the manifold norm; more (a tangent
+// contact) still closes once resolveEdgeUses splits it into twice-used edges, so even is the
+// right test; an odd or zero count cannot close.
+func allUsesPaired(uses map[[2]int][]loopEdgeUse) bool {
+	for _, u := range uses {
+		if len(u) == 0 || len(u)%2 != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// buildResolvedEdges creates the shared topo edges and maps each half-edge use (face,ring,pos)
+// to its edge. A pair used twice makes one edge; a pair used more — coincident edges left by a
+// tangent/grazing contact between the operands — is split by resolveEdgeUses into manifold
+// pairs, each its own coincident edge between the same endpoints, so no edge ends up shared by
+// more than two faces.
+func buildResolvedEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, uses map[[2]int][]loopEdgeUse, faces []builtFace) map[[3]int]*topo.Edge {
+	keys := sortedPairKeys(uses)
+	useEdge := make(map[[3]int]*topo.Edge)
+	idx := 0
+	for _, k := range keys {
+		for _, group := range resolveEdgeUses(k, uses[k], verts, faces) {
+			e := bld.AddEdge(geom.NewLineSegment(verts[k[0]], verts[k[1]]), tv[k[0]], tv[k[1]], topo.NewLineage(topo.Tok("brep", "edge", idx)))
+			idx++
+			for _, h := range group {
+				useEdge[[3]int{h.face, h.ring, h.pos}] = e
+			}
+		}
+	}
+	return useEdge
+}
+
+// sortedPairKeys returns the vertex pairs in ascending order for stable edge lineage.
+func sortedPairKeys(uses map[[2]int][]loopEdgeUse) [][2]int {
+	keys := make([][2]int, 0, len(uses))
+	for k := range uses {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i][0] != keys[j][0] {
+			return keys[i][0] < keys[j][0]
+		}
+		return keys[i][1] < keys[j][1]
+	})
+	return keys
+}
+
+// resolveEdgeUses partitions a vertex pair's uses into manifold groups of two. The common case
+// (two uses) is one shared edge. A pair used more is a tangent/grazing contact where the two
+// operands' surfaces touch along this edge: collapsing all uses onto one edge would make it
+// non-manifold (>2 faces). The half-edges are sorted by the azimuth of their face-interior
+// direction about the edge axis, then paired (pairTangentDihedrals) so each group is one
+// manifold dihedral — and, where it can, FUSING the operands (an A face with a B face) so the
+// joined surface is continuous and leaves no coincident-edge crack for a later re-weld (a
+// fillet/shell) to collapse back to non-manifold.
+func resolveEdgeUses(pair [2]int, uses []loopEdgeUse, verts []math.Point3, faces []builtFace) [][]loopEdgeUse {
+	if len(uses) <= 2 {
+		return [][]loopEdgeUse{uses}
+	}
+	axis := verts[pair[0]].VectorTo(verts[pair[1]]).AsUnit().AsVector()
+	u, v := perpBasis(axis)
+	sort.SliceStable(uses, func(i, j int) bool {
+		return edgeAzimuth(uses[i], axis, u, v, faces) < edgeAzimuth(uses[j], axis, u, v, faces)
+	})
+	return pairTangentDihedrals(uses)
+}
+
+// pairTangentDihedrals walks the azimuth-sorted uses and pairs each unpaired half-edge with
+// the nearest following (cyclically) one of opposite traversal direction — so each group is a
+// pair of faces meeting at a real dihedral (used once each way), manifold and closed. A
+// cross-operand partner (one operand's face meeting the other's) is preferred over a
+// same-operand one at equal reach: fusing the operands' surfaces into one continuous shell
+// avoids a zero-width crack between two coincident edges that a downstream re-weld would merge.
+func pairTangentDihedrals(uses []loopEdgeUse) [][]loopEdgeUse {
+	used := make([]bool, len(uses))
+	groups := make([][]loopEdgeUse, 0, len(uses)/2)
+	for i := range uses {
+		if used[i] {
+			continue
+		}
+		if j := pickPartner(uses, used, i); j >= 0 {
+			groups = append(groups, []loopEdgeUse{uses[i], uses[j]})
+			used[i], used[j] = true, true
+		}
+	}
+	// Any half-edge left unpaired (an odd over-use from a near-degenerate contact) gets its
+	// own edge so every use still resolves to a real edge — the body will then be open at that
+	// edge, which the caller detects (not solid) and rejects, rather than crashing on a nil edge.
+	for i := range uses {
+		if !used[i] {
+			groups = append(groups, []loopEdgeUse{uses[i]})
+		}
+	}
+	return groups
+}
+
+// pickPartner returns the index of the half-edge to pair with use i: the nearest following
+// (cyclic) one of opposite traversal direction, preferring a cross-operand partner so the two
+// solids fuse. Returns -1 if none remain (an odd, unpairable count).
+func pickPartner(uses []loopEdgeUse, used []bool, i int) int {
+	fallback := -1
+	for d := 1; d < len(uses); d++ {
+		j := (i + d) % len(uses)
+		if used[j] || uses[j].reversed == uses[i].reversed {
+			continue
+		}
+		if uses[j].fromB != uses[i].fromB {
+			return j // cross-operand: fuse the surfaces
+		}
+		if fallback < 0 {
+			fallback = j
+		}
+	}
+	return fallback
+}
+
+// edgeAzimuth is the angle, about the edge axis, of a half-edge's face-interior direction —
+// the unit normal crossed with the ring's traversal direction (which keeps face material on
+// its left for both outer and hole loops). Used to order the faces radially around the edge.
+func edgeAzimuth(h loopEdgeUse, axis, u, v math.Vector3, faces []builtFace) float64 {
+	travel := axis
+	if h.reversed {
+		travel = axis.Scale(-1)
+	}
+	interior := faces[h.face].normal.Cross(travel)
+	return stdmath.Atan2(interior.Dot(v), interior.Dot(u))
+}
+
+// perpBasis returns two orthonormal vectors spanning the plane perpendicular to axis.
+func perpBasis(axis math.Vector3) (math.Vector3, math.Vector3) {
+	ref := math.V3(1, 0, 0)
+	if stdmath.Abs(axis.X) > 0.9 {
+		ref = math.V3(0, 1, 0)
+	}
+	u := axis.Cross(ref).AsUnit().AsVector()
+	return u, axis.Cross(u)
+}
+
+// loopSpecResolved builds a face loop from a ring of vertex indices, resolving each directed
+// edge to the topo edge assigned to that exact use (so coincident, tangent-contact edges stay
+// distinct), reversed when the ring traverses the pair high→low.
+func loopSpecResolved(outer bool, ring []int, fi, ri int, useEdge map[[3]int]*topo.Edge) topo.LoopSpec {
+	uses := make([]topo.Use, len(ring))
+	for i := range ring {
+		a, b := ring[i], ring[(i+1)%len(ring)]
+		uses[i] = topo.Use{Edge: useEdge[[3]int{fi, ri, i}], Reversed: a > b}
+	}
+	if outer {
+		return topo.OuterLoop(uses...)
+	}
+	return topo.InnerLoop(uses...)
+}

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -17,9 +17,13 @@ import (
 // Result faces carry their source face's lineage (K1a), so a face surviving the boolean
 // keeps its reference key; edges/vertices still get fresh lineage (edge-key survival is a
 // follow-up, as edges are routinely split by the operation).
-func stitch(faces []subFace) (*topo.Body, error) {
+// The second result is a non-zero "away" direction when a tangent/grazing contact was
+// resolved (an edge used by more than two faces): operand B nudged along it separates from the
+// contact, so a re-run yields a non-degenerate, re-weld-safe result. It is the zero vector when
+// the result is already clean.
+func stitch(faces []subFace) (*topo.Body, math.Vector3, error) {
 	if len(faces) == 0 {
-		return nil, nil
+		return nil, math.Vector3{}, nil
 	}
 	w := newWelder3()
 	// Pass 1: weld every face's loops to vertex indices (collect the full vertex set).
@@ -30,23 +34,39 @@ func stitch(faces []subFace) (*topo.Body, error) {
 			rings = append(rings, w.ring(orientRing(h, sf.normal, false)))
 		}
 		surf, _ := geom.NewPlane(centroid3(sf.outer), sf.normal)
-		out[i] = builtFace{rings: rings, surf: surf, lineage: sf.lineage}
+		out[i] = builtFace{rings: rings, surf: surf, normal: sf.normal, fromB: sf.fromB, lineage: sf.lineage}
 	}
 	// Pass 2: with all vertices known, split every loop edge at any welded vertex lying on
 	// it — propagating each imprint split-point to the neighbour face sharing that edge, so
 	// shared edges subdivide identically (eliminates cross-face T-junctions).
-	edgeUse := map[[2]int]int{}
 	for fi := range out {
 		for ri := range out[fi].rings {
 			out[fi].rings[ri] = splitRingTJunctions(out[fi].rings[ri], w.points)
 		}
-		for _, r := range out[fi].rings {
-			for i := 0; i < len(r); i++ {
-				edgeUse[canonEdge(r[i], r[(i+1)%len(r)])]++
+	}
+	body, away := assemble(w.points, out)
+	return body, away, nil
+}
+
+// awayFromContacts sums the unit normals of operand-B faces at each over-used (tangent) edge —
+// each points from B into A at the contact — so its negation is the direction to nudge B to
+// open a clean clearance. The zero vector means no tangent contact was found.
+func awayFromContacts(uses map[[2]int][]loopEdgeUse, faces []builtFace) math.Vector3 {
+	var into math.Vector3
+	for _, u := range uses {
+		if len(u) <= 2 {
+			continue
+		}
+		for _, h := range u {
+			if h.fromB {
+				into = into.Add(faces[h.face].normal)
 			}
 		}
 	}
-	return assemble(w.points, out, edgeUse), nil
+	if into.LengthSquared() < 1e-18 {
+		return math.Vector3{}
+	}
+	return into.AsUnit().AsVector().Scale(-1)
 }
 
 // splitRingTJunctions inserts, into each edge of the ring, any other vertex that lies in
@@ -120,26 +140,34 @@ func collectSegHits(pa math.Point3, ab math.Vector3, lenSq float64, onRing map[i
 type builtFace struct {
 	rings   [][]int
 	surf    geom.Plane
+	normal  math.Vector3
+	fromB   bool
 	lineage topo.Lineage
 }
 
-// assemble builds the topo body from welded vertices, per-face loop rings, and the edge
-// use counts (to decide solid vs. surface).
-func assemble(verts []math.Point3, faces []builtFace, edgeUse map[[2]int]int) *topo.Body {
-	bld := topo.NewBuilder(allEdgesPaired(edgeUse), topo.NewLineage(topo.Tok("brep", "body", 0)))
+// assemble builds the topo body from welded vertices and per-face loop rings. Each directed
+// loop edge (a "use") is resolved to a shared topo edge: the common case is two uses per
+// undirected vertex pair (one shared edge). Where coincident geometry leaves a pair used by
+// MORE than twice — a tangent/grazing contact between the two operands, which would be a
+// non-manifold edge if collapsed onto one edge — the uses are split into manifold pairs by
+// radial order around the edge (resolveEdgeUses), so each resulting edge is used exactly
+// twice. This keeps a tangent union a valid manifold solid (M20-F01).
+func assemble(verts []math.Point3, faces []builtFace) (*topo.Body, math.Vector3) {
+	uses := collectEdgeUses(faces)
+	bld := topo.NewBuilder(allUsesPaired(uses), topo.NewLineage(topo.Tok("brep", "body", 0)))
 	tv := make([]*topo.Vertex, len(verts))
 	for i, p := range verts {
 		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
 	}
-	edges := buildEdges(bld, verts, tv, edgeUse)
+	useEdge := buildResolvedEdges(bld, verts, tv, uses, faces)
 	for fi, f := range faces {
 		specs := make([]topo.LoopSpec, len(f.rings))
 		for ri, r := range f.rings {
-			specs[ri] = loopSpec(ri == 0, r, edges)
+			specs[ri] = loopSpecResolved(ri == 0, r, fi, ri, useEdge)
 		}
 		bld.AddFace(f.surf, faceLineage(f, fi), specs...)
 	}
-	return bld.Build()
+	return bld.Build(), awayFromContacts(uses, faces)
 }
 
 // faceLineage uses the source face's carried lineage when present (K1a reference-key
@@ -152,7 +180,8 @@ func faceLineage(f builtFace, fi int) topo.Lineage {
 }
 
 // allEdgesPaired reports whether every undirected edge is used exactly twice — the
-// combinatorial test for a closed (solid) shell.
+// combinatorial test for a closed (solid) shell. Used by the drill paths, which key edges by
+// vertex pair directly (no tangent-contact resolution needed for a single drilled hole).
 func allEdgesPaired(edgeUse map[[2]int]int) bool {
 	for _, c := range edgeUse {
 		if c != 2 {

--- a/kernel/brep/boolean_tangent_test.go
+++ b/kernel/brep/boolean_tangent_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// TestTangentContactUnionStaysManifold is the M20-F01 regression for a tangent/grazing union.
+// When two features joined onto the same body touch along a single line (zero volumetric
+// overlap) — e.g. a faceted boss whose rim grazes a flat mounting-lug wall, which is exactly
+// what the 28BYJ-48 geared stepper's data-sheet dimensions produce (boss radius == offset −
+// lug_w/2) — the naive weld leaves an edge bordered by FOUR faces (two from each operand), a
+// non-manifold pinch. The boolean detects the tangent and re-runs with operand B nudged a hair
+// out of the contact (retryNudged), turning the degenerate touch into a ~0.1 µm clearance — so
+// the result is a valid solid AND, crucially, carries no coincident edge that a downstream
+// re-weld would collapse: each case must still be a valid solid after a top-rim fillet.
+// Clearance and overlap (the non-degenerate neighbours) must stay clean too.
+func TestTangentContactUnionStaysManifold(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		lugBack float64 // Y of the lug wall facing the boss; boss rim reaches y = -0.45
+	}{
+		{"clearance", -0.50}, // wall short of the boss — two separate contacts on the can
+		{"tangent", -0.45},   // wall exactly on the boss rim — the degenerate pinch
+		{"overlap", -0.40},   // wall past the boss rim — features interpenetrate
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			can := cylinderZAt(0, -0.8, 0, 1.9, 1.4, "can")   // Ø2.8 can offset −0.8 in Y
+			boss := cylinderZAt(0, 0, -0.15, 0, 0.45, "boss") // Ø0.9 boss on the axis, rim at y=−0.45
+			body := joinOrFatal(t, can, boss, "boss")
+			lug := box(-2.1, -1.15, -0.085, 4.2, tc.lugBack-(-1.15), 0.085)
+			body = joinOrFatal(t, body, lug, "lug")
+			assertManifoldSolid(t, body, tc.name)
+			assertFilletable(t, body, tc.name)
+		})
+	}
+}
+
+// assertFilletable rounds the body's highest edge (the can's top rim, far from the contact) and
+// fails unless the result is a valid solid — the end-to-end proof that the tangent fix left no
+// coincident edge for the fillet's re-weld to collapse back to non-manifold.
+func assertFilletable(t *testing.T, b *topo.Body, label string) {
+	t.Helper()
+	var top *topo.Edge
+	bz := -1e18
+	for _, e := range b.Edges() {
+		vs := e.Vertices()
+		if z := (vs[0].Point().Z + vs[len(vs)-1].Point().Z) / 2; z > bz {
+			bz, top = z, e
+		}
+	}
+	out, err := ops.FilletEdges(b, [][]byte{top.ReferenceKey()}, 0.1)
+	if err != nil {
+		t.Fatalf("%s: fillet after tangent union failed: %v", label, err)
+	}
+	if r := ops.Validate(out); !r.Valid {
+		t.Fatalf("%s: filleted body invalid: %v", label, r.Issues)
+	}
+}
+
+// TestTangentBoxEdgeUnion exercises the resolver on the simplest exact tangency: two boxes
+// kitty-corner so they meet ONLY along one vertical line (no shared face, no overlap), each
+// also joined to a base plate so the result is one body. The shared vertical edge is bordered
+// by four planar faces (two from each box) and must split into two manifold dihedrals.
+func TestTangentBoxEdgeUnion(t *testing.T) {
+	base := box(-1, -1, 0, 2, 2, 0.2) // a plate both blocks sit on (keeps it one body)
+	a := box(-1, -1, 0, 1, 1, 1)      // x[-1,0] y[-1,0]
+	b := box(0, 0, 0, 1, 1, 1)        // x[0,1]  y[0,1]; touches `a` only along the (0,0) vertical line
+	body := joinOrFatal(t, base, a, "a")
+	body = joinOrFatal(t, body, b, "b")
+	assertManifoldSolid(t, body, "box-corner-tangent")
+}
+
+// assertManifoldSolid fails unless every edge borders exactly two faces and ops.Validate passes.
+func assertManifoldSolid(t *testing.T, b *topo.Body, label string) {
+	t.Helper()
+	open, nonManifold := 0, 0
+	for _, e := range b.Edges() {
+		switch n := len(e.Faces()); {
+		case n < 2:
+			open++
+		case n > 2:
+			nonManifold++
+		}
+	}
+	if open != 0 || nonManifold != 0 {
+		t.Fatalf("%s: not manifold: open=%d nonManifold=%d", label, open, nonManifold)
+	}
+}

--- a/kernel/brep/imprint_public.go
+++ b/kernel/brep/imprint_public.go
@@ -64,7 +64,7 @@ func rebuildImprinted(faces []planarFace, imprints [][][2]math.Point3) (ImprintR
 		}
 		kept = append(kept, pieces...)
 	}
-	body, err := stitch(kept)
+	body, _, err := stitch(kept)
 	if err != nil || body == nil {
 		return ImprintResult{}, err
 	}


### PR DESCRIPTION
## What & why

A union that joins two features **touching along a single line** — zero volumetric overlap — left an edge bordered by **four faces** (two from each operand), which `ops.Validate` correctly flags non-manifold, so the result could not be used downstream.

This is real and common in assembly-tier part modelling: porting the NopSCADlib **28BYJ-48 geared stepper** (for the PT_camera example assembly) surfaced it, because its data-sheet dimensions make the shaft **boss rim exactly graze the mounting-lug wall** (`boss_d/2 == offset − lug_w/2`). Any tangent assembly contact reproduces it.

This is **not** the #470 coplanar-imprint gap — that path works. It is a genuine degenerate **tangent/grazing contact**.

## How

- The stitch detects a tangent contact (a vertex pair used by **more than two** faces) and reports an *away* direction (the negated operand-B face normals at the contact).
- `Boolean` re-runs **once** with operand B nudged a hair (`nudgeEps = 1e-5` cm — above the weld grid, ~0.1 µm) along that direction, opening a clean **clearance**. A line tangency carries no material, so replacing the exact touch with a negligible gap loses nothing — and, **unlike** the exact tangent (or a topology-only edge split, which a downstream re-weld re-collapses), leaves no coincident edge for a fillet/shell to collapse back to non-manifold.
- The retry keeps its result only when it is a proper solid, else it falls back to the radial-resolved first pass — so a nudge that would disconnect the part is rejected.
- Non-degenerate unions never hit the retry (it engages only when a pass produced an over-used edge), bounding the regression surface.

## Tests

- New `kernel/brep/boolean_tangent_test.go`: the faceted-boss-grazes-flat-wall case (clearance / tangent / overlap) and a kitty-corner box-edge tangency — each asserted a valid manifold solid **and** still valid after a subsequent top-rim fillet (the re-weld-safety the fix buys).
- Full `go test ./kernel/... ./model/... ./addin/...` green (37 packages), `-race` clean on `kernel/brep` + `kernel/ops`, `golangci-lint` 0 issues, `gofmt` clean.

Related: M20-F01 (#453), boolean-robustness line #470 (a separate facet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)