### PR TITLE
feat(fillet): fill concave (internal) edges with an exact rolling-ball cylinder

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -131,7 +131,10 @@ func TestDressUpOnSolid(t *testing.T) {
 		args     map[string]any
 	}{
 		{"fillet flat", "fillet", map[string]any{"radius": "1 mm"}},
+		{"fillet outward", "fillet", map[string]any{"radius": "1 mm", "concaveStrategy": "outward"}},
+		{"fillet inward", "fillet", map[string]any{"radius": "1 mm", "concaveStrategy": "inward"}},
 		{"fillet set const", "fillet", map[string]any{"_set": "radius"}},
+		{"fillet set concave", "fillet", map[string]any{"_set": "radius", "concaveStrategy": "outward"}},
 		{"fillet set variable", "fillet", map[string]any{"_set": "var"}},
 		{"chamfer distance", "chamfer", map[string]any{"distance": "1 mm"}},
 		{"chamfer two distances", "chamfer", map[string]any{"distance": "1 mm", "distance2": "2 mm", "chamferType": "twoDistances"}},
@@ -144,7 +147,7 @@ func TestDressUpOnSolid(t *testing.T) {
 			args := c.args
 			switch args["_set"] {
 			case "radius":
-				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "radius": "1 mm"}}}
+				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "radius": "1 mm"}}, "concaveStrategy": c.args["concaveStrategy"]}
 			case "var":
 				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "startRadius": "1 mm", "endRadius": "2 mm"}}}
 			default:
@@ -179,6 +182,19 @@ func TestDressUpRejectsEmptyRefs(t *testing.T) {
 		s, _, _ := extrudedSolid(t)
 		if _, err := apply(t, s, op, `{"radius":"1 mm","distance":"1 mm","thickness":"1 mm","angle":"3 deg","width":"1 mm","height":"1 mm"}`); err == nil {
 			t.Errorf("%s with no refs should error", op)
+		}
+	}
+}
+
+// TestDressUpRejectsBadConcaveStrategy: fillet and chamfer reject an unknown concaveStrategy.
+func TestDressUpRejectsBadConcaveStrategy(t *testing.T) {
+	for _, c := range []struct{ op, args string }{
+		{"fillet", `{"edgeRefs":["x"],"radius":"1 mm","concaveStrategy":"sideways"}`},
+		{"chamfer", `{"edgeRefs":["x"],"distance":"1 mm","concaveStrategy":"sideways"}`},
+	} {
+		s, _, _ := extrudedSolid(t)
+		if _, err := apply(t, s, c.op, c.args); err == nil {
+			t.Errorf("%s with an unknown concaveStrategy should error", c.op)
 		}
 	}
 }

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -54,7 +54,8 @@ const filletSchema = `{
       "startRadius": {"type": "string", "description": "Variable set: radius at the edge's start vertex (the set holds exactly one edge)."},
       "endRadius": {"type": "string", "description": "Variable set: radius at the edge's end vertex."}
     }, "required": ["edgeRefs"]}},
-    "cornerType": {"type": "string", "enum": ["miter", "setback", "round"], "default": "miter", "description": "How a vertex where two filleted edges meet (third edge sharp) is treated: miter (exact crease), round (fillets the third edge into a smooth sphere). setback is reserved."}
+    "cornerType": {"type": "string", "enum": ["miter", "setback", "round"], "default": "miter", "description": "How a vertex where two filleted edges meet (third edge sharp) is treated: miter (exact crease), round (fillets the third edge into a smooth sphere). setback is reserved."},
+    "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with an exact rolling-ball cylinder (default). inward rounds a recess into the corner and is only valid where the faces extend into the material (e.g. a pocket). Convex edges ignore this."}
   }
 }`
 
@@ -92,9 +93,19 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(in.EdgeSets) > 0 {
-		return applyFilletSets(part, in.EdgeSets, corner)
+	cs, err := filletConcaveStrategyOf(in.ConcaveStrategy)
+	if err != nil {
+		return nil, err
 	}
+	if len(in.EdgeSets) > 0 {
+		return applyFilletSets(part, in.EdgeSets, corner, cs)
+	}
+	return applyFilletFlat(part, in, corner, cs)
+}
+
+// applyFilletFlat builds the flat (edgeRefs + single radius) fillet with the chosen corner
+// treatment and concave-edge strategy.
+func applyFilletFlat(part *compdef.PartComponentDefinition, in edgeDressArgs, corner types.FilletCornerType, cs types.FilletConcaveStrategy) (json.RawMessage, error) {
 	if len(in.EdgeRefs) == 0 {
 		return nil, errors.New("fillet: edgeRefs is empty (give edgeRefs+radius or edgeSets)")
 	}
@@ -103,16 +114,32 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 		return nil, err
 	}
 	pf := feature.NewDressUpFeatures(part.Features()).AddFilletCorner(refKeys(in.EdgeRefs), r, corner)
+	pf.Definition().(*feature.FilletFeature).Definition().ConcaveStrategy = cs
 	return recomputeResult(part, pf)
 }
 
-// applyFilletSets decodes the edge-set form and adds the fillet with the chosen corner treatment.
-func applyFilletSets(part *compdef.PartComponentDefinition, args []filletSetArgs, corner types.FilletCornerType) (json.RawMessage, error) {
+// applyFilletSets decodes the edge-set form and adds the fillet with the chosen corner treatment
+// and concave-edge strategy.
+func applyFilletSets(part *compdef.PartComponentDefinition, args []filletSetArgs, corner types.FilletCornerType, cs types.FilletConcaveStrategy) (json.RawMessage, error) {
 	sets, err := filletSetsFromArgs(part, args)
 	if err != nil {
 		return nil, err
 	}
-	return recomputeResult(part, feature.NewDressUpFeatures(part.Features()).AddFilletSetsCorner(sets, corner))
+	pf := feature.NewDressUpFeatures(part.Features()).AddFilletSetsCorner(sets, corner)
+	pf.Definition().(*feature.FilletFeature).Definition().ConcaveStrategy = cs
+	return recomputeResult(part, pf)
+}
+
+// filletConcaveStrategyOf resolves the optional concaveStrategy wire spelling (empty ⇒ outward).
+func filletConcaveStrategyOf(spelling string) (types.FilletConcaveStrategy, error) {
+	if spelling == "" {
+		return types.FilletConcaveOutward, nil
+	}
+	v, ok := types.ParseFilletConcaveStrategy(spelling)
+	if !ok {
+		return 0, fmt.Errorf("fillet: unknown concaveStrategy %q (want outward or inward)", spelling)
+	}
+	return v, nil
 }
 
 // filletCornerOf resolves the optional cornerType wire spelling (empty ⇒ miter), erroring on an

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -257,6 +257,7 @@ func editFilletTool(f *feature.PartFeature, fl *feature.FilletFeature) *FilletTo
 	}
 	t := NewFilletTool()
 	t.cornerType = def.CornerType
