### PR TITLE
feat(sketch): consumed/owned-by state + dependents + delete guard (#154 impl)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -254,6 +254,7 @@ func (r *Router) registerSketchHandlers() {
 	r.handlers[wire.MethodSketchRectangle] = sketchRectangle
 	r.handlers[wire.MethodSketchList] = listSketches
 	r.handlers[wire.MethodSketchGet] = getSketch
+	r.handlers[wire.MethodSketchDependents] = sketchDependents
 	r.handlers[wire.MethodSketchEdit] = editSketch
 	r.handlers[wire.MethodSketchExitEdit] = exitEditSketch
 	r.handlers[wire.MethodSketchSolve] = solveSketch

--- a/addin/router/sketch3d_spine.go
+++ b/addin/router/sketch3d_spine.go
@@ -197,6 +197,7 @@ func sketch3DInfo(index int, sk *sketch.Sketch3D) wire.Sketch3DInfo {
 		DOF:               sk.DegreesOfFreedom(),
 		Editing:           sk.IsEditing(),
 		Healthy:           sk.Health().OK(),
+		Shared:            sk.Shared(),
 		Color:             sk.Color(),
 		DeferUpdates:      sk.DeferUpdates(),
 	}

--- a/addin/router/sketch_dependents.go
+++ b/addin/router/sketch_dependents.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// Sketch consumed/owned-by state + dependents (#154). A sketch is "consumed" when a feature
+// uses it as profile/path/centerline input — the same relationship the model browser nests by
+// ([feature.PartFeature.ConsumedSketches]). The owning feature is the first to consume it;
+// every consumer is a dependent that a delete or edit affects.
+
+// sketchConsumers returns the features that consume sk, in history order.
+func sketchConsumers(part *compdef.PartComponentDefinition, sk *sketch.Sketch) []*feature.PartFeature {
+	var out []*feature.PartFeature
+	feats := part.Features()
+	for i := 0; i < feats.Count(); i++ {
+		f := feats.Item(i)
+		for _, c := range f.ConsumedSketches() {
+			if c == sk {
+				out = append(out, f)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// sketchDependentRefs renders a sketch's consuming features as wire dependents.
+func sketchDependentRefs(part *compdef.PartComponentDefinition, sk *sketch.Sketch) []wire.SketchDependent {
+	cons := sketchConsumers(part, sk)
+	out := make([]wire.SketchDependent, len(cons))
+	for i, f := range cons {
+		out[i] = wire.SketchDependent{ID: uint64(f.ID()), Name: f.Name(), Kind: f.Kind()}
+	}
+	return out
+}
+
+// sketchDependents lists the features that consume the addressed sketch (#154).
+func sketchDependents(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	sk, _, err := resolveSketch(s, raw)
+	if err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SketchDependentsResult{Dependents: sketchDependentRefs(part, sk)})
+}
+
+// dependentNames joins the dependent feature names for a delete-guard error message.
+func dependentNames(deps []wire.SketchDependent) string {
+	names := make([]string, len(deps))
+	for i, d := range deps {
+		names[i] = d.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+// rejectIfConsumed returns an error naming the dependents when the sketch is still used by a
+// feature — Inventor's "Delete is only valid for sketches not used by a feature" (#154).
+func rejectIfConsumed(part *compdef.PartComponentDefinition, sk *sketch.Sketch) error {
+	deps := sketchDependentRefs(part, sk)
+	if len(deps) == 0 {
+		return nil
+	}
+	return fmt.Errorf("sketch.delete: sketch %q is used by %d feature(s): %s — delete the features first (or re-pick their profiles)",
+		sk.Name(), len(deps), dependentNames(deps))
+}

--- a/addin/router/sketch_dependents_test.go
+++ b/addin/router/sketch_dependents_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// extrudedSketchFixture: sketch 0 (a rectangle) consumed by an extrude, plus an unconsumed
+// sketch 1. Returns the router/session and the extrude's feature id.
+func extrudedSketchFixture(t *testing.T) (*Router, *app.Session, uint64) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"20 mm"}}`, &struct{}{})
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{}) // sketch 1, unconsumed
+	return r, s, lastFeatureID(t, r, s)
+}
+
+// TestSketchConsumedStateReported: sketch.get reports consumed/ownedBy for a sketch a feature
+// uses, and clears them for an unconsumed sketch (#154).
+func TestSketchConsumedStateReported(t *testing.T) {
+	r, s, _ := extrudedSketchFixture(t)
+
+	var consumed wire.SketchInfo
+	call(t, r, s, "sketch.get", `{"sketchIndex":0}`, &consumed)
+	if !consumed.Consumed || consumed.OwnedBy == "" {
+		t.Errorf("consumed sketch info = %+v, want consumed=true and a non-empty ownedBy", consumed)
+	}
+
+	var free wire.SketchInfo
+	call(t, r, s, "sketch.get", `{"sketchIndex":1}`, &free)
+	if free.Consumed || free.OwnedBy != "" {
+		t.Errorf("unconsumed sketch info = %+v, want consumed=false and empty ownedBy", free)
+	}
+}
+
+// TestSketchDependents: sketch.dependents lists the consuming feature for a used sketch and is
+// empty for an unused one.
+func TestSketchDependents(t *testing.T) {
+	r, s, extrudeID := extrudedSketchFixture(t)
+
+	var deps wire.SketchDependentsResult
+	call(t, r, s, "sketch.dependents", `{"sketchIndex":0}`, &deps)
+	if len(deps.Dependents) != 1 || deps.Dependents[0].ID != extrudeID || deps.Dependents[0].Kind != "extrude" {
+		t.Errorf("dependents of consumed sketch = %+v, want one extrude id %d", deps.Dependents, extrudeID)
+	}
+
+	call(t, r, s, "sketch.dependents", `{"sketchIndex":1}`, &deps)
+	if len(deps.Dependents) != 0 {
+		t.Errorf("dependents of unconsumed sketch = %+v, want none", deps.Dependents)
+	}
+}
+
+// TestSketchDeleteRejectsConsumed: sketch.delete refuses a sketch a feature still uses and
+// reports the dependent, but deletes an unused sketch (#154).
+func TestSketchDeleteRejectsConsumed(t *testing.T) {
+	r, s, _ := extrudedSketchFixture(t)
+
+	if _, err := r.Handle(s, "sketch.delete", []byte(`{"sketchIndex":0}`)); err == nil {
+		t.Error("deleting a consumed sketch should fail")
+	}
+	// The unused sketch deletes fine.
+	var ok wire.OKResult
+	call(t, r, s, "sketch.delete", `{"sketchIndex":1}`, &ok)
+	if !ok.OK {
+		t.Error("deleting an unconsumed sketch should succeed")
+	}
+}
+
+// TestSketchDependentsNoActivePart: the method errors without an active part.
+func TestSketchDependentsNoActivePart(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	if _, err := r.Handle(s, "sketch.dependents", []byte(`{"sketchIndex":0}`)); err == nil {
+		t.Error("sketch.dependents with no active part should fail")
+	}
+}

--- a/addin/router/sketch_properties.go
+++ b/addin/router/sketch_properties.go
@@ -33,7 +33,7 @@ func setSketchProperty(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 	if err := applySketchProperty(part, sk, in.Property, in.Value); err != nil {
 		return nil, err
 	}
-	return json.Marshal(sketchInfo(in.SketchIndex, sk))
+	return json.Marshal(sketchInfo(part, in.SketchIndex, sk))
 }
 
 // applySketchProperty applies one property=value to the sketch, parsing typed values.

--- a/addin/router/sketch_spine.go
+++ b/addin/router/sketch_spine.go
@@ -10,6 +10,7 @@ import (
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/sketch"
 )
 
@@ -22,7 +23,7 @@ func listSketches(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	sketches := part.Sketches()
 	out := make([]wire.SketchInfo, sketches.Count())
 	for i := 0; i < sketches.Count(); i++ {
-		out[i] = sketchInfo(i, sketches.Item(i))
+		out[i] = sketchInfo(part, i, sketches.Item(i))
 	}
 	return json.Marshal(wire.ListSketchesResult{Sketches: out})
 }
@@ -33,7 +34,11 @@ func getSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(sketchInfo(idx, sk))
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(sketchInfo(part, idx, sk))
 }
 
 // editSketch enters edit mode; exitEditSketch leaves it.
@@ -113,15 +118,19 @@ func deleteSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
+	if err := rejectIfConsumed(part, sk); err != nil {
+		return nil, err
+	}
 	if !part.Sketches().Remove(sk.ID()) {
 		return nil, fmt.Errorf("sketch.delete: sketch %d could not be removed", sk.ID())
 	}
 	return json.Marshal(wire.OKResult{OK: true})
 }
 
-// sketchInfo renders a sketch as its wire summary (DOF computed without moving geometry).
-func sketchInfo(index int, sk *sketch.Sketch) wire.SketchInfo {
-	return wire.SketchInfo{
+// sketchInfo renders a sketch as its wire summary (DOF computed without moving geometry),
+// including its consumed/owned-by/shared state derived from the part's features (#154).
+func sketchInfo(part *compdef.PartComponentDefinition, index int, sk *sketch.Sketch) wire.SketchInfo {
+	info := wire.SketchInfo{
 		Index:        index,
 		Name:         sk.Name(),
 		Plane:        planeLabel(sk.Plane()),
@@ -130,11 +139,16 @@ func sketchInfo(index int, sk *sketch.Sketch) wire.SketchInfo {
 		DOF:          sk.DegreesOfFreedom(),
 		Editing:      sk.IsEditing(),
 		Healthy:      sk.Health().OK(),
+		Shared:       sk.Shared(),
 		Color:        sk.Color(),
 		LineType:     sk.LineType(),
 		LineWeight:   sk.LineWeight(),
 		DeferUpdates: sk.DeferUpdates(),
 	}
+	if cons := sketchConsumers(part, sk); len(cons) > 0 {
+		info.Consumed, info.OwnedBy = true, cons[0].Name()
+	}
+	return info
 }
 
 // activeSketchAt returns the active part's sketch at the given index.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.62.0
+	oblikovati.org/api v0.63.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.62.0
+	oblikovati.org/api v0.63.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

The `/source` implementation of #154 (pins api **v0.63.0**) — surface the feature↔sketch relationships the engine already tracks but the API didn't report.

## Surface

- `sketch.get`/`sketch.list` → `consumed` (a feature uses the sketch), `ownedBy` (the consuming feature's name), `shared`. `Sketch3DInfo` → `shared`.
- `sketch.dependents` → the consuming features (`id`, `name`, `kind`) in history order; empty ⇒ safe to delete.
- `sketch.delete` → now **rejects** a sketch a feature still uses, naming the dependents (Inventor's "Delete is only valid for sketches not used by a feature").

## How

Derived from `PartFeature.ConsumedSketches()` — the same relationship the model browser nests by. The owning feature is the first consumer.

3D `consumed`/`ownedBy` await a 3D path→sketch dependency link (no such relationship exists yet); `shared` lands now.

## Tests

Consumed/ownedBy reported (and cleared for an unused sketch); dependents enumerated; delete rejected for a consumed sketch and allowed for a free one; no-active-part rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)