### PR TITLE
feat(events): relay document open/close + model-changed (#148 impl)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -53,6 +53,7 @@ func styleEventType(k app.StyleChangeKind) string {
 func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 	bus := s.Events()
 	subs := subscribeDocuments(s.Workspace().Events(), sink)
+	subs = append(subs, subscribeModelChanges(s.Workspace().Events(), sink)...)
 	subs = append(subs, subscribeSessionUI(bus, sink)...)
 	subs = append(subs, subscribeRepresentations(bus, sink)...)
 	subs = append(subs, subscribeParameters(bus, sink)...)
@@ -131,16 +132,41 @@ func subscribeRepresentations(bus *event.Bus, sink Sink) []event.Subscription {
 func subscribeDocuments(ws *event.Bus, sink Sink) []event.Subscription {
 	return []event.Subscription{
 		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentCreated) event.Outcome {
-			relayClientOperation(sink, e.Document, "created")
-			return relay(sink, wireEvent{Type: "document.created", Document: e.Document.DisplayName(), ID: uint64(e.Document.ID())})
+			return relayDocumentLifecycle(sink, e.Document, wire.EventDocumentCreated, "created")
+		}),
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentOpened) event.Outcome {
+			// DocumentOpened carries only the name (the document object is paged in afterwards).
+			return relay(sink, wireEvent{Type: wire.EventDocumentOpened, Document: e.FullDocumentName})
 		}),
 		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentSave) event.Outcome {
-			relayClientOperation(sink, e.Document, "saved")
-			return relay(sink, wireEvent{Type: "document.saved", Document: e.Document.DisplayName(), ID: uint64(e.Document.ID())})
+			return relayDocumentLifecycle(sink, e.Document, wire.EventDocumentSaved, "saved")
+		}),
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentClose) event.Outcome {
+			return relayDocumentLifecycle(sink, e.Document, wire.EventDocumentClosed, "closed")
 		}),
 		event.Subscribe(ws, event.After, func(_ event.Context, e doc.DocumentActivate) event.Outcome {
-			relayClientOperation(sink, e.Document, "activated")
-			return relay(sink, wireEvent{Type: "document.activated", Document: e.Document.DisplayName(), ID: uint64(e.Document.ID())})
+			return relayDocumentLifecycle(sink, e.Document, wire.EventDocumentActivated, "activated")
+		}),
+	}
+}
+
+// relayDocumentLifecycle forwards one document lifecycle event (and services a flavored
+// document's owner via client.operation).
+func relayDocumentLifecycle(sink Sink, d *doc.Document, eventType, operation string) event.Outcome {
+	relayClientOperation(sink, d, operation)
+	return relay(sink, wireEvent{Type: eventType, Document: d.DisplayName(), ID: uint64(d.ID())})
+}
+
+// subscribeModelChanges relays the committed batch of model changes on a document (#148): the
+// feature/sketch/parameter mutations the engine just applied, so an add-in re-queries it.
+func subscribeModelChanges(ws *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(ws, event.After, func(_ event.Context, e doc.ModelChanged) event.Outcome {
+			name := ""
+			if e.Document != nil {
+				name = e.Document.DisplayName()
+			}
+			return relayJSON(sink, wire.ModelChangedEvent{Type: wire.EventModelChanged, Document: name, Changes: len(e.Changes)})
 		}),
 	}
 }
@@ -237,7 +263,8 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.FileResolutionEventPayload | wire.FileDirtyEventPayload |
 	wire.FileDialogHookPayload | wire.OccurrenceEventPayload |
 	wire.AssemblyFeaturesChangedEvent | wire.ConstraintEventPayload |
-	wire.JointEventPayload | wire.ParameterChangedEvent](sink Sink, ev E) event.Outcome {
+	wire.JointEventPayload | wire.ParameterChangedEvent |
+	wire.ModelChangedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/events/events_148_test.go
+++ b/addin/events/events_148_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/doc"
+)
+
+// TestForwardsDocumentClosedAndModelChanged (#148): closing a document and committing a model
+// change both reach the add-in sink as document.closed and model.changed.
+func TestForwardsDocumentClosedAndModelChanged(t *testing.T) {
+	s := app.NewSession()
+	var rec recorder
+	Subscribe(s, rec.sink)
+
+	d, err := s.Workspace().Add(doc.Part, "ev148.obk", true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	if err := s.Workspace().NotifyModelChanged(d, doc.ChangeDefinition{}); err != nil {
+		t.Fatalf("notify model changed: %v", err)
+	}
+	if err := s.Workspace().Close(d, true); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	got := rec.types()
+	if !has(got, "model.changed") {
+		t.Errorf("missing model.changed in %v", got)
+	}
+	if !has(got, "document.closed") {
+		t.Errorf("missing document.closed in %v", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.67.0
+	oblikovati.org/api v0.68.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.67.0
+	oblikovati.org/api v0.68.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

The `/source` relay for #148 (pins api **v0.68.0**) — bridge internal bus events that already fire but weren't exposed to add-ins.

## Relays

- `subscribeDocuments` now forwards **document.opened** (`doc.DocumentOpened`) and **document.closed** (`doc.DocumentClose`) alongside the existing created/saved/activated — all keyed on the new `wire.EventDocument*` constants (via an extracted `relayDocumentLifecycle`).
- `subscribeModelChanges` forwards `doc.ModelChanged` as **model.changed** (`ModelChangedEvent`) with the committed change count, so an add-in re-queries the affected document.

## Tests

A model-change commit and a document close reach the add-in sink. The API↔relay parity guard confirms every new wire event is relayed.

Granular per-feature / per-sketch events (featureAdded/Edited/Deleted, sketchEditEntered/Exited) need new model-event instrumentation — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)