### PR TITLE
Help ▸ Report Bug: in-app diagnostic submission

### DIFF
--- a/app/bug_report.go
+++ b/app/bug_report.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"oblikovati.org/report"
+)
+
+// Help ▸ Report Bug surface. The session owns the report's lifecycle but never blocks the
+// frame loop or touches itself off-thread: BeginBugReport snapshots the diagnostics and
+// asks the head to capture the two screenshots; ServiceBugReport (called each frame) waits
+// for both PNGs, then submits on a goroutine and drains the result through an atomic
+// pointer — the same off-thread handoff the update check uses (see update_notice.go).
+
+// bugSubmitTimeout bounds the upload so a slow network never strands the submit goroutine.
+// Generous because the payload carries two base64 PNGs.
+const bugSubmitTimeout = 30 * time.Second
+
+// bugSubmitter is the seam the session POSTs reports through; report.Submitter is the real
+// implementation and tests inject a fake (CLAUDE.md: external I/O behind a thin interface).
+type bugSubmitter interface {
+	Submit(ctx context.Context, p report.Payload) error
+}
+
+// bugPhase tracks where a report is in the capture→submit pipeline.
+type bugPhase int
+
+const (
+	bugIdle       bugPhase = iota // no report in flight
+	bugCapturing                  // waiting for the head to write both screenshot PNGs
+	bugSubmitting                 // upload goroutine running
+)
+
+// bugReportState is the in-flight report: its phase, the diagnostics gathered at Begin
+// (screenshots filled in once captured), and the temp paths the head writes the PNGs to.
+type bugReportState struct {
+	phase    bugPhase
+	payload  report.Payload
+	winPath  string
+	viewPath string
+}
+
+// bugResult is the submit goroutine's outcome handed back to the frame loop.
+type bugResult struct{ err error }
+
+// BeginBugReport starts a report: it snapshots the diagnostics, attaches the user's
+// comment, and requests a whole-window and a viewport screenshot to temp files. It is a
+// no-op while a report is already in flight, so a double-click can't start two.
+func (s *Session) BeginBugReport(comment string) {
+	if s.bugReport.phase != bugIdle {
+		return
+	}
+	p := s.CollectDiagnostics()
+	p.Comment = comment
+	id := fmt.Sprintf("oblikovati-bugreport-%d", time.Now().UnixNano())
+	s.bugReport = bugReportState{
+		phase:    bugCapturing,
+		payload:  p,
+		winPath:  filepath.Join(os.TempDir(), id+"-window.png"),
+		viewPath: filepath.Join(os.TempDir(), id+"-viewport.png"),
+	}
+	s.RequestWindowCapture(s.bugReport.winPath)
+	s.RequestViewportCapture(s.bugReport.viewPath)
+	s.feedNotice("Capturing bug report…")
+}
+
+// BugReportInProgress reports whether a report is being captured or submitted (the dialog
+// uses it to show progress / disable Send).
+func (s *Session) BugReportInProgress() bool { return s.bugReport.phase != bugIdle }
+
+// ServiceBugReport advances the report state machine. It must run once per frame AFTER the
+// head's window/viewport captures for the frame (so the PNGs exist to read). It is cheap
+// and a no-op when idle.
+func (s *Session) ServiceBugReport() {
+	switch s.bugReport.phase {
+	case bugCapturing:
+		s.serviceBugCapture()
+	case bugSubmitting:
+		s.serviceBugSubmit()
+	}
+}
+
+// serviceBugCapture waits until both screenshot PNGs have been written (atomically, by the
+// head), folds them into the payload, and launches the upload goroutine.
+func (s *Session) serviceBugCapture() {
+	win, okWin := readCapture(s.bugReport.winPath)
+	view, okView := readCapture(s.bugReport.viewPath)
+	if !okWin || !okView {
+		return // the head has not finished writing both captures yet
+	}
+	s.bugReport.payload.WindowPNG = win
+	s.bugReport.payload.ViewportPNG = view
+	_ = os.Remove(s.bugReport.winPath)
+	_ = os.Remove(s.bugReport.viewPath)
+	s.bugReport.phase = bugSubmitting
+
+	payload := s.bugReport.payload
+	submitter := s.submitter()
+	out := &s.bugOutcome
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), bugSubmitTimeout)
+		defer cancel()
+		out.Store(&bugResult{err: submitter.Submit(ctx, payload)})
+	}()
+}
+
+// serviceBugSubmit drains a finished upload and reports the outcome to the user, returning
+// the machine to idle.
+func (s *Session) serviceBugSubmit() {
+	r := s.bugOutcome.Swap(nil)
+	if r == nil {
+		return
+	}
+	s.bugReport = bugReportState{} // back to idle, releasing the captured payload
+	switch {
+	case r.err == nil:
+		s.feedNotice("Bug report sent — thank you! We'll follow up on GitHub.")
+	case errors.Is(r.err, report.ErrOffline):
+		s.feedNotice("Bug report not sent: no connection to the reporting service.")
+	default:
+		s.feedNotice(fmt.Sprintf("Bug report failed: %v", r.err))
+	}
+}
+
+// submitter returns the injected reporting submitter, lazily creating the real HTTP one so
+// headless/test sessions that never file a report pay nothing and can inject a fake first.
+func (s *Session) submitter() bugSubmitter {
+	if s.bugSubmitter == nil {
+		s.bugSubmitter = report.NewSubmitter("", &http.Client{Timeout: bugSubmitTimeout})
+	}
+	return s.bugSubmitter
+}
+
+// SetBugSubmitter injects the reporting submitter (the head can point it at a configured
+// endpoint; tests pass a fake). Pass nil to fall back to the default.
+func (s *Session) SetBugSubmitter(sub bugSubmitter) { s.bugSubmitter = sub }
+
+// readCapture reads a screenshot PNG, returning ok=false until it exists and is non-empty.
+// The head writes captures via temp-file rename, so a present file is always complete.
+func readCapture(path string) ([]byte, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil || len(b) == 0 {
+		return nil, false
+	}
+	return b, true
+}

