### PR TITLE
Make earcut total: no nil-deref panic on collapsed rings (#873)

### DIFF
--- a/kernel/ops/earcut.go
+++ b/kernel/ops/earcut.go
@@ -175,6 +175,9 @@ func (tc *triContext) isEar(ear *triNode) bool {
 // cureLocalIntersections removes self-intersections by clipping any diagonal whose endpoints'
 // neighbors form a valid triangle, emitting that triangle.
 func (tc *triContext) cureLocalIntersections(start *triNode, tris *[][3]int) *triNode {
+	if start == nil {
+		return nil // filterPoints collapsed the ring (e.g. degenerate/overlapping holes) — #873
+	}
 	p := start
 	for {
 		a, b := p.prev, p.next.next
@@ -197,6 +200,9 @@ func (tc *triContext) cureLocalIntersections(start *triNode, tris *[][3]int) *tr
 // splitEarcut is the last-resort fallback: find a valid diagonal that splits the polygon in
 // two and triangulate each half independently.
 func (tc *triContext) splitEarcut(start *triNode, tris *[][3]int) {
+	if start == nil {
+		return // a collapsed ring has nothing left to split (#873)
+	}
 	a := start
 	for {
 		b := a.next.next
@@ -227,6 +233,9 @@ func (tc *triContext) eliminateHoles(holeIdx []int, end int, outerNode *triNode)
 			stop = holeIdx[k+1]
 		}
 		list := tc.linkedList(start, stop, false)
+		if list == nil {
+			continue // a degenerate (empty/collinear) hole range contributes no ring (#873)
+		}
 		if list == list.next {
 			list.steiner = true
 		}

--- a/kernel/ops/earcut_overlap_test.go
+++ b/kernel/ops/earcut_overlap_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// rectHole returns an axis-aligned rectangle [x0,x1]×[y0,y1] as a hole loop.
+func rectHole(x0, y0, x1, y1 float64) []math.Point2 {
+	return []math.Point2{{X: x0, Y: y0}, {X: x1, Y: y0}, {X: x1, Y: y1}, {X: x0, Y: y1}}
+}
+
+// triSetArea sums the absolute area of earcut's triangles over a combined vertex list (outer
+// then holes), so a result can be area-checked.
+func triSetArea(tris [][3]int, outer []math.Point2, holes [][]math.Point2) float64 {
+	verts := append([]math.Point2(nil), outer...)
+	for _, h := range holes {
+		verts = append(verts, h...)
+	}
+	var a float64
+	for _, t := range tris {
+		a += stdmath.Abs(triArea(verts[t[0]], verts[t[1]], verts[t[2]]))
+	}
+	return a
+}
+
+// TestEarcutOverlappingGridHolesNoPanic regresses #873: a boundary with a grid of crossing
+// (overlapping) bar holes used to collapse a ring and nil-deref in cureLocalIntersections /
+// splitEarcut. It must now triangulate without panicking (best-effort on this degenerate input).
+func TestEarcutOverlappingGridHolesNoPanic(t *testing.T) {
+	outer := rectHole(0, 0, 10, 10)
+	var holes [][]math.Point2
+	for _, x := range []float64{3, 5, 7} {
+		holes = append(holes, rectHole(x-0.2, 1, x+0.2, 9)) // vertical bars
+	}
+	for _, y := range []float64{3, 5, 7} {
+		holes = append(holes, rectHole(1, y-0.2, 9, y+0.2)) // horizontal bars (cross the verticals)
+	}
+	tris := earcut(outer, holes) // must not panic
+	if len(tris) == 0 {
+		t.Error("earcut returned no triangles for the grid-holes face")
+	}
+}
+
+// TestEarcutPairOverlapNoPanic: a pair of overlapping holes also triangulates without panic.
+func TestEarcutPairOverlapNoPanic(t *testing.T) {
+	outer := rectHole(0, 0, 10, 10)
+	holes := [][]math.Point2{rectHole(3, 3, 6, 6), rectHole(5, 5, 8, 8)}
+	_ = earcut(outer, holes) // must not panic
+}
+
+// TestEarcutDisjointHolesExactArea guards against regression: with valid, non-overlapping
+// holes the triangulation still covers exactly outer − holes.
+func TestEarcutDisjointHolesExactArea(t *testing.T) {
+	outer := rectHole(0, 0, 10, 10)
+	holes := [][]math.Point2{rectHole(1, 1, 3, 9), rectHole(4, 1, 6, 9), rectHole(7, 1, 9, 9)}
+	want := 100.0
+	for _, h := range holes {
+		want -= stdmath.Abs(signedArea(h))
+	}
+	if got := triSetArea(earcut(outer, holes), outer, holes); stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("earcut area = %g, want %g (outer − 3 disjoint holes)", got, want)
+	}
+}


### PR DESCRIPTION
## What

Fixes **#873**: `kernel/ops/earcut.go` panicked (nil-deref in `cureLocalIntersections` / `splitEarcut`) when tessellating a planar face whose inner loops **overlap or cross** — e.g. a grill boundary whose rib+spar holes cross. The overlap drives `filterPoints` to collapse a ring to `nil`, and the cure/split fallback passes then dereferenced that nil ring, crashing `Recompute` mid-tessellation.

## Fix

Guard the collapsed-ring cases so `earcut` is **total** (never panics):
- `cureLocalIntersections(nil)` → returns `nil`,
- `splitEarcut(nil)` → returns,
- `eliminateHoles` skips a degenerate (empty/collinear) hole range.

On this degenerate, geometrically-invalid input (a valid B-rep face has non-overlapping inner loops) earcut now returns a best-effort triangulation instead of crashing. Valid, non-overlapping multi-hole faces are unaffected.

## Tests

- `TestEarcutOverlappingGridHolesNoPanic` — the exact crossing-bar grid that crashed now triangulates without panic.
- `TestEarcutPairOverlapNoPanic` — overlapping pair, no panic.
- `TestEarcutDisjointHolesExactArea` — regression guard: valid non-overlapping holes still cover exactly `outer − holes`.
- Full `go test ./kernel/ops` green; `golangci-lint`/SPDX clean.

## Scope note

This is the robustness (no-panic) fix the issue called for. *Correct* handling of overlapping holes (a 2D union/merge of the loops) is a larger, separate enhancement; in practice grills should be authored with non-overlapping structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)