### PR TITLE
fix(sketch): invalidate Profiles() cache on a circle/ellipse radius change

### DIFF
--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -175,17 +175,41 @@ func (s *Sketch) geomSignature() uint64 {
 		mix(stdmath.Float64bits(p.X))
 		mix(stdmath.Float64bits(p.Y))
 	}
-	// Construction/centerline entities are excluded from profiles (normalGeometry),
-	// so toggling that flag changes the regions without changing any coordinate —
-	// fold it in so the cache invalidates on a construction toggle.
 	for _, e := range s.ents {
+		// Construction/centerline entities are excluded from profiles (normalGeometry), so
+		// toggling that flag changes the regions without changing any coordinate — fold it in.
 		if cg, ok := e.(interface{ IsConstruction() bool }); ok && cg.IsConstruction() {
 			mix(1)
 		} else {
 			mix(2)
 		}
+		mixEntityScalars(mix, e)
 	}
 	return h
+}
+
+// mixEntityScalars folds an entity's intrinsic scalars that are NOT stored as points — a
+// circle's radius, an ellipse's axes/angles. A dimension resizing one (e.g. radius = od/2)
+// leaves the centre point, and so the point-coordinate signature, unchanged; without this the
+// cache would return a stale profile and break parametric resize (the spacer/flange regressions).
+func mixEntityScalars(mix func(uint64), e Entity) {
+	bits := func(v math.Scalar) { mix(stdmath.Float64bits(float64(v))) }
+	switch c := e.(type) {
+	case *Circle:
+		bits(c.Radius)
+	case *Ellipse:
+		bits(c.MajorRadius)
+		bits(c.MinorRadius)
+		bits(c.MajorAxis.X)
+		bits(c.MajorAxis.Y)
+	case *EllipticalArc:
+		bits(c.MajorRadius)
+		bits(c.MinorRadius)
+		bits(c.MajorAxis.X)
+		bits(c.MajorAxis.Y)
+		bits(c.StartAngle)
+		bits(c.EndAngle)
+	}
 }
 
 // ClosedLoops returns the sketch's standalone closed loops detected by endpoint chaining

--- a/model/sketch/profile_cache_test.go
+++ b/model/sketch/profile_cache_test.go
@@ -70,6 +70,34 @@ func TestProfilesCacheInvalidatesOnRadiusChange(t *testing.T) {
 	}
 }
 
+// TestProfilesCacheInvalidatesOnEllipseChange the same stored-scalar guard for ellipses and
+// elliptical arcs (major/minor radii, axis, and arc angles are not points either).
+func TestProfilesCacheInvalidatesOnEllipseChange(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		build func(*Sketch) func()
+	}{
+		{"ellipse major radius", func(s *Sketch) func() {
+			e := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 0.4, 0.2)
+			return func() { e.MajorRadius = 0.6 }
+		}},
+		{"elliptical-arc end angle", func(s *Sketch) func() {
+			e := s.EllipticalArcs().Add(math.P2(0, 0), math.V2(1, 0), 0.4, 0.2, 0, 3.0)
+			return func() { e.EndAngle = 2.0 }
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			s := NewSketches().Add(XYPlane())
+			resize := c.build(s)
+			before := s.Profiles()
+			resize() // change a stored scalar in place — no point moves
+			if s.Profiles() == before {
+				t.Fatalf("Profiles() cache not invalidated after a %s change", c.name)
+			}
+		})
+	}
+}
+
 // TestProfilesCappedForHugeSketch checks that a sketch past the entity cap (an
 // imported drawing) offers no profiles and returns immediately, so the hover
 // picker never arranges hundreds of thousands of segments.

--- a/model/sketch/profile_cache_test.go
+++ b/model/sketch/profile_cache_test.go
@@ -56,6 +56,20 @@ func TestProfilesCacheInvalidatesOnConstructionToggle(t *testing.T) {
 	}
 }
 
+// TestProfilesCacheInvalidatesOnRadiusChange guards the regression where resizing a circle via
+// its radius (a stored DOF, not a point) — e.g. a "radius = od/2" dimension driven by a
+// parameter — left every point unmoved, so the cached profiles went stale and a parametric
+// resize produced the OLD geometry (the spacer/flange resize failures).
+func TestProfilesCacheInvalidatesOnRadiusChange(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.Circles().AddByCenterRadius(math.P2(0, 0), 0.3)
+	before := s.Profiles()
+	s.circles.items[0].Radius = 0.4 // resize in place — the centre point does not move
+	if s.Profiles() == before {
+		t.Fatal("Profiles() cache not invalidated after a circle radius change")
+	}
+}
+
 // TestProfilesCappedForHugeSketch checks that a sketch past the entity cap (an
 // imported drawing) offers no profiles and returns immediately, so the hover
 // picker never arranges hundreds of thousands of segments.


### PR DESCRIPTION
## What

The `Profiles()` memoisation (8e1f400, "cache Profiles() — the dense-sketch hover freeze") keys its cache on a geometry signature folded from entity/point **counts + every point coordinate**. A circle's radius and an ellipse's axes are **stored scalars, not points**, so resizing one via a dimension (e.g. `radius = od/2` driven by a parameter) moves no point → the signature is unchanged → `Profiles()` returns the **stale** cached profile.

Result: a **parametric resize produced the old geometry** — a spacer or flange resized by changing `od` kept its original volume.

## Fix

Fold each entity's intrinsic non-point scalars into the signature: a circle's radius; an ellipse's major/minor radii + axis direction; an elliptical arc's radii + axis + start/end angles. (An arc's radius is the centre→start distance, already captured by its points, so it needs nothing extra.)

## Tests

- New `TestProfilesCacheInvalidatesOnRadiusChange`: resizing a circle in place (no point moves) invalidates the cache.
- Full `model/sketch` suite green; lint 0 issues.
- Verified the downstream regressions clear: the bridge's `TestNopSpacerParametric`, `TestNopLeadnutFlange`, and `TestNopBoltCircleFlangeCircularPattern` (parametric resize → expected volume) now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)