### PR TITLE
feat(sheet-metal): M13-F03 modify features — rip, lip, punch, cosmetic bend

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -266,6 +266,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalContourRoll":   `{"profileSketch":0,"axisLine":0}`,
 		"sheetMetalCornerSeam":    `{"edges":["x"],"gap":"0.2 mm"}`,
 		"sheetMetalCut":           `{"sketchIndex":0}`,
+		"sheetMetalRip":           `{"sketchIndex":0,"gap":"0.1 mm"}`,
 		"sheetMetalCosmeticBend":  `{"sketchIndex":0}`,
 		"sheetMetalUnfold":        `{}`,
 		"sheetMetalRefold":        `{}`,

--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -267,6 +267,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalCornerSeam":    `{"edges":["x"],"gap":"0.2 mm"}`,
 		"sheetMetalCut":           `{"sketchIndex":0}`,
 		"sheetMetalRip":           `{"sketchIndex":0,"gap":"0.1 mm"}`,
+		"sheetMetalPunch":         `{"sketchIndex":0}`,
 		"sheetMetalCosmeticBend":  `{"sketchIndex":0}`,
 		"sheetMetalUnfold":        `{}`,
 		"sheetMetalRefold":        `{}`,

--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -266,6 +266,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalContourRoll":   `{"profileSketch":0,"axisLine":0}`,
 		"sheetMetalCornerSeam":    `{"edges":["x"],"gap":"0.2 mm"}`,
 		"sheetMetalCut":           `{"sketchIndex":0}`,
+		"sheetMetalCosmeticBend":  `{"sketchIndex":0}`,
 		"sheetMetalUnfold":        `{}`,
 		"sheetMetalRefold":        `{}`,
 		"splitSolid":              `{"toolSketch":0}`,

--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -268,6 +268,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sheetMetalCut":           `{"sketchIndex":0}`,
 		"sheetMetalRip":           `{"sketchIndex":0,"gap":"0.1 mm"}`,
 		"sheetMetalPunch":         `{"sketchIndex":0}`,
+		"sheetMetalLip":           `{"edge":"x","height":"10 mm"}`,
 		"sheetMetalCosmeticBend":  `{"sketchIndex":0}`,
 		"sheetMetalUnfold":        `{}`,
 		"sheetMetalRefold":        `{}`,

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -142,6 +142,7 @@ func Default() *Registry {
 		sheetMetalCornerSeamDescriptor(),
 		sheetMetalCutDescriptor(),
 		sheetMetalRipDescriptor(),
+		sheetMetalPunchDescriptor(),
 		sheetMetalCosmeticBendDescriptor(),
 		sheetMetalUnfoldDescriptor(),
 		sheetMetalRefoldDescriptor(),

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -143,6 +143,7 @@ func Default() *Registry {
 		sheetMetalCutDescriptor(),
 		sheetMetalRipDescriptor(),
 		sheetMetalPunchDescriptor(),
+		sheetMetalLipDescriptor(),
 		sheetMetalCosmeticBendDescriptor(),
 		sheetMetalUnfoldDescriptor(),
 		sheetMetalRefoldDescriptor(),

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -141,6 +141,7 @@ func Default() *Registry {
 		sheetMetalContourRollDescriptor(),
 		sheetMetalCornerSeamDescriptor(),
 		sheetMetalCutDescriptor(),
+		sheetMetalCosmeticBendDescriptor(),
 		sheetMetalUnfoldDescriptor(),
 		sheetMetalRefoldDescriptor(),
 		splitSolidDescriptor(),

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -141,6 +141,7 @@ func Default() *Registry {
 		sheetMetalContourRollDescriptor(),
 		sheetMetalCornerSeamDescriptor(),
 		sheetMetalCutDescriptor(),
+		sheetMetalRipDescriptor(),
 		sheetMetalCosmeticBendDescriptor(),
 		sheetMetalUnfoldDescriptor(),
 		sheetMetalRefoldDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -18,7 +18,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
 		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
-		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
+		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalLip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
 		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",

--- a/addin/opregistry/sheet_metal_bend.go
+++ b/addin/opregistry/sheet_metal_bend.go
@@ -69,20 +69,9 @@ func applySheetMetalBend(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 // bendDef resolves the bend args into a definition: the sketch + line, and the optional
 // angle/radius closures (omitted ⇒ nil, so the feature uses its defaults).
 func bendDef(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in sheetMetalBendArgs) (*feature.SheetMetalBendDefinition, error) {
-	def := &feature.SheetMetalBendDefinition{Sketch: sk, LineIndex: in.LineIndex, Flip: in.Flip}
-	if in.Angle != "" {
-		angle, err := angleClosure(part, in.Angle, "sheetMetalBend: angle")
-		if err != nil {
-			return nil, err
-		}
-		def.Angle = angle
+	angle, radius, err := optionalBendDims(part, in.Angle, in.Radius, "sheetMetalBend")
+	if err != nil {
+		return nil, err
 	}
-	if in.Radius != "" {
-		radius, err := lengthClosure(part, in.Radius, "sheetMetalBend: radius")
-		if err != nil {
-			return nil, err
-		}
-		def.Radius = radius
-	}
-	return def, nil
+	return &feature.SheetMetalBendDefinition{Sketch: sk, LineIndex: in.LineIndex, Flip: in.Flip, Angle: angle, Radius: radius}, nil
 }

--- a/addin/opregistry/sheet_metal_common.go
+++ b/addin/opregistry/sheet_metal_common.go
@@ -33,3 +33,25 @@ func angleOverride(part *compdef.PartComponentDefinition, expr, field string) (f
 	}
 	return angleClosure(part, expr, field)
 }
+
+// lengthOverride returns the length closure for a non-empty expression, else nil so the feature
+// falls through to its rule default (e.g. the bend radius).
+func lengthOverride(part *compdef.PartComponentDefinition, expr, field string) (func() float64, error) {
+	if expr == "" {
+		return nil, nil
+	}
+	return lengthClosure(part, expr, field)
+}
+
+// optionalBendDims resolves the optional angle + inside-radius expressions a bend-style feature
+// (Bend, Cosmetic Bend) accepts into parameter-backed closures — blank ⇒ nil, so the feature
+// uses its rule defaults (90° / the rule's bend radius).
+func optionalBendDims(part *compdef.PartComponentDefinition, angleExpr, radiusExpr, op string) (angle, radius func() float64, err error) {
+	if angle, err = angleOverride(part, angleExpr, op+": angle"); err != nil {
+		return nil, nil, err
+	}
+	if radius, err = lengthOverride(part, radiusExpr, op+": radius"); err != nil {
+		return nil, nil, err
+	}
+	return angle, radius, nil
+}

--- a/addin/opregistry/sheet_metal_cosmetic_bend.go
+++ b/addin/opregistry/sheet_metal_cosmetic_bend.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalCosmeticBendArgs is the argument shape for the "sheetMetalCosmeticBend" operation:
+// the sketch bend line (sketch + line index) and the optional bend angle/radius. It marks a
+// fold for manufacturing without deforming the model.
+type sheetMetalCosmeticBendArgs struct {
+	SketchIndex int    `json:"sketchIndex"`
+	LineIndex   int    `json:"lineIndex"`
+	Angle       string `json:"angle,omitempty"`
+	Radius      string `json:"radius,omitempty"`
+}
+
+const sheetMetalCosmeticBendSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the cosmetic bend line (see model.tree)."},
+    "lineIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which line of the sketch is the bend axis."},
+    "angle": {"type": "string", "description": "Bend angle, e.g. \"90 deg\" (default), for the bend table."},
+    "radius": {"type": "string", "description": "Inside bend radius (default: the rule's bend radius)."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalCosmeticBendDescriptor is the self-describing "sheetMetalCosmeticBend" operation:
+// annotate a fold line for manufacturing without folding the geometry.
+func sheetMetalCosmeticBendDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalCosmeticBend",
+		Summary: "Mark a cosmetic bend line on a sheet-metal part — it joins the bend table without deforming the model.",
+		Schema:  json.RawMessage(sheetMetalCosmeticBendSchema),
+		Apply:   applySheetMetalCosmeticBend,
+	}
+}
+
+func applySheetMetalCosmeticBend(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalCosmeticBend")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalCosmeticBendArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalCosmeticBend: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	angle, radius, err := optionalBendDims(part, in.Angle, in.Radius, "sheetMetalCosmeticBend")
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalCosmeticBendDefinition{Sketch: sk, LineIndex: in.LineIndex, Angle: angle, Radius: radius}
+	return recomputeResult(part, feature.NewSheetMetalCosmeticBendFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_cosmetic_bend_test.go
+++ b/addin/opregistry/sheet_metal_cosmetic_bend_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSheetMetalCosmeticBendApply seeds a sheet-metal wall, adds a bend line crossing it, and
+// marks it cosmetic — the result is the unchanged base solid; then checks the error paths.
+func TestSheetMetalCosmeticBendApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	line := def.Sketches().Add(sketch.XYPlane())
+	line.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(2, 3)) // across the 4×3 sheet at x=2
+
+	out, err := apply(t, s, "sheetMetalCosmeticBend", `{"sketchIndex":1,"lineIndex":0,"angle":"90 deg","radius":"2 mm"}`)
+	if err != nil {
+		t.Fatalf("cosmetic bend apply: %v", err)
+	}
+	expectMergedSolid(t, out, "cosmetic bend") // the body is unchanged but still one healthy solid
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalCosmeticBend", `{"sketchIndex":0}`); err == nil {
+		t.Error("cosmetic bend on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalCosmeticBend", `{"sketchIndex":99}`); err == nil {
+		t.Error("cosmetic bend with an out-of-range sketch must error")
+	}
+	if _, err := apply(t, s, "sheetMetalCosmeticBend", `{"sketchIndex":1,"angle":"bad"}`); err == nil {
+		t.Error("cosmetic bend with a bad angle must error")
+	}
+}

--- a/addin/opregistry/sheet_metal_lip.go
+++ b/addin/opregistry/sheet_metal_lip.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalLipArgs is the argument shape for the "sheetMetalLip" operation: the edge to build
+// on, the flange height, the return-wall length, the optional bend angle/radius, and a flip.
+// (Distinct from the solid-modeling "lip" bead — this is the sheet-metal stiffening edge return.)
+type sheetMetalLipArgs struct {
+	Edge         string `json:"edge"`
+	Height       string `json:"height"`
+	ReturnLength string `json:"returnLength,omitempty"`
+	Angle        string `json:"angle,omitempty"`
+	Radius       string `json:"radius,omitempty"`
+	Flip         bool   `json:"flip,omitempty"`
+}
+
+const sheetMetalLipSchema = `{
+  "type": "object",
+  "properties": {
+    "edge": {"type": "string", "description": "Reference key of the straight sheet edge to build the lip on."},
+    "height": {"type": "string", "description": "Flange wall height before the return, e.g. \"10 mm\"."},
+    "returnLength": {"type": "string", "default": "3 mm", "description": "Return wall length after the 180° curl."},
+    "angle": {"type": "string", "description": "Flange bend angle, e.g. \"90 deg\" (default)."},
+    "radius": {"type": "string", "description": "Inside bend radius (default: the rule's bend radius)."},
+    "flip": {"type": "boolean", "default": false, "description": "Fold toward the opposite side of the sheet."}
+  },
+  "required": ["edge", "height"]
+}`
+
+// sheetMetalLipDescriptor is the self-describing "sheetMetalLip" operation: fold a stiffening
+// lip (a short flange curled 180° back on itself) onto a sheet edge.
+func sheetMetalLipDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalLip",
+		Summary: "Fold a stiffening lip (a short flange curled 180° back on itself) onto a straight sheet-metal edge.",
+		Schema:  json.RawMessage(sheetMetalLipSchema),
+		Apply:   applySheetMetalLip,
+	}
+}
+
+// defaultLipReturn is the return-wall length used when none is given.
+const defaultLipReturn = "3 mm"
+
+func applySheetMetalLip(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalLip")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalLipArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalLip: invalid args: %w", err)
+	}
+	def, err := lipDef(part, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, feature.NewSheetMetalLipFeatures(part.Features()).Add(def))
+}
+
+// lipDef resolves the lip args into a definition: the edge + parameter-backed height/return and
+// the optional angle/radius closures (omitted ⇒ nil, so the feature uses its defaults).
+func lipDef(part *compdef.PartComponentDefinition, in sheetMetalLipArgs) (*feature.SheetMetalLipDefinition, error) {
+	if in.Edge == "" {
+		return nil, fmt.Errorf("sheetMetalLip: edge is required")
+	}
+	height, err := lengthClosure(part, in.Height, "sheetMetalLip: height")
+	if err != nil {
+		return nil, err
+	}
+	returnExpr := in.ReturnLength
+	if returnExpr == "" {
+		returnExpr = defaultLipReturn
+	}
+	returnLen, err := lengthClosure(part, returnExpr, "sheetMetalLip: returnLength")
+	if err != nil {
+		return nil, err
+	}
+	angle, radius, err := optionalBendDims(part, in.Angle, in.Radius, "sheetMetalLip")
+	if err != nil {
+		return nil, err
+	}
+	return &feature.SheetMetalLipDefinition{
+		EdgeKey: []byte(in.Edge), Height: height, ReturnLength: returnLen,
+		Angle: angle, Radius: radius, Flip: in.Flip,
+	}, nil
+}

