### PR TITLE
feat(fillet): intermediate radius points for variable fillets (#695)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -136,6 +136,7 @@ func TestDressUpOnSolid(t *testing.T) {
 		{"fillet set const", "fillet", map[string]any{"_set": "radius"}},
 		{"fillet set concave", "fillet", map[string]any{"_set": "radius", "concaveStrategy": "outward"}},
 		{"fillet set variable", "fillet", map[string]any{"_set": "var"}},
+		{"fillet set radius points", "fillet", map[string]any{"_set": "points"}},
 		{"chamfer distance", "chamfer", map[string]any{"distance": "1 mm"}},
 		{"chamfer two distances", "chamfer", map[string]any{"distance": "1 mm", "distance2": "2 mm", "chamferType": "twoDistances"}},
 		{"chamfer distance angle", "chamfer", map[string]any{"distance": "1 mm", "angle": "30 deg", "chamferType": "distanceAndAngle"}},
@@ -150,6 +151,9 @@ func TestDressUpOnSolid(t *testing.T) {
 				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "radius": "1 mm"}}, "concaveStrategy": c.args["concaveStrategy"]}
 			case "var":
 				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "startRadius": "1 mm", "endRadius": "2 mm"}}}
+			case "points":
+				args = map[string]any{"edgeSets": []map[string]any{{"edgeRefs": []string{edge}, "startRadius": "1 mm", "endRadius": "2 mm",
+					"radiusPoints": []map[string]any{{"t": 0.5, "radius": "3 mm"}}}}}
 			default:
 				args["edgeRefs"] = []string{edge}
 			}

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -37,12 +37,19 @@ type edgeDressArgs struct {
 }
 
 // filletSetArgs is one fillet edge set over the wire: constant (radius) or variable
-// (startRadius+endRadius over exactly one edge).
+// (startRadius+endRadius over exactly one edge, plus optional intermediate radiusPoints, #695).
 type filletSetArgs struct {
-	EdgeRefs    []string `json:"edgeRefs"`
-	Radius      string   `json:"radius,omitempty"`
-	StartRadius string   `json:"startRadius,omitempty"`
-	EndRadius   string   `json:"endRadius,omitempty"`
+	EdgeRefs     []string             `json:"edgeRefs"`
+	Radius       string               `json:"radius,omitempty"`
+	StartRadius  string               `json:"startRadius,omitempty"`
+	EndRadius    string               `json:"endRadius,omitempty"`
+	RadiusPoints []filletRadiusPtArgs `json:"radiusPoints,omitempty"`
+}
+
+// filletRadiusPtArgs is one intermediate radius stop on a variable fillet edge over the wire (#695).
+type filletRadiusPtArgs struct {
+	T      float64 `json:"t"`
+	Radius string  `json:"radius"`
 }
 
 const filletSchema = `{
@@ -56,7 +63,11 @@ const filletSchema = `{
       "edgeRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
       "radius": {"type": "string", "description": "Constant radius for this set, e.g. \"3 mm\"."},
       "startRadius": {"type": "string", "description": "Variable set: radius at the edge's start vertex (the set holds exactly one edge)."},
-      "endRadius": {"type": "string", "description": "Variable set: radius at the edge's end vertex."}
+      "endRadius": {"type": "string", "description": "Variable set: radius at the edge's end vertex."},
+      "radiusPoints": {"type": "array", "description": "Variable set: optional intermediate radius stops along the edge (#695), each strictly between the ends and strictly increasing in t.", "items": {"type": "object", "properties": {
+        "t": {"type": "number", "description": "Fraction along the edge from start vertex (0) to end vertex (1); 0<t<1."},
+        "radius": {"type": "string", "description": "Radius at this stop, e.g. \"4 mm\"."}
+      }, "required": ["t", "radius"]}}
     }, "required": ["edgeRefs"]}},
     "cornerType": {"type": "string", "enum": ["miter", "setback", "round"], "default": "miter", "description": "How a vertex where two filleted edges meet (third edge sharp) is treated: miter (exact crease), round (fillets the third edge into a smooth sphere). setback is reserved."},
     "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with an exact rolling-ball cylinder (default). inward rounds a recess into the corner and is only valid where the faces extend into the material (e.g. a pocket). Convex edges ignore this."}
