### PR TITLE
feat(fillet): user-selectable corner strategy (miter / round / setback)

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -27,6 +27,7 @@ type edgeDressArgs struct {
 	Radius      string          `json:"radius,omitempty"`      // fillet
 	Distance    string          `json:"distance,omitempty"`    // chamfer
 	EdgeSets    []filletSetArgs `json:"edgeSets,omitempty"`    // fillet
+	CornerType  string          `json:"cornerType,omitempty"`  // fillet shared-corner treatment (default miter)
 	ChamferType string          `json:"chamferType,omitempty"` // chamfer mode (default distance)
 	Distance2   string          `json:"distance2,omitempty"`   // chamfer twoDistances
 	Angle       string          `json:"angle,omitempty"`       // chamfer distanceAndAngle
@@ -51,7 +52,8 @@ const filletSchema = `{
       "radius": {"type": "string", "description": "Constant radius for this set, e.g. \"3 mm\"."},
       "startRadius": {"type": "string", "description": "Variable set: radius at the edge's start vertex (the set holds exactly one edge)."},
       "endRadius": {"type": "string", "description": "Variable set: radius at the edge's end vertex."}
-    }, "required": ["edgeRefs"]}}
+    }, "required": ["edgeRefs"]}},
+    "cornerType": {"type": "string", "enum": ["miter", "setback", "round"], "default": "miter", "description": "How a vertex where two filleted edges meet (third edge sharp) is treated: miter (exact crease), round (fillets the third edge into a smooth sphere). setback is reserved."}
   }
 }`
 
@@ -84,12 +86,12 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, err
 	}
+	corner, err := filletCornerOf(in.CornerType)
+	if err != nil {
+		return nil, err
+	}
 	if len(in.EdgeSets) > 0 {
-		sets, err := filletSetsFromArgs(part, in.EdgeSets)
-		if err != nil {
-			return nil, err
-		}
-		return recomputeResult(part, feature.NewDressUpFeatures(part.Features()).AddFilletSets(sets))
+		return applyFilletSets(part, in.EdgeSets, corner)
 	}
 	if len(in.EdgeRefs) == 0 {
 		return nil, errors.New("fillet: edgeRefs is empty (give edgeRefs+radius or edgeSets)")
@@ -98,8 +100,30 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewDressUpFeatures(part.Features()).AddFillet(refKeys(in.EdgeRefs), r)
+	pf := feature.NewDressUpFeatures(part.Features()).AddFilletCorner(refKeys(in.EdgeRefs), r, corner)
 	return recomputeResult(part, pf)
+}
+
+// applyFilletSets decodes the edge-set form and adds the fillet with the chosen corner treatment.
+func applyFilletSets(part *compdef.PartComponentDefinition, args []filletSetArgs, corner types.FilletCornerType) (json.RawMessage, error) {
+	sets, err := filletSetsFromArgs(part, args)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewDressUpFeatures(part.Features()).AddFilletSetsCorner(sets, corner))
+}
+
+// filletCornerOf resolves the optional cornerType wire spelling (empty ⇒ miter), erroring on an
+// unknown value with the accepted set.
+func filletCornerOf(spelling string) (types.FilletCornerType, error) {
+	if spelling == "" {
+		return types.FilletCornerMiter, nil
+	}
+	c, ok := types.ParseFilletCornerType(spelling)
+	if !ok {
+		return 0, fmt.Errorf("fillet: unknown cornerType %q (want miter, setback, or round)", spelling)
+	}
+	return c, nil
 }
 
 // filletSetsFromArgs decodes the edge-set form: each set is constant (radius) or variable

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -256,6 +256,7 @@ func editFilletTool(f *feature.PartFeature, fl *feature.FilletFeature) *FilletTo
 		return nil // a multi-set fillet doesn't fit the single-radius panel
 	}
 	t := NewFilletTool()
+	t.cornerType = def.CornerType
 	if len(def.EdgeSets) == 1 {
 		seedFilletSet(t, def.EdgeSets[0])
 	} else {

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/feature"
 )
 
@@ -19,11 +20,37 @@ type FilletTool struct {
 	variable        bool // variable mode: each edge blends startRadius → endRadius (#323)
 	startRadius     float64
 	endRadius       float64
+	cornerType      feature.FilletCornerType // shared-corner treatment (miter default)
 	added           *feature.PartFeature
 }
 
