### PR TITLE
feat(sheet-metal): bend-lineage projection for the flat pattern (M13-F04)

### DIFF
--- a/addin/router/sheet_metal.go
+++ b/addin/router/sheet_metal.go
@@ -25,6 +25,7 @@ func (r *Router) registerSheetMetalHandlers() {
 	r.handlers[wire.MethodSheetMetalGetStyle] = sheetMetalGetStyle
 	r.handlers[wire.MethodSheetMetalSetStyle] = sheetMetalSetStyle
 	r.handlers[wire.MethodSheetMetalBendAllowance] = sheetMetalBendAllowance
+	r.handlers[wire.MethodSheetMetalBends] = sheetMetalBends
 }
 
 // activeSheetMetal returns the active part and its rule, or an error if the active document
@@ -168,6 +169,30 @@ func sheetMetalBendAllowance(s *app.Session, raw json.RawMessage) (json.RawMessa
 		BendDeduction: rule.BendDeduction(angle.Value, radius),
 	})
 }
+
+func sheetMetalBends(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	bends := part.Bends()
+	out := wire.BendsResult{Bends: make([]wire.BendInfo, 0, len(bends))}
+	for _, b := range bends {
+		out.Bends = append(out.Bends, wire.BendInfo{
+			Feature:   b.Feature,
+			Angle:     b.Angle * degPerRad,
+			Radius:    b.Radius,
+			Thickness: b.Thickness,
+			Allowance: b.Allowance,
+			Deduction: b.Deduction,
+		})
+		out.TotalAllowance += b.Allowance
+	}
+	return json.Marshal(out)
+}
+
+// degPerRad converts a bend's stored angle (radians) to the degrees the wire reports.
+const degPerRad = 180.0 / 3.141592653589793
 
 // styleInfo renders the active rule as wire, formatting lengths in the document's units and
 // including the bend allowance of a 90° bend as a convenience preview. The two

