### PR TITLE
feat: minimum-distance measurement between entities (M18-F01 PBI-164, #428)

### DIFF
--- a/addin/router/analysis.go
+++ b/addin/router/analysis.go
@@ -52,26 +52,65 @@ func measureEntity(body *topo.Body, mt types.MeasureType, keyA, keyB string) (fl
 	q := ops.DefaultQuality()
 	switch mt {
 	case types.MeasureLength:
-		e, ok := body.FindEdgeByKey(decodeKey(keyA))
-		if !ok {
-			return 0, "", fmt.Errorf("analysis.measure: no edge for key %q", keyA)
-		}
-		return analysis.EdgeLengthMm(e, q), "mm", nil
+		return measureEdgeLength(body, keyA, q)
 	case types.MeasureArea:
-		f, ok := body.FindFaceByKey(decodeKey(keyA))
-		if !ok {
-			return 0, "", fmt.Errorf("analysis.measure: no face for key %q", keyA)
-		}
-		return analysis.FaceAreaMm2(f, q), "mm²", nil
+		return measureFaceArea(body, keyA, q)
 	case types.MeasureDistance:
-		a, okA := body.FindVertexByKey(decodeKey(keyA))
-		b, okB := body.FindVertexByKey(decodeKey(keyB))
-		if !okA || !okB {
-			return 0, "", fmt.Errorf("analysis.measure: distance needs two vertex keys (keyA=%q, keyB=%q)", keyA, keyB)
-		}
-		return analysis.VertexDistanceMm(a, b), "mm", nil
+		return measureVertexDistance(body, keyA, keyB)
+	case types.MeasureMinDistance:
+		return measureMinDistance(body, keyA, keyB, q)
 	}
 	return 0, "", fmt.Errorf("analysis.measure: unsupported measure type %v", mt)
+}
+
+func measureEdgeLength(body *topo.Body, keyA string, q ops.Quality) (float64, string, error) {
+	e, ok := body.FindEdgeByKey(decodeKey(keyA))
+	if !ok {
+		return 0, "", fmt.Errorf("analysis.measure: no edge for key %q", keyA)
+	}
+	return analysis.EdgeLengthMm(e, q), "mm", nil
+}
+
+func measureFaceArea(body *topo.Body, keyA string, q ops.Quality) (float64, string, error) {
+	f, ok := body.FindFaceByKey(decodeKey(keyA))
+	if !ok {
+		return 0, "", fmt.Errorf("analysis.measure: no face for key %q", keyA)
+	}
+	return analysis.FaceAreaMm2(f, q), "mm²", nil
+}
+
+func measureVertexDistance(body *topo.Body, keyA, keyB string) (float64, string, error) {
+	a, okA := body.FindVertexByKey(decodeKey(keyA))
+	b, okB := body.FindVertexByKey(decodeKey(keyB))
+	if !okA || !okB {
+		return 0, "", fmt.Errorf("analysis.measure: distance needs two vertex keys (keyA=%q, keyB=%q)", keyA, keyB)
+	}
+	return analysis.VertexDistanceMm(a, b), "mm", nil
+}
+
+func measureMinDistance(body *topo.Body, keyA, keyB string, q ops.Quality) (float64, string, error) {
+	a, errA := resolveMeasureEntity(body, keyA)
+	b, errB := resolveMeasureEntity(body, keyB)
+	if errA != nil || errB != nil {
+		return 0, "", fmt.Errorf("analysis.measure: minDistance needs two entity keys (keyA=%q, keyB=%q)", keyA, keyB)
+	}
+	return analysis.MinDistanceMm(a, b, q), "mm", nil
+}
+
+// resolveMeasureEntity resolves a reference key to a vertex, edge or face of the body (whichever it
+// names), for entity-to-entity measurement.
+func resolveMeasureEntity(body *topo.Body, key string) (analysis.MeasureEntity, error) {
+	k := decodeKey(key)
+	if f, ok := body.FindFaceByKey(k); ok {
+		return analysis.MeasureEntity{Face: f}, nil
+	}
+	if e, ok := body.FindEdgeByKey(k); ok {
+		return analysis.MeasureEntity{Edge: e}, nil
+	}
+	if v, ok := body.FindVertexByKey(k); ok {
+		return analysis.MeasureEntity{Vertex: v}, nil
+	}
+	return analysis.MeasureEntity{}, fmt.Errorf("analysis.measure: no entity for key %q", key)
 }
 
 // decodeKey carries a reference key as raw bytes — matching get_reference_keys and every other

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -78,6 +78,20 @@ func TestAnalysisMeasureOverWire(t *testing.T) {
 	if _, err := r.Handle(s, "analysis.measure", []byte(measureArgs(t, "distance", vA, ""))); err == nil {
 		t.Error("distance with one vertex key = ok, want error")
 	}
+
+	// minDistance between two faces of the box equals one of its dimensions (opposite) or 0 (adjacent).
+	allFaces := body.Faces()
+	fA := string(allFaces[0].ReferenceKey())
+	for i := 1; i < len(allFaces); i++ {
+		fB := string(allFaces[i].ReferenceKey())
+		call(t, r, s, "analysis.measure", measureArgs(t, "minDistance", fA, fB), &m)
+		if m.Unit != "mm" || !nearAny(m.Value, 0, 30, 40, 50) {
+			t.Errorf("minDistance(face0,face%d) = %+v, want one of 0/30/40/50 mm", i, m)
+		}
+	}
+	if _, err := r.Handle(s, "analysis.measure", []byte(measureArgs(t, "minDistance", fA, "nope"))); err == nil {
+		t.Error("minDistance with an unknown entity key = ok, want error")
+	}
 	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"bogus","keyA":"00"}`)); err == nil {
 		t.Error("measure with a bad type = ok, want error")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.52.1
+	oblikovati.org/api v0.53.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.52.1
+	oblikovati.org/api v0.53.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/mindistance.go
+++ b/kernel/ops/mindistance.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Minimum-distance geometry primitives (M18-F01 PBI-164, Oblikovati/Oblikovati#428): closest
+// approach between two simplices (segment or triangle). Topology entities reduce to these — a
+// vertex to a zero-length segment, an edge to its polyline segments, a face to its mesh triangles —
+// so the entity-level minimum distance is the smallest of all simplex-pair distances. The closest
+// points of two disjoint convex simplices lie on their boundaries, so each pair routine is exact;
+// intersecting triangles report zero. Builds on closestPointOnTriangle and rayTriangleDist.
+
+// SegmentSegmentDistance returns the minimum distance between segments p1q1 and p2q2, clamped to
+// both endpoints (Ericson, Real-Time Collision Detection §5.1.9). Handles zero-length segments
+// (a point), so it doubles as point-point and point-segment distance.
+func SegmentSegmentDistance(p1, q1, p2, q2 math.Point3) float64 {
+	d1 := p1.VectorTo(q1)
+	d2 := p2.VectorTo(q2)
+	r := p2.VectorTo(p1)
+	a := float64(d1.Dot(d1))
+	e := float64(d2.Dot(d2))
+	s, t := segmentParams(a, e, float64(d2.Dot(r)), float64(d1.Dot(r)), float64(d1.Dot(d2)))
+	c1 := p1.TranslateBy(d1.Scale(math.Scalar(s)))
+	c2 := p2.TranslateBy(d2.Scale(math.Scalar(t)))
+	return float64(c1.DistanceTo(c2))
+}
+
+// segmentParams solves the clamped closest-point parameters s,t∈[0,1] for two segments from the
+// precomputed dot products: a=|d1|², e=|d2|², f=d2·r, c=d1·r, b=d1·d2, with r = p1−p2.
+func segmentParams(a, e, f, c, b float64) (s, t float64) {
+	const eps = 1e-15
+	if a <= eps && e <= eps {
+		return 0, 0
+	}
+	if a <= eps { // segment 1 degenerates to a point
+		return 0, clamp01(f / e)
+	}
+	if e <= eps { // segment 2 degenerates to a point
+		return clamp01(-c / a), 0
+	}
+	if denom := a*e - b*b; denom > eps {
+		s = clamp01((b*f - c*e) / denom)
+	}
+	return reclampSForT(s, (b*s+f)/e, a, b, c)
+}
+
+// reclampSForT re-derives s after clamping t back into [0,1] (the unclamped t left the segment).
+func reclampSForT(s, t, a, b, c float64) (float64, float64) {
+	if t < 0 {
+		return clamp01(-c / a), 0
+	}
+	if t > 1 {
+		return clamp01((b - c) / a), 1
+	}
+	return s, t
+}
+
+// SegmentTriangleDistance returns the minimum distance between segment s0s1 and triangle abc; zero
+// when the segment pierces the triangle.
+func SegmentTriangleDistance(s0, s1, a, b, c math.Point3) float64 {
+	if segmentHitsTriangle(s0, s1, a, b, c) {
+		return 0
+	}
+	best := pointTriangleDistance(s0, a, b, c)
+	best = stdmath.Min(best, pointTriangleDistance(s1, a, b, c))
+	best = stdmath.Min(best, SegmentSegmentDistance(s0, s1, a, b))
+	best = stdmath.Min(best, SegmentSegmentDistance(s0, s1, b, c))
+	return stdmath.Min(best, SegmentSegmentDistance(s0, s1, c, a))
+}
+
+// segmentHitsTriangle reports whether segment s0s1 crosses triangle abc within its extent.
+func segmentHitsTriangle(s0, s1, a, b, c math.Point3) bool {
+	t, ok := rayTriangleDist(s0, s0.VectorTo(s1), a, b, c)
+	return ok && t <= 1
+}
+
+// TriangleTriangleDistance returns the minimum distance between two triangles (zero when they
+// intersect): the closest approach of disjoint triangles lies on an edge of one against the other,
+// which the six edge-vs-triangle tests (covering edge-edge and vertex-face) cover exhaustively.
+func TriangleTriangleDistance(a1, b1, c1, a2, b2, c2 math.Point3) float64 {
+	best := SegmentTriangleDistance(a1, b1, a2, b2, c2)
+	best = stdmath.Min(best, SegmentTriangleDistance(b1, c1, a2, b2, c2))
+	best = stdmath.Min(best, SegmentTriangleDistance(c1, a1, a2, b2, c2))
+	best = stdmath.Min(best, SegmentTriangleDistance(a2, b2, a1, b1, c1))
+	best = stdmath.Min(best, SegmentTriangleDistance(b2, c2, a1, b1, c1))
+	return stdmath.Min(best, SegmentTriangleDistance(c2, a2, a1, b1, c1))
+}

--- a/kernel/ops/mindistance_test.go
+++ b/kernel/ops/mindistance_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+func p3(x, y, z float64) gmath.Point3 { return gmath.P3(x, y, z) }
+
+func approxDist(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s = %.12g, want %.12g", name, got, want)
+	}
+}
+
+// TestSegmentSegmentDistance checks the analytic cases: parallel offset, crossing (zero),
+// skew, and a degenerate (point) segment.
+func TestSegmentSegmentDistance(t *testing.T) {
+	// Two parallel unit segments offset by 3 in y.
+	approxDist(t, "parallel", SegmentSegmentDistance(
+		p3(0, 0, 0), p3(1, 0, 0), p3(0, 3, 0), p3(1, 3, 0)), 3)
+	// Crossing segments in the z=0 plane touch → 0.
+	approxDist(t, "crossing", SegmentSegmentDistance(
+		p3(-1, 0, 0), p3(1, 0, 0), p3(0, -1, 0), p3(0, 1, 0)), 0)
+	// Skew: x-axis segment and a z-offset y-axis segment shifted in z by 2 → 2.
+	approxDist(t, "skew", SegmentSegmentDistance(
+		p3(-1, 0, 0), p3(1, 0, 0), p3(0, -1, 2), p3(0, 1, 2)), 2)
+	// A degenerate segment (point) 5 above a segment's midpoint → 5.
+	approxDist(t, "point-segment", SegmentSegmentDistance(
+		p3(0, 5, 0), p3(0, 5, 0), p3(-2, 0, 0), p3(2, 0, 0)), 5)
+}
+
+// TestSegmentTriangleDistance checks a segment above a triangle, a piercing segment (zero),
+// and a segment beyond a triangle edge.
+func TestSegmentTriangleDistance(t *testing.T) {
+	a, b, c := p3(0, 0, 0), p3(4, 0, 0), p3(0, 4, 0) // triangle in z=0
+	// Segment parallel to the plane, 3 above the interior → 3.
+	approxDist(t, "above", SegmentTriangleDistance(
+		p3(1, 1, 3), p3(1, 1, 5), a, b, c), 3)
+	// Segment piercing the triangle interior → 0.
+	approxDist(t, "pierce", SegmentTriangleDistance(
+		p3(1, 1, -1), p3(1, 1, 1), a, b, c), 0)
+	// A point 2 in −x beyond vertex a → 2.
+	approxDist(t, "beyond-vertex", SegmentTriangleDistance(
+		p3(-2, 0, 0), p3(-2, 0, 0), a, b, c), 2)
+}
+
+// TestTriangleTriangleDistance checks parallel triangles (gap), an edge-edge gap, and
+// intersecting triangles (zero).
+func TestTriangleTriangleDistance(t *testing.T) {
+	a, b, c := p3(0, 0, 0), p3(4, 0, 0), p3(0, 4, 0)
+	// Identical triangle lifted 2 in z → 2.
+	approxDist(t, "parallel", TriangleTriangleDistance(
+		a, b, c, p3(0, 0, 2), p3(4, 0, 2), p3(0, 4, 2)), 2)
+	// A triangle that crosses the first → 0.
+	approxDist(t, "intersect", TriangleTriangleDistance(
+		a, b, c, p3(1, 1, -1), p3(1, 1, 1), p3(2, 2, 1)), 0)
+}

--- a/model/analysis/mindistance.go
+++ b/model/analysis/mindistance.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Minimum distance (M18-F01 PBI-164, #428): the closest approach between two model entities of any
+// kind. Each entity reduces to tessellated simplices — a vertex to a zero-length segment, an edge
+// to its polyline segments, a face to its mesh triangles — and the minimum distance is the smallest
+// over all simplex pairs (see kernel/ops mindistance). Result is millimetres; zero when the
+// entities touch or intersect.
+
+// MeasureEntity is a resolved model entity (exactly one of Vertex/Edge/Face) for distance queries.
+type MeasureEntity struct {
+	Vertex *topo.Vertex
+	Edge   *topo.Edge
+	Face   *topo.Face
+}
+
+// segment is a line segment, triangle a mesh triangle — both in database units (centimetres).
+type segment struct{ a, b math.Point3 }
+type triangle struct{ a, b, c math.Point3 }
+
+// MinDistanceMm returns the minimum distance in millimetres between two entities.
+func MinDistanceMm(a, b MeasureEntity, q ops.Quality) float64 {
+	segA, triA := a.simplices(q)
+	segB, triB := b.simplices(q)
+	best := stdmath.Inf(1)
+	best = minSegSeg(best, segA, segB)
+	best = minSegTri(best, segA, triB)
+	best = minSegTri(best, segB, triA)
+	best = minTriTri(best, triA, triB)
+	return best * cmToMM
+}
+
+// simplices returns the entity's segments and triangles in database units.
+func (e MeasureEntity) simplices(q ops.Quality) ([]segment, []triangle) {
+	switch {
+	case e.Vertex != nil:
+		p := e.Vertex.Point()
+		return []segment{{p, p}}, nil
+	case e.Edge != nil:
+		return edgeSegments(e.Edge, q), nil
+	case e.Face != nil:
+		return nil, faceTriangles(e.Face, q)
+	}
+	return nil, nil
+}
+
+func edgeSegments(e *topo.Edge, q ops.Quality) []segment {
+	pts := ops.TessellateEdge(e, q)
+	segs := make([]segment, 0, len(pts))
+	for i := 1; i < len(pts); i++ {
+		segs = append(segs, segment{pts[i-1], pts[i]})
+	}
+	return segs
+}
+
+func faceTriangles(f *topo.Face, q ops.Quality) []triangle {
+	mesh := ops.TessellateFace(f, q)
+	tris := make([]triangle, 0, mesh.TriangleCount())
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		tris = append(tris, triangle{
+			mesh.Positions[mesh.Indices[t]], mesh.Positions[mesh.Indices[t+1]], mesh.Positions[mesh.Indices[t+2]]})
+	}
+	return tris
+}
+
+func minSegSeg(best float64, as, bs []segment) float64 {
+	for _, x := range as {
+		for _, y := range bs {
+			best = stdmath.Min(best, ops.SegmentSegmentDistance(x.a, x.b, y.a, y.b))
+		}
+	}
+	return best
+}
+
+func minSegTri(best float64, segs []segment, tris []triangle) float64 {
+	for _, s := range segs {
+		for _, t := range tris {
+			best = stdmath.Min(best, ops.SegmentTriangleDistance(s.a, s.b, t.a, t.b, t.c))
+		}
+	}
+	return best
+}
+
+func minTriTri(best float64, as, bs []triangle) float64 {
+	for _, x := range as {
+		for _, y := range bs {
+			best = stdmath.Min(best, ops.TriangleTriangleDistance(x.a, x.b, x.c, y.a, y.b, y.c))
+		}
+	}
+	return best
+}

--- a/model/analysis/mindistance_test.go
+++ b/model/analysis/mindistance_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	gmath "oblikovati.org/math"
+)
+
+// TestMinDistanceBox checks minimum distance on a 4×3×5 cm (40×30×50 mm) block:
+//   - the farthest face pair (opposite 40×30 faces) is 50 mm apart;
+//   - some face pair touches (adjacent faces share an edge) → 0;
+//   - a corner vertex sits on three faces (distance 0) and is 30/40/50 mm from the opposite three;
+//   - opposite corners are the space diagonal apart, matching VertexDistanceMm.
+func TestMinDistanceBox(t *testing.T) {
+	block, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(4, 3, 5), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	q := ops.DefaultQuality()
+	faces := block.Faces()
+
+	maxPair, minPair := 0.0, math.Inf(1)
+	for i := range faces {
+		for j := i + 1; j < len(faces); j++ {
+			d := MinDistanceMm(MeasureEntity{Face: faces[i]}, MeasureEntity{Face: faces[j]}, q)
+			maxPair = math.Max(maxPair, d)
+			minPair = math.Min(minPair, d)
+		}
+	}
+	if math.Abs(maxPair-50) > 1e-6 {
+		t.Errorf("max face-pair min-distance = %g mm, want 50 (opposite 40×30 faces)", maxPair)
+	}
+	if minPair > 1e-6 {
+		t.Errorf("min face-pair min-distance = %g mm, want 0 (adjacent faces touch)", minPair)
+	}
+
+	// A corner vertex: three faces touch it (0), the opposite three are the box dimensions away.
+	v := block.Vertices()[0]
+	var gaps []float64
+	for _, f := range faces {
+		if d := MinDistanceMm(MeasureEntity{Vertex: v}, MeasureEntity{Face: f}, q); d > 1e-6 {
+			gaps = append(gaps, d)
+		}
+	}
+	if !sameSet(gaps, []float64{30, 40, 50}) {
+		t.Errorf("vertex-to-opposite-face gaps = %v mm, want {30,40,50}", gaps)
+	}
+
+	// Vertex-vertex min-distance equals the straight-line vertex distance (space diagonal here).
+	var diag float64
+	for _, w := range block.Vertices() {
+		if d := MinDistanceMm(MeasureEntity{Vertex: v}, MeasureEntity{Vertex: w}, q); d > diag {
+			diag = d
+		}
+	}
+	if want := math.Sqrt(40*40 + 30*30 + 50*50); math.Abs(diag-want) > 1e-6 {
+		t.Errorf("space diagonal = %g mm, want %g", diag, want)
+	}
+}
+
+// sameSet reports whether got contains exactly the wanted values (within tolerance, any order).
+func sameSet(got, want []float64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	used := make([]bool, len(got))
+	for _, w := range want {
+		matched := false
+		for i, g := range got {
+			if !used[i] && math.Abs(g-w) < 1e-6 {
+				used[i], matched = true, true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What & why

Implements the **minDistance** measure — the closest approach between two model
entities of any kind (vertex/edge/face), matching the reference
`GetMinimumDistance`. Zero when the entities touch or intersect.

### How
Each entity reduces to tessellated simplices — a vertex → a point, an edge →
its polyline segments, a face → its mesh triangles — and the minimum distance
is the smallest over all simplex pairs:

- **kernel/ops** — exact `SegmentSegmentDistance`, `SegmentTriangleDistance`
  (zero when the segment pierces), `TriangleTriangleDistance` (six
  edge-vs-triangle tests covering edge-edge and vertex-face). Reuses the
  existing `closestPointOnTriangle`/`rayTriangleDist`. Analytic unit tests
  (parallel/skew/crossing/pierce).
- **model/analysis** — `MinDistanceMm` over an entity's simplices; box test
  asserts the farthest face pair = 50 mm, an adjacent pair = 0, and a corner
  vertex is {30,40,50} mm from its opposite faces.
- **addin/router** — `minDistance` case resolving each key to whichever entity
  (vertex/edge/face) it names.

Pins API **v0.53.0** (the `MeasureMinDistance` enum).

Acceptance (#428): *Min-distance between two faces matches reference within tolerance.* ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)