-// NewFilletTool returns a fillet tool with a default 1-unit radius.
+// NewFilletTool returns a fillet tool with a default 1-unit radius and mitered corners.
 func NewFilletTool() *FilletTool { return &FilletTool{radius: 1, startRadius: 1, endRadius: 1} }
+
+// filletCornerOrder maps the UI option index to the corner-type enum.
+var filletCornerOrder = []feature.FilletCornerType{
+	types.FilletCornerMiter, types.FilletCornerSetback, types.FilletCornerRound,
+}
+
+// FilletCornerOptions are the corner-treatment labels for the property panel, in index order.
+func FilletCornerOptions() []string { return []string{"Miter (crease)", "Setback", "Round (sphere)"} }
+
+// CornerTypeIndex returns the selected corner treatment as a [FilletCornerOptions] index.
+func (t *FilletTool) CornerTypeIndex() int {
+	for i, c := range filletCornerOrder {
+		if c == t.cornerType {
+			return i
+		}
+	}
+	return 0
+}
+
+// SetCornerTypeIndex selects the corner treatment from a [FilletCornerOptions] index.
+func (t *FilletTool) SetCornerTypeIndex(i int) {
+	if i >= 0 && i < len(filletCornerOrder) {
+		t.cornerType = filletCornerOrder[i]
+	}
+}
 
 // Name implements [Tool].
 func (t *FilletTool) Name() string { return "Fillet" }
