### PR TITLE
feat(drawing): New Drawing command, Drawing ribbon tab & 2D sheet canvas (M14-F01)

### DIFF
--- a/addin/router/drawing.go
+++ b/addin/router/drawing.go
@@ -5,13 +5,10 @@ package router
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
-	"oblikovati.org/model/attr"
-	"oblikovati.org/model/doc"
 	"oblikovati.org/model/drawing"
 )
 
@@ -29,20 +26,11 @@ func (r *Router) registerDrawingHandlers() {
 	r.handlers[wire.MethodDrawingTitleBlockFields] = drawingTitleBlockFields
 }
 
-// activeDrawing returns the active document's drawing content, erroring if no drawing is
-// active. It (re)wires the title-block resolver to the workspace so fields resolve
-// against the current referenced model.
+// activeDrawing returns the active document's drawing content with its title-block
+// resolver wired to the workspace (app.ActiveDrawing is shared with the Drawing-tab tools
+// and the head sheet canvas, so resolution behaves identically on every path).
 func activeDrawing(s *app.Session) (*drawing.Content, error) {
-	d := s.ActiveDocument()
-	if d == nil {
-		return nil, fmt.Errorf("drawing: no active document")
-	}
-	c, ok := d.Content().(*drawing.Content)
-	if !ok {
-		return nil, fmt.Errorf("drawing: active document %q is not a drawing", d.FullDocumentName())
-	}
-	c.SetModelProperties(referencedModelProperties{ws: s.Workspace(), ref: c.ModelReference})
-	return c, nil
+	return app.ActiveDrawing(s)
 }
 
 func drawingListSheets(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
@@ -204,50 +192,4 @@ func titleBlockFieldsResult(sh *drawing.Sheet) wire.TitleBlockFieldsResult {
 		out.Fields = append(out.Fields, wire.TitleBlockField{Name: f.Name, Value: f.Value, Source: f.Source})
 	}
 	return out
-}
-
-// referencedModelProperties resolves a drawing's referenced model iProperties by looking
-// the document up by name in the workspace on each read (so it tracks the model being
-// opened or edited after the drawing references it). ref re-reads the drawing's current
-// reference so a later setModelReference is honoured.
-type referencedModelProperties struct {
-	ws  *doc.Workspace
-	ref func() string
-}
-
-func (p referencedModelProperties) Property(set, name string) (string, bool) {
-	d, ok := p.ws.ByName(p.ref())
-	if !ok || d.Content() == nil {
-		return "", false
-	}
-	props, ok := d.Content().(interface{ Properties() *attr.PropertySets })
-	if !ok {
-		return "", false
-	}
-	ps, ok := props.Properties().Lookup(set)
-	if !ok {
-		return "", false
-	}
-	prop, ok := ps.Property(name)
-	if !ok {
-		return "", false
-	}
-	return propertyText(prop.Value()), true
-}
-
-// propertyText renders an iProperty value as the plain text a title block shows.
-func propertyText(v attr.Value) string {
-	if s, ok := v.Str(); ok {
-		return s
-	}
-	if i, ok := v.Int(); ok {
-		return strconv.FormatInt(i, 10)
-	}
-	if f, ok := v.Float(); ok {
-		return strconv.FormatFloat(f, 'g', -1, 64)
-	}
-	if b, ok := v.Bool(); ok {
-		return strconv.FormatBool(b)
-	}
-	return ""
 }

