### PR TITLE
fix(fillet): miter two-edge corners instead of rejecting them

### DIFF
--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -8,7 +8,6 @@ import (
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
-	"oblikovati.org/kernel/topo"
 )
 
 // TestFilletToolEndToEnd drives the Fillet UI: start the tool, click a vertical edge of a
@@ -74,18 +73,18 @@ func TestFilletViaRibbonCommand(t *testing.T) {
 	}
 }
 
-// TestFilletUnsupportedCornerSurfacesNotice checks that committing a fillet over an
-// unsupported corner config (two of the three edges at a vertex) fails loudly: the tool stays
-// open and the session carries a notice the status bar shows — not a silent "nothing happened".
-func TestFilletUnsupportedCornerSurfacesNotice(t *testing.T) {
+// TestFilletUnbuildableSurfacesNotice checks that committing a fillet the kernel cannot build
+// (here, a rolling-ball radius far larger than the 2×2×2 block admits — the ball centre falls
+// outside the solid) fails loudly: the tool stays open and the session carries a notice the
+// status bar shows — not a silent "nothing happened".
+func TestFilletUnbuildableSurfacesNotice(t *testing.T) {
 	s, block := newPartWithBlock(t, 2)
 	f := NewFilletTool()
 	s.StartTool(f)
-	for _, e := range cornerEdges(block)[:2] { // two of the three edges at one corner (unsupported)
-		f.Pick(s, EdgeHandle{Edge: e})
-	}
+	f.Pick(s, verticalEdgeOf(t, block))
+	f.SetRadius(10) // a 10-unit rolling ball cannot round a 2×2×2 block's edge
 	if err := s.OK(); err == nil {
-		t.Fatal("filleting an unsupported corner config should fail")
+		t.Fatal("filleting with an impossible radius should fail")
 	}
 	if s.ActiveTool() == nil {
 		t.Error("a failed commit should keep the fillet tool open")
@@ -96,18 +95,6 @@ func TestFilletUnsupportedCornerSurfacesNotice(t *testing.T) {
 	if v := ops.BodyGeometryProperties(activePartDef(t, s).SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, 8) > 1e-6 {
 		t.Errorf("body should be unchanged (vol 8) after a failed fillet, got %g", v)
 	}
-}
-
-// cornerEdges returns the three edges meeting at the (0,0,0) corner of a box.
-func cornerEdges(b *topo.Body) []*topo.Edge {
-	var out []*topo.Edge
-	for _, e := range b.Edges() {
-		a, c := e.StartVertex().Point(), e.EndVertex().Point()
-		if (a.X == 0 && a.Y == 0 && a.Z == 0) || (c.X == 0 && c.Y == 0 && c.Z == 0) {
-			out = append(out, e)
-		}
-	}
-	return out
 }
 
 // TestFilletToolNeedsEdge checks the tool is not committable until an edge is picked.

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -45,13 +45,13 @@ func FilletEdgesVarying(body *topo.Body, picks []EdgeFilletRadii) (*topo.Body, e
 	if err != nil {
 		return nil, err
 	}
-	blends, err := computeBlends(edges)
+	blends, miters, err := computeCorners(edges)
 	if err != nil {
 		return nil, err
 	}
 	fils := make([]edgeFillet, 0, len(edges))
 	for _, p := range edges {
-		ef, err := computeEdgeFillet(body, p, blends)
+		ef, err := computeEdgeFillet(body, p, blends, miters)
 		if err != nil {
 			return nil, err
 		}
@@ -102,9 +102,11 @@ type corner struct {
 	ta, tb  math.Point3
 	mid     math.Point3
 	chords  []math.Point3 // variable fillet only: the end arc as chord samples ta…tb
-	endFace *topo.Face    // the flat end cap to arc (nil at a blend corner)
+	endFace *topo.Face    // the flat end cap to arc (nil at a blend or miter corner)
 	vertex  *topo.Vertex
 	blend   bool
+	miter   bool          // two-fillet corner: the end is bounded by seam (no end face, no sphere)
+	seam    []math.Point3 // miter only: the seam chords from ta to tb, shared with the other cylinder
 }
 
 // tOf returns the tangent point on face f (a or b).
@@ -128,7 +130,7 @@ type edgeFillet struct {
 // computeEdgeFillet solves the rolling-ball geometry for one convex straight edge, using a
 // corner blend at either endpoint that is a shared corner. A varying pick gets its end arcs
 // sampled as chords (shared by the ruling strips and the end faces).
-func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend) (edgeFillet, error) {
+func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter) (edgeFillet, error) {
 	e := p.edge
 	a, b, nA, nB, err := edgePlanarFaces(e)
 	if err != nil {
@@ -144,13 +146,13 @@ func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerB
 		return edgeFillet{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
 	}
 	in := cornerInputs{a: a, b: b, nA: nA, nB: nB, offDir: offDir, axis: axis.AsVector()}
-	return solvedEdgeFillet(e, p, in, blends)
+	return solvedEdgeFillet(e, p, in, blends, miters)
 }
 
 // solvedEdgeFillet assembles the edgeFillet once the edge's frame is known: corners per end
 // radius, then either the chord-sampled varying blend or the constant cylinder.
-func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend) (edgeFillet, error) {
-	c0, c1, err := edgeCorners(e, p, in, blends)
+func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter) (edgeFillet, error) {
+	c0, c1, err := edgeCorners(e, p, in, blends, miters)
 	if err != nil {
 		return edgeFillet{}, err
 	}
@@ -167,11 +169,11 @@ func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[ui
 
 // edgeCorners solves the rounded corners at both endpoints of an edge (each blended when its
 // vertex is a shared corner), with the pick's per-end radius.
-func edgeCorners(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend) (c0, c1 corner, err error) {
-	if c0, err = cornerAt(e.StartVertex(), in, p.r0, blends[e.StartVertex().ID()]); err != nil {
+func edgeCorners(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter) (c0, c1 corner, err error) {
+	if c0, err = cornerAt(e.StartVertex(), in, p.r0, blends[e.StartVertex().ID()], miters[e.StartVertex().ID()]); err != nil {
 		return corner{}, corner{}, err
 	}
-	c1, err = cornerAt(e.EndVertex(), in, p.r1, blends[e.EndVertex().ID()])
+	c1, err = cornerAt(e.EndVertex(), in, p.r1, blends[e.EndVertex().ID()], miters[e.EndVertex().ID()])
 	return c0, c1, err
 }
 
@@ -195,13 +197,9 @@ func sampleCornerChords(c0, c1 *corner, in cornerInputs) {
 // rolling-ball contact directions at evenly spaced stations.
 func arcChords(c corner, in cornerInputs, k int) []math.Point3 {
 	r := c.cen.DistanceTo(c.ta)
-	wedge := stdmath.Acos(float64(in.nA.Dot(in.nB)))
-	sinW := stdmath.Sin(wedge)
 	out := make([]math.Point3, k+1)
 	for j := 0; j <= k; j++ {
-		s := float64(j) / float64(k)
-		dir := in.nA.Scale(stdmath.Sin((1-s)*wedge) / sinW).
-			Add(in.nB.Scale(stdmath.Sin(s*wedge) / sinW))
+		dir := slerpVec(in.nA, in.nB, float64(j)/float64(k))
 		out[j] = c.cen.TranslateBy(dir.Scale(r))
 	}
 	return out
@@ -237,22 +235,50 @@ type cornerInputs struct {
 // face. With a blend (v is a shared corner) the centre is the blend sphere's centre and the
 // tangent points are the sphere's tangents on the two faces; the corner-end arc joins the
 // sphere patch (no end face), and the arc is registered on the blend.
-func cornerAt(v *topo.Vertex, in cornerInputs, r float64, blend *cornerBlend) (corner, error) {
-	cen := v.Point().TranslateBy(in.offDir.Scale(r))
+func cornerAt(v *topo.Vertex, in cornerInputs, r float64, blend *cornerBlend, miter *cornerMiter) (corner, error) {
+	cen := v.Point().TranslateBy(in.offDir.Scale(r)) // the rolling-ball centre, on the cylinder axis
 	ta := cen.TranslateBy(in.nA.Scale(r))
 	tb := cen.TranslateBy(in.nB.Scale(r))
 	var end *topo.Face
-	if blend != nil {
+	var seam []math.Point3
+	switch {
+	case miter != nil:
+		ta, tb, seam = miterTangents(in, miter) // the end is the seam, not an end-face arc
+	case blend != nil:
 		cen, ta, tb = blend.center, blend.tan[in.a.ID()], blend.tan[in.b.ID()]
-	} else if end = endFaceAt(v, in.a, in.b); end == nil {
-		return corner{}, fmt.Errorf("fillet: edge endpoint has no end face to round")
+	default:
+		if end = endFaceAt(v, in.a, in.b); end == nil {
+			return corner{}, fmt.Errorf("fillet: edge endpoint has no end face to round")
+		}
 	}
+	// mid is computed AFTER the switch so a blend corner's arc midpoint uses the sphere centre.
 	mid := cen.TranslateBy(perpToward(cen, v.Point(), in.axis).Scale(r))
-	c := corner{a: in.a, b: in.b, endFace: end, vertex: v, cen: cen, ta: ta, tb: tb, mid: mid, blend: blend != nil}
+	c := corner{a: in.a, b: in.b, endFace: end, vertex: v, cen: cen, ta: ta, tb: tb, mid: mid, blend: blend != nil, miter: miter != nil, seam: seam}
 	if blend != nil {
 		blend.arcs = append(blend.arcs, blendArc{ta: ta, tb: tb, mid: mid})
 	}
 	return c, nil
+}
+
+// miterTangents returns this edge's corner tangents and the seam oriented ta→tb: the shared
+// face carries the seam's top (sTop, on the shared face), the outer face carries its bottom
+// (sBot, on the now-shortened sharp edge). The seam is the SAME point list for both edges of
+// the miter — reversed for the edge whose A face is the outer one — so the two cylinders weld
+// along it watertight.
+func miterTangents(in cornerInputs, m *cornerMiter) (ta, tb math.Point3, seam []math.Point3) {
+	if in.a == m.shared {
+		return m.seam[0], m.sBot, m.seam
+	}
+	return m.sBot, m.seam[0], reversePoints(m.seam)
+}
+
+// reversePoints returns a reversed copy of pts.
+func reversePoints(pts []math.Point3) []math.Point3 {
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[len(pts)-1-i] = p
+	}
+	return out
 }
 
 // perpToward returns the unit direction from cen toward p projected into the plane
@@ -295,38 +321,62 @@ type cornerBlend struct {
 	arcs   []blendArc
 }
 
-// computeBlends finds the shared corners of the filleted edge set and solves a sphere patch
-// for each. A vertex where ≥2 filleted edges meet must be a fully-filleted trihedral corner
-// (exactly 3 of the selected edges, 3 faces) at ONE constant radius — a variable edge's
-// faceted end chords cannot meet a sphere patch's true arcs watertight, and a sphere blend
-// has a single radius, so both cases error clearly. Returns a map keyed by corner vertex id.
-func computeBlends(picks []filletPick) (map[uint64]*cornerBlend, error) {
+// computeCorners finds the shared corners of the filleted edge set and solves a corner
+// treatment for each, keyed by corner vertex id:
+//
+//   - three filleted edges at a trihedral (3-face) vertex → a spherical corner patch (blend);
+//   - two filleted edges that share a face, the third edge staying sharp → a miter seam where
+//     the two rolling-ball cylinders mutually trim (miter).
+//
+// All edges meeting at a corner must use ONE constant radius — a variable edge's faceted end
+// chords cannot meet a corner watertight, and a blend/seam has a single radius — so those and
+// any other configuration error clearly.
+func computeCorners(picks []filletPick) (map[uint64]*cornerBlend, map[uint64]*cornerMiter, error) {
 	groups := map[uint64][]filletPick{}
 	for _, p := range picks {
 		groups[p.edge.StartVertex().ID()] = append(groups[p.edge.StartVertex().ID()], p)
 		groups[p.edge.EndVertex().ID()] = append(groups[p.edge.EndVertex().ID()], p)
 	}
-	out := map[uint64]*cornerBlend{}
+	blends := map[uint64]*cornerBlend{}
+	miters := map[uint64]*cornerMiter{}
 	for vid, ps := range groups {
 		if len(ps) < 2 {
 			continue
 		}
-		r, err := blendRadius(ps)
+		cb, cm, err := solveCorner(vid, ps)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		v := vertexByID(edgesOf(ps), vid)
-		faces := facesAtVertex(v)
-		if len(ps) != 3 || len(faces) != 3 {
-			return nil, fmt.Errorf("fillet: corner blend needs exactly 3 mutually filleted edges at a 3-face vertex (got %d edges, %d faces); other corner configs are not yet supported", len(ps), len(faces))
+		if cb != nil {
+			blends[vid] = cb
 		}
-		cb, err := solveBlend(v, faces, r)
-		if err != nil {
-			return nil, err
+		if cm != nil {
+			miters[vid] = cm
 		}
-		out[vid] = cb
 	}
-	return out, nil
+	return blends, miters, nil
+}
+
+// solveCorner solves the corner treatment at vertex vid where the picks ps meet: a sphere blend
+// (3 edges, trihedral vertex) or a miter seam (2 edges sharing a face), at the corner's one shared
+// radius. Exactly one of (blend, miter) is returned; any other configuration errors.
+func solveCorner(vid uint64, ps []filletPick) (*cornerBlend, *cornerMiter, error) {
+	r, err := blendRadius(ps)
+	if err != nil {
+		return nil, nil, err
+	}
+	v := vertexByID(edgesOf(ps), vid)
+	faces := facesAtVertex(v)
+	switch {
+	case len(ps) == 3 && len(faces) == 3:
+		cb, err := solveBlend(v, faces, r)
+		return cb, nil, err
+	case len(ps) == 2:
+		cm, err := solveMiter(v, ps, r)
+		return nil, cm, err
+	default:
+		return nil, nil, fmt.Errorf("fillet: corner where %d filleted edges meet a %d-face vertex is not a supported blend (need 3 edges at a trihedral vertex, or 2 edges sharing a face)", len(ps), len(faces))
+	}
 }
 
 // blendRadius returns the single constant radius shared by every pick meeting at the corner,

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -79,8 +79,8 @@ func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*
 		for _, c := range []corner{ef.c0, ef.c1} {
 			put(ab, c.a, c.vertex.ID(), c.ta)
 			put(ab, c.b, c.vertex.ID(), c.tb)
-			if c.blend {
-				continue // the rounded corner is the sphere patch, not an end-face arc
+			if c.blend || c.miter {
+				continue // the rounded corner is the sphere patch or the miter seam, not an end-face arc
 			}
 			if ends[c.endFace] == nil {
 				ends[c.endFace] = map[uint64]corner{}
@@ -181,40 +181,78 @@ func otherFace(e *topo.Edge, f *topo.Face) *topo.Face {
 	return nil
 }
 
-// cylinderFace builds the rolling-ball cylinder face: tangent line on A, end arc, tangent
-// line on B, end arc — wound so its geometric normal matches the cylinder's outward radial.
+// cylinderFace builds the rolling-ball cylinder face: tangent line on A, the rounded end at
+// corner 1, tangent line on B, the rounded end at corner 0. Each end is a single arc for a
+// simple/blend corner, or the seam chords for a miter corner. The loop is wound so its normal
+// matches the cylinder's outward radial.
 func cylinderFace(ef edgeFillet) filletFace {
-	c0, c1 := ef.c0, ef.c1
-	arc1, _ := geom.Arc3dByThreePoints(c1.ta, c1.mid, c1.tb) // TA1 → TB1 at end 1
-	arc0, _ := geom.Arc3dByThreePoints(c0.tb, c0.mid, c0.ta) // TB0 → TA0 at end 0
-	loop := filletLoop{
-		pts:    []math.Point3{c0.ta, c1.ta, c1.tb, c0.tb},
-		curves: []geom.Curve3{nil, arc1, nil, arc0},
+	segs := []endSeg{{from: ef.c0.ta, to: ef.c1.ta}}             // A-tangent line c0.ta → c1.ta
+	segs = append(segs, cornerEndSegs(ef.c1)...)                 // rounded end 1: c1.ta → c1.tb
+	segs = append(segs, endSeg{from: ef.c1.tb, to: ef.c0.tb})    // B-tangent line c1.tb → c0.tb
+	segs = append(segs, reverseEndSegs(cornerEndSegs(ef.c0))...) // rounded end 0: c0.tb → c0.ta
+	if cylinderSegsFlipped(ef, segs) {
+		segs = reverseEndSegs(segs)
 	}
-	if cylinderLoopFlipped(ef.cyl, loop) {
-		loop = reverseFilletLoop(loop, ef)
-	}
-	return filletFace{surface: ef.cyl, loops: []filletLoop{loop}}
+	return filletFace{surface: ef.cyl, loops: []filletLoop{loopFromSegs(segs)}}
 }
 
-// cylinderLoopFlipped reports whether the loop winds against the cylinder's outward normal at
-// the first end arc's midpoint (so it should be reversed for a consistent, outward face).
-func cylinderLoopFlipped(cyl geom.Cylinder, loop filletLoop) bool {
-	a, b, c := loop.pts[0], loop.pts[1], loop.pts[2]
+// endSeg is one boundary segment from→to of a cylinder loop, with the arc curve (and its
+// midpoint, for re-deriving the arc when the loop is reversed) when the end is rounded by an
+// arc; a miter seam's chords are straight (curve nil, arc false).
+type endSeg struct {
+	from, to math.Point3
+	curve    geom.Curve3
+	mid      math.Point3
+	arc      bool
+}
+
+// cornerEndSegs returns the segments rounding corner c from its ta to its tb: the seam chords
+// for a miter corner, otherwise a single arc through the corner's mid.
+func cornerEndSegs(c corner) []endSeg {
+	if c.miter {
+		segs := make([]endSeg, 0, len(c.seam)-1)
+		for i := 0; i+1 < len(c.seam); i++ {
+			segs = append(segs, endSeg{from: c.seam[i], to: c.seam[i+1]})
+		}
+		return segs
+	}
+	arc, _ := geom.Arc3dByThreePoints(c.ta, c.mid, c.tb)
+	return []endSeg{{from: c.ta, to: c.tb, curve: arc, mid: c.mid, arc: true}}
+}
+
+// reverseEndSegs reverses a chain of segments (swapping each from/to and re-deriving any arc in
+// the new direction), so a forward end-rounding ta→tb can run tb→ta.
+func reverseEndSegs(segs []endSeg) []endSeg {
+	out := make([]endSeg, len(segs))
+	for i, s := range segs {
+		r := endSeg{from: s.to, to: s.from, mid: s.mid, arc: s.arc}
+		if s.arc {
+			r.curve, _ = geom.Arc3dByThreePoints(s.to, s.mid, s.from)
+		}
+		out[len(segs)-1-i] = r
+	}
+	return out
+}
+
+// loopFromSegs flattens a closed chain of segments (each seg's to is the next seg's from) into a
+// filletLoop: each point with the curve of the segment leaving it.
+func loopFromSegs(segs []endSeg) filletLoop {
+	var fl filletLoop
+	for _, s := range segs {
+		fl.pts = append(fl.pts, s.from)
+		fl.curves = append(fl.curves, s.curve)
+	}
+	return fl
+}
+
+// cylinderSegsFlipped reports whether the loop winds against the cylinder's outward normal. It
+// builds the test triangle from the four tangent corners (always well separated, unlike a
+// miter seam's near-collinear chords), so the sign is robust for both arc and seam ends.
+func cylinderSegsFlipped(ef edgeFillet, segs []endSeg) bool {
+	a, b, c := ef.c0.ta, ef.c1.ta, ef.c1.tb
 	n := a.VectorTo(b).Cross(a.VectorTo(c))
-	u, v := cyl.ParamAt(centroidPts(loop.pts))
-	return n.Dot(cyl.NormalAt(u, v)) < 0
-}
-
-// reverseFilletLoop reverses the cylinder loop (and rebuilds its arcs in the new direction).
-func reverseFilletLoop(_ filletLoop, ef edgeFillet) filletLoop {
-	c0, c1 := ef.c0, ef.c1
-	arc0, _ := geom.Arc3dByThreePoints(c0.ta, c0.mid, c0.tb) // TA0 → TB0
-	arc1, _ := geom.Arc3dByThreePoints(c1.tb, c1.mid, c1.ta) // TB1 → TA1
-	return filletLoop{
-		pts:    []math.Point3{c0.ta, c0.tb, c1.tb, c1.ta},
-		curves: []geom.Curve3{arc0, nil, arc1, nil},
-	}
+	u, v := ef.cyl.ParamAt(centroidPts(loopFromSegs(segs).pts))
+	return n.Dot(ef.cyl.NormalAt(u, v)) < 0
 }
 
 // spherePatchFace builds the corner sphere patch: a spherical triangle bounded by the blend's

--- a/kernel/ops/fillet_miter.go
+++ b/kernel/ops/fillet_miter.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// cornerMiter is a two-fillet corner: where two filleted edges that SHARE a face meet at a
+// vertex (the third edge at that vertex stays sharp), the two rolling-ball cylinders cannot be
+// joined by a sphere — instead they mutually trim along a seam curve. shared is the common
+// face; sBot is the seam's lower end on the now-shortened sharp edge (the cylinders' common
+// tangent point, the new top vertex of that edge); seam samples the intersection curve from the
+// shared-face tangent point (sTop = seam[0]) down to sBot, as chords shared by both cylinders so
+// the welded result is watertight.
+type cornerMiter struct {
+	vertex *topo.Vertex
+	shared *topo.Face
+	sBot   math.Point3
+	seam   []math.Point3
+}
+
+// miterArm is one filleted edge's rolling-ball data at a miter corner: the cylinder centre at
+// the corner (on the axis), the edge direction, and the outer (non-shared) face normal.
+type miterArm struct {
+	cen  math.Point3
+	axis math.Vector3
+	nF   math.Vector3
+}
+
+// solveMiter builds the seam where two filleted edges that share a face meet at v. Each edge's
+// cylinder is tangent to the shared face and to its own outer face; for equal radii the two
+// cylinders intersect along an elliptical seam lying in the plane through v that mirror-swaps
+// the two outer faces. The seam runs from the shared-face tangent point to the sharp edge.
+func solveMiter(v *topo.Vertex, ps []filletPick, r float64) (*cornerMiter, error) {
+	shared := sharedFace(ps[0].edge, ps[1].edge)
+	if shared == nil {
+		return nil, fmt.Errorf("fillet: two filleted edges meeting at a vertex must share a face to miter (none shared)")
+	}
+	nS, ok := planeNormal(shared)
+	if !ok {
+		return nil, fmt.Errorf("fillet: miter corner's shared face must be planar")
+	}
+	a1, err := miterArmOf(ps[0].edge, shared, nS, v, r)
+	if err != nil {
+		return nil, err
+	}
+	a2, err := miterArmOf(ps[1].edge, shared, nS, v, r)
+	if err != nil {
+		return nil, err
+	}
+	seam, err := sampleMiterSeam(v.Point(), r, nS, a1, a2)
+	if err != nil {
+		return nil, err
+	}
+	return &cornerMiter{vertex: v, shared: shared, sBot: seam[len(seam)-1], seam: seam}, nil
+}
+
+// miterArmOf solves one edge's rolling-ball frame at the corner: centre v+offDir·r (offDir is
+// the per-unit-radius offset into the solid from the shared+outer face pair) and the outer
+// face normal. Both faces must be planar.
+func miterArmOf(e *topo.Edge, shared *topo.Face, nS math.Vector3, v *topo.Vertex, r float64) (miterArm, error) {
+	outer := otherFace(e, shared)
+	if outer == nil {
+		return miterArm{}, fmt.Errorf("fillet: miter edge has no outer face opposite the shared face")
+	}
+	nF, ok := planeNormal(outer)
+	if !ok {
+		return miterArm{}, fmt.Errorf("fillet: miter corner's outer face must be planar")
+	}
+	axis, err := math.UnitVector3FromVector(e.StartVertex().Point().VectorTo(e.EndVertex().Point()))
+	if err != nil {
+		return miterArm{}, fmt.Errorf("fillet: degenerate miter edge")
+	}
+	offDir := nS.Add(nF).Scale(-1 / (1 + nS.Dot(nF)))
+	return miterArm{cen: v.Point().TranslateBy(offDir.Scale(r)), axis: axis.AsVector(), nF: nF}, nil
+}
+
+// sampleMiterSeam samples the seam between two equal-radius fillet cylinders that share a face.
+// The seam is cyl(arm1) ∩ Π, where Π is the plane through v with normal nF1−nF2 (the mirror that
+// swaps the two outer faces). Sampling walks the rolling-ball contact direction d from the shared
+// face (nS, giving sTop on the shared face) to arm1's outer face (nF1, giving sBot on the sharp
+// edge); for each d the axial position λ is solved so the cylinder point lands on Π. For equal
+// radii the result lies exactly on both cylinders, so both can weld to the same point list.
+func sampleMiterSeam(v math.Point3, r float64, nS math.Vector3, a1, a2 miterArm) ([]math.Point3, error) {
+	m := a1.nF.Sub(a2.nF) // Π normal (its scale cancels in the λ ratio)
+	denom := a1.axis.Dot(m)
+	if stdmath.Abs(denom) < 1e-9 {
+		return nil, fmt.Errorf("fillet: degenerate miter (edge axis lies in the seam plane)")
+	}
+	w := stdmath.Acos(clamp(nS.Dot(a1.nF), -1, 1)) // rolling-ball wedge spanned on arm 1
+	k := int(stdmath.Ceil(w / (2 * stdmath.Pi / filletChordsPerTurn)))
+	if k < 4 {
+		k = 4
+	}
+	vMinusCen := a1.cen.VectorTo(v) // v − cen1
+	out := make([]math.Point3, k+1)
+	for j := 0; j <= k; j++ {
+		d := slerpVec(nS, a1.nF, float64(j)/float64(k)) // contact direction at this station
+		lambda := (vMinusCen.Dot(m) - r*d.Dot(m)) / denom
+		out[j] = a1.cen.TranslateBy(a1.axis.Scale(lambda)).TranslateBy(d.Scale(r))
+	}
+	return out, nil
+}
+
+// slerpVec interpolates the unit direction from a to b along the shorter great-circle arc at
+// parameter s∈[0,1] (the exact rolling-ball contact direction between two face normals).
+func slerpVec(a, b math.Vector3, s float64) math.Vector3 {
+	w := stdmath.Acos(clamp(a.Dot(b), -1, 1))
+	if w < 1e-9 {
+		return a
+	}
+	sinW := stdmath.Sin(w)
+	return a.Scale(stdmath.Sin((1-s)*w) / sinW).Add(b.Scale(stdmath.Sin(s*w) / sinW))
+}
+
+// sharedFace returns the face bounding both edges, or nil if they share none.
+func sharedFace(e1, e2 *topo.Edge) *topo.Face {
+	for _, f1 := range e1.Faces() {
+		for _, f2 := range e2.Faces() {
+			if f1 == f2 {
+				return f1
+			}
+		}
+	}
+	return nil
+}
+
+// planeNormal returns f's unit normal and ok=true when f is planar.
+func planeNormal(f *topo.Face) (math.Vector3, bool) {
+	pl, ok := f.Geometry().(geom.Plane)
+	if !ok {
+		return math.Vector3{}, false
+	}
+	return pl.Normal(), true
+}

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -5,7 +5,6 @@ package ops_test
 import (
 	stdmath "math"
 	"runtime"
-	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -201,6 +200,33 @@ func TestFilletCornerBlendMeshWatertight(t *testing.T) {
 	}
 }
 
+// TestFilletCornerBlendPatchOnSphere checks the 3-edge corner blend's spherical patch is built on
+// the analytic rolling-ball sphere: every tessellated vertex of the sphere face lies at radius r
+// from the sphere centre. This guards the corner-arc midpoints (a wrong mid leaves a watertight but
+// dented/bulged patch — invisible to the volume and open-edge checks, only to the eye).
+func TestFilletCornerBlendPatchOnSphere(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	res, err := ops.FilletEdges(box, cornerEdgeKeys(t, box), 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sphere *geom.Sphere
+	for _, f := range res.Faces() {
+		if s, ok := f.Geometry().(geom.Sphere); ok {
+			sphere = &s
+			m := ops.TessellateFace(f, ops.Quality{ChordTolerance: 1e-3})
+			for _, p := range m.Positions {
+				if d := sphere.Center.DistanceTo(p); stdmath.Abs(float64(d)-sphere.Radius) > 1e-3 {
+					t.Fatalf("sphere-patch vertex %v is %g from centre, want radius %g", p, d, sphere.Radius)
+				}
+			}
+		}
+	}
+	if sphere == nil {
+		t.Fatal("corner blend produced no sphere face")
+	}
+}
+
 // TestFilletAllBoxEdges rounds every edge of a 2×2×2 box: 12 cylinder fillets joined by 8
 // spherical corner patches into a valid solid (a fully-rounded box), with material removed.
 func TestFilletAllBoxEdges(t *testing.T) {
@@ -235,17 +261,43 @@ func TestFilletAllBoxEdges(t *testing.T) {
 	}
 }
 
-// TestFilletTwoEdgeCornerErrors checks an unsupported corner config (two of the three edges
-// at a vertex) errors clearly rather than producing a broken solid.
-func TestFilletTwoEdgeCornerErrors(t *testing.T) {
+// TestFilletTwoEdgeCornerMiters checks the two-edge corner config (two of the three edges at a
+// vertex, the third staying sharp): the two cylinder fillets mutually trim along a miter seam
+// into a valid solid (2 cylinders, no sphere), with material removed. The third edge of the
+// corner is sharp, so no sphere patch is built.
+func TestFilletTwoEdgeCornerMiters(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	keys := cornerEdgeKeys(t, box)[:2] // two of the three edges meeting at the corner
-	_, err := ops.FilletEdges(box, keys, 0.3)
-	if err == nil {
-		t.Fatal("filleting only two of the three edges at a corner should error")
+	res, err := ops.FilletEdges(box, keys, 0.3)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "corner") {
-		t.Errorf("error %q should mention the corner limitation", err)
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("two-edge mitered box not a valid solid: %+v", r)
+	}
+	if c, s := hasCylinderFaces(res), hasSphereFaces(res); c != 2 || s != 0 {
+		t.Errorf("got %d cylinder + %d sphere faces, want 2 + 0 (a miter, not a sphere blend)", c, s)
+	}
+	if v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume; v <= 7.5 || v >= 8 {
+		t.Errorf("two-edge miter volume = %g, want material removed (7.5 < v < 8)", v)
+	}
+}
+
+// TestFilletTwoEdgeCornerMiterMeshWatertight checks the miter seam's TESSELLATION is watertight
+// across qualities — the two cylinders share the seam chord polyline exactly, so the welded mesh
+// must have no cracks where they meet.
+func TestFilletTwoEdgeCornerMiterMeshWatertight(t *testing.T) {
+	box := shellBox(4, 3, 5)
+	keys := cornerEdgeKeys(t, box)[:2]
+	res, err := ops.FilletEdges(box, keys, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("two-edge miter mesh at tol %g has %d open edges, want watertight", tol, open)
+		}
 	}
 }
 

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -58,25 +58,58 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
-	return nonRectangularMesh(s, outer3D, holes3D, outerUV, holesUV)
+	return nonRectangularMesh(f, s, outer3D, holes3D, outerUV, holesUV)
 }
 
 // nonRectangularMesh meshes a non-iso-rectangular curved trim. A sphere cap is meshed over its own
 // (u,v) with interior nodes (gridPatchMesh) so it reads smooth; a B-spline uses the same CDT without
-// interior Steiner points (trimmedPatchMesh). Everything else — cylinder, cone, torus — keeps the
-// best-fit-plane boundary ear-clip (boundaryPatchMesh): it is coarse and can leave a small watertight
-// gap on a trimmed wall, but it is O(boundary) fast. (Routing cyl/cone through the (u,v) CDT closed
-// those gaps but made a few large cone trims pathologically slow — a 122-triangle face took 2.4s,
-// because the O(n²) CDT chokes on ~120 boundary constraints + interior nodes — freezing import. The
-// watertightness gain there is not worth the freeze; a faster constrained triangulation is the fix.)
-func nonRectangularMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+// interior Steiner points (trimmedPatchMesh). A cyl/cone that shares a curved seam with another
+// cyl/cone — two fillet cylinders that mutually trim where two edges miter — ALSO needs the interior
+// nodes: meshed boundary-only, both faces fan a coincident diagonal across the shared seam into a
+// non-manifold overlap, so it gets gridPatchMesh too (small trims only — the (u,v) CDT is too slow on
+// the ~120-point cone trims that once froze import). Every other cyl/cone — an ordinary fillet wall, a
+// corner-blend cylinder meeting only planes and the sphere — keeps the O(boundary) best-fit-plane
+// ear-clip (boundaryPatchMesh), coarse but fast, with the conformance pass closing any small gap.
+func nonRectangularMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
 	switch s.(type) {
 	case geom.Sphere:
 		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
 	case geom.BSplineSurface:
 		return trimmedPatchMesh(s, outer3D, holes3D)
+	case geom.Cylinder, geom.Cone:
+		if boundaryPointCount(outer3D, holes3D) <= curvedSeamMeshMax && sharesCurvedSeam(f) {
+			return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
+		}
 	}
 	return boundaryPatchMesh(s, outer3D, holes3D)
+}
+
+// curvedSeamMeshMax bounds the boundary size for which a curved-seam cyl/cone trim takes the
+// interior-node CDT (gridPatchMesh) instead of the fast ear-clip — comfortably above a fillet miter's
+// ~30-point boundary and below the ~120-point cone trims whose CDT froze import.
+const curvedSeamMeshMax = 64
+
+// boundaryPointCount totals a trim's outer and hole boundary points.
+func boundaryPointCount(outer3D []math.Point3, holes3D [][]math.Point3) int {
+	n := len(outer3D)
+	for _, h := range holes3D {
+		n += len(h)
+	}
+	return n
+}
+
+// sharesCurvedSeam reports whether f shares an edge with ANOTHER cylinder/cone face — a curved-curved
+// seam (two mutually-trimming fillet cylinders meet this way). A cyl/cone touching only planes and a
+// sphere (an ordinary fillet wall, a corner-blend cylinder) does not qualify.
+func sharesCurvedSeam(f *topo.Face) bool {
+	for _, e := range f.Edges() {
+		for _, nf := range e.Faces() {
+			if nf != f && isCylOrCone(nf.Geometry()) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // boundaryPatchMesh triangulates a curved face from its boundary loops alone (no interior


### PR DESCRIPTION
## What

A fillet where **two edges sharing a face** meet at a vertex (the third edge staying sharp) — the four top edges of a box, an L-pair — was rejected with *"corner blend needs exactly 3 mutually filleted edges."* The kernel only handled the symmetric 3-edge/3-face vertex (a sphere patch).

Such a corner is now a **miter**: the two rolling-ball cylinders mutually trim along the elliptical seam where they intersect (in the plane that mirror-swaps the two outer faces), from the shared-face tangent point down to the now-shortened sharp edge. `computeBlends` → `computeCorners` dispatches 3-edge → sphere, 2-edge-sharing-a-face → miter.

## Why

It maps onto the existing machinery — each cylinder's corner end becomes the seam polyline instead of an end-face arc, the shared face pulls its corner to the seam top and the outer faces to the seam bottom — so no new face kind was needed. This is the flush corner expected from filleting adjacent edges.

## Mesh

Two miter cylinders share a multi-vertex seam, which the boundary-only ear-clip turns into a non-manifold overlap (both faces fan a coincident diagonal). A non-rectangular cyl/cone trim that shares an edge with **another cyl/cone** (a curved-curved seam) now routes through the interior-node CDT; ordinary fillet walls and corner-blend cylinders (meeting only planes + the sphere) keep the fast ear-clip.

## Also

Fixes a corner-arc-midpoint regression: `cornerAt` must compute `mid` **after** resolving the blend sphere centre, else the 3-edge sphere patch is built on wrong arc midpoints (watertight but dented — only the eye and the new on-sphere test catch it).

## Tests

- Two-edge miter is a valid solid (2 cylinders, no sphere, material removed) and watertight across tolerances.
- 3-edge / whole-box blends still pass; sphere-patch vertices verified on the analytic sphere.
- The obsolete "two-edge corner errors" test becomes the success case.

Live-verified over the MCP bridge (single edge, sphere blend, top-loop miter, whole box, L-pair) — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)