### PR TITLE
fix(fillet): classify fillet-of-fillet edges with precise errors

### DIFF
--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -132,6 +132,9 @@ type edgeFillet struct {
 // sampled as chords (shared by the ruling strips and the end faces).
 func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter) (edgeFillet, error) {
 	e := p.edge
+	if cyl, pl, ok := cylinderPlaneEdge(e); ok {
+		return edgeFillet{}, curvedFilletError(e, cyl, pl) // fillet of a fillet — Phase A: classify & report
+	}
 	a, b, nA, nB, err := edgePlanarFaces(e)
 	if err != nil {
 		return edgeFillet{}, err

--- a/kernel/ops/fillet_curved.go
+++ b/kernel/ops/fillet_curved.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Curved-adjacent fillets — rounding an edge that borders a CYLINDER face (the surface a prior
+// fillet created) rather than two planes. The plane-plane rolling ball is a cylinder; against a
+// cylinder neighbour it is a cylinder (a straight, axis-parallel edge) or a torus (an arc edge
+// around the cylinder axis). Phase A classifies the edge and reports precisely what is and is not
+// yet handled; Phase B builds the torus. See computeEdgeFillet for the dispatch.
+
+// cylinderPlaneEdge reports an edge bounded by one cylinder face and one plane face, returning
+// both surfaces. This is the "fillet of a fillet" input — the prior fillet left the cylinder.
+func cylinderPlaneEdge(e *topo.Edge) (cyl geom.Cylinder, pl geom.Plane, ok bool) {
+	faces := e.Faces()
+	if len(faces) != 2 {
+		return geom.Cylinder{}, geom.Plane{}, false
+	}
+	for i := 0; i < 2; i++ {
+		c, okc := faces[i].Geometry().(geom.Cylinder)
+		p, okp := faces[1-i].Geometry().(geom.Plane)
+		if okc && okp {
+			return c, p, true
+		}
+	}
+	return geom.Cylinder{}, geom.Plane{}, false
+}
+
+// curvedFilletError reports why a cylinder+plane edge cannot (yet) be rounded. A tangent edge —
+// the cylinder is G1-smooth into the plane (a fillet cylinder meeting the very face it was made
+// tangent to) — has NO corner to round, so it is rejected as smooth, not "unsupported". Any other
+// cylinder+plane edge (a sharp arc cap, or a sharp axial cut) is a real fillet target Phase B/C
+// will build; until then it errors clearly instead of producing the misleading "invalid solid" /
+// "miter" the planar path emitted.
+func curvedFilletError(e *topo.Edge, cyl geom.Cylinder, pl geom.Plane) error {
+	mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point())
+	u, _ := cyl.ParamAt(mid)
+	if stdmath.Abs(cyl.NormalAt(u, 0).Dot(pl.Normal())) > 1-1e-6 {
+		return fmt.Errorf("fillet: edge between a cylinder and a tangent plane is smooth (no corner to round)")
+	}
+	return fmt.Errorf("fillet: rounding an edge that borders a curved (cylinder) face is not yet supported")
+}

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -5,6 +5,7 @@ package ops_test
 import (
 	stdmath "math"
 	"runtime"
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -298,6 +299,48 @@ func TestFilletTwoEdgeCornerMiterMeshWatertight(t *testing.T) {
 		if open := meshOpenEdges(m); open != 0 {
 			t.Errorf("two-edge miter mesh at tol %g has %d open edges, want watertight", tol, open)
 		}
+	}
+}
+
+// TestFilletCurvedAdjacentReported checks the "fillet of a fillet" inputs are classified and
+// reported precisely (instead of the old misleading "invalid solid" / "miter"): after rounding a
+// box's vertical edge, the resulting cylinder's TANGENT line into the side plane is G1-smooth (no
+// corner to round) and is rejected as smooth, while its sharp ARC cap edge is a real target
+// reported as not-yet-supported. Guards the curved-adjacent dispatch in computeEdgeFillet.
+func TestFilletCurvedAdjacentReported(t *testing.T) {
+	box := shellBox(4, 3, 2)
+	var vert []byte
+	for _, e := range box.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.X == 4 && a.Y == 3 && c.X == 4 && c.Y == 3 {
+			vert = e.ReferenceKey()
+		}
+	}
+	f1, err := ops.FilletEdges(box, [][]byte{vert}, 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	near := func(a, b float64) bool { return stdmath.Abs(a-b) < 1e-6 }
+	checked := 0
+	for _, e := range f1.Edges() {
+		m := e.RangeBox().Center()
+		switch {
+		case near(m.X, 4) && near(m.Y, 2.7): // tangent line: cylinder G1-smooth into the x=4 plane
+			_, err := ops.FilletEdges(f1, [][]byte{e.ReferenceKey()}, 0.1)
+			if err == nil || !strings.Contains(err.Error(), "smooth") {
+				t.Errorf("tangent line should be rejected as smooth, got: %v", err)
+			}
+			checked++
+		case near(m.X, 3.85) && near(m.Y, 2.85) && m.Z > 1.9: // sharp arc cap (cylinder ∩ top plane)
+			_, err := ops.FilletEdges(f1, [][]byte{e.ReferenceKey()}, 0.1)
+			if err == nil || !strings.Contains(err.Error(), "not yet supported") {
+				t.Errorf("arc cap should report not-yet-supported, got: %v", err)
+			}
+			checked++
+		}
+	}
+	if checked != 2 {
+		t.Fatalf("expected to check both the tangent line and the arc cap, checked %d", checked)
 	}
 }
 


### PR DESCRIPTION
## What

Filleting an edge that borders a **cylinder** face (the surface a prior fillet created — "fillet of a fillet") hit the plane-plane path and produced a misleading `result is not a valid solid` or `two filleted edges must share a face to miter`, or in the UI a feature node that **silently built nothing**.

This classifies a cylinder+plane edge up front (`computeEdgeFillet` → `cylinderPlaneEdge`) and reports precisely:
- a **G1-tangent** edge — the fillet cylinder meeting the very face it was made tangent to — has no corner to round, so it's rejected as *smooth*;
- any other cylinder+plane edge (a sharp arc cap, a sharp axial cut) is a real fillet target reported as *not yet supported* (the curved rolling-ball blend is a follow-up).

## Why

The reported symptom was a fillet feature appearing in the browser with no geometry. The root cause is that the analytic rolling-ball fillet is plane-plane only; this gives an honest diagnosis instead of the misleading/silent behavior, and is the classification foundation the curved-fillet work builds on.

The plane-plane path is **unchanged**. Tests cover both the smooth-tangent and the sharp-arc edges of a first fillet (`TestFilletCurvedAdjacentReported`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)