### PR TITLE
fix(model): resolve both reference-key forms for highlight/selection (#157)

### DIFF
--- a/addin/router/highlight_sets_test.go
+++ b/addin/router/highlight_sets_test.go
@@ -56,11 +56,22 @@ func TestHighlightSetCreateDuplicateAndBadColor(t *testing.T) {
 }
 
 // TestHighlightSetItemsResolveToGeometry (#157): a highlight set's stored references resolve to
-// real selectables against the live bodies — the path the viewport overlay draws.
+// real selectables against the live bodies — the path the viewport overlay draws. Both ref forms
+// an add-in encounters must work: the "face/…" form model.selection reports AND the raw key
+// form model.referenceKeys reports (the documented highlight-set input), including edges.
 func TestHighlightSetItemsResolveToGeometry(t *testing.T) {
-	_, s, ref0, _ := boxFaceRefs(t)
+	r, s, ref0, _ := boxFaceRefs(t)
 	if sel, ok := s.ResolveReference(ref0); !ok || sel == nil {
-		t.Errorf("a box face reference did not resolve to a selectable (ok=%v)", ok)
+		t.Errorf("the selection-form face reference did not resolve (ok=%v)", ok)
+	}
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	if sel, ok := s.ResolveReference(keys.Bodies[0].Faces[0].Key); !ok || sel == nil {
+		t.Errorf("the raw model.referenceKeys face key did not resolve (ok=%v)", ok)
+	}
+	if sel, ok := s.ResolveReference(keys.Bodies[0].Edges[0].Key); !ok || sel == nil {
+		t.Errorf("the raw model.referenceKeys edge key did not resolve (ok=%v)", ok)
 	}
 	if _, ok := s.ResolveReference("face/ZZZZ"); ok {
 		t.Error("a bogus reference resolved unexpectedly")

--- a/app/highlight_set.go
+++ b/app/highlight_set.go
@@ -112,21 +112,55 @@ func (s *Session) ResolveReference(ref string) (Selectable, bool) {
 	return ResolveRefOnBodies(part.SurfaceBodies().All(), ref)
 }
 
-// ResolveRefOnBodies resolves a face/vertex reference string against the given bodies. Edges and
-// work features are not round-trippable through model.selection yet, so they are not resolved.
+// ResolveRefOnBodies resolves a topology reference string against the given bodies, accepting
+// BOTH ref forms an add-in encounters: the "face/…" / "vertex/…" form model.selection reports
+// (decoded via feature.*RefKey) and the RAW reference-key bytes model.referenceKeys reports.
+// The raw form additionally resolves edges (which the selection form does not round-trip).
 func ResolveRefOnBodies(bodies []*topo.Body, ref string) (Selectable, bool) {
 	if key, ok := feature.FaceRefKey(feature.WorkRef(ref)); ok {
-		for _, b := range bodies {
-			if f, found := b.FindFaceByKey(key); found {
-				return FaceHandle{Face: f, Body: b}, true
-			}
+		if sel, found := findFace(bodies, key); found {
+			return sel, true
 		}
 	}
 	if key, ok := feature.VertexRefKey(feature.WorkRef(ref)); ok {
-		for _, b := range bodies {
-			if v, found := b.FindVertexByKey(key); found {
-				return VertexHandle{Vertex: v}, true
-			}
+		if sel, found := findVertex(bodies, key); found {
+			return sel, true
+		}
+	}
+	// Raw reference-key form (model.referenceKeys): try face, edge, then vertex.
+	raw := []byte(ref)
+	if sel, found := findFace(bodies, raw); found {
+		return sel, true
+	}
+	if sel, found := findEdge(bodies, raw); found {
+		return sel, true
+	}
+	return findVertex(bodies, raw)
+}
+
+// findFace/findEdge/findVertex bind a raw reference key to a selectable across the bodies.
+func findFace(bodies []*topo.Body, key []byte) (Selectable, bool) {
+	for _, b := range bodies {
+		if f, ok := b.FindFaceByKey(key); ok {
+			return FaceHandle{Face: f, Body: b}, true
+		}
+	}
+	return nil, false
+}
+
+func findEdge(bodies []*topo.Body, key []byte) (Selectable, bool) {
+	for _, b := range bodies {
+		if e, ok := b.FindEdgeByKey(key); ok {
+			return EdgeHandle{Edge: e}, true
+		}
+	}
+	return nil, false
+}
+
+func findVertex(bodies []*topo.Body, key []byte) (Selectable, bool) {
+	for _, b := range bodies {
+		if v, ok := b.FindVertexByKey(key); ok {
+			return VertexHandle{Vertex: v}, true
 		}
 	}
 	return nil, false


### PR DESCRIPTION
## What

A correctness fix found right after #157 landed: `ResolveRefOnBodies` only accepted the `"face/…"`/`"vertex/…"` form `model.selection` reports — so a highlight set built from the keys `model.referenceKeys` reports (**the documented input**) resolved to nothing and drew nothing.

## Fix

Accept **both** ref forms an add-in encounters:
- the `feature.*RefKey`-encoded form (`model.selection`),
- the **raw reference-key bytes** (`model.referenceKeys`) — and resolve **edges** too (only the raw form round-trips them).

Purely additive (more refs resolve, no regression). This makes the documented highlight-set flow work and incidentally lets `model.select` accept raw reference keys. /source-only.

## Test

A regression test asserts the selection-form face, the raw `model.referenceKeys` face, and a raw edge all resolve; a bogus ref still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)