### PR TITLE
feat: entity measurement — length, area, distance (M18-F01 PBI-164, #428)

### DIFF
--- a/addin/router/analysis.go
+++ b/addin/router/analysis.go
@@ -3,6 +3,7 @@
 package router
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -10,6 +11,8 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/analysis"
 )
 
@@ -18,6 +21,64 @@ import (
 // registerAnalysisHandlers wires the analysis.* methods.
 func (r *Router) registerAnalysisHandlers() {
 	r.handlers[wire.MethodAnalysisMassProperties] = analysisMassProperties
+	r.handlers[wire.MethodAnalysisMeasure] = analysisMeasure
+}
+
+func analysisMeasure(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.MeasureArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	mt, ok := types.ParseMeasureType(in.Type)
+	if !ok {
+		return nil, fmt.Errorf("analysis.measure: unknown measure type %q (want length|area|distance)", in.Type)
+	}
+	bodies := part.SurfaceBodies().All()
+	if in.BodyIndex < 0 || in.BodyIndex >= len(bodies) {
+		return nil, fmt.Errorf("analysis.measure: body index %d out of range [0,%d)", in.BodyIndex, len(bodies))
+	}
+	value, unit, err := measureEntity(bodies[in.BodyIndex], mt, in.KeyA, in.KeyB)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.MeasureResult{Type: mt.String(), Value: value, Unit: unit})
+}
+
+// measureEntity resolves the entity (or pair) by reference key and computes the requested quantity.
+func measureEntity(body *topo.Body, mt types.MeasureType, keyA, keyB string) (float64, string, error) {
+	q := ops.DefaultQuality()
+	switch mt {
+	case types.MeasureLength:
+		e, ok := body.FindEdgeByKey(decodeKey(keyA))
+		if !ok {
+			return 0, "", fmt.Errorf("analysis.measure: no edge for key %q", keyA)
+		}
+		return analysis.EdgeLengthMm(e, q), "mm", nil
+	case types.MeasureArea:
+		f, ok := body.FindFaceByKey(decodeKey(keyA))
+		if !ok {
+			return 0, "", fmt.Errorf("analysis.measure: no face for key %q", keyA)
+		}
+		return analysis.FaceAreaMm2(f, q), "mm²", nil
+	case types.MeasureDistance:
+		a, okA := body.FindVertexByKey(decodeKey(keyA))
+		b, okB := body.FindVertexByKey(decodeKey(keyB))
+		if !okA || !okB {
+			return 0, "", fmt.Errorf("analysis.measure: distance needs two vertex keys (keyA=%q, keyB=%q)", keyA, keyB)
+		}
+		return analysis.VertexDistanceMm(a, b), "mm", nil
+	}
+	return 0, "", fmt.Errorf("analysis.measure: unsupported measure type %v", mt)
+}
+
+// decodeKey hex-decodes a reference key (an invalid string decodes to nil, which matches nothing).
+func decodeKey(s string) []byte {
+	b, _ := hex.DecodeString(s)
+	return b
 }
 
 func analysisMassProperties(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -3,9 +3,11 @@
 package router
 
 import (
+	"encoding/hex"
 	"math"
 	"testing"
 
+	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/addin/opregistry"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
@@ -42,4 +44,43 @@ func TestAnalysisMassPropertiesOverWire(t *testing.T) {
 	if _, err := br.Handle(bs, "analysis.massProperties", []byte(`{}`)); err == nil {
 		t.Error("massProperties with no active part = ok, want error")
 	}
+}
+
+// TestAnalysisMeasureOverWire drives the measurement surface: an edge of the box-part fixture
+// reports a length in {40, 30, 50} mm, and a face an area in {1200, 1500, 2000} mm².
+func TestAnalysisMeasureOverWire(t *testing.T) {
+	r, s := boxPartSession(t)
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("ActivePart: %v", err)
+	}
+	body := part.SurfaceBodies().Item(0)
+	edgeKey := hex.EncodeToString(body.Edges()[0].ReferenceKey())
+	faceKey := hex.EncodeToString(body.Faces()[0].ReferenceKey())
+
+	var m wire.MeasureResult
+	call(t, r, s, "analysis.measure", `{"type":"length","keyA":"`+edgeKey+`"}`, &m)
+	if m.Unit != "mm" || !nearAny(m.Value, 40, 30, 50) {
+		t.Errorf("edge length = %+v, want one of 40/30/50 mm", m)
+	}
+	call(t, r, s, "analysis.measure", `{"type":"area","keyA":"`+faceKey+`"}`, &m)
+	if m.Unit != "mm²" || !nearAny(m.Value, 1200, 1500, 2000) {
+		t.Errorf("face area = %+v, want one of 1200/1500/2000 mm²", m)
+	}
+	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"bogus","keyA":"00"}`)); err == nil {
+		t.Error("measure with a bad type = ok, want error")
+	}
+	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"length","keyA":"dead"}`)); err == nil {
+		t.Error("measure with an unknown edge key = ok, want error")
+	}
+}
+
+// nearAny reports whether v is within 0.01 of any of the candidate values.
+func nearAny(v float64, candidates ...float64) bool {
+	for _, c := range candidates {
+		if math.Abs(v-c) < 0.01 {
+			return true
+		}
+	}
+	return false
 }

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -67,6 +67,15 @@ func TestAnalysisMeasureOverWire(t *testing.T) {
 	if m.Unit != "mm²" || !nearAny(m.Value, 1200, 1500, 2000) {
 		t.Errorf("face area = %+v, want one of 1200/1500/2000 mm²", m)
 	}
+	vA := hex.EncodeToString(body.Vertices()[0].ReferenceKey())
+	vB := hex.EncodeToString(body.Vertices()[1].ReferenceKey())
+	call(t, r, s, "analysis.measure", `{"type":"distance","keyA":"`+vA+`","keyB":"`+vB+`"}`, &m)
+	if m.Unit != "mm" || m.Value <= 0 {
+		t.Errorf("vertex distance = %+v, want a positive mm distance", m)
+	}
+	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"distance","keyA":"`+vA+`"}`)); err == nil {
+		t.Error("distance with one vertex key = ok, want error")
+	}
 	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"bogus","keyA":"00"}`)); err == nil {
 		t.Error("measure with a bad type = ok, want error")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.51.0
+	oblikovati.org/api v0.52.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.51.0
+	oblikovati.org/api v0.52.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/analysis/measure.go
+++ b/model/analysis/measure.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Measurement (M18-F01 PBI-164, #428): geometric quantities of model entities, in user units (mm).
+
+// EdgeLengthMm returns an edge's length in millimetres, summing its tessellated polyline (exact for
+// lines/arcs/circles; converges with q for general curves).
+func EdgeLengthMm(e *topo.Edge, q ops.Quality) float64 {
+	pts := ops.TessellateEdge(e, q)
+	var lengthCm float64
+	for i := 1; i < len(pts); i++ {
+		lengthCm += float64(pts[i-1].VectorTo(pts[i]).Length())
+	}
+	return lengthCm * cmToMM
+}
+
+// FaceAreaMm2 returns a face's area in square millimetres, summing its tessellated triangle areas
+// (exact for planar faces; converges with q for curved ones).
+func FaceAreaMm2(f *topo.Face, q ops.Quality) float64 {
+	mesh := ops.TessellateFace(f, q)
+	var areaCm2 float64
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		a := mesh.Positions[mesh.Indices[t]]
+		b := mesh.Positions[mesh.Indices[t+1]]
+		c := mesh.Positions[mesh.Indices[t+2]]
+		areaCm2 += float64(a.VectorTo(b).Cross(a.VectorTo(c)).Length()) / 2
+	}
+	return areaCm2 * cmToMM * cmToMM
+}
+
+// VertexDistanceMm returns the straight-line distance between two vertices in millimetres.
+func VertexDistanceMm(a, b *topo.Vertex) float64 {
+	return distanceMm(a.Point(), b.Point())
+}
+
+// distanceMm is the millimetre distance between two database-unit points.
+func distanceMm(a, b math.Point3) float64 {
+	return float64(a.VectorTo(b).Length()) * cmToMM
+}

--- a/model/analysis/measure_test.go
+++ b/model/analysis/measure_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	gmath "oblikovati.org/math"
+)
+
+// TestMeasureBox checks edge length, face area and vertex distance against the analytic box
+// (4×3×5 cm = 40×30×50 mm): total edge length 4(40+30+50) = 480 mm; total face area
+// 2(40·30+40·50+30·50) = 9400 mm²; the space diagonal between opposite corners is √(40²+30²+50²).
+func TestMeasureBox(t *testing.T) {
+	block, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(4, 3, 5), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	q := ops.DefaultQuality()
+
+	var totalEdge float64
+	for _, e := range block.Edges() {
+		totalEdge += EdgeLengthMm(e, q)
+	}
+	approx(t, "total edge length", totalEdge, 480)
+
+	var totalArea float64
+	for _, f := range block.Faces() {
+		totalArea += FaceAreaMm2(f, q)
+	}
+	approx(t, "total face area", totalArea, 9400)
+
+	verts := block.Vertices()
+	var maxDist float64
+	for i := range verts {
+		for j := i + 1; j < len(verts); j++ {
+			if d := VertexDistanceMm(verts[i], verts[j]); d > maxDist {
+				maxDist = d
+			}
+		}
+	}
+	approx(t, "space diagonal", maxDist, math.Sqrt(40*40+30*30+50*50))
+}


### PR DESCRIPTION
## What
`analysis.measure` — measure an entity of the active part by reference key: an **edge's length**, a **face's area**, or the **distance between two vertices** (mm / mm²).

## Why
M18-F01 PBI-164 (#428) measurement tools. First increment; min-distance, angle, and the interactive Measure tool follow.

## How
- **Model** (`model/analysis/measure.go`): `EdgeLengthMm` (sum the tessellated polyline), `FaceAreaMm2` (sum tessellated triangle areas), `VertexDistanceMm` — exact for planar/linear, converging for curved.
- **Router**: resolve the entity by hex reference key (`FindEdge/Face/VertexByKey`) and dispatch on `MeasureType`.
- Pins the api contract to **v0.52.0**.

## Tests
- `model/analysis`: the analytic box (4×3×5 cm) → total edge length **480 mm**, total face area **9400 mm²**, space diagonal **√(40²+30²+50²)**.
- `addin/router`: an edge length ∈ {40,30,50} mm and a face area ∈ {1200,1500,2000} mm² over the wire; bad-type + unknown-key errors.
- Full `go test ./...` green, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)