### PR TITLE
feat(fillet): torus-band tessellation + rim-fillet B-rep (foundation)

### DIFF
--- a/kernel/brep/cylinder_filleted.go
+++ b/kernel/brep/cylinder_filleted.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// SolidCylinderFilletedTop builds a closed cylinder whose TOP rim — the circle where the side wall
+// meets the top cap — is rounded by a rolling-ball fillet of radius r, a toroidal band. It is the
+// closed-rim ("no run-out") case of a curved-adjacent fillet: the rim is a FULL circle, so the
+// blend closes on itself with no corner ends (unlike a partial arc, which terminates at smooth
+// tangent vertices and needs variable-radius run-out). Topology mirrors SolidCylinder with one
+// extra band: bottom cap, side wall (base → z=h−r), the torus blend (z=h−r → z=h), and the receded
+// top cap (radius Rc−r). r must be < radius and < height.
+func SolidCylinderFilletedTop(baseCenter math.Point3, axisDir math.Vector3, radius, height, r float64) (*topo.Body, error) {
+	if r <= 0 || r >= radius || r >= height {
+		return nil, fmt.Errorf("brep: fillet %g must be in (0, min(radius %g, height %g))", r, radius, height)
+	}
+	a, err := math.UnitVector3FromVector(axisDir)
+	if err != nil {
+		return nil, err
+	}
+	av := a.AsVector()
+	cylTopC := baseCenter.TranslateBy(av.Scale(math.Scalar(height - r)))
+	capC := baseCenter.TranslateBy(av.Scale(math.Scalar(height)))
+
+	bottom, err := geom.NewCircle(baseCenter, axisDir, radius)
+	if err != nil {
+		return nil, err
+	}
+	// Share the bottom circle's frame so every seam sits at angle 0.
+	cylTan := geom.Circle{Center: cylTopC, Normal: bottom.Normal, RefDir: bottom.RefDir, Radius: radius}
+	capTan := geom.Circle{Center: capC, Normal: bottom.Normal, RefDir: bottom.RefDir, Radius: radius - r}
+
+	wall, err := geom.NewCylinder(baseCenter, axisDir, radius)
+	if err != nil {
+		return nil, err
+	}
+	capBottom, err := geom.NewPlane(baseCenter, av.Scale(-1)) // outward −axis
+	if err != nil {
+		return nil, err
+	}
+	capTop, err := geom.NewPlane(capC, av) // outward +axis
+	if err != nil {
+		return nil, err
+	}
+	// Torus tube centre on the cyl-tangent circle: major Rc−r, minor r. v=0 → cyl-tangent (Rc, z=h−r),
+	// v=π/2 → cap-tangent (Rc−r, z=h). Share the bottom frame so the torus seam lines up at angle 0.
+	tor, err := geom.NewTorusWithRef(cylTopC, av, bottom.RefDir.AsVector(), radius-r, r)
+	if err != nil {
+		return nil, err
+	}
+
+	vbp, vcp, vtp := bottom.PointAt(0), cylTan.PointAt(0), capTan.PointAt(0)
+	seamArc, err := geom.Arc3dByThreePoints(vcp, tor.PointAt(0, stdmath.Pi/4), vtp) // torus seam, v: 0→π/2
+	if err != nil {
+		return nil, err
+	}
+
+	bld := topo.NewBuilder(true, filLin("body", 0))
+	vb := bld.AddVertex(vbp, filLin("v", 0))
+	vc := bld.AddVertex(vcp, filLin("v", 1))
+	vt := bld.AddVertex(vtp, filLin("v", 2))
+	eb := bld.AddEdge(bottom, vb, vb, filLin("e", 0)) // bottom circle (closed)
+	ec := bld.AddEdge(cylTan, vc, vc, filLin("e", 1)) // cyl-tangent circle (closed)
+	et := bld.AddEdge(capTan, vt, vt, filLin("e", 2)) // cap-tangent circle (closed)
+	esw := bld.AddEdge(geom.NewLineSegment(vbp, vcp), vb, vc, filLin("e", 3))
+	est := bld.AddEdge(seamArc, vc, vt, filLin("e", 4))
+
+	bld.AddFace(capBottom, filLin("f", 0), topo.OuterLoop(topo.Rev(eb)))
+	bld.AddFace(capTop, filLin("f", 1), topo.OuterLoop(topo.Fwd(et)))
+	// Periodic wall: seam up, cyl-tangent circle (opposite the torus), seam down, bottom circle.
+	bld.AddFace(wall, filLin("f", 2), topo.OuterLoop(topo.Fwd(esw), topo.Rev(ec), topo.Rev(esw), topo.Fwd(eb)))
+	// Periodic torus band: seam up, cap-tangent circle (opposite the cap), seam down, cyl-tangent circle.
+	bld.AddFace(tor, filLin("f", 3), topo.OuterLoop(topo.Fwd(est), topo.Rev(et), topo.Rev(est), topo.Fwd(ec)))
+	return bld.Build(), nil
+}
+
+func filLin(role string, i int) topo.Lineage { return topo.NewLineage(topo.Tok("cylfillet", role, i)) }

