### PR TITLE
feat(fillet): full-round fillet — replace a center face with a half-round (#694)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -299,6 +299,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"sweep":                   `{"sketchIndex":0,"path":{"sketchIndex":1}}`,
 		"fillet":                  `{"edges":["e1"],"radius":"1 mm"}`,
 		"ruleFillet":              `{"rule":"allRounds","radius":"1 mm"}`,
+		"fullRoundFillet":         `{"side1Ref":"f1","centerRef":"f2","side2Ref":"f3"}`,
 		"snapFit":                 `{"length":"10 mm","width":"4 mm","thickness":"2 mm","catchLength":"2 mm","catchHeight":"1 mm"}`,
 		"rest":                    `{"sketchIndex":0,"depth":"2 mm"}`,
 		"chamfer":                 `{"edges":["e1"],"distance":"1 mm"}`,

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -154,6 +154,49 @@ func applyFillet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	return applyFilletFlat(part, in, corner, cs)
 }
 
+const fullRoundSchema = `{
+  "type": "object",
+  "properties": {
+    "side1Ref": {"type": "string", "description": "First side face (reference key)."},
+    "centerRef": {"type": "string", "description": "Center face to replace with the round."},
+    "side2Ref": {"type": "string", "description": "Second side face, parallel to the first."}
+  },
+  "required": ["side1Ref", "centerRef", "side2Ref"]
+}`
+
+func fullRoundDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{
+		Name:    "fullRoundFillet",
+		Summary: "Replace a center face with a full round (half-cylinder) tangent to two parallel side faces.",
+		Schema:  json.RawMessage(fullRoundSchema),
+		Apply:   applyFullRound,
+	}
+}
+
+// fullRoundArgs is the full-round op's wire shape: the two side faces and the center face to round.
+type fullRoundArgs struct {
+	Side1Ref  string `json:"side1Ref"`
+	CenterRef string `json:"centerRef"`
+	Side2Ref  string `json:"side2Ref"`
+}
+
+func applyFullRound(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in fullRoundArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Side1Ref == "" || in.CenterRef == "" || in.Side2Ref == "" {
+		return nil, errors.New("full round: side1Ref, centerRef and side2Ref are all required")
+	}
+	pf := feature.NewDressUpFeatures(part.Features()).AddFullRoundFillet(
+		refKeys([]string{in.Side1Ref}), refKeys([]string{in.CenterRef}), refKeys([]string{in.Side2Ref}))
+	return recomputeResult(part, pf)
+}
+
 // applyFaceFillet rounds the edges shared between two face sets (#694, adjacent-faces case): both
 // faceRefsA and faceRefsB plus a radius are required.
 func applyFaceFillet(part *compdef.PartComponentDefinition, in edgeDressArgs) (json.RawMessage, error) {

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -108,6 +108,7 @@ func Default() *Registry {
 		// Subtractive / dress-up (edge & face reference keys).
 		filletDescriptor(),
 		ruleFilletDescriptor(),
+		fullRoundDescriptor(),
 		snapFitDescriptor(),
 		restDescriptor(),
 		chamferDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -16,7 +16,7 @@ func TestDefaultDescriptors(t *testing.T) {
 	r := Default()
 	all := []string{
 		"extrude", "revolve", "rib", "emboss", "coil", "loft",
-		"fillet", "ruleFillet", "snapFit", "rest", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
+		"fillet", "ruleFillet", "fullRoundFillet", "snapFit", "rest", "chamfer", "shell", "draft", "lip", "hole", "boss", "grill", "thread",
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalLip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",

--- a/model/feature/full_round_fillet.go
+++ b/model/feature/full_round_fillet.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// FullRoundFilletDefinition is a full-round fillet (#694, Inventor FilletFullRoundSet): it replaces a
+// CENTER face between two parallel SIDE faces with a half-cylinder tangent to both sides, removing the
+// center face — the rounded top of a rib/wall. Unlike an edge fillet (which fails to fully consume the
+// center face at the round radius), this is built by reconstruction: a tool the size of the center-face
+// footprint (a box minus the round cylinder = the two sharp corners) is cut from the body, so it stays
+// local to the rib and leaves a clean half-round. The radius is half the side-to-side distance.
+type FullRoundFilletDefinition struct {
+	Side1Keys  [][]byte
+	CenterKeys [][]byte
+	Side2Keys  [][]byte
+}
+
+// FullRoundFilletFeature rounds a center face into a half-cylinder between two parallel sides.
+type FullRoundFilletFeature struct{ def *FullRoundFilletDefinition }
+
+// Definition returns the feature's definition.
+func (f *FullRoundFilletFeature) Definition() *FullRoundFilletDefinition { return f.def }
+
+// Kind names the feature type.
+func (f *FullRoundFilletFeature) Kind() string { return "full-round-fillet" }
+
+// Recompute replaces the center face with a full round between the two side faces.
+func (f *FullRoundFilletFeature) Recompute(in Input) (Output, error) {
+	return fullRoundFilletBody(in, f.def, "full-round-fillet")
+}
+
+// fullRoundFilletBody reconstructs the full round: it derives the rib frame from the three faces,
+// builds a corner tool (the center-face-footprint box minus the round cylinder) and cuts it from the
+// body. Non-planar faces, non-parallel sides, or a degenerate frame are clean errors (the feature
+// goes Sick) — this slice handles the parallel-sides case (variable-radius rounds are a follow-up).
+func fullRoundFilletBody(in Input, def *FullRoundFilletDefinition, feat string) (Output, error) {
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	center, err := singlePlanarFace(body, def.CenterKeys, feat, "center")
+	if err != nil {
+		return Output{}, err
+	}
+	fr, err := fullRoundFrame(body, def, center, feat)
+	if err != nil {
+		return Output{}, err
+	}
+	pc := center.face.RangeBox().Center()
+	l := faceExtentAlong(center.face, pc, fr.axis) + 4*fr.radius // generous overhang so the tool cuts cleanly
+	tool, err := fullRoundCornerTool(pc, fr.up, fr.sideN, fr.axis, fr.radius, l, feat)
+	if err != nil {
+		return Output{}, err
+	}
+	result, err := ops.Boolean(ops.Cut, planarized(body, feat), tool)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// ribFrame is the orthonormal frame + radius of a full round, derived from the three faces.
+type ribFrame struct {
+	up, sideN, axis math.Vector3
+	radius          float64
+}
+
+// fullRoundFrame resolves the two side faces and derives the rib frame: up (center normal), sideN
+// (side normal), axis (along the rib), and the round radius (half the side-to-side distance). It
+// errors when the sides are not parallel, the center is not perpendicular to them, or the radius is 0.
+func fullRoundFrame(body *topo.Body, def *FullRoundFilletDefinition, center planarFace, feat string) (ribFrame, error) {
+	side1, err := singlePlanarFace(body, def.Side1Keys, feat, "side1")
+	if err != nil {
+		return ribFrame{}, err
+	}
+	side2, err := singlePlanarFace(body, def.Side2Keys, feat, "side2")
+	if err != nil {
+		return ribFrame{}, err
+	}
+	up, sideN := normalize(center.Normal()), normalize(side1.Normal())
+	if d := stdmath.Abs(float64(normalize(side2.Normal()).Dot(sideN))); d < 0.999 {
+		return ribFrame{}, fmt.Errorf("%s: the two side faces must be parallel (|n1·n2| = %.3f)", feat, d)
+	}
+	axis := normalize(up.Cross(sideN))
+	if float64(axis.Dot(axis)) < 0.5 {
+		return ribFrame{}, fmt.Errorf("%s: the center face must be perpendicular to the sides", feat)
+	}
+	r := stdmath.Abs(float64(side1.Origin.VectorTo(side2.Origin).Dot(sideN))) / 2
+	if r <= 0 {
+		return ribFrame{}, fmt.Errorf("%s: the side faces are coincident (zero radius)", feat)
+	}
+	return ribFrame{up: up, sideN: sideN, axis: axis, radius: r}, nil
+}
+
+// fullRoundCornerTool builds the cut tool: a box covering the center-face footprint from the round's
+// base plane up to the center face, MINUS the round cylinder — i.e. the two sharp corners the round
+// shaves off. pc is the center-face centre; up/sideN/axisDir the orthonormal rib frame; r the radius;
+// l the length along the rib.
+func fullRoundCornerTool(pc math.Point3, up, sideN, axisDir math.Vector3, r, l float64, feat string) (*topo.Body, error) {
+	plane, err := sketch.NewPlane(pc, sideN.AsUnit(), up.AsUnit())
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", feat, err)
+	}
+	// Box (in the sideN×up plane, centred on pc): full width 2r across the sides, depth r below the
+	// centre face, extruded ±l/2 along the rib axis (the plane normal).
+	rect := []math.Point2{{X: -r, Y: -r}, {X: r, Y: -r}, {X: r, Y: 0}, {X: -r, Y: 0}}
+	box := buildPrism(rect, plane, span{near: -l / 2, far: l / 2}, 0, feat)
+
+	axisPt := pc.TranslateBy(up.Scale(-r)) // the cylinder axis sits r below the centre face, on the midline
+	base := axisPt.TranslateBy(axisDir.Scale(-l / 2))
+	cyl, err := brep.SolidCylinder(base, axisDir, r, l)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", feat, err)
+	}
+	corner, err := ops.Boolean(ops.Cut, planarized(box, feat), planarized(cyl, feat))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", feat, err)
+	}
+	return corner, nil
+}
+
+// planarFace pairs a face with its plane geometry.
+type planarFace struct {
+	face *topo.Face
+	geom.Plane
+}
+
+// singlePlanarFace resolves exactly one planar face from keys (a full round takes one face per set).
+func singlePlanarFace(body *topo.Body, keys [][]byte, feat, role string) (planarFace, error) {
+	want := keyLookup(keys)
+	var found *topo.Face
+	for _, f := range body.Faces() {
+		if want[string(f.ReferenceKey())] {
+			if found != nil {
+				return planarFace{}, fmt.Errorf("%s: %s must be a single face", feat, role)
+			}
+			found = f
+		}
+	}
+	if found == nil {
+		return planarFace{}, fmt.Errorf("%s: %s face not found", feat, role)
+	}
+	pl, ok := found.Geometry().(geom.Plane)
+	if !ok {
+		return planarFace{}, fmt.Errorf("%s: %s must be a planar face", feat, role)
+	}
+	return planarFace{face: found, Plane: pl}, nil
+}
+
+// faceExtentAlong returns the span of the face's vertices projected onto dir, relative to origin.
+func faceExtentAlong(f *topo.Face, origin math.Point3, dir math.Vector3) float64 {
+	lo, hi := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range f.Vertices() {
+		d := float64(origin.VectorTo(v.Point()).Dot(dir))
+		lo, hi = stdmath.Min(lo, d), stdmath.Max(hi, d)
+	}
+	if hi < lo {
+		return 0
+	}
+	return hi - lo
+}
+
+// normalize returns the unit vector in v's direction (zero stays zero).
+func normalize(v math.Vector3) math.Vector3 {
+	if l := float64(v.Length()); l > 1e-12 {
+		return v.Scale(math.Scalar(1 / l))
+	}
+	return math.V3(0, 0, 0)
+}
+
+// AddFullRoundFillet replaces the center face with a full round between the two parallel side faces
+// (#694). Each set is a single planar face.
+func (c *DressUpFeatures) AddFullRoundFillet(side1Keys, centerKeys, side2Keys [][]byte) *PartFeature {
+	return c.engine.Add(&FullRoundFilletFeature{def: &FullRoundFilletDefinition{
+		Side1Keys: side1Keys, CenterKeys: centerKeys, Side2Keys: side2Keys,
+	}})
+}

--- a/model/feature/full_round_fillet_test.go
+++ b/model/feature/full_round_fillet_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// ribForFullRound builds a 4×10×5 rib and returns the engine plus the side/center face keys (the two
+// vertical x faces and the top z=5 face).
+func ribForFullRound(t *testing.T) (fs *PartFeatures, side1, center, side2 [][]byte) {
+	t.Helper()
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 10}, {X: 0, Y: 10}},
+		sketch.XYPlane(), span{near: 0, far: 5}, 0, "rib")
+	for _, f := range box.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok {
+			continue
+		}
+		n, o := pl.Normal(), pl.Origin
+		switch {
+		case n.X < -0.5:
+			side1 = [][]byte{f.ReferenceKey()}
+		case n.X > 0.5:
+			side2 = [][]byte{f.ReferenceKey()}
+		case n.Z > 0.5 && o.Z > 4:
+			center = [][]byte{f.ReferenceKey()}
+		}
+	}
+	fs = NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	return fs, side1, center, side2
+}
+
+// TestFullRoundRoundsRibTop: a full round between the two parallel side faces replaces the top with a
+// half-round — a valid solid whose volume is the lower box plus the half-cylinder (the corners gone).
+func TestFullRoundRoundsRibTop(t *testing.T) {
+	fs, s1, ctr, s2 := ribForFullRound(t)
+	pf := NewDressUpFeatures(fs).AddFullRoundFillet(s1, ctr, s2)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("full round went sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("full-round body not a valid solid: %+v", r.Issues)
+	}
+	// rib 4×10×5 = 200; rounded = lower box 4×10×3 (120) + half-cylinder r2 len10 (≈62.8) ≈ 182.8.
+	// The boolean facets the round, so the value lands a little under; bound it generously.
+	v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume
+	if v <= 178 || v >= 185 {
+		t.Errorf("full-round volume = %g, want ≈ 182.8 (lower box + half cylinder, faceted)", v)
+	}
+	if v >= 200 {
+		t.Error("full round should remove the top corners (volume < the original 200)")
+	}
+}
+
+// TestFullRoundRejectsNonParallelSides: choosing a side and the top (not parallel) is a clean error.
+func TestFullRoundRejectsNonParallelSides(t *testing.T) {
+	fs, s1, ctr, _ := ribForFullRound(t)
+	pf := NewDressUpFeatures(fs).AddFullRoundFillet(s1, ctr, ctr) // ctr (top) is not parallel to s1
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("full round with non-parallel sides should be sick")
+	}
+}
+
+// TestFullRoundRejectsMissingFace: an unknown face key is a clean error.
+func TestFullRoundRejectsMissingFace(t *testing.T) {
+	fs, s1, ctr, _ := ribForFullRound(t)
+	pf := NewDressUpFeatures(fs).AddFullRoundFillet(s1, ctr, [][]byte{[]byte("nope")})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("full round with a missing side face should be sick")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -28,6 +28,7 @@ type FeatureData struct {
 	Extrude        *ExtrudeData        `yaml:"extrude,omitempty"`
 	Fillet         *EdgeDressData      `yaml:"fillet,omitempty"`
 	FaceFillet     *FaceFilletData     `yaml:"faceFillet,omitempty"`
+	FullRound      *FullRoundData      `yaml:"fullRound,omitempty"`
 	RuleFillet     *RuleFilletData     `yaml:"ruleFillet,omitempty"`
 	SnapFit        *SnapFitData        `yaml:"snapFit,omitempty"`
 	Rest           *RestData           `yaml:"rest,omitempty"`
@@ -144,6 +145,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius), CornerType: int32(f.def.CornerType)}
 	case *FaceFilletFeature:
 		fd.FaceFillet = &FaceFilletData{FacesA: encodeKeys(f.def.FaceKeysA), FacesB: encodeKeys(f.def.FaceKeysB), Value: evalFloat(f.def.Radius)}
