### PR TITLE
feat(chamfer): fill or relieve concave (internal) edges

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -23,14 +23,15 @@ import (
 // EdgeSets is fillet-only: the edge-set form (#323), taking precedence over the flat
 // edgeRefs+radius pair.
 type edgeDressArgs struct {
-	EdgeRefs    []string        `json:"edgeRefs"`
-	Radius      string          `json:"radius,omitempty"`      // fillet
-	Distance    string          `json:"distance,omitempty"`    // chamfer
-	EdgeSets    []filletSetArgs `json:"edgeSets,omitempty"`    // fillet
-	CornerType  string          `json:"cornerType,omitempty"`  // fillet shared-corner treatment (default miter)
-	ChamferType string          `json:"chamferType,omitempty"` // chamfer mode (default distance)
-	Distance2   string          `json:"distance2,omitempty"`   // chamfer twoDistances
-	Angle       string          `json:"angle,omitempty"`       // chamfer distanceAndAngle
+	EdgeRefs        []string        `json:"edgeRefs"`
+	Radius          string          `json:"radius,omitempty"`          // fillet
+	Distance        string          `json:"distance,omitempty"`        // chamfer
+	EdgeSets        []filletSetArgs `json:"edgeSets,omitempty"`        // fillet
+	CornerType      string          `json:"cornerType,omitempty"`      // fillet shared-corner treatment (default miter)
+	ChamferType     string          `json:"chamferType,omitempty"`     // chamfer mode (default distance)
+	Distance2       string          `json:"distance2,omitempty"`       // chamfer twoDistances
+	Angle           string          `json:"angle,omitempty"`           // chamfer distanceAndAngle
+	ConcaveStrategy string          `json:"concaveStrategy,omitempty"` // chamfer concave-edge handling (default outward)
 }
 
 // filletSetArgs is one fillet edge set over the wire: constant (radius) or variable
@@ -64,7 +65,8 @@ const chamferSchema = `{
     "distance": {"type": "string", "description": "Chamfer setback with units, e.g. \"2 mm\" (the first face for the asymmetric modes)."},
     "chamferType": {"type": "string", "enum": ["distance", "distanceAndAngle", "twoDistances"], "default": "distance", "description": "Setback mode."},
     "distance2": {"type": "string", "description": "twoDistances: setback on the second face, e.g. \"4 mm\"."},
-    "angle": {"type": "string", "description": "distanceAndAngle: chamfer-face angle, e.g. \"30 deg\"."}
+    "angle": {"type": "string", "description": "distanceAndAngle: chamfer-face angle, e.g. \"30 deg\"."},
+    "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with material (default), inward cuts a recessed relief groove. Convex edges ignore this."}
   },
   "required": ["edgeRefs", "distance"]
 }`
@@ -174,6 +176,16 @@ func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if len(in.EdgeRefs) == 0 {
 		return nil, errors.New("chamfer: edgeRefs is empty")
 	}
+	pf, err := buildChamfer(part, in)
+	if err != nil {
+		return nil, err
+	}
+	return recomputeResult(part, pf)
+}
+
+// buildChamfer resolves the chamfer mode, setbacks, and concave-edge strategy from the args and
+// adds the feature (not yet recomputed).
+func buildChamfer(part *compdef.PartComponentDefinition, in edgeDressArgs) (*feature.PartFeature, error) {
 	d, err := lengthClosure(part, in.Distance, "chamfer: distance")
 	if err != nil {
 		return nil, err
@@ -182,11 +194,16 @@ func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
+	cs, err := chamferConcaveStrategyOf(in.ConcaveStrategy)
+	if err != nil {
+		return nil, err
+	}
 	pf, err := applyChamferMode(part, refKeys(in.EdgeRefs), d, ct, in)
 	if err != nil {
 		return nil, err
 	}
-	return recomputeResult(part, pf)
+	pf.Definition().(*feature.ChamferFeature).Definition().ConcaveStrategy = cs
+	return pf, nil
 }
 
 // chamferTypeOf resolves the chamfer mode spelling, defaulting to equal-distance.
@@ -197,6 +214,18 @@ func chamferTypeOf(spelling string) (types.ChamferType, error) {
 	v, ok := types.ParseChamferType(spelling)
 	if !ok {
 		return 0, fmt.Errorf("chamfer: unknown chamferType %q", spelling)
+	}
+	return v, nil
+}
+
+// chamferConcaveStrategyOf resolves the concave-edge strategy spelling, defaulting to outward.
+func chamferConcaveStrategyOf(spelling string) (types.ChamferConcaveStrategy, error) {
+	if spelling == "" {
+		return types.ChamferConcaveOutward, nil
+	}
+	v, ok := types.ParseChamferConcaveStrategy(spelling)
+	if !ok {
+		return 0, fmt.Errorf("chamfer: unknown concaveStrategy %q (want outward or inward)", spelling)
 	}
 	return v, nil
 }

--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/feature"
 )
 
