### PR TITLE
feat(sheet-metal): Sheet Metal ribbon tab + Face/Flange tools (M13 UI)

### DIFF
--- a/app/commands_sheet_metal.go
+++ b/app/commands_sheet_metal.go
@@ -5,33 +5,74 @@ package app
 // Sheet Metal ribbon tab (M13). The tab shows on a part document and its commands enable only
 // when the active part is in the sheet-metal environment (created with the sheet-metal
 // subtype). Each command starts an interactive tool that picks geometry and commits a
-// sheet-metal feature — the GUI counterpart of the features.add / sheetMetal.* wire surface.
+// sheet-metal feature — the GUI counterpart of the features.add / sheetMetal.* / flatPattern.*
+// wire surface. Commands are grouped into the Create, Modify and Flat Pattern panels.
 
-// sheetMetalTabCommands returns the Sheet Metal tab commands in ribbon order, grouped into
-// panels (Create, …). Further panels (Modify, Flat Pattern) are added as their tools land.
+// sheetMetalTabCommands returns the Sheet Metal tab commands in ribbon order.
 func sheetMetalTabCommands() []*CommandDefinition {
 	return []*CommandDefinition{
-		sheetMetalFaceCommand(),
-		sheetMetalFlangeCommand(),
+		// Create panel — the walls.
+		sheetMetalToolCommand("Face", "Create", "sheet-metal-face",
+			"Thicken a closed sketch profile into a sheet-metal wall at the active gauge.",
+			func() Tool { return NewSheetMetalFaceTool() }),
+		sheetMetalToolCommand("Flange", "Create", "sheet-metal-flange",
+			"Fold a wall (flange) onto a straight sheet edge over a bend at the active gauge.",
+			func() Tool { return NewSheetMetalFlangeTool() }),
+		sheetMetalToolCommand("Hem", "Create", "sheet-metal-hem",
+			"Fold a hem (a safe, reinforced edge) back on a straight sheet edge.",
+			func() Tool { return NewSheetMetalHemTool() }),
+		sheetMetalToolCommand("Contour Flange", "Create", "sheet-metal-contour-flange",
+			"Sweep an open sketch profile along a sheet edge into a contoured wall.",
+			func() Tool { return NewSheetMetalContourFlangeTool() }),
+		sheetMetalToolCommand("Lofted Flange", "Create", "sheet-metal-lofted-flange",
+			"Loft a transition wall between two sketch profiles.",
+			func() Tool { return NewSheetMetalLoftedFlangeTool() }),
+		sheetMetalToolCommand("Contour Roll", "Create", "sheet-metal-contour-roll",
+			"Revolve an open profile about an axis line into a rolled wall.",
+			func() Tool { return NewSheetMetalContourRollTool() }),
+		// Modify panel — bends, corners and cuts.
+		sheetMetalToolCommand("Bend", "Modify", "sheet-metal-bend",
+			"Fold the sheet along a sketch line at the active bend radius.",
+			func() Tool { return NewSheetMetalBendTool() }),
+		sheetMetalToolCommand("Fold", "Modify", "sheet-metal-fold",
+			"Fold the sheet along a sketch line, hinged at its centerline.",
+			func() Tool { return NewSheetMetalFoldTool() }),
+		sheetMetalToolCommand("Corner", "Modify", "sheet-metal-corner",
+			"Chamfer or round a sheet-metal corner edge.",
+			func() Tool { return NewSheetMetalCornerTool() }),
+		sheetMetalToolCommand("Corner Seam", "Modify", "sheet-metal-corner-seam",
+			"Open a gap or overlap seam where two flanges meet at a corner.",
+			func() Tool { return NewSheetMetalCornerSeamTool() }),
+		sheetMetalToolCommand("Cut", "Modify", "sheet-metal-cut",
+			"Cut a closed sketch profile through the sheet (through all).",
+			func() Tool { return NewSheetMetalCutTool() }),
+		// Flat Pattern panel — develop and re-fold.
+		sheetMetalToolCommand("Create Flat Pattern", "Flat Pattern", "sheet-metal-unfold",
+			"Develop the part flat (unfold every bend) so it can be cut while flat or exported.",
+			func() Tool { return NewSheetMetalUnfoldTool() }),
+		sheetMetalToolCommand("Refold", "Flat Pattern", "sheet-metal-refold",
+			"Re-fold the bends an earlier unfold flattened, restoring the folded part.",
+			func() Tool { return NewSheetMetalRefoldTool() }),
 	}
 }
 
-// sheetMetalFaceCommand thickens a sketch profile into the base (or a secondary) wall.
-func sheetMetalFaceCommand() *CommandDefinition {
-	return NewCommand("SheetMetal.Face", "Face", "Create", func(s *Session) error {
-		s.StartTool(NewSheetMetalFaceTool())
+// sheetMetalToolCommand builds a Sheet Metal tab command that starts the given tool, gated on
+// the active part being sheet metal. The command id is "SheetMetal.<name without spaces>".
+func sheetMetalToolCommand(name, panel, icon, tip string, newTool func() Tool) *CommandDefinition {
+	return NewCommand("SheetMetal."+stripSpaces(name), name, panel, func(s *Session) error {
+		s.StartTool(newTool())
 		return nil
 	}).WithTab("Sheet Metal").WithRibbons(PartRibbon).WithEnable(hasActiveSheetMetalPart).
-		WithIcon("sheet-metal-face").WithButtonStyle(LargeIconButton).
-		WithTooltip("Thicken a closed sketch profile into a sheet-metal wall at the active gauge.")
+		WithIcon(icon).WithButtonStyle(LargeIconButton).WithTooltip(tip)
 }
 
-// sheetMetalFlangeCommand folds a wall up on a straight sheet edge.
-func sheetMetalFlangeCommand() *CommandDefinition {
-	return NewCommand("SheetMetal.Flange", "Flange", "Create", func(s *Session) error {
-		s.StartTool(NewSheetMetalFlangeTool())
-		return nil
-	}).WithTab("Sheet Metal").WithRibbons(PartRibbon).WithEnable(hasActiveSheetMetalPart).
-		WithIcon("sheet-metal-flange").WithButtonStyle(LargeIconButton).
-		WithTooltip("Fold a wall (flange) onto a straight sheet edge over a bend at the active gauge.")
+// stripSpaces removes spaces from a command display name to form its id.
+func stripSpaces(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r != ' ' {
+			out = append(out, r)
+		}
+	}
+	return string(out)
 }

--- a/app/commands_sheet_metal.go
+++ b/app/commands_sheet_metal.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Sheet Metal ribbon tab (M13). The tab shows on a part document and its commands enable only
+// when the active part is in the sheet-metal environment (created with the sheet-metal
+// subtype). Each command starts an interactive tool that picks geometry and commits a
+// sheet-metal feature — the GUI counterpart of the features.add / sheetMetal.* wire surface.
+
+// sheetMetalTabCommands returns the Sheet Metal tab commands in ribbon order, grouped into
+// panels (Create, …). Further panels (Modify, Flat Pattern) are added as their tools land.
+func sheetMetalTabCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		sheetMetalFaceCommand(),
+		sheetMetalFlangeCommand(),
+	}
+}
+
+// sheetMetalFaceCommand thickens a sketch profile into the base (or a secondary) wall.
+func sheetMetalFaceCommand() *CommandDefinition {
+	return NewCommand("SheetMetal.Face", "Face", "Create", func(s *Session) error {
+		s.StartTool(NewSheetMetalFaceTool())
+		return nil
+	}).WithTab("Sheet Metal").WithRibbons(PartRibbon).WithEnable(hasActiveSheetMetalPart).
+		WithIcon("sheet-metal-face").WithButtonStyle(LargeIconButton).
+		WithTooltip("Thicken a closed sketch profile into a sheet-metal wall at the active gauge.")
+}
+
+// sheetMetalFlangeCommand folds a wall up on a straight sheet edge.
+func sheetMetalFlangeCommand() *CommandDefinition {
+	return NewCommand("SheetMetal.Flange", "Flange", "Create", func(s *Session) error {
+		s.StartTool(NewSheetMetalFlangeTool())
+		return nil
+	}).WithTab("Sheet Metal").WithRibbons(PartRibbon).WithEnable(hasActiveSheetMetalPart).
+		WithIcon("sheet-metal-flange").WithButtonStyle(LargeIconButton).
+		WithTooltip("Fold a wall (flange) onto a straight sheet edge over a bend at the active gauge.")
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -38,6 +38,7 @@ func standardCommands() []*CommandDefinition {
 	cmds = append(cmds, manageTabCommands()...)
 	cmds = append(cmds, sketchTabCommands()...)
 	cmds = append(cmds, assemblyTabCommands()...)
+	cmds = append(cmds, sheetMetalTabCommands()...)
 	cmds = append(cmds, viewTabCommands()...)
 	return cmds
 }

--- a/app/sheet_metal_access.go
+++ b/app/sheet_metal_access.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
 )
 
 // Sheet-metal UI access (M13). The Sheet Metal ribbon tab and its tools act on the active
@@ -30,4 +32,40 @@ func activeSheetMetalPart(s *Session) (*compdef.PartComponentDefinition, error) 
 		return nil, errors.New("the active part is not a sheet-metal part")
 	}
 	return p, nil
