### PR TITLE
feat: mass-properties inertia, principal axes & material density (M18-F01, #429)

### DIFF
--- a/addin/router/analysis.go
+++ b/addin/router/analysis.go
@@ -4,8 +4,10 @@ package router
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/analysis"
@@ -27,9 +29,31 @@ func analysisMassProperties(s *app.Session, raw json.RawMessage) (json.RawMessag
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	mp := analysis.MassPropertiesOf(part.SurfaceBodies().All(), in.DensityGCm3)
-	return json.Marshal(wire.MassPropertiesResult{
-		VolumeMm3: mp.VolumeMm3, SurfaceAreaMm2: mp.SurfaceAreaMm2, MassG: mp.MassG,
-		DensityGCm3: mp.DensityGCm3, CentroidXMm: mp.CentroidXMm, CentroidYMm: mp.CentroidYMm, CentroidZMm: mp.CentroidZMm,
-	})
+	accuracy := types.MassPropertiesMedium
+	if in.Accuracy != "" {
+		a, ok := types.ParseMassPropertiesAccuracy(in.Accuracy)
+		if !ok {
+			return nil, fmt.Errorf("analysis.massProperties: unknown accuracy %q (want low|medium|high)", in.Accuracy)
+		}
+		accuracy = a
+	}
+	density := in.DensityGCm3
+	if density == 0 { // default to the part's assigned material density
+		if props, ok := s.PhysicalProperties(); ok && props.Density > 0 {
+			density = props.Density
+		}
+	}
+	mp := analysis.MassPropertiesOf(part.SurfaceBodies().All(), density, accuracy)
+	return json.Marshal(massPropertiesResult(mp))
+}
+
+// massPropertiesResult flattens the model mass properties into the wire DTO.
+func massPropertiesResult(mp analysis.MassProperties) wire.MassPropertiesResult {
+	return wire.MassPropertiesResult{
+		VolumeMm3: mp.VolumeMm3, SurfaceAreaMm2: mp.SurfaceAreaMm2, MassG: mp.MassG, DensityGCm3: mp.DensityGCm3,
+		CentroidXMm: mp.CentroidXMm, CentroidYMm: mp.CentroidYMm, CentroidZMm: mp.CentroidZMm,
+		InertiaXxGmm2: mp.InertiaXxGmm2, InertiaYyGmm2: mp.InertiaYyGmm2, InertiaZzGmm2: mp.InertiaZzGmm2,
+		InertiaXyGmm2: mp.InertiaXyGmm2, InertiaYzGmm2: mp.InertiaYzGmm2, InertiaZxGmm2: mp.InertiaZxGmm2,
+		PrincipalMomentsGmm2: mp.PrincipalMomentsGmm2, PrincipalAxes: mp.PrincipalAxes,
+	}
 }

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -29,8 +29,15 @@ func TestAnalysisMassPropertiesOverWire(t *testing.T) {
 	if math.Abs(mp.MassG-120) > 1e-3 {
 		t.Errorf("mass = %g g, want 120", mp.MassG)
 	}
+	// Inertia is populated; principal moments positive and sorted ascending.
+	if mp.InertiaXxGmm2 <= 0 || mp.PrincipalMomentsGmm2[0] <= 0 || mp.PrincipalMomentsGmm2[0] > mp.PrincipalMomentsGmm2[2] {
+		t.Errorf("inertia = %+v, want positive Ixx + ascending principal moments", mp)
+	}
 
-	// With no active part, the method errors.
+	// A bad accuracy errors; with no active part, the method errors.
+	if _, err := r.Handle(s, "analysis.massProperties", []byte(`{"accuracy":"bogus"}`)); err == nil {
+		t.Error("massProperties with a bad accuracy = ok, want error")
+	}
 	br, bs := New(opregistry.Default()), app.NewSession()
 	if _, err := br.Handle(bs, "analysis.massProperties", []byte(`{}`)); err == nil {
 		t.Error("massProperties with no active part = ok, want error")

--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,12 +58,7 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{
-	// M18-F01 mass-properties: the contract landed in API v0.50.0 (#423) ahead of the
-	// router handler. Keyed by CONSTANT NAME (not the "analysis.massProperties" value).
-	// DELETE when the handler lands.
-	"MethodAnalysisMassProperties": true,
-}
+var notYetHandled = map[string]bool{}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They

--- a/app/commands_analysis.go
+++ b/app/commands_analysis.go
@@ -5,6 +5,7 @@ package app
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/analysis"
 )
 
@@ -27,8 +28,13 @@ func physicalProperties(s *Session) error {
 	if err != nil {
 		return err
 	}
-	mp := analysis.MassPropertiesOf(part.SurfaceBodies().All(), 0)
-	s.SetNotice(fmt.Sprintf("Physical Properties — volume %.2f mm³, area %.2f mm², mass %.2f g, CoM (%.2f, %.2f, %.2f) mm",
-		mp.VolumeMm3, mp.SurfaceAreaMm2, mp.MassG, mp.CentroidXMm, mp.CentroidYMm, mp.CentroidZMm))
+	density := 0.0 // default to the assigned material density
+	if props, ok := s.PhysicalProperties(); ok && props.Density > 0 {
+		density = props.Density
+	}
+	mp := analysis.MassPropertiesOf(part.SurfaceBodies().All(), density, types.MassPropertiesMedium)
+	s.SetNotice(fmt.Sprintf("Physical Properties — volume %.2f mm³, area %.2f mm², mass %.2f g, CoM (%.2f, %.2f, %.2f) mm, principal I (%.1f, %.1f, %.1f) g·mm²",
+		mp.VolumeMm3, mp.SurfaceAreaMm2, mp.MassG, mp.CentroidXMm, mp.CentroidYMm, mp.CentroidZMm,
+		mp.PrincipalMomentsGmm2[0], mp.PrincipalMomentsGmm2[1], mp.PrincipalMomentsGmm2[2]))
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.50.0
+	oblikovati.org/api v0.51.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.50.0
+	oblikovati.org/api v0.51.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/analysis/inertia.go
+++ b/model/analysis/inertia.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// cm2ToMm2 converts the per-unit-density inertia (database units, cm⁵) once multiplied by density
+// (g/cm³ → g·cm²) into g·mm² (1 cm² = 100 mm²).
+const cm2ToMm2 = 100.0
+
+// applyInertia fills mp's inertia fields: each body's inertia about its own centroid (per unit
+// density) is shifted to the combined centroid by the parallel-axis theorem and summed, scaled to
+// g·mm² by the density, then diagonalised for the principal moments and axes.
+func applyInertia(mp *MassProperties, bodies []*topo.Body, q ops.Quality, density float64, centroidCm [3]float64) {
+	var total sym3
+	for _, b := range bodies {
+		gp := ops.BodyGeometryProperties(b, q)
+		it := ops.BodyInertia(b, q) // about the body's own centroid, per unit density
+		body := sym3{it.Ixx, it.Iyy, it.Izz, it.Ixy, it.Iyz, it.Izx}
+		d := [3]float64{centroidCm[0] - float64(gp.Centroid.X), centroidCm[1] - float64(gp.Centroid.Y), centroidCm[2] - float64(gp.Centroid.Z)}
+		total = total.add(body).add(parallelAxis(gp.Volume, d))
+	}
+	scale := density * cm2ToMm2 // per-unit-density cm⁵ → g·mm²
+	mp.InertiaXxGmm2, mp.InertiaYyGmm2, mp.InertiaZzGmm2 = total.xx*scale, total.yy*scale, total.zz*scale
+	mp.InertiaXyGmm2, mp.InertiaYzGmm2, mp.InertiaZxGmm2 = total.xy*scale, total.yz*scale, total.zx*scale
+	vals, vecs := jacobiEigenSym3(total)
+	for i := 0; i < 3; i++ {
+		mp.PrincipalMomentsGmm2[i] = vals[i] * scale
+		mp.PrincipalAxes[i] = vecs[i]
+	}
+}
+
+// sym3 is a symmetric 3×3 matrix (the inertia tensor): diagonal xx/yy/zz and products xy/yz/zx.
+type sym3 struct{ xx, yy, zz, xy, yz, zx float64 }
+
+func (a sym3) add(b sym3) sym3 {
+	return sym3{a.xx + b.xx, a.yy + b.yy, a.zz + b.zz, a.xy + b.xy, a.yz + b.yz, a.zx + b.zx}
+}
+
+// parallelAxis is the inertia (per unit density) added when shifting a body's inertia from its
+// centroid to a point offset by d: vol·(|d|²·Id − d⊗d), with products following Ixy = −∫xy.
+func parallelAxis(vol float64, d [3]float64) sym3 {
+	d2 := d[0]*d[0] + d[1]*d[1] + d[2]*d[2]
+	return sym3{
+		xx: vol * (d2 - d[0]*d[0]), yy: vol * (d2 - d[1]*d[1]), zz: vol * (d2 - d[2]*d[2]),
+		xy: vol * (-d[0] * d[1]), yz: vol * (-d[1] * d[2]), zx: vol * (-d[2] * d[0]),
+	}
+}
+
+// jacobiEigenSym3 diagonalises a symmetric 3×3 matrix by cyclic Jacobi rotation, returning the
+// eigenvalues sorted ascending and their unit eigenvectors (vecs[i] pairs with vals[i]).
+func jacobiEigenSym3(s sym3) (vals [3]float64, vecs [3][3]float64) {
+	a := [3][3]float64{{s.xx, s.xy, s.zx}, {s.xy, s.yy, s.yz}, {s.zx, s.yz, s.zz}}
+	v := [3][3]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}} // accumulated rotations (columns = eigenvectors)
+	for sweep := 0; sweep < 50; sweep++ {
+		if offDiagNorm(a) < 1e-18 {
+			break
+		}
+		for _, pq := range [3][2]int{{0, 1}, {0, 2}, {1, 2}} {
+			jacobiRotate(&a, &v, pq[0], pq[1])
+		}
+	}
+	idx := [3]int{0, 1, 2} // sort eigenvalues ascending
+	for i := 0; i < 3; i++ {
+		for j := i + 1; j < 3; j++ {
+			if a[idx[j]][idx[j]] < a[idx[i]][idx[i]] {
+				idx[i], idx[j] = idx[j], idx[i]
+			}
+		}
+	}
+	for i := 0; i < 3; i++ {
+		k := idx[i]
+		vals[i] = a[k][k]
+		vecs[i] = [3]float64{v[0][k], v[1][k], v[2][k]} // column k is the eigenvector
+	}
+	return vals, vecs
+}
+
+// offDiagNorm is the sum of squared off-diagonal entries (the Jacobi convergence measure).
+func offDiagNorm(a [3][3]float64) float64 {
+	return a[0][1]*a[0][1] + a[0][2]*a[0][2] + a[1][2]*a[1][2]
+}
+
+// jacobiRotate zeroes the (p,q) off-diagonal entry of a with a Givens rotation, accumulating it
+// into the eigenvector matrix v.
+func jacobiRotate(a *[3][3]float64, v *[3][3]float64, p, q int) {
+	if stdmath.Abs(a[p][q]) < 1e-300 {
+		return
+	}
+	theta := (a[q][q] - a[p][p]) / (2 * a[p][q])
+	t := sign(theta) / (stdmath.Abs(theta) + stdmath.Sqrt(theta*theta+1))
+	if theta == 0 {
+		t = 1
+	}
+	c := 1 / stdmath.Sqrt(t*t+1)
+	sn := t * c
+	for k := 0; k < 3; k++ {
+		akp, akq := a[k][p], a[k][q]
+		a[k][p] = c*akp - sn*akq
+		a[k][q] = sn*akp + c*akq
+	}
+	for k := 0; k < 3; k++ {
+		apk, aqk := a[p][k], a[q][k]
+		a[p][k] = c*apk - sn*aqk
+		a[q][k] = sn*apk + c*aqk
+	}
+	for k := 0; k < 3; k++ {
+		vkp, vkq := v[k][p], v[k][q]
+		v[k][p] = c*vkp - sn*vkq
+		v[k][q] = sn*vkp + c*vkq
+	}
+}
+
+// sign returns ±1 (with +1 for zero), for the Jacobi rotation angle.
+func sign(x float64) float64 {
+	if x < 0 {
+		return -1
+	}
+	return 1
+}

--- a/model/analysis/inertia_test.go
+++ b/model/analysis/inertia_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/topo"
+)
+
+// TestJacobiEigenSym3 diagonalises a non-diagonal symmetric matrix (exercising the Jacobi
+// rotations): [[2,1,0],[1,2,0],[0,0,5]] has eigenvalues 1, 3, 5. The 2×2 block (2,1;1,2) has
+// eigenvectors (1,∓1)/√2.
+func TestJacobiEigenSym3(t *testing.T) {
+	vals, vecs := jacobiEigenSym3(sym3{xx: 2, yy: 2, zz: 5, xy: 1, yz: 0, zx: 0})
+	want := [3]float64{1, 3, 5} // ascending
+	for i := 0; i < 3; i++ {
+		if math.Abs(vals[i]-want[i]) > 1e-9 {
+			t.Fatalf("eigenvalue[%d] = %g, want %g (all: %v)", i, vals[i], want[i], vals)
+		}
+		if math.Abs(vecLen(vecs[i])-1) > 1e-9 {
+			t.Errorf("eigenvector[%d] = %v, want unit length", i, vecs[i])
+		}
+	}
+	// The smallest eigenvalue (1) pairs with (1,-1,0)/√2; check |components| up to sign.
+	const inv2 = 0.70710678
+	if math.Abs(math.Abs(vecs[0][0])-inv2) > 1e-6 || math.Abs(math.Abs(vecs[0][1])-inv2) > 1e-6 {
+		t.Errorf("eigenvector for λ=1 = %v, want (±1,∓1,0)/√2", vecs[0])
+	}
+}
+
+// TestQualityForAccuracyLevels: every accuracy level computes the box's (tessellation-exact)
+// volume, exercising the low/medium/high quality mapping.
+func TestQualityForAccuracyLevels(t *testing.T) {
+	for _, acc := range []types.MassPropertiesAccuracy{types.MassPropertiesLow, types.MassPropertiesMedium, types.MassPropertiesHigh} {
+		mp := MassPropertiesOf([]*topo.Body{block53x2(t)}, 1, acc)
+		approx(t, "volume@"+acc.String(), mp.VolumeMm3, 30000)
+	}
+}
+
+func vecLen(v [3]float64) float64 { return math.Sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]) }

