### PR TITLE
feat(sketch): resolve & report persistent reference keys (#153 impl)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -73,6 +73,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerDocumentPropertyHandlers()
 	r.registerAttributeHandlers()
 	r.registerSelectionMutationHandlers()
+	r.registerSketchReferenceKeyHandlers()
 	r.registerDrawingHandlers()
 	r.registerDrawingStyleHandlers()
 	r.registerDrawingViewHandlers()

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
 	"oblikovati.org/model/sketch"
 )
 
@@ -20,6 +21,7 @@ func enumerateEntities(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 	}
 	ents := sk.Entities()
 	moveable := sk.MoveableClassifier()
+	guid, _ := activeDocumentGUID(s) // empty ⇒ omit keys; never fails for a real document
 	out := make([]wire.SketchEntityInfo, len(ents))
 	for i, e := range ents {
 		kind, pts, radius := entityShape(e)
@@ -30,11 +32,25 @@ func enumerateEntities(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 			Construction:   isConstruction(e),
 			Points:         pts,
 			Radius:         radius,
+			ReferenceKey:   entityReferenceKey(guid, e),
 			MoveableStatus: moveable.Of(e).String(),
 			FitMethod:      splineFitSpelling(e),
 		}
 	}
 	return json.Marshal(wire.EnumerateEntitiesResult{Entities: out})
+}
+
+// entityReferenceKey derives an entity's persistent reference key (#153); empty when the
+// document guid is unavailable, so the field is simply omitted.
+func entityReferenceKey(guid string, e sketch.Entity) string {
+	if guid == "" {
+		return ""
+	}
+	k, err := identity.SketchEntityKey(guid, uint64(e.EntityID()))
+	if err != nil {
+		return ""
+	}
+	return k
 }
 
 // enumerateConstraints lists a sketch's geometric constraints (kind + related entity ids).

--- a/addin/router/sketch_reference_key.go
+++ b/addin/router/sketch_reference_key.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/identity"
+	"oblikovati.org/model/sketch"
+)
+
+// Persistent sketch reference keys (#153). A sketch and each of its entities are named by a
+// UUID derived from the document's stable GUID and the object's document-local id (see
+// model/identity). The key survives save/load and unrelated edits, so an add-in can hold a
+// durable reference. sketch.referenceKey hands out a sketch's key; sketch.resolveReference
+// rebinds a stored key (sketch or entity) to its current location.
+
+// registerSketchReferenceKeyHandlers wires the sketch.referenceKey / sketch.resolveReference
+// methods.
+func (r *Router) registerSketchReferenceKeyHandlers() {
+	r.handlers[wire.MethodSketchReferenceKey] = sketchReferenceKey
+	r.handlers[wire.MethodSketchResolveReference] = sketchResolveReference
+}
+
+// activeDocumentGUID returns the active document's stable GUID — the namespace every sketch
+// reference key in the document is derived from.
+func activeDocumentGUID(s *app.Session) (string, error) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return "", modelaccess.ErrNoActiveDocument
+	}
+	guid := d.FileIdentity().InternalName
+	if guid == "" {
+		return "", fmt.Errorf("router: active document %q has no identity guid", d.DisplayName())
+	}
+	return guid, nil
+}
+
+// sketchReferenceKey returns the persistent reference key of the addressed sketch.
+func sketchReferenceKey(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	sk, _, err := resolveSketch(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	guid, err := activeDocumentGUID(s)
+	if err != nil {
+		return nil, err
+	}
+	key, err := identity.SketchKey(guid, uint64(sk.ID()))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SketchReferenceKeyResult{ReferenceKey: key})
+}
+
+// sketchResolveReference rebinds a stored sketch/entity key to its current location, or
+// reports found=false when nothing in the active part matches it (the referent was deleted).
+func sketchResolveReference(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ResolveSketchReferenceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	guid, err := activeDocumentGUID(s)
+	if err != nil {
+		return nil, err
+	}
+	res := matchReference(part.Sketches(), guid, in.ReferenceKey)
+	return json.Marshal(res)
+}
+
+// matchReference scans every sketch and entity for the one whose derived key equals want,
+// returning the first match (sketch keys before entity keys). A miss is found=false.
+func matchReference(sketches *sketch.Sketches, guid, want string) wire.ResolveSketchReferenceResult {
+	for i := 0; i < sketches.Count(); i++ {
+		sk := sketches.Item(i)
+		if k, err := identity.SketchKey(guid, uint64(sk.ID())); err == nil && k == want {
+			return wire.ResolveSketchReferenceResult{Found: true, Kind: "sketch", SketchIndex: i}
+		}
+		if id, ok := matchEntity(sk, guid, want); ok {
+			return wire.ResolveSketchReferenceResult{Found: true, Kind: "sketchEntity", SketchIndex: i, EntityID: id}
+		}
+	}
+	return wire.ResolveSketchReferenceResult{Found: false}
+}
+
+// matchEntity returns the session id of the sketch entity whose derived key equals want.
+func matchEntity(sk *sketch.Sketch, guid, want string) (uint64, bool) {
+	for _, e := range sk.Entities() {
+		if k, err := identity.SketchEntityKey(guid, uint64(e.EntityID())); err == nil && k == want {
+			return uint64(e.EntityID()), true
+		}
+	}
+	return 0, false
+}

