### PR TITLE
kernel/brep: repair boolean output orientation (M20-F01)

### DIFF
--- a/kernel/brep/boolean_orient.go
+++ b/kernel/brep/boolean_orient.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import "oblikovati.org/math"
+
+// reorientFaces repairs the global orientation of a stitched shell: it makes every face wound
+// consistently with its neighbours (each shared edge traversed in opposite directions by its two
+// faces) and then, if the shell ends up inward-facing, flips the whole thing outward. The
+// boolean classification orients each kept sub-face from its source face's normal, which is
+// correct for clean overlaps but can be flipped for some sub-faces on complex geometry — e.g. a
+// helical coil unioned onto a cylinder, where the result came back manifold-but-inconsistent.
+// For an already-consistent, outward shell this is a no-op: the flood fill flips nothing and the
+// signed volume is positive.
+func reorientFaces(faces []builtFace, verts []math.Point3) {
+	flip := orientationFlips(faces)
+	for i := range faces {
+		if flip[i] {
+			reverseFaceRings(&faces[i])
+		}
+	}
+	if signedVolume(faces, verts) < 0 {
+		for i := range faces {
+			reverseFaceRings(&faces[i])
+		}
+	}
+}
+
+// orientFlipNeighbour pairs a neighbour face with whether the shared edge is traversed the SAME
+// direction by both (which means one of them must be flipped for consistency).
+type orientFlipNeighbour struct {
+	face    int
+	sameDir bool
+}
+
+// faceAdjacency lists, per face, the faces it shares a manifold edge with and whether that edge
+// is traversed the SAME direction by both (meaning one must be flipped for consistency). Edges
+// used other than exactly twice (tangent contacts, resolved separately) are skipped.
+func faceAdjacency(faces []builtFace) [][]orientFlipNeighbour {
+	adj := make([][]orientFlipNeighbour, len(faces))
+	for _, us := range collectEdgeUses(faces) {
+		if len(us) != 2 {
+			continue
+		}
+		same := us[0].reversed == us[1].reversed
+		adj[us[0].face] = append(adj[us[0].face], orientFlipNeighbour{us[1].face, same})
+		adj[us[1].face] = append(adj[us[1].face], orientFlipNeighbour{us[0].face, same})
+	}
+	return adj
+}
+
+// orientationFlips two-colours the face-adjacency graph (BFS over each connected shell) so that,
+// after flipping the marked faces, every shared edge is traversed in opposite directions.
+func orientationFlips(faces []builtFace) []bool {
+	adj := faceAdjacency(faces)
+	flip := make([]bool, len(faces))
+	seen := make([]bool, len(faces))
+	for s := range faces {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		for q := []int{s}; len(q) > 0; {
+			f := q[0]
+			q = q[1:]
+			for _, e := range adj[f] {
+				if seen[e.face] {
+					continue
+				}
+				seen[e.face] = true
+				flip[e.face] = flip[f] != e.sameDir // consistency: flip[nbr] = flip[f] XOR sameDir
+				q = append(q, e.face)
+			}
+		}
+	}
+	return flip
+}
+
+// reverseFaceRings flips a face by reversing the winding of all its loop rings and negating its
+// stored outward normal.
+func reverseFaceRings(f *builtFace) {
+	for ri := range f.rings {
+		r := f.rings[ri]
+		for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+			r[i], r[j] = r[j], r[i]
+		}
+	}
+	f.normal = f.normal.Scale(-1)
+}
+
+// signedVolume is six times the signed volume of the shell (sum of origin-tetrahedra over each
+// outer ring's fan triangulation). Its sign tells whether the consistently-wound shell faces
+// outward (positive) or inward (negative); holes are omitted as they do not change the sign.
+func signedVolume(faces []builtFace, verts []math.Point3) float64 {
+	var v float64
+	for _, f := range faces {
+		if len(f.rings) == 0 || len(f.rings[0]) < 3 {
+			continue
+		}
+		r := f.rings[0]
+		a := asVec(verts[r[0]])
+		for i := 1; i+1 < len(r); i++ {
+			v += a.Dot(asVec(verts[r[i]]).Cross(asVec(verts[r[i+1]])))
+		}
+	}
+	return v
+}
+
+func asVec(p math.Point3) math.Vector3 { return math.V3(p.X, p.Y, p.Z) }