--- a/app/bug_report.go
+++ b/app/bug_report.go
@@ -132,9 +132,12 @@ func (s *Session) serviceBugSubmit() {
 
 // submitter returns the injected reporting submitter, lazily creating the real HTTP one so
 // headless/test sessions that never file a report pay nothing and can inject a fake first.
+// OBLIKOVATI_REPORTING_ENDPOINT overrides the target so a dev/staging build can point at a
+// local reporting service (empty ⇒ report.DefaultEndpoint).
 func (s *Session) submitter() bugSubmitter {
 	if s.bugSubmitter == nil {
-		s.bugSubmitter = report.NewSubmitter("", &http.Client{Timeout: bugSubmitTimeout})
+		endpoint := os.Getenv("OBLIKOVATI_REPORTING_ENDPOINT")
+		s.bugSubmitter = report.NewSubmitter(endpoint, &http.Client{Timeout: bugSubmitTimeout})
 	}
 	return s.bugSubmitter
 }

--- a/app/bug_report_diag.go
+++ b/app/bug_report_diag.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"runtime"
+
+	"gopkg.in/yaml.v3"
+
+	"oblikovati.org/app/options"
+	"oblikovati.org/build"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/report"
+)
+
+// CollectDiagnostics gathers everything a triager needs to reproduce a bug — the user's
+// options, the open documents, the platform and build, and the active document's
+// transaction history — into a report.Payload. The two screenshots are filled in later by
+// the capture step; the comment by BeginBugReport.
+func (s *Session) CollectDiagnostics() report.Payload {
+	return report.Payload{
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		AppVersion:     build.Version,
+		AppCommit:      build.Commit,
+		AppBuildDate:   build.Date,
+		UserSettings:   marshalOptions(s.appOptions),
+		OpenDocuments:  s.openDocumentInfos(),
+		TransactionLog: s.TransactionLog(),
+	}
+}
+
+// TransactionLog returns the active document's undo/redo step labels, oldest first — the
+// "what the user did" trail. Empty when no document is active. This is the public accessor
+// over the per-document command.History the session keeps in docHistory.
+func (s *Session) TransactionLog() []string {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil
+	}
+	dh := s.documentHistory(d)
+	if dh == nil || dh.hist == nil {
+		return nil
+	}
+	return dh.hist.Labels()
+}
+
+// openDocumentInfos summarises every open document for the report.
+func (s *Session) openDocumentInfos() []report.DocumentInfo {
+	docs := s.workspace.Documents()
+	out := make([]report.DocumentInfo, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, report.DocumentInfo{
+			Path:            d.FullDocumentName(),
+			Name:            d.DisplayName(),
+			Type:            d.DocumentType().String(),
+			Dirty:           d.Dirty(),
+			DisplaySettings: displaySettingsText(d),
+		})
+	}
+	return out
+}
+
+// displaySettingsText renders a document's per-document display settings as YAML, or ""
+// when the document uses the application defaults (the common case).
+func displaySettingsText(d *doc.Document) string {
+	set, ok := d.DisplaySettings()
+	if !ok {
+		return ""
+	}
+	b, err := yaml.Marshal(set)
+	if err != nil {
+		return fmt.Sprintf("(failed to render display settings: %v)", err)
+	}
+	return string(b)
+}
+
+// marshalOptions renders the user's typed options as YAML for the report (the same shape
+// they are persisted in), so a triager sees exactly the preferences in effect.
+func marshalOptions(all options.All) string {
+	b, err := yaml.Marshal(all)
+	if err != nil {
+		return fmt.Sprintf("(failed to render options: %v)", err)
+	}
+	return string(b)
+}

