### PR TITLE
feat(exchange): STEP import/export honor the document's length unit (#146)

### DIFF
--- a/kernel/exchange/step/geommap/placement_to_step.go
+++ b/kernel/exchange/step/geommap/placement_to_step.go
@@ -10,27 +10,29 @@ import (
 // Emitter writes kernel geometry into a part21.Writer, sharing identical leaf
 // entities (points, directions). It is the export counterpart of the from_step
 // mappers and the only place /source emits STEP geometry, keeping the encoding in
-// one module. divScale converts database mm back into the file's length unit.
+// one module. dbToFile scales each database-unit (centimetre) length into the
+// file's declared length unit.
 type Emitter struct {
 	w        *part21.Writer
-	mmToUnit float64 // multiply a mm length by this to get the file unit
+	dbToFile float64 // multiply a database-unit length by this to get the file-unit value
 }
 
-// NewEmitter builds an emitter writing into w, expressing lengths in file units
-// where one file unit is unitMM millimeters (so mm→unit is 1/unitMM).
-func NewEmitter(w *part21.Writer, unitMM float64) *Emitter {
-	if unitMM == 0 {
-		unitMM = 1
+// NewEmitter builds an emitter writing into w, scaling each database-unit length
+// by dbToFile to express it in the file's declared length unit (the
+// exchange.TranslationOptions.ExportScale). A zero scale is treated as 1.
+func NewEmitter(w *part21.Writer, dbToFile float64) *Emitter {
+	if dbToFile == 0 {
+		dbToFile = 1
 	}
-	return &Emitter{w: w, mmToUnit: 1 / unitMM}
+	return &Emitter{w: w, dbToFile: dbToFile}
 }
 
-// Point emits a CARTESIAN_POINT (shared) for p, scaled mm→file-unit, returning its id.
+// Point emits a CARTESIAN_POINT (shared) for p, scaled database-unit→file-unit, returning its id.
 func (e *Emitter) Point(p math.Point3) int {
 	coords := part21.FormatList(
-		part21.FormatReal(float64(p.X)*e.mmToUnit),
-		part21.FormatReal(float64(p.Y)*e.mmToUnit),
-		part21.FormatReal(float64(p.Z)*e.mmToUnit),
+		part21.FormatReal(float64(p.X)*e.dbToFile),
+		part21.FormatReal(float64(p.Y)*e.dbToFile),
+		part21.FormatReal(float64(p.Z)*e.dbToFile),
 	)
 	return e.w.AddShared("CARTESIAN_POINT", part21.QuoteString(""), coords)
 }
@@ -57,7 +59,7 @@ func (e *Emitter) Placement(origin math.Point3, axisZ, axisX math.Vector3) int {
 // Writer exposes the underlying part21 writer for the topology emitter.
 func (e *Emitter) Writer() *part21.Writer { return e.w }
 
-// LengthValue formats a mm length in file units as a Part 21 real.
-func (e *Emitter) LengthValue(mm float64) string {
-	return part21.FormatReal(mm * e.mmToUnit)
+// LengthValue formats a database-unit length in file units as a Part 21 real.
+func (e *Emitter) LengthValue(dbLen float64) string {
+	return part21.FormatReal(dbLen * e.dbToFile)
 }

--- a/kernel/exchange/step/geommap/surface_to_step_test.go
+++ b/kernel/exchange/step/geommap/surface_to_step_test.go
@@ -63,12 +63,12 @@ func TestCylinderRadiusRoundTrips(t *testing.T) {
 
 func TestEmitterWriterScalingAndSharing(t *testing.T) {
 	w := part21.NewWriter()
-	e := NewEmitter(w, 2.0)
+	e := NewEmitter(w, 0.5) // dbToFile = 0.5 (e.g. exporting cm geometry to a 2 cm-per-unit file)
 	if e.Writer() != w {
 		t.Fatal("Writer did not expose the backing writer")
 	}
 	if got := e.LengthValue(6); got != "3." {
-		t.Fatalf("LengthValue with 2mm units = %q, want 3.", got)
+		t.Fatalf("LengthValue with dbToFile 0.5 = %q, want 3.", got)
 	}
 	p1 := e.Point(math.P3(2, 4, 6))
 	p2 := e.Point(math.P3(2, 4, 6))

--- a/kernel/exchange/step/reader.go
+++ b/kernel/exchange/step/reader.go
@@ -31,8 +31,8 @@ func (Reader) ImportSolids(data []byte, opts exchange.TranslationOptions) ([]*to
 	if err != nil {
 		return nil, nil, err
 	}
-	scale, warns := unitScale(f.Graph)
-	bodies, bw, err := importAllBreps(f.Graph, scale)
+	mmPerUnit, warns := unitScale(f.Graph)
+	bodies, bw, err := importAllBreps(f.Graph, opts.ImportScale(mmPerUnit))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kernel/exchange/step/units.go
+++ b/kernel/exchange/step/units.go
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 // Package step is the AP203/214/242 reader/writer facade over the part21, schema,
-// geommap and topomap layers. units.go resolves a file's length unit into the
-// scale factor that converts file lengths into the kernel's database unit (mm).
+// geommap and topomap layers. units.go resolves a file's declared length unit into
+// millimetres per file unit; the reader then divides by the database-unit size
+// (exchange.TranslationOptions.TargetUnitMM — 10 mm, since the kernel works in
+// centimetres) to scale file lengths into database units.
 package step
 
 import (

--- a/kernel/exchange/step/writer_facade.go
+++ b/kernel/exchange/step/writer_facade.go
@@ -3,6 +3,8 @@
 package step
 
 import (
+	"fmt"
+
 	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/kernel/exchange/step/geommap"
 	"oblikovati.org/kernel/exchange/step/part21"
@@ -23,14 +25,18 @@ type Writer struct{}
 // compile-time assertion that Writer is a BodyExporter.
 var _ exchange.BodyExporter = Writer{}
 
-// ExportSolids writes the bodies as one AP203 file. Lengths are emitted in mm (the
-// kernel's database unit) so the file declares a millimeter unit. A body with a
-// surface type that cannot be exported yields an error (tessellated fallback is
-// PBI-E); the geometry that does export is byte-stable for a given body.
+// ExportSolids writes the bodies as one AP203 file in opts.FileUnit (millimetres
+// when unset), scaling the kernel's centimetre geometry into that unit and
+// declaring it so the lengths are unambiguous on re-import. A body with a surface
+// type that cannot be exported yields an error (tessellated fallback is PBI-E);
+// the geometry that does export is byte-stable for a given body and unit.
 func (Writer) ExportSolids(bodies []*topo.Body, opts exchange.TranslationOptions) ([]byte, []string, error) {
+	if _, ok := opts.FileUnitMM(); !ok {
+		return nil, nil, fmt.Errorf("step export: unknown file unit %q", opts.FileUnit)
+	}
 	w := part21.NewWriter()
-	emit := geommap.NewEmitter(w, 1.0) // 1 file unit = 1 mm
-	emitUnitContext(w)
+	emit := geommap.NewEmitter(w, opts.ExportScale()) // database-unit (cm) → file unit
+	emitUnitContext(w, opts.FileUnit)
 	for _, body := range bodies {
 		if _, err := topomap.BodyToStep(emit, body); err != nil {
 			return nil, nil, err
@@ -39,11 +45,38 @@ func (Writer) ExportSolids(bodies []*topo.Body, opts exchange.TranslationOptions
 	return w.Emit(ap203Header()), nil, nil
 }
 
-// emitUnitContext emits the millimeter SI length unit + a unit-assigned context, so
-// the file's lengths are unambiguous on re-import.
-func emitUnitContext(w *part21.Writer) int {
-	mm := w.AddRaw("(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT(.MILLI.,.METRE.))")
-	return w.Add("GLOBAL_UNIT_ASSIGNED_CONTEXT", part21.FormatList(part21.Ref(mm)))
+// emitUnitContext emits the file's SI (mm/cm/m) or conversion-based (in/ft) length
+// unit plus a unit-assigned context, so the file's lengths are unambiguous on
+// re-import. An empty unit defaults to millimetres.
+func emitUnitContext(w *part21.Writer, fileUnit string) int {
+	return w.Add("GLOBAL_UNIT_ASSIGNED_CONTEXT", part21.FormatList(part21.Ref(lengthUnitRef(w, fileUnit))))
+}
+
+// lengthUnitRef emits the LENGTH_UNIT entity for fileUnit and returns its id.
+func lengthUnitRef(w *part21.Writer, fileUnit string) int {
+	switch fileUnit {
+	case "cm":
+		return w.AddRaw("(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT(.CENTI.,.METRE.))")
+	case "m":
+		return w.AddRaw("(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT($,.METRE.))")
+	case "in":
+		return conversionLengthUnit(w, "INCH", 0.0254)
+	case "ft":
+		return conversionLengthUnit(w, "FOOT", 0.3048)
+	default: // "" or "mm"
+		return w.AddRaw("(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT(.MILLI.,.METRE.))")
+	}
+}
+
+// conversionLengthUnit emits a CONVERSION_BASED_UNIT of metresPerUnit metres (an
+// imperial length), returning its id. The reader's units_conversion.go parses it.
+func conversionLengthUnit(w *part21.Writer, name string, metresPerUnit float64) int {
+	dim := w.AddRaw("DIMENSIONAL_EXPONENTS(1.,0.,0.,0.,0.,0.,0.)")
+	metre := w.AddRaw("(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT($,.METRE.))")
+	measure := w.AddRaw("LENGTH_MEASURE_WITH_UNIT(LENGTH_MEASURE(" +
+		part21.FormatReal(metresPerUnit) + ")," + part21.Ref(metre) + ")")
+	return w.AddRaw("(CONVERSION_BASED_UNIT(" + part21.QuoteString(name) + "," +
+		part21.Ref(measure) + ")LENGTH_UNIT()NAMED_UNIT(" + part21.Ref(dim) + "))")
 }
 
 // ap203Header builds the HEADER for an exported AP203 file.

--- a/kernel/exchange/step/writer_units_test.go
+++ b/kernel/exchange/step/writer_units_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package step
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// cmBox is a 6×6×6 database-unit (centimetre) cube — 216 cm³.
+func cmBox(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(6, 6, 6), "box")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// TestExportHonorsFileUnit checks that an export declares the requested file unit
+// and scales the kernel's centimetre geometry into it (#146): a 6 cm cube becomes
+// "60" in a millimetre file and "6" in a centimetre file, and inch uses a
+// conversion-based unit. The centimetre kernel is anchored by DBUnitMM.
+func TestExportHonorsFileUnit(t *testing.T) {
+	box := cmBox(t)
+
+	mm, _, err := Writer{}.ExportSolids([]*topo.Body{box},
+		exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM, FileUnit: "mm"})
+	if err != nil {
+		t.Fatalf("export mm: %v", err)
+	}
+	if !strings.Contains(string(mm), "SI_UNIT(.MILLI.,.METRE.)") {
+		t.Error("mm export must declare a millimetre SI unit")
+	}
+	if !strings.Contains(string(mm), "60.") {
+		t.Error("a 6 cm edge must be written as 60 in a millimetre file")
+	}
+
+	cm, _, err := Writer{}.ExportSolids([]*topo.Body{box},
+		exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM, FileUnit: "cm"})
+	if err != nil {
+		t.Fatalf("export cm: %v", err)
+	}
+	if !strings.Contains(string(cm), "SI_UNIT(.CENTI.,.METRE.)") {
+		t.Error("cm export must declare a centimetre SI unit")
+	}
+
+	in, _, err := Writer{}.ExportSolids([]*topo.Body{box},
+		exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM, FileUnit: "in"})
+	if err != nil {
+		t.Fatalf("export in: %v", err)
+	}
+	if !strings.Contains(string(in), "CONVERSION_BASED_UNIT") {
+		t.Error("inch export must declare a conversion-based unit")
+	}
+
+	_, _, badErr := Writer{}.ExportSolids([]*topo.Body{box}, exchange.TranslationOptions{FileUnit: "furlong"})
+	if badErr == nil {
+		t.Error("an unknown file unit must error")
+	}
+}
+
+// TestExportImportUnitRoundTrip checks the physical size survives a round-trip in
+// each file unit: export the 6 cm cube, re-import into the centimetre kernel, and
+// the volume is 216 cm³ regardless of the file unit used.
+func TestExportImportUnitRoundTrip(t *testing.T) {
+	box := cmBox(t)
+	for _, unit := range []string{"mm", "cm", "m", "in", "ft"} {
+		data, _, err := Writer{}.ExportSolids([]*topo.Body{box},
+			exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM, FileUnit: unit})
+		if err != nil {
+			t.Fatalf("export %s: %v", unit, err)
+		}
+		bodies, _, err := Reader{}.ImportSolids(data,
+			exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM})
+		if err != nil || len(bodies) != 1 {
+			t.Fatalf("re-import %s: %v (%d bodies)", unit, err, len(bodies))
+		}
+		got := ops.BodyGeometryProperties(bodies[0], ops.DefaultQuality()).Volume
+		if rel := (got - 216) / 216; rel < -0.01 || rel > 0.01 {
+			t.Errorf("%s round-trip volume = %.3f cm³, want 216", unit, got)
+		}
+	}
+}
+
+// TestImportScalesFileUnitToCentimetres pins the import-side fix: a millimetre STEP
+// (declared mm) of a 60 mm cube imports as a 6 cm (216 cm³) body, not 60 cm.
+func TestImportScalesFileUnitToCentimetres(t *testing.T) {
+	// A 60 mm cube authored by exporting the 6 cm kernel box in millimetres.
+	mmFile, _, err := Writer{}.ExportSolids([]*topo.Body{cmBox(t)},
+		exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM, FileUnit: "mm"})
+	if err != nil {
+		t.Fatalf("author mm file: %v", err)
+	}
+	bodies, _, err := Reader{}.ImportSolids(mmFile,
+		exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM})
+	if err != nil || len(bodies) != 1 {
+		t.Fatalf("import: %v (%d bodies)", err, len(bodies))
+	}
+	got := ops.BodyGeometryProperties(bodies[0], ops.DefaultQuality()).Volume
+	if rel := (got - 216) / 216; rel < -0.01 || rel > 0.01 {
+		t.Errorf("imported volume = %.3f cm³, want 216 (a 60 mm cube is 6 cm)", got)
+	}
+}

--- a/kernel/exchange/translate.go
+++ b/kernel/exchange/translate.go
@@ -19,10 +19,65 @@ import "oblikovati.org/kernel/topo"
 //	body, warns, err := imp.ImportSolids(data, opts)
 type TranslationOptions struct {
 	// TargetUnitMM is the database-unit size in millimeters (1 ⇒ the kernel works
-	// in mm). Imported lengths are scaled from the file's unit into this unit.
+	// in mm; 10 ⇒ centimetres). Imported lengths are scaled from the file's unit
+	// into this unit; exported lengths are scaled from it into the file unit.
 	TargetUnitMM float64
+	// FileUnit is the length unit an EXPORT writes (and declares) — "mm", "cm",
+	// "m", "in" or "ft". Empty ⇒ millimetres. It is ignored on import, where the
+	// unit is read from the file.
+	FileUnit string
 	// ChordTolerance bounds curve/surface faceting used by validation/mass props.
 	ChordTolerance float64
+}
+
+// DBUnitMM is the database-unit size in millimetres the model works in: the
+// kernel's geometry is centimetres, so one database unit is 10 mm. Translators
+// receive this via [TranslationOptions.TargetUnitMM]; it is the single place the
+// model↔file unit scale is anchored (Oblikovati/Oblikovati#146).
+const DBUnitMM = 10.0
+
+// mmPerFileUnit is the millimetre size of a named export unit. It is the codec's
+// own small unit vocabulary so the kernel exchange need not depend on the model's
+// parameter engine. Unknown/empty names fall back to millimetres.
+var mmPerFileUnit = map[string]float64{
+	"mm": 1, "cm": 10, "m": 1000, "in": 25.4, "ft": 304.8,
+}
+
+// FileUnitMM returns the millimetre size of opts.FileUnit (millimetres when unset
+// or unknown), plus whether the name was recognised.
+func (o TranslationOptions) FileUnitMM() (float64, bool) {
+	if o.FileUnit == "" {
+		return 1, true
+	}
+	mm, ok := mmPerFileUnit[o.FileUnit]
+	if !ok {
+		return 1, false
+	}
+	return mm, true
+}
+
+// dbUnitMM returns the effective database-unit size in millimetres, defaulting a
+// zero TargetUnitMM to 1 (the historical millimetre kernel) so existing direct
+// callers are unaffected.
+func (o TranslationOptions) dbUnitMM() float64 {
+	if o.TargetUnitMM == 0 {
+		return 1
+	}
+	return o.TargetUnitMM
+}
+
+// ImportScale is the file→database length factor: a length in the file's unit
+// times this yields database units. The reader resolves the file unit (mm per
+// file unit) and divides by the database unit size.
+func (o TranslationOptions) ImportScale(mmPerFileUnit float64) float64 {
+	return mmPerFileUnit / o.dbUnitMM()
+}
+
+// ExportScale is the database→file length factor: a database-unit length times
+// this yields a value in opts.FileUnit.
+func (o TranslationOptions) ExportScale() float64 {
+	mm, _ := o.FileUnitMM()
+	return o.dbUnitMM() / mm
 }
 
 // BodyImporter turns foreign-format bytes into kernel bodies. Implementations

--- a/kernel/exchange/translate_test.go
+++ b/kernel/exchange/translate_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// TestUnitScales pins the database↔file length scaling helpers (#146). The
+// database unit is the centimetre (DBUnitMM = 10 mm).
+func TestUnitScales(t *testing.T) {
+	if DBUnitMM != 10 {
+		t.Fatalf("DBUnitMM = %g, want 10 (the kernel works in centimetres)", DBUnitMM)
+	}
+
+	cm := TranslationOptions{TargetUnitMM: DBUnitMM}
+	// Import: a millimetre file (1 mm per unit) → ×0.1 into cm; an inch file → ×2.54.
+	if got := cm.ImportScale(1); !approx(got, 0.1) {
+		t.Errorf("ImportScale(mm) = %g, want 0.1", got)
+	}
+	if got := cm.ImportScale(25.4); !approx(got, 2.54) {
+		t.Errorf("ImportScale(in) = %g, want 2.54", got)
+	}
+
+	// Export: cm → mm is ×10, cm → cm is ×1, cm → inch is /2.54.
+	for unit, want := range map[string]float64{"mm": 10, "cm": 1, "m": 0.01, "in": 10.0 / 25.4} {
+		o := TranslationOptions{TargetUnitMM: DBUnitMM, FileUnit: unit}
+		if got := o.ExportScale(); !approx(got, want) {
+			t.Errorf("ExportScale(%q) = %g, want %g", unit, got, want)
+		}
+	}
+
+	// FileUnitMM reports the unit's mm size and recognition; unknown is rejected.
+	if mm, ok := cm.FileUnitMM(); !ok || mm != 1 { // empty FileUnit ⇒ mm
+		t.Errorf("FileUnitMM(empty) = (%g, %v), want (1, true)", mm, ok)
+	}
+	if mm, ok := (TranslationOptions{FileUnit: "in"}).FileUnitMM(); !ok || mm != 25.4 {
+		t.Errorf("FileUnitMM(in) = (%g, %v), want (25.4, true)", mm, ok)
+	}
+	if _, ok := (TranslationOptions{FileUnit: "furlong"}).FileUnitMM(); ok {
+		t.Error("FileUnitMM must reject an unknown unit")
+	}
+
+	// A zero TargetUnitMM defaults to the historical 1 mm kernel, so direct callers
+	// that pass the zero value are unaffected.
+	if got := (TranslationOptions{}).ImportScale(1); !approx(got, 1) {
+		t.Errorf("zero-value ImportScale(mm) = %g, want 1", got)
+	}
+}

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -14,6 +14,7 @@ import (
 	"oblikovati.org/kernel/exchange/step"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
 )
 
 // Import reads path as format into the part as imported-body features — routing mesh formats
@@ -73,7 +74,7 @@ func Export(part *compdef.PartComponentDefinition, path string, format types.Exc
 	case format.IsMesh():
 		data, tris, err = meshio.ExportBodies(format, bodies, res)
 	case format == types.FormatSTEP:
-		data, warns, err = step.Writer{}.ExportSolids(bodies, exchange.TranslationOptions{TargetUnitMM: 1})
+		data, warns, err = step.Writer{}.ExportSolids(bodies, exportUnits(part))
 	default:
 		return ExportResult{}, fmt.Errorf("export: unsupported format %q (want stl|obj|3mf|step)", format)
 	}
@@ -84,6 +85,17 @@ func Export(part *compdef.PartComponentDefinition, path string, format types.Exc
 		return ExportResult{}, fmt.Errorf("export: write %q: %w", path, err)
 	}
 	return ExportResult{TriangleCount: tris, Warnings: warns}, nil
+}
+
+// exportUnits builds the translation options for an export: the kernel works in
+// centimetres (TargetUnitMM = exchange.DBUnitMM), and the file is written in the
+// document's preferred length unit so the exported numbers match what the user
+// sees (Oblikovati/Oblikovati#146).
+func exportUnits(part *compdef.PartComponentDefinition) exchange.TranslationOptions {
+	return exchange.TranslationOptions{
+		TargetUnitMM: exchange.DBUnitMM,
+		FileUnit:     part.Units().PreferredName(param.Length),
+	}
 }
 
 // FormatFromPath infers the exchange format from a file's extension (case-insensitive), so the

--- a/model/exchange/dispatch_test.go
+++ b/model/exchange/dispatch_test.go
@@ -3,7 +3,9 @@
 package exchange_test
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"oblikovati.org/api/types"
@@ -85,4 +87,34 @@ func relErr(a, b float64) float64 {
 		return -d
 	}
 	return d
+}
+
+// TestStepExportDeclaresDocumentUnit checks the dispatch threads the document's
+// preferred length unit into the STEP export's declared unit (#146): the same
+// part exports as inch or centimetre depending on its units.
+func TestStepExportDeclaresDocumentUnit(t *testing.T) {
+	part := compdef.NewPartComponentDefinition()
+	if _, err := exchange.Import(part, stepFixture("cube.step"), types.FormatSTEP); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	for unit, marker := range map[string]string{
+		"in": "CONVERSION_BASED_UNIT",
+		"cm": "SI_UNIT(.CENTI.,.METRE.)",
+		"mm": "SI_UNIT(.MILLI.,.METRE.)",
+	} {
+		if err := part.SetLengthUnit(unit); err != nil {
+			t.Fatalf("SetLengthUnit(%q): %v", unit, err)
+		}
+		out := filepath.Join(t.TempDir(), "u.step")
+		if _, err := exchange.Export(part, out, types.FormatSTEP, ""); err != nil {
+			t.Fatalf("export %s: %v", unit, err)
+		}
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("read %s: %v", unit, err)
+		}
+		if !strings.Contains(string(data), marker) {
+			t.Errorf("a %q document's STEP must declare %q", unit, marker)
+		}
+	}
 }

--- a/model/feature/serialize_import.go
+++ b/model/feature/serialize_import.go
@@ -30,7 +30,8 @@ func ImportBodies(format types.ExchangeFormat, path string) ([]*topo.Body, []str
 func ImportBodiesFromData(format types.ExchangeFormat, data []byte) ([]*topo.Body, []string, error) {
 	switch {
 	case format == types.FormatSTEP:
-		return step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: 1})
+		// The kernel works in centimetres; the reader scales the file's declared unit into it.
+		return step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM})
 	case format.IsMesh():
 		body, warns, err := meshio.ImportBody(format, data, fmt.Sprintf("import:%s#0", format), 0)
 		if err != nil {

--- a/model/param/doc.go
+++ b/model/param/doc.go
@@ -18,4 +18,14 @@
 //     ([UnitsOfMeasure]).
 //   - expression references bind by stable [ID], not display text, so
 //     renaming a parameter is a relabel — never a global string rewrite.
+//
+// Unit system, end to end (Oblikovati/Oblikovati#146): the database length unit
+// is the CENTIMETRE — the same unit the geometry kernel's coordinates use, so a
+// Quantity value, a sketch coordinate, and a topo vertex all share one scale (no
+// hidden conversion between the parameter and geometry layers). Display units are
+// a presentation choice on top ([UnitsOfMeasure] turns 6 cm into "60 mm" or
+// "2.36 in"). Foreign-format exchange is the only place lengths leave this unit:
+// kernel/exchange scales database centimetres to/from a file's declared unit via
+// exchange.TranslationOptions (TargetUnitMM = exchange.DBUnitMM = 10 mm), and an
+// export writes the document's preferred unit.
 package param


### PR DESCRIPTION
## What

PBI-4 (STEP) of #146. The geometry kernel works in **centimetres**, but the STEP codec assumed **millimetres** — it declared `MILLI·METRE` for cm coordinates and imported a file's mm values 1:1 into the cm kernel. That's a silent **10× scale error** vs external tools (a 6 cm cube exported as "6", read as 6 mm), hidden because our own round-trip is self-consistent. This makes the STEP seam unit-correct and lets an export use the document's unit.

## How

- **`kernel/exchange`** — `TranslationOptions` gains `FileUnit` (the export unit) and helpers: `DBUnitMM = 10` (the kernel is cm), `ImportScale`, `ExportScale`, `FileUnitMM`. The database unit is now documented as the centimetre the kernel actually uses.
- **STEP reader** — `scale = mm-per-file-unit ÷ TargetUnitMM`, so a mm file lands as cm (was treated as mm → 10× too big).
- **STEP writer** — scales cm→`FileUnit` and declares it: SI for mm/cm/m, `CONVERSION_BASED_UNIT` for in/ft (the reader already parses both).
- **`model`** — `exchange.Export` passes the document's preferred length unit; the shared importer scales into centimetres.
- **docs** — corrected the misleading "kernel works in mm" comments (STEP writer/units, `TranslationOptions`) and added one end-to-end unit-system note in `model/param/doc.go`: db = cm, geometry shares it, exchange is the only place lengths leave it.

## Verified

A 6 cm cube exports as **60** in a mm file, **6** in a cm file, conversion-based in inch; re-import yields **216 cm³** in every unit; a 60 mm STEP imports as **6 cm** (the 10× import fix). Kernel + dispatch tests; 100% new-code coverage.

## Scope note

Mesh (STL/OBJ/3MF) and DXF/DWG unit handling are the same class of fix and follow in a separate change (they need their own scale plumbing + tests). The kernel geometry representation (cm) is untouched, per guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)