### PR TITLE
feat(fillet): build the taper set-back corner (variable-fillet run-out)

### DIFF
--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -45,16 +45,17 @@ func FilletEdgesVarying(body *topo.Body, picks []EdgeFilletRadii) (*topo.Body, e
 }
 
 // CornerStrategy selects how a corner where two filleted edges meet a vertex whose third edge stays
-// sharp is treated (mirrors api types.FilletCornerType's miter/setback; the "round" form is realised
-// by the feature adding the third edge, which makes the corner a 3-edge sphere blend automatically).
+// sharp is treated (mirrors api types.FilletCornerType). Round and setback both augment the selection
+// with the sharp third edge — round at constant radius, setback as a taper that runs out to 0 — so
+// the corner resolves as a 3-edge sphere blend; miter keeps the two edges' cylinders meeting at a seam.
 type CornerStrategy int
 
 const (
 	// CornerMiter mutually trims the two cylinders along their intersection seam (a crease).
 	CornerMiter CornerStrategy = iota
-	// CornerSetback scoops the corner with a sphere patch set back from the sharp edge.
+	// CornerSetback rounds the corner into a sphere and tapers the third edge to a run-out (set-back).
 	CornerSetback
-	// CornerRound rounds the corner fully by also filleting the third edge — a true 3-edge sphere.
+	// CornerRound rounds the corner fully by also filleting the third edge at constant radius (sphere).
 	CornerRound
 )
 
@@ -72,17 +73,20 @@ func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerSt
 	if err != nil {
 		return nil, err
 	}
-	if corner == CornerRound {
-		edges = roundThirdEdges(edges) // round the corners fully → 3-edge blends
-		corner = CornerMiter           // the augmented corners are now 3-edge (sphere); none stay 2-edge
+	switch corner {
+	case CornerRound:
+		edges = roundThirdEdges(edges) // fillet the third edge at constant radius → 3-edge sphere
+	case CornerSetback:
+		edges = setbackThirdEdges(edges) // taper the third edge (r→0 run-out) → smooth set-back sphere
 	}
-	return filletResolvedEdges(body, edges, corner)
+	return filletResolvedEdges(body, edges)
 }
 
 // filletResolvedEdges solves the corners and edge fillets of an already-resolved pick list and
