### PR TITLE
fix(head): add a sheet-tab switcher to the drawing canvas

### DIFF
--- a/head/ui/sheet_canvas.go
+++ b/head/ui/sheet_canvas.go
@@ -42,7 +42,8 @@ type rect struct {
 // handles canvas interaction (view placement, selection, right-click) — the drawing
 // counterpart of the 3D viewport.
 func drawSheetCanvas(s *app.Session, c *drawing.Content) {
-	c.SyncViews() // re-project if the referenced model was recomputed (live associativity)
+	c.SyncViews()    // re-project if the referenced model was recomputed (live associativity)
+	drawSheetTabs(c) // a tab per sheet so the user can switch which sheet the canvas shows
 	sheet := c.Sheets().Active()
 	ox, oy := native.GetCursorScreenPos()
 	availW, availH := native.ContentRegionAvail()
@@ -61,6 +62,56 @@ func drawSheetCanvas(s *app.Session, c *drawing.Content) {
 	drawSheetViews(s, face, sheet)
 	drawSheetCaption(ox, oy, sheet, c.ModelReference(), c.Styles().ActiveStandard().String())
 	handleSheetCanvasInput(s, face, hovered, mx, my)
+}
+
+// prevActiveSheetName tracks the active sheet across frames so a programmatic switch (New Sheet
+// on the ribbon, an add-in) force-selects its tab once without fighting the user's tab clicks —
+// the same one-frame-force pattern the document tabs use.
+var prevActiveSheetName string
+
+// drawSheetTabs renders a tab per sheet at the top of the drawing canvas so the user can switch
+// the active sheet (the canvas only shows the active sheet). Clicking a tab activates that sheet;
+// New Sheet / Delete Sheet stay on the ribbon. With a single sheet there is nothing to switch, so
+// no strip is drawn.
+func drawSheetTabs(c *drawing.Content) {
+	sheets := c.Sheets()
+	if sheets.Count() <= 1 {
+		prevActiveSheetName = ""
+		return
+	}
+	active := sheets.Active()
+	var cur string
+	if active != nil {
+		cur = active.Name()
+	}
+	force := cur != prevActiveSheetName
+	prevActiveSheetName = cur
+	if native.BeginTabBar("##sheet-tabs") {
+		for i := 0; i < sheets.Count(); i++ {
+			drawSheetTab(sheets, sheets.Item(i), active, force)
+		}
+		native.EndTabBar()
+	}
+}
+
+// drawSheetTab renders one sheet's tab and activates it when the user selects it (but not on the
+// force frame, which only mirrors an external switch into ImGui's selection).
+func drawSheetTab(sheets *drawing.Sheets, sh, active *drawing.Sheet, force bool) {
+	selected := force && active != nil && sh.Name() == active.Name()
+	if !native.BeginTabItemSelected(sheetTabLabel(sh), selected) {
+		return
+	}
+	if !force && (active == nil || sh.Name() != active.Name()) {
+		_ = sheets.SetActive(sh.Name())
+	}
+	native.EndTabItem()
+}
+
+// sheetTabLabel is the ImGui label for a sheet's tab: the sheet name, with a stable "###id" suffix
+// (sheet names are unique within a drawing) so the visible text is just the name. See the document
+// tabs for why ImGui tab ids must not collide.
+func sheetTabLabel(sh *drawing.Sheet) string {
+	return sh.Name() + "###sheet-" + sh.Name()
 }
 
 // View-curve colors: visible edges solid dark ink, hidden edges dashed in a lighter grey.

--- a/head/ui/sheet_canvas_inwindow_test.go
+++ b/head/ui/sheet_canvas_inwindow_test.go
@@ -95,3 +95,30 @@ func TestInWindowDrawingCanvasRenders(t *testing.T) {
 		t.Error("rendered base view lost its curves")
 	}
 }
+
+// TestInWindowDrawingSheetTabsRender renders a drawing with two sheets so the sheet-tab strip
+// (drawSheetTabs) actually executes — the affordance for switching the active sheet, which only
+// appears when a drawing has more than one sheet. Skips when no display/Vulkan is available.
+func TestInWindowDrawingSheetTabsRender(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := drawingWithViewsSession(t)
+	c, _ := app.ActiveDrawing(s)
+	if _, err := c.Sheets().Add(drawing.SheetSpec{Size: types.SheetSizeA3, Orientation: types.SheetLandscape}); err != nil {
+		t.Fatalf("add second sheet: %v", err)
+	}
+	if c.Sheets().Count() != 2 {
+		t.Fatalf("want 2 sheets for a tab strip, got %d", c.Sheets().Count())
+	}
+
+	// Several frames: the first force-selects the active tab; later frames let ImGui drive —
+	// exercising the whole sheet-tab strip (force and steady-state paths).
+	for i := 0; i < 4; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}

--- a/head/ui/sheet_canvas_tabs_test.go
+++ b/head/ui/sheet_canvas_tabs_test.go
@@ -1,0 +1,54 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/drawing"
+)
+
+// TestSheetTabLabelShowsNameWithStableID: a sheet tab displays just the sheet name, with a
+// "###id" suffix so ImGui keys the tab uniquely without showing the id.
+func TestSheetTabLabelShowsNameWithStableID(t *testing.T) {
+	c := drawing.NewContent()
+	sh := c.Sheets().Active()
+	label := sheetTabLabel(sh)
+	visible, _, found := strings.Cut(label, "###")
+	if !found || visible != sh.Name() {
+		t.Errorf("label %q: want visible text %q before a \"###\" id suffix", label, sh.Name())
+	}
+}
+
+// TestSheetSwitchingChangesActiveSheet proves the canvas's switch path: activating another sheet
+// changes which sheet Sheets().Active() returns (the sheet the canvas draws). This is the model
+// behaviour a sheet-tab click invokes via SetActive.
+func TestSheetSwitchingChangesActiveSheet(t *testing.T) {
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Drawing, "deck.odd", true)
+	if err != nil {
+		t.Fatalf("add drawing: %v", err)
+	}
+	c := d.Content().(*drawing.Content)
+	first := c.Sheets().Active().Name()
+	second, err := c.Sheets().Add(drawing.SheetSpec{Size: types.SheetSizeA3, Orientation: types.SheetLandscape})
+	if err != nil {
+		t.Fatalf("add second sheet: %v", err)
+	}
+	if c.Sheets().Active().Name() != second.Name() {
+		t.Fatalf("a new sheet should become active, got %q", c.Sheets().Active().Name())
+	}
+
+	if err := c.Sheets().SetActive(first); err != nil {
+		t.Fatalf("switch back to %q: %v", first, err)
+	}
+	if got := c.Sheets().Active().Name(); got != first {
+		t.Errorf("active sheet = %q after switching, want %q", got, first)
+	}
+}


