### PR TITLE
feat: sheet-metal Bend feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -258,6 +258,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalFace":      `{"sketchIndex":0}`,
 		"sheetMetalFlange":    `{"edge":"x","height":"10 mm"}`,
 		"sheetMetalHem":       `{"edge":"x","length":"6 mm"}`,
+		"sheetMetalBend":      `{"sketchIndex":0}`,
 		"splitSolid":          `{"toolSketch":0}`,
 		"coreCavity":          `{}`,
 		"hull":                `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -133,6 +133,7 @@ func Default() *Registry {
 		sheetMetalFaceDescriptor(),
 		sheetMetalFlangeDescriptor(),
 		sheetMetalHemDescriptor(),
+		sheetMetalBendDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_bend.go
+++ b/addin/opregistry/sheet_metal_bend.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// sheetMetalBendArgs is the argument shape for the "sheetMetalBend" operation: the sketch bend
+// line (sketch + line index), the optional bend angle/radius (radius defaults to the rule's
+// bend radius, angle to 90°), and a flip. Thickness comes from the rule.
+type sheetMetalBendArgs struct {
+	SketchIndex int    `json:"sketchIndex"`
+	LineIndex   int    `json:"lineIndex"`
+	Angle       string `json:"angle,omitempty"`
+	Radius      string `json:"radius,omitempty"`
+	Flip        bool   `json:"flip,omitempty"`
+}
+
+const sheetMetalBendSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the bend line (see model.tree)."},
+    "lineIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which line of the sketch is the bend axis. It must cross the sheet."},
+    "angle": {"type": "string", "description": "Bend angle, e.g. \"90 deg\" (default)."},
+    "radius": {"type": "string", "description": "Inside bend radius (default: the rule's bend radius)."},
+    "flip": {"type": "boolean", "default": false, "description": "Fold toward the opposite side of the sketch plane."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalBendDescriptor is the self-describing "sheetMetalBend" operation: fold a flat
+// sheet along a sketch line at the active rule's bend radius.
+func sheetMetalBendDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalBend",
+		Summary: "Fold a flat sheet-metal wall along a sketch line over a bend, at the active rule's thickness and bend radius.",
+		Schema:  json.RawMessage(sheetMetalBendSchema),
+		Apply:   applySheetMetalBend,
+	}
+}
+
+func applySheetMetalBend(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalBend")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalBendArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalBend: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	def, err := bendDef(part, sk, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewSheetMetalBendFeatures(part.Features()).Add(def))
+}
+
+// bendDef resolves the bend args into a definition: the sketch + line, and the optional
+// angle/radius closures (omitted ⇒ nil, so the feature uses its defaults).
+func bendDef(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in sheetMetalBendArgs) (*feature.SheetMetalBendDefinition, error) {
+	def := &feature.SheetMetalBendDefinition{Sketch: sk, LineIndex: in.LineIndex, Flip: in.Flip}
+	if in.Angle != "" {
+		angle, err := angleClosure(part, in.Angle, "sheetMetalBend: angle")
+		if err != nil {
+			return nil, err
+		}
+		def.Angle = angle
+	}
+	if in.Radius != "" {
+		radius, err := lengthClosure(part, in.Radius, "sheetMetalBend: radius")
+		if err != nil {
+			return nil, err
+		}
+		def.Radius = radius
+	}
+	return def, nil
+}

--- a/addin/opregistry/sheet_metal_bend_test.go
+++ b/addin/opregistry/sheet_metal_bend_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSheetMetalBendApply seeds a sheet-metal wall, adds a bend line crossing it, folds it,
+// and confirms one valid solid; then checks the error paths.
+func TestSheetMetalBendApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	line := def.Sketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(2, 3)) // across the 4×3 sheet at x=2
+
+	out, err := apply(t, s, "sheetMetalBend", `{"sketchIndex":1,"lineIndex":0,"angle":"90 deg","radius":"2 mm"}`)
+	if err != nil {
+		t.Fatalf("bend apply: %v", err)
+	}
+	expectMergedSolid(t, out, "bend")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalBend", `{"sketchIndex":0}`); err == nil {
+		t.Error("bend on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalBend", `{"sketchIndex":99}`); err == nil {
+		t.Error("bend with an out-of-range sketch must error")
+	}
+	if _, err := apply(t, s, "sheetMetalBend", `{"sketchIndex":1,"angle":"bad"}`); err == nil {
+		t.Error("bend with a bad angle must error")
+	}
+}

--- a/model/feature/bend_part.go
+++ b/model/feature/bend_part.go
@@ -65,19 +65,25 @@ func (b *BendPartFeature) Recompute(in Input) (Output, error) {
 // bendLine resolves the bend line's model-space point, direction, and the up-normal (the
 // sketch plane normal, flipped when Flip is set) the moving flange folds toward.
 func (b *BendPartFeature) bendLine() (point math.Point3, dir, up math.Vector3, err error) {
-	sk := b.def.Sketch
+	return sketchBendLine(b.def.Sketch, b.def.LineIndex, b.def.Flip, "bend-part")
+}
+
+// sketchBendLine resolves a sketch line into the model-space bend axis: a point on it, its
+// direction, and the fold-toward normal (the sketch plane normal, flipped when flip is set).
+// Shared by the part bend and the sheet-metal bend.
+func sketchBendLine(sk *sketch.Sketch, lineIndex int, flip bool, what string) (point math.Point3, dir, up math.Vector3, err error) {
 	if sk == nil {
-		return point, dir, up, fmt.Errorf("bend-part: no sketch set")
+		return point, dir, up, fmt.Errorf("%s: no sketch set", what)
 	}
 	lines := sk.Lines()
-	if b.def.LineIndex < 0 || b.def.LineIndex >= lines.Count() {
-		return point, dir, up, fmt.Errorf("bend-part: line index %d out of range (%d lines)", b.def.LineIndex, lines.Count())
+	if lineIndex < 0 || lineIndex >= lines.Count() {
+		return point, dir, up, fmt.Errorf("%s: line index %d out of range (%d lines)", what, lineIndex, lines.Count())
 	}
-	l := lines.Item(b.def.LineIndex)
+	l := lines.Item(lineIndex)
 	pl := sk.Plane()
 	p0, p1 := pl.ToModel(l.StartPoint().Position()), pl.ToModel(l.EndPoint().Position())
 	up = pl.Normal().AsVector()
-	if b.def.Flip {
+	if flip {
 		up = up.Scale(-1)
 	}
 	return p0, p0.VectorTo(p1), up, nil

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -74,6 +74,7 @@ type FeatureData struct {
 	SheetMetalFace   *SheetMetalFaceData   `yaml:"sheetMetalFace,omitempty"`   // M13-F02
 	SheetMetalFlange *SheetMetalFlangeData `yaml:"sheetMetalFlange,omitempty"` // M13-F02
 	SheetMetalHem    *SheetMetalHemData    `yaml:"sheetMetalHem,omitempty"`    // M13-F02
+	SheetMetalBend   *SheetMetalBendData   `yaml:"sheetMetalBend,omitempty"`   // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -275,6 +276,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.SheetMetalFlange = serializeSheetMetalFlange(f.def)
 	case *SheetMetalHemFeature:
 		fd.SheetMetalHem = serializeSheetMetalHem(f.def)
+	case *SheetMetalBendFeature:
+		smb, err := serializeSheetMetalBend(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalBend = smb
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -468,6 +475,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalFlange(fs, fd.SheetMetalFlange)
 	case "sheet-metal-hem":
 		return restoreSheetMetalHem(fs, fd.SheetMetalHem)
+	case "sheet-metal-bend":
+		return restoreSheetMetalBend(fs, fd.SheetMetalBend, sk)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_bend.go
+++ b/model/feature/serialize_sheet_metal_bend.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalBendData is the serialized form of a SheetMetalBendFeature: the bend line (sketch
+// index + line index), the optional bend angle/radius (0 ⇒ default 90° / the rule's bend
+// radius), and the flip. Thickness is read live from the rule.
+type SheetMetalBendData struct {
+	Sketch int     `yaml:"sketch"`
+	Line   int     `yaml:"line"`
+	Angle  float64 `yaml:"angle,omitempty"`  // 0 ⇒ 90° default
+	Radius float64 `yaml:"radius,omitempty"` // 0 ⇒ rule bend radius
+	Flip   bool    `yaml:"flip,omitempty"`
+}
+
+// serializeSheetMetalBend projects a bend recipe to its persisted form, erroring if its
+// sketch is not in the part (so the bend line cannot be lost silently).
+func serializeSheetMetalBend(def *SheetMetalBendDefinition, sk SketchIndexer) (*SheetMetalBendData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal bend references a sketch that is not in the part")
+	}
+	return &SheetMetalBendData{
+		Sketch: idx, Line: def.LineIndex,
+		Angle: evalFloat(def.Angle), Radius: evalFloat(def.Radius), Flip: def.Flip,
+	}, nil
+}
+
+// restoreSheetMetalBend rebuilds a bend feature, erroring on a missing payload or unknown
+// sketch. A zero angle/radius restores as nil (default 90° / rule radius).
+func restoreSheetMetalBend(fs *PartFeatures, d *SheetMetalBendData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal bend feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal bend references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalBendDefinition{Sketch: s, LineIndex: d.Line, Flip: d.Flip}
+	if d.Angle != 0 {
+		def.Angle = constFloat(d.Angle)
+	}
+	if d.Radius != 0 {
+		def.Radius = constFloat(d.Radius)
+	}
+	return NewSheetMetalBendFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_bend.go
+++ b/model/feature/sheet_metal_bend.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Bend feature (M13-F02). A bend folds a flat sheet along a sketch line through a
+// given angle over the rule's bend radius — the in-environment counterpart of the part bend
+// (#651), differing in that the radius defaults to the active sheet-metal rule so a radius
+// edit repropagates, and the bend records its place in the sheet-metal feature history for
+// the flat pattern (F04). The geometry is the shared straight→arc→straight fold (bendSolid).
+
+// SheetMetalBendDefinition is the bend recipe: the sketch bend line (sketch + line index),
+// the bend angle (parameter-backed; nil ⇒ 90°), an optional radius override (nil ⇒ the rule's
+// bend radius), and a flip that folds to the opposite side of the sketch plane.
+type SheetMetalBendDefinition struct {
+	Sketch    *sketch.Sketch
+	LineIndex int
+	Angle     func() float64
+	Radius    func() float64
+	Flip      bool
+}
+
+// SheetMetalBendFeature folds the running sheet along the bend line each recompute.
+type SheetMetalBendFeature struct {
+	def      *SheetMetalBendDefinition
+	featName string
+}
+
+// Definition returns the bend recipe.
+func (f *SheetMetalBendFeature) Definition() *SheetMetalBendDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalBendFeature) Kind() string { return "sheet-metal-bend" }
+
+// Recompute resolves the bend line and folds the sheet over the rule radius through the angle.
+func (f *SheetMetalBendFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal bend")
+	if err != nil {
+		return Output{}, err
+	}
+	point, dir, up, err := sketchBendLine(f.def.Sketch, f.def.LineIndex, f.def.Flip, "sheet-metal bend")
+	if err != nil {
+		return Output{}, err
+	}
+	radius := f.resolveRadius(in.Params)
+	angle := f.resolveAngle()
+	if radius <= 0 || angle <= 0 {
+		return Output{}, fmt.Errorf("sheet-metal bend: radius/angle must be positive (r=%g a=%g)", radius, angle)
+	}
+	bent, err := bendSolid(body, point, dir, up, radius, angle, featOr(f.featName, "bend"))
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, bent)}, nil
+}
+
+// resolveRadius returns the bend radius: the override closure, else the rule's BendRadius
+// parameter, else 0 (which Recompute rejects).
+func (f *SheetMetalBendFeature) resolveRadius(ps *param.Parameters) float64 {
+	if f.def.Radius != nil {
+		return f.def.Radius()
+	}
+	if ps != nil {
+		if p, ok := ps.ByName(flangeBendParamName); ok {
+			return p.ModelValue()
+		}
+	}
+	return 0
+}
+
+// resolveAngle returns the bend angle, defaulting to a 90° fold.
+func (f *SheetMetalBendFeature) resolveAngle() float64 {
+	if f.def.Angle == nil {
+		return stdmath.Pi / 2
+	}
+	return f.def.Angle()
+}
+
+// SheetMetalBendFeatures adds bend features into the engine.
+type SheetMetalBendFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalBendFeatures binds the collection to a feature engine.
+func NewSheetMetalBendFeatures(engine *PartFeatures) *SheetMetalBendFeatures {
+	return &SheetMetalBendFeatures{engine}
+}
+
+// Add appends a bend feature, naming it Bend1, Bend2, … .
+func (c *SheetMetalBendFeatures) Add(def *SheetMetalBendDefinition) *PartFeature {
+	f := &SheetMetalBendFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Bend"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalBendFeature)(nil)

--- a/model/feature/sheet_metal_bend_test.go
+++ b/model/feature/sheet_metal_bend_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// sheetForBend builds a square sheet (side cm, 2 mm thick) on XY with a Thickness parameter,
+// plus a bend-line sketch crossing it at x=mid, and returns the engine, the bend-line sketch,
+// and the feature engine ready to add a bend.
+func sheetForBend(t *testing.T, side, mid float64) (*PartFeatures, *sketch.Sketch) {
+	t.Helper()
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	mustParam(t, ps, "BendRadius", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(side), ProfileIndex: 0, Operation: ops.NewBody})
+
+	line := sketch.NewSketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(mid, 0), math.P2(mid, side)) // across the sheet at x=mid
+	return fs, line
+}
+
+// TestSheetMetalBendFoldsValidSolid bending a flat sheet along a line over the rule radius
+// yields one valid solid that folded up.
+func TestSheetMetalBendFoldsValidSolid(t *testing.T) {
+	fs, line := sheetForBend(t, 4, 2)
+	pf := NewSheetMetalBendFeatures(fs).Add(&SheetMetalBendDefinition{
+		Sketch: line, LineIndex: 0, Angle: func() float64 { return stdmath.Pi / 2 }, // radius from rule
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("bend sick: %+v", pf.Health())
+	}
+	if len(fs.Result()) != 1 {
+		t.Fatalf("bend result = %d bodies, want 1", len(fs.Result()))
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("bent sheet invalid: %v", r.Issues)
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("bent sheet has %d boundary edges, want watertight", len(open))
+	}
+	// The half-sheet beyond the line folded up out of the XY plane.
+	if box := body.RangeBox(); box.Max.Z < 1.0 {
+		t.Errorf("bent top Z = %g, want the folded half to rise (>1)", box.Max.Z)
+	}
+}
+
+// TestSheetMetalBendUsesRuleRadius with no radius override the bend reads the rule's
+// BendRadius parameter (a missing parameter ⇒ sick), and the 90° default applies.
+func TestSheetMetalBendUsesRuleRadius(t *testing.T) {
+	// No BendRadius parameter ⇒ radius resolves to 0 ⇒ sick.
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	line := sketch.NewSketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(2, 4))
+	pf := NewSheetMetalBendFeatures(fs).Add(&SheetMetalBendDefinition{Sketch: line, LineIndex: 0})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("bend with no radius override and no BendRadius parameter should be sick")
+	}
+}
+
+// TestSheetMetalBendDefinitionAndKind the accessors return the recipe.
+func TestSheetMetalBendDefinitionAndKind(t *testing.T) {
+	def := &SheetMetalBendDefinition{LineIndex: 1}
+	f := &SheetMetalBendFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-bend" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// TestSheetMetalBendRoundTrip the bend recipe (sketch + line + angle + radius + flip)
+// marshals and restores, preserving the kind and payload.
+func TestSheetMetalBendRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalBendFeatures(fs).Add(&SheetMetalBendDefinition{
+		Sketch: sk, LineIndex: 0,
+		Angle: func() float64 { return stdmath.Pi / 3 }, Radius: func() float64 { return 0.3 }, Flip: true,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalBend
+	if data[0].Kind != "sheet-metal-bend" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-bend", data[0])
+	}
+	if d.Line != 0 || stdmath.Abs(d.Angle-stdmath.Pi/3) > 1e-9 || d.Radius != 0.3 || !d.Flip {
+		t.Errorf("payload = %+v, want line 0 / angle π/3 / radius 0.3 / flip", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-bend" {
+		t.Errorf("restored = %d features, want one bend", fresh.Count())
+	}
+}
+
+// TestSheetMetalBendSerializeUnknownSketch serializing a bend whose sketch is not in the part
+// errors rather than dropping the line reference.
+func TestSheetMetalBendSerializeUnknownSketch(t *testing.T) {
+	def := &SheetMetalBendDefinition{Sketch: sketch.NewSketches().Add(sketch.XYPlane())}
+	if _, err := serializeSheetMetalBend(def, oneSketch{s: sketch.NewSketches().Add(sketch.XYPlane())}); err == nil {
+		t.Error("serializeSheetMetalBend with an unknown sketch must error")
+	}
+}
+
+// TestSheetMetalBendMissingPayload restoring a bend record with no payload errors.
+func TestSheetMetalBendMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalBend(NewPartFeatures(nil, nil), nil, oneSketch{}); err == nil {
+		t.Error("restoreSheetMetalBend(nil) must error")
+	}
+}


### PR DESCRIPTION
## What

The **Bend** — fold a flat sheet along a sketch line over a bend at the active rule's bend radius. Completes the core bend trio (Flange #921, Hem #923, Bend) of M13-F02.

It reuses the proven straight→arc→straight fold geometry (`bendSolid`); a shared `sketchBendLine` resolver — extracted from the part bend (#651) — keeps the two from duplicating their sketch-line resolution. The radius **defaults to the rule's `BendRadius` parameter** (so a radius edit repropagates), the angle is parameter-backed (default 90°), and a `flip` folds to the other side. The recipe round-trips. The operation reuses the shared `activeSheetMetalPart` guard introduced with the Hem.

- **model/feature** — `SheetMetalBendDefinition`/`Feature`, `sketchBendLine` shared with the part bend; recipe codec.
- **addin/opregistry** — the `sheetMetalBend` operation, registered + covered by the descriptor/args guards.

## Test
A flat sheet folds along a line into one **watertight valid solid** that rises out of plane; missing-radius (no override, no `BendRadius` parameter) → sick; recipe round-trip + serialize-unknown-sketch error; over-the-wire add + error paths. Lint 0; the part-bend tests stay green after the `sketchBendLine` extraction.

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> Adds `sheetMetalBend` to the source feature registry — to be absorbed (with `sheetMetalFace`/`sheetMetalFlange`/`sheetMetalHem`) into the bridge's `TestE2EFeatureRegistryCoverage` in a follow-up bridge PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)