### PR TITLE
Live in-canvas feature preview (green adds / red removes) for all part features

### DIFF
--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -120,8 +120,7 @@ func (t *ChamferTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	d := t.distance
-	t.added = feature.NewDressUpFeatures(part.Features()).AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
+	t.added = t.addChamfer(feature.NewDressUpFeatures(part.Features()))
 	part.Recompute()
 	s.recordEdit(part, "Chamfer")
 	if !t.added.Health().OK() {
@@ -131,8 +130,27 @@ func (t *ChamferTool) Commit(s *Session) error {
 	return nil
 }
 
+// addChamfer builds the chamfer feature into collection dress — the shared constructor used by
+// both Commit (the part's engine) and DraftFeature (a scratch engine).
+func (t *ChamferTool) addChamfer(dress *feature.DressUpFeatures) *feature.PartFeature {
+	d := t.distance
+	return dress.AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ChamferTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached chamfer feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addChamfer the commit uses. Empty until an
+// edge is selected.
+func (t *ChamferTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addChamfer(feature.NewDressUpFeatures(fs)), nil
+	})
+}
 
 // Prompt guides the user through the chamfer steps.
 func (t *ChamferTool) Prompt(*Session) string {

--- a/app/coil_tool.go
+++ b/app/coil_tool.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 
 	"oblikovati.org/kernel/ops"
-	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
-	"oblikovati.org/renderer"
 )
 
 // CoilTool is the interactive Coil command: activate it, click a sketch region, choose
@@ -100,14 +99,9 @@ func (t *CoilTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	axis, ok := part.WorkGeometry().AxisByRef(t.axis)
-	if !ok {
-		return errors.New("coil: axis " + string(t.axis) + " not found")
+	if t.added, err = t.addCoil(part, part.Features()); err != nil {
+		return err
 	}
-	pitch, revs := t.pitch, t.revolutions
-	t.added = feature.NewCoilFeatures(part.Features()).Add(t.profile.Sketch, t.profile.ProfileIndex, axis,
-		func() float64 { return pitch }, func() float64 { return revs }, 0, t.operation)
-	t.applyVariableRail(t.added.Definition().(*feature.CoilFeature).Definition())
 	part.Recompute()
 	s.recordEdit(part, "Coil")
 	if !t.added.Health().OK() {
@@ -147,20 +141,35 @@ func (t *CoilTool) Prompt(*Session) string {
 	return "Set the axis, pitch and revolutions, then click OK"
 }
 
-// Preview returns a transient outline of the region to coil, until a region is picked.
-func (t *CoilTool) Preview(*Session) []renderer.DrawItem {
-	if t.profile == nil || t.profile.ProfileIndex >= t.profile.Sketch.Profiles().Count() {
-		return nil
+// addCoil resolves the helix axis and builds the coil feature (including the variable-rail
+// extras) into engine fs — the shared constructor used by both Commit (the part's engine) and
+// DraftFeature (a scratch engine), so the preview matches the committed result.
+func (t *CoilTool) addCoil(part *compdef.PartComponentDefinition, fs *feature.PartFeatures) (*feature.PartFeature, error) {
+	axis, ok := part.WorkGeometry().AxisByRef(t.axis)
+	if !ok {
+		return nil, errors.New("coil: axis " + string(t.axis) + " not found")
 	}
-	poly := t.profile.Sketch.Profiles().Item(t.profile.ProfileIndex).OuterLoop().Polygon()
-	plane := t.profile.Sketch.Plane()
-	pts := make([]math.Point3, len(poly))
-	idx := make([]int, 0, 2*len(poly))
-	for i, p := range poly {
-		pts[i] = plane.ToModel(p)
-		idx = append(idx, i, (i+1)%len(poly))
+	pitch, revs := t.pitch, t.revolutions
+	pf := feature.NewCoilFeatures(fs).Add(t.profile.Sketch, t.profile.ProfileIndex, axis,
+		func() float64 { return pitch }, func() float64 { return revs }, 0, t.operation)
+	t.applyVariableRail(pf.Definition().(*feature.CoilFeature).Definition())
+	return pf, nil
+}
+
+// DraftFeature returns the unattached coil feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addCoil the commit uses. Empty until a
+// region is picked and revolutions are set.
+func (t *CoilTool) DraftFeature(s *Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
 	}
-	return []renderer.DrawItem{{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}}}
+	part, err := activePart(s)
+	if err != nil {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addCoil(part, fs)
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/core_cavity_tool.go
+++ b/app/core_cavity_tool.go
@@ -66,15 +66,29 @@ func (t *CoreCavityTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	pos := t.position
-	t.added = feature.NewCoreCavityFeatures(part.Features()).
-		AddByPartingPlaneFn(t.axis, func() float64 { return pos }, t.shrinkage)
+	t.added = t.addCoreCavity(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Core/Cavity")
 	if !t.added.Health().OK() {
 		return errors.New("core/cavity: " + t.added.Health().Reason)
 	}
 	return nil
+}
+
+// addCoreCavity builds the core/cavity feature into engine fs — shared by Commit and preview.
+func (t *CoreCavityTool) addCoreCavity(fs *feature.PartFeatures) *feature.PartFeature {
+	pos := t.position
+	return feature.NewCoreCavityFeatures(fs).AddByPartingPlaneFn(t.axis, func() float64 { return pos }, t.shrinkage)
+}
+
+// DraftFeature returns the unattached core/cavity feature the viewport previews before commit.
+func (t *CoreCavityTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addCoreCavity(fs), nil
+	})
 }
 
 // Cancel implements [Tool] (nothing to restore).

--- a/app/delete_face_tool.go
+++ b/app/delete_face_tool.go
@@ -56,11 +56,7 @@ func (t *DeleteFaceTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.faces))
-	for i, f := range t.faces {
-		keys[i] = f.Face.ReferenceKey()
-	}
-	t.added = feature.NewModifyFeatures(part.Features()).AddDeleteFace(keys)
+	t.added = t.addDeleteFace(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Delete Face")
 	if !t.added.Health().OK() {
@@ -70,8 +66,23 @@ func (t *DeleteFaceTool) Commit(s *Session) error {
 	return nil
 }
 
+// addDeleteFace builds the delete-face feature into engine fs — shared by Commit and preview.
+func (t *DeleteFaceTool) addDeleteFace(fs *feature.PartFeatures) *feature.PartFeature {
+	return feature.NewModifyFeatures(fs).AddDeleteFace(faceKeys(t.faces))
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *DeleteFaceTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached delete-face feature the viewport previews before commit.
+func (t *DeleteFaceTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addDeleteFace(fs), nil
+	})
+}
 
 // Prompt guides the user through the delete-face steps.
 func (t *DeleteFaceTool) Prompt(*Session) string {

--- a/app/draft_tool.go
+++ b/app/draft_tool.go
@@ -84,8 +84,7 @@ func (t *DraftTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	rad := t.angleDeg * degToRad
-	t.added = feature.NewDressUpFeatures(part.Features()).AddDraft(t.selectedFaceKeys(), func() float64 { return rad })
+	t.added = t.addDraft(feature.NewDressUpFeatures(part.Features()))
 	part.Recompute()
 	s.recordEdit(part, "Draft")
 	if !t.added.Health().OK() {
@@ -95,8 +94,27 @@ func (t *DraftTool) Commit(s *Session) error {
 	return nil
 }
 
+// addDraft builds the draft feature into collection dress — the shared constructor used by
+// both Commit (the part's engine) and DraftFeature (a scratch engine).
+func (t *DraftTool) addDraft(dress *feature.DressUpFeatures) *feature.PartFeature {
+	rad := t.angleDeg * degToRad
+	return dress.AddDraft(t.selectedFaceKeys(), func() float64 { return rad })
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *DraftTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached draft feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addDraft the commit uses. Empty until a
+// face is selected.
+func (t *DraftTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addDraft(feature.NewDressUpFeatures(fs)), nil
+	})
+}
 
 // Prompt guides the user through the draft steps.
 func (t *DraftTool) Prompt(*Session) string {

--- a/app/emboss_tool.go
+++ b/app/emboss_tool.go
@@ -79,9 +79,7 @@ func (t *EmbossTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	skt := t.profiles[0].Sketch
-	d, eng := t.depth, t.engrave
-	t.added = feature.NewEmbossFeatures(part.Features()).Add(skt, profileIndicesOn(t.profiles, skt), func() float64 { return d }, eng, 0)
+	t.added = t.addEmboss(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Emboss")
 	if !t.added.Health().OK() {
@@ -89,6 +87,23 @@ func (t *EmbossTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addEmboss builds the emboss feature into engine fs — shared by Commit and the preview.
+func (t *EmbossTool) addEmboss(fs *feature.PartFeatures) *feature.PartFeature {
+	skt := t.profiles[0].Sketch
+	d, eng := t.depth, t.engrave
+	return feature.NewEmbossFeatures(fs).Add(skt, profileIndicesOn(t.profiles, skt), func() float64 { return d }, eng, 0)
+}
+
+// DraftFeature returns the unattached emboss feature the viewport previews before commit.
+func (t *EmbossTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addEmboss(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/extend_tool.go
+++ b/app/extend_tool.go
@@ -60,8 +60,7 @@ func (t *ExtendTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	d := t.distance
-	t.added = feature.NewExtendFeatures(part.Features()).Add(t.edge.Edge.ReferenceKey(), func() float64 { return d })
+	t.added = t.addExtend(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Extend")
 	if !t.added.Health().OK() {
@@ -69,6 +68,22 @@ func (t *ExtendTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addExtend builds the extend feature into engine fs — shared by Commit and the preview.
+func (t *ExtendTool) addExtend(fs *feature.PartFeatures) *feature.PartFeature {
+	d := t.distance
+	return feature.NewExtendFeatures(fs).Add(t.edge.Edge.ReferenceKey(), func() float64 { return d })
+}
+
+// DraftFeature returns the unattached extend feature the viewport previews before commit.
+func (t *ExtendTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addExtend(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -171,10 +171,8 @@ func (t *ExtrudeTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	skt := t.profiles[0].Sketch
-	indices := profileIndicesOn(t.profiles, skt)
-	t.added = feature.NewExtrudeFeatures(part.Features()).
-		AddExtrude(skt, indices, t.operation, t.buildExtent(), t.taper)
+	def, _ := t.draftDefinition() // CanCommit (checked by the dialog) guarantees ok
+	t.added = feature.NewExtrudeFeatures(part.Features()).AddExtrudeFeature(def)
 	part.Recompute()
 	s.recordEdit(part, "Extrude")
 	if !t.added.Health().OK() {
@@ -207,6 +205,31 @@ func profileIndicesOn(handles []ProfileHandle, skt *sketch.Sketch) []int {
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ExtrudeTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// draftDefinition builds the ExtrudeDefinition from the tool's current state — the single
+// source of truth shared by Commit and the live preview, so the previewed solid is exactly
+// the geometry OK will create. ok is false until at least one region is picked.
+func (t *ExtrudeTool) draftDefinition() (*feature.ExtrudeDefinition, bool) {
+	if len(t.profiles) == 0 {
+		return nil, false
+	}
+	skt := t.profiles[0].Sketch
+	return &feature.ExtrudeDefinition{
+		Sketch: skt, ProfileIndices: profileIndicesOn(t.profiles, skt),
+		Operation: t.operation, Extent: t.buildExtent(), Taper: t.taper,
+	}, true
+}
+
+// DraftFeature returns the unattached extrude feature the viewport previews before commit
+// (satisfying DraftPreviewable), and whether enough input is gathered to show it — the same
+// gate as CanCommit, so the translucent preview appears exactly when OK becomes available.
+func (t *ExtrudeTool) DraftFeature(*Session) (feature.Feature, bool) {
+	def, ok := t.draftDefinition()
+	if !ok || !t.CanCommit() {
+		return nil, false
+	}
+	return feature.NewExtrudeFeature(def), true
+}
 
 // Prompt guides the user through the extrude steps (Inventor's status-bar prompts).
 func (t *ExtrudeTool) Prompt(*Session) string {

--- a/app/face_offset_tool.go
+++ b/app/face_offset_tool.go
@@ -69,13 +69,7 @@ func (t *FaceOffsetTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.faces))
-	for i, f := range t.faces {
-		keys[i] = f.Face.ReferenceKey()
-	}
-	d := t.distance
-	t.added = feature.NewModifyFeatures(part.Features()).
-		AddFaceOffsetApprox(keys, func() float64 { return d }, approximationAt(t.approxIdx))
+	t.added = t.addFaceOffset(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Offset Face")
 	if !t.added.Health().OK() {
@@ -85,8 +79,25 @@ func (t *FaceOffsetTool) Commit(s *Session) error {
 	return nil
 }
 
+// addFaceOffset builds the offset-face feature into engine fs — shared by Commit and preview.
+func (t *FaceOffsetTool) addFaceOffset(fs *feature.PartFeatures) *feature.PartFeature {
+	d := t.distance
+	return feature.NewModifyFeatures(fs).
+		AddFaceOffsetApprox(faceKeys(t.faces), func() float64 { return d }, approximationAt(t.approxIdx))
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *FaceOffsetTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached offset-face feature the viewport previews before commit.
+func (t *FaceOffsetTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFaceOffset(fs), nil
+	})
+}
 
 // Prompt guides the user through the offset steps.
 func (t *FaceOffsetTool) Prompt(*Session) string {

--- a/app/feature_preview.go
+++ b/app/feature_preview.go
@@ -38,6 +38,25 @@ var (
 	_ DraftPreviewable = (*ShellTool)(nil)
 	_ DraftPreviewable = (*DraftTool)(nil)
 	_ DraftPreviewable = (*ThreadTool)(nil)
+	_ DraftPreviewable = (*RibTool)(nil)
+	_ DraftPreviewable = (*EmbossTool)(nil)
+	_ DraftPreviewable = (*ThickenTool)(nil)
+	_ DraftPreviewable = (*SplitTool)(nil)
+	_ DraftPreviewable = (*GrillTool)(nil)
+	_ DraftPreviewable = (*CoreCavityTool)(nil)
+	_ DraftPreviewable = (*FaceOffsetTool)(nil)
+	_ DraftPreviewable = (*ReplaceFaceTool)(nil)
+	_ DraftPreviewable = (*DeleteFaceTool)(nil)
+	_ DraftPreviewable = (*PatchTool)(nil)
+	_ DraftPreviewable = (*StitchTool)(nil)
+	_ DraftPreviewable = (*SurfaceTrimTool)(nil)
+	_ DraftPreviewable = (*SculptTool)(nil)
+	_ DraftPreviewable = (*ExtendTool)(nil)
+	_ DraftPreviewable = (*SheetMetalFaceTool)(nil)
+	_ DraftPreviewable = (*SheetMetalFlangeTool)(nil)
+	_ DraftPreviewable = (*SheetMetalLipTool)(nil)
+	_ DraftPreviewable = (*SheetMetalRipTool)(nil)
+	_ DraftPreviewable = (*SheetMetalPunchTool)(nil)
 )
 
 // previewAddColor / previewRemoveColor are the operation-coded preview tints: a feature that
@@ -82,6 +101,16 @@ func (s *Session) featurePreviewItems(t DraftPreviewable) []renderer.DrawItem {
 		return nil
 	}
 	return deltaPreviewItems(base, result)
+}
+
+// faceKeys returns the reference keys of picked faces — the input the modify features
+// (delete/replace/offset face) consume, shared by their tools' commit and preview builders.
+func faceKeys(faces []FaceHandle) [][]byte {
+	keys := make([][]byte, len(faces))
+	for i, f := range faces {
+		keys[i] = f.Face.ReferenceKey()
+	}
+	return keys
 }
 
 // draftFromScratch builds a tool's feature into a throwaway engine — so the part's real

--- a/app/feature_preview.go
+++ b/app/feature_preview.go
@@ -3,6 +3,9 @@
 package app
 
 import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -100,7 +103,32 @@ func (s *Session) featurePreviewItems(t DraftPreviewable) []renderer.DrawItem {
 	if err != nil || len(result) == 0 {
 		return nil
 	}
-	return deltaPreviewItems(base, result)
+	if items := deltaPreviewItems(base, result); items != nil {
+		return items
+	}
+	// Fallback for features with no clean solid delta (surface features, multi-body splits):
+	// highlight the faces the feature introduced.
+	if items := changedFacePreview(base, result); items != nil {
+		return items
+	}
+	// Last resort for features that retrim/weld/fill existing surfaces without introducing a new
+	// surface or volume delta (delete/replace face, stitch, trim, sculpt, extend): show the
+	// resulting body itself, so the preview always shows the outcome.
+	return resultBodyPreview(base, result)
+}
+
+// resultBodyPreview renders every result body as a translucent ghost — the fallback when there
+// is no localizable delta. Green when the model grew, red when it shrank.
+func resultBodyPreview(base, result []*topo.Body) []renderer.DrawItem {
+	color := previewAddColor
+	if totalVolume(result) < totalVolume(base) {
+		color = previewRemoveColor
+	}
+	var items []renderer.DrawItem
+	for _, b := range result {
+		items = append(items, bodyPreviewItems(b, color)...)
+	}
+	return items
 }
 
 // faceKeys returns the reference keys of picked faces — the input the modify features
@@ -246,6 +274,227 @@ func solidDifference(target, tool *topo.Body) *topo.Body {
 		return nil
 	}
 	return diff
+}
+
+// changedFacePreview highlights the faces a feature introduced — result faces whose underlying
+// surface is absent from the base — as one translucent mesh plus their feature edges, colored
+// green when the model grew and red when it shrank. It is the fallback when a feature exposes
+// no tool body and produces no clean solid delta (surface features, multi-body splits, and
+// coincident-face edits), so every feature shows *something* meaningful.
+func changedFacePreview(base, result []*topo.Body) []renderer.DrawItem {
+	mesh, newFaces := collectNewFaces(base, result)
+	if mesh.TriangleCount() == 0 {
+		return nil
+	}
+	color := previewAddColor
+	if totalVolume(result) < totalVolume(base) {
+		color = previewRemoveColor
+	}
+	mesh.Normals = ops.SmoothShadeNormals(mesh, ops.DefaultCreaseAngle())
+	items := []renderer.DrawItem{previewBodyFill(mesh, color)}
+	if line := changedFaceEdges(result, newFaces, color); line != nil {
+		items = append(items, *line)
+	}
+	return items
+}
+
+// collectNewFaces tessellates every result face whose surface is absent from the base into one
+// merged mesh, and returns the set of those new faces (for edge selection).
+func collectNewFaces(base, result []*topo.Body) (*ops.Mesh, map[*topo.Face]bool) {
+	baseSurf := faceSurfacesOf(base)
+	q := ops.DefaultQuality()
+	mesh := &ops.Mesh{}
+	newFaces := map[*topo.Face]bool{}
+	for _, b := range result {
+		for _, f := range b.Faces() {
+			if surfaceInBase(baseSurf, f) {
+				continue
+			}
+			if m := ops.TessellateFace(f, q); m != nil && m.TriangleCount() > 0 {
+				newFaces[f] = true
+				appendMesh(mesh, m)
+			}
+		}
+	}
+	return mesh, newFaces
+}
+
+// changedFaceEdges draws the feature edges that bound a new face (tangent seams suppressed) as
+// one opaque line item in the preview hue.
+func changedFaceEdges(result []*topo.Body, newFaces map[*topo.Face]bool, color [4]float32) *renderer.DrawItem {
+	q := ops.DefaultQuality()
+	var pts []math.Point3
+	var idx []int
+	for _, b := range result {
+		for _, e := range b.Edges() {
+			if !edgeTouchesNewFace(e, newFaces) || isTangentEdge(e) {
+				continue
+			}
+			pl := ops.TessellateEdge(e, q)
+			base := len(pts)
+			pts = append(pts, pl...)
+			for i := 0; i+1 < len(pl); i++ {
+				idx = append(idx, base+i, base+i+1)
+			}
+		}
+	}
+	if len(idx) == 0 {
+		return nil
+	}
+	return &renderer.DrawItem{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{color[0], color[1], color[2], 1}, OnTop: true}
+}
+
+// edgeTouchesNewFace reports whether any face adjacent to e is one the feature introduced.
+func edgeTouchesNewFace(e *topo.Edge, newFaces map[*topo.Face]bool) bool {
+	for _, f := range e.Faces() {
+		if newFaces[f] {
+			return true
+		}
+	}
+	return false
+}
+
+// isTangentEdge reports whether an edge's two faces meet smoothly (within the crease angle), so
+// it should not be drawn as a feature edge — mirrors ops.VisibleEdges' tangent suppression.
+func isTangentEdge(e *topo.Edge) bool {
+	faces := e.Faces()
+	if len(faces) != 2 {
+		return false
+	}
+	mid := e.Geometry().PointAt(0.5)
+	cos := math.Scalar(stdmath.Cos(ops.DefaultCreaseAngle()))
+	return faceNormalAt(faces[0], mid).Dot(faceNormalAt(faces[1], mid)) > cos
+}
+
+// faceNormalAt returns a face's outward unit normal at point p.
+func faceNormalAt(f *topo.Face, p math.Point3) math.Vector3 {
+	u, v := f.Geometry().ParamAt(p)
+	n := f.Geometry().NormalAt(u, v)
+	if f.Reversed() {
+		n = n.Scale(-1)
+	}
+	return n.AsUnit().AsVector()
+}
+
+// appendMesh appends src into dst, offsetting indices (a local mesh merge).
+func appendMesh(dst, src *ops.Mesh) {
+	b := len(dst.Positions)
+	dst.Positions = append(dst.Positions, src.Positions...)
+	dst.Normals = append(dst.Normals, src.Normals...)
+	for _, i := range src.Indices {
+		dst.Indices = append(dst.Indices, b+i)
+	}
+}
+
+// faceSig fingerprints a face's underlying surface, trim-independently, so an unchanged face is
+// recognised across a rebuild while a feature's new face is not. Analytic surfaces use their
+// intrinsic parameters; an unrecognised surface falls back to its area-weighted centroid.
+type faceSig struct {
+	kind     int
+	dir      math.Vector3
+	anchor   math.Point3
+	r1, r2   float64
+	centroid math.Point3
+	area     float64
+}
+
+func surfaceSigOf(f *topo.Face) faceSig {
+	switch g := f.Geometry().(type) {
+	case geom.Plane:
+		n := g.UAxis.AsVector().Cross(g.VAxis.AsVector()).AsUnit().AsVector()
+		return faceSig{kind: 1, dir: signNorm(n), anchor: math.P3(0, 0, 0).TranslateBy(n.Scale(n.Dot(g.Origin.AsVector())))}
+	case geom.Cylinder:
+		return faceSig{kind: 2, dir: signNorm(g.AxisDir.AsVector()), anchor: axisFoot(g.Origin, g.AxisDir.AsVector()), r1: g.Radius}
+	case geom.Cone:
+		return faceSig{kind: 3, dir: signNorm(g.AxisDir.AsVector()), anchor: g.Apex, r1: g.HalfAngle}
+	case geom.Sphere:
+		return faceSig{kind: 4, anchor: g.Center, r1: g.Radius}
+	case geom.Torus:
+		return faceSig{kind: 5, dir: signNorm(g.AxisDir.AsVector()), anchor: g.Center, r1: g.MajorRadius, r2: g.MinorRadius}
+	default:
+		c, a := faceAreaCentroid(f)
+		return faceSig{kind: 0, centroid: c, area: a}
+	}
+}
+
+func faceSurfacesOf(bodies []*topo.Body) []faceSig {
+	var out []faceSig
+	for _, b := range bodies {
+		for _, f := range b.Faces() {
+			out = append(out, surfaceSigOf(f))
+		}
+	}
+	return out
+}
+
+func surfaceInBase(base []faceSig, f *topo.Face) bool {
+	s := surfaceSigOf(f)
+	for _, b := range base {
+		if sigEqual(b, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func sigEqual(a, b faceSig) bool {
+	if a.kind != b.kind {
+		return false
+	}
+	if a.kind == 0 {
+		return a.centroid.IsEqualTo(b.centroid, 1e-4) && absVal(a.area-b.area) <= 1e-3*maxVal(a.area, b.area)+1e-9
+	}
+	return a.dir.IsEqualTo(b.dir, 1e-4) && a.anchor.IsEqualTo(b.anchor, 1e-4) && absVal(a.r1-b.r1) <= 1e-4 && absVal(a.r2-b.r2) <= 1e-4
+}
+
+// signNorm flips v so its dominant component is positive (a surface and its reverse share a sig).
+func signNorm(v math.Vector3) math.Vector3 {
+	ax, ay, az := absVal(v.X), absVal(v.Y), absVal(v.Z)
+	if (ax >= ay && ax >= az && v.X < 0) || (ay > ax && ay >= az && v.Y < 0) || (az > ax && az > ay && v.Z < 0) {
+		return v.Scale(-1)
+	}
+	return v
+}
+
+// axisFoot returns the point on the axis line nearest the world origin (invariant to where
+// along the axis origin sits).
+func axisFoot(origin math.Point3, dir math.Vector3) math.Point3 {
+	ov := origin.AsVector()
+	return math.P3(0, 0, 0).TranslateBy(ov.Sub(dir.Scale(ov.Dot(dir))))
+}
+
+// faceAreaCentroid returns a face's tessellated area and area-weighted centroid.
+func faceAreaCentroid(f *topo.Face) (math.Point3, float64) {
+	m := ops.TessellateFace(f, ops.DefaultQuality())
+	if m == nil {
+		return math.P3(0, 0, 0), 0
+	}
+	var area, cx, cy, cz float64
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		a, b, c := m.Positions[m.Indices[t]], m.Positions[m.Indices[t+1]], m.Positions[m.Indices[t+2]]
+		ar := float64(a.VectorTo(b).Cross(a.VectorTo(c)).Length()) * 0.5
+		area += ar
+		cx += ar * (a.X + b.X + c.X) / 3
+		cy += ar * (a.Y + b.Y + c.Y) / 3
+		cz += ar * (a.Z + b.Z + c.Z) / 3
+	}
+	if area == 0 {
+		return math.P3(0, 0, 0), 0
+	}
+	return math.P3(cx/area, cy/area, cz/area), area
+}
+
+func absVal(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func maxVal(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // previewBodyFill wraps a body mesh as a translucent, on-top triangle item — drawn ignoring

--- a/app/feature_preview.go
+++ b/app/feature_preview.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/renderer"
+)
+
+// Live in-canvas feature preview (Inventor's "the feature previews the expected results
+// before you commit"). A tool that can build the feature it would commit evaluates it
+// non-destructively (feature.PartFeatures.PreviewResult) and the session highlights just the
+// faces the feature introduces, translucent — GREEN when the feature adds material, RED when
+// it removes it.
+
+// DraftPreviewable is an optional Tool capability: a feature tool that can build the
+// unattached feature it would commit, so the session can evaluate it speculatively and show
+// a translucent solid result preview. It supersedes the wireframe-only Previewable for tools
+// that implement it (RenderFrame prefers the solid preview, falling back to the wireframe).
+type DraftPreviewable interface {
+	DraftFeature(s *Session) (feature.Feature, bool)
+}
+
+// Every part-feature tool drives the live preview through DraftPreviewable; these assertions
+// pin the wiring so a tool that loses its DraftFeature method fails to compile.
+var (
+	_ DraftPreviewable = (*ExtrudeTool)(nil)
+	_ DraftPreviewable = (*RevolveTool)(nil)
+	_ DraftPreviewable = (*SweepTool)(nil)
+	_ DraftPreviewable = (*LoftTool)(nil)
+	_ DraftPreviewable = (*CoilTool)(nil)
+	_ DraftPreviewable = (*HoleTool)(nil)
+	_ DraftPreviewable = (*FilletTool)(nil)
+	_ DraftPreviewable = (*ChamferTool)(nil)
+	_ DraftPreviewable = (*ShellTool)(nil)
+	_ DraftPreviewable = (*DraftTool)(nil)
+	_ DraftPreviewable = (*ThreadTool)(nil)
+)
+
+// previewAddColor / previewRemoveColor are the operation-coded preview tints: a feature that
+// adds volume previews green, one that removes volume previews red. previewOpacity keeps the
+// underlying model visible through the preview.
+var (
+	previewAddColor    = [4]float32{0.30, 0.85, 0.35, 1}
+	previewRemoveColor = [4]float32{0.90, 0.30, 0.30, 1}
+)
+
+// previewOpacity keeps the ghost light so the model reads through it; the matching opaque
+// edge lines give the volume a crisp outline (Inventor draws the preview's edges).
+const previewOpacity = 0.25
+
+// featurePreviewItems evaluates a tool's draft feature against the current model without
+// committing it and returns translucent triangle items over the feature's new faces — green
+// when it adds material, red when it removes it. Empty when the draft is not ready, the
+// active document is not a part, or the speculative build fails (a sick preview shows nothing
+// rather than partial geometry).
+func (s *Session) featurePreviewItems(t DraftPreviewable) []renderer.DrawItem {
+	draft, ok := t.DraftFeature(s)
+	if !ok {
+		return nil
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	base := s.VisibleBodies()
+	// Evaluating the draft both produces the result bodies and, for an operational feature,
+	// populates its tool body (built before the boolean, so it survives a failing op).
+	result, err := part.Features().PreviewResult(draft)
+	// Prefer the feature's tool body (the swept/drilled solid it contributes): rendering it
+	// whole and translucent shows the pending feature's volume as a ghost colored by its
+	// operation — crucially for a CUT, whose volume is interior and would be hidden.
+	if items := toolBodyPreview(draft); items != nil {
+		return items
+	}
+	// Dress-ups (fillet/chamfer/shell/…) have no separable tool body: show the solid volume
+	// they add or remove, computed as the boolean difference between the result and the base.
+	if err != nil || len(result) == 0 {
+		return nil
+	}
+	return deltaPreviewItems(base, result)
+}
+
+// draftFromScratch builds a tool's feature into a throwaway engine — so the part's real
+// feature program is untouched — and returns the underlying Feature value for the preview to
+// evaluate non-destructively. build runs the tool's exact commit-time construction (every
+// variant) against the scratch engine, so the previewed feature is identical to what OK
+// creates with no duplicated builder. The scratch engine needs no params/keys: Add only stores
+// and names the feature; resolution happens later in PreviewResult against the part's engine.
+func draftFromScratch(build func(*feature.PartFeatures) (*feature.PartFeature, error)) (feature.Feature, bool) {
+	pf, err := build(feature.NewPartFeatures(nil, nil))
+	if err != nil || pf == nil {
+		return nil, false
+	}
+	return pf.Definition(), true
+}
+
+// toolBodyPreview tessellates an operational feature's tool body — the solid it sweeps/drills,
+// populated by the preview recompute — as a translucent ghost, GREEN when the operation adds
+// material (new body / join) and RED when it removes it (cut / intersect). Nil when the
+// feature exposes no tool body (e.g. a dress-up feature).
+func toolBodyPreview(draft feature.Feature) []renderer.DrawItem {
+	tf, ok := draft.(feature.ToolFeature)
+	if !ok || tf.ToolBody() == nil {
+		return nil
+	}
+	return bodyPreviewItems(tf.ToolBody(), operationColor(tf.Operation()))
+}
+
+// operationColor maps a boolean operation to the preview tint: material-adding operations
+// (new body / join) preview green, material-removing ones (cut / intersect) preview red.
+func operationColor(op ops.PartFeatureOperation) [4]float32 {
+	if op == ops.NewBody || op == ops.Join {
+		return previewAddColor
+	}
+	return previewRemoveColor
+}
+
+// bodyPreviewItems renders a preview solid as a translucent ghost (one triangle item per
+// face) plus its edges as opaque lines in the same hue — the outline makes the light
+// translucent volume legible, the way Inventor draws a feature preview.
+func bodyPreviewItems(b *topo.Body, color [4]float32) []renderer.DrawItem {
+	q := ops.DefaultQuality()
+	mesh, _ := ops.TessellateBody(b, q)
+	if mesh == nil || mesh.TriangleCount() == 0 {
+		return nil
+	}
+	// Smooth the normals across facets meeting below the crease angle so a curved delta (a
+	// fillet's round wedge) reads as one surface instead of flat-shaded stripes.
+	mesh.Normals = ops.SmoothShadeNormals(mesh, ops.DefaultCreaseAngle())
+	items := []renderer.DrawItem{previewBodyFill(mesh, color)}
+	if line := previewEdgeLines(b, q, color); line != nil {
+		items = append(items, *line)
+	}
+	return items
+}
+
+// previewEdgeLines draws the body's CREASE edges (tangent/facet seams suppressed, like the
+// model renderer) as one opaque line item in the preview hue — so a curved delta shows only
+// its real boundary outline, not a web of tessellation seams.
+func previewEdgeLines(b *topo.Body, q ops.Quality, color [4]float32) *renderer.DrawItem {
+	polylines := ops.VisibleEdges(b, q, ops.DefaultCreaseAngle())
+	var pts []math.Point3
+	var idx []int
+	for _, pl := range polylines {
+		base := len(pts)
+		pts = append(pts, pl...)
+		for i := 0; i+1 < len(pl); i++ {
+			idx = append(idx, base+i, base+i+1)
+		}
+	}
+	if len(idx) == 0 {
+		return nil
+	}
+	return &renderer.DrawItem{
+		Primitive: renderer.Lines,
+		Positions: pts,
+		Indices:   idx,
+		Color:     [4]float32{color[0], color[1], color[2], 1}, // same hue, fully opaque
+		OnTop:     true,
+	}
+}
+
+// totalVolume sums the enclosed volume (cm³) of the solid bodies; open surface bodies add 0.
+func totalVolume(bodies []*topo.Body) float64 {
+	q := ops.DefaultQuality()
+	var v float64
+	for _, b := range bodies {
+		if b.IsSolid() {
+			v += ops.BodyGeometryProperties(b, q).Volume
+		}
+	}
+	return v
+}
+
+// deltaPreviewItems renders the solid volume a dress-up feature adds or removes — the boolean
+// difference between the base and the speculative result — as a translucent ghost: RED for the
+// material removed (base − result, e.g. a fillet's corner wedge, a shell's hollowed interior),
+// GREEN for material added (result − base, e.g. an outward draft). This is Inventor's solid
+// feature preview: the changed VOLUME, not just the changed faces. Nil when neither difference
+// is a solid (a sick or no-op preview shows nothing). Dress-ups act on one body; multi-body
+// states are skipped.
+func deltaPreviewItems(base, result []*topo.Body) []renderer.DrawItem {
+	b, r := singleSolid(base), singleSolid(result)
+	if b == nil || r == nil {
+		return nil
+	}
+	var items []renderer.DrawItem
+	if removed := solidDifference(b, r); removed != nil {
+		items = append(items, bodyPreviewItems(removed, previewRemoveColor)...)
+	}
+	if added := solidDifference(r, b); added != nil {
+		items = append(items, bodyPreviewItems(added, previewAddColor)...)
+	}
+	return items
+}
+
+// singleSolid returns the lone solid body in bodies, or nil when there isn't exactly one.
+func singleSolid(bodies []*topo.Body) *topo.Body {
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		return nil
+	}
+	return bodies[0]
+}
+
+// solidDifference returns target − tool as a solid body, or nil when the difference is empty
+// or the boolean fails (preview must never show partial/garbage geometry).
+func solidDifference(target, tool *topo.Body) *topo.Body {
+	diff, err := ops.Boolean(ops.Cut, target, tool)
+	if err != nil || diff == nil || len(diff.Faces()) == 0 || !diff.IsSolid() {
+		return nil
+	}
+	if ops.BodyGeometryProperties(diff, ops.DefaultQuality()).Volume < 1e-9 {
+		return nil
+	}
+	return diff
+}
+
+// previewBodyFill wraps a body mesh as a translucent, on-top triangle item — drawn ignoring
+// the depth test so the preview ghost is always visible over the model, even where it sits
+// inside or behind existing material (a cut's volume is interior, a join boss may be occluded).
+// The translucency rides in the COLOR's alpha (the viewport flattens vertex color, not the
+// Opacity field; see head/viewport/flatten.go), so we bake previewOpacity in.
+func previewBodyFill(m *ops.Mesh, color [4]float32) renderer.DrawItem {
+	fill := [4]float32{color[0], color[1], color[2], previewOpacity}
+	return renderer.DrawItem{
+		Primitive: renderer.Triangles,
+		Positions: m.Positions,
+		Normals:   m.Normals,
+		Indices:   m.Indices,
+		Color:     fill,
+		Opacity:   previewOpacity,
+		Shading:   renderer.ShadeFlat,
+		OnTop:     true,
+	}
+}

--- a/app/feature_preview_coverage_test.go
+++ b/app/feature_preview_coverage_test.go
@@ -2,7 +2,12 @@
 
 package app
 
-import "testing"
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
 
 // TestEveryFeatureToolPreviews drives each remaining part-feature tool (beyond the sketched
 // solids covered elsewhere) to its commit-ready state, reusing each tool's own test setup, and
@@ -60,6 +65,15 @@ func TestEveryFeatureToolPreviews(t *testing.T) {
 		s.Click(50, 50)
 		wantPreview(t, s)
 	})
+	t.Run("face_offset", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 4)
+		s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+		off := NewFaceOffsetTool()
+		s.StartTool(off)
+		s.Click(100, 100)
+		off.SetDistance(1)
+		wantPreview(t, s)
+	})
 	t.Run("split", func(t *testing.T) {
 		s, _, wp := partWithMidPlane(t, 6)
 		sp := NewSplitTool()
@@ -105,6 +119,161 @@ func TestEveryFeatureToolPreviews(t *testing.T) {
 		s.StartTool(ex)
 		ex.Pick(s, EdgeHandle{Edge: bottom})
 		ex.SetDistance(2)
+		wantPreview(t, s)
+	})
+}
+
+// TestSweptAndDressUpToolsPreview drives the sketched-solid (revolve/sweep/loft/coil/hole) and
+// dress-up (fillet/chamfer/shell/draft/thread) tools to commit-ready state, reusing each tool's
+// own end-to-end setup, and asserts ToolPreview() yields a ghost. This pins the DraftFeature
+// path of every tool that does NOT go through the changed-face/result-body fallbacks.
+func TestSweptAndDressUpToolsPreview(t *testing.T) {
+	t.Run("revolve", func(t *testing.T) {
+		s, profile := newPartWithOffsetSquare(t, 2, 2)
+		s.SetPicker(stubPicker{sel: profile})
+		rv := NewRevolveTool()
+		s.StartTool(rv)
+		s.Click(120, 90)
+		wantPreview(t, s)
+	})
+	t.Run("coil", func(t *testing.T) {
+		s, profile := newPartWithOffsetSquare(t, 4, 1)
+		s.SetPicker(stubPicker{sel: profile})
+		c := NewCoilTool()
+		s.StartTool(c)
+		s.Click(120, 90)
+		c.SetPitch(2)
+		c.SetRevolutions(3)
+		wantPreview(t, s)
+	})
+	t.Run("sweep", func(t *testing.T) {
+		s, profile, path := newPartWithProfileAndPath(t)
+		s.SetPicker(&seqPicker{sels: []Selectable{profile, path}})
+		sw := NewSweepTool()
+		s.StartTool(sw)
+		s.Click(10, 10)
+		s.Click(10, 200)
+		wantPreview(t, s)
+	})
+	t.Run("loft", func(t *testing.T) {
+		s, bottom, top := newPartWithStackedSquares(t)
+		s.SetPicker(&seqPicker{sels: []Selectable{bottom, top}})
+		l := NewLoftTool()
+		s.StartTool(l)
+		s.Click(10, 10)
+		s.Click(10, 200)
+		wantPreview(t, s)
+	})
+	t.Run("hole", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 4)
+		s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+		hole := NewHoleTool()
+		s.StartTool(hole)
+		s.Click(100, 100)
+		hole.SetDiameter(2)
+		hole.SetDepth(3)
+		wantPreview(t, s)
+	})
+	t.Run("fillet", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 2)
+		s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+		f := NewFilletTool()
+		s.StartTool(f)
+		s.Click(50, 50)
+		f.SetRadius(0.5)
+		wantPreview(t, s)
+	})
+	t.Run("chamfer", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 2)
+		s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+		ch := NewChamferTool()
+		s.StartTool(ch)
+		s.Click(50, 50)
+		ch.SetDistance(0.5)
+		wantPreview(t, s)
+	})
+	t.Run("shell", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 4)
+		s.SetPicker(stubPicker{sel: FaceHandle{Face: topFaceOf(t, block), Body: block}})
+		sh := NewShellTool()
+		s.StartTool(sh)
+		s.Click(100, 100)
+		sh.SetThickness(0.5)
+		wantPreview(t, s)
+	})
+	t.Run("draft", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 2)
+		s.SetPicker(stubPicker{sel: FaceHandle{Face: plusXFaceOf(t, block), Body: block}})
+		d := NewDraftTool()
+		s.StartTool(d)
+		s.Click(50, 50)
+		d.SetAngleDegrees(-10)
+		wantPreview(t, s)
+	})
+	t.Run("thread", func(t *testing.T) {
+		s, cyl := newPartWithCylinder(t)
+		s.SetPicker(stubPicker{sel: FaceHandle{Face: cylinderFaceOf(t, cyl), Body: cyl}})
+		tool := NewThreadTool()
+		s.StartTool(tool)
+		s.Click(100, 100)
+		tool.SetStandardIndex(0)
+		tool.SetSizeIndex(6)
+		tool.SetPitchIndex(0)
+		tool.SetCut(true)
+		wantPreview(t, s)
+	})
+}
+
+// TestSheetMetalToolsPreview drives the sheet-metal tools to commit-ready state and asserts a
+// preview ghost, pinning each sheet-metal DraftFeature wiring.
+func TestSheetMetalToolsPreview(t *testing.T) {
+	t.Run("face", func(t *testing.T) {
+		s, part := sheetMetalSession(t)
+		face := NewSheetMetalFaceTool()
+		s.StartTool(face)
+		face.Pick(s, squareProfile(part, 4))
+		wantPreview(t, s)
+	})
+	t.Run("flange", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		flange := NewSheetMetalFlangeTool()
+		s.StartTool(flange)
+		flange.Pick(s, EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])})
+		flange.SetHeight(1)
+		wantPreview(t, s)
+	})
+	t.Run("lip", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		lip := NewSheetMetalLipTool()
+		s.StartTool(lip)
+		lip.Pick(s, EdgeHandle{Edge: topXEdge(t, part.Features().Result()[0])})
+		lip.SetHeight(1.0)
+		lip.SetReturnLength(0.4)
+		lip.SetAngle(halfPiAngle)
+		wantPreview(t, s)
+	})
+	t.Run("rip", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		rip := NewSheetMetalRipTool()
+		s.StartTool(rip)
+		rip.Pick(s, lineSketch(part, gmath.P2(1, 1.5), gmath.P2(3, 1.5)))
+		rip.SetGap(0.05)
+		wantPreview(t, s)
+	})
+	t.Run("punch", func(t *testing.T) {
+		s, part := faceSheet(t, 4)
+		holes := part.Sketches().Add(sketch.XYPlane())
+		q := []gmath.Point2{gmath.P2(0.7, 0.7), gmath.P2(1.3, 0.7), gmath.P2(1.3, 1.3), gmath.P2(0.7, 1.3)}
+		var pts []*sketch.Point
+		for _, p := range q {
+			pts = append(pts, holes.Points().Add(p))
+		}
+		for i := range pts {
+			holes.Lines().Add(pts[i], pts[(i+1)%len(pts)])
+		}
+		punch := NewSheetMetalPunchTool()
+		s.StartTool(punch)
+		punch.Pick(s, ProfileHandle{Sketch: holes, ProfileIndex: 0})
 		wantPreview(t, s)
 	})
 }

--- a/app/feature_preview_coverage_test.go
+++ b/app/feature_preview_coverage_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestEveryFeatureToolPreviews drives each remaining part-feature tool (beyond the sketched
+// solids covered elsewhere) to its commit-ready state, reusing each tool's own test setup, and
+// asserts ToolPreview() yields a non-empty ghost. This guards that wiring DraftFeature into a
+// tool actually produces a preview through the full featurePreviewItems path (tool body, solid
+// delta, changed faces, or result-body fallback) — not just that it compiles.
+func TestEveryFeatureToolPreviews(t *testing.T) {
+	t.Run("rib", func(t *testing.T) {
+		s, _ := ribbedPart(t)
+		rib := NewRibTool()
+		s.StartTool(rib)
+		rib.SetThickness(1)
+		rib.SetDepth(3)
+		wantPreview(t, s)
+	})
+	t.Run("emboss", func(t *testing.T) {
+		s, _, region := partWithTopRegion(t)
+		s.SetPicker(stubPicker{sel: region})
+		emb := NewEmbossTool()
+		s.StartTool(emb)
+		s.Click(100, 100)
+		emb.SetDepth(1)
+		wantPreview(t, s)
+	})
+	t.Run("grill", func(t *testing.T) {
+		s, _, region := partWithGrillSketch(t)
+		s.SetPicker(stubPicker{sel: region})
+		g := NewGrillTool()
+		s.StartTool(g)
+		s.Click(100, 100)
+		wantPreview(t, s)
+	})
+	t.Run("core_cavity", func(t *testing.T) {
+		s, _ := newPartWithBlock(t, 6)
+		s.StartTool(NewCoreCavityTool())
+		wantPreview(t, s)
+	})
+	t.Run("replace_face", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 2)
+		top := topFaceOf(t, block)
+		s.SetPicker(stubPicker{sel: FaceHandle{Face: top, Body: block}})
+		r := NewReplaceFaceTool()
+		s.StartTool(r)
+		s.Click(50, 50)
+		r.SetPickingTarget(true)
+		s.Click(50, 50)
+		wantPreview(t, s)
+	})
+	t.Run("delete_face", func(t *testing.T) {
+		s, block := newPartWithBlock(t, 2)
+		chamfered := chamferOneEdge(t, s, block)
+		s.SetPicker(stubPicker{sel: chamferFaceHandleOf(t, chamfered)})
+		d := NewDeleteFaceTool()
+		s.StartTool(d)
+		s.Click(50, 50)
+		wantPreview(t, s)
+	})
+	t.Run("split", func(t *testing.T) {
+		s, _, wp := partWithMidPlane(t, 6)
+		sp := NewSplitTool()
+		s.StartTool(sp)
+		sp.Pick(s, WorkPlaneHandle{Plane: wp})
+		wantPreview(t, s)
+	})
+	t.Run("thicken", func(t *testing.T) {
+		s := newPartWithSurface(t)
+		th := NewThickenTool()
+		s.StartTool(th)
+		th.SetThickness(0.5)
+		wantPreview(t, s)
+	})
+	t.Run("patch", func(t *testing.T) {
+		s, _, region := partWithSquareRegion(t)
+		s.SetPicker(stubPicker{sel: region})
+		p := NewPatchTool()
+		s.StartTool(p)
+		p.Pick(s, region)
+		wantPreview(t, s)
+	})
+	t.Run("stitch", func(t *testing.T) {
+		s, _ := twoAdjacentPatches(t)
+		s.StartTool(NewStitchTool())
+		wantPreview(t, s)
+	})
+	t.Run("surface_trim", func(t *testing.T) {
+		s, _, wp := patchedPartWithCutPlane(t)
+		tr := NewSurfaceTrimTool()
+		s.StartTool(tr)
+		tr.Pick(s, WorkPlaneHandle{Plane: wp})
+		wantPreview(t, s)
+	})
+	t.Run("sculpt", func(t *testing.T) {
+		s, _ := partWithCubeShell(t)
+		s.StartTool(NewSculptTool())
+		wantPreview(t, s)
+	})
+	t.Run("extend", func(t *testing.T) {
+		s, _, bottom := patchWithBottomEdge(t)
+		ex := NewExtendTool()
+		s.StartTool(ex)
+		ex.Pick(s, EdgeHandle{Edge: bottom})
+		ex.SetDistance(2)
+		wantPreview(t, s)
+	})
+}
+
+// wantPreview asserts the active tool renders a non-empty translucent ghost with feature edges.
+func wantPreview(t *testing.T, s *Session) {
+	t.Helper()
+	items := s.ToolPreview()
+	if len(items) == 0 {
+		t.Fatal("tool produced no preview")
+	}
+	tris, lines := 0, 0
+	for _, it := range items {
+		switch it.Primitive {
+		case 0: // Triangles
+			tris++
+		case 1: // Lines
+			lines++
+		}
+	}
+	if tris == 0 {
+		t.Errorf("preview has no translucent ghost (items=%d, lines=%d)", len(items), lines)
+	}
+}

--- a/app/feature_preview_test.go
+++ b/app/feature_preview_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+)
+
+// addSquareSketch adds a side×side square sketch on the XY plane with its lower-left corner
+// at (ox,oy) and returns the profile handle for its single region.
+func addSquareSketch(def *compdef.PartComponentDefinition, ox, oy, side float64) ProfileHandle {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(ox, oy))
+	c1 := sk.Points().Add(math.P2(ox+side, oy))
+	c2 := sk.Points().Add(math.P2(ox+side, oy+side))
+	c3 := sk.Points().Add(math.P2(ox, oy+side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return ProfileHandle{Sketch: sk, ProfileIndex: 0}
+}
+
+// TestFeaturePreviewCutIsRed builds a base solid, then previews an extrude-cut that bores a
+// hole through it. Removing material drops the volume, so the live preview is RED.
+func TestFeaturePreviewCutIsRed(t *testing.T) {
+	s, base := newPartWithSquare(t, 4)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+
+	// Commit a 4×4×4 base solid.
+	s.SetPicker(stubPicker{sel: base})
+	e0 := NewExtrudeTool()
+	s.StartTool(e0)
+	s.Click(0, 0)
+	e0.SetOperation(ops.NewBody)
+	e0.SetDistance(4)
+	if err := s.OK(); err != nil {
+		t.Fatalf("base extrude OK: %v", err)
+	}
+	baseVol := totalVolume(s.VisibleBodies())
+
+	// Preview a 2×2 through-cut centered in the base.
+	cut := addSquareSketch(def, 1, 1, 2)
+	s.SetPicker(stubPicker{sel: cut})
+	e1 := NewExtrudeTool()
+	s.StartTool(e1)
+	s.Click(0, 0)
+	e1.SetOperation(ops.Cut)
+	e1.SetDistance(4)
+
+	null := &renderer.NullBackend{}
+	s.RenderFrame(null)
+	prev := previewItems(null.LastFrame())
+	if len(prev) == 0 {
+		t.Fatal("no cut preview items")
+	}
+	if !sameHue(prev[0].Color, previewRemoveColor) {
+		t.Errorf("cut preview color = %v, want red %v", prev[0].Color, previewRemoveColor)
+	}
+	// The preview is non-destructive: the committed base is untouched.
+	if got := totalVolume(s.VisibleBodies()); got != baseVol {
+		t.Errorf("preview mutated the model volume: %v → %v", baseVol, got)
+	}
+}
+
+// TestPreviewDeltaHelpers covers the dress-up delta path (boolean difference) used when a
+// feature has no separable tool body.
+func TestPreviewDeltaHelpers(t *testing.T) {
+	s := extrudedBox(t, 4, 4)
+	base := s.VisibleBodies()
+	// Identical body sets differ by nothing → no delta solid to show.
+	if items := deltaPreviewItems(base, base); items != nil {
+		t.Errorf("identical bodies should yield no delta items, got %d", len(items))
+	}
+	// The box volume is ~64 cm³ (4×4×4).
+	if v := totalVolume(base); v < 63 || v > 65 {
+		t.Errorf("box volume = %v, want ~64", v)
+	}
+}
+
+// TestDressUpPreviewIsTheDeltaSolid is the regression guard for the "flooding" bug: a chamfer
+// on one edge of a 4×4×4 box must preview only the small wedge of material it removes (a red
+// solid ghost), NOT the whole part. We assert the preview's footprint is thin in X and Y (the
+// wedge spans one edge) — a flooded preview would span the full 4-unit box.
+func TestDressUpPreviewIsTheDeltaSolid(t *testing.T) {
+	s := extrudedBox(t, 4, 4)
+	edge := firstVerticalEdge(t, s.VisibleBodies()[0])
+
+	ch := NewChamferTool()
+	s.StartTool(ch)
+	ch.Pick(s, EdgeHandle{Edge: edge})
+	ch.SetDistance(1)
+
+	null := &renderer.NullBackend{}
+	s.RenderFrame(null)
+	prev := previewItems(null.LastFrame())
+	if len(prev) == 0 {
+		t.Fatal("chamfer preview produced no delta solid")
+	}
+	if !sameHue(prev[0].Color, previewRemoveColor) {
+		t.Errorf("chamfer (removes material) preview color = %v, want red %v", prev[0].Color, previewRemoveColor)
+	}
+	dx, dy, _ := previewExtent(prev)
+	if dx > 2 || dy > 2 { // the wedge is ~1×1 in cross-section; flooding would be the full 4×4
+		t.Errorf("chamfer delta footprint = %.2f×%.2f; expected a thin edge wedge (flooding regression)", dx, dy)
+	}
+}
+
+// sameHue reports whether two colors share RGB (ignoring alpha — the fill bakes opacity into
+// alpha, so only the hue is asserted).
+func sameHue(a, b [4]float32) bool {
+	return a[0] == b[0] && a[1] == b[1] && a[2] == b[2]
+}
+
+// previewExtent returns the X/Y/Z span of all preview vertex positions.
+func previewExtent(items []renderer.DrawItem) (dx, dy, dz float64) {
+	first := true
+	var minX, minY, minZ, maxX, maxY, maxZ float64
+	for _, it := range items {
+		for _, p := range it.Positions {
+			if first {
+				minX, minY, minZ = p.X, p.Y, p.Z
+				maxX, maxY, maxZ = p.X, p.Y, p.Z
+				first = false
+				continue
+			}
+			minX, maxX = min(minX, p.X), max(maxX, p.X)
+			minY, maxY = min(minY, p.Y), max(maxY, p.Y)
+			minZ, maxZ = min(minZ, p.Z), max(maxZ, p.Z)
+		}
+	}
+	return maxX - minX, maxY - minY, maxZ - minZ
+}
+
+// firstVerticalEdge returns a body edge running mostly along Z.
+func firstVerticalEdge(t *testing.T, b *topo.Body) *topo.Edge {
+	t.Helper()
+	for _, e := range b.Edges() {
+		pts := ops.TessellateEdge(e, ops.DefaultQuality())
+		if len(pts) >= 2 {
+			dz := pts[0].Z - pts[len(pts)-1].Z
+			if dz < 0 {
+				dz = -dz
+			}
+			if dz > 1 {
+				return e
+			}
+		}
+	}
+	t.Fatal("no vertical edge found")
+	return nil
+}
+
+// TestFeaturePreviewEmptyUntilReady asserts no preview is drawn before the tool has enough
+// input to commit (no region picked yet).
+func TestFeaturePreviewEmptyUntilReady(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	if items := s.ToolPreview(); items != nil {
+		t.Errorf("preview before any profile picked = %d items, want none", len(items))
+	}
+}
+
+// TestFeaturePreviewIsAGhostSolid checks the tool-body preview is one translucent mesh of the
+// whole feature solid (the prism), accompanied by its opaque feature edges.
+func TestFeaturePreviewIsAGhostSolid(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2)
+	s.SetPicker(stubPicker{sel: profile})
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	s.Click(0, 0)
+	ext.SetOperation(ops.NewBody)
+	ext.SetDistance(5)
+
+	null := &renderer.NullBackend{}
+	s.RenderFrame(null)
+	prev := previewItems(null.LastFrame())
+	if len(prev) != 1 {
+		t.Errorf("preview fill items = %d, want 1 merged ghost mesh", len(prev))
+	}
+	if previewTriangles(prev) < 12 { // a box prism has ≥12 triangles
+		t.Errorf("preview has %d triangles, want the whole prism (≥12)", previewTriangles(prev))
+	}
+	// The ghost is accompanied by opaque feature-edge lines.
+	if edgeLines(null.LastFrame()) == 0 {
+		t.Error("preview has no feature edge lines")
+	}
+}
+
+// edgeLines counts the opaque (alpha==1) on-top line items — the preview's feature edges.
+func edgeLines(frame renderer.DrawList) int {
+	n := 0
+	for _, it := range frame.Items {
+		if it.Primitive == renderer.Lines && it.OnTop && it.Color[3] == 1 {
+			n++
+		}
+	}
+	return n
+}

--- a/app/feature_preview_test.go
+++ b/app/feature_preview_test.go
@@ -205,3 +205,46 @@ func edgeLines(frame renderer.DrawList) int {
 	}
 	return n
 }
+
+// TestFaceSigHelpers pins the surface-signature comparison helpers used by changedFacePreview
+// to tell a feature's NEW faces from the base body's faces. A surface and its reverse share a
+// signature (signNorm), the freeform branch compares area+centroid (exercising maxVal), and a
+// different kind/anchor/radius never matches.
+func TestFaceSigHelpers(t *testing.T) {
+	// signNorm flips a vector so its dominant component is positive, so opposite normals match.
+	up, down := math.V3(0, 0, 1), math.V3(0, 0, -1)
+	if !signNorm(up).IsEqualTo(signNorm(down), 1e-9) {
+		t.Errorf("signNorm(%v) != signNorm(%v)", up, down)
+	}
+	// A cylinder axis foot is invariant to where along the axis the origin sits.
+	a := axisFoot(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	b := axisFoot(math.P3(0, 0, 7), math.V3(0, 0, 1))
+	if !a.IsEqualTo(b, 1e-9) {
+		t.Errorf("axisFoot not invariant along axis: %v vs %v", a, b)
+	}
+	if got := maxVal(2, 5); got != 5 {
+		t.Errorf("maxVal(2,5) = %g, want 5", got)
+	}
+	if got := absVal(-3); got != 3 {
+		t.Errorf("absVal(-3) = %g, want 3", got)
+	}
+
+	// Two freeform sigs (kind 0) with equal area+centroid match; differing area does not.
+	c := math.P3(1, 2, 3)
+	free := faceSig{kind: 0, centroid: c, area: 10}
+	if !sigEqual(free, faceSig{kind: 0, centroid: c, area: 10}) {
+		t.Error("identical freeform sigs should match")
+	}
+	if sigEqual(free, faceSig{kind: 0, centroid: c, area: 12}) {
+		t.Error("freeform sigs with different area should not match")
+	}
+	// A plane and a cylinder (different kind) never match.
+	if sigEqual(faceSig{kind: 1}, faceSig{kind: 2}) {
+		t.Error("different surface kinds should not match")
+	}
+	// Same-kind cylinders with different radii do not match.
+	cyl := faceSig{kind: 2, dir: math.V3(0, 0, 1), anchor: c, r1: 1}
+	if sigEqual(cyl, faceSig{kind: 2, dir: math.V3(0, 0, 1), anchor: c, r1: 2}) {
+		t.Error("cylinders with different radii should not match")
+	}
+}

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -180,6 +180,18 @@ func (t *FilletTool) Commit(s *Session) error {
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *FilletTool) AddedFeature() *feature.PartFeature { return t.added }
 
+// DraftFeature returns the unattached fillet feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addFillet the commit uses — so the
+// translucent preview is exactly what OK creates. Empty until an edge is selected.
+func (t *FilletTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFillet(feature.NewDressUpFeatures(fs)), nil
+	})
+}
+
 // Prompt guides the user through the fillet steps.
 func (t *FilletTool) Prompt(*Session) string {
 	if len(t.edges) == 0 {

--- a/app/grill_tool.go
+++ b/app/grill_tool.go
@@ -74,10 +74,7 @@ func (t *GrillTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	skt := t.profiles[0].Sketch
-	t.added = feature.NewGrillFeatures(part.Features()).Add(&feature.GrillDefinition{
-		Sketch: skt, Boundaries: profileIndicesOn(t.profiles, skt), Draft: t.draft,
-	})
+	t.added = t.addGrill(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Grill")
 	if !t.added.Health().OK() {
@@ -85,6 +82,24 @@ func (t *GrillTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addGrill builds the grill feature into engine fs — shared by Commit and the preview.
+func (t *GrillTool) addGrill(fs *feature.PartFeatures) *feature.PartFeature {
+	skt := t.profiles[0].Sketch
+	return feature.NewGrillFeatures(fs).Add(&feature.GrillDefinition{
+		Sketch: skt, Boundaries: profileIndicesOn(t.profiles, skt), Draft: t.draft,
+	})
+}
+
+// DraftFeature returns the unattached grill feature the viewport previews before commit.
+func (t *GrillTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addGrill(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -221,6 +221,18 @@ func konst(v float64) func() float64 { return func() float64 { return v } }
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *HoleTool) AddedFeature() *feature.PartFeature { return t.added }
 
+// DraftFeature returns the unattached hole feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addFeature the commit uses. The hole's
+// drill tool body previews red (a cut). Empty until placement is valid.
+func (t *HoleTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFeature(feature.NewHoleFeatures(fs)), nil
+	})
+}
+
 // Prompt guides the user through the hole steps.
 func (t *HoleTool) Prompt(*Session) string {
 	if t.face == nil {

--- a/app/loft_tool.go
+++ b/app/loft_tool.go
@@ -8,7 +8,6 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
-	"oblikovati.org/renderer"
 )
 
 // LoftTool is the interactive Loft command: activate it, click two or more cross-sections in
@@ -163,26 +162,7 @@ func (t *LoftTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	sections := make([]feature.LoftSection, len(t.sections))
-	for i, h := range t.sections {
-		switch {
-		case h.isPoint():
-			sections[i] = feature.LoftSection{Point: h.apex}
-		case h.isFace():
-			sections[i] = feature.LoftSection{FaceKey: h.faceKey}
-		default:
-			sections[i] = feature.LoftSection{Sketch: h.profile.Sketch, ProfileIndex: h.profile.ProfileIndex}
-		}
-	}
-	guides := feature.LoftGuideSet{
-		Rails:     t.railProviders(),
-		MapCurves: t.mapCurveProviders(),
-		AreaGraph: t.areaStops(),
-	}
-	if t.centerline != nil { // a centerline (spine) is exclusive with rails
-		guides.Rails, guides.Centerline = nil, t.centerlineProvider()
-	}
-	t.added = feature.NewLoftFeatures(part.Features()).AddGuided(sections, t.closed, t.operation, t.first, t.last, guides)
+	t.added = t.addLoft(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Loft")
 	if !t.added.Health().OK() {
@@ -258,27 +238,42 @@ func (t *LoftTool) Prompt(*Session) string {
 
 // Preview outlines each picked profile cross-section so the user sees what will be blended (a
 // point section is a single vertex, already drawn by the selection highlight).
-func (t *LoftTool) Preview(*Session) []renderer.DrawItem {
-	var items []renderer.DrawItem
-	for _, s := range t.sections {
-		if s.isPoint() || s.isFace() {
-			continue // a point/face section has no profile polygon to outline
+// addLoft assembles the cross-sections and guide set and builds the loft feature into engine
+// fs — the shared constructor used by both Commit (the part's engine) and DraftFeature (a
+// scratch engine), so the preview matches the committed result.
+func (t *LoftTool) addLoft(fs *feature.PartFeatures) *feature.PartFeature {
+	sections := make([]feature.LoftSection, len(t.sections))
+	for i, h := range t.sections {
+		switch {
+		case h.isPoint():
+			sections[i] = feature.LoftSection{Point: h.apex}
+		case h.isFace():
+			sections[i] = feature.LoftSection{FaceKey: h.faceKey}
+		default:
+			sections[i] = feature.LoftSection{Sketch: h.profile.Sketch, ProfileIndex: h.profile.ProfileIndex}
 		}
-		h := s.profile
-		if h.ProfileIndex >= h.Sketch.Profiles().Count() {
-			continue
-		}
-		poly := h.Sketch.Profiles().Item(h.ProfileIndex).OuterLoop().Polygon()
-		plane := h.Sketch.Plane()
-		pts := make([]math.Point3, len(poly))
-		idx := make([]int, 0, 2*len(poly))
-		for i, p := range poly {
-			pts[i] = plane.ToModel(p)
-			idx = append(idx, i, (i+1)%len(poly))
-		}
-		items = append(items, renderer.DrawItem{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}})
 	}
-	return items
+	guides := feature.LoftGuideSet{
+		Rails:     t.railProviders(),
+		MapCurves: t.mapCurveProviders(),
+		AreaGraph: t.areaStops(),
+	}
+	if t.centerline != nil { // a centerline (spine) is exclusive with rails
+		guides.Rails, guides.Centerline = nil, t.centerlineProvider()
+	}
+	return feature.NewLoftFeatures(fs).AddGuided(sections, t.closed, t.operation, t.first, t.last, guides)
+}
+
+// DraftFeature returns the unattached loft feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addLoft the commit uses. Empty until at
+// least two cross-sections are picked.
+func (t *LoftTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addLoft(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/patch_tool.go
+++ b/app/patch_tool.go
@@ -53,8 +53,7 @@ func (t *PatchTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	t.added = feature.NewBoundaryPatchFeatures(part.Features()).
-		Add(t.profile.Sketch, t.profile.ProfileIndex, feature.PatchFree)
+	t.added = t.addPatch(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Patch")
 	if !t.added.Health().OK() {
@@ -62,6 +61,21 @@ func (t *PatchTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addPatch builds the boundary-patch feature into engine fs — shared by Commit and the preview.
+func (t *PatchTool) addPatch(fs *feature.PartFeatures) *feature.PartFeature {
+	return feature.NewBoundaryPatchFeatures(fs).Add(t.profile.Sketch, t.profile.ProfileIndex, feature.PatchFree)
+}
+
+// DraftFeature returns the unattached patch feature the viewport previews before commit.
+func (t *PatchTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addPatch(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/render.go
+++ b/app/render.go
@@ -21,6 +21,28 @@ type Previewable interface {
 	Preview(s *Session) []renderer.DrawItem
 }
 
+// ToolPreview returns the active tool's transient preview draw items for the UI head, which
+// assembles its own frame draw list (the headless RenderFrame path uses the same source).
+func (s *Session) ToolPreview() []renderer.DrawItem { return s.toolPreviewItems() }
+
+// toolPreviewItems returns the active tool's transient preview: the translucent solid
+// result preview when the tool can draft its feature (DraftPreviewable), otherwise the
+// legacy wireframe (Previewable). Nil when no tool is active or it offers no preview.
+func (s *Session) toolPreviewItems() []renderer.DrawItem {
+	if s.tool == nil {
+		return nil
+	}
+	if dp, ok := s.tool.tool.(DraftPreviewable); ok {
+		if items := s.featurePreviewItems(dp); items != nil {
+			return items
+		}
+	}
+	if p, ok := s.tool.tool.(Previewable); ok {
+		return p.Preview(s)
+	}
+	return nil
+}
+
 // AddOverlay adds a persistent client-graphics primitive (overlay line/points drawn
 // over the model). ClearOverlays removes them; Overlays returns a snapshot.
 func (s *Session) AddOverlay(item renderer.DrawItem) { s.overlays = append(s.overlays, item) }
@@ -48,11 +70,7 @@ func (s *Session) GraphicsLabels() []clientgraphics.Label {
 func (s *Session) RenderFrame(backend renderer.Backend) {
 	list := renderer.BuildDrawListStyled(s.VisibleBodies(), s.camera, ops.DefaultQuality(), s.SurfaceLookup(), s.visualStyle)
 	list.Items = append(list.Items, s.overlays...)
-	if s.tool != nil {
-		if p, ok := s.tool.tool.(Previewable); ok {
-			list.Items = append(list.Items, p.Preview(s)...)
-		}
-	}
+	list.Items = append(list.Items, s.toolPreviewItems()...)
 	graphics, _, _ := s.graphics.Build(s.camera)
 	list.Items = append(list.Items, graphics...)
 	backend.Render(list)

--- a/app/render_test.go
+++ b/app/render_test.go
@@ -53,22 +53,27 @@ func TestExtrudeToolLivePreview(t *testing.T) {
 
 	s.Click(0, 0)
 	ext.SetDistance(5)
-	// Now the tool contributes a transient wireframe preview to the frame.
+	// Now the tool contributes a translucent solid result preview to the frame.
 	null.Reset()
 	s.RenderFrame(null)
 	if len(null.LastFrame().Items) <= preCount {
 		t.Fatal("no preview item added once the extrude is ready")
 	}
-	// The preview is a line item with the expected vertex count (2n ring points).
-	var preview *renderer.DrawItem
-	for i := range null.LastFrame().Items {
-		if null.LastFrame().Items[i].Primitive == renderer.Lines {
-			preview = &null.LastFrame().Items[i]
-		}
+	prev := previewItems(null.LastFrame())
+	if len(prev) == 0 {
+		t.Fatal("expected translucent triangle preview items once the extrude is ready")
 	}
-	if preview == nil || len(preview.Positions) != 8 { // square → 4 bottom + 4 top
-		t.Errorf("extrude preview wireframe wrong: %+v", preview)
+	// Building a new body on an empty part adds volume → the preview is GREEN.
+	if !sameHue(prev[0].Color, previewAddColor) {
+		t.Errorf("additive extrude preview color = %v, want green %v", prev[0].Color, previewAddColor)
 	}
+	if previewTriangles(prev) == 0 {
+		t.Error("preview has no triangles")
+	}
+
+	// A Cut of the same region previews RED (it would remove material from the new body).
+	// (Here there is no base material yet, so this only exercises the color path on commit
+	// order; the cut/remove color is covered directly in TestFeaturePreviewCutIsRed.)
 
 	// After OK the preview is gone and the real solid is rendered.
 	if err := s.OK(); err != nil {
@@ -79,6 +84,29 @@ func TestExtrudeToolLivePreview(t *testing.T) {
 	if null.LastFrame().Triangles() != 12 {
 		t.Errorf("post-commit frame triangles = %d, want 12", null.LastFrame().Triangles())
 	}
+	if len(previewItems(null.LastFrame())) != 0 {
+		t.Error("preview items should be gone after commit")
+	}
+}
+
+// previewItems returns the translucent (Opacity<1) triangle items in a frame — the live
+// feature preview, distinct from the opaque modeled solid.
+func previewItems(frame renderer.DrawList) []renderer.DrawItem {
+	var out []renderer.DrawItem
+	for _, it := range frame.Items {
+		if it.Primitive == renderer.Triangles && it.Opacity > 0 && it.Opacity < 1 {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+func previewTriangles(items []renderer.DrawItem) int {
+	n := 0
+	for _, it := range items {
+		n += len(it.Indices) / 3
+	}
+	return n
 }
 
 func TestRenderFrameNoActivePart(t *testing.T) {

--- a/app/replace_face_tool.go
+++ b/app/replace_face_tool.go
@@ -79,11 +79,7 @@ func (t *ReplaceFaceTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	keys := make([][]byte, len(t.faces))
-	for i, f := range t.faces {
-		keys[i] = f.Face.ReferenceKey()
-	}
-	t.added = feature.NewModifyFeatures(part.Features()).AddReplaceFace(keys, t.target.Face.ReferenceKey())
+	t.added = t.addReplaceFace(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Replace Face")
 	if !t.added.Health().OK() {
@@ -93,8 +89,23 @@ func (t *ReplaceFaceTool) Commit(s *Session) error {
 	return nil
 }
 
+// addReplaceFace builds the replace-face feature into engine fs — shared by Commit and preview.
+func (t *ReplaceFaceTool) addReplaceFace(fs *feature.PartFeatures) *feature.PartFeature {
+	return feature.NewModifyFeatures(fs).AddReplaceFace(faceKeys(t.faces), t.target.Face.ReferenceKey())
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ReplaceFaceTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached replace-face feature the viewport previews before commit.
+func (t *ReplaceFaceTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addReplaceFace(fs), nil
+	})
+}
 
 // Prompt guides the user through the replace-face steps.
 func (t *ReplaceFaceTool) Prompt(*Session) string {

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -11,7 +11,6 @@ import (
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
-	"oblikovati.org/renderer"
 )
 
 // preselectCenterline chooses the centerline a revolve should auto-select once a profile is
@@ -242,7 +241,7 @@ func (t *RevolveTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	if t.added, err = t.addRevolve(part); err != nil {
+	if t.added, err = t.addRevolve(part, part.Features()); err != nil {
 		return err
 	}
 	part.Recompute()
@@ -292,9 +291,9 @@ func (t *RevolveTool) writeEditAxis(s *Session, def *feature.RevolveDefinition) 
 
 // addRevolve adds the revolve feature about the tool's chosen axis: a specific picked centerline,
 // the sketch's own centerline, or a named work axis.
-func (t *RevolveTool) addRevolve(part *compdef.PartComponentDefinition) (*feature.PartFeature, error) {
+func (t *RevolveTool) addRevolve(part *compdef.PartComponentDefinition, fs *feature.PartFeatures) (*feature.PartFeature, error) {
 	angle := func() float64 { return t.angle }
-	revolves := feature.NewRevolveFeatures(part.Features())
+	revolves := feature.NewRevolveFeatures(fs)
 	switch {
 	case t.centerline != nil: // a specific picked/pre-selected centerline
 		return revolves.AddAboutCenterlineLine(t.profile.Sketch, t.profile.ProfileIndex, t.centerlineSk, t.centerline, angle, t.operation), nil
@@ -320,21 +319,20 @@ func (t *RevolveTool) Prompt(*Session) string {
 	return "Set the axis and angle, then click OK"
 }
 
-// Preview returns a transient outline of the region to revolve, so the viewport shows
-// what will be swept before OK. Empty until a region is picked.
-func (t *RevolveTool) Preview(*Session) []renderer.DrawItem {
-	if t.profile == nil || t.profile.ProfileIndex >= t.profile.Sketch.Profiles().Count() {
-		return nil
+// DraftFeature returns the unattached revolve feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addRevolve the commit uses — so the
+// translucent solid preview is exactly what OK creates. Empty until a region is picked.
+func (t *RevolveTool) DraftFeature(s *Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
 	}
-	poly := t.profile.Sketch.Profiles().Item(t.profile.ProfileIndex).OuterLoop().Polygon()
-	plane := t.profile.Sketch.Plane()
-	pts := make([]math.Point3, len(poly))
-	idx := make([]int, 0, 2*len(poly))
-	for i, p := range poly {
-		pts[i] = plane.ToModel(p)
-		idx = append(idx, i, (i+1)%len(poly))
+	part, err := activePart(s)
+	if err != nil {
+		return nil, false
 	}
-	return []renderer.DrawItem{{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}}}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addRevolve(part, fs)
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/rib_tool.go
+++ b/app/rib_tool.go
@@ -59,8 +59,7 @@ func (t *RibTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	th, d := t.thickness, t.depth
-	t.added = feature.NewRibFeatures(part.Features()).Add(t.profile, t.pathIndex, konst(th), konst(d), ops.Join)
+	t.added = t.addRib(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Rib")
 	if !t.added.Health().OK() {
@@ -69,11 +68,27 @@ func (t *RibTool) Commit(s *Session) error {
 	return nil
 }
 
+// addRib builds the rib feature into engine fs — shared by Commit and the preview.
+func (t *RibTool) addRib(fs *feature.PartFeatures) *feature.PartFeature {
+	th, d := t.thickness, t.depth
+	return feature.NewRibFeatures(fs).Add(t.profile, t.pathIndex, konst(th), konst(d), ops.Join)
+}
+
 // Cancel abandons the tool with no change.
 func (t *RibTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *RibTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached rib feature the viewport previews before commit.
+func (t *RibTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addRib(fs), nil
+	})
+}
 
 // ribProfile picks the sketch + open-path index the rib operates on: the active sketch if it
 // has an open path, else the part's most recent sketch that does. Returns nil when none.

--- a/app/sculpt_tool.go
+++ b/app/sculpt_tool.go
@@ -49,7 +49,7 @@ func (t *SculptTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	t.added = feature.NewSculptFeatures(part.Features()).Add(ops.NewBody, t.tolerance)
+	t.added = t.addSculpt(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Sculpt")
 	if !t.added.Health().OK() {
@@ -58,8 +58,23 @@ func (t *SculptTool) Commit(s *Session) error {
 	return nil
 }
 
+// addSculpt builds the sculpt feature into engine fs — shared by Commit and the preview.
+func (t *SculptTool) addSculpt(fs *feature.PartFeatures) *feature.PartFeature {
+	return feature.NewSculptFeatures(fs).Add(ops.NewBody, t.tolerance)
+}
+
 // Cancel abandons the tool with no change.
 func (t *SculptTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SculptTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached sculpt feature the viewport previews before commit.
+func (t *SculptTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addSculpt(fs), nil
+	})
+}

--- a/app/sheet_metal_f03_tools.go
+++ b/app/sheet_metal_f03_tools.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
 
@@ -60,14 +61,28 @@ func (t *SheetMetalLipTool) Commit(s *Session) error {
 	if !t.CanCommit() {
 		return errors.New("sheet-metal lip: pick an edge and set a positive height/return/angle")
 	}
+	t.added = t.addLip(part.Features())
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Lip")
+}
+
+func (t *SheetMetalLipTool) addLip(fs *feature.PartFeatures) *feature.PartFeature {
 	height, returnLen, angle := t.height, t.returnLen, t.angle
-	t.added = feature.NewSheetMetalLipFeatures(part.Features()).Add(&feature.SheetMetalLipDefinition{
+	return feature.NewSheetMetalLipFeatures(fs).Add(&feature.SheetMetalLipDefinition{
 		EdgeKey:      t.edge.Edge.ReferenceKey(),
 		Height:       func() float64 { return height },
 		ReturnLength: func() float64 { return returnLen },
 		Angle:        func() float64 { return angle },
 	})
-	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Lip")
+}
+
+// DraftFeature returns the unattached sheet-metal lip feature the viewport previews.
+func (t *SheetMetalLipTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addLip(fs), nil
+	})
 }
 
 // SheetMetalRipTool slits the sheet along a picked sketch line, opening a seam of the gap width.
@@ -103,15 +118,37 @@ func (t *SheetMetalRipTool) Commit(s *Session) error {
 	if !t.CanCommit() {
 		return errors.New("sheet-metal rip: pick a sketch line and set a positive gap")
 	}
+	added, err := t.addRip(part, part.Features())
+	if err != nil {
+		return err
+	}
+	t.added = added
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Rip")
+}
+
+func (t *SheetMetalRipTool) addRip(part *compdef.PartComponentDefinition, fs *feature.PartFeatures) (*feature.PartFeature, error) {
 	sk, idx, ok := lineHandleInPart(part, t.line.Entity)
 	if !ok {
-		return errors.New("sheet-metal rip: the pick is not a sketch line")
+		return nil, errors.New("sheet-metal rip: the pick is not a sketch line")
 	}
 	gap := t.gap
-	t.added = feature.NewSheetMetalRipFeatures(part.Features()).Add(&feature.SheetMetalRipDefinition{
+	return feature.NewSheetMetalRipFeatures(fs).Add(&feature.SheetMetalRipDefinition{
 		Sketch: sk, LineIndex: idx, Gap: func() float64 { return gap },
+	}), nil
+}
+
+// DraftFeature returns the unattached sheet-metal rip feature the viewport previews.
+func (t *SheetMetalRipTool) DraftFeature(s *Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addRip(part, fs)
 	})
-	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Rip")
 }
 
 // SheetMetalPunchTool stamps every closed profile of the picked profile's sketch through the
@@ -145,10 +182,24 @@ func (t *SheetMetalPunchTool) Commit(s *Session) error {
 	if t.profile == nil {
 		return errors.New("sheet-metal punch: pick a closed sketch profile (all profiles of its sketch are punched)")
 	}
-	t.added = feature.NewSheetMetalPunchFeatures(part.Features()).Add(&feature.SheetMetalPunchDefinition{
+	t.added = t.addPunch(part.Features())
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Punch")
+}
+
+func (t *SheetMetalPunchTool) addPunch(fs *feature.PartFeatures) *feature.PartFeature {
+	return feature.NewSheetMetalPunchFeatures(fs).Add(&feature.SheetMetalPunchDefinition{
 		Sketch: t.profile.Sketch,
 	})
-	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Punch")
+}
+
+// DraftFeature returns the unattached sheet-metal punch feature the viewport previews.
+func (t *SheetMetalPunchTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addPunch(fs), nil
+	})
 }
 
 // SheetMetalCosmeticBendTool marks a cosmetic bend line (no fold) on a picked sketch line.

--- a/app/sheet_metal_face_tool.go
+++ b/app/sheet_metal_face_tool.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
 
@@ -48,15 +49,22 @@ func (t *SheetMetalFaceTool) Commit(s *Session) error {
 	if len(t.profiles) == 0 {
 		return errors.New("sheet-metal face: pick a closed sketch profile")
 	}
+	t.added = t.addFace(part, part.Features())
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Face")
+}
+
+// addFace builds the sheet-metal face feature into engine fs — shared by Commit and the
+// preview. The operation (new body vs join the running sheet) is decided from the PART's
+// current result, not fs, so the preview matches whether a sheet already exists.
+func (t *SheetMetalFaceTool) addFace(part *compdef.PartComponentDefinition, fs *feature.PartFeatures) *feature.PartFeature {
 	op := ops.NewBody
 	if len(part.Features().Result()) > 0 {
 		op = ops.Join
 	}
 	p := t.profiles[0]
-	t.added = feature.NewSheetMetalFaceFeatures(part.Features()).Add(&feature.SheetMetalFaceDefinition{
+	return feature.NewSheetMetalFaceFeatures(fs).Add(&feature.SheetMetalFaceDefinition{
 		Sketch: p.Sketch, ProfileIndex: p.ProfileIndex, Operation: op,
 	})
-	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Face")
 }
 
 // Cancel abandons the tool.
@@ -64,3 +72,17 @@ func (t *SheetMetalFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSel
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SheetMetalFaceTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached sheet-metal face feature the viewport previews.
+func (t *SheetMetalFaceTool) DraftFeature(s *Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	part, err := activeSheetMetalPart(s)
+	if err != nil {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFace(part, fs), nil
+	})
+}

--- a/app/sheet_metal_flange_tool.go
+++ b/app/sheet_metal_flange_tool.go
@@ -64,13 +64,18 @@ func (t *SheetMetalFlangeTool) Commit(s *Session) error {
 	if !t.CanCommit() {
 		return errors.New("sheet-metal flange: pick an edge and set a positive height/angle")
 	}
+	t.added = t.addFlange(part.Features())
+	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Flange")
+}
+
+// addFlange builds the sheet-metal flange feature into engine fs — shared by Commit and preview.
+func (t *SheetMetalFlangeTool) addFlange(fs *feature.PartFeatures) *feature.PartFeature {
 	height, angle := t.height, t.angle
-	t.added = feature.NewSheetMetalFlangeFeatures(part.Features()).Add(&feature.SheetMetalFlangeDefinition{
+	return feature.NewSheetMetalFlangeFeatures(fs).Add(&feature.SheetMetalFlangeDefinition{
 		EdgeKey: t.edge.Edge.ReferenceKey(),
 		Height:  func() float64 { return height },
 		Angle:   func() float64 { return angle },
 	})
-	return commitSheetMetalFeature(s, part, t.added, "Sheet Metal Flange")
 }
 
 // Cancel abandons the tool.
@@ -78,3 +83,13 @@ func (t *SheetMetalFlangeTool) Cancel(s *Session) { s.Selection().SetFilter(NewS
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SheetMetalFlangeTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached sheet-metal flange feature the viewport previews.
+func (t *SheetMetalFlangeTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFlange(fs), nil
+	})
+}

--- a/app/shell_tool.go
+++ b/app/shell_tool.go
@@ -83,8 +83,7 @@ func (t *ShellTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	th := t.thickness
-	t.added = feature.NewDressUpFeatures(part.Features()).AddShell(t.selectedFaceKeys(), func() float64 { return th })
+	t.added = t.addShell(feature.NewDressUpFeatures(part.Features()))
 	part.Recompute()
 	s.recordEdit(part, "Shell")
 	if !t.added.Health().OK() {
@@ -94,8 +93,27 @@ func (t *ShellTool) Commit(s *Session) error {
 	return nil
 }
 
+// addShell builds the shell feature into collection dress — the shared constructor used by
+// both Commit (the part's engine) and DraftFeature (a scratch engine).
+func (t *ShellTool) addShell(dress *feature.DressUpFeatures) *feature.PartFeature {
+	th := t.thickness
+	return dress.AddShell(t.selectedFaceKeys(), func() float64 { return th })
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ShellTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached shell feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addShell the commit uses. Empty until a
+// face is selected.
+func (t *ShellTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addShell(feature.NewDressUpFeatures(fs)), nil
+	})
+}
 
 // Prompt guides the user through the shell steps.
 func (t *ShellTool) Prompt(*Session) string {

--- a/app/split_tool.go
+++ b/app/split_tool.go
@@ -80,12 +80,7 @@ func (t *SplitTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	mods := feature.NewModifyFeatures(part.Features())
-	if t.facesOnly {
-		t.added = mods.AddSplitFaces(t.plane)
-	} else {
-		t.added = mods.AddSplitSolid(t.plane, t.keep)
-	}
+	t.added = t.addSplit(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Split")
 	if !t.added.Health().OK() {
@@ -93,6 +88,25 @@ func (t *SplitTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addSplit builds the split feature into engine fs — shared by Commit and the preview.
+func (t *SplitTool) addSplit(fs *feature.PartFeatures) *feature.PartFeature {
+	mods := feature.NewModifyFeatures(fs)
+	if t.facesOnly {
+		return mods.AddSplitFaces(t.plane)
+	}
+	return mods.AddSplitSolid(t.plane, t.keep)
+}
+
+// DraftFeature returns the unattached split feature the viewport previews before commit.
+func (t *SplitTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addSplit(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/stitch_tool.go
+++ b/app/stitch_tool.go
@@ -52,7 +52,7 @@ func (t *StitchTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	t.added = feature.NewStitchFeatures(part.Features()).Add(t.tolerance, t.keepSurface)
+	t.added = t.addStitch(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Stitch")
 	if !t.added.Health().OK() {
@@ -61,8 +61,23 @@ func (t *StitchTool) Commit(s *Session) error {
 	return nil
 }
 
+// addStitch builds the stitch feature into engine fs — shared by Commit and the preview.
+func (t *StitchTool) addStitch(fs *feature.PartFeatures) *feature.PartFeature {
+	return feature.NewStitchFeatures(fs).Add(t.tolerance, t.keepSurface)
+}
+
 // Cancel abandons the tool with no change.
 func (t *StitchTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *StitchTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached stitch feature the viewport previews before commit.
+func (t *StitchTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addStitch(fs), nil
+	})
+}

--- a/app/surface_trim_tool.go
+++ b/app/surface_trim_tool.go
@@ -59,8 +59,7 @@ func (t *SurfaceTrimTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	sp := t.plane.Plane()
-	t.added = feature.NewTrimFeatures(part.Features()).AddByPlane(sp.Origin(), sp.Normal().AsVector(), t.keepPositive)
+	t.added = t.addTrim(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Trim")
 	if !t.added.Health().OK() {
@@ -68,6 +67,22 @@ func (t *SurfaceTrimTool) Commit(s *Session) error {
 	}
 	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
+}
+
+// addTrim builds the surface-trim feature into engine fs — shared by Commit and the preview.
+func (t *SurfaceTrimTool) addTrim(fs *feature.PartFeatures) *feature.PartFeature {
+	sp := t.plane.Plane()
+	return feature.NewTrimFeatures(fs).AddByPlane(sp.Origin(), sp.Normal().AsVector(), t.keepPositive)
+}
+
+// DraftFeature returns the unattached trim feature the viewport previews before commit.
+func (t *SurfaceTrimTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addTrim(fs), nil
+	})
 }
 
 // Cancel restores the default selection filter.

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 
 	"oblikovati.org/kernel/ops"
-	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
-	"oblikovati.org/renderer"
 )
 
 // SweepTool is the interactive Sweep command: activate it, click a sketch region (the
@@ -94,13 +92,9 @@ func (t *SweepTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	path3d, err := resolveSweepPath(t.path)
-	if err != nil {
+	if t.added, err = t.addSweep(part.Features()); err != nil {
 		return err
 	}
-	twist := t.twist
-	t.added = feature.NewSweepFeatures(part.Features()).
-		Add(t.profile.Sketch, t.profile.ProfileIndex, path3d, func() float64 { return twist }, t.operation)
 	part.Recompute()
 	s.recordEdit(part, "Sweep")
 	if !t.added.Health().OK() {
@@ -143,19 +137,27 @@ func (t *SweepTool) Prompt(*Session) string {
 }
 
 // Preview outlines the picked profile region until the sweep is committed.
-func (t *SweepTool) Preview(*Session) []renderer.DrawItem {
-	if t.profile == nil || t.profile.ProfileIndex >= t.profile.Sketch.Profiles().Count() {
-		return nil
+// addSweep resolves the path to a 3D rail and builds the sweep feature into engine fs — the
+// shared constructor used by both Commit (the part's engine) and DraftFeature (a scratch
+// engine), so the preview matches the committed result.
+func (t *SweepTool) addSweep(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+	path3d, err := resolveSweepPath(t.path)
+	if err != nil {
+		return nil, err
 	}
-	poly := t.profile.Sketch.Profiles().Item(t.profile.ProfileIndex).OuterLoop().Polygon()
-	plane := t.profile.Sketch.Plane()
-	pts := make([]math.Point3, len(poly))
-	idx := make([]int, 0, 2*len(poly))
-	for i, p := range poly {
-		pts[i] = plane.ToModel(p)
-		idx = append(idx, i, (i+1)%len(poly))
+	twist := t.twist
+	return feature.NewSweepFeatures(fs).
+		Add(t.profile.Sketch, t.profile.ProfileIndex, path3d, func() float64 { return twist }, t.operation), nil
+}
+
+// DraftFeature returns the unattached sweep feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addSweep the commit uses. Empty until both
+// a profile and a path are picked.
+func (t *SweepTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
 	}
-	return []renderer.DrawItem{{Primitive: renderer.Lines, Positions: pts, Indices: idx, Color: [4]float32{1, 0.6, 0, 1}}}
+	return draftFromScratch(t.addSweep)
 }
 
 // Cancel restores the default selection filter.

--- a/app/thicken_tool.go
+++ b/app/thicken_tool.go
@@ -50,8 +50,7 @@ func (t *ThickenTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	t.added = feature.NewModifyFeatures(part.Features()).AddThicken(t.thickness)
-	t.added.Definition().(*feature.ThickenFeature).SetApproximation(approximationAt(t.approxIdx))
+	t.added = t.addThicken(part.Features())
 	part.Recompute()
 	s.recordEdit(part, "Thicken")
 	if !t.added.Health().OK() {
@@ -60,8 +59,25 @@ func (t *ThickenTool) Commit(s *Session) error {
 	return nil
 }
 
+// addThicken builds the thicken feature into engine fs — shared by Commit and the preview.
+func (t *ThickenTool) addThicken(fs *feature.PartFeatures) *feature.PartFeature {
+	pf := feature.NewModifyFeatures(fs).AddThicken(t.thickness)
+	pf.Definition().(*feature.ThickenFeature).SetApproximation(approximationAt(t.approxIdx))
+	return pf
+}
+
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ThickenTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached thicken feature the viewport previews before commit.
+func (t *ThickenTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addThicken(fs), nil
+	})
+}
 
 // Prompt guides the user.
 func (t *ThickenTool) Prompt(*Session) string { return "Set the thickness, then click OK" }

--- a/app/thread_tool.go
+++ b/app/thread_tool.go
@@ -170,17 +170,9 @@ func (t *ThreadTool) Commit(s *Session) error {
 	if err != nil {
 		return err
 	}
-	if t.face == nil {
-		return errors.New("thread: click a cylindrical face first")
-	}
-	designation, err := t.Designation()
-	if err != nil {
+	if t.added, err = t.addThread(feature.NewDressUpFeatures(part.Features())); err != nil {
 		return err
 	}
-	t.added = feature.NewDressUpFeatures(part.Features()).AddThreadDef(&feature.ThreadDefinition{
-		FaceKey: t.face.Face.ReferenceKey(), Designation: designation, Cut: t.cut,
-		Class: t.class(), Tapered: t.tapered, ModelDiameter: threadModelDiameters[clampRange(t.modelDiaIdx, len(threadModelDiameters))],
-	})
 	part.Recompute()
 	s.recordEdit(part, "Thread")
 	if !t.added.Health().OK() {
@@ -190,11 +182,40 @@ func (t *ThreadTool) Commit(s *Session) error {
 	return nil
 }
 
+// addThread builds the thread feature into collection dress — the shared constructor used by
+// both Commit (the part's engine) and DraftFeature (a scratch engine).
+func (t *ThreadTool) addThread(dress *feature.DressUpFeatures) (*feature.PartFeature, error) {
+	if t.face == nil {
+		return nil, errors.New("thread: click a cylindrical face first")
+	}
+	designation, err := t.Designation()
+	if err != nil {
+		return nil, err
+	}
+	return dress.AddThreadDef(&feature.ThreadDefinition{
+		FaceKey: t.face.Face.ReferenceKey(), Designation: designation, Cut: t.cut,
+		Class: t.class(), Tapered: t.tapered, ModelDiameter: threadModelDiameters[clampRange(t.modelDiaIdx, len(threadModelDiameters))],
+	}), nil
+}
+
 // Cancel abandons the tool.
 func (t *ThreadTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ThreadTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached thread feature the viewport previews before commit
+// (satisfying DraftPreviewable), built by the same addThread the commit uses. A cut thread
+// previews red; an applied (cosmetic/raised) thread changes little volume. Empty until a
+// cylindrical face is picked.
+func (t *ThreadTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addThread(feature.NewDressUpFeatures(fs))
+	})
+}
 
 // clampRange keeps an index within [0, n).
 func clampRange(i, n int) int {

--- a/head/cmd/previewshot/main.go
+++ b/head/cmd/previewshot/main.go
@@ -116,6 +116,22 @@ func setupOp(s *app.Session, op string) error {
 		startPendingRib(s)
 	case "thicken":
 		startPendingThicken(s)
+	case "emboss":
+		startPendingEmboss(s, mustBlock(s))
+	case "grill":
+		startPendingGrill(s, mustBlock(s))
+	case "replaceface":
+		startPendingReplaceFace(s, mustBlock(s))
+	case "patch":
+		startPendingPatch(s)
+	case "stitch":
+		startPendingStitch(s)
+	case "surfacetrim":
+		startPendingSurfaceTrim(s)
+	case "sculpt":
+		startPendingSculpt(s)
+	case "extend":
+		startPendingExtend(s)
 	default:
 		return fmt.Errorf("unknown -op %q", op)
 	}
@@ -399,6 +415,156 @@ func startPendingThicken(s *app.Session) {
 	t := app.NewThickenTool()
 	s.StartTool(t)
 	t.SetThickness(1)
+}
+
+// startPendingEmboss raises a region sketched on the block's top face (adds material → green).
+func startPendingEmboss(s *app.Session, def *compdef.PartComponentDefinition) {
+	es := def.Sketches().Add(topPlaneZ(3))
+	rectOn(es, 2, 2, 4, 4)
+	def.Recompute()
+	t := app.NewEmbossTool()
+	s.StartTool(t)
+	t.Pick(s, app.ProfileHandle{Sketch: es, ProfileIndex: 0})
+	t.SetDepth(1)
+}
+
+// startPendingGrill cuts a grill (vents + ribs) on the block's top face (removes material → red).
+func startPendingGrill(s *app.Session, def *compdef.PartComponentDefinition) {
+	es := def.Sketches().Add(topPlaneZ(3))
+	rectOn(es, 1, 1, 5, 5)
+	rectOn(es, 2.25, 1.5, 2.75, 4.5)
+	rectOn(es, 3.25, 1.5, 3.75, 4.5)
+	def.Recompute()
+	t := app.NewGrillTool()
+	s.StartTool(t)
+	t.Pick(s, app.ProfileHandle{Sketch: es, ProfileIndex: 0})
+}
+
+// startPendingReplaceFace replaces the block's chamfered face with a flat side plane (the
+// retrimmed solid result is shown). A chamfer first gives a non-axis face to replace onto a
+// neighbouring plane, producing a visible change.
+func startPendingReplaceFace(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	feature.NewDressUpFeatures(def.Features()).AddChamfer([][]byte{verticalEdge(body.Edges()).ReferenceKey()}, func() float64 { return 1.2 })
+	def.Recompute()
+	body = def.SurfaceBodies().Item(0)
+	t := app.NewReplaceFaceTool()
+	s.StartTool(t)
+	t.Pick(s, app.FaceHandle{Face: nonAxisAlignedFace(body), Body: body}) // the chamfer face
+	t.SetPickingTarget(true)
+	t.Pick(s, app.FaceHandle{Face: faceByNormalX(body, 1), Body: body}) // onto the +X side plane
+}
+
+// startPendingPatch fills a sketched region with a surface patch (creates surface → green).
+func startPendingPatch(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	sk := addSquare(def, 0, 0, 4)
+	def.Recompute()
+	t := app.NewPatchTool()
+	s.StartTool(t)
+	t.Pick(s, app.ProfileHandle{Sketch: sk, ProfileIndex: 0})
+}
+
+// startPendingStitch welds two adjacent surface patches (result surface → green).
+func startPendingStitch(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	addPatchFeature(def, 0, 0, 2, 3)
+	addPatchFeature(def, 2, 0, 4, 3)
+	def.Recompute()
+	s.StartTool(app.NewStitchTool())
+}
+
+// startPendingSurfaceTrim trims a surface patch by a work plane (removes area → red).
+func startPendingSurfaceTrim(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	addPatchFeature(def, 0, 0, 4, 4)
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginYZPlane, func() float64 { return 2 })
+	def.Recompute()
+	t := app.NewSurfaceTrimTool()
+	s.StartTool(t)
+	t.Pick(s, app.WorkPlaneHandle{Plane: wp})
+}
+
+// startPendingSculpt closes a 6-face surface shell into a solid (creates volume → green).
+func startPendingSculpt(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	feature.NewBaseFeatures(def.Features()).AddBase(unitCubeShell()...)
+	def.Recompute()
+	s.StartTool(app.NewSculptTool())
+}
+
+// startPendingExtend grows a surface patch beyond its bottom edge (adds area → green).
+func startPendingExtend(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	addPatchFeature(def, 0, 0, 4, 4)
+	def.Recompute()
+	body := def.SurfaceBodies().Item(0)
+	var bottom *topo.Edge
+	for _, e := range body.Edges() {
+		if e.StartVertex().Point().Y == 0 && e.EndVertex().Point().Y == 0 {
+			bottom = e
+		}
+	}
+	t := app.NewExtendTool()
+	s.StartTool(t)
+	t.Pick(s, app.EdgeHandle{Edge: bottom})
+	t.SetDistance(2)
+}
+
+// topPlaneZ is a sketch plane parallel to XY at height z.
+func topPlaneZ(z float64) sketch.Plane {
+	p, _ := sketch.NewPlane(math.P3(0, 0, z), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	return p
+}
+
+// rectOn adds a rectangle [x0,y0]-[x1,y1] to sketch sk.
+func rectOn(sk *sketch.Sketch, x0, y0, x1, y1 float64) {
+	c0 := sk.Points().Add(math.P2(x0, y0))
+	c1 := sk.Points().Add(math.P2(x1, y0))
+	c2 := sk.Points().Add(math.P2(x1, y1))
+	c3 := sk.Points().Add(math.P2(x0, y1))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+}
+
+// addPatchFeature adds a rectangular boundary-patch surface to the part.
+func addPatchFeature(def *compdef.PartComponentDefinition, x0, y0, x1, y1 float64) {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	rectOn(sk, x0, y0, x1, y1)
+	feature.NewBoundaryPatchFeatures(def.Features()).Add(sk, 0, feature.PatchFree)
+}
+
+// unitCubeShell builds the six surface faces of a unit cube (an open shell sculpt closes).
+func unitCubeShell() []*topo.Body {
+	p := math.P3
+	return []*topo.Body{
+		cubeFace(p(0, 0, 0), p(0, 1, 0), p(1, 1, 0), p(1, 0, 0)),
+		cubeFace(p(0, 0, 1), p(1, 0, 1), p(1, 1, 1), p(0, 1, 1)),
+		cubeFace(p(0, 0, 0), p(1, 0, 0), p(1, 0, 1), p(0, 0, 1)),
+		cubeFace(p(0, 1, 0), p(0, 1, 1), p(1, 1, 1), p(1, 1, 0)),
+		cubeFace(p(0, 0, 0), p(0, 0, 1), p(0, 1, 1), p(0, 1, 0)),
+		cubeFace(p(1, 0, 0), p(1, 1, 0), p(1, 1, 1), p(1, 0, 1)),
+	}
+}
+
+// cubeFace builds one quad surface face from four corners.
+func cubeFace(p0, p1, p2, p3 math.Point3) *topo.Body {
+	lin := topo.NewLineage(topo.Tok("previewshot", "cubeface", 0))
+	bld := topo.NewBuilder(false, lin)
+	surf, _ := geom.NewPlane(p0, p0.VectorTo(p1).Cross(p1.VectorTo(p2)))
+	pts := []math.Point3{p0, p1, p2, p3}
+	v := make([]*topo.Vertex, 4)
+	for i, q := range pts {
+		v[i] = bld.AddVertex(q, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := 0; i < 4; i++ {
+		uses[i] = topo.Fwd(bld.AddEdge(geom.NewLineSegment(pts[i], pts[(i+1)%4]), v[i], v[(i+1)%4], lin))
+	}
+	bld.AddFace(surf, lin, topo.OuterLoop(uses...))
+	return bld.Build()
 }
 
 // patchSurface builds a w×h planar (open) surface body on the XY plane.

--- a/head/cmd/previewshot/main.go
+++ b/head/cmd/previewshot/main.go
@@ -1,0 +1,388 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Command previewshot is a throwaway live-capture driver for the in-canvas feature preview:
+// it opens the real native window, sets up a part with a pending (uncommitted) feature of the
+// requested kind, runs the production DrawChrome frame loop, and saves the 3D viewport — so the
+// PNG shows the translucent result ghost exactly as the app draws it (green where the feature
+// adds material, red where it removes it).
+//
+//	go run ./head/cmd/previewshot -op join   -out /tmp/p-join.png
+//	go run ./head/cmd/previewshot -op cut    -out /tmp/p-cut.png
+//	go run ./head/cmd/previewshot -op revolve -out /tmp/p-revolve.png   # join|cut|revolve|
+//	  sweep|loft|coil|hole|fillet|chamfer|shell|draft|thread
+package main
+
+import (
+	"flag"
+	"fmt"
+	stdmath "math"
+	"os"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/ui"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+func main() {
+	op := flag.String("op", "cut", "pending feature to preview: join|cut|revolve|sweep|loft|coil|hole|fillet|chamfer|shell|draft|thread")
+	out := flag.String("out", "/tmp/previewshot.png", "viewport PNG output path")
+	frames := flag.Int("frames", 8, "frames to render before capture")
+	flag.Parse()
+	if err := run(*op, *out, *frames); err != nil {
+		fmt.Fprintln(os.Stderr, "previewshot:", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, "wrote", *out)
+}
+
+func run(op, out string, frames int) error {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		return err
+	}
+	if err := setupOp(s, op); err != nil {
+		return err
+	}
+	// Edge dress-ups (fillet/chamfer) set their own camera aimed at the modified corner so the
+	// thin wedge faces us; everything else uses the standard iso view.
+	if op != "fillet" && op != "chamfer" {
+		if err := s.SetViewOrientation(types.IsoTopRightViewOrientation, true); err != nil {
+			return err
+		}
+	}
+	s.TickCameraAnimation(100)
+
+	win, err := native.CreateWindow(1280, 800, "previewshot")
+	if err != nil {
+		return err
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	for i := 0; i < frames; i++ {
+		win.BeginFrame()
+		ui.DrawChrome(win, s)
+		win.EndFrame(ui.WindowClearColor())
+	}
+	return win.SaveViewportPNG(out)
+}
+
+// setupOp builds the part and starts the requested feature tool, leaving it pending so the
+// viewport previews it.
+func setupOp(s *app.Session, op string) error {
+	switch op {
+	case "join", "cut":
+		startPendingExtrude(s, mustBaseBox(s), op)
+	case "fillet":
+		startPendingFillet(s, mustBaseBox(s))
+	case "chamfer":
+		startPendingChamfer(s, mustBaseBox(s))
+	case "shell":
+		startPendingShell(s, mustBlock(s))
+	case "draft":
+		startPendingDraft(s, mustBlock(s))
+	case "hole":
+		startPendingHole(s, mustBlock(s))
+	case "revolve":
+		startPendingRevolve(s)
+	case "sweep":
+		startPendingSweep(s)
+	case "loft":
+		startPendingLoft(s)
+	case "coil":
+		startPendingCoil(s)
+	case "thread":
+		return startPendingThread(s)
+	default:
+		return fmt.Errorf("unknown -op %q", op)
+	}
+	return nil
+}
+
+// --- base solids -----------------------------------------------------------------------
+
+// newPart adds and activates an empty part, returning its definition.
+func newPart(s *app.Session, name string) *compdef.PartComponentDefinition {
+	pd, err := compdef.AddPart(s.Workspace(), name, true)
+	if err != nil {
+		panic(err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	return pd.Content().(*compdef.PartComponentDefinition)
+}
+
+// mustBaseBox commits a 6×6×6 base cube (the target for join/cut/fillet/chamfer).
+func mustBaseBox(s *app.Session) *compdef.PartComponentDefinition { return buildBaseBox(s) }
+
+func buildBaseBox(s *app.Session) *compdef.PartComponentDefinition {
+	def := newPart(s, "previewshot.opd")
+	sk := addSquare(def, 0, 0, 6)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 6 })
+	def.Recompute()
+	return def
+}
+
+// mustBlock commits a 6×6×3 base solid (the target for shell/draft/hole).
+func mustBlock(s *app.Session) *compdef.PartComponentDefinition {
+	def := newPart(s, "previewshot.opd")
+	sk := addSquare(def, 0, 0, 6)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 3 })
+	def.Recompute()
+	return def
+}
+
+// addSquare adds a side×side square sketch on the XY plane with its corner at (ox,oy).
+func addSquare(def *compdef.PartComponentDefinition, ox, oy, side float64) *sketch.Sketch {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(ox, oy))
+	c1 := sk.Points().Add(math.P2(ox+side, oy))
+	c2 := sk.Points().Add(math.P2(ox+side, oy+side))
+	c3 := sk.Points().Add(math.P2(ox, oy+side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return sk
+}
+
+// offsetSquare adds a side×side square on XY whose lower-left corner is at (x0,0).
+func offsetSquare(def *compdef.PartComponentDefinition, x0, side float64) app.ProfileHandle {
+	return app.ProfileHandle{Sketch: addSquare(def, x0, 0, side), ProfileIndex: 0}
+}
+
+// --- swept-solid features (tool body → green) ------------------------------------------
+
+func startPendingExtrude(s *app.Session, def *compdef.PartComponentDefinition, op string) {
+	sk := addSquare(def, 2, 2, 4)
+	def.Recompute()
+	ext := app.NewExtrudeTool()
+	s.StartTool(ext)
+	ext.Pick(s, app.ProfileHandle{Sketch: sk, ProfileIndex: 0})
+	if op == "join" {
+		ext.SetOperation(ops.Join)
+		ext.SetDistance(8) // a column standing proud above the base → green
+	} else {
+		ext.SetOperation(ops.Cut)
+		ext.SetDistance(4) // a hole bored through the base → red
+	}
+}
+
+func startPendingRevolve(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	prof := offsetSquare(def, 3, 2) // 2×2 square 3 units off the Y axis → a ring
+	def.Recompute()
+	rv := app.NewRevolveTool()
+	s.StartTool(rv)
+	rv.Pick(s, prof)
+	rv.SetAxis(feature.OriginYAxis)
+	rv.SetAngle(3 * stdmath.Pi / 2) // 270° so the ring's opening is visible
+}
+
+func startPendingSweep(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	prof := app.ProfileHandle{Sketch: centeredSquare(def, sketch.XYPlane(), 1), ProfileIndex: 0}
+	pathSk := def.Sketches().Add(sketch.XZPlane())
+	a := pathSk.Points().Add(math.P2(0, 0))
+	b := pathSk.Points().Add(math.P2(0, 6))
+	pathSk.Lines().Add(a, b)
+	def.Recompute()
+	sw := app.NewSweepTool()
+	s.StartTool(sw)
+	sw.Pick(s, prof)
+	sw.Pick(s, app.PathHandle{Sketch: pathSk, PathIndex: 0})
+}
+
+func startPendingLoft(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	bottom := app.ProfileHandle{Sketch: centeredSquare(def, sketch.XYPlane(), 3), ProfileIndex: 0}
+	top := app.ProfileHandle{Sketch: centeredSquare(def, planeAtZ(6), 1), ProfileIndex: 0}
+	def.Recompute()
+	l := app.NewLoftTool()
+	s.StartTool(l)
+	l.Pick(s, bottom)
+	l.Pick(s, top)
+}
+
+func startPendingCoil(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	prof := offsetSquare(def, 3, 1) // 1×1 square 3 off the Y axis → a helical spring
+	def.Recompute()
+	c := app.NewCoilTool()
+	s.StartTool(c)
+	c.Pick(s, prof)
+	c.SetAxis(feature.OriginYAxis)
+	c.SetPitch(2)
+	c.SetRevolutions(3)
+}
+
+// --- hole (drill tool body → red) ------------------------------------------------------
+
+func startPendingHole(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	hole := app.NewHoleTool()
+	s.StartTool(hole)
+	hole.Pick(s, app.FaceHandle{Face: faceByNormalZ(body, 1), Body: body})
+	hole.SetDiameter(2)
+	hole.SetDepth(4) // through the 3-thick block → red drill
+}
+
+// --- dress-ups (changed-faces diff) ----------------------------------------------------
+
+func startPendingFillet(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	edge := verticalEdge(body.Edges())
+	fillet := app.NewFilletTool()
+	s.StartTool(fillet)
+	fillet.Pick(s, app.EdgeHandle{Edge: edge})
+	fillet.SetRadius(1.2)
+	aimCameraAtEdge(s, body, edge)
+}
+
+func startPendingChamfer(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	edge := verticalEdge(body.Edges())
+	ch := app.NewChamferTool()
+	s.StartTool(ch)
+	ch.Pick(s, app.EdgeHandle{Edge: edge})
+	ch.SetDistance(1.2)
+	aimCameraAtEdge(s, body, edge)
+}
+
+// aimCameraAtEdge frames the body from outside the given edge (looking at its midpoint along
+// the outward direction, tilted down), so a thin edge wedge faces the camera rather than
+// presenting edge-on.
+func aimCameraAtEdge(s *app.Session, body *topo.Body, e *topo.Edge) {
+	pts := ops.TessellateEdge(e, ops.DefaultQuality())
+	mid := pts[len(pts)/2]
+	rb := body.RangeBox()
+	cx, cy := (rb.Min.X+rb.Max.X)/2, (rb.Min.Y+rb.Max.Y)/2
+	ox, oy := mid.X-cx, mid.Y-cy
+	n := stdmath.Hypot(ox, oy)
+	if n == 0 {
+		n = 1
+	}
+	dist := (rb.Max.X - rb.Min.X) * 2.4
+	cam := scene.NewCamera(1280, 800)
+	cam.Target = mid
+	cam.Eye = math.P3(mid.X+ox/n*dist, mid.Y+oy/n*dist, mid.Z+dist*0.5)
+	cam.Up = math.V3(0, 0, 1)
+	s.SetCamera(cam)
+}
+
+func startPendingShell(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	sh := app.NewShellTool()
+	s.StartTool(sh)
+	sh.Pick(s, app.FaceHandle{Face: faceByNormalZ(body, 1), Body: body}) // open the top
+	sh.SetThickness(0.6)
+}
+
+func startPendingDraft(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	d := app.NewDraftTool()
+	s.StartTool(d)
+	d.Pick(s, app.FaceHandle{Face: faceByNormalX(body, 1), Body: body})
+	d.SetAngleDegrees(12)
+}
+
+func startPendingThread(s *app.Session) error {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1.0, 5.0)
+	if err != nil {
+		return err
+	}
+	def := newPart(s, "previewshot.opd")
+	feature.NewBaseFeatures(def.Features()).AddBase(cyl)
+	def.Recompute()
+	body := def.SurfaceBodies().Item(0)
+	tool := app.NewThreadTool()
+	s.StartTool(tool)
+	tool.Pick(s, app.FaceHandle{Face: cylindricalFace(body), Body: body})
+	tool.SetStandardIndex(0)
+	tool.SetSizeIndex(6) // M8
+	tool.SetPitchIndex(0)
+	tool.SetCut(true) // cut thread → removes material → red
+	return nil
+}
+
+// --- geometry helpers ------------------------------------------------------------------
+
+func centeredSquare(def *compdef.PartComponentDefinition, plane sketch.Plane, half float64) *sketch.Sketch {
+	sk := def.Sketches().Add(plane)
+	c0 := sk.Points().Add(math.P2(-half, -half))
+	c1 := sk.Points().Add(math.P2(half, -half))
+	c2 := sk.Points().Add(math.P2(half, half))
+	c3 := sk.Points().Add(math.P2(-half, half))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return sk
+}
+
+func planeAtZ(z float64) sketch.Plane {
+	p, _ := sketch.NewPlane(math.P3(0, 0, z), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	return p
+}
+
+// faceByNormalZ / faceByNormalX return the body's first face whose outward normal points
+// along ±Z / ±X (sign = +1 or -1).
+func faceByNormalZ(b *topo.Body, sign float64) *topo.Face {
+	for _, f := range b.Faces() {
+		if sign*float64(f.Geometry().NormalAt(0, 0).Z) > 0.9 {
+			return f
+		}
+	}
+	return b.Faces()[0]
+}
+
+func faceByNormalX(b *topo.Body, sign float64) *topo.Face {
+	for _, f := range b.Faces() {
+		if sign*float64(f.Geometry().NormalAt(0, 0).X) > 0.9 {
+			return f
+		}
+	}
+	return b.Faces()[0]
+}
+
+func cylindricalFace(b *topo.Body) *topo.Face {
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			return f
+		}
+	}
+	return b.Faces()[0]
+}
+
+// verticalEdge returns the first edge running mostly along Z (a box's vertical corner).
+func verticalEdge(edges []*topo.Edge) *topo.Edge {
+	for _, e := range edges {
+		pts := ops.TessellateEdge(e, ops.DefaultQuality())
+		if len(pts) < 2 {
+			continue
+		}
+		a, b := pts[0], pts[len(pts)-1]
+		dz := abs(a.Z - b.Z)
+		if dz > abs(a.X-b.X) && dz > abs(a.Y-b.Y) {
+			return e
+		}
+	}
+	return edges[0]
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/head/cmd/previewshot/main.go
+++ b/head/cmd/previewshot/main.go
@@ -104,6 +104,10 @@ func setupOp(s *app.Session, op string) error {
 		startPendingCoil(s)
 	case "thread":
 		return startPendingThread(s)
+	case "faceoffset":
+		startPendingFaceOffset(s, mustBlock(s))
+	case "deleteface":
+		startPendingDeleteFace(s, mustBlock(s))
 	default:
 		return fmt.Errorf("unknown -op %q", op)
 	}
@@ -313,6 +317,23 @@ func startPendingThread(s *app.Session) error {
 	tool.SetPitchIndex(0)
 	tool.SetCut(true) // cut thread → removes material → red
 	return nil
+}
+
+// startPendingFaceOffset offsets the block's top face outward (adds material → green delta).
+func startPendingFaceOffset(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	t := app.NewFaceOffsetTool()
+	s.StartTool(t)
+	t.Pick(s, app.FaceHandle{Face: faceByNormalZ(body, 1), Body: body})
+	t.SetDistance(2)
+}
+
+// startPendingDeleteFace deletes (and heals) the block's top face (removes material → red delta).
+func startPendingDeleteFace(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	t := app.NewDeleteFaceTool()
+	s.StartTool(t)
+	t.Pick(s, app.FaceHandle{Face: faceByNormalZ(body, 1), Body: body})
 }
 
 // --- geometry helpers ------------------------------------------------------------------

--- a/head/cmd/previewshot/main.go
+++ b/head/cmd/previewshot/main.go
@@ -108,6 +108,14 @@ func setupOp(s *app.Session, op string) error {
 		startPendingFaceOffset(s, mustBlock(s))
 	case "deleteface":
 		startPendingDeleteFace(s, mustBlock(s))
+	case "split":
+		startPendingSplit(s, mustBlock(s))
+	case "corecavity":
+		startPendingCoreCavity(s, mustBlock(s))
+	case "rib":
+		startPendingRib(s)
+	case "thicken":
+		startPendingThicken(s)
 	default:
 		return fmt.Errorf("unknown -op %q", op)
 	}
@@ -328,12 +336,88 @@ func startPendingFaceOffset(s *app.Session, def *compdef.PartComponentDefinition
 	t.SetDistance(2)
 }
 
-// startPendingDeleteFace deletes (and heals) the block's top face (removes material → red delta).
+// startPendingDeleteFace chamfers a vertical edge, then deletes (and heals) that chamfer face —
+// restoring the sharp corner, so material is added back (green). Deleting an outer box face
+// instead cannot heal closed (a no-op preview), hence the chamfer setup.
 func startPendingDeleteFace(s *app.Session, def *compdef.PartComponentDefinition) {
 	body := def.SurfaceBodies().Item(0)
+	feature.NewDressUpFeatures(def.Features()).AddChamfer([][]byte{verticalEdge(body.Edges()).ReferenceKey()}, func() float64 { return 1.2 })
+	def.Recompute()
+	body = def.SurfaceBodies().Item(0)
 	t := app.NewDeleteFaceTool()
 	s.StartTool(t)
-	t.Pick(s, app.FaceHandle{Face: faceByNormalZ(body, 1), Body: body})
+	t.Pick(s, app.FaceHandle{Face: nonAxisAlignedFace(body), Body: body})
+}
+
+// nonAxisAlignedFace returns the body's first face whose normal is not along ±X/±Y/±Z (the
+// chamfer bevel), or the first face as a fallback.
+func nonAxisAlignedFace(b *topo.Body) *topo.Face {
+	for _, f := range b.Faces() {
+		n := f.Geometry().NormalAt(0, 0)
+		if abs(float64(n.X)) < 0.9 && abs(float64(n.Y)) < 0.9 && abs(float64(n.Z)) < 0.9 {
+			return f
+		}
+	}
+	return b.Faces()[0]
+}
+
+// startPendingSplit cuts the block with a mid work plane (multi-body delta → highlighted).
+func startPendingSplit(s *app.Session, def *compdef.PartComponentDefinition) {
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 1.5 })
+	def.Recompute()
+	t := app.NewSplitTool()
+	s.StartTool(t)
+	t.Pick(s, app.WorkPlaneHandle{Plane: wp})
+}
+
+// startPendingCoreCavity splits the tooling block at the parting plane (its default).
+func startPendingCoreCavity(s *app.Session, def *compdef.PartComponentDefinition) {
+	t := app.NewCoreCavityTool()
+	s.StartTool(t)
+	_ = def
+}
+
+// startPendingRib thickens an open profile into a rib joined to a base block (tool body → green).
+func startPendingRib(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	sk := addSquare(def, 0, 0, 6)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 2 })
+	rs := def.Sketches().Add(sketch.XYPlane())
+	rs.Lines().AddByTwoPoints(math.P2(1, 3), math.P2(5, 3)) // open path across the block
+	def.Recompute()
+	t := app.NewRibTool()
+	s.StartTool(t)
+	t.SetThickness(1)
+	t.SetDepth(3)
+}
+
+// startPendingThicken thickens a planar surface patch into a solid (surface→solid → green).
+func startPendingThicken(s *app.Session) {
+	def := newPart(s, "previewshot.opd")
+	feature.NewBaseFeatures(def.Features()).AddBase(patchSurface(4, 4))
+	def.Recompute()
+	t := app.NewThickenTool()
+	s.StartTool(t)
+	t.SetThickness(1)
+}
+
+// patchSurface builds a w×h planar (open) surface body on the XY plane.
+func patchSurface(w, h float64) *topo.Body {
+	lin := topo.NewLineage(topo.Tok("previewshot", "patch", 0))
+	bld := topo.NewBuilder(false, lin)
+	p := []math.Point3{{X: 0, Y: 0}, {X: w, Y: 0}, {X: w, Y: h}, {X: 0, Y: h}}
+	v := make([]*topo.Vertex, 4)
+	for i, q := range p {
+		v[i] = bld.AddVertex(q, lin)
+	}
+	uses := make([]topo.Use, 4)
+	for i := range p {
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[(i+1)%4]), v[i], v[(i+1)%4], lin)
+		uses[i] = topo.Use{Edge: e}
+	}
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, lin, topo.OuterLoop(uses...))
+	return bld.Build()
 }
 
 // --- geometry helpers ------------------------------------------------------------------

--- a/head/cmd/previewshot/main_test.go
+++ b/head/cmd/previewshot/main_test.go
@@ -1,0 +1,63 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/renderer"
+)
+
+// previewSession builds the driver's base box and starts a pending extrude of the given
+// operation, returning the session whose ToolPreview should carry the live preview ghost.
+func previewSession(t *testing.T, op string) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	startPendingExtrude(s, buildBaseBox(s), op)
+	return s
+}
+
+// translucentTriangles returns the translucent triangle items of a tool preview — the feature
+// ghost, distinct from any wireframe.
+func translucentTriangles(items []renderer.DrawItem) []renderer.DrawItem {
+	var out []renderer.DrawItem
+	for _, it := range items {
+		if it.Primitive == renderer.Triangles && it.Opacity > 0 && it.Opacity < 1 {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// TestPendingExtrudePreviewColors checks the driver's pending extrude shows a translucent
+// ghost that is green-dominant for a material-adding join and red-dominant for a cut — the
+// behaviour the live PNGs capture (run() opens a real window and is exercised manually).
+func TestPendingExtrudePreviewColors(t *testing.T) {
+	for _, tc := range []struct {
+		op         string
+		wantGreen  bool
+		moreOfChan int // index of the channel that must dominate (0=R, 1=G)
+		lessChan   int
+	}{
+		{op: "join", wantGreen: true, moreOfChan: 1, lessChan: 0},
+		{op: "cut", wantGreen: false, moreOfChan: 0, lessChan: 1},
+	} {
+		t.Run(tc.op, func(t *testing.T) {
+			s := previewSession(t, tc.op)
+			ghost := translucentTriangles(s.ToolPreview())
+			if len(ghost) == 0 {
+				t.Fatalf("%s: no translucent preview items", tc.op)
+			}
+			c := ghost[0].Color
+			if c[tc.moreOfChan] <= c[tc.lessChan] {
+				t.Errorf("%s preview color = %v, want channel %d to dominate", tc.op, c, tc.moreOfChan)
+			}
+		})
+	}
+}

--- a/head/cmd/previewshot/main_test.go
+++ b/head/cmd/previewshot/main_test.go
@@ -35,6 +35,46 @@ func translucentTriangles(items []renderer.DrawItem) []renderer.DrawItem {
 	return out
 }
 
+// TestSetupOpPreviewsEveryFeature drives the driver's headless setup for every -op value and
+// asserts each leaves the session with a non-empty preview ghost. This exercises every
+// startPendingX builder + the base-solid/face/edge helpers without opening a native window
+// (run() does that and is exercised manually), so the demo driver can't silently rot when a
+// tool's preview wiring changes. Mirrors m16shot's setup-coverage test.
+func TestSetupOpPreviewsEveryFeature(t *testing.T) {
+	ops := []string{
+		"join", "cut", "revolve", "sweep", "loft", "coil", "hole",
+		"fillet", "chamfer", "shell", "draft", "thread",
+		"faceoffset", "deleteface", "split", "corecavity", "rib", "thicken",
+		"emboss", "grill", "replaceface", "patch", "stitch", "surfacetrim",
+		"sculpt", "extend",
+	}
+	for _, op := range ops {
+		t.Run(op, func(t *testing.T) {
+			s := app.NewSession()
+			if err := app.RegisterStandardCommands(s); err != nil {
+				t.Fatalf("RegisterStandardCommands: %v", err)
+			}
+			if err := setupOp(s, op); err != nil {
+				t.Fatalf("setupOp(%q): %v", op, err)
+			}
+			if len(s.ToolPreview()) == 0 {
+				t.Errorf("setupOp(%q): no preview ghost", op)
+			}
+		})
+	}
+}
+
+// TestSetupOpUnknown rejects an unknown op so the CLI fails loudly instead of drawing nothing.
+func TestSetupOpUnknown(t *testing.T) {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if err := setupOp(s, "bogus"); err == nil {
+		t.Fatal("setupOp(\"bogus\") = nil error, want failure")
+	}
+}
+
 // TestPendingExtrudePreviewColors checks the driver's pending extrude shows a translucent
 // ghost that is green-dominant for a material-adding join and red-dominant for a cut — the
 // behaviour the live PNGs capture (run() opens a real window and is exercised manually).

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -252,17 +252,10 @@ func profileOutline(ph app.ProfileHandle, color [4]float32) []renderer.DrawItem 
 	return appendGrid(nil, acc, color)
 }
 
-// activeToolPreviewItems returns the active tool's transient preview (the Extrude prism
-// wireframe), drawn in the 3D view outside the sketch environment. Nil when the tool has
-// no preview or nothing to show yet.
+// activeToolPreviewItems returns the active tool's transient preview, drawn in the 3D view
+// outside the sketch environment — the translucent solid result preview when the tool can
+// draft its feature, else the legacy wireframe. The session resolves which (see
+// Session.ToolPreview); nil when nothing is shown yet.
 func activeToolPreviewItems(s *app.Session) []renderer.DrawItem {
-	ti := s.ActiveTool()
-	if ti == nil {
-		return nil
-	}
-	pv, ok := ti.Tool().(app.Previewable)
-	if !ok {
-		return nil
-	}
-	return pv.Preview(s)
+	return s.ToolPreview()
 }

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -168,6 +168,26 @@ func (fs *PartFeatures) Recompute() {
 	fs.result = bodies
 }
 
+// PreviewResult evaluates a candidate feature as if it were appended at the end-of-part
+// marker, against the cached prefix bodies, and returns the resulting body state — WITHOUT
+// mutating the program (no Add, no dirty flags, no fs.result change, no events). It is the
+// non-destructive seam behind the live in-canvas feature preview: a tool builds its draft
+// feature and asks "what would the model look like?" once per change, reusing the clean
+// prefix the engine already cached, so a preview costs ~one feature recompute.
+//
+// Example: ext := buildExtrudeFeature(def); bodies, err := part.Features().PreviewResult(ext).
+func (fs *PartFeatures) PreviewResult(candidate Feature) ([]*topo.Body, error) {
+	if candidate == nil {
+		return nil, errors.New("feature: PreviewResult got a nil candidate")
+	}
+	bodies := fs.prefixBodies(fs.effectiveEnd())
+	out, err := candidate.Recompute(Input{Bodies: bodies, Params: fs.params, Keys: fs.keys, SourceTool: fs.sourceTool})
+	if err != nil {
+		return nil, err
+	}
+	return out.Bodies, nil
+}
+
 // evaluate runs one feature, updating its health/cache and returning the running
 // body state after it.
 func (fs *PartFeatures) evaluate(pf *PartFeature, bodies []*topo.Body, sick map[ID]bool) []*topo.Body {

--- a/model/feature/engine_test.go
+++ b/model/feature/engine_test.go
@@ -74,6 +74,46 @@ func TestUniqueNameNumbersFromOneAndSkipsTaken(t *testing.T) {
 	}
 }
 
+func TestPreviewResultIsNonDestructive(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	fs.Add(body())
+	fs.Add(body())
+	fs.Recompute()
+	before := fs.Result()
+	beforeCounts := []int{fs.Item(0).RecomputeCount(), fs.Item(1).RecomputeCount()}
+
+	// Previewing a candidate appended at end-of-part sees the 2 committed bodies and
+	// returns 3, without touching the program.
+	got, err := fs.PreviewResult(body())
+	if err != nil {
+		t.Fatalf("PreviewResult: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("preview result has %d bodies, want 3 (2 committed + 1 candidate)", len(got))
+	}
+	if len(fs.Result()) != 2 || &fs.Result()[0] != &before[0] {
+		t.Errorf("PreviewResult mutated fs.Result(): now %d bodies", len(fs.Result()))
+	}
+	if fs.Count() != 2 {
+		t.Errorf("PreviewResult changed the program length to %d, want 2", fs.Count())
+	}
+	if c0, c1 := fs.Item(0).RecomputeCount(), fs.Item(1).RecomputeCount(); c0 != beforeCounts[0] || c1 != beforeCounts[1] {
+		t.Errorf("PreviewResult re-evaluated committed features: counts %d,%d → %d,%d", beforeCounts[0], beforeCounts[1], c0, c1)
+	}
+}
+
+func TestPreviewResultPropagatesCandidateError(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	fs.Add(body())
+	fs.Recompute()
+	if _, err := fs.PreviewResult(failer{}); err == nil {
+		t.Fatal("PreviewResult should surface a sick candidate's error, got nil")
+	}
+	if _, err := fs.PreviewResult(nil); err == nil {
+		t.Fatal("PreviewResult(nil) should error")
+	}
+}
+
 func TestEditingEarlyFeatureReusesCleanPrefix(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)
 	a := fs.Add(body())

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -142,16 +142,28 @@ func (c *ExtrudeFeatures) AddByDistanceExtentProfiles(skt *sketch.Sketch, profil
 // operation, and taper (draft) angle — the general constructor the Extrude tool and the
 // automation API drive. The distance constructors above delegate here.
 func (c *ExtrudeFeatures) AddExtrude(skt *sketch.Sketch, profileIndices []int, op ops.PartFeatureOperation, extent Extent, taper float64) *PartFeature {
-	def := &ExtrudeDefinition{
+	return c.AddExtrudeFeature(&ExtrudeDefinition{
 		Sketch: skt, ProfileIndices: append([]int(nil), profileIndices...),
 		Operation: op, Extent: extent, Taper: taper,
-	}
-	ef := &ExtrudeFeature{def: def}
+	})
+}
+
+// AddExtrudeFeature registers and names an extrude built from def — the seam shared by the
+// arg-based AddExtrude above and the Extrude tool, which builds the same def for both the
+// live preview ([NewExtrudeFeature]) and commit so the previewed geometry is exactly what
+// OK creates.
+func (c *ExtrudeFeatures) AddExtrudeFeature(def *ExtrudeDefinition) *PartFeature {
+	ef := NewExtrudeFeature(def)
 	pf := c.engine.Add(ef)
 	pf.SetName(c.engine.UniqueName("Extrusion")) // Extrusion1, Extrusion2, … (Inventor's naming)
 	ef.featName = pf.name
 	return pf
 }
+
+// NewExtrudeFeature builds an extrude feature value from a definition WITHOUT adding it to
+// any engine — the unattached, unnamed [Feature] the live preview evaluates speculatively
+// (see [PartFeatures.PreviewResult]). AddExtrudeFeature wraps this, then registers and names it.
+func NewExtrudeFeature(def *ExtrudeDefinition) *ExtrudeFeature { return &ExtrudeFeature{def: def} }
 
 // combine applies an operation between the running bodies and a new body. Phase A
 // handles the first body / new-body and the non-overlapping boolean cases.


### PR DESCRIPTION
## What

Adds an Inventor-style **live preview** for part-feature commands: once a tool's selection + parameters are filled, the viewport shows a **translucent ghost of the pending feature** before OK — **green where it adds material, red where it removes it** — with the feature's B-rep edges drawn opaque for legibility. Covers **every** modelling and sheet-metal feature.

![join](https://github.com/Oblikovati/Oblikovati) extrude join → green prism · cut → red plug · fillet/chamfer → red wedge · hole → red drill · revolve/sweep/loft/coil → green · shell → red cavity walls · rib/emboss → green · grill → red vents · thicken/patch/stitch/sculpt/extend → result surface/solid · split/core-cavity → new faces.

## Why

Users had no faithful in-canvas preview of a feature's result before committing — confirming selection/parameters meant committing then undoing. This is standard Inventor behaviour and was a roadmap gap (the dialog DoD convention lists "in-canvas preview" but no issue tracked it).

## How

- **`feature.PartFeatures.PreviewResult`** evaluates a candidate feature against the cached prefix **non-destructively** (no recipe mutation, no events) — the pure `Feature.Recompute` seam makes this ~one extra evaluation per change.
- **`app.DraftPreviewable`** seam: each tool builds the exact feature it would commit (shared `addX(fs)` builder reused by `Commit` + a scratch-engine draft, so preview == committed result). Compile-time assertions pin every tool.
- **Render strategy chain** in `featurePreviewItems`: (1) the feature's tool body (extrude/revolve/sweep/loft/coil/hole/rib), (2) the boolean **solid delta** base−result/result−base (fillet/chamfer/shell/draft/thread/face-offset/grill/…), (3) **changed faces** by surface-signature diff (split/core-cavity/patch), (4) the **result body** (delete/replace-face, stitch, trim, sculpt, extend). So every feature shows something meaningful.
- One smooth-shaded translucent mesh (opacity baked into vertex-color alpha — the viewport flattens color, not the `Opacity` field) + `ops.VisibleEdges` (B-rep edges, tangent seams suppressed — feature edges only, no triangle mesh), both on the depth-disabled on-top pass so interior volumes (cut/hole/shell) stay visible.

Host-internal interaction behaviour (ADR-0018): no `api/wire` surface.

## Tests / verification

- `TestEveryFeatureToolPreviews` drives all remaining tools to commit-ready (reusing their own setups) and asserts a non-empty ghost — guards that wiring actually previews.
- Engine non-destructiveness test, app green/red + colour + "only new faces" + delta-helper tests.
- **GUI-verified every feature** in the live head (Vulkan/lavapipe) via `head/cmd/previewshot -op <feature>`, across all four render strategies.
- Build + `go test` + golangci-lint (0 issues) + gofmt all green; rebased on latest develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)