--- a/addin/router/sheet_metal_bends_test.go
+++ b/addin/router/sheet_metal_bends_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// flangedSheet builds a sheet-metal part with a base Face and one 90° flange over the wire,
+// returning the router + session ready for a bends query.
+func flangedSheet(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := newSheetMetalPart(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"rectangle","points":[[0,0],[4,3]]}`, &struct{}{})
+	var face featureResult
+	call(t, r, s, "features.add", `{"kind":"sheetMetalFace","args":{"sketchIndex":0}}`, &face)
+	if !face.Healthy {
+		t.Fatal("base Face unhealthy")
+	}
+
+	// The reference key is binary, so marshal the payload (json escapes control bytes)
+	// rather than concatenating it into a JSON literal.
+	payload, err := json.Marshal(map[string]any{
+		"kind": "sheetMetalFlange",
+		"args": map[string]any{"edge": topXEdgeKey(t, s), "height": "10 mm"},
+	})
+	if err != nil {
+		t.Fatalf("marshal flange args: %v", err)
+	}
+	var flange featureResult
+	call(t, r, s, "features.add", string(payload), &flange)
+	if !flange.Healthy {
+		t.Fatal("flange unhealthy")
+	}
+	return r, s
+}
+
+// topXEdgeKey returns the reference key of an X-aligned top edge of the active part's body —
+// a valid edge to flange from.
+func topXEdgeKey(t *testing.T, s *app.Session) string {
+	t.Helper()
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	body := part.Features().Result()[0]
+	maxZ := math.Inf(-1)
+	for _, e := range body.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-b.X) > 1e-6 && math.Abs(a.Y-b.Y) < 1e-6 && math.Abs(a.Z-maxZ) < 1e-6 {
+			return string(e.ReferenceKey())
+		}
+	}
+	t.Fatal("no X-aligned top edge on the sheet")
+	return ""
+}
+
+// TestSheetMetalBendsOverWire a flanged sheet reports its bend lineage: one 90° bend with a
+// positive developed allowance, and the total allowance equals that bend's.
+func TestSheetMetalBendsOverWire(t *testing.T) {
+	r, s := flangedSheet(t)
+	var res wire.BendsResult
+	call(t, r, s, wire.MethodSheetMetalBends, "{}", &res)
+	if len(res.Bends) != 1 {
+		t.Fatalf("bends = %d, want 1", len(res.Bends))
+	}
+	b := res.Bends[0]
+	if math.Abs(b.Angle-90) > 1e-6 {
+		t.Errorf("bend angle = %v deg, want 90", b.Angle)
+	}
+	if b.Allowance <= 0 || b.Radius <= 0 || b.Thickness <= 0 {
+		t.Errorf("bend developed values must be positive: %+v", b)
+	}
+	if math.Abs(res.TotalAllowance-b.Allowance) > 1e-12 {
+		t.Errorf("total allowance = %v, want %v", res.TotalAllowance, b.Allowance)
+	}
+}
+
+// TestSheetMetalBendsEmptyWithoutBends a flat base sheet (no folds) reports no bends.
+func TestSheetMetalBendsEmptyWithoutBends(t *testing.T) {
+	r, s := newSheetMetalPart(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"rectangle","points":[[0,0],[4,3]]}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"sheetMetalFace","args":{"sketchIndex":0}}`, &featureResult{})
+
+	var res wire.BendsResult
+	call(t, r, s, wire.MethodSheetMetalBends, "{}", &res)
+	if len(res.Bends) != 0 || res.TotalAllowance != 0 {
+		t.Errorf("flat sheet bends = %+v, want empty", res)
+	}
+}
+
+// TestSheetMetalBendsRejectsPlainPart bends on an ordinary part errors (no sheet-metal rule).
+func TestSheetMetalBendsRejectsPlainPart(t *testing.T) {
+	r, s := seededSession(t)
+	if _, err := r.Handle(s, wire.MethodSheetMetalBends, []byte("{}")); err == nil {
+		t.Fatal("bends on a plain part must error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.6.0
+	oblikovati.org/api v0.7.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.6.0
+	oblikovati.org/api v0.7.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/sheet_metal_bends.go
+++ b/model/compdef/sheet_metal_bends.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// Bends projects the part's bend lineage (M13-F04, #377): every bend the wall/bend features
+// introduced, in creation order, developed by the active rule's unfold method. It is the
+// flat pattern's prerequisite — the architecture requires every bend to record its unfold
+// parameters, and here the feature history IS the bend graph, so no faceted-geometry
+// detection is needed. Returns nil when the part is not in the sheet-metal environment.
+//
+// Only healthy, unsuppressed features contribute: a sick or suppressed wall added no bend
+// to the current folded body, so it adds none to the flat development either.
+func (d *PartComponentDefinition) Bends() []sheetmetal.Bend {
+	if d.sheetMetal == nil {
+		return nil
+	}
+	thickness := d.sheetMetal.Thickness()
+	unfold := d.sheetMetal.Unfold()
+	fs := d.features
+	var bends []sheetmetal.Bend
+	for i := 0; i < fs.Count(); i++ {
+		pf := fs.Item(i)
+		if pf.Suppressed() || !pf.Health().OK() {
+			continue
+		}
+		lineage, ok := pf.Definition().(feature.BendLineage)
+		if !ok {
+			continue
+		}
+		bends = append(bends, d.developBends(pf.Name(), lineage, thickness, unfold)...)
+	}
+	return bends
+}
+
+// developBends turns one feature's raw bend specs into developed bend records, filling a
+// missing radius override with the rule's default bend radius.
+func (d *PartComponentDefinition) developBends(name string, lineage feature.BendLineage, thickness float64, unfold sheetmetal.UnfoldMethod) []sheetmetal.Bend {
+	out := make([]sheetmetal.Bend, 0, 1)
+	for _, spec := range lineage.BendSpecs(thickness) {
+		radius := spec.Radius
+		if radius <= 0 {
+			radius = d.sheetMetal.BendRadius()
+		}
+		out = append(out, sheetmetal.NewBend(name, spec.Angle, radius, thickness, unfold))
+	}
+	return out
+}
+
+// TotalBendAllowance sums the developed allowance over all bends — the total length the flat
+// pattern adds for bending (the developed model is longer than the folded outside extents by
+// this minus the deductions).
+func (d *PartComponentDefinition) TotalBendAllowance() float64 {
+	var total float64
+	for _, b := range d.Bends() {
+		total += b.Allowance
+	}
+	return total
+}

--- a/model/compdef/sheet_metal_bends_test.go
+++ b/model/compdef/sheet_metal_bends_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+)
+
+// addFlange folds a 90° flange onto a top +X edge of the running sheet and recomputes,
+// returning the feature so a test can suppress it. The default rule (1 mm gauge, 1 mm
+// radius) drives the bend, so the developed values are deterministic.
+func addFlange(t *testing.T, d *PartComponentDefinition) *feature.PartFeature {
+	t.Helper()
+	edge := topXEdge(t, d.Features().Result()[0])
+	pf := feature.NewSheetMetalFlangeFeatures(d.Features()).Add(&feature.SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(),
+		Height:  func() float64 { return 1 },
+	})
+	d.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("flange unhealthy: %s", pf.Health().Reason)
+	}
+	return pf
+}
+
+// topXEdge returns an X-aligned edge on the sheet's top face — a valid edge to flange from.
+func topXEdge(t *testing.T, body *topo.Body) *topo.Edge {
+	t.Helper()
+	maxZ := math.Inf(-1)
+	for _, e := range body.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-b.X) > 1e-6 && math.Abs(a.Y-b.Y) < 1e-6 && math.Abs(a.Z-maxZ) < 1e-6 {
+			return e
+		}
+	}
+	t.Fatal("no X-aligned top edge on the sheet")
+	return nil
+}
+
+// sheetWithFlange builds a sheet-metal part (square base + one flange) for the bend tests.
+func sheetWithFlange(t *testing.T) (*PartComponentDefinition, *feature.PartFeature) {
+	t.Helper()
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	addSquareFace(d, 4)
+	return d, addFlange(t, d)
+}
+
+// TestBendsReportsFlangeLineage a flanged sheet reports its single 90° bend with the
+// developed allowance the rule's unfold method computes.
+func TestBendsReportsFlangeLineage(t *testing.T) {
+	d, flange := sheetWithFlange(t)
+
+	bends := d.Bends()
+	if len(bends) != 1 {
+		t.Fatalf("Bends len = %d, want 1", len(bends))
+	}
+	b := bends[0]
+	if b.Feature != flange.Name() {
+		t.Errorf("bend feature = %q, want %q", b.Feature, flange.Name())
+	}
+	if math.Abs(b.Angle-math.Pi/2) > 1e-12 {
+		t.Errorf("bend angle = %g, want π/2", b.Angle)
+	}
+	rule := d.SheetMetal()
+	if b.Radius != rule.BendRadius() || b.Thickness != rule.Thickness() {
+		t.Errorf("bend (r=%g,t=%g), want rule (r=%g,t=%g)", b.Radius, b.Thickness, rule.BendRadius(), rule.Thickness())
+	}
+	if want := rule.Unfold().BendAllowance(b.Angle, b.Radius, b.Thickness); b.Allowance != want {
+		t.Errorf("allowance = %g, want %g", b.Allowance, want)
+	}
+	if got := d.TotalBendAllowance(); math.Abs(got-b.Allowance) > 1e-12 {
+		t.Errorf("TotalBendAllowance = %g, want %g", got, b.Allowance)
+	}
+}
+
+// TestBendsNilWhenNotSheetMetal an ordinary part has no bend lineage.
+func TestBendsNilWhenNotSheetMetal(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if bends := d.Bends(); bends != nil {
+		t.Errorf("plain part Bends = %v, want nil", bends)
+	}
+}
+
+// TestBendsExcludesSuppressed a suppressed flange contributes no bend (it added no geometry).
+func TestBendsExcludesSuppressed(t *testing.T) {
+	d, flange := sheetWithFlange(t)
+	flange.SetSuppressed(true)
+	d.Recompute()
+	if bends := d.Bends(); len(bends) != 0 {
+		t.Errorf("suppressed flange still reports %d bends, want 0", len(bends))
+	}
+}

