### PR TITLE
feat(fillet): Full Round fillet UI tool + panel (#694)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,7 +58,12 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{}
+var notYetHandled = map[string]bool{
+	// M18-F01 measurement: the contract landed in API v0.52.0 (#428) ahead of the router
+	// handler. Keyed by CONSTANT NAME (not the "analysis.measure" value). DELETE when the
+	// handler lands (the M18 agent may land it concurrently — expect to shrink this soon).
+	"MethodAnalysisMeasure": true,
+}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -489,13 +489,19 @@ func filletCommand() *CommandDefinition {
 	}).WithTab(tab3DModel).WithEnable(notInSketch).
 		WithIcon("fillet").WithButtonStyle(LargeIconButton).
 		WithTooltip("Face Fillet — round the edges shared between two sets of faces.")
+	fullRound := NewCommand("Modify.FullRoundFillet", "Full Round Fillet", "Modify", func(s *Session) error {
+		s.StartTool(NewFullRoundFilletTool())
+		return nil
+	}).WithTab(tab3DModel).WithEnable(notInSketch).
+		WithIcon("fillet").WithButtonStyle(LargeIconButton).
+		WithTooltip("Full Round Fillet — replace a face between two parallel sides with a half-round.")
 	return NewCommand("Modify.Fillet", "Fillet", "Modify", func(s *Session) error {
 		s.StartTool(NewFilletTool())
 		return nil
 	}).WithTab(tab3DModel).WithAlias("F").WithEnable(notInSketch).
 		WithIcon("fillet").WithButtonStyle(LargeIconButton).
 		WithTooltip("Fillet — round selected convex edges with a rolling-ball radius.").