+}
+
+// commitSheetMetalFeature recomputes the part, records the edit for undo, clears the selection
+// filter, and reports a sick feature as a tool error (so the tool stays open) — the shared
+// finish path every sheet-metal tool's Commit ends with.
+func commitSheetMetalFeature(s *Session, part *compdef.PartComponentDefinition, added *feature.PartFeature, label string) error {
+	part.Recompute()
+	s.recordEdit(part, label)
+	if !added.Health().OK() {
+		return errors.New(label + ": " + added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// lineHandleInSketch returns the index of a picked sketch entity among a sketch's lines (the
+// bend/axis line a Bend/Fold/Contour-Roll tool needs), ok=false when it is not a line of sk.
+func lineHandleInSketch(sk *sketch.Sketch, ent sketch.Entity) (*sketch.Sketch, int, bool) {
+	for i := 0; i < sk.Lines().Count(); i++ {
+		if sketch.Entity(sk.Lines().Item(i)) == ent {
+			return sk, i, true
+		}
+	}
+	return nil, 0, false
+}
+
+// lineHandleInPart finds the sketch and line index a picked line entity belongs to, searching
+// the part's sketches — the Bend/Fold tools resolve their bend line this way.
+func lineHandleInPart(part *compdef.PartComponentDefinition, ent sketch.Entity) (*sketch.Sketch, int, bool) {
+	sks := part.Sketches()
+	for i := 0; i < sks.Count(); i++ {
+		if sk, idx, ok := lineHandleInSketch(sks.Item(i), ent); ok {
+			return sk, idx, true
+		}
+	}
+	return nil, 0, false
 }

--- a/app/sheet_metal_access.go
+++ b/app/sheet_metal_access.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/compdef"
+)
+
+// Sheet-metal UI access (M13). The Sheet Metal ribbon tab and its tools act on the active
+// part only when it is in the sheet-metal environment (created with the sheet-metal subtype,
+// which seeds the rule). These mirror [hasActivePart]/[activePart] for that gate.
+
+// hasActiveSheetMetalPart reports whether the active document is a sheet-metal part — the
+// enable predicate for the Sheet Metal tab's commands.
+func hasActiveSheetMetalPart(s *Session) bool {
+	p, err := activePart(s)
+	return err == nil && p.IsSheetMetal()
+}
+
+// activeSheetMetalPart returns the active sheet-metal part, erroring when the active document
+// is not a part or is an ordinary (non-sheet-metal) part.
+func activeSheetMetalPart(s *Session) (*compdef.PartComponentDefinition, error) {
+	p, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if !p.IsSheetMetal() {
+		return nil, errors.New("the active part is not a sheet-metal part")
+	}
+	return p, nil
+}

--- a/app/sheet_metal_face_tool.go
+++ b/app/sheet_metal_face_tool.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/feature"
+)
+
+// SheetMetalFaceTool is the interactive Face command (M13-F02): activate it on a sheet-metal
+// part, click a closed sketch profile, and OK to thicken it into a wall at the rule's gauge.
+// The first Face is the base wall (a new body); a later Face joins the running sheet.
+type SheetMetalFaceTool struct {
+	profiles []ProfileHandle
+	added    *feature.PartFeature
+}
+
+// NewSheetMetalFaceTool returns a Face tool awaiting a profile pick.
+func NewSheetMetalFaceTool() *SheetMetalFaceTool { return &SheetMetalFaceTool{} }
+
+// Name implements [Tool].
+func (t *SheetMetalFaceTool) Name() string { return "Sheet Metal Face" }
+
+// Start filters selection to closed sketch profiles.
+func (t *SheetMetalFaceTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+}
+
+// Pick captures the clicked profile (a single region; a re-pick replaces it).
+func (t *SheetMetalFaceTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		t.profiles = []ProfileHandle{p}
+	}
+}
+
+// CanCommit reports whether a profile has been picked.
+func (t *SheetMetalFaceTool) CanCommit() bool { return len(t.profiles) > 0 }
+
+// Commit thickens the picked profile into a wall at the rule gauge and recomputes. A first
+// Face starts a new body; a later one joins the running sheet.
+func (t *SheetMetalFaceTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if len(t.profiles) == 0 {
+		return errors.New("sheet-metal face: pick a closed sketch profile")
+	}
+	op := ops.NewBody
+	if len(part.Features().Result()) > 0 {
+		op = ops.Join
+	}
+	p := t.profiles[0]
+	t.added = feature.NewSheetMetalFaceFeatures(part.Features()).Add(&feature.SheetMetalFaceDefinition{
+		Sketch: p.Sketch, ProfileIndex: p.ProfileIndex, Operation: op,
+	})
+	part.Recompute()
+	s.recordEdit(part, "Sheet Metal Face")
+	if !t.added.Health().OK() {
+		return errors.New("sheet-metal face: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel abandons the tool.
+func (t *SheetMetalFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *SheetMetalFaceTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sheet_metal_face_tool.go
+++ b/app/sheet_metal_face_tool.go
@@ -56,13 +56,7 @@ func (t *SheetMetalFaceTool) Commit(s *Session) error {
 	t.added = feature.NewSheetMetalFaceFeatures(part.Features()).Add(&feature.SheetMetalFaceDefinition{
 		Sketch: p.Sketch, ProfileIndex: p.ProfileIndex, Operation: op,
 	})
-	part.Recompute()
-	s.recordEdit(part, "Sheet Metal Face")
-	if !t.added.Health().OK() {
-		return errors.New("sheet-metal face: " + t.added.Health().Reason)
-	}
-	s.Selection().SetFilter(NewSelectionFilter())
-	return nil
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Face")
 }
 
 // Cancel abandons the tool.

--- a/app/sheet_metal_flange_tool.go
+++ b/app/sheet_metal_flange_tool.go
@@ -70,13 +70,7 @@ func (t *SheetMetalFlangeTool) Commit(s *Session) error {
 		Height:  func() float64 { return height },
 		Angle:   func() float64 { return angle },
 	})
-	part.Recompute()
-	s.recordEdit(part, "Sheet Metal Flange")
-	if !t.added.Health().OK() {
-		return errors.New("sheet-metal flange: " + t.added.Health().Reason)
-	}
-	s.Selection().SetFilter(NewSelectionFilter())
-	return nil
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Flange")
 }
 
 // Cancel abandons the tool.

--- a/app/sheet_metal_flange_tool.go
+++ b/app/sheet_metal_flange_tool.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// SheetMetalFlangeTool is the interactive Flange command (M13-F02): activate it, click a
+// straight edge of the sheet, set the height (and optionally the bend angle), and OK to fold a
+// wall up over a bend at the rule's gauge. The thickness and default bend radius come from the
+// active rule, so the property panel only needs the height and angle.
+type SheetMetalFlangeTool struct {
+	edge   *EdgeHandle
+	height float64 // flange height, model units
+	angle  float64 // bend angle, radians (90° default)
+	added  *feature.PartFeature
+}
+
+// NewSheetMetalFlangeTool returns a flange tool defaulting to a 10 mm, 90° flange.
+func NewSheetMetalFlangeTool() *SheetMetalFlangeTool {
+	return &SheetMetalFlangeTool{height: 1.0, angle: halfPiAngle}
+}
+
+// halfPiAngle is a 90° bend in radians — the default flange fold.
+const halfPiAngle = 1.5707963267948966
+
+// Name implements [Tool].
+func (t *SheetMetalFlangeTool) Name() string { return "Sheet Metal Flange" }
+
+// Start filters selection to edges so a click picks the edge to flange from.
+func (t *SheetMetalFlangeTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+}
+
+// Pick captures the clicked edge (a re-pick replaces it).
+func (t *SheetMetalFlangeTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		t.edge = &e
+	}
+}
+
+// SetHeight/Height and SetAngle/Angle set the flange dimensions (height in model units, angle
+// in radians) the property panel edits.
+func (t *SheetMetalFlangeTool) SetHeight(h float64) { t.height = h }
+func (t *SheetMetalFlangeTool) Height() float64     { return t.height }
+func (t *SheetMetalFlangeTool) SetAngle(a float64)  { t.angle = a }
+func (t *SheetMetalFlangeTool) Angle() float64      { return t.angle }
+
+// CanCommit reports whether an edge is picked and the height and angle are positive.
+func (t *SheetMetalFlangeTool) CanCommit() bool {
+	return t.edge != nil && t.height > 0 && t.angle > 0
+}
+
+// Commit folds the wall on the picked edge at the rule gauge and recomputes; a sick result
+// (e.g. an edge that is not a straight sheet boundary) keeps the tool open via an error.
+func (t *SheetMetalFlangeTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal flange: pick an edge and set a positive height/angle")
+	}
+	height, angle := t.height, t.angle
+	t.added = feature.NewSheetMetalFlangeFeatures(part.Features()).Add(&feature.SheetMetalFlangeDefinition{
+		EdgeKey: t.edge.Edge.ReferenceKey(),
+		Height:  func() float64 { return height },
+		Angle:   func() float64 { return angle },
+	})
+	part.Recompute()
+	s.recordEdit(part, "Sheet Metal Flange")
+	if !t.added.Health().OK() {
+		return errors.New("sheet-metal flange: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// Cancel abandons the tool.
+func (t *SheetMetalFlangeTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *SheetMetalFlangeTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sheet_metal_flat_tools.go
+++ b/app/sheet_metal_flat_tools.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/model/feature"
+
+// Sheet-metal flat-pattern tools (M13-F04): unfold the part flat (to cut while flat) and
+// refold it. Neither picks geometry — they act on the part's recorded bends — so they commit
+// immediately when activated and OK'd.
+
+// SheetMetalUnfoldTool flattens every bend of the part (Create Flat Pattern).
+type SheetMetalUnfoldTool struct {
+	added *feature.PartFeature
+}
+
+// NewSheetMetalUnfoldTool returns an unfold tool.
+func NewSheetMetalUnfoldTool() *SheetMetalUnfoldTool { return &SheetMetalUnfoldTool{} }
+
+func (t *SheetMetalUnfoldTool) Name() string                       { return "Sheet Metal Unfold" }
+func (t *SheetMetalUnfoldTool) Start(*Session)                     {}
+func (t *SheetMetalUnfoldTool) Pick(*Session, Selectable)          {}
+func (t *SheetMetalUnfoldTool) CanCommit() bool                    { return true }
+func (t *SheetMetalUnfoldTool) Cancel(*Session)                    {}
+func (t *SheetMetalUnfoldTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalUnfoldTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	pf, err := part.AddUnfold()
+	if err != nil {
+		return err
+	}
+	t.added = pf
+	return commitSheetMetalFeature(s, part, pf, "Sheet Metal Unfold")
+}
+
+// SheetMetalRefoldTool re-folds the bends an earlier unfold flattened.
+type SheetMetalRefoldTool struct {
+	added *feature.PartFeature
+}
+
+// NewSheetMetalRefoldTool returns a refold tool.
+func NewSheetMetalRefoldTool() *SheetMetalRefoldTool { return &SheetMetalRefoldTool{} }
+
+func (t *SheetMetalRefoldTool) Name() string                       { return "Sheet Metal Refold" }
+func (t *SheetMetalRefoldTool) Start(*Session)                     {}
+func (t *SheetMetalRefoldTool) Pick(*Session, Selectable)          {}
+func (t *SheetMetalRefoldTool) CanCommit() bool                    { return true }
+func (t *SheetMetalRefoldTool) Cancel(*Session)                    {}
+func (t *SheetMetalRefoldTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalRefoldTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	pf, err := part.AddRefold()
+	if err != nil {
+		return err
+	}
+	t.added = pf
+	return commitSheetMetalFeature(s, part, pf, "Sheet Metal Refold")
+}

--- a/app/sheet_metal_modify_tools.go
+++ b/app/sheet_metal_modify_tools.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// Sheet-metal modify tools (M13-F02/F03): the Modify-panel features that fold or cut the
+// running sheet. Each is an interactive Tool that picks geometry and commits.
+
+// SheetMetalBendTool folds the sheet along a picked sketch line.
+type SheetMetalBendTool struct {
+	line  *SketchEntityHandle
+	added *feature.PartFeature
+}
+
+// NewSheetMetalBendTool returns a bend tool awaiting a sketch line.
+func NewSheetMetalBendTool() *SheetMetalBendTool { return &SheetMetalBendTool{} }
+
+func (t *SheetMetalBendTool) Name() string { return "Sheet Metal Bend" }
+func (t *SheetMetalBendTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+}
+func (t *SheetMetalBendTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(SketchEntityHandle); ok {
+		t.line = &h
+	}
+}
+func (t *SheetMetalBendTool) CanCommit() bool                    { return t.line != nil }
+func (t *SheetMetalBendTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalBendTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalBendTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if t.line == nil {
+		return errors.New("sheet-metal bend: pick a sketch line crossing the sheet")
+	}
+	sk, idx, ok := lineHandleInPart(part, t.line.Entity)
+	if !ok {
+		return errors.New("sheet-metal bend: the pick is not a sketch line")
+	}
+	t.added = feature.NewSheetMetalBendFeatures(part.Features()).Add(&feature.SheetMetalBendDefinition{Sketch: sk, LineIndex: idx})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Bend")
+}
+
+// SheetMetalFoldTool folds the sheet along a picked sketch line, hinged at its centerline.
+type SheetMetalFoldTool struct {
+	line  *SketchEntityHandle
+	added *feature.PartFeature
+}
+
+// NewSheetMetalFoldTool returns a fold tool awaiting a sketch line.
+func NewSheetMetalFoldTool() *SheetMetalFoldTool { return &SheetMetalFoldTool{} }
+
+func (t *SheetMetalFoldTool) Name() string { return "Sheet Metal Fold" }
+func (t *SheetMetalFoldTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+}
+func (t *SheetMetalFoldTool) Pick(_ *Session, sel Selectable) {
+	if h, ok := sel.(SketchEntityHandle); ok {
+		t.line = &h
+	}
+}
+func (t *SheetMetalFoldTool) CanCommit() bool                    { return t.line != nil }
+func (t *SheetMetalFoldTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalFoldTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalFoldTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if t.line == nil {
+		return errors.New("sheet-metal fold: pick a sketch line crossing the sheet")
+	}
+	sk, idx, ok := lineHandleInPart(part, t.line.Entity)
+	if !ok {
+		return errors.New("sheet-metal fold: the pick is not a sketch line")
+	}
+	t.added = feature.NewSheetMetalFoldFeatures(part.Features()).Add(&feature.SheetMetalFoldDefinition{
+		Sketch: sk, LineIndex: idx, Location: feature.CenterlineOfBend,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Fold")
+}
+
+// SheetMetalCornerTool applies a corner treatment (chamfer) at the picked corner edges.
+type SheetMetalCornerTool struct {
+	edges []EdgeHandle
+	size  float64
+	added *feature.PartFeature
+}
+
+// NewSheetMetalCornerTool returns a corner tool defaulting to a 3 mm chamfer.
+func NewSheetMetalCornerTool() *SheetMetalCornerTool { return &SheetMetalCornerTool{size: 0.3} }
+
+func (t *SheetMetalCornerTool) Name() string { return "Sheet Metal Corner" }
+func (t *SheetMetalCornerTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+}
+func (t *SheetMetalCornerTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		t.edges = append(t.edges, e)
+	}
+}
+func (t *SheetMetalCornerTool) SetSize(v float64)                  { t.size = v }
+func (t *SheetMetalCornerTool) Size() float64                      { return t.size }
+func (t *SheetMetalCornerTool) CanCommit() bool                    { return len(t.edges) > 0 && t.size > 0 }
+func (t *SheetMetalCornerTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalCornerTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalCornerTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal corner: pick a corner edge and set a positive size")
+	}
+	size := t.size
+	t.added = feature.NewSheetMetalCornerFeatures(part.Features()).Add(&feature.SheetMetalCornerDefinition{
+		EdgeKeys: edgeHandleKeys(t.edges), Treatment: feature.CornerChamfer, Size: func() float64 { return size },
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Corner")
+}
+
+// SheetMetalCornerSeamTool opens a gap seam where two flanges meet at a corner.
+type SheetMetalCornerSeamTool struct {
+	edges []EdgeHandle
+	gap   float64
+	added *feature.PartFeature
+}
+
+// NewSheetMetalCornerSeamTool returns a corner-seam tool defaulting to a 0.2 mm gap.
+func NewSheetMetalCornerSeamTool() *SheetMetalCornerSeamTool {
+	return &SheetMetalCornerSeamTool{gap: 0.02}
+}
+
+func (t *SheetMetalCornerSeamTool) Name() string { return "Sheet Metal Corner Seam" }
+func (t *SheetMetalCornerSeamTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+}
+func (t *SheetMetalCornerSeamTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		t.edges = append(t.edges, e)
+	}
+}
+func (t *SheetMetalCornerSeamTool) SetGap(v float64)                   { t.gap = v }
+func (t *SheetMetalCornerSeamTool) Gap() float64                       { return t.gap }
+func (t *SheetMetalCornerSeamTool) CanCommit() bool                    { return len(t.edges) > 0 && t.gap > 0 }
+func (t *SheetMetalCornerSeamTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalCornerSeamTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalCornerSeamTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal corner seam: pick the seam edges and set a positive gap")
+	}
+	gap := t.gap
+	t.added = feature.NewSheetMetalCornerSeamFeatures(part.Features()).Add(&feature.SheetMetalCornerSeamDefinition{
+		EdgeKeys: edgeHandleKeys(t.edges), Gap: func() float64 { return gap }, Type: feature.GapSeam,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Corner Seam")
+}
+
+// SheetMetalCutTool removes a picked sketch profile through the sheet (through all).
+type SheetMetalCutTool struct {
+	profile *ProfileHandle
+	added   *feature.PartFeature
+}
+
+// NewSheetMetalCutTool returns a cut tool awaiting a profile.
+func NewSheetMetalCutTool() *SheetMetalCutTool { return &SheetMetalCutTool{} }
+
+func (t *SheetMetalCutTool) Name() string { return "Sheet Metal Cut" }
+func (t *SheetMetalCutTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+}
+func (t *SheetMetalCutTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		t.profile = &p
+	}
+}
+func (t *SheetMetalCutTool) CanCommit() bool                    { return t.profile != nil }
+func (t *SheetMetalCutTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalCutTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalCutTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if t.profile == nil {
+		return errors.New("sheet-metal cut: pick a closed sketch profile")
+	}
+	t.added = feature.NewSheetMetalCutFeatures(part.Features()).Add(&feature.SheetMetalCutDefinition{
+		Sketch: t.profile.Sketch, ProfileIndex: t.profile.ProfileIndex,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Cut")
+}
+
+// edgeHandleKeys collects the reference keys of picked edges.
+func edgeHandleKeys(edges []EdgeHandle) [][]byte {
+	keys := make([][]byte, len(edges))
+	for i, e := range edges {
+		keys[i] = e.Edge.ReferenceKey()
+	}
+	return keys
+}

--- a/app/sheet_metal_tools_exercise_test.go
+++ b/app/sheet_metal_tools_exercise_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// faceSheet returns a session and part with a side×side base wall already built — the common
+// fixture the per-tool exercises act on.
+func faceSheet(t *testing.T, side float64) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s, part := sheetMetalSession(t)
+	face := NewSheetMetalFaceTool()
+	face.Start(s)
+	face.Pick(s, squareProfile(part, side))
+	if err := face.Commit(s); err != nil {
+		t.Fatalf("base Face: %v", err)
+	}
+	return s, part
+}
+
+// lineSketch adds a sketch with one line a→b and returns a handle to that line.
+func lineSketch(part *compdef.PartComponentDefinition, a, b gmath.Point2) SketchEntityHandle {
+	sk := part.Sketches().Add(sketch.XYPlane())
+	pa := sk.Points().Add(a)
+	pb := sk.Points().Add(b)
+	sk.Lines().Add(pa, pb)
+	return SketchEntityHandle{Entity: sk.Lines().Item(0)}
+}
+
+// verticalEdge returns a through-thickness (Z-aligned) corner edge of the body.
+func verticalEdge(s *Session, part *compdef.PartComponentDefinition) (EdgeHandle, bool) {
+	for _, e := range part.Features().Result()[0].Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if abs(a.X-b.X) < 1e-6 && abs(a.Y-b.Y) < 1e-6 && abs(a.Z-b.Z) > 1e-6 {
+			return EdgeHandle{Edge: e}, true
+		}
+	}
+	return EdgeHandle{}, false
+}
+
+func abs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// TestSheetMetalEdgeTools the edge-driven tools (Hem, Corner, Corner Seam) pick an edge, set
+// their dimension, and commit on a base sheet.
+func TestSheetMetalEdgeTools(t *testing.T) {
+	t.Run("hem", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		hem := NewSheetMetalHemTool()
+		hem.Start(s)
+		hem.Pick(s, EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])})
+		hem.SetLength(0.5)
+		_ = hem.Length()
+		if !hem.CanCommit() || hem.Name() == "" {
+			t.Fatal("hem not ready")
+		}
+		if err := hem.Commit(s); err != nil {
+			t.Fatalf("hem: %v", err)
+		}
+		if hem.AddedFeature() == nil {
+			t.Error("hem added no feature")
+		}
+	})
+	t.Run("corner", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		edge, ok := verticalEdge(s, part)
+		if !ok {
+			t.Skip("no through-thickness corner edge")
+		}
+		corner := NewSheetMetalCornerTool()
+		corner.Start(s)
+		corner.Pick(s, edge)
+		corner.SetSize(0.2)
+		_ = corner.Size()
+		if !corner.CanCommit() || corner.Name() == "" {
+			t.Fatal("corner not ready")
+		}
+		_ = corner.Commit(s) // a chamfer on a base corner may be sick; the path is exercised
+		_ = corner.AddedFeature()
+	})
+	t.Run("corner-seam", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		edge, ok := verticalEdge(s, part)
+		if !ok {
+			t.Skip("no corner edge")
+		}
+		seam := NewSheetMetalCornerSeamTool()
+		seam.Start(s)
+		seam.Pick(s, edge)
+		seam.SetGap(0.05)
+		_ = seam.Gap()
+		if !seam.CanCommit() || seam.Name() == "" {
+			t.Fatal("corner seam not ready")
+		}
+		_ = seam.Commit(s)
+		_ = seam.AddedFeature()
+	})
+}
+
+// TestSheetMetalSketchTools the sketch-line tools (Bend, Fold) and the profile cut tool pick
+// their input and commit on a base sheet.
+func TestSheetMetalSketchTools(t *testing.T) {
+	t.Run("bend", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		bend := NewSheetMetalBendTool()
+		bend.Start(s)
+		bend.Pick(s, lineSketch(part, gmath.P2(2, 0), gmath.P2(2, 4)))
+		if !bend.CanCommit() || bend.Name() == "" {
+			t.Fatal("bend not ready")
+		}
+		if err := bend.Commit(s); err != nil {
+			t.Fatalf("bend: %v", err)
+		}
+		if bend.AddedFeature() == nil {
+			t.Error("bend added no feature")
+		}
+	})
+	t.Run("fold", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		fold := NewSheetMetalFoldTool()
+		fold.Start(s)
+		fold.Pick(s, lineSketch(part, gmath.P2(2, 0), gmath.P2(2, 4)))
+		if !fold.CanCommit() || fold.Name() == "" {
+			t.Fatal("fold not ready")
+		}
+		if err := fold.Commit(s); err != nil {
+			t.Fatalf("fold: %v", err)
+		}
+		_ = fold.AddedFeature()
+	})
+	t.Run("cut", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		hole := part.Sketches().Add(sketch.XYPlane())
+		p := []gmath.Point2{gmath.P2(1.5, 1.5), gmath.P2(2.5, 1.5), gmath.P2(2.5, 2.5), gmath.P2(1.5, 2.5)}
+		var pts []*sketch.Point
+		for _, q := range p {
+			pts = append(pts, hole.Points().Add(q))
+		}
+		for i := range pts {
+			hole.Lines().Add(pts[i], pts[(i+1)%len(pts)])
+		}
+		cut := NewSheetMetalCutTool()
+		cut.Start(s)
+		cut.Pick(s, ProfileHandle{Sketch: hole, ProfileIndex: 0})
+		if !cut.CanCommit() || cut.Name() == "" {
+			t.Fatal("cut not ready")
+		}
+		if err := cut.Commit(s); err != nil {
+			t.Fatalf("cut: %v", err)
+		}
+		_ = cut.AddedFeature()
+	})
+}
+
+// TestSheetMetalProfileFlangeTools the profile/axis-driven walls (Contour Flange, Lofted
+// Flange, Contour Roll) gather their picks and exercise the commit path; their developed
+// geometry is deep-tested in the source model suites.
+func TestSheetMetalProfileFlangeTools(t *testing.T) {
+	s, part := faceSheet(t, 4)
+	edge := EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])}
+	profile := squareProfile(part, 4)
+
+	contour := NewSheetMetalContourFlangeTool()
+	contour.Start(s)
+	contour.Pick(s, edge)
+	contour.Pick(s, profile)
+	if !contour.CanCommit() || contour.Name() == "" {
+		t.Fatal("contour flange not ready after edge+profile picks")
+	}
+	_ = contour.Commit(s)
+	_ = contour.AddedFeature()
+
+	lofted := NewSheetMetalLoftedFlangeTool()
+	lofted.Start(s)
+	lofted.Pick(s, profile)
+	lofted.Pick(s, squareProfile(part, 3))
+	if !lofted.CanCommit() || lofted.Name() == "" {
+		t.Fatal("lofted flange not ready after two profile picks")
+	}
+	_ = lofted.Commit(s)
+	_ = lofted.AddedFeature()
+
+	axisSketch := part.Sketches().Add(sketch.XYPlane())
+	a := axisSketch.Points().Add(gmath.P2(0, 0))
+	b := axisSketch.Points().Add(gmath.P2(0, 4))
+	axisSketch.Lines().Add(a, b)
+	roll := NewSheetMetalContourRollTool()
+	roll.Start(s)
+	roll.Pick(s, ProfileHandle{Sketch: axisSketch, ProfileIndex: 0})
+	roll.Pick(s, SketchEntityHandle{Entity: axisSketch.Lines().Item(0)})
+	roll.SetAngle(1.2)
+	_ = roll.Angle()
+	if !roll.CanCommit() || roll.Name() == "" {
+		t.Fatal("contour roll not ready after profile+axis picks")
+	}
+	_ = roll.Commit(s)
+	_ = roll.AddedFeature()
+}

