### PR TITLE
feat(sketch3d): resolve & report 3D persistent reference keys (#153 impl)

### DIFF
--- a/addin/router/sketch3d_enumerate.go
+++ b/addin/router/sketch3d_enumerate.go
@@ -20,9 +20,11 @@ func enumerateEntities3D(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	}
 	ents := sk.Entities()
 	moveable := sk.MoveableClassifier()
+	guid, _ := activeDocumentGUID(s) // empty ⇒ omit keys; never fails for a real document
 	out := make([]wire.Sketch3DEntityInfo, 0, len(ents))
 	for i, e := range ents {
 		info := entity3DInfo(i, e)
+		info.ReferenceKey = entityReferenceKey(guid, e)
 		info.MoveableStatus = moveable.Of(e).String()
 		out = append(out, info)
 	}

--- a/addin/router/sketch3d_reference_key_test.go
+++ b/addin/router/sketch3d_reference_key_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// keyed3DSketch creates a 3D sketch with a line and a circle, returning the router/session.
+func keyed3DSketch(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0,0],[3,0,4]]}`, &wire.AddSketch3DEntityResult{})
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0,0]],"radius":"10 mm"}`, &wire.AddSketch3DEntityResult{})
+	return r, s
+}
+
+// TestSketch3DEntitiesReportReferenceKeys: sketch3d.entities reports a persistent reference
+// key per entity (#153), non-empty and distinct.
+func TestSketch3DEntitiesReportReferenceKeys(t *testing.T) {
+	r, s := keyed3DSketch(t)
+	var ents wire.EnumerateEntities3DResult
+	call(t, r, s, "sketch3d.entities", `{"sketchIndex":0}`, &ents)
+	if len(ents.Entities) == 0 {
+		t.Fatal("no 3D entities enumerated")
+	}
+	seen := map[string]bool{}
+	for _, e := range ents.Entities {
+		if e.ReferenceKey == "" {
+			t.Errorf("3D entity %d (%s) has no reference key", e.ID, e.Kind)
+		}
+		if seen[e.ReferenceKey] {
+			t.Errorf("duplicate 3D reference key %q", e.ReferenceKey)
+		}
+		seen[e.ReferenceKey] = true
+	}
+}
+
+// TestResolveSketch3DEntityReference: a key from sketch3d.entities resolves back to the same
+// entity with Kind "sketch3dEntity".
+func TestResolveSketch3DEntityReference(t *testing.T) {
+	r, s := keyed3DSketch(t)
+	var ents wire.EnumerateEntities3DResult
+	call(t, r, s, "sketch3d.entities", `{"sketchIndex":0}`, &ents)
+	want := ents.Entities[0]
+
+	var res wire.ResolveSketchReferenceResult
+	call(t, r, s, "sketch.resolveReference", mustJSON(t, wire.ResolveSketchReferenceArgs{ReferenceKey: want.ReferenceKey}), &res)
+	if !res.Found || res.Kind != "sketch3dEntity" || res.SketchIndex != 0 || res.EntityID != want.ID {
+		t.Errorf("resolve 3D entity = %+v, want found sketch3dEntity sketch 0 id %d", res, want.ID)
+	}
+}
+
+// TestSketch3DReferenceKeyResolvesToSketch: a 3D sketch's own key (sketch3d.referenceKey)
+// resolves back to it with Kind "sketch3d".
+func TestSketch3DReferenceKeyResolvesToSketch(t *testing.T) {
+	r, s := keyed3DSketch(t)
+	var key wire.SketchReferenceKeyResult
+	call(t, r, s, "sketch3d.referenceKey", `{"sketchIndex":0}`, &key)
+	k := key.ReferenceKey
+	if k == "" {
+		t.Fatal("sketch3d.referenceKey returned an empty key")
+	}
+
+	var res wire.ResolveSketchReferenceResult
+	call(t, r, s, "sketch.resolveReference", mustJSON(t, wire.ResolveSketchReferenceArgs{ReferenceKey: k}), &res)
+	if !res.Found || res.Kind != "sketch3d" || res.SketchIndex != 0 {
+		t.Errorf("resolve 3D sketch = %+v, want found sketch3d index 0", res)
+	}
+}
+
+// TestSketch3DReferenceKeyBadIndexFails: an out-of-range 3D sketch index is rejected.
+func TestSketch3DReferenceKeyBadIndexFails(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "sketch3d.referenceKey", []byte(`{"sketchIndex":5}`)); err == nil {
+		t.Error("sketch3d.referenceKey with an out-of-range index should fail")
+	}
+}

