### PR TITLE
feat(sketch3d): stable document-derived reference keys across round-trip (#153)

### DIFF
--- a/model/sketch/constraints_3d.go
+++ b/model/sketch/constraints_3d.go
@@ -21,6 +21,10 @@ func NewPoint3D(p math.Point3) *Point3D {
 // EntityID implements [Entity].
 func (p *Point3D) EntityID() ID { return p.id }
 
+// setID pins the point's local id to a persisted value (restore path only); see
+// [entityBase.setID]. Keeps a 3D point's derived persistent reference key stable (#153).
+func (p *Point3D) setID(id ID) { p.id = id }
+
 // Position returns the point as a [math.Point3].
 func (p *Point3D) Position() math.Point3 { return math.P3(p.X, p.Y, p.Z) }
 

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -19,6 +19,10 @@ import (
 // SketchData3D is the serializable form of one 3D sketch. Hidden inverts Visible so the
 // common visible=true case omits the field; DimsHidden inverts DimensionsVisible likewise.
 type SketchData3D struct {
+	// ID is the 3D sketch's document-local id, persisted (#153) so it and its entities'
+	// derived reference keys survive the round trip. Zero in legacy recipes; restore then
+	// keeps the freshly-minted id.
+	ID           uint64            `yaml:"id,omitempty"`
 	Name         string            `yaml:"name,omitempty"`
 	Hidden       bool              `yaml:"hidden,omitempty"`
 	DimsHidden   bool              `yaml:"dimsHidden,omitempty"`
@@ -151,6 +155,7 @@ func (c *Sketches3D) MarshalRecipe3D() ([]SketchData3D, error) {
 
 func serializeSketch3D(s *Sketch3D) (SketchData3D, error) {
 	sd := SketchData3D{
+		ID:           uint64(s.id),
 		Name:         s.name,
 		Hidden:       !s.visible,
 		DimsHidden:   !s.dimensionsVisible,
@@ -399,32 +404,15 @@ func (c *Sketches3D) ApplyRecipe3D(data []SketchData3D) error {
 
 func (c *Sketches3D) restoreSketch3D(sd SketchData3D) error {
 	s := c.AddNamed(sd.Name)
-	s.visible = !sd.Hidden
-	s.dimensionsVisible = !sd.DimsHidden
-	s.shared = sd.Shared
-	s.color = sd.Color
-	s.deferUpdates = sd.DeferUpdates
-	seq.Restore(&s.seq, sd.Seq)
-	// Re-create points, mapping their saved ids onto the freshly minted ones so
-	// constraints can re-bind by id.
-	idmap := make(map[int]*Point3D, len(sd.Points))
-	for _, pd := range sd.Points {
-		var p *Point3D
-		if pd.Standalone {
-			p = s.AddPoint3D(math.P3(pd.X, pd.Y, pd.Z))
-		} else {
-			p = s.newPoint3D(math.P3(pd.X, pd.Y, pd.Z))
-		}
-		idmap[pd.ID] = p
+	c.restoreSketch3DID(s, sd.ID)
+	restoreSketch3DProps(s, sd)
+	idmap, maxPoint := restorePoints3D(s, sd.Points)
+	entmap, maxEntity, err := restoreEntities3D(s, sd.Entities, idmap)
+	if err != nil {
+		return err
 	}
-	entmap := make(map[int]Entity, len(sd.Entities))
-	for _, ed := range sd.Entities {
-		e, err := restoreEntity3D(s, ed, idmap)
-		if err != nil {
-			return err
-		}
-		entmap[ed.ID] = e
-	}
+	raiseIDSeq(maxPoint) // ids minted after load must not collide with the restored ones
+	raiseIDSeq(maxEntity)
 	for _, cd := range sd.Constraints {
 		if err := restoreConstraint3D(s, cd, idmap, entmap); err != nil {
 			return err
@@ -436,6 +424,61 @@ func (c *Sketches3D) restoreSketch3D(sd SketchData3D) error {
 		}
 	}
 	return nil
+}
+
+// restoreSketch3DProps reapplies a 3D sketch's persisted display/solve properties.
+func restoreSketch3DProps(s *Sketch3D, sd SketchData3D) {
+	s.visible = !sd.Hidden
+	s.dimensionsVisible = !sd.DimsHidden
+	s.shared = sd.Shared
+	s.color = sd.Color
+	s.deferUpdates = sd.DeferUpdates
+	seq.Restore(&s.seq, sd.Seq)
+}
+
+// restorePoints3D recreates the sketch's 3D points (standalone or curve-owned), pinning
+// each saved id verbatim so derived reference keys stay stable, and returns the id map plus
+// the largest id seen.
+func restorePoints3D(s *Sketch3D, points []Point3DData) (map[int]*Point3D, uint64) {
+	idmap := make(map[int]*Point3D, len(points))
+	var maxID uint64
+	for _, pd := range points {
+		p := restorePoint3D(s, pd)
+		s.pinEntityID3D(p, pd.ID)
+		idmap[pd.ID] = p
+		if uint64(pd.ID) > maxID {
+			maxID = uint64(pd.ID)
+		}
+	}
+	return idmap, maxID
+}
+
+// restorePoint3D creates one 3D point — standalone (an entity) or curve-owned — exactly one.
+func restorePoint3D(s *Sketch3D, pd Point3DData) *Point3D {
+	pos := math.P3(pd.X, pd.Y, pd.Z)
+	if pd.Standalone {
+		return s.AddPoint3D(pos)
+	}
+	return s.newPoint3D(pos)
+}
+
+// restoreEntities3D recreates the sketch's 3D curve entities over the restored points,
+// pinning each saved id, and returns the entity map plus the largest id seen.
+func restoreEntities3D(s *Sketch3D, entities []Entity3DData, idmap map[int]*Point3D) (map[int]Entity, uint64, error) {
+	entmap := make(map[int]Entity, len(entities))
+	var maxID uint64
+	for _, ed := range entities {
+		e, err := restoreEntity3D(s, ed, idmap)
+		if err != nil {
+			return nil, 0, err
+		}
+		s.pinEntityID3D(e, ed.ID)
+		entmap[ed.ID] = e
+		if uint64(ed.ID) > maxID {
+			maxID = uint64(ed.ID)
+		}
+	}
+	return entmap, maxID, nil
 }
 
 // restoreDimension3D re-adds one 3D dimension, binding operands through the id maps and

--- a/model/sketch/serialize_3d_refkey_test.go
+++ b/model/sketch/serialize_3d_refkey_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
+)
+
+// roundTrip3D serializes a 3D sketch collection and rebuilds it in a fresh collection,
+// returning the reopened first sketch — the real save→restore path the part recipe uses.
+func roundTrip3D(t *testing.T, sc *Sketches3D) *Sketch3D {
+	t.Helper()
+	data, err := sc.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("MarshalRecipe3D: %v", err)
+	}
+	fresh := NewSketches3D()
+	if err := fresh.ApplyRecipe3D(data); err != nil {
+		t.Fatalf("ApplyRecipe3D: %v", err)
+	}
+	if fresh.Count() != sc.Count() {
+		t.Fatalf("3D sketch count after round trip = %d, want %d", fresh.Count(), sc.Count())
+	}
+	return fresh.Item(0)
+}
+
+// buildKeyed3DSketch makes a 3D sketch with a line, a circle, and a standalone point.
+func buildKeyed3DSketch(t *testing.T) (*Sketches3D, *Line3D, *Circle3D, *Point3D) {
+	t.Helper()
+	sc := NewSketches3D()
+	s := sc.Add()
+	line := s.AddLine3D(math.P3(0, 0, 0), math.P3(4, 0, 0))
+	axis, err := math.NewUnitVector3(0, 0, 1)
+	if err != nil {
+		t.Fatalf("axis: %v", err)
+	}
+	circle := s.AddCircle3D(math.P3(2, 3, 0), axis, 1.5)
+	pt := s.AddPoint3D(math.P3(5, 5, 5))
+	return sc, line, circle, pt
+}
+
+// entity3DKeys derives the persistent reference key of each 3D entity (#153).
+func entity3DKeys(t *testing.T, ents ...Entity) []string {
+	t.Helper()
+	out := make([]string, len(ents))
+	for i, e := range ents {
+		k, err := identity.SketchEntityKey(docGUID, uint64(e.EntityID()))
+		if err != nil {
+			t.Fatalf("derive 3D key %d: %v", i, err)
+		}
+		out[i] = k
+	}
+	return out
+}
+
+// firstOfEach3D returns the first line, circle, and standalone point of a restored 3D sketch.
+func firstOfEach3D(t *testing.T, s *Sketch3D) (*Line3D, *Circle3D, *Point3D) {
+	t.Helper()
+	var line *Line3D
+	var circle *Circle3D
+	var pt *Point3D
+	for _, e := range s.Entities() {
+		switch v := e.(type) {
+		case *Line3D:
+			line = v
+		case *Circle3D:
+			circle = v
+		case *Point3D:
+			pt = v
+		}
+	}
+	if line == nil || circle == nil || pt == nil {
+		t.Fatalf("restored 3D sketch missing entities: line=%v circle=%v point=%v", line, circle, pt)
+	}
+	return line, circle, pt
+}
+
+// TestEntity3DIDsSurviveRoundTrip is the #153 fast-follow for 3D sketches: a 3D entity's
+// local id — and its derived persistent reference key — must be identical after a save/load
+// cycle (previously the id was re-minted on load, like the 2D case fixed in the foundation).
+func TestEntity3DIDsSurviveRoundTrip(t *testing.T) {
+	sc, line, circle, pt := buildKeyed3DSketch(t)
+	wantIDs := []ID{line.EntityID(), circle.EntityID(), pt.EntityID()}
+	wantKeys := entity3DKeys(t, line, circle, pt)
+
+	out := roundTrip3D(t, sc)
+	gotLine, gotCircle, gotPoint := firstOfEach3D(t, out)
+	gotIDs := []ID{gotLine.EntityID(), gotCircle.EntityID(), gotPoint.EntityID()}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("3D entity %d id = %d after round trip, want %d (re-minted)", i, gotIDs[i], wantIDs[i])
+		}
+	}
+	gotKeys := entity3DKeys(t, gotLine, gotCircle, gotPoint)
+	for i := range wantKeys {
+		if gotKeys[i] != wantKeys[i] {
+			t.Errorf("3D entity %d persistent key changed: %q -> %q", i, wantKeys[i], gotKeys[i])
+		}
+	}
+}
+
+// TestSketch3DIDSurvivesRoundTrip: the 3D sketch's own local id survives the round trip.
+func TestSketch3DIDSurvivesRoundTrip(t *testing.T) {
+	sc, _, _, _ := buildKeyed3DSketch(t)
+	want := sc.Item(0).ID()
+	if got := roundTrip3D(t, sc).ID(); got != want {
+		t.Errorf("3D sketch id = %d after round trip, want %d", got, want)
+	}
+}
+
+// TestSketch3DByIDReindexedAfterRestore: restoring pins ids verbatim AND re-keys the byID
+// index, so EntityByID resolves the restored entity by its persisted id (a regression guard
+// for the 3D-specific id index the 2D path does not have).
+func TestSketch3DByIDReindexedAfterRestore(t *testing.T) {
+	sc, line, _, pt := buildKeyed3DSketch(t)
+	out := roundTrip3D(t, sc)
+
+	if e, ok := out.EntityByID(line.EntityID()); !ok || e.EntityID() != line.EntityID() {
+		t.Errorf("EntityByID(line) after restore failed: ok=%v", ok)
+	}
+	if e, ok := out.EntityByID(pt.EntityID()); !ok || e.EntityID() != pt.EntityID() {
+		t.Errorf("EntityByID(standalone point) after restore failed: ok=%v", ok)
+	}
+}
+
+// TestNew3DEntityAfterRestoreDoesNotCollide: an entity created after a 3D restore gets an id
+// past every restored id (guards the raiseIDSeq clock-raise).
+func TestNew3DEntityAfterRestoreDoesNotCollide(t *testing.T) {
+	sc, _, _, _ := buildKeyed3DSketch(t)
+	out := roundTrip3D(t, sc)
+	var maxRestored ID
+	for _, e := range out.Entities() {
+		if e.EntityID() > maxRestored {
+			maxRestored = e.EntityID()
+		}
+	}
+	added := out.AddLine3D(math.P3(9, 9, 9), math.P3(9, 8, 9))
+	if added.EntityID() <= maxRestored {
+		t.Errorf("new 3D entity id %d not past max restored id %d", added.EntityID(), maxRestored)
+	}
+}

--- a/model/sketch/sketch3d.go
+++ b/model/sketch/sketch3d.go
@@ -157,6 +157,19 @@ func (s *Sketch3D) addEntity3D(e Entity) {
 	s.byID[e.EntityID()] = e
 }
 
+// pinEntityID3D pins a restored point/entity's local id to its persisted value so its
+// derived persistent reference key (#153) is stable across save/load, re-keying the byID
+// index when the object is registered there (standalone points and curve entities; a
+// curve-owned point is not in byID, so the re-key is skipped).
+func (s *Sketch3D) pinEntityID3D(e Entity, saved int) {
+	old := e.EntityID()
+	e.(idCarrier).setID(ID(saved))
+	if _, ok := s.byID[old]; ok {
+		delete(s.byID, old)
+		s.byID[e.EntityID()] = e
+	}
+}
+
 // Constraints returns every residual-bearing constraint — all geometric plus the driving
 // dimensions — which is exactly what the solver consumes. Driven dimensions are excluded.
 func (s *Sketch3D) Constraints() []Constraint {
@@ -224,6 +237,20 @@ func (c *Sketches3D) AddNamed(name string) *Sketch3D {
 	c.items = append(c.items, s)
 	c.byID[s.id] = s
 	return s
+}
+
+// restoreSketch3DID pins a freshly-added 3D sketch's local id to its persisted value so the
+// sketch's document-derived persistent reference key (#153) is stable across load, re-keying
+// the byID index and raising the id clock past it. A zero saved id (a legacy recipe) keeps
+// the minted one.
+func (c *Sketches3D) restoreSketch3DID(s *Sketch3D, saved uint64) {
+	if saved == 0 {
+		return
+	}
+	delete(c.byID, s.id)
+	s.id = ID(saved)
+	c.byID[s.id] = s
+	raiseIDSeq(saved)
 }
 
 // nextName mints the first unused "3D Sketch{N}" name, advancing past taken numbers.


### PR DESCRIPTION
## What

The **3D-sketch fast-follow** to the #153 foundation. 3D sketch/entity/point local ids were re-minted on `.obk` load, so a 3D entity's document-derived persistent reference key drifted across save/load. This restores them verbatim — bringing 3D to parity with the 2D fix.

## How

- Persist the 3D sketch's local id (`SketchData3D.ID`) and restore it, re-keying the `Sketches3D` byID index.
- Pin point/entity ids verbatim on restore, **re-keying the `Sketch3D` byID index** (the 3D-specific entity index the 2D path doesn't have), and raise the id clock past the largest restored id so ids minted after a load never collide.
- `Point3D` gains the `setID` restore seam (curve entities already had it via `entityBase`).

## Tests

- id + derived-key stability across the 3D round trip
- 3D sketch-id stability
- byID re-index — `EntityByID` resolves restored entities by their persisted id
- post-restore collision freedom (new entity ids land past every restored id)

Model-layer only (no API change). The 3D API exposure (a `ReferenceKey` field on the 3D entity enumeration + extending `resolveReference` to scan 3D sketches) is the natural next increment if we want add-ins to consume 3D keys over the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)