@@ -17,20 +18,24 @@ type ChamferTool struct {
 	seededEdgeKeys  [][]byte // edit mode: the feature's existing edge keys (their edges are consumed, so no live handles exist)
 	distance        float64
 	flatCorners     bool
+	concaveStrategy types.ChamferConcaveStrategy // concave edges: outward fill (default) or inward relief
 	added           *feature.PartFeature
 }
 
-// NewChamferTool returns a chamfer tool with a default 1-unit setback and flat three-edge
-// corners (overridden from the session preference in Start).
-func NewChamferTool() *ChamferTool { return &ChamferTool{distance: 1, flatCorners: true} }
+// NewChamferTool returns a chamfer tool with a default 1-unit setback, flat three-edge corners,
+// and outward concave fill (all overridden from the session preferences in Start).
+func NewChamferTool() *ChamferTool {
+	return &ChamferTool{distance: 1, flatCorners: true, concaveStrategy: types.ChamferConcaveOutward}
+}
 
 // Name implements [Tool].
 func (t *ChamferTool) Name() string { return "Chamfer" }
 
-// Start sets the selection filter to edges and seeds the corner treatment from the
-// session's chamfer preference.
+// Start sets the selection filter to edges and seeds the corner treatment and concave-edge
+// strategy from the session's chamfer preferences.
 func (t *ChamferTool) Start(s *Session) {
 	t.flatCorners = s.ChamferFlatCorners()
+	t.concaveStrategy = s.ChamferConcaveStrategy()
 	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
 }
 
@@ -38,6 +43,29 @@ func (t *ChamferTool) Start(s *Session) {
 // blended into a flat triangular face (true) or left pointy (false).
 func (t *ChamferTool) SetFlatCorners(flat bool) { t.flatCorners = flat }
 func (t *ChamferTool) FlatCorners() bool        { return t.flatCorners }
+
+// concaveStrategyNames orders the concave-strategy combo: index 0 outward, 1 inward.
+var concaveStrategyNames = []types.ChamferConcaveStrategy{types.ChamferConcaveOutward, types.ChamferConcaveInward}
+
+// ConcaveStrategyNames labels the concave-edge combo (the UI renders these in index order).
+func ConcaveStrategyNames() []string { return []string{"Outward (fill)", "Inward (relief)"} }
+
+// ConcaveStrategyIndex / SetConcaveStrategyIndex expose the concave-edge strategy as a combo
+// index (0 outward, 1 inward) for the property panel, mirroring the relief-shape combos.
+func (t *ChamferTool) ConcaveStrategyIndex() int {
+	if t.concaveStrategy == types.ChamferConcaveInward {
+		return 1
+	}
+	return 0
+}
+
+// SetConcaveStrategyIndex selects the concave-edge strategy from the combo index (out of range
+// is ignored, keeping the current strategy).
+func (t *ChamferTool) SetConcaveStrategyIndex(i int) {
+	if i >= 0 && i < len(concaveStrategyNames) {
+		t.concaveStrategy = concaveStrategyNames[i]
+	}
+}
 
 // Pick appends the clicked edge (ignoring one already chosen, so a double-click does not
 // duplicate it).
@@ -93,7 +121,7 @@ func (t *ChamferTool) Commit(s *Session) error {
 		return err
 	}
 	d := t.distance
-	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferCorners(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners)
+	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
 	part.Recompute()
 	s.recordEdit(part, "Chamfer")
 	if !t.added.Health().OK() {
@@ -129,6 +157,7 @@ func (t *ChamferTool) commitEdit(s *Session) error {
 	def.EdgeKeys = t.selectedEdgeKeys()
 	def.Distance = konst(t.distance)
 	def.FlatCorners = t.flatCorners
+	def.ConcaveStrategy = t.concaveStrategy
 	return commitFeatureEdit(s, t.target)
 }
 

--- a/app/chamfer_tool_test.go
+++ b/app/chamfer_tool_test.go
@@ -5,6 +5,7 @@ package app
 import (
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/compdef"
@@ -102,6 +103,28 @@ func TestChamferToolSeedsCornerPreference(t *testing.T) {
 	}
 	if def := ch.AddedFeature().Definition().(*feature.ChamferFeature).Definition(); def.FlatCorners {
 		t.Error("committed chamfer should carry the pointy preference")
+	}
+}
+
+// TestChamferToolSeedsConcaveStrategy checks the tool adopts the session's default concave-edge
+// strategy on Start and carries it (via the combo index) to the committed feature's definition.
+func TestChamferToolSeedsConcaveStrategy(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	s.SetChamferConcaveStrategy(types.ChamferConcaveInward)
+
+	ch := NewChamferTool()
+	s.StartTool(ch)
+	if ch.ConcaveStrategyIndex() != 1 {
+		t.Errorf("tool concave index = %d, want 1 (inward) from the session preference", ch.ConcaveStrategyIndex())
+	}
+	ch.SetConcaveStrategyIndex(0) // user switches back to outward in the panel
+	s.Click(1, 1)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def := ch.AddedFeature().Definition().(*feature.ChamferFeature).Definition(); def.ConcaveStrategy != types.ChamferConcaveOutward {
+		t.Errorf("committed chamfer concave strategy = %v, want outward (the panel choice)", def.ConcaveStrategy)
 	}
 }
 

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -292,6 +292,7 @@ func editChamferTool(f *feature.PartFeature, c *feature.ChamferFeature) *Chamfer
 	t.seededEdgeKeys = cloneKeys(def.EdgeKeys)
 	t.distance = callOrZeroFn(def.Distance)
 	t.flatCorners = def.FlatCorners
+	t.concaveStrategy = def.ConcaveStrategy
 	t.bindEdit(f, snapshotChamferDef(def))
 	return t
 }

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/param"
 )
 
