### PR TITLE
feat(drawing): drawing sheet DXF export (M14-F05 PBI-145)

### DIFF
--- a/addin/router/drawing.go
+++ b/addin/router/drawing.go
@@ -10,6 +10,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/drawing"
+	"oblikovati.org/model/exchange"
 )
 
 // The drawing-document sheet surface (M14-F01, #384): list/add/remove sheets, pick the
@@ -24,6 +25,33 @@ func (r *Router) registerDrawingHandlers() {
 	r.handlers[wire.MethodDrawingSetActiveSheet] = drawingSetActiveSheet
 	r.handlers[wire.MethodDrawingSetModelReference] = drawingSetModelReference
 	r.handlers[wire.MethodDrawingTitleBlockFields] = drawingTitleBlockFields
+	r.handlers[wire.MethodDrawingExportDXF] = drawingExportDXF
+}
+
+// drawingExportDXF writes the active sheet (its views' visible/hidden edges, border and title
+// block) to a DXF file. Views are re-projected first so the export reflects the current model.
+func drawingExportDXF(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	c, err := activeDrawing(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ExportDrawingDXFArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Path == "" {
+		return nil, fmt.Errorf("drawing: export path is required")
+	}
+	c.RecomputeViews()
+	sheet := c.Sheets().Active()
+	if sheet == nil {
+		return nil, fmt.Errorf("drawing: no active sheet to export")
+	}
+	n, err := exchange.ExportDrawingDXFFile(sheet, in.Path, exchange.DefaultDrawingExportLayers(), types.DXFVersion(in.Version).Normalized())
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ExportDrawingDXFResult{Path: in.Path, Entities: n})
 }
 
 // activeDrawing returns the active document's drawing content with its title-block