--- a/app/bug_report_test.go
+++ b/app/bug_report_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"oblikovati.org/build"
+	"oblikovati.org/report"
+)
+
+// fakeBugSubmitter records the payload it is handed instead of POSTing it, so the
+// capture→submit flow can be driven without a network.
+type fakeBugSubmitter struct {
+	mu   sync.Mutex
+	got  report.Payload
+	err  error
+	hits int
+}
+
+func (f *fakeBugSubmitter) Submit(_ context.Context, p report.Payload) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.got = p
+	f.hits++
+	return f.err
+}
+
+func (f *fakeBugSubmitter) payload() (report.Payload, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.got, f.hits
+}
+
+func TestCollectDiagnosticsPopulatesPlatformAndSettings(t *testing.T) {
+	s := NewSession()
+	d := s.CollectDiagnostics()
+	if d.OS != runtime.GOOS || d.Arch != runtime.GOARCH {
+		t.Errorf("platform = %s/%s, want %s/%s", d.OS, d.Arch, runtime.GOOS, runtime.GOARCH)
+	}
+	if d.AppVersion != build.Version {
+		t.Errorf("AppVersion = %q, want %q", d.AppVersion, build.Version)
+	}
+	if d.UserSettings == "" {
+		t.Error("UserSettings should render the options YAML, got empty")
+	}
+}
+
+func TestBugReportCaptureThenSubmit(t *testing.T) {
+	s := NewSession()
+	fake := &fakeBugSubmitter{}
+	s.SetBugSubmitter(fake)
+
+	s.BeginBugReport("crash when I extrude")
+	if !s.BugReportInProgress() {
+		t.Fatal("report should be in progress after Begin")
+	}
+	// The head would write both PNGs to the requested paths; simulate that.
+	mustWrite(t, s.bugReport.winPath, "WINDOWPNG")
+	mustWrite(t, s.bugReport.viewPath, "VIEWPORTPNG")
+
+	s.ServiceBugReport() // captures present → launches the submit goroutine
+	waitUntil(t, func() bool { return s.bugOutcome.Load() != nil })
+	s.ServiceBugReport() // drains the outcome → idle
+
+	if s.BugReportInProgress() {
+		t.Fatal("report should be idle after submit drains")
+	}
+	got, hits := fake.payload()
+	if hits != 1 {
+		t.Fatalf("submit hits = %d, want 1", hits)
+	}
+	if got.Comment != "crash when I extrude" {
+		t.Errorf("comment = %q", got.Comment)
+	}
+	if string(got.WindowPNG) != "WINDOWPNG" || string(got.ViewportPNG) != "VIEWPORTPNG" {
+		t.Errorf("screenshots not folded into payload: win=%q view=%q", got.WindowPNG, got.ViewportPNG)
+	}
+	// Temp captures are cleaned up after they are read.
+	if _, err := os.Stat(s.bugReport.winPath); err == nil {
+		t.Error("temp window capture not removed")
+	}
+}
+
+func TestBugReportWaitsForBothCaptures(t *testing.T) {
+	s := NewSession()
+	fake := &fakeBugSubmitter{}
+	s.SetBugSubmitter(fake)
+	s.BeginBugReport("note")
+	mustWrite(t, s.bugReport.winPath, "WINDOWPNG") // only one capture ready
+
+	s.ServiceBugReport() // must NOT submit yet
+	if _, hits := fake.payload(); hits != 0 {
+		t.Fatalf("submitted before both captures present (hits=%d)", hits)
+	}
+	if !s.BugReportInProgress() {
+		t.Error("should still be capturing")
+	}
+}
+
+func TestBeginBugReportIgnoredWhileInProgress(t *testing.T) {
+	s := NewSession()
+	s.SetBugSubmitter(&fakeBugSubmitter{})
+	s.BeginBugReport("first")
+	first := s.bugReport.winPath
+	s.BeginBugReport("second") // no-op
+	if s.bugReport.winPath != first || s.bugReport.payload.Comment != "first" {
+		t.Error("second Begin should be ignored while one is in flight")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+}
+
+func waitUntil(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}

--- a/app/bug_report_test.go
+++ b/app/bug_report_test.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"os"
 	"runtime"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"oblikovati.org/build"
+	"oblikovati.org/model/display"
 	"oblikovati.org/report"
 )
 
