### PR TITLE
feat(sheet-metal): flat-pattern orientation container + reporting (M13-F05)

### DIFF
--- a/addin/router/flat_pattern.go
+++ b/addin/router/flat_pattern.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// The flat-pattern orientation surface (M13-F05, #635): a sheet-metal part's developed flat
+// carries named orientations — saved alignment states that frame it for drawing views and
+// export. The active orientation drives the flat's reported length/width. Orientations persist
+// in the document.
+
+// registerFlatPatternHandlers wires the flatPattern.* methods.
+func (r *Router) registerFlatPatternHandlers() {
+	r.handlers[wire.MethodFlatPatternListOrientations] = flatPatternListOrientations
+	r.handlers[wire.MethodFlatPatternAddOrientation] = flatPatternAddOrientation
+	r.handlers[wire.MethodFlatPatternActivateOrientation] = flatPatternActivateOrientation
+	r.handlers[wire.MethodFlatPatternDeleteOrientation] = flatPatternDeleteOrientation
+}
+
+func flatPatternListOrientations(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(orientationsResult(part))
+}
+
+func flatPatternAddOrientation(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddOrientationArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	or, err := orientationFromArgs(part, in)
+	if err != nil {
+		return nil, err
+	}
+	if err := part.FlatOrientations().Add(or); err != nil {
+		return nil, err
+	}
+	if in.Activate {
+		if err := part.FlatOrientations().Activate(or.Name); err != nil {
+			return nil, err
+		}
+	}
+	return json.Marshal(wire.OrientationResult{Orientation: orientationInfo(part, or)})
+}
+
+func flatPatternActivateOrientation(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ActivateOrientationArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := part.FlatOrientations().Activate(in.Name); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.OrientationResult{Orientation: orientationInfo(part, part.FlatOrientations().Active())})
+}
+
+func flatPatternDeleteOrientation(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.DeleteOrientationArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := part.FlatOrientations().Delete(in.Name); err != nil {
+		return nil, err
+	}
+	return json.Marshal(orientationsResult(part))
+}
+
+// orientationFromArgs builds an orientation from the wire args: alignment type (default
+// horizontal), rotation in degrees, and an optional hex alignment-axis reference key.
+func orientationFromArgs(part *compdef.PartComponentDefinition, in wire.AddOrientationArgs) (*sheetmetal.FlatPatternOrientation, error) {
+	at := types.HorizontalAlignment
+	if in.AlignmentType != "" {
+		parsed, ok := types.ParseAlignmentType(in.AlignmentType)
+		if !ok {
+			return nil, fmt.Errorf("flatPattern: alignmentType %q: want horizontal|vertical", in.AlignmentType)
+		}
+		at = parsed
+	}
+	rotation, err := part.Units().Parse(fmt.Sprintf("%g deg", in.AlignmentRotation), param.Angle)
+	if err != nil {
+		return nil, fmt.Errorf("flatPattern: alignmentRotation %g: %w", in.AlignmentRotation, err)
+	}
+	key, err := hex.DecodeString(in.AlignmentAxis)
+	if err != nil {
+		return nil, fmt.Errorf("flatPattern: alignmentAxis %q is not a hex reference key: %w", in.AlignmentAxis, err)
+	}
+	return &sheetmetal.FlatPatternOrientation{
+		Name: in.Name, AlignmentType: at, AlignmentRotation: rotation.Value,
+		AlignmentAxisKey: key, FlipAlignmentAxis: in.FlipAlignmentAxis, FlipBaseFace: in.FlipBaseFace,
+	}, nil
+}
+
+// orientationsResult renders all orientations as wire.
+func orientationsResult(part *compdef.PartComponentDefinition) wire.OrientationsResult {
+	set := part.FlatOrientations()
+	out := wire.OrientationsResult{Orientations: make([]wire.FlatPatternOrientationInfo, 0, len(set.List()))}
+	for _, or := range set.List() {
+		out.Orientations = append(out.Orientations, orientationInfo(part, or))
+	}
+	return out
+}
+
+// orientationInfo renders one orientation as wire, including the flat's length/width under it
+// (zero when the part has no developable flat yet). AlignmentRotation is reported in degrees.
+func orientationInfo(part *compdef.PartComponentDefinition, or *sheetmetal.FlatPatternOrientation) wire.FlatPatternOrientationInfo {
+	length, width, err := part.FlatLengthWidth(or)
+	if err != nil {
+		length, width = 0, 0
+	}
+	return wire.FlatPatternOrientationInfo{
+		Name:              or.Name,
+		AlignmentType:     or.AlignmentType.String(),
+		AlignmentRotation: or.AlignmentRotation * degPerRad,
+		AlignmentAxis:     hex.EncodeToString(or.AlignmentAxisKey),
+		FlipAlignmentAxis: or.FlipAlignmentAxis,
+		FlipBaseFace:      or.FlipBaseFace,
+		Active:            part.FlatOrientations().IsActive(or),
+		Length:            length,
+		Width:             width,
+	}
+}

