### PR TITLE
feat(sketch): straight/arc slot placement variants (#149)

### DIFF
--- a/addin/router/sketch_add_entity.go
+++ b/addin/router/sketch_add_entity.go
@@ -185,16 +185,58 @@ func buildSlot(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in wire
 	if err != nil {
 		return nil, fmt.Errorf("sketch.addEntity: slot width %q: %w", in.Width, err)
 	}
-	if in.Variant == "arc" {
-		if err := wantPoints("arc slot", pts, 3); err != nil {
+	width := math.Scalar(w.Value)
+	switch in.Variant {
+	case "arc":
+		return buildArcSlot(in, pts, width, sk.AddArcSlot)
+	case "arcThreePoint":
+		return buildArcSlot(in, pts, width, func(a, b, c math.Point2, _ math.Scalar, _ bool) ([]sketch.Entity, error) {
+			return sk.AddArcSlotByThreePoints(a, b, c, width)
+		})
+	case "arcCenterPoint":
+		return buildArcCenterPointSlot(part, sk, in, pts, width)
+	case "overall", "slotCenter":
+		return buildStraightSlotVariant(sk, in, pts, width)
+	default:
+		if err := wantPoints("slot", pts, 2); err != nil {
 			return nil, err
 		}
-		return sk.AddArcSlot(pts[0], pts[1], pts[2], math.Scalar(w.Value), in.CCW)
+		return sk.AddStraightSlot(pts[0], pts[1], width)
 	}
+}
+
+// buildArcSlot resolves the 3-point arc-slot input shared by the centerline-3-point and
+// through-3-points placements; add is the matching builder.
+func buildArcSlot(in wire.AddSketchEntityArgs, pts []math.Point2, width math.Scalar,
+	add func(a, b, c math.Point2, w math.Scalar, ccw bool) ([]sketch.Entity, error)) ([]sketch.Entity, error) {
+	if err := wantPoints("arc slot", pts, 3); err != nil {
+		return nil, err
+	}
+	return add(pts[0], pts[1], pts[2], width, in.CCW)
+}
+
+// buildArcCenterPointSlot builds an arc slot from center + start + a unit-bearing sweep angle
+// (in EndAngle), the Inventor by-center-point placement (#149).
+func buildArcCenterPointSlot(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in wire.AddSketchEntityArgs, pts []math.Point2, width math.Scalar) ([]sketch.Entity, error) {
+	if err := wantPoints("arc slot by center point", pts, 2); err != nil {
+		return nil, err
+	}
+	sweep, err := part.Units().Parse(in.EndAngle, param.Angle)
+	if err != nil {
+		return nil, fmt.Errorf("sketch.addEntity: arc slot sweep angle %q: %w", in.EndAngle, err)
+	}
+	return sk.AddArcSlotByCenterPoint(pts[0], pts[1], math.Scalar(sweep.Value), width)
+}
+
+// buildStraightSlotVariant builds the by-overall and by-slot-center straight placements (#149).
+func buildStraightSlotVariant(sk *sketch.Sketch, in wire.AddSketchEntityArgs, pts []math.Point2, width math.Scalar) ([]sketch.Entity, error) {
 	if err := wantPoints("slot", pts, 2); err != nil {
 		return nil, err
 	}
-	return sk.AddStraightSlot(pts[0], pts[1], math.Scalar(w.Value))
+	if in.Variant == "overall" {
+		return sk.AddStraightSlotByOverall(pts[0], pts[1], width)
+	}
+	return sk.AddStraightSlotBySlotCenter(pts[0], pts[1], width)
 }
 
 // buildSketchEntity dispatches a create request to the matching model constructor,

--- a/addin/router/sketch_gaps_test.go
+++ b/addin/router/sketch_gaps_test.go
@@ -28,6 +28,31 @@ func TestControlPointSplineKind(t *testing.T) {
 	}
 }
 
+// TestSlotPlacementVariants (#149): the by-overall straight slot and the by-center-point arc
+// slot (sweep angle via endAngle) create closed profiles over the wire.
+func TestSlotPlacementVariants(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+
+	var res wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"slot","variant":"overall","points":[[0,0],[8,0]],"width":"2 cm"}`, &res)
+	if len(res.EntityIDs) != 4 {
+		t.Errorf("by-overall slot = %d entities, want 4", len(res.EntityIDs))
+	}
+
+	var prof wire.ListProfilesResult
+	call(t, r, s, "sketch.profiles", `{"sketchIndex":0}`, &prof)
+	if len(prof.Profiles) < 1 {
+		t.Errorf("by-overall slot profiles = %d, want >= 1", len(prof.Profiles))
+	}
+
+	// Arc slot by center point: center + start + a sweep angle in endAngle.
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"slot","variant":"arcCenterPoint","points":[[20,0],[25,0]],"width":"1 cm","endAngle":"90 deg"}`, &res)
+	if len(res.EntityIDs) != 4 {
+		t.Errorf("arc-center-point slot = %d entities, want 4", len(res.EntityIDs))
+	}
+}
+
 // TestTangentDistanceDimension (#152): the distance from a line to a circle's near and far
 // tangent point. With the line on y=0 and the circle centered at (0,5) r=2, near = 5-2 = 3,
 // far = 5+2 = 7.