--- a/addin/opregistry/sheet_metal_lip_test.go
+++ b/addin/opregistry/sheet_metal_lip_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// TestSheetMetalLipApply seeds a sheet-metal wall and folds a stiffening lip onto a top edge,
+// confirming one healthy solid; then checks the error paths.
+func TestSheetMetalLipApply(t *testing.T) {
+	s, _ := seedSheetMetalSheet(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	edge := topEdgeKey(t, def)
+
+	out, err := applyMap(t, s, "sheetMetalLip", map[string]any{"edge": edge, "height": "8 mm", "returnLength": "3 mm"})
+	if err != nil {
+		t.Fatalf("lip apply: %v", err)
+	}
+	expectMergedSolid(t, out, "lip")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalLip", `{"edge":"x","height":"8 mm"}`); err == nil {
+		t.Error("lip on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalLip", `{"height":"8 mm"}`); err == nil {
+		t.Error("lip without an edge must error")
+	}
+	if _, err := applyMap(t, s, "sheetMetalLip", map[string]any{"edge": edge, "height": "bad"}); err == nil {
+		t.Error("lip with a bad height must error")
+	}
+}

--- a/addin/opregistry/sheet_metal_punch.go
+++ b/addin/opregistry/sheet_metal_punch.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/model/feature"
+
+	"oblikovati.org/app"
+)
+
+// sheetMetalPunchArgs is the argument shape for the "sheetMetalPunch" operation: the sketch
+// whose closed profiles are stamped and an optional depth (omitted ⇒ through all).
+type sheetMetalPunchArgs struct {
+	SketchIndex int    `json:"sketchIndex"`
+	Depth       string `json:"depth,omitempty"`
+}
+
+const sheetMetalPunchSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch whose closed profiles are punched (see model.tree)."},
+    "depth": {"type": "string", "description": "Punch depth (default: through all the material)."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalPunchDescriptor is the self-describing "sheetMetalPunch" operation: stamp every
+// closed profile of a sketch through the sheet in one die-pattern punch.
+func sheetMetalPunchDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalPunch",
+		Summary: "Punch every closed profile of a sketch through a sheet-metal part — a die pattern (vents, louvers, perforations) in one operation.",
+		Schema:  json.RawMessage(sheetMetalPunchSchema),
+		Apply:   applySheetMetalPunch,
+	}
+}
+
+func applySheetMetalPunch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalPunch")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalPunchArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalPunch: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalPunchDefinition{Sketch: sk}
+	if in.Depth != "" {
+		depth, err := lengthClosure(part, in.Depth, "sheetMetalPunch: depth")
+		if err != nil {
+			return nil, err
+		}
+		def.Depth = depth
+	}
+	return recomputeResult(part, feature.NewSheetMetalPunchFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_punch_test.go
+++ b/addin/opregistry/sheet_metal_punch_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSheetMetalPunchApply seeds a sheet-metal wall, punches two holes from one sketch, and
+// confirms one healthy solid; then checks the error paths.
+func TestSheetMetalPunchApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	holes := def.Sketches().Add(sketch.XYPlane())
+	for _, c := range []math.Point2{math.P2(1, 1), math.P2(3, 2)} {
+		a := holes.Points().Add(math.P2(c.X-0.3, c.Y-0.3))
+		b := holes.Points().Add(math.P2(c.X+0.3, c.Y-0.3))
+		d := holes.Points().Add(math.P2(c.X+0.3, c.Y+0.3))
+		e := holes.Points().Add(math.P2(c.X-0.3, c.Y+0.3))
+		holes.Lines().Add(a, b)
+		holes.Lines().Add(b, d)
+		holes.Lines().Add(d, e)
+		holes.Lines().Add(e, a)
+	}
+
+	out, err := apply(t, s, "sheetMetalPunch", `{"sketchIndex":1}`)
+	if err != nil {
+		t.Fatalf("punch apply: %v", err)
+	}
+	expectMergedSolid(t, out, "punch")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalPunch", `{"sketchIndex":0}`); err == nil {
+		t.Error("punch on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalPunch", `{"sketchIndex":99}`); err == nil {
+		t.Error("punch with an out-of-range sketch must error")
+	}
+	if _, err := apply(t, s, "sheetMetalPunch", `{"sketchIndex":1,"depth":"bad"}`); err == nil {
+		t.Error("punch with a bad depth must error")
+	}
+}