--- a/addin/router/drawing_views_test.go
+++ b/addin/router/drawing_views_test.go
@@ -3,6 +3,9 @@
 package router
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"oblikovati.org/addin/opregistry"
@@ -93,6 +96,25 @@ func TestDrawingViewsLifecycleOverWire(t *testing.T) {
 	call(t, r, s, "drawingViews.delete", `{"name":"FRONT"}`, &after)
 	if len(after.Views) != 0 {
 		t.Errorf("views after deleting the base = %d, want 0 (projected cascades)", len(after.Views))
+	}
+}
+
+// TestDrawingExportDXFOverWire checks the active sheet (with a view) exports to a DXF file.
+func TestDrawingExportDXFOverWire(t *testing.T) {
+	r, s := drawingViewSession(t)
+	call(t, r, s, "drawingViews.addBase", `{"name":"FRONT","orientation":"front","scale":2,"centerXmm":120,"centerYmm":100}`, nil)
+
+	// Forward-slash the temp path so it is a valid JSON string on Windows (backslashes are
+	// JSON escapes); Go's file ops accept forward slashes on every OS.
+	path := filepath.ToSlash(t.TempDir()) + "/sheet.dxf"
+	var res wire.ExportDrawingDXFResult
+	call(t, r, s, "drawing.exportDXF", `{"path":"`+path+`","version":"r2018"}`, &res)
+	if res.Entities == 0 || res.Path != path {
+		t.Fatalf("export result = %+v, want entities written to %q", res, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || !strings.Contains(string(data), "LINE") {
+		t.Fatalf("exported DXF unreadable or empty: err=%v", err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.19.0
+	oblikovati.org/api v0.20.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.19.0
+	oblikovati.org/api v0.20.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/exchange/drawing_export.go
+++ b/model/exchange/drawing_export.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange/drawing"
+	dmodel "oblikovati.org/model/drawing"
+)
+
+// Drawing-document DXF export (M14-F05 PBI-145, #392): a drawing sheet — its views' hidden-line
+// curves, border and title block — written to DXF on separate named layers, so the sheet opens
+// in any CAD/CAM tool with visible and hidden geometry on the layers it expects. It reuses the
+// DXF codec via encodeDXF; only the sheet → neutral-drawing conversion is new here. Coordinates
+// are sheet millimetres (the drawing's working unit), written verbatim.
+
+// DrawingExportLayers names the DXF layers a sheet's geometry classes land on. A zero value
+// (empty names) resolves to the defaults via withDefaults.
+type DrawingExportLayers struct {
+	Visible    string // view edges that are visible (solid)
+	Hidden     string // view edges hidden behind the solid (dashed)
+	Border     string // the sheet border rectangle
+	TitleBlock string // the title-block grid and field text
+}
+
+// DefaultDrawingExportLayers is the layer scheme used when the caller passes none.
+func DefaultDrawingExportLayers() DrawingExportLayers {
+	return DrawingExportLayers{Visible: "Visible", Hidden: "Hidden", Border: "Border", TitleBlock: "TitleBlock"}
+}
+
+func (l DrawingExportLayers) withDefaults() DrawingExportLayers {
+	d := DefaultDrawingExportLayers()
+	if l.Visible == "" {
+		l.Visible = d.Visible
+	}
+	if l.Hidden == "" {
+		l.Hidden = d.Hidden
+	}
+	if l.Border == "" {
+		l.Border = d.Border
+	}
+	if l.TitleBlock == "" {
+		l.TitleBlock = d.TitleBlock
+	}
+	return l
+}
+
+// SheetToDrawing converts a drawing sheet into the neutral drawing model: every view's edges on
+// the Visible/Hidden layer per their classification, the border rectangle, and the title-block
+// grid with its resolved field text.
+func SheetToDrawing(sheet *dmodel.Sheet, layers DrawingExportLayers) []drawing.Entity {
+	layers = layers.withDefaults()
+	out := viewEntities(sheet, layers)
+	out = append(out, borderEntities(sheet, layers.Border)...)
+	return append(out, titleBlockEntities(sheet, layers.TitleBlock)...)
+}
+
+// ExportDrawingDXF encodes a sheet as ASCII DXF of the given version, returning the bytes and
+// the number of entities written.
+//
+//	data, n, err := exchange.ExportDrawingDXF(sheet, exchange.DefaultDrawingExportLayers(), types.DXFR2018)
+func ExportDrawingDXF(sheet *dmodel.Sheet, layers DrawingExportLayers, version types.DXFVersion) ([]byte, int, error) {
+	return encodeDXF(SheetToDrawing(sheet, layers), version)
+}
+
+// ExportDrawingDXFFile writes ExportDrawingDXF's output to path.
+func ExportDrawingDXFFile(sheet *dmodel.Sheet, path string, layers DrawingExportLayers, version types.DXFVersion) (int, error) {
+	return writeDXFFile(SheetToDrawing(sheet, layers), path, version)
+}
+
+// viewEntities emits every view's drawing curves as line segments on the visible or hidden
+// layer per the curve's classification.
+func viewEntities(sheet *dmodel.Sheet, layers DrawingExportLayers) []drawing.Entity {
+	var out []drawing.Entity
+	views := sheet.Views()
+	for i := 0; i < views.Count(); i++ {
+		for _, c := range views.Item(i).Curves() {
+			layer := layers.Visible
+			if !c.IsVisible() {
+				layer = layers.Hidden
+			}
+			out = append(out, &drawing.Line{Layer: layer, Start: point2to3(c.Start()), End: point2to3(c.End())})
+		}
+	}
+	return out
+}
+
+// borderEntities emits the sheet border as a rectangle inset from the sheet edge by the border
+// margins; a sheet with no border yields nothing.
+func borderEntities(sheet *dmodel.Sheet, layer string) []drawing.Entity {
+	b := sheet.Border()
+	if b == nil {
+		return nil
+	}
+	left, right, top, bottom := b.Margins()
+	x0, y0 := left, bottom
+	x1, y1 := sheet.WidthMM()-right, sheet.HeightMM()-top
+	return rectEntities(layer, x0, y0, x1, y1)
+}
+
+// titleBlockEntities emits the title block at the border's lower-right: an outlined box with a
+// row per resolved field (label left, value right). A sheet with no title block yields nothing.
+func titleBlockEntities(sheet *dmodel.Sheet, layer string) []drawing.Entity {
+	tb, ok := sheet.TitleBlock().(*dmodel.TitleBlock)
+	if !ok {
+		return nil
+	}
+	fields := tb.Fields()
+	if len(fields) == 0 {
+		return nil
+	}
+	left, right, _, bottom := borderMargins(sheet)
+	const tbWidth, rowH = 80.0, 8.0 // mm
+	x1 := sheet.WidthMM() - right
+	x0 := x1 - tbWidth
+	if x0 < left {
+		x0 = left
+	}
+	y0 := bottom
+	out := rectEntities(layer, x0, y0, x1, y0+rowH*float64(len(fields)))
+	return append(out, titleBlockRows(layer, fields, x0, y0, x1, tbWidth, rowH)...)
+}
+
+// titleBlockRows emits each field's row: a divider line (except the first) and the label/value
+// text, on the title-block layer.
+func titleBlockRows(layer string, fields []dmodel.ResolvedField, x0, y0, x1, tbWidth, rowH float64) []drawing.Entity {
+	var out []drawing.Entity
+	for i, f := range fields {
+		ry := y0 + rowH*float64(i)
+		if i > 0 {
+			out = append(out, &drawing.Line{Layer: layer, Start: [3]float64{x0, ry, 0}, End: [3]float64{x1, ry, 0}})
+		}
+		out = append(out, &drawing.Text{Layer: layer, Position: [3]float64{x0 + 2, ry + 2, 0}, Height: 2.5, Value: f.Name})
+		out = append(out, &drawing.Text{Layer: layer, Position: [3]float64{x0 + tbWidth*0.45, ry + 2, 0}, Height: 2.5, Value: f.Value})
+	}
+	return out
+}
+
+// borderMargins returns the sheet's border margins, or zeros when it has no border.
+func borderMargins(sheet *dmodel.Sheet) (left, right, top, bottom float64) {
+	if b := sheet.Border(); b != nil {
+		return b.Margins()
+	}
+	return 0, 0, 0, 0
+}
+
+// rectEntities emits the four edges of an axis-aligned rectangle on the layer.
+func rectEntities(layer string, x0, y0, x1, y1 float64) []drawing.Entity {
+	return []drawing.Entity{
+		&drawing.Line{Layer: layer, Start: [3]float64{x0, y0, 0}, End: [3]float64{x1, y0, 0}},
+		&drawing.Line{Layer: layer, Start: [3]float64{x1, y0, 0}, End: [3]float64{x1, y1, 0}},
+		&drawing.Line{Layer: layer, Start: [3]float64{x1, y1, 0}, End: [3]float64{x0, y1, 0}},
+		&drawing.Line{Layer: layer, Start: [3]float64{x0, y1, 0}, End: [3]float64{x0, y0, 0}},
+	}
+}

--- a/model/exchange/drawing_export_test.go
+++ b/model/exchange/drawing_export_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	kdraw "oblikovati.org/kernel/exchange/drawing"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	dmodel "oblikovati.org/model/drawing"
+)
+
+// fakeViewBody is a named fake (CLAUDE.md: no inline stubs) resolving one body for any
+// reference — the model a drawing's views project.
+type fakeViewBody struct{ body *topo.Body }
+
+func (f fakeViewBody) Body(string) (*topo.Body, bool) { return f.body, f.body != nil }
+
+// drawingWithBaseView builds a drawing referencing a 2×3×4 box with one iso base view (general
+// position, so the visible/hidden split is stable).
+func drawingWithBaseView(t *testing.T) *dmodel.Content {
+	t.Helper()
+	c := dmodel.NewContent()
+	c.SetBodyResolver(fakeViewBody{body: subd.ToBody(subd.Box(2, 3, 4), "box")})
+	c.SetModelReference("box.opd")
+	if _, err := c.Sheets().Active().Views().AddBase(dmodel.BaseViewSpec{
+		Orientation: types.BaseViewIso, Scale: 2, CenterX: 120, CenterY: 100,
+	}); err != nil {
+		t.Fatalf("AddBase: %v", err)
+	}
+	return c
+}
+
+// TestExportDrawingDXF checks a sheet exports to DXF with its view edges on the Visible/Hidden
+// layers, the border rectangle, and the title-block text — the manufacturing/handoff artifact.
+func TestExportDrawingDXF(t *testing.T) {
+	c := drawingWithBaseView(t)
+	data, n, err := ExportDrawingDXF(c.Sheets().Active(), DefaultDrawingExportLayers(), types.DXFR2018)
+	if err != nil {
+		t.Fatalf("ExportDrawingDXF: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("exported no entities")
+	}
+	dxf := string(data)
+	for _, want := range []string{"LINE", "TEXT", "Visible", "Hidden", "Border", "TitleBlock", "Part Number"} {
+		if !strings.Contains(dxf, want) {
+			t.Errorf("DXF missing %q", want)
+		}
+	}
+}
+
+// TestExportDrawingDXFFile checks the file path writes a non-empty DXF.
+func TestExportDrawingDXFFile(t *testing.T) {
+	c := drawingWithBaseView(t)
+	path := t.TempDir() + "/sheet.dxf"
+	n, err := ExportDrawingDXFFile(c.Sheets().Active(), path, DrawingExportLayers{}, types.DXFR2000)
+	if err != nil || n == 0 {
+		t.Fatalf("ExportDrawingDXFFile = (%d, %v), want entities written", n, err)
+	}
+}
+
+// TestSheetToDrawingClassifiesLayers checks visible vs hidden view curves land on distinct
+// layers (the core value of the export for a drafter).
+func TestSheetToDrawingClassifiesLayers(t *testing.T) {
+	c := drawingWithBaseView(t)
+	ents := SheetToDrawing(c.Sheets().Active(), DefaultDrawingExportLayers())
+	var visible, hidden int
+	for _, e := range ents {
+		line, ok := e.(*kdraw.Line)
+		if !ok {
+			continue
+		}
+		switch line.Layer {
+		case "Visible":
+			visible++
+		case "Hidden":
+			hidden++
+		}
+	}
+	if visible == 0 || hidden == 0 {
+		t.Errorf("layers = %d visible / %d hidden, want both populated", visible, hidden)
+	}
+}


### PR DESCRIPTION
## What

Export a **drawing sheet to DXF** — the DXF slice of M14-F05 PBI-145 (#392), reusing the existing DXF codec.

- **`model/exchange/drawing_export.go`** — `SheetToDrawing` maps the sheet's view curves → DXF **lines on Visible/Hidden layers** (per the hidden-line classification), the **border** rectangle, and the **title block** (grid + resolved field text) on its own layer. `ExportDrawingDXF` / `ExportDrawingDXFFile` feed the shared `encodeDXF` core. Coordinates are sheet millimetres.
- **`addin/router/drawing.go`** — the `drawing.exportDXF` handler re-projects the views (so the export reflects the current model) and writes the active sheet to the requested file/version.

## Why

The F02 views already produce 2D visible/hidden curves; this turns a sheet into a portable DXF a drafter/CAM tool can open, with geometry split onto the layers it expects. Built on `oblikovati.org/api` v0.20.0.

## Test

- `model/exchange`: a sheet with an iso view exports with LINE + TEXT on Visible/Hidden/Border/TitleBlock layers (+ field labels); file path writes non-empty DXF; visible vs hidden curves land on distinct layers.
- `addin/router`: `drawing.exportDXF` writes a readable DXF file over the wire.

Bridge e2e + a live capture (export a real drawing, confirm the DXF) follow; closes #392.

Refs Oblikovati/Oblikovati#392

🤖 Generated with [Claude Code](https://claude.com/claude-code)