### PR TITLE
feat(viewport): Zoom Window — drag a box to fit it (N16) (#913)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -668,6 +668,12 @@ func viewNavigateCommands() []*CommandDefinition {
 			return nil
 		}).WithTab("View").WithIcon("look-at").WithButtonStyle(LargeIconButton).WithEnable(canLookAt).
 			WithTooltip("Look At — reorient the view normal to the selected planar face or work plane."),
+		NewCommand("View.ZoomWindow", "Zoom Window", "Navigate", func(s *Session) error {
+			s.ArmZoomWindow()
+			return nil
+		}).WithTab("View").WithIcon("zoom-window").WithButtonStyle(LargeIconButton).WithEnable(hasActivePart).
+			WithActive(func(s *Session) bool { return s.ZoomWindowArmed() }).
+			WithTooltip("Zoom Window — drag a rectangle in the viewport; the view zooms to fit it."),
 	}
 }
 

--- a/app/session.go
+++ b/app/session.go
@@ -54,6 +54,8 @@ type Session struct {
 	picker               Picker
 	regionPicker         RegionPicker      // resolves a box-select rectangle (nil ⇒ box-select disabled)
 	boxSelect            BoxSelection      // the in-progress rubber-band rectangle, if any
+	zoomWindow           BoxSelection      // the in-progress Zoom Window rubber-band, if any (#913 N16)
+	zoomWindowArmed      bool              // the Zoom Window tool is armed: the next left-drag zooms
 	entityDrag           sketchDrag        // the in-progress direct drag of sketch entities, if any
 	dimDrag              dimDragState      // the in-progress drag of a drawing dimension's text/line
 	selectOther          selectOther       // the in-progress Select Other cycle, if any

--- a/app/zoom_window.go
+++ b/app/zoom_window.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Zoom Window (Inventor's Zoom Area, N18→N16 in the viewport audit, #913): arm the tool, drag a
+// rectangle over the viewport, and the view zooms to fit it. The rubber band reuses BoxSelection's
+// geometry but is independent of box-select — no RegionPicker, no window/crossing hit semantics —
+// because it changes the camera, not the selection. The camera math is scene.Camera.ZoomToRect.
+
+// ArmZoomWindow arms the Zoom Window tool: the next left-drag over the viewport sweeps the zoom
+// rectangle. It clears any stale rubber band.
+func (s *Session) ArmZoomWindow() {
+	s.zoomWindowArmed = true
+	s.zoomWindow = BoxSelection{}
+}
+
+// ZoomWindowArmed reports whether the Zoom Window tool is waiting for (or running) a drag — the
+// enable/active state for its command and the head's input routing.
+func (s *Session) ZoomWindowArmed() bool { return s.zoomWindowArmed }
+
+// DisarmZoomWindow cancels the tool and any in-progress rubber band (e.g. Esc).
+func (s *Session) DisarmZoomWindow() {
+	s.zoomWindowArmed = false
+	s.zoomWindow = BoxSelection{}
+}
+
+// BeginZoomWindow anchors the zoom rectangle at the press point (no-op unless armed).
+func (s *Session) BeginZoomWindow(x, y float64) {
+	if !s.zoomWindowArmed {
+		return
+	}
+	s.zoomWindow = BoxSelection{X0: x, Y0: y, X1: x, Y1: y, Active: true}
+}
+
+// UpdateZoomWindow moves the rectangle's free corner to the current cursor position.
+func (s *Session) UpdateZoomWindow(x, y float64) {
+	if s.zoomWindow.Active {
+		s.zoomWindow.X1, s.zoomWindow.Y1 = x, y
+	}
+}
+
+// ZoomWindowDragging reports whether a zoom rectangle is being swept (the head draws it then).
+func (s *Session) ZoomWindowDragging() bool { return s.zoomWindow.Active }
+
+// ZoomWindowRect returns the in-progress rectangle in viewport-local pixels for the head to draw.
+func (s *Session) ZoomWindowRect() (x0, y0, x1, y1 float64) {
+	b := s.zoomWindow
+	return b.X0, b.Y0, b.X1, b.Y1
+}
+
+// CommitZoomWindow zooms the active view to the swept rectangle and disarms the tool. A degenerate
+// rectangle (a click, or no drag) just disarms — ZoomToRect ignores it. The view change is recorded
+// so Previous View returns.
+func (s *Session) CommitZoomWindow() {
+	b := s.zoomWindow
+	s.DisarmZoomWindow()
+	if !b.Active {
+		return
+	}
+	cam := s.Camera().ZoomToRect(b.X0, b.Y0, b.X1, b.Y1)
+	if cam == s.Camera() {
+		return // degenerate box: ZoomToRect was a no-op, don't churn view history
+	}
+	s.PushViewHistory()
+	s.SetCamera(cam)
+}

--- a/app/zoom_window_test.go
+++ b/app/zoom_window_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// TestZoomWindowDragZoomsAndDisarms: arm → drag a centred half-size box → release zooms the view in
+// (eye–target distance halves) and disarms the tool.
+func TestZoomWindowDragZoomsAndDisarms(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	cam := s.Camera()
+	cam.Width, cam.Height = 800, 600
+	s.SetCamera(cam)
+	d0 := float64(s.Camera().Eye.DistanceTo(s.Camera().Target))
+
+	s.ArmZoomWindow()
+	if !s.ZoomWindowArmed() {
+		t.Fatal("ArmZoomWindow should arm the tool")
+	}
+	s.BeginZoomWindow(200, 150)
+	s.UpdateZoomWindow(600, 450) // a 400×300 box (half the 800×600 viewport)
+	if !s.ZoomWindowDragging() {
+		t.Fatal("a begun drag should report dragging")
+	}
+	s.CommitZoomWindow()
+
+	if s.ZoomWindowArmed() || s.ZoomWindowDragging() {
+		t.Error("commit should disarm the tool and end the drag")
+	}
+	d1 := float64(s.Camera().Eye.DistanceTo(s.Camera().Target))
+	if stdmath.Abs(d1-d0/2) > 1e-6 {
+		t.Errorf("zoom-window distance = %v, want %v (half: box is half the viewport)", d1, d0/2)
+	}
+}
+
+// TestZoomWindowDegenerateIsNoOp: a click (no real rectangle) disarms without moving the camera.
+func TestZoomWindowDegenerateIsNoOp(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	before := s.Camera()
+	s.ArmZoomWindow()
+	s.BeginZoomWindow(300, 300)
+	s.UpdateZoomWindow(301, 301) // sub-threshold
+	s.CommitZoomWindow()
+	if s.ZoomWindowArmed() {
+		t.Error("a degenerate Zoom Window should still disarm")
+	}
+	if s.Camera() != before {
+		t.Error("a degenerate Zoom Window must not move the camera")
+	}
+}
+
+// TestDisarmZoomWindowCancels: Esc/disarm drops an armed tool and any in-progress rubber band.
+func TestDisarmZoomWindowCancels(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	s.ArmZoomWindow()
+	s.BeginZoomWindow(100, 100)
+	s.DisarmZoomWindow()
+	if s.ZoomWindowArmed() || s.ZoomWindowDragging() {
+		t.Error("DisarmZoomWindow should clear both the armed flag and the rubber band")
+	}
+}
+
+// TestBeginZoomWindowRequiresArm: Begin is a no-op unless the tool is armed.
+func TestBeginZoomWindowRequiresArm(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	s.BeginZoomWindow(10, 10)
+	if s.ZoomWindowDragging() {
+		t.Error("BeginZoomWindow without arming should not start a drag")
+	}
+}

--- a/head/icon/assets/zoom-window.svg
+++ b/head/icon/assets/zoom-window.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="4" y="6" width="11" height="9" stroke-dasharray="2 2"/><circle cx="15" cy="15" r="4"/><path d="M18 18 L21 21"/></svg>

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -34,6 +34,9 @@ func handleViewportSelection(s *app.Session) {
 	if heldNavMode() != NavNone {
 		return // a held F2/F3/F4 turns a left-drag into navigation, not selection (#911)
 	}
+	if updateZoomWindow(s) {
+		return // the Zoom Window tool owns the left-drag while armed (#913 N16)
+	}
 	if s.SelectOtherActive() {
 		if native.IsItemClicked(native.MouseLeft) {
 			s.CommitSelectOther() // a click in the viewport accepts the highlighted candidate (#910)
@@ -97,6 +100,46 @@ func updateBoxSelect(s *app.Session) bool {
 	}
 	s.BeginBoxSelect(lx, ly)
 	return s.BoxSelectActive() // false when no RegionPicker is installed → fall through to click
+}
+
+// updateZoomWindow drives the Zoom Window rubber band while the tool is armed: a fresh left press
+// anchors the box, the cursor sweeps it, and release zooms the view to fit it (#913 N16). It consumes
+// all left input while armed so the drag never also selects. Esc disarms via cancelViewportTool.
+func updateZoomWindow(s *app.Session) bool {
+	if !s.ZoomWindowArmed() {
+		return false
+	}
+	lx, ly := viewportCursor()
+	if s.ZoomWindowDragging() {
+		if native.MouseDown(native.MouseLeft) {
+			s.UpdateZoomWindow(lx, ly)
+		} else {
+			s.CommitZoomWindow()
+		}
+		return true
+	}
+	if native.IsItemClicked(native.MouseLeft) {
+		s.BeginZoomWindow(lx, ly)
+	}
+	return true
+}
+
+// drawZoomWindowRect draws the in-progress Zoom Window rubber band over the viewport image, in a
+// neutral white (distinct from box-select's blue/green window/crossing colours). No-op when idle.
+func drawZoomWindowRect(s *app.Session, bx, by float32) {
+	if !s.ZoomWindowDragging() {
+		return
+	}
+	x0, y0, x1, y1 := s.ZoomWindowRect()
+	sx0, sy0 := bx+float32(x0), by+float32(y0)
+	sx1, sy1 := bx+float32(x1), by+float32(y1)
+	fill := [4]float32{0.85, 0.85, 0.90, 0.15}
+	border := [4]float32{0.95, 0.95, 1.00, 0.95}
+	native.DrawQuadFilled(sx0, sy0, sx1, sy0, sx1, sy1, sx0, sy1, fill)
+	native.DrawLine(sx0, sy0, sx1, sy0, border, 1.2)
+	native.DrawLine(sx1, sy0, sx1, sy1, border, 1.2)
+	native.DrawLine(sx1, sy1, sx0, sy1, border, 1.2)
+	native.DrawLine(sx0, sy1, sx0, sy0, border, 1.2)
 }
 
 // viewportSelectMods reads the Shift/Ctrl modifiers held this frame (Shift adds, Ctrl

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -183,9 +183,12 @@ func handleKeyboard(s *app.Session) {
 	}
 	mods := heldModifiers()
 	if native.EscapePressed() {
-		if s.SelectOtherActive() {
+		switch {
+		case s.SelectOtherActive():
 			s.CancelSelectOther() // Esc ends the cycle, keeping the highlighted candidate (#910)
-		} else {
+		case s.ZoomWindowArmed():
+			s.DisarmZoomWindow() // Esc cancels an armed Zoom Window before/while dragging (#913 N16)
+		default:
 			_ = s.PressKey(app.KeyEvent{Key: "Escape", Mods: mods})
 		}
 	}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -77,7 +77,8 @@ func drawSingleViewport(win *native.Window, s *app.Session) {
 	cam, hovered := updateViewportCamera(s, pw, ph, hit.overCube)
 	sketchPlane, dims, gfxLabels, gfxImages := buildAndRenderScene(win, s, cam, hovered, pw, ph, cx, cy, t0)
 	drawViewportOverlays(s, cam, sketchPlane, dims, gfxLabels, gfxImages, cx, cy, ph)
-	drawBoxSelectRect(s, bx, by) // the rubber-band selection rectangle, on top of the image
+	drawBoxSelectRect(s, bx, by)  // the rubber-band selection rectangle, on top of the image
+	drawZoomWindowRect(s, bx, by) // the Zoom Window rubber band (#913 N16), if armed
 	if s.ShowViewCube() {
 		drawViewCube(cam, s.CubeOrientation(), p, hit.region, hit.homeHit, s.ShowCompass(), s.InactiveOpacity(), hit.arrow)
 	}

--- a/scene/camera.go
+++ b/scene/camera.go
@@ -202,6 +202,36 @@ func (c Camera) DollyToCursor(factor, px, py float64) Camera {
 	return c
 }
 
+// zoomRectMinPixels is the smallest drag (in viewport pixels) ZoomToRect acts on; a smaller box
+// (a click or a twitch) is treated as no rectangle and ignored.
+const zoomRectMinPixels = 3
+
+// ZoomToRect reframes the view to the screen rectangle (x0,y0)-(x1,y1) in viewport pixels — Inventor's
+// Zoom Window / Zoom Area (N16). The rectangle's centre becomes the new view centre and the box
+// expands to fill the viewport: its larger relative dimension fits exactly, so the whole box stays
+// visible. The view direction and up are unchanged. A degenerate (near-zero) rectangle, or a centre
+// ray parallel to the target plane, is a no-op.
+//
+// Example: cam = cam.ZoomToRect(x0, y0, x1, y1) // fit the dragged window
+func (c Camera) ZoomToRect(x0, y0, x1, y1 float64) Camera {
+	if c.Width <= 0 || c.Height <= 0 {
+		return c
+	}
+	w, h := stdmath.Abs(x1-x0), stdmath.Abs(y1-y0)
+	if w < zoomRectMinPixels || h < zoomRectMinPixels {
+		return c
+	}
+	pivot, ok := c.cursorPlanePoint((x0+x1)/2, (y0+y1)/2)
+	if !ok {
+		return c
+	}
+	fwd := c.Forward()
+	dist := float64(c.Eye.DistanceTo(c.Target))
+	c.Target = pivot
+	c.Eye = pivot.TranslateBy(fwd.Scale(-dist))
+	return c.Dolly(stdmath.Max(w/float64(c.Width), h/float64(c.Height)))
+}
+
 // cursorPlanePoint returns the world point where the ray through pixel (px, py) meets the plane
 // through the target perpendicular to the view direction — the focal-depth point under the cursor.
 // ok is false when the ray is parallel to that plane or points away from it.

--- a/scene/camera_test.go
+++ b/scene/camera_test.go
@@ -93,6 +93,41 @@ func TestDollyToCursorClampsMinDistance(t *testing.T) {
 	}
 }
 
+// TestZoomToRectCentersAndFills: zooming to a centred half-size box keeps the view direction, recentres
+// on the box centre, and halves the eye–target distance (the box's relative size sets the zoom).
+func TestZoomToRectCentersAndFills(t *testing.T) {
+	c := NewCamera(800, 600)
+	before, _ := c.cursorPlanePoint(400, 300) // box centre = viewport centre → the current target depth
+	z := c.ZoomToRect(200, 150, 600, 450)     // a 400×300 box (half W, half H) centred
+	if !z.Forward().IsEqualTo(c.Forward(), 1e-9) {
+		t.Error("ZoomToRect must keep the view direction")
+	}
+	if !z.Target.IsEqualTo(before, 1e-6) {
+		t.Errorf("recentre target = %v, want the box-centre world point %v", z.Target, before)
+	}
+	if d := float64(z.Eye.DistanceTo(z.Target)); stdmath.Abs(d-5) > 1e-6 {
+		t.Errorf("zoom distance = %v, want 5 (half of 10: the box is half the viewport)", d)
+	}
+}
+
+// TestZoomToRectOffCentreRecenters: an off-centre box moves the target to that box's centre.
+func TestZoomToRectOffCentreRecenters(t *testing.T) {
+	c := NewCamera(800, 600)
+	pivot, _ := c.cursorPlanePoint(650, 180)
+	z := c.ZoomToRect(600, 130, 700, 230) // centre (650,180)
+	if !z.Target.IsEqualTo(pivot, 1e-6) {
+		t.Errorf("off-centre zoom target = %v, want %v", z.Target, pivot)
+	}
+}
+
+// TestZoomToRectIgnoresDegenerate: a near-zero box (a click) is a no-op.
+func TestZoomToRectIgnoresDegenerate(t *testing.T) {
+	c := NewCamera(800, 600)
+	if z := c.ZoomToRect(400, 300, 401, 301); z != c {
+		t.Error("a degenerate rectangle should leave the camera unchanged")
+	}
+}
+
 func TestDollyScalesDistanceKeepingDirection(t *testing.T) {
 	c := NewCamera(800, 600) // eye (0,0,10), target origin
 	in := c.Dolly(0.5)


### PR DESCRIPTION
## What

Inventor's **Zoom Window / Zoom Area** (spec N16): arm **View ▸ Navigate ▸ Zoom Window**, drag a rectangle over the viewport, and the view zooms to fit it.

## How

- `scene.Camera.ZoomToRect(x0,y0,x1,y1)`: the rectangle's centre becomes the new view centre and the box expands to fill the viewport — its larger relative dimension fits exactly, so the whole box stays visible — keeping the view direction and up. Reuses `cursorPlanePoint` for the pivot and `Dolly` for the zoom; a degenerate (near-zero) box is a no-op.
- An **armed mode** independent of box-select (no RegionPicker, no window/crossing meaning): `ArmZoomWindow` → `Begin/Update/CommitZoomWindow` drive a `BoxSelection`-backed rubber band; commit applies `ZoomToRect`, records view history, and disarms.
- Head: while armed, the left-drag routes to `updateZoomWindow` (ahead of selection), a neutral-white rubber band draws over the image, and **Esc disarms**.
- Command on the View tab's Navigate panel with a new `zoom-window` icon (shows active while armed).

## Tests

- Camera math (`scene`): centred half-box halves the distance + recentres; off-centre recenters; degenerate box is a no-op.
- Session state machine (`app`): drag zooms and disarms; degenerate no-op; disarm cancels; Begin requires arming.
- Icon/button-style guards pass; `scene` + `app` + `head/ui` green; `--new-from-rev` lint clean.

## Scope (#913 stays open)

Third slice (after zoom-to-cursor #1022, Look At #1025). Remaining: Free/Constrained Orbit ring (N5–N10), Navigation Bar (N25), SteeringWheels (N26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)