### PR TITLE
feat(fillet): non-parallel full round via sliver-prism tool (#694)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.52.1
+	oblikovati.org/api v0.53.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.52.1
+	oblikovati.org/api v0.53.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/full_round_fillet.go
+++ b/model/feature/full_round_fillet.go
@@ -15,18 +15,18 @@ import (
 )
 
 // FullRoundFilletDefinition is a full-round fillet (#694, Inventor FilletFullRoundSet): it replaces a
-// CENTER face between two parallel SIDE faces with a half-cylinder tangent to both sides, removing the
-// center face — the rounded top of a rib/wall. Unlike an edge fillet (which fails to fully consume the
-// center face at the round radius), this is built by reconstruction: a tool the size of the center-face
-// footprint (a box minus the round cylinder = the two sharp corners) is cut from the body, so it stays
-// local to the rib and leaves a clean half-round. The radius is half the side-to-side distance.
+// CENTER face between two SIDE faces with a round tangent to both sides, removing the center face —
+// the rounded top of a rib/wall. PARALLEL sides give a constant half-cylinder (radius = half the
+// side-to-side distance); CONVERGING (non-parallel) sides give a round whose radius is the value
+// tangent to both with its apex on the center plane. Built by reconstruction (a cut tool), not an
+// edge fillet, since an edge fillet cannot fully consume the center face at the round radius.
 type FullRoundFilletDefinition struct {
 	Side1Keys  [][]byte
 	CenterKeys [][]byte
 	Side2Keys  [][]byte
 }
 
-// FullRoundFilletFeature rounds a center face into a half-cylinder between two parallel sides.
+// FullRoundFilletFeature rounds a center face into a round between two sides (parallel or converging).
 type FullRoundFilletFeature struct{ def *FullRoundFilletDefinition }
 
 // Definition returns the feature's definition.
@@ -40,10 +40,11 @@ func (f *FullRoundFilletFeature) Recompute(in Input) (Output, error) {
 	return fullRoundFilletBody(in, f.def, "full-round-fillet")
 }
 
-// fullRoundFilletBody reconstructs the full round: it derives the rib frame from the three faces,
-// builds a corner tool (the center-face-footprint box minus the round cylinder) and cuts it from the
-// body. Non-planar faces, non-parallel sides, or a degenerate frame are clean errors (the feature
-// goes Sick) — this slice handles the parallel-sides case (variable-radius rounds are a follow-up).
+// fullRoundFilletBody reconstructs the full round, dispatching on whether the sides are parallel.
+// PARALLEL sides give a constant half-cylinder, cut as a corner tool (the center-face-footprint box
+// minus the round cylinder). NON-PARALLEL sides converge to a virtual apex, so the round's radius is
+// the value tangent to both sides with its apex on the center plane, cut as per-side sliver prisms
+// (nonParallelFullRound). Non-planar faces or a degenerate frame are clean errors (the feature Sick).
 func fullRoundFilletBody(in Input, def *FullRoundFilletDefinition, feat string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
@@ -53,6 +54,27 @@ func fullRoundFilletBody(in Input, def *FullRoundFilletDefinition, feat string) 
 	if err != nil {
 		return Output{}, err
 	}
+	side1, err := singlePlanarFace(body, def.Side1Keys, feat, "side1")
+	if err != nil {
+		return Output{}, err
+	}
+	side2, err := singlePlanarFace(body, def.Side2Keys, feat, "side2")
+	if err != nil {
+		return Output{}, err
+	}
+	if parallelSides(side1, side2) {
+		return parallelFullRound(in, body, def, center, feat)
+	}
+	return nonParallelFullRound(in, body, center, side1, side2, feat)
+}
+
+// parallelSides reports whether the two side faces' planes are parallel (the constant-cylinder case).
+func parallelSides(side1, side2 planarFace) bool {
+	return abs(float64(normalize(side1.Normal()).Dot(normalize(side2.Normal())))) > 0.999
+}
+
+// parallelFullRound cuts the constant half-cylinder corner tool between two parallel sides.
+func parallelFullRound(in Input, body *topo.Body, def *FullRoundFilletDefinition, center planarFace, feat string) (Output, error) {
 	fr, err := fullRoundFrame(body, def, center, feat)
 	if err != nil {
 		return Output{}, err
@@ -68,6 +90,156 @@ func fullRoundFilletBody(in Input, def *FullRoundFilletDefinition, feat string) 
 		return Output{}, err
 	}
 	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// convergingFrame is the geometry of a non-parallel full round: the tangent cylinder's axis point C
+// and radius r, the rib axis, the in-cross-section "cross" direction, up (center normal), and the
+// center-face centroid pc.
+type convergingFrame struct {
+	C, pc           math.Point3
+	r               float64
+	axis, up, cross math.Vector3
+}
+
+// nonParallelFullRound rounds the center face between two converging (non-parallel) sides (#694): it
+// cuts a corner SLIVER PRISM at each side — the region between the original top corner/side and the
+// round arc — so the round is tangent to both sides with its apex on the center plane (it replaces
+// the center face exactly, removing the top corners). Bounding each sliver at its side's tangent line
+// is what avoids undercutting the rib below the round (a plain boolean tool cannot, since the tangent
+// cylinder bulges outside the slanted sides below the tangent).
+func nonParallelFullRound(in Input, body *topo.Body, center, side1, side2 planarFace, feat string) (Output, error) {
+	fr, err := convergingRoundFrame(center, side1, side2, feat)
+	if err != nil {
+		return Output{}, err
+	}
+	l := faceExtentAlong(center.face, fr.pc, fr.axis) + 4*fr.r // overhang so the prism spans the rib
+	result := body
+	for _, side := range []planarFace{side1, side2} {
+		prism, perr := cornerSliverPrism(fr, l, center, side, feat)
+		if perr != nil {
+			return Output{}, perr
+		}
+		result, err = ops.Boolean(ops.Cut, planarized(result, feat), prism)
+		if err != nil {
+			return Output{}, fmt.Errorf("%s: cutting the corner round: %w", feat, err)
+		}
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+}
+
+// convergingRoundFrame solves the tangent cylinder for non-parallel sides: a cylinder tangent to
+// both side planes (axis ∥ their intersection line) whose apex — its topmost point along +up —
+// lies on the center-face plane, so it replaces the center face exactly. The axis point C and radius
+// r satisfy (C−o1)·n1 = (C−o2)·n2 = (C−pc)·up = −r with C in the cross-section through pc; eliminating
+// r gives a 3×3 system in C, then r = −n1·(C−o1).
+func convergingRoundFrame(center, side1, side2 planarFace, feat string) (convergingFrame, error) {
+	up := normalize(center.Normal())
+	n1, n2 := normalize(side1.Normal()), normalize(side2.Normal())
+	axis := normalize(n1.Cross(n2))
+	if float64(axis.Dot(axis)) < 0.5 {
+		return convergingFrame{}, fmt.Errorf("%s: the side faces are parallel (no converging apex)", feat)
+	}
+	pc := center.face.RangeBox().Center()
+	o1, o2 := side1.Origin, side2.Origin
+	C, ok := linearSolve3(n1.Sub(n2), n1.Sub(up), axis,
+		planeDot(n1, o1)-planeDot(n2, o2), planeDot(n1, o1)-planeDot(up, pc), planeDot(axis, pc))
+	if !ok {
+		return convergingFrame{}, fmt.Errorf("%s: cannot solve the round geometry (degenerate faces)", feat)
+	}
+	r := -float64(n1.Dot(o1.VectorTo(C)))
+	if r <= 1e-9 {
+		return convergingFrame{}, fmt.Errorf("%s: the sides do not form a positive round (radius %g)", feat, r)
+	}
+	return convergingFrame{C: C, pc: pc, r: r, axis: axis, up: up, cross: normalize(up.Cross(axis))}, nil
+}
+
+// cornerSliverPrism builds one corner of the non-parallel round as a prism in the cross-section
+// (cross, up) plane through C: the sliver polygon is the original top corner, down the side to its
+// tangent point (C + r·n), the round arc (chorded) back to the apex (C + r·up), then along the center
+// face back to the corner — extruded ±l/2 along the rib axis.
+func cornerSliverPrism(fr convergingFrame, l float64, center, side planarFace, feat string) (*topo.Body, error) {
+	n := normalize(side.Normal())
+	corner, ok := sharedEdgeMidpoint(center.face, side.face)
+	if !ok {
+		return nil, fmt.Errorf("%s: the center face does not border a side", feat)
+	}
+	to2 := func(p math.Point3) math.Point2 {
+		d := fr.C.VectorTo(p)
+		return math.P2(float64(fr.cross.Dot(d)), float64(fr.up.Dot(d)))
+	}
+	tangent2, apex2 := to2(fr.C.TranslateBy(n.Scale(fr.r))), to2(fr.C.TranslateBy(fr.up.Scale(fr.r)))
+	poly := append([]math.Point2{to2(corner), tangent2}, roundArcChords(tangent2, apex2, fr.r)...)
+	plane, err := sketch.NewPlane(fr.C, fr.cross.AsUnit(), fr.up.AsUnit())
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", feat, err)
+	}
+	return buildPrism(poly, plane, span{near: -l / 2, far: l / 2}, 0, feat), nil
+}
+
+// roundArcChords samples the round circle (centre origin in the cross-section, radius r) from the
+// tangent point to the apex the short way, returning points j=1..k (apex included, tangent not — it
+// is already in the polygon). Density matches the hole/fillet facet convention.
+func roundArcChords(tangent, apex math.Point2, r float64) []math.Point2 {
+	a0 := stdmath.Atan2(float64(tangent.Y), float64(tangent.X))
+	a1 := stdmath.Atan2(float64(apex.Y), float64(apex.X))
+	for a1-a0 > stdmath.Pi {
+		a1 -= 2 * stdmath.Pi
+	}
+	for a0-a1 > stdmath.Pi {
+		a1 += 2 * stdmath.Pi
+	}
+	k := int(stdmath.Ceil(stdmath.Abs(a1-a0) / (2 * stdmath.Pi / 32)))
+	if k < 2 {
+		k = 2
+	}
+	out := make([]math.Point2, 0, k)
+	for j := 1; j <= k; j++ {
+		a := a0 + (a1-a0)*float64(j)/float64(k)
+		out = append(out, math.P2(r*stdmath.Cos(a), r*stdmath.Sin(a)))
+	}
+	return out
+}
+
+// sharedEdgeMidpoint returns the midpoint of an edge shared by faces a and b, if any.
+func sharedEdgeMidpoint(a, b *topo.Face) (math.Point3, bool) {
+	for _, e := range a.Edges() {
+		for _, f := range e.Faces() {
+			if f == b {
+				return e.StartVertex().Point().Midpoint(e.EndVertex().Point()), true
+			}
+		}
+	}
+	return math.Point3{}, false
+}
+
+// planeDot is n·(p as a position vector) — the plane-equation constant for normal n through p.
+func planeDot(n math.Vector3, p math.Point3) float64 { return float64(n.Dot(p.AsVector())) }
+
+// linearSolve3 solves [rowA;rowB;rowC]·x = [a;b;c] by Cramer's rule, reporting false if singular.
+func linearSolve3(rowA, rowB, rowC math.Vector3, a, b, c float64) (math.Point3, bool) {
+	m := [3][3]float64{
+		{float64(rowA.X), float64(rowA.Y), float64(rowA.Z)},
+		{float64(rowB.X), float64(rowB.Y), float64(rowB.Z)},
+		{float64(rowC.X), float64(rowC.Y), float64(rowC.Z)},
+	}
+	det3 := func(mm [3][3]float64) float64 {
+		return mm[0][0]*(mm[1][1]*mm[2][2]-mm[1][2]*mm[2][1]) -
+			mm[0][1]*(mm[1][0]*mm[2][2]-mm[1][2]*mm[2][0]) +
+			mm[0][2]*(mm[1][0]*mm[2][1]-mm[1][1]*mm[2][0])
+	}
+	det := det3(m)
+	if stdmath.Abs(det) < 1e-12 {
+		return math.Point3{}, false
+	}
+	col := func(i int, v [3]float64) [3][3]float64 {
+		mm := m
+		for r := 0; r < 3; r++ {
+			mm[r][i] = v[r]
+		}
+		return mm
+	}
+	rhs := [3]float64{a, b, c}
+	return math.P3(det3(col(0, rhs))/det, det3(col(1, rhs))/det, det3(col(2, rhs))/det), true
 }
 
 // ribFrame is the orthonormal frame + radius of a full round, derived from the three faces.
@@ -179,7 +351,7 @@ func normalize(v math.Vector3) math.Vector3 {
 	return math.V3(0, 0, 0)
 }
 
-// AddFullRoundFillet replaces the center face with a full round between the two parallel side faces
+// AddFullRoundFillet replaces the center face with a full round between the two side faces (parallel or converging)
 // (#694). Each set is a single planar face.
 func (c *DressUpFeatures) AddFullRoundFillet(side1Keys, centerKeys, side2Keys [][]byte) *PartFeature {
 	return c.engine.Add(&FullRoundFilletFeature{def: &FullRoundFilletDefinition{

--- a/model/feature/full_round_fillet_test.go
+++ b/model/feature/full_round_fillet_test.go
@@ -3,10 +3,12 @@
 package feature
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
@@ -61,14 +63,74 @@ func TestFullRoundRoundsRibTop(t *testing.T) {
 	}
 }
 
-// TestFullRoundRejectsNonParallelSides: choosing a side and the top (not parallel) is a clean error.
-func TestFullRoundRejectsNonParallelSides(t *testing.T) {
+// TestFullRoundRejectsDegenerateSide: reusing the center face as a side cannot resolve a round — a
+// clean error (the would-be sides share the center's plane, so there is no enclosed round).
+func TestFullRoundRejectsDegenerateSide(t *testing.T) {
 	fs, s1, ctr, _ := ribForFullRound(t)
-	pf := NewDressUpFeatures(fs).AddFullRoundFillet(s1, ctr, ctr) // ctr (top) is not parallel to s1
+	pf := NewDressUpFeatures(fs).AddFullRoundFillet(s1, ctr, ctr) // side2 == center
 	fs.Recompute()
 	if pf.Health().OK() {
-		t.Error("full round with non-parallel sides should be sick")
+		t.Error("full round with the center reused as a side should be sick")
 	}
+}
+
+// TestFullRoundConvergingSides: a trapezoidal rib (sides converge upward) full-rounds the narrow top
+// between the two slanted sides (#694). The round is tangent to both sides with its apex on the
+// original top plane — a valid solid whose volume DROPS (corners rounded off) and whose apex stays at
+// the original top height (no upward bulge). The round is faceted (the boolean planarizes it).
+func TestFullRoundConvergingSides(t *testing.T) {
+	trap := []math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 3, Y: 2}, {X: 1, Y: 2}}
+	rib := buildPrism(trap, sketch.XYPlane(), span{near: 0, far: 6}, 0, "rib")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(rib)
+	orig := ops.BodyGeometryProperties(rib, ops.DefaultQuality()).Volume
+
+	top := faceKeyByNormal(t, rib, math.V3(0, 1, 0)) // narrow +Y top = center
+	pf := NewDressUpFeatures(fs).AddFullRoundFillet(
+		[][]byte{slantedSideKey(t, rib, -1)}, [][]byte{top}, [][]byte{slantedSideKey(t, rib, +1)})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("converging full round sick: %+v", pf.Health())
+	}
+	res := fs.Result()[0]
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("converging full round not a valid solid: %+v", r)
+	}
+	v := ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume
+	if v >= orig {
+		t.Errorf("converging full round volume = %g, want < %g (corners rounded off)", v, orig)
+	}
+	if maxY := maxVertexY(res); maxY > 2.0001 {
+		t.Errorf("round apex maxY = %g, want ≈2 (no bulge above the original top)", maxY)
+	}
+}
+
+// slantedSideKey returns the key of the trapezoid rib's slanted side whose normal has the given X sign.
+func slantedSideKey(t *testing.T, b *topo.Body, sign float64) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok {
+			continue
+		}
+		n := pl.Normal()
+		if float64(n.Dot(math.V3(0, 1, 0))) > 0.2 && float64(n.X)*sign > 0.2 {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatalf("no slanted side with X sign %g", sign)
+	return nil
+}
+
+// maxVertexY returns the highest vertex Y over all the body's faces.
+func maxVertexY(b *topo.Body) float64 {
+	hi := stdmath.Inf(-1)
+	for _, f := range b.Faces() {
+		for _, v := range f.Vertices() {
+			hi = stdmath.Max(hi, float64(v.Point().Y))
+		}
+	}
+	return hi
 }
 
 // TestFullRoundRejectsMissingFace: an unknown face key is a clean error.


### PR DESCRIPTION
## What

The full round fillet now handles **non-parallel (converging) sides**, not just the parallel half-cylinder case. A trapezoidal/drafted rib's narrow top can be rounded between its two slanted sides.

`fullRoundFilletBody` dispatches on `parallelSides`:
- **Parallel** → the existing corner-tool cut (unchanged).
- **Converging** → `nonParallelFullRound`: the round is the cylinder tangent to both side planes whose **apex lies on the center plane** (so it replaces the center face exactly, removing the top corners). The axis point + radius come from a 3×3 solve (`convergingRoundFrame`). It's cut as a per-side **sliver prism**: the cross-section sliver bounded by the original top corner → down the side to its tangent point → the round arc (chorded) → back to the apex → along the center face, extruded along the rib.

## Why the sliver prism (not a plain boolean)

I validated in a spike that boolean tools (slab/wedge minus the tangent cylinder) **undercut** the rib: below the tangent line the tangent cylinder bulges *outside* the slanted sides, so no plane/slab/half-space can bound the cut there. The parallel case avoids this only because tangent = axis level. Bounding each sliver at its side's **tangent line** is what keeps the rib below the round intact. (Confirmed empirically: `body − cylinder` left only 4.3 of 36; the sliver-prism build leaves the correct 33.9 with the apex at the original top.)

## Notes

- **/source-only — no public-API change.** Reachable through the existing **Full Round UI** (#1054) — the tool picks Side 1 / Center / Side 2 and the feature computes the radius. No radius input needed.
- Round is faceted (the boolean planarizes the chorded arc), same convention as the parallel full round.

## Tests

`TestFullRoundConvergingSides`: a trapezoidal rib's top rounds to a valid solid with volume **dropping** (corners off) and the **apex staying at the original top height** (no upward bulge — the failure mode of the earlier wrong delete-heal approach). The parallel regression (`TestFullRoundRoundsRibTop`) is unchanged; the degenerate-side rejection is retained.

Live-confirmed in the real Vulkan app: the Full Round tool on a converging trapezoidal rib replaces the top with a round tangent to both slanted sides.

Verified: `go build ./...`, `go test ./model/feature ./addin/opregistry ./app`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)