### PR TITLE
feat(plastic): cantilever snap-fit feature (#486)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -299,6 +299,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sweep":                   `{"sketchIndex":0,"path":{"sketchIndex":1}}`,
 		"fillet":                  `{"edges":["e1"],"radius":"1 mm"}`,
 		"ruleFillet":              `{"rule":"allRounds","radius":"1 mm"}`,
+		"snapFit":                 `{"length":"10 mm","width":"4 mm","thickness":"2 mm","catchLength":"2 mm","catchHeight":"1 mm"}`,
 		"chamfer":                 `{"edges":["e1"],"distance":"1 mm"}`,
 		"shell":                   `{"faces":["f1"],"thickness":"1 mm"}`,
 		"draft":                   `{"faces":["f1"],"angle":"3 deg","neutralFace":"f2"}`,

--- a/addin/opregistry/plastic_features.go
+++ b/addin/opregistry/plastic_features.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// Plastic-part features (M20-F10, #486): the cantilever snap-fit connector. Reachable over MCP via
+// features.add like the other opregistry operations; the geometry + validation live in model/feature.
+
+const snapFitSchema = `{
+  "type": "object",
+  "properties": {
+    "length": {"type": "string", "description": "Cantilever arm length (along the beam), e.g. \"20 mm\"."},
+    "width": {"type": "string", "description": "Arm width, e.g. \"6 mm\"."},
+    "thickness": {"type": "string", "description": "Arm thickness, e.g. \"2 mm\"."},
+    "catchLength": {"type": "string", "description": "Catch-lip length along the free end (must be <= length), e.g. \"3 mm\"."},
+    "catchHeight": {"type": "string", "description": "Catch-lip height above the arm, e.g. \"1.5 mm\"."}
+  },
+  "required": ["length", "width", "thickness", "catchLength", "catchHeight"]
+}`
+
+func snapFitDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "snapFit",
+		Summary: "Add a cantilever snap-fit hook (a beam with a catch lip) to the part.",
+		Schema:  json.RawMessage(snapFitSchema),
+		Apply:   applySnapFit,
+	}
+}
+
+// snapFitArgs is the snap-fit op's wire shape: the beam and catch dimensions as length strings.
+type snapFitArgs struct {
+	Length      string `json:"length"`
+	Width       string `json:"width"`
+	Thickness   string `json:"thickness"`
+	CatchLength string `json:"catchLength"`
+	CatchHeight string `json:"catchHeight"`
+}
+
+func applySnapFit(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in snapFitArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	var l, w, t, cl, ch func() float64
+	for _, d := range []struct {
+		spelling, label string
+		out             *func() float64
+	}{
+		{in.Length, "snapFit: length", &l},
+		{in.Width, "snapFit: width", &w},
+		{in.Thickness, "snapFit: thickness", &t},
+		{in.CatchLength, "snapFit: catchLength", &cl},
+		{in.CatchHeight, "snapFit: catchHeight", &ch},
+	} {
+		fn, err := lengthClosure(part, d.spelling, d.label)
+		if err != nil {
+			return nil, err
+		}
+		*d.out = fn
+	}
+	pf := feature.NewPlasticFeatures(part.Features()).AddCantileverSnapFit(l, w, t, cl, ch)
+	return recomputeResult(part, pf)
+}

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -108,6 +108,7 @@ func Default() *Registry {
 		// Subtractive / dress-up (edge & face reference keys).
 		filletDescriptor(),
 		ruleFilletDescriptor(),
+		snapFitDescriptor(),
 		chamferDescriptor(),
 		shellDescriptor(),
 		draftDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
-		"fillet", "ruleFillet", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
+		"fillet", "ruleFillet", "snapFit", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalLip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -29,6 +29,7 @@ type FeatureData struct {
 	Fillet         *EdgeDressData      `yaml:"fillet,omitempty"`
 	FaceFillet     *FaceFilletData     `yaml:"faceFillet,omitempty"`
 	RuleFillet     *RuleFilletData     `yaml:"ruleFillet,omitempty"`
+	SnapFit        *SnapFitData        `yaml:"snapFit,omitempty"`
 	Chamfer        *EdgeDressData      `yaml:"chamfer,omitempty"`
 	Shell          *FaceDressData      `yaml:"shell,omitempty"`
 	Draft          *FaceDressData      `yaml:"draft,omitempty"`
@@ -144,6 +145,11 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.FaceFillet = &FaceFilletData{FacesA: encodeKeys(f.def.FaceKeysA), FacesB: encodeKeys(f.def.FaceKeysB), Value: evalFloat(f.def.Radius)}
 	case *RuleFilletFeature:
 		fd.RuleFillet = &RuleFilletData{Rule: f.def.Rule.String(), Value: evalFloat(f.def.Radius)}
+	case *SnapFitFeature:
+		fd.SnapFit = &SnapFitData{
+			Length: evalFloat(f.def.Length), Width: evalFloat(f.def.Width), Thickness: evalFloat(f.def.Thickness),
+			CatchLength: evalFloat(f.def.CatchLength), CatchHeight: evalFloat(f.def.CatchHeight),
+		}
 	case *ChamferFeature:
 		flat := f.def.FlatCorners
 		fd.Chamfer = &EdgeDressData{
@@ -461,6 +467,14 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 			return nil, fmt.Errorf("rule-fillet: unknown rule %q", fd.RuleFillet.Rule)
 		}
 		return du.AddRuleFillet(rule, constFloat(fd.RuleFillet.Value)), nil
+	case "snap-fit":
+		if fd.SnapFit == nil {
+			return nil, fmt.Errorf("snap-fit feature is missing its payload")
+		}
+		d := fd.SnapFit
+		return NewPlasticFeatures(fs).AddCantileverSnapFit(
+			constFloat(d.Length), constFloat(d.Width), constFloat(d.Thickness),
+			constFloat(d.CatchLength), constFloat(d.CatchHeight)), nil
 	case "chamfer":
 		d, err := requireEdgeDress(fd.Chamfer, "chamfer")
 		if err != nil {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -116,6 +116,15 @@ type RuleFilletData struct {
 	Value float64 `yaml:"value"`
 }
 
+// SnapFitData persists a cantilever snap-fit (#486): the beam and catch dimensions.
+type SnapFitData struct {
+	Length      float64 `yaml:"length"`
+	Width       float64 `yaml:"width"`
+	Thickness   float64 `yaml:"thickness"`
+	CatchLength float64 `yaml:"catchLength"`
+	CatchHeight float64 `yaml:"catchHeight"`
+}
+
 // ThreadData tags a single cylindrical face (reference key) with a thread designation, plus
 // the #325 parity fields: the tolerance class, the tapered (pipe) flag, and which thread
 // diameter the modeled face represents (wire spelling; absent = major).

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -137,6 +137,25 @@ func TestRuleFilletRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSnapFitRoundTrip checks the cantilever snap-fit's dimensions survive a recipe round trip (#486).
+func TestSnapFitRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewPlasticFeatures(fs).AddCantileverSnapFit(cf(20), cf(6), cf(2), cf(3), cf(1.5))
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*SnapFitFeature).Definition()
+	if d.Length() != 20 || d.Width() != 6 || d.Thickness() != 2 || d.CatchLength() != 3 || d.CatchHeight() != 1.5 {
+		t.Errorf("snap-fit dims = %g/%g/%g/%g/%g, want 20/6/2/3/1.5",
+			d.Length(), d.Width(), d.Thickness(), d.CatchLength(), d.CatchHeight())
+	}
+}
+
 // TestChamferFlatCornersRoundTrip checks the chamfer corner treatment survives a recipe
 // round trip in both states, and that an older recipe with no flag restores as flat (the
 // default, matching a freshly created chamfer).

--- a/model/feature/snap_fit.go
+++ b/model/feature/snap_fit.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// SnapFitDefinition is a cantilever snap-fit connector (#486, M20-F10 plastic features): a beam of
+// Length×Width×Thickness with a catch lip (CatchLength×CatchHeight) on top of its free end. The whole
+// hook is one extruded step-profile (so it is a single valid solid, no boolean), built at the origin
+// on the XZ plane — the beam runs +X, the catch rises +Z, the width extrudes +Y — and joined to the
+// running body (or placed as a new body when there is none).
+type SnapFitDefinition struct {
+	Length      func() float64
+	Width       func() float64
+	Thickness   func() float64
+	CatchLength func() float64
+	CatchHeight func() float64
+}
+
+// SnapFitFeature adds a cantilever snap-fit hook.
+//
+// Example: a 20×6×2 mm arm with a 3×1.5 mm catch —
+//
+//	NewPlasticFeatures(part.Features()).AddCantileverSnapFit(
+//	    cf(20), cf(6), cf(2), cf(3), cf(1.5)) // cf wraps a constant in func() float64
+type SnapFitFeature struct {
+	def      *SnapFitDefinition
+	featName string
+}
+
+// Definition returns the feature's definition.
+func (f *SnapFitFeature) Definition() *SnapFitDefinition { return f.def }
+
+// Kind names the feature type.
+func (f *SnapFitFeature) Kind() string { return "snap-fit" }
+
+// Recompute builds the hook and joins it to the running body.
+func (f *SnapFitFeature) Recompute(in Input) (Output, error) {
+	return snapFitBody(in, f.def, featOr(f.featName, "snap-fit"))
+}
+
+// snapFitBody builds the cantilever hook as one step-profile prism and combines it with the running
+// body. Non-positive dimensions, or a catch longer than the beam, are a clean error (the feature
+// goes Sick) rather than a degenerate solid.
+func snapFitBody(in Input, def *SnapFitDefinition, feat string) (Output, error) {
+	l, w, t := callOrZero(def.Length), callOrZero(def.Width), callOrZero(def.Thickness)
+	cl, ch := callOrZero(def.CatchLength), callOrZero(def.CatchHeight)
+	if l <= 0 || w <= 0 || t <= 0 {
+		return Output{}, fmt.Errorf("%s: length/width/thickness must be > 0 (got %g, %g, %g)", feat, l, w, t)
+	}
+	if cl <= 0 || ch <= 0 || cl > l {
+		return Output{}, fmt.Errorf("%s: catch length/height must be > 0 and catch length ≤ length (got %g, %g; length %g)", feat, cl, ch, l)
+	}
+	// The cantilever's side profile (XZ): the beam rectangle [0,l]×[0,t] with the catch bump
+	// [l-cl,l]×[t,t+ch] on top of the free end, traced CCW.
+	profile := []math.Point2{
+		{X: 0, Y: 0}, {X: l, Y: 0},
+		{X: l, Y: t + ch},
+		{X: l - cl, Y: t + ch},
+		{X: l - cl, Y: t},
+		{X: 0, Y: t},
+	}
+	hook := buildPrism(profile, sketch.XZPlane(), span{near: 0, far: w}, 0, feat)
+	bodies, err := combine(in.Bodies, hook, ops.Join)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// PlasticFeatures adds the M20-F10 plastic-part features (snap fits; rest pads to follow) into the
+// engine.
+type PlasticFeatures struct{ engine *PartFeatures }
+
+// NewPlasticFeatures binds the collection to an engine.
+func NewPlasticFeatures(engine *PartFeatures) *PlasticFeatures { return &PlasticFeatures{engine} }
+
+// AddCantileverSnapFit adds a cantilever snap-fit hook with the given beam and catch dimensions.
+func (c *PlasticFeatures) AddCantileverSnapFit(length, width, thickness, catchLength, catchHeight func() float64) *PartFeature {
+	return c.engine.Add(&SnapFitFeature{def: &SnapFitDefinition{
+		Length: length, Width: width, Thickness: thickness, CatchLength: catchLength, CatchHeight: catchHeight,
+	}})
+}

--- a/model/feature/snap_fit_test.go
+++ b/model/feature/snap_fit_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// cf wraps a constant as a func() float64 dimension.
+func cf(v float64) func() float64 { return func() float64 { return v } }
+
+// TestSnapFitBuildsValidHookSolid: a standalone cantilever snap-fit is one valid solid whose volume
+// is the beam plus the catch lip (#486).
+func TestSnapFitBuildsValidHookSolid(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewPlasticFeatures(fs).AddCantileverSnapFit(cf(20), cf(6), cf(2), cf(3), cf(1.5))
+	fs.Recompute()
+
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("snap fit → %d bodies, want 1", len(res))
+	}
+	if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+		t.Fatalf("snap-fit hook is not a valid solid: %+v", r.Issues)
+	}
+	beam, catch := 20.0*2*6, 3.0*1.5*6
+	if got := ops.BodyGeometryProperties(res[0], ops.Quality{ChordTolerance: 1e-4}).Volume; relErr(got, beam+catch) > 1e-3 {
+		t.Errorf("snap-fit volume = %g, want ≈ %g (beam %g + catch %g)", got, beam+catch, beam, catch)
+	}
+}
+
+// TestSnapFitJoinsRunningBody: a snap fit added after a base box merges into one body.
+func TestSnapFitJoinsRunningBody(t *testing.T) {
+	fs, _ := boxAndPlanarFace(t) // a 2×2×2 base box at the origin
+	NewPlasticFeatures(fs).AddCantileverSnapFit(cf(6), cf(1), cf(1), cf(1), cf(0.5))
+	fs.Recompute()
+	if got := len(fs.Result()); got != 1 {
+		t.Fatalf("base + snap fit → %d bodies, want 1 merged body", got)
+	}
+}
+
+// TestSnapFitRejectsBadDimensions: non-positive dims and an over-long catch are clean errors.
+func TestSnapFitRejectsBadDimensions(t *testing.T) {
+	for _, c := range []struct {
+		name             string
+		l, w, th, cl, ch float64
+	}{
+		{"zero thickness", 10, 4, 0, 2, 1},
+		{"catch longer than beam", 5, 4, 2, 6, 1},
+	} {
+		fs := NewPartFeatures(nil, nil)
+		pf := NewPlasticFeatures(fs).AddCantileverSnapFit(cf(c.l), cf(c.w), cf(c.th), cf(c.cl), cf(c.ch))
+		fs.Recompute()
+		if pf.Health().OK() {
+			t.Errorf("%s: expected the feature to be sick", c.name)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds the M20-F10 **cantilever snap-fit** (`SnapFitFeature`): a beam of Length×Width×Thickness with a catch lip (CatchLength×CatchHeight) on its free end.

## How

The whole hook is **one extruded step-profile** (the beam rectangle with the catch bump traced as a single polygon) — a single valid solid, no boolean — built at the origin on the XZ plane and **joined** to the running body (or placed as a new body when there is none). Non-positive dimensions, or a catch longer than the beam, are a clean **Sick** error.

**No API change**: reachable over MCP through the `/source` opregistry `snapFit` op (`features.add`); dimensions round-trip in the recipe (`SnapFitData`).

## Tests

- Feature: a standalone hook is a valid solid whose volume = beam + catch; it joins a base box into one body; bad dimensions go Sick.
- Registry/MCP path + the default-registry and every-op-handles-args guards.
- Serialize round trip.
- `./model/... ./addin/...` green; lint clean.

## Scope (#486 stays open)

The **SnapFit** slice (after RuleFillet #1020). The **Rest** pad remains; SnapFit refinements (placement on a selected face, lead-in chamfer) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)