### PR TITLE
feat(attributes): document attribute sets — storage + persistence + router (#155)

### DIFF
--- a/addin/router/attributes.go
+++ b/addin/router/attributes.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/identity"
+)
+
+// Add-in attribute sets (#155): named, typed values an add-in attaches to a document and that
+// persist with it. This surface targets the document itself — its sets are anchored under
+// [identity.DocumentKey] in the document's [attr.AttributeManager] — and values cross the wire as
+// the shared [types.Variant], converted to/from the model [attr.Value] by the document-properties
+// helpers (variantFromValue / valueFromVariant).
+
+// registerAttributeHandlers wires the attributes.* methods.
+func (r *Router) registerAttributeHandlers() {
+	r.handlers[wire.MethodAttributesSet] = setAttribute
+	r.handlers[wire.MethodAttributesGet] = getAttribute
+	r.handlers[wire.MethodAttributesList] = listAttributes
+	r.handlers[wire.MethodAttributesListSets] = listAttributeSets
+	r.handlers[wire.MethodAttributesDelete] = deleteAttribute
+	r.handlers[wire.MethodAttributesFind] = findByAttribute
+}
+
+// documentAttributeSets resolves the open document's document-level attribute sets, anchored under
+// the well-known [identity.DocumentKey].
+func documentAttributeSets(s *app.Session, id uint64, method string) (*attr.AttributeSets, error) {
+	d, err := documentByID(s, id)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	return d.Attributes().AttributeSets(identity.DocumentKey()), nil
+}
+
+// setAttribute creates or replaces the named attribute in the set with the typed value.
+func setAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetAttributeArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Set == "" || in.Name == "" {
+		return nil, fmt.Errorf("%s: a set and a name are required", wire.MethodAttributesSet)
+	}
+	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesSet)
+	if err != nil {
+		return nil, err
+	}
+	a := ss.Set(in.Set).Put(in.Name, valueFromVariant(in.Value))
+	return json.Marshal(wire.AttributeResult{Attribute: attributeInfo(in.Set, a), Found: true})
+}
+
+// getAttribute reads one attribute by set and name; Found is false when it is absent.
+func getAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.GetAttributeArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesGet)
+	if err != nil {
+		return nil, err
+	}
+	set, ok := ss.Lookup(in.Set)
+	if !ok {
+		return json.Marshal(notFoundAttribute(in.Set, in.Name))
+	}
+	a, ok := set.Attribute(in.Name)
+	if !ok {
+		return json.Marshal(notFoundAttribute(in.Set, in.Name))
+	}
+	return json.Marshal(wire.AttributeResult{Attribute: attributeInfo(in.Set, a), Found: true})
+}
+
+// listAttributes returns every attribute on the document, or only those in Set when it is set.
+func listAttributes(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListAttributesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesList)
+	if err != nil {
+		return nil, err
+	}
+	var infos []wire.AttributeInfo
+	for _, set := range ss.Sets() {
+		if in.Set != "" && set.Name() != in.Set {
+			continue
+		}
+		for _, a := range set.Attributes() {
+			infos = append(infos, attributeInfo(set.Name(), a))
+		}
+	}
+	return json.Marshal(wire.ListAttributesResult{Attributes: infos})
+}
+
+// listAttributeSets returns the document's attribute set names, sorted.
+func listAttributeSets(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListAttributeSetsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesListSets)
+	if err != nil {
+		return nil, err
+	}
+	names := ss.Names()
+	sort.Strings(names)
+	return json.Marshal(wire.ListAttributeSetsResult{Sets: names})
+}
+
+// deleteAttribute removes the named attribute, or the whole set when Name is empty, reporting how
+// many attributes were removed.
+func deleteAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.DeleteAttributeArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesDelete)
+	if err != nil {
+		return nil, err
+	}
+	set, ok := ss.Lookup(in.Set)
+	if !ok {
+		return json.Marshal(wire.DeleteAttributeResult{Removed: 0})
+	}
+	if in.Name == "" {
+		removed := set.Count()
+		ss.Remove(in.Set)
+		return json.Marshal(wire.DeleteAttributeResult{Removed: removed})
+	}
+	removed := 0
+	if set.Remove(in.Name) {
+		removed = 1
+	}
+	return json.Marshal(wire.DeleteAttributeResult{Removed: removed})
+}
+
+// findByAttribute locates the open documents carrying an attribute in Set (optionally by Name).
+func findByAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.FindByAttributeArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if in.Set == "" {
+		return nil, fmt.Errorf("%s: a set is required", wire.MethodAttributesFind)
+	}
+	var matches []wire.AttributeMatch
+	for _, d := range s.Workspace().Documents() {
+		for _, h := range d.Attributes().FindAttributes(in.Set, in.Name) {
+			matches = append(matches, wire.AttributeMatch{
+				Document:  uint64(d.ID()),
+				Attribute: attributeInfo(h.Set.Name(), h.Attribute),
+			})
+		}
+	}
+	return json.Marshal(wire.FindByAttributeResult{Matches: matches})
+}
+
+// attributeInfo renders a model attribute in set as a wire DTO.
+func attributeInfo(set string, a *attr.Attribute) wire.AttributeInfo {
+	return wire.AttributeInfo{Set: set, Name: a.Name(), Value: variantFromValue(a.Value())}
+}
+
+// notFoundAttribute is the get reply for an absent attribute: Found=false echoing the requested
+// set/name with an empty (but well-typed, so it serializes) value the caller ignores.
+func notFoundAttribute(set, name string) wire.AttributeResult {
+	return wire.AttributeResult{Attribute: wire.AttributeInfo{Set: set, Name: name, Value: types.StringVariant("")}, Found: false}
+}