--- a/app/add_sheet_tool.go
+++ b/app/add_sheet_tool.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/drawing"
+)
+
+// sheetSizeChoice pairs a New Sheet dropdown label with the size it selects, in dropdown
+// order (index → size).
+type sheetSizeChoice struct {
+	label string
+	size  types.SheetSize
+}
+
+var sheetSizeChoices = []sheetSizeChoice{
+	{"Custom", types.SheetSizeCustom},
+	{"A0", types.SheetSizeA0},
+	{"A1", types.SheetSizeA1},
+	{"A2", types.SheetSizeA2},
+	{"A3", types.SheetSizeA3},
+	{"A4", types.SheetSizeA4},
+	{"ANSI A", types.SheetSizeAnsiA},
+	{"ANSI B", types.SheetSizeAnsiB},
+	{"ANSI C", types.SheetSizeAnsiC},
+	{"ANSI D", types.SheetSizeAnsiD},
+	{"ANSI E", types.SheetSizeAnsiE},
+}
+
+func sheetSizeIndexOf(s types.SheetSize) int {
+	for i, c := range sheetSizeChoices {
+		if c.size == s {
+			return i
+		}
+	}
+	return 0
+}
+
+// AddSheetTool adds a sheet to the active drawing. It is a dialog-only tool (no picks):
+// the user chooses a standard size or a custom width×height and an orientation, then OK
+// adds the sheet and makes it active.
+type AddSheetTool struct {
+	sizeIndex   int
+	orientation int // index into {portrait, landscape}
+	widthMM     float64
+	heightMM    float64
+}
+
+// NewAddSheetTool starts on the default A3 landscape sheet (the drawing's default sheet).
+func NewAddSheetTool() *AddSheetTool {
+	return &AddSheetTool{
+		sizeIndex:   sheetSizeIndexOf(types.SheetSizeA3),
+		orientation: int(types.SheetLandscape),
+		widthMM:     297,
+		heightMM:    210,
+	}
+}
+
+func (t *AddSheetTool) Name() string              { return "New Sheet" }
+func (t *AddSheetTool) Start(*Session)            {}
+func (t *AddSheetTool) Pick(*Session, Selectable) {}
+func (t *AddSheetTool) CanCommit() bool           { return true }
+func (t *AddSheetTool) Cancel(*Session)           {}
+
+// Commit adds the configured sheet to the active drawing.
+func (t *AddSheetTool) Commit(s *Session) error {
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		return err
+	}
+	idx := t.sizeIndex
+	if idx < 0 || idx >= len(sheetSizeChoices) {
+		idx = 0
+	}
+	spec := drawing.SheetSpec{
+		Size:        sheetSizeChoices[idx].size,
+		Orientation: types.SheetOrientation(t.orientation),
+		WidthMM:     t.widthMM,
+		HeightMM:    t.heightMM,
+	}
+	if _, err := c.Sheets().Add(spec); err != nil {
+		return err
+	}
+	s.ActiveDocument().MarkDirty()
+	return nil
+}
+
+// Params exposes the size, orientation and custom-dimension fields for the property
+// dialog (the width/height fields apply only when Size is Custom).
+func (t *AddSheetTool) Params() ToolParams {
+	sizeLabels := make([]string, len(sheetSizeChoices))
+	for i, c := range sheetSizeChoices {
+		sizeLabels[i] = c.label
+	}
+	return ToolParams{
+		Choices: []ChoiceParam{
+			{Label: "Size", Options: sizeLabels, Get: func() int { return t.sizeIndex }, Set: func(i int) { t.sizeIndex = i }},
+			{Label: "Orientation", Options: []string{"Portrait", "Landscape"}, Get: func() int { return t.orientation }, Set: func(i int) { t.orientation = i }},
+		},
+		Floats: []FloatParam{
+			{"Width (mm)", func() float64 { return t.widthMM }, func(v float64) { t.widthMM = v }},
+			{"Height (mm)", func() float64 { return t.heightMM }, func(v float64) { t.heightMM = v }},
+		},
+	}
+}

--- a/app/commands_drawing.go
+++ b/app/commands_drawing.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Drawing ribbon commands (M14-F01, #384). New Drawing launches a drawing document from
+// the ZeroDoc ribbon (alongside New Part / New Assembly). The Drawing tab — shown on the
+// drawing ribbon — manages the document's sheets and the model it documents: each command
+// starts a dialog-only tool (the GUI counterpart of the drawing.* wire surface).
+
+// newDrawingCommand is the New Drawing launch action on the Get Started tab.
+func newDrawingCommand() *CommandDefinition {
+	return NewCommand("GetStarted.NewDrawing", "New Drawing", "Launch", func(s *Session) error {
+		_, err := s.NewDrawing()
+		return err
+	}).WithTab("Get Started").WithRibbons(ZeroDocRibbon).
+		WithIcon("new-drawing").WithButtonStyle(LargeIconButton).
+		WithTooltip("New Drawing — create a drawing document with one sheet, where you lay out views and annotations of a model.")
+}
+
+// drawingTabCommands are the Drawing tab: the Sheets panel (add/delete sheets) and the
+// Setup panel (choose the model the drawing documents).
+func drawingTabCommands() []*CommandDefinition {
+	return []*CommandDefinition{
+		drawingToolCommand("New Sheet", "Sheets", "sheet-add",
+			"Add a sheet to the drawing — choose a standard size (ISO A or ANSI) or a custom size and orientation.",
+			func() Tool { return NewAddSheetTool() }),
+		NewCommand("Drawing.DeleteSheet", "Delete Sheet", "Sheets", deleteActiveSheet).
+			WithTab("Drawing").WithRibbons(DrawingRibbon).WithEnable(canDeleteSheet).
+			WithIcon("sheet-delete").WithButtonStyle(SmallIconButton).
+			WithTooltip("Delete the active sheet (a drawing must keep at least one sheet)."),
+		drawingToolCommand("Model Reference", "Setup", "drawing-model",
+			"Choose the model this drawing documents; its iProperties fill the title-block fields.",
+			func() Tool { return NewModelReferenceTool() }),
+	}
+}
+
+// drawingToolCommand builds a Drawing-tab command that starts the given tool, enabled only
+// when a drawing is active (mirrors sheetMetalToolCommand).
+func drawingToolCommand(name, panel, icon, tip string, newTool func() Tool) *CommandDefinition {
+	return NewCommand("Drawing."+stripSpaces(name), name, panel, func(s *Session) error {
+		s.StartTool(newTool())
+		return nil
+	}).WithTab("Drawing").WithRibbons(DrawingRibbon).WithEnable(hasActiveDrawing).
+		WithIcon(icon).WithButtonStyle(LargeIconButton).WithTooltip(tip)
+}
+
+// deleteActiveSheet removes the active sheet from the active drawing.
+func deleteActiveSheet(s *Session) error {
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		return err
+	}
+	active := c.Sheets().Active()
+	if active == nil {
+		return nil
+	}
+	if err := c.Sheets().Remove(active.Name()); err != nil {
+		return err
+	}
+	s.ActiveDocument().MarkDirty()
+	return nil
+}
+
+// canDeleteSheet reports whether the active drawing has more than one sheet (a drawing
+// must keep at least one), so the Delete Sheet button is inert on a single-sheet drawing.
+func canDeleteSheet(s *Session) bool {
+	c, err := ActiveDrawing(s)
+	return err == nil && c.Sheets().Count() > 1
+}

