### PR TITLE
feat(viewport): Free-Orbit ring — zone-dependent orbit + roll (N5–N8) (#913)

### DIFF
--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
@@ -140,6 +142,27 @@ func drawZoomWindowRect(s *app.Session, bx, by float32) {
 	native.DrawLine(sx1, sy0, sx1, sy1, border, 1.2)
 	native.DrawLine(sx1, sy1, sx0, sy1, border, 1.2)
 	native.DrawLine(sx0, sy1, sx0, sy0, border, 1.2)
+}
+
+// drawOrbitRing draws the Free-Orbit ring centred on the viewport while F4 (Free Orbit) is held, so
+// the user sees the zones a drag selects: inside = free orbit, rim = axis-locked, outside = roll
+// (#913 N5–N8). bx,by is the viewport image's top-left in screen pixels; pw,ph its pixel size.
+func drawOrbitRing(bx, by float32, pw, ph int) {
+	if heldNavMode() != NavOrbit {
+		return
+	}
+	cx, cy := bx+float32(pw)/2, by+float32(ph)/2
+	radius := float32(orbitRingRadius(float64(pw), float64(ph)))
+	col := [4]float32{0.85, 0.85, 0.95, 0.55}
+	const seg = 48
+	prevx, prevy := cx+radius, cy
+	for i := 1; i <= seg; i++ {
+		a := 2 * stdmath.Pi * float64(i) / seg
+		x := cx + radius*float32(stdmath.Cos(a))
+		y := cy + radius*float32(stdmath.Sin(a))
+		native.DrawLine(prevx, prevy, x, y, col, 1.4)
+		prevx, prevy = x, y
+	}
 }
 
 // viewportSelectMods reads the Shift/Ctrl modifiers held this frame (Shift adds, Ctrl

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -79,6 +79,7 @@ func drawSingleViewport(win *native.Window, s *app.Session) {
 	drawViewportOverlays(s, cam, sketchPlane, dims, gfxLabels, gfxImages, cx, cy, ph)
 	drawBoxSelectRect(s, bx, by)  // the rubber-band selection rectangle, on top of the image
 	drawZoomWindowRect(s, bx, by) // the Zoom Window rubber band (#913 N16), if armed
+	drawOrbitRing(bx, by, pw, ph) // the Free-Orbit ring while F4 is held (#913 N5–N8)
 	if s.ShowViewCube() {
 		drawViewCube(cam, s.CubeOrientation(), p, hit.region, hit.homeHit, s.ShowCompass(), s.InactiveOpacity(), hit.arrow)
 	}
@@ -645,7 +646,7 @@ func readNavInput() NavInput {
 	dx, dy := native.MouseDelta()
 	modal := heldNavMode()
 	cx, cy := viewportCursor()
-	return NavInput{
+	in := NavInput{
 		Hovered: native.IsItemHovered(),
 		Active:  native.IsItemActive(),
 		Wheel:   native.MouseWheel(),
@@ -658,6 +659,38 @@ func readNavInput() NavInput {
 		Modal:   modal,
 		Left:    modal != NavNone && native.MouseDown(native.MouseLeft),
 	}
+	in.OrbitZone = latchOrbitZone(in, cx, cy)
+	return in
+}
+
+// orbitLatch holds the Free-Orbit ring zone for the duration of one F4 orbit drag.
+var orbitLatch struct {
+	active bool
+	zone   OrbitZone
+}
+
+// latchOrbitZone classifies the Free-Orbit ring zone once at the start of an F4 orbit drag (Modal ==
+// NavOrbit + left held) and holds it until the drag ends, so the whole drag uses the zone the cursor
+// started in — Inventor's ring behaviour (#913 N5–N8). Non-F4 orbits (Shift+middle) keep OrbitFree.
+func latchOrbitZone(in NavInput, cx, cy float64) OrbitZone {
+	if !in.Active || in.Modal != NavOrbit || !in.Left {
+		orbitLatch.active = false
+		return OrbitFree
+	}
+	if !orbitLatch.active {
+		w, h := viewportPixelSize()
+		orbitLatch.zone = classifyOrbitZone(cx, cy, w/2, h/2, orbitRingRadius(w, h))
+		orbitLatch.active = true
+	}
+	return orbitLatch.zone
+}
+
+// viewportPixelSize returns the viewport image's pixel size (ItemRectMax − ItemRectMin), valid right
+// after the viewport's InvisibleButton.
+func viewportPixelSize() (float64, float64) {
+	x0, y0 := native.ItemRectMin()
+	x1, y1 := native.ItemRectMax()
+	return float64(x1 - x0), float64(y1 - y0)
 }
 
 // heldNavMode reports which hold-to-navigate function key is down — F2 pan, F3 zoom, F4 orbit

--- a/head/ui/navigate.go
+++ b/head/ui/navigate.go
@@ -18,7 +18,47 @@ const (
 	orbitRadPerPixel = 0.01
 	zoomPerNotch     = 0.9
 	zoomDragPerPixel = 1.01
+	// orbitRingFraction sizes the Free-Orbit ring (radius = fraction of the smaller viewport side);
+	// orbitRimFraction is where the rim band begins (inside it is free orbit, the band splits
+	// yaw/pitch, outside the ring rolls). See classifyOrbitZone (#913 N5–N8).
+	orbitRingFraction = 0.40
+	orbitRimFraction  = 0.85
 )
+
+// OrbitZone is which region of the Free-Orbit ring a drag began in; it selects the rotation kind
+// (#913 N5–N8). The zone is latched at the start of the drag and held until release.
+type OrbitZone int
+
+const (
+	OrbitFree  OrbitZone = iota // inside the inner disc: free (yaw+pitch) orbit
+	OrbitYaw                    // left/right rim band: rotate about the screen vertical axis
+	OrbitPitch                  // top/bottom rim band: rotate about the screen horizontal axis
+	OrbitRoll                   // outside the ring: roll about the view axis
+)
+
+// orbitRingRadius is the Free-Orbit ring radius for a w×h viewport — a fraction of the smaller side.
+func orbitRingRadius(w, h float64) float64 { return orbitRingFraction * stdmath.Min(w, h) }
+
+// classifyOrbitZone picks the orbit zone for a drag starting at (px,py) relative to a ring centred at
+// (cx,cy) with the given radius: the inner disc is free orbit; the rim band splits into yaw (nearer
+// the left/right of the ring, |dx|≥|dy|) and pitch (nearer top/bottom); outside the ring rolls.
+func classifyOrbitZone(px, py, cx, cy, radius float64) OrbitZone {
+	if radius <= 0 {
+		return OrbitFree // no ring (degenerate viewport) → plain free orbit
+	}
+	dx, dy := px-cx, py-cy
+	r := stdmath.Hypot(dx, dy)
+	switch {
+	case r > radius:
+		return OrbitRoll
+	case r < radius*orbitRimFraction:
+		return OrbitFree
+	case stdmath.Abs(dx) >= stdmath.Abs(dy):
+		return OrbitYaw
+	default:
+		return OrbitPitch
+	}
+}
 
 // NavMode is a held function-key navigation mode (Inventor's F2 pan / F3 zoom / F4 orbit): while
 // the key is down, a left-drag drives that gesture.
@@ -42,8 +82,9 @@ type NavInput struct {
 	CursorX, CursorY float32 // viewport-local cursor pixels (for zoom-to-cursor, N2)
 	Middle           bool
 	Shift            bool
-	Modal            NavMode // a held F2/F3/F4 navigation mode (drives a left-drag)
-	Left             bool    // left button down — only consulted in a Modal mode
+	Modal            NavMode   // a held F2/F3/F4 navigation mode (drives a left-drag)
+	Left             bool      // left button down — only consulted in a Modal mode
+	OrbitZone        OrbitZone // the Free-Orbit ring zone latched at drag start (#913 N5–N8)
 }
 
 // ApplyNavigation maps one frame of pointer input to a camera move, mirroring Inventor:
@@ -62,11 +103,42 @@ func ApplyNavigation(cam scene.Camera, in NavInput) scene.Camera {
 	case NavPan:
 		cam = cam.Pan(float64(in.DX), float64(in.DY))
 	case NavOrbit:
-		cam = cam.Orbit(float64(-in.DX)*orbitRadPerPixel, float64(-in.DY)*orbitRadPerPixel)
+		cam = applyOrbit(cam, in)
 	case NavZoom:
 		cam = cam.Dolly(stdmath.Pow(zoomDragPerPixel, float64(in.DY)))
 	}
 	return cam
+}
+
+// applyOrbit applies one frame of the Free-Orbit ring gesture: the drag-start zone (latched by the
+// head into in.OrbitZone) selects free orbit, yaw-only (about the screen vertical axis), pitch-only
+// (about the horizontal axis), or roll about the view axis (#913 N5–N8). The default zone (OrbitFree)
+// is also what a Shift+middle orbit uses, so that gesture keeps its existing free-orbit behaviour.
+func applyOrbit(cam scene.Camera, in NavInput) scene.Camera {
+	switch in.OrbitZone {
+	case OrbitYaw:
+		return cam.Orbit(float64(-in.DX)*orbitRadPerPixel, 0)
+	case OrbitPitch:
+		return cam.Orbit(0, float64(-in.DY)*orbitRadPerPixel)
+	case OrbitRoll:
+		return cam.Roll(ringRollAngle(cam, in))
+	default:
+		return cam.Orbit(float64(-in.DX)*orbitRadPerPixel, float64(-in.DY)*orbitRadPerPixel)
+	}
+}
+
+// ringRollAngle returns this frame's roll from a perimeter drag: the tangential component of the
+// (DX,DY) move about the ring centre (the viewport centre), per unit radius — a small-angle arc.
+// Screen y is down, so a counter-clockwise drag yields a positive roll.
+func ringRollAngle(cam scene.Camera, in NavInput) float64 {
+	rx := float64(in.CursorX) - float64(cam.Width)/2
+	ry := float64(in.CursorY) - float64(cam.Height)/2
+	r := stdmath.Hypot(rx, ry)
+	if r < 1 {
+		return 0
+	}
+	tangential := (float64(in.DX)*(-ry) + float64(in.DY)*rx) / r // drag · tangent unit
+	return tangential / r
 }
 
 // navGesture resolves a drag into a navigation gesture: a held F-key (F2 pan / F3 zoom / F4

--- a/head/ui/navigate_test.go
+++ b/head/ui/navigate_test.go
@@ -40,6 +40,51 @@ func TestApplyNavigationWheelZoomsTowardCursor(t *testing.T) {
 	}
 }
 
+// TestClassifyOrbitZone covers the Free-Orbit ring zones (#913 N5–N8): inner disc → free, rim
+// left/right → yaw, rim top/bottom → pitch, outside → roll, and a degenerate ring → free.
+func TestClassifyOrbitZone(t *testing.T) {
+	const cx, cy, radius = 400, 300, 200
+	cases := []struct {
+		name   string
+		px, py float64
+		want   OrbitZone
+	}{
+		{"centre", cx, cy, OrbitFree},
+		{"left rim", cx - 190, cy, OrbitYaw},
+		{"right rim", cx + 190, cy, OrbitYaw},
+		{"top rim", cx, cy - 190, OrbitPitch},
+		{"bottom rim", cx, cy + 190, OrbitPitch},
+		{"outside", cx + 260, cy, OrbitRoll},
+	}
+	for _, c := range cases {
+		if got := classifyOrbitZone(c.px, c.py, cx, cy, radius); got != c.want {
+			t.Errorf("%s: zone = %d, want %d", c.name, got, c.want)
+		}
+	}
+	if got := classifyOrbitZone(cx, cy, cx, cy, 0); got != OrbitFree {
+		t.Errorf("degenerate ring zone = %d, want OrbitFree", got)
+	}
+}
+
+// TestApplyOrbitZones: the latched zone selects the rotation — yaw-only keeps the eye in the
+// up-plane (Y=0), pitch-only keeps it in the yaw-plane (X=0), roll spins up without moving the eye.
+func TestApplyOrbitZones(t *testing.T) {
+	base := scene.NewCamera(800, 600) // eye (0,0,10), up +Y, centre (400,300)
+
+	yaw := ApplyNavigation(base, NavInput{Active: true, Modal: NavOrbit, Left: true, DX: 20, DY: 20, OrbitZone: OrbitYaw})
+	if stdmath.Abs(float64(yaw.Eye.Y)) > 1e-9 || yaw.Eye.IsEqualTo(base.Eye, 1e-9) {
+		t.Errorf("yaw-only orbit eye = %v, want moved with Y=0", yaw.Eye)
+	}
+	pitch := ApplyNavigation(base, NavInput{Active: true, Modal: NavOrbit, Left: true, DX: 20, DY: 20, OrbitZone: OrbitPitch})
+	if stdmath.Abs(float64(pitch.Eye.X)) > 1e-9 || pitch.Eye.IsEqualTo(base.Eye, 1e-9) {
+		t.Errorf("pitch-only orbit eye = %v, want moved with X=0", pitch.Eye)
+	}
+	roll := ApplyNavigation(base, NavInput{Active: true, Modal: NavOrbit, Left: true, DX: 20, CursorX: 400, CursorY: 200, OrbitZone: OrbitRoll})
+	if !roll.Eye.IsEqualTo(base.Eye, 1e-9) || roll.Up.IsEqualTo(base.Up, 1e-9) {
+		t.Errorf("roll should spin up (got %v) without moving the eye (got %v)", roll.Up, roll.Eye)
+	}
+}
+
 func TestApplyNavigationPansWithMiddleDrag(t *testing.T) {
 	cam := scene.NewCamera(800, 600)
 	out := ApplyNavigation(cam, NavInput{Active: true, Middle: true, DX: 50})

--- a/scene/camera.go
+++ b/scene/camera.go
@@ -264,6 +264,20 @@ func (c Camera) Orbit(yaw, pitch float64) Camera {
 	return c
 }
 
+// Roll twists the view about the forward (eye→target) axis — the spin a Free-Orbit ring perimeter
+// drag produces (#913 N8). Eye and Target are unchanged; only Up rotates, so the model appears to
+// turn in-plane about the view centre. A degenerate view direction is a no-op.
+//
+// Example: cam = cam.Roll(0.1) // twist the view ~5.7°
+func (c Camera) Roll(angle float64) Camera {
+	forward := c.Forward()
+	if forward == (math.Vector3{}) {
+		return c
+	}
+	c.Up = unit(rotateAboutAxis(c.Up, forward, angle))
+	return c
+}
+
 // Pan slides the eye and target together in the view plane so the point under the
 // cursor tracks the drag (Inventor's Pan). dxPixels/dyPixels are screen-space deltas
 // (y down); the world step per pixel is derived from the target distance and FOV.

--- a/scene/camera_test.go
+++ b/scene/camera_test.go
@@ -128,6 +128,22 @@ func TestZoomToRectIgnoresDegenerate(t *testing.T) {
 	}
 }
 
+// TestRollRotatesUpAboutView: roll spins the up vector about the forward axis without moving the
+// eye or target; a quarter turn takes +Y up to ±X (in the screen plane).
+func TestRollRotatesUpAboutView(t *testing.T) {
+	c := NewCamera(800, 600) // eye (0,0,10) → target origin, forward −Z, up +Y
+	r := c.Roll(stdmath.Pi / 2)
+	if !r.Eye.IsEqualTo(c.Eye, 1e-9) || !r.Target.IsEqualTo(c.Target, 1e-9) {
+		t.Error("roll must not move the eye or target")
+	}
+	if stdmath.Abs(float64(r.Up.Y)) > 1e-9 || stdmath.Abs(stdmath.Abs(float64(r.Up.X))-1) > 1e-9 {
+		t.Errorf("rolled up = %v, want ±X (a quarter turn of +Y about −Z)", r.Up)
+	}
+	if !r.Up.IsEqualTo(unit(r.Up), 1e-9) {
+		t.Error("rolled up should stay unit length")
+	}
+}
+
 func TestDollyScalesDistanceKeepingDirection(t *testing.T) {
 	c := NewCamera(800, 600) // eye (0,0,10), target origin
 	in := c.Dolly(0.5)


### PR DESCRIPTION
## What

Holding **F4 (Free Orbit)** now shows an orbit ring, and the drag's **start zone** selects the rotation — matching Inventor's Free Orbit:
- **inside** the ring → free orbit (yaw + pitch), as before (N5);
- **left/right rim** → yaw only, about the screen vertical axis (N6);
- **top/bottom rim** → pitch only, about the horizontal axis (N7);
- **outside** the ring → roll about the view axis (N8).

## How

- New `scene.Camera.Roll` twists `Up` about the forward axis (eye/target fixed).
- Pure `classifyOrbitZone(px,py,cx,cy,radius)` maps the drag-start pixel to the zone; `applyOrbit` dispatches the per-zone rotation; `ringRollAngle` derives the roll from the tangential component of the drag about the ring centre.
- The head **latches the zone once** at the start of an F4 orbit drag (`latchOrbitZone`) and holds it for the whole drag, and draws the ring overlay while F4 is held. **Shift+middle orbit is unchanged** (default free-orbit zone).

The camera math is pure and unit-tested in `scene`; the input→zone→camera mapping is pure (no cgo) and tested in `head/ui`.

## Tests

- `scene`: `Roll` spins up without moving eye/target.
- `head/ui`: the zone classifier (inner/rim-left-right/rim-top-bottom/outside/degenerate); `applyOrbit` per zone (yaw keeps the eye in the up-plane, pitch in the yaw-plane, roll spins up without moving the eye).
- `scene` + `head/ui` green; `--new-from-rev` lint clean.

## Scope (#913 stays open)

Continues #913 (after zoom-to-cursor #1022, Look At #1025, Zoom Window #1028). Remaining: set-pivot on click (N9) and the Constrained Orbit / Navigation Bar entry (N10, N25), SteeringWheels (N26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)