### PR TITLE
feat(sheet-metal): unfold/refold features for cut-while-flat (M13-F04)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -266,6 +266,8 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalContourRoll":   `{"profileSketch":0,"axisLine":0}`,
 		"sheetMetalCornerSeam":    `{"edges":["x"],"gap":"0.2 mm"}`,
 		"sheetMetalCut":           `{"sketchIndex":0}`,
+		"sheetMetalUnfold":        `{}`,
+		"sheetMetalRefold":        `{}`,
 		"splitSolid":              `{"toolSketch":0}`,
 		"coreCavity":              `{}`,
 		"hull":                    `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -141,6 +141,8 @@ func Default() *Registry {
 		sheetMetalContourRollDescriptor(),
 		sheetMetalCornerSeamDescriptor(),
 		sheetMetalCutDescriptor(),
+		sheetMetalUnfoldDescriptor(),
+		sheetMetalRefoldDescriptor(),
 		splitSolidDescriptor(),
 		coreCavityDescriptor(),
 		hullDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_unfold.go
+++ b/addin/opregistry/sheet_metal_unfold.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/app"
+)
+
+// Sheet-metal Unfold/Refold operations (M13-F04). Unfold flattens every edge bend of the
+// active part (leaving it flat for a subsequent cut); Refold re-folds them, carrying any
+// edits made while flat. Both take no arguments — they act on the part's recorded bends.
+
+const sheetMetalNoArgsSchema = `{"type": "object", "properties": {}}`
+
+// sheetMetalUnfoldDescriptor is the self-describing "sheetMetalUnfold" operation.
+func sheetMetalUnfoldDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalUnfold",
+		Summary: "Flatten every bend of the active sheet-metal part (develop it flat) so a following cut works in developed space.",
+		Schema:  json.RawMessage(sheetMetalNoArgsSchema),
+		Apply:   applySheetMetalUnfold,
+	}
+}
+
+// sheetMetalRefoldDescriptor is the self-describing "sheetMetalRefold" operation.
+func sheetMetalRefoldDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalRefold",
+		Summary: "Re-fold the bends an earlier unfold flattened, restoring the folded part and carrying any edits made while flat.",
+		Schema:  json.RawMessage(sheetMetalNoArgsSchema),
+		Apply:   applySheetMetalRefold,
+	}
+}
+
+func applySheetMetalUnfold(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalUnfold")
+	if err != nil {
+		return nil, err
+	}
+	pf, err := part.AddUnfold()
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, pf)
+}
+
+func applySheetMetalRefold(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalRefold")
+	if err != nil {
+		return nil, err
+	}
+	pf, err := part.AddRefold()
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/sheet_metal_unfold_test.go
+++ b/addin/opregistry/sheet_metal_unfold_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import "testing"
+
+// TestSheetMetalUnfoldRefoldApply seeds a flanged sheet, flattens it (unfold), and refolds it
+// — each yields one merged solid — then checks the error paths.
+func TestSheetMetalUnfoldRefoldApply(t *testing.T) {
+	s, edge := seedSheetMetalSheet(t)
+	if _, err := applyMap(t, s, "sheetMetalFlange", map[string]any{"edge": edge, "height": "10 mm", "radius": "2 mm"}); err != nil {
+		t.Fatalf("flange apply: %v", err)
+	}
+
+	out, err := apply(t, s, "sheetMetalUnfold", `{}`)
+	if err != nil {
+		t.Fatalf("unfold apply: %v", err)
+	}
+	expectMergedSolid(t, out, "unfold")
+
+	out, err = apply(t, s, "sheetMetalRefold", `{}`)
+	if err != nil {
+		t.Fatalf("refold apply: %v", err)
+	}
+	expectMergedSolid(t, out, "refold")
+
+	// Error paths: a non-sheet-metal part, and a sheet-metal part with no bends.
+	if _, err := apply(t, profiledPart(t), "sheetMetalUnfold", `{}`); err == nil {
+		t.Error("unfold on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, sheetMetalProfiledPart(t), "sheetMetalUnfold", `{}`); err == nil {
+		t.Error("unfold with no bends must error")
+	}
+}

--- a/model/compdef/sheet_metal_unfold.go
+++ b/model/compdef/sheet_metal_unfold.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// Unfold/Refold features (M13-F04, #377). These flatten and re-fold the running body in the
+// feature stream so a cut placed while flat develops correctly on the folded part. The bends
+// to act on are baked from the part's recorded bend placements at creation time, so the
+// feature stays self-contained at recompute (it never reaches back into the other features).
+
+// AddUnfold appends an unfold feature that flattens every edge bend of the part, leaving the
+// part flat for subsequent features. It errors when the part is not sheet metal or has no
+// bends to flatten.
+func (d *PartComponentDefinition) AddUnfold() (*feature.PartFeature, error) {
+	bends, err := d.bendTransforms("unfold")
+	if err != nil {
+		return nil, err
+	}
+	return feature.NewSheetMetalUnfoldFeatures(d.features).Add(&feature.SheetMetalUnfoldDefinition{Bends: bends}), nil
+}
+
+// AddRefold appends a refold feature that re-folds the same bends an earlier unfold flattened,
+// restoring the folded part (and carrying any edits made while flat).
+func (d *PartComponentDefinition) AddRefold() (*feature.PartFeature, error) {
+	bends, err := d.bendTransforms("refold")
+	if err != nil {
+		return nil, err
+	}
+	return feature.NewSheetMetalRefoldFeatures(d.features).Add(&feature.SheetMetalRefoldDefinition{Bends: bends}), nil
+}
+
+// bendTransforms bakes one [feature.BendTransform] per recorded edge bend: the bend line, the
+// base sheet normal (which fixes the split plane), and the fold angle.
+func (d *PartComponentDefinition) bendTransforms(op string) ([]feature.BendTransform, error) {
+	if d.sheetMetal == nil {
+		return nil, fmt.Errorf("%s: the active part is not a sheet-metal part", op)
+	}
+	base, ok := d.baseFace()
+	if !ok {
+		return nil, fmt.Errorf("%s: the part has no base Face", op)
+	}
+	normal := base.Definition().Sketch.Plane().Normal().AsVector()
+	var out []feature.BendTransform
+	fs := d.features
+	for i := 0; i < fs.Count(); i++ {
+		if bt, ok := bakeBendTransform(fs.Item(i), normal); ok {
+			out = append(out, bt)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("%s: the part has no bends to act on", op)
+	}
+	return out, nil
+}
+
+// bakeBendTransform turns one feature's recorded bend placement into a transform, or ok=false
+// when it is not a healthy placed edge bend.
+func bakeBendTransform(pf *feature.PartFeature, baseNormal math.Vector3) (feature.BendTransform, bool) {
+	if pf.Suppressed() || !pf.Health().OK() {
+		return feature.BendTransform{}, false
+	}
+	placed, ok := pf.Definition().(feature.PlacedBend)
+	if !ok {
+		return feature.BendTransform{}, false
+	}
+	p, ok := placed.Placement()
+	if !ok {
+		return feature.BendTransform{}, false
+	}
+	return feature.BendTransform{
+		LinePoint:  p.AxisStart,
+		LineDir:    p.AxisStart.VectorTo(p.AxisEnd),
+		BaseNormal: baseNormal,
+		Angle:      p.Angle,
+	}, true
+}

--- a/model/compdef/sheet_metal_unfold_test.go
+++ b/model/compdef/sheet_metal_unfold_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// maxZ returns the body's highest vertex Z — the out-of-plane extent that drops to ~the gauge
+// when the part is flat and rises again when refolded.
+func maxZ(b *topo.Body) float64 {
+	m := math.Inf(-1)
+	for _, v := range b.Vertices() {
+		if v.Point().Z > m {
+			m = v.Point().Z
+		}
+	}
+	return m
+}
+
+func assertFlatSolid(t *testing.T, b *topo.Body) {
+	t.Helper()
+	if !b.IsSolid() {
+		t.Error("unfold/refold result is not a solid")
+	}
+	if open := ops.BoundaryEdges(b); len(open) != 0 {
+		t.Errorf("result has %d boundary edges, want 0 (watertight)", len(open))
+	}
+}
+
+// TestUnfoldRefoldRoundTrip a flanged sheet unfolds to a flat watertight solid (the flange
+// lies in the base plane) and refolds back to the folded part — volume preserved throughout
+// (the moving flange is rigidly transformed and rejoined, no material added or lost).
+func TestUnfoldRefoldRoundTrip(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	folded := d.Features().Result()[0]
+	v0, z0 := flatVolume(folded), maxZ(folded)
+	gauge := d.SheetMetal().Thickness()
+	if z0 < 5*gauge {
+		t.Fatalf("folded flange should rise well above the gauge; maxZ=%.3f gauge=%.3f", z0, gauge)
+	}
+
+	if _, err := d.AddUnfold(); err != nil {
+		t.Fatalf("AddUnfold: %v", err)
+	}
+	d.Recompute()
+	flat := d.Features().Result()[0]
+	assertFlatSolid(t, flat)
+	if mz := maxZ(flat); mz > 2*gauge {
+		t.Errorf("unfolded part is not flat: maxZ=%.3f, want ~gauge %.3f", mz, gauge)
+	}
+	if v := flatVolume(flat); math.Abs(v-v0)/v0 > 0.02 {
+		t.Errorf("unfold changed volume: %.4f vs folded %.4f", v, v0)
+	}
+
+	if _, err := d.AddRefold(); err != nil {
+		t.Fatalf("AddRefold: %v", err)
+	}
+	d.Recompute()
+	refolded := d.Features().Result()[0]
+	assertFlatSolid(t, refolded)
+	if mz := maxZ(refolded); math.Abs(mz-z0) > 0.05 {
+		t.Errorf("refold did not restore the fold: maxZ=%.3f, want %.3f", mz, z0)
+	}
+	if v := flatVolume(refolded); math.Abs(v-v0)/v0 > 0.02 {
+		t.Errorf("refold changed volume: %.4f vs original %.4f", v, v0)
+	}
+}
+
+// TestCutWhileFlatSurvivesRefold the headline of the body-transform unfold: a hole cut into
+// the developed flange while flat is carried back onto the folded part by refold — because
+// unfold/refold are body transforms, the cut is part of the topology, not lost.
+func TestCutWhileFlatSurvivesRefold(t *testing.T) {
+	d, _ := sheetWithFlange(t) // flange on the y=0 top edge; unfolded it extends into −Y
+	foldedVol := flatVolume(d.Features().Result()[0])
+
+	if _, err := d.AddUnfold(); err != nil {
+		t.Fatalf("AddUnfold: %v", err)
+	}
+	d.Recompute()
+
+	// Cut a 0.4×0.4 square hole through the developed flange (y in [−0.8,−0.4] lies on it).
+	sk := d.Sketches().Add(sketch.XYPlane())
+	a := sk.Points().Add(gmath.P2(1.8, -0.8))
+	b := sk.Points().Add(gmath.P2(2.2, -0.8))
+	c := sk.Points().Add(gmath.P2(2.2, -0.4))
+	e := sk.Points().Add(gmath.P2(1.8, -0.4))
+	sk.Lines().Add(a, b)
+	sk.Lines().Add(b, c)
+	sk.Lines().Add(c, e)
+	sk.Lines().Add(e, a)
+	cut := feature.NewSheetMetalCutFeatures(d.features).Add(&feature.SheetMetalCutDefinition{Sketch: sk, ProfileIndex: 0})
+	d.Recompute()
+	if !cut.Health().OK() {
+		t.Fatalf("cut on the flat flange unhealthy: %s", cut.Health().Reason)
+	}
+	flatCutVol := flatVolume(d.Features().Result()[0])
+	if !(flatCutVol < foldedVol) {
+		t.Fatalf("cut did not remove material: %.4f vs %.4f", flatCutVol, foldedVol)
+	}
+
+	if _, err := d.AddRefold(); err != nil {
+		t.Fatalf("AddRefold: %v", err)
+	}
+	d.Recompute()
+	refolded := d.Features().Result()[0]
+	assertFlatSolid(t, refolded)
+	// The hole survives refold: volume stays reduced (matches the flat-cut volume) and the
+	// flange is folded up again.
+	if v := flatVolume(refolded); math.Abs(v-flatCutVol)/flatCutVol > 0.02 {
+		t.Errorf("refold volume %.4f != flat-cut volume %.4f (the cut was not carried back)", v, flatCutVol)
+	}
+	if v := flatVolume(refolded); !(v < foldedVol) {
+		t.Errorf("refolded part volume %.4f should stay below the uncut folded %.4f", v, foldedVol)
+	}
+}
+
+// TestUnfoldRejectsNoBends unfold on a flat base sheet (no bends) errors.
+func TestUnfoldRejectsNoBends(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	addRectFace(t, d, 4, 3)
+	if _, err := d.AddUnfold(); err == nil {
+		t.Error("AddUnfold with no bends must error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -82,6 +82,8 @@ type FeatureData struct {
 	SheetMetalContourRoll   *SheetMetalContourRollData   `yaml:"sheetMetalContourRoll,omitempty"`   // M13-F02
 	SheetMetalCornerSeam    *SheetMetalCornerSeamData    `yaml:"sheetMetalCornerSeam,omitempty"`    // M13-F02
 	SheetMetalCut           *SheetMetalCutData           `yaml:"sheetMetalCut,omitempty"`           // M13-F03
+	SheetMetalUnfold        *SheetMetalUnfoldData        `yaml:"sheetMetalUnfold,omitempty"`        // M13-F04
+	SheetMetalRefold        *SheetMetalRefoldData        `yaml:"sheetMetalRefold,omitempty"`        // M13-F04
 }
 
 // SketchIndexer maps between a sketch pointer and its index in the part, so a feature
@@ -323,6 +325,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalCut = smc
+	case *SheetMetalUnfoldFeature:
+		fd.SheetMetalUnfold = &SheetMetalUnfoldData{Bends: serializeBendTransforms(f.def.Bends)}
+	case *SheetMetalRefoldFeature:
+		fd.SheetMetalRefold = &SheetMetalRefoldData{Bends: serializeBendTransforms(f.def.Bends)}
 	case *DecalFeature:
 		fd.Decal = &DecalData{Face: encodeKey(f.def.FaceKey), Image: f.def.Image}
 	case *ReferenceFeature:
@@ -532,6 +538,10 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalCornerSeam(fs, fd.SheetMetalCornerSeam)
 	case "sheet-metal-cut":
 		return restoreSheetMetalCut(fs, fd.SheetMetalCut, sk)
+	case "sheet-metal-unfold":
+		return restoreSheetMetalUnfold(fs, fd.SheetMetalUnfold)
+	case "sheet-metal-refold":
+		return restoreSheetMetalRefold(fs, fd.SheetMetalRefold)
 	case "importedBody":
 		return restoreImportedBody(fs, fd.Import)
 	case "decal", "reference", "client", "mark", "finish":

--- a/model/feature/serialize_sheet_metal_unfold.go
+++ b/model/feature/serialize_sheet_metal_unfold.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Serialized forms of the sheet-metal Unfold/Refold features (M13-F04): the list of bend
+// transforms each acts on. Points and directions persist as [x,y,z] triples; the angle is in
+// radians. The transforms are self-contained (baked from placements at creation), so the
+// round-trip needs no reference to the part's other features.
+
+// bendTransformData is one persisted bend transform.
+type bendTransformData struct {
+	LinePoint  []float64 `yaml:"linePoint"`
+	LineDir    []float64 `yaml:"lineDir"`
+	BaseNormal []float64 `yaml:"baseNormal"`
+	Angle      float64   `yaml:"angle"`
+}
+
+// SheetMetalUnfoldData / SheetMetalRefoldData persist the bend list of an unfold / refold.
+type SheetMetalUnfoldData struct {
+	Bends []bendTransformData `yaml:"bends"`
+}
+type SheetMetalRefoldData struct {
+	Bends []bendTransformData `yaml:"bends"`
+}
+
+// serializeBendTransforms projects bend transforms to their persisted form.
+func serializeBendTransforms(bends []BendTransform) []bendTransformData {
+	out := make([]bendTransformData, len(bends))
+	for i, b := range bends {
+		out[i] = bendTransformData{
+			LinePoint:  []float64{b.LinePoint.X, b.LinePoint.Y, b.LinePoint.Z},
+			LineDir:    []float64{b.LineDir.X, b.LineDir.Y, b.LineDir.Z},
+			BaseNormal: []float64{b.BaseNormal.X, b.BaseNormal.Y, b.BaseNormal.Z},
+			Angle:      b.Angle,
+		}
+	}
+	return out
+}
+
+// restoreBendTransforms rebuilds bend transforms, erroring on a malformed triple.
+func restoreBendTransforms(data []bendTransformData) ([]BendTransform, error) {
+	out := make([]BendTransform, len(data))
+	for i, d := range data {
+		if len(d.LinePoint) != 3 || len(d.LineDir) != 3 || len(d.BaseNormal) != 3 {
+			return nil, fmt.Errorf("sheet-metal unfold: bend %d has a malformed [x,y,z] triple", i)
+		}
+		out[i] = BendTransform{
+			LinePoint:  math.P3(d.LinePoint[0], d.LinePoint[1], d.LinePoint[2]),
+			LineDir:    math.V3(d.LineDir[0], d.LineDir[1], d.LineDir[2]),
+			BaseNormal: math.V3(d.BaseNormal[0], d.BaseNormal[1], d.BaseNormal[2]),
+			Angle:      d.Angle,
+		}
+	}
+	return out, nil
+}
+
+// restoreSheetMetalUnfold / restoreSheetMetalRefold rebuild the features from their payload.
+func restoreSheetMetalUnfold(fs *PartFeatures, d *SheetMetalUnfoldData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal unfold feature is missing its payload")
+	}
+	bends, err := restoreBendTransforms(d.Bends)
+	if err != nil {
+		return nil, err
+	}
+	return NewSheetMetalUnfoldFeatures(fs).Add(&SheetMetalUnfoldDefinition{Bends: bends}), nil
+}
+
+func restoreSheetMetalRefold(fs *PartFeatures, d *SheetMetalRefoldData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal refold feature is missing its payload")
+	}
+	bends, err := restoreBendTransforms(d.Bends)
+	if err != nil {
+		return nil, err
+	}
+	return NewSheetMetalRefoldFeatures(fs).Add(&SheetMetalRefoldDefinition{Bends: bends}), nil
+}

--- a/model/feature/sheet_metal_unfold.go
+++ b/model/feature/sheet_metal_unfold.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Sheet-metal Unfold/Refold geometry (M13-F04, #377). Unfold flattens a folded bend by a
+// rigid body transform: it splits the body at the bend line, rotates the moving (flange) side
+// back into the base plane, and unions it on. Refold is the inverse rotation. Because both are
+// body transforms — not rebuilds — any feature applied while flat (a cut on the developed
+// flange) is part of the body topology and is carried back on refold, so cut-while-flat works
+// without a separate folded↔flat entity map (the bend arc flattens approximately: cuts away
+// from the bend are exact).
+
+// BendTransform is one bend an unfold/refold acts on: the bend line (a point + direction) and
+// the swept fold angle. The flange feature folds the moving side by −angle about the line, so
+// unfold rotates it by +angle and refold by −angle. Baked into the feature at creation from
+// the recorded [BendPlacement] so Recompute stays self-contained (it never reaches back into
+// the part's other features).
+type BendTransform struct {
+	LinePoint  math.Point3  // a point on the bend line
+	LineDir    math.Vector3 // the bend line direction (the picked edge)
+	BaseNormal math.Vector3 // the base sheet's outward normal (defines the split plane)
+	Angle      float64      // swept fold angle (radians)
+}
+
+// unfoldBend flattens one bend: split at the bend-line plane, rotate the moving side by the
+// signed angle about the bend line, union back. A positive angle unfolds a +angle-folded
+// flange; refold passes the negated angle. Returns one watertight solid, erroring when the
+// bend line does not divide the body in two.
+func unfoldBend(body *topo.Body, bt BendTransform, signedAngle float64) (*topo.Body, error) {
+	dir, err := math.UnitVector3FromVector(bt.LineDir)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal unfold: bend line direction is degenerate: %v", bt.LineDir)
+	}
+	across, err := math.UnitVector3FromVector(bt.LineDir.Cross(bt.BaseNormal))
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal unfold: bend line is parallel to the base normal")
+	}
+	fixed, moving, err := splitAtBendLine(body, bt.LinePoint, across)
+	if err != nil {
+		return nil, err
+	}
+	rotated, err := ops.TransformBody(moving, math.Rotation4(signedAngle, dir, bt.LinePoint), identityLineage)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal unfold: rotating the flange: %w", err)
+	}
+	merged, err := combine([]*topo.Body{fixed}, rotated, ops.Join)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal unfold: rejoining the flange: %w", err)
+	}
+	if len(merged) != 1 {
+		return nil, fmt.Errorf("sheet-metal unfold: flange rejoin produced %d bodies, want 1", len(merged))
+	}
+	return merged[0], nil
+}
+
+// splitAtBendLine cuts the body with the plane through the bend line whose normal is across
+// (perpendicular to the line, in the base plane), returning the fixed side (base) and the
+// moving side (the flange, on the +across side). It errors unless the plane divides the body.
+func splitAtBendLine(body *topo.Body, linePoint math.Point3, across math.UnitVector3) (fixed, moving *topo.Body, err error) {
+	plane, err := geom.NewPlane(linePoint, across.AsVector())
+	if err != nil {
+		return nil, nil, err
+	}
+	pieces, err := ops.SplitSolidByPlane(body, plane)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sheet-metal unfold: splitting at the bend line: %w", err)
+	}
+	if len(pieces) != 2 {
+		return nil, nil, fmt.Errorf("sheet-metal unfold: bend line does not divide the body (got %d pieces)", len(pieces))
+	}
+	at := across.AsVector().Dot(linePoint.AsVector())
+	if across.AsVector().Dot(pieces[0].RangeBox().Center().AsVector()) > at {
+		return pieces[1], pieces[0], nil
+	}
+	return pieces[0], pieces[1], nil
+}
+
+// identityLineage keeps lineage unchanged under a body transform (the flange's faces keep
+// their reference keys, so a cut on the flat flange survives the refold transform).
+func identityLineage(l topo.Lineage) topo.Lineage { return l }
+
+// applyBends flattens (sign +1) or refolds (sign −1) every bend on the running body, in order.
+func applyBends(in Input, bends []BendTransform, sign float64, what string) (Output, error) {
+	body, err := lastBody(in, what)
+	if err != nil {
+		return Output{}, err
+	}
+	result := body
+	for _, bt := range bends {
+		result, err = unfoldBend(result, bt, sign*bt.Angle)
+		if err != nil {
+			return Output{}, err
+		}
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// SheetMetalUnfoldDefinition lists the bends to flatten. It is baked from the part's recorded
+// bend placements when the feature is created, so the feature never reaches back into the
+// part's other features at recompute.
+type SheetMetalUnfoldDefinition struct{ Bends []BendTransform }
+
+// SheetMetalUnfoldFeature flattens the listed bends each recompute, leaving the part flat so
+// later features (e.g. a cut) operate in developed space.
+type SheetMetalUnfoldFeature struct {
+	def *SheetMetalUnfoldDefinition
+}
+
+// Definition returns the unfold recipe.
+func (f *SheetMetalUnfoldFeature) Definition() *SheetMetalUnfoldDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalUnfoldFeature) Kind() string { return "sheet-metal-unfold" }
+
+// Recompute flattens every listed bend (rotates each moving flange by +angle into the base
+// plane).
+func (f *SheetMetalUnfoldFeature) Recompute(in Input) (Output, error) {
+	return applyBends(in, f.def.Bends, +1, "sheet-metal unfold")
+}
+
+// SheetMetalRefoldDefinition lists the bends to refold — the inverse of an earlier unfold.
+type SheetMetalRefoldDefinition struct{ Bends []BendTransform }
+
+// SheetMetalRefoldFeature refolds the listed bends each recompute, restoring the folded part
+// (and carrying any edits made while flat, because the refold is a body transform).
+type SheetMetalRefoldFeature struct {
+	def *SheetMetalRefoldDefinition
+}
+
+// Definition returns the refold recipe.
+func (f *SheetMetalRefoldFeature) Definition() *SheetMetalRefoldDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalRefoldFeature) Kind() string { return "sheet-metal-refold" }
+
+// Recompute refolds every listed bend (rotates each moving flange by −angle back out of the
+// base plane).
+func (f *SheetMetalRefoldFeature) Recompute(in Input) (Output, error) {
+	return applyBends(in, f.def.Bends, -1, "sheet-metal refold")
+}
+
+// SheetMetalUnfoldFeatures and SheetMetalRefoldFeatures add the paired features into the
+// engine.
+type SheetMetalUnfoldFeatures struct{ engine *PartFeatures }
+type SheetMetalRefoldFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalUnfoldFeatures binds the unfold collection to a feature engine.
+func NewSheetMetalUnfoldFeatures(engine *PartFeatures) *SheetMetalUnfoldFeatures {
+	return &SheetMetalUnfoldFeatures{engine}
+}
+
+// NewSheetMetalRefoldFeatures binds the refold collection to a feature engine.
+func NewSheetMetalRefoldFeatures(engine *PartFeatures) *SheetMetalRefoldFeatures {
+	return &SheetMetalRefoldFeatures{engine}
+}
+
+// Add appends an unfold feature, naming it Unfold1, Unfold2, … .
+func (c *SheetMetalUnfoldFeatures) Add(def *SheetMetalUnfoldDefinition) *PartFeature {
+	f := &SheetMetalUnfoldFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Unfold"))
+	return pf
+}
+
+// Add appends a refold feature, naming it Refold1, Refold2, … .
+func (c *SheetMetalRefoldFeatures) Add(def *SheetMetalRefoldDefinition) *PartFeature {
+	f := &SheetMetalRefoldFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Refold"))
+	return pf
+}
+
+var (
+	_ Feature = (*SheetMetalUnfoldFeature)(nil)
+	_ Feature = (*SheetMetalRefoldFeature)(nil)
+)

--- a/model/feature/sheet_metal_unfold_test.go
+++ b/model/feature/sheet_metal_unfold_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// flangedSheetForUnfold builds a square sheet with one 90° flange and returns the engine and
+// the bend transform that flattens it (base normal +Z; bend line = the flange's recorded edge).
+func flangedSheetForUnfold(t *testing.T) (*PartFeatures, BendTransform) {
+	t.Helper()
+	fs, edge := seedSheetMetalSheet(t, 4, map[string]string{"BendRadius": "2 mm"})
+	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(), Height: func() float64 { return 2 },
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("flange unhealthy: %s", pf.Health().Reason)
+	}
+	p, _ := pf.Definition().(*SheetMetalFlangeFeature).Placement()
+	return fs, BendTransform{
+		LinePoint: p.AxisStart, LineDir: p.AxisStart.VectorTo(p.AxisEnd),
+		BaseNormal: math.V3(0, 0, 1), Angle: p.Angle,
+	}
+}
+
+// topZ returns the body's highest vertex Z.
+func topZ(b *topo.Body) float64 {
+	m := stdmath.Inf(-1)
+	for _, v := range b.Vertices() {
+		if v.Point().Z > m {
+			m = v.Point().Z
+		}
+	}
+	return m
+}
+
+// TestUnfoldFeatureFlattens the unfold feature flattens the flange to a watertight solid lying
+// in the base plane (the wall no longer rises above the gauge).
+func TestUnfoldFeatureFlattens(t *testing.T) {
+	fs, bt := flangedSheetForUnfold(t)
+	if folded := topZ(fs.Result()[0]); folded < 1.5 {
+		t.Fatalf("folded flange should rise; maxZ=%.3f", folded)
+	}
+	NewSheetMetalUnfoldFeatures(fs).Add(&SheetMetalUnfoldDefinition{Bends: []BendTransform{bt}})
+	fs.Recompute()
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	if mz := topZ(body); mz > 0.5 {
+		t.Errorf("unfolded flange not flat: maxZ=%.3f, want ~gauge (0.2)", mz)
+	}
+}
+
+// TestRefoldFeatureRestores refold after unfold restores the fold (the wall rises again) as a
+// watertight solid.
+func TestRefoldFeatureRestores(t *testing.T) {
+	fs, bt := flangedSheetForUnfold(t)
+	z0 := topZ(fs.Result()[0])
+	NewSheetMetalUnfoldFeatures(fs).Add(&SheetMetalUnfoldDefinition{Bends: []BendTransform{bt}})
+	fs.Recompute()
+	NewSheetMetalRefoldFeatures(fs).Add(&SheetMetalRefoldDefinition{Bends: []BendTransform{bt}})
+	fs.Recompute()
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	if mz := topZ(body); stdmath.Abs(mz-z0) > 0.05 {
+		t.Errorf("refold did not restore the fold: maxZ=%.3f, want %.3f", mz, z0)
+	}
+}
+
+// TestUnfoldRefoldRoundTrip an unfold and a refold feature persist their bend transforms and
+// restore (they reference no sketch, so the recipe is self-contained).
+func TestUnfoldRefoldRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	bend := BendTransform{LinePoint: math.P3(0, 0, 0.2), LineDir: math.V3(4, 0, 0), BaseNormal: math.V3(0, 0, 1), Angle: stdmath.Pi / 2}
+	NewSheetMetalUnfoldFeatures(fs).Add(&SheetMetalUnfoldDefinition{Bends: []BendTransform{bend}})
+	NewSheetMetalRefoldFeatures(fs).Add(&SheetMetalRefoldDefinition{Bends: []BendTransform{bend}})
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if data[0].Kind != "sheet-metal-unfold" || data[0].SheetMetalUnfold == nil || len(data[0].SheetMetalUnfold.Bends) != 1 {
+		t.Fatalf("unfold marshaled = %+v", data[0])
+	}
+	if data[1].Kind != "sheet-metal-refold" || data[1].SheetMetalRefold == nil {
+		t.Fatalf("refold marshaled = %+v", data[1])
+	}
+
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 2 || fresh.Item(0).Kind() != "sheet-metal-unfold" || fresh.Item(1).Kind() != "sheet-metal-refold" {
+		t.Errorf("restored %d features (%q, …), want unfold+refold", fresh.Count(), fresh.Item(0).Kind())
+	}
+	restored := fresh.Item(0).Definition().(*SheetMetalUnfoldFeature).Definition().Bends
+	if len(restored) != 1 || stdmath.Abs(restored[0].Angle-stdmath.Pi/2) > 1e-12 {
+		t.Errorf("restored unfold bends = %+v, want one π/2 bend", restored)
+	}
+}
+
+// TestUnfoldRefoldMissingPayload restoring a nil payload errors.
+func TestUnfoldRefoldMissingPayload(t *testing.T) {
+	if _, err := restoreSheetMetalUnfold(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreSheetMetalUnfold(nil) must error")
+	}
+	if _, err := restoreSheetMetalRefold(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreSheetMetalRefold(nil) must error")
+	}
+}
+
+// TestUnfoldBendRejectsParallelNormal a bend line parallel to the base normal can't define a
+// split plane and errors with the offending input.
+func TestUnfoldBendRejectsParallelNormal(t *testing.T) {
+	fs, bt := flangedSheetForUnfold(t)
+	bt.BaseNormal = bt.LineDir // parallel ⇒ degenerate across
+	if _, err := unfoldBend(fs.Result()[0], bt, bt.Angle); err == nil {
+		t.Error("unfoldBend with a normal parallel to the bend line must error")
+	}
+}


### PR DESCRIPTION
## What

Adds the **Unfold** and **Refold** features — the cut-while-flat workflow of M13-F04.

- **Unfold** flattens the part by a rigid body transform: split at each bend line, rotate the moving flange by +angle back into the base plane, union it on (`unfoldBend`). Leaves the part flat for subsequent features.
- **Refold** is the −angle inverse, restoring the folded part.
- Because both are **body transforms, not rebuilds**, a cut placed on the developed flange while flat is part of the body topology and is **carried back onto the folded part by refold** — cut-while-flat works without a folded↔flat entity map (F05). The bend arc flattens approximately; cuts away from the bend are exact.
- The bends to act on are baked from the part's recorded bend placements at creation (`compdef.AddUnfold`/`AddRefold`), so the features stay self-contained at recompute (they never reach into the part's other features).
- Driven via `features.add` (kinds `sheetMetalUnfold` / `sheetMetalRefold`); the recipe round-trips the bend transforms.

## Why

The architecture's cut-across-bends path is *unfold the affected region, cut in flat space, and refold*. This delivers that mechanism and unblocks F03's across-bend Cut/Rip.

## Tests
- `feature`: unfold flattens a flange to a watertight flat solid (maxZ → gauge); refold restores the fold; serialize round-trip of the bend transforms; degenerate-normal rejection.
- `compdef`: **unfold→refold round-trip** preserves volume and restores the fold; **cut-while-flat survives refold** (a hole cut in the flat flange persists on the folded part, volume stays reduced, watertight); unfold on a bend-less part errors.
- `opregistry`: `sheetMetalUnfold`/`sheetMetalRefold` apply to a flanged part (merged solid each) + error paths; registry + apply coverage.
- `golangci-lint` 0 issues.

Refs #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)