--- a/addin/router/sketch_reference_key_test.go
+++ b/addin/router/sketch_reference_key_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// TestSketchEntitiesReportReferenceKeys: sketch.entities now reports a persistent reference
+// key per entity (#153), and the keys are non-empty and distinct.
+func TestSketchEntitiesReportReferenceKeys(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &ents)
+	if len(ents.Entities) == 0 {
+		t.Fatal("no entities enumerated")
+	}
+	seen := map[string]bool{}
+	for _, e := range ents.Entities {
+		if e.ReferenceKey == "" {
+			t.Errorf("entity %d (%s) has no reference key", e.ID, e.Kind)
+		}
+		if seen[e.ReferenceKey] {
+			t.Errorf("duplicate reference key %q", e.ReferenceKey)
+		}
+		seen[e.ReferenceKey] = true
+	}
+}
+
+// TestResolveSketchEntityReference: a key from sketch.entities resolves back to the same
+// entity (kind=sketchEntity, right sketch index and session id).
+func TestResolveSketchEntityReference(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &ents)
+	want := ents.Entities[0]
+
+	var res wire.ResolveSketchReferenceResult
+	call(t, r, s, "sketch.resolveReference", mustJSON(t, wire.ResolveSketchReferenceArgs{ReferenceKey: want.ReferenceKey}), &res)
+	if !res.Found || res.Kind != "sketchEntity" || res.SketchIndex != 0 || res.EntityID != want.ID {
+		t.Errorf("resolve entity = %+v, want found sketchEntity sketch 0 id %d", res, want.ID)
+	}
+}
+
+// TestSketchReferenceKeyResolvesToSketch: a sketch's own key (sketch.referenceKey) resolves
+// back to that sketch (kind=sketch).
+func TestSketchReferenceKeyResolvesToSketch(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+
+	var key wire.SketchReferenceKeyResult
+	call(t, r, s, "sketch.referenceKey", `{"sketchIndex":0}`, &key)
+	k := key.ReferenceKey
+	if k == "" {
+		t.Fatal("sketch.referenceKey returned an empty key")
+	}
+
+	var res wire.ResolveSketchReferenceResult
+	call(t, r, s, "sketch.resolveReference", mustJSON(t, wire.ResolveSketchReferenceArgs{ReferenceKey: k}), &res)
+	if !res.Found || res.Kind != "sketch" || res.SketchIndex != 0 {
+		t.Errorf("resolve sketch = %+v, want found sketch index 0", res)
+	}
+}
+
+// TestReferenceKeyMethodsRejectNoActivePart: both methods error without an active part,
+// rather than returning an empty/zero result.
+func TestReferenceKeyMethodsRejectNoActivePart(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	cases := map[string]string{
+		"sketch.referenceKey":     `{"sketchIndex":0}`,
+		"sketch.resolveReference": `{"referenceKey":"x"}`,
+	}
+	for method, args := range cases {
+		if _, err := r.Handle(s, method, []byte(args)); err == nil {
+			t.Errorf("%s with no active part should fail", method)
+		}
+	}
+}
+
+// TestSketchReferenceKeyBadIndexFails: an out-of-range sketch index is a rejection.
+func TestSketchReferenceKeyBadIndexFails(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "sketch.referenceKey", []byte(`{"sketchIndex":7}`)); err == nil {
+		t.Error("sketch.referenceKey with an out-of-range index should fail")
+	}
+}
+
+// TestResolveUnknownReferenceNotFound: an unrecognized key resolves to found=false (the
+// referent was deleted), not an error.
+func TestResolveUnknownReferenceNotFound(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+
+	var res wire.ResolveSketchReferenceResult
+	call(t, r, s, "sketch.resolveReference", `{"referenceKey":"00000000-0000-5000-8000-000000000000"}`, &res)
+	if res.Found {
+		t.Errorf("unknown key resolved as found: %+v", res)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.59.0
+	oblikovati.org/api v0.60.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.59.0
+	oblikovati.org/api v0.60.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

The `/source` implementation of #153's public surface (pins api **v0.60.0**), completing durable references to sketches and sketch entities. Builds on #1067 (the document-derived, round-trip-stable key foundation).

## Surface

- `sketch.entities` → each `SketchEntityInfo` now carries its persistent `ReferenceKey`.
- `sketch.referenceKey` → a sketch's own key.
- `sketch.resolveReference` → rebinds a stored sketch/entity key to its current sketch index + entity id; `found=false` when the referent was deleted.

## How

Keys are derived in `model/identity` from the active document's stable GUID (`FileIdentity.InternalName`) and the object's round-trip-stable local id. So a key an add-in stores **before** a save/load still resolves **after** — the whole point of #153 (robust feature-editing automations, #140/#163).

## Tests

- entities report non-empty, distinct keys
- entity key resolves back to the same entity (kind/index/id)
- sketch key resolves to its sketch (kind=sketch)
- unknown key ⇒ `found=false` (not an error)
- both methods reject no-active-part; out-of-range index rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)