### PR TITLE
feat(sheet-metal): map flat-pattern entities folded<->flat by key (M13-F05)

### DIFF
--- a/addin/router/flat_pattern.go
+++ b/addin/router/flat_pattern.go
@@ -30,6 +30,33 @@ func (r *Router) registerFlatPatternHandlers() {
 	r.handlers[wire.MethodFlatPatternDeleteOrientation] = flatPatternDeleteOrientation
 	r.handlers[wire.MethodFlatPatternEdgesOfType] = flatPatternEdgesOfType
 	r.handlers[wire.MethodFlatPatternFaces] = flatPatternFaces
+	r.handlers[wire.MethodFlatPatternMapEntity] = flatPatternMapEntity
+}
+
+func flatPatternMapEntity(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.MapEntityArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	mapper := part.MapFlatToFolded
+	if in.ToFlat {
+		mapper = part.MapFoldedToFlat
+	}
+	// Keys are the raw topology reference keys model.referenceKeys reports, so a caller can
+	// feed one straight back in.
+	mapped, found, err := mapper([]byte(in.Key))
+	if err != nil {
+		return nil, err
+	}
+	out := wire.MapEntityResult{Found: found}
+	if found {
+		out.Key, out.Kind = string(mapped), "face"
+	}
+	return json.Marshal(out)
 }
 
 func flatPatternEdgesOfType(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/flat_pattern_test.go
+++ b/addin/router/flat_pattern_test.go
@@ -3,10 +3,46 @@
 package router
 
 import (
+	"encoding/json"
 	"testing"
 
 	"oblikovati.org/api/wire"
 )
+
+// TestFlatPatternMapEntityOverWire a folded face maps to a flat face (and back) by reference
+// key over the wire — the correspondence a flat drawing dimension survives recompute by.
+func TestFlatPatternMapEntityOverWire(t *testing.T) {
+	r, s := flangedSheet(t)
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, wire.MethodModelReferenceKeys, "{}", &keys)
+	if len(keys.Bodies) == 0 || len(keys.Bodies[0].Faces) == 0 {
+		t.Fatal("no face reference keys")
+	}
+	faceKey := keys.Bodies[0].Faces[0].Key
+
+	toFlat, _ := json.Marshal(map[string]any{"key": faceKey, "toFlat": true})
+	var flat wire.MapEntityResult
+	call(t, r, s, wire.MethodFlatPatternMapEntity, string(toFlat), &flat)
+	if !flat.Found || flat.Kind != "face" || flat.Key == "" {
+		t.Fatalf("folded→flat map = %+v, want a found face", flat)
+	}
+
+	toFolded, _ := json.Marshal(map[string]any{"key": flat.Key})
+	var folded wire.MapEntityResult
+	call(t, r, s, wire.MethodFlatPatternMapEntity, string(toFolded), &folded)
+	if !folded.Found {
+		t.Errorf("flat→folded map = %+v, want a found face", folded)
+	}
+
+	// An unknown key reports not-found (not an error).
+	unknown, _ := json.Marshal(map[string]any{"key": "bogus", "toFlat": true})
+	var miss wire.MapEntityResult
+	call(t, r, s, wire.MethodFlatPatternMapEntity, string(unknown), &miss)
+	if miss.Found {
+		t.Error("an unknown key should report not-found")
+	}
+}
 
 // TestFlatPatternOrientationsOverWire drives the M13-F05 orientation surface: a flanged sheet
 // reports the default orientation with a positive length/width; adding a vertical orientation

--- a/addin/router/flat_pattern_test.go
+++ b/addin/router/flat_pattern_test.go
@@ -125,10 +125,17 @@ func TestFlatPatternEdgesAndFaces(t *testing.T) {
 	}
 }
 