--- a/model/feature/bend_lineage.go
+++ b/model/feature/bend_lineage.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+// BendLineage is implemented by sheet-metal features that introduce one or more bends. The
+// flat pattern (M13-F04, #377) reads it to develop each bend: the architecture requires
+// every bend to record its unfold parameters (angle + radius) so the flat develops at the
+// correct length. Recording lives on the feature definition — the feature history IS the
+// bend graph — rather than being detected from the faceted bend geometry after the fact.
+type BendLineage interface {
+	// BendSpecs reports the bends this feature introduces, given the material thickness.
+	// Thickness is passed because some bends derive their radius from the gauge (a closed
+	// hem folds at a fraction of the thickness). A feature with no live bend returns nil.
+	BendSpecs(thickness float64) []BendSpec
+}
+
+// BendSpec is the raw geometry of one bend before it is developed: the swept angle and the
+// inside bend radius. A non-positive Radius means "this feature does not override the
+// radius" — the projecting layer fills in the rule's default bend radius. The developed
+// values (allowance/deduction) are computed by the rule, not here, so the spec stays a
+// pure geometric statement independent of the unfold method.
+type BendSpec struct {
+	Angle  float64 // swept bend angle (radians)
+	Radius float64 // inside bend radius (cm); <= 0 ⇒ use the rule's default
+}

