### PR TITLE
feat(fillet): rule fillet — round a class of edges in one feature (#486)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -200,6 +200,23 @@ func TestFaceFilletThroughRegistry(t *testing.T) {
 	}
 }
 
+// TestRuleFilletThroughRegistry rounds every convex edge of an extruded solid in one feature via the
+// ruleFillet op (#486) — the end-to-end registry/MCP path.
+func TestRuleFilletThroughRegistry(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := applyMap(t, s, "ruleFillet", map[string]any{"rule": "allRounds", "radius": "0.5 mm"}); err != nil {
+		t.Fatalf("rule fillet through registry: %v", err)
+	}
+}
+
+// TestRuleFilletRejectsBadRule: an unknown rule is a clean error.
+func TestRuleFilletRejectsBadRule(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := applyMap(t, s, "ruleFillet", map[string]any{"rule": "everything", "radius": "0.5 mm"}); err == nil {
+		t.Error("ruleFillet with an unknown rule should error")
+	}
+}
+
 // TestFaceFilletRequiresBothSets: the face-fillet form rejects only one face set given.
 func TestFaceFilletRequiresBothSets(t *testing.T) {
 	s, _, face := extrudedSolid(t)
@@ -281,6 +298,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"loft":                    `{"sections":[{"sketchIndex":0,"profileIndex":0},{"sketchIndex":1,"profileIndex":0}]}`,
 		"sweep":                   `{"sketchIndex":0,"path":{"sketchIndex":1}}`,
 		"fillet":                  `{"edges":["e1"],"radius":"1 mm"}`,
+		"ruleFillet":              `{"rule":"allRounds","radius":"1 mm"}`,
 		"chamfer":                 `{"edges":["e1"],"distance":"1 mm"}`,
 		"shell":                   `{"faces":["f1"],"thickness":"1 mm"}`,
 		"draft":                   `{"faces":["f1"],"angle":"3 deg","neutralFace":"f2"}`,

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -84,6 +84,50 @@ func chamferDescriptor() *OperationDescriptor {
 	return &OperationDescriptor{Name: "chamfer", Summary: "Bevel picked edges of a body by a setback distance.", Schema: json.RawMessage(chamferSchema), Apply: applyChamfer}
 }
 
+const ruleFilletSchema = `{
+  "type": "object",
+  "properties": {
+    "rule": {"type": "string", "enum": ["allRounds", "allFillets", "allEdges"], "default": "allRounds", "description": "Which edges to round, by dihedral class: allRounds = every convex (outside) edge, allFillets = every concave (inside) edge, allEdges = both."},
+    "radius": {"type": "string", "description": "Fillet radius with units, e.g. \"1 mm\"."}
+  },
+  "required": ["radius"]
+}`
+
+func ruleFilletDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "ruleFillet", Summary: "Round a whole class of a body's edges (all rounds / all fillets) in one feature.", Schema: json.RawMessage(ruleFilletSchema), Apply: applyRuleFillet}
+}
+
+// ruleFilletArgs is the rule-fillet op's wire shape: a dihedral rule + a radius.
+type ruleFilletArgs struct {
+	Rule   string `json:"rule"`
+	Radius string `json:"radius"`
+}
+
+func applyRuleFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in ruleFilletArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	rule := feature.RuleFilletAllRounds
+	if in.Rule != "" {
+		r, ok := feature.ParseRuleFilletRule(in.Rule)
+		if !ok {
+			return nil, fmt.Errorf("ruleFillet: unknown rule %q (want allRounds, allFillets, or allEdges)", in.Rule)
+		}
+		rule = r
+	}
+	radius, err := lengthClosure(part, in.Radius, "ruleFillet: radius")
+	if err != nil {
+		return nil, err
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddRuleFillet(rule, radius)
+	return recomputeResult(part, pf)
+}
+
 func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	part, err := modelaccess.ActivePart(s)
 	if err != nil {

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -107,6 +107,7 @@ func Default() *Registry {
 		loftDescriptor(),
 		// Subtractive / dress-up (edge & face reference keys).
 		filletDescriptor(),
+		ruleFilletDescriptor(),
 		chamferDescriptor(),
 		shellDescriptor(),
 		draftDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
-		"fillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
+		"fillet", "ruleFillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalLip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -302,6 +302,12 @@ func (c *DressUpFeatures) AddFaceFillet(faceKeysA, faceKeysB [][]byte, radius fu
 	return c.engine.Add(&FaceFilletFeature{def: &FaceFilletDefinition{FaceKeysA: faceKeysA, FaceKeysB: faceKeysB, Radius: radius}})
 }
 
+// AddRuleFillet rounds the running body's edges that match a dihedral rule, all at one radius
+// (#486, the plastic-part rule fillet).
+func (c *DressUpFeatures) AddRuleFillet(rule RuleFilletRule, radius func() float64) *PartFeature {
+	return c.engine.Add(&RuleFilletFeature{def: &RuleFilletDefinition{Rule: rule, Radius: radius}})
+}
+
 // AddChamfer bevels the given edges by distance, blending three-edge corners flat (the
 // default treatment). Use [AddChamferCorners] to choose the pointy corner instead.
 func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64) *PartFeature {

--- a/model/feature/rule_fillet.go
+++ b/model/feature/rule_fillet.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// RuleFilletRule selects which of the running body's edges a rule fillet rounds, by dihedral class —
+// the M20-F10 plastic-part "rule fillet" (#486), where you round a whole class of edges in one
+// feature instead of picking them individually.
+type RuleFilletRule int
+
+const (
+	// RuleFilletAllRounds rounds every CONVEX (outside) edge — Inventor's "All Rounds".
+	RuleFilletAllRounds RuleFilletRule = iota
+	// RuleFilletAllFillets fills every CONCAVE (inside) edge — Inventor's "All Fillets".
+	RuleFilletAllFillets
+	// RuleFilletAllEdges rounds every manifold edge, convex and concave.
+	RuleFilletAllEdges
+)
+
+var ruleFilletNames = map[RuleFilletRule]string{
+	RuleFilletAllRounds:  "allRounds",
+	RuleFilletAllFillets: "allFillets",
+	RuleFilletAllEdges:   "allEdges",
+}
+
+// String returns the rule's wire spelling.
+func (r RuleFilletRule) String() string {
+	if s, ok := ruleFilletNames[r]; ok {
+		return s
+	}
+	return fmt.Sprintf("RuleFilletRule(%d)", int(r))
+}
+
+// ParseRuleFilletRule resolves a wire spelling back to its rule.
+func ParseRuleFilletRule(s string) (RuleFilletRule, bool) {
+	for r, name := range ruleFilletNames {
+		if name == s {
+			return r, true
+		}
+	}
+	return 0, false
+}
+
+// RuleFilletDefinition rounds the edges of the running body that match Rule, all at one Radius.
+type RuleFilletDefinition struct {
+	Rule   RuleFilletRule
+	Radius func() float64
+}
+
+// RuleFilletFeature rounds a rule-selected class of edges.
+//
+// Example: round every outside edge of the running body at 1 mm —
+//
+//	NewDressUpFeatures(part.Features()).AddRuleFillet(RuleFilletAllRounds, func() float64 { return 1 })
+type RuleFilletFeature struct{ def *RuleFilletDefinition }
+
+// Definition returns the feature's definition.
+func (f *RuleFilletFeature) Definition() *RuleFilletDefinition { return f.def }
+
+// Kind names the feature type.
+func (f *RuleFilletFeature) Kind() string { return "rule-fillet" }
+
+// Recompute rounds the rule-selected edges of the running body.
+func (f *RuleFilletFeature) Recompute(in Input) (Output, error) {
+	return ruleFilletBody(in, f.def.Rule, callOrZero(f.def.Radius), "rule-fillet")
+}
+
+// ruleFilletBody selects the running body's edges matching rule and rounds them with the constant-
+// radius edge-fillet kernel. A body with no matching edge is a no-op (e.g. a rule fillet of an
+// already-rounded body), not an error. Concave edges fill outward (the standard rule-fillet result).
+func ruleFilletBody(in Input, rule RuleFilletRule, radius float64, feat string) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	if radius <= 0 {
+		return Output{}, fmt.Errorf("%s: radius %g must be > 0", feat, radius)
+	}
+	keys := ruleEdgeKeys(body, rule)
+	if len(keys) == 0 {
+		return Output{Bodies: in.Bodies}, nil
+	}
+	return filletBody(in, keys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, feat)
+}
+
+// ruleEdgeKeys returns the reference keys of every edge whose dihedral class matches rule.
+func ruleEdgeKeys(body *topo.Body, rule RuleFilletRule) [][]byte {
+	var out [][]byte
+	for _, e := range body.Edges() {
+		if matchesFilletRule(rule, ops.ClassifyEdgeConvexity(e)) {
+			out = append(out, e.ReferenceKey())
+		}
+	}
+	return out
+}
+
+// matchesFilletRule reports whether a dihedral class is selected by rule.
+func matchesFilletRule(rule RuleFilletRule, c ops.EdgeConvexity) bool {
+	switch rule {
+	case RuleFilletAllRounds:
+		return c == ops.EdgeConvex
+	case RuleFilletAllFillets:
+		return c == ops.EdgeConcave
+	case RuleFilletAllEdges:
+		return c == ops.EdgeConvex || c == ops.EdgeConcave
+	}
+	return false
+}

