### PR TITLE
Correct grill vent for crossing ribs/spars (#863)

### DIFF
--- a/model/feature/grill.go
+++ b/model/feature/grill.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
 
@@ -40,8 +41,12 @@ func (g *GrillFeature) Definition() *GrillDefinition { return g.def }
 // Kind implements [Feature].
 func (g *GrillFeature) Kind() string { return "grill" }
 
-// Recompute cuts the boundary profiles (honoring their structure holes) through the running
-// wall, leaving the ribs/spars/islands bridging the vent.
+// Recompute cuts each boundary's vent through the running wall, leaving the rib/spar/island
+// structure bridging it. The vent of a boundary is boundary − union(bars), where the bars are
+// the sketch's closed loops lying inside that boundary; computing it as a boundary solid drilled
+// by each bar (a sequence of booleans = union subtraction) is robust even when the bars cross —
+// unlike the boundary profile's inner loops, which the even–odd region finder mis-forms for
+// overlapping structure (#863).
 func (g *GrillFeature) Recompute(in Input) (Output, error) {
 	if _, err := lastBody(in, "grill"); err != nil {
 		return Output{}, err
@@ -55,12 +60,75 @@ func (g *GrillFeature) Recompute(in Input) (Output, error) {
 	}
 	plane := g.def.Sketch.Plane()
 	sp := throughSpan(in.Bodies, plane)
-	cutTool := buildProfilePrisms(boundaries, plane, sp, g.def.Draft, featOr(g.featName, "grill"))
+	loops := g.def.Sketch.ClosedLoops()
+	cutTool := ventTool(boundaries, loops, plane, sp, g.def.Draft, featOr(g.featName, "grill"))
 	bodies, err := combine(in.Bodies, cutTool, ops.Cut)
 	if err != nil {
 		return Output{}, fmt.Errorf("grill: %w", err)
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// ventTool builds the merged cut tool: for each boundary, a solid prism of its outer loop drilled
+// by every closed loop (bar) lying inside it, giving boundary − union(bars).
+func ventTool(boundaries []*sketch.Profile, loops []sketch.Loop, plane sketch.Plane, sp span, draft float64, feat string) *topo.Body {
+	tools := make([]*topo.Body, 0, len(boundaries))
+	for i, b := range boundaries {
+		name := feat
+		if len(boundaries) > 1 {
+			name = fmt.Sprintf("%s/b%d", feat, i)
+		}
+		outer := b.OuterLoop().Polygon()
+		solid := buildPrism(outer, plane, sp, draft, name)
+		if bars := loopsInside(loops, outer); len(bars) > 0 {
+			solid = drillProfileHoles(solid, bars, plane, sp, draft, name)
+		}
+		tools = append(tools, solid)
+	}
+	if len(tools) == 1 {
+		return tools[0]
+	}
+	return topo.MergeBodies(topo.NewLineage(topo.Tok(feat, "merged", 0)), true, tools...)
+}
+
+// loopsInside returns the loops lying strictly inside the boundary polygon (the bars) — excluding
+// the boundary loop itself and anything outside it.
+func loopsInside(loops []sketch.Loop, boundary []math.Point2) []sketch.Loop {
+	var inside []sketch.Loop
+	for _, l := range loops {
+		if loopStrictlyInside(l.Polygon(), boundary) {
+			inside = append(inside, l)
+		}
+	}
+	return inside
+}
+
+// loopStrictlyInside reports whether every vertex of poly lies inside boundary (so the boundary
+// loop, whose vertices lie on its own edge, is excluded).
+func loopStrictlyInside(poly, boundary []math.Point2) bool {
+	if len(poly) == 0 {
+		return false
+	}
+	for _, v := range poly {
+		if !pointInPolygon2D(v, boundary) {
+			return false
+		}
+	}
+	return true
+}
+
+// pointInPolygon2D is the even–odd ray-cast test.
+func pointInPolygon2D(p math.Point2, poly []math.Point2) bool {
+	in := false
+	for i, j := 0, len(poly)-1; i < len(poly); j, i = i, i+1 {
+		yi, yj := poly[i].Y, poly[j].Y
+		if (yi > p.Y) != (yj > p.Y) {
+			if p.X < poly[i].X+(p.Y-yi)/(yj-yi)*(poly[j].X-poly[i].X) {
+				in = !in
+			}
+		}
+	}
+	return in
 }
 
 // throughSpan spans the whole running material along the sketch-plane normal (plus a margin on

--- a/model/feature/grill_test.go
+++ b/model/feature/grill_test.go
@@ -45,6 +45,38 @@ func TestGrillCutsVentLeavingRibs(t *testing.T) {
 	}
 }
 
+// TestGrillCrossingBarsVolume: a grid of crossing ribs and spars (overlapping rectangles) cuts
+// the correct vent — boundary 49 minus the bars' union 13.92 = 35.08 removed from a 100 wall,
+// leaving 64.92. Built as boundary − union(bars), robust to the crossings (#863).
+func TestGrillCrossingBarsVolume(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	wall := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(wall, 0, 0, 10, 10)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(wall, 0, ops.NewBody, func() float64 { return 1 })
+
+	g := sketch.NewSketches().Add(sketch.XYPlane())
+	addRect(g, 1.5, 1.5, 8.5, 8.5) // boundary 7×7 = 49
+	for _, x := range []float64{3, 5, 7} {
+		addRect(g, x-0.2, 1.8, x+0.2, 8.2) // vertical ribs
+	}
+	for _, y := range []float64{3, 5, 7} {
+		addRect(g, 1.8, y-0.2, 8.2, y+0.2) // horizontal spars (cross the ribs)
+	}
+	grill := NewGrillFeatures(fs).Add(&GrillDefinition{Sketch: g, Boundaries: []int{0}})
+	fs.Recompute()
+
+	if !grill.Health().OK() {
+		t.Fatalf("crossing-bar grill sick: %+v", grill.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("crossing-bar grill body not a valid solid: %+v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-64.92) > 1e-3 {
+		t.Errorf("crossing-bar grill volume = %g, want 64.92 (100 − vent 35.08)", v)
+	}
+}
+
 // TestGrillBoundaryOnlyIsAWindow: a boundary with no inner structure cuts a plain window
 // (vol 100 − 36 = 64).
 func TestGrillBoundaryOnlyIsAWindow(t *testing.T) {

--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -140,6 +140,17 @@ func (s *Sketch) Profiles() *Profiles {
 	return ps
 }
 
+// ClosedLoops returns the sketch's standalone closed loops detected by endpoint chaining
+// (detectLoops), independent of the planar-arrangement region finder. Because each loop is a
+// connected chain, crossing loops (e.g. a grid of bars whose rectangles intersect mid-edge but
+// share no endpoints) are returned individually and intact — unlike Profiles, whose even–odd
+// region nesting cannot represent overlapping interior loops. Callers that need a boolean of
+// loops (grill: boundary − union(bars), #863) use this instead of profile inner loops.
+func (s *Sketch) ClosedLoops() []Loop {
+	closed, _ := detectLoops(s.normalGeometry())
+	return closed
+}
+
 // openChainsOutside returns the open chains formed by entities that bound no detected
 // region — the geometry an extrude rightly rejects but a surface may consume. Entities
 // already used by a region are excluded so a dividing curve is not also reported open.


### PR DESCRIPTION
## What

Fixes the malformed cut tool / wrong boolean for a **grill with crossing bars** (a grid of ribs and spars). Such a grill produced volume ~75 instead of ~65 and was pathologically slow (~123 s).

## Root cause

The grill cut the boundary **profile**, whose inner loops the sketch's **even–odd region finder mis-forms for overlapping interior loops** — 37 spurious loops covering the wrong area (24.16 instead of the bars' 13.92). A grill's intent (`boundary − union(bars)`) is a specific boolean that no generic fill rule produces, so it must be grill-computed.

## Fix

Build the vent explicitly as **`boundary − union(bars)`**: drill each bar out of the boundary solid — a sequence of booleans that is exactly the union subtraction and is robust when bars cross. The bars come from **`Sketch.ClosedLoops`** (endpoint-chaining detection), which returns each rectangle intact even when they intersect mid-edge, unlike the region finder.

- `model/sketch`: `ClosedLoops()` exposes the chain-detected closed loops.
- `model/feature`: `GrillFeature.ventTool` drills `boundary − union(bars)`; `loopsInside` selects the bars strictly inside each boundary.

## Result

A 3+3 crossing grid now cuts the **exact** vent (boundary 49 − union 13.92 = 35.08 ⇒ a 100 wall leaves **64.92**), as a validated solid, in **0.02 s** (was ~123 s). Non-crossing grills are unchanged.

## Validation

- `go test ./model/sketch ./model/feature ./addin/... ./app` green; `golangci-lint`/SPDX clean.
- **Live-confirmed**: rendered the grid grille — a framed vent bridged by a clean 3×3 crossing rib/spar grid (16 cells), manifold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)