--- a/model/analysis/massprops.go
+++ b/model/analysis/massprops.go
@@ -6,6 +6,9 @@
 package analysis
 
 import (
+	stdmath "math"
+
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 )
@@ -14,7 +17,7 @@ import (
 // surface reports in. See [[database-unit-is-cm]].
 const cmToMM = 10.0
 
-// MassProperties is a part's combined geometry properties and mass, in user units.
+// MassProperties is a part's combined geometry properties, mass and inertia, in user units.
 type MassProperties struct {
 	VolumeMm3      float64
 	SurfaceAreaMm2 float64
@@ -23,19 +26,42 @@ type MassProperties struct {
 	CentroidXMm    float64
 	CentroidYMm    float64
 	CentroidZMm    float64
+	// Mass moment of inertia about the centroid (g·mm²); Ixy/Iyz/Izx are products of inertia.
+	InertiaXxGmm2 float64
+	InertiaYyGmm2 float64
+	InertiaZzGmm2 float64
+	InertiaXyGmm2 float64
+	InertiaYzGmm2 float64
+	InertiaZxGmm2 float64
+	// Principal moments of inertia (g·mm²) and their unit axes (rows aligned to the moments).
+	PrincipalMomentsGmm2 [3]float64
+	PrincipalAxes        [3][3]float64
+}
+
+// qualityFor maps an accuracy level to a tessellation quality (planar bodies are exact regardless).
+func qualityFor(accuracy types.MassPropertiesAccuracy) ops.Quality {
+	switch accuracy {
+	case types.MassPropertiesLow:
+		return ops.Quality{ChordTolerance: 0.2, AngleTolerance: 20 * stdmath.Pi / 180}
+	case types.MassPropertiesHigh:
+		return ops.Quality{ChordTolerance: 0.01, AngleTolerance: 5 * stdmath.Pi / 180}
+	default:
+		return ops.DefaultQuality()
+	}
 }
 
 // MassPropertiesOf returns the combined mass properties of the given solid bodies for a material
-// density (g/cm³; ≤0 ⇒ 1.0, so the mass equals the volume in cm³). Volume, area and centroid come
-// from each body's tessellated geometry (divergence theorem); the centroid is volume-weighted
-// across the bodies.
-func MassPropertiesOf(bodies []*topo.Body, densityGCm3 float64) MassProperties {
+// density (g/cm³; ≤0 ⇒ 1.0) at the given accuracy. Volume/area/centroid come from each body's
+// tessellated geometry; the centroid is volume-weighted, and the inertia tensor is each body's
+// inertia (about its own centroid) shifted to the combined centroid by the parallel-axis theorem.
+func MassPropertiesOf(bodies []*topo.Body, densityGCm3 float64, accuracy types.MassPropertiesAccuracy) MassProperties {
 	if densityGCm3 <= 0 {
 		densityGCm3 = 1
 	}
+	q := qualityFor(accuracy)
 	var volCm3, areaCm2, cx, cy, cz float64
 	for _, b := range bodies {
-		p := ops.BodyGeometryProperties(b, ops.DefaultQuality())
+		p := ops.BodyGeometryProperties(b, q)
 		volCm3 += p.Volume
 		areaCm2 += p.Area
 		cx += float64(p.Centroid.X) * p.Volume
@@ -45,7 +71,7 @@ func MassPropertiesOf(bodies []*topo.Body, densityGCm3 float64) MassProperties {
 	if volCm3 > 0 {
 		cx, cy, cz = cx/volCm3, cy/volCm3, cz/volCm3
 	}
-	return MassProperties{
+	mp := MassProperties{
 		VolumeMm3:      volCm3 * cmToMM * cmToMM * cmToMM,
 		SurfaceAreaMm2: areaCm2 * cmToMM * cmToMM,
 		MassG:          densityGCm3 * volCm3,
@@ -54,4 +80,6 @@ func MassPropertiesOf(bodies []*topo.Body, densityGCm3 float64) MassProperties {
 		CentroidYMm:    cy * cmToMM,
 		CentroidZMm:    cz * cmToMM,
 	}
+	applyInertia(&mp, bodies, q, densityGCm3, [3]float64{cx, cy, cz})
+	return mp
 }

--- a/model/analysis/massprops_test.go
+++ b/model/analysis/massprops_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/topo"
 	gmath "oblikovati.org/math"
@@ -24,7 +25,7 @@ func block53x2(t *testing.T) *topo.Body {
 // TestMassPropertiesOfBox checks volume, surface area, centroid and mass against the analytic
 // values for the 5×3×2 cm block, including the default-density path.
 func TestMassPropertiesOfBox(t *testing.T) {
-	mp := MassPropertiesOf([]*topo.Body{block53x2(t)}, 2.0) // density 2 g/cm³
+	mp := MassPropertiesOf([]*topo.Body{block53x2(t)}, 2.0, types.MassPropertiesMedium) // density 2 g/cm³
 
 	// 50×30×20 mm: volume 30000 mm³, area 2(50·30+50·20+30·20)=6200 mm², centroid (25,15,10) mm.
 	approx(t, "volume", mp.VolumeMm3, 30000)
@@ -34,7 +35,19 @@ func TestMassPropertiesOfBox(t *testing.T) {
 	approx(t, "centroidZ", mp.CentroidZMm, 10)
 	approx(t, "mass", mp.MassG, 60) // 2 g/cm³ × 30 cm³
 
-	def := MassPropertiesOf([]*topo.Body{block53x2(t)}, 0) // zero density ⇒ 1 g/cm³
+	// Inertia (g·mm²) about the centroid: mass m = 60 g, full dims (50,30,20) mm →
+	// Ixx = m(30²+20²)/12 = 60·1300/12 = 6500; Iyy = m(50²+20²)/12 = 60·2900/12 = 14500;
+	// Izz = m(50²+30²)/12 = 60·3400/12 = 17000. Products zero (axis-aligned about centroid).
+	approx(t, "Ixx", mp.InertiaXxGmm2, 6500)
+	approx(t, "Iyy", mp.InertiaYyGmm2, 14500)
+	approx(t, "Izz", mp.InertiaZzGmm2, 17000)
+	approx(t, "Ixy", mp.InertiaXyGmm2, 0)
+	// Principal moments equal the (sorted-ascending) diagonal for an axis-aligned box.
+	approx(t, "principal0", mp.PrincipalMomentsGmm2[0], 6500)
+	approx(t, "principal1", mp.PrincipalMomentsGmm2[1], 14500)
+	approx(t, "principal2", mp.PrincipalMomentsGmm2[2], 17000)
+
+	def := MassPropertiesOf([]*topo.Body{block53x2(t)}, 0, types.MassPropertiesMedium) // zero density ⇒ 1 g/cm³
 	if def.DensityGCm3 != 1 {
 		t.Errorf("default density = %g, want 1", def.DensityGCm3)
 	}
@@ -43,7 +56,7 @@ func TestMassPropertiesOfBox(t *testing.T) {
 
 // TestMassPropertiesEmpty: no bodies yields zero properties (and no divide-by-zero centroid).
 func TestMassPropertiesEmpty(t *testing.T) {
-	mp := MassPropertiesOf(nil, 5)
+	mp := MassPropertiesOf(nil, 5, types.MassPropertiesMedium)
 	if mp.VolumeMm3 != 0 || mp.MassG != 0 || mp.CentroidXMm != 0 {
 		t.Fatalf("empty mass properties = %+v, want all zero", mp)
 	}


### PR DESCRIPTION
## What
Completes the analysis **mass-properties** surface: **inertia tensor about the centroid** + **principal moments/axes**, an **accuracy** level, and **material-density default**.

## How
- **Model** (`model/analysis`): each body's `ops.BodyInertia` (about its own centroid) is shifted to the combined part centroid by the **parallel-axis theorem** and summed, scaled to **g·mm²** by density; a **3×3 symmetric Jacobi eigensolver** diagonalises it into principal moments + unit axes. `accuracy` (low/medium/high) → tessellation `ops.Quality`.
- **Router + app**: default density to the part's **assigned material** (`s.PhysicalProperties().Density`) when none given (aligns `analysis.massProperties` with `model.physicalProperties`, per the #423 audit + your "align next increment" call); report inertia + principal moments. Removes the now-handled `MethodAnalysisMassProperties` from the api-parity `notYetHandled` list.
- Pins the api contract to **v0.51.0**.

## Tests
- `model/analysis`: a 5×3×2 cm block → **exact** analytic inertia (`Ixx = m(b²+c²)/12` = 6500/14500/17000 g·mm² @ 2 g/cm³), zero products, principal moments = the sorted diagonal.
- `addin/router`: inertia populated, principal moments positive + sorted; bad-accuracy + no-part errors.
- Full `go test ./...` green, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)