### PR TITLE
feat(sheet-metal): cosmetic centerlines on the flat pattern (M13-F06)

### DIFF
--- a/addin/router/flat_pattern.go
+++ b/addin/router/flat_pattern.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/kernel/ops"
+	gmath "oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
@@ -36,6 +37,55 @@ func (r *Router) registerFlatPatternHandlers() {
 	r.handlers[wire.MethodFlatPatternSetSettings] = flatPatternSetSettings
 	r.handlers[wire.MethodFlatPatternListBendOrder] = flatPatternListBendOrder
 	r.handlers[wire.MethodFlatPatternSetBendOrder] = flatPatternSetBendOrder
+	r.handlers[wire.MethodFlatPatternAddCenterline] = flatPatternAddCenterline
+	r.handlers[wire.MethodFlatPatternListCenterlines] = flatPatternListCenterlines
+	r.handlers[wire.MethodFlatPatternDeleteCenterline] = flatPatternDeleteCenterline
+}
+
+func flatPatternAddCenterline(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddCenterlineArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part.AddCosmeticCenterline(gmath.P2(in.Start.X, in.Start.Y), gmath.P2(in.End.X, in.End.Y))
+	return json.Marshal(centerlinesResult(part))
+}
+
+func flatPatternListCenterlines(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(centerlinesResult(part))
+}
+
+func flatPatternDeleteCenterline(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, _, err := activeSheetMetal(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.DeleteCenterlineArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := part.DeleteCosmeticCenterline(in.Index); err != nil {
+		return nil, err
+	}
+	return json.Marshal(centerlinesResult(part))
+}
+
+// centerlinesResult renders the part's cosmetic centerlines as wire.
+func centerlinesResult(part *compdef.PartComponentDefinition) wire.CenterlinesResult {
+	lines := part.CosmeticCenterlines()
+	out := wire.CenterlinesResult{Centerlines: make([]wire.CenterlineInfo, len(lines))}
+	for i, c := range lines {
+		out.Centerlines[i] = wire.CenterlineInfo{Index: i, Start: point2d(c.Start), End: point2d(c.End)}
+	}
+	return out
 }
 
 func flatPatternListBendOrder(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/flat_pattern_test.go
+++ b/addin/router/flat_pattern_test.go
@@ -176,6 +176,30 @@ func TestFlatPatternBendOrderOverWire(t *testing.T) {
 	}
 }
 
+// TestFlatPatternCenterlinesOverWire add/list/delete cosmetic centerlines over the wire.
+func TestFlatPatternCenterlinesOverWire(t *testing.T) {
+	r, s := flangedSheet(t)
+
+	var res wire.CenterlinesResult
+	call(t, r, s, wire.MethodFlatPatternListCenterlines, "{}", &res)
+	if len(res.Centerlines) != 0 {
+		t.Fatalf("fresh centerlines = %d, want 0", len(res.Centerlines))
+	}
+	call(t, r, s, wire.MethodFlatPatternAddCenterline, `{"start":[0,0],"end":[4,0]}`, &res)
+	call(t, r, s, wire.MethodFlatPatternAddCenterline, `{"start":[2,-1],"end":[2,1]}`, &res)
+	if len(res.Centerlines) != 2 || res.Centerlines[1].Index != 1 {
+		t.Fatalf("after adds = %+v, want 2 centerlines", res.Centerlines)
+	}
+
+	call(t, r, s, wire.MethodFlatPatternDeleteCenterline, `{"index":0}`, &res)
+	if len(res.Centerlines) != 1 || res.Centerlines[0].Start.X != 2 {
+		t.Errorf("after delete = %+v, want the vertical centerline", res.Centerlines)
+	}
+	if _, err := r.Handle(s, wire.MethodFlatPatternDeleteCenterline, []byte(`{"index":9}`)); err == nil {
+		t.Error("deleting an out-of-range centerline must error")
+	}
+}
+
 // TestFlatPatternRejectsPlainPart every flat-pattern method errors on an ordinary part.
 func TestFlatPatternRejectsPlainPart(t *testing.T) {
 	r, s := seededSession(t)
@@ -189,6 +213,9 @@ func TestFlatPatternRejectsPlainPart(t *testing.T) {
 		wire.MethodFlatPatternSetSettings,
 		wire.MethodFlatPatternListBendOrder,
 		wire.MethodFlatPatternSetBendOrder,
+		wire.MethodFlatPatternAddCenterline,
+		wire.MethodFlatPatternListCenterlines,
+		wire.MethodFlatPatternDeleteCenterline,
 	} {
 		if _, err := r.Handle(s, m, []byte("{}")); err == nil {
 			t.Errorf("%s on a plain part must error", m)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.13.0
+	oblikovati.org/api v0.14.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.13.0
+	oblikovati.org/api v0.14.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -65,6 +65,9 @@ type PartComponentDefinition struct {
 	// bendOrder is the press-brake bend sequence (M13-F06) as an overlay of bend feature names;
 	// empty means the natural (creation) order. Bends not listed follow the listed ones.
 	bendOrder []string
+	// centerlines are the flat pattern's cosmetic centerlines (M13-F06) — annotation lines that
+	// persist with the part.
+	centerlines []sheetmetal.CosmeticCenterline
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature

--- a/model/compdef/sheet_metal.go
+++ b/model/compdef/sheet_metal.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	gmath "oblikovati.org/math"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sheetmetal"
 )
@@ -111,6 +112,15 @@ type sheetMetalRecipe struct {
 	ActiveOrient string               `yaml:"activeOrientation,omitempty"`
 	DeferUpdate  bool                 `yaml:"deferFlatUpdate,omitempty"` // M13-F05
 	BendOrder    []string             `yaml:"bendOrder,omitempty"`       // M13-F06
+	Centerlines  []centerlineRecipe   `yaml:"centerlines,omitempty"`     // M13-F06
+}
+
+// centerlineRecipe is one persisted cosmetic centerline (flat 2D coordinates, cm).
+type centerlineRecipe struct {
+	X1 float64 `yaml:"x1"`
+	Y1 float64 `yaml:"y1"`
+	X2 float64 `yaml:"x2"`
+	Y2 float64 `yaml:"y2"`
 }
 
 // bendTableRowRecipe is one persisted bend-table sample (database units, cm; angle radians).
@@ -171,6 +181,9 @@ func (d *PartComponentDefinition) captureOrientations(rec *sheetMetalRecipe) {
 	rec.ActiveOrient = d.flatOrientations.Active().Name
 	rec.DeferUpdate = d.flatSettings.DeferUpdate
 	rec.BendOrder = d.bendOrder
+	for _, c := range d.centerlines {
+		rec.Centerlines = append(rec.Centerlines, centerlineRecipe{c.Start.X, c.Start.Y, c.End.X, c.End.Y})
+	}
 }
 
 // applySheetMetalRecipe rebuilds the rule from rec, binding its thickness/bend-radius to the
@@ -223,6 +236,10 @@ func (d *PartComponentDefinition) restoreOrientations(rec *sheetMetalRecipe) err
 	}
 	d.flatSettings.DeferUpdate = rec.DeferUpdate
 	d.bendOrder = rec.BendOrder
+	d.centerlines = nil
+	for _, c := range rec.Centerlines {
+		d.centerlines = append(d.centerlines, sheetmetal.CosmeticCenterline{Start: gmath.P2(c.X1, c.Y1), End: gmath.P2(c.X2, c.Y2)})
+	}
 	return nil
 }
 

--- a/model/compdef/sheet_metal_centerline.go
+++ b/model/compdef/sheet_metal_centerline.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// Flat-pattern cosmetic centerlines (M13-F06, #809). A cosmetic centerline is a manufacturing
+// annotation line on the flat pattern (e.g. a centerline through a hole pattern). They are
+// part state — added, listed, deleted, and persisted — not geometry features.
+
+// AddCosmeticCenterline appends a cosmetic centerline (a line from start to end in flat 2D)
+// and returns its index.
+func (d *PartComponentDefinition) AddCosmeticCenterline(start, end gmath.Point2) int {
+	d.centerlines = append(d.centerlines, sheetmetal.CosmeticCenterline{Start: start, End: end})
+	return len(d.centerlines) - 1
+}
+
+// CosmeticCenterlines returns the flat pattern's cosmetic centerlines in creation order.
+func (d *PartComponentDefinition) CosmeticCenterlines() []sheetmetal.CosmeticCenterline {
+	return d.centerlines
+}
+
+// DeleteCosmeticCenterline removes the centerline at index, erroring when it is out of range.
+func (d *PartComponentDefinition) DeleteCosmeticCenterline(index int) error {
+	if index < 0 || index >= len(d.centerlines) {
+		return fmt.Errorf("cosmetic centerline: index %d out of range (have %d)", index, len(d.centerlines))
+	}
+	d.centerlines = append(d.centerlines[:index], d.centerlines[index+1:]...)
+	return nil
+}

--- a/model/compdef/sheet_metal_centerline_test.go
+++ b/model/compdef/sheet_metal_centerline_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestCosmeticCenterlines add, list, delete, and persist cosmetic centerlines.
+func TestCosmeticCenterlines(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	if len(d.CosmeticCenterlines()) != 0 {
+		t.Fatal("a fresh part should have no centerlines")
+	}
+	d.AddCosmeticCenterline(gmath.P2(0, 0), gmath.P2(4, 0))
+	i := d.AddCosmeticCenterline(gmath.P2(2, -1), gmath.P2(2, 1))
+	if i != 1 || len(d.CosmeticCenterlines()) != 2 {
+		t.Fatalf("after adds: index=%d, count=%d, want 1 and 2", i, len(d.CosmeticCenterlines()))
+	}
+
+	if err := d.DeleteCosmeticCenterline(5); err == nil {
+		t.Error("deleting an out-of-range centerline must error")
+	}
+	if err := d.DeleteCosmeticCenterline(0); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got := d.CosmeticCenterlines()
+	if len(got) != 1 || got[0].Start != gmath.P2(2, -1) {
+		t.Errorf("after delete = %+v, want the vertical centerline", got)
+	}
+
+	blob, _ := d.MarshalRecipe()
+	dst := NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(blob); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	r := dst.CosmeticCenterlines()
+	if len(r) != 1 || r[0].Start != gmath.P2(2, -1) || r[0].End != gmath.P2(2, 1) {
+		t.Errorf("restored centerlines = %+v, want the vertical one", r)
+	}
+}

--- a/model/sheetmetal/centerline.go
+++ b/model/sheetmetal/centerline.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sheetmetal
+
+import "oblikovati.org/math"
+
+// CosmeticCenterline is a manufacturing annotation line drawn on the flat pattern (M13-F06,
+// #809) — for example a centerline through a hole pattern. It is a plain line segment in the
+// flat's 2D coordinates; it carries no geometry, only the annotation.
+type CosmeticCenterline struct {
+	Start, End math.Point2
+}


### PR DESCRIPTION
## What

Implements **cosmetic centerlines** (M13-F06 PR-F) — the last piece of M13: manufacturing annotation lines on the flat pattern.

- **model/sheetmetal**: a `CosmeticCenterline` value (a flat-2D line segment).
- **compdef**: the part's centerline collection with add/list/delete (range-checked) and recipe persistence.
- **addin/router**: `flatPattern.addCenterline` / `listCenterlines` / `deleteCenterline`.

Pins `api v0.14.0` (contract: Oblikovati.API#128).

## Tests
- `compdef`: add/list/delete + out-of-range rejection; centerlines round-trip through the recipe.
- `router`: over-wire add/list/delete + out-of-range error; all twelve flat-pattern methods reject a plain part.
- `golangci-lint` 0 issues.

Refs #809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)