--- a/addin/router/attributes_test.go
+++ b/addin/router/attributes_test.go
@@ -82,3 +82,25 @@ func TestSetAttributeRequiresSetAndName(t *testing.T) {
 		t.Error("set with a blank set name should fail")
 	}
 }
+
+// TestAttributeHandlersRejectBadInput: every attribute handler rejects malformed JSON and (for the
+// document-targeted methods) an unknown document id, rather than panicking or silently succeeding.
+func TestAttributeHandlersRejectBadInput(t *testing.T) {
+	r, s := emptyPartSession(t)
+	docMethods := []string{"attributes.set", "attributes.get", "attributes.list", "attributes.listSets", "attributes.delete"}
+	for _, m := range append([]string{"attributes.find"}, docMethods...) {
+		if _, err := r.Handle(s, m, []byte(`{ not json`)); err == nil {
+			t.Errorf("%s accepted malformed JSON", m)
+		}
+	}
+	for _, m := range docMethods {
+		args := []byte(`{"document":999999,"set":"s","name":"n"}`) // no such open document
+		if _, err := r.Handle(s, m, args); err == nil {
+			t.Errorf("%s accepted an unknown document id", m)
+		}
+	}
+	// find with a blank set is a rejection.
+	if _, err := r.Handle(s, "attributes.find", []byte(`{"set":""}`)); err == nil {
+		t.Error("find with a blank set should fail")
+	}
+}

