### PR TITLE
feat(units): host router + param service for document units (#146)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -157,6 +157,22 @@ func (r *Router) registerFileHandlers() {
 	r.handlers[wire.MethodDocumentsAddInterest] = addDocumentInterest
 	r.handlers[wire.MethodDocumentsRemoveInterest] = removeDocumentInterest
 	r.handlers[wire.MethodDocumentsHasInterest] = hasDocumentInterest
+
+	// Document units of measure + unit/expression service (#146).
+	r.handlers[wire.MethodDocumentsGetUnits] = getDocumentUnits
+	r.handlers[wire.MethodDocumentsSetUnits] = setDocumentUnits
+	r.handlers[wire.MethodUnitsConvert] = unitsConvert
+	r.handlers[wire.MethodUnitsGetStringFromValue] = unitsGetStringFromValue
+	r.handlers[wire.MethodUnitsGetPreciseStringFromValue] = unitsGetPreciseStringFromValue
+	r.handlers[wire.MethodUnitsGetValueFromExpression] = unitsGetValueFromExpression
+	r.handlers[wire.MethodUnitsGetDatabaseUnitsFromExpression] = unitsGetDatabaseUnitsFromExpression
+	r.handlers[wire.MethodUnitsIsExpressionValid] = unitsIsExpressionValid
+	r.handlers[wire.MethodUnitsCompatibleUnits] = unitsCompatibleUnits
+	r.handlers[wire.MethodUnitsGetTypeFromString] = unitsGetTypeFromString
+	r.handlers[wire.MethodUnitsGetStringFromType] = unitsGetStringFromType
+	r.handlers[wire.MethodUnitsGetLocaleCorrectedExpression] = unitsGetLocaleCorrectedExpression
+	r.handlers[wire.MethodUnitsGetDrivingParameters] = unitsGetDrivingParameters
+
 	r.handlers[wire.MethodDocumentsOpen] = openDocument
 	r.handlers[wire.MethodDocumentsSave] = saveDocument
 	r.handlers[wire.MethodDocumentsSaveAs] = saveDocumentAs

--- a/addin/router/units.go
+++ b/addin/router/units.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/param"
+)
+
+// Document units of measure + the unit conversion / expression / formatting
+// service (Oblikovati/Oblikovati#146). Backed by the active document's
+// param.UnitsOfMeasure and parameter set.
+
+// unitsDocument is the document content that owns display units and a parameter
+// scope — satisfied by both part and assembly definitions.
+type unitsDocument interface {
+	Units() param.UnitsOfMeasure
+	SetUnits(param.UnitsOfMeasure)
+	Parameters() *param.Parameters
+}
+
+// activeUnitsDocument resolves the active document's units-bearing content.
+func activeUnitsDocument(s *app.Session) (unitsDocument, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, errors.New("units: no active document")
+	}
+	doc, ok := d.Content().(unitsDocument)
+	if !ok {
+		return nil, fmt.Errorf("units: active document %q has no units of measure", d.DisplayName())
+	}
+	return doc, nil
+}
+
+// unitsInfoOf marshals a document's display-unit preferences into the wire DTO.
+func unitsInfoOf(u param.UnitsOfMeasure) wire.DocumentUnitsInfo {
+	return wire.DocumentUnitsInfo{
+		LengthUnit:             u.PreferredName(param.Length),
+		AngleUnit:              u.PreferredName(param.Angle),
+		MassUnit:               u.PreferredName(param.Mass),
+		TimeUnit:               u.PreferredName(param.Time),
+		LengthDisplayPrecision: u.LengthPrecision(),
+		AngleDisplayPrecision:  u.AnglePrecision(),
+		LengthDisplayFormat:    u.LengthFormat().String(),
+	}
+}
+
+// categoryOf resolves a types.UnitsType spelling ("length") to a param.Unit.
+func categoryOf(spelling string) (param.Unit, error) {
+	cat, ok := param.ParseUnitCategory(spelling)
+	if !ok {
+		return 0, fmt.Errorf("units: unknown unit category %q", spelling)
+	}
+	return cat, nil
+}
+
+// getDocumentUnits returns the active document's display-unit preferences.
+func getDocumentUnits(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	doc, err := activeUnitsDocument(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(unitsInfoOf(doc.Units()))
+}
+
+// setDocumentUnits applies the non-nil unit/precision/format preferences and
+// returns the updated units. It validates each change first; a bad value
+// rejects the whole update naming the offending value.
+func setDocumentUnits(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, err := activeUnitsDocument(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetDocumentUnitsArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	u := doc.Units().Clone()
+	if err := applyUnitPreferences(&u, in); err != nil {
+		return nil, err
+	}
+	doc.SetUnits(u)
+	return json.Marshal(unitsInfoOf(doc.Units()))
+}
+
+// applyUnitPreferences mutates u with each supplied (non-nil) preference.
+func applyUnitPreferences(u *param.UnitsOfMeasure, in wire.SetDocumentUnitsArgs) error {
+	for cat, name := range map[param.Unit]*string{
+		param.Length: in.LengthUnit, param.Angle: in.AngleUnit,
+		param.Mass: in.MassUnit, param.Time: in.TimeUnit,
+	} {
+		if name != nil {
+			if err := u.SetPreferred(cat, *name); err != nil {
+				return err
+			}
+		}
+	}
+	if in.LengthDisplayPrecision != nil {
+		if err := u.SetLengthPrecision(*in.LengthDisplayPrecision); err != nil {
+			return err
+		}
+	}
+	if in.AngleDisplayPrecision != nil {
+		if err := u.SetAnglePrecision(*in.AngleDisplayPrecision); err != nil {
+			return err
+		}
+	}
+	if in.LengthDisplayFormat != nil {
+		f, ok := types.ParseParameterDisplayFormat(*in.LengthDisplayFormat)
+		if !ok {
+			return fmt.Errorf("units: unknown length display format %q", *in.LengthDisplayFormat)
+		}
+		u.SetLengthFormat(f)
+	}
+	return nil
+}
+
+// unitsConvert converts a value between two unit names of the same category.
+func unitsConvert(_ *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ConvertUnitsArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	v, err := param.ConvertValue(in.Value, in.From, in.To)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.ConvertUnitsResult{Value: v})
+}
+
+// unitsGetStringFromValue formats a database-unit value in the document's
+// display unit (honoring display precision, once #146's formatter lands).
+func unitsGetStringFromValue(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, cat, value, err := stringFromValueInputs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.StringResult{Value: doc.Units().Format(param.Q(value, cat))})
+}
+
+// unitsGetPreciseStringFromValue formats a database-unit value at full
+// precision (no display rounding).
+func unitsGetPreciseStringFromValue(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, cat, value, err := stringFromValueInputs(s, args)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.StringResult{Value: doc.Units().Format(param.Q(value, cat))})
+}
+
+// stringFromValueInputs decodes and resolves the shared inputs of the two
+// value-formatting methods.
+func stringFromValueInputs(s *app.Session, args json.RawMessage) (unitsDocument, param.Unit, float64, error) {
+	doc, err := activeUnitsDocument(s)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	var in wire.StringFromValueArgs
+	if err := decode(args, &in); err != nil {
+		return nil, 0, 0, err
+	}
+	cat, err := categoryOf(in.UnitsType)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	return doc, cat, in.Value, nil
+}
+
+// unitsGetValueFromExpression evaluates an expression to a database-unit value
+// of the target category. A bare number is interpreted in that category's
+// display unit (the GetValueFromExpression convention).
+func unitsGetValueFromExpression(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, in, err := expressionWithType(s, args)
+	if err != nil {
+		return nil, err
+	}
+	cat, err := categoryOf(in.UnitsType)
+	if err != nil {
+		return nil, err
+	}
+	q, err := doc.Parameters().EvaluateExpression(in.Expression)
+	if err != nil {
+		return nil, err
+	}
+	if q.Unit == param.Unitless && cat != param.Unitless {
+		q = doc.Units().FromPreferred(q.Value, cat)
+	}
+	return json.Marshal(wire.ValueResult{Value: q.Value})
+}
+
+// unitsGetDatabaseUnitsFromExpression evaluates an expression to a database-unit
+// value, auto-detecting its category.
+func unitsGetDatabaseUnitsFromExpression(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, err := activeUnitsDocument(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.ExpressionArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	q, err := doc.Parameters().EvaluateExpression(in.Expression)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.DatabaseUnitsResult{Value: q.Value, UnitsType: q.Unit.String()})
+}
+
+// unitsIsExpressionValid reports whether an expression parses, evaluates, and is
+// dimensionally compatible with the target category.
+func unitsIsExpressionValid(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, in, err := expressionWithType(s, args)
+	if err != nil {
+		return nil, err
+	}
+	cat, err := categoryOf(in.UnitsType)
+	if err != nil {
+		return nil, err
+	}
+	if q, evErr := doc.Parameters().EvaluateExpression(in.Expression); evErr != nil {
+		return json.Marshal(wire.ExpressionValidResult{Valid: false, Error: evErr.Error()})
+	} else if !unitCompatible(q.Unit, cat) {
+		return json.Marshal(wire.ExpressionValidResult{
+			Valid: false,
+			Error: fmt.Sprintf("expression unit %s is not compatible with %s", q.Unit, cat),
+		})
+	}
+	return json.Marshal(wire.ExpressionValidResult{Valid: true})
+}
+
+// unitsCompatibleUnits reports whether an expression's resolved unit is
+// dimensionally compatible with the target category.
+func unitsCompatibleUnits(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, in, err := expressionWithType(s, args)
+	if err != nil {
+		return nil, err
+	}
+	cat, err := categoryOf(in.UnitsType)
+	if err != nil {
+		return nil, err
+	}
+	q, evErr := doc.Parameters().EvaluateExpression(in.Expression)
+	return json.Marshal(wire.CompatibleUnitsResult{Compatible: evErr == nil && unitCompatible(q.Unit, cat)})
+}
+
+// unitCompatible reports whether a resolved unit can stand in for the target
+// category: an exact category match, or a bare (unitless) number coerced to it.
+func unitCompatible(got, want param.Unit) bool {
+	return got == want || got == param.Unitless
+}
+
+// expressionWithType decodes the shared {expression, unitsType} request and
+// resolves the active units document.
+func expressionWithType(s *app.Session, args json.RawMessage) (unitsDocument, wire.ExpressionWithTypeArgs, error) {
+	doc, err := activeUnitsDocument(s)
+	if err != nil {
+		return nil, wire.ExpressionWithTypeArgs{}, err
+	}
+	var in wire.ExpressionWithTypeArgs
+	if err := decode(args, &in); err != nil {
+		return nil, wire.ExpressionWithTypeArgs{}, err
+	}
+	return doc, in, nil
+}
+
+// unitsGetTypeFromString returns the category a unit name belongs to.
+func unitsGetTypeFromString(_ *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.UnitStringArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	cat, ok := param.UnitCategoryOf(in.UnitString)
+	if !ok {
+		return nil, fmt.Errorf("units: unknown unit %q", in.UnitString)
+	}
+	return json.Marshal(wire.UnitsTypeResult{UnitsType: cat.String()})
+}
+
+// unitsGetStringFromType returns the document-preferred unit name for a category.
+func unitsGetStringFromType(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	doc, err := activeUnitsDocument(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.UnitsTypeArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	cat, err := categoryOf(in.UnitsType)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.StringResult{Value: doc.Units().PreferredName(cat)})
+}
+
+// unitsGetLocaleCorrectedExpression normalizes an expression's number formatting
+// to the canonical evaluator form. The evaluator currently accepts the
+// canonical (en) form directly, so this is a validated passthrough.
+func unitsGetLocaleCorrectedExpression(_ *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ExpressionArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if _, err := param.Parse(in.Expression); err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.StringResult{Value: in.Expression})
+}
+
+// unitsGetDrivingParameters returns the parameter names an expression references.
+func unitsGetDrivingParameters(_ *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var in wire.ExpressionArgs
+	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	names, err := param.ExpressionReferences(in.Expression)
+	if err != nil {
+		return nil, err
+	}
+	if names == nil {
+		names = []string{}
+	}
+	return json.Marshal(wire.DrivingParametersResult{Names: names})
+}