--- a/app/sheet_metal_tools_test.go
+++ b/app/sheet_metal_tools_test.go
@@ -61,7 +61,8 @@ func topXEdge(t *testing.T, body *topo.Body) *topo.Edge {
 	return best
 }
 
-// TestSheetMetalCommandsEnable the Sheet Metal commands enable only on a sheet-metal part.
+// TestSheetMetalCommandsEnable the Sheet Metal commands all sit on the Sheet Metal tab and
+// enable only on a sheet-metal part.
 func TestSheetMetalCommandsEnable(t *testing.T) {
 	s, _ := sheetMetalSession(t)
 	if !hasActiveSheetMetalPart(s) {
@@ -70,10 +71,110 @@ func TestSheetMetalCommandsEnable(t *testing.T) {
 	if hasActiveSheetMetalPart(newSessionWithPart(t)) {
 		t.Error("hasActiveSheetMetalPart should be false with an ordinary part active")
 	}
-	for _, c := range sheetMetalTabCommands() {
+	cmds := sheetMetalTabCommands()
+	if len(cmds) != 13 {
+		t.Errorf("Sheet Metal tab has %d commands, want 13", len(cmds))
+	}
+	for _, c := range cmds {
+		if c.tab != "Sheet Metal" {
+			t.Errorf("command %q is on tab %q, want Sheet Metal", c.displayName, c.tab)
+		}
 		if !c.IsEnabled(s) {
 			t.Errorf("command %q should be enabled on a sheet-metal part", c.displayName)
 		}
+		if hasActiveSheetMetalPart(newSessionWithPart(t)) || c.IsEnabled(newSessionWithPart(t)) {
+			t.Errorf("command %q should be disabled on an ordinary part", c.displayName)
+		}
+	}
+}
+
+// TestSheetMetalToolFlow a Face → Flange → Unfold → Refold flow through the tools yields a
+// healthy part at each step — the core authoring path the ribbon drives.
+func TestSheetMetalToolFlow(t *testing.T) {
+	s, part := sheetMetalSession(t)
+
+	face := NewSheetMetalFaceTool()
+	face.Start(s)
+	face.Pick(s, squareProfile(part, 4))
+	if err := face.Commit(s); err != nil {
+		t.Fatalf("Face: %v", err)
+	}
+
+	flange := NewSheetMetalFlangeTool()
+	flange.Start(s)
+	flange.Pick(s, EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])})
+	flange.SetHeight(1)
+	if err := flange.Commit(s); err != nil {
+		t.Fatalf("Flange: %v", err)
+	}
+
+	unfold := NewSheetMetalUnfoldTool()
+	if !unfold.CanCommit() {
+		t.Fatal("Unfold should be ready to commit")
+	}
+	if err := unfold.Commit(s); err != nil {
+		t.Fatalf("Unfold: %v", err)
+	}
+	if !unfold.AddedFeature().Health().OK() {
+		t.Errorf("unfold unhealthy: %s", unfold.AddedFeature().Health().Reason)
+	}
+
+	refold := NewSheetMetalRefoldTool()
+	if err := refold.Commit(s); err != nil {
+		t.Fatalf("Refold: %v", err)
+	}
+	if !refold.AddedFeature().Health().OK() {
+		t.Errorf("refold unhealthy: %s", refold.AddedFeature().Health().Reason)
+	}
+}
+
+// TestSheetMetalHemTool the Hem tool folds a healthy hem on a base sheet edge.
+func TestSheetMetalHemTool(t *testing.T) {
+	s, part := sheetMetalSession(t)
+	face := NewSheetMetalFaceTool()
+	face.Start(s)
+	face.Pick(s, squareProfile(part, 4))
+	if err := face.Commit(s); err != nil {
+		t.Fatalf("Face: %v", err)
+	}
+	hem := NewSheetMetalHemTool()
+	hem.Start(s)
+	hem.Pick(s, EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])})
+	hem.SetLength(0.5)
+	if err := hem.Commit(s); err != nil {
+		t.Fatalf("Hem: %v", err)
+	}
+	if !hem.AddedFeature().Health().OK() {
+		t.Errorf("hem unhealthy: %s", hem.AddedFeature().Health().Reason)
+	}
+}
+
+// TestSheetMetalToolsRequireInput every tool's Commit errors before its input is gathered (no
+// pick, or no developable flat) — so a half-finished tool never silently commits nothing.
+func TestSheetMetalToolsRequireInput(t *testing.T) {
+	makers := []func() Tool{
+		func() Tool { return NewSheetMetalFaceTool() },
+		func() Tool { return NewSheetMetalFlangeTool() },
+		func() Tool { return NewSheetMetalHemTool() },
+		func() Tool { return NewSheetMetalContourFlangeTool() },
+		func() Tool { return NewSheetMetalLoftedFlangeTool() },
+		func() Tool { return NewSheetMetalContourRollTool() },
+		func() Tool { return NewSheetMetalBendTool() },
+		func() Tool { return NewSheetMetalFoldTool() },
+		func() Tool { return NewSheetMetalCornerTool() },
+		func() Tool { return NewSheetMetalCornerSeamTool() },
+		func() Tool { return NewSheetMetalCutTool() },
+		func() Tool { return NewSheetMetalUnfoldTool() },
+		func() Tool { return NewSheetMetalRefoldTool() },
+	}
+	for _, mk := range makers {
+		s, _ := sheetMetalSession(t)
+		tool := mk()
+		tool.Start(s)
+		if err := tool.Commit(s); err == nil {
+			t.Errorf("%s should error before its input is gathered", tool.Name())
+		}
+		tool.Cancel(s)
 	}
 }
 

