### PR TITLE
feat: model-health aggregation (analysis.modelHealth + Model Health command) (M18-F02, #430)

### DIFF
--- a/addin/router/analysis.go
+++ b/addin/router/analysis.go
@@ -21,6 +21,26 @@ import (
 func (r *Router) registerAnalysisHandlers() {
 	r.handlers[wire.MethodAnalysisMassProperties] = analysisMassProperties
 	r.handlers[wire.MethodAnalysisMeasure] = analysisMeasure
+	r.handlers[wire.MethodAnalysisModelHealth] = analysisModelHealth
+}
+
+func analysisModelHealth(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	mh := analysis.ModelHealthOf(part.Features())
+	return json.Marshal(modelHealthResult(mh))
+}
+
+// modelHealthResult flattens the aggregated health into the wire DTO, carrying each status as its
+// stable lowercase name.
+func modelHealthResult(mh analysis.ModelHealth) wire.ModelHealthResult {
+	out := wire.ModelHealthResult{Overall: mh.Overall.String(), SickCount: mh.SickCount}
+	for _, f := range mh.Unhealthy {
+		out.Unhealthy = append(out.Unhealthy, wire.FeatureHealth{Name: f.Name, Status: f.Status.String(), Reason: f.Reason})
+	}
+	return out
 }
 
 func analysisMeasure(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/analysis_test.go
+++ b/addin/router/analysis_test.go
@@ -152,6 +152,38 @@ func measureArgs(t *testing.T, measureType, keyA, keyB string) string {
 	return string(b)
 }
 
+// TestAnalysisModelHealthOverWire drives the model-health aggregation: a clean box reports ok with
+// nothing to repair, and a suppressed feature is enumerated as suppressed.
+func TestAnalysisModelHealthOverWire(t *testing.T) {
+	r, s := boxPartSession(t)
+
+	var clean wire.ModelHealthResult
+	call(t, r, s, "analysis.modelHealth", `{}`, &clean)
+	if clean.Overall != "ok" || clean.SickCount != 0 || len(clean.Unhealthy) != 0 {
+		t.Errorf("clean box health = %+v, want ok with nothing unhealthy", clean)
+	}
+
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("ActivePart: %v", err)
+	}
+	part.Features().Item(0).SetSuppressed(true)
+
+	var suppressed wire.ModelHealthResult
+	call(t, r, s, "analysis.modelHealth", `{}`, &suppressed)
+	if len(suppressed.Unhealthy) != 1 || suppressed.Unhealthy[0].Status != "suppressed" {
+		t.Errorf("after suppress = %+v, want one suppressed feature", suppressed)
+	}
+	if suppressed.Overall != "ok" {
+		t.Errorf("overall after suppress = %q, want ok (suppression is neutral)", suppressed.Overall)
+	}
+
+	br, bs := New(opregistry.Default()), app.NewSession()
+	if _, err := br.Handle(bs, "analysis.modelHealth", []byte(`{}`)); err == nil {
+		t.Error("modelHealth with no active part = ok, want error")
+	}
+}
+
 // nearAny reports whether v is within 0.01 of any of the candidate values.
 func nearAny(v float64, candidates ...float64) bool {
 	for _, c := range candidates {

--- a/app/commands_analysis.go
+++ b/app/commands_analysis.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/model/analysis"
@@ -23,7 +24,36 @@ func analysisCommands() []*CommandDefinition {
 			WithTab("Inspect").WithRibbons(PartRibbon).WithEnable(hasActivePart).
 			WithIcon("physical-properties").WithButtonStyle(LargeIconButton).
 			WithTooltip("Compute the part's volume, surface area, centre of mass and mass, and show them in the status bar."),
+		NewCommand("Inspect.ModelHealth", "Model Health", "Validate", modelHealth).
+			WithTab("Inspect").WithRibbons(PartRibbon).WithEnable(hasActivePart).
+			WithIcon("model-health").WithButtonStyle(LargeIconButton).
+			WithTooltip("Report the part's overall health and list every feature that is sick, warning or suppressed for repair."),
 	}
+}
+
+// modelHealth aggregates the active part's feature health and reports it as a notice.
+func modelHealth(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	mh := analysis.ModelHealthOf(part.Features())
+	if len(mh.Unhealthy) == 0 {
+		s.SetNotice("Model Health — all features OK")
+		return nil
+	}
+	s.SetNotice(fmt.Sprintf("Model Health — overall %s, %d sick: %s",
+		mh.Overall, mh.SickCount, unhealthySummary(mh.Unhealthy)))
+	return nil
+}
+
+// unhealthySummary lists each unhealthy feature as "Name (status)".
+func unhealthySummary(items []analysis.FeatureHealthItem) string {
+	parts := make([]string, len(items))
+	for i, it := range items {
+		parts[i] = fmt.Sprintf("%s (%s)", it.Name, it.Status)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // startMeasure activates the interactive Measure tool on the active part.

--- a/app/commands_analysis_test.go
+++ b/app/commands_analysis_test.go
@@ -28,3 +28,27 @@ func TestPhysicalPropertiesWithoutPart(t *testing.T) {
 		t.Error("physicalProperties with no active part = ok, want error")
 	}
 }
+
+// TestModelHealthCommand: the Model Health command reports a clean part as all-OK, lists a
+// suppressed feature, and errors without an active part.
+func TestModelHealthCommand(t *testing.T) {
+	s, _ := newPartWithBlock(t, 2)
+	if err := modelHealth(s); err != nil {
+		t.Fatalf("modelHealth: %v", err)
+	}
+	if !strings.Contains(s.Notice(), "all features OK") {
+		t.Errorf("clean notice = %q, want all-OK", s.Notice())
+	}
+
+	activePartDef(t, s).Features().Item(0).SetSuppressed(true)
+	if err := modelHealth(s); err != nil {
+		t.Fatalf("modelHealth after suppress: %v", err)
+	}
+	if !strings.Contains(s.Notice(), "suppressed") {
+		t.Errorf("suppressed notice = %q, want a suppressed feature listed", s.Notice())
+	}
+
+	if err := modelHealth(NewSession()); err == nil {
+		t.Error("modelHealth with no active part = ok, want error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.58.0
+	oblikovati.org/api v0.59.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.58.0
+	oblikovati.org/api v0.59.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/icon/assets/model-health.svg
+++ b/head/icon/assets/model-health.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 12 H8 L10 7 L13 17 L15 12 H20" stroke-width="1.6"/></svg>

--- a/model/analysis/health.go
+++ b/model/analysis/health.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/health"
+)
+
+// Model health aggregation (M18-F02 #430): the design-doctor roll-up of a part's feature health.
+// Each feature already carries its own health.Health (a recompute or bind failure becomes Sick on
+// the feature, never a panic); this enumerates the unhealthy ones and reports the worst status so
+// the UI can list everything that needs repair.
+
+// FeatureHealthItem is one feature's aggregated health: its name, status and the reason it is unwell.
+type FeatureHealthItem struct {
+	Name   string
+	Status health.Status
+	Reason string
+}
+
+// ModelHealth is a part's aggregated feature health.
+type ModelHealth struct {
+	Overall   health.Status // the most severe status across the part's features (suppressed ⇒ OK)
+	SickCount int
+	Unhealthy []FeatureHealthItem // every feature that is not OK, for repair
+}
+
+// ModelHealthOf aggregates the health of a part's features.
+func ModelHealthOf(features *feature.PartFeatures) ModelHealth {
+	mh := ModelHealth{Overall: health.OK}
+	for i := 0; i < features.Count(); i++ {
+		f := features.Item(i)
+		status, reason := featureStatus(f)
+		if status == health.OK {
+			continue
+		}
+		mh.Unhealthy = append(mh.Unhealthy, FeatureHealthItem{Name: f.Name(), Status: status, Reason: reason})
+		if status == health.Sick {
+			mh.SickCount++
+		}
+		if severity(status) > severity(mh.Overall) {
+			mh.Overall = status
+		}
+	}
+	return mh
+}
+
+// featureStatus reads a feature's status, treating a suppressed-but-otherwise-OK feature as
+// Suppressed (the suppression is the salient state).
+func featureStatus(f *feature.PartFeature) (health.Status, string) {
+	h := f.Health()
+	if f.Suppressed() && h.Status == health.OK {
+		return health.Suppressed, ""
+	}
+	return h.Status, h.Reason
+}
+
+// severity orders statuses for the overall roll-up: OK < Warning < Sick, with Suppressed neutral
+// (an intentionally excluded feature does not make the model worse).
+func severity(s health.Status) int {
+	switch s {
+	case health.Warning:
+		return 1
+	case health.Sick:
+		return 2
+	default: // OK, Suppressed
+		return 0
+	}
+}

--- a/model/analysis/health_test.go
+++ b/model/analysis/health_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/health"
+)
+
+// okFeature recomputes cleanly (a healthy feature); failingFeature always errors (goes Sick).
+type okFeature struct{}
+
+func (okFeature) Kind() string                                    { return "ok" }
+func (okFeature) Recompute(feature.Input) (feature.Output, error) { return feature.Output{}, nil }
+
+type failingFeature struct{}
+
+func (failingFeature) Kind() string { return "failer" }
+func (failingFeature) Recompute(feature.Input) (feature.Output, error) {
+	return feature.Output{}, errors.New("boom")
+}
+
+// TestModelHealthOf checks the aggregation across a clean, a failing and a suppressed feature.
+func TestModelHealthOf(t *testing.T) {
+	fs := feature.NewPartFeatures(nil, nil)
+	fs.Add(okFeature{})
+	bad := fs.Add(failingFeature{})
+	bad.SetName("Extrusion2")
+	supp := fs.Add(okFeature{})
+	supp.SetName("Fillet1")
+	supp.SetSuppressed(true)
+	fs.Recompute()
+
+	mh := ModelHealthOf(fs)
+	if mh.Overall != health.Sick {
+		t.Errorf("overall = %v, want sick (a feature failed)", mh.Overall)
+	}
+	if mh.SickCount != 1 {
+		t.Errorf("sick count = %d, want 1", mh.SickCount)
+	}
+	if len(mh.Unhealthy) != 2 {
+		t.Fatalf("unhealthy = %+v, want 2 (the sick + the suppressed)", mh.Unhealthy)
+	}
+	if !hasStatus(mh.Unhealthy, "Extrusion2", health.Sick) {
+		t.Error("the failing feature is not reported sick")
+	}
+	if !hasStatus(mh.Unhealthy, "Fillet1", health.Suppressed) {
+		t.Error("the suppressed feature is not reported suppressed")
+	}
+}
+
+// TestModelHealthOfAllHealthy checks a clean part reports OK with nothing to repair.
+func TestModelHealthOfAllHealthy(t *testing.T) {
+	fs := feature.NewPartFeatures(nil, nil)
+	fs.Add(okFeature{})
+	fs.Recompute()
+	mh := ModelHealthOf(fs)
+	if mh.Overall != health.OK || mh.SickCount != 0 || len(mh.Unhealthy) != 0 {
+		t.Errorf("clean part health = %+v, want OK with no unhealthy features", mh)
+	}
+}
+
+// TestHealthSeverityOrder checks the roll-up ordering: OK < Warning < Sick, Suppressed neutral.
+func TestHealthSeverityOrder(t *testing.T) {
+	if severity(health.OK) >= severity(health.Warning) || severity(health.Warning) >= severity(health.Sick) {
+		t.Error("severity must order OK < Warning < Sick")
+	}
+	if severity(health.Suppressed) != severity(health.OK) {
+		t.Error("suppressed must be neutral (severity of OK)")
+	}
+}
+
+func hasStatus(items []FeatureHealthItem, name string, status health.Status) bool {
+	for _, it := range items {
+		if it.Name == name && it.Status == status {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What & why

Implements **model-health aggregation** for M18-F02 (#430) — the design-doctor
roll-up that satisfies the PBI-166 acceptance *"all sick features are enumerable"*.

- **model/analysis/health.go** — `ModelHealthOf(features)` walks the part's
  features, lists every one that is **not OK** (sick / warning / suppressed)
  with its reason, counts the sick, and reports the worst status overall
  (suppression is neutral). Reuses each feature's existing `health.Health`.
- **addin/router** — serves `analysis.modelHealth`.
- **app** — a **Model Health** command on the Inspect tab reports the summary
  (overall + sick count + the unhealthy features) to the status bar, plus a
  `model-health` icon.

Reuses the existing `HealthStatus` vocabulary (API v0.59.0 adds the wire method
only). Tests cover clean / sick / suppressed parts and the command. The
clearance-threshold half of F02 lands in a follow-up; the bridge e2e follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)