-		WithVariants(faceFillet)
+		WithVariants(faceFillet, fullRound)
 }
 
 // localFaceCommands are the F04 local face operations — the metric edits (shell, offset

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -98,6 +98,8 @@ func editDressUpTool(f *feature.PartFeature) (Tool, bool) {
 		return editFilletToolOr(f, d)
 	case *feature.FaceFilletFeature:
 		return editFaceFilletTool(f, d), true
+	case *feature.FullRoundFilletFeature:
+		return editFullRoundFilletTool(f, d), true
 	case *feature.ChamferFeature:
 		return editChamferTool(f, d), true
 	case *feature.ShellFeature:
@@ -315,6 +317,26 @@ func snapshotFaceFilletDef(def *feature.FaceFilletDefinition) func() {
 	orig := *def
 	orig.FaceKeysA = cloneKeys(def.FaceKeysA)
 	orig.FaceKeysB = cloneKeys(def.FaceKeysB)
+	return func() { *def = orig }
+}
+
+// editFullRoundFilletTool seeds the Full Round panel from a committed full round (#694): the three
+// face sets' reference keys are retained as the seeded selection (their faces are consumed).
+func editFullRoundFilletTool(f *feature.PartFeature, fr *feature.FullRoundFilletFeature) *FullRoundFilletTool {
+	def := fr.Definition()
+	t := NewFullRoundFilletTool()
+	t.seeded1 = cloneKeys(def.Side1Keys)
+	t.seededCenter = cloneKeys(def.CenterKeys)
+	t.seeded2 = cloneKeys(def.Side2Keys)
+	t.bindEdit(f, snapshotFullRoundFilletDef(def))
+	return t
+}
+
+func snapshotFullRoundFilletDef(def *feature.FullRoundFilletDefinition) func() {
+	orig := *def
+	orig.Side1Keys = cloneKeys(def.Side1Keys)
+	orig.CenterKeys = cloneKeys(def.CenterKeys)
+	orig.Side2Keys = cloneKeys(def.Side2Keys)
 	return func() { *def = orig }
 }
 

--- a/app/full_round_fillet_session.go
+++ b/app/full_round_fillet_session.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Session bridge for the Full Round Fillet tool's property window.
+
+// ActiveFullRoundFillet returns the running Full Round Fillet tool, or nil when the active tool is
+// not a full round (or there is none).
+func (s *Session) ActiveFullRoundFillet() *FullRoundFilletTool {
+	if s.tool == nil {
+		return nil
+	}
+	f, _ := s.tool.tool.(*FullRoundFilletTool)
+	return f
+}

--- a/app/full_round_fillet_tool.go
+++ b/app/full_round_fillet_tool.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// FullRoundFilletTool is the interactive Full Round Fillet command (#694): pick a center face and
+// the two parallel side faces it sits between, and OK to replace the center with a half-cylinder
+// tangent to both sides (the rounded top of a rib/wall). There is no radius — it is derived as half
+// the side-to-side distance. Picks land in the ACTIVE set (Side 1 first); arm the others from the
+// panel.
+type FullRoundFilletTool struct {
+	featureEditMode      // set ⇒ this panel re-edits a committed full round (see editFullRoundFilletTool)
+	side1, center, side2 []FaceHandle
+	seeded1              [][]byte // edit mode: retained keys per set (their faces are consumed, so no live handles exist)
+	seededCenter         [][]byte
+	seeded2              [][]byte
+	activeSet            int // 0 = Side 1, 1 = Center, 2 = Side 2 — which set a pick extends
+	added                *feature.PartFeature
+}
+
+// NewFullRoundFilletTool returns a full-round tool with Side 1 active.
+func NewFullRoundFilletTool() *FullRoundFilletTool { return &FullRoundFilletTool{} }
+
+// Name implements [Tool].
+func (t *FullRoundFilletTool) Name() string { return "Full Round Fillet" }
+
+// Start sets the selection filter to faces so clicks pick the center and side faces.
+func (t *FullRoundFilletTool) Start(s *Session) {
+	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
+}
+
+// Pick appends the clicked face to the active set, ignoring a face already in any set.
+func (t *FullRoundFilletTool) Pick(_ *Session, sel Selectable) {
+	f, ok := sel.(FaceHandle)
+	if !ok || t.hasFace(f) {
+		return
+	}
+	switch t.activeSet {
+	case 1:
+		t.center = append(t.center, f)
+	case 2:
+		t.side2 = append(t.side2, f)
+	default:
+		t.side1 = append(t.side1, f)
+	}
+}
+
+// hasFace reports whether the face is already picked into any of the three sets.
+func (t *FullRoundFilletTool) hasFace(f FaceHandle) bool {
+	return faceSetHas(t.side1, f) || faceSetHas(t.center, f) || faceSetHas(t.side2, f)
+}
+
+// ArmSide1 / ArmCenter / ArmSide2 choose which set the next picks extend (the panel's three chips).
+func (t *FullRoundFilletTool) ArmSide1()  { t.activeSet = 0 }
+func (t *FullRoundFilletTool) ArmCenter() { t.activeSet = 1 }
+func (t *FullRoundFilletTool) ArmSide2()  { t.activeSet = 2 }
+
+// ActiveSet reports which set picks currently extend (0 = Side 1, 1 = Center, 2 = Side 2).
+func (t *FullRoundFilletTool) ActiveSet() int { return t.activeSet }
+
+// Count1 / CountCenter / Count2 count each set's faces: retained keys (edit mode) plus picks.
+func (t *FullRoundFilletTool) Count1() int      { return len(t.seeded1) + len(t.side1) }
+func (t *FullRoundFilletTool) CountCenter() int { return len(t.seededCenter) + len(t.center) }
+func (t *FullRoundFilletTool) Count2() int      { return len(t.seeded2) + len(t.side2) }
+
+// Faces returns every picked face (all sets) so the viewport highlight (toolPicks) lights them.
+func (t *FullRoundFilletTool) Faces() []FaceHandle {
+	out := append([]FaceHandle(nil), t.side1...)
+	out = append(out, t.center...)
+	return append(out, t.side2...)
+}
+
+// ClearSide1 / ClearCenter / ClearSide2 empty a set — the panel's selector clear (×).
+func (t *FullRoundFilletTool) ClearSide1()  { t.side1, t.seeded1 = nil, nil }
+func (t *FullRoundFilletTool) ClearCenter() { t.center, t.seededCenter = nil, nil }
+func (t *FullRoundFilletTool) ClearSide2()  { t.side2, t.seeded2 = nil, nil }
+
+// keys1 / keysCenter / keys2 are the reference-key set a commit writes per set: retained keys plus
+// this session's picks.
+func (t *FullRoundFilletTool) keys1() [][]byte {
+	return appendFaceKeys(cloneKeys(t.seeded1), t.side1)
+}
+func (t *FullRoundFilletTool) keysCenter() [][]byte {
+	return appendFaceKeys(cloneKeys(t.seededCenter), t.center)
+}
+func (t *FullRoundFilletTool) keys2() [][]byte {
+	return appendFaceKeys(cloneKeys(t.seeded2), t.side2)
+}
+
+// CanCommit reports whether all three sets have at least one face.
+func (t *FullRoundFilletTool) CanCommit() bool {
+	return t.Count1() > 0 && t.CountCenter() > 0 && t.Count2() > 0
+}
+
+// Commit replaces the center face with a full round and recomputes; a sick feature (the sides are
+// not parallel, or the center does not sit between them) keeps the tool open via an error.
+func (t *FullRoundFilletTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = t.addFullRound(feature.NewDressUpFeatures(part.Features()))
+	part.Recompute()
+	s.recordEdit(part, "Full Round Fillet")
+	if !t.added.Health().OK() {
+		return errors.New("full round fillet: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// addFullRound appends the full-round feature — shared by Commit and the preview.
+func (t *FullRoundFilletTool) addFullRound(dress *feature.DressUpFeatures) *feature.PartFeature {
+	return dress.AddFullRoundFillet(t.keys1(), t.keysCenter(), t.keys2())
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *FullRoundFilletTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// DraftFeature returns the unattached full round the viewport previews before commit (the same
+// addFullRound the commit uses, so the translucent ghost is exactly what OK creates).
+func (t *FullRoundFilletTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addFullRound(feature.NewDressUpFeatures(fs)), nil
+	})
+}
+
+// commitEdit writes the panel state back into the committed full round's definition.
+func (t *FullRoundFilletTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.FullRoundFilletFeature).Definition()
+	def.Side1Keys, def.CenterKeys, def.Side2Keys = t.keys1(), t.keysCenter(), t.keys2()
+	return commitFeatureEdit(s, t.target)
+}
+
+// Prompt guides the user through the three picks.
+func (t *FullRoundFilletTool) Prompt(*Session) string {
+	switch {
+	case t.Count1() == 0:
+		return "Click the first side face"
+	case t.CountCenter() == 0:
+		return "Arm Center, then click the face to round"
+	case t.Count2() == 0:
+		return "Arm Side 2, then click the opposite side face"
+	default:
+		return "Click OK to round the center face"
+	}
+}
+
+// Cancel restores the default selection filter, or aborts the edit when re-editing.
+func (t *FullRoundFilletTool) Cancel(s *Session) {
+	if t.IsEditing() {
+		cancelFeatureEdit(s, t.target, t.restoreDef)
+		return
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+}

--- a/app/full_round_fillet_tool_test.go
+++ b/app/full_round_fillet_tool_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+)
+
+// minusXFaceOf returns the body's −X-facing planar face.
+func minusXFaceOf(t *testing.T, b *topo.Body) *topo.Face {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if f.Geometry().NormalAt(0, 0).X < -0.9 {
+			return f
+		}
+	}
+	t.Fatal("no -X face found")
+	return nil
+}
+
+// pickFullRoundSets drives the three picks on a fresh 2×2×2 block: the −X face into Side 1, the top
+// face into Center, and the +X face into Side 2 (the top sits between the two parallel sides).
+func pickFullRoundSets(t *testing.T) (*Session, *FullRoundFilletTool) {
+	t.Helper()
+	s, block := newPartWithBlock(t, 2) // 2×2×2, vol 8
+	tool := NewFullRoundFilletTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{Face: minusXFaceOf(t, block), Body: block}) // Side 1 active by default
+	tool.ArmCenter()
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	tool.ArmSide2()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	return s, tool
+}
+
+// TestFullRoundToolEndToEnd drives the Full Round UI: pick the three faces, OK — and asserts a valid
+// solid that rounded the center face (volume below the box, the top corners gone).
+func TestFullRoundToolEndToEnd(t *testing.T) {
+	s, tool := pickFullRoundSets(t)
+	if !tool.CanCommit() {
+		t.Fatal("full round not ready after all three sets")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if _, ok := tool.AddedFeature().Definition().(*feature.FullRoundFilletFeature); !ok {
+		t.Fatalf("added feature is %T, want *FullRoundFilletFeature", tool.AddedFeature().Definition())
+	}
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("full-round body not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-3}).Volume; v >= 8 {
+		t.Errorf("full round did not remove the top corners: volume %g, want < 8", v)
+	}
+}
+
+// TestFullRoundToolActiveSet checks picks land in the armed set and a face is never double-counted.
+func TestFullRoundToolActiveSet(t *testing.T) {
+	_, tool := pickFullRoundSets(t)
+	if tool.ActiveSet() != 2 {
+		t.Errorf("active set = %d after ArmSide2, want 2", tool.ActiveSet())
+	}
+	if tool.Count1() != 1 || tool.CountCenter() != 1 || tool.Count2() != 1 {
+		t.Fatalf("counts = (%d, %d, %d), want (1, 1, 1)", tool.Count1(), tool.CountCenter(), tool.Count2())
+	}
+	tool.Pick(nil, tool.Faces()[0]) // a face already in Side 1: ignored even while Side 2 is armed
+	if tool.Count2() != 1 {
+		t.Errorf("re-picking a Side-1 face added to Side 2: Count2 = %d, want 1", tool.Count2())
+	}
+	tool.ArmSide1()
+	if tool.ActiveSet() != 0 {
+		t.Errorf("active set = %d after ArmSide1, want 0", tool.ActiveSet())
+	}
+}
+
+// TestFullRoundToolNeedsThreeSets gates commit until all three sets have a face.
+func TestFullRoundToolNeedsThreeSets(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	tool := NewFullRoundFilletTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{Face: minusXFaceOf(t, block), Body: block})
+	tool.ArmCenter()
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	if tool.CanCommit() {
+		t.Error("ready with only two sets")
+	}
+	tool.ArmSide2()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	if !tool.CanCommit() {
+		t.Error("not ready after all three sets")
+	}
+}
+
+// TestFullRoundToolClearSets checks each set's clear empties only that set.
+func TestFullRoundToolClearSets(t *testing.T) {
+	_, tool := pickFullRoundSets(t)
+	tool.ClearCenter()
+	if tool.CountCenter() != 0 || tool.Count1() != 1 || tool.Count2() != 1 {
+		t.Errorf("after ClearCenter, counts = (%d, %d, %d), want (1, 0, 1)",
+			tool.Count1(), tool.CountCenter(), tool.Count2())
+	}
+	tool.ClearSide1()
+	tool.ClearSide2()
+	if tool.Count1() != 0 || tool.Count2() != 0 {
+		t.Errorf("after clearing sides, counts = (%d, %d), want (0, 0)", tool.Count1(), tool.Count2())
+	}
+}
+
+// TestFullRoundToolPromptAndName covers the name, the step-by-step prompt, the session accessor,
+// and the non-edit Cancel path.
+func TestFullRoundToolPromptAndName(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	tool := NewFullRoundFilletTool()
+	s.StartTool(tool)
+	if tool.Name() != "Full Round Fillet" {
+		t.Errorf("Name = %q, want Full Round Fillet", tool.Name())
+	}
+	if s.ActiveFullRoundFillet() != tool {
+		t.Error("ActiveFullRoundFillet did not return the running tool")
+	}
+	if got := tool.Prompt(s); got != "Click the first side face" {
+		t.Errorf("prompt with no faces = %q", got)
+	}
+	tool.Pick(s, FaceHandle{Face: minusXFaceOf(t, block), Body: block})
+	if got := tool.Prompt(s); got != "Arm Center, then click the face to round" {
+		t.Errorf("prompt with Side 1 only = %q", got)
+	}
+	tool.ArmCenter()
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	if got := tool.Prompt(s); got != "Arm Side 2, then click the opposite side face" {
+		t.Errorf("prompt with Side 1 + Center = %q", got)
+	}
+	tool.ArmSide2()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	if got := tool.Prompt(s); got != "Click OK to round the center face" {
+		t.Errorf("prompt with all three = %q", got)
+	}
+	tool.Cancel(s) // non-edit: restores the default selection filter
+}
+
+// TestFullRoundDraftPreview offers the viewport draft only once all three sets are picked.
+func TestFullRoundDraftPreview(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	tool := NewFullRoundFilletTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{Face: minusXFaceOf(t, block), Body: block})
+	if _, ok := tool.DraftFeature(s); ok {
+		t.Error("draft offered with only one set")
+	}
+	tool.ArmCenter()
+	tool.Pick(s, FaceHandle{Face: topFaceOf(t, block), Body: block})
+	tool.ArmSide2()
+	tool.Pick(s, FaceHandle{Face: plusXFaceOf(t, block), Body: block})
+	if _, ok := tool.DraftFeature(s); !ok {
+		t.Error("no draft preview after all three sets")
+	}
+}
+
+// TestFullRoundEditRoundTrip re-edits a committed full round and asserts the three sets seed back,
+// then re-commits and cancels an edit (covering commitEdit and the edit-cancel branch).
+func TestFullRoundEditRoundTrip(t *testing.T) {
+	s, tool := pickFullRoundSets(t)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	pf := tool.AddedFeature()
+	fr := pf.Definition().(*feature.FullRoundFilletFeature)
+	et := editFullRoundFilletTool(pf, fr)
+	if !et.IsEditing() || et.Count1() != 1 || et.CountCenter() != 1 || et.Count2() != 1 {
+		t.Fatalf("seeded edit = (editing:%v, %d, %d, %d), want (true, 1, 1, 1)",
+			et.IsEditing(), et.Count1(), et.CountCenter(), et.Count2())
+	}
+	s.StartTool(et)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit edit: %v", err)
+	}
+	// A fresh edit that is cancelled must leave the feature healthy.
+	ce := editFullRoundFilletTool(pf, pf.Definition().(*feature.FullRoundFilletFeature))
+	s.StartTool(ce)
+	ce.Cancel(s)
+	if !pf.Health().OK() {
+		t.Error("cancelling the edit should leave the feature healthy")
+	}
+}
+
+// TestFullRoundViaRibbonCommand checks the Full Round command (a Fillet split-button variant) starts
+// the tool.
+func TestFullRoundViaRibbonCommand(t *testing.T) {
+	s, _ := newPartWithBlock(t, 2)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.FullRoundFillet"); err != nil {
+		t.Fatalf("execute Modify.FullRoundFillet: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*FullRoundFilletTool); !ok {
+		t.Fatal("Full Round command did not start the full-round tool")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.51.0
+	oblikovati.org/api v0.52.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.51.0
+	oblikovati.org/api v0.52.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -123,6 +123,7 @@ func drawSolidFeatureDialogs(s *app.Session) {
 	drawThreadDialog(s)
 	drawFilletDialog(s)
 	drawFaceFilletDialog(s)
+	drawFullRoundFilletDialog(s)
 	drawShellDialog(s)
 	drawSplitDialog(s)
 	drawGripSnapDialog(s)

--- a/head/ui/feature_dialogs_units_test.go
+++ b/head/ui/feature_dialogs_units_test.go
@@ -59,6 +59,7 @@ func TestFeatureDialogsRenderUnitFields(t *testing.T) {
 		"sweep":      drawSweepDialog,
 		"fillet":     drawFilletDialog,
 		"faceFillet": drawFaceFilletDialog,
+		"fullRound":  drawFullRoundFilletDialog,
 		"chamfer":    drawChamferDialog,
 		"shell":      drawShellDialog,
 		"draft":      drawDraftDialog,
@@ -82,6 +83,10 @@ func TestFeatureDialogsRenderUnitFields(t *testing.T) {
 				s.ActiveFaceFillet().ArmSetB() // re-render with set 2 as the armed (accent) selector
 				frame(func() { drawFaceFilletDialog(s) })
 			}
+			if name == "fullRound" {
+				s.ActiveFullRoundFillet().ArmCenter() // re-render with the center selector armed
+				frame(func() { drawFullRoundFilletDialog(s) })
+			}
 		})
 	}
 }