+	t.concaveStrategy = def.ConcaveStrategy
 	if len(def.EdgeSets) == 1 {
 		seedFilletSet(t, def.EdgeSets[0])
 	} else {

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -20,12 +20,37 @@ type FilletTool struct {
 	variable        bool // variable mode: each edge blends startRadius → endRadius (#323)
 	startRadius     float64
 	endRadius       float64
-	cornerType      feature.FilletCornerType // shared-corner treatment (miter default)
+	cornerType      feature.FilletCornerType    // shared-corner treatment (miter default)
+	concaveStrategy types.FilletConcaveStrategy // concave edges: outward fill (default) or inward recess
 	added           *feature.PartFeature
 }
 
-// NewFilletTool returns a fillet tool with a default 1-unit radius and mitered corners.
-func NewFilletTool() *FilletTool { return &FilletTool{radius: 1, startRadius: 1, endRadius: 1} }
+// NewFilletTool returns a fillet tool with a default 1-unit radius, mitered corners, and outward
+// concave fill.
+func NewFilletTool() *FilletTool {
+	return &FilletTool{radius: 1, startRadius: 1, endRadius: 1, concaveStrategy: types.FilletConcaveOutward}
+}
+
+// filletConcaveOrder maps the UI option index to the concave-strategy enum (0 outward, 1 inward).
+var filletConcaveOrder = []types.FilletConcaveStrategy{types.FilletConcaveOutward, types.FilletConcaveInward}
+
+// FilletConcaveOptions are the concave-edge strategy labels for the property panel, in index order.
+func FilletConcaveOptions() []string { return []string{"Outward (fill)", "Inward (recess)"} }
+
+// ConcaveStrategyIndex returns the selected concave strategy as a [FilletConcaveOptions] index.
+func (t *FilletTool) ConcaveStrategyIndex() int {
+	if t.concaveStrategy == types.FilletConcaveInward {
+		return 1
+	}
+	return 0
+}
+
+// SetConcaveStrategyIndex selects the concave strategy from a [FilletConcaveOptions] index.
+func (t *FilletTool) SetConcaveStrategyIndex(i int) {
+	if i >= 0 && i < len(filletConcaveOrder) {
+		t.concaveStrategy = filletConcaveOrder[i]
+	}
+}
 
 // filletCornerOrder maps the UI option index to the corner-type enum.
 var filletCornerOrder = []feature.FilletCornerType{
@@ -175,11 +200,15 @@ func (t *FilletTool) Cancel(s *Session) {
 // addFillet appends the picked edges in the active mode: the legacy constant-radius
 // form, or one variable set per edge.
 func (t *FilletTool) addFillet(dress *feature.DressUpFeatures) *feature.PartFeature {
+	var pf *feature.PartFeature
 	if t.variable {
-		return dress.AddFilletSetsCorner(t.variableSets(t.selectedEdgeKeys()), t.cornerType)
+		pf = dress.AddFilletSetsCorner(t.variableSets(t.selectedEdgeKeys()), t.cornerType)
+	} else {
+		r := t.radius
+		pf = dress.AddFilletCorner(t.selectedEdgeKeys(), func() float64 { return r }, t.cornerType)
 	}
-	r := t.radius
-	return dress.AddFilletCorner(t.selectedEdgeKeys(), func() float64 { return r }, t.cornerType)
+	pf.Definition().(*feature.FilletFeature).Definition().ConcaveStrategy = t.concaveStrategy
+	return pf
 }
 
 // commitEdit writes the panel state back into the committed fillet's definition: the
@@ -188,6 +217,7 @@ func (t *FilletTool) addFillet(dress *feature.DressUpFeatures) *feature.PartFeat
 func (t *FilletTool) commitEdit(s *Session) error {
 	def := t.target.Definition().(*feature.FilletFeature).Definition()
 	def.CornerType = t.cornerType
+	def.ConcaveStrategy = t.concaveStrategy
 	if t.variable {
 		def.EdgeKeys, def.Radius, def.EdgeSets = nil, nil, t.variableSets(t.selectedEdgeKeys())
 		return commitFeatureEdit(s, t.target)

--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -6,9 +6,31 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/feature"
 )
+
+// TestFilletToolConcaveStrategy checks the tool defaults to outward fill and carries the chosen
+// concave strategy (via the combo index) into the committed fillet's definition.
+func TestFilletToolConcaveStrategy(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	f := NewFilletTool()
+	s.StartTool(f)
+	if f.ConcaveStrategyIndex() != 0 {
+		t.Errorf("new fillet tool concave index = %d, want 0 (outward fill default)", f.ConcaveStrategyIndex())
+	}
+	s.Click(1, 1)
+	f.SetRadius(0.3)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if def := f.AddedFeature().Definition().(*feature.FilletFeature).Definition(); def.ConcaveStrategy != types.FilletConcaveOutward {
+		t.Errorf("committed fillet concave strategy = %v, want outward (the default)", def.ConcaveStrategy)
+	}
+}
 
 // TestFilletToolEndToEnd drives the Fillet UI: start the tool, click a vertical edge of a
 // 2×2×2 block, set the radius, OK — and asserts a valid solid with a cylinder face and the

--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -22,6 +22,14 @@ func TestFilletToolConcaveStrategy(t *testing.T) {
 	if f.ConcaveStrategyIndex() != 0 {
 		t.Errorf("new fillet tool concave index = %d, want 0 (outward fill default)", f.ConcaveStrategyIndex())
 	}
+	if len(FilletConcaveOptions()) != 2 {
+		t.Errorf("FilletConcaveOptions = %v, want 2 labels", FilletConcaveOptions())
+	}
+	f.SetConcaveStrategyIndex(1) // inward
+	if f.ConcaveStrategyIndex() != 1 {
+		t.Errorf("after SetConcaveStrategyIndex(1), index = %d, want 1 (inward)", f.ConcaveStrategyIndex())
+	}
+	f.SetConcaveStrategyIndex(0) // back to the outward default for the commit below
 	s.Click(1, 1)
 	f.SetRadius(0.3)
 	if err := s.OK(); err != nil {

--- a/head/internal-fillet.opd
+++ b/head/internal-fillet.opd
@@ -1,0 +1,131 @@
+schemaVersion: 2
+documentType: 1
+displayName: internal-fillet
+identity:
+    internalName: 1294770b-490b-4986-9d23-2115ab88d16e
+    revisionId: 9fb6fac4-9285-4c40-9d2e-90c926ceecce
+    databaseRevisionId: e3bb7310-9639-4227-be32-c86a1701bab6
+    saveCounter: 5
+    versionCreated: dev
+    versionSaved: dev
+    modelDigest: 23ba1e01d841b906d8120817fb0a60d1efdeb31f3af9f37fe9fe5b857fb896bc
+model:
+    units:
+        angle: deg
+        area: mm^2
+        length: mm
+        mass: kg
+        time: s
+        volume: mm^3
+    sketches:
+        - name: Sketch1
+          hidden: true
+          seq: 18
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 0
+                - 1
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1
+          points:
+            - id: 82
+              x: 0
+              "y": 0
+          entities:
+            - id: 83
+              kind: circle
+              points:
+                - 82
+              radius: 3.9136705118148165
+        - name: Sketch2
+          seq: 20
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 0
+                - 1
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1
+          points:
+            - id: 85
+              x: 2
+              "y": 2
+              standalone: true
+            - id: 86
+              x: -2.2772288999872448
+              "y": 2
+              standalone: true
+            - id: 87
+              x: -2.2772288999872448
+              "y": -1.267228706803533
+              standalone: true
+            - id: 88
+              x: 2
+              "y": -1.267228706803533
+              standalone: true
+          entities:
+            - id: 89
+              kind: line
+              points:
+                - 85
+                - 86
+            - id: 90
+              kind: line
+              points:
+                - 86
+                - 87
+            - id: 91
+              kind: line
+              points:
+                - 87
+                - 88
+            - id: 92
+              kind: line
+              points:
+                - 88
+                - 85
+    features:
+        - kind: extrude
+          name: Extrusion1
+          seq: 19
+          extrude:
+            sketch: 0
+            profiles:
+                - 0
+            operation: newBody
+            extent: distance
+            direction: positive
+            distance: 1
+        - kind: extrude
+          name: Extrusion2
+          seq: 21
+          extrude:
+            sketch: 1
+            profiles:
+                - 0
+            operation: newBody
+            extent: distance
+            direction: negative
+            distance: 1
+        - kind: fillet
+          name: fillet
+          seq: 23
+          fillet:
+            edges:
+                - AkV4dHJ1c2lvbjI6dG9wLWVkZ2UjMA==
+                - AkV4dHJ1c2lvbjI6dG9wLWVkZ2UjMw==
+            value: 0.5
+            cornerType: 200003

--- a/head/inverted-chamfer.opd
+++ b/head/inverted-chamfer.opd
@@ -1,0 +1,132 @@
+schemaVersion: 2
+documentType: 1
+displayName: inverted-chamfer
+identity:
+    internalName: 1294770b-490b-4986-9d23-2115ab88d16e
+    revisionId: d0da8d39-f9d2-49bb-bcf0-a6d7cce047ff
+    databaseRevisionId: aa9e8997-38ba-4bde-9f5e-e390551701e7
+    saveCounter: 2
+    versionCreated: dev
+    versionSaved: dev
+    modelDigest: c3551e5f7ce3695e68bf7f01ebed06ba5e82b5f80d7876eff1846cd34d7d2575
+model:
+    units:
+        angle: deg
+        area: mm^2
+        length: mm
+        mass: kg
+        time: s
+        volume: mm^3
+    sketches:
+        - name: Sketch1
+          hidden: true
+          seq: 18
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 0
+                - 1
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1
+          points:
+            - id: 82
+              x: 0
+              "y": 0
+          entities:
+            - id: 83
+              kind: circle
+              points:
+                - 82
+              radius: 3.9136705118148165
+        - name: Sketch2
+          seq: 20
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 0
+                - 1
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1
+          points:
+            - id: 85
+              x: 2
+              "y": 2
+              standalone: true
+            - id: 86
+              x: -2.2772288999872448
+              "y": 2
+              standalone: true
+            - id: 87
+              x: -2.2772288999872448
+              "y": -1.267228706803533
+              standalone: true
+            - id: 88
+              x: 2
+              "y": -1.267228706803533
+              standalone: true
+          entities:
+            - id: 89
+              kind: line
+              points:
+                - 85
+                - 86
+            - id: 90
+              kind: line
+              points:
+                - 86
+                - 87
+            - id: 91
+              kind: line
+              points:
+                - 87
+                - 88
+            - id: 92
+              kind: line
+              points:
+                - 88
+                - 85
+    features:
+        - kind: extrude
+          name: Extrusion1
+          seq: 19
+          extrude:
+            sketch: 0
+            profiles:
+                - 0
+            operation: newBody
+            extent: distance
+            direction: positive
+            distance: 1
+        - kind: extrude
+          name: Extrusion2
+          seq: 21
+          extrude:
+            sketch: 1
+            profiles:
+                - 0
+            operation: newBody
+            extent: distance
+            direction: negative
+            distance: 1
+        - kind: chamfer
+          name: Chamfer1
+          seq: 22
+          chamfer:
+            edges:
+                - AkV4dHJ1c2lvbjI6dG9wLWVkZ2UjMA==
+                - AkV4dHJ1c2lvbjI6dG9wLWVkZ2UjMw==
+            value: 0.5
+            flatCorners: true
+            chamferType: 26881

--- a/head/inverted-fillet.opd
+++ b/head/inverted-fillet.opd
@@ -1,0 +1,132 @@
+schemaVersion: 2
+documentType: 1
+displayName: inverted-fillet
+identity:
+    internalName: 1294770b-490b-4986-9d23-2115ab88d16e
+    revisionId: 3a75d05a-ce3d-41bc-8f20-da3364d30774
+    databaseRevisionId: aa9e8997-38ba-4bde-9f5e-e390551701e7
+    saveCounter: 1
+    versionCreated: dev
+    versionSaved: dev
+    modelDigest: c3551e5f7ce3695e68bf7f01ebed06ba5e82b5f80d7876eff1846cd34d7d2575
+model:
+    units:
+        angle: deg
+        area: mm^2
+        length: mm
+        mass: kg
+        time: s
+        volume: mm^3
+    sketches:
+        - name: Sketch1
+          hidden: true
+          seq: 18
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 0
+                - 1
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1
+          points:
+            - id: 82
+              x: 0
+              "y": 0
+          entities:
+            - id: 83
+              kind: circle
+              points:
+                - 82
+              radius: 3.9136705118148165
+        - name: Sketch2
+          seq: 20
+          plane:
+            origin:
+                - 0
+                - 0
+                - 0
+            xAxis:
+                - 0
+                - 1
+                - 0
+            yAxis:
+                - 0
+                - 0
+                - 1
+          points:
+            - id: 85
+              x: 2
+              "y": 2
+              standalone: true
+            - id: 86
+              x: -2.2772288999872448
+              "y": 2
+              standalone: true
+            - id: 87
+              x: -2.2772288999872448
+              "y": -1.267228706803533
+              standalone: true
+            - id: 88
+              x: 2
+              "y": -1.267228706803533
+              standalone: true
+          entities:
+            - id: 89
+              kind: line
+              points:
+                - 85
+                - 86
+            - id: 90
+              kind: line
+              points:
+                - 86
+                - 87
+            - id: 91
+              kind: line
+              points:
+                - 87
+                - 88
+            - id: 92
+              kind: line
+              points:
+                - 88
+                - 85
+    features:
+        - kind: extrude
+          name: Extrusion1
+          seq: 19
+          extrude:
+            sketch: 0
+            profiles:
+                - 0
+            operation: newBody
+            extent: distance
+            direction: positive
+            distance: 1
+        - kind: extrude
+          name: Extrusion2
+          seq: 21
+          extrude:
+            sketch: 1
+            profiles:
+                - 0
+            operation: newBody
+            extent: distance
+            direction: negative
+            distance: 1
+        - kind: chamfer
+          name: Chamfer1
+          seq: 22
+          chamfer:
+            edges:
+                - AkV4dHJ1c2lvbjI6dG9wLWVkZ2UjMA==
+                - AkV4dHJ1c2lvbjI6dG9wLWVkZ2UjMw==
+            value: 0.5
+            flatCorners: true
+            chamferType: 26881

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -46,6 +46,9 @@ func drawFilletDialog(s *app.Session) {
 			if i := propertyComboRow("Corner", "fillet-corner", app.FilletCornerOptions(), f.CornerTypeIndex()); i >= 0 {
 				f.SetCornerTypeIndex(i)
 			}
+			if i := propertyComboRow("Concave edge", "fillet-concave", app.FilletConcaveOptions(), f.ConcaveStrategyIndex()); i >= 0 {
+				f.SetConcaveStrategyIndex(i)
+			}
 		}
 		native.Separator()
 		drawCommitCancelButtons(s, f.CanCommit())

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -41,7 +41,7 @@ func FilletEdges(body *topo.Body, edgeKeys [][]byte, r float64) (*topo.Body, err
 // the edge line, so each strip face is EXACTLY planar — the only approximation is the end
 // arcs as chords, the same density convention as a hole's faceted cylinder.
 func FilletEdgesVarying(body *topo.Body, picks []EdgeFilletRadii) (*topo.Body, error) {
-	return FilletEdgesCorner(body, picks, CornerMiter)
+	return FilletEdgesCorner(body, picks, CornerMiter, FillConcaveOutward)
 }
 
 // CornerStrategy selects how a corner where two filleted edges meet a vertex whose third edge stays
@@ -59,10 +59,23 @@ const (
 	CornerRound
 )
 
+// ConcaveFill selects how a fillet treats a CONCAVE (internal) edge — one whose faces fold over the
+// material (dihedral > π). A convex edge always rounds its corner away (material removed) and ignores
+// this. Mirrors api types.FilletConcaveStrategy.
+type ConcaveFill int
+
+const (
+	// FillConcaveOutward fills the inside corner with material: the rolling ball sits in the void and
+	// the cylinder face bridges the two faces (the default — also the zero value).
+	FillConcaveOutward ConcaveFill = iota
+	// FillConcaveInward rounds a recess into the corner instead (the ball sits in the material).
+	FillConcaveInward
+)
+
 // FilletEdgesCorner is FilletEdgesVarying with an explicit 2-edge corner strategy. Lone curved
 // (rim/arc) picks ignore it (they have no shared corner). CornerRound augments the selection with the
 // sharp third edge of each 2-edge corner so the corner resolves as a watertight 3-edge sphere blend.
-func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerStrategy) (*topo.Body, error) {
+func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerStrategy, concave ConcaveFill) (*topo.Body, error) {
 	if rim := loneRimPick(body, picks); rim != nil {
 		return FilletCylinderRim(body, rim.Key, rim.R0) // a circular cylinder/cap rim → toroidal band
 	}
@@ -79,20 +92,20 @@ func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerSt
 	case CornerSetback:
 		edges = setbackThirdEdges(edges) // taper the third edge (r→0 run-out) → smooth set-back sphere
 	}
-	return filletResolvedEdges(body, edges)
+	return filletResolvedEdges(body, edges, concave)
 }
 
 // filletResolvedEdges solves the corners and edge fillets of an already-resolved pick list and
 // assembles the validated result body. Round/setback corners have already been reduced to 3-edge
 // sphere blends by augmenting the third edge, so the corner solver only ever sees miters and blends.
-func filletResolvedEdges(body *topo.Body, edges []filletPick) (*topo.Body, error) {
+func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFill) (*topo.Body, error) {
 	blends, miters, err := computeCorners(edges)
 	if err != nil {
 		return nil, err
 	}
 	fils := make([]edgeFillet, 0, len(edges))
 	for _, p := range edges {
-		ef, err := computeEdgeFillet(body, p, blends, miters)
+		ef, err := computeEdgeFillet(body, p, blends, miters, concave)
 		if err != nil {
 			return nil, err
 		}
@@ -167,12 +180,13 @@ type edgeFillet struct {
 	c0, c1  corner
 	edge    *topo.Edge
 	varying bool
+	flip    bool // concave fillet: the cylinder face's outward sense is inverted (surface faces the centre)
 }
 
 // computeEdgeFillet solves the rolling-ball geometry for one convex straight edge, using a
 // corner blend at either endpoint that is a shared corner. A varying pick gets its end arcs
 // sampled as chords (shared by the ruling strips and the end faces).
-func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter) (edgeFillet, error) {
+func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter, concave ConcaveFill) (edgeFillet, error) {
 	e := p.edge
 	if cyl, pl, ok := cylinderPlaneEdge(e); ok {
 		return edgeFillet{}, curvedFilletError(e, cyl, pl) // fillet of a fillet — Phase A: classify & report
@@ -185,13 +199,39 @@ func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerB
 	if err != nil {
 		return edgeFillet{}, fmt.Errorf("fillet: degenerate edge")
 	}
-	offDir := nA.Add(nB).Scale(-1 / (1 + nA.Dot(nB))) // per-unit-radius centre offset into the solid
-	rMid := (p.r0 + p.r1) / 2
-	if mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point()); !PointInsideBody(body, mid.TranslateBy(offDir.Scale(rMid))) {
-		return edgeFillet{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
+	in, err := filletFrame(body, e, nA, nB, (p.r0+p.r1)/2, concave)
+	if err != nil {
+		return edgeFillet{}, err
 	}
-	in := cornerInputs{a: a, b: b, nA: nA, nB: nB, offDir: offDir, axis: axis.AsVector()}
+	in.a, in.b, in.axis = a, b, axis.AsVector()
 	return solvedEdgeFillet(e, p, in, blends, miters)
+}
+
+// filletFrame resolves the rolling-ball centre offset and the tangent-point normals for an edge,
+// choosing the side from the edge's convexity and (for concave edges) the fill strategy:
+//   - convex: the ball centre sits INSIDE the solid (offDir = −(nA+nB)/(1+nA·nB)); the corner is
+//     rounded away. A centre that is not inside means the edge is not actually convex.
+//   - concave + outward (default): the ball sits in the VOID so the cylinder bridges the faces and
+//     FILLS the inside corner — the same offDir/normals negated to put the centre on the void side.
+//   - concave + inward: the ball sits in the MATERIAL (the convex formula's side), rounding a recess
+//     into the corner.
+func filletFrame(body *topo.Body, e *topo.Edge, nA, nB math.Vector3, rMid float64, concave ConcaveFill) (cornerInputs, error) {
+	offDir := nA.Add(nB).Scale(-1 / (1 + nA.Dot(nB))) // per-unit-radius centre offset into the solid
+	mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point())
+	if ClassifyEdgeConvexity(e) == EdgeConcave {
+		if concave == FillConcaveOutward {
+			return cornerInputs{nA: nA.Scale(-1), nB: nB.Scale(-1), offDir: offDir.Scale(-1), flip: true}, nil
+		}
+		// Inward recess: the ball rolls in the MATERIAL (the convex-formula side). Its tangent points
+		// land off the bounded faces unless they extend that way, so it is only valid on geometry that
+		// permits it (e.g. a pocket); elsewhere the assembled body fails validation and the feature
+		// goes sick honestly. A concave edge's natural fillet is the outward fill above.
+		return cornerInputs{nA: nA, nB: nB, offDir: offDir}, nil
+	}
+	if !PointInsideBody(body, mid.TranslateBy(offDir.Scale(rMid))) {
+		return cornerInputs{}, fmt.Errorf("fillet: edge is not convex (only convex edges are supported)")
+	}
+	return cornerInputs{nA: nA, nB: nB, offDir: offDir}, nil
 }
 
 // solvedEdgeFillet assembles the edgeFillet once the edge's frame is known: corners per end
@@ -203,13 +243,13 @@ func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[ui
 	}
 	if p.varying() {
 		sampleCornerChords(&c0, &c1, in)
-		return edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, edge: e, varying: true}, nil
+		return edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, edge: e, varying: true, flip: in.flip}, nil
 	}
 	cyl, err := geom.NewCylinder(c0.cen, in.axis, p.r0)
 	if err != nil {
 		return edgeFillet{}, err
 	}
-	return edgeFillet{a: in.a, b: in.b, cyl: cyl, c0: c0, c1: c1, edge: e}, nil
+	return edgeFillet{a: in.a, b: in.b, cyl: cyl, c0: c0, c1: c1, edge: e, flip: in.flip}, nil
 }
 
 // edgeCorners solves the rounded corners at both endpoints of an edge (each blended when its
@@ -284,6 +324,7 @@ type cornerInputs struct {
 	nA, nB math.Vector3
 	offDir math.Vector3
 	axis   math.Vector3
+	flip   bool // invert the cylinder face's outward sense (a concave fillet's surface faces the centre)
 }
 
 // cornerAt solves a fillet corner at vertex v with the local radius r. Without a blend it is

--- a/kernel/ops/fillet_corner_test.go
+++ b/kernel/ops/fillet_corner_test.go
@@ -89,7 +89,7 @@ func TestFilletCornerStrategiesValidWatertight(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.strategy+"-"+c.scenario, func(t *testing.T) {
 			box := shellBox(2, 2, 2)
-			res, err := ops.FilletEdgesCorner(box, cornerStrategyPicks(t, box, c.scenario), cornerStrategyOf(c.strategy))
+			res, err := ops.FilletEdgesCorner(box, cornerStrategyPicks(t, box, c.scenario), cornerStrategyOf(c.strategy), ops.FillConcaveOutward)
 			if err != nil {
 				t.Fatalf("%s/%s: %v", c.strategy, c.scenario, err)
 			}
@@ -114,7 +114,7 @@ func TestFilletCornerStrategiesValidWatertight(t *testing.T) {
 func TestFilletCornerVolumeOrdering(t *testing.T) {
 	vol := func(strategy string) float64 {
 		box := shellBox(2, 2, 2)
-		res, err := ops.FilletEdgesCorner(box, cornerStrategyPicks(t, box, "oneCorner"), cornerStrategyOf(strategy))
+		res, err := ops.FilletEdgesCorner(box, cornerStrategyPicks(t, box, "oneCorner"), cornerStrategyOf(strategy), ops.FillConcaveOutward)
 		if err != nil {
 			t.Fatalf("%s: %v", strategy, err)
 		}
@@ -145,7 +145,7 @@ func TestFilletCornerRadiusMismatchRejected(t *testing.T) {
 		{Key: keys[0], R0: 0.3, R1: 0.3},
 		{Key: keys[1], R0: 0.3, R1: 0.3},
 		{Key: keys[2], R0: 0.5, R1: 0.5},
-	}, ops.CornerMiter)
+	}, ops.CornerMiter, ops.FillConcaveOutward)
 	if err == nil || !strings.Contains(err.Error(), "one radius") {
 		t.Fatalf("radius-mismatch err = %v, want the one-radius-at-corner rejection", err)
 	}

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -205,7 +205,9 @@ func cylinderFace(ef edgeFillet) filletFace {
 	segs = append(segs, cornerEndSegs(ef.c1)...)                 // rounded end 1: c1.ta → c1.tb
 	segs = append(segs, endSeg{from: ef.c1.tb, to: ef.c0.tb})    // B-tangent line c1.tb → c0.tb
 	segs = append(segs, reverseEndSegs(cornerEndSegs(ef.c0))...) // rounded end 0: c0.tb → c0.ta
-	if cylinderSegsFlipped(ef, segs) {
+	// A concave fillet's surface faces the cylinder CENTRE (material is on the far side), so its loop
+	// must wind against the cylinder's outward radial — invert the convex sense.
+	if cylinderSegsFlipped(ef, segs) != ef.flip {
 		segs = reverseEndSegs(segs)
 	}
 	return filletFace{surface: ef.cyl, loops: []filletLoop{loopFromSegs(segs)}}

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -291,7 +291,7 @@ func TestFilletCornerRoundAddsThirdEdge(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	keys := cornerEdgeKeys(t, box)[:2] // two of the three edges meeting at the corner
 	picks := []ops.EdgeFilletRadii{{Key: keys[0], R0: 0.3, R1: 0.3}, {Key: keys[1], R0: 0.3, R1: 0.3}}
-	res, err := ops.FilletEdgesCorner(box, picks, ops.CornerRound)
+	res, err := ops.FilletEdgesCorner(box, picks, ops.CornerRound, ops.FillConcaveOutward)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -44,10 +44,11 @@ type FilletCornerType = types.FilletCornerType
 // constant and variable sets (#323). CornerType selects how a vertex where two filleted edges
 // meet (third edge sharp) is treated — miter crease (default/zero), or a full round.
 type FilletDefinition struct {
-	EdgeKeys   [][]byte
-	Radius     func() float64
-	EdgeSets   []FilletEdgeSet
-	CornerType FilletCornerType
+	EdgeKeys        [][]byte
+	Radius          func() float64
+	EdgeSets        []FilletEdgeSet
+	CornerType      FilletCornerType
+	ConcaveStrategy types.FilletConcaveStrategy // concave edges: outward fill (zero/default) or inward recess
 }
 
 // FilletType reports the definition's discriminator: always an edge fillet for now (the
@@ -67,9 +68,9 @@ func (f *FilletFeature) Kind() string { return "fillet" }
 // blend (cylinder faces; planar ruling strips for variable sets). See fillet.go.
 func (f *FilletFeature) Recompute(in Input) (Output, error) {
 	if len(f.def.EdgeSets) > 0 {
-		return filletBodySets(in, f.def.EdgeSets, f.def.CornerType, "fillet")
+		return filletBodySets(in, f.def.EdgeSets, f.def.CornerType, f.def.ConcaveStrategy, "fillet")
 	}
-	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), f.def.CornerType, "fillet")
+	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), f.def.CornerType, f.def.ConcaveStrategy, "fillet")
 }
 
 // ChamferType aliases the public chamfer-mode discriminator (ADR-0018).
@@ -272,8 +273,16 @@ func (c *DressUpFeatures) AddFillet(edgeKeys [][]byte, radius func() float64) *P
 }
 
 // AddFilletCorner rounds the given edges to radius with an explicit shared-corner treatment.
+// Concave edges fill outward (the default); use [AddFilletConcave] to round a recess inward.
 func (c *DressUpFeatures) AddFilletCorner(edgeKeys [][]byte, radius func() float64, corner FilletCornerType) *PartFeature {
 	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: corner}})
+}
+
+// AddFilletConcave rounds the given edges to radius with an explicit concave-edge strategy: outward
+// fills the inside corner with material (the default), inward rounds a recess into it. Convex edges
+// are unaffected by the strategy. Shared corners miter.
+func (c *DressUpFeatures) AddFilletConcave(edgeKeys [][]byte, radius func() float64, concave types.FilletConcaveStrategy) *PartFeature {
+	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: types.FilletCornerMiter, ConcaveStrategy: concave}})
 }
 
 // AddFilletSets rounds any mix of constant and variable radius edge sets in one feature

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -22,11 +22,19 @@ func cornerStrategy(t types.FilletCornerType) ops.CornerStrategy {
 	}
 }
 
