### PR TITLE
Bug report: carry each transaction's full recipe payload

### DIFF
--- a/app/bug_report_diag.go
+++ b/app/bug_report_diag.go
@@ -32,14 +32,19 @@ func (s *Session) CollectDiagnostics() report.Payload {
 }
 
 // TransactionLog returns the transaction-manager events recorded since the application
-// opened — every committed edit across all documents, oldest first — as
-// "<time>  <document>: <label>" lines. It is an append-only audit (see watchTransactions),
-// not a document's current undo stack: undo does not erase entries here, so the report shows
-// the full sequence of what the user did.
-func (s *Session) TransactionLog() []string {
-	out := make([]string, 0, len(s.txEvents))
+// opened — every committed edit across all documents, oldest first — each carrying the
+// document's full recipe (the complete, replayable command payload). It is an append-only
+// audit (see watchTransactions), not a document's current undo stack: undo does not erase
+// entries here, so the report shows the full sequence of what the user did.
+func (s *Session) TransactionLog() []report.TransactionEvent {
+	out := make([]report.TransactionEvent, 0, len(s.txEvents))
 	for _, e := range s.txEvents {
-		out = append(out, fmt.Sprintf("%s  %s: %s", e.when.Format("15:04:05"), e.doc, e.label))
+		out = append(out, report.TransactionEvent{
+			Time:     e.when.Format("15:04:05"),
+			Document: e.doc,
+			Label:    e.label,
+			Recipe:   string(e.recipe),
+		})
 	}
 	return out
 }

--- a/app/bug_report_test.go
+++ b/app/bug_report_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -210,11 +209,18 @@ func TestTransactionLogIsAppendOnlySinceOpen(t *testing.T) {
 	if len(log) != before+2 {
 		t.Fatalf("want %d events, got %d: %v", before+2, len(log), log)
 	}
-	if !strings.Contains(log[before], "Sketch") || !strings.Contains(log[before+1], "Extrude") {
-		t.Errorf("events out of order or missing labels: %v", log[before:])
+	if log[before].Label != "Sketch" || log[before+1].Label != "Extrude" {
+		t.Errorf("events out of order or missing labels: %+v", log[before:])
 	}
-	if !strings.Contains(log[before], d.DisplayName()) {
-		t.Errorf("event missing document name %q: %q", d.DisplayName(), log[before])
+	if log[before].Document != d.DisplayName() {
+		t.Errorf("event document = %q, want %q", log[before].Document, d.DisplayName())
+	}
+	// The replayable recipe payload is captured from the document's content.
+	if rc, ok := d.Content().(recipeStore); ok {
+		want, _ := rc.MarshalRecipe()
+		if log[before].Recipe != string(want) {
+			t.Errorf("recipe payload not captured:\n got %q\nwant %q", log[before].Recipe, want)
+		}
 	}
 }
 

--- a/app/undo.go
+++ b/app/undo.go
@@ -20,24 +20,30 @@ const maxSessionTxEvents = 2000
 
 // sessionTxEvent is one committed transaction recorded for the life of the session — an
 // append-only audit of what the user did since the app opened, independent of the
-// per-document undo stacks (which shrink on undo). It feeds the bug report's transaction log.
+// per-document undo stacks (which shrink on undo). recipe is the document's full parametric
+// recipe after the step (the complete command payload), so the sequence replays precisely.
 type sessionTxEvent struct {
-	when  time.Time
-	doc   string
-	label string
+	when   time.Time
+	doc    string
+	label  string
+	recipe []byte
 }
 
 // watchTransactions appends every committed transaction (on any document) to the session's
-// append-only event log, so a bug report can show everything the user did since launch.
-// Undo/redo do not emit TransactionCommitted, so the log is a forward audit that survives
-// undo — unlike a document's undo stack.
+// append-only event log, capturing the document's resulting recipe as the replayable
+// command payload. Undo/redo do not emit TransactionCommitted, so the log is a forward
+// audit that survives undo — unlike a document's undo stack. The event fires right after
+// commitRecipeDelta advances the snapshot, so the content's recipe is the after-state.
 func (s *Session) watchTransactions() {
 	event.Subscribe(s.bus, event.After, func(_ event.Context, e TransactionCommitted) event.Outcome {
-		name := "untitled"
+		name, recipe := "untitled", []byte(nil)
 		if d, ok := s.workspace.ByID(e.Document); ok {
 			name = d.DisplayName()
+			if rc, ok := d.Content().(recipeStore); ok {
+				recipe, _ = rc.MarshalRecipe()
+			}
 		}
-		s.txEvents = append(s.txEvents, sessionTxEvent{when: time.Now().UTC(), doc: name, label: e.Label})
+		s.txEvents = append(s.txEvents, sessionTxEvent{when: time.Now().UTC(), doc: name, label: e.Label, recipe: recipe})
 		if len(s.txEvents) > maxSessionTxEvents {
 			s.txEvents = s.txEvents[len(s.txEvents)-maxSessionTxEvents:]
 		}

--- a/report/payload.go
+++ b/report/payload.go
@@ -8,17 +8,27 @@ package report
 // round-trip test on each side guards against drift). The two PNGs are encoded as base64
 // by encoding/json automatically because they are []byte.
 type Payload struct {
-	Comment        string         `json:"comment"`
-	OS             string         `json:"os"`
-	Arch           string         `json:"arch"`
-	AppVersion     string         `json:"appVersion"`
-	AppCommit      string         `json:"appCommit"`
-	AppBuildDate   string         `json:"appBuildDate"`
-	UserSettings   string         `json:"userSettings"`
-	OpenDocuments  []DocumentInfo `json:"openDocuments"`
-	TransactionLog []string       `json:"transactionLog"`
-	WindowPNG      []byte         `json:"windowPng,omitempty"`
-	ViewportPNG    []byte         `json:"viewportPng,omitempty"`
+	Comment        string             `json:"comment"`
+	OS             string             `json:"os"`
+	Arch           string             `json:"arch"`
+	AppVersion     string             `json:"appVersion"`
+	AppCommit      string             `json:"appCommit"`
+	AppBuildDate   string             `json:"appBuildDate"`
+	UserSettings   string             `json:"userSettings"`
+	OpenDocuments  []DocumentInfo     `json:"openDocuments"`
+	TransactionLog []TransactionEvent `json:"transactionLog"`
+	WindowPNG      []byte             `json:"windowPng,omitempty"`
+	ViewportPNG    []byte             `json:"viewportPng,omitempty"`
+}
+
+// TransactionEvent is one committed transaction-manager event since the application opened.
+// Recipe is the document's full parametric recipe (the complete command payload) at that
+// step, so the sequence can be replayed to reproduce the user's interactions precisely.
+type TransactionEvent struct {
+	Time     string `json:"time"`
+	Document string `json:"document"`
+	Label    string `json:"label"`
+	Recipe   string `json:"recipe,omitempty"`
 }
 
 // DocumentInfo is one open document in the report: its file path, display name, kind, dirty

--- a/report/submit_test.go
+++ b/report/submit_test.go
@@ -46,7 +46,7 @@ func samplePayload() Payload {
 		Arch:           "amd64",
 		AppVersion:     "0.16.0",
 		OpenDocuments:  []DocumentInfo{{Path: "/tmp/p.obk", Name: "p", Type: "Part"}},
-		TransactionLog: []string{"Sketch", "Extrude"},
+		TransactionLog: []TransactionEvent{{Time: "09:00:01", Document: "p", Label: "Extrude", Recipe: "features: []\n"}},
 		WindowPNG:      []byte{0x89, 0x50, 0x4e, 0x47},
 		ViewportPNG:    []byte{0x89, 0x50, 0x4e, 0x47, 0x0d},
 	}


### PR DESCRIPTION
## What & why
The transaction log listed only labels (e.g. "Extrude"), which isn't enough to reproduce what the user did. Each committed transaction now carries the document's **full parametric recipe** at that step — the complete, replayable command payload.

## How
- `report.TransactionEvent` (`time`, `document`, `label`, `recipe`) replaces the plain-string transaction log.
- `watchTransactions` captures the document's recipe via `MarshalRecipe()` when a `TransactionCommitted` event fires (that event is emitted right after the recipe advances, so the content is the after-state). Still append-only across all documents and surviving undo; bounded to the most recent 2000.

## Tests
- `app`: the transaction log records committed events in order with document + the captured recipe payload.
- `report`/build green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)