@@ -149,10 +176,10 @@ func (t *FilletTool) Cancel(s *Session) {
 // form, or one variable set per edge.
 func (t *FilletTool) addFillet(dress *feature.DressUpFeatures) *feature.PartFeature {
 	if t.variable {
-		return dress.AddFilletSets(t.variableSets(t.selectedEdgeKeys()))
+		return dress.AddFilletSetsCorner(t.variableSets(t.selectedEdgeKeys()), t.cornerType)
 	}
 	r := t.radius
-	return dress.AddFillet(t.selectedEdgeKeys(), func() float64 { return r })
+	return dress.AddFilletCorner(t.selectedEdgeKeys(), func() float64 { return r }, t.cornerType)
 }
 
 // commitEdit writes the panel state back into the committed fillet's definition: the
@@ -160,6 +187,7 @@ func (t *FilletTool) addFillet(dress *feature.DressUpFeatures) *feature.PartFeat
 // rewrites the sets.
 func (t *FilletTool) commitEdit(s *Session) error {
 	def := t.target.Definition().(*feature.FilletFeature).Definition()
+	def.CornerType = t.cornerType
 	if t.variable {
 		def.EdgeKeys, def.Radius, def.EdgeSets = nil, nil, t.variableSets(t.selectedEdgeKeys())
 		return commitFeatureEdit(s, t.target)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.2.0
+	oblikovati.org/api v0.4.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.2.0
+	oblikovati.org/api v0.4.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -43,6 +43,9 @@ func drawFilletDialog(s *app.Session) {
 		}
 		if propertySection("Behavior") {
 			drawFilletRadiusRows(s, f)
+			if i := propertyComboRow("Corner", "fillet-corner", app.FilletCornerOptions(), f.CornerTypeIndex()); i >= 0 {
+				f.SetCornerTypeIndex(i)
+			}
 		}
 		native.Separator()
 		drawCommitCancelButtons(s, f.CanCommit())

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -41,6 +41,27 @@ func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, err
 // the edge line, so each strip face is EXACTLY planar — the only approximation is the end
 // arcs as chords, the same density convention as a hole's faceted cylinder.
 func FilletEdgesVarying(body *topo.Body, picks []EdgeFilletRadii) (*topo.Body, error) {
+	return FilletEdgesCorner(body, picks, CornerMiter)
+}
+
+// CornerStrategy selects how a corner where two filleted edges meet a vertex whose third edge stays
+// sharp is treated (mirrors api types.FilletCornerType's miter/setback; the "round" form is realised
+// by the feature adding the third edge, which makes the corner a 3-edge sphere blend automatically).
+type CornerStrategy int
+
+const (
+	// CornerMiter mutually trims the two cylinders along their intersection seam (a crease).
+	CornerMiter CornerStrategy = iota
+	// CornerSetback scoops the corner with a sphere patch set back from the sharp edge.
+	CornerSetback
+	// CornerRound rounds the corner fully by also filleting the third edge — a true 3-edge sphere.
+	CornerRound
+)
+
+// FilletEdgesCorner is FilletEdgesVarying with an explicit 2-edge corner strategy. Lone curved
+// (rim/arc) picks ignore it (they have no shared corner). CornerRound augments the selection with the
+// sharp third edge of each 2-edge corner so the corner resolves as a watertight 3-edge sphere blend.
+func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerStrategy) (*topo.Body, error) {
 	if rim := loneRimPick(body, picks); rim != nil {
 		return FilletCylinderRim(body, rim.Key, rim.R0) // a circular cylinder/cap rim → toroidal band
 	}
@@ -51,7 +72,17 @@ func FilletEdgesVarying(body *topo.Body, picks []EdgeFilletRadii) (*topo.Body, e
 	if err != nil {
 		return nil, err
 	}
-	blends, miters, err := computeCorners(edges)
+	if corner == CornerRound {
+		edges = roundThirdEdges(edges) // round the corners fully → 3-edge blends
+		corner = CornerMiter           // the augmented corners are now 3-edge (sphere); none stay 2-edge
+	}
+	return filletResolvedEdges(body, edges, corner)
+}
+
+// filletResolvedEdges solves the corners and edge fillets of an already-resolved pick list and
+// assembles the validated result body.
+func filletResolvedEdges(body *topo.Body, edges []filletPick, corner CornerStrategy) (*topo.Body, error) {
+	blends, miters, err := computeCorners(edges, corner)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +371,7 @@ type cornerBlend struct {
 // All edges meeting at a corner must use ONE constant radius — a variable edge's faceted end
 // chords cannot meet a corner watertight, and a blend/seam has a single radius — so those and
 // any other configuration error clearly.
-func computeCorners(picks []filletPick) (map[uint64]*cornerBlend, map[uint64]*cornerMiter, error) {
+func computeCorners(picks []filletPick, strategy CornerStrategy) (map[uint64]*cornerBlend, map[uint64]*cornerMiter, error) {
 	groups := map[uint64][]filletPick{}
 	for _, p := range picks {
 		groups[p.edge.StartVertex().ID()] = append(groups[p.edge.StartVertex().ID()], p)
@@ -352,7 +383,7 @@ func computeCorners(picks []filletPick) (map[uint64]*cornerBlend, map[uint64]*co
 		if len(ps) < 2 {
 			continue
 		}
-		cb, cm, err := solveCorner(vid, ps)
+		cb, cm, err := solveCorner(vid, ps, strategy)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -369,7 +400,7 @@ func computeCorners(picks []filletPick) (map[uint64]*cornerBlend, map[uint64]*co
 // solveCorner solves the corner treatment at vertex vid where the picks ps meet: a sphere blend
 // (3 edges, trihedral vertex) or a miter seam (2 edges sharing a face), at the corner's one shared
 // radius. Exactly one of (blend, miter) is returned; any other configuration errors.
-func solveCorner(vid uint64, ps []filletPick) (*cornerBlend, *cornerMiter, error) {
+func solveCorner(vid uint64, ps []filletPick, strategy CornerStrategy) (*cornerBlend, *cornerMiter, error) {
 	r, err := blendRadius(ps)
 	if err != nil {
 		return nil, nil, err
@@ -380,6 +411,11 @@ func solveCorner(vid uint64, ps []filletPick) (*cornerBlend, *cornerMiter, error
 	case len(ps) == 3 && len(faces) == 3:
 		cb, err := solveBlend(v, faces, r)
 		return cb, nil, err
+	case len(ps) == 2 && strategy == CornerSetback:
+		// A pure sphere tangent to the three corner planes pinches to points at the two side-plane
+		// tangents, so a distinct watertight set-back patch is still being built; the miter is the
+		// exact alternative and the round the smooth one.
+		return nil, nil, fmt.Errorf("fillet: the setback corner at %v is not yet available — use the miter (exact crease) or round (smooth sphere) corner strategy", v.Point())
 	case len(ps) == 2:
 		cm, err := solveMiter(v, ps, r)
 		return nil, cm, err

--- a/kernel/ops/fillet_setback.go
+++ b/kernel/ops/fillet_setback.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import "oblikovati.org/kernel/topo"
+
+// roundThirdEdges augments the pick list so every 2-edge corner becomes a full 3-edge sphere blend:
+// at each vertex where exactly two picked edges meet and a single sharp edge remains, that third edge
+// is added at the corner's radius. This realises the CornerRound strategy by reusing the watertight
+// 3-edge blend (solveBlend) instead of a degenerate 2-edge sphere. Added edges are de-duplicated (an
+// edge may be the third edge of corners at both its ends).
+func roundThirdEdges(picks []filletPick) []filletPick {
+	already := map[*topo.Edge]bool{}
+	byVertex := map[uint64][]filletPick{}
+	for _, p := range picks {
+		already[p.edge] = true
+		byVertex[p.edge.StartVertex().ID()] = append(byVertex[p.edge.StartVertex().ID()], p)
+		byVertex[p.edge.EndVertex().ID()] = append(byVertex[p.edge.EndVertex().ID()], p)
+	}
+	out := picks
+	added := map[*topo.Edge]bool{}
+	for vid, ps := range byVertex {
+		if len(ps) != 2 {
+			continue // only a 2-edge corner has a single sharp edge to round
+		}
+		v := vertexByID(edgesOf(ps), vid)
+		third := thirdSharpEdge(v, ps)
+		if third == nil || already[third] || added[third] {
+			continue
+		}
+		added[third] = true
+		out = append(out, filletPick{edge: third, r0: ps[0].r0, r1: ps[0].r0})
+	}
+	return out
+}
+
+// thirdSharpEdge returns the lone edge at v that is none of the picked edges — the sharp edge a 2-edge
+// corner leaves between the two filleted edges' outer faces. nil unless exactly one such edge exists.
+func thirdSharpEdge(v *topo.Vertex, ps []filletPick) *topo.Edge {
+	picked := map[*topo.Edge]bool{}
+	for _, p := range ps {
+		picked[p.edge] = true
+	}
+	var third *topo.Edge
+	for _, e := range v.Edges() {
+		if picked[e] {
+			continue
+		}
+		if third != nil {
+			return nil // more than one sharp edge — not a clean 3-edge corner
+		}
+		third = e
+	}
+	return third
+}

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -284,6 +284,31 @@ func TestFilletTwoEdgeCornerMiters(t *testing.T) {
 	}
 }
 
+// TestFilletCornerRoundAddsThirdEdge checks the CornerRound strategy: selecting two of the three
+// edges at a corner rounds the corner FULLY by auto-filleting the sharp third edge, so the corner
+// becomes a watertight 3-edge sphere blend (3 cylinders + 1 sphere), not a 2-cylinder miter crease.
+func TestFilletCornerRoundAddsThirdEdge(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	keys := cornerEdgeKeys(t, box)[:2] // two of the three edges meeting at the corner
+	picks := []ops.EdgeFilletRadii{{Key: keys[0], R0: 0.3, R1: 0.3}, {Key: keys[1], R0: 0.3, R1: 0.3}}
+	res, err := ops.FilletEdgesCorner(box, picks, ops.CornerRound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("rounded-corner box not a valid solid: %+v", r)
+	}
+	if c, s := hasCylinderFaces(res), hasSphereFaces(res); c != 3 || s != 1 {
+		t.Errorf("got %d cylinder + %d sphere faces, want 3 + 1 (the third edge auto-rounded into a sphere)", c, s)
+	}
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("rounded corner at tol %g: %d open edges", tol, open)
+		}
+	}
+}
+
 // TestFilletTwoEdgeCornerMiterMeshWatertight checks the miter seam's TESSELLATION is watertight
 // across qualities — the two cylinders share the seam chord polyline exactly, so the welded mesh
 // must have no cracks where they meet.

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -36,13 +36,18 @@ type FilletEdgeSet struct {
 // variable reports whether the set carries a start→end radius instead of a constant one.
 func (s FilletEdgeSet) variable() bool { return s.Radius == nil }
 
+// FilletCornerType aliases the public corner-treatment discriminator (ADR-0018).
+type FilletCornerType = types.FilletCornerType
+
 // FilletDefinition rounds selected edges. EdgeKeys+Radius is the original single
 // constant-radius form; EdgeSets (when non-empty) takes precedence and carries any mix of
-// constant and variable sets (#323).
+// constant and variable sets (#323). CornerType selects how a vertex where two filleted edges
+// meet (third edge sharp) is treated — miter crease (default/zero), or a full round.
 type FilletDefinition struct {
-	EdgeKeys [][]byte
-	Radius   func() float64
-	EdgeSets []FilletEdgeSet
+	EdgeKeys   [][]byte
+	Radius     func() float64
+	EdgeSets   []FilletEdgeSet
+	CornerType FilletCornerType
 }
 
 // FilletType reports the definition's discriminator: always an edge fillet for now (the
@@ -62,9 +67,9 @@ func (f *FilletFeature) Kind() string { return "fillet" }
 // blend (cylinder faces; planar ruling strips for variable sets). See fillet.go.
 func (f *FilletFeature) Recompute(in Input) (Output, error) {
 	if len(f.def.EdgeSets) > 0 {
-		return filletBodySets(in, f.def.EdgeSets, "fillet")
+		return filletBodySets(in, f.def.EdgeSets, f.def.CornerType, "fillet")
 	}
-	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), "fillet")
+	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), f.def.CornerType, "fillet")
 }
 
 // ChamferType aliases the public chamfer-mode discriminator (ADR-0018).
@@ -255,15 +260,25 @@ type DressUpFeatures struct{ engine *PartFeatures }
 // NewDressUpFeatures binds the collection to an engine.
 func NewDressUpFeatures(engine *PartFeatures) *DressUpFeatures { return &DressUpFeatures{engine} }
 
-// AddFillet rounds the given edges (by reference key) to radius.
+// AddFillet rounds the given edges (by reference key) to radius, mitering shared corners.
 func (c *DressUpFeatures) AddFillet(edgeKeys [][]byte, radius func() float64) *PartFeature {
-	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius}})
+	return c.AddFilletCorner(edgeKeys, radius, types.FilletCornerMiter)
+}
+
+// AddFilletCorner rounds the given edges to radius with an explicit shared-corner treatment.
+func (c *DressUpFeatures) AddFilletCorner(edgeKeys [][]byte, radius func() float64, corner FilletCornerType) *PartFeature {
+	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: corner}})
 }
 
 // AddFilletSets rounds any mix of constant and variable radius edge sets in one feature
-// (the reference's FilletDefinition edge-set model, #323).
+// (the reference's FilletDefinition edge-set model, #323), mitering shared corners.
 func (c *DressUpFeatures) AddFilletSets(sets []FilletEdgeSet) *PartFeature {
-	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeSets: sets}})
+	return c.AddFilletSetsCorner(sets, types.FilletCornerMiter)
+}
+
+// AddFilletSetsCorner rounds the edge sets with an explicit shared-corner treatment.
+func (c *DressUpFeatures) AddFilletSetsCorner(sets []FilletEdgeSet, corner FilletCornerType) *PartFeature {
+	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeSets: sets, CornerType: corner}})
 }
 
 // AddChamfer bevels the given edges by distance, blending three-edge corners flat (the

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -5,15 +5,28 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 )
 