@@ -95,6 +100,8 @@ func toolFor(name string) app.Tool {
 		return app.NewFilletTool()
 	case "faceFillet":
 		return app.NewFaceFilletTool()
+	case "fullRound":
+		return app.NewFullRoundFilletTool()
 	case "chamfer":
 		return app.NewChamferTool()
 	case "shell":

--- a/head/ui/full_round_fillet_dialog.go
+++ b/head/ui/full_round_fillet_dialog.go
@@ -1,0 +1,50 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The Full Round Fillet flow in the head (#694): while the tool runs, a modeless property panel
+// shows three face-set selectors — Side 1, the Center face to round, and Side 2 — then OK/Cancel.
+// There is no radius (it is derived as half the side-to-side distance).
+var fullRoundUI = struct {
+	seeded *app.FullRoundFilletTool // the tool the panel was bound to (nil = none)
+}{}
+
+// drawFullRoundFilletDialog shows the Full Round property panel while the tool is active — creating
+// a full round or re-editing a committed one (the same panel serves both).
+func drawFullRoundFilletDialog(s *app.Session) {
+	f := s.ActiveFullRoundFillet()
+	if f == nil {
+		fullRoundUI.seeded = nil
+		return
+	}
+	fullRoundUI.seeded = f
+	native.SetNextWindowSizeOnce(340, 230)
+	if native.Begin("Full Round Fillet") {
+		drawFullRoundPanelBody(s, f)
+	}
+	native.End()
+}
+
+// drawFullRoundPanelBody draws the panel's sections (the Begin/End wrapper stays in
+// drawFullRoundFilletDialog): the breadcrumb and the three face-set pickers.
+func drawFullRoundPanelBody(s *app.Session, f *app.FullRoundFilletTool) {
+	title := "Full Round Fillet"
+	if name := f.EditingName(); name != "" {
+		title = name // re-editing a committed full round: the breadcrumb names it
+	}
+	drawFeatureBreadcrumb(title, "")
+	if propertySection("Input Geometry") {
+		drawFaceSetRow("Side 1", "fullround-s1", f.Count1(), f.ActiveSet() == 0, f.ArmSide1, f.ClearSide1)
+		drawFaceSetRow("Center face", "fullround-c", f.CountCenter(), f.ActiveSet() == 1, f.ArmCenter, f.ClearCenter)
+		drawFaceSetRow("Side 2", "fullround-s2", f.Count2(), f.ActiveSet() == 2, f.ArmSide2, f.ClearSide2)
+	}
+	native.Separator()
+	drawCommitCancelButtons(s, f.CanCommit())
+}


### PR DESCRIPTION
## What

Adds the interactive **Full Round Fillet** command — picking a center face and the two parallel side faces it sits between, and replacing the center with a half-cylinder tangent to both sides (the rounded top of a rib/wall). The underlying `FullRoundFilletFeature` (merged in #1042) was previously reachable only over MCP; this brings it to viewport definition-of-done.

- **`FullRoundFilletTool` (app):** three face sets (Side 1 / Center / Side 2) with an active-set switch — picks land in the armed set, a face is never double-counted. No radius (derived as half the side-to-side distance). Commit via `AddFullRoundFillet`, draft preview, edit-mode re-seed, and a `Faces()` accessor for viewport highlighting.
- **Ribbon:** the Fillet split-button dropdown now carries **Face Fillet** (#1051) and **Full Round Fillet** (`Modify.FullRoundFillet`), grouping the fillet variants the way Inventor does.
- **`head/ui/full_round_fillet_dialog.go`:** three face-set selector chips (clicking one arms it as the pick target, accent-highlighted while active, with a clear ×).

## Why

Completes another #694 tail. Together with the Face Fillet UI (#1051), the by-face fillet variants are now usable directly in the canvas. (Non-adjacent face fillet — the gap-bridging ball-path solve — and variable/non-parallel full round remain the harder kernel efforts on #694.)

## Notes

- **/source-only — no public-API change.** `FullRoundFilletFeature` + `AddFullRoundFillet` already exist; this is the app tool + head panel + ribbon wiring.

## Tests

`app/full_round_fillet_tool_test.go`: end-to-end (pick three faces → OK → valid solid with the top corners removed), active-set routing + de-dup, commit gating on all three sets, per-set clear, the three-stage prompt + name + session accessor, draft-preview gating, an edit round-trip (re-seed + re-commit + cancel), and the ribbon command. The head dialog is rendered (with the center selector armed) in `TestFeatureDialogsRenderUnitFields` for coverage.

Live-confirmed in the real Vulkan app: the panel renders the three selectors, and committing replaces a 4×10×5 rib's flat top with a half-cylinder.

Verified: `go build ./...`, `go test ./app`, head `ui` cgo build + dialog test, `golangci-lint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)