### PR TITLE
feat: sheet-metal Corner feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -260,6 +260,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalHem":       `{"edge":"x","length":"6 mm"}`,
 		"sheetMetalBend":      `{"sketchIndex":0}`,
 		"sheetMetalFold":      `{"sketchIndex":0}`,
+		"sheetMetalCorner":    `{"edges":["x"],"treatment":"round","size":"3 mm"}`,
 		"splitSolid":          `{"toolSketch":0}`,
 		"coreCavity":          `{}`,
 		"hull":                `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -135,6 +135,7 @@ func Default() *Registry {
 		sheetMetalHemDescriptor(),
 		sheetMetalBendDescriptor(),
 		sheetMetalFoldDescriptor(),
+		sheetMetalCornerDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_corner.go
+++ b/addin/opregistry/sheet_metal_corner.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalCornerArgs is the argument shape for the "sheetMetalCorner" operation: the corner
+// edges (through-thickness edge reference keys), the treatment (chamfer|round), and its size.
+type sheetMetalCornerArgs struct {
+	Edges     []string `json:"edges"`
+	Treatment string   `json:"treatment"`
+	Size      string   `json:"size"`
+}
+
+const sheetMetalCornerSchema = `{
+  "type": "object",
+  "properties": {
+    "edges": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the through-thickness corner edges to finish (from get_reference_keys)."},
+    "treatment": {"type": "string", "enum": ["chamfer", "round"], "description": "chamfer cuts a flat across the corner; round rolls a fillet."},
+    "size": {"type": "string", "description": "Chamfer setback or round radius, e.g. \"3 mm\"."}
+  },
+  "required": ["edges", "treatment", "size"]
+}`
+
+// sheetMetalCornerDescriptor is the self-describing "sheetMetalCorner" operation: chamfer or
+// round one or more sheet-metal corners.
+func sheetMetalCornerDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalCorner",
+		Summary: "Chamfer or round one or more corners of a sheet-metal face (the through-thickness corner edges).",
+		Schema:  json.RawMessage(sheetMetalCornerSchema),
+		Apply:   applySheetMetalCorner,
+	}
+}
+
+func applySheetMetalCorner(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalCorner")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalCornerArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalCorner: invalid args: %w", err)
+	}
+	if len(in.Edges) == 0 {
+		return nil, fmt.Errorf("sheetMetalCorner: edges is empty")
+	}
+	treatment, ok := feature.ParseCornerTreatment(in.Treatment)
+	if !ok {
+		return nil, fmt.Errorf("sheetMetalCorner: unknown treatment %q (want chamfer or round)", in.Treatment)
+	}
+	size, err := lengthClosure(part, in.Size, "sheetMetalCorner: size")
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalCornerDefinition{EdgeKeys: refKeys(in.Edges), Treatment: treatment, Size: size}
+	return recomputeResult(part, feature.NewSheetMetalCornerFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_corner_test.go
+++ b/addin/opregistry/sheet_metal_corner_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// verticalCornerEdgeKey returns the reference key of a through-thickness corner edge of the
+// part's first body.
+func verticalCornerEdgeKey(t *testing.T, def *compdef.PartComponentDefinition) string {
+	t.Helper()
+	b := def.SurfaceBodies().Item(0)
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-c.X) < 1e-6 && math.Abs(a.Y-c.Y) < 1e-6 && math.Abs(a.Z-c.Z) > 1e-6 {
+			return string(e.ReferenceKey())
+		}
+	}
+	t.Fatal("no vertical corner edge found")
+	return ""
+}
+
+// TestSheetMetalCornerApply seeds a sheet-metal wall and rounds a corner, confirming one
+// healthy solid; then checks the error paths.
+func TestSheetMetalCornerApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	edge := verticalCornerEdgeKey(t, def)
+
+	out, err := applyMap(t, s, "sheetMetalCorner", map[string]any{"edges": []string{edge}, "treatment": "round", "size": "3 mm"})
+	if err != nil {
+		t.Fatalf("corner apply: %v", err)
+	}
+	expectMergedSolid(t, out, "corner")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalCorner", `{"edges":["x"],"treatment":"round","size":"1 mm"}`); err == nil {
+		t.Error("corner on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalCorner", `{"edges":[],"treatment":"round","size":"1 mm"}`); err == nil {
+		t.Error("corner with no edges must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalCorner", map[string]any{"edges": []string{edge}, "treatment": "seam", "size": "1 mm"}); err == nil {
+		t.Error("corner with an unknown treatment must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalCorner", map[string]any{"edges": []string{edge}, "treatment": "round", "size": "bad"}); err == nil {
+		t.Error("corner with a bad size must error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -76,6 +76,7 @@ type FeatureData struct {
 	SheetMetalHem    *SheetMetalHemData    `yaml:"sheetMetalHem,omitempty"`    // M13-F02
 	SheetMetalBend   *SheetMetalBendData   `yaml:"sheetMetalBend,omitempty"`   // M13-F02
 	SheetMetalFold   *SheetMetalFoldData   `yaml:"sheetMetalFold,omitempty"`   // M13-F02
+	SheetMetalCorner *SheetMetalCornerData `yaml:"sheetMetalCorner,omitempty"` // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -289,6 +290,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalFold = smf
+	case *SheetMetalCornerFeature:
+		fd.SheetMetalCorner = serializeSheetMetalCorner(f.def)
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -486,6 +489,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalBend(fs, fd.SheetMetalBend, sk)
 	case "sheet-metal-fold":
 		return restoreSheetMetalFold(fs, fd.SheetMetalFold, sk)
+	case "sheet-metal-corner":
+		return restoreSheetMetalCorner(fs, fd.SheetMetalCorner)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_corner.go
+++ b/model/feature/serialize_sheet_metal_corner.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalCornerData is the serialized form of a SheetMetalCornerFeature: the corner edges
+// (base64 reference keys), the treatment, and its size.
+type SheetMetalCornerData struct {
+	Edges     []string `yaml:"edges"`
+	Treatment int32    `yaml:"treatment,omitempty"`
+	Size      float64  `yaml:"size"`
+}
+
+// serializeSheetMetalCorner projects a corner recipe to its persisted form.
+func serializeSheetMetalCorner(def *SheetMetalCornerDefinition) *SheetMetalCornerData {
+	return &SheetMetalCornerData{
+		Edges:     encodeKeys(def.EdgeKeys),
+		Treatment: int32(def.Treatment),
+		Size:      evalFloat(def.Size),
+	}
+}
+
+// restoreSheetMetalCorner rebuilds a corner feature, erroring on a missing payload or an
+// undecodable edge key.
+func restoreSheetMetalCorner(fs *PartFeatures, d *SheetMetalCornerData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal corner feature is missing its payload")
+	}
+	keys, err := decodeKeys(d.Edges)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal corner edge keys: %w", err)
+	}
+	return NewSheetMetalCornerFeatures(fs).Add(&SheetMetalCornerDefinition{
+		EdgeKeys:  keys,
+		Treatment: CornerTreatment(d.Treatment),
+		Size:      constFloat(d.Size),
+	}), nil
+}

--- a/model/feature/sheet_metal_corner.go
+++ b/model/feature/sheet_metal_corner.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// Sheet-metal Corner feature (M13-F02). A corner treatment chamfers or rounds the corner of a
+// sheet-metal face — the through-thickness edge where two boundary edges of the wall meet.
+// CornerChamfer cuts a flat across the corner; CornerRound rolls a fillet. Both reuse the
+// part-modeling chamfer/fillet geometry (a corner is just that vertical edge), wrapped as a
+// sheet-metal feature so it lives in the sheet-metal history and the flat pattern (F04).
+
+// CornerTreatment discriminates how a sheet-metal corner is finished.
+type CornerTreatment int
+
+const (
+	// CornerChamfer cuts a flat bevel across the corner (a triangular notch through the wall).
+	CornerChamfer CornerTreatment = iota
+	// CornerRound rolls a fillet around the corner.
+	CornerRound
+)
+
+// ParseCornerTreatment resolves a wire spelling to a corner treatment.
+func ParseCornerTreatment(s string) (CornerTreatment, bool) {
+	switch s {
+	case "chamfer":
+		return CornerChamfer, true
+	case "round":
+		return CornerRound, true
+	}
+	return 0, false
+}
+
+// SheetMetalCornerDefinition is the corner recipe: the corner edges (through-thickness edge
+// reference keys), the treatment, and its size (chamfer setback / round radius).
+type SheetMetalCornerDefinition struct {
+	EdgeKeys  [][]byte
+	Treatment CornerTreatment
+	Size      func() float64
+}
+
+// SheetMetalCornerFeature finishes the sheet's corners each recompute.
+type SheetMetalCornerFeature struct {
+	def      *SheetMetalCornerDefinition
+	featName string
+}
+
+// Definition returns the corner recipe.
+func (f *SheetMetalCornerFeature) Definition() *SheetMetalCornerDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalCornerFeature) Kind() string { return "sheet-metal-corner" }
+
+// Recompute resolves the corner edges and chamfers or rounds them on the running sheet.
+func (f *SheetMetalCornerFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal corner")
+	if err != nil {
+		return Output{}, err
+	}
+	size := evalFloat(f.def.Size)
+	if size <= 0 {
+		return Output{}, fmt.Errorf("sheet-metal corner: size must be positive, got %g", size)
+	}
+	if len(f.def.EdgeKeys) == 0 {
+		return Output{}, fmt.Errorf("sheet-metal corner: no corner edges selected")
+	}
+	if f.def.Treatment == CornerRound {
+		return f.roundCorners(in, body, size)
+	}
+	return f.chamferCorners(in, body, size)
+}
+
+// roundCorners rolls a fillet of the given radius around the corner edges.
+func (f *SheetMetalCornerFeature) roundCorners(in Input, body *topo.Body, radius float64) (Output, error) {
+	res, err := ops.FilletEdges(body, f.def.EdgeKeys, radius)
+	if err != nil {
+		return Output{}, fmt.Errorf("sheet-metal corner round: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+}
+
+// chamferCorners cuts a flat bevel of the given setback across the corner edges.
+func (f *SheetMetalCornerFeature) chamferCorners(in Input, body *topo.Body, setback float64) (Output, error) {
+	edges, err := resolveEdges(body, f.def.EdgeKeys)
+	if err != nil {
+		return Output{}, err
+	}
+	work, edges := planarizeForEdges(body, edges, f.featName)
+	tools, err := chamferWedges(edges, setback, setback, f.featName)
+	if err != nil {
+		return Output{}, fmt.Errorf("sheet-metal corner chamfer: %w", err)
+	}
+	res, err := cutAll(work, tools)
+	if err != nil {
+		return Output{}, fmt.Errorf("sheet-metal corner chamfer: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+}
+
+// SheetMetalCornerFeatures adds corner features into the engine.
+type SheetMetalCornerFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalCornerFeatures binds the collection to a feature engine.
+func NewSheetMetalCornerFeatures(engine *PartFeatures) *SheetMetalCornerFeatures {
+	return &SheetMetalCornerFeatures{engine}
+}
+
+// Add appends a corner feature, naming it Corner1, Corner2, … .
+func (c *SheetMetalCornerFeatures) Add(def *SheetMetalCornerDefinition) *PartFeature {
+	f := &SheetMetalCornerFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Corner"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalCornerFeature)(nil)

--- a/model/feature/sheet_metal_corner_test.go
+++ b/model/feature/sheet_metal_corner_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// verticalCornerEdge returns a through-thickness (Z-aligned) corner edge of the sheet — the
+// edge a sheet-metal corner treatment finishes.
+func verticalCornerEdge(t *testing.T, body *topo.Body) *topo.Edge {
+	t.Helper()
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-b.X) < 1e-6 && math.Abs(a.Y-b.Y) < 1e-6 && math.Abs(a.Z-b.Z) > 1e-6 {
+			return e
+		}
+	}
+	t.Fatal("no vertical corner edge found on the sheet")
+	return nil
+}
+
+// flatSheetVolume is the volume of the un-cornered 4×4×0.2 sheet.
+const flatSheetVolume = 4.0 * 4.0 * 0.2
+
+func sheetVolume(body *topo.Body) float64 {
+	return ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-4}).Volume
+}
+
+// TestCornerChamferRemovesCorner a corner chamfer cuts a triangular notch off the sheet
+// corner: the result is a valid watertight solid whose volume drops by setback²/2 · thickness.
+func TestCornerChamferRemovesCorner(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	edge := verticalCornerEdge(t, fs.Result()[0])
+	pf := NewSheetMetalCornerFeatures(fs).Add(&SheetMetalCornerDefinition{
+		EdgeKeys: [][]byte{edge.ReferenceKey()}, Treatment: CornerChamfer, Size: func() float64 { return 1.0 },
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("corner chamfer sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("chamfered corner invalid: %v", r.Issues)
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("chamfered corner not watertight: %d boundary edges", len(open))
+	}
+	want := flatSheetVolume - (1.0*1.0/2)*0.2 // triangular prism removed
+	if got := sheetVolume(body); math.Abs(got-want) > 1e-4 {
+		t.Errorf("chamfered volume = %.5f, want %.5f", got, want)
+	}
+}
+
+// TestCornerRoundRemovesCorner a corner round rolls a fillet off the corner: a valid solid
+// whose volume drops by the corner sliver (r² − πr²/4) · thickness.
+func TestCornerRoundRemovesCorner(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	edge := verticalCornerEdge(t, fs.Result()[0])
+	const r = 1.0
+	pf := NewSheetMetalCornerFeatures(fs).Add(&SheetMetalCornerDefinition{
+		EdgeKeys: [][]byte{edge.ReferenceKey()}, Treatment: CornerRound, Size: func() float64 { return r },
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("corner round sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("rounded corner invalid: %v", r.Issues)
+	}
+	want := flatSheetVolume - (r*r-math.Pi*r*r/4)*0.2 // corner sliver removed
+	if got := sheetVolume(body); math.Abs(got-want)/want > 0.02 {
+		t.Errorf("rounded volume = %.5f, want ~%.5f (±2%%)", got, want)
+	}
+}
+
+// TestCornerRejectsBadInput a corner with no edges or a non-positive size goes sick.
+func TestCornerRejectsBadInput(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	edge := verticalCornerEdge(t, fs.Result()[0])
+	noSize := NewSheetMetalCornerFeatures(fs).Add(&SheetMetalCornerDefinition{
+		EdgeKeys: [][]byte{edge.ReferenceKey()}, Treatment: CornerChamfer, Size: func() float64 { return 0 },
+	})
+	fs.Recompute()
+	if noSize.Health().OK() {
+		t.Error("zero-size corner should be sick")
+	}
+}
+
+// TestParseCornerTreatment the wire spellings resolve, with an unknown one rejected.
+func TestParseCornerTreatment(t *testing.T) {
+	for s, want := range map[string]CornerTreatment{"chamfer": CornerChamfer, "round": CornerRound} {
+		if got, ok := ParseCornerTreatment(s); !ok || got != want {
+			t.Errorf("ParseCornerTreatment(%q) = (%d,%v), want (%d,true)", s, got, ok, want)
+		}
+	}
+	if _, ok := ParseCornerTreatment("seam"); ok {
+		t.Error("ParseCornerTreatment(seam) should be rejected here")
+	}
+}
+
+// TestCornerDefinitionAndKind the accessors return the recipe.
+func TestCornerDefinitionAndKind(t *testing.T) {
+	def := &SheetMetalCornerDefinition{Treatment: CornerRound}
+	f := &SheetMetalCornerFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-corner" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// TestCornerRoundTrip the corner recipe (edges + treatment + size) marshals and restores.
+func TestCornerRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalCornerFeatures(fs).Add(&SheetMetalCornerDefinition{
+		EdgeKeys: [][]byte{[]byte("k1"), []byte("k2")}, Treatment: CornerRound, Size: func() float64 { return 0.4 },
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalCorner
+	if data[0].Kind != "sheet-metal-corner" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-corner", data[0])
+	}
+	if len(d.Edges) != 2 || d.Treatment != int32(CornerRound) || d.Size != 0.4 {
+		t.Errorf("payload = %+v, want 2 edges / round / size 0.4", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-corner" {
+		t.Errorf("restored = %d features, want one corner", fresh.Count())
+	}
+}
+
+// TestCornerMissingPayload restoring a corner record with no payload errors.
+func TestCornerMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalCorner(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreSheetMetalCorner(nil) must error")
+	}
+}
+
+// TestCornerNoEdges a corner with no edge keys goes sick.
+func TestCornerNoEdges(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	pf := NewSheetMetalCornerFeatures(fs).Add(&SheetMetalCornerDefinition{Treatment: CornerChamfer, Size: func() float64 { return 1 }})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("corner with no edges should be sick")
+	}
+}


### PR DESCRIPTION
## What

The **Corner** treatment — chamfer or round one or more corners of a sheet-metal face (the through-thickness edge where two boundary edges of the wall meet). A single feature with a `treatment` enum covers both **CornerChamfer** (cut a flat across the corner) and **CornerRound** (roll a fillet), avoiding two near-identical wrappers.

The geometry reuses the part-modeling chamfer/fillet (a corner is just that vertical edge): round delegates to `ops.FilletEdges`; chamfer planarizes, builds the chamfer wedges and cuts them. Wrapped as a sheet-metal feature so it lives in the sheet-metal history and the flat pattern (F04). Recipe round-trips.

- **model/feature** — `SheetMetalCornerDefinition`/`Feature`, `CornerTreatment` + `ParseCornerTreatment`; recipe codec.
- **addin/opregistry** — the `sheetMetalCorner` operation (edges + treatment + size), reusing the shared `activeSheetMetalPart` guard.

## Test
Chamfer removes the **exact triangular prism** (`setback²/2·t`); round removes the corner sliver (`(r²−πr²/4)·t`, ±2%); both stay watertight valid solids; no-edges / zero-size → sick; recipe round-trip; over-the-wire add + error paths. Per-package coverage ~92% (model) / ~97% (opreg); lint 0.

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> Adds `sheetMetalCorner` to the source feature registry — to be absorbed (with the other `sheetMetal*` kinds) into the bridge's `TestE2EFeatureRegistryCoverage` in a follow-up bridge PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)