### PR TITLE
fix(sheet-metal): orient flat tabs from base geometry, not the fold vector (M13-F04)

### DIFF
--- a/model/compdef/sheet_metal_flat.go
+++ b/model/compdef/sheet_metal_flat.go
@@ -5,7 +5,6 @@ package compdef
 import (
 	"fmt"
 
-	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
@@ -77,13 +76,10 @@ func (d *PartComponentDefinition) developTab(pf *feature.PartFeature, plane sket
 	if !ok {
 		return feature.FlatTab{}, false
 	}
-	out := p.Outward.AsVector()
-	x, y := plane.XAxis().AsVector(), plane.YAxis().AsVector()
 	return feature.FlatTab{
-		A:       plane.ToSketch(p.AxisStart),
-		B:       plane.ToSketch(p.AxisEnd),
-		Outward: math.V2(out.Dot(x), out.Dot(y)),
-		Length:  d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
-		Angle:   p.Angle,
+		A:      plane.ToSketch(p.AxisStart),
+		B:      plane.ToSketch(p.AxisEnd),
+		Length: d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
+		Angle:  p.Angle,
 	}, true
 }

--- a/model/compdef/sheet_metal_flat_test.go
+++ b/model/compdef/sheet_metal_flat_test.go
@@ -8,7 +8,10 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sheetmetal"
+	"oblikovati.org/model/sketch"
 )
 
 // flatVolume is the developed flat body's mesh volume at a fine chord tolerance.
@@ -63,6 +66,53 @@ func TestUnfoldDevelopsWatertightFlat(t *testing.T) {
 	if len(fp.Bends) != 1 || math.Abs(fp.Bends[0].Angle-math.Pi/2) > 1e-12 {
 		t.Errorf("flat bends = %+v, want one 90° fold line", fp.Bends)
 	}
+}
+
+// TestUnfoldDevelopsTabForOutOfPlaneFold a flange whose 3D fold direction leaves the base
+// plane (a flange folded off a bottom edge folds in −Z) must still develop a tab in the base
+// plane: the tab outward is derived from the base geometry, not the 3D fold vector. Regression
+// for the bridge-found bug where such a tab collapsed (projected −Z → zero) and the flat was
+// just the base.
+func TestUnfoldDevelopsTabForOutOfPlaneFold(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	addRectFace(t, d, 4, 3)
+	body := d.Features().Result()[0]
+	edge := body.Edges()[0] // a bottom edge: its flange folds out of the base plane (−Z)
+	pf := feature.NewSheetMetalFlangeFeatures(d.Features()).Add(&feature.SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(), Height: func() float64 { return 1 },
+	})
+	d.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("flange unhealthy: %s", pf.Health().Reason)
+	}
+
+	fp, err := d.Unfold()
+	if err != nil {
+		t.Fatalf("Unfold: %v", err)
+	}
+	baseVol := 4 * 3 * d.SheetMetal().Thickness()
+	if got := flatVolume(fp.Body); got <= baseVol*1.05 {
+		t.Errorf("flat volume = %.4f, want clearly above the base %.4f (the tab must develop)", got, baseVol)
+	}
+}
+
+// addRectFace adds a w×h rectangle base Face on XY and recomputes.
+func addRectFace(t *testing.T, d *PartComponentDefinition, w, h float64) {
+	t.Helper()
+	sk := d.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(gmath.P2(0, 0))
+	c1 := sk.Points().Add(gmath.P2(w, 0))
+	c2 := sk.Points().Add(gmath.P2(w, h))
+	c3 := sk.Points().Add(gmath.P2(0, h))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewSheetMetalFaceFeatures(d.Features()).Add(&feature.SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Operation: ops.NewBody})
+	d.Recompute()
 }
 
 // TestUnfoldTracksKFactor the flat is associative on the rule: raising the K-factor lengthens

