### PR TITLE
feat(sheet-metal): flat-pattern development from edge bends (M13-F04)

### DIFF
--- a/model/compdef/sheet_metal_flat.go
+++ b/model/compdef/sheet_metal_flat.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// Unfold develops the folded sheet-metal part into its flat pattern (M13-F04, #377): the
+// base plate with every edge flange/hem laid out as a coplanar tab, each extending from its
+// bend line by the developed length (the rule's bend allowance plus the flange's straight
+// run). The flat is a derived body — it recomputes from the current folded model and rule,
+// so a thickness or K-factor edit changes the flat extents through the same allowance math.
+//
+// It errors when the part is not sheet metal or has no base Face to develop. Mid-sheet
+// bend/fold lines and stacked flange chains are not yet placed (see flat_pattern.go); the
+// developed tabs cover the common tray/bracket topology.
+func (d *PartComponentDefinition) Unfold() (*feature.FlatPattern, error) {
+	if d.sheetMetal == nil {
+		return nil, fmt.Errorf("unfold: the active part is not a sheet-metal part")
+	}
+	base, ok := d.baseFace()
+	if !ok {
+		return nil, fmt.Errorf("unfold: the part has no base Face to develop")
+	}
+	def := base.Definition()
+	return feature.BuildFlatPattern(def.Sketch, def.ProfileIndex, d.sheetMetal.Thickness(), d.flatTabs())
+}
+
+// baseFace returns the first sheet-metal base Face feature — the flat region the development
+// is anchored on.
+func (d *PartComponentDefinition) baseFace() (*feature.SheetMetalFaceFeature, bool) {
+	fs := d.features
+	for i := 0; i < fs.Count(); i++ {
+		if face, ok := fs.Item(i).Definition().(*feature.SheetMetalFaceFeature); ok {
+			return face, true
+		}
+	}
+	return nil, false
+}
+
+// flatTabs develops every healthy, unsuppressed edge bend into a flat tab, projecting its
+// recorded bend geometry into the base sketch plane and adding the rule's bend allowance to
+// the flange's straight run.
+func (d *PartComponentDefinition) flatTabs() []feature.FlatTab {
+	base, ok := d.baseFace()
+	if !ok {
+		return nil
+	}
+	plane := base.Definition().Sketch.Plane()
+	fs := d.features
+	var tabs []feature.FlatTab
+	for i := 0; i < fs.Count(); i++ {
+		if tab, ok := d.developTab(fs.Item(i), plane); ok {
+			tabs = append(tabs, tab)
+		}
+	}
+	return tabs
+}
+
+// developTab develops one feature into a flat tab, or ok=false when it is not a healthy
+// placed edge bend. It projects the recorded bend line and outward direction into the base
+// plane and adds the rule's bend allowance to the flange's straight run.
+func (d *PartComponentDefinition) developTab(pf *feature.PartFeature, plane sketch.Plane) (feature.FlatTab, bool) {
+	if pf.Suppressed() || !pf.Health().OK() {
+		return feature.FlatTab{}, false
+	}
+	placed, ok := pf.Definition().(feature.PlacedBend)
+	if !ok {
+		return feature.FlatTab{}, false
+	}
+	p, ok := placed.Placement()
+	if !ok {
+		return feature.FlatTab{}, false
+	}
+	out := p.Outward.AsVector()
+	x, y := plane.XAxis().AsVector(), plane.YAxis().AsVector()
+	return feature.FlatTab{
+		A:       plane.ToSketch(p.AxisStart),
+		B:       plane.ToSketch(p.AxisEnd),
+		Outward: math.V2(out.Dot(x), out.Dot(y)),
+		Length:  d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
+		Angle:   p.Angle,
+	}, true
+}