--- a/addin/router/units_test.go
+++ b/addin/router/units_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"oblikovati.org/addin/opregistry"
 	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
 )
 
 // Document units of measure + unit/expression service over the wire (#146).
@@ -104,5 +106,97 @@ func TestUnitsServiceOverWire(t *testing.T) {
 	call(t, r, s, "units.getDrivingParameters", `{"expression":"width + height"}`, &dp)
 	if len(dp.Names) != 2 || dp.Names[0] != "width" || dp.Names[1] != "height" {
 		t.Errorf("drivingParameters = %v, want [width height]", dp.Names)
+	}
+}
+
+// TestUnitsExtraMethodsOverWire covers the methods not exercised above: the
+// precise string formatter, compatibility check, and the locale-corrected
+// expression passthrough.
+func TestUnitsExtraMethodsOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	var str wire.StringResult
+	call(t, r, s, "units.getPreciseStringFromValue", `{"value":4,"unitsType":"length"}`, &str)
+	if str.Value != "40 mm" {
+		t.Errorf("precise(4 cm) = %q, want \"40 mm\"", str.Value)
+	}
+
+	var comp wire.CompatibleUnitsResult
+	call(t, r, s, "units.compatibleUnits", `{"expression":"5 mm","unitsType":"length"}`, &comp)
+	if !comp.Compatible {
+		t.Error("5 mm should be compatible with length")
+	}
+	call(t, r, s, "units.compatibleUnits", `{"expression":"5 deg","unitsType":"length"}`, &comp)
+	if comp.Compatible {
+		t.Error("5 deg should not be compatible with length")
+	}
+
+	var lc wire.StringResult
+	call(t, r, s, "units.getLocaleCorrectedExpression", `{"expression":"3 mm + 1 cm"}`, &lc)
+	if lc.Value != "3 mm + 1 cm" {
+		t.Errorf("locale-corrected = %q, want the canonical passthrough", lc.Value)
+	}
+}
+
+// TestUnitsHandlersNeedActiveDocument covers the no-active-document early-return
+// branch of every document-scoped units handler.
+func TestUnitsHandlersNeedActiveDocument(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession() // no document added
+	args := `{"unitsType":"length","expression":"1","value":1}`
+	for _, m := range []string{
+		"documents.getUnits", "documents.setUnits",
+		"units.getStringFromValue", "units.getPreciseStringFromValue",
+		"units.getValueFromExpression", "units.getDatabaseUnitsFromExpression",
+		"units.isExpressionValid", "units.compatibleUnits", "units.getStringFromType",
+	} {
+		if _, err := r.Handle(s, m, []byte(args)); err == nil {
+			t.Errorf("%s with no active document should error", m)
+		}
+	}
+}
+
+// TestUnitsHandlerErrors covers the decode / bad-category / bad-expression error
+// branches across the units handlers.
+func TestUnitsHandlerErrors(t *testing.T) {
+	r, s := seededSession(t)
+
+	// Malformed JSON → decode error.
+	for _, m := range []string{
+		"units.convert", "units.getStringFromValue", "units.getTypeFromString",
+		"units.getDrivingParameters", "units.getLocaleCorrectedExpression",
+		"documents.setUnits", "units.getValueFromExpression",
+	} {
+		if _, err := r.Handle(s, m, []byte(`{`)); err == nil {
+			t.Errorf("%s with malformed JSON should error", m)
+		}
+	}
+
+	// Unknown category spelling → categoryOf error.
+	for _, m := range []string{
+		"units.getStringFromValue", "units.getStringFromType",
+		"units.getValueFromExpression", "units.isExpressionValid", "units.compatibleUnits",
+	} {
+		if _, err := r.Handle(s, m, []byte(`{"unitsType":"bogus","expression":"1","value":1}`)); err == nil {
+			t.Errorf("%s with unknown category should error", m)
+		}
+	}
+
+	// Unknown unit name → getTypeFromString error.
+	if _, err := r.Handle(s, "units.getTypeFromString", []byte(`{"unitString":"furlong"}`)); err == nil {
+		t.Error("getTypeFromString of an unknown unit should error")
+	}
+	// Malformed / undefined-reference expression → eval and parse errors.
+	if _, err := r.Handle(s, "units.getValueFromExpression", []byte(`{"expression":"missing + 1","unitsType":"length"}`)); err == nil {
+		t.Error("an undefined reference should error")
+	}
+	if _, err := r.Handle(s, "units.getLocaleCorrectedExpression", []byte(`{"expression":"3 +"}`)); err == nil {
+		t.Error("a malformed expression should error")
+	}
+	if _, err := r.Handle(s, "units.getDrivingParameters", []byte(`{"expression":"3 +"}`)); err == nil {
+		t.Error("getDrivingParameters of a malformed expression should error")
+	}
+	if _, err := r.Handle(s, "units.convert", []byte(`{"value":1,"from":"furlong","to":"cm"}`)); err == nil {
+		t.Error("convert from an unknown unit should error")
 	}
 }