+// concaveFill maps the public concave-edge strategy to the kernel's fill direction (zero ⇒ outward).
+func concaveFill(t types.FilletConcaveStrategy) ops.ConcaveFill {
+	if t == types.FilletConcaveInward {
+		return ops.FillConcaveInward
+	}
+	return ops.FillConcaveOutward
+}
+
 // filletBody rounds the selected convex edges of the running body to the given radius via
 // ops.FilletEdgesCorner (a real rolling-ball blend with cylinder faces), replacing it in the body
 // list. corner selects how a 2-edge corner is treated. A lost edge, a non-convex edge, or a
 // non-positive radius is an error so the feature goes Sick. See kernel/ops/fillet.go for the geometry.
-func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCornerType, feat string) (Output, error) {
+func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCornerType, concave types.FilletConcaveStrategy, feat string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -42,7 +50,7 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCorner
 	for i, k := range keys {
 		picks[i] = ops.EdgeFilletRadii{Key: k, R0: radius, R1: radius}
 	}
-	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner))
+	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner), concaveFill(concave))
 	if err != nil {
 		return Output{}, err
 	}
@@ -91,9 +99,9 @@ func planarizedFillet(body *topo.Body, edgeKeys [][]byte, feat string) (*topo.Bo
 // filletBodySets rounds the definition's edge sets in one kernel pass: each constant set
 // contributes its edges at one radius, each variable set one edge with a start→end radius.
 // A single constant set routes through filletBody to keep the analytic cylinder-rim path.
-func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, feat string) (Output, error) {
+func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, concave types.FilletConcaveStrategy, feat string) (Output, error) {
 	if len(sets) == 1 && !sets[0].variable() {
-		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), corner, feat)
+		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), corner, concave, feat)
 	}
 	body, err := runningBody(in)
 	if err != nil {
@@ -104,7 +112,7 @@ func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, fea
 		return Output{}, err
 	}
 	work := planarizeFilletPicks(body, picks, feat)
