### PR TITLE
feat(model): highlight sets — named colored emphasis groups (#157 impl)

### DIFF
--- a/addin/router/highlight_sets.go
+++ b/addin/router/highlight_sets.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// Highlight sets (#157): named, colored emphasis groups the viewport outlines without selecting.
+// The state lives on the session (app.HighlightSets); these handlers create/mutate/list it, and
+// the head's viewport overlay resolves each set's refs against the live geometry and draws them.
+
+// registerHighlightSetHandlers wires the model.highlightSets.* methods.
+func (r *Router) registerHighlightSetHandlers() {
+	r.handlers[wire.MethodModelHighlightSetCreate] = createHighlightSet
+	r.handlers[wire.MethodModelHighlightSetDelete] = deleteHighlightSet
+	r.handlers[wire.MethodModelHighlightSetAddItems] = addHighlightItems
+	r.handlers[wire.MethodModelHighlightSetSetColor] = setHighlightSetColor
+	r.handlers[wire.MethodModelHighlightSetList] = listHighlightSets
+}
+
+// createHighlightSet adds a named, colored emphasis group.
+func createHighlightSet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.CreateHighlightSetArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	color, err := parseHexColor(in.Color)
+	if err != nil {
+		return nil, fmt.Errorf("model.highlightSets.create: %w", err)
+	}
+	h, err := s.HighlightSets().Create(in.Name, color)
+	if err != nil {
+		return nil, fmt.Errorf("model.highlightSets.create: %w", err)
+	}
+	return json.Marshal(highlightSetInfo(h))
+}
+
+// addHighlightItems adds references to a named set.
+func addHighlightItems(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.HighlightSetItemsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	h, ok := s.HighlightSets().ByName(in.Name)
+	if !ok {
+		return nil, fmt.Errorf("model.highlightSets.addItems: no highlight set %q", in.Name)
+	}
+	h.AddItems(in.Refs...)
+	return json.Marshal(highlightSetInfo(h))
+}
+
+// setHighlightSetColor re-colours a named set.
+func setHighlightSetColor(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetHighlightSetColorArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	h, ok := s.HighlightSets().ByName(in.Name)
+	if !ok {
+		return nil, fmt.Errorf("model.highlightSets.setColor: no highlight set %q", in.Name)
+	}
+	color, err := parseHexColor(in.Color)
+	if err != nil {
+		return nil, fmt.Errorf("model.highlightSets.setColor: %w", err)
+	}
+	h.SetColor(color)
+	return json.Marshal(highlightSetInfo(h))
+}
+
+// deleteHighlightSet removes a named set.
+func deleteHighlightSet(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.HighlightSetRefArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	if !s.HighlightSets().Delete(in.Name) {
+		return nil, fmt.Errorf("model.highlightSets.delete: no highlight set %q", in.Name)
+	}
+	return json.Marshal(wire.OKResult{OK: true})
+}
+
+// listHighlightSets lists the session's highlight sets.
+func listHighlightSets(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	sets := s.HighlightSets().All()
+	out := make([]wire.HighlightSetInfo, len(sets))
+	for i, h := range sets {
+		out[i] = highlightSetInfo(h)
+	}
+	return json.Marshal(wire.ListHighlightSetsResult{Sets: out})
+}
+
+// highlightSetInfo renders a highlight set's wire summary.
+func highlightSetInfo(h *app.HighlightSet) wire.HighlightSetInfo {
+	return wire.HighlightSetInfo{Name: h.Name(), Color: h.Color().Hex(), Count: h.Count()}
+}
+
+// parseHexColor parses a "#rrggbb" string into a types.Color.
+func parseHexColor(hex string) (types.Color, error) {
+	rgba, err := types.ParseHex(hex)
+	if err != nil {
+		return types.Color{}, fmt.Errorf("color %q: %w", hex, err)
+	}
+	return types.NewColor(uint8(rgba.R*255+0.5), uint8(rgba.G*255+0.5), uint8(rgba.B*255+0.5)), nil
+}

