### PR TITLE
feat(sheet-metal): classify flat-pattern edges and faces (M13-F05)

### DIFF
--- a/addin/router/flat_pattern.go
+++ b/addin/router/flat_pattern.go
@@ -10,7 +10,9 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sheetmetal"
 )
@@ -26,6 +28,80 @@ func (r *Router) registerFlatPatternHandlers() {
 	r.handlers[wire.MethodFlatPatternAddOrientation] = flatPatternAddOrientation
 	r.handlers[wire.MethodFlatPatternActivateOrientation] = flatPatternActivateOrientation
 	r.handlers[wire.MethodFlatPatternDeleteOrientation] = flatPatternDeleteOrientation
+	r.handlers[wire.MethodFlatPatternEdgesOfType] = flatPatternEdgesOfType
+	r.handlers[wire.MethodFlatPatternFaces] = flatPatternFaces
+}
+
+func flatPatternEdgesOfType(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.EdgesOfTypeArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	filter, err := edgeTypeFilter(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	flat, err := part.Unfold()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.EdgesResult{Edges: classifiedEdges(flat.Bends, filter)})
+}
+
+// classifiedEdges turns the flat's fold lines into classified wire edges (bend-up unless the
+// bend folds toward the back), keeping only those matching filter (nil ⇒ all).
+func classifiedEdges(bends []feature.FlatBendLine, filter *types.FlatPatternEdgeType) []wire.FlatEdgeInfo {
+	out := make([]wire.FlatEdgeInfo, 0, len(bends))
+	for _, b := range bends {
+		et := types.BendUpFlatPatternEdge
+		if b.FoldDown {
+			et = types.BendDownFlatPatternEdge
+		}
+		if filter != nil && *filter != et {
+			continue
+		}
+		out = append(out, wire.FlatEdgeInfo{
+			Start: point2d(b.A), End: point2d(b.B), Type: et.String(), Angle: b.Angle * degPerRad,
+		})
+	}
+	return out
+}
+
+// edgeTypeFilter parses an optional edge-type filter; an empty string means "all types".
+func edgeTypeFilter(s string) (*types.FlatPatternEdgeType, error) {
+	if s == "" {
+		return nil, nil
+	}
+	et, ok := types.ParseFlatPatternEdgeType(s)
+	if !ok {
+		return nil, fmt.Errorf("flatPattern: edge type %q: want bendUp|bendDown|tangent", s)
+	}
+	return &et, nil
+}
+
+func flatPatternFaces(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	flat, err := part.Unfold()
+	if err != nil {
+		return nil, err
+	}
+	// The flat is a constant-thickness plate: its front (top) and back (bottom) faces share
+	// the developed footprint area (the body volume over the gauge).
+	area := 0.0
+	if flat.Thickness > 0 {
+		area = ops.BodyGeometryProperties(flat.Body, ops.Quality{ChordTolerance: 1e-3}).Volume / flat.Thickness
+	}
+	return json.Marshal(wire.FacesResult{Faces: []wire.FlatFaceInfo{
+		{Type: types.FrontFlatPatternFace.String(), Area: area},
+		{Type: types.BackFlatPatternFace.String(), Area: area},
+	}})
 }
 
 func flatPatternListOrientations(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/flat_pattern_test.go
+++ b/addin/router/flat_pattern_test.go
@@ -54,6 +54,41 @@ func TestFlatPatternOrientationsOverWire(t *testing.T) {
 	}
 }
 