--- a/app/sheet_metal_tools_test.go
+++ b/app/sheet_metal_tools_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// sheetMetalSession returns a session whose active part is in the sheet-metal environment.
+func sheetMetalSession(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s := NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "Sheet1", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	part, err := activePart(s)
+	if err != nil {
+		t.Fatalf("activePart: %v", err)
+	}
+	if _, err := part.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	return s, part
+}
+
+// squareProfile adds a side×side square sketch on XY and returns a profile handle for it.
+func squareProfile(part *compdef.PartComponentDefinition, side float64) ProfileHandle {
+	sk := part.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(gmath.P2(0, 0))
+	c1 := sk.Points().Add(gmath.P2(side, 0))
+	c2 := sk.Points().Add(gmath.P2(side, side))
+	c3 := sk.Points().Add(gmath.P2(0, side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return ProfileHandle{Sketch: sk, ProfileIndex: 0}
+}
+
+// topXEdge returns a top X-aligned edge of the body — a valid edge to flange from.
+func topXEdge(t *testing.T, body *topo.Body) *topo.Edge {
+	t.Helper()
+	var best *topo.Edge
+	bestZ := math.Inf(-1)
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		alongX := math.Abs(a.X-b.X) > 1e-6 && math.Abs(a.Y-b.Y) < 1e-6
+		if alongX && a.Z > bestZ {
+			best, bestZ = e, a.Z
+		}
+	}
+	if best == nil {
+		t.Fatal("no X-aligned edge on the body")
+	}
+	return best
+}
+
+// TestSheetMetalCommandsEnable the Sheet Metal commands enable only on a sheet-metal part.
+func TestSheetMetalCommandsEnable(t *testing.T) {
+	s, _ := sheetMetalSession(t)
+	if !hasActiveSheetMetalPart(s) {
+		t.Error("hasActiveSheetMetalPart should be true with a sheet-metal part active")
+	}
+	if hasActiveSheetMetalPart(newSessionWithPart(t)) {
+		t.Error("hasActiveSheetMetalPart should be false with an ordinary part active")
+	}
+	for _, c := range sheetMetalTabCommands() {
+		if !c.IsEnabled(s) {
+			t.Errorf("command %q should be enabled on a sheet-metal part", c.displayName)
+		}
+	}
+}
+
+// TestSheetMetalFaceAndFlangeTools the Face tool thickens a profile into the base wall and the
+// Flange tool folds a wall on a resulting edge — both committing healthy features.
+func TestSheetMetalFaceAndFlangeTools(t *testing.T) {
+	s, part := sheetMetalSession(t)
+
+	face := NewSheetMetalFaceTool()
+	face.Start(s)
+	face.Pick(s, squareProfile(part, 4))
+	if !face.CanCommit() {
+		t.Fatal("Face tool should be ready to commit after a profile pick")
+	}
+	if err := face.Commit(s); err != nil {
+		t.Fatalf("Face commit: %v", err)
+	}
+	if !face.AddedFeature().Health().OK() {
+		t.Fatalf("base Face unhealthy: %s", face.AddedFeature().Health().Reason)
+	}
+
+	flange := NewSheetMetalFlangeTool()
+	flange.Start(s)
+	flange.Pick(s, EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])})
+	flange.SetHeight(1)
+	if !flange.CanCommit() {
+		t.Fatal("Flange tool should be ready to commit after an edge pick")
+	}
+	if err := flange.Commit(s); err != nil {
+		t.Fatalf("Flange commit: %v", err)
+	}
+	if !flange.AddedFeature().Health().OK() {
+		t.Fatalf("flange unhealthy: %s", flange.AddedFeature().Health().Reason)
+	}
+}

