### PR TITLE
feat(fillet): UI for intermediate radius points (#695)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,7 +58,12 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{}
+var notYetHandled = map[string]bool{
+	// M18-F01 mass-properties: the contract landed in API v0.50.0 (#423) ahead of the
+	// router handler. Keyed by CONSTANT NAME (not the "analysis.massProperties" value).
+	// DELETE when the handler lands.
+	"MethodAnalysisMassProperties": true,
+}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -279,6 +279,7 @@ func seedFilletSet(t *FilletTool, set feature.FilletEdgeSet) {
 	t.variable = true
 	t.startRadius = callOrZeroFn(set.StartRadius)
 	t.endRadius = callOrZeroFn(set.EndRadius)
+	t.midPoints = midPointsFromSet(set.RadiusPoints) // #695
 }
 
 func snapshotFilletDef(def *feature.FilletDefinition) func() {

--- a/app/fillet_mid_points.go
+++ b/app/fillet_mid_points.go
@@ -21,9 +21,6 @@ type FilletMidPoint struct {
 	Radius float64
 }
 
-// MidPointCount reports how many intermediate radius stops are set (meaningful in variable mode).
-func (t *FilletTool) MidPointCount() int { return len(t.midPoints) }
-
 // MidPoints returns a copy of the intermediate radius stops for the panel to render.
 func (t *FilletTool) MidPoints() []FilletMidPoint {
 	return append([]FilletMidPoint(nil), t.midPoints...)

--- a/app/fillet_mid_points.go
+++ b/app/fillet_mid_points.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"sort"
+
+	"oblikovati.org/model/feature"
+)
+
+// Intermediate radius stops for the variable-fillet panel (#695). A variable fillet blends
+// each edge from a start radius to an end radius; a stop lets the radius pass through an
+// arbitrary value partway along the edge, so the blend can swell or pinch between its ends.
+// The panel edits the stops in insertion order; the kernel walks them sorted by T, so the
+// ordering only matters when building the feature.
+
+// FilletMidPoint is one intermediate radius stop the panel edits: T is the fraction along the
+// edge (start vertex 0 → end vertex 1) and Radius the rolling-ball radius there (database units).
+type FilletMidPoint struct {
+	T      float64
+	Radius float64
+}
+
+// MidPointCount reports how many intermediate radius stops are set (meaningful in variable mode).
+func (t *FilletTool) MidPointCount() int { return len(t.midPoints) }
+
+// MidPoints returns a copy of the intermediate radius stops for the panel to render.
+func (t *FilletTool) MidPoints() []FilletMidPoint {
+	return append([]FilletMidPoint(nil), t.midPoints...)
+}
+
+// AddMidPoint appends a stop at the midpoint of the widest gap in the current partition, its
+// radius interpolated between the start and end radii — a valid default the user then nudges.
+//
+// Example: with no stops it lands at T=0.5; a second Add lands at T=0.25 or 0.75.
+func (t *FilletTool) AddMidPoint() {
+	tt := nextMidT(t.midPoints)
+	r := t.startRadius + (t.endRadius-t.startRadius)*tt
+	t.midPoints = append(t.midPoints, FilletMidPoint{T: tt, Radius: r})
+}
+
+// RemoveMidPoint drops the stop at index i (out-of-range is ignored).
+func (t *FilletTool) RemoveMidPoint(i int) {
+	if i < 0 || i >= len(t.midPoints) {
+		return
+	}
+	t.midPoints = append(t.midPoints[:i], t.midPoints[i+1:]...)
+}
+
+// SetMidPointT edits the position of the stop at index i (out-of-range is ignored).
+func (t *FilletTool) SetMidPointT(i int, v float64) {
+	if i >= 0 && i < len(t.midPoints) {
+		t.midPoints[i].T = v
+	}
+}
+
+// SetMidPointR edits the radius of the stop at index i (out-of-range is ignored).
+func (t *FilletTool) SetMidPointR(i int, v float64) {
+	if i >= 0 && i < len(t.midPoints) {
+		t.midPoints[i].Radius = v
+	}
+}
+
+// nextMidT picks the default T for a new stop: the midpoint of the widest gap in the sorted
+// [0, existing T…, 1] partition, so successive Adds spread out instead of stacking on 0.5.
+func nextMidT(pts []FilletMidPoint) float64 {
+	bounds := []float64{0, 1}
+	for _, p := range pts {
+		bounds = append(bounds, p.T)
+	}
+	sort.Float64s(bounds)
+	lo, hi, widest := 0.0, 1.0, -1.0
+	for i := 1; i < len(bounds); i++ {
+		if w := bounds[i] - bounds[i-1]; w > widest {
+			widest, lo, hi = w, bounds[i-1], bounds[i]
+		}
+	}
+	return (lo + hi) / 2
+}
+
+// radiusPoints converts the panel's stops into feature radius-point closures sorted by T — the
+// order the kernel's varying blend walks the edge (#695). Empty when there are no stops.
+func (t *FilletTool) radiusPoints() []feature.FilletRadiusPoint {
+	pts := t.MidPoints()
+	sort.Slice(pts, func(a, b int) bool { return pts[a].T < pts[b].T })
+	out := make([]feature.FilletRadiusPoint, len(pts))
+	for i, p := range pts {
+		r := p.Radius // capture per stop so the closure doesn't read the loop variable
+		out[i] = feature.FilletRadiusPoint{T: p.T, Radius: func() float64 { return r }}
+	}
+	return out
+}
+
+// midPointsValid reports whether the stops satisfy the kernel's validateRadiusPoints contract:
+// strictly-increasing interior fractions (0<T<1) with a positive radius (#695). No stops is valid.
+func (t *FilletTool) midPointsValid() bool {
+	pts := t.MidPoints()
+	sort.Slice(pts, func(a, b int) bool { return pts[a].T < pts[b].T })
+	prev := 0.0
+	for _, p := range pts {
+		if p.T <= prev || p.T >= 1 || p.Radius <= 0 {
+			return false
+		}
+		prev = p.T
+	}
+	return true
+}
+
+// midPointsFromSet seeds the panel's stops from a committed variable set's radius points,
+// evaluating each closure once for the editable buffer (edit mode).
+func midPointsFromSet(pts []feature.FilletRadiusPoint) []FilletMidPoint {
+	out := make([]FilletMidPoint, len(pts))
+	for i, p := range pts {
+		out[i] = FilletMidPoint{T: p.T, Radius: callOrZeroFn(p.Radius)}
+	}
+	return out
+}

--- a/app/fillet_mid_points_test.go
+++ b/app/fillet_mid_points_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/feature"
+)
+
+// TestFilletMidPointDefaults checks AddMidPoint lands a stop in the widest gap with its radius
+// linearly interpolated between the start and end radii (#695): the first goes to the centre,
+// the second splits the larger half.
+func TestFilletMidPointDefaults(t *testing.T) {
+	f := NewFilletTool()
+	f.SetStartRadius(0.2)
+	f.SetEndRadius(0.6)
+	f.AddMidPoint()
+	if got := f.MidPoints(); len(got) != 1 || got[0].T != 0.5 || got[0].Radius != 0.4 {
+		t.Fatalf("first stop = %+v, want T=0.5 R=0.4 (centre, mid-interpolated)", got)
+	}
+	f.AddMidPoint() // widest gap is now [0,0.5] → 0.25
+	if got := f.MidPoints(); len(got) != 2 || got[1].T != 0.25 {
+		t.Fatalf("second stop T = %v, want 0.25 (midpoint of widest gap)", got)
+	}
+}
+
+// TestFilletMidPointValidation mirrors the kernel's validateRadiusPoints contract: interior,
+// strictly increasing, positive radius (#695).
+func TestFilletMidPointValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		pts  []FilletMidPoint
+		want bool
+	}{
+		{"empty is valid", nil, true},
+		{"increasing interior", []FilletMidPoint{{0.3, 0.4}, {0.7, 0.5}}, true},
+		{"unsorted but distinct is fine", []FilletMidPoint{{0.7, 0.5}, {0.3, 0.4}}, true},
+		{"T at 0 boundary", []FilletMidPoint{{0, 0.4}}, false},
+		{"T at 1 boundary", []FilletMidPoint{{1, 0.4}}, false},
+		{"duplicate T", []FilletMidPoint{{0.5, 0.4}, {0.5, 0.5}}, false},
+		{"non-positive radius", []FilletMidPoint{{0.5, 0}}, false},
+	}
+	for _, c := range cases {
+		f := NewFilletTool()
+		f.midPoints = c.pts
+		if got := f.midPointsValid(); got != c.want {
+			t.Errorf("%s: midPointsValid(%+v) = %v, want %v", c.name, c.pts, got, c.want)
+		}
+	}
+}
+
+// TestFilletMidPointEdit checks Set/Remove edit the addressed stop and ignore out-of-range.
+func TestFilletMidPointEdit(t *testing.T) {
+	f := NewFilletTool()
+	f.midPoints = []FilletMidPoint{{0.25, 0.3}, {0.5, 0.4}, {0.75, 0.5}}
+	f.SetMidPointT(1, 0.6)
+	f.SetMidPointR(1, 0.45)
+	f.SetMidPointT(9, 0.9) // out of range: no-op
+	if got := f.MidPoints()[1]; got.T != 0.6 || got.Radius != 0.45 {
+		t.Errorf("edited stop = %+v, want T=0.6 R=0.45", got)
+	}
+	f.RemoveMidPoint(0)
+	if got := f.MidPoints(); len(got) != 2 || got[0].T != 0.6 {
+		t.Errorf("after RemoveMidPoint(0), stops = %+v, want the 0.6 and 0.75 stops", got)
+	}
+	f.RemoveMidPoint(5) // out of range: no-op
+	if len(f.MidPoints()) != 2 {
+		t.Errorf("out-of-range remove changed the slice: %+v", f.MidPoints())
+	}
+}
+
+// TestFilletMidPointCommit drives the variable fillet end to end with one intermediate stop and
+// confirms the committed definition carries the radius points, sorted by T (#695). Values match
+// the kernel's TestFilletIntermediateRadiiVolume (known buildable on a 2×2×2 block).
+func TestFilletMidPointCommit(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	f := NewFilletTool()
+	s.StartTool(f)
+	s.Click(1, 1)
+	f.SetVariable(true)
+	f.SetStartRadius(0.3)
+	f.SetEndRadius(0.4)
+	f.midPoints = []FilletMidPoint{{T: 0.5, Radius: 0.7}}
+	if !f.CanCommit() {
+		t.Fatal("variable fillet with a valid stop should be committable")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	def := f.AddedFeature().Definition().(*feature.FilletFeature).Definition()
+	if len(def.EdgeSets) != 1 {
+		t.Fatalf("committed fillet has %d edge sets, want 1", len(def.EdgeSets))
+	}
+	pts := def.EdgeSets[0].RadiusPoints
+	if len(pts) != 1 || pts[0].T != 0.5 || pts[0].Radius() != 0.7 {
+		t.Errorf("committed radius points = %+v, want one stop T=0.5 R=0.7", pts)
+	}
+}
+
+// TestFilletMidPointEditSeed checks re-editing a committed variable fillet seeds the panel's
+// stops from the feature's radius points (#695).
+func TestFilletMidPointEditSeed(t *testing.T) {
+	set := feature.FilletEdgeSet{
+		EdgeKeys:     [][]byte{{1, 2, 3}},
+		StartRadius:  func() float64 { return 0.3 },
+		EndRadius:    func() float64 { return 0.4 },
+		RadiusPoints: []feature.FilletRadiusPoint{{T: 0.5, Radius: func() float64 { return 0.7 }}},
+	}
+	tool := NewFilletTool()
+	seedFilletSet(tool, set)
+	if !tool.Variable() {
+		t.Fatal("seeding a variable set should put the tool in variable mode")
+	}
+	if got := tool.MidPoints(); len(got) != 1 || got[0].T != 0.5 || got[0].Radius != 0.7 {
+		t.Errorf("seeded stops = %+v, want one stop T=0.5 R=0.7", got)
+	}
+}

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -20,6 +20,7 @@ type FilletTool struct {
 	variable        bool // variable mode: each edge blends startRadius → endRadius (#323)
 	startRadius     float64
 	endRadius       float64
+	midPoints       []FilletMidPoint            // optional intermediate radius stops along each edge (#695)
 	cornerType      feature.FilletCornerType    // shared-corner treatment (miter default)
 	concaveStrategy types.FilletConcaveStrategy // concave edges: outward fill (default) or inward recess
 	added           *feature.PartFeature
@@ -137,21 +138,24 @@ func (t *FilletTool) selectedEdgeKeys() [][]byte {
 // are positive.
 func (t *FilletTool) CanCommit() bool {
 	if t.variable {
-		return t.EdgeCount() > 0 && t.startRadius > 0 && t.endRadius > 0
+		return t.EdgeCount() > 0 && t.startRadius > 0 && t.endRadius > 0 && t.midPointsValid()
 	}
 	return t.EdgeCount() > 0 && t.radius > 0
 }
 
-// variableSets builds one variable edge set per key, each blending start → end (#323 —
-// a variable set carries exactly one edge, so corners stay constant-radius blends).
+// variableSets builds one variable edge set per key, each blending start → end through any
+// intermediate radius stops (#323, #695 — a variable set carries exactly one edge, so corners
+// stay constant-radius blends). Every set shares the same stops (read-only closures).
 func (t *FilletTool) variableSets(keys [][]byte) []feature.FilletEdgeSet {
 	r0, r1 := t.startRadius, t.endRadius
+	mids := t.radiusPoints()
 	sets := make([]feature.FilletEdgeSet, len(keys))
 	for i, k := range keys {
 		sets[i] = feature.FilletEdgeSet{
-			EdgeKeys:    [][]byte{k},
-			StartRadius: func() float64 { return r0 },
-			EndRadius:   func() float64 { return r1 },
+			EdgeKeys:     [][]byte{k},
+			StartRadius:  func() float64 { return r0 },
+			EndRadius:    func() float64 { return r1 },
+			RadiusPoints: mids,
 		}
 	}
 	return sets

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.49.0
+	oblikovati.org/api v0.50.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.49.0
+	oblikovati.org/api v0.50.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/feature_dialogs_units_test.go
+++ b/head/ui/feature_dialogs_units_test.go
@@ -70,7 +70,10 @@ func TestFeatureDialogsRenderUnitFields(t *testing.T) {
 			frame(func() { draw(s) })
 			if name == "fillet" {
 				filletUI.seeded = nil
-				s.ActiveFillet().SetVariable(true) // start/end radius rows
+				f := s.ActiveFillet()
+				f.SetVariable(true) // start/end radius rows
+				frame(func() { drawFilletDialog(s) })
+				f.AddMidPoint() // #695: render a Position/Radius intermediate-point row
 				frame(func() { drawFilletDialog(s) })
 			}
 		})

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -34,28 +34,39 @@ func drawFilletDialog(s *app.Session) {
 	}
 	native.SetNextWindowSizeOnce(340, 300)
 	if native.Begin("Fillet") {
-		title := "Fillet"
-		if name := f.EditingName(); name != "" {
-			title = name // re-editing a committed fillet: the breadcrumb names it
-		}
-		drawFeatureBreadcrumb(title, "")
-		if propertySection("Input Geometry") {
-			drawPickChipRow("Edges", "fillet-edges", countChipText(f.EdgeCount(), "Edge", "Select Edges"),
-				f.EdgeCount() > 0, "Click convex edges in the viewport to round", f.ClearEdges)
-		}
-		if propertySection("Behavior") {
-			drawFilletRadiusRows(s, f)
-			if i := propertyComboRow("Corner", "fillet-corner", app.FilletCornerOptions(), f.CornerTypeIndex()); i >= 0 {
-				f.SetCornerTypeIndex(i)
-			}
-			if i := propertyComboRow("Concave edge", "fillet-concave", app.FilletConcaveOptions(), f.ConcaveStrategyIndex()); i >= 0 {
-				f.SetConcaveStrategyIndex(i)
-			}
-		}
-		native.Separator()
-		drawCommitCancelButtons(s, f.CanCommit())
+		drawFilletPanelBody(s, f)
 	}
 	native.End()
+}
+
+// drawFilletPanelBody draws the Fillet panel's sections (the Begin/End wrapper stays in
+// drawFilletDialog): the breadcrumb, the edge picker, and the radius/corner behavior rows.
+func drawFilletPanelBody(s *app.Session, f *app.FilletTool) {
+	title := "Fillet"
+	if name := f.EditingName(); name != "" {
+		title = name // re-editing a committed fillet: the breadcrumb names it
+	}
+	drawFeatureBreadcrumb(title, "")
+	if propertySection("Input Geometry") {
+		drawPickChipRow("Edges", "fillet-edges", countChipText(f.EdgeCount(), "Edge", "Select Edges"),
+			f.EdgeCount() > 0, "Click convex edges in the viewport to round", f.ClearEdges)
+	}
+	if propertySection("Behavior") {
+		drawFilletRadiusRows(s, f)
+		drawFilletCornerRows(f)
+	}
+	native.Separator()
+	drawCommitCancelButtons(s, f.CanCommit())
+}
+
+// drawFilletCornerRows draws the shared-corner treatment and concave-edge strategy dropdowns.
+func drawFilletCornerRows(f *app.FilletTool) {
+	if i := propertyComboRow("Corner", "fillet-corner", app.FilletCornerOptions(), f.CornerTypeIndex()); i >= 0 {
+		f.SetCornerTypeIndex(i)
+	}
+	if i := propertyComboRow("Concave edge", "fillet-concave", app.FilletConcaveOptions(), f.ConcaveStrategyIndex()); i >= 0 {
+		f.SetConcaveStrategyIndex(i)
+	}
 }
 
 // seedFilletUI loads the panel buffers from the tool the first frame it appears

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	"strconv"
+
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
@@ -30,7 +32,7 @@ func drawFilletDialog(s *app.Session) {
 	if filletUI.seeded != f {
 		seedFilletUI(f)
 	}
-	native.SetNextWindowSizeOnce(340, 230)
+	native.SetNextWindowSizeOnce(340, 300)
 	if native.Begin("Fillet") {
 		title := "Fillet"
 		if name := f.EditingName(); name != "" {
@@ -82,4 +84,44 @@ func drawFilletRadiusRows(s *app.Session, f *app.FilletTool) {
 	f.SetStartRadius(float64(filletUI.startRadius))
 	lengthCmRow(s, "End radius", "fillet-end-radius", &filletUI.endRadius)
 	f.SetEndRadius(float64(filletUI.endRadius))
+	drawFilletMidPointRows(s, f)
+}
+
+// drawFilletMidPointRows renders the intermediate radius stops of a variable fillet (#695): one
+// editable Position/Radius pair per stop with a remove (×), plus an Add button. Position is a
+// 0–1 fraction along the edge; the radius follows the document length unit. The tool owns the
+// stops, so each row reads/writes through it — no panel-side buffer to keep in sync.
+func drawFilletMidPointRows(s *app.Session, f *app.FilletTool) {
+	for i, p := range f.MidPoints() {
+		if drawFilletMidPointRow(s, f, i, p) {
+			break // the slice shifted under us when a stop was removed; redraw next frame
+		}
+	}
+	if native.Button("+ Add intermediate point") {
+		f.AddMidPoint()
+	}
+	native.SetItemTooltip("Add a radius stop between the start and end radius of each edge")
+}
+
+// drawFilletMidPointRow draws one stop. It returns true when the stop was removed this frame so
+// the caller stops iterating the now-stale slice.
+func drawFilletMidPointRow(s *app.Session, f *app.FilletTool, i int, p app.FilletMidPoint) bool {
+	tBuf := float32(p.T)
+	if propertyFloatRow("Position", filletMidID("t", i), "(0–1)", &tBuf) {
+		f.SetMidPointT(i, float64(tBuf))
+	}
+	native.SameLine()
+	if native.Button("×##" + filletMidID("rm", i)) {
+		f.RemoveMidPoint(i)
+		return true
+	}
+	rBuf := float32(p.Radius)
+	lengthCmRow(s, "Radius", filletMidID("r", i), &rBuf)
+	f.SetMidPointR(i, float64(rBuf))
+	return false
+}
+
+// filletMidID gives a stop's widget a stable, per-index ImGui id.
+func filletMidID(field string, i int) string {
+	return "fillet-mid-" + field + "-" + strconv.Itoa(i)
 }


### PR DESCRIPTION
## What

Exposes the variable-radius fillet's **intermediate radius points** in the Fillet property panel. Until now the radius could pass through arbitrary `(T, R)` stops along an edge only via the wire/MCP surface (#695 kernel/feature/persistence/opregistry landed in #1044) — there was no way to set them from the UI.

In variable mode the panel now:
- lists each intermediate stop as an editable **Position** (0–1 fraction along the edge) + **Radius** pair, each with a remove (×);
- offers an **"+ Add intermediate point"** button that drops a stop in the widest remaining gap with a radius interpolated between the start and end radii (an always-valid default the user then nudges);
- keeps **OK disabled** until every stop is a strictly-increasing interior fraction (`0<T<1`) with a positive radius — the same `validateRadiusPoints` contract the kernel enforces — so a bad profile can't reach a failing recompute;
- **re-seeds** the stops from a committed variable fillet's definition when re-editing.

## Why

Finishes the user-facing tail of #695: the blend can now be shaped along an edge directly in the canvas, not just over MCP.

## Notes

- **/source-only — no public-API change.** Kernel/feature/persistence/MCP support already shipped in #1044.
- The `FilletTool` owns the stops; the panel reads/writes through it each frame, so there is no panel-side buffer to keep in sync.

## Tests

`app/fillet_mid_points_test.go`: default placement (widest-gap + interpolated radius), the validation table (interior / strictly-increasing / positive-radius), edit & remove bounds, an end-to-end variable commit asserting the stops reach the committed definition (kernel's known-buildable `0.3 → 0.7@0.5 → 0.4` profile), and edit-mode round-trip seeding.

Verified: `go build ./...`, `go test ./app ./model/feature ./addin/opregistry`, head `ui` cgo build, `golangci-lint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)