### PR TITLE
feat(sketch): stable document-derived persistent reference keys (#153, foundation)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.58.0
+	oblikovati.org/api v0.59.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.58.0
+	oblikovati.org/api v0.59.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/identity/derived_uuid.go
+++ b/model/identity/derived_uuid.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import (
+	"crypto/sha1" //nolint:gosec // SHA-1 is mandated by RFC 4122 §4.3 for v5 names, not security
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Persistent sketch references (#153): a sketch or sketch entity is named durably by a
+// UUID DERIVED from its document's stable GUID and its document-local id, rather than by
+// the transient session id (which is re-minted on load). Deriving from the document GUID
+// makes a cross-document collision structurally impossible: two documents never share a
+// GUID, so the same local id in two files yields two different UUIDs. Within one document
+// the local id is unique, so the UUID is unique there too. Because the derivation is a
+// pure function of (GUID, kind, local id) and the local id now survives the .obk round
+// trip, the same entity yields the same UUID across save/load and unrelated edits.
+
+// Sketch-reference kind tags. They namespace the derived UUID so a sketch and an entity
+// that happened to share a local id (they cannot today, but the tag future-proofs it)
+// can never collide, and so the kind is self-describing in the derived name.
+const (
+	sketchKindTag       = "sketch"
+	sketchEntityKindTag = "sketchEntity"
+)
+
+// SketchKey returns the persistent reference UUID of a sketch, derived from its document's
+// GUID and the sketch's document-local id.
+//
+//	key, err := identity.SketchKey(doc.FileIdentity().InternalName, uint64(sk.ID()))
+func SketchKey(documentGUID string, localID uint64) (string, error) {
+	return deriveDocumentUUID(documentGUID, sketchKindTag, localID)
+}
+
+// SketchEntityKey returns the persistent reference UUID of a sketch entity (line, point,
+// arc, …), derived from its document's GUID and the entity's document-local id.
+//
+//	key, err := identity.SketchEntityKey(doc.FileIdentity().InternalName, uint64(e.EntityID()))
+func SketchEntityKey(documentGUID string, localID uint64) (string, error) {
+	return deriveDocumentUUID(documentGUID, sketchEntityKindTag, localID)
+}
+
+// deriveDocumentUUID builds an RFC 4122 version-5 (name-based, SHA-1) UUID whose namespace
+// is the document GUID and whose name is "<kind>:<localID>". The document GUID is the
+// namespace, so the result is unique per document by construction.
+func deriveDocumentUUID(documentGUID, kind string, localID uint64) (string, error) {
+	ns, err := parseUUID(documentGUID)
+	if err != nil {
+		return "", fmt.Errorf("identity: derive %s uuid: document guid %q: %w", kind, documentGUID, err)
+	}
+	name := fmt.Sprintf("%s:%d", kind, localID)
+	return formatUUID(uuidV5(ns, name)), nil
+}
+
+// uuidV5 hashes the namespace bytes followed by the name (RFC 4122 §4.3) and stamps the
+// version (5) and variant (RFC 4122) bits.
+func uuidV5(namespace [16]byte, name string) [16]byte {
+	h := sha1.New() //nolint:gosec // see file header: RFC 4122 v5 is defined over SHA-1
+	h.Write(namespace[:])
+	h.Write([]byte(name))
+	sum := h.Sum(nil)
+
+	var out [16]byte
+	copy(out[:], sum[:16])
+	out[6] = (out[6] & 0x0f) | 0x50 // version 5
+	out[8] = (out[8] & 0x3f) | 0x80 // RFC 4122 variant
+	return out
+}
+
+// parseUUID decodes the canonical 8-4-4-4-12 hex form into 16 bytes.
+func parseUUID(s string) ([16]byte, error) {
+	var out [16]byte
+	clean := strings.ReplaceAll(s, "-", "")
+	if len(clean) != 32 {
+		return out, fmt.Errorf("want 32 hex digits (8-4-4-4-12), got %d in %q", len(clean), s)
+	}
+	b, err := hex.DecodeString(clean)
+	if err != nil {
+		return out, fmt.Errorf("not hexadecimal: %w", err)
+	}
+	copy(out[:], b)
+	return out, nil
+}
+
+// formatUUID renders 16 bytes as the canonical 8-4-4-4-12 lowercase hex string.
+func formatUUID(b [16]byte) string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/model/identity/derived_uuid_test.go
+++ b/model/identity/derived_uuid_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import (
+	"regexp"
+	"testing"
+)
+
+const (
+	docA = "11111111-2222-3333-4444-555555555555"
+	docB = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+)
+
+var canonicalUUID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// TestSketchEntityKeyDeterministic: the same inputs always derive the same UUID — the
+// property the whole persistent-reference scheme rests on.
+func TestSketchEntityKeyDeterministic(t *testing.T) {
+	k1, err := SketchEntityKey(docA, 42)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	k2, _ := SketchEntityKey(docA, 42)
+	if k1 != k2 {
+		t.Errorf("non-deterministic: %q != %q", k1, k2)
+	}
+	if !canonicalUUID.MatchString(k1) {
+		t.Errorf("not a canonical v5 UUID: %q", k1)
+	}
+}
+
+// TestKeysUniqueAcrossDocuments is the user's core requirement: the same local id in two
+// different documents must derive two different UUIDs (no cross-document collision ever).
+func TestKeysUniqueAcrossDocuments(t *testing.T) {
+	a, _ := SketchEntityKey(docA, 7)
+	b, _ := SketchEntityKey(docB, 7)
+	if a == b {
+		t.Errorf("same local id in different documents collided: %q", a)
+	}
+}
+
+// TestKeysUniqueAcrossLocalIDs: distinct local ids in one document derive distinct UUIDs.
+func TestKeysUniqueAcrossLocalIDs(t *testing.T) {
+	a, _ := SketchEntityKey(docA, 1)
+	b, _ := SketchEntityKey(docA, 2)
+	if a == b {
+		t.Errorf("distinct local ids collided: %q", a)
+	}
+}
+
+// TestSketchAndEntityKindsDoNotCollide: a sketch and an entity with the same local id and
+// document derive different UUIDs, because the kind tag namespaces the derived name.
+func TestSketchAndEntityKindsDoNotCollide(t *testing.T) {
+	s, _ := SketchKey(docA, 5)
+	e, _ := SketchEntityKey(docA, 5)
+	if s == e {
+		t.Errorf("sketch and entity keys collided for the same id: %q", s)
+	}
+}
+
+// TestDeriveRejectsMalformedGUID: a non-UUID document guid is a clear error, not a silent
+// bad key.
+func TestDeriveRejectsMalformedGUID(t *testing.T) {
+	for _, bad := range []string{"", "not-a-uuid", "11111111-2222-3333-4444"} {
+		if _, err := SketchEntityKey(bad, 1); err == nil {
+			t.Errorf("SketchEntityKey(%q) should fail", bad)
+		}
+	}
+}
+
+// TestDeriveAcceptsUnhyphenatedGUID: a 32-hex-digit guid without hyphens parses too.
+func TestDeriveAcceptsUnhyphenatedGUID(t *testing.T) {
+	hyphenated, _ := SketchEntityKey(docA, 9)
+	plain, err := SketchEntityKey("11111111222233334444555555555555", 9)
+	if err != nil {
+		t.Fatalf("unhyphenated guid: %v", err)
+	}
+	if hyphenated != plain {
+		t.Errorf("hyphenation changed the derived key: %q != %q", hyphenated, plain)
+	}
+}

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -22,6 +22,10 @@ type Point struct {
 // EntityID implements [Entity].
 func (p *Point) EntityID() ID { return p.id }
 
+// setID pins the point's local id to a persisted value (restore path only); see
+// [entityBase.setID].
+func (p *Point) setID(id ID) { p.id = id }
+
 // Position returns the point as a [math.Point2].
 func (p *Point) Position() math.Point2 { return math.P2(p.X, p.Y) }
 
@@ -39,6 +43,11 @@ func newEntity() entityBase { return entityBase{id: nextID()} }
 
 // EntityID implements [Entity].
 func (e *entityBase) EntityID() ID { return e.id }
+
+// setID overrides the minted local id with a persisted one (restore path only). A sketch
+// entity's local id must survive the .obk round trip so its document-derived persistent
+// reference key (#153) is stable across save/load; see model/identity.SketchEntityKey.
+func (e *entityBase) setID(id ID) { e.id = id }
 
 // IsConstruction reports whether the entity is construction (reference) geometry — it shapes
 // constraints but is not part of a profile. A centerline is always construction (an axis never

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -20,6 +20,10 @@ import (
 // common visible=true case omits the field (M21-F01 PBI-201 persists name/display props,
 // closing the previous name-not-persisted gap).
 type SketchData struct {
+	// ID is the sketch's document-local id, persisted (#153) so it survives the round trip
+	// and the sketch's document-derived reference key stays stable. Zero in legacy recipes
+	// that predate it; restore then keeps the freshly-minted id.
+	ID           uint64  `yaml:"id,omitempty"`
 	Name         string  `yaml:"name,omitempty"`
 	Hidden       bool    `yaml:"hidden,omitempty"`
 	Shared       bool    `yaml:"shared,omitempty"` // shared sketch stays at top level (issue #132)
@@ -160,6 +164,7 @@ func (sc *Sketches) MarshalRecipe() ([]SketchData, error) {
 
 func serializeSketch(s *Sketch) (SketchData, error) {
 	sd := SketchData{
+		ID:           uint64(s.id),
 		Name:         s.name,
 		Hidden:       !s.visible,
 		Shared:       s.shared,

--- a/model/sketch/serialize_refkey_test.go
+++ b/model/sketch/serialize_refkey_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
+)
+
+// docGUID is a stable document namespace for deriving persistent reference keys in tests.
+const docGUID = "11111111-2222-3333-4444-555555555555"
+
+// buildKeyedSketch makes a sketch with a line, a circle, and a standalone point, returning
+// the collection and the three entities for id comparison.
+func buildKeyedSketch(t *testing.T) (*Sketches, *Line, *Circle, *Point) {
+	t.Helper()
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	a := s.NewPoint(math.P2(0, 0))
+	b := s.NewPoint(math.P2(4, 0))
+	line := s.Lines().Add(a, b)
+	center := s.NewPoint(math.P2(2, 3))
+	circle := s.Circles().Add(center, 1.5)
+	pt := s.Points().Add(math.P2(5, 5))
+	return sc, line, circle, pt
+}
+
+// entityKeys derives the persistent reference key of each entity (#153). It fails the test
+// on a derivation error so callers can compare keys directly.
+func entityKeys(t *testing.T, ents ...Entity) []string {
+	t.Helper()
+	out := make([]string, len(ents))
+	for i, e := range ents {
+		k, err := identity.SketchEntityKey(docGUID, uint64(e.EntityID()))
+		if err != nil {
+			t.Fatalf("derive key for entity %d: %v", i, err)
+		}
+		out[i] = k
+	}
+	return out
+}
+
+// TestEntityIDsSurviveRoundTrip is the #153 foundation: a sketch entity's local id — and
+// therefore its document-derived persistent reference key — must be identical after a
+// save/load cycle. Before this change the id was re-minted on load, so any durable
+// reference an add-in held went stale.
+func TestEntityIDsSurviveRoundTrip(t *testing.T) {
+	sc, line, circle, pt := buildKeyedSketch(t)
+	wantIDs := []ID{line.EntityID(), circle.EntityID(), pt.EntityID()}
+	wantKeys := entityKeys(t, line, circle, pt)
+
+	out := roundTrip(t, sc)
+	gotLine, gotCircle, gotPoint := firstOfEach(t, out)
+
+	gotIDs := []ID{gotLine.EntityID(), gotCircle.EntityID(), gotPoint.EntityID()}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("entity %d id = %d after round trip, want %d (re-minted)", i, gotIDs[i], wantIDs[i])
+		}
+	}
+	gotKeys := entityKeys(t, gotLine, gotCircle, gotPoint)
+	for i := range wantKeys {
+		if gotKeys[i] != wantKeys[i] {
+			t.Errorf("entity %d persistent key changed: %q -> %q", i, wantKeys[i], gotKeys[i])
+		}
+	}
+}
+
+// TestSketchIDSurvivesRoundTrip: the sketch's own local id (and its derived key) survive
+// the round trip, so a reference to "this sketch" stays valid (#153).
+func TestSketchIDSurvivesRoundTrip(t *testing.T) {
+	sc, _, _, _ := buildKeyedSketch(t)
+	want := sc.Item(0).ID()
+	if got := roundTrip(t, sc).ID(); got != want {
+		t.Errorf("sketch id = %d after round trip, want %d", got, want)
+	}
+}
+
+// TestNewEntityAfterRestoreDoesNotCollide: an entity created after a restore gets an id
+// past every restored id, so it never collides with a pinned (verbatim) id. This guards
+// the raiseIDSeq clock-raise.
+func TestNewEntityAfterRestoreDoesNotCollide(t *testing.T) {
+	sc, _, _, _ := buildKeyedSketch(t)
+	data, err := sc.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewSketches()
+	if err := fresh.ApplyRecipe(data); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	restored := fresh.Item(0)
+	maxRestored := maxEntityID(restored)
+
+	added := restored.Lines().Add(restored.NewPoint(math.P2(9, 9)), restored.NewPoint(math.P2(9, 8)))
+	if added.EntityID() <= maxRestored {
+		t.Errorf("new entity id %d not past max restored id %d (collision risk)", added.EntityID(), maxRestored)
+	}
+}
+
+// TestIDsStableAcrossUnrelatedEdit: editing a sketch (adding geometry) must not perturb
+// the ids/keys of existing entities, so references to them survive an edit (#153).
+func TestIDsStableAcrossUnrelatedEdit(t *testing.T) {
+	sc, line, circle, pt := buildKeyedSketch(t)
+	wantKeys := entityKeys(t, line, circle, pt)
+
+	// An unrelated edit: add another line, then round-trip again.
+	s := sc.Item(0)
+	s.Lines().Add(s.NewPoint(math.P2(1, 1)), s.NewPoint(math.P2(2, 2)))
+
+	out := roundTrip(t, sc)
+	gotLine, gotCircle, gotPoint := firstOfEach(t, out)
+	gotKeys := entityKeys(t, gotLine, gotCircle, gotPoint)
+	for i := range wantKeys {
+		if gotKeys[i] != wantKeys[i] {
+			t.Errorf("entity %d key changed after an unrelated edit: %q -> %q", i, wantKeys[i], gotKeys[i])
+		}
+	}
+}
+
+// firstOfEach returns the first line, circle, and standalone point of a restored sketch.
+func firstOfEach(t *testing.T, s *Sketch) (*Line, *Circle, *Point) {
+	t.Helper()
+	var line *Line
+	var circle *Circle
+	for _, e := range s.Entities() {
+		switch v := e.(type) {
+		case *Line:
+			if line == nil {
+				line = v
+			}
+		case *Circle:
+			circle = v
+		}
+	}
+	pts := s.Points().items
+	if line == nil || circle == nil || len(pts) == 0 {
+		t.Fatalf("restored sketch missing entities: line=%v circle=%v points=%d", line, circle, len(pts))
+	}
+	return line, circle, pts[0]
+}
+
+// maxEntityID returns the largest local id among a sketch's points and entities.
+func maxEntityID(s *Sketch) ID {
+	var max ID
+	for _, p := range s.AllPoints() {
+		if p.EntityID() > max {
+			max = p.EntityID()
+		}
+	}
+	for _, e := range s.Entities() {
+		if e.EntityID() > max {
+			max = e.EntityID()
+		}
+	}
+	return max
+}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -36,11 +36,13 @@ func restoreSketch(sc *Sketches, sd SketchData) error {
 		pointMap:  make(map[int]*Point, len(sd.Points)),
 		entityMap: make(map[int]Entity, len(sd.Entities)),
 	}
+	sc.restoreSketchID(r.s, sd.ID)
 	restoreSketchProps(r.s, sd)
 	r.restorePoints(sd.Points)
 	if err := r.restoreEntities(sd.Entities); err != nil {
 		return err
 	}
+	raiseIDSeq(r.maxID) // ids minted after load must not collide with the restored ones
 	if err := r.restoreConstraints(sd.Constraints); err != nil {
 		return err
 	}
@@ -112,23 +114,51 @@ func restoreSeq(s *Sketch, saved uint64) {
 	seq.Restore(&s.seq, saved)
 }
 
-// sketchRestorer carries the id→object maps while rebuilding one sketch.
+// sketchRestorer carries the id→object maps while rebuilding one sketch. maxID tracks the
+// largest persisted local id pinned onto a point/entity, so the id clock can be raised
+// past it once the sketch is rebuilt (#153).
 type sketchRestorer struct {
 	s         *Sketch
 	blockDefs *BlockDefinitions
 	pointMap  map[int]*Point
 	entityMap map[int]Entity
+	maxID     uint64
+}
+
+// idCarrier is the restore-only seam for pinning a sketch object's local id to its
+// persisted value. Every entity satisfies it (curves/annotations via entityBase, points
+// directly), so the same restore code path keeps all ids stable across save/load (#153).
+type idCarrier interface{ setID(ID) }
+
+// pin overrides obj's minted id with its persisted value and tracks the maximum seen.
+func (r *sketchRestorer) pin(obj idCarrier, saved int) {
+	obj.setID(ID(saved))
+	if uint64(saved) > r.maxID {
+		r.maxID = uint64(saved)
+	}
 }
 
 func (r *sketchRestorer) restorePoints(points []PointData) {
 	for _, pd := range points {
-		pos := math.P2(pd.X, pd.Y)
-		if pd.Standalone {
-			r.pointMap[pd.ID] = r.s.points.Add(pos)
-			continue
-		}
-		r.pointMap[pd.ID] = r.s.newPoint(pos)
+		r.pointMap[pd.ID] = r.restorePoint(pd)
 	}
+}
+
+// restorePoint recreates one point (standalone SketchPoint or a curve-owned point) and
+// pins its persisted local id.
+func (r *sketchRestorer) restorePoint(pd PointData) *Point {
+	pos := math.P2(pd.X, pd.Y)
+	p := r.newPointFor(pd.Standalone, pos)
+	r.pin(p, pd.ID)
+	return p
+}
+
+// newPointFor creates a standalone SketchPoint or a curve-owned solver point, exactly one.
+func (r *sketchRestorer) newPointFor(standalone bool, pos math.Point2) *Point {
+	if standalone {
+		return r.s.points.Add(pos)
+	}
+	return r.s.newPoint(pos)
 }
 
 func (r *sketchRestorer) restoreEntities(entities []EntityData) error {
@@ -143,6 +173,7 @@ func (r *sketchRestorer) restoreEntities(entities []EntityData) error {
 				cl.SetCenterline(true)
 			}
 		}
+		r.pin(e.(idCarrier), ed.ID)
 		r.entityMap[ed.ID] = e
 	}
 	return nil

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -23,6 +23,21 @@ var idSeq atomic.Uint64
 
 func nextID() ID { return ID(idSeq.Add(1)) }
 
+// raiseIDSeq lifts the entity id clock to at least n. Restoring a document pins its
+// entity/sketch ids to their persisted (verbatim) values; raising the clock past the
+// largest restored id ensures ids minted afterwards never collide with them (#153).
+func raiseIDSeq(n uint64) {
+	for {
+		cur := idSeq.Load()
+		if cur >= n {
+			return
+		}
+		if idSeq.CompareAndSwap(cur, n) {
+			return
+		}
+	}
+}
+
 // Entity is a piece of sketch geometry (line, arc, circle, point, …). The full
 // interface — constrainable points, curve evaluation — is filled in by the entity
 // types (M06-F02); here it is the minimum the container needs.
@@ -460,6 +475,20 @@ func (c *Sketches) AddNamed(name string, plane Plane) *Sketch {
 	c.items = append(c.items, s)
 	c.byID[s.id] = s
 	return s
+}
+
+// restoreSketchID pins a freshly-added sketch's local id to its persisted value so the
+// sketch's document-derived persistent reference key (#153) is stable across load, re-keying
+// the byID index and raising the id clock past it. A zero saved id (a legacy recipe with no
+// persisted sketch id) keeps the minted one.
+func (c *Sketches) restoreSketchID(s *Sketch, saved uint64) {
+	if saved == 0 {
+		return
+	}
+	delete(c.byID, s.id)
+	s.id = ID(saved)
+	c.byID[s.id] = s
+	raiseIDSeq(saved)
 }
 
 // Count returns the number of sketches.


### PR DESCRIPTION
## What

The `/source` foundation for #153 — durable references to sketches and sketch entities. No public API change yet (that's the follow-up PR).

## Why

A sketch entity's local id was **re-minted on every `.obk` load**, so any persistent reference an add-in held (for robust feature-editing automations, #140/#163) went stale across save/load. References need a stable, document-scoped identity.

## How

- **`model/identity`** — derive a sketch/entity persistent reference **UUID (RFC 4122 v5)** from the document's already-persisted stable GUID (`FileIdentity.InternalName`) and the object's document-local id. Deriving from the document GUID makes a **cross-document collision structurally impossible**: two documents never share a GUID, so the same local id in two files yields different UUIDs.
- **`model/sketch`** — persist the sketch's local id and restore point/entity/sketch ids **verbatim** instead of re-minting, raising the id clock past the largest restored id so ids minted after a load never collide with the pinned ones. The derived key is now stable across save/load and unrelated edits.

## Tests

- id/key stability across round trips and unrelated edits
- post-restore collision-freedom (new entity ids land past every restored id)
- cross-document key uniqueness (same local id, different document ⇒ different UUID)
- derivation determinism, kind-namespacing, malformed-GUID rejection

Foundation only; the cross-repo API exposure (`SketchInfo`/entity-info key fields + a resolve method) follows in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)