### PR TITLE
test(router): API↔router parity guard + sketch.addEntity coverage

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -44,7 +44,7 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // emit them (the representations / model-state surface has no app-level event yet). They
 // are tracked debt: when that feature fires an app event, relay it in addin/events and
 // DELETE it from this list. Any OTHER unrelayed event fails the test below — so this list
-// may only shrink.
+// may only shrink. See https://github.com/Oblikovati/Oblikovati/issues/901.
 var notYetRelayed = map[string]bool{
 	"EventModelStateActivated":     true,
 	"EventRepresentationActivated": true,

--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+)
+
+// TestEveryWireMethodHasAHandler is the API↔router parity guard: every wire.Method*
+// constant declared in the public contract MUST be registered in the router, or this
+// fails. It is what stops a new wire method from shipping in the API while the router
+// silently never handles it.
+func TestEveryWireMethodHasAHandler(t *testing.T) {
+	methods := wireConstants(t, "Method")
+	if len(methods) == 0 {
+		t.Fatal("parsed zero wire Method constants — the wire source lookup is broken")
+	}
+	r := New(opregistry.Default())
+	var missing []string
+	for name, value := range methods {
+		if _, ok := r.handlers[value]; !ok {
+			missing = append(missing, name+" = "+strconv.Quote(value))
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("%d wire method(s) declared in the API have NO router handler:\n  %s",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+}
+
+// notYetRelayed are wire events the API declares ahead of the host behavior that would
+// emit them (the representations / model-state surface has no app-level event yet). They
+// are tracked debt: when that feature fires an app event, relay it in addin/events and
+// DELETE it from this list. Any OTHER unrelayed event fails the test below — so this list
+// may only shrink.
+var notYetRelayed = map[string]bool{
+	"EventModelStateActivated":     true,
+	"EventRepresentationActivated": true,
+	"EventRepresentationCaptured":  true,
+}
+
+// TestEveryWireEventIsRelayed guards the other direction: every wire.Event* constant
+// must be referenced by the add-in's event relay (addin/events) or the router, so a
+// declared host→add-in event cannot be left unrelayed (except the tracked debt above).
+func TestEveryWireEventIsRelayed(t *testing.T) {
+	events := wireConstants(t, "Event")
+	if len(events) == 0 {
+		t.Fatal("parsed zero wire Event constants — the wire source lookup is broken")
+	}
+	used := identifiersUsedIn(t, "oblikovati.org/addin/events", "oblikovati.org/addin/router")
+	var missing []string
+	for name := range events {
+		if !used[name] && !notYetRelayed[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Fatalf("%d wire event(s) declared in the API are never relayed:\n  %s",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+	// The allowlist may only shrink: a tracked event that is now relayed (or is no longer
+	// a declared event) must be removed from it.
+	for name := range notYetRelayed {
+		if used[name] {
+			t.Errorf("event %q is now relayed — delete it from notYetRelayed", name)
+		}
+		if _, declared := events[name]; !declared {
+			t.Errorf("notYetRelayed lists %q, which is not a wire Event constant", name)
+		}
+	}
+}
+
+// wireConstants parses the oblikovati.org/api/wire package source and returns the
+// {name: value} of every string const whose name starts with prefix (e.g. "Method").
+func wireConstants(t *testing.T, prefix string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	fset := token.NewFileSet()
+	for _, dir := range packageDirs(t, "oblikovati.org/api/wire") {
+		pkgs, err := parser.ParseDir(fset, dir, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", dir, err)
+		}
+		for _, pkg := range pkgs {
+			for _, file := range pkg.Files {
+				collectStringConsts(file, prefix, out)
+			}
+		}
+	}
+	return out
+}
+
+// collectStringConsts records every `Name = "value"` const whose name starts with prefix.
+func collectStringConsts(file *ast.File, prefix string, out map[string]string) {
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+				continue
+			}
+			lit, ok := vs.Values[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			if name := vs.Names[0].Name; strings.HasPrefix(name, prefix) {
+				if v, err := strconv.Unquote(lit.Value); err == nil {
+					out[name] = v
+				}
+			}
+		}
+	}
+}
+
+// identifiersUsedIn returns the set of identifier names referenced anywhere in the given
+// packages' .go files (excluding tests) — used to confirm an event constant is consumed.
+func identifiersUsedIn(t *testing.T, importPaths ...string) map[string]bool {
+	t.Helper()
+	used := map[string]bool{}
+	fset := token.NewFileSet()
+	for _, ip := range importPaths {
+		for _, dir := range packageDirs(t, ip) {
+			pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+				return !strings.HasSuffix(fi.Name(), "_test.go")
+			}, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", dir, err)
+			}
+			for _, pkg := range pkgs {
+				for _, file := range pkg.Files {
+					ast.Inspect(file, func(n ast.Node) bool {
+						if id, ok := n.(*ast.Ident); ok {
+							used[id.Name] = true
+						}
+						return true
+					})
+				}
+			}
+		}
+	}
+	return used
+}
+
+// packageDirs resolves an import path to its on-disk directory via `go list` (which
+// honors the go.work / CI replace that points oblikovati.org/api at the sibling checkout).
+func packageDirs(t *testing.T, importPath string) []string {
+	t.Helper()
+	out, err := exec.Command("go", "list", "-f", "{{.Dir}}", importPath).Output()
+	if err != nil {
+		t.Fatalf("go list %s: %v", importPath, err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" || !filepath.IsAbs(dir) {
+		t.Fatalf("go list %s returned %q", importPath, dir)
+	}
+	return []string{dir}
+}

--- a/addin/router/sketch_add_entity_coverage_test.go
+++ b/addin/router/sketch_add_entity_coverage_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// tryCall invokes a method and returns its error (for paths where a clean error on
+// finicky geometry is acceptable but a panic/crash is not).
+func tryCall(t *testing.T, r *Router, s *app.Session, method, args string) error {
+	t.Helper()
+	_, err := r.Handle(s, method, []byte(args))
+	return err
+}
+
+// TestSketchAddEntityMoreKinds drives the sketch.addEntity kinds the existing
+// TestSketchAddEntityKinds does not (the composite shapes, derived curves, and the
+// construction flag), so every per-kind builder is exercised.
+func TestSketchAddEntityMoreKinds(t *testing.T) {
+	kinds := []struct{ name, args string }{
+		{"circle center", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[0,0]],"radius":"2 cm"}`},
+		{"circle threePoint", `{"sketchIndex":0,"kind":"circle","variant":"threePoint","points":[[0,0],[2,0],[1,1]]}`},
+		{"rectangle center", `{"sketchIndex":0,"kind":"rectangle","variant":"center","points":[[0,0],[3,2]]}`},
+		{"rectangle threePoint", `{"sketchIndex":0,"kind":"rectangle","variant":"threePoint","points":[[0,0],[4,0],[0,2]]}`},
+		{"polygon", `{"sketchIndex":0,"kind":"polygon","points":[[0,0],[2,0]],"sides":6}`},
+		{"slot", `{"sketchIndex":0,"kind":"slot","points":[[0,0],[5,0]],"width":"2 cm"}`},
+		{"polyline", `{"sketchIndex":0,"kind":"polyline","points":[[0,0],[2,0],[2,2]]}`},
+		{"construction line", `{"sketchIndex":0,"kind":"line","points":[[0,0],[1,1]],"construction":true}`},
+		{"equationCurve", `{"sketchIndex":0,"kind":"equationCurve","xExpr":"t","yExpr":"t*t","t0":0,"t1":1}`},
+	}
+	for _, k := range kinds {
+		t.Run(k.name, func(t *testing.T) {
+			r, s := seededSession(t)
+			if err := tryCall(t, r, s, "sketch.addEntity", k.args); err != nil {
+				t.Fatalf("sketch.addEntity %s: %v", k.name, err)
+			}
+		})
+	}
+}
+
+// TestSketchFilletChamfer drives the two entity-reference composite kinds (corner fillet
+// and chamfer between two connected lines).
+func TestSketchFilletChamfer(t *testing.T) {
+	for _, c := range []struct{ kind, extra string }{
+		{"fillet", `"radius":"1 cm"`},
+		{"chamfer", `"radius":"1 cm","distance2":"2 cm"`},
+	} {
+		t.Run(c.kind, func(t *testing.T) {
+			r, s := seededSession(t)
+			var a, b wire.AddSketchEntityResult
+			call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[6,0]]}`, &a)
+			call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[6,0],[6,6]]}`, &b)
+			args := fmt.Sprintf(`{"sketchIndex":0,"kind":%q,"entityRefs":[%d,%d],%s}`, c.kind, a.EntityID, b.EntityID, c.extra)
+			if err := tryCall(t, r, s, "sketch.addEntity", args); err != nil {
+				t.Fatalf("%s: %v", c.kind, err)
+			}
+		})
+	}
+}
+
+// TestSketchAddEntityErrors covers the validation/error branches.
+func TestSketchAddEntityErrors(t *testing.T) {
+	bad := []string{
+		`{"sketchIndex":9,"kind":"line","points":[[0,0],[1,1]]}`,                // sketch out of range
+		`{"sketchIndex":0,"kind":"unicorn","points":[[0,0]]}`,                   // unknown kind
+		`{"sketchIndex":0,"kind":"line","points":[[0,0]]}`,                      // too few points
+		`{"sketchIndex":0,"kind":"slot","points":[[0,0],[5,0]],"width":"wide"}`, // bad unit
+	}
+	for i, args := range bad {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			r, s := seededSession(t)
+			if err := tryCall(t, r, s, "sketch.addEntity", args); err == nil {
+				t.Errorf("expected an error for %s", args)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

**The parity guard you asked for** — declared API surface must be handled, or tests fail:
- **`TestEveryWireMethodHasAHandler`** — fails if any `wire.Method*` constant has no registered router handler. All **414** are handled today.
- **`TestEveryWireEventIsRelayed`** — fails if any `wire.Event*` is never relayed.

Both enumerate the wire constants **from source** (`go/ast`), so the guard can't silently drift out of sync with the contract.

### It already caught real drift
The event guard found **3 events declared in the API but emitted/relayed nowhere** (no app-level event fires them yet): `EventModelStateActivated`, `EventRepresentationActivated`, `EventRepresentationCaptured`. They're declared ahead of the representations/model-state host behavior. I put them in a **shrink-only allowlist** (with a "may only shrink" assertion) so the build is green while the debt stays visible — any *new* unhandled method/event still fails. Wiring those 3 up is host-behavior feature work (new app events fired across model→relay), best done with that feature.

### Coverage
Also covers `sketch.addEntity`'s composite/derived kinds (rectangle, polygon, slot, polyline, equationCurve, construction, fillet, chamfer + circle/rectangle variants) and its validation errors. Router 76.1% → 76.5% (this PR is mostly the guard; broader handler coverage continues in follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)