### PR TITLE
feat(features): re-pick geometric references in features.edit (#163 impl)

### DIFF
--- a/addin/router/feature_lifecycle.go
+++ b/addin/router/feature_lifecycle.go
@@ -42,7 +42,10 @@ func partFeatureByID(part *compdef.PartComponentDefinition, id uint64, method st
 // featureDetail renders one feature with its history index and the editable scalars
 // features.edit accepts, mirroring workPlaneInfo for datum planes.
 func featureDetail(part *compdef.PartComponentDefinition, f *feature.PartFeature, index int) wire.FeatureDetail {
-	return wire.FeatureDetail{FeatureInfo: featureInfo(f), Index: index, Scalars: featureScalars(part, f)}
+	return wire.FeatureDetail{
+		FeatureInfo: featureInfo(f), Index: index,
+		Scalars: featureScalars(part, f), Slots: featureSlots(f),
+	}
 }
 
 // featureScalars renders the feature's editable scalars with their value in the
@@ -100,15 +103,38 @@ func editFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	apply, err := parseScalarEdits(part, f, in.Scalars)
-	if err != nil {
+	if err := planAndApplyFeatureEdits(part, f, in); err != nil {
 		return nil, err
 	}
-	apply()
 	if err := s.CommitFeatureEdit(f); err != nil {
 		return nil, err
 	}
 	return featureDetailReply(part, f, idx)
+}
+
+// planAndApplyFeatureEdits validates the WHOLE batch — scalars and reference re-picks — before
+// applying any, so a failure (bad value, missing profile, wrong slot kind) leaves the definition
+// untouched (#163). Scalars are parsed only when present, so a repick-only edit works on a feature
+// that exposes references but no editable scalars (e.g. a mirror's plane). The caller recomputes.
+func planAndApplyFeatureEdits(part *compdef.PartComponentDefinition, f *feature.PartFeature, in wire.EditFeatureArgs) error {
+	if len(in.Scalars) == 0 && len(in.Repick) == 0 {
+		return fmt.Errorf("features.edit: feature %d has no scalar or repick edits to apply", in.ID)
+	}
+	applyScalars := func() {}
+	if len(in.Scalars) > 0 {
+		apply, err := parseScalarEdits(part, f, in.Scalars)
+		if err != nil {
+			return err
+		}
+		applyScalars = apply
+	}
+	applyRepicks, err := planFeatureRepicks(part, f, in.Repick)
+	if err != nil {
+		return err
+	}
+	applyScalars()
+	applyRepicks()
+	return nil
 }
 
 // parseScalarEdits validates the whole batch — the feature must be editable, each

--- a/addin/router/feature_repick.go
+++ b/addin/router/feature_repick.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Feature reference re-pick (#163): the geometry half of features.edit. A feature whose
+// definition is [feature.ReferenceEditable] exposes re-pickable slots (a fillet's edges, an
+// extrude's profile, a mirror's plane). featureSlots renders them for FeatureDetail;
+// planFeatureRepicks resolves wire refs into [feature.PickedRef] and returns an apply closure
+// — resolution is read-only, so the whole batch (scalars + repicks) is validated before ANY
+// mutation, matching the scalar precedent (a failed batch leaves the definition untouched).
+
+// refKindName maps a model RefKind to its wire spelling.
+func refKindName(k feature.RefKind) string {
+	switch k {
+	case feature.RefEdges:
+		return "edges"
+	case feature.RefFaces:
+		return "faces"
+	case feature.RefFace:
+		return "face"
+	case feature.RefProfile:
+		return "profile"
+	case feature.RefPlane:
+		return "plane"
+	default:
+		return "unknown"
+	}
+}
+
+// featureSlots renders a feature's re-pickable reference slots; nil when the definition has none.
+func featureSlots(f *feature.PartFeature) []wire.FeatureSlot {
+	re, ok := f.Definition().(feature.ReferenceEditable)
+	if !ok {
+		return nil
+	}
+	slots := re.EditableRefs()
+	out := make([]wire.FeatureSlot, len(slots))
+	for i, sl := range slots {
+		out[i] = wire.FeatureSlot{Index: i, Label: sl.Label, Kind: refKindName(sl.Kind), Multi: sl.Multi, Count: sl.Count()}
+	}
+	return out
+}
+
+// plannedRepick is a validated repick (read-only resolution done) ready to apply.
+type plannedRepick struct {
+	slot  feature.EditableRefSlot
+	clear bool
+	ref   feature.PickedRef
+}
+
+// planFeatureRepicks validates every repick (slot in range, clearable if Clear, profile index
+// and plane ref resolvable) WITHOUT mutating, and returns a closure that applies them. An error
+// means nothing was applied. Edge/face topology keys are not bind-checked here — they reference
+// the feature's INPUT (rollback) geometry, not the final body, and a lost reference surfaces as
+// feature health after recompute, exactly as it does for features.add (parametric, not edit-time).
+func planFeatureRepicks(part *compdef.PartComponentDefinition, f *feature.PartFeature, repicks []wire.FeatureRepick) (func(), error) {
+	if len(repicks) == 0 {
+		return func() {}, nil
+	}
+	re, ok := f.Definition().(feature.ReferenceEditable)
+	if !ok {
+		return nil, fmt.Errorf("features.edit: feature %d (%s) has no re-pickable references", uint64(f.ID()), f.Kind())
+	}
+	slots := re.EditableRefs()
+	planned := make([]plannedRepick, 0, len(repicks))
+	for _, rp := range repicks {
+		p, err := planOneRepick(part, slots, rp)
+		if err != nil {
+			return nil, err
+		}
+		planned = append(planned, p)
+	}
+	return func() {
+		for _, p := range planned {
+			if p.clear {
+				p.slot.Clear()
+			} else {
+				p.slot.Add(p.ref)
+			}
+		}
+	}, nil
+}
+
+// planOneRepick validates a single repick against its slot.
+func planOneRepick(part *compdef.PartComponentDefinition, slots []feature.EditableRefSlot, rp wire.FeatureRepick) (plannedRepick, error) {
+	if rp.Slot < 0 || rp.Slot >= len(slots) {
+		return plannedRepick{}, fmt.Errorf("features.edit: repick slot %d out of range (%d slots)", rp.Slot, len(slots))
+	}
+	sl := slots[rp.Slot]
+	if rp.Clear {
+		if sl.Clear == nil {
+			return plannedRepick{}, fmt.Errorf("features.edit: slot %d (%s) is not clearable", rp.Slot, sl.Label)
+		}
+		return plannedRepick{slot: sl, clear: true}, nil
+	}
+	pr, err := resolvePickedRef(part, sl.Kind, rp)
+	if err != nil {
+		return plannedRepick{}, fmt.Errorf("features.edit: slot %d (%s): %w", rp.Slot, sl.Label, err)
+	}
+	return plannedRepick{slot: sl, ref: pr}, nil
+}
+
+// resolvePickedRef turns a wire repick into a [feature.PickedRef] for the slot's kind. Edge/face
+// keys pass through as raw key bytes (from model.referenceKeys); a profile index and a plane ref
+// are validated against the part (a missing profile / unresolvable plane is an edit-time error).
+func resolvePickedRef(part *compdef.PartComponentDefinition, kind feature.RefKind, rp wire.FeatureRepick) (feature.PickedRef, error) {
+	switch kind {
+	case feature.RefEdges, feature.RefFaces, feature.RefFace:
+		return feature.PickedRef{Key: []byte(rp.Ref)}, nil
+	case feature.RefProfile:
+		return resolveProfilePick(part, rp)
+	case feature.RefPlane:
+		return resolvePlanePick(part, rp.Ref)
+	default:
+		return feature.PickedRef{}, fmt.Errorf("unsupported slot kind")
+	}
+}
+
+// resolveProfilePick validates the (sketchIndex, profileIndex) against the part's sketches.
+func resolveProfilePick(part *compdef.PartComponentDefinition, rp wire.FeatureRepick) (feature.PickedRef, error) {
+	sketches := part.Sketches()
+	if rp.SketchIndex < 0 || rp.SketchIndex >= sketches.Count() {
+		return feature.PickedRef{}, fmt.Errorf("sketch index %d out of range (%d sketches)", rp.SketchIndex, sketches.Count())
+	}
+	sk := sketches.Item(rp.SketchIndex)
+	if n := sk.Profiles().Count(); rp.ProfileIndex < 0 || rp.ProfileIndex >= n {
+		return feature.PickedRef{}, fmt.Errorf("profile index %d out of range (sketch has %d profiles)", rp.ProfileIndex, n)
+	}
+	return feature.PickedRef{Sketch: sk, Profile: rp.ProfileIndex}, nil
+}
+
+// resolvePlanePick resolves a plane ref — a planar-face key, a work plane ("plane/N"), or an
+// origin plane ("origin/plane/xy") — to a plane pick. A face ref also carries its key so the
+// mirror tracks the face through edits.
+func resolvePlanePick(part *compdef.PartComponentDefinition, ref string) (feature.PickedRef, error) {
+	wr := toWorkRef(ref)
+	pl, err := part.WorkGeometry().ResolvePlaneRef(wr)
+	if err != nil {
+		return feature.PickedRef{}, err
+	}
+	pr := feature.PickedRef{Origin: pl.Origin(), Normal: pl.Normal().AsVector()}
+	if key, isFace := feature.FaceRefKey(wr); isFace {
+		pr.PlaneKey = key
+	}
+	return pr, nil
+}

--- a/addin/router/feature_repick_test.go
+++ b/addin/router/feature_repick_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// lastFeatureID returns the id of the most recently added feature.
+func lastFeatureID(t *testing.T, r *Router, s *app.Session) uint64 {
+	t.Helper()
+	tree := modelTreeOf(t, r, s)
+	if len(tree.Features) == 0 {
+		t.Fatal("no features in the part")
+	}
+	return tree.Features[len(tree.Features)-1].ID
+}
+
+// partVol measures the active part's first body volume (for before/after re-pick comparisons).
+func partVol(t *testing.T, s *app.Session) float64 {
+	t.Helper()
+	def, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	return bodyVolume(def)
+}
+
+// addFilletOnEdge adds a single-edge constant-radius fillet (the simple edgeRefs+radius form,
+// which drives def.EdgeKeys — the slot the re-pick mutates) and returns its feature id.
+func addFilletOnEdge(t *testing.T, r *Router, s *app.Session, edge string) uint64 {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{
+		"kind": "fillet",
+		"args": map[string]any{"edgeRefs": []string{edge}, "radius": "4 mm"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	call(t, r, s, "features.add", string(args), &struct {
+		Bodies int `json:"bodies"`
+	}{})
+	return lastFeatureID(t, r, s)
+}
+
+// TestFeatureSlotsReported: features.get reports a feature's re-pickable reference slots (#163).
+func TestFeatureSlotsReported(t *testing.T) {
+	r, s, vertical := filletBoxFixture(t)
+	id := addFilletOnEdge(t, r, s, vertical[0])
+
+	var det wire.FeatureDetailResult
+	call(t, r, s, "features.get", fmt.Sprintf(`{"id":%d}`, id), &det)
+	if len(det.Feature.Slots) != 1 {
+		t.Fatalf("fillet slots = %+v, want one", det.Feature.Slots)
+	}
+	sl := det.Feature.Slots[0]
+	if sl.Kind != "edges" || !sl.Multi || sl.Count != 1 {
+		t.Errorf("fillet slot = %+v, want kind=edges multi=true count=1", sl)
+	}
+}
+
+// TestRepickFilletAddAndClearEdges drives the #163 acceptance: add an edge to a placed fillet by
+// reference key (more geometry, slot count up), then clear it (back to the bare box).
+func TestRepickFilletAddAndClearEdges(t *testing.T) {
+	r, s, vertical := filletBoxFixture(t)
+	id := addFilletOnEdge(t, r, s, vertical[0])
+	faces1 := partBodyFaces(t, s) // box (6) + one rounded edge = 7
+
+	// Add a second edge by reference key.
+	var det wire.FeatureDetailResult
+	addArgs, _ := json.Marshal(wire.EditFeatureArgs{ID: id, Repick: []wire.FeatureRepick{{Slot: 0, Ref: vertical[1]}}})
+	call(t, r, s, "features.edit", string(addArgs), &det)
+	if det.Feature.Slots[0].Count != 2 {
+		t.Fatalf("after adding an edge, slot count = %d, want 2", det.Feature.Slots[0].Count)
+	}
+	if faces2 := partBodyFaces(t, s); faces2 <= faces1 {
+		t.Errorf("adding a filleted edge gave %d faces, want > %d", faces2, faces1)
+	}
+
+	// Clear the slot → the fillet rounds nothing → back to the bare box (6 faces).
+	clearArgs, _ := json.Marshal(wire.EditFeatureArgs{ID: id, Repick: []wire.FeatureRepick{{Slot: 0, Clear: true}}})
+	call(t, r, s, "features.edit", string(clearArgs), &det)
+	if det.Feature.Slots[0].Count != 0 {
+		t.Errorf("after clear, slot count = %d, want 0", det.Feature.Slots[0].Count)
+	}
+	if faces := partBodyFaces(t, s); faces != 6 {
+		t.Errorf("after clearing the fillet edges, %d faces, want 6 (bare box)", faces)
+	}
+}
+
+// TestRepickExtrudeProfile drives the #163 acceptance: re-point an extrude at a different sketch
+// profile and recompute to different geometry.
+func TestRepickExtrudeProfile(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[0,0]],"radius":"2 cm"}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[6,0]],"radius":"1 cm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"20 mm"}}`, &struct{}{})
+	id := lastFeatureID(t, r, s)
+	v0 := partVol(t, s)
+
+	var det wire.FeatureDetailResult
+	call(t, r, s, "features.get", fmt.Sprintf(`{"id":%d}`, id), &det)
+	if len(det.Feature.Slots) != 1 || det.Feature.Slots[0].Kind != "profile" {
+		t.Fatalf("extrude slots = %+v, want one profile slot", det.Feature.Slots)
+	}
+
+	args, _ := json.Marshal(wire.EditFeatureArgs{ID: id, Repick: []wire.FeatureRepick{{Slot: 0, SketchIndex: 0, ProfileIndex: 1}}})
+	call(t, r, s, "features.edit", string(args), &det)
+	if v1 := partVol(t, s); v1 == v0 {
+		t.Errorf("re-picking the extrude profile did not change the volume (%.3f)", v1)
+	}
+}
+
+// TestRepickInvalidProfileLeavesUntouched: an out-of-range profile index fails the edit and
+// leaves the definition untouched (the #163 atomic-batch acceptance — nothing applies until the
+// whole batch validates).
+func TestRepickInvalidProfileLeavesUntouched(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &struct{}{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[0,0]],"radius":"2 cm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"20 mm"}}`, &struct{}{})
+	id := lastFeatureID(t, r, s)
+	v0 := partVol(t, s)
+
+	bad, _ := json.Marshal(wire.EditFeatureArgs{ID: id, Repick: []wire.FeatureRepick{{Slot: 0, SketchIndex: 0, ProfileIndex: 9}}})
+	if _, err := r.Handle(s, "features.edit", bad); err == nil {
+		t.Fatal("features.edit with an out-of-range profile index should fail")
+	}
+	if v1 := partVol(t, s); v1 != v0 {
+		t.Errorf("a failed re-pick changed the geometry (%.3f -> %.3f); want untouched", v0, v1)
+	}
+}
+
+// TestRepickSlotOutOfRange: a slot index past the feature's slots is a clear rejection.
+func TestRepickSlotOutOfRange(t *testing.T) {
+	r, s, vertical := filletBoxFixture(t)
+	id := addFilletOnEdge(t, r, s, vertical[0])
+	bad, _ := json.Marshal(wire.EditFeatureArgs{ID: id, Repick: []wire.FeatureRepick{{Slot: 9, Ref: vertical[1]}}})
+	if _, err := r.Handle(s, "features.edit", bad); err == nil {
+		t.Error("features.edit with an out-of-range slot should fail")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.61.0
+	oblikovati.org/api v0.62.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.61.0
+	oblikovati.org/api v0.62.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -156,6 +156,12 @@ func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
 	return w.Plane(), nil
 }
 
+// ResolvePlaneRef resolves any plane reference — a planar B-rep face key, a user work plane
+// ("plane/N"), or an origin plane ("origin/plane/xy") — to its plane (origin + normal). It is
+// the public entry the feature-edit re-pick (#163) uses to turn a wire plane ref into a
+// mirror's plane; errors when the ref names no resolvable plane.
+func (g *WorkGeometry) ResolvePlaneRef(ref WorkRef) (sketch.Plane, error) { return g.plane(ref) }
+
 // WorkPlaneByRef resolves a WorkRef to its *WorkPlane (origin or user) — for features
 // that reference a datum plane, e.g. an extrude's to-face / from-to target.
 func (g *WorkGeometry) WorkPlaneByRef(ref WorkRef) (*WorkPlane, error) {


### PR DESCRIPTION
## What

The `/source` implementation of #163 (pins api **v0.62.0**) — re-selecting the geometry a placed feature is built on, completing in-place feature editing alongside the scalar edits from #140.

## Surface

- `features.get`/`features.edit` now report each feature's re-pickable **`Slots`** (kind `edges`|`faces`|`face`|`profile`|`plane`, multi flag, current count) from the model's `EditableRefs()`.
- `features.edit` applies **`Repick`** entries:
  - edge/face topology keys (raw, from `model.referenceKeys`),
  - a `{sketchIndex, profileIndex}` profile,
  - a plane ref (planar-face key / `plane/N` / `origin/plane/xy`, via new `WorkGeometry.ResolvePlaneRef`),
  - or `Clear` for a clearable multi-slot.

The whole batch (scalars + repicks) is validated **before any is applied**, then the part recomputes once — a structural failure (bad profile index, out-of-range slot, non-clearable clear, unresolvable plane) leaves the definition untouched.

## Note on edge/face keys

They're passed through as raw keys, not bind-checked at edit time: a dress-up feature's edges reference its **rollback input** body, not the final body, and a lost reference surfaces as feature health on recompute — exactly as `features.add` already behaves (parametric, not edit-time).

## Tests

Re-pick an extrude's profile (geometry changes); add then clear a fillet's edges (faces up, then bare box); atomic rollback on a bad profile index; out-of-range slot rejected; slots reported. All acceptance criteria of #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)