@@ -77,6 +78,20 @@ func (s *Session) ChamferFlatCorners() bool { return s.chamferFlatCorners }
 
 // SetChamferFlatCorners sets the default corner treatment for new chamfers.
 func (s *Session) SetChamferFlatCorners(flat bool) { s.chamferFlatCorners = flat }
+
+// ChamferConcaveStrategy reports the default concave-edge strategy new Chamfer tools start with:
+// outward fills the inside corner with material (the default), inward cuts a recessed relief.
+func (s *Session) ChamferConcaveStrategy() types.ChamferConcaveStrategy {
+	if !s.chamferConcaveOut {
+		return types.ChamferConcaveInward
+	}
+	return types.ChamferConcaveOutward
+}
+
+// SetChamferConcaveStrategy sets the default concave-edge strategy for new chamfers.
+func (s *Session) SetChamferConcaveStrategy(strategy types.ChamferConcaveStrategy) {
+	s.chamferConcaveOut = strategy != types.ChamferConcaveInward
+}
 
 // Grid returns the session's sketch-grid settings (created on first use).
 func (s *Session) Grid() *GridSettings {

--- a/app/session.go
+++ b/app/session.go
@@ -117,6 +117,7 @@ type Session struct {
 	bodyColorStyles      map[string]string              // body reference key → assigned color-style name (M16-F02 #403/#408)
 	displayOptions       display.Options                // app-level display options that parameterize the display modes (M16-F07 #643)
 	chamferFlatCorners   bool                           // default three-edge-corner treatment for new chamfers
+	chamferConcaveOut    bool                           // default concave-edge strategy for new chamfers (true ⇒ outward fill)
 	paramsDialogOpen     bool                           // the Manage ▸ Parameters dialog is open
 	keymapEditorOpen     bool                           // the Tools ▸ Customize Keyboard panel is open (M05-F17)
 	lightingPanelOpen    bool                           // the View ▸ Lighting settings panel is open
@@ -198,6 +199,7 @@ func newSession(store doc.Store) *Session {
 		lightingStyle:      renderer.LightingThreePoint,
 		lighting:           renderer.SceneLightingFor(renderer.LightingThreePoint),
 		chamferFlatCorners: true, // match Inventor's default flat three-edge-corner blend
+		chamferConcaveOut:  true, // concave edges fill the inside corner by default (outward)
 	}
 	s.seedVisualState()
 	s.graphics.SetBodyResolver(s.resolveOverlayMesh) // M16-F05: surface-overlay body tessellation

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.14.1
+	oblikovati.org/api v0.15.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.14.1
+	oblikovati.org/api v0.15.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -13,9 +13,10 @@ import (
 // (the reference panel schema) shows the picked-edges chip, the setback distance, and
 // the flat-corner toggle, then OK/Cancel.
 var chamferUI = struct {
-	distance    float32
-	flatCorners bool
-	seeded      *app.ChamferTool // the tool the fields were seeded from (nil = none)
+	distance     float32
+	flatCorners  bool
+	concaveIndex int              // concave-edge strategy combo: 0 outward (fill), 1 inward (relief)
+	seeded       *app.ChamferTool // the tool the fields were seeded from (nil = none)
 }{distance: 1, flatCorners: true}
 
 // drawChamferDialog shows the Chamfer property panel while the Chamfer tool is active —
@@ -29,6 +30,7 @@ func drawChamferDialog(s *app.Session) {
 	if chamferUI.seeded != c {
 		chamferUI.distance = float32(c.Distance())
 		chamferUI.flatCorners = c.FlatCorners()
+		chamferUI.concaveIndex = c.ConcaveStrategyIndex()
 		chamferUI.seeded = c
 	}
 	native.SetNextWindowSizeOnce(340, 250)
@@ -51,10 +53,15 @@ func drawChamferDialog(s *app.Session) {
 	native.End()
 }
 
-// drawChamferBehaviorRows renders the setback distance and the flat-corner toggle.
+// drawChamferBehaviorRows renders the setback distance, the concave-edge strategy combo, and the
+// flat-corner toggle.
 func drawChamferBehaviorRows(s *app.Session, c *app.ChamferTool) {
 	propertyFloatRow("Distance", "chamfer-distance", s.LengthUnitName(), &chamferUI.distance)
 	c.SetDistance(float64(chamferUI.distance))
+	if i := propertyComboRow("Concave edge", "chamfer-concave", app.ConcaveStrategyNames(), chamferUI.concaveIndex); i >= 0 {
+		chamferUI.concaveIndex = i
+	}
+	c.SetConcaveStrategyIndex(chamferUI.concaveIndex)
 	propertyRow("")
 	if native.Checkbox("Flat corner (3 edges)", &chamferUI.flatCorners) {
 		c.SetFlatCorners(chamferUI.flatCorners)

--- a/model/feature/assembly_dressup.go
+++ b/model/feature/assembly_dressup.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/param"
@@ -38,7 +39,7 @@ func (f *AssemblyChamferFeature) Kind() string { return kindAssemblyChamfer }
 func (f *AssemblyChamferFeature) Recompute(in Input) (Output, error) {
 	dist := f.distance()
 	bodies, err := dressParticipants(in.Bodies, edgeSuffixKeys(f.edgeSuffixes), func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
-		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, dist, "asmChamfer", f.flatCorners)
+		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, dist, "asmChamfer", f.flatCorners, types.ChamferConcaveOutward)
 		if err != nil {
 			return nil, err
 		}

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -22,18 +22,20 @@ import (
 // (roughly unit) vectors, not a length.
 const singularDetTol = 1e-12
 
-// chamferEdges bevels each selected edge by cutting a triangular wedge tool that runs
-// along it. All cut tools are built from the original body up front (a boolean rebuilds
-// topology with new lineage, so a reference key would not survive the first cut), then
-// each is subtracted in turn. Convex edges only in phase A — a concave edge would add
-// material, which is a follow-up.
+// chamferEdges bevels each selected edge with a triangular wedge tool that runs along it. All
+// tools are built from the original body up front (a boolean rebuilds topology with new lineage,
+// so a reference key would not survive the first boolean), then applied in turn.
 //
-// When flatCorners is set, every vertex where exactly three selected edges meet also gets
-// a tetrahedron cut that trims the pointy three-plane intersection into one flat
-// triangular face — the default corner blend. With it clear the three chamfer planes are
-// left to meet at a point. The blend honours per-face setbacks (d1, d2), so it is correct
-// for asymmetric chamfers too, not only the symmetric equal-distance case.
-func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorners bool) (Output, error) {
+// A CONVEX edge cuts a wedge from the material (the corner bevel). A CONCAVE (internal) edge —
+// where the faces fold over the material — instead either fills the inside corner with a gusset
+// (strategy ChamferConcaveOutward, the default) or cuts a recessed relief groove
+// (ChamferConcaveInward); see concaveChamferWedge.
+//
+// When flatCorners is set, every vertex where exactly three selected CONVEX edges meet also gets
+// a tetrahedron cut that trims the pointy three-plane intersection into one flat triangular face
+// — the default corner blend. With it clear the three chamfer planes are left to meet at a point.
+// The blend honours per-face setbacks (d1, d2), so it is correct for asymmetric chamfers too.
+func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorners bool, strategy types.ChamferConcaveStrategy) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -45,44 +47,100 @@ func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorn
 	if err != nil {
 		return Output{}, err
 	}
-	// The analytic conical chamfer (#127) assumes a SYMMETRIC setback; an asymmetric
-	// (two-distance / distance-angle) chamfer takes the faceted-wedge path. The flat-corner
-	// blend, by contrast, now handles both (chamferByWedges builds it from per-face setbacks).
-	if d1 == d2 {
+	// The analytic conical chamfer (#127) assumes a SYMMETRIC setback on a CONVEX cylinder rim;
+	// an asymmetric chamfer or any concave edge takes the faceted-wedge path (which develops the
+	// per-edge fill/relief). The flat-corner blend handles both symmetric and asymmetric setbacks.
+	if d1 == d2 && allConvex(edges) {
 		// A rim of a simple analytic cylinder gets a TRUE conical chamfer (one geom.Cone face) by
 		// rebuilding the body as a surface of revolution (#127). Anything else falls through.
 		if res, ok := analyticCylinderChamfer(body, edges, d1, feat); ok {
 			return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
 		}
 	}
-	return chamferByWedges(in, body, edges, d1, d2, feat, flatCorners)
+	return chamferByWedges(in, body, edges, d1, d2, feat, flatCorners, strategy)
 }
 
-// chamferByWedges bevels the edges by cutting a wedge tool per edge (plus the flat-corner
-// blend cuts when requested) — the general faceted path used for every non-analytic chamfer.
-func chamferByWedges(in Input, body *topo.Body, edges []*topo.Edge, d1, d2 float64, feat string, flatCorners bool) (Output, error) {
+// allConvex reports whether every edge is a convex dihedral (so the analytic conical fast path,
+// which assumes material is cut away, is valid for the whole selection).
+func allConvex(edges []*topo.Edge) bool {
+	for _, e := range edges {
+		if ops.ClassifyEdgeConvexity(e) == ops.EdgeConcave {
+			return false
+		}
+	}
+	return true
+}
+
+// wedgeOp is one chamfer tool body paired with the boolean that applies it: convex/relief wedges
+// Cut, an outward concave fill Joins.
+type wedgeOp struct {
+	body *topo.Body
+	op   ops.PartFeatureOperation
+}
+
+// chamferByWedges bevels the edges by applying a per-edge wedge tool (plus the flat-corner blend
+// cuts when requested) — the general faceted path used for every non-analytic chamfer.
+func chamferByWedges(in Input, body *topo.Body, edges []*topo.Edge, d1, d2 float64, feat string, flatCorners bool, strategy types.ChamferConcaveStrategy) (Output, error) {
 	// A curved body (analytic cylinder) is re-faceted and the selected edges remapped to its faceted
 	// segments, so the wedge cut works instead of hitting a degenerate closed edge (#129/#127).
 	work, edges := planarizeForEdges(body, edges, feat)
-	tools, err := chamferWedges(edges, d1, d2, feat)
+	tools, convex, err := chamferWedgeTools(edges, d1, d2, strategy, feat)
 	if err != nil {
 		return Output{}, err
 	}
+	// The flat-corner blend is a convex-corner construct; concave edges have no pointy three-plane
+	// tip to trim, so only the convex edges feed it.
 	if flatCorners {
-		tools = append(tools, cornerCutTools(edges, d1, d2, feat)...)
+		for _, t := range cornerCutTools(convex, d1, d2, feat) {
+			tools = append(tools, wedgeOp{body: t, op: ops.Cut})
+		}
 	}
-	result, err := cutAll(work, tools)
+	result, err := applyChamferTools(work, tools)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
 }
 
-// cutAll subtracts each tool from work in turn, returning the carved body.
-func cutAll(work *topo.Body, tools []*topo.Body) (*topo.Body, error) {
+// chamferWedgeTools builds the per-edge wedge for each resolved edge, classifying it convex or
+// concave, and returns the tools-with-operation plus the convex-edge subset (for corner blending).
+func chamferWedgeTools(edges []*topo.Edge, d1, d2 float64, strategy types.ChamferConcaveStrategy, feat string) ([]wedgeOp, []*topo.Edge, error) {
+	tools := make([]wedgeOp, 0, len(edges))
+	convex := make([]*topo.Edge, 0, len(edges))
+	for i, edge := range edges {
+		name := fmt.Sprintf("%s/w%d", feat, i)
+		if ops.ClassifyEdgeConvexity(edge) == ops.EdgeConcave {
+			tool, err := concaveChamferWedge(edge, d1, d2, strategy, name)
+			if err != nil {
+				return nil, nil, err
+			}
+			tools = append(tools, wedgeOp{body: tool, op: concaveOp(strategy)})
+			continue
+		}
+		tool, err := chamferWedge(edge, d1, d2, name)
+		if err != nil {
+			return nil, nil, err
+		}
+		tools = append(tools, wedgeOp{body: tool, op: ops.Cut})
+		convex = append(convex, edge)
+	}
+	return tools, convex, nil
+}
+
+// concaveOp is the boolean a concave-edge wedge applies: an inward relief Cuts material, the
+// default outward fill Joins it.
+func concaveOp(strategy types.ChamferConcaveStrategy) ops.PartFeatureOperation {
+	if strategy == types.ChamferConcaveInward {
+		return ops.Cut
+	}
+	return ops.Join
+}
+
+// applyChamferTools applies each wedge to work in turn (Cut or Join), returning the body.
+func applyChamferTools(work *topo.Body, tools []wedgeOp) (*topo.Body, error) {
 	result := work
-	for _, tool := range tools {
-		r, err := ops.Boolean(ops.Cut, result, tool)
+	for _, t := range tools {
+		r, err := ops.Boolean(t.op, result, t.body)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +183,8 @@ func chamferSetbacks(def *ChamferDefinition) (d1, d2 float64, err error) {
 	return d1, d2, nil
 }
 
-// chamferWedges builds the bevel wedge for each resolved edge (setbacks d1, d2).
+// chamferWedges builds a plain CUT wedge for each edge (setbacks d1, d2) — the convex-only path
+// the sheet-metal corner / corner-seam reliefs reuse (they never fill or relieve a concave edge).
 func chamferWedges(edges []*topo.Edge, d1, d2 float64, feat string) ([]*topo.Body, error) {
 	tools := make([]*topo.Body, 0, len(edges))
 	for i, edge := range edges {
@@ -138,6 +197,20 @@ func chamferWedges(edges []*topo.Edge, d1, d2 float64, feat string) ([]*topo.Bod
 	return tools, nil
 }
 
+// cutAll subtracts each tool from work in turn, returning the carved body. Shared with the
+// sheet-metal corner reliefs, which only ever cut.
+func cutAll(work *topo.Body, tools []*topo.Body) (*topo.Body, error) {
+	result := work
+	for _, tool := range tools {
+		r, err := ops.Boolean(ops.Cut, result, tool)
+		if err != nil {
+			return nil, err
+		}
+		result = r
+	}
+	return result, nil
+}
+
 // chamferOverhang extends the wedge past each end of the edge. The overhang must reach past the
 // lip remnant that the per-edge bevel otherwise leaves where the edge runs into an adjacent face
 // (so the boolean consumes it and the bevel meets that face FLUSH); the lip sits at most about
@@ -147,18 +220,42 @@ func chamferOverhang(d1, d2 float64) float64 {
 	return 2 * stdmath.Max(d1, d2)
 }
 
-// chamferWedge builds the triangular prism removed to bevel an edge: a triangle cross-section
-// with leg d1 along the first adjacent face's interior and d2 along the second's, swept along
-// the edge (with a small overhang past each end so the boolean is clean). Equal d1==d2 is the
-// symmetric chamfer; d1≠d2 is the asymmetric two-distance / distance-angle chamfer.
+// wedgePrism builds the triangular prism for an edge from the section frame: a triangle with leg
+// s1 along the first adjacent face's interior direction and s2 along the second's, swept along
+// the edge with the given overhang past each end. A NEGATIVE leg points the triangle to the
+// material side of the face (used by the concave relief cut); a point reflection preserves the
+// 2D winding, so buildPrism orients either form into a valid solid the boolean can apply.
+func wedgePrism(fr edgeFrame, s1, s2, overhang float64, feat string) *topo.Body {
+	poly := []math.Point2{{X: 0, Y: 0}, fr.proj(fr.t1.Scale(s1)), fr.proj(fr.t2.Scale(s2))}
+	return buildPrism(poly, fr.plane, span{near: -overhang, far: fr.length + overhang}, 0, feat)
+}
+
+// chamferWedge builds the triangular prism CUT to bevel a convex edge: legs d1, d2 along the two
+// adjacent faces' interiors, with an overhang past each end so the boolean meets the neighbours
+// flush. Equal d1==d2 is the symmetric chamfer; d1≠d2 is the asymmetric two-distance / angle one.
 func chamferWedge(edge *topo.Edge, d1, d2 float64, feat string) (*topo.Body, error) {
 	fr, err := edgeCornerFrame(edge, "chamfer")
 	if err != nil {
 		return nil, err
 	}
-	poly := []math.Point2{{X: 0, Y: 0}, fr.proj(fr.t1.Scale(d1)), fr.proj(fr.t2.Scale(d2))}
-	oh := chamferOverhang(d1, d2)
-	return buildPrism(poly, fr.plane, span{near: -oh, far: fr.length + oh}, 0, feat), nil
+	return wedgePrism(fr, d1, d2, chamferOverhang(d1, d2), feat), nil
+}
+
+// concaveChamferWedge builds the wedge for a CONCAVE (internal) edge. The two faces' interior
+// directions point into the open notch, so the wedge {edge, d1·t1, d2·t2} lies in the void:
+//   - outward (default): JOIN that wedge to fill the inside corner with a 45° gusset. No overhang
+//     — an overhanging fill would protrude past the edge's end faces (it adds, not removes).
+//   - inward: reflect the legs to the material side (−d1·t1, −d2·t2) and CUT, gouging a recessed
+//     relief groove out of the corner; an overhang keeps that cut flush at the ends.
+func concaveChamferWedge(edge *topo.Edge, d1, d2 float64, strategy types.ChamferConcaveStrategy, feat string) (*topo.Body, error) {
+	fr, err := edgeCornerFrame(edge, "chamfer")
+	if err != nil {
+		return nil, err
+	}
+	if strategy == types.ChamferConcaveInward {
+		return wedgePrism(fr, -d1, -d2, chamferOverhang(d1, d2), feat), nil
+	}
+	return wedgePrism(fr, d1, d2, 0, feat), nil
 }
 
 // edgeFrame is the resolved corner-cut frame at an edge (see edgeCornerFrame).

--- a/model/feature/chamfer_concave_test.go
+++ b/model/feature/chamfer_concave_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// lExtrude builds an L-shaped prism — a 2×2 square with its +X+Y unit square removed — extruded 1
+// unit in Z, and returns it with the reference key of the single CONCAVE (reflex) vertical edge at
+// (1,1). Its volume is 3 (area 3 × height 1); the concave edge's notch opens toward +X,+Y, so an
+// outward chamfer fills that quadrant and an inward chamfer relieves the solid behind it.
+func lExtrude(t *testing.T) (*topo.Body, []byte) {
+	t.Helper()
+	poly := []math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 1}, {X: 1, Y: 1}, {X: 1, Y: 2}, {X: 0, Y: 2}}
+	body := buildPrism(poly, sketch.XYPlane(), span{near: 0, far: 1}, 0, "L")
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		at11 := func(p math.Point3) bool { return stdmath.Abs(p.X-1) < 1e-9 && stdmath.Abs(p.Y-1) < 1e-9 }
+		if at11(a) && at11(b) && ops.ClassifyEdgeConvexity(e) == ops.EdgeConcave {
+			return body, e.ReferenceKey()
+		}
+	}
+	t.Fatal("no concave vertical edge at (1,1)")
+	return nil, nil
+}
+
+// chamferedConcave runs an equal-distance chamfer on the L's concave edge with the given strategy
+// and returns the resulting body, failing on a sick feature or an invalid solid.
+func chamferedConcave(t *testing.T, d float64, strategy types.ChamferConcaveStrategy) *topo.Body {
+	t.Helper()
+	body, edge := lExtrude(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(body)
+	ch := NewDressUpFeatures(fs).AddChamferConcave([][]byte{edge}, func() float64 { return d }, true, strategy)
+	fs.Recompute()
+	if !ch.Health().OK() {
+		t.Fatalf("concave chamfer (%v) sick: %+v", strategy, ch.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("concave chamfer (%v) not a valid solid: %+v", strategy, r)
+	}
+	return res
+}
+
+// TestChamferConcaveOutwardFills is the regression for the inverted-chamfer bug: an internal
+// (concave) edge chamfered outward must FILL the inside corner with a 45° gusset, adding ½·d²·L of
+// material — not cut a malformed sliver as the convex-only path did.
+func TestChamferConcaveOutwardFills(t *testing.T) {
+	const d = 0.4
+	res := chamferedConcave(t, d, types.ChamferConcaveOutward)
+	want := 3 + 0.5*d*d // L volume 3 + triangular fill ½·d·d·length(1)
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, want) > 1e-6 {
+		t.Errorf("outward concave chamfer volume = %g, want %g (notch should be filled)", got, want)
+	}
+}
+
+// TestChamferConcaveInwardRelieves checks the inward strategy cuts a recessed relief groove out of
+// the corner instead, removing ½·d²·L of material.
+func TestChamferConcaveInwardRelieves(t *testing.T) {
+	const d = 0.4
+	res := chamferedConcave(t, d, types.ChamferConcaveInward)
+	want := 3 - 0.5*d*d // L volume 3 − triangular relief ½·d·d·length(1)
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, want) > 1e-6 {
+		t.Errorf("inward concave chamfer volume = %g, want %g (corner should be relieved)", got, want)
+	}
+}
+
+// TestChamferConcaveOutwardIsDefault confirms the zero-value strategy (AddChamferCorners) fills
+// outward — so an existing/default chamfer of a concave edge adds material, the chosen default.
+func TestChamferConcaveOutwardIsDefault(t *testing.T) {
+	const d = 0.4
+	body, edge := lExtrude(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(body)
+	ch := NewDressUpFeatures(fs).AddChamferCorners([][]byte{edge}, func() float64 { return d }, true)
+	fs.Recompute()
+	if !ch.Health().OK() {
+		t.Fatalf("default concave chamfer sick: %+v", ch.Health())
+	}
+	res := fs.Result()[0]
+	want := 3 + 0.5*d*d
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; relErr(got, want) > 1e-6 {
+		t.Errorf("default concave chamfer volume = %g, want %g (default must fill outward)", got, want)
+	}
+}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -75,18 +75,24 @@ func (f *FilletFeature) Recompute(in Input) (Output, error) {
 // ChamferType aliases the public chamfer-mode discriminator (ADR-0018).
 type ChamferType = types.ChamferType
 
+// ChamferConcaveStrategy aliases the public concave-edge strategy discriminator (ADR-0018).
+type ChamferConcaveStrategy = types.ChamferConcaveStrategy
+
 // ChamferDefinition bevels selected edges. Type (M20-F03) selects the setback mode: equal
 // Distance on both faces (the default / zero value), two independent distances (Distance +
 // Distance2, asymmetric), or a Distance plus the chamfer-face Angle. FlatCorners blends a
 // vertex where three selected edges meet into a flat triangular face — only for the
 // equal-distance mode; an asymmetric chamfer leaves the corner planes to meet at a point.
+// ConcaveStrategy applies only to CONCAVE (internal) edges: fill the inside corner with material
+// (outward, the zero-value default) or cut a recessed relief groove (inward).
 type ChamferDefinition struct {
-	EdgeKeys    [][]byte
-	Distance    func() float64
-	Distance2   func() float64 // twoDistances: setback on the second face
-	Angle       func() float64 // distanceAndAngle: chamfer-face angle (radians)
-	Type        ChamferType    // zero value ⇒ equal-distance
-	FlatCorners bool
+	EdgeKeys        [][]byte
+	Distance        func() float64
+	Distance2       func() float64 // twoDistances: setback on the second face
+	Angle           func() float64 // distanceAndAngle: chamfer-face angle (radians)
+	Type            ChamferType    // zero value ⇒ equal-distance
+	FlatCorners     bool
+	ConcaveStrategy ChamferConcaveStrategy // zero value ⇒ outward (fill the inside corner)
 }
 
 // ChamferFeature bevels selected edges (equal-distance, two-distance, or distance-and-angle).
@@ -107,7 +113,7 @@ func (c *ChamferFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return chamferEdges(in, c.def.EdgeKeys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners)
+	return chamferEdges(in, c.def.EdgeKeys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners, c.def.ConcaveStrategy)
 }
 
 // ShellDefinition hollows a body, removing the selected faces, to a wall thickness.
@@ -289,8 +295,16 @@ func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64)
 
 // AddChamferCorners bevels the given edges by distance; flatCorners selects whether a
 // three-edge corner is blended into a flat triangular face (true) or left pointy (false).
+// Concave edges fill outward (the default); use [AddChamferConcave] to relieve them inward.
 func (c *DressUpFeatures) AddChamferCorners(edgeKeys [][]byte, distance func() float64, flatCorners bool) *PartFeature {
 	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners})
+}
+
+// AddChamferConcave bevels the given edges by distance with an explicit concave-edge strategy:
+// outward fills the inside corner with material (the default), inward cuts a recessed relief
+// groove. Convex edges are unaffected by the strategy. Three-edge corners blend flat.
+func (c *DressUpFeatures) AddChamferConcave(edgeKeys [][]byte, distance func() float64, flatCorners bool, strategy ChamferConcaveStrategy) *PartFeature {
+	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners, ConcaveStrategy: strategy})
 }
 
 // AddChamferTwoDistances bevels the given edges with independent setbacks on the two adjacent


### PR DESCRIPTION
## What

Chamfering a **concave (internal) edge** now does the right thing, with a user-selectable strategy:

- **Outward (default):** fills the inside corner with a 45° gusset (Boolean join of a notch-fill wedge).
- **Inward:** cuts a recessed relief groove (Boolean cut on the material side).

Convex edges cut their corner exactly as before — the strategy only affects concave edges.

## Why

The chamfer ran a convex-only path: it built a wedge from the faces' interior directions and always *cut* it. On a concave edge that wedge lies in the open notch, so the cut removed nothing useful and left a malformed sliver (the reported "inverted chamfer" bug). Edges are now classified with `ops.ClassifyEdgeConvexity`, and concave edges fill or relieve instead.

## How it threads through

- `ChamferDefinition.ConcaveStrategy` (+ `AddChamferConcave`), kernel routing in `model/feature/chamfer.go`.
- API enum `types.ChamferConcaveStrategy` (Oblikovati.API#130, released v0.15.0 — go.mod bumped here).
- `opregistry` chamfer `concaveStrategy` arg; Chamfer tool field + session default; head dialog "Concave edge" combo.

## Verification

- Regression `model/feature/chamfer_concave_test.go`: an L-extrude's concave edge filled outward adds exactly **+½·d²·L**; relieved inward removes it; both stay valid solids.
- Live over the MCP bridge: a single-body L-prism (vol 24) chamfered outward on its concave edge → **24.36** (the +0.36 fill), feature healthy, inside corner shows a clean flat fillet face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)