### PR TITLE
feat(units): tool dialog inputs honor document units (#146)

### DIFF
--- a/app/units_display.go
+++ b/app/units_display.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/model/param"
+)
+
+// Session-level conversions between a tool's database-unit values (cm for
+// length, radians for angle) and the document's preferred display units — the
+// boundary every tool dialog field crosses so its value and label follow the
+// document's units (Oblikovati/Oblikovati#146). LengthUnitName/AngleUnitName
+// (extrude_session.go) supply the matching labels.
+
+// LengthToDisplay converts a database-unit length (cm) to the document's
+// preferred length unit; LengthFromDisplay is its inverse.
+func (s *Session) LengthToDisplay(cm float64) float64 {
+	return s.DocumentUnits().ToPreferred(param.Q(cm, param.Length))
+}
+
+func (s *Session) LengthFromDisplay(value float64) float64 {
+	return s.DocumentUnits().FromPreferred(value, param.Length).Value
+}
+
+// AngleToDisplay converts a database-unit angle (radians) to the document's
+// preferred angle unit; AngleFromDisplay is its inverse.
+func (s *Session) AngleToDisplay(radians float64) float64 {
+	return s.DocumentUnits().ToPreferred(param.Q(radians, param.Angle))
+}
+
+func (s *Session) AngleFromDisplay(value float64) float64 {
+	return s.DocumentUnits().FromPreferred(value, param.Angle).Value
+}
+
+// AngleDegToDisplay / AngleDisplayToDeg bridge dialogs that hold an angle in
+// DEGREES (their on-screen buffer) to the document's preferred angle unit.
+func (s *Session) AngleDegToDisplay(degrees float64) float64 {
+	return s.AngleToDisplay(degrees * stdmath.Pi / 180)
+}
+
+func (s *Session) AngleDisplayToDeg(value float64) float64 {
+	return s.AngleFromDisplay(value) * 180 / stdmath.Pi
+}