+// TestFlatPatternEdgesAndFaces a flanged sheet reports its fold line as a bend-up edge (a
+// plain flange folds up), filterable by type, and its front/back faces with equal areas.
+func TestFlatPatternEdgesAndFaces(t *testing.T) {
+	r, s := flangedSheet(t)
+
+	var all wire.EdgesResult
+	call(t, r, s, wire.MethodFlatPatternEdgesOfType, "{}", &all)
+	if len(all.Edges) != 1 || all.Edges[0].Type != "bendUp" {
+		t.Fatalf("edges = %+v, want one bendUp fold line", all.Edges)
+	}
+	if all.Edges[0].Angle <= 0 {
+		t.Errorf("fold line angle = %v, want positive", all.Edges[0].Angle)
+	}
+
+	var up, down wire.EdgesResult
+	call(t, r, s, wire.MethodFlatPatternEdgesOfType, `{"type":"bendUp"}`, &up)
+	call(t, r, s, wire.MethodFlatPatternEdgesOfType, `{"type":"bendDown"}`, &down)
+	if len(up.Edges) != 1 || len(down.Edges) != 0 {
+		t.Errorf("filtered up=%d down=%d, want 1 and 0", len(up.Edges), len(down.Edges))
+	}
+
+	var faces wire.FacesResult
+	call(t, r, s, wire.MethodFlatPatternFaces, "{}", &faces)
+	if len(faces.Faces) != 2 || faces.Faces[0].Type != "front" || faces.Faces[1].Type != "back" {
+		t.Fatalf("faces = %+v, want front+back", faces.Faces)
+	}
+	if faces.Faces[0].Area <= 0 || faces.Faces[0].Area != faces.Faces[1].Area {
+		t.Errorf("front/back areas = %v/%v, want equal positive", faces.Faces[0].Area, faces.Faces[1].Area)
+	}
+
+	if _, err := r.Handle(s, wire.MethodFlatPatternEdgesOfType, []byte(`{"type":"nope"}`)); err == nil {
+		t.Error("a bad edge type must error")
+	}
+}
+
 // TestFlatPatternRejectsPlainPart the flat-pattern surface errors on an ordinary part.
 func TestFlatPatternRejectsPlainPart(t *testing.T) {
 	r, s := seededSession(t)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.9.0
+	oblikovati.org/api v0.10.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.9.0
+	oblikovati.org/api v0.10.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/sheet_metal_flat.go
+++ b/model/compdef/sheet_metal_flat.go
@@ -77,9 +77,10 @@ func (d *PartComponentDefinition) developTab(pf *feature.PartFeature, plane sket
 		return feature.FlatTab{}, false
 	}
 	return feature.FlatTab{
-		A:      plane.ToSketch(p.AxisStart),
-		B:      plane.ToSketch(p.AxisEnd),
-		Length: d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
-		Angle:  p.Angle,
+		A:        plane.ToSketch(p.AxisStart),
+		B:        plane.ToSketch(p.AxisEnd),
+		Length:   d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
+		Angle:    p.Angle,
+		FoldDown: p.FoldDown,
 	}, true
 }

--- a/model/compdef/sheet_metal_flat_test.go
+++ b/model/compdef/sheet_metal_flat_test.go
@@ -115,6 +115,39 @@ func addRectFace(t *testing.T, d *PartComponentDefinition, w, h float64) {
 	d.Recompute()
 }
 