--- a/model/feature/bend_lineage_test.go
+++ b/model/feature/bend_lineage_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+)
+
+// constClosure makes a parameter-backed-style constant closure for a test definition.
+func constClosure(v float64) func() float64 { return func() float64 { return v } }
+
+// TestFlangeBendSpecsDefaultsTo90 a flange with no overrides reports one 90° bend deferring
+// its radius to the rule (signalled by a non-positive radius).
+func TestFlangeBendSpecsDefaultsTo90(t *testing.T) {
+	f := &SheetMetalFlangeFeature{def: &SheetMetalFlangeDefinition{Height: constClosure(1)}}
+	specs := f.BendSpecs(0.1)
+	if len(specs) != 1 {
+		t.Fatalf("flange BendSpecs len = %d, want 1", len(specs))
+	}
+	if math.Abs(specs[0].Angle-math.Pi/2) > 1e-12 {
+		t.Errorf("angle = %g, want π/2", specs[0].Angle)
+	}
+	if specs[0].Radius > 0 {
+		t.Errorf("radius = %g, want <= 0 (defer to rule)", specs[0].Radius)
+	}
+}
+
+// TestFlangeBendSpecsHonorsOverrides a flange with explicit angle/radius reports them.
+func TestFlangeBendSpecsHonorsOverrides(t *testing.T) {
+	f := &SheetMetalFlangeFeature{def: &SheetMetalFlangeDefinition{
+		Height: constClosure(1), Angle: constClosure(math.Pi / 3), Radius: constClosure(0.5),
+	}}
+	specs := f.BendSpecs(0.1)
+	if math.Abs(specs[0].Angle-math.Pi/3) > 1e-12 || specs[0].Radius != 0.5 {
+		t.Errorf("specs = %+v, want angle π/3 radius 0.5", specs[0])
+	}
+}
+
+// TestBendAndFoldBendSpecs the bend and fold features each report one 90° bend by default.
+func TestBendAndFoldBendSpecs(t *testing.T) {
+	bend := &SheetMetalBendFeature{def: &SheetMetalBendDefinition{}}
+	fold := &SheetMetalFoldFeature{def: &SheetMetalFoldDefinition{}}
+	for name, specs := range map[string][]BendSpec{"bend": bend.BendSpecs(0.1), "fold": fold.BendSpecs(0.1)} {
+		if len(specs) != 1 || math.Abs(specs[0].Angle-math.Pi/2) > 1e-12 {
+			t.Errorf("%s BendSpecs = %+v, want one π/2 bend", name, specs)
+		}
+	}
+}
+
+// TestHemBendSpecsGaugeDerivedRadius a hem reports a 180° fold whose radius is derived from
+// the gauge — a closed hem at half the thickness, an open hem at half its gap.
+func TestHemBendSpecsGaugeDerivedRadius(t *testing.T) {
+	closed := &SheetMetalHemFeature{def: &SheetMetalHemDefinition{Type: ClosedHem}}
+	specs := closed.BendSpecs(0.2)
+	if len(specs) != 1 || math.Abs(specs[0].Angle-math.Pi) > 1e-12 {
+		t.Fatalf("closed hem specs = %+v, want one π fold", specs)
+	}
+	if specs[0].Radius != 0.1 {
+		t.Errorf("closed hem radius = %g, want 0.1 (half the 0.2 gauge)", specs[0].Radius)
+	}
+	open := &SheetMetalHemFeature{def: &SheetMetalHemDefinition{Type: OpenHem, Gap: constClosure(0.4)}}
+	if r := open.BendSpecs(0.2)[0].Radius; r != 0.2 {
+		t.Errorf("open hem radius = %g, want 0.2 (half the 0.4 gap)", r)
+	}
+}

--- a/model/feature/sheet_metal_bend.go
+++ b/model/feature/sheet_metal_bend.go
@@ -83,6 +83,16 @@ func (f *SheetMetalBendFeature) resolveAngle() float64 {
 	return f.def.Angle()
 }
 
