### PR TITLE
feat(viewport): Select Other — cycle occluded geometry (#910)

### DIFF
--- a/app/select_other.go
+++ b/app/select_other.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"sort"
+
+	"oblikovati.org/event"
+	"oblikovati.org/kernel/ops"
+)
+
+// Select Other — Inventor's S10: when several objects stack up under the cursor, cycle through
+// the occluded candidates (front to back) and commit the one you want, instead of always getting
+// the front-most. The picker resolves every body the ray crosses (PickAll); the session owns the
+// cycle state and applies the current candidate to the selection so each step is visible.
+
+// MultiPicker is a Picker that can also return every selectable under a pixel, depth-sorted —
+// the input to Select Other. The RayPicker implements it; a plain Picker (e.g. a test stub) does
+// not, so BeginSelectOther is a no-op there.
+type MultiPicker interface {
+	PickAll(x, y float64, filter *SelectionFilter) []Selectable
+}
+
+// RayPicker also answers the depth-sorted multi-pick that Select Other cycles through.
+var _ MultiPicker = (*RayPicker)(nil)
+
+// PickAll returns one candidate per body the ray crosses, depth-sorted front to back — the
+// occluded-geometry list Select Other cycles through. Each body resolves to the same selectable
+// Pick would give it (its component occurrence under a permissive filter, otherwise its face or
+// body), so cycling steps through distinct objects.
+func (p *RayPicker) PickAll(x, y float64, filter *SelectionFilter) []Selectable {
+	origin, dir := p.camera.RayThrough(x, y)
+	var cands []pickCandidate
+	for _, b := range p.bodies() {
+		f, t, ok := ops.RayCastFaces(b, origin, dir, ops.DefaultQuality())
+		if !ok {
+			continue
+		}
+		if occ, ok := p.occurrenceForBody(b, filter); ok {
+			cands = append(cands, pickCandidate{t, OccurrenceHandle{Occurrence: occ}})
+		} else if sel, ok := facePick(f, b, filter); ok {
+			cands = append(cands, pickCandidate{t, sel})
+		}
+	}
+	sort.SliceStable(cands, func(i, j int) bool { return cands[i].t < cands[j].t })
+	out := make([]Selectable, 0, len(cands))
+	for _, c := range cands {
+		out = append(out, c.sel)
+	}
+	return out
+}
+
+// selectOther is the in-progress Select Other cycle: the depth-sorted candidates and the index of
+// the one currently applied to the selection.
+type selectOther struct {
+	cands  []Selectable
+	index  int
+	active bool
+}
+
+// SelectOtherActive reports whether a Select Other cycle is in progress.
+func (s *Session) SelectOtherActive() bool { return s.selectOther.active }
+
+// SelectOtherStatus returns the 1-based position and the total candidate count, for the cycle
+// widget's "i / N" label.
+func (s *Session) SelectOtherStatus() (pos, count int) {
+	return s.selectOther.index + 1, len(s.selectOther.cands)
+}
+
+// BeginSelectOther starts a Select Other cycle at (x,y): it resolves every object under the cursor
+// and selects the front-most. It is a no-op (returning false, so the caller keeps the plain pick)
+// when the picker cannot enumerate candidates or fewer than two stack up — Select Other is only
+// meaningful when something is actually occluded.
+func (s *Session) BeginSelectOther(x, y float64) bool {
+	mp, ok := s.picker.(MultiPicker)
+	if !ok {
+		return false
+	}
+	cands := mp.PickAll(x, y, s.selection.Filter())
+	if len(cands) < 2 {
+		return false
+	}
+	s.selectOther = selectOther{cands: cands, index: 0, active: true}
+	s.applySelectOther()
+	return true
+}
+
+// CycleSelectOther advances the cycle by delta (+1 next / −1 previous), wrapping, and applies the
+// new candidate to the selection so it highlights.
+func (s *Session) CycleSelectOther(delta int) {
+	if !s.selectOther.active {
+		return
+	}
+	n := len(s.selectOther.cands)
+	s.selectOther.index = ((s.selectOther.index+delta)%n + n) % n
+	s.applySelectOther()
+}
+
+// applySelectOther replaces the selection with the current candidate and announces the change.
+func (s *Session) applySelectOther() {
+	s.selection.Clear()
+	if s.selection.Add(s.selectOther.cands[s.selectOther.index]) {
+		event.Emit(s.bus, event.After, SelectionChanged{Count: s.selection.Count()})
+	}
+}
+
+// CommitSelectOther ends the cycle, keeping the current candidate selected.
+func (s *Session) CommitSelectOther() { s.selectOther = selectOther{} }
+
+// CancelSelectOther ends the cycle (e.g. on Escape); the current candidate stays selected, as in
+// Inventor where Esc leaves the last-highlighted object picked.
+func (s *Session) CancelSelectOther() { s.selectOther = selectOther{} }

