### PR TITLE
feat(events): relay representation / model-state change events (#901)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -53,7 +53,19 @@ func styleEventType(k app.StyleChangeKind) string {
 func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 	bus := s.Events()
 	subs := subscribeDocuments(s.Workspace().Events(), sink)
-	subs = append(subs,
+	subs = append(subs, subscribeSessionUI(bus, sink)...)
+	subs = append(subs, subscribeRepresentations(bus, sink)...)
+	subs = append(subs, subscribeTransactions(bus, sink)...)
+	subs = append(subs, subscribeFileAccess(s.Workspace().Events(), sink)...)
+	subs = append(subs, subscribeAssemblies(s.Workspace().Events(), sink)...)
+	subs = append(subs, subscribeFileUIHooks(bus, sink)...)
+	return append(subs, subscribeUISurfaces(bus, sink)...)
+}
+
+// subscribeSessionUI relays the session bus's command, selection, environment, edit, camera and
+// style change events (M05/M16) to the add-in sink.
+func subscribeSessionUI(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
 		event.Subscribe(bus, event.Before, func(_ event.Context, e app.CommandStarted) event.Outcome {
 			return relay(sink, wireEvent{Type: wire.EventCommandStarted, Command: e.ID})
 		}),
@@ -69,9 +81,7 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
 			return relayEdit(sink, e)
 		}),
-		// M16-F03 (#404): the active view's camera moved (named-view restore / orientation
-		// jump). The add-in reads the new frame via get_camera; wire.CameraChangedEvent is the
-		// richer DTO for an out-of-band transport.
+		// M16-F03 (#404): the active view's camera moved (named-view restore / orientation jump).
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.CameraChanged) event.Outcome {
 			return relay(sink, wireEvent{Type: wire.EventCameraChanged, Document: strconv.FormatUint(uint64(e.Document), 10)})
 		}),
@@ -79,12 +89,24 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.StyleChanged) event.Outcome {
 			return relay(sink, wireEvent{Type: styleEventType(e.Kind), Name: e.Name})
 		}),
-	)
-	subs = append(subs, subscribeTransactions(bus, sink)...)
-	subs = append(subs, subscribeFileAccess(s.Workspace().Events(), sink)...)
-	subs = append(subs, subscribeAssemblies(s.Workspace().Events(), sink)...)
-	subs = append(subs, subscribeFileUIHooks(bus, sink)...)
-	return append(subs, subscribeUISurfaces(bus, sink)...)
+	}
+}
+
+// subscribeRepresentations relays the representation / model-state change notifications (#901): the
+// request/response methods are handled in addin/router; these forward the matching app events so a
+// subscriber learns of an activation/capture (Name carries the representation / model-state name).
+func subscribeRepresentations(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.RepresentationActivated) event.Outcome {
+			return relay(sink, wireEvent{Type: wire.EventRepresentationActivated, Name: e.Name})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.RepresentationCaptured) event.Outcome {
+			return relay(sink, wireEvent{Type: wire.EventRepresentationCaptured, Name: e.Name})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.ModelStateActivated) event.Outcome {
+			return relay(sink, wireEvent{Type: wire.EventModelStateActivated, Name: e.Name})
+		}),
+	}
 }
 
 // subscribeDocuments wires the workspace document events; a flavored document's

--- a/addin/events/representation_relay_test.go
+++ b/addin/events/representation_relay_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// TestForwardsRepresentationEvents: the representation / model-state change events emitted by the
+// representation router handlers are relayed to the add-in sink (#901) — closing the gap the
+// parity guard found (the methods were handled, only the change notifications were missing).
+func TestForwardsRepresentationEvents(t *testing.T) {
+	s := app.NewSession()
+	var rec recorder
+	if subs := Subscribe(s, rec.sink); len(subs) == 0 {
+		t.Fatal("Subscribe returned no subscriptions")
+	}
+
+	event.Emit(s.Events(), event.After, app.RepresentationActivated{Kind: "design", Name: "Master"})
+	event.Emit(s.Events(), event.After, app.RepresentationCaptured{Kind: "lod", Name: "Lightweight"})
+	event.Emit(s.Events(), event.After, app.ModelStateActivated{Name: "Primary"})
+
+	got := rec.types()
+	for _, want := range []string{"representations.activated", "representations.captured", "modelStates.activated"} {
+		if !has(got, want) {
+			t.Errorf("missing %s in relayed events %v", want, got)
+		}
+	}
+}

--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -65,11 +65,7 @@ var notYetHandled = map[string]bool{}
 // are tracked debt: when that feature fires an app event, relay it in addin/events and
 // DELETE it from this list. Any OTHER unrelayed event fails the test below — so this list
 // may only shrink. See https://github.com/Oblikovati/Oblikovati/issues/901.
-var notYetRelayed = map[string]bool{
-	"EventModelStateActivated":     true,
-	"EventRepresentationActivated": true,
-	"EventRepresentationCaptured":  true,
-}
+var notYetRelayed = map[string]bool{}
 
 // TestEveryWireEventIsRelayed guards the other direction: every wire.Event* constant
 // must be referenced by the add-in's event relay (addin/events) or the router, so a

--- a/addin/router/representations.go
+++ b/addin/router/representations.go
@@ -8,6 +8,7 @@ import (
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/event"
 	"oblikovati.org/model/assembly"
 	"oblikovati.org/model/compdef"
 )