-	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner))
+	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner), concaveFill(concave))
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/fillet_concave_test.go
+++ b/model/feature/fillet_concave_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// filletConcaved fillets the L-extrude's concave edge (radius r) with the given strategy and
+// returns the result, failing on a sick feature or an invalid solid. lExtrude (chamfer_concave_test.go)
+// is the small L: a 2×2 square less its 1×1 corner, height 1 — volume 3, concave edge at (1,1).
+func filletConcaved(t *testing.T, r float64, strategy types.FilletConcaveStrategy) *topo.Body {
+	t.Helper()
+	body, edge := lExtrude(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(body)
+	fl := NewDressUpFeatures(fs).AddFilletConcave([][]byte{edge}, func() float64 { return r }, strategy)
+	fs.Recompute()
+	if !fl.Health().OK() {
+		t.Fatalf("concave fillet (%v) sick: %+v", strategy, fl.Health())
+	}
+	res := fs.Result()[0]
+	if rep := ops.Validate(res); !rep.Valid || !res.IsSolid() {
+		t.Fatalf("concave fillet (%v) not a valid solid: %+v", strategy, rep)
+	}
+	return res
+}
+
+// concaveFilletNotch is the rolling-ball fillet's quarter-corner cross-section for a 90° concave
+// edge of radius r: the square corner minus the inscribed quarter-disc (r² − πr²/4).
+func concaveFilletNotch(r float64) float64 { return r*r - stdmath.Pi*r*r/4 }
+
+// TestFilletConcaveOutwardFills is the regression for the inverted-fillet bug: an internal
+// (concave) edge filleted outward must FILL the inside corner with an exact rolling-ball cylinder
+// face, adding the notch cross-section over the edge length — not scoop material out as the
+// convex-only path (which left the centre in the material) did. The L is volume 3, edge length 1.
+func TestFilletConcaveOutwardFills(t *testing.T) {
+	const r = 0.6
+	res := filletConcaved(t, r, types.FilletConcaveOutward)
+	want := 3 + concaveFilletNotch(r) // L volume 3 + fillet fill over edge length 1
+	got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume
+	if stdmath.Abs(got-want) > 2e-3 {
+		t.Errorf("outward concave fillet volume = %g, want %g±2e-3 (notch should be filled)", got, want)
+	}
+}
+
+// TestFilletConcaveInwardDegenerate documents that an inward recess is NOT geometrically realizable
+// at a generic concave edge: the rolling ball rolls into the material, but the two bounded faces
+// extend only toward the void, so its tangent points fall off them. The feature goes sick honestly
+// rather than emitting a malformed solid. (A concave edge's valid fillet is the outward fill.)
+func TestFilletConcaveInwardDegenerate(t *testing.T) {
+	body, edge := lExtrude(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(body)
+	fl := NewDressUpFeatures(fs).AddFilletConcave([][]byte{edge}, func() float64 { return 0.6 }, types.FilletConcaveInward)
+	fs.Recompute()
+	if fl.Health().OK() {
+		t.Error("inward fillet of this L should be sick (recess tangents fall off the bounded faces)")
+	}
+}
+
+// openEdgeCount counts mesh edges not shared by exactly two triangles (welding coincident vertices
+// on a 1e-5 grid) — a watertight closed mesh has none.
+func openEdgeCount(m *ops.Mesh) int {
+	grid := func(x float64) int64 { return int64(stdmath.Round(x / 1e-5)) }
+	id := map[[3]int64]int{}
+	vid := func(i int) int {
+		p := m.Positions[i]
+		k := [3]int64{grid(p.X), grid(p.Y), grid(p.Z)}
+		if v, ok := id[k]; ok {
+			return v
+		}
+		v := len(id)
+		id[k] = v
+		return v
+	}
+	use := map[[2]int]int{}
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		vs := [3]int{vid(m.Indices[t]), vid(m.Indices[t+1]), vid(m.Indices[t+2])}
+		for _, e := range [][2]int{{vs[0], vs[1]}, {vs[1], vs[2]}, {vs[2], vs[0]}} {
+			if e[0] > e[1] {
+				e[0], e[1] = e[1], e[0]
+			}
+			use[e]++
+		}
+	}
+	open := 0
+	for _, c := range use {
+		if c != 2 {
+			open++
+		}
+	}
+	return open
+}
+
+// TestFilletConcaveOutwardWatertight verifies the filled concave fillet tessellates watertight
+// across tolerances — tessellation correctness is paramount (a faceted-but-open mesh is a defect).
+func TestFilletConcaveOutwardWatertight(t *testing.T) {
+	res := filletConcaved(t, 0.6, types.FilletConcaveOutward)
+	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
+		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
+		if open := openEdgeCount(m); open != 0 {
+			t.Errorf("outward concave fillet at tol %g has %d open mesh edges, want watertight", tol, open)
+		}
+	}
+}

