### PR TITLE
dwg: synthesise a complete AutoCAD-grade R2000 file on export

### DIFF
--- a/kernel/exchange/dwg/synth_test.go
+++ b/kernel/exchange/dwg/synth_test.go
@@ -13,9 +13,19 @@ import (
 // stream be exercised without the real .dwg corpus.
 func buildInsertObject(ownHandle, blockHandle uint64, ins [3]float64, rot float64) []byte {
 	body := NewBitWriter()
-	body.WriteHandle(0, ownHandle)     // own handle
-	body.WriteBS(0)                    // EED size 0
-	writeCommonEntityData(body)        // model-space entity (entmode 2), nolinks
+	body.WriteHandle(0, ownHandle) // own handle
+	body.WriteBS(0)                // EED size 0
+	// common entity data: model-space entity (entmode 2), nolinks (no prev/next handles).
+	body.WriteBit(0)
+	body.WriteBits(2, 2)
+	body.WriteBL(0)
+	body.WriteBit(1)
+	body.WriteBS(0)
+	body.WriteBD(1.0)
+	body.WriteBits(0, 2)
+	body.WriteBits(0, 2)
+	body.WriteBS(0)
+	body.WriteRC(0)
 	body.Write3BD(ins)                 // ins_pt
 	body.WriteBits(3, 2)               // scale_flag 3 -> (1,1,1)
 	body.WriteBD(rot)                  // rotation
@@ -218,15 +228,19 @@ func TestDecodeBlockInsertFile(t *testing.T) {
 		buildLineObject(0x10, block, entmodeBlock, [3]float64{0, 0, 0}, [3]float64{1, 0, 0}),
 		buildInsertObject(0x11, block, [3]float64{10, 5, 0}, 0),
 	}
-	b := &r2000Builder{}
+	var refs []ObjectRef
 	out := make([]byte, 0x100)
 	for i, o := range objs {
-		b.refs = append(b.refs, ObjectRef{Handle: uint64(0x10 + i), Offset: int64(len(out))})
+		refs = append(refs, ObjectRef{Handle: uint64(0x10 + i), Offset: int64(len(out))})
 		out = append(out, o...)
 	}
 	mapOff := len(out)
-	out = append(out, b.encodeObjectMap()...)
-	copy(out, b.encodeHeader(int64(mapOff), int64(len(out)-mapOff)))
+	out = append(out, encodeObjectMap(refs)...)
+	copy(out, encodeFileHeader([]SectionLocator{
+		{ID: secHeaderVars, Address: 0, Size: 0},
+		{ID: secClasses, Address: 0, Size: 0},
+		{ID: secObjectMap, Address: int64(mapOff), Size: int64(len(out) - mapOff)},
+	}))
 
 	dr, _, err := Decode(out)
 	if err != nil {

--- a/kernel/exchange/dwg/write.go
+++ b/kernel/exchange/dwg/write.go
@@ -18,8 +18,7 @@ func Write(d *Drawing) ([]byte, error) {
 	if d == nil {
 		return nil, fmt.Errorf("dwg: Write nil drawing")
 	}
-	b := newR2000Builder()
-	return b.build(d.Entities)
+	return buildR2000(d.Entities, d.Units)
 }
 
 // objectTypeBS is the BitShort type code each writable entity encodes with.
@@ -44,51 +43,6 @@ func objectTypeBS(e Entity) (int, bool) {
 	}
 }
 
-// encodeEntityObject lays out one R2000 object: the MS byte size, then the data stream
-// (BS type, RL bitsize, the object's own handle, empty EED, common entity data, geometry),
-// then the handle stream and the object CRC. bitsize — the bit offset from just after the
-// MS size to the handle stream — is computed from the pre-encoded body so it can be
-// written before the body. Validated against LibreDWG's dwgread, which reads the resulting
-// entities with no CRC mismatch.
-//
-//nolint:funlen // sequential object framing: size, type, bitsize, body, handle stream, CRC.
-func encodeEntityObject(handle uint64, e Entity) ([]byte, error) {
-	typ, ok := objectTypeBS(e)
-	if !ok {
-		return nil, fmt.Errorf("dwg: cannot write entity type %s", e.EntityType().Name())
-	}
-	body := NewBitWriter()
-	body.WriteHandle(0, handle) // the object's own handle
-	body.WriteBS(0)             // EED size 0 (none)
-	writeCommonEntityData(body)
-	writeGeometry(body, e)
-
-	bitsize := bsBits(typ) + 32 + body.Position() // type + the RL itself + body
-
-	w := NewBitWriter()
-	w.WriteBS(typ)
-	w.WriteRL(uint32(bitsize))
-	w.Append(body)
-	// Handle stream (starts exactly at bitsize, bit-packed): the common-entity handles a
-	// reader expects for a model-space entity with nolinks set — a null xdic and a null
-	// layer reference. Without these a conforming reader runs past the object decoding the
-	// handles. They are null (code 5, value 0) until a layer table is emitted.
-	w.WriteHandle(5, 0) // xdicobjhandle (null)
-	w.WriteHandle(5, 0) // layer (null)
-	w.AlignToByte()
-	payload := w.Bytes()
-
-	out := NewBitWriter()
-	out.WriteMS(len(payload)) // object size: the data bytes only (size field and CRC excluded)
-	for _, by := range payload {
-		out.WriteRC(by)
-	}
-	// Object CRC: over the object so far — the MS size field plus the payload — seeded
-	// 0xC0C1 and stored little-endian, matching what conforming readers verify (ODA).
-	out.WriteRS(crc16(0xC0C1, out.Bytes()))
-	return out.Bytes(), nil
-}
-
 // bsBits returns the encoded bit length of a BitShort type code, matching WriteBS.
 func bsBits(v int) int {
 	switch {
@@ -99,22 +53,6 @@ func bsBits(v int) int {
 	default:
 		return 2 + 16
 	}
-}
-
-// writeCommonEntityData emits the R2000 common-entity-data data-stream fields for a
-// model-space entity with no reactors, links, or special colour — the inverse of
-// readCommonEntityData on the R2000 path.
-func writeCommonEntityData(w *BitWriter) {
-	w.WriteBit(0)     // preview_exists = no
-	w.WriteBits(2, 2) // entmode = 2 (model space)
-	w.WriteBL(0)      // num_reactors
-	w.WriteBit(1)     // nolinks = 1 (no prev/next entity handles)
-	w.WriteBS(0)      // colour (CMC index, pre-R2004)
-	w.WriteBD(1.0)    // ltype_scale
-	w.WriteBits(0, 2) // ltype_flags = ByLayer
-	w.WriteBits(0, 2) // plotstyle_flags = ByLayer
-	w.WriteBS(0)      // invisible
-	w.WriteRC(0)      // linewt
 }
 
 // writeGeometry dispatches to the per-type geometry encoder (exact inverse of decodeEntity).
@@ -279,62 +217,80 @@ func boolBit(b bool) uint {
 	return 0
 }
 
-// r2000Builder assembles the flat R2000 file: a header + section locator, then the object
-// records, then the handle→offset object map, with the locator pointing at the map.
-type r2000Builder struct {
-	refs []ObjectRef
-}
-
-func newR2000Builder() *r2000Builder { return &r2000Builder{} }
-
-// sentinelHeaderEnd is the 16-byte sentinel that closes the R2000 header section (the
-// reader checks the first sentinelSignatureLen bytes).
+// sentinelHeaderEnd is the 16-byte sentinel that closes the R2000 file header (the reader
+// checks the first sentinelSignatureLen bytes).
 var sentinelHeaderEnd = [16]byte{
 	0x95, 0xA0, 0x4E, 0x28, 0x99, 0x82, 0x1A, 0xE5,
 	0x5E, 0x41, 0xE0, 0x5F, 0x9D, 0x3A, 0x4D, 0x00,
 }
 
-// build lays out the whole file: a fixed header area is reserved, objects are written
-// after it (recording each handle→offset), then the object map, and finally the header +
-// locator are filled in pointing at the map.
-func (b *r2000Builder) build(entities []Entity) ([]byte, error) {
-	const headerReserve = 0x100 // header + locator table fit comfortably in 256 bytes
-	out := make([]byte, headerReserve)
+// fileHeaderReserve is the bytes set aside at the start of the file for the version string,
+// section-locator table, CRC and sentinel (the three records fit in well under this).
+const fileHeaderReserve = 0x80
 
-	for i, e := range entities {
-		if _, ok := objectTypeBS(e); !ok {
-			continue
-		}
-		handle := uint64(i + 1)
-		obj, err := encodeEntityObject(handle, e)
-		if err != nil {
-			return nil, err
-		}
-		b.refs = append(b.refs, ObjectRef{Handle: handle, Offset: int64(len(out))})
-		out = append(out, obj...)
+// buildR2000 lays out a complete R2000 file: the file header, the header-variables section,
+// the classes section, every system object plus the model-space entities, and the object
+// map. Section addresses are absolute, so the file header is filled in last once every
+// section's size is known. The synthesised object graph (writegraph.go and friends) gives the
+// drawing the symbol tables, block records and dictionaries AutoCAD requires.
+//
+//nolint:funlen // sequential file assembly: handles, sections, objects, map, locator table.
+func buildR2000(entities []Entity, units int) ([]byte, error) {
+	var h graphHandles
+	h.allocate()
+	clearDictionaryChain(&h) // not yet emitted; header/layer/blocks reference them as null
+
+	objs, refs, err := encodeGraph(&h, entities)
+	if err != nil {
+		return nil, err
 	}
+	handseed := refs[len(refs)-1].Handle + 1
 
-	mapOffset := len(out)
-	out = append(out, b.encodeObjectMap()...)
-	mapSize := len(out) - mapOffset
+	out := make([]byte, fileHeaderReserve)
+	hdrAddr := len(out)
+	out = append(out, encodeHeaderVars(&h, units, handseed)...)
+	classAddr := len(out)
+	out = append(out, encodeClasses(nil)...)
 
-	header := b.encodeHeader(int64(mapOffset), int64(mapSize))
-	if len(header) > headerReserve {
-		return nil, fmt.Errorf("dwg: R2000 header %d bytes exceeds reserve %d", len(header), headerReserve)
+	objBase := int64(len(out))
+	for i := range refs {
+		refs[i].Offset += objBase // offsets were relative to the object block start
+	}
+	out = append(out, objs...)
+
+	mapAddr := len(out)
+	out = append(out, encodeObjectMap(refs)...)
+
+	sections := []SectionLocator{
+		{ID: secHeaderVars, Address: int64(hdrAddr), Size: int64(classAddr - hdrAddr)},
+		{ID: secClasses, Address: int64(classAddr), Size: objBase - int64(classAddr)},
+		{ID: secObjectMap, Address: int64(mapAddr), Size: int64(len(out) - mapAddr)},
+	}
+	header := encodeFileHeader(sections)
+	if len(header) > fileHeaderReserve {
+		return nil, fmt.Errorf("dwg: R2000 file header %d bytes exceeds reserve %d", len(header), fileHeaderReserve)
 	}
 	copy(out, header)
 	return out, nil
+}
+
+// clearDictionaryChain zeroes the named-object-dictionary-chain handles so the header,
+// layer and block records reference them as null pointers until the chain is emitted.
+func clearDictionaryChain(h *graphHandles) {
+	h.groupDict, h.mlineDict, h.mlineStandard = 0, 0, 0
+	h.plotStyleDict, h.placeholder = 0, 0
+	h.layoutDict, h.layoutModel, h.layoutPaper, h.plotSettingsDict = 0, 0, 0, 0
 }
 
 // encodeObjectMap writes the handle→offset directory: one section of (handle delta,
 // location delta) pairs followed by the terminating size-2 section.
 //
 //nolint:funlen // builds the object-map section and its CRC byte-by-byte; length is the format.
-func (b *r2000Builder) encodeObjectMap() []byte {
+func encodeObjectMap(refs []ObjectRef) []byte {
 	pairs := NewBitWriter()
 	var lastHandle uint64
 	var lastLoc int64
-	for _, ref := range b.refs {
+	for _, ref := range refs {
 		pairs.WriteUMC(ref.Handle - lastHandle)
 		pairs.WriteMC(int(ref.Offset - lastLoc))
 		lastHandle, lastLoc = ref.Handle, ref.Offset
@@ -369,21 +325,16 @@ func (b *r2000Builder) encodeObjectMap() []byte {
 	return out.Bytes()
 }
 
-// encodeHeader writes the fixed R2000 file header and the section locator table, pointing
-// section id secObjectMap at the object map. The header-variables and classes sections are
-// declared empty (address/size 0); Decode treats an absent header as unitless.
-func (b *r2000Builder) encodeHeader(mapOffset, mapSize int64) []byte {
+// encodeFileHeader writes the fixed R2000 file header and the section-locator table for the
+// given sections (header variables, classes, object map). The CRC is seeded 0xC0C1 over the
+// header up to the CRC — the same value Decode and dwgread verify for a three-record table.
+func encodeFileHeader(sections []SectionLocator) []byte {
 	buf := make([]byte, 0x19)
 	copy(buf, "AC1015")
 	buf[0x0C] = 0x00
 	binary.LittleEndian.PutUint16(buf[0x13:], 30) // codepage ANSI_1252
-	records := []SectionLocator{
-		{ID: secHeaderVars, Address: 0, Size: 0},
-		{ID: secClasses, Address: 0, Size: 0},
-		{ID: secObjectMap, Address: mapOffset, Size: mapSize},
-	}
-	binary.LittleEndian.PutUint32(buf[0x15:], uint32(len(records)))
-	for _, r := range records {
+	binary.LittleEndian.PutUint32(buf[0x15:], uint32(len(sections)))
+	for _, r := range sections {
 		rec := make([]byte, 9)
 		rec[0] = r.ID
 		binary.LittleEndian.PutUint32(rec[1:], uint32(r.Address))

--- a/kernel/exchange/dwg/write.go
+++ b/kernel/exchange/dwg/write.go
@@ -238,7 +238,6 @@ const fileHeaderReserve = 0x80
 func buildR2000(entities []Entity, units int) ([]byte, error) {
 	var h graphHandles
 	h.allocate()
-	clearDictionaryChain(&h) // not yet emitted; header/layer/blocks reference them as null
 
 	objs, refs, err := encodeGraph(&h, entities)
 	if err != nil {
@@ -250,7 +249,7 @@ func buildR2000(entities []Entity, units int) ([]byte, error) {
 	hdrAddr := len(out)
 	out = append(out, encodeHeaderVars(&h, units, handseed)...)
 	classAddr := len(out)
-	out = append(out, encodeClasses(nil)...)
+	out = append(out, encodeClasses(chainClasses())...)
 
 	objBase := int64(len(out))
 	for i := range refs {
@@ -272,14 +271,6 @@ func buildR2000(entities []Entity, units int) ([]byte, error) {
 	}
 	copy(out, header)
 	return out, nil
-}
-
-// clearDictionaryChain zeroes the named-object-dictionary-chain handles so the header,
-// layer and block records reference them as null pointers until the chain is emitted.
-func clearDictionaryChain(h *graphHandles) {
-	h.groupDict, h.mlineDict, h.mlineStandard = 0, 0, 0
-	h.plotStyleDict, h.placeholder = 0, 0
-	h.layoutDict, h.layoutModel, h.layoutPaper, h.plotSettingsDict = 0, 0, 0, 0
 }
 
 // encodeObjectMap writes the handle→offset directory: one section of (handle delta,

--- a/kernel/exchange/dwg/write_test.go
+++ b/kernel/exchange/dwg/write_test.go
@@ -113,7 +113,11 @@ func TestWriteFullGraphStructure(t *testing.T) {
 		{typeViewControl, 1}, {typeUcsControl, 1}, {typeVportControl, 1}, {typeAppidControl, 1},
 		{typeDimstyleControl, 1}, {TypeLayer, 1}, {TypeStyle, 1}, {TypeLtype, 3}, {TypeAppid, 1},
 		{TypeVport, 1}, {TypeDimstyle, 1}, {TypeBlockHeader, 2}, {TypeBlock, 2}, {TypeEndblk, 2},
-		{TypeDictionary, 1},
+		// NOD + ACAD_GROUP/MLINESTYLE/PLOTSETTINGS/LAYOUT sub-dictionaries.
+		{TypeDictionary, 5},
+		// Named-object-dictionary chain objects (MLINESTYLE is fixed 0x49; the rest are
+		// class-resolved at 500/501/502 in the writer's class order).
+		{0x49, 1}, {classDictWDflt, 1}, {classPlaceholder, 1}, {classLayout, 2},
 	} {
 		if counts[w.typ] != w.want {
 			t.Errorf("object type %#x count = %d, want %d", int(w.typ), counts[w.typ], w.want)

--- a/kernel/exchange/dwg/write_test.go
+++ b/kernel/exchange/dwg/write_test.go
@@ -75,3 +75,71 @@ func TestWriteDecodeRoundTrip(t *testing.T) {
 		t.Errorf("fit spline round-trip: fit=%v", fs.FitPoints)
 	}
 }
+
+// TestWriteFullGraphStructure checks that a written R2000 file carries the complete system
+// object graph AutoCAD requires — the nine symbol-table control objects, the standard
+// records, the block records and the named-object dictionary — alongside the model-space
+// entities, and that the $INSUNITS code round-trips through the header. The whole graph
+// decoding without warning is the in-CI proxy for the dwgread "SUCCESS" validation.
+func TestWriteFullGraphStructure(t *testing.T) {
+	in := []Entity{
+		&Line{Start: [3]float64{0, 0, 0}, End: [3]float64{10, 5, 0}},
+		&Circle{Center: [3]float64{3, 4, 0}, Radius: 2.5, Normal: [3]float64{0, 0, 1}},
+	}
+	data, err := Write(&Drawing{Entities: in, Units: 4}) // 4 = millimetres
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	dr, warns, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("unexpected decode warnings: %v", warns)
+	}
+	if dr.Units != 4 {
+		t.Errorf("units round-trip = %d, want 4", dr.Units)
+	}
+	if len(dr.Entities) != len(in) {
+		t.Fatalf("entities round-trip = %d, want %d", len(dr.Entities), len(in))
+	}
+
+	counts := tallyObjectTypes(t, data)
+	for _, w := range []struct {
+		typ  ObjectType
+		want int
+	}{
+		{typeBlockControl, 1}, {typeLayerControl, 1}, {typeStyleControl, 1}, {typeLtypeControl, 1},
+		{typeViewControl, 1}, {typeUcsControl, 1}, {typeVportControl, 1}, {typeAppidControl, 1},
+		{typeDimstyleControl, 1}, {TypeLayer, 1}, {TypeStyle, 1}, {TypeLtype, 3}, {TypeAppid, 1},
+		{TypeVport, 1}, {TypeDimstyle, 1}, {TypeBlockHeader, 2}, {TypeBlock, 2}, {TypeEndblk, 2},
+		{TypeDictionary, 1},
+	} {
+		if counts[w.typ] != w.want {
+			t.Errorf("object type %#x count = %d, want %d", int(w.typ), counts[w.typ], w.want)
+		}
+	}
+}
+
+// tallyObjectTypes walks the written file's object map and counts each object by type.
+func tallyObjectTypes(t *testing.T, data []byte) map[ObjectType]int {
+	t.Helper()
+	h, err := ParseFileHeader(data)
+	if err != nil {
+		t.Fatalf("ParseFileHeader: %v", err)
+	}
+	omb, _ := h.ObjectMapBytes(data)
+	refs, err := parseObjectMap(omb)
+	if err != nil {
+		t.Fatalf("parseObjectMap: %v", err)
+	}
+	counts := map[ObjectType]int{}
+	for _, ref := range refs {
+		hdr, err := decodeObjectHeader(data, ref, h.Version)
+		if err != nil {
+			t.Fatalf("object %d header: %v", ref.Handle, err)
+		}
+		counts[hdr.Type]++
+	}
+	return counts
+}

--- a/kernel/exchange/dwg/writeblocks.go
+++ b/kernel/exchange/dwg/writeblocks.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+import "fmt"
+
+// writeblocks.go encodes the block layer of the graph: the *Model_Space and *Paper_Space
+// block records (BLOCK_HEADER) with their BLOCK/ENDBLK markers, and the model-space drawing
+// entities themselves. Model-space entities are a doubly linked list (prev/next soft
+// pointers) bracketed by the block record's first/last pointers — the R2000 representation
+// the oracle confirms (nolinks = 0, layer is a hard pointer, colour 256 = ByLayer).
+
+// colorByLayer / linewtByLayer are the common-entity defaults for a drawing entity: colour
+// and lineweight inherited from the layer (the values the oracle reads on real entities).
+const (
+	colorByLayer  = 256
+	linewtByLayer = 0x1d
+)
+
+// writeEntityCommon emits the common-entity data stream (entmode 2 = model space, an explicit
+// prev/next link list) and the common handle stream (null xdic, prev, next, layer). It is
+// shared by drawing entities and the BLOCK/ENDBLK markers, which are also model-space
+// entities. prev/next of 0 encode a null soft pointer (list end).
+func writeEntityCommon(b *objectBody, prev, next, layer uint64) {
+	b.data.WriteBit(0)            // preview_exists
+	b.data.WriteBits(2, 2)        // entmode = 2 (model space)
+	b.data.WriteBL(0)             // num_reactors
+	b.data.WriteBit(0)            // nolinks = 0 → explicit prev/next handles follow
+	b.data.WriteBS(colorByLayer)  // colour (ByLayer)
+	b.data.WriteBD(1.0)           // ltype_scale
+	b.data.WriteBits(0, 2)        // ltype_flags = ByLayer
+	b.data.WriteBits(0, 2)        // plotstyle_flags = ByLayer
+	b.data.WriteBS(0)             // invisible
+	b.data.WriteRC(linewtByLayer) // lineweight (ByLayer)
+
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdicobjhandle (null)
+	b.handles.WriteHandle(softPtrCode, prev)
+	b.handles.WriteHandle(softPtrCode, next)
+	b.handles.WriteHandle(hardPtrCode, layer)
+}
+
+// encodeModelEntity frames one model-space drawing entity (line/circle/arc/…): the common
+// entity data with its place in the prev/next list, then the type-specific geometry.
+func encodeModelEntity(handle uint64, e Entity, prev, next, layer uint64) ([]byte, error) {
+	typ, ok := objectTypeBS(e)
+	if !ok {
+		return nil, fmt.Errorf("dwg: cannot write entity type %s", e.EntityType().Name())
+	}
+	b := newObjectBody(handle, typ)
+	writeEntityCommon(b, prev, next, layer)
+	writeGeometry(b.data, e)
+	return frameObject(b), nil
+}
+
+// writeBlock frames a BLOCK marker entity: the common entity data (no links — it is the
+// definition header, not part of the entity list) followed by the block name.
+func writeBlock(handle, layer uint64, name string) []byte {
+	b := newObjectBody(handle, int(TypeBlock))
+	writeEntityCommon(b, 0, 0, layer)
+	writeName(b.data, name)
+	return frameObject(b)
+}
+
+// writeEndblk frames an ENDBLK marker entity: common entity data only.
+func writeEndblk(handle, layer uint64) []byte {
+	b := newObjectBody(handle, int(TypeEndblk))
+	writeEntityCommon(b, 0, 0, layer)
+	return frameObject(b)
+}
+
+// blockHeaderRefs carries the cross-references a BLOCK_HEADER needs: its BLOCK/ENDBLK
+// markers, the first/last entity of its content (0/0 when empty), and its layout object.
+type blockHeaderRefs struct {
+	block, endblk, first, last, layout uint64
+}
+
+// writeBlockHeader frames a *Model_Space or *Paper_Space block record. The data stream holds
+// the name and the block flags (all clear for an ordinary loaded block); the handle stream
+// links the block control owner, the BLOCK/ENDBLK markers, the first/last content entity and
+// the layout. Field order matches the oracle's R2000 decode (no insert-units/explodable, no
+// extra null pointer before BLOCK).
+//
+//nolint:funlen // sequential BLOCK_HEADER field/handle writes in the fixed R2000 order.
+func writeBlockHeader(handle, control uint64, name string, r blockHeaderRefs) []byte {
+	b := newObjectBody(handle, int(TypeBlockHeader))
+	writeRecordCommon(b, control, name)
+	b.data.WriteBit(0)            // anonymous
+	b.data.WriteBit(0)            // has attrs
+	b.data.WriteBit(0)            // blkisxref
+	b.data.WriteBit(0)            // xrefoverlaid
+	b.data.WriteBit(0)            // xref loaded
+	b.data.Write3BD([3]float64{}) // base point
+	writeTextEmpty(b.data)        // xref pathname
+	b.data.WriteRC(0)             // insert count terminator (0 inserts)
+	writeTextEmpty(b.data)        // block description
+	b.data.WriteBL(0)             // preview data size (none)
+
+	// writeRecordCommon already wrote owner (block control) + xdic; append the block links.
+	b.handles.WriteHandle(hardOwnerCode, r.block)
+	b.handles.WriteHandle(softPtrCode, r.first)
+	b.handles.WriteHandle(softPtrCode, r.last)
+	b.handles.WriteHandle(hardOwnerCode, r.endblk)
+	b.handles.WriteHandle(hardPtrCode, r.layout)
+	return frameObject(b)
+}

--- a/kernel/exchange/dwg/writeclasses.go
+++ b/kernel/exchange/dwg/writeclasses.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writeclasses.go emits the R2000 AcDb:Classes section (ODA §10.1): a begin sentinel, the
+// class-data byte size, the class entries (each maps a dynamic type code ≥ 500 to a DXF
+// name), a CRC, and an end sentinel. Only the non-fixed object types the writer actually
+// emits need entries; a drawing of purely fixed types (LINE..SPLINE, the symbol tables)
+// needs none, so the section is valid but empty.
+
+// classBeginSentinel / classEndSentinel bracket the class-data area (ODA §10.1).
+var (
+	classBeginSentinel = []byte{
+		0x8D, 0xA1, 0xC4, 0xB8, 0xC4, 0xA9, 0xF8, 0xC5,
+		0xC0, 0xDC, 0xF4, 0x5F, 0xE7, 0xCF, 0xB6, 0x8A,
+	}
+	classEndSentinel = []byte{
+		0x72, 0x5E, 0x3B, 0x47, 0x3B, 0x56, 0x07, 0x3A,
+		0x3F, 0x23, 0x0B, 0xA0, 0x18, 0x30, 0x49, 0x75,
+	}
+)
+
+// classDef is one class entry: the dynamic type number (≥ 500), the DXF record name, the
+// owning application, and whether instances are objects (true) or entities (false).
+type classDef struct {
+	num      int
+	dxfName  string
+	cppName  string
+	isObject bool
+}
+
+// itemClassEntity / itemClassObject are the ODA item-class-id values distinguishing classes
+// that produce entities from those that produce objects.
+const (
+	itemClassEntity = 0x1F2
+	itemClassObject = 0x1F3
+)
+
+// encodeClasses builds the AcDb:Classes section bytes for the given class definitions (which
+// may be empty). The CRC covers the size field plus the class data, matching the header
+// section's framing.
+//
+//nolint:funlen // sequential section framing: sentinels, class data, size, CRC.
+func encodeClasses(defs []classDef) []byte {
+	body := NewBitWriter()
+	for _, d := range defs {
+		body.WriteBS(d.num)
+		body.WriteBS(0) // version / proxy flags
+		writeName(body, "ObjectDBX Classes")
+		writeName(body, d.cppName)
+		writeName(body, d.dxfName)
+		body.WriteBit(0) // wasazombie
+		if d.isObject {
+			body.WriteBS(itemClassObject)
+		} else {
+			body.WriteBS(itemClassEntity)
+		}
+	}
+	body.AlignToByte()
+	classData := body.Bytes()
+
+	sized := NewBitWriter()
+	sized.WriteRL(uint32(len(classData)))
+	for _, by := range classData {
+		sized.WriteRC(by)
+	}
+	sizedBytes := sized.Bytes()
+
+	out := NewBitWriter()
+	for _, by := range classBeginSentinel {
+		out.WriteRC(by)
+	}
+	for _, by := range sizedBytes {
+		out.WriteRC(by)
+	}
+	out.WriteRS(crc16(0xC0C1, sizedBytes))
+	for _, by := range classEndSentinel {
+		out.WriteRC(by)
+	}
+	return out.Bytes()
+}

--- a/kernel/exchange/dwg/writedict.go
+++ b/kernel/exchange/dwg/writedict.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writedict.go encodes DICTIONARY objects — the named-object dictionary (NOD) at the root of
+// the object graph and any sub-dictionaries. A dictionary is a list of name→handle pairs
+// (ODA §20.4.44): the names live in the data stream, the target handles (soft owner) in the
+// handle stream, after the owner and xdic.
+
+// dictEntry is one name→object mapping in a dictionary.
+type dictEntry struct {
+	name   string
+	handle uint64
+}
+
+// TypeDictionary is the fixed R2000 type code for a DICTIONARY object (ODA §20.3).
+const TypeDictionary ObjectType = 0x2A
+
+// writeDictionary frames a DICTIONARY: cloning flag 1 (keep existing on name clash), not a
+// hard-owner dictionary, the entry names, then the owner/xdic/item handles. owner is the
+// dictionary's parent (0 = root, for the NOD).
+func writeDictionary(handle, owner uint64, entries []dictEntry) []byte {
+	b := newObjectBody(handle, int(TypeDictionary))
+	b.data.WriteBL(0)            // numreactors
+	b.data.WriteBL(len(entries)) // numitems
+	b.data.WriteBS(1)            // cloning flag (keep existing)
+	b.data.WriteRC(0)            // hard-owner flag (soft-owned items)
+	for _, e := range entries {
+		writeName(b.data, e.name)
+	}
+	b.handles.WriteHandle(softPtrCode, owner)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdicobjhandle (null)
+	for _, e := range entries {
+		b.handles.WriteHandle(softOwnerCode, e.handle)
+	}
+	return frameObject(b)
+}

--- a/kernel/exchange/dwg/writeframe.go
+++ b/kernel/exchange/dwg/writeframe.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// This file frames a single R2000 object on disk. Every object — entity or table/dictionary
+// object — shares the same outer layout: an MS byte size, then a bit stream of
+// [type][bitsize RL][own-handle][EED][object body][handle stream], byte-aligned, then a
+// 16-bit object CRC. The data-stream/handle-stream split at `bitsize` and the CRC seed
+// (0xC0C1) are validated against LibreDWG's dwgread, which reads the result with no
+// mismatch. See ODA §2.13 / the per-object prescriptions in §20.4.
+
+// Handle reference codes (ODA §2.13). Codes 2–5 store the handle as an absolute value and
+// also convey the ownership relation; the writer always uses absolute references (the
+// relative forms 6/8/A/C are a size optimisation the reader supports but we do not need).
+const (
+	hardOwnerCode = 0x3 // owner needs the owned object; it cannot exist alone
+	softPtrCode   = 0x4 // referencing object neither owns nor requires the target
+	hardPtrCode   = 0x5 // referencing object requires the target, owned elsewhere
+	softOwnerCode = 0x2 // owner does not need the owned object
+	ownHandleCode = 0x0 // an object's own handle (no relation)
+)
+
+// objectBody is one object's two bit streams before framing: the data stream (everything
+// after the type and bitsize: own handle, EED, common header, type-specific fields) and the
+// handle stream (the trailing handle references). frameObject joins them.
+type objectBody struct {
+	handle  uint64
+	typ     int
+	data    *BitWriter // own-handle, EED, common header, type-specific data-stream fields
+	handles *BitWriter // trailing handle-stream references
+}
+
+// newObjectBody starts an object's body with the common prefix every object shares: the
+// own handle (code 0) and an empty EED block (size 0). Callers append the type-specific
+// data-stream fields to .data and the handle references to .handles.
+func newObjectBody(handle uint64, typ int) *objectBody {
+	data := NewBitWriter()
+	data.WriteHandle(ownHandleCode, handle) // the object's own handle
+	data.WriteBS(0)                         // EED size 0 (no extended data)
+	return &objectBody{handle: handle, typ: typ, data: data, handles: NewBitWriter()}
+}
+
+// frameObject assembles a finished object record: MS size, the bit stream, byte alignment,
+// and the trailing CRC. bitsize is the bit offset (from just after the MS size) at which the
+// handle stream begins — type + the RL field itself + the data stream — so a reader can split
+// the two streams. The CRC covers the MS size field plus the payload (ODA), seeded 0xC0C1.
+func frameObject(b *objectBody) []byte {
+	bitsize := bsBits(b.typ) + 32 + b.data.Position() // type + the RL + data stream
+
+	w := NewBitWriter()
+	w.WriteBS(b.typ)
+	w.WriteRL(uint32(bitsize))
+	w.Append(b.data)
+	w.Append(b.handles)
+	w.AlignToByte()
+	payload := w.Bytes()
+
+	out := NewBitWriter()
+	out.WriteMS(len(payload)) // object size: payload bytes only (size field and CRC excluded)
+	for _, by := range payload {
+		out.WriteRC(by)
+	}
+	out.WriteRS(crc16(0xC0C1, out.Bytes()))
+	return out.Bytes()
+}
+
+// writeName writes a pre-R2007 text value (TV): a BitShort character count then the raw
+// bytes, with NO terminating NUL — the form AutoCAD reads back (the ODA SHAPEFILE example
+// stores "STANDARD" as length 8 + 8 bytes). Matches readTV's inverse.
+func writeName(w *BitWriter, s string) {
+	w.WriteBS(len(s))
+	for i := 0; i < len(s); i++ {
+		w.WriteRC(s[i])
+	}
+}
+
+// writeTextEmpty writes an empty text value (length 0, no bytes) for unset
+// description/path strings on table records.
+func writeTextEmpty(w *BitWriter) { writeName(w, "") }

--- a/kernel/exchange/dwg/writegraph.go
+++ b/kernel/exchange/dwg/writegraph.go
@@ -115,7 +115,11 @@ func encodeGraph(h *graphHandles, entities []Entity) ([]byte, []ObjectRef, error
 	add(h.vportControl, writeControlObject(h.vportControl, typeVportControl, []uint64{h.vportActive}))
 	add(h.appidControl, writeControlObject(h.appidControl, typeAppidControl, []uint64{h.appidAcad}))
 	add(h.dimstyleControl, writeDimstyleControl(h))
-	add(h.nod, writeDictionary(h.nod, 0, nil))
+	add(h.nod, writeDictionary(h.nod, 0, []dictEntry{
+		{"ACAD_GROUP", h.groupDict}, {"ACAD_LAYOUT", h.layoutDict},
+		{"ACAD_MLINESTYLE", h.mlineDict}, {"ACAD_PLOTSETTINGS", h.plotSettingsDict},
+		{"ACAD_PLOTSTYLENAME", h.plotStyleDict},
+	}))
 	add(h.layer0, writeLayer(h))
 	add(h.styleStandard, writeStyle(h))
 	add(h.ltypeByBlock, writeLinetype(h.ltypeByBlock, h.ltypeControl, "ByBlock"))
@@ -137,6 +141,19 @@ func encodeGraph(h *graphHandles, entities []Entity) ([]byte, []ObjectRef, error
 	add(h.modelEndblk, writeEndblk(h.modelEndblk, h.layer0))
 	add(h.paperBlock, writeBlock(h.paperBlock, h.layer0, "*Paper_Space"))
 	add(h.paperEndblk, writeEndblk(h.paperEndblk, h.layer0))
+
+	// Named-object-dictionary chain (emitted in ascending handle order; see allocate()).
+	add(h.groupDict, writeSubDictionary(h.groupDict, h.nod, nil))
+	add(h.mlineDict, writeSubDictionary(h.mlineDict, h.nod, []dictEntry{{"Standard", h.mlineStandard}}))
+	add(h.mlineStandard, writeMlinestyle(h.mlineStandard, h.mlineDict))
+	add(h.plotStyleDict, writeDictionaryWDflt(h.plotStyleDict, h.nod, []dictEntry{{"Normal", h.placeholder}}, h.placeholder))
+	add(h.placeholder, writePlaceholder(h.placeholder, h.plotStyleDict))
+	add(h.layoutDict, writeSubDictionary(h.layoutDict, h.nod, []dictEntry{
+		{"Model", h.layoutModel}, {"Layout1", h.layoutPaper},
+	}))
+	add(h.layoutModel, writeLayout(h.layoutModel, layoutRefs{owner: h.layoutDict, blockHeader: h.modelHdr, name: "Model", tabOrder: 0, flags: 1}))
+	add(h.layoutPaper, writeLayout(h.layoutPaper, layoutRefs{owner: h.layoutDict, blockHeader: h.paperHdr, name: "Layout1", tabOrder: 1, flags: 0}))
+	add(h.plotSettingsDict, writeSubDictionary(h.plotSettingsDict, h.nod, nil))
 
 	for i, e := range ents {
 		handle := h.entityBase + uint64(i)

--- a/kernel/exchange/dwg/writegraph.go
+++ b/kernel/exchange/dwg/writegraph.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writegraph.go synthesises the full R2000 system-object graph that AutoCAD requires in
+// every drawing: the nine symbol-table control objects, their standard records (layer 0,
+// the BYLAYER/BYBLOCK/CONTINUOUS linetypes, the STANDARD text/dim styles, the ACAD appid,
+// the *Active viewport), the *Model_Space/*Paper_Space block records with their BLOCK/ENDBLK
+// markers, and the named-object dictionary. The model-space entities are linked into the
+// model-space block record. Handles are allocated up front (graphHandles) so every
+// cross-reference resolves. Layouts/plotstyles are emitted by writedict.go.
+
+// graphHandles holds the handle assigned to every system object, allocated in ascending
+// order so the object map (which encodes ascending handle deltas) stays monotonic. Entities
+// take the handles after blockEntityBase.
+type graphHandles struct {
+	blockControl, layerControl, styleControl, ltypeControl uint64
+	viewControl, ucsControl, vportControl, appidControl    uint64
+	dimstyleControl                                        uint64
+	nod                                                    uint64
+	layer0, styleStandard                                  uint64
+	ltypeByBlock, ltypeByLayer, ltypeContinuous            uint64
+	appidAcad, vportActive, dimstyleStandard               uint64
+	modelHdr, paperHdr                                     uint64
+	modelBlock, modelEndblk, paperBlock, paperEndblk       uint64
+	groupDict, mlineDict, mlineStandard                    uint64
+	layoutDict, plotSettingsDict, plotStyleDict            uint64
+	placeholder, layoutModel, layoutPaper                  uint64
+	entityBase                                             uint64 // first model-space entity handle
+}
+
+// allocate assigns every system-object handle in ascending order and returns the next free
+// handle (the first entity handle). The order here is also the file write order.
+//
+//nolint:funlen // one handle assignment per system object; length is the object count.
+func (h *graphHandles) allocate() {
+	n := uint64(0)
+	next := func() uint64 { n++; return n }
+	h.blockControl = next()
+	h.layerControl = next()
+	h.styleControl = next()
+	h.ltypeControl = next()
+	h.viewControl = next()
+	h.ucsControl = next()
+	h.vportControl = next()
+	h.appidControl = next()
+	h.dimstyleControl = next()
+	h.nod = next()
+	h.layer0 = next()
+	h.styleStandard = next()
+	h.ltypeByBlock = next()
+	h.ltypeByLayer = next()
+	h.ltypeContinuous = next()
+	h.appidAcad = next()
+	h.vportActive = next()
+	h.dimstyleStandard = next()
+	h.modelHdr = next()
+	h.paperHdr = next()
+	h.modelBlock = next()
+	h.modelEndblk = next()
+	h.paperBlock = next()
+	h.paperEndblk = next()
+	h.allocateDictionaries(next)
+	h.entityBase = next()
+}
+
+// allocateDictionaries assigns the named-object-dictionary chain handles (group, mlinestyle,
+// plotstyle, layouts). Kept separate so the symbol-table allocation above stays readable.
+func (h *graphHandles) allocateDictionaries(next func() uint64) {
+	h.groupDict = next()
+	h.mlineDict = next()
+	h.mlineStandard = next()
+	h.plotStyleDict = next()
+	h.placeholder = next()
+	h.layoutDict = next()
+	h.layoutModel = next()
+	h.layoutPaper = next()
+	h.plotSettingsDict = next()
+}
+
+// Fixed R2000 type codes for the symbol-table control objects (ODA §20.3).
+const (
+	typeBlockControl    = 0x30
+	typeLayerControl    = 0x32
+	typeStyleControl    = 0x34
+	typeLtypeControl    = 0x38
+	typeViewControl     = 0x3C
+	typeUcsControl      = 0x3E
+	typeVportControl    = 0x40
+	typeAppidControl    = 0x42
+	typeDimstyleControl = 0x44
+)
+
+// encodeGraph encodes every object in ascending handle order — the nine control objects,
+// the dictionary, the standard records, the block records and markers, and the model-space
+// entities — returning the concatenated bytes and the handle→offset references (offsets
+// relative to the first object). The caller rebases the offsets to the file position.
+//
+//nolint:funlen // a flat list of the system objects in fixed handle order; length is the graph.
+func encodeGraph(h *graphHandles, entities []Entity) ([]byte, []ObjectRef, error) {
+	var buf []byte
+	var refs []ObjectRef
+	add := func(handle uint64, b []byte) {
+		refs = append(refs, ObjectRef{Handle: handle, Offset: int64(len(buf))})
+		buf = append(buf, b...)
+	}
+	ents := writableEntities(entities)
+
+	add(h.blockControl, writeBlockControl(h))
+	add(h.layerControl, writeControlObject(h.layerControl, typeLayerControl, []uint64{h.layer0}))
+	add(h.styleControl, writeControlObject(h.styleControl, typeStyleControl, []uint64{h.styleStandard}))
+	add(h.ltypeControl, writeLtypeControl(h))
+	add(h.viewControl, writeControlObject(h.viewControl, typeViewControl, nil))
+	add(h.ucsControl, writeControlObject(h.ucsControl, typeUcsControl, nil))
+	add(h.vportControl, writeControlObject(h.vportControl, typeVportControl, []uint64{h.vportActive}))
+	add(h.appidControl, writeControlObject(h.appidControl, typeAppidControl, []uint64{h.appidAcad}))
+	add(h.dimstyleControl, writeDimstyleControl(h))
+	add(h.nod, writeDictionary(h.nod, 0, nil))
+	add(h.layer0, writeLayer(h))
+	add(h.styleStandard, writeStyle(h))
+	add(h.ltypeByBlock, writeLinetype(h.ltypeByBlock, h.ltypeControl, "ByBlock"))
+	add(h.ltypeByLayer, writeLinetype(h.ltypeByLayer, h.ltypeControl, "ByLayer"))
+	add(h.ltypeContinuous, writeLinetype(h.ltypeContinuous, h.ltypeControl, "Continuous"))
+	add(h.appidAcad, writeAppid(h))
+	add(h.vportActive, writeVport(h))
+	add(h.dimstyleStandard, writeDimstyle(h))
+
+	first, last := uint64(0), uint64(0)
+	if len(ents) > 0 {
+		first, last = h.entityBase, h.entityBase+uint64(len(ents))-1
+	}
+	add(h.modelHdr, writeBlockHeader(h.modelHdr, h.blockControl, "*Model_Space",
+		blockHeaderRefs{block: h.modelBlock, endblk: h.modelEndblk, first: first, last: last, layout: h.layoutModel}))
+	add(h.paperHdr, writeBlockHeader(h.paperHdr, h.blockControl, "*Paper_Space",
+		blockHeaderRefs{block: h.paperBlock, endblk: h.paperEndblk, layout: h.layoutPaper}))
+	add(h.modelBlock, writeBlock(h.modelBlock, h.layer0, "*Model_Space"))
+	add(h.modelEndblk, writeEndblk(h.modelEndblk, h.layer0))
+	add(h.paperBlock, writeBlock(h.paperBlock, h.layer0, "*Paper_Space"))
+	add(h.paperEndblk, writeEndblk(h.paperEndblk, h.layer0))
+
+	for i, e := range ents {
+		handle := h.entityBase + uint64(i)
+		prev, next := uint64(0), uint64(0)
+		if i > 0 {
+			prev = handle - 1
+		}
+		if i < len(ents)-1 {
+			next = handle + 1
+		}
+		b, err := encodeModelEntity(handle, e, prev, next, h.layer0)
+		if err != nil {
+			return nil, nil, err
+		}
+		add(handle, b)
+	}
+	return buf, refs, nil
+}
+
+// writableEntities filters to the entity types the geometry encoder supports.
+func writableEntities(entities []Entity) []Entity {
+	var ents []Entity
+	for _, e := range entities {
+		if _, ok := objectTypeBS(e); ok {
+			ents = append(ents, e)
+		}
+	}
+	return ents
+}
+
+// writeBlockControl frames the BLOCK_CONTROL object. numentries excludes *Model_Space and
+// *Paper_Space, which are appended as hard-owner handles after the (null) owner and xdic.
+func writeBlockControl(h *graphHandles) []byte {
+	b := newObjectBody(h.blockControl, typeBlockControl)
+	b.data.WriteBL(0)                       // numreactors
+	b.data.WriteBL(0)                       // numentries (model/paper space not counted)
+	b.handles.WriteHandle(softPtrCode, 0)   // owner: root (null)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdicobjhandle (null)
+	b.handles.WriteHandle(hardOwnerCode, h.modelHdr)
+	b.handles.WriteHandle(hardOwnerCode, h.paperHdr)
+	return frameObject(b)
+}
+
+// writeLtypeControl frames the LTYPE_CONTROL object. numentries counts only the soft-owner
+// linetypes (Continuous); BYLAYER and BYBLOCK follow as hard-owner handles (ODA §20.4.57).
+func writeLtypeControl(h *graphHandles) []byte {
+	b := newObjectBody(h.ltypeControl, typeLtypeControl)
+	b.data.WriteBL(0)                       // numreactors
+	b.data.WriteBL(1)                       // numentries: Continuous only
+	b.handles.WriteHandle(softPtrCode, 0)   // owner: root (null)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdicobjhandle (null)
+	b.handles.WriteHandle(softOwnerCode, h.ltypeContinuous)
+	b.handles.WriteHandle(hardOwnerCode, h.ltypeByLayer)
+	b.handles.WriteHandle(hardOwnerCode, h.ltypeByBlock)
+	return frameObject(b)
+}
+
+// writeDimstyleControl frames the DIMSTYLE_CONTROL object. Beyond the generic control
+// layout it carries an extra num_morehandles count (a libredwg-observed field, written 0)
+// after numentries; the single dimstyle is a soft-owner handle.
+func writeDimstyleControl(h *graphHandles) []byte {
+	b := newObjectBody(h.dimstyleControl, typeDimstyleControl)
+	b.data.WriteBL(0)                                        // numreactors
+	b.data.WriteBS(1)                                        // num_entries (BitShort, not BL)
+	b.data.WriteRC(1)                                        // num_morehandles (one APPID handle per dimstyle)
+	b.handles.WriteHandle(softPtrCode, 0)                    // owner: root (null)
+	b.handles.WriteHandle(hardOwnerCode, 0)                  // xdicobjhandle (null)
+	b.handles.WriteHandle(softOwnerCode, h.dimstyleStandard) // entry
+	b.handles.WriteHandle(hardPtrCode, h.dimstyleStandard)   // morehandle
+	return frameObject(b)
+}
+
+// writeControlObject frames a generic symbol-table control object (LAYER/STYLE/VIEW/UCS/
+// VPORT/APPID CONTROL): the common header, the entry count, then the handle stream — a null
+// owner (the root), the xdic, and the entry records as soft-owner handles. BLOCK, LTYPE and
+// DIMSTYLE controls have extra fields and are framed by their own writers.
+func writeControlObject(handle uint64, typ int, entries []uint64) []byte {
+	b := newObjectBody(handle, typ)
+	b.data.WriteBL(0)                       // numreactors
+	b.data.WriteBL(len(entries))            // numentries
+	b.handles.WriteHandle(softPtrCode, 0)   // owner: root (null soft pointer)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdicobjhandle (null)
+	for _, e := range entries {
+		b.handles.WriteHandle(softOwnerCode, e)
+	}
+	return frameObject(b)
+}

--- a/kernel/exchange/dwg/writeheadervars.go
+++ b/kernel/exchange/dwg/writeheadervars.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writeheadervars.go emits the R2000 drawing-header-variables section: the VARIABLE_BEGIN
+// sentinel, an RL byte size, the variable list (the exact inverse of readHeaderVarsR2000 in
+// headervars.go, extended through the trailing GUID/space/linetype handles the reader stops
+// short of), a CRC, and the VARIABLE_END sentinel. Numeric variables use neutral defaults; the
+// handle references are wired to the synthesised object graph so AutoCAD resolves every system
+// pointer. Values that must be specific (INSUNITS, the control/space/linetype handles) are set
+// from the caller's graph; the rest mirror a fresh AutoCAD drawing.
+
+// vendSentinel closes the header-variable block (ODA DWG_SENTINEL_VARIABLE_END).
+var vendSentinel = []byte{
+	0x30, 0x84, 0xE0, 0xDC, 0x02, 0x21, 0xC7, 0x56,
+	0xA0, 0x83, 0x97, 0x47, 0xB1, 0x92, 0xCC, 0xA0,
+}
+
+// nullGUID is a syntactically valid all-zero GUID for FINGERPRINTGUID/VERSIONGUID.
+const nullGUID = "{00000000-0000-0000-0000-000000000000}"
+
+// encodeHeaderVars builds the complete header-variables section bytes for the given graph and
+// $INSUNITS code. handseed is the next free handle (must exceed every object handle).
+func encodeHeaderVars(h *graphHandles, insunits int, handseed uint64) []byte {
+	v := NewBitWriter()
+	writeHeaderVarBody(v, h, insunits, handseed)
+	v.AlignToByte()
+	vardata := v.Bytes()
+
+	out := NewBitWriter()
+	for _, by := range vbeginSentinel {
+		out.WriteRC(by)
+	}
+	crcStart := NewBitWriter()
+	crcStart.WriteRL(uint32(len(vardata)))
+	for _, by := range vardata {
+		crcStart.WriteRC(by)
+	}
+	sized := crcStart.Bytes()
+	for _, by := range sized {
+		out.WriteRC(by)
+	}
+	out.WriteRS(crc16(0xC0C1, sized)) // CRC over the size field + variable data
+	for _, by := range vendSentinel {
+		out.WriteRC(by)
+	}
+	return out.Bytes()
+}
+
+// writeHeaderVarBody writes the R2000 variable list in spec order, the inverse of
+// readHeaderVarsR2000. It is one long fixed sequence; the sub-writers group it for clarity.
+func writeHeaderVarBody(w *BitWriter, h *graphHandles, insunits int, handseed uint64) {
+	writeHeaderUnitsModes(w)
+	writeHeaderSizesAndCurrent(w, h, handseed)
+	writeHeaderUcsAndExtents(w)
+	writeHeaderDimVars(w)
+	writeHeaderControlHandles(w, h)
+	w.WriteBL(0x2a1d)   // FLAGS
+	w.WriteBS(insunits) // INSUNITS
+	writeHeaderTail(w, h)
+}
+
+// writeHeaderUnitsModes writes the unit ratios/names, the two unknown longs, the VX handle,
+// the run of boolean mode flags, and the unit/count BitShorts (DIMASO..TEXTQLTY).
+//
+//nolint:funlen // sequential header-variable writes in spec order; length is the field layout.
+func writeHeaderUnitsModes(w *BitWriter) {
+	for i := 0; i < 4; i++ {
+		w.WriteBD(1) // unit1..4 ratio
+	}
+	for i := 0; i < 4; i++ {
+		writeTextEmpty(w) // unit1..4 name
+	}
+	w.WriteBL(0)                  // unknown_8
+	w.WriteBL(0)                  // unknown_9
+	w.WriteHandle(hardPtrCode, 0) // VX_TABLE_RECORD (null)
+	for i := 0; i < 20; i++ {     // DIMASO..PELLIPSE mode bits (see readModeFlags, R2000)
+		w.WriteBit(0)
+	}
+	w.WriteBS(0)             // PROXYGRAPHICS
+	w.WriteBS(0)             // TREEDEPTH
+	w.WriteBS(2)             // LUNITS
+	w.WriteBS(4)             // LUPREC
+	w.WriteBS(0)             // AUNITS
+	w.WriteBS(0)             // AUPREC
+	w.WriteBS(0)             // ATTMODE
+	w.WriteBS(0)             // PDMODE
+	for i := 0; i < 5; i++ { // USERI1..5
+		w.WriteBS(0)
+	}
+	for i := 0; i < 14; i++ { // SPLINESEGS..TEXTQLTY
+		w.WriteBS(0)
+	}
+}
+
+// writeHeaderSizesAndCurrent writes the BD size defaults, the MENU string, the four timers,
+// CECOLOR, then the current-setting handles (HANDSEED, CLAYER, TEXTSTYLE, CELTYPE, DIMSTYLE,
+// CMLSTYLE).
+//
+//nolint:funlen // sequential header size/handle writes in spec order; length is the layout.
+func writeHeaderSizesAndCurrent(w *BitWriter, h *graphHandles, handseed uint64) {
+	w.WriteBD(1) // LTSCALE
+	w.WriteBD(1) // TEXTSIZE
+	w.WriteBD(0) // TRACEWID
+	w.WriteBD(1) // SKETCHINC
+	w.WriteBD(0) // FILLETRAD
+	w.WriteBD(0) // THICKNESS
+	w.WriteBD(0) // ANGBASE
+	w.WriteBD(0) // PDSIZE
+	w.WriteBD(0) // PLINEWID
+	for i := 0; i < 5; i++ {
+		w.WriteBD(0) // USERR1..5
+	}
+	for i := 0; i < 4; i++ {
+		w.WriteBD(0) // CHAMFERA..D
+	}
+	w.WriteBD(0.5)    // FACETRES
+	w.WriteBD(1)      // CMLSCALE
+	w.WriteBD(1)      // CELTSCALE
+	writeName(w, ".") // MENU
+	for i := 0; i < 4; i++ {
+		w.WriteBL(0) // TDCREATE, TDUPDATE, TDINDWG, TDUSRTIMER (each TIMEBLL = 2 BL)
+		w.WriteBL(0)
+	}
+	w.WriteBS(colorByLayer)                        // CECOLOR (index)
+	w.WriteHandle(ownHandleCode, handseed)         // HANDSEED (DATAHANDLE, code 0)
+	w.WriteHandle(hardPtrCode, h.layer0)           // CLAYER
+	w.WriteHandle(hardPtrCode, h.styleStandard)    // TEXTSTYLE
+	w.WriteHandle(hardPtrCode, h.ltypeByLayer)     // CELTYPE
+	w.WriteHandle(hardPtrCode, h.dimstyleStandard) // DIMSTYLE
+	w.WriteHandle(hardPtrCode, h.mlineStandard)    // CMLSTYLE
+}
+
+// writeHeaderUcsAndExtents writes the paper- and model-space UCS, base, extents and limits
+// blocks (all neutral/origin defaults) plus their UCS-name handles and the inline DIMPOST/
+// DIMAPOST strings. Mirrors readUcsDimAndInsunits' R2000 path.
+//
+//nolint:funlen // sequential point/handle writes in the fixed R2000 order; length is the layout.
+func writeHeaderUcsAndExtents(w *BitWriter) {
+	w.WriteBD(1)                  // PSVPSCALE
+	writePoints(w, 3)             // PINSBASE, PEXTMIN, PEXTMAX
+	w.Write2RD([2]float64{})      // PLIMMIN
+	w.Write2RD([2]float64{})      // PLIMMAX
+	w.WriteBD(0)                  // PELEVATION
+	writePoints(w, 3)             // PUCSORG, PUCSXDIR, PUCSYDIR
+	w.WriteHandle(hardPtrCode, 0) // PUCSNAME
+	w.WriteHandle(hardPtrCode, 0) // PUCSORTHOREF
+	w.WriteBS(0)                  // PUCSORTHOVIEW
+	w.WriteHandle(hardPtrCode, 0) // PUCSBASE
+	writePoints(w, 6)             // PUCSORGTOP..BACK
+	writePoints(w, 3)             // INSBASE, EXTMIN, EXTMAX
+	w.Write2RD([2]float64{})      // LIMMIN
+	w.Write2RD([2]float64{})      // LIMMAX
+	w.WriteBD(0)                  // ELEVATION
+	writePoints(w, 3)             // UCSORG, UCSXDIR, UCSYDIR
+	w.WriteHandle(hardPtrCode, 0) // UCSNAME
+	w.WriteHandle(hardPtrCode, 0) // UCSORTHOREF
+	w.WriteBS(0)                  // UCSORTHOVIEW
+	w.WriteHandle(hardPtrCode, 0) // UCSBASE
+	writePoints(w, 6)             // UCSORGTOP..BACK
+	writeTextEmpty(w)             // DIMPOST
+	writeTextEmpty(w)             // DIMAPOST
+}
+
+// writePoints writes n origin 3D points (BitDouble triples).
+func writePoints(w *BitWriter, n int) {
+	for i := 0; i < n; i++ {
+		w.Write3BD([3]float64{})
+	}
+}
+
+// writeHeaderDimVars writes the R2000 dimension-variable block (DIMSCALE..DIMLWE) with
+// AutoCAD's default values, mirroring readDimVars' R2000 path. The five DIM block handles
+// are null.
+//
+//nolint:funlen // one dimension variable per line in the fixed R2000 order; length is the layout.
+func writeHeaderDimVars(w *BitWriter) {
+	w.WriteBD(1)                                                        // DIMSCALE
+	for _, v := range []float64{0.18, 0.0625, 0.38, 0.18, 0, 0, 0, 0} { // DIMASZ..DIMTM
+		w.WriteBD(v)
+	}
+	for i := 0; i < 6; i++ { // DIMTOL,DIMLIM,DIMTIH,DIMTOH,DIMSE1,DIMSE2
+		w.WriteBit(0)
+	}
+	w.WriteBS(0)                                                      // DIMTAD
+	w.WriteBS(0)                                                      // DIMZIN
+	w.WriteBS(0)                                                      // DIMAZIN
+	for _, v := range []float64{0.18, 0.09, 0, 25.4, 1, 0, 1, 0.09} { // DIMTXT..DIMGAP
+		w.WriteBD(v)
+	}
+	w.WriteBD(0)                                                // DIMALTRND
+	w.WriteBit(0)                                               // DIMALT
+	w.WriteBS(2)                                                // DIMALTD
+	w.WriteBit(1)                                               // DIMTOFL
+	w.WriteBit(0)                                               // DIMSAH
+	w.WriteBit(0)                                               // DIMTIX
+	w.WriteBit(0)                                               // DIMSOXD
+	w.WriteBS(0)                                                // DIMCLRD
+	w.WriteBS(0)                                                // DIMCLRE
+	w.WriteBS(0)                                                // DIMCLRT
+	for _, v := range []int{0, 4, 4, 2, 3, 0, 0, 2, 46, 0, 0} { // DIMADEC..DIMJUST
+		w.WriteBS(v)
+	}
+	w.WriteBit(0)                         // DIMSD1
+	w.WriteBit(0)                         // DIMSD2
+	for _, v := range []int{0, 8, 0, 0} { // DIMTOLJ,DIMTZIN,DIMALTZ,DIMALTTZ
+		w.WriteBS(v)
+	}
+	w.WriteBit(0) // DIMUPT
+	w.WriteBS(3)  // DIMATFIT
+	for i := 0; i < 5; i++ {
+		w.WriteHandle(hardPtrCode, 0) // DIMTXSTY,DIMLDRBLK,DIMBLK,DIMBLK1,DIMBLK2 (null)
+	}
+	w.WriteBS(-2) // DIMLWD
+	w.WriteBS(-2) // DIMLWE
+}
+
+// writeHeaderControlHandles writes the nine symbol-table control-object handles, the null
+// viewport-entity-header control, the ACAD_GROUP/ACAD_MLINESTYLE/named-object dictionaries,
+// the text-stack settings, the two inline strings, and the layout/plotsettings/plotstyle
+// dictionaries.
+func writeHeaderControlHandles(w *BitWriter, h *graphHandles) {
+	for _, c := range []uint64{
+		h.blockControl, h.layerControl, h.styleControl, h.ltypeControl,
+		h.viewControl, h.ucsControl, h.vportControl, h.appidControl, h.dimstyleControl,
+	} {
+		w.WriteHandle(hardOwnerCode, c)
+	}
+	w.WriteHandle(hardOwnerCode, 0)                // VIEWPORT ENTITY HEADER control (null)
+	w.WriteHandle(hardPtrCode, h.groupDict)        // ACAD_GROUP
+	w.WriteHandle(hardPtrCode, h.mlineDict)        // ACAD_MLINESTYLE
+	w.WriteHandle(hardOwnerCode, h.nod)            // NAMED OBJECTS dictionary
+	w.WriteBS(1)                                   // TSTACKALIGN
+	w.WriteBS(70)                                  // TSTACKSIZE
+	writeTextEmpty(w)                              // HYPERLINKBASE
+	writeTextEmpty(w)                              // STYLESHEET
+	w.WriteHandle(hardPtrCode, h.layoutDict)       // LAYOUTS
+	w.WriteHandle(hardPtrCode, h.plotSettingsDict) // PLOTSETTINGS
+	w.WriteHandle(hardPtrCode, h.plotStyleDict)    // PLOTSTYLES
+}
+
+// writeHeaderTail writes the variables after INSUNITS: the plot-style name type, the two
+// GUIDs, then the paper/model space block records and the three system linetype handles.
+func writeHeaderTail(w *BitWriter, h *graphHandles) {
+	w.WriteBS(0)                                  // CEPSNTYPE (0 → no CPSNID handle)
+	writeName(w, nullGUID)                        // FINGERPRINTGUID
+	writeName(w, nullGUID)                        // VERSIONGUID
+	w.WriteHandle(hardPtrCode, h.paperHdr)        // *PAPER_SPACE block record
+	w.WriteHandle(hardPtrCode, h.modelHdr)        // *MODEL_SPACE block record
+	w.WriteHandle(hardPtrCode, h.ltypeByLayer)    // LTYPE BYLAYER
+	w.WriteHandle(hardPtrCode, h.ltypeByBlock)    // LTYPE BYBLOCK
+	w.WriteHandle(hardPtrCode, h.ltypeContinuous) // LTYPE CONTINUOUS
+}

--- a/kernel/exchange/dwg/writelayouts.go
+++ b/kernel/exchange/dwg/writelayouts.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writelayouts.go encodes the named-object-dictionary chain AutoCAD expects under the NOD:
+// the ACAD_GROUP/ACAD_MLINESTYLE/ACAD_PLOTSETTINGS/ACAD_PLOTSTYLENAME/ACAD_LAYOUT
+// dictionaries and the objects they own — the STANDARD multiline style, the "Normal"
+// plot-style placeholder, and the Model/Layout1 paper layouts (each embedding a default
+// PLOTSETTINGS block). These are the non-fixed (class-resolved) object types, so the writer
+// also declares their classes (writeclasses.go). Field layouts mirror the oracle's R2000
+// decode.
+
+// Dynamic class numbers for the non-fixed objects the chain emits. They index the class list
+// emitted in this same order (class 0 → 500), so writeclasses.go must list them identically.
+const (
+	classDictWDflt   = 500 // ACDBDICTIONARYWDFLT (the plot-style-name dictionary)
+	classPlaceholder = 501 // ACDBPLACEHOLDER (a plot-style entry)
+	classLayout      = 502 // LAYOUT
+)
+
+// chainClasses are the class definitions for the dictionary-chain objects, in the order their
+// type numbers assume (classDictWDflt first → 500).
+func chainClasses() []classDef {
+	return []classDef{
+		{num: classDictWDflt, dxfName: "ACDBDICTIONARYWDFLT", cppName: "AcDbDictionaryWithDefault", isObject: true},
+		{num: classPlaceholder, dxfName: "ACDBPLACEHOLDER", cppName: "AcDbPlaceHolder", isObject: true},
+		{num: classLayout, dxfName: "LAYOUT", cppName: "AcDbLayout", isObject: true},
+	}
+}
+
+// writeSubDictionary frames a DICTIONARY owned by another dictionary (e.g. ACAD_MLINESTYLE
+// under the NOD). It is writeDictionary with a non-root owner.
+func writeSubDictionary(handle, owner uint64, entries []dictEntry) []byte {
+	return writeDictionary(handle, owner, entries)
+}
+
+// writeDictionaryWDflt frames an ACDBDICTIONARYWDFLT (the plot-style-name dictionary): a
+// DICTIONARY plus a trailing default-entry hard pointer. Used for ACAD_PLOTSTYLENAME, whose
+// default is the "Normal" placeholder.
+func writeDictionaryWDflt(handle, owner uint64, entries []dictEntry, defaultID uint64) []byte {
+	b := newObjectBody(handle, classDictWDflt)
+	b.data.WriteBL(0)            // numreactors
+	b.data.WriteBL(len(entries)) // numitems
+	b.data.WriteBS(1)            // cloning flag
+	b.data.WriteRC(0)            // hard-owner flag
+	for _, e := range entries {
+		writeName(b.data, e.name)
+	}
+	b.handles.WriteHandle(softPtrCode, owner)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdic
+	for _, e := range entries {
+		b.handles.WriteHandle(softOwnerCode, e.handle)
+	}
+	b.handles.WriteHandle(hardPtrCode, defaultID) // default entry
+	return frameObject(b)
+}
+
+// writePlaceholder frames an ACDBPLACEHOLDER ("Normal" plot style): a common object header
+// only, owned by the plot-style-name dictionary.
+func writePlaceholder(handle, owner uint64) []byte {
+	b := newObjectBody(handle, classPlaceholder)
+	b.data.WriteBL(0) // numreactors
+	b.handles.WriteHandle(softPtrCode, owner)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdic
+	return frameObject(b)
+}
+
+// writeMlinestyle frames the STANDARD MLINESTYLE: two element lines at ±0.5 offset, ByLayer
+// colour, the default linetype index. MLINESTYLE is a fixed type (0x49).
+func writeMlinestyle(handle, owner uint64) []byte {
+	b := newObjectBody(handle, 0x49)
+	b.data.WriteBL(0)                  // numreactors
+	writeName(b.data, "Standard")      // name
+	writeTextEmpty(b.data)             // description
+	b.data.WriteBS(0)                  // flags
+	b.data.WriteBS(colorByLayer)       // fill colour
+	b.data.WriteBD(1.5707963267948966) // start angle (90°)
+	b.data.WriteBD(1.5707963267948966) // end angle
+	b.data.WriteRC(2)                  // num lines
+	for _, off := range []float64{0.5, -0.5} {
+		b.data.WriteBD(off)          // element offset
+		b.data.WriteBS(colorByLayer) // element colour
+		b.data.WriteBS(32767)        // element linetype index (BYLAYER sentinel)
+	}
+	b.handles.WriteHandle(softPtrCode, owner)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdic
+	return frameObject(b)
+}
+
+// layoutRefs carries the cross-references a LAYOUT needs: its owning dictionary and the block
+// record (paper or model space) it controls.
+type layoutRefs struct {
+	owner, blockHeader uint64
+	name               string
+	tabOrder, flags    int
+}
+
+// writeLayout frames a LAYOUT object: a default PLOTSETTINGS block followed by the layout's
+// name, tab order, flags and UCS/extent defaults, then the handle stream (owner dictionary,
+// the controlled block record, and null viewport/UCS handles). Field order and bit types
+// mirror the oracle's R2000 decode.
+//
+//nolint:funlen // one PLOTSETTINGS/LAYOUT field per line in the fixed R2000 order.
+func writeLayout(handle uint64, r layoutRefs) []byte {
+	b := newObjectBody(handle, classLayout)
+	b.data.WriteBL(0) // numreactors
+	writePlotSettings(b.data)
+	writeName(b.data, r.name)            // layout name
+	b.data.WriteBS(r.tabOrder)           // tab order
+	b.data.WriteBS(r.flags)              // layout flags
+	b.data.Write3BD([3]float64{})        // INSBASE
+	b.data.Write2RD([2]float64{0, 0})    // LIMMIN
+	b.data.Write2RD([2]float64{12, 9})   // LIMMAX
+	b.data.Write3BD([3]float64{})        // UCSORG
+	b.data.Write3BD([3]float64{1, 0, 0}) // UCSXDIR
+	b.data.Write3BD([3]float64{0, 1, 0}) // UCSYDIR
+	b.data.WriteBD(0)                    // ucs elevation
+	b.data.WriteBS(0)                    // UCSORTHOVIEW
+	b.data.Write3BD([3]float64{})        // EXTMIN
+	b.data.Write3BD([3]float64{})        // EXTMAX
+
+	b.handles.WriteHandle(softPtrCode, r.owner)
+	b.handles.WriteHandle(hardOwnerCode, 0)           // xdic
+	b.handles.WriteHandle(softPtrCode, r.blockHeader) // associated block record
+	b.handles.WriteHandle(softPtrCode, 0)             // active viewport (null)
+	b.handles.WriteHandle(hardPtrCode, 0)             // base UCS (null)
+	b.handles.WriteHandle(hardPtrCode, 0)             // named UCS (null)
+	return frameObject(b)
+}
+
+// writePlotSettings writes the embedded PLOTSETTINGS block with the default "none_device"
+// page setup (ODA §20.4 PLOTSETTINGS; matches the oracle's field order/types).
+//
+//nolint:funlen // one PLOTSETTINGS field per line in the fixed R2000 order; length is the layout.
+func writePlotSettings(w *BitWriter) {
+	writeTextEmpty(w)                            // page setup / printer config file
+	writeName(w, "none_device")                  // plot device name
+	w.WriteBS(0x2eb0)                            // plot layout flags
+	w.WriteBD(6.35)                              // left margin
+	w.WriteBD(19.05)                             // bottom margin
+	w.WriteBD(6.35)                              // right margin
+	w.WriteBD(19.05)                             // top margin
+	w.WriteBD(215.9)                             // paper width (mm)
+	w.WriteBD(279.4)                             // paper height (mm)
+	writeName(w, "ANSI_A_(8.50_x_11.00_Inches)") // canonical media name
+	w.WriteBD(0)                                 // plot origin x
+	w.WriteBD(0)                                 // plot origin y
+	w.WriteBS(0)                                 // plot paper units
+	w.WriteBS(0)                                 // plot rotation
+	w.WriteBS(0)                                 // plot type
+	w.WriteBD(0)                                 // plot window LL x
+	w.WriteBD(0)                                 // plot window LL y
+	w.WriteBD(0)                                 // plot window UR x
+	w.WriteBD(0)                                 // plot window UR y
+	writeTextEmpty(w)                            // plot view name
+	w.WriteBD(1)                                 // custom-scale numerator
+	w.WriteBD(1)                                 // custom-scale denominator
+	writeTextEmpty(w)                            // current style sheet
+	w.WriteBS(0)                                 // standard scale type
+	w.WriteBD(1)                                 // scale factor
+	w.WriteBD(0)                                 // paper image origin x
+	w.WriteBD(0)                                 // paper image origin y
+}

--- a/kernel/exchange/dwg/writetables.go
+++ b/kernel/exchange/dwg/writetables.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writetables.go encodes the standard symbol-table records every R2000 drawing carries:
+// layer "0", the three system linetypes, the STANDARD text and dimension styles, the ACAD
+// application id, and the *Active viewport. Field order, types and the handle-stream tails
+// are taken from LibreDWG's decode of a real R2000 file (the validation oracle) and the ODA
+// §20.4 prescriptions. Each record's common preamble (name, flags, owner, xdic) is written
+// by writeRecordCommon; the type-specific fields follow.
+
+// writeRecordCommon writes the shared symbol-table-record preamble: numreactors and the
+// entry name in the data stream, then the handle stream's owning control object, a null
+// xdic, and a null external-reference block handle. The oracle reads that external-reference
+// handle on every table record (even non-xref ones), so it is always emitted here.
+func writeRecordCommon(b *objectBody, control uint64, name string) {
+	b.data.WriteBL(0)       // numreactors
+	writeName(b.data, name) // entry name (TV)
+	b.data.WriteBit(1)      // 64-flag: entry is referenced (the 0x40 bit of the 70 group)
+	b.data.WriteBS(0)       // xrefindex+1 → -1 (not from an xref)
+	b.data.WriteBit(0)      // Xdep: not xref-dependent
+	b.handles.WriteHandle(softPtrCode, control)
+	b.handles.WriteHandle(hardOwnerCode, 0) // xdicobjhandle (null)
+	b.handles.WriteHandle(hardPtrCode, 0)   // external reference block (null)
+}
+
+// writeLayer encodes LAYER "0": the on/plottable flag word with default lineweight, the
+// layer colour (7, white), then the plotstyle and linetype handles. The flag word 0x3F0 is
+// the value the oracle decodes for a normal on, plottable, default-lineweight layer.
+func writeLayer(h *graphHandles) []byte {
+	b := newObjectBody(h.layer0, int(TypeLayer))
+	writeRecordCommon(b, h.layerControl, "0")
+	b.data.WriteBS(0x3F0)                                 // values: plot flag (0x10) | lineweight 0x1F (mask 0x3E0)
+	b.data.WriteBS(7)                                     // colour index (white)
+	b.handles.WriteHandle(hardPtrCode, h.placeholder)     // plotstyle → "Normal" placeholder
+	b.handles.WriteHandle(hardPtrCode, h.ltypeContinuous) // linetype
+	return frameObject(b)
+}
+
+// writeStyle encodes the STANDARD text style (SHAPEFILE record): a plain (non-vertical,
+// non-shape) font with unit width and the default "txt" font file.
+func writeStyle(h *graphHandles) []byte {
+	b := newObjectBody(h.styleStandard, int(TypeStyle))
+	writeRecordCommon(b, h.styleControl, "Standard")
+	b.data.WriteBit(0)       // vertical
+	b.data.WriteBit(0)       // shape file
+	b.data.WriteBD(0)        // fixed height
+	b.data.WriteBD(1)        // width factor
+	b.data.WriteBD(0)        // oblique angle
+	b.data.WriteRC(0)        // generation flags
+	b.data.WriteBD(0)        // last height
+	writeName(b.data, "txt") // font name
+	writeTextEmpty(b.data)   // big-font name
+	return frameObject(b)
+}
+
+// TypeStyle/TypeLtype/TypeVport/TypeAppid/TypeDimstyle are the fixed R2000 type codes for
+// the symbol-table records (ODA §20.3); only the ones the writer emits are named.
+const (
+	TypeStyle    ObjectType = 0x35
+	TypeLtype    ObjectType = 0x39
+	TypeVport    ObjectType = 0x41
+	TypeAppid    ObjectType = 0x43
+	TypeDimstyle ObjectType = 0x45
+)
+
+// writeLinetype encodes a simple (dashless) LTYPE record. R2000 LTYPE records always carry
+// the 256-byte string area (confirmed by the oracle: a continuous linetype decodes to a
+// 280-byte object), so 256 zero bytes are emitted after the dash count.
+func writeLinetype(handle, control uint64, name string) []byte {
+	b := newObjectBody(handle, int(TypeLtype))
+	writeRecordCommon(b, control, name)
+	writeTextEmpty(b.data) // description
+	b.data.WriteBD(0)      // pattern length
+	b.data.WriteRC('A')    // alignment, always 'A'
+	b.data.WriteRC(0)      // numdashes
+	for i := 0; i < 256; i++ {
+		b.data.WriteRC(0) // string area
+	}
+	return frameObject(b)
+}
+
+// writeAppid encodes the ACAD application id: the standard preamble plus a single trailing
+// unknown byte (DXF 71) the oracle always reads as 0.
+func writeAppid(h *graphHandles) []byte {
+	b := newObjectBody(h.appidAcad, int(TypeAppid))
+	writeRecordCommon(b, h.appidControl, "ACAD")
+	b.data.WriteRC(0) // unknown (DXF 71)
+	return frameObject(b)
+}

--- a/kernel/exchange/dwg/writevport.go
+++ b/kernel/exchange/dwg/writevport.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+// writevport.go encodes the two large symbol-table records: the *Active VPORT (the model
+// viewport) and the STANDARD DIMSTYLE. Both field layouts mirror LibreDWG's decode of a real
+// R2000 file field-for-field (the bit types matter: BD vs RD, B vs BB, the 4-bit VIEWMODE),
+// using neutral default values for a fresh drawing.
+
+// writeVport encodes the *Active VPORT record with a unit-square view and the standard grid
+// and snap defaults. The handle-stream tail is the vport control owner, a null xdic, and the
+// null named/base UCS handles.
+//
+//nolint:funlen // one VPORT field per line in the fixed R2000 order; length is the layout.
+func writeVport(h *graphHandles) []byte {
+	b := newObjectBody(h.vportActive, int(TypeVport))
+	writeRecordCommon(b, h.vportControl, "*Active")
+	b.data.WriteBD(1)                     // VIEWSIZE
+	b.data.WriteBD(1)                     // view width
+	b.data.Write2RD([2]float64{0, 0})     // VIEWCTR
+	b.data.Write3BD([3]float64{0, 0, 0})  // view target
+	b.data.Write3BD([3]float64{0, 0, 1})  // VIEWDIR
+	b.data.WriteBD(0)                     // VIEWTWIST
+	b.data.WriteBD(50)                    // LENSLENGTH
+	b.data.WriteBD(0)                     // FRONTZ
+	b.data.WriteBD(0)                     // BACKZ
+	b.data.WriteBits(0, 4)                // VIEWMODE (4 bits)
+	b.data.WriteRC(0)                     // render mode
+	b.data.Write2RD([2]float64{0, 0})     // lower-left
+	b.data.Write2RD([2]float64{1, 1})     // upper-right
+	b.data.WriteBit(0)                    // UCSFOLLOW
+	b.data.WriteBS(1000)                  // circle zoom
+	b.data.WriteBit(1)                    // FASTZOOM
+	b.data.WriteBits(3, 2)                // UCSICON (2 bits)
+	b.data.WriteBit(0)                    // GRIDMODE
+	b.data.Write2RD([2]float64{10, 10})   // GRIDUNIT
+	b.data.WriteBit(0)                    // SNAPMODE
+	b.data.WriteBit(0)                    // SNAPSTYLE
+	b.data.WriteBS(0)                     // SNAPISOPAIR
+	b.data.WriteBD(0)                     // SNAPANG
+	b.data.Write2RD([2]float64{0, 0})     // SNAPBASE
+	b.data.Write2RD([2]float64{10, 10})   // SNAPUNIT
+	b.data.WriteBit(0)                    // ucs at origin
+	b.data.WriteBit(1)                    // UCSVP
+	b.data.Write3BD([3]float64{0, 0, 0})  // ucs origin
+	b.data.Write3BD([3]float64{1, 0, 0})  // ucs x-dir
+	b.data.Write3BD([3]float64{0, 1, 0})  // ucs y-dir
+	b.data.WriteBD(0)                     // ucs elevation
+	b.data.WriteBS(0)                     // UCSORTHOVIEW
+	b.handles.WriteHandle(hardPtrCode, 0) // named UCS (null)
+	b.handles.WriteHandle(hardPtrCode, 0) // base UCS (null)
+	return frameObject(b)
+}
+
+// writeDimstyle encodes the STANDARD dimension style with AutoCAD's default DIMxxx values.
+// The trailing handle stream is the style reference (DIMTXSTY → STANDARD text style) and the
+// four null arrowhead-block handles (DIMLDRBLK/DIMBLK/DIMBLK1/DIMBLK2).
+//
+//nolint:funlen // one DIMxxx variable per line in the fixed R2000 order; length is the layout.
+func writeDimstyle(h *graphHandles) []byte {
+	b := newObjectBody(h.dimstyleStandard, int(TypeDimstyle))
+	writeRecordCommon(b, h.dimstyleControl, "Standard")
+	writeTextEmpty(b.data)                                                 // DIMPOST
+	writeTextEmpty(b.data)                                                 // DIMAPOST
+	for _, v := range []float64{1, 0.18, 0.0625, 0.38, 0.18, 0, 0, 0, 0} { // DIMSCALE..DIMTM
+		b.data.WriteBD(v)
+	}
+	for i := 0; i < 6; i++ { // DIMTOL,DIMLIM,DIMTIH,DIMTOH,DIMSE1,DIMSE2
+		b.data.WriteBit(0)
+	}
+	b.data.WriteBS(0)                                                 // DIMTAD
+	b.data.WriteBS(0)                                                 // DIMZIN
+	b.data.WriteBS(0)                                                 // DIMAZIN
+	for _, v := range []float64{0.18, 0.09, 0, 25.4, 1, 0, 1, 0.09} { // DIMTXT..DIMGAP
+		b.data.WriteBD(v)
+	}
+	b.data.WriteBD(0)                                           // DIMALTRND
+	b.data.WriteBit(0)                                          // DIMALT
+	b.data.WriteBS(2)                                           // DIMALTD
+	b.data.WriteBit(1)                                          // DIMTOFL
+	b.data.WriteBit(0)                                          // DIMSAH
+	b.data.WriteBit(0)                                          // DIMTIX
+	b.data.WriteBit(0)                                          // DIMSOXD
+	b.data.WriteBS(0)                                           // DIMCLRD
+	b.data.WriteBS(0)                                           // DIMCLRE
+	b.data.WriteBS(0)                                           // DIMCLRT
+	for _, v := range []int{0, 4, 4, 2, 3, 0, 0, 2, 46, 0, 0} { // DIMADEC..DIMJUST
+		b.data.WriteBS(v)
+	}
+	b.data.WriteBit(0)                    // DIMSD1
+	b.data.WriteBit(0)                    // DIMSD2
+	for _, v := range []int{0, 8, 0, 0} { // DIMTOLJ,DIMTZIN,DIMALTZ,DIMALTTZ
+		b.data.WriteBS(v)
+	}
+	b.data.WriteBit(0)                                  // DIMUPT
+	b.data.WriteBS(3)                                   // DIMATFIT
+	b.data.WriteBS(-2)                                  // DIMLWD (default)
+	b.data.WriteBS(-2)                                  // DIMLWE (default)
+	b.data.WriteBit(0)                                  // unknown trailing flag the oracle reads as 0
+	b.handles.WriteHandle(hardPtrCode, h.styleStandard) // DIMTXSTY
+	for i := 0; i < 4; i++ {
+		b.handles.WriteHandle(hardPtrCode, 0) // DIMLDRBLK, DIMBLK, DIMBLK1, DIMBLK2 (null)
+	}
+	return frameObject(b)
+}


### PR DESCRIPTION
## What & why

DWG export previously wrote only the model-space curve entities plus an object map. LibreDWG could recover the geometry, but the file had **no header-variables section, no classes section, and none of the symbol tables, block records or dictionaries every DWG must carry** — so AutoCAD would reject it as malformed.

This PR makes `dwg.Write` synthesise the **complete R2000 system-object graph**, so the exported file is a structurally valid drawing other applications open:

- **header-variables section** — full inverse of the reader, with every system handle reference wired up and `$INSUNITS` round-tripping;
- **classes section** — declares `ACDBDICTIONARYWDFLT` / `ACDBPLACEHOLDER` / `LAYOUT`;
- the **nine symbol-table control objects** and their standard records: layer `0`, the `ByLayer`/`ByBlock`/`Continuous` linetypes, the `Standard` text & dimension styles, the `ACAD` appid, the `*Active` viewport;
- the **`*Model_Space` / `*Paper_Space` block records** with their BLOCK/ENDBLK markers;
- the **named-object dictionary chain**: `ACAD_GROUP`, `ACAD_MLINESTYLE`→MLINESTYLE, `ACAD_PLOTSTYLENAME`→"Normal" placeholder, `ACAD_LAYOUT`→**Model + Layout1** layouts (each with an embedded PLOTSETTINGS), `ACAD_PLOTSETTINGS`;
- model-space entities written as a proper **prev/next linked list** owned by the model block record (entmode 2, ByLayer colour, real layer pointer).

Field layouts and handle-stream tails were derived from the ODA spec and verified field-by-field against LibreDWG's decode of a real R2000 file.

## Validation (LibreDWG oracle — no AutoCAD in the environment)

- `dwgread export.dwg` → **SUCCESS, 0 errors / 0 warnings** (`-v4`)
- `dwg2dxf export.dwg` → valid DXF, layouts intact, geometry byte-exact
- `dwgwrite DXF → DWG` → SUCCESS (full interop loop, both directions)
- All Go tests + `golangci-lint` clean; new `TestWriteFullGraphStructure` asserts the whole object graph + unit round-trip in CI (dwgread isn't available there).

## Known follow-up

The R2000 **"second header"** recovery-redundancy block is not emitted (LibreDWG tolerates its absence — zero warnings). It's a hardening item, not a correctness blocker; true zero-repair AutoCAD behaviour can't be verified here without AutoCAD itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)