### PR TITLE
feat(sketch): box-select 2D entities in the sketch editor (#909)

### DIFF
--- a/app/box_select.go
+++ b/app/box_select.go
@@ -39,10 +39,11 @@ type BoxSelection struct {
 // crossing select; left→right is a window select.
 func (b BoxSelection) Crossing() bool { return b.X1 < b.X0 }
 
-// BeginBoxSelect starts a rubber-band rectangle anchored at the press point. It is a no-op
-// when no RegionPicker is installed, so callers can begin unconditionally.
+// BeginBoxSelect starts a rubber-band rectangle anchored at the press point. It is a no-op when
+// box-select cannot resolve hits — no RegionPicker installed and not editing a sketch — so callers
+// can begin unconditionally.
 func (s *Session) BeginBoxSelect(x, y float64) {
-	if s.regionPicker == nil {
+	if s.regionPicker == nil && s.activeSketch == nil {
 		return
 	}
 	s.boxSelect = BoxSelection{X0: x, Y0: y, X1: x, Y1: y, Active: true}
@@ -75,17 +76,29 @@ func (s *Session) CancelBoxSelect() { s.boxSelect = BoxSelection{} }
 // then ends the drag. It emits SelectionChanged when the set changed. Returns the number of
 // objects the rectangle covered.
 func (s *Session) CommitBoxSelect(mods Modifier) int {
-	if !s.boxSelect.Active || s.regionPicker == nil {
+	if !s.boxSelect.Active {
 		s.boxSelect = BoxSelection{}
 		return 0
 	}
 	b := s.boxSelect
-	hits := s.regionPicker.PickRegion(b.X0, b.Y0, b.X1, b.Y1, b.Crossing(), s.selection.Filter())
+	hits := s.regionHits(b)
 	s.boxSelect = BoxSelection{}
 	if s.applyRegionToSelection(hits, mods) {
 		event.Emit(s.bus, event.After, SelectionChanged{Count: s.selection.Count()})
 	}
 	return len(hits)
+}
+
+// regionHits resolves the box rectangle to selectables: the active sketch's entities while
+// editing a sketch (2D), otherwise the model bodies via the installed RegionPicker (3D).
+func (s *Session) regionHits(b BoxSelection) []Selectable {
+	if s.activeSketch != nil {
+		return s.pickSketchRegion(b.X0, b.Y0, b.X1, b.Y1, b.Crossing())
+	}
+	if s.regionPicker == nil {
+		return nil
+	}
+	return s.regionPicker.PickRegion(b.X0, b.Y0, b.X1, b.Y1, b.Crossing(), s.selection.Filter())
 }
 
 // applyRegionToSelection folds box-select hits into the selection set: a plain box replaces

--- a/app/region_pick.go
+++ b/app/region_pick.go
@@ -64,6 +64,11 @@ func (r screenRect) overlaps(other screenRect) bool {
 		r.minY <= other.maxY && r.maxY >= other.minY
 }
 
+// containsPoint reports whether (x,y) lies inside r (inclusive).
+func (r screenRect) containsPoint(x, y float64) bool {
+	return x >= r.minX && x <= r.maxX && y >= r.minY && y <= r.maxY
+}
+
 // projectBodyRect projects the eight corners of a body's range box to screen and returns
 // their bounding rectangle. ok is false when any corner is at/behind the camera (the body
 // is partly off-screen), in which case the caller skips it.

--- a/app/sketch_region.go
+++ b/app/sketch_region.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+)
+
+// Sketch box-select: in the sketch editor a rubber-band rectangle selects the 2D entities it
+// covers. Each entity's outline (sketch.EntityOutline) is projected to screen through the sketch
+// plane and the viewport camera, then classified — window (drag L→R) keeps entities fully
+// enclosed by the box, crossing (R→L) also keeps entities the box merely touches. This is the
+// sketch-env counterpart to RayPicker.PickRegion (#909).
+
+// screenPt is a projected outline vertex in viewport pixels.
+type screenPt struct{ x, y float64 }
+
+// pickSketchRegion returns the active sketch's entities covered by the box-select rectangle.
+func (s *Session) pickSketchRegion(x0, y0, x1, y1 float64, crossing bool) []Selectable {
+	if s.activeSketch == nil {
+		return nil
+	}
+	plane := s.activeSketch.Plane()
+	rect := orderedRect(x0, y0, x1, y1)
+	var hits []Selectable
+	for _, e := range s.activeSketch.Entities() {
+		pts := s.projectOutline(plane, sketch.EntityOutline(e))
+		if len(pts) > 0 && regionCoversOutline(pts, rect, crossing) {
+			hits = append(hits, SketchEntityHandle{Entity: e})
+		}
+	}
+	return hits
+}
+
+// projectOutline maps an entity's sketch-space outline to viewport pixels through the sketch
+// plane and camera, dropping vertices that fall at/behind the camera.
+func (s *Session) projectOutline(plane sketch.Plane, outline []math.Point2) []screenPt {
+	pts := make([]screenPt, 0, len(outline))
+	for _, p := range outline {
+		if sx, sy, ok := renderer.Project(s.camera, regionNear, regionFar, plane.ToModel(p)); ok {
+			pts = append(pts, screenPt{sx, sy})
+		}
+	}
+	return pts
+}
+
+// regionCoversOutline classifies a projected outline against the box: window (crossing=false)
+// requires every vertex inside the rectangle; crossing requires any vertex inside OR any outline
+// segment to cross a rectangle edge (so a long line passing through the box, all vertices outside,
+// is still caught).
+func regionCoversOutline(pts []screenPt, rect screenRect, crossing bool) bool {
+	inside := 0
+	for _, p := range pts {
+		if rect.containsPoint(p.x, p.y) {
+			inside++
+		}
+	}
+	if !crossing {
+		return inside == len(pts)
+	}
+	if inside > 0 {
+		return true
+	}
+	for i := 1; i < len(pts); i++ {
+		if segmentCrossesRect(pts[i-1], pts[i], rect) {
+			return true
+		}
+	}
+	return false
+}
+
+// segmentCrossesRect reports whether segment a–b intersects any edge of the rectangle (the
+// endpoint-inside case is handled by the caller's vertex test).
+func segmentCrossesRect(a, b screenPt, r screenRect) bool {
+	corners := [4]screenPt{{r.minX, r.minY}, {r.maxX, r.minY}, {r.maxX, r.maxY}, {r.minX, r.maxY}}
+	for i := 0; i < 4; i++ {
+		if segmentsIntersect(a, b, corners[i], corners[(i+1)%4]) {
+			return true
+		}
+	}
+	return false
+}
+
+// segmentsIntersect reports whether segments p1–p2 and p3–p4 properly cross, using the standard
+// orientation (CCW) test.
+func segmentsIntersect(p1, p2, p3, p4 screenPt) bool {
+	d1 := orient(p3, p4, p1)
+	d2 := orient(p3, p4, p2)
+	d3 := orient(p1, p2, p3)
+	d4 := orient(p1, p2, p4)
+	return ((d1 > 0) != (d2 > 0)) && ((d3 > 0) != (d4 > 0))
+}
+
+// orient returns the signed area sign of triangle (a,b,c): >0 CCW, <0 CW, 0 collinear.
+func orient(a, b, c screenPt) float64 {
+	return (b.x-a.x)*(c.y-a.y) - (b.y-a.y)*(c.x-a.x)
+}

--- a/app/sketch_region_test.go
+++ b/app/sketch_region_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+	"oblikovati.org/scene"
+)
+
+// sketchRegionFixture builds a sketch viewed head-on by a 200×200 camera centred on the origin,
+// plus a projector from sketch coordinates to screen pixels (matching pickSketchRegion).
+func sketchRegionFixture(t *testing.T) (*Session, *sketch.Sketch, func(math.Point2) (float64, float64)) {
+	t.Helper()
+	s, sk := sketchSession(t)
+	s.Grid().SnapToGrid = false
+	cam := scene.NewCamera(200, 200)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	plane := sk.Plane()
+	proj := func(p math.Point2) (float64, float64) {
+		x, y, _ := renderer.Project(s.Camera(), regionNear, regionFar, plane.ToModel(p))
+		return x, y
+	}
+	return s, sk, proj
+}
+
+func TestPickSketchRegionWindowEnclosesEntities(t *testing.T) {
+	s, sk, proj := sketchRegionFixture(t)
+	ln := sk.Lines().AddByTwoPoints(math.P2(-1, 0), math.P2(1, 0))
+	sk.Points().Add(math.P2(40, 40)) // far off to the side
+
+	ax, ay := proj(math.P2(-1, 0))
+	bx, by := proj(math.P2(1, 0))
+	pad := 6.0
+	x0, y0 := minF(ax, bx)-pad, minF(ay, by)-pad
+	x1, y1 := maxF(ax, bx)+pad, maxF(ay, by)+pad
+
+	hits := s.pickSketchRegion(x0, y0, x1, y1, false) // window
+	if len(hits) != 1 {
+		t.Fatalf("window enclosing the line should select exactly it, got %d hits", len(hits))
+	}
+	if h, ok := hits[0].(SketchEntityHandle); !ok || h.Entity != ln {
+		t.Errorf("window hit = %v, want the line", hits[0])
+	}
+}
+
+func TestPickSketchRegionCrossingCatchesPartialLine(t *testing.T) {
+	s, sk, proj := sketchRegionFixture(t)
+	ln := sk.Lines().AddByTwoPoints(math.P2(-2, 0), math.P2(2, 0))
+
+	// A rectangle around the line's MIDDLE: both endpoints are outside it, so a window misses,
+	// but the segment crosses it → crossing selects it.
+	mx, my := proj(math.P2(0, 0))
+	x0, y0, x1, y1 := mx-5, my-5, mx+5, my+5
+
+	if got := s.pickSketchRegion(x0, y0, x1, y1, false); len(got) != 0 {
+		t.Fatalf("window over the line's middle should select nothing (endpoints outside), got %d", len(got))
+	}
+	hits := s.pickSketchRegion(x0, y0, x1, y1, true) // crossing
+	if len(hits) != 1 {
+		t.Fatalf("crossing over the line's middle should select it, got %d", len(hits))
+	}
+	if h := hits[0].(SketchEntityHandle); h.Entity != ln {
+		t.Errorf("crossing hit = %v, want the line", hits[0])
+	}
+}
+
+func TestPickSketchRegionNoActiveSketch(t *testing.T) {
+	if got := NewSession().pickSketchRegion(0, 0, 10, 10, false); got != nil {
+		t.Errorf("pickSketchRegion with no active sketch should return nil, got %d", len(got))
+	}
+}
+
+// TestBoxSelectStateMachineInSketch drives the box-select state machine in a sketch (no
+// RegionPicker installed) and checks BeginBoxSelect is allowed and CommitBoxSelect routes to the
+// sketch region pick, selecting the enclosed entity.
+func TestBoxSelectStateMachineInSketch(t *testing.T) {
+	s, sk, proj := sketchRegionFixture(t)
+	ln := sk.Lines().AddByTwoPoints(math.P2(-1, 0), math.P2(1, 0))
+	ax, ay := proj(math.P2(-1, 0))
+	bx, by := proj(math.P2(1, 0))
+
+	s.BeginBoxSelect(minF(ax, bx)-6, minF(ay, by)-6) // editing a sketch, so this is allowed
+	if !s.BoxSelectActive() {
+		t.Fatal("BeginBoxSelect should start a box in the sketch editor (no RegionPicker needed)")
+	}
+	s.UpdateBoxSelect(maxF(ax, bx)+6, maxF(ay, by)+6) // L→R window enclosing the line
+	if n := s.CommitBoxSelect(0); n != 1 {
+		t.Fatalf("commit should select the enclosed line, got %d hits", n)
+	}
+	if s.Selection().Count() != 1 || !s.Selection().Contains(SketchEntityHandle{Entity: ln}) {
+		t.Errorf("the line should be the selection after the box: count=%d", s.Selection().Count())
+	}
+}

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -66,11 +66,10 @@ func updateSketchDrag(s *app.Session) bool {
 
 // updateBoxSelect advances the box-select state machine and reports whether it consumed this
 // frame's left input. It begins a box only on a fresh left press over empty space, tracks the
-// cursor while the button is held, and commits on release.
+// cursor while the button is held, and commits on release. In the sketch editor it selects 2D
+// entities; in the model env it selects bodies (#909). updateSketchDrag runs first, so a press on
+// a draggable sketch entity moves it rather than starting a box.
 func updateBoxSelect(s *app.Session) bool {
-	if s.InSketch() && !s.BoxSelectActive() {
-		return false // sketch-entity box-select is a follow-up (#909); the sketch env drags/click-selects
-	}
 	if s.BoxSelectActive() {
 		lx, ly := viewportCursor()
 		if native.MouseDown(native.MouseLeft) {

--- a/head/ui/inwindow_test.go
+++ b/head/ui/inwindow_test.go
@@ -346,3 +346,46 @@ func pressFindsSketchPoint(win *native.Window, s *app.Session) (float32, float32
 	}
 	return x, float32(inWinH / 2), false
 }
+
+// TestInWindowSketchBoxSelect drives a real left-drag box across a line in the sketch editor and
+// asserts the head selected the enclosed entity (sketch-entity box-select, #909).
+func TestInWindowSketchBoxSelect(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	s := app.NewSession()
+	docu, _ := compdef.AddPart(s.Workspace(), "boxsel.opd", true)
+	part := docu.Content().(*compdef.PartComponentDefinition)
+	sk := part.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	s.Grid().SnapToGrid = false
+	s.SetPicker(fakeEmptyPicker{}) // a corner press is "empty" → box-select arms
+	ln := sk.Lines().AddByTwoPoints(math.P2(-1, 0), math.P2(1, 0))
+
+	s.TickCameraAnimation(100) // finish the enter-sketch swing (test dt≈0)
+	cam := scene.NewCamera(inWinW, inWinH)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+
+	// Press at an empty corner, drag a window to the opposite corner enclosing the centred line.
+	native.InjectMousePos(60, 70)
+	viewportFrame(win, s)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, true)
+	viewportFrame(win, s)
+	if !s.BoxSelectActive() {
+		t.Fatal("a corner press in the sketch did not begin a box-select")
+	}
+	for i := 1; i <= 4; i++ {
+		native.InjectMousePos(60+float32(170*i), 70+float32(120*i))
+		viewportFrame(win, s)
+	}
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+
+	if s.BoxSelectActive() {
+		t.Error("releasing should end the box-select")
+	}
+	if s.Selection().Count() != 1 || !s.Selection().Contains(app.SketchEntityHandle{Entity: ln}) {
+		t.Errorf("the box should select the enclosed line: count=%d", s.Selection().Count())
+	}
+}

--- a/model/sketch/region.go
+++ b/model/sketch/region.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// EntityOutline returns sample points (in sketch coordinates) approximating an entity's outline —
+// the points a box / region selection projects to screen and tests against the rubber-band
+// rectangle. A standalone point yields itself; every curve reuses the shared polyline samplers
+// (entityPolyline), so the resolution matches the rendered overlay. Entities with no outline
+// (text, images) return nil.
+func EntityOutline(e Entity) []math.Point2 {
+	if p, ok := e.(*Point); ok {
+		return []math.Point2{p.Position()}
+	}
+	pts, _ := entityPolyline(e)
+	return pts
+}

--- a/model/sketch/region_test.go
+++ b/model/sketch/region_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+func TestEntityOutline(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	pt := s.Points().Add(math.P2(1, 2))
+	ln := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(3, 0))
+	ci := s.Circles().AddByCenterRadius(math.P2(0, 0), 1)
+
+	if got := EntityOutline(pt); len(got) != 1 || !got[0].IsEqualTo(math.P2(1, 2), 1e-9) {
+		t.Errorf("point outline = %v, want just its position", got)
+	}
+	if got := EntityOutline(ln); len(got) < 2 {
+		t.Errorf("line outline = %d points, want at least its 2 endpoints", len(got))
+	}
+	if got := EntityOutline(ci); len(got) < 8 {
+		t.Errorf("circle outline = %d points, want a sampled polygon", len(got))
+	}
+}


### PR DESCRIPTION
## What

Box-select now works **in the sketch editor**, selecting the 2D entities the rubber-band covers (it was model-only before, and explicitly gated out of sketches). Window (drag L→R) selects entities fully enclosed; crossing (R→L) also selects entities the box touches. Completes another part of #909.

## How

- `model/sketch/region.go` — `EntityOutline(e)` samples an entity's outline in sketch coordinates (a point yields itself; curves reuse the shared `entityPolyline` samplers, matching the rendered overlay resolution).
- `app/sketch_region.go` — `pickSketchRegion` projects each active-sketch entity's outline to screen through the sketch plane + viewport camera, then classifies it: **window** keeps entities with every vertex inside; **crossing** keeps any with a vertex inside *or* a segment crossing a rectangle edge (segment-rect intersection, so a long line passing through the box with both endpoints outside is still caught).
- `app/box_select.go` — `CommitBoxSelect` routes through `regionHits` (sketch entities while editing a sketch, bodies otherwise); `BeginBoxSelect` is allowed in a sketch without a `RegionPicker`.
- `head/ui` — drop the gate that disabled box-select in the sketch env. `updateSketchDrag` still runs first, so a press on a draggable entity moves it (drag-to-move) rather than starting a box.

## Tests

- `model/sketch/region_test.go` — `EntityOutline` across point/line/circle.
- `app/sketch_region_test.go` — window encloses, crossing catches a partial line (segment-rect), no-active-sketch, and the full box-select state machine in a sketch.
- Head in-window live test (`TestInWindowSketchBoxSelect`) drags a real box across a line and asserts selection.

## Follow-ups (remain in #909)

Per-face/edge box-select granularity in the model env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)