### PR TITLE
test(addin): cover modelaccess, opregistry, trace (coverage installment 1)

### DIFF
--- a/addin/modelaccess/modelaccess_test.go
+++ b/addin/modelaccess/modelaccess_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package modelaccess
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+func TestActivePart(t *testing.T) {
+	// No active document.
+	if _, err := ActivePart(app.NewSession()); !errors.Is(err, ErrNoActiveDocument) {
+		t.Fatalf("ActivePart(empty) = %v, want ErrNoActiveDocument", err)
+	}
+
+	// A realized part document.
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Part, "p.obk", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	if got, err := ActivePart(s); err != nil || got != def {
+		t.Fatalf("ActivePart(part) = %v, %v; want the part definition", got, err)
+	}
+
+	// The active document is not a part.
+	as := app.NewSession()
+	ad, _ := as.Workspace().Add(doc.Assembly, "a.obk", true)
+	ad.SetContent(compdef.NewAssemblyComponentDefinition())
+	if _, err := ActivePart(as); err == nil {
+		t.Fatal("ActivePart(assembly) = nil error, want a not-a-part error")
+	}
+}
+
+func TestActiveAssembly(t *testing.T) {
+	if _, err := ActiveAssembly(app.NewSession()); !errors.Is(err, ErrNoActiveDocument) {
+		t.Fatalf("ActiveAssembly(empty) = %v, want ErrNoActiveDocument", err)
+	}
+
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Assembly, "a.obk", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := compdef.NewAssemblyComponentDefinition()
+	d.SetContent(def)
+	if got, err := ActiveAssembly(s); err != nil || got != def {
+		t.Fatalf("ActiveAssembly(assembly) = %v, %v; want the assembly definition", got, err)
+	}
+
+	ps := app.NewSession()
+	pd, _ := ps.Workspace().Add(doc.Part, "p.obk", true)
+	pd.SetContent(compdef.NewPartComponentDefinition())
+	if _, err := ActiveAssembly(ps); err == nil {
+		t.Fatal("ActiveAssembly(part) = nil error, want a not-an-assembly error")
+	}
+}

--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -35,16 +35,14 @@ func profiledPart(t *testing.T) *app.Session {
 	return s
 }
 
-// addRect draws a closed w×h rectangle at the sketch origin (one profile).
+// addRect draws a closed w×h rectangle at the sketch origin (one profile), chaining the
+// four corners into a loop.
 func addRect(sk *sketch.Sketch, w, h float64) {
-	c0 := sk.Points().Add(math.P2(0, 0))
-	c1 := sk.Points().Add(math.P2(w, 0))
-	c2 := sk.Points().Add(math.P2(w, h))
-	c3 := sk.Points().Add(math.P2(0, h))
-	sk.Lines().Add(c0, c1)
-	sk.Lines().Add(c1, c2)
-	sk.Lines().Add(c2, c3)
-	sk.Lines().Add(c3, c0)
+	at := func(x, y float64) *sketch.Point { return sk.Points().Add(math.P2(x, y)) }
+	corners := []*sketch.Point{at(0, 0), at(w, 0), at(w, h), at(0, h)}
+	for i, c := range corners {
+		sk.Lines().Add(c, corners[(i+1)%len(corners)])
+	}
 }
 
 // apply runs the named default-registry operation with JSON args.

