### PR TITLE
feat: sheet-metal Flange feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -256,6 +256,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"moveBody":            `{"body":0,"type":"freeDrag","x":"1 mm"}`,
 		"bendPart":            `{}`,
 		"sheetMetalFace":      `{"sketchIndex":0}`,
+		"sheetMetalFlange":    `{"edge":"x","height":"10 mm"}`,
 		"splitSolid":          `{"toolSketch":0}`,
 		"coreCavity":          `{}`,
 		"hull":                `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -131,6 +131,7 @@ func Default() *Registry {
 		moveBodyDescriptor(),
 		bendPartDescriptor(),
 		sheetMetalFaceDescriptor(),
+		sheetMetalFlangeDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_flange.go
+++ b/addin/opregistry/sheet_metal_flange.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalFlangeArgs is the argument shape for the "sheetMetalFlange" operation: the edge
+// to flange from, the flange height, and the optional bend angle/radius (radius defaults to
+// the rule's bend radius). Thickness comes from the active rule.
+type sheetMetalFlangeArgs struct {
+	Edge   string `json:"edge"`
+	Height string `json:"height"`
+	Angle  string `json:"angle,omitempty"`  // default 90 deg
+	Radius string `json:"radius,omitempty"` // default: rule bend radius
+	Flip   bool   `json:"flip,omitempty"`
+}
+
+const sheetMetalFlangeSchema = `{
+  "type": "object",
+  "properties": {
+    "edge": {"type": "string", "description": "Reference key of the straight sheet edge to flange from (from get_reference_keys)."},
+    "height": {"type": "string", "description": "Flange wall length with units, e.g. \"15 mm\"."},
+    "angle": {"type": "string", "description": "Bend angle, e.g. \"90 deg\" (default). The wall folds this far from the parent face."},
+    "radius": {"type": "string", "description": "Inside bend radius (default: the rule's bend radius)."},
+    "flip": {"type": "boolean", "default": false, "description": "Fold toward the opposite side of the sheet."}
+  },
+  "required": ["edge", "height"]
+}`
+
+// sheetMetalFlangeDescriptor is the self-describing "sheetMetalFlange" operation: fold a wall
+// onto a sheet edge over a bend at the active rule's gauge.
+func sheetMetalFlangeDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalFlange",
+		Summary: "Fold a wall (flange) onto a straight sheet-metal edge over a cylindrical bend, at the active rule's thickness and bend radius.",
+		Schema:  json.RawMessage(sheetMetalFlangeSchema),
+		Apply:   applySheetMetalFlange,
+	}
+}
+
+func applySheetMetalFlange(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if !part.IsSheetMetal() {
+		return nil, fmt.Errorf("sheetMetalFlange: the active part is not a sheet-metal part")
+	}
+	var in sheetMetalFlangeArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalFlange: invalid args: %w", err)
+	}
+	if in.Edge == "" {
+		return nil, fmt.Errorf("sheetMetalFlange: edge is required")
+	}
+	def, err := flangeDef(part, in)
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewSheetMetalFlangeFeatures(part.Features()).Add(def)
+	return recomputeResult(part, pf)
+}
+
+// flangeDef resolves the flange args into a definition: the edge key, the height closure, and
+// the optional angle/radius closures (omitted ⇒ nil, so the feature uses its defaults).
+func flangeDef(part *compdef.PartComponentDefinition, in sheetMetalFlangeArgs) (*feature.SheetMetalFlangeDefinition, error) {
+	height, err := lengthClosure(part, in.Height, "sheetMetalFlange: height")
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalFlangeDefinition{EdgeKey: []byte(in.Edge), Height: height, Flip: in.Flip}
+	if in.Angle != "" {
+		angle, err := angleClosure(part, in.Angle, "sheetMetalFlange: angle")
+		if err != nil {
+			return nil, err
+		}
+		def.Angle = angle
+	}
+	if in.Radius != "" {
+		radius, err := lengthClosure(part, in.Radius, "sheetMetalFlange: radius")
+		if err != nil {
+			return nil, err
+		}
+		def.Radius = radius
+	}
+	return def, nil
+}

--- a/addin/opregistry/sheet_metal_flange_test.go
+++ b/addin/opregistry/sheet_metal_flange_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// TestSheetMetalFlangeApply seeds a sheet-metal wall, flanges a top edge, and confirms one
+// merged solid results; then checks the error paths (non-sheet-metal part, missing edge).
+func TestSheetMetalFlangeApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	edge := topEdgeKey(t, def)
+
+	out, err := applyMap(t, s, "sheetMetalFlange", map[string]any{"edge": edge, "height": "10 mm", "angle": "90 deg", "radius": "2 mm"})
+	if err != nil {
+		t.Fatalf("flange apply: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if res.Bodies != 1 || !res.Healthy {
+		t.Errorf("flange: bodies=%d healthy=%v, want 1 healthy", res.Bodies, res.Healthy)
+	}
+
+	// Error paths.
+	if _, err := apply(t, sheetMetalProfiledPart(t), "sheetMetalFlange", `{"height":"5 mm"}`); err == nil {
+		t.Error("flange without an edge must error")
+	}
+	if _, err := apply(t, profiledPart(t), "sheetMetalFlange", `{"edge":"x","height":"5 mm"}`); err == nil {
+		t.Error("flange on a non-sheet-metal part must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalFlange", map[string]any{"edge": edge, "height": "bad"}); err == nil {
+		t.Error("flange with a bad height must error")
+	}
+}
+
+// topEdgeKey returns the reference key of a top-face edge of the part's first body — a
+// deterministic edge to flange from.
+func topEdgeKey(t *testing.T, def *compdef.PartComponentDefinition) string {
+	t.Helper()
+	if def.SurfaceBodies().Count() == 0 {
+		t.Fatal("no body to flange")
+	}
+	b := def.SurfaceBodies().Item(0)
+	maxZ := math.Inf(-1)
+	for _, e := range b.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-c.X) > 1e-6 && math.Abs(a.Y-c.Y) < 1e-6 && math.Abs(a.Z-maxZ) < 1e-6 && math.Abs(c.Z-maxZ) < 1e-6 {
+			return string(e.ReferenceKey())
+		}
+	}
+	t.Fatal("no top X-edge found")
+	return ""
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -71,7 +71,8 @@ type FeatureData struct {
 	DerivedPart     *DerivedPartData     `yaml:"derivedPart,omitempty"`
 	Shrinkwrap      *ShrinkwrapData      `yaml:"shrinkwrap,omitempty"`
 
-	SheetMetalFace *SheetMetalFaceData `yaml:"sheetMetalFace,omitempty"` // M13-F02
+	SheetMetalFace   *SheetMetalFaceData   `yaml:"sheetMetalFace,omitempty"`   // M13-F02
+	SheetMetalFlange *SheetMetalFlangeData `yaml:"sheetMetalFlange,omitempty"` // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -269,6 +270,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalFace = sm
+	case *SheetMetalFlangeFeature:
+		fd.SheetMetalFlange = serializeSheetMetalFlange(f.def)
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -458,6 +461,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreBend(fs, fd.Bend, sk)
 	case "sheet-metal-face":
 		return restoreSheetMetalFace(fs, fd.SheetMetalFace, sk)
+	case "sheet-metal-flange":
+		return restoreSheetMetalFlange(fs, fd.SheetMetalFlange)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_flange.go
+++ b/model/feature/serialize_sheet_metal_flange.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalFlangeData is the serialized form of a SheetMetalFlangeFeature: the picked edge
+// (base64 reference key), the flange height, and the optional bend angle/radius (0 ⇒ default
+// 90° / the rule's bend radius). Thickness is not stored — it is read live from the rule.
+type SheetMetalFlangeData struct {
+	Edge   string  `yaml:"edge"`
+	Height float64 `yaml:"height"`
+	Angle  float64 `yaml:"angle,omitempty"`  // 0 ⇒ 90° default
+	Radius float64 `yaml:"radius,omitempty"` // 0 ⇒ use the rule's bend radius
+	Flip   bool    `yaml:"flip,omitempty"`
+}
+
+// serializeSheetMetalFlange projects a flange recipe to its persisted form, freezing the
+// height/angle/radius closures to their current values.
+func serializeSheetMetalFlange(def *SheetMetalFlangeDefinition) *SheetMetalFlangeData {
+	return &SheetMetalFlangeData{
+		Edge:   encodeKey(def.EdgeKey),
+		Height: evalFloat(def.Height),
+		Angle:  evalFloat(def.Angle),
+		Radius: evalFloat(def.Radius),
+		Flip:   def.Flip,
+	}
+}
+
+// restoreSheetMetalFlange rebuilds a flange feature, erroring on a missing payload or an
+// undecodable edge key. A zero angle/radius restores as nil (default 90° / rule radius).
+func restoreSheetMetalFlange(fs *PartFeatures, d *SheetMetalFlangeData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal flange feature is missing its payload")
+	}
+	key, err := decodeKey(d.Edge)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal flange edge key: %w", err)
+	}
+	def := &SheetMetalFlangeDefinition{
+		EdgeKey: key,
+		Height:  constFloat(d.Height),
+		Flip:    d.Flip,
+	}
+	if d.Angle != 0 {
+		def.Angle = constFloat(d.Angle)
+	}
+	if d.Radius != 0 {
+		def.Radius = constFloat(d.Radius)
+	}
+	return NewSheetMetalFlangeFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// Sheet-metal Flange feature (M13-F02). A flange adds a wall on a straight edge of an
+// existing sheet, folded up over a cylindrical bend. The wall and its bend are built as one
+// solid — the bend+wall CROSS-SECTION (a constant-thickness band: a faceted inner arc of the
+// bend radius, an outer arc of radius+thickness, then a straight run for the flange height)
+// extruded along the picked edge — then unioned onto the sheet. Thickness and the default
+// bend radius come from the active rule (read live from the part's parameters), so a gauge or
+// radius edit repropagates here like every other wall.
+
+// flangeBendParamName is the rule's default bend-radius parameter (compdef seeds it). Dup'd
+// here so the feature engine reads it without importing compdef.
+const flangeBendParamName = "BendRadius"
+
+// flangeFacetStep caps the bend arc's facet size (~10°) — the same smoothness/face-count
+// trade the part bend uses.
+const flangeFacetStep = stdmath.Pi / 18
+
+// SheetMetalFlangeDefinition is the flange recipe: the edge to flange from, the flange height
+// and bend angle (parameter-backed closures), an optional bend-radius override (nil ⇒ the
+// rule's BendRadius), and a flip that folds to the opposite side of the sheet.
+type SheetMetalFlangeDefinition struct {
+	EdgeKey []byte
+	Height  func() float64
+	Angle   func() float64 // bend angle (radians); nil ⇒ 90°
+	Radius  func() float64 // inside bend radius; nil ⇒ rule BendRadius
+	Flip    bool
+}
+
+// SheetMetalFlangeFeature folds a wall onto the sheet each recompute.
+type SheetMetalFlangeFeature struct {
+	def      *SheetMetalFlangeDefinition
+	featName string
+}
+
+// Definition returns the flange recipe.
+func (f *SheetMetalFlangeFeature) Definition() *SheetMetalFlangeDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalFlangeFeature) Kind() string { return "sheet-metal-flange" }
+
+// Recompute resolves the edge, builds the bend+wall solid at the rule gauge, and unions it
+// onto the running sheet.
+func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal flange")
+	if err != nil {
+		return Output{}, err
+	}
+	dims, err := f.resolveDims(in.Params)
+	if err != nil {
+		return Output{}, err
+	}
+	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	if err != nil {
+		return Output{}, err
+	}
+	wall, err := buildFlangeSolid(edges[0], dims.thickness, dims.radius, dims.height, dims.angle, f.def.Flip, f.featName)
+	if err != nil {
+		return Output{}, err
+	}
+	// Union the wall onto the sheet (combine planarizes both before the planar boolean).
+	bodies, err := combine(in.Bodies, wall, ops.Join)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// flangeDims is the resolved, validated set of flange dimensions for one recompute.
+type flangeDims struct{ thickness, radius, height, angle float64 }
+
+// resolveDims reads the live thickness, the bend radius (override or rule), the height, and
+// the angle, erroring if any is non-positive.
+func (f *SheetMetalFlangeFeature) resolveDims(ps *param.Parameters) (flangeDims, error) {
+	t, err := sheetThickness(ps)
+	if err != nil {
+		return flangeDims{}, err
+	}
+	d := flangeDims{thickness: t, radius: f.resolveRadius(ps), height: evalFloat(f.def.Height), angle: f.resolveAngle()}
+	if d.radius <= 0 || d.height <= 0 || d.angle <= 0 {
+		return flangeDims{}, fmt.Errorf("sheet-metal flange: radius/height/angle must be positive (r=%g h=%g a=%g)", d.radius, d.height, d.angle)
+	}
+	return d, nil
+}
+
+// resolveRadius returns the bend radius: the override closure, else the rule's BendRadius
+// parameter, else 0 (which Recompute rejects).
+func (f *SheetMetalFlangeFeature) resolveRadius(ps *param.Parameters) float64 {
+	if f.def.Radius != nil {
+		return f.def.Radius()
+	}
+	if ps != nil {
+		if p, ok := ps.ByName(flangeBendParamName); ok {
+			return p.ModelValue()
+		}
+	}
+	return 0
+}
+
+// resolveAngle returns the bend angle, defaulting to a 90° fold.
+func (f *SheetMetalFlangeFeature) resolveAngle() float64 {
+	if f.def.Angle == nil {
+		return stdmath.Pi / 2
+	}
+	return f.def.Angle()
+}
+
+// buildFlangeSolid constructs the bend+wall solid on edge: the cross-section band extruded
+// along the edge. up is the parent face's outward normal (the fold-toward side); out is the
+// in-plane direction away from the sheet. flip folds toward the opposite face.
+func buildFlangeSolid(edge *topo.Edge, thickness, radius, height, angle float64, flip bool, feat string) (*topo.Body, error) {
+	v0, v1 := edge.StartVertex().Point(), edge.EndVertex().Point()
+	e, err := math.UnitVector3FromVector(v0.VectorTo(v1))
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal flange: degenerate edge")
+	}
+	up, out, err := flangeFrame(edge, v0.Midpoint(v1), e, flip)
+	if err != nil {
+		return nil, err
+	}
+	plane := planePerp(v0, e)
+	u, v := plane.XAxis().AsVector(), plane.YAxis().AsVector()
+	proj := func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) }
+	poly := flangeBandPolygon(out.AsVector(), up.AsVector(), thickness, radius, height, angle, proj)
+	return buildPrism(poly, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), nil
+}
+
+// flangeFrame returns the parent face's outward normal (up) and the in-plane outward
+// direction (out, away from the sheet) for the edge. The parent face is the larger of the
+// two faces the edge bounds (the wide sheet face, not the thin side). flip negates up.
+func flangeFrame(edge *topo.Edge, mid math.Point3, e math.UnitVector3, flip bool) (up, out math.UnitVector3, err error) {
+	faces := edge.Faces()
+	if len(faces) != 2 {
+		return up, out, fmt.Errorf("sheet-metal flange: edge bounds %d faces, need 2", len(faces))
+	}
+	parent := widerFace(faces[0], faces[1])
+	pts := faceVertexPoints(parent)
+	n := faceNormal(parent, pts)
+	if parent.Reversed() {
+		n = n.Negate()
+	}
+	outward := interiorDir(parent, mid, e) // points INTO the sheet
+	o, err := math.UnitVector3FromVector(outward.Negate())
+	if err != nil {
+		return up, out, fmt.Errorf("sheet-metal flange: cannot orient against the edge")
+	}
+	if flip {
+		n = n.Negate()
+	}
+	return n, o, nil
+}
+
+// widerFace returns the face with the larger boundary area (the wide sheet face vs the thin
+// edge side).
+func widerFace(a, b *topo.Face) *topo.Face {
+	if polygonArea3(faceVertexPoints(a)) >= polygonArea3(faceVertexPoints(b)) {
+		return a
+	}
+	return b
+}
+
+// flangeBandPolygon returns the bend+wall cross-section as a closed 2D polygon in the section
+// plane (projected via proj). The inner arc has radius r about a centre offset up·r from the
+// edge; the outer arc has radius r+t; after the bend the wall runs straight for height h. The
+// loop is ordered inner-arc → inner-wall-end → outer-wall-end → outer-arc(reversed).
+func flangeBandPolygon(out, up math.Vector3, t, r, h, angle float64, proj func(math.Vector3) math.Point2) []math.Point2 {
+	centre := up.Scale(r) // bend-axis centre, relative to the edge origin
+	dir := func(phi float64) math.Vector3 {
+		return up.Scale(-stdmath.Cos(phi)).Add(out.Scale(stdmath.Sin(phi)))
+	}
+	steps := int(stdmath.Max(2, stdmath.Round(angle/flangeFacetStep)))
+	inner := make([]math.Point2, 0, steps+1)
+	outer := make([]math.Point2, 0, steps+1)
+	for k := 0; k <= steps; k++ {
+		phi := angle * float64(k) / float64(steps)
+		d := dir(phi)
+		inner = append(inner, proj(centre.Add(d.Scale(r))))
+		outer = append(outer, proj(centre.Add(d.Scale(r+t))))
+	}
+	wall := out.Scale(stdmath.Cos(angle)).Add(up.Scale(stdmath.Sin(angle))).Scale(h) // straight-run offset
+	innerEnd := proj(centre.Add(dir(angle).Scale(r)).Add(wall))
+	outerEnd := proj(centre.Add(dir(angle).Scale(r + t)).Add(wall))
+
+	poly := append([]math.Point2(nil), inner...) // inner arc, edge → bend end
+	poly = append(poly, innerEnd, outerEnd)      // across the wall's far end
+	for k := len(outer) - 1; k >= 0; k-- {       // outer arc back, bend end → edge
+		poly = append(poly, outer[k])
+	}
+	return poly
+}
+
+// polygonArea3 returns the area of a planar polygon in 3D (Newell's method).
+func polygonArea3(pts []math.Point3) float64 {
+	if len(pts) < 3 {
+		return 0
+	}
+	var n math.Vector3
+	for i := range pts {
+		a, b := pts[i], pts[(i+1)%len(pts)]
+		n = n.Add(math.V3(
+			(a.Y-b.Y)*(a.Z+b.Z),
+			(a.Z-b.Z)*(a.X+b.X),
+			(a.X-b.X)*(a.Y+b.Y),
+		))
+	}
+	return n.Length() / 2
+}
+
+// SheetMetalFlangeFeatures adds flange features into the engine.
+type SheetMetalFlangeFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalFlangeFeatures binds the collection to a feature engine.
+func NewSheetMetalFlangeFeatures(engine *PartFeatures) *SheetMetalFlangeFeatures {
+	return &SheetMetalFlangeFeatures{engine}
+}
+
+// Add appends a flange feature, naming it Flange1, Flange2, … .
+func (c *SheetMetalFlangeFeatures) Add(def *SheetMetalFlangeDefinition) *PartFeature {
+	f := &SheetMetalFlangeFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Flange"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalFlangeFeature)(nil)

--- a/model/feature/sheet_metal_flange_test.go
+++ b/model/feature/sheet_metal_flange_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// sheetWithFlange builds a square sheet (side cm, thickness 2 mm) then flanges its highest +Y
+// boundary edge up 90° over the given radius/height. It returns the engine's result bodies.
+func sheetWithFlange(t *testing.T, side, radiusCm, heightCm float64) []*topo.Body {
+	t.Helper()
+	ps := param.NewParameters()
+	if _, err := ps.AddUserParameter("Thickness", "2 mm"); err != nil {
+		t.Fatalf("Thickness: %v", err)
+	}
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(side), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+
+	edge := topEdgeAlongX(t, fs.Result()[0])
+	NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(),
+		Height:  func() float64 { return heightCm },
+		Radius:  func() float64 { return radiusCm },
+		Angle:   func() float64 { return math.Pi / 2 }, // explicit 90° (override path)
+	})
+	fs.Recompute()
+	return fs.Result()
+}
+
+// topEdgeAlongX returns a boundary edge of the body that runs in X at the top face (max Z) —
+// a deterministic edge to flange from.
+func topEdgeAlongX(t *testing.T, body *topo.Body) *topo.Edge {
+	t.Helper()
+	maxZ := math.Inf(-1)
+	for _, e := range body.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		alongX := math.Abs(a.X-b.X) > 1e-6 && math.Abs(a.Y-b.Y) < 1e-6 && math.Abs(a.Z-b.Z) < 1e-6
+		if alongX && math.Abs(a.Z-maxZ) < 1e-6 {
+			return e
+		}
+	}
+	t.Fatal("no X-aligned top edge found on the sheet")
+	return nil
+}
+
+// TestFlangeBuildsWatertightSolid the flange unions onto the sheet as one valid, watertight
+// solid whose volume is the sheet plus the developed bend+wall band.
+func TestFlangeBuildsWatertightSolid(t *testing.T) {
+	const side, r, h, th = 4.0, 0.2, 1.0, 0.2
+	bodies := sheetWithFlange(t, side, r, h)
+	if len(bodies) != 1 {
+		t.Fatalf("flange produced %d bodies, want 1 merged sheet", len(bodies))
+	}
+	body := bodies[0]
+	if !body.IsSolid() {
+		t.Fatal("flanged sheet is not a solid")
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("flanged sheet has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if res := ops.Validate(body); !res.Valid {
+		t.Fatalf("flanged sheet failed validation: %+v", res)
+	}
+
+	// Volume ≈ sheet + flange band swept along the edge. The faceted arc under-fills the true
+	// arc band slightly, so allow a few percent.
+	sheetVol := side * side * th
+	bandArea := (math.Pi/2)*th*(r+th/2) + h*th // arc band + straight band
+	want := sheetVol + bandArea*side
+	got := ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-4}).Volume
+	if math.Abs(got-want)/want > 0.03 {
+		t.Errorf("flanged volume = %.4f cm³, want ~%.4f (±3%%)", got, want)
+	}
+}
+
+// TestFlangeRisesAboveSheet the flange folds up — the body extends well above the flat
+// sheet's thickness in +Z.
+func TestFlangeRisesAboveSheet(t *testing.T) {
+	const side, r, h = 4.0, 0.2, 1.0
+	body := sheetWithFlange(t, side, r, h)[0]
+	maxZ := math.Inf(-1)
+	for _, v := range body.Vertices() {
+		if z := v.Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	// A 90° flange of height 1 cm over a 2 mm sheet rises to roughly r+t+h ≈ 1.4 cm.
+	if maxZ < 1.0 {
+		t.Errorf("flange top Z = %.3f cm, want it to rise (≳1 cm) above the flat sheet", maxZ)
+	}
+	_ = gmath.P2 // keep gmath referenced for future fixtures
+}
+
+// TestFlangeDefaultsAndFlip a flange with no radius override reads the rule's BendRadius
+// parameter, the default 90° angle applies, and flip folds the wall to the opposite (−Z)
+// side. Also exercises the Definition accessor.
+func TestFlangeDefaultsAndFlip(t *testing.T) {
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	mustParam(t, ps, "BendRadius", "2 mm") // the rule's default radius the flange should read
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+
+	edge := topEdgeAlongX(t, fs.Result()[0])
+	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(),
+		Height:  func() float64 { return 1.0 },
+		Flip:    true, // no Radius/Angle ⇒ rule radius + 90° default
+	})
+	if pf.Definition().(*SheetMetalFlangeFeature).Definition().EdgeKey == nil {
+		t.Fatal("Definition() lost the edge key")
+	}
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("flipped flange sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("flipped flange has %d boundary edges, want watertight", len(open))
+	}
+	// Flip folds toward −Z (below the sheet): the body should dip well below 0.
+	minZ := 0.0
+	for _, v := range body.Vertices() {
+		if z := v.Point().Z; z < minZ {
+			minZ = z
+		}
+	}
+	if minZ > -0.5 {
+		t.Errorf("flipped flange min Z = %.3f, want it to fold below the sheet (≲−0.5)", minZ)
+	}
+}
+
+func mustParam(t *testing.T, ps *param.Parameters, name, expr string) {
+	t.Helper()
+	if _, err := ps.AddUserParameter(name, expr); err != nil {
+		t.Fatalf("add %s: %v", name, err)
+	}
+}
+
+// TestFlangeRejectsBadDims a flange with a non-positive height (and no Thickness parameter)
+// goes sick rather than building degenerate geometry.
+func TestFlangeRejectsBadDims(t *testing.T) {
+	const side, r = 4.0, 0.2
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(side), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+	edge := topEdgeAlongX(t, fs.Result()[0])
+	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(),
+		Height:  func() float64 { return 0 }, // zero height
+		Radius:  func() float64 { return r },
+	})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("zero-height flange should be sick")
+	}
+}
+
+// TestFlangeRoundTrip the flange recipe (edge key + height + angle + radius + flip) marshals
+// and restores, preserving the kind and payload; a 0 angle/radius restores as the defaults.
+func TestFlangeRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: []byte("edge-key"),
+		Height:  func() float64 { return 1.5 },
+		Angle:   func() float64 { return math.Pi / 3 },
+		Radius:  func() float64 { return 0.3 },
+		Flip:    true,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalFlange
+	if data[0].Kind != "sheet-metal-flange" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-flange", data[0])
+	}
+	if d.Height != 1.5 || math.Abs(d.Angle-math.Pi/3) > 1e-9 || d.Radius != 0.3 || !d.Flip {
+		t.Errorf("payload = %+v, want height 1.5 / angle π/3 / radius 0.3 / flip", d)
+	}
+
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-flange" {
+		t.Errorf("restored = %d features, want one flange", fresh.Count())
+	}
+}
+
+// TestFlangeMissingPayload restoring a flange record with no payload errors.
+func TestFlangeMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalFlange(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreSheetMetalFlange(nil) must error")
+	}
+}


### PR DESCRIPTION
## What

The **Flange** — fold a wall onto a straight sheet edge over a cylindrical bend. The first *bend* feature of M13, building on the base Face (#919, merged).

**Geometry.** The bend+wall is built as one solid by constructing its constant-thickness **cross-section band** — a faceted inner arc of the bend radius, an outer arc of radius+thickness through the bend angle, then a straight run for the flange height — and extruding that 2D band along the picked edge, then unioning it onto the sheet. This reuses the proven faceted-arc + prism + planar-boolean machinery rather than new kernel code. The band's start segment is exactly the sheet's edge cross-section, so the union is watertight.

Thickness and the default bend radius come from the active rule (read live from the part's `Thickness`/`BendRadius` parameters), so a gauge/radius edit repropagates here like every wall. Height and bend angle (default 90°) are parameter-backed; an optional radius override and a `flip` (fold to the opposite side) round out the recipe, which round-trips.

- **model/feature** — `SheetMetalFlangeDefinition`/`Feature` (+ band geometry, Newell area to pick the parent face), recipe codec.
- **addin/opregistry** — the `sheetMetalFlange` operation (edge + height + optional angle/radius/flip), registered + covered by the descriptor/args guards.

## Test
Watertight valid solid with **volume = sheet + developed band (±3%)**; the flange rises above the sheet and `flip` folds it below; rule-radius default, 90° default, bad-dims → sick; recipe round-trip; over-the-wire add + error paths. Per-package coverage 88% (model) / 84% (opreg); lint 0.

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> Adds `sheetMetalFlange` to the source feature registry — the bridge's `TestE2EFeatureRegistryCoverage` will need it (with `sheetMetalFace`) in a follow-up bridge PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)