-// assembles the validated result body.
-func filletResolvedEdges(body *topo.Body, edges []filletPick, corner CornerStrategy) (*topo.Body, error) {
-	blends, miters, err := computeCorners(edges, corner)
+// assembles the validated result body. Round/setback corners have already been reduced to 3-edge
+// sphere blends by augmenting the third edge, so the corner solver only ever sees miters and blends.
+func filletResolvedEdges(body *topo.Body, edges []filletPick) (*topo.Body, error) {
+	blends, miters, err := computeCorners(edges)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +119,8 @@ func (p filletPick) varying() bool { return p.r0 != p.r1 }
 func resolveFilletPicks(body *topo.Body, picks []EdgeFilletRadii) ([]filletPick, error) {
 	out := make([]filletPick, 0, len(picks))
 	for _, p := range picks {
-		if p.R0 <= 0 || p.R1 <= 0 {
-			return nil, fmt.Errorf("fillet: radii %g/%g must be > 0", p.R0, p.R1)
+		if p.R0 < 0 || p.R1 < 0 || p.R0+p.R1 <= 0 {
+			return nil, fmt.Errorf("fillet: radii %g/%g must be >= 0 with at least one > 0 (a run-out tapers to 0 at one end)", p.R0, p.R1)
 		}
 		e, ok := body.FindEdgeByKey(p.Key)
 		if !ok {
@@ -144,6 +148,7 @@ type corner struct {
 	blend   bool
 	miter   bool          // two-fillet corner: the end is bounded by seam (no end face, no sphere)
 	seam    []math.Point3 // miter only: the seam chords from ta to tb, shared with the other cylinder
+	runout  bool          // variable fillet only: r=0 here, the blend collapses to an apex on the edge
 }
 
 // tOf returns the tangent point on face f (a or b).
@@ -210,10 +215,10 @@ func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[ui
 // edgeCorners solves the rounded corners at both endpoints of an edge (each blended when its
 // vertex is a shared corner), with the pick's per-end radius.
 func edgeCorners(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter) (c0, c1 corner, err error) {
-	if c0, err = cornerAt(e.StartVertex(), in, p.r0, blends[e.StartVertex().ID()], miters[e.StartVertex().ID()]); err != nil {
+	if c0, err = cornerAt(e.StartVertex(), in, p.r0, blends[e.StartVertex().ID()], miters[e.StartVertex().ID()], p.varying()); err != nil {
 		return corner{}, corner{}, err
 	}
-	c1, err = cornerAt(e.EndVertex(), in, p.r1, blends[e.EndVertex().ID()], miters[e.EndVertex().ID()])
+	c1, err = cornerAt(e.EndVertex(), in, p.r1, blends[e.EndVertex().ID()], miters[e.EndVertex().ID()], p.varying())
 	return c0, c1, err
 }
 
@@ -221,14 +226,25 @@ func edgeCorners(e *topo.Edge, p filletPick, in cornerInputs, blends map[uint64]
 // had this many sides, so a 90° wedge gets 8.
 const filletChordsPerTurn = 32
 
-// sampleCornerChords samples both corners' arcs at the same angular stations, so chord j of
-// one corner pairs with chord j of the other as a straight ruling of the blend cone.
-func sampleCornerChords(c0, c1 *corner, in cornerInputs) {
+// runoutTol is the radius at or below which a variable fillet is treated as a run-out: the blend
+// collapses to a single apex on the edge (no end face), so the fillet fades smoothly into the corner.
+const runoutTol = 1e-9
+
+// cornerChordCount is the number of chord segments spanning the corner's rolling-ball wedge — sized
+// as if the full circle had filletChordsPerTurn sides (a 90° wedge gets 8), with a floor of 4.
+func cornerChordCount(in cornerInputs) int {
 	wedge := stdmath.Acos(float64(in.nA.Dot(in.nB)))
 	k := int(stdmath.Ceil(wedge / (2 * stdmath.Pi / filletChordsPerTurn)))
 	if k < 4 {
 		k = 4
 	}
+	return k
+}
+
+// sampleCornerChords samples both corners' arcs at the same angular stations, so chord j of
+// one corner pairs with chord j of the other as a straight ruling of the blend cone.
+func sampleCornerChords(c0, c1 *corner, in cornerInputs) {
+	k := cornerChordCount(in)
 	c0.chords = arcChords(*c0, in, k)
 	c1.chords = arcChords(*c1, in, k)
 }
@@ -275,7 +291,11 @@ type cornerInputs struct {
 // face. With a blend (v is a shared corner) the centre is the blend sphere's centre and the
 // tangent points are the sphere's tangents on the two faces; the corner-end arc joins the
 // sphere patch (no end face), and the arc is registered on the blend.
-func cornerAt(v *topo.Vertex, in cornerInputs, r float64, blend *cornerBlend, miter *cornerMiter) (corner, error) {
+func cornerAt(v *topo.Vertex, in cornerInputs, r float64, blend *cornerBlend, miter *cornerMiter, variable bool) (corner, error) {
+	if r <= runoutTol { // a variable fillet tapered to 0: the blend collapses to an apex on the edge here
+		p := v.Point()
+		return corner{a: in.a, b: in.b, vertex: v, cen: p, ta: p, tb: p, mid: p, runout: true}, nil
+	}
 	cen := v.Point().TranslateBy(in.offDir.Scale(r)) // the rolling-ball centre, on the cylinder axis
 	ta := cen.TranslateBy(in.nA.Scale(r))
 	tb := cen.TranslateBy(in.nB.Scale(r))
@@ -294,10 +314,21 @@ func cornerAt(v *topo.Vertex, in cornerInputs, r float64, blend *cornerBlend, mi
 	// mid is computed AFTER the switch so a blend corner's arc midpoint uses the sphere centre.
 	mid := cen.TranslateBy(perpToward(cen, v.Point(), in.axis).Scale(r))
 	c := corner{a: in.a, b: in.b, endFace: end, vertex: v, cen: cen, ta: ta, tb: tb, mid: mid, blend: blend != nil, miter: miter != nil, seam: seam}
-	if blend != nil {
-		blend.arcs = append(blend.arcs, blendArc{ta: ta, tb: tb, mid: mid})
-	}
+	registerBlendArc(blend, c, in, variable)
 	return c, nil
+}
+
+// registerBlendArc records the corner's boundary arc on the sphere patch when v is a blend corner. A
+// variable edge stores the arc as the cone's chord polyline so the patch and cone meet edge-for-edge.
+func registerBlendArc(blend *cornerBlend, c corner, in cornerInputs, variable bool) {
+	if blend == nil {
+		return
+	}
+	arc := blendArc{ta: c.ta, tb: c.tb, mid: c.mid}
+	if variable {
+		arc.chords = arcChords(c, in, cornerChordCount(in))
+	}
+	blend.arcs = append(blend.arcs, arc)
 }
 
 // miterTangents returns this edge's corner tangents and the seam oriented ta→tb: the shared
@@ -346,9 +377,13 @@ func endFaceAt(v *topo.Vertex, a, b *topo.Face) *topo.Face {
 	return nil
 }
 
-// blendArc is one boundary arc of a corner sphere patch (shared with a cylinder fillet):
-// from ta to tb through mid, all on the sphere.
-type blendArc struct{ ta, tb, mid math.Point3 }
+// blendArc is one boundary arc of a corner sphere patch (shared with a cylinder fillet). chords is
+// nil for an analytic single arc (a constant cylinder), or the chord polyline ta…tb when the arc is
+// shared with a VARIABLE cone, whose faceted end must match the patch edge-for-edge to stay watertight.
+type blendArc struct {
+	ta, tb, mid math.Point3
+	chords      []math.Point3
+}
 
 // cornerBlend is a spherical corner patch where several filleted edges meet at one vertex:
 // the rolling-ball sphere tangent to the corner's faces, its tangent point on each face
@@ -371,7 +406,7 @@ type cornerBlend struct {
 // All edges meeting at a corner must use ONE constant radius — a variable edge's faceted end
 // chords cannot meet a corner watertight, and a blend/seam has a single radius — so those and
 // any other configuration error clearly.
-func computeCorners(picks []filletPick, strategy CornerStrategy) (map[uint64]*cornerBlend, map[uint64]*cornerMiter, error) {
+func computeCorners(picks []filletPick) (map[uint64]*cornerBlend, map[uint64]*cornerMiter, error) {
 	groups := map[uint64][]filletPick{}
 	for _, p := range picks {
 		groups[p.edge.StartVertex().ID()] = append(groups[p.edge.StartVertex().ID()], p)
@@ -383,7 +418,7 @@ func computeCorners(picks []filletPick, strategy CornerStrategy) (map[uint64]*co
 		if len(ps) < 2 {
 			continue
 		}
-		cb, cm, err := solveCorner(vid, ps, strategy)
+		cb, cm, err := solveCorner(vid, ps)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -400,8 +435,8 @@ func computeCorners(picks []filletPick, strategy CornerStrategy) (map[uint64]*co
 // solveCorner solves the corner treatment at vertex vid where the picks ps meet: a sphere blend
 // (3 edges, trihedral vertex) or a miter seam (2 edges sharing a face), at the corner's one shared
 // radius. Exactly one of (blend, miter) is returned; any other configuration errors.
-func solveCorner(vid uint64, ps []filletPick, strategy CornerStrategy) (*cornerBlend, *cornerMiter, error) {
-	r, err := blendRadius(ps)
+func solveCorner(vid uint64, ps []filletPick) (*cornerBlend, *cornerMiter, error) {
+	r, err := cornerRadius(vid, ps)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -411,12 +446,10 @@ func solveCorner(vid uint64, ps []filletPick, strategy CornerStrategy) (*cornerB
 	case len(ps) == 3 && len(faces) == 3:
 		cb, err := solveBlend(v, faces, r)
 		return cb, nil, err
-	case len(ps) == 2 && strategy == CornerSetback:
-		// A pure sphere tangent to the three corner planes pinches to points at the two side-plane
-		// tangents, so a distinct watertight set-back patch is still being built; the miter is the
-		// exact alternative and the round the smooth one.
-		return nil, nil, fmt.Errorf("fillet: the setback corner at %v is not yet available — use the miter (exact crease) or round (smooth sphere) corner strategy", v.Point())
 	case len(ps) == 2:
+		if p := varyingPick(ps); p != nil {
+			return nil, nil, fmt.Errorf("fillet: a variable-radius edge (radii %g→%g) cannot share a 2-edge miter corner (its cone has no seam with a cylinder); round the third edge for a setback instead", p.r0, p.r1)
+		}
 		cm, err := solveMiter(v, ps, r)
 		return nil, cm, err
 	default:
@@ -424,19 +457,35 @@ func solveCorner(vid uint64, ps []filletPick, strategy CornerStrategy) (*cornerB
 	}
 }
 
-// blendRadius returns the single constant radius shared by every pick meeting at the corner,
-// erroring on a variable pick or on differing radii (with the offending values).
-func blendRadius(ps []filletPick) (float64, error) {
-	r := ps[0].r0
+// cornerRadius returns the radius every pick carries AT the shared corner vertex vid — the radius of
+// the corner sphere. A variable edge is allowed (e.g. a setback's tapered third edge) as long as its
+// radius at this corner matches the others; only the far ends may differ.
+func cornerRadius(vid uint64, ps []filletPick) (float64, error) {
+	r := radiusAtVertex(ps[0], vid)
 	for _, p := range ps {
-		if p.varying() {
-			return 0, fmt.Errorf("fillet: a variable-radius edge (radii %g→%g) cannot share a filleted corner with another filleted edge", p.r0, p.r1)
-		}
-		if p.r0 != r {
-			return 0, fmt.Errorf("fillet: edges meeting at a shared corner must use one radius (got %g and %g)", r, p.r0)
+		if rv := radiusAtVertex(p, vid); rv != r {
+			return 0, fmt.Errorf("fillet: edges meeting at a shared corner must use one radius there (got %g and %g)", r, rv)
 		}
 	}
 	return r, nil
+}
+
+// varyingPick returns the first pick whose radius varies along the edge, or nil if all are constant.
+func varyingPick(ps []filletPick) *filletPick {
+	for i := range ps {
+		if ps[i].varying() {
+			return &ps[i]
+		}
+	}
+	return nil
+}
+
+// radiusAtVertex returns the pick's radius at the endpoint vid (r0 at the start vertex, else r1).
+func radiusAtVertex(p filletPick, vid uint64) float64 {
+	if p.edge.StartVertex().ID() == vid {
+		return p.r0
+	}
+	return p.r1
 }
 
 // edgesOf projects the picks' edges.

--- a/kernel/ops/fillet_corner_test.go
+++ b/kernel/ops/fillet_corner_test.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Comprehensive coverage of the three fillet CORNER strategies (miter / round / setback) and the
+// run-out they are built on, plus the fillet-of-a-fillet (refillet) matrix. The corner strategy
+// controls how a vertex where two filleted edges meet — its third edge sharp — is treated:
+//   - miter:   the two cylinders mutually trim at a crease (exact rolling ball; no sphere);
+//   - round:   the sharp third edge is rounded at constant radius → a full 3-edge sphere;
+//   - setback: the sharp third edge is tapered to a run-out → a smooth sphere that fades to sharp.
+
+// topLoopKeys returns the four top edges of a box (both endpoints at z == top).
+func topLoopKeys(t *testing.T, b *topo.Body, top float64) [][]byte {
+	t.Helper()
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.Z == top && c.Z == top {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	if len(keys) != 4 {
+		t.Fatalf("expected 4 top edges at z=%g, found %d", top, len(keys))
+	}
+	return keys
+}
+
+// cornerStrategyOf maps a wire-style spelling to the kernel strategy (the test's own small table).
+func cornerStrategyOf(name string) ops.CornerStrategy {
+	switch name {
+	case "round":
+		return ops.CornerRound
+	case "setback":
+		return ops.CornerSetback
+	default:
+		return ops.CornerMiter
+	}
+}
+
+// TestFilletCornerStrategiesValidWatertight drives every strategy across a single-corner selection
+// (two of a vertex's three edges) and a whole top-loop selection (four corners), asserting a valid
+// watertight solid, the expected sphere count, and that material was removed.
+func TestFilletCornerStrategiesValidWatertight(t *testing.T) {
+	cases := []struct {
+		strategy   string
+		scenario   string
+		wantSphere int
+	}{
+		{"miter", "oneCorner", 0}, {"round", "oneCorner", 1}, {"setback", "oneCorner", 1},
+		{"miter", "allTop", 0}, {"round", "allTop", 4}, {"setback", "allTop", 4},
+	}
+	for _, c := range cases {
+		t.Run(c.strategy+"-"+c.scenario, func(t *testing.T) {
+			box := shellBox(2, 2, 2)
+			var picks []ops.EdgeFilletRadii
+			if c.scenario == "oneCorner" {
+				for _, k := range cornerEdgeKeys(t, box)[:2] {
+					picks = append(picks, ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3})
+				}
+			} else {
+				for _, k := range topLoopKeys(t, box, 2) {
+					picks = append(picks, ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3})
+				}
+			}
+			res, err := ops.FilletEdgesCorner(box, picks, cornerStrategyOf(c.strategy))
+			if err != nil {
+				t.Fatalf("%s/%s: %v", c.strategy, c.scenario, err)
+			}
+			if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+				t.Fatalf("%s/%s not a valid solid: %+v", c.strategy, c.scenario, r)
+			}
+			if s := hasSphereFaces(res); s != c.wantSphere {
+				t.Errorf("%s/%s: %d sphere faces, want %d", c.strategy, c.scenario, s, c.wantSphere)
+			}
+			for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+				m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+				if open := meshOpenEdges(m); open != 0 {
+					t.Errorf("%s/%s at tol %g: %d open edges", c.strategy, c.scenario, tol, open)
+				}
+			}
+			if v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume; v >= 8 {
+				t.Errorf("%s/%s volume = %g, want < 8 (material removed)", c.strategy, c.scenario, v)
+			}
+		})
+	}
+}
+
+// TestFilletCornerVolumeOrdering checks the strategies differ as expected on the SAME selection: a
+// miter keeps the most material (it only rounds the two picked edges); a round removes the most (it
+// rounds the third edge full length too); a setback sits strictly between (it rounds the third edge
+// only near the corner, tapering to a run-out). So vol(miter) > vol(setback) > vol(round).
+func TestFilletCornerVolumeOrdering(t *testing.T) {
+	vol := func(strategy string) float64 {
+		box := shellBox(2, 2, 2)
+		var picks []ops.EdgeFilletRadii
+		for _, k := range cornerEdgeKeys(t, box)[:2] {
+			picks = append(picks, ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3})
+		}
+		res, err := ops.FilletEdgesCorner(box, picks, cornerStrategyOf(strategy))
+		if err != nil {
+			t.Fatalf("%s: %v", strategy, err)
+		}
+		return ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume
+	}
+	miter, setback, round := vol("miter"), vol("setback"), vol("round")
+	if !(miter > setback && setback > round) {
+		t.Errorf("expected vol(miter) > vol(setback) > vol(round), got %g, %g, %g", miter, setback, round)
+	}
+}
+
+// TestFilletRunOutBothEndsZeroRejected: a fillet of radius 0 at BOTH ends is no fillet — a precise
+// error, not a degenerate body (a single end at 0 is the valid run-out).
+func TestFilletRunOutBothEndsZeroRejected(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	_, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{{Key: verticalEdgeKey(t, box), R0: 0, R1: 0}})
+	if err == nil || !strings.Contains(err.Error(), "at least one") {
+		t.Fatalf("both-ends-zero err = %v, want the >=0 / at-least-one rejection", err)
+	}
+}
+
+// TestFilletCornerRadiusMismatchRejected: at a shared corner every edge must carry the SAME radius
+// there (the corner sphere has one radius) — differing corner radii are a precise error.
+func TestFilletCornerRadiusMismatchRejected(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	keys := cornerEdgeKeys(t, box)
+	_, err := ops.FilletEdgesCorner(box, []ops.EdgeFilletRadii{
+		{Key: keys[0], R0: 0.3, R1: 0.3},
+		{Key: keys[1], R0: 0.3, R1: 0.3},
+		{Key: keys[2], R0: 0.5, R1: 0.5},
+	}, ops.CornerMiter)
+	if err == nil || !strings.Contains(err.Error(), "one radius") {
+		t.Fatalf("radius-mismatch err = %v, want the one-radius-at-corner rejection", err)
+	}
+}
+
+// TestFilletOfAFilletArcCap: rounding a box's vertical edge leaves a quarter-cylinder whose top cap
+// edge is a sharp ARC (cylinder ∩ top plane); filleting THAT arc (a fillet of a fillet) rounds it
+// into a torus + setback end-caps — a valid watertight solid with exactly one torus face.
+func TestFilletOfAFilletArcCap(t *testing.T) {
+	f1 := filletBoxVertical(t, 4, 3, 0.3)
+	var arc []byte
+	for _, e := range f1.Edges() {
+		m := e.RangeBox().Center()
+		if stdmath.Abs(m.X-3.85) < 1e-6 && stdmath.Abs(m.Y-2.85) < 1e-6 && m.Z > 1.9 {
+			arc = e.ReferenceKey()
+		}
+	}
+	if arc == nil {
+		t.Fatal("no sharp arc cap on the filleted box")
+	}
+	res, err := ops.FilletEdges(f1, [][]byte{arc}, 0.1)
+	if err != nil {
+		t.Fatalf("arc-cap refillet: %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("arc-cap refillet not a valid solid: %+v", r)
+	}
+	tor := 0
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Torus); ok {
+			tor++
+		}
+	}
+	if tor != 1 {
+		t.Errorf("torus faces = %d, want 1", tor)
+	}
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("arc-cap refillet at tol %g: %d open edges", tol, open)
+		}
+	}
+}
+
+// TestFilletOfAFilletSmoothLineRejected: the cylinder a vertical-edge fillet leaves runs G1-smooth
+// into the side plane; that tangent line has no corner to round, so filleting it (a fillet of a
+// fillet) is rejected cleanly as smooth — not a misleading invalid-solid.
+func TestFilletOfAFilletSmoothLineRejected(t *testing.T) {
+	f1 := filletBoxVertical(t, 4, 3, 0.3)
+	var line []byte
+	for _, e := range f1.Edges() {
+		m := e.RangeBox().Center()
+		if stdmath.Abs(m.X-4) < 1e-6 && stdmath.Abs(m.Y-2.7) < 1e-6 {
+			line = e.ReferenceKey()
+		}
+	}
+	if line == nil {
+		t.Fatal("no smooth tangent line on the filleted box")
+	}
+	if _, err := ops.FilletEdges(f1, [][]byte{line}, 0.1); err == nil || !strings.Contains(err.Error(), "smooth") {
+		t.Errorf("smooth tangent line should be rejected as smooth, got: %v", err)
+	}
+}
+
+// TestFilletOfAFilletRim: rounding the top rim of an analytic cylinder is a fillet of a (degenerate)
+// closed edge — it routes to the toroidal-band rim fillet, a valid watertight solid with one torus.
+func TestFilletOfAFilletRim(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1.0, 2.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := ops.FilletEdges(cyl, [][]byte{topRimKey(t, cyl, 2.0)}, 0.3)
+	if err != nil {
+		t.Fatalf("rim refillet: %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("rim refillet not a valid solid: %+v", r)
+	}
+	tor := 0
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Torus); ok {
+			tor++
+		}
+	}
+	if tor != 1 {
+		t.Errorf("rim torus faces = %d, want 1", tor)
+	}
+}

--- a/kernel/ops/fillet_corner_test.go
+++ b/kernel/ops/fillet_corner_test.go
@@ -36,6 +36,28 @@ func topLoopKeys(t *testing.T, b *topo.Body, top float64) [][]byte {
 	return keys
 }
 
+// assertWatertight fails t if res has any open mesh edges across coarse-to-fine tolerances.
+func assertWatertight(t *testing.T, res *topo.Body, label string) {
+	t.Helper()
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("%s at tol %g: %d open edges", label, tol, open)
+		}
+	}
+}
+
+// countTorusFaces counts the body's analytic torus faces.
+func countTorusFaces(res *topo.Body) int {
+	n := 0
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Torus); ok {
+			n++
+		}
+	}
+	return n
+}
+
 // cornerStrategyOf maps a wire-style spelling to the kernel strategy (the test's own small table).
 func cornerStrategyOf(name string) ops.CornerStrategy {
 	switch name {
@@ -83,12 +105,7 @@ func TestFilletCornerStrategiesValidWatertight(t *testing.T) {
 			if s := hasSphereFaces(res); s != c.wantSphere {
 				t.Errorf("%s/%s: %d sphere faces, want %d", c.strategy, c.scenario, s, c.wantSphere)
 			}
-			for _, tol := range []float64{0.05, 1e-2, 1e-3} {
-				m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
-				if open := meshOpenEdges(m); open != 0 {
-					t.Errorf("%s/%s at tol %g: %d open edges", c.strategy, c.scenario, tol, open)
-				}
-			}
+			assertWatertight(t, res, c.strategy+"/"+c.scenario)
 			if v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume; v >= 8 {
 				t.Errorf("%s/%s volume = %g, want < 8 (material removed)", c.strategy, c.scenario, v)
 			}
@@ -166,21 +183,10 @@ func TestFilletOfAFilletArcCap(t *testing.T) {
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
 		t.Fatalf("arc-cap refillet not a valid solid: %+v", r)
 	}
-	tor := 0
-	for _, f := range res.Faces() {
-		if _, ok := f.Geometry().(geom.Torus); ok {
-			tor++
-		}
-	}
-	if tor != 1 {
+	if tor := countTorusFaces(res); tor != 1 {
 		t.Errorf("torus faces = %d, want 1", tor)
 	}
-	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
-		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
-		if open := meshOpenEdges(m); open != 0 {
-			t.Errorf("arc-cap refillet at tol %g: %d open edges", tol, open)
-		}
-	}
+	assertWatertight(t, res, "arc-cap refillet")
 }
 
 // TestFilletOfAFilletSmoothLineRejected: the cylinder a vertical-edge fillet leaves runs G1-smooth
@@ -217,13 +223,7 @@ func TestFilletOfAFilletRim(t *testing.T) {
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
 		t.Fatalf("rim refillet not a valid solid: %+v", r)
 	}
-	tor := 0
-	for _, f := range res.Faces() {
-		if _, ok := f.Geometry().(geom.Torus); ok {
-			tor++
-		}
-	}
-	if tor != 1 {
+	if tor := countTorusFaces(res); tor != 1 {
 		t.Errorf("rim torus faces = %d, want 1", tor)
 	}
 }

--- a/kernel/ops/fillet_corner_test.go
+++ b/kernel/ops/fillet_corner_test.go
@@ -3,23 +3,34 @@
 package ops_test
 
 import (
-	stdmath "math"
 	"strings"
 	"testing"
 
-	"oblikovati.org/kernel/brep"
-	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/math"
 )
 
 // Comprehensive coverage of the three fillet CORNER strategies (miter / round / setback) and the
-// run-out they are built on, plus the fillet-of-a-fillet (refillet) matrix. The corner strategy
-// controls how a vertex where two filleted edges meet — its third edge sharp — is treated:
+// run-out they are built on. The strategy controls how a vertex where two filleted edges meet — its
+// third edge sharp — is treated:
 //   - miter:   the two cylinders mutually trim at a crease (exact rolling ball; no sphere);
 //   - round:   the sharp third edge is rounded at constant radius → a full 3-edge sphere;
 //   - setback: the sharp third edge is tapered to a run-out → a smooth sphere that fades to sharp.
+//
+// The fillet-of-a-fillet (refillet) cases live with their features: TestFilletEdgesRoutesArc /
+// TestFilletCurvedAdjacentReported (arc cap → torus, smooth tangent line → rejected) and
+// TestFilletEdgesRoutesRim / TestRimFilletTorusBand (cylinder rim → toroidal band).
+
+// assertWatertight fails t if res has any open mesh edges across coarse-to-fine tolerances.
+func assertWatertight(t *testing.T, res *topo.Body, label string) {
+	t.Helper()
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("%s at tol %g: %d open edges", label, tol, open)
+		}
+	}
+}
 
 // topLoopKeys returns the four top edges of a box (both endpoints at z == top).
 func topLoopKeys(t *testing.T, b *topo.Body, top float64) [][]byte {
@@ -36,28 +47,6 @@ func topLoopKeys(t *testing.T, b *topo.Body, top float64) [][]byte {
 	return keys
 }
 
-// assertWatertight fails t if res has any open mesh edges across coarse-to-fine tolerances.
-func assertWatertight(t *testing.T, res *topo.Body, label string) {
-	t.Helper()
-	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
-		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
-		if open := meshOpenEdges(m); open != 0 {
-			t.Errorf("%s at tol %g: %d open edges", label, tol, open)
-		}
-	}
-}
-
-// countTorusFaces counts the body's analytic torus faces.
-func countTorusFaces(res *topo.Body) int {
-	n := 0
-	for _, f := range res.Faces() {
-		if _, ok := f.Geometry().(geom.Torus); ok {
-			n++
-		}
-	}
-	return n
-}
-
 // cornerStrategyOf maps a wire-style spelling to the kernel strategy (the test's own small table).
 func cornerStrategyOf(name string) ops.CornerStrategy {
 	switch name {
@@ -68,6 +57,21 @@ func cornerStrategyOf(name string) ops.CornerStrategy {
 	default:
 		return ops.CornerMiter
 	}
+}
+
+// cornerStrategyPicks selects the fillet edges for a scenario: two of one vertex's three edges
+// ("oneCorner"), or the whole top loop ("allTop"), all at radius 0.3.
+func cornerStrategyPicks(t *testing.T, box *topo.Body, scenario string) []ops.EdgeFilletRadii {
+	t.Helper()
+	keys := topLoopKeys(t, box, 2)
+	if scenario == "oneCorner" {
+		keys = cornerEdgeKeys(t, box)[:2]
+	}
+	picks := make([]ops.EdgeFilletRadii, len(keys))
+	for i, k := range keys {
+		picks[i] = ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3}
+	}
+	return picks
 }
 
 // TestFilletCornerStrategiesValidWatertight drives every strategy across a single-corner selection
@@ -85,17 +89,7 @@ func TestFilletCornerStrategiesValidWatertight(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.strategy+"-"+c.scenario, func(t *testing.T) {
 			box := shellBox(2, 2, 2)
-			var picks []ops.EdgeFilletRadii
-			if c.scenario == "oneCorner" {
-				for _, k := range cornerEdgeKeys(t, box)[:2] {
-					picks = append(picks, ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3})
-				}
-			} else {
-				for _, k := range topLoopKeys(t, box, 2) {
-					picks = append(picks, ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3})
-				}
-			}
-			res, err := ops.FilletEdgesCorner(box, picks, cornerStrategyOf(c.strategy))
+			res, err := ops.FilletEdgesCorner(box, cornerStrategyPicks(t, box, c.scenario), cornerStrategyOf(c.strategy))
 			if err != nil {
 				t.Fatalf("%s/%s: %v", c.strategy, c.scenario, err)
 			}
@@ -120,11 +114,7 @@ func TestFilletCornerStrategiesValidWatertight(t *testing.T) {
 func TestFilletCornerVolumeOrdering(t *testing.T) {
 	vol := func(strategy string) float64 {
 		box := shellBox(2, 2, 2)
-		var picks []ops.EdgeFilletRadii
-		for _, k := range cornerEdgeKeys(t, box)[:2] {
-			picks = append(picks, ops.EdgeFilletRadii{Key: k, R0: 0.3, R1: 0.3})
-		}
-		res, err := ops.FilletEdgesCorner(box, picks, cornerStrategyOf(strategy))
+		res, err := ops.FilletEdgesCorner(box, cornerStrategyPicks(t, box, "oneCorner"), cornerStrategyOf(strategy))
 		if err != nil {
 			t.Fatalf("%s: %v", strategy, err)
 		}
@@ -137,7 +127,7 @@ func TestFilletCornerVolumeOrdering(t *testing.T) {
 }
 
 // TestFilletRunOutBothEndsZeroRejected: a fillet of radius 0 at BOTH ends is no fillet — a precise
-// error, not a degenerate body (a single end at 0 is the valid run-out).
+// error, not a degenerate body (a single end at 0 is the valid run-out, TestFilletRunOutToZero).
 func TestFilletRunOutBothEndsZeroRejected(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	_, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{{Key: verticalEdgeKey(t, box), R0: 0, R1: 0}})
@@ -158,72 +148,5 @@ func TestFilletCornerRadiusMismatchRejected(t *testing.T) {
 	}, ops.CornerMiter)
 	if err == nil || !strings.Contains(err.Error(), "one radius") {
 		t.Fatalf("radius-mismatch err = %v, want the one-radius-at-corner rejection", err)
-	}
-}
-
-// TestFilletOfAFilletArcCap: rounding a box's vertical edge leaves a quarter-cylinder whose top cap
-// edge is a sharp ARC (cylinder ∩ top plane); filleting THAT arc (a fillet of a fillet) rounds it
-// into a torus + setback end-caps — a valid watertight solid with exactly one torus face.
-func TestFilletOfAFilletArcCap(t *testing.T) {
-	f1 := filletBoxVertical(t, 4, 3, 0.3)
-	var arc []byte
-	for _, e := range f1.Edges() {
-		m := e.RangeBox().Center()
-		if stdmath.Abs(m.X-3.85) < 1e-6 && stdmath.Abs(m.Y-2.85) < 1e-6 && m.Z > 1.9 {
-			arc = e.ReferenceKey()
-		}
-	}
-	if arc == nil {
-		t.Fatal("no sharp arc cap on the filleted box")
-	}
-	res, err := ops.FilletEdges(f1, [][]byte{arc}, 0.1)
-	if err != nil {
-		t.Fatalf("arc-cap refillet: %v", err)
-	}
-	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
-		t.Fatalf("arc-cap refillet not a valid solid: %+v", r)
-	}
-	if tor := countTorusFaces(res); tor != 1 {
-		t.Errorf("torus faces = %d, want 1", tor)
-	}
-	assertWatertight(t, res, "arc-cap refillet")
-}
-
-// TestFilletOfAFilletSmoothLineRejected: the cylinder a vertical-edge fillet leaves runs G1-smooth
-// into the side plane; that tangent line has no corner to round, so filleting it (a fillet of a
-// fillet) is rejected cleanly as smooth — not a misleading invalid-solid.
-func TestFilletOfAFilletSmoothLineRejected(t *testing.T) {
-	f1 := filletBoxVertical(t, 4, 3, 0.3)
-	var line []byte
-	for _, e := range f1.Edges() {
-		m := e.RangeBox().Center()
-		if stdmath.Abs(m.X-4) < 1e-6 && stdmath.Abs(m.Y-2.7) < 1e-6 {
-			line = e.ReferenceKey()
-		}
-	}
-	if line == nil {
-		t.Fatal("no smooth tangent line on the filleted box")
-	}
-	if _, err := ops.FilletEdges(f1, [][]byte{line}, 0.1); err == nil || !strings.Contains(err.Error(), "smooth") {
-		t.Errorf("smooth tangent line should be rejected as smooth, got: %v", err)
-	}
-}
-
-// TestFilletOfAFilletRim: rounding the top rim of an analytic cylinder is a fillet of a (degenerate)
-// closed edge — it routes to the toroidal-band rim fillet, a valid watertight solid with one torus.
-func TestFilletOfAFilletRim(t *testing.T) {
-	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1.0, 2.0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := ops.FilletEdges(cyl, [][]byte{topRimKey(t, cyl, 2.0)}, 0.3)
-	if err != nil {
-		t.Fatalf("rim refillet: %v", err)
-	}
-	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
-		t.Fatalf("rim refillet not a valid solid: %+v", r)
-	}
-	if tor := countTorusFaces(res); tor != 1 {
-		t.Errorf("rim torus faces = %d, want 1", tor)
 	}
 }

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -43,42 +43,38 @@ func rulingStripFaces(ef edgeFillet) []filletFace {
 	for j := 0; j+1 < len(ef.c0.chords); j++ {
 		switch {
 		case ef.c1.runout: // fan from corner-0's arc to corner-1's apex
-			out = append(out, planarTriangleFace(ef.c0.chords[j], ef.c1.cen, ef.c0.chords[j+1], cmid))
+			out = append(out, planarFaceFromRing([]math.Point3{ef.c0.chords[j], ef.c1.cen, ef.c0.chords[j+1]}, cmid))
 		case ef.c0.runout: // fan from corner-1's arc to corner-0's apex
-			out = append(out, planarTriangleFace(ef.c1.chords[j], ef.c0.cen, ef.c1.chords[j+1], cmid))
+			out = append(out, planarFaceFromRing([]math.Point3{ef.c1.chords[j], ef.c0.cen, ef.c1.chords[j+1]}, cmid))
 		default:
-			quad := [4]math.Point3{ef.c0.chords[j], ef.c1.chords[j], ef.c1.chords[j+1], ef.c0.chords[j+1]}
-			out = append(out, planarQuadFace(quad, cmid))
+			out = append(out, planarFaceFromRing([]math.Point3{ef.c0.chords[j], ef.c1.chords[j], ef.c1.chords[j+1], ef.c0.chords[j+1]}, cmid))
 		}
 	}
 	return out
 }
 
-// planarTriangleFace builds one planar triangle, wound so its normal points away from cmid.
-func planarTriangleFace(p0, p1, p2, cmid math.Point3) filletFace {
-	n := p0.VectorTo(p1).Cross(p0.VectorTo(p2))
-	tri := [3]math.Point3{p0, p1, p2}
-	if n.Dot(cmid.VectorTo(centroidPts(tri[:]))) < 0 {
-		tri = [3]math.Point3{p0, p2, p1}
-	}
-	pl, _ := geom.NewPlane(tri[0], p0.VectorTo(tri[1]).Cross(p0.VectorTo(tri[2])))
-	return filletFace{surface: pl, loops: []filletLoop{{pts: tri[:], curves: make([]geom.Curve3, 3)}}}
-}
-
-// planarQuadFace builds one planar face over the quad, wound so its normal points away from
-// the blend centre line (approximated by cmid — the wedge spans < π, so the sign is robust).
-func planarQuadFace(quad [4]math.Point3, cmid math.Point3) filletFace {
-	n := quad[0].VectorTo(quad[1]).Cross(quad[0].VectorTo(quad[3]))
-	qc := centroidPts(quad[:])
-	if n.Dot(cmid.VectorTo(qc)) < 0 {
-		quad = [4]math.Point3{quad[0], quad[3], quad[2], quad[1]}
+// planarFaceFromRing builds one planar face over a closed point ring (a quad strip or a triangle fan
+// of the cone), wound so its normal points away from the blend centre line (cmid; the wedge spans < π,
+// so the sign is robust).
+func planarFaceFromRing(ring []math.Point3, cmid math.Point3) filletFace {
+	n := ring[0].VectorTo(ring[1]).Cross(ring[0].VectorTo(ring[len(ring)-1]))
+	if n.Dot(cmid.VectorTo(centroidPts(ring))) < 0 {
+		ring = reversedRing(ring)
 		n = n.Scale(-1)
 	}
-	pl, _ := geom.NewPlane(quad[0], n)
-	return filletFace{surface: pl, loops: []filletLoop{{
-		pts:    quad[:],
-		curves: make([]geom.Curve3, 4),
-	}}}
+	pl, _ := geom.NewPlane(ring[0], n)
+	return filletFace{surface: pl, loops: []filletLoop{{pts: ring, curves: make([]geom.Curve3, len(ring))}}}
+}
+
+// reversedRing reverses a closed point ring while keeping its first point first (so the winding flips
+// but the loop still starts at ring[0]): [p0,p1,…,pn] → [p0,pn,…,p1].
+func reversedRing(ring []math.Point3) []math.Point3 {
+	out := make([]math.Point3, len(ring))
+	out[0] = ring[0]
+	for i := 1; i < len(ring); i++ {
+		out[i] = ring[len(ring)-i]
+	}
+	return out
 }
 
 // filletMaps indexes, per face: the corner-vertex → tangent-point pullbacks (where the face

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -35,15 +35,34 @@ func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*co
 // rulings: chord j of corner 0 pairs with chord j of corner 1 (the corners are sampled at the
 // same angular stations). Adjacent rulings of the blend meet at its cone apex on the edge
 // line, so each strip face is exactly planar; winding is fixed outward (away from the centre
-// line) per quad.
+// line) per quad. When one end is a RUN-OUT (radius 0, all its chords are the apex vertex), the
+// strips collapse to a triangle fan to that apex so the cone closes manifold (not degenerate quads).
 func rulingStripFaces(ef edgeFillet) []filletFace {
 	cmid := ef.c0.cen.Midpoint(ef.c1.cen)
 	out := make([]filletFace, 0, len(ef.c0.chords)-1)
 	for j := 0; j+1 < len(ef.c0.chords); j++ {
-		quad := [4]math.Point3{ef.c0.chords[j], ef.c1.chords[j], ef.c1.chords[j+1], ef.c0.chords[j+1]}
-		out = append(out, planarQuadFace(quad, cmid))
+		switch {
+		case ef.c1.runout: // fan from corner-0's arc to corner-1's apex
+			out = append(out, planarTriangleFace(ef.c0.chords[j], ef.c1.cen, ef.c0.chords[j+1], cmid))
+		case ef.c0.runout: // fan from corner-1's arc to corner-0's apex
+			out = append(out, planarTriangleFace(ef.c1.chords[j], ef.c0.cen, ef.c1.chords[j+1], cmid))
+		default:
+			quad := [4]math.Point3{ef.c0.chords[j], ef.c1.chords[j], ef.c1.chords[j+1], ef.c0.chords[j+1]}
+			out = append(out, planarQuadFace(quad, cmid))
+		}
 	}
 	return out
+}
+
+// planarTriangleFace builds one planar triangle, wound so its normal points away from cmid.
+func planarTriangleFace(p0, p1, p2, cmid math.Point3) filletFace {
+	n := p0.VectorTo(p1).Cross(p0.VectorTo(p2))
+	tri := [3]math.Point3{p0, p1, p2}
+	if n.Dot(cmid.VectorTo(centroidPts(tri[:]))) < 0 {
+		tri = [3]math.Point3{p0, p2, p1}
+	}
+	pl, _ := geom.NewPlane(tri[0], p0.VectorTo(tri[1]).Cross(p0.VectorTo(tri[2])))
+	return filletFace{surface: pl, loops: []filletLoop{{pts: tri[:], curves: make([]geom.Curve3, 3)}}}
 }
 
 // planarQuadFace builds one planar face over the quad, wound so its normal points away from
@@ -79,8 +98,8 @@ func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*
 		for _, c := range []corner{ef.c0, ef.c1} {
 			put(ab, c.a, c.vertex.ID(), c.ta)
 			put(ab, c.b, c.vertex.ID(), c.tb)
-			if c.blend || c.miter {
-				continue // the rounded corner is the sphere patch or the miter seam, not an end-face arc
+			if c.blend || c.miter || c.runout {
+				continue // the rounded corner is a sphere patch / miter seam / run-out apex, not an end-face arc
 			}
 			if ends[c.endFace] == nil {
 				ends[c.endFace] = map[uint64]corner{}
@@ -282,14 +301,29 @@ func chainArcs(arcs []blendArc) filletLoop {
 				continue
 			}
 			used[j] = true
-			arc, _ := geom.Arc3dByThreePoints(from, a.mid, to)
-			fl.pts = append(fl.pts, from)
-			fl.curves = append(fl.curves, arc)
+			appendBlendArc(&fl, a, from, to)
 			cur = to
 			break
 		}
 	}
 	return fl
+}
+
+// appendBlendArc appends one blend arc oriented from→to: a faceted chord polyline (straight segments)
+// when the arc is shared with a variable cone, otherwise a single Arc3d through its midpoint. Only the
+// segment's start points are added (its end is the next arc's start), so the loop stays closed.
+func appendBlendArc(fl *filletLoop, a blendArc, from, to math.Point3) {
+	if a.chords == nil {
+		arc, _ := geom.Arc3dByThreePoints(from, a.mid, to)
+		fl.pts = append(fl.pts, from)
+		fl.curves = append(fl.curves, arc)
+		return
+	}
+	pts := orientedChords(a.chords, from) // ta…tb, reversed when entering from tb
+	for i := 0; i+1 < len(pts); i++ {
+		fl.pts = append(fl.pts, pts[i])
+		fl.curves = append(fl.curves, nil) // straight chord matching the cone's ruling end
+	}
 }
 
 // arcEndpoints orients an arc so it starts at cur (returning from=cur, to=other), or ok=false
@@ -312,8 +346,9 @@ func spherePatchFlipped(cb *cornerBlend, loop filletLoop) bool {
 	return n.Dot(cb.center.VectorTo(c)) < 0
 }
 
-// reverseArcLoop reverses a closed arc loop, re-deriving each segment's arc in the new
-// direction (the arc midpoints are recovered from the original arcs).
+// reverseArcLoop reverses a closed arc loop, re-deriving each segment's arc in the new direction
+// (the arc midpoints are recovered from the original arcs). Straight chord segments (nil curve, from a
+// faceted variable-cone arc) stay straight rather than being mis-fitted to an arc through the origin.
 func reverseArcLoop(loop filletLoop) filletLoop {
 	n := len(loop.pts)
 	mids := arcMidpoints(loop)
@@ -321,9 +356,13 @@ func reverseArcLoop(loop filletLoop) filletLoop {
 	for i := 0; i < n; i++ {
 		from := loop.pts[(n-i)%n]
 		to := loop.pts[(n-i-1+n)%n]
-		arc, _ := geom.Arc3dByThreePoints(from, mids[(n-i-1+n)%n], to)
+		src := (n - i - 1 + n) % n
+		var curve geom.Curve3
+		if loop.curves[src] != nil {
+			curve, _ = geom.Arc3dByThreePoints(from, mids[src], to)
+		}
 		out.pts = append(out.pts, from)
-		out.curves = append(out.curves, arc)
+		out.curves = append(out.curves, curve)
 	}
 	return out
 }

--- a/kernel/ops/fillet_setback.go
+++ b/kernel/ops/fillet_setback.go
@@ -4,12 +4,28 @@ package ops
 
 import "oblikovati.org/kernel/topo"
 
-// roundThirdEdges augments the pick list so every 2-edge corner becomes a full 3-edge sphere blend:
-// at each vertex where exactly two picked edges meet and a single sharp edge remains, that third edge
-// is added at the corner's radius. This realises the CornerRound strategy by reusing the watertight
-// 3-edge blend (solveBlend) instead of a degenerate 2-edge sphere. Added edges are de-duplicated (an
-// edge may be the third edge of corners at both its ends).
+// roundThirdEdges augments the pick list so every 2-edge corner becomes a full 3-edge sphere blend by
+// adding the sharp third edge at the corner's CONSTANT radius (CornerRound) — reusing the watertight
+// 3-edge blend instead of a degenerate 2-edge sphere.
 func roundThirdEdges(picks []filletPick) []filletPick {
+	return augmentThirdEdges(picks, func(e *topo.Edge, _ uint64, r float64) filletPick {
+		return filletPick{edge: e, r0: r, r1: r}
+	})
+}
+
+// setbackThirdEdges augments the pick list so each 2-edge corner becomes a smooth sphere whose sharp
+// third edge is filleted with a VARIABLE taper — the corner radius at the vertex, running out to 0 at
+// the edge's far end (CornerSetback) — a smooth corner that fades back to the sharp edge. The run-out
+// apex at each far end is handled by the variable-fillet path.
+func setbackThirdEdges(picks []filletPick) []filletPick {
+	return augmentThirdEdges(picks, taperFromCorner)
+}
+
+// augmentThirdEdges adds, for each 2-edge corner (a vertex where exactly two picked edges meet leaving
+// one sharp edge), that sharp third edge to the selection — its pick built by mk from the corner
+// vertex and the corner radius. Added edges are de-duplicated (an edge may be the third edge of
+// corners at both its ends).
+func augmentThirdEdges(picks []filletPick, mk func(third *topo.Edge, vid uint64, r float64) filletPick) []filletPick {
 	already := map[*topo.Edge]bool{}
 	byVertex := map[uint64][]filletPick{}
 	for _, p := range picks {
@@ -23,43 +39,12 @@ func roundThirdEdges(picks []filletPick) []filletPick {
 		if len(ps) != 2 {
 			continue // only a 2-edge corner has a single sharp edge to round
 		}
-		v := vertexByID(edgesOf(ps), vid)
-		third := thirdSharpEdge(v, ps)
+		third := thirdSharpEdge(vertexByID(edgesOf(ps), vid), ps)
 		if third == nil || already[third] || added[third] {
 			continue
 		}
 		added[third] = true
-		out = append(out, filletPick{edge: third, r0: ps[0].r0, r1: ps[0].r0})
-	}
-	return out
-}
-
-// setbackThirdEdges augments the pick list so each 2-edge corner becomes a smooth sphere whose sharp
-// third edge is filleted with a VARIABLE taper — the corner radius at the vertex, running out to 0 at
-// the edge's far end. This realises CornerSetback: a smooth corner that fades back to the sharp edge
-// (distinct from CornerRound, which fillets the third edge at constant radius full-length). Added
-// edges are de-duplicated; the run-out apex at each far end is handled by the variable-fillet path.
-func setbackThirdEdges(picks []filletPick) []filletPick {
-	already := map[*topo.Edge]bool{}
-	byVertex := map[uint64][]filletPick{}
-	for _, p := range picks {
-		already[p.edge] = true
-		byVertex[p.edge.StartVertex().ID()] = append(byVertex[p.edge.StartVertex().ID()], p)
-		byVertex[p.edge.EndVertex().ID()] = append(byVertex[p.edge.EndVertex().ID()], p)
-	}
-	out := picks
-	added := map[*topo.Edge]bool{}
-	for vid, ps := range byVertex {
-		if len(ps) != 2 {
-			continue
-		}
-		v := vertexByID(edgesOf(ps), vid)
-		third := thirdSharpEdge(v, ps)
-		if third == nil || already[third] || added[third] {
-			continue
-		}
-		added[third] = true
-		out = append(out, taperFromCorner(third, vid, radiusAtVertex(ps[0], vid)))
+		out = append(out, mk(third, vid, radiusAtVertex(ps[0], vid)))
 	}
 	return out
 }

--- a/kernel/ops/fillet_setback.go
+++ b/kernel/ops/fillet_setback.go
@@ -34,6 +34,45 @@ func roundThirdEdges(picks []filletPick) []filletPick {
 	return out
 }
 
+// setbackThirdEdges augments the pick list so each 2-edge corner becomes a smooth sphere whose sharp
+// third edge is filleted with a VARIABLE taper — the corner radius at the vertex, running out to 0 at
+// the edge's far end. This realises CornerSetback: a smooth corner that fades back to the sharp edge
+// (distinct from CornerRound, which fillets the third edge at constant radius full-length). Added
+// edges are de-duplicated; the run-out apex at each far end is handled by the variable-fillet path.
+func setbackThirdEdges(picks []filletPick) []filletPick {
+	already := map[*topo.Edge]bool{}
+	byVertex := map[uint64][]filletPick{}
+	for _, p := range picks {
+		already[p.edge] = true
+		byVertex[p.edge.StartVertex().ID()] = append(byVertex[p.edge.StartVertex().ID()], p)
+		byVertex[p.edge.EndVertex().ID()] = append(byVertex[p.edge.EndVertex().ID()], p)
+	}
+	out := picks
+	added := map[*topo.Edge]bool{}
+	for vid, ps := range byVertex {
+		if len(ps) != 2 {
+			continue
+		}
+		v := vertexByID(edgesOf(ps), vid)
+		third := thirdSharpEdge(v, ps)
+		if third == nil || already[third] || added[third] {
+			continue
+		}
+		added[third] = true
+		out = append(out, taperFromCorner(third, vid, radiusAtVertex(ps[0], vid)))
+	}
+	return out
+}
+
+// taperFromCorner builds a variable pick on edge e that carries radius r at the vertex vid (the corner)
+// and runs out to 0 at the far end.
+func taperFromCorner(e *topo.Edge, vid uint64, r float64) filletPick {
+	if e.StartVertex().ID() == vid {
+		return filletPick{edge: e, r0: r, r1: 0}
+	}
+	return filletPick{edge: e, r0: 0, r1: r}
+}
+
 // thirdSharpEdge returns the lone edge at v that is none of the picked edges — the sharp edge a 2-edge
 // corner leaves between the two filleted edges' outer faces. nil unless exactly one such edge exists.
 func thirdSharpEdge(v *topo.Vertex, ps []filletPick) *topo.Edge {

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -309,6 +309,53 @@ func TestFilletCornerRoundAddsThirdEdge(t *testing.T) {
 	}
 }
 
+// TestFilletCornerSetbackTapersThirdEdge checks the CornerSetback strategy: selecting two of the
+// three edges at a corner rounds the corner into a sphere and tapers the sharp third edge from the
+// corner radius to a run-out (radius 0) at its far end — a watertight set-back (3 cylinders/cones + 1
+// sphere), distinct from the constant round. The taper makes it a variable (cone) blend, so the body
+// is watertight at every tolerance with no degenerate run-out apex.
+func TestFilletCornerSetbackTapersThirdEdge(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	keys := cornerEdgeKeys(t, box)[:2]
+	picks := []ops.EdgeFilletRadii{{Key: keys[0], R0: 0.3, R1: 0.3}, {Key: keys[1], R0: 0.3, R1: 0.3}}
+	res, err := ops.FilletEdgesCorner(box, picks, ops.CornerSetback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("set-back corner box not a valid solid: %+v", r)
+	}
+	if s := hasSphereFaces(res); s != 1 {
+		t.Errorf("got %d sphere faces, want 1 (the corner is rounded)", s)
+	}
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("set-back corner at tol %g: %d open edges", tol, open)
+		}
+	}
+}
+
+// TestFilletRunOutToZero checks a lone variable fillet that tapers to radius 0 at one end: the blend
+// cone closes to a single apex on the edge (a run-out / "fade out"), producing a watertight solid
+// rather than the degenerate non-manifold fan the unguarded collapse would leave.
+func TestFilletRunOutToZero(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{{Key: verticalEdgeKey(t, box), R0: 0.3, R1: 0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("run-out fillet not a valid solid: %+v", r)
+	}
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := meshOpenEdges(m); open != 0 {
+			t.Errorf("run-out fillet at tol %g: %d open edges", tol, open)
+		}
+	}
+}
+
 // TestFilletTwoEdgeCornerMiterMeshWatertight checks the miter seam's TESSELLATION is watertight
 // across qualities — the two cylinders share the seam chord polyline exactly, so the welded mesh
 // must have no cracks where they meet.

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -328,12 +328,7 @@ func TestFilletCornerSetbackTapersThirdEdge(t *testing.T) {
 	if s := hasSphereFaces(res); s != 1 {
 		t.Errorf("got %d sphere faces, want 1 (the corner is rounded)", s)
 	}
-	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
-		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
-		if open := meshOpenEdges(m); open != 0 {
-			t.Errorf("set-back corner at tol %g: %d open edges", tol, open)
-		}
-	}
+	assertWatertight(t, res, "set-back corner")
 }
 
 // TestFilletRunOutToZero checks a lone variable fillet that tapers to radius 0 at one end: the blend
@@ -348,12 +343,7 @@ func TestFilletRunOutToZero(t *testing.T) {
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
 		t.Fatalf("run-out fillet not a valid solid: %+v", r)
 	}
-	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
-		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
-		if open := meshOpenEdges(m); open != 0 {
-			t.Errorf("run-out fillet at tol %g: %d open edges", tol, open)
-		}
-	}
+	assertWatertight(t, res, "run-out fillet")
 }
 
 // TestFilletTwoEdgeCornerMiterMeshWatertight checks the miter seam's TESSELLATION is watertight

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -309,28 +309,6 @@ func TestFilletCornerRoundAddsThirdEdge(t *testing.T) {
 	}
 }
 
-// TestFilletCornerSetbackTapersThirdEdge checks the CornerSetback strategy: selecting two of the
-// three edges at a corner rounds the corner into a sphere and tapers the sharp third edge from the
-// corner radius to a run-out (radius 0) at its far end — a watertight set-back (3 cylinders/cones + 1
-// sphere), distinct from the constant round. The taper makes it a variable (cone) blend, so the body
-// is watertight at every tolerance with no degenerate run-out apex.
-func TestFilletCornerSetbackTapersThirdEdge(t *testing.T) {
-	box := shellBox(2, 2, 2)
-	keys := cornerEdgeKeys(t, box)[:2]
-	picks := []ops.EdgeFilletRadii{{Key: keys[0], R0: 0.3, R1: 0.3}, {Key: keys[1], R0: 0.3, R1: 0.3}}
-	res, err := ops.FilletEdgesCorner(box, picks, ops.CornerSetback)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
-		t.Fatalf("set-back corner box not a valid solid: %+v", r)
-	}
-	if s := hasSphereFaces(res); s != 1 {
-		t.Errorf("got %d sphere faces, want 1 (the corner is rounded)", s)
-	}
-	assertWatertight(t, res, "set-back corner")
-}
-
 // TestFilletRunOutToZero checks a lone variable fillet that tapers to radius 0 at one end: the blend
 // cone closes to a single apex on the edge (a run-out / "fade out"), producing a watertight solid
 // rather than the degenerate non-manifold fan the unguarded collapse would leave.


### PR DESCRIPTION
## What

Makes the **setback** fillet corner strategy real (it was reserved). The set-back rounds the corner into a sphere and **tapers the sharp third edge from the corner radius down to a run-out (radius 0)** — a smooth corner that fades back to the sharp edge, distinct from the constant `round` and the exact `miter` crease.

Built on two new kernel capabilities:

### 1. Variable-fillet run-out (taper to 0)
A variable fillet may now taper to radius 0 at one end. The blend cone closes to a single **apex** on the edge (a clean fade-out) instead of the degenerate non-manifold fan the unguarded collapse left:
- `rulingStripFaces` emits a triangle fan to the apex when one end is a run-out;
- the run-out corner carries no end face (`corner.runout`);
- `resolveFilletPicks` accepts a 0 at one end (both 0 still errors).

### 2. Set-back = a 3-edge sphere whose third edge is the run-out
- `setbackThirdEdges` augments each 2-edge corner with the sharp third edge as a taper (corner radius → 0), so it resolves as the watertight 3-edge sphere blend.
- `cornerRadius` allows a variable edge at a **blend** corner when its radius *there* matches (far ends may differ); a 2-edge **miter** still rejects a variable edge (a cone has no seam with a cylinder) — `TestFilletVaryingAtSharedCornerRejected` keeps that guard.
- The sphere patch **facets its arc on the variable side** (`blendArc.chords`) to match the cone's ruled end edge-for-edge, so patch and cone weld watertight.

No API/feature/router/head change — `types.FilletCornerSetback` already routes to `ops.CornerSetback`; only the kernel changes.

## Tests

- `TestFilletCornerSetbackTapersThirdEdge` (sphere corner + tapered run-out, watertight at every tol), `TestFilletRunOutToZero` (lone fade-out, watertight). Full regression green, `-race` on ops, lint 0.

## Live verification (head over the MCP bridge, `mcpcornerdemo`)

One document per corner type, single-corner case:
- **miter** → crease, sharp verticals;
- **round** → smooth sphere + full-length rounded vertical;
- **setback** → smooth sphere + vertical that **tapers to a run-out** and fades back to sharp.

All three healthy and watertight; screenshots captured and visually distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)