--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// profiledPart builds a session whose active part has a "width" parameter and two
+// sketches, each holding a closed rectangle profile (sketch 0 on XY, sketch 1 on a
+// plane 10 cm up) — enough geometry for the additive operations to consume.
+func profiledPart(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Part, "t.obk", true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	if _, err := def.Parameters().AddUserParameter("width", "4 cm"); err != nil {
+		t.Fatalf("add parameter: %v", err)
+	}
+	addRect(def.Sketches().Add(sketch.XYPlane()), 4, 3)
+	addRect(def.Sketches().Add(sketch.XYPlane()), 4, 3)
+	def.Recompute()
+	return s
+}
+
+// addRect draws a closed w×h rectangle at the sketch origin (one profile).
+func addRect(sk *sketch.Sketch, w, h float64) {
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(w, 0))
+	c2 := sk.Points().Add(math.P2(w, h))
+	c3 := sk.Points().Add(math.P2(0, h))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}
+
+// apply runs the named default-registry operation with JSON args.
+func apply(t *testing.T, s *app.Session, name, args string) (json.RawMessage, error) {
+	t.Helper()
+	d, ok := Default().ByName(name)
+	if !ok {
+		t.Fatalf("no descriptor named %q", name)
+	}
+	return d.Apply(s, json.RawMessage(args))
+}
+
+// TestExtrudeApply drives every extent/direction/taper branch of the reference
+// operation, plus its validation errors.
+func TestExtrudeApply(t *testing.T) {
+	ok := []struct{ name, args string }{
+		{"distance new", `{"sketchIndex":0,"profileIndex":0,"distance":"10 mm","operation":"new"}`},
+		{"symmetric", `{"sketchIndex":0,"distance":"8 mm","direction":"symmetric"}`},
+		{"negative + taper", `{"sketchIndex":0,"distance":"6 mm","direction":"negative","taper":"3 deg"}`},
+		{"two-direction", `{"sketchIndex":0,"distance":"6 mm","secondDistance":"4 mm"}`},
+		{"through-all", `{"sketchIndex":0,"extent":"through-all"}`},
+		{"expression distance", `{"sketchIndex":0,"distance":"width/2"}`},
+	}
+	for _, c := range ok {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := apply(t, profiledPart(t), "extrude", c.args); err != nil {
+				t.Fatalf("extrude %s: unexpected error: %v", c.name, err)
+			}
+		})
+	}
+
+	bad := []struct{ name, args, want string }{
+		{"bad json", `{`, "invalid args"},
+		{"sketch out of range", `{"sketchIndex":9,"distance":"1 mm"}`, "out of range"},
+		{"unknown operation", `{"sketchIndex":0,"distance":"1 mm","operation":"melt"}`, "unknown operation"},
+		{"unknown extent", `{"sketchIndex":0,"extent":"to-infinity"}`, "unknown extent"},
+		{"zero distance", `{"sketchIndex":0,"distance":"0 mm"}`, "zero"},
+		{"bad taper", `{"sketchIndex":0,"distance":"1 mm","taper":"banana"}`, "taper"},
+	}
+	for _, c := range bad {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := apply(t, profiledPart(t), "extrude", c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("extrude %s: err = %v, want it to contain %q", c.name, err, c.want)
+			}
+		})
+	}
+}
+
+// extrudedSolid seeds a part with one extruded box body and returns the session plus the
+// reference-key strings of its first edge and first face — real keys for the dress-up ops.
+func extrudedSolid(t *testing.T) (s *app.Session, edgeKey, faceKey string) {
+	t.Helper()
+	s = profiledPart(t)
+	if _, err := apply(t, s, "extrude", `{"sketchIndex":0,"distance":"10 mm"}`); err != nil {
+		t.Fatalf("seed extrude: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if def.SurfaceBodies().Count() == 0 {
+		t.Fatal("seed extrude produced no body")
+	}
+	b := def.SurfaceBodies().Item(0)
+	if len(b.Edges()) == 0 || len(b.Faces()) == 0 {
+		t.Fatalf("extruded body has %d edges, %d faces", len(b.Edges()), len(b.Faces()))
+	}
+	return s, string(b.Edges()[0].ReferenceKey()), string(b.Faces()[0].ReferenceKey())
+}
+
+// applyMap marshals args (so a binary reference key is JSON-escaped the way the router
+// does) and runs the operation.
+func applyMap(t *testing.T, s *app.Session, op string, args map[string]any) (json.RawMessage, error) {
+	t.Helper()
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal %s args: %v", op, err)
+	}
+	return apply(t, s, op, string(raw))
+}
+
+// TestDressUpOnSolid drives the dress-up operations with REAL edge/face reference keys,
+// covering the feature-building success path of each (recomputeResult reports geometry
+// health in the result, so a valid request never errors here).
+func TestDressUpOnSolid(t *testing.T) {
+	edgeCases := []struct {
+		name, op string
+		args     map[string]any
+	}{
+		{"fillet flat", "fillet", map[string]any{"radius": "1 mm"}},
+		{"fillet set const", "fillet", map[string]any{"_set": "radius"}},
+		{"fillet set variable", "fillet", map[string]any{"_set": "var"}},
+		{"chamfer distance", "chamfer", map[string]any{"distance": "1 mm"}},
+		{"chamfer two distances", "chamfer", map[string]any{"distance": "1 mm", "distance2": "2 mm", "chamferType": "twoDistances"}},
+		{"chamfer distance angle", "chamfer", map[string]any{"distance": "1 mm", "angle": "30 deg", "chamferType": "distanceAndAngle"}},
+		{"lip", "lip", map[string]any{"width": "1 mm", "height": "1 mm"}},
+	}
+	for _, c := range edgeCases {
+		t.Run(c.name, func(t *testing.T) {
+			s, edge, _ := extrudedSolid(t)
+			args := c.args
+			switch args["_set"] {
+			case "radius":
+				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "radius": "1 mm"}}}
+			case "var":
+				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "startRadius": "1 mm", "endRadius": "2 mm"}}}
+			default:
+				args["edgeRefs"] = []string{edge}
+			}
+			if _, err := applyMap(t, s, c.op, args); err != nil {
+				t.Fatalf("%s: %v", c.name, err)
+			}
+		})
+	}
+	faceCases := []struct {
+		name, op string
+		args     map[string]any
+	}{
+		{"shell", "shell", map[string]any{"thickness": "1 mm"}},
+		{"draft", "draft", map[string]any{"angle": "3 deg"}},
+	}
+	for _, c := range faceCases {
+		t.Run(c.name, func(t *testing.T) {
+			s, _, face := extrudedSolid(t)
+			c.args["faceRefs"] = []string{face}
+			if _, err := applyMap(t, s, c.op, c.args); err != nil {
+				t.Fatalf("%s: %v", c.name, err)
+			}
+		})
+	}
+}
+
+// TestDressUpRejectsEmptyRefs: each dress-up op rejects a missing reference list.
+func TestDressUpRejectsEmptyRefs(t *testing.T) {
+	for _, op := range []string{"fillet", "chamfer", "shell", "draft", "lip"} {
+		s, _, _ := extrudedSolid(t)
+		if _, err := apply(t, s, op, `{"radius":"1 mm","distance":"1 mm","thickness":"1 mm","angle":"3 deg","width":"1 mm","height":"1 mm"}`); err == nil {
+			t.Errorf("%s with no refs should error", op)
+		}
+	}
+}
+
+// TestExtrudeNeedsActivePart: the operation surfaces the no-part error.
+func TestExtrudeNeedsActivePart(t *testing.T) {
+	if _, err := apply(t, app.NewSession(), "extrude", `{"sketchIndex":0,"distance":"1 mm"}`); err == nil {
+		t.Fatal("extrude without an active part should error")
+	}
+}
+
+// TestParseHelpers covers the pure string→enum mappers directly.
+func TestParseHelpers(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want bool // expect ok (no error)
+	}{{"", true}, {"distance", true}, {"through-all", true}, {"to-next", true}, {"nope", false}} {
+		_, err := parseExtentType(c.in)
+		if (err == nil) != c.want {
+			t.Errorf("parseExtentType(%q) err=%v, want ok=%v", c.in, err, c.want)
+		}
+	}
+	if parseExtentDirection("negative") == parseExtentDirection("symmetric") {
+		t.Error("negative and symmetric directions must differ")
+	}
+	if parseExtentDirection("garbage") != parseExtentDirection("positive") {
+		t.Error("unknown direction must default to positive")
+	}
+	for _, op := range []string{"new", "join", "cut", "intersect"} {
+		if _, err := parseOperation(op); err != nil {
+			t.Errorf("parseOperation(%q): %v", op, err)
+		}
+	}
+	if _, err := parseOperation("blend"); err == nil {
+		t.Error("parseOperation(blend) should error")
+	}
+}
+
+// TestEveryOperationHandlesArgsCleanly drives each default descriptor's Apply against a
+// seeded part: with representative args it must return a result OR a descriptive error,
+// never panic. This exercises the argument-parsing/resolution path of every operation.
+func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
+	// Representative args per operation. Many additive ops succeed on the seeded profile;
+	// reference-bearing ops (dress-up, holes) return a clean "needs a reference" error,
+	// which still exercises their decode/resolve code.
+	args := map[string]string{
+		"extrude":             `{"sketchIndex":0,"distance":"10 mm"}`,
+		"revolve":             `{"sketchIndex":0,"angle":"360 deg"}`,
+		"rib":                 `{"sketchIndex":0,"thickness":"2 mm","depth":"5 mm"}`,
+		"emboss":              `{"sketchIndex":0,"depth":"1 mm"}`,
+		"coil":                `{"sketchIndex":0,"pitch":"5 mm","revolutions":3}`,
+		"loft":                `{"sections":[{"sketchIndex":0,"profileIndex":0},{"sketchIndex":1,"profileIndex":0}]}`,
+		"sweep":               `{"sketchIndex":0,"path":{"sketchIndex":1}}`,
+		"fillet":              `{"edges":["e1"],"radius":"1 mm"}`,
+		"chamfer":             `{"edges":["e1"],"distance":"1 mm"}`,
+		"shell":               `{"faces":["f1"],"thickness":"1 mm"}`,
+		"draft":               `{"faces":["f1"],"angle":"3 deg","neutralFace":"f2"}`,
+		"lip":                 `{"edges":["e1"],"width":"1 mm","height":"1 mm"}`,
+		"hole":                `{"faceRef":"f1","diameter":"3 mm","depth":"5 mm"}`,
+		"boss":                `{"faceRef":"f1","diameter":"3 mm","height":"5 mm"}`,
+		"grill":               `{"faceRef":"f1"}`,
+		"thread":              `{"faceRef":"f1"}`,
+		"combine":             `{"operation":"join","toolBody":1}`,
+		"thicken":             `{"faces":["f1"],"thickness":"1 mm"}`,
+		"trim":                `{"sketchIndex":0}`,
+		"directEdit":          `{"faces":["f1"]}`,
+		"moveFace":            `{"faces":["f1"]}`,
+		"faceOffset":          `{"faces":["f1"],"distance":"1 mm"}`,
+		"deleteFace":          `{"faces":["f1"]}`,
+		"split":               `{"faces":["f1"],"toolSketch":0}`,
+		"replaceFace":         `{"faces":["f1"]}`,
+		"simplify":            `{}`,
+		"unwrap":              `{"faces":["f1"]}`,
+		"modelTolerance":      `{"linear":"0.01 mm"}`,
+		"moveBody":            `{"body":0,"type":"freeDrag","x":"1 mm"}`,
+		"bendPart":            `{}`,
+		"splitSolid":          `{"toolSketch":0}`,
+		"coreCavity":          `{}`,
+		"hull":                `{}`,
+		"patternRectangular":  `{"feature":0,"count":2,"spacing":"5 mm"}`,
+		"patternCircular":     `{"feature":0,"count":3,"angle":"120 deg"}`,
+		"mirror":              `{"feature":0,"plane":"XY"}`,
+		"patternSketchDriven": `{"feature":0,"sketchIndex":0}`,
+		"boundaryPatch":       `{"edges":["e1"]}`,
+		"ruledSurface":        `{"edges":["e1"],"distance":"1 mm"}`,
+		"surfaceOffset":       `{"faces":["f1"],"distance":"1 mm"}`,
+		"extend":              `{"edges":["e1"],"distance":"1 mm"}`,
+		"midSurface":          `{"faces":["f1"]}`,
+		"stitch":              `{"faces":["f1"]}`,
+		"sculpt":              `{"faces":["f1"]}`,
+		"freeformBox":         `{"length":"10 mm","width":"10 mm","height":"10 mm"}`,
+		"freeformPlane":       `{"length":"10 mm","width":"10 mm"}`,
+		"freeformQuadBall":    `{"radius":"5 mm"}`,
+		"mesh":                `{}`,
+	}
+	for _, d := range Default().All() {
+		a, ok := args[d.Name]
+		if !ok {
+			t.Errorf("no representative args for operation %q — add one", d.Name)
+			continue
+		}
+		t.Run(d.Name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("operation %q panicked on %s: %v", d.Name, a, r)
+				}
+			}()
+			if _, err := d.Apply(profiledPart(t), json.RawMessage(a)); err != nil {
+				// A descriptive error is fine (e.g. an unresolved reference); a bare or
+				// empty message is not.
+				if strings.TrimSpace(err.Error()) == "" {
+					t.Fatalf("operation %q returned an empty error", d.Name)
+				}
+			}
+		})
+	}
+}

