### PR TITLE
feat(sketch): control-point spline kind + tangent-distance dimension (#150, #152 impl)

### DIFF
--- a/addin/router/sketch_add_entity.go
+++ b/addin/router/sketch_add_entity.go
@@ -226,7 +226,7 @@ func buildCurvedEntity(part *compdef.PartComponentDefinition, sk *sketch.Sketch,
 		return buildEllipse(part, sk, in, pts)
 	case "ellipticalArc":
 		return buildEllipticalArc(part, sk, in, pts)
-	case "spline":
+	case "spline", "controlPointSpline":
 		return buildSpline(sk, in, pts)
 	case "fillet":
 		return buildFillet(part, sk, in)
@@ -461,7 +461,9 @@ func buildSpline(sk *sketch.Sketch, in wire.AddSketchEntityArgs, pts []math.Poin
 		return nil, nil, fmt.Errorf("sketch.addEntity: spline needs at least 2 points, got %d", len(pts))
 	}
 	var sp *sketch.Spline
-	if in.Variant == "controlPoint" {
+	// A control-point (approximating) spline is named either by the first-class
+	// "controlPointSpline" kind (#150) or the legacy variant=controlPoint flag.
+	if in.Kind == "controlPointSpline" || in.Variant == "controlPoint" {
 		sp = sk.Splines().AddByControlPoints(pts, in.Closed)
 	} else {
 		sp = sk.Splines().AddByPoints(pts, in.Closed)

--- a/addin/router/sketch_dimensions.go
+++ b/addin/router/sketch_dimensions.go
@@ -26,7 +26,7 @@ func addDimension(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	dim, err := buildDimension(sk, types.DimensionConstraintKind(in.Kind), in.Entities, in.Expression)
+	dim, err := buildDimension(sk, types.DimensionConstraintKind(in.Kind), in.Entities, in.Expression, in.FarSide)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func applyDimensionEdit(part *compdef.PartComponentDefinition, dim *sketch.Dimen
 }
 
 // buildDimension resolves references and applies the matching model dimension factory.
-func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string) (*sketch.DimensionConstraint, error) {
+func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide bool) (*sketch.DimensionConstraint, error) {
 	dc := sk.DimensionConstraints()
 	switch kind {
 	case types.DimConstraintDistance:
@@ -97,15 +97,18 @@ func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs 
 	case types.DimConstraintArcLength:
 		return arcLengthDimension(sk, refs, expr)
 	default:
-		return buildAdvancedDimension(sk, kind, refs, expr)
+		return buildAdvancedDimension(sk, kind, refs, expr, farSide)
 	}
 }
 
 // buildAdvancedDimension handles the M21 dimension kinds (offset/three-point-angle/
-// ellipse-radius); split out of buildDimension to keep that switch small.
-func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string) (*sketch.DimensionConstraint, error) {
+// ellipse-radius) plus the tangent-distance dimension (#152); split out of buildDimension to
+// keep that switch small.
+func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide bool) (*sketch.DimensionConstraint, error) {
 	dc := sk.DimensionConstraints()
 	switch kind {
+	case types.DimConstraintTangentDistance:
+		return tangentDistanceDimension(sk, refs, expr, farSide)
 	case types.DimConstraintOffset:
 		return offsetDimension(sk, refs, expr)
 	case types.DimConstraintThreePointAngle:
@@ -123,6 +126,23 @@ func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKin
 	default:
 		return nil, fmt.Errorf("sketch.addDimension: unsupported kind %q", kind)
 	}
+}
+
+// tangentDistanceDimension resolves a line + circle/arc ref and dimensions the distance from
+// the line to the curve's near (default) or far tangent point (#152).
+func tangentDistanceDimension(sk *sketch.Sketch, refs []uint64, expr string, farSide bool) (*sketch.DimensionConstraint, error) {
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("sketch.addDimension: tangentDistance needs a line ref and a circle/arc ref, got %d", len(refs))
+	}
+	l, err := lineRef(sk, refs[0])
+	if err != nil {
+		return nil, err
+	}
+	c, err := circularRef(sk, refs[1])
+	if err != nil {
+		return nil, err
+	}
+	return sk.DimensionConstraints().AddTangentDistance(l, c, farSide, expr)
 }
 
 // offsetDimension resolves a point + line ref and dimensions their perpendicular distance.

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -121,12 +121,21 @@ func entityShape(e sketch.Entity) (types.SketchEntityKind, [][]float64, float64)
 	case *sketch.EllipticalArc:
 		return types.SketchEntityEllipticalArc, [][]float64{pt(v.Center)}, 0
 	case *sketch.Spline:
-		return types.SketchEntitySpline, splinePts(v), 0
+		return splineKind(v), splinePts(v), 0
 	case *sketch.SplineHandle:
 		return types.SketchEntitySplineHandle, [][]float64{pt(v.Anchor), pt(v.End)}, 0
 	default:
 		return annotationShape(e)
 	}
+}
+
+// splineKind reports a spline's wire kind: a fit (interpolating) spline is "spline", a
+// control-point (approximating) spline is "controlPointSpline" (#150).
+func splineKind(s *sketch.Spline) types.SketchEntityKind {
+	if s.IsFitType() {
+		return types.SketchEntitySpline
+	}
+	return types.SketchEntityControlPointSpline
 }
 
 // splineFitSpelling reports a fit spline's fit-method wire spelling (the
