### PR TITLE
feat(sketch): sketch-to-sketch copy (#151 impl)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -330,6 +330,7 @@ func (r *Router) registerSketchAuthoringHandlers() {
 	r.handlers[wire.MethodSketchAddDimension] = addDimension
 	r.handlers[wire.MethodSketchDriveDimension] = driveDimension
 	r.handlers[wire.MethodSketchTransform] = transformSketch
+	r.handlers[wire.MethodSketchCopyTo] = sketchCopyTo
 	r.handlers[wire.MethodSketchAddPattern] = addSketchPattern
 	r.handlers[wire.MethodSketchOffset] = offsetSketchEntity
 	r.handlers[wire.MethodSketchAddImage] = addSketchImage

--- a/addin/router/sketch_copy.go
+++ b/addin/router/sketch_copy.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Sketch-to-sketch copy (#151): re-instantiate one sketch's geometry in another. The source
+// entities' sketch-local coordinates are cloned into the target sketch's plane (offset by
+// Position), reusing the cross-sketch clone machinery (Sketch.CopyEntities reads the source
+// and creates fresh geometry on the target). v1 copies geometry only — external constraints
+// and dimensions are dropped (Inventor CopyEntitiesTo); carry-over among the copied set is a
+// follow-up.
+
+// sketchCopyTo copies geometry from one 2D sketch into another.
+func sketchCopyTo(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CopySketchArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	source, target, err := resolveCopySketches(s, in)
+	if err != nil {
+		return nil, err
+	}
+	ents, err := copySourceEntities(source, in.EntityIDs)
+	if err != nil {
+		return nil, err
+	}
+	offset, err := copyOffset(in.Position)
+	if err != nil {
+		return nil, err
+	}
+	created := target.CopyEntities(ents, offset)
+	ids := make([]uint64, len(created))
+	for i, e := range created {
+		ids[i] = uint64(e.EntityID())
+	}
+	return json.Marshal(wire.CopySketchResult{Created: ids, Count: len(ids)})
+}
+
+// resolveCopySketches resolves and validates the distinct source and target sketches.
+func resolveCopySketches(s *app.Session, in wire.CopySketchArgs) (*sketch.Sketch, *sketch.Sketch, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	source, err := sketchAtIndex(part, in.SourceIndex)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sketch.copyTo: source: %w", err)
+	}
+	target, err := sketchAtIndex(part, in.TargetIndex)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sketch.copyTo: target: %w", err)
+	}
+	if source == target {
+		return nil, nil, fmt.Errorf("sketch.copyTo: source and target are the same sketch (%d) — use sketch.transform to copy within a sketch", in.SourceIndex)
+	}
+	return source, target, nil
+}
+
+// copySourceEntities resolves the entities to copy: the listed ids, or the whole sketch when
+// none are given.
+func copySourceEntities(source *sketch.Sketch, ids []uint64) ([]sketch.Entity, error) {
+	if len(ids) == 0 {
+		return source.Entities(), nil
+	}
+	out := make([]sketch.Entity, 0, len(ids))
+	for _, id := range ids {
+		e, ok := source.EntityByID(sketch.ID(id))
+		if !ok {
+			return nil, fmt.Errorf("sketch.copyTo: entity %d is not in the source sketch", id)
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// copyOffset turns the optional [x, y] position into a translation vector (zero when absent).
+func copyOffset(pos []float64) (math.Vector2, error) {
+	if len(pos) == 0 {
+		return math.V2(0, 0), nil
+	}
+	if len(pos) != 2 {
+		return math.Vector2{}, fmt.Errorf("sketch.copyTo: position must be [x, y], got %d values", len(pos))
+	}
+	return math.V2(math.Scalar(pos[0]), math.Scalar(pos[1])), nil
+}

--- a/addin/router/sketch_copy_test.go
+++ b/addin/router/sketch_copy_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSketchCopyToCopiesGeometry (#151): copying a sketch's contents to another sketch
+// re-instantiates its geometry and the profile closes in the target.
+func TestSketchCopyToCopiesGeometry(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{}) // sketch 1, empty
+
+	var srcEnts wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &srcEnts)
+
+	var res wire.CopySketchResult
+	call(t, r, s, "sketch.copyTo", `{"sourceIndex":0,"targetIndex":1}`, &res)
+	if res.Count != len(srcEnts.Entities) || res.Count == 0 {
+		t.Errorf("copyTo created %d entities, want %d (every source entity)", res.Count, len(srcEnts.Entities))
+	}
+
+	var prof wire.ListProfilesResult
+	call(t, r, s, "sketch.profiles", `{"sketchIndex":1}`, &prof)
+	if len(prof.Profiles) != 1 {
+		t.Errorf("target sketch profiles = %d, want 1 (the copied rectangle closes)", len(prof.Profiles))
+	}
+	// The source is untouched.
+	call(t, r, s, "sketch.profiles", `{"sketchIndex":0}`, &prof)
+	if len(prof.Profiles) != 1 {
+		t.Errorf("source sketch profiles = %d after copy, want 1 (unchanged)", len(prof.Profiles))
+	}
+}
+
+// TestSketchCopyToOffsetAndSubset (#151): a placement offset and an entity-id subset.
+func TestSketchCopyToOffsetAndSubset(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	var line wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,0]]}`, &line)
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[10,0]],"radius":"1 cm"}`, &wire.AddSketchEntityResult{})
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{})
+
+	// Copy only the line, offset by (0,5).
+	args := mustJSON(t, wire.CopySketchArgs{SourceIndex: 0, TargetIndex: 1, EntityIDs: []uint64{line.EntityID}, Position: []float64{0, 5}})
+	var res wire.CopySketchResult
+	call(t, r, s, "sketch.copyTo", args, &res)
+	if res.Count != 1 {
+		t.Errorf("subset copy created = %d, want 1 (just the line)", res.Count)
+	}
+
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":1}`, &ents)
+	if len(ents.Entities) != 1 || ents.Entities[0].Kind != "line" {
+		t.Errorf("target entities = %+v, want one line", ents.Entities)
+	}
+}
+
+// TestSketchCopyToSameSketchFails (#151): copying a sketch onto itself is rejected.
+func TestSketchCopyToSameSketchFails(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	if _, err := r.Handle(s, "sketch.copyTo", []byte(`{"sourceIndex":0,"targetIndex":0}`)); err == nil {
+		t.Error("copyTo onto the same sketch should fail")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.66.0
+	oblikovati.org/api v0.67.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.66.0
+	oblikovati.org/api v0.67.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

The `/source` impl of `sketch.copyTo` (pins api **v0.67.0**) — copy geometry from one 2D sketch into another.

## How

Reuses the cross-sketch clone machinery: `targetSketch.CopyEntities(sourceEntities, offset)` reads the source (read-only) and creates fresh geometry on the target, deduping shared points so a copied rectangle/profile closes. Optional entity-id subset (empty ⇒ whole sketch) and a target-plane placement offset; copying onto the same sketch is rejected (use `sketch.transform`).

**v1 copies geometry only** — external constraints/dimensions are dropped (Inventor `CopyEntitiesTo`); carry-over among the copied set is a follow-up (filed separately).

## Tests

Full + subset + offset copy faithfully re-creates every source entity and the profile closes in the target; the source is untouched; same-sketch rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)