### PR TITLE
model/assembly: propagate gear ratio through the drive (fixes #883)

### DIFF
--- a/model/assembly/drive.go
+++ b/model/assembly/drive.go
@@ -50,19 +50,21 @@ func DriveJoint(occs *occurrence.Occurrences, cs *ConstraintSet, js *JointSet, j
 	if !ok {
 		return DriveResult{}, fmt.Errorf("assembly: joint %d (%s) is not drivable for variable %s", jointID, joint.kind, s.variable)
 	}
-	return sweep(occs, combinedRelationships(cs, js), joint, resolved, s), nil
+	return sweep(occs, cs, js, joint, resolved, s), nil
 }
 
-// sweep runs the value sequence, restoring the assembly afterwards. base is the assembly's
-// constraints+joints; each step appends a fresh pin so base is never mutated.
-func sweep(occs *occurrence.Occurrences, base []relationship, joint *assemblyJoint, resolved types.DriveVariable, s DriveSettings) DriveResult {
+// sweep runs the value sequence, restoring the assembly afterwards. Each step pins the driven
+// joint — and any gears it is geared to (couplingPins, #883) — onto a fresh copy of the
+// assembly's constraints+joints, so the base set is never mutated.
+func sweep(occs *occurrence.Occurrences, cs *ConstraintSet, js *JointSet, joint *assemblyJoint, resolved types.DriveVariable, s DriveSettings) DriveResult {
+	base := combinedRelationships(cs, js)
 	saved := snapshotPlacements(occs)
 	defer restorePlacements(occs, saved)
 
 	var res DriveResult
 	for i, v := range driveValues(s) {
-		pin := &drivenPin{joint: joint, resolved: resolved, value: v}
-		solveOver(occs, append(append([]relationship{}, base...), pin), true)
+		pins := couplingPins(joint, resolved, v, cs, js)
+		solveOver(occs, append(append([]relationship{}, base...), pins...), true)
 		frame := DriveFrame{Value: v, Placements: capturePlacements(occs)}
 		if s.collision && occurrencesInterfere(occs) {
 			frame.Collided = true

--- a/model/assembly/drive_coupling.go
+++ b/model/assembly/drive_coupling.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import "oblikovati.org/api/types"
+
+// Driving a joint must also turn the gears it is geared to: a rotate-rotate constraint is a
+// pure ratio that contributes no static residual (motion.go), so the static re-solve alone
+// leaves the coupled gear behind. couplingPins fixes that (#883) by adding, for each
+// rotate-rotate relationship reachable from the driven gear through the gear graph, a pin on the
+// coupled gear's own rotational joint at the ratioed angle — so a drive of one gear propagates
+// through the whole train.
+
+// rateCoupling is a rotate-rotate gear relationship reduced to its two occurrences and ratio
+// (revolutions of B per revolution of A).
+type rateCoupling struct {
+	a, b  uint64
+	ratio float64
+}
+
+// partner returns the occurrence coupled to occ and the angle it turns through (occ turns val;
+// its partner turns val·ratio when occ is A, val/ratio when occ is B), or ok=false when the
+// coupling does not touch occ.
+func (c rateCoupling) partner(occ uint64, val float64) (uint64, float64, bool) {
+	switch occ {
+	case c.a:
+		return c.b, val * c.ratio, true
+	case c.b:
+		if c.ratio == 0 {
+			return 0, 0, false
+		}
+		return c.a, val / c.ratio, true
+	}
+	return 0, 0, false
+}
+
+// couplingPins returns the drive pins for one step: the driven joint pinned to v, plus — for
+// every gear reachable from it through rotate-rotate constraints — a pin on that gear's own
+// rotational joint at the ratioed angle, so a geared train is driven as a whole, not just the
+// one joint (#883). Without any rotate-rotate constraint it is exactly the single driven pin.
+func couplingPins(driver *assemblyJoint, resolved types.DriveVariable, v float64, cs *ConstraintSet, js *JointSet) []relationship {
+	pins := []relationship{&drivenPin{joint: driver, resolved: resolved, value: v}}
+	couplings := rateCouplings(cs)
+	if len(couplings) == 0 {
+		return pins
+	}
+	return append(pins, gearTrainPins(movingOccID(driver), v, couplings, rotationalJointByMovingOccurrence(js))...)
+}
+
+// gearPin is one occurrence reached through the gear graph and the angle it turns.
+type gearPin struct {
+	occ uint64
+	val float64
+}
+
+// gearTrainPins walks the gear graph breadth-first from the driven occurrence and returns a pin
+// for each coupled gear's rotational joint at its ratioed angle (each gear visited once).
+func gearTrainPins(start uint64, v float64, couplings []rateCoupling, byOcc map[uint64]*assemblyJoint) []relationship {
+	var pins []relationship
+	visited := map[uint64]bool{start: true}
+	for queue := []gearPin{{start, v}}; len(queue) > 0; {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, c := range couplings {
+			next, val, ok := c.partner(cur.occ, cur.val)
+			if !ok || visited[next] {
+				continue
+			}
+			j, ok := byOcc[next]
+			if !ok {
+				continue
+			}
+			rv, drivable := drivableVariable(j.kind, types.DriveAngular)
+			if !drivable {
+				continue
+			}
+			visited[next] = true
+			pins = append(pins, &drivenPin{joint: j, resolved: rv, value: val})
+			queue = append(queue, gearPin{next, val})
+		}
+	}
+	return pins
+}
+
+// rateCouplings extracts the active rotate-rotate gear relationships from the constraint set.
+func rateCouplings(cs *ConstraintSet) []rateCoupling {
+	var out []rateCoupling
+	for _, c := range cs.All() {
+		if rr, ok := c.(*RotateRotateConstraint); ok && !rr.Suppressed() {
+			out = append(out, rateCoupling{a: rr.a.occ.ID(), b: rr.b.occ.ID(), ratio: rr.Ratio()})
+		}
+	}
+	return out
+}
+
+// rotationalJointByMovingOccurrence maps each rotational joint's moving (non-grounded)
+// occurrence to the joint, so a coupled gear's spin can be pinned through its own joint.
+func rotationalJointByMovingOccurrence(js *JointSet) map[uint64]*assemblyJoint {
+	out := map[uint64]*assemblyJoint{}
+	for _, j := range js.All() {
+		aj, ok := j.(*assemblyJoint)
+		if !ok || aj.kind != types.JointRotational {
+			continue
+		}
+		out[movingOccID(aj)] = aj
+	}
+	return out
+}
+
+// movingOccID is the id of a joint's moving occurrence — the non-grounded anchor, the gear that
+// spins (falling back to the first anchor when neither is grounded).
+func movingOccID(j *assemblyJoint) uint64 {
+	if j.a.occ.Grounded() {
+		return j.b.occ.ID()
+	}
+	return j.a.occ.ID()
+}

--- a/model/assembly/drive_coupling_test.go
+++ b/model/assembly/drive_coupling_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package assembly
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// TestDriveRotateRotatePropagatesGearRatio is the #883 regression: driving one gear of a
+// rotate-rotate–coupled pair must turn the other gear THROUGH the ratio. A driver and a driven
+// gear each spin on a grounded frame (their own rotational joints); a rotate-rotate constraint
+// gears them 2:1. Driving the driver π/4 must turn the driven gear 2×π/4. Before the
+// drive-coupling fix the driven gear did not move at all (rotate-rotate contributes no static
+// residual, so the static re-solve left it behind).
+func TestDriveRotateRotatePropagatesGearRatio(t *testing.T) {
+	occs := occurrence.NewOccurrences()
+	ground := place(occs, "ground:1", math.Identity4())
+	ground.SetGrounded(true)
+	driver := place(occs, "driver:1", math.Identity4())
+	driven := place(occs, "driven:1", math.Translation4(math.V3(10, 0, 0)))
+
+	cs := NewConstraintSet(occs, nil)
+	js := NewJointSet(occs, nil)
+	zAxis := func(o *occurrence.Occurrence, x float64) Ref {
+		return Ref{Occurrence: o, Primitive: LinePrimitive(math.P3(x, 0, 0), unit(t, 0, 0, 1))}
+	}
+	driverJoint := js.AddRotational(zAxis(ground, 0), zAxis(driver, 0))
+	js.AddRotational(zAxis(ground, 10), zAxis(driven, 10))
+	cs.AddRotateRotate(zAxis(driver, 0), zAxis(driven, 10), 2.0)
+
+	span := stdmath.Pi / 4
+	res, err := DriveJoint(occs, cs, js, driverJoint.ID(), NewDriveSettings(types.DriveAngular, 0, span, span/4, 1, false, false))
+	if err != nil {
+		t.Fatalf("DriveJoint: %v", err)
+	}
+
+	roll := func(occID uint64, frame int) float64 {
+		for _, p := range res.Frames[frame].Placements {
+			if p.Occurrence == occID {
+				return rollAboutZ(p.Transform)
+			}
+		}
+		t.Fatalf("occurrence %d absent from frame %d", occID, frame)
+		return 0
+	}
+	last := len(res.Frames) - 1
+	driverSwept := stdmath.Abs(roll(driver.ID(), last) - roll(driver.ID(), 0))
+	drivenSwept := stdmath.Abs(roll(driven.ID(), last) - roll(driven.ID(), 0))
+	if stdmath.Abs(driverSwept-span) > 1e-3 {
+		t.Errorf("driver swept %.4f rad, want %.4f", driverSwept, span)
+	}
+	if stdmath.Abs(drivenSwept-2*span) > 1e-3 {
+		t.Errorf("driven gear swept %.4f rad, want %.4f (2:1 gear ratio propagated by the drive)", drivenSwept, 2*span)
+	}
+}


### PR DESCRIPTION
Fixes #883.

## What & why

A `rotate-rotate` constraint contributes **no static residual** — it's a pure gear ratio (`motion.go`'s `bind` returns nil, with the note that *"the coupling is applied by the drive, F03"*). But the drive only pinned the driven joint's own variable and re-solved statically, so the gears geared to it stayed put: a gear train recorded its ratio yet wouldn't turn when driven. The propagation was the intended design, just never implemented.

## How

Each drive step, `couplingPins` walks the **gear graph breadth-first** from the driven occurrence through the rotate-rotate constraints and adds a pin on every reachable gear's **own rotational joint** at the ratioed angle (revolutions of B per revolution of A, inverted when traversed B→A). So driving one gear turns the whole train, at the correct ratios, through chains. A drive with no rotate-rotate constraint is unchanged (just the single driven pin) — bounding the blast radius.

## Tests

- `TestDriveRotateRotatePropagatesGearRatio`: drives a 2:1 pair and asserts the driven gear sweeps **twice** the driver's angle (it didn't move at all before).
- Full `go test ./kernel/... ./model/... ./addin/...` green (37 packages), `-race` clean on `model/assembly`, `golangci-lint` 0 issues.
- The bridge gear-train port (`nopscad_geartrain_test.go`) now logs the driven gear following (a stacked bridge change will turn that log into an assertion).

Milestone M12-F03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)