@@ -296,7 +307,27 @@ func filletSetRadii(part *compdef.PartComponentDefinition, a filletSetArgs, i in
 		return feature.FilletEdgeSet{}, err
 	}
 	r1, err := lengthClosure(part, a.EndRadius, "fillet: endRadius")
-	return feature.FilletEdgeSet{StartRadius: r0, EndRadius: r1}, err
+	if err != nil {
+		return feature.FilletEdgeSet{}, err
+	}
+	pts, err := filletRadiusPoints(part, a.RadiusPoints)
+	return feature.FilletEdgeSet{StartRadius: r0, EndRadius: r1, RadiusPoints: pts}, err
+}
+
+// filletRadiusPoints resolves a variable set's intermediate radius stops' closures (#695).
+func filletRadiusPoints(part *compdef.PartComponentDefinition, pts []filletRadiusPtArgs) ([]feature.FilletRadiusPoint, error) {
+	if len(pts) == 0 {
+		return nil, nil
+	}
+	out := make([]feature.FilletRadiusPoint, len(pts))
+	for i, p := range pts {
+		r, err := lengthClosure(part, p.Radius, "fillet: radiusPoints radius")
+		if err != nil {
+			return nil, err
+		}
+		out[i] = feature.FilletRadiusPoint{T: p.T, Radius: r}
+	}
+	return out, nil
 }
 
 func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -11,12 +11,21 @@ import (
 	"oblikovati.org/math"
 )
 
+// FilletRadiusPoint is an intermediate radius along a variable fillet edge: R at parameter T in
+// (0,1) measured from the start vertex (#695). Points let the radius follow a piecewise profile —
+// e.g. a bulge in the middle — instead of only the linear R0→R1 taper.
+type FilletRadiusPoint struct {
+	T, R float64
+}
+
 // EdgeFilletRadii is one picked edge with its blend radius at each end: R0 at the edge's
 // start vertex, R1 at its end vertex. Equal radii give a constant fillet; differing radii a
-// variable fillet whose radius runs linearly along the edge (#323).
+// variable fillet whose radius runs linearly along the edge (#323). Mids adds intermediate radius
+// points the blend interpolates through (#695), sorted by T; empty = the plain R0→R1 taper.
 type EdgeFilletRadii struct {
 	Key    []byte
 	R0, R1 float64
+	Mids   []FilletRadiusPoint
 }
 
 // FilletEdges rounds the selected convex straight edges of a planar solid with a constant-
@@ -122,10 +131,12 @@ func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFil
 type filletPick struct {
 	edge   *topo.Edge
 	r0, r1 float64
+	mids   []FilletRadiusPoint
 }
 
-// varying reports whether the pick's radius changes along the edge.
-func (p filletPick) varying() bool { return p.r0 != p.r1 }
+// varying reports whether the pick's radius changes along the edge (differing ends, or any
+// intermediate radius point that bulges/pinches the profile).
+func (p filletPick) varying() bool { return p.r0 != p.r1 || len(p.mids) > 0 }
 
 // resolveFilletPicks resolves the edge reference keys against the body, erroring on a lost
 // key or a non-positive radius.
@@ -135,11 +146,14 @@ func resolveFilletPicks(body *topo.Body, picks []EdgeFilletRadii) ([]filletPick,
 		if p.R0 < 0 || p.R1 < 0 || p.R0+p.R1 <= 0 {
 			return nil, fmt.Errorf("fillet: radii %g/%g must be >= 0 with at least one > 0 (a run-out tapers to 0 at one end)", p.R0, p.R1)
 		}
+		if err := validateRadiusPoints(p.Mids); err != nil {
+			return nil, err
+		}
 		e, ok := body.FindEdgeByKey(p.Key)
 		if !ok {
 			return nil, fmt.Errorf("fillet: edge reference lost: %x", p.Key)
 		}
-		out = append(out, filletPick{edge: e, r0: p.R0, r1: p.R1})
+		out = append(out, filletPick{edge: e, r0: p.R0, r1: p.R1, mids: p.Mids})
 	}
 	return out, nil
 }