--- a/model/feature/flat_pattern.go
+++ b/model/feature/flat_pattern.go
@@ -24,13 +24,15 @@ import (
 // it can place.
 
 // FlatTab is one edge bend developed into the base plane: its bend line (A→B, in base-plane
-// 2D) and the tab that extends Outward (a unit direction) by the developed Length. Angle is
-// carried through for the fold-line annotation.
+// 2D) and the developed Length the tab extends from that line. The outward direction is NOT
+// carried here — it is derived in BuildFlatPattern from the base geometry (perpendicular to
+// the bend line, away from the base), because the bend's 3D fold direction can leave the base
+// plane (a flange folded off a bottom edge folds in −Z) and so cannot be projected into it.
+// Angle is carried through for the fold-line annotation.
 type FlatTab struct {
-	A, B    math.Point2
-	Outward math.Vector2
-	Length  float64
-	Angle   float64
+	A, B   math.Point2
+	Length float64
+	Angle  float64
 }
 
 // FlatBendLine is one fold line in the flat pattern: the segment (base-plane 2D) and the
@@ -67,9 +69,10 @@ func BuildFlatPattern(baseSketch *sketch.Sketch, baseProfile int, thickness floa
 	plane := baseSketch.Plane()
 	sp := span{near: 0, far: thickness}
 	body := buildProfilePrisms(profiles, plane, sp, 0, "FlatPattern")
+	centroid := polygonCentroid(profiles[0].OuterLoop().Polygon())
 	fp := &FlatPattern{Thickness: thickness}
 	for _, tab := range tabs {
-		if body, err = appendTab(body, plane, sp, tab); err != nil {
+		if body, err = appendTab(body, plane, sp, tab, centroid); err != nil {
 			return nil, err
 		}
 		fp.Bends = append(fp.Bends, FlatBendLine{A: tab.A, B: tab.B, Angle: tab.Angle})
@@ -80,9 +83,11 @@ func BuildFlatPattern(baseSketch *sketch.Sketch, baseProfile int, thickness floa
 }
 
 // appendTab unions one developed tab plate onto the running flat body. The tab is the quad
-// bounded by the bend line (A→B) and that line shifted Outward by the developed length.
-func appendTab(body *topo.Body, plane sketch.Plane, sp span, tab FlatTab) (*topo.Body, error) {
-	offset := tab.Outward.Scale(tab.Length)
+// bounded by the bend line (A→B) and that line shifted outward by the developed length, where
+// outward is the in-plane perpendicular pointing away from the base (the bend opens the flange
+// onto the far side of its bend line).
+func appendTab(body *topo.Body, plane sketch.Plane, sp span, tab FlatTab, baseCentroid math.Point2) (*topo.Body, error) {
+	offset := tabOutward(tab.A, tab.B, baseCentroid).Scale(tab.Length)
 	poly := []math.Point2{tab.A, tab.B, tab.B.TranslateBy(offset), tab.A.TranslateBy(offset)}
 	plate := buildPrism(poly, plane, sp, 0, "FlatPattern")
 	merged, err := combine([]*topo.Body{body}, plate, ops.Join)
@@ -93,6 +98,36 @@ func appendTab(body *topo.Body, plane sketch.Plane, sp span, tab FlatTab) (*topo
 		return nil, fmt.Errorf("flat pattern: tab union produced %d bodies, want 1 connected flat", len(merged))
 	}
 	return merged[0], nil
+}
+
+// tabOutward is the unit in-plane direction the flat tab extends: perpendicular to the bend
+// line (a→b), oriented away from the base centroid so the developed flange lands outside the
+// base rather than overlapping it.
+func tabOutward(a, b, centroid math.Point2) math.Vector2 {
+	edge := a.VectorTo(b)
+	perp := math.V2(-edge.Y, edge.X)
+	if l := perp.Length(); l > 0 {
+		perp = perp.Scale(1 / l)
+	}
+	if centroid.VectorTo(a.Midpoint(b)).Dot(perp) < 0 {
+		perp = perp.Negate()
+	}
+	return perp
+}
+
+// polygonCentroid is the average of a polygon's vertices — enough to orient tabs away from a
+// convex base.
+func polygonCentroid(poly []math.Point2) math.Point2 {
+	if len(poly) == 0 {
+		return math.P2(0, 0)
+	}
+	var sx, sy float64
+	for _, p := range poly {
+		sx += float64(p.X)
+		sy += float64(p.Y)
+	}
+	n := float64(len(poly))
+	return math.P2(sx/n, sy/n)
 }
 
 // flatExtents is the 2D bounding box of the flat body's footprint in the base plane —

--- a/model/feature/flat_pattern_test.go
+++ b/model/feature/flat_pattern_test.go
@@ -13,9 +13,9 @@ import (
 // watertight flat solid whose footprint is the square plus the tab, with one fold line.
 func TestBuildFlatPatternWatertightWithTab(t *testing.T) {
 	const side, thickness, tab = 4.0, 0.2, 1.5
-	// Tab on the y=0 edge extending outward (-Y) by the developed length.
+	// Tab on the y=0 edge; BuildFlatPattern orients it outward (−Y, away from the base).
 	tabs := []FlatTab{{
-		A: math.P2(0, 0), B: math.P2(side, 0), Outward: math.V2(0, -1), Length: tab, Angle: stdmath.Pi / 2,
+		A: math.P2(0, 0), B: math.P2(side, 0), Length: tab, Angle: stdmath.Pi / 2,
 	}}
 
 	fp, err := BuildFlatPattern(squareSketch(side), 0, thickness, tabs)


### PR DESCRIPTION
## What

Fixes flat-pattern development for flanges whose **3D fold direction leaves the base plane**.

`BendPlacement.Outward` is the flange's 3D fold direction. For a flange folded off a **bottom edge** it points in −Z, so projecting it into the base plane gave a **zero vector** → the developed tab collapsed and the flat pattern was just the base (no tab).

Now `BuildFlatPattern` derives each tab's outward itself: the in-plane perpendicular to the bend line, oriented **away from the base centroid** (unfolding opens the flange onto the far side of its bend line). This is always in-plane and independent of the 3D fold direction. `FlatTab` drops its `Outward` field accordingly.

## How it was found

Driving `sheet_metal_unfold` over the MCP bridge on a flange placed on `topology()[0]` (a bottom edge): the response had the correct fold line but `area == base` and extents == base. Reproduced at the source level (`outward = {0,0,-1}`), then fixed.

## Tests
- New regression: a flange whose fold leaves the base plane still develops a tab (flat volume clearly exceeds the base).
- Existing flat-pattern / unfold tests still pass; `golangci-lint` 0 issues.

Refs #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)