### PR TITLE
feat: sheet-metal environment, rule & unfold methods (M13-F01)

### DIFF
--- a/addin/router/documents.go
+++ b/addin/router/documents.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
@@ -58,8 +59,28 @@ func createDocument(s *app.Session, args json.RawMessage) (json.RawMessage, erro
 		if err := s.StampDocumentSubType(d, doc.SubTypeID(in.SubType)); err != nil {
 			return nil, err
 		}
+		if err := enableSheetMetalIfFlavored(d, doc.SubTypeID(in.SubType)); err != nil {
+			return nil, err
+		}
 	}
 	return json.Marshal(docInfo(d, d))
+}
+
+// enableSheetMetalIfFlavored seeds the sheet-metal rule on a part stamped with the
+// sheet-metal subtype, so a part created as sheet metal enters the environment ready to
+// take wall/bend features (M13-F01). Other flavors are left untouched.
+func enableSheetMetalIfFlavored(d *doc.Document, sub doc.SubTypeID) error {
+	if sub != types.SubTypeSheetMetalPart {
+		return nil
+	}
+	part, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return fmt.Errorf("documents.create: sheet-metal subtype on a non-part document %q", d.DisplayName())
+	}
+	if _, err := part.EnableSheetMetal(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // registerDocumentSubType declares an add-in flavor (wire documents.registerSubType).

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -107,6 +107,7 @@ func (r *Router) registerStandardHandlers() {
 	r.handlers[wire.MethodFreeformCreaseEdges] = freeformCreaseEdges
 	r.registerSketchHandlers()
 	r.registerFeatureHandlers()
+	r.registerSheetMetalHandlers()
 	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes
 	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
 	r.handlers[wire.MethodWorkPlanesRedefine] = redefineWorkPlane

--- a/addin/router/sheet_metal.go
+++ b/addin/router/sheet_metal.go
@@ -166,14 +166,22 @@ func sheetMetalBendAllowance(s *app.Session, raw json.RawMessage) (json.RawMessa
 }
 
 // styleInfo renders the active rule as wire, formatting lengths in the document's units and
-// including the bend allowance of a 90° bend as a convenience preview.
+// including the bend allowance of a 90° bend as a convenience preview. The two
+// parameter-backed lengths report their authored expression (e.g. "3 mm" or "t*2"), which
+// is both more faithful and free of the floating-point noise a unit reconversion introduces.
 func styleInfo(part *compdef.PartComponentDefinition, rule *sheetmetal.Rule) wire.SheetMetalStyleInfo {
 	fmtLen := func(v float64) string { return part.Units().Format(param.Q(v, param.Length)) }
+	paramExpr := func(name string, value float64) string {
+		if p, ok := part.Parameters().ByName(name); ok {
+			return p.Expression()
+		}
+		return fmtLen(value)
+	}
 	unfold := rule.Unfold()
 	return wire.SheetMetalStyleInfo{
 		Name:          rule.Name(),
-		Thickness:     fmtLen(rule.Thickness()),
-		BendRadius:    fmtLen(rule.BendRadius()),
+		Thickness:     paramExpr(compdef.ThicknessParamName(), rule.Thickness()),
+		BendRadius:    paramExpr(compdef.BendRadiusParamName(), rule.BendRadius()),
 		ReliefShape:   rule.Relief().Shape.String(),
 		ReliefWidth:   fmtLen(rule.ReliefWidth()),
 		ReliefDepth:   fmtLen(rule.ReliefDepth()),

--- a/addin/router/sheet_metal.go
+++ b/addin/router/sheet_metal.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// The sheet-metal rule/style surface (M13-F01, #373/#369): read the active part's rule,
+// edit it (recomputing so a thickness/K-factor change repropagates), and preview the
+// developed flat length of one bend. A part is in the sheet-metal environment when it was
+// created with the sheet-metal subtype, which seeds its rule.
+
+// registerSheetMetalHandlers wires the sheetMetal.* methods.
+func (r *Router) registerSheetMetalHandlers() {
+	r.handlers[wire.MethodSheetMetalGetStyle] = sheetMetalGetStyle
+	r.handlers[wire.MethodSheetMetalSetStyle] = sheetMetalSetStyle
+	r.handlers[wire.MethodSheetMetalBendAllowance] = sheetMetalBendAllowance
+}
+
+// activeSheetMetal returns the active part and its rule, or an error if the active document
+// is not a sheet-metal part.
+func activeSheetMetal(s *app.Session) (*compdef.PartComponentDefinition, *sheetmetal.Rule, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	rule := part.SheetMetal()
+	if rule == nil {
+		return nil, nil, fmt.Errorf("sheetMetal: the active part is not a sheet-metal part (create it with subType %q)", types.SubTypeSheetMetalPart)
+	}
+	return part, rule, nil
+}
+
+func sheetMetalGetStyle(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, rule, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SheetMetalStyleResult{Style: styleInfo(part, rule)})
+}
+
+func sheetMetalSetStyle(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, rule, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetSheetMetalStyleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := applyStyleEdits(part, rule, in); err != nil {
+		return nil, err
+	}
+	part.Recompute()
+	return json.Marshal(wire.SheetMetalStyleResult{Style: styleInfo(part, rule)})
+}
+
+// applyStyleEdits mutates the rule (and its backing parameters) per the non-empty fields of
+// in. Lengths are re-authored on the Thickness/BendRadius parameters so the rule stays
+// parameter-backed; relief/gap/unfold edits land on the rule directly.
+func applyStyleEdits(part *compdef.PartComponentDefinition, rule *sheetmetal.Rule, in wire.SetSheetMetalStyleArgs) error {
+	if in.Thickness != "" {
+		if err := part.SetSheetMetalLengthParam(compdef.ThicknessParamName(), in.Thickness); err != nil {
+			return err
+		}
+	}
+	if in.BendRadius != "" {
+		if err := part.SetSheetMetalLengthParam(compdef.BendRadiusParamName(), in.BendRadius); err != nil {
+			return err
+		}
+	}
+	if err := applyReliefEdits(part, rule, in); err != nil {
+		return err
+	}
+	if in.MinimumGap != "" {
+		gap, err := part.Units().Parse(in.MinimumGap, param.Length)
+		if err != nil {
+			return fmt.Errorf("sheetMetal minimumGap %q: %w", in.MinimumGap, err)
+		}
+		rule.SetGap(sheetmetal.Constant(gap.Value))
+	}
+	return applyUnfoldEdits(rule, in)
+}
+
+// applyReliefEdits updates the relief shape and notch sizes from the non-empty fields.
+func applyReliefEdits(part *compdef.PartComponentDefinition, rule *sheetmetal.Rule, in wire.SetSheetMetalStyleArgs) error {
+	relief := rule.Relief()
+	if in.ReliefShape != "" {
+		shape, ok := types.ParseReliefShape(in.ReliefShape)
+		if !ok {
+			return fmt.Errorf("sheetMetal reliefShape %q: want round|square|tear", in.ReliefShape)
+		}
+		relief.Shape = shape
+	}
+	for _, e := range []struct {
+		expr  string
+		field *func() float64
+	}{{in.ReliefWidth, &relief.Width}, {in.ReliefDepth, &relief.Depth}} {
+		if e.expr == "" {
+			continue
+		}
+		v, err := part.Units().Parse(e.expr, param.Length)
+		if err != nil {
+			return fmt.Errorf("sheetMetal relief size %q: %w", e.expr, err)
+		}
+		*e.field = sheetmetal.Constant(v.Value)
+	}
+	rule.SetRelief(relief)
+	return nil
+}
+
+// applyUnfoldEdits sets the unfold method. F01 wires the K-factor method (the default and
+// most common); a bend-table or equation method carries data the simple style DTO does not,
+// so those are configured by their own surface (M13-F04) and rejected here with a clear note.
+func applyUnfoldEdits(rule *sheetmetal.Rule, in wire.SetSheetMetalStyleArgs) error {
+	method := in.UnfoldMethod
+	if method == "" && in.KFactor == 0 {
+		return nil
+	}
+	if method != "" && method != types.KFactorUnfold.String() {
+		return fmt.Errorf("sheetMetal unfoldMethod %q: only %q is settable via setStyle (bend-table/equation are configured separately)", method, types.KFactorUnfold)
+	}
+	k := in.KFactor
+	if k == 0 {
+		k = rule.Unfold().KFactor // keep the current K-factor when only the method was named
+	}
+	rule.SetUnfold(sheetmetal.KFactorMethod(k))
+	return nil
+}
+
+func sheetMetalBendAllowance(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, rule, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.BendAllowanceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	angle, err := part.Units().Parse(in.Angle, param.Angle)
+	if err != nil {
+		return nil, fmt.Errorf("sheetMetal bendAllowance angle %q: %w", in.Angle, err)
+	}
+	radius := 0.0
+	if in.Radius != "" {
+		r, err := part.Units().Parse(in.Radius, param.Length)
+		if err != nil {
+			return nil, fmt.Errorf("sheetMetal bendAllowance radius %q: %w", in.Radius, err)
+		}
+		radius = r.Value
+	}
+	return json.Marshal(wire.BendAllowanceResult{
+		BendAllowance: rule.BendAllowance(angle.Value, radius),
+		BendDeduction: rule.BendDeduction(angle.Value, radius),
+	})
+}
+
+// styleInfo renders the active rule as wire, formatting lengths in the document's units and
+// including the bend allowance of a 90° bend as a convenience preview.
+func styleInfo(part *compdef.PartComponentDefinition, rule *sheetmetal.Rule) wire.SheetMetalStyleInfo {
+	fmtLen := func(v float64) string { return part.Units().Format(param.Q(v, param.Length)) }
+	unfold := rule.Unfold()
+	return wire.SheetMetalStyleInfo{
+		Name:          rule.Name(),
+		Thickness:     fmtLen(rule.Thickness()),
+		BendRadius:    fmtLen(rule.BendRadius()),
+		ReliefShape:   rule.Relief().Shape.String(),
+		ReliefWidth:   fmtLen(rule.ReliefWidth()),
+		ReliefDepth:   fmtLen(rule.ReliefDepth()),
+		MindGap:       fmtLen(rule.Gap()),
+		UnfoldMethod:  unfold.Type.String(),
+		KFactor:       unfold.KFactor,
+		BendAllowance: rule.BendAllowance(halfPi, 0),
+	}
+}
+
+// halfPi is a 90° bend in radians — the angle styleInfo previews the bend allowance at.
+const halfPi = 1.5707963267948966

--- a/addin/router/sheet_metal_test.go
+++ b/addin/router/sheet_metal_test.go
@@ -92,3 +92,54 @@ func TestSheetMetalSetStyleRejectsUnsupportedUnfold(t *testing.T) {
 		t.Fatal("setStyle must reject bendTable (no table payload in the style DTO)")
 	}
 }
+
+// TestSheetMetalSetStyleAllProperties setStyle edits every simple property in one call:
+// bend radius, relief width/depth, minimum gap, and the named K-factor method.
+func TestSheetMetalSetStyleAllProperties(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	var res wire.SheetMetalStyleResult
+	call(t, r, s, wire.MethodSheetMetalSetStyle,
+		`{"bendRadius":"3 mm","reliefShape":"square","reliefWidth":"0.5 mm","reliefDepth":"0.5 mm","minimumGap":"1 mm","unfoldMethod":"kFactor"}`, &res)
+	if res.Style.BendRadius != "3 mm" {
+		t.Errorf("bend radius = %q, want 3 mm", res.Style.BendRadius)
+	}
+	if res.Style.ReliefWidth != "0.5 mm" || res.Style.ReliefDepth != "0.5 mm" {
+		t.Errorf("relief size = %q/%q, want 0.5 mm/0.5 mm", res.Style.ReliefWidth, res.Style.ReliefDepth)
+	}
+	if res.Style.MindGap != "1 mm" {
+		t.Errorf("minimum gap = %q, want 1 mm", res.Style.MindGap)
+	}
+	if res.Style.UnfoldMethod != types.KFactorUnfold.String() {
+		t.Errorf("unfold = %q, want kFactor", res.Style.UnfoldMethod)
+	}
+}
+
+// TestSheetMetalSetStyleRejectsBadExpressions setStyle reports a clear error for an
+// unparseable length and a bad relief shape.
+func TestSheetMetalSetStyleRejectsBadExpressions(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	// reliefShape/minimumGap/reliefWidth go through a hard unit parse, so a bad value errors.
+	// (thickness/bendRadius re-author a parameter, where an unparseable token becomes a sick
+	// parameter rather than a setStyle error — that path is the parameter engine's contract.)
+	for _, bad := range []string{
+		`{"reliefShape":"hexagon"}`,
+		`{"minimumGap":"zzz"}`,
+		`{"reliefWidth":"zzz"}`,
+		`{"reliefDepth":"zzz"}`,
+	} {
+		if _, err := r.Handle(s, wire.MethodSheetMetalSetStyle, []byte(bad)); err == nil {
+			t.Errorf("setStyle(%s) should error", bad)
+		}
+	}
+}
+
+// TestSheetMetalBendAllowanceRejectsBadInput bendAllowance reports a clear error for a bad
+// angle or radius expression.
+func TestSheetMetalBendAllowanceRejectsBadInput(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	for _, bad := range []string{`{"angle":"oops"}`, `{"angle":"90 deg","radius":"oops"}`} {
+		if _, err := r.Handle(s, wire.MethodSheetMetalBendAllowance, []byte(bad)); err == nil {
+			t.Errorf("bendAllowance(%s) should error", bad)
+		}
+	}
+}

--- a/addin/router/sheet_metal_test.go
+++ b/addin/router/sheet_metal_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// newSheetMetalPart creates a sheet-metal part document over the router (the create path
+// that seeds the rule) and makes it active, returning the router + session.
+func newSheetMetalPart(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := seededSession(t)
+	var doc wire.DocumentInfo
+	call(t, r, s, "documents.create", fmt.Sprintf(`{"type":"part","name":"panel.obk","subType":%q}`, string(types.SubTypeSheetMetalPart)), &doc)
+	call(t, r, s, "documents.activate", fmt.Sprintf(`{"id":%d}`, doc.ID), nil)
+	return r, s
+}
+
+// TestSheetMetalGetStyleDefaults a part created with the sheet-metal subtype reports the
+// seeded default rule (1 mm thickness, round relief, K-factor unfold).
+func TestSheetMetalGetStyleDefaults(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	var res wire.SheetMetalStyleResult
+	call(t, r, s, wire.MethodSheetMetalGetStyle, "{}", &res)
+	if res.Style.UnfoldMethod != types.KFactorUnfold.String() {
+		t.Errorf("unfold method = %q, want kFactor", res.Style.UnfoldMethod)
+	}
+	if res.Style.ReliefShape != types.ReliefRound.String() {
+		t.Errorf("relief shape = %q, want round", res.Style.ReliefShape)
+	}
+	if math.Abs(res.Style.KFactor-0.44) > 1e-9 {
+		t.Errorf("K-factor = %v, want 0.44", res.Style.KFactor)
+	}
+}
+
+// TestSheetMetalGetStyleRejectsPlainPart getStyle on a non-sheet-metal part errors.
+func TestSheetMetalGetStyleRejectsPlainPart(t *testing.T) {
+	r, s := seededSession(t) // the seeded part is an ordinary part
+	if _, err := r.Handle(s, wire.MethodSheetMetalGetStyle, []byte("{}")); err == nil {
+		t.Fatal("getStyle on a plain part must error")
+	}
+}
+
+// TestSheetMetalSetStyleEditsRuleAndKFactor setStyle changes thickness and K-factor; the
+// developed bend allowance changes accordingly (the F01 acceptance criterion over the wire).
+func TestSheetMetalSetStyleEditsRuleAndKFactor(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+
+	var before wire.BendAllowanceResult
+	call(t, r, s, wire.MethodSheetMetalBendAllowance, `{"angle":"90 deg","radius":"2 mm"}`, &before)
+
+	var styled wire.SheetMetalStyleResult
+	call(t, r, s, wire.MethodSheetMetalSetStyle, `{"thickness":"2 mm","kFactor":0.5}`, &styled)
+	if math.Abs(styled.Style.KFactor-0.5) > 1e-9 {
+		t.Errorf("K-factor after setStyle = %v, want 0.5", styled.Style.KFactor)
+	}
+
+	var after wire.BendAllowanceResult
+	call(t, r, s, wire.MethodSheetMetalBendAllowance, `{"angle":"90 deg","radius":"2 mm"}`, &after)
+	// BA = angle·(r + K·t); a thicker sheet with a larger K develops a longer flat.
+	if !(after.BendAllowance > before.BendAllowance) {
+		t.Errorf("bend allowance did not grow after thickening: before=%.6f after=%.6f", before.BendAllowance, after.BendAllowance)
+	}
+	wantAfter := (math.Pi / 2) * (0.2 + 0.5*0.2) // r=2mm=0.2cm, t=2mm=0.2cm, K=0.5
+	if math.Abs(after.BendAllowance-wantAfter) > 1e-6 {
+		t.Errorf("bend allowance = %.6f, want %.6f", after.BendAllowance, wantAfter)
+	}
+}
+
+// TestSheetMetalSetStyleRelief setStyle switches the relief shape.
+func TestSheetMetalSetStyleRelief(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	var res wire.SheetMetalStyleResult
+	call(t, r, s, wire.MethodSheetMetalSetStyle, `{"reliefShape":"square"}`, &res)
+	if res.Style.ReliefShape != types.ReliefSquare.String() {
+		t.Errorf("relief shape after setStyle = %q, want square", res.Style.ReliefShape)
+	}
+}
+
+// TestSheetMetalSetStyleRejectsUnsupportedUnfold setStyle rejects a bend-table/equation
+// method (configured by its own surface), naming the value.
+func TestSheetMetalSetStyleRejectsUnsupportedUnfold(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	if _, err := r.Handle(s, wire.MethodSheetMetalSetStyle, []byte(`{"unfoldMethod":"bendTable"}`)); err == nil {
+		t.Fatal("setStyle must reject bendTable (no table payload in the style DTO)")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.5.0
+	oblikovati.org/api v0.6.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.5.0
+	oblikovati.org/api v0.6.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -13,6 +13,7 @@ import (
 	"oblikovati.org/model/identity"
 	"oblikovati.org/model/material"
 	"oblikovati.org/model/param"
+	"oblikovati.org/model/sheetmetal"
 	"oblikovati.org/model/sketch"
 )
 
@@ -48,6 +49,12 @@ type PartComponentDefinition struct {
 	// props are the document's iProperties (metadata sets) — title/author/part number/custom,
 	// which feed BOMs and title blocks (#156).
 	props *attr.PropertySets
+	// sheetMetal is the active sheet-metal rule when this part is in the sheet-metal
+	// environment (M13-F01), else nil. A sheet-metal part is still a PartComponentDefinition
+	// (so every part feature works on it); the rule adds the constant-thickness invariant and
+	// the unfold method that bend/flat-pattern features consult. It is parameter-backed — its
+	// thickness/bend-radius read the part's Thickness/BendRadius parameters.
+	sheetMetal *sheetmetal.Rule
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -47,6 +47,7 @@ type partRecipe struct {
 	Features          []feature.FeatureData        `yaml:"features,omitempty"`
 	Materials         *material.RecipeData         `yaml:"materials,omitempty"`
 	Properties        []propertyRecipe             `yaml:"properties,omitempty"` // document iProperties (#156)
+	SheetMetal        *sheetMetalRecipe            `yaml:"sheetMetal,omitempty"` // sheet-metal rule (M13-F01); nil for ordinary parts
 }
 
 // sketchIndex adapts a part's sketch collection to feature.SketchIndexer so features
@@ -201,6 +202,7 @@ func (d *PartComponentDefinition) MarshalRecipe() ([]byte, error) {
 		Features:          features,
 		Materials:         d.materialsRecipe(),
 		Properties:        propertiesRecipeOf(d.props),
+		SheetMetal:        d.sheetMetalRecipeOf(),
 	}
 	if d.eop != endOfPartAtEnd {
 		eop := d.eop
@@ -239,6 +241,7 @@ func (d *PartComponentDefinition) resetRecipe() {
 	d.assets = material.NewAssetSet()
 	d.bodies = topo.NewSurfaceBodies()
 	d.props = attr.NewPropertySets()
+	d.sheetMetal = nil // re-derived from the recipe's sheetMetal section on restore
 }
 
 // ApplyRecipe restores the part from recipe YAML and recomputes (doc.RecipeContent).
@@ -280,6 +283,9 @@ func (d *PartComponentDefinition) ApplyRecipe(model []byte) error {
 		if err := material.ApplyRecipe(*r.Materials, d.assets, d.assignments); err != nil {
 			return fmt.Errorf("compdef: restore materials: %w", err)
 		}
+	}
+	if err := d.applySheetMetalRecipe(r.SheetMetal); err != nil {
+		return fmt.Errorf("compdef: restore sheet-metal rule: %w", err)
 	}
 	if r.EndOfPart != nil {
 		d.SetEndOfPart(*r.EndOfPart)

--- a/model/compdef/sheet_metal.go
+++ b/model/compdef/sheet_metal.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// Sheet-metal environment attachment (M13-F01). A sheet-metal part is a normal part whose
+// content carries a [sheetmetal.Rule] and exposes the Thickness/BendRadius parameters the
+// rule reads, so a parameter edit repropagates to every wall and bend.
+
+// Default sheet-metal rule seed (database units, cm): 1 mm material, 1 mm inside bend radius
+// — a common light-gauge starting point the user then restyles.
+const (
+	defaultSheetThickness  = 0.1 // cm (1 mm)
+	defaultSheetBendRadius = 0.1 // cm (1 mm)
+)
+
+// thicknessParamName and bendRadiusParamName are the well-known parameter names the rule
+// binds to; they appear in the parameter table so the user can drive them by expression.
+const (
+	thicknessParamName  = "Thickness"
+	bendRadiusParamName = "BendRadius"
+)
+
+// IsSheetMetal reports whether this part is in the sheet-metal environment.
+func (d *PartComponentDefinition) IsSheetMetal() bool { return d.sheetMetal != nil }
+
+// SheetMetal returns the active sheet-metal rule, or nil when the part is not sheet metal.
+func (d *PartComponentDefinition) SheetMetal() *sheetmetal.Rule { return d.sheetMetal }
+
+// EnableSheetMetal puts the part into the sheet-metal environment with a default rule,
+// creating the Thickness and BendRadius parameters that back it (idempotent: a part already
+// in the environment keeps its rule). The rule's length closures read those parameters, so
+// editing Thickness recomputes every dependent wall through the normal feature engine.
+func (d *PartComponentDefinition) EnableSheetMetal() (*sheetmetal.Rule, error) {
+	if d.sheetMetal != nil {
+		return d.sheetMetal, nil
+	}
+	thickness, err := d.ensureLengthParam(thicknessParamName, defaultSheetThickness)
+	if err != nil {
+		return nil, err
+	}
+	bendRadius, err := d.ensureLengthParam(bendRadiusParamName, defaultSheetBendRadius)
+	if err != nil {
+		return nil, err
+	}
+	relief := sheetmetal.Relief{
+		Shape: types.ReliefRound,
+		Width: sheetmetal.Constant(0.5 * thickness.ModelValue()),
+		Depth: sheetmetal.Constant(0.5 * thickness.ModelValue()),
+	}
+	d.sheetMetal = sheetmetal.NewRule(
+		"Default",
+		func() float64 { return thickness.ModelValue() },
+		func() float64 { return bendRadius.ModelValue() },
+		sheetmetal.Constant(0),
+		relief,
+		sheetmetal.KFactorMethod(0.44),
+	)
+	return d.sheetMetal, nil
+}
+
+// SetSheetMetalLengthParam re-authors one of the rule's backing length parameters
+// (Thickness or BendRadius) from a unit expression, keeping the rule parameter-backed. The
+// caller recomputes afterwards.
+func (d *PartComponentDefinition) SetSheetMetalLengthParam(name, expr string) error {
+	p, ok := d.params.ByName(name)
+	if !ok {
+		return fmt.Errorf("sheet-metal: no %q parameter on this part", name)
+	}
+	if err := d.params.SetExpression(p.ID(), expr); err != nil {
+		return fmt.Errorf("sheet-metal %s = %q: %w", name, expr, err)
+	}
+	return nil
+}
+
+// ThicknessParamName and BendRadiusParamName expose the well-known parameter names so the
+// router can address them in setStyle.
+func ThicknessParamName() string  { return thicknessParamName }
+func BendRadiusParamName() string { return bendRadiusParamName }
+
+// sheetMetalRecipe is the persisted form of the rule: the parameter-backed lengths
+// (thickness/bend-radius) round-trip as ordinary parameters, so the recipe carries only the
+// rule's own state — its name, relief geometry, gap, and the full unfold method (K-factor,
+// equation source, or bend-table rows).
+type sheetMetalRecipe struct {
+	Name         string               `yaml:"name,omitempty"`
+	ReliefShape  string               `yaml:"reliefShape,omitempty"`
+	ReliefWidth  float64              `yaml:"reliefWidth,omitempty"`
+	ReliefDepth  float64              `yaml:"reliefDepth,omitempty"`
+	Gap          float64              `yaml:"gap,omitempty"`
+	UnfoldMethod string               `yaml:"unfoldMethod,omitempty"`
+	KFactor      float64              `yaml:"kFactor,omitempty"`
+	Equation     string               `yaml:"equation,omitempty"`
+	BendTable    []bendTableRowRecipe `yaml:"bendTable,omitempty"`
+}
+
+// bendTableRowRecipe is one persisted bend-table sample (database units, cm; angle radians).
+type bendTableRowRecipe struct {
+	Angle     float64 `yaml:"angle"`
+	Radius    float64 `yaml:"radius"`
+	Thickness float64 `yaml:"thickness"`
+	Allowance float64 `yaml:"allowance"`
+}
+
+// sheetMetalRecipeOf captures the active rule, or nil when the part is not sheet metal.
+func (d *PartComponentDefinition) sheetMetalRecipeOf() *sheetMetalRecipe {
+	if d.sheetMetal == nil {
+		return nil
+	}
+	r := d.sheetMetal
+	rec := &sheetMetalRecipe{
+		Name:         r.Name(),
+		ReliefShape:  r.Relief().Shape.String(),
+		ReliefWidth:  r.ReliefWidth(),
+		ReliefDepth:  r.ReliefDepth(),
+		Gap:          r.Gap(),
+		UnfoldMethod: r.Unfold().Type.String(),
+		KFactor:      r.Unfold().KFactor,
+		Equation:     r.Unfold().EquationSource(),
+	}
+	if t := r.Unfold().Table; t != nil {
+		for _, row := range t.Rows() {
+			rec.BendTable = append(rec.BendTable, bendTableRowRecipe{row.Angle, row.Radius, row.Thickness, row.Allowance})
+		}
+	}
+	return rec
+}
+
+// applySheetMetalRecipe rebuilds the rule from rec, binding its thickness/bend-radius to the
+// already-restored Thickness/BendRadius parameters. Called after parameters are applied.
+func (d *PartComponentDefinition) applySheetMetalRecipe(rec *sheetMetalRecipe) error {
+	if rec == nil {
+		return nil
+	}
+	rule, err := d.EnableSheetMetal() // creates/reuses the backing parameters, seeds defaults
+	if err != nil {
+		return err
+	}
+	rule.SetName(rec.Name)
+	if err := d.restoreReliefAndGap(rule, rec); err != nil {
+		return err
+	}
+	unfold, err := unfoldFromRecipe(rec)
+	if err != nil {
+		return err
+	}
+	rule.SetUnfold(unfold)
+	return nil
+}
+
+// restoreReliefAndGap applies the persisted relief shape/size and gap onto the rule.
+func (d *PartComponentDefinition) restoreReliefAndGap(rule *sheetmetal.Rule, rec *sheetMetalRecipe) error {
+	shape := types.ReliefRound
+	if rec.ReliefShape != "" {
+		s, ok := types.ParseReliefShape(rec.ReliefShape)
+		if !ok {
+			return fmt.Errorf("sheet-metal recipe: bad relief shape %q", rec.ReliefShape)
+		}
+		shape = s
+	}
+	rule.SetRelief(sheetmetal.Relief{
+		Shape: shape,
+		Width: sheetmetal.Constant(rec.ReliefWidth),
+		Depth: sheetmetal.Constant(rec.ReliefDepth),
+	})
+	rule.SetGap(sheetmetal.Constant(rec.Gap))
+	return nil
+}
+
+// unfoldFromRecipe reconstructs the unfold method (K-factor / bend-table / equation).
+func unfoldFromRecipe(rec *sheetMetalRecipe) (sheetmetal.UnfoldMethod, error) {
+	method, ok := types.ParseUnfoldMethodType(rec.UnfoldMethod)
+	if !ok && rec.UnfoldMethod != "" {
+		return sheetmetal.UnfoldMethod{}, fmt.Errorf("sheet-metal recipe: bad unfold method %q", rec.UnfoldMethod)
+	}
+	switch method {
+	case types.BendTableUnfold:
+		rows := make([]sheetmetal.BendTableRow, len(rec.BendTable))
+		for i, r := range rec.BendTable {
+			rows[i] = sheetmetal.BendTableRow{Angle: r.Angle, Radius: r.Radius, Thickness: r.Thickness, Allowance: r.Allowance}
+		}
+		return sheetmetal.BendTableMethod(sheetmetal.NewBendTable(rows)), nil
+	case types.EquationUnfold:
+		return sheetmetal.EquationMethod(rec.Equation)
+	default:
+		return sheetmetal.KFactorMethod(rec.KFactor), nil
+	}
+}
+
+// ensureLengthParam returns the named length parameter, creating it from a default value
+// (in database units) when absent — so re-enabling or restoring a sheet-metal part reuses
+// the existing parameter rather than failing on a duplicate name.
+func (d *PartComponentDefinition) ensureLengthParam(name string, defaultValue float64) (*param.Parameter, error) {
+	if p, ok := d.params.ByName(name); ok {
+		return p, nil
+	}
+	expr := d.units.Format(param.Q(defaultValue, param.Length))
+	p, err := d.params.AddUserParameter(name, expr)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal %s parameter (%q): %w", name, expr, err)
+	}
+	return p, nil
+}

--- a/model/compdef/sheet_metal_test.go
+++ b/model/compdef/sheet_metal_test.go
@@ -104,3 +104,30 @@ func TestSheetMetalRecipeRoundTrips(t *testing.T) {
 		t.Errorf("restored bend allowance = %v, want %v", g, want)
 	}
 }
+
+// TestSheetMetalBendTableRecipeRoundTrips a bend-table unfold method (its measured rows)
+// survives marshal/restore and develops the same length.
+func TestSheetMetalBendTableRecipeRoundTrips(t *testing.T) {
+	src := NewPartComponentDefinition()
+	rule, _ := src.EnableSheetMetal()
+	table := sheetmetal.NewBendTable([]sheetmetal.BendTableRow{
+		{Angle: math.Pi / 2, Radius: 0.1, Thickness: 0.1, Allowance: 0.31},
+	})
+	rule.SetUnfold(sheetmetal.BendTableMethod(table))
+
+	blob, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dst := NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(blob); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got := dst.SheetMetal()
+	if got == nil || got.Unfold().Type != types.BendTableUnfold {
+		t.Fatalf("restored unfold = %v, want bendTable", got)
+	}
+	if ba := got.BendAllowance(math.Pi/2, 0.1); math.Abs(ba-0.31) > 1e-9 {
+		t.Errorf("restored table allowance = %v, want 0.31", ba)
+	}
+}

--- a/model/compdef/sheet_metal_test.go
+++ b/model/compdef/sheet_metal_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// TestEnableSheetMetalSeedsRule a fresh part enters the environment with a default rule and
+// the backing Thickness/BendRadius parameters.
+func TestEnableSheetMetalSeedsRule(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if d.IsSheetMetal() {
+		t.Fatal("a fresh part must not be sheet metal")
+	}
+	rule, err := d.EnableSheetMetal()
+	if err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	if !d.IsSheetMetal() || d.SheetMetal() != rule {
+		t.Fatal("EnableSheetMetal did not attach the rule")
+	}
+	if _, ok := d.Parameters().ByName("Thickness"); !ok {
+		t.Error("Thickness parameter was not created")
+	}
+	if _, ok := d.Parameters().ByName("BendRadius"); !ok {
+		t.Error("BendRadius parameter was not created")
+	}
+	if math.Abs(rule.Thickness()-defaultSheetThickness) > 1e-9 {
+		t.Errorf("default thickness = %v cm, want %v", rule.Thickness(), defaultSheetThickness)
+	}
+}
+
+// TestEnableSheetMetalIdempotent re-enabling keeps the same rule (and does not duplicate
+// the parameters).
+func TestEnableSheetMetalIdempotent(t *testing.T) {
+	d := NewPartComponentDefinition()
+	first, _ := d.EnableSheetMetal()
+	second, err := d.EnableSheetMetal()
+	if err != nil {
+		t.Fatalf("re-EnableSheetMetal: %v", err)
+	}
+	if first != second {
+		t.Error("re-enabling produced a different rule")
+	}
+}
+
+// TestRuleIsParameterBacked editing the Thickness parameter changes the rule's thickness —
+// the core invariant that makes a thickness/K-factor edit repropagate to every wall.
+func TestRuleIsParameterBacked(t *testing.T) {
+	d := NewPartComponentDefinition()
+	rule, _ := d.EnableSheetMetal()
+	if err := d.SetSheetMetalLengthParam("Thickness", "3 mm"); err != nil {
+		t.Fatalf("set Thickness: %v", err)
+	}
+	if got := rule.Thickness(); math.Abs(got-0.3) > 1e-9 { // 3 mm = 0.3 cm
+		t.Errorf("rule.Thickness() after edit = %v cm, want 0.3", got)
+	}
+}
+
+// TestSheetMetalRecipeRoundTrips a sheet-metal part with an edited rule (thickness, relief,
+// equation unfold) survives a marshal/restore: the part is still sheet metal and the rule
+// matches.
+func TestSheetMetalRecipeRoundTrips(t *testing.T) {
+	src := NewPartComponentDefinition()
+	rule, _ := src.EnableSheetMetal()
+	_ = src.SetSheetMetalLengthParam("Thickness", "2 mm")
+	rule.SetRelief(sheetmetal.Relief{Shape: types.ReliefSquare, Width: sheetmetal.Constant(0.05), Depth: sheetmetal.Constant(0.07)})
+	eq, err := sheetmetal.EquationMethod("a * (r + 0.4 * t)")
+	if err != nil {
+		t.Fatalf("equation: %v", err)
+	}
+	rule.SetUnfold(eq)
+
+	blob, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	dst := NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(blob); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got := dst.SheetMetal()
+	if got == nil {
+		t.Fatal("restored part is not sheet metal")
+	}
+	if math.Abs(got.Thickness()-0.2) > 1e-9 {
+		t.Errorf("restored thickness = %v cm, want 0.2", got.Thickness())
+	}
+	if got.Relief().Shape != types.ReliefSquare {
+		t.Errorf("restored relief shape = %v, want square", got.Relief().Shape)
+	}
+	if got.Unfold().Type != types.EquationUnfold {
+		t.Errorf("restored unfold type = %v, want equation", got.Unfold().Type)
+	}
+	// The restored equation must compute the same allowance as the original.
+	want := rule.BendAllowance(math.Pi/2, 0.2)
+	if g := got.BendAllowance(math.Pi/2, 0.2); math.Abs(g-want) > 1e-9 {
+		t.Errorf("restored bend allowance = %v, want %v", g, want)
+	}
+}

--- a/model/sheetmetal/bend_table.go
+++ b/model/sheetmetal/bend_table.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import "sort"
+
+// BendTable is a measured bend-allowance table: rows of (angle, radius, thickness →
+// allowance) captured from shop tests for a material. Lookups select the rows whose radius
+// and thickness match (within tolerance), then linearly interpolate the allowance by bend
+// angle; outside the sampled angle range the nearest row's value is held. This is the
+// honest minimum — a single material/gauge characterised across angles — and is the input
+// most bend tables actually carry; multi-gauge tables stack independent BendTables.
+type BendTable struct {
+	rows []BendTableRow
+}
+
+// BendTableRow is one measured sample: at this bend angle (radians), inside radius and
+// material thickness (database units, cm), the developed neutral-axis length is Allowance.
+type BendTableRow struct {
+	Angle     float64
+	Radius    float64
+	Thickness float64
+	Allowance float64
+}
+
+// matchTol is the radius/thickness match tolerance (cm) — 1 µm, tight enough that distinct
+// gauges never alias yet loose enough to absorb floating-point noise in stored geometry.
+const matchTol = 1e-4
+
+// NewBendTable returns a table over the given rows (copied, then sorted by angle so lookups
+// can binary-search and interpolate).
+func NewBendTable(rows []BendTableRow) *BendTable {
+	cp := append([]BendTableRow(nil), rows...)
+	sort.Slice(cp, func(i, j int) bool { return cp[i].Angle < cp[j].Angle })
+	return &BendTable{rows: cp}
+}
+
+// Rows returns the table's sample rows (sorted by angle).
+func (t *BendTable) Rows() []BendTableRow { return t.rows }
+
+// BendAllowance returns the interpolated allowance for a bend at angle/radius/thickness, or
+// ok=false when no row matches the radius+thickness so the caller falls back to K-factor.
+func (t *BendTable) BendAllowance(angle, radius, thickness float64) (float64, bool) {
+	matches := t.rowsMatching(radius, thickness)
+	if len(matches) == 0 {
+		return 0, false
+	}
+	return interpolateByAngle(matches, angle), true
+}
+
+// rowsMatching returns the rows whose radius and thickness equal the query within matchTol.
+func (t *BendTable) rowsMatching(radius, thickness float64) []BendTableRow {
+	var out []BendTableRow
+	for _, r := range t.rows {
+		if abs(r.Radius-radius) <= matchTol && abs(r.Thickness-thickness) <= matchTol {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// interpolateByAngle linearly interpolates the allowance at angle across angle-sorted rows,
+// holding the end value outside the sampled range. rows is non-empty and sorted by angle.
+func interpolateByAngle(rows []BendTableRow, angle float64) float64 {
+	if angle <= rows[0].Angle {
+		return rows[0].Allowance
+	}
+	last := rows[len(rows)-1]
+	if angle >= last.Angle {
+		return last.Allowance
+	}
+	for i := 1; i < len(rows); i++ {
+		hi := rows[i]
+		if angle <= hi.Angle {
+			lo := rows[i-1]
+			span := hi.Angle - lo.Angle
+			if span == 0 {
+				return lo.Allowance
+			}
+			f := (angle - lo.Angle) / span
+			return lo.Allowance + f*(hi.Allowance-lo.Allowance)
+		}
+	}
+	return last.Allowance
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/model/sheetmetal/rule.go
+++ b/model/sheetmetal/rule.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import "oblikovati.org/api/types"
+
+// Relief geometry default sizes, as multiples of thickness — the standard starting point a
+// rule uses until the user overrides them.
+const (
+	defaultReliefWidthFactor = 0.5 // relief notch width = 0.5·thickness
+	defaultReliefDepthFactor = 0.5 // relief notch depth = 0.5·thickness
+	defaultGapFactor         = 0.0 // corner gap (0 = closed) until set
+)
+
+// Relief describes the cut placed at the ends of a bend so the adjacent web folds without
+// tearing: its shape plus the notch width and depth (parameter-backed lengths in database
+// units, cm).
+type Relief struct {
+	Shape ReliefShape
+	Width func() float64
+	Depth func() float64
+}
+
+// Rule is the active sheet-metal style: the constant material thickness, the default bend
+// radius, the relief geometry, the corner gap, and the unfold method that develops bends
+// into the flat pattern. Every length is a closure so the rule stays parameter-backed —
+// editing the part's Thickness parameter repropagates to every wall and bend through the
+// normal feature engine.
+type Rule struct {
+	name       string
+	thickness  func() float64
+	bendRadius func() float64
+	gap        func() float64
+	relief     Relief
+	unfold     UnfoldMethod
+}
+
+// NewRule builds a rule from parameter-backed closures. The caller (the compdef layer)
+// supplies closures that read the part's named parameters; tests pass constant closures.
+func NewRule(name string, thickness, bendRadius, gap func() float64, relief Relief, unfold UnfoldMethod) *Rule {
+	return &Rule{name: name, thickness: thickness, bendRadius: bendRadius, gap: gap, relief: relief, unfold: unfold}
+}
+
+// Constant returns a closure that always reports v — for tests and constant defaults.
+func Constant(v float64) func() float64 { return func() float64 { return v } }
+
+// DefaultRule returns a rule with constant defaults (thickness/bendRadius supplied, relief
+// at half thickness, round relief, K-factor unfold). Used as the seed when a part enters
+// the sheet-metal environment before the user picks a style.
+func DefaultRule(thickness, bendRadius float64) *Rule {
+	relief := Relief{
+		Shape: types.ReliefRound,
+		Width: Constant(defaultReliefWidthFactor * thickness),
+		Depth: Constant(defaultReliefDepthFactor * thickness),
+	}
+	return NewRule("Default", Constant(thickness), Constant(bendRadius), Constant(defaultGapFactor), relief, KFactorMethod(defaultKFactor))
+}
+
+// Name returns the rule's style name.
+func (r *Rule) Name() string { return r.name }
+
+// SetName renames the rule.
+func (r *Rule) SetName(name string) { r.name = name }
+
+// Thickness returns the material thickness (database units, cm).
+func (r *Rule) Thickness() float64 { return call(r.thickness) }
+
+// BendRadius returns the default inside bend radius (cm).
+func (r *Rule) BendRadius() float64 { return call(r.bendRadius) }
+
+// Gap returns the corner gap (cm).
+func (r *Rule) Gap() float64 { return call(r.gap) }
+
+// Relief returns the rule's relief geometry.
+func (r *Rule) Relief() Relief { return r.relief }
+
+// ReliefWidth and ReliefDepth report the relief notch size (cm).
+func (r *Rule) ReliefWidth() float64 { return call(r.relief.Width) }
+func (r *Rule) ReliefDepth() float64 { return call(r.relief.Depth) }
+
+// Unfold returns the rule's unfold method.
+func (r *Rule) Unfold() UnfoldMethod { return r.unfold }
+
+// SetUnfold replaces the unfold method (e.g. switching from K-factor to a bend table).
+func (r *Rule) SetUnfold(m UnfoldMethod) { r.unfold = m }
+
+// SetThickness/SetBendRadius/SetGap replace a length closure (the compdef layer rebinds
+// these to the edited parameter; tests pass constants).
+func (r *Rule) SetThickness(f func() float64)  { r.thickness = f }
+func (r *Rule) SetBendRadius(f func() float64) { r.bendRadius = f }
+func (r *Rule) SetGap(f func() float64)        { r.gap = f }
+
+// SetRelief replaces the relief geometry.
+func (r *Rule) SetRelief(relief Relief) { r.relief = relief }
+
+// BendAllowance and BendDeduction develop a single bend under this rule's unfold method,
+// defaulting the radius to the rule's bend radius when a non-positive radius is passed.
+func (r *Rule) BendAllowance(angle, radius float64) float64 {
+	return r.unfold.BendAllowance(angle, r.radiusOr(radius), r.Thickness())
+}
+
+func (r *Rule) BendDeduction(angle, radius float64) float64 {
+	return r.unfold.BendDeduction(angle, r.radiusOr(radius), r.Thickness())
+}
+
+func (r *Rule) radiusOr(radius float64) float64 {
+	if radius > 0 {
+		return radius
+	}
+	return r.BendRadius()
+}
+
+// call evaluates a length closure, treating nil as zero so a half-built rule never panics.
+func call(f func() float64) float64 {
+	if f == nil {
+		return 0
+	}
+	return f()
+}

--- a/model/sheetmetal/rule_test.go
+++ b/model/sheetmetal/rule_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// TestDefaultRuleAccessors a default rule reports its seeded thickness/radius/relief and the
+// gentle round relief, and develops a 90° bend via the K-factor method.
+func TestDefaultRuleAccessors(t *testing.T) {
+	r := DefaultRule(0.1, 0.2) // 1 mm thick, 2 mm radius (cm)
+	if r.Name() != "Default" {
+		t.Errorf("name = %q, want Default", r.Name())
+	}
+	if math.Abs(r.Thickness()-0.1) > tol || math.Abs(r.BendRadius()-0.2) > tol {
+		t.Errorf("thickness/radius = %v/%v, want 0.1/0.2", r.Thickness(), r.BendRadius())
+	}
+	if r.Relief().Shape != types.ReliefRound {
+		t.Errorf("relief shape = %v, want round", r.Relief().Shape)
+	}
+	if math.Abs(r.ReliefWidth()-0.05) > tol || math.Abs(r.ReliefDepth()-0.05) > tol {
+		t.Errorf("relief size = %v/%v, want 0.05/0.05", r.ReliefWidth(), r.ReliefDepth())
+	}
+	if r.Gap() != 0 {
+		t.Errorf("default gap = %v, want 0", r.Gap())
+	}
+	if r.Unfold().Type != types.KFactorUnfold {
+		t.Errorf("unfold = %v, want kFactor", r.Unfold().Type)
+	}
+}
+
+// TestRuleSetters every setter replaces its closure/value and the accessor reflects it.
+func TestRuleSetters(t *testing.T) {
+	r := DefaultRule(0.1, 0.1)
+	r.SetName("16ga steel")
+	r.SetThickness(Constant(0.15))
+	r.SetBendRadius(Constant(0.25))
+	r.SetGap(Constant(0.02))
+	r.SetRelief(Relief{Shape: types.ReliefTear, Width: Constant(0.03), Depth: Constant(0.04)})
+	r.SetUnfold(KFactorMethod(0.5))
+
+	if r.Name() != "16ga steel" {
+		t.Errorf("name = %q", r.Name())
+	}
+	if r.Thickness() != 0.15 || r.BendRadius() != 0.25 || r.Gap() != 0.02 {
+		t.Errorf("setters: t/r/gap = %v/%v/%v", r.Thickness(), r.BendRadius(), r.Gap())
+	}
+	if r.Relief().Shape != types.ReliefTear || r.ReliefWidth() != 0.03 || r.ReliefDepth() != 0.04 {
+		t.Errorf("relief = %+v", r.Relief())
+	}
+	if r.Unfold().KFactor != 0.5 {
+		t.Errorf("K-factor = %v, want 0.5", r.Unfold().KFactor)
+	}
+}
+
+// TestRuleBendAllowanceDefaultsRadius a non-positive radius falls back to the rule's bend
+// radius, so callers can omit it.
+func TestRuleBendAllowanceDefaultsRadius(t *testing.T) {
+	r := DefaultRule(0.1, 0.2)
+	angle := math.Pi / 2
+	withExplicit := r.BendAllowance(angle, 0.2)
+	withDefault := r.BendAllowance(angle, 0) // 0 ⇒ use rule's 0.2 radius
+	if math.Abs(withExplicit-withDefault) > tol {
+		t.Errorf("defaulted radius gave %v, explicit gave %v", withDefault, withExplicit)
+	}
+	// Deduction is consistent with allowance for the same bend.
+	if bd := r.BendDeduction(angle, 0); math.IsNaN(bd) {
+		t.Error("bend deduction is NaN")
+	}
+}
+
+// TestCallNilClosure a nil length closure reads as zero rather than panicking.
+func TestCallNilClosure(t *testing.T) {
+	r := NewRule("bare", nil, nil, nil, Relief{}, KFactorMethod(0.44))
+	if r.Thickness() != 0 || r.BendRadius() != 0 || r.Gap() != 0 || r.ReliefWidth() != 0 {
+		t.Error("nil closures must read as zero")
+	}
+}
+
+// TestBendTableRowsAndEquationSource the table exposes its sorted rows and the equation
+// method reports its source (persistence reads both).
+func TestBendTableRowsAndEquationSource(t *testing.T) {
+	table := NewBendTable([]BendTableRow{
+		{Angle: 2, Allowance: 0.2}, {Angle: 1, Allowance: 0.1},
+	})
+	rows := table.Rows()
+	if len(rows) != 2 || rows[0].Angle != 1 {
+		t.Errorf("rows not sorted by angle: %+v", rows)
+	}
+	if KFactorMethod(0.44).EquationSource() != "" {
+		t.Error("K-factor method must report no equation source")
+	}
+	eq, _ := EquationMethod("a*r")
+	if eq.EquationSource() != "a*r" {
+		t.Errorf("equation source = %q, want a*r", eq.EquationSource())
+	}
+}
+
+// TestBendTableMatchToleranceBothSigns a row whose radius is below and one above the query
+// both fail to match (exercising the tolerance check in both directions), so the lookup
+// falls back to K-factor.
+func TestBendTableMatchToleranceBothSigns(t *testing.T) {
+	table := NewBendTable([]BendTableRow{
+		{Angle: math.Pi / 2, Radius: 0.05, Thickness: 0.1, Allowance: 1.1}, // radius below query
+		{Angle: math.Pi / 2, Radius: 0.50, Thickness: 0.1, Allowance: 2.2}, // radius above query
+	})
+	if _, ok := table.BendAllowance(math.Pi/2, 0.2, 0.1); ok {
+		t.Error("neither row should match radius 0.2 within tolerance")
+	}
+}

--- a/model/sheetmetal/unfold.go
+++ b/model/sheetmetal/unfold.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package sheetmetal holds the sheet-metal environment's rule model and the unfold
+// math that turns a folded bend into its flat-pattern development (M13-F01). It is
+// pure model/geometry support: no document, no feature engine — the compdef layer
+// attaches a [Rule] to a part and the bend/flat-pattern features (M13-F02/F04)
+// consult the rule's [UnfoldMethod] for each bend's developed length.
+package sheetmetal
+
+import (
+	"fmt"
+	"math"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/param"
+)
+
+// UnfoldMethodType and ReliefShape are the canonical Apache-2.0 enums (ADR-0018); the
+// sheet-metal model aliases them so call sites read `sheetmetal.ReliefRound`.
+type (
+	UnfoldMethodType = types.UnfoldMethodType
+	ReliefShape      = types.ReliefShape
+)
+
+// defaultKFactor is the neutral-axis ratio used when a rule does not specify one — 0.44
+// is the standard mild-steel default (the neutral axis sits a little inside the mid-plane).
+const defaultKFactor = 0.44
+
+// UnfoldMethod governs how a single bend develops into the flat pattern: its bend
+// allowance (the developed neutral-axis arc length the flat must include) and its bend
+// deduction (the setback subtracted from the two outside flange lengths). All three
+// industry methods are supported — a single K-factor, a per-angle bend table, or a custom
+// equation in {thickness, radius, angle}.
+type UnfoldMethod struct {
+	Type     types.UnfoldMethodType
+	KFactor  float64
+	Table    *BendTable        // consulted when Type == BendTableUnfold
+	equation *compiledEquation // consulted when Type == EquationUnfold
+}
+
+// KFactorMethod returns a K-factor unfold method. A non-positive k falls back to the
+// standard default so a half-built rule still develops sensibly.
+func KFactorMethod(k float64) UnfoldMethod {
+	if k <= 0 {
+		k = defaultKFactor
+	}
+	return UnfoldMethod{Type: types.KFactorUnfold, KFactor: k}
+}
+
+// BendTableMethod returns a bend-table unfold method over t.
+func BendTableMethod(t *BendTable) UnfoldMethod {
+	return UnfoldMethod{Type: types.BendTableUnfold, KFactor: defaultKFactor, Table: t}
+}
+
+// EquationMethod compiles a custom bend-allowance equation in the variables `t`
+// (thickness), `r` (radius) and `a` (bend angle, radians). It returns an error naming
+// the offending source if the expression does not parse or references an unknown name.
+func EquationMethod(src string) (UnfoldMethod, error) {
+	eq, err := compileEquation(src)
+	if err != nil {
+		return UnfoldMethod{}, err
+	}
+	return UnfoldMethod{Type: types.EquationUnfold, KFactor: defaultKFactor, equation: eq}, nil
+}
+
+// EquationSource returns the authored bend-allowance equation when the method is an
+// equation method, else "" — used by persistence to round-trip the formula.
+func (m UnfoldMethod) EquationSource() string {
+	if m.equation == nil {
+		return ""
+	}
+	return m.equation.src
+}
+
+// kFactor returns the method's K-factor, defaulting when unset.
+func (m UnfoldMethod) kFactor() float64 {
+	if m.KFactor <= 0 {
+		return defaultKFactor
+	}
+	return m.KFactor
+}
+
+// BendAllowance returns the developed flat length contributed by one bend. angle is the
+// swept bend angle in radians (90° flange ⇒ π/2), radius the inside bend radius, thickness
+// the material thickness; all lengths in database units (cm). The K-factor relation
+// BA = angle·(radius + K·thickness) is the fallback for every method, so an empty table or
+// equation still yields a physically sensible length rather than zero.
+func (m UnfoldMethod) BendAllowance(angle, radius, thickness float64) float64 {
+	switch m.Type {
+	case types.BendTableUnfold:
+		if m.Table != nil {
+			if ba, ok := m.Table.BendAllowance(angle, radius, thickness); ok {
+				return ba
+			}
+		}
+	case types.EquationUnfold:
+		if m.equation != nil {
+			if ba, ok := m.equation.eval(thickness, radius, angle); ok {
+				return ba
+			}
+		}
+	}
+	return angle * (radius + m.kFactor()*thickness)
+}
+
+// BendDeduction returns the bend deduction (setback) for one bend: the amount by which the
+// sum of the two outside flange lengths overshoots the developed length, so a flat built
+// from outside dimensions subtracts one deduction per bend. BD = 2·OSSB − BA, where the
+// outside setback OSSB = (radius + thickness)·tan(angle/2).
+func (m UnfoldMethod) BendDeduction(angle, radius, thickness float64) float64 {
+	ossb := (radius + thickness) * math.Tan(angle/2)
+	return 2*ossb - m.BendAllowance(angle, radius, thickness)
+}
+
+// compiledEquation is a parsed bend-allowance equation bound to the three synthetic
+// variables t/r/a, ready to evaluate per bend.
+type compiledEquation struct {
+	src  string
+	expr param.Expr
+}
+
+// equation variable ids — synthetic, local to the equation scope (not real parameters).
+const (
+	eqThicknessID param.ID = 1
+	eqRadiusID    param.ID = 2
+	eqAngleID     param.ID = 3
+)
+
+// eqScope binds {t, r, a} for one bend's evaluation. The variables are exposed as unitless
+// scalars (their numeric value in database units — cm for lengths, radians for the angle):
+// a bend-allowance formula is raw arithmetic, so passing them dimensionless sidesteps the
+// param engine's dimensional checks (which would reject e.g. angle·length) while keeping the
+// numeric result correct.
+type eqScope struct{ thickness, radius, angle float64 }
+
+func (s eqScope) ValueOf(id param.ID) (param.Quantity, bool) {
+	switch id {
+	case eqThicknessID:
+		return param.Scalar(s.thickness), true
+	case eqRadiusID:
+		return param.Scalar(s.radius), true
+	case eqAngleID:
+		return param.Scalar(s.angle), true
+	}
+	return param.Quantity{}, false
+}
+
+// compileEquation parses src and binds its t/r/a references; any other name is rejected so
+// a typo fails loudly at rule-set time, not silently at unfold time.
+func compileEquation(src string) (*compiledEquation, error) {
+	expr, err := param.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal unfold equation %q: %w", src, err)
+	}
+	unresolved := expr.Bind(func(name string) (param.ID, bool) {
+		switch name {
+		case "t", "thickness":
+			return eqThicknessID, true
+		case "r", "radius":
+			return eqRadiusID, true
+		case "a", "angle":
+			return eqAngleID, true
+		}
+		return 0, false
+	})
+	if len(unresolved) != 0 {
+		return nil, fmt.Errorf("sheet-metal unfold equation %q: unknown variable(s) %v (use t, r, a)", src, unresolved)
+	}
+	return &compiledEquation{src: src, expr: expr}, nil
+}
+
+// eval returns the equation's value for one bend, or ok=false if evaluation fails (a
+// dimensional mismatch in the authored formula), letting the caller fall back to K-factor.
+func (e *compiledEquation) eval(thickness, radius, angle float64) (float64, bool) {
+	q, err := e.expr.Eval(eqScope{thickness, radius, angle})
+	if err != nil {
+		return 0, false
+	}
+	return q.Value, true
+}

--- a/model/sheetmetal/unfold_test.go
+++ b/model/sheetmetal/unfold_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+const tol = 1e-9
+
+// TestKFactorBendAllowance pins the canonical K-factor relation BA = angle·(r + K·t) for a
+// 90° bend, and that bend deduction BD = 2·OSSB − BA with OSSB = (r+t)·tan(45°) = r+t.
+func TestKFactorBendAllowance(t *testing.T) {
+	m := KFactorMethod(0.44)
+	const r, th = 0.2, 0.1 // cm
+	angle := math.Pi / 2
+
+	wantBA := angle * (r + 0.44*th)
+	if got := m.BendAllowance(angle, r, th); math.Abs(got-wantBA) > tol {
+		t.Errorf("BendAllowance(90°) = %.9f, want %.9f", got, wantBA)
+	}
+	wantBD := 2*(r+th) - wantBA // tan(45°)=1
+	if got := m.BendDeduction(angle, r, th); math.Abs(got-wantBD) > tol {
+		t.Errorf("BendDeduction(90°) = %.9f, want %.9f", got, wantBD)
+	}
+}
+
+// TestKFactorChangesFlatExtents is the F01 acceptance criterion: changing K-factor changes
+// the developed length. A larger K pushes the neutral axis outward, lengthening the flat.
+func TestKFactorChangesFlatExtents(t *testing.T) {
+	const r, th = 0.2, 0.1
+	angle := math.Pi / 2
+	lo := KFactorMethod(0.33).BendAllowance(angle, r, th)
+	hi := KFactorMethod(0.50).BendAllowance(angle, r, th)
+	if !(hi > lo) {
+		t.Errorf("higher K-factor must lengthen the flat: K=0.50 gave %.6f, K=0.33 gave %.6f", hi, lo)
+	}
+	delta := angle * (0.50 - 0.33) * th
+	if math.Abs((hi-lo)-delta) > tol {
+		t.Errorf("flat-length delta = %.9f, want %.9f", hi-lo, delta)
+	}
+}
+
+// TestKFactorMethodDefaults a non-positive K-factor falls back to the standard default.
+func TestKFactorMethodDefaults(t *testing.T) {
+	if got := KFactorMethod(0).kFactor(); got != defaultKFactor {
+		t.Errorf("KFactorMethod(0).kFactor() = %v, want default %v", got, defaultKFactor)
+	}
+	if got := KFactorMethod(-1).kFactor(); got != defaultKFactor {
+		t.Errorf("KFactorMethod(-1).kFactor() = %v, want default %v", got, defaultKFactor)
+	}
+}
+
+// TestEquationMethod evaluates a custom bend-allowance equation in t/r/a and confirms it is
+// used over the K-factor fallback.
+func TestEquationMethod(t *testing.T) {
+	// A deliberately distinct equation: BA = a · (r + 0.3·t).
+	m, err := EquationMethod("a * (r + 0.3 * t)")
+	if err != nil {
+		t.Fatalf("EquationMethod: %v", err)
+	}
+	if m.Type != types.EquationUnfold {
+		t.Fatalf("Type = %v, want EquationUnfold", m.Type)
+	}
+	const r, th = 0.2, 0.1
+	angle := math.Pi / 2
+	want := angle * (r + 0.3*th)
+	if got := m.BendAllowance(angle, r, th); math.Abs(got-want) > tol {
+		t.Errorf("equation BendAllowance = %.9f, want %.9f", got, want)
+	}
+}
+
+// TestEquationMethodRejectsUnknownVariable a typo'd variable fails at compile time, naming it.
+func TestEquationMethodRejectsUnknownVariable(t *testing.T) {
+	_, err := EquationMethod("a * (radius + bogus)")
+	if err == nil {
+		t.Fatal("EquationMethod accepted an unknown variable, want error")
+	}
+}
+
+// TestBendTableInterpolation a table characterised at 60° and 90° interpolates linearly at
+// 75° and holds the endpoints outside the sampled range.
+func TestBendTableInterpolation(t *testing.T) {
+	const r, th = 0.2, 0.1
+	table := NewBendTable([]BendTableRow{
+		{Angle: math.Pi / 3, Radius: r, Thickness: th, Allowance: 0.30}, // 60°
+		{Angle: math.Pi / 2, Radius: r, Thickness: th, Allowance: 0.40}, // 90°
+	})
+	m := BendTableMethod(table)
+
+	mid := (math.Pi/3 + math.Pi/2) / 2 // 75°
+	if got := m.BendAllowance(mid, r, th); math.Abs(got-0.35) > 1e-9 {
+		t.Errorf("table allowance at 75° = %.9f, want 0.35 (linear midpoint)", got)
+	}
+	if got := m.BendAllowance(math.Pi/6, r, th); math.Abs(got-0.30) > 1e-9 {
+		t.Errorf("table allowance below range = %.9f, want held 0.30", got)
+	}
+}
+
+// TestBendTableFallsBackWhenNoRowMatches an unmatched radius/thickness reverts to K-factor.
+func TestBendTableFallsBackWhenNoRowMatches(t *testing.T) {
+	table := NewBendTable([]BendTableRow{{Angle: math.Pi / 2, Radius: 1.0, Thickness: 1.0, Allowance: 9.9}})
+	m := BendTableMethod(table)
+	angle := math.Pi / 2
+	const r, th = 0.2, 0.1
+	want := angle * (r + defaultKFactor*th) // K-factor fallback
+	if got := m.BendAllowance(angle, r, th); math.Abs(got-want) > tol {
+		t.Errorf("unmatched table row = %.9f, want K-factor fallback %.9f", got, want)
+	}
+}


### PR DESCRIPTION
## What

The foundation of M13 (Sheet Metal): a part can enter the **sheet-metal environment**, carrying a parameter-backed rule (constant thickness, default bend radius, relief geometry, corner gap) and an **unfold method** that develops bends into the flat pattern. Implements the F01 contract (API PR #120).

- **`model/sheetmetal`** (new) — the rule model + unfold math, pure and self-contained. All three industry unfold methods, implemented and tested:
  - **K-factor**: `BA = angle·(radius + K·thickness)` (the default)
  - **bend table**: measured `(angle,radius,thickness→allowance)` rows, linearly interpolated by angle, endpoints held outside the sampled range
  - **equation**: a custom formula in `{t, r, a}`, compiled via the parameter expression engine, rejecting unknown variables at set-time
  - Bend deduction (setback) follows: `BD = 2·OSSB − BA`
- **`model/compdef`** — a `PartComponentDefinition` gains an optional sheet-metal rule (nil for ordinary parts, so **every existing part feature still works** on a sheet-metal part — no separate content type). `EnableSheetMetal` seeds the rule + the backing `Thickness`/`BendRadius` parameters, so a parameter edit repropagates to every wall. The rule round-trips in the part recipe (all three unfold methods).
- **`addin/router`** — `sheetMetal.getStyle` / `setStyle` / `bendAllowance`; creating a part with the sheet-metal subtype now enters the environment automatically.

## Why

Sheet metal is a part-content flavor + a rule + a derived flat pattern, reusing the existing feature engine (architecture/modeling/05-sheet-metal.md). This PR lands the rule + unfold math that F02–F04 build on. The F01 acceptance — *"the active rule governs feature defaults; changing K-factor changes flat extents"* — is covered by tests at the model, compdef and router (over-the-wire) layers.

## Test
`go test ./model/sheetmetal/ ./model/compdef/ ./addin/router/` green; lint 0 issues; rule persistence round-trips.

Part of M13 #373/#369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)