### PR TITLE
feat(drawing): readable dimension text + drag to reposition (M14-F03)

### DIFF
--- a/app/drawing_dimension_actions.go
+++ b/app/drawing_dimension_actions.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"math"
+
+	"oblikovati.org/model/drawing"
+)
+
+// Drawing-dimension canvas interaction (M14-F03): a dimension's value text and its dimension line
+// can be grabbed and dragged on the sheet, so overlapping dimensions are separated for readability.
+
+// dimDragState tracks an in-progress drag of a dimension's text or line across frames.
+type dimDragState struct {
+	name   string
+	text   bool
+	active bool
+}
+
+// DragDimension drives a dimension drag on the canvas from the canvas item's ImGui state
+// (itemActive/itemClicked), the cursor in sheet mm (cx,cy) and the per-frame move in sheet mm
+// (dx,dy). It returns true while a drag is in progress, so the head suppresses view selection.
+func (s *Session) DragDimension(itemActive, itemClicked bool, cx, cy, dx, dy float64) bool {
+	if s.dimDrag.active {
+		if !itemActive {
+			s.dimDrag.active = false
+			return false
+		}
+		if dx != 0 || dy != 0 {
+			if s.dimDrag.text {
+				s.MoveDimensionText(s.dimDrag.name, dx, dy)
+			} else {
+				s.MoveDimensionLine(s.dimDrag.name, dx, dy)
+			}
+		}
+		return true
+	}
+	if itemClicked {
+		if name, text, ok := s.PickDrawingDimensionAt(cx, cy); ok {
+			s.dimDrag.name, s.dimDrag.text, s.dimDrag.active = name, text, true
+			return true
+		}
+	}
+	return false
+}
+
+// PickDrawingDimensionAt finds the topmost active-sheet dimension near the sheet point (mm) and
+// reports whether the pick landed on its value text (grabText) rather than its line.
+func (s *Session) PickDrawingDimensionAt(xMM, yMM float64) (name string, grabText, ok bool) {
+	c, err := ActiveDrawing(s)
+	if err != nil {
+		return "", false, false
+	}
+	const textR, lineR = 7.0, 3.0 // mm pick tolerances
+	ds := c.Sheets().Active().Dimensions()
+	for i := ds.Count() - 1; i >= 0; i-- {
+		d := ds.Item(i)
+		tx, ty := d.TextAnchorMM()
+		if math.Hypot(xMM-tx, yMM-ty) <= textR {
+			return d.Name(), true, true
+		}
+		if nearDimensionLine(d, xMM, yMM, lineR) {
+			return d.Name(), false, true
+		}
+	}
+	return "", false, false
+}
+
+// nearDimensionLine reports whether (x, y) lies within tol of any of the dimension's curves.
+func nearDimensionLine(d *drawing.DrawingDimension, x, y, tol float64) bool {
+	for _, c := range d.Curves() {
+		if pointSegmentDistanceMM(x, y, float64(c.Start().X), float64(c.Start().Y), float64(c.End().X), float64(c.End().Y)) <= tol {
+			return true
+		}
+	}
+	return false
+}
+
+// MoveDimensionText nudges a dimension's value text by (dx, dy) sheet mm (drag-the-text).
+func (s *Session) MoveDimensionText(name string, dx, dy float64) {
+	if c, err := ActiveDrawing(s); err == nil {
+		c.Sheets().Active().Dimensions().MoveText(name, dx, dy)
+		s.markActiveDirty()
+	}
+}
+
+// MoveDimensionLine shifts a dimension's line by (dx, dy) sheet mm (drag-the-line).
+func (s *Session) MoveDimensionLine(name string, dx, dy float64) {
+	if c, err := ActiveDrawing(s); err == nil {
+		c.Sheets().Active().Dimensions().MoveLine(name, dx, dy)
+		s.markActiveDirty()
+	}
+}
+
+// markActiveDirty marks the active document dirty after a canvas edit.
+func (s *Session) markActiveDirty() {
+	if d := s.ActiveDocument(); d != nil {
+		d.MarkDirty()
+	}
+}
+
+// pointSegmentDistanceMM is the distance from (px, py) to the segment (ax, ay)-(bx, by).
+func pointSegmentDistanceMM(px, py, ax, ay, bx, by float64) float64 {
+	dx, dy := bx-ax, by-ay
+	l2 := dx*dx + dy*dy
+	if l2 < 1e-12 {
+		return math.Hypot(px-ax, py-ay)
+	}
+	t := math.Max(0, math.Min(1, ((px-ax)*dx+(py-ay)*dy)/l2))
+	return math.Hypot(px-(ax+t*dx), py-(ay+t*dy))
+}