--- a/addin/router/highlight_sets_test.go
+++ b/addin/router/highlight_sets_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestHighlightSetLifecycle (#157): create, add items, recolour, list, delete.
+func TestHighlightSetLifecycle(t *testing.T) {
+	r, s, ref0, ref1 := boxFaceRefs(t)
+
+	var info wire.HighlightSetInfo
+	call(t, r, s, "model.highlightSets.create", `{"name":"guide","color":"#ff0000"}`, &info)
+	if info.Name != "guide" || info.Color != "#ff0000" || info.Count != 0 {
+		t.Fatalf("create = %+v, want guide #ff0000 count 0", info)
+	}
+
+	call(t, r, s, "model.highlightSets.addItems", mustJSON(t, wire.HighlightSetItemsArgs{Name: "guide", Refs: []string{ref0, ref1}}), &info)
+	if info.Count != 2 {
+		t.Errorf("after addItems count = %d, want 2", info.Count)
+	}
+
+	call(t, r, s, "model.highlightSets.setColor", `{"name":"guide","color":"#00ff00"}`, &info)
+	if info.Color != "#00ff00" {
+		t.Errorf("after setColor = %q, want #00ff00", info.Color)
+	}
+
+	var list wire.ListHighlightSetsResult
+	call(t, r, s, "model.highlightSets.list", `{}`, &list)
+	if len(list.Sets) != 1 || list.Sets[0].Count != 2 {
+		t.Errorf("list = %+v, want one set with 2 items", list.Sets)
+	}
+
+	var ok wire.OKResult
+	call(t, r, s, "model.highlightSets.delete", `{"name":"guide"}`, &ok)
+	call(t, r, s, "model.highlightSets.list", `{}`, &list)
+	if len(list.Sets) != 0 {
+		t.Errorf("after delete, list = %+v, want empty", list.Sets)
+	}
+}
+
+// TestHighlightSetCreateDuplicateAndBadColor (#157): a duplicate name and a malformed colour
+// are rejections.
+func TestHighlightSetCreateDuplicateAndBadColor(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "model.highlightSets.create", `{"name":"a","color":"#123456"}`, &wire.HighlightSetInfo{})
+	if _, err := r.Handle(s, "model.highlightSets.create", []byte(`{"name":"a","color":"#123456"}`)); err == nil {
+		t.Error("creating a duplicate-named highlight set should fail")
+	}
+	if _, err := r.Handle(s, "model.highlightSets.create", []byte(`{"name":"b","color":"not-a-color"}`)); err == nil {
+		t.Error("a malformed colour should fail")
+	}
+}
+
+// TestHighlightSetItemsResolveToGeometry (#157): a highlight set's stored references resolve to
+// real selectables against the live bodies — the path the viewport overlay draws.
+func TestHighlightSetItemsResolveToGeometry(t *testing.T) {
+	_, s, ref0, _ := boxFaceRefs(t)
+	if sel, ok := s.ResolveReference(ref0); !ok || sel == nil {
+		t.Errorf("a box face reference did not resolve to a selectable (ok=%v)", ok)
+	}
+	if _, ok := s.ResolveReference("face/ZZZZ"); ok {
+		t.Error("a bogus reference resolved unexpectedly")
+	}
+}

--- a/addin/router/model_select.go
+++ b/addin/router/model_select.go
@@ -11,7 +11,6 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/event"
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/model/feature"
 )
 
 // Selection mutation (#157): make the read-only selection writable. References are the face/vertex