--- a/addin/router/sketch_reference_key.go
+++ b/addin/router/sketch_reference_key.go
@@ -20,10 +20,11 @@ import (
 // rebinds a stored key (sketch or entity) to its current location.
 
 // registerSketchReferenceKeyHandlers wires the sketch.referenceKey / sketch.resolveReference
-// methods.
+// / sketch3d.referenceKey methods.
 func (r *Router) registerSketchReferenceKeyHandlers() {
 	r.handlers[wire.MethodSketchReferenceKey] = sketchReferenceKey
 	r.handlers[wire.MethodSketchResolveReference] = sketchResolveReference
+	r.handlers[wire.MethodSketch3DReferenceKey] = sketch3DReferenceKey
 }
 
 // activeDocumentGUID returns the active document's stable GUID — the namespace every sketch
@@ -57,8 +58,26 @@ func sketchReferenceKey(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 	return json.Marshal(wire.SketchReferenceKeyResult{ReferenceKey: key})
 }
 
-// sketchResolveReference rebinds a stored sketch/entity key to its current location, or
-// reports found=false when nothing in the active part matches it (the referent was deleted).
+// sketch3DReferenceKey returns the persistent reference key of the addressed 3D sketch.
+func sketch3DReferenceKey(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	sk, _, err := resolveSketch3D(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	guid, err := activeDocumentGUID(s)
+	if err != nil {
+		return nil, err
+	}
+	key, err := identity.SketchKey(guid, uint64(sk.ID()))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SketchReferenceKeyResult{ReferenceKey: key})
+}
+
+// sketchResolveReference rebinds a stored sketch/entity key (2D or 3D) to its current
+// location, or reports found=false when nothing in the active part matches it (the referent
+// was deleted). 2D sketches are scanned first, then 3D.
 func sketchResolveReference(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	var in wire.ResolveSketchReferenceArgs
 	if err := decode(raw, &in); err != nil {
@@ -73,6 +92,9 @@ func sketchResolveReference(s *app.Session, raw json.RawMessage) (json.RawMessag
 		return nil, err
 	}
 	res := matchReference(part.Sketches(), guid, in.ReferenceKey)
+	if !res.Found {
+		res = matchReference3D(part.Sketches3D(), guid, in.ReferenceKey)
+	}
 	return json.Marshal(res)
 }
 
@@ -93,6 +115,31 @@ func matchReference(sketches *sketch.Sketches, guid, want string) wire.ResolveSk
 
 // matchEntity returns the session id of the sketch entity whose derived key equals want.
 func matchEntity(sk *sketch.Sketch, guid, want string) (uint64, bool) {
+	for _, e := range sk.Entities() {
+		if k, err := identity.SketchEntityKey(guid, uint64(e.EntityID())); err == nil && k == want {
+			return uint64(e.EntityID()), true
+		}
+	}
+	return 0, false
+}
+
+// matchReference3D scans every 3D sketch and entity for the one whose derived key equals
+// want, returning the first match with the 3D-flavoured Kind. A miss is found=false.
+func matchReference3D(sketches *sketch.Sketches3D, guid, want string) wire.ResolveSketchReferenceResult {
+	for i := 0; i < sketches.Count(); i++ {
+		sk := sketches.Item(i)
+		if k, err := identity.SketchKey(guid, uint64(sk.ID())); err == nil && k == want {
+			return wire.ResolveSketchReferenceResult{Found: true, Kind: "sketch3d", SketchIndex: i}
+		}
+		if id, ok := matchEntity3D(sk, guid, want); ok {
+			return wire.ResolveSketchReferenceResult{Found: true, Kind: "sketch3dEntity", SketchIndex: i, EntityID: id}
+		}
+	}
+	return wire.ResolveSketchReferenceResult{Found: false}
+}
+
+// matchEntity3D returns the session id of the 3D sketch entity whose derived key equals want.
+func matchEntity3D(sk *sketch.Sketch3D, guid, want string) (uint64, bool) {
 	for _, e := range sk.Entities() {
 		if k, err := identity.SketchEntityKey(guid, uint64(e.EntityID())); err == nil && k == want {
 			return uint64(e.EntityID()), true

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.60.0
+	oblikovati.org/api v0.61.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.60.0
+	oblikovati.org/api v0.61.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

The `/source` implementation of the 3D public surface (pins api **v0.61.0**), bringing 3D sketches to parity with 2D for #153. Builds on #1070 (3D round-trip key stability).

## Surface

- `sketch3d.entities` → each `Sketch3DEntityInfo` now carries its persistent `ReferenceKey`.
- `sketch3d.referenceKey` → a 3D sketch's own key.
- `sketch.resolveReference` → now also scans 3D sketches, reporting `Kind` `"sketch3d"` / `"sketch3dEntity"` (2D scanned first, then 3D).

## How

Keys derive in `model/identity` from the active document's GUID and each object's round-trip-stable local id — the same mechanism as 2D. A single resolve method handles both dimensions because keys are globally unique within a document.

## Tests

- 3D entities report non-empty, distinct keys
- a 3D entity key resolves back to the same entity (`Kind="sketch3dEntity"`)
- a 3D sketch key resolves to its sketch (`Kind="sketch3d"`)
- out-of-range 3D index rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)