### PR TITLE
feat(documents): update/rebuild/requiresUpdate (#139 impl)

### DIFF
--- a/addin/router/documents_update.go
+++ b/addin/router/documents_update.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/health"
+)
+
+// Document update/rebuild (#139): drive and query the feature engine's recompute over the wire.
+// update recomputes the out-of-date tail; rebuild marks every feature dirty first (a full
+// parametric rebuild); requiresUpdate is the read-only stale-feature flag. The engine never
+// aborts — a failed feature goes sick and poisons dependents — so update/rebuild report the sick
+// features; with acceptErrorsAndContinue=false a sick feature instead fails the call.
+
+// documentsUpdate recomputes the active part's out-of-date features.
+func documentsUpdate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	return recomputeActivePart(s, raw, false)
+}
+
+// documentsRebuild recomputes the active part's entire feature program (all features dirtied).
+func documentsRebuild(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	return recomputeActivePart(s, raw, true)
+}
+
+// recomputeActivePart runs the engine (optionally dirtying everything first), then reports the
+// resulting sick features — failing the call when any is sick and acceptErrorsAndContinue is off.
+func recomputeActivePart(s *app.Session, raw json.RawMessage, rebuild bool) (json.RawMessage, error) {
+	var in wire.UpdateDocumentArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	if rebuild {
+		part.Features().MarkAllDirty()
+	}
+	part.Recompute()
+	errs := sickFeatures(part)
+	if len(errs) > 0 && !in.AcceptErrorsAndContinue {
+		return nil, fmt.Errorf("documents.update: %d feature(s) are sick after recompute: %s "+
+			"(pass acceptErrorsAndContinue to report them instead)", len(errs), errs[0].Name)
+	}
+	return json.Marshal(wire.UpdateDocumentResult{RequiresUpdate: part.Features().RequiresUpdate(), Errors: errs})
+}
+
+// documentsRequiresUpdate reports whether the active part has out-of-date features.
+func documentsRequiresUpdate(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.RequiresUpdateResult{RequiresUpdate: part.Features().RequiresUpdate()})
+}
+
+// sickFeatures collects the features that ended up sick after a recompute, in history order.
+func sickFeatures(part *compdef.PartComponentDefinition) []wire.FeatureError {
+	var out []wire.FeatureError
+	feats := part.Features()
+	for i := 0; i < feats.Count(); i++ {
+		f := feats.Item(i)
+		if h := f.Health(); h.Status == health.Sick {
+			out = append(out, wire.FeatureError{ID: uint64(f.ID()), Name: f.Name(), Kind: f.Kind(), Message: h.Reason})
+		}
+	}
+	return out
+}

