### PR TITLE
feat(sketch): constrained drag-resolve (#909)

### DIFF
--- a/app/sketch_drag.go
+++ b/app/sketch_drag.go
@@ -12,17 +12,24 @@ import (
 // Direct manipulation of sketch geometry: in the sketch editor a left-drag that starts on an
 // unconstrained entity moves it (and any entities sharing its points) live, following the
 // cursor — Inventor's drag-to-move. Only MoveableFree geometry drags; fixed / fully-dimensioned
-// entities fall through to click-select. Constrained re-solving during the drag is a follow-up
-// (#909); v1 translates the picked free geometry directly, which is the unconstrained case the
-// user works in.
+// entities fall through to click-select. Each frame the dragged entities' points are pinned to
+// their start position plus the cursor delta and the sketch is re-solved (sketch.DragSolve), so
+// the geometry follows the cursor *within its constraints* (#909): a coincident neighbour tracks
+// along, a horizontal line stays horizontal, and a free point lands exactly on the cursor.
 
-// sketchDrag is an in-progress direct drag of one or more sketch entities. lastPt is the cursor
-// position (in sketch coordinates) at the previous frame, so each update applies the incremental
-// delta.
+// dragAnchor is one point being dragged, remembered with its position at the drag's start so the
+// solve can pin it to start+delta absolutely (no per-frame drift).
+type dragAnchor struct {
+	p     *sketch.Point
+	start math.Point2
+}
+
+// sketchDrag is an in-progress direct drag of one or more sketch entities. grabPt is the cursor
+// position (sketch coordinates) where the drag began, so the per-frame delta is absolute.
 type sketchDrag struct {
-	ents   []sketch.Entity
-	lastPt math.Point2
-	active bool
+	anchors []dragAnchor
+	grabPt  math.Point2
+	active  bool
 }
 
 // EntityDragActive reports whether a sketch entity is currently being dragged.
@@ -41,12 +48,29 @@ func (s *Session) BeginEntityDrag(px, py float64) bool {
 	if !ok || s.activeSketch.MoveableClassifier().Of(ent) != types.MoveableFree {
 		return false
 	}
-	start, ok := screenToSketch(s, px, py)
+	grab, ok := screenToSketch(s, px, py)
 	if !ok {
 		return false
 	}
-	s.entityDrag = sketchDrag{ents: s.dragSet(ent), lastPt: start, active: true}
+	s.entityDrag = sketchDrag{anchors: s.dragAnchors(ent), grabPt: grab, active: true}
 	return true
+}
+
+// dragAnchors collects the distinct points to pin while dragging — the defining points of every
+// entity in the drag set (selection or the clicked entity), each captured at its start position.
+func (s *Session) dragAnchors(ent sketch.Entity) []dragAnchor {
+	seen := map[*sketch.Point]bool{}
+	var anchors []dragAnchor
+	for _, e := range s.dragSet(ent) {
+		for _, p := range sketch.DefiningPoints(e) {
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			anchors = append(anchors, dragAnchor{p: p, start: p.Position()})
+		}
+	}
+	return anchors
 }
 
 // dragSet returns the entities a drag of ent should move: the selected sketch entities when ent
@@ -77,9 +101,9 @@ func (s *Session) selectedSketchEntities() []sketch.Entity {
 	return out
 }
 
-// UpdateEntityDrag translates the dragged entities by the cursor delta since the last frame, so
-// the geometry follows the pointer. The sketch overlay rebuilds from the live sketch each frame,
-// so the move is visible immediately.
+// UpdateEntityDrag pins each dragged point to its start position plus the cursor delta and
+// re-solves the sketch, so the geometry follows the pointer while honouring its constraints. The
+// sketch overlay rebuilds from the live sketch each frame, so the move is visible immediately.
 func (s *Session) UpdateEntityDrag(px, py float64) {
 	if !s.entityDrag.active {
 		return
@@ -88,9 +112,12 @@ func (s *Session) UpdateEntityDrag(px, py float64) {
 	if !ok {
 		return
 	}
-	delta := s.entityDrag.lastPt.VectorTo(cur)
-	s.activeSketch.MoveEntities(s.entityDrag.ents, delta)
-	s.entityDrag.lastPt = cur
+	delta := s.entityDrag.grabPt.VectorTo(cur)
+	pins := make([]sketch.PinTarget, len(s.entityDrag.anchors))
+	for i, a := range s.entityDrag.anchors {
+		pins[i] = sketch.PinTarget{P: a.p, Target: a.start.TranslateBy(delta)}
+	}
+	s.activeSketch.DragSolve(pins)
 }
 
 // CommitEntityDrag ends the drag. The geometry was moved live during the drag, so this only

--- a/app/sketch_drag_test.go
+++ b/app/sketch_drag_test.go
@@ -46,6 +46,28 @@ func TestEntityDragMovesFreePoint(t *testing.T) {
 	}
 }
 
+func TestEntityDragResolvesConstraint(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.Grid().SnapToGrid = false
+	a := sk.Points().Add(math.P2(1, 0))
+	b := sk.Points().Add(math.P2(1, 0)) // coincident with a
+	sk.GeometricConstraints().AddCoincident(a, b)
+	centerOnSketchPoint(s, 1) // (1,0) is at screen centre
+
+	if !s.BeginEntityDrag(100, 100) {
+		t.Fatal("did not begin a drag on the constrained point")
+	}
+	s.UpdateEntityDrag(150, 100) // drag right
+	s.CommitEntityDrag()
+
+	if a.Position().X <= 1.0 {
+		t.Errorf("dragged point did not move in +x: %v", a.Position())
+	}
+	if !b.Position().IsEqualTo(a.Position(), 1e-6) {
+		t.Errorf("the coincident point did not follow the drag: a=%v b=%v", a.Position(), b.Position())
+	}
+}
+
 func TestBeginEntityDragRejectsWhenNotDraggable(t *testing.T) {
 	// No active sketch → no drag.
 	plain := NewSession()

--- a/app/sketch_drag_test.go
+++ b/app/sketch_drag_test.go
@@ -68,6 +68,50 @@ func TestEntityDragResolvesConstraint(t *testing.T) {
 	}
 }
 
+func TestEntityDragGuardsAndCancel(t *testing.T) {
+	s, sk := sketchSession(t)
+	s.Grid().SnapToGrid = false
+
+	// A fixed (grounded) point is not MoveableFree → BeginEntityDrag declines it.
+	fixed := sk.Points().Add(math.P2(1, 0))
+	sk.GeometricConstraints().AddFix(fixed)
+	centerOnSketchPoint(s, 1)
+	if s.BeginEntityDrag(100, 100) {
+		t.Error("a fixed point must not begin a drag")
+	}
+
+	// UpdateEntityDrag with no active drag is a no-op (must not panic).
+	s.UpdateEntityDrag(120, 100)
+
+	// Begin on a free point, then cancel → the drag is dropped.
+	sk.Points().Add(math.P2(5, 0))
+	centerOnSketchPoint(s, 5)
+	if !s.BeginEntityDrag(100, 100) {
+		t.Fatal("should begin a drag on the free point")
+	}
+	s.CancelEntityDrag()
+	if s.EntityDragActive() {
+		t.Error("CancelEntityDrag should clear the drag")
+	}
+}
+
+// TestDragAnchorsDedupesSharedPoints checks that dragging a selection of two lines that share an
+// endpoint pins that shared point once (the de-dup branch of dragAnchors).
+func TestDragAnchorsDedupesSharedPoints(t *testing.T) {
+	s, sk := sketchSession(t)
+	shared := sk.Points().Add(math.P2(0, 0))
+	l1 := sk.Lines().Add(shared, sk.Points().Add(math.P2(2, 0)))
+	l2 := sk.Lines().Add(shared, sk.Points().Add(math.P2(0, 2)))
+	s.Selection().Add(SketchEntityHandle{Entity: l1})
+	s.Selection().Add(SketchEntityHandle{Entity: l2})
+
+	anchors := s.dragAnchors(l1) // l1 is selected → drag the whole selection
+	// l1 (shared, p2) + l2 (shared, p3) → shared counted once → 3 distinct points.
+	if len(anchors) != 3 {
+		t.Errorf("dragAnchors over two lines sharing a point = %d anchors, want 3 (de-duplicated)", len(anchors))
+	}
+}
+
 func TestBeginEntityDragRejectsWhenNotDraggable(t *testing.T) {
 	// No active sketch → no drag.
 	plain := NewSession()

--- a/model/sketch/drag.go
+++ b/model/sketch/drag.go
@@ -35,24 +35,25 @@ func (s *Sketch) DragSolve(pins []PinTarget) SolveResult {
 	return Solve(cons, s.variables(), Options{})
 }
 
+// pointDefined is an entity that can name its constrainable points (each entity declares its own
+// so DefiningPoints needs no type switch — which would duplicate entityFreedomVars in
+// moveable_status.go). The method is unexported, sealing the set to this package's entities.
+type pointDefined interface{ definingPoints() []*Point }
+
+func (p *Point) definingPoints() []*Point         { return []*Point{p} }
+func (l *Line) definingPoints() []*Point          { return []*Point{l.A, l.B} }
+func (c *Circle) definingPoints() []*Point        { return []*Point{c.Center} }
+func (a *Arc) definingPoints() []*Point           { return []*Point{a.Center, a.Start, a.End} }
+func (e *Ellipse) definingPoints() []*Point       { return []*Point{e.Center} }
+func (e *EllipticalArc) definingPoints() []*Point { return []*Point{e.Center} }
+
 // DefiningPoints returns the entity's constrainable points — the handles a drag pins. Dragging a
 // single point pins just it; dragging a whole curve pins all its points so it translates rigidly
-// (the solver then re-satisfies the constraints touching them).
+// (the solver then re-satisfies the constraints touching them). Entities without points (text,
+// images) and nil return none.
 func DefiningPoints(e Entity) []*Point {
-	switch t := e.(type) {
-	case *Point:
-		return []*Point{t}
-	case *Line:
-		return []*Point{t.A, t.B}
-	case *Circle:
-		return []*Point{t.Center}
-	case *Arc:
-		return []*Point{t.Center, t.Start, t.End}
-	case *Ellipse:
-		return []*Point{t.Center}
-	case *EllipticalArc:
-		return []*Point{t.Center}
-	default:
-		return nil
+	if d, ok := e.(pointDefined); ok {
+		return d.definingPoints()
 	}
+	return nil
 }

--- a/model/sketch/drag.go
+++ b/model/sketch/drag.go
@@ -16,16 +16,12 @@ type PinTarget struct {
 	Target math.Point2
 }
 
-// dragPin is a temporary constraint that pulls point P toward (tx,ty). It is appended to the
-// constraint set only for the duration of one DragSolve and is never persisted on the sketch.
-type dragPin struct {
-	constraintBase
-	P      *Point
-	tx, ty math.Scalar
+// dragFix is a temporary pin pulling point p toward target. It reuses FixConstraint (a fix to a
+// position) rather than re-declaring its residual/variable math; it is appended only for the
+// duration of one DragSolve and is never added to the sketch's persisted constraints.
+func dragFix(p *Point, target math.Point2) *FixConstraint {
+	return &FixConstraint{constraintBase: newConstraint(), P: p, x0: target.X, y0: target.Y}
 }
-
-func (c *dragPin) Residuals() []float64      { return []float64{c.P.X - c.tx, c.P.Y - c.ty} }
-func (c *dragPin) Variables() []*math.Scalar { return []*math.Scalar{&c.P.X, &c.P.Y} }
 
 // DragSolve re-solves the sketch with the given points temporarily pinned to their drag targets.
 // The dragged points follow the cursor while the existing constraints pull the dependent geometry
@@ -34,7 +30,7 @@ func (c *dragPin) Variables() []*math.Scalar { return []*math.Scalar{&c.P.X, &c.
 func (s *Sketch) DragSolve(pins []PinTarget) SolveResult {
 	cons := append([]Constraint(nil), s.Constraints()...)
 	for _, pt := range pins {
-		cons = append(cons, &dragPin{constraintBase: newConstraint(), P: pt.P, tx: pt.Target.X, ty: pt.Target.Y})
+		cons = append(cons, dragFix(pt.P, pt.Target))
 	}
 	return Solve(cons, s.variables(), Options{})
 }

--- a/model/sketch/drag.go
+++ b/model/sketch/drag.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// Interactive drag-resolve: dragging a sketch entity should not blindly translate its points
+// (which breaks any constraint touching them) but re-solve the sketch with the dragged points
+// pinned to the cursor target, so the dependent geometry follows within the remaining degrees of
+// freedom — Inventor's behaviour. This is the constrained counterpart to MoveEntities; the free
+// (unconstrained) case falls out of it automatically (a lone pin just moves the point).
+
+// PinTarget pairs a sketch point with the position a drag wants it at.
+type PinTarget struct {
+	P      *Point
+	Target math.Point2
+}
+
+// dragPin is a temporary constraint that pulls point P toward (tx,ty). It is appended to the
+// constraint set only for the duration of one DragSolve and is never persisted on the sketch.
+type dragPin struct {
+	constraintBase
+	P      *Point
+	tx, ty math.Scalar
+}
+
+func (c *dragPin) Residuals() []float64      { return []float64{c.P.X - c.tx, c.P.Y - c.ty} }
+func (c *dragPin) Variables() []*math.Scalar { return []*math.Scalar{&c.P.X, &c.P.Y} }
+
+// DragSolve re-solves the sketch with the given points temporarily pinned to their drag targets.
+// The dragged points follow the cursor while the existing constraints pull the dependent geometry
+// along (and hold the pinned points back along any directions they are constrained in). The pins
+// are not persisted; geometry is left in the solved configuration. Returns the solve result.
+func (s *Sketch) DragSolve(pins []PinTarget) SolveResult {
+	cons := append([]Constraint(nil), s.Constraints()...)
+	for _, pt := range pins {
+		cons = append(cons, &dragPin{constraintBase: newConstraint(), P: pt.P, tx: pt.Target.X, ty: pt.Target.Y})
+	}
+	return Solve(cons, s.variables(), Options{})
+}
+
+// DefiningPoints returns the entity's constrainable points — the handles a drag pins. Dragging a
+// single point pins just it; dragging a whole curve pins all its points so it translates rigidly
+// (the solver then re-satisfies the constraints touching them).
+func DefiningPoints(e Entity) []*Point {
+	switch t := e.(type) {
+	case *Point:
+		return []*Point{t}
+	case *Line:
+		return []*Point{t.A, t.B}
+	case *Circle:
+		return []*Point{t.Center}
+	case *Arc:
+		return []*Point{t.Center, t.Start, t.End}
+	case *Ellipse:
+		return []*Point{t.Center}
+	case *EllipticalArc:
+		return []*Point{t.Center}
+	default:
+		return nil
+	}
+}

--- a/model/sketch/drag_test.go
+++ b/model/sketch/drag_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestDragSolvePullsCoincidentPoint checks that dragging one of two coincident points re-solves
+// the sketch so the other point follows — the constraint stays satisfied, unlike a blind translate.
+func TestDragSolvePullsCoincidentPoint(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a := s.Points().Add(math.P2(1, 1))
+	b := s.Points().Add(math.P2(1, 1))
+	co := s.GeometricConstraints().AddCoincident(a, b)
+
+	s.DragSolve([]PinTarget{{P: a, Target: math.P2(4, 3)}})
+
+	if !a.Position().IsEqualTo(math.P2(4, 3), 1e-6) {
+		t.Errorf("dragged point a = %v, want it pulled to (4,3)", a.Position())
+	}
+	if !b.Position().IsEqualTo(a.Position(), 1e-6) {
+		t.Errorf("coincident point b = %v, should follow a to %v", b.Position(), a.Position())
+	}
+	for _, r := range co.Residuals() {
+		if r > 1e-6 || r < -1e-6 {
+			t.Errorf("coincident constraint violated after drag (residual %v)", r)
+		}
+	}
+}
+
+// TestDragSolveRespectsHorizontalConstraint checks a horizontal line dragged by one endpoint
+// keeps both endpoints at the same Y (the constraint slides the other endpoint), so the line
+// follows the cursor within its remaining freedom rather than tilting.
+func TestDragSolveRespectsHorizontalConstraint(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(4, 0))
+	s.GeometricConstraints().AddHorizontal(a, b)
+
+	// Drag endpoint b up and to the right; horizontal forces a's Y to track b's Y.
+	s.DragSolve([]PinTarget{{P: b, Target: math.P2(6, 2)}})
+
+	if d := b.Position().Y - a.Position().Y; d > 1e-6 || d < -1e-6 {
+		t.Errorf("horizontal violated: a.Y=%v b.Y=%v should match", a.Position().Y, b.Position().Y)
+	}
+	if b.Position().X <= 4 {
+		t.Errorf("dragged endpoint did not follow the cursor in +x: %v", b.Position())
+	}
+}
+
+// TestDragSolveFreePointMovesToTarget checks the unconstrained case still lands the point exactly
+// on the cursor (so the existing free-drag behaviour is preserved by the solve path).
+func TestDragSolveFreePointMovesToTarget(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	p := s.Points().Add(math.P2(2, 2))
+	s.DragSolve([]PinTarget{{P: p, Target: math.P2(-1, 5)}})
+	if !p.Position().IsEqualTo(math.P2(-1, 5), 1e-6) {
+		t.Errorf("free point drag = %v, want exactly (-1,5)", p.Position())
+	}
+}
+
+func TestDefiningPointsByEntity(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	pt := s.Points().Add(math.P2(0, 0))
+	ln := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	if got := DefiningPoints(pt); len(got) != 1 || got[0] != pt {
+		t.Errorf("DefiningPoints(point) = %v, want the point itself", got)
+	}
+	if got := DefiningPoints(ln); len(got) != 2 {
+		t.Errorf("DefiningPoints(line) = %d points, want 2 (both endpoints)", len(got))
+	}
+}

--- a/model/sketch/drag_test.go
+++ b/model/sketch/drag_test.go
@@ -66,10 +66,30 @@ func TestDefiningPointsByEntity(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	pt := s.Points().Add(math.P2(0, 0))
 	ln := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
-	if got := DefiningPoints(pt); len(got) != 1 || got[0] != pt {
-		t.Errorf("DefiningPoints(point) = %v, want the point itself", got)
+	ci := s.Circles().AddByCenterRadius(math.P2(0, 0), 1)
+	ar := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1, 0), math.P2(0, 1), true)
+	el := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 2, 1)
+	ea := s.EllipticalArcs().Add(math.P2(0, 0), math.V2(1, 0), 2, 1, 0, 1)
+
+	cases := []struct {
+		name string
+		ent  Entity
+		want int
+	}{
+		{"point", pt, 1},
+		{"line", ln, 2},
+		{"circle", ci, 1},
+		{"arc", ar, 3},
+		{"ellipse", el, 1},
+		{"ellipticalArc", ea, 1},
+		{"unknown", nil, 0},
 	}
-	if got := DefiningPoints(ln); len(got) != 2 {
-		t.Errorf("DefiningPoints(line) = %d points, want 2 (both endpoints)", len(got))
+	for _, c := range cases {
+		if got := DefiningPoints(c.ent); len(got) != c.want {
+			t.Errorf("DefiningPoints(%s) = %d points, want %d", c.name, len(got), c.want)
+		}
+	}
+	if got := DefiningPoints(pt); got[0] != pt {
+		t.Error("DefiningPoints(point) should return the point itself")
 	}
 }


### PR DESCRIPTION
## What

Dragging a sketch entity now **re-solves the sketch within its remaining degrees of freedom** instead of blind-translating its points. Part of #909 (the constrained-drag follow-up to #916's sketch drag-to-move).

Before, `UpdateEntityDrag` called `sketch.MoveEntities`, which moved the picked points directly and silently **broke any constraint touching them**. Now each frame pins the dragged points to the cursor target and runs the existing solver, so:
- a **coincident** neighbour tracks along,
- a **horizontal** line stays horizontal (the other endpoint slides),
- a fully-**free** point still lands exactly on the cursor (no regression).

## How

- `model/sketch/drag.go` — `DragSolve(pins)` appends temporary, non-persisted `dragPin` constraints (pull a point toward a target) and runs the warm-started Gauss–Newton solver over the full sketch; `DefiningPoints(e)` maps an entity to the points a drag pins.
- `app/sketch_drag.go` — `UpdateEntityDrag` pins each dragged point to `start+delta` (absolute, no per-frame drift) and calls `DragSolve`. The `MoveableFree` gate already admits constrained-but-moveable entities, so only the move changed.

## Tests

- `model/sketch/drag_test.go` — coincident point follows, horizontal constraint preserved, free point exact, `DefiningPoints` by entity.
- `app/sketch_drag_test.go` — constrained drag through the session API (coincident neighbour follows); existing free-drag + rejection tests still pass.
- Head in-window sketch-drag test still green.

## Follow-ups (remain in #909)

Per-face/edge box-select granularity and sketch-entity box-select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)