@@ -178,6 +192,7 @@ type edgeFillet struct {
 	a, b    *topo.Face
 	cyl     geom.Cylinder
 	c0, c1  corner
+	mids    []corner // variable fillet only: intermediate profiles ruled between c0 and c1 (#695)
 	edge    *topo.Edge
 	varying bool
 	flip    bool // concave fillet: the cylinder face's outward sense is inverted (surface faces the centre)
@@ -243,7 +258,8 @@ func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[ui
 	}
 	if p.varying() {
 		sampleCornerChords(&c0, &c1, in)
-		return edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, edge: e, varying: true, flip: in.flip}, nil
+		mids := midProfiles(e, in, p.mids, cornerChordCount(in))
+		return edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, mids: mids, edge: e, varying: true, flip: in.flip}, nil
 	}
 	cyl, err := geom.NewCylinder(c0.cen, in.axis, p.r0)
 	if err != nil {
@@ -279,6 +295,45 @@ func cornerChordCount(in cornerInputs) int {
 		k = 4
 	}
 	return k
+}
+
+// validateRadiusPoints checks intermediate fillet radius points are strictly inside the edge
+// (0 < T < 1), positive, and strictly increasing in T (so the ruled profiles stay in order).
+func validateRadiusPoints(mids []FilletRadiusPoint) error {
+	prev := 0.0
+	for _, m := range mids {
+		if m.T <= 0 || m.T >= 1 {
+			return fmt.Errorf("fillet: intermediate radius point T=%g must be strictly between 0 and 1", m.T)
+		}
+		if m.R <= 0 {
+			return fmt.Errorf("fillet: intermediate radius %g must be > 0", m.R)
+		}
+		if m.T <= prev {
+			return fmt.Errorf("fillet: intermediate radius points must be strictly increasing in T (got %g after %g)", m.T, prev)
+		}
+		prev = m.T
+	}
+	return nil
+}
+
+// midProfiles builds one corner cross-section per intermediate radius point: the rolling-ball circle
+// at the interpolated edge point and radius, sampled as chords with the same frame as the end corners
+// (#695). They have no end face/blend — they are pure ruling profiles between c0 and c1.
+func midProfiles(e *topo.Edge, in cornerInputs, mids []FilletRadiusPoint, k int) []corner {
+	if len(mids) == 0 {
+		return nil
+	}
+	p0, p1 := e.StartVertex().Point(), e.EndVertex().Point()
+	span := p0.VectorTo(p1)
+	out := make([]corner, 0, len(mids))
+	for _, m := range mids {
+		p := p0.TranslateBy(span.Scale(m.T))
+		cen := p.TranslateBy(in.offDir.Scale(m.R))
+		c := corner{a: in.a, b: in.b, cen: cen, ta: cen.TranslateBy(in.nA.Scale(m.R)), tb: cen.TranslateBy(in.nB.Scale(m.R))}
+		c.chords = arcChords(c, in, k)
+		out = append(out, c)
+	}
+	return out
 }
 
 // sampleCornerChords samples both corners' arcs at the same angular stations, so chord j of

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -13,10 +13,10 @@ import (
 // end corners replaced by an arc or chord fan), one cylinder face per constant filleted edge
 // (or a planar ruling strip per variable one), and one sphere patch per corner blend.
 func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*cornerBlend) []filletFace {
-	abSubst, endCorner := filletMaps(fils)
+	abSubst, endCorner, edgeInserts := filletMaps(fils)
 	var out []filletFace
 	for _, f := range body.Faces() {
-		out = append(out, transformFace(f, abSubst[f], endCorner[f]))
+		out = append(out, transformFace(f, abSubst[f], endCorner[f], edgeInserts[f]))
 	}
 	for _, ef := range fils {
 		if ef.varying {
@@ -39,15 +39,27 @@ func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*co
 // strips collapse to a triangle fan to that apex so the cone closes manifold (not degenerate quads).
 func rulingStripFaces(ef edgeFillet) []filletFace {
 	cmid := ef.c0.cen.Midpoint(ef.c1.cen)
-	out := make([]filletFace, 0, len(ef.c0.chords)-1)
-	for j := 0; j+1 < len(ef.c0.chords); j++ {
+	profiles := append([]corner{ef.c0}, ef.mids...) // c0, intermediate profiles (#695), c1
+	profiles = append(profiles, ef.c1)
+	var out []filletFace
+	for i := 0; i+1 < len(profiles); i++ {
+		out = append(out, ruleStripBetween(profiles[i], profiles[i+1], cmid)...)
+	}
+	return out
+}
+
+// ruleStripBetween rules one strip of planar faces between two corner profiles' chord arrays. Only an
+// end corner can be a run-out (collapse to an apex); intermediate profiles are always full arcs.
+func ruleStripBetween(a, b corner, cmid math.Point3) []filletFace {
+	out := make([]filletFace, 0, len(a.chords))
+	for j := 0; j+1 < len(a.chords) && j+1 < len(b.chords); j++ {
 		switch {
-		case ef.c1.runout: // fan from corner-0's arc to corner-1's apex
-			out = append(out, planarFaceFromRing([]math.Point3{ef.c0.chords[j], ef.c1.cen, ef.c0.chords[j+1]}, cmid))
-		case ef.c0.runout: // fan from corner-1's arc to corner-0's apex
-			out = append(out, planarFaceFromRing([]math.Point3{ef.c1.chords[j], ef.c0.cen, ef.c1.chords[j+1]}, cmid))
+		case b.runout: // fan from a's arc to b's apex
+			out = append(out, planarFaceFromRing([]math.Point3{a.chords[j], b.cen, a.chords[j+1]}, cmid))
+		case a.runout: // fan from b's arc to a's apex
+			out = append(out, planarFaceFromRing([]math.Point3{b.chords[j], a.cen, b.chords[j+1]}, cmid))
 		default:
-			out = append(out, planarFaceFromRing([]math.Point3{ef.c0.chords[j], ef.c1.chords[j], ef.c1.chords[j+1], ef.c0.chords[j+1]}, cmid))
+			out = append(out, planarFaceFromRing([]math.Point3{a.chords[j], b.chords[j], b.chords[j+1], a.chords[j+1]}, cmid))
 		}
 	}
 	return out
@@ -81,9 +93,10 @@ func reversedRing(ring []math.Point3) []math.Point3 {
 // is a fillet's A or B face — every corner, simple or blended), and the corner-vertex →
 // corner arc (only for SIMPLE end corners; a blend corner's arc lives on the sphere patch,
 // and all its faces just pull back to the sphere tangent points).
-func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*topo.Face]map[uint64]corner) {
+func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*topo.Face]map[uint64]corner, map[*topo.Face]map[uint64][]math.Point3) {
 	ab := map[*topo.Face]map[uint64]math.Point3{}
 	ends := map[*topo.Face]map[uint64]corner{}
+	inserts := map[*topo.Face]map[uint64][]math.Point3{}
 	put := func(m map[*topo.Face]map[uint64]math.Point3, f *topo.Face, id uint64, p math.Point3) {
 		if m[f] == nil {
 			m[f] = map[uint64]math.Point3{}
@@ -102,23 +115,46 @@ func filletMaps(fils []edgeFillet) (map[*topo.Face]map[uint64]math.Point3, map[*
 			}
 			ends[c.endFace][c.vertex.ID()] = c
 		}
+		putEdgeInserts(inserts, ef) // variable fillets split the A/B tangent lines at each mid station (#695)
 	}
-	return ab, ends
+	return ab, ends, inserts
+}
+
+// putEdgeInserts records, for a variable fillet, the intermediate tangent points that must be inserted
+// into the two adjacent faces' filleted-edge boundary so they weld to the subdivided ruling strips: the
+// A face gets each mid profile's ta, the B face each mid's tb, ordered from the edge's start vertex (#695).
+func putEdgeInserts(inserts map[*topo.Face]map[uint64][]math.Point3, ef edgeFillet) {
+	if len(ef.mids) == 0 {
+		return
+	}
+	eid := ef.edge.ID()
+	ta := make([]math.Point3, len(ef.mids))
+	tb := make([]math.Point3, len(ef.mids))
+	for i, m := range ef.mids {
+		ta[i], tb[i] = m.ta, m.tb
+	}
+	for f, pts := range map[*topo.Face][]math.Point3{ef.a: ta, ef.b: tb} {
+		if inserts[f] == nil {
+			inserts[f] = map[uint64][]math.Point3{}
+		}
+		inserts[f][eid] = pts
+	}
 }
 
 // transformFace rebuilds a face's loops, pulling A/B corners to their tangent points and
 // expanding each end corner into a tangent-point-to-tangent-point arc. A face untouched by
 // any fillet is copied unchanged.
-func transformFace(f *topo.Face, subs map[uint64]math.Point3, ends map[uint64]corner) filletFace {
+func transformFace(f *topo.Face, subs map[uint64]math.Point3, ends map[uint64]corner, inserts map[uint64][]math.Point3) filletFace {
 	ff := filletFace{surface: f.Geometry()}
 	for _, l := range f.Loops() {
-		ff.loops = append(ff.loops, transformLoop(f, l, subs, ends))
+		ff.loops = append(ff.loops, transformLoop(f, l, subs, ends, inserts))
 	}
 	return ff
 }
 
-// transformLoop walks a loop's edge uses and applies the per-vertex fillet substitutions.
-func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends map[uint64]corner) filletLoop {
+// transformLoop walks a loop's edge uses and applies the per-vertex fillet substitutions, then
+// subdivides the filleted edge at any intermediate tangent points (variable fillets, #695).
+func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends map[uint64]corner, inserts map[uint64][]math.Point3) filletLoop {
 	uses := l.EdgeUses()
 	n := len(uses)
 	var fl filletLoop
@@ -135,8 +171,37 @@ func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends
 		default:
 			fl.add(v.Point(), nil)
 		}
+		addEdgeInserts(&fl, inserts, u)
 	}
 	return fl
+}
+
+// addEdgeInserts appends the mid tangent points along edge use u (oriented to the traversal direction),
+// subdividing a variable fillet's tangent line so the adjacent face welds to the ruling strips (#695).
+func addEdgeInserts(fl *filletLoop, inserts map[uint64][]math.Point3, u *topo.EdgeUse) {
+	if inserts == nil {
+		return
+	}
+	pts, ok := inserts[u.Edge().ID()]
+	if !ok {
+		return
+	}
+	for _, p := range orientedInserts(pts, u.Reversed()) {
+		fl.add(p, nil)
+	}
+}
+
+// orientedInserts returns the start→end-ordered insert points, reversed when the edge is traversed
+// from its end vertex.
+func orientedInserts(pts []math.Point3, reversed bool) []math.Point3 {
+	if !reversed {
+		return pts
+	}
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[len(pts)-1-i] = p
+	}
+	return out
 }
 
 // addCornerRound expands a simple end corner into its rounded boundary: one true arc for a

--- a/kernel/ops/fillet_varying_test.go
+++ b/kernel/ops/fillet_varying_test.go
@@ -47,6 +47,52 @@ func TestFilletVaryingRadiusVolume(t *testing.T) {
 	}
 }
 
