### PR TITLE
feat: hole-note quantity grouping (M14-F07, #637)

### DIFF
--- a/addin/router/drawing_annotations.go
+++ b/addin/router/drawing_annotations.go
@@ -328,7 +328,15 @@ func drawingAnnotationsAddHoleNotes(s *app.Session, raw json.RawMessage) (json.R
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	a, err := an.AddHoleNotes(in.Name, in.ViewName)
+	quantity := types.HoleNotePerHole
+	if in.Quantity != "" {
+		q, ok := types.ParseHoleNoteQuantity(in.Quantity)
+		if !ok {
+			return nil, fmt.Errorf("drawing: unknown hole-note quantity %q (want perHole|combined)", in.Quantity)
+		}
+		quantity = q
+	}
+	a, err := an.AddHoleNotes(in.Name, in.ViewName, quantity)
 	if err != nil {
 		return nil, err
 	}

--- a/addin/router/drawing_annotations_test.go
+++ b/addin/router/drawing_annotations_test.go
@@ -245,12 +245,15 @@ func TestDrawingHoleNotesOverWire(t *testing.T) {
 	call(t, r, s, "drawingViews.addBase", `{"name":"TOP","orientation":"top","scale":1,"centerXmm":100,"centerYmm":100}`, nil)
 
 	var hn wire.AnnotationResult
-	call(t, r, s, "drawingAnnotations.addHoleNotes", `{"name":"HN","viewName":"TOP"}`, &hn)
+	call(t, r, s, "drawingAnnotations.addHoleNotes", `{"name":"HN","viewName":"TOP","quantity":"combined"}`, &hn)
 	if hn.Annotation.Kind != "holeNote" || hn.Annotation.CurveCount == 0 || hn.Annotation.RowCount != 1 {
 		t.Fatalf("hole notes = %+v, want a holeNote with 1 callout (dedup rims)", hn.Annotation)
 	}
 	if _, err := r.Handle(s, "drawingAnnotations.addHoleNotes", []byte(`{"viewName":"NOPE"}`)); err == nil {
 		t.Error("addHoleNotes on a missing view = ok, want error")
+	}
+	if _, err := r.Handle(s, "drawingAnnotations.addHoleNotes", []byte(`{"viewName":"TOP","quantity":"bogus"}`)); err == nil {
+		t.Error("addHoleNotes with a bad quantity = ok, want error")
 	}
 }
 

--- a/app/drawing_annotation_tools.go
+++ b/app/drawing_annotation_tools.go
@@ -289,11 +289,15 @@ func (t *RevisionTagTool) Params() ToolParams {
 	}}
 }
 
+// holeNoteQuantities indexes the hole-notes Quantity dropdown.
+var holeNoteQuantities = []types.HoleNoteQuantity{types.HoleNotePerHole, types.HoleNoteCombined}
+
 // HoleNotesTool annotates every hole in a chosen base view with a leadered diameter callout that
-// re-resolves with the model.
+// re-resolves with the model; the Quantity option groups same-diameter holes into one callout.
 type HoleNotesTool struct {
-	views     []string
-	viewIndex int
+	views         []string
+	viewIndex     int
+	quantityIndex int
 }
 
 // NewHoleNotesTool creates the tool; its base-view list is captured on Start.