@@ -112,6 +114,70 @@ func TestBeginBugReportIgnoredWhileInProgress(t *testing.T) {
 	if s.bugReport.winPath != first || s.bugReport.payload.Comment != "first" {
 		t.Error("second Begin should be ignored while one is in flight")
 	}
+}
+
+func TestBugReportReturnsToIdleOnError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"offline", report.ErrOffline},
+		{"generic", errors.New("server exploded")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSession()
+			s.SetBugSubmitter(&fakeBugSubmitter{err: tc.err})
+			s.BeginBugReport("note")
+			mustWrite(t, s.bugReport.winPath, "W")
+			mustWrite(t, s.bugReport.viewPath, "V")
+			s.ServiceBugReport() // launch submit
+			waitUntil(t, func() bool { return s.bugOutcome.Load() != nil })
+			s.ServiceBugReport() // drain
+			if s.BugReportInProgress() {
+				t.Error("report should return to idle even after a failed submit")
+			}
+		})
+	}
+}
+
+func TestSubmitterLazilyDefaults(t *testing.T) {
+	s := NewSession() // no SetBugSubmitter: the real HTTP submitter is created on demand
+	if s.submitter() == nil {
+		t.Fatal("submitter() returned nil")
+	}
+}
+
+func TestDiagnosticsIncludesOpenDocuments(t *testing.T) {
+	s := NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	// Before display settings are set, the document uses defaults (no per-doc dump).
+	if before := s.CollectDiagnostics(); len(before.OpenDocuments) == 0 {
+		t.Fatal("expected the new part among open documents")
+	} else if before.OpenDocuments[0].DisplaySettings != "" {
+		t.Error("a defaults document should carry no display-settings dump")
+	}
+
+	d := s.ActiveDocument()
+	if d == nil {
+		t.Fatal("no active document after NewPart")
+	}
+	d.SetDisplaySettings(display.DefaultSettings())
+
+	diag := s.CollectDiagnostics()
+	if len(diag.OpenDocuments) == 0 {
+		t.Fatal("expected open documents")
+	}
+	doc0 := diag.OpenDocuments[0]
+	if doc0.Type == "" || doc0.Name == "" {
+		t.Errorf("document info incomplete: %+v", doc0)
+	}
+	if doc0.DisplaySettings == "" {
+		t.Error("expected a display-settings dump once set")
+	}
+	// Exercises the per-document transaction-history accessor (the active-document path).
+	_ = s.TransactionLog()
 }
 
 func mustWrite(t *testing.T, path, content string) {

--- a/app/session.go
+++ b/app/session.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app/options"
@@ -138,6 +139,9 @@ type Session struct {
 	bomViewKind          bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
 	updateCheckRequested bool                           // Help ▸ Check for Updates was clicked; the head runs the (network) check
 	pendingUpdate        *update.Result                 // last update-check outcome to show in the update window; nil = closed
+	bugReport            bugReportState                 // in-progress Help ▸ Report Bug capture+submit, if any
+	bugOutcome           atomic.Pointer[bugResult]      // submit goroutine → frame loop handoff (session never touched off-thread)
+	bugSubmitter         bugSubmitter                   // injectable reporting endpoint (DI; lazily defaults to real HTTP)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -94,6 +94,7 @@ func pumpFrame(win *native.Window, session *app.Session, addins *addInHost, upda
 	exit := ui.HandleClose(win, session)
 	win.EndFrame(ui.WindowClearColor())   // themed swapchain background (ADR-0021)
 	ui.ServiceWindowCapture(win, session) // whole-window PNG: AFTER the swapchain composited this frame
+	session.ServiceBugReport()            // Help ▸ Report Bug: both captures are now on disk; submit off-thread
 	return exit || addins.addInChanged()
 }
 

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -146,11 +146,12 @@ func drawChromeWindows(s *app.Session) {
 	drawColorStylesWindow(s)     // View ▸ Color Styles (M16-F02 #403/#408)
 	drawDisplaySettingsWindow(s) // View ▸ Display Settings (M16-F07 #643)
 	drawScriptConsole(s)
-	drawKeymapEditor(s)  // Tools ▸ Customize Keyboard (M05-F17)
-	drawCommandInput(s)  // command-alias input box (M05-F17)
-	drawCommandWindow(s) // docked Command Window REPL panel (M26 F04)
-	drawUpdateWindow(s)  // Help ▸ Check for Updates notification
-	drawAddInPanels(s)   // add-in dockable windows (M05-F03)
+	drawKeymapEditor(s)    // Tools ▸ Customize Keyboard (M05-F17)
+	drawCommandInput(s)    // command-alias input box (M05-F17)
+	drawCommandWindow(s)   // docked Command Window REPL panel (M26 F04)
+	drawUpdateWindow(s)    // Help ▸ Check for Updates notification
+	drawReportBugDialog(s) // Help ▸ Report Bug
+	drawAddInPanels(s)     // add-in dockable windows (M05-F03)
 	// M26 F03: toasts / prompt modal / message-center windows are retired — every message
 	// now funnels into the docked Command Window, and prompts are answered inline there.
 	drawWebViews(s)          // web dialogs/views (M05-F08)

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -36,6 +36,9 @@ func drawHelpMenu(s *app.Session) {
 		if native.MenuItem("Check for Updates") {
 			s.RequestUpdateCheck()
 		}
+		if native.MenuItem("Report Bug") { // opens the report window; submit happens off-thread
+			reportBugUI.open = true
+		}
 		native.EndMenu()
 	}
 }

--- a/head/ui/report_bug_dialog.go
+++ b/head/ui/report_bug_dialog.go
@@ -1,0 +1,58 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// reportBugUI holds the Help ▸ Report Bug modal's UI-only state: whether it is open and the
+// comment buffer. The actual capture + submit lifecycle is session state (see app.BeginBugReport),
+// so this stays a thin view, like the other head-only dialog toggles (showPreferences et al.).
+var reportBugUI struct {
+	open bool
+	buf  [4096]byte
+}
+
+// drawReportBugDialog renders the Report Bug window when open: a free-text box plus Send /
+// Cancel. Send hands the comment to the session, which snapshots diagnostics and requests
+// the two screenshots; the frame loop's ServiceBugReport finishes capture and submits. The
+// window closes on Send so the captures grab the app WITHOUT this dialog covering it.
+func drawReportBugDialog(s *app.Session) {
+	if !reportBugUI.open {
+		return
+	}
+	native.SetNextWindowSizeOnce(520, 360)
+	if native.Begin("Report Bug") {
+		native.Text("Describe what you were doing and what went wrong.")
+		native.Text("Your settings, open files, platform, recent actions, and two")
+		native.Text("screenshots (whole window + viewport) are attached automatically.")
+		native.Separator()
+		native.InputTextMultiline("##bug-comment", reportBugUI.buf[:], 0, 200)
+		native.Separator()
+		drawReportBugActions(s)
+	}
+	native.End()
+}
+
+// drawReportBugActions draws the Send / Cancel row, or a progress line while a previous
+// report is still being captured or submitted (so a second can't pile on).
+func drawReportBugActions(s *app.Session) {
+	if s.BugReportInProgress() {
+		native.Text("Sending the previous report…")
+		return
+	}
+	if native.Button("Send Report") {
+		s.BeginBugReport(bufString(reportBugUI.buf[:]))
+		clearBuf(reportBugUI.buf[:])
+		reportBugUI.open = false
+	}
+	native.SameLine()
+	if native.Button("Cancel") {
+		clearBuf(reportBugUI.buf[:])
+		reportBugUI.open = false
+	}
+}

--- a/head/ui/report_bug_dialog.go
+++ b/head/ui/report_bug_dialog.go
@@ -46,13 +46,25 @@ func drawReportBugActions(s *app.Session) {
 		return
 	}
 	if native.Button("Send Report") {
-		s.BeginBugReport(bufString(reportBugUI.buf[:]))
-		clearBuf(reportBugUI.buf[:])
-		reportBugUI.open = false
+		sendReportFromDialog(s)
 	}
 	native.SameLine()
 	if native.Button("Cancel") {
-		clearBuf(reportBugUI.buf[:])
-		reportBugUI.open = false
+		cancelReportDialog()
 	}
+}
+
+// sendReportFromDialog hands the typed comment to the session (which captures + submits)
+// then empties and closes the dialog. Split from the draw so it is unit-testable without a
+// click: the window must close so the captures grab the app without it covering the view.
+func sendReportFromDialog(s *app.Session) {
+	s.BeginBugReport(bufString(reportBugUI.buf[:]))
+	clearBuf(reportBugUI.buf[:])
+	reportBugUI.open = false
+}
+
+// cancelReportDialog discards the draft and closes the dialog.
+func cancelReportDialog() {
+	clearBuf(reportBugUI.buf[:])
+	reportBugUI.open = false
 }