+// TestFilletIntermediateRadiiVolume rounds one vertical edge of a 2×2×2 box with a
+// piecewise-linear radius profile: 0.3 at the start, 0.7 at the mid (T=0.5), 0.4 at
+// the end (#695). The removed volume is the per-segment chord integral summed — every
+// ruling strip is still planar, so the tessellation adds no error.
+func TestFilletIntermediateRadiiVolume(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	pick := ops.EdgeFilletRadii{
+		Key: verticalEdgeKey(t, box), R0: 0.3, R1: 0.4,
+		Mids: []ops.FilletRadiusPoint{{T: 0.5, R: 0.7}},
+	}
+	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{pick})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("intermediate-radii box not a valid solid: %+v", r)
+	}
+	if n := hasCylinderFaces(res); n != 0 {
+		t.Errorf("intermediate-radii fillet produced %d cylinder faces, want 0 (planar strips)", n)
+	}
+	const k = 8 // ceil((π/2) / (2π/32)) chords across the 90° wedge
+	seg := func(ra, rb, length float64) float64 { return length * (ra*ra + ra*rb + rb*rb) / 3 }
+	removed := varyingNotchFactor(k) * (seg(0.3, 0.7, 1.0) + seg(0.7, 0.4, 1.0))
+	want := 8 - removed
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("intermediate-radii fillet volume = %g, want %g (exact chord geometry)", got, want)
+	}
+}
+
+// TestFilletIntermediateRadiiValidation rejects out-of-range and non-increasing points (#695).
+func TestFilletIntermediateRadiiValidation(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	key := verticalEdgeKey(t, box)
+	cases := map[string][]ops.FilletRadiusPoint{
+		"must be strictly between 0 and 1": {{T: 0, R: 0.5}},
+		"radius":                           {{T: 0.5, R: 0}},
+		"strictly increasing in T":         {{T: 0.6, R: 0.4}, {T: 0.6, R: 0.5}},
+	}
+	for want, mids := range cases {
+		_, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{{Key: key, R0: 0.3, R1: 0.4, Mids: mids}})
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("mids %+v: err = %v, want %q", mids, err, want)
+		}
+	}
+}
+
 // TestFilletVaryingCollapsesToConstant: equal end radii through the varying API
 // must reproduce the constant cylinder fillet exactly.
 func TestFilletVaryingCollapsesToConstant(t *testing.T) {

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -25,12 +25,22 @@ import (
 // FilletEdgeSet is one edge set of a fillet definition (the reference's
 // FilletConstantRadiusEdgeSet / FilletVariableRadiusEdgeSet): a constant Radius over the
 // whole set, or — when Radius is nil — a variable StartRadius→EndRadius over a single edge
-// (radius runs linearly from the edge's start vertex to its end vertex).
+// (radius runs linearly from the edge's start vertex to its end vertex). RadiusPoints are
+// optional intermediate (position, radius) stops along that variable edge (#695), each at a
+// fraction 0<T<1 of the edge, strictly increasing in T — the reference's FilletRadius set points.
 type FilletEdgeSet struct {
-	EdgeKeys    [][]byte
-	Radius      func() float64
-	StartRadius func() float64
-	EndRadius   func() float64
+	EdgeKeys     [][]byte
+	Radius       func() float64
+	StartRadius  func() float64
+	EndRadius    func() float64
+	RadiusPoints []FilletRadiusPoint
+}
+
+// FilletRadiusPoint is one intermediate radius stop on a variable fillet edge: T is the fraction
+// along the edge (start vertex = 0, end vertex = 1), Radius the rolling-ball radius there.
+type FilletRadiusPoint struct {
+	T      float64
+	Radius func() float64
 }
 
 // variable reports whether the set carries a start→end radius instead of a constant one.

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -135,9 +135,24 @@ func filletPicksOf(sets []FilletEdgeSet, feat string) ([]ops.EdgeFilletRadii, er
 		if len(s.EdgeKeys) != 1 {
 			return nil, fmt.Errorf("%s: a variable-radius set must hold exactly 1 edge, got %d (tangent chains are a follow-up)", feat, len(s.EdgeKeys))
 		}
-		out = append(out, ops.EdgeFilletRadii{Key: s.EdgeKeys[0], R0: callOrZero(s.StartRadius), R1: callOrZero(s.EndRadius)})
+		out = append(out, ops.EdgeFilletRadii{
+			Key: s.EdgeKeys[0], R0: callOrZero(s.StartRadius), R1: callOrZero(s.EndRadius),
+			Mids: midRadiiOf(s.RadiusPoints),
+		})
 	}
 	return out, nil
+}
+
+// midRadiiOf evaluates the feature-layer radius-point closures into kernel FilletRadiusPoints (#695).
+func midRadiiOf(pts []FilletRadiusPoint) []ops.FilletRadiusPoint {
+	if len(pts) == 0 {
+		return nil
+	}
+	out := make([]ops.FilletRadiusPoint, len(pts))
+	for i, p := range pts {
+		out[i] = ops.FilletRadiusPoint{T: p.T, R: callOrZero(p.Radius)}
+	}
+	return out
 }
 
 // planarizeFilletPicks re-facets a curved body for the picks' edges (remapping each pick's

--- a/model/feature/fillet_sets_test.go
+++ b/model/feature/fillet_sets_test.go
@@ -80,6 +80,34 @@ func TestFilletVariableSetThroughEngine(t *testing.T) {
 	}
 }
 
