### PR TITLE
fix: analysis.measure resolves raw reference keys (not hex)

### DIFF
--- a/addin/router/analysis.go
+++ b/addin/router/analysis.go
@@ -3,7 +3,6 @@
 package router
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -75,10 +74,10 @@ func measureEntity(body *topo.Body, mt types.MeasureType, keyA, keyB string) (fl
 	return 0, "", fmt.Errorf("analysis.measure: unsupported measure type %v", mt)
 }
 
-// decodeKey hex-decodes a reference key (an invalid string decodes to nil, which matches nothing).
+// decodeKey carries a reference key as raw bytes — matching get_reference_keys and every other
+// key-consuming wire method (body_facets, brep, assembly_features); an unknown key matches nothing.
 func decodeKey(s string) []byte {
-	b, _ := hex.DecodeString(s)
-	return b
+	return []byte(s)
 }
 
 func analysisMassProperties(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -3,7 +3,7 @@
 package router
 
 import (
-	"encoding/hex"
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -55,25 +55,27 @@ func TestAnalysisMeasureOverWire(t *testing.T) {
 		t.Fatalf("ActivePart: %v", err)
 	}
 	body := part.SurfaceBodies().Item(0)
-	edgeKey := hex.EncodeToString(body.Edges()[0].ReferenceKey())
-	faceKey := hex.EncodeToString(body.Faces()[0].ReferenceKey())
+	edgeKey := string(body.Edges()[0].ReferenceKey())
+	faceKey := string(body.Faces()[0].ReferenceKey())
 
+	// Reference keys carry raw bytes (e.g. a leading \x02); marshal via a map so they are JSON-escaped,
+	// exactly as the bridge sends them — string concatenation would emit invalid JSON.
 	var m wire.MeasureResult
-	call(t, r, s, "analysis.measure", `{"type":"length","keyA":"`+edgeKey+`"}`, &m)
+	call(t, r, s, "analysis.measure", measureArgs(t, "length", edgeKey, ""), &m)
 	if m.Unit != "mm" || !nearAny(m.Value, 40, 30, 50) {
 		t.Errorf("edge length = %+v, want one of 40/30/50 mm", m)
 	}
-	call(t, r, s, "analysis.measure", `{"type":"area","keyA":"`+faceKey+`"}`, &m)
+	call(t, r, s, "analysis.measure", measureArgs(t, "area", faceKey, ""), &m)
 	if m.Unit != "mm²" || !nearAny(m.Value, 1200, 1500, 2000) {
 		t.Errorf("face area = %+v, want one of 1200/1500/2000 mm²", m)
 	}
-	vA := hex.EncodeToString(body.Vertices()[0].ReferenceKey())
-	vB := hex.EncodeToString(body.Vertices()[1].ReferenceKey())
-	call(t, r, s, "analysis.measure", `{"type":"distance","keyA":"`+vA+`","keyB":"`+vB+`"}`, &m)
+	vA := string(body.Vertices()[0].ReferenceKey())
+	vB := string(body.Vertices()[1].ReferenceKey())
+	call(t, r, s, "analysis.measure", measureArgs(t, "distance", vA, vB), &m)
 	if m.Unit != "mm" || m.Value <= 0 {
 		t.Errorf("vertex distance = %+v, want a positive mm distance", m)
 	}
-	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"distance","keyA":"`+vA+`"}`)); err == nil {
+	if _, err := r.Handle(s, "analysis.measure", []byte(measureArgs(t, "distance", vA, ""))); err == nil {
 		t.Error("distance with one vertex key = ok, want error")
 	}
 	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"bogus","keyA":"00"}`)); err == nil {
@@ -82,6 +84,21 @@ func TestAnalysisMeasureOverWire(t *testing.T) {
 	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"length","keyA":"dead"}`)); err == nil {
 		t.Error("measure with an unknown edge key = ok, want error")
 	}
+}
+
+// measureArgs JSON-encodes analysis.measure arguments through a map, so raw reference-key bytes are
+// escaped exactly as the bridge sends them (an omitted keyB stays absent).
+func measureArgs(t *testing.T, measureType, keyA, keyB string) string {
+	t.Helper()
+	args := map[string]any{"type": measureType, "keyA": keyA}
+	if keyB != "" {
+		args["keyB"] = keyB
+	}
+	b, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal measure args: %v", err)
+	}
+	return string(b)
 }
 
 // nearAny reports whether v is within 0.01 of any of the candidate values.

--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,12 +58,7 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{
-	// M18-F01 measurement: the contract landed in API v0.52.0 (#428) ahead of the router
-	// handler. Keyed by CONSTANT NAME (not the "analysis.measure" value). DELETE when the
-	// handler lands (the M18 agent may land it concurrently — expect to shrink this soon).
-	"MethodAnalysisMeasure": true,
-}
+var notYetHandled = map[string]bool{}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They


### PR DESCRIPTION
## What & why

Live bridge e2e for `analysis_measure` failed to resolve any entity:
`analysis.measure: no edge for key "\x02Extrusion1:bottom-edge#0"`.

Root cause: `get_reference_keys` emits reference keys as **raw byte strings**
(matching how `body_facets`, `brep`, and `assembly_features` resolve keys),
but the measure handler hex-decoded them — so real bridge keys matched nothing.
The in-process router test only passed because it hex round-tripped its own keys.

This makes `decodeKey` carry keys as raw bytes (`[]byte(s)`), aligning measure
with every other key-consuming wire method. The router test now marshals args
through a map so the raw key's control byte is JSON-escaped exactly as the
bridge sends it.

Also clears the stale `notYetHandled["MethodAnalysisMeasure"]` entry — its
handler already shipped (#1053), so the api-parity guard was failing on develop.

Pairs with API #169 (corrects the misleading "hex reference key" docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)