### PR TITLE
fix(sheet-metal): develop the bend on unfold/refold (fix broken bend + cut-through)

### DIFF
--- a/kernel/ops/deform.go
+++ b/kernel/ops/deform.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// DeformBody returns a copy of b with every vertex moved by the non-affine map fn, preserving
+// the exact combinatorial topology. Unlike [TransformBody] (which carries an affine matrix on
+// curves/surfaces), DeformBody is for POLYHEDRAL bodies: every edge is rebuilt as a straight
+// segment between its moved endpoints and every face's plane is re-fitted through its moved
+// loop. It is the engine behind sheet-metal develop/refold, where a bend is unrolled or rolled
+// by a cylindrical point map — any cut made while flat moves with its vertices, so it is carried
+// through the bend without a separate entity map.
+//
+// fn must be applied consistently to coincident points (it is a pure function of position), so
+// shared vertices stay welded. Faces that are badly non-planar after the map yield a degenerate
+// plane error — subdivide the bend finely enough (small facet steps) that each face stays
+// near-planar, exactly as the faceted bend arc already is.
+func DeformBody(b *topo.Body, fn func(math.Point3) math.Point3, derive func(topo.Lineage) topo.Lineage) (*topo.Body, error) {
+	bld := topo.NewBuilder(b.IsSolid(), derive(b.Lineage()))
+
+	verts := make(map[*topo.Vertex]*topo.Vertex, len(b.Vertices()))
+	for _, v := range b.Vertices() {
+		verts[v] = bld.AddVertex(fn(v.Point()), derive(v.Lineage()))
+	}
+	edges := make(map[*topo.Edge]*topo.Edge, len(b.Edges()))
+	for _, e := range b.Edges() {
+		s, t := verts[e.StartVertex()], verts[e.EndVertex()]
+		if s.Point().DistanceTo(t.Point()) < deformTol {
+			return nil, fmt.Errorf("ops.DeformBody: edge %d collapsed to a point under the map", e.ID())
+		}
+		edges[e] = bld.AddEdge(geom.NewLineSegment(s.Point(), t.Point()), s, t, derive(e.Lineage()))
+	}
+	for _, f := range b.Faces() {
+		if err := deformFaceInto(bld, f, edges, derive); err != nil {
+			return nil, err
+		}
+	}
+	return bld.Build(), nil
+}
+
+// deformTol is the minimum moved-edge length below which the map is treated as collapsing an
+// edge (a degenerate result the boolean kernel cannot use).
+const deformTol = 1e-9
+
+// deformFaceInto clones one face with a plane re-fitted through its moved outer loop, preserving
+// the face's material sense (a reversed cut/bore wall must stay reversed or its tessellation
+// winds inward and the divergence-theorem volume flips on it).
+func deformFaceInto(bld *topo.Builder, f *topo.Face, edges map[*topo.Edge]*topo.Edge, derive func(topo.Lineage) topo.Lineage) error {
+	plane, err := refitPlane(f, edges)
+	if err != nil {
+		return fmt.Errorf("ops.DeformBody: face %d: %w", f.ID(), err)
+	}
+	if f.Reversed() {
+		bld.AddReversedFace(plane, derive(f.Lineage()), loopSpecs(f, edges, false)...)
+		return nil
+	}
+	bld.AddFace(plane, derive(f.Lineage()), loopSpecs(f, edges, false)...)
+	return nil
+}
+
+// refitPlane fits a plane through a face's moved outer-loop vertices. The normal follows the
+// loop winding (Newell's method) so it stays consistent with the preserved loop orientation,
+// and the origin is the loop's centroid. It errors when the moved loop is degenerate (all
+// points collinear ⇒ zero-area normal).
+func refitPlane(f *topo.Face, edges map[*topo.Edge]*topo.Edge) (geom.Plane, error) {
+	pts := movedOuterLoopPoints(f, edges)
+	if len(pts) < 3 {
+		return geom.Plane{}, fmt.Errorf("outer loop has %d moved vertices, need ≥3", len(pts))
+	}
+	var n math.Vector3
+	var c math.Vector3
+	for i := range pts {
+		a, b := pts[i], pts[(i+1)%len(pts)]
+		n = n.Add(math.V3((a.Y-b.Y)*(a.Z+b.Z), (a.Z-b.Z)*(a.X+b.X), (a.X-b.X)*(a.Y+b.Y)))
+		c = c.Add(a.AsVector())
+	}
+	if n.Length() < deformTol {
+		return geom.Plane{}, fmt.Errorf("moved outer loop is degenerate (zero-area)")
+	}
+	origin := math.P3(c.X/float64(len(pts)), c.Y/float64(len(pts)), c.Z/float64(len(pts)))
+	return geom.NewPlane(origin, n)
+}
+
+// movedOuterLoopPoints walks a face's outer loop and returns its vertices' positions on the
+// already-moved (cloned) edges, in loop order.
+func movedOuterLoopPoints(f *topo.Face, edges map[*topo.Edge]*topo.Edge) []math.Point3 {
+	for _, l := range f.Loops() {
+		if !l.IsOuter() {
+			continue
+		}
+		uses := l.EdgeUses()
+		pts := make([]math.Point3, 0, len(uses))
+		for _, u := range uses {
+			clone := edges[u.Edge()]
+			v := clone.StartVertex()
+			if u.Reversed() {
+				v = clone.EndVertex()
+			}
+			pts = append(pts, v.Point())
+		}
+		return pts
+	}
+	return nil
+}

