### PR TITLE
Area-exact mesh for overlapping holes via 2D loop union (#873)

### DIFF
--- a/kernel/ops/earclip.go
+++ b/kernel/ops/earclip.go
@@ -41,6 +41,11 @@ func holedPlanarMesh(outer2D []math.Point2, outer3D []math.Point3, holes3D [][]m
 	for i, h := range holes3D {
 		holes2D[i] = project2D(h, flat)
 	}
+	if holesOverlap(holes2D) {
+		// Overlapping inner loops are degenerate for direct earcut; union them via the planar
+		// arrangement so the mesh covers exactly outer − union(holes) (#873).
+		return unionHoledMesh(outer3D, holes3D, normal)
+	}
 	m := &Mesh{}
 	for _, p := range outer3D {
 		m.addVertex(p, normal)

--- a/kernel/ops/union_holes.go
+++ b/kernel/ops/union_holes.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/math"
+)
+
+// A planar face whose inner loops OVERLAP each other (e.g. a grill boundary whose rib and spar
+// holes cross) is geometrically degenerate for plain earcut: feeding the raw overlapping loops
+// over- or under-counts the void and used to collapse a ring (#873). unionTris instead computes
+// the true union of the holes via the 2D planar arrangement (brep.Arrange) — which splits the
+// loops at their crossings into clean, non-overlapping cells — keeps the material cells (outer
+// minus the holes' union), and ear-clips each. The result covers exactly outer − union(holes),
+// so mass properties and display are area-exact on overlapping holes too.
+
+// unionHoledMesh tessellates a planar face whose hole loops overlap: it projects the face to its
+// plane with an orthonormal basis (an exact inverse, so original vertices round-trip and the
+// crossing points the union introduces land back on the plane), unions the holes, and lifts the
+// triangulation to 3D.
+func unionHoledMesh(outer3D []math.Point3, holes3D [][]math.Point3, normal math.Vector3) *Mesh {
+	origin := outer3D[0]
+	e1, e2 := planeBasis(normal)
+	to2D := func(p math.Point3) math.Point2 {
+		d := origin.VectorTo(p)
+		return math.P2(d.Dot(e1), d.Dot(e2))
+	}
+	to3D := func(q math.Point2) math.Point3 {
+		return origin.TranslateBy(e1.Scale(q.X).Add(e2.Scale(q.Y)))
+	}
+	outer2D := make([]math.Point2, len(outer3D))
+	for i, p := range outer3D {
+		outer2D[i] = to2D(p)
+	}
+	holes2D := make([][]math.Point2, len(holes3D))
+	for i, h := range holes3D {
+		holes2D[i] = project2D(h, to2D)
+	}
+	verts2D, tris := unionTris(outer2D, holes2D)
+	m := &Mesh{}
+	for _, q := range verts2D {
+		m.addVertex(to3D(q), normal)
+	}
+	for _, t := range tris {
+		m.addTriangle(t[0], t[1], t[2])
+	}
+	return m
+}
+
+// unionTris triangulates outer minus the union of holes, returning a fresh vertex list (the
+// arrangement may introduce crossing points absent from the inputs) and triangles indexing it.
+// It is used only when the holes overlap; non-overlapping faces stay on the direct earcut path.
+func unionTris(outer []math.Point2, holes [][]math.Point2) ([]math.Point2, [][3]int) {
+	segs := loopSegments(outer)
+	for _, h := range holes {
+		segs = append(segs, loopSegments(h)...)
+	}
+	var verts []math.Point2
+	var tris [][3]int
+	for _, cell := range brep.Arrange(segs) {
+		if !cellIsMaterial(cell, holes) {
+			continue
+		}
+		base := len(verts)
+		cellVerts, cellTris := tessellateCell(cell)
+		verts = append(verts, cellVerts...)
+		for _, t := range cellTris {
+			tris = append(tris, [3]int{t[0] + base, t[1] + base, t[2] + base})
+		}
+	}
+	return verts, tris
+}
+
+// loopSegments returns a closed loop's undirected edges as point pairs.
+func loopSegments(loop []math.Point2) [][2]math.Point2 {
+	if len(loop) < 2 {
+		return nil
+	}
+	segs := make([][2]math.Point2, len(loop))
+	for i := range loop {
+		segs[i] = [2]math.Point2{loop[i], loop[(i+1)%len(loop)]}
+	}
+	return segs
+}
+
+// tessellateCell ear-clips one arrangement cell. A material cell's holes can be several abutting
+// void sub-cells (the arrangement splits an overlapping-hole union into pieces); they are merged
+// into their true outline first, since abutting hole loops share edges and break earcut.
+func tessellateCell(cell brep.Face2D) ([]math.Point2, [][3]int) {
+	holes := mergeAbuttingHoles(cell.Holes)
+	verts := append([]math.Point2(nil), cell.Outer...)
+	for _, h := range holes {
+		verts = append(verts, h...)
+	}
+	return verts, earcut(cell.Outer, holes)
+}
+
+// mergeAbuttingHoles fuses hole loops that share edges into their boundary outline: a directed
+// edge shared by two abutting loops (traversed oppositely) is interior and dropped; the surviving
+// edges chain into the union's boundary loops. A single (or disjoint) hole set is returned as-is.
+func mergeAbuttingHoles(holes [][]math.Point2) [][]math.Point2 {
+	if len(holes) <= 1 {
+		return holes
+	}
+	w := newHoleWelder()
+	dirCount := map[[2]int]int{}
+	for _, h := range holes {
+		idx := make([]int, len(h))
+		for i, p := range h {
+			idx[i] = w.add(p)
+		}
+		for i := range idx {
+			a, b := idx[i], idx[(i+1)%len(idx)]
+			if a != b {
+				dirCount[[2]int{a, b}]++
+			}
+		}
+	}
+	return chainBoundaryEdges(boundaryEdges(dirCount), w.points)
+}
+
+// boundaryEdges keeps the directed edges whose reverse is absent — the outline of the union (an
+// edge shared by two abutting loops appears in both directions and cancels).
+func boundaryEdges(dirCount map[[2]int]int) [][2]int {
+	var keep [][2]int
+	for e, c := range dirCount {
+		if dirCount[[2]int{e[1], e[0]}] == 0 {
+			for k := 0; k < c; k++ {
+				keep = append(keep, e)
+			}
+		}
+	}
+	return keep
+}
+
+// chainBoundaryEdges links directed edges head-to-tail into closed loops.
+func chainBoundaryEdges(edges [][2]int, pts []math.Point2) [][]math.Point2 {
+	next := make(map[int][]int, len(edges))
+	for _, e := range edges {
+		next[e[0]] = append(next[e[0]], e[1])
+	}
+	var loops [][]math.Point2
+	for start := range next {
+		for len(next[start]) > 0 {
+			loop := traceBoundaryLoop(start, next)
+			if len(loop) >= 3 {
+				ring := make([]math.Point2, len(loop))
+				for i, v := range loop {
+					ring[i] = pts[v]
+				}
+				loops = append(loops, ring)
+			}
+		}
+	}
+	return loops
+}
+
+// traceBoundaryLoop walks next-edges from start until it returns, consuming each edge once.
+func traceBoundaryLoop(start int, next map[int][]int) []int {
+	loop := []int{start}
+	for cur := start; ; {
+		outs := next[cur]
+		if len(outs) == 0 {
+			return nil // open chain (degenerate) — abandon
+		}
+		nxt := outs[0]
+		next[cur] = outs[1:]
+		if nxt == start {
+			return loop
+		}
+		loop = append(loop, nxt)
+		cur = nxt
+	}
+}
+
+// holeWelder merges coincident hole vertices onto a shared index list (1e-9 grid, the
+// arrangement tolerance).
+type holeWelder struct {
+	index  map[[2]int64]int
+	points []math.Point2
+}
+
+func newHoleWelder() *holeWelder { return &holeWelder{index: map[[2]int64]int{}} }
+
+func (w *holeWelder) add(p math.Point2) int {
+	k := [2]int64{int64(stdmath.Round(p.X / arrWeld)), int64(stdmath.Round(p.Y / arrWeld))}
+	if i, ok := w.index[k]; ok {
+		return i
+	}
+	w.index[k] = len(w.points)
+	w.points = append(w.points, p)
+	return len(w.points) - 1
+}
+
+// arrWeld is the hole-vertex welding grid (matches the planar arrangement's coincidence tol).
+const arrWeld = 1e-9
+
+// cellIsMaterial reports whether an arrangement cell is solid material — its interior lies
+// outside every original hole. A cell wholly inside the holes' union is a void and is dropped.
+// The interior is sampled just inside the cell's (CCW) outer edge, which lies in the cell's
+// material region (between the outer boundary and any holes), unlike a triangle centroid that
+// can fall in a hole.
+func cellIsMaterial(cell brep.Face2D, holes [][]math.Point2) bool {
+	if len(cell.Outer) < 3 {
+		return false
+	}
+	p := probeInsideOuter(cell.Outer)
+	for _, h := range holes {
+		if pointInLoop2D(p, h) {
+			return false
+		}
+	}
+	return true
+}
+
+// probeInsideOuter returns a point just inside a CCW loop's first edge (the interior side),
+// matching the arrangement's own nesting probe.
+func probeInsideOuter(loop []math.Point2) math.Point2 {
+	a, b := loop[0], loop[1]
+	e := a.VectorTo(b)
+	mid := math.P2((a.X+b.X)/2, (a.Y+b.Y)/2)
+	return mid.TranslateBy(math.V2(-e.Y, e.X).Scale(1e-4)) // left normal = interior of a CCW loop
+}
+
+// pointInLoop2D is a ray-cast point-in-polygon test for a closed loop.
+func pointInLoop2D(p math.Point2, loop []math.Point2) bool {
+	in := false
+	for i, j := 0, len(loop)-1; i < len(loop); j, i = i, i+1 {
+		yi, yj := loop[i].Y, loop[j].Y
+		if (yi > p.Y) != (yj > p.Y) {
+			x := loop[i].X + (p.Y-yi)/(yj-yi)*(loop[j].X-loop[i].X)
+			if p.X < x {
+				in = !in
+			}
+		}
+	}
+	return in
+}
+
+// holesOverlap reports whether any two hole loops overlap — their edges cross, or a vertex of
+// one lies strictly inside another (so their union is smaller than the sum of their areas). Only
+// then is the costlier arrangement-union tessellation needed.
+func holesOverlap(holes [][]math.Point2) bool {
+	for i := 0; i < len(holes); i++ {
+		for j := i + 1; j < len(holes); j++ {
+			if loopsOverlap(holes[i], holes[j]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// loopsOverlap reports whether two closed loops share interior area.
+func loopsOverlap(a, b []math.Point2) bool {
+	for _, sa := range loopSegments(a) {
+		for _, sb := range loopSegments(b) {
+			if segmentsCross(xy(sa[0]), xy(sa[1]), xy(sb[0]), xy(sb[1])) {
+				return true
+			}
+		}
+	}
+	return pointInLoop2D(a[0], b) || pointInLoop2D(b[0], a)
+}
+
+// xy converts a Point2 to the [2]float64 form the shared geometry predicates use.
+func xy(p math.Point2) [2]float64 { return [2]float64{p.X, p.Y} }

--- a/kernel/ops/union_holes_test.go
+++ b/kernel/ops/union_holes_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// trisArea sums the absolute area of triangles over their own vertex list.
+func trisArea(verts []math.Point2, tris [][3]int) float64 {
+	var a float64
+	for _, t := range tris {
+		a += triArea(verts[t[0]], verts[t[1]], verts[t[2]])
+	}
+	return a
+}
+
+// TestUnionTrisTwoOverlappingSquares: outer 10×10 minus two 3×3 holes overlapping in a 1×1
+// square ⇒ union area 9+9−1 = 17, material 83 — area-exact (#873).
+func TestUnionTrisTwoOverlappingSquares(t *testing.T) {
+	outer := rectHole(0, 0, 10, 10)
+	holes := [][]math.Point2{rectHole(3, 3, 6, 6), rectHole(5, 5, 8, 8)}
+	verts, tris := unionTris(outer, holes)
+	if got := trisArea(verts, tris); stdmath.Abs(got-83) > 1e-6 {
+		t.Errorf("union area = %g, want 83 (100 − union 17)", got)
+	}
+}
+
+// TestUnionTrisGridHoles: outer 10×10 minus a grid of 3 vertical + 3 horizontal crossing bars
+// (width 0.4, length 8) ⇒ union 9.6+9.6−1.44 = 17.76, material 82.24 — the exact area earcut on
+// the raw overlapping loops could not produce.
+func TestUnionTrisGridHoles(t *testing.T) {
+	outer := rectHole(0, 0, 10, 10)
+	var holes [][]math.Point2
+	for _, x := range []float64{3, 5, 7} {
+		holes = append(holes, rectHole(x-0.2, 1, x+0.2, 9))
+	}
+	for _, y := range []float64{3, 5, 7} {
+		holes = append(holes, rectHole(1, y-0.2, 9, y+0.2))
+	}
+	verts, tris := unionTris(outer, holes)
+	if got := trisArea(verts, tris); stdmath.Abs(got-82.24) > 1e-6 {
+		t.Errorf("union area = %g, want 82.24 (100 − union 17.76)", got)
+	}
+}
+
+// TestHolesOverlapDetection: crossing/overlapping loops are detected; disjoint ones are not (so
+// the fast direct-earcut path is kept for clean faces).
+func TestHolesOverlapDetection(t *testing.T) {
+	overlapping := [][]math.Point2{rectHole(3, 3, 6, 6), rectHole(5, 5, 8, 8)}
+	if !holesOverlap(overlapping) {
+		t.Error("overlapping holes not detected")
+	}
+	disjoint := [][]math.Point2{rectHole(1, 1, 3, 9), rectHole(4, 1, 6, 9), rectHole(7, 1, 9, 9)}
+	if holesOverlap(disjoint) {
+		t.Error("disjoint holes wrongly flagged as overlapping")
+	}
+}
+
+// TestUnionHoledMeshArea lifts the union to 3D (the holedPlanarMesh overlap path) and checks the
+// mesh area equals outer − union, exercising the orthonormal project/unproject round-trip.
+func TestUnionHoledMeshArea(t *testing.T) {
+	normal := math.V3(0, 0, 1)
+	lift := func(x, y float64) math.Point3 { return math.P3(x, y, 5) }
+	outer3D := []math.Point3{lift(0, 0), lift(10, 0), lift(10, 10), lift(0, 10)}
+	hole := func(x0, y0, x1, y1 float64) []math.Point3 {
+		return []math.Point3{lift(x0, y0), lift(x1, y0), lift(x1, y1), lift(x0, y1)}
+	}
+	holes3D := [][]math.Point3{hole(3, 3, 6, 6), hole(5, 5, 8, 8)}
+	m := unionHoledMesh(outer3D, holes3D, normal)
+	if got := meshArea(m); stdmath.Abs(got-83) > 1e-4 {
+		t.Errorf("3D mesh area = %g, want 83 (100 − union 17)", got)
+	}
+}
+
+// TestHoledPlanarMeshRoutesOverlapToUnion checks the integrated tessellation entry routes an
+// overlapping-hole face through the union path (area-exact), exercising holesOverlap + the
+// projector handoff.
+func TestHoledPlanarMeshRoutesOverlapToUnion(t *testing.T) {
+	normal := math.V3(0, 0, 1)
+	flat := planeProjector(normal)
+	lift := func(x, y float64) math.Point3 { return math.P3(x, y, 0) }
+	outer3D := []math.Point3{lift(0, 0), lift(10, 0), lift(10, 10), lift(0, 10)}
+	hole := func(x0, y0, x1, y1 float64) []math.Point3 {
+		return []math.Point3{lift(x0, y0), lift(x1, y0), lift(x1, y1), lift(x0, y1)}
+	}
+	holes3D := [][]math.Point3{hole(3, 3, 6, 6), hole(5, 5, 8, 8)}
+	m := holedPlanarMesh(project2D(outer3D, flat), outer3D, holes3D, flat, normal)
+	if got := meshArea(m); stdmath.Abs(got-83) > 1e-4 {
+		t.Errorf("holedPlanarMesh area = %g, want 83 (overlap routed to union)", got)
+	}
+}


### PR DESCRIPTION
## What

Follow-up to the #873 nil-guard (#874): make the tessellation of a planar face with **overlapping/crossing inner loops area-exact**, not just crash-free.

When a face's hole loops overlap, union them through the 2D planar arrangement (`brep.Arrange`) — which splits the loops at their crossings into clean, non-overlapping cells — keep the **material** cells (outer minus the holes' union), and ear-clip each.

- `holesOverlap` gates the costlier union path, so clean non-overlapping faces stay on the direct earcut hot path (no perf regression).
- Material cells are classified by a point **just inside the cell's CCW outer edge** (the arrangement's own nesting probe) — robust where a triangle centroid can land in a hole.
- A material cell whose hole is an overlapping union arrives as several **abutting** sub-loops; `mergeAbuttingHoles` fuses them into the true outline (a shared edge appears in both directions and cancels), so earcut sees one clean hole.
- `unionHoledMesh` lifts the result to 3D with an **orthonormal plane basis** (exact inverse), so original vertices round-trip and the new crossing points land on the face plane.

## Result

Tessellation now covers exactly `outer − union(holes)`:
- two overlapping 3×3 squares → **83** (100 − union 17),
- a 3+3 crossing-bar grid → **82.24** (100 − union 17.76),
- the 3D path on an axis-aligned face → 83,
- `holedPlanarMesh` routes overlapping-hole faces through the union path.

Non-overlapping multi-hole faces are unaffected (exact-area regression retained).

## Scope

This is the **mesh** (mass-properties / display) fix the issue asked for. The planar boolean operating on a *tool whose B-rep itself carries overlapping profile loops* (e.g. a crossing-bar grill prism) is a separate concern — that tool is malformed before tessellation; grills should still be authored with non-overlapping structure for a correct boolean result.

## Validation

- `go test ./kernel/ops` (incl. the new union tests) green; `golangci-lint`/SPDX clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)