+// TestFilletRadiusPointsThroughEngine rounds one vertical edge with an intermediate
+// radius stop (0.3 → 0.7 at T=0.5 → 0.4) through the feature engine — the per-segment
+// chord-geometry volume (#695).
+func TestFilletRadiusPointsThroughEngine(t *testing.T) {
+	fs, keys := boxAndVerticalEdges(t)
+	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{{
+		EdgeKeys:     [][]byte{keys[0]},
+		StartRadius:  angleConst(0.3),
+		EndRadius:    angleConst(0.4),
+		RadiusPoints: []FilletRadiusPoint{{T: 0.5, Radius: angleConst(0.7)}},
+	}})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("radius-points fillet sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("radius-points fillet not a valid solid: %+v", r)
+	}
+	const k = 8 // chords across the 90° wedge at the holeFacets density
+	c := 1 - float64(k)/2*stdmath.Sin(stdmath.Pi/2/float64(k))
+	seg := func(ra, rb float64) float64 { return 1.0 * (ra*ra + ra*rb + rb*rb) / 3 }
+	want := 8 - c*(seg(0.3, 0.7)+seg(0.7, 0.4))
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("radius-points fillet volume = %g, want %g", got, want)
+	}
+}
+
 // TestFilletVariableSetNeedsOneEdge: a variable set over two edges is a
 // precise Sick, not a broken body.
 func TestFilletVariableSetNeedsOneEdge(t *testing.T) {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -46,12 +46,19 @@ type EdgeDressData struct {
 }
 
 // FilletSetData is one serialized fillet edge set: constant (Radius) or variable
-// (StartRadius/EndRadius over one edge).
+// (StartRadius/EndRadius over one edge, plus optional intermediate RadiusPoints, #695).
 type FilletSetData struct {
-	Edges       []string `yaml:"edges"`
-	Radius      float64  `yaml:"radius,omitempty"`
-	StartRadius float64  `yaml:"startRadius,omitempty"`
-	EndRadius   float64  `yaml:"endRadius,omitempty"`
+	Edges        []string                `yaml:"edges"`
+	Radius       float64                 `yaml:"radius,omitempty"`
+	StartRadius  float64                 `yaml:"startRadius,omitempty"`
+	EndRadius    float64                 `yaml:"endRadius,omitempty"`
+	RadiusPoints []FilletRadiusPointData `yaml:"radiusPoints,omitempty"`
+}
+
+// FilletRadiusPointData is one serialized intermediate radius stop on a variable fillet edge (#695).
+type FilletRadiusPointData struct {
+	T      float64 `yaml:"t"`
+	Radius float64 `yaml:"radius"`
 }
 
 // cornerTypeOrZero returns the fillet corner-treatment id, defaulting to 0 (miter) for an absent
@@ -70,6 +77,7 @@ func serializeFilletSets(sets []FilletEdgeSet) []FilletSetData {
 		out[i] = FilletSetData{Edges: encodeKeys(s.EdgeKeys)}
 		if s.variable() {
 			out[i].StartRadius, out[i].EndRadius = evalFloat(s.StartRadius), evalFloat(s.EndRadius)
+			out[i].RadiusPoints = serializeRadiusPoints(s.RadiusPoints)
 			continue
 		}
 		out[i].Radius = evalFloat(s.Radius)
@@ -91,8 +99,33 @@ func restoreFilletSets(sets []FilletSetData) ([]FilletEdgeSet, error) {
 			continue
 		}
 		out[i].StartRadius, out[i].EndRadius = constFloat(s.StartRadius), constFloat(s.EndRadius)
+		out[i].RadiusPoints = restoreRadiusPoints(s.RadiusPoints)
 	}
 	return out, nil
+}
+
+// serializeRadiusPoints / restoreRadiusPoints round-trip a variable fillet's intermediate
+// radius stops (#695).
+func serializeRadiusPoints(pts []FilletRadiusPoint) []FilletRadiusPointData {
+	if len(pts) == 0 {
+		return nil
+	}
+	out := make([]FilletRadiusPointData, len(pts))
+	for i, p := range pts {
+		out[i] = FilletRadiusPointData{T: p.T, Radius: evalFloat(p.Radius)}
+	}
+	return out
+}
+
+func restoreRadiusPoints(pts []FilletRadiusPointData) []FilletRadiusPoint {
+	if len(pts) == 0 {
+		return nil
+	}
+	out := make([]FilletRadiusPoint, len(pts))
+	for i, p := range pts {
+		out[i] = FilletRadiusPoint{T: p.T, Radius: constFloat(p.Radius)}
+	}
+	return out
 }
 
 // FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -90,6 +90,34 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestFilletRadiusPointsRoundTrip checks a variable fillet's intermediate radius stops survive a