+// TestFlatBendDownForFlippedFlange a flipped flange (folds toward the back) marks its fold
+// line bend-down in the flat; a plain flange marks it bend-up.
+func TestFlatBendDownForFlippedFlange(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		flip     bool
+		wantDown bool
+	}{{"plain", false, false}, {"flipped", true, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewPartComponentDefinition()
+			if _, err := d.EnableSheetMetal(); err != nil {
+				t.Fatalf("EnableSheetMetal: %v", err)
+			}
+			addSquareFace(d, 4)
+			edge := topXEdge(t, d.Features().Result()[0])
+			pf := feature.NewSheetMetalFlangeFeatures(d.Features()).Add(&feature.SheetMetalFlangeDefinition{
+				EdgeKey: edge.ReferenceKey(), Height: func() float64 { return 1 }, Flip: tc.flip,
+			})
+			d.Recompute()
+			if !pf.Health().OK() {
+				t.Fatalf("flange unhealthy: %s", pf.Health().Reason)
+			}
+			fp, err := d.Unfold()
+			if err != nil {
+				t.Fatalf("Unfold: %v", err)
+			}
+			if len(fp.Bends) != 1 || fp.Bends[0].FoldDown != tc.wantDown {
+				t.Errorf("bends = %+v, want one with FoldDown=%v", fp.Bends, tc.wantDown)
+			}
+		})
+	}
+}
+
 // TestUnfoldTracksKFactor the flat is associative on the rule: raising the K-factor lengthens
 // the bend allowance and so the developed extent, without recomputing the folded model.
 func TestUnfoldTracksKFactor(t *testing.T) {

--- a/model/feature/bend_lineage.go
+++ b/model/feature/bend_lineage.go
@@ -37,6 +37,7 @@ type BendPlacement struct {
 	Outward            math.UnitVector3 // in-plane direction the flat tab extends (away from the sheet)
 	Angle, Radius      float64          // swept bend angle (radians) and inside radius (cm)
 	Thickness, Length  float64          // material thickness and the flange's straight-run length (cm)
+	FoldDown           bool             // the bend folds the material toward the back (a flipped flange) ⇒ a bend-down fold line
 }
 
 // PlacedBend is implemented by the edge-bend walls (flange, hem) that develop into a flat

--- a/model/feature/flat_pattern.go
+++ b/model/feature/flat_pattern.go
@@ -30,16 +30,18 @@ import (
 // plane (a flange folded off a bottom edge folds in −Z) and so cannot be projected into it.
 // Angle is carried through for the fold-line annotation.
 type FlatTab struct {
-	A, B   math.Point2
-	Length float64
-	Angle  float64
+	A, B     math.Point2
+	Length   float64
+	Angle    float64
+	FoldDown bool // the bend folds toward the back ⇒ a bend-down fold line
 }
 
-// FlatBendLine is one fold line in the flat pattern: the segment (base-plane 2D) and the
-// bend angle — what a DXF export draws on the bend layer.
+// FlatBendLine is one fold line in the flat pattern: the segment (base-plane 2D), the bend
+// angle, and the fold direction — what a DXF export draws on the bend-up/bend-down layers.
 type FlatBendLine struct {
-	A, B  math.Point2
-	Angle float64
+	A, B     math.Point2
+	Angle    float64
+	FoldDown bool
 }
 
 // FlatPattern is the developed flat: the flat solid, its fold lines, the 2D extents, the
@@ -77,7 +79,7 @@ func BuildFlatPattern(baseSketch *sketch.Sketch, baseProfile int, thickness floa
 		if body, err = appendTab(body, plane, sp, tab, centroid); err != nil {
 			return nil, err
 		}
-		fp.Bends = append(fp.Bends, FlatBendLine{A: tab.A, B: tab.B, Angle: tab.Angle})
+		fp.Bends = append(fp.Bends, FlatBendLine{A: tab.A, B: tab.B, Angle: tab.Angle, FoldDown: tab.FoldDown})
 	}
 	fp.Body = body
 	fp.Extents = flatExtents(body, plane)

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -160,7 +160,7 @@ func buildFlangeSolid(edge *topo.Edge, thickness, radius, height, angle float64,
 	poly := flangeBandPolygon(out.AsVector(), up.AsVector(), thickness, radius, height, angle, proj)
 	placement := BendPlacement{
 		AxisStart: v0, AxisEnd: v1, Outward: out,
-		Angle: angle, Radius: radius, Thickness: thickness, Length: height,
+		Angle: angle, Radius: radius, Thickness: thickness, Length: height, FoldDown: flip,
 	}
 	return buildPrism(poly, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), placement, nil
 }


### PR DESCRIPTION
## What

Classifies the developed flat's topology (M13-F05 PR-B), building on the orientation container (#943).

- Threads the **fold direction** through the bend lineage: a flipped flange folds toward the back ⇒ its fold line is **bend-down**; a plain flange is **bend-up**.
- **`flatPattern.edgesOfType`** returns the flat's fold lines classified bend-up/bend-down (optionally filtered to one type).
- **`flatPattern.faces`** reports the **front** (top) and **back** (bottom) faces with the developed footprint area (the constant-thickness plate's volume over the gauge).

Pins `api v0.10.0` (contract: Oblikovati.API#124).

## Why

The fold-line/face classification is the drawing-view (and descoped DXF) layer-mapping input.

## Tests
- `compdef`: a flipped flange marks its fold line bend-down; a plain flange bend-up.
- `router`: `edgesOfType` reports the bend-up fold line, filters by type, rejects a bad type; `faces` reports front+back with equal positive areas; plain-part rejection.
- `golangci-lint` 0 issues.

Refs #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)