--- a/head/ui/report_bug_dialog_test.go
+++ b/head/ui/report_bug_dialog_test.go
@@ -54,3 +54,30 @@ func TestInWindowReportBugDialogRenders(t *testing.T) {
 	frame()
 	frame()
 }
+
+// TestReportBugDialogSendAndCancel exercises the Send and Cancel actions directly (no click
+// simulation): Send starts a report and closes the window; Cancel just discards and closes.
+func TestReportBugDialogSendAndCancel(t *testing.T) {
+	s := framedSession()
+	s.SetBugSubmitter(stubBugSubmitter{})
+
+	reportBugUI.open = true
+	setBuf(reportBugUI.buf[:], "something broke")
+	sendReportFromDialog(s)
+	if reportBugUI.open {
+		t.Error("Send should close the dialog so the capture excludes it")
+	}
+	if !s.BugReportInProgress() {
+		t.Error("Send should start the report")
+	}
+	if bufString(reportBugUI.buf[:]) != "" {
+		t.Error("Send should clear the draft")
+	}
+
+	reportBugUI.open = true
+	setBuf(reportBugUI.buf[:], "never mind")
+	cancelReportDialog()
+	if reportBugUI.open || bufString(reportBugUI.buf[:]) != "" {
+		t.Error("Cancel should clear the draft and close the dialog")
+	}
+}