--- a/model/sketch/composite.go
+++ b/model/sketch/composite.go
@@ -199,6 +199,48 @@ func (s *Sketch) AddArcSlot(center, start, end math.Point2, width math.Scalar, c
 	}, nil
 }
 
+// AddStraightSlotByOverall builds a straight slot whose end0/end1 are the OUTER cap tips
+// (the overall extents, Inventor AddStraightSlotByOverall): it shrinks each end inward by
+// width/2 to the cap centers and delegates to AddStraightSlot (#149).
+func (s *Sketch) AddStraightSlotByOverall(end0, end1 math.Point2, width math.Scalar) ([]Entity, error) {
+	d := end0.VectorTo(end1)
+	if d.Length() <= float64(width) {
+		return nil, fmt.Errorf("slot by overall: overall length %.4g must exceed the width %.4g", d.Length(), float64(width))
+	}
+	du := d.Scale(1 / d.Length()).Scale(float64(width / 2))
+	return s.AddStraightSlot(end0.TranslateBy(du), end1.TranslateBy(du.Negate()), width)
+}
+
+// AddStraightSlotBySlotCenter builds a straight slot from its center point and one end cap
+// center; the other cap is the reflection of endCenter through slotCenter (Inventor
+// AddStraightSlotBySlotCenter, #149).
+func (s *Sketch) AddStraightSlotBySlotCenter(slotCenter, endCenter math.Point2, width math.Scalar) ([]Entity, error) {
+	other := math.P2(2*slotCenter.X-endCenter.X, 2*slotCenter.Y-endCenter.Y)
+	return s.AddStraightSlot(other, endCenter, width)
+}
+
+// AddArcSlotByCenterPoint builds an arc slot from the arc center, the start cap center, and a
+// signed sweep angle in radians: the end cap is start rotated about center by sweep (Inventor
+// AddArcSlotByCenterPointArc, #149).
+func (s *Sketch) AddArcSlotByCenterPoint(center, start math.Point2, sweep, width math.Scalar) ([]Entity, error) {
+	v := center.VectorTo(start)
+	cos, sin := stdmath.Cos(float64(sweep)), stdmath.Sin(float64(sweep))
+	end := center.TranslateBy(math.V2(v.X*math.Scalar(cos)-v.Y*math.Scalar(sin), v.X*math.Scalar(sin)+v.Y*math.Scalar(cos)))
+	return s.AddArcSlot(center, start, end, width, sweep > 0)
+}
+
+// AddArcSlotByThreePoints builds an arc slot whose centerline passes through three points on
+// it (start, a mid point, end); the arc center is their circumcenter, the sweep direction from
+// the points' turn (Inventor AddArcSlotByThreePointArc, #149).
+func (s *Sketch) AddArcSlotByThreePoints(p0, p1, p2 math.Point2, width math.Scalar) ([]Entity, error) {
+	center, _, err := circumcircle(p0, p1, p2)
+	if err != nil {
+		return nil, fmt.Errorf("arc slot by three points: %w", err)
+	}
+	turn := (p1.X-p0.X)*(p2.Y-p0.Y) - (p1.Y-p0.Y)*(p2.X-p0.X) // >0 ⇒ p0→p1→p2 turns left (ccw)
+	return s.AddArcSlot(center, p0, p2, width, turn > 0)
+}
+
 // polygonVertices returns the n vertex positions. For circumscribed polygons the vertex
 // radius is the apothem / cos(π/n) and the ring is rotated half a step so the through
 // point lands on an edge midpoint.

