### PR TITLE
feat(sheet-metal): serve the unfold (flat pattern) query (M13-F04)

### DIFF
--- a/addin/router/sheet_metal.go
+++ b/addin/router/sheet_metal.go
@@ -10,7 +10,10 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	gmath "oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sheetmetal"
 )
@@ -26,6 +29,7 @@ func (r *Router) registerSheetMetalHandlers() {
 	r.handlers[wire.MethodSheetMetalSetStyle] = sheetMetalSetStyle
 	r.handlers[wire.MethodSheetMetalBendAllowance] = sheetMetalBendAllowance
 	r.handlers[wire.MethodSheetMetalBends] = sheetMetalBends
+	r.handlers[wire.MethodSheetMetalUnfold] = sheetMetalUnfold
 }
 
 // activeSheetMetal returns the active part and its rule, or an error if the active document
@@ -193,6 +197,44 @@ func sheetMetalBends(s *app.Session, _ json.RawMessage) (json.RawMessage, error)
 
 // degPerRad converts a bend's stored angle (radians) to the degrees the wire reports.
 const degPerRad = 180.0 / 3.141592653589793
+
+func sheetMetalUnfold(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	flat, err := part.Unfold()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.UnfoldResult{Flat: flatInfo(flat)})
+}
+
+// flatInfo renders a developed flat pattern as wire: its extents, gauge, developed footprint
+// area (the constant-thickness plate's volume divided by the gauge), and the fold lines.
+func flatInfo(flat *feature.FlatPattern) wire.FlatPatternInfo {
+	area := 0.0
+	if flat.Thickness > 0 {
+		area = ops.BodyGeometryProperties(flat.Body, ops.Quality{ChordTolerance: 1e-3}).Volume / flat.Thickness
+	}
+	info := wire.FlatPatternInfo{
+		Extents:   types.Box2d{Min: point2d(flat.Extents.Min), Max: point2d(flat.Extents.Max)},
+		Thickness: flat.Thickness,
+		Area:      area,
+		Bends:     make([]wire.FlatBendLineInfo, 0, len(flat.Bends)),
+	}
+	for _, b := range flat.Bends {
+		info.Bends = append(info.Bends, wire.FlatBendLineInfo{
+			Start: point2d(b.A), End: point2d(b.B), Angle: b.Angle * degPerRad,
+		})
+	}
+	return info
+}
+
+// point2d converts a model 2D point to the wire value type.
+func point2d(p gmath.Point2) types.Point2d {
+	return types.Point2d{X: float64(p.X), Y: float64(p.Y)}
+}
 
 // styleInfo renders the active rule as wire, formatting lengths in the document's units and
 // including the bend allowance of a 90° bend as a convenience preview. The two

--- a/addin/router/sheet_metal_bends_test.go
+++ b/addin/router/sheet_metal_bends_test.go
@@ -109,3 +109,30 @@ func TestSheetMetalBendsRejectsPlainPart(t *testing.T) {
 		t.Fatal("bends on a plain part must error")
 	}
 }
+
+// TestSheetMetalUnfoldOverWire a flanged sheet unfolds over the wire to a flat with a positive
+// gauge/area, extents that exceed the folded footprint (the developed tab), and one fold line.
+func TestSheetMetalUnfoldOverWire(t *testing.T) {
+	r, s := flangedSheet(t) // 40×30 mm base, 10 mm flange
+	var res wire.UnfoldResult
+	call(t, r, s, wire.MethodSheetMetalUnfold, "{}", &res)
+	flat := res.Flat
+	if flat.Thickness <= 0 || flat.Area <= 0 {
+		t.Errorf("flat gauge/area must be positive: %+v", flat)
+	}
+	// Base is 4×3 cm; the flange develops a tab beyond it, so one extent exceeds 4 cm.
+	if w, h := flat.Extents.Max.X-flat.Extents.Min.X, flat.Extents.Max.Y-flat.Extents.Min.Y; w < 3.9 || h < 3.9 || math.Max(w, h) < 4.1 {
+		t.Errorf("flat extents = %.3f × %.3f cm, want base 4×3 plus a developed tab", w, h)
+	}
+	if len(flat.Bends) != 1 || math.Abs(flat.Bends[0].Angle-90) > 1e-6 {
+		t.Errorf("flat fold lines = %+v, want one 90° bend", flat.Bends)
+	}
+}
+
+// TestSheetMetalUnfoldRejectsPlainPart unfold on an ordinary part errors (no sheet-metal rule).
+func TestSheetMetalUnfoldRejectsPlainPart(t *testing.T) {
+	r, s := seededSession(t)
+	if _, err := r.Handle(s, wire.MethodSheetMetalUnfold, []byte("{}")); err == nil {
+		t.Fatal("unfold on a plain part must error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.7.0
+	oblikovati.org/api v0.8.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.7.0
+	oblikovati.org/api v0.8.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

Serves **`sheetMetal.unfold`** over the router: develops the active sheet-metal part via `compdef.Unfold()` and renders the flat pattern as wire — its extents, gauge, developed footprint area, and the fold lines (segment + bend angle).

Pins `api v0.8.0` (contract: Oblikovati.API#122).

## Why

Completes the F04 unfold surface end-to-end: PR #938 recorded the bend lineage, #939 developed the flat body, this exposes it to add-ins and the bridge. The reported flat (extents, area, fold lines) is the input a manufacturing add-in needs to size stock and place bend lines — and tracks thickness/K-factor edits since the flat is a derived body.

## Tests
- `router`: `sheetMetal.unfold` over the wire — a flanged sheet yields a flat with a positive gauge/area, extents that exceed the folded footprint (the developed tab), and one 90° fold line; rejects a plain part.
- `golangci-lint` 0 issues.

Refs #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)