--- a/addin/router/documents_update_test.go
+++ b/addin/router/documents_update_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// markPartDirty drives the active part into a needs-update state (a parameter edit would do this
+// in the model; the test marks every feature dirty directly).
+func markPartDirty(t *testing.T, s *app.Session) {
+	t.Helper()
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	part.Features().MarkAllDirty()
+}
+
+// TestRequiresUpdateReflectsDirtyAndClears: documents.requiresUpdate is false on a freshly
+// recomputed part, true once a feature is dirtied, and false again after documents.update (#139).
+func TestRequiresUpdateReflectsDirtyAndClears(t *testing.T) {
+	r, s := boxBodySession(t) // extrude already recomputed → clean
+
+	var st wire.RequiresUpdateResult
+	call(t, r, s, "documents.requiresUpdate", `{}`, &st)
+	if st.RequiresUpdate {
+		t.Errorf("freshly built part requiresUpdate=true, want false")
+	}
+
+	markPartDirty(t, s)
+	call(t, r, s, "documents.requiresUpdate", `{}`, &st)
+	if !st.RequiresUpdate {
+		t.Errorf("dirtied part requiresUpdate=false, want true")
+	}
+
+	var up wire.UpdateDocumentResult
+	call(t, r, s, "documents.update", `{}`, &up)
+	if up.RequiresUpdate || len(up.Errors) != 0 {
+		t.Errorf("after update = %+v, want requiresUpdate=false and no errors", up)
+	}
+	call(t, r, s, "documents.requiresUpdate", `{}`, &st)
+	if st.RequiresUpdate {
+		t.Errorf("after update requiresUpdate=true, want false")
+	}
+}
+
+// TestDocumentsRebuildRecomputes: documents.rebuild recomputes the whole program and leaves the
+// part up to date with no errors on a healthy model.
+func TestDocumentsRebuildRecomputes(t *testing.T) {
+	r, s := boxBodySession(t)
+	var up wire.UpdateDocumentResult
+	call(t, r, s, "documents.rebuild", `{}`, &up)
+	if up.RequiresUpdate || len(up.Errors) != 0 {
+		t.Errorf("rebuild of a healthy part = %+v, want requiresUpdate=false and no errors", up)
+	}
+	// The body still exists after a full rebuild.
+	if faces := partBodyFaces(t, s); faces != 6 {
+		t.Errorf("after rebuild: %d faces, want 6 (the box survived)", faces)
+	}
+}
+
+// TestDocumentsUpdateReportsSickFeatures: a recompute that leaves a feature sick fails a strict
+// update but succeeds — reporting the sick feature — with acceptErrorsAndContinue (Update2, #139).
+func TestDocumentsUpdateReportsSickFeatures(t *testing.T) {
+	r, s := boxBodySession(t)
+	// A fillet on a non-existent edge recomputes sick (a lost reference).
+	args, _ := json.Marshal(map[string]any{
+		"kind": "fillet",
+		"args": map[string]any{"edgeRefs": []string{"bogus-edge-key"}, "radius": "2 mm"},
+	})
+	call(t, r, s, "features.add", string(args), &struct {
+		Bodies int `json:"bodies"`
+	}{})
+
+	if _, err := r.Handle(s, "documents.update", []byte(`{}`)); err == nil {
+		t.Error("strict documents.update should fail when a feature is sick")
+	}
+
+	var up wire.UpdateDocumentResult
+	call(t, r, s, "documents.update", `{"acceptErrorsAndContinue":true}`, &up)
+	if len(up.Errors) != 1 || up.Errors[0].Kind != "fillet" {
+		t.Errorf("update errors = %+v, want one fillet", up.Errors)
+	}
+}
+
+// TestDocumentsUpdateNoActivePart: the methods error without an active part.
+func TestDocumentsUpdateNoActivePart(t *testing.T) {
+	r := New(opregistry.Default())
+	s := app.NewSession()
+	for _, m := range []string{"documents.update", "documents.rebuild", "documents.requiresUpdate"} {
+		if _, err := r.Handle(s, m, []byte(`{}`)); err == nil {
+			t.Errorf("%s with no active part should fail", m)
+		}
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -95,6 +95,9 @@ func (r *Router) Trace() *trace.Buffer { return r.trace }
 func (r *Router) registerStandardHandlers() {
 	r.registerCommandHandlers()
 	r.handlers[wire.MethodDocumentsList] = listDocuments
+	r.handlers[wire.MethodDocumentsUpdate] = documentsUpdate
+	r.handlers[wire.MethodDocumentsRebuild] = documentsRebuild
+	r.handlers[wire.MethodDocumentsRequiresUpdate] = documentsRequiresUpdate
 	r.handlers[wire.MethodDocumentsCreate] = createDocument
 	r.handlers[wire.MethodDocumentsActivate] = activateDocument
 	r.handlers[wire.MethodDocumentsClose] = closeDocument

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.64.0
+	oblikovati.org/api v0.65.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.64.0
+	oblikovati.org/api v0.65.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -133,6 +133,11 @@ func (fs *PartFeatures) Result() []*topo.Body { return fs.result }
 // MarkDirty flags a feature for re-evaluation on the next recompute.
 func (fs *PartFeatures) MarkDirty(f *PartFeature) { f.dirty = true }
 
+// RequiresUpdate reports whether any feature up to the end-of-part marker is dirty — i.e. a
+// recompute would change the result. It is the read-only "needs update" flag the API exposes
+// (Inventor PartDocument.RequiresUpdate), the predicate behind documents.update (#139).
+func (fs *PartFeatures) RequiresUpdate() bool { return fs.earliestDirty(fs.effectiveEnd()) >= 0 }
+
 // MarkAllDirty flags every feature for re-evaluation. A parameter edit can change
 // any feature's inputs — a dimension expression a sketch profile is built from, or
 // a feature's own value closure (extrude distance, revolve angle) — but those


### PR DESCRIPTION
## What

The `/source` implementation of #139 (pins api **v0.65.0**) — drive and query the feature engine's recompute over the wire.

## Surface

- `documents.update` → recompute out-of-date features (`part.Recompute`).
- `documents.rebuild` → mark every feature dirty, then recompute (full parametric rebuild).
- `documents.requiresUpdate` → the read-only stale-feature flag (new `PartFeatures.RequiresUpdate`).

`update`/`rebuild` collect the features left **sick** after recompute; with `acceptErrorsAndContinue` they're reported in `UpdateDocumentResult.Errors`, otherwise the call fails naming them (Update2/Rebuild2 parity).

## Tests

- `requiresUpdate` false → dirtied → true → false after update
- `rebuild` on a healthy part (no errors, body survives)
- a sick feature (fillet on a bogus edge) fails a strict update but is reported with `acceptErrorsAndContinue`
- no-active-part rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)