@@ -300,12 +309,23 @@ func dimensionKind(k sketch.DimKind) types.DimensionConstraintKind {
 		return types.DimConstraintDiameter
 	case sketch.ArcLengthDim:
 		return types.DimConstraintArcLength
+	default:
+		return advancedDimensionKind(k)
+	}
+}
+
+// advancedDimensionKind maps the M21+ dimension kinds (offset/three-point-angle/ellipse-radius/
+// tangent-distance); split from dimensionKind to keep each switch small.
+func advancedDimensionKind(k sketch.DimKind) types.DimensionConstraintKind {
+	switch k {
 	case sketch.OffsetDim:
 		return types.DimConstraintOffset
 	case sketch.ThreePointAngleDim:
 		return types.DimConstraintThreePointAngle
 	case sketch.EllipseRadiusDim:
 		return types.DimConstraintEllipseRadius
+	case sketch.TangentDistanceDim:
+		return types.DimConstraintTangentDistance
 	default:
 		return types.DimConstraintUnknown
 	}

--- a/addin/router/sketch_gaps_test.go
+++ b/addin/router/sketch_gaps_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestControlPointSplineKind (#150): a control-point spline is created by the first-class kind
+// and enumerates distinctly from a fit spline.
+func TestControlPointSplineKind(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"controlPointSpline","points":[[0,0],[2,1],[4,0]]}`, &wire.AddSketchEntityResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"spline","points":[[0,5],[2,6],[4,5]]}`, &wire.AddSketchEntityResult{})
+
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &ents)
+	kinds := map[string]int{}
+	for _, e := range ents.Entities {
+		kinds[e.Kind]++
+	}
+	if kinds["controlPointSpline"] != 1 || kinds["spline"] != 1 {
+		t.Errorf("spline kinds = %v, want one controlPointSpline and one spline", kinds)
+	}
+}
+
+// TestTangentDistanceDimension (#152): the distance from a line to a circle's near and far
+// tangent point. With the line on y=0 and the circle centered at (0,5) r=2, near = 5-2 = 3,
+// far = 5+2 = 7.
+func TestTangentDistanceDimension(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	var line, circle wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,0]]}`, &line)
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[0,5]],"radius":"2 cm"}`, &circle)
+
+	near := mustJSON(t, wire.AddDimensionArgs{SketchIndex: 0, Kind: "tangentDistance", Entities: []uint64{line.EntityID, circle.EntityID}, Expression: "1 cm"})
+	var dim wire.AddDimensionResult
+	call(t, r, s, "sketch.addDimension", near, &dim)
+	if dim.Kind != "tangentDistance" || math.Abs(dim.Value-3) > 1e-6 {
+		t.Errorf("near tangent-distance = %+v, want kind tangentDistance value 3", dim)
+	}
+
+	far := mustJSON(t, wire.AddDimensionArgs{SketchIndex: 0, Kind: "tangentDistance", Entities: []uint64{line.EntityID, circle.EntityID}, Expression: "1 cm", FarSide: true})
+	call(t, r, s, "sketch.addDimension", far, &dim)
+	if math.Abs(dim.Value-7) > 1e-6 {
+		t.Errorf("far tangent-distance value = %v, want 7", dim.Value)
+	}
+}
+
+// TestTangentDistanceDimensionBadOperands: wrong operand count/kind is a clear rejection.
+func TestTangentDistanceDimensionBadOperands(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	var line wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,0]]}`, &line)
+	// Only a line, no circle.
+	args := mustJSON(t, wire.AddDimensionArgs{SketchIndex: 0, Kind: "tangentDistance", Entities: []uint64{line.EntityID}, Expression: "1 cm"})
+	if _, err := r.Handle(s, "sketch.addDimension", []byte(args)); err == nil {
+		t.Error("tangentDistance with a single operand should fail")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.65.0
+	oblikovati.org/api v0.66.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.65.0
+	oblikovati.org/api v0.66.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/sketch/constraints_2d.go
+++ b/model/sketch/constraints_2d.go
@@ -279,16 +279,26 @@ func (g *GeometricConstraints) AddTangent(l *Line, c CircularCurve) *TangentCons
 }
 
 func (t *TangentConstraint) Residuals() []float64 {
-	dx, dy := lineDir(t.L)
-	length := stdmath.Hypot(dx, dy)
-	if length == 0 {
+	signed, ok := signedCenterToLine(t.L, t.C)
+	if !ok {
 		return []float64{t.C.CurveRadius()} // degenerate line: cannot be tangent
 	}
 	// Unsigned perpendicular distance from the center to the line equals the
 	// radius at tangency. (The center may lie on either side of the line.)
-	ctr := t.C.CenterPoint()
-	signed := (dx*(ctr.Y-t.L.A.Y) - dy*(ctr.X-t.L.A.X)) / length
 	return []float64{stdmath.Abs(signed) - t.C.CurveRadius()}
+}
+
+// signedCenterToLine returns the signed perpendicular distance from a circular curve's center
+// to the infinite line through l, and false for a degenerate (zero-length) line. Shared by the
+// tangent constraint and the tangent-distance dimension (#152).
+func signedCenterToLine(l *Line, c CircularCurve) (float64, bool) {
+	dx, dy := lineDir(l)
+	length := stdmath.Hypot(dx, dy)
+	if length == 0 {
+		return 0, false
+	}
+	ctr := c.CenterPoint()
+	return (dx*(ctr.Y-l.A.Y) - dy*(ctr.X-l.A.X)) / length, true
 }
 
 func (t *TangentConstraint) Variables() []*math.Scalar {

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -28,6 +28,8 @@ const (
 	PointPlaneDimKind3D // signed distance from a 3D point to an origin plane
 	// Appended for issue #144 (do not reorder).
 	SplineLengthDimKind3D // a 3D spline's sampled arc length
+	// Appended for issue #152 (do not reorder).
+	TangentDistanceDim // distance from a line to a circle/arc's near/far tangent point
 )
 
 // ConstraintLimits bounds a dimension's value for drive/animation. When Enabled,
@@ -67,7 +69,12 @@ type DimensionConstraint struct {
 	measure func() float64
 	vars    []*math.Scalar
 	refs    []Entity // the dimensioned geometry (points/lines/arcs), for editing + serialization
+	farSide bool     // tangentDistance only: dimension to the far tangent point (#152)
 }
+
+// FarSide reports whether a tangent-distance dimension measures to the far tangent point
+// (#152); false (the near side) for every other kind.
+func (d *DimensionConstraint) FarSide() bool { return d.farSide }
 
 // Refs returns the geometry the dimension measures (points for a distance, the line
 // pair for an angle, the circle for a radius, …). It is what serialization records so
@@ -178,6 +185,31 @@ func (dc *DimensionConstraints) AddAngle(l1, l2 *Line, expression string) (*Dime
 		return stdmath.Atan2(stdmath.Abs(d1x*d2y-d1y*d2x), d1x*d2x+d1y*d2y)
 	}
 	return dc.create(AngleDim, expression, []Entity{l1, l2}, measure, lineVars(l1, l2))
+}
+
+// AddTangentDistance dimensions the distance from a line to a circle/arc measured to its
+// tangent point: |perpendicular distance from the center to the line| ∓ radius — the near
+// side (default) subtracts the radius, the far side adds it (#152). The solver drives the
+// line's endpoints and the curve's center/radius (circularVars) to satisfy the target.
+func (dc *DimensionConstraints) AddTangentDistance(l *Line, c CircularCurve, farSide bool, expression string) (*DimensionConstraint, error) {
+	measure := func() float64 {
+		signed, ok := signedCenterToLine(l, c)
+		if !ok {
+			return 0
+		}
+		d := stdmath.Abs(signed)
+		if farSide {
+			return d + c.CurveRadius()
+		}
+		return d - c.CurveRadius()
+	}
+	vars := append([]*math.Scalar{&l.A.X, &l.A.Y, &l.B.X, &l.B.Y}, c.circularVars()...)
+	d, err := dc.create(TangentDistanceDim, expression, []Entity{l, c}, measure, vars)
+	if err != nil {
+		return nil, err
+	}
+	d.farSide = farSide
+	return d, nil
 }
 
 // AddArcLength dimensions an arc's length (radius × swept angle).

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -139,6 +139,7 @@ type DimensionData struct {
 	Curves     []int       `yaml:"curves,omitempty"`
 	Expression string      `yaml:"expression"`
 	Driven     bool        `yaml:"driven,omitempty"`
+	FarSide    bool        `yaml:"farSide,omitempty"` // tangentDistance only (#152)
 	Limits     *LimitsData `yaml:"limits,omitempty"`
 }
 
@@ -387,7 +388,7 @@ func serializeSplineHandles(sp *Spline) []SplineHandleData {
 }
 
 func serializeDimension(d *DimensionConstraint) (DimensionData, error) {
-	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven}
+	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven, FarSide: d.farSide}
 	if d.limits.Enabled {
 		dd.Limits = &LimitsData{Min: d.limits.Min, Max: d.limits.Max}
 	}
@@ -427,6 +428,8 @@ func dimKindName(k DimKind) (string, error) {
 		return "threePointAngle", nil
 	case EllipseRadiusDim:
 		return "ellipseRadius", nil
+	case TangentDistanceDim:
+		return "tangentDistance", nil
 	default:
 		return "", fmt.Errorf("cannot serialize dimension of kind %d (no codec)", k)
 	}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -503,6 +503,16 @@ func (r *sketchRestorer) restoreAdvancedDimension(dd DimensionData) (*DimensionC
 			return nil, err
 		}
 		return dc.AddEllipseRadius(e, dd.Expression)
+	case "tangentDistance":
+		l, err := r.line(dd.Curves, 0)
+		if err != nil {
+			return nil, err
+		}
+		c, err := r.curve(dd.Curves, 1)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddTangentDistance(l, c, dd.FarSide, dd.Expression)
 	default:
 		return nil, fmt.Errorf("unknown dimension kind %q", dd.Kind)
 	}

--- a/model/sketch/sketch_gaps_test.go
+++ b/model/sketch/sketch_gaps_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestControlSplineRoundTrip (#150): a control-point (approximating) spline keeps its mode
+// across a save/load cycle — it is not silently restored as a fit spline.
+func TestControlSplineRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	sp := s.Splines().AddByControlPoints([]math.Point2{math.P2(0, 0), math.P2(2, 1), math.P2(4, 0)}, false)
+	if sp.IsFitType() {
+		t.Fatal("AddByControlPoints produced a fit spline")
+	}
+
+	out := roundTrip(t, sc)
+	var restored *Spline
+	for _, e := range out.Entities() {
+		if v, ok := e.(*Spline); ok {
+			restored = v
+		}
+	}
+	if restored == nil {
+		t.Fatal("no spline after round trip")
+	}
+	if restored.IsFitType() {
+		t.Error("control-point spline restored as a fit spline (mode lost)")
+	}
+}
+
+// TestTangentDistanceDimRoundTrip (#152): a tangent-distance dimension keeps its far-side flag
+// and resolves its line/circle operands across a save/load cycle.
+func TestTangentDistanceDimRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	a, b := s.NewPoint(math.P2(0, 0)), s.NewPoint(math.P2(4, 0))
+	line := s.Lines().Add(a, b)
+	circle := s.Circles().Add(s.NewPoint(math.P2(0, 5)), 2)
+	d, err := s.DimensionConstraints().AddTangentDistance(line, circle, true, "1 cm")
+	if err != nil {
+		t.Fatalf("AddTangentDistance: %v", err)
+	}
+	if !d.FarSide() || d.Kind() != TangentDistanceDim {
+		t.Fatalf("dimension = farSide %v kind %d, want true tangentDistance", d.FarSide(), d.Kind())
+	}
+
+	out := roundTrip(t, sc)
+	dims := out.DimensionConstraints()
+	if dims.Count() != 1 {
+		t.Fatalf("restored dimensions = %d, want 1", dims.Count())
+	}
+	rd := dims.Item(0)
+	if rd.Kind() != TangentDistanceDim || !rd.FarSide() {
+		t.Errorf("restored dimension = kind %d farSide %v, want tangentDistance far=true", rd.Kind(), rd.FarSide())
+	}
+	// Far tangent distance with center 5 above the line and radius 2 is 5+2 = 7.
+	if got := rd.Measured(); got < 6.99 || got > 7.01 {
+		t.Errorf("restored measured = %v, want ~7", got)
+	}
+}


### PR DESCRIPTION
## What

The `/source` impls of two 2D-sketch parity gaps (pins api **v0.66.0**).

### #150 — control-point spline kind
- `sketch.addEntity` accepts the first-class `"controlPointSpline"` kind (alongside the legacy `variant:"controlPoint"`).
- Enumeration reports a spline's mode: `"spline"` (fit/interpolating) vs `"controlPointSpline"` (control/approximating). Existing fit splines still enumerate as `"spline"` — backward compatible.

### #152 — tangent-distance dimension
- `DimensionConstraints.AddTangentDistance` dimensions the distance from a line to a circle/arc's tangent point: `|signed center-to-line distance| ∓ radius` (near default, far via `FarSide`).
- Shares the center-to-line math with the tangent *constraint* (extracted `signedCenterToLine`, DRY), serializes the far-side flag, and routes through `sketch.addDimension`.

## Tests

Control vs fit spline enumeration; near (3) / far (7) tangent distance over the wire + bad-operand rejection; control-mode and far-side round-trip through the recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)