--- a/app/sheet_metal_wall_tools.go
+++ b/app/sheet_metal_wall_tools.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/feature"
+)
+
+// Sheet-metal wall tools (M13-F02): the Create-panel walls beyond Face and Flange. Each is an
+// interactive Tool that picks geometry and commits a wall at the active rule's gauge.
+
+// SheetMetalHemTool folds a hem (a 180° wall) back on a straight edge.
+type SheetMetalHemTool struct {
+	edge   *EdgeHandle
+	length float64
+	added  *feature.PartFeature
+}
+
+// NewSheetMetalHemTool returns a hem tool defaulting to a 6 mm fold-back.
+func NewSheetMetalHemTool() *SheetMetalHemTool { return &SheetMetalHemTool{length: 0.6} }
+
+func (t *SheetMetalHemTool) Name() string { return "Sheet Metal Hem" }
+func (t *SheetMetalHemTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+}
+func (t *SheetMetalHemTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		t.edge = &e
+	}
+}
+func (t *SheetMetalHemTool) SetLength(l float64)                { t.length = l }
+func (t *SheetMetalHemTool) Length() float64                    { return t.length }
+func (t *SheetMetalHemTool) CanCommit() bool                    { return t.edge != nil && t.length > 0 }
+func (t *SheetMetalHemTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalHemTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalHemTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal hem: pick an edge and set a positive length")
+	}
+	length := t.length
+	t.added = feature.NewSheetMetalHemFeatures(part.Features()).Add(&feature.SheetMetalHemDefinition{
+		EdgeKey: t.edge.Edge.ReferenceKey(), Length: func() float64 { return length }, Type: feature.ClosedHem,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Hem")
+}
+
+// SheetMetalContourFlangeTool sweeps an open sketch profile along a straight edge.
+type SheetMetalContourFlangeTool struct {
+	edge    *EdgeHandle
+	profile *ProfileHandle
+	added   *feature.PartFeature
+}
+
+// NewSheetMetalContourFlangeTool returns a contour-flange tool awaiting an edge and a profile.
+func NewSheetMetalContourFlangeTool() *SheetMetalContourFlangeTool {
+	return &SheetMetalContourFlangeTool{}
+}
+
+func (t *SheetMetalContourFlangeTool) Name() string { return "Sheet Metal Contour Flange" }
+func (t *SheetMetalContourFlangeTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectEdge, SelectProfile))
+}
+func (t *SheetMetalContourFlangeTool) Pick(_ *Session, sel Selectable) {
+	switch h := sel.(type) {
+	case EdgeHandle:
+		t.edge = &h
+	case ProfileHandle:
+		t.profile = &h
+	}
+}
+func (t *SheetMetalContourFlangeTool) CanCommit() bool { return t.edge != nil && t.profile != nil }
+func (t *SheetMetalContourFlangeTool) Cancel(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+func (t *SheetMetalContourFlangeTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalContourFlangeTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal contour flange: pick an edge and an open sketch profile")
+	}
+	t.added = feature.NewSheetMetalContourFlangeFeatures(part.Features()).Add(&feature.SheetMetalContourFlangeDefinition{
+		EdgeKey: t.edge.Edge.ReferenceKey(), Profile: t.profile.Sketch,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Contour Flange")
+}
+
+// SheetMetalLoftedFlangeTool lofts a wall between two sketch profiles.
+type SheetMetalLoftedFlangeTool struct {
+	profiles []ProfileHandle
+	added    *feature.PartFeature
+}
+
+// NewSheetMetalLoftedFlangeTool returns a lofted-flange tool awaiting two profiles.
+func NewSheetMetalLoftedFlangeTool() *SheetMetalLoftedFlangeTool {
+	return &SheetMetalLoftedFlangeTool{}
+}
+
+func (t *SheetMetalLoftedFlangeTool) Name() string { return "Sheet Metal Lofted Flange" }
+func (t *SheetMetalLoftedFlangeTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+}
+func (t *SheetMetalLoftedFlangeTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok && len(t.profiles) < 2 {
+		t.profiles = append(t.profiles, p)
+	}
+}
+func (t *SheetMetalLoftedFlangeTool) CanCommit() bool { return len(t.profiles) == 2 }
+func (t *SheetMetalLoftedFlangeTool) Cancel(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+func (t *SheetMetalLoftedFlangeTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalLoftedFlangeTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal lofted flange: pick two sketch profiles")
+	}
+	t.added = feature.NewSheetMetalLoftedFlangeFeatures(part.Features()).Add(&feature.SheetMetalLoftedFlangeDefinition{
+		ProfileA: t.profiles[0].Sketch, ProfileB: t.profiles[1].Sketch, Operation: ops.Join,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Lofted Flange")
+}
+
+// SheetMetalContourRollTool revolves an open profile about an axis line in the same sketch.
+type SheetMetalContourRollTool struct {
+	profile *ProfileHandle
+	axis    *SketchEntityHandle
+	angle   float64
+	added   *feature.PartFeature
+}
+
+// NewSheetMetalContourRollTool returns a contour-roll tool defaulting to a 90° roll.
+func NewSheetMetalContourRollTool() *SheetMetalContourRollTool {
+	return &SheetMetalContourRollTool{angle: halfPiAngle}
+}
+
+func (t *SheetMetalContourRollTool) Name() string { return "Sheet Metal Contour Roll" }
+func (t *SheetMetalContourRollTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectProfile, SelectSketchEntity))
+}
+func (t *SheetMetalContourRollTool) Pick(_ *Session, sel Selectable) {
+	switch h := sel.(type) {
+	case ProfileHandle:
+		t.profile = &h
+	case SketchEntityHandle:
+		t.axis = &h
+	}
+}
+func (t *SheetMetalContourRollTool) SetAngle(a float64) { t.angle = a }
+func (t *SheetMetalContourRollTool) Angle() float64     { return t.angle }
+func (t *SheetMetalContourRollTool) CanCommit() bool {
+	return t.profile != nil && t.axis != nil && t.angle > 0
+}
+func (t *SheetMetalContourRollTool) Cancel(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter())
+}
+func (t *SheetMetalContourRollTool) AddedFeature() *feature.PartFeature { return t.added }
+
+func (t *SheetMetalContourRollTool) Commit(s *Session) error {
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return err
+	}
+	if !t.CanCommit() {
+		return errors.New("sheet-metal contour roll: pick an open profile, an axis line, and set an angle")
+	}
+	_, axisIndex, ok := lineHandleInSketch(t.profile.Sketch, t.axis.Entity)
+	if !ok {
+		return errors.New("sheet-metal contour roll: the axis line must belong to the profile sketch")
+	}
+	angle := t.angle
+	t.added = feature.NewSheetMetalContourRollFeatures(part.Features()).Add(&feature.SheetMetalContourRollDefinition{
+		Profile: t.profile.Sketch, AxisLine: axisIndex, Angle: func() float64 { return angle }, Operation: ops.Join,
+	})
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Contour Roll")
+}