--- a/model/feature/rule_fillet_test.go
+++ b/model/feature/rule_fillet_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Rule fillet (#486, M20-F10): round a whole dihedral class of edges (all rounds / all fillets) in
+// one feature, instead of picking edges individually.
+
+// TestRuleFilletAllRoundsRoundsWholeBox rounds every convex edge of a 4×4×4 box in one feature: the
+// result is a valid solid with cylindrical fillet faces and less material than the box.
+func TestRuleFilletAllRoundsRoundsWholeBox(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 4}, 0, "box")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	pf := NewDressUpFeatures(fs).AddRuleFillet(RuleFilletAllRounds, func() float64 { return 0.5 })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("rule fillet (all rounds) sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("rule fillet result not a valid solid: %+v", r)
+	}
+	if !hasCylinderFace(res) {
+		t.Error("rule fillet (all rounds) produced no cylindrical face")
+	}
+	if v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume; v <= 0 || v >= 64 {
+		t.Errorf("rounded box volume = %g, want 0 < v < 64 (material removed at every edge)", v)
+	}
+}
+
+// TestRuleFilletAllFilletsFillsConcaveEdge fills the one concave edge of an L-prism, leaving the
+// convex edges sharp: a valid solid with a cylindrical fillet face.
+func TestRuleFilletAllFilletsFillsConcaveEdge(t *testing.T) {
+	l := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 2}, {X: 2, Y: 2}, {X: 2, Y: 4}, {X: 0, Y: 4}},
+		sketch.XYPlane(), span{near: 0, far: 3}, 0, "L")
+	if n := concaveEdgeCount(l); n != 1 {
+		t.Fatalf("L-prism has %d concave edges, want 1", n)
+	}
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(l)
+	pf := NewDressUpFeatures(fs).AddRuleFillet(RuleFilletAllFillets, func() float64 { return 0.5 })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("rule fillet (all fillets) sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("rule fillet result not a valid solid: %+v", r)
+	}
+	if !hasCylinderFace(res) {
+		t.Error("rule fillet (all fillets) produced no cylindrical face")
+	}
+}
+
+// TestRuleFilletNoMatchNoOp: all-fillets on a plain box (no concave edge) changes nothing.
+func TestRuleFilletNoMatchNoOp(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	pf := NewDressUpFeatures(fs).AddRuleFillet(RuleFilletAllFillets, func() float64 { return 0.3 })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("no-match rule fillet sick: %+v", pf.Health())
+	}
+	if v := ops.BodyGeometryProperties(fs.Result()[0], ops.Quality{ChordTolerance: 1e-3}).Volume; relErr(v, 8) > 1e-6 {
+		t.Errorf("box volume after no-match all-fillets = %g, want 8 (unchanged)", v)
+	}
+}
+
+func concaveEdgeCount(b *topo.Body) int {
+	n := 0
+	for _, e := range b.Edges() {
+		if ops.ClassifyEdgeConvexity(e) == ops.EdgeConcave {
+			n++
+		}
+	}
+	return n
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -28,6 +28,7 @@ type FeatureData struct {
 	Extrude        *ExtrudeData        `yaml:"extrude,omitempty"`
 	Fillet         *EdgeDressData      `yaml:"fillet,omitempty"`
 	FaceFillet     *FaceFilletData     `yaml:"faceFillet,omitempty"`
+	RuleFillet     *RuleFilletData     `yaml:"ruleFillet,omitempty"`
 	Chamfer        *EdgeDressData      `yaml:"chamfer,omitempty"`
 	Shell          *FaceDressData      `yaml:"shell,omitempty"`
 	Draft          *FaceDressData      `yaml:"draft,omitempty"`
@@ -141,6 +142,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius), CornerType: int32(f.def.CornerType)}
 	case *FaceFilletFeature:
 		fd.FaceFillet = &FaceFilletData{FacesA: encodeKeys(f.def.FaceKeysA), FacesB: encodeKeys(f.def.FaceKeysB), Value: evalFloat(f.def.Radius)}
