### PR TITLE
test(router): drop stale measure allowlist entry (#428)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,12 +58,7 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{
-	// M18-F01 measurement: the contract landed in API v0.52.0 (#428) ahead of the router
-	// handler. Keyed by CONSTANT NAME (not the "analysis.measure" value). DELETE when the
-	// handler lands (the M18 agent may land it concurrently — expect to shrink this soon).
-	"MethodAnalysisMeasure": true,
-}
+var notYetHandled = map[string]bool{}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They


### PR DESCRIPTION
## What

Removes `MethodAnalysisMeasure` from the `notYetHandled` parity allowlist.

## Why

`#1054` added that entry because API v0.52.0 declared `analysis.measure` ahead of its router handler. The M18 agent has since landed the handler (`addin/router/analysis.go`), so develop now has **both** the handler and the allowlist entry, and `TestEveryWireMethodHasAHandler` fails:

```
api_parity_test.go:52: method "MethodAnalysisMeasure" is now handled — delete it from notYetHandled
```

Deleting the entry is the documented "shrink the allowlist when the handler lands" step. Restores develop to green. (Same interleave pattern as #1050 for massProperties.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)