### PR TITLE
feat: angle measurement between entities (M18-F01 PBI-164, #428)

### DIFF
--- a/addin/router/analysis.go
+++ b/addin/router/analysis.go
@@ -34,13 +34,13 @@ func analysisMeasure(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	}
 	mt, ok := types.ParseMeasureType(in.Type)
 	if !ok {
-		return nil, fmt.Errorf("analysis.measure: unknown measure type %q (want length|area|distance)", in.Type)
+		return nil, fmt.Errorf("analysis.measure: unknown measure type %q (want length|area|distance|minDistance|angle)", in.Type)
 	}
 	bodies := part.SurfaceBodies().All()
 	if in.BodyIndex < 0 || in.BodyIndex >= len(bodies) {
 		return nil, fmt.Errorf("analysis.measure: body index %d out of range [0,%d)", in.BodyIndex, len(bodies))
 	}
-	value, unit, err := measureEntity(bodies[in.BodyIndex], mt, in.KeyA, in.KeyB)
+	value, unit, err := measureEntity(bodies[in.BodyIndex], mt, in.KeyA, in.KeyB, in.KeyC)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func analysisMeasure(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 }
 
 // measureEntity resolves the entity (or pair) by reference key and computes the requested quantity.
-func measureEntity(body *topo.Body, mt types.MeasureType, keyA, keyB string) (float64, string, error) {
+func measureEntity(body *topo.Body, mt types.MeasureType, keyA, keyB, keyC string) (float64, string, error) {
 	q := ops.DefaultQuality()
 	switch mt {
 	case types.MeasureLength:
@@ -59,6 +59,8 @@ func measureEntity(body *topo.Body, mt types.MeasureType, keyA, keyB string) (fl
 		return measureVertexDistance(body, keyA, keyB)
 	case types.MeasureMinDistance:
 		return measureMinDistance(body, keyA, keyB, q)
+	case types.MeasureAngle:
+		return measureAngle(body, keyA, keyB, keyC, q)
 	}
 	return 0, "", fmt.Errorf("analysis.measure: unsupported measure type %v", mt)
 }
@@ -95,6 +97,34 @@ func measureMinDistance(body *topo.Body, keyA, keyB string, q ops.Quality) (floa
 		return 0, "", fmt.Errorf("analysis.measure: minDistance needs two entity keys (keyA=%q, keyB=%q)", keyA, keyB)
 	}
 	return analysis.MinDistanceMm(a, b, q), "mm", nil
+}
+
+// measureAngle returns a two-entity angle (edge/face), or a three-vertex angle when keyC is given.
+func measureAngle(body *topo.Body, keyA, keyB, keyC string, q ops.Quality) (float64, string, error) {
+	if keyC != "" {
+		return threePointAngle(body, keyA, keyB, keyC)
+	}
+	a, errA := resolveMeasureEntity(body, keyA)
+	b, errB := resolveMeasureEntity(body, keyB)
+	if errA != nil || errB != nil {
+		return 0, "", fmt.Errorf("analysis.measure: angle needs two entity keys (keyA=%q, keyB=%q)", keyA, keyB)
+	}
+	deg, err := analysis.AngleDegrees(a, b, q)
+	if err != nil {
+		return 0, "", err
+	}
+	return deg, "deg", nil
+}
+
+// threePointAngle returns the angle at apex vertex keyB between vertices keyA and keyC.
+func threePointAngle(body *topo.Body, keyA, keyB, keyC string) (float64, string, error) {
+	a, okA := body.FindVertexByKey(decodeKey(keyA))
+	apex, okB := body.FindVertexByKey(decodeKey(keyB))
+	c, okC := body.FindVertexByKey(decodeKey(keyC))
+	if !okA || !okB || !okC {
+		return 0, "", fmt.Errorf("analysis.measure: angle needs three vertex keys (keyA=%q, keyB=%q, keyC=%q)", keyA, keyB, keyC)
+	}
+	return analysis.ThreePointAngleDegrees(a, apex, c), "deg", nil
 }
 
 // resolveMeasureEntity resolves a reference key to a vertex, edge or face of the body (whichever it

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -98,6 +98,34 @@ func TestAnalysisMeasureOverWire(t *testing.T) {
 	if _, err := r.Handle(s, "analysis.measure", []byte(`{"type":"length","keyA":"dead"}`)); err == nil {
 		t.Error("measure with an unknown edge key = ok, want error")
 	}
+
+	// angle between two faces of the box is 90° (adjacent) or 180° (opposite).
+	for i := 1; i < len(allFaces); i++ {
+		call(t, r, s, "analysis.measure", measureArgs(t, "angle", fA, string(allFaces[i].ReferenceKey())), &m)
+		if m.Unit != "deg" || (!nearAny(m.Value, 90) && !nearAny(m.Value, 180)) {
+			t.Errorf("angle(face0,face%d) = %+v, want 90 or 180 deg", i, m)
+		}
+	}
+	// angle on two vertices (no direction) errors.
+	if _, err := r.Handle(s, "analysis.measure", []byte(measureArgs(t, "angle", vA, vB))); err == nil {
+		t.Error("angle on two vertices = ok, want error")
+	}
+	// three-vertex angle is reported as a degree in [0,180].
+	vC := string(body.Vertices()[2].ReferenceKey())
+	call(t, r, s, "analysis.measure", threeKeyArgs(t, "angle", vA, vB, vC), &m)
+	if m.Unit != "deg" || m.Value < 0 || m.Value > 180 {
+		t.Errorf("three-point angle = %+v, want a degree in [0,180]", m)
+	}
+}
+
+// threeKeyArgs JSON-encodes analysis.measure arguments with all three keys (raw-byte safe).
+func threeKeyArgs(t *testing.T, measureType, keyA, keyB, keyC string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"type": measureType, "keyA": keyA, "keyB": keyB, "keyC": keyC})
+	if err != nil {
+		t.Fatalf("marshal measure args: %v", err)
+	}
+	return string(b)
 }
 
 // measureArgs JSON-encodes analysis.measure arguments through a map, so raw reference-key bytes are

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.53.0
+	oblikovati.org/api v0.54.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.53.0
+	oblikovati.org/api v0.54.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/analysis/angle.go
+++ b/model/analysis/angle.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Angle measurement (M18-F01 PBI-164, #428): the angle between two entities, mirroring the
+// reference GetAngle. Each entity contributes a direction — an edge its chord (tangent for a
+// straight edge), a planar face its outward normal — and the result is the angle between those two
+// directions, in degrees over [0,180]. A three-vertex form measures the angle at the apex.
+
+// AngleDegrees returns the angle in degrees between two entities (an edge's direction or a planar
+// face's normal), over [0,180].
+func AngleDegrees(a, b MeasureEntity, q ops.Quality) (float64, error) {
+	da, err := entityDirection(a, q)
+	if err != nil {
+		return 0, err
+	}
+	db, err := entityDirection(b, q)
+	if err != nil {
+		return 0, err
+	}
+	return angleBetweenDeg(da, db), nil
+}
+
+// ThreePointAngleDegrees returns the angle at apex between apex→p and apex→r, in degrees over
+// [0,180] — the angle of the three vertices with apex in the middle.
+func ThreePointAngleDegrees(p, apex, r *topo.Vertex) float64 {
+	return angleBetweenDeg(apex.Point().VectorTo(p.Point()), apex.Point().VectorTo(r.Point()))
+}
+
+// entityDirection derives the angle direction of an entity: an edge's chord or a planar face's
+// outward normal. A vertex has no direction and is rejected.
+func entityDirection(e MeasureEntity, q ops.Quality) (math.Vector3, error) {
+	switch {
+	case e.Edge != nil:
+		return edgeDirection(e.Edge, q)
+	case e.Face != nil:
+		return faceNormal(e.Face, q)
+	}
+	return math.Vector3{}, fmt.Errorf("angle: entity must be an edge or a face (got a vertex or nothing)")
+}
+
+// edgeDirection is the chord from an edge's first to last tessellated point (the exact direction of
+// a straight edge). A closed edge (zero chord) has no single direction and is rejected.
+func edgeDirection(e *topo.Edge, q ops.Quality) (math.Vector3, error) {
+	pts := ops.TessellateEdge(e, q)
+	if len(pts) < 2 {
+		return math.Vector3{}, fmt.Errorf("angle: edge has %d tessellation points, need ≥2", len(pts))
+	}
+	d := pts[0].VectorTo(pts[len(pts)-1])
+	if d.LengthSquared() == 0 {
+		return math.Vector3{}, fmt.Errorf("angle: closed edge has no single direction")
+	}
+	return d, nil
+}
+
+// faceNormal is the outward normal of a face, from its first non-degenerate mesh triangle (constant
+// for a planar face; the first triangle's normal for a curved one).
+func faceNormal(f *topo.Face, q ops.Quality) (math.Vector3, error) {
+	mesh := ops.TessellateFace(f, q)
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		a := mesh.Positions[mesh.Indices[t]]
+		n := a.VectorTo(mesh.Positions[mesh.Indices[t+1]]).Cross(a.VectorTo(mesh.Positions[mesh.Indices[t+2]]))
+		if n.LengthSquared() > 0 {
+			return n, nil
+		}
+	}
+	return math.Vector3{}, fmt.Errorf("angle: face has no non-degenerate triangle to take a normal from")
+}
+
+// angleBetweenDeg is the angle in degrees between two vectors, over [0,180].
+func angleBetweenDeg(u, v math.Vector3) float64 {
+	lu, lv := float64(u.Length()), float64(v.Length())
+	if lu == 0 || lv == 0 {
+		return 0
+	}
+	cos := float64(u.Dot(v)) / (lu * lv)
+	cos = stdmath.Max(-1, stdmath.Min(1, cos))
+	return stdmath.Acos(cos) * 180 / stdmath.Pi
+}

