### PR TITLE
feat(fillet): non-adjacent face fillet via heal-to-virtual-edge (#694)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.52.0
+	oblikovati.org/api v0.52.1
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.52.0
+	oblikovati.org/api v0.52.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -6,14 +6,18 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 )
 
 // FaceFilletDefinition rounds the edges shared between two face sets with a rolling-ball blend of
 // the given radius — the adjacent-faces case of Inventor's face fillet (FilletConstantRadiusFaceSet,
 // #694), where the two sets meet at one or more edges. Picking by face (rather than by edge) is the
 // natural selection when a long chain of edges separates two regions. Non-adjacent face sets, where
-// the ball bridges a gap between faces that share no edge, are a follow-up.
+// the two faces share no edge, are handled by healing the gap to the virtual edge (see
+// nonAdjacentFaceFilletBody).
 type FaceFilletDefinition struct {
 	FaceKeysA [][]byte
 	FaceKeysB [][]byte
@@ -41,9 +45,9 @@ func (f *FaceFilletFeature) Recompute(in Input) (Output, error) {
 	return faceFilletBody(in, f.def.FaceKeysA, f.def.FaceKeysB, callOrZero(f.def.Radius), "face-fillet")
 }
 
-// faceFilletBody resolves the edges shared between the two face sets on the running body and rounds
-// them with the constant-radius edge-fillet kernel. No shared edge is an error (the feature goes
-// Sick): non-adjacent face sets, which need a gap-bridging rolling-ball path, are not yet supported.
+// faceFilletBody rounds the edges between the two face sets with the constant-radius edge fillet.
+// When the sets share edges it rounds them directly; when they share none (non-adjacent) it heals
+// the gap to the virtual edge first (nonAdjacentFaceFilletBody).
 func faceFilletBody(in Input, faceKeysA, faceKeysB [][]byte, radius float64, feat string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
@@ -54,10 +58,162 @@ func faceFilletBody(in Input, faceKeysA, faceKeysB [][]byte, radius float64, fea
 	}
 	edgeKeys := sharedEdgeKeys(body, faceKeysA, faceKeysB)
 	if len(edgeKeys) == 0 {
-		return Output{}, fmt.Errorf("%s: the two face sets share no edge "+
-			"(non-adjacent face fillet is not yet supported)", feat)
+		return nonAdjacentFaceFilletBody(in, body, faceKeysA, faceKeysB, radius, feat)
 	}
 	return filletBody(in, edgeKeys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, feat)
+}
+
+// nonAdjacentFaceFilletBody rounds two face sets that share no edge (#694): it deletes the faces in
+// the gap between them so the two sets HEAL together at the virtual edge their planes define, then
+// rounds that recreated edge with the constant-radius edge fillet. The heal recreates the true edge
+// (with its real convexity), so the existing fillet — and its tessellation — just works; there is no
+// case-dependent boolean to choose. Only faces whose planes intersect (a real virtual edge) are
+// supported; parallel faces have no edge to heal to (the slot/full-round case) and error.
+func nonAdjacentFaceFilletBody(in Input, body *topo.Body, faceKeysA, faceKeysB [][]byte, radius float64, feat string) (Output, error) {
+	gap := gapFaceKeys(body, faceKeysA, faceKeysB)
+	if len(gap) == 0 {
+		return Output{}, fmt.Errorf("%s: the two face sets are not separated by a fillable gap "+
+			"(parallel or disjoint faces are not supported)", feat)
+	}
+	healed, err := ops.DeleteFaces(planarized(body, feat), gap)
+	if err != nil {
+		return Output{}, fmt.Errorf("%s: healing the gap between the faces: %w", feat, err)
+	}
+	edgeKeys := healedEdgeKeys(healed, body, faceKeysA, faceKeysB)
+	if len(edgeKeys) == 0 {
+		return Output{}, fmt.Errorf("%s: the faces did not heal to a shared edge to round", feat)
+	}
+	picks := make([]ops.EdgeFilletRadii, len(edgeKeys))
+	for i, k := range edgeKeys {
+		picks[i] = ops.EdgeFilletRadii{Key: k, R0: radius, R1: radius}
+	}
+	result, err := ops.FilletEdgesCorner(healed, picks, ops.CornerMiter, ops.FillConcaveOutward)
+	if err != nil {
+		return Output{}, fmt.Errorf("%s: %w", feat, err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// gapFaceKeys returns the reference keys of the faces that bridge the gap between the two sets: a
+// face neither in A nor B that borders SOME face in A and SOME face in B, and whose normal faces
+// partly the same way as both (so it sits in the corner between them). The normal test excludes
+// shared neighbours that merely touch both sets (e.g. an end cap perpendicular to the blend axis).
+func gapFaceKeys(body *topo.Body, faceKeysA, faceKeysB [][]byte) [][]byte {
+	inA, inB := keyLookup(faceKeysA), keyLookup(faceKeysB)
+	nsA, nsB := planeNormals(body, faceKeysA), planeNormals(body, faceKeysB)
+	var out [][]byte
+	for _, f := range body.Faces() {
+		k := string(f.ReferenceKey())
+		if inA[k] || inB[k] {
+			continue
+		}
+		n, ok := planarFaceNormal(f)
+		if !ok || !bordersSet(f, inA) || !bordersSet(f, inB) {
+			continue
+		}
+		if facesToward(n, nsA) && facesToward(n, nsB) {
+			out = append(out, f.ReferenceKey())
+		}
+	}
+	return out
+}
+
+// healedEdgeKeys returns the edges of the healed body whose two faces lie on the planes of an A face
+// and a B face — the virtual edge(s) the heal recreated between the two sets.
+func healedEdgeKeys(healed, orig *topo.Body, faceKeysA, faceKeysB [][]byte) [][]byte {
+	plA, plB := facePlanes(orig, faceKeysA), facePlanes(orig, faceKeysB)
+	var out [][]byte
+	for _, e := range healed.Edges() {
+		fs := e.Faces()
+		if len(fs) != 2 {
+			continue
+		}
+		p0, ok0 := facePlane(fs[0])
+		p1, ok1 := facePlane(fs[1])
+		if !ok0 || !ok1 {
+			continue
+		}
+		if (onAnyPlane(p0, plA) && onAnyPlane(p1, plB)) || (onAnyPlane(p0, plB) && onAnyPlane(p1, plA)) {
+			out = append(out, e.ReferenceKey())
+		}
+	}
+	return out
+}
+
+// bordersSet reports whether face f shares an edge with any face in the set.
+func bordersSet(f *topo.Face, set map[string]bool) bool {
+	for _, e := range f.Edges() {
+		for _, nb := range e.Faces() {
+			if nb != f && set[string(nb.ReferenceKey())] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// facesToward reports whether n has a positive dot with at least one of the set normals.
+func facesToward(n math.Vector3, normals []math.Vector3) bool {
+	for _, m := range normals {
+		if float64(n.Dot(m)) > 1e-9 {
+			return true
+		}
+	}
+	return false
+}
+
+// planarFaceNormal / facePlane read a face's plane (normal), reporting false for a non-planar face.
+func planarFaceNormal(f *topo.Face) (math.Vector3, bool) {
+	pl, ok := f.Geometry().(geom.Plane)
+	if !ok {
+		return math.Vector3{}, false
+	}
+	return pl.Normal(), true
+}
+
+func facePlane(f *topo.Face) (geom.Plane, bool) {
+	pl, ok := f.Geometry().(geom.Plane)
+	return pl, ok
+}
+
+// planeNormals / facePlanes collect the planes (or just normals) of the named faces on body.
+func planeNormals(body *topo.Body, keys [][]byte) []math.Vector3 {
+	var out []math.Vector3
+	for _, p := range facePlanes(body, keys) {
+		out = append(out, p.Normal())
+	}
+	return out
+}
+
+func facePlanes(body *topo.Body, keys [][]byte) []geom.Plane {
+	var out []geom.Plane
+	for _, k := range keys {
+		if f, ok := body.FindFaceByKey(k); ok {
+			if pl, ok := facePlane(f); ok {
+				out = append(out, pl)
+			}
+		}
+	}
+	return out
+}
+
+// onAnyPlane reports whether plane p coincides with any plane in the set (same normal and offset).
+func onAnyPlane(p geom.Plane, set []geom.Plane) bool {
+	for _, q := range set {
+		if float64(p.Normal().Dot(q.Normal())) > 0.999 &&
+			abs(float64(p.Origin.VectorTo(q.Origin).Dot(q.Normal()))) < 1e-6 {
+			return true
+		}
+	}
+	return false
+}
+
+// abs is the float64 absolute value (local to avoid a math import alias clash).
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 // sharedEdgeKeys returns the reference key of every edge of body whose two adjacent faces lie one in

--- a/model/feature/face_fillet_test.go
+++ b/model/feature/face_fillet_test.go
@@ -74,8 +74,51 @@ func TestFaceFilletRoundsSharedEdge(t *testing.T) {
 	}
 }
 
+// TestFaceFilletNonAdjacentHealsAndRounds: a 4×4×4 box with a chamfered vertical edge — the +X and
+// +Y faces share no edge (the chamfer face separates them). The non-adjacent face fillet heals the
+// chamfer to the virtual edge and rounds it: a valid solid whose volume is the FULL box minus one
+// quarter-round (the chamfer absorbed), r=1 over a length-4 edge (#694).
+func TestFaceFilletNonAdjacentHealsAndRounds(t *testing.T) {
+	pent := []math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 3}, {X: 3, Y: 4}, {X: 0, Y: 4}}
+	box := buildPrism(pent, sketch.XYPlane(), span{near: 0, far: 4}, 0, "box")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+
+	xf := faceKeyByNormal(t, box, math.V3(1, 0, 0))
+	yf := faceKeyByNormal(t, box, math.V3(0, 1, 0))
+	pf := NewDressUpFeatures(fs).AddFaceFillet([][]byte{xf}, [][]byte{yf}, func() float64 { return 1 })
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("non-adjacent face fillet sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("non-adjacent face fillet not a valid solid: %+v", r)
+	}
+	if !hasCylinderFace(res) {
+		t.Error("non-adjacent face fillet produced no cylindrical face")
+	}
+	want := 64 - (1*1-stdmath.Pi/4)*4 // full box minus the quarter-round notch, length 4
+	if got := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-4}).Volume; relErr(got, want) > 2e-3 {
+		t.Errorf("non-adjacent face fillet volume = %g, want ≈ %g", got, want)
+	}
+}
+
+// faceKeyByNormal returns the reference key of the body's planar face whose normal points along n.
+func faceKeyByNormal(t *testing.T, b *topo.Body, n math.Vector3) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if pl, ok := f.Geometry().(geom.Plane); ok && float64(pl.Normal().Dot(n)) > 0.99 {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatalf("no planar face with normal %v", n)
+	return nil
+}
+
 // TestFaceFilletNonAdjacentSick: two parallel faces that share no edge (top and bottom) cannot be
-// filleted by this adjacent-faces slice — the feature goes Sick rather than silently doing nothing.
+// healed to a virtual edge (their planes never meet) — the feature goes Sick rather than silently
+// doing nothing.
 func TestFaceFilletNonAdjacentSick(t *testing.T) {
 	fs, face := boxAndPlanarFace(t)
 	pf := NewDressUpFeatures(fs).AddFaceFillet([][]byte{face('z', 2)}, [][]byte{face('z', 0)}, func() float64 { return 0.3 })


### PR DESCRIPTION
## What

A **face fillet between two face sets that share no edge** (separated by a chamfer/step) previously went Sick ("not yet supported"). It now heals the gap and rounds the recreated edge — completing the last geometry tail of #694's by-face fillet.

**Approach (`nonAdjacentFaceFilletBody`):** find the faces bridging the gap (those bordering *both* sets whose normal faces toward both — the normal test excludes shared neighbours like end caps), `ops.DeleteFaces` them so the two sets **heal together at the virtual edge** their planes define, then round that recreated edge with the existing constant-radius edge fillet.

**Why this is the right construction:** because the heal recreates the *true* virtual edge with its real convexity, the existing edge fillet — and its tessellation — just works. There's **no case-dependent boolean direction** to decide (the hard part the issue flagged). I validated in a spike that a raw boolean union does *not* work — it leaves coplanar face fragments → a non-manifold edge-fillet input; `DeleteFaces` heals cleanly instead.

Only faces whose planes intersect (a real virtual edge) are supported; parallel faces have no edge to heal to (the slot/full-round case) and still error — the existing `TestFaceFilletNonAdjacentSick` is preserved.

## Why

Closes the non-adjacent slice of #694. Together with the adjacent face fillet (#1019/#1051) and full round (#1042/#1054), the by-face fillet now handles faces meeting at an edge **and** separated by a gap.

## Notes

- **/source-only — no public-API change.** Reachable through the existing **Face Fillet UI** (#1051) and the opregistry `faceFillet` path — `faceFilletBody` is the shared entry, so no UI/MCP wiring changed.

## Tests

`TestFaceFilletNonAdjacentHealsAndRounds`: a 4×4×4 box with a chamfered vertical edge (the +X and +Y faces share no edge) heals + rounds to the **full box minus one quarter-round** (exact volume), a valid solid with a cylinder face. The parallel-faces-Sick case is retained.

Live-confirmed in the real Vulkan app: driving the Face Fillet tool on the two non-adjacent faces of a chamfered box replaces the chamfer with a tangent round.

Verified: `go build ./...`, `go test ./model/feature ./addin/opregistry ./app`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)