+	case *RuleFilletFeature:
+		fd.RuleFillet = &RuleFilletData{Rule: f.def.Rule.String(), Value: evalFloat(f.def.Radius)}
 	case *ChamferFeature:
 		flat := f.def.FlatCorners
 		fd.Chamfer = &EdgeDressData{
@@ -449,6 +452,15 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 			return nil, err
 		}
 		return du.AddFaceFillet(a, b, constFloat(fd.FaceFillet.Value)), nil
+	case "rule-fillet":
+		if fd.RuleFillet == nil {
+			return nil, fmt.Errorf("rule-fillet feature is missing its payload")
+		}
+		rule, ok := ParseRuleFilletRule(fd.RuleFillet.Rule)
+		if !ok {
+			return nil, fmt.Errorf("rule-fillet: unknown rule %q", fd.RuleFillet.Rule)
+		}
+		return du.AddRuleFillet(rule, constFloat(fd.RuleFillet.Value)), nil
 	case "chamfer":
 		d, err := requireEdgeDress(fd.Chamfer, "chamfer")
 		if err != nil {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -110,6 +110,12 @@ type FaceFilletData struct {
 	Value  float64  `yaml:"value"`
 }
 
+// RuleFilletData persists a rule fillet (#486): the dihedral rule (wire spelling) and the radius.
+type RuleFilletData struct {
+	Rule  string  `yaml:"rule"`
+	Value float64 `yaml:"value"`
+}
+
 // ThreadData tags a single cylindrical face (reference key) with a thread designation, plus
 // the #325 parity fields: the tolerance class, the tapered (pipe) flag, and which thread
 // diameter the modeled face represents (wire spelling; absent = major).

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -116,6 +116,27 @@ func TestFaceFilletRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRuleFilletRoundTrip checks the rule fillet's rule + radius survive a recipe round trip (#486).
+func TestRuleFilletRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewDressUpFeatures(fs).AddRuleFillet(RuleFilletAllFillets, func() float64 { return 1.5 })
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*RuleFilletFeature).Definition()
+	if d.Rule != RuleFilletAllFillets {
+		t.Errorf("rule = %v, want %v", d.Rule, RuleFilletAllFillets)
+	}
+	if d.Radius() != 1.5 {
+		t.Errorf("radius = %v, want 1.5", d.Radius())
+	}
+}
+
 // TestChamferFlatCornersRoundTrip checks the chamfer corner treatment survives a recipe
 // round trip in both states, and that an older recipe with no flag restores as flat (the
 // default, matching a freshly created chamfer).