--- a/kernel/ops/fillet_rim_test.go
+++ b/kernel/ops/fillet_rim_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestRimFilletTorusBand checks the closed-rim ("no run-out") curved fillet: a cylinder whose top
+// rim is rounded into a toroidal band is a valid solid with one torus face, material removed, and a
+// WATERTIGHT mesh at practical tolerances — exercising the doubly-periodic torus-band tessellation
+// path (doublyPeriodicBandGrid). It is the foundation for the run-out cases: a torus band that closes
+// on itself. The fine-tolerance seam between the torus and the smaller-radius cap circle still needs a
+// loft-between-rings mesher (next increment), so watertightness is asserted at the practical
+// tolerances the head and mass-properties use.
+func TestRimFilletTorusBand(t *testing.T) {
+	b, err := brep.SolidCylinderFilletedTop(math.P3(0, 0, 0), math.V3(0, 0, 1), 1.0, 2.0, 0.3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(b); !r.Valid || !b.IsSolid() {
+		t.Fatalf("rim-filleted cylinder not a valid solid: %+v", r)
+	}
+	tor, cyl, pln := 0, 0, 0
+	for _, f := range b.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Torus:
+			tor++
+		case geom.Cylinder:
+			cyl++
+		case geom.Plane:
+			pln++
+		}
+	}
+	if tor != 1 || cyl != 1 || pln != 2 {
+		t.Errorf("faces: torus=%d cyl=%d plane=%d, want 1/1/2", tor, cyl, pln)
+	}
+	for _, tol := range []float64{0.05, 1e-2} {
+		m, _ := ops.TessellateBody(b, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("rim-fillet mesh at tol %g has %d open edges, want watertight", tol, open)
+		}
+	}
+	full := stdmath.Pi * 1.0 * 1.0 * 2.0 // π·R²·h
+	v := ops.BodyGeometryProperties(b, ops.Quality{ChordTolerance: 1e-3}).Volume
+	if v >= full || v < full-0.5 {
+		t.Errorf("rim-fillet volume = %g, want a little under the full cylinder %g (rim notch removed)", v, full)
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -42,23 +42,29 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	}
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
-		if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
-			return closedDomainMesh(s, us, vs) // full cylinder/cone side: wraps the seam watertight
-		}
-		// A SINGLY-periodic surface (a sphere: periodic longitude, bounded latitude) whose (u,v)
-		// degenerates here is a cap straddling the pole — mesh its real boundary trim via the CDT in
-		// the best-fit plane, not the whole sphere (fullDomainGridMesh gave the torn radiating fan).
-		// A doubly-periodic surface (a torus) keeps the full-domain grid: its seam boundary bounds no
-		// planar trim, so the CDT would be meaningless.
-		if isPeriodic(s.UDomain()) != isPeriodic(s.VDomain()) {
-			return trimmedPatchMesh(s, outer3D, holes3D)
-		}
-		return fullDomainGridMesh(s, q) // doubly-periodic / aperiodic seam face we can't reduce
+		return meshSeamCrossingFace(s, outer3D, holes3D, q) // a loop wrapping the seam: band/cap fallbacks
 	}
 	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
 	return nonRectangularMesh(f, s, outer3D, holes3D, outerUV, holesUV)
+}
+
+// meshSeamCrossingFace meshes a curved face whose boundary loop wraps the periodic seam (so toUVLoops
+// can't unwrap it): a full cylinder/cone side or a torus rim-fillet band closes the seam watertight via
+// closedDomainMesh; a singly-periodic sphere cap straddling the pole goes through the best-fit-plane CDT
+// (the full-domain grid tears there); a doubly-periodic torus we can't reduce keeps the full-domain grid.
+func meshSeamCrossingFace(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) *Mesh {
+	if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
+		return closedDomainMesh(s, us, vs) // full cylinder/cone side: wraps the seam watertight
+	}
+	if us, vs, isBand := doublyPeriodicBandGrid(s, outer3D, holes3D); isBand {
+		return closedDomainMesh(s, us, vs) // torus rim-fillet band: wraps the axis, bounded in the tube
+	}
+	if isPeriodic(s.UDomain()) != isPeriodic(s.VDomain()) {
+		return trimmedPatchMesh(s, outer3D, holes3D) // sphere cap on the pole: CDT in the best-fit plane
+	}
+	return fullDomainGridMesh(s, q) // doubly-periodic / aperiodic seam face we can't reduce
 }
 
 // nonRectangularMesh meshes a non-iso-rectangular curved trim. A sphere cap is meshed over its own