--- a/app/commands_drawing_test.go
+++ b/app/commands_drawing_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/compdef"
+)
+
+// drawingSession returns a session with a part "widget.opd" carrying iProperties and an
+// active drawing created through Session.NewDrawing (so its resolver is wired).
+func drawingSession(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	part, err := compdef.AddPart(s.Workspace(), "widget.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	props := part.Content().(*compdef.PartComponentDefinition).Properties()
+	props.Set(attr.DesignTracking).Put("Part Number", attr.StringValue("PN-7"))
+	if _, err := s.NewDrawing(); err != nil {
+		t.Fatalf("NewDrawing: %v", err)
+	}
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	return s
+}
+
+func TestNewDrawingActivatesDrawingWithDefaultSheet(t *testing.T) {
+	s := drawingSession(t)
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		t.Fatalf("ActiveDrawing: %v", err)
+	}
+	if c.Sheets().Count() != 1 || c.Sheets().Active().Size() != types.SheetSizeA3 {
+		t.Errorf("new drawing = %d sheets / %v, want 1 / A3", c.Sheets().Count(), c.Sheets().Active().Size())
+	}
+	if !hasActiveDrawing(s) {
+		t.Error("hasActiveDrawing should be true with a drawing active")
+	}
+}
+
+func TestDrawingRibbonTabAndPanels(t *testing.T) {
+	tab, ok := BuildRibbon(drawingSession(t)).Tab("Drawing")
+	if !ok {
+		t.Fatal("an active drawing should show the Drawing ribbon tab")
+	}
+	for _, panel := range []string{"Sheets", "Setup"} {
+		if _, ok := tab.Panel(panel); !ok {
+			t.Errorf("Drawing tab has no %s panel", panel)
+		}
+	}
+}
+
+func TestDrawingTabAbsentForPart(t *testing.T) {
+	s := NewSession()
+	if _, err := s.NewPart(); err != nil {
+		t.Fatalf("NewPart: %v", err)
+	}
+	if _, ok := BuildRibbon(s).Tab("Drawing"); ok {
+		t.Error("a part ribbon should not show the Drawing tab")
+	}
+}
+
+func TestAddSheetToolAddsConfiguredSheet(t *testing.T) {
+	s := drawingSession(t)
+	tool := NewAddSheetTool()
+	tool.Start(s)
+	// Choose A4 portrait via the exposed params, as the dialog would.
+	p := tool.Params()
+	p.Choices[0].Set(sheetSizeIndexOf(types.SheetSizeA4))
+	p.Choices[1].Set(int(types.SheetPortrait))
+	if !tool.CanCommit() {
+		t.Fatal("AddSheetTool should be committable")
+	}
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	c, _ := ActiveDrawing(s)
+	if c.Sheets().Count() != 2 {
+		t.Fatalf("sheet count = %d, want 2", c.Sheets().Count())
+	}
+	added := c.Sheets().Active()
+	if added.Size() != types.SheetSizeA4 || added.WidthMM() != 210 {
+		t.Errorf("added sheet = %v %g wide, want A4 210", added.Size(), added.WidthMM())
+	}
+}
+
+// TestModelReferenceToolDrivesTitleBlock is the PBI-137 acceptance through the UI tool:
+// referencing the part fills the title block from its iProperties.
+func TestModelReferenceToolDrivesTitleBlock(t *testing.T) {
+	s := drawingSession(t)
+	tool := NewModelReferenceTool()
+	tool.Start(s)
+	if !tool.CanCommit() {
+		t.Fatal("ModelReferenceTool should be committable with an open model")
+	}
+	// The only referenceable model is widget.opd.
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	c, _ := ActiveDrawing(s)
+	if c.ModelReference() != "widget.opd" {
+		t.Fatalf("model reference = %q, want widget.opd", c.ModelReference())
+	}
+	tb := c.Sheets().Active().TitleBlock()
+	if v, _ := tb.FieldValue("Part Number"); v != "PN-7" {
+		t.Errorf("title block Part Number = %q, want PN-7", v)
+	}
+}
+
+func TestDeleteSheetKeepsAtLeastOne(t *testing.T) {
+	s := drawingSession(t)
+	if canDeleteSheet(s) {
+		t.Error("a single-sheet drawing should not allow delete")
+	}
+	if err := NewAddSheetTool().Commit(s); err != nil {
+		t.Fatalf("add sheet: %v", err)
+	}
+	if !canDeleteSheet(s) {
+		t.Fatal("a two-sheet drawing should allow delete")
+	}
+	if err := deleteActiveSheet(s); err != nil {
+		t.Fatalf("deleteActiveSheet: %v", err)
+	}
+	c, _ := ActiveDrawing(s)
+	if c.Sheets().Count() != 1 {
+		t.Errorf("sheet count after delete = %d, want 1", c.Sheets().Count())
+	}
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -39,6 +39,8 @@ func standardCommands() []*CommandDefinition {
 	cmds = append(cmds, sketchTabCommands()...)
 	cmds = append(cmds, assemblyTabCommands()...)
 	cmds = append(cmds, sheetMetalTabCommands()...)
+	cmds = append(cmds, newDrawingCommand())
+	cmds = append(cmds, drawingTabCommands()...)
 	cmds = append(cmds, viewTabCommands()...)
 	return cmds
 }

--- a/app/drawing_environment.go
+++ b/app/drawing_environment.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"strconv"
+
+	"oblikovati.org/event"
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/drawing"
+)
+
+// The drawing environment (M14-F01, #384): creating a drawing document and reaching the
+// active drawing's content, with its title-block fields wired to resolve against the
+// referenced model's iProperties. New Drawing is the launch action; ActiveDrawing backs
+// the Drawing-tab tools and the head's sheet canvas.
+
+// NewDrawing creates a drawing document with a unique "DrawingN" name and makes it
+// active (the workspace activates a newly added document), so the ribbon switches to the
+// drawing environment. It mirrors [Session.NewPart] / [Session.NewAssembly] and backs the
+// New Drawing command on the ZeroDoc ribbon.
+//
+//	d, err := session.NewDrawing()
+func (s *Session) NewDrawing() (*doc.Document, error) {
+	ev := FileNew{DocumentType: doc.Drawing}
+	if out := event.Emit(s.bus, event.Before, ev); out.Vetoed() {
+		s.notice = out.Reason
+		return nil, &doc.VetoError{Operation: "new drawing", Reason: out.Reason}
+	}
+	d, err := s.workspace.Add(doc.Drawing, s.uniqueDocumentName("Drawing"), true)
+	if err != nil {
+		return nil, err
+	}
+	wireDrawingResolver(s, d)
+	s.documentHistory(d) // open the event stream now so the first sheet edit is undoable
+	event.Emit(s.bus, event.After, ev)
+	return d, nil
+}
+
+// ActiveDrawing returns the active document's drawing content with its title-block
+// resolver wired to the workspace, or an error if the active document is not a drawing.
+// Both the Drawing-tab tools and the router's drawing.* handlers go through it.
+func ActiveDrawing(s *Session) (*drawing.Content, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, fmt.Errorf("drawing: no active document")
+	}
+	c, ok := d.Content().(*drawing.Content)
+	if !ok {
+		return nil, fmt.Errorf("drawing: active document %q is not a drawing", d.FullDocumentName())
+	}
+	c.SetModelProperties(referencedModelProperties{ws: s.workspace, ref: c.ModelReference})
+	return c, nil
+}
+
+// hasActiveDrawing reports whether the active document is a drawing — the enable
+// predicate for the Drawing ribbon tab (mirrors [hasActivePart]).
+func hasActiveDrawing(s *Session) bool {
+	c, _ := ActiveDrawing(s)
+	return c != nil
+}
+
+// wireDrawingResolver injects the workspace-backed iProperty resolver into a drawing's
+// content so its title block resolves against the referenced model — for in-proc readers
+// (the head sheet canvas) that do not go through ActiveDrawing.
+func wireDrawingResolver(s *Session, d *doc.Document) {
+	if c, ok := d.Content().(*drawing.Content); ok {
+		c.SetModelProperties(referencedModelProperties{ws: s.workspace, ref: c.ModelReference})
+	}
+}
+
+// referencedModelProperties resolves a drawing's referenced model iProperties by looking
+// the document up by name in the workspace on each read (so it tracks the model being
+// opened or edited after the drawing references it). ref re-reads the drawing's current
+// reference so a later setModelReference is honoured.
+type referencedModelProperties struct {
+	ws  *doc.Workspace
+	ref func() string
+}
+
+func (p referencedModelProperties) Property(set, name string) (string, bool) {
+	d, ok := p.ws.ByName(p.ref())
+	if !ok || d.Content() == nil {
+		return "", false
+	}
+	props, ok := d.Content().(interface{ Properties() *attr.PropertySets })
+	if !ok {
+		return "", false
+	}
+	ps, ok := props.Properties().Lookup(set)
+	if !ok {
+		return "", false
+	}
+	prop, ok := ps.Property(name)
+	if !ok {
+		return "", false
+	}
+	return propertyText(prop.Value()), true
+}
+
+// propertyText renders an iProperty value as the plain text a title block shows.
+func propertyText(v attr.Value) string {
+	if s, ok := v.Str(); ok {
+		return s
+	}
+	if i, ok := v.Int(); ok {
+		return strconv.FormatInt(i, 10)
+	}
+	if f, ok := v.Float(); ok {
+		return strconv.FormatFloat(f, 'g', -1, 64)
+	}
+	if b, ok := v.Bool(); ok {
+		return strconv.FormatBool(b)
+	}
+	return ""
+}

