### PR TITLE
test(sketch): real-file + multi-document reference-key coverage (#153)

### DIFF
--- a/addin/router/sketch_reference_key_test.go
+++ b/addin/router/sketch_reference_key_test.go
@@ -8,6 +8,7 @@ import (
 	"oblikovati.org/addin/opregistry"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
 )
 
 // TestSketchEntitiesReportReferenceKeys: sketch.entities now reports a persistent reference
@@ -93,6 +94,47 @@ func TestSketchReferenceKeyBadIndexFails(t *testing.T) {
 	r, s := emptyPartSession(t)
 	if _, err := r.Handle(s, "sketch.referenceKey", []byte(`{"sketchIndex":7}`)); err == nil {
 		t.Error("sketch.referenceKey with an out-of-range index should fail")
+	}
+}
+
+// TestResolveReferenceIsDocumentScoped opens a second part document and proves resolve is
+// scoped to the active document: a key minted in document A resolves only while A is active,
+// and is found=false while B is active — even though both documents hold sketches at once.
+// This is the multi-document guarantee behind #153's cross-document collision-impossibility.
+func TestResolveReferenceIsDocumentScoped(t *testing.T) {
+	r, s := emptyPartSession(t) // document A is active
+	docA := s.ActiveDocument()
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	var entsA wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &entsA)
+	keyA := entsA.Entities[0].ReferenceKey
+
+	// Open a second part document with its own sketch and make it active.
+	docB, err := compdef.AddPart(s.Workspace(), "second.obk", true)
+	if err != nil {
+		t.Fatalf("AddPart B: %v", err)
+	}
+	if err := s.Workspace().SetActiveDocument(docB); err != nil {
+		t.Fatalf("activate B: %v", err)
+	}
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"10 mm","height":"10 mm"}`, &wire.SketchRectangleResult{})
+
+	// Document A's key must not resolve against document B.
+	var res wire.ResolveSketchReferenceResult
+	call(t, r, s, "sketch.resolveReference", mustJSON(t, wire.ResolveSketchReferenceArgs{ReferenceKey: keyA}), &res)
+	if res.Found {
+		t.Errorf("document A's key resolved while B is active: %+v", res)
+	}
+
+	// Switch back to A: the same key resolves again.
+	if err := s.Workspace().SetActiveDocument(docA); err != nil {
+		t.Fatalf("reactivate A: %v", err)
+	}
+	call(t, r, s, "sketch.resolveReference", mustJSON(t, wire.ResolveSketchReferenceArgs{ReferenceKey: keyA}), &res)
+	if !res.Found || res.Kind != "sketchEntity" {
+		t.Errorf("document A's key did not resolve while A is active: %+v", res)
 	}
 }
 

--- a/model/compdef/sketch_refkey_multidoc_test.go
+++ b/model/compdef/sketch_refkey_multidoc_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// allEntityKeys derives the persistent reference keys of every entity across every sketch of
+// a part, in order — the full durable-reference surface of the document.
+func allEntityKeys(t *testing.T, d *doc.Document, part *compdef.PartComponentDefinition) []string {
+	t.Helper()
+	var keys []string
+	for i := 0; i < part.Sketches().Count(); i++ {
+		for _, e := range part.Sketches().Item(i).Entities() {
+			keys = append(keys, entityKey(t, d, e))
+		}
+	}
+	return keys
+}
+
+// TestMultipleDocumentsKeepDistinctSketchKeys opens two part documents at once, edits their
+// sketches interleaved (the kernel juggling several sketches simultaneously), saves and
+// reopens both, and proves: each document's keys are stable across its own round trip; the
+// two documents' keys never collide (the #153 cross-document guarantee — derived from
+// distinct document GUIDs); and editing one reopened document does not perturb the other's
+// keys.
+func TestMultipleDocumentsKeepDistinctSketchKeys(t *testing.T) {
+	store, ws, dir := assemblyWorkspace(t)
+	pathA := filepath.Join(dir, "alpha.obk")
+	pathB := filepath.Join(dir, "beta.obk")
+
+	docA, partA := newKeyedPart(t, ws, pathA)
+	docB, partB := newKeyedPart(t, ws, pathB)
+	if docA.FileIdentity().InternalName == docB.FileIdentity().InternalName {
+		t.Fatal("two documents share a GUID — cross-document keys could collide")
+	}
+
+	// Interleave edits across the two open documents, as a session juggling both would.
+	editSketch(t, partA, math.P2(10, 0), math.P2(12, 0))
+	editSketch(t, partB, math.P2(20, 0), math.P2(22, 0))
+	editSketch(t, partA, math.P2(10, 5), math.P2(12, 5))
+
+	wantA := allEntityKeys(t, docA, partA)
+	wantB := allEntityKeys(t, docB, partB)
+	assertNoCollision(t, wantA, wantB)
+
+	for _, d := range []*doc.Document{docA, docB} {
+		if err := ws.Save(d); err != nil {
+			t.Fatalf("Save %q: %v", d.FullFileName(), err)
+		}
+	}
+
+	rDocA, rPartA := openPartDoc(t, store, pathA)
+	rDocB, rPartB := openPartDoc(t, store, pathB)
+	assertSameKeys(t, "alpha", wantA, allEntityKeys(t, rDocA, rPartA))
+	assertSameKeys(t, "beta", wantB, allEntityKeys(t, rDocB, rPartB))
+	assertNoCollision(t, allEntityKeys(t, rDocA, rPartA), allEntityKeys(t, rDocB, rPartB))
+
+	// Editing one reopened document must not disturb the other's keys.
+	editSketch(t, rPartA, math.P2(30, 0), math.P2(31, 0))
+	assertSameKeys(t, "beta after editing alpha", wantB, allEntityKeys(t, rDocB, rPartB))
+}
+
+// newKeyedPart adds a part at path with one rectangle+circle sketch and returns its doc/def.
+func newKeyedPart(t *testing.T, ws *doc.Workspace, path string) (*doc.Document, *compdef.PartComponentDefinition) {
+	t.Helper()
+	d, err := compdef.AddPart(ws, path, true)
+	if err != nil {
+		t.Fatalf("AddPart %q: %v", path, err)
+	}
+	part := d.Content().(*compdef.PartComponentDefinition)
+	addRectangleSketch(t, part)
+	return d, part
+}
+
+// editSketch appends a line to the part's first sketch — a representative in-place edit.
+func editSketch(t *testing.T, part *compdef.PartComponentDefinition, a, b math.Point2) {
+	t.Helper()
+	sk := part.Sketches().Item(0)
+	sk.Lines().Add(sk.NewPoint(a), sk.NewPoint(b))
+}
+
+// openPartDoc reopens a saved document from disk in a fresh workspace, returning doc + def.
+func openPartDoc(t *testing.T, store *persistence.PackageStore, path string) (*doc.Document, *compdef.PartComponentDefinition) {
+	t.Helper()
+	d, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open %q: %v", path, err)
+	}
+	return d, d.Content().(*compdef.PartComponentDefinition)
+}
+
+// assertSameKeys fails when two key slices differ (order-sensitive).
+func assertSameKeys(t *testing.T, label string, want, got []string) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("%s: key count = %d, want %d", label, len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s: key %d = %q, want %q", label, i, got[i], want[i])
+		}
+	}
+}
+
+// assertNoCollision fails when any key appears in both slices.
+func assertNoCollision(t *testing.T, a, b []string) {
+	t.Helper()
+	seen := make(map[string]bool, len(a))
+	for _, k := range a {
+		seen[k] = true
+	}
+	for _, k := range b {
+		if seen[k] {
+			t.Errorf("cross-document key collision: %q is in both documents", k)
+		}
+	}
+}

--- a/model/compdef/sketch_refkey_persistence_test.go
+++ b/model/compdef/sketch_refkey_persistence_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/identity"
+	"oblikovati.org/model/sketch"
+)
+
+// addRectangleSketch adds one sketch with a four-line rectangle and a circle to a part,
+// returning the part's first line entity for key derivation.
+func addRectangleSketch(t *testing.T, part *compdef.PartComponentDefinition) sketch.Entity {
+	t.Helper()
+	sk := part.Sketches().Add(sketch.XYPlane())
+	corners := []math.Point2{math.P2(0, 0), math.P2(4, 0), math.P2(4, 3), math.P2(0, 3)}
+	pts := make([]*sketch.Point, len(corners))
+	for i, c := range corners {
+		pts[i] = sk.NewPoint(c)
+	}
+	first := sk.Lines().Add(pts[0], pts[1])
+	for i := 1; i < len(pts); i++ {
+		sk.Lines().Add(pts[i], pts[(i+1)%len(pts)])
+	}
+	sk.Circles().Add(sk.NewPoint(math.P2(2, 1.5)), 0.5)
+	return first
+}
+
+// entityKey derives an entity's persistent reference key against a document's GUID, failing
+// the test on a derivation error.
+func entityKey(t *testing.T, d *doc.Document, e sketch.Entity) string {
+	t.Helper()
+	k, err := identity.SketchEntityKey(d.FileIdentity().InternalName, uint64(e.EntityID()))
+	if err != nil {
+		t.Fatalf("derive key: %v", err)
+	}
+	return k
+}
+
+// firstLine returns the first line entity of a reopened part's first sketch.
+func firstLine(t *testing.T, part *compdef.PartComponentDefinition) sketch.Entity {
+	t.Helper()
+	for _, e := range part.Sketches().Item(0).Entities() {
+		if _, ok := e.(*sketch.Line); ok {
+			return e
+		}
+	}
+	t.Fatal("reopened sketch has no line")
+	return nil
+}
+
+// TestSketchKeySurvivesRealFileRoundTrip is the integration proof for #153: a persistent
+// reference key derived BEFORE a real .obk save still derives identically AFTER reopening
+// the file from disk — tying the persistence store, the document GUID, verbatim-id restore,
+// and key derivation together (not just the in-memory recipe codec).
+func TestSketchKeySurvivesRealFileRoundTrip(t *testing.T) {
+	store, ws, dir := assemblyWorkspace(t)
+	path := filepath.Join(dir, "keyed.obk")
+
+	partDoc, err := compdef.AddPart(ws, path, true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	part := partDoc.Content().(*compdef.PartComponentDefinition)
+	line := addRectangleSketch(t, part)
+	wantKey := entityKey(t, partDoc, line)
+	wantGUID := partDoc.FileIdentity().InternalName
+
+	if err := ws.Save(partDoc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Reopen from disk in a fresh workspace to force the on-disk load path.
+	reopenedDoc, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// The document GUID — the key's namespace — must survive the file round trip.
+	if got := reopenedDoc.FileIdentity().InternalName; got != wantGUID {
+		t.Fatalf("document GUID changed across save/reopen: %q -> %q", wantGUID, got)
+	}
+	reopenedPart := reopenedDoc.Content().(*compdef.PartComponentDefinition)
+	gotKey := entityKey(t, reopenedDoc, firstLine(t, reopenedPart))
+	if gotKey != wantKey {
+		t.Errorf("entity key changed across the real file round trip: %q -> %q", wantKey, gotKey)
+	}
+}


### PR DESCRIPTION
## What

Integration coverage closing the seam the #153 unit tests left open: real `.obk` file round-trips and several documents open at once.

## Why

The foundation/impl PRs proved key stability through the in-memory recipe codec and the router. This proves it through the **actual persistence store** and with the **kernel juggling multiple documents' sketches simultaneously** — the real-world conditions add-ins depend on.

## Coverage

- **compdef** — a key derived *before* a real `ws.Save` derives *identically* after reopening the file from disk (document GUID + verbatim entity id both preserved).
- **compdef** — two part documents open and edited interleaved, both round-tripped through real files: per-document keys stable, the two documents' key sets never collide (distinct GUIDs), and editing one document leaves the other's keys intact.
- **router** — `sketch.resolveReference` is document-scoped: a key minted in document A resolves only while A is active, `found=false` while a second document B is active.

Tests only; no production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)