--- a/addin/trace/sloghandler_test.go
+++ b/addin/trace/sloghandler_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package trace
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestSlogHandlerFoldsRecords drives the slog.Handler: level mapping, the Enabled filter,
+// and WithAttrs/WithGroup folding attrs (namespaced) onto the message.
+func TestSlogHandlerFoldsRecords(t *testing.T) {
+	b := NewBuffer(0)
+	log := slog.New(b.SlogHandler(slog.LevelDebug))
+
+	log.Debug("tiny")
+	log.With("svc", "kernel").WithGroup("op").Info("built", "id", 7)
+	log.Warn("careful")
+	log.Error("boom", "code", 500)
+
+	res := b.Tail(0, "", 0)
+	if len(res.Records) != 4 {
+		t.Fatalf("got %d records, want 4", len(res.Records))
+	}
+	for i, want := range []string{"debug", "info", "warn", "error"} {
+		if res.Records[i].Level != want {
+			t.Errorf("record %d level = %q, want %q", i, res.Records[i].Level, want)
+		}
+		if res.Records[i].Method != "" {
+			t.Errorf("record %d Method = %q, want empty (a log, not an op)", i, res.Records[i].Method)
+		}
+	}
+	if m := res.Records[1].Message; !strings.Contains(m, "built") || !strings.Contains(m, "svc=kernel") || !strings.Contains(m, "op.id=7") {
+		t.Errorf("info message = %q, want it to carry built + svc=kernel + op.id=7", m)
+	}
+	if m := res.Records[3].Message; !strings.Contains(m, "code=500") {
+		t.Errorf("error message = %q, want code=500", m)
+	}
+}
+
+// TestSlogHandlerEnabledFilter: a record below the handler's level is dropped.
+func TestSlogHandlerEnabledFilter(t *testing.T) {
+	b := NewBuffer(0)
+	h := b.SlogHandler(slog.LevelWarn)
+	log := slog.New(h)
+	log.Info("dropped")
+	log.Warn("kept")
+	if res := b.Tail(0, "", 0); len(res.Records) != 1 || res.Records[0].Level != "warn" {
+		t.Fatalf("tail = %+v, want only the warn record", res.Records)
+	}
+}