@@ -69,6 +70,7 @@ func designRepsCapture(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 		return nil, err
 	}
 	d := asm.Representations().CaptureDesignView(in.Name, capturedCamera(s))
+	event.Emit(s.Events(), event.After, app.RepresentationCaptured{Kind: "design", Name: d.Name()})
 	return json.Marshal(wire.DesignViewResult{Representation: designViewInfo(d)})
 }
 
@@ -81,6 +83,7 @@ func designRepsActivate(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 	if err != nil {
 		return nil, err
 	}
+	event.Emit(s.Events(), event.After, app.RepresentationActivated{Kind: "design", Name: d.Name()})
 	return json.Marshal(wire.DesignViewResult{Representation: designViewInfo(d)})
 }
 
@@ -166,6 +169,7 @@ func positionalRepsCapture(s *app.Session, raw json.RawMessage) (json.RawMessage
 		return nil, err
 	}
 	p := asm.Representations().CapturePositional(in.Name)
+	event.Emit(s.Events(), event.After, app.RepresentationCaptured{Kind: "positional", Name: p.Name()})
 	return json.Marshal(wire.PositionalResult{Representation: positionalInfo(p)})
 }
 
@@ -178,6 +182,7 @@ func positionalRepsActivate(s *app.Session, raw json.RawMessage) (json.RawMessag
 	if err != nil {
 		return nil, err
 	}
+	event.Emit(s.Events(), event.After, app.RepresentationActivated{Kind: "positional", Name: p.Name()})
 	return json.Marshal(wire.PositionalResult{Representation: positionalInfo(p)})
 }
 
@@ -244,6 +249,7 @@ func lodRepsCapture(s *app.Session, raw json.RawMessage) (json.RawMessage, error
 		return nil, err
 	}
 	l := asm.Representations().CaptureLOD(in.Name)
+	event.Emit(s.Events(), event.After, app.RepresentationCaptured{Kind: "lod", Name: l.Name()})
 	return json.Marshal(wire.LODResult{Representation: lodInfo(l)})
 }
 
@@ -256,6 +262,7 @@ func lodRepsActivate(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	if err != nil {
 		return nil, err
 	}
+	event.Emit(s.Events(), event.After, app.RepresentationActivated{Kind: "lod", Name: l.Name()})
 	return json.Marshal(wire.LODResult{Representation: lodInfo(l)})
 }
 
@@ -323,6 +330,7 @@ func modelStatesActivate(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	if err != nil {
 		return nil, err
 	}
+	event.Emit(s.Events(), event.After, app.ModelStateActivated{Name: m.Name()})
 	return json.Marshal(wire.ModelStateResult{ModelState: modelStateInfo(m)})
 }
 

--- a/app/representation_events.go
+++ b/app/representation_events.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/event"
+
+// Representation / model-state change events on the session bus (#901): emitted when a
+// representation is activated or captured, or a model state is activated, so an add-in subscribing
+// to the representations surface is notified of the change (the request/response methods were
+// already handled; these are the missing change notifications). 0x0bxx = M11 assembly representations.
+const (
+	tidRepresentationActivated event.TypeID = 0x0b01
+	tidRepresentationCaptured  event.TypeID = 0x0b02
+	tidModelStateActivated     event.TypeID = 0x0b03
+)
+
+// RepresentationActivated announces that a representation became active. Kind is the representation
+// family ("design", "positional", or "lod"); Name is the representation's name.
+type RepresentationActivated struct {
+	Kind string
+	Name string
+}
+
+// EventID implements event.Event.
+func (RepresentationActivated) EventID() event.TypeID { return tidRepresentationActivated }
+
+// RepresentationCaptured announces that a new representation was captured (same Kind/Name shape).
+type RepresentationCaptured struct {
+	Kind string
+	Name string
+}
+
+// EventID implements event.Event.
+func (RepresentationCaptured) EventID() event.TypeID { return tidRepresentationCaptured }
+
+// ModelStateActivated announces that a model state became active.
+type ModelStateActivated struct {
+	Name string
+}
+
+// EventID implements event.Event.
+func (ModelStateActivated) EventID() event.TypeID { return tidModelStateActivated }


### PR DESCRIPTION
## What

Closes the event-side gap the parity guard (`TestEveryWireEventIsRelayed`) found: three `wire.Event*` constants the API declares but the host never emitted —

- `representations.activated`
- `representations.captured`
- `modelStates.activated`

An add-in subscribing to these never received them; the request/response methods were already handled, only the change notifications were missing.

## How (3 layers + shrink)

- **`app`** — new session-bus events `RepresentationActivated` / `RepresentationCaptured` / `ModelStateActivated` (Kind + Name; `0x0bxx` = M11 assembly representations).
- **`addin/router/representations.go`** — emit them from the activate/capture handlers (design / positional / LOD representations, and model states).
- **`addin/events`** — relay them to the add-in sink via a new `subscribeRepresentations` helper. Also split the inline session-event block into `subscribeSessionUI` so `Subscribe` stays under the statement limit.
- **`addin/router/api_parity_test.go`** — delete the three `notYetRelayed` entries (the guard requires that allowlist to only shrink).

## Notes

- **/source-only — no public-API change** (the events were already declared in the contract).

## Tests

`addin/events/representation_relay_test.go` asserts the three events relay to the sink, and `TestEveryWireEventIsRelayed` now passes with an **empty** allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)