### PR TITLE
Add Grill ventilation feature (M20-F10 #863)

### DIFF
--- a/addin/opregistry/feature_grill.go
+++ b/addin/opregistry/feature_grill.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// Grill ventilation feature (M20-F10 #863): cut a vent through a thin wall, leaving the
+// boundary profile's inner-loop structure (ribs/spars/islands) bridging it. The structure is
+// drawn as holes of the boundary profile in the sketch.
+
+type grillArgs struct {
+	SketchIndex int     `json:"sketchIndex"`
+	Boundaries  []int   `json:"boundaries"`
+	Draft       float64 `json:"draft"`
+}
+
+const grillSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the grill profiles (see model.tree)."},
+    "boundaries": {"type": "array", "items": {"type": "integer", "minimum": 0}, "minItems": 1, "description": "Profile indices of the vent boundaries; each profile's inner loops are the kept ribs/spars/islands that bridge the vent."},
+    "draft": {"type": "number", "description": "Draft angle (radians) tapering the vent walls. Optional."}
+  },
+  "required": ["sketchIndex", "boundaries"]
+}`
+
+func grillDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "grill", Summary: "Cut a ventilation grill: a vent bridged by the boundary profile's rib/spar/island structure.", Schema: json.RawMessage(grillSchema), Apply: applyGrill}
+}
+
+func applyGrill(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in grillArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if len(in.Boundaries) == 0 {
+		return nil, fmt.Errorf("grill: boundaries is empty")
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.GrillDefinition{Sketch: sk, Boundaries: append([]int(nil), in.Boundaries...), Draft: in.Draft}
+	return recomputeResult(part, feature.NewGrillFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -113,6 +113,7 @@ func Default() *Registry {
 		lipDescriptor(),
 		holeDescriptor(),
 		bossDescriptor(),
+		grillDescriptor(),
 		threadDescriptor(),
 		// Direct edits and booleans.
 		combineDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
-		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "thread",
+		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",

--- a/addin/router/grill_test.go
+++ b/addin/router/grill_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// The #863 acceptance over the wire: the grill op cuts a vent through a wall, leaving the
+// boundary profile's rib structure bridging it — one validated solid.
+func TestGrillOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// Wall: a 10×10×1 panel (sketch 0).
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"rectangle","points":[[0,0],[10,10]]}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"1 cm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+
+	// Grill sketch (1): a 6×6 boundary bridged by two ribs (drawn as inner rectangles ⇒ holes).
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"rectangle","points":[[2,2],[8,8]]}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"rectangle","points":[[3.75,2.5],[4.25,7.5]]}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":1,"kind":"rectangle","points":[[5.75,2.5],[6.25,7.5]]}`, &struct{}{})
+
+	var res struct {
+		Bodies int `json:"bodies"`
+	}
+	call(t, r, s, "features.add", `{"kind":"grill","args":{"sketchIndex":1,"boundaries":[0]}}`, &res)
+	if res.Bodies != 1 {
+		t.Fatalf("grill body count = %d, want 1", res.Bodies)
+	}
+	var v wire.ValidateBodyResult
+	call(t, r, s, "body.validate", `{"bodyIndex":0}`, &v)
+	if !v.Valid {
+		t.Fatalf("grill body invalid: %+v", v.Problems)
+	}
+}
+
+// TestGrillOverWireRejectsEmptyBoundaries: a grill with no boundaries must error.
+func TestGrillOverWireRejectsEmptyBoundaries(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"rectangle","points":[[0,0],[10,10]]}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"1 cm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	if _, err := r.Handle(s, "features.add", []byte(`{"kind":"grill","args":{"sketchIndex":0,"boundaries":[]}}`)); err == nil {
+		t.Fatal("a grill with no boundaries must error")
+	}
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -579,6 +579,12 @@ func sweptSolidCommands() []*CommandDefinition {
 		}).WithTab(tab3DModel).WithEnable(notInSketch).
 			WithIcon("emboss").WithButtonStyle(LargeIconButton).
 			WithTooltip("Emboss — raise or engrave a closed sketch profile on the part."),