### PR DESCRIPTION
## What

Implements the **rule fillet** (M20-F10 plastic-part feature, #486): round a whole dihedral *class* of the running body's edges at one radius in a single feature, instead of picking each edge.

Rules: `allRounds` (every convex/outside edge), `allFillets` (every concave/inside edge), `allEdges`.

## How

`RuleFilletFeature` classifies the body's edges with `ops.ClassifyEdgeConvexity` and routes the matching keys through the existing `filletBody` edge-fillet kernel — so it inherits the proven rolling-ball geometry and corner blends (filleting all 12 edges of a box, three meeting at each corner, yields a valid solid). A body with no matching edge is a clean **no-op**, not an error.

**No API change** (non-API phase): reachable over **MCP** through the `/source` opregistry `ruleFillet` op (`features.add`); the rule + radius round-trip in the recipe (`RuleFilletData`).

## Tests

- Feature: `allRounds` rounds a whole box → valid solid, cylinder faces, volume < box; `allFillets` fills an L-prism's concave edge; no-match → exact no-op.
- Registry/MCP path + unknown-rule rejection; the default-registry and every-op-handles-args guards updated.
- Serialize round trip of the rule + radius.
- `./model/... ./addin/... ./app/...` green; lint clean.

## Scope (#486 stays open)

This is the **RuleFillet** slice. Remaining on #486: **Rest** (raised mounting pad) and **SnapFit** (cantilever hook / annular ring connectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)