--- a/model/compdef/sheet_metal_flat_test.go
+++ b/model/compdef/sheet_metal_flat_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// flatVolume is the developed flat body's mesh volume at a fine chord tolerance.
+func flatVolume(body *topo.Body) float64 {
+	return ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-3}).Volume
+}
+
+// developedTabLength is the expected flat tab length for the default-rule fixture: the bend
+// allowance of a 90° bend plus the flange's straight run.
+func developedTabLength(rule *sheetmetal.Rule, height float64) float64 {
+	return rule.Unfold().BendAllowance(math.Pi/2, rule.BendRadius(), rule.Thickness()) + height
+}
+
+// TestUnfoldDevelopsWatertightFlat a flanged sheet unfolds to one watertight flat solid whose
+// footprint is the base square plus the developed flange tab, and whose extents grow with the
+// bend allowance — the flat-pattern acceptance criterion.
+func TestUnfoldDevelopsWatertightFlat(t *testing.T) {
+	const side, height = 4.0, 1.0
+	d, _ := sheetWithFlange(t) // square side=4, 90° flange height=1, default rule
+
+	fp, err := d.Unfold()
+	if err != nil {
+		t.Fatalf("Unfold: %v", err)
+	}
+	if !fp.Body.IsSolid() {
+		t.Fatal("flat pattern body is not a solid")
+	}
+	if open := ops.BoundaryEdges(fp.Body); len(open) != 0 {
+		t.Errorf("flat has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	if r := ops.Validate(fp.Body); !r.Valid {
+		t.Errorf("flat failed validation: %+v", r.Issues)
+	}
+
+	// Footprint: base side² plus the tab (side × developed length); volume = footprint × gauge.
+	rule := d.SheetMetal()
+	tab := developedTabLength(rule, height)
+	wantVol := (side*side + side*tab) * rule.Thickness()
+	if got := flatVolume(fp.Body); math.Abs(got-wantVol)/wantVol > 1e-3 {
+		t.Errorf("flat volume = %.5f, want %.5f", got, wantVol)
+	}
+
+	// Extents: one side stays at the base width; the other grows by the developed tab.
+	dx, dy := float64(fp.Extents.Diagonal().X), float64(fp.Extents.Diagonal().Y)
+	long, short := math.Max(dx, dy), math.Min(dx, dy)
+	if math.Abs(short-side) > 1e-6 {
+		t.Errorf("flat short extent = %.5f, want %.5f", short, side)
+	}
+	if math.Abs(long-(side+tab)) > 1e-6 {
+		t.Errorf("flat long extent = %.5f, want %.5f (side + developed tab)", long, side+tab)
+	}
+	if len(fp.Bends) != 1 || math.Abs(fp.Bends[0].Angle-math.Pi/2) > 1e-12 {
+		t.Errorf("flat bends = %+v, want one 90° fold line", fp.Bends)
+	}
+}
+
+// TestUnfoldTracksKFactor the flat is associative on the rule: raising the K-factor lengthens
+// the bend allowance and so the developed extent, without recomputing the folded model.
+func TestUnfoldTracksKFactor(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	tight, err := d.Unfold()
+	if err != nil {
+		t.Fatalf("Unfold (tight): %v", err)
+	}
+	d.SheetMetal().SetUnfold(sheetmetal.KFactorMethod(0.9)) // neutral axis nearer the outside
+	loose, err := d.Unfold()
+	if err != nil {
+		t.Fatalf("Unfold (loose): %v", err)
+	}
+	if !(flatVolume(loose.Body) > flatVolume(tight.Body)) {
+		t.Errorf("looser K-factor flat volume %.5f should exceed %.5f", flatVolume(loose.Body), flatVolume(tight.Body))
+	}
+}
+
+// TestUnfoldRejectsNonSheetMetal and a sheet-metal part with no base Face both error clearly.
+func TestUnfoldRejectsNonSheetMetal(t *testing.T) {
+	plain := NewPartComponentDefinition()
+	if _, err := plain.Unfold(); err == nil {
+		t.Error("Unfold on a plain part must error")
+	}
+	empty := NewPartComponentDefinition()
+	if _, err := empty.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	if _, err := empty.Unfold(); err == nil {
+		t.Error("Unfold with no base Face must error")
+	}
+}

--- a/model/feature/bend_lineage.go
+++ b/model/feature/bend_lineage.go
@@ -2,6 +2,8 @@
 
 package feature
 
+import "oblikovati.org/math"
+
 // BendLineage is implemented by sheet-metal features that introduce one or more bends. The
 // flat pattern (M13-F04, #377) reads it to develop each bend: the architecture requires
 // every bend to record its unfold parameters (angle + radius) so the flat develops at the
@@ -22,4 +24,25 @@ type BendLineage interface {
 type BendSpec struct {
 	Angle  float64 // swept bend angle (radians)
 	Radius float64 // inside bend radius (cm); <= 0 ⇒ use the rule's default
+}
+
+// BendPlacement is the resolved geometry of one edge bend, captured during the feature's
+// recompute (when its edge and frame are in hand). The flat pattern lays the bend's flange
+// out as a tab in the base plane, extending from the bend line (AxisStart→AxisEnd) along
+// Outward by the developed length (the rule's bend allowance + Length). The allowance is
+// filled in by the rule at unfold time, so the placement itself stays free of the unfold
+// method — the same separation BendSpec keeps.
+type BendPlacement struct {
+	AxisStart, AxisEnd math.Point3      // the bend line — the picked edge's endpoints
+	Outward            math.UnitVector3 // in-plane direction the flat tab extends (away from the sheet)
+	Angle, Radius      float64          // swept bend angle (radians) and inside radius (cm)
+	Thickness, Length  float64          // material thickness and the flange's straight-run length (cm)
+}
+
+// PlacedBend is implemented by the edge-bend walls (flange, hem) that develop into a flat
+// tab. Placement reports the resolved bend geometry from the last successful recompute; ok
+// is false before the first recompute or after the feature went sick. The flat pattern reads
+// it to lay each flange out in the base plane.
+type PlacedBend interface {
+	Placement() (BendPlacement, bool)
 }

--- a/model/feature/flat_pattern.go
+++ b/model/feature/flat_pattern.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Flat-pattern development (M13-F04, #377). The flat pattern is the manufacturable
+// unfolding of the folded sheet: the base plate with each edge flange laid out as a
+// coplanar tab, extending from its bend line by the developed length (the rule's bend
+// allowance plus the flange's straight run). Building all pieces in the base sketch plane at
+// the gauge yields one watertight flat solid whose extents grow with the K-factor exactly as
+// the bend allowance does — the acceptance criterion for the flat pattern.
+//
+// This increment develops edge flanges/hems (the common tray/bracket topology). Mid-sheet
+// bend/fold lines (which split the base into hinged regions) and stacked flange-on-flange
+// chains develop differently and are a follow-up; compdef.Unfold passes only the edge bends
+// it can place.
+
+// FlatTab is one edge bend developed into the base plane: its bend line (A→B, in base-plane
+// 2D) and the tab that extends Outward (a unit direction) by the developed Length. Angle is
+// carried through for the fold-line annotation.
+type FlatTab struct {
+	A, B    math.Point2
+	Outward math.Vector2
+	Length  float64
+	Angle   float64
+}
+
+// FlatBendLine is one fold line in the flat pattern: the segment (base-plane 2D) and the
+// bend angle — what a DXF export draws on the bend layer.
+type FlatBendLine struct {
+	A, B  math.Point2
+	Angle float64
+}
+
+// FlatPattern is the developed flat: the flat solid, its fold lines, the 2D extents, and the
+// gauge. Body is one watertight solid (the base plate unioned with every tab).
+type FlatPattern struct {
+	Body      *topo.Body
+	Bends     []FlatBendLine
+	Extents   math.Box2d
+	Thickness float64
+}
+
+// BuildFlatPattern thickens the base profile in its plane, unions each tab on as a coplanar
+// plate, and reports the fold lines and the 2D extents (the footprint in the base plane).
+//
+// Example:
+//
+//	fp, err := BuildFlatPattern(face.Sketch, 0, 0.1, tabs) // tabs from compdef.Unfold
+//	width, height := fp.Extents.Diagonal().X, fp.Extents.Diagonal().Y
+func BuildFlatPattern(baseSketch *sketch.Sketch, baseProfile int, thickness float64, tabs []FlatTab) (*FlatPattern, error) {
+	if thickness <= 0 {
+		return nil, fmt.Errorf("flat pattern: thickness must be positive, got %g", thickness)
+	}
+	profiles, err := resolveClosedProfiles(baseSketch, []int{baseProfile}, "flat pattern base")
+	if err != nil {
+		return nil, err
+	}
+	plane := baseSketch.Plane()
+	sp := span{near: 0, far: thickness}
+	body := buildProfilePrisms(profiles, plane, sp, 0, "FlatPattern")
+	fp := &FlatPattern{Thickness: thickness}
+	for _, tab := range tabs {
+		if body, err = appendTab(body, plane, sp, tab); err != nil {
+			return nil, err
+		}
+		fp.Bends = append(fp.Bends, FlatBendLine{A: tab.A, B: tab.B, Angle: tab.Angle})
+	}
+	fp.Body = body
+	fp.Extents = flatExtents(body, plane)
+	return fp, nil
+}
+
+// appendTab unions one developed tab plate onto the running flat body. The tab is the quad
+// bounded by the bend line (A→B) and that line shifted Outward by the developed length.
+func appendTab(body *topo.Body, plane sketch.Plane, sp span, tab FlatTab) (*topo.Body, error) {
+	offset := tab.Outward.Scale(tab.Length)
+	poly := []math.Point2{tab.A, tab.B, tab.B.TranslateBy(offset), tab.A.TranslateBy(offset)}
+	plate := buildPrism(poly, plane, sp, 0, "FlatPattern")
+	merged, err := combine([]*topo.Body{body}, plate, ops.Join)
+	if err != nil {
+		return nil, err
+	}
+	if len(merged) != 1 {
+		return nil, fmt.Errorf("flat pattern: tab union produced %d bodies, want 1 connected flat", len(merged))
+	}
+	return merged[0], nil
+}
+
+// flatExtents is the 2D bounding box of the flat body's footprint in the base plane —
+// computed from the body's vertices so it captures the base plate and every tab.
+func flatExtents(body *topo.Body, plane sketch.Plane) math.Box2d {
+	box := math.EmptyBox2d()
+	for _, v := range body.Vertices() {
+		box = box.ExtendPoint(plane.ToSketch(v.Point()))
+	}
+	return box
+}

--- a/model/feature/flat_pattern_test.go
+++ b/model/feature/flat_pattern_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestBuildFlatPatternWatertightWithTab a base square plus one developed tab unions into one
+// watertight flat solid whose footprint is the square plus the tab, with one fold line.
+func TestBuildFlatPatternWatertightWithTab(t *testing.T) {
+	const side, thickness, tab = 4.0, 0.2, 1.5
+	// Tab on the y=0 edge extending outward (-Y) by the developed length.
+	tabs := []FlatTab{{
+		A: math.P2(0, 0), B: math.P2(side, 0), Outward: math.V2(0, -1), Length: tab, Angle: stdmath.Pi / 2,
+	}}
+
+	fp, err := BuildFlatPattern(squareSketch(side), 0, thickness, tabs)
+	if err != nil {
+		t.Fatalf("BuildFlatPattern: %v", err)
+	}
+	assertWatertightSolid(t, fp.Body)
+
+	wantVol := (side*side + side*tab) * thickness
+	if got := meshVolume(fp.Body); stdmath.Abs(got-wantVol)/wantVol > 1e-3 {
+		t.Errorf("flat volume = %.5f, want %.5f", got, wantVol)
+	}
+	dy := float64(fp.Extents.Diagonal().Y)
+	if stdmath.Abs(dy-(side+tab)) > 1e-6 {
+		t.Errorf("flat Y-extent = %.5f, want %.5f (side + tab)", dy, side+tab)
+	}
+	if len(fp.Bends) != 1 || fp.Bends[0].A != tabs[0].A {
+		t.Errorf("flat bends = %+v, want one fold line at the tab edge", fp.Bends)
+	}
+}
+
+// TestBuildFlatPatternRejectsBadGauge a non-positive thickness is rejected with the value.
+func TestBuildFlatPatternRejectsBadGauge(t *testing.T) {
+	if _, err := BuildFlatPattern(squareSketch(4), 0, 0, nil); err == nil {
+		t.Error("BuildFlatPattern with zero thickness must error")
+	}
+}
+
+// TestBuildFlatPatternBaseOnly with no tabs the flat is just the thickened base plate.
+func TestBuildFlatPatternBaseOnly(t *testing.T) {
+	const side, thickness = 3.0, 0.1
+	fp, err := BuildFlatPattern(squareSketch(side), 0, thickness, nil)
+	if err != nil {
+		t.Fatalf("BuildFlatPattern: %v", err)
+	}
+	assertWatertightSolid(t, fp.Body)
+	if got, want := meshVolume(fp.Body), side*side*thickness; stdmath.Abs(got-want)/want > 1e-3 {
+		t.Errorf("base-only flat volume = %.5f, want %.5f", got, want)
+	}
+	if len(fp.Bends) != 0 {
+		t.Errorf("base-only flat has %d fold lines, want 0", len(fp.Bends))
+	}
+}
+
+// TestFlangePlacementCaptured a recomputed flange records its bend geometry: the bend line is
+// the picked edge and the outward direction is in the sheet plane (perpendicular to the
+// edge), so the flat pattern can lay the tab out.
+func TestFlangePlacementCaptured(t *testing.T) {
+	fs, edge := seedSheetMetalSheet(t, 4, map[string]string{"BendRadius": "1 mm"})
+	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(),
+		Height:  func() float64 { return 1 },
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("flange unhealthy: %s", pf.Health().Reason)
+	}
+	placed, ok := pf.Definition().(PlacedBend)
+	if !ok {
+		t.Fatal("flange does not implement PlacedBend")
+	}
+	p, ok := placed.Placement()
+	if !ok {
+		t.Fatal("flange placement not captured after recompute")
+	}
+	if p.AxisStart.DistanceTo(p.AxisEnd) <= 0 {
+		t.Error("placement bend line is degenerate")
+	}
+	// Outward must be perpendicular to the bend line (it is the in-plane fold-out direction).
+	axis, err := math.UnitVector3FromVector(p.AxisStart.VectorTo(p.AxisEnd))
+	if err != nil {
+		t.Fatalf("axis dir: %v", err)
+	}
+	if dot := p.Outward.AsVector().Dot(axis.AsVector()); stdmath.Abs(dot) > 1e-9 {
+		t.Errorf("outward·axis = %g, want 0 (perpendicular)", dot)
+	}
+	if p.Length != 1 || p.Angle <= 0 {
+		t.Errorf("placement length/angle = (%g,%g), want (1, >0)", p.Length, p.Angle)
+	}
+}

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -41,8 +41,9 @@ type SheetMetalFlangeDefinition struct {
 
 // SheetMetalFlangeFeature folds a wall onto the sheet each recompute.
 type SheetMetalFlangeFeature struct {
-	def      *SheetMetalFlangeDefinition
-	featName string
+	def       *SheetMetalFlangeDefinition
+	featName  string
+	placement *BendPlacement // resolved bend geometry from the last recompute (for the flat pattern)
 }
 
 // Definition returns the flange recipe.
@@ -66,7 +67,7 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	wall, err := buildFlangeSolid(edges[0], dims.thickness, dims.radius, dims.height, dims.angle, f.def.Flip, f.featName)
+	wall, placement, err := buildFlangeSolid(edges[0], dims.thickness, dims.radius, dims.height, dims.angle, f.def.Flip, f.featName)
 	if err != nil {
 		return Output{}, err
 	}
@@ -75,7 +76,18 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
+	f.placement = &placement // record the resolved bend for the flat pattern (M13-F04)
 	return Output{Bodies: bodies}, nil
+}
+
+// Placement returns the resolved bend geometry captured by the last successful recompute,
+// for the flat pattern to lay this flange out as a tab. ok is false before the first
+// recompute.
+func (f *SheetMetalFlangeFeature) Placement() (BendPlacement, bool) {
+	if f.placement == nil {
+		return BendPlacement{}, false
+	}
+	return *f.placement, true
 }
 
 // flangeDims is the resolved, validated set of flange dimensions for one recompute.
@@ -129,22 +141,28 @@ func (f *SheetMetalFlangeFeature) BendSpecs(_ float64) []BendSpec {
 
 // buildFlangeSolid constructs the bend+wall solid on edge: the cross-section band extruded
 // along the edge. up is the parent face's outward normal (the fold-toward side); out is the
-// in-plane direction away from the sheet. flip folds toward the opposite face.
-func buildFlangeSolid(edge *topo.Edge, thickness, radius, height, angle float64, flip bool, feat string) (*topo.Body, error) {
+// in-plane direction away from the sheet. flip folds toward the opposite face. It also
+// returns the resolved [BendPlacement] (the bend line + outward direction + dims) so the
+// flat pattern can lay this flange out as a tab without re-resolving the edge.
+func buildFlangeSolid(edge *topo.Edge, thickness, radius, height, angle float64, flip bool, feat string) (*topo.Body, BendPlacement, error) {
 	v0, v1 := edge.StartVertex().Point(), edge.EndVertex().Point()
 	e, err := math.UnitVector3FromVector(v0.VectorTo(v1))
 	if err != nil {
-		return nil, fmt.Errorf("sheet-metal flange: degenerate edge")
+		return nil, BendPlacement{}, fmt.Errorf("sheet-metal flange: degenerate edge")
 	}
 	up, out, err := flangeFrame(edge, v0.Midpoint(v1), e, flip)
 	if err != nil {
-		return nil, err
+		return nil, BendPlacement{}, err
 	}
 	plane := planePerp(v0, e)
 	u, v := plane.XAxis().AsVector(), plane.YAxis().AsVector()
 	proj := func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) }
 	poly := flangeBandPolygon(out.AsVector(), up.AsVector(), thickness, radius, height, angle, proj)
-	return buildPrism(poly, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), nil
+	placement := BendPlacement{
+		AxisStart: v0, AxisEnd: v1, Outward: out,
+		Angle: angle, Radius: radius, Thickness: thickness, Length: height,
+	}
+	return buildPrism(poly, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), placement, nil
 }
 
 // flangeFrame returns the parent face's outward normal (up) and the in-plane outward

--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/param"
 )
 
 // Sheet-metal Hem feature (M13-F02). A hem folds the material at an edge back on itself —
@@ -41,8 +42,9 @@ type SheetMetalHemDefinition struct {
 
 // SheetMetalHemFeature folds a hem onto the sheet each recompute.
 type SheetMetalHemFeature struct {
-	def      *SheetMetalHemDefinition
-	featName string
+	def       *SheetMetalHemDefinition
+	featName  string
+	placement *BendPlacement // resolved bend geometry from the last recompute (for the flat pattern)
 }
 
 // Definition returns the hem recipe.
@@ -57,20 +59,15 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	t, err := sheetThickness(in.Params)
+	t, radius, length, err := f.hemDims(in.Params)
 	if err != nil {
 		return Output{}, err
-	}
-	radius := f.hemRadius(t)
-	length := evalFloat(f.def.Length)
-	if radius <= 0 || length <= 0 {
-		return Output{}, fmt.Errorf("sheet-metal hem: radius/length must be positive (r=%g l=%g)", radius, length)
 	}
 	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
 	if err != nil {
 		return Output{}, err
 	}
-	wall, err := buildFlangeSolid(edges[0], t, radius, length, hemFoldAngle, f.def.Flip, f.featName)
+	wall, placement, err := buildFlangeSolid(edges[0], t, radius, length, hemFoldAngle, f.def.Flip, f.featName)
 	if err != nil {
 		return Output{}, err
 	}
@@ -78,7 +75,32 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
+	f.placement = &placement // record the resolved bend for the flat pattern (M13-F04)
 	return Output{Bodies: bodies}, nil
+}
+
+// Placement returns the resolved bend geometry captured by the last successful recompute,
+// for the flat pattern to lay this hem out as a tab. ok is false before the first recompute.
+func (f *SheetMetalHemFeature) Placement() (BendPlacement, bool) {
+	if f.placement == nil {
+		return BendPlacement{}, false
+	}
+	return *f.placement, true
+}
+
+// hemDims reads the live thickness and resolves the hem's bend radius and fold-back length,
+// erroring if either is non-positive.
+func (f *SheetMetalHemFeature) hemDims(ps *param.Parameters) (thickness, radius, length float64, err error) {
+	thickness, err = sheetThickness(ps)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	radius = f.hemRadius(thickness)
+	length = evalFloat(f.def.Length)
+	if radius <= 0 || length <= 0 {
+		return 0, 0, 0, fmt.Errorf("sheet-metal hem: radius/length must be positive (r=%g l=%g)", radius, length)
+	}
+	return thickness, radius, length, nil
 }
 
 // hemRadius returns the inside bend radius for the hem type: a closed hem folds at half the


### PR DESCRIPTION
## What

Develops the **flat pattern** — the manufacturable unfolding of the folded sheet — for the common tray/bracket topology (edge flanges and hems), building on the bend lineage from #938.

- `feature.FlatPattern` + `BuildFlatPattern` — thickens the base profile in its sketch plane and unions each flange/hem on as a **coplanar tab** extending from its bend line by the developed length. One watertight flat solid + fold lines + 2D extents + gauge.
- `feature.BendPlacement` / `PlacedBend` — the edge-bend walls now **record their resolved bend geometry during recompute** (`buildFlangeSolid` returns the bend line + outward direction + dims; flange and hem capture it). This avoids re-resolving reference keys against the post-union body, which is fragile.
- `compdef.Unfold()` — projects each placement into the base plane, adds the rule's bend allowance to the flange's straight run, and calls the builder. The flat is a **derived body**: a thickness or K-factor edit changes its extents through the same allowance math, no model recompute needed.

## Why

M13-F04's flat pattern is *a derived body computed from the folded model* (`architecture/modeling/05-sheet-metal.md`), generated by developing each region into the plane using its recorded bend allowance. PR #938 recorded the bends; this PR develops them into the flat.

The developed length per K-factor is the PBI's acceptance criterion — verified directly: the flat extent equals base + (allowance + flange length), and grows when the K-factor rises.

**Scope:** edge flanges/hems develop now (the canonical box/bracket). Mid-sheet bend/fold lines (which split the base into hinged regions) and stacked flange-on-flange chains develop differently and are a focused follow-up — `compdef.Unfold` passes only the edge bends it can place. Source-only; no API change (the wire surface `sheetMetal.unfold` is the next stacked PR).

## Tests
- `feature`: `BuildFlatPattern` — watertight solid + analytic volume (base + tab); base-only; bad-gauge rejection; flange placement captured (bend line = picked edge, outward ⟂ edge).
- `compdef`: `Unfold` — watertight flat, footprint volume = (base² + base·tab)·gauge, extents = base + developed tab, one 90° fold line; K-factor associativity (looser K → larger flat); rejects non-sheet-metal / no-base-Face.
- `golangci-lint` 0 issues.

Refs #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)