--- a/app/drawing_dimension_actions.go
+++ b/app/drawing_dimension_actions.go
@@ -18,6 +18,12 @@ type dimDragState struct {
 	active bool
 }
 
+// DraggingDimension reports the dimension currently being dragged and whether its text (vs its
+// line) is the grabbed part — so the canvas can highlight the active selection.
+func (s *Session) DraggingDimension() (name string, text, active bool) {
+	return s.dimDrag.name, s.dimDrag.text, s.dimDrag.active
+}
+
 // DragDimension drives a dimension drag on the canvas from the canvas item's ImGui state
 // (itemActive/itemClicked), the cursor in sheet mm (cx,cy) and the per-frame move in sheet mm
 // (dx,dy). It returns true while a drag is in progress, so the head suppresses view selection.

--- a/app/drawing_dimension_actions_test.go
+++ b/app/drawing_dimension_actions_test.go
@@ -66,6 +66,9 @@ func TestDragDimensionStateMachine(t *testing.T) {
 	if !s.DragDimension(true, true, tx, ty, 0, 0) {
 		t.Fatal("press on a dimension's text should start a drag")
 	}
+	if name, text, active := s.DraggingDimension(); !active || !text || name != d.Name() {
+		t.Errorf("DraggingDimension = (%q,%v,%v), want the text of %q active", name, text, active, d.Name())
+	}
 	// Held with a move nudges the text.
 	s.DragDimension(true, false, tx, ty, 4, -2)
 	if nx, ny := d.TextAnchorMM(); nx != tx+4 || ny != ty-2 {

--- a/app/drawing_dimension_actions_test.go
+++ b/app/drawing_dimension_actions_test.go
@@ -2,11 +2,16 @@
 
 package app
 
-import "testing"
+import (
+	"testing"
 
-// TestPickAndMoveDrawingDimension: a dimension's text and line can be picked on the canvas and
-// moved, so overlapping dimensions are separated.
-func TestPickAndMoveDrawingDimension(t *testing.T) {
+	"oblikovati.org/model/drawing"
+)
+
+// dimensionedDrawingSession builds a boxed-part drawing with one placed base view + linear
+// dimension — the shared fixture for the dimension-canvas-interaction tests.
+func dimensionedDrawingSession(t *testing.T) (*Session, *drawing.DrawingDimension) {
+	t.Helper()
 	s := drawingWithModelSession(t)
 	base := NewBaseViewTool()
 	base.Start(s)
@@ -20,7 +25,13 @@ func TestPickAndMoveDrawingDimension(t *testing.T) {
 		t.Fatalf("place dimension: %v", err)
 	}
 	c, _ := ActiveDrawing(s)
-	d := c.Sheets().Active().Dimensions().Item(0)
+	return s, c.Sheets().Active().Dimensions().Item(0)
+}
+
+// TestPickAndMoveDrawingDimension: a dimension's text and line can be picked on the canvas and
+// moved, so overlapping dimensions are separated.
+func TestPickAndMoveDrawingDimension(t *testing.T) {
+	s, d := dimensionedDrawingSession(t)
 
 	// Picking at the text anchor grabs the text.
 	tx, ty := d.TextAnchorMM()
@@ -46,20 +57,7 @@ func TestPickAndMoveDrawingDimension(t *testing.T) {
 // TestDragDimensionStateMachine: a press over the text starts a drag, subsequent active frames
 // move the text, and releasing ends it.
 func TestDragDimensionStateMachine(t *testing.T) {
-	s := drawingWithModelSession(t)
-	base := NewBaseViewTool()
-	base.Start(s)
-	base.SetPlacement(120, 100)
-	if err := base.Commit(s); err != nil {
-		t.Fatalf("place base view: %v", err)
-	}
-	lin := NewLinearDimensionTool()
-	lin.Start(s)
-	if err := lin.Commit(s); err != nil {
-		t.Fatalf("place dimension: %v", err)
-	}
-	c, _ := ActiveDrawing(s)
-	d := c.Sheets().Active().Dimensions().Item(0)
+	s, d := dimensionedDrawingSession(t)
 	tx, ty := d.TextAnchorMM()
 
 	// Press on the text (itemClicked) starts the drag and consumes the input.

--- a/app/drawing_dimension_actions_test.go
+++ b/app/drawing_dimension_actions_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestPickAndMoveDrawingDimension: a dimension's text and line can be picked on the canvas and
+// moved, so overlapping dimensions are separated.
+func TestPickAndMoveDrawingDimension(t *testing.T) {
+	s := drawingWithModelSession(t)
+	base := NewBaseViewTool()
+	base.Start(s)
+	base.SetPlacement(120, 100)
+	if err := base.Commit(s); err != nil {
+		t.Fatalf("place base view: %v", err)
+	}
+	lin := NewLinearDimensionTool()
+	lin.Start(s)
+	if err := lin.Commit(s); err != nil {
+		t.Fatalf("place dimension: %v", err)
+	}
+	c, _ := ActiveDrawing(s)
+	d := c.Sheets().Active().Dimensions().Item(0)
+
+	// Picking at the text anchor grabs the text.
+	tx, ty := d.TextAnchorMM()
+	name, grabText, ok := s.PickDrawingDimensionAt(tx, ty)
+	if !ok || !grabText || name != d.Name() {
+		t.Fatalf("pick at text = (%q,%v,%v), want (%q,true,true)", name, grabText, ok, d.Name())
+	}
+	s.MoveDimensionText(name, 6, 3)
+	if nx, ny := d.TextAnchorMM(); nx != tx+6 || ny != ty+3 {
+		t.Errorf("text moved to (%v,%v), want (%v,%v)", nx, ny, tx+6, ty+3)
+	}
+
+	// Picking on the dimension line away from the (centred) text grabs the line, not the text.
+	line := d.Curves()[2]
+	lx := float64(line.Start().X)*0.8 + float64(line.End().X)*0.2
+	ly := float64(line.Start().Y)*0.8 + float64(line.End().Y)*0.2
+	_, grabText, ok = s.PickDrawingDimensionAt(lx, ly)
+	if !ok || grabText {
+		t.Errorf("pick on line = (grabText %v, ok %v), want (false, true)", grabText, ok)
+	}
+}
+
+// TestDragDimensionStateMachine: a press over the text starts a drag, subsequent active frames
+// move the text, and releasing ends it.
+func TestDragDimensionStateMachine(t *testing.T) {
+	s := drawingWithModelSession(t)
+	base := NewBaseViewTool()
+	base.Start(s)
+	base.SetPlacement(120, 100)
+	if err := base.Commit(s); err != nil {
+		t.Fatalf("place base view: %v", err)
+	}
+	lin := NewLinearDimensionTool()
+	lin.Start(s)
+	if err := lin.Commit(s); err != nil {
+		t.Fatalf("place dimension: %v", err)
+	}
+	c, _ := ActiveDrawing(s)
+	d := c.Sheets().Active().Dimensions().Item(0)
+	tx, ty := d.TextAnchorMM()
+
+	// Press on the text (itemClicked) starts the drag and consumes the input.
+	if !s.DragDimension(true, true, tx, ty, 0, 0) {
+		t.Fatal("press on a dimension's text should start a drag")
+	}
+	// Held with a move nudges the text.
+	s.DragDimension(true, false, tx, ty, 4, -2)
+	if nx, ny := d.TextAnchorMM(); nx != tx+4 || ny != ty-2 {
+		t.Errorf("dragged text to (%v,%v), want (%v,%v)", nx, ny, tx+4, ty-2)
+	}
+	// Release ends the drag (no longer consumes input).
+	if s.DragDimension(false, false, tx, ty, 0, 0) {
+		t.Error("releasing should end the drag")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -55,6 +55,7 @@ type Session struct {
 	regionPicker         RegionPicker      // resolves a box-select rectangle (nil ⇒ box-select disabled)
 	boxSelect            BoxSelection      // the in-progress rubber-band rectangle, if any
 	entityDrag           sketchDrag        // the in-progress direct drag of sketch entities, if any
+	dimDrag              dimDragState      // the in-progress drag of a drawing dimension's text/line
 	selectOther          selectOther       // the in-progress Select Other cycle, if any
 	viewHistory          viewHistory       // recorded views for Previous View (F5)
 	selectionPriority    SelectionPriority // biases no-tool picking (Edge/Face/Part) (#912)

--- a/head/ui/sheet_canvas.go
+++ b/head/ui/sheet_canvas.go
@@ -7,6 +7,7 @@ package ui
 import (
 	"fmt"
 	stdmath "math"
+	"unicode/utf8"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/app"
@@ -153,7 +154,9 @@ func drawSheetDimensions(face rect, sheet *drawing.Sheet) {
 			native.DrawLine(ax, ay, bx, by, viewVisibleInk, 1.2)
 		}
 		tx, ty := curveToScreen(face, math.P2(math.Scalar(dimAnchorX(d)), math.Scalar(dimAnchorY(d))))
-		native.DrawText(tx+2, ty-14, d.Text(), sheetInk)
+		// Centre the value text on its anchor (already lifted off the dimension line).
+		runes := utf8.RuneCountInString(d.Text())
+		native.DrawText(tx-float32(runes)*3.2, ty-7, d.Text(), sheetInk)
 	}
 }
 

--- a/head/ui/sheet_canvas.go
+++ b/head/ui/sheet_canvas.go
@@ -139,25 +139,42 @@ func drawSheetViews(s *app.Session, face rect, sheet *drawing.Sheet) {
 		}
 	}
 	drawSheetAnnotations(face, sheet)
-	drawSheetDimensions(face, sheet)
+	drawSheetDimensions(s, face, sheet)
 }
 
-// drawSheetDimensions strokes each dimension's glyph (extension/dimension lines, arrowheads) in
-// the ink colour and draws its measured value at the dimension-line midpoint.
-func drawSheetDimensions(face rect, sheet *drawing.Sheet) {
+// drawSheetDimensions strokes each dimension's glyph (extension/dimension lines, arrowheads) and
+// draws its centred value text. The part being dragged (the line or the text) is highlighted so
+// the active selection is visible.
+func drawSheetDimensions(s *app.Session, face rect, sheet *drawing.Sheet) {
+	dragName, dragText, dragging := s.DraggingDimension()
 	ds := sheet.Dimensions()
 	for i := 0; i < ds.Count(); i++ {
 		d := ds.Item(i)
+		grabbed := dragging && d.Name() == dragName
+		lineInk, thick := viewVisibleInk, float32(1.2)
+		if grabbed && !dragText {
+			lineInk, thick = viewSelectInk, 1.8
+		}
 		for _, c := range d.Curves() {
 			ax, ay := curveToScreen(face, c.Start())
 			bx, by := curveToScreen(face, c.End())
-			native.DrawLine(ax, ay, bx, by, viewVisibleInk, 1.2)
+			native.DrawLine(ax, ay, bx, by, lineInk, thick)
 		}
 		tx, ty := curveToScreen(face, math.P2(math.Scalar(dimAnchorX(d)), math.Scalar(dimAnchorY(d))))
-		// Centre the value text on its anchor (already lifted off the dimension line).
-		runes := utf8.RuneCountInString(d.Text())
-		native.DrawText(tx-float32(runes)*3.2, ty-7, d.Text(), sheetInk)
+		runes := utf8.RuneCountInString(d.Text()) // centre the text on its (lifted) anchor
+		textInk := sheetInk
+		if grabbed && dragText {
+			textInk = viewSelectInk
+			drawTextHighlightBox(tx, ty, runes)
+		}
+		native.DrawText(tx-float32(runes)*3.2, ty-7, d.Text(), textInk)
 	}
+}
+
+// drawTextHighlightBox outlines the dragged value text in the highlight colour.
+func drawTextHighlightBox(tx, ty float32, runes int) {
+	w := float32(runes)*6.4 + 4
+	rectOutline(rect{x: tx - w/2, y: ty - 9, w: w, h: 16}, viewSelectInk, 1)
 }
 
 // dimAnchorX / dimAnchorY split the dimension's text-anchor for the mm→screen mapping.

--- a/head/ui/sheet_canvas_input.go
+++ b/head/ui/sheet_canvas_input.go
@@ -36,8 +36,24 @@ func handleSheetCanvasInput(s *app.Session, face rect, hovered bool, mx, my floa
 			return
 		}
 	}
+	if handleDimensionDrag(s, face, hovered, cx, cy) {
+		return
+	}
 	handleSelection(s, hovered, cx, cy)
 	drawViewCtxMenu(s)
+}
+
+// handleDimensionDrag forwards the canvas item's ImGui state and the per-frame mouse move to the
+// session's dimension-drag state machine, returning true while a drag is in progress so view
+// selection is suppressed. The drag logic itself lives in app (Session.DragDimension).
+func handleDimensionDrag(s *app.Session, face rect, hovered bool, cx, cy float64) bool {
+	ddx, ddy := native.MouseDelta()
+	var dx, dy float64
+	if face.scale != 0 {
+		dx, dy = float64(ddx)/float64(face.scale), -float64(ddy)/float64(face.scale)
+	}
+	clicked := hovered && native.IsItemClicked(native.MouseLeft)
+	return s.DragDimension(native.IsItemActive(), clicked, cx, cy, dx, dy)
 }
 
 // handlePlacement tracks the cursor as the pending view centre, draws the preview there, and

--- a/head/ui/sheet_canvas_inwindow_test.go
+++ b/head/ui/sheet_canvas_inwindow_test.go
@@ -9,6 +9,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
@@ -80,31 +81,19 @@ func TestInWindowDrawingCanvasRenders(t *testing.T) {
 
 	// Frame 1–2: a base-view placement tool is active → the preview branch renders.
 	s.StartTool(app.NewBaseViewTool())
-	for i := 0; i < 2; i++ {
-		win.BeginFrame()
-		DrawChrome(win, s)
-		win.EndFrame(0.1, 0.1, 0.1)
-	}
+	renderChromeFrames(win, s, 2)
 	s.CancelTool()
 
 	// Frame 3–4: a view is selected → the highlight + selection branch render.
 	s.Select(app.DrawingViewHandle{Views: views, View: views.Item(0)})
-	for i := 0; i < 2; i++ {
-		win.BeginFrame()
-		DrawChrome(win, s)
-		win.EndFrame(0.1, 0.1, 0.1)
-	}
+	renderChromeFrames(win, s, 2)
 
 	// Frame 5–6: a dimension's text is being dragged → its highlight branch renders.
 	dc, _ := app.ActiveDrawing(s)
 	if d := dc.Sheets().Active().Dimensions().Item(0); d != nil {
 		tx, ty := d.TextAnchorMM()
 		s.DragDimension(true, true, tx, ty, 0, 0)
-		for i := 0; i < 2; i++ {
-			win.BeginFrame()
-			DrawChrome(win, s)
-			win.EndFrame(0.1, 0.1, 0.1)
-		}
+		renderChromeFrames(win, s, 2)
 	}
 
 	if views.Item(0).CurveCount() == 0 {
@@ -132,7 +121,12 @@ func TestInWindowDrawingSheetTabsRender(t *testing.T) {
 
 	// Several frames: the first force-selects the active tab; later frames let ImGui drive —
 	// exercising the whole sheet-tab strip (force and steady-state paths).
-	for i := 0; i < 4; i++ {
+	renderChromeFrames(win, s, 4)
+}
+
+// renderChromeFrames draws n full chrome frames — the in-window tests' shared render loop.
+func renderChromeFrames(win *native.Window, s *app.Session, n int) {
+	for i := 0; i < n; i++ {
 		win.BeginFrame()
 		DrawChrome(win, s)
 		win.EndFrame(0.1, 0.1, 0.1)

--- a/head/ui/sheet_canvas_inwindow_test.go
+++ b/head/ui/sheet_canvas_inwindow_test.go
@@ -95,6 +95,18 @@ func TestInWindowDrawingCanvasRenders(t *testing.T) {
 		win.EndFrame(0.1, 0.1, 0.1)
 	}
 
+	// Frame 5–6: a dimension's text is being dragged → its highlight branch renders.
+	dc, _ := app.ActiveDrawing(s)
+	if d := dc.Sheets().Active().Dimensions().Item(0); d != nil {
+		tx, ty := d.TextAnchorMM()
+		s.DragDimension(true, true, tx, ty, 0, 0)
+		for i := 0; i < 2; i++ {
+			win.BeginFrame()
+			DrawChrome(win, s)
+			win.EndFrame(0.1, 0.1, 0.1)
+		}
+	}
+
 	if views.Item(0).CurveCount() == 0 {
 		t.Error("rendered base view lost its curves")
 	}

--- a/model/drawing/dimension.go
+++ b/model/drawing/dimension.go
@@ -35,10 +35,17 @@ type DrawingDimension struct {
 	valueMM  float64 // measured model distance (mm), scale-independent (0 for angular)
 	valueDeg float64 // measured angle (degrees) for an angular dimension
 	text     string  // displayed text (the formatted value)
-	anchorX  float64 // dimension-line midpoint (sheet mm) — where the head draws the text
+	anchorX  float64 // text anchor (sheet mm), lifted off the dimension line by textGapMM
 	anchorY  float64
+	textDX   float64 // user text nudge from the anchor (sheet mm) — drag the text to set it
+	textDY   float64
+	nx       float64 // unit perpendicular of the dimension line — text-lift + line-drag direction
+	ny       float64
 	curves   []DrawingCurve
 }
+
+// textGapMM lifts the value text off the dimension line so it stays readable by default.
+const textGapMM = 5.0
 
 var _ contract.DrawingDimension = (*DrawingDimension)(nil)
 
@@ -53,7 +60,9 @@ func (d *DrawingDimension) CurveCount() int                  { return len(d.curv
 func (d *DrawingDimension) Curves() []DrawingCurve           { return d.curves }
 
 // TextAnchorMM is the dimension line's midpoint (sheet mm) — where the value text is centred.
-func (d *DrawingDimension) TextAnchorMM() (x, y float64) { return d.anchorX, d.anchorY }
+func (d *DrawingDimension) TextAnchorMM() (x, y float64) {
+	return d.anchorX + d.textDX, d.anchorY + d.textDY
+}
 
 // DrawingDimensions is a sheet's dimension collection. It holds the view collection (to resolve a
 // dimension's view and project through it) and the body-resolution hook (to re-bind the attached
@@ -195,6 +204,27 @@ func (ds *DrawingDimensions) addAngularEdges(viewName string, keyA, keyB []byte)
 	return d
 }
 
+// MoveText nudges the named dimension's value text by (dx, dy) sheet millimetres — the drag-the-
+// text gesture, so overlapping dimensions can be separated for readability.
+func (ds *DrawingDimensions) MoveText(name string, dx, dy float64) {
+	if d, ok := ds.ByName(name); ok {
+		d.textDX += dx
+		d.textDY += dy
+	}
+}
+
+// MoveLine shifts the named dimension's dimension line perpendicular to itself by the drag
+// (dx, dy) sheet millimetres and re-derives the glyph — the drag-the-line gesture. Linear only in
+// this increment (radial/angular line position is fixed; nudge their text instead).
+func (ds *DrawingDimensions) MoveLine(name string, dx, dy float64) {
+	d, ok := ds.ByName(name)
+	if !ok || isRadial(d.dimType) || d.dimType == types.AngularDimension {
+		return
+	}
+	d.offset += dx*d.nx + dy*d.ny
+	ds.recompute(d)
+}
+
 // Recompute re-measures every dimension against the current model — the associativity path.
 func (ds *DrawingDimensions) Recompute() {
 	for _, d := range ds.items {
@@ -231,7 +261,9 @@ func (ds *DrawingDimensions) recomputeAngular(d *DrawingDimension, view *Drawing
 	}
 	d.valueDeg = angleBetweenDeg(a.dir, b.dir)
 	d.text = strconv.FormatFloat(d.valueDeg, 'g', 4, 64) + "°"
-	d.curves, d.anchorX, d.anchorY = angularDimensionCurves(a, b)
+	curves, mx, my, nx, ny := angularDimensionCurves(a, b)
+	d.curves = curves
+	d.setTextAnchor(mx, my, nx, ny, 1)
 }
 
 // recomputeLinear re-binds the two vertices, re-projects them and rebuilds the linear glyph.
@@ -247,7 +279,21 @@ func (ds *DrawingDimensions) recomputeLinear(d *DrawingDimension, view *DrawingV
 	d.text = strconv.FormatFloat(d.valueMM, 'g', 4, 64)
 	s1, s2 := view.place(p1), view.place(p2)
 	ax, ay := dimensionAxis(d.dimType, s1, s2)
-	d.curves, d.anchorX, d.anchorY = linearDimensionCurves(s1, s2, ax, ay, d.offset)
+	var mx, my float64
+	d.curves, mx, my = linearDimensionCurves(s1, s2, ax, ay, d.offset)
+	// Lift the text off the dimension line, on the side away from the measured geometry.
+	d.setTextAnchor(mx, my, -ay, ax, sign(d.offset))
+}
+
+// setTextAnchor records the dimension-line midpoint (mx, my) and the dimension line's unit
+// perpendicular nx,ny (the offset axis — line-drag follows it). It lifts the default text anchor
+// textGapMM off the line along liftSign*perpendicular (away from the measured geometry).
+func (d *DrawingDimension) setTextAnchor(mx, my, nx, ny, liftSign float64) {
+	if l := math.Hypot(nx, ny); l > 1e-9 {
+		nx, ny = nx/l, ny/l
+	}
+	d.nx, d.ny = nx, ny
+	d.anchorX, d.anchorY = mx+nx*liftSign*textGapMM, my+ny*liftSign*textGapMM
 }
 
 // isRadial reports whether a dimension type measures a circular edge (radius or diameter).
@@ -279,7 +325,9 @@ func (ds *DrawingDimensions) recomputeRadial(d *DrawingDimension, view *DrawingV
 	center := view.place(hlr.ProjectPoint(basis, circle.Center))
 	arc := view.place(hlr.ProjectPoint(basis, circle.PointAt(0)))
 	opp := view.place(hlr.ProjectPoint(basis, circle.PointAt(0.5)))
-	d.curves, d.anchorX, d.anchorY = radialDimensionCurves(center, arc, opp, d.dimType == types.DiameterDimension)
+	curves, mx, my, nx, ny := radialDimensionCurves(center, arc, opp, d.dimType == types.DiameterDimension)
+	d.curves = curves
+	d.setTextAnchor(mx, my, nx, ny, 1)
 }
 
 // nearestCircularEdgeKey returns the reference key of the circular model edge whose centre projects
@@ -304,19 +352,21 @@ func nearestCircularEdgeKey(body *topo.Body, v *DrawingView, basis hlr.View, x, 
 // radialDimensionCurves builds a radial dimension's glyph (sheet mm): a radius leader from the
 // centre to the arc with an arrowhead, or a diameter line across the circle with arrowheads at
 // both ends. It returns the text anchor (the midpoint of the leader / the centre).
-func radialDimensionCurves(center, arc, opp gmath.Point2, diameter bool) (curves []DrawingCurve, anchorX, anchorY float64) {
+func radialDimensionCurves(center, arc, opp gmath.Point2, diameter bool) (curves []DrawingCurve, anchorX, anchorY, nx, ny float64) {
 	cx, cy := float64(center.X), float64(center.Y)
 	ax, ay := float64(arc.X), float64(arc.Y)
+	// Lift the text perpendicular to the leader/diameter line so it clears it.
+	pnx, pny := -(ay - cy), ax-cx
 	if diameter {
 		ox, oy := float64(opp.X), float64(opp.Y)
 		out := []DrawingCurve{dimSegment(ax, ay, ox, oy)}
 		out = append(out, arrowheadCurves(ax, ay, cx, cy)...)
 		out = append(out, arrowheadCurves(ox, oy, cx, cy)...)
-		return out, cx, cy
+		return out, cx, cy, pnx, pny
 	}
 	out := []DrawingCurve{dimSegment(cx, cy, ax, ay)}
 	out = append(out, arrowheadCurves(ax, ay, cx, cy)...)
-	return out, (cx + ax) / 2, (cy + ay) / 2
+	return out, (cx + ax) / 2, (cy + ay) / 2, pnx, pny
 }
 
 // sheetSegment is a straight model edge projected onto the sheet: its endpoints, midpoint and unit
@@ -377,7 +427,7 @@ func angleBetweenDeg(d1, d2 [2]float64) float64 {
 // angularDimensionCurves builds an angular dimension's arc glyph (sheet mm) spanning between the
 // two edges, centred on their intersection, with arrowheads at the arc ends. It returns the text
 // anchor on the arc's bisector.
-func angularDimensionCurves(a, b sheetSegment) (curves []DrawingCurve, anchorX, anchorY float64) {
+func angularDimensionCurves(a, b sheetSegment) (curves []DrawingCurve, anchorX, anchorY, nx, ny float64) {
 	cx, cy, ok := lineIntersection(a, b)
 	if !ok {
 		cx, cy = (a.mx+b.mx)/2, (a.my+b.my)/2
@@ -388,7 +438,8 @@ func angularDimensionCurves(a, b sheetSegment) (curves []DrawingCurve, anchorX, 
 	out := arcPolyline(cx, cy, radius, a0, a0+sweep)
 	out = append(out, arcArrowheads(cx, cy, radius, a0, a0+sweep)...)
 	mid := a0 + sweep/2
-	return out, cx + radius*math.Cos(mid), cy + radius*math.Sin(mid)
+	// The text sits on the bisector, lifted radially outward (away from the corner).
+	return out, cx + radius*math.Cos(mid), cy + radius*math.Sin(mid), math.Cos(mid), math.Sin(mid)
 }
 
 // lineIntersection returns the intersection of the two segments' infinite lines, ok=false when

--- a/model/drawing/dimension_test.go
+++ b/model/drawing/dimension_test.go
@@ -99,6 +99,49 @@ func TestRadialForEachCircleDedupsRims(t *testing.T) {
 	}
 }
 
+// TestDimensionTextLiftedAndDraggable: the value text sits off the dimension line by default
+// (readable), and dragging the text nudges its anchor.
+func TestDimensionTextLiftedAndDraggable(t *testing.T) {
+	c := drawingWithBox(t)
+	views := c.Sheets().Active().Views()
+	frontBase(t, views)
+	dims := c.Sheets().Active().Dimensions()
+	d, err := dims.AddLinear("D1", "FRONT", types.HorizontalDimension, 88, 80, 112, 80, -12)
+	if err != nil {
+		t.Fatalf("AddLinear: %v", err)
+	}
+	// The text anchor is lifted off the dimension line (curve[2] is the horizontal dimension line).
+	line := d.Curves()[2]
+	tx, ty := d.TextAnchorMM()
+	if math.Abs(ty-float64(line.Start().Y)) < 1e-6 {
+		t.Errorf("text anchor y %v sits on the dimension line y %v — should be lifted off", ty, float64(line.Start().Y))
+	}
+
+	dims.MoveText("D1", 7, 4)
+	mx, my := d.TextAnchorMM()
+	if math.Abs(mx-tx-7) > 1e-9 || math.Abs(my-ty-4) > 1e-9 {
+		t.Errorf("after MoveText the anchor moved by (%v,%v), want (7,4)", mx-tx, my-ty)
+	}
+}
+
+// TestMoveLineShiftsDimensionLine: dragging the dimension line moves it perpendicular to itself.
+func TestMoveLineShiftsDimensionLine(t *testing.T) {
+	c := drawingWithBox(t)
+	views := c.Sheets().Active().Views()
+	frontBase(t, views)
+	dims := c.Sheets().Active().Dimensions()
+	d, err := dims.AddLinear("D1", "FRONT", types.HorizontalDimension, 88, 80, 112, 80, -12)
+	if err != nil {
+		t.Fatalf("AddLinear: %v", err)
+	}
+	before := float64(d.Curves()[2].Start().Y)
+	dims.MoveLine("D1", 0, -6) // drag the horizontal dimension line down 6 mm
+	after := float64(d.Curves()[2].Start().Y)
+	if math.Abs(after-before+6) > 1e-6 {
+		t.Errorf("dimension line moved by %v mm, want -6", after-before)
+	}
+}
+
 // TestAngularDimensionMeasuresCorner: an angular dimension between a horizontal and a vertical box
 // edge reports 90°, with ValueMM 0 (the value is in degrees) and an arc glyph.
 func TestAngularDimensionMeasuresCorner(t *testing.T) {

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -61,6 +61,8 @@ type dimensionRecipe struct {
 	EdgeKey  string  `yaml:"edgeKey,omitempty"`  // radial: circular edge; angular: first straight edge
 	EdgeKeyB string  `yaml:"edgeKeyB,omitempty"` // angular: second straight edge
 	Offset   float64 `yaml:"offsetMm,omitempty"`
+	TextDX   float64 `yaml:"textDxMm,omitempty"` // user text nudge (drag-the-text)
+	TextDY   float64 `yaml:"textDyMm,omitempty"`
 }
 
 // annotationRecipe is the YAML shape of one drawing annotation. A CoG marker's glyph re-derives
@@ -181,7 +183,8 @@ func dimensionRecipesOf(sh *Sheet) []dimensionRecipe {
 		out = append(out, dimensionRecipe{
 			Name: d.name, Type: d.dimType.String(), ViewName: d.viewName,
 			KeyA: hex.EncodeToString(d.keyA), KeyB: hex.EncodeToString(d.keyB),
-			EdgeKey: hex.EncodeToString(d.edgeKey), EdgeKeyB: hex.EncodeToString(d.edgeKeyB), Offset: d.offset,
+			EdgeKey: hex.EncodeToString(d.edgeKey), EdgeKeyB: hex.EncodeToString(d.edgeKeyB),
+			Offset: d.offset, TextDX: d.textDX, TextDY: d.textDY,
 		})
 	}
 	return out
@@ -247,7 +250,11 @@ func restoreDimensions(sh *Sheet, recs []dimensionRecipe) {
 		keyB, _ := hex.DecodeString(dr.KeyB)
 		edgeKey, _ := hex.DecodeString(dr.EdgeKey)
 		edgeKeyB, _ := hex.DecodeString(dr.EdgeKeyB)
-		d := &DrawingDimension{name: dr.Name, dimType: dimType, viewName: dr.ViewName, keyA: keyA, keyB: keyB, edgeKey: edgeKey, edgeKeyB: edgeKeyB, offset: dr.Offset}
+		d := &DrawingDimension{
+			name: dr.Name, dimType: dimType, viewName: dr.ViewName,
+			keyA: keyA, keyB: keyB, edgeKey: edgeKey, edgeKeyB: edgeKeyB,
+			offset: dr.Offset, textDX: dr.TextDX, textDY: dr.TextDY,
+		}
 		ds.recompute(d)
 		ds.items = append(ds.items, d)
 	}


### PR DESCRIPTION
Addresses dimension readability: the value text overlapped the dimension line, and overlapping dimensions could not be separated.

## What changed
- **Text off the line by default**: the value text is lifted off its dimension line (perpendicular gap) and centred, so it's readable for every dimension type (linear / radial / angular).
- **Drag to reposition**: a dimension's text and its dimension line can be grabbed and dragged on the sheet canvas — press on the text to move it, press on the line to shift it perpendicular to itself. So overlapping dimensions can be pulled apart.
- **model**: per-dimension `textDX/textDY` (text nudge) + `MoveText`/`MoveLine`; the dimension stores its line perpendicular for the line drag; persisted in the recipe.
- **app**: the drag state machine (`Session.DragDimension`) + `PickDrawingDimensionAt` (text vs line) + `MoveDimensionText`/`MoveDimensionLine`.
- **head**: the canvas forwards the canvas item's ImGui state to `DragDimension` and centres the text.

Head/app/model only — **no API or wire change** (the head edits the model in-proc).

## Tests
- model: text lifted off the line + draggable; `MoveLine` shifts the line perpendicular.
- app: pick text vs line; the drag state machine (press → move → release).

## Live-verified over the MCP bridge
A box FRONT view with horizontal **60**, vertical **30** and **90°** dimensions — each value now sits clearly off its line and they don't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)