+// cornerStrategy maps the public corner-type discriminator to the kernel's 2-edge corner strategy.
+func cornerStrategy(t types.FilletCornerType) ops.CornerStrategy {
+	switch t {
+	case types.FilletCornerSetback:
+		return ops.CornerSetback
+	case types.FilletCornerRound:
+		return ops.CornerRound
+	default:
+		return ops.CornerMiter
+	}
+}
+
 // filletBody rounds the selected convex edges of the running body to the given radius via
-// ops.FilletEdges (a real rolling-ball blend with cylinder faces), replacing it in the body
-// list. A lost edge, a non-convex edge, or a non-positive radius is an error so the feature
-// goes Sick. See kernel/ops/fillet.go for the geometry.
-func filletBody(in Input, edgeKeys [][]byte, radius float64, feat string) (Output, error) {
+// ops.FilletEdgesCorner (a real rolling-ball blend with cylinder faces), replacing it in the body
+// list. corner selects how a 2-edge corner is treated. A lost edge, a non-convex edge, or a
+// non-positive radius is an error so the feature goes Sick. See kernel/ops/fillet.go for the geometry.
+func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCornerType, feat string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -25,7 +38,11 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, feat string) (Outpu
 		return out, err
 	}
 	work, keys := planarizedFillet(body, edgeKeys, feat)