### PR DESCRIPTION
## Problem
A drawing with multiple sheets had **no way to switch the active sheet** in the UI. The sheet canvas renders only the active sheet, the browser's sheet nodes aren't clickable, and New/Delete Sheet on the ribbon don't let you choose which sheet to view — so a second sheet was effectively unreachable. (Spotted during the M14 live audit: Sheet:1 + Sheet:2 in the browser, but no switch.)

## Fix
A tab strip across the top of the drawing canvas, one tab per sheet (shown only when there's more than one). Clicking a tab activates that sheet — the canvas, caption and title block follow. A programmatic switch (New Sheet, an add-in, `drawing.setActiveSheet`) force-selects the matching tab on the change frame only, so hand clicks still work; the tab carries a stable `###id` suffix so ImGui tab ids never collide (same lesson as the document tabs).

No API change: `Sheets().SetActive` and the `drawing.setActiveSheet` wire method already exist — this is purely the missing head affordance.

## Tests
- `head/ui`: `sheetTabLabel` shows the bare sheet name with a `###id` suffix; switching the active sheet changes which sheet the canvas reads.

## Verified live over the MCP bridge
- A 2-sheet drawing shows `Sheet:1  Sheet:2` tabs; Sheet:2 active shows the ISO view, and `drawing.setActiveSheet Sheet:1` flips the selected tab and the canvas to the FRONT view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)