### PR TITLE
test(router): drop stale massProperties allowlist entry (#423)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,12 +58,7 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{
-	// M18-F01 mass-properties: the contract landed in API v0.50.0 (#423) ahead of the
-	// router handler. Keyed by CONSTANT NAME (not the "analysis.massProperties" value).
-	// DELETE when the handler lands.
-	"MethodAnalysisMassProperties": true,
-}
+var notYetHandled = map[string]bool{}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They


### PR DESCRIPTION
## What

Removes `MethodAnalysisMassProperties` from the `notYetHandled` parity allowlist in `addin/router/api_parity_test.go`.

## Why

`#1048` added that entry because API v0.50.0 declared `analysis.massProperties` ahead of its router handler. **`#1047` (mass-properties) then merged the handler** (`addin/router/analysis.go`). Because the two PRs interleaved, develop's HEAD now has **both** the handler and the allowlist entry — and `TestEveryWireMethodHasAHandler` fails on a now-handled allowlist entry (the allowlist may only shrink):

```
api_parity_test.go:52: method "MethodAnalysisMassProperties" is now handled — delete it from notYetHandled
```

Deleting the entry is the documented "shrink the allowlist when the handler lands" step. Restores develop to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)