### PR TITLE
feat(sheet-metal): bend-order annotation for press-brake sequencing (M13-F06)

### DIFF
--- a/addin/router/flat_pattern.go
+++ b/addin/router/flat_pattern.go
@@ -34,6 +34,43 @@ func (r *Router) registerFlatPatternHandlers() {
 	r.handlers[wire.MethodFlatPatternListPlates] = flatPatternListPlates
 	r.handlers[wire.MethodFlatPatternGetSettings] = flatPatternGetSettings
 	r.handlers[wire.MethodFlatPatternSetSettings] = flatPatternSetSettings
+	r.handlers[wire.MethodFlatPatternListBendOrder] = flatPatternListBendOrder
+	r.handlers[wire.MethodFlatPatternSetBendOrder] = flatPatternSetBendOrder
+}
+
+func flatPatternListBendOrder(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(bendOrderResult(part))
+}
+
+func flatPatternSetBendOrder(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetBendOrderArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := part.SetBendOrder(in.Order); err != nil {
+		return nil, err
+	}
+	return json.Marshal(bendOrderResult(part))
+}
+
+// bendOrderResult renders the part's bends in their press-brake sequence (1-based order).
+func bendOrderResult(part *compdef.PartComponentDefinition) wire.BendOrderResult {
+	bends := part.OrderedBends()
+	out := wire.BendOrderResult{Bends: make([]wire.BendOrderInfo, len(bends))}
+	for i, b := range bends {
+		out.Bends[i] = wire.BendOrderInfo{
+			Feature: b.Feature, Order: i + 1, Angle: b.Angle * degPerRad, Radius: b.Radius,
+		}
+	}
+	return out
 }
 
 func flatPatternListPlates(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/flat_pattern_test.go
+++ b/addin/router/flat_pattern_test.go
@@ -151,6 +151,31 @@ func TestFlatPatternPlatesAndSettings(t *testing.T) {
 	}
 }
 
+// TestFlatPatternBendOrderOverWire a flanged sheet lists its bend order; setting the order by
+// feature name round-trips; an unknown name errors.
+func TestFlatPatternBendOrderOverWire(t *testing.T) {
+	r, s := flangedSheet(t)
+
+	var list wire.BendOrderResult
+	call(t, r, s, wire.MethodFlatPatternListBendOrder, "{}", &list)
+	if len(list.Bends) != 1 || list.Bends[0].Order != 1 || list.Bends[0].Feature == "" {
+		t.Fatalf("bend order = %+v, want one bend at order 1", list.Bends)
+	}
+	feature := list.Bends[0].Feature
+
+	var set wire.BendOrderResult
+	toFlat, _ := json.Marshal(map[string]any{"order": []string{feature}})
+	call(t, r, s, wire.MethodFlatPatternSetBendOrder, string(toFlat), &set)
+	if len(set.Bends) != 1 || set.Bends[0].Feature != feature {
+		t.Errorf("set bend order = %+v, want %s", set.Bends, feature)
+	}
+
+	bad, _ := json.Marshal(map[string]any{"order": []string{"NoSuchBend"}})
+	if _, err := r.Handle(s, wire.MethodFlatPatternSetBendOrder, bad); err == nil {
+		t.Error("setBendOrder with an unknown bend must error")
+	}
+}
+
 // TestFlatPatternRejectsPlainPart every flat-pattern method errors on an ordinary part.
 func TestFlatPatternRejectsPlainPart(t *testing.T) {
 	r, s := seededSession(t)
@@ -162,6 +187,8 @@ func TestFlatPatternRejectsPlainPart(t *testing.T) {
 		wire.MethodFlatPatternListPlates,
 		wire.MethodFlatPatternGetSettings,
 		wire.MethodFlatPatternSetSettings,
+		wire.MethodFlatPatternListBendOrder,
+		wire.MethodFlatPatternSetBendOrder,
 	} {
 		if _, err := r.Handle(s, m, []byte("{}")); err == nil {
 			t.Errorf("%s on a plain part must error", m)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.12.0
+	oblikovati.org/api v0.13.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.12.0
+	oblikovati.org/api v0.13.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -62,6 +62,9 @@ type PartComponentDefinition struct {
 	// flatSettings is the per-part flat-pattern settings (M13-F05): currently the deferred-update
 	// flag so a heavy flat only develops on demand.
 	flatSettings sheetmetal.FlatPatternSettings
+	// bendOrder is the press-brake bend sequence (M13-F06) as an overlay of bend feature names;
+	// empty means the natural (creation) order. Bends not listed follow the listed ones.
+	bendOrder []string
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature

--- a/model/compdef/sheet_metal.go
+++ b/model/compdef/sheet_metal.go
@@ -110,6 +110,7 @@ type sheetMetalRecipe struct {
 	Orientations []orientationRecipe  `yaml:"orientations,omitempty"` // M13-F05
 	ActiveOrient string               `yaml:"activeOrientation,omitempty"`
 	DeferUpdate  bool                 `yaml:"deferFlatUpdate,omitempty"` // M13-F05
+	BendOrder    []string             `yaml:"bendOrder,omitempty"`       // M13-F06
 }
 
 // bendTableRowRecipe is one persisted bend-table sample (database units, cm; angle radians).
@@ -169,6 +170,7 @@ func (d *PartComponentDefinition) captureOrientations(rec *sheetMetalRecipe) {
 	}
 	rec.ActiveOrient = d.flatOrientations.Active().Name
 	rec.DeferUpdate = d.flatSettings.DeferUpdate
+	rec.BendOrder = d.bendOrder
 }
 
 // applySheetMetalRecipe rebuilds the rule from rec, binding its thickness/bend-radius to the
@@ -220,6 +222,7 @@ func (d *PartComponentDefinition) restoreOrientations(rec *sheetMetalRecipe) err
 		}
 	}
 	d.flatSettings.DeferUpdate = rec.DeferUpdate
+	d.bendOrder = rec.BendOrder
 	return nil
 }
 

