### PR TITLE
feat(viewport): Look At — reorient the view normal to a selection (N18) (#913)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -663,8 +663,16 @@ func viewNavigateCommands() []*CommandDefinition {
 			return nil
 		}).WithTab("View").WithIcon("home").WithButtonStyle(LargeIconButton).
 			WithTooltip("Home View — the default isometric view, framed to fit."),
+		NewCommand("View.LookAt", "Look At", "Navigate", func(s *Session) error {
+			s.LookAtSelection()
+			return nil
+		}).WithTab("View").WithIcon("look-at").WithButtonStyle(LargeIconButton).WithEnable(canLookAt).
+			WithTooltip("Look At — reorient the view normal to the selected planar face or work plane."),
 	}
 }
+
+// canLookAt enables Look At only when a planar face or work plane is selected.
+func canLookAt(s *Session) bool { return s.CanLookAt() }
 
 // visualStyleSpec maps a renderer VisualStyle to its View-tab command id and tooltip. The ids
 // are stable (tests + aliases depend on "View.Shaded" etc.); the styles and labels come from

--- a/app/look_at_test.go
+++ b/app/look_at_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// facesNormal asserts the camera now looks straight along n (forward ∥ n) after the swing completes.
+func facesNormal(t *testing.T, s *Session, n [3]float64) {
+	t.Helper()
+	runCameraAnimation(s)
+	f := s.Camera().Forward()
+	dot := stdmath.Abs(float64(f.X)*n[0] + float64(f.Y)*n[1] + float64(f.Z)*n[2])
+	if dot < 1-1e-6 {
+		t.Errorf("view not facing the reference: |fwd·n| = %v, want 1", dot)
+	}
+}
+
+// TestLookAtSelectionFacesWorkPlane: with a work plane selected, Look At swings the view normal to it.
+func TestLookAtSelectionFacesWorkPlane(t *testing.T) {
+	s, def := emptyPartSession(t)
+	wp := def.OriginPlanes()[0]
+	s.Selection().Add(WorkPlaneHandle{Plane: wp})
+	if !s.CanLookAt() {
+		t.Fatal("CanLookAt should be true with a work plane selected")
+	}
+	if !s.LookAtSelection() {
+		t.Fatal("LookAtSelection should report the work plane as a planar reference")
+	}
+	n := wp.Plane().Normal().AsVector()
+	facesNormal(t, s, [3]float64{float64(n.X), float64(n.Y), float64(n.Z)})
+}
+
+// TestLookAtSelectionFacesPlanarFace: with a planar face selected, Look At faces its normal (+Z here).
+func TestLookAtSelectionFacesPlanarFace(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	s.Selection().Add(FaceHandle{Face: aFace()}) // a +Z planar face
+	if !s.CanLookAt() {
+		t.Fatal("CanLookAt should be true with a planar face selected")
+	}
+	if !s.LookAtSelection() {
+		t.Fatal("LookAtSelection should report the planar face as a reference")
+	}
+	facesNormal(t, s, [3]float64{0, 0, 1})
+}
+
+// TestLookAtSelectionNoPlanarSelection: nothing planar selected ⇒ Look At is a reported no-op.
+func TestLookAtSelectionNoPlanarSelection(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if s.CanLookAt() {
+		t.Error("CanLookAt with nothing selected should be false")
+	}
+	if s.LookAtSelection() {
+		t.Error("LookAtSelection with nothing selected should report false")
+	}
+	if s.CameraAnimating() {
+		t.Error("a no-op Look At must not start a camera transition")
+	}
+}

--- a/app/view.go
+++ b/app/view.go
@@ -2,7 +2,10 @@
 
 package app
 
-import "oblikovati.org/math"
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
 
 // View navigation commands operate on the session camera. FitView frames the active
 // part in the viewport keeping the current orientation (Inventor's Zoom All); HomeView
@@ -19,6 +22,46 @@ func (s *Session) FitView() {
 // HomeView switches to the default isometric view, framed to fit the active part, writing
 // through the active view so the framing is remembered.
 func (s *Session) HomeView() { s.SetCamera(s.Camera().Home(s.modelBounds())) }
+
+// LookAtSelection reorients the camera to look straight at the selected planar reference — a work
+// plane or a planar face (Inventor's Look At, N18). It keeps the eye–target distance and swings the
+// view with the standard tween, recording view history so Previous View returns. A selected work
+// plane wins over a selected face. Reports whether a planar reference was selected (false ⇒ no-op).
+func (s *Session) LookAtSelection() bool {
+	if wp := s.SelectedWorkPlane(); wp != nil {
+		p := wp.Plane()
+		s.lookAtPlane(p.Origin(), p.Normal().AsVector(), p.YAxis().AsVector())
+		return true
+	}
+	if f, ok := s.SelectedFace(); ok {
+		if pl, planar := f.Geometry().(geom.Plane); planar {
+			_, up := pl.DerivativesAt(0, 0) // the plane's in-plane v-axis is a stable screen-up
+			s.lookAtPlane(f.RangeBox().Center(), pl.Normal(), up)
+			return true
+		}
+	}
+	return false
+}
+
+// CanLookAt reports whether the current selection has a planar reference LookAtSelection can face —
+// the enable predicate for the Look At command.
+func (s *Session) CanLookAt() bool {
+	if s.SelectedWorkPlane() != nil {
+		return true
+	}
+	f, ok := s.SelectedFace()
+	if !ok {
+		return false
+	}
+	_, planar := f.Geometry().(geom.Plane)
+	return planar
+}
+
+// lookAtPlane swings the camera to face the plane at target with the given normal and up.
+func (s *Session) lookAtPlane(target math.Point3, normal, up math.Vector3) {
+	s.PushViewHistory()
+	s.animateCameraTo(s.Camera().Facing(target, normal, up), sketchViewTweenSeconds)
+}
 
 // modelBounds is the union of the active part's body bounding boxes (empty if none).
 func (s *Session) modelBounds() math.Box {

--- a/head/icon/assets/look-at.svg
+++ b/head/icon/assets/look-at.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 12 Q12 5 21 12 Q12 19 3 12 Z"/><circle cx="12" cy="12" r="3" fill="#000" stroke="none"/></svg>


### PR DESCRIPTION
## What

Inventor's **Look At** (spec N18): with a planar face or a work plane selected, the **View ▸ Navigate ▸ Look At** command swings the camera to look straight at it (forward ∥ the reference normal).

## How

`Session.LookAtSelection` resolves the selected reference (a work plane wins over a planar face) to a plane and reuses `scene.Camera.Facing` via `animateCameraTo` — the same swing `EnterSketch` uses — keeping the eye–target distance and the standard tween, and recording view history so Previous View returns.
- **Work plane** → plane origin + Y-axis up.
- **Planar face** → bounding-box centre + the plane's in-plane v-axis as up.

`Session.CanLookAt` gates the command (enabled only when a planar reference is selected). The command sits on the View tab's Navigate panel with a new `look-at` icon.

## Tests

- Faces a selected **work plane** and a selected **planar face** (forward ∥ normal after the swing completes).
- No-op when nothing planar is selected (`CanLookAt` false, no transition started).
- The ribbon-icon / button-style guards pass (icon bundled + large style); `app` + `head/ui` green; lint clean.

## Scope (#913 stays open)

Second slice (after zoom-to-cursor #1022). Remaining nav gaps: Free/Constrained Orbit ring (N5–N10), Zoom Window (N16), Navigation Bar (N25), SteeringWheels (N26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)