--- a/model/analysis/angle_test.go
+++ b/model/analysis/angle_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+)
+
+// TestAngleBox checks angle measurement on a 4×3×5 cm block: every face is 90° from each adjacent
+// face and 180° from its opposite, every meeting edge pair is 90°, and the three edges at a corner
+// vertex make 90° three-point angles.
+func TestAngleBox(t *testing.T) {
+	block, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(4, 3, 5), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	q := ops.DefaultQuality()
+	faces := block.Faces()
+
+	sawOpposite := false
+	for i := range faces {
+		for j := i + 1; j < len(faces); j++ {
+			deg, err := AngleDegrees(MeasureEntity{Face: faces[i]}, MeasureEntity{Face: faces[j]}, q)
+			if err != nil {
+				t.Fatalf("AngleDegrees(face%d,face%d): %v", i, j, err)
+			}
+			if !near(deg, 90) && !near(deg, 180) {
+				t.Errorf("angle(face%d,face%d) = %g°, want 90 or 180", i, j, deg)
+			}
+			if near(deg, 180) {
+				sawOpposite = true
+			}
+		}
+	}
+	if !sawOpposite {
+		t.Error("no opposite face pair measured 180°")
+	}
+
+	// A vertex has no direction → entity angle rejects it.
+	if _, err := AngleDegrees(MeasureEntity{Vertex: block.Vertices()[0]}, MeasureEntity{Face: faces[0]}, q); err == nil {
+		t.Error("AngleDegrees(vertex, face) = ok, want error")
+	}
+}
+
+// TestAngleEdgesAndThreePoint checks a perpendicular edge pair and a corner three-point angle.
+func TestAngleEdgesAndThreePoint(t *testing.T) {
+	block, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(4, 3, 5), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	q := ops.DefaultQuality()
+
+	// Adjacent box edges meet at right angles: at least one edge pair measures 90°.
+	edges := block.Edges()
+	sawRight := false
+	for i := range edges {
+		for j := i + 1; j < len(edges); j++ {
+			deg, err := AngleDegrees(MeasureEntity{Edge: edges[i]}, MeasureEntity{Edge: edges[j]}, q)
+			if err != nil {
+				t.Fatalf("edge angle: %v", err)
+			}
+			if near(deg, 90) {
+				sawRight = true
+			}
+		}
+	}
+	if !sawRight {
+		t.Error("no perpendicular edge pair measured 90°")
+	}
+
+	// Three box corners sharing axes: apex (0,0,0) to (4,0,0) and (0,3,0) is a right angle.
+	apex := vertexAt(t, block, 0, 0, 0)
+	px := vertexAt(t, block, 4, 0, 0)
+	py := vertexAt(t, block, 0, 3, 0)
+	if deg := ThreePointAngleDegrees(px, apex, py); !near(deg, 90) {
+		t.Errorf("three-point angle = %g°, want 90", deg)
+	}
+}
+
+func vertexAt(t *testing.T, b *topo.Body, x, y, z float64) *topo.Vertex {
+	t.Helper()
+	want := gmath.P3(x, y, z)
+	for _, v := range b.Vertices() {
+		if v.Point().DistanceTo(want) < 1e-6 {
+			return v
+		}
+	}
+	t.Fatalf("no vertex at (%g,%g,%g)", x, y, z)
+	return nil
+}
+
+func near(got, want float64) bool { return math.Abs(got-want) < 1e-6 }


### PR DESCRIPTION
## What & why

Implements the **angle** measure — the angle in degrees between two entities
(an edge's chord direction or a planar face's outward normal), over [0,180],
mirroring the reference `GetAngle`. A three-vertex form measures the angle at
apex vertex `keyB` between vertices `keyA` and `keyC`.

### How
- **model/analysis/angle.go** — `entityDirection` (edge chord / first
  non-degenerate face-triangle normal), `AngleDegrees` between two entities,
  `ThreePointAngleDegrees` for the vertex apex. Box test: every face pair is
  90° (adjacent) or 180° (opposite), perpendicular edges 90°, corner three-
  point 90°.
- **addin/router** — `angle` case threading `keyC`; the two-entity form
  rejects vertices (no direction), the three-vertex form needs three vertices.

Pins API **v0.54.0** (the `MeasureAngle` enum + `KeyC`). The bridge e2e lands
in a follow-up PR.

Part of M18-F01 PBI-164 (#428).

🤖 Generated with [Claude Code](https://claude.com/claude-code)