--- a/addin/router/flat_pattern_test.go
+++ b/addin/router/flat_pattern_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestFlatPatternOrientationsOverWire drives the M13-F05 orientation surface: a flanged sheet
+// reports the default orientation with a positive length/width; adding a vertical orientation
+// swaps them; activate/delete behave; the default is undeletable.
+func TestFlatPatternOrientationsOverWire(t *testing.T) {
+	r, s := flangedSheet(t)
+
+	var list wire.OrientationsResult
+	call(t, r, s, wire.MethodFlatPatternListOrientations, "{}", &list)
+	if len(list.Orientations) != 1 || !list.Orientations[0].Active {
+		t.Fatalf("default list = %+v, want one active orientation", list.Orientations)
+	}
+	def := list.Orientations[0]
+	if def.Length <= 0 || def.Width <= 0 {
+		t.Errorf("default length/width = %g×%g, want positive", def.Length, def.Width)
+	}
+
+	var added wire.OrientationResult
+	call(t, r, s, wire.MethodFlatPatternAddOrientation, `{"name":"Vertical","alignmentType":"vertical","activate":true}`, &added)
+	if !added.Orientation.Active || added.Orientation.AlignmentType != "vertical" {
+		t.Errorf("added = %+v, want active vertical", added.Orientation)
+	}
+	if added.Orientation.Length != def.Width || added.Orientation.Width != def.Length {
+		t.Errorf("vertical (%g×%g) should swap default (%g×%g)", added.Orientation.Length, added.Orientation.Width, def.Length, def.Width)
+	}
+
+	// Activate the default again, then delete the custom one.
+	var act wire.OrientationResult
+	call(t, r, s, wire.MethodFlatPatternActivateOrientation, `{"name":"Flat Pattern Default"}`, &act)
+	if !act.Orientation.Active || act.Orientation.Name != "Flat Pattern Default" {
+		t.Errorf("activated = %+v, want the default active", act.Orientation)
+	}
+	var afterDelete wire.OrientationsResult
+	call(t, r, s, wire.MethodFlatPatternDeleteOrientation, `{"name":"Vertical"}`, &afterDelete)
+	if len(afterDelete.Orientations) != 1 {
+		t.Errorf("after delete = %d orientations, want 1", len(afterDelete.Orientations))
+	}
+
+	// Error paths.
+	if _, err := r.Handle(s, wire.MethodFlatPatternDeleteOrientation, []byte(`{"name":"Flat Pattern Default"}`)); err == nil {
+		t.Error("deleting the default orientation must error")
+	}
+	if _, err := r.Handle(s, wire.MethodFlatPatternActivateOrientation, []byte(`{"name":"Nope"}`)); err == nil {
+		t.Error("activating an unknown orientation must error")
+	}
+}
+
+// TestFlatPatternRejectsPlainPart the flat-pattern surface errors on an ordinary part.
+func TestFlatPatternRejectsPlainPart(t *testing.T) {
+	r, s := seededSession(t)
+	if _, err := r.Handle(s, wire.MethodFlatPatternListOrientations, []byte("{}")); err == nil {
+		t.Fatal("flatPattern on a plain part must error")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -108,6 +108,7 @@ func (r *Router) registerStandardHandlers() {
 	r.registerSketchHandlers()
 	r.registerFeatureHandlers()
 	r.registerSheetMetalHandlers()
+	r.registerFlatPatternHandlers()
 	r.handlers[wire.MethodWorkPlanesList] = listWorkPlanes
 	r.handlers[wire.MethodWorkPlanesCreate] = createWorkPlanes
 	r.handlers[wire.MethodWorkPlanesRedefine] = redefineWorkPlane

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.8.0
+	oblikovati.org/api v0.9.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.8.0
+	oblikovati.org/api v0.9.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -55,6 +55,10 @@ type PartComponentDefinition struct {
 	// the unfold method that bend/flat-pattern features consult. It is parameter-backed — its
 	// thickness/bend-radius read the part's Thickness/BendRadius parameters.
 	sheetMetal *sheetmetal.Rule
+	// flatOrientations holds the part's flat-pattern orientations (M13-F05) — named alignment
+	// states that frame the developed flat. Seeded with the default orientation when the part
+	// enters the sheet-metal environment; nil for ordinary parts.
+	flatOrientations *sheetmetal.Orientations
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature

--- a/model/compdef/sheet_metal.go
+++ b/model/compdef/sheet_metal.go
@@ -3,6 +3,7 @@
 package compdef
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"oblikovati.org/api/types"
@@ -63,7 +64,14 @@ func (d *PartComponentDefinition) EnableSheetMetal() (*sheetmetal.Rule, error) {
 		relief,
 		sheetmetal.KFactorMethod(0.44),
 	)
+	d.flatOrientations = sheetmetal.NewOrientations()
 	return d.sheetMetal, nil
+}
+
+// FlatOrientations returns the part's flat-pattern orientations (M13-F05), or nil when the
+// part is not in the sheet-metal environment.
+func (d *PartComponentDefinition) FlatOrientations() *sheetmetal.Orientations {
+	return d.flatOrientations
 }
 
 // SetSheetMetalLengthParam re-authors one of the rule's backing length parameters
@@ -99,6 +107,8 @@ type sheetMetalRecipe struct {
 	KFactor      float64              `yaml:"kFactor,omitempty"`
 	Equation     string               `yaml:"equation,omitempty"`
 	BendTable    []bendTableRowRecipe `yaml:"bendTable,omitempty"`
+	Orientations []orientationRecipe  `yaml:"orientations,omitempty"` // M13-F05
+	ActiveOrient string               `yaml:"activeOrientation,omitempty"`
 }
 
 // bendTableRowRecipe is one persisted bend-table sample (database units, cm; angle radians).
@@ -107,6 +117,17 @@ type bendTableRowRecipe struct {
 	Radius    float64 `yaml:"radius"`
 	Thickness float64 `yaml:"thickness"`
 	Allowance float64 `yaml:"allowance"`
+}
+
+// orientationRecipe is one persisted flat-pattern orientation (M13-F05; rotation in radians,
+// alignment axis as a hex reference key).
+type orientationRecipe struct {
+	Name              string  `yaml:"name"`
+	AlignmentType     string  `yaml:"alignmentType,omitempty"`
+	AlignmentRotation float64 `yaml:"alignmentRotation,omitempty"`
+	AlignmentAxis     string  `yaml:"alignmentAxis,omitempty"`
+	FlipAlignmentAxis bool    `yaml:"flipAlignmentAxis,omitempty"`
+	FlipBaseFace      bool    `yaml:"flipBaseFace,omitempty"`
 }
 
 // sheetMetalRecipeOf captures the active rule, or nil when the part is not sheet metal.
@@ -130,7 +151,22 @@ func (d *PartComponentDefinition) sheetMetalRecipeOf() *sheetMetalRecipe {
 			rec.BendTable = append(rec.BendTable, bendTableRowRecipe{row.Angle, row.Radius, row.Thickness, row.Allowance})
 		}
 	}
+	d.captureOrientations(rec)
 	return rec
+}
+
+// captureOrientations records the flat-pattern orientations (and which is active) into rec.
+func (d *PartComponentDefinition) captureOrientations(rec *sheetMetalRecipe) {
+	if d.flatOrientations == nil {
+		return
+	}
+	for _, o := range d.flatOrientations.List() {
+		rec.Orientations = append(rec.Orientations, orientationRecipe{
+			Name: o.Name, AlignmentType: o.AlignmentType.String(), AlignmentRotation: o.AlignmentRotation,
+			AlignmentAxis: hex.EncodeToString(o.AlignmentAxisKey), FlipAlignmentAxis: o.FlipAlignmentAxis, FlipBaseFace: o.FlipBaseFace,
+		})
+	}
+	rec.ActiveOrient = d.flatOrientations.Active().Name
 }
 
 // applySheetMetalRecipe rebuilds the rule from rec, binding its thickness/bend-radius to the
@@ -152,6 +188,35 @@ func (d *PartComponentDefinition) applySheetMetalRecipe(rec *sheetMetalRecipe) e
 		return err
 	}
 	rule.SetUnfold(unfold)
