### PR TITLE
feat(sheet-metal): flat pattern DXF export with bend lines & punch tags (#378)

### DIFF
--- a/cmd/oblikovati-cli/cmd_export.go
+++ b/cmd/oblikovati-cli/cmd_export.go
@@ -76,5 +76,39 @@ func exportSketchDXF(part *compdef.PartComponentDefinition, src, dst string, arg
 	return nil
 }
 
+// cmdExportFlat develops a sheet-metal part's flat pattern and writes it to a .dxf with the
+// outline, bend lines and punch tokens on named layers, at a version (r2000|r2018; default r2000):
+//
+//	oblikovati-cli export-flat fixtures/bracket.opd bracket-flat.dxf r2018
+func cmdExportFlat(args []string, out io.Writer) error {
+	if len(args) < 2 || len(args) > 3 {
+		return fmt.Errorf("export-flat: expected <src.opd> <out.dxf> [r2000|r2018], got %d arg(s)", len(args))
+	}
+	src, dst := args[0], args[1]
+	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	d, err := ws.Open(src, true)
+	if err != nil {
+		return fmt.Errorf("export-flat: open %q: %w", src, err)
+	}
+	part, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return fmt.Errorf("export-flat: %q is not a part document", src)
+	}
+	flat, err := part.Unfold()
+	if err != nil {
+		return fmt.Errorf("export-flat: %w", err)
+	}
+	version := types.DXFR2000
+	if len(args) == 3 {
+		version = types.DXFVersion(args[2])
+	}
+	n, err := exchange.ExportFlatPatternDXFFile(flat, dst, exchange.FlatExportLayers{}, version)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "exported %s flat pattern to %s (%d entities, %s)\n", src, dst, n, version.Normalized())
+	return nil
+}
+
 // lowerExt returns path's lower-cased extension (including the dot).
 func lowerExt(path string) string { return strings.ToLower(filepath.Ext(path)) }

--- a/cmd/oblikovati-cli/cmd_export.go
+++ b/cmd/oblikovati-cli/cmd_export.go
@@ -26,19 +26,36 @@ func cmdExport(args []string, out io.Writer) error {
 		return fmt.Errorf("export: expected <src.opd> <out-file> [low|medium|high | r2000|r2018], got %d arg(s)", len(args))
 	}
 	src, dst := args[0], args[1]
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
-	d, err := ws.Open(src, true)
+	part, err := openCLIPart(src)
 	if err != nil {
-		return fmt.Errorf("export: open %q: %w", src, err)
-	}
-	part, ok := d.Content().(*compdef.PartComponentDefinition)
-	if !ok {
-		return fmt.Errorf("export: %q is not a part document", src)
+		return fmt.Errorf("export: %w", err)
 	}
 	if lowerExt(dst) == ".dxf" {
 		return exportSketchDXF(part, src, dst, args, out)
 	}
 	return exportBodies(part, src, dst, args, out)
+}
+
+// openCLIPart opens an .opd and returns its part component definition, erroring if the document
+// is missing or is not a part.
+func openCLIPart(src string) (*compdef.PartComponentDefinition, error) {
+	d, err := doc.NewWorkspace(persistence.NewPackageStore()).Open(src, true)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", src, err)
+	}
+	part, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return nil, fmt.Errorf("%q is not a part document", src)
+	}
+	return part, nil
+}
+
+// dxfVersionArg resolves an optional trailing version arg (r2000|r2018), defaulting to R2000.
+func dxfVersionArg(args []string) types.DXFVersion {
+	if len(args) == 3 {
+		return types.DXFVersion(args[2])
+	}
+	return types.DXFR2000
 }
 
 // exportBodies writes the part's bodies to a mesh/B-rep file at the chosen resolution.
@@ -64,10 +81,7 @@ func exportSketchDXF(part *compdef.PartComponentDefinition, src, dst string, arg
 	if part.Sketches().Count() == 0 {
 		return fmt.Errorf("export: %q has no sketch to export to DXF", src)
 	}
-	version := types.DXFR2000
-	if len(args) == 3 {
-		version = types.DXFVersion(args[2])
-	}
+	version := dxfVersionArg(args)
 	n, err := exchange.ExportDXFFile(part.Sketches().Item(0), dst, version)
 	if err != nil {
 		return err
@@ -85,23 +99,15 @@ func cmdExportFlat(args []string, out io.Writer) error {
 		return fmt.Errorf("export-flat: expected <src.opd> <out.dxf> [r2000|r2018], got %d arg(s)", len(args))
 	}
 	src, dst := args[0], args[1]
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
-	d, err := ws.Open(src, true)
+	part, err := openCLIPart(src)
 	if err != nil {
-		return fmt.Errorf("export-flat: open %q: %w", src, err)
-	}
-	part, ok := d.Content().(*compdef.PartComponentDefinition)
-	if !ok {
-		return fmt.Errorf("export-flat: %q is not a part document", src)
+		return fmt.Errorf("export-flat: %w", err)
 	}
 	flat, err := part.Unfold()
 	if err != nil {
 		return fmt.Errorf("export-flat: %w", err)
 	}
-	version := types.DXFR2000
-	if len(args) == 3 {
-		version = types.DXFVersion(args[2])
-	}
+	version := dxfVersionArg(args)
 	n, err := exchange.ExportFlatPatternDXFFile(flat, dst, exchange.FlatExportLayers{}, version)
 	if err != nil {
 		return err

--- a/cmd/oblikovati-cli/cmd_export_test.go
+++ b/cmd/oblikovati-cli/cmd_export_test.go
@@ -17,90 +17,74 @@ import (
 	"oblikovati.org/persistence"
 )
 
-// writeCLIPartWithSketch saves a part document carrying one sketch with a single line, for
-// the DXF-export CLI test.
-func writeCLIPartWithSketch(t *testing.T, dir string) string {
+// saveCLIPart builds a part with build and saves it to dir/<name>, returning the path — the
+// shared fixture for the DXF-export CLI tests.
+func saveCLIPart(t *testing.T, dir, name string, build func(*compdef.PartComponentDefinition)) string {
 	t.Helper()
-	opd := filepath.Join(dir, "plate.opd")
+	opd := filepath.Join(dir, name)
 	ws := doc.NewWorkspace(persistence.NewPackageStore())
 	d, err := compdef.AddPart(ws, opd, true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
 	}
-	part := d.Content().(*compdef.PartComponentDefinition)
-	sk := part.Sketches().Add(sketch.XYPlane())
-	sk.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(5, 5))
+	build(d.Content().(*compdef.PartComponentDefinition))
 	if err := ws.Save(d); err != nil {
 		t.Fatalf("save: %v", err)
 	}
 	return opd
 }
 
-// writeCLISheetMetalPart saves a sheet-metal part with a square base face, for the
-// flat-pattern DXF export CLI test.
-func writeCLISheetMetalPart(t *testing.T, dir string) string {
+// runCLIExport runs an export subcommand and returns its stdout plus the written DXF's contents.
+func runCLIExport(t *testing.T, dxfPath string, args ...string) (stdout, dxf string) {
 	t.Helper()
-	opd := filepath.Join(dir, "tray.opd")
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
-	d, err := compdef.AddPart(ws, opd, true)
+	out, err := runCLI(t, args...)
 	if err != nil {
-		t.Fatalf("AddPart: %v", err)
+		t.Fatalf("%v: %v", args, err)
 	}
-	part := d.Content().(*compdef.PartComponentDefinition)
-	if _, err := part.EnableSheetMetal(); err != nil {
-		t.Fatalf("EnableSheetMetal: %v", err)
+	data, err := os.ReadFile(dxfPath)
+	if err != nil {
+		t.Fatalf("expected %s on disk: %v", dxfPath, err)
 	}
-	sk := part.Sketches().Add(sketch.XYPlane())
-	sk.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 4))
-	feature.NewSheetMetalFaceFeatures(part.Features()).Add(&feature.SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Operation: ops.NewBody})
-	part.Recompute()
-	if err := ws.Save(d); err != nil {
-		t.Fatalf("save: %v", err)
+	return out, string(data)
+}
+
+// TestCLIExportSketchDXF exports a part's sketch to a .dxf at a chosen version via the CLI.
+func TestCLIExportSketchDXF(t *testing.T) {
+	dir := t.TempDir()
+	opd := saveCLIPart(t, dir, "plate.opd", func(p *compdef.PartComponentDefinition) {
+		p.Sketches().Add(sketch.XYPlane()).Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(5, 5))
+	})
+	dxfPath := filepath.Join(dir, "plate.dxf")
+
+	out, data := runCLIExport(t, dxfPath, "export", opd, dxfPath, "r2018")
+	if !strings.Contains(out, "curves") || !strings.Contains(out, "r2018") {
+		t.Errorf("export output = %q, want curve count + r2018", out)
 	}
-	return opd
+	if !strings.Contains(data, "AC1032") || !strings.Contains(data, "\nLINE\n") {
+		t.Errorf("exported DXF missing AC1032 header or LINE entity")
+	}
 }
 
 // TestCLIExportFlat develops a sheet-metal part's flat pattern to DXF via the CLI, asserting the
 // outline lands on the Outline layer.
 func TestCLIExportFlat(t *testing.T) {
 	dir := t.TempDir()
-	opd := writeCLISheetMetalPart(t, dir)
+	opd := saveCLIPart(t, dir, "tray.opd", func(p *compdef.PartComponentDefinition) {
+		if _, err := p.EnableSheetMetal(); err != nil {
+			t.Fatalf("EnableSheetMetal: %v", err)
+		}
+		sk := p.Sketches().Add(sketch.XYPlane())
+		sk.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 4))
+		feature.NewSheetMetalFaceFeatures(p.Features()).Add(&feature.SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Operation: ops.NewBody})
+		p.Recompute()
+	})
 	dxfPath := filepath.Join(dir, "tray-flat.dxf")
 
