### PR TITLE
fix(tessellate): loft the torus rim-fillet band for watertightness at all tolerances

### DIFF
--- a/kernel/ops/closed_band_loft.go
+++ b/kernel/ops/closed_band_loft.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// closedBandLoftMesh meshes a closed curved band whose two edge circles can carry DIFFERENT vertex
+// counts — a torus rim-fillet band, whose cap-tangent circle (smaller radius) tessellates coarser
+// than its cyl-tangent circle. closedDomainMesh grids the wrap direction at ONE resolution (a
+// `PointAt` grid), so it conforms only to neighbours sharing that resolution — fine for a cylinder
+// wall (same-radius caps), but it cracks a torus band against its plane cap and cylinder wall at
+// fine tolerance, and neither (a plane, a closed periodic band) can be re-meshed by the conformance
+// pass. This lofts the tube instead: each boundary ring is the EXACT tessellation of its own circle
+// edge (so it matches whatever neighbour shares that edge), the interior rings sample the finer
+// ring's angular stations, and consecutive rings are stitched watertight even at differing counts.
+//
+// The two rings are read from the face's boundary EDGES — the two closed circles + the seam arc
+// (its sample count sets the tube subdivision) — NOT from the boundary point soup, whose seam-arc
+// points all share angle 0 and pollute the v-partition. ok=false unless the band is exactly two
+// circle edges + one arc seam.
+func closedBandLoftMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
+	rings, seamN := bandRingsAndSeam(f, q)
+	if len(rings) != 2 || seamN < 2 {
+		return nil, false
+	}
+	lo, hi := orderedRing(s, rings[0]), orderedRing(s, rings[1])
+	if len(lo) < 3 || len(hi) < 3 {
+		return nil, false
+	}
+	vLo, vHi := vParam(s, lo[0]), vParam(s, hi[0])
+	if vLo > vHi {
+		lo, hi, vLo, vHi = hi, lo, vHi, vLo // lo is the smaller tube-parameter ring
+	}
+	mid := make([]float64, 0, seamN-2)
+	for k := 1; k < seamN-1; k++ {
+		mid = append(mid, vLo+(vHi-vLo)*float64(k)/float64(seamN-1))
+	}
+	return loftRows(s, lo, hi, mid), true
+}
+
+// bandRingsAndSeam reads the band face's boundary edges: each closed circle (with its closing
+// duplicate dropped) is a ring; seamN is the largest arc-edge sample count (the tube subdivision).
+func bandRingsAndSeam(f *topo.Face, q Quality) (rings [][]math.Point3, seamN int) {
+	for _, e := range f.Edges() {
+		switch e.Geometry().(type) {
+		case geom.Circle:
+			rings = append(rings, dropClosingDup(TessellateEdge(e, q)))
+		case geom.Arc3d:
+			if n := len(TessellateEdge(e, q)); n > seamN {
+				seamN = n
+			}
+		}
+	}
+	return rings, seamN
+}
+
+// dropClosingDup removes the trailing point a closed-edge tessellation repeats at its seam.
+func dropClosingDup(pts []math.Point3) []math.Point3 {
+	if len(pts) > 1 && pts[0].DistanceTo(pts[len(pts)-1]) < weldPointTol {
+		return pts[:len(pts)-1]
+	}
+	return pts
+}
+
+// vParam returns a point's tube parameter (the surface's v).
+func vParam(s geom.Surface, p math.Point3) float64 { _, v := s.ParamAt(p); return v }
+
+// orderedRing sorts a ring's points ascending by angle around the surface axis.
+func orderedRing(s geom.Surface, pts []math.Point3) []math.Point3 {
+	out := append([]math.Point3(nil), pts...)
+	sort.SliceStable(out, func(i, j int) bool { return angleOf(s, out[i]) < angleOf(s, out[j]) })
+	return out
+}
+
+// bandRow is one loft cross-section: the vertex indices around the ring and their INTENDED angles
+// (the tessellation/grid stations, NOT round-tripped through ParamAt — round-trip noise would make
+// the zipper's per-station order inconsistent between rows and overlap triangles).
+type bandRow struct {
+	idx []int
+	ang []float64
+}
+
+// loftRows builds the row vertices (the two edge rings at their own tessellations, the interior
+// rings at the finer ring's angular stations) and stitches consecutive rows watertight.
+func loftRows(s geom.Surface, lo, hi []math.Point3, midVs []float64) *Mesh {
+	m := &Mesh{}
+	loA, hiA := ringAngles(s, lo), ringAngles(s, hi)
+	baseU := loA
+	if len(hi) > len(lo) {
+		baseU = hiA // loft the interior at the finer ring's stations
+	}
+	rows := []bandRow{addRow(m, s, lo, loA)}
+	for _, v := range midVs {
+		rows = append(rows, addRow(m, s, sampleRow(s, baseU, v), baseU))
+	}
+	rows = append(rows, addRow(m, s, hi, hiA))
+	for i := 0; i+1 < len(rows); i++ {
+		stitchBandRows(m, rows[i], rows[i+1])
+	}
+	return m
+}
+
+// ringAngles returns the angles of an ordered ring.
+func ringAngles(s geom.Surface, ring []math.Point3) []float64 {
+	out := make([]float64, len(ring))
+	for i, p := range ring {
+		out[i] = angleOf(s, p)
+	}
+	return out
+}
+
+// sampleRow evaluates the surface at angular stations us and tube parameter v.
+func sampleRow(s geom.Surface, us []float64, v float64) []math.Point3 {
+	out := make([]math.Point3, len(us))
+	for i, u := range us {
+		out[i] = s.PointAt(u, v)
+	}
+	return out
+}
+
+// addRow adds a row's vertices (with surface normals) and returns the row with its intended angles.
+func addRow(m *Mesh, s geom.Surface, pts []math.Point3, ang []float64) bandRow {
+	idx := make([]int, len(pts))
+	for i, p := range pts {
+		u, v := s.ParamAt(p)
+		idx[i] = m.addVertex(p, s.NormalAt(u, v))
+	}
+	return bandRow{idx: idx, ang: ang}
+}
+
+// angleOf returns a point's angle around the surface axis (its u parameter).
+func angleOf(s geom.Surface, p math.Point3) float64 {
+	u, _ := s.ParamAt(p)
+	return u
+}
+
+// stitchBandRows triangulates the closed strip between two rows. When they share a station count
+// (an aligned pair, both at the same angular stations) it emits a clean quad strip by index; when
+// the counts differ (the coarser edge circle against the finer interior) it zips them in angle order
+// using the intended angles. emitClosedTri winds each triangle outward by its vertex normals.
+func stitchBandRows(m *Mesh, a, b bandRow) {
+	if len(a.idx) < 3 || len(b.idx) < 3 {
+		return
+	}
+	if len(a.idx) == len(b.idx) {
+		n := len(a.idx)
+		for i := 0; i < n; i++ {
+			ni := (i + 1) % n
+			emitClosedTri(m, a.idx[i], a.idx[ni], b.idx[ni])
+			emitClosedTri(m, a.idx[i], b.idx[ni], b.idx[i])
+		}
+		return
+	}
+	zipUnequalRows(m, a, b)
+}
+
+// zipUnequalRows stitches two rings of DIFFERING counts by merging their vertices in intended-angle
+// order: each vertex forms a triangle with the running vertex of the opposite ring (a zipper),
+// closing the seam. The intended angles (not ParamAt round-trips) keep the per-station order stable.
+func zipUnequalRows(m *Mesh, a, b bandRow) {
+	type event struct {
+		ang float64
+		v   int
+		isA bool
+	}
+	evs := make([]event, 0, len(a.idx)+len(b.idx))
+	for i, v := range a.idx {
+		evs = append(evs, event{a.ang[i], v, true})
+	}
+	for i, v := range b.idx {
+		evs = append(evs, event{b.ang[i], v, false})
+	}
+	sort.SliceStable(evs, func(i, j int) bool {
+		if stdmath.Abs(evs[i].ang-evs[j].ang) > 1e-9 {
+			return evs[i].ang < evs[j].ang
+		}
+		return evs[i].isA && !evs[j].isA // break ties A-before-B so an aligned pair makes a clean quad
+	})
+	curA, curB := a.idx[len(a.idx)-1], b.idx[len(b.idx)-1] // largest-angle verts: the first events bridge the seam
+	for _, e := range evs {
+		if e.isA {
+			emitClosedTri(m, curA, e.v, curB)
+			curA = e.v
+		} else {
+			emitClosedTri(m, curB, e.v, curA)
+			curB = e.v
+		}
+	}
+}