--- a/model/feature/fillet_concave_test.go
+++ b/model/feature/fillet_concave_test.go
@@ -64,48 +64,15 @@ func TestFilletConcaveInwardDegenerate(t *testing.T) {
 	}
 }
 
-// openEdgeCount counts mesh edges not shared by exactly two triangles (welding coincident vertices
-// on a 1e-5 grid) — a watertight closed mesh has none.
-func openEdgeCount(m *ops.Mesh) int {
-	grid := func(x float64) int64 { return int64(stdmath.Round(x / 1e-5)) }
-	id := map[[3]int64]int{}
-	vid := func(i int) int {
-		p := m.Positions[i]
-		k := [3]int64{grid(p.X), grid(p.Y), grid(p.Z)}
-		if v, ok := id[k]; ok {
-			return v
-		}
-		v := len(id)
-		id[k] = v
-		return v
-	}
-	use := map[[2]int]int{}
-	for t := 0; t+2 < len(m.Indices); t += 3 {
-		vs := [3]int{vid(m.Indices[t]), vid(m.Indices[t+1]), vid(m.Indices[t+2])}
-		for _, e := range [][2]int{{vs[0], vs[1]}, {vs[1], vs[2]}, {vs[2], vs[0]}} {
-			if e[0] > e[1] {
-				e[0], e[1] = e[1], e[0]
-			}
-			use[e]++
-		}
-	}
-	open := 0
-	for _, c := range use {
-		if c != 2 {
-			open++
-		}
-	}
-	return open
-}
-
-// TestFilletConcaveOutwardWatertight verifies the filled concave fillet tessellates watertight
-// across tolerances — tessellation correctness is paramount (a faceted-but-open mesh is a defect).
+// TestFilletConcaveOutwardWatertight verifies the filled concave fillet validates at the
+// tessellating geometry level across qualities — tessellation correctness is paramount (a
+// faceted-but-open mesh is a defect). ValidateBodyEntities at CheckGeometry tessellates and runs
+// the manifold/orientation/closure + self-intersection checks.
 func TestFilletConcaveOutwardWatertight(t *testing.T) {
 	res := filletConcaved(t, 0.6, types.FilletConcaveOutward)
 	for _, tol := range []float64{0.05, 1e-2, 1e-3} {
-		m, _ := ops.TessellateBody(res, ops.Quality{ChordTolerance: tol})
-		if open := openEdgeCount(m); open != 0 {
-			t.Errorf("outward concave fillet at tol %g has %d open mesh edges, want watertight", tol, open)
+		if ok, problems := ops.ValidateBodyEntities(res, ops.CheckGeometry, ops.Quality{ChordTolerance: tol}); !ok {
+			t.Errorf("outward concave fillet at tol %g is not watertight/valid: %+v", tol, problems)
 		}
 	}
 }


### PR DESCRIPTION
## What

Filleting a **concave (internal) edge** now fills the inside corner with an **exact rolling-ball cylinder** (the natural concave fillet), instead of leaving the broken inward scoop. A user-selectable strategy mirrors the chamfer:

- **Outward (default):** the ball rolls in the void, the exact cylinder bridges the two faces and *adds* material.
- **Inward:** rounds a recess into the corner — valid only where the faces extend into the material (e.g. a pocket); at a generic concave edge its tangent points fall off the bounded faces and the feature goes sick honestly.

Convex fillets are unchanged.

## Why

The rolling-ball fillet builds exact B-rep cylinder faces and was convex-only: it placed the ball centre with the convex formula, which on an internal corner sits in the material — rounding a recess (the reported "inverted fillet"). Edges are now classified with `ops.ClassifyEdgeConvexity`; a concave edge's outward fill negates the centre offset (ball → void) and winds the cylinder face against its outward radial (the surface faces the centre).

## How it threads through

- Kernel `kernel/ops/fillet.go` (`filletFrame` + a `flip` on the cylinder face), `ConcaveFill` op enum.
- API enum `types.FilletConcaveStrategy` (Oblikovati.API#132, released v0.16.0 — go.mod bumped here).
- `FilletDefinition.ConcaveStrategy` (+ `AddFilletConcave`), opregistry `concaveStrategy` arg, Fillet tool + head dialog combo.

## Verification

- `model/feature/fillet_concave_test.go`: an L-extrude's concave edge filled outward adds exactly **r²(1−π/4)** over the edge length and stays **watertight** across tolerances; inward on that L is sick (documents the geometric limitation). Convex fillet suite unaffected.
- Live over the bridge: a single-body L-prism (vol 24) filleted outward on its concave edge → **24.158** (≈ the r²(1−π/4)·2 fill), feature healthy, the inside corner shows a smooth cylindrical fillet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)