--- a/addin/router/attributes_test.go
+++ b/addin/router/attributes_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestAttributesOverWire drives the #155 add-in attribute round trip over the router: set a typed
+// value in a named set on the document, read it back, list it, enumerate the sets, find it, then
+// delete it.
+func TestAttributesOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	id := uint64(s.ActiveDocument().ID())
+	const set = "com.acme.bom"
+
+	var setRes wire.AttributeResult
+	call(t, r, s, "attributes.set",
+		mustJSON(t, wire.SetAttributeArgs{Document: id, Set: set, Name: "partNo", Value: types.StringVariant("BRK-001")}), &setRes)
+	if !setRes.Found {
+		t.Fatalf("set reply not found: %+v", setRes)
+	}
+	if v, ok := setRes.Attribute.Value.Str(); !ok || v != "BRK-001" {
+		t.Fatalf("set value = %v (ok=%v), want BRK-001", v, ok)
+	}
+
+	// a second typed attribute in the same set.
+	call(t, r, s, "attributes.set",
+		mustJSON(t, wire.SetAttributeArgs{Document: id, Set: set, Name: "qty", Value: types.IntegerVariant(4)}), &setRes)
+
+	var getRes wire.AttributeResult
+	call(t, r, s, "attributes.get", fmt.Sprintf(`{"document":%d,"set":%q,"name":"partNo"}`, id, set), &getRes)
+	if !getRes.Found {
+		t.Errorf("get partNo not found")
+	}
+
+	var miss wire.AttributeResult
+	call(t, r, s, "attributes.get", fmt.Sprintf(`{"document":%d,"set":%q,"name":"nope"}`, id, set), &miss)
+	if miss.Found {
+		t.Errorf("get of an absent attribute should report Found=false")
+	}
+
+	var list wire.ListAttributesResult
+	call(t, r, s, "attributes.list", fmt.Sprintf(`{"document":%d,"set":%q}`, id, set), &list)
+	if len(list.Attributes) != 2 {
+		t.Errorf("list = %+v, want 2 attributes", list.Attributes)
+	}
+
+	var sets wire.ListAttributeSetsResult
+	call(t, r, s, "attributes.listSets", fmt.Sprintf(`{"document":%d}`, id), &sets)
+	if len(sets.Sets) != 1 || sets.Sets[0] != set {
+		t.Errorf("listSets = %+v, want [%s]", sets.Sets, set)
+	}
+
+	var found wire.FindByAttributeResult
+	call(t, r, s, "attributes.find", fmt.Sprintf(`{"set":%q,"name":"partNo"}`, set), &found)
+	if len(found.Matches) != 1 || found.Matches[0].Document != id {
+		t.Errorf("find = %+v, want one match on document %d", found.Matches, id)
+	}
+
+	var del wire.DeleteAttributeResult
+	call(t, r, s, "attributes.delete", fmt.Sprintf(`{"document":%d,"set":%q,"name":"partNo"}`, id, set), &del)
+	if del.Removed != 1 {
+		t.Errorf("delete Removed = %d, want 1", del.Removed)
+	}
+	// deleting the whole set removes the remaining attribute too.
+	call(t, r, s, "attributes.delete", fmt.Sprintf(`{"document":%d,"set":%q}`, id, set), &del)
+	if del.Removed != 1 {
+		t.Errorf("delete-set Removed = %d, want 1 (the qty attribute)", del.Removed)
+	}
+}
+
+// TestSetAttributeRequiresSetAndName: a blank set or name is a rejection, not a silent no-op.
+func TestSetAttributeRequiresSetAndName(t *testing.T) {
+	r, s := emptyPartSession(t)
+	id := uint64(s.ActiveDocument().ID())
+	if _, err := r.Handle(s, "attributes.set", []byte(fmt.Sprintf(`{"document":%d,"set":"","name":"x"}`, id))); err == nil {
+		t.Error("set with a blank set name should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -71,6 +71,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyReplicationHandlers()
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()
+	r.registerAttributeHandlers()
 	r.registerDrawingHandlers()
 	r.registerDrawingStyleHandlers()
 	r.registerDrawingViewHandlers()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.54.0
+	oblikovati.org/api v0.55.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.54.0
+	oblikovati.org/api v0.55.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/doc/attributes_doc_test.go
+++ b/model/doc/attributes_doc_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"testing"
+
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/identity"
+)
+
+// TestDocumentAttributesAccessor covers the lazy-seeded manager and the persistence-bytes helpers:
+// an empty document encodes no attribute block; a populated one round-trips through the bytes.
+func TestDocumentAttributesAccessor(t *testing.T) {
+	d := NewReference(Part, "/w/x.obk")
+
+	if got := d.Attributes(); got == nil {
+		t.Fatal("Attributes() returned nil")
+	}
+	if b := d.AttributeBytes(); b != nil {
+		t.Errorf("AttributeBytes() of an empty document = %v, want nil", b)
+	}
+
+	d.Attributes().AttributeSets(identity.DocumentKey()).Set("com.acme").Put("k", attr.StringValue("v"))
+	bytes := d.AttributeBytes()
+	if len(bytes) == 0 {
+		t.Fatal("AttributeBytes() of an annotated document is empty")
+	}
+
+	// SetAttributeBytes restores them into a fresh document.
+	d2 := NewReference(Part, "/w/x.obk")
+	if err := d2.SetAttributeBytes(bytes); err != nil {
+		t.Fatalf("SetAttributeBytes: %v", err)
+	}
+	set, ok := d2.Attributes().AttributeSets(identity.DocumentKey()).Lookup("com.acme")
+	if !ok {
+		t.Fatal("restored document missing the com.acme set")
+	}
+	if a, ok := set.Attribute("k"); !ok {
+		t.Error("restored set missing attribute k")
+	} else if v, _ := a.Value().Str(); v != "v" {
+		t.Errorf("restored k = %q, want v", v)
+	}
+}
+
+// TestSetAttributeBytesRejectsCorrupt: empty bytes are a no-op; corrupt bytes are a clean error.
+func TestSetAttributeBytesRejectsCorrupt(t *testing.T) {
+	d := NewReference(Part, "/w/x.obk")
+	if err := d.SetAttributeBytes(nil); err != nil {
+		t.Errorf("SetAttributeBytes(nil) = %v, want no-op", err)
+	}
+	if err := d.SetAttributeBytes([]byte{0xff, 0x01, 0x02}); err == nil {
+		t.Error("SetAttributeBytes of corrupt bytes should error")
+	}
+}

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"oblikovati.org/event"
+	"oblikovati.org/model/attr"
 	"oblikovati.org/model/display"
 )
 
@@ -48,8 +49,9 @@ type Document struct {
 	displaySettings  *display.Settings // per-document display settings (background/edges/ground/shadows), nil ⇒ defaults (M16-F07 #643)
 	identity         FileIdentity      // the file's persisted identity block (M03-F07, #159)
 	fileReferences   []*FileReference
-	attachments      *FileAttachments   // external-file attachment records (M03-F08); lazily seeded
-	interests        *DocumentInterests // add-in data registry (M03-F10); lazily seeded
+	attachments      *FileAttachments       // external-file attachment records (M03-F08); lazily seeded
+	interests        *DocumentInterests     // add-in data registry (M03-F10); lazily seeded
+	attributes       *attr.AttributeManager // add-in attribute sets (#155); lazily seeded
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;
@@ -87,6 +89,39 @@ func (d *Document) SubType() SubTypeID { return d.subType }
 
 // SetSubType stamps the flavored subtype id.
 func (d *Document) SetSubType(id SubTypeID) { d.subType = id }
+
+// Attributes returns the document's add-in attribute manager (#155), lazily seeded.
+// Document-level attribute sets are anchored under [identity.DocumentKey]; per-entity
+// sets (features, bodies) share the same manager under their own keys.
+func (d *Document) Attributes() *attr.AttributeManager {
+	if d.attributes == nil {
+		d.attributes = attr.NewAttributeManager()
+	}
+	return d.attributes
+}
+
+// AttributeBytes returns the encoded attribute manager for persistence, or nil when no
+// attributes exist (so an unannotated document writes no attribute block).
+func (d *Document) AttributeBytes() []byte {
+	if d.attributes == nil || d.attributes.Count() == 0 {
+		return nil
+	}
+	return d.attributes.Encode()
+}
+
+// SetAttributeBytes restores the attribute manager from persisted bytes (the load path);
+// empty data leaves the manager unseeded.
+func (d *Document) SetAttributeBytes(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	m, err := attr.DecodeAttributes(data)
+	if err != nil {
+		return err
+	}
+	d.attributes = m
+	return nil
+}
 
 // Content returns the modeling payload, or nil if this is an unopened reference
 // stub. Callers needing a typed view use the specialization accessors

--- a/model/identity/entity.go
+++ b/model/identity/entity.go
@@ -32,7 +32,16 @@ const (
 	// identity (GetReferenceKey applies to features and parameters too).
 	KindFeature   EntityKind = 10
 	KindParameter EntityKind = 11
+	// KindDocument names the document itself — the anchor for document-level
+	// attribute sets (#155). There is one such key per document; see [DocumentKey].
+	KindDocument EntityKind = 20
 )
+
+// DocumentKey is the single well-known reference key that names the document itself
+// (not any entity within it) — the anchor for document-level attribute sets (#155).
+// It is fixed (no lineage payload), so it survives recompute and round-trips through
+// the attribute codec like any other key.
+func DocumentKey() RefKey { return RefKey{kind: KindDocument} }
 
 // String returns a stable lowercase name for diagnostics.
 func (k EntityKind) String() string {
@@ -49,6 +58,8 @@ func (k EntityKind) String() string {
 		return "feature"
 	case KindParameter:
 		return "parameter"
+	case KindDocument:
+		return "document"
 	default:
 		return "unknown"
 	}

--- a/persistence/attributes_test.go
+++ b/persistence/attributes_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/model/attr"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/identity"
+)
+
+// TestAttributesRoundTripThroughPackage: an add-in attribute attached to a document persists in the
+// .obk and reloads with it (#155) — the durable storage that makes attributes useful.
+func TestAttributesRoundTripThroughPackage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tagged.obk")
+	store := NewPackageStore()
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, path, true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	d.Attributes().AttributeSets(identity.DocumentKey()).Set("com.acme.bom").Put("partNo", attr.StringValue("BRK-001"))
+	d.Attributes().AttributeSets(identity.DocumentKey()).Set("com.acme.bom").Put("qty", attr.IntValue(4))
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ss := reopened.Attributes().AttributeSets(identity.DocumentKey())
+	set, ok := ss.Lookup("com.acme.bom")
+	if !ok {
+		t.Fatalf("reloaded document missing the com.acme.bom set; sets=%v", ss.Names())
+	}
+	a, ok := set.Attribute("partNo")
+	if !ok {
+		t.Fatalf("reloaded set missing partNo")
+	}
+	if v, ok := a.Value().Str(); !ok || v != "BRK-001" {
+		t.Errorf("reloaded partNo = %v (ok=%v), want BRK-001", v, ok)
+	}
+	if q, ok := set.Attribute("qty"); !ok {
+		t.Error("reloaded set missing qty")
+	} else if iv, _ := q.Value().Int(); iv != 4 {
+		t.Errorf("reloaded qty = %d, want 4", iv)
+	}
+}
+
+// TestUnannotatedDocumentWritesNoAttributes: a document with no attributes round-trips with an
+// empty attribute manager (the .obk carries no attribute block).
+func TestUnannotatedDocumentWritesNoAttributes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plain.obk")
+	store := NewPackageStore()
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, path, true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if n := reopened.Attributes().Count(); n != 0 {
+		t.Errorf("reloaded plain document has %d anchored attribute objects, want 0", n)
+	}
+}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -54,6 +54,7 @@ func (p *Package) marshal() ([]byte, error) {
 		References:      p.references,
 		Attachments:     p.attachments,
 		Interests:       p.interests,
+		Attributes:      p.attributes,
 		DisplaySettings: p.display,
 		Model:           p.model,
 		Data:            p.streams,
@@ -82,6 +83,7 @@ func decode(raw []byte) (*Package, error) {
 	p.references = doc.References
 	p.attachments = doc.Attachments
 	p.interests = doc.Interests
+	p.attributes = doc.Attributes
 	p.display = doc.DisplaySettings
 	for name, data := range doc.Data {
 		p.WriteStream(name, data)

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -34,6 +34,7 @@ type Package struct {
 	references  []yamlcodec.FileReferenceRecord
 	attachments []yamlcodec.AttachmentRecord     // external-file attachments (M03-F08)
 	interests   []yamlcodec.InterestRecord       // add-in data registry (M03-F10)
+	attributes  []byte                           // add-in attribute sets, encoded (#155)
 	display     *yamlcodec.DisplaySettingsRecord // per-document display settings (M16-F07 #643)
 }
 
@@ -71,6 +72,12 @@ func (p *Package) SetInterests(i []yamlcodec.InterestRecord) { p.interests = i }
 
 // Interests returns the add-in data-registry records.
 func (p *Package) Interests() []yamlcodec.InterestRecord { return p.interests }
+
+// SetAttributes stores the encoded add-in attribute sets (#155).
+func (p *Package) SetAttributes(a []byte) { p.attributes = a }
+
+// Attributes returns the encoded add-in attribute sets, nil when none.
+func (p *Package) Attributes() []byte { return p.attributes }
 
 // SetResources stores the document's embedded resource table (ADR-0031), keyed by UUID.
 func (p *Package) SetResources(r map[string]yamlcodec.Resource) { p.resources = r }

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -95,6 +95,7 @@ func (s *PackageStore) buildPackage(d *doc.Document, displayName, subType string
 	pkg.SetFileReferences(toCodecFileReferences(d.FileReferenceRecords()))
 	pkg.SetAttachments(toCodecAttachments(d.AttachmentRecords()))
 	pkg.SetInterests(toCodecInterests(d.InterestRecords()))
+	pkg.SetAttributes(d.AttributeBytes())   // #155 add-in attribute sets
 	if set, ok := d.DisplaySettings(); ok { // M16-F07 #643: per-document display settings
 		pkg.SetDisplaySettings(toCodecDisplaySettings(set))
 	}
@@ -180,6 +181,9 @@ func restoreIdentity(d *doc.Document, pkg *Package) error {
 	}
 	d.SetAttachmentRecords(recs)
 	d.SetInterestRecords(fromCodecInterests(pkg.Interests()))
+	if err := d.SetAttributeBytes(pkg.Attributes()); err != nil { // #155
+		return err
+	}
 	return nil
 }
 

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -48,6 +48,9 @@ type Document struct {
 	Attachments []AttachmentRecord
 	// Interests are the add-in data registry records (M03-F10).
 	Interests []InterestRecord
+	// Attributes is the add-in attribute-set block (#155): the encoded AttributeManager
+	// (model/attr), nil for a document that carries no attributes.
+	Attributes []byte
 	// DisplaySettings are the per-document display settings (background/edges/ground/shadows),
 	// nil for a document that never customized them (M16-F07 #643).
 	DisplaySettings *DisplaySettingsRecord `yaml:"displaySettings,omitempty"`
@@ -153,6 +156,7 @@ type onDisk struct {
 	References      []FileReferenceRecord  `yaml:"references,omitempty"`
 	Attachments     []AttachmentRecord     `yaml:"attachments,omitempty"`
 	Interests       []InterestRecord       `yaml:"interests,omitempty"`
+	Attributes      []byte                 `yaml:"attributes,omitempty"`
 	DisplaySettings *DisplaySettingsRecord `yaml:"displaySettings,omitempty"`
 	Resources       yaml.Node              `yaml:"resources,omitempty"`
 	Model           yaml.Node              `yaml:"model,omitempty"`
@@ -171,6 +175,7 @@ func MarshalDocument(d Document) ([]byte, error) {
 		References:      d.References,
 		Attachments:     d.Attachments,
 		Interests:       d.Interests,
+		Attributes:      d.Attributes,
 		DisplaySettings: d.DisplaySettings,
 	}
 	if err := embedNativeNodes(&od, d); err != nil {
@@ -247,6 +252,7 @@ func documentHeader(od onDisk) Document {
 		References:      od.References,
 		Attachments:     od.Attachments,
 		Interests:       od.Interests,
+		Attributes:      od.Attributes,
 		DisplaySettings: od.DisplaySettings,
 	}
 }


### PR DESCRIPTION
## What

Implements the **add-in attribute-set** API (contract released in `api v0.55.0`, PR Oblikovati.API#172): named, typed values an add-in attaches to a document and that persist with it — the sanctioned mechanism for add-ins to store their own data and tag the model (#155).

The model layer **already existed** (`model/attr`: an `AttributeManager` anchoring sets by `identity.RefKey` so they *survive recompute*, with `FindAttributes` + a binary codec, all tested). This PR wires it end-to-end:

- **`model/identity`** — `KindDocument` + `DocumentKey()`, the well-known key that anchors document-level sets.
- **`model/doc`** — `Document.Attributes()` (lazily-seeded manager) + `AttributeBytes`/`SetAttributeBytes` for persistence.
- **`persistence`** — round-trips the encoded manager through the `.obk` `attributes` block (`yamlcodec` + `Package` + `io` + `store`), mirroring the interests registry.
- **`addin/router`** — handlers for `attributes.set` / `get` / `list` / `listSets` / `delete` / `find`, resolving the document by session id and converting `attr.Value` ↔ the wire `types.Variant` via the existing document-properties helpers. Satisfies the API↔router parity guard.

## Scope

**Document-target only** for now (anchored under `DocumentKey`). Per-entity targets (features, bodies, sketch entities) extend the same manager + DTOs later (sketch entities ride #153). `find` scans the open documents.

## Tests

- `addin/router/attributes_test.go` — the wire round trip: set → get (hit and miss) → list → listSets → find → delete (single + whole-set), plus blank-set/name rejection.
- `persistence/attributes_test.go` — an `.obk` **save/reload** round trip proving attributes are durable, and that an unannotated document writes no attribute block.

Live MCP confirmation of the generated `set_attribute`/`get_attribute` tools follows once the MCP bridge regenerates from `api v0.55.0` (hourly).

Verified: `go build ./...`, `go test ./addin/... ./model/... ./persistence/... ./app`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)