### PR TITLE
feat: sheet-metal Hem feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -257,6 +257,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"bendPart":            `{}`,
 		"sheetMetalFace":      `{"sketchIndex":0}`,
 		"sheetMetalFlange":    `{"edge":"x","height":"10 mm"}`,
+		"sheetMetalHem":       `{"edge":"x","length":"6 mm"}`,
 		"splitSolid":          `{"toolSketch":0}`,
 		"coreCavity":          `{}`,
 		"hull":                `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -132,6 +132,7 @@ func Default() *Registry {
 		bendPartDescriptor(),
 		sheetMetalFaceDescriptor(),
 		sheetMetalFlangeDescriptor(),
+		sheetMetalHemDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_common.go
+++ b/addin/opregistry/sheet_metal_common.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+)
+
+// activeSheetMetalPart returns the active part, erroring (named by op) when there is none or
+// it is not in the sheet-metal environment. Shared by every sheetMetal* operation so the
+// "is this a sheet-metal part?" guard lives in one place.
+func activeSheetMetalPart(s *app.Session, op string) (*compdef.PartComponentDefinition, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if !part.IsSheetMetal() {
+		return nil, fmt.Errorf("%s: the active part is not a sheet-metal part", op)
+	}
+	return part, nil
+}

--- a/addin/opregistry/sheet_metal_common_test.go
+++ b/addin/opregistry/sheet_metal_common_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+)
+
+// seedSheetMetalSheet builds a sheet-metal part, lays down a base wall, and returns the
+// session plus a top-edge reference key — the common fixture the bend-family operation tests
+// (flange/hem) flange/hem/bend from.
+func seedSheetMetalSheet(t *testing.T) (*app.Session, string) {
+	t.Helper()
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	return s, topEdgeKey(t, def)
+}
+
+// topEdgeKey returns the reference key of a top-face edge of the part's first body — a
+// deterministic edge to fold from.
+func topEdgeKey(t *testing.T, def *compdef.PartComponentDefinition) string {
+	t.Helper()
+	if def.SurfaceBodies().Count() == 0 {
+		t.Fatal("no body to fold")
+	}
+	b := def.SurfaceBodies().Item(0)
+	maxZ := math.Inf(-1)
+	for _, e := range b.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-c.X) > 1e-6 && math.Abs(a.Y-c.Y) < 1e-6 && math.Abs(a.Z-maxZ) < 1e-6 && math.Abs(c.Z-maxZ) < 1e-6 {
+			return string(e.ReferenceKey())
+		}
+	}
+	t.Fatal("no top X-edge found")
+	return ""
+}
+
+// expectMergedSolid decodes a feature-add result and asserts it produced one healthy solid.
+func expectMergedSolid(t *testing.T, out json.RawMessage, what string) {
+	t.Helper()
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("%s: decode: %v", what, err)
+	}
+	if res.Bodies != 1 || !res.Healthy {
+		t.Errorf("%s: bodies=%d healthy=%v, want 1 healthy", what, res.Bodies, res.Healthy)
+	}
+}

--- a/addin/opregistry/sheet_metal_face.go
+++ b/addin/opregistry/sheet_metal_face.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/app"
 	"oblikovati.org/model/feature"
 )
@@ -44,12 +43,9 @@ func sheetMetalFaceDescriptor() *OperationDescriptor {
 }
 
 func applySheetMetalFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	part, err := activeSheetMetalPart(s, "sheetMetalFace")
 	if err != nil {
 		return nil, err
-	}
-	if !part.IsSheetMetal() {
-		return nil, fmt.Errorf("sheetMetalFace: the active part is not a sheet-metal part")
 	}
 	var in sheetMetalFaceArgs
 	if err := json.Unmarshal(raw, &in); err != nil {

--- a/addin/opregistry/sheet_metal_flange.go
+++ b/addin/opregistry/sheet_metal_flange.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -47,12 +46,9 @@ func sheetMetalFlangeDescriptor() *OperationDescriptor {
 }
 
 func applySheetMetalFlange(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	part, err := activeSheetMetalPart(s, "sheetMetalFlange")
 	if err != nil {
 		return nil, err
-	}
-	if !part.IsSheetMetal() {
-		return nil, fmt.Errorf("sheetMetalFlange: the active part is not a sheet-metal part")
 	}
 	var in sheetMetalFlangeArgs
 	if err := json.Unmarshal(raw, &in); err != nil {

--- a/addin/opregistry/sheet_metal_flange_test.go
+++ b/addin/opregistry/sheet_metal_flange_test.go
@@ -2,38 +2,17 @@
 
 package opregistry
 
-import (
-	"encoding/json"
-	"math"
-	"testing"
-
-	"oblikovati.org/model/compdef"
-)
+import "testing"
 
 // TestSheetMetalFlangeApply seeds a sheet-metal wall, flanges a top edge, and confirms one
 // merged solid results; then checks the error paths (non-sheet-metal part, missing edge).
 func TestSheetMetalFlangeApply(t *testing.T) {
-	s := sheetMetalProfiledPart(t)
-	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
-		t.Fatalf("seed face: %v", err)
-	}
-	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
-	edge := topEdgeKey(t, def)
-
+	s, edge := seedSheetMetalSheet(t)
 	out, err := applyMap(t, s, "sheetMetalFlange", map[string]any{"edge": edge, "height": "10 mm", "angle": "90 deg", "radius": "2 mm"})
 	if err != nil {
 		t.Fatalf("flange apply: %v", err)
 	}
-	var res struct {
-		Bodies  int  `json:"bodies"`
-		Healthy bool `json:"healthy"`
-	}
-	if err := json.Unmarshal(out, &res); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if res.Bodies != 1 || !res.Healthy {
-		t.Errorf("flange: bodies=%d healthy=%v, want 1 healthy", res.Bodies, res.Healthy)
-	}
+	expectMergedSolid(t, out, "flange")
 
 	// Error paths.
 	if _, err := apply(t, sheetMetalProfiledPart(t), "sheetMetalFlange", `{"height":"5 mm"}`); err == nil {
@@ -45,28 +24,4 @@ func TestSheetMetalFlangeApply(t *testing.T) {
 	if _, err := applyMap(t, s, "sheetMetalFlange", map[string]any{"edge": edge, "height": "bad"}); err == nil {
 		t.Error("flange with a bad height must error")
 	}
-}
-
-// topEdgeKey returns the reference key of a top-face edge of the part's first body — a
-// deterministic edge to flange from.
-func topEdgeKey(t *testing.T, def *compdef.PartComponentDefinition) string {
-	t.Helper()
-	if def.SurfaceBodies().Count() == 0 {
-		t.Fatal("no body to flange")
-	}
-	b := def.SurfaceBodies().Item(0)
-	maxZ := math.Inf(-1)
-	for _, e := range b.Edges() {
-		if z := e.StartVertex().Point().Z; z > maxZ {
-			maxZ = z
-		}
-	}
-	for _, e := range b.Edges() {
-		a, c := e.StartVertex().Point(), e.EndVertex().Point()
-		if math.Abs(a.X-c.X) > 1e-6 && math.Abs(a.Y-c.Y) < 1e-6 && math.Abs(a.Z-maxZ) < 1e-6 && math.Abs(c.Z-maxZ) < 1e-6 {
-			return string(e.ReferenceKey())
-		}
-	}
-	t.Fatal("no top X-edge found")
-	return ""
 }

--- a/addin/opregistry/sheet_metal_hem.go
+++ b/addin/opregistry/sheet_metal_hem.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -46,12 +45,9 @@ func sheetMetalHemDescriptor() *OperationDescriptor {
 }
 
 func applySheetMetalHem(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
-	part, err := modelaccess.ActivePart(s)
+	part, err := activeSheetMetalPart(s, "sheetMetalHem")
 	if err != nil {
 		return nil, err
-	}
-	if !part.IsSheetMetal() {
-		return nil, fmt.Errorf("sheetMetalHem: the active part is not a sheet-metal part")
 	}
 	var in sheetMetalHemArgs
 	if err := json.Unmarshal(raw, &in); err != nil {

--- a/addin/opregistry/sheet_metal_hem.go
+++ b/addin/opregistry/sheet_metal_hem.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalHemArgs is the argument shape for the "sheetMetalHem" operation: the edge to hem,
+// the hem length, the type (closed|open), and an open hem's gap. Thickness comes from the rule.
+type sheetMetalHemArgs struct {
+	Edge   string `json:"edge"`
+	Length string `json:"length"`
+	Type   string `json:"type,omitempty"` // closed (default) | open
+	Gap    string `json:"gap,omitempty"`  // open-hem loop gap
+	Flip   bool   `json:"flip,omitempty"`
+}
+
+const sheetMetalHemSchema = `{
+  "type": "object",
+  "properties": {
+    "edge": {"type": "string", "description": "Reference key of the straight sheet edge to hem (from get_reference_keys)."},
+    "length": {"type": "string", "description": "How far the folded-back wall runs, e.g. \"6 mm\"."},
+    "type": {"type": "string", "enum": ["closed", "open"], "default": "closed", "description": "closed folds tight (radius ~ t/2); open leaves a rounded loop of the gap."},
+    "gap": {"type": "string", "description": "Open-hem loop gap (radius = gap/2); ignored for a closed hem."},
+    "flip": {"type": "boolean", "default": false, "description": "Fold toward the opposite side of the sheet."}
+  },
+  "required": ["edge", "length"]
+}`
+
+// sheetMetalHemDescriptor is the self-describing "sheetMetalHem" operation: fold a sheet edge
+// back on itself.
+func sheetMetalHemDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalHem",
+		Summary: "Fold a sheet-metal edge back on itself (a hem): closed (tight) or open (a rounded loop of the given gap).",
+		Schema:  json.RawMessage(sheetMetalHemSchema),
+		Apply:   applySheetMetalHem,
+	}
+}
+
+func applySheetMetalHem(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if !part.IsSheetMetal() {
+		return nil, fmt.Errorf("sheetMetalHem: the active part is not a sheet-metal part")
+	}
+	var in sheetMetalHemArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalHem: invalid args: %w", err)
+	}
+	if in.Edge == "" {
+		return nil, fmt.Errorf("sheetMetalHem: edge is required")
+	}
+	def, err := hemDef(part, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewSheetMetalHemFeatures(part.Features()).Add(def))
+}
+
+// hemDef resolves the hem args into a definition: the edge, the length closure, the type, and
+// the optional open-hem gap.
+func hemDef(part *compdef.PartComponentDefinition, in sheetMetalHemArgs) (*feature.SheetMetalHemDefinition, error) {
+	hemType, ok := feature.ParseHemType(in.Type)
+	if !ok {
+		return nil, fmt.Errorf("sheetMetalHem: unknown type %q (want closed or open)", in.Type)
+	}
+	length, err := lengthClosure(part, in.Length, "sheetMetalHem: length")
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalHemDefinition{EdgeKey: []byte(in.Edge), Length: length, Type: hemType, Flip: in.Flip}
+	if in.Gap != "" {
+		gap, err := lengthClosure(part, in.Gap, "sheetMetalHem: gap")
+		if err != nil {
+			return nil, err
+		}
+		def.Gap = gap
+	}
+	return def, nil
+}

--- a/addin/opregistry/sheet_metal_hem_test.go
+++ b/addin/opregistry/sheet_metal_hem_test.go
@@ -2,37 +2,17 @@
 
 package opregistry
 
-import (
-	"encoding/json"
-	"testing"
-
-	"oblikovati.org/model/compdef"
-)
+import "testing"
 
 // TestSheetMetalHemApply seeds a sheet-metal wall, hems a top edge, and confirms one merged
 // solid results; then checks the error paths.
 func TestSheetMetalHemApply(t *testing.T) {
-	s := sheetMetalProfiledPart(t)
-	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
-		t.Fatalf("seed face: %v", err)
-	}
-	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
-	edge := topEdgeKey(t, def)
-
+	s, edge := seedSheetMetalSheet(t)
 	out, err := applyMap(t, s, "sheetMetalHem", map[string]any{"edge": edge, "length": "6 mm", "type": "open", "gap": "4 mm"})
 	if err != nil {
 		t.Fatalf("hem apply: %v", err)
 	}
-	var res struct {
-		Bodies  int  `json:"bodies"`
-		Healthy bool `json:"healthy"`
-	}
-	if err := json.Unmarshal(out, &res); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if res.Bodies != 1 || !res.Healthy {
-		t.Errorf("hem: bodies=%d healthy=%v, want 1 healthy", res.Bodies, res.Healthy)
-	}
+	expectMergedSolid(t, out, "hem")
 
 	// Error paths.
 	if _, err := apply(t, sheetMetalProfiledPart(t), "sheetMetalHem", `{"length":"5 mm"}`); err == nil {

--- a/addin/opregistry/sheet_metal_hem_test.go
+++ b/addin/opregistry/sheet_metal_hem_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// TestSheetMetalHemApply seeds a sheet-metal wall, hems a top edge, and confirms one merged
+// solid results; then checks the error paths.
+func TestSheetMetalHemApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	edge := topEdgeKey(t, def)
+
+	out, err := applyMap(t, s, "sheetMetalHem", map[string]any{"edge": edge, "length": "6 mm", "type": "open", "gap": "4 mm"})
+	if err != nil {
+		t.Fatalf("hem apply: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if res.Bodies != 1 || !res.Healthy {
+		t.Errorf("hem: bodies=%d healthy=%v, want 1 healthy", res.Bodies, res.Healthy)
+	}
+
+	// Error paths.
+	if _, err := apply(t, sheetMetalProfiledPart(t), "sheetMetalHem", `{"length":"5 mm"}`); err == nil {
+		t.Error("hem without an edge must error")
+	}
+	if _, err := apply(t, profiledPart(t), "sheetMetalHem", `{"edge":"x","length":"5 mm"}`); err == nil {
+		t.Error("hem on a non-sheet-metal part must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalHem", map[string]any{"edge": edge, "length": "6 mm", "type": "rolled"}); err == nil {
+		t.Error("hem with an unknown type must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalHem", map[string]any{"edge": edge, "length": "bad"}); err == nil {
+		t.Error("hem with a bad length must error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -73,6 +73,7 @@ type FeatureData struct {
 
 	SheetMetalFace   *SheetMetalFaceData   `yaml:"sheetMetalFace,omitempty"`   // M13-F02
 	SheetMetalFlange *SheetMetalFlangeData `yaml:"sheetMetalFlange,omitempty"` // M13-F02
+	SheetMetalHem    *SheetMetalHemData    `yaml:"sheetMetalHem,omitempty"`    // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -272,6 +273,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.SheetMetalFace = sm
 	case *SheetMetalFlangeFeature:
 		fd.SheetMetalFlange = serializeSheetMetalFlange(f.def)
+	case *SheetMetalHemFeature:
+		fd.SheetMetalHem = serializeSheetMetalHem(f.def)
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -463,6 +466,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalFace(fs, fd.SheetMetalFace, sk)
 	case "sheet-metal-flange":
 		return restoreSheetMetalFlange(fs, fd.SheetMetalFlange)
+	case "sheet-metal-hem":
+		return restoreSheetMetalHem(fs, fd.SheetMetalHem)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_hem.go
+++ b/model/feature/serialize_sheet_metal_hem.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalHemData is the serialized form of a SheetMetalHemFeature: the picked edge (base64
+// reference key), the hem length, the hem type, the open-hem gap, and the flip. Thickness is
+// read live from the rule, so it is not stored.
+type SheetMetalHemData struct {
+	Edge   string  `yaml:"edge"`
+	Length float64 `yaml:"length"`
+	Type   int32   `yaml:"type,omitempty"`
+	Gap    float64 `yaml:"gap,omitempty"`
+	Flip   bool    `yaml:"flip,omitempty"`
+}
+
+// serializeSheetMetalHem projects a hem recipe to its persisted form.
+func serializeSheetMetalHem(def *SheetMetalHemDefinition) *SheetMetalHemData {
+	return &SheetMetalHemData{
+		Edge:   encodeKey(def.EdgeKey),
+		Length: evalFloat(def.Length),
+		Type:   int32(def.Type),
+		Gap:    evalFloat(def.Gap),
+		Flip:   def.Flip,
+	}
+}
+
+// restoreSheetMetalHem rebuilds a hem feature, erroring on a missing payload or an undecodable
+// edge key.
+func restoreSheetMetalHem(fs *PartFeatures, d *SheetMetalHemData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal hem feature is missing its payload")
+	}
+	key, err := decodeKey(d.Edge)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal hem edge key: %w", err)
+	}
+	def := &SheetMetalHemDefinition{
+		EdgeKey: key,
+		Length:  constFloat(d.Length),
+		Type:    HemType(d.Type),
+		Flip:    d.Flip,
+	}
+	if d.Gap != 0 {
+		def.Gap = constFloat(d.Gap)
+	}
+	return NewSheetMetalHemFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_flange_test.go
+++ b/model/feature/sheet_metal_flange_test.go
@@ -16,15 +16,7 @@ import (
 // boundary edge up 90° over the given radius/height. It returns the engine's result bodies.
 func sheetWithFlange(t *testing.T, side, radiusCm, heightCm float64) []*topo.Body {
 	t.Helper()
-	ps := param.NewParameters()
-	if _, err := ps.AddUserParameter("Thickness", "2 mm"); err != nil {
-		t.Fatalf("Thickness: %v", err)
-	}
-	fs := NewPartFeatures(ps, nil)
-	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(side), ProfileIndex: 0, Operation: ops.NewBody})
-	fs.Recompute()
-
-	edge := topEdgeAlongX(t, fs.Result()[0])
+	fs, edge := seedSheetMetalSheet(t, side, nil)
 	NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
 		EdgeKey: edge.ReferenceKey(),
 		Height:  func() float64 { return heightCm },
@@ -108,14 +100,7 @@ func TestFlangeRisesAboveSheet(t *testing.T) {
 // parameter, the default 90° angle applies, and flip folds the wall to the opposite (−Z)
 // side. Also exercises the Definition accessor.
 func TestFlangeDefaultsAndFlip(t *testing.T) {
-	ps := param.NewParameters()
-	mustParam(t, ps, "Thickness", "2 mm")
-	mustParam(t, ps, "BendRadius", "2 mm") // the rule's default radius the flange should read
-	fs := NewPartFeatures(ps, nil)
-	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
-	fs.Recompute()
-
-	edge := topEdgeAlongX(t, fs.Result()[0])
+	fs, edge := seedSheetMetalSheet(t, 4, map[string]string{"BendRadius": "2 mm"}) // rule radius the flange reads
 	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
 		EdgeKey: edge.ReferenceKey(),
 		Height:  func() float64 { return 1.0 },
@@ -154,17 +139,11 @@ func mustParam(t *testing.T, ps *param.Parameters, name, expr string) {
 // TestFlangeRejectsBadDims a flange with a non-positive height (and no Thickness parameter)
 // goes sick rather than building degenerate geometry.
 func TestFlangeRejectsBadDims(t *testing.T) {
-	const side, r = 4.0, 0.2
-	ps := param.NewParameters()
-	mustParam(t, ps, "Thickness", "2 mm")
-	fs := NewPartFeatures(ps, nil)
-	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(side), ProfileIndex: 0, Operation: ops.NewBody})
-	fs.Recompute()
-	edge := topEdgeAlongX(t, fs.Result()[0])
+	fs, edge := seedSheetMetalSheet(t, 4, nil)
 	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
 		EdgeKey: edge.ReferenceKey(),
 		Height:  func() float64 { return 0 }, // zero height
-		Radius:  func() float64 { return r },
+		Radius:  func() float64 { return 0.2 },
 	})
 	fs.Recompute()
 	if pf.Health().OK() {

--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// Sheet-metal Hem feature (M13-F02). A hem folds the material at an edge back on itself —
+// the reinforced/safe edge on a finished panel. Geometrically it is a flange bent through
+// ~180°, so it reuses the flange's cross-section band (buildFlangeSolid at a half-turn): the
+// wall curls over the bend radius and runs back across the parent. The hem TYPE sets the
+// bend radius: a closed hem folds tight (radius ≈ half the thickness, the wall nearly flat
+// against the sheet); an open hem leaves a rounded loop of the given gap (radius = gap/2).
+
+// HemType discriminates the hem geometry.
+type HemType int
+
+const (
+	// ClosedHem folds the material flat back on itself (a tight radius ≈ t/2).
+	ClosedHem HemType = iota
+	// OpenHem leaves a rounded loop of the configured gap (radius = gap/2).
+	OpenHem
+)
+
+// hemFoldAngle is the half-turn every hem folds through.
+const hemFoldAngle = stdmath.Pi
+
+// SheetMetalHemDefinition is the hem recipe: the edge to hem, the hem length (how far the
+// folded-back wall runs), the type, an open hem's gap, and a flip to fold to the other side.
+type SheetMetalHemDefinition struct {
+	EdgeKey []byte
+	Length  func() float64
+	Type    HemType
+	Gap     func() float64 // open-hem loop gap; ignored for a closed hem
+	Flip    bool
+}
+
+// SheetMetalHemFeature folds a hem onto the sheet each recompute.
+type SheetMetalHemFeature struct {
+	def      *SheetMetalHemDefinition
+	featName string
+}
+
+// Definition returns the hem recipe.
+func (f *SheetMetalHemFeature) Definition() *SheetMetalHemDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalHemFeature) Kind() string { return "sheet-metal-hem" }
+
+// Recompute resolves the edge and folds a 180° hem onto the sheet at the type's radius.
+func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal hem")
+	if err != nil {
+		return Output{}, err
+	}
+	t, err := sheetThickness(in.Params)
+	if err != nil {
+		return Output{}, err
+	}
+	radius := f.hemRadius(t)
+	length := evalFloat(f.def.Length)
+	if radius <= 0 || length <= 0 {
+		return Output{}, fmt.Errorf("sheet-metal hem: radius/length must be positive (r=%g l=%g)", radius, length)
+	}
+	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	if err != nil {
+		return Output{}, err
+	}
+	wall, err := buildFlangeSolid(edges[0], t, radius, length, hemFoldAngle, f.def.Flip, f.featName)
+	if err != nil {
+		return Output{}, err
+	}
+	bodies, err := combine(in.Bodies, wall, ops.Join)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// hemRadius returns the inside bend radius for the hem type: a closed hem folds at half the
+// material thickness; an open hem at half its gap (defaulting to the thickness when unset).
+func (f *SheetMetalHemFeature) hemRadius(thickness float64) float64 {
+	if f.def.Type == OpenHem {
+		if g := evalFloat(f.def.Gap); g > 0 {
+			return g / 2
+		}
+		return thickness
+	}
+	return thickness / 2
+}
+
+// SheetMetalHemFeatures adds hem features into the engine.
+type SheetMetalHemFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalHemFeatures binds the collection to a feature engine.
+func NewSheetMetalHemFeatures(engine *PartFeatures) *SheetMetalHemFeatures {
+	return &SheetMetalHemFeatures{engine}
+}
+
+// Add appends a hem feature, naming it Hem1, Hem2, … .
+func (c *SheetMetalHemFeatures) Add(def *SheetMetalHemDefinition) *PartFeature {
+	f := &SheetMetalHemFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Hem"))
+	f.featName = pf.Name()
+	return pf
+}
+
+// ParseHemType resolves a wire spelling to a hem type.
+func ParseHemType(s string) (HemType, bool) {
+	switch s {
+	case "", "closed":
+		return ClosedHem, true
+	case "open":
+		return OpenHem, true
+	}
+	return 0, false
+}
+
+var _ Feature = (*SheetMetalHemFeature)(nil)

--- a/model/feature/sheet_metal_hem_test.go
+++ b/model/feature/sheet_metal_hem_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/param"
+)
+
+// sheetWithHem builds a square sheet then hems its highest +X top edge with the given type.
+func sheetWithHem(t *testing.T, hemType HemType, lengthCm, gapCm float64) *topo.Body {
+	t.Helper()
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+
+	edge := topEdgeAlongX(t, fs.Result()[0])
+	def := &SheetMetalHemDefinition{EdgeKey: edge.ReferenceKey(), Length: func() float64 { return lengthCm }, Type: hemType}
+	if gapCm > 0 {
+		def.Gap = func() float64 { return gapCm }
+	}
+	pf := NewSheetMetalHemFeatures(fs).Add(def)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("hem sick: %+v", pf.Health())
+	}
+	return fs.Result()[0]
+}
+
+// TestClosedHemBuildsWatertightSolid a closed hem folds the edge back as one valid watertight
+// solid, adding material above the sheet.
+func TestClosedHemBuildsWatertightSolid(t *testing.T) {
+	body := sheetWithHem(t, ClosedHem, 0.8, 0)
+	if !body.IsSolid() {
+		t.Fatal("hemmed sheet is not a solid")
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("hemmed sheet has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if res := ops.Validate(body); !res.Valid {
+		t.Fatalf("hemmed sheet failed validation: %+v", res)
+	}
+	// The fold curls back over the parent, so the body rises above the flat sheet's 0.2 cm.
+	maxZ := math.Inf(-1)
+	for _, v := range body.Vertices() {
+		if z := v.Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	if maxZ < 0.25 {
+		t.Errorf("closed hem top Z = %.3f, want it to rise above the sheet", maxZ)
+	}
+}
+
+// TestOpenHemLeavesLargerLoop an open hem with a gap folds over a larger radius than a closed
+// hem, so it rises higher.
+func TestOpenHemLeavesLargerLoop(t *testing.T) {
+	closedTop := topZOf(sheetWithHem(t, ClosedHem, 0.8, 0))
+	openTop := topZOf(sheetWithHem(t, OpenHem, 0.8, 0.6)) // gap 6 mm ⇒ radius 3 mm
+	if !(openTop > closedTop) {
+		t.Errorf("open hem (top %.3f) should loop higher than closed hem (top %.3f)", openTop, closedTop)
+	}
+}
+
+func topZOf(body *topo.Body) float64 {
+	maxZ := math.Inf(-1)
+	for _, v := range body.Vertices() {
+		if z := v.Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	return maxZ
+}
+
+// TestHemTypeParse the wire spellings resolve, and an unknown one is rejected.
+func TestHemTypeParse(t *testing.T) {
+	for s, want := range map[string]HemType{"": ClosedHem, "closed": ClosedHem, "open": OpenHem} {
+		if got, ok := ParseHemType(s); !ok || got != want {
+			t.Errorf("ParseHemType(%q) = (%d,%v), want (%d,true)", s, got, ok, want)
+		}
+	}
+	if _, ok := ParseHemType("rolled"); ok {
+		t.Error("ParseHemType(rolled) should be unsupported for now")
+	}
+}
+
+// TestHemRoundTrip the hem recipe (edge + length + type + gap + flip) marshals and restores.
+func TestHemRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{
+		EdgeKey: []byte("edge"),
+		Length:  func() float64 { return 0.6 },
+		Type:    OpenHem,
+		Gap:     func() float64 { return 0.4 },
+		Flip:    true,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalHem
+	if data[0].Kind != "sheet-metal-hem" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-hem", data[0])
+	}
+	if d.Length != 0.6 || d.Type != int32(OpenHem) || d.Gap != 0.4 || !d.Flip {
+		t.Errorf("payload = %+v, want length 0.6 / open / gap 0.4 / flip", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-hem" {
+		t.Errorf("restored = %d features, want one hem", fresh.Count())
+	}
+}
+
+// TestHemDefinitionAccessor Definition/Kind return the stored recipe.
+func TestHemDefinitionAccessor(t *testing.T) {
+	def := &SheetMetalHemDefinition{EdgeKey: []byte("k"), Length: func() float64 { return 1 }, Type: OpenHem}
+	f := &SheetMetalHemFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-hem" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// TestHemMissingPayload restoring a hem record with no payload errors.
+func TestHemMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalHem(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreSheetMetalHem(nil) must error")
+	}
+}
+
+// TestHemRejectsBadDims a zero-length hem goes sick.
+func TestHemRejectsBadDims(t *testing.T) {
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+	edge := topEdgeAlongX(t, fs.Result()[0])
+	pf := NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{EdgeKey: edge.ReferenceKey(), Length: func() float64 { return 0 }})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("zero-length hem should be sick")
+	}
+}

--- a/model/feature/sheet_metal_hem_test.go
+++ b/model/feature/sheet_metal_hem_test.go
@@ -8,19 +8,12 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/model/param"
 )
 
 // sheetWithHem builds a square sheet then hems its highest +X top edge with the given type.
 func sheetWithHem(t *testing.T, hemType HemType, lengthCm, gapCm float64) *topo.Body {
 	t.Helper()
-	ps := param.NewParameters()
-	mustParam(t, ps, "Thickness", "2 mm")
-	fs := NewPartFeatures(ps, nil)
-	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
-	fs.Recompute()
-
-	edge := topEdgeAlongX(t, fs.Result()[0])
+	fs, edge := seedSheetMetalSheet(t, 4, nil)
 	def := &SheetMetalHemDefinition{EdgeKey: edge.ReferenceKey(), Length: func() float64 { return lengthCm }, Type: hemType}
 	if gapCm > 0 {
 		def.Gap = func() float64 { return gapCm }
@@ -138,12 +131,7 @@ func TestHemMissingPayload(t *testing.T) {
 
 // TestHemRejectsBadDims a zero-length hem goes sick.
 func TestHemRejectsBadDims(t *testing.T) {
-	ps := param.NewParameters()
-	mustParam(t, ps, "Thickness", "2 mm")
-	fs := NewPartFeatures(ps, nil)
-	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
-	fs.Recompute()
-	edge := topEdgeAlongX(t, fs.Result()[0])
+	fs, edge := seedSheetMetalSheet(t, 4, nil)
 	pf := NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{EdgeKey: edge.ReferenceKey(), Length: func() float64 { return 0 }})
 	fs.Recompute()
 	if pf.Health().OK() {

--- a/model/feature/sheet_metal_seed_test.go
+++ b/model/feature/sheet_metal_seed_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/param"
+)
+
+// seedSheetMetalSheet builds a square sheet-metal wall (side cm, 2 mm thick) and returns the
+// engine and a top +X boundary edge to fold from — the common fixture the bend-family
+// feature tests (flange/hem/bend) share so their setup is not duplicated. extraParams adds
+// further parameters (e.g. BendRadius) the test needs.
+func seedSheetMetalSheet(t *testing.T, side float64, extraParams map[string]string) (*PartFeatures, *topo.Edge) {
+	t.Helper()
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	for name, expr := range extraParams {
+		mustParam(t, ps, name, expr)
+	}
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(side), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+	return fs, topEdgeAlongX(t, fs.Result()[0])
+}


### PR DESCRIPTION
## What

The **Hem** — fold a sheet edge back on itself (the reinforced/safe edge of a finished panel). Continues M13-F02's bend family after the Flange (#921, merged).

A hem is geometrically a flange bent through a half-turn, so it **reuses the flange's cross-section band** (`buildFlangeSolid` at 180°): the wall curls over the bend radius and runs back across the parent. The hem **type** sets the radius — a *closed* hem folds tight (radius ≈ t/2, wall nearly flat against the sheet); an *open* hem leaves a rounded loop of the configured gap (radius = gap/2). Thickness comes from the active rule; length/gap are parameter-backed; a `flip` folds to the other side. The recipe round-trips.

- **model/feature** — `SheetMetalHemDefinition`/`Feature`, `HemType` + `ParseHemType`, reusing the flange band; recipe codec.
- **addin/opregistry** — the `sheetMetalHem` operation, registered + covered by the descriptor/args guards.

## Test
Closed and open hems each build a **watertight valid solid**; the open hem loops higher than the closed; type parsing; bad-dims → sick; recipe round-trip; over-the-wire add + error paths. Per-package coverage ≥83% (model) / 94% (opreg); lint 0.

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> Adds `sheetMetalHem` to the source feature registry — to be absorbed (with `sheetMetalFace`/`sheetMetalFlange`) into the bridge's `TestE2EFeatureRegistryCoverage` in a follow-up bridge PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)