-	result, err := ops.FilletEdges(work, keys, radius)
+	picks := make([]ops.EdgeFilletRadii, len(keys))
+	for i, k := range keys {
+		picks[i] = ops.EdgeFilletRadii{Key: k, R0: radius, R1: radius}
+	}
+	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner))
 	if err != nil {
 		return Output{}, err
 	}
@@ -74,9 +91,9 @@ func planarizedFillet(body *topo.Body, edgeKeys [][]byte, feat string) (*topo.Bo
 // filletBodySets rounds the definition's edge sets in one kernel pass: each constant set
 // contributes its edges at one radius, each variable set one edge with a start→end radius.
 // A single constant set routes through filletBody to keep the analytic cylinder-rim path.
-func filletBodySets(in Input, sets []FilletEdgeSet, feat string) (Output, error) {
+func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, feat string) (Output, error) {
 	if len(sets) == 1 && !sets[0].variable() {
-		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), feat)
+		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), corner, feat)
 	}
 	body, err := runningBody(in)
 	if err != nil {
@@ -87,7 +104,7 @@ func filletBodySets(in Input, sets []FilletEdgeSet, feat string) (Output, error)
 		return Output{}, err
 	}
 	work := planarizeFilletPicks(body, picks, feat)
-	result, err := ops.FilletEdgesVarying(work, picks)
+	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner))
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -116,10 +116,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Extrude = ed
 	case *FilletFeature:
 		if len(f.def.EdgeSets) > 0 {
-			fd.Fillet = &EdgeDressData{Sets: serializeFilletSets(f.def.EdgeSets)}
+			fd.Fillet = &EdgeDressData{Sets: serializeFilletSets(f.def.EdgeSets), CornerType: int32(f.def.CornerType)}
 			break
 		}