@@ -314,17 +318,19 @@ func (t *HoleNotesTool) Commit(s *Session) error {
 	if len(t.views) == 0 {
 		return fmt.Errorf("drawing: no base view for hole notes — add a base view first")
 	}
-	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("", t.views[clampIndex(t.viewIndex, len(t.views))]); err != nil {
+	quantity := holeNoteQuantities[clampIndex(t.quantityIndex, len(holeNoteQuantities))]
+	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("", t.views[clampIndex(t.viewIndex, len(t.views))], quantity); err != nil {
 		return err
 	}
 	s.ActiveDocument().MarkDirty()
 	return nil
 }
 
-// Params exposes the base-view choice for the property dialog.
+// Params exposes the base-view and quantity-mode choices for the property dialog.
 func (t *HoleNotesTool) Params() ToolParams {
 	return ToolParams{Choices: []ChoiceParam{
 		{Label: "View", Options: t.views, Get: func() int { return t.viewIndex }, Set: func(i int) { t.viewIndex = i }},
+		{Label: "Quantity", Options: []string{"Per hole", "Combined"}, Get: func() int { return t.quantityIndex }, Set: func(i int) { t.quantityIndex = i }},
 	}}
 }
 

--- a/app/drawing_annotation_tools_test.go
+++ b/app/drawing_annotation_tools_test.go
@@ -350,6 +350,7 @@ func TestHoleNotesToolAnnotatesHoles(t *testing.T) {
 	}
 	tool := NewHoleNotesTool()
 	tool.Start(s)
+	tool.Params().Choices[1].Set(1) // Quantity = Combined
 	if tool.Name() != "Hole Notes" || !tool.CanCommit() {
 		t.Fatalf("hole-notes tool name/commit wrong: %q / %v", tool.Name(), tool.CanCommit())
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.45.0
+	oblikovati.org/api v0.46.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.45.0
+	oblikovati.org/api v0.46.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/drawing/annotation.go
+++ b/model/drawing/annotation.go
@@ -35,10 +35,11 @@ type DrawingAnnotation struct {
 	datums         []string
 	// surface texture: the material-removal variant (the roughness value reuses tag).
 	materialRemoval types.MaterialRemoval
-	rowCount        int           // parts list / hole table / custom table: the number of data rows
-	revisions       []RevisionRow // revision table: the user-supplied change-history rows
-	headers         []string      // custom table: the column headers
-	tableRows       [][]string    // custom table: the data rows (cells aligned to headers)
+	rowCount        int                    // parts list / hole table / custom table: the number of data rows
+	revisions       []RevisionRow          // revision table: the user-supplied change-history rows
+	headers         []string               // custom table: the column headers
+	tableRows       [][]string             // custom table: the data rows (cells aligned to headers)
+	holeQuantity    types.HoleNoteQuantity // hole notes: per-hole vs combined-by-diameter callouts
 	labels          []AnnotationLabel
 	curves          []DrawingCurve
 }

--- a/model/drawing/hole_note.go
+++ b/model/drawing/hole_note.go
@@ -4,15 +4,19 @@ package drawing
 
 import (
 	"fmt"
+	"strconv"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/hlr"
+	"oblikovati.org/kernel/topo"
 )
 
 // Hole notes (M14-F07, #637): a feature note on each hole in a base view — a leadered diameter
 // callout (Ø<d>) whose text is COMPUTED from the hole's circular edge, so it re-resolves when the
 // model changes (a hole drilled larger updates its note). Distinct from a plain leader note, whose
 // text is fixed. One annotation carries every hole's callout; recompute rebuilds it from the
-// current projection (associative to the view, like centre marks).
+// current projection (associative to the view, like centre marks). A combined quantity mode groups
+// holes by diameter into one "<n>x Ø<d>" callout per size.
 
 const (
 	holeNoteOffsetMM = 16.0 // how far the callout text sits from the hole centre
@@ -20,12 +24,13 @@ const (
 )
 
 // AddHoleNotes adds the hole-note annotation for the named base view: a leadered diameter callout
-// per hole. It errors when no holes resolve (no model, a non-base view, or no circular edges).
-func (as *DrawingAnnotations) AddHoleNotes(name, viewName string) (*DrawingAnnotation, error) {
+// per hole (or per distinct diameter, when quantity is combined). It errors when no holes resolve
+// (no model, a non-base view, or no circular edges).
+func (as *DrawingAnnotations) AddHoleNotes(name, viewName string, quantity types.HoleNoteQuantity) (*DrawingAnnotation, error) {
 	if _, _, _, err := as.annotationBasis(viewName); err != nil {
 		return nil, err
 	}
-	a := &DrawingAnnotation{name: as.uniqueName(name), kind: types.HoleNoteAnnotation, viewName: viewName}
+	a := &DrawingAnnotation{name: as.uniqueName(name), kind: types.HoleNoteAnnotation, viewName: viewName, holeQuantity: quantity}
 	as.recomputeHoleNotes(a)
 	if a.rowCount == 0 {
 		return nil, fmt.Errorf("drawing: view %q has no holes for hole notes", viewName)
@@ -34,15 +39,35 @@ func (as *DrawingAnnotations) AddHoleNotes(name, viewName string) (*DrawingAnnot
 	return a, nil
 }
 
-// recomputeHoleNotes re-reads the view's holes and rebuilds a leadered Ø callout for each; with no
-// resolvable holes it clears the annotation.
+// projectedHoleNote is one hole's callout anchor: its centre on the sheet (mm) and radius (mm).
+type projectedHoleNote struct {
+	sx, sy   float64
+	radiusMM float64
+}
+
+// recomputeHoleNotes re-reads the view's holes and rebuilds a leadered Ø callout for each (or one
+// "<n>x Ø<d>" callout per diameter when combined); with no resolvable holes it clears the note.
 func (as *DrawingAnnotations) recomputeHoleNotes(a *DrawingAnnotation) {
 	a.curves, a.labels, a.rowCount = nil, nil, 0
 	view, body, basis, err := as.annotationBasis(a.viewName)
 	if err != nil {
 		return
 	}
+	holes := dedupedHoleNotes(view, body, basis)
+	if a.holeQuantity == types.HoleNoteCombined {
+		renderCombinedHoleNotes(a, holes)
+		return
+	}
+	for _, h := range holes {
+		appendHoleNote(a, h, "Ø"+holeCoord(h.radiusMM*2))
+	}
+}
+
+// dedupedHoleNotes collects each distinct hole's sheet anchor + radius, fitting the view's
+// projection (so cut holes are found) and listing coincident rims once.
+func dedupedHoleNotes(view *DrawingView, body *topo.Body, basis hlr.View) []projectedHoleNote {
 	seen := map[string]bool{}
+	var out []projectedHoleNote
 	for _, c := range circlesFromProjection(body, basis) {
 		s := view.place(c.center)
 		key := fmt.Sprintf("%.1f/%.1f", float64(s.X), float64(s.Y))
@@ -50,21 +75,56 @@ func (as *DrawingAnnotations) recomputeHoleNotes(a *DrawingAnnotation) {
 			continue
 		}
 		seen[key] = true
-		curves, label := holeNoteCallout(float64(s.X), float64(s.Y), c.radius*cmToMM, c.radius*2*cmToMM)
-		a.curves = append(a.curves, curves...)
-		a.labels = append(a.labels, label)
-		a.rowCount++
+		out = append(out, projectedHoleNote{sx: float64(s.X), sy: float64(s.Y), radiusMM: c.radius * cmToMM})
+	}
+	return out
+}
+
+// renderCombinedHoleNotes groups holes by diameter and emits one "<n>x Ø<d>" callout per size,
+// anchored at the first hole of each group (in encounter order).
+func renderCombinedHoleNotes(a *DrawingAnnotation, holes []projectedHoleNote) {
+	type group struct {
+		first projectedHoleNote
+		count int
+	}
+	order := []string{}
+	groups := map[string]*group{}
+	for _, h := range holes {
+		key := holeCoord(h.radiusMM * 2)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{first: h}
+			groups[key] = g
+			order = append(order, key)
+		}
+		g.count++
+	}
+	for _, key := range order {
+		g := groups[key]
+		text := "Ø" + key
+		if g.count > 1 {
+			text = strconv.Itoa(g.count) + "x Ø" + key
+		}
+		appendHoleNote(a, g.first, text)
 	}
 }
 
-// holeNoteCallout builds one hole's leadered diameter callout: a leader from the text anchor to the
-// hole rim (with an arrowhead) and the Ø<d> text label, placed up-right of the hole centre.
-func holeNoteCallout(cx, cy, radiusMM, diameterMM float64) ([]DrawingCurve, AnnotationLabel) {
+// appendHoleNote adds one hole's leadered callout (curves + label) to the annotation.
+func appendHoleNote(a *DrawingAnnotation, h projectedHoleNote, text string) {
+	curves, label := holeNoteCallout(h.sx, h.sy, h.radiusMM, text)
+	a.curves = append(a.curves, curves...)
+	a.labels = append(a.labels, label)
+	a.rowCount++
+}
+
+// holeNoteCallout builds one hole's leadered callout: a leader from the text anchor to the hole rim
+// (with an arrowhead) and the callout text, placed up-right of the hole centre.
+func holeNoteCallout(cx, cy, radiusMM float64, text string) ([]DrawingCurve, AnnotationLabel) {
 	const k = 0.70710678 // unit diagonal (cos 45°)
 	tx, ty := cx+holeNoteOffsetMM*k, cy-holeNoteOffsetMM*k
 	// Start the leader on the hole rim nearest the text, stopping a small gap short.
 	rx, ry := cx+(radiusMM+holeNoteGapMM)*k, cy-(radiusMM+holeNoteGapMM)*k
 	curves := []DrawingCurve{dimSegment(tx, ty, rx, ry)}
 	curves = append(curves, noteArrowhead(tx, ty, rx, ry)...)
-	return curves, AnnotationLabel{Text: "Ø" + holeCoord(diameterMM), X: tx + 6, Y: ty}
+	return curves, AnnotationLabel{Text: text, X: tx + 6, Y: ty}
 }

--- a/model/drawing/hole_note_test.go
+++ b/model/drawing/hole_note_test.go
@@ -15,7 +15,7 @@ import (
 func TestAddHoleNotes(t *testing.T) {
 	c := drawingWithCylinder(t, 2) // 2 cm radius → Ø40
 	topBase(t, c.Sheets().Active().Views())
-	hn, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "TOP")
+	hn, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "TOP", types.HoleNotePerHole)
 	if err != nil {
 		t.Fatalf("AddHoleNotes: %v", err)
 	}
@@ -41,7 +41,25 @@ func TestAddHoleNotes(t *testing.T) {
 func TestHoleNotesNeedHoles(t *testing.T) {
 	c := drawingWithBox(t)
 	frontBase(t, c.Sheets().Active().Views())
-	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "FRONT"); err == nil {
+	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "FRONT", types.HoleNotePerHole); err == nil {
 		t.Error("AddHoleNotes on a box (no holes) = ok, want error")
+	}
+}
+
+// TestRenderCombinedHoleNotes: combined grouping collapses equal-diameter holes into one
+// "<n>x Ø<d>" callout per size, in encounter order, leaving distinct sizes as their own callouts.
+func TestRenderCombinedHoleNotes(t *testing.T) {
+	holes := []projectedHoleNote{
+		{sx: 10, sy: 10, radiusMM: 4}, // Ø8.00
+		{sx: 40, sy: 10, radiusMM: 6}, // Ø12.00
+		{sx: 70, sy: 10, radiusMM: 4}, // Ø8.00 (groups with the first)
+	}
+	a := &DrawingAnnotation{kind: types.HoleNoteAnnotation, holeQuantity: types.HoleNoteCombined}
+	renderCombinedHoleNotes(a, holes)
+	if a.rowCount != 2 || len(a.labels) != 2 {
+		t.Fatalf("combined notes = %d callouts, want 2 (Ø8 group + Ø12)", a.rowCount)
+	}
+	if a.labels[0].Text != "2x Ø8.00" || a.labels[1].Text != "Ø12.00" {
+		t.Errorf("combined labels = [%q, %q], want [2x Ø8.00, Ø12.00]", a.labels[0].Text, a.labels[1].Text)
 	}
 }

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -90,6 +90,8 @@ type annotationRecipe struct {
 	// custom table: the column headers and data rows.
 	Headers []string   `yaml:"headers,omitempty"`
 	Rows    [][]string `yaml:"rows,omitempty"`
+	// hole notes: the quantity-grouping mode ("" ⇒ perHole).
+	HoleQuantity string `yaml:"holeQuantity,omitempty"`
 }
 
 // revisionRowRecipe is the YAML shape of one revision-table row.
@@ -190,10 +192,19 @@ func annotationRecipesOf(sh *Sheet) []annotationRecipe {
 			X: a.x, Y: a.y, W: a.w, H: a.h, Tag: a.tag, EdgeKey: hex.EncodeToString(a.edgeKey),
 			Characteristic: a.characteristic.String(), Tolerance: a.tolerance, Datums: a.datums,
 			MaterialRemoval: a.materialRemoval.String(), Revisions: revisionRowRecipesOf(a.revisions),
-			Headers: a.headers, Rows: a.tableRows,
+			Headers: a.headers, Rows: a.tableRows, HoleQuantity: holeQuantityString(a),
 		})
 	}
 	return out
+}
+
+// holeQuantityString persists a hole note's grouping mode, and only that — "" for every other
+// annotation and for the per-hole default, so recipes stay clean.
+func holeQuantityString(a *DrawingAnnotation) string {
+	if a.kind != types.HoleNoteAnnotation || a.holeQuantity == types.HoleNotePerHole {
+		return ""
+	}
+	return a.holeQuantity.String()
 }
 
 // revisionRowRecipesOf snapshots a revision table's rows for persistence.
@@ -319,9 +330,10 @@ func restoreAnnotations(sh *Sheet, recs []annotationRecipe) {
 		kind, _ := types.ParseDrawingAnnotationKind(ar.Kind)
 		edgeKey, _ := hex.DecodeString(ar.EdgeKey)
 		characteristic, _ := types.ParseGeometricCharacteristic(ar.Characteristic)
+		holeQuantity, _ := types.ParseHoleNoteQuantity(ar.HoleQuantity)
 		a := &DrawingAnnotation{name: ar.Name, kind: kind, viewName: ar.ViewName, x: ar.X, y: ar.Y, w: ar.W, h: ar.H, tag: ar.Tag, edgeKey: edgeKey,
 			characteristic: characteristic, tolerance: ar.Tolerance, datums: ar.Datums, revisions: revisionRowsOf(ar.Revisions),
-			headers: ar.Headers, tableRows: ar.Rows}
+			headers: ar.Headers, tableRows: ar.Rows, holeQuantity: holeQuantity}
 		restoreAnnotationGeometry(a, ar)
 		as.items = append(as.items, a)
 	}


### PR DESCRIPTION
## What
A **quantity mode** for hole notes: **combined** groups a base view's holes by diameter into one **`<n>× Ø<d>`** callout per distinct size (anchored at the first hole of each group, in encounter order), instead of one callout per hole.

## Why
M14-F07 (#637) names a `HoleNoteQuantityEnum`. Combined callouts are the standard way to tabulate a repeated hole pattern.

## How
- **Model** — `recomputeHoleNotes` first gathers the deduped holes (`dedupedHoleNotes`), then either renders one callout per hole or, in combined mode, groups by diameter (`renderCombinedHoleNotes`) and prefixes the count. The mode is stored on the annotation and persists (`holeQuantity` recipe field, written only for combined hole notes so other recipes stay clean); the callouts still re-resolve with the model.
- **Surface** — router parses the wire spelling (rejecting unknown values); the **Hole Notes** tool gains a **Per hole / Combined** choice.
- Pins the api contract to **v0.46.0**.

## Tests
- `model/drawing`: `renderCombinedHoleNotes` groups two equal Ø8 + one Ø12 into `[2x Ø8.00, Ø12.00]`; per-hole on a cylinder still `Ø40.00→Ø60.00` associative.
- `addin/router`: combined over the wire (one callout) + bad-quantity error.
- `app`: the tool's Combined choice.
- Full `go test ./...` green, `golangci-lint` 0 issues, head build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)