### PR TITLE
feat(model): writable selection — select/deselect/clear (#157)

### DIFF
--- a/addin/router/model.go
+++ b/addin/router/model.go
@@ -39,14 +39,5 @@ func modelTree(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 // modelSelection returns the current selection summary (read-only). Mutating the
 // selection by reference key is a fast-follow.
 func modelSelection(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
-	items := s.Selection().Items()
-	kinds := make([]int, len(items))
-	for i, it := range items {
-		kinds[i] = int(it.SelectionKind())
-	}
-	return json.Marshal(wire.SelectionResult{
-		Count: len(items),
-		Kinds: kinds,
-		Refs:  s.Selection().References(),
-	})
+	return json.Marshal(currentSelection(s))
 }

--- a/addin/router/model_select.go
+++ b/addin/router/model_select.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+)
+
+// Selection mutation (#157): make the read-only selection writable. References are the face/vertex
+// strings model.selection / model.referenceKeys report; these resolve them against the active part's
+// bodies, mutate the session selection, announce the change (relayed to add-ins via #148), and
+// return the new selection summary.
+
+// registerSelectionMutationHandlers wires the model.select/deselect/clearSelection methods.
+func (r *Router) registerSelectionMutationHandlers() {
+	r.handlers[wire.MethodModelSelect] = modelSelect
+	r.handlers[wire.MethodModelDeselect] = modelDeselect
+	r.handlers[wire.MethodModelClearSelection] = modelClearSelection
+}
+
+// modelSelect selects the referenced entities, replacing the selection unless Mode is "add".
+func modelSelect(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SelectArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	bodies, err := activeBodies(s, wire.MethodModelSelect)
+	if err != nil {
+		return nil, err
+	}
+	if in.Mode != "add" {
+		s.Selection().Clear()
+	}
+	for _, ref := range in.Refs {
+		sel, ok := resolveSelectionRef(bodies, ref)
+		if !ok {
+			return nil, fmt.Errorf("%s: cannot resolve reference %q (not a face/vertex of the active part)", wire.MethodModelSelect, ref)
+		}
+		s.Selection().Add(sel)
+	}
+	return announceSelection(s)
+}
+
+// modelDeselect removes the referenced entities from the selection (unknown refs are ignored).
+func modelDeselect(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.DeselectArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	bodies, err := activeBodies(s, wire.MethodModelDeselect)
+	if err != nil {
+		return nil, err
+	}
+	for _, ref := range in.Refs {
+		if sel, ok := resolveSelectionRef(bodies, ref); ok {
+			s.Selection().Remove(sel)
+		}
+	}
+	return announceSelection(s)
+}
+
+// modelClearSelection clears the whole selection.
+func modelClearSelection(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	s.Selection().Clear()
+	return announceSelection(s)
+}
+
+// activeBodies returns the active part's surface bodies, erroring when there is no active part.
+func activeBodies(s *app.Session, method string) ([]*topo.Body, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	n := part.SurfaceBodies().Count()
+	bodies := make([]*topo.Body, 0, n)
+	for i := 0; i < n; i++ {
+		bodies = append(bodies, part.SurfaceBodies().Item(i))
+	}
+	return bodies, nil
+}
+
+// resolveSelectionRef resolves a face/vertex reference string to a selectable handle on the bodies.
+// Edges/work-features are not round-trippable through model.selection yet (it reports no ref for
+// them), so they are not resolved here.
+func resolveSelectionRef(bodies []*topo.Body, ref string) (app.Selectable, bool) {
+	if key, ok := feature.FaceRefKey(feature.WorkRef(ref)); ok {
+		for _, b := range bodies {
+			if f, found := b.FindFaceByKey(key); found {
+				return app.FaceHandle{Face: f, Body: b}, true
+			}
+		}
+	}
+	if key, ok := feature.VertexRefKey(feature.WorkRef(ref)); ok {
+		for _, b := range bodies {
+			if v, found := b.FindVertexByKey(key); found {
+				return app.VertexHandle{Vertex: v}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// announceSelection emits the selection-changed event (relayed to add-ins, #148) and returns the
+// new selection summary — the same shape model.selection reports.
+func announceSelection(s *app.Session) (json.RawMessage, error) {
+	event.Emit(s.Events(), event.After, app.SelectionChanged{Count: s.Selection().Count()})
+	return json.Marshal(currentSelection(s))
+}
+
+// currentSelection builds the selection summary DTO from the session selection.
+func currentSelection(s *app.Session) wire.SelectionResult {
+	items := s.Selection().Items()
+	kinds := make([]int, len(items))
+	for i, it := range items {
+		kinds[i] = int(it.SelectionKind())
+	}
+	return wire.SelectionResult{Count: len(items), Kinds: kinds, Refs: s.Selection().References()}
+}

--- a/addin/router/model_select_mutation_test.go
+++ b/addin/router/model_select_mutation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/addin/opregistry"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/feature"
@@ -30,6 +31,41 @@ func boxFaceRefs(t *testing.T) (*Router, *app.Session, string, string) {
 		t.Fatalf("box has %d faces, want >= 2", len(faces))
 	}
 	return r, s, string(feature.FaceRef(faces[0].ReferenceKey())), string(feature.FaceRef(faces[1].ReferenceKey()))
+}
+
+// boxVertexRef returns one of the box's vertex selection references.
+func boxVertexRef(t *testing.T, s *app.Session) string {
+	t.Helper()
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	verts := part.SurfaceBodies().Item(0).Vertices()
+	if len(verts) == 0 {
+		t.Fatal("box has no vertices")
+	}
+	return string(feature.VertexRef(verts[0].ReferenceKey()))
+}
+
+// TestModelSelectVertexByReference covers the vertex resolution path.
+func TestModelSelectVertexByReference(t *testing.T) {
+	r, s, _, _ := boxFaceRefs(t)
+	var sel wire.SelectionResult
+	call(t, r, s, "model.select", mustJSON(t, wire.SelectArgs{Refs: []string{boxVertexRef(t, s)}}), &sel)
+	if sel.Count != 1 {
+		t.Errorf("select vertex = %+v, want 1", sel)
+	}
+}
+
+// TestModelSelectNoActivePartFails: the mutation methods reject when there is no active part.
+func TestModelSelectNoActivePartFails(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	for _, m := range []string{"model.select", "model.deselect"} {
+		if _, err := r.Handle(s, m, []byte(`{"refs":["face/AAA"]}`)); err == nil {
+			t.Errorf("%s with no active part should fail", m)
+		}
+	}
 }
 
 // TestModelSelectMutationOverWire drives the #157 selection round trip: select two faces by

--- a/addin/router/model_select_mutation_test.go
+++ b/addin/router/model_select_mutation_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// boxFaceRefs builds a box and returns two of its faces' selection reference strings (the WorkRef
+// shape model.selection reports), plus the session/router.
+func boxFaceRefs(t *testing.T) (*Router, *app.Session, string, string) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	faces := part.SurfaceBodies().Item(0).Faces()
+	if len(faces) < 2 {
+		t.Fatalf("box has %d faces, want >= 2", len(faces))
+	}
+	return r, s, string(feature.FaceRef(faces[0].ReferenceKey())), string(feature.FaceRef(faces[1].ReferenceKey()))
+}
+
+// TestModelSelectMutationOverWire drives the #157 selection round trip: select two faces by
+// reference, deselect one, add it back, then clear — asserting the new selection each step.
+func TestModelSelectMutationOverWire(t *testing.T) {
+	r, s, ref0, ref1 := boxFaceRefs(t)
+
+	var sel wire.SelectionResult
+	call(t, r, s, "model.select", mustJSON(t, wire.SelectArgs{Refs: []string{ref0, ref1}, Mode: "replace"}), &sel)
+	if sel.Count != 2 {
+		t.Fatalf("select replace = %+v, want 2", sel)
+	}
+
+	call(t, r, s, "model.deselect", mustJSON(t, wire.DeselectArgs{Refs: []string{ref1}}), &sel)
+	if sel.Count != 1 || sel.Refs[0] != ref0 {
+		t.Errorf("after deselect = %+v, want just ref0", sel)
+	}
+
+	call(t, r, s, "model.select", mustJSON(t, wire.SelectArgs{Refs: []string{ref1}, Mode: "add"}), &sel)
+	if sel.Count != 2 {
+		t.Errorf("after add = %+v, want 2", sel)
+	}
+
+	call(t, r, s, "model.clearSelection", "{}", &sel)
+	if sel.Count != 0 {
+		t.Errorf("after clear = %+v, want 0", sel)
+	}
+}
+
+// TestModelSelectUnknownReferenceFails: an unresolvable reference is a rejection, not a silent no-op.
+func TestModelSelectUnknownReferenceFails(t *testing.T) {
+	r, s, _, _ := boxFaceRefs(t)
+	if _, err := r.Handle(s, "model.select", []byte(`{"refs":["face/ZZZZ"]}`)); err == nil {
+		t.Error("selecting an unknown face reference should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -72,6 +72,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()
 	r.registerAttributeHandlers()
+	r.registerSelectionMutationHandlers()
 	r.registerDrawingHandlers()
 	r.registerDrawingStyleHandlers()
 	r.registerDrawingViewHandlers()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.57.0
+	oblikovati.org/api v0.58.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.57.0
+	oblikovati.org/api v0.58.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/work_surface_ref.go
+++ b/model/feature/work_surface_ref.go
@@ -101,6 +101,26 @@ func (g *WorkGeometry) surface(ref WorkRef) (geom.Surface, error) {
 	return nil, fmt.Errorf("work geometry: face reference %q is lost", ref)
 }
 
+// FaceRefKey decodes a face WorkRef back to its reference key, reporting ok=false for a ref that is
+// not a face reference (#157 selection mutation resolves picked-by-reference faces this way).
+func FaceRefKey(ref WorkRef) ([]byte, bool) { return decodeRefKey(string(ref), faceRefPrefix) }
+
+// VertexRefKey decodes a vertex WorkRef back to its reference key, reporting ok=false otherwise.
+func VertexRefKey(ref WorkRef) ([]byte, bool) { return decodeRefKey(string(ref), vertexRefPrefix) }
+
+// decodeRefKey strips prefix and base64-decodes the key, reporting ok=false on a prefix mismatch
+// or a malformed payload.
+func decodeRefKey(s, prefix string) ([]byte, bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return nil, false
+	}
+	key, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(s, prefix))
+	if err != nil {
+		return nil, false
+	}
+	return key, true
+}
+
 const vertexRefPrefix = "vertex/"
 
 // VertexRef encodes a B-rep vertex's reference key as a point WorkRef, so a picked solid


### PR DESCRIPTION
## What

Implements the **selection-mutation** surface (#157, part 1 — contract released in `api v0.58.0`, Oblikovati.API#175): the previously read-only selection is now writable by reference.

- **`model/feature`** — exported `FaceRefKey` / `VertexRefKey` to decode a face/vertex `WorkRef` back to its reference key.
- **`addin/router/model_select.go`** — `model.select` (refs + `add`/`replace` mode), `model.deselect`, `model.clearSelection`. Each resolves a ref against the active part's bodies (`FindFaceByKey` / `FindVertexByKey`) to a `Selectable` handle, mutates `app.Selection`, emits `SelectionChanged` (relayed to add-ins, #148), and returns the new `SelectionResult`.
- References are the same strings `model.selection` reports, so an add-in round-trips its own reads. `modelSelection` now shares `currentSelection` (no duplication).

## Scope

Faces/vertices of the active part for this slice (edges/work-features aren't round-trippable through `model.selection` yet — it reports no ref for them). **Highlight sets** (colored emphasis groups, needing the renderer emphasis path) are the deferred second half of #157.

## Tests

`addin/router/model_select_mutation_test.go`: select two faces by reference → deselect one → add it back → clear (asserting the selection each step), plus an unknown-reference rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)