### PR TITLE
feat(drawing): drawing document sheets, borders & title blocks (M14-F01)

### DIFF
--- a/addin/router/drawing.go
+++ b/addin/router/drawing.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/drawing"
+)
+
+// The drawing-document sheet surface (M14-F01, #384): list/add/remove sheets, pick the
+// active sheet, point the drawing at the model it documents, and read a title block's
+// fields resolved against that model's iProperties.
+
+// registerDrawingHandlers wires the drawing.* methods.
+func (r *Router) registerDrawingHandlers() {
+	r.handlers[wire.MethodDrawingListSheets] = drawingListSheets
+	r.handlers[wire.MethodDrawingAddSheet] = drawingAddSheet
+	r.handlers[wire.MethodDrawingRemoveSheet] = drawingRemoveSheet
+	r.handlers[wire.MethodDrawingSetActiveSheet] = drawingSetActiveSheet
+	r.handlers[wire.MethodDrawingSetModelReference] = drawingSetModelReference
+	r.handlers[wire.MethodDrawingTitleBlockFields] = drawingTitleBlockFields
+}
+
+// activeDrawing returns the active document's drawing content, erroring if no drawing is
+// active. It (re)wires the title-block resolver to the workspace so fields resolve
+// against the current referenced model.
+func activeDrawing(s *app.Session) (*drawing.Content, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, fmt.Errorf("drawing: no active document")
+	}
+	c, ok := d.Content().(*drawing.Content)
+	if !ok {
+		return nil, fmt.Errorf("drawing: active document %q is not a drawing", d.FullDocumentName())
+	}
+	c.SetModelProperties(referencedModelProperties{ws: s.Workspace(), ref: c.ModelReference})
+	return c, nil
+}
+
+func drawingListSheets(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(listSheetsResult(c))
+}
+
+func drawingAddSheet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddSheetArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	spec, err := sheetSpecOf(in)
+	if err != nil {
+		return nil, err
+	}
+	sh, err := c.Sheets().Add(spec)
+	if err != nil {
+		return nil, err
+	}
+	s.ActiveDocument().MarkDirty()
+	return json.Marshal(wire.SheetResult{Sheet: sheetInfo(c, sh)})
+}
+
+func drawingRemoveSheet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.RemoveSheetArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := c.Sheets().Remove(in.Name); err != nil {
+		return nil, err
+	}
+	s.ActiveDocument().MarkDirty()
+	return json.Marshal(listSheetsResult(c))
+}
+
+func drawingSetActiveSheet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetActiveSheetArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if err := c.Sheets().SetActive(in.Name); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SheetResult{Sheet: sheetInfo(c, c.Sheets().Active())})
+}
+
+func drawingSetModelReference(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetModelReferenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	c.SetModelReference(in.FullDocumentName)
+	s.ActiveDocument().MarkDirty()
+	return json.Marshal(wire.SetModelReferenceResult{ModelReference: c.ModelReference()})
+}
+
+func drawingTitleBlockFields(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.TitleBlockFieldsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	sh, err := sheetByNameOrActive(c, in.Sheet)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(titleBlockFieldsResult(sh))
+}
+
+// sheetByNameOrActive returns the named sheet, or the active sheet when name is empty.
+func sheetByNameOrActive(c *drawing.Content, name string) (*drawing.Sheet, error) {
+	if name == "" {
+		sh := c.Sheets().Active()
+		if sh == nil {
+			return nil, fmt.Errorf("drawing: no active sheet")
+		}
+		return sh, nil
+	}
+	sh, ok := c.Sheets().ByName(name)
+	if !ok {
+		return nil, fmt.Errorf("drawing: no sheet named %q", name)
+	}
+	return sh, nil
+}
+
+// sheetSpecOf converts the wire request into a model SheetSpec, parsing the size and
+// orientation spellings (empty size ⇒ custom).
+func sheetSpecOf(in wire.AddSheetArgs) (drawing.SheetSpec, error) {
+	size := types.SheetSizeCustom
+	if in.Size != "" {
+		parsed, ok := types.ParseSheetSize(in.Size)
+		if !ok {
+			return drawing.SheetSpec{}, fmt.Errorf("drawing: unknown sheet size %q", in.Size)
+		}
+		size = parsed
+	}
+	orient := types.SheetPortrait
+	if in.Orientation != "" {
+		parsed, ok := types.ParseSheetOrientation(in.Orientation)
+		if !ok {
+			return drawing.SheetSpec{}, fmt.Errorf("drawing: unknown sheet orientation %q", in.Orientation)
+		}
+		orient = parsed
+	}
+	return drawing.SheetSpec{Name: in.Name, Size: size, Orientation: orient, WidthMM: in.WidthMM, HeightMM: in.HeightMM}, nil
+}
+
+func listSheetsResult(c *drawing.Content) wire.ListSheetsResult {
+	out := wire.ListSheetsResult{ModelReference: c.ModelReference()}
+	for i := 0; i < c.Sheets().Count(); i++ {
+		out.Sheets = append(out.Sheets, sheetInfo(c, c.Sheets().Item(i)))
+	}
+	return out
+}
+
+func sheetInfo(c *drawing.Content, sh *drawing.Sheet) wire.SheetInfo {
+	return wire.SheetInfo{
+		Name:          sh.Name(),
+		Size:          sh.Size().String(),
+		Orientation:   sh.Orientation().String(),
+		WidthMM:       sh.WidthMM(),
+		HeightMM:      sh.HeightMM(),
+		Active:        c.Sheets().Active() == sh,
+		HasBorder:     sh.Border() != nil,
+		HasTitleBlock: sh.TitleBlock() != nil,
+	}
+}
+
+func titleBlockFieldsResult(sh *drawing.Sheet) wire.TitleBlockFieldsResult {
+	tb, ok := sh.TitleBlock().(*drawing.TitleBlock)
+	if !ok {
+		return wire.TitleBlockFieldsResult{}
+	}
+	out := wire.TitleBlockFieldsResult{DefinitionName: tb.DefinitionName()}
+	for _, f := range tb.Fields() {
+		out.Fields = append(out.Fields, wire.TitleBlockField{Name: f.Name, Value: f.Value, Source: f.Source})
+	}
+	return out
+}
+
+// referencedModelProperties resolves a drawing's referenced model iProperties by looking
+// the document up by name in the workspace on each read (so it tracks the model being
+// opened or edited after the drawing references it). ref re-reads the drawing's current
+// reference so a later setModelReference is honoured.
+type referencedModelProperties struct {
+	ws  *doc.Workspace
+	ref func() string
+}
+
+func (p referencedModelProperties) Property(set, name string) (string, bool) {
+	d, ok := p.ws.ByName(p.ref())
+	if !ok || d.Content() == nil {
+		return "", false
+	}
+	props, ok := d.Content().(interface{ Properties() *attr.PropertySets })
+	if !ok {
+		return "", false
+	}
+	ps, ok := props.Properties().Lookup(set)
+	if !ok {
+		return "", false
+	}
+	prop, ok := ps.Property(name)
+	if !ok {
+		return "", false
+	}
+	return propertyText(prop.Value()), true
+}
+
+// propertyText renders an iProperty value as the plain text a title block shows.
+func propertyText(v attr.Value) string {
+	if s, ok := v.Str(); ok {
+		return s
+	}
+	if i, ok := v.Int(); ok {
+		return strconv.FormatInt(i, 10)
+	}
+	if f, ok := v.Float(); ok {
+		return strconv.FormatFloat(f, 'g', -1, 64)
+	}
+	if b, ok := v.Bool(); ok {
+		return strconv.FormatBool(b)
+	}
+	return ""
+}

