### PR TITLE
chore(units): post-#146 audit cleanups

### DIFF
--- a/kernel/exchange/step/writer_facade.go
+++ b/kernel/exchange/step/writer_facade.go
@@ -47,9 +47,11 @@ func (Writer) ExportSolids(bodies []*topo.Body, opts exchange.TranslationOptions
 
 // emitUnitContext emits the file's SI (mm/cm/m) or conversion-based (in/ft) length
 // unit plus a unit-assigned context, so the file's lengths are unambiguous on
-// re-import. An empty unit defaults to millimetres.
-func emitUnitContext(w *part21.Writer, fileUnit string) int {
-	return w.Add("GLOBAL_UNIT_ASSIGNED_CONTEXT", part21.FormatList(part21.Ref(lengthUnitRef(w, fileUnit))))
+// re-import. An empty unit defaults to millimetres. The reader locates the unit by
+// scanning for GLOBAL_UNIT_ASSIGNED_CONTEXT (units.go), so the context id needs no
+// further reference here.
+func emitUnitContext(w *part21.Writer, fileUnit string) {
+	w.Add("GLOBAL_UNIT_ASSIGNED_CONTEXT", part21.FormatList(part21.Ref(lengthUnitRef(w, fileUnit))))
 }
 
 // lengthUnitRef emits the LENGTH_UNIT entity for fileUnit and returns its id.

--- a/model/param/units_of_measure_test.go
+++ b/model/param/units_of_measure_test.go
@@ -87,6 +87,29 @@ func TestSetPreferredRejectsWrongCategory(t *testing.T) {
 	}
 }
 
+// TestToFromPreferredRoundTrip pins the database↔preferred-unit conversion pair
+// the UI fields cross every frame: ToPreferred expresses a stored cm value in the
+// preferred unit, and FromPreferred is its exact inverse.
+func TestToFromPreferredRoundTrip(t *testing.T) {
+	m := DefaultUnitsOfMeasure().Clone()
+	if err := m.SetPreferred(Length, "in"); err != nil {
+		t.Fatalf("SetPreferred: %v", err)
+	}
+	// 2.54 cm == 1 in in the preferred unit.
+	if got := m.ToPreferred(Q(2.54, Length)); !approxScalar(got, 1) {
+		t.Errorf("ToPreferred(2.54 cm) = %g in, want 1", got)
+	}
+	// FromPreferred(1 in) rebuilds the 2.54 cm database quantity.
+	q := m.FromPreferred(1, Length)
+	if q.Unit != Length || !approxScalar(q.Value, 2.54) {
+		t.Errorf("FromPreferred(1 in) = %+v, want {2.54 Length}", q)
+	}
+	// Round-trip through both is identity.
+	if back := m.ToPreferred(m.FromPreferred(3.7, Length)); !approxScalar(back, 3.7) {
+		t.Errorf("round-trip = %g, want 3.7", back)
+	}
+}
+
 func TestParseErrors(t *testing.T) {
 	m := DefaultUnitsOfMeasure()
 	if _, err := m.Parse("12 furlongs", Length); err == nil {


### PR DESCRIPTION
## What
Two small cleanups surfaced by auditing the merged #146 units-of-measure PRs.

- **Drop a dead return value** in `kernel/exchange/step/writer_facade.go`:
  `emitUnitContext` returned the `GLOBAL_UNIT_ASSIGNED_CONTEXT` id that no
  caller (or test) ever consumed — the reader locates the unit by keyword
  scan (`units.go`). Made it a plain emit so there's no misleading unused
  return.
- **Cover `param.ToPreferred`/`FromPreferred` directly**: the pair was only
  exercised transitively through the `app` layer, leaving it at 0% in its own
  package. Added a round-trip test; both are now 100%.

## Why
Keeps the units surface free of dead code and ensures the database↔preferred-unit
conversion the UI fields cross every frame has a direct, in-package regression test.

No behaviour change. Lint clean; `model/param`, `kernel/exchange/step` and the head
cgo build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)