--- a/kernel/brep/boolean_orient_test.go
+++ b/kernel/brep/boolean_orient_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestReorientFacesMakesConsistentOutward is the unit regression for the boolean orientation
+// repair (M20-F01): given a closed shell whose faces are wound inconsistently — the state the
+// boolean classification can leave on complex geometry such as a helical coil unioned onto a
+// cylinder — reorientFaces must flood-fill a consistent winding (every shared edge traversed in
+// opposite directions by its two faces) and flip the whole shell outward (positive volume).
+func TestReorientFacesMakesConsistentOutward(t *testing.T) {
+	verts := []math.Point3{
+		math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0),
+		math.P3(0, 0, 1), math.P3(1, 0, 1), math.P3(1, 1, 1), math.P3(0, 1, 1),
+	}
+	// The six quad faces of the unit cube, wound HAPHAZARDLY (some CW, some CCW) so adjacent
+	// faces disagree across their shared edges — the inconsistency the repair must resolve.
+	rings := [][]int{
+		{0, 1, 2, 3}, // bottom
+		{4, 5, 6, 7}, // top
+		{0, 1, 5, 4}, // y=0
+		{3, 2, 6, 7}, // y=1
+		{0, 3, 7, 4}, // x=0
+		{1, 2, 6, 5}, // x=1
+	}
+	faces := make([]builtFace, len(rings))
+	for i, r := range rings {
+		faces[i] = builtFace{rings: [][]int{r}, normal: math.V3(0, 0, 1)}
+	}
+
+	reorientFaces(faces, verts)
+
+	for e, us := range collectEdgeUses(faces) {
+		if len(us) != 2 {
+			t.Fatalf("edge %v used %d times, want 2 (a closed shell)", e, len(us))
+		}
+		if us[0].reversed == us[1].reversed {
+			t.Errorf("edge %v still traversed the same way by both faces after reorient", e)
+		}
+	}
+	if v := signedVolume(faces, verts); v <= 0 {
+		t.Errorf("signed volume = %g after reorient, want > 0 (outward-facing shell)", v)
+	}
+}

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -44,6 +44,7 @@ func stitch(faces []subFace) (*topo.Body, math.Vector3, error) {
 			out[fi].rings[ri] = splitRingTJunctions(out[fi].rings[ri], w.points)
 		}
 	}
+	reorientFaces(out, w.points)
 	body, away := assemble(w.points, out)
 	return body, away, nil
 }


### PR DESCRIPTION
## What & why

A union of intricate geometry could come back **manifold and closed but with inconsistent face orientation** — a closed shell with some faces' normals flipped — which `ops.Validate` rejects (orientation), so the result was unusable.

Surfaced while porting a **threaded rod** for the NopSCADlib sweep: a helical **coil JOINED onto a core cylinder** produced exactly this (orientation inconsistent, regardless of turn count; not a regression — reproduces on pre-#871 `develop` too).

The boolean classification orients each kept sub-face from its source face's normal — correct for clean overlaps, but able to flip individual sub-faces on complex geometry.

## How

The stitch now runs a final orientation repair (`reorientFaces`):
1. **Flood-fill** the face-adjacency graph (faces sharing a manifold edge) so every shared edge is traversed in **opposite directions** by its two faces — a globally consistent winding.
2. **Flip the whole shell outward** when its signed volume comes out negative.

For an already-consistent, outward result it is a **no-op** (the flood fill flips nothing, the volume is positive), so existing booleans are unaffected.

## Effect

- The coil feature's `join` can now build threaded parts: a coil-joined helical thread on a cylinder is a valid solid for non-self-intersecting pitches. (Fine pitches whose coils overlap still leave open edges — a separate self-intersection issue, not orientation.)

## Tests

- New `kernel/brep/boolean_orient_test.go`: a haphazardly-wound cube → consistent + outward.
- Full `go test ./kernel/... ./model/... ./addin/...` green (37 packages), `-race` clean on `kernel/brep` + `kernel/ops`, `golangci-lint` 0 issues, `gofmt` clean.
- Integration: the threaded-rod port over the bridge (coil-join → valid solid).

Related: M20-F01 (#453), boolean-robustness line (#470, #871).

🤖 Generated with [Claude Code](https://claude.com/claude-code)