--- a/app/model_reference_tool.go
+++ b/app/model_reference_tool.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/doc"
+)
+
+// ModelReferenceTool sets the model the active drawing documents — the part or assembly
+// whose iProperties fill the title block. It is a dialog-only tool: the user picks one of
+// the open part/assembly documents and OK stores the reference.
+type ModelReferenceTool struct {
+	candidates []string // full document names of the open part/assembly documents
+	selected   int
+}
+
+// NewModelReferenceTool creates the tool; its candidate list is captured on Start.
+func NewModelReferenceTool() *ModelReferenceTool { return &ModelReferenceTool{} }
+
+func (t *ModelReferenceTool) Name() string { return "Model Reference" }
+
+// Start captures the open models that can be referenced, pre-selecting the drawing's
+// current reference if it is among them.
+func (t *ModelReferenceTool) Start(s *Session) {
+	t.candidates = referenceableModels(s)
+	if c, err := ActiveDrawing(s); err == nil {
+		for i, name := range t.candidates {
+			if name == c.ModelReference() {
+				t.selected = i
+			}
+		}
+	}
+}
+
+func (t *ModelReferenceTool) Pick(*Session, Selectable) {}
+
+// CanCommit requires at least one open model to reference.
+func (t *ModelReferenceTool) CanCommit() bool { return len(t.candidates) > 0 }
+
+func (t *ModelReferenceTool) Cancel(*Session) {}
+
+// Commit stores the selected model as the drawing's referenced model.
+func (t *ModelReferenceTool) Commit(s *Session) error {
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		return err
+	}
+	if t.selected < 0 || t.selected >= len(t.candidates) {
+		return fmt.Errorf("drawing: no model selected (%d open models)", len(t.candidates))
+	}
+	c.SetModelReference(t.candidates[t.selected])
+	s.ActiveDocument().MarkDirty()
+	return nil
+}
+
+// Params exposes the open-model dropdown for the property dialog.
+func (t *ModelReferenceTool) Params() ToolParams {
+	return ToolParams{Choices: []ChoiceParam{
+		{Label: "Model", Options: t.candidates, Get: func() int { return t.selected }, Set: func(i int) { t.selected = i }},
+	}}
+}
+
+// referenceableModels returns the full document names of the open part and assembly
+// documents — the models a drawing can document (drawings and presentations are excluded).
+func referenceableModels(s *Session) []string {
+	var names []string
+	for _, d := range s.workspace.Documents() {
+		switch d.DocumentType() {
+		case doc.Part, doc.Assembly:
+			names = append(names, d.FullDocumentName())
+		}
+	}
+	return names
+}