--- a/model/compdef/sheet_metal_bend_order.go
+++ b/model/compdef/sheet_metal_bend_order.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+	"sort"
+
+	"oblikovati.org/model/sheetmetal"
+)
+
+// Bend-order annotation (M13-F06, #809). The part's bends carry a press-brake sequence: the
+// order they are folded in. The order is an overlay of bend feature names on the bend lineage
+// (compdef.Bends), editable and persisted. An empty overlay is the natural creation order;
+// bends the overlay omits keep their natural order after the listed ones.
+
+// OrderedBends returns the part's bends in their press-brake sequence (the bend-order overlay
+// applied to the natural lineage). The caller numbers them 1..N by position.
+func (d *PartComponentDefinition) OrderedBends() []sheetmetal.Bend {
+	bends := d.Bends()
+	if len(d.bendOrder) == 0 {
+		return bends
+	}
+	rank := make(map[string]int, len(d.bendOrder))
+	for i, name := range d.bendOrder {
+		rank[name] = i
+	}
+	sort.SliceStable(bends, func(i, j int) bool {
+		ri, iok := rank[bends[i].Feature]
+		rj, jok := rank[bends[j].Feature]
+		if iok && jok {
+			return ri < rj
+		}
+		return iok && !jok // a listed bend precedes an unlisted one; otherwise keep natural order
+	})
+	return bends
+}
+
+// SetBendOrder sets the press-brake sequence from a list of bend feature names, erroring on a
+// name that is not a current bend (so a stale order can't silently mis-sequence the brake). An
+// empty list resets to the natural order.
+func (d *PartComponentDefinition) SetBendOrder(order []string) error {
+	known := make(map[string]bool)
+	for _, b := range d.Bends() {
+		known[b.Feature] = true
+	}
+	for _, name := range order {
+		if !known[name] {
+			return fmt.Errorf("bend order: %q is not a bend of this part", name)
+		}
+	}
+	d.bendOrder = append([]string(nil), order...)
+	return nil
+}