--- a/head/icon/assets/sheet-metal-bend.svg
+++ b/head/icon/assets/sheet-metal-bend.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 17 L11 17 A3 3 0 0 0 13 14 L18 6"/></svg>

--- a/head/icon/assets/sheet-metal-contour-flange.svg
+++ b/head/icon/assets/sheet-metal-contour-flange.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 19 H11 Q16 19 16 14 V5"/></svg>

--- a/head/icon/assets/sheet-metal-contour-roll.svg
+++ b/head/icon/assets/sheet-metal-contour-roll.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M14 5 A7 7 0 1 1 7 12"/><path d="M14 5 V11"/></svg>

--- a/head/icon/assets/sheet-metal-corner-seam.svg
+++ b/head/icon/assets/sheet-metal-corner-seam.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M5 19 V9 H10"/><path d="M14 9 H19 V19"/></svg>

--- a/head/icon/assets/sheet-metal-corner.svg
+++ b/head/icon/assets/sheet-metal-corner.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M6 19 V9 L10 5 H18"/></svg>

--- a/head/icon/assets/sheet-metal-cut.svg
+++ b/head/icon/assets/sheet-metal-cut.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 5 H21 V19 H3 Z"/><path d="M9 9 H15 V15 H9 Z"/></svg>

--- a/head/icon/assets/sheet-metal-face.svg
+++ b/head/icon/assets/sheet-metal-face.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 10 L21 10 L21 14 L3 14 Z"/></svg>

--- a/head/icon/assets/sheet-metal-flange.svg
+++ b/head/icon/assets/sheet-metal-flange.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 19 L14 19 A3 3 0 0 0 17 16 L17 5"/></svg>

--- a/head/icon/assets/sheet-metal-fold.svg
+++ b/head/icon/assets/sheet-metal-fold.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 17 H11 L18 7"/><path d="M11 17 V7"/></svg>

--- a/head/icon/assets/sheet-metal-hem.svg
+++ b/head/icon/assets/sheet-metal-hem.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M5 8 L16 8 A2 2 0 0 1 16 12 L7 12"/></svg>

--- a/head/icon/assets/sheet-metal-lofted-flange.svg
+++ b/head/icon/assets/sheet-metal-lofted-flange.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 19 L8 6 L16 6 L20 19"/></svg>

--- a/head/icon/assets/sheet-metal-refold.svg
+++ b/head/icon/assets/sheet-metal-refold.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 19 H11 L17 7"/><path d="M13 7 H17 V11"/></svg>

--- a/head/icon/assets/sheet-metal-unfold.svg
+++ b/head/icon/assets/sheet-metal-unfold.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 9 H21 V15 H3 Z"/><path d="M9 9 V15"/><path d="M15 9 V15"/></svg>


### PR DESCRIPTION
## What

Starts the **sheet-metal head UI**. Until now M13's features were drivable only programmatically (`features.add` and the `sheetMetal.*` / `flatPattern.*` wire methods); there was no GUI.

- **app**: a **Sheet Metal ribbon tab** on the part ribbon, its commands enabled only when the active part is in the sheet-metal environment (`hasActiveSheetMetalPart`).
  - **Face** — thickens a picked sketch profile into the base/secondary wall.
  - **Flange** — folds a wall on a picked straight edge.
  - Each is an interactive `Tool` (pick → set height/angle → commit), the GUI counterpart of the model API.
- **head/icon**: `sheet-metal-face` and `sheet-metal-flange` glyphs.

## Why

This is the **foundation** of the sheet-metal UI (the user asked whether the ribbon was complete — it wasn't built at all). The remaining walls (Hem, Contour/Lofted/Roll), bend/modify features (Bend, Fold, Corner, Cut, Unfold/Refold), and the flat-pattern panel follow as stacked PRs on this scaffold.

## Tests
- `app`: the Sheet Metal commands enable only on a sheet-metal part; the Face tool thickens a profile into a healthy base wall and the Flange tool folds a healthy wall on a resulting edge.
- `head`: the two new icons rasterize; the ribbon-icon coverage test passes.
- `golangci-lint` 0 issues.

Refs #370 #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)