### PR TITLE
fix: stop part↔drawing active-document ping-pong + enforce unique document identity GUIDs

### DIFF
--- a/app/identity_collision_watch.go
+++ b/app/identity_collision_watch.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// Open-time identity-collision notice: two open files must never share an identity GUID
+// (references key on it, and the document tabs are keyed by it). When a file is opened whose
+// persisted GUID clashes with an already-open document, the workspace mints the newcomer a
+// fresh GUID; this surfaces that to the user so they know the on-disk file's id will change on
+// its next save. A status notice, never fatal.
+
+// watchDocumentIdentityCollisions subscribes the open-time identity-reassignment notice.
+func (s *Session) watchDocumentIdentityCollisions() {
+	event.Subscribe(s.workspace.Events(), event.After,
+		func(_ event.Context, e doc.DocumentIdentityReassigned) event.Outcome {
+			s.notice = identityCollisionNotice(e)
+			return event.Continue()
+		})
+}
+
+// identityCollisionNotice is the user-facing message for a reassigned identity: the opened
+// file shared an id with an open document and was given a new one, saved on its next save.
+func identityCollisionNotice(e doc.DocumentIdentityReassigned) string {
+	return fmt.Sprintf(
+		"%s shared a file identity with an already-open document; it was assigned a new id, which will be written on its next save.",
+		e.Document.DisplayName())
+}