--- a/model/compdef/sheet_metal_bend_order_test.go
+++ b/model/compdef/sheet_metal_bend_order_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// twoBendSheet builds a sheet with two flanges (on opposite top edges) so the bend order has
+// something to reorder, returning the part and the two flange feature names.
+func twoBendSheet(t *testing.T) (*PartComponentDefinition, string, string) {
+	t.Helper()
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	addSquareFace(d, 4)
+	// Resolve each edge against the current body (the first flange's union relabels keys, so
+	// the y=4 edge must be found after the y=0 flange is built).
+	f1 := addFlangeOnEdge(t, d, topEdgeAt(t, d, 0).ReferenceKey())
+	f2 := addFlangeOnEdge(t, d, topEdgeAt(t, d, 4).ReferenceKey())
+	return d, f1, f2
+}
+
+// topEdgeAt returns the highest X-aligned edge at the given Y of the running body (the base
+// boundary edge at that Y, even after another flange has raised the body elsewhere).
+func topEdgeAt(t *testing.T, d *PartComponentDefinition, y float64) *topo.Edge {
+	t.Helper()
+	var best *topo.Edge
+	bestZ := -1e18
+	for _, e := range d.Features().Result()[0].Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		dx, dy := a.X-b.X, a.Y-b.Y
+		alongX := (dx > 1e-6 || dx < -1e-6) && dy < 1e-6 && dy > -1e-6
+		if alongX && a.Y > y-1e-6 && a.Y < y+1e-6 && a.Z > bestZ {
+			best, bestZ = e, a.Z
+		}
+	}
+	if best == nil {
+		t.Fatalf("no X-edge at y=%g", y)
+	}
+	return best
+}
+
+// addFlangeOnEdge flanges the edge (by reference key) and returns the flange feature's name.
+func addFlangeOnEdge(t *testing.T, d *PartComponentDefinition, edgeKey []byte) string {
+	t.Helper()
+	pf := feature.NewSheetMetalFlangeFeatures(d.Features()).Add(&feature.SheetMetalFlangeDefinition{
+		EdgeKey: edgeKey, Height: func() float64 { return 1 },
+	})
+	d.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("flange unhealthy: %s", pf.Health().Reason)
+	}
+	return pf.Name()
+}
+
+// TestBendOrderReorderAndPersist the default bend order is creation order; setting a custom
+// order reorders the bends and persists through the recipe.
+func TestBendOrderReorderAndPersist(t *testing.T) {
+	d, f1, f2 := twoBendSheet(t)
+
+	nat := d.OrderedBends()
+	if len(nat) != 2 || nat[0].Feature != f1 || nat[1].Feature != f2 {
+		t.Fatalf("natural order = %v, want [%s %s]", featureNames(nat), f1, f2)
+	}
+
+	if err := d.SetBendOrder([]string{f2, f1}); err != nil {
+		t.Fatalf("SetBendOrder: %v", err)
+	}
+	if got := d.OrderedBends(); got[0].Feature != f2 || got[1].Feature != f1 {
+		t.Errorf("reordered = %v, want [%s %s]", featureNames(got), f2, f1)
+	}
+	if err := d.SetBendOrder([]string{"NoSuchBend"}); err == nil {
+		t.Error("an unknown bend name must error")
+	}
+
+	blob, _ := d.MarshalRecipe()
+	dst := NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(blob); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got := dst.OrderedBends(); len(got) != 2 || got[0].Feature != f2 {
+		t.Errorf("restored order = %v, want %s first", featureNames(got), f2)
+	}
+}
+
+func featureNames(bends []sheetmetal.Bend) []string {
+	out := make([]string, len(bends))
+	for i, b := range bends {
+		out[i] = b.Feature
+	}
+	return out
+}


### PR DESCRIPTION
## What

Implements the **bend-order annotation** (M13-F06 PR-E): the press-brake sequence the part's bends are folded in.

- **compdef**: a bend-order overlay of bend feature names on the bend lineage. `OrderedBends` applies it (default = creation order; omitted bends follow the listed ones); `SetBendOrder` validates names against current bends; the order persists in the recipe.
- **addin/router**: `flatPattern.listBendOrder` / `setBendOrder`, numbering the bends 1..N by sequence.

Pins `api v0.13.0` (contract: Oblikovati.API#127).

## Tests
- `compdef`: a two-flange sheet defaults to creation order, reorders by feature name, rejects an unknown name, and the order persists through the recipe.
- `router`: `listBendOrder`/`setBendOrder` round-trip; all nine flat-pattern methods reject a plain part.
- `golangci-lint` 0 issues.

Refs #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)