--- a/kernel/ops/fillet_rim_test.go
+++ b/kernel/ops/fillet_rim_test.go
@@ -14,11 +14,9 @@ import (
 
 // TestRimFilletTorusBand checks the closed-rim ("no run-out") curved fillet: a cylinder whose top
 // rim is rounded into a toroidal band is a valid solid with one torus face, material removed, and a
-// WATERTIGHT mesh at practical tolerances — exercising the doubly-periodic torus-band tessellation
-// path (doublyPeriodicBandGrid). It is the foundation for the run-out cases: a torus band that closes
-// on itself. The fine-tolerance seam between the torus and the smaller-radius cap circle still needs a
-// loft-between-rings mesher (next increment), so watertightness is asserted at the practical
-// tolerances the head and mass-properties use.
+// WATERTIGHT mesh across tolerances — exercising the doubly-periodic torus-band loft
+// (closedBandLoftMesh), which lofts the tube between each circle edge's OWN tessellation so the
+// differing-radius cap and cyl circles both seam to their neighbours watertight at any resolution.
 func TestRimFilletTorusBand(t *testing.T) {
 	b, err := brep.SolidCylinderFilletedTop(math.P3(0, 0, 0), math.V3(0, 0, 1), 1.0, 2.0, 0.3)
 	if err != nil {
@@ -41,7 +39,7 @@ func TestRimFilletTorusBand(t *testing.T) {
 	if tor != 1 || cyl != 1 || pln != 2 {
 		t.Errorf("faces: torus=%d cyl=%d plane=%d, want 1/1/2", tor, cyl, pln)
 	}
-	for _, tol := range []float64{0.05, 1e-2} {
+	for _, tol := range []float64{0.05, 1e-2, 1e-3, 1e-4} {
 		m, _ := ops.TessellateBody(b, ops.Quality{ChordTolerance: tol})
 		if open := meshOpenEdges(m); open != 0 {
 			t.Errorf("rim-fillet mesh at tol %g has %d open edges, want watertight", tol, open)
@@ -51,5 +49,28 @@ func TestRimFilletTorusBand(t *testing.T) {
 	v := ops.BodyGeometryProperties(b, ops.Quality{ChordTolerance: 1e-3}).Volume
 	if v >= full || v < full-0.5 {
 		t.Errorf("rim-fillet volume = %g, want a little under the full cylinder %g (rim notch removed)", v, full)
+	}
+}
+
+// TestRimFilletWatertightAcrossSizes checks the torus-band loft stays a watertight valid solid over
+// a range of radius/height/fillet ratios (the cap and cyl circles tessellate at different counts, so
+// the loft's differing-ring stitch is exercised differently each time).
+func TestRimFilletWatertightAcrossSizes(t *testing.T) {
+	cases := []struct{ R, h, r float64 }{{1, 2, 0.3}, {2, 3, 0.5}, {0.5, 1, 0.1}, {1.5, 4, 0.7}, {3, 2, 0.9}}
+	for _, c := range cases {
+		b, err := brep.SolidCylinderFilletedTop(math.P3(0, 0, 0), math.V3(0, 0, 1), c.R, c.h, c.r)
+		if err != nil {
+			t.Errorf("R=%g h=%g r=%g: %v", c.R, c.h, c.r, err)
+			continue
+		}
+		if rep := ops.Validate(b); !rep.Valid || !b.IsSolid() {
+			t.Errorf("R=%g r=%g: not a valid solid: %+v", c.R, c.r, rep.Issues)
+		}
+		for _, tol := range []float64{0.05, 1e-2, 1e-3, 1e-4} {
+			m, _ := ops.TessellateBody(b, ops.Quality{ChordTolerance: tol})
+			if open := meshOpenEdges(m); open != 0 {
+				t.Errorf("R=%g h=%g r=%g at tol %g: %d open edges", c.R, c.h, c.r, tol, open)
+			}
+		}
 	}
 }

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -42,7 +42,7 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	}
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
-		return meshSeamCrossingFace(s, outer3D, holes3D, q) // a loop wrapping the seam: band/cap fallbacks
+		return meshSeamCrossingFace(f, s, outer3D, holes3D, q) // a loop wrapping the seam: band/cap fallbacks
 	}
 	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
@@ -54,12 +54,15 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 // can't unwrap it): a full cylinder/cone side or a torus rim-fillet band closes the seam watertight via
 // closedDomainMesh; a singly-periodic sphere cap straddling the pole goes through the best-fit-plane CDT
 // (the full-domain grid tears there); a doubly-periodic torus we can't reduce keeps the full-domain grid.
-func meshSeamCrossingFace(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) *Mesh {
+func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) *Mesh {
 	if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
 		return closedDomainMesh(s, us, vs) // full cylinder/cone side: wraps the seam watertight
 	}
-	if us, vs, isBand := doublyPeriodicBandGrid(s, outer3D, holes3D); isBand {
-		return closedDomainMesh(s, us, vs) // torus rim-fillet band: wraps the axis, bounded in the tube
+	if _, _, isBand := doublyPeriodicBandGrid(s, outer3D, holes3D); isBand {
+		if m, ok := closedBandLoftMesh(f, s, q); ok {
+			return m // torus rim-fillet band: loft so each edge ring keeps its own (differing) tessellation
+		}
+		return fullDomainGridMesh(s, q) // shouldn't reach: a doubly-periodic band that isn't two circles + a seam
 	}
 	if isPeriodic(s.UDomain()) != isPeriodic(s.VDomain()) {
 		return trimmedPatchMesh(s, outer3D, holes3D) // sphere cap on the pole: CDT in the best-fit plane


### PR DESCRIPTION
## What

The closed-band conformance rework: a torus rim-fillet band now meshes **watertight at every tolerance** (0.05 → 1e-4), closing the fine-tolerance seam left by the foundation PR (#894).

## Why it cracked

The band was meshed by `closedDomainMesh`, which grids the wrap direction at one resolution via a `PointAt` grid — so it conforms only to neighbours sharing that resolution. A cylinder wall works (both caps same radius), but a torus band's two edge circles **differ in radius** (cap-tangent `Rc−r` vs cyl-tangent `Rc`) and tessellate at different counts, so it cracked against the plane cap and the cylinder wall at fine tolerance. Neither neighbour (a plane; a closed periodic band) can be re-meshed by the conformance pass — so the **band itself** must conform.

## Fix — `closedBandLoftMesh`

Lofts the tube between the two rings instead of gridding:
- reads the two rings from the face's **circle edges** (the exact tessellations the neighbours share) and the seam arc (its sample count sets the tube subdivision) — not the seam-polluted boundary point soup, whose arc points all share angle 0;
- stitches consecutive rings: a clean **index quad-strip** where counts match, a **merge-by-intended-angle zipper** where they differ (the coarser cap circle against the finer interior). Intended angles (not `ParamAt` round-trips, whose noise reorders aligned stations) keep it watertight.

## Tests

`TestRimFilletTorusBand` now asserts watertight at 0.05…1e-4; `TestRimFilletWatertightAcrossSizes` sweeps radius/height/fillet ratios. No regression on cylinder/cone/sphere bands (they keep `closedDomainMesh`); full `kernel/ops`, `kernel/brep`, `model/feature` suites green; lint clean.

Next on the curved-fillet roadmap: wire the rim fillet into `FilletEdges` (rim detection), then variable-radius run-out for partial-arc edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)