### PR TITLE
fix(loft): correct elongated-section volume and twisted closed-loft seam

### DIFF
--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -71,6 +71,16 @@ func alignSections(sections [][]math.Point3) [][]math.Point3 {
 
 // rotateToBestOffset returns cur cyclically shifted to the offset minimizing Σ|ref[k]−cur[k]|².
 func rotateToBestOffset(ref, cur []math.Point3) []math.Point3 {
+	return rotateLoop(cur, bestLoopOffset(ref, cur))
+}
+
+// bestLoopOffset is the cyclic shift of cur that minimizes Σ|ref[k]−cur[(k+off)]|² — the start
+// offset that best lines cur up with ref. For a CLOSED loft it is also the loop's correspondence
+// monodromy: going once around a twisted closed loft, index k returns shifted by this offset (e.g.
+// half the points for a 180°-twisted Möbius band, whose rectangular section maps onto itself under
+// that shift). The closure (blend + mesh wrap) must apply it, or the wrap crams the whole twist
+// into one segment — the seam notch.
+func bestLoopOffset(ref, cur []math.Point3) int {
 	n := len(cur)
 	best, bestCost := 0, stdmath.Inf(1)
 	for off := 0; off < n; off++ {
@@ -83,14 +93,32 @@ func rotateToBestOffset(ref, cur []math.Point3) []math.Point3 {
 			bestCost, best = cost, off
 		}
 	}
-	if best == 0 {
-		return cur
+	return best
+}
+
+// closureShift is the wrap correspondence offset of a closed section sequence: 0 for an open or
+// trivially-closing loft, else the best alignment of the last section back onto the first. It is
+// the monodromy the blend and the mesh wrap must apply so a twisted closed loft (a Möbius band)
+// closes seamlessly instead of pinching at the seam. A non-twisted closed loft (a full revolve,
+// an untwisted ring) returns 0, so existing closed sweeps are unaffected.
+func closureShift(sections [][]math.Point3, closed bool) int {
+	if !closed || len(sections) < 3 {
+		return 0
 	}
-	res := make([]math.Point3, n)
+	return bestLoopOffset(sections[len(sections)-1], sections[0])
+}
+
+// rotateVecLoop is rotateLoop for a tangent array (cyclically shifts so index off becomes 0).
+func rotateVecLoop(vecs []math.Vector3, off int) []math.Vector3 {
+	if off == 0 {
+		return vecs
+	}
+	n := len(vecs)
+	out := make([]math.Vector3, n)
 	for k := 0; k < n; k++ {
-		res[k] = cur[(k+best)%n]
+		out[k] = vecs[(k+off)%n]
 	}
-	return res
+	return out
 }
 
 // splineSections inserts loftSegmentSamples interpolated sub-sections between each consecutive
@@ -99,12 +127,12 @@ func rotateToBestOffset(ref, cur []math.Point3) []math.Point3 {
 // dictated by their end condition (Free keeps the natural Catmull-Rom tangent, so an all-Free
 // loft is the same ruled/curved blend as before — see loftEnds). Corresponding points must
 // already be aligned.
-func splineSections(sections [][]math.Point3, closed bool, ends loftEnds) [][]math.Point3 {
+func splineSections(sections [][]math.Point3, closed bool, ends loftEnds, wrapShift int) [][]math.Point3 {
 	m := len(sections)
 	if m < 2 || loftSegmentSamples < 2 {
 		return sections
 	}
-	return hermiteBlend(sections, sectionTangents(sections, closed, ends), closed)
+	return hermiteBlend(sections, sectionTangents(sections, closed, ends, wrapShift), closed, wrapShift)
 }
 
 // railGuide deforms the densified sections so the loft follows guide rails (the kLoftWithRails
@@ -335,7 +363,7 @@ func resamplePath(poly []math.Point3, count int) []math.Point3 {
 // (half the chord from the previous to the next section) at interior sections, overridden at
 // the first/last section by an angled end condition. Feeding these to a Hermite blend with the
 // Catmull-Rom tangents reproduces the Catmull-Rom curve exactly, so Free ends are unchanged.
-func sectionTangents(sections [][]math.Point3, closed bool, ends loftEnds) [][]math.Vector3 {
+func sectionTangents(sections [][]math.Point3, closed bool, ends loftEnds, wrapShift int) [][]math.Vector3 {
 	m, n := len(sections), len(sections[0])
 	idx := func(i int) int {
 		if closed {
@@ -343,11 +371,25 @@ func sectionTangents(sections [][]math.Point3, closed bool, ends loftEnds) [][]m
 		}
 		return clampInt(i, 0, m-1)
 	}
+	// Across the closed seam (between section m-1 and 0) the correspondence is offset by the
+	// monodromy wrapShift, so a periodic neighbour's matching point is reindexed by it. Without this
+	// the Catmull-Rom tangent at the seam sections points across the cross-section (a kink/crease at
+	// the seam) instead of along the loop.
+	corr := func(j, shift int) int { return ((j+shift)%n + n) % n }
 	tan := make([][]math.Vector3, m)
 	for i := 0; i < m; i++ {
 		tan[i] = make([]math.Vector3, n)
+		predShift, succShift := 0, 0
+		if closed && i == 0 {
+			predShift = -wrapShift // stepping back to section m-1 crosses the seam
+		}
+		if closed && i == m-1 {
+			succShift = wrapShift // stepping forward to section 0 crosses the seam
+		}
 		for j := 0; j < n; j++ {
-			tan[i][j] = sections[idx(i-1)][j].VectorTo(sections[idx(i+1)][j]).Scale(0.5)
+			p := sections[idx(i-1)][corr(j, predShift)]
+			q := sections[idx(i+1)][corr(j, succShift)]
+			tan[i][j] = p.VectorTo(q).Scale(0.5)
 		}
 	}
 	if !closed {
@@ -512,7 +554,11 @@ func unitOrFallback(v, fallback math.Vector3) math.Vector3 {
 
 // hermiteBlend samples a cubic Hermite spline through each corresponding-point track, using the
 // per-section tangents, into loftSegmentSamples sub-sections per segment (periodic when closed).
-func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool) [][]math.Point3 {
+// For a closed loft with a correspondence monodromy (wrapShift != 0 — a twisted band such as a
+// Möbius), the closing segment blends toward the start section REINDEXED by wrapShift, so the wrap
+// is a small twist (one step) instead of cramming the whole accumulated twist into one segment.
+// sweptSolid's mesh wrap applies the same shift, so the two stay consistent.
+func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool, wrapShift int) [][]math.Point3 {
 	m := len(sections)
 	segs := m - 1
 	if closed {
@@ -521,14 +567,17 @@ func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool) [
 	out := make([][]math.Point3, 0, 1+segs*loftSegmentSamples)
 	out = append(out, sections[0])
 	for i := 0; i < segs; i++ {
-		i1 := (i + 1) % m
-		n := segmentSamples(sections[i], sections[i1], tan[i], tan[i1])
+		p1, t1 := sections[(i+1)%m], tan[(i+1)%m]
+		if closed && i == segs-1 && wrapShift != 0 { // the wrap: aim at the start reindexed by the monodromy
+			p1, t1 = rotateLoop(sections[0], wrapShift), rotateVecLoop(tan[0], wrapShift)
+		}
+		n := segmentSamples(sections[i], p1, tan[i], t1)
 		for s := 1; s <= n; s++ {
-			out = append(out, hermiteSection(sections[i], sections[i1], tan[i], tan[i1], float64(s)/float64(n)))
+			out = append(out, hermiteSection(sections[i], p1, tan[i], t1, float64(s)/float64(n)))
 		}
 	}
 	if closed {
-		out = out[:len(out)-1] // the final sample equals sections[0]; drop it (sweptSolid closes the loop)
+		out = out[:len(out)-1] // the final sample equals the (reindexed) start; drop it (sweptSolid closes the loop)
 	}
 	return out
 }

--- a/model/feature/loft_skin_test.go
+++ b/model/feature/loft_skin_test.go
@@ -39,7 +39,7 @@ func TestAlignSectionsUntwists(t *testing.T) {
 func TestSplineTwoSectionsIsRuled(t *testing.T) {
 	tri0 := sq(0, [2]float64{0, 0}, [2]float64{2, 0}, [2]float64{1, 2})
 	tri1 := sq(3, [2]float64{0, 0}, [2]float64{2, 0}, [2]float64{1, 2})
-	out := splineSections([][]math.Point3{tri0, tri1}, false, loftEnds{})
+	out := splineSections([][]math.Point3{tri0, tri1}, false, loftEnds{}, 0)
 	if len(out) < 6 {
 		t.Fatalf("2-section loft densified to %d sections, want many", len(out))
 	}
@@ -59,7 +59,7 @@ func TestSplineThreeSectionsBulges(t *testing.T) {
 	tri := func(z, dx float64) []math.Point3 {
 		return sq(z, [2]float64{dx, 0}, [2]float64{dx + 2, 0}, [2]float64{dx + 1, 2})
 	}
-	out := splineSections([][]math.Point3{tri(0, 0), tri(1, 1), tri(2, 0)}, false, loftEnds{})
+	out := splineSections([][]math.Point3{tri(0, 0), tri(1, 1), tri(2, 0)}, false, loftEnds{}, 0)
 	// The end sections sit at dx=0; a ruled (straight) blend would keep x of point0 at 0
 	// throughout. The spline must reach the middle's dx=1 and stay between.
 	var maxX float64

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -600,7 +600,10 @@ func skinnedSections(loops [][]math.Point3, n int, closed bool, ends loftEnds, g
 	// even when finely sampled along the length. Subdivide each section edge (corner-preserving)
 	// proportional to the twist, so the skin is narrow enough across its width to read smooth.
 	aligned = densifyAround(aligned, aroundSubdivisions(aligned, closed))
-	secs := splineSections(aligned, closed, ends)
+	// A closed loft that twists comes back with a correspondence shift (the monodromy): the closing
+	// segment blends toward the start REINDEXED by it, so the wrap is one small twist, not a crammed
+	// 180° pinch (the Möbius seam notch). sweptSolid applies the same shift to the mesh wrap.
+	secs := splineSections(aligned, closed, ends, closureShift(aligned, closed))
 	secs = areaGraphScale(secs, guides.areaGraph)
 	secs = centerlineGuide(secs, guides.centerline)
 	return railGuide(secs, guides.rails)
@@ -698,37 +701,73 @@ func centroidOf(pts []math.Point3) math.Point3 {
 	return math.P3(sx/n, sy/n, sz/n)
 }
 
-// resampleLoop returns n points spaced evenly by arc length around the closed polygon, so
-// sections of differing vertex counts blend point-for-point. A degenerate loop (a point section,
-// or all-coincident points) expands to n copies of its point — an apex the mesher welds to one
-// vertex, so a loft to a point skins a cone/dome.
+// resampleLoop returns n points around the closed polygon that PRESERVE its original vertices
+// (corners) and fill the remaining budget with collinear points along the edges (proportional to
+// edge length), so an elongated polygon keeps its exact shape and area. A plain arc-length
+// resample lands samples mid-edge and cuts the corners off any non-square polygon: a 16×2 mm
+// rectangle resampled to 4 points became an 18 mm² quad (0.5625× its 32 mm² area), which then
+// under-filled every swept solid's volume by the same factor (Oblikovati loft volume deficit,
+// found 2026-06-15). Because interior points are collinear, the shape (and area) is unchanged;
+// because every loop is resampled to the same n, sections of differing vertex counts still blend
+// point-for-point. maxLoopCount guarantees n >= len(poly), so the densest loop (n == m) is
+// returned verbatim. A degenerate loop (a point section) expands to n copies of its point — an
+// apex the mesher welds to one vertex, so a loft to a point skins a cone/dome.
 func resampleLoop(poly []math.Point3, n int) []math.Point3 {
+	m := len(poly)
 	segLen, total := loopSegmentLengths(poly)
-	if total == 0 {
+	if m == 0 || total == 0 { // a point/apex section: n copies of its point
 		out := make([]math.Point3, n)
 		for k := range out {
-			out[k] = poly[0]
+			if m > 0 {
+				out[k] = poly[0]
+			}
 		}
 		return out
 	}
-	m := len(poly)
-	out := make([]math.Point3, n)
-	step := total / float64(n)
-	seg, acc := 0, 0.0
-	for k := 0; k < n; k++ {
-		target := step * float64(k)
-		for seg < m-1 && acc+segLen[seg] < target {
-			acc += segLen[seg]
-			seg++
+	if n <= m { // the densest loop (n == m): keep its corners exactly (n < m can't occur, see above)
+		return append([]math.Point3(nil), poly...)
+	}
+	interior := edgeInteriorCounts(segLen, total, n-m)
+	out := make([]math.Point3, 0, n)
+	for i := 0; i < m; i++ {
+		a, b := poly[i], poly[(i+1)%m]
+		out = append(out, a) // the corner — always preserved
+		for t := 1; t <= interior[i]; t++ {
+			f := math.Scalar(float64(t) / float64(interior[i]+1))
+			out = append(out, a.TranslateBy(a.VectorTo(b).Scale(f)))
 		}
-		f := 0.0
-		if segLen[seg] > 0 {
-			f = (target - acc) / segLen[seg]
-		}
-		a, b := poly[seg], poly[(seg+1)%m]
-		out[k] = a.TranslateBy(a.VectorTo(b).Scale(f))
 	}
 	return out
+}
+
+// edgeInteriorCounts apportions `extra` interior points across edges of the given lengths,
+// proportional to length (largest-remainder rounding so the counts sum to exactly extra) — longer
+// edges get more in-between samples. Used by resampleLoop to upsample a loop without moving its
+// corners.
+func edgeInteriorCounts(segLen []float64, total float64, extra int) []int {
+	counts := make([]int, len(segLen))
+	if extra <= 0 || total <= 0 {
+		return counts
+	}
+	rema := make([]float64, len(segLen))
+	assigned := 0
+	for i, l := range segLen {
+		ideal := float64(extra) * l / total
+		counts[i] = int(ideal) // floor (ideal >= 0)
+		rema[i] = ideal - float64(counts[i])
+		assigned += counts[i]
+	}
+	for ; assigned < extra; assigned++ { // hand the leftover to the biggest remainders
+		best := 0
+		for i := 1; i < len(rema); i++ {
+			if rema[i] > rema[best] {
+				best = i
+			}
+		}
+		counts[best]++
+		rema[best] = -1 // don't pick the same edge twice
+	}
+	return counts
 }
 
 // loopSegmentLengths returns each edge length of the closed polygon and their total.

--- a/model/feature/sweep_loft_test.go
+++ b/model/feature/sweep_loft_test.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/ops"
@@ -29,6 +30,192 @@ func centeredSquareOn(plane sketch.Plane, half float64) *sketch.Sketch {
 func planeAtZ(z float64) sketch.Plane {
 	p, _ := sketch.NewPlane(math.P3(0, 0, z), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
 	return p
+}
+
+// centeredRectOn returns a sketch on plane with a centered halfW×halfH rectangle (corners
+// ±halfW, ±halfH), wound counter-clockwise — an elongated section when halfW≠halfH.
+func centeredRectOn(plane sketch.Plane, halfW, halfH float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(plane)
+	c0 := s.Points().Add(math.P2(-halfW, -halfH))
+	c1 := s.Points().Add(math.P2(halfW, -halfH))
+	c2 := s.Points().Add(math.P2(halfW, halfH))
+	c3 := s.Points().Add(math.P2(-halfW, halfH))
+	s.Lines().Add(c0, c1)
+	s.Lines().Add(c1, c2)
+	s.Lines().Add(c2, c3)
+	s.Lines().Add(c3, c0)
+	return s
+}
+
+// polygonAreaXY is the shoelace area of a loop projected to the XY plane.
+func polygonAreaXY(loop []math.Point3) float64 {
+	var sum float64
+	n := len(loop)
+	for i := 0; i < n; i++ {
+		a, b := loop[i], loop[(i+1)%n]
+		sum += float64(a.X*b.Y - b.X*a.Y)
+	}
+	if sum < 0 {
+		sum = -sum
+	}
+	return sum / 2
+}
+
+// TestResampleLoopPreservesArea pins the loft volume-deficit fix (2026-06-15): resampling an
+// elongated rectangle to a common point count must NOT cut its corners. A plain arc-length
+// resample turned an 8×1 rectangle (area 8) into a 4.5-area quad (0.5625×); resampleLoop now
+// preserves the corners, so the area is unchanged whether n equals or exceeds the vertex count.
+func TestResampleLoopPreservesArea(t *testing.T) {
+	rect := []math.Point3{
+		math.P3(-4, -0.5, 0), math.P3(4, -0.5, 0), math.P3(4, 0.5, 0), math.P3(-4, 0.5, 0),
+	}
+	const want = 8.0 // 8 wide × 1 tall
+	for _, n := range []int{4, 8, 13, 32} {
+		got := polygonAreaXY(resampleLoop(rect, n))
+		if relErr(got, want) > 1e-9 {
+			t.Errorf("resampleLoop(8×1 rect, n=%d) area = %g, want %g (corners must be preserved)", n, got, want)
+		}
+		if len(resampleLoop(rect, n)) != n {
+			t.Errorf("resampleLoop(rect, n=%d) returned %d points, want %d", n, len(resampleLoop(rect, n)), n)
+		}
+	}
+}
+
+// mobiusSectionLoops builds n elongated-rectangle cross-sections around a ring of radius R, each
+// twisted by `turns`·azimuth (turns=0.5 → a 0→180° half-twist = a Möbius band; turns=0 → a flat
+// untwisted ring). W is the band width, T its thickness. CCW in the width/thickness frame.
+func mobiusSectionLoops(n int, radius, width, thick, turns float64) [][]math.Point3 {
+	loops := make([][]math.Point3, n)
+	for i := 0; i < n; i++ {
+		u := 2 * stdmath.Pi * float64(i) / float64(n)
+		a := u * turns
+		cu, su := stdmath.Cos(u), stdmath.Sin(u)
+		ca, sa := stdmath.Cos(a), stdmath.Sin(a)
+		w := math.V3(ca*cu, ca*su, sa)        // width direction
+		td := math.V3(-sa*cu, -sa*su, ca)     // thickness direction
+		c := math.P3(radius*cu, radius*su, 0) // section centre on the ring
+		hw, ht := width/2, thick/2
+		loops[i] = []math.Point3{
+			c.TranslateBy(w.Scale(-hw)).TranslateBy(td.Scale(-ht)),
+			c.TranslateBy(w.Scale(hw)).TranslateBy(td.Scale(-ht)),
+			c.TranslateBy(w.Scale(hw)).TranslateBy(td.Scale(ht)),
+			c.TranslateBy(w.Scale(-hw)).TranslateBy(td.Scale(ht)),
+		}
+	}
+	return loops
+}
+
+// TestClosureShiftDetectsMonodromy pins the seam fix's core: a closed loft that twists 180° over a
+// 180°-symmetric (rectangular) section comes back shifted by half its points; an untwisted ring
+// does not. The closure (blend + mesh wrap) applies this offset so the seam doesn't pinch.
+func TestClosureShiftDetectsMonodromy(t *testing.T) {
+	if got := closureShift(mobiusSectionLoops(12, 30, 16, 2, 0.5), true); got != 2 {
+		t.Errorf("closureShift(Möbius rects) = %d, want 2 (rectangle 180° monodromy)", got)
+	}
+	if got := closureShift(mobiusSectionLoops(12, 30, 16, 2, 0), true); got != 0 {
+		t.Errorf("closureShift(untwisted ring) = %d, want 0", got)
+	}
+	if got := closureShift(mobiusSectionLoops(12, 30, 16, 2, 0.5), false); got != 0 {
+		t.Errorf("closureShift(open loft) = %d, want 0 (no wrap)", got)
+	}
+}
+
+// TestClosedMobiusLoftClosesWithoutCram is the seam-notch regression: a closed loft twisting 180°
+// around a ring must close as a clean watertight solid (volume ≈ W·T·2πR) AND must NOT cram the
+// whole twist into the wrap segment — the old behaviour blew the wrap up to loftMaxSegmentSamples
+// (a pinched notch); the monodromy-aware closure keeps every segment at the floor.
+func TestClosedMobiusLoftClosesWithoutCram(t *testing.T) {
+	const n, R, W, T = 36, 30.0, 16.0, 2.0
+	loops := mobiusSectionLoops(n, R, W, T, 0.5)
+
+	secs := skinnedSections(loops, maxLoopCount(loops), true, loftEnds{}, loftGuides{})
+	if len(secs) > n*(loftSegmentSamples+2) { // ~n·floor with the fix; a crammed wrap balloons this
+		t.Errorf("closed twisted loft densified to %d sections — the seam is cramming (want ≈%d)", len(secs), n*loftSegmentSamples)
+	}
+
+	body, err := skinLoops(loops, true, "mobius", loftEnds{}, loftGuides{})
+	if err != nil {
+		t.Fatalf("skinLoops: %v", err)
+	}
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("Möbius loft is not a valid solid: %+v", r)
+	}
+	wantV := W * T * 2 * stdmath.Pi * R // cross-section · centroid path length
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(v, wantV) > 0.03 {
+		t.Errorf("Möbius volume = %g, want ≈%g (W·T·2πR)", v, wantV)
+	}
+}
+
+// mobiusSectionSketch builds one Möbius cross-section as a sketch: a centered width×thick rectangle
+// on a plane at azimuth u around a ring of radius `radius`, with its in-plane axes twisted by
+// `twist` (width along cosθ·r̂+sinθ·ẑ, thickness perpendicular in the radial/axial plane) — the
+// design's fixed-frame section. The plane's xAxis is the width direction, yAxis the thickness.
+func mobiusSectionSketch(u, twist, radius, width, thick float64) *sketch.Sketch {
+	cu, su := stdmath.Cos(u), stdmath.Sin(u)
+	ca, sa := stdmath.Cos(twist), stdmath.Sin(twist)
+	wdir := math.V3(ca*cu, ca*su, sa).AsUnit()   // width direction (plane xAxis)
+	tdir := math.V3(-sa*cu, -sa*su, ca).AsUnit() // thickness direction (plane yAxis)
+	center := math.P3(radius*cu, radius*su, 0)
+	plane, _ := sketch.NewPlane(center, wdir, tdir)
+	return centeredRectOn(plane, width/2, thick/2)
+}
+
+// TestLoftMobiusStripDesign is the kernel unit test for the loft built with this project's Möbius
+// strip design parameters: 36 rectangular cross-sections (16×2 mm) on planes around a ring (R=30
+// mm), each twisted by half the azimuth (a 180° half-twist over the loop), joined by a CLOSED loft.
+// It drives the whole loft feature (profile → skin → solid) and pins the two 2026-06-15 fixes: the
+// corner-preserving resample (full cross-section → right volume) and the monodromy-aware closure
+// (seamless seam). A thin band of section w×t swept along the ring centroid (length 2πR) has
+// volume w·t·2πR and one-sided surface area ≈ 2(w+t)·2πR, independent of the twist.
+func TestLoftMobiusStripDesign(t *testing.T) {
+	const n = 36
+	const R, W, T = 3.0, 1.6, 0.2 // cm: ring 30 mm, band 16×2 mm (model units = cm)
+	fs := NewPartFeatures(nil, nil)
+	sections := make([]LoftSection, n)
+	for i := 0; i < n; i++ {
+		u := 2 * stdmath.Pi * float64(i) / float64(n)
+		sections[i] = LoftSection{Sketch: mobiusSectionSketch(u, u/2, R, W, T), ProfileIndex: 0}
+	}
+	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("Möbius loft went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("Möbius loft is not a valid solid: %+v", r)
+	}
+	props := ops.BodyGeometryProperties(body, ops.DefaultQuality())
+	if wantV := W * T * 2 * stdmath.Pi * R; relErr(props.Volume, wantV) > 0.03 { // 6.032 cm³
+		t.Errorf("Möbius volume = %g cm³, want ≈%g (w·t·2πR); ~%g would mean corners are being cut",
+			props.Volume, wantV, 0.5625*wantV)
+	}
+	if wantA := 2 * (W + T) * 2 * stdmath.Pi * R; relErr(props.Area, wantA) > 0.05 { // ≈67.86 cm²
+		t.Errorf("Möbius area = %g cm², want ≈%g (2(w+t)·2πR)", props.Area, wantA)
+	}
+}
+
+func TestLoftElongatedRectKeepsVolume(t *testing.T) {
+	// An 8×1 rectangle lofted straight from z=0 to z=5 is a prism: V = area·h = 8·5 = 40.
+	// The arc-length-resample bug skinned a 4.5-area quad → ~22.5; the corner-preserving
+	// resample restores the full cross-section.
+	fs := NewPartFeatures(nil, nil)
+	bottom := centeredRectOn(sketch.XYPlane(), 4, 0.5)
+	top := centeredRectOn(planeAtZ(5), 4, 0.5)
+	pf := NewLoftFeatures(fs).Add([]LoftSection{{Sketch: bottom, ProfileIndex: 0}, {Sketch: top, ProfileIndex: 0}}, false, ops.NewBody)
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("loft went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("lofted body is not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(v, 40) > 0.02 {
+		t.Errorf("elongated-rect prism volume = %g, want ≈40 (area 8 × height 5)", v)
+	}
 }
 
 // sketchList is a SketchIndexer over an ordered set of sketches (loft uses several).

--- a/model/feature/sweep_loft_test.go
+++ b/model/feature/sweep_loft_test.go
@@ -196,6 +196,52 @@ func TestLoftMobiusStripDesign(t *testing.T) {
 	}
 }
 
+// mobiusSectionEllipseSketch is mobiusSectionSketch with an elliptical profile: an ellipse
+// centered on the plane (semi-axes width/2 along the width direction, thick/2 across) — the
+// rounded counterpart of the rectangular Möbius section.
+func mobiusSectionEllipseSketch(u, twist, radius, width, thick float64) *sketch.Sketch {
+	cu, su := stdmath.Cos(u), stdmath.Sin(u)
+	ca, sa := stdmath.Cos(twist), stdmath.Sin(twist)
+	wdir := math.V3(ca*cu, ca*su, sa).AsUnit()
+	tdir := math.V3(-sa*cu, -sa*su, ca).AsUnit()
+	center := math.P3(radius*cu, radius*su, 0)
+	plane, _ := sketch.NewPlane(center, wdir, tdir)
+	s := sketch.NewSketches().Add(plane)
+	s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), math.Scalar(width/2), math.Scalar(thick/2))
+	return s
+}
+
+// TestLoftMobiusStripEllipseDesign is the kernel unit test for the Möbius design with an ELLIPTICAL
+// cross-section (the rectangle replaced by a 16×2 mm ellipse). A loft over a curved profile feeds
+// the corner-preserving resample a finely-sampled loop and the closure the same 180° monodromy, so
+// the rounded band must also close seamlessly with the right mass. An elliptical band of semi-axes
+// a,b swept along the ring centroid has volume π·a·b·2πR.
+func TestLoftMobiusStripEllipseDesign(t *testing.T) {
+	const n = 36
+	const R, W, T = 3.0, 1.6, 0.2 // cm: ring 30 mm, ellipse 16×2 mm
+	fs := NewPartFeatures(nil, nil)
+	sections := make([]LoftSection, n)
+	for i := 0; i < n; i++ {
+		u := 2 * stdmath.Pi * float64(i) / float64(n)
+		sections[i] = LoftSection{Sketch: mobiusSectionEllipseSketch(u, u/2, R, W, T), ProfileIndex: 0}
+	}
+	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("elliptical Möbius loft went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("elliptical Möbius loft is not a valid solid: %+v", r)
+	}
+	a, b := W/2, T/2
+	if wantV := stdmath.Pi * a * b * 2 * stdmath.Pi * R; relErr(ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume, wantV) > 0.05 {
+		got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+		t.Errorf("elliptical Möbius volume = %g cm³, want ≈%g (π·a·b·2πR)", got, wantV)
+	}
+}
+
 func TestLoftElongatedRectKeepsVolume(t *testing.T) {
 	// An 8×1 rectangle lofted straight from z=0 to z=5 is a prism: V = area·h = 8·5 = 40.
 	// The arc-length-resample bug skinned a 4.5-area quad → ~22.5; the corner-preserving

--- a/model/feature/swept.go
+++ b/model/feature/swept.go
@@ -26,7 +26,7 @@ func sweptSolid(sections [][]math.Point3, closedLoop bool, feat string) (*topo.B
 	if err := validateSections(sections, closedLoop); err != nil {
 		return nil, err
 	}
-	mesh := sectionMesh(sections, closedLoop)
+	mesh := sectionMesh(sections, closedLoop, closureShift(sections, closedLoop))
 	body := subd.ToBody(mesh, feat)
 	// A consistently-wound cage is either all-outward or all-inward; if the signed
 	// volume came out negative the cage is inside-out, so rebuild it face-reversed.
@@ -59,8 +59,10 @@ func validateSections(sections [][]math.Point3, closedLoop bool) error {
 }
 
 // sectionMesh assembles the cage: vertex (s,i) at index s*n+i, a quad per (segment,
-// cross-section edge), and start/end caps unless the sweep is a closed loop.
-func sectionMesh(sections [][]math.Point3, closedLoop bool) subd.Mesh {
+// cross-section edge), and start/end caps unless the sweep is a closed loop. wrapShift offsets
+// the cross-section index across the CLOSING segment only, so a twisted closed loft (a Möbius
+// band) joins corresponding points across the seam instead of pairing them off by the monodromy.
+func sectionMesh(sections [][]math.Point3, closedLoop bool, wrapShift int) subd.Mesh {
 	k, n := len(sections), len(sections[0])
 	verts := make([]math.Point3, 0, k*n)
 	for _, s := range sections {
@@ -73,9 +75,14 @@ func sectionMesh(sections [][]math.Point3, closedLoop bool) subd.Mesh {
 	var faces [][]int
 	for s := 0; s < segs; s++ {
 		ns := (s + 1) % k
+		shift := 0
+		if closedLoop && ns == 0 { // the wrap segment carries the loop's correspondence offset
+			shift = wrapShift
+		}
 		for i := 0; i < n; i++ {
 			j := (i + 1) % n
-			a, b, c, d := s*n+i, s*n+j, ns*n+j, ns*n+i
+			a, b := s*n+i, s*n+j
+			c, d := ns*n+(j+shift)%n, ns*n+(i+shift)%n
 			faces = append(faces, sideQuad(verts, a, b, c, d)...)
 		}
 	}


### PR DESCRIPTION
## What
Two correctness fixes for the loft/sweep skinner, found while modelling a Möbius strip:

1. **Elongated-section volume.** `resampleLoop` resampled every cross-section to a common point count purely by **arc length**, without preserving the polygon's corners. An elongated section (e.g. a 16×2 rectangle) was therefore skinned as a smaller polygon — **0.5625×** its area for that rectangle — under-filling the swept solid's volume by the same factor. It is now **corner-preserving**: original vertices are always kept, and the remaining budget is filled with collinear points apportioned along edges by length, so the cross-section keeps its exact shape and area. Affects every skinned solid (loft / tube / sweep).

2. **Twisted closed-loft seam.** A closed loft that twists comes back with a correspondence **monodromy** (a 180° half-twist of a rectangle returns shifted by half its points). The old closed wrap paired sections index-to-index, cramming the whole accumulated twist into the single wrap segment — a pinched seam (the Möbius "notch"). Guides/rails can't fix this; the wrap pairing lives in the mesher. The closure now detects the offset (`closureShift`) and applies it across the seam in the blend (`hermiteBlend`), the seam tangents (`sectionTangents`), and the mesh wrap (`sectionMesh`). Non-twisted closures (full revolve, untwisted ring) get offset 0 and are unchanged.

## Why
A thin lofted band reported ~56% of its true volume (signature: correct area, half volume), and twisted closed lofts pinched at the seam. Both are loft-correctness defects (mass properties / watertight geometry), which the repo prioritises above features.

## Tests
- `TestResampleLoopPreservesArea` — corner-preserving resample keeps an 8×1 rectangle's area at any point count.
- `TestLoftElongatedRectKeepsVolume` — an elongated-rect prism is `area·h` (was ~0.5625×).
- `TestClosureShiftDetectsMonodromy` — monodromy detected for a Möbius section, 0 for untwisted/open.
- `TestClosedMobiusLoftClosesWithoutCram`, `TestLoftMobiusStripDesign`, `TestLoftMobiusStripEllipseDesign` — the full Möbius design (rect + ellipse) is a valid watertight solid with the analytic volume.

Full `model/feature` + `kernel/ops` suites green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)