### PR TITLE
feat(fillet): Face Fillet UI tool + panel (#694)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -468,12 +468,7 @@ func cutFeatureCommands() []*CommandDefinition {
 		}).WithTab(tab3DModel).WithEnable(notInSketch).
 			WithIcon("chamfer").WithButtonStyle(LargeIconButton).
 			WithTooltip("Chamfer — bevel selected edges by a setback distance."),
-		NewCommand("Modify.Fillet", "Fillet", "Modify", func(s *Session) error {
-			s.StartTool(NewFilletTool())
-			return nil
-		}).WithTab(tab3DModel).WithAlias("F").WithEnable(notInSketch).
-			WithIcon("fillet").WithButtonStyle(LargeIconButton).
-			WithTooltip("Fillet — round selected convex edges with a rolling-ball radius."),
+		filletCommand(),
 		NewCommand("Modify.Thread", "Thread", "Modify", func(s *Session) error {
 			s.StartTool(NewThreadTool())
 			return nil
@@ -481,6 +476,26 @@ func cutFeatureCommands() []*CommandDefinition {
 			WithIcon("thread").WithButtonStyle(LargeIconButton).
 			WithTooltip("Thread — apply a cosmetic or modeled-cut thread to a cylindrical face (ISO/ANSI/JIS)."),
 	}
+}
+
+// filletCommand is the Fillet split button: the primary rounds picked edges (Edge Fillet), and
+// the dropdown adds Face Fillet — rounding the edges shared between two face sets (#694), the way
+// Inventor groups the fillet variants under one command. Only the primary is returned;
+// RegisterStandardCommands registers the variant for id dispatch by walking primary.Variants().
+func filletCommand() *CommandDefinition {
+	faceFillet := NewCommand("Modify.FaceFillet", "Face Fillet", "Modify", func(s *Session) error {
+		s.StartTool(NewFaceFilletTool())
+		return nil
+	}).WithTab(tab3DModel).WithEnable(notInSketch).
+		WithIcon("fillet").WithButtonStyle(LargeIconButton).
+		WithTooltip("Face Fillet — round the edges shared between two sets of faces.")
+	return NewCommand("Modify.Fillet", "Fillet", "Modify", func(s *Session) error {
+		s.StartTool(NewFilletTool())
+		return nil
+	}).WithTab(tab3DModel).WithAlias("F").WithEnable(notInSketch).
+		WithIcon("fillet").WithButtonStyle(LargeIconButton).
+		WithTooltip("Fillet — round selected convex edges with a rolling-ball radius.").
+		WithVariants(faceFillet)
 }
 
 // localFaceCommands are the F04 local face operations — the metric edits (shell, offset

--- a/app/face_fillet_session.go
+++ b/app/face_fillet_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Face Fillet tool's property window.
+
+// ActiveFaceFillet returns the running Face Fillet tool, or nil when the active tool is not a
+// face fillet (or there is none).
+func (s *Session) ActiveFaceFillet() *FaceFilletTool {
+	if s.tool == nil {
+		return nil
+	}
+	f, _ := s.tool.tool.(*FaceFilletTool)
+	return f
+}

--- a/app/face_fillet_tool.go
+++ b/app/face_fillet_tool.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// FaceFilletTool is the interactive Face Fillet command (#694): pick two sets of faces, set the
+// blend radius, and OK to round every edge shared between the two sets. Selecting by face — rather
+// than edge — is the natural choice when a long chain of edges separates two regions. Picks land in
+// the ACTIVE set (Face Set 1 by default); arm the other set from the panel to extend it.
+type FaceFilletTool struct {
+	featureEditMode // set ⇒ this panel re-edits a committed face fillet (see editFaceFilletTool)
+	setA, setB      []FaceHandle
+	seededKeysA     [][]byte // edit mode: the retained face keys per set (their faces are consumed, so no live handles exist)
+	seededKeysB     [][]byte
+	activeSet       int // 0 = set A, 1 = set B — which set a pick extends
+	radius          float64
+	added           *feature.PartFeature
+}
+
+// NewFaceFilletTool returns a face-fillet tool with a default 1-unit radius and Face Set 1 active.
+func NewFaceFilletTool() *FaceFilletTool { return &FaceFilletTool{radius: 1} }
+
+// Name implements [Tool].
+func (t *FaceFilletTool) Name() string { return "Face Fillet" }
+
+// Start sets the selection filter to faces so clicks pick faces to round between.
+func (t *FaceFilletTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+
+// Pick appends the clicked face to the active set, ignoring a face already in either set.
+func (t *FaceFilletTool) Pick(_ *Session, sel Selectable) {
+	f, ok := sel.(FaceHandle)
+	if !ok || t.hasFace(f) {
+		return
+	}
+	if t.activeSet == 1 {
+		t.setB = append(t.setB, f)
+		return
+	}
+	t.setA = append(t.setA, f)
+}
+
+// hasFace reports whether the face is already picked into either set.
+func (t *FaceFilletTool) hasFace(f FaceHandle) bool {
+	return faceSetHas(t.setA, f) || faceSetHas(t.setB, f)
+}
+
+// faceSetHas reports whether set already contains f.
+func faceSetHas(set []FaceHandle, f FaceHandle) bool {
+	for _, h := range set {
+		if h == f {
+			return true
+		}
+	}
+	return false
+}
+
+// ArmSetA / ArmSetB choose which set the next picks extend (the panel's two selector chips).
+func (t *FaceFilletTool) ArmSetA() { t.activeSet = 0 }
+func (t *FaceFilletTool) ArmSetB() { t.activeSet = 1 }
+
+// ActiveSet reports which face set picks currently extend (0 = set A, 1 = set B).
+func (t *FaceFilletTool) ActiveSet() int { return t.activeSet }
+
+// CountA / CountB count each set's faces: the retained keys (edit mode) plus this session's picks.
+func (t *FaceFilletTool) CountA() int { return len(t.seededKeysA) + len(t.setA) }
+func (t *FaceFilletTool) CountB() int { return len(t.seededKeysB) + len(t.setB) }
+
+// Faces returns every picked face (both sets) so the viewport highlight (toolPicks) lights them.
+func (t *FaceFilletTool) Faces() []FaceHandle {
+	return append(append([]FaceHandle(nil), t.setA...), t.setB...)
+}
+
+// SetRadius / Radius set the blend radius (database units).
+func (t *FaceFilletTool) SetRadius(r float64) { t.radius = r }
+func (t *FaceFilletTool) Radius() float64     { return t.radius }
+
+// ClearSetA / ClearSetB empty a set — the panel's selector clear (×) — including any retained keys.
+func (t *FaceFilletTool) ClearSetA() { t.setA, t.seededKeysA = nil, nil }
+func (t *FaceFilletTool) ClearSetB() { t.setB, t.seededKeysB = nil, nil }
+
+// keysA / keysB are the reference-key set a commit writes per set: retained keys plus this
+// session's picks.
+func (t *FaceFilletTool) keysA() [][]byte { return appendFaceKeys(cloneKeys(t.seededKeysA), t.setA) }
+func (t *FaceFilletTool) keysB() [][]byte { return appendFaceKeys(cloneKeys(t.seededKeysB), t.setB) }
+
+// appendFaceKeys appends the reference keys of picked faces onto keys.
+func appendFaceKeys(keys [][]byte, faces []FaceHandle) [][]byte {
+	for _, f := range faces {
+		keys = append(keys, f.Face.ReferenceKey())
+	}
+	return keys
+}
+
+// CanCommit reports whether both sets have at least one face and the radius is positive.
+func (t *FaceFilletTool) CanCommit() bool {
+	return t.CountA() > 0 && t.CountB() > 0 && t.radius > 0
+}
+
+// Commit rounds the edges shared between the two face sets and recomputes; a sick feature (the
+// sets share no edge, or a radius the geometry can't take) keeps the tool open via an error.
+func (t *FaceFilletTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = t.addFaceFillet(feature.NewDressUpFeatures(part.Features()))
+	part.Recompute()
+	s.recordEdit(part, "Face Fillet")
+	if !t.added.Health().OK() {
+		return errors.New("face fillet: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// addFaceFillet appends the face fillet between the two sets — shared by Commit and the preview.
+func (t *FaceFilletTool) addFaceFillet(dress *feature.DressUpFeatures) *feature.PartFeature {
+	r := t.radius
+	return dress.AddFaceFillet(t.keysA(), t.keysB(), func() float64 { return r })
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *FaceFilletTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached face fillet the viewport previews before commit (the same
+// addFaceFillet the commit uses, so the translucent ghost is exactly what OK creates).
+func (t *FaceFilletTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFaceFillet(feature.NewDressUpFeatures(fs)), nil
+	})
+}
+
+// commitEdit writes the panel state back into the committed face fillet's definition.
+func (t *FaceFilletTool) commitEdit(s *Session) error {
+	r := t.radius
+	def := t.target.Definition().(*feature.FaceFilletFeature).Definition()
+	def.FaceKeysA, def.FaceKeysB, def.Radius = t.keysA(), t.keysB(), func() float64 { return r }
+	return commitFeatureEdit(s, t.target)
+}
+
+// Prompt guides the user through the face-fillet steps.
+func (t *FaceFilletTool) Prompt(*Session) string {
+	switch {
+	case t.CountA() == 0:
+		return "Click the first set of faces"
+	case t.CountB() == 0:
+		return "Arm Face Set 2, then click the second set of faces"
+	default:
+		return "Set the radius, then click OK"
+	}
+}
+
+// Cancel restores the default selection filter, or aborts the edit when re-editing.
+func (t *FaceFilletTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}

--- a/app/face_fillet_tool_test.go
+++ b/app/face_fillet_tool_test.go
@@ -131,6 +131,101 @@ func TestFaceFilletEditSeed(t *testing.T) {
 	}
 }
 
+// TestFaceFilletToolPromptAndName covers the tool's name and the step-by-step prompt, and the
+// non-edit Cancel path (restores the default selection filter).
+func TestFaceFilletToolPromptAndName(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	tool := NewFaceFilletTool()
+	s.StartTool(tool)
+	if tool.Name() != "Face Fillet" {
+		t.Errorf("Name = %q, want Face Fillet", tool.Name())
+	}
+	if s.ActiveFaceFillet() != tool {
+		t.Error("ActiveFaceFillet did not return the running tool")
+	}
+	if got := tool.Prompt(s); got != "Click the first set of faces" {
+		t.Errorf("prompt with no faces = %q", got)
+	}
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	if got := tool.Prompt(s); got != "Arm Face Set 2, then click the second set of faces" {
+		t.Errorf("prompt with set A only = %q", got)
+	}
+	tool.ArmSetB()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	if got := tool.Prompt(s); got != "Set the radius, then click OK" {
+		t.Errorf("prompt with both sets = %q", got)
+	}
+	tool.Cancel(s) // non-edit: restores the default selection filter
+}
+
+// TestFaceFilletDraftPreview checks the viewport draft is offered only once both sets and a
+// positive radius are set.
+func TestFaceFilletDraftPreview(t *testing.T) {
+	s, tool := pickFaceFilletSets(t)
+	tool.SetRadius(0)
+	if _, ok := tool.DraftFeature(s); ok {
+		t.Error("draft offered with a zero radius")
+	}
+	tool.SetRadius(0.3)
+	if _, ok := tool.DraftFeature(s); !ok {
+		t.Error("no draft preview after both sets + radius")
+	}
+}
+
+// TestFaceFilletCommitEdit re-edits a committed face fillet with a new radius and re-commits,
+// covering the edit-write path.
+func TestFaceFilletCommitEdit(t *testing.T) {
+	s, tool := pickFaceFilletSets(t)
+	tool.SetRadius(0.3)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	pf := tool.AddedFeature()
+	et := editFaceFilletTool(pf, pf.Definition().(*feature.FaceFilletFeature))
+	s.StartTool(et)
+	et.SetRadius(0.4)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit edit: %v", err)
+	}
+	if got := pf.Definition().(*feature.FaceFilletFeature).Definition().Radius(); got != 0.4 {
+		t.Errorf("edited radius = %g, want 0.4", got)
+	}
+}
+
+// TestFaceFilletCancelEdit cancels an in-progress edit, covering the edit-abort branch of Cancel.
+func TestFaceFilletCancelEdit(t *testing.T) {
+	s, tool := pickFaceFilletSets(t)
+	tool.SetRadius(0.3)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	pf := tool.AddedFeature()
+	et := editFaceFilletTool(pf, pf.Definition().(*feature.FaceFilletFeature))
+	s.StartTool(et)
+	et.Cancel(s) // edit branch: restore the original definition
+	if !pf.Health().OK() {
+		t.Error("cancelling the edit should leave the feature healthy")
+	}
+}
+
+// TestFaceFilletNonAdjacentErrors keeps the tool open with a notice when the two sets share no
+// edge (parallel top/bottom faces) — the non-adjacent case is not yet supported.
+func TestFaceFilletNonAdjacentErrors(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	tool := NewFaceFilletTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	tool.ArmSetB()
+	tool.Pick(s, FaceHandle{Face: lowestFaceOf(t, block), Body: block})
+	tool.SetRadius(0.3)
+	if err := s.OK(); err == nil {
+		t.Fatal("face fillet between parallel faces sharing no edge should fail")
+	}
+	if s.ActiveTool() == nil {
+		t.Error("a failed commit should keep the tool open")
+	}
+}
+
 // TestFaceFilletViaRibbonCommand checks the Face Fillet command (a Fillet split-button variant)
 // starts the tool.
 func TestFaceFilletViaRibbonCommand(t *testing.T) {

--- a/app/face_fillet_tool_test.go
+++ b/app/face_fillet_tool_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/feature"
+)
+
+// pickFaceFilletSets drives the two-set face pick on a fresh 2×2×2 block: the top face into set A
+// and the +X side face into set B (they share one edge), returning the tool and block.
+func pickFaceFilletSets(t *testing.T) (*Session, *FaceFilletTool) {
+	t.Helper()
+	s, block := newPartWithBlock(t, 2) // 2×2×2, vol 8
+	tool := NewFaceFilletTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block}) // set A active by default
+	tool.ArmSetB()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	return s, tool
+}
+
+// TestFaceFilletToolEndToEnd drives the Face Fillet UI: pick a face into each set, set the radius,
+// OK — and asserts a valid solid that rounds the shared edge (a cylinder face, volume below the box).
+func TestFaceFilletToolEndToEnd(t *testing.T) {
+	s, tool := pickFaceFilletSets(t)
+	tool.SetRadius(0.3)
+	if !tool.CanCommit() {
+		t.Fatal("face fillet not ready after two sets + radius")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if _, ok := tool.AddedFeature().Definition().(*feature.FaceFilletFeature); !ok {
+		t.Fatalf("added feature is %T, want *FaceFilletFeature", tool.AddedFeature().Definition())
+	}
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("face-filleted body not a valid solid: %+v", r)
+	}
+	cyls := 0
+	for _, fc := range body.Faces() {
+		if _, ok := fc.Geometry().(geom.Cylinder); ok {
+			cyls++
+		}
+	}
+	if cyls != 1 {
+		t.Errorf("face-filleted body has %d cylinder faces, want 1 (the rounded shared edge)", cyls)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; v >= 8 {
+		t.Errorf("face fillet did not round material: volume %g, want < 8", v)
+	}
+}
+
+// TestFaceFilletToolActiveSet checks picks land in the armed set and a face is never double-counted.
+func TestFaceFilletToolActiveSet(t *testing.T) {
+	_, tool := pickFaceFilletSets(t)
+	if tool.ActiveSet() != 1 {
+		t.Errorf("active set = %d after ArmSetB, want 1", tool.ActiveSet())
+	}
+	if tool.CountA() != 1 || tool.CountB() != 1 {
+		t.Fatalf("counts = (A:%d, B:%d), want (1, 1)", tool.CountA(), tool.CountB())
+	}
+	// Re-picking a face already in set A must be ignored even while set B is armed.
+	tool.Pick(nil, tool.Faces()[0])
+	if tool.CountB() != 1 {
+		t.Errorf("re-picking a set-A face added to B: CountB = %d, want 1", tool.CountB())
+	}
+	tool.ArmSetA()
+	if tool.ActiveSet() != 0 {
+		t.Errorf("active set = %d after ArmSetA, want 0", tool.ActiveSet())
+	}
+}
+
+// TestFaceFilletToolNeedsBothSets gates commit on two non-empty sets and a positive radius.
+func TestFaceFilletToolNeedsBothSets(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	tool := NewFaceFilletTool()
+	s.StartTool(tool)
+	tool.SetRadius(0.3)
+	if tool.CanCommit() {
+		t.Error("ready with no faces picked")
+	}
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	if tool.CanCommit() {
+		t.Error("ready with only set A picked")
+	}
+	tool.ArmSetB()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	if !tool.CanCommit() {
+		t.Error("not ready after both sets + radius")
+	}
+	tool.SetRadius(0)
+	if tool.CanCommit() {
+		t.Error("ready with a zero radius")
+	}
+}
+
+// TestFaceFilletToolClearSets checks each set's clear empties only that set.
+func TestFaceFilletToolClearSets(t *testing.T) {
+	_, tool := pickFaceFilletSets(t)
+	tool.ClearSetA()
+	if tool.CountA() != 0 || tool.CountB() != 1 {
+		t.Errorf("after ClearSetA, counts = (A:%d, B:%d), want (0, 1)", tool.CountA(), tool.CountB())
+	}
+	tool.ClearSetB()
+	if tool.CountB() != 0 {
+		t.Errorf("after ClearSetB, CountB = %d, want 0", tool.CountB())
+	}
+}
+
+// TestFaceFilletEditSeed checks re-editing a committed face fillet seeds both sets' counts and the
+// radius back into the panel.
+func TestFaceFilletEditSeed(t *testing.T) {
+	s, tool := pickFaceFilletSets(t)
+	tool.SetRadius(0.3)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	pf := tool.AddedFeature()
+	ff := pf.Definition().(*feature.FaceFilletFeature)
+	et := editFaceFilletTool(pf, ff)
+	if !et.IsEditing() {
+		t.Error("editFaceFilletTool should bind edit mode")
+	}
+	if et.CountA() != 1 || et.CountB() != 1 || et.Radius() != 0.3 {
+		t.Errorf("seeded edit = (A:%d, B:%d, r:%g), want (1, 1, 0.3)", et.CountA(), et.CountB(), et.Radius())
+	}
+}
+
+// TestFaceFilletViaRibbonCommand checks the Face Fillet command (a Fillet split-button variant)
+// starts the tool.
+func TestFaceFilletViaRibbonCommand(t *testing.T) {
+	s, _ := newPartWithBlock(t, 2)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.FaceFillet"); err != nil {
+		t.Fatalf("execute Modify.FaceFillet: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*FaceFilletTool); !ok {
+		t.Fatal("Face Fillet command did not start the face-fillet tool")
+	}
+}

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -86,8 +86,18 @@ func editToolFor(s *Session, f *feature.PartFeature) (Tool, bool) {
 		return editCoilTool(s, f, d), true
 	case *feature.HoleFeature:
 		return editHoleTool(f, d), true
+	}
+	return editDressUpTool(f)
+}
+
+// editDressUpTool seeds the edit panel for the dress-up / local-op features (fillet, face fillet,
+// chamfer, shell, draft); any other kind falls through to the generic editor.
+func editDressUpTool(f *feature.PartFeature) (Tool, bool) {
+	switch d := f.Definition().(type) {
 	case *feature.FilletFeature:
 		return editFilletToolOr(f, d)
+	case *feature.FaceFilletFeature:
+		return editFaceFilletTool(f, d), true
 	case *feature.ChamferFeature:
 		return editChamferTool(f, d), true
 	case *feature.ShellFeature:
@@ -285,6 +295,26 @@ func seedFilletSet(t *FilletTool, set feature.FilletEdgeSet) {
 func snapshotFilletDef(def *feature.FilletDefinition) func() {
 	orig := *def
 	orig.EdgeKeys = cloneKeys(def.EdgeKeys)
+	return func() { *def = orig }
+}
+
+// editFaceFilletTool seeds the Face Fillet panel from a committed face fillet (#694): the two
+// face sets' reference keys are retained as the seeded selection (their faces are consumed, so no
+// live handles exist), and the radius fills the field.
+func editFaceFilletTool(f *feature.PartFeature, ff *feature.FaceFilletFeature) *FaceFilletTool {
+	def := ff.Definition()
+	t := NewFaceFilletTool()
+	t.seededKeysA = cloneKeys(def.FaceKeysA)
+	t.seededKeysB = cloneKeys(def.FaceKeysB)
+	t.radius = callOrZeroFn(def.Radius)
+	t.bindEdit(f, snapshotFaceFilletDef(def))
+	return t
+}
+
+func snapshotFaceFilletDef(def *feature.FaceFilletDefinition) func() {
+	orig := *def
+	orig.FaceKeysA = cloneKeys(def.FaceKeysA)
+	orig.FaceKeysB = cloneKeys(def.FaceKeysB)
 	return func() { *def = orig }
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.50.0
+	oblikovati.org/api v0.51.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.50.0
+	oblikovati.org/api v0.51.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -122,6 +122,7 @@ func drawSolidFeatureDialogs(s *app.Session) {
 	drawChamferDialog(s)
 	drawThreadDialog(s)
 	drawFilletDialog(s)
+	drawFaceFilletDialog(s)
 	drawShellDialog(s)
 	drawSplitDialog(s)
 	drawGripSnapDialog(s)

--- a/head/ui/face_fillet_dialog.go
+++ b/head/ui/face_fillet_dialog.go
@@ -1,0 +1,79 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The Face Fillet flow in the head (#694): while the Face Fillet tool runs, a modeless property
+// panel shows two face-set selectors (clicking one arms it as the target for viewport picks) and
+// the blend radius, then OK/Cancel. It rounds every edge shared between the two face sets.
+var faceFilletUI = struct {
+	radius float32
+	seeded *app.FaceFilletTool // the tool the fields were seeded from (nil = none)
+}{radius: 1}
+
+// drawFaceFilletDialog shows the Face Fillet property panel while the tool is active — creating a
+// face fillet or re-editing a committed one (the same panel serves both).
+func drawFaceFilletDialog(s *app.Session) {
+	f := s.ActiveFaceFillet()
+	if f == nil {
+		faceFilletUI.seeded = nil
+		return
+	}
+	if faceFilletUI.seeded != f {
+		faceFilletUI.radius = float32(f.Radius())
+		faceFilletUI.seeded = f
+	}
+	native.SetNextWindowSizeOnce(340, 240)
+	if native.Begin("Face Fillet") {
+		drawFaceFilletPanelBody(s, f)
+	}
+	native.End()
+}
+
+// drawFaceFilletPanelBody draws the panel's sections (the Begin/End wrapper stays in
+// drawFaceFilletDialog): the breadcrumb, the two face-set pickers, and the radius row.
+func drawFaceFilletPanelBody(s *app.Session, f *app.FaceFilletTool) {
+	title := "Face Fillet"
+	if name := f.EditingName(); name != "" {
+		title = name // re-editing a committed face fillet: the breadcrumb names it
+	}
+	drawFeatureBreadcrumb(title, "")
+	if propertySection("Input Geometry") {
+		drawFaceSetRow("Face Set 1", "facefillet-a", f.CountA(), f.ActiveSet() == 0, f.ArmSetA, f.ClearSetA)
+		drawFaceSetRow("Face Set 2", "facefillet-b", f.CountB(), f.ActiveSet() == 1, f.ArmSetB, f.ClearSetB)
+	}
+	if propertySection("Behavior") {
+		lengthCmRow(s, "Radius", "facefillet-radius", &faceFilletUI.radius)
+		f.SetRadius(float64(faceFilletUI.radius))
+	}
+	native.Separator()
+	drawCommitCancelButtons(s, f.CanCommit())
+}
+
+// drawFaceSetRow draws one face-set selector: a count chip that arms the set as the pick target
+// when clicked (accent while it is the active set), and a clear (×). The picking itself happens in
+// the viewport — this row shows each set's count and switches which set the next pick extends.
+func drawFaceSetRow(label, id string, count int, armed bool, onArm, onClear func()) {
+	propertyRow(label)
+	if armed {
+		native.PushStyleColor("Button", accentColor)
+		native.PushStyleColor("ButtonHovered", accentColor)
+		native.PushStyleColor("ButtonActive", accentColor)
+	}
+	if native.Button(countChipText(count, "Face", "Select Faces") + "##" + id) {
+		onArm()
+	}
+	if armed {
+		native.PopStyleColor(3)
+	}
+	native.SameLine()
+	if native.Button("×##" + id + "-clear") {
+		onClear()
+	}
+}

--- a/head/ui/feature_dialogs_units_test.go
+++ b/head/ui/feature_dialogs_units_test.go
@@ -58,6 +58,7 @@ func TestFeatureDialogsRenderUnitFields(t *testing.T) {
 	for name, draw := range map[string]func(*app.Session){
 		"sweep":      drawSweepDialog,
 		"fillet":     drawFilletDialog,
+		"faceFillet": drawFaceFilletDialog,
 		"chamfer":    drawChamferDialog,
 		"shell":      drawShellDialog,
 		"draft":      drawDraftDialog,
@@ -76,6 +77,11 @@ func TestFeatureDialogsRenderUnitFields(t *testing.T) {
 				f.AddMidPoint() // #695: render a Position/Radius intermediate-point row
 				frame(func() { drawFilletDialog(s) })
 			}
+			if name == "faceFillet" {
+				faceFilletUI.seeded = nil
+				s.ActiveFaceFillet().ArmSetB() // re-render with set 2 as the armed (accent) selector
+				frame(func() { drawFaceFilletDialog(s) })
+			}
 		})
 	}
 }
@@ -87,6 +93,8 @@ func toolFor(name string) app.Tool {
 		return app.NewSweepTool()
 	case "fillet":
 		return app.NewFilletTool()
+	case "faceFillet":
+		return app.NewFaceFilletTool()
 	case "chamfer":
 		return app.NewChamferTool()
 	case "shell":


### PR DESCRIPTION
## What

Adds the interactive **Face Fillet** command — picking two sets of faces and rounding every edge shared between them. The underlying `FaceFilletFeature` (the adjacent-faces case, merged in #1019) was previously reachable only over MCP; this brings it to viewport definition-of-done.

- **`FaceFilletTool` (app):** two face sets with an active-set switch — picks land in the armed set, a face is never double-counted across sets. Radius input, commit via `AddFaceFillet`, draft preview (translucent ghost), edit-mode re-seed from a committed feature, and a `Faces()` accessor so the viewport highlights the picks.
- **Ribbon:** the Fillet button becomes a split-button whose dropdown adds **Face Fillet** (`Modify.FaceFillet`), the way Inventor groups the fillet variants under one command.
- **`head/ui/face_fillet_dialog.go`:** two face-set selector chips (clicking one arms it as the pick target, accent-highlighted while active, with a clear ×) + a radius row.

## Why

Completes a #694 tail: the face fillet is now usable directly in the canvas, not just over the wire. (Non-adjacent face fillet — the gap-bridging ball-path solve — and variable/non-parallel full round remain separate efforts on #694.)

## Notes

- **/source-only — no public-API change.** `FaceFilletFeature` + `AddFaceFillet` already exist; this is the app tool + head panel + ribbon wiring (the opregistry/features path, like #1019).

## Tests

`app/face_fillet_tool_test.go`: end-to-end (pick a face into each set → OK → valid solid with one cylinder face, volume below the box), active-set routing + de-dup, commit gating on both sets + positive radius, per-set clear, edit-mode re-seed, and the ribbon command starting the tool. The head dialog is rendered (both armed states) in `TestFeatureDialogsRenderUnitFields` for coverage.

Live-confirmed in the real Vulkan app: the panel renders the two selectors + radius, and committing rounds the shared edge into a clean blend.

Verified: `go build ./...`, `go test ./app ./model/feature`, head `ui` cgo build + dialog test, `golangci-lint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)