### PR TITLE
feat: sheet-metal Fold feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -259,6 +259,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalFlange":    `{"edge":"x","height":"10 mm"}`,
 		"sheetMetalHem":       `{"edge":"x","length":"6 mm"}`,
 		"sheetMetalBend":      `{"sketchIndex":0}`,
+		"sheetMetalFold":      `{"sketchIndex":0}`,
 		"splitSolid":          `{"toolSketch":0}`,
 		"coreCavity":          `{}`,
 		"hull":                `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -134,6 +134,7 @@ func Default() *Registry {
 		sheetMetalFlangeDescriptor(),
 		sheetMetalHemDescriptor(),
 		sheetMetalBendDescriptor(),
+		sheetMetalFoldDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_fold.go
+++ b/addin/opregistry/sheet_metal_fold.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// sheetMetalFoldArgs is the argument shape for the "sheetMetalFold" operation: the sketch
+// fold line (sketch + line index), the optional bend angle/radius, the bend location
+// (start|centerline|end), and a flip. Thickness comes from the rule.
+type sheetMetalFoldArgs struct {
+	SketchIndex int    `json:"sketchIndex"`
+	LineIndex   int    `json:"lineIndex"`
+	Angle       string `json:"angle,omitempty"`
+	Radius      string `json:"radius,omitempty"`
+	Location    string `json:"location,omitempty"`
+	Flip        bool   `json:"flip,omitempty"`
+}
+
+const sheetMetalFoldSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the fold line (see model.tree)."},
+    "lineIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which line of the sketch is the fold axis. It must lie on the face."},
+    "angle": {"type": "string", "description": "Bend angle, e.g. \"90 deg\" (default)."},
+    "radius": {"type": "string", "description": "Inside bend radius (default: the rule's bend radius)."},
+    "location": {"type": "string", "enum": ["centerline", "start", "end"], "default": "centerline", "description": "Where the fold line sits relative to the bend."},
+    "flip": {"type": "boolean", "default": false, "description": "Fold toward the opposite side of the sketch plane."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalFoldDescriptor is the self-describing "sheetMetalFold" operation: fold a face
+// along a sketch line at the active rule's bend radius, positioning the bend by location.
+func sheetMetalFoldDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalFold",
+		Summary: "Fold a sheet-metal face along a sketch line, placing the bend at the start, centerline, or end of the line.",
+		Schema:  json.RawMessage(sheetMetalFoldSchema),
+		Apply:   applySheetMetalFold,
+	}
+}
+
+func applySheetMetalFold(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalFold")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalFoldArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalFold: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	def, err := foldDef(part, sk, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewSheetMetalFoldFeatures(part.Features()).Add(def))
+}
+
+// foldDef resolves the fold args into a definition: the sketch + line, the bend location, and
+// the optional angle/radius closures.
+func foldDef(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in sheetMetalFoldArgs) (*feature.SheetMetalFoldDefinition, error) {
+	loc, ok := feature.ParseBendLocation(in.Location)
+	if !ok {
+		return nil, fmt.Errorf("sheetMetalFold: unknown location %q (want centerline, start or end)", in.Location)
+	}
+	def := &feature.SheetMetalFoldDefinition{Sketch: sk, LineIndex: in.LineIndex, Location: loc, Flip: in.Flip}
+	if in.Angle != "" {
+		angle, err := angleClosure(part, in.Angle, "sheetMetalFold: angle")
+		if err != nil {
+			return nil, err
+		}
+		def.Angle = angle
+	}
+	if in.Radius != "" {
+		radius, err := lengthClosure(part, in.Radius, "sheetMetalFold: radius")
+		if err != nil {
+			return nil, err
+		}
+		def.Radius = radius
+	}
+	return def, nil
+}

--- a/addin/opregistry/sheet_metal_fold_test.go
+++ b/addin/opregistry/sheet_metal_fold_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSheetMetalFoldApply seeds a sheet-metal wall, adds a fold line crossing it, folds it at
+// the end-of-bend location, and confirms one valid solid; then checks the error paths.
+func TestSheetMetalFoldApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	line := def.Sketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(2, 3))
+
+	out, err := apply(t, s, "sheetMetalFold", `{"sketchIndex":1,"lineIndex":0,"angle":"90 deg","radius":"2 mm","location":"end"}`)
+	if err != nil {
+		t.Fatalf("fold apply: %v", err)
+	}
+	expectMergedSolid(t, out, "fold")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalFold", `{"sketchIndex":0}`); err == nil {
+		t.Error("fold on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalFold", `{"sketchIndex":1,"location":"middle"}`); err == nil {
+		t.Error("fold with an unknown location must error")
+	}
+	if _, err := apply(t, s, "sheetMetalFold", `{"sketchIndex":1,"radius":"bad"}`); err == nil {
+		t.Error("fold with a bad radius must error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -75,6 +75,7 @@ type FeatureData struct {
 	SheetMetalFlange *SheetMetalFlangeData `yaml:"sheetMetalFlange,omitempty"` // M13-F02
 	SheetMetalHem    *SheetMetalHemData    `yaml:"sheetMetalHem,omitempty"`    // M13-F02
 	SheetMetalBend   *SheetMetalBendData   `yaml:"sheetMetalBend,omitempty"`   // M13-F02
+	SheetMetalFold   *SheetMetalFoldData   `yaml:"sheetMetalFold,omitempty"`   // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -282,6 +283,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalBend = smb
+	case *SheetMetalFoldFeature:
+		smf, err := serializeSheetMetalFold(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalFold = smf
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -477,6 +484,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalHem(fs, fd.SheetMetalHem)
 	case "sheet-metal-bend":
 		return restoreSheetMetalBend(fs, fd.SheetMetalBend, sk)
+	case "sheet-metal-fold":
+		return restoreSheetMetalFold(fs, fd.SheetMetalFold, sk)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_fold.go
+++ b/model/feature/serialize_sheet_metal_fold.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalFoldData is the serialized form of a SheetMetalFoldFeature: the fold line (sketch
+// index + line index), the optional bend angle/radius (0 ⇒ default 90° / the rule's bend
+// radius), the bend location, and the flip.
+type SheetMetalFoldData struct {
+	Sketch   int     `yaml:"sketch"`
+	Line     int     `yaml:"line"`
+	Angle    float64 `yaml:"angle,omitempty"`  // 0 ⇒ 90° default
+	Radius   float64 `yaml:"radius,omitempty"` // 0 ⇒ rule bend radius
+	Location int32   `yaml:"location,omitempty"`
+	Flip     bool    `yaml:"flip,omitempty"`
+}
+
+// serializeSheetMetalFold projects a fold recipe to its persisted form, erroring if its
+// sketch is not in the part.
+func serializeSheetMetalFold(def *SheetMetalFoldDefinition, sk SketchIndexer) (*SheetMetalFoldData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal fold references a sketch that is not in the part")
+	}
+	return &SheetMetalFoldData{
+		Sketch: idx, Line: def.LineIndex,
+		Angle: evalFloat(def.Angle), Radius: evalFloat(def.Radius),
+		Location: int32(def.Location), Flip: def.Flip,
+	}, nil
+}
+
+// restoreSheetMetalFold rebuilds a fold feature, erroring on a missing payload or unknown
+// sketch. A zero angle/radius restores as nil (default 90° / rule radius).
+func restoreSheetMetalFold(fs *PartFeatures, d *SheetMetalFoldData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal fold feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal fold references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalFoldDefinition{Sketch: s, LineIndex: d.Line, Location: BendLocation(d.Location), Flip: d.Flip}
+	if d.Angle != 0 {
+		def.Angle = constFloat(d.Angle)
+	}
+	if d.Radius != 0 {
+		def.Radius = constFloat(d.Radius)
+	}
+	return NewSheetMetalFoldFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_fold.go
+++ b/model/feature/sheet_metal_fold.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Fold feature (M13-F02). A fold bends a flat face along a sketch line drawn on
+// it. Unlike the Bend (which treats the line as the bend's inside tangent), the Fold adds a
+// BEND LOCATION: the line can be the start, centerline, or end of the bend, so the fold sits
+// where the designer dimensioned it. The geometry reuses the shared fold (bendSolid); the
+// location shifts the fold line along the across-direction by a fraction of the bend's flat
+// footprint (r·sin(angle)) — a first-order placement refined by the flat-pattern unfold (F04).
+
+// BendLocation places the sketch line relative to the bend it produces.
+type BendLocation int
+
+const (
+	// CenterlineOfBend centres the bend on the line (the default).
+	CenterlineOfBend BendLocation = iota
+	// StartOfBend makes the line the inside tangent where the bend begins.
+	StartOfBend
+	// EndOfBend makes the line the tangent where the bend ends.
+	EndOfBend
+)
+
+// locationFactor is how far into the bend's footprint the line sits, per location.
+func (l BendLocation) locationFactor() float64 {
+	switch l {
+	case StartOfBend:
+		return 0
+	case EndOfBend:
+		return 1
+	default: // CenterlineOfBend
+		return 0.5
+	}
+}
+
+// ParseBendLocation resolves a wire spelling to a bend location.
+func ParseBendLocation(s string) (BendLocation, bool) {
+	switch s {
+	case "", "centerline":
+		return CenterlineOfBend, true
+	case "start":
+		return StartOfBend, true
+	case "end":
+		return EndOfBend, true
+	}
+	return 0, false
+}
+
+// SheetMetalFoldDefinition is the fold recipe: the sketch fold line (sketch + line index),
+// the bend angle (parameter-backed; nil ⇒ 90°), an optional radius override (nil ⇒ the rule's
+// bend radius), the bend location, and a flip that folds to the opposite side.
+type SheetMetalFoldDefinition struct {
+	Sketch    *sketch.Sketch
+	LineIndex int
+	Angle     func() float64
+	Radius    func() float64
+	Location  BendLocation
+	Flip      bool
+}
+
+// SheetMetalFoldFeature folds the running sheet along the fold line each recompute.
+type SheetMetalFoldFeature struct {
+	def      *SheetMetalFoldDefinition
+	featName string
+}
+
+// Definition returns the fold recipe.
+func (f *SheetMetalFoldFeature) Definition() *SheetMetalFoldDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalFoldFeature) Kind() string { return "sheet-metal-fold" }
+
+// Recompute resolves the fold line, shifts it per the bend location, and folds the sheet.
+func (f *SheetMetalFoldFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal fold")
+	if err != nil {
+		return Output{}, err
+	}
+	point, dir, up, err := sketchBendLine(f.def.Sketch, f.def.LineIndex, f.def.Flip, "sheet-metal fold")
+	if err != nil {
+		return Output{}, err
+	}
+	radius := f.resolveRadius(in.Params)
+	angle := f.resolveAngle()
+	if radius <= 0 || angle <= 0 {
+		return Output{}, fmt.Errorf("sheet-metal fold: radius/angle must be positive (r=%g a=%g)", radius, angle)
+	}
+	at := foldLinePoint(point, dir, up, radius, angle, f.def.Location)
+	bent, err := bendSolid(body, at, dir, up, radius, angle, featOr(f.featName, "fold"))
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, bent)}, nil
+}
+
+// foldLinePoint shifts the user's line toward the fixed side by the bend location's fraction
+// of the bend footprint, so bendSolid (which puts the bend start at the point it is given)
+// places the bend so the original line is at the requested start/center/end.
+func foldLinePoint(point math.Point3, dir, up math.Vector3, radius, angle float64, loc BendLocation) math.Point3 {
+	across, err := math.UnitVector3FromVector(dir.Cross(up))
+	if err != nil {
+		return point // degenerate; bendSolid will report it
+	}
+	footprint := radius * stdmath.Sin(angle) // flat across-extent the bend spans
+	return point.TranslateBy(across.AsVector().Scale(-loc.locationFactor() * footprint))
+}
+
+// resolveRadius returns the bend radius: the override closure, else the rule's BendRadius
+// parameter, else 0 (which Recompute rejects).
+func (f *SheetMetalFoldFeature) resolveRadius(ps *param.Parameters) float64 {
+	if f.def.Radius != nil {
+		return f.def.Radius()
+	}
+	if ps != nil {
+		if p, ok := ps.ByName(flangeBendParamName); ok {
+			return p.ModelValue()
+		}
+	}
+	return 0
+}
+
+// resolveAngle returns the bend angle, defaulting to a 90° fold.
+func (f *SheetMetalFoldFeature) resolveAngle() float64 {
+	if f.def.Angle == nil {
+		return stdmath.Pi / 2
+	}
+	return f.def.Angle()
+}
+
+// SheetMetalFoldFeatures adds fold features into the engine.
+type SheetMetalFoldFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalFoldFeatures binds the collection to a feature engine.
+func NewSheetMetalFoldFeatures(engine *PartFeatures) *SheetMetalFoldFeatures {
+	return &SheetMetalFoldFeatures{engine}
+}
+
+// Add appends a fold feature, naming it Fold1, Fold2, … .
+func (c *SheetMetalFoldFeatures) Add(def *SheetMetalFoldDefinition) *PartFeature {
+	f := &SheetMetalFoldFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Fold"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalFoldFeature)(nil)

--- a/model/feature/sheet_metal_fold_test.go
+++ b/model/feature/sheet_metal_fold_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// foldedSheet builds a square sheet, draws a fold line across it at x=mid, and folds it 90°
+// over the rule radius at the given bend location. Returns the result body.
+func foldedSheet(t *testing.T, side, mid float64, loc BendLocation) *topo.Body {
+	t.Helper()
+	fs, _ := seedSheetMetalSheet(t, side, map[string]string{"BendRadius": "2 mm"})
+	line := sketch.NewSketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(mid, 0), math.P2(mid, side))
+	pf := NewSheetMetalFoldFeatures(fs).Add(&SheetMetalFoldDefinition{
+		Sketch: line, LineIndex: 0, Angle: func() float64 { return stdmath.Pi / 2 }, Location: loc,
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("fold (loc %d) sick: %+v", loc, pf.Health())
+	}
+	return fs.Result()[0]
+}
+
+// TestFoldFoldsValidSolid a fold along a line over the rule radius yields one valid watertight
+// solid that rises out of the plane.
+func TestFoldFoldsValidSolid(t *testing.T) {
+	body := foldedSheet(t, 4, 2, CenterlineOfBend)
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("folded sheet invalid: %v", r.Issues)
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("folded sheet has %d boundary edges, want watertight", len(open))
+	}
+	if box := body.RangeBox(); box.Max.Z < 1.0 {
+		t.Errorf("folded top Z = %g, want the folded half to rise (>1)", box.Max.Z)
+	}
+}
+
+// TestFoldBendLocationShiftsTheFold the three bend locations place the fold at different
+// positions along the sheet (the folded half's extent in +X differs), proving the location
+// actually moves the bend.
+func TestFoldBendLocationShiftsTheFold(t *testing.T) {
+	// Measure where the folded (raised) material begins in X for each location: the min X of
+	// any vertex above the flat sheet.
+	raisedMinX := func(loc BendLocation) float64 {
+		body := foldedSheet(t, 4, 2, loc)
+		minX := stdmath.Inf(1)
+		for _, v := range body.Vertices() {
+			p := v.Point()
+			if p.Z > 0.3 && p.X < minX { // above the 2 mm sheet ⇒ part of the fold
+				minX = p.X
+			}
+		}
+		return minX
+	}
+	start := raisedMinX(StartOfBend)
+	end := raisedMinX(EndOfBend)
+	// End-of-bend shifts the bend toward the fixed (−X) side, so its raised material begins
+	// further in −X than start-of-bend.
+	if !(end < start) {
+		t.Errorf("bend location did not shift the fold: start raised@%.3f, end raised@%.3f (want end < start)", start, end)
+	}
+}
+
+// TestParseBendLocation the wire spellings resolve, with an unknown one rejected.
+func TestParseBendLocation(t *testing.T) {
+	for s, want := range map[string]BendLocation{"": CenterlineOfBend, "centerline": CenterlineOfBend, "start": StartOfBend, "end": EndOfBend} {
+		if got, ok := ParseBendLocation(s); !ok || got != want {
+			t.Errorf("ParseBendLocation(%q) = (%d,%v), want (%d,true)", s, got, ok, want)
+		}
+	}
+	if _, ok := ParseBendLocation("middle"); ok {
+		t.Error("ParseBendLocation(middle) should be rejected")
+	}
+}
+
+// TestFoldNeedsRadius a fold with no radius override and no BendRadius parameter goes sick.
+func TestFoldNeedsRadius(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil) // Thickness only, no BendRadius
+	line := sketch.NewSketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(2, 4))
+	pf := NewSheetMetalFoldFeatures(fs).Add(&SheetMetalFoldDefinition{Sketch: line, LineIndex: 0})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("fold with no radius should be sick")
+	}
+}
+
+// TestFoldDefinitionAndKind the accessors return the recipe.
+func TestFoldDefinitionAndKind(t *testing.T) {
+	def := &SheetMetalFoldDefinition{LineIndex: 2, Location: EndOfBend}
+	f := &SheetMetalFoldFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-fold" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// TestFoldRoundTrip the fold recipe (sketch + line + angle + radius + location + flip)
+// marshals and restores, preserving the kind and payload.
+func TestFoldRoundTrip(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalFoldFeatures(fs).Add(&SheetMetalFoldDefinition{
+		Sketch: sk, LineIndex: 0,
+		Angle: func() float64 { return stdmath.Pi / 3 }, Radius: func() float64 { return 0.3 },
+		Location: EndOfBend, Flip: true,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalFold
+	if data[0].Kind != "sheet-metal-fold" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-fold", data[0])
+	}
+	if d.Location != int32(EndOfBend) || stdmath.Abs(d.Angle-stdmath.Pi/3) > 1e-9 || d.Radius != 0.3 || !d.Flip {
+		t.Errorf("payload = %+v, want end / angle π/3 / radius 0.3 / flip", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-fold" {
+		t.Errorf("restored = %d features, want one fold", fresh.Count())
+	}
+}
+
+// TestFoldMissingPayload restoring a fold record with no payload errors.
+func TestFoldMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalFold(NewPartFeatures(nil, nil), nil, oneSketch{}); err == nil {
+		t.Error("restoreSheetMetalFold(nil) must error")
+	}
+}
+
+// TestFoldSerializeUnknownSketch serializing a fold whose sketch is not in the part errors.
+func TestFoldSerializeUnknownSketch(t *testing.T) {
+	def := &SheetMetalFoldDefinition{Sketch: sketch.NewSketches().Add(sketch.XYPlane())}
+	if _, err := serializeSheetMetalFold(def, oneSketch{s: sketch.NewSketches().Add(sketch.XYPlane())}); err == nil {
+		t.Error("serializeSheetMetalFold with an unknown sketch must error")
+	}
+}


### PR DESCRIPTION
## What

The **Fold** — fold a flat face along a sketch line drawn on it. Builds on the Bend (#924, merged).

Unlike the Bend (which treats the line as the bend's inside tangent), the Fold adds a **bend location**: the line can be the *start*, *centerline* (default), or *end* of the bend, so the fold sits where the designer dimensioned it.

The geometry reuses the shared fold (`bendSolid`); the location shifts the fold line along the across-direction by a fraction of the bend's flat footprint (`r·sin θ`) — a first-order placement the flat-pattern unfold (F04) will refine. Radius defaults to the rule's `BendRadius` (parameter-backed); angle parameter-backed (default 90°); `flip` folds to the other side. Recipe round-trips. Reuses the shared `activeSheetMetalPart` guard.

- **model/feature** — `SheetMetalFoldDefinition`/`Feature`, `BendLocation` + `ParseBendLocation`; recipe codec.
- **addin/opregistry** — the `sheetMetalFold` operation, registered + covered by the descriptor/args guards.

## Test
A flat sheet folds into one **watertight valid solid** that rises out of plane; the **three bend locations place the fold at different positions** (verified by where the raised material begins in X); missing-radius → sick; recipe round-trip + serialize-unknown-sketch error; over-the-wire add + error paths. Per-package coverage ~94% (model) / ~93% (opreg); lint 0.

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> Adds `sheetMetalFold` to the source feature registry — to be absorbed (with the other `sheetMetal*` kinds) into the bridge's `TestE2EFeatureRegistryCoverage` in a follow-up bridge PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)