--- a/app/units_display_test.go
+++ b/app/units_display_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/param"
+)
+
+// TestUnitDisplayConversionsDefault covers the metric defaults (mm / deg): the
+// converters are identity-ish but exercise the ToPreferred/FromPreferred path.
+func TestUnitDisplayConversionsDefault(t *testing.T) {
+	s := NewSession() // no document ⇒ default mm/deg units
+	if got := s.LengthToDisplay(1); got != 10 {
+		t.Errorf("LengthToDisplay(1 cm) = %g, want 10 mm", got)
+	}
+	if got := s.LengthFromDisplay(10); got != 1 {
+		t.Errorf("LengthFromDisplay(10 mm) = %g, want 1 cm", got)
+	}
+	if got := s.AngleDegToDisplay(90); math.Abs(got-90) > 1e-9 {
+		t.Errorf("AngleDegToDisplay(90) = %g, want 90 deg", got)
+	}
+	if got := s.AngleDisplayToDeg(90); math.Abs(got-90) > 1e-9 {
+		t.Errorf("AngleDisplayToDeg(90) = %g, want 90", got)
+	}
+}
+
+// TestUnitDisplayConversionsInchRadian sets the document to inches and radians
+// and checks the converters honor it.
+func TestUnitDisplayConversionsInchRadian(t *testing.T) {
+	s := NewSession()
+	part, err := compdef.AddPart(s.Workspace(), "widget.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := part.Content().(*compdef.PartComponentDefinition)
+	u := def.Units().Clone()
+	if err := u.SetPreferred(param.Length, "in"); err != nil {
+		t.Fatalf("set length unit: %v", err)
+	}
+	if err := u.SetPreferred(param.Angle, "rad"); err != nil {
+		t.Fatalf("set angle unit: %v", err)
+	}
+	def.SetUnits(u)
+
+	// 2.54 cm = 1 in.
+	if got := s.LengthToDisplay(2.54); math.Abs(got-1) > 1e-9 {
+		t.Errorf("LengthToDisplay(2.54 cm) = %g, want 1 in", got)
+	}
+	if got := s.LengthFromDisplay(1); math.Abs(got-2.54) > 1e-9 {
+		t.Errorf("LengthFromDisplay(1 in) = %g, want 2.54 cm", got)
+	}
+	// 180 deg = π rad.
+	if got := s.AngleDegToDisplay(180); math.Abs(got-math.Pi) > 1e-9 {
+		t.Errorf("AngleDegToDisplay(180) = %g, want π rad", got)
+	}
+	if got := s.AngleDisplayToDeg(math.Pi); math.Abs(got-180) > 1e-9 {
+		t.Errorf("AngleDisplayToDeg(π) = %g, want 180 deg", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.22.0
+	oblikovati.org/api v0.23.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.22.0
+	oblikovati.org/api v0.23.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -56,7 +56,7 @@ func drawChamferDialog(s *app.Session) {
 // drawChamferBehaviorRows renders the setback distance, the concave-edge strategy combo, and the
 // flat-corner toggle.
 func drawChamferBehaviorRows(s *app.Session, c *app.ChamferTool) {
-	propertyFloatRow("Distance", "chamfer-distance", s.LengthUnitName(), &chamferUI.distance)
+	lengthCmRow(s, "Distance", "chamfer-distance", &chamferUI.distance)
 	c.SetDistance(float64(chamferUI.distance))
 	if i := propertyComboRow("Concave edge", "chamfer-concave", app.ConcaveStrategyNames(), chamferUI.concaveIndex); i >= 0 {
 		chamferUI.concaveIndex = i

--- a/head/ui/coil_dialog.go
+++ b/head/ui/coil_dialog.go
@@ -124,12 +124,12 @@ func drawCoilBehavior(s *app.Session, c *app.CoilTool) {
 	if !propertySection("Behavior") {
 		return
 	}
-	propertyFloatRow("Pitch", "coil-pitch", s.LengthUnitName(), &coilUI.pitch)
+	lengthCmRow(s, "Pitch", "coil-pitch", &coilUI.pitch)
 	c.SetPitch(float64(coilUI.pitch))
 	propertyFloatRow("Revolutions", "coil-revolutions", "", &coilUI.revolutions)
 	c.SetRevolutions(float64(coilUI.revolutions))
 	drawCoilPitchRows(s, c)
-	drawCoilEnds(c)
+	drawCoilEnds(s, c)
 }
 
 // drawCoilPitchRows is the variable-pitch rows grid: toggle, per-row pitch +
@@ -147,7 +147,7 @@ func drawCoilPitchRows(s *app.Session, c *app.CoilTool) {
 	}
 	for i := range coilUI.rows {
 		id := fmt.Sprintf("coil-row-%d", i)
-		propertyFloatRow(fmt.Sprintf("Row %d Pitch", i+1), id+"-pitch", s.LengthUnitName(), &coilUI.rows[i].pitch)
+		lengthCmRow(s, fmt.Sprintf("Row %d Pitch", i+1), id+"-pitch", &coilUI.rows[i].pitch)
 		propertyFloatRow(fmt.Sprintf("Row %d Rev", i+1), id+"-rev", "", &coilUI.rows[i].revolution)
 	}
 	if native.Button("Add Row") {
@@ -166,16 +166,16 @@ func drawCoilPitchRows(s *app.Session, c *app.CoilTool) {
 }
 
 // drawCoilEnds is the flat start/end condition controls (angles in degrees).
-func drawCoilEnds(c *app.CoilTool) {
+func drawCoilEnds(s *app.Session, c *app.CoilTool) {
 	native.Checkbox("Flat start", &coilUI.startFlat)
 	if coilUI.startFlat {
-		propertyFloatRow("Start Transition", "coil-start-trans", "deg", &coilUI.startTransition)
-		propertyFloatRow("Start Flat", "coil-start-flat", "deg", &coilUI.startFlatAngle)
+		angleDegRow(s, "Start Transition", "coil-start-trans", &coilUI.startTransition)
+		angleDegRow(s, "Start Flat", "coil-start-flat", &coilUI.startFlatAngle)
 	}
 	native.Checkbox("Flat end", &coilUI.endFlat)
 	if coilUI.endFlat {
-		propertyFloatRow("End Transition", "coil-end-trans", "deg", &coilUI.endTransition)
-		propertyFloatRow("End Flat", "coil-end-flat", "deg", &coilUI.endFlatAngle)
+		angleDegRow(s, "End Transition", "coil-end-trans", &coilUI.endTransition)
+		angleDegRow(s, "End Flat", "coil-end-flat", &coilUI.endFlatAngle)
 	}
 	c.SetEndConditions(coilEnd(coilUI.startFlat, coilUI.startTransition, coilUI.startFlatAngle),
 		coilEnd(coilUI.endFlat, coilUI.endTransition, coilUI.endFlatAngle))

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -41,7 +41,7 @@ func drawDraftDialog(s *app.Session) {
 				d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
 		}
 		if propertySection("Behavior") {
-			propertyFloatRow("Angle", "draft-angle", "deg (+out / −in)", &draftUI.angle)
+			angleDegRowHint(s, "Angle", "draft-angle", " (+out / −in)", &draftUI.angle)
 			d.SetAngleDegrees(float64(draftUI.angle))
 		}
 		native.Separator()

--- a/head/ui/face_offset_dialog.go
+++ b/head/ui/face_offset_dialog.go
@@ -36,7 +36,7 @@ func drawFaceOffsetDialog(s *app.Session) {
 				len(o.Faces()) > 0, "Click faces in the viewport to offset", o.ClearFaces)
 		}
 		if propertySection("Behavior") {
-			propertyFloatRow("Distance", "face-offset-distance", s.LengthUnitName()+" (+out / −in)", &faceOffsetUI.distance)
+			lengthCmRowHint(s, "Distance", "face-offset-distance", " (+out / −in)", &faceOffsetUI.distance)
 			o.SetDistance(float64(faceOffsetUI.distance))
 			if i := propertyComboRow("Approximation", "face-offset-approx", app.ApproximationOptions(), o.ApproximationIndex()); i >= 0 {
 				o.SetApproximationIndex(i)

--- a/head/ui/feature_dialogs_units_test.go
+++ b/head/ui/feature_dialogs_units_test.go
@@ -1,0 +1,98 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestFeatureDialogsRenderUnitFields renders each migrated part-feature dialog in
+// a real window, flipping the toggles that reveal every length/angle field, so
+// the unit-aware rows (lengthCmRow/angleDegRow) actually execute. It guards that
+// the #146 dialog sweep renders without panicking and exercises the conversion
+// rows. Skips cleanly where no display/Vulkan is available.
+func TestFeatureDialogsRenderUnitFields(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = newIconCache(win) // bind the icon cache (dialogs draw icon toggles directly)
+
+	frame := func(draw func()) {
+		win.BeginFrame()
+		draw()
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	t.Run("hole", func(t *testing.T) {
+		s := app.NewSession()
+		h := app.NewHoleTool()
+		s.StartTool(h)
+		frame(func() { drawHoleDialog(s) }) // plain: Diameter/Depth/point angle
+		h.SetCounterbore(true)
+		frame(func() { drawHoleDialog(s) }) // Seat Ø / Seat Depth
+		h.SetCounterbore(false)
+		h.SetCountersink(true)
+		frame(func() { drawHoleDialog(s) }) // Seat Ø / Seat Angle
+	})
+	t.Run("coil", func(t *testing.T) {
+		s := app.NewSession()
+		s.StartTool(app.NewCoilTool())
+		frame(func() { drawCoilDialog(s) }) // seeds + opens the panel
+		// Now reveal the variable-pitch rows and flat end angles, then re-render.
+		coilUI.variable = true
+		coilUI.rows = []coilRowUI{{pitch: 1}, {pitch: 1, revolution: 1}}
+		coilUI.startFlat, coilUI.endFlat = true, true
+		frame(func() { drawCoilDialog(s) })
+		coilUI.variable, coilUI.startFlat, coilUI.endFlat = false, false, false
+	})
+	t.Run("loft", func(t *testing.T) {
+		s := app.NewSession()
+		s.StartTool(app.NewLoftTool())
+		frame(func() { drawLoftDialog(s) })        // seed loftUI
+		loftUI.first.cond, loftUI.last.cond = 1, 2 // angle / direction → angle rows
+		frame(func() { drawLoftDialog(s) })
+	})
+	for name, draw := range map[string]func(*app.Session){
+		"sweep":      drawSweepDialog,
+		"fillet":     drawFilletDialog,
+		"chamfer":    drawChamferDialog,
+		"shell":      drawShellDialog,
+		"draft":      drawDraftDialog,
+		"thicken":    drawThickenDialog,
+		"faceOffset": drawFaceOffsetDialog,
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := app.NewSession()
+			s.StartTool(toolFor(name))
+			frame(func() { draw(s) })
+			if name == "fillet" {
+				filletUI.seeded = nil
+				s.ActiveFillet().SetVariable(true) // start/end radius rows
+				frame(func() { drawFilletDialog(s) })
+			}
+		})
+	}
+}
+
+// toolFor returns a fresh tool for the named dialog.
+func toolFor(name string) app.Tool {
+	switch name {
+	case "sweep":
+		return app.NewSweepTool()
+	case "fillet":
+		return app.NewFilletTool()
+	case "chamfer":
+		return app.NewChamferTool()
+	case "shell":
+		return app.NewShellTool()
+	case "draft":
+		return app.NewDraftTool()
+	case "thicken":
+		return app.NewThickenTool()
+	default:
+		return app.NewFaceOffsetTool()
+	}
+}

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -74,12 +74,12 @@ func drawFilletRadiusRows(s *app.Session, f *app.FilletTool) {
 		f.SetVariable(variable)
 	}
 	if !variable {
-		propertyFloatRow("Radius", "fillet-radius", s.LengthUnitName(), &filletUI.radius)
+		lengthCmRow(s, "Radius", "fillet-radius", &filletUI.radius)
 		f.SetRadius(float64(filletUI.radius))
 		return
 	}
-	propertyFloatRow("Start radius", "fillet-start-radius", s.LengthUnitName(), &filletUI.startRadius)
+	lengthCmRow(s, "Start radius", "fillet-start-radius", &filletUI.startRadius)
 	f.SetStartRadius(float64(filletUI.startRadius))
-	propertyFloatRow("End radius", "fillet-end-radius", s.LengthUnitName(), &filletUI.endRadius)
+	lengthCmRow(s, "End radius", "fillet-end-radius", &filletUI.endRadius)
 	f.SetEndRadius(float64(filletUI.endRadius))
 }

--- a/head/ui/hole_dialog.go
+++ b/head/ui/hole_dialog.go
@@ -128,14 +128,14 @@ func applyHoleSeat(h *app.HoleTool, index int) {
 // Ø + depth, or a countersink's sink Ø + included angle.
 func drawHoleSeatParams(s *app.Session, h *app.HoleTool) {
 	if h.Counterbore() {
-		propertyFloatRow("Seat Ø", "hole-cdia", s.LengthUnitName(), &holeUI.cDiameter)
-		propertyFloatRow("Seat Depth", "hole-cdepth", s.LengthUnitName(), &holeUI.cDepth)
+		lengthCmRow(s, "Seat Ø", "hole-cdia", &holeUI.cDiameter)
+		lengthCmRow(s, "Seat Depth", "hole-cdepth", &holeUI.cDepth)
 		h.SetCounterDiameter(float64(holeUI.cDiameter))
 		h.SetCounterDepth(float64(holeUI.cDepth))
 	}
 	if h.Countersink() {
-		propertyFloatRow("Seat Ø", "hole-sdia", s.LengthUnitName(), &holeUI.cDiameter)
-		propertyFloatRow("Seat Angle", "hole-sang", "deg", &holeUI.sinkAngleDeg)
+		lengthCmRow(s, "Seat Ø", "hole-sdia", &holeUI.cDiameter)
+		angleDegRow(s, "Seat Angle", "hole-sang", &holeUI.sinkAngleDeg)
 		h.SetCounterDiameter(float64(holeUI.cDiameter))
 		h.SetSinkAngle(float64(holeUI.sinkAngleDeg) * stdmath.Pi / 180)
 	}
@@ -164,10 +164,10 @@ func drawHoleBehavior(s *app.Session, h *app.HoleTool) {
 		return
 	}
 	drawHoleTerminationRow(h)
-	propertyFloatRow("Diameter", "hole-diameter", s.LengthUnitName(), &holeUI.diameter)
+	lengthCmRow(s, "Diameter", "hole-diameter", &holeUI.diameter)
 	h.SetDiameter(float64(holeUI.diameter))
 	drawHoleDepthRow(s, h)
-	drawHoleDrillPointRow(h)
+	drawHoleDrillPointRow(s, h)
 }
 
 // drawHoleTerminationRow renders the Termination toggles (distance / through-all).
@@ -187,7 +187,7 @@ func drawHoleTerminationRow(h *app.HoleTool) {
 // drawHoleDepthRow renders the Depth field, greyed while drilling through everything.
 func drawHoleDepthRow(s *app.Session, h *app.HoleTool) {
 	native.BeginDisabled(holeUI.through)
-	propertyFloatRow("Depth", "hole-depth", s.LengthUnitName(), &holeUI.depth)
+	lengthCmRow(s, "Depth", "hole-depth", &holeUI.depth)
 	native.EndDisabled()
 	h.SetDepth(float64(holeUI.depth))
 }
@@ -195,7 +195,7 @@ func drawHoleDepthRow(s *app.Session, h *app.HoleTool) {
 // drawHoleDrillPointRow renders the Drill Point toggles with the included-angle field
 // beside them in angle mode. The row greys out when the bottom shape is moot: a
 // through hole has no bottom, and a seated hole's recess owns the profile.
-func drawHoleDrillPointRow(h *app.HoleTool) {
+func drawHoleDrillPointRow(s *app.Session, h *app.HoleTool) {
 	native.BeginDisabled(holeUI.through || holeUI.counterbore || holeUI.countersink)
 	propertyRow("Drill Point")
 	active := 0
@@ -206,21 +206,24 @@ func drawHoleDrillPointRow(h *app.HoleTool) {
 	if i := propertyIconToggles("hole-drill", dt.keys, dt.tips, active); i >= 0 {
 		applyHoleDrillPoint(h, i)
 	}
-	drawHolePointAngleField(h)
+	drawHolePointAngleField(s, h)
 	native.EndDisabled()
 }
 
 // drawHolePointAngleField is the included-angle input shown beside the toggles while a
 // conical drill point is selected.
-func drawHolePointAngleField(h *app.HoleTool) {
+func drawHolePointAngleField(s *app.Session, h *app.HoleTool) {
 	if h.PointAngle() <= 0 {
 		return
 	}
 	native.SameLine()
 	native.SetNextItemWidth(60)
-	native.InputFloat("##hole-pang", &holeUI.pointAngleDeg)
+	disp := float32(s.AngleDegToDisplay(float64(holeUI.pointAngleDeg)))
+	if native.InputFloat("##hole-pang", &disp) {
+		holeUI.pointAngleDeg = float32(s.AngleDisplayToDeg(float64(disp)))
+	}
 	native.SameLine()
-	native.Text("deg")
+	native.Text(s.AngleUnitName())
 	h.SetPointAngle(float64(holeUI.pointAngleDeg) * stdmath.Pi / 180)
 }
 

--- a/head/ui/loft_dialog.go
+++ b/head/ui/loft_dialog.go
@@ -50,7 +50,7 @@ func drawLoftDialog(s *app.Session) {
 	if native.Begin("Loft") {
 		drawFeatureBreadcrumb("Loft", "")
 		drawLoftInputGeometry(l)
-		drawLoftBehavior(l)
+		drawLoftBehavior(s, l)
 		drawLoftOutput(l)
 		native.Separator()
 		drawCommitCancelButtons(s, l.CanCommit())
@@ -123,7 +123,7 @@ func drawLoftGuideKindCombo(l *app.LoftTool) {
 
 // drawLoftBehavior is the Behavior section: the closed-loop toggle, the area-graph mid
 // scale, and — for an open loft — the start/end section conditions.
-func drawLoftBehavior(l *app.LoftTool) {
+func drawLoftBehavior(s *app.Session, l *app.LoftTool) {
 	if !propertySection("Behavior") {
 		return
 	}
@@ -134,22 +134,22 @@ func drawLoftBehavior(l *app.LoftTool) {
 	}
 	propertyFloatRow("Area Mid", "loft-area-mid", "× (1 = off)", &loftUI.areaMid)
 	l.SetAreaMidScale(float64(loftUI.areaMid))
-	drawOpenLoftConditions(l, closed)
+	drawOpenLoftConditions(s, l, closed)
 }
 
-func drawOpenLoftConditions(l *app.LoftTool, closed bool) {
+func drawOpenLoftConditions(s *app.Session, l *app.LoftTool, closed bool) {
 	if closed {
 		return
 	}
-	drawLoftEndConditionRows("Start", "loft-start", &loftUI.first)
-	drawLoftEndConditionRows("End", "loft-end", &loftUI.last)
+	drawLoftEndConditionRows(s, "Start", "loft-start", &loftUI.first)
+	drawLoftEndConditionRows(s, "End", "loft-end", &loftUI.last)
 	l.SetFirstCondition(loftUI.first.toEnd())
 	l.SetLastCondition(loftUI.last.toEnd())
 }
 
 // drawLoftEndConditionRows renders one end's condition combo plus, for an angle/
 // direction takeoff, its angle (degrees), impact (takeoff weight) and reversed flag.
-func drawLoftEndConditionRows(title, id string, u *loftEndUI) {
+func drawLoftEndConditionRows(s *app.Session, title, id string, u *loftEndUI) {
 	propertyRow(title)
 	native.SetNextItemWidth(propertyComboWidth)
 	if native.BeginCombo("##"+id+"-cond", loftCondLabels[u.cond]) {
@@ -160,18 +160,18 @@ func drawLoftEndConditionRows(title, id string, u *loftEndUI) {
 		}
 		native.EndCombo()
 	}
-	drawLoftEndConditionParams(id, u)
+	drawLoftEndConditionParams(s, id, u)
 }
 
 // drawLoftEndConditionParams renders the condition's dependent fields: nothing for
 // Free/Sharp, a takeoff angle for Angle/Direction, and the impact weight + reversed
 // flag for every shaped condition.
-func drawLoftEndConditionParams(id string, u *loftEndUI) {
+func drawLoftEndConditionParams(s *app.Session, id string, u *loftEndUI) {
 	if u.cond == 0 || u.cond == 3 { // Free / Sharp: no further controls (sharp = a straight apex)
 		return
 	}
 	if u.cond == 1 || u.cond == 2 { // Angle / Direction: takeoff angle on a profile section
-		propertyFloatRow("  Angle", id+"-angle", "deg", &u.angleDeg)
+		angleDegRow(s, "  Angle", id+"-angle", &u.angleDeg)
 	}
 	propertyFloatRow("  Impact", id+"-impact", "", &u.impact)
 	propertyRow("")

--- a/head/ui/sheet_metal_dialog.go
+++ b/head/ui/sheet_metal_dialog.go
@@ -126,9 +126,9 @@ func drawSheetMetalFlange(s *app.Session, t *app.SheetMetalFlangeTool) {
 		smUI.angle = float32(t.Angle() * degPerRad)
 	})
 	sheetMetalPanel(s, "Flange", "Edge", "sm-flange", "Click a straight sheet edge", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Height", "sm-flange-height", s.LengthUnitName(), &smUI.height)
+		lengthCmRow(s, "Height", "sm-flange-height", &smUI.height)
 		t.SetHeight(float64(smUI.height))
-		propertyFloatRow("Angle", "sm-flange-angle", "deg", &smUI.angle)
+		angleDegRow(s, "Angle", "sm-flange-angle", &smUI.angle)
 		t.SetAngle(float64(smUI.angle) / degPerRad)
 	})
 }
@@ -136,7 +136,7 @@ func drawSheetMetalFlange(s *app.Session, t *app.SheetMetalFlangeTool) {
 func drawSheetMetalHem(s *app.Session, t *app.SheetMetalHemTool) {
 	seedSheetMetal(t, func() { smUI.length = float32(t.Length()) })
 	sheetMetalPanel(s, "Hem", "Edge", "sm-hem", "Click a straight sheet edge", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Length", "sm-hem-length", s.LengthUnitName(), &smUI.length)
+		lengthCmRow(s, "Length", "sm-hem-length", &smUI.length)
 		t.SetLength(float64(smUI.length))
 	})
 }
@@ -144,7 +144,7 @@ func drawSheetMetalHem(s *app.Session, t *app.SheetMetalHemTool) {
 func drawSheetMetalContourRoll(s *app.Session, t *app.SheetMetalContourRollTool) {
 	seedSheetMetal(t, func() { smUI.roll = float32(t.Angle() * degPerRad) })
 	sheetMetalPanel(s, "Contour Roll", "Profile + Axis", "sm-roll", "Click an open profile and its axis line", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Angle", "sm-roll-angle", "deg", &smUI.roll)
+		angleDegRow(s, "Angle", "sm-roll-angle", &smUI.roll)
 		t.SetAngle(float64(smUI.roll) / degPerRad)
 	})
 }
@@ -152,7 +152,7 @@ func drawSheetMetalContourRoll(s *app.Session, t *app.SheetMetalContourRollTool)
 func drawSheetMetalCorner(s *app.Session, t *app.SheetMetalCornerTool) {
 	seedSheetMetal(t, func() { smUI.size = float32(t.Size()) })
 	sheetMetalPanel(s, "Corner", "Corner Edges", "sm-corner", "Click corner edges to chamfer", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Size", "sm-corner-size", s.LengthUnitName(), &smUI.size)
+		lengthCmRow(s, "Size", "sm-corner-size", &smUI.size)
 		t.SetSize(float64(smUI.size))
 	})
 }
@@ -160,7 +160,7 @@ func drawSheetMetalCorner(s *app.Session, t *app.SheetMetalCornerTool) {
 func drawSheetMetalCornerSeam(s *app.Session, t *app.SheetMetalCornerSeamTool) {
 	seedSheetMetal(t, func() { smUI.gap = float32(t.Gap()) })
 	sheetMetalPanel(s, "Corner Seam", "Seam Edges", "sm-seam", "Click the seam edges", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Gap", "sm-seam-gap", s.LengthUnitName(), &smUI.gap)
+		lengthCmRow(s, "Gap", "sm-seam-gap", &smUI.gap)
 		t.SetGap(float64(smUI.gap))
 	})
 }

--- a/head/ui/sheet_metal_f03_dialog.go
+++ b/head/ui/sheet_metal_f03_dialog.go
@@ -35,7 +35,7 @@ func drawSheetMetalF03Dialogs(s *app.Session) bool {
 func drawSheetMetalRip(s *app.Session, t *app.SheetMetalRipTool) {
 	seedSheetMetal(t, func() { smUI.gap = float32(t.Gap()) })
 	sheetMetalPanel(s, "Rip", "Rip Line", "sm-rip", "Click a sketch line to rip along", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Gap", "sm-rip-gap", s.LengthUnitName(), &smUI.gap)
+		lengthCmRow(s, "Gap", "sm-rip-gap", &smUI.gap)
 		t.SetGap(float64(smUI.gap))
 	})
 }
@@ -47,12 +47,11 @@ func drawSheetMetalLip(s *app.Session, t *app.SheetMetalLipTool) {
 		smUI.angle = float32(t.Angle() * degPerRad)
 	})
 	sheetMetalPanel(s, "Lip", "Edge", "sm-lip", "Click a straight sheet edge", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		unit := s.LengthUnitName()
-		propertyFloatRow("Height", "sm-lip-height", unit, &smUI.height)
+		lengthCmRow(s, "Height", "sm-lip-height", &smUI.height)
 		t.SetHeight(float64(smUI.height))
-		propertyFloatRow("Return", "sm-lip-return", unit, &smUI.length)
+		lengthCmRow(s, "Return", "sm-lip-return", &smUI.length)
 		t.SetReturnLength(float64(smUI.length))
-		propertyFloatRow("Angle", "sm-lip-angle", "deg", &smUI.angle)
+		angleDegRow(s, "Angle", "sm-lip-angle", &smUI.angle)
 		t.SetAngle(float64(smUI.angle) / degPerRad)
 	})
 }
@@ -60,7 +59,7 @@ func drawSheetMetalLip(s *app.Session, t *app.SheetMetalLipTool) {
 func drawSheetMetalCosmeticBend(s *app.Session, t *app.SheetMetalCosmeticBendTool) {
 	seedSheetMetal(t, func() { smUI.angle = float32(t.Angle() * degPerRad) })
 	sheetMetalPanel(s, "Cosmetic Bend", "Bend Line", "sm-cosbend", "Click a sketch line to mark", t.PickCount(), t.ClearPicks, t.CanCommit(), func() {
-		propertyFloatRow("Angle", "sm-cosbend-angle", "deg", &smUI.angle)
+		angleDegRow(s, "Angle", "sm-cosbend-angle", &smUI.angle)
 		t.SetAngle(float64(smUI.angle) / degPerRad)
 	})
 }

--- a/head/ui/shell_dialog.go
+++ b/head/ui/shell_dialog.go
@@ -41,7 +41,7 @@ func drawShellDialog(s *app.Session) {
 				sh.FaceCount() > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
 		}
 		if propertySection("Behavior") {
-			propertyFloatRow("Thickness", "shell-thickness", s.LengthUnitName(), &shellUI.thickness)
+			lengthCmRow(s, "Thickness", "shell-thickness", &shellUI.thickness)
 			sh.SetThickness(float64(shellUI.thickness))
 		}
 		native.Separator()

--- a/head/ui/sweep_dialog.go
+++ b/head/ui/sweep_dialog.go
@@ -36,7 +36,7 @@ func drawSweepDialog(s *app.Session) {
 	if native.Begin("Sweep") {
 		drawFeatureBreadcrumb("Sweep", sw.SourceSketchName())
 		drawSweepInputGeometry(sw)
-		drawSweepBehavior(sw)
+		drawSweepBehavior(s, sw)
 		drawSweepOutput(sw)
 		native.Separator()
 		drawCommitCancelButtons(s, sw.CanCommit())
@@ -65,11 +65,11 @@ func drawSweepInputGeometry(sw *app.SweepTool) {
 }
 
 // drawSweepBehavior is the Behavior section: the twist spread along the path.
-func drawSweepBehavior(sw *app.SweepTool) {
+func drawSweepBehavior(s *app.Session, sw *app.SweepTool) {
 	if !propertySection("Behavior") {
 		return
 	}
-	propertyFloatRow("Twist", "sweep-twist", "deg", &sweepUI.twistDeg)
+	angleDegRow(s, "Twist", "sweep-twist", &sweepUI.twistDeg)
 	sw.SetTwist(float64(sweepUI.twistDeg) * stdmath.Pi / 180)
 }
 

--- a/head/ui/thicken_dialog.go
+++ b/head/ui/thicken_dialog.go
@@ -32,7 +32,7 @@ func drawThickenDialog(s *app.Session) {
 	if native.Begin("Thicken") {
 		drawFeatureBreadcrumb("Thicken", "")
 		if propertySection("Behavior") {
-			propertyFloatRow("Thickness", "thicken-thickness", s.LengthUnitName(), &thickenUI.thickness)
+			lengthCmRow(s, "Thickness", "thicken-thickness", &thickenUI.thickness)
 			th.SetThickness(float64(thickenUI.thickness))
 			if i := propertyComboRow("Approximation", "thicken-approx", app.ApproximationOptions(), th.ApproximationIndex()); i >= 0 {
 				th.SetApproximationIndex(i)

--- a/head/ui/unit_rows.go
+++ b/head/ui/unit_rows.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "oblikovati.org/app"
+
+// Unit-aware property rows (Oblikovati/Oblikovati#146): a length/angle field
+// whose label AND value follow the document's preferred unit, replacing the
+// hand-rolled rows that hardcoded "mm"/"deg".
+//
+// They are drop-in replacements that preserve each dialog's existing buffer
+// convention — a length buffer in database centimetres, an angle buffer in
+// degrees — and only adapt what the field SHOWS. The on-screen value is derived
+// from the buffer every frame and written back ONLY when edited, so an untouched
+// inch/radian field never accumulates round-trip error.
+
+// lengthCmRow shows a length buffer held in database centimetres as a field in
+// the document's length unit. cmBuf stays in cm, so the dialog's existing
+// tool-write line keeps working unchanged.
+func lengthCmRow(s *app.Session, label, id string, cmBuf *float32) {
+	lengthCmRowHint(s, label, id, "", cmBuf)
+}
+
+// angleDegRow shows an angle buffer held in degrees as a field in the document's
+// angle unit. degBuf stays in degrees (its tool boundary already expects them).
+func angleDegRow(s *app.Session, label, id string, degBuf *float32) {
+	angleDegRowHint(s, label, id, "", degBuf)
+}
+
+// lengthCmRowHint / angleDegRowHint are the same rows with a free-text hint
+// appended after the unit label (e.g. " (+out / −in)" for a signed value).
+func lengthCmRowHint(s *app.Session, label, id, hint string, cmBuf *float32) {
+	disp := float32(s.LengthToDisplay(float64(*cmBuf)))
+	if propertyFloatRow(label, id, s.LengthUnitName()+hint, &disp) {
+		*cmBuf = float32(s.LengthFromDisplay(float64(disp)))
+	}
+}
+
+func angleDegRowHint(s *app.Session, label, id, hint string, degBuf *float32) {
+	disp := float32(s.AngleDegToDisplay(float64(*degBuf)))
+	if propertyFloatRow(label, id, s.AngleUnitName()+hint, &disp) {
+		*degBuf = float32(s.AngleDisplayToDeg(float64(disp)))
+	}
+}

--- a/head/ui/unit_rows_test.go
+++ b/head/ui/unit_rows_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hardcodedUnitLiterals are unit labels that must NOT be passed as a literal to
+// propertyFloatRow — a length/angle field's unit has to come from the document
+// (s.LengthUnitName()/s.AngleUnitName(), via lengthCmRow/angleDegRow) so it
+// follows the document's units (Oblikovati/Oblikovati#146).
+var hardcodedUnitLiterals = map[string]bool{
+	"mm": true, "cm": true, "m": true, "km": true,
+	"in": true, "ft": true, "deg": true, "rad": true, "°": true,
+}
+
+// TestNoHardcodedUnitLabelsInRows guards every dialog: a propertyFloatRow whose
+// suffix argument is a hardcoded unit string is a units bug waiting to happen.
+// Non-unit suffixes ("× (1 = off)", "") and dynamic s.*UnitName() calls are fine.
+func TestNoHardcodedUnitLabelsInRows(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	var offences []string
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		tree, err := parser.ParseFile(fset, f, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		ast.Inspect(tree, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isIdentCall(call, "propertyFloatRow") || len(call.Args) < 3 {
+				return true
+			}
+			if lit, ok := call.Args[2].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+				// Flag a bare unit ("deg") or a composite that LEADS with one
+				// ("deg (+out / −in)"); a non-unit hint ("× (1 = off)", "") is fine.
+				val := strings.Trim(lit.Value, "`\"")
+				if first, _, _ := strings.Cut(val, " "); hardcodedUnitLiterals[first] {
+					offences = append(offences, f+": propertyFloatRow suffix "+lit.Value)
+				}
+			}
+			return true
+		})
+	}
+	if len(offences) > 0 {
+		t.Errorf("hardcoded unit labels (use lengthCmRow/angleDegRow instead):\n  %s",
+			strings.Join(offences, "\n  "))
+	}
+}
+
+// isIdentCall reports whether call is a call to the named bare function.
+func isIdentCall(call *ast.CallExpr, name string) bool {
+	id, ok := call.Fun.(*ast.Ident)
+	return ok && id.Name == name
+}


### PR DESCRIPTION
## What

PBI-3 of #146 — every length/angle field in the part & sheet-metal tool dialogs now shows its **value and label** in the document's preferred unit.

Fixes two classes of bug:
1. **Hardcoded `"deg"` labels** (coil, hole, loft, sweep, sheet-metal flange/roll/lip/cosmetic-bend, draft) that ignored the document's angle unit.
2. **Length fields showing raw database centimetres** under an `mm`/`in` label — e.g. a 2 cm hole read **"2 mm"**. Affected hole, fillet, chamfer, shell, thicken, face-offset, coil pitch, and sheet-metal dimensions.

## How

- **`app`** — `Session` display converters over `DocumentUnits()`: `LengthToDisplay`/`LengthFromDisplay`, `AngleDegToDisplay`/`AngleDisplayToDeg`.
- **`head/ui`** — drift-free `lengthCmRow` / `angleDegRow` (+ `*Hint` variants) rows: the on-screen value is derived from the tool's database value each frame and written back **only on edit**, so an untouched inch/radian field never accumulates round-trip error. The buffers keep their existing convention (cm / degrees), so each dialog's tool-write line is unchanged.
- Migrated coil, hole, loft, sweep, fillet, chamfer, shell, draft, thicken, face-offset and all sheet-metal dialogs. Extrude, sketch dimensions, offset-plane and the sheet-metal **style** rule were already converting and are left as-is.
- A **guard test** (`unit_rows_test.go`) fails if any `propertyFloatRow` is passed a hardcoded unit label, so this can't regress.

## Live verification

`head/cmd/unitshot` opens the Hole dialog with the document in a chosen unit and captures the full window. The same 2 cm / 1 cm hole reads **20.000 / 10.000 mm** in a millimetre document and **0.787 / 0.394 in** in an inch document — labels following the unit:

| mm document | inch document |
|---|---|
| Diameter 20.000 mm, Depth 10.000 mm | Diameter 0.787 in, Depth 0.394 in |

## Tests

`app` converter tests (mm + inch/radian), the head guard test, and the driver's headless setup test. Builds, full test suite, and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)