### PR TITLE
feat(viewport): Constrained Orbit — turntable locked to the model vertical (N10) (#913)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -674,6 +674,12 @@ func viewNavigateCommands() []*CommandDefinition {
 		}).WithTab("View").WithIcon("zoom-window").WithButtonStyle(LargeIconButton).WithEnable(hasActivePart).
 			WithActive(func(s *Session) bool { return s.ZoomWindowArmed() }).
 			WithTooltip("Zoom Window — drag a rectangle in the viewport; the view zooms to fit it."),
+		NewCommand("View.ConstrainedOrbit", "Constrained Orbit", "Navigate", func(s *Session) error {
+			s.ToggleConstrainedOrbit()
+			return nil
+		}).WithTab("View").WithIcon("orbit-constrained").WithButtonStyle(LargeIconButton).WithEnable(hasActivePart).
+			WithActive(func(s *Session) bool { return s.ConstrainedOrbitActive() }).
+			WithTooltip("Constrained Orbit — left-drag turntables about the vertical axis (horizontal = turn, vertical = tilt)."),
 	}
 }
 

--- a/app/session.go
+++ b/app/session.go
@@ -56,6 +56,7 @@ type Session struct {
 	boxSelect            BoxSelection      // the in-progress rubber-band rectangle, if any
 	zoomWindow           BoxSelection      // the in-progress Zoom Window rubber-band, if any (#913 N16)
 	zoomWindowArmed      bool              // the Zoom Window tool is armed: the next left-drag zooms
+	constrainedOrbit     bool              // the Constrained Orbit tool is active: left-drag turntables (#913 N10)
 	entityDrag           sketchDrag        // the in-progress direct drag of sketch entities, if any
 	dimDrag              dimDragState      // the in-progress drag of a drawing dimension's text/line
 	selectOther          selectOther       // the in-progress Select Other cycle, if any

--- a/app/set_pivot_test.go
+++ b/app/set_pivot_test.go
@@ -4,6 +4,27 @@ package app
 
 import "testing"
 
+// TestToggleConstrainedOrbit covers the Constrained Orbit tool's on/off/disarm state (#913 N10).
+func TestToggleConstrainedOrbit(t *testing.T) {
+	s := NewSession()
+	if s.ConstrainedOrbitActive() {
+		t.Fatal("Constrained Orbit should be off by default")
+	}
+	s.ToggleConstrainedOrbit()
+	if !s.ConstrainedOrbitActive() {
+		t.Fatal("toggle should turn it on")
+	}
+	s.ToggleConstrainedOrbit()
+	if s.ConstrainedOrbitActive() {
+		t.Fatal("toggle should turn it off")
+	}
+	s.ToggleConstrainedOrbit()
+	s.DisarmConstrainedOrbit()
+	if s.ConstrainedOrbitActive() {
+		t.Fatal("disarm should turn it off")
+	}
+}
+
 // TestSetOrbitPivotRecenters: clicking off-centre to set the Free-Orbit pivot moves the orbit centre
 // (the camera target) to the clicked point while keeping the view direction (#913 N9).
 func TestSetOrbitPivotRecenters(t *testing.T) {

--- a/app/view.go
+++ b/app/view.go
@@ -57,6 +57,17 @@ func (s *Session) CanLookAt() bool {
 	return planar
 }
 
+// ToggleConstrainedOrbit turns the Constrained Orbit tool (#913 N10) on or off — a turntable locked
+// to the model vertical, entered from the View tab / Navigation Bar. While on, a viewport left-drag
+// orbits about the vertical axis (horizontal = turn, vertical = tilt) instead of selecting.
+func (s *Session) ToggleConstrainedOrbit() { s.constrainedOrbit = !s.constrainedOrbit }
+
+// ConstrainedOrbitActive reports whether the Constrained Orbit tool is on.
+func (s *Session) ConstrainedOrbitActive() bool { return s.constrainedOrbit }
+
+// DisarmConstrainedOrbit turns the Constrained Orbit tool off (e.g. Esc).
+func (s *Session) DisarmConstrainedOrbit() { s.constrainedOrbit = false }
+
 // SetOrbitPivot recenters the orbit on the world point under viewport pixel (x,y) — Free Orbit's
 // click-to-set-pivot (#913 N9). The clicked point becomes the orbit centre and is brought to the
 // view centre, keeping the view direction and distance.

--- a/head/icon/assets/orbit-constrained.svg
+++ b/head/icon/assets/orbit-constrained.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><line x1="12" y1="3" x2="12" y2="21"/><ellipse cx="12" cy="12" rx="8" ry="3.5"/></svg>

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -36,6 +36,9 @@ func handleViewportSelection(s *app.Session) {
 	if updateOrbitPivot(s) {
 		return // Free Orbit: a no-drag click set the orbit pivot (#913 N9)
 	}
+	if s.ConstrainedOrbitActive() {
+		return // Constrained Orbit owns the left-drag, which turntables (#913 N10)
+	}
 	if heldNavMode() != NavNone {
 		return // a held F2/F3/F4 turns a left-drag into navigation, not selection (#911)
 	}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -188,6 +188,8 @@ func handleKeyboard(s *app.Session) {
 			s.CancelSelectOther() // Esc ends the cycle, keeping the highlighted candidate (#910)
 		case s.ZoomWindowArmed():
 			s.DisarmZoomWindow() // Esc cancels an armed Zoom Window before/while dragging (#913 N16)
+		case s.ConstrainedOrbitActive():
+			s.DisarmConstrainedOrbit() // Esc exits the Constrained Orbit tool (#913 N10)
 		default:
 			_ = s.PressKey(app.KeyEvent{Key: "Escape", Mods: mods})
 		}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -247,7 +247,7 @@ func tileInput(s *app.Session, i int, hit viewCubeHit, cam *scene.Camera, pw, ph
 // tileNavigate applies hover/drag/wheel to tile i's camera; on a non-active tile a real
 // manipulation (drag/wheel) makes it the active view. Returns the (possibly updated) active.
 func tileNavigate(s *app.Session, i int, cam *scene.Camera, isActive bool) bool {
-	nav := readNavInput()
+	nav := readNavInput(s)
 	if nav.Hovered && navInteracted(nav) && !isActive {
 		_ = s.ActivateView(i)
 		isActive = true
@@ -345,7 +345,7 @@ func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Came
 	if overCube {
 		return cam, nil // the ViewCube owns the cursor this frame: no orbit, no pick
 	}
-	cam = ApplyNavigation(cam, readNavInput())
+	cam = ApplyNavigation(cam, readNavInput(s))
 	s.SetCamera(cam)
 	// The triad/manipulators own the pointer when hovered or mid-drag (M05-F13);
 	// picking and tool clicks stand down for the frame.
@@ -642,7 +642,7 @@ const (
 // viewport's InvisibleButton, so IsItemActive/Hovered refer to it. Navigation is driven by
 // the middle button only (pan / Shift+orbit); the left button belongs to selection and
 // box-select, handled separately, so it is not read here.
-func readNavInput() NavInput {
+func readNavInput(s *app.Session) NavInput {
 	dx, dy := native.MouseDelta()
 	modal := heldNavMode()
 	cx, cy := viewportCursor()
@@ -660,6 +660,7 @@ func readNavInput() NavInput {
 		Left:    modal != NavNone && native.MouseDown(native.MouseLeft),
 	}
 	in.OrbitZone = latchOrbitZone(in, cx, cy)
+	in.Constrained = s.ConstrainedOrbitActive() && native.MouseDown(native.MouseLeft)
 	return in
 }
 

--- a/head/ui/navigate.go
+++ b/head/ui/navigate.go
@@ -8,8 +8,13 @@ package ui
 import (
 	stdmath "math"
 
+	"oblikovati.org/math"
 	"oblikovati.org/scene"
 )
+
+// modelUp is the world vertical axis Constrained Orbit (#913 N10) locks to — the app's up convention
+// (Home/sketch views use +Y).
+var modelUp = math.V3(0, 1, 0)
 
 const (
 	// orbitRadPerPixel turns a drag pixel into an orbit angle; zoomPerNotch is the dolly
@@ -85,6 +90,7 @@ type NavInput struct {
 	Modal            NavMode   // a held F2/F3/F4 navigation mode (drives a left-drag)
 	Left             bool      // left button down — only consulted in a Modal mode
 	OrbitZone        OrbitZone // the Free-Orbit ring zone latched at drag start (#913 N5–N8)
+	Constrained      bool      // Constrained Orbit tool active: a left-drag turntables about modelUp (#913 N10)
 }
 
 // ApplyNavigation maps one frame of pointer input to a camera move, mirroring Inventor:
@@ -98,6 +104,9 @@ func ApplyNavigation(cam scene.Camera, in NavInput) scene.Camera {
 	}
 	if !in.Active || (in.DX == 0 && in.DY == 0) {
 		return cam
+	}
+	if in.Constrained {
+		return cam.OrbitConstrained(float64(-in.DX)*orbitRadPerPixel, float64(-in.DY)*orbitRadPerPixel, modelUp)
 	}
 	switch navGesture(in) {
 	case NavPan:

--- a/head/ui/navigate_test.go
+++ b/head/ui/navigate_test.go
@@ -85,6 +85,19 @@ func TestApplyOrbitZones(t *testing.T) {
 	}
 }
 
+// TestApplyNavigationConstrainedOrbit: a Constrained-Orbit drag turntables about the model vertical
+// and re-levels the view (removes roll), regardless of the drag's start zone (#913 N10).
+func TestApplyNavigationConstrainedOrbit(t *testing.T) {
+	cam := scene.NewCamera(800, 600).Roll(0.5) // a rolled view
+	out := ApplyNavigation(cam, NavInput{Active: true, Constrained: true, DX: 30})
+	if out.Eye.IsEqualTo(cam.Eye, 1e-9) {
+		t.Error("constrained-orbit drag should move the eye")
+	}
+	if !out.Up.IsEqualTo(modelUp, 1e-9) {
+		t.Errorf("constrained orbit up = %v, want the model vertical %v (re-levelled)", out.Up, modelUp)
+	}
+}
+
 func TestApplyNavigationPansWithMiddleDrag(t *testing.T) {
 	cam := scene.NewCamera(800, 600)
 	out := ApplyNavigation(cam, NavInput{Active: true, Middle: true, DX: 50})

--- a/scene/camera.go
+++ b/scene/camera.go
@@ -300,6 +300,28 @@ func (c Camera) Roll(angle float64) Camera {
 	return c
 }
 
+// OrbitConstrained is a turntable orbit locked to a world vertical axis — Inventor's Constrained
+// Orbit (N10): yaw rotates the eye about worldUp (the model vertical), pitch tilts about the
+// horizontal screen axis, and the view is re-levelled so worldUp stays vertical on screen (no roll).
+// Unlike Orbit, which yaws about the camera's own (possibly rolled) up, this keeps vertical lines
+// vertical regardless of any prior roll. The eye–target distance is preserved; a pitch that would
+// flip over the pole is skipped. A degenerate worldUp falls back to Orbit.
+func (c Camera) OrbitConstrained(yaw, pitch float64, worldUp math.Vector3) Camera {
+	up := unit(worldUp)
+	if up == (math.Vector3{}) {
+		return c.Orbit(yaw, pitch)
+	}
+	offset := rotateAboutAxis(c.Target.VectorTo(c.Eye), up, yaw)
+	forward := unit(offset.Scale(-1)) // eye → target after the yaw
+	right := unit(forward.Cross(up))
+	if pitched := rotateAboutAxis(offset, right, pitch); absDot(unit(pitched), up) < poleCos {
+		offset = pitched
+	}
+	c.Eye = c.Target.TranslateBy(offset)
+	c.Up = up // re-level: the world vertical stays up, removing any roll
+	return c
+}
+
 // Pan slides the eye and target together in the view plane so the point under the
 // cursor tracks the drag (Inventor's Pan). dxPixels/dyPixels are screen-space deltas
 // (y down); the world step per pixel is derived from the target distance and FOV.

--- a/scene/camera_test.go
+++ b/scene/camera_test.go
@@ -207,6 +207,31 @@ func TestOrbitPreservesDistanceAndYawsAroundUp(t *testing.T) {
 	}
 }
 
+// TestOrbitConstrainedYawsAboutWorldUpAndLevels: constrained orbit yaws about the world vertical and
+// re-levels the view (removing roll), unlike Orbit which yaws about the camera's own up.
+func TestOrbitConstrainedYawsAboutWorldUpAndLevels(t *testing.T) {
+	c := NewCamera(800, 600).Roll(0.6) // a rolled view: camera up is no longer world +Y
+	worldUp := math.V3(0, 1, 0)
+
+	q := c.OrbitConstrained(stdmath.Pi/2, 0, worldUp) // quarter turn about world +Y: (0,0,10)→(10,0,0)
+	if !q.Eye.IsEqualTo(math.P3(10, 0, 0), 1e-9) {
+		t.Errorf("eye after constrained 90° yaw = %v, want (10,0,0)", q.Eye)
+	}
+	if !q.Up.IsEqualTo(worldUp, 1e-9) {
+		t.Errorf("constrained orbit up = %v, want world +Y (re-levelled, no roll)", q.Up)
+	}
+	if d := float64(q.Eye.DistanceTo(q.Target)); stdmath.Abs(d-10) > 1e-9 {
+		t.Errorf("constrained orbit changed distance: %v, want 10", d)
+	}
+	// A near-pole pitch is skipped; a degenerate worldUp falls back to Orbit.
+	if !c.OrbitConstrained(0, stdmath.Pi/2, worldUp).Eye.IsEqualTo(c.Eye, 1e-9) {
+		t.Error("near-pole constrained pitch should be clamped")
+	}
+	if c.OrbitConstrained(0.3, 0, math.V3(0, 0, 0)) != c.Orbit(0.3, 0) {
+		t.Error("degenerate worldUp should fall back to Orbit")
+	}
+}
+
 func TestFitFramesBoxKeepingDirection(t *testing.T) {
 	c := NewCamera(800, 600) // looks −Z
 	box := math.NewBox(math.P3(2, 2, 2), math.P3(6, 4, 8))


### PR DESCRIPTION
## What

Inventor's **Constrained Orbit** (spec N10): a **View ▸ Navigate** toggle tool where a viewport left-drag turntables about the model's vertical axis — horizontal = turn, vertical = tilt — keeping vertical lines vertical (no roll), unlike Free Orbit.

## How

- `scene.Camera.OrbitConstrained(yaw,pitch,worldUp)` yaws the eye about `worldUp`, pitches about the horizontal screen axis (pole-guarded), and **re-levels `Up`** to `worldUp` so any prior roll is removed.
- The head feeds it via a new `NavInput.Constrained` (set while the tool is on and the left button is down); `ApplyNavigation` routes a constrained drag to `OrbitConstrained` about `modelUp` (+Y).
- A **toggle command** (active state shown) on the Navigate panel with a new `orbit-constrained` icon; selection stands down while it's on, and **Esc exits** it.

## Tests

- `scene`: yaws about world +Y and re-levels even from a rolled view, preserves distance, pole-clamp + degenerate-up fallback to `Orbit`.
- `head/ui`: a `Constrained` drag moves the eye and re-levels up.
- `app`: toggle on/off/disarm.
- `scene` + `app` + `head/ui` green; `--new-from-rev` lint clean.

## Scope

Completes the #913 **orbit** gaps (after zoom-to-cursor #1022, Look At #1025, Zoom Window #1028, orbit ring N5–N8 #1031, set-pivot N9 #1033). Remaining on #913: the Navigation Bar (N25) and SteeringWheels (N26) floating widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)