### PR TITLE
fix(drawing): report a section view's parent over the wire

### DIFF
--- a/addin/router/drawing_views.go
+++ b/addin/router/drawing_views.go
@@ -199,13 +199,12 @@ func drawingViewInfo(v *drawing.DrawingView) wire.DrawingViewInfo {
 		Name: v.Name(), Type: v.Type().String(), Projected: v.IsProjected(),
 		Orientation: v.Orientation().String(), Scale: v.Scale(), Style: v.Style().String(),
 		CenterXMM: x, CenterYMM: y, VisibleCount: visible, HiddenCount: hidden,
+		BaseView: v.BaseViewName(), // the parent of any derived view (projected/auxiliary/section)
 	}
 	switch v.Type() {
 	case types.DrawingViewProjected:
-		info.BaseView = v.BaseViewName()
 		info.Direction = v.Direction().String()
 	case types.DrawingViewAuxiliary:
-		info.BaseView = v.BaseViewName()
 		info.FoldAngleDeg = v.FoldAngle() * 180 / math.Pi
 	}
 	return info


### PR DESCRIPTION
A follow-up to the section views work (#982). `drawingViewInfo` only set `baseView` for projected/auxiliary views, so a **section** view's `DrawingViewInfo` came back with an empty `baseView` over the wire — an add-in querying section views couldn't see their parent. Populate `BaseView` for any derived view (base views report empty, omitted by `omitempty`).

Surfaced by the bridge section e2e (which asserts the section view reports its parent). No API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)