### PR DESCRIPTION
First installment of raising **`addin/` coverage toward >90%**. Test-only — no production changes.

| Package | Before | After |
|---|---|---|
| `modelaccess` | 0% | **100%** |
| `opregistry` | 5.2% | **54.1%** |
| `trace` | 78.3% | **97.1%** |
| **addin (aggregate)** | 65.2% | **73.0%** |

## What
- **modelaccess** — `ActivePart`/`ActiveAssembly` across all branches (no doc, wrong kind, success).
- **opregistry** — a profiled-part session helper drives the operation registry directly (coverage is credited per-package, so the tests live here, not in `router`):
  - `extrude` across every extent/direction/taper branch + all validation errors;
  - **dress-up** (`fillet` flat/sets/variable, `chamfer` 3 modes, `shell`, `draft`, `lip`) against **real** edge/face reference keys pulled from an extruded solid — hitting the feature-building success paths;
  - the pure parse helpers (`parseExtentType`/`Direction`/`Operation`);
  - a smoke test asserting every descriptor's `Apply` handles representative args without panicking.
- **trace** — the `slog.Handler` (level mapping, `Enabled` filter, `WithAttrs`/`WithGroup` attr folding).

## Remaining toward >90% (next installments)
- `opregistry` 54%→90%: the additive success paths (revolve/rib/coil/loft/sweep/emboss) and direct-edit/pattern/surfacing/freeform/mesh ops.
- `router` 76%→90%: the largest absolute gap (~1690 uncovered statements).
- `events` 76%→90%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)