### PR TITLE
feat(drawing): break views — compressed view with break lines (M14-F02 PBI-140)

### DIFF
--- a/addin/router/drawing_views.go
+++ b/addin/router/drawing_views.go
@@ -26,6 +26,7 @@ func (r *Router) registerDrawingViewHandlers() {
 	r.handlers[wire.MethodDrawingViewsAddAuxiliary] = drawingViewsAddAuxiliary
 	r.handlers[wire.MethodDrawingViewsAddSection] = drawingViewsAddSection
 	r.handlers[wire.MethodDrawingViewsAddDetail] = drawingViewsAddDetail
+	r.handlers[wire.MethodDrawingViewsAddBreak] = drawingViewsAddBreak
 	r.handlers[wire.MethodDrawingViewsDelete] = drawingViewsDelete
 	r.handlers[wire.MethodDrawingViewsCurves] = drawingViewsCurves
 }
@@ -159,6 +160,34 @@ func drawingViewsAddDetail(s *app.Session, raw json.RawMessage) (json.RawMessage
 	v, err := views.AddDetail(drawing.DetailViewSpec{
 		Name: in.Name, ParentView: in.ParentView, BoundaryX: in.BoundaryXMM, BoundaryY: in.BoundaryYMM,
 		RadiusMM: in.RadiusMM, Scale: in.Scale, CenterX: in.CenterXMM, CenterY: in.CenterYMM,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.ActiveDocument().MarkDirty()
+	return json.Marshal(wire.ViewResult{View: drawingViewInfo(v)})
+}
+
+func drawingViewsAddBreak(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	views, err := activeSheetViews(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.AddBreakViewArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	orient := types.BreakHorizontal
+	if in.Orientation != "" {
+		o, ok := types.ParseBreakOrientation(in.Orientation)
+		if !ok {
+			return nil, fmt.Errorf("drawing: unknown break orientation %q", in.Orientation)
+		}
+		orient = o
+	}
+	v, err := views.AddBreak(drawing.BreakViewSpec{
+		Name: in.Name, ParentView: in.ParentView, Orientation: orient,
+		GapStart: in.GapStartMM, GapEnd: in.GapEndMM, CenterX: in.CenterXMM, CenterY: in.CenterYMM,
 	})
 	if err != nil {
 		return nil, err

--- a/addin/router/drawing_views_test.go
+++ b/addin/router/drawing_views_test.go
@@ -82,10 +82,16 @@ func TestDrawingViewsLifecycleOverWire(t *testing.T) {
 		t.Fatalf("detail view = %+v, want a detail off FRONT", det.View)
 	}
 
+	var brk wire.ViewResult
+	call(t, r, s, "drawingViews.addBreak", `{"name":"BRK","parentView":"FRONT","orientation":"horizontal","gapStartMm":110,"gapEndMm":130,"centerXmm":120,"centerYmm":320}`, &brk)
+	if brk.View.Type != "break" || brk.View.BaseView != "FRONT" {
+		t.Fatalf("break view = %+v, want a break off FRONT", brk.View)
+	}
+
 	var list wire.ListDrawingViewsResult
 	call(t, r, s, "drawingViews.list", "{}", &list)
-	if len(list.Views) != 4 {
-		t.Fatalf("views = %d, want 4 (base + projected + auxiliary + detail)", len(list.Views))
+	if len(list.Views) != 5 {
+		t.Fatalf("views = %d, want 5 (base + projected + auxiliary + detail + break)", len(list.Views))
 	}
 
 	var curves wire.ViewCurvesResult

--- a/app/commands_drawing.go
+++ b/app/commands_drawing.go
@@ -49,6 +49,9 @@ func drawingTabCommands() []*CommandDefinition {
 		drawingToolCommand("Detail View", "Views", "drawing-detail-view",
 			"Magnify a circular region of a base view at a larger scale.",
 			func() Tool { return NewDetailViewTool() }),
+		drawingToolCommand("Break View", "Views", "drawing-break-view",
+			"Compress a base view by removing a band (horizontal or vertical) with break lines at the join.",
+			func() Tool { return NewBreakViewTool() }),
 		NewCommand("Drawing.ExportDXF", "Export DXF", "Output", requestDrawingDXFExport).
 			WithTab("Drawing").WithRibbons(DrawingRibbon).WithEnable(hasActiveDrawing).
 			WithIcon("drawing-export-dxf").WithButtonStyle(LargeIconButton).

--- a/app/drawing_view_tools.go
+++ b/app/drawing_view_tools.go
@@ -460,6 +460,102 @@ func maxf64(a, b float64) float64 {
 	return b
 }
 
+// breakOrientations is the orientation choice for the Break View tool (index → orientation).
+var breakOrientations = []struct {
+	label  string
+	orient types.BreakOrientation
+}{
+	{"Horizontal", types.BreakHorizontal}, {"Vertical", types.BreakVertical},
+}
+
+// BreakViewTool compresses a base view by removing its middle third along a horizontal or
+// vertical axis; the preview follows the cursor and a click drops the break view. (A
+// user-dragged gap is a follow-up; the middle third is the common case.)
+type BreakViewTool struct {
+	derivedViewTool
+	orient int
+}
+
+// NewBreakViewTool creates the tool; its base-view list is captured on Start.
+func NewBreakViewTool() *BreakViewTool {
+	return &BreakViewTool{derivedViewTool: derivedViewTool{centerX: 150, centerY: 250}}
+}
+
+func (t *BreakViewTool) Name() string { return "Break View" }
+
+// gapOn returns the removed band (sheet mm) — the middle third of the named base view along the
+// chosen axis; ok is false when the view has no geometry yet.
+func (t *BreakViewTool) gapOn(s *Session, parent string) (orient types.BreakOrientation, start, end float64, ok bool) {
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	v, found := c.Sheets().Active().Views().ByName(parent)
+	if !found {
+		return 0, 0, 0, false
+	}
+	minX, minY, maxX, maxY, has := v.BoundsMM()
+	if !has {
+		return 0, 0, 0, false
+	}
+	o := breakOrientations[clampIndex(t.orient, len(breakOrientations))].orient
+	lo, hi := minX, maxX
+	if o == types.BreakVertical {
+		lo, hi = minY, maxY
+	}
+	return o, lo + (hi-lo)/3, lo + 2*(hi-lo)/3, true
+}
+
+// PreviewCurves compresses the chosen parent at the origin, cached until parent/orientation change.
+func (t *BreakViewTool) PreviewCurves(s *Session) []drawing.DrawingCurve {
+	parent := t.parent()
+	if parent == "" {
+		return nil
+	}
+	key := fmt.Sprintf("%s/%d", parent, t.orient)
+	if key != t.previewKey {
+		t.preview = nil
+		if o, start, end, ok := t.gapOn(s, parent); ok {
+			c, _ := ActiveDrawing(s)
+			t.preview, _ = c.Sheets().Active().Views().PreviewBreak(parent, o, start, end)
+		}
+		t.previewKey = key
+	}
+	return t.preview
+}
+
+// Commit compresses the selected base view by removing its middle third.
+func (t *BreakViewTool) Commit(s *Session) error {
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		return err
+	}
+	parent := t.parent()
+	if parent == "" {
+		return fmt.Errorf("drawing: no base view to break — add a base view first")
+	}
+	o, start, end, ok := t.gapOn(s, parent)
+	if !ok {
+		return fmt.Errorf("drawing: base view %q has no geometry to break", parent)
+	}
+	if _, err := c.Sheets().Active().Views().AddBreak(drawing.BreakViewSpec{
+		ParentView: parent, Orientation: o, GapStart: start, GapEnd: end, CenterX: t.centerX, CenterY: t.centerY,
+	}); err != nil {
+		return err
+	}
+	s.ActiveDocument().MarkDirty()
+	return nil
+}
+
+// Params exposes the base-view and break-orientation choices for the property dialog.
+func (t *BreakViewTool) Params() ToolParams {
+	return ToolParams{Choices: []ChoiceParam{
+		t.baseChoice("Base View"),
+		{Label: "Break", Options: labelsOf(len(breakOrientations), func(i int) string { return breakOrientations[i].label }),
+			Get: func() int { return t.orient }, Set: func(i int) { t.orient = i }},
+	}}
+}
+
 // baseViewNames lists the active sheet's base views (the candidates a projected view derives
 // from); empty when no drawing is active.
 func baseViewNames(s *Session) []string {

--- a/app/drawing_view_tools_test.go
+++ b/app/drawing_view_tools_test.go
@@ -219,6 +219,41 @@ func TestDetailViewToolWithoutBaseView(t *testing.T) {
 	}
 }
 
+func TestBreakViewToolCompressesBase(t *testing.T) {
+	s := drawingWithFrontBase(t)
+	c, _ := ActiveDrawing(s)
+	tool := NewBreakViewTool()
+	tool.Start(s)
+	if tool.Name() != "Break View" || !tool.CanCommit() {
+		t.Fatalf("break tool name/commit wrong: %q / %v", tool.Name(), tool.CanCommit())
+	}
+	tool.Params().Choices[1].Set(1) // vertical break
+	tool.PreviewCurves(s)
+	tool.SetPlacement(260, 220)
+	if err := tool.Commit(s); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	v, ok := c.Sheets().Active().Views().ByName("VIEW:2")
+	if !ok || v.Type() != types.DrawingViewBreak {
+		t.Fatalf("break view not added correctly (ok=%v)", ok)
+	}
+}
+
+func TestBreakViewToolWithoutBaseView(t *testing.T) {
+	s := drawingWithModelSession(t)
+	tool := NewBreakViewTool()
+	tool.Start(s)
+	if tool.CanCommit() {
+		t.Error("break tool can commit with no base view, want it disabled")
+	}
+	if got := tool.PreviewCurves(s); got != nil {
+		t.Errorf("preview with no base view = %d curves, want none", len(got))
+	}
+	if err := tool.Commit(s); err == nil {
+		t.Error("Commit with no base view = ok, want error")
+	}
+}
+
 func TestPickSelectEditDeleteDrawingView(t *testing.T) {
 	s := drawingWithModelSession(t)
 	c, _ := ActiveDrawing(s)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.24.0
+	oblikovati.org/api v0.25.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.24.0
+	oblikovati.org/api v0.25.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/icon/assets/drawing-break-view.svg
+++ b/head/icon/assets/drawing-break-view.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 8 H8 M16 8 H21 M3 16 H8 M16 16 H21"/><path d="M11 4 L13 7 L11 10 L13 13 L11 16 L13 19 L11 20" stroke="#ff0000" stroke-width="1.4"/></svg>

--- a/head/ui/sheet_canvas.go
+++ b/head/ui/sheet_canvas.go
@@ -121,6 +121,8 @@ func drawViewCurve(face rect, c drawing.DrawingCurve) {
 		native.DrawLine(ax, ay, bx, by, viewVisibleInk, 2.2)
 	case types.DrawingHatchCurve:
 		native.DrawLine(ax, ay, bx, by, sheetFaint, 1)
+	case types.DrawingBreakCurve:
+		native.DrawLine(ax, ay, bx, by, viewVisibleInk, 1)
 	default:
 		if c.IsVisible() {
 			native.DrawLine(ax, ay, bx, by, viewVisibleInk, 1.4)

--- a/model/drawing/break_view_test.go
+++ b/model/drawing/break_view_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// TestAddBreakViewCompressesAndGlyphs cuts a horizontal break through the middle of a FRONT
+// view: the result keeps the model edges (minus the removed band), is narrower than the parent,
+// and carries break-line glyph curves at the join.
+func TestAddBreakViewCompressesAndGlyphs(t *testing.T) {
+	c := drawingWithBox(t)
+	views := c.Sheets().Active().Views()
+	frontBase(t, views)
+	front, _ := views.ByName("FRONT")
+	minX, _, maxX, _, _ := front.BoundsMM()
+	// Remove the middle third of the width.
+	gapStart := minX + (maxX-minX)/3
+	gapEnd := minX + 2*(maxX-minX)/3
+
+	brk, err := views.AddBreak(BreakViewSpec{
+		Name: "BREAK-A", ParentView: "FRONT", Orientation: types.BreakHorizontal,
+		GapStart: gapStart, GapEnd: gapEnd, CenterX: 100, CenterY: 220,
+	})
+	if err != nil {
+		t.Fatalf("AddBreak: %v", err)
+	}
+	if brk.Type() != types.DrawingViewBreak || brk.BreakOrientation() != types.BreakHorizontal {
+		t.Fatalf("break view = type %v orient %v, want break/horizontal", brk.Type(), brk.BreakOrientation())
+	}
+	var glyphs int
+	for _, cv := range brk.Curves() {
+		if cv.Kind() == types.DrawingBreakCurve {
+			glyphs++
+		}
+	}
+	if glyphs == 0 {
+		t.Error("break view has no break-line glyph curves")
+	}
+	// The compressed view is narrower than the parent by ~the removed band width.
+	bMinX, _, bMaxX, _, _ := brk.BoundsMM()
+	if bMaxX-bMinX >= maxX-minX {
+		t.Errorf("break view width %g not narrower than parent %g — band not removed", bMaxX-bMinX, maxX-minX)
+	}
+}
+
+// TestBreakRejectsNonBaseParent checks a break can only compress a base view.
+func TestBreakRejectsNonBaseParent(t *testing.T) {
+	c := drawingWithBox(t)
+	views := c.Sheets().Active().Views()
+	if _, err := views.AddBreak(BreakViewSpec{ParentView: "NOPE", GapStart: 1, GapEnd: 2}); err == nil {
+		t.Error("break off a missing parent = ok, want error")
+	}
+}
+
+// TestBreakRecipeRoundTrip checks a break view's type, parent, orientation and gap survive
+// persistence and that its curves (with glyphs) re-derive on open.
+func TestBreakRecipeRoundTrip(t *testing.T) {
+	c := drawingWithBox(t)
+	views := c.Sheets().Active().Views()
+	frontBase(t, views)
+	front, _ := views.ByName("FRONT")
+	minX, _, maxX, _, _ := front.BoundsMM()
+	gs, ge := minX+(maxX-minX)/3, minX+2*(maxX-minX)/3
+	if _, err := views.AddBreak(BreakViewSpec{Name: "BK", ParentView: "FRONT", Orientation: types.BreakVertical, GapStart: gs, GapEnd: ge, CenterX: 100, CenterY: 220}); err != nil {
+		t.Fatalf("AddBreak: %v", err)
+	}
+	v, ok := reopen(t, c).Sheets().Active().Views().ByName("BK")
+	if !ok || v.Type() != types.DrawingViewBreak || v.BreakOrientation() != types.BreakVertical {
+		t.Fatalf("restored break wrong: ok=%v type=%v orient=%v", ok, v.Type(), v.BreakOrientation())
+	}
+	if start, end := v.BreakGapMM(); start != gs || end != ge {
+		t.Errorf("restored break gap = (%g,%g), want (%g,%g)", start, end, gs, ge)
+	}
+	if v.CurveCount() == 0 {
+		t.Error("restored break re-derived no curves")
+	}
+}

--- a/model/drawing/derived_view.go
+++ b/model/drawing/derived_view.go
@@ -5,6 +5,7 @@ package drawing
 import (
 	"math"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/hlr"
 	gmath "oblikovati.org/math"
 )
@@ -91,6 +92,137 @@ func minf2(a, b float64) float64 {
 		return a
 	}
 	return b
+}
+
+// breakBand is a break view's removed band. g0/g1 bound it (g0<g1) along the break axis in the
+// parent's projection space; sheetG0/G1 keep the parent-sheet-mm band the user gave.
+type breakBand struct {
+	orientation      types.BreakOrientation
+	g0, g1           float64 // parent model-2D, along the break axis
+	sheetG0, sheetG1 float64 // parent sheet mm
+}
+
+// axisX reports whether the break compresses along the X axis (a horizontal break removes a
+// vertical band, so it clips/shifts on X).
+func (b breakBand) axisX() bool { return b.orientation == types.BreakHorizontal }
+
+// breakBandOf maps a removed band given on the parent (sheet mm, along the break axis) into the
+// parent's projection space, inverting the parent's placement.
+func breakBandOf(parent *DrawingView, orientation types.BreakOrientation, gapStart, gapEnd float64) breakBand {
+	s := cmToMM * parent.scale
+	centre := parent.centerX
+	if orientation == types.BreakVertical {
+		centre = parent.centerY
+	}
+	g0, g1 := (gapStart-centre)/s, (gapEnd-centre)/s
+	if g0 > g1 {
+		g0, g1 = g1, g0
+	}
+	return breakBand{orientation: orientation, g0: g0, g1: g1, sheetG0: gapStart, sheetG1: gapEnd}
+}
+
+// recomputeBreak compresses the projected segments by removing the band and butting the two
+// sides together, then draws a zigzag break line at the join. The far side is shifted toward
+// the near side by the band width; segments inside the band are dropped.
+func (v *DrawingView) recomputeBreak(segs []hlr.Segment) {
+	wireframe := v.style == types.WireframeViewStyle
+	axisX, g0, g1 := v.brk.axisX(), v.brk.g0, v.brk.g1
+	w := g1 - g0
+	pmin, pmax := perpBounds(segs, axisX)
+	for _, s := range segs {
+		vis := wireframe || s.Visible
+		if a, b, ok := clipHalfAxis(s.A, s.B, axisX, g0, true); ok {
+			v.appendCurve(a, b, vis, types.DrawingEdgeCurve, s.EdgeKey)
+		}
+		if a, b, ok := clipHalfAxis(s.A, s.B, axisX, g1, false); ok {
+			v.appendCurve(shiftAxis(a, axisX, -w), shiftAxis(b, axisX, -w), vis, types.DrawingEdgeCurve, s.EdgeKey)
+		}
+	}
+	for _, g := range breakGlyph(axisX, g0, pmin, pmax) {
+		v.appendCurve(g[0], g[1], true, types.DrawingBreakCurve, nil)
+	}
+}
+
+// clipHalfAxis keeps the part of a→b on one side of an axis-aligned line. With keepLE it keeps
+// the portion whose axis coordinate is ≤ limit; otherwise ≥ limit. axisX selects which
+// coordinate is the axis. ok is false when nothing is kept.
+func clipHalfAxis(a, b gmath.Point2, axisX bool, limit float64, keepLE bool) (gmath.Point2, gmath.Point2, bool) {
+	sa, sb := axisCoord(a, axisX), axisCoord(b, axisX)
+	in := func(s float64) bool {
+		if keepLE {
+			return s <= limit
+		}
+		return s >= limit
+	}
+	ina, inb := in(sa), in(sb)
+	if ina && inb {
+		return a, b, true
+	}
+	if !ina && !inb {
+		return a, b, false
+	}
+	t := (limit - sa) / (sb - sa)
+	cross := lerp2(a, float64(b.X-a.X), float64(b.Y-a.Y), t)
+	if ina {
+		return a, cross, true
+	}
+	return cross, b, true
+}
+
+func axisCoord(p gmath.Point2, axisX bool) float64 {
+	if axisX {
+		return float64(p.X)
+	}
+	return float64(p.Y)
+}
+
+func shiftAxis(p gmath.Point2, axisX bool, delta float64) gmath.Point2 {
+	if axisX {
+		return gmath.P2(p.X+gmath.Scalar(delta), p.Y)
+	}
+	return gmath.P2(p.X, p.Y+gmath.Scalar(delta))
+}
+
+// perpBounds returns the min/max of the coordinate perpendicular to the break axis, over all
+// segment endpoints — the extent the break-line glyph spans.
+func perpBounds(segs []hlr.Segment, axisX bool) (lo, hi float64) {
+	lo, hi = math.Inf(1), math.Inf(-1)
+	for _, s := range segs {
+		for _, p := range [2]gmath.Point2{s.A, s.B} {
+			c := axisCoord(p, !axisX)
+			lo, hi = minf2(lo, c), maxf2(hi, c)
+		}
+	}
+	return lo, hi
+}
+
+// breakGlyph builds the zigzag break line at the join (axis coordinate g0), spanning the
+// perpendicular extent [pmin, pmax].
+func breakGlyph(axisX bool, g0, pmin, pmax float64) [][2]gmath.Point2 {
+	const segments = 6
+	amp := 0.06 * (pmax - pmin)
+	pts := make([]gmath.Point2, segments+1)
+	for i := 0; i <= segments; i++ {
+		perp := pmin + (pmax-pmin)*float64(i)/float64(segments)
+		axis := g0
+		if i%2 == 1 {
+			axis = g0 + amp
+		}
+		pts[i] = axisPoint(axisX, axis, perp)
+	}
+	out := make([][2]gmath.Point2, 0, segments)
+	for i := 0; i+1 < len(pts); i++ {
+		out = append(out, [2]gmath.Point2{pts[i], pts[i+1]})
+	}
+	return out
+}
+
+// axisPoint builds a point from an axis coordinate and a perpendicular coordinate.
+func axisPoint(axisX bool, axis, perp float64) gmath.Point2 {
+	if axisX {
+		return gmath.P2(gmath.Scalar(axis), gmath.Scalar(perp))
+	}
+	return gmath.P2(gmath.Scalar(perp), gmath.Scalar(axis))
 }
 
 // sectionBasis derives a section view's cut-plane frame from its parent frame and the cut line

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -59,6 +59,8 @@ type viewRecipe struct {
 	FoldAngleDeg float64    `yaml:"foldAngleDeg,omitempty"` // auxiliary fold-line angle on the parent
 	SectionLine  [4]float64 `yaml:"sectionLine,omitempty"`  // section cut line on the parent (sheet mm)
 	Detail       [3]float64 `yaml:"detail,omitempty"`       // detail boundary on the parent: centreX, centreY, radius (sheet mm)
+	BreakOrient  string     `yaml:"breakOrient,omitempty"`  // break orientation (horizontal/vertical)
+	BreakGap     [2]float64 `yaml:"breakGap,omitempty"`     // break band on the parent: start, end (sheet mm)
 	Scale        float64    `yaml:"scale,omitempty"`
 	Style        string     `yaml:"style,omitempty"`
 	CenterX      float64    `yaml:"centerXmm,omitempty"`
@@ -128,6 +130,8 @@ func viewRecipeOf(v *DrawingView) viewRecipe {
 		FoldAngleDeg: v.foldAngle * 180 / math.Pi,
 		SectionLine:  [4]float64{v.section.x1, v.section.y1, v.section.x2, v.section.y2},
 		Detail:       [3]float64{v.detail.sheetCX, v.detail.sheetCY, v.detail.sheetR},
+		BreakOrient:  v.brk.orientation.String(),
+		BreakGap:     [2]float64{v.brk.sheetG0, v.brk.sheetG1},
 		Scale:        v.scale, Style: v.style.String(), CenterX: v.centerX, CenterY: v.centerY,
 	}
 }
@@ -169,11 +173,13 @@ func restoreView(vr viewRecipe) *DrawingView {
 	dir, _ := types.ParseProjectionDirection(vr.Direction)
 	style, _ := types.ParseDrawingViewStyle(vr.Style)
 	vt := restoredViewType(vr)
-	sl, dt := vr.SectionLine, vr.Detail
+	sl, dt, bg := vr.SectionLine, vr.Detail, vr.BreakGap
+	brkOrient, _ := types.ParseBreakOrientation(vr.BreakOrient)
 	return &DrawingView{
 		name: vr.Name, viewType: vt, projected: vt == types.DrawingViewProjected, baseView: vr.BaseView,
 		foldAngle: vr.FoldAngleDeg * math.Pi / 180, section: sectionLine{sl[0], sl[1], sl[2], sl[3]},
 		detail:      detailBoundary{sheetCX: dt[0], sheetCY: dt[1], sheetR: dt[2]},
+		brk:         breakBand{orientation: brkOrient, sheetG0: bg[0], sheetG1: bg[1]},
 		orientation: orient, direction: dir,
 		scale: positiveScale(vr.Scale), style: style, centerX: vr.CenterX, centerY: vr.CenterY,
 	}

--- a/model/drawing/view.go
+++ b/model/drawing/view.go
@@ -48,6 +48,7 @@ type DrawingView struct {
 	foldAngle   float64        // auxiliary fold-line angle on the parent, radians
 	section     sectionLine    // section-view cut line on the parent (sheet mm)
 	detail      detailBoundary // detail-view circular boundary (parent model-2D)
+	brk         breakBand      // break-view removed band (parent model-2D, along the break axis)
 	orientation types.BaseViewOrientation
 	direction   types.ProjectionDirection
 	scale       float64
@@ -94,6 +95,12 @@ func (v *DrawingView) SectionLineMM() (x1, y1, x2, y2 float64) {
 func (v *DrawingView) DetailBoundaryMM() (cx, cy, r float64) {
 	return v.detail.sheetCX, v.detail.sheetCY, v.detail.sheetR
 }
+
+// BreakOrientation returns the axis a break view compresses along.
+func (v *DrawingView) BreakOrientation() types.BreakOrientation { return v.brk.orientation }
+
+// BreakGapMM returns the removed band's start/end on the parent (sheet millimetres).
+func (v *DrawingView) BreakGapMM() (start, end float64) { return v.brk.sheetG0, v.brk.sheetG1 }
 
 // Curves returns the view's computed drawing curves.
 func (v *DrawingView) Curves() []DrawingCurve { return v.curves }
@@ -149,17 +156,23 @@ func (v *DrawingView) VisibleHidden() (visible, hidden int) {
 func (v *DrawingView) recompute(body *topo.Body, basis hlr.View) {
 	segs := v.project(body, basis)
 	v.curves = make([]DrawingCurve, 0, len(segs))
+	if v.viewType == types.DrawingViewBreak {
+		v.recomputeBreak(segs)
+		return
+	}
 	wireframe := v.style == types.WireframeViewStyle
 	for _, s := range segs {
 		a, b, ok := v.clip(s.A, s.B)
 		if !ok {
 			continue
 		}
-		v.curves = append(v.curves, DrawingCurve{
-			A: v.place(a), B: v.place(b), Visible: wireframe || s.Visible,
-			kind: curveKind(s.Kind), edgeKey: s.EdgeKey,
-		})
+		v.appendCurve(a, b, wireframe || s.Visible, curveKind(s.Kind), s.EdgeKey)
 	}
+}
+
+// appendCurve places a model-2D segment on the sheet and adds it to the view's curves.
+func (v *DrawingView) appendCurve(a, b math.Point2, visible bool, kind types.DrawingCurveKind, edgeKey []byte) {
+	v.curves = append(v.curves, DrawingCurve{A: v.place(a), B: v.place(b), Visible: visible, kind: kind, edgeKey: edgeKey})
 }
 
 // project runs the projection a view's type calls for: a section view's clipped cut-away, or

--- a/model/drawing/views.go
+++ b/model/drawing/views.go
@@ -221,6 +221,53 @@ func (vs *DrawingViews) PreviewDetail(parentView string, boundaryX, boundaryY, r
 	return v.curves, true
 }
 
+// BreakViewSpec describes a break view: the parent compressed by removing a band along an axis.
+// GapStart/GapEnd bound the removed band on the parent (sheet mm) along the break axis.
+type BreakViewSpec struct {
+	Name             string
+	ParentView       string
+	Orientation      types.BreakOrientation
+	GapStart, GapEnd float64 // on the parent (sheet mm)
+	CenterX, CenterY float64
+}
+
+// AddBreak adds a break view: the parent's projection with the band removed and the two sides
+// butted together (a zigzag break line at the join). The parent must be a base view.
+func (vs *DrawingViews) AddBreak(spec BreakViewSpec) (*DrawingView, error) {
+	parent, body, err := vs.parentBaseFor(spec.ParentView)
+	if err != nil {
+		return nil, err
+	}
+	name, err := vs.uniqueName(spec.Name)
+	if err != nil {
+		return nil, err
+	}
+	v := &DrawingView{
+		name: name, viewType: types.DrawingViewBreak, baseView: spec.ParentView,
+		brk:         breakBandOf(parent, spec.Orientation, spec.GapStart, spec.GapEnd),
+		orientation: parent.orientation, style: parent.style, scale: parent.scale,
+		centerX: spec.CenterX, centerY: spec.CenterY,
+	}
+	v.recompute(body, baseBasis(parent.orientation, bodyCenter(body)))
+	vs.items = append(vs.items, v)
+	return v, nil
+}
+
+// PreviewBreak returns the origin-placed curves a break view of parentView (band removed) would
+// produce, without adding it.
+func (vs *DrawingViews) PreviewBreak(parentView string, orientation types.BreakOrientation, gapStart, gapEnd float64) ([]DrawingCurve, bool) {
+	parent, body, err := vs.parentBaseFor(parentView)
+	if err != nil {
+		return nil, false
+	}
+	v := &DrawingView{
+		viewType: types.DrawingViewBreak, style: parent.style, scale: parent.scale,
+		brk: breakBandOf(parent, orientation, gapStart, gapEnd),
+	}
+	v.recompute(body, baseBasis(parent.orientation, bodyCenter(body)))
+	return v.curves, true
+}
+
 // PreviewAuxiliary returns the origin-centred curves an auxiliary view folded off parentView at
 // foldAngleRad would produce, without adding it. ok is false when the parent or model is missing.
 func (vs *DrawingViews) PreviewAuxiliary(parentView string, foldAngleRad float64) ([]DrawingCurve, bool) {
@@ -337,10 +384,22 @@ func (vs *DrawingViews) basisFor(v *DrawingView, origin math.Point3) (hlr.View, 
 		return auxiliaryBasis(parent, v.foldAngle, origin), true
 	case types.DrawingViewSection:
 		return sectionBasis(parent, v.section, base.scale, base.centerX, base.centerY, origin), true
-	default: // detail: reuse the parent projection (recompute clips). Re-derive the clip circle
-		// from the persisted sheet-mm boundary so it tracks a parent rescale/move (associativity).
-		v.detail = detailBoundaryOf(base, v.detail.sheetCX, v.detail.sheetCY, v.detail.sheetR)
+	default: // detail & break reuse the parent projection (recompute clips/breaks); re-map their
+		// sheet-mm region against the parent's current placement so they track a rescale/move.
+		v.refreshParentRegion(base)
 		return parent, true
+	}
+}
+
+// refreshParentRegion re-derives a detail/break view's region (clip circle or break band) from
+// its persisted sheet-mm definition against the parent's current placement — the associativity
+// path when the parent is rescaled or moved.
+func (v *DrawingView) refreshParentRegion(parent *DrawingView) {
+	switch v.viewType {
+	case types.DrawingViewDetail:
+		v.detail = detailBoundaryOf(parent, v.detail.sheetCX, v.detail.sheetCY, v.detail.sheetR)
+	case types.DrawingViewBreak:
+		v.brk = breakBandOf(parent, v.brk.orientation, v.brk.sheetG0, v.brk.sheetG1)
 	}
 }
 


### PR DESCRIPTION
## What

Implements **break drawing views** — the final derived-view slice of **PBI-140** (#387), completing the section/detail/auxiliary/break set. Pairs with Oblikovati.API#141 (v0.25.0).

A break view compresses a long part by removing a band along an axis and butting the two sides together, with a zigzag break line at the join.

## How

- **`model/drawing`**: `clipHalfAxis` (axis-aligned half-plane clip), `recomputeBreak` (drop the band, shift the far side inward by the band width, draw the zigzag break glyph). The band is stored in sheet mm and re-mapped into the parent's projection space each recompute (associativity); the recipe round-trips orientation + gap. `recompute` gained a shared `appendCurve` helper.
- **`addin/router`**: `drawingViews.addBreak`.
- **`app`/`head`**: `BreakViewTool` (middle-third cut, horizontal/vertical) + a **Break View** command; the canvas styles break-glyph curves; new icon.

## Tests

- `model/drawing`: break compresses (narrower than the parent), emits glyph curves, recipe round-trip.
- `addin/router`/`app`: `addBreak` over the wire; `BreakViewTool` commit + no-base path; `head/ui` icon coverage. Root `golangci-lint` 0 issues.

Completes #387 (with the bridge e2e to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)