### PR TITLE
kernel/brep: weld coincident vertices across grid-cell boundaries (#879)

### DIFF
--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -226,6 +226,10 @@ func buildEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, edgeU
 	return edges
 }
 
+// weldGrid is the coincidence tolerance for merging stitched vertices (cm). Points within it
+// are the same vertex.
+const weldGrid = 1e-6
+
 // welder3 merges coincident 3D points onto a shared index list.
 type welder3 struct {
 	index  map[[3]int64]int
@@ -234,13 +238,25 @@ type welder3 struct {
 
 func newWelder3() *welder3 { return &welder3{index: map[[3]int64]int{}} }
 
+// add returns the index of the welded vertex for p, merging it with any existing vertex within
+// weldGrid. The point is hashed to a grid cell, but the 26 neighbouring cells are also searched:
+// two coincident points either side of a cell boundary hash to different cells, so a cell-exact
+// lookup would leave them unmerged — the failure that shredded dense self-proximate geometry
+// (a fine-pitch coil-join) into unpaired, coincident open edges (#879).
 func (w *welder3) add(p math.Point3) int {
-	const grid = 1e-6
-	k := [3]int64{int64(stdmath.Round(p.X / grid)), int64(stdmath.Round(p.Y / grid)), int64(stdmath.Round(p.Z / grid))}
-	if i, ok := w.index[k]; ok {
-		return i
+	cx := int64(stdmath.Round(p.X / weldGrid))
+	cy := int64(stdmath.Round(p.Y / weldGrid))
+	cz := int64(stdmath.Round(p.Z / weldGrid))
+	for dx := int64(-1); dx <= 1; dx++ {
+		for dy := int64(-1); dy <= 1; dy++ {
+			for dz := int64(-1); dz <= 1; dz++ {
+				if i, ok := w.index[[3]int64{cx + dx, cy + dy, cz + dz}]; ok && w.points[i].DistanceTo(p) <= weldGrid {
+					return i
+				}
+			}
+		}
 	}
-	w.index[k] = len(w.points)
+	w.index[[3]int64{cx, cy, cz}] = len(w.points)
 	w.points = append(w.points, p)
 	return len(w.points) - 1
 }

--- a/kernel/brep/boolean_weld_test.go
+++ b/kernel/brep/boolean_weld_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestWelder3MergesAcrossGridBoundary is the unit regression for #879: two coincident points
+// that hash to DIFFERENT grid cells (they straddle a cell boundary) must still weld to one
+// vertex. The cell-exact lookup used before left such pairs unmerged, which shredded dense
+// self-proximate geometry (a fine-pitch coil-join) into coincident, unpaired open edges.
+func TestWelder3MergesAcrossGridBoundary(t *testing.T) {
+	w := newWelder3()
+	// 0.00050049 and 0.00050051 are 2e-8 cm apart (well within weldGrid) but round to cells
+	// 500 and 501 — opposite sides of a 1e-6 grid boundary.
+	a := w.add(math.P3(0.00050049, 0, 0))
+	b := w.add(math.P3(0.00050051, 0, 0))
+	if a != b {
+		t.Errorf("coincident points across a grid boundary welded to %d and %d, want one vertex", a, b)
+	}
+	// A point farther than weldGrid stays a distinct vertex.
+	if c := w.add(math.P3(0.01, 0, 0)); c == a {
+		t.Errorf("a point %g cm away merged with the first; weld tolerance is %g", 0.01, weldGrid)
+	}
+}

--- a/model/feature/coil_join_fine_pitch_test.go
+++ b/model/feature/coil_join_fine_pitch_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// coreDiscSketch is a faceted disc of radius r on XY — a thread core profile.
+func coreDiscSketch(r float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	s.Circles().AddByCenterRadius(math.P2(0, 0), r)
+	return s
+}
+
+// roundThreadSketch is a round wire of radius wireR centred at radius meanR — a coil thread.
+func roundThreadSketch(meanR, wireR float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	s.Circles().AddByCenterRadius(math.P2(meanR, 0), wireR)
+	return s
+}
+
+// TestCoilJoinFinePitchWatertight is the integration regression for #879. A helical thread
+// coiled onto a core and JOINED produced a body shredded into coincident, unpaired OPEN edges
+// at fine pitch — the dense self-proximate geometry put thousands of coincident vertices on
+// opposite sides of the stitch weld grid's cell boundaries, so they failed to merge. The weld
+// now searches neighbouring cells, so the coil-join is one watertight solid across the pitches
+// of a real thread (the 3 mm pitch on a Ø6 core was the worst case: ~9600 open edges before).
+func TestCoilJoinFinePitchWatertight(t *testing.T) {
+	for _, pitch := range []float64{0.4, 0.3, 0.25, 0.2} { // cm: 4, 3, 2.5, 2 mm
+		fs := NewPartFeatures(nil, nil)
+		NewExtrudeFeatures(fs).AddByDistanceExtent(coreDiscSketch(0.3), 0, ops.NewBody, func() float64 { return 1.2 })
+		NewCoilFeatures(fs).AddDefinition(&CoilDefinition{
+			Sketch: roundThreadSketch(0.35, 0.1), Axis: zWorkAxis(),
+			Pitch: angleConst(pitch), Height: angleConst(1.2), Operation: ops.Join,
+		})
+		fs.Recompute()
+
+		bodies := fs.Result()
+		if len(bodies) != 1 {
+			t.Fatalf("pitch %g cm: coil-join produced %d bodies, want 1", pitch, len(bodies))
+		}
+		open := 0
+		for _, e := range bodies[0].Edges() {
+			if len(e.Faces()) < 2 {
+				open++
+			}
+		}
+		if r := ops.Validate(bodies[0]); !r.Valid || !r.Closed || open != 0 {
+			t.Errorf("pitch %g cm: threaded rod not watertight: valid=%v closed=%v open=%d",
+				pitch, r.Valid, r.Closed, open)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #879.

## What & why

The stitch welds coincident vertices by hashing each to a **1e-6 cm grid cell** and merging points that share a cell. Two coincident points on opposite sides of a cell boundary hash to **different** cells, so the cell-exact lookup left them unmerged.

That boundary case is rare for most geometry, but **dense self-proximate geometry hits it constantly**: a fine-pitch helical thread **coil-JOINED** onto a core cylinder (a threaded rod) put thousands of coincident vertices on cell boundaries → they didn't weld → **coincident, unpaired open edges**. A 3 mm-pitch thread on a Ø6 core came back with ~9600 open edges (`closed=false`); the part was not watertight. (Non-monotonic in pitch — only the pitches whose vertices happened to land on boundaries failed.)

## How

`welder3.add` now also searches the **26 neighbouring cells**, merging any existing vertex within `weldGrid` regardless of which cell it hashed to. The **tolerance is unchanged** (1e-6 cm) — only its application is made boundary-robust — so it can only fix under-welding, never over-merge beyond the existing tolerance.

## Effect

A coil-join is now **one watertight solid across the pitches of a real thread** (verified 4 / 3 / 2.5 / 2 mm on a Ø6 core, all `valid, closed, 0 open edges`).

## Tests

- `kernel/brep/boolean_weld_test.go`: two coincident points straddling a grid boundary weld to one vertex; a far point stays distinct.
- `model/feature/coil_join_fine_pitch_test.go`: a threaded rod is watertight at 4/3/2.5/2 mm pitch.
- Full `go test ./kernel/... ./model/... ./addin/...` green (37 packages), `-race` clean, `golangci-lint` 0 issues, gofmt clean. No measurable perf change.

Related: M20-F01 (#453), boolean robustness (#470, #871, #877).

🤖 Generated with [Claude Code](https://claude.com/claude-code)