+	return d.restoreOrientations(rec)
+}
+
+// restoreOrientations rebuilds the flat-pattern orientations from rec onto the seeded set
+// (the default orientation already exists), then re-activates the persisted active one.
+func (d *PartComponentDefinition) restoreOrientations(rec *sheetMetalRecipe) error {
+	for _, o := range rec.Orientations {
+		at, _ := types.ParseAlignmentType(o.AlignmentType)
+		key, err := hex.DecodeString(o.AlignmentAxis)
+		if err != nil {
+			return fmt.Errorf("sheet-metal recipe: bad alignment axis key %q: %w", o.AlignmentAxis, err)
+		}
+		restored := &sheetmetal.FlatPatternOrientation{
+			Name: o.Name, AlignmentType: at, AlignmentRotation: o.AlignmentRotation,
+			AlignmentAxisKey: key, FlipAlignmentAxis: o.FlipAlignmentAxis, FlipBaseFace: o.FlipBaseFace,
+		}
+		if existing, _, ok := d.flatOrientations.ByName(o.Name); ok {
+			*existing = *restored // the seeded default already exists — restore its edited fields
+			continue
+		}
+		if err := d.flatOrientations.Add(restored); err != nil {
+			return err
+		}
+	}
+	if rec.ActiveOrient != "" {
+		if err := d.flatOrientations.Activate(rec.ActiveOrient); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/model/compdef/sheet_metal_orientation.go
+++ b/model/compdef/sheet_metal_orientation.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/api/types"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// Flat-pattern orientation reporting (M13-F05, #635). The active orientation frames the
+// developed flat: its alignment rotation turns the flat in its plane and its alignment type
+// decides which extent is the length. FlatLengthWidth develops the flat and measures it under
+// a given orientation, so drawing views and export read a stable length/width.
+
+// FlatLengthWidth returns the flat pattern's length and width under the orientation: the
+// footprint is turned by the negative alignment rotation (bringing the alignment axis to the
+// page horizontal) and bounded; a vertical alignment swaps the two extents.
+func (d *PartComponentDefinition) FlatLengthWidth(or *sheetmetal.FlatPatternOrientation) (length, width float64, err error) {
+	fp, err := d.Unfold()
+	if err != nil {
+		return 0, 0, err
+	}
+	plane := fp.Plane
+	cos, sin := stdmath.Cos(-or.AlignmentRotation), stdmath.Sin(-or.AlignmentRotation)
+	box := gmath.EmptyBox2d()
+	for _, v := range fp.Body.Vertices() {
+		p := plane.ToSketch(v.Point())
+		box = box.ExtendPoint(gmath.P2(p.X*cos-p.Y*sin, p.X*sin+p.Y*cos))
+	}
+	diag := box.Diagonal()
+	length, width = float64(diag.X), float64(diag.Y)
+	if or.AlignmentType == types.VerticalAlignment {
+		length, width = width, length
+	}
+	return length, width, nil
+}

--- a/model/compdef/sheet_metal_orientation_test.go
+++ b/model/compdef/sheet_metal_orientation_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/model/sheetmetal"
+)
+
+// TestFlatOrientationsRoundTrip orientations (and which is active) persist through the recipe.
+func TestFlatOrientationsRoundTrip(t *testing.T) {
+	src := NewPartComponentDefinition()
+	if _, err := src.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	if err := src.FlatOrientations().Add(&sheetmetal.FlatPatternOrientation{
+		Name: "Long Edge", AlignmentType: sheetmetal.VerticalAlignment, AlignmentRotation: 0.5, FlipBaseFace: true,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := src.FlatOrientations().Activate("Long Edge"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	blob, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dst := NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(blob); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	set := dst.FlatOrientations()
+	if set == nil || len(set.List()) != 2 {
+		t.Fatalf("restored orientations = %v, want 2", set)
+	}
+	if set.Active().Name != "Long Edge" {
+		t.Errorf("restored active = %q, want Long Edge", set.Active().Name)
+	}
+	long, _, ok := set.ByName("Long Edge")
+	if !ok || long.AlignmentType != sheetmetal.VerticalAlignment || math.Abs(long.AlignmentRotation-0.5) > 1e-9 || !long.FlipBaseFace {
+		t.Errorf("restored orientation = %+v, want vertical / rot 0.5 / flipBaseFace", long)
+	}
+}
+
+// TestFlatLengthWidthSwapsWithAlignment a vertical orientation swaps the flat's length and
+// width relative to the horizontal default.
+func TestFlatLengthWidthSwapsWithAlignment(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	lh, wh, err := d.FlatLengthWidth(d.FlatOrientations().Active()) // default horizontal
+	if err != nil {
+		t.Fatalf("FlatLengthWidth: %v", err)
+	}
+	if lh <= 0 || wh <= 0 {
+		t.Fatalf("length/width must be positive: %g × %g", lh, wh)
+	}
+	if err := d.FlatOrientations().Add(&sheetmetal.FlatPatternOrientation{Name: "V", AlignmentType: sheetmetal.VerticalAlignment}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	v, _, _ := d.FlatOrientations().ByName("V")
+	lv, wv, err := d.FlatLengthWidth(v)
+	if err != nil {
+		t.Fatalf("FlatLengthWidth(V): %v", err)
+	}
+	if math.Abs(lv-wh) > 1e-9 || math.Abs(wv-lh) > 1e-9 {
+		t.Errorf("vertical (%g×%g) should swap horizontal (%g×%g)", lv, wv, lh, wh)
+	}
+}

--- a/model/feature/flat_pattern.go
+++ b/model/feature/flat_pattern.go
@@ -42,13 +42,15 @@ type FlatBendLine struct {
 	Angle float64
 }
 
-// FlatPattern is the developed flat: the flat solid, its fold lines, the 2D extents, and the
-// gauge. Body is one watertight solid (the base plate unioned with every tab).
+// FlatPattern is the developed flat: the flat solid, its fold lines, the 2D extents, the
+// gauge, and the base plane the flat lies in (so callers can project the body to 2D). Body is
+// one watertight solid (the base plate unioned with every tab).
 type FlatPattern struct {
 	Body      *topo.Body
 	Bends     []FlatBendLine
 	Extents   math.Box2d
 	Thickness float64
+	Plane     sketch.Plane
 }
 
 // BuildFlatPattern thickens the base profile in its plane, unions each tab on as a coplanar
@@ -79,6 +81,7 @@ func BuildFlatPattern(baseSketch *sketch.Sketch, baseProfile int, thickness floa
 	}
 	fp.Body = body
 	fp.Extents = flatExtents(body, plane)
+	fp.Plane = plane
 	return fp, nil
 }
 

--- a/model/sheetmetal/orientation.go
+++ b/model/sheetmetal/orientation.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// Flat-pattern orientations (M13-F05, #635). An orientation is a saved alignment state of the
+// developed flat: an alignment axis (a topology reference key, or none for the part's natural
+// axes) laid horizontal or vertical, an extra alignment rotation, and flips for the alignment
+// direction and the base face. The active orientation frames the flat for drawing views and
+// export and drives its reported length/width. Orientations are container/value objects, not
+// history features (they have no Definition→Add→Feature triangle).
+
+// AlignmentType is the canonical Apache-2.0 enum (ADR-0018), aliased so call sites read
+// sheetmetal.HorizontalAlignment.
+type AlignmentType = types.AlignmentType
+
+const (
+	HorizontalAlignment = types.HorizontalAlignment
+	VerticalAlignment   = types.VerticalAlignment
+)
+
+// DefaultOrientationName is the seeded orientation every sheet-metal part starts with; it
+// cannot be deleted.
+const DefaultOrientationName = "Flat Pattern Default"
+
+// FlatPatternOrientation is one named alignment state.
+type FlatPatternOrientation struct {
+	Name              string
+	AlignmentType     AlignmentType
+	AlignmentRotation float64 // extra rotation applied after the axis is aligned (radians)
+	AlignmentAxisKey  []byte  // topology reference key of the alignment edge/axis; nil ⇒ natural axes
+	FlipAlignmentAxis bool
+	FlipBaseFace      bool
+}
+
+// Orientations is the ordered set of a part's flat-pattern orientations with one active.
+type Orientations struct {
+	items  []*FlatPatternOrientation
+	active int
+}
+
+// NewOrientations returns a set seeded with the (active) default orientation.
+func NewOrientations() *Orientations {
+	return &Orientations{items: []*FlatPatternOrientation{{Name: DefaultOrientationName}}}
+}
+
+// List returns the orientations in creation order.
+func (o *Orientations) List() []*FlatPatternOrientation { return o.items }
+
+// Active returns the active orientation (never nil for a seeded set).
+func (o *Orientations) Active() *FlatPatternOrientation { return o.items[o.active] }
+
+// ByName returns the named orientation and its index, or ok=false.
+func (o *Orientations) ByName(name string) (*FlatPatternOrientation, int, bool) {
+	for i, it := range o.items {
+		if it.Name == name {
+			return it, i, true
+		}
+	}
+	return nil, 0, false
+}
+
+// Add appends a new orientation, erroring on a blank or duplicate name. It does not activate.
+func (o *Orientations) Add(or *FlatPatternOrientation) error {
+	if or.Name == "" {
+		return fmt.Errorf("flat-pattern orientation: name is required")
+	}
+	if _, _, ok := o.ByName(or.Name); ok {
+		return fmt.Errorf("flat-pattern orientation %q already exists", or.Name)
+	}
+	o.items = append(o.items, or)
+	return nil
+}
+
+// Activate makes the named orientation current, erroring if it is unknown.
+func (o *Orientations) Activate(name string) error {
+	if _, i, ok := o.ByName(name); ok {
+		o.active = i
+		return nil
+	}
+	return fmt.Errorf("flat-pattern orientation %q does not exist", name)
+}
+
+// Copy duplicates the named orientation under newName (defaulting to "<name> Copy"), erroring
+// on an unknown source or a duplicate target.
+func (o *Orientations) Copy(name, newName string) (*FlatPatternOrientation, error) {
+	src, _, ok := o.ByName(name)
+	if !ok {
+		return nil, fmt.Errorf("flat-pattern orientation %q does not exist", name)
+	}
+	if newName == "" {
+		newName = name + " Copy"
+	}
+	dup := *src
+	dup.Name = newName
+	if err := o.Add(&dup); err != nil {
+		return nil, err
+	}
+	return &dup, nil
+}
+
+// Delete removes the named orientation; the default orientation cannot be deleted. Deleting
+// the active orientation falls back to the default.
+func (o *Orientations) Delete(name string) error {
+	if name == DefaultOrientationName {
+		return fmt.Errorf("the default flat-pattern orientation cannot be deleted")
+	}
+	_, i, ok := o.ByName(name)
+	if !ok {
+		return fmt.Errorf("flat-pattern orientation %q does not exist", name)
+	}
+	o.items = append(o.items[:i], o.items[i+1:]...)
+	if o.active == i {
+		o.active = 0
+	} else if o.active > i {
+		o.active--
+	}
+	return nil
+}
+
+// IsActive reports whether or is the active orientation.
+func (o *Orientations) IsActive(or *FlatPatternOrientation) bool { return o.Active() == or }

--- a/model/sheetmetal/orientation_test.go
+++ b/model/sheetmetal/orientation_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import "testing"
+
+// TestOrientationsSeededWithDefault a fresh set has the active default orientation.
+func TestOrientationsSeededWithDefault(t *testing.T) {
+	o := NewOrientations()
+	if len(o.List()) != 1 || o.Active().Name != DefaultOrientationName {
+		t.Fatalf("seeded set = %d items, active %q; want 1 default", len(o.List()), o.Active().Name)
+	}
+}
+
+// TestOrientationsAddActivate add a named orientation, activate it, and confirm it is current.
+func TestOrientationsAddActivate(t *testing.T) {
+	o := NewOrientations()
+	if err := o.Add(&FlatPatternOrientation{Name: "Long Edge"}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if o.IsActive(o.List()[1]) {
+		t.Error("new orientation should not auto-activate")
+	}
+	if err := o.Activate("Long Edge"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if o.Active().Name != "Long Edge" {
+		t.Errorf("active = %q, want Long Edge", o.Active().Name)
+	}
+	if err := o.Add(&FlatPatternOrientation{Name: "Long Edge"}); err == nil {
+		t.Error("duplicate name must error")
+	}
+	if err := o.Add(&FlatPatternOrientation{Name: ""}); err == nil {
+		t.Error("blank name must error")
+	}
+}
+
+// TestOrientationsCopy duplicates an orientation's fields under a new name.
+func TestOrientationsCopy(t *testing.T) {
+	o := NewOrientations()
+	_ = o.Add(&FlatPatternOrientation{Name: "A", AlignmentType: VerticalAlignment, FlipBaseFace: true})
+	dup, err := o.Copy("A", "B")
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if dup.Name != "B" || dup.AlignmentType != VerticalAlignment || !dup.FlipBaseFace {
+		t.Errorf("copy = %+v, want B with A's fields", dup)
+	}
+	if _, err := o.Copy("missing", "C"); err == nil {
+		t.Error("copy of an unknown orientation must error")
+	}
+}
+
+// TestOrientationsDelete delete a custom orientation; the default is undeletable; deleting the
+// active falls back to the default.
+func TestOrientationsDelete(t *testing.T) {
+	o := NewOrientations()
+	_ = o.Add(&FlatPatternOrientation{Name: "Temp"})
+	_ = o.Activate("Temp")
+	if err := o.Delete(DefaultOrientationName); err == nil {
+		t.Error("deleting the default orientation must error")
+	}
+	if err := o.Delete("Temp"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(o.List()) != 1 || o.Active().Name != DefaultOrientationName {
+		t.Errorf("after delete: %d items, active %q; want default active", len(o.List()), o.Active().Name)
+	}
+	if err := o.Delete("Temp"); err == nil {
+		t.Error("deleting an unknown orientation must error")
+	}
+}


### PR DESCRIPTION
## What

Implements the flat-pattern **orientation** model (M13-F05) — named alignment states that frame the developed flat for drawing views and export, with the active one driving its reported length/width.

- **model/sheetmetal**: an `Orientations` container (seeded with the undeletable default) — `Add`/`Activate`/`Copy`/`Delete`; `FlatPatternOrientation` carries alignment type, rotation, axis reference key, and flips.
- **compdef**: the container hangs off the sheet-metal content (seeded on entering the environment); `FlatLengthWidth` develops the flat and measures it under an orientation (a **vertical** alignment swaps length/width); orientations + the active one persist in the recipe.
- **addin/router**: `flatPattern.listOrientations` / `addOrientation` / `activateOrientation` / `deleteOrientation` — each orientation reported with the flat's length/width under it.

Pins `api v0.9.0` (contract: Oblikovati.API#123).

## Why

First increment of M13-F05 (#635): the flat pattern is a container, and orientations are the part drawing views (M14) need to pick a stable framing. Edge/face classification, the folded↔flat entity map, plates and settings follow as stacked PRs.

## Tests
- `sheetmetal`: seeded default; Add/Activate/Copy/Delete; default undeletable; deleting the active falls back to default; duplicate/blank-name rejection.
- `compdef`: orientations + active one round-trip through the recipe; `FlatLengthWidth` swaps with a vertical alignment.
- `router`: the `flatPattern.*` surface over the wire (default active with positive length/width; add vertical → swapped; activate/delete; default undeletable; plain-part rejection) + wire-coverage.
- `golangci-lint` 0 issues.

Refs #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)