### PR TITLE
feat: sheet-metal Lofted Flange feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -262,6 +262,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalFold":          `{"sketchIndex":0}`,
 		"sheetMetalCorner":        `{"edges":["x"],"treatment":"round","size":"3 mm"}`,
 		"sheetMetalContourFlange": `{"edge":"x","profileSketch":0}`,
+		"sheetMetalLoftedFlange":  `{"profileA":0,"profileB":0}`,
 		"splitSolid":              `{"toolSketch":0}`,
 		"coreCavity":              `{}`,
 		"hull":                    `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -137,6 +137,7 @@ func Default() *Registry {
 		sheetMetalFoldDescriptor(),
 		sheetMetalCornerDescriptor(),
 		sheetMetalContourFlangeDescriptor(),
+		sheetMetalLoftedFlangeDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_lofted_flange.go
+++ b/addin/opregistry/sheet_metal_lofted_flange.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalLoftedFlangeArgs is the argument shape for the "sheetMetalLoftedFlange" operation:
+// the two open-profile sketch indices and the boolean operation. Thickness comes from the rule.
+type sheetMetalLoftedFlangeArgs struct {
+	ProfileA  int    `json:"profileA"`
+	ProfileB  int    `json:"profileB"`
+	Operation string `json:"operation"` // new (default) | join
+}
+
+const sheetMetalLoftedFlangeSchema = `{
+  "type": "object",
+  "properties": {
+    "profileA": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the first open profile."},
+    "profileB": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the second open profile (same vertex count as A)."},
+    "operation": {"type": "string", "enum": ["new", "join"], "default": "new", "description": "new for a standalone transition wall, join to merge it onto the running part."}
+  },
+  "required": ["profileA", "profileB"]
+}`
+
+// sheetMetalLoftedFlangeDescriptor is the self-describing "sheetMetalLoftedFlange" operation:
+// loft a constant-thickness wall between two open profiles.
+func sheetMetalLoftedFlangeDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalLoftedFlange",
+		Summary: "Loft a constant-thickness sheet-metal wall between two open profiles (a transition piece), at the rule's thickness.",
+		Schema:  json.RawMessage(sheetMetalLoftedFlangeSchema),
+		Apply:   applySheetMetalLoftedFlange,
+	}
+}
+
+func applySheetMetalLoftedFlange(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalLoftedFlange")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalLoftedFlangeArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalLoftedFlange: invalid args: %w", err)
+	}
+	profileA, err := sketchAt(part, in.ProfileA)
+	if err != nil {
+		return nil, err
+	}
+	profileB, err := sketchAt(part, in.ProfileB)
+	if err != nil {
+		return nil, err
+	}
+	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalLoftedFlangeDefinition{ProfileA: profileA, ProfileB: profileB, Operation: op}
+	return recomputeResult(part, feature.NewSheetMetalLoftedFlangeFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_lofted_flange_test.go
+++ b/addin/opregistry/sheet_metal_lofted_flange_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// addLProfile adds an open L-profile (out w, up h) on the given plane to the part and returns
+// its sketch index.
+func addLProfile(def *compdef.PartComponentDefinition, plane sketch.Plane, w, h float64) int {
+	s := def.Sketches().Add(plane)
+	p0 := s.Points().Add(math.P2(0, 0))
+	p1 := s.Points().Add(math.P2(math.Scalar(w), 0))
+	p2 := s.Points().Add(math.P2(math.Scalar(w), math.Scalar(h)))
+	s.Lines().Add(p0, p1)
+	s.Lines().Add(p1, p2)
+	return def.Sketches().Count() - 1
+}
+
+// TestSheetMetalLoftedFlangeApply lofts a wall between two open profiles on a sheet-metal part
+// and confirms one healthy solid; then checks the error paths.
+func TestSheetMetalLoftedFlangeApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	a := addLProfile(def, sketch.XYPlane(), 1, 1)
+	b := addLProfile(def, planeB, 2, 2)
+
+	out, err := applyMap(t, s, "sheetMetalLoftedFlange", map[string]any{"profileA": a, "profileB": b})
+	if err != nil {
+		t.Fatalf("lofted flange apply: %v", err)
+	}
+	expectMergedSolid(t, out, "loftedFlange")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalLoftedFlange", `{"profileA":0,"profileB":0}`); err == nil {
+		t.Error("lofted flange on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalLoftedFlange", `{"profileA":99,"profileB":0}`); err == nil {
+		t.Error("lofted flange with an out-of-range profile must error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -78,6 +78,7 @@ type FeatureData struct {
 	SheetMetalFold          *SheetMetalFoldData          `yaml:"sheetMetalFold,omitempty"`          // M13-F02
 	SheetMetalCorner        *SheetMetalCornerData        `yaml:"sheetMetalCorner,omitempty"`        // M13-F02
 	SheetMetalContourFlange *SheetMetalContourFlangeData `yaml:"sheetMetalContourFlange,omitempty"` // M13-F02
+	SheetMetalLoftedFlange  *SheetMetalLoftedFlangeData  `yaml:"sheetMetalLoftedFlange,omitempty"`  // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -299,6 +300,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalContourFlange = smcf
+	case *SheetMetalLoftedFlangeFeature:
+		smlf, err := serializeSheetMetalLoftedFlange(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalLoftedFlange = smlf
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -500,6 +507,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalCorner(fs, fd.SheetMetalCorner)
 	case "sheet-metal-contour-flange":
 		return restoreSheetMetalContourFlange(fs, fd.SheetMetalContourFlange, sk)
+	case "sheet-metal-lofted-flange":
+		return restoreSheetMetalLoftedFlange(fs, fd.SheetMetalLoftedFlange, sk)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_lofted_flange.go
+++ b/model/feature/serialize_sheet_metal_lofted_flange.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// SheetMetalLoftedFlangeData is the serialized form of a SheetMetalLoftedFlangeFeature: the
+// two profile sketch indices and the boolean operation. Thickness is read live from the rule.
+type SheetMetalLoftedFlangeData struct {
+	ProfileA  int   `yaml:"profileA"`
+	ProfileB  int   `yaml:"profileB"`
+	Operation int32 `yaml:"operation,omitempty"`
+}
+
+// serializeSheetMetalLoftedFlange projects a lofted-flange recipe to its persisted form,
+// erroring if either profile sketch is not in the part.
+func serializeSheetMetalLoftedFlange(def *SheetMetalLoftedFlangeDefinition, sk SketchIndexer) (*SheetMetalLoftedFlangeData, error) {
+	a, ok := sk.IndexOf(def.ProfileA)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal lofted flange references a profile A sketch not in the part")
+	}
+	b, ok := sk.IndexOf(def.ProfileB)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal lofted flange references a profile B sketch not in the part")
+	}
+	return &SheetMetalLoftedFlangeData{ProfileA: a, ProfileB: b, Operation: int32(def.Operation)}, nil
+}
+
+// restoreSheetMetalLoftedFlange rebuilds a lofted-flange feature, erroring on a missing
+// payload or an unknown profile sketch.
+func restoreSheetMetalLoftedFlange(fs *PartFeatures, d *SheetMetalLoftedFlangeData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal lofted flange feature is missing its payload")
+	}
+	a, ok := sk.At(d.ProfileA)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal lofted flange references sketch %d which is not in the part", d.ProfileA)
+	}
+	b, ok := sk.At(d.ProfileB)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal lofted flange references sketch %d which is not in the part", d.ProfileB)
+	}
+	return NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
+		ProfileA: a, ProfileB: b, Operation: ops.PartFeatureOperation(d.Operation),
+	}), nil
+}

--- a/model/feature/sheet_metal_contour_flange.go
+++ b/model/feature/sheet_metal_contour_flange.go
@@ -94,17 +94,25 @@ func buildContourFlangeSolid(edge *topo.Edge, profile []math.Point2, thickness f
 	return buildPrism(band, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), nil
 }
 
-// contourBand returns the closed cross-section band for the profile: the inner contour, then
-// the outer contour (the inner offset toward the material by the thickness) reversed, each
-// mapped into the section plane via at.
+// contourBand returns the closed cross-section band for the profile mapped into the section
+// plane via at.
 func contourBand(profile []math.Point2, thickness float64, at func(math.Point2) math.Point2) []math.Point2 {
-	outer := offsetProfile(profile, -thickness) // offset toward −up (the sheet's material side)
-	band := make([]math.Point2, 0, len(profile)+len(outer))
-	for _, p := range profile {
-		band = append(band, at(p))
+	band := profileBand2D(profile, thickness)
+	for i, p := range band {
+		band[i] = at(p)
 	}
+	return band
+}
+
+// profileBand2D returns the closed constant-thickness band of an open profile: the inner
+// contour, then its outer offset (toward the material side) reversed. Shared by the contour
+// flange and the lofted flange.
+func profileBand2D(profile []math.Point2, thickness float64) []math.Point2 {
+	outer := offsetProfile(profile, -thickness)
+	band := make([]math.Point2, 0, len(profile)+len(outer))
+	band = append(band, profile...)
 	for i := len(outer) - 1; i >= 0; i-- {
-		band = append(band, at(outer[i]))
+		band = append(band, outer[i])
 	}
 	return band
 }

--- a/model/feature/sheet_metal_lofted_flange.go
+++ b/model/feature/sheet_metal_lofted_flange.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Lofted Flange feature (M13-F02). A lofted flange is a constant-thickness wall
+// that transitions between TWO open profiles on two sketch planes — the sheet-metal way to
+// build a transition piece (e.g. a square-to-round duct). Each profile is thickened in its
+// plane into a band; the two bands loft into one solid. Both profiles must have the same
+// vertex count so their bands correspond point-for-point. Thickness is read live from the
+// rule. The result is a new body (or joined to the running part).
+
+// SheetMetalLoftedFlangeDefinition is the lofted-flange recipe: the two open profile sketches
+// and the boolean operation (new body / join).
+type SheetMetalLoftedFlangeDefinition struct {
+	ProfileA  *sketch.Sketch
+	ProfileB  *sketch.Sketch
+	Operation ops.PartFeatureOperation
+}
+
+// SheetMetalLoftedFlangeFeature lofts the transition wall each recompute.
+type SheetMetalLoftedFlangeFeature struct {
+	def      *SheetMetalLoftedFlangeDefinition
+	featName string
+}
+
+// Definition returns the lofted-flange recipe.
+func (f *SheetMetalLoftedFlangeFeature) Definition() *SheetMetalLoftedFlangeDefinition {
+	return f.def
+}
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalLoftedFlangeFeature) Kind() string { return "sheet-metal-lofted-flange" }
+
+// Recompute thickens each profile into a band and lofts the two into a transition wall.
+func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
+	t, err := sheetThickness(in.Params)
+	if err != nil {
+		return Output{}, err
+	}
+	bandA, err := loftBand(f.def.ProfileA, t)
+	if err != nil {
+		return Output{}, err
+	}
+	bandB, err := loftBand(f.def.ProfileB, t)
+	if err != nil {
+		return Output{}, err
+	}
+	if len(bandA) != len(bandB) {
+		return Output{}, fmt.Errorf("sheet-metal lofted flange: profiles have %d and %d vertices; both must match to loft", len(bandA), len(bandB))
+	}
+	wall, err := sweptSolid([][]math.Point3{bandA, bandB}, false, featOr(f.featName, "loftedFlange"))
+	if err != nil {
+		return Output{}, fmt.Errorf("sheet-metal lofted flange: %w", err)
+	}
+	bodies, err := combine(in.Bodies, wall, f.def.Operation)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// loftBand thickens an open profile into its closed 3D band on the profile's sketch plane.
+func loftBand(sk *sketch.Sketch, thickness float64) ([]math.Point3, error) {
+	profile, err := openProfilePoints(sk)
+	if err != nil {
+		return nil, err
+	}
+	band2D := profileBand2D(profile, thickness)
+	plane := sk.Plane()
+	band := make([]math.Point3, len(band2D))
+	for i, p := range band2D {
+		band[i] = plane.ToModel(p)
+	}
+	return band, nil
+}
+
+// SheetMetalLoftedFlangeFeatures adds lofted-flange features into the engine.
+type SheetMetalLoftedFlangeFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalLoftedFlangeFeatures binds the collection to a feature engine.
+func NewSheetMetalLoftedFlangeFeatures(engine *PartFeatures) *SheetMetalLoftedFlangeFeatures {
+	return &SheetMetalLoftedFlangeFeatures{engine}
+}
+
+// Add appends a lofted-flange feature, naming it LoftedFlange1, … .
+func (c *SheetMetalLoftedFlangeFeatures) Add(def *SheetMetalLoftedFlangeDefinition) *PartFeature {
+	f := &SheetMetalLoftedFlangeFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("LoftedFlange"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalLoftedFlangeFeature)(nil)

--- a/model/feature/sheet_metal_lofted_flange_test.go
+++ b/model/feature/sheet_metal_lofted_flange_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// lProfileOnPlane returns an open L-profile (out `w`, then up `h`) on the given plane.
+func lProfileOnPlane(plane sketch.Plane, w, h float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(plane)
+	p0 := s.Points().Add(math.P2(0, 0))
+	p1 := s.Points().Add(math.P2(math.Scalar(w), 0))
+	p2 := s.Points().Add(math.P2(math.Scalar(w), math.Scalar(h)))
+	s.Lines().Add(p0, p1)
+	s.Lines().Add(p1, p2)
+	return s
+}
+
+// thicknessParams returns a parameter set with just the Thickness parameter.
+func thicknessParams(t *testing.T) *param.Parameters {
+	t.Helper()
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	return ps
+}
+
+// TestLoftedFlangeLoftsTransition a lofted flange between two L-profiles on parallel planes
+// builds one valid watertight transition wall.
+func TestLoftedFlangeLoftsTransition(t *testing.T) {
+	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	fs := NewPartFeatures(thicknessParams(t), nil)
+	pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
+		ProfileA:  lProfileOnPlane(sketch.XYPlane(), 1, 1),
+		ProfileB:  lProfileOnPlane(planeB, 2, 2),
+		Operation: ops.NewBody,
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("lofted flange sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if !body.IsSolid() {
+		t.Fatal("lofted flange is not a solid")
+	}
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("lofted flange invalid: %v", r.Issues)
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("lofted flange not watertight: %d boundary edges", len(open))
+	}
+	if v := ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-3}).Volume; v <= 0 {
+		t.Errorf("lofted flange volume = %g, want positive", v)
+	}
+}
+
+// TestLoftedFlangeMismatchedProfiles profiles with different vertex counts cannot loft.
+func TestLoftedFlangeMismatchedProfiles(t *testing.T) {
+	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	threePt := lProfileOnPlane(planeB, 2, 2) // 3 vertices
+	// A two-vertex profile (single segment) on XY.
+	twoPt := sketch.NewSketches().Add(sketch.XYPlane())
+	a := twoPt.Points().Add(math.P2(0, 0))
+	b := twoPt.Points().Add(math.P2(1, 0))
+	twoPt.Lines().Add(a, b)
+
+	fs := NewPartFeatures(thicknessParams(t), nil)
+	pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
+		ProfileA: twoPt, ProfileB: threePt, Operation: ops.NewBody,
+	})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("lofting mismatched-vertex profiles should be sick")
+	}
+}
+
+// TestLoftedFlangeNeedsThickness without a Thickness parameter the feature goes sick.
+func TestLoftedFlangeNeedsThickness(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters(), nil) // no Thickness
+	pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
+		ProfileA: lProfileOnPlane(sketch.XYPlane(), 1, 1), ProfileB: lProfileOnPlane(sketch.XYPlane(), 1, 1),
+	})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("lofted flange without a Thickness parameter should be sick")
+	}
+}
+
+// TestLoftedFlangeDefinitionAndKind the accessors return the recipe.
+func TestLoftedFlangeDefinitionAndKind(t *testing.T) {
+	def := &SheetMetalLoftedFlangeDefinition{}
+	f := &SheetMetalLoftedFlangeFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-lofted-flange" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// twoSketchIndexer is a SketchIndexer over two sketches at indices 0 and 1.
+type twoSketchIndexer struct{ a, b *sketch.Sketch }
+
+func (x twoSketchIndexer) IndexOf(s *sketch.Sketch) (int, bool) {
+	switch s {
+	case x.a:
+		return 0, true
+	case x.b:
+		return 1, true
+	}
+	return 0, false
+}
+
+func (x twoSketchIndexer) At(i int) (*sketch.Sketch, bool) {
+	switch i {
+	case 0:
+		return x.a, true
+	case 1:
+		return x.b, true
+	}
+	return nil, false
+}
+
+// TestLoftedFlangeRoundTrip the recipe (two profile indices + operation) marshals and restores.
+func TestLoftedFlangeRoundTrip(t *testing.T) {
+	pa := lProfileOnPlane(sketch.XYPlane(), 1, 1)
+	pb := lProfileOnPlane(sketch.XYPlane(), 2, 2)
+	idx := twoSketchIndexer{a: pa, b: pb}
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{ProfileA: pa, ProfileB: pb, Operation: ops.Join})
+
+	data, err := fs.MarshalRecipe(idx)
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalLoftedFlange
+	if data[0].Kind != "sheet-metal-lofted-flange" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-lofted-flange", data[0])
+	}
+	if d.ProfileA != 0 || d.ProfileB != 1 || d.Operation != int32(ops.Join) {
+		t.Errorf("payload = %+v, want profiles 0/1 / join", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, idx, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-lofted-flange" {
+		t.Errorf("restored = %d features, want one lofted flange", fresh.Count())
+	}
+}
+
+// TestLoftedFlangeMissingPayload / unknown sketch restore errors.
+func TestLoftedFlangeMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalLoftedFlange(NewPartFeatures(nil, nil), nil, twoSketchIndexer{}); err == nil {
+		t.Error("restoreSheetMetalLoftedFlange(nil) must error")
+	}
+	if _, err := serializeSheetMetalLoftedFlange(&SheetMetalLoftedFlangeDefinition{ProfileA: lProfileOnPlane(sketch.XYPlane(), 1, 1)}, twoSketchIndexer{}); err == nil {
+		t.Error("serialize with an unknown profile A must error")
+	}
+}


### PR DESCRIPTION
## What

The **Lofted Flange** — a constant-thickness wall that transitions between **two** open profiles on two sketch planes (the sheet-metal way to build a transition piece, e.g. square-to-round duct). Continues the profile-driven F02 features after the Contour Flange (#929, merged).

Each profile is thickened in its plane into a band (reusing the contour flange's `profileBand2D`, extracted here as a shared helper); the two bands loft into one solid via `sweptSolid`. Both profiles must have the same vertex count so their bands correspond. Thickness read live from the rule; the result is a new body or joined to the running part.

- **model/feature** — `SheetMetalLoftedFlangeDefinition`/`Feature`, the per-profile band-on-plane builder; recipe codec. `profileBand2D` extracted from the contour flange so both reuse one band routine.
- **addin/opregistry** — the `sheetMetalLoftedFlange` operation (two profile sketches + operation), reusing the shared `activeSheetMetalPart` guard.

## Test
Two L-profiles on parallel planes loft into one **watertight valid solid**; mismatched-vertex profiles and missing thickness → sick; recipe round-trip + serialize-unknown-sketch error; over-the-wire add + error paths. Per-package coverage ~91% (model) / ~91% (opreg); lint 0.

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> Adds `sheetMetalLoftedFlange` to the source feature registry — to be absorbed (with the other `sheetMetal*` kinds) into the bridge's `TestE2EFeatureRegistryCoverage` in a follow-up bridge PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)