--- a/app/select_other_test.go
+++ b/app/select_other_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+// TestPickAllReturnsOccludedBodiesFrontToBack aims a ray through two stacked boxes and checks
+// PickAll returns both, the nearer one first — the occluded-geometry list Select Other walks.
+func TestPickAllReturnsOccludedBodiesFrontToBack(t *testing.T) {
+	s := extrudedBox(t, 2, 4) // box [0,2]×[0,2]×[0,4], centre (1,1,2)
+	front := partBodies(s)()[0]
+	back := front
+	near, err := ops.TransformBody(front, math.Translation4(math.V3(10, 0, 0)), func(l topo.Lineage) topo.Lineage { return l })
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+	// Camera at +X looking toward −X: the +10x copy (near) is in front of the original (back).
+	cam := scene.NewCamera(200, 200)
+	cam.Eye, cam.Target, cam.Up = math.P3(40, 1, 2), math.P3(0, 1, 2), math.V3(0, 0, 1)
+	p := NewRayPicker(cam, func() []*topo.Body { return []*topo.Body{back, near} })
+
+	hits := p.PickAll(100, 100, NewSelectionFilter()) // screen centre → the ray through both
+	if len(hits) != 2 {
+		t.Fatalf("PickAll through two stacked boxes = %d hits, want 2", len(hits))
+	}
+	if h, ok := hits[0].(FaceHandle); !ok || h.Body != near {
+		t.Errorf("front hit = %v, want a face of the nearer box", hits[0])
+	}
+	if h := hits[1].(FaceHandle); h.Body != back {
+		t.Errorf("second hit = %v, want a face of the farther box", hits[1])
+	}
+}
+
+// fakeMultiPicker returns a canned candidate list for PickAll (and the front-most for Pick), so the
+// cycle state machine is testable without real geometry.
+type fakeMultiPicker struct{ all []Selectable }
+
+func (f fakeMultiPicker) Pick(_, _ float64, _ *SelectionFilter) (Selectable, bool) {
+	if len(f.all) == 0 {
+		return nil, false
+	}
+	return f.all[0], true
+}
+func (f fakeMultiPicker) PickAll(_, _ float64, _ *SelectionFilter) []Selectable { return f.all }
+
+func TestSelectOtherCyclesAndCommits(t *testing.T) {
+	a, b, c := FaceHandle{Face: aFace()}, EdgeHandle{}, FaceHandle{Face: aFace()}
+	s := NewSession()
+	s.SetPicker(fakeMultiPicker{all: []Selectable{a, b, c}})
+
+	if !s.BeginSelectOther(0, 0) || !s.SelectOtherActive() {
+		t.Fatal("BeginSelectOther should start a cycle with 3 candidates")
+	}
+	if pos, count := s.SelectOtherStatus(); pos != 1 || count != 3 || !s.Selection().Contains(a) {
+		t.Fatalf("first candidate: pos=%d count=%d containsA=%v", pos, count, s.Selection().Contains(a))
+	}
+	s.CycleSelectOther(1)
+	if !s.Selection().Contains(b) {
+		t.Error("cycle +1 should select the second candidate")
+	}
+	s.CycleSelectOther(1)
+	s.CycleSelectOther(1) // wrap 2 → 0
+	if !s.Selection().Contains(a) {
+		t.Error("cycle should wrap back to the first candidate")
+	}
+	s.CycleSelectOther(-1) // wrap 0 → 2
+	if !s.Selection().Contains(c) {
+		t.Error("cycle −1 from the first should wrap to the last")
+	}
+	s.CommitSelectOther()
+	if s.SelectOtherActive() || !s.Selection().Contains(c) {
+		t.Errorf("commit should end the cycle keeping c: active=%v containsC=%v", s.SelectOtherActive(), s.Selection().Contains(c))
+	}
+}
+
+func TestBeginSelectOtherNoopWhenNothingOccluded(t *testing.T) {
+	a := FaceHandle{Face: aFace()}
+	// Fewer than two candidates → not worth cycling.
+	one := NewSession()
+	one.SetPicker(fakeMultiPicker{all: []Selectable{a}})
+	if one.BeginSelectOther(0, 0) || one.SelectOtherActive() {
+		t.Error("Select Other should not begin with a single candidate")
+	}
+	// A plain picker (no PickAll) → no Select Other.
+	plain := NewSession()
+	plain.SetPicker(stubPicker{sel: a})
+	if plain.BeginSelectOther(0, 0) {
+		t.Error("Select Other should not begin without a MultiPicker")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -54,6 +54,7 @@ type Session struct {
 	regionPicker         RegionPicker // resolves a box-select rectangle (nil ⇒ box-select disabled)
 	boxSelect            BoxSelection // the in-progress rubber-band rectangle, if any
 	entityDrag           sketchDrag   // the in-progress direct drag of sketch entities, if any
+	selectOther          selectOther  // the in-progress Select Other cycle, if any
 	camera               scene.Camera
 	camTween             cameraTween
 	driveAnim            driveAnimation

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -31,6 +31,12 @@ var (
 // single-pick click handler. Replaces the bare handleViewportClick call so they never both
 // fire on the same press.
 func handleViewportSelection(s *app.Session) {
+	if s.SelectOtherActive() {
+		if native.IsItemClicked(native.MouseLeft) {
+			s.CommitSelectOther() // a click in the viewport accepts the highlighted candidate (#910)
+		}
+		return // the Select Other cycle owns viewport picking until it ends
+	}
 	if updateSketchDrag(s) {
 		return
 	}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -152,8 +152,14 @@ func drawChromeWindows(s *app.Session) {
 	drawAddInPanels(s)   // add-in dockable windows (M05-F03)
 	// M26 F03: toasts / prompt modal / message-center windows are retired — every message
 	// now funnels into the docked Command Window, and prompts are answered inline there.
-	drawWebViews(s)                     // web dialogs/views (M05-F08)
-	drawMarkingMenu(s)                  // radial marking menu popup (M05-F12)
+	drawWebViews(s)          // web dialogs/views (M05-F08)
+	drawMarkingMenu(s)       // radial marking menu popup (M05-F12)
+	drawSelectOtherWidget(s) // Select Other cycle control over stacked geometry (#910)
+	serviceFileModalRequests(s)
+}
+
+// serviceFileModalRequests arms the file modal for ribbon buttons that request a file picker.
+func serviceFileModalRequests(s *app.Session) {
 	if s.TakeLoadEnvironmentRequest() { // the View ▸ Load HDR ribbon button arms the file modal
 		fileModal.openFor(dialogLoadHDR)
 	}
@@ -173,7 +179,11 @@ func handleKeyboard(s *app.Session) {
 	}
 	mods := heldModifiers()
 	if native.EscapePressed() {
-		_ = s.PressKey(app.KeyEvent{Key: "Escape", Mods: mods})
+		if s.SelectOtherActive() {
+			s.CancelSelectOther() // Esc ends the cycle, keeping the highlighted candidate (#910)
+		} else {
+			_ = s.PressKey(app.KeyEvent{Key: "Escape", Mods: mods})
+		}
 	}
 	// M26 F05: modifier chords (Ctrl/Alt — e.g. Ctrl+S, Ctrl+Z) fire even while the
 	// command-window input is focused, so they work mid-typing; PressKey routes them through

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -56,9 +56,7 @@ func drawSingleViewport(win *native.Window, s *app.Session) {
 	// Reserve the region with an input-capturing button, then read navigation from it.
 	cx, cy := native.GetCursorPos()
 	native.InvisibleButton("##viewport-nav", float32(pw), float32(ph))
-	if native.IsItemClicked(native.MouseRight) {
-		openMarkingMenu() // the radial marking menu (M05-F12)
-	}
+	handleViewportRightClick(s)
 	bx, by := native.ItemRectMin()
 
 	cam := s.Camera()

--- a/head/ui/inwindow_test.go
+++ b/head/ui/inwindow_test.go
@@ -389,3 +389,47 @@ func TestInWindowSketchBoxSelect(t *testing.T) {
 		t.Errorf("the box should select the enclosed line: count=%d", s.Selection().Count())
 	}
 }
+
+// fakeStackPicker reports two stacked candidates under any pixel — the input Select Other cycles
+// through (implements app.Picker + app.MultiPicker).
+type fakeStackPicker struct{ all []app.Selectable }
+
+func (f fakeStackPicker) Pick(_, _ float64, _ *app.SelectionFilter) (app.Selectable, bool) {
+	if len(f.all) == 0 {
+		return nil, false
+	}
+	return f.all[0], true
+}
+func (f fakeStackPicker) PickAll(_, _ float64, _ *app.SelectionFilter) []app.Selectable { return f.all }
+
+// TestInWindowRightClickBeginsSelectOther drives a real right-click over stacked geometry and
+// asserts the head began the Select Other cycle (instead of the marking menu) and renders its
+// widget (#910).
+func TestInWindowRightClickBeginsSelectOther(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+	s.SetPicker(fakeStackPicker{all: []app.Selectable{app.BodyHandle{}, app.EdgeHandle{}}})
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	cx, cy := float32(inWinW/2), float32(inWinH/2) // the docked viewport node
+
+	native.InjectMousePos(cx, cy)
+	frame()
+	frame()
+	native.InjectMouseButton(native.MouseRight, true) // right-click over the stack
+	frame()
+	if !s.SelectOtherActive() {
+		t.Fatal("right-click on stacked geometry did not begin Select Other")
+	}
+	if _, count := s.SelectOtherStatus(); count != 2 {
+		t.Errorf("Select Other count = %d, want 2", count)
+	}
+	native.InjectMouseButton(native.MouseRight, false)
+	frame() // the widget renders (drawSelectOtherWidget) without crashing
+}

--- a/head/ui/select_other_view.go
+++ b/head/ui/select_other_view.go
@@ -1,0 +1,71 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strconv"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Select Other (#910): a right-click on stacked geometry begins a cycle through the occluded
+// candidates instead of opening the marking menu. A small widget near the cursor steps through
+// them (each is selected as you go), and committing keeps the chosen one. The app.Session owns the
+// cycle; this file is just the trigger + the widget.
+
+// selectOtherScreenX/Y anchor the cycle widget at the press position.
+var selectOtherScreenX, selectOtherScreenY float32
+
+// handleViewportRightClick routes a viewport right-click: on stacked geometry it digs through the
+// occluded objects (Select Other, #910); otherwise it opens the radial marking menu (M05-F12).
+// Must be called right after the viewport's InvisibleButton.
+func handleViewportRightClick(s *app.Session) {
+	if !native.IsItemClicked(native.MouseRight) {
+		return
+	}
+	lx, ly := viewportCursor()
+	if !beginSelectOtherAt(s, lx, ly) {
+		openMarkingMenu()
+	}
+}
+
+// beginSelectOtherAt starts the cycle at a viewport pixel and, when it starts (more than one
+// object stacks up), remembers the screen position for the widget. Returns whether it started, so
+// the caller falls back to the marking menu when there is nothing occluded.
+func beginSelectOtherAt(s *app.Session, lx, ly float64) bool {
+	if !s.BeginSelectOther(lx, ly) {
+		return false
+	}
+	selectOtherScreenX, selectOtherScreenY = native.MousePos()
+	return true
+}
+
+// drawSelectOtherWidget draws the cycle control near the cursor while Select Other is active:
+// Next steps one object deeper (wrapping), Prev steps back, and Select commits the highlighted
+// one. Esc (keyboard path) also commits.
+func drawSelectOtherWidget(s *app.Session) {
+	if !s.SelectOtherActive() {
+		return
+	}
+	pos, count := s.SelectOtherStatus()
+	native.SetNextWindowPos(selectOtherScreenX+12, selectOtherScreenY+12)
+	if native.Begin("Select Other###select-other") {
+		if native.Button("Prev##so-prev") {
+			s.CycleSelectOther(-1)
+		}
+		native.SameLine()
+		native.Text(strconv.Itoa(pos) + " / " + strconv.Itoa(count))
+		native.SameLine()
+		if native.Button("Next##so-next") {
+			s.CycleSelectOther(1) // deeper into the occluded stack
+		}
+		native.SameLine()
+		if native.Button("Select##so-ok") {
+			s.CommitSelectOther()
+		}
+	}
+	native.End()
+}


### PR DESCRIPTION
## What

Implements **Select Other** (Inventor's S10): right-clicking stacked geometry digs through the objects under the cursor instead of always picking the front-most.

## How

- `app/select_other.go` — `RayPicker.PickAll` returns one candidate per body the ray crosses, **depth-sorted front to back** (behind a `MultiPicker` interface). The session owns the cycle: `Begin`/`Cycle`/`Commit`/`CancelSelectOther` + `SelectOtherActive`/`SelectOtherStatus`. Each step applies the current candidate to the selection so it highlights; `Begin` is a no-op unless something is actually occluded (≥2 candidates).
- `head/ui` — a viewport **right-click** begins the cycle (otherwise opens the marking menu); a small near-cursor widget steps **Prev / Next / Select**; **Esc** or a viewport click commits, keeping the highlighted object. Picking is suppressed while the cycle is active.

## Tests

- `app/select_other_test.go` — depth-ordered `PickAll` over two stacked boxes, the cycle state machine (begin/cycle/wrap/commit), and the no-op cases (single candidate, non-MultiPicker).
- Head in-window live test — a real right-click begins the cycle and the widget renders.

## Follow-ups (audit)

Remaining: #911 F-key navigation, #912 selection priority, #914 ViewCube zones, and curved-edge box-select sampling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)