### PR TITLE
ci: fix script injection in api-contract action (SonarCloud BLOCKER)

### DIFF
--- a/.github/actions/api-contract/action.yml
+++ b/.github/actions/api-contract/action.yml
@@ -41,12 +41,16 @@ runs:
         path: ${{ inputs.path }}
 
     - shell: bash
+      # Route every action input through env, never interpolated into the script body:
+      # inputs are caller-controlled, so a `${{ inputs.x }}` in a run block is a script
+      # -injection vector (githubactions:S7630).
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
         MODULES: ${{ inputs.modules }}
+        API_PATH: ${{ inputs.path }}
       run: |
         set -euo pipefail
-        api="$GITHUB_WORKSPACE/${{ inputs.path }}"
+        api="$GITHUB_WORKSPACE/$API_PATH"
         for m in $MODULES; do
           echo "→ $m: require + replace oblikovati.org/api@$VERSION (-> $api)"
           go -C "$m" mod edit -require="oblikovati.org/api@$VERSION"


### PR DESCRIPTION
## What
Route the `api-contract` composite action's `path` input through `env` instead of interpolating `${{ inputs.path }}` directly into the `run` block.

## Why
SonarCloud's Quality Gate failed on #890 with `new_security_rating = E`, from a single BLOCKER: `githubactions:S7630` — *"inputs.path is vulnerable to script injection: values of inputs are provided by whoever triggers the workflow."* The other inputs (`version`, `modules`) were already passed via `env`; `path` was the one expanded in the shell body. Now every caller-controlled value goes through `env`, so nothing untrusted is expanded in the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)