+// BendSpecs reports the single bend this fold introduces, for the flat pattern. A nil
+// radius override defers to the rule's default (signalled by a non-positive radius).
+func (f *SheetMetalBendFeature) BendSpecs(_ float64) []BendSpec {
+	radius := 0.0
+	if f.def.Radius != nil {
+		radius = f.def.Radius()
+	}
+	return []BendSpec{{Angle: f.resolveAngle(), Radius: radius}}
+}
+
 // SheetMetalBendFeatures adds bend features into the engine.
 type SheetMetalBendFeatures struct{ engine *PartFeatures }
 

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -117,6 +117,16 @@ func (f *SheetMetalFlangeFeature) resolveAngle() float64 {
 	return f.def.Angle()
 }
 
+// BendSpecs reports the single bend a flange introduces (its fold), for the flat pattern.
+// A nil radius override defers to the rule's default (signalled by a non-positive radius).
+func (f *SheetMetalFlangeFeature) BendSpecs(_ float64) []BendSpec {
+	radius := 0.0
+	if f.def.Radius != nil {
+		radius = f.def.Radius()
+	}
+	return []BendSpec{{Angle: f.resolveAngle(), Radius: radius}}
+}
+
 // buildFlangeSolid constructs the bend+wall solid on edge: the cross-section band extruded
 // along the edge. up is the parent face's outward normal (the fold-toward side); out is the
 // in-plane direction away from the sheet. flip folds toward the opposite face.

--- a/model/feature/sheet_metal_fold.go
+++ b/model/feature/sheet_metal_fold.go
@@ -136,6 +136,16 @@ func (f *SheetMetalFoldFeature) resolveAngle() float64 {
 	return f.def.Angle()
 }
 
+// BendSpecs reports the single bend this fold introduces, for the flat pattern. A nil
+// radius override defers to the rule's default (signalled by a non-positive radius).
+func (f *SheetMetalFoldFeature) BendSpecs(_ float64) []BendSpec {
+	radius := 0.0
+	if f.def.Radius != nil {
+		radius = f.def.Radius()
+	}
+	return []BendSpec{{Angle: f.resolveAngle(), Radius: radius}}
+}
+
 // SheetMetalFoldFeatures adds fold features into the engine.
 type SheetMetalFoldFeatures struct{ engine *PartFeatures }
 

--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -93,6 +93,13 @@ func (f *SheetMetalHemFeature) hemRadius(thickness float64) float64 {
 	return thickness / 2
 }
 
+// BendSpecs reports the single 180° fold a hem introduces, for the flat pattern. The hem
+// radius is gauge-derived (a closed hem folds at half the thickness), so it is always
+// resolved here from the passed thickness rather than deferred to the rule's default.
+func (f *SheetMetalHemFeature) BendSpecs(thickness float64) []BendSpec {
+	return []BendSpec{{Angle: hemFoldAngle, Radius: f.hemRadius(thickness)}}
+}
+
 // SheetMetalHemFeatures adds hem features into the engine.
 type SheetMetalHemFeatures struct{ engine *PartFeatures }
 

--- a/model/sheetmetal/bend.go
+++ b/model/sheetmetal/bend.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+// Bend is one recorded bend in a sheet-metal part's history, carrying the unfold values the
+// flat pattern (M13-F04, #377) develops it by. The architecture requires every bend to
+// record its unfold parameters so the flat develops at the correct length; this is that
+// record, projected from the part's feature history rather than detected from the faceted
+// geometry. Lengths are in database units (cm); Angle is the swept bend angle in radians.
+type Bend struct {
+	Feature   string  // the feature that introduced the bend (e.g. "Flange1")
+	Angle     float64 // swept bend angle (radians)
+	Radius    float64 // inside bend radius (cm)
+	Thickness float64 // material thickness at the bend (cm)
+	Allowance float64 // developed neutral-axis arc length the flat must include (cm)
+	Deduction float64 // setback subtracted from the two outside flange lengths (cm)
+}
+
+// NewBend records a bend, computing its allowance and deduction from the rule's unfold
+// method so the values are fixed to the rule active at projection time.
+//
+// Example:
+//
+//	b := sheetmetal.NewBend("Flange1", math.Pi/2, 0.2, 0.1, rule.Unfold())
+//	flatLen := legA + legB + b.Allowance // develop two legs through one 90° bend
+func NewBend(feature string, angle, radius, thickness float64, m UnfoldMethod) Bend {
+	return Bend{
+		Feature:   feature,
+		Angle:     angle,
+		Radius:    radius,
+		Thickness: thickness,
+		Allowance: m.BendAllowance(angle, radius, thickness),
+		Deduction: m.BendDeduction(angle, radius, thickness),
+	}
+}

