### PR TITLE
feat: sheet-metal Cut feature (M13-F03)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -265,6 +265,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalLoftedFlange":  `{"profileA":0,"profileB":0}`,
 		"sheetMetalContourRoll":   `{"profileSketch":0,"axisLine":0}`,
 		"sheetMetalCornerSeam":    `{"edges":["x"],"gap":"0.2 mm"}`,
+		"sheetMetalCut":           `{"sketchIndex":0}`,
 		"splitSolid":              `{"toolSketch":0}`,
 		"coreCavity":              `{}`,
 		"hull":                    `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -140,6 +140,7 @@ func Default() *Registry {
 		sheetMetalLoftedFlangeDescriptor(),
 		sheetMetalContourRollDescriptor(),
 		sheetMetalCornerSeamDescriptor(),
+		sheetMetalCutDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_cut.go
+++ b/addin/opregistry/sheet_metal_cut.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalCutArgs is the argument shape for the "sheetMetalCut" operation: the profile to
+// remove, the cut side, an optional depth (omitted ⇒ through all), and the (reserved)
+// across-bend flag.
+type sheetMetalCutArgs struct {
+	SketchIndex  int    `json:"sketchIndex"`
+	ProfileIndex int    `json:"profileIndex"`
+	Direction    string `json:"direction,omitempty"`
+	Distance     string `json:"distance,omitempty"`
+	AcrossBend   bool   `json:"acrossBend,omitempty"`
+}
+
+const sheetMetalCutSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch whose profile is removed (see model.tree)."},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which closed profile of the sketch to cut."},
+    "direction": {"type": "string", "enum": ["positive", "negative", "symmetric"], "default": "positive", "description": "Which side of the sketch plane to cut toward."},
+    "distance": {"type": "string", "description": "Cut depth, e.g. \"5 mm\" (omitted ⇒ cut through all the material)."},
+    "acrossBend": {"type": "boolean", "default": false, "description": "Cut across bends (unfold/cut/refold) — reserved for the flat pattern (M13-F04), not yet supported."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalCutDescriptor is the self-describing "sheetMetalCut" operation: remove a sketch
+// profile from a sheet-metal part.
+func sheetMetalCutDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalCut",
+		Summary: "Cut a closed sketch profile through a sheet-metal part (through all by default, or to a depth).",
+		Schema:  json.RawMessage(sheetMetalCutSchema),
+		Apply:   applySheetMetalCut,
+	}
+}
+
+func applySheetMetalCut(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalCut")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalCutArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalCut: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalCutDefinition{
+		Sketch: sk, ProfileIndex: in.ProfileIndex,
+		Direction: parseExtentDirection(in.Direction), AcrossBend: in.AcrossBend,
+	}
+	if in.Distance != "" {
+		dist, err := lengthClosure(part, in.Distance, "sheetMetalCut: distance")
+		if err != nil {
+			return nil, err
+		}
+		def.Distance = dist
+	}
+	return recomputeResult(part, feature.NewSheetMetalCutFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_cut_test.go
+++ b/addin/opregistry/sheet_metal_cut_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSheetMetalCutApply seeds a sheet-metal wall, adds a smaller profile, and cuts it through
+// all the material — confirming one healthy solid; then checks the error paths.
+func TestSheetMetalCutApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	addRect(def.Sketches().Add(sketch.XYPlane()), 2, 2) // a 2×2 cut profile inside the 4×3 sheet
+
+	out, err := apply(t, s, "sheetMetalCut", `{"sketchIndex":1,"profileIndex":0}`)
+	if err != nil {
+		t.Fatalf("cut apply: %v", err)
+	}
+	expectMergedSolid(t, out, "cut")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalCut", `{"sketchIndex":0}`); err == nil {
+		t.Error("cut on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalCut", `{"sketchIndex":99}`); err == nil {
+		t.Error("cut with an out-of-range sketch must error")
+	}
+	// across-bend is reserved for F04: the feature goes sick (a healthy:false result), not a
+	// Go error, since the add succeeds and the recompute reports the unsupported option.
+	out, err = apply(t, s, "sheetMetalCut", `{"sketchIndex":1,"acrossBend":true}`)
+	if err != nil {
+		t.Fatalf("across-bend cut apply: %v", err)
+	}
+	var res struct {
+		Healthy bool `json:"healthy"`
+	}
+	if e := json.Unmarshal(out, &res); e == nil && res.Healthy {
+		t.Error("across-bend cut should be unhealthy (reserved for F04)")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -81,6 +81,7 @@ type FeatureData struct {
 	SheetMetalLoftedFlange  *SheetMetalLoftedFlangeData  `yaml:"sheetMetalLoftedFlange,omitempty"`  // M13-F02
 	SheetMetalContourRoll   *SheetMetalContourRollData   `yaml:"sheetMetalContourRoll,omitempty"`   // M13-F02
 	SheetMetalCornerSeam    *SheetMetalCornerSeamData    `yaml:"sheetMetalCornerSeam,omitempty"`    // M13-F02
+	SheetMetalCut           *SheetMetalCutData           `yaml:"sheetMetalCut,omitempty"`           // M13-F03
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -316,6 +317,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.SheetMetalContourRoll = smcr
 	case *SheetMetalCornerSeamFeature:
 		fd.SheetMetalCornerSeam = serializeSheetMetalCornerSeam(f.def)
+	case *SheetMetalCutFeature:
+		smc, err := serializeSheetMetalCut(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalCut = smc
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -523,6 +530,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalContourRoll(fs, fd.SheetMetalContourRoll, sk)
 	case "sheet-metal-corner-seam":
 		return restoreSheetMetalCornerSeam(fs, fd.SheetMetalCornerSeam)
+	case "sheet-metal-cut":
+		return restoreSheetMetalCut(fs, fd.SheetMetalCut, sk)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_cut.go
+++ b/model/feature/serialize_sheet_metal_cut.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalCutData is the serialized form of a SheetMetalCutFeature: the profile (sketch
+// index + region index), the cut side, an optional depth (0 ⇒ through all), and the
+// across-bend flag.
+type SheetMetalCutData struct {
+	Sketch     int     `yaml:"sketch"`
+	Profile    int     `yaml:"profile"`
+	Direction  int32   `yaml:"direction,omitempty"`
+	Distance   float64 `yaml:"distance,omitempty"` // 0 ⇒ through all
+	AcrossBend bool    `yaml:"acrossBend,omitempty"`
+}
+
+// serializeSheetMetalCut projects a cut recipe to its persisted form, erroring if its sketch
+// is not in the part.
+func serializeSheetMetalCut(def *SheetMetalCutDefinition, sk SketchIndexer) (*SheetMetalCutData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal cut references a sketch that is not in the part")
+	}
+	return &SheetMetalCutData{
+		Sketch: idx, Profile: def.ProfileIndex, Direction: int32(def.Direction),
+		Distance: evalFloat(def.Distance), AcrossBend: def.AcrossBend,
+	}, nil
+}
+
+// restoreSheetMetalCut rebuilds a cut feature, erroring on a missing payload or unknown
+// sketch. A zero distance restores as nil (cut through all).
+func restoreSheetMetalCut(fs *PartFeatures, d *SheetMetalCutData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal cut feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal cut references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalCutDefinition{Sketch: s, ProfileIndex: d.Profile, Direction: ExtentDirection(d.Direction), AcrossBend: d.AcrossBend}
+	if d.Distance != 0 {
+		def.Distance = constFloat(d.Distance)
+	}
+	return NewSheetMetalCutFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_cut.go
+++ b/model/feature/sheet_metal_cut.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Cut feature (M13-F03). A cut removes a closed sketch profile from the sheet,
+// normal to the sketch plane. By default it cuts through all the material (the common case —
+// holes, slots, openings); a distance limits it. This is the normal cut; the across-bend
+// variant (unfold the spanned region, cut flat, refold) builds on the flat pattern (F04) and
+// is a follow-up — AcrossBend is reserved and rejected until then.
+//
+// The geometry reuses the shared profile-prism builder + the through-all span computation, so
+// a cut is the boolean complement of the base Face's thickening.
+
+// SheetMetalCutDefinition is the cut recipe: the profile to remove, the side to cut toward,
+// an optional depth (nil ⇒ through all), and the (reserved) across-bend flag.
+type SheetMetalCutDefinition struct {
+	Sketch       *sketch.Sketch
+	ProfileIndex int
+	Direction    ExtentDirection
+	Distance     func() float64 // nil ⇒ cut through all the material
+	AcrossBend   bool           // reserved for F04; rejected until the flat pattern lands
+}
+
+// SheetMetalCutFeature removes the profile from the running sheet each recompute.
+type SheetMetalCutFeature struct {
+	def      *SheetMetalCutDefinition
+	featName string
+}
+
+// Definition returns the cut recipe.
+func (f *SheetMetalCutFeature) Definition() *SheetMetalCutDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalCutFeature) Kind() string { return "sheet-metal-cut" }
+
+// Recompute resolves the profile, builds the cutter prism, and subtracts it from the sheet.
+func (f *SheetMetalCutFeature) Recompute(in Input) (Output, error) {
+	if f.def.AcrossBend {
+		return Output{}, fmt.Errorf("sheet-metal cut: across-bend cuts need the flat pattern (M13-F04); not yet supported")
+	}
+	profiles, err := resolveClosedProfiles(f.def.Sketch, []int{f.def.ProfileIndex}, "sheet-metal cut")
+	if err != nil {
+		return Output{}, err
+	}
+	plane := f.def.Sketch.Plane()
+	sp, err := f.cutSpan(in.Bodies, plane)
+	if err != nil {
+		return Output{}, err
+	}
+	tool := buildProfilePrisms(profiles, plane, sp, 0, f.featName)
+	bodies, err := combine(in.Bodies, tool, ops.Cut)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// cutSpan returns the cutter's span: a fixed depth when Distance is set, else through all the
+// running material on the chosen side of the sketch plane.
+func (f *SheetMetalCutFeature) cutSpan(bodies []*topo.Body, plane sketch.Plane) (span, error) {
+	if f.def.Distance != nil {
+		ext := Extent{Type: DistanceExtent, Direction: f.def.Direction, Distance: f.def.Distance}
+		return distanceSpan(ext)
+	}
+	return throughAllSpan(Extent{Type: ThroughAllExtent, Direction: f.def.Direction}, bodies, plane)
+}
+
+// SheetMetalCutFeatures adds cut features into the engine.
+type SheetMetalCutFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalCutFeatures binds the collection to a feature engine.
+func NewSheetMetalCutFeatures(engine *PartFeatures) *SheetMetalCutFeatures {
+	return &SheetMetalCutFeatures{engine}
+}
+
+// Add appends a cut feature, naming it Cut1, Cut2, … .
+func (c *SheetMetalCutFeatures) Add(def *SheetMetalCutDefinition) *PartFeature {
+	f := &SheetMetalCutFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Cut"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalCutFeature)(nil)

--- a/model/feature/sheet_metal_cut_test.go
+++ b/model/feature/sheet_metal_cut_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+)
+
+// TestSheetMetalCutThroughAll a through-all cut of a 2×2 square removes that column from the
+// 4×4 sheet: the result is a valid watertight solid lighter by 2²·thickness.
+func TestSheetMetalCutThroughAll(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	pf := NewSheetMetalCutFeatures(fs).Add(&SheetMetalCutDefinition{Sketch: squareSketch(2), ProfileIndex: 0})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("cut sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	want := flatSheetVolume - 2.0*2.0*0.2 // the 2×2 column through the 2 mm sheet
+	if got := smSolidVolume(body); math.Abs(got-want) > 1e-4 {
+		t.Errorf("cut volume = %.5f, want %.5f", got, want)
+	}
+}
+
+// TestSheetMetalCutDistance a depth-limited cut removes less than through-all (a partial pocket).
+func TestSheetMetalCutDistance(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	pf := NewSheetMetalCutFeatures(fs).Add(&SheetMetalCutDefinition{
+		Sketch: squareSketch(2), ProfileIndex: 0, Distance: func() float64 { return 0.1 }, // 1 mm of the 2 mm sheet
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("pocket cut sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	want := flatSheetVolume - 2.0*2.0*0.1 // half-depth pocket
+	if got := smSolidVolume(body); math.Abs(got-want) > 1e-4 {
+		t.Errorf("pocket volume = %.5f, want %.5f", got, want)
+	}
+}
+
+// TestSheetMetalCutAcrossBendRejected the across-bend option is reserved until the flat
+// pattern (F04) and must error rather than silently do a normal cut.
+func TestSheetMetalCutAcrossBendRejected(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	pf := NewSheetMetalCutFeatures(fs).Add(&SheetMetalCutDefinition{Sketch: squareSketch(2), ProfileIndex: 0, AcrossBend: true})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("across-bend cut should be sick (not supported until F04)")
+	}
+}
+
+// TestSheetMetalCutDefinitionAndKind the accessors return the recipe.
+func TestSheetMetalCutDefinitionAndKind(t *testing.T) {
+	def := &SheetMetalCutDefinition{ProfileIndex: 1}
+	f := &SheetMetalCutFeature{def: def}
+	if f.Definition() != def || f.Kind() != "sheet-metal-cut" {
+		t.Error("Definition/Kind mismatch")
+	}
+}
+
+// TestSheetMetalCutRoundTrip the recipe (sketch + profile + direction + distance + acrossBend)
+// marshals and restores; a 0 distance restores as nil (through all).
+func TestSheetMetalCutRoundTrip(t *testing.T) {
+	sk := squareSketch(2)
+	fs := NewPartFeatures(nil, nil)
+	NewSheetMetalCutFeatures(fs).Add(&SheetMetalCutDefinition{
+		Sketch: sk, ProfileIndex: 0, Direction: NegativeDir, Distance: func() float64 { return 0.5 },
+	})
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].SheetMetalCut
+	if data[0].Kind != "sheet-metal-cut" || d == nil {
+		t.Fatalf("marshaled = %+v, want sheet-metal-cut", data[0])
+	}
+	if d.Direction != int32(NegativeDir) || d.Distance != 0.5 {
+		t.Errorf("payload = %+v, want negative / distance 0.5", d)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-cut" {
+		t.Errorf("restored = %d features, want one cut", fresh.Count())
+	}
+}
+
+// TestSheetMetalCutMissingPayload / unknown sketch restore errors.
+func TestSheetMetalCutMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalCut(NewPartFeatures(nil, nil), nil, oneSketch{}); err == nil {
+		t.Error("restoreSheetMetalCut(nil) must error")
+	}
+	if _, err := serializeSheetMetalCut(&SheetMetalCutDefinition{Sketch: squareSketch(1)}, oneSketch{s: squareSketch(2)}); err == nil {
+		t.Error("serialize with an unknown sketch must error")
+	}
+}


### PR DESCRIPTION
## What

The first **M13-F03 modify feature**: cut a closed sketch profile through (or into) a sheet-metal part — holes, slots, openings. Through-all by default, or to a given depth. Reuses the shared profile-prism builder + through-all span computation, so a cut is the boolean complement of the base Face's thickening.

The **across-bend** variant (unfold the spanned region, cut flat, refold) builds on the flat pattern (M13-F04); `AcrossBend` is reserved and the feature goes sick if asked for it until F04 lands.

- **model/feature** — `SheetMetalCutDefinition`/`Feature`; recipe codec.
- **addin/opregistry** — the `sheetMetalCut` operation (sketch + profile + direction + optional distance + acrossBend), reusing the shared `activeSheetMetalPart` guard.

## Test
Through-all removes **exactly the profile column** (`2²·thickness`); a depth-limited pocket removes less; across-bend → sick; recipe round-trip + serialize-unknown-sketch error; over-the-wire add + error paths. Per-package coverage ~96%; lint 0; duplication-clean (reuses the shared helpers).

Source-only (generic `features.add`; no new API). Part of M13 #376/#371. (Corner Seam, also in PBI-134, shipped under F02 #935.)

> Adds `sheetMetalCut` to the source registry — to be added to the bridge's `TestE2EFeatureRegistryCoverage` in the next bridge-registry update (after the current bridge PR #36 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)