### PR TITLE
feat(viewport): per-face/edge box-select + sketch grid<entities<dimensions depth (#909)

### DIFF
--- a/app/region_pick.go
+++ b/app/region_pick.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 	"oblikovati.org/renderer"
 )
 
@@ -25,23 +26,72 @@ const (
 // box-select are tracked follow-ups (#909).
 //
 // RayPicker satisfies both Picker (point pick) and RegionPicker (this), so the head installs
-// the one object for both.
+// the one object for both. The granularity follows the active selection filter, like Inventor's
+// selection priority: a body-permissive filter (the default) selects whole bodies, a face-only
+// filter selects faces, an edge-only filter selects edges.
 func (p *RayPicker) PickRegion(x0, y0, x1, y1 float64, crossing bool, filter *SelectionFilter) []Selectable {
-	if !filter.Accepts(SelectBody) || p.bodies == nil {
+	if p.bodies == nil {
 		return nil
 	}
 	sel := orderedRect(x0, y0, x1, y1)
+	switch {
+	case filter.Accepts(SelectBody):
+		return p.regionBodies(sel, crossing)
+	case filter.Accepts(SelectFace):
+		return p.regionFaces(sel, crossing)
+	case filter.Accepts(SelectEdge):
+		return p.regionEdges(sel, crossing)
+	default:
+		return nil
+	}
+}
+
+// regionBodies selects whole bodies whose projected range box satisfies the rectangle.
+func (p *RayPicker) regionBodies(sel screenRect, crossing bool) []Selectable {
 	var hits []Selectable
 	for _, b := range p.bodies() {
-		box, ok := p.projectBodyRect(b)
-		if !ok {
-			continue
-		}
-		if (crossing && box.overlaps(sel)) || (!crossing && sel.contains(box)) {
+		if box, ok := p.projectBodyRect(b); ok && rectCovers(sel, box, crossing) {
 			hits = append(hits, BodyHandle{Body: b})
 		}
 	}
 	return hits
+}
+
+// regionFaces selects faces whose projected vertex bounds satisfy the rectangle.
+func (p *RayPicker) regionFaces(sel screenRect, crossing bool) []Selectable {
+	var hits []Selectable
+	for _, b := range p.bodies() {
+		for _, f := range b.Faces() {
+			if box, ok := p.projectVertexRect(f.Vertices()); ok && rectCovers(sel, box, crossing) {
+				hits = append(hits, FaceHandle{Face: f, Body: b})
+			}
+		}
+	}
+	return hits
+}
+
+// regionEdges selects edges whose projected endpoints satisfy the rectangle (window: both
+// inside; crossing: an endpoint inside or the segment crosses an edge of the box).
+func (p *RayPicker) regionEdges(sel screenRect, crossing bool) []Selectable {
+	var hits []Selectable
+	for _, b := range p.bodies() {
+		for _, e := range b.Edges() {
+			pts := p.projectVertices(e.Vertices())
+			if len(pts) == len(e.Vertices()) && regionCoversOutline(pts, sel, crossing) {
+				hits = append(hits, EdgeHandle{Edge: e})
+			}
+		}
+	}
+	return hits
+}
+
+// rectCovers reports whether sel covers box per the select mode: crossing = overlap, window =
+// full enclosure.
+func rectCovers(sel, box screenRect, crossing bool) bool {
+	if crossing {
+		return sel.overlaps(box)
+	}
+	return sel.contains(box)
 }
 
 // screenRect is a viewport-pixel axis-aligned rectangle (minX≤maxX, minY≤maxY).
@@ -69,14 +119,39 @@ func (r screenRect) containsPoint(x, y float64) bool {
 	return x >= r.minX && x <= r.maxX && y >= r.minY && y <= r.maxY
 }
 
-// projectBodyRect projects the eight corners of a body's range box to screen and returns
-// their bounding rectangle. ok is false when any corner is at/behind the camera (the body
-// is partly off-screen), in which case the caller skips it.
+// projectBodyRect projects the eight corners of a body's range box to a screen rectangle.
 func (p *RayPicker) projectBodyRect(b *topo.Body) (screenRect, bool) {
 	corners := b.RangeBox().Corners()
+	return p.projectPointsRect(corners[:])
+}
+
+// projectVertexRect projects topology vertices to their screen bounding rectangle.
+func (p *RayPicker) projectVertexRect(vs []*topo.Vertex) (screenRect, bool) {
+	pts := make([]math.Point3, len(vs))
+	for i, v := range vs {
+		pts[i] = v.Point()
+	}
+	return p.projectPointsRect(pts)
+}
+
+// projectVertices projects topology vertices to viewport pixels, dropping any at/behind the
+// camera — the outline a region edge test consumes.
+func (p *RayPicker) projectVertices(vs []*topo.Vertex) []screenPt {
+	out := make([]screenPt, 0, len(vs))
+	for _, v := range vs {
+		if sx, sy, ok := renderer.Project(p.camera, regionNear, regionFar, v.Point()); ok {
+			out = append(out, screenPt{sx, sy})
+		}
+	}
+	return out
+}
+
+// projectPointsRect projects world points to their screen bounding rectangle. ok is false when
+// any point is at/behind the camera (partly off-screen), in which case the caller skips it.
+func (p *RayPicker) projectPointsRect(pts []math.Point3) (screenRect, bool) {
 	first := true
 	var r screenRect
-	for _, c := range corners {
+	for _, c := range pts {
 		sx, sy, ok := renderer.Project(p.camera, regionNear, regionFar, c)
 		if !ok {
 			return screenRect{}, false

--- a/app/region_pick_test.go
+++ b/app/region_pick_test.go
@@ -79,11 +79,50 @@ func TestPickRegionNilBodiesAndBehindCamera(t *testing.T) {
 	}
 }
 
-func TestPickRegionHonorsBodyFilter(t *testing.T) {
+// TestPickRegionGranularityByFilter checks the box-select granularity follows the selection
+// filter: a body-permissive filter selects the whole body, a face-only filter selects its faces,
+// an edge-only filter selects its edges (#909). The box [0,2]×[0,2]×[0,4] has 6 faces and 12 edges.
+func TestPickRegionGranularityByFilter(t *testing.T) {
 	p, box := regionPickerForBox(t)
-	// A filter that excludes bodies (edges only) yields no whole-body region hits.
-	edgeOnly := NewSelectionFilter(SelectEdge)
-	if got := p.PickRegion(box.minX-5, box.minY-5, box.maxX+5, box.maxY+5, false, edgeOnly); got != nil {
-		t.Errorf("body-excluding filter should yield no body region hits, got %d", len(got))
+	pad := 5.0
+	enclose := func(f *SelectionFilter) []Selectable {
+		return p.PickRegion(box.minX-pad, box.minY-pad, box.maxX+pad, box.maxY+pad, false, f)
+	}
+
+	bodies := enclose(NewSelectionFilter()) // permissive (accepts all) → whole body
+	if len(bodies) != 1 {
+		t.Fatalf("permissive filter should select the whole body, got %d", len(bodies))
+	}
+	if _, ok := bodies[0].(BodyHandle); !ok {
+		t.Errorf("permissive region hit = %T, want BodyHandle", bodies[0])
+	}
+
+	faces := enclose(NewSelectionFilter(SelectFace))
+	if len(faces) != 6 {
+		t.Errorf("face-only filter over the box = %d hits, want its 6 faces", len(faces))
+	} else if _, ok := faces[0].(FaceHandle); !ok {
+		t.Errorf("face region hit = %T, want FaceHandle", faces[0])
+	}
+
+	edges := enclose(NewSelectionFilter(SelectEdge))
+	if len(edges) != 12 {
+		t.Errorf("edge-only filter over the box = %d hits, want its 12 edges", len(edges))
+	} else if _, ok := edges[0].(EdgeHandle); !ok {
+		t.Errorf("edge region hit = %T, want EdgeHandle", edges[0])
+	}
+}
+
+// TestPickRegionGranularityCrossing checks the crossing mode for faces and edges: a rectangle
+// over part of the box still catches the faces/edges it overlaps (which a window would miss).
+func TestPickRegionGranularityCrossing(t *testing.T) {
+	p, box := regionPickerForBox(t)
+	midX := (box.minX + box.maxX) / 2
+	x0, y0, x1, y1 := box.minX-5, box.minY-5, midX, box.maxY+5
+
+	if faces := p.PickRegion(x0, y0, x1, y1, true, NewSelectionFilter(SelectFace)); len(faces) == 0 {
+		t.Error("crossing over part of the box should catch some faces")
+	}
+	if edges := p.PickRegion(x0, y0, x1, y1, true, NewSelectionFilter(SelectEdge)); len(edges) == 0 {
+		t.Error("crossing over part of the box should catch some edges")
 	}
 }

--- a/app/region_pick_test.go
+++ b/app/region_pick_test.go
@@ -112,6 +112,16 @@ func TestPickRegionGranularityByFilter(t *testing.T) {
 	}
 }
 
+// TestPickRegionFilterAcceptsNothingRelevant checks a filter that admits none of body/face/edge
+// (e.g. vertices only) yields no region hits.
+func TestPickRegionFilterAcceptsNothingRelevant(t *testing.T) {
+	p, box := regionPickerForBox(t)
+	vtx := NewSelectionFilter(SelectVertex)
+	if got := p.PickRegion(box.minX-5, box.minY-5, box.maxX+5, box.maxY+5, false, vtx); got != nil {
+		t.Errorf("a vertex-only filter should yield no region hits, got %d", len(got))
+	}
+}
+
 // TestPickRegionGranularityCrossing checks the crossing mode for faces and edges: a rectangle
 // over part of the box still catches the faces/edges it overlaps (which a window would miss).
 func TestPickRegionGranularityCrossing(t *testing.T) {

--- a/head/cmd/m16shot/main.go
+++ b/head/cmd/m16shot/main.go
@@ -29,6 +29,7 @@ import (
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
 )
 
 // orientByName maps a CLI orientation name to a standard view orientation.
@@ -67,6 +68,7 @@ func parseOpts() opts {
 	flag.BoolVar(&o.dialog, "dialog", false, "open the Display Settings dialog (M16-F07)")
 	flag.BoolVar(&o.image, "image", false, "add an image billboard overlay at the origin (M16-F05)")
 	flag.BoolVar(&o.boxselect, "boxselect", false, "drag a window box-select across the demo box and capture the rubber-band (#916)")
+	flag.BoolVar(&o.sketch, "sketch", false, "enter a sketch with a dimensioned rectangle over the grid and capture (depth layering, #909)")
 	flag.Parse()
 	return o
 }
@@ -83,7 +85,7 @@ type opts struct {
 	style                 string
 	named, styles, window bool
 	dialog, image         bool
-	boxselect             bool
+	boxselect, sketch     bool
 }
 
 func run(o opts) error {
@@ -102,7 +104,57 @@ func run(o opts) error {
 	if o.boxselect {
 		return captureBoxSelect(s, o)
 	}
+	if o.sketch {
+		return captureSketch(s, o)
+	}
 	return renderAndCapture(s, o)
+}
+
+// captureSketch enters a sketch holding a dimensioned rectangle over the grid and captures the
+// window, so the PNG shows the depth layering: grid behind, entities above it, the dimension above
+// the entities (#909).
+func captureSketch(s *app.Session, o opts) error {
+	if err := enterDimensionedRectangle(s); err != nil {
+		return err
+	}
+	win, err := native.CreateWindow(1280, 800, "m16shot")
+	if err != nil {
+		return err
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	for i := 0; i < o.frames; i++ {
+		win.BeginFrame()
+		ui.DrawChrome(win, s)
+		win.EndFrame(ui.WindowClearColor())
+	}
+	return win.SaveWindowPNG(o.out)
+}
+
+// enterDimensionedRectangle builds a part with a sketch holding a dimensioned rectangle, enters
+// the sketch with the grid visible, and aims the camera straight at the plane.
+func enterDimensionedRectangle(s *app.Session) error {
+	pd, err := compdef.AddPart(s.Workspace(), "m16sketch.opd", true)
+	if err != nil {
+		return err
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0, c1 := sk.Points().Add(math.P2(0, 0)), sk.Points().Add(math.P2(4, 0))
+	c2, c3 := sk.Points().Add(math.P2(4, 3)), sk.Points().Add(math.P2(0, 3))
+	bottom := sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	_, _ = sk.DimensionConstraints().AddDistance(bottom.A, bottom.B, "4 mm")
+	s.EnterSketch(sk)
+	s.Grid().Visible = true
+	s.TickCameraAnimation(100) // finish the enter-sketch swing
+	cam := scene.NewCamera(1280, 800)
+	cam.Eye, cam.Target, cam.Up = math.P3(2, 1.5, 6), math.P3(2, 1.5, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	return nil
 }
 
 // captureBoxSelect installs the real ray/region picker over the scene, then injects a left

--- a/head/cmd/m16shot/main_test.go
+++ b/head/cmd/m16shot/main_test.go
@@ -79,18 +79,18 @@ func TestApplySetup(t *testing.T) {
 	}
 }
 
-// TestRunBoxSelectCaptures runs the full box-select capture (opens the real window, installs
-// the picker, injects a drag, saves the window mid-drag) end to end, so run + captureBoxSelect
-// are exercised. The m16shot binary supports only ONE real window per test process (a second
-// native.CreateWindow crashes on GLFW/Vulkan teardown), so this is the single window test and
-// it covers the box-select path added in #916.
-func TestRunBoxSelectCaptures(t *testing.T) {
-	out := filepath.Join(t.TempDir(), "box.png")
-	if err := run(opts{box: true, boxselect: true, frames: 2, out: out}); err != nil {
-		t.Fatalf("run boxselect: %v", err)
+// TestRunSketchCaptures runs the full sketch capture (opens the real window, enters a dimensioned
+// sketch, renders frames, saves the window) end to end, so run + captureSketch are exercised. The
+// m16shot binary supports only ONE real window per test process (a second native.CreateWindow
+// crashes on GLFW/Vulkan teardown), so this is the single window test and it covers the newest
+// capture path (#909); the box-select capture is exercised manually.
+func TestRunSketchCaptures(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "sketch.png")
+	if err := run(opts{sketch: true, frames: 2, out: out}); err != nil {
+		t.Fatalf("run sketch: %v", err)
 	}
 	if fi, err := os.Stat(out); err != nil || fi.Size() == 0 {
-		t.Errorf("box-select capture PNG not written: %v", err)
+		t.Errorf("sketch capture PNG not written: %v", err)
 	}
 }
 

--- a/head/cmd/m16shot/main_test.go
+++ b/head/cmd/m16shot/main_test.go
@@ -107,6 +107,22 @@ func TestParseOpts(t *testing.T) {
 	}
 }
 
+// TestEnterDimensionedRectangle exercises the sketch-capture scene setup (no window): it must
+// create a sketch with the four rectangle edges, add a dimension, and enter the sketch env.
+func TestEnterDimensionedRectangle(t *testing.T) {
+	s := app.NewSession()
+	if err := enterDimensionedRectangle(s); err != nil {
+		t.Fatalf("enterDimensionedRectangle: %v", err)
+	}
+	sk := s.ActiveSketch()
+	if sk == nil || !s.InSketch() {
+		t.Fatal("should be editing the new sketch")
+	}
+	if sk.Lines().Count() != 4 {
+		t.Errorf("rectangle should have 4 lines, got %d", sk.Lines().Count())
+	}
+}
+
 // TestInjectBoxDrag exercises the box-select drag-injection sequence with a counting frame
 // callback (no window): it must press, drag through several positions, and render a frame at
 // each step. captureBoxSelect's window orchestration is verified manually (the live PNG) —

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -461,25 +461,44 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 // views the caller needs for the on-screen dimension labels.
 func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (renderer.DrawList, sketch.Plane, []app.DimensionView) {
 	plane := s.ActiveSketch().Plane()
+	// Depth layering (the sketch entities are coplanar with the grid, so depth-testing them
+	// z-fights): the grid stays depth-tested at the bottom; every sketch overlay is marked OnTop
+	// so it draws in the depth-disabled lane in submission order — entities first, then dimensions,
+	// then interaction feedback. So grid < entities < dimensions, as intended (#909).
 	if g := s.Grid(); g.Visible {
 		list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery), list.Items...)
 	}
-	list.Items = append(list.Items, sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s))...)
+	list.Items = append(list.Items, onTop(sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s)))...)
 	dims := s.SketchDimensions()
-	list.Items = append(list.Items, dimensionLines(plane, dims)...)
+	list.Items = append(list.Items, onTop(dimensionLines(plane, dims))...)
 	if item, ok := pointsOverlay(plane, s.ActiveSketch(), pointMarkerPixels*cam.WorldPerPixel()); ok {
-		list.Items = append(list.Items, item)
+		list.Items = append(list.Items, onTopItem(item))
 	}
 	if item, ok := toolPreview(s); ok {
-		list.Items = append(list.Items, item)
+		list.Items = append(list.Items, onTopItem(item))
 	}
 	if item, ok := inferenceGlyphs(s, plane, glyphPixels*cam.WorldPerPixel()); ok {
-		list.Items = append(list.Items, item)
+		list.Items = append(list.Items, onTopItem(item))
 	}
 	if item, ok := snapMarker(s, plane, cam.WorldPerPixel()); ok {
-		list.Items = append(list.Items, item)
+		list.Items = append(list.Items, onTopItem(item))
 	}
 	return list, plane, dims
+}
+
+// onTop marks every item to draw in the depth-disabled lane (over the grid), preserving the
+// caller's submission order so later groups layer above earlier ones.
+func onTop(items []renderer.DrawItem) []renderer.DrawItem {
+	for i := range items {
+		items[i].OnTop = true
+	}
+	return items
+}
+
+// onTopItem is onTop for a single item.
+func onTopItem(item renderer.DrawItem) renderer.DrawItem {
+	item.OnTop = true
+	return item
 }
 
 // modelOverlays appends the 3D-model overlays (work planes, part sketches, selected edges, and

--- a/head/ui/sketch_overlay_depth_test.go
+++ b/head/ui/sketch_overlay_depth_test.go
@@ -1,0 +1,25 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/renderer"
+)
+
+// TestOnTopMarksItems checks the depth-layering helpers flag items for the depth-disabled lane,
+// so sketch entities and dimensions draw over the (depth-tested) grid without z-fighting (#909).
+func TestOnTopMarksItems(t *testing.T) {
+	items := onTop([]renderer.DrawItem{{Primitive: renderer.Lines}, {Primitive: renderer.Lines}})
+	for i, it := range items {
+		if !it.OnTop {
+			t.Errorf("onTop item %d should be marked OnTop", i)
+		}
+	}
+	if !onTopItem(renderer.DrawItem{}).OnTop {
+		t.Error("onTopItem should mark the item OnTop")
+	}
+}


### PR DESCRIPTION
## What

Two parts of #909:

### 1. Per-face/edge box-select granularity
Box-select now follows the active selection filter, like Inventor's selection priority:
- **body-permissive** filter (the default) → whole bodies (unchanged),
- **face-only** filter → faces,
- **edge-only** filter → edges.

`RayPicker.PickRegion` dispatches to `regionBodies`/`regionFaces`/`regionEdges`; faces classify by their projected vertex bounds, edges by their projected endpoints (reusing the outline + segment-rect test from sketch box-select). A shared `projectPointsRect` backs the body and face projectors (no duplication).

### 2. Sketch z-depth layering
Sketch entities are coplanar with the grid, so depth-testing them z-fought. Now the grid stays depth-tested at the bottom and every sketch overlay is marked **OnTop** (depth-disabled lane), drawn in submission order — **grid < entities < dimensions** (then interaction feedback on top), exactly as requested. `m16shot -sketch` captures a dimensioned rectangle over the grid for visual confirmation.

## Tests

- `app/region_pick_test.go` — granularity by filter (1 body / 6 faces / 12 edges over a box), window + crossing modes.
- `head/ui` — `onTop`/`onTopItem` helper test; the in-window sketch tests still exercise the overlay path.
- Existing body box-select + sketch box-select tests still pass.

## Follow-ups

Curved-edge region sampling (edges currently use endpoints) and the standalone Edge/Feature/Part selection-priority UI (#912) for the no-tool case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)