--- a/model/sheetmetal/bend_test.go
+++ b/model/sheetmetal/bend_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import (
+	"math"
+	"testing"
+)
+
+// TestNewBendDevelopsAllowanceAndDeduction checks NewBend fills the developed values from
+// the unfold method, matching the method's own formulas for the same bend.
+func TestNewBendDevelopsAllowanceAndDeduction(t *testing.T) {
+	m := KFactorMethod(0.5)
+	const angle, radius, thickness = math.Pi / 2, 0.2, 0.1
+
+	b := NewBend("Flange1", angle, radius, thickness, m)
+
+	if b.Feature != "Flange1" {
+		t.Errorf("Feature = %q, want Flange1", b.Feature)
+	}
+	if b.Angle != angle || b.Radius != radius || b.Thickness != thickness {
+		t.Errorf("geometry = (%g,%g,%g), want (%g,%g,%g)", b.Angle, b.Radius, b.Thickness, angle, radius, thickness)
+	}
+	if want := m.BendAllowance(angle, radius, thickness); b.Allowance != want {
+		t.Errorf("Allowance = %g, want %g", b.Allowance, want)
+	}
+	if want := m.BendDeduction(angle, radius, thickness); b.Deduction != want {
+		t.Errorf("Deduction = %g, want %g", b.Deduction, want)
+	}
+	// A 90° bend at K=0.5 develops to the neutral-axis arc (r + 0.5t)·angle.
+	if got, want := b.Allowance, (radius+0.5*thickness)*angle; math.Abs(got-want) > 1e-12 {
+		t.Errorf("Allowance = %g, want %g (neutral-axis arc)", got, want)
+	}
+}
+
+// TestNewBendUsesActiveUnfoldMethod confirms a different method changes the developed length
+// (so the record is fixed to the rule active at projection time, not a constant).
+func TestNewBendUsesActiveUnfoldMethod(t *testing.T) {
+	const angle, radius, thickness = math.Pi / 2, 0.2, 0.1
+	loose := NewBend("B", angle, radius, thickness, KFactorMethod(0.5))
+	tight := NewBend("B", angle, radius, thickness, KFactorMethod(0.25))
+	if !(tight.Allowance < loose.Allowance) {
+		t.Errorf("tighter K-factor allowance %g should be < %g", tight.Allowance, loose.Allowance)
+	}
+}


### PR DESCRIPTION
## What

Projects the folded part's **bend lineage** — the keystone the flat pattern develops from — and serves it over the wire (`sheetMetal.bends`).

- `sheetmetal.Bend` — one recorded bend with the unfold values to develop it: angle, radius, thickness, and the rule-computed **allowance** (developed neutral-axis arc length) + **deduction** (setback).
- `feature.BendLineage` / `BendSpec` — implemented by the discrete-bend walls (Flange, Hem, Bend, Fold); each reports its swept angle + radius. Hem's radius is gauge-derived (half the thickness), so it's resolved from the live thickness.
- `compdef.Bends()` / `TotalBendAllowance()` — walk the feature history, skip suppressed/sick features, fill a missing radius override with the rule default, and develop each bend via the active unfold method.
- `addin/router` — the `sheetMetal.bends` handler (angle reported in degrees; lengths in database units, matching the existing sheet-metal surface).

## Why

M13-F04's flat pattern is generated by *walking the bend graph and developing each face using its recorded bend allowance* (`architecture/modeling/05-sheet-metal.md`), which requires that *every bend record its unfold parameters*. This PR is that record.

**Design note:** rather than tag bend attributes onto the faceted arc geometry the F02 builders emit (multi-facet polygons that are awkward to re-detect post-hoc), the lineage is projected from the feature *definitions* — the feature history is the bend graph. This is robust, parameter-faithful, and is the natural input for the upcoming unfold geometry (F04-PR2).

**Coverage:** the discrete single-bend walls (flange/hem/bend/fold) report lineage now. The profile-swept walls (contour flange / lofted flange / contour roll) develop as continuous transitions rather than discrete bends; their development is handled in the unfold-geometry increment.

Pins `api v0.7.0` (contract: Oblikovati.API#121). Refs #377.

## Tests
- `sheetmetal`: `NewBend` develops allowance/deduction; tracks the active unfold method.
- `feature`: `BendSpecs` for flange (default 90° / overrides), bend, fold, and gauge-derived hem radius.
- `compdef`: a flanged sheet reports its bend with rule-developed values; nil off-environment; suppressed excluded; total sums.
- `router`: `sheetMetal.bends` over the wire (flanged sheet → 1 bend; flat sheet → none; plain part → error).
- `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)