--- a/kernel/ops/deform_test.go
+++ b/kernel/ops/deform_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// identityLineage keeps lineage unchanged under a deform (the test bodies carry none anyway).
+func identityLineage(l topo.Lineage) topo.Lineage { return l }
+
+// TestDeformBodyIdentity an identity map reproduces the body exactly — same volume, still a
+// valid closed solid.
+func TestDeformBodyIdentity(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 3, 4) // volume 24
+	out, err := ops.DeformBody(box, func(p math.Point3) math.Point3 { return p }, identityLineage)
+	if err != nil {
+		t.Fatalf("DeformBody: %v", err)
+	}
+	if r := ops.Validate(out); !r.Valid {
+		t.Fatalf("identity deform invalid: %v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(out, ops.DefaultQuality()).Volume; stdmath.Abs(v-24) > 1e-6 {
+		t.Errorf("identity deform volume = %v, want 24", v)
+	}
+}
+
+// TestDeformBodyShearPreservesVolume a shear (x += 0.5·z) keeps a box a valid solid of the same
+// volume — the non-affine path the affine TransformBody cannot take but DeformBody must.
+func TestDeformBodyShearPreservesVolume(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2) // volume 8
+	shear := func(p math.Point3) math.Point3 { return math.P3(p.X+0.5*p.Z, p.Y, p.Z) }
+	out, err := ops.DeformBody(box, shear, identityLineage)
+	if err != nil {
+		t.Fatalf("DeformBody: %v", err)
+	}
+	if r := ops.Validate(out); !r.Valid {
+		t.Fatalf("sheared box invalid: %v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(out, ops.DefaultQuality()).Volume; stdmath.Abs(v-8) > 1e-6 {
+		t.Errorf("sheared box volume = %v, want 8 (shear preserves volume)", v)
+	}
+}
+
+// TestDeformBodyRigidMatchesMove a rigid map (translate) leaves the volume unchanged and the
+// body valid — the deform must agree with a Move on the affine subset.
+func TestDeformBodyRigidMatchesMove(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 1, 1, 1)
+	out, err := ops.DeformBody(box, func(p math.Point3) math.Point3 {
+		return math.P3(p.X+5, p.Y-2, p.Z+1)
+	}, identityLineage)
+	if err != nil {
+		t.Fatalf("DeformBody: %v", err)
+	}
+	if r := ops.Validate(out); !r.Valid {
+		t.Fatalf("translated box invalid: %v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(out, ops.DefaultQuality()).Volume; stdmath.Abs(v-1) > 1e-6 {
+		t.Errorf("translated box volume = %v, want 1", v)
+	}
+	if c := out.RangeBox().Center(); stdmath.Abs(c.X-5.5) > 1e-6 || stdmath.Abs(c.Y-(-1.5)) > 1e-6 {
+		t.Errorf("translated box centre = %v, want ~(5.5,-1.5,1.5)", c)
+	}
+}

--- a/model/compdef/sheet_metal_unfold.go
+++ b/model/compdef/sheet_metal_unfold.go
@@ -5,8 +5,8 @@ package compdef
 import (
 	"fmt"
 
-	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sheetmetal"
 )
 
 // Unfold/Refold features (M13-F04, #377). These flatten and re-fold the running body in the
@@ -35,21 +35,20 @@ func (d *PartComponentDefinition) AddRefold() (*feature.PartFeature, error) {
 	return feature.NewSheetMetalRefoldFeatures(d.features).Add(&feature.SheetMetalRefoldDefinition{Bends: bends}), nil
 }
 