@@ -340,6 +346,42 @@ func periodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Po
 		return nil, nil, false
 	}
 	return us, vs, true
+}
+
+// doublyPeriodicBandGrid meshes a band on a DOUBLY-periodic surface (a torus) whose boundary wraps
+// exactly ONE parameter direction around its full period — two edge circles joined by a seam — and is
+// bounded in the other. The torus rim fillet is such a band: it wraps the axis (u over [0,2π]) and
+// spans only a quarter of the tube (v). periodicBandGrid rejects it (a torus is periodic in BOTH
+// directions), so the wrap direction is read from the boundary's own parameter span here instead.
+func doublyPeriodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) (us, vs []float64, ok bool) {
+	if !isPeriodic(s.UDomain()) || !isPeriodic(s.VDomain()) || len(holes3D) != 0 {
+		return nil, nil, false // need a doubly-periodic surface and no holes
+	}
+	uu := make([]float64, len(outer3D))
+	vv := make([]float64, len(outer3D))
+	for i, p := range outer3D {
+		uu[i], vv[i] = s.ParamAt(p)
+	}
+	uWrap, vWrap := spansFullPeriod(uu), spansFullPeriod(vv)
+	if uWrap == vWrap {
+		return nil, nil, false // need exactly one direction wrapping the full period
+	}
+	if uWrap {
+		us, vs = bracketPeriod(uu), sortUnique(vv)
+	} else {
+		us, vs = sortUnique(uu), bracketPeriod(vv)
+	}
+	if len(us) < 2 || len(vs) < 2 {
+		return nil, nil, false
+	}
+	return us, vs, true
+}
+
+// spansFullPeriod reports whether a periodic parameter's samples cover essentially its whole [0,2π]
+// period (a band that wraps the seam), versus a bounded sub-range (the tube of a rim-fillet torus).
+func spansFullPeriod(g []float64) bool {
+	u := sortUnique(g)
+	return len(u) > 1 && u[len(u)-1]-u[0] > 2*stdmath.Pi-0.5
 }
 
 // coneApexFan tessellates a cone face that closes to its apex (a drill point): its single rim


### PR DESCRIPTION
## What

The first building block of the curved-adjacent ("fillet of a fillet") feature: the **closed-rim** case that terminates cleanly — a full circular rim rounded into a **toroidal band** — and the tessellator support it needs.

- `brep.SolidCylinderFilletedTop` — a closed B-rep whose top rim is a rolling-ball torus band (bottom cap, wall to z=h−r, torus blend, receded top cap), built with the low-level `topo.Builder` seam pattern (`assembleBody` is disk-topology). A **valid solid** with the rim material removed.
- `doublyPeriodicBandGrid` — the tessellator could not mesh a torus band at all: a torus is periodic in **both** directions, so `periodicBandGrid` rejected it and it fell through to the torn full-domain grid. It now reads the wrap direction from the boundary's own parameter span and meshes the band via `closedDomainMesh` — **watertight at the practical tolerances** the head and mass-properties use, with **no regression** on existing cylinder/cone/sphere bands.

## Why

This is the toroidal blend — the heart of the curved fillet — as valid, watertight geometry, and the foundation the run-out cases layer onto. The `doublyPeriodicBandGrid` change is independently useful (torus bands are now meshable).

## Scope / follow-ups (tracked)

- **Fine-tolerance seam**: at very fine tolerance the torus's smaller cap circle samples coarser than the band, leaving a hairline seam. The two boundary circles differ in radius, and the kernel's closed-band mesher (`closedDomainMesh`) conforms via `PointAt` grids that only match **same-radius** bands — so the fix is a closed-band-conformance rework (have closed bands honor the shared edge tessellation), not a local change. The test asserts watertightness at the practical tolerances (0.05, 1e-2).
- **Not yet wired into `FilletEdges`** (rim detection + param extraction is the next increment); **variable-radius run-out** for partial-arc edges is the increment after.

Stacked on #892 (Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)