--- a/head/ui/report_bug_dialog_test.go
+++ b/head/ui/report_bug_dialog_test.go
@@ -1,0 +1,56 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"context"
+	"testing"
+
+	"oblikovati.org/report"
+)
+
+// stubBugSubmitter satisfies the session's bug submitter without any network — the render
+// test never completes a capture, so Submit is never actually called, but injecting it
+// keeps the default HTTP client out of the test.
+type stubBugSubmitter struct{}
+
+func (stubBugSubmitter) Submit(context.Context, report.Payload) error { return nil }
+
+// TestInWindowReportBugDialogRenders opens the real window with the Report Bug dialog
+// visible and renders frames in both the idle (Send/Cancel) and in-progress (progress
+// line) branches — so a mismatched ImGui Begin/End in either branch trips Dear ImGui's
+// assertions here rather than in front of a user.
+func TestInWindowReportBugDialogRenders(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+	s.SetBugSubmitter(stubBugSubmitter{})
+
+	reportBugUI.open = true
+	t.Cleanup(func() { reportBugUI.open = false })
+
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	// Idle branch: the Send Report / Cancel row.
+	frame()
+	frame()
+	if !reportBugUI.open {
+		t.Fatal("dialog should stay open while idle")
+	}
+
+	// In-progress branch: requesting a report flips the dialog to its progress line.
+	s.BeginBugReport("render-test note")
+	if !s.BugReportInProgress() {
+		t.Fatal("BeginBugReport should mark the report in progress")
+	}
+	frame()
+	frame()
+}

--- a/report/doc.go
+++ b/report/doc.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package report submits a user bug report — a typed diagnostic [Payload] plus two
+// screenshots — to the reporting.oblikovati.org endpoint, which queues it and opens a
+// GitHub issue. Like the sibling update package, the network I/O lives behind a thin
+// [httpDoer] seam so the flow is unit-testable without a live server, and connectivity
+// failures map to [ErrOffline] so a missing network is a graceful skip, not a crash.
+//
+// The endpoint is an open POST, so each request carries an Authorization token equal to
+// the CRC-32 (IEEE) of the exact JSON body (see [Token]); the server recomputes it over
+// the bytes it received and rejects a mismatch. This is a cheap probe filter, not real
+// authentication.
+package report

--- a/report/endpoint.go
+++ b/report/endpoint.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package report
+
+// DefaultEndpoint is the public reporting service that ingests a [Payload], queues it, and
+// opens a GitHub issue. It is overridable (NewSubmitter takes the URL) so a local instance
+// can be targeted during development and tests.
+const DefaultEndpoint = "https://reporting.oblikovati.org/report"

--- a/report/errors.go
+++ b/report/errors.go
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package report
+
+import "errors"
+
+// ErrOffline reports that the reporting service could not be reached (DNS, connection, or
+// timeout). Callers treat it as a graceful skip — being offline is not a failure to shout
+// about — mirroring update.ErrOffline.
+var ErrOffline = errors.New("report: reporting server unreachable")