-// TestFlatPatternRejectsPlainPart the flat-pattern surface errors on an ordinary part.
+// TestFlatPatternRejectsPlainPart every flat-pattern method errors on an ordinary part.
 func TestFlatPatternRejectsPlainPart(t *testing.T) {
 	r, s := seededSession(t)
-	if _, err := r.Handle(s, wire.MethodFlatPatternListOrientations, []byte("{}")); err == nil {
-		t.Fatal("flatPattern on a plain part must error")
+	for _, m := range []string{
+		wire.MethodFlatPatternListOrientations,
+		wire.MethodFlatPatternEdgesOfType,
+		wire.MethodFlatPatternFaces,
+		wire.MethodFlatPatternMapEntity,
+	} {
+		if _, err := r.Handle(s, m, []byte("{}")); err == nil {
+			t.Errorf("%s on a plain part must error", m)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.10.0
+	oblikovati.org/api v0.11.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.10.0
+	oblikovati.org/api v0.11.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/sheet_metal_entity_map.go
+++ b/model/compdef/sheet_metal_entity_map.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Folded↔flat entity map (M13-F05, #635). Drawing dimensions and selections on the flat
+// pattern must survive recompute, so the flat-pattern container maps topology entities between
+// the folded model and the developed flat by reference key. This first increment maps at the
+// face level: a folded face that faces the base normal (a top face) maps to the flat's front
+// face, and a back face to the flat's back face — the two faces a flat-pattern drawing or DXF
+// presents. (Edge/vertex mapping is a follow-up.)
+
+// MapFoldedToFlat maps a folded face (by reference key) to the developed flat's corresponding
+// front/back face. ok is false when the key is not a face of the folded body.
+func (d *PartComponentDefinition) MapFoldedToFlat(key []byte) ([]byte, bool, error) {
+	folded := d.foldedBody()
+	if folded == nil {
+		return nil, false, fmt.Errorf("flat-pattern map: the part has no body")
+	}
+	face, ok := folded.FindFaceByKey(key)
+	if !ok {
+		return nil, false, nil
+	}
+	dir, err := d.faceSide(face)
+	if err != nil {
+		return nil, false, err
+	}
+	fp, err := d.Unfold()
+	if err != nil {
+		return nil, false, err
+	}
+	return mappedFaceKey(fp.Body, dir)
+}
+
+// MapFlatToFolded maps a flat face (by reference key) back to the folded model's corresponding
+// front/back face (the base top/bottom face).
+func (d *PartComponentDefinition) MapFlatToFolded(key []byte) ([]byte, bool, error) {
+	fp, err := d.Unfold()
+	if err != nil {
+		return nil, false, err
+	}
+	face, ok := fp.Body.FindFaceByKey(key)
+	if !ok {
+		return nil, false, nil
+	}
+	dir, err := d.faceSide(face)
+	if err != nil {
+		return nil, false, err
+	}
+	folded := d.foldedBody()
+	if folded == nil {
+		return nil, false, fmt.Errorf("flat-pattern map: the part has no body")
+	}
+	return mappedFaceKey(folded, dir)
+}
+
+// faceSide returns the base-normal direction the face points toward (front: +base normal,
+// back: −base normal), erroring when the part has no base or the face is not planar.
+func (d *PartComponentDefinition) faceSide(face *topo.Face) (math.Vector3, error) {
+	base, ok := d.baseFace()
+	if !ok {
+		return math.Vector3{}, fmt.Errorf("flat-pattern map: the part has no base Face")
+	}
+	normal := base.Definition().Sketch.Plane().Normal().AsVector()
+	dot, ok := faceNormalAlong(face, normal)
+	if !ok {
+		return math.Vector3{}, fmt.Errorf("flat-pattern map: entity is not a planar face")
+	}
+	if dot < 0 {
+		return normal.Negate(), nil
+	}
+	return normal, nil
+}
+
+// mappedFaceKey returns the reference key of body's face that most strongly faces dir (the
+// front or back plate face), or ok=false when the body has no such face.
+func mappedFaceKey(body *topo.Body, dir math.Vector3) ([]byte, bool, error) {
+	if f := dominantFace(body, dir); f != nil {
+		return f.ReferenceKey(), true, nil
+	}
+	return nil, false, nil
+}
+
+// foldedBody returns the part's current folded solid, or nil when it has none.
+func (d *PartComponentDefinition) foldedBody() *topo.Body {
+	bodies := d.features.Result()
+	if len(bodies) == 0 {
+		return nil
+	}
+	return bodies[0]
+}
+
+// faceNormalAlong returns the planar face's outward normal projected onto dir, ok=false when
+// the face is not planar.
+func faceNormalAlong(f *topo.Face, dir math.Vector3) (float64, bool) {
+	pl, ok := f.Geometry().(geom.Plane)
+	if !ok {
+		return 0, false
+	}
+	n := pl.Normal()
+	if f.Reversed() {
+		n = n.Negate()
+	}
+	return n.Dot(dir), true
+}
+
+// dominantFace returns the body's planar face whose outward normal most strongly aligns with
+// dir — for the flat plate or the folded sheet, the single front (or back) face.
+func dominantFace(body *topo.Body, dir math.Vector3) *topo.Face {
+	var best *topo.Face
+	bestDot := stdmath.Inf(-1)
+	for _, f := range body.Faces() {
+		if dot, ok := faceNormalAlong(f, dir); ok && dot > bestDot {
+			best, bestDot = f, dot
+		}
+	}
+	return best
+}

--- a/model/compdef/sheet_metal_entity_map.go
+++ b/model/compdef/sheet_metal_entity_map.go
@@ -3,7 +3,6 @@
 package compdef
 
 import (
-	"fmt"
 	stdmath "math"
 
 	"oblikovati.org/kernel/geom"
@@ -21,23 +20,12 @@ import (
 // MapFoldedToFlat maps a folded face (by reference key) to the developed flat's corresponding
 // front/back face. ok is false when the key is not a face of the folded body.
 func (d *PartComponentDefinition) MapFoldedToFlat(key []byte) ([]byte, bool, error) {
-	folded := d.foldedBody()
-	if folded == nil {
-		return nil, false, fmt.Errorf("flat-pattern map: the part has no body")
-	}
-	face, ok := folded.FindFaceByKey(key)
-	if !ok {
-		return nil, false, nil
-	}
-	dir, err := d.faceSide(face)
-	if err != nil {
-		return nil, false, err
-	}
 	fp, err := d.Unfold()
 	if err != nil {
 		return nil, false, err
 	}
-	return mappedFaceKey(fp.Body, dir)
+	mapped, found := mapFace(d.foldedBody(), fp.Body, fp.Plane.Normal().AsVector(), key)
+	return mapped, found, nil
 }
 
 // MapFlatToFolded maps a flat face (by reference key) back to the folded model's corresponding
@@ -47,55 +35,29 @@ func (d *PartComponentDefinition) MapFlatToFolded(key []byte) ([]byte, bool, err
 	if err != nil {
 		return nil, false, err
 	}
-	face, ok := fp.Body.FindFaceByKey(key)
-	if !ok {
-		return nil, false, nil
-	}
-	dir, err := d.faceSide(face)
-	if err != nil {
-		return nil, false, err
-	}
-	folded := d.foldedBody()
-	if folded == nil {
-		return nil, false, fmt.Errorf("flat-pattern map: the part has no body")
-	}
-	return mappedFaceKey(folded, dir)
+	mapped, found := mapFace(fp.Body, d.foldedBody(), fp.Plane.Normal().AsVector(), key)
+	return mapped, found, nil
 }
 
-// faceSide returns the base-normal direction the face points toward (front: +base normal,
-// back: −base normal), erroring when the part has no base or the face is not planar.
-func (d *PartComponentDefinition) faceSide(face *topo.Face) (math.Vector3, error) {
-	base, ok := d.baseFace()
+// mapFace resolves key to a face of src, classifies which side of the base plane it faces, and
+// returns the reference key of dst's face most strongly facing that side — the front↔front,
+// back↔back correspondence. found is false when key is not a face of src.
+func mapFace(src, dst *topo.Body, baseNormal math.Vector3, key []byte) ([]byte, bool) {
+	face, ok := src.FindFaceByKey(key)
 	if !ok {
-		return math.Vector3{}, fmt.Errorf("flat-pattern map: the part has no base Face")
+		return nil, false
 	}
-	normal := base.Definition().Sketch.Plane().Normal().AsVector()
-	dot, ok := faceNormalAlong(face, normal)
-	if !ok {
-		return math.Vector3{}, fmt.Errorf("flat-pattern map: entity is not a planar face")
+	dir := baseNormal
+	if dot, ok := faceNormalAlong(face, baseNormal); ok && dot < 0 {
+		dir = baseNormal.Negate()
 	}
-	if dot < 0 {
-		return normal.Negate(), nil
-	}
-	return normal, nil
+	return dominantFace(dst, dir).ReferenceKey(), true
 }
 
-// mappedFaceKey returns the reference key of body's face that most strongly faces dir (the
-// front or back plate face), or ok=false when the body has no such face.
-func mappedFaceKey(body *topo.Body, dir math.Vector3) ([]byte, bool, error) {
-	if f := dominantFace(body, dir); f != nil {
-		return f.ReferenceKey(), true, nil
-	}
-	return nil, false, nil
-}
-
-// foldedBody returns the part's current folded solid, or nil when it has none.
+// foldedBody returns the part's current folded solid (non-nil whenever a flat develops, since
+// the flat needs the base Face that produced it).
 func (d *PartComponentDefinition) foldedBody() *topo.Body {
-	bodies := d.features.Result()
-	if len(bodies) == 0 {
-		return nil
-	}
-	return bodies[0]
+	return d.features.Result()[0]
 }
 
 // faceNormalAlong returns the planar face's outward normal projected onto dir, ok=false when

--- a/model/compdef/sheet_metal_entity_map_test.go
+++ b/model/compdef/sheet_metal_entity_map_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"bytes"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestEntityMapRoundTrip a folded top face maps to a real flat face, and mapping that flat
+// face back returns the same folded top face — the correspondence a flat drawing dimension
+// relies on across recompute.
+func TestEntityMapRoundTrip(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	folded := d.Features().Result()[0]
+	top := dominantFace(folded, gmath.V3(0, 0, 1)) // the base top face (+Z)
+	if top == nil {
+		t.Fatal("no top face on the folded body")
+	}
+	foldedKey := top.ReferenceKey()
+
+	flatKey, found, err := d.MapFoldedToFlat(foldedKey)
+	if err != nil || !found {
+		t.Fatalf("MapFoldedToFlat: found=%v err=%v", found, err)
+	}
+	// The mapped key resolves to a real flat face.
+	fp, err := d.Unfold()
+	if err != nil {
+		t.Fatalf("Unfold: %v", err)
+	}
+	if _, ok := fp.Body.FindFaceByKey(flatKey); !ok {
+		t.Error("mapped flat key does not resolve to a flat face")
+	}
+
+	backKey, found, err := d.MapFlatToFolded(flatKey)
+	if err != nil || !found {
+		t.Fatalf("MapFlatToFolded: found=%v err=%v", found, err)
+	}
+	if !bytes.Equal(backKey, foldedKey) {
+		t.Errorf("round-trip key = %x, want the original folded top face %x", backKey, foldedKey)
+	}
+}
+
+// TestEntityMapFrontBackDistinct the top and bottom folded faces map to distinct flat faces.
+func TestEntityMapFrontBackDistinct(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	folded := d.Features().Result()[0]
+	topKey := dominantFace(folded, gmath.V3(0, 0, 1)).ReferenceKey()
+	bottomKey := dominantFace(folded, gmath.V3(0, 0, -1)).ReferenceKey()
+
+	front, _, _ := d.MapFoldedToFlat(topKey)
+	back, _, _ := d.MapFoldedToFlat(bottomKey)
+	if bytes.Equal(front, back) {
+		t.Error("top and bottom folded faces mapped to the same flat face")
+	}
+}
+
+// TestEntityMapUnknownKey an unresolvable key reports not-found rather than erroring.
+func TestEntityMapUnknownKey(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	if _, found, err := d.MapFoldedToFlat([]byte("not-a-real-key")); err != nil || found {
+		t.Errorf("unknown key: found=%v err=%v, want found=false err=nil", found, err)
+	}
+}

--- a/model/compdef/sheet_metal_entity_map_test.go
+++ b/model/compdef/sheet_metal_entity_map_test.go
@@ -64,3 +64,18 @@ func TestEntityMapUnknownKey(t *testing.T) {
 		t.Errorf("unknown key: found=%v err=%v, want found=false err=nil", found, err)
 	}
 }
+
+// TestEntityMapNoFlat mapping on a sheet-metal part with no developable flat errors (there is
+// no base Face to develop).
+func TestEntityMapNoFlat(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	if _, _, err := d.MapFoldedToFlat([]byte("k")); err == nil {
+		t.Error("MapFoldedToFlat with no flat must error")
+	}
+	if _, _, err := d.MapFlatToFolded([]byte("k")); err == nil {
+		t.Error("MapFlatToFolded with no flat must error")
+	}
+}


### PR DESCRIPTION
## What

Implements the folded↔flat **entity map** (M13-F05 PR-C), building on orientations (#943) and classification (#944).

- **compdef**: `MapFoldedToFlat` / `MapFlatToFolded` resolve a face by reference key, classify it front/back by the base normal, and return the dominant front/back face of the other body.
- **addin/router**: `flatPattern.mapEntity`, keyed on the raw reference keys `model.referenceKeys` reports (so a key feeds straight back in).

Pins `api v0.11.0` (contract: Oblikovati.API#125).

## Why

Drawing dimensions and selections on the flat must survive recompute, which needs a stable folded↔flat correspondence. **Face-level** for now (top/bottom ↔ front/back); edge/vertex mapping is a documented follow-up.

## Tests
- `compdef`: a folded top face → flat face → **round-trips** back to the same folded face (keys stable across rebuilds); top/bottom map to distinct flat faces; an unknown key reports not-found.
- `router`: `mapEntity` over the wire (folded→flat→folded by reference key; unknown key → not-found).
- `golangci-lint` 0 issues.

Refs #635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)