@@ -91,21 +90,7 @@ func activeBodies(s *app.Session, method string) ([]*topo.Body, error) {
 // Edges/work-features are not round-trippable through model.selection yet (it reports no ref for
 // them), so they are not resolved here.
 func resolveSelectionRef(bodies []*topo.Body, ref string) (app.Selectable, bool) {
-	if key, ok := feature.FaceRefKey(feature.WorkRef(ref)); ok {
-		for _, b := range bodies {
-			if f, found := b.FindFaceByKey(key); found {
-				return app.FaceHandle{Face: f, Body: b}, true
-			}
-		}
-	}
-	if key, ok := feature.VertexRefKey(feature.WorkRef(ref)); ok {
-		for _, b := range bodies {
-			if v, found := b.FindVertexByKey(key); found {
-				return app.VertexHandle{Vertex: v}, true
-			}
-		}
-	}
-	return nil, false
+	return app.ResolveRefOnBodies(bodies, ref)
 }
 
 // announceSelection emits the selection-changed event (relayed to add-ins, #148) and returns the

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -74,6 +74,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAttributeHandlers()
 	r.registerSelectionMutationHandlers()
 	r.registerSketchReferenceKeyHandlers()
+	r.registerHighlightSetHandlers()
 	r.registerDrawingHandlers()
 	r.registerDrawingStyleHandlers()
 	r.registerDrawingViewHandlers()

--- a/app/highlight_set.go
+++ b/app/highlight_set.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Highlight sets (#157): named, colored emphasis groups — entity references (the face/vertex
+// key strings model.referenceKeys/model.selection report) the viewport outlines in the set's
+// colour WITHOUT selecting them, so an add-in can guide the user (Inventor HighlightSet). The
+// session holds the sets; the viewport resolves and draws them each frame, so they follow the
+// geometry across recomputes (a lost reference simply isn't drawn).
+
+// HighlightSet is one named, colored emphasis group.
+type HighlightSet struct {
+	name  string
+	color types.Color
+	refs  []string
+}
+
+// Name returns the set's name; Color its emphasis colour; Refs its current references.
+func (h *HighlightSet) Name() string           { return h.name }
+func (h *HighlightSet) Color() types.Color     { return h.color }
+func (h *HighlightSet) Refs() []string         { return append([]string(nil), h.refs...) }
+func (h *HighlightSet) Count() int             { return len(h.refs) }
+func (h *HighlightSet) SetColor(c types.Color) { h.color = c }
+
+// AddItems appends reference strings, ignoring blanks and duplicates.
+func (h *HighlightSet) AddItems(refs ...string) {
+	for _, r := range refs {
+		if r != "" && !containsRef(h.refs, r) {
+			h.refs = append(h.refs, r)
+		}
+	}
+}
+
+// HighlightSets is the session's ordered registry of highlight sets.
+type HighlightSets struct {
+	items  []*HighlightSet
+	byName map[string]*HighlightSet
+}
+
+// NewHighlightSets returns an empty registry.
+func NewHighlightSets() *HighlightSets {
+	return &HighlightSets{byName: map[string]*HighlightSet{}}
+}
+
+// Create adds a new named set, erroring on an empty or already-used name.
+func (hs *HighlightSets) Create(name string, color types.Color) (*HighlightSet, error) {
+	if name == "" {
+		return nil, fmt.Errorf("highlight set: name must not be empty")
+	}
+	if _, ok := hs.byName[name]; ok {
+		return nil, fmt.Errorf("highlight set %q already exists", name)
+	}
+	h := &HighlightSet{name: name, color: color}
+	hs.items = append(hs.items, h)
+	hs.byName[name] = h
+	return h, nil
+}
+
+// ByName returns the named set, or false.
+func (hs *HighlightSets) ByName(name string) (*HighlightSet, bool) {
+	h, ok := hs.byName[name]
+	return h, ok
+}
+
+// Delete removes the named set, reporting whether it existed.
+func (hs *HighlightSets) Delete(name string) bool {
+	if _, ok := hs.byName[name]; !ok {
+		return false
+	}
+	delete(hs.byName, name)
+	for i, h := range hs.items {
+		if h.name == name {
+			hs.items = append(hs.items[:i], hs.items[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+// All returns the sets in creation order.
+func (hs *HighlightSets) All() []*HighlightSet { return append([]*HighlightSet(nil), hs.items...) }
+
+// HighlightSets returns the session's highlight-set registry (lazily created).
+func (s *Session) HighlightSets() *HighlightSets {
+	if s.highlightSets == nil {
+		s.highlightSets = NewHighlightSets()
+	}
+	return s.highlightSets
+}
+
+// ResolveReference resolves a face/vertex reference string (from model.referenceKeys /
+// model.selection) to a selectable on the active part's bodies, or false when it does not bind.
+// Shared by selection mutation (#157) and highlight-set rendering.
+func (s *Session) ResolveReference(ref string) (Selectable, bool) {
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, false
+	}
+	part, ok := d.Content().(*compdef.PartComponentDefinition)
+	if !ok {
+		return nil, false
+	}
+	return ResolveRefOnBodies(part.SurfaceBodies().All(), ref)
+}
+
+// ResolveRefOnBodies resolves a face/vertex reference string against the given bodies. Edges and
+// work features are not round-trippable through model.selection yet, so they are not resolved.
+func ResolveRefOnBodies(bodies []*topo.Body, ref string) (Selectable, bool) {
+	if key, ok := feature.FaceRefKey(feature.WorkRef(ref)); ok {
+		for _, b := range bodies {
+			if f, found := b.FindFaceByKey(key); found {
+				return FaceHandle{Face: f, Body: b}, true
+			}
+		}
+	}
+	if key, ok := feature.VertexRefKey(feature.WorkRef(ref)); ok {
+		for _, b := range bodies {
+			if v, found := b.FindVertexByKey(key); found {
+				return VertexHandle{Vertex: v}, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func containsRef(refs []string, r string) bool {
+	for _, x := range refs {
+		if x == r {
+			return true
+		}
+	}
+	return false
+}

--- a/app/session.go
+++ b/app/session.go
@@ -50,6 +50,7 @@ type Session struct {
 	prefsStore           userprefs.Store        // persists prefs to the user config dir (nil ⇒ in-session only)
 	bus                  *event.Bus
 	selection            *Selection
+	highlightSets        *HighlightSets // named, colored emphasis groups for add-ins (#157)
 	tool                 *ToolInstance
 	picker               Picker
 	regionPicker         RegionPicker      // resolves a box-select rectangle (nil ⇒ box-select disabled)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
-	oblikovati.org/api v0.68.0
+	oblikovati.org/api v0.69.0
 )
 
 require golang.org/x/text v0.22.0 // indirect

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.68.0
+	oblikovati.org/api v0.69.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -537,6 +537,7 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	list.Items = append(list.Items, threadOverlay(s)...)
 	list.Items = append(list.Items, toolHoverHighlight(s)...)
 	list.Items = append(list.Items, toolSelectedHighlight(s)...)
+	list.Items = append(list.Items, highlightSetItems(s)...)
 	list.Items = append(list.Items, revolveCenterlineHighlight(s)...)
 	list.Items = append(list.Items, activeToolPreviewItems(s)...)
 	return list

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -49,6 +49,23 @@ func edgeWire(edges []*topo.Edge, color [4]float32) []renderer.DrawItem {
 	return []renderer.DrawItem{lineItem(acc, color)}
 }
 
+// highlightSetItems draws the session's add-in highlight sets (#157): each set's references are
+// resolved against the live geometry and outlined in the set's colour — a non-selecting emphasis
+// the renderer reads every frame, so the highlight follows edits (a lost reference isn't drawn).
+func highlightSetItems(s *app.Session) []renderer.DrawItem {
+	var items []renderer.DrawItem
+	for _, set := range s.HighlightSets().All() {
+		rgba := set.Color().Rgba()
+		color := [4]float32{rgba.R, rgba.G, rgba.B, rgba.A}
+		for _, ref := range set.Refs() {
+			if sel, ok := s.ResolveReference(ref); ok {
+				items = append(items, drawSelectable(sel, color)...)
+			}
+		}
+	}
+	return items
+}
+
 // toolHoverHighlight outlines the selectable under the cursor that the active tool would pick,
 // in the candidate colour — the same hover feedback for every tool.
 func toolHoverHighlight(s *app.Session) []renderer.DrawItem {


### PR DESCRIPTION
## What

The `/source` impl completing #157 (pins api **v0.69.0**) — **highlight sets**: named, colored emphasis the viewport outlines *without* selecting, so an add-in can guide the user (Inventor `HighlightSet`). The selection-mutation half shipped earlier this milestone.

## How

- **app** — `HighlightSet`/`HighlightSets` session state; `Session.ResolveReference` resolves a face/vertex ref string to a selectable against the live bodies. The router's `resolveSelectionRef` (#157 selection mutation) now delegates to the shared `app.ResolveRefOnBodies` (DRY).
- **router** — `model.highlightSets.create`/`delete`/`addItems`/`setColor`/`list` (`#rrggbb` colours).
- **head** — `highlightSetItems` draws each set's resolved refs in its colour every frame, so the emphasis follows edits (a lost reference simply isn't drawn).

## Verification

Headless tests: lifecycle (create/add/recolour/list/delete), duplicate-name + bad-colour rejection, and that stored refs resolve to real geometry.

**Live-confirmed** in the running Vulkan app: a magenta highlight set on two box faces renders their outlines in magenta over the viewport (captured via a throwaway driver on the production `DrawChrome` path).

![highlight set rendered](magenta outline on two box faces — confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)