--- a/model/sketch/composite_slot_variants_test.go
+++ b/model/sketch/composite_slot_variants_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// assertClosedSlot fails unless ents is a 4-entity slot forming exactly one closed profile.
+func assertClosedSlot(t *testing.T, s *Sketch, ents []Entity, err error, what string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", what, err)
+	}
+	if len(ents) != 4 {
+		t.Fatalf("%s = %d entities, want 4", what, len(ents))
+	}
+	if got := s.Profiles().Count(); got != 1 {
+		t.Fatalf("%s profiles = %d, want 1 closed region", what, got)
+	}
+}
+
+// TestStraightSlotByOverall (#149): the end tips are the overall extents, so the center-to-
+// center length is overall − width and the slot still closes.
+func TestStraightSlotByOverall(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	ents, err := s.AddStraightSlotByOverall(gmath.P2(0, 0), gmath.P2(8, 0), 2)
+	assertClosedSlot(t, s, ents, err, "AddStraightSlotByOverall")
+	// An overall length no greater than the width cannot form a slot.
+	if _, err := s.AddStraightSlotByOverall(gmath.P2(0, 0), gmath.P2(1, 0), 2); err == nil {
+		t.Error("overall length ≤ width should fail")
+	}
+}
+
+// TestStraightSlotBySlotCenter (#149): the slot is symmetric about the given center.
+func TestStraightSlotBySlotCenter(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	ents, err := s.AddStraightSlotBySlotCenter(gmath.P2(0, 0), gmath.P2(3, 0), 2)
+	assertClosedSlot(t, s, ents, err, "AddStraightSlotBySlotCenter")
+}
+
+// TestArcSlotByCenterPoint (#149): center + start + sweep angle closes into a profile.
+func TestArcSlotByCenterPoint(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	ents, err := s.AddArcSlotByCenterPoint(gmath.P2(0, 0), gmath.P2(5, 0), math.Pi/2, 1)
+	assertClosedSlot(t, s, ents, err, "AddArcSlotByCenterPoint")
+}
+
+// TestArcSlotByThreePoints (#149): three centerline points close into a profile; collinear
+// points are rejected.
+func TestArcSlotByThreePoints(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	ents, err := s.AddArcSlotByThreePoints(gmath.P2(5, 0), gmath.P2(0, 5), gmath.P2(-5, 0), 1)
+	assertClosedSlot(t, s, ents, err, "AddArcSlotByThreePoints")
+
+	s2 := NewSketches().Add(XYPlane())
+	if _, err := s2.AddArcSlotByThreePoints(gmath.P2(0, 0), gmath.P2(2, 0), gmath.P2(4, 0), 1); err == nil {
+		t.Error("collinear three points should fail")
+	}
+}


### PR DESCRIPTION
## What

The Inventor slot placement modes — all reducible to the existing center-to-center / center-start-end builders with input arithmetic. **No API change**: they reuse the existing `AddSketchEntityArgs.Variant` discriminator and `EndAngle` (sweep) field.

## Variants (model wrappers in `composite.go`, routed via `sketch.addEntity`)

| Variant | Builder | Input |
|---|---|---|
| `overall` | `AddStraightSlotByOverall` | end tips are the overall extents (shrink each by width/2) |
| `slotCenter` | `AddStraightSlotBySlotCenter` | slot center + one end cap center (reflect for the other) |
| `arcCenterPoint` | `AddArcSlotByCenterPoint` | center + start + signed sweep angle (`endAngle`) |
| `arcThreePoint` | `AddArcSlotByThreePoints` | three centerline points (circumcenter + turn direction) |

(The existing center-to-center straight and 3-point arc forms are unchanged defaults.)

## Tests

Each variant forms exactly one closed profile (model + wire); degenerate inputs (overall ≤ width, collinear three points) are rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)