-	out, err := runCLI(t, "export-flat", opd, dxfPath, "r2018")
-	if err != nil {
-		t.Fatalf("export-flat: %v", err)
-	}
+	out, data := runCLIExport(t, dxfPath, "export-flat", opd, dxfPath, "r2018")
 	if !strings.Contains(out, "flat pattern") || !strings.Contains(out, "r2018") {
 		t.Errorf("export-flat output = %q, want flat-pattern entity count + r2018", out)
 	}
-	data, err := os.ReadFile(dxfPath)
-	if err != nil {
-		t.Fatalf("expected %s on disk: %v", dxfPath, err)
-	}
-	if !strings.Contains(string(data), "\n2\nOutline\n") || !strings.Contains(string(data), "\nLINE\n") {
+	if !strings.Contains(data, "\n2\nOutline\n") || !strings.Contains(data, "\nLINE\n") {
 		t.Errorf("exported flat DXF missing the Outline layer or outline geometry")
-	}
-}
-
-// TestCLIExportSketchDXF exports a part's sketch to a .dxf at a chosen version via the CLI.
-func TestCLIExportSketchDXF(t *testing.T) {
-	dir := t.TempDir()
-	opd := writeCLIPartWithSketch(t, dir)
-	dxfPath := filepath.Join(dir, "plate.dxf")
-
-	out, err := runCLI(t, "export", opd, dxfPath, "r2018")
-	if err != nil {
-		t.Fatalf("export dxf: %v", err)
-	}
-	if !strings.Contains(out, "curves") || !strings.Contains(out, "r2018") {
-		t.Errorf("export output = %q, want curve count + r2018", out)
-	}
-	data, err := os.ReadFile(dxfPath)
-	if err != nil {
-		t.Fatalf("expected %s on disk: %v", dxfPath, err)
-	}
-	if !strings.Contains(string(data), "AC1032") || !strings.Contains(string(data), "\nLINE\n") {
-		t.Errorf("exported DXF missing AC1032 header or LINE entity")
 	}
 }

--- a/cmd/oblikovati-cli/cmd_export_test.go
+++ b/cmd/oblikovati-cli/cmd_export_test.go
@@ -51,14 +51,7 @@ func writeCLISheetMetalPart(t *testing.T, dir string) string {
 		t.Fatalf("EnableSheetMetal: %v", err)
 	}
 	sk := part.Sketches().Add(sketch.XYPlane())
-	c0 := sk.Points().Add(gmath.P2(0, 0))
-	c1 := sk.Points().Add(gmath.P2(4, 0))
-	c2 := sk.Points().Add(gmath.P2(4, 4))
-	c3 := sk.Points().Add(gmath.P2(0, 4))
-	sk.Lines().Add(c0, c1)
-	sk.Lines().Add(c1, c2)
-	sk.Lines().Add(c2, c3)
-	sk.Lines().Add(c3, c0)
+	sk.AddRectangleByCorners(gmath.P2(0, 0), gmath.P2(4, 4))
 	feature.NewSheetMetalFaceFeatures(part.Features()).Add(&feature.SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Operation: ops.NewBody})
 	part.Recompute()
 	if err := ws.Save(d); err != nil {

--- a/cmd/oblikovati-cli/cmd_export_test.go
+++ b/cmd/oblikovati-cli/cmd_export_test.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"oblikovati.org/kernel/ops"
 	gmath "oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/persistence"
 )
@@ -32,6 +34,60 @@ func writeCLIPartWithSketch(t *testing.T, dir string) string {
 		t.Fatalf("save: %v", err)
 	}
 	return opd
+}
+
+// writeCLISheetMetalPart saves a sheet-metal part with a square base face, for the
+// flat-pattern DXF export CLI test.
+func writeCLISheetMetalPart(t *testing.T, dir string) string {
+	t.Helper()
+	opd := filepath.Join(dir, "tray.opd")
+	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	d, err := compdef.AddPart(ws, opd, true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	part := d.Content().(*compdef.PartComponentDefinition)
+	if _, err := part.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	sk := part.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(gmath.P2(0, 0))
+	c1 := sk.Points().Add(gmath.P2(4, 0))
+	c2 := sk.Points().Add(gmath.P2(4, 4))
+	c3 := sk.Points().Add(gmath.P2(0, 4))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewSheetMetalFaceFeatures(part.Features()).Add(&feature.SheetMetalFaceDefinition{Sketch: sk, ProfileIndex: 0, Operation: ops.NewBody})
+	part.Recompute()
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	return opd
+}
+
+// TestCLIExportFlat develops a sheet-metal part's flat pattern to DXF via the CLI, asserting the
+// outline lands on the Outline layer.
+func TestCLIExportFlat(t *testing.T) {
+	dir := t.TempDir()
+	opd := writeCLISheetMetalPart(t, dir)
+	dxfPath := filepath.Join(dir, "tray-flat.dxf")
+
+	out, err := runCLI(t, "export-flat", opd, dxfPath, "r2018")
+	if err != nil {
+		t.Fatalf("export-flat: %v", err)
+	}
+	if !strings.Contains(out, "flat pattern") || !strings.Contains(out, "r2018") {
+		t.Errorf("export-flat output = %q, want flat-pattern entity count + r2018", out)
+	}
+	data, err := os.ReadFile(dxfPath)
+	if err != nil {
+		t.Fatalf("expected %s on disk: %v", dxfPath, err)
+	}
+	if !strings.Contains(string(data), "\n2\nOutline\n") || !strings.Contains(string(data), "\nLINE\n") {
+		t.Errorf("exported flat DXF missing the Outline layer or outline geometry")
+	}
 }
 
 // TestCLIExportSketchDXF exports a part's sketch to a .dxf at a chosen version via the CLI.

--- a/cmd/oblikovati-cli/main.go
+++ b/cmd/oblikovati-cli/main.go
@@ -45,6 +45,8 @@ func run(args []string, out io.Writer) error {
 		return cmdImport(args[1:], out)
 	case "export":
 		return cmdExport(args[1:], out)
+	case "export-flat":
+		return cmdExportFlat(args[1:], out)
 	case "script":
 		return cmdScript(args[1:], out)
 	case "version":
@@ -55,7 +57,7 @@ func run(args []string, out io.Writer) error {
 		fmt.Fprintln(out, usage)
 		return nil
 	default:
-		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|import|export|script|version|check-updates)", args[0])
+		return fmt.Errorf("oblikovati-cli: unknown command %q (want new|open|info|save-as|import|export|export-flat|script|version|check-updates)", args[0])
 	}
 }
 