--- a/head/icon/assets/drawing-model.svg
+++ b/head/icon/assets/drawing-model.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 5 H12 V19 H3 Z"/><path d="M15 9 L19 7 L23 9 L19 11 Z M15 9 V14 L19 16 V11 M23 9 V14 L19 16" stroke="#ff0000" stroke-width="1.6"/></svg>

--- a/head/icon/assets/new-drawing.svg
+++ b/head/icon/assets/new-drawing.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 3 H13 V21 H4 Z"/><path d="M6 15 H11 M6 18 H11" stroke-width="1.4"/><path d="M19 3 V9 M16 6 H22" stroke="#ff0000"/></svg>

--- a/head/icon/assets/sheet-add.svg
+++ b/head/icon/assets/sheet-add.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 4 H14 V20 H4 Z"/><path d="M19 4 V12 M15 8 H23" stroke="#ff0000"/></svg>

--- a/head/icon/assets/sheet-delete.svg
+++ b/head/icon/assets/sheet-delete.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 4 H14 V20 H4 Z"/><path d="M16 8 L22 14 M22 8 L16 14" stroke="#ff0000"/></svg>

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -29,6 +29,12 @@ func drawViewportPanel(win *native.Window, s *app.Session) {
 	win.SetViewportNormalDebug(normalDebugOn || s.NormalDebug()) // Tools ▸ Normal Debug, or viewport.setNormalDebug
 	if native.Begin("Viewport") {
 		drawDocumentTabs(s)
+		// A drawing document shows a 2D sheet canvas, not the 3D viewport (M14-F01).
+		if dc, err := app.ActiveDrawing(s); err == nil {
+			drawSheetCanvas(dc)
+			native.End()
+			return
+		}
 		// View configuration (layout, new/close view) lives on the View ribbon tab's
 		// Windows panel — see app.windowsViewCommands.
 		// Per-document views can tile (split layouts); a single view takes the classic

--- a/head/ui/sheet_canvas.go
+++ b/head/ui/sheet_canvas.go
@@ -1,0 +1,172 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/drawing"
+)
+
+// The drawing sheet canvas (M14-F01, #384): a 2D view of the active drawing's active
+// sheet drawn directly into the viewport panel (ImGui draw-list, no 3D pipeline). It
+// renders the sheet face, its border, and the title block with the fields resolved from
+// the referenced model's iProperties — so a drawing document shows a real sheet instead
+// of an empty 3D viewport.
+
+// Canvas colors (0..1 RGBA): a dark mat, a paper-white sheet, dark ink, and faint rules.
+var (
+	canvasMat  = [4]float32{0.16, 0.17, 0.19, 1}
+	sheetPaper = [4]float32{0.96, 0.96, 0.94, 1}
+	sheetInk   = [4]float32{0.10, 0.10, 0.12, 1}
+	sheetFaint = [4]float32{0.42, 0.43, 0.47, 1}
+	captionInk = [4]float32{0.80, 0.82, 0.86, 1}
+	titleLabel = [4]float32{0.35, 0.36, 0.40, 1}
+)
+
+// rect is a screen-space rectangle (top-left origin) plus the mm→pixel scale that
+// produced it, so nested geometry (border, title block) shares one scale.
+type rect struct {
+	x, y, w, h float32
+	scale      float32
+}
+
+// drawSheetCanvas renders the active drawing's active sheet across the viewport panel.
+// It reads the resolved content directly (display-only in F01; canvas interaction arrives
+// with drawing views in F02).
+func drawSheetCanvas(c *drawing.Content) {
+	sheet := c.Sheets().Active()
+	ox, oy := native.GetCursorScreenPos()
+	availW, availH := native.ContentRegionAvail()
+	native.InvisibleButton("##sheet-canvas", availW, availH) // reserve the region
+	native.DrawQuadFilled(ox, oy, ox+availW, oy, ox+availW, oy+availH, ox, oy+availH, canvasMat)
+	if sheet == nil {
+		native.DrawText(ox+12, oy+12, "Drawing has no sheet", captionInk)
+		return
+	}
+	face := fitSheet(ox, oy, availW, availH, sheet.WidthMM(), sheet.HeightMM())
+	drawSheetFace(face)
+	inner := drawSheetBorder(face, sheet)
+	drawTitleBlock(inner, sheet)
+	drawSheetCaption(ox, oy, sheet, c.ModelReference())
+}
+
+// fitSheet centers the sheet (given in mm) inside the panel with padding and returns its
+// screen rectangle and the mm→pixel scale.
+func fitSheet(ox, oy, availW, availH float32, sheetWmm, sheetHmm float64) rect {
+	const pad = 40
+	scale := minf(float64(availW-2*pad)/sheetWmm, float64(availH-2*pad)/sheetHmm)
+	if scale <= 0 {
+		scale = 1
+	}
+	w := float32(sheetWmm * scale)
+	h := float32(sheetHmm * scale)
+	return rect{x: ox + (availW-w)/2, y: oy + (availH-h)/2, w: w, h: h, scale: float32(scale)}
+}
+
+// drawSheetFace paints the paper-white sheet and outlines it.
+func drawSheetFace(r rect) {
+	native.DrawQuadFilled(r.x, r.y, r.x+r.w, r.y, r.x+r.w, r.y+r.h, r.x, r.y+r.h, sheetPaper)
+	rectOutline(r, sheetInk, 1.5)
+}
+
+// drawSheetBorder insets the sheet by its border margins (mm) and outlines the printable
+// area, returning that inner rectangle for the title block. With no border it returns the
+// full face.
+func drawSheetBorder(face rect, sheet *drawing.Sheet) rect {
+	b := sheet.Border()
+	if b == nil {
+		return face
+	}
+	left, right, top, bottom := b.Margins()
+	inner := rect{
+		x:     face.x + float32(left)*face.scale,
+		y:     face.y + float32(top)*face.scale,
+		w:     face.w - float32(left+right)*face.scale,
+		h:     face.h - float32(top+bottom)*face.scale,
+		scale: face.scale,
+	}
+	rectOutline(inner, sheetInk, 1)
+	return inner
+}
+
+// drawTitleBlock draws the title block at the inner area's lower-right, one row per
+// resolved field (label on the left, value on the right).
+func drawTitleBlock(inner rect, sheet *drawing.Sheet) {
+	tb, ok := sheet.TitleBlock().(*drawing.TitleBlock)
+	if !ok {
+		return
+	}
+	fields := tb.Fields()
+	if len(fields) == 0 {
+		return
+	}
+	box := titleBlockRect(inner, len(fields))
+	native.DrawQuadFilled(box.x, box.y, box.x+box.w, box.y, box.x+box.w, box.y+box.h, box.x, box.y+box.h, sheetPaper)
+	rectOutline(box, sheetInk, 1.5)
+	rowH := box.h / float32(len(fields))
+	for i, f := range fields {
+		ry := box.y + float32(i)*rowH
+		if i > 0 {
+			native.DrawLine(box.x, ry, box.x+box.w, ry, sheetFaint, 1)
+		}
+		native.DrawText(box.x+4, ry+2, f.Name, titleLabel)
+		native.DrawText(box.x+box.w*0.42, ry+2, f.Value, sheetInk)
+	}
+}
+
+// titleBlockRect places the title block: 70 mm wide (clamped to the inner width and a
+// readable minimum) and a readable row height, anchored to the inner lower-right corner.
+func titleBlockRect(inner rect, rows int) rect {
+	w := clampf(70*inner.scale, 150, inner.w)
+	rowH := maxf(7*inner.scale, 14)
+	h := rowH * float32(rows)
+	return rect{x: inner.x + inner.w - w, y: inner.y + inner.h - h, w: w, h: h, scale: inner.scale}
+}
+
+// drawSheetCaption labels the canvas (top-left) with the sheet and the referenced model.
+func drawSheetCaption(ox, oy float32, sheet *drawing.Sheet, modelRef string) {
+	caption := fmt.Sprintf("%s — %s %s (%.0f×%.0f mm)",
+		sheet.Name(), sheet.Size(), sheet.Orientation(), sheet.WidthMM(), sheet.HeightMM())
+	native.DrawText(ox+12, oy+10, caption, captionInk)
+	model := modelRef
+	if model == "" {
+		model = "(no model referenced)"
+	}
+	native.DrawText(ox+12, oy+28, "Model: "+model, captionInk)
+}
+
+// rectOutline strokes a rectangle's four edges.
+func rectOutline(r rect, c [4]float32, th float32) {
+	native.DrawLine(r.x, r.y, r.x+r.w, r.y, c, th)
+	native.DrawLine(r.x+r.w, r.y, r.x+r.w, r.y+r.h, c, th)
+	native.DrawLine(r.x+r.w, r.y+r.h, r.x, r.y+r.h, c, th)
+	native.DrawLine(r.x, r.y+r.h, r.x, r.y, c, th)
+}
+
+func minf(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxf(a, b float32) float32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func clampf(v, lo, hi float32) float32 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/head/ui/sheet_canvas_test.go
+++ b/head/ui/sheet_canvas_test.go
@@ -1,0 +1,50 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// TestFitSheetCentersAndScales checks the sheet fits inside the panel with padding,
+// preserves aspect (uniform scale), and is centered.
+func TestFitSheetCentersAndScales(t *testing.T) {
+	// A landscape A3 (420×297 mm) in an 840×600 panel at origin (0,0). After 40 px
+	// padding each side: width fit (840-80)/420 ≈ 1.810, height fit (600-80)/297 ≈ 1.751.
+	// Height is the tighter constraint, so it sets the uniform scale.
+	r := fitSheet(0, 0, 840, 600, 420, 297)
+	wantScale := float32((600.0 - 80) / 297.0)
+	if d := r.scale - wantScale; d < -1e-3 || d > 1e-3 {
+		t.Errorf("scale = %g, want %g", r.scale, wantScale)
+	}
+	if d := r.w - 420*r.scale; d < -1e-3 || d > 1e-3 {
+		t.Errorf("width = %g, want %g", r.w, 420*r.scale)
+	}
+	// Centered: equal margins left/right.
+	if leftMargin, rightMargin := r.x, 840-(r.x+r.w); abs32(leftMargin-rightMargin) > 1e-2 {
+		t.Errorf("not horizontally centered: left=%g right=%g", leftMargin, rightMargin)
+	}
+	if r.y <= 0 || r.y+r.h >= 600 {
+		t.Errorf("sheet not within panel vertically: y=%g h=%g", r.y, r.h)
+	}
+}
+
+// TestTitleBlockRectAnchorsLowerRight checks the title block sits at the inner area's
+// lower-right corner and stays within it.
+func TestTitleBlockRectAnchorsLowerRight(t *testing.T) {
+	inner := rect{x: 100, y: 50, w: 600, h: 400, scale: 2}
+	box := titleBlockRect(inner, 6)
+	if box.x+box.w-(inner.x+inner.w) > 1e-3 || box.y+box.h-(inner.y+inner.h) > 1e-3 {
+		t.Errorf("title block not anchored to lower-right: box=%+v inner=%+v", box, inner)
+	}
+	if box.x < inner.x || box.y < inner.y {
+		t.Errorf("title block escapes the inner area: box=%+v inner=%+v", box, inner)
+	}
+}
+
+func abs32(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}


### PR DESCRIPTION
## What

The **interactive surface** for the drawing document — completing M14-F01 / PBI-137 (#384) end-to-end (model + wire were the prior PRs; this adds the GUI so the feature is usable, per "feature done means UI too").

**App — commands & tools**
- **New Drawing** on the Get Started tab (next to New Part / New Assembly), backed by `Session.NewDrawing`; opens a drawing with one A3-landscape sheet.
- A contextual **Drawing ribbon tab** (shown only for a drawing): **New Sheet** / **Delete Sheet** (Sheets panel) and **Model Reference** (Setup panel). Each is a dialog-only `ParameterizedTool`, so the head's generic property dialog renders it:
  - *New Sheet* — pick a standard size (ISO A0–A4 / ANSI A–E) or a custom width×height, and orientation.
  - *Model Reference* — pick one of the open part/assembly documents to document.
- `ActiveDrawing` centralises reaching the active drawing's content with its title-block resolver wired to the workspace; the `drawing.*` router handlers now share it (the resolver **moved out of `addin/router` into `app`**, removing the duplicate from the prior PR).

**Head — 2D sheet canvas**
- A drawing document renders a **2D sheet canvas** in the viewport panel (ImGui draw-list — no 3D pipeline): the sheet face, its border, and the **title block with fields resolved live from the referenced model's iProperties**.
- New ribbon icons: `new-drawing`, `sheet-add`, `sheet-delete`, `drawing-model`.

## Why

A drawing needed a way in (New Drawing), a way to manage its sheets and the model it documents, and a way to *see* the sheet. The canvas reads the same `model/drawing` content the wire path does, so what the head shows matches `drawing.titleBlockFields`.

## Test

- `app`: New Drawing activates a drawing with the default sheet; Drawing tab shows Sheets/Setup panels (and is absent for a part); New Sheet tool adds a configured sheet; **Model Reference tool fills the title block from the part's iProperties**; Delete Sheet keeps ≥1.
- `head/ui`: sheet-fit centering/scale and title-block lower-right placement; ribbon-icon coverage (the four new icons resolve to conforming assets).

Stacked on the merged model+router PR (#970). Bridge e2e + closing #384 follow.

Refs Oblikovati/Oblikovati#384

🤖 Generated with [Claude Code](https://claude.com/claude-code)