### PR TITLE
feat(plastic): rest pad feature — completes #486

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -300,6 +300,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"fillet":                  `{"edges":["e1"],"radius":"1 mm"}`,
 		"ruleFillet":              `{"rule":"allRounds","radius":"1 mm"}`,
 		"snapFit":                 `{"length":"10 mm","width":"4 mm","thickness":"2 mm","catchLength":"2 mm","catchHeight":"1 mm"}`,
+		"rest":                    `{"sketchIndex":0,"depth":"2 mm"}`,
 		"chamfer":                 `{"edges":["e1"],"distance":"1 mm"}`,
 		"shell":                   `{"faces":["f1"],"thickness":"1 mm"}`,
 		"draft":                   `{"faces":["f1"],"angle":"3 deg","neutralFace":"f2"}`,

--- a/addin/opregistry/plastic_features.go
+++ b/addin/opregistry/plastic_features.go
@@ -43,6 +43,61 @@ type snapFitArgs struct {
 	CatchHeight string `json:"catchHeight"`
 }
 
+const restSchema = `{
+  "type": "object",
+  "properties": {
+    "sketchIndex": {"type": "integer", "minimum": 0},
+    "profileIndices": {"type": "array", "items": {"type": "integer", "minimum": 0}, "description": "Closed profiles bounding the rest; omit to use profileIndex."},
+    "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
+    "depth": {"type": "string", "description": "Raise (or, when recessed, cut) depth, e.g. \"2 mm\"."},
+    "recessed": {"type": "boolean", "default": false, "description": "Recess a pocket into the face instead of raising a pad."}
+  },
+  "required": ["sketchIndex", "depth"]
+}`
+
+func restDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "rest",
+		Summary: "Add a raised or recessed rest pad bounded by a closed sketch profile.",
+		Schema:  json.RawMessage(restSchema),
+		Apply:   applyRest,
+	}
+}
+
+// restArgs is the rest op's wire shape: a sketch profile + depth, raised or recessed.
+type restArgs struct {
+	SketchIndex    int    `json:"sketchIndex"`
+	ProfileIndices []int  `json:"profileIndices,omitempty"`
+	ProfileIndex   int    `json:"profileIndex"`
+	Depth          string `json:"depth"`
+	Recessed       bool   `json:"recessed,omitempty"`
+}
+
+func applyRest(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in restArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	sk, err := sketchAt(part, in.SketchIndex)
+	if err != nil {
+		return nil, err
+	}
+	depth, err := lengthClosure(part, in.Depth, "rest: depth")
+	if err != nil {
+		return nil, err
+	}
+	profiles := in.ProfileIndices
+	if len(profiles) == 0 {
+		profiles = []int{in.ProfileIndex}
+	}
+	pf := feature.NewPlasticFeatures(part.Features()).AddRest(sk, profiles, depth, in.Recessed, 0)
+	return recomputeResult(part, pf)
+}
+
 func applySnapFit(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	part, err := modelaccess.ActivePart(s)
 	if err != nil {

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -109,6 +109,7 @@ func Default() *Registry {
 		filletDescriptor(),
 		ruleFilletDescriptor(),
 		snapFitDescriptor(),
+		restDescriptor(),
 		chamferDescriptor(),
 		shellDescriptor(),
 		draftDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
-		"fillet", "ruleFillet", "snapFit", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
+		"fillet", "ruleFillet", "snapFit", "rest", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalLip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.46.0
+	oblikovati.org/api v0.47.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.46.0
+	oblikovati.org/api v0.47.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/rest.go
+++ b/model/feature/rest.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/sketch"
+)
+
+// RestDefinition is a rest pad (#486, M20-F10 plastic features): a flat landing bounded by a closed
+// sketch profile, raised above the face by Depth (joined) or recessed into it (cut), along the sketch-
+// plane normal, with an optional draft. It is the profile-based sibling of the snap-fit; geometrically
+// it extrudes the profile and combines it with the running body, like emboss, but is its own feature
+// so it serializes as a "rest" and can grow rest-specific options (the surrounding land) later.
+type RestDefinition struct {
+	Sketch         *sketch.Sketch
+	ProfileIndices []int
+	Depth          func() float64
+	Recessed       bool    // cut a recess into the part instead of raising a pad
+	Taper          float64 // draft angle (radians)
+}
+
+// RestFeature adds a raised or recessed rest pad.
+type RestFeature struct {
+	def      *RestDefinition
+	tool     *topo.Body
+	featName string
+}
+
+// Definition returns the feature's definition.
+func (f *RestFeature) Definition() *RestDefinition { return f.def }
+
+// Kind names the feature type.
+func (f *RestFeature) Kind() string { return "rest" }
+
+// Recompute extrudes the profile to the rest depth and joins (pad) or cuts (recess) it into the body.
+func (f *RestFeature) Recompute(in Input) (Output, error) {
+	profiles, err := resolveClosedProfiles(f.def.Sketch, f.def.ProfileIndices, "rest")
+	if err != nil {
+		return Output{}, err
+	}
+	d := callOrZero(f.def.Depth)
+	if d <= 0 {
+		return Output{}, fmt.Errorf("rest: depth %g must be > 0", d)
+	}
+	sp, op := orderedSpan(0, d), ops.Join
+	if f.def.Recessed {
+		sp, op = orderedSpan(0, -d), ops.Cut // recess: cut into the part, below the sketch plane
+	}
+	f.tool = buildProfilePrisms(profiles, f.def.Sketch.Plane(), sp, f.def.Taper, featOr(f.featName, "rest"))
+	bodies, err := combine(in.Bodies, f.tool, op)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// AddRest adds a rest pad over the given closed profiles: raised by depth (recessed cuts instead),
+// with an optional draft taper.
+func (c *PlasticFeatures) AddRest(skt *sketch.Sketch, profileIndices []int, depth func() float64, recessed bool, taper float64) *PartFeature {
+	return c.engine.Add(&RestFeature{def: &RestDefinition{
+		Sketch: skt, ProfileIndices: profileIndices, Depth: depth, Recessed: recessed, Taper: taper,
+	}})
+}

--- a/model/feature/rest_test.go
+++ b/model/feature/rest_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// A raised rest pad adds a 4×4×1 landing on the top face → block volume + 16 (#486).
+func TestRestRaisesPad(t *testing.T) {
+	fs := embossedBlock(t) // a 10×10×2 block (vol 200)
+	rs := squareOn(planeAtZ(2), 4, 3)
+	pad := NewPlasticFeatures(fs).AddRest(rs, []int{0}, func() float64 { return 1 }, false, 0)
+	fs.Recompute()
+	if !pad.Health().OK() {
+		t.Fatalf("rest pad went sick: %+v", pad.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("rest body not valid: %+v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-216) > 1e-6 {
+		t.Errorf("raised rest volume = %g, want 216 (200 + 4×4×1)", v)
+	}
+}
+
+// A recessed rest cuts a 4×4×1 pocket into the top face → block volume − 16.
+func TestRestRecesses(t *testing.T) {
+	fs := embossedBlock(t)
+	rs := squareOn(planeAtZ(2), 4, 3)
+	pad := NewPlasticFeatures(fs).AddRest(rs, []int{0}, func() float64 { return 1 }, true, 0) // recessed
+	fs.Recompute()
+	if !pad.Health().OK() {
+		t.Fatalf("recessed rest went sick: %+v", pad.Health())
+	}
+	if v := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; stdmath.Abs(v-184) > 1e-6 {
+		t.Errorf("recessed rest volume = %g, want 184 (200 − 4×4×1)", v)
+	}
+}
+
+// TestRestRejectsBadDepth: a non-positive depth is a clean error.
+func TestRestRejectsBadDepth(t *testing.T) {
+	fs := embossedBlock(t)
+	rs := squareOn(planeAtZ(2), 4, 3)
+	pad := NewPlasticFeatures(fs).AddRest(rs, []int{0}, func() float64 { return 0 }, false, 0)
+	fs.Recompute()
+	if pad.Health().OK() {
+		t.Error("a zero-depth rest should be sick")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -30,6 +30,7 @@ type FeatureData struct {
 	FaceFillet     *FaceFilletData     `yaml:"faceFillet,omitempty"`
 	RuleFillet     *RuleFilletData     `yaml:"ruleFillet,omitempty"`
 	SnapFit        *SnapFitData        `yaml:"snapFit,omitempty"`
+	Rest           *RestData           `yaml:"rest,omitempty"`
 	Chamfer        *EdgeDressData      `yaml:"chamfer,omitempty"`
 	Shell          *FaceDressData      `yaml:"shell,omitempty"`
 	Draft          *FaceDressData      `yaml:"draft,omitempty"`
@@ -200,6 +201,12 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.Emboss = ed
+	case *RestFeature:
+		rd, err := serializeRest(f.def, sk)
+		if err != nil {
+			return FeatureData{}, err
+		}
+		fd.Rest = rd
 	case *SplitSolidFeature:
 		sd, err := serializeSplitSolid(f.def)
 		if err != nil {
@@ -576,6 +583,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreRib(fs, fd.Rib, sk)
 	case "emboss":
 		return restoreEmboss(fs, fd.Emboss, sk)
+	case "rest":
+		return restoreRest(fs, fd.Rest, sk)
 	case "splitSolid":
 		return restoreSplitSolid(fs, fd.SplitSolid, work)
 	case "move":

--- a/model/feature/serialize_rest.go
+++ b/model/feature/serialize_rest.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// RestData persists a rest pad (#486): the sketch (by index), the profile indices, the depth, the
+// raised/recessed flag and the draft taper.
+type RestData struct {
+	Sketch   int     `yaml:"sketch"`
+	Profiles []int   `yaml:"profiles,omitempty"`
+	Depth    float64 `yaml:"depth"`
+	Recessed bool    `yaml:"recessed,omitempty"`
+	Taper    float64 `yaml:"taper,omitempty"`
+}
+
+func serializeRest(def *RestDefinition, sk SketchIndexer) (*RestData, error) {
+	idx, ok := sk.IndexOf(def.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("rest references a sketch that is not in the part")
+	}
+	return &RestData{
+		Sketch:   idx,
+		Profiles: append([]int(nil), def.ProfileIndices...),
+		Depth:    evalFloat(def.Depth),
+		Recessed: def.Recessed,
+		Taper:    def.Taper,
+	}, nil
+}
+
+func restoreRest(fs *PartFeatures, d *RestData, sk SketchIndexer) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("rest feature is missing its payload")
+	}
+	skt, ok := sk.At(d.Sketch)
+	if !ok {
+		return nil, fmt.Errorf("rest references sketch index %d, which does not exist", d.Sketch)
+	}
+	return NewPlasticFeatures(fs).AddRest(skt, d.Profiles, constFloat(d.Depth), d.Recessed, d.Taper), nil
+}

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -381,6 +381,28 @@ func TestEmbossRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRestRoundTrip checks the rest pad's sketch ref, profiles, depth, recessed flag and taper
+// survive a recipe round trip (#486).
+func TestRestRoundTrip(t *testing.T) {
+	sk := squareSketch(4)
+	fs := NewPartFeatures(nil, nil)
+	NewPlasticFeatures(fs).AddRest(sk, []int{0}, func() float64 { return 1.2 }, true, 0.05)
+
+	data, err := fs.MarshalRecipe(oneSketch{s: sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{s: sk}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	r := fresh.Item(0).Definition().(*RestFeature).Definition()
+	if !r.Recessed || r.Depth() != 1.2 || len(r.ProfileIndices) != 1 || r.Taper != 0.05 {
+		t.Errorf("restored rest = recessed %v depth %v profiles %v taper %v, want true 1.2 [0] 0.05",
+			r.Recessed, r.Depth(), r.ProfileIndices, r.Taper)
+	}
+}
+
 func TestRevolveAboutCenterlineRoundTrip(t *testing.T) {
 	sk := offsetSquareSketch(2, 2)
 	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))


### PR DESCRIPTION
## What

Adds the M20-F10 **rest pad** (`RestFeature`): a flat landing bounded by a closed sketch profile, **raised** above the face by a depth (joined) or **recessed** into it (cut), with an optional draft.

## How

It extrudes the profile and combines it with the running body (the same `buildProfilePrisms` + `combine` path as emboss), but is its own feature so it serializes as `"rest"` and can grow rest-specific options (the surrounding land) later. Non-positive depth → clean Sick error.

**No API change**: reachable over MCP through the `/source` opregistry `rest` op (`features.add`); the sketch ref + profiles + depth + recessed flag + taper round-trip in the recipe (`RestData`).

## Tests

- Feature: a raised pad is a valid solid (block 200 + pad 16 = 216); a recess cuts the right volume (184); zero depth goes Sick.
- Registry/MCP path + the default-registry & every-op-handles-args guards.
- Serialize round trip (sketch ref, profiles, depth, recessed, taper).
- `./model/... ./addin/...` green; lint clean.

## Closes #486

The three M20-F10 plastic features are complete: **RuleFillet** (#1020), **SnapFit** (#1039), and now **Rest**. (Refinements — SnapFit face-placement/lead-in/annular, Rest surrounding-land — are future enhancements, not part of this PBI's scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)