+// recipe round trip (#695).
+func TestFilletRadiusPointsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{{
+		EdgeKeys:     [][]byte{[]byte("edge-v")},
+		StartRadius:  func() float64 { return 0.3 },
+		EndRadius:    func() float64 { return 0.4 },
+		RadiusPoints: []FilletRadiusPoint{{T: 0.5, Radius: func() float64 { return 0.7 }}},
+	}})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*FilletFeature).Definition()
+	if len(d.EdgeSets) != 1 {
+		t.Fatalf("edge sets after round trip = %d, want 1", len(d.EdgeSets))
+	}
+	pts := d.EdgeSets[0].RadiusPoints
+	if len(pts) != 1 || pts[0].T != 0.5 || pts[0].Radius() != 0.7 {
+		t.Errorf("radius points = %+v, want [{T:0.5 R:0.7}]", pts)
+	}
+}
+
 // TestFaceFilletRoundTrip checks the face-fillet feature's two face sets + radius survive a recipe
 // round trip (#694).
 func TestFaceFilletRoundTrip(t *testing.T) {


### PR DESCRIPTION
## What

Adds **intermediate radius set points** to the variable-radius edge fillet (#695). A variable fillet could only interpolate linearly between a start and an end radius; this lets the radius pass through arbitrary `(position, radius)` stops along the edge — Inventor's `FilletVariableRadiusEdgeSet` set-point parity.

## Why

The linear start→end variable fillet (#323) is a strict subset of the reference behaviour. Designers shape a varying round by placing several radius stops along an edge (e.g. a handle that swells in the middle); a single end-to-end ramp can't express that.

## How

- **Kernel** (`kernel/ops`): `EdgeFilletRadii` gains `Mids []FilletRadiusPoint{T, R}`. The varying blend rules its exactly-planar strips through the whole profile chain `[c0, mids…, c1]` instead of just `c0→c1`. Crucially, each mid station splits the two adjacent faces' tangent lines, so those faces' filleted-edge boundary is subdivided at each mid tangent point (`putEdgeInserts`/`addEdgeInserts`) — otherwise the strips leave boundary edges and the body isn't a solid. Points are validated `0<T<1`, `R>0`, strictly increasing in `T`.
- **Feature** (`model/feature`): `FilletEdgeSet.RadiusPoints []FilletRadiusPoint`, evaluated into kernel points at recompute.
- **Persistence**: `radiusPoints` round-trips in the fillet recipe codec.
- **MCP**: the `fillet` op's `edgeSets[].radiusPoints` — reachable over the bridge with **no public-API change** (kernel/opregistry only).

The removed volume remains the exact per-segment chord integral `Σ Lₛ·(rₐ²+rₐrᵦ+rᵦ²)/3`, so the planar tessellation stays exact (asserted to `1e-9`).

## Tests

- `kernel/ops`: piecewise-radius volume (exact), validation rejections, planarity (existing) still green.
- `model/feature`: variable fillet with a mid stop through the engine (valid solid + exact volume); recipe round-trip of `radiusPoints`.
- `addin/opregistry`: `edgeSets[].radiusPoints` through the registry apply path.
- `go test ./kernel/ops ./model/feature ./addin/opregistry` green; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)