-// bendTransforms bakes one [feature.BendTransform] per recorded edge bend: the bend line, the
-// base sheet normal (which fixes the split plane), and the fold angle.
+// bendTransforms bakes one [feature.BendTransform] per recorded edge bend: the bend line, its
+// fold frame, and the rule-developed neutral-fibre radius (the developed length per radian), so
+// the unfold/refold map unrolls each bend at the correct length for the active unfold method.
 func (d *PartComponentDefinition) bendTransforms(op string) ([]feature.BendTransform, error) {
 	if d.sheetMetal == nil {
 		return nil, fmt.Errorf("%s: the active part is not a sheet-metal part", op)
 	}
-	base, ok := d.baseFace()
-	if !ok {
+	if _, ok := d.baseFace(); !ok {
 		return nil, fmt.Errorf("%s: the part has no base Face", op)
 	}
-	normal := base.Definition().Sketch.Plane().Normal().AsVector()
 	var out []feature.BendTransform
 	fs := d.features
 	for i := 0; i < fs.Count(); i++ {
-		if bt, ok := bakeBendTransform(fs.Item(i), normal); ok {
+		if bt, ok := bakeBendTransform(fs.Item(i), d.sheetMetal); ok {
 			out = append(out, bt)
 		}
 	}
@@ -60,8 +59,10 @@ func (d *PartComponentDefinition) bendTransforms(op string) ([]feature.BendTrans
 }
 
 // bakeBendTransform turns one feature's recorded bend placement into a transform, or ok=false
-// when it is not a healthy placed edge bend.
-func bakeBendTransform(pf *feature.PartFeature, baseNormal math.Vector3) (feature.BendTransform, bool) {
+// when it is not a healthy placed edge bend. The neutral-fibre radius is the rule's developed
+// length for this bend divided by its angle (so it honours the active unfold method — K-factor,
+// bend table, or equation — not just a fixed K-factor).
+func bakeBendTransform(pf *feature.PartFeature, rule *sheetmetal.Rule) (feature.BendTransform, bool) {
 	if pf.Suppressed() || !pf.Health().OK() {
 		return feature.BendTransform{}, false
 	}
@@ -70,13 +71,17 @@ func bakeBendTransform(pf *feature.PartFeature, baseNormal math.Vector3) (featur
 		return feature.BendTransform{}, false
 	}
 	p, ok := placed.Placement()
-	if !ok {
+	if !ok || p.Angle <= 0 {
 		return feature.BendTransform{}, false
 	}
 	return feature.BendTransform{
-		LinePoint:  p.AxisStart,
-		LineDir:    p.AxisStart.VectorTo(p.AxisEnd),
-		BaseNormal: baseNormal,
-		Angle:      p.Angle,
+		LinePoint: p.AxisStart,
+		LineDir:   p.AxisStart.VectorTo(p.AxisEnd),
+		Up:        p.Up.AsVector(),
+		Out:       p.Outward.AsVector(),
+		Angle:     p.Angle,
+		Radius:    p.Radius,
+		Thickness: p.Thickness,
+		Neutral:   rule.BendAllowance(p.Angle, p.Radius) / p.Angle,
 	}, true
 }

--- a/model/compdef/sheet_metal_unfold_test.go
+++ b/model/compdef/sheet_metal_unfold_test.go
@@ -13,6 +13,52 @@ import (
 	"oblikovati.org/model/sketch"
 )
 
+// TestCutCrossingBendSurvivesRefold a slot cut while flat that STRADDLES the bend line is
+// carried fully through the bend on refold — reaching the base, the bend region, and the
+// flange. The regression for the rigid-rotation defect, where the bend stayed curved so a
+// crossing cut reached only one face: the refolded volume must match the flat-cut volume (if
+// the bend region kept its material, the refolded volume would be higher).
+func TestCutCrossingBendSurvivesRefold(t *testing.T) {
+	d, _ := sheetWithFlange(t) // base y∈[0,4]; flange on the y=0 edge, develops into −Y
+	foldedVol := flatVolume(d.Features().Result()[0])
+
+	if _, err := d.AddUnfold(); err != nil {
+		t.Fatalf("AddUnfold: %v", err)
+	}
+	d.Recompute()
+	assertFlatSolid(t, d.Features().Result()[0]) // the bend developed to a proper flat strip
+
+	// A slot crossing y=0: from the base (y>0) through the bend region into the flange (y<0).
+	sk := d.Sketches().Add(sketch.XYPlane())
+	a := sk.Points().Add(gmath.P2(1.6, -0.6))
+	b := sk.Points().Add(gmath.P2(2.4, -0.6))
+	c := sk.Points().Add(gmath.P2(2.4, 0.6))
+	e := sk.Points().Add(gmath.P2(1.6, 0.6))
+	sk.Lines().Add(a, b)
+	sk.Lines().Add(b, c)
+	sk.Lines().Add(c, e)
+	sk.Lines().Add(e, a)
+	cut := feature.NewSheetMetalCutFeatures(d.features).Add(&feature.SheetMetalCutDefinition{Sketch: sk, ProfileIndex: 0})
+	d.Recompute()
+	if !cut.Health().OK() {
+		t.Fatalf("slot crossing the bend (flat) unhealthy: %s", cut.Health().Reason)
+	}
+	flatCutVol := flatVolume(d.Features().Result()[0])
+	if !(flatCutVol < foldedVol) {
+		t.Fatalf("slot removed no material: %.4f vs %.4f", flatCutVol, foldedVol)
+	}
+
+	if _, err := d.AddRefold(); err != nil {
+		t.Fatalf("AddRefold: %v", err)
+	}
+	d.Recompute()
+	refolded := d.Features().Result()[0]
+	assertFlatSolid(t, refolded)
+	if v := flatVolume(refolded); math.Abs(v-flatCutVol)/flatCutVol > 0.02 {
+		t.Errorf("refolded volume %.4f != flat-cut %.4f: the slot was not carried through the bend (one face kept its material)", v, flatCutVol)
+	}
+}
+
 // maxZ returns the body's highest vertex Z — the out-of-plane extent that drops to ~the gauge
 // when the part is flat and rises again when refolded.
 func maxZ(b *topo.Body) float64 {

--- a/model/compdef/sheet_metal_unfold_test.go
+++ b/model/compdef/sheet_metal_unfold_test.go
@@ -13,6 +13,50 @@ import (
 	"oblikovati.org/model/sketch"
 )
 
+// cutRectangle adds a closed rectangle (two opposite corners) on the XY plane and returns the
+// sketch — the cut profile the unfold/refold round-trip tests develop.
+func cutRectangle(d *PartComponentDefinition, x1, y1, x2, y2 float64) *sketch.Sketch {
+	sk := d.Sketches().Add(sketch.XYPlane())
+	a := sk.Points().Add(gmath.P2(x1, y1))
+	b := sk.Points().Add(gmath.P2(x2, y1))
+	c := sk.Points().Add(gmath.P2(x2, y2))
+	e := sk.Points().Add(gmath.P2(x1, y2))
+	sk.Lines().Add(a, b)
+	sk.Lines().Add(b, c)
+	sk.Lines().Add(c, e)
+	sk.Lines().Add(e, a)
+	return sk
+}
+
+// unfoldCutRefold runs the cut-while-flat round trip on d: unfold flat, cut the rectangle
+// through the developed part, then refold. It fails the test if any step is unhealthy or the
+// cut removes no material, and returns the folded, flat-cut, and refolded volumes — so each
+// caller asserts the carry-back (refolded ≈ flat-cut) for its own cut placement.
+func unfoldCutRefold(t *testing.T, d *PartComponentDefinition, x1, y1, x2, y2 float64) (folded, flatCut, refolded float64) {
+	t.Helper()
+	folded = flatVolume(d.Features().Result()[0])
+	if _, err := d.AddUnfold(); err != nil {
+		t.Fatalf("AddUnfold: %v", err)
+	}
+	d.Recompute()
+	assertFlatSolid(t, d.Features().Result()[0]) // the bend developed to a proper flat strip
+	cut := feature.NewSheetMetalCutFeatures(d.features).Add(&feature.SheetMetalCutDefinition{Sketch: cutRectangle(d, x1, y1, x2, y2), ProfileIndex: 0})
+	d.Recompute()
+	if !cut.Health().OK() {
+		t.Fatalf("cut on the flat unhealthy: %s", cut.Health().Reason)
+	}
+	flatCut = flatVolume(d.Features().Result()[0])
+	if !(flatCut < folded) {
+		t.Fatalf("cut removed no material: %.4f vs %.4f", flatCut, folded)
+	}
+	if _, err := d.AddRefold(); err != nil {
+		t.Fatalf("AddRefold: %v", err)
+	}
+	d.Recompute()
+	assertFlatSolid(t, d.Features().Result()[0])
+	return folded, flatCut, flatVolume(d.Features().Result()[0])
+}
+
 // TestCutCrossingBendSurvivesRefold a slot cut while flat that STRADDLES the bend line is
 // carried fully through the bend on refold — reaching the base, the bend region, and the
 // flange. The regression for the rigid-rotation defect, where the bend stayed curved so a
@@ -20,42 +64,10 @@ import (
 // the bend region kept its material, the refolded volume would be higher).
 func TestCutCrossingBendSurvivesRefold(t *testing.T) {
 	d, _ := sheetWithFlange(t) // base y∈[0,4]; flange on the y=0 edge, develops into −Y
-	foldedVol := flatVolume(d.Features().Result()[0])
-
-	if _, err := d.AddUnfold(); err != nil {
-		t.Fatalf("AddUnfold: %v", err)
-	}
-	d.Recompute()
-	assertFlatSolid(t, d.Features().Result()[0]) // the bend developed to a proper flat strip
-
 	// A slot crossing y=0: from the base (y>0) through the bend region into the flange (y<0).
-	sk := d.Sketches().Add(sketch.XYPlane())
-	a := sk.Points().Add(gmath.P2(1.6, -0.6))
-	b := sk.Points().Add(gmath.P2(2.4, -0.6))
-	c := sk.Points().Add(gmath.P2(2.4, 0.6))
-	e := sk.Points().Add(gmath.P2(1.6, 0.6))
-	sk.Lines().Add(a, b)
-	sk.Lines().Add(b, c)
-	sk.Lines().Add(c, e)
-	sk.Lines().Add(e, a)
-	cut := feature.NewSheetMetalCutFeatures(d.features).Add(&feature.SheetMetalCutDefinition{Sketch: sk, ProfileIndex: 0})
-	d.Recompute()
-	if !cut.Health().OK() {
-		t.Fatalf("slot crossing the bend (flat) unhealthy: %s", cut.Health().Reason)
-	}
-	flatCutVol := flatVolume(d.Features().Result()[0])
-	if !(flatCutVol < foldedVol) {
-		t.Fatalf("slot removed no material: %.4f vs %.4f", flatCutVol, foldedVol)
-	}
-
-	if _, err := d.AddRefold(); err != nil {
-		t.Fatalf("AddRefold: %v", err)
-	}
-	d.Recompute()
-	refolded := d.Features().Result()[0]
-	assertFlatSolid(t, refolded)
-	if v := flatVolume(refolded); math.Abs(v-flatCutVol)/flatCutVol > 0.02 {
-		t.Errorf("refolded volume %.4f != flat-cut %.4f: the slot was not carried through the bend (one face kept its material)", v, flatCutVol)
+	_, flatCut, refolded := unfoldCutRefold(t, d, 1.6, -0.6, 2.4, 0.6)
+	if math.Abs(refolded-flatCut)/flatCut > 0.02 {
+		t.Errorf("refolded volume %.4f != flat-cut %.4f: the slot was not carried through the bend (one face kept its material)", refolded, flatCut)
 	}
 }
 
@@ -125,46 +137,13 @@ func TestUnfoldRefoldRoundTrip(t *testing.T) {
 // unfold/refold are body transforms, the cut is part of the topology, not lost.
 func TestCutWhileFlatSurvivesRefold(t *testing.T) {
 	d, _ := sheetWithFlange(t) // flange on the y=0 top edge; unfolded it extends into −Y
-	foldedVol := flatVolume(d.Features().Result()[0])
-
-	if _, err := d.AddUnfold(); err != nil {
-		t.Fatalf("AddUnfold: %v", err)
+	// A 0.4×0.4 hole wholly on the developed flange (y in [−0.8,−0.4]) — away from the bend.
+	folded, flatCut, refolded := unfoldCutRefold(t, d, 1.8, -0.8, 2.2, -0.4)
+	if math.Abs(refolded-flatCut)/flatCut > 0.02 {
+		t.Errorf("refold volume %.4f != flat-cut volume %.4f (the cut was not carried back)", refolded, flatCut)
 	}
-	d.Recompute()
-
-	// Cut a 0.4×0.4 square hole through the developed flange (y in [−0.8,−0.4] lies on it).
-	sk := d.Sketches().Add(sketch.XYPlane())
-	a := sk.Points().Add(gmath.P2(1.8, -0.8))
-	b := sk.Points().Add(gmath.P2(2.2, -0.8))
-	c := sk.Points().Add(gmath.P2(2.2, -0.4))
-	e := sk.Points().Add(gmath.P2(1.8, -0.4))
-	sk.Lines().Add(a, b)
-	sk.Lines().Add(b, c)
-	sk.Lines().Add(c, e)
-	sk.Lines().Add(e, a)
-	cut := feature.NewSheetMetalCutFeatures(d.features).Add(&feature.SheetMetalCutDefinition{Sketch: sk, ProfileIndex: 0})
-	d.Recompute()
-	if !cut.Health().OK() {
-		t.Fatalf("cut on the flat flange unhealthy: %s", cut.Health().Reason)
-	}
-	flatCutVol := flatVolume(d.Features().Result()[0])
-	if !(flatCutVol < foldedVol) {
-		t.Fatalf("cut did not remove material: %.4f vs %.4f", flatCutVol, foldedVol)
-	}
-
-	if _, err := d.AddRefold(); err != nil {
-		t.Fatalf("AddRefold: %v", err)
-	}
-	d.Recompute()
-	refolded := d.Features().Result()[0]
-	assertFlatSolid(t, refolded)
-	// The hole survives refold: volume stays reduced (matches the flat-cut volume) and the
-	// flange is folded up again.
-	if v := flatVolume(refolded); math.Abs(v-flatCutVol)/flatCutVol > 0.02 {
-		t.Errorf("refold volume %.4f != flat-cut volume %.4f (the cut was not carried back)", v, flatCutVol)
-	}
-	if v := flatVolume(refolded); !(v < foldedVol) {
-		t.Errorf("refolded part volume %.4f should stay below the uncut folded %.4f", v, foldedVol)
+	if !(refolded < folded) {
+		t.Errorf("refolded part volume %.4f should stay below the uncut folded %.4f", refolded, folded)
 	}
 }
 

--- a/model/feature/bend_lineage.go
+++ b/model/feature/bend_lineage.go
@@ -35,6 +35,7 @@ type BendSpec struct {
 type BendPlacement struct {
 	AxisStart, AxisEnd math.Point3      // the bend line — the picked edge's endpoints
 	Outward            math.UnitVector3 // in-plane direction the flat tab extends (away from the sheet)
+	Up                 math.UnitVector3 // fold normal: the bend-axis centre is the bend line + Up·Radius (M13-F04 develop)
 	Angle, Radius      float64          // swept bend angle (radians) and inside radius (cm)
 	Thickness, Length  float64          // material thickness and the flange's straight-run length (cm)
 	FoldDown           bool             // the bend folds the material toward the back (a flipped flange) ⇒ a bend-down fold line

--- a/model/feature/serialize_sheet_metal_unfold.go
+++ b/model/feature/serialize_sheet_metal_unfold.go
@@ -15,10 +15,14 @@ import (
 
 // bendTransformData is one persisted bend transform.
 type bendTransformData struct {
-	LinePoint  []float64 `yaml:"linePoint"`
-	LineDir    []float64 `yaml:"lineDir"`
-	BaseNormal []float64 `yaml:"baseNormal"`
-	Angle      float64   `yaml:"angle"`
+	LinePoint []float64 `yaml:"linePoint"`
+	LineDir   []float64 `yaml:"lineDir"`
+	Up        []float64 `yaml:"up"`
+	Out       []float64 `yaml:"out"`
+	Angle     float64   `yaml:"angle"`
+	Radius    float64   `yaml:"radius"`
+	Thickness float64   `yaml:"thickness"`
+	Neutral   float64   `yaml:"neutral"`
 }
 
 // SheetMetalUnfoldData / SheetMetalRefoldData persist the bend list of an unfold / refold.
@@ -34,10 +38,14 @@ func serializeBendTransforms(bends []BendTransform) []bendTransformData {
 	out := make([]bendTransformData, len(bends))
 	for i, b := range bends {
 		out[i] = bendTransformData{
-			LinePoint:  []float64{b.LinePoint.X, b.LinePoint.Y, b.LinePoint.Z},
-			LineDir:    []float64{b.LineDir.X, b.LineDir.Y, b.LineDir.Z},
-			BaseNormal: []float64{b.BaseNormal.X, b.BaseNormal.Y, b.BaseNormal.Z},
-			Angle:      b.Angle,
+			LinePoint: []float64{b.LinePoint.X, b.LinePoint.Y, b.LinePoint.Z},
+			LineDir:   []float64{b.LineDir.X, b.LineDir.Y, b.LineDir.Z},
+			Up:        []float64{b.Up.X, b.Up.Y, b.Up.Z},
+			Out:       []float64{b.Out.X, b.Out.Y, b.Out.Z},
+			Angle:     b.Angle,
+			Radius:    b.Radius,
+			Thickness: b.Thickness,
+			Neutral:   b.Neutral,
 		}
 	}
 	return out
@@ -47,14 +55,18 @@ func serializeBendTransforms(bends []BendTransform) []bendTransformData {
 func restoreBendTransforms(data []bendTransformData) ([]BendTransform, error) {
 	out := make([]BendTransform, len(data))
 	for i, d := range data {
-		if len(d.LinePoint) != 3 || len(d.LineDir) != 3 || len(d.BaseNormal) != 3 {
+		if len(d.LinePoint) != 3 || len(d.LineDir) != 3 || len(d.Up) != 3 || len(d.Out) != 3 {
 			return nil, fmt.Errorf("sheet-metal unfold: bend %d has a malformed [x,y,z] triple", i)
 		}
 		out[i] = BendTransform{
-			LinePoint:  math.P3(d.LinePoint[0], d.LinePoint[1], d.LinePoint[2]),
-			LineDir:    math.V3(d.LineDir[0], d.LineDir[1], d.LineDir[2]),
-			BaseNormal: math.V3(d.BaseNormal[0], d.BaseNormal[1], d.BaseNormal[2]),
-			Angle:      d.Angle,
+			LinePoint: math.P3(d.LinePoint[0], d.LinePoint[1], d.LinePoint[2]),
+			LineDir:   math.V3(d.LineDir[0], d.LineDir[1], d.LineDir[2]),
+			Up:        math.V3(d.Up[0], d.Up[1], d.Up[2]),
+			Out:       math.V3(d.Out[0], d.Out[1], d.Out[2]),
+			Angle:     d.Angle,
+			Radius:    d.Radius,
+			Thickness: d.Thickness,
+			Neutral:   d.Neutral,
 		}
 	}
 	return out, nil

--- a/model/feature/sheet_metal_develop.go
+++ b/model/feature/sheet_metal_develop.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Sheet-metal bend development (M13-F04, #377). A bend develops by a non-affine point map that
+// unrolls (unfold) or rolls (refold) the bend region around its neutral fibre, applied to the
+// whole body by [ops.DeformBody]. Because the map moves every vertex — including those a cut
+// added while flat — a slot that crosses the bend rides through it on refold, with no separate
+// folded↔flat entity map. This replaces the earlier rigid-rotation approximation, which left
+// the bend arc curved (so the bend looked broken and a crossing cut reached only one face).
+//
+// Frame (from the flange's recorded [BendPlacement]): the bend line lies on the inner surface
+// (radius r from the bend-axis centre, which is the line offset by Up·r). `out` is the in-plane
+// direction toward the flange; `up` is the fold normal. A point of the folded body at swept
+// angle φ ∈ [0, angle] and radius ρ ∈ [r, r+t] develops to flat at across-distance φ·ρ_neutral
+// from the bend line (neutral-fibre arc length) and through-thickness offset (r−ρ) along up;
+// the straight flange beyond the arc continues at across ≥ angle·ρ_neutral.
+
+// bendDevelop is the resolved frame + dimensions for developing one bend, both directions.
+type bendDevelop struct {
+	line                              math.Point3      // a point on the inner-edge bend line
+	dir, up, out                      math.UnitVector3 // bend-line, fold-normal, in-plane-outward axes
+	radius, thickness, angle, neutral float64          // inside radius, gauge, swept angle, neutral-fibre radius
+}
+
+// newBendDevelop resolves and validates the development frame from a baked transform.
+func newBendDevelop(bt BendTransform) (bendDevelop, error) {
+	dir, err := math.UnitVector3FromVector(bt.LineDir)
+	if err != nil {
+		return bendDevelop{}, fmt.Errorf("sheet-metal develop: degenerate bend line direction %v", bt.LineDir)
+	}
+	up, err := math.UnitVector3FromVector(bt.Up)
+	if err != nil {
+		return bendDevelop{}, fmt.Errorf("sheet-metal develop: degenerate fold normal %v", bt.Up)
+	}
+	out, err := math.UnitVector3FromVector(bt.Out)
+	if err != nil {
+		return bendDevelop{}, fmt.Errorf("sheet-metal develop: degenerate outward direction %v", bt.Out)
+	}
+	if bt.Angle <= 0 || bt.Radius <= 0 || bt.Neutral <= 0 {
+		return bendDevelop{}, fmt.Errorf("sheet-metal develop: angle/radius/neutral must be positive (a=%g r=%g n=%g)", bt.Angle, bt.Radius, bt.Neutral)
+	}
+	return bendDevelop{line: bt.LinePoint, dir: dir, up: up, out: out, radius: bt.Radius, thickness: bt.Thickness, angle: bt.Angle, neutral: bt.Neutral}, nil
+}
+
+// lineAt returns the bend-line point sharing q's coordinate along the bend axis (so the map is
+// a pure section-plane transform that preserves position along the bend line).
+func (b bendDevelop) lineAt(q math.Point3) math.Point3 {
+	t := b.dir.AsVector().Dot(b.line.VectorTo(q))
+	return b.line.TranslateBy(b.dir.AsVector().Scale(t))
+}
+
+// radial is the unit radial direction at swept angle phi (matching the flange band's
+// construction: up·(−cos φ) + out·(sin φ), so φ=0 points along −up to the inner edge).
+func (b bendDevelop) radial(phi float64) math.Vector3 {
+	return b.up.AsVector().Scale(-stdmath.Cos(phi)).Add(b.out.AsVector().Scale(stdmath.Sin(phi)))
+}
+
+// wall is the unit direction the straight flange runs past the arc end.
+func (b bendDevelop) wall() math.Vector3 {
+	return b.out.AsVector().Scale(stdmath.Cos(b.angle)).Add(b.up.AsVector().Scale(stdmath.Sin(b.angle)))
+}
+
+// foldedToFlat maps a folded-body point to its developed-flat position (unfold). Base-side
+// points (swept angle ≤ 0) are unchanged.
+func (b bendDevelop) foldedToFlat(q math.Point3) math.Point3 {
+	o := b.lineAt(q)
+	centre := o.TranslateBy(b.up.AsVector().Scale(b.radius))
+	v := centre.VectorTo(q)
+	av, hv := b.out.AsVector().Dot(v), b.up.AsVector().Dot(v)
+	phi := stdmath.Atan2(av, -hv)
+	if phi <= 0 {
+		return q
+	}
+	var across, rho float64
+	if phi < b.angle {
+		rho = stdmath.Hypot(av, hv)
+		across = phi * b.neutral
+	} else {
+		rho = b.radial(b.angle).Dot(v)               // radial offset at the arc end
+		across = b.angle*b.neutral + b.wall().Dot(v) // arc length + straight run
+	}
+	return o.TranslateBy(b.out.AsVector().Scale(across)).TranslateBy(b.up.AsVector().Scale(b.radius - rho))
+}
+
+// flatToFolded maps a developed-flat point back onto the folded bend (refold) — the inverse of
+// foldedToFlat. Base-side points (across ≤ 0) are unchanged.
+func (b bendDevelop) flatToFolded(p math.Point3) math.Point3 {
+	o := b.lineAt(p)
+	v := o.VectorTo(p)
+	across := b.out.AsVector().Dot(v)
+	if across <= 0 {
+		return p
+	}
+	rho := b.radius - b.up.AsVector().Dot(v) // through-thickness: up-offset (r−ρ) ⇒ ρ = r − up·v
+	centre := o.TranslateBy(b.up.AsVector().Scale(b.radius))
+	arcLen := b.angle * b.neutral
+	if across <= arcLen {
+		return centre.TranslateBy(b.radial(across / b.neutral).Scale(rho))
+	}
+	end := centre.TranslateBy(b.radial(b.angle).Scale(rho))
+	return end.TranslateBy(b.wall().Scale(across - arcLen))
+}

--- a/model/feature/sheet_metal_develop_test.go
+++ b/model/feature/sheet_metal_develop_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// devForTest builds a development for a 90° fold about the X axis at z=t: up=+Z, out=+Y, inner
+// radius r=0.2, gauge t=0.1, neutral ρ=r+0.44t — the canonical top-edge flange frame.
+func devForTest(t *testing.T) bendDevelop {
+	t.Helper()
+	dev, err := newBendDevelop(BendTransform{
+		LinePoint: math.P3(0, 0, 0.1), LineDir: math.V3(1, 0, 0),
+		Up: math.V3(0, 0, 1), Out: math.V3(0, 1, 0),
+		Angle: stdmath.Pi / 2, Radius: 0.2, Thickness: 0.1, Neutral: 0.2 + 0.44*0.1,
+	})
+	if err != nil {
+		t.Fatalf("newBendDevelop: %v", err)
+	}
+	return dev
+}
+
+// TestDevelopRoundTrip flatToFolded inverts foldedToFlat across the base, the bend arc, and the
+// flange — the bijection that lets a cut placed while flat ride back through the bend.
+func TestDevelopRoundTrip(t *testing.T) {
+	dev := devForTest(t)
+	// Sample points spanning the three regions: base (y<0 side of the line), the arc (a point on
+	// the inner surface part-way round), and the flange (well up the wall). Use folded positions.
+	centre := math.P3(0, 0, 0.1+0.2) // line + up·r
+	pts := []math.Point3{
+		math.P3(1, -1, 0.05), // base, below the bend line
+		centre.TranslateBy(math.V3(0, stdmath.Sin(0.6), -stdmath.Cos(0.6)).Scale(0.25)), // arc, φ≈0.6, ρ=0.25
+		math.P3(2, 0.2, 0.8), // flange wall (up high, out by ~r)
+	}
+	for i, q := range pts {
+		flat := dev.foldedToFlat(q)
+		back := dev.flatToFolded(flat)
+		if back.DistanceTo(q) > 1e-9 {
+			t.Errorf("point %d: round-trip moved it %.3g (q=%v flat=%v back=%v)", i, back.DistanceTo(q), q, flat, back)
+		}
+	}
+}
+
+// TestDevelopFlattensArc the inner-surface arc develops to a flat strip: a folded inner point at
+// 90° lands at across = (π/2)·neutral and z = t (coplanar with the base top), proving the bend
+// is unrolled, not rigidly rotated.
+func TestDevelopFlattensArc(t *testing.T) {
+	dev := devForTest(t)
+	centre := math.P3(0, 0, 0.3)
+	innerAt90 := centre.TranslateBy(math.V3(0, 1, 0).Scale(0.2)) // φ=90°, ρ=r ⇒ inner end of the arc
+	flat := dev.foldedToFlat(innerAt90)
+	wantAcross := (stdmath.Pi / 2) * (0.2 + 0.44*0.1)
+	if stdmath.Abs(float64(flat.Y)-wantAcross) > 1e-9 {
+		t.Errorf("developed across = %.4f, want %.4f (neutral arc length)", flat.Y, wantAcross)
+	}
+	if stdmath.Abs(float64(flat.Z)-0.1) > 1e-9 {
+		t.Errorf("developed inner point z = %.4f, want 0.1 (flush with the base top)", flat.Z)
+	}
+}

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -159,7 +159,7 @@ func buildFlangeSolid(edge *topo.Edge, thickness, radius, height, angle float64,
 	proj := func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) }
 	poly := flangeBandPolygon(out.AsVector(), up.AsVector(), thickness, radius, height, angle, proj)
 	placement := BendPlacement{
-		AxisStart: v0, AxisEnd: v1, Outward: out,
+		AxisStart: v0, AxisEnd: v1, Outward: out, Up: up,
 		Angle: angle, Radius: radius, Thickness: thickness, Length: height, FoldDown: flip,
 	}
 	return buildPrism(poly, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), placement, nil

--- a/model/feature/sheet_metal_unfold.go
+++ b/model/feature/sheet_metal_unfold.go
@@ -5,7 +5,6 @@ package feature
 import (
 	"fmt"
 
-	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -19,76 +18,48 @@ import (
 // without a separate folded↔flat entity map (the bend arc flattens approximately: cuts away
 // from the bend are exact).
 
-// BendTransform is one bend an unfold/refold acts on: the bend line (a point + direction) and
-// the swept fold angle. The flange feature folds the moving side by −angle about the line, so
-// unfold rotates it by +angle and refold by −angle. Baked into the feature at creation from
-// the recorded [BendPlacement] so Recompute stays self-contained (it never reaches back into
-// the part's other features).
+// BendTransform is one bend an unfold/refold acts on: the bend line, its fold frame, and the
+// developed dimensions. Unfold develops the bend region flat (unrolls it about the neutral
+// fibre); refold rolls it back. Baked into the feature at creation from the recorded
+// [BendPlacement] + the rule's developed length, so Recompute stays self-contained (it never
+// reaches back into the part's other features).
 type BendTransform struct {
-	LinePoint  math.Point3  // a point on the bend line
-	LineDir    math.Vector3 // the bend line direction (the picked edge)
-	BaseNormal math.Vector3 // the base sheet's outward normal (defines the split plane)
-	Angle      float64      // swept fold angle (radians)
+	LinePoint math.Point3  // a point on the inner-edge bend line
+	LineDir   math.Vector3 // the bend line direction (the picked edge)
+	Up        math.Vector3 // fold normal — the bend-axis centre is the bend line + Up·Radius
+	Out       math.Vector3 // in-plane direction toward the flange
+	Angle     float64      // swept fold angle (radians)
+	Radius    float64      // inside bend radius (cm)
+	Thickness float64      // material gauge (cm)
+	Neutral   float64      // neutral-fibre radius (cm) — the developed length per radian of bend
 }
 
-// unfoldBend flattens one bend: split at the bend-line plane, rotate the moving side by the
-// signed angle about the bend line, union back. A positive angle unfolds a +angle-folded
-// flange; refold passes the negated angle. Returns one watertight solid, erroring when the
-// bend line does not divide the body in two.
-func unfoldBend(body *topo.Body, bt BendTransform, signedAngle float64) (*topo.Body, error) {
-	dir, err := math.UnitVector3FromVector(bt.LineDir)
-	if err != nil {
-		return nil, fmt.Errorf("sheet-metal unfold: bend line direction is degenerate: %v", bt.LineDir)
-	}
-	across, err := math.UnitVector3FromVector(bt.LineDir.Cross(bt.BaseNormal))
-	if err != nil {
-		return nil, fmt.Errorf("sheet-metal unfold: bend line is parallel to the base normal")
-	}
-	fixed, moving, err := splitAtBendLine(body, bt.LinePoint, across)
+// unfoldBend develops one bend: it applies the development point map to the whole body via
+// [ops.DeformBody], so any cut placed while flat moves with its vertices through the bend. sign
+// > 0 unrolls the bend flat (unfold); sign < 0 rolls it back (refold). Returns one watertight
+// solid.
+func unfoldBend(body *topo.Body, bt BendTransform, sign float64, what string) (*topo.Body, error) {
+	dev, err := newBendDevelop(bt)
 	if err != nil {
 		return nil, err
 	}
-	rotated, err := ops.TransformBody(moving, math.Rotation4(signedAngle, dir, bt.LinePoint), identityLineage)
+	fn := dev.foldedToFlat
+	if sign < 0 {
+		fn = dev.flatToFolded
+	}
+	out, err := ops.DeformBody(body, fn, identityLineage)
 	if err != nil {
-		return nil, fmt.Errorf("sheet-metal unfold: rotating the flange: %w", err)
+		return nil, fmt.Errorf("%s: %w", what, err)
 	}
-	merged, err := combine([]*topo.Body{fixed}, rotated, ops.Join)
-	if err != nil {
-		return nil, fmt.Errorf("sheet-metal unfold: rejoining the flange: %w", err)
-	}
-	if len(merged) != 1 {
-		return nil, fmt.Errorf("sheet-metal unfold: flange rejoin produced %d bodies, want 1", len(merged))
-	}
-	return merged[0], nil
+	return out, nil
 }
 
-// splitAtBendLine cuts the body with the plane through the bend line whose normal is across
-// (perpendicular to the line, in the base plane), returning the fixed side (base) and the
-// moving side (the flange, on the +across side). It errors unless the plane divides the body.
-func splitAtBendLine(body *topo.Body, linePoint math.Point3, across math.UnitVector3) (fixed, moving *topo.Body, err error) {
-	plane, err := geom.NewPlane(linePoint, across.AsVector())
-	if err != nil {
-		return nil, nil, err
-	}
-	pieces, err := ops.SplitSolidByPlane(body, plane)
-	if err != nil {
-		return nil, nil, fmt.Errorf("sheet-metal unfold: splitting at the bend line: %w", err)
-	}
-	if len(pieces) != 2 {
-		return nil, nil, fmt.Errorf("sheet-metal unfold: bend line does not divide the body (got %d pieces)", len(pieces))
-	}
-	at := across.AsVector().Dot(linePoint.AsVector())
-	if across.AsVector().Dot(pieces[0].RangeBox().Center().AsVector()) > at {
-		return pieces[1], pieces[0], nil
-	}
-	return pieces[0], pieces[1], nil
-}
-
-// identityLineage keeps lineage unchanged under a body transform (the flange's faces keep
-// their reference keys, so a cut on the flat flange survives the refold transform).
+// identityLineage keeps lineage unchanged under a body transform (every face keeps its
+// reference key, so a cut on the flat flange survives the develop/refold map).
 func identityLineage(l topo.Lineage) topo.Lineage { return l }
 
-// applyBends flattens (sign +1) or refolds (sign −1) every bend on the running body, in order.
+// applyBends develops (sign +1, unfold) or refolds (sign −1) every bend on the running body, in
+// order.
 func applyBends(in Input, bends []BendTransform, sign float64, what string) (Output, error) {
 	body, err := lastBody(in, what)
 	if err != nil {
@@ -96,7 +67,7 @@ func applyBends(in Input, bends []BendTransform, sign float64, what string) (Out
 	}
 	result := body
 	for _, bt := range bends {
-		result, err = unfoldBend(result, bt, sign*bt.Angle)
+		result, err = unfoldBend(result, bt, sign, what)
 		if err != nil {
 			return Output{}, err
 		}

--- a/model/feature/sheet_metal_unfold_test.go
+++ b/model/feature/sheet_metal_unfold_test.go
@@ -25,7 +25,8 @@ func flangedSheetForUnfold(t *testing.T) (*PartFeatures, BendTransform) {
 	p, _ := pf.Definition().(*SheetMetalFlangeFeature).Placement()
 	return fs, BendTransform{
 		LinePoint: p.AxisStart, LineDir: p.AxisStart.VectorTo(p.AxisEnd),
-		BaseNormal: math.V3(0, 0, 1), Angle: p.Angle,
+		Up: p.Up.AsVector(), Out: p.Outward.AsVector(), Angle: p.Angle,
+		Radius: p.Radius, Thickness: p.Thickness, Neutral: p.Radius + 0.44*p.Thickness,
 	}
 }
 
@@ -76,7 +77,7 @@ func TestRefoldFeatureRestores(t *testing.T) {
 // restore (they reference no sketch, so the recipe is self-contained).
 func TestUnfoldRefoldRoundTrip(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
-	bend := BendTransform{LinePoint: math.P3(0, 0, 0.2), LineDir: math.V3(4, 0, 0), BaseNormal: math.V3(0, 0, 1), Angle: stdmath.Pi / 2}
+	bend := BendTransform{LinePoint: math.P3(0, 0, 0.2), LineDir: math.V3(4, 0, 0), Up: math.V3(0, 0, 1), Out: math.V3(0, 1, 0), Angle: stdmath.Pi / 2, Radius: 0.2, Thickness: 0.1, Neutral: 0.244}
 	NewSheetMetalUnfoldFeatures(fs).Add(&SheetMetalUnfoldDefinition{Bends: []BendTransform{bend}})
 	NewSheetMetalRefoldFeatures(fs).Add(&SheetMetalRefoldDefinition{Bends: []BendTransform{bend}})
 
@@ -114,12 +115,18 @@ func TestUnfoldRefoldMissingPayload(t *testing.T) {
 	}
 }
 
-// TestUnfoldBendRejectsParallelNormal a bend line parallel to the base normal can't define a
-// split plane and errors with the offending input.
-func TestUnfoldBendRejectsParallelNormal(t *testing.T) {
+// TestUnfoldBendRejectsDegenerateFrame a bend transform with a degenerate fold normal or a
+// non-positive developed length cannot define a development and errors with the offending input.
+func TestUnfoldBendRejectsDegenerateFrame(t *testing.T) {
 	fs, bt := flangedSheetForUnfold(t)
-	bt.BaseNormal = bt.LineDir // parallel ⇒ degenerate across
-	if _, err := unfoldBend(fs.Result()[0], bt, bt.Angle); err == nil {
-		t.Error("unfoldBend with a normal parallel to the bend line must error")
+	zeroUp := bt
+	zeroUp.Up = math.V3(0, 0, 0)
+	if _, err := unfoldBend(fs.Result()[0], zeroUp, +1, "unfold"); err == nil {
+		t.Error("unfoldBend with a degenerate fold normal must error")
+	}
+	badNeutral := bt
+	badNeutral.Neutral = 0
+	if _, err := unfoldBend(fs.Result()[0], badNeutral, +1, "unfold"); err == nil {
+		t.Error("unfoldBend with a non-positive neutral radius must error")
 	}
 }


### PR DESCRIPTION
## What

Reworks M13-F04 **unfold/refold** to *develop* a bend (unroll it about the neutral fibre) instead of rigid-rotating it about the bend line.

## Why (two defects, found in live testing)

The old body-transform flattened/re-folded by a **rigid rotation** about the bend line. A rotation can swing a flat flange wall down, but it never unrolls the curved bend arc, so:

1. **The bend looked broken** — the quarter-cylinder bend region collapsed into degenerate sliver triangles.
2. **A cut crossing the bend reached only one face** — the slot's −Z cut prism passed through the flat base/flange but missed the still-curved bend face, which then refolded with its material intact.

## How

- **New kernel op `ops.DeformBody`** — rebuilds a *polyhedral* body under a per-vertex map (straight edges between moved endpoints, planar faces re-fitted through the moved loop). `TransformBody` only carries affine matrices; develop needs a non-affine map.
- **`model/feature/sheet_metal_develop.go`** — a reversible folded↔flat point map: the bend region unrolls about the neutral fibre (across-distance = swept angle × neutral radius); the straight flange continues past the arc. Applied to the whole body, it moves **every** vertex — including ones a cut added while flat — so a slot crossing the bend rides through it on refold, **with no separate folded↔flat entity map**.
- The fold frame (fold normal / inside radius / gauge) is recorded on `BendPlacement`; the rule's developed length is baked into `BendTransform`, so develop honours the active unfold method (K-factor / bend table / equation), not just a fixed K-factor.

No API change — source-only (`kernel/ops` + `model/feature` + `model/compdef`).

## Tests

- `ops.DeformBody`: identity / shear (non-affine, volume-preserving) / rigid — all yield valid closed solids with correct volume.
- The development map: folded↔flat **round-trips** across base, arc, and flange; the inner arc develops to a flat strip at the neutral arc length, flush with the base.
- Existing unfold/refold round-trip + cut-while-flat tests still pass.
- **New regression** `TestCutCrossingBendSurvivesRefold`: a slot cut **crossing the bend line** while flat, refolded — the refolded volume must match the flat-cut volume (if the bend kept its material, it'd be higher).
- Root `golangci-lint` 0 issues; full build green.

## Live verification

Bracket → Face → Flange → unwrap → slot cut across the bend → wrap, over the MCP bridge:
- **shaded**: a clean bend with the slot a window through *both* the base and the upstanding flange;
- **per-triangle color**: no sliver triangles at the bend (vs. the old rainbow-sliver band);
- **normal-debug**: all faces front-facing (green) — watertight, consistent normals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)