### PR TITLE
build: auto-pin oblikovati.org/api to the latest release in CI

### DIFF
--- a/.github/actions/api-contract/action.yml
+++ b/.github/actions/api-contract/action.yml
@@ -1,0 +1,54 @@
+# Resolve the latest oblikovati.org/api RELEASE, check it out, and wire the build
+# against it. Replaces the per-job "checkout api@develop + go mod edit -replace"
+# boilerplate (ADR-0018: the contract is a sibling repo, no replace is committed).
+#
+# It does two things so the build matches what ships:
+#   1. pins each module's `require oblikovati.org/api` to the resolved release tag
+#      (keeps the committed pin honest with what we built against), and
+#   2. adds a `replace` to the checked-out tag so the build resolves the contract
+#      from disk without needing the oblikovati.org vanity host or a go.sum entry.
+#
+# Requires Go to be set up already (it runs `go mod edit`). Run it after setup-go.
+name: API contract
+description: Check out the latest oblikovati.org/api release and pin/replace the given module(s) to it.
+
+inputs:
+  modules:
+    description: Space-separated module dirs to wire (e.g. "." for the root, "head" for the GUI).
+    required: false
+    default: "."
+  path:
+    description: Directory to check the contract out into.
+    required: false
+    default: _api
+
+outputs:
+  version:
+    description: The resolved oblikovati.org/api release tag (vX.Y.Z).
+    value: ${{ steps.resolve.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      run: echo "version=$(scripts/latest-api-version.sh)" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/checkout@v5
+      with:
+        repository: Oblikovati/Oblikovati.API
+        ref: ${{ steps.resolve.outputs.version }}
+        path: ${{ inputs.path }}
+
+    - shell: bash
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+        MODULES: ${{ inputs.modules }}
+      run: |
+        set -euo pipefail
+        api="$GITHUB_WORKSPACE/${{ inputs.path }}"
+        for m in $MODULES; do
+          echo "→ $m: require + replace oblikovati.org/api@$VERSION (-> $api)"
+          go -C "$m" mod edit -require="oblikovati.org/api@$VERSION"
+          go -C "$m" mod edit -replace "oblikovati.org/api=$api"
+        done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,11 @@ name: build
 # packages the cgo/Vulkan GUI head per OS, uploading everything as run artifacts.
 # Called by nightly.yml and release.yml.
 #
-# The Apache-2.0 API contract is a sibling repo (Oblikovati/Oblikovati.API). Each
-# Go job checks it out into ./_api and points the `api` require at it via
-# `go mod edit -replace` on the job's MAIN module (root for the CLI, head for the
-# GUI) — the committed go.mod has no replace (local dev uses go.work).
+# The Apache-2.0 API contract is a sibling repo (Oblikovati/Oblikovati.API). Each Go
+# job wires the build against the LATEST published api RELEASE via the local
+# .github/actions/api-contract composite (checks the release tag out into ./_api and
+# pins + replaces the job's MAIN module — root for the CLI, head for the GUI). So a
+# shipped build always links a real released contract, never an unreleased develop.
 on:
   workflow_call:
     inputs:
@@ -39,16 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - run: go mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
       - name: Cross-build CLI
         env:
           VER: ${{ inputs.version }} # via env, never interpolated into the script (script injection)
@@ -74,16 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: false
-      - run: go -C head mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
+        with:
+          modules: head
       - name: Install build + packaging deps
         run: |
           sudo apt-get update
@@ -118,10 +111,16 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v5
+      # Resolve + check out the latest api release. The api-contract composite runs its
+      # `go mod edit` under bash, but this job's Go lives in the msys2 environment, so we
+      # do the resolve/checkout here and the mod edit in the msys2 shell below.
+      - id: api
+        shell: bash
+        run: echo "version=$(scripts/latest-api-version.sh)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v5
         with:
           repository: Oblikovati/Oblikovati.API
-          ref: develop
+          ref: ${{ steps.api.outputs.version }}
           path: _api
       - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
         with:
@@ -135,7 +134,12 @@ jobs:
             mingw-w64-x86_64-vulkan-loader
             mingw-w64-x86_64-vulkan-headers
             zip
-      - run: go -C head mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - name: Pin + replace api to the release
+        env:
+          VERSION: ${{ steps.api.outputs.version }}
+        run: |
+          go -C head mod edit -require="oblikovati.org/api@$VERSION"
+          go -C head mod edit -replace "oblikovati.org/api=$GITHUB_WORKSPACE/_api"
       - name: Build head
         working-directory: head
         env:
@@ -205,16 +209,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache: false
-      - run: go -C head mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
+        with:
+          modules: head
       - name: Install deps
         run: brew install glfw vulkan-loader vulkan-headers molten-vk pkg-config
       - name: Build head

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,54 @@ defaults:
     shell: bash
 
 jobs:
-  lint:
+  # Keep the committed `oblikovati.org/api` pin tracking the latest published release.
+  # The contract auto-releases a vX.Y.Z tag on every merge (Oblikovati.API), so a source
+  # PR's pin drifts behind on its own; this bumps both modules to the newest release and
+  # commits the result back onto the PR branch. The build/test jobs below build against
+  # that same release regardless (via the api-contract action), so this only persists the
+  # pin — it never gates the PR. Skipped for forks (no write access to the head branch).
+  api-version:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
-      # The Apache-2.0 contract is a sibling repo now; check it out and point the
-      # `api` require at it (the committed go.mod has no replace — local dev uses
-      # go.work, CI injects an equivalent replace).
-      - uses: actions/checkout@v5
         with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - run: go mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - id: pin
+        run: echo "version=$(scripts/sync-api-version.sh)" >> "$GITHUB_OUTPUT"
+      - name: Commit the pin if it changed
+        env:
+          VERSION: ${{ steps.pin.outputs.version }}
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- go.mod head/go.mod; then
+            echo "oblikovati.org/api already pinned to $VERSION"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add go.mod head/go.mod
+          git commit -m "build: pin oblikovati.org/api $VERSION"
+          git push origin "HEAD:$BRANCH"
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+      # Check out the latest api release and wire the build against it (ADR-0018).
+      - uses: ./.github/actions/api-contract
       - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.1.0
@@ -73,16 +104,11 @@ jobs:
       CGO_ENABLED: "0"
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - run: go mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
       - run: go install gotest.tools/gotestsum@v1.12.0
       - name: Test
         run: gotestsum --junitfile test-results-${{ matrix.os }}.xml -- -coverprofile=coverage.out -covermode=count ./...
@@ -97,16 +123,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - run: go mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
       - run: go test -race -skip 'TestNop.*CSG' ./...
 
   # cgo GUI head (Vulkan + Dear ImGui). The PR test/race/build jobs above run `./...`
@@ -123,17 +144,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           # Match build.yml's head-linux toolchain.
           go-version: "1.24"
           cache: false
-      - run: go -C head mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
+        with:
+          modules: head
       - name: Install cgo + headless-Vulkan deps
         run: |
           sudo apt-get update
@@ -159,16 +177,11 @@ jobs:
         target: [linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: Oblikovati/Oblikovati.API
-          ref: develop
-          path: _api
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - run: go mod edit -replace oblikovati.org/api="$GITHUB_WORKSPACE/_api"
+      - uses: ./.github/actions/api-contract
       - name: Cross-compile
         run: |
           GOOS=$(echo "${{ matrix.target }}" | cut -d/ -f1)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.1.0
+	oblikovati.org/api v0.2.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.1.0
+	oblikovati.org/api v0.2.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/scripts/latest-api-version.sh
+++ b/scripts/latest-api-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Print the newest published oblikovati.org/api release tag (e.g. "v0.2.0").
+#
+# The contract is a sibling repo that auto-releases a vX.Y.Z tag on every merge
+# (Oblikovati.API/RELEASING.md). This is the single source of truth both the CI
+# composite action and scripts/sync-api-version.sh use to resolve "the latest
+# release", so the resolution logic lives in exactly one place.
+#
+#   $ scripts/latest-api-version.sh
+#   v0.2.0
+set -euo pipefail
+
+API_REPO="${API_REPO:-https://github.com/Oblikovati/Oblikovati.API}"
+
+# --refs drops the dereferenced "^{}" peel lines; -v:refname sorts semver newest-first,
+# so the first clean vMAJOR.MINOR.PATCH tag is the latest stable release (pre-releases
+# carrying a -suffix are intentionally excluded).
+tag=$(git ls-remote --tags --refs --sort=-v:refname "$API_REPO" 'refs/tags/v*' \
+  | sed -nE 's@.*refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$@\1@p' \
+  | head -1)
+
+if [ -z "$tag" ]; then
+  echo "latest-api-version: no vX.Y.Z release tag found at $API_REPO" >&2
+  exit 1
+fi
+
+echo "$tag"

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Pin oblikovati.org/api to the latest published release across this repo's modules
+# (the root application module and the cgo `head` submodule), so the committed
+# `require` never drifts behind the auto-released contract.
+#
+# CI runs this on every PR and auto-commits the result to the PR branch; run it
+# locally the same way. It edits only the `require` version string (a textual
+# `go mod edit`, no network, no go.sum change — local builds still resolve the
+# contract through go.work). Prints the version it pinned.
+#
+#   $ scripts/sync-api-version.sh           # pin to the latest release
+#   $ scripts/sync-api-version.sh v0.2.0    # pin to a specific release
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+version="${1:-$("$here/latest-api-version.sh")}"
+
+case "$version" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  *) echo "sync-api-version: $version is not a vX.Y.Z release tag" >&2; exit 1 ;;
+esac
+
+# The repo's two Go modules; both depend on the contract and must stay in lockstep.
+for mod in . head; do
+  go -C "$here/../$mod" mod edit -require="oblikovati.org/api@$version"
+done
+
+echo "$version"


### PR DESCRIPTION
## What

Make the application's `oblikovati.org/api` dependency track the **newest published contract release** automatically, in both PR validation and publishing.

- **`scripts/latest-api-version.sh`** — resolves the newest `vX.Y.Z` api release tag (single source of truth for the resolution).
- **`scripts/sync-api-version.sh`** — pins both Go modules (root + `head`) to it; run it locally the same way CI does.
- **`.github/actions/api-contract`** — a composite action that checks out the resolved release and wires the build against it (`require` + `replace`), replacing the duplicated *"checkout api@develop + `go mod edit -replace`"* block in every job. **CI, build, release, and nightly now build against the latest api RELEASE, not `develop`.**
- **`ci.yml` `api-version` job** — on every PR, pins to the latest release and **commits the bump back onto the PR branch** (skipped for forks). It does not gate the PR; the build/test jobs already build against that release via the composite.
- First application: root + `head` pinned `v0.1.0 → v0.2.0`.

## Why

The committed pin was hand-maintained and stale (`v0.1.0` while the contract was at `v0.2.0`), and every job ignored it — they injected a `replace` against api `develop` HEAD. So source was validated against *unreleased* api while the pin a real build would consume drifted behind. Now that the contract [auto-releases on every merge](https://github.com/Oblikovati/Oblikovati.API/blob/develop/RELEASING.md), the application can track real releases.

## Behavior change worth noting

CI now builds against the latest api **release** rather than `develop` HEAD. This enforces a clean cross-repo ordering: a source change depending on new API must wait until that API change is **merged (and thus released)** — which is already the workflow. Local development is unchanged (it still resolves the contract through `go.work` over the sibling checkout).

## Validation

- `scripts/latest-api-version.sh` → `v0.2.0`; `scripts/sync-api-version.sh` pins both modules; local workspace build still resolves the contract and compiles.
- All workflow YAML parses; no `ref: develop` api checkouts remain; SPDX check passes (no Go files added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)