+	case *FullRoundFilletFeature:
+		fd.FullRound = &FullRoundData{Side1: encodeKeys(f.def.Side1Keys), Center: encodeKeys(f.def.CenterKeys), Side2: encodeKeys(f.def.Side2Keys)}
 	case *RuleFilletFeature:
 		fd.RuleFillet = &RuleFilletData{Rule: f.def.Rule.String(), Value: evalFloat(f.def.Radius)}
 	case *SnapFitFeature:
@@ -465,6 +468,23 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 			return nil, err
 		}
 		return du.AddFaceFillet(a, b, constFloat(fd.FaceFillet.Value)), nil
+	case "full-round-fillet":
+		if fd.FullRound == nil {
+			return nil, fmt.Errorf("full-round-fillet feature is missing its payload")
+		}
+		s1, err := decodeKeys(fd.FullRound.Side1)
+		if err != nil {
+			return nil, err
+		}
+		ctr, err := decodeKeys(fd.FullRound.Center)
+		if err != nil {
+			return nil, err
+		}
+		s2, err := decodeKeys(fd.FullRound.Side2)
+		if err != nil {
+			return nil, err
+		}
+		return du.AddFullRoundFillet(s1, ctr, s2), nil
 	case "rule-fillet":
 		if fd.RuleFillet == nil {
 			return nil, fmt.Errorf("rule-fillet feature is missing its payload")

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -116,6 +116,13 @@ type RuleFilletData struct {
 	Value float64 `yaml:"value"`
 }
 
+// FullRoundData persists a full-round fillet (#694): the three face-set reference keys.
+type FullRoundData struct {
+	Side1  []string `yaml:"side1"`
+	Center []string `yaml:"center"`
+	Side2  []string `yaml:"side2"`
+}
+
 // SnapFitData persists a cantilever snap-fit (#486): the beam and catch dimensions.
 type SnapFitData struct {
 	Length      float64 `yaml:"length"`

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -116,6 +116,26 @@ func TestFaceFilletRoundTrip(t *testing.T) {
 	}
 }
 
+// TestFullRoundRoundTrip checks the full-round fillet's three face sets survive a recipe round trip (#694).
+func TestFullRoundRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewDressUpFeatures(fs).AddFullRoundFillet(
+		[][]byte{[]byte("side-1")}, [][]byte{[]byte("center")}, [][]byte{[]byte("side-2")})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*FullRoundFilletFeature).Definition()
+	if string(d.Side1Keys[0]) != "side-1" || string(d.CenterKeys[0]) != "center" || string(d.Side2Keys[0]) != "side-2" {
+		t.Errorf("restored full round = %s/%s/%s, want side-1/center/side-2",
+			d.Side1Keys[0], d.CenterKeys[0], d.Side2Keys[0])
+	}
+}
+
 // TestRuleFilletRoundTrip checks the rule fillet's rule + radius survive a recipe round trip (#486).
 func TestRuleFilletRoundTrip(t *testing.T) {
 	fs := NewPartFeatures(nil, nil)


### PR DESCRIPTION
## What

Inventor's **full-round fillet** (`FilletFullRoundSet`): replaces a **center** face between two **parallel side** faces with a half-cylinder tangent to both, removing the center face — the rounded top of a rib/wall.

## Why not an edge fillet

Proven by probe: filleting both center↔side edges at the round radius **goes Sick** — the two fillets must *fully consume* the center face (they share an axis), a degeneracy the rolling-ball edge fillet can't resolve. So full-round needs dedicated geometry.

## How

**Boolean reconstruction**, local to the rib:
- Derive the rib frame from the three faces — up = center normal, side normal, axis = up × side — and `radius = ½·distance(side1, side2)`.
- Build a **corner tool** sized to the center-face footprint: a box from the round's base plane up to the center face, **minus the round cylinder** = the two sharp corners.
- Cut the tool from the body. Bounded to the rib footprint, so it stays local (works on parts with other features).

Non-planar faces, non-parallel sides, or a degenerate frame are clean **Sick** errors (this slice handles the parallel-sides case; variable-radius rounds are a follow-up). The boolean facets the cylinder, so the round is faceted (a valid solid) rather than analytic.

**No API change**: reachable over MCP via the `/source` opregistry `fullRoundFillet` op; the three face sets round-trip (`FullRoundData`).

## Tests

- Feature: a rib top becomes a valid half-round of the expected volume (≈ lower box + half-cylinder); non-parallel sides and a missing face go Sick.
- Registry/MCP path + the default-registry & every-op-handles-args guards.
- Serialize round trip.
- `./model/... ./addin/...` green; lint clean.

## Scope (#694 stays open)

The **full-round** slice (after the face-fillet adjacent case #1019). Remaining on #694: non-adjacent face fillet (gap-bridging ball) and the face-picking UI; variable-radius/non-parallel full round is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)