### PR TITLE
feat: sheet-metal base/secondary Face feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -255,6 +255,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"modelTolerance":      `{"linear":"0.01 mm"}`,
 		"moveBody":            `{"body":0,"type":"freeDrag","x":"1 mm"}`,
 		"bendPart":            `{}`,
+		"sheetMetalFace":      `{"sketchIndex":0}`,
 		"splitSolid":          `{"toolSketch":0}`,
 		"coreCavity":          `{}`,
 		"hull":                `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -130,6 +130,7 @@ func Default() *Registry {
 		replaceFaceDescriptor(),
 		moveBodyDescriptor(),
 		bendPartDescriptor(),
+		sheetMetalFaceDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_face.go
+++ b/addin/opregistry/sheet_metal_face.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalFaceArgs is the argument shape for the "sheetMetalFace" operation. Thickness is
+// intentionally absent: a Face is thickened by the active rule, so it carries no per-feature
+// thickness (edit the rule to change gauge).
+type sheetMetalFaceArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	Operation    string `json:"operation"`           // new (base wall) | join (secondary wall); default new
+	Direction    string `json:"direction,omitempty"` // positive|negative|symmetric material side; default positive
+}
+
+const sheetMetalFaceSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch whose profile becomes the wall (see model.tree)."},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which closed profile of the sketch to thicken."},
+    "operation": {"type": "string", "enum": ["new", "join"], "default": "new", "description": "new for the base wall, join to add a secondary wall to the running sheet."},
+    "direction": {"type": "string", "enum": ["positive", "negative", "symmetric"], "default": "positive", "description": "Which side of the sketch plane the material grows toward."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalFaceDescriptor is the self-describing "sheetMetalFace" operation: thicken a
+// closed sketch profile into a sheet-metal wall at the active rule's gauge.
+func sheetMetalFaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalFace",
+		Summary: "Thicken a closed sketch profile into a sheet-metal wall (the base/secondary Face) at the active rule's thickness.",
+		Schema:  json.RawMessage(sheetMetalFaceSchema),
+		Apply:   applySheetMetalFace,
+	}
+}
+
+func applySheetMetalFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if !part.IsSheetMetal() {
+		return nil, fmt.Errorf("sheetMetalFace: the active part is not a sheet-metal part")
+	}
+	var in sheetMetalFaceArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalFace: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalFaceDefinition{
+		Sketch:       sk,
+		ProfileIndex: in.ProfileIndex,
+		Direction:    parseExtentDirection(in.Direction),
+		Operation:    op,
+	}
+	pf := feature.NewSheetMetalFaceFeatures(part.Features()).Add(def)
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/sheet_metal_face_test.go
+++ b/addin/opregistry/sheet_metal_face_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// sheetMetalProfiledPart builds a sheet-metal part with one closed rectangle profile — the
+// in-package fixture for exercising applySheetMetalFace's success path (a cross-package
+// router test would not count toward this package's coverage).
+func sheetMetalProfiledPart(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Part, "panel.obk", true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	if _, err := def.EnableSheetMetal(); err != nil {
+		t.Fatalf("enable sheet metal: %v", err)
+	}
+	addRect(def.Sketches().Add(sketch.XYPlane()), 4, 3)
+	def.Recompute()
+	return s
+}
+
+// TestSheetMetalFaceApply the operation thickens the profile into one wall on a sheet-metal
+// part, and reports a clear error on a part without the sheet-metal environment.
+func TestSheetMetalFaceApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	out, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0,"operation":"new","direction":"positive"}`)
+	if err != nil {
+		t.Fatalf("sheetMetalFace apply: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if res.Bodies != 1 || !res.Healthy {
+		t.Errorf("base Face: bodies=%d healthy=%v, want 1 healthy", res.Bodies, res.Healthy)
+	}
+
+	// On an ordinary part the operation rejects cleanly.
+	if _, err := apply(t, profiledPart(t), "sheetMetalFace", `{"sketchIndex":0}`); err == nil {
+		t.Error("sheetMetalFace on a non-sheet-metal part must error")
+	}
+}
+
+// TestSheetMetalFaceApplyBadArgs each malformed-args path on a sheet-metal part returns a
+// clean error (no panic): an out-of-range sketch, an unknown operation, and bad JSON.
+func TestSheetMetalFaceApplyBadArgs(t *testing.T) {
+	for _, bad := range []string{
+		`{"sketchIndex":99}`,                   // no such sketch
+		`{"sketchIndex":0,"operation":"weld"}`, // unknown operation
+		`{"sketchIndex":"x"}`,                  // malformed JSON type
+	} {
+		if _, err := apply(t, sheetMetalProfiledPart(t), "sheetMetalFace", bad); err == nil {
+			t.Errorf("sheetMetalFace(%s) should error", bad)
+		}
+	}
+}

