### PR TITLE
feat: sheet-metal Corner Seam feature (M13-F02)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -264,6 +264,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalContourFlange": `{"edge":"x","profileSketch":0}`,
 		"sheetMetalLoftedFlange":  `{"profileA":0,"profileB":0}`,
 		"sheetMetalContourRoll":   `{"profileSketch":0,"axisLine":0}`,
+		"sheetMetalCornerSeam":    `{"edges":["x"],"gap":"0.2 mm"}`,
 		"splitSolid":              `{"toolSketch":0}`,
 		"coreCavity":              `{}`,
 		"hull":                    `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -139,6 +139,7 @@ func Default() *Registry {
 		sheetMetalContourFlangeDescriptor(),
 		sheetMetalLoftedFlangeDescriptor(),
 		sheetMetalContourRollDescriptor(),
+		sheetMetalCornerSeamDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_corner_seam.go
+++ b/addin/opregistry/sheet_metal_corner_seam.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalCornerSeamArgs is the argument shape for the "sheetMetalCornerSeam" operation: the
+// corner edges (the shared through-thickness edges where flanges meet), the gap, and the seam
+// type.
+type sheetMetalCornerSeamArgs struct {
+	Edges []string `json:"edges"`
+	Gap   string   `json:"gap"`
+	Type  string   `json:"type,omitempty"` // gap (default)
+}
+
+const sheetMetalCornerSeamSchema = `{
+  "type": "object",
+  "properties": {
+    "edges": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the corner edges where flanges meet (from get_reference_keys)."},
+    "gap": {"type": "string", "description": "Seam gap, e.g. \"0.2 mm\" — the relief left between the two corner walls."},
+    "type": {"type": "string", "enum": ["gap"], "default": "gap", "description": "The seam relief type."}
+  },
+  "required": ["edges", "gap"]
+}`
+
+// sheetMetalCornerSeamDescriptor is the self-describing "sheetMetalCornerSeam" operation:
+// relieve the corner where two flanges meet with a gap.
+func sheetMetalCornerSeamDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalCornerSeam",
+		Summary: "Relieve the corner where two sheet-metal flanges meet with a gap seam (a square notch of the given gap along the shared corner edges).",
+		Schema:  json.RawMessage(sheetMetalCornerSeamSchema),
+		Apply:   applySheetMetalCornerSeam,
+	}
+}
+
+func applySheetMetalCornerSeam(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalCornerSeam")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalCornerSeamArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalCornerSeam: invalid args: %w", err)
+	}
+	if len(in.Edges) == 0 {
+		return nil, fmt.Errorf("sheetMetalCornerSeam: edges is empty")
+	}
+	seam, ok := feature.ParseSeamType(in.Type)
+	if !ok {
+		return nil, fmt.Errorf("sheetMetalCornerSeam: unknown type %q (want gap)", in.Type)
+	}
+	gap, err := lengthClosure(part, in.Gap, "sheetMetalCornerSeam: gap")
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalCornerSeamDefinition{EdgeKeys: refKeys(in.Edges), Gap: gap, Type: seam}
+	return recomputeResult(part, feature.NewSheetMetalCornerSeamFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_corner_seam_test.go
+++ b/addin/opregistry/sheet_metal_corner_seam_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// TestSheetMetalCornerSeamApply seeds a sheet-metal wall and cuts a gap seam at a corner edge,
+// confirming one healthy solid; then checks the error paths.
+func TestSheetMetalCornerSeamApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	edge := verticalCornerEdgeKey(t, def)
+
+	out, err := applyMap(t, s, "sheetMetalCornerSeam", map[string]any{"edges": []string{edge}, "gap": "3 mm"})
+	if err != nil {
+		t.Fatalf("corner seam apply: %v", err)
+	}
+	expectMergedSolid(t, out, "cornerSeam")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalCornerSeam", `{"edges":["x"],"gap":"1 mm"}`); err == nil {
+		t.Error("corner seam on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalCornerSeam", `{"edges":[],"gap":"1 mm"}`); err == nil {
+		t.Error("corner seam with no edges must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalCornerSeam", map[string]any{"edges": []string{edge}, "gap": "1 mm", "type": "overlap"}); err == nil {
+		t.Error("corner seam with an unsupported type must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalCornerSeam", map[string]any{"edges": []string{edge}, "gap": "bad"}); err == nil {
+		t.Error("corner seam with a bad gap must error")
+	}
+}

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -12,6 +12,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
 )
 
 // singularDetTol is the magnitude below which a normal determinant (three planes' triple
@@ -151,27 +152,49 @@ func chamferOverhang(d1, d2 float64) float64 {
 // the edge (with a small overhang past each end so the boolean is clean). Equal d1==d2 is the
 // symmetric chamfer; d1≠d2 is the asymmetric two-distance / distance-angle chamfer.
 func chamferWedge(edge *topo.Edge, d1, d2 float64, feat string) (*topo.Body, error) {
+	fr, err := edgeCornerFrame(edge, "chamfer")
+	if err != nil {
+		return nil, err
+	}
+	poly := []math.Point2{{X: 0, Y: 0}, fr.proj(fr.t1.Scale(d1)), fr.proj(fr.t2.Scale(d2))}
+	oh := chamferOverhang(d1, d2)
+	return buildPrism(poly, fr.plane, span{near: -oh, far: fr.length + oh}, 0, feat), nil
+}
+
+// edgeFrame is the resolved corner-cut frame at an edge (see edgeCornerFrame).
+type edgeFrame struct {
+	t1, t2 math.Vector3
+	plane  sketch.Plane
+	proj   func(math.Vector3) math.Point2
+	length float64
+}
+
+// edgeCornerFrame resolves the section frame at an edge for a corner cut: the two adjacent
+// faces' interior directions (t1/t2), the plane perpendicular to the edge, a projector into
+// that plane's 2D coords, and the edge length. Shared by the chamfer wedge and the
+// sheet-metal corner-seam relief, which differ only in the 2D notch polygon they build.
+func edgeCornerFrame(edge *topo.Edge, what string) (edgeFrame, error) {
 	faces := edge.Faces()
 	if len(faces) != 2 {
-		return nil, fmt.Errorf("chamfer: edge bounds %d faces, need 2", len(faces))
+		return edgeFrame{}, fmt.Errorf("%s: edge bounds %d faces, need 2", what, len(faces))
 	}
 	v0, v1 := edge.StartVertex().Point(), edge.EndVertex().Point()
 	e, err := math.UnitVector3FromVector(v0.VectorTo(v1))
 	if err != nil {
-		return nil, fmt.Errorf("chamfer: degenerate edge")
+		return edgeFrame{}, fmt.Errorf("%s: degenerate edge", what)
 	}
 	mid := v0.Midpoint(v1)
 	t1 := interiorDir(faces[0], mid, e)
 	t2 := interiorDir(faces[1], mid, e)
 	if t1.LengthSquared() == 0 || t2.LengthSquared() == 0 {
-		return nil, fmt.Errorf("chamfer: cannot orient the wedge against the edge faces")
+		return edgeFrame{}, fmt.Errorf("%s: cannot orient the cut against the edge faces", what)
 	}
 	plane := planePerp(v0, e)
 	u, v := plane.XAxis().AsVector(), plane.YAxis().AsVector()
-	proj := func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) }
-	poly := []math.Point2{{X: 0, Y: 0}, proj(t1.Scale(d1)), proj(t2.Scale(d2))}
-	oh := chamferOverhang(d1, d2)
-	return buildPrism(poly, plane, span{near: -oh, far: v0.DistanceTo(v1) + oh}, 0, feat), nil
+	return edgeFrame{
+		t1: t1, t2: t2, plane: plane, length: v0.DistanceTo(v1),
+		proj: func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) },
+	}, nil
 }
 
 // interiorDir returns the unit direction, perpendicular to the edge, pointing from the

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -80,6 +80,7 @@ type FeatureData struct {
 	SheetMetalContourFlange *SheetMetalContourFlangeData `yaml:"sheetMetalContourFlange,omitempty"` // M13-F02
 	SheetMetalLoftedFlange  *SheetMetalLoftedFlangeData  `yaml:"sheetMetalLoftedFlange,omitempty"`  // M13-F02
 	SheetMetalContourRoll   *SheetMetalContourRollData   `yaml:"sheetMetalContourRoll,omitempty"`   // M13-F02
+	SheetMetalCornerSeam    *SheetMetalCornerSeamData    `yaml:"sheetMetalCornerSeam,omitempty"`    // M13-F02
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -313,6 +314,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalContourRoll = smcr
+	case *SheetMetalCornerSeamFeature:
+		fd.SheetMetalCornerSeam = serializeSheetMetalCornerSeam(f.def)
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -518,6 +521,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalLoftedFlange(fs, fd.SheetMetalLoftedFlange, sk)
 	case "sheet-metal-contour-roll":
 		return restoreSheetMetalContourRoll(fs, fd.SheetMetalContourRoll, sk)
+	case "sheet-metal-corner-seam":
+		return restoreSheetMetalCornerSeam(fs, fd.SheetMetalCornerSeam)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_corner_seam.go
+++ b/model/feature/serialize_sheet_metal_corner_seam.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalCornerSeamData is the serialized form of a SheetMetalCornerSeamFeature: the corner
+// edges (base64 reference keys), the gap, and the seam type.
+type SheetMetalCornerSeamData struct {
+	Edges []string `yaml:"edges"`
+	Gap   float64  `yaml:"gap"`
+	Type  int32    `yaml:"type,omitempty"`
+}
+
+// serializeSheetMetalCornerSeam projects a corner-seam recipe to its persisted form.
+func serializeSheetMetalCornerSeam(def *SheetMetalCornerSeamDefinition) *SheetMetalCornerSeamData {
+	return &SheetMetalCornerSeamData{Edges: encodeKeys(def.EdgeKeys), Gap: evalFloat(def.Gap), Type: int32(def.Type)}
+}
+
+// restoreSheetMetalCornerSeam rebuilds a corner-seam feature, erroring on a missing payload or
+// an undecodable edge key.
+func restoreSheetMetalCornerSeam(fs *PartFeatures, d *SheetMetalCornerSeamData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal corner seam feature is missing its payload")
+	}
+	keys, err := decodeKeys(d.Edges)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal corner seam edge keys: %w", err)
+	}
+	return NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{
+		EdgeKeys: keys, Gap: constFloat(d.Gap), Type: SeamType(d.Type),
+	}), nil
+}

--- a/model/feature/sheet_metal_corner_seam.go
+++ b/model/feature/sheet_metal_corner_seam.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Sheet-metal Corner Seam feature (M13-F02). Where two flange walls meet at a corner, the
+// seam controls the relief between them. The gap seam cuts a square notch of the given gap
+// along the shared corner edge — relieving the corner so the two walls leave a controlled
+// gap (no interference, room for welding/fastening). The cut removes a parallelogram
+// cross-section (gap along each adjacent face) swept along the edge, distinct from the corner
+// CHAMFER's triangular bevel. Overlap/edge seam types build on this and are a follow-up.
+
+// SeamType discriminates the corner-seam relief.
+type SeamType int
+
+const (
+	// GapSeam cuts a square relief leaving a gap between the two corner walls (the default).
+	GapSeam SeamType = iota
+)
+
+// ParseSeamType resolves a wire spelling to a seam type.
+func ParseSeamType(s string) (SeamType, bool) {
+	switch s {
+	case "", "gap":
+		return GapSeam, true
+	}
+	return 0, false
+}
+
+// SheetMetalCornerSeamDefinition is the corner-seam recipe: the corner edges (the shared
+// through-thickness edges where flanges meet), the gap, and the seam type.
+type SheetMetalCornerSeamDefinition struct {
+	EdgeKeys [][]byte
+	Gap      func() float64
+	Type     SeamType
+}
+
+// SheetMetalCornerSeamFeature relieves the sheet's corner seams each recompute.
+type SheetMetalCornerSeamFeature struct {
+	def      *SheetMetalCornerSeamDefinition
+	featName string
+}
+
+// Definition returns the corner-seam recipe.
+func (f *SheetMetalCornerSeamFeature) Definition() *SheetMetalCornerSeamDefinition {
+	return f.def
+}
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalCornerSeamFeature) Kind() string { return "sheet-metal-corner-seam" }
+
+// Recompute resolves the corner edges and cuts a gap relief at each.
+func (f *SheetMetalCornerSeamFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal corner seam")
+	if err != nil {
+		return Output{}, err
+	}
+	gap := evalFloat(f.def.Gap)
+	if gap <= 0 {
+		return Output{}, fmt.Errorf("sheet-metal corner seam: gap must be positive, got %g", gap)
+	}
+	if len(f.def.EdgeKeys) == 0 {
+		return Output{}, fmt.Errorf("sheet-metal corner seam: no corner edges selected")
+	}
+	edges, err := resolveEdges(body, f.def.EdgeKeys)
+	if err != nil {
+		return Output{}, err
+	}
+	work, edges := planarizeForEdges(body, edges, f.featName)
+	tools, err := seamCutters(edges, gap, f.featName)
+	if err != nil {
+		return Output{}, err
+	}
+	res, err := cutAll(work, tools)
+	if err != nil {
+		return Output{}, fmt.Errorf("sheet-metal corner seam: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+}
+
+// seamCutters builds the gap-relief notch cutter for each corner edge.
+func seamCutters(edges []*topo.Edge, gap float64, feat string) ([]*topo.Body, error) {
+	tools := make([]*topo.Body, 0, len(edges))
+	for i, edge := range edges {
+		tool, err := seamCutter(edge, gap, fmt.Sprintf("%s/s%d", feat, i))
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, tool)
+	}
+	return tools, nil
+}
+
+// seamCutter builds the square relief notch removed at a corner edge: a parallelogram of gap
+// along each adjacent face's interior, swept along the edge with a small overhang for a clean
+// boolean.
+func seamCutter(edge *topo.Edge, gap float64, feat string) (*topo.Body, error) {
+	fr, err := edgeCornerFrame(edge, "sheet-metal corner seam")
+	if err != nil {
+		return nil, err
+	}
+	// A parallelogram corner notch: origin → gap·t1 → gap·(t1+t2) → gap·t2 (vs the chamfer's
+	// triangle), so the relief is a square gap rather than a bevel.
+	poly := []math.Point2{
+		{X: 0, Y: 0},
+		fr.proj(fr.t1.Scale(gap)),
+		fr.proj(fr.t1.Add(fr.t2).Scale(gap)),
+		fr.proj(fr.t2.Scale(gap)),
+	}
+	oh := gap * 0.1
+	return buildPrism(poly, fr.plane, span{near: -oh, far: fr.length + oh}, 0, feat), nil
+}
+
+// SheetMetalCornerSeamFeatures adds corner-seam features into the engine.
+type SheetMetalCornerSeamFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalCornerSeamFeatures binds the collection to a feature engine.
+func NewSheetMetalCornerSeamFeatures(engine *PartFeatures) *SheetMetalCornerSeamFeatures {
+	return &SheetMetalCornerSeamFeatures{engine}
+}
+
+// Add appends a corner-seam feature, naming it CornerSeam1, … .
+func (c *SheetMetalCornerSeamFeatures) Add(def *SheetMetalCornerSeamDefinition) *PartFeature {
+	f := &SheetMetalCornerSeamFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("CornerSeam"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalCornerSeamFeature)(nil)

--- a/model/feature/sheet_metal_corner_seam_test.go
+++ b/model/feature/sheet_metal_corner_seam_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+)
+
+// TestCornerSeamCutsGap a gap corner seam removes a square notch (gap²·thickness) at the
+// corner edge: the result is a valid watertight solid with that much material removed.
+func TestCornerSeamCutsGap(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	edge := verticalCornerEdge(t, fs.Result()[0])
+	pf := NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{
+		EdgeKeys: [][]byte{edge.ReferenceKey()}, Gap: func() float64 { return 1.0 },
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("corner seam sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	want := flatSheetVolume - (1.0*1.0)*0.2 // square notch gap²·thickness
+	if got := sheetVolume(body); math.Abs(got-want) > 1e-4 {
+		t.Errorf("seamed volume = %.5f, want %.5f", got, want)
+	}
+}
+
+// TestCornerSeamRejectsBadInput a seam with no edges or a non-positive gap goes sick.
+func TestCornerSeamRejectsBadInput(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	edge := verticalCornerEdge(t, fs.Result()[0])
+	noGap := NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{
+		EdgeKeys: [][]byte{edge.ReferenceKey()}, Gap: func() float64 { return 0 },
+	})
+	fs.Recompute()
+	if noGap.Health().OK() {
+		t.Error("zero-gap corner seam should be sick")
+	}
+
+	fs2, _ := seedSheetMetalSheet(t, 4, nil)
+	noEdges := NewSheetMetalCornerSeamFeatures(fs2).Add(&SheetMetalCornerSeamDefinition{Gap: func() float64 { return 1 }})
+	fs2.Recompute()
+	if noEdges.Health().OK() {
+		t.Error("corner seam with no edges should be sick")
+	}
+}
+
+// TestParseSeamType the gap spelling resolves, with an unknown one rejected.
+func TestParseSeamType(t *testing.T) {
+	for _, s := range []string{"", "gap"} {
+		if got, ok := ParseSeamType(s); !ok || got != GapSeam {
+			t.Errorf("ParseSeamType(%q) = (%d,%v), want (gap,true)", s, got, ok)
+		}
+	}
+	if _, ok := ParseSeamType("overlap"); ok {
+		t.Error("ParseSeamType(overlap) should be unsupported for now")
+	}
+}
+
+// TestCornerSeamDefinitionAndKind the accessors return the recipe.
+func TestCornerSeamDefinitionAndKind(t *testing.T) {
+	def := &SheetMetalCornerSeamDefinition{Type: GapSeam}
+	f := &SheetMetalCornerSeamFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-corner-seam" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// TestCornerSeamRoundTrip the recipe (edges + gap + type) marshals and restores.
+func TestCornerSeamRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{
+		EdgeKeys: [][]byte{[]byte("k1"), []byte("k2")}, Gap: func() float64 { return 0.3 }, Type: GapSeam,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalCornerSeam
+	if data[0].Kind != "sheet-metal-corner-seam" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-corner-seam", data[0])
+	}
+	if len(d.Edges) != 2 || d.Gap != 0.3 {
+		t.Errorf("payload = %+v, want 2 edges / gap 0.3", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-corner-seam" {
+		t.Errorf("restored = %d features, want one corner seam", fresh.Count())
+	}
+}
+
+// TestCornerSeamMissingPayload restoring a corner-seam record with no payload errors.
+func TestCornerSeamMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalCornerSeam(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreSheetMetalCornerSeam(nil) must error")
+	}
+}


### PR DESCRIPTION
## What

The **Corner Seam** — where two flange walls meet at a corner, the seam controls the relief between them. The **gap seam** cuts a square notch of the given gap along the shared corner edge, so the two walls leave a controlled gap (room for welding/fastening, no interference). This **completes the M13-F02 corner family** alongside the corner chamfer/round (#927).

The cut removes a parallelogram cross-section (the gap along each adjacent face's interior) swept along the edge — distinct from the corner chamfer's *triangular* bevel — reusing the chamfer-wedge machinery (`interiorDir` + `planePerp` + `buildPrism` + `cutAll`). Overlap/edge seam types build on this and are a follow-up; the `SeamType` enum reserves them. Recipe round-trips.

- **model/feature** — `SheetMetalCornerSeamDefinition`/`Feature`, the parallelogram relief cutter, `SeamType` + `ParseSeamType`; recipe codec.
- **addin/opregistry** — the `sheetMetalCornerSeam` operation (edges + gap + type), reusing the shared `activeSheetMetalPart` guard.

## Test
The gap seam removes **exactly `gap²·thickness`** and stays a watertight valid solid; no-edges / zero-gap → sick; type parsing; recipe round-trip; over-the-wire add + error paths. Per-package coverage ~93% (model) / ~97% (opreg); lint 0; duplication-clean (reuses the shared `assertWatertightSolid` + opregistry helpers).

Source-only (generic `features.add`; no new API). Part of M13 #375/#370.

> **Completes M13-F02's feature set.** Adds `sheetMetalCornerSeam` to the source registry — to be absorbed with the other nine `sheetMetal*` kinds into the bridge's `TestE2EFeatureRegistryCoverage` in a follow-up bridge PR. Once this merges, #375 (PBI-133) and the F02 parent #370 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)