### PR TITLE
feat: hole-note format-string override (M14-F07, #637)

### DIFF
--- a/addin/router/drawing_annotations.go
+++ b/addin/router/drawing_annotations.go
@@ -336,7 +336,7 @@ func drawingAnnotationsAddHoleNotes(s *app.Session, raw json.RawMessage) (json.R
 		}
 		quantity = q
 	}
-	a, err := an.AddHoleNotes(in.Name, in.ViewName, quantity)
+	a, err := an.AddHoleNotes(in.Name, in.ViewName, quantity, in.Format)
 	if err != nil {
 		return nil, err
 	}

--- a/addin/router/drawing_annotations_test.go
+++ b/addin/router/drawing_annotations_test.go
@@ -255,6 +255,11 @@ func TestDrawingHoleNotesOverWire(t *testing.T) {
 	if _, err := r.Handle(s, "drawingAnnotations.addHoleNotes", []byte(`{"viewName":"TOP","quantity":"bogus"}`)); err == nil {
 		t.Error("addHoleNotes with a bad quantity = ok, want error")
 	}
+	var fmt1 wire.AnnotationResult
+	call(t, r, s, "drawingAnnotations.addHoleNotes", `{"name":"HNF","viewName":"TOP","format":"Ø{d} THRU"}`, &fmt1)
+	if fmt1.Annotation.Kind != "holeNote" || fmt1.Annotation.CurveCount == 0 {
+		t.Fatalf("formatted hole notes = %+v, want a holeNote callout", fmt1.Annotation)
+	}
 }
 
 func TestDrawingAnnotationsRejectBadArgs(t *testing.T) {

--- a/app/drawing_annotation_tools.go
+++ b/app/drawing_annotation_tools.go
@@ -293,11 +293,13 @@ func (t *RevisionTagTool) Params() ToolParams {
 var holeNoteQuantities = []types.HoleNoteQuantity{types.HoleNotePerHole, types.HoleNoteCombined}
 
 // HoleNotesTool annotates every hole in a chosen base view with a leadered diameter callout that
-// re-resolves with the model; the Quantity option groups same-diameter holes into one callout.
+// re-resolves with the model; the Quantity option groups same-diameter holes into one callout, and
+// the Format option overrides the callout text ({d} = diameter, {n} = count).
 type HoleNotesTool struct {
 	views         []string
 	viewIndex     int
 	quantityIndex int
+	format        string
 }
 
 // NewHoleNotesTool creates the tool; its base-view list is captured on Start.
@@ -319,19 +321,24 @@ func (t *HoleNotesTool) Commit(s *Session) error {
 		return fmt.Errorf("drawing: no base view for hole notes — add a base view first")
 	}
 	quantity := holeNoteQuantities[clampIndex(t.quantityIndex, len(holeNoteQuantities))]
-	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("", t.views[clampIndex(t.viewIndex, len(t.views))], quantity); err != nil {
+	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("", t.views[clampIndex(t.viewIndex, len(t.views))], quantity, t.format); err != nil {
 		return err
 	}
 	s.ActiveDocument().MarkDirty()
 	return nil
 }
 
-// Params exposes the base-view and quantity-mode choices for the property dialog.
+// Params exposes the base-view, quantity-mode and format-template inputs for the property dialog.
 func (t *HoleNotesTool) Params() ToolParams {
-	return ToolParams{Choices: []ChoiceParam{
-		{Label: "View", Options: t.views, Get: func() int { return t.viewIndex }, Set: func(i int) { t.viewIndex = i }},
-		{Label: "Quantity", Options: []string{"Per hole", "Combined"}, Get: func() int { return t.quantityIndex }, Set: func(i int) { t.quantityIndex = i }},
-	}}
+	return ToolParams{
+		Choices: []ChoiceParam{
+			{Label: "View", Options: t.views, Get: func() int { return t.viewIndex }, Set: func(i int) { t.viewIndex = i }},
+			{Label: "Quantity", Options: []string{"Per hole", "Combined"}, Get: func() int { return t.quantityIndex }, Set: func(i int) { t.quantityIndex = i }},
+		},
+		Texts: []TextParam{
+			{Label: "Format ({d},{n})", Get: func() string { return t.format }, Set: func(v string) { t.format = v }},
+		},
+	}
 }
 
 // NoteTool drops a free text note at the cursor, with an optional leader to a point.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.46.0
+	oblikovati.org/api v0.47.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.46.0
+	oblikovati.org/api v0.47.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/drawing/hole_note.go
+++ b/model/drawing/hole_note.go
@@ -5,6 +5,7 @@ package drawing
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/hlr"
@@ -24,19 +25,35 @@ const (
 )
 
 // AddHoleNotes adds the hole-note annotation for the named base view: a leadered diameter callout
-// per hole (or per distinct diameter, when quantity is combined). It errors when no holes resolve
-// (no model, a non-base view, or no circular edges).
-func (as *DrawingAnnotations) AddHoleNotes(name, viewName string, quantity types.HoleNoteQuantity) (*DrawingAnnotation, error) {
+// per hole (or per distinct diameter, when quantity is combined). An optional format template with
+// {d} (diameter) and {n} (count) placeholders overrides the callout text; empty uses the default.
+// It errors when no holes resolve (no model, a non-base view, or no circular edges).
+func (as *DrawingAnnotations) AddHoleNotes(name, viewName string, quantity types.HoleNoteQuantity, format string) (*DrawingAnnotation, error) {
 	if _, _, _, err := as.annotationBasis(viewName); err != nil {
 		return nil, err
 	}
-	a := &DrawingAnnotation{name: as.uniqueName(name), kind: types.HoleNoteAnnotation, viewName: viewName, holeQuantity: quantity}
+	a := &DrawingAnnotation{name: as.uniqueName(name), kind: types.HoleNoteAnnotation, viewName: viewName, holeQuantity: quantity, tag: format}
 	as.recomputeHoleNotes(a)
 	if a.rowCount == 0 {
 		return nil, fmt.Errorf("drawing: view %q has no holes for hole notes", viewName)
 	}
 	as.items = append(as.items, a)
 	return a, nil
+}
+
+// formatHoleNote renders a hole callout: the format template with {d} (diameter, 2 decimals) and
+// {n} (count) substituted, or the built-in default when the template is empty ("Ø<d>", or
+// "<n>x Ø<d>" when count > 1).
+func formatHoleNote(format string, diameterMM float64, count int) string {
+	d := holeCoord(diameterMM)
+	if format == "" {
+		if count > 1 {
+			return strconv.Itoa(count) + "x Ø" + d
+		}
+		return "Ø" + d
+	}
+	out := strings.ReplaceAll(format, "{d}", d)
+	return strings.ReplaceAll(out, "{n}", strconv.Itoa(count))
 }
 
 // projectedHoleNote is one hole's callout anchor: its centre on the sheet (mm) and radius (mm).
@@ -55,11 +72,11 @@ func (as *DrawingAnnotations) recomputeHoleNotes(a *DrawingAnnotation) {
 	}
 	holes := dedupedHoleNotes(view, body, basis)
 	if a.holeQuantity == types.HoleNoteCombined {
-		renderCombinedHoleNotes(a, holes)
+		renderCombinedHoleNotes(a, holes, a.tag)
 		return
 	}
 	for _, h := range holes {
-		appendHoleNote(a, h, "Ø"+holeCoord(h.radiusMM*2))
+		appendHoleNote(a, h, formatHoleNote(a.tag, h.radiusMM*2, 1))
 	}
 }
 
@@ -80,9 +97,9 @@ func dedupedHoleNotes(view *DrawingView, body *topo.Body, basis hlr.View) []proj
 	return out
 }
 
-// renderCombinedHoleNotes groups holes by diameter and emits one "<n>x Ø<d>" callout per size,
-// anchored at the first hole of each group (in encounter order).
-func renderCombinedHoleNotes(a *DrawingAnnotation, holes []projectedHoleNote) {
+// renderCombinedHoleNotes groups holes by diameter and emits one "<n>x Ø<d>" callout per size
+// (or the format template), anchored at the first hole of each group (in encounter order).
+func renderCombinedHoleNotes(a *DrawingAnnotation, holes []projectedHoleNote, format string) {
 	type group struct {
 		first projectedHoleNote
 		count int
@@ -101,11 +118,7 @@ func renderCombinedHoleNotes(a *DrawingAnnotation, holes []projectedHoleNote) {
 	}
 	for _, key := range order {
 		g := groups[key]
-		text := "Ø" + key
-		if g.count > 1 {
-			text = strconv.Itoa(g.count) + "x Ø" + key
-		}
-		appendHoleNote(a, g.first, text)
+		appendHoleNote(a, g.first, formatHoleNote(format, g.first.radiusMM*2, g.count))
 	}
 }
 

--- a/model/drawing/hole_note_test.go
+++ b/model/drawing/hole_note_test.go
@@ -15,7 +15,7 @@ import (
 func TestAddHoleNotes(t *testing.T) {
 	c := drawingWithCylinder(t, 2) // 2 cm radius → Ø40
 	topBase(t, c.Sheets().Active().Views())
-	hn, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "TOP", types.HoleNotePerHole)
+	hn, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "TOP", types.HoleNotePerHole, "")
 	if err != nil {
 		t.Fatalf("AddHoleNotes: %v", err)
 	}
@@ -41,8 +41,43 @@ func TestAddHoleNotes(t *testing.T) {
 func TestHoleNotesNeedHoles(t *testing.T) {
 	c := drawingWithBox(t)
 	frontBase(t, c.Sheets().Active().Views())
-	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "FRONT", types.HoleNotePerHole); err == nil {
+	if _, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "FRONT", types.HoleNotePerHole, ""); err == nil {
 		t.Error("AddHoleNotes on a box (no holes) = ok, want error")
+	}
+}
+
+// TestFormatHoleNote: the format template substitutes {d} (diameter) and {n} (count); an empty
+// template uses the default ("Ø<d>", or "<n>x Ø<d>" when count > 1).
+func TestFormatHoleNote(t *testing.T) {
+	cases := []struct {
+		format     string
+		diameterMM float64
+		count      int
+		want       string
+	}{
+		{"", 8, 1, "Ø8.00"},
+		{"", 8, 3, "3x Ø8.00"},
+		{"Ø{d} THRU", 8, 1, "Ø8.00 THRU"},
+		{"TAP M8 x{n}", 8, 4, "TAP M8 x4"},
+	}
+	for _, c := range cases {
+		if got := formatHoleNote(c.format, c.diameterMM, c.count); got != c.want {
+			t.Errorf("formatHoleNote(%q, %g, %d) = %q, want %q", c.format, c.diameterMM, c.count, got, c.want)
+		}
+	}
+}
+
+// TestHoleNotesFormatOverride: a custom format flows through to a base view's hole callout, with the
+// diameter still computed from the model.
+func TestHoleNotesFormatOverride(t *testing.T) {
+	c := drawingWithCylinder(t, 2) // Ø40
+	topBase(t, c.Sheets().Active().Views())
+	hn, err := c.Sheets().Active().Annotations().AddHoleNotes("HN", "TOP", types.HoleNotePerHole, "Ø{d} THRU")
+	if err != nil {
+		t.Fatalf("AddHoleNotes: %v", err)
+	}
+	if len(hn.Labels()) != 1 || hn.Labels()[0].Text != "Ø40.00 THRU" {
+		t.Fatalf("formatted hole note = %v, want Ø40.00 THRU", hn.Labels())
 	}
 }
 
@@ -55,7 +90,7 @@ func TestRenderCombinedHoleNotes(t *testing.T) {
 		{sx: 70, sy: 10, radiusMM: 4}, // Ø8.00 (groups with the first)
 	}
 	a := &DrawingAnnotation{kind: types.HoleNoteAnnotation, holeQuantity: types.HoleNoteCombined}
-	renderCombinedHoleNotes(a, holes)
+	renderCombinedHoleNotes(a, holes, "")
 	if a.rowCount != 2 || len(a.labels) != 2 {
 		t.Fatalf("combined notes = %d callouts, want 2 (Ø8 group + Ø12)", a.rowCount)
 	}


### PR DESCRIPTION
## What
An optional **format template** for hole notes with **`{d}`** (diameter) and **`{n}`** (count) placeholders — e.g. `Ø{d} THRU` → `Ø8.00 THRU`, or `TAP M8 x{n}` → `TAP M8 x4`. Empty keeps the default (`Ø<d>`, or `<n>x Ø<d>` combined).

## Why
M14-F07 (#637): "format-string override + restore-default semantics." The `{d}` value is computed from the hole, so a callout can carry drafting suffixes (THRU/TAP/…) while staying associative.

## How
- **Model** — a `formatHoleNote(format, diameter, count)` helper substitutes the placeholders or falls back to the default; both the per-hole and combined paths route through it. The template is stored on the annotation (reusing the `tag` field, which persists) and re-applied on every recompute.
- **Surface** — router passes the format through; the **Hole Notes** tool gains a **Format ({d},{n})** input.
- Pins the api contract to **v0.47.0**.

## Tests
- `model/drawing`: `formatHoleNote` table (default / count / `Ø{d} THRU` / `TAP M8 x{n}`); an end-to-end `Ø{d} THRU` → `Ø40.00 THRU` on a cylinder (diameter still computed).
- `addin/router`: a formatted callout over the wire.
- Full `go test ./...` green, `golangci-lint` 0 issues, head build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)