--- a/app/identity_collision_watch_test.go
+++ b/app/identity_collision_watch_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// TestIdentityCollisionSetsNotice proves the session surfaces an open-time identity
+// reassignment to the user: when the workspace fires DocumentIdentityReassigned, the watcher
+// wired in newSession sets a notice naming the affected document.
+func TestIdentityCollisionSetsNotice(t *testing.T) {
+	s := NewSession()
+	d, err := s.Workspace().Add(doc.Drawing, "box.odd", true)
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	event.Emit(s.Workspace().Events(), event.After, doc.DocumentIdentityReassigned{
+		Document:             d,
+		PreviousInternalName: "shared-guid",
+		NewInternalName:      "fresh-guid",
+	})
+
+	notice := s.Notice()
+	if !strings.Contains(notice, d.DisplayName()) {
+		t.Errorf("notice %q should name the reassigned document %q", notice, d.DisplayName())
+	}
+	if !strings.Contains(strings.ToLower(notice), "new id") {
+		t.Errorf("notice %q should tell the user a new id was assigned", notice)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -214,8 +214,9 @@ func newSession(store doc.Store) *Session {
 	s.initShellSurfaces()
 	s.watchDocumentCloses()
 	s.watchDocumentInterests()
-	s.watchTransactions()  // append-only transaction log for bug reports
-	s.watchDrawingExport() // Drawing tab Export DXF: write the sheet when its file dialog is answered
+	s.watchDocumentIdentityCollisions() // open-time identity-GUID clash → reassign + notify
+	s.watchTransactions()               // append-only transaction log for bug reports
+	s.watchDrawingExport()              // Drawing tab Export DXF: write the sheet when its file dialog is answered
 	return s
 }
 

--- a/head/ui/chrome_doctabs.go
+++ b/head/ui/chrome_doctabs.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	"fmt"
+
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/math"
@@ -89,7 +91,7 @@ func drawDocumentTabs(s *app.Session) {
 
 func drawDocumentTab(s *app.Session, d *doc.Document, active *doc.Document, force bool) {
 	selected := force && active != nil && d.ID() == active.ID()
-	open, keep := native.BeginTabItemClosable(d.DisplayName(), selected)
+	open, keep := native.BeginTabItemClosable(documentTabLabel(d), selected)
 	if open && keep && !force && (active == nil || d.ID() != active.ID()) {
 		_ = s.Workspace().SetActiveDocument(d)
 	}
@@ -99,4 +101,19 @@ func drawDocumentTab(s *app.Session, d *doc.Document, active *doc.Document, forc
 	if !keep && closeDocumentModal.request(d) {
 		closeDocumentNow(s, d, false)
 	}
+}
+
+// documentTabLabel is the ImGui label for a document's tab. ImGui identifies a tab by its
+// label string, so two documents whose display names collide (e.g. a part "box.opd" and a
+// drawing "box.odd" both show "box") would hash to the SAME tab id — making ImGui report both
+// as selected and the active document ping-pong between them every frame. The "###<uuid>"
+// suffix gives each tab a stable, unique id from the document's persisted identity GUID (not
+// the visible text, so a rename keeps the tab's identity) while ImGui still displays only the
+// name before "###". A reference stub minted without a GUID falls back to the in-memory id.
+func documentTabLabel(d *doc.Document) string {
+	id := d.File().InternalName()
+	if id == "" {
+		id = fmt.Sprintf("%d", d.ID())
+	}
+	return fmt.Sprintf("%s###%s", d.DisplayName(), id)
 }

--- a/head/ui/chrome_doctabs_test.go
+++ b/head/ui/chrome_doctabs_test.go
@@ -1,0 +1,47 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/doc"
+)
+
+// TestDocumentTabLabelDisambiguatesCollidingNames is the regression for the part↔drawing
+// active-document ping-pong: a part "box.opd" and a drawing "box.odd" both display as "box",
+// and ImGui keys tabs by their label, so identical labels collided to one tab id and the head
+// flipped the active document every frame. The tab label must carry a unique per-document id
+// suffix while still showing the bare display name.
+func TestDocumentTabLabelDisambiguatesCollidingNames(t *testing.T) {
+	s := app.NewSession()
+	part, err := s.Workspace().Add(doc.Part, "box.opd", true)
+	if err != nil {
+		t.Fatalf("add part: %v", err)
+	}
+	drawing, err := s.Workspace().Add(doc.Drawing, "box.odd", true)
+	if err != nil {
+		t.Fatalf("add drawing: %v", err)
+	}
+
+	if part.DisplayName() != drawing.DisplayName() {
+		t.Fatalf("precondition: want colliding display names, got %q vs %q",
+			part.DisplayName(), drawing.DisplayName())
+	}
+
+	partLabel, drawingLabel := documentTabLabel(part), documentTabLabel(drawing)
+	if partLabel == drawingLabel {
+		t.Fatalf("tab labels collide (%q) — ImGui would treat both tabs as one and flip the active document",
+			partLabel)
+	}
+	// The visible text (before "###") must still be the bare display name.
+	for _, lbl := range []string{partLabel, drawingLabel} {
+		if visible, _, found := strings.Cut(lbl, "###"); !found || visible != "box" {
+			t.Errorf("label %q: want visible text %q before a \"###\" id suffix", lbl, "box")
+		}
+	}
+}

--- a/model/doc/events.go
+++ b/model/doc/events.go
@@ -16,13 +16,14 @@ import (
 //
 // TypeIDs are stable across versions (they cross the gRPC seam); never renumber.
 const (
-	tidDocumentCreated  event.TypeID = 0x0401
-	tidDocumentOpened   event.TypeID = 0x0402
-	tidDocumentSave     event.TypeID = 0x0403
-	tidDocumentClose    event.TypeID = 0x0404
-	tidDocumentActivate event.TypeID = 0x0405
-	tidApplicationQuit  event.TypeID = 0x0410
-	tidModelChanged     event.TypeID = 0x0420
+	tidDocumentCreated            event.TypeID = 0x0401
+	tidDocumentOpened             event.TypeID = 0x0402
+	tidDocumentSave               event.TypeID = 0x0403
+	tidDocumentClose              event.TypeID = 0x0404
+	tidDocumentActivate           event.TypeID = 0x0405
+	tidDocumentIdentityReassigned event.TypeID = 0x0406
+	tidApplicationQuit            event.TypeID = 0x0410
+	tidModelChanged               event.TypeID = 0x0420
 )
 
 // DocumentCreated is fired (After only) when a new document is created from a
@@ -57,6 +58,19 @@ type DocumentActivate struct{ Document *Document }
 
 // EventID implements event.Event.
 func (DocumentActivate) EventID() event.TypeID { return tidDocumentActivate }
+
+// DocumentIdentityReassigned is fired (After) when a document is opened whose persisted
+// identity GUID collides with an already-open document, so the workspace minted it a fresh
+// identity to keep identities unique within the session. The new GUID is in memory only until
+// the document's next save persists it. The host surfaces this to the user as a notice.
+type DocumentIdentityReassigned struct {
+	Document             *Document
+	PreviousInternalName string
+	NewInternalName      string
+}
+
+// EventID implements event.Event.
+func (DocumentIdentityReassigned) EventID() event.TypeID { return tidDocumentIdentityReassigned }
 
 // ApplicationQuit is fired around shutting down the session; a Before handler may
 // veto it. ApplicationEvents.OnQuit.

--- a/model/doc/file_identity_test.go
+++ b/model/doc/file_identity_test.go
@@ -75,3 +75,22 @@ func (s *failingStore) Load(name string) (*Document, error) {
 	return nil, errNotStored{name}
 }
 func (s *failingStore) Exists(string) bool { return false }
+
+// TestCopyIdentityMintsFreshNameKeepsModelStamp: a copy is a NEW file — its internal name must
+// differ from the source's — but it documents the source's model, so the database revision and
+// digest carry over (a derived part keyed on them still matches). (M03-F09)
+func TestCopyIdentityMintsFreshNameKeepsModelStamp(t *testing.T) {
+	src := newFileIdentity()
+	src.DatabaseRevisionID = "db-rev-123"
+	src.ModelDigest = "digest-abc"
+
+	cp := CopyIdentity(src)
+
+	if cp.InternalName == src.InternalName || cp.InternalName == "" {
+		t.Errorf("copy internal name = %q, want a fresh GUID distinct from source %q", cp.InternalName, src.InternalName)
+	}
+	if cp.DatabaseRevisionID != src.DatabaseRevisionID || cp.ModelDigest != src.ModelDigest {
+		t.Errorf("copy model stamp = (%q, %q), want the source's (%q, %q)",
+			cp.DatabaseRevisionID, cp.ModelDigest, src.DatabaseRevisionID, src.ModelDigest)
+	}
+}

--- a/model/doc/identity_collision_test.go
+++ b/model/doc/identity_collision_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"testing"
+
+	"oblikovati.org/event"
+)
+
+// TestOpenWithCollidingIdentityReassigns proves two files that carry the same persisted
+// identity GUID (e.g. one copied outside the application) cannot be open at once sharing it:
+// opening the second mints it a fresh GUID, marks it dirty so the new id is written on its
+// next save, and fires DocumentIdentityReassigned so the host can notify the user.
+func TestOpenWithCollidingIdentityReassigns(t *testing.T) {
+	const sharedGUID = "11111111-1111-4111-8111-111111111111"
+	store := newFakeStore()
+	store.saved["original.opd"] = storedDoc{docType: Part, displayName: "original", internalName: sharedGUID}
+	store.saved["clone.opd"] = storedDoc{docType: Part, displayName: "clone", internalName: sharedGUID}
+	ws := NewWorkspace(store)
+
+	var reassigned *DocumentIdentityReassigned
+	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e DocumentIdentityReassigned) event.Outcome {
+		reassigned = &e
+		return event.Continue()
+	})
+
+	first, err := ws.Open("original.opd", true)
+	if err != nil {
+		t.Fatalf("open original: %v", err)
+	}
+	if first.FileIdentity().InternalName != sharedGUID {
+		t.Fatalf("first document id = %q, want the stored %q", first.FileIdentity().InternalName, sharedGUID)
+	}
+
+	second, err := ws.Open("clone.opd", true)
+	if err != nil {
+		t.Fatalf("open clone: %v", err)
+	}
+
+	if second.FileIdentity().InternalName == sharedGUID {
+		t.Fatal("second document kept the colliding identity — two open files share a GUID")
+	}
+	if first.FileIdentity().InternalName == second.FileIdentity().InternalName {
+		t.Fatalf("both open documents have id %q — identities must be unique within a session",
+			first.FileIdentity().InternalName)
+	}
+	if !second.Dirty() {
+		t.Error("reassigned document must be dirty so its new id is written on the next save")
+	}
+	if reassigned == nil {
+		t.Fatal("no DocumentIdentityReassigned event fired")
+	}
+	if reassigned.Document != second || reassigned.PreviousInternalName != sharedGUID {
+		t.Errorf("event = %+v, want clone reassigned away from %q", reassigned, sharedGUID)
+	}
+	if reassigned.NewInternalName != second.FileIdentity().InternalName {
+		t.Errorf("event new id %q != document id %q", reassigned.NewInternalName, second.FileIdentity().InternalName)
+	}
+}
+
+// TestClosingFreesIdentityForReopen proves the GUID index releases an identity on close, so a
+// file can be reopened under its original id once the colliding document is gone.
+func TestClosingFreesIdentityForReopen(t *testing.T) {
+	const guid = "22222222-2222-4222-8222-222222222222"
+	store := newFakeStore()
+	store.saved["a.opd"] = storedDoc{docType: Part, displayName: "a", internalName: guid}
+	ws := NewWorkspace(store)
+
+	d, err := ws.Open("a.opd", true)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := ws.Close(d, true); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, err := ws.Open("a.opd", true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if reopened.FileIdentity().InternalName != guid {
+		t.Errorf("reopened id = %q, want the original %q (no live collision after close)",
+			reopened.FileIdentity().InternalName, guid)
+	}
+}

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -22,6 +22,7 @@ type Workspace struct {
 	ordered       []*Document          // insertion order, for stable enumeration
 	byID          map[ID]*Document     // session-id lookup
 	byName        map[string]*Document // full-document-name lookup (ItemByName)
+	byGUID        map[string]*Document // identity-GUID lookup, enforces one open doc per identity
 	graph         *RefGraph            // shared document reference graph (M03-F04)
 	bus           *event.Bus           // application/document/modeling events (M04-F04)
 	externalFiles ExternalFileProbe    // foreign-file access for attachments (M03-F08)
@@ -35,6 +36,7 @@ func NewWorkspace(store Store) *Workspace {
 		store:         store,
 		byID:          map[ID]*Document{},
 		byName:        map[string]*Document{},
+		byGUID:        map[string]*Document{},
 		bus:           event.NewBus(),
 		externalFiles: osFileProbe{},
 	}
@@ -133,6 +135,7 @@ func (ws *Workspace) loadNew(fullDocumentName string, opts OpenOptions) (*Docume
 		return nil, err
 	}
 	d.visible = opts.Visible
+	ws.reassignCollidingIdentity(d)
 	ws.register(d)
 	if opts.Background {
 		ws.active = prevActive // register() activated d; a background load must not switch focus
@@ -233,6 +236,29 @@ func (ws *Workspace) SaveAs(d *Document, newFullDocumentName string) error {
 	return ws.Save(d)
 }
 
+// reassignCollidingIdentity mints d a fresh identity GUID when an already-open document
+// carries the same one. Two open files must never share an identity (references key on it,
+// and the UI tabs it by it), but a file copied outside the application keeps the source's
+// GUID, so a collision is detected on open and resolved here. The new GUID lives in memory
+// until d's next save persists it; d is marked dirty so the save happens, and the host is
+// told via [DocumentIdentityReassigned] so it can notify the user.
+func (ws *Workspace) reassignCollidingIdentity(d *Document) {
+	guid := d.identity.InternalName
+	if guid == "" {
+		return
+	}
+	existing, clash := ws.byGUID[guid]
+	if !clash || existing == d {
+		return
+	}
+	fresh := mintFileGUID()
+	d.identity.InternalName = fresh
+	d.dirty = true
+	event.Emit(ws.bus, event.After, DocumentIdentityReassigned{
+		Document: d, PreviousInternalName: guid, NewInternalName: fresh,
+	})
+}
+
 // register inserts d into all indexes, links it to the reference graph, and makes
 // it the active document.
 func (ws *Workspace) register(d *Document) {
@@ -240,5 +266,8 @@ func (ws *Workspace) register(d *Document) {
 	ws.ordered = append(ws.ordered, d)
 	ws.byID[d.id] = d
 	ws.byName[d.fullDocumentName] = d
+	if guid := d.identity.InternalName; guid != "" {
+		ws.byGUID[guid] = d
+	}
 	ws.active = d
 }

--- a/model/doc/workspace_query.go
+++ b/model/doc/workspace_query.go
@@ -133,6 +133,9 @@ func (ws *Workspace) CloseAll(unreferencedOnly, skipSave bool) error {
 func (ws *Workspace) remove(d *Document) {
 	delete(ws.byID, d.id)
 	delete(ws.byName, d.fullDocumentName)
+	if guid := d.identity.InternalName; guid != "" && ws.byGUID[guid] == d {
+		delete(ws.byGUID, guid)
+	}
 	for i, other := range ws.ordered {
 		if other == d {
 			ws.ordered = append(ws.ordered[:i], ws.ordered[i+1:]...)

--- a/model/doc/workspace_test.go
+++ b/model/doc/workspace_test.go
@@ -14,8 +14,9 @@ type fakeStore struct {
 }
 
 type storedDoc struct {
-	docType     DocumentType
-	displayName string
+	docType      DocumentType
+	displayName  string
+	internalName string // persisted identity GUID; "" keeps the freshly minted one
 }
 
 func newFakeStore() *fakeStore { return &fakeStore{saved: map[string]storedDoc{}} }
@@ -40,7 +41,11 @@ func (s *fakeStore) Load(fullDocumentName string) (*Document, error) {
 		return nil, errNotStored{fullDocumentName}
 	}
 	s.loads++
-	return Restore(rec.docType, fullDocumentName, rec.displayName)
+	d, err := Restore(rec.docType, fullDocumentName, rec.displayName)
+	if err == nil && rec.internalName != "" {
+		d.SetFileIdentity(FileIdentity{InternalName: rec.internalName})
+	}
+	return d, err
 }
 
 func (s *fakeStore) Exists(fullDocumentName string) bool {


### PR DESCRIPTION
Found during the M14 live drawing audit: with a part and a drawing of it open together (`box.opd` + `box.odd`), the head's active document flips between the two every frame, breaking the drawing tools and sheet canvas (which act on the active document).

## Root cause
ImGui keys tab items by their **label string**. `Document.DisplayName()` strips the path and extension, so a part `box.opd` and a drawing `box.odd` both display as `box` and hash to the **same tab id**. ImGui reports both tabs as selected and the per-frame reconciliation toggles the active document between the collided tabs every frame. This is the common case — a drawing is almost always made *of* a part with the same base name.

## What changed

### 1. Unique tab id (the flicker fix) — `head/ui/chrome_doctabs.go`
Identify each tab by the document's persisted identity GUID via the `label###id` idiom, so the visible text stays the bare display name and the id is unique and rename-stable.

### 2. Enforce unique identity GUIDs across open files — `model/doc`
Keying tabs (and references) on the identity GUID only holds if two open files never share one. A file copied *outside* the application keeps the source's GUID, so:
- the `Workspace` now indexes open documents by identity GUID and, on open, **mints a fresh GUID for any document whose persisted id collides with an already-open one**;
- the reassigned document is marked dirty so the new id is **written on its next save**;
- a `DocumentIdentityReassigned` event fires and the session surfaces it as a **user notice** ("… was assigned a new id, which will be written on its next save").
- **Save-as-copy** already mints a fresh identity (`CopyIdentity`); now covered by a focused unit test in addition to the persistence round-trip test.

## Tests
- `head/ui`: two documents with colliding display names produce distinct tab labels.
- `model/doc`: opening a second file with the same persisted GUID reassigns it (fresh id, dirty, event); closing frees the id for reopen; `CopyIdentity` mints a fresh id while carrying the source's model stamp.
- `app`: the session sets a user notice on `DocumentIdentityReassigned`.

Verified live over the MCP bridge: the two `box` tabs now coexist without flipping, and the full M14 drawing surface (base/projected/auxiliary/section/detail/break/slice/breakout/draft views, CoG marker, revision cloud, DXF export) drives end-to-end.

Closes #995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)