### PR TITLE
feat(units): Document Settings — Units dialog (#146, final)

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -125,6 +125,7 @@ type Session struct {
 	namedViewsPanelOpen  bool                           // the View ▸ Named Views panel is open (M16-F03 #404)
 	colorStylesPanelOpen bool                           // the Color Styles panel is open (M16-F02 #403/#408)
 	displaySettingsOpen  bool                           // the Display Settings dialog is open (M16-F07 #643)
+	unitsSettingsOpen    bool                           // the Document Settings ▸ Units dialog is open (#146)
 	loadEnvRequested     bool                           // a "Load HDR…" was requested; the head opens the file dialog
 	meshImportRequested  bool                           // a "Place Mesh…" was requested; the head opens the file dialog (#700)
 	scriptConsoleOpen    bool                           // the Manage ▸ Scripts ▸ Script Console panel is open

--- a/app/units_settings.go
+++ b/app/units_settings.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/param"
+)
+
+// Document Settings ▸ Units dialog state and the write side of the document's
+// units (Oblikovati/Oblikovati#146). The head opens the dialog from the Tools
+// menu, edits a copy of DocumentUnits, and applies it through SetDocumentUnits —
+// the same units object the API reads/writes and the .obk persists.
+
+// OpenUnitsSettings / CloseUnitsSettings / UnitsSettingsOpen drive the dialog.
+func (s *Session) OpenUnitsSettings()      { s.unitsSettingsOpen = true }
+func (s *Session) CloseUnitsSettings()     { s.unitsSettingsOpen = false }
+func (s *Session) UnitsSettingsOpen() bool { return s.unitsSettingsOpen }
+
+// SetDocumentUnits applies an edited units object to the active part — the write
+// counterpart of [Session.DocumentUnits]. Build it from DocumentUnits().Clone()
+// so the edit does not touch the live document until stored. A no-op when there
+// is no active part.
+func (s *Session) SetDocumentUnits(u param.UnitsOfMeasure) {
+	if part, err := activePart(s); err == nil {
+		part.SetUnits(u)
+	}
+}
+
+// LengthUnitOptions / AngleUnitOptions / MassUnitOptions / TimeUnitOptions are the
+// unit names the Units dialog offers per category, so the head needs no unit
+// vocabulary of its own.
+func LengthUnitOptions() []string { return []string{"mm", "cm", "m", "in", "ft"} }
+func AngleUnitOptions() []string  { return []string{"deg", "rad"} }
+func MassUnitOptions() []string   { return []string{"kg", "g", "lb"} }
+func TimeUnitOptions() []string   { return []string{"s", "ms", "min", "hr"} }
+
+// Apply* mutate a units object from a UI control's current value, returning
+// whether anything changed. They are the pure decision logic behind the Units
+// dialog's combos and inputs (the head draws the control and feeds its value
+// here), so the apply paths are testable without a GUI. An invalid/unchanged
+// value is a no-op returning false.
+
+// ApplyUnit sets a category's preferred unit by name.
+func ApplyUnit(u *param.UnitsOfMeasure, cat param.Unit, name string) bool {
+	if name == u.PreferredName(cat) {
+		return false
+	}
+	return u.SetPreferred(cat, name) == nil
+}
+
+// ApplyLengthFormat sets the length display format from its wire spelling.
+func ApplyLengthFormat(u *param.UnitsOfMeasure, spelling string) bool {
+	f, ok := types.ParseParameterDisplayFormat(spelling)
+	if !ok || f == u.LengthFormat() {
+		return false
+	}
+	u.SetLengthFormat(f)
+	return true
+}
+
+// ApplyLengthPrecision / ApplyAnglePrecision set the display decimal places.
+func ApplyLengthPrecision(u *param.UnitsOfMeasure, places int) bool {
+	if places == u.LengthPrecision() {
+		return false
+	}
+	return u.SetLengthPrecision(places) == nil
+}
+
+func ApplyAnglePrecision(u *param.UnitsOfMeasure, places int) bool {
+	if places == u.AnglePrecision() {
+		return false
+	}
+	return u.SetAnglePrecision(places) == nil
+}
+
+// ApplyAngleDMS selects degrees-minutes-seconds (true) or decimal degrees.
+func ApplyAngleDMS(u *param.UnitsOfMeasure, dms bool) bool {
+	want := param.AngleDecimal
+	if dms {
+		want = param.AngleDMS
+	}
+	if want == u.AngleFormat() {
+		return false
+	}
+	u.SetAngleFormat(want)
+	return true
+}

--- a/app/units_settings_test.go
+++ b/app/units_settings_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/param"
+)
+
+// TestSetDocumentUnitsAppliesToActivePart drives the write side of the units
+// dialog: an edited units object lands on the active part (units, precision and
+// format), and there is no active-part no-op crash.
+func TestSetDocumentUnitsAppliesToActivePart(t *testing.T) {
+	s := NewSession()
+	// No active part: SetDocumentUnits is a safe no-op.
+	s.SetDocumentUnits(param.DefaultUnitsOfMeasure())
+
+	doc, err := compdef.AddPart(s.Workspace(), "p.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := doc.Content().(*compdef.PartComponentDefinition)
+
+	u := s.DocumentUnits().Clone()
+	if err := u.SetPreferred(param.Length, "in"); err != nil {
+		t.Fatal(err)
+	}
+	if err := u.SetLengthPrecision(5); err != nil {
+		t.Fatal(err)
+	}
+	u.SetAngleFormat(param.AngleDMS)
+	s.SetDocumentUnits(u)
+
+	got := def.Units()
+	if got.PreferredName(param.Length) != "in" || got.LengthPrecision() != 5 || got.AngleFormat() != param.AngleDMS {
+		t.Errorf("units after SetDocumentUnits = %+v, want in / prec 5 / DMS", got)
+	}
+}
+
+// TestUnitsSettingsOpenClose drives the dialog's open/close flag.
+func TestUnitsSettingsOpenClose(t *testing.T) {
+	s := NewSession()
+	if s.UnitsSettingsOpen() {
+		t.Error("units settings should start closed")
+	}
+	s.OpenUnitsSettings()
+	if !s.UnitsSettingsOpen() {
+		t.Error("OpenUnitsSettings did not open the dialog")
+	}
+	s.CloseUnitsSettings()
+	if s.UnitsSettingsOpen() {
+		t.Error("CloseUnitsSettings did not close the dialog")
+	}
+}
+
+// TestUnitOptionLists checks each category offers its expected units.
+func TestUnitOptionLists(t *testing.T) {
+	has := func(opts []string, want string) bool {
+		for _, o := range opts {
+			if o == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(LengthUnitOptions(), "mm") || !has(LengthUnitOptions(), "in") {
+		t.Error("length options missing mm/in")
+	}
+	if !has(AngleUnitOptions(), "deg") || !has(AngleUnitOptions(), "rad") {
+		t.Error("angle options missing deg/rad")
+	}
+	if !has(MassUnitOptions(), "kg") || !has(TimeUnitOptions(), "s") {
+		t.Error("mass/time options missing kg/s")
+	}
+}
+
+// TestApplyUnitsHelpers covers the pure apply helpers behind the dialog controls.
+func TestApplyUnitsHelpers(t *testing.T) {
+	u := param.DefaultUnitsOfMeasure().Clone()
+
+	if !ApplyUnit(&u, param.Length, "in") || u.PreferredName(param.Length) != "in" {
+		t.Error("ApplyUnit(length, in) should change to in")
+	}
+	if ApplyUnit(&u, param.Length, "in") {
+		t.Error("ApplyUnit to the same unit should be a no-op")
+	}
+	if ApplyUnit(&u, param.Length, "deg") { // wrong category → rejected
+		t.Error("ApplyUnit with a wrong-category unit should be a no-op")
+	}
+
+	if !ApplyLengthFormat(&u, "fractional") || u.LengthFormat() != types.DisplayFormatFractional {
+		t.Error("ApplyLengthFormat(fractional) should change the format")
+	}
+	if ApplyLengthFormat(&u, "fractional") || ApplyLengthFormat(&u, "bogus") {
+		t.Error("ApplyLengthFormat unchanged/invalid should be a no-op")
+	}
+
+	if !ApplyLengthPrecision(&u, 5) || u.LengthPrecision() != 5 {
+		t.Error("ApplyLengthPrecision(5) should change precision")
+	}
+	if ApplyLengthPrecision(&u, 5) || ApplyLengthPrecision(&u, -1) {
+		t.Error("ApplyLengthPrecision unchanged/negative should be a no-op")
+	}
+	if !ApplyAnglePrecision(&u, 4) || ApplyAnglePrecision(&u, 4) {
+		t.Error("ApplyAnglePrecision change/no-op wrong")
+	}
+
+	if !ApplyAngleDMS(&u, true) || u.AngleFormat() != param.AngleDMS {
+		t.Error("ApplyAngleDMS(true) should switch to DMS")
+	}
+	if ApplyAngleDMS(&u, true) {
+		t.Error("ApplyAngleDMS to the same state should be a no-op")
+	}
+	if !ApplyAngleDMS(&u, false) || u.AngleFormat() != param.AngleDecimal {
+		t.Error("ApplyAngleDMS(false) should switch back to decimal")
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -145,6 +145,7 @@ func drawChromeWindows(s *app.Session) {
 	drawNamedViewsWindow(s)      // View ▸ Named Views (M16-F03 #404)
 	drawColorStylesWindow(s)     // View ▸ Color Styles (M16-F02 #403/#408)
 	drawDisplaySettingsWindow(s) // View ▸ Display Settings (M16-F07 #643)
+	drawUnitsSettingsWindow(s)   // Tools ▸ Document Settings — Units (#146)
 	drawScriptConsole(s)
 	drawKeymapEditor(s)    // Tools ▸ Customize Keyboard (M05-F17)
 	drawCommandInput(s)    // command-alias input box (M05-F17)

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -139,6 +139,9 @@ func drawToolsMenu(s *app.Session) {
 		if native.MenuItem("Preferences") {
 			showPreferences = !showPreferences
 		}
+		if native.MenuItem("Document Settings — Units") { // #146: per-document units & precision
+			s.OpenUnitsSettings()
+		}
 		if native.MenuItem("Customize Keyboard") { // M05-F17: rebind shortcuts / aliases
 			s.OpenKeymapEditor()
 		}

--- a/head/ui/units_settings_window.go
+++ b/head/ui/units_settings_window.go
@@ -1,0 +1,87 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/param"
+)
+
+// drawUnitsSettingsWindow renders the Document Settings ▸ Units dialog while it is
+// open (Oblikovati/Oblikovati#146): the document's length/angle/mass/time display
+// units, the length/angle display precision, the length format (decimal /
+// fractional / architectural) and the angle DMS toggle. Each edit writes the whole
+// units value back through the session (the same surface the API uses and the .obk
+// persists), so every open tool dialog and dimension immediately re-renders.
+func drawUnitsSettingsWindow(s *app.Session) {
+	if !s.UnitsSettingsOpen() {
+		return
+	}
+	native.SetNextWindowSizeOnce(340, 360)
+	if native.Begin("Document Settings — Units") {
+		u := s.DocumentUnits().Clone()
+		if editDocumentUnits(&u) {
+			s.SetDocumentUnits(u)
+		}
+		native.Separator()
+		if native.Button("Done") {
+			s.CloseUnitsSettings()
+		}
+	}
+	native.End()
+}
+
+// editDocumentUnits draws the unit pickers, precision inputs and format controls
+// into u, returning whether any changed. The controls only READ + render here; the
+// apply decisions live in the app layer (app.Apply*), which run every frame (a
+// no-op when the value is unchanged) so the dialog stays drift-free and the apply
+// logic is unit-testable without a GUI.
+func editDocumentUnits(u *param.UnitsOfMeasure) bool {
+	changed := app.ApplyUnit(u, param.Length, unitCombo("Length", "units-length", u.PreferredName(param.Length), app.LengthUnitOptions()))
+	changed = app.ApplyUnit(u, param.Angle, unitCombo("Angle", "units-angle", u.PreferredName(param.Angle), app.AngleUnitOptions())) || changed
+	changed = app.ApplyUnit(u, param.Mass, unitCombo("Mass", "units-mass", u.PreferredName(param.Mass), app.MassUnitOptions())) || changed
+	changed = app.ApplyUnit(u, param.Time, unitCombo("Time", "units-time", u.PreferredName(param.Time), app.TimeUnitOptions())) || changed
+	native.Separator()
+	changed = app.ApplyLengthFormat(u, unitCombo("Length format", "units-lenfmt", u.LengthFormat().String(), []string{"decimal", "fractional", "architectural"})) || changed
+	lp, ap := precisionInputs(u)
+	changed = app.ApplyLengthPrecision(u, lp) || changed
+	changed = app.ApplyAnglePrecision(u, ap) || changed
+	changed = app.ApplyAngleDMS(u, angleDMSToggle(u)) || changed
+	return changed
+}
+
+// unitCombo draws a labelled combo over options and returns the user's selection
+// (the unchanged current value when nothing is picked this frame).
+func unitCombo(label, id, current string, options []string) string {
+	selected := current
+	native.Text(label)
+	native.SameLine()
+	if native.BeginCombo("##"+id, current) {
+		for _, o := range options {
+			if native.Selectable(o, o == current) {
+				selected = o
+			}
+		}
+		native.EndCombo()
+	}
+	return selected
+}
+
+// precisionInputs draws the length/angle precision fields and returns their values.
+func precisionInputs(u *param.UnitsOfMeasure) (length, angle int) {
+	lp := int32(u.LengthPrecision())
+	native.InputInt("Length precision", &lp)
+	ap := int32(u.AnglePrecision())
+	native.InputInt("Angle precision", &ap)
+	return int(lp), int(ap)
+}
+
+// angleDMSToggle draws the DMS checkbox and returns its state.
+func angleDMSToggle(u *param.UnitsOfMeasure) bool {
+	dms := u.AngleFormat() == param.AngleDMS
+	native.Checkbox("Angle as DMS (deg/min/sec)", &dms)
+	return dms
+}

--- a/head/ui/units_settings_window_test.go
+++ b/head/ui/units_settings_window_test.go
@@ -1,0 +1,31 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// TestInWindowUnitsSettingsDraws opens the real window with the Document Settings ▸
+// Units dialog visible and runs frames — exercising the unit combos, precision
+// inputs and format controls without tripping Dear ImGui's Begin/End assertions
+// (#146). It skips cleanly where no display/Vulkan is available.
+func TestInWindowUnitsSettingsDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+
+	s.OpenUnitsSettings()
+	defer s.CloseUnitsSettings()
+
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	if !s.UnitsSettingsOpen() {
+		t.Error("Units settings dialog should stay open across frames")
+	}
+}


### PR DESCRIPTION
## What

PBI-5 of #146 — the **Tools ▸ Document Settings — Units** dialog, the GUI to choose a document's units. This is the **final piece** of the units-of-measure milestone.

Lets the user set the document's:
- **length / angle / mass / time** display units,
- **length & angle display precision** (decimal places),
- **length format** (decimal / fractional / architectural),
- **angle as DMS** (deg/min/sec) toggle.

Edits apply through `Session.SetDocumentUnits` (the write counterpart of `DocumentUnits`) and persist with the document; every open tool dialog and dimension re-renders in the new units the next frame.

## How

- `app`: `OpenUnitsSettings`/`CloseUnitsSettings`/`UnitsSettingsOpen`, `SetDocumentUnits` (applies an edited units object to the active part), per-category unit option lists, and pure `Apply*` helpers (the dialog's decision logic, unit-testable without a GUI).
- `head/ui`: `drawUnitsSettingsWindow` (unit combos, precision inputs, format combo, DMS toggle) wired into the chrome draw loop and the Tools menu.

## Verified

App tests cover `SetDocumentUnits` apply, open/close, option lists and every `Apply*` branch (100%); a live in-window render test draws the dialog. **Live capture** confirms the dialog: Length mm / Angle deg / Mass kg / Time s, Length format decimal, precision 3/2, DMS toggle. 87.8% new-code coverage; lint clean.

## Milestone

This closes #146 end-to-end: units API (#985-pre), formatter, the per-tool UI sweep, importers/exporters (STEP/mesh/DXF/DWG), and now the settings dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)