--- a/report/payload.go
+++ b/report/payload.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package report
+
+// Payload is the bug report sent to the reporting service. Its JSON shape is the contract
+// with reporting.oblikovati.org; by project decision it is duplicated there rather than
+// shared through a module, so the field json tags on both sides must stay in lockstep (a
+// round-trip test on each side guards against drift). The two PNGs are encoded as base64
+// by encoding/json automatically because they are []byte.
+type Payload struct {
+	Comment        string         `json:"comment"`
+	OS             string         `json:"os"`
+	Arch           string         `json:"arch"`
+	AppVersion     string         `json:"appVersion"`
+	AppCommit      string         `json:"appCommit"`
+	AppBuildDate   string         `json:"appBuildDate"`
+	UserSettings   string         `json:"userSettings"`
+	OpenDocuments  []DocumentInfo `json:"openDocuments"`
+	TransactionLog []string       `json:"transactionLog"`
+	WindowPNG      []byte         `json:"windowPng,omitempty"`
+	ViewportPNG    []byte         `json:"viewportPng,omitempty"`
+}
+
+// DocumentInfo summarises one open document for the report: its file path, display name,
+// kind, dirty flag, and a human-readable dump of its display settings (empty when the
+// document uses defaults). It deliberately carries no model geometry — just the context a
+// triager needs to reproduce.
+type DocumentInfo struct {
+	Path            string `json:"path"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Dirty           bool   `json:"dirty"`
+	DisplaySettings string `json:"displaySettings,omitempty"`
+}

--- a/report/submit.go
+++ b/report/submit.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package report
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net/http"
+)
+
+// httpDoer is the one method of *http.Client this package needs, named so tests can fake
+// the transport without a live server (CLAUDE.md: wrap external I/O behind a thin seam).
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// maxErrorBody caps how much of a rejection body we read into the error message.
+const maxErrorBody = 4 << 10
+
+// Submitter POSTs a [Payload] to the reporting endpoint with the CRC-32 authorization
+// token the open endpoint expects.
+type Submitter struct {
+	endpoint string
+	http     httpDoer
+}
+
+// NewSubmitter returns a submitter for endpoint over doer (typically an *http.Client with
+// a timeout so a slow network never blocks the caller). An empty endpoint falls back to
+// [DefaultEndpoint].
+//
+// Example:
+//
+//	sub := report.NewSubmitter("", &http.Client{Timeout: 15 * time.Second})
+//	err := sub.Submit(ctx, payload)
+func NewSubmitter(endpoint string, doer httpDoer) *Submitter {
+	if endpoint == "" {
+		endpoint = DefaultEndpoint
+	}
+	return &Submitter{endpoint: endpoint, http: doer}
+}
+
+// Token is the authorization token for a request body: the lowercase, zero-padded hex
+// CRC-32 (IEEE) of the exact bytes. The reporting service recomputes it over the body it
+// receives, so both sides must hash the identical bytes — which is why Submit hashes the
+// marshaled body it is about to send.
+func Token(body []byte) string {
+	return fmt.Sprintf("%08x", crc32.ChecksumIEEE(body))
+}
+
+// Submit marshals p, POSTs it as JSON with the CRC token in the Authorization header, and
+// maps a transport failure to [ErrOffline] so the caller can skip silently when offline. A
+// non-2xx response is returned as an error carrying the status and (capped) body.
+func (s *Submitter) Submit(ctx context.Context, p Payload) error {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("report: marshal payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("report: build request for %q: %w", s.endpoint, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", Token(body))
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrOffline, err) // no network / DNS / timeout
+	}
+	defer resp.Body.Close()
+	return checkStatus(resp, s.endpoint)
+}
+
+// checkStatus accepts 200/202 and turns any other status into an error with the capped
+// response body for context.
+func checkStatus(resp *http.Response, endpoint string) error {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	return fmt.Errorf("report: POST %q rejected: %s: %s", endpoint, resp.Status, bytes.TrimSpace(body))
+}

--- a/report/submit_test.go
+++ b/report/submit_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package report
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// fakeDoer captures the request it is handed and replies with a canned response (or a
+// transport error), so Submit can be exercised without a live server.
+type fakeDoer struct {
+	gotReq  *http.Request
+	gotBody []byte
+	status  int
+	body    string
+	err     error
+}
+
+func (f *fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.gotReq = req
+	if req.Body != nil {
+		f.gotBody, _ = io.ReadAll(req.Body)
+	}
+	return &http.Response{
+		StatusCode: f.status,
+		Status:     fmt.Sprintf("%d %s", f.status, http.StatusText(f.status)),
+		Body:       io.NopCloser(strings.NewReader(f.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func samplePayload() Payload {
+	return Payload{
+		Comment:        "it crashed when I extruded",
+		OS:             "linux",
+		Arch:           "amd64",
+		AppVersion:     "0.16.0",
+		OpenDocuments:  []DocumentInfo{{Path: "/tmp/p.obk", Name: "p", Type: "Part"}},
+		TransactionLog: []string{"Sketch", "Extrude"},
+		WindowPNG:      []byte{0x89, 0x50, 0x4e, 0x47},
+		ViewportPNG:    []byte{0x89, 0x50, 0x4e, 0x47, 0x0d},
+	}
+}
+
+func TestSubmitSendsCRCTokenOverExactBody(t *testing.T) {
+	doer := &fakeDoer{status: http.StatusAccepted}
+	sub := NewSubmitter("https://example.test/report", doer)
+
+	if err := sub.Submit(context.Background(), samplePayload()); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if doer.gotReq.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", doer.gotReq.Method)
+	}
+	if got := doer.gotReq.URL.String(); got != "https://example.test/report" {
+		t.Errorf("url = %q", got)
+	}
+	if ct := doer.gotReq.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	// The token must be the CRC-32 of the EXACT bytes that were sent — recompute over the
+	// captured body and compare. This is the contract the server re-verifies.
+	want := fmt.Sprintf("%08x", crc32.ChecksumIEEE(doer.gotBody))
+	if got := doer.gotReq.Header.Get("Authorization"); got != want {
+		t.Errorf("authorization = %q, want %q", got, want)
+	}
+}
+
+func TestTokenIsDeterministicCRC32(t *testing.T) {
+	body := []byte(`{"comment":"hi"}`)
+	want := fmt.Sprintf("%08x", crc32.ChecksumIEEE(body))
+	if got := Token(body); got != want {
+		t.Errorf("Token = %q, want %q", got, want)
+	}
+	// Same content in a distinct slice must yield the same token (it hashes bytes, not identity).
+	if a, b := Token(body), Token([]byte(`{"comment":"hi"}`)); a != b {
+		t.Errorf("Token not content-deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestSubmitOfflineMapsToErrOffline(t *testing.T) {
+	doer := &fakeDoer{err: errors.New("dial tcp: no route to host")}
+	sub := NewSubmitter("", doer)
+	err := sub.Submit(context.Background(), samplePayload())
+	if !errors.Is(err, ErrOffline) {
+		t.Fatalf("err = %v, want ErrOffline", err)
+	}
+}
+
+func TestSubmitRejectsNon2xx(t *testing.T) {
+	doer := &fakeDoer{status: http.StatusUnauthorized, body: "bad token"}
+	sub := NewSubmitter("", doer)
+	err := sub.Submit(context.Background(), samplePayload())
+	if err == nil {
+		t.Fatal("want error on 401")
+	}
+	if errors.Is(err, ErrOffline) {
+		t.Error("401 should not be ErrOffline")
+	}
+	if !strings.Contains(err.Error(), "bad token") {
+		t.Errorf("err missing body context: %v", err)
+	}
+}
+
+func TestNewSubmitterDefaultsEndpoint(t *testing.T) {
+	doer := &fakeDoer{status: http.StatusOK}
+	sub := NewSubmitter("", doer)
+	if err := sub.Submit(context.Background(), samplePayload()); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if doer.gotReq.URL.String() != DefaultEndpoint {
+		t.Errorf("url = %q, want default %q", doer.gotReq.URL, DefaultEndpoint)
+	}
+}


### PR DESCRIPTION
## What

Adds a **Help ▸ Report Bug** flow to the application. The user types a comment and clicks **Send Report**; the app gathers diagnostics plus a whole-window and a viewport screenshot and POSTs them to the new `reporting.oblikovati.org` service, which queues the report and opens a GitHub issue.

## Why

Alpha users had no in-app way to report a bug with the context needed to reproduce it (settings, open files, platform, what they did, what they saw). This captures all of that in one click.

## How

- **`report/`** (mirrors `update/`): `Payload` DTO + a `Submitter` over an injectable httpDoer seam. Each POST is authorized with `Authorization: crc32(body)` (a cheap probe filter for the open endpoint); transport failures map to `ErrOffline` so being offline is a graceful skip.
- **`app/bug_report.go` + `bug_report_diag.go`**: `CollectDiagnostics()` (options, open documents, OS/arch, build, active-document transaction log) and an Idle→Capturing→Submitting state machine. It reuses the existing window/viewport capture plumbing (`app/viewport_capture.go`) and submits off-thread via an atomic handoff (like the update poller). The submitter is injected for tests; `OBLIKOVATI_REPORTING_ENDPOINT` overrides the target for dev/staging.
- **head**: a Help menu item + a Report Bug modal (comment + Send/Cancel); the frame loop calls `ServiceBugReport` after the captures are written.

Outbound submission is host-internal (no `api/wire` surface) and the payload DTO is duplicated in the service, so this PR touches only this repo.

## Tests

- `report/`: CRC token over exact body, offline-graceful submit, non-2xx rejection, default endpoint.
- `app/`: diagnostics collection, the capture→submit state machine (incl. "waits for both captures"), no-op-while-in-flight; passes under `-race`.
- `head/ui`: in-window render test (DISPLAY=:1) covering the idle and in-progress dialog branches.
- Validated **end-to-end on localhost** against the reporting service in Docker (see the companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)