@@ -69,6 +71,7 @@ usage:
   oblikovati-cli save-as <src> <dst>
   oblikovati-cli import <mesh-file.stl|.obj|.3mf> <dst.opd>
   oblikovati-cli export <src.opd> <mesh-file.stl|.obj|.3mf> [low|medium|high]
+  oblikovati-cli export-flat <src.opd> <out.dxf> [r2000|r2018]
   oblikovati-cli script run <file.lua> [--doc in.opd] [--save out.opd]
   oblikovati-cli version
   oblikovati-cli check-updates`

--- a/kernel/exchange/drawing/entity.go
+++ b/kernel/exchange/drawing/entity.go
@@ -34,13 +34,14 @@ const (
 	KindLwPolyline
 	KindSpline
 	KindInsert
+	KindText
 )
 
 // kindNames maps each Kind to its canonical (DXF) entity name.
 var kindNames = map[Kind]string{
 	KindUnknown: "UNKNOWN", KindLine: "LINE", KindCircle: "CIRCLE", KindArc: "ARC",
 	KindPoint: "POINT", KindEllipse: "ELLIPSE", KindLwPolyline: "LWPOLYLINE",
-	KindSpline: "SPLINE", KindInsert: "INSERT",
+	KindSpline: "SPLINE", KindInsert: "INSERT", KindText: "TEXT",
 }
 
 // String returns the canonical entity name, or "UNKNOWN" for an unrecognised kind.
@@ -63,6 +64,7 @@ type Drawing struct {
 // Line is a straight segment between two 3D points.
 type Line struct {
 	Handle uint64
+	Layer  string // target layer name ("" ⇒ the default "0" layer)
 	Start  [3]float64
 	End    [3]float64
 }
@@ -73,6 +75,7 @@ func (e *Line) Kind() Kind           { return KindLine }
 // Circle is a full circle: a centre, radius and normal (extrusion) direction.
 type Circle struct {
 	Handle uint64
+	Layer  string
 	Center [3]float64
 	Radius float64
 	Normal [3]float64
@@ -84,6 +87,7 @@ func (e *Circle) Kind() Kind           { return KindCircle }
 // Arc is a circular arc, angles in radians measured in the plane of Normal.
 type Arc struct {
 	Handle     uint64
+	Layer      string
 	Center     [3]float64
 	Radius     float64
 	StartAngle float64
@@ -97,6 +101,7 @@ func (e *Arc) Kind() Kind           { return KindArc }
 // Point is a single model-space point.
 type Point struct {
 	Handle   uint64
+	Layer    string
 	Position [3]float64
 }
 
@@ -107,6 +112,7 @@ func (e *Point) Kind() Kind           { return KindPoint }
 // relative to Center; AxisRatio is minor/major; angles are parametric, in radians.
 type Ellipse struct {
 	Handle     uint64
+	Layer      string
 	Center     [3]float64
 	MajorAxis  [3]float64
 	AxisRatio  float64
@@ -123,6 +129,7 @@ func (e *Ellipse) Kind() Kind           { return KindEllipse }
 // planar at Elevation, oriented by Normal. Closed joins the last vertex back to the first.
 type LwPolyline struct {
 	Handle    uint64
+	Layer     string
 	Closed    bool
 	Elevation float64
 	Points    [][2]float64
@@ -138,6 +145,7 @@ func (e *LwPolyline) Kind() Kind           { return KindLwPolyline }
 // whichever is present).
 type Spline struct {
 	Handle        uint64
+	Layer         string
 	Degree        int
 	Closed        bool
 	Rational      bool
@@ -166,3 +174,19 @@ type Insert struct {
 
 func (e *Insert) EntityHandle() uint64 { return e.Handle }
 func (e *Insert) Kind() Kind           { return KindInsert }
+
+// Text is a single-line annotation string placed at Position, of the given Height (drawing
+// units) and Rotation (radians, about Z). It carries no geometry of its own — exporters use
+// it to tag drawings (e.g. a flat pattern's punch tokens). Importers that only rebuild curve
+// geometry skip it.
+type Text struct {
+	Handle   uint64
+	Layer    string
+	Position [3]float64
+	Height   float64
+	Value    string
+	Rotation float64
+}
+
+func (e *Text) EntityHandle() uint64 { return e.Handle }
+func (e *Text) Kind() Kind           { return KindText }

--- a/kernel/exchange/dxf/encode.go
+++ b/kernel/exchange/dxf/encode.go
@@ -3,6 +3,7 @@
 package dxf
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -17,19 +18,36 @@ import (
 //
 //	data, err := dxf.Encode(dr, dxf.R2000)
 func Encode(dr *drawing.Drawing, version Version) ([]byte, error) {
-	h := newEncHandles()
+	layers := extraLayerNames(dr.Entities)
+	h := newEncHandles(len(layers))
 	for range dr.Entities {
 		h.alloc() // reserve an entity handle per entity (assigned in order on write)
 	}
 	w := &tagWriter{}
 	writeHeader(w, version, dr.Units, h.next+1)
 	writeClasses(w, version)
-	writeTables(w, h)
+	writeTables(w, h, layers)
 	writeBlocks(w, h)
 	writeEntitiesSection(w, dr.Entities, h)
 	writeObjects(w, h)
 	w.tag(0, "EOF")
 	return []byte(w.string()), nil
+}
+
+// extraLayerNames returns the distinct non-default layer names the entities reference, sorted
+// for a stable output. The "0" layer is always present and written separately, so it is
+// excluded here.
+func extraLayerNames(entities []drawing.Entity) []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, e := range entities {
+		if l := layerOf(e); l != "" && l != "0" && !seen[l] {
+			seen[l] = true
+			names = append(names, l)
+		}
+	}
+	sort.Strings(names)
+	return names
 }
 
 // writeHeader emits the HEADER section with the variables a reader needs: the version, the

--- a/kernel/exchange/dxf/encode_layers_test.go
+++ b/kernel/exchange/dxf/encode_layers_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dxf
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/exchange/drawing"
+)
+
+// TestEncodeNamedLayers checks that entities on custom layers emit a LAYER record per distinct
+// layer (plus the default "0"), tag each entity with its layer (group code 8), and that a Text
+// entity is written — the surface a flat-pattern export needs (outline / bend / punch layers).
+func TestEncodeNamedLayers(t *testing.T) {
+	in := &drawing.Drawing{Units: drawing.INSCentimetres, Entities: []drawing.Entity{
+		&drawing.Line{Layer: "Outline", Start: [3]float64{0, 0, 0}, End: [3]float64{10, 0, 0}},
+		&drawing.Line{Layer: "BendUp", Start: [3]float64{0, 5, 0}, End: [3]float64{10, 5, 0}},
+		&drawing.Circle{Layer: "Punches", Center: [3]float64{5, 2, 0}, Radius: 1, Normal: [3]float64{0, 0, 1}},
+		&drawing.Text{Layer: "Punches", Position: [3]float64{5, 2, 0}, Height: 0.5, Value: "PUNCH-8"},
+	}}
+	data, err := Encode(in, R2000)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out := string(data)
+
+	// One LAYER record per distinct layer name (group code "2" followed by the name on its own line).
+	for _, layer := range []string{"0", "Outline", "BendUp", "Punches"} {
+		if !strings.Contains(out, "\n2\n"+layer+"\n") {
+			t.Errorf("LAYER table missing a record for %q", layer)
+		}
+	}
+	// Each entity tags its layer (group code 8).
+	for _, layer := range []string{"Outline", "BendUp", "Punches"} {
+		if !strings.Contains(out, "\n8\n"+layer+"\n") {
+			t.Errorf("no entity tagged on layer %q (group code 8)", layer)
+		}
+	}
+	// The TEXT token is written with its string.
+	if !strings.Contains(out, "\n0\nTEXT\n") || !strings.Contains(out, "\n1\nPUNCH-8\n") {
+		t.Error("TEXT token not emitted")
+	}
+
+	// The geometry still decodes (the lines/circle survive; TEXT is not a curve and is skipped).
+	dr, _, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got := len(dr.Entities); got < 3 {
+		t.Errorf("decoded %d curve entities, want >= 3 (the lines + circle)", got)
+	}
+}

--- a/kernel/exchange/dxf/encodeentities.go
+++ b/kernel/exchange/dxf/encodeentities.go
@@ -10,21 +10,22 @@ import "oblikovati.org/kernel/exchange/drawing"
 //
 //nolint:funlen // one-case-per-entity-type encode dispatch (inverse of decodeEntity).
 func encodeEntity(w *tagWriter, e drawing.Entity, handle, owner uint64) {
+	layer := layerOf(e)
 	switch g := e.(type) {
 	case *drawing.Line:
-		entityHead(w, "LINE", handle, owner, "AcDbLine")
+		entityHead(w, "LINE", handle, owner, "AcDbLine", layer)
 		w.coord(10, g.Start)
 		w.coord(11, g.End)
 	case *drawing.Circle:
-		entityHead(w, "CIRCLE", handle, owner, "AcDbCircle")
+		entityHead(w, "CIRCLE", handle, owner, "AcDbCircle", layer)
 		w.coord(10, g.Center)
 		w.real(40, g.Radius)
 	case *drawing.Point:
-		entityHead(w, "POINT", handle, owner, "AcDbPoint")
+		entityHead(w, "POINT", handle, owner, "AcDbPoint", layer)
 		w.coord(10, g.Position)
 	case *drawing.Arc:
 		// ARC carries two subclass markers (AcDbCircle then AcDbArc); angles are DEGREES.
-		entityHead(w, "ARC", handle, owner, "AcDbCircle")
+		entityHead(w, "ARC", handle, owner, "AcDbCircle", layer)
 		w.coord(10, g.Center)
 		w.real(40, g.Radius)
 		w.tag(100, "AcDbArc")
@@ -32,7 +33,7 @@ func encodeEntity(w *tagWriter, e drawing.Entity, handle, owner uint64) {
 		w.real(51, radToDeg(g.EndAngle))
 	case *drawing.Ellipse:
 		// ELLIPSE start/end parameters are RADIANS — written unconverted, unlike ARC.
-		entityHead(w, "ELLIPSE", handle, owner, "AcDbEllipse")
+		entityHead(w, "ELLIPSE", handle, owner, "AcDbEllipse", layer)
 		w.coord(10, g.Center)
 		w.coord(11, g.MajorAxis)
 		w.coord(210, normalOrZ(g.Normal))
@@ -40,22 +41,68 @@ func encodeEntity(w *tagWriter, e drawing.Entity, handle, owner uint64) {
 		w.real(41, g.StartAngle)
 		w.real(42, g.EndAngle)
 	case *drawing.LwPolyline:
-		entityHead(w, "LWPOLYLINE", handle, owner, "AcDbPolyline")
-		w.integer(90, len(g.Points))
-		w.integer(70, closedFlag(g.Closed))
-		if g.Elevation != 0 {
-			w.real(38, g.Elevation)
-		}
-		for i, pt := range g.Points {
-			w.real(10, pt[0])
-			w.real(20, pt[1])
-			if i < len(g.Bulges) && g.Bulges[i] != 0 {
-				w.real(42, g.Bulges[i]) // bulge attaches to the vertex it follows
-			}
-		}
+		encodeLwPolyline(w, g, handle, owner, layer)
 	case *drawing.Spline:
-		encodeSpline(w, g, handle, owner)
+		encodeSpline(w, g, handle, owner, layer)
+	case *drawing.Text:
+		encodeText(w, g, handle, owner, layer)
 	}
+}
+
+// encodeLwPolyline writes an LWPOLYLINE: vertex count, closed flag, optional elevation, then
+// each vertex with its trailing bulge (0 = straight to the next).
+func encodeLwPolyline(w *tagWriter, g *drawing.LwPolyline, handle, owner uint64, layer string) {
+	entityHead(w, "LWPOLYLINE", handle, owner, "AcDbPolyline", layer)
+	w.integer(90, len(g.Points))
+	w.integer(70, closedFlag(g.Closed))
+	if g.Elevation != 0 {
+		w.real(38, g.Elevation)
+	}
+	for i, pt := range g.Points {
+		w.real(10, pt[0])
+		w.real(20, pt[1])
+		if i < len(g.Bulges) && g.Bulges[i] != 0 {
+			w.real(42, g.Bulges[i]) // bulge attaches to the vertex it follows
+		}
+	}
+}
+
+// encodeText writes a single-line TEXT label. It repeats the AcDbText subclass after the
+// geometry (the second marker is the alignment block); a minimal label needs only the
+// insertion point, height and string.
+func encodeText(w *tagWriter, g *drawing.Text, handle, owner uint64, layer string) {
+	entityHead(w, "TEXT", handle, owner, "AcDbText", layer)
+	w.coord(10, g.Position)
+	w.real(40, g.Height)
+	w.tag(1, g.Value)
+	if g.Rotation != 0 {
+		w.real(50, radToDeg(g.Rotation))
+	}
+	w.tag(100, "AcDbText")
+}
+
+// layerOf returns an entity's target layer name (empty for a geometry that carries none),
+// which entityHead maps to the default "0" layer.
+func layerOf(e drawing.Entity) string {
+	switch g := e.(type) {
+	case *drawing.Line:
+		return g.Layer
+	case *drawing.Circle:
+		return g.Layer
+	case *drawing.Arc:
+		return g.Layer
+	case *drawing.Point:
+		return g.Layer
+	case *drawing.Ellipse:
+		return g.Layer
+	case *drawing.LwPolyline:
+		return g.Layer
+	case *drawing.Spline:
+		return g.Layer
+	case *drawing.Text:
+		return g.Layer
+	}
+	return ""
 }
 
 // closedFlag is the LWPOLYLINE 70 flag value for an open/closed polyline.
@@ -72,8 +119,8 @@ func closedFlag(closed bool) int {
 // AutoCAD accepts rather than a knot-less spline.
 //
 //nolint:funlen // sequential SPLINE field writes across header, knots, control and fit points.
-func encodeSpline(w *tagWriter, s *drawing.Spline, handle, owner uint64) {
-	entityHead(w, "SPLINE", handle, owner, "AcDbSpline")
+func encodeSpline(w *tagWriter, s *drawing.Spline, handle, owner uint64, layer string) {
+	entityHead(w, "SPLINE", handle, owner, "AcDbSpline", layer)
 	degree := splineDegree(s)
 	knots := s.Knots
 	if len(knots) == 0 && len(s.ControlPoints) >= 2 {
@@ -149,12 +196,20 @@ func normalOrZ(n [3]float64) [3]float64 {
 
 // entityHead writes the common ENTITIES preamble shared by every entity: the type marker,
 // the handle, the owner (the *Model_Space block record), the AcDbEntity subclass, the layer
-// (always "0" — the geometry carries no layer), and the type-specific subclass marker.
-func entityHead(w *tagWriter, typ string, handle, owner uint64, subclass string) {
+// (the entity's named layer, or "0" when it carries none), and the type-specific subclass.
+func entityHead(w *tagWriter, typ string, handle, owner uint64, subclass, layer string) {
 	w.tag(0, typ)
 	w.handle(5, handle)
 	w.handle(330, owner)
 	w.tag(100, "AcDbEntity")
-	w.tag(8, "0")
+	w.tag(8, layerOr0(layer))
 	w.tag(100, subclass)
+}
+
+// layerOr0 returns the layer name, or the default "0" layer when empty.
+func layerOr0(layer string) string {
+	if layer == "" {
+		return "0"
+	}
+	return layer
 }

--- a/kernel/exchange/dxf/encodetables.go
+++ b/kernel/exchange/dxf/encodetables.go
@@ -10,12 +10,12 @@ package dxf
 // dxf2dwg → dwgread oracle.
 
 // writeTables emits the TABLES section with the nine standard symbol tables.
-func writeTables(w *tagWriter, h *encHandles) {
+func writeTables(w *tagWriter, h *encHandles, layers []string) {
 	w.tag(0, "SECTION")
 	w.tag(2, "TABLES")
 	writeVportTable(w, h)
 	writeLtypeTable(w, h)
-	writeLayerTable(w, h)
+	writeLayerTable(w, h, layers)
 	writeStyleTable(w, h)
 	writeEmptyTable(w, "VIEW", h.viewTable)
 	writeEmptyTable(w, "UCS", h.ucsTable)
@@ -112,16 +112,25 @@ func writeLtype(w *tagWriter, handle, owner uint64, name, desc string) {
 	w.real(40, 0)     // pattern length
 }
 
-// writeLayerTable writes the LAYER table with the default "0" layer.
-func writeLayerTable(w *tagWriter, h *encHandles) {
-	tableHead(w, "LAYER", h.layerTable, 1)
-	recordHead(w, "LAYER", h.layer0, h.layerTable, "AcDbLayerTableRecord")
-	w.tag(2, "0")
+// writeLayerTable writes the LAYER table: the default "0" layer plus one record per custom
+// layer the entities reference (handles from h.extraLayers, names in the same order).
+func writeLayerTable(w *tagWriter, h *encHandles, layers []string) {
+	tableHead(w, "LAYER", h.layerTable, 1+len(layers))
+	writeLayerRecord(w, h.layer0, h.layerTable, "0")
+	for i, name := range layers {
+		writeLayerRecord(w, h.extraLayers[i], h.layerTable, name)
+	}
+	w.tag(0, "ENDTAB")
+}
+
+// writeLayerRecord writes one LAYER record (white, continuous, default lineweight).
+func writeLayerRecord(w *tagWriter, handle, owner uint64, name string) {
+	recordHead(w, "LAYER", handle, owner, "AcDbLayerTableRecord")
+	w.tag(2, name)
 	w.integer(70, 0)
 	w.integer(62, 7) // colour white
 	w.tag(6, "Continuous")
 	w.integer(370, -3) // lineweight by default
-	w.tag(0, "ENDTAB")
 }
 
 // writeStyleTable writes the STYLE table with the "Standard" text style.

--- a/kernel/exchange/dxf/handles.go
+++ b/kernel/exchange/dxf/handles.go
@@ -21,6 +21,10 @@ type encHandles struct {
 	layer0, styleStandard, appidACAD, dimstyleStd uint64
 	modelSpaceBR, paperSpaceBR                    uint64
 
+	// extraLayers holds one handle per custom (non-"0") layer record, in the order their
+	// names are written; allocated before entityBase so entity handles stay sequential.
+	extraLayers []uint64
+
 	// Block definitions (BLOCK/ENDBLK markers).
 	modelBlock, modelEndblk, paperBlock, paperEndblk uint64
 
@@ -41,7 +45,7 @@ func (h *encHandles) alloc() uint64 {
 // output is stable) and sets entityBase to the first handle the entities will use.
 //
 //nolint:funlen // one allocation per fixed object; the list is the object graph.
-func newEncHandles() *encHandles {
+func newEncHandles(extraLayers int) *encHandles {
 	h := &encHandles{}
 	h.blockRecordTable = h.alloc()
 	h.vportTable = h.alloc()
@@ -70,6 +74,13 @@ func newEncHandles() *encHandles {
 	h.paperEndblk = h.alloc()
 
 	h.rootDict = h.alloc()
+
+	// Custom layer records take handles before the entities so entity handles stay a
+	// contiguous run from entityBase (the decoder and $HANDSEED rely on the ordering).
+	h.extraLayers = make([]uint64, extraLayers)
+	for i := range h.extraLayers {
+		h.extraLayers[i] = h.alloc()
+	}
 
 	h.entityBase = h.next + 1
 	return h

--- a/model/compdef/sheet_metal_flat.go
+++ b/model/compdef/sheet_metal_flat.go
@@ -4,7 +4,9 @@ package compdef
 
 import (
 	"fmt"
+	stdmath "math"
 
+	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
@@ -27,7 +29,57 @@ func (d *PartComponentDefinition) Unfold() (*feature.FlatPattern, error) {
 		return nil, fmt.Errorf("unfold: the part has no base Face to develop")
 	}
 	def := base.Definition()
-	return feature.BuildFlatPattern(def.Sketch, def.ProfileIndex, d.sheetMetal.Thickness(), d.flatTabs())
+	fp, err := feature.BuildFlatPattern(def.Sketch, def.ProfileIndex, d.sheetMetal.Thickness(), d.flatTabs())
+	if err != nil {
+		return nil, err
+	}
+	fp.Punches = d.flatPunches(def.Sketch.Plane())
+	return fp, nil
+}
+
+// flatPunches develops every healthy punch feature whose sketch is coplanar with the base into a
+// flat punch representation (its outline + the feature name as the token). A punch on a flange
+// develops through the fold and is a follow-up, so it is skipped here.
+func (d *PartComponentDefinition) flatPunches(basePlane sketch.Plane) []feature.FlatPunch {
+	fs := d.features
+	var out []feature.FlatPunch
+	for i := 0; i < fs.Count(); i++ {
+		pf := fs.Item(i)
+		punch, ok := pf.Definition().(*feature.SheetMetalPunchFeature)
+		if !ok || pf.Suppressed() || !pf.Health().OK() {
+			continue
+		}
+		out = append(out, developPunch(pf, punch, basePlane)...)
+	}
+	return out
+}
+
+// developPunch projects each closed profile of a coplanar punch into the base plane as a flat
+// punch outline tagged with the feature name.
+func developPunch(pf *feature.PartFeature, punch *feature.SheetMetalPunchFeature, basePlane sketch.Plane) []feature.FlatPunch {
+	sk := punch.Definition().Sketch
+	if stdmath.Abs(sk.Plane().Normal().AsVector().Dot(basePlane.Normal().AsVector())) < 0.999 {
+		return nil // not coplanar: a flange punch, developed through the fold — a follow-up
+	}
+	profs := sk.Profiles()
+	out := make([]feature.FlatPunch, 0, profs.Count())
+	for j := 0; j < profs.Count(); j++ {
+		out = append(out, feature.FlatPunch{
+			Outline: projectToPlane(profs.Item(j).OuterLoop().Polygon(), sk.Plane(), basePlane),
+			Token:   pf.Name(),
+		})
+	}
+	return out
+}
+
+// projectToPlane maps a loop's 2D points from one plane's frame into another's (lift to model
+// space, drop back into the target plane) — for a coplanar punch this is its outline in base 2D.
+func projectToPlane(poly []math.Point2, from, to sketch.Plane) []math.Point2 {
+	out := make([]math.Point2, len(poly))
+	for i, p := range poly {
+		out[i] = to.ToSketch(from.ToModel(p))
+	}
+	return out
 }
 
 // baseFace returns the first sheet-metal base Face feature — the flat region the development

--- a/model/compdef/sheet_metal_flat_test.go
+++ b/model/compdef/sheet_metal_flat_test.go
@@ -73,14 +73,7 @@ func TestUnfoldDevelopsWatertightFlat(t *testing.T) {
 func TestUnfoldDevelopsPunchRepresentation(t *testing.T) {
 	d, _ := sheetWithFlange(t)
 	sk := d.Sketches().Add(sketch.XYPlane())
-	p0 := sk.Points().Add(gmath.P2(1, 1))
-	p1 := sk.Points().Add(gmath.P2(2, 1))
-	p2 := sk.Points().Add(gmath.P2(2, 2))
-	p3 := sk.Points().Add(gmath.P2(1, 2))
-	sk.Lines().Add(p0, p1)
-	sk.Lines().Add(p1, p2)
-	sk.Lines().Add(p2, p3)
-	sk.Lines().Add(p3, p0)
+	sk.AddRectangleByCorners(gmath.P2(1, 1), gmath.P2(2, 2))
 	punch := feature.NewSheetMetalPunchFeatures(d.Features()).Add(&feature.SheetMetalPunchDefinition{Sketch: sk})
 	d.Recompute()
 

--- a/model/compdef/sheet_metal_flat_test.go
+++ b/model/compdef/sheet_metal_flat_test.go
@@ -68,6 +68,37 @@ func TestUnfoldDevelopsWatertightFlat(t *testing.T) {
 	}
 }
 
+// TestUnfoldDevelopsPunchRepresentation a coplanar (base-plane) punch develops into a flat punch
+// representation: its outline projected into the base plane, tagged with the feature name (#378).
+func TestUnfoldDevelopsPunchRepresentation(t *testing.T) {
+	d, _ := sheetWithFlange(t)
+	sk := d.Sketches().Add(sketch.XYPlane())
+	p0 := sk.Points().Add(gmath.P2(1, 1))
+	p1 := sk.Points().Add(gmath.P2(2, 1))
+	p2 := sk.Points().Add(gmath.P2(2, 2))
+	p3 := sk.Points().Add(gmath.P2(1, 2))
+	sk.Lines().Add(p0, p1)
+	sk.Lines().Add(p1, p2)
+	sk.Lines().Add(p2, p3)
+	sk.Lines().Add(p3, p0)
+	punch := feature.NewSheetMetalPunchFeatures(d.Features()).Add(&feature.SheetMetalPunchDefinition{Sketch: sk})
+	d.Recompute()
+
+	fp, err := d.Unfold()
+	if err != nil {
+		t.Fatalf("Unfold: %v", err)
+	}
+	if len(fp.Punches) != 1 {
+		t.Fatalf("flat punches = %d, want 1 (the base-plane punch)", len(fp.Punches))
+	}
+	if fp.Punches[0].Token != punch.Name() {
+		t.Errorf("punch token = %q, want the feature name %q", fp.Punches[0].Token, punch.Name())
+	}
+	if len(fp.Punches[0].Outline) < 4 {
+		t.Errorf("punch outline = %d points, want >= 4 (the square profile)", len(fp.Punches[0].Outline))
+	}
+}
+
 // TestUnfoldDevelopsTabForOutOfPlaneFold a flange whose 3D fold direction leaves the base
 // plane (a flange folded off a bottom edge folds in −Z) must still develop a tab in the base
 // plane: the tab outward is derived from the base geometry, not the 3D fold vector. Regression

--- a/model/exchange/dxfexport.go
+++ b/model/exchange/dxfexport.go
@@ -19,14 +19,25 @@ import (
 //
 //	data, n, err := exchange.ExportDXF(sk, types.DXFR2018)
 func ExportDXF(sk *sketch.Sketch, version types.DXFVersion) ([]byte, int, error) {
-	dr := &drawing.Drawing{Entities: sketchToDrawing(sk), Units: drawing.INSCentimetres}
-	data, err := dxf.Encode(dr, dxfVersion(version))
-	return data, len(dr.Entities), err
+	return encodeDXF(sketchToDrawing(sk), version)
 }
 
 // ExportDXFFile writes ExportDXF's output to path, returning the number of curves written.
 func ExportDXFFile(sk *sketch.Sketch, path string, version types.DXFVersion) (int, error) {
-	data, n, err := ExportDXF(sk, version)
+	return writeDXFFile(sketchToDrawing(sk), path, version)
+}
+
+// encodeDXF encodes neutral drawing entities to DXF bytes of the given version (database units),
+// returning the bytes and the entity count — the shared core of every DXF exporter.
+func encodeDXF(entities []drawing.Entity, version types.DXFVersion) ([]byte, int, error) {
+	dr := &drawing.Drawing{Entities: entities, Units: drawing.INSCentimetres}
+	data, err := dxf.Encode(dr, dxfVersion(version))
+	return data, len(dr.Entities), err
+}
+
+// writeDXFFile encodes the entities and writes them to path, returning the entity count.
+func writeDXFFile(entities []drawing.Entity, path string, version types.DXFVersion) (int, error) {
+	data, n, err := encodeDXF(entities, version)
 	if err != nil {
 		return 0, err
 	}

--- a/model/exchange/flatpattern_export.go
+++ b/model/exchange/flatpattern_export.go
@@ -94,14 +94,42 @@ func flatOutlineEntities(flat *feature.FlatPattern, layer string) []drawing.Enti
 	return out
 }
 
-// flatPunchEntities emits each punch representation as its outline plus a TEXT token at the
-// centroid, both on the punch layer. The flat pattern carries no punch development yet (only
-// base + edge flanges are unfolded), so this is currently empty; it is the seam the punch
-// representation populates.
+// flatPunchEntities emits each punch representation as its closed outline plus a TEXT token at
+// the centroid, both on the punch layer — the manufacturing tag a CAM programmer reads.
 func flatPunchEntities(flat *feature.FlatPattern, layer string) []drawing.Entity {
-	_ = flat
-	_ = layer
-	return nil
+	var out []drawing.Entity
+	for _, p := range flat.Punches {
+		if len(p.Outline) < 2 {
+			continue
+		}
+		pts := make([][2]float64, len(p.Outline))
+		for i, q := range p.Outline {
+			pts[i] = [2]float64{float64(q.X), float64(q.Y)}
+		}
+		out = append(out, &drawing.LwPolyline{Layer: layer, Closed: true, Points: pts})
+		if p.Token != "" {
+			c, h := punchLabel(p.Outline)
+			out = append(out, &drawing.Text{Layer: layer, Position: [3]float64{c[0], c[1], 0}, Height: h, Value: p.Token})
+		}
+	}
+	return out
+}
+
+// punchLabel returns where to place a punch's token (the outline centroid) and a legible text
+// height (a fraction of the smaller bounding-box dimension, with a small floor).
+func punchLabel(outline []math.Point2) (centroid [2]float64, height float64) {
+	minX, minY := stdmath.Inf(1), stdmath.Inf(1)
+	maxX, maxY := stdmath.Inf(-1), stdmath.Inf(-1)
+	var sx, sy float64
+	for _, p := range outline {
+		x, y := float64(p.X), float64(p.Y)
+		sx, sy = sx+x, sy+y
+		minX, minY = stdmath.Min(minX, x), stdmath.Min(minY, y)
+		maxX, maxY = stdmath.Max(maxX, x), stdmath.Max(maxY, y)
+	}
+	n := float64(len(outline))
+	span := stdmath.Min(maxX-minX, maxY-minY)
+	return [2]float64{sx / n, sy / n}, stdmath.Max(0.3*span, flatTokenMinHeight)
 }
 
 // onPlaneAt reports whether p sits on the plane offset height h along normal n from origin
@@ -135,6 +163,8 @@ const (
 	flatPlaneTol = 1e-6
 	// flatParallelTol is the |normal·planeNormal| above which a face counts as in-plane (flat).
 	flatParallelTol = 0.999
+	// flatTokenMinHeight floors a punch token's text height (database units, cm).
+	flatTokenMinHeight = 0.1
 )
 
 // ExportFlatPatternDXF encodes a developed flat pattern as an ASCII DXF of the given version,

--- a/model/exchange/flatpattern_export.go
+++ b/model/exchange/flatpattern_export.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"fmt"
+	stdmath "math"
+	"os"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange/drawing"
+	"oblikovati.org/kernel/exchange/dxf"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// Flat-pattern DXF export (M13-F04, #378): a developed sheet-metal flat pattern written to DXF
+// with its outline, bend lines and punch tokens on separate named layers, so a CAM/laser/punch
+// programmer can pick the manufacturing geometry off the layers it expects. It reuses the DXF
+// codec (kernel/exchange/dxf) — only the flat → neutral-drawing conversion is new here.
+
+// FlatExportLayers names the DXF layers the flat pattern's geometry classes land on. A zero
+// value (empty names) resolves to the defaults via withDefaults.
+type FlatExportLayers struct {
+	Outline  string // the flat footprint boundary
+	BendUp   string // fold-up bend lines
+	BendDown string // fold-down bend lines
+	Punches  string // punch outlines + tokens
+}
+
+// DefaultFlatExportLayers is the layer scheme used when the caller passes none.
+func DefaultFlatExportLayers() FlatExportLayers {
+	return FlatExportLayers{Outline: "Outline", BendUp: "Bend-Up", BendDown: "Bend-Down", Punches: "Punches"}
+}
+
+// withDefaults fills any empty layer name from the default scheme.
+func (l FlatExportLayers) withDefaults() FlatExportLayers {
+	d := DefaultFlatExportLayers()
+	if l.Outline == "" {
+		l.Outline = d.Outline
+	}
+	if l.BendUp == "" {
+		l.BendUp = d.BendUp
+	}
+	if l.BendDown == "" {
+		l.BendDown = d.BendDown
+	}
+	if l.Punches == "" {
+		l.Punches = d.Punches
+	}
+	return l
+}
+
+// FlatPatternToDrawing converts a developed flat pattern into the neutral drawing model: the
+// footprint outline on the Outline layer and every fold line on the Bend-Up/Bend-Down layer
+// per its direction. Punch tokens are added by the caller from the flat's punch representation.
+func FlatPatternToDrawing(flat *feature.FlatPattern, layers FlatExportLayers) []drawing.Entity {
+	layers = layers.withDefaults()
+	out := flatOutlineEntities(flat, layers.Outline)
+	for _, b := range flat.Bends {
+		layer := layers.BendUp
+		if b.FoldDown {
+			layer = layers.BendDown
+		}
+		out = append(out, &drawing.Line{Layer: layer, Start: point2to3(b.A), End: point2to3(b.B)})
+	}
+	return append(out, flatPunchEntities(flat, layers.Punches)...)
+}
+
+// flatOutlineEntities emits the flat footprint as line segments on the outline layer: the body's
+// edges that lie on the top plane and bound exactly one in-plane (top) face — i.e. the boundary
+// between a flat top face and a vertical wall. A seam between two coplanar top faces (where a tab
+// meets the base) bounds two top faces and is skipped, so only the silhouette is drawn.
+func flatOutlineEntities(flat *feature.FlatPattern, layer string) []drawing.Entity {
+	plane := flat.Plane
+	n := plane.Normal().AsVector()
+	origin := plane.Origin()
+	var out []drawing.Entity
+	for _, e := range flat.Body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if !onPlaneAt(a, origin, n, flat.Thickness) || !onPlaneAt(b, origin, n, flat.Thickness) {
+			continue
+		}
+		if inPlaneFaceCount(e, n) != 1 {
+			continue
+		}
+		out = append(out, &drawing.Line{
+			Layer: layer,
+			Start: point2to3(plane.ToSketch(a)),
+			End:   point2to3(plane.ToSketch(b)),
+		})
+	}
+	return out
+}
+
+// flatPunchEntities emits each punch representation as its outline plus a TEXT token at the
+// centroid, both on the punch layer. The flat pattern carries no punch development yet (only
+// base + edge flanges are unfolded), so this is currently empty; it is the seam the punch
+// representation populates.
+func flatPunchEntities(flat *feature.FlatPattern, layer string) []drawing.Entity {
+	_ = flat
+	_ = layer
+	return nil
+}
+
+// onPlaneAt reports whether p sits on the plane offset height h along normal n from origin
+// (the flat body's top face is at h = thickness; the bottom at h = 0).
+func onPlaneAt(p, origin math.Point3, n math.Vector3, h float64) bool {
+	return stdmath.Abs(origin.VectorTo(p).Dot(n)-h) < flatPlaneTol
+}
+
+// inPlaneFaceCount counts an edge's adjacent faces whose normal is parallel to n (a flat,
+// in-plane face). An outline edge has exactly one; an interior seam between two top faces has two.
+func inPlaneFaceCount(e *topo.Edge, n math.Vector3) int {
+	count := 0
+	for _, f := range e.Faces() {
+		fn := f.Geometry().NormalAt(0, 0)
+		l := float64(fn.Length())
+		if l == 0 {
+			continue
+		}
+		if stdmath.Abs(fn.Scale(1/l).Dot(n)) > flatParallelTol {
+			count++
+		}
+	}
+	return count
+}
+
+// point2to3 lifts a 2D flat-plane point into a Z=0 drawing coordinate.
+func point2to3(p math.Point2) [3]float64 { return [3]float64{float64(p.X), float64(p.Y), 0} }
+
+const (
+	// flatPlaneTol bounds "lies on the top/bottom plane" (database units, cm).
+	flatPlaneTol = 1e-6
+	// flatParallelTol is the |normal·planeNormal| above which a face counts as in-plane (flat).
+	flatParallelTol = 0.999
+)
+
+// ExportFlatPatternDXF encodes a developed flat pattern as an ASCII DXF of the given version,
+// returning the bytes and the entity count. Layers default when layers is the zero value.
+//
+//	data, n, err := exchange.ExportFlatPatternDXF(flat, exchange.FlatExportLayers{}, types.DXFR2018)
+func ExportFlatPatternDXF(flat *feature.FlatPattern, layers FlatExportLayers, version types.DXFVersion) ([]byte, int, error) {
+	dr := &drawing.Drawing{Entities: FlatPatternToDrawing(flat, layers), Units: drawing.INSCentimetres}
+	data, err := dxf.Encode(dr, dxfVersion(version))
+	return data, len(dr.Entities), err
+}
+
+// ExportFlatPatternDXFFile writes ExportFlatPatternDXF's output to path, returning the entity count.
+func ExportFlatPatternDXFFile(flat *feature.FlatPattern, path string, layers FlatExportLayers, version types.DXFVersion) (int, error) {
+	data, n, err := ExportFlatPatternDXF(flat, layers, version)
+	if err != nil {
+		return 0, err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return 0, fmt.Errorf("export flat pattern dxf: write %q: %w", path, err)
+	}
+	return n, nil
+}

--- a/model/exchange/flatpattern_export.go
+++ b/model/exchange/flatpattern_export.go
@@ -3,13 +3,10 @@
 package exchange
 
 import (
-	"fmt"
 	stdmath "math"
-	"os"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/exchange/drawing"
-	"oblikovati.org/kernel/exchange/dxf"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
@@ -172,19 +169,10 @@ const (
 //
 //	data, n, err := exchange.ExportFlatPatternDXF(flat, exchange.FlatExportLayers{}, types.DXFR2018)
 func ExportFlatPatternDXF(flat *feature.FlatPattern, layers FlatExportLayers, version types.DXFVersion) ([]byte, int, error) {
-	dr := &drawing.Drawing{Entities: FlatPatternToDrawing(flat, layers), Units: drawing.INSCentimetres}
-	data, err := dxf.Encode(dr, dxfVersion(version))
-	return data, len(dr.Entities), err
+	return encodeDXF(FlatPatternToDrawing(flat, layers), version)
 }
 
 // ExportFlatPatternDXFFile writes ExportFlatPatternDXF's output to path, returning the entity count.
 func ExportFlatPatternDXFFile(flat *feature.FlatPattern, path string, layers FlatExportLayers, version types.DXFVersion) (int, error) {
-	data, n, err := ExportFlatPatternDXF(flat, layers, version)
-	if err != nil {
-		return 0, err
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return 0, fmt.Errorf("export flat pattern dxf: write %q: %w", path, err)
-	}
-	return n, nil
+	return writeDXFFile(FlatPatternToDrawing(flat, layers), path, version)
 }

--- a/model/exchange/flatpattern_export_test.go
+++ b/model/exchange/flatpattern_export_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange/dxf"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// flatWithTab develops a side×side base plate with one tab on the y=0 edge (developed length
+// tab), at the given gauge — the common tray fixture, with one fold line.
+func flatWithTab(t *testing.T, side, thickness, tab float64) *feature.FlatPattern {
+	t.Helper()
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	c0 := s.Points().Add(math.P2(0, 0))
+	c1 := s.Points().Add(math.P2(side, 0))
+	c2 := s.Points().Add(math.P2(side, side))
+	c3 := s.Points().Add(math.P2(0, side))
+	s.Lines().Add(c0, c1)
+	s.Lines().Add(c1, c2)
+	s.Lines().Add(c2, c3)
+	s.Lines().Add(c3, c0)
+	tabs := []feature.FlatTab{{A: math.P2(0, 0), B: math.P2(side, 0), Length: tab, Angle: stdmath.Pi / 2}}
+	fp, err := feature.BuildFlatPattern(s, 0, thickness, tabs)
+	if err != nil {
+		t.Fatalf("BuildFlatPattern: %v", err)
+	}
+	return fp
+}
+
+// TestExportFlatPatternDXF develops a tray flat and exports it: the footprint must land on the
+// Outline layer and the fold line on the Bend-Up layer, with both layers in the LAYER table —
+// the #378 acceptance (flat exports to DXF with bend lines on configured layers).
+func TestExportFlatPatternDXF(t *testing.T) {
+	fp := flatWithTab(t, 4, 0.2, 1.5)
+	data, n, err := ExportFlatPatternDXF(fp, FlatExportLayers{}, types.DXFR2018)
+	if err != nil {
+		t.Fatalf("ExportFlatPatternDXF: %v", err)
+	}
+	out := string(data)
+
+	// The two layers used appear as LAYER records.
+	for _, layer := range []string{"Outline", "Bend-Up"} {
+		if !strings.Contains(out, "\n2\n"+layer+"\n") {
+			t.Errorf("LAYER table missing %q", layer)
+		}
+	}
+	// The fold line is drawn on the bend-up layer (this tray's bend folds up).
+	if !strings.Contains(out, "\n8\nBend-Up\n") {
+		t.Error("fold line not emitted on the Bend-Up layer")
+	}
+	// Footprint outline: the tray's outer rectangle is at least 4 segments, plus the 1 fold line.
+	outline := strings.Count(out, "\n8\nOutline\n")
+	if outline < 4 {
+		t.Errorf("outline emitted %d segments, want >= 4 (the footprint rectangle)", outline)
+	}
+	if n != outline+1 {
+		t.Errorf("entity count = %d, want %d (outline %d + 1 fold line)", n, outline+1, outline)
+	}
+
+	// The export re-decodes to valid geometry (the outline lines + fold line survive).
+	dr, _, err := dxf.Decode(data)
+	if err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	if len(dr.Entities) < 5 {
+		t.Errorf("re-decoded %d entities, want >= 5 (outline + fold line)", len(dr.Entities))
+	}
+}
+
+// TestFlatExportLayersDefaults the zero layer value resolves to the default scheme.
+func TestFlatExportLayersDefaults(t *testing.T) {
+	got := FlatExportLayers{}.withDefaults()
+	if got != DefaultFlatExportLayers() {
+		t.Errorf("withDefaults() = %+v, want the default scheme %+v", got, DefaultFlatExportLayers())
+	}
+	custom := FlatExportLayers{Outline: "CUT"}.withDefaults()
+	if custom.Outline != "CUT" || custom.BendUp != "Bend-Up" {
+		t.Errorf("withDefaults kept/filled wrong: %+v", custom)
+	}
+}

--- a/model/exchange/flatpattern_export_test.go
+++ b/model/exchange/flatpattern_export_test.go
@@ -75,6 +75,30 @@ func TestExportFlatPatternDXF(t *testing.T) {
 	}
 }
 
+// TestExportFlatPatternPunches a punch representation exports as a closed outline plus its token
+// (a TEXT entity) on the Punches layer — the manufacturing tag from #378's acceptance.
+func TestExportFlatPatternPunches(t *testing.T) {
+	fp := flatWithTab(t, 4, 0.2, 1.5)
+	fp.Punches = []feature.FlatPunch{{
+		Outline: []math.Point2{math.P2(1, 1), math.P2(2, 1), math.P2(2, 2), math.P2(1, 2)},
+		Token:   "Punch1",
+	}}
+	data, _, err := ExportFlatPatternDXF(fp, FlatExportLayers{}, types.DXFR2018)
+	if err != nil {
+		t.Fatalf("ExportFlatPatternDXF: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "\n2\nPunches\n") {
+		t.Error("LAYER table missing the Punches layer")
+	}
+	if !strings.Contains(out, "\n8\nPunches\n") {
+		t.Error("no punch geometry on the Punches layer")
+	}
+	if !strings.Contains(out, "\n0\nTEXT\n") || !strings.Contains(out, "\n1\nPunch1\n") {
+		t.Error("punch token TEXT not emitted")
+	}
+}
+
 // TestFlatExportLayersDefaults the zero layer value resolves to the default scheme.
 func TestFlatExportLayersDefaults(t *testing.T) {
 	got := FlatExportLayers{}.withDefaults()

--- a/model/exchange/flatpattern_export_test.go
+++ b/model/exchange/flatpattern_export_test.go
@@ -19,14 +19,7 @@ import (
 func flatWithTab(t *testing.T, side, thickness, tab float64) *feature.FlatPattern {
 	t.Helper()
 	s := sketch.NewSketches().Add(sketch.XYPlane())
-	c0 := s.Points().Add(math.P2(0, 0))
-	c1 := s.Points().Add(math.P2(side, 0))
-	c2 := s.Points().Add(math.P2(side, side))
-	c3 := s.Points().Add(math.P2(0, side))
-	s.Lines().Add(c0, c1)
-	s.Lines().Add(c1, c2)
-	s.Lines().Add(c2, c3)
-	s.Lines().Add(c3, c0)
+	s.AddRectangleByCorners(math.P2(0, 0), math.P2(side, side))
 	tabs := []feature.FlatTab{{A: math.P2(0, 0), B: math.P2(side, 0), Length: tab, Angle: stdmath.Pi / 2}}
 	fp, err := feature.BuildFlatPattern(s, 0, thickness, tabs)
 	if err != nil {

--- a/model/feature/flat_pattern.go
+++ b/model/feature/flat_pattern.go
@@ -44,12 +44,22 @@ type FlatBendLine struct {
 	FoldDown bool
 }
 
-// FlatPattern is the developed flat: the flat solid, its fold lines, the 2D extents, the
-// gauge, and the base plane the flat lies in (so callers can project the body to 2D). Body is
-// one watertight solid (the base plate unioned with every tab).
+// FlatPunch is one punch's representation in the flat pattern: its closed outline (base-plane
+// 2D) and a token naming the punch/tool, drawn on the punch layer for the CAM programmer. It is
+// an annotation — a marker, not a body hole — so it represents a punch even where the flat solid
+// does not yet carry the cut.
+type FlatPunch struct {
+	Outline []math.Point2
+	Token   string
+}
+
+// FlatPattern is the developed flat: the flat solid, its fold lines, punch representations, the
+// 2D extents, the gauge, and the base plane the flat lies in (so callers can project the body to
+// 2D). Body is one watertight solid (the base plate unioned with every tab).
 type FlatPattern struct {
 	Body      *topo.Body
 	Bends     []FlatBendLine
+	Punches   []FlatPunch
 	Extents   math.Box2d
 	Thickness float64
 	Plane     sketch.Plane


### PR DESCRIPTION
Closes #378 (M13-F04 PBI-136). Builds on the merged DXF codec to export a sheet-metal **flat pattern** to DXF for manufacturing.

## What

`oblikovati-cli export-flat <part.opd> <out.dxf> [r2000|r2018]` (and `exchange.ExportFlatPatternDXF`) develops the flat pattern and writes, on named layers:

- **Outline** — the flat footprint (the top-plane boundary edges; tab seams between coplanar tops are skipped, so only the silhouette is drawn).
- **Bend-Up / Bend-Down** — each fold line, by direction.
- **Punches** — each punch's closed outline + a **TEXT token** (the feature name) at its centroid.

## How it threads through

1. **DXF codec** (`kernel/exchange/dxf` + `drawing`): added an optional `Layer` to each entity and a `Text` entity; the encoder emits a LAYER record per distinct layer (group code 8 per entity) and single-line TEXT. Geometry with no layer still lands on `0`, so existing sketch exports are byte-unchanged.
2. **Flat → drawing** (`model/exchange/flatpattern_export.go`): `FlatPatternToDrawing` + `ExportFlatPatternDXF[File]`, with an overridable `FlatExportLayers` scheme.
3. **Punch representation** (`model/feature` `FlatPunch`, `model/compdef` `Unfold`): every coplanar (base-plane) punch develops into a flat outline + token. A punch on a *flange* develops through the fold — a documented follow-up.
4. **CLI** `export-flat`.

## Acceptance

✓ *The flat exports to DXF with bend lines and punch tags on configured layers.*

## Verification

- `kernel/exchange/dxf`: LAYER table + per-entity layer + TEXT emission; geometry still round-trips.
- `model/exchange`: tray flat → DXF puts the footprint on Outline and the fold on Bend-Up; punch → outline + token on Punches.
- `model/compdef`: `Unfold` develops a coplanar punch into a `FlatPunch` tagged with the feature name.
- `cmd/oblikovati-cli`: `export-flat` writes a valid r2018 DXF with the Outline layer.

## Follow-ups (out of scope)

- **DWG** export (shares the same `FlatPatternToDrawing`; the chosen DXF-first split).
- Flange-punch and general cut/hole development into the flat body (the flat currently develops base + edge flanges).
- A `flatPattern.exportDXF` **wire/bridge method** (parity with the sketch DXF export) — the feature is usable via CLI + Go API today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)