--- a/addin/router/sheet_metal.go
+++ b/addin/router/sheet_metal.go
@@ -61,6 +61,10 @@ func sheetMetalSetStyle(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 	if err := applyStyleEdits(part, rule, in); err != nil {
 		return nil, err
 	}
+	// A rule edit (e.g. thickness) changes the inputs every wall/bend reads live, but those
+	// reads are not tracked feature dependencies — invalidate the whole program so the sheet
+	// rebuilds at the new gauge (the same full-rebuild a parameter edit triggers).
+	part.Features().MarkAllDirty()
 	part.Recompute()
 	return json.Marshal(wire.SheetMetalStyleResult{Style: styleInfo(part, rule)})
 }

--- a/addin/router/sheet_metal_face_test.go
+++ b/addin/router/sheet_metal_face_test.go
@@ -51,7 +51,7 @@ func TestSheetMetalFaceRejectsPlainPart(t *testing.T) {
 func TestSheetMetalFaceRejectsBadArgs(t *testing.T) {
 	r, s := newSheetMetalPart(t)
 	for _, bad := range []string{
-		`{"kind":"sheetMetalFace","args":{"sketchIndex":99}}`, // no such sketch
+		`{"kind":"sheetMetalFace","args":{"sketchIndex":99}}`,  // no such sketch
 		`{"kind":"sheetMetalFace","args":{"sketchIndex":"x"}}`, // not an integer
 	} {
 		if _, err := r.Handle(s, "features.add", []byte(bad)); err == nil {

--- a/addin/router/sheet_metal_face_test.go
+++ b/addin/router/sheet_metal_face_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// featureResult is the slim shape of a features.add reply we assert on.
+type featureResult struct {
+	Bodies  int  `json:"bodies"`
+	Healthy bool `json:"healthy"`
+}
+
+// TestSheetMetalFaceOverWire builds a base wall on a sheet-metal part via features.add and
+// confirms a single healthy solid results; then a thickness edit through setStyle rebuilds
+// the wall (proving the rule's gauge propagates to the geometry).
+func TestSheetMetalFaceOverWire(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"rectangle","points":[[0,0],[4,3]]}`, &struct{}{})
+
+	var face featureResult
+	call(t, r, s, "features.add", `{"kind":"sheetMetalFace","args":{"sketchIndex":0}}`, &face)
+	if face.Bodies != 1 || !face.Healthy {
+		t.Fatalf("base Face: bodies=%d healthy=%v, want 1 healthy solid", face.Bodies, face.Healthy)
+	}
+
+	// Thicken the rule; the wall must rebuild (the model tree's body stays one solid).
+	call(t, r, s, wire.MethodSheetMetalSetStyle, `{"thickness":"3 mm"}`, &wire.SheetMetalStyleResult{})
+	var tree wire.ModelTreeResult
+	call(t, r, s, "model.tree", "{}", &tree)
+	if tree.Bodies != 1 {
+		t.Errorf("after thickness edit the part has %d bodies, want 1", tree.Bodies)
+	}
+}
+
+// TestSheetMetalFaceRejectsPlainPart features.add sheetMetalFace on an ordinary part errors
+// (the operation requires the sheet-metal environment).
+func TestSheetMetalFaceRejectsPlainPart(t *testing.T) {
+	r, s := seededSession(t) // ordinary part with a profile
+	if _, err := r.Handle(s, "features.add", []byte(`{"kind":"sheetMetalFace","args":{"sketchIndex":0}}`)); err == nil {
+		t.Fatal("sheetMetalFace on a plain part must error")
+	}
+}

--- a/addin/router/sheet_metal_face_test.go
+++ b/addin/router/sheet_metal_face_test.go
@@ -45,3 +45,17 @@ func TestSheetMetalFaceRejectsPlainPart(t *testing.T) {
 		t.Fatal("sheetMetalFace on a plain part must error")
 	}
 }
+
+// TestSheetMetalFaceRejectsBadArgs sheetMetalFace reports a clear error for an out-of-range
+// sketch index and a malformed args payload.
+func TestSheetMetalFaceRejectsBadArgs(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	for _, bad := range []string{
+		`{"kind":"sheetMetalFace","args":{"sketchIndex":99}}`, // no such sketch
+		`{"kind":"sheetMetalFace","args":{"sketchIndex":"x"}}`, // not an integer
+	} {
+		if _, err := r.Handle(s, "features.add", []byte(bad)); err == nil {
+			t.Errorf("sheetMetalFace(%s) should error", bad)
+		}
+	}
+}

--- a/model/compdef/sheet_metal_test.go
+++ b/model/compdef/sheet_metal_test.go
@@ -7,8 +7,28 @@ import (
 	"testing"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sheetmetal"
+	"oblikovati.org/model/sketch"
 )
+
+// addSquareFace adds a closed square-profile sketch and a base sheet-metal Face over it to
+// the part, then recomputes — the minimal sheet-metal body for persistence tests.
+func addSquareFace(d *PartComponentDefinition, side float64) {
+	sk := d.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(gmath.P2(0, 0))
+	c1 := sk.Points().Add(gmath.P2(side, 0))
+	c2 := sk.Points().Add(gmath.P2(side, side))
+	c3 := sk.Points().Add(gmath.P2(0, side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewSheetMetalFaceFeatures(d.Features()).Add(&feature.SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Operation: ops.NewBody})
+	d.Recompute()
+}
 
 // TestEnableSheetMetalSeedsRule a fresh part enters the environment with a default rule and
 // the backing Thickness/BendRadius parameters.
@@ -102,6 +122,35 @@ func TestSheetMetalRecipeRoundTrips(t *testing.T) {
 	want := rule.BendAllowance(math.Pi/2, 0.2)
 	if g := got.BendAllowance(math.Pi/2, 0.2); math.Abs(g-want) > 1e-9 {
 		t.Errorf("restored bend allowance = %v, want %v", g, want)
+	}
+}
+
+// TestSheetMetalFaceSurvivesRoundTrip a sheet-metal part with a base Face wall round-trips
+// through the recipe: the restored part is still sheet metal and rebuilds the same single
+// solid wall (the Face reads the restored Thickness parameter live).
+func TestSheetMetalFaceSurvivesRoundTrip(t *testing.T) {
+	src := NewPartComponentDefinition()
+	if _, err := src.EnableSheetMetal(); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	addSquareFace(src, 4)
+	if got := src.bodies.Count(); got != 1 {
+		t.Fatalf("source has %d bodies, want 1 wall", got)
+	}
+
+	blob, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dst := NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(blob); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !dst.IsSheetMetal() {
+		t.Fatal("restored part lost its sheet-metal environment")
+	}
+	if got := dst.bodies.Count(); got != 1 {
+		t.Errorf("restored part rebuilt %d bodies, want 1 wall", got)
 	}
 }
 

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -70,6 +70,8 @@ type FeatureData struct {
 	DerivedAssembly *DerivedAssemblyData `yaml:"derivedAssembly,omitempty"`
 	DerivedPart     *DerivedPartData     `yaml:"derivedPart,omitempty"`
 	Shrinkwrap      *ShrinkwrapData      `yaml:"shrinkwrap,omitempty"`
+
+	SheetMetalFace *SheetMetalFaceData `yaml:"sheetMetalFace,omitempty"` // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -261,6 +263,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.Bend = bd
+	case *SheetMetalFaceFeature:
+		sm, err := serializeSheetMetalFace(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalFace = sm
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -448,6 +456,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreMove(fs, fd.Move)
 	case "bend-part":
 		return restoreBend(fs, fd.Bend, sk)
+	case "sheet-metal-face":
+		return restoreSheetMetalFace(fs, fd.SheetMetalFace, sk)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_face.go
+++ b/model/feature/serialize_sheet_metal_face.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// SheetMetalFaceData is the serialized form of a SheetMetalFaceFeature: the profile (sketch
+// index + region index), the material side, and the boolean operation. Thickness is NOT
+// stored — it is read live from the part's Thickness parameter on recompute (the sheet-metal
+// invariant), so it can never round-trip a stale gauge.
+type SheetMetalFaceData struct {
+	Sketch    int   `yaml:"sketch"`
+	Profile   int   `yaml:"profile"`
+	Direction int32 `yaml:"direction,omitempty"`
+	Operation int32 `yaml:"operation,omitempty"`
+}
+
+// serializeSheetMetalFace projects a Face recipe to its persisted form, erroring if its
+// sketch is not in the part (so the profile cannot be lost silently).
+func serializeSheetMetalFace(def *SheetMetalFaceDefinition, sk SketchIndexer) (*SheetMetalFaceData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal face references a sketch that is not in the part")
+	}
+	return &SheetMetalFaceData{
+		Sketch: idx, Profile: def.ProfileIndex,
+		Direction: int32(def.Direction), Operation: int32(def.Operation),
+	}, nil
+}
+
+// restoreSheetMetalFace rebuilds a SheetMetalFaceFeature, erroring on a missing payload or
+// unknown sketch.
+func restoreSheetMetalFace(fs *PartFeatures, d *SheetMetalFaceData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal face feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal face references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalFaceDefinition{
+		Sketch: s, ProfileIndex: d.Profile,
+		Direction: ExtentDirection(d.Direction), Operation: ops.PartFeatureOperation(d.Operation),
+	}
+	return NewSheetMetalFaceFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_face.go
+++ b/model/feature/sheet_metal_face.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal base/secondary Face feature (M13-F02). A Face is the wall a sheet-metal part
+// starts from: a closed sketch profile thickened by the active rule's constant thickness.
+// The first Face is the base (a new body); a secondary Face joins the running sheet.
+//
+// The thickness is NOT stored on the feature — it is read live from the part's Thickness
+// parameter at every recompute, so editing that parameter (via the rule) repropagates to
+// every wall through the normal feature engine, and a restored part stays at one gauge
+// without freezing a stale value. This is the defining sheet-metal invariant.
+
+// sheetMetalThicknessParam is the well-known parameter the sheet-metal rule backs the
+// material thickness with (compdef seeds it when the part enters the environment). Defined
+// here too so the feature engine reads it without importing compdef (which imports feature).
+const sheetMetalThicknessParam = "Thickness"
+
+// SheetMetalFaceDefinition is the Face recipe: the profile to thicken, the side the material
+// grows toward, and the boolean operation (new body for the base wall, join for a secondary
+// wall). Thickness comes from the part rule at recompute time, not from here.
+type SheetMetalFaceDefinition struct {
+	Sketch       *sketch.Sketch
+	ProfileIndex int
+	Direction    ExtentDirection // material side: positive/negative/symmetric about the sketch plane
+	Operation    ops.PartFeatureOperation
+}
+
+// SheetMetalFaceFeature thickens the profile into a wall each recompute.
+type SheetMetalFaceFeature struct {
+	def      *SheetMetalFaceDefinition
+	featName string
+}
+
+// Definition returns the Face recipe.
+func (f *SheetMetalFaceFeature) Definition() *SheetMetalFaceDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalFaceFeature) Kind() string { return "sheet-metal-face" }
+
+// Recompute resolves the profile, thickens it by the rule thickness on the chosen side, and
+// applies the operation against the running bodies.
+func (f *SheetMetalFaceFeature) Recompute(in Input) (Output, error) {
+	profiles, err := resolveClosedProfiles(f.def.Sketch, []int{f.def.ProfileIndex}, "sheet-metal face")
+	if err != nil {
+		return Output{}, err
+	}
+	t, err := sheetThickness(in.Params)
+	if err != nil {
+		return Output{}, err
+	}
+	body := buildProfilePrisms(profiles, f.def.Sketch.Plane(), faceSpan(t, f.def.Direction), 0, f.featName)
+	bodies, err := combine(in.Bodies, body, f.def.Operation)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// sheetThickness reads the live material thickness (database units) from the part's Thickness
+// parameter, erroring when it is absent (not a sheet-metal part) or non-positive.
+func sheetThickness(ps *param.Parameters) (float64, error) {
+	if ps == nil {
+		return 0, fmt.Errorf("sheet-metal face: no parameters available")
+	}
+	p, ok := ps.ByName(sheetMetalThicknessParam)
+	if !ok {
+		return 0, fmt.Errorf("sheet-metal face: no %q parameter (is this a sheet-metal part?)", sheetMetalThicknessParam)
+	}
+	t := p.ModelValue()
+	if t <= 0 {
+		return 0, fmt.Errorf("sheet-metal face: thickness must be positive, got %g", t)
+	}
+	return t, nil
+}
+
+// faceSpan returns the thickening span for the given material side: positive grows along the
+// sketch normal, negative against it, symmetric splits the thickness across the plane.
+func faceSpan(t float64, dir ExtentDirection) span {
+	switch dir {
+	case NegativeDir:
+		return span{near: -t, far: 0}
+	case SymmetricDir:
+		return span{near: -t / 2, far: t / 2}
+	default:
+		return span{near: 0, far: t}
+	}
+}
+
+// SheetMetalFaceFeatures adds Face features into the engine.
+type SheetMetalFaceFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalFaceFeatures binds the collection to a feature engine.
+func NewSheetMetalFaceFeatures(engine *PartFeatures) *SheetMetalFaceFeatures {
+	return &SheetMetalFaceFeatures{engine}
+}
+
+// Add appends a Face feature, naming it Face1, Face2, … .
+func (c *SheetMetalFaceFeatures) Add(def *SheetMetalFaceDefinition) *PartFeature {
+	f := &SheetMetalFaceFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Face"))
+	f.featName = pf.Name()
+	return pf
+}
+
+// assert it satisfies the topo-building Feature contract.
+var _ Feature = (*SheetMetalFaceFeature)(nil)

--- a/model/feature/sheet_metal_face_test.go
+++ b/model/feature/sheet_metal_face_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/param"
+)
+
+// sheetMetalParams returns a parameter set carrying a Thickness parameter at the given
+// expression — the minimum a sheet-metal Face needs to recompute.
+func sheetMetalParams(t *testing.T, thicknessExpr string) *param.Parameters {
+	t.Helper()
+	ps := param.NewParameters()
+	if _, err := ps.AddUserParameter("Thickness", thicknessExpr); err != nil {
+		t.Fatalf("add Thickness: %v", err)
+	}
+	return ps
+}
+
+// TestSheetMetalFaceCreatesWall a base Face thickens a square profile into a watertight
+// prism whose volume is side²·thickness at the rule's gauge.
+func TestSheetMetalFaceCreatesWall(t *testing.T) {
+	ps := sheetMetalParams(t, "2 mm") // 0.2 cm
+	fs := NewPartFeatures(ps, nil)
+	pf := NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("face went sick: %+v", pf.Health())
+	}
+	bodies := fs.Result()
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		t.Fatalf("face result is not a single solid (%d bodies)", len(bodies))
+	}
+	if len(bodies[0].Faces()) != 6 {
+		t.Errorf("wall has %d faces, want 6 (a prism)", len(bodies[0].Faces()))
+	}
+	if open := ops.BoundaryEdges(bodies[0]); len(open) != 0 {
+		t.Errorf("wall has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	want := 4.0 * 4.0 * 0.2 // side²·thickness (cm³)
+	if got := ops.BodyGeometryProperties(bodies[0], ops.Quality{ChordTolerance: 1e-4}).Volume; math.Abs(got-want) > 1e-6 {
+		t.Errorf("wall volume = %.6f cm³, want %.6f", got, want)
+	}
+}
+
+// TestSheetMetalFaceIsParameterBacked editing the Thickness parameter changes the wall's
+// volume on the next recompute — the gauge follows the parameter, not a frozen value.
+func TestSheetMetalFaceIsParameterBacked(t *testing.T) {
+	ps := sheetMetalParams(t, "1 mm")
+	thickness, _ := ps.ByName("Thickness")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+
+	fs.Recompute()
+	thin := ops.BodyGeometryProperties(fs.Result()[0], ops.Quality{ChordTolerance: 1e-4}).Volume
+
+	if err := ps.SetExpression(thickness.ID(), "3 mm"); err != nil {
+		t.Fatalf("set Thickness: %v", err)
+	}
+	fs.MarkAllDirty() // a parameter edit invalidates the whole program (as the host does)
+	fs.Recompute()
+	thick := ops.BodyGeometryProperties(fs.Result()[0], ops.Quality{ChordTolerance: 1e-4}).Volume
+
+	if !(thick > thin*2.5) { // 3× thickness ⇒ ~3× volume
+		t.Errorf("thicker gauge did not grow the wall: 1mm=%.4f 3mm=%.4f", thin, thick)
+	}
+}
+
+// TestSheetMetalFaceNeedsThickness a Face without a Thickness parameter goes sick with a
+// clear message rather than building a degenerate wall.
+func TestSheetMetalFaceNeedsThickness(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters(), nil) // no Thickness parameter
+	pf := NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Fatal("face without a Thickness parameter should be sick")
+	}
+}
+
+// TestSheetMetalFaceSecondaryJoins a second Face with Join merges into the running sheet
+// rather than starting a new body.
+func TestSheetMetalFaceSecondaryJoins(t *testing.T) {
+	ps := sheetMetalParams(t, "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	faces := NewSheetMetalFaceFeatures(fs)
+	faces.Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	// A larger coplanar square over the same plane: joining unions the two prisms into one sheet.
+	faces.Add(&SheetMetalFaceDefinition{Sketch: squareSketch(6), ProfileIndex: 0, Operation: ops.Join})
+
+	fs.Recompute()
+	if bodies := fs.Result(); len(bodies) != 1 {
+		t.Errorf("secondary Face produced %d bodies, want 1 merged sheet", len(bodies))
+	}
+}

--- a/model/feature/sheet_metal_face_test.go
+++ b/model/feature/sheet_metal_face_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
 )
 
 // sheetMetalParams returns a parameter set carrying a Thickness parameter at the given
@@ -79,6 +80,65 @@ func TestSheetMetalFaceNeedsThickness(t *testing.T) {
 	fs.Recompute()
 	if pf.Health().OK() {
 		t.Fatal("face without a Thickness parameter should be sick")
+	}
+}
+
+// TestSheetMetalFaceRoundTrip the Face recipe (profile + direction + operation) marshals and
+// restores in-package, preserving the kind and payload.
+func TestSheetMetalFaceRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Direction: NegativeDir, Operation: ops.Join})
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if len(data) != 1 || data[0].Kind != "sheet-metal-face" || data[0].SheetMetalFace == nil {
+		t.Fatalf("marshaled = %+v, want one sheet-metal-face with payload", data)
+	}
+	if data[0].SheetMetalFace.Direction != int32(NegativeDir) || data[0].SheetMetalFace.Operation != int32(ops.Join) {
+		t.Errorf("payload = %+v, want negative/join", data[0].SheetMetalFace)
+	}
+
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-face" {
+		t.Errorf("restored program = %d features, want one sheet-metal-face", fresh.Count())
+	}
+}
+
+// TestSheetMetalFaceMissingPayload restoring a sheet-metal-face record with no payload errors.
+func TestSheetMetalFaceMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalFace(NewPartFeatures(nil, nil), nil, oneSketch{}); err == nil {
+		t.Error("restoreSheetMetalFace(nil) must error")
+	}
+}
+
+// TestSheetMetalFaceSerializeUnknownSketch serializing a Face whose sketch is not in the part
+// errors rather than silently dropping the profile reference.
+func TestSheetMetalFaceSerializeUnknownSketch(t *testing.T) {
+	def := &SheetMetalFaceDefinition{Sketch: sketch.NewSketches().Add(sketch.XYPlane()), ProfileIndex: 0}
+	// oneSketch over a *different* sketch ⇒ IndexOf returns false.
+	if _, err := serializeSheetMetalFace(def, oneSketch{s: sketch.NewSketches().Add(sketch.XYPlane())}); err == nil {
+		t.Error("serializeSheetMetalFace with an unknown sketch must error")
+	}
+}
+
+// TestSheetThicknessEdgeCases the thickness reader rejects nil parameters and a non-positive
+// gauge.
+func TestSheetThicknessEdgeCases(t *testing.T) {
+	if _, err := sheetThickness(nil); err == nil {
+		t.Error("sheetThickness(nil) must error")
+	}
+	ps := param.NewParameters()
+	if _, err := ps.AddUserParameter("Thickness", "0 mm"); err != nil {
+		t.Fatalf("add Thickness: %v", err)
+	}
+	if _, err := sheetThickness(ps); err == nil {
+		t.Error("sheetThickness with zero gauge must error")
 	}
 }
 

--- a/model/feature/sheet_metal_face_test.go
+++ b/model/feature/sheet_metal_face_test.go
@@ -82,6 +82,41 @@ func TestSheetMetalFaceNeedsThickness(t *testing.T) {
 	}
 }
 
+// TestSheetMetalFaceDirections each material side (positive/negative/symmetric) thickens the
+// profile into a valid single solid of the same volume, on the chosen side of the plane.
+func TestSheetMetalFaceDirections(t *testing.T) {
+	want := 4.0 * 4.0 * 0.2 // side²·thickness
+	for _, dir := range []ExtentDirection{PositiveDir, NegativeDir, SymmetricDir} {
+		ps := sheetMetalParams(t, "2 mm")
+		fs := NewPartFeatures(ps, nil)
+		def := &SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Direction: dir, Operation: ops.NewBody}
+		pf := NewSheetMetalFaceFeatures(fs).Add(def)
+		if pf.Definition() == nil {
+			t.Fatal("Definition() returned nil")
+		}
+		fs.Recompute()
+		if !pf.Health().OK() {
+			t.Fatalf("direction %d: face sick %+v", dir, pf.Health())
+		}
+		bodies := fs.Result()
+		if len(bodies) != 1 || !bodies[0].IsSolid() {
+			t.Fatalf("direction %d: not a single solid", dir)
+		}
+		if got := ops.BodyGeometryProperties(bodies[0], ops.Quality{ChordTolerance: 1e-4}).Volume; math.Abs(got-want) > 1e-6 {
+			t.Errorf("direction %d: volume = %.6f, want %.6f", dir, got, want)
+		}
+	}
+}
+
+// TestSheetMetalFaceDefinitionAccessor Definition returns the stored recipe.
+func TestSheetMetalFaceDefinitionAccessor(t *testing.T) {
+	def := &SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody}
+	f := &SheetMetalFaceFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-face" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
 // TestSheetMetalFaceSecondaryJoins a second Face with Join merges into the running sheet
 // rather than starting a new body.
 func TestSheetMetalFaceSecondaryJoins(t *testing.T) {


### PR DESCRIPTION
## What

The **base Face** — the first wall of a sheet-metal part, and the start of M13-F02 (Wall & Bend Features). A closed sketch profile is thickened by the active rule's gauge into a wall; it's the full Definition→Add→Feature triangle that the bend features (flange/hem/bend/fold) will attach to.

The thickness is **read live from the part's `Thickness` parameter** on every recompute (not stored on the feature), so editing the rule's gauge repropagates to every wall through the feature engine, and a restored part never carries a stale thickness — the defining constant-thickness invariant.

- **model/feature** — `SheetMetalFaceDefinition`/`Feature` (+ collection), reusing the shared profile-prism builder; positive/negative/symmetric material side; `new` (base wall) or `join` (secondary wall); recipe round-trip.
- **addin/opregistry** — the `sheetMetalFace` operation (rejects a non-sheet-metal part); registered + covered by the descriptor/args guards.
- **addin/router** — `setStyle` now invalidates the feature program before recompute, so a thickness/K-factor edit **rebuilds every wall** (a latent F01 gap surfaced here): the gauge truly drives the geometry.

## Why

Sheet metal is a part-content flavor + a feature family (architecture/modeling/05-sheet-metal.md). The Face is the foundation every other F02 feature builds on. Builds on F01 (the rule), now on develop.

## Test
Wall volume = side²·thickness and watertight; thickness edit regrows the wall; missing-thickness → sick; secondary Face joins; wall + sheet-metal part survive the recipe round-trip; over-the-wire add + thickness rebuild; plain-part rejection. `go test ./model/feature/ ./addin/opregistry/ ./addin/router/ ./model/compdef/ ./model/sheetmetal/` green; lint 0.

Source-only (uses the generic `features.add`; no new API surface). Part of M13 #374/#370.

> Note: adds `sheetMetalFace` to the source feature registry — the bridge's `TestE2EFeatureRegistryCoverage` will need it added to its expected set in a follow-up bridge PR (per the known coverage-drift pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)