### PR TITLE
fix: hole table finds extrude-cut holes, not just primitive cylinders (#391)

### DIFF
--- a/model/drawing/annotation_test.go
+++ b/model/drawing/annotation_test.go
@@ -373,6 +373,41 @@ func TestAddHoleTable(t *testing.T) {
 	}
 }
 
+// TestHoleTableFromDrilledHole checks a hole table finds a hole drilled into a slab (a composite
+// body, not a primitive cylinder), reporting its diameter. It complements the projection-fit unit
+// test (TestFitCircleRecoversFacetedCircle), which guards the live-verify finding (#391) that a
+// sketch extrude-cut facets the rim away from an analytic geom.Circle edge.
+func TestHoleTableFromDrilledHole(t *testing.T) {
+	slab, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(6, 4, 1), "slab")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	slab, err = brep.CutCylindricalHole(slab, gmath.P3(3, 2, 0), gmath.V3(0, 0, 1), 0.4)
+	if err != nil {
+		t.Fatalf("CutCylindricalHole: %v", err)
+	}
+
+	c := NewContent()
+	c.SetBodyResolver(fakeBodyResolver{body: slab})
+	c.SetModelReference("slab.opd")
+	topBase(t, c.Sheets().Active().Views())
+
+	ht, err := c.Sheets().Active().Annotations().AddHoleTable("HT", "TOP", 40, 260)
+	if err != nil {
+		t.Fatalf("AddHoleTable on a drilled slab: %v", err)
+	}
+	if ht.RowCount() != 1 {
+		t.Fatalf("drilled-slab hole table = %d rows, want 1 (the cut hole)", ht.RowCount())
+	}
+	texts := map[string]bool{}
+	for _, l := range ht.Labels() {
+		texts[l.Text] = true
+	}
+	if !texts["Ø8.00"] { // 0.4 cm radius → 8 mm diameter
+		t.Errorf("drilled-hole diameter label missing Ø8.00: %v", ht.Labels())
+	}
+}
+
 // TestHoleTableNeedsCircularEdge: a box has no circular edges, so a hole table errors.
 func TestHoleTableNeedsCircularEdge(t *testing.T) {
 	c := drawingWithBox(t)

--- a/model/drawing/circles.go
+++ b/model/drawing/circles.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/hlr"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Circle recovery from a view's projection (M14-F04 PBI-144, #391). A hole table tabulates
+// drilled holes, which are extrude-cut features — and a cut hole's B-rep rim is NOT an analytic
+// geom.Circle edge, so scanning body.Edges() (what centre marks do) misses it. The hidden-line
+// projection, however, tessellates every edge into segments tagged by source edge; a hole rim's
+// segments form a closed, equidistant loop. So we recover holes by circle-fitting those loops,
+// which works for cut holes and primitive cylinders alike.
+
+// projectedCircle is a circular edge recovered from a view's projection: its centre on the view
+// plane and radius, both in model centimetres (the projection's units).
+type projectedCircle struct {
+	center math.Point2
+	radius float64
+}
+
+const (
+	circleFitSectors = 6    // angular bins a loop must all hit to count as a full circle (not an arc)
+	circleFitTolFrac = 0.06 // max radius standard-deviation / mean for a loop to read as circular
+)
+
+// circlesFromProjection clusters the body's projected edge segments into connected loops (segments
+// sharing an endpoint) and fits a circle to each closed, equidistant, fully-revolved loop. It
+// clusters by connectivity rather than by source edge because a sketch extrude-cut FACETS a hole
+// rim into many separate straight edges — so grouping by edge key would split one rim into dozens
+// of one-segment groups. Connectivity reunites the faceted rim, recovering the hole.
+func circlesFromProjection(body *topo.Body, basis hlr.View) []projectedCircle {
+	segs := hlr.Project(body, basis, ops.DefaultQuality())
+	clusters := clusterConnectedSegments(segs)
+	var out []projectedCircle
+	for _, pts := range clusters {
+		if c, ok := fitCircle(pts); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// quantizeKey snaps a projected point to a grid so segments that share an endpoint (up to
+// floating-point noise) hash equal and so connect in the union-find.
+func quantizeKey(p math.Point2) [2]int64 {
+	const grid = 1e4 // 1/grid cm ≈ 1 µm resolution — finer than any tessellation chord
+	return [2]int64{int64(stdmath.Round(float64(p.X) * grid)), int64(stdmath.Round(float64(p.Y) * grid))}
+}
+
+// endpointUnionFind groups quantized projected points into connected sets.
+type endpointUnionFind struct{ parent map[[2]int64][2]int64 }
+
+func newEndpointUnionFind() *endpointUnionFind {
+	return &endpointUnionFind{parent: map[[2]int64][2]int64{}}
+}
+
+// find returns the representative of k's set, inserting k as its own root on first sight.
+func (u *endpointUnionFind) find(k [2]int64) [2]int64 {
+	p, ok := u.parent[k]
+	if !ok {
+		u.parent[k] = k
+		return k
+	}
+	if p != k {
+		u.parent[k] = u.find(p)
+	}
+	return u.parent[k]
+}
+
+// union merges the sets of a and b.
+func (u *endpointUnionFind) union(a, b [2]int64) { u.parent[u.find(a)] = u.find(b) }
+
+// clusterConnectedSegments groups segment endpoints into connected components via union-find on
+// shared (quantized) endpoints, returning each component's points. A hole rim — even faceted into
+// many edges — is one connected component; the outer silhouette is another.
+func clusterConnectedSegments(segs []hlr.Segment) [][]math.Point2 {
+	uf := newEndpointUnionFind()
+	pointOf := map[[2]int64]math.Point2{}
+	for _, s := range segs {
+		ka, kb := quantizeKey(s.A), quantizeKey(s.B)
+		pointOf[ka], pointOf[kb] = s.A, s.B
+		uf.union(ka, kb)
+	}
+	groups := map[[2]int64][]math.Point2{}
+	for k, p := range pointOf {
+		groups[uf.find(k)] = append(groups[uf.find(k)], p)
+	}
+	out := make([][]math.Point2, 0, len(groups))
+	for _, pts := range groups {
+		out = append(out, pts)
+	}
+	return out
+}
+
+// fitCircle fits a circle to a loop of projected points, returning it only when the points lie at a
+// near-constant radius from their centroid and revolve fully around it (so a straight edge or a
+// partial arc is rejected). The centroid is the centre; the mean radius is the radius.
+func fitCircle(pts []math.Point2) (projectedCircle, bool) {
+	if len(pts) < circleFitSectors {
+		return projectedCircle{}, false
+	}
+	cx, cy := centroid(pts)
+	mean, stddev := radiusStats(pts, cx, cy)
+	if mean < 1e-6 || stddev/mean > circleFitTolFrac {
+		return projectedCircle{}, false
+	}
+	if !revolvesFully(pts, cx, cy) {
+		return projectedCircle{}, false
+	}
+	return projectedCircle{center: math.P2(math.Scalar(cx), math.Scalar(cy)), radius: mean}, true
+}
+
+// centroid returns the mean position of the points.
+func centroid(pts []math.Point2) (cx, cy float64) {
+	for _, p := range pts {
+		cx, cy = cx+float64(p.X), cy+float64(p.Y)
+	}
+	n := float64(len(pts))
+	return cx / n, cy / n
+}
+
+// radiusStats returns the mean and standard deviation of the points' distances from (cx, cy).
+func radiusStats(pts []math.Point2, cx, cy float64) (mean, stddev float64) {
+	var sum, sumSq float64
+	for _, p := range pts {
+		r := stdmath.Hypot(float64(p.X)-cx, float64(p.Y)-cy)
+		sum, sumSq = sum+r, sumSq+r*r
+	}
+	n := float64(len(pts))
+	mean = sum / n
+	variance := sumSq/n - mean*mean
+	if variance < 0 {
+		variance = 0 // guard floating-point noise below zero
+	}
+	return mean, stdmath.Sqrt(variance)
+}
+
+// revolvesFully reports whether the points hit every angular sector around (cx, cy), so a full
+// circle passes but a partial arc (which leaves sectors empty) does not.
+func revolvesFully(pts []math.Point2, cx, cy float64) bool {
+	var hit [circleFitSectors]bool
+	for _, p := range pts {
+		ang := stdmath.Atan2(float64(p.Y)-cy, float64(p.X)-cx) + stdmath.Pi
+		idx := int(ang / (2 * stdmath.Pi) * circleFitSectors)
+		if idx >= circleFitSectors {
+			idx = circleFitSectors - 1
+		}
+		hit[idx] = true
+	}
+	for _, h := range hit {
+		if !h {
+			return false
+		}
+	}
+	return true
+}

--- a/model/drawing/circles_test.go
+++ b/model/drawing/circles_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/hlr"
+	"oblikovati.org/math"
+)
+
+// facetedLoopSegments returns the circle as N separate one-segment edges sharing endpoints — what
+// a sketch extrude-cut produces (each facet is its own B-rep edge), so clustering must reunite them
+// by connectivity, not by edge key.
+func facetedLoopSegments(cx, cy, r float64, n int) []hlr.Segment {
+	pts := circleLoop(cx, cy, r, n)
+	segs := make([]hlr.Segment, n)
+	for i := 0; i < n; i++ {
+		segs[i] = hlr.Segment{A: pts[i], B: pts[(i+1)%n], EdgeKey: []byte{byte(i)}}
+	}
+	return segs
+}
+
+// circleLoop returns n points evenly spaced on the circle of radius r about (cx, cy) — a stand-in
+// for a hole rim tessellated into segment endpoints by the projection.
+func circleLoop(cx, cy, r float64, n int) []math.Point2 {
+	pts := make([]math.Point2, n)
+	for i := 0; i < n; i++ {
+		a := 2 * stdmath.Pi * float64(i) / float64(n)
+		pts[i] = math.P2(math.Scalar(cx+r*stdmath.Cos(a)), math.Scalar(cy+r*stdmath.Sin(a)))
+	}
+	return pts
+}
+
+// TestFitCircleRecoversFacetedCircle guards the live-verify finding (#391): a hole rim arrives as
+// a loop of faceted points (not an analytic circle), and fitCircle must recover its centre and
+// radius so the hole table can tabulate cut holes — the case body.Edges() misses.
+func TestFitCircleRecoversFacetedCircle(t *testing.T) {
+	c, ok := fitCircle(circleLoop(3, 2, 0.4, 24))
+	if !ok {
+		t.Fatal("fitCircle rejected a full faceted circle loop, want it recovered")
+	}
+	if stdmath.Abs(float64(c.center.X)-3) > 1e-6 || stdmath.Abs(float64(c.center.Y)-2) > 1e-6 {
+		t.Errorf("fitted centre = (%v, %v), want (3, 2)", c.center.X, c.center.Y)
+	}
+	if stdmath.Abs(c.radius-0.4) > 1e-6 {
+		t.Errorf("fitted radius = %v, want 0.4", c.radius)
+	}
+}
+
+// TestFitCircleRejectsNonCircles checks fitCircle rejects loops that are not full circles: a
+// straight run of points (a flat edge) and a half-circle arc (a fillet), so neither is mistaken
+// for a hole.
+func TestFitCircleRejectsNonCircles(t *testing.T) {
+	line := []math.Point2{}
+	for i := 0; i <= 12; i++ {
+		line = append(line, math.P2(math.Scalar(float64(i)), 0))
+	}
+	if _, ok := fitCircle(line); ok {
+		t.Error("fitCircle accepted a straight line, want it rejected")
+	}
+
+	full := circleLoop(0, 0, 1, 24)
+	if _, ok := fitCircle(full[:7]); ok { // first ~half of the loop = an arc
+		t.Error("fitCircle accepted a half-arc, want it rejected (a fillet is not a hole)")
+	}
+}
+
+// TestClusterConnectedSegmentsReunitesFacetedRim is the regression for the live-verify finding
+// (#391): a sketch extrude-cut splits a hole rim into many separate edges, so clustering must
+// reunite them by shared endpoints into one loop — recovering the hole that per-edge grouping
+// would shatter. Two disjoint rims stay two clusters.
+func TestClusterConnectedSegmentsReunitesFacetedRim(t *testing.T) {
+	one := clusterConnectedSegments(facetedLoopSegments(3, 2, 0.4, 16))
+	if len(one) != 1 {
+		t.Fatalf("a faceted rim of 16 separate edges = %d clusters, want 1 (reunited by connectivity)", len(one))
+	}
+	if c, ok := fitCircle(one[0]); !ok || stdmath.Abs(c.radius-0.4) > 1e-6 {
+		t.Errorf("reunited rim did not fit a 0.4 circle: ok=%v c=%+v", ok, c)
+	}
+
+	two := clusterConnectedSegments(append(
+		facetedLoopSegments(0, 0, 1, 12),
+		facetedLoopSegments(10, 0, 1, 12)...,
+	))
+	if len(two) != 2 {
+		t.Errorf("two disjoint rims = %d clusters, want 2", len(two))
+	}
+}

--- a/model/drawing/hole_table.go
+++ b/model/drawing/hole_table.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"oblikovati.org/api/types"
-	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/hlr"
 	"oblikovati.org/kernel/topo"
 )
@@ -59,25 +58,21 @@ func (as *DrawingAnnotations) recomputeHoleTable(a *DrawingAnnotation) {
 	a.curves, a.labels = holeTableGeometry(a.x, a.y, holes)
 }
 
-// projectedHoles collects each distinct circular edge's centre (projected onto the view plane, cm)
-// and diameter (mm); coincident projections (a through-hole's two rims) are listed once — keyed on
-// the sheet position like the centre-mark dedup.
+// projectedHoles collects each distinct hole's centre (on the view plane, cm) and diameter (mm),
+// recovered by circle-fitting the view's projected edge loops (so it sees cut holes, not just
+// primitive cylinders). Coincident projections (a through-hole's two rims) are listed once — keyed
+// on the sheet position like the centre-mark dedup.
 func projectedHoles(view *DrawingView, body *topo.Body, basis hlr.View) []holeRow {
 	seen := map[string]bool{}
 	var out []holeRow
-	for _, e := range body.Edges() {
-		circle, ok := e.Geometry().(geom.Circle)
-		if !ok {
-			continue
-		}
-		p := hlr.ProjectPoint(basis, circle.Center)
-		s := view.place(p)
+	for _, c := range circlesFromProjection(body, basis) {
+		s := view.place(c.center)
 		key := fmt.Sprintf("%.1f/%.1f", float64(s.X), float64(s.Y))
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
-		out = append(out, holeRow{cx: float64(p.X), cy: float64(p.Y), diameter: circle.Radius * 2 * cmToMM})
+		out = append(out, holeRow{cx: float64(c.center.X), cy: float64(c.center.Y), diameter: c.radius * 2 * cmToMM})
 	}
 	return out
 }


### PR DESCRIPTION
## What
A hole table now tabulates **sketch extrude-cut holes** — its primary use case — not only primitive cylinders.

## Why
Live verification (running head, driven over the bridge) exposed that a hole table on a plate with two drilled holes found **zero** holes, even though the TOP view clearly renders both circles. The annotation layer scanned the 3D body's edges for an analytic `geom.Circle`, but a sketch extrude-cut **facets** the hole rim into many separate straight edges — so no `geom.Circle` edge exists to find. (Centre marks share this scan and the same blind spot; this PR fixes the hole table's path.)

## How
Recover holes from the **hidden-line projection** instead of the raw B-rep edges:
- cluster the projected edge segments into connected loops via union-find on shared (quantized) endpoints — so a rim faceted across dozens of edges is reunited into one loop;
- fit a circle to each loop, accepting only **closed, equidistant, fully-revolved** loops (centroid = centre, near-constant radius, all angular sectors hit) — which rejects straight edges and partial arcs (a fillet is not a hole).

This finds cut holes and primitive cylinders alike. Pure model change — no API/wire surface change.

## Tests
- `TestFitCircleRecoversFacetedCircle` / `TestFitCircleRejectsNonCircles` — the fit accepts a faceted full circle, rejects a line and a half-arc.
- `TestClusterConnectedSegmentsReunitesFacetedRim` — a rim split into 16 separate edges clusters back to one loop; two disjoint rims stay two.
- `TestHoleTableFromDrilledHole` — a hole drilled into a slab (a composite body) is tabulated with its Ø8.00 diameter.
- Full `go test ./...` green, `golangci-lint` 0 issues.

## Live verification
Plate with two extrude-cut holes → two-row table (HOLE / X / Y / Ø), correct positions and `Ø8.00` diameters, rendered on the sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)