-		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius)}
+		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius), CornerType: int32(f.def.CornerType)}
 	case *ChamferFeature:
 		flat := f.def.FlatCorners
 		fd.Chamfer = &EdgeDressData{
@@ -325,18 +325,22 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 	case "extrude":
 		return requireExtrude(fs, fd.Extrude, sk, work)
 	case "fillet":
+		corner := types.FilletCornerType(fd.Fillet.cornerTypeOrZero())
+		if corner == 0 {
+			corner = types.FilletCornerMiter // absent / older recipe ⇒ the miter default
+		}
 		if fd.Fillet != nil && len(fd.Fillet.Sets) > 0 {
 			sets, err := restoreFilletSets(fd.Fillet.Sets)
 			if err != nil {
 				return nil, err
 			}
-			return du.AddFilletSets(sets), nil
+			return du.AddFilletSetsCorner(sets, corner), nil
 		}
 		d, err := requireEdgeDress(fd.Fillet, "fillet")
 		if err != nil {
 			return nil, err
 		}
-		return du.AddFillet(d.keys, constFloat(d.value)), nil
+		return du.AddFilletCorner(d.keys, constFloat(d.value), corner), nil
 	case "chamfer":
 		d, err := requireEdgeDress(fd.Chamfer, "chamfer")
 		if err != nil {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -41,6 +41,8 @@ type EdgeDressData struct {
 	ChamferType int32   `yaml:"chamferType,omitempty"`
 	Value2      float64 `yaml:"value2,omitempty"`
 	Angle       float64 `yaml:"angle,omitempty"`
+	// Fillet-only: the shared-corner treatment. FilletCornerType 0 (or absent) ⇒ the miter default.
+	CornerType int32 `yaml:"cornerType,omitempty"`
 }
 
 // FilletSetData is one serialized fillet edge set: constant (Radius) or variable
@@ -50,6 +52,15 @@ type FilletSetData struct {
 	Radius      float64  `yaml:"radius,omitempty"`
 	StartRadius float64  `yaml:"startRadius,omitempty"`
 	EndRadius   float64  `yaml:"endRadius,omitempty"`
+}
+
+// cornerTypeOrZero returns the fillet corner-treatment id, defaulting to 0 (miter) for an absent
+// payload or an older recipe.
+func (d *EdgeDressData) cornerTypeOrZero() int32 {
+	if d == nil {
+		return 0
+	}
+	return d.CornerType
 }
 
 // serializeFilletSets encodes a fillet's edge sets (nil for the legacy single-set form).

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -124,6 +124,38 @@ func TestChamferFlatCornersRoundTrip(t *testing.T) {
 	}
 }
 
+// TestFilletCornerTypeRoundTrip checks the fillet corner treatment survives a recipe round trip,
+// and that an older recipe with no field restores as miter (the zero-value default).
+func TestFilletCornerTypeRoundTrip(t *testing.T) {
+	for _, corner := range []types.FilletCornerType{types.FilletCornerMiter, types.FilletCornerSetback, types.FilletCornerRound} {
+		fs := NewPartFeatures(nil, nil)
+		NewDressUpFeatures(fs).AddFilletCorner([][]byte{[]byte("edge")}, func() float64 { return 0.3 }, corner)
+		data, err := fs.MarshalRecipe(oneSketch{})
+		if err != nil {
+			t.Fatalf("MarshalRecipe(%v): %v", corner, err)
+		}
+		if got := types.FilletCornerType(data[0].Fillet.CornerType); got != corner {
+			t.Fatalf("serialized CornerType = %v, want %v", got, corner)
+		}
+		fresh := NewPartFeatures(nil, nil)
+		if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+			t.Fatalf("ApplyRecipe(%v): %v", corner, err)
+		}
+		if got := fresh.Item(0).Definition().(*FilletFeature).Definition().CornerType; got != corner {
+			t.Errorf("restored CornerType = %v, want %v", got, corner)
+		}
+	}
+	// An older recipe without the field restores as miter (the zero default).
+	fresh := NewPartFeatures(nil, nil)
+	legacy := []FeatureData{{Kind: "fillet", Fillet: &EdgeDressData{Edges: []string{}, Value: 0.3}}}
+	if err := fresh.ApplyRecipe(legacy, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe(legacy): %v", err)
+	}
+	if got := fresh.Item(0).Definition().(*FilletFeature).Definition().CornerType; got != types.FilletCornerMiter {
+		t.Errorf("legacy fillet without cornerType should restore as miter, got %v", got)
+	}
+}
+
 func TestSolidFeaturesRoundTrip(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	NewHoleFeatures(fs).AddTapped([]byte("face-1"), func() float64 { return 6 }, func() float64 { return 10 }, "M6x1")


### PR DESCRIPTION
## What

Lets the user choose how an edge fillet treats a **corner where two filleted edges meet a vertex whose third edge stays sharp**, end to end (kernel → feature → router → head UI), keyed on the `FilletCornerType` enum (API #118):

- **miter** (default) — the two rolling-ball cylinders mutually trim along their intersection seam: the geometrically **exact** crease for rounding only two of a corner's three edges. Unchanged behaviour.
- **round** — augments the selection with the sharp third edge of each such corner (`roundThirdEdges`), so it resolves as the existing **watertight 3-edge sphere blend** — a fully smooth corner.
- **setback** — reserved. A pure sphere tangent to the three corner planes pinches to points at the two side-plane tangents, so a distinct watertight set-back patch isn't ready; it **reports clearly** instead of emitting an invalid solid.

## Why

Rounding all of a box's top edges (mcpfillet 07) left a mitered multi-cylinder corner; the only ways to a *smooth* corner are to round the third edge too (now the `round` option) or to keep the exact crease (`miter`). Surfacing the choice at creation time mirrors reference-CAD corner controls.

## How it threads

- **kernel** (`fillet.go`, `fillet_setback.go`): `FilletEdgesCorner(body, picks, CornerStrategy)`; `FilletEdges`/`FilletEdgesVarying` keep the miter default.
- **feature**: `FilletDefinition.CornerType`; `AddFilletCorner`/`AddFilletSetsCorner`; serialises (`cornerType`, absent ⇒ miter) and round-trips.
- **router**: the fillet schema accepts `"cornerType": "miter"|"setback"|"round"`.
- **head**: a "Corner" dropdown in the Fillet panel (`FilletCornerOptions`).

## Tests

- Kernel `TestFilletCornerRoundAddsThirdEdge` (3 cylinders + 1 sphere, watertight); recipe round-trip `TestFilletCornerTypeRoundTrip`; full regression green, `-race` on ops, lint 0 issues.

## Live verification (head over the MCP bridge, `mcpcorner`)

Filleting all four top edges of a 4×3×2 box:
- **miter** → healthy, 0 spheres (crease, sharp verticals), vol 24→23.74;
- **round** → healthy, **4 sphere octants** (smooth corners), vol 24→23.58;
- **setback** → clean WIP error (no invalid solid).

Both render correctly and are visually distinct (screenshots captured). Pairs with API #118 and the bridge e2e + `mcpcorner` driver PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)