--- a/addin/router/drawing_test.go
+++ b/addin/router/drawing_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/compdef"
+)
+
+// drawingSession seeds a part "widget.opd" with iProperties and an active drawing
+// "sheet.odd" that references it — the fixture for the title-block resolution test.
+func drawingSession(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r := New(opregistry.Default())
+	s := app.NewSession()
+
+	part, err := compdef.AddPart(s.Workspace(), "widget.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	props := part.Content().(*compdef.PartComponentDefinition).Properties()
+	props.Set(attr.DesignTracking).Put("Part Number", attr.StringValue("PN-1001"))
+	props.Set(attr.SummaryInformation).Put("Title", attr.StringValue("Mounting Bracket"))
+
+	// Create the drawing through the wire create path: this proves the registered
+	// content factory yields live drawing content, and leaves the drawing active.
+	var info wire.DocumentInfo
+	call(t, r, s, "documents.create", `{"type":"drawing","name":"sheet.odd"}`, &info)
+	if info.Type != "drawing" {
+		t.Fatalf("created document type = %q, want drawing", info.Type)
+	}
+	return r, s
+}
+
+func TestDrawingDefaultSheetOverWire(t *testing.T) {
+	r, s := drawingSession(t)
+
+	var sheets wire.ListSheetsResult
+	call(t, r, s, "drawing.listSheets", "{}", &sheets)
+	if len(sheets.Sheets) != 1 {
+		t.Fatalf("default sheet count = %d, want 1", len(sheets.Sheets))
+	}
+	sh := sheets.Sheets[0]
+	if sh.Size != "a3" || sh.Orientation != "landscape" || sh.WidthMM != 420 || !sh.Active {
+		t.Errorf("default sheet = %+v, want active A3 landscape 420 wide", sh)
+	}
+	if !sh.HasBorder || !sh.HasTitleBlock {
+		t.Errorf("default sheet = %+v, want a border and title block", sh)
+	}
+}
+
+func TestDrawingSheetLifecycleOverWire(t *testing.T) {
+	r, s := drawingSession(t)
+
+	var added wire.SheetResult
+	call(t, r, s, "drawing.addSheet", `{"size":"a4","orientation":"portrait"}`, &added)
+	if added.Sheet.Name != "Sheet:2" || added.Sheet.HeightMM != 297 || !added.Sheet.Active {
+		t.Fatalf("added = %+v, want active A4 Sheet:2", added.Sheet)
+	}
+
+	var activated wire.SheetResult
+	call(t, r, s, "drawing.setActiveSheet", `{"name":"Sheet:1"}`, &activated)
+	if !activated.Sheet.Active || activated.Sheet.Name != "Sheet:1" {
+		t.Errorf("activated = %+v, want Sheet:1 active", activated.Sheet)
+	}
+
+	var afterRemove wire.ListSheetsResult
+	call(t, r, s, "drawing.removeSheet", `{"name":"Sheet:2"}`, &afterRemove)
+	if len(afterRemove.Sheets) != 1 || afterRemove.Sheets[0].Name != "Sheet:1" {
+		t.Errorf("after remove = %+v, want only Sheet:1", afterRemove.Sheets)
+	}
+}
+
+// TestDrawingTitleBlockResolvesReferencedModel is the PBI-137 acceptance over the wire:
+// a title block's fields resolve from the referenced model's iProperties.
+func TestDrawingTitleBlockResolvesReferencedModel(t *testing.T) {
+	r, s := drawingSession(t)
+
+	var ref wire.SetModelReferenceResult
+	call(t, r, s, "drawing.setModelReference", `{"fullDocumentName":"widget.opd"}`, &ref)
+	if ref.ModelReference != "widget.opd" {
+		t.Fatalf("model reference = %q, want widget.opd", ref.ModelReference)
+	}
+
+	var fields wire.TitleBlockFieldsResult
+	call(t, r, s, "drawing.titleBlockFields", "{}", &fields)
+	got := map[string]string{}
+	for _, f := range fields.Fields {
+		got[f.Name] = f.Value
+	}
+	if got["Part Number"] != "PN-1001" {
+		t.Errorf("Part Number = %q, want PN-1001 (fields=%+v)", got["Part Number"], fields.Fields)
+	}
+	if got["Title"] != "Mounting Bracket" {
+		t.Errorf("Title = %q, want Mounting Bracket", got["Title"])
+	}
+}
+
+func TestDrawingTitleBlockBlankWithoutReference(t *testing.T) {
+	r, s := drawingSession(t)
+	var fields wire.TitleBlockFieldsResult
+	call(t, r, s, "drawing.titleBlockFields", "{}", &fields)
+	for _, f := range fields.Fields {
+		if f.Value != "" {
+			t.Errorf("field %q = %q without a model reference, want empty", f.Name, f.Value)
+		}
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -71,6 +71,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyReplicationHandlers()
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()
+	r.registerDrawingHandlers()
 	r.handlers[wire.MethodLogsTail] = r.logsTail
 	r.handlers[wire.MethodScriptRun] = r.scriptsRun
 	return r

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.16.0
+	oblikovati.org/api v0.17.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.16.0
+	oblikovati.org/api v0.17.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/drawing/border.go
+++ b/model/drawing/border.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+// BorderDefinition is a reusable border template: the printable-area margins inset
+// (millimetres) from the sheet edge on each side. A drawing standard owns a set of
+// these; V1 ships one default (custom border definitions are a follow-up).
+type BorderDefinition struct {
+	name                     string
+	left, right, top, bottom float64
+}
+
+// DefaultBorderDefinition is the standard border: 10 mm on three sides and a wider
+// 20 mm left (binding) edge — a common drafting default.
+func DefaultBorderDefinition() *BorderDefinition {
+	return &BorderDefinition{name: "Default", left: 20, right: 10, top: 10, bottom: 10}
+}
+
+// Name returns the border definition's name.
+func (d *BorderDefinition) Name() string { return d.name }
+
+// Border is a sheet's border — an instance of a [BorderDefinition].
+type Border struct {
+	def *BorderDefinition
+}
+
+func newBorder(def *BorderDefinition) *Border { return &Border{def: def} }
+
+// DefinitionName returns the name of the border definition this border instantiates.
+func (b *Border) DefinitionName() string { return b.def.name }
+
+// Margins returns the left, right, top and bottom inset in millimetres
+// (contract.DrawingBorder).
+func (b *Border) Margins() (left, right, top, bottom float64) {
+	return b.def.left, b.def.right, b.def.top, b.def.bottom
+}

--- a/model/drawing/content.go
+++ b/model/drawing/content.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package drawing is the modeling content of a drawing document (M14-F01, #384): an
+// ordered set of sheets (sizes/orientation, borders, title blocks) plus the primary
+// referenced model the drawing documents. Title-block fields resolve against that
+// model's iProperties, so a title block shows live part/assembly metadata.
+//
+// This is the GPL implementation of the api/contract drawing surface (ADR-0018); it
+// registers itself as the real content for doc.Drawing so opening a .odd reconstructs
+// live sheets rather than the identity-only stub.
+package drawing
+
+import "oblikovati.org/model/doc"
+
+// ModelProperties resolves a referenced model document's iProperty values for
+// title-block field resolution. It is the seam between this package (which knows
+// nothing of the workspace) and the host, which finds the referenced model and reads
+// its property sets. The host injects it via [Content.SetModelProperties]; a nil
+// resolver (an unwired drawing, or no reference set) leaves property fields blank.
+type ModelProperties interface {
+	// Property returns the value of the named property in the named iProperty set
+	// (e.g. "Design Tracking Properties", "Part Number"), and whether it exists.
+	Property(set, name string) (value string, ok bool)
+}
+
+// Content is a drawing document's modeling content. It implements doc.Content (and
+// doc.RecipeContent, in recipe.go) so the document/persistence layers treat it like
+// any other content kind.
+type Content struct {
+	sheets   *Sheets
+	modelRef string          // full document name of the primary referenced model
+	props    ModelProperties // resolves modelRef's iProperties; nil ⇒ unresolved
+}
+
+// NewContent creates a drawing with one default A3 landscape sheet (bordered, with the
+// standard title block) — the state a freshly created drawing document opens in.
+func NewContent() *Content {
+	c := &Content{sheets: newSheets()}
+	c.sheets.lookup = c.resolveProperty
+	c.sheets.addDefault()
+	return c
+}
+
+// DocumentType identifies this as drawing content.
+func (c *Content) DocumentType() doc.DocumentType { return doc.Drawing }
+
+// Sheets returns the drawing's sheets.
+func (c *Content) Sheets() *Sheets { return c.sheets }
+
+// ModelReference returns the full document name of the primary referenced model, or ""
+// if none is set.
+func (c *Content) ModelReference() string { return c.modelRef }
+
+// SetModelReference points the drawing at the model it documents; its title-block
+// fields resolve against that model's iProperties. An empty name clears the reference.
+func (c *Content) SetModelReference(fullDocumentName string) { c.modelRef = fullDocumentName }
+
+// SetModelProperties injects the resolver for the referenced model's iProperties. The
+// host (router/app) calls it after wiring the drawing to its workspace; until then,
+// property-bound title-block fields resolve to "".
+func (c *Content) SetModelProperties(props ModelProperties) { c.props = props }
+
+// resolveProperty is the title-block resolution hook handed to every sheet: it reads
+// the referenced model's iProperties through the injected resolver, or returns
+// ("", false) when no model is referenced or no resolver is wired.
+func (c *Content) resolveProperty(set, name string) (string, bool) {
+	if c.props == nil || c.modelRef == "" {
+		return "", false
+	}
+	return c.props.Property(set, name)
+}

--- a/model/drawing/drawing_test.go
+++ b/model/drawing/drawing_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/attr"
+)
+
+// fakeModelProperties is a named fake (CLAUDE.md: no inline stubs) standing in for a
+// referenced model's iProperties. Mutating it between reads exercises the "title block
+// updates with iProperties" acceptance.
+type fakeModelProperties struct {
+	values map[string]string // "Set:Prop" → value
+}
+
+func newFakeModelProperties() *fakeModelProperties {
+	return &fakeModelProperties{values: map[string]string{}}
+}
+
+func (f *fakeModelProperties) set(setName, prop, value string) { f.values[setName+":"+prop] = value }
+
+func (f *fakeModelProperties) Property(setName, prop string) (string, bool) {
+	v, ok := f.values[setName+":"+prop]
+	return v, ok
+}
+
+func TestNewContentHasDefaultSheet(t *testing.T) {
+	c := NewContent()
+	if got := c.Sheets().Count(); got != 1 {
+		t.Fatalf("new drawing sheet count = %d, want 1", got)
+	}
+	sh := c.Sheets().Active()
+	if sh == nil {
+		t.Fatal("new drawing has no active sheet")
+	}
+	if sh.Size() != types.SheetSizeA3 || sh.Orientation() != types.SheetLandscape {
+		t.Errorf("default sheet = %v/%v, want A3/landscape", sh.Size(), sh.Orientation())
+	}
+	if sh.WidthMM() != 420 || sh.HeightMM() != 297 {
+		t.Errorf("A3 landscape = %g×%g mm, want 420×297", sh.WidthMM(), sh.HeightMM())
+	}
+	if sh.Border() == nil || sh.TitleBlock() == nil {
+		t.Error("default sheet should have a border and a title block")
+	}
+}
+
+func TestAddSheetAutoNamesAndActivates(t *testing.T) {
+	c := NewContent()
+	sh, err := c.Sheets().Add(SheetSpec{Size: types.SheetSizeA4, Orientation: types.SheetPortrait})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if sh.Name() != "Sheet:2" {
+		t.Errorf("auto name = %q, want Sheet:2", sh.Name())
+	}
+	if c.Sheets().Active() != sh {
+		t.Error("added sheet should become active")
+	}
+	if sh.WidthMM() != 210 || sh.HeightMM() != 297 {
+		t.Errorf("A4 portrait = %g×%g, want 210×297", sh.WidthMM(), sh.HeightMM())
+	}
+}
+
+func TestAddCustomSheetRequiresPositiveDims(t *testing.T) {
+	c := NewContent()
+	if _, err := c.Sheets().Add(SheetSpec{Size: types.SheetSizeCustom}); err == nil {
+		t.Error("custom sheet with zero dimensions should error")
+	}
+	sh, err := c.Sheets().Add(SheetSpec{Size: types.SheetSizeCustom, WidthMM: 300, HeightMM: 200})
+	if err != nil {
+		t.Fatalf("custom Add: %v", err)
+	}
+	if sh.WidthMM() != 300 || sh.HeightMM() != 200 {
+		t.Errorf("custom = %g×%g, want 300×200", sh.WidthMM(), sh.HeightMM())
+	}
+}
+
+// TestTitleBlockResolvesAndUpdatesWithModel is the PBI-137 acceptance: a title block's
+// fields resolve from the referenced model's iProperties, and tracking a later edit.
+func TestTitleBlockResolvesAndUpdatesWithModel(t *testing.T) {
+	c := NewContent()
+	props := newFakeModelProperties()
+	props.set(attr.DesignTracking, "Part Number", "PN-1001")
+	c.SetModelProperties(props)
+	c.SetModelReference("widget.opd")
+
+	tb := c.Sheets().Active().titleBlock
+	if v, _ := tb.FieldValue("Part Number"); v != "PN-1001" {
+		t.Fatalf("Part Number = %q, want PN-1001", v)
+	}
+	// Edit the model's iProperty: the title block must reflect it on the next read.
+	props.set(attr.DesignTracking, "Part Number", "PN-2002")
+	if v, _ := tb.FieldValue("Part Number"); v != "PN-2002" {
+		t.Errorf("after edit Part Number = %q, want PN-2002", v)
+	}
+}
+
+func TestTitleBlockBlankWithoutModelReference(t *testing.T) {
+	c := NewContent()
+	props := newFakeModelProperties()
+	props.set(attr.SummaryInformation, "Title", "Bracket")
+	c.SetModelProperties(props)
+	// No SetModelReference: property fields resolve to "".
+	if v, _ := c.Sheets().Active().titleBlock.FieldValue("Title"); v != "" {
+		t.Errorf("Title without model reference = %q, want empty", v)
+	}
+}
+
+func TestRemoveKeepsAtLeastOneSheet(t *testing.T) {
+	c := NewContent()
+	if err := c.Sheets().Remove("Sheet:1"); err == nil {
+		t.Error("removing the last sheet should error")
+	}
+	if _, err := c.Sheets().Add(SheetSpec{Size: types.SheetSizeA4}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := c.Sheets().Remove("Sheet:1"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if c.Sheets().Count() != 1 || c.Sheets().Active() == nil {
+		t.Error("after remove, one sheet should remain active")
+	}
+}
+
+func TestRecipeRoundTrip(t *testing.T) {
+	c := NewContent()
+	c.SetModelReference("widget.opd")
+	if _, err := c.Sheets().Add(SheetSpec{Name: "Detail", Size: types.SheetSizeCustom, WidthMM: 500, HeightMM: 350, Orientation: types.SheetLandscape}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := c.Sheets().SetActive("Sheet:1"); err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+
+	blob, err := c.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	restored := NewContent()
+	props := newFakeModelProperties()
+	props.set(attr.SummaryInformation, "Title", "Widget")
+	restored.SetModelProperties(props)
+	if err := restored.ApplyRecipe(blob); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	if restored.ModelReference() != "widget.opd" {
+		t.Errorf("restored model ref = %q, want widget.opd", restored.ModelReference())
+	}
+	if restored.Sheets().Count() != 2 {
+		t.Fatalf("restored sheet count = %d, want 2", restored.Sheets().Count())
+	}
+	if restored.Sheets().Active().Name() != "Sheet:1" {
+		t.Errorf("restored active = %q, want Sheet:1", restored.Sheets().Active().Name())
+	}
+	detail, ok := restored.Sheets().ByName("Detail")
+	if !ok || detail.WidthMM() != 500 || detail.HeightMM() != 350 {
+		t.Errorf("restored custom sheet = %+v, want 500×350", detail)
+	}
+	// Title block re-resolves against the (re-injected) model after restore.
+	if v, _ := detail.titleBlock.FieldValue("Title"); v != "Widget" {
+		t.Errorf("restored title resolves to %q, want Widget", v)
+	}
+}

--- a/model/drawing/format.go
+++ b/model/drawing/format.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+)
+
+// SheetSpec describes a sheet to create: a standard Size (or types.SheetSizeCustom
+// with explicit WidthMM/HeightMM), an Orientation, and an optional Name ("" ⇒ the
+// collection auto-assigns the next "Sheet:N").
+type SheetSpec struct {
+	Name        string
+	Size        types.SheetSize
+	Orientation types.SheetOrientation
+	WidthMM     float64
+	HeightMM    float64
+}
+
+// laidOutDimsMM resolves a spec's width and height in millimetres with orientation
+// applied. A standard size reads its portrait dimensions from types.SheetDimensionsMM;
+// a custom size uses the spec's explicit dimensions (which must be positive). Landscape
+// swaps width and height.
+func laidOutDimsMM(size types.SheetSize, orient types.SheetOrientation, customW, customH float64) (float64, float64, error) {
+	w, h, ok := types.SheetDimensionsMM(size)
+	if !ok {
+		// A custom size's explicit dimensions are final; orientation is not applied
+		// (the caller already gave the width and height it wants).
+		if customW <= 0 || customH <= 0 {
+			return 0, 0, fmt.Errorf("drawing: custom sheet needs positive width and height, got %g×%g mm", customW, customH)
+		}
+		return customW, customH, nil
+	}
+	if orient == types.SheetLandscape {
+		w, h = h, w
+	}
+	return w, h, nil
+}

--- a/model/drawing/persistence_test.go
+++ b/model/drawing/persistence_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// TestDrawingSurvivesStoreRoundTrip proves the document/persistence seam: a drawing
+// created through the workspace (so the registered content factory yields live content)
+// saves to a .odd package and reopens with its sheets and model reference intact.
+func TestDrawingSurvivesStoreRoundTrip(t *testing.T) {
+	store := persistence.NewPackageStore()
+	path := filepath.Join(t.TempDir(), "drawing.odd")
+
+	saveWS := doc.NewWorkspace(store)
+	d, err := saveWS.Add(doc.Drawing, path, true)
+	if err != nil {
+		t.Fatalf("Add(Drawing): %v", err)
+	}
+	c, ok := d.Content().(*Content)
+	if !ok {
+		t.Fatalf("content is %T, want *drawing.Content (factory not registered?)", d.Content())
+	}
+	c.SetModelReference("widget.opd")
+	if _, err := c.Sheets().Add(SheetSpec{Name: "Detail", Size: types.SheetSizeCustom, WidthMM: 500, HeightMM: 350}); err != nil {
+		t.Fatalf("Add sheet: %v", err)
+	}
+	if err := saveWS.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	rc, ok := reopened.Content().(*Content)
+	if !ok {
+		t.Fatalf("reopened content is %T, want *drawing.Content", reopened.Content())
+	}
+	if rc.ModelReference() != "widget.opd" {
+		t.Errorf("reopened model reference = %q, want widget.opd", rc.ModelReference())
+	}
+	if rc.Sheets().Count() != 2 {
+		t.Fatalf("reopened sheet count = %d, want 2 (default + Detail)", rc.Sheets().Count())
+	}
+	detail, ok := rc.Sheets().ByName("Detail")
+	if !ok || detail.Size() != types.SheetSizeCustom || detail.WidthMM() != 500 {
+		t.Errorf("reopened Detail sheet = %+v, want custom 500 wide", detail)
+	}
+}

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence/yamlcodec"
+)
+
+// init registers the real drawing content with the document layer so opening a .odd
+// reconstructs live sheets (with the recipe machinery), not the identity-only stub
+// (see doc.RegisterContentFactory).
+func init() {
+	doc.RegisterContentFactory(doc.Drawing, func() doc.Content { return NewContent() })
+}
+
+// var assertion: a drawing's content is recipe-bearing (doc.RecipeContent), so the
+// store persists and restores its sheets on save/open.
+var _ doc.RecipeContent = (*Content)(nil)
+
+// drawingRecipe is the YAML shape of a drawing's persisted state: the primary
+// referenced model, which sheet is active, and the sheets themselves. The resolved
+// title-block values are never stored — they are re-resolved from the referenced model
+// on open, so the title block always reflects the current iProperties.
+type drawingRecipe struct {
+	ModelReference string        `yaml:"modelReference,omitempty"`
+	ActiveSheet    int           `yaml:"activeSheet,omitempty"`
+	Sheets         []sheetRecipe `yaml:"sheets,omitempty"`
+}
+
+// sheetRecipe is the YAML shape of one sheet. WidthMM/HeightMM are written only for a
+// custom size (a standard size's dimensions come from the size+orientation on open).
+type sheetRecipe struct {
+	Name        string  `yaml:"name"`
+	Size        string  `yaml:"size"`
+	Orientation string  `yaml:"orientation,omitempty"`
+	WidthMM     float64 `yaml:"widthMm,omitempty"`
+	HeightMM    float64 `yaml:"heightMm,omitempty"`
+	Border      bool    `yaml:"border"`
+	TitleBlock  string  `yaml:"titleBlock,omitempty"` // definition name; "" ⇒ no title block
+}
+
+// MarshalRecipe renders the drawing's sheets and referenced model as YAML
+// (doc.RecipeContent).
+func (c *Content) MarshalRecipe() ([]byte, error) {
+	r := drawingRecipe{ModelReference: c.modelRef, ActiveSheet: c.sheets.active}
+	for _, sh := range c.sheets.items {
+		r.Sheets = append(r.Sheets, sheetRecipeOf(sh))
+	}
+	return yamlcodec.Marshal(r)
+}
+
+// ApplyRecipe restores the drawing from recipe YAML. It replaces the content's sheets
+// outright (so applying onto the factory's default sheet yields exactly the saved set),
+// re-wiring the title-block resolution hook so fields resolve against the model again.
+func (c *Content) ApplyRecipe(model []byte) error {
+	var r drawingRecipe
+	if err := yamlcodec.Unmarshal(model, &r); err != nil {
+		return fmt.Errorf("drawing: parse recipe: %w", err)
+	}
+	c.modelRef = r.ModelReference
+	c.sheets = newSheets()
+	c.sheets.lookup = c.resolveProperty
+	for _, sr := range r.Sheets {
+		if err := c.sheets.restore(sr); err != nil {
+			return err
+		}
+	}
+	c.sheets.setActiveIndex(r.ActiveSheet)
+	return nil
+}
+
+// sheetRecipeOf snapshots one sheet. A custom size carries its laid-out dimensions
+// (already orientation-applied) so restore reproduces them without re-swapping.
+func sheetRecipeOf(sh *Sheet) sheetRecipe {
+	rec := sheetRecipe{
+		Name:        sh.name,
+		Size:        sh.size.String(),
+		Orientation: sh.orientation.String(),
+		Border:      sh.border != nil,
+	}
+	if sh.size == types.SheetSizeCustom {
+		rec.WidthMM, rec.HeightMM = sh.width, sh.height
+	}
+	if sh.titleBlock != nil {
+		rec.TitleBlock = sh.titleBlock.def.name
+	}
+	return rec
+}
+
+// restore rebuilds one sheet from its recipe and appends it. A standard size derives
+// its dimensions from size+orientation; a custom size takes the persisted laid-out
+// dimensions verbatim.
+func (s *Sheets) restore(rec sheetRecipe) error {
+	size, ok := types.ParseSheetSize(rec.Size)
+	if !ok {
+		return fmt.Errorf("drawing: unknown sheet size %q", rec.Size)
+	}
+	orient, ok := types.ParseSheetOrientation(rec.Orientation)
+	if !ok {
+		orient = types.SheetPortrait
+	}
+	w, h, err := s.restoreDims(size, orient, rec)
+	if err != nil {
+		return err
+	}
+	sh := &Sheet{name: rec.Name, size: size, orientation: orient, width: w, height: h}
+	if rec.Border {
+		sh.border = newBorder(DefaultBorderDefinition())
+	}
+	if rec.TitleBlock != "" {
+		sh.titleBlock = newTitleBlock(DefaultTitleBlockDefinition(), s.lookup)
+	}
+	s.items = append(s.items, sh)
+	return nil
+}
+
+// restoreDims resolves a restored sheet's dimensions: the table value for a standard
+// size, or the persisted laid-out dimensions for a custom size.
+func (s *Sheets) restoreDims(size types.SheetSize, orient types.SheetOrientation, rec sheetRecipe) (float64, float64, error) {
+	if size == types.SheetSizeCustom {
+		if rec.WidthMM <= 0 || rec.HeightMM <= 0 {
+			return 0, 0, fmt.Errorf("drawing: custom sheet %q has non-positive dimensions %g×%g mm", rec.Name, rec.WidthMM, rec.HeightMM)
+		}
+		return rec.WidthMM, rec.HeightMM, nil
+	}
+	return laidOutDimsMM(size, orient, 0, 0)
+}
+
+// setActiveIndex clamps the restored active-sheet index into range.
+func (s *Sheets) setActiveIndex(i int) {
+	if i < 0 || i >= len(s.items) {
+		i = 0
+	}
+	s.active = i
+}

--- a/model/drawing/sheet.go
+++ b/model/drawing/sheet.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/api/types"
+)
+
+// propertyLookup resolves a referenced model's iProperty for a title block (set, name
+// → value). Title blocks hold this hook rather than a back-pointer to the document, so
+// the package stays free of doc/workspace dependencies.
+type propertyLookup func(set, name string) (string, bool)
+
+// Sheet is one sheet of a drawing: its size/orientation (which fix its laid-out width
+// and height in millimetres), its border, and its title block.
+type Sheet struct {
+	name        string
+	size        types.SheetSize
+	orientation types.SheetOrientation
+	width       float64 // laid-out mm (orientation applied)
+	height      float64
+	border      *Border
+	titleBlock  *TitleBlock
+}
+
+// compile-time: a sheet and its sub-objects satisfy the api/contract surface (ADR-0018).
+var (
+	_ contract.DrawingSheet      = (*Sheet)(nil)
+	_ contract.DrawingBorder     = (*Border)(nil)
+	_ contract.DrawingTitleBlock = (*TitleBlock)(nil)
+)
+
+// Name returns the sheet's display name (unique within the drawing).
+func (s *Sheet) Name() string { return s.name }
+
+// Size returns the standard sheet size, or types.SheetSizeCustom for an explicit
+// width/height.
+func (s *Sheet) Size() types.SheetSize { return s.size }
+
+// Orientation returns how the standard dimensions are laid out (portrait/landscape).
+func (s *Sheet) Orientation() types.SheetOrientation { return s.orientation }
+
+// WidthMM and HeightMM return the laid-out dimensions in millimetres.
+func (s *Sheet) WidthMM() float64  { return s.width }
+func (s *Sheet) HeightMM() float64 { return s.height }
+
+// Border returns the sheet's border as a contract.DrawingBorder, or nil if it has none.
+func (s *Sheet) Border() contract.DrawingBorder {
+	if s.border == nil {
+		return nil
+	}
+	return s.border
+}
+
+// TitleBlock returns the sheet's title block as a contract.DrawingTitleBlock, or nil if
+// it has none. Type-assert to *drawing.TitleBlock to enumerate its resolved fields.
+func (s *Sheet) TitleBlock() contract.DrawingTitleBlock {
+	if s.titleBlock == nil {
+		return nil
+	}
+	return s.titleBlock
+}
+
+// Sheets is a drawing's ordered, named sheet collection, tracking which sheet is active.
+type Sheets struct {
+	items  []*Sheet
+	active int
+	lookup propertyLookup // handed to each new title block; set by the owning Content
+}
+
+func newSheets() *Sheets { return &Sheets{} }
+
+// addDefault seeds the default first sheet (A3 landscape, bordered, standard title
+// block) — the state a freshly created drawing opens in.
+func (s *Sheets) addDefault() {
+	// A new drawing always starts with one valid sheet; the default spec cannot error.
+	_, _ = s.Add(SheetSpec{Size: types.SheetSizeA3, Orientation: types.SheetLandscape})
+}
+
+// Add appends a sheet built from spec, gives it a border and the standard title block,
+// and makes it the active sheet. A custom size needs positive WidthMM/HeightMM.
+func (s *Sheets) Add(spec SheetSpec) (*Sheet, error) {
+	w, h, err := laidOutDimsMM(spec.Size, spec.Orientation, spec.WidthMM, spec.HeightMM)
+	if err != nil {
+		return nil, err
+	}
+	name := spec.Name
+	if name == "" {
+		name = s.nextName()
+	}
+	if _, exists := s.ByName(name); exists {
+		return nil, fmt.Errorf("drawing: sheet %q already exists", name)
+	}
+	sh := &Sheet{
+		name: name, size: spec.Size, orientation: spec.Orientation, width: w, height: h,
+		border:     newBorder(DefaultBorderDefinition()),
+		titleBlock: newTitleBlock(DefaultTitleBlockDefinition(), s.lookup),
+	}
+	s.items = append(s.items, sh)
+	s.active = len(s.items) - 1
+	return sh, nil
+}
+
+// nextName returns the lowest unused "Sheet:N" name.
+func (s *Sheets) nextName() string {
+	for n := len(s.items) + 1; ; n++ {
+		name := fmt.Sprintf("Sheet:%d", n)
+		if _, exists := s.ByName(name); !exists {
+			return name
+		}
+	}
+}
+
+// Count returns the number of sheets.
+func (s *Sheets) Count() int { return len(s.items) }
+
+// Item returns the sheet at index i, or nil if out of range.
+func (s *Sheets) Item(i int) *Sheet {
+	if i < 0 || i >= len(s.items) {
+		return nil
+	}
+	return s.items[i]
+}
+
+// ByName returns the named sheet and whether it exists.
+func (s *Sheets) ByName(name string) (*Sheet, bool) {
+	for _, sh := range s.items {
+		if sh.name == name {
+			return sh, true
+		}
+	}
+	return nil, false
+}
+
+// Active returns the active sheet, or nil if the drawing has no sheets.
+func (s *Sheets) Active() *Sheet { return s.Item(s.active) }
+
+// SetActive makes the named sheet active, erroring if it does not exist.
+func (s *Sheets) SetActive(name string) error {
+	for i, sh := range s.items {
+		if sh.name == name {
+			s.active = i
+			return nil
+		}
+	}
+	return fmt.Errorf("drawing: no sheet named %q", name)
+}
+
+// Remove deletes the named sheet. A drawing must keep at least one sheet, so removing
+// the last one errors. The active sheet stays valid (it shifts to a neighbour).
+func (s *Sheets) Remove(name string) error {
+	if len(s.items) <= 1 {
+		return fmt.Errorf("drawing: cannot remove %q — a drawing must keep at least one sheet", name)
+	}
+	for i, sh := range s.items {
+		if sh.name == name {
+			s.items = append(s.items[:i], s.items[i+1:]...)
+			if s.active >= len(s.items) {
+				s.active = len(s.items) - 1
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("drawing: no sheet named %q", name)
+}

--- a/model/drawing/titleblock.go
+++ b/model/drawing/titleblock.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import "oblikovati.org/model/attr"
+
+// titleBlockField is one field of a title block: a label, and either a binding to a
+// referenced-model iProperty (set+prop) or a static literal (set==""). The value is
+// resolved on demand against the drawing's referenced model, so editing the model's
+// iProperties updates the title block.
+type titleBlockField struct {
+	name   string // the field label / key
+	set    string // iProperty set name; "" ⇒ static
+	prop   string // iProperty name within the set
+	static string // literal value when set==""
+}
+
+// source returns the field's wire source token ("Set:Prop"), or "" for a static field.
+func (f titleBlockField) source() string {
+	if f.set == "" {
+		return ""
+	}
+	return f.set + ":" + f.prop
+}
+
+// TitleBlockDefinition is a reusable title-block template: an ordered set of fields.
+// V1 ships one default whose fields bind to the standard iProperty sets; custom
+// definitions are a follow-up.
+type TitleBlockDefinition struct {
+	name   string
+	fields []titleBlockField
+}
+
+// DefaultTitleBlockDefinition is the standard title block: the common drafting fields,
+// each bound to the model iProperty that drives it.
+func DefaultTitleBlockDefinition() *TitleBlockDefinition {
+	return &TitleBlockDefinition{
+		name: "Default",
+		fields: []titleBlockField{
+			{name: "Title", set: attr.SummaryInformation, prop: "Title"},
+			{name: "Part Number", set: attr.DesignTracking, prop: "Part Number"},
+			{name: "Material", set: attr.DesignTracking, prop: "Material"},
+			{name: "Drawn By", set: attr.SummaryInformation, prop: "Author"},
+			{name: "Revision", set: attr.DesignTracking, prop: "Revision Number"},
+			{name: "Company", set: attr.DocumentSummary, prop: "Company"},
+		},
+	}
+}
+
+// Name returns the title-block definition's name.
+func (d *TitleBlockDefinition) Name() string { return d.name }
+
+// ResolvedField is a title-block field paired with its resolved value and the source it
+// resolved from (a "Set:Prop" iProperty token, or "" for static text).
+type ResolvedField struct {
+	Name   string
+	Value  string
+	Source string
+}
+
+// TitleBlock is a sheet's title block — an instance of a [TitleBlockDefinition] that
+// resolves its fields against the drawing's referenced model via the lookup hook.
+type TitleBlock struct {
+	def    *TitleBlockDefinition
+	lookup propertyLookup
+}
+
+func newTitleBlock(def *TitleBlockDefinition, lookup propertyLookup) *TitleBlock {
+	return &TitleBlock{def: def, lookup: lookup}
+}
+
+// DefinitionName returns the name of the title-block definition this block instantiates
+// (contract.DrawingTitleBlock).
+func (t *TitleBlock) DefinitionName() string { return t.def.name }
+
+// FieldValue resolves the named field against the referenced model, returning the value
+// and whether the field exists (contract.DrawingTitleBlock).
+func (t *TitleBlock) FieldValue(name string) (string, bool) {
+	f, ok := t.field(name)
+	if !ok {
+		return "", false
+	}
+	return t.resolve(f), true
+}
+
+// Fields returns every field resolved against the current referenced model — the title
+// block as the renderer and export draw it, in definition order.
+func (t *TitleBlock) Fields() []ResolvedField {
+	out := make([]ResolvedField, 0, len(t.def.fields))
+	for _, f := range t.def.fields {
+		out = append(out, ResolvedField{Name: f.name, Value: t.resolve(f), Source: f.source()})
+	}
+	return out
+}
+
+func (t *TitleBlock) field(name string) (titleBlockField, bool) {
+	for _, f := range t.def.fields {
+		if f.name == name {
+			return f, true
+		}
+	}
+	return titleBlockField{}, false
+}
+
+// resolve returns a field's value: static text directly, or the referenced model's
+// iProperty via the lookup hook (empty when no model is referenced or the property is
+// absent).
+func (t *TitleBlock) resolve(f titleBlockField) string {
+	if f.set == "" {
+		return f.static
+	}
+	if t.lookup == nil {
+		return ""
+	}
+	v, _ := t.lookup(f.set, f.prop)
+	return v
+}


### PR DESCRIPTION
## What

The modeling content behind the **drawing document type** — the implementation half of M14-F01 / PBI-137 (#384). The drawing *type* already existed (`DocumentDrawing`, `.odd`) but held an empty stub; a drawing now holds real sheets.

- **`model/drawing`** — a `Content` type registered as `doc.Drawing`'s real content (via `doc.RegisterContentFactory`), owning:
  - an ordered, named **`Sheets`** collection (add / remove / set-active; a drawing always keeps ≥1 sheet);
  - **`Sheet`** with a standard size (ISO A0–A4 / ANSI A–E) or a custom width×height, plus orientation → laid-out mm dimensions;
  - **`Border`/`BorderDefinition`** and **`TitleBlock`/`TitleBlockDefinition`** (default definitions shipped);
  - the **primary referenced model** the drawing documents, and the title-block resolution seam.
- **Title-block fields bind to the referenced model's iProperties** (`ModelProperties` resolver) and resolve on demand, so editing the model updates the title block.
- **Persistence**: `MarshalRecipe`/`ApplyRecipe` round-trip the sheets + reference; resolved title-block values are never stored (re-resolved on open). Proven with a full store save/open round-trip test.
- **`addin/router/drawing.go`** — the `drawing.*` handlers (list/add/remove/setActive sheets, setModelReference, titleBlockFields), resolving fields against the referenced model document's iProperties through the workspace.

A new drawing opens with one **A3-landscape sheet, bordered, with the standard title block** — the acceptance state for PBI-137.

## Why

PBI-137 needs the drawing to carry sheets and a property-driven title block. Per the chosen design, title-block fields resolve against the **referenced model's** iProperties, so the drawing carries a model reference independent of drawing views (F02). Built on the released `api/contract` surface (`oblikovati.org/api` v0.17.0).

## Test

- `model/drawing`: default-sheet state, auto-naming/activation, custom-dimension validation, remove-keeps-one, **title block resolves & tracks model iProperty edits**, recipe round-trip, full store save/open round-trip.
- `addin/router`: default sheet over the wire, sheet lifecycle, **title block resolves the referenced part's Part Number/Title**, blank without a reference.

Stacked on the merged API PR (Oblikovati.API#133). App commands (New Drawing / Add Sheet / title-block UI) and the head 2D sheet canvas follow in subsequent PRs.

Refs Oblikovati/Oblikovati#384

🤖 Generated with [Claude Code](https://claude.com/claude-code)