### PR TITLE
fix(loft): stop closed-twist seam from over-tessellating every section

### DIFF
--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -607,7 +607,7 @@ func segmentSamples(p0, p1 []math.Point3, m0, m1 []math.Vector3) int {
 // (no extra) for an untwisted loft, more as the loft twists, so the skin's warped quads stay
 // narrow enough to read smooth (a wide quad on a twisting surface folds steeply when split into
 // triangles, regardless of longitudinal density). Proportional to the max inter-section twist.
-func aroundSubdivisions(sections [][]math.Point3, closed bool) int {
+func aroundSubdivisions(sections [][]math.Point3, closed bool, wrapShift int) int {
 	if len(sections) < 2 {
 		return 1
 	}
@@ -618,7 +618,11 @@ func aroundSubdivisions(sections [][]math.Point3, closed bool) int {
 		}
 	}
 	if closed {
-		if a := segmentTwist(sections[len(sections)-1], sections[0]); a > maxTwist {
+		// Measure the wrap twist against the start REINDEXED by the monodromy (wrapShift); otherwise
+		// a twisted/non-orientable closure (a Möbius band) reads its seam as the full accumulated
+		// twist (~180°) and over-subdivides EVERY cross-section to "smooth" a twist that does not
+		// happen between adjacent sections — a 12× mesh blow-up on the ellipse Möbius.
+		if a := segmentTwist(sections[len(sections)-1], rotateLoop(sections[0], wrapShift)); a > maxTwist {
 			maxTwist = a
 		}
 	}

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -599,10 +599,12 @@ func skinnedSections(loops [][]math.Point3, n int, closed bool, ends loftEnds, g
 	// A twisting loft's skin quads are a full section-edge wide, so they warp steeply and facet
 	// even when finely sampled along the length. Subdivide each section edge (corner-preserving)
 	// proportional to the twist, so the skin is narrow enough across its width to read smooth.
-	aligned = densifyAround(aligned, aroundSubdivisions(aligned, closed))
-	// A closed loft that twists comes back with a correspondence shift (the monodromy): the closing
-	// segment blends toward the start REINDEXED by it, so the wrap is one small twist, not a crammed
-	// 180° pinch (the Möbius seam notch). sweptSolid applies the same shift to the mesh wrap.
+	// The wrap's correspondence is offset by the monodromy (a 180° half-twist returns shifted by
+	// half the points); the around-subdivision and the spline blend both measure the wrap twist
+	// against the start REINDEXED by that shift, else a Möbius/twisted closure reads its seam as a
+	// ~180° twist and over-subdivides every section (the seam notch's cousin — a 12× mesh blow-up).
+	shift := closureShift(aligned, closed)
+	aligned = densifyAround(aligned, aroundSubdivisions(aligned, closed, shift))
 	secs := splineSections(aligned, closed, ends, closureShift(aligned, closed))
 	secs = areaGraphScale(secs, guides.areaGraph)
 	secs = centerlineGuide(secs, guides.centerline)

--- a/model/feature/sweep_loft_test.go
+++ b/model/feature/sweep_loft_test.go
@@ -7,9 +7,34 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
+
+// closedMobiusLoftBody builds a closed Möbius loft of n cross-sections (each twisted by half its
+// azimuth) from the given section-sketch builder, asserts it is a valid solid, and returns the body
+// — the shared spine of the Möbius design tests, so they don't each repeat the section/loft loop.
+func closedMobiusLoftBody(t *testing.T, n int, radius, width, thick float64,
+	section func(u, twist, radius, width, thick float64) *sketch.Sketch) *topo.Body {
+	t.Helper()
+	fs := NewPartFeatures(nil, nil)
+	sections := make([]LoftSection, n)
+	for i := 0; i < n; i++ {
+		u := 2 * stdmath.Pi * float64(i) / float64(n)
+		sections[i] = LoftSection{Sketch: section(u, u/2, radius, width, thick), ProfileIndex: 0}
+	}
+	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("Möbius loft went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("Möbius loft is not a valid solid: %+v", r)
+	}
+	return body
+}
 
 // centeredSquareOn returns a sketch on plane with a centered square of the given half
 // width (corners ±half), wound counter-clockwise.
@@ -168,24 +193,8 @@ func mobiusSectionSketch(u, twist, radius, width, thick float64) *sketch.Sketch 
 // (seamless seam). A thin band of section w×t swept along the ring centroid (length 2πR) has
 // volume w·t·2πR and one-sided surface area ≈ 2(w+t)·2πR, independent of the twist.
 func TestLoftMobiusStripDesign(t *testing.T) {
-	const n = 36
 	const R, W, T = 3.0, 1.6, 0.2 // cm: ring 30 mm, band 16×2 mm (model units = cm)
-	fs := NewPartFeatures(nil, nil)
-	sections := make([]LoftSection, n)
-	for i := 0; i < n; i++ {
-		u := 2 * stdmath.Pi * float64(i) / float64(n)
-		sections[i] = LoftSection{Sketch: mobiusSectionSketch(u, u/2, R, W, T), ProfileIndex: 0}
-	}
-	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
-	fs.Recompute()
-
-	if !pf.Health().OK() {
-		t.Fatalf("Möbius loft went sick: %+v", pf.Health())
-	}
-	body := fs.Result()[0]
-	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
-		t.Fatalf("Möbius loft is not a valid solid: %+v", r)
-	}
+	body := closedMobiusLoftBody(t, 36, R, W, T, mobiusSectionSketch)
 	props := ops.BodyGeometryProperties(body, ops.DefaultQuality())
 	if wantV := W * T * 2 * stdmath.Pi * R; relErr(props.Volume, wantV) > 0.03 { // 6.032 cm³
 		t.Errorf("Möbius volume = %g cm³, want ≈%g (w·t·2πR); ~%g would mean corners are being cut",
@@ -217,24 +226,8 @@ func mobiusSectionEllipseSketch(u, twist, radius, width, thick float64) *sketch.
 // the rounded band must also close seamlessly with the right mass. An elliptical band of semi-axes
 // a,b swept along the ring centroid has volume π·a·b·2πR.
 func TestLoftMobiusStripEllipseDesign(t *testing.T) {
-	const n = 36
 	const R, W, T = 3.0, 1.6, 0.2 // cm: ring 30 mm, ellipse 16×2 mm
-	fs := NewPartFeatures(nil, nil)
-	sections := make([]LoftSection, n)
-	for i := 0; i < n; i++ {
-		u := 2 * stdmath.Pi * float64(i) / float64(n)
-		sections[i] = LoftSection{Sketch: mobiusSectionEllipseSketch(u, u/2, R, W, T), ProfileIndex: 0}
-	}
-	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
-	fs.Recompute()
-
-	if !pf.Health().OK() {
-		t.Fatalf("elliptical Möbius loft went sick: %+v", pf.Health())
-	}
-	body := fs.Result()[0]
-	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
-		t.Fatalf("elliptical Möbius loft is not a valid solid: %+v", r)
-	}
+	body := closedMobiusLoftBody(t, 36, R, W, T, mobiusSectionEllipseSketch)
 	a, b := W/2, T/2
 	if wantV := stdmath.Pi * a * b * 2 * stdmath.Pi * R; relErr(ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume, wantV) > 0.05 {
 		got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
@@ -248,20 +241,8 @@ func TestLoftMobiusStripEllipseDesign(t *testing.T) {
 // ~166k triangles and stalling the viewport (14 ms/frame just to flatten). The correct mesh tracks
 // the loop density (≈ longitudinal sections × ellipse points); this pins it well under the blow-up.
 func TestLoftClosedTwistMeshStaysBounded(t *testing.T) {
-	const n = 36
-	const R, W, T = 3.0, 1.6, 0.2
-	fs := NewPartFeatures(nil, nil)
-	sections := make([]LoftSection, n)
-	for i := 0; i < n; i++ {
-		u := 2 * stdmath.Pi * float64(i) / float64(n)
-		sections[i] = LoftSection{Sketch: mobiusSectionEllipseSketch(u, u/2, R, W, T), ProfileIndex: 0}
-	}
-	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
-	fs.Recompute()
-	if !pf.Health().OK() {
-		t.Fatalf("elliptical Möbius loft went sick: %+v", pf.Health())
-	}
-	mesh, _ := ops.TessellateBody(fs.Result()[0], ops.DefaultQuality())
+	body := closedMobiusLoftBody(t, 36, 3.0, 1.6, 0.2, mobiusSectionEllipseSketch)
+	mesh, _ := ops.TessellateBody(body, ops.DefaultQuality())
 	if got := mesh.TriangleCount(); got > 30000 { // correct ≈14k; the monodromy bug produced ~166k
 		t.Errorf("elliptical Möbius tessellated to %d triangles — the closed-twist seam is over-subdividing every section", got)
 	}

--- a/model/feature/sweep_loft_test.go
+++ b/model/feature/sweep_loft_test.go
@@ -242,6 +242,31 @@ func TestLoftMobiusStripEllipseDesign(t *testing.T) {
 	}
 }
 
+// TestLoftClosedTwistMeshStaysBounded guards the closed-twist over-tessellation fix: the seam
+// monodromy must NOT be read as a per-segment twist. When it was, aroundSubdivisions saw the
+// wrap as a ~180° twist and subdivided every cross-section ~12×, ballooning the ellipse Möbius to
+// ~166k triangles and stalling the viewport (14 ms/frame just to flatten). The correct mesh tracks
+// the loop density (≈ longitudinal sections × ellipse points); this pins it well under the blow-up.
+func TestLoftClosedTwistMeshStaysBounded(t *testing.T) {
+	const n = 36
+	const R, W, T = 3.0, 1.6, 0.2
+	fs := NewPartFeatures(nil, nil)
+	sections := make([]LoftSection, n)
+	for i := 0; i < n; i++ {
+		u := 2 * stdmath.Pi * float64(i) / float64(n)
+		sections[i] = LoftSection{Sketch: mobiusSectionEllipseSketch(u, u/2, R, W, T), ProfileIndex: 0}
+	}
+	pf := NewLoftFeatures(fs).Add(sections, true, ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("elliptical Möbius loft went sick: %+v", pf.Health())
+	}
+	mesh, _ := ops.TessellateBody(fs.Result()[0], ops.DefaultQuality())
+	if got := mesh.TriangleCount(); got > 30000 { // correct ≈14k; the monodromy bug produced ~166k
+		t.Errorf("elliptical Möbius tessellated to %d triangles — the closed-twist seam is over-subdividing every section", got)
+	}
+}
+
 func TestLoftElongatedRectKeepsVolume(t *testing.T) {
 	// An 8×1 rectangle lofted straight from z=0 to z=5 is a prism: V = area·h = 8·5 = 40.
 	// The arc-length-resample bug skinned a 4.5-area quad → ~22.5; the corner-preserving


### PR DESCRIPTION
## What
A closed loft that twists (a Möbius band) was tessellating ~12× more than needed: the ellipse Möbius came out **165,888 triangles** where ~13,800 suffice.

`aroundSubdivisions` takes the max cross-section twist across segments *including the closed wrap*, but measured the wrap against the **un-shifted** start section. For a twisted/non-orientable closure the wrap's correspondence is offset by the monodromy, so that raw measurement read the seam as the full accumulated twist (~180°) — even though adjacent sections only twist a few degrees — and it then subdivided **every** cross-section edge ~12× to "smooth" a twist that doesn't happen between neighbors.

Fix: measure the wrap twist against the start **reindexed by the monodromy** (`closureShift` — the same shift the blend, tangents, and mesh wrap already use). `aroundSubdiv` drops 12 → 1; **165,888 → 13,824 triangles**, identical shape/volume/appearance.

## Why
The 12× mesh blow-up made the viewport crawl (the tessellation is cached, but the per-frame flatten + GPU upload scale with triangle count). Found while profiling a Möbius part.

## Test
`TestLoftClosedTwistMeshStaysBounded` asserts the elliptical Möbius stays well under the blow-up. Full `model/feature` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)