--- a/addin/opregistry/sheet_metal_rip.go
+++ b/addin/opregistry/sheet_metal_rip.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// sheetMetalRipArgs is the argument shape for the "sheetMetalRip" operation: the sketch line to
+// rip along and the gap width the slit opens.
+type sheetMetalRipArgs struct {
+	SketchIndex int    `json:"sketchIndex"`
+	LineIndex   int    `json:"lineIndex"`
+	Gap         string `json:"gap,omitempty"`
+}
+
+const sheetMetalRipSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch holding the rip line (see model.tree)."},
+    "lineIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which line of the sketch is the rip seam."},
+    "gap": {"type": "string", "default": "0.1 mm", "description": "Width of the slit the rip opens, e.g. \"0.1 mm\"."}
+  },
+  "required": ["sketchIndex"]
+}`
+
+// sheetMetalRipDescriptor is the self-describing "sheetMetalRip" operation: cut a narrow slit
+// along a sketch line so a closed or folded sheet can be developed flat.
+func sheetMetalRipDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "sheetMetalRip",
+		Summary: "Rip a sheet-metal part along a sketch line — a narrow through-thickness slit that opens a seam for unfolding.",
+		Schema:  json.RawMessage(sheetMetalRipSchema),
+		Apply:   applySheetMetalRip,
+	}
+}
+
+// defaultRipGap is the slit width used when none is given — a thin manufacturing kerf (0.1 mm).
+const defaultRipGap = "0.1 mm"
+
+func applySheetMetalRip(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := activeSheetMetalPart(s, "sheetMetalRip")
+	if err != nil {
+		return nil, err
+	}
+	var in sheetMetalRipArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, fmt.Errorf("sheetMetalRip: invalid args: %w", err)
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	gapExpr := in.Gap
+	if gapExpr == "" {
+		gapExpr = defaultRipGap
+	}
+	gap, err := lengthClosure(part, gapExpr, "sheetMetalRip: gap")
+	if err != nil {
+		return nil, err
+	}
+	def := &feature.SheetMetalRipDefinition{Sketch: sk, LineIndex: in.LineIndex, Gap: gap}
+	return recomputeResult(part, feature.NewSheetMetalRipFeatures(part.Features()).Add(def))
+}

--- a/addin/opregistry/sheet_metal_rip_test.go
+++ b/addin/opregistry/sheet_metal_rip_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSheetMetalRipApply seeds a sheet-metal wall, adds a rip line across the middle, and slits
+// it — the result is one healthy solid with material removed; then checks the error paths.
+func TestSheetMetalRipApply(t *testing.T) {
+	s := sheetMetalProfiledPart(t)
+	if _, err := apply(t, s, "sheetMetalFace", `{"sketchIndex":0}`); err != nil {
+		t.Fatalf("seed face: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	rip := def.Sketches().Add(sketch.XYPlane())
+	rip.Lines().AddByTwoPoints(math.P2(1, 1.5), math.P2(3, 1.5)) // partial line across the 4×3 sheet
+
+	out, err := apply(t, s, "sheetMetalRip", `{"sketchIndex":1,"lineIndex":0,"gap":"0.5 mm"}`)
+	if err != nil {
+		t.Fatalf("rip apply: %v", err)
+	}
+	expectMergedSolid(t, out, "rip")
+
+	// Error paths.
+	if _, err := apply(t, profiledPart(t), "sheetMetalRip", `{"sketchIndex":0}`); err == nil {
+		t.Error("rip on a non-sheet-metal part must error")
+	}
+	if _, err := apply(t, s, "sheetMetalRip", `{"sketchIndex":99}`); err == nil {
+		t.Error("rip with an out-of-range sketch must error")
+	}
+	if _, err := apply(t, s, "sheetMetalRip", `{"sketchIndex":1,"gap":"bad"}`); err == nil {
+		t.Error("rip with a bad gap must error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -84,6 +84,7 @@ type FeatureData struct {
 	SheetMetalCut           *SheetMetalCutData           `yaml:"sheetMetalCut,omitempty"`           // M13-F03
 	SheetMetalRip           *SheetMetalRipData           `yaml:"sheetMetalRip,omitempty"`           // M13-F03
 	SheetMetalPunch         *SheetMetalPunchData         `yaml:"sheetMetalPunch,omitempty"`         // M13-F03
+	SheetMetalLip           *SheetMetalLipData           `yaml:"sheetMetalLip,omitempty"`           // M13-F03
 	SheetMetalCosmeticBend  *SheetMetalCosmeticBendData  `yaml:"sheetMetalCosmeticBend,omitempty"`  // M13-F03
 	SheetMetalUnfold        *SheetMetalUnfoldData        `yaml:"sheetMetalUnfold,omitempty"`        // M13-F04
 	SheetMetalRefold        *SheetMetalRefoldData        `yaml:"sheetMetalRefold,omitempty"`        // M13-F04
@@ -312,6 +313,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalPunch = smp
+	case *SheetMetalLipFeature:
+		fd.SheetMetalLip = serializeSheetMetalLip(f.def)
 	case *SheetMetalFoldFeature:
 		smf, err := serializeSheetMetalFold(f.def, sk)
 		if err != nil {
@@ -551,6 +554,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalRip(fs, fd.SheetMetalRip, sk)
 	case "sheet-metal-punch":
 		return restoreSheetMetalPunch(fs, fd.SheetMetalPunch, sk)
+	case "sheet-metal-lip":
+		return restoreSheetMetalLip(fs, fd.SheetMetalLip)
 	case "sheet-metal-fold":
 		return restoreSheetMetalFold(fs, fd.SheetMetalFold, sk)
 	case "sheet-metal-corner":

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -82,6 +82,7 @@ type FeatureData struct {
 	SheetMetalContourRoll   *SheetMetalContourRollData   `yaml:"sheetMetalContourRoll,omitempty"`   // M13-F02
 	SheetMetalCornerSeam    *SheetMetalCornerSeamData    `yaml:"sheetMetalCornerSeam,omitempty"`    // M13-F02
 	SheetMetalCut           *SheetMetalCutData           `yaml:"sheetMetalCut,omitempty"`           // M13-F03
+	SheetMetalCosmeticBend  *SheetMetalCosmeticBendData  `yaml:"sheetMetalCosmeticBend,omitempty"`  // M13-F03
 	SheetMetalUnfold        *SheetMetalUnfoldData        `yaml:"sheetMetalUnfold,omitempty"`        // M13-F04
 	SheetMetalRefold        *SheetMetalRefoldData        `yaml:"sheetMetalRefold,omitempty"`        // M13-F04
 }
@@ -291,6 +292,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalBend = smb
+	case *SheetMetalCosmeticBendFeature:
+		smcb, err := serializeSheetMetalCosmeticBend(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalCosmeticBend = smcb
 	case *SheetMetalFoldFeature:
 		smf, err := serializeSheetMetalFold(f.def, sk)
 		if err != nil {
@@ -524,6 +531,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalHem(fs, fd.SheetMetalHem)
 	case "sheet-metal-bend":
 		return restoreSheetMetalBend(fs, fd.SheetMetalBend, sk)
+	case "sheet-metal-cosmetic-bend":
+		return restoreSheetMetalCosmeticBend(fs, fd.SheetMetalCosmeticBend, sk)
 	case "sheet-metal-fold":
 		return restoreSheetMetalFold(fs, fd.SheetMetalFold, sk)
 	case "sheet-metal-corner":

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -83,6 +83,7 @@ type FeatureData struct {
 	SheetMetalCornerSeam    *SheetMetalCornerSeamData    `yaml:"sheetMetalCornerSeam,omitempty"`    // M13-F02
 	SheetMetalCut           *SheetMetalCutData           `yaml:"sheetMetalCut,omitempty"`           // M13-F03
 	SheetMetalRip           *SheetMetalRipData           `yaml:"sheetMetalRip,omitempty"`           // M13-F03
+	SheetMetalPunch         *SheetMetalPunchData         `yaml:"sheetMetalPunch,omitempty"`         // M13-F03
 	SheetMetalCosmeticBend  *SheetMetalCosmeticBendData  `yaml:"sheetMetalCosmeticBend,omitempty"`  // M13-F03
 	SheetMetalUnfold        *SheetMetalUnfoldData        `yaml:"sheetMetalUnfold,omitempty"`        // M13-F04
 	SheetMetalRefold        *SheetMetalRefoldData        `yaml:"sheetMetalRefold,omitempty"`        // M13-F04
@@ -305,6 +306,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalRip = smr
+	case *SheetMetalPunchFeature:
+		smp, err := serializeSheetMetalPunch(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalPunch = smp
 	case *SheetMetalFoldFeature:
 		smf, err := serializeSheetMetalFold(f.def, sk)
 		if err != nil {
@@ -542,6 +549,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalCosmeticBend(fs, fd.SheetMetalCosmeticBend, sk)
 	case "sheet-metal-rip":
 		return restoreSheetMetalRip(fs, fd.SheetMetalRip, sk)
+	case "sheet-metal-punch":
+		return restoreSheetMetalPunch(fs, fd.SheetMetalPunch, sk)
 	case "sheet-metal-fold":
 		return restoreSheetMetalFold(fs, fd.SheetMetalFold, sk)
 	case "sheet-metal-corner":

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -82,6 +82,7 @@ type FeatureData struct {
 	SheetMetalContourRoll   *SheetMetalContourRollData   `yaml:"sheetMetalContourRoll,omitempty"`   // M13-F02
 	SheetMetalCornerSeam    *SheetMetalCornerSeamData    `yaml:"sheetMetalCornerSeam,omitempty"`    // M13-F02
 	SheetMetalCut           *SheetMetalCutData           `yaml:"sheetMetalCut,omitempty"`           // M13-F03
+	SheetMetalRip           *SheetMetalRipData           `yaml:"sheetMetalRip,omitempty"`           // M13-F03
 	SheetMetalCosmeticBend  *SheetMetalCosmeticBendData  `yaml:"sheetMetalCosmeticBend,omitempty"`  // M13-F03
 	SheetMetalUnfold        *SheetMetalUnfoldData        `yaml:"sheetMetalUnfold,omitempty"`        // M13-F04
 	SheetMetalRefold        *SheetMetalRefoldData        `yaml:"sheetMetalRefold,omitempty"`        // M13-F04
@@ -298,6 +299,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.SheetMetalCosmeticBend = smcb
+	case *SheetMetalRipFeature:
+		smr, err := serializeSheetMetalRip(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.SheetMetalRip = smr
 	case *SheetMetalFoldFeature:
 		smf, err := serializeSheetMetalFold(f.def, sk)
 		if err != nil {
@@ -533,6 +540,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreSheetMetalBend(fs, fd.SheetMetalBend, sk)
 	case "sheet-metal-cosmetic-bend":
 		return restoreSheetMetalCosmeticBend(fs, fd.SheetMetalCosmeticBend, sk)
+	case "sheet-metal-rip":
+		return restoreSheetMetalRip(fs, fd.SheetMetalRip, sk)
 	case "sheet-metal-fold":
 		return restoreSheetMetalFold(fs, fd.SheetMetalFold, sk)
 	case "sheet-metal-corner":

--- a/model/feature/serialize_sheet_metal_cosmetic_bend.go
+++ b/model/feature/serialize_sheet_metal_cosmetic_bend.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalCosmeticBendData is the serialized form of a SheetMetalCosmeticBendFeature: the
+// bend line (sketch index + line index) and the optional angle/radius (0 ⇒ default 90° / the
+// rule's bend radius). Thickness is read live from the rule; there is no flip (a cosmetic bend
+// does not fold).
+type SheetMetalCosmeticBendData struct {
+	Sketch int     `yaml:"sketch"`
+	Line   int     `yaml:"line"`
+	Angle  float64 `yaml:"angle,omitempty"`  // 0 ⇒ 90° default
+	Radius float64 `yaml:"radius,omitempty"` // 0 ⇒ rule bend radius
+}
+
+// serializeSheetMetalCosmeticBend projects a cosmetic-bend recipe to its persisted form,
+// erroring if its sketch is not in the part (so the bend line cannot be lost silently).
+func serializeSheetMetalCosmeticBend(def *SheetMetalCosmeticBendDefinition, sk SketchIndexer) (*SheetMetalCosmeticBendData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal cosmetic bend references a sketch that is not in the part")
+	}
+	return &SheetMetalCosmeticBendData{
+		Sketch: idx, Line: def.LineIndex,
+		Angle: evalFloat(def.Angle), Radius: evalFloat(def.Radius),
+	}, nil
+}
+
+// restoreSheetMetalCosmeticBend rebuilds a cosmetic-bend feature, erroring on a missing payload
+// or unknown sketch. A zero angle/radius restores as nil (default 90° / rule radius).
+func restoreSheetMetalCosmeticBend(fs *PartFeatures, d *SheetMetalCosmeticBendData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal cosmetic bend feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal cosmetic bend references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalCosmeticBendDefinition{Sketch: s, LineIndex: d.Line}
+	if d.Angle != 0 {
+		def.Angle = constFloat(d.Angle)
+	}
+	if d.Radius != 0 {
+		def.Radius = constFloat(d.Radius)
+	}
+	return NewSheetMetalCosmeticBendFeatures(fs).Add(def), nil
+}

--- a/model/feature/serialize_sheet_metal_lip.go
+++ b/model/feature/serialize_sheet_metal_lip.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalLipData is the serialized form of a SheetMetalLipFeature: the edge reference key, the
+// flange height + return length, the optional bend angle/radius (0 ⇒ default 90° / rule radius),
+// and the flip. Thickness is read live from the rule.
+type SheetMetalLipData struct {
+	Edge         string  `yaml:"edge"`
+	Height       float64 `yaml:"height"`
+	ReturnLength float64 `yaml:"returnLength"`
+	Angle        float64 `yaml:"angle,omitempty"`  // 0 ⇒ 90° default
+	Radius       float64 `yaml:"radius,omitempty"` // 0 ⇒ rule bend radius
+	Flip         bool    `yaml:"flip,omitempty"`
+}
+
+// serializeSheetMetalLip projects a lip recipe to its persisted form.
+func serializeSheetMetalLip(def *SheetMetalLipDefinition) *SheetMetalLipData {
+	return &SheetMetalLipData{
+		Edge:         encodeKey(def.EdgeKey),
+		Height:       evalFloat(def.Height),
+		ReturnLength: evalFloat(def.ReturnLength),
+		Angle:        evalFloat(def.Angle),
+		Radius:       evalFloat(def.Radius),
+		Flip:         def.Flip,
+	}
+}
+
+// restoreSheetMetalLip rebuilds a lip feature, erroring on a missing payload. A zero angle/radius
+// restores as nil (default 90° / rule radius).
+func restoreSheetMetalLip(fs *PartFeatures, d *SheetMetalLipData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal lip feature is missing its payload")
+	}
+	key, err := decodeKey(d.Edge)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal lip edge: %w", err)
+	}
+	def := &SheetMetalLipDefinition{
+		EdgeKey:      key,
+		Height:       constFloat(d.Height),
+		ReturnLength: constFloat(d.ReturnLength),
+		Flip:         d.Flip,
+	}
+	if d.Angle != 0 {
+		def.Angle = constFloat(d.Angle)
+	}
+	if d.Radius != 0 {
+		def.Radius = constFloat(d.Radius)
+	}
+	return NewSheetMetalLipFeatures(fs).Add(def), nil
+}

--- a/model/feature/serialize_sheet_metal_punch.go
+++ b/model/feature/serialize_sheet_metal_punch.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalPunchData is the serialized form of a SheetMetalPunchFeature: the sketch index, the
+// punch direction, and the optional depth (0 ⇒ through all).
+type SheetMetalPunchData struct {
+	Sketch    int     `yaml:"sketch"`
+	Direction int32   `yaml:"direction,omitempty"`
+	Depth     float64 `yaml:"depth,omitempty"` // 0 ⇒ through all
+}
+
+// serializeSheetMetalPunch projects a punch recipe to its persisted form, erroring if its
+// sketch is not in the part.
+func serializeSheetMetalPunch(def *SheetMetalPunchDefinition, sk SketchIndexer) (*SheetMetalPunchData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal punch references a sketch that is not in the part")
+	}
+	return &SheetMetalPunchData{Sketch: idx, Direction: int32(def.Direction), Depth: evalFloat(def.Depth)}, nil
+}
+
+// restoreSheetMetalPunch rebuilds a punch feature, erroring on a missing payload or unknown
+// sketch. A zero depth restores as nil (through all).
+func restoreSheetMetalPunch(fs *PartFeatures, d *SheetMetalPunchData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal punch feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal punch references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalPunchDefinition{Sketch: s, Direction: ExtentDirection(d.Direction)}
+	if d.Depth != 0 {
+		def.Depth = constFloat(d.Depth)
+	}
+	return NewSheetMetalPunchFeatures(fs).Add(def), nil
+}

--- a/model/feature/serialize_sheet_metal_rip.go
+++ b/model/feature/serialize_sheet_metal_rip.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// SheetMetalRipData is the serialized form of a SheetMetalRipFeature: the rip line (sketch index
+// + line index) and the gap width.
+type SheetMetalRipData struct {
+	Sketch int     `yaml:"sketch"`
+	Line   int     `yaml:"line"`
+	Gap    float64 `yaml:"gap"`
+}
+
+// serializeSheetMetalRip projects a rip recipe to its persisted form, erroring if its sketch is
+// not in the part (so the rip line cannot be lost silently).
+func serializeSheetMetalRip(def *SheetMetalRipDefinition, sk SketchIndexer) (*SheetMetalRipData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal rip references a sketch that is not in the part")
+	}
+	return &SheetMetalRipData{Sketch: idx, Line: def.LineIndex, Gap: evalFloat(def.Gap)}, nil
+}
+
+// restoreSheetMetalRip rebuilds a rip feature, erroring on a missing payload or unknown sketch.
+func restoreSheetMetalRip(fs *PartFeatures, d *SheetMetalRipData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sheet-metal rip feature is missing its payload")
+	}
+	s, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("sheet-metal rip references sketch %d which is not in the part", d.Sketch)
+	}
+	def := &SheetMetalRipDefinition{Sketch: s, LineIndex: d.Line}
+	if d.Gap != 0 {
+		def.Gap = constFloat(d.Gap)
+	}
+	return NewSheetMetalRipFeatures(fs).Add(def), nil
+}

--- a/model/feature/sheet_metal_cosmetic_bend.go
+++ b/model/feature/sheet_metal_cosmetic_bend.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Cosmetic Bend feature (M13-F03). A cosmetic bend marks a fold line on the sheet
+// for manufacturing WITHOUT deforming the model — the part stays flat (or as built), but the
+// bend joins the bend table and bend-allowance preview ([compdef.Bends]) so the developed length
+// and the fold annotation are reported. It is the geometry-neutral counterpart of the Bend
+// feature: same sketch-line + angle + radius inputs, but Recompute leaves the body unchanged.
+// Use it to call out a bend a downstream process applies, or to annotate a part modelled flat.
+
+// SheetMetalCosmeticBendDefinition is the cosmetic-bend recipe: the sketch bend line (sketch +
+// line index), the bend angle (parameter-backed; nil ⇒ 90°), and an optional inside-radius
+// override (nil ⇒ the rule's bend radius).
+type SheetMetalCosmeticBendDefinition struct {
+	Sketch    *sketch.Sketch
+	LineIndex int
+	Angle     func() float64
+	Radius    func() float64
+}
+
+// SheetMetalCosmeticBendFeature records the cosmetic bend each recompute, passing the body
+// through unchanged.
+type SheetMetalCosmeticBendFeature struct {
+	def      *SheetMetalCosmeticBendDefinition
+	featName string
+}
+
+// Definition returns the cosmetic-bend recipe.
+func (f *SheetMetalCosmeticBendFeature) Definition() *SheetMetalCosmeticBendDefinition {
+	return f.def
+}
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalCosmeticBendFeature) Kind() string { return "sheet-metal-cosmetic-bend" }
+
+// Recompute validates the bend line resolves (so a dangling line reports the feature sick) and
+// leaves the geometry untouched — a cosmetic bend annotates, it does not fold.
+func (f *SheetMetalCosmeticBendFeature) Recompute(in Input) (Output, error) {
+	if _, _, _, err := sketchBendLine(f.def.Sketch, f.def.LineIndex, false, "sheet-metal cosmetic bend"); err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: in.Bodies}, nil
+}
+
+// BendSpecs reports the cosmetic bend for the bend table / allowance preview. A nil radius
+// override defers to the rule's default (signalled by a non-positive radius).
+func (f *SheetMetalCosmeticBendFeature) BendSpecs(_ float64) []BendSpec {
+	radius := 0.0
+	if f.def.Radius != nil {
+		radius = f.def.Radius()
+	}
+	return []BendSpec{{Angle: f.resolveAngle(), Radius: radius}}
+}
+
+// resolveAngle returns the bend angle, defaulting to a 90° fold.
+func (f *SheetMetalCosmeticBendFeature) resolveAngle() float64 {
+	if f.def.Angle == nil {
+		return stdmath.Pi / 2
+	}
+	return f.def.Angle()
+}
+
+// SheetMetalCosmeticBendFeatures adds cosmetic-bend features into the engine.
+type SheetMetalCosmeticBendFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalCosmeticBendFeatures binds the collection to a feature engine.
+func NewSheetMetalCosmeticBendFeatures(engine *PartFeatures) *SheetMetalCosmeticBendFeatures {
+	return &SheetMetalCosmeticBendFeatures{engine}
+}
+
+// Add appends a cosmetic-bend feature, naming it CosmeticBend1, CosmeticBend2, … .
+func (c *SheetMetalCosmeticBendFeatures) Add(def *SheetMetalCosmeticBendDefinition) *PartFeature {
+	f := &SheetMetalCosmeticBendFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("CosmeticBend"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var (
+	_ Feature     = (*SheetMetalCosmeticBendFeature)(nil)
+	_ BendLineage = (*SheetMetalCosmeticBendFeature)(nil)
+)

--- a/model/feature/sheet_metal_cosmetic_bend_test.go
+++ b/model/feature/sheet_metal_cosmetic_bend_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestCosmeticBendLeavesGeometryUnchanged a cosmetic bend records the fold but does not deform
+// the sheet — the body is the flat base, unchanged, and the feature is healthy.
+func TestCosmeticBendLeavesGeometryUnchanged(t *testing.T) {
+	fs, line := sheetForBend(t, 4, 2)
+	fs.Recompute()
+	flat := fs.Result()[0]
+	flatBox := flat.RangeBox()
+
+	pf := NewSheetMetalCosmeticBendFeatures(fs).Add(&SheetMetalCosmeticBendDefinition{Sketch: line, LineIndex: 0})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("cosmetic bend sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if box := body.RangeBox(); box.Max.Z != flatBox.Max.Z {
+		t.Errorf("cosmetic bend changed the geometry: maxZ %g → %g (it must not fold)", flatBox.Max.Z, box.Max.Z)
+	}
+}
+
+// TestCosmeticBendReportsBendSpec the cosmetic bend contributes its angle/radius to the bend
+// table (BendLineage), defaulting to a 90° fold at the rule radius.
+func TestCosmeticBendReportsBendSpec(t *testing.T) {
+	f := &SheetMetalCosmeticBendFeature{def: &SheetMetalCosmeticBendDefinition{}}
+	specs := f.BendSpecs(0.2)
+	if len(specs) != 1 {
+		t.Fatalf("BendSpecs = %d, want 1", len(specs))
+	}
+	if stdmath.Abs(specs[0].Angle-stdmath.Pi/2) > 1e-12 {
+		t.Errorf("default cosmetic bend angle = %g, want π/2", specs[0].Angle)
+	}
+	if specs[0].Radius != 0 {
+		t.Errorf("a nil radius override should report 0 (rule default), got %g", specs[0].Radius)
+	}
+}
+
+// TestCosmeticBendRejectsBadLine a line index outside the sketch makes the feature sick (the
+// dangling bend line is reported, not silently ignored).
+func TestCosmeticBendRejectsBadLine(t *testing.T) {
+	fs, line := sheetForBend(t, 4, 2)
+	pf := NewSheetMetalCosmeticBendFeatures(fs).Add(&SheetMetalCosmeticBendDefinition{Sketch: line, LineIndex: 7})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("cosmetic bend with an out-of-range line index should be sick")
+	}
+}
+
+// TestCosmeticBendRoundTrip a cosmetic bend persists its bend line + angle/radius and restores.
+func TestCosmeticBendRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(2, 4))
+	NewSheetMetalCosmeticBendFeatures(fs).Add(&SheetMetalCosmeticBendDefinition{
+		Sketch: sk, LineIndex: 0, Angle: constFloat(stdmath.Pi / 3), Radius: constFloat(0.3),
+	})
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if data[0].Kind != "sheet-metal-cosmetic-bend" || data[0].SheetMetalCosmeticBend == nil {
+		t.Fatalf("marshaled = %+v", data[0])
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-cosmetic-bend" {
+		t.Errorf("restored %d features, want one cosmetic bend", fresh.Count())
+	}
+}

--- a/model/feature/sheet_metal_lip.go
+++ b/model/feature/sheet_metal_lip.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// Sheet-metal Lip feature (M13-F03). A lip is a stiffening edge return: a short flange folded up
+// over a bend, then curled 180° back on itself (a J/hem-with-stand-off profile) so the free edge
+// is safe and rigid. It is built like a flange — one constant-thickness cross-section band
+// extruded along the picked edge — but the band continues past the flange wall through a second
+// (return) bend and a return wall. The band turns the same way through both bends, so the inner
+// surface stays the inner radius and the outer stays +thickness throughout (no surface swap).
+
+// lipFacetStep caps each arc's facet size (~10°), matching the flange/bend faceting.
+const lipFacetStep = stdmath.Pi / 18
+
+// SheetMetalLipDefinition is the lip recipe: the edge to build on, the flange wall height, the
+// flange and return bend angles/radii (parameter-backed; nil ⇒ defaults), the return wall
+// length, and a flip that folds to the opposite side of the sheet.
+type SheetMetalLipDefinition struct {
+	EdgeKey      []byte
+	Height       func() float64 // flange wall height before the return
+	Angle        func() float64 // flange bend angle (radians); nil ⇒ 90°
+	Radius       func() float64 // inside bend radius; nil ⇒ rule BendRadius
+	ReturnLength func() float64 // return wall length after the 180° curl
+	Flip         bool
+}
+
+// SheetMetalLipFeature folds a stiffening lip onto the sheet each recompute.
+type SheetMetalLipFeature struct {
+	def      *SheetMetalLipDefinition
+	featName string
+}
+
+// Definition returns the lip recipe.
+func (f *SheetMetalLipFeature) Definition() *SheetMetalLipDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalLipFeature) Kind() string { return "sheet-metal-lip" }
+
+// Recompute resolves the edge and dimensions, builds the lip band solid, and unions it on.
+func (f *SheetMetalLipFeature) Recompute(in Input) (Output, error) {
+	body, err := lastBody(in, "sheet-metal lip")
+	if err != nil {
+		return Output{}, err
+	}
+	dims, err := f.resolveDims(in.Params)
+	if err != nil {
+		return Output{}, err
+	}
+	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	if err != nil {
+		return Output{}, err
+	}
+	wall, err := buildLipSolid(edges[0], dims, f.def.Flip, f.featName)
+	if err != nil {
+		return Output{}, err
+	}
+	bodies, err := combine(in.Bodies, wall, ops.Join)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// lipDims is the resolved, validated set of lip dimensions for one recompute. The return bend
+// uses the same inside radius as the flange; its angle is a half turn (180°).
+type lipDims struct{ thickness, radius, height, angle, returnLen float64 }
+
+// resolveDims reads thickness (live), the bend radius (override or rule), the flange height,
+// angle, and the return length, erroring if any required value is non-positive.
+func (f *SheetMetalLipFeature) resolveDims(ps *param.Parameters) (lipDims, error) {
+	t, err := sheetThickness(ps)
+	if err != nil {
+		return lipDims{}, err
+	}
+	d := lipDims{
+		thickness: t, radius: f.resolveRadius(ps), height: evalFloat(f.def.Height),
+		angle: f.resolveAngle(), returnLen: evalFloat(f.def.ReturnLength),
+	}
+	if d.radius <= 0 || d.height <= 0 || d.angle <= 0 || d.returnLen <= 0 {
+		return lipDims{}, fmt.Errorf("sheet-metal lip: radius/height/angle/returnLength must be positive (r=%g h=%g a=%g L=%g)", d.radius, d.height, d.angle, d.returnLen)
+	}
+	return d, nil
+}
+
+// resolveRadius returns the bend radius: the override closure, else the rule's BendRadius
+// parameter, else 0 (which Recompute rejects).
+func (f *SheetMetalLipFeature) resolveRadius(ps *param.Parameters) float64 {
+	if f.def.Radius != nil {
+		return f.def.Radius()
+	}
+	if ps != nil {
+		if p, ok := ps.ByName(flangeBendParamName); ok {
+			return p.ModelValue()
+		}
+	}
+	return 0
+}
+
+// resolveAngle returns the flange bend angle, defaulting to a 90° fold.
+func (f *SheetMetalLipFeature) resolveAngle() float64 {
+	if f.def.Angle == nil {
+		return stdmath.Pi / 2
+	}
+	return f.def.Angle()
+}
+
+// buildLipSolid constructs the lip band solid on edge: the cross-section band (flange bend +
+// wall + 180° return bend + return wall) extruded along the edge.
+func buildLipSolid(edge *topo.Edge, d lipDims, flip bool, feat string) (*topo.Body, error) {
+	v0, v1 := edge.StartVertex().Point(), edge.EndVertex().Point()
+	e, err := math.UnitVector3FromVector(v0.VectorTo(v1))
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal lip: degenerate edge")
+	}
+	up, out, err := flangeFrame(edge, v0.Midpoint(v1), e, flip)
+	if err != nil {
+		return nil, err
+	}
+	plane := planePerp(v0, e)
+	u, v := plane.XAxis().AsVector(), plane.YAxis().AsVector()
+	proj := func(w math.Vector3) math.Point2 { return math.P2(w.Dot(u), w.Dot(v)) }
+	poly := lipBandPolygon(out.AsVector(), up.AsVector(), d, proj)
+	return buildPrism(poly, plane, span{near: 0, far: v0.DistanceTo(v1)}, 0, feat), nil
+}
+
+// lipTurtle walks the band's inner surface, emitting the inner and outer (inner + normal·t)
+// boundary points. It tracks a position and heading in the (out, up) section plane; the outer
+// side is the heading rotated −90°, so a consistent left turn keeps the inner radius inside.
+type lipTurtle struct {
+	pos, tang math.Vector2 // inner-surface point and unit heading, in (out, up) components
+	t         float64      // band thickness
+	inner     []math.Vector2
+	outer     []math.Vector2
+}
+
+// emit records the current inner point and its outer offset.
+func (lt *lipTurtle) emit() {
+	n := math.V2(lt.tang.Y, -lt.tang.X) // heading rotated −90° ⇒ outer side
+	lt.inner = append(lt.inner, lt.pos)
+	lt.outer = append(lt.outer, lt.pos.Add(n.Scale(lt.t)))
+}
+
+// straight advances the turtle by len along its heading.
+func (lt *lipTurtle) straight(length float64) {
+	lt.emit()
+	lt.pos = lt.pos.Add(lt.tang.Scale(length))
+	lt.emit()
+}
+
+// rotate2 rotates a 2D vector by angle (counter-clockwise).
+func rotate2(v math.Vector2, angle float64) math.Vector2 {
+	c, s := stdmath.Cos(angle), stdmath.Sin(angle)
+	return math.V2(v.X*c-v.Y*s, v.X*s+v.Y*c)
+}
+
+// lipBandPolygon returns the lip cross-section as a closed 2D polygon in the section plane: the
+// flange bend (radius r, angle a), the flange wall (height h), the 180° return bend (radius r),
+// and the return wall (length L) — then projected via proj. The loop is inner-forward then
+// outer-reversed.
+func lipBandPolygon(out, up math.Vector3, d lipDims, proj func(math.Vector3) math.Point2) []math.Point2 {
+	lt := &lipTurtle{pos: math.V2(0, 0), tang: math.V2(1, 0), t: d.thickness} // start at the edge, heading +out
+	lt.runPath(d)
+	poly := make([]math.Point2, 0, len(lt.inner)+len(lt.outer))
+	to3 := func(c math.Vector2) math.Point2 { return proj(out.Scale(c.X).Add(up.Scale(c.Y))) }
+	for _, p := range lt.inner {
+		poly = append(poly, to3(p))
+	}
+	for k := len(lt.outer) - 1; k >= 0; k-- {
+		poly = append(poly, to3(lt.outer[k]))
+	}
+	return poly
+}
+
+// runPath drives the turtle through the lip's four segments (all left turns, so the band's inner
+// surface stays the inner radius throughout).
+func (lt *lipTurtle) runPath(d lipDims) {
+	lt.arcSeg(d.radius, d.angle)    // flange bend
+	lt.straight(d.height)           // flange wall
+	lt.arcSeg(d.radius, stdmath.Pi) // 180° return
+	lt.straight(d.returnLen)        // return wall
+}
+
+// arcSeg sweeps a left arc of inside radius r through angle, emitting faceted inner/outer points
+// and advancing the turtle's position and heading to the arc's end.
+func (lt *lipTurtle) arcSeg(r, angle float64) {
+	centre := lt.pos.Add(math.V2(-lt.tang.Y, lt.tang.X).Scale(r))
+	rel0, tang0 := lt.pos.Sub(centre), lt.tang
+	steps := int(stdmath.Max(2, stdmath.Round(angle/lipFacetStep)))
+	for k := 0; k <= steps; k++ {
+		phi := angle * float64(k) / float64(steps)
+		lt.pos = centre.Add(rotate2(rel0, phi))
+		lt.tang = rotate2(tang0, phi)
+		lt.emit()
+	}
+}
+
+// SheetMetalLipFeatures adds lip features into the engine.
+type SheetMetalLipFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalLipFeatures binds the collection to a feature engine.
+func NewSheetMetalLipFeatures(engine *PartFeatures) *SheetMetalLipFeatures {
+	return &SheetMetalLipFeatures{engine}
+}
+
+// Add appends a lip feature, naming it Lip1, Lip2, … . (The dress-up "lip" bead is a separate,
+// solid-modeling feature; this is the sheet-metal edge return.)
+func (c *SheetMetalLipFeatures) Add(def *SheetMetalLipDefinition) *PartFeature {
+	f := &SheetMetalLipFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Lip"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalLipFeature)(nil)

--- a/model/feature/sheet_metal_lip_test.go
+++ b/model/feature/sheet_metal_lip_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// lipDef returns a lip recipe with a 90° flange of the given height and a return wall — the
+// common stiffening-lip case.
+func lipDef(edge []byte, height, returnLen float64) *SheetMetalLipDefinition {
+	return &SheetMetalLipDefinition{
+		EdgeKey:      edge,
+		Height:       func() float64 { return height },
+		Radius:       func() float64 { return 0.2 },
+		Angle:        func() float64 { return stdmath.Pi / 2 },
+		ReturnLength: func() float64 { return returnLen },
+	}
+}
+
+// TestLipBuildsWatertightStiffener a lip folds a flange + 180° return onto an edge, yielding one
+// watertight solid that rises above the sheet and adds material (the lip band).
+func TestLipBuildsWatertightStiffener(t *testing.T) {
+	fs, edge := seedSheetMetalSheet(t, 4, map[string]string{"BendRadius": "2 mm"})
+	base := sheetVolume(fs.Result()[0])
+
+	pf := NewSheetMetalLipFeatures(fs).Add(lipDef(edge.ReferenceKey(), 1.0, 0.4))
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("lip sick: %s", pf.Health().Reason)
+	}
+	if n := len(fs.Result()); n != 1 {
+		t.Fatalf("lip result = %d bodies, want 1", n)
+	}
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	if v := sheetVolume(body); !(v > base) {
+		t.Errorf("lip added no material: %g vs base %g", v, base)
+	}
+	if z := body.RangeBox().Max.Z; z < 0.8 {
+		t.Errorf("lip flange should rise (maxZ=%g), want it to stand up", z)
+	}
+}
+
+// TestLipRejectsBadDims a lip with a non-positive height/return errors.
+func TestLipRejectsBadDims(t *testing.T) {
+	fs, edge := seedSheetMetalSheet(t, 4, map[string]string{"BendRadius": "2 mm"})
+	pf := NewSheetMetalLipFeatures(fs).Add(lipDef(edge.ReferenceKey(), 1.0, 0)) // zero return length
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("lip with a zero return length should be sick")
+	}
+}

--- a/model/feature/sheet_metal_punch.go
+++ b/model/feature/sheet_metal_punch.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Punch Tool feature (M13-F03). A punch stamps every closed profile of a sketch
+// through the sheet in one shot — the die-pattern counterpart of the single-profile Cut, for a
+// row of louvers, a grid of vents, or a perforation array placed from one sketch. By default it
+// punches through all the material; a depth limits it to a coined/embossed cutout. The geometry
+// reuses the shared profile-prism builder + through-all span, so a punch is the boolean
+// complement of the sketch's thickened profiles.
+
+// SheetMetalPunchDefinition is the punch recipe: the sketch whose closed profiles are stamped,
+// and an optional depth (nil ⇒ through all).
+type SheetMetalPunchDefinition struct {
+	Sketch    *sketch.Sketch
+	Direction ExtentDirection
+	Depth     func() float64 // nil ⇒ punch through all the material
+}
+
+// SheetMetalPunchFeature stamps the sketch's profiles through the running sheet each recompute.
+type SheetMetalPunchFeature struct {
+	def      *SheetMetalPunchDefinition
+	featName string
+}
+
+// Definition returns the punch recipe.
+func (f *SheetMetalPunchFeature) Definition() *SheetMetalPunchDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalPunchFeature) Kind() string { return "sheet-metal-punch" }
+
+// Recompute resolves every closed profile of the sketch, builds the punch tool, and subtracts
+// it from the sheet.
+func (f *SheetMetalPunchFeature) Recompute(in Input) (Output, error) {
+	n := f.def.Sketch.Profiles().Count()
+	if n == 0 {
+		return Output{}, fmt.Errorf("sheet-metal punch: the sketch has no closed profile to punch")
+	}
+	indices := make([]int, n)
+	for i := range indices {
+		indices[i] = i
+	}
+	profiles, err := resolveClosedProfiles(f.def.Sketch, indices, "sheet-metal punch")
+	if err != nil {
+		return Output{}, err
+	}
+	plane := f.def.Sketch.Plane()
+	sp, err := f.punchSpan(in.Bodies, plane)
+	if err != nil {
+		return Output{}, err
+	}
+	tool := buildProfilePrisms(profiles, plane, sp, 0, f.featName)
+	bodies, err := combine(in.Bodies, tool, ops.Cut)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// punchSpan returns the punch's span: a fixed depth when Depth is set, else through all the
+// running material on the chosen side of the sketch plane.
+func (f *SheetMetalPunchFeature) punchSpan(bodies []*topo.Body, plane sketch.Plane) (span, error) {
+	if f.def.Depth != nil {
+		return distanceSpan(Extent{Type: DistanceExtent, Direction: f.def.Direction, Distance: f.def.Depth})
+	}
+	return throughAllSpan(Extent{Type: ThroughAllExtent, Direction: f.def.Direction}, bodies, plane)
+}
+
+// SheetMetalPunchFeatures adds punch features into the engine.
+type SheetMetalPunchFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalPunchFeatures binds the collection to a feature engine.
+func NewSheetMetalPunchFeatures(engine *PartFeatures) *SheetMetalPunchFeatures {
+	return &SheetMetalPunchFeatures{engine}
+}
+
+// Add appends a punch feature, naming it Punch1, Punch2, … .
+func (c *SheetMetalPunchFeatures) Add(def *SheetMetalPunchDefinition) *PartFeature {
+	f := &SheetMetalPunchFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Punch"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalPunchFeature)(nil)

--- a/model/feature/sheet_metal_punch_test.go
+++ b/model/feature/sheet_metal_punch_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// twoHolePunchSketch builds a sketch with two small square profiles (the punch die pattern),
+// placed inside a 4×4 sheet.
+func twoHolePunchSketch() *sketch.Sketch {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	for _, c := range []math.Point2{math.P2(1, 1), math.P2(3, 3)} {
+		a := sk.Points().Add(math.P2(c.X-0.3, c.Y-0.3))
+		b := sk.Points().Add(math.P2(c.X+0.3, c.Y-0.3))
+		d := sk.Points().Add(math.P2(c.X+0.3, c.Y+0.3))
+		e := sk.Points().Add(math.P2(c.X-0.3, c.Y+0.3))
+		sk.Lines().Add(a, b)
+		sk.Lines().Add(b, d)
+		sk.Lines().Add(d, e)
+		sk.Lines().Add(e, a)
+	}
+	return sk
+}
+
+// TestPunchStampsEveryProfile a punch removes all of the sketch's closed profiles in one shot,
+// leaving one watertight solid with material removed.
+func TestPunchStampsEveryProfile(t *testing.T) {
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	fs.Recompute()
+	full := sheetVolume(fs.Result()[0])
+
+	pf := NewSheetMetalPunchFeatures(fs).Add(&SheetMetalPunchDefinition{Sketch: twoHolePunchSketch()})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("punch sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	// Two 0.6×0.6 holes through a 2 mm sheet remove 2·0.36·0.2 = 0.144 cm³.
+	if v := sheetVolume(body); !(v < full-0.1) {
+		t.Errorf("punch removed too little: %g vs %g", v, full)
+	}
+}
+
+// TestPunchRejectsEmptySketch a punch with no closed profile is sick.
+func TestPunchRejectsEmptySketch(t *testing.T) {
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	empty := sketch.NewSketches().Add(sketch.XYPlane()) // no profiles
+	pf := NewSheetMetalPunchFeatures(fs).Add(&SheetMetalPunchDefinition{Sketch: empty})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("punch with no closed profile should be sick")
+	}
+}
+
+// TestPunchRoundTrip a punch persists its sketch + depth and restores.
+func TestPunchRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := twoHolePunchSketch()
+	NewSheetMetalPunchFeatures(fs).Add(&SheetMetalPunchDefinition{Sketch: sk, Depth: constFloat(0.1)})
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if data[0].Kind != "sheet-metal-punch" || data[0].SheetMetalPunch == nil || data[0].SheetMetalPunch.Depth != 0.1 {
+		t.Fatalf("marshaled = %+v", data[0])
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-punch" {
+		t.Errorf("restored %d features, want one punch", fresh.Count())
+	}
+}

--- a/model/feature/sheet_metal_rip.go
+++ b/model/feature/sheet_metal_rip.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Sheet-metal Rip feature (M13-F03). A rip cuts a narrow slit of a given gap width along a
+// sketch line, through the full thickness — opening a seam so a closed or folded sheet can be
+// developed flat (a rip across a corner or roll lets the part unfold). The geometry is a thin
+// rectangular cutter (the line offset ±gap/2) subtracted through-all, so a rip is the boolean
+// complement of a sliver prism — the same machinery the Cut feature uses, narrowed to a line.
+
+// ripOvershoot extends the cutter a hair past the line's endpoints so a rip that reaches a
+// boundary cuts cleanly through it rather than leaving a coincident-face sliver.
+const ripOvershoot = 1e-4
+
+// SheetMetalRipDefinition is the rip recipe: the sketch line to rip along and the gap width the
+// slit opens (parameter-backed).
+type SheetMetalRipDefinition struct {
+	Sketch    *sketch.Sketch
+	LineIndex int
+	Gap       func() float64
+}
+
+// SheetMetalRipFeature slits the running sheet along the rip line each recompute.
+type SheetMetalRipFeature struct {
+	def      *SheetMetalRipDefinition
+	featName string
+}
+
+// Definition returns the rip recipe.
+func (f *SheetMetalRipFeature) Definition() *SheetMetalRipDefinition { return f.def }
+
+// Kind identifies the feature for serialization and the model tree.
+func (f *SheetMetalRipFeature) Kind() string { return "sheet-metal-rip" }
+
+// Recompute resolves the rip line, builds the slit cutter, and subtracts it through the sheet.
+func (f *SheetMetalRipFeature) Recompute(in Input) (Output, error) {
+	a, b, err := sketchLineEnds(f.def.Sketch, f.def.LineIndex, "sheet-metal rip")
+	if err != nil {
+		return Output{}, err
+	}
+	gap := evalFloat(f.def.Gap)
+	if gap <= 0 {
+		return Output{}, fmt.Errorf("sheet-metal rip: gap must be positive, got %g", gap)
+	}
+	plane := f.def.Sketch.Plane()
+	sp, err := throughAllSpan(Extent{Type: ThroughAllExtent}, in.Bodies, plane)
+	if err != nil {
+		return Output{}, err
+	}
+	tool := buildPrism(ripPolygon(a, b, gap), plane, sp, 0, f.featName)
+	bodies, err := combine(in.Bodies, tool, ops.Cut)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// ripPolygon is the slit cutter cross-section: the rectangle bounded by the line offset ±gap/2
+// perpendicular, extended by ripOvershoot past each end so a boundary-reaching rip cuts through.
+func ripPolygon(a, b math.Point2, gap float64) []math.Point2 {
+	dir := a.VectorTo(b)
+	if l := dir.Length(); l > 0 {
+		dir = dir.Scale(1 / l)
+	}
+	perp := math.V2(-dir.Y, dir.X).Scale(gap / 2)
+	a = a.TranslateBy(dir.Scale(-ripOvershoot))
+	b = b.TranslateBy(dir.Scale(ripOvershoot))
+	return []math.Point2{
+		a.TranslateBy(perp.Negate()), b.TranslateBy(perp.Negate()),
+		b.TranslateBy(perp), a.TranslateBy(perp),
+	}
+}
+
+// sketchLineEnds returns the 2D endpoints of a sketch line, erroring (named by what) when the
+// line index is out of range.
+func sketchLineEnds(sk *sketch.Sketch, lineIndex int, what string) (a, b math.Point2, err error) {
+	lines := sk.Lines()
+	if lineIndex < 0 || lineIndex >= lines.Count() {
+		return a, b, fmt.Errorf("%s: line index %d out of range (%d lines)", what, lineIndex, lines.Count())
+	}
+	l := lines.Item(lineIndex)
+	return l.StartPoint().Position(), l.EndPoint().Position(), nil
+}
+
+// SheetMetalRipFeatures adds rip features into the engine.
+type SheetMetalRipFeatures struct{ engine *PartFeatures }
+
+// NewSheetMetalRipFeatures binds the collection to a feature engine.
+func NewSheetMetalRipFeatures(engine *PartFeatures) *SheetMetalRipFeatures {
+	return &SheetMetalRipFeatures{engine}
+}
+
+// Add appends a rip feature, naming it Rip1, Rip2, … .
+func (c *SheetMetalRipFeatures) Add(def *SheetMetalRipDefinition) *PartFeature {
+	f := &SheetMetalRipFeature{def: def}
+	pf := c.engine.Add(f)
+	pf.SetName(c.engine.UniqueName("Rip"))
+	f.featName = pf.Name()
+	return pf
+}
+
+var _ Feature = (*SheetMetalRipFeature)(nil)

--- a/model/feature/sheet_metal_rip_test.go
+++ b/model/feature/sheet_metal_rip_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// sheetForRip builds a 4×4 sheet-metal wall (2 mm thick) on XY plus a rip-line sketch, and
+// returns the engine and the rip sketch ready to add a rip.
+func sheetForRip(t *testing.T, a, b math.Point2) (*PartFeatures, *sketch.Sketch) {
+	t.Helper()
+	ps := param.NewParameters()
+	mustParam(t, ps, "Thickness", "2 mm")
+	fs := NewPartFeatures(ps, nil)
+	NewSheetMetalFaceFeatures(fs).Add(&SheetMetalFaceDefinition{Sketch: squareSketch(4), ProfileIndex: 0, Operation: ops.NewBody})
+	rip := sketch.NewSketches().Add(sketch.XYPlane())
+	rip.Lines().AddByTwoPoints(a, b)
+	return fs, rip
+}
+
+// TestRipSlitsSheet a rip cuts a slit along the line, removing material and leaving one
+// watertight solid (a partial rip line keeps the sheet connected).
+func TestRipSlitsSheet(t *testing.T) {
+	fs, rip := sheetForRip(t, math.P2(1, 2), math.P2(3, 2)) // a line across the middle, ends inside
+	fs.Recompute()
+	full := sheetVolume(fs.Result()[0])
+
+	pf := NewSheetMetalRipFeatures(fs).Add(&SheetMetalRipDefinition{Sketch: rip, LineIndex: 0, Gap: func() float64 { return 0.05 }})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("rip sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	if v := sheetVolume(body); !(v < full) {
+		t.Errorf("rip removed no material: %g vs %g", v, full)
+	}
+}
+
+// TestRipRejectsBadInput a rip with an out-of-range line index, or a non-positive gap, is sick.
+func TestRipRejectsBadInput(t *testing.T) {
+	fs, rip := sheetForRip(t, math.P2(1, 2), math.P2(3, 2))
+	bad := NewSheetMetalRipFeatures(fs).Add(&SheetMetalRipDefinition{Sketch: rip, LineIndex: 9, Gap: func() float64 { return 0.05 }})
+	fs.Recompute()
+	if bad.Health().OK() {
+		t.Error("rip with an out-of-range line index should be sick")
+	}
+
+	fs2, rip2 := sheetForRip(t, math.P2(1, 2), math.P2(3, 2))
+	zero := NewSheetMetalRipFeatures(fs2).Add(&SheetMetalRipDefinition{Sketch: rip2, LineIndex: 0, Gap: func() float64 { return 0 }})
+	fs2.Recompute()
+	if zero.Health().OK() {
+		t.Error("rip with a non-positive gap should be sick")
+	}
+}
+
+// TestRipRoundTrip a rip persists its line + gap and restores.
+func TestRipRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(1, 2), math.P2(3, 2))
+	NewSheetMetalRipFeatures(fs).Add(&SheetMetalRipDefinition{Sketch: sk, LineIndex: 0, Gap: constFloat(0.05)})
+
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if data[0].Kind != "sheet-metal-rip" || data[0].SheetMetalRip == nil || data[0].SheetMetalRip.Gap != 0.05 {
+		t.Fatalf("marshaled = %+v", data[0])
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if fresh.Count() != 1 || fresh.Item(0).Kind() != "sheet-metal-rip" {
+		t.Errorf("restored %d features, want one rip", fresh.Count())
+	}
+}


### PR DESCRIPTION
## What

Completes M13-F03 (Sheet Metal Modify Features). Cut and Corner Seam shipped earlier; this adds the four remaining modify features, each as a generic `features.add` kind (no API change), wired end-to-end (model + serialize + opregistry + registry) with model and opregistry tests:

- **Cosmetic Bend** (`sheetMetalCosmeticBend`) — marks a fold line for the bend table **without** deforming the model (geometry-neutral; reports via `BendLineage`).
- **Rip** (`sheetMetalRip`) — a through-thickness slit of a given gap width along a sketch line, to open a seam so a closed/folded sheet can develop flat.
- **Punch Tool** (`sheetMetalPunch`) — stamps **every** closed profile of a sketch through the sheet in one die-pattern operation (vents, louvers, perforations); through-all by default, optional depth.
- **Lip** (`sheetMetalLip`) — a stiffening edge return: a short flange curled 180° back on itself (J profile). Built as one constant-thickness band via a turtle that walks the flange bend → wall → 180° return → return wall, all turning the same way so the inner surface stays the inner radius throughout. Named `sheetMetalLip` to avoid colliding with the existing solid-modeling `lip` bead.

## Notes

- Cosmetic Bend's flat-pattern fold-line placement (mid-sheet development) rides on the same follow-up as other mid-sheet bend lines; it contributes to the bend table today.
- A shared `optionalBendDims` helper resolves the optional angle/radius for Bend and Cosmetic Bend.

## Tests

- `model/feature`: each feature's geometry (watertight where solid-modifying, geometry-neutral for cosmetic bend), validation/error paths, and serialize round-trips.
- `addin/opregistry`: apply success + error paths (non-sheet-metal part, missing edge/sketch, bad dimensions); registry-coverage + apply-success lists updated.
- Root `golangci-lint` 0 issues; full build green.

Follow-up: a bridge e2e PR will register the four new kinds in `TestE2EFeatureRegistryCoverage` (per the usual coverage-drift cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)