### PR TITLE
feat(body): name/visibility + body.setVisible (#158 impl)

### DIFF
--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -39,13 +39,36 @@ func bodyList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	}
 	var out wire.BodyListResult
 	for i, b := range part.SurfaceBodies().All() {
-		out.Bodies = append(out.Bodies, wire.BodyInfo{
-			Index: i, Solid: b.IsSolid(),
-			Faces: len(b.Faces()), Edges: len(b.Edges()), Vertices: len(b.Vertices()),
-			Shells: len(b.Shells()), Wires: len(b.Wires()),
-		})
+		out.Bodies = append(out.Bodies, bodyInfo(s, i, b))
 	}
 	return json.Marshal(out)
+}
+
+// bodyInfo builds a body's wire summary, including its display name and current visibility (#158).
+func bodyInfo(s *app.Session, index int, b *topo.Body) wire.BodyInfo {
+	return wire.BodyInfo{
+		Index: index, Name: bodyDisplayName(index), Solid: b.IsSolid(), Visible: s.BodyVisible(b),
+		Faces: len(b.Faces()), Edges: len(b.Edges()), Vertices: len(b.Vertices()),
+		Shells: len(b.Shells()), Wires: len(b.Wires()),
+	}
+}
+
+// bodyDisplayName is the body's browser name ("Solid1", …), index-derived until bodies carry
+// stored, renamable names (the #158 rename follow-up). Matches the model browser.
+func bodyDisplayName(index int) string { return fmt.Sprintf("Solid%d", index+1) }
+
+// bodySetVisible shows or hides one body of the active part (#158); the renderer reads the flag.
+func bodySetVisible(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodySetVisibleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	s.SetBodyVisible(b, in.Visible)
+	return json.Marshal(wire.BodyInfoResult{Body: bodyInfo(s, in.BodyIndex, b)})
 }
 
 // bodyShells serves wire.MethodBodyShells.

--- a/addin/router/body_visibility_test.go
+++ b/addin/router/body_visibility_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// boxBodySession builds a part with one extruded box body.
+func boxBodySession(t *testing.T) (*Router, *app.Session) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"20 mm"}}`, &struct{}{})
+	return r, s
+}
+
+// TestBodyListReportsNameAndVisibility: body.list now reports each body's display name, solid
+// flag, and visibility (#158).
+func TestBodyListReportsNameAndVisibility(t *testing.T) {
+	r, s := boxBodySession(t)
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if len(list.Bodies) != 1 {
+		t.Fatalf("body.list = %d bodies, want 1", len(list.Bodies))
+	}
+	b := list.Bodies[0]
+	if b.Name != "Solid1" || !b.Solid || !b.Visible {
+		t.Errorf("body info = %+v, want Solid1 solid and visible", b)
+	}
+}
+
+// TestBodySetVisibleHidesAndShows drives the #158 acceptance: hide a body, see it reflected,
+// then show it again.
+func TestBodySetVisibleHidesAndShows(t *testing.T) {
+	r, s := boxBodySession(t)
+
+	var res wire.BodyInfoResult
+	call(t, r, s, "body.setVisible", `{"bodyIndex":0,"visible":false}`, &res)
+	if res.Body.Visible {
+		t.Errorf("after hide, body.visible = true, want false")
+	}
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if list.Bodies[0].Visible {
+		t.Errorf("body.list after hide shows visible=true, want false")
+	}
+
+	call(t, r, s, "body.setVisible", `{"bodyIndex":0,"visible":true}`, &res)
+	if !res.Body.Visible {
+		t.Errorf("after show, body.visible = false, want true")
+	}
+}
+
+// TestBodySetVisibleBadIndexFails: an out-of-range body index is a rejection.
+func TestBodySetVisibleBadIndexFails(t *testing.T) {
+	r, s := boxBodySession(t)
+	if _, err := r.Handle(s, "body.setVisible", []byte(`{"bodyIndex":9,"visible":false}`)); err == nil {
+		t.Error("body.setVisible with an out-of-range index should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -366,6 +366,7 @@ func (r *Router) registerMaterialHandlers() {
 
 	// Body topology, queries and facet sets (M07 #293/#629/#630).
 	r.handlers[wire.MethodBodyList] = bodyList
+	r.handlers[wire.MethodBodySetVisible] = bodySetVisible
 	r.handlers[wire.MethodBodyShells] = bodyShells
 	r.handlers[wire.MethodBodyWires] = bodyWires
 	r.handlers[wire.MethodWireOffsetPlanar] = wireOffsetPlanar

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.63.0
+	oblikovati.org/api v0.64.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.63.0
+	oblikovati.org/api v0.64.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

The `/source` implementation of the body-level API slice for #158 (pins api **v0.64.0**).

## Surface

- `body.list` → each body now reports `name` ("Solid{N}") and `visible`.
- `body.setVisible` → show/hide one body by index, returning its refreshed summary.

## How

Wires the app's existing per-body visibility (`Session.SetBodyVisible`/`BodyVisible`) over the wire — the renderer already reads the flag, so multi-body workflows (Combine, Split, Mold) can now show/hide results via the API.

Rename, delete, and per-body physical properties remain a follow-up (rename needs stored body names — today they're index-derived; delete is a model-mutating feature).

## Tests

Name/solid/visibility reporting; hide→show round trip reflected in `body.list`; out-of-range index rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)