### PR TITLE
feat(units): display formatter — precision, fractional/architectural, DMS (#146)

### DIFF
--- a/addin/router/units.go
+++ b/addin/router/units.go
@@ -135,13 +135,14 @@ func unitsConvert(_ *app.Session, args json.RawMessage) (json.RawMessage, error)
 }
 
 // unitsGetStringFromValue formats a database-unit value in the document's
-// display unit (honoring display precision, once #146's formatter lands).
+// display unit, honoring the display precision and format (decimal / fractional
+// / architectural lengths, decimal-degree / DMS angles).
 func unitsGetStringFromValue(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	doc, cat, value, err := stringFromValueInputs(s, args)
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(wire.StringResult{Value: doc.Units().Format(param.Q(value, cat))})
+	return json.Marshal(wire.StringResult{Value: doc.Units().FormatDisplay(param.Q(value, cat))})
 }
 
 // unitsGetPreciseStringFromValue formats a database-unit value at full

--- a/addin/router/units_test.go
+++ b/addin/router/units_test.go
@@ -59,8 +59,8 @@ func TestUnitsServiceOverWire(t *testing.T) {
 
 	var str wire.StringResult
 	call(t, r, s, "units.getStringFromValue", `{"value":4,"unitsType":"length"}`, &str)
-	if str.Value != "40 mm" {
-		t.Errorf("getStringFromValue(4 cm) = %q, want \"40 mm\"", str.Value)
+	if str.Value != "40.000 mm" { // display precision = 3 decimals
+		t.Errorf("getStringFromValue(4 cm) = %q, want \"40.000 mm\"", str.Value)
 	}
 
 	var val wire.ValueResult

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -151,7 +151,7 @@ func (a *AssemblyComponentDefinition) ApplyRecipe(model []byte) error {
 	if err := yamlcodec.Unmarshal(model, &r); err != nil {
 		return fmt.Errorf("compdef: parse assembly recipe: %w", err)
 	}
-	if err := applyUnitsTo(a.units, r.Units); err != nil {
+	if err := applyUnitsTo(&a.units, r.Units); err != nil {
 		return err
 	}
 	applyPropertiesRecipe(a.props, r.Properties)

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -4,6 +4,7 @@ package compdef
 
 import (
 	"fmt"
+	"strconv"
 
 	"oblikovati.org/api/types"
 
@@ -311,32 +312,105 @@ func (d *PartComponentDefinition) unitsRecipe() map[string]string {
 
 // applyUnits restores the preferred display unit for each named category.
 func (d *PartComponentDefinition) applyUnits(units map[string]string) error {
-	return applyUnitsTo(d.units, units)
+	return applyUnitsTo(&d.units, units)
 }
 
-// unitsRecipeFor captures the preferred display-unit name for each category — shared by
-// the part and assembly recipes, which persist units identically.
+// Reserved units-recipe keys carry the display precision/format alongside the
+// per-category unit names in the same map. They are NOT category names, so old
+// recipes that lack them simply restore the defaults.
+const (
+	keyLengthPrecision = "lengthPrecision"
+	keyAnglePrecision  = "anglePrecision"
+	keyLengthFormat    = "lengthFormat"
+	keyAngleFormat     = "angleFormat"
+)
+
+// unitsRecipeFor captures the preferred display-unit name for each category plus
+// the display precision/format — shared by the part and assembly recipes, which
+// persist units identically.
 func unitsRecipeFor(u param.UnitsOfMeasure) map[string]string {
-	out := make(map[string]string, len(unitCategories))
+	out := make(map[string]string, len(unitCategories)+4)
 	for _, cat := range unitCategories {
 		out[cat.String()] = u.PreferredName(cat)
 	}
+	out[keyLengthPrecision] = strconv.Itoa(u.LengthPrecision())
+	out[keyAnglePrecision] = strconv.Itoa(u.AnglePrecision())
+	out[keyLengthFormat] = u.LengthFormat().String()
+	out[keyAngleFormat] = angleFormatName(u.AngleFormat())
 	return out
 }
 
-// applyUnitsTo restores the preferred display unit for each named category onto u. An
-// unknown category name or an invalid unit is a corrupt-recipe error (no silent loss).
-func applyUnitsTo(u param.UnitsOfMeasure, units map[string]string) error {
-	for name, unitName := range units {
+// applyUnitsTo restores the preferred display unit for each named category plus
+// the precision/format reserved keys onto u. An unknown category name or an
+// invalid value is a corrupt-recipe error (no silent loss).
+func applyUnitsTo(u *param.UnitsOfMeasure, units map[string]string) error {
+	for name, val := range units {
+		handled, err := applyReservedUnitKey(u, name, val)
+		if err != nil {
+			return err
+		}
+		if handled {
+			continue
+		}
 		cat, ok := unitCategoryByName(name)
 		if !ok {
 			return fmt.Errorf("compdef: unknown unit category %q in recipe", name)
 		}
-		if err := u.SetPreferred(cat, unitName); err != nil {
+		if err := u.SetPreferred(cat, val); err != nil {
 			return fmt.Errorf("compdef: restore units: %w", err)
 		}
 	}
 	return nil
+}
+
+// applyReservedUnitKey applies a precision/format reserved key, reporting whether
+// the key was one (so the category path is skipped) and any parse/validation error.
+func applyReservedUnitKey(u *param.UnitsOfMeasure, name, val string) (bool, error) {
+	switch name {
+	case keyLengthPrecision, keyAnglePrecision:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return true, fmt.Errorf("compdef: %s %q is not an integer: %w", name, val, err)
+		}
+		set := u.SetLengthPrecision
+		if name == keyAnglePrecision {
+			set = u.SetAnglePrecision
+		}
+		return true, set(n)
+	case keyLengthFormat:
+		f, ok := types.ParseParameterDisplayFormat(val)
+		if !ok {
+			return true, fmt.Errorf("compdef: unknown length display format %q in recipe", val)
+		}
+		u.SetLengthFormat(f)
+		return true, nil
+	case keyAngleFormat:
+		f, ok := parseAngleFormat(val)
+		if !ok {
+			return true, fmt.Errorf("compdef: unknown angle display format %q in recipe", val)
+		}
+		u.SetAngleFormat(f)
+		return true, nil
+	}
+	return false, nil
+}
+
+// angleFormatName / parseAngleFormat are the recipe spellings of param.AngleFormat.
+func angleFormatName(f param.AngleFormat) string {
+	if f == param.AngleDMS {
+		return "dms"
+	}
+	return "decimal"
+}
+
+func parseAngleFormat(s string) (param.AngleFormat, bool) {
+	switch s {
+	case "decimal":
+		return param.AngleDecimal, true
+	case "dms":
+		return param.AngleDMS, true
+	}
+	return param.AngleDecimal, false
 }
 
 // parametersRecipe captures every parameter in creation order (a valid order to

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -546,6 +546,36 @@ func TestLengthUnitSurvivesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestUnitsPrecisionAndFormatSurviveRoundTrip persists the display precision and
+// the length/angle formats (the #146 additions) and restores them.
+func TestUnitsPrecisionAndFormatSurviveRoundTrip(t *testing.T) {
+	ws := doc.NewWorkspace(nil)
+	d, _ := compdef.AddPart(ws, "Part1", true)
+	def := d.Content().(*compdef.PartComponentDefinition)
+
+	u := def.Units().Clone()
+	if err := u.SetPreferred(param.Length, "in"); err != nil {
+		t.Fatal(err)
+	}
+	if err := u.SetLengthPrecision(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := u.SetAnglePrecision(4); err != nil {
+		t.Fatal(err)
+	}
+	u.SetLengthFormat(types.DisplayFormatFractional)
+	u.SetAngleFormat(param.AngleDMS)
+	def.SetUnits(u)
+
+	got := reopenThroughStore(t, d).Units()
+	if got.LengthPrecision() != 5 || got.AnglePrecision() != 4 {
+		t.Errorf("precision after reopen = %d/%d, want 5/4", got.LengthPrecision(), got.AnglePrecision())
+	}
+	if got.LengthFormat() != types.DisplayFormatFractional || got.AngleFormat() != param.AngleDMS {
+		t.Errorf("formats after reopen = %v/%v, want fractional/DMS", got.LengthFormat(), got.AngleFormat())
+	}
+}
+
 // TestRevolveTwoDirectionalSurvivesReopen: the second-direction sweep (#313)
 // persists and the restored revolve rebuilds the same straddling solid.
 func TestRevolveTwoDirectionalSurvivesReopen(t *testing.T) {

--- a/model/compdef/units_test.go
+++ b/model/compdef/units_test.go
@@ -57,3 +57,24 @@ func TestAssemblySetUnits(t *testing.T) {
 		t.Errorf("assembly length unit after SetUnits = %q, want ft", name)
 	}
 }
+
+func TestApplyUnitsToReservedKeys(t *testing.T) {
+	u := param.DefaultUnitsOfMeasure().Clone()
+	if err := applyUnitsTo(&u, map[string]string{
+		"lengthPrecision": "4", "anglePrecision": "1",
+		"lengthFormat": "fractional", "angleFormat": "dms",
+	}); err != nil {
+		t.Fatalf("apply reserved keys: %v", err)
+	}
+	if u.LengthPrecision() != 4 || u.AnglePrecision() != 1 || u.AngleFormat() != param.AngleDMS {
+		t.Errorf("reserved keys not applied: %+v", u)
+	}
+	for _, bad := range []map[string]string{
+		{"lengthPrecision": "x"}, {"lengthFormat": "bogus"},
+		{"angleFormat": "bogus"}, {"nonsense": "mm"},
+	} {
+		if err := applyUnitsTo(&u, bad); err == nil {
+			t.Errorf("applyUnitsTo(%v) should error", bad)
+		}
+	}
+}

--- a/model/param/format_display.go
+++ b/model/param/format_display.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"fmt"
+	stdmath "math"
+	"strconv"
+	"strings"
+
+	"oblikovati.org/api/types"
+)
+
+// Display formatting (Oblikovati/Oblikovati#146): the GetStringFromValue
+// equivalent that honors the document's display PRECISION and FORMAT — decimal,
+// fractional and architectural lengths, and decimal-degree or DMS angles. It is
+// distinct from [UnitsOfMeasure.Format], which is the lossless, full-precision
+// rendering (GetPreciseStringFromValue) that parse round-trips depend on.
+
+// FormatDisplay renders q in its category's preferred unit at the document's
+// display precision and format, with the unit appended (e.g. a 0.3175 cm length
+// in fractional inches → "1/8 in"). Lengths and angles get the rich treatment;
+// other categories fall back to the precise form.
+//
+// Example: with mm units at precision 2, FormatDisplay(Q(1.005, Length)) → "10.05 mm".
+func (m UnitsOfMeasure) FormatDisplay(q Quantity) string {
+	value := m.FormatValueDisplay(q)
+	// Architectural lengths and DMS angles already carry their own ' " ° symbols.
+	if q.Unit == Length && m.lengthFormat == types.DisplayFormatArchitectural {
+		return value
+	}
+	if q.Unit == Angle && m.angleFormat == AngleDMS {
+		return value
+	}
+	if name := m.PreferredName(q.Unit); name != "" {
+		return value + " " + name
+	}
+	return value
+}
+
+// FormatValueDisplay renders just the numeric part of q at the display precision
+// and format (no trailing unit name; architectural/DMS forms keep their inline
+// ' " ° symbols since those ARE the value). It is what a UI field shows while
+// the unit label is drawn separately.
+func (m UnitsOfMeasure) FormatValueDisplay(q Quantity) string {
+	switch q.Unit {
+	case Length:
+		return m.formatLengthDisplay(q)
+	case Angle:
+		return m.formatAngleDisplay(q)
+	default:
+		return m.FormatValue(q)
+	}
+}
+
+// formatLengthDisplay renders a length per the configured length format.
+func (m UnitsOfMeasure) formatLengthDisplay(q Quantity) string {
+	switch m.lengthFormat {
+	case types.DisplayFormatFractional:
+		return fractionString(m.ToPreferred(q), m.fractionDenominator())
+	case types.DisplayFormatArchitectural:
+		return architecturalString(m.inchesOf(q), m.fractionDenominator())
+	default:
+		return formatFixed(m.ToPreferred(q), m.lengthPrecision)
+	}
+}
+
+// formatAngleDisplay renders an angle as decimal degrees or DMS.
+func (m UnitsOfMeasure) formatAngleDisplay(q Quantity) string {
+	if m.angleFormat == AngleDMS {
+		return dmsString(m.degreesOf(q))
+	}
+	return formatFixed(m.ToPreferred(q), m.anglePrecision)
+}
+
+// fractionDenominator maps the length precision to a power-of-two fraction
+// denominator: precision 1→halves, 3→eighths, 6→sixty-fourths, clamped to the
+// 1/2…1/128 range Inventor offers.
+func (m UnitsOfMeasure) fractionDenominator() int {
+	p := m.lengthPrecision
+	if p < 1 {
+		p = 1
+	}
+	if p > 7 {
+		p = 7
+	}
+	return 1 << p
+}
+
+// inchesOf returns q (a database-unit length) expressed in inches.
+func (m UnitsOfMeasure) inchesOf(q Quantity) float64 {
+	return q.Value / namedUnits["in"].factor
+}
+
+// degreesOf returns q (a database-unit angle) expressed in degrees.
+func (m UnitsOfMeasure) degreesOf(q Quantity) float64 {
+	return q.Value / namedUnits["deg"].factor
+}
+
+// formatFixed renders v with exactly places decimals (display precision).
+func formatFixed(v float64, places int) string {
+	return strconv.FormatFloat(v, 'f', places, 64)
+}
+
+// fractionString renders v as a whole number plus a reduced power-of-two
+// fraction with the given denominator (e.g. 1.25, /8 → "1-1/4").
+func fractionString(v float64, denom int) string {
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	units := int(stdmath.Round(v * float64(denom)))
+	s := fractionPart(units/denom, units%denom, denom)
+	if neg {
+		return "-" + s
+	}
+	return s
+}
+
+// fractionPart renders whole + rem/denom, reducing the fraction; rem==0 yields
+// the bare whole number.
+func fractionPart(whole, rem, denom int) string {
+	if rem == 0 {
+		return strconv.Itoa(whole)
+	}
+	g := gcdInt(rem, denom)
+	rem, denom = rem/g, denom/g
+	if whole == 0 {
+		return fmt.Sprintf("%d/%d", rem, denom)
+	}
+	return fmt.Sprintf("%d-%d/%d", whole, rem, denom)
+}
+
+// architecturalString renders a length given in inches as feet and fractional
+// inches (e.g. 13.5 in, /2 → "1' 1-1/2\""). The 1/denom rounding is done on the
+// total so a rounded-up inch carries into feet.
+func architecturalString(inches float64, denom int) string {
+	neg := inches < 0
+	if neg {
+		inches = -inches
+	}
+	units := int(stdmath.Round(inches * float64(denom))) // total in 1/denom inch
+	feetUnits := 12 * denom
+	feet := units / feetUnits
+	rem := units - feet*feetUnits
+	inchStr := fractionPart(rem/denom, rem%denom, denom) + `"`
+
+	var b strings.Builder
+	if neg {
+		b.WriteByte('-')
+	}
+	if feet > 0 {
+		fmt.Fprintf(&b, "%d' ", feet)
+	}
+	b.WriteString(inchStr)
+	return b.String()
+}
+
+// dmsString renders an angle in degrees as degrees-minutes-seconds, carrying
+// rounded 60s up (e.g. 30.5 → `30° 30' 0"`).
+func dmsString(deg float64) string {
+	neg := deg < 0
+	if neg {
+		deg = -deg
+	}
+	d := int(deg)
+	minutes := (deg - float64(d)) * 60
+	mi := int(minutes)
+	si := int(stdmath.Round((minutes - float64(mi)) * 60))
+	if si == 60 {
+		si, mi = 0, mi+1
+	}
+	if mi == 60 {
+		mi, d = 0, d+1
+	}
+	s := fmt.Sprintf("%d° %d' %d\"", d, mi, si)
+	if neg {
+		return "-" + s
+	}
+	return s
+}
+
+// gcdInt is the greatest common divisor (Euclid), for reducing fractions.
+func gcdInt(a, b int) int {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	if a == 0 {
+		return 1
+	}
+	return a
+}

--- a/model/param/format_display_test.go
+++ b/model/param/format_display_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// TestFormatDisplayDecimal honors the length/angle display precision with fixed
+// decimals, distinct from the lossless Format.
+func TestFormatDisplayDecimal(t *testing.T) {
+	m := DefaultUnitsOfMeasure() // mm, 3 length decimals; deg, 2 angle decimals
+	// Display pads to the fixed precision; the lossless Format stays shortest.
+	if got := m.FormatDisplay(Q(1, Length)); got != "10.000 mm" {
+		t.Errorf("length display = %q, want \"10.000 mm\"", got)
+	}
+	if got := m.Format(Q(1, Length)); got != "10 mm" {
+		t.Errorf("length precise = %q, want \"10 mm\"", got)
+	}
+	// Display rounds to the precision (12.3456 mm → 12.346 mm).
+	if got := m.FormatDisplay(Q(1.23456, Length)); got != "12.346 mm" {
+		t.Errorf("length display = %q, want \"12.346 mm\"", got)
+	}
+	// 45° rendered with two angle decimals.
+	if got := m.FormatDisplay(Q(45*namedUnits["deg"].factor, Angle)); got != "45.00 deg" {
+		t.Errorf("angle display = %q, want \"45.00 deg\"", got)
+	}
+}
+
+// TestFormatDisplayFractional renders the preferred (inch) unit as reduced
+// power-of-two fractions.
+func TestFormatDisplayFractional(t *testing.T) {
+	m := DefaultUnitsOfMeasure().Clone()
+	if err := m.SetPreferred(Length, "in"); err != nil {
+		t.Fatal(err)
+	}
+	m.SetLengthFormat(types.DisplayFormatFractional)
+	if err := m.SetLengthPrecision(3); err != nil { // eighths
+		t.Fatal(err)
+	}
+	cases := map[float64]string{ // value in cm → display
+		2.54:    "1 in",       // exactly 1"
+		3.175:   "1-1/4 in",   // 1.25"
+		0.3175:  "1/8 in",     // 0.125"
+		0:       "0 in",       // zero
+		-3.9688: "-1-9/16 in", // negative, needs 1/16 (precision bumped below)
+	}
+	if err := m.SetLengthPrecision(4); err != nil { // sixteenths for the -1-9/16 case
+		t.Fatal(err)
+	}
+	for cm, want := range cases {
+		if got := m.FormatDisplay(Q(cm, Length)); got != want {
+			t.Errorf("FormatDisplay(%g cm) = %q, want %q", cm, got, want)
+		}
+	}
+}
+
+// TestFormatDisplayArchitectural renders feet and fractional inches.
+func TestFormatDisplayArchitectural(t *testing.T) {
+	m := DefaultUnitsOfMeasure().Clone()
+	if err := m.SetPreferred(Length, "in"); err != nil {
+		t.Fatal(err)
+	}
+	m.SetLengthFormat(types.DisplayFormatArchitectural)
+	if err := m.SetLengthPrecision(2); err != nil { // quarters
+		t.Fatal(err)
+	}
+	// 13.5 in = 34.29 cm → 1' 1-1/2"
+	if got := m.FormatDisplay(Q(34.29, Length)); got != `1' 1-1/2"` {
+		t.Errorf("architectural = %q, want \"1' 1-1/2\\\"\"", got)
+	}
+	// 12 in = 30.48 cm → 1' 0"
+	if got := m.FormatDisplay(Q(30.48, Length)); got != `1' 0"` {
+		t.Errorf("architectural = %q, want \"1' 0\\\"\"", got)
+	}
+	// 5.5 in = 13.97 cm → 5-1/2" (no feet)
+	if got := m.FormatDisplay(Q(13.97, Length)); got != `5-1/2"` {
+		t.Errorf("architectural = %q, want \"5-1/2\\\"\"", got)
+	}
+}
+
+// TestFormatDisplayDMS renders angles as degrees-minutes-seconds, carrying 60s.
+func TestFormatDisplayDMS(t *testing.T) {
+	m := DefaultUnitsOfMeasure()
+	m.SetAngleFormat(AngleDMS)
+	degToRad := namedUnits["deg"].factor
+	cases := map[float64]string{ // degrees → display
+		30.5:    `30° 30' 0"`,
+		0:       `0° 0' 0"`,
+		90:      `90° 0' 0"`,
+		10.2589: `10° 15' 32"`,
+	}
+	for deg, want := range cases {
+		if got := m.FormatDisplay(Q(deg*degToRad, Angle)); got != want {
+			t.Errorf("DMS(%g deg) = %q, want %q", deg, got, want)
+		}
+	}
+}
+
+// TestFractionHelpers pins the fraction/gcd primitives.
+func TestFractionHelpers(t *testing.T) {
+	if g := gcdInt(12, 8); g != 4 {
+		t.Errorf("gcd(12,8) = %d, want 4", g)
+	}
+	if s := fractionString(1.25, 8); s != "1-1/4" {
+		t.Errorf("fractionString(1.25,8) = %q, want 1-1/4", s)
+	}
+	// Rounds up to the next whole when the fraction completes the denominator.
+	if s := fractionString(0.999, 2); s != "1" {
+		t.Errorf("fractionString(0.999,2) = %q, want 1", s)
+	}
+}
+
+// TestFormatDisplayEdgeCases covers the fallback, clamp, and negative paths.
+func TestFormatDisplayEdgeCases(t *testing.T) {
+	m := DefaultUnitsOfMeasure()
+	// A non-length/angle category falls back to the precise value form.
+	if got, want := m.FormatValueDisplay(Q(2, Mass)), m.FormatValue(Q(2, Mass)); got != want {
+		t.Errorf("mass display = %q, want precise %q", got, want)
+	}
+	if m.AngleFormat() != AngleDecimal {
+		t.Error("default angle format should be decimal")
+	}
+
+	inFrac := func(prec int, format types.ParameterDisplayFormat) UnitsOfMeasure {
+		u := m.Clone()
+		if err := u.SetPreferred(Length, "in"); err != nil {
+			t.Fatal(err)
+		}
+		if err := u.SetLengthPrecision(prec); err != nil {
+			t.Fatal(err)
+		}
+		u.SetLengthFormat(format)
+		return u
+	}
+
+	// Precision 0 clamps the fraction denominator up to halves.
+	if got := inFrac(0, types.DisplayFormatFractional).FormatDisplay(Q(2.54*1.5, Length)); got != "1-1/2 in" {
+		t.Errorf("clamped-low fraction = %q, want \"1-1/2 in\"", got)
+	}
+	// Precision 20 clamps down to 128ths; renders feet-inches.
+	if got := inFrac(20, types.DisplayFormatArchitectural).FormatDisplay(Q(2.54*13.5, Length)); got != `1' 1-1/2"` {
+		t.Errorf("clamped-high architectural = %q", got)
+	}
+	// Negative architectural and DMS keep the leading sign.
+	if got := inFrac(2, types.DisplayFormatArchitectural).FormatDisplay(Q(-2.54*13.5, Length)); got != `-1' 1-1/2"` {
+		t.Errorf("negative architectural = %q", got)
+	}
+	dms := m.Clone()
+	dms.SetAngleFormat(AngleDMS)
+	if got := dms.FormatDisplay(Q(-30.5*namedUnits["deg"].factor, Angle)); got != `-30° 30' 0"` {
+		t.Errorf("negative DMS = %q", got)
+	}
+	if gcdInt(0, 0) != 1 {
+		t.Error("gcd(0,0) should fall back to 1")
+	}
+}

--- a/model/param/units_of_measure.go
+++ b/model/param/units_of_measure.go
@@ -51,10 +51,23 @@ func lookupUnit(name string) (unitDef, bool) {
 // rendering for fractional/architectural/DMS is built on top of these in #146.
 type UnitsOfMeasure struct {
 	prefs           map[Unit]string // category → preferred user-unit name
-	lengthPrecision int             // length display precision (decimal places)
+	lengthPrecision int             // length display precision (decimal places / fraction subdivision exponent)
 	anglePrecision  int             // angle display precision (decimal places)
 	lengthFormat    types.ParameterDisplayFormat
+	angleFormat     AngleFormat
 }
+
+// AngleFormat is how an angle is rendered for display: as decimal degrees or as
+// degrees-minutes-seconds (DMS). Length has the richer
+// [types.ParameterDisplayFormat]; angle needs only this binary choice.
+type AngleFormat uint8
+
+const (
+	// AngleDecimal renders an angle as decimal degrees (e.g. "30.5 deg").
+	AngleDecimal AngleFormat = iota
+	// AngleDMS renders an angle in degrees-minutes-seconds (e.g. "30° 30' 0\"").
+	AngleDMS
+)
 
 // DefaultUnitsOfMeasure returns metric defaults (mm, degrees, kg, seconds) with
 // three length / two angle display decimals and decimal length formatting.
@@ -66,6 +79,7 @@ func DefaultUnitsOfMeasure() UnitsOfMeasure {
 		lengthPrecision: 3,
 		anglePrecision:  2,
 		lengthFormat:    types.DisplayFormatDecimal,
+		angleFormat:     AngleDecimal,
 	}
 }
 
@@ -88,6 +102,12 @@ func (m UnitsOfMeasure) AnglePrecision() int  { return m.anglePrecision }
 
 // LengthFormat is how lengths are rendered (decimal / fractional / architectural).
 func (m UnitsOfMeasure) LengthFormat() types.ParameterDisplayFormat { return m.lengthFormat }
+
+// AngleFormat is how angles are rendered (decimal degrees / DMS).
+func (m UnitsOfMeasure) AngleFormat() AngleFormat { return m.angleFormat }
+
+// SetAngleFormat sets the angle display format (decimal degrees / DMS).
+func (m *UnitsOfMeasure) SetAngleFormat(f AngleFormat) { m.angleFormat = f }
 
 // SetLengthPrecision / SetAnglePrecision set the display decimal places; a
 // negative count is rejected naming the offending value.


### PR DESCRIPTION
## What

The full-parity display formatter for issue #146 (PBI-2, `/source`-only — builds on the units fields shipped in #980 / api v0.22.0).

- **`model/param`** — `FormatDisplay` / `FormatValueDisplay`: the GetStringFromValue-equivalent that honors the document's display **precision** and **format**:
  - decimal (fixed places),
  - reduced power-of-two **fractional** inches (e.g. `1-1/4 in`),
  - **architectural** feet-inches (e.g. `1' 1-1/2"`),
  - decimal-degree or **DMS** angles (e.g. `30° 30' 0"`).
  A new `AngleFormat` (decimal / DMS) field sits beside the length format. The lossless `Format` (GetPreciseStringFromValue) is untouched, so parse round-trips still hold.
- **`compdef`** — persists the display precision + length/angle formats in the units recipe (reserved keys; older recipes restore the defaults). `applyUnitsTo` now takes a pointer so scalar fields write back.
- **`addin/router`** — `units.getStringFromValue` now uses `FormatDisplay`; `getPreciseStringFromValue` stays on the lossless `Format`.

## Why

Add-ins/MCP (and the upcoming tool-input UI sweep) need values formatted the way the document is configured to show them — not just the raw shortest decimal. This is the rendering half of #146.

## Tests

Decimal / fractional / architectural / DMS rendering (incl. clamps and negatives), the fraction/gcd helpers, the reserved-key apply paths, and a serialize round-trip of the precision/format fields. New-code coverage 98%.

## Notes

`angleDisplayFormat` is host-internal for now (model + persistence + future Units dialog); exposing it on the wire DTO can follow in a later API bump. The per-tool UI sweep and import/export unit handling remain as separate PBIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)