### PR TITLE
feat(fillet): face fillet between two face sets (adjacent case) (#694)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -176,6 +176,38 @@ func TestDressUpOnSolid(t *testing.T) {
 	}
 }
 
+// TestFaceFilletThroughRegistry rounds the edge two adjacent faces share, selected by face over the
+// fillet op's face-fillet form (#694) — the end-to-end registry path an MCP driver uses.
+func TestFaceFilletThroughRegistry(t *testing.T) {
+	s := profiledPart(t)
+	if _, err := apply(t, s, "extrude", `{"sketchIndex":0,"distance":"10 mm"}`); err != nil {
+		t.Fatalf("seed extrude: %v", err)
+	}
+	b := s.ActiveDocument().Content().(*compdef.PartComponentDefinition).SurfaceBodies().Item(0)
+	var fa, fb string
+	for _, e := range b.Edges() {
+		if fs := e.Faces(); len(fs) == 2 {
+			fa, fb = string(fs[0].ReferenceKey()), string(fs[1].ReferenceKey())
+			break
+		}
+	}
+	if fa == "" {
+		t.Fatal("no edge with two adjacent faces")
+	}
+	args := map[string]any{"faceRefsA": []string{fa}, "faceRefsB": []string{fb}, "radius": "1 mm"}
+	if _, err := applyMap(t, s, "fillet", args); err != nil {
+		t.Fatalf("face fillet through registry: %v", err)
+	}
+}
+
+// TestFaceFilletRequiresBothSets: the face-fillet form rejects only one face set given.
+func TestFaceFilletRequiresBothSets(t *testing.T) {
+	s, _, face := extrudedSolid(t)
+	if _, err := applyMap(t, s, "fillet", map[string]any{"faceRefsA": []string{face}, "radius": "1 mm"}); err == nil {
+		t.Error("face fillet with only faceRefsA should error")
+	}
+}
+
 // TestDressUpRejectsEmptyRefs: each dress-up op rejects a missing reference list.
 func TestDressUpRejectsEmptyRefs(t *testing.T) {
 	for _, op := range []string{"fillet", "chamfer", "shell", "draft", "lip"} {

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -27,6 +27,8 @@ type edgeDressArgs struct {
 	Radius          string          `json:"radius,omitempty"`          // fillet
 	Distance        string          `json:"distance,omitempty"`        // chamfer
 	EdgeSets        []filletSetArgs `json:"edgeSets,omitempty"`        // fillet
+	FaceRefsA       []string        `json:"faceRefsA,omitempty"`       // fillet face-fillet: first face set (#694)
+	FaceRefsB       []string        `json:"faceRefsB,omitempty"`       // fillet face-fillet: second face set
 	CornerType      string          `json:"cornerType,omitempty"`      // fillet shared-corner treatment (default miter)
 	ChamferType     string          `json:"chamferType,omitempty"`     // chamfer mode (default distance)
 	Distance2       string          `json:"distance2,omitempty"`       // chamfer twoDistances
@@ -47,7 +49,9 @@ const filletSchema = `{
   "type": "object",
   "properties": {
     "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the edges to round (from get_reference_keys). Flat form: one constant radius over these edges."},
-    "radius": {"type": "string", "description": "Fillet radius with units, e.g. \"3 mm\" (flat form)."},
+    "radius": {"type": "string", "description": "Fillet radius with units, e.g. \"3 mm\" (flat and face-fillet forms)."},
+    "faceRefsA": {"type": "array", "items": {"type": "string"}, "description": "Face-fillet form (#694): first face set (reference keys). With faceRefsB + radius, rounds the edges the two sets share — pick by face instead of by edge. Adjacent faces only for now."},
+    "faceRefsB": {"type": "array", "items": {"type": "string"}, "description": "Face-fillet form: second face set."},
     "edgeSets": {"type": "array", "minItems": 1, "description": "Edge-set form (takes precedence over edgeRefs): any mix of constant and variable radius sets.", "items": {"type": "object", "properties": {
       "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
       "radius": {"type": "string", "description": "Constant radius for this set, e.g. \"3 mm\"."},
@@ -97,10 +101,27 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(in.FaceRefsA) > 0 || len(in.FaceRefsB) > 0 {
+		return applyFaceFillet(part, in)
+	}
 	if len(in.EdgeSets) > 0 {
 		return applyFilletSets(part, in.EdgeSets, corner, cs)
 	}
 	return applyFilletFlat(part, in, corner, cs)
+}
+
+// applyFaceFillet rounds the edges shared between two face sets (#694, adjacent-faces case): both
+// faceRefsA and faceRefsB plus a radius are required.
+func applyFaceFillet(part *compdef.PartComponentDefinition, in edgeDressArgs) (json.RawMessage, error) {
+	if len(in.FaceRefsA) == 0 || len(in.FaceRefsB) == 0 {
+		return nil, errors.New("face fillet: both faceRefsA and faceRefsB are required")
+	}
+	r, err := lengthClosure(part, in.Radius, "fillet: radius")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddFaceFillet(refKeys(in.FaceRefsA), refKeys(in.FaceRefsB), r)
+	return recomputeResult(part, pf)
 }
 
 // applyFilletFlat builds the flat (edgeRefs + single radius) fillet with the chosen corner

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -296,6 +296,12 @@ func (c *DressUpFeatures) AddFilletSetsCorner(sets []FilletEdgeSet, corner Fille
 	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeSets: sets, CornerType: corner}})
 }
 
+// AddFaceFillet rounds the edges shared between two face sets with a constant-radius rolling-ball
+// blend (#694, the adjacent-faces case of FilletConstantRadiusFaceSet).
+func (c *DressUpFeatures) AddFaceFillet(faceKeysA, faceKeysB [][]byte, radius func() float64) *PartFeature {
+	return c.engine.Add(&FaceFilletFeature{def: &FaceFilletDefinition{FaceKeysA: faceKeysA, FaceKeysB: faceKeysB, Radius: radius}})
+}
+
 // AddChamfer bevels the given edges by distance, blending three-edge corners flat (the
 // default treatment). Use [AddChamferCorners] to choose the pointy corner instead.
 func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64) *PartFeature {

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/topo"
+)
+
+// FaceFilletDefinition rounds the edges shared between two face sets with a rolling-ball blend of
+// the given radius — the adjacent-faces case of Inventor's face fillet (FilletConstantRadiusFaceSet,
+// #694), where the two sets meet at one or more edges. Picking by face (rather than by edge) is the
+// natural selection when a long chain of edges separates two regions. Non-adjacent face sets, where
+// the ball bridges a gap between faces that share no edge, are a follow-up.
+type FaceFilletDefinition struct {
+	FaceKeysA [][]byte
+	FaceKeysB [][]byte
+	Radius    func() float64
+}
+
+// FaceFilletFeature is a face fillet between two face sets.
+//
+// Example: round where the top face meets a side face of a box —
+//
+//	NewDressUpFeatures(part.Features()).AddFaceFillet(topKeys, sideKeys, func() float64 { return 0.3 })
+type FaceFilletFeature struct{ def *FaceFilletDefinition }
+
+// Definition returns the feature's definition.
+func (f *FaceFilletFeature) Definition() *FaceFilletDefinition { return f.def }
+
+// Kind names the feature type.
+func (f *FaceFilletFeature) Kind() string { return "face-fillet" }
+
+// FilletType reports the public discriminator for this feature: a face fillet.
+func (f *FaceFilletFeature) FilletType() types.FilletType { return types.FaceFillet }
+
+// Recompute rounds the edges shared by the two face sets against the running body.
+func (f *FaceFilletFeature) Recompute(in Input) (Output, error) {
+	return faceFilletBody(in, f.def.FaceKeysA, f.def.FaceKeysB, callOrZero(f.def.Radius), "face-fillet")
+}
+
+// faceFilletBody resolves the edges shared between the two face sets on the running body and rounds
+// them with the constant-radius edge-fillet kernel. No shared edge is an error (the feature goes
+// Sick): non-adjacent face sets, which need a gap-bridging rolling-ball path, are not yet supported.
+func faceFilletBody(in Input, faceKeysA, faceKeysB [][]byte, radius float64, feat string) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	if radius <= 0 {
+		return Output{}, fmt.Errorf("%s: radius %g must be > 0", feat, radius)
+	}
+	edgeKeys := sharedEdgeKeys(body, faceKeysA, faceKeysB)
+	if len(edgeKeys) == 0 {
+		return Output{}, fmt.Errorf("%s: the two face sets share no edge "+
+			"(non-adjacent face fillet is not yet supported)", feat)
+	}
+	return filletBody(in, edgeKeys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, feat)
+}
+
+// sharedEdgeKeys returns the reference key of every edge of body whose two adjacent faces lie one in
+// face set A and one in set B — the edges a face fillet between the two sets rounds.
+func sharedEdgeKeys(body *topo.Body, faceKeysA, faceKeysB [][]byte) [][]byte {
+	inA, inB := keyLookup(faceKeysA), keyLookup(faceKeysB)
+	var out [][]byte
+	for _, e := range body.Edges() {
+		fs := e.Faces()
+		if len(fs) != 2 {
+			continue
+		}
+		ka, kb := string(fs[0].ReferenceKey()), string(fs[1].ReferenceKey())
+		if (inA[ka] && inB[kb]) || (inA[kb] && inB[ka]) {
+			out = append(out, e.ReferenceKey())
+		}
+	}
+	return out
+}
+
+// keyLookup indexes reference keys for membership tests (string(key) is a stable map key for bytes).
+func keyLookup(keys [][]byte) map[string]bool {
+	m := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		m[string(k)] = true
+	}
+	return m
+}

--- a/model/feature/face_fillet_test.go
+++ b/model/feature/face_fillet_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Face fillet (#694, adjacent-faces case): round the edge(s) shared by two face sets, selecting by
+// face instead of by edge.
+
+// boxAndPlanarFace builds a 2×2×2 box and returns the engine plus a helper that finds the reference
+// key of the axis-aligned planar face flush against the given min/max plane (e.g. top = z==2).
+func boxAndPlanarFace(t *testing.T) (*PartFeatures, func(axis byte, at float64) []byte) {
+	t.Helper()
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	find := func(axis byte, at float64) []byte {
+		t.Helper()
+		for _, f := range box.Faces() {
+			rb := f.RangeBox()
+			lo, hi := boxAxisSpan(rb, axis)
+			if lo == at && hi == at {
+				return f.ReferenceKey()
+			}
+		}
+		t.Fatalf("no planar face flush at %c==%g", axis, at)
+		return nil
+	}
+	return fs, find
+}
+
+func boxAxisSpan(rb math.Box, axis byte) (float64, float64) {
+	switch axis {
+	case 'x':
+		return rb.Min.X, rb.Max.X
+	case 'y':
+		return rb.Min.Y, rb.Max.Y
+	default:
+		return rb.Min.Z, rb.Max.Z
+	}
+}
+
+// TestFaceFilletRoundsSharedEdge rounds the single edge shared by the top face and a side face,
+// selected by face: the result is a valid solid whose volume is the box minus one quarter-round.
+func TestFaceFilletRoundsSharedEdge(t *testing.T) {
+	fs, face := boxAndPlanarFace(t)
+	top := face('z', 2)
+	side := face('x', 2)
+	pf := NewDressUpFeatures(fs).AddFaceFillet([][]byte{top}, [][]byte{side}, func() float64 { return 0.3 })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("face fillet sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("face fillet not a valid solid: %+v", r)
+	}
+	if !hasCylinderFace(res) {
+		t.Error("face fillet produced no cylindrical face")
+	}
+	notch := func(r float64) float64 { return r*r - stdmath.Pi*r*r/4 } // cross-section removed per unit length
+	want := 8 - notch(0.3)*2                                           // one edge of length 2
+	if got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume; relErr(got, want) > 1e-3 {
+		t.Errorf("face fillet volume = %g, want ≈ %g", got, want)
+	}
+}
+
+// TestFaceFilletNonAdjacentSick: two parallel faces that share no edge (top and bottom) cannot be
+// filleted by this adjacent-faces slice — the feature goes Sick rather than silently doing nothing.
+func TestFaceFilletNonAdjacentSick(t *testing.T) {
+	fs, face := boxAndPlanarFace(t)
+	pf := NewDressUpFeatures(fs).AddFaceFillet([][]byte{face('z', 2)}, [][]byte{face('z', 0)}, func() float64 { return 0.3 })
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Fatal("face fillet of two non-adjacent faces should be sick (no shared edge)")
+	}
+}
+
+func hasCylinderFace(b *topo.Body) bool {
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -27,6 +27,7 @@ type FeatureData struct {
 	Seq            uint64              `yaml:"seq,omitempty"` // global creation stamp; see model/seq
 	Extrude        *ExtrudeData        `yaml:"extrude,omitempty"`
 	Fillet         *EdgeDressData      `yaml:"fillet,omitempty"`
+	FaceFillet     *FaceFilletData     `yaml:"faceFillet,omitempty"`
 	Chamfer        *EdgeDressData      `yaml:"chamfer,omitempty"`
 	Shell          *FaceDressData      `yaml:"shell,omitempty"`
 	Draft          *FaceDressData      `yaml:"draft,omitempty"`
@@ -138,6 +139,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			break
 		}
 		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius), CornerType: int32(f.def.CornerType)}
+	case *FaceFilletFeature:
+		fd.FaceFillet = &FaceFilletData{FacesA: encodeKeys(f.def.FaceKeysA), FacesB: encodeKeys(f.def.FaceKeysB), Value: evalFloat(f.def.Radius)}
 	case *ChamferFeature:
 		flat := f.def.FlatCorners
 		fd.Chamfer = &EdgeDressData{
@@ -433,6 +436,19 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 			return nil, err
 		}
 		return du.AddFilletCorner(d.keys, constFloat(d.value), corner), nil
+	case "face-fillet":
+		if fd.FaceFillet == nil {
+			return nil, fmt.Errorf("face-fillet feature is missing its payload")
+		}
+		a, err := decodeKeys(fd.FaceFillet.FacesA)
+		if err != nil {
+			return nil, err
+		}
+		b, err := decodeKeys(fd.FaceFillet.FacesB)
+		if err != nil {
+			return nil, err
+		}
+		return du.AddFaceFillet(a, b, constFloat(fd.FaceFillet.Value)), nil
 	case "chamfer":
 		d, err := requireEdgeDress(fd.Chamfer, "chamfer")
 		if err != nil {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -103,6 +103,13 @@ type FaceDressData struct {
 	Pull  []float64 `yaml:"pull,omitempty"` // draft pull direction (dx,dy,dz); absent ⇒ +Z
 }
 
+// FaceFilletData persists a face fillet (#694): the two face-set reference keys and the radius.
+type FaceFilletData struct {
+	FacesA []string `yaml:"facesA"`
+	FacesB []string `yaml:"facesB"`
+	Value  float64  `yaml:"value"`
+}
+
 // ThreadData tags a single cylindrical face (reference key) with a thread designation, plus
 // the #325 parity fields: the tolerance class, the tapered (pipe) flag, and which thread
 // diameter the modeled face represents (wire spelling; absent = major).

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -90,6 +90,32 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestFaceFilletRoundTrip checks the face-fillet feature's two face sets + radius survive a recipe
+// round trip (#694).
+func TestFaceFilletRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewDressUpFeatures(fs).AddFaceFillet(
+		[][]byte{[]byte("face-a"), []byte("face-b")}, [][]byte{[]byte("face-c")}, func() float64 { return 0.7 })
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*FaceFilletFeature).Definition()
+	if len(d.FaceKeysA) != 2 || string(d.FaceKeysA[0]) != "face-a" || string(d.FaceKeysA[1]) != "face-b" {
+		t.Errorf("faceA keys = %v, want [face-a face-b]", d.FaceKeysA)
+	}
+	if len(d.FaceKeysB) != 1 || string(d.FaceKeysB[0]) != "face-c" {
+		t.Errorf("faceB keys = %v, want [face-c]", d.FaceKeysB)
+	}
+	if d.Radius() != 0.7 {
+		t.Errorf("radius = %v, want 0.7", d.Radius())
+	}
+}
+
 // TestChamferFlatCornersRoundTrip checks the chamfer corner treatment survives a recipe
 // round trip in both states, and that an older recipe with no flag restores as flat (the
 // default, matching a freshly created chamfer).


### PR DESCRIPTION
## What

Implements **face fillet** (Inventor's `FilletConstantRadiusFaceSet`) for the common **adjacent-faces** case: pick two face sets and round the edge(s) they share with a constant-radius rolling-ball blend. Picking by *face* is the natural selection when a long chain of edges separates two regions.

## How

`FaceFilletFeature` resolves the edges whose two adjacent faces lie one in each set (`sharedEdgeKeys`) and routes them through the existing `filletBody` edge-fillet kernel — so it inherits the proven rolling-ball geometry. No shared edge is a clean **Sick** error.

**No API change** (fits the non-API phase): the `types.FilletType{face}` discriminator and `FaceRefs` selection already exist in the contract, and part fillets flow through the `/source` opregistry schema, so the new `faceRefsA`/`faceRefsB` form on the `fillet` op is reachable over **MCP** (`features.add`). The feature round-trips in the recipe (`FaceFilletData`).

## Tests

- Feature: round the edge two adjacent faces share → valid solid, a cylindrical fillet face, volume = box − one quarter-round; non-adjacent faces → Sick.
- Registry/MCP path: `fillet` op with `faceRefsA`/`faceRefsB`; rejects only one set given.
- Serialize round trip of the two face sets + radius.
- `./model/... ./addin/... ./app/...` green; lint clean.

## Scope (#694 stays open)

This is the **adjacent-faces, headless + MCP** slice. Remaining on #694:
- **Non-adjacent** face sets (rolling ball bridges a gap between faces that share no edge).
- **Full-round fillet** (`FilletFullRoundSet`) — variable round tangent to three face sets with the center face removed.
- A **face-picking UI mode** in the fillet tool/dialog (the viewport-DoD piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)