### PR TITLE
feat(viewport): Free-Orbit set-pivot on click (N9) (#913)

### DIFF
--- a/app/set_pivot_test.go
+++ b/app/set_pivot_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestSetOrbitPivotRecenters: clicking off-centre to set the Free-Orbit pivot moves the orbit centre
+// (the camera target) to the clicked point while keeping the view direction (#913 N9).
+func TestSetOrbitPivotRecenters(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	cam := s.Camera()
+	cam.Width, cam.Height = 800, 600
+	s.SetCamera(cam)
+
+	before := s.Camera().Target
+	s.SetOrbitPivot(650, 180) // off-centre viewport pixel
+	if s.Camera().Target.IsEqualTo(before, 1e-9) {
+		t.Error("set-pivot should move the orbit centre (target) to the clicked point")
+	}
+	if !s.Camera().Forward().IsEqualTo(cam.Forward(), 1e-9) {
+		t.Error("set-pivot must keep the view direction")
+	}
+}

--- a/app/view.go
+++ b/app/view.go
@@ -57,6 +57,13 @@ func (s *Session) CanLookAt() bool {
 	return planar
 }
 
+// SetOrbitPivot recenters the orbit on the world point under viewport pixel (x,y) — Free Orbit's
+// click-to-set-pivot (#913 N9). The clicked point becomes the orbit centre and is brought to the
+// view centre, keeping the view direction and distance.
+func (s *Session) SetOrbitPivot(x, y float64) {
+	s.SetCamera(s.Camera().SetPivotUnderCursor(x, y))
+}
+
 // lookAtPlane swings the camera to face the plane at target with the given normal and up.
 func (s *Session) lookAtPlane(target math.Point3, normal, up math.Vector3) {
 	s.PushViewHistory()

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -33,6 +33,9 @@ var (
 // single-pick click handler. Replaces the bare handleViewportClick call so they never both
 // fire on the same press.
 func handleViewportSelection(s *app.Session) {
+	if updateOrbitPivot(s) {
+		return // Free Orbit: a no-drag click set the orbit pivot (#913 N9)
+	}
 	if heldNavMode() != NavNone {
 		return // a held F2/F3/F4 turns a left-drag into navigation, not selection (#911)
 	}
@@ -142,6 +145,46 @@ func drawZoomWindowRect(s *app.Session, bx, by float32) {
 	native.DrawLine(sx1, sy0, sx1, sy1, border, 1.2)
 	native.DrawLine(sx1, sy1, sx0, sy1, border, 1.2)
 	native.DrawLine(sx0, sy1, sx0, sy0, border, 1.2)
+}
+
+// orbitPivotClickSlop is the max drag (pixels) under which an F4 left press counts as a click
+// (set-pivot) rather than an orbit drag.
+const orbitPivotClickSlop = 4
+
+// orbitPivot tracks one F4 left press: armed once pressed, moved once it drags past the slop.
+var orbitPivot struct {
+	armed bool
+	moved bool
+}
+
+// updateOrbitPivot sets a new orbit pivot when the user clicks (presses then releases without
+// dragging past the slop) in the viewport while Free Orbit (F4) is held — Inventor's set-pivot
+// (#913 N9). A drag orbits instead (ApplyNavigation handles the rotation), so only a no-drag click
+// sets the pivot. Reports whether it consumed this frame's left input (so selection stands down).
+func updateOrbitPivot(s *app.Session) bool {
+	if heldNavMode() != NavOrbit {
+		orbitPivot.armed = false
+		return false
+	}
+	if native.IsItemClicked(native.MouseLeft) {
+		orbitPivot.armed, orbitPivot.moved = true, false
+	}
+	if !orbitPivot.armed {
+		return false
+	}
+	if native.MouseDown(native.MouseLeft) {
+		dx, dy := native.MouseDelta()
+		if dx*dx+dy*dy > orbitPivotClickSlop*orbitPivotClickSlop {
+			orbitPivot.moved = true
+		}
+		return true // the drag (if any) orbits via ApplyNavigation; selection stands down
+	}
+	if !orbitPivot.moved { // released without dragging → a click sets the pivot
+		cx, cy := viewportCursor()
+		s.SetOrbitPivot(cx, cy)
+	}
+	orbitPivot.armed = false
+	return true
 }
 
 // drawOrbitRing draws the Free-Orbit ring centred on the viewport while F4 (Free Orbit) is held, so

--- a/scene/camera.go
+++ b/scene/camera.go
@@ -264,6 +264,28 @@ func (c Camera) Orbit(yaw, pitch float64) Camera {
 	return c
 }
 
+// SetPivotUnderCursor recenters the orbit on the world point under screen pixel (px,py) — at the
+// current focal depth (the cursor ray ∩ target plane) — keeping the view direction and eye–target
+// distance. That point becomes the orbit centre (the target) and is brought to the view centre;
+// nothing rotates or scales, so subsequent orbits pivot about it. This is Inventor's "set a new
+// pivot" in Free Orbit (N9). A degenerate cursor ray is a no-op.
+//
+// Example: cam = cam.SetPivotUnderCursor(mouseX, mouseY) // click to re-centre the orbit
+func (c Camera) SetPivotUnderCursor(px, py float64) Camera {
+	p, ok := c.cursorPlanePoint(px, py)
+	if !ok {
+		return c
+	}
+	dist := float64(c.Eye.DistanceTo(c.Target))
+	if dist < minDistance {
+		dist = 1
+	}
+	fwd := c.Forward()
+	c.Target = p
+	c.Eye = p.TranslateBy(fwd.Scale(-dist))
+	return c
+}
+
 // Roll twists the view about the forward (eye→target) axis — the spin a Free-Orbit ring perimeter
 // drag produces (#913 N8). Eye and Target are unchanged; only Up rotates, so the model appears to
 // turn in-plane about the view centre. A degenerate view direction is a no-op.

--- a/scene/camera_test.go
+++ b/scene/camera_test.go
@@ -128,6 +128,29 @@ func TestZoomToRectIgnoresDegenerate(t *testing.T) {
 	}
 }
 
+// TestSetPivotUnderCursorRecenters: clicking off-centre to set the orbit pivot brings that point to
+// the view centre (the new target) while keeping the view direction and eye–target distance.
+func TestSetPivotUnderCursorRecenters(t *testing.T) {
+	c := NewCamera(800, 600)
+	dist0 := float64(c.Eye.DistanceTo(c.Target))
+	pivot, _ := c.cursorPlanePoint(650, 180)
+	p := c.SetPivotUnderCursor(650, 180)
+	if !p.Target.IsEqualTo(pivot, 1e-6) {
+		t.Errorf("new target = %v, want the clicked world point %v", p.Target, pivot)
+	}
+	if !p.Forward().IsEqualTo(c.Forward(), 1e-9) {
+		t.Error("set-pivot must keep the view direction")
+	}
+	if d := float64(p.Eye.DistanceTo(p.Target)); stdmath.Abs(d-dist0) > 1e-6 {
+		t.Errorf("set-pivot distance = %v, want %v (unchanged)", d, dist0)
+	}
+	// The new pivot is the target, so it projects to the view centre.
+	o, dir := p.RayThrough(400, 300)
+	if dd := pointRayDistance(p.Target, o, dir); dd > 1e-6 {
+		t.Errorf("pivot is %g off the centre ray (should be centred)", dd)
+	}
+}
+
 // TestRollRotatesUpAboutView: roll spins the up vector about the forward axis without moving the
 // eye or target; a quarter turn takes +Y up to ±X (in the screen plane).
 func TestRollRotatesUpAboutView(t *testing.T) {


### PR DESCRIPTION
## What

While **Free Orbit (F4)** is held, a left-**click** (press + release without dragging) now sets a new orbit pivot at the clicked point — Inventor's set-pivot (spec N9). A drag still orbits; only a no-drag click re-centres.

## How

- `scene.Camera.SetPivotUnderCursor(px,py)` recenters the orbit on the world point under the cursor (cursor ray ∩ target plane, the current focal depth): that point becomes the target and is brought to the view centre, keeping the view direction and eye–target distance — so nothing rotates or scales and later orbits pivot about it.
- `Session.SetOrbitPivot` applies it.
- The head distinguishes a click from an orbit drag with a small pixel slop (`updateOrbitPivot`) and calls it on release.

## Tests

- `scene`: set-pivot recenters to the clicked world point, keeps the view direction + distance, and the pivot lands on the centre ray.
- `app`: `SetOrbitPivot` moves the target to the clicked point keeping the view direction.
- `scene` + `app` + `head/ui` green; `--new-from-rev` lint clean.

## Scope (#913 stays open)

Continues #913 (after zoom-to-cursor #1022, Look At #1025, Zoom Window #1028, orbit ring N5–N8 #1031). Remaining: Constrained Orbit (N10), Navigation Bar (N25), SteeringWheels (N26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)