### PR TITLE
fix(tessellate): trim-local metric CDT for analytic curved faces — EDF volume +35.6% → ≈exact (#585)

### DIFF
--- a/kernel/exchange/step/occ_oracle_test.go
+++ b/kernel/exchange/step/occ_oracle_test.go
@@ -59,10 +59,9 @@ var knownGaps = map[string]string{
 
 // knownFolds are fixtures whose tessellation still has fold edges (a watertight self-crease). The
 // fold gate in checkOracle skips them; the list may only shrink (delete an entry when its folds are
-// fixed). filleted_box: 2 residual folds on the spherical corner-fillet caps — tracked in #1011.
-var knownFolds = map[string]bool{
-	"filleted_box": true,
-}
+// fixed). Currently empty — the metric-scaled analytic-patch mesher (#585) made every oracle fixture,
+// including filleted_box's spherical corner caps (formerly #1011), fold-free.
+var knownFolds = map[string]bool{}
 
 func checkOracle(t *testing.T, dir, name string, want oracleEntry) {
 	if reason, gap := knownGaps[name]; gap {

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -168,6 +168,70 @@ func pointInUVPoly(poly []math.Point2, p [2]float64) bool {
 	return in
 }
 
+// metricPatchMesh meshes an analytic curved trim (torus/sphere/cone/cylinder) over its OWN (u,v) with
+// a METRIC-SCALED constrained-Delaunay triangulation — the same anti-fold approach nurbsPcurveMesh
+// uses for B-splines. gridPatchMesh's plain (u,v) CDT folds where the surface metric is anisotropic
+// (a torus's tube vs ring, a sphere near its poles): u and v have very different 3D scales, so an
+// isotropic Delaunay twists in 3D. Scaling each axis by its mean 3D length (√E, √G via metricScale)
+// makes the parameter space ≈ isometric to 3D, so the triangulation is well-shaped and fold-free.
+// Boundary loops keep their exact 3D edge points (watertight); interior nodes are deflection-adaptive;
+// residual folds are swept by repairFolds. Falls back to the best-fit-plane boundary triangulation if
+// the CDT degenerates or tears (a pole/seam-distorted cap).
+func metricPatchMesh(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+	su, sv := trimMetricScale(s, outerUV)
+	b := newPatchBuilder(s, su, sv)
+	loops := [][]int{b.addLoop(outer3D, outerUV)}
+	for i := range holes3D {
+		loops = append(loops, b.addLoop(holes3D[i], holesUV[i]))
+	}
+	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q) {
+		b.addInterior(g)
+	}
+	tris := constrainedDelaunay(b.scaled, loops)
+	if len(tris) == 0 {
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	m := patchMeshFrom(b.pos, b.nrm, tris)
+	repairFolds(m, 8)
+	if !patchIsManifold(m, loops) {
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	return m
+}
+
+// trimMetricScale returns the per-axis (u,v) metric (mean 3D length of a unit u/v step) sampled over
+// the TRIM region's (u,v) bounding box, not the surface's whole domain. This matters where a surface's
+// metric varies across the domain: a cone's u-step length (the circumference) shrinks to zero toward
+// the apex, so the whole-domain mean (metricScale) is dominated by the degenerate apex and the scaled
+// CDT folds — but a cone-frustum trim sits away from the apex, where the local metric is well behaved.
+// Falls back to the whole-domain metricScale when the trim bbox is empty/degenerate.
+func trimMetricScale(s geom.Surface, outerUV []math.Point2) (su, sv float64) {
+	if len(outerUV) == 0 {
+		return metricScale(s)
+	}
+	umin, umax, vmin, vmax := uvBBox(outerUV)
+	if umax <= umin || vmax <= vmin {
+		return metricScale(s)
+	}
+	var sumU, sumV float64
+	const n = 4
+	for i := 0; i <= n; i++ {
+		for j := 0; j <= n; j++ {
+			du, dv := s.DerivativesAt(umin+(umax-umin)*float64(i)/n, vmin+(vmax-vmin)*float64(j)/n)
+			sumU += du.Length()
+			sumV += dv.Length()
+		}
+	}
+	su, sv = sumU/float64((n+1)*(n+1)), sumV/float64((n+1)*(n+1))
+	if su <= 0 {
+		su = 1
+	}
+	if sv <= 0 {
+		sv = 1
+	}
+	return su, sv
+}
+
 // trimmedPatchMesh meshes a non-rectangular curved patch via a constrained Delaunay triangulation
 // of its boundary loops. The 2D embedding to triangulate in is chosen by patchProjection: the
 // surface's own (u,v) for a B-spline (where the trim loops are a simple polygon), or the boundary's

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -47,7 +47,7 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if us, vs, isRect := isoRectangleGrid(outerUV); len(holesUV) == 0 && isRect {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
-	return nonRectangularMesh(f, s, outer3D, holes3D, outerUV, holesUV)
+	return nonRectangularMesh(s, q, outer3D, holes3D, outerUV, holesUV)
 }
 
 // meshSeamCrossingFace meshes a curved face whose boundary loop wraps the periodic seam (so toUVLoops
@@ -70,55 +70,25 @@ func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, h
 	return fullDomainGridMesh(s, q) // doubly-periodic / aperiodic seam face we can't reduce
 }
 
-// nonRectangularMesh meshes a non-iso-rectangular curved trim. A sphere cap is meshed over its own
-// (u,v) with interior nodes (gridPatchMesh) so it reads smooth; a B-spline uses the same CDT without
-// interior Steiner points (trimmedPatchMesh). A cyl/cone that shares a curved seam with another
-// cyl/cone — two fillet cylinders that mutually trim where two edges miter — ALSO needs the interior
-// nodes: meshed boundary-only, both faces fan a coincident diagonal across the shared seam into a
-// non-manifold overlap, so it gets gridPatchMesh too (small trims only — the (u,v) CDT is too slow on
-// the ~120-point cone trims that once froze import). Every other cyl/cone — an ordinary fillet wall, a
-// corner-blend cylinder meeting only planes and the sphere — keeps the O(boundary) best-fit-plane
-// ear-clip (boundaryPatchMesh), coarse but fast, with the conformance pass closing any small gap.
-func nonRectangularMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+// nonRectangularMesh meshes a non-iso-rectangular curved trim. Every analytic curved surface (torus,
+// sphere, cylinder, cone) goes through metricPatchMesh — a trim-local metric-scaled (u,v) CDT that
+// stays fold-free and volume-correct (#585). A B-spline that fell through nurbsPcurveMesh uses the same
+// CDT without interior Steiner points (trimmedPatchMesh). Anything else keeps the best-fit-plane
+// ear-clip (boundaryPatchMesh).
+func nonRectangularMesh(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
 	switch s.(type) {
-	case geom.Sphere:
-		return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
+	case geom.Torus, geom.Sphere, geom.Cylinder, geom.Cone:
+		// Analytic curved trims fold when flattened to a best-fit plane (boundaryPatchMesh) or meshed
+		// over a plain anisotropic (u,v) (gridPatchMesh): a torus's ring-vs-tube, a sphere near its
+		// poles, a trimmed cyl/cone. metricPatchMesh triangulates in a TRIM-LOCAL metric-scaled (u,v)
+		// (√E,√G over the trim's own (u,v) bbox, so even a cone — whose metric degenerates only toward
+		// the far-off apex — stays well conditioned), plus repairFolds. This was the bulk of the EDF
+		// over-enclosure (#585: total volume +35.6% → ≈exact, torus the single largest fold source).
+		return metricPatchMesh(s, q, outer3D, holes3D, outerUV, holesUV)
 	case geom.BSplineSurface:
 		return trimmedPatchMesh(s, outer3D, holes3D)
-	case geom.Cylinder, geom.Cone:
-		if boundaryPointCount(outer3D, holes3D) <= curvedSeamMeshMax && sharesCurvedSeam(f) {
-			return gridPatchMesh(s, outer3D, holes3D, outerUV, holesUV)
-		}
 	}
 	return boundaryPatchMesh(s, outer3D, holes3D)
-}
-
-// curvedSeamMeshMax bounds the boundary size for which a curved-seam cyl/cone trim takes the
-// interior-node CDT (gridPatchMesh) instead of the fast ear-clip — comfortably above a fillet miter's
-// ~30-point boundary and below the ~120-point cone trims whose CDT froze import.
-const curvedSeamMeshMax = 64
-
-// boundaryPointCount totals a trim's outer and hole boundary points.
-func boundaryPointCount(outer3D []math.Point3, holes3D [][]math.Point3) int {
-	n := len(outer3D)
-	for _, h := range holes3D {
-		n += len(h)
-	}
-	return n
-}
-
-// sharesCurvedSeam reports whether f shares an edge with ANOTHER cylinder/cone face — a curved-curved
-// seam (two mutually-trimming fillet cylinders meet this way). A cyl/cone touching only planes and a
-// sphere (an ordinary fillet wall, a corner-blend cylinder) does not qualify.
-func sharesCurvedSeam(f *topo.Face) bool {
-	for _, e := range f.Edges() {
-		for _, nf := range e.Faces() {
-			if nf != f && isCylOrCone(nf.Geometry()) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // boundaryPatchMesh triangulates a curved face from its boundary loops alone (no interior

--- a/kernel/ops/watertight_test.go
+++ b/kernel/ops/watertight_test.go
@@ -3,6 +3,7 @@
 package ops
 
 import (
+	stdmath "math"
 	"os"
 	"testing"
 
@@ -99,5 +100,42 @@ func TestImportedNurbsDuctWatertight(t *testing.T) {
 	}
 	if total != 0 {
 		t.Errorf("imported model total free edges = %d; want 0 (watertightness regression)", total)
+	}
+}
+
+// edfOCCVolume is OCC getMass for the EDF model (mm³); edfFoldCeiling is the current residual fold
+// count (sphere pole + B-spline pcurve self-proximity), which may only shrink. See edfVolumeTol.
+const (
+	edfOCCVolume   = 207002.0
+	edfVolumeTol   = 0.01 // 1% — the trim-local metric mesher lands EDF at ≈ -0.4% (was +35.6%)
+	edfFoldCeiling = 38
+)
+
+// TestImportedNurbsDuctVolumeAndFolds guards the #585 fix: EDF's tessellation is not merely watertight
+// (TestImportedNurbsDuctWatertight) but VOLUME-CORRECT and (almost) fold-free. A watertight mesh can
+// still fold over itself and over-enclose — the EDF duct used to be +35.6% over OCC's getMass because
+// its trimmed analytic faces (torus/cylinder/sphere/cone) folded. Routing them through metricPatchMesh
+// (a TRIM-LOCAL metric-scaled (u,v) CDT) collapses the over-enclosure to ≈ -0.4% and the fold count
+// from 139 to the residual ceiling (the remaining folds are the B-spline pcurve path + a few sphere
+// pole facets, tracked separately). Env-gated like the watertightness guard.
+func TestImportedNurbsDuctVolumeAndFolds(t *testing.T) {
+	path := os.Getenv("OBK_PERF_STEP")
+	if path == "" {
+		t.Skip("set OBK_PERF_STEP=/path/EDF.STEP to run the imported-NURBS volume/fold guard")
+	}
+	var volume float64
+	folds := 0
+	for _, body := range stepBodies(t, path) {
+		mesh, _ := TessellateBody(body, DefaultQuality())
+		folds += FoldEdgeCount(mesh)
+		volume += BodyGeometryProperties(body, DefaultQuality()).Volume
+	}
+	if rel := stdmath.Abs(volume-edfOCCVolume) / edfOCCVolume; rel > edfVolumeTol {
+		t.Errorf("EDF total volume %.0f vs OCC %.0f (rel %.4f > %.4f) — an over-enclosure regression",
+			volume, edfOCCVolume, rel, edfVolumeTol)
+	}
+	if folds > edfFoldCeiling {
+		t.Errorf("EDF total fold edges = %d, want <= %d (the ceiling may only shrink as the residual "+
+			"B-spline/sphere folds are fixed)", folds, edfFoldCeiling)
 	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,4 +25,8 @@ sonar.go.coverage.reportPaths=coverage.out,head/coverage.out
 # exercised only by the real-file corpus integration tests (kernel/exchange/dwg), and those
 # .dwg fixtures are 8–26 MB and git-ignored — they are not present in CI, so this code shows
 # as uncovered there despite being tested locally. Same rationale as the native bindings.
-sonar.coverage.exclusions=**/*_test.go,**/testdata/**,head/internal/native/**,kernel/exchange/dwg/decompress.go,kernel/exchange/dwg/header_r2004.go,kernel/exchange/dwg/sectionmap.go
+#
+# test-utilities holds offline fixture generators (the OCC/gmsh step-oracle script, blender
+# projects) — tooling that produces committed test artifacts, not shipped code, so it is not
+# unit-tested and must not count toward coverage.
+sonar.coverage.exclusions=**/*_test.go,**/testdata/**,test-utilities/**,head/internal/native/**,kernel/exchange/dwg/decompress.go,kernel/exchange/dwg/header_r2004.go,kernel/exchange/dwg/sectionmap.go


### PR DESCRIPTION
## What

Collapses the imported-EDF over-enclosure: total tessellated volume **+35.6% → −0.36%** of OCC `getMass` (280,770 → 206,256 vs 207,002), and fold edges **139 → 38**. Also makes the `filleted_box` oracle fixture fold-free (**closes #1011**).

## Why

#596 proved EDF was watertight (0 free edges) yet still **over-enclosed +35.6%** — a watertight mesh can fold over itself. The fold detector (#584) localized 139 folds and **corrected the long-standing hypothesis**: they were **not** in the B-spline faces (0 there) but in the **trimmed analytic faces** — torus (50), cylinder (18), sphere (18), cone (12).

Root cause: `nonRectangularMesh` sent analytic curved trims to `boundaryPatchMesh` (flatten onto a best-fit plane + ear-clip → folds on a curved patch) or `gridPatchMesh` (a plain `(u,v)` CDT → folds where the metric is anisotropic).

## How

- New **`metricPatchMesh`**: the metric-scaled `(u,v)` CDT `nurbsPcurveMesh` already uses for B-splines (`patchBuilder` + `repairFolds`), now for analytic curved trims — torus/sphere/cylinder/cone all route here.
- New **`trimMetricScale`**: samples √E,√G over the **trim's own `(u,v)` bbox**, not the whole surface domain. This is what makes a **cone** work — its metric degenerates only toward the far-off apex, so a frustum trim stays well conditioned (the whole-domain mean folded it). The trim-local metric is also what drops the volume error from +4.5% (whole-domain) to −0.36%.
- Dead routing removed (`sharesCurvedSeam`, `boundaryPointCount`, `curvedSeamMeshMax`); `nonRectangularMesh` no longer needs the face arg.

## Tests

- **`TestImportedNurbsDuctVolumeAndFolds`** (new, env-gated on `OBK_PERF_STEP=…/EDF.STEP`): EDF total volume within 1% of OCC + fold ceiling (shrink-only). Passes at −0.36% / 38 folds.
- **OCC oracle suite** now passes the 0-fold gate on **every** fixture (incl. `filleted_box`, formerly allowlisted via `knownFolds` — now emptied) and the freeform fixture; volumes unchanged.
- Full `./kernel/...`, `./model/...`, `./app/...` green; lint clean.

## Scope note (#585)

This nails #585's **volume** criterion and the env-gated regression. The **0-fold** criterion is not fully met: **38 residual folds** remain — the **B-spline pcurve path** (a separate M25 NURBS-robustness problem) plus a few **sphere pole** facets. #585 stays open for those; this is the analytic-face half (the bulk: 101 of 139 folds, and the entire volume error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)