+		NewCommand("Create.Grill", "Grill", "Create", func(s *Session) error {
+			s.StartTool(NewGrillTool())
+			return nil
+		}).WithTab(tab3DModel).WithEnable(notInSketch).
+			WithIcon("grill").WithButtonStyle(LargeIconButton).
+			WithTooltip("Grill — cut a ventilation grill: a vent bridged by the boundary profile's rib/spar/island structure."),
 		NewCommand("Create.Decal", "Decal", "Create", func(s *Session) error {
 			s.StartTool(NewDecalTool())
 			return nil

--- a/app/grill_tool.go
+++ b/app/grill_tool.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// GrillTool is the interactive Grill command: pick one or more boundary vent profiles (whose
+// inner loops are the bridging ribs/spars/islands), optionally set a draft angle, then OK to
+// cut the vent through the active part. It exposes its parameters through ParameterizedTool, so
+// the head renders the generic property dialog.
+type GrillTool struct {
+	profiles []ProfileHandle
+	draft    float64
+	added    *feature.PartFeature
+}
+
+// NewGrillTool returns a grill tool with no draft.
+func NewGrillTool() *GrillTool { return &GrillTool{} }
+
+// Name implements [Tool].
+func (t *GrillTool) Name() string { return "Grill" }
+
+// Start filters selection to closed regions so clicks pick a boundary profile.
+func (t *GrillTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+
+// Pick captures a single clicked region (replacing any previous selection).
+func (t *GrillTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		t.profiles = []ProfileHandle{p}
+	}
+}
+
+// PickWithMods extends the selection on Ctrl+click (toggling), to vent several boundaries.
+func (t *GrillTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
+	p, ok := sel.(ProfileHandle)
+	if !ok {
+		return
+	}
+	if !mods.Has(CtrlMod) {
+		t.Pick(s, sel)
+		return
+	}
+	if i := indexOfProfile(t.profiles, p); i >= 0 {
+		t.profiles = append(t.profiles[:i], t.profiles[i+1:]...)
+		return
+	}
+	t.profiles = append(t.profiles, p)
+}
+
+// The option the property window drives: the draft angle on the vent walls.
+func (t *GrillTool) SetDraft(d float64) { t.draft = d }
+func (t *GrillTool) Draft() float64     { return t.draft }
+
+// Params exposes the draft angle for the generic property dialog.
+func (t *GrillTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{{Label: "Draft", Get: t.Draft, Set: t.SetDraft}}}
+}
+
+// PickedProfiles returns the picked boundaries for the unified tool highlight.
+func (t *GrillTool) PickedProfiles() []ProfileHandle {
+	return append([]ProfileHandle(nil), t.profiles...)
+}
+
+// CanCommit reports whether at least one boundary is picked.
+func (t *GrillTool) CanCommit() bool { return len(t.profiles) > 0 }
+
+// Commit cuts the grill on the active part and recomputes; a sick feature keeps the tool open.
+func (t *GrillTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	skt := t.profiles[0].Sketch
+	t.added = feature.NewGrillFeatures(part.Features()).Add(&feature.GrillDefinition{
+		Sketch: skt, Boundaries: profileIndicesOn(t.profiles, skt), Draft: t.draft,
+	})
+	part.Recompute()
+	s.recordEdit(part, "Grill")
+	if !t.added.Health().OK() {
+		return errors.New("grill: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel restores the default selection filter.
+func (t *GrillTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *GrillTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/grill_tool_test.go
+++ b/app/grill_tool_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// partWithGrillSketch builds a 6×6×2 block and a grill sketch on its top face: a 4×4 boundary
+// (area 16) bridged by two 0.5-wide ribs drawn as inner rectangles (total 3) ⇒ one profile of
+// area 13.
+func partWithGrillSketch(t *testing.T) (*Session, *compdef.PartComponentDefinition, ProfileHandle) {
+	t.Helper()
+	s, _ := newPartWithBlock(t, 6) // block on XY, z 0..2, vol 72
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	top, _ := sketch.NewPlane(math.P3(0, 0, 2), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	es := def.Sketches().Add(top)
+	rectOn(es, 1, 1, 5, 5)           // boundary 4×4
+	rectOn(es, 2.25, 1.5, 2.75, 4.5) // rib 1 (0.5 × 3)
+	rectOn(es, 3.25, 1.5, 3.75, 4.5) // rib 2 (0.5 × 3)
+	return s, def, ProfileHandle{Sketch: es, ProfileIndex: 0}
+}
+
+// rectOn adds a closed axis-aligned rectangle [x0,x1]×[y0,y1] to a sketch.
+func rectOn(sk *sketch.Sketch, x0, y0, x1, y1 float64) {
+	c0 := sk.Points().Add(math.P2(x0, y0))
+	c1 := sk.Points().Add(math.P2(x1, y0))
+	c2 := sk.Points().Add(math.P2(x1, y1))
+	c3 := sk.Points().Add(math.P2(x0, y1))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}
+
+// TestGrillToolEndToEnd drives the Grill UI: pick the boundary, OK — and asserts the vent cut
+// through the block left the ribs (block 72 − 13×2 = 46).
+func TestGrillToolEndToEnd(t *testing.T) {
+	s, def, region := partWithGrillSketch(t)
+	s.SetPicker(stubPicker{sel: region})
+
+	g := NewGrillTool()
+	s.StartTool(g)
+	s.Click(100, 100)
+	if !g.CanCommit() {
+		t.Fatal("grill tool not ready after picking a boundary")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("grill body not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(v, 46) > 0.01 {
+		t.Errorf("grill volume = %g, want ≈46 (72 − 13×2 vent)", v)
+	}
+}
+
+// TestGrillViaRibbonCommand confirms the ribbon command starts the grill tool.
+func TestGrillViaRibbonCommand(t *testing.T) {
+	s, _, _ := partWithGrillSketch(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Create.Grill"); err != nil {
+		t.Fatalf("execute Create.Grill: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*GrillTool); !ok {
+		t.Fatal("Grill command did not start the grill tool")
+	}
+}

--- a/head/icon/assets/grill.svg
+++ b/head/icon/assets/grill.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="4" y="4" width="16" height="16" rx="1"/><path d="M9 5 V19 M15 5 V19" stroke="#ff0000"/></svg>

--- a/model/feature/grill.go
+++ b/model/feature/grill.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sketch"
+)
+
+// Grill (M20-F10 #863) is a plastic ventilation feature: a boundary region of a thin wall is
+// cut open and bridged by a structure of ribs, spars and islands that stay solid (the reference
+// GrillFeature). The structure is drawn as the inner loops of the boundary profile(s): a sketch
+// rectangle (the vent) with rib/spar/island shapes inside it resolves to one profile whose
+// outer loop is the boundary and whose holes are the kept structure. Cutting that profile
+// through the wall removes the open area and leaves the structure bridging the vent.
+//
+// Geometrically every kept element (rib/spar/island) is a hole of the cut profile; they share
+// one cut depth. A draft angle tapers the vent walls.
+
+// GrillDefinition is the grill recipe: the boundary vent profile(s) (whose inner loops are the
+// bridging structure), in one sketch, and a draft angle on the cut walls.
+type GrillDefinition struct {
+	Sketch     *sketch.Sketch
+	Boundaries []int
+	Draft      float64
+}
+
+// GrillFeature cuts the vent(s), leaving each boundary profile's inner-loop structure bridging.
+type GrillFeature struct {
+	def      *GrillDefinition
+	featName string
+}
+
+// Definition returns the grill recipe.
+func (g *GrillFeature) Definition() *GrillDefinition { return g.def }
+
+// Kind implements [Feature].
+func (g *GrillFeature) Kind() string { return "grill" }
+
+// Recompute cuts the boundary profiles (honoring their structure holes) through the running
+// wall, leaving the ribs/spars/islands bridging the vent.
+func (g *GrillFeature) Recompute(in Input) (Output, error) {
+	if _, err := lastBody(in, "grill"); err != nil {
+		return Output{}, err
+	}
+	if len(g.def.Boundaries) == 0 {
+		return Output{}, fmt.Errorf("grill: no boundary profile selected")
+	}
+	boundaries, err := resolveClosedProfiles(g.def.Sketch, g.def.Boundaries, "grill boundary")
+	if err != nil {
+		return Output{}, err
+	}
+	plane := g.def.Sketch.Plane()
+	sp := throughSpan(in.Bodies, plane)
+	cutTool := buildProfilePrisms(boundaries, plane, sp, g.def.Draft, featOr(g.featName, "grill"))
+	bodies, err := combine(in.Bodies, cutTool, ops.Cut)
+	if err != nil {
+		return Output{}, fmt.Errorf("grill: %w", err)
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// throughSpan spans the whole running material along the sketch-plane normal (plus a margin on
+// each side) so the vent cut passes cleanly through the wall whichever side the sketch sits on.
+func throughSpan(bodies []*topo.Body, plane sketch.Plane) span {
+	lo, hi := normalExtent(bodies, plane)
+	return span{near: lo - throughAllMargin, far: hi + throughAllMargin}
+}
+
+// GrillFeatures adds grill features into the engine.
+type GrillFeatures struct{ engine *PartFeatures }
+
+// NewGrillFeatures binds the collection to a feature engine.
+func NewGrillFeatures(engine *PartFeatures) *GrillFeatures { return &GrillFeatures{engine: engine} }
+
+// Add creates a grill from its definition.
+func (c *GrillFeatures) Add(def *GrillDefinition) *PartFeature {
+	g := &GrillFeature{def: def}
+	pf := c.engine.Add(g)
+	pf.SetName(c.engine.UniqueName("Grill"))
+	g.featName = pf.name
+	return pf
+}

--- a/model/feature/grill_test.go
+++ b/model/feature/grill_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/sketch"
+)
+
+// grillSketch returns a sketch with a 6×6 boundary vent (at 2..8) bridged by two 0.5-wide ribs
+// drawn as inner rectangles — the finder resolves it to one profile (area 31) whose holes are
+// the ribs.
+func grillSketch() *sketch.Sketch {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(sk, 2, 2, 8, 8)           // boundary 6×6 (area 36)
+	addRect(sk, 3.75, 2.5, 4.25, 7.5) // rib 1 (0.5 × 5)
+	addRect(sk, 5.75, 2.5, 6.25, 7.5) // rib 2 (0.5 × 5)
+	return sk
+}
+
+// TestGrillCutsVentLeavingRibs builds a 10×10×1 wall (vol 100) and a grill: the vent removes
+// the boundary-minus-ribs area (31), leaving the ribs bridging — a validated solid of vol 69,
+// which is more than the 64 a plain 6×6 window would leave (so the ribs stayed).
+func TestGrillCutsVentLeavingRibs(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	wall := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(wall, 0, 0, 10, 10)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(wall, 0, ops.NewBody, func() float64 { return 1 })
+
+	grill := NewGrillFeatures(fs).Add(&GrillDefinition{Sketch: grillSketch(), Boundaries: []int{0}})
+	fs.Recompute()
+
+	if !grill.Health().OK() {
+		t.Fatalf("grill sick: %+v", grill.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("grill body not a valid solid: %+v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-69) > 1e-6 {
+		t.Errorf("grill volume = %g, want 69 (100 − 31 vent), so >64 ⇒ ribs remain", v)
+	}
+}
+
+// TestGrillBoundaryOnlyIsAWindow: a boundary with no inner structure cuts a plain window
+// (vol 100 − 36 = 64).
+func TestGrillBoundaryOnlyIsAWindow(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	wall := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(wall, 0, 0, 10, 10)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(wall, 0, ops.NewBody, func() float64 { return 1 })
+
+	plain := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(plain, 2, 2, 8, 8)
+	NewGrillFeatures(fs).Add(&GrillDefinition{Sketch: plain, Boundaries: []int{0}})
+	fs.Recompute()
+
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("windowed body not a valid solid: %+v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-64) > 1e-6 {
+		t.Errorf("window volume = %g, want 64 (100 − 36)", v)
+	}
+}
+
+// TestGrillNoBoundaryRejected: an empty boundary set is an error.
+func TestGrillNoBoundaryRejected(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	wall := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(wall, 0, 0, 10, 10)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(wall, 0, ops.NewBody, func() float64 { return 1 })
+	g := NewGrillFeatures(fs).Add(&GrillDefinition{Sketch: grillSketch(), Boundaries: nil})
+	fs.Recompute()
+	if g.Health().OK() {
+		t.Error("grill with no boundary should be sick")
+	}
+}
+
+// TestGrillRoundTrip checks the grill survives the recipe codec (sketch index + boundaries).
+func TestGrillRoundTrip(t *testing.T) {
+	wallSk := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(wallSk, 0, 0, 10, 10)
+	gSk := grillSketch()
+	idx := sketchList{sks: []*sketch.Sketch{wallSk, gSk}}
+
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(wallSk, 0, ops.NewBody, func() float64 { return 1 })
+	NewGrillFeatures(fs).Add(&GrillDefinition{Sketch: gSk, Boundaries: []int{0}, Draft: 0.1})
+
+	data, err := fs.MarshalRecipe(idx)
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, idx, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(1).Definition().(*GrillFeature).Definition()
+	if len(def.Boundaries) != 1 || def.Boundaries[0] != 0 || def.Sketch != gSk || stdmath.Abs(def.Draft-0.1) > 1e-9 {
+		t.Errorf("restored grill = %+v, want boundary [0] draft 0.1 on the grill sketch", def)
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -35,6 +35,7 @@ type FeatureData struct {
 	Unwrap         *UnwrapData         `yaml:"unwrap,omitempty"`
 	MeshSolid      *MeshSolidData      `yaml:"meshSolid,omitempty"`
 	ModelTolerance *ModelToleranceData `yaml:"modelTolerance,omitempty"`
+	Grill          *GrillData          `yaml:"grill,omitempty"`
 	Thread         *ThreadData         `yaml:"thread,omitempty"`
 	Hole           *HoleData           `yaml:"hole,omitempty"`
 	Boss           *BossData           `yaml:"boss,omitempty"`
@@ -140,6 +141,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.MeshSolid = serializeMeshSolid(f.geom)
 	case *ModelToleranceFeature:
 		fd.ModelTolerance = serializeModelTolerance(f.def)
+	case *GrillFeature:
+		gd, err := serializeGrill(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Grill = gd
 	case *ThreadFeature:
 		fd.Thread = &ThreadData{Face: encodeKey(f.def.FaceKey), Designation: f.def.Designation, Cut: f.def.Cut,
 			Class: f.def.Class, Tapered: f.def.Tapered, ModelDiameter: threadModelDiameterName(f.def.ModelDiameter)}
@@ -353,6 +360,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreMeshSolid(fs, fd.MeshSolid)
 	case "modelTolerance":
 		return restoreModelTolerance(fs, fd.ModelTolerance)
+	case "grill":
+		return restoreGrill(fs, fd.Grill, sk)
 	case "shell":
 		d, err := requireFaceDress(fd.Shell, "shell")
 		if err != nil {

--- a/model/feature/serialize_grill.go
+++ b/model/feature/serialize_grill.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// GrillData is the serialized form of a GrillFeature (#863): the sketch (by index) and the
+// boundary vent-profile indices (whose inner loops are the bridging ribs/spars/islands).
+type GrillData struct {
+	Sketch     int     `yaml:"sketch"`
+	Boundaries []int   `yaml:"boundaries"`
+	Draft      float64 `yaml:"draft,omitempty"`
+}
+
+// serializeGrill captures a grill, recording its sketch by index.
+func serializeGrill(def *GrillDefinition, sk SketchIndexer) (*GrillData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("grill: sketch is not indexed by the part")
+	}
+	return &GrillData{Sketch: idx, Boundaries: append([]int(nil), def.Boundaries...), Draft: def.Draft}, nil
+}
+
+// restoreGrill rebuilds a GrillFeature, re-binding its sketch by index.
+func restoreGrill(fs *PartFeatures, d *GrillData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("grill feature is missing its payload")
+	}
+	skt, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("grill: sketch %d not found", d.Sketch)
+	}
+	return NewGrillFeatures(fs).Add(&GrillDefinition{
+		Sketch:     skt,
+		Boundaries: append([]int(nil), d.Boundaries...),
+		Draft:      d.Draft,
+	}), nil
+}


### PR DESCRIPTION
## What

Implements **M20-F10 #863**: the **Grill** plastic ventilation feature — cut a vent through a thin wall, leaving the boundary profile's structure (ribs/spars/islands) bridging it.

The structure is drawn as the **inner loops of the boundary profile**: a sketch rectangle (the vent) with rib/spar/island shapes inside resolves to one profile whose outer loop is the boundary and whose holes are the kept material. `Recompute` builds that profile's prism through the wall (`buildProfilePrisms`, honoring the holes) and `Cut`s it from the running solid — removing the open area while the structure remains.

Full feature triangle:
- **model**: `GrillDefinition`/`GrillFeature` on a `GrillFeatures` collection; `throughSpan` cuts the full wall thickness; draft tapers the vent walls.
- **serialize**: `.obk` codec (sketch by index + boundary profile indices + draft).
- **opregistry**: `grill` kind + JSON schema.
- **UI**: interactive `GrillTool` (pick boundaries, draft property) + a Create-panel ribbon command (`Create.Grill`) + icon.

## Acceptance (#863)

- ✅ A 10×10×1 wall vented by a 6×6 boundary with two ribs → validated solid of vol **69** (100 − 31), > the 64 a plain window leaves (so the ribs remain).
- ✅ Boundary-only grill = a plain window (vol 64); empty boundary errors.
- ✅ Round-trips through the recipe.
- ✅ Reachable over the wire (`features.add` grill) and via the ribbon tool (app e2e).

## Validation

- `go build/vet ./...`, `go test ./model/feature ./addin/... ./app` green; `golangci-lint` clean; SPDX present.
- **Live-confirmed**: rendered a framed vent bridged by parallel ribs — a clean manifold grille.

## Follow-up

Surfaced a **pre-existing** earcut tessellation crash (nil deref in `kernel/ops/earcut.go`) when a face has **overlapping/crossing holes** (e.g. a rib+spar grid drawn as crossing rectangles, which produces overlapping inner loops). Not introduced here and not hit by clean (non-overlapping) grill inputs; filing separately as a tessellation-robustness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)