--- a/addin/router/units_test.go
+++ b/addin/router/units_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// Document units of measure + unit/expression service over the wire (#146).
+
+func TestDocumentUnitsRoundTripOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	var got wire.DocumentUnitsInfo
+	call(t, r, s, "documents.getUnits", "{}", &got)
+	if got.LengthUnit != "mm" || got.AngleUnit != "deg" || got.MassUnit != "kg" || got.TimeUnit != "s" {
+		t.Fatalf("default units = %+v, want metric mm/deg/kg/s", got)
+	}
+	if got.LengthDisplayPrecision != 3 || got.AngleDisplayPrecision != 2 || got.LengthDisplayFormat != "decimal" {
+		t.Fatalf("default precision/format = %+v, want 3/2/decimal", got)
+	}
+
+	call(t, r, s, "documents.setUnits", `{"lengthUnit":"in","lengthDisplayPrecision":4,"lengthDisplayFormat":"fractional"}`, &got)
+	if got.LengthUnit != "in" || got.LengthDisplayPrecision != 4 || got.LengthDisplayFormat != "fractional" {
+		t.Errorf("after set = %+v, want in/4/fractional", got)
+	}
+	// Unsent fields stay untouched.
+	if got.AngleUnit != "deg" || got.AngleDisplayPrecision != 2 {
+		t.Errorf("angle prefs changed to %s/%d, want the untouched deg/2", got.AngleUnit, got.AngleDisplayPrecision)
+	}
+
+	for args, want := range map[string]string{
+		`{"lengthUnit":"furlong"}`:        "registered length unit",
+		`{"lengthDisplayFormat":"bogus"}`: "display format",
+		`{"lengthDisplayPrecision":-1}`:   "negative",
+	} {
+		if _, err := r.Handle(s, "documents.setUnits", []byte(args)); err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("setUnits(%s) err = %v, want it to mention %q", args, err, want)
+		}
+	}
+}
+
+func TestUnitsServiceOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	var conv wire.ConvertUnitsResult
+	call(t, r, s, "units.convert", `{"value":1,"from":"in","to":"cm"}`, &conv)
+	if conv.Value != 2.54 {
+		t.Errorf("convert 1 in→cm = %g, want 2.54", conv.Value)
+	}
+	if _, err := r.Handle(s, "units.convert", []byte(`{"value":1,"from":"mm","to":"deg"}`)); err == nil {
+		t.Error("converting mm→deg (different categories) should error")
+	}
+
+	var str wire.StringResult
+	call(t, r, s, "units.getStringFromValue", `{"value":4,"unitsType":"length"}`, &str)
+	if str.Value != "40 mm" {
+		t.Errorf("getStringFromValue(4 cm) = %q, want \"40 mm\"", str.Value)
+	}
+
+	var val wire.ValueResult
+	call(t, r, s, "units.getValueFromExpression", `{"expression":"width * 2","unitsType":"length"}`, &val)
+	if val.Value != 8 {
+		t.Errorf("width*2 = %g cm, want 8", val.Value)
+	}
+	// A bare number is interpreted in the category's display unit (mm → cm).
+	call(t, r, s, "units.getValueFromExpression", `{"expression":"5","unitsType":"length"}`, &val)
+	if val.Value != 0.5 {
+		t.Errorf("bare 5 (mm) = %g cm, want 0.5", val.Value)
+	}
+
+	var dbu wire.DatabaseUnitsResult
+	call(t, r, s, "units.getDatabaseUnitsFromExpression", `{"expression":"25 mm"}`, &dbu)
+	if dbu.Value != 2.5 || dbu.UnitsType != "length" {
+		t.Errorf("25 mm = %+v, want 2.5 cm / length", dbu)
+	}
+
+	var typ wire.UnitsTypeResult
+	call(t, r, s, "units.getTypeFromString", `{"unitString":"in"}`, &typ)
+	if typ.UnitsType != "length" {
+		t.Errorf("typeFromString(in) = %q, want length", typ.UnitsType)
+	}
+
+	var name wire.StringResult
+	call(t, r, s, "units.getStringFromType", `{"unitsType":"length"}`, &name)
+	if name.Value != "mm" {
+		t.Errorf("stringFromType(length) = %q, want mm", name.Value)
+	}
+
+	var v wire.ExpressionValidResult
+	call(t, r, s, "units.isExpressionValid", `{"expression":"3 mm + 1 cm","unitsType":"length"}`, &v)
+	if !v.Valid {
+		t.Errorf("3 mm + 1 cm should be valid length, got %+v", v)
+	}
+	call(t, r, s, "units.isExpressionValid", `{"expression":"width","unitsType":"angle"}`, &v)
+	if v.Valid {
+		t.Error("a length expression should be invalid for the angle category")
+	}
+
+	var dp wire.DrivingParametersResult
+	call(t, r, s, "units.getDrivingParameters", `{"expression":"width + height"}`, &dp)
+	if len(dp.Names) != 2 || dp.Names[0] != "width" || dp.Names[1] != "height" {
+		t.Errorf("drivingParameters = %v, want [width height]", dp.Names)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.21.0
+	oblikovati.org/api v0.22.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.21.0
+	oblikovati.org/api v0.22.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -378,6 +378,10 @@ func (a *AssemblyComponentDefinition) SetLengthUnit(name string) error {
 	return a.units.SetPreferred(param.Length, name)
 }
 
+// SetUnits replaces the document's display units wholesale (build from
+// Units().Clone()).
+func (a *AssemblyComponentDefinition) SetUnits(u param.UnitsOfMeasure) { a.units = u }
+
 // ModelGeometryVersion is a string that changes whenever the assembly's occurrences
 // change (add/remove/move/suppress), so consumers (drawings, parent assemblies) can
 // detect when they must update. It is derived from the occurrence collection's

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -204,6 +204,11 @@ func (d *PartComponentDefinition) SetLengthUnit(name string) error {
 	return d.units.SetPreferred(param.Length, name)
 }
 
+// SetUnits replaces the document's display units wholesale — the way the units
+// API and the Units settings dialog apply an edited preferences object (build
+// it from Units().Clone()).
+func (d *PartComponentDefinition) SetUnits(u param.UnitsOfMeasure) { d.units = u }
+
 // Sketches returns the part's planar (2D) sketches.
 func (d *PartComponentDefinition) Sketches() *sketch.Sketches { return d.sketches }
 

--- a/model/compdef/units_test.go
+++ b/model/compdef/units_test.go
@@ -27,3 +27,33 @@ func TestPartSetLengthUnit(t *testing.T) {
 		t.Error("setting a non-length unit as the length unit should error")
 	}
 }
+
+func TestPartSetUnits(t *testing.T) {
+	d := NewPartComponentDefinition()
+	u := d.Units().Clone()
+	if err := u.SetPreferred(param.Length, "in"); err != nil {
+		t.Fatalf("set preferred: %v", err)
+	}
+	if err := u.SetLengthPrecision(5); err != nil {
+		t.Fatalf("set precision: %v", err)
+	}
+	d.SetUnits(u)
+	if name := d.Units().PreferredName(param.Length); name != "in" {
+		t.Errorf("length unit after SetUnits = %q, want in", name)
+	}
+	if p := d.Units().LengthPrecision(); p != 5 {
+		t.Errorf("length precision after SetUnits = %d, want 5", p)
+	}
+}
+
+func TestAssemblySetUnits(t *testing.T) {
+	a := NewAssemblyComponentDefinition()
+	u := a.Units().Clone()
+	if err := u.SetPreferred(param.Length, "ft"); err != nil {
+		t.Fatalf("set preferred: %v", err)
+	}
+	a.SetUnits(u)
+	if name := a.Units().PreferredName(param.Length); name != "ft" {
+		t.Errorf("assembly length unit after SetUnits = %q, want ft", name)
+	}
+}

--- a/model/param/units_of_measure.go
+++ b/model/param/units_of_measure.go
@@ -7,6 +7,8 @@ import (
 	stdmath "math"
 	"strconv"
 	"strings"
+
+	"oblikovati.org/api/types"
 )
 
 // unitDef defines a named user unit: its dimension category and the factor that
@@ -42,15 +44,74 @@ func lookupUnit(name string) (unitDef, bool) {
 // UnitsOfMeasure holds a document's display-unit preferences and performs the
 // conversion/formatting at the boundary (contract: UnitsOfMeasure). Stored
 // values never change when preferences do — only their presentation.
+//
+// Beyond the per-category preferred unit, it carries the length/angle display
+// precision (decimal places) and the length display format (decimal /
+// fractional / architectural). These drive presentation only; the rich
+// rendering for fractional/architectural/DMS is built on top of these in #146.
 type UnitsOfMeasure struct {
-	prefs map[Unit]string // category → preferred user-unit name
+	prefs           map[Unit]string // category → preferred user-unit name
+	lengthPrecision int             // length display precision (decimal places)
+	anglePrecision  int             // angle display precision (decimal places)
+	lengthFormat    types.ParameterDisplayFormat
 }
 
-// DefaultUnitsOfMeasure returns metric defaults (mm, degrees, kg, seconds).
+// DefaultUnitsOfMeasure returns metric defaults (mm, degrees, kg, seconds) with
+// three length / two angle display decimals and decimal length formatting.
 func DefaultUnitsOfMeasure() UnitsOfMeasure {
-	return UnitsOfMeasure{prefs: map[Unit]string{
-		Length: "mm", Angle: "deg", Area: "mm^2", Volume: "mm^3", Mass: "kg", Time: "s",
-	}}
+	return UnitsOfMeasure{
+		prefs: map[Unit]string{
+			Length: "mm", Angle: "deg", Area: "mm^2", Volume: "mm^3", Mass: "kg", Time: "s",
+		},
+		lengthPrecision: 3,
+		anglePrecision:  2,
+		lengthFormat:    types.DisplayFormatDecimal,
+	}
+}
+
+// Clone returns an independent copy whose preference edits do not touch the
+// receiver's shared map — the safe basis for building an updated units object
+// before storing it back on a document.
+func (m UnitsOfMeasure) Clone() UnitsOfMeasure {
+	prefs := make(map[Unit]string, len(m.prefs))
+	for k, v := range m.prefs {
+		prefs[k] = v
+	}
+	m.prefs = prefs
+	return m
+}
+
+// LengthPrecision / AnglePrecision are the display decimal places for lengths
+// and angles.
+func (m UnitsOfMeasure) LengthPrecision() int { return m.lengthPrecision }
+func (m UnitsOfMeasure) AnglePrecision() int  { return m.anglePrecision }
+
+// LengthFormat is how lengths are rendered (decimal / fractional / architectural).
+func (m UnitsOfMeasure) LengthFormat() types.ParameterDisplayFormat { return m.lengthFormat }
+
+// SetLengthPrecision / SetAnglePrecision set the display decimal places; a
+// negative count is rejected naming the offending value.
+func (m *UnitsOfMeasure) SetLengthPrecision(places int) error {
+	return setPrecision(&m.lengthPrecision, places)
+}
+
+func (m *UnitsOfMeasure) SetAnglePrecision(places int) error {
+	return setPrecision(&m.anglePrecision, places)
+}
+
+// setPrecision validates and assigns a display-precision decimal-place count.
+func setPrecision(dst *int, places int) error {
+	if places < 0 {
+		return fmt.Errorf("param: display precision %d is negative; want ≥ 0", places)
+	}
+	*dst = places
+	return nil
+}
+
+// SetLengthFormat sets the length display format (decimal / fractional /
+// architectural).
+func (m *UnitsOfMeasure) SetLengthFormat(f types.ParameterDisplayFormat) {
+	m.lengthFormat = f
 }
 
 // SetPreferred sets the display unit for a category; the name must be registered

--- a/model/param/units_service.go
+++ b/model/param/units_service.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "fmt"
+
+// The unit conversion / expression service that backs the public units API
+// (Oblikovati/Oblikovati#146). It converts between registered unit names,
+// resolves a unit name's category, and evaluates unit-bearing expressions
+// against a document's parameter set.
+
+// ParseUnitCategory resolves a category name (the inverse of [Unit.String], e.g.
+// "length") back to its [Unit].
+func ParseUnitCategory(name string) (Unit, bool) {
+	for u, n := range unitNames {
+		if n == name {
+			return u, true
+		}
+	}
+	return 0, false
+}
+
+// UnitCategoryOf returns the category a registered unit NAME ("mm", "deg")
+// belongs to.
+func UnitCategoryOf(unitName string) (Unit, bool) {
+	d, ok := lookupUnit(unitName)
+	if !ok {
+		return 0, false
+	}
+	return d.category, true
+}
+
+// ConvertValue converts a value expressed in unit From to unit To. Both must be
+// registered units of the SAME category; a mismatch is an error naming both.
+func ConvertValue(value float64, from, to string) (float64, error) {
+	fd, ok := lookupUnit(from)
+	if !ok {
+		return 0, fmt.Errorf("param: unknown unit %q", from)
+	}
+	td, ok := lookupUnit(to)
+	if !ok {
+		return 0, fmt.Errorf("param: unknown unit %q", to)
+	}
+	if fd.category != td.category {
+		return 0, fmt.Errorf("param: cannot convert %q (%s) to %q (%s): different categories",
+			from, fd.category, to, td.category)
+	}
+	return value * fd.factor / td.factor, nil
+}
+
+// EvaluateExpression parses and evaluates a unit-bearing expression against the
+// parameter set, returning the database-unit [Quantity]. A parse error, an
+// undefined reference, or a dimensional error is returned (a units-service
+// caller wants a definite value or a clear reason it has none).
+//
+// Example: with width = 4 cm, EvaluateExpression("width * 2") → {8 cm, Length}.
+func (ps *Parameters) EvaluateExpression(src string) (Quantity, error) {
+	expr, err := Parse(src)
+	if err != nil {
+		return Quantity{}, err
+	}
+	if unresolved := expr.Bind(ps.resolver()); len(unresolved) > 0 {
+		return Quantity{}, fmt.Errorf("param: expression %q references undefined parameter(s) %v", src, unresolved)
+	}
+	return expr.Eval(ps)
+}
+
+// ExpressionReferences returns the distinct parameter names an expression reads,
+// in first-seen order (the driving parameters of the expression). It does not
+// need a parameter set — it is a pure parse.
+func ExpressionReferences(src string) ([]string, error) {
+	expr, err := Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	return expr.References(), nil
+}

--- a/model/param/units_service_test.go
+++ b/model/param/units_service_test.go
@@ -73,4 +73,14 @@ func TestUnitsOfMeasurePrecisionFields(t *testing.T) {
 	if err := c.SetLengthPrecision(-1); err == nil {
 		t.Error("a negative precision must error")
 	}
+	if err := c.SetAnglePrecision(1); err != nil || c.AnglePrecision() != 1 {
+		t.Errorf("SetAnglePrecision = (%v); angle precision %d, want 1", err, c.AnglePrecision())
+	}
+	if err := c.SetAnglePrecision(-2); err == nil {
+		t.Error("a negative angle precision must error")
+	}
+	c.SetLengthFormat(types.DisplayFormatFractional)
+	if c.LengthFormat() != types.DisplayFormatFractional {
+		t.Errorf("length format = %v, want fractional", c.LengthFormat())
+	}
 }

--- a/model/param/units_service_test.go
+++ b/model/param/units_service_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+func TestConvertValue(t *testing.T) {
+	got, err := ConvertValue(1, "in", "cm")
+	if err != nil || !approxScalar(got, 2.54) {
+		t.Errorf("1 in→cm = (%g, %v), want 2.54", got, err)
+	}
+	if _, err := ConvertValue(1, "mm", "deg"); err == nil {
+		t.Error("mm→deg must error (different categories)")
+	}
+	if _, err := ConvertValue(1, "furlong", "cm"); err == nil {
+		t.Error("an unknown unit must error")
+	}
+}
+
+func TestParseUnitCategoryAndUnitCategoryOf(t *testing.T) {
+	if cat, ok := ParseUnitCategory("length"); !ok || cat != Length {
+		t.Errorf("ParseUnitCategory(length) = (%v, %v), want Length", cat, ok)
+	}
+	if _, ok := ParseUnitCategory("nope"); ok {
+		t.Error("ParseUnitCategory must reject unknown categories")
+	}
+	if cat, ok := UnitCategoryOf("deg"); !ok || cat != Angle {
+		t.Errorf("UnitCategoryOf(deg) = (%v, %v), want Angle", cat, ok)
+	}
+}
+
+func TestEvaluateExpressionAndReferences(t *testing.T) {
+	ps := NewParameters()
+	if _, err := ps.AddUserParameter("width", "4 cm"); err != nil {
+		t.Fatalf("add width: %v", err)
+	}
+	q, err := ps.EvaluateExpression("width * 2")
+	if err != nil || q.Unit != Length || !approxScalar(q.Value, 8) {
+		t.Errorf("width*2 = (%g %s, %v), want 8 cm", q.Value, q.Unit, err)
+	}
+	if _, err := ps.EvaluateExpression("missing + 1"); err == nil {
+		t.Error("an undefined reference must error")
+	}
+	refs, err := ExpressionReferences("a + b * a")
+	if err != nil || len(refs) != 2 || refs[0] != "a" || refs[1] != "b" {
+		t.Errorf("references = (%v, %v), want [a b] in first-seen order", refs, err)
+	}
+}
+
+func TestUnitsOfMeasurePrecisionFields(t *testing.T) {
+	u := DefaultUnitsOfMeasure()
+	if u.LengthPrecision() != 3 || u.AnglePrecision() != 2 || u.LengthFormat() != types.DisplayFormatDecimal {
+		t.Fatalf("defaults = %d/%d/%v, want 3/2/decimal", u.LengthPrecision(), u.AnglePrecision(), u.LengthFormat())
+	}
+	// Clone is independent: editing the clone's unit map leaves the original alone.
+	c := u.Clone()
+	if err := c.SetPreferred(Length, "in"); err != nil {
+		t.Fatalf("set clone length: %v", err)
+	}
+	if u.PreferredName(Length) != "mm" {
+		t.Errorf("original length changed to %q after editing the clone", u.PreferredName(Length))
+	}
+	if err := c.SetLengthPrecision(5); err != nil {
+		t.Fatalf("set precision: %v", err)
+	}
+	if c.LengthPrecision() != 5 {
+		t.Errorf("clone precision = %d, want 5", c.LengthPrecision())
+	}
+	if err := c.SetLengthPrecision(-1); err == nil {
+		t.Error("a negative precision must error")
+	}
+}


### PR DESCRIPTION
## What

The GPL/host half of issue #146 — backs the units API contract released in `oblikovati.org/api` v0.22.0.

- **`model/param`** — the reusable units service: `ConvertValue` (between unit names of one category), `ParseUnitCategory` / `UnitCategoryOf`, `Parameters.EvaluateExpression` + `ExpressionReferences` (expression evaluation/driving-params), and length/angle display-precision + length-display-format fields on `UnitsOfMeasure` (with `Clone` for safe edits).
- **`compdef`** — `SetUnits` on part and assembly definitions.
- **`addin/router/units.go`** — `documents.getUnits` / `documents.setUnits` and the `units.*` service (convert, get[Precise]StringFromValue, get[Value|DatabaseUnits]FromExpression, isExpressionValid, compatibleUnits, get[Type|String]From*, getLocaleCorrectedExpression, getDrivingParameters), keyed on the api/wire constants and served for both part and assembly documents.
- **build** — pin `oblikovati.org/api` v0.22.0.

## Why

Add-ins/MCP could not read or set a document's units or evaluate unit-bearing expressions (#146, severity high). This makes the units engine reachable over the wire; the per-tool UI sweep and import/export unit handling follow as separate PBIs.

## Tests

Router tests cover convert, formatting, expression eval, validation and the partial-update set path; `model/param` tests cover the service helpers and the new `UnitsOfMeasure` fields. The API↔router parity guard stays green.

## Scoped to the follow-up formatter PBI

Persisting the new precision/format fields and the rich fractional / architectural / DMS rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)