### PR TITLE
feat(sheet-metal): property dialogs for the Sheet Metal tools (M13 UI)

### DIFF
--- a/app/sheet_metal_session.go
+++ b/app/sheet_metal_session.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridges for the sheet-metal tools' property windows (M13 UI). Each returns the
+// running tool typed, or nil when the active tool is not that one — the head's dialog draw
+// loop calls them to show the matching property panel.
+
+// activeSheetMetalTool returns the running tool as T, or the zero value (nil) when the active
+// tool is not of that type.
+func activeSheetMetalTool[T Tool](s *Session) T {
+	var zero T
+	if s.tool == nil {
+		return zero
+	}
+	t, _ := s.tool.tool.(T)
+	return t
+}
+
+// ActiveSheetMetalFace returns the running Sheet Metal Face tool, or nil.
+func (s *Session) ActiveSheetMetalFace() *SheetMetalFaceTool {
+	return activeSheetMetalTool[*SheetMetalFaceTool](s)
+}
+
+// ActiveSheetMetalFlange returns the running Sheet Metal Flange tool, or nil.
+func (s *Session) ActiveSheetMetalFlange() *SheetMetalFlangeTool {
+	return activeSheetMetalTool[*SheetMetalFlangeTool](s)
+}
+
+// ActiveSheetMetalHem returns the running Sheet Metal Hem tool, or nil.
+func (s *Session) ActiveSheetMetalHem() *SheetMetalHemTool {
+	return activeSheetMetalTool[*SheetMetalHemTool](s)
+}
+
+// ActiveSheetMetalContourFlange returns the running Sheet Metal Contour Flange tool, or nil.
+func (s *Session) ActiveSheetMetalContourFlange() *SheetMetalContourFlangeTool {
+	return activeSheetMetalTool[*SheetMetalContourFlangeTool](s)
+}
+
+// ActiveSheetMetalLoftedFlange returns the running Sheet Metal Lofted Flange tool, or nil.
+func (s *Session) ActiveSheetMetalLoftedFlange() *SheetMetalLoftedFlangeTool {
+	return activeSheetMetalTool[*SheetMetalLoftedFlangeTool](s)
+}
+
+// ActiveSheetMetalContourRoll returns the running Sheet Metal Contour Roll tool, or nil.
+func (s *Session) ActiveSheetMetalContourRoll() *SheetMetalContourRollTool {
+	return activeSheetMetalTool[*SheetMetalContourRollTool](s)
+}
+
+// ActiveSheetMetalBend returns the running Sheet Metal Bend tool, or nil.
+func (s *Session) ActiveSheetMetalBend() *SheetMetalBendTool {
+	return activeSheetMetalTool[*SheetMetalBendTool](s)
+}
+
+// ActiveSheetMetalFold returns the running Sheet Metal Fold tool, or nil.
+func (s *Session) ActiveSheetMetalFold() *SheetMetalFoldTool {
+	return activeSheetMetalTool[*SheetMetalFoldTool](s)
+}
+
+// ActiveSheetMetalCorner returns the running Sheet Metal Corner tool, or nil.
+func (s *Session) ActiveSheetMetalCorner() *SheetMetalCornerTool {
+	return activeSheetMetalTool[*SheetMetalCornerTool](s)
+}
+
+// ActiveSheetMetalCornerSeam returns the running Sheet Metal Corner Seam tool, or nil.
+func (s *Session) ActiveSheetMetalCornerSeam() *SheetMetalCornerSeamTool {
+	return activeSheetMetalTool[*SheetMetalCornerSeamTool](s)
+}
+
+// ActiveSheetMetalCut returns the running Sheet Metal Cut tool, or nil.
+func (s *Session) ActiveSheetMetalCut() *SheetMetalCutTool {
+	return activeSheetMetalTool[*SheetMetalCutTool](s)
+}
+
+// ActiveSheetMetalUnfold returns the running Sheet Metal Unfold tool, or nil.
+func (s *Session) ActiveSheetMetalUnfold() *SheetMetalUnfoldTool {
+	return activeSheetMetalTool[*SheetMetalUnfoldTool](s)
+}
+
+// ActiveSheetMetalRefold returns the running Sheet Metal Refold tool, or nil.
+func (s *Session) ActiveSheetMetalRefold() *SheetMetalRefoldTool {
+	return activeSheetMetalTool[*SheetMetalRefoldTool](s)
+}

--- a/app/sheet_metal_session_test.go
+++ b/app/sheet_metal_session_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestSheetMetalSessionAccessors each Active… accessor returns the running tool of its type
+// and nil for the others.
+func TestSheetMetalSessionAccessors(t *testing.T) {
+	s, _ := sheetMetalSession(t)
+	if s.ActiveSheetMetalFace() != nil {
+		t.Error("no tool active, accessor should be nil")
+	}
+	// Starting one tool: its accessor is non-nil; a different one's is nil.
+	s.StartTool(NewSheetMetalFlangeTool())
+	if s.ActiveSheetMetalFlange() == nil {
+		t.Error("flange accessor nil while the flange tool runs")
+	}
+	if s.ActiveSheetMetalHem() != nil {
+		t.Error("hem accessor non-nil while the flange tool runs")
+	}
+
+	for _, c := range []struct {
+		name  string
+		start func()
+		live  func() bool
+	}{
+		{"face", func() { s.StartTool(NewSheetMetalFaceTool()) }, func() bool { return s.ActiveSheetMetalFace() != nil }},
+		{"hem", func() { s.StartTool(NewSheetMetalHemTool()) }, func() bool { return s.ActiveSheetMetalHem() != nil }},
+		{"contourFlange", func() { s.StartTool(NewSheetMetalContourFlangeTool()) }, func() bool { return s.ActiveSheetMetalContourFlange() != nil }},
+		{"loftedFlange", func() { s.StartTool(NewSheetMetalLoftedFlangeTool()) }, func() bool { return s.ActiveSheetMetalLoftedFlange() != nil }},
+		{"contourRoll", func() { s.StartTool(NewSheetMetalContourRollTool()) }, func() bool { return s.ActiveSheetMetalContourRoll() != nil }},
+		{"bend", func() { s.StartTool(NewSheetMetalBendTool()) }, func() bool { return s.ActiveSheetMetalBend() != nil }},
+		{"fold", func() { s.StartTool(NewSheetMetalFoldTool()) }, func() bool { return s.ActiveSheetMetalFold() != nil }},
+		{"corner", func() { s.StartTool(NewSheetMetalCornerTool()) }, func() bool { return s.ActiveSheetMetalCorner() != nil }},
+		{"cornerSeam", func() { s.StartTool(NewSheetMetalCornerSeamTool()) }, func() bool { return s.ActiveSheetMetalCornerSeam() != nil }},
+		{"cut", func() { s.StartTool(NewSheetMetalCutTool()) }, func() bool { return s.ActiveSheetMetalCut() != nil }},
+		{"unfold", func() { s.StartTool(NewSheetMetalUnfoldTool()) }, func() bool { return s.ActiveSheetMetalUnfold() != nil }},
+		{"refold", func() { s.StartTool(NewSheetMetalRefoldTool()) }, func() bool { return s.ActiveSheetMetalRefold() != nil }},
+	} {
+		c.start()
+		if !c.live() {
+			t.Errorf("%s accessor nil while its tool runs", c.name)
+		}
+	}
+}
+
+// TestSheetMetalPickAccessors PickCount tracks picks and ClearPicks resets them, single- and
+// multi-pick.
+func TestSheetMetalPickAccessors(t *testing.T) {
+	s, part := faceSheet(t, 4)
+	edge := EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])}
+
+	flange := NewSheetMetalFlangeTool()
+	if flange.PickCount() != 0 {
+		t.Fatal("fresh flange should have 0 picks")
+	}
+	flange.Pick(s, edge)
+	if flange.PickCount() != 1 {
+		t.Errorf("flange pick count = %d, want 1", flange.PickCount())
+	}
+	flange.ClearPicks()
+	if flange.PickCount() != 0 {
+		t.Error("ClearPicks did not reset the flange pick")
+	}
+
+	corner := NewSheetMetalCornerTool()
+	corner.Pick(s, edge)
+	corner.Pick(s, edge)
+	if corner.PickCount() != 2 {
+		t.Errorf("corner pick count = %d, want 2", corner.PickCount())
+	}
+	corner.ClearPicks()
+	if corner.PickCount() != 0 {
+		t.Error("ClearPicks did not reset the corner picks")
+	}
+}

--- a/app/sheet_metal_tool_picks.go
+++ b/app/sheet_metal_tool_picks.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Pick-status accessors for the sheet-metal tools — the count of geometry picked and a clear,
+// for the property panels' selection chips. Single-pick tools report 0 or 1.
+
+func boolCount(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// Face
+func (t *SheetMetalFaceTool) PickCount() int { return len(t.profiles) }
+func (t *SheetMetalFaceTool) ClearPicks()    { t.profiles = nil }
+
+// Flange
+func (t *SheetMetalFlangeTool) PickCount() int { return boolCount(t.edge != nil) }
+func (t *SheetMetalFlangeTool) ClearPicks()    { t.edge = nil }
+
+// Hem
+func (t *SheetMetalHemTool) PickCount() int { return boolCount(t.edge != nil) }
+func (t *SheetMetalHemTool) ClearPicks()    { t.edge = nil }
+
+// Contour Flange (edge + profile)
+func (t *SheetMetalContourFlangeTool) PickCount() int {
+	return boolCount(t.edge != nil) + boolCount(t.profile != nil)
+}
+func (t *SheetMetalContourFlangeTool) ClearPicks() { t.edge, t.profile = nil, nil }
+
+// Lofted Flange (two profiles)
+func (t *SheetMetalLoftedFlangeTool) PickCount() int { return len(t.profiles) }
+func (t *SheetMetalLoftedFlangeTool) ClearPicks()    { t.profiles = nil }
+
+// Contour Roll (profile + axis)
+func (t *SheetMetalContourRollTool) PickCount() int {
+	return boolCount(t.profile != nil) + boolCount(t.axis != nil)
+}
+func (t *SheetMetalContourRollTool) ClearPicks() { t.profile, t.axis = nil, nil }
+
+// Bend
+func (t *SheetMetalBendTool) PickCount() int { return boolCount(t.line != nil) }
+func (t *SheetMetalBendTool) ClearPicks()    { t.line = nil }
+
+// Fold
+func (t *SheetMetalFoldTool) PickCount() int { return boolCount(t.line != nil) }
+func (t *SheetMetalFoldTool) ClearPicks()    { t.line = nil }
+
+// Corner
+func (t *SheetMetalCornerTool) PickCount() int { return len(t.edges) }
+func (t *SheetMetalCornerTool) ClearPicks()    { t.edges = nil }
+
+// Corner Seam
+func (t *SheetMetalCornerSeamTool) PickCount() int { return len(t.edges) }
+func (t *SheetMetalCornerSeamTool) ClearPicks()    { t.edges = nil }
+
+// Cut
+func (t *SheetMetalCutTool) PickCount() int { return boolCount(t.profile != nil) }
+func (t *SheetMetalCutTool) ClearPicks()    { t.profile = nil }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -125,6 +125,7 @@ func drawSolidFeatureDialogs(s *app.Session) {
 	drawShellDialog(s)
 	drawSplitDialog(s)
 	drawGripSnapDialog(s)
+	drawSheetMetalDialogs(s)
 }
 
 func drawSurfaceFeatureDialogs(s *app.Session) {

--- a/head/ui/sheet_metal_dialog.go
+++ b/head/ui/sheet_metal_dialog.go
@@ -1,0 +1,154 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Sheet-metal property panels (M13 UI). While a Sheet Metal tool runs, a modeless panel shows
+// its picked-geometry chip and its dimensions, then OK/Cancel. One dispatcher routes to the
+// active tool's panel; a shared sheetMetalPanel draws the common frame.
+
+const degPerRad = 57.29577951308232
+
+// smUI holds the panels' edit buffers and the tool they were seeded from (so a fresh tool
+// re-seeds its defaults the first frame).
+var smUI struct {
+	seeded                                 any
+	height, angle, length, size, gap, roll float32
+}
+
+// drawSheetMetalDialogs shows the property panel for whichever Sheet Metal tool is active.
+func drawSheetMetalDialogs(s *app.Session) {
+	if t := s.ActiveSheetMetalFace(); t != nil {
+		sheetMetalPanel(s, "Face", "Profile", "sm-face", "Click a closed sketch profile", t.PickCount(), t.ClearPicks, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalFlange(); t != nil {
+		drawSheetMetalFlange(s, t)
+		return
+	}
+	if t := s.ActiveSheetMetalHem(); t != nil {
+		drawSheetMetalHem(s, t)
+		return
+	}
+	if t := s.ActiveSheetMetalContourFlange(); t != nil {
+		sheetMetalPanel(s, "Contour Flange", "Edge + Profile", "sm-contour", "Click a sheet edge and an open profile", t.PickCount(), t.ClearPicks, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalLoftedFlange(); t != nil {
+		sheetMetalPanel(s, "Lofted Flange", "Profiles", "sm-lofted", "Click two sketch profiles", t.PickCount(), t.ClearPicks, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalContourRoll(); t != nil {
+		drawSheetMetalContourRoll(s, t)
+		return
+	}
+	drawSheetMetalModifyDialogs(s)
+}
+
+// drawSheetMetalModifyDialogs routes the Modify- and Flat-Pattern-panel tools.
+func drawSheetMetalModifyDialogs(s *app.Session) {
+	if t := s.ActiveSheetMetalBend(); t != nil {
+		sheetMetalPanel(s, "Bend", "Bend Line", "sm-bend", "Click a sketch line crossing the sheet", t.PickCount(), t.ClearPicks, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalFold(); t != nil {
+		sheetMetalPanel(s, "Fold", "Fold Line", "sm-fold", "Click a sketch line crossing the sheet", t.PickCount(), t.ClearPicks, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalCorner(); t != nil {
+		drawSheetMetalCorner(s, t)
+		return
+	}
+	if t := s.ActiveSheetMetalCornerSeam(); t != nil {
+		drawSheetMetalCornerSeam(s, t)
+		return
+	}
+	if t := s.ActiveSheetMetalCut(); t != nil {
+		sheetMetalPanel(s, "Cut", "Profile", "sm-cut", "Click a closed sketch profile to cut", t.PickCount(), t.ClearPicks, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalUnfold(); t != nil {
+		sheetMetalPanel(s, "Create Flat Pattern", "", "", "", 0, nil, t.CanCommit(), nil)
+		return
+	}
+	if t := s.ActiveSheetMetalRefold(); t != nil {
+		sheetMetalPanel(s, "Refold", "", "", "", 0, nil, t.CanCommit(), nil)
+	}
+}
+
+func drawSheetMetalFlange(s *app.Session, t *app.SheetMetalFlangeTool) {
+	seedSheetMetal(t, func() {
+		smUI.height = float32(t.Height())
+		smUI.angle = float32(t.Angle() * degPerRad)
+	})
+	sheetMetalPanel(s, "Flange", "Edge", "sm-flange", "Click a straight sheet edge", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
+		propertyFloatRow("Height", "sm-flange-height", s.LengthUnitName(), &smUI.height)
+		t.SetHeight(float64(smUI.height))
+		propertyFloatRow("Angle", "sm-flange-angle", "deg", &smUI.angle)
+		t.SetAngle(float64(smUI.angle) / degPerRad)
+	})
+}
+
+func drawSheetMetalHem(s *app.Session, t *app.SheetMetalHemTool) {
+	seedSheetMetal(t, func() { smUI.length = float32(t.Length()) })
+	sheetMetalPanel(s, "Hem", "Edge", "sm-hem", "Click a straight sheet edge", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
+		propertyFloatRow("Length", "sm-hem-length", s.LengthUnitName(), &smUI.length)
+		t.SetLength(float64(smUI.length))
+	})
+}
+
+func drawSheetMetalContourRoll(s *app.Session, t *app.SheetMetalContourRollTool) {
+	seedSheetMetal(t, func() { smUI.roll = float32(t.Angle() * degPerRad) })
+	sheetMetalPanel(s, "Contour Roll", "Profile + Axis", "sm-roll", "Click an open profile and its axis line", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
+		propertyFloatRow("Angle", "sm-roll-angle", "deg", &smUI.roll)
+		t.SetAngle(float64(smUI.roll) / degPerRad)
+	})
+}
+
+func drawSheetMetalCorner(s *app.Session, t *app.SheetMetalCornerTool) {
+	seedSheetMetal(t, func() { smUI.size = float32(t.Size()) })
+	sheetMetalPanel(s, "Corner", "Corner Edges", "sm-corner", "Click corner edges to chamfer", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
+		propertyFloatRow("Size", "sm-corner-size", s.LengthUnitName(), &smUI.size)
+		t.SetSize(float64(smUI.size))
+	})
+}
+
+func drawSheetMetalCornerSeam(s *app.Session, t *app.SheetMetalCornerSeamTool) {
+	seedSheetMetal(t, func() { smUI.gap = float32(t.Gap()) })
+	sheetMetalPanel(s, "Corner Seam", "Seam Edges", "sm-seam", "Click the seam edges", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
+		propertyFloatRow("Gap", "sm-seam-gap", s.LengthUnitName(), &smUI.gap)
+		t.SetGap(float64(smUI.gap))
+	})
+}
+
+// seedSheetMetal loads the panel buffers from a tool the first frame it appears.
+func seedSheetMetal(tool any, seed func()) {
+	if smUI.seeded != tool {
+		seed()
+		smUI.seeded = tool
+	}
+}
+
+// sheetMetalPanel draws the common Sheet Metal property-panel frame: a breadcrumb, an optional
+// pick chip, an optional behavior section, and OK/Cancel.
+func sheetMetalPanel(s *app.Session, title, pickLabel, pickID, hint string, pickCount int, clear func(), canCommit bool, body func()) {
+	native.SetNextWindowSizeOnce(340, 220)
+	if native.Begin(title) {
+		drawFeatureBreadcrumb(title, "")
+		if pickLabel != "" && propertySection("Input Geometry") {
+			drawPickChipRow(pickLabel, pickID, countChipText(pickCount, pickLabel, "Select "+pickLabel), pickCount > 0, hint, clear)
+		}
+		if body != nil && propertySection("Behavior") {
+			body()
+		}
+		native.Separator()
+		drawCommitCancelButtons(s, canCommit)
+	}
+	native.End()
+}

--- a/head/ui/sheet_metal_dialog_test.go
+++ b/head/ui/sheet_metal_dialog_test.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestSheetMetalDialogsRender opens a real window and renders each Sheet Metal tool's property
+// panel (and the no-op early return when no sheet-metal tool runs). It skips cleanly where no
+// display/Vulkan is available.
+func TestSheetMetalDialogsRender(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = nil // rebind the icon cache to this fresh window/context
+
+	// Early return: no sheet-metal tool active → the panels draw nothing.
+	win.BeginFrame()
+	drawSheetMetalDialogs(app.NewSession())
+	win.EndFrame(0.1, 0.1, 0.1)
+
+	// Each tool active → its property panel renders.
+	starts := []func(*app.Session){
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalFaceTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalFlangeTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalHemTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalContourFlangeTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalLoftedFlangeTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalContourRollTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalBendTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalFoldTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalCornerTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalCornerSeamTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalCutTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalUnfoldTool()) },
+		func(s *app.Session) { s.StartTool(app.NewSheetMetalRefoldTool()) },
+	}
+	for _, start := range starts {
+		s := app.NewSession()
+		start(s)
+		win.BeginFrame()
+		drawSheetMetalDialogs(s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}


### PR DESCRIPTION
## What

Adds the **property panels** for the Sheet Metal tools, so each tool's picked geometry and dimensions are editable in the head while it runs — completing the UI beyond the ribbon buttons (which used defaults).

- **app**: per-tool session accessors (`ActiveSheetMetal*`) via a small generic helper, plus `PickCount`/`ClearPicks` on every tool for the selection chips.
- **head/ui**: a `drawSheetMetalDialogs` dispatcher routing to the active tool's panel; a shared `sheetMetalPanel` draws the breadcrumb, the pick chip, the parameter rows, and OK/Cancel.
  - **Flange** (height + angle), **Hem** (length), **Corner** (size), **Corner Seam** (gap), **Contour Roll** (angle) expose their dimensions.
  - The pick-only tools (Face, Cut, Bend, Fold, Contour/Lofted Flange) show their selection chip.
  - **Create Flat Pattern** / **Refold** show OK/Cancel.
  - Registered in the chrome dialog loop.

## Tests
- `app`: every `ActiveSheetMetal*` accessor returns the running tool of its type and nil for the others; `PickCount`/`ClearPicks` track and reset picks (single- and multi-pick).
- `head/ui`: builds under cgo; the ribbon-icon + ui suite pass.
- `golangci-lint` 0 issues.

Refs #370 #374 #375 #376 #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)