### PR TITLE
feat(viewport): selection priority — Edge / Face / Part (#912)

### DIFF
--- a/app/box_select.go
+++ b/app/box_select.go
@@ -98,7 +98,7 @@ func (s *Session) regionHits(b BoxSelection) []Selectable {
 	if s.regionPicker == nil {
 		return nil
 	}
-	return s.regionPicker.PickRegion(b.X0, b.Y0, b.X1, b.Y1, b.Crossing(), s.selection.Filter())
+	return s.regionPicker.PickRegion(b.X0, b.Y0, b.X1, b.Y1, b.Crossing(), s.pickFilter())
 }
 
 // applyRegionToSelection folds box-select hits into the selection set: a plain box replaces

--- a/app/commands_selection_priority.go
+++ b/app/commands_selection_priority.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// selectionPrioritySpec pairs a priority with its ribbon label and tooltip.
+type selectionPrioritySpec struct {
+	priority       SelectionPriority
+	id, label, tip string
+}
+
+var selectionPrioritySpecs = []selectionPrioritySpec{
+	{PriorityGeneral, "Select.Priority.General", "General", "Select any geometry (the default)."},
+	{PriorityPart, "Select.Priority.Part", "Part Priority", "A click selects the whole body / component."},
+	{PriorityFace, "Select.Priority.Face", "Face Priority", "A click selects faces."},
+	{PriorityEdge, "Select.Priority.Edge", "Edge Priority", "A click selects edges."},
+}
+
+// selectionPriorityCommands are the View tab's Select panel: a mutually-exclusive combo (like the
+// Visual Style box) that sets the no-tool selection priority, biasing both click and box-select
+// picking (#912 / Inventor's Select dropdown).
+func selectionPriorityCommands() []*CommandDefinition {
+	cmds := make([]*CommandDefinition, 0, len(selectionPrioritySpecs))
+	for _, sp := range selectionPrioritySpecs {
+		cmds = append(cmds, NewCommand(sp.id, sp.label, "Select", func(s *Session) error {
+			s.SetSelectionPriority(sp.priority)
+			return nil
+		}).WithTab("View").WithKind(ComboControl).WithTooltip(sp.tip).
+			WithActive(func(s *Session) bool { return s.SelectionPriority() == sp.priority }))
+	}
+	return cmds
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -600,6 +600,7 @@ func viewTabCommands() []*CommandDefinition {
 	cmds := append(viewNavigateCommands(), orientViewCommands()...)
 	cmds = append(cmds, displayViewCommands()...)
 	cmds = append(cmds, colorStylesCommand())
+	cmds = append(cmds, selectionPriorityCommands()...)
 	cmds = append(cmds, visualStyleCommands()...)
 	cmds = append(cmds, colorSchemeCommands()...)
 	cmds = append(cmds, lightingViewCommands()...)

--- a/app/selection.go
+++ b/app/selection.go
@@ -179,6 +179,10 @@ func (f *SelectionFilter) Accepts(k SelectionKind) bool {
 	return f.kinds[k]
 }
 
+// IsRestricted reports whether the filter limits the accepted kinds (i.e. it is not the
+// accept-everything default) — so a caller can tell an explicitly-set filter from the default.
+func (f *SelectionFilter) IsRestricted() bool { return f != nil && len(f.kinds) > 0 }
+
 // Selection is the current selection set — Inventor's SelectSet. It is an ordered,
 // de-duplicated list of selectables with an active filter.
 type Selection struct {

--- a/app/selection_priority.go
+++ b/app/selection_priority.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Selection priority — Inventor's S11: with no tool active, the priority biases what an ambiguous
+// viewport pick (a click or a box-select) prefers. It maps to the filter the no-tool pick honours,
+// so the same setting drives both click selection and box-select granularity (#922): Part priority
+// selects whole bodies/components, Face faces, Edge edges, and General accepts anything (the
+// context default). A tool, when active, sets its own filter, which always wins.
+
+// SelectionPriority biases no-tool picking toward a kind of geometry.
+type SelectionPriority uint8
+
+const (
+	// PriorityGeneral accepts any geometry — the default, context-driven pick.
+	PriorityGeneral SelectionPriority = iota
+	// PriorityPart selects whole bodies (and components in an assembly).
+	PriorityPart
+	// PriorityFace selects faces.
+	PriorityFace
+	// PriorityEdge selects edges.
+	PriorityEdge
+)
+
+// SelectionPriority returns the active no-tool selection priority.
+func (s *Session) SelectionPriority() SelectionPriority { return s.selectionPriority }
+
+// SetSelectionPriority sets the no-tool selection priority.
+func (s *Session) SetSelectionPriority(p SelectionPriority) { s.selectionPriority = p }
+
+// pickFilter is the filter a viewport pick honours. An active tool's filter, or any explicitly
+// restricted filter, always wins; only when nothing has restricted it (no tool, default
+// accept-all filter) does the selection priority apply. The no-tool click (Session.Pointer) and
+// box-select consult it so a priority biases both.
+func (s *Session) pickFilter() *SelectionFilter {
+	if s.tool == nil && !s.selection.Filter().IsRestricted() {
+		return priorityFilter(s.selectionPriority)
+	}
+	return s.selection.Filter()
+}
+
+// priorityFilter maps a selection priority to the kinds a no-tool pick accepts.
+func priorityFilter(p SelectionPriority) *SelectionFilter {
+	switch p {
+	case PriorityPart:
+		return NewSelectionFilter(SelectBody, SelectOccurrence)
+	case PriorityFace:
+		return NewSelectionFilter(SelectFace)
+	case PriorityEdge:
+		return NewSelectionFilter(SelectEdge)
+	default:
+		return NewSelectionFilter() // General: accept everything
+	}
+}

--- a/app/selection_priority_test.go
+++ b/app/selection_priority_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+func TestPriorityFilterMapping(t *testing.T) {
+	cases := []struct {
+		p      SelectionPriority
+		kind   SelectionKind
+		accept bool
+	}{
+		{PriorityGeneral, SelectFace, true}, // accepts everything
+		{PriorityGeneral, SelectEdge, true},
+		{PriorityPart, SelectBody, true},
+		{PriorityPart, SelectFace, false},
+		{PriorityFace, SelectFace, true},
+		{PriorityFace, SelectEdge, false},
+		{PriorityEdge, SelectEdge, true},
+		{PriorityEdge, SelectFace, false},
+	}
+	for _, c := range cases {
+		if got := priorityFilter(c.p).Accepts(c.kind); got != c.accept {
+			t.Errorf("priority %d accepts %d = %v, want %v", c.p, c.kind, got, c.accept)
+		}
+	}
+}
+
+func TestPickFilterUsesToolFilterThenPriority(t *testing.T) {
+	s := NewSession()
+	s.SetSelectionPriority(PriorityEdge)
+	// No tool → the priority filter (edge-only).
+	if s.pickFilter().Accepts(SelectFace) {
+		t.Error("with no tool, pickFilter should be the edge-priority filter (no faces)")
+	}
+	// A tool active → its own filter wins (the default tool filter accepts all here).
+	s.StartTool(stubSketchTool{})
+	if !s.pickFilter().Accepts(SelectFace) {
+		t.Error("with a tool active, pickFilter should be the tool's filter, not the priority")
+	}
+}
+
+// rayPickerSession builds a box viewed head-on at a face, with the RayPicker installed, so a
+// screen-centre click lands on the +X face centre.
+func rayPickerSession(t *testing.T) *Session {
+	t.Helper()
+	s := extrudedBox(t, 2, 4) // [0,2]×[0,2]×[0,4]; +X face centre ≈ (2,1,2)
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target, cam.Up = math.P3(20, 1, 2), math.P3(0, 1, 2), math.V3(0, 0, 1)
+	s.SetCamera(cam)
+	s.SetPicker(NewRayPicker(cam, partBodies(s)))
+	return s
+}
+
+func TestSelectionPriorityRibbonCombo(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if err := s.Execute("Select.Priority.Edge"); err != nil {
+		t.Fatalf("execute Select.Priority.Edge: %v", err)
+	}
+	if s.SelectionPriority() != PriorityEdge {
+		t.Errorf("the Edge-priority combo command did not set the priority: got %d", s.SelectionPriority())
+	}
+	if _, ok := s.Commands().ByID("Select.Priority.General"); !ok {
+		t.Error("the General-priority combo command should be registered")
+	}
+}
+
+func TestSelectionPriorityBiasesClick(t *testing.T) {
+	s := rayPickerSession(t)
+
+	// General priority: a click on a face selects the face.
+	s.SetSelectionPriority(PriorityGeneral)
+	s.Click(200, 200)
+	if _, ok := s.Selection().First().(FaceHandle); !ok {
+		t.Fatalf("General priority click = %T, want a FaceHandle", s.Selection().First())
+	}
+
+	// Part priority: the same click selects the whole body.
+	s.Selection().Clear()
+	s.SetSelectionPriority(PriorityPart)
+	s.Click(200, 200)
+	if _, ok := s.Selection().First().(BodyHandle); !ok {
+		t.Fatalf("Part priority click = %T, want a BodyHandle", s.Selection().First())
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -51,11 +51,12 @@ type Session struct {
 	selection            *Selection
 	tool                 *ToolInstance
 	picker               Picker
-	regionPicker         RegionPicker // resolves a box-select rectangle (nil ⇒ box-select disabled)
-	boxSelect            BoxSelection // the in-progress rubber-band rectangle, if any
-	entityDrag           sketchDrag   // the in-progress direct drag of sketch entities, if any
-	selectOther          selectOther  // the in-progress Select Other cycle, if any
-	viewHistory          viewHistory  // recorded views for Previous View (F5)
+	regionPicker         RegionPicker      // resolves a box-select rectangle (nil ⇒ box-select disabled)
+	boxSelect            BoxSelection      // the in-progress rubber-band rectangle, if any
+	entityDrag           sketchDrag        // the in-progress direct drag of sketch entities, if any
+	selectOther          selectOther       // the in-progress Select Other cycle, if any
+	viewHistory          viewHistory       // recorded views for Previous View (F5)
+	selectionPriority    SelectionPriority // biases no-tool picking (Edge/Face/Part) (#912)
 	camera               scene.Camera
 	camTween             cameraTween
 	driveAnim            driveAnimation

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -163,7 +163,7 @@ func (s *Session) Pointer(e PointerEvent) {
 	if s.picker == nil {
 		return
 	}
-	sel, ok := s.picker.Pick(e.X, e.Y, s.selection.Filter())
+	sel, ok := s.picker.Pick(e.X, e.Y, s.pickFilter())
 	if !ok {
 		s.clearSelectionOnEmptyClick(e.Mods)
 		return


### PR DESCRIPTION
## What

Adds Inventor's **selection priority** (S11): with no tool active, the priority biases what an ambiguous viewport pick prefers — **Part** selects whole bodies/components, **Face** faces, **Edge** edges, **General** anything (the default).

## How

- `app/selection_priority.go` — `Session.SetSelectionPriority`/`SelectionPriority` + `pickFilter`. The priority maps to the filter a no-tool pick honours, so one setting drives **both** click selection and **box-select granularity** (reusing #922). An active tool's filter — or any explicitly-restricted filter — always wins; the priority applies only to the unrestricted default (so tools and existing filter-setting code are unaffected).
- Wired into the click pick (`Session.Pointer`) and box-select (`regionHits`).
- `app/commands_selection_priority.go` — a **View-tab Select combo** (ComboControl, like the Visual Style box) to switch it.

## Tests

`app/selection_priority_test.go` — priority→filter mapping, tool-vs-priority precedence, a real click biased General→face / Part→body, and the ribbon combo registration/dispatch. Full app + head/ui suites green.

## Follow-ups (audit)

Remaining: #914 ViewCube zones, curved-edge box-select sampling. (Feature priority needs face→feature resolution — a later refinement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)