### PR TITLE
Maintainability: remove duplicated empty tool hooks (S1186)

### DIFF
--- a/addin/router/feature_lifecycle.go
+++ b/addin/router/feature_lifecycle.go
@@ -120,7 +120,7 @@ func planAndApplyFeatureEdits(part *compdef.PartComponentDefinition, f *feature.
 	if len(in.Scalars) == 0 && len(in.Repick) == 0 {
 		return fmt.Errorf("features.edit: feature %d has no scalar or repick edits to apply", in.ID)
 	}
-	applyScalars := func() {}
+	applyScalars := func() { /* default: no scalar edits to apply */ }
 	if len(in.Scalars) > 0 {
 		apply, err := parseScalarEdits(part, f, in.Scalars)
 		if err != nil {

--- a/addin/router/feature_repick.go
+++ b/addin/router/feature_repick.go
@@ -63,7 +63,7 @@ type plannedRepick struct {
 // feature health after recompute, exactly as it does for features.add (parametric, not edit-time).
 func planFeatureRepicks(part *compdef.PartComponentDefinition, f *feature.PartFeature, repicks []wire.FeatureRepick) (func(), error) {
 	if len(repicks) == 0 {
-		return func() {}, nil
+		return func() { /* nothing to re-pick */ }, nil
 	}
 	re, ok := f.Definition().(feature.ReferenceEditable)
 	if !ok {

--- a/app/add_sheet_tool.go
+++ b/app/add_sheet_tool.go
@@ -41,6 +41,7 @@ func sheetSizeIndexOf(s types.SheetSize) int {
 // the user chooses a standard size or a custom width×height and an orientation, then OK
 // adds the sheet and makes it active.
 type AddSheetTool struct {
+	dialogTool
 	sizeIndex   int
 	orientation int // index into {portrait, landscape}
 	widthMM     float64
@@ -57,11 +58,8 @@ func NewAddSheetTool() *AddSheetTool {
 	}
 }
 
-func (t *AddSheetTool) Name() string              { return "New Sheet" }
-func (t *AddSheetTool) Start(*Session)            {}
-func (t *AddSheetTool) Pick(*Session, Selectable) {}
-func (t *AddSheetTool) CanCommit() bool           { return true }
-func (t *AddSheetTool) Cancel(*Session)           {}
+func (t *AddSheetTool) Name() string    { return "New Sheet" }
+func (t *AddSheetTool) CanCommit() bool { return true }
 
 // Commit adds the configured sheet to the active drawing.
 func (t *AddSheetTool) Commit(s *Session) error {

--- a/app/assembly_feature_edit.go
+++ b/app/assembly_feature_edit.go
@@ -17,6 +17,7 @@ import (
 
 // AssemblyFeatureEditTool edits one committed assembly feature's scalar parameters in place.
 type AssemblyFeatureEditTool struct {
+	dialogTool
 	feature *compdef.AssemblyFeature
 	params  []feature.EditableParam
 	orig    []float64 // values captured at open, restored on Cancel
@@ -39,11 +40,9 @@ func (t *AssemblyFeatureEditTool) Name() string { return "Edit " + t.feature.Nam
 
 // Start is a no-op: the editable parameters were snapshotted in the constructor, so the dialog
 // can open straight away.
-func (t *AssemblyFeatureEditTool) Start(*Session) {}
 
 // Pick is unused — an assembly feature edit changes scalar parameters, not geometric references
 // (re-picking participant edges/faces is a later refinement).
-func (t *AssemblyFeatureEditTool) Pick(*Session, Selectable) {}
 
 // CanCommit reports the feature has editable parameters to apply.
 func (t *AssemblyFeatureEditTool) CanCommit() bool { return len(t.params) > 0 }

--- a/app/assembly_machining_tools.go
+++ b/app/assembly_machining_tools.go
@@ -105,6 +105,7 @@ func (t *AssemblyRevolveTool) Params() ToolParams {
 // AssemblyHoleTool drills a parametric cylindrical bore (centre, axis, diameter, depth) through
 // every participant — a through-feature placed by coordinate, no sketch needed.
 type AssemblyHoleTool struct {
+	dialogTool
 	cx, cy, cz float64
 	axisIndex  int // index into signedAxes (the drill direction)
 	diameter   float64
@@ -122,10 +123,7 @@ func (t *AssemblyHoleTool) Prompt(*Session) string {
 
 // The hole tool takes only numeric input (centre, axis, diameter, depth), so it has no
 // selection lifecycle: nothing to set up, pick, or undo on cancel.
-func (t *AssemblyHoleTool) Start(*Session)            {}
-func (t *AssemblyHoleTool) Pick(*Session, Selectable) {}
-func (t *AssemblyHoleTool) Cancel(*Session)           {}
-func (t *AssemblyHoleTool) CanCommit() bool           { return t.diameter > 0 && t.depth > 0 }
+func (t *AssemblyHoleTool) CanCommit() bool { return t.diameter > 0 && t.depth > 0 }
 
 func (t *AssemblyHoleTool) Commit(s *Session) error {
 	asm, err := activeAssembly(s)

--- a/app/assembly_sketch_features.go
+++ b/app/assembly_sketch_features.go
@@ -27,6 +27,7 @@ var (
 // AssemblyExtrudeTool extrudes a picked assembly-sketch profile into a machining feature applied to
 // every participant.
 type AssemblyExtrudeTool struct {
+	dialogTool
 	profile   *ProfileHandle
 	distance  float64
 	operation int // index into assemblyExtrudeOps
@@ -38,7 +39,6 @@ func (t *AssemblyExtrudeTool) Name() string        { return "Extrude" }
 func (t *AssemblyExtrudeTool) Prompt(*Session) string {
 	return "Pick a sketch profile, set the distance and operation, then OK."
 }
-func (t *AssemblyExtrudeTool) Start(*Session) {}
 
 // Pick collects the profile region clicked in the viewport.
 func (t *AssemblyExtrudeTool) Pick(_ *Session, sel Selectable) {

--- a/app/core_cavity_tool.go
+++ b/app/core_cavity_tool.go
@@ -16,6 +16,7 @@ var partingAxisNames = []string{"Z", "X", "Y"}
 // parting (M10-F04, #701) — parameter-only: choose the parting axis, position and the
 // shrinkage allowance in the generic tool dialog, then OK.
 type CoreCavityTool struct {
+	dialogTool
 	axis      feature.PartingAxis
 	position  float64
 	shrinkage float64
@@ -34,8 +35,6 @@ func (t *CoreCavityTool) Prompt(*Session) string {
 }
 
 // Start/Pick implement [Tool] (parameter-only — the running block is the input).
-func (t *CoreCavityTool) Start(*Session)            {}
-func (t *CoreCavityTool) Pick(*Session, Selectable) {}
 
 // Params exposes the parting inputs for the generic property dialog.
 func (t *CoreCavityTool) Params() ToolParams {
@@ -92,7 +91,6 @@ func (t *CoreCavityTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel implements [Tool] (nothing to restore).
-func (t *CoreCavityTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *CoreCavityTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/derive_tools.go
+++ b/app/derive_tools.go
@@ -15,6 +15,7 @@ import (
 
 // deriveSourceTool collects the source-assembly choice shared by Derive and Shrinkwrap.
 type deriveSourceTool struct {
+	dialogTool
 	sources  []*doc.Document // open assemblies, captured on Start
 	selected int             // index into sources
 }
@@ -23,8 +24,6 @@ type deriveSourceTool struct {
 func (t *deriveSourceTool) Start(s *Session) { t.sources = s.OpenAssemblies() }
 
 // Pick is unused — the source is chosen from the dialog, not by a viewport pick.
-func (t *deriveSourceTool) Pick(*Session, Selectable) {}
-func (t *deriveSourceTool) Cancel(*Session)           {}
 
 // source returns the chosen source document, or nil when no assembly is open.
 func (t *deriveSourceTool) source() *doc.Document {

--- a/app/dialog_tool.go
+++ b/app/dialog_tool.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// dialogTool supplies the no-op viewport-interaction hooks (Start/Pick/Cancel) shared by
+// dialog-driven tools — tools that gather all their input from the Params dialog, so they
+// capture no activation state, pick nothing in the 3D view, and keep nothing to discard on
+// cancel. Embed it and override only the hooks a tool actually needs (commonly Start, to
+// capture the base-view list). It mirrors the no-op hooks derivedViewTool already provides.
+type dialogTool struct{}
+
+func (dialogTool) Start(*Session) {
+	// no-op: a dialog-driven tool captures no state when it is activated
+}
+
+func (dialogTool) Pick(*Session, Selectable) {
+	// no-op: a dialog-driven tool takes its input from the Params dialog, not viewport picks
+}
+
+func (dialogTool) Cancel(*Session) {
+	// no-op: a dialog-driven tool keeps no in-progress state to discard
+}

--- a/app/drawing_annotation_tools.go
+++ b/app/drawing_annotation_tools.go
@@ -18,6 +18,7 @@ import (
 
 // CoGMarkerTool places a centre-of-gravity marker on a chosen base view.
 type CoGMarkerTool struct {
+	dialogTool
 	views     []string
 	viewIndex int
 }
@@ -25,11 +26,9 @@ type CoGMarkerTool struct {
 // NewCoGMarkerTool creates the tool; its view list is captured on Start.
 func NewCoGMarkerTool() *CoGMarkerTool { return &CoGMarkerTool{} }
 
-func (t *CoGMarkerTool) Name() string              { return "Center of Gravity" }
-func (t *CoGMarkerTool) Start(s *Session)          { t.views = baseViewNames(s) }
-func (t *CoGMarkerTool) Pick(*Session, Selectable) {}
-func (t *CoGMarkerTool) CanCommit() bool           { return len(t.views) > 0 }
-func (t *CoGMarkerTool) Cancel(*Session)           {}
+func (t *CoGMarkerTool) Name() string     { return "Center of Gravity" }
+func (t *CoGMarkerTool) Start(s *Session) { t.views = baseViewNames(s) }
+func (t *CoGMarkerTool) CanCommit() bool  { return len(t.views) > 0 }
 
 // Commit adds the marker on the selected view.
 func (t *CoGMarkerTool) Commit(s *Session) error {
@@ -57,6 +56,7 @@ func (t *CoGMarkerTool) Params() ToolParams {
 // CenterMarkTool places a centre mark (crosshair) at every circular edge's centre in a chosen base
 // view — the auto centre-mark-all-holes action.
 type CenterMarkTool struct {
+	dialogTool
 	views     []string
 	viewIndex int
 }
@@ -64,11 +64,9 @@ type CenterMarkTool struct {
 // NewCenterMarkTool creates the tool; its view list is captured on Start.
 func NewCenterMarkTool() *CenterMarkTool { return &CenterMarkTool{} }
 
-func (t *CenterMarkTool) Name() string              { return "Center Mark" }
-func (t *CenterMarkTool) Start(s *Session)          { t.views = baseViewNames(s) }
-func (t *CenterMarkTool) Pick(*Session, Selectable) {}
-func (t *CenterMarkTool) CanCommit() bool           { return len(t.views) > 0 }
-func (t *CenterMarkTool) Cancel(*Session)           {}
+func (t *CenterMarkTool) Name() string     { return "Center Mark" }
+func (t *CenterMarkTool) Start(s *Session) { t.views = baseViewNames(s) }
+func (t *CenterMarkTool) CanCommit() bool  { return len(t.views) > 0 }
 
 // Commit centre-marks every circular edge in the selected view.
 func (t *CenterMarkTool) Commit(s *Session) error {
@@ -96,6 +94,7 @@ func (t *CenterMarkTool) Params() ToolParams {
 // CenterlineTool adds the horizontal+vertical dash-dot symmetry centerlines through a chosen base
 // view's centre.
 type CenterlineTool struct {
+	dialogTool
 	views     []string
 	viewIndex int
 }
@@ -103,11 +102,9 @@ type CenterlineTool struct {
 // NewCenterlineTool creates the tool; its view list is captured on Start.
 func NewCenterlineTool() *CenterlineTool { return &CenterlineTool{} }
 
-func (t *CenterlineTool) Name() string              { return "Centerline" }
-func (t *CenterlineTool) Start(s *Session)          { t.views = baseViewNames(s) }
-func (t *CenterlineTool) Pick(*Session, Selectable) {}
-func (t *CenterlineTool) CanCommit() bool           { return len(t.views) > 0 }
-func (t *CenterlineTool) Cancel(*Session)           {}
+func (t *CenterlineTool) Name() string     { return "Centerline" }
+func (t *CenterlineTool) Start(s *Session) { t.views = baseViewNames(s) }
+func (t *CenterlineTool) CanCommit() bool  { return len(t.views) > 0 }
 
 // Commit adds the centerlines on the selected view.
 func (t *CenterlineTool) Commit(s *Session) error {
@@ -150,6 +147,7 @@ var fcfCharacteristics = []struct {
 // FeatureControlFrameTool drops a GD&T feature control frame at the cursor with a chosen
 // characteristic, tolerance value and comma-separated datum references.
 type FeatureControlFrameTool struct {
+	dialogTool
 	charIndex        int
 	tolerance        string
 	datums           string
@@ -162,10 +160,7 @@ func NewFeatureControlFrameTool() *FeatureControlFrameTool {
 }
 
 func (t *FeatureControlFrameTool) Name() string              { return "Feature Control Frame" }
-func (t *FeatureControlFrameTool) Start(*Session)            {}
-func (t *FeatureControlFrameTool) Pick(*Session, Selectable) {}
 func (t *FeatureControlFrameTool) CanCommit() bool           { return t.tolerance != "" }
-func (t *FeatureControlFrameTool) Cancel(*Session)           {}
 func (t *FeatureControlFrameTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the frame at the placed point.
@@ -212,6 +207,7 @@ func splitDatums(s string) []string {
 // RevisionTableTool drops a revision table seeded with one revision row (revision/date/description)
 // at the cursor; the API/bridge can place multi-row tables.
 type RevisionTableTool struct {
+	dialogTool
 	revision, date, description string
 	centerX, centerY            float64
 }
@@ -222,10 +218,7 @@ func NewRevisionTableTool() *RevisionTableTool {
 }
 
 func (t *RevisionTableTool) Name() string              { return "Revision Table" }
-func (t *RevisionTableTool) Start(*Session)            {}
-func (t *RevisionTableTool) Pick(*Session, Selectable) {}
 func (t *RevisionTableTool) CanCommit() bool           { return t.revision != "" }
-func (t *RevisionTableTool) Cancel(*Session)           {}
 func (t *RevisionTableTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the one-row revision table at the placed point.
@@ -253,6 +246,7 @@ func (t *RevisionTableTool) Params() ToolParams {
 
 // RevisionTagTool drops a revision tag (a triangle holding a revision letter) at the cursor.
 type RevisionTagTool struct {
+	dialogTool
 	revision         string
 	centerX, centerY float64
 }
@@ -263,10 +257,7 @@ func NewRevisionTagTool() *RevisionTagTool {
 }
 
 func (t *RevisionTagTool) Name() string              { return "Revision Tag" }
-func (t *RevisionTagTool) Start(*Session)            {}
-func (t *RevisionTagTool) Pick(*Session, Selectable) {}
 func (t *RevisionTagTool) CanCommit() bool           { return t.revision != "" }
-func (t *RevisionTagTool) Cancel(*Session)           {}
 func (t *RevisionTagTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the revision tag at the placed point.
@@ -296,6 +287,7 @@ var holeNoteQuantities = []types.HoleNoteQuantity{types.HoleNotePerHole, types.H
 // re-resolves with the model; the Quantity option groups same-diameter holes into one callout, and
 // the Format option overrides the callout text ({d} = diameter, {n} = count).
 type HoleNotesTool struct {
+	dialogTool
 	views         []string
 	viewIndex     int
 	quantityIndex int
@@ -305,11 +297,9 @@ type HoleNotesTool struct {
 // NewHoleNotesTool creates the tool; its base-view list is captured on Start.
 func NewHoleNotesTool() *HoleNotesTool { return &HoleNotesTool{} }
 
-func (t *HoleNotesTool) Name() string              { return "Hole Notes" }
-func (t *HoleNotesTool) Start(s *Session)          { t.views = baseViewNames(s) }
-func (t *HoleNotesTool) Pick(*Session, Selectable) {}
-func (t *HoleNotesTool) CanCommit() bool           { return len(t.views) > 0 }
-func (t *HoleNotesTool) Cancel(*Session)           {}
+func (t *HoleNotesTool) Name() string     { return "Hole Notes" }
+func (t *HoleNotesTool) Start(s *Session) { t.views = baseViewNames(s) }
+func (t *HoleNotesTool) CanCommit() bool  { return len(t.views) > 0 }
 
 // Commit annotates every hole in the selected view with a diameter callout.
 func (t *HoleNotesTool) Commit(s *Session) error {
@@ -343,6 +333,7 @@ func (t *HoleNotesTool) Params() ToolParams {
 
 // NoteTool drops a free text note at the cursor, with an optional leader to a point.
 type NoteTool struct {
+	dialogTool
 	text             string
 	leaderX, leaderY float64
 	centerX, centerY float64
@@ -352,10 +343,7 @@ type NoteTool struct {
 func NewNoteTool() *NoteTool { return &NoteTool{text: "NOTE", centerX: 150, centerY: 150} }
 
 func (t *NoteTool) Name() string              { return "Note" }
-func (t *NoteTool) Start(*Session)            {}
-func (t *NoteTool) Pick(*Session, Selectable) {}
 func (t *NoteTool) CanCommit() bool           { return t.text != "" }
-func (t *NoteTool) Cancel(*Session)           {}
 func (t *NoteTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the note (with its optional leader) at the placed point.
@@ -385,6 +373,7 @@ func (t *NoteTool) Params() ToolParams {
 // CustomTableTool drops a general-purpose table seeded with two columns and one empty row at the
 // cursor; the API/bridge place tables with arbitrary headers and rows.
 type CustomTableTool struct {
+	dialogTool
 	col1, col2       string
 	centerX, centerY float64
 }
@@ -395,10 +384,7 @@ func NewCustomTableTool() *CustomTableTool {
 }
 
 func (t *CustomTableTool) Name() string              { return "Custom Table" }
-func (t *CustomTableTool) Start(*Session)            {}
-func (t *CustomTableTool) Pick(*Session, Selectable) {}
 func (t *CustomTableTool) CanCommit() bool           { return t.col1 != "" }
-func (t *CustomTableTool) Cancel(*Session)           {}
 func (t *CustomTableTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the seeded two-column table at the placed point.
@@ -427,6 +413,7 @@ func (t *CustomTableTool) Params() ToolParams {
 // DatumFeatureTool drops a GD&T datum feature symbol (a lettered box + datum triangle) at the
 // cursor.
 type DatumFeatureTool struct {
+	dialogTool
 	letter           string
 	centerX, centerY float64
 }
@@ -437,10 +424,7 @@ func NewDatumFeatureTool() *DatumFeatureTool {
 }
 
 func (t *DatumFeatureTool) Name() string              { return "Datum Feature" }
-func (t *DatumFeatureTool) Start(*Session)            {}
-func (t *DatumFeatureTool) Pick(*Session, Selectable) {}
 func (t *DatumFeatureTool) CanCommit() bool           { return t.letter != "" }
-func (t *DatumFeatureTool) Cancel(*Session)           {}
 func (t *DatumFeatureTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the datum symbol at the placed point.
@@ -476,6 +460,7 @@ var surfaceVariants = []struct {
 // SurfaceTextureTool drops an ISO 1302 surface texture symbol at the cursor with a roughness value
 // and material-removal variant.
 type SurfaceTextureTool struct {
+	dialogTool
 	roughness        string
 	variantIndex     int
 	centerX, centerY float64
@@ -487,10 +472,7 @@ func NewSurfaceTextureTool() *SurfaceTextureTool {
 }
 
 func (t *SurfaceTextureTool) Name() string              { return "Surface Texture" }
-func (t *SurfaceTextureTool) Start(*Session)            {}
-func (t *SurfaceTextureTool) Pick(*Session, Selectable) {}
 func (t *SurfaceTextureTool) CanCommit() bool           { return true }
-func (t *SurfaceTextureTool) Cancel(*Session)           {}
 func (t *SurfaceTextureTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the surface texture symbol at the placed point.
@@ -522,6 +504,7 @@ func (t *SurfaceTextureTool) Params() ToolParams {
 // PartsListTool drops a parts list table (sourced from the referenced assembly's BOM) at the
 // cursor (the table's top-left corner).
 type PartsListTool struct {
+	dialogTool
 	centerX, centerY float64
 }
 
@@ -529,10 +512,7 @@ type PartsListTool struct {
 func NewPartsListTool() *PartsListTool { return &PartsListTool{centerX: 40, centerY: 260} }
 
 func (t *PartsListTool) Name() string              { return "Parts List" }
-func (t *PartsListTool) Start(*Session)            {}
-func (t *PartsListTool) Pick(*Session, Selectable) {}
 func (t *PartsListTool) CanCommit() bool           { return true }
-func (t *PartsListTool) Cancel(*Session)           {}
 func (t *PartsListTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the parts list at the placed point.
@@ -551,6 +531,7 @@ func (t *PartsListTool) Commit(s *Session) error {
 // BalloonTool drops a balloon (a circled parts-list item number) at the cursor, with an optional
 // leader to a previously-picked point.
 type BalloonTool struct {
+	dialogTool
 	item             int
 	centerX, centerY float64
 	leaderX, leaderY float64
@@ -560,10 +541,7 @@ type BalloonTool struct {
 func NewBalloonTool() *BalloonTool { return &BalloonTool{item: 1, centerX: 150, centerY: 150} }
 
 func (t *BalloonTool) Name() string              { return "Balloon" }
-func (t *BalloonTool) Start(*Session)            {}
-func (t *BalloonTool) Pick(*Session, Selectable) {}
 func (t *BalloonTool) CanCommit() bool           { return t.item > 0 }
-func (t *BalloonTool) Cancel(*Session)           {}
 func (t *BalloonTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the balloon at the placed point.
@@ -593,6 +571,7 @@ func (t *BalloonTool) Params() ToolParams {
 // HoleTableTool drops a hole table for a chosen base view at the cursor (the table's top-left
 // corner), listing the view's circular edges with X/Y from a datum and diameter.
 type HoleTableTool struct {
+	dialogTool
 	views            []string
 	viewIndex        int
 	centerX, centerY float64
@@ -603,9 +582,7 @@ func NewHoleTableTool() *HoleTableTool { return &HoleTableTool{centerX: 250, cen
 
 func (t *HoleTableTool) Name() string              { return "Hole Table" }
 func (t *HoleTableTool) Start(s *Session)          { t.views = baseViewNames(s) }
-func (t *HoleTableTool) Pick(*Session, Selectable) {}
 func (t *HoleTableTool) CanCommit() bool           { return len(t.views) > 0 }
-func (t *HoleTableTool) Cancel(*Session)           {}
 func (t *HoleTableTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops the hole table for the selected view at the placed point.
@@ -633,6 +610,7 @@ func (t *HoleTableTool) Params() ToolParams {
 
 // RevisionCloudTool drops a scalloped revision cloud of a chosen size at the cursor.
 type RevisionCloudTool struct {
+	dialogTool
 	width, height    float64
 	centerX, centerY float64
 	preview          []drawing.DrawingCurve
@@ -644,10 +622,7 @@ func NewRevisionCloudTool() *RevisionCloudTool {
 }
 
 func (t *RevisionCloudTool) Name() string              { return "Revision Cloud" }
-func (t *RevisionCloudTool) Start(*Session)            {}
-func (t *RevisionCloudTool) Pick(*Session, Selectable) {}
 func (t *RevisionCloudTool) CanCommit() bool           { return true }
-func (t *RevisionCloudTool) Cancel(*Session)           {}
 func (t *RevisionCloudTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // PreviewCurves outlines the cloud region (a plain rectangle) at the origin to follow the cursor;

--- a/app/drawing_sketch_tools.go
+++ b/app/drawing_sketch_tools.go
@@ -18,7 +18,10 @@ const (
 )
 
 // SketchRectangleTool drops a new sketch containing a default-sized rectangle at the cursor.
-type SketchRectangleTool struct{ centerX, centerY float64 }
+type SketchRectangleTool struct {
+	dialogTool
+	centerX, centerY float64
+}
 
 // NewSketchRectangleTool creates the tool.
 func NewSketchRectangleTool() *SketchRectangleTool {
@@ -26,10 +29,7 @@ func NewSketchRectangleTool() *SketchRectangleTool {
 }
 
 func (t *SketchRectangleTool) Name() string              { return "Sketch Rectangle" }
-func (t *SketchRectangleTool) Start(*Session)            {}
-func (t *SketchRectangleTool) Pick(*Session, Selectable) {}
 func (t *SketchRectangleTool) CanCommit() bool           { return true }
-func (t *SketchRectangleTool) Cancel(*Session)           {}
 func (t *SketchRectangleTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops a sketch with a rectangle centred on the placed point.
@@ -53,6 +53,7 @@ var hatchPatterns = []types.HatchPattern{types.HatchGeneral, types.HatchCross, t
 
 // HatchRegionTool fills a default-sized rectangular region with a hatch pattern at the cursor.
 type HatchRegionTool struct {
+	dialogTool
 	patternIndex     int
 	centerX, centerY float64
 }
@@ -61,10 +62,7 @@ type HatchRegionTool struct {
 func NewHatchRegionTool() *HatchRegionTool { return &HatchRegionTool{centerX: 150, centerY: 150} }
 
 func (t *HatchRegionTool) Name() string              { return "Hatch Region" }
-func (t *HatchRegionTool) Start(*Session)            {}
-func (t *HatchRegionTool) Pick(*Session, Selectable) {}
 func (t *HatchRegionTool) CanCommit() bool           { return true }
-func (t *HatchRegionTool) Cancel(*Session)           {}
 func (t *HatchRegionTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops a hatch-filled rectangle centred on the placed point.
@@ -90,16 +88,16 @@ func (t *HatchRegionTool) Params() ToolParams {
 }
 
 // SketchCircleTool drops a new sketch containing a default-sized circle at the cursor.
-type SketchCircleTool struct{ centerX, centerY float64 }
+type SketchCircleTool struct {
+	dialogTool
+	centerX, centerY float64
+}
 
 // NewSketchCircleTool creates the tool.
 func NewSketchCircleTool() *SketchCircleTool { return &SketchCircleTool{centerX: 150, centerY: 150} }
 
 func (t *SketchCircleTool) Name() string              { return "Sketch Circle" }
-func (t *SketchCircleTool) Start(*Session)            {}
-func (t *SketchCircleTool) Pick(*Session, Selectable) {}
 func (t *SketchCircleTool) CanCommit() bool           { return true }
-func (t *SketchCircleTool) Cancel(*Session)           {}
 func (t *SketchCircleTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // Commit drops a sketch with a circle centred on the placed point.

--- a/app/drawing_standard_tool.go
+++ b/app/drawing_standard_tool.go
@@ -29,6 +29,7 @@ func draftingStandardIndexOf(std types.DraftingStandard) int {
 // tool: the user picks ISO or ANSI and OK re-points the active style preset, so every
 // annotation re-renders to that standard.
 type DraftingStandardTool struct {
+	dialogTool
 	index int
 }
 
@@ -45,9 +46,7 @@ func (t *DraftingStandardTool) Start(s *Session) {
 	}
 }
 
-func (t *DraftingStandardTool) Pick(*Session, Selectable) {}
-func (t *DraftingStandardTool) CanCommit() bool           { return true }
-func (t *DraftingStandardTool) Cancel(*Session)           {}
+func (t *DraftingStandardTool) CanCommit() bool { return true }
 
 // Commit applies the selected standard to the active drawing.
 func (t *DraftingStandardTool) Commit(s *Session) error {

--- a/app/drawing_view_edit.go
+++ b/app/drawing_view_edit.go
@@ -10,6 +10,7 @@ import "oblikovati.org/model/drawing"
 // view edits orientation/style/scale/centre; a projected view edits direction/centre (its
 // orientation/scale/style follow its base).
 type DrawingViewEditTool struct {
+	dialogTool
 	views     *drawing.DrawingViews
 	view      *drawing.DrawingView
 	projected bool
@@ -33,11 +34,8 @@ func newDrawingViewEditTool(views *drawing.DrawingViews, view *drawing.DrawingVi
 	}
 }
 
-func (t *DrawingViewEditTool) Name() string              { return "Edit View" }
-func (t *DrawingViewEditTool) Start(*Session)            {}
-func (t *DrawingViewEditTool) Pick(*Session, Selectable) {}
-func (t *DrawingViewEditTool) CanCommit() bool           { return true }
-func (t *DrawingViewEditTool) Cancel(*Session)           {}
+func (t *DrawingViewEditTool) Name() string    { return "Edit View" }
+func (t *DrawingViewEditTool) CanCommit() bool { return true }
 
 // Commit writes the edited settings back to the view and re-projects it.
 func (t *DrawingViewEditTool) Commit(s *Session) error {

--- a/app/drawing_view_tools.go
+++ b/app/drawing_view_tools.go
@@ -43,6 +43,7 @@ type DrawingPlacementTool interface {
 // orientation/style/scale in the dialog and clicks the sheet to drop the view; the preview
 // follows the cursor.
 type BaseViewTool struct {
+	dialogTool
 	orientation int
 	style       int
 	scale       float64
@@ -57,11 +58,8 @@ func NewBaseViewTool() *BaseViewTool {
 	return &BaseViewTool{scale: 1, centerX: 150, centerY: 150}
 }
 
-func (t *BaseViewTool) Name() string              { return labelBaseView }
-func (t *BaseViewTool) Start(*Session)            {}
-func (t *BaseViewTool) Pick(*Session, Selectable) {}
-func (t *BaseViewTool) CanCommit() bool           { return true }
-func (t *BaseViewTool) Cancel(*Session)           {}
+func (t *BaseViewTool) Name() string    { return labelBaseView }
+func (t *BaseViewTool) CanCommit() bool { return true }
 
 // SetPlacement records the cursor sheet position the view will be centred on.
 func (t *BaseViewTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
@@ -122,6 +120,7 @@ func (t *BaseViewTool) Params() ToolParams {
 // and the cached cursor-follow preview. The concrete tools embed it and add their own option
 // (direction / fold angle / cut orientation) plus PreviewCurves/Commit/Params.
 type derivedViewTool struct {
+	dialogTool
 	bases      []string
 	baseIndex  int
 	centerX    float64
@@ -131,9 +130,7 @@ type derivedViewTool struct {
 }
 
 // Start captures the base views the derived view can be built from.
-func (t *derivedViewTool) Start(s *Session)          { t.bases = baseViewNames(s) }
-func (t *derivedViewTool) Pick(*Session, Selectable) {}
-func (t *derivedViewTool) Cancel(*Session)           {}
+func (t *derivedViewTool) Start(s *Session) { t.bases = baseViewNames(s) }
 
 // CanCommit requires at least one base view to derive from.
 func (t *derivedViewTool) CanCommit() bool { return len(t.bases) > 0 }
@@ -672,6 +669,7 @@ func (t *BreakoutViewTool) Params() ToolParams {
 // DraftViewTool drops a model-less framed draft view (a container for manual 2D geometry); the
 // frame follows the cursor and a click drops it.
 type DraftViewTool struct {
+	dialogTool
 	width, height    float64
 	centerX, centerY float64
 	preview          []drawing.DrawingCurve
@@ -683,10 +681,7 @@ func NewDraftViewTool() *DraftViewTool {
 }
 
 func (t *DraftViewTool) Name() string              { return "Draft View" }
-func (t *DraftViewTool) Start(*Session)            {}
-func (t *DraftViewTool) Pick(*Session, Selectable) {}
 func (t *DraftViewTool) CanCommit() bool           { return true }
-func (t *DraftViewTool) Cancel(*Session)           {}
 func (t *DraftViewTool) SetPlacement(x, y float64) { t.centerX, t.centerY = x, y }
 
 // PreviewCurves builds the origin-centred frame rectangle to follow the cursor.

--- a/app/feature_extra_tools.go
+++ b/app/feature_extra_tools.go
@@ -100,6 +100,7 @@ func (t *BossTool) AddedFeature() *feature.PartFeature { return t.added }
 
 // HullTool wraps the running solids into their single convex hull — no inputs, just OK.
 type HullTool struct {
+	dialogTool
 	added *feature.PartFeature
 }
 
@@ -115,8 +116,6 @@ func (t *HullTool) Prompt(*Session) string {
 }
 
 // Start/Pick implement [Tool] (no inputs).
-func (t *HullTool) Start(*Session)            {}
-func (t *HullTool) Pick(*Session, Selectable) {}
 
 // CanCommit is always true — the running solids are the input.
 func (t *HullTool) CanCommit() bool { return true }
@@ -137,7 +136,6 @@ func (t *HullTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (nothing to restore).
-func (t *HullTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *HullTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/feature_pattern_tools.go
+++ b/app/feature_pattern_tools.go
@@ -17,6 +17,7 @@ import (
 
 // featureSelectTool collects the source features (by id) the pattern/mirror replicates.
 type featureSelectTool struct {
+	dialogTool
 	sources []feature.ID
 	added   *feature.PartFeature
 }
@@ -28,7 +29,6 @@ func (t *featureSelectTool) Pick(_ *Session, sel Selectable) {
 	}
 }
 
-func (t *featureSelectTool) Start(*Session)  {}
 func (t *featureSelectTool) Cancel(*Session) { t.sources = nil }
 
 // patternFeatures resolves the active part and its pattern-feature collection, erroring on

--- a/app/freeform_tools.go
+++ b/app/freeform_tools.go
@@ -36,6 +36,7 @@ func levelParam(get func() int, set func(int)) IntParam {
 
 // FreeformBoxTool places a sub-D box primitive (sx × sy × sz cage at a subdivision level).
 type FreeformBoxTool struct {
+	dialogTool
 	sx, sy, sz float64
 	level      int
 	added      *feature.PartFeature
@@ -53,8 +54,6 @@ func (t *FreeformBoxTool) Prompt(*Session) string {
 }
 
 // Start/Pick implement [Tool] (parameter-only, nothing is picked).
-func (t *FreeformBoxTool) Start(*Session)            {}
-func (t *FreeformBoxTool) Pick(*Session, Selectable) {}
 
 // Params exposes the cage sizes and level for the generic property dialog.
 func (t *FreeformBoxTool) Params() ToolParams {
@@ -81,13 +80,13 @@ func (t *FreeformBoxTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (nothing to restore).
-func (t *FreeformBoxTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *FreeformBoxTool) AddedFeature() *feature.PartFeature { return t.added }
 
 // FreeformPlaneTool places a sub-D plane primitive (an open sx × sy cage — a surface body).
 type FreeformPlaneTool struct {
+	dialogTool
 	sx, sy float64
 	level  int
 	added  *feature.PartFeature
@@ -105,8 +104,6 @@ func (t *FreeformPlaneTool) Prompt(*Session) string {
 }
 
 // Start/Pick implement [Tool] (parameter-only).
-func (t *FreeformPlaneTool) Start(*Session)            {}
-func (t *FreeformPlaneTool) Pick(*Session, Selectable) {}
 
 // Params exposes the cage sizes and level for the generic property dialog.
 func (t *FreeformPlaneTool) Params() ToolParams {
@@ -132,13 +129,13 @@ func (t *FreeformPlaneTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (nothing to restore).
-func (t *FreeformPlaneTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *FreeformPlaneTool) AddedFeature() *feature.PartFeature { return t.added }
 
 // FreeformQuadBallTool places a sub-D quad-ball primitive (a closed sphere-like cage).
 type FreeformQuadBallTool struct {
+	dialogTool
 	radius float64
 	level  int
 	added  *feature.PartFeature
@@ -158,8 +155,6 @@ func (t *FreeformQuadBallTool) Prompt(*Session) string {
 }
 
 // Start/Pick implement [Tool] (parameter-only).
-func (t *FreeformQuadBallTool) Start(*Session)            {}
-func (t *FreeformQuadBallTool) Pick(*Session, Selectable) {}
 
 // Params exposes the radius and level for the generic property dialog.
 func (t *FreeformQuadBallTool) Params() ToolParams {
@@ -186,7 +181,6 @@ func (t *FreeformQuadBallTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (nothing to restore).
-func (t *FreeformQuadBallTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *FreeformQuadBallTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/model_reference_tool.go
+++ b/app/model_reference_tool.go
@@ -12,6 +12,7 @@ import (
 // whose iProperties fill the title block. It is a dialog-only tool: the user picks one of
 // the open part/assembly documents and OK stores the reference.
 type ModelReferenceTool struct {
+	dialogTool
 	candidates []string // full document names of the open part/assembly documents
 	selected   int
 }
@@ -34,12 +35,8 @@ func (t *ModelReferenceTool) Start(s *Session) {
 	}
 }
 
-func (t *ModelReferenceTool) Pick(*Session, Selectable) {}
-
 // CanCommit requires at least one open model to reference.
 func (t *ModelReferenceTool) CanCommit() bool { return len(t.candidates) > 0 }
-
-func (t *ModelReferenceTool) Cancel(*Session) {}
 
 // Commit stores the selected model as the drawing's referenced model.
 func (t *ModelReferenceTool) Commit(s *Session) error {

--- a/app/place_component_tool.go
+++ b/app/place_component_tool.go
@@ -24,6 +24,7 @@ import (
 //	s.StartTool(tool)
 //	s.Click(px, py)                   // drops widget:1 on the ground plane
 type PlaceComponentTool struct {
+	dialogTool
 	component *doc.Document // the document to instance; nil until chosen
 	placed    int           // occurrences dropped so far, for unique instance names
 }
@@ -50,7 +51,6 @@ func (t *PlaceComponentTool) Start(s *Session) { s.selection.Clear() }
 
 // Pick implements [Tool]. Placement is driven by ground-plane clicks (ClickAt), not entity
 // picks, so a pick is ignored — snapping a placement to existing geometry is a later refinement.
-func (t *PlaceComponentTool) Pick(_ *Session, _ Selectable) {}
 
 // ClickAt drops one instance of the component at the clicked point on the assembly ground plane
 // (Z = 0) and records it as an undo step, leaving the tool open for the next drop
@@ -91,7 +91,6 @@ func (t *PlaceComponentTool) Commit(_ *Session) error { return nil }
 
 // Cancel stops the tool. Instances dropped before cancelling remain (each is its own undo step),
 // matching the reference command where Esc keeps what was already placed.
-func (t *PlaceComponentTool) Cancel(_ *Session) {}
 
 // groundRayEpsilon is the |ray.Z| below which the view is treated as edge-on to the ground
 // plane, so no stable intersection exists.

--- a/app/rib_tool.go
+++ b/app/rib_tool.go
@@ -15,6 +15,7 @@ import (
 // property window and OK to thicken the profile into a rib joined to the active part. It exposes
 // its parameters through ParameterizedTool, so the head renders the generic dialog.
 type RibTool struct {
+	dialogTool
 	profile   *sketch.Sketch
 	pathIndex int
 	thickness float64
@@ -33,7 +34,6 @@ func (t *RibTool) Name() string { return "Rib" }
 func (t *RibTool) Start(s *Session) { t.profile, t.pathIndex = ribProfile(s) }
 
 // Pick is unused — the rib operates on the resolved open profile, not a viewport selection.
-func (t *RibTool) Pick(*Session, Selectable) {}
 
 // The options the property window drives: thickness and signed depth (database units).
 func (t *RibTool) SetThickness(v float64) { t.thickness = v }
@@ -75,7 +75,6 @@ func (t *RibTool) addRib(fs *feature.PartFeatures) *feature.PartFeature {
 }
 
 // Cancel abandons the tool with no change.
-func (t *RibTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *RibTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sculpt_tool.go
+++ b/app/sculpt_tool.go
@@ -14,6 +14,7 @@ import (
 // dialog drives the closing tolerance. The bounding surfaces must enclose a closed cell, else the
 // feature goes sick.
 type SculptTool struct {
+	dialogTool
 	tolerance float64
 	added     *feature.PartFeature
 }
@@ -25,10 +26,8 @@ func NewSculptTool() *SculptTool { return &SculptTool{} }
 func (t *SculptTool) Name() string { return "Sculpt" }
 
 // Start has nothing to select — sculpt acts on every bounding surface.
-func (t *SculptTool) Start(*Session) {}
 
 // Pick is unused.
-func (t *SculptTool) Pick(*Session, Selectable) {}
 
 // SetTolerance/Tolerance drive the coincidence tolerance for closing the bounding surfaces.
 func (t *SculptTool) SetTolerance(v float64) { t.tolerance = v }
@@ -64,7 +63,6 @@ func (t *SculptTool) addSculpt(fs *feature.PartFeatures) *feature.PartFeature {
 }
 
 // Cancel abandons the tool with no change.
-func (t *SculptTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SculptTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sheet_metal_flat_tools.go
+++ b/app/sheet_metal_flat_tools.go
@@ -10,6 +10,7 @@ import "oblikovati.org/model/feature"
 
 // SheetMetalUnfoldTool flattens every bend of the part (Create Flat Pattern).
 type SheetMetalUnfoldTool struct {
+	dialogTool
 	added *feature.PartFeature
 }
 
@@ -17,10 +18,7 @@ type SheetMetalUnfoldTool struct {
 func NewSheetMetalUnfoldTool() *SheetMetalUnfoldTool { return &SheetMetalUnfoldTool{} }
 
 func (t *SheetMetalUnfoldTool) Name() string                       { return "Sheet Metal Unfold" }
-func (t *SheetMetalUnfoldTool) Start(*Session)                     {}
-func (t *SheetMetalUnfoldTool) Pick(*Session, Selectable)          {}
 func (t *SheetMetalUnfoldTool) CanCommit() bool                    { return true }
-func (t *SheetMetalUnfoldTool) Cancel(*Session)                    {}
 func (t *SheetMetalUnfoldTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalUnfoldTool) Commit(s *Session) error {
@@ -38,6 +36,7 @@ func (t *SheetMetalUnfoldTool) Commit(s *Session) error {
 
 // SheetMetalRefoldTool re-folds the bends an earlier unfold flattened.
 type SheetMetalRefoldTool struct {
+	dialogTool
 	added *feature.PartFeature
 }
 
@@ -45,10 +44,7 @@ type SheetMetalRefoldTool struct {
 func NewSheetMetalRefoldTool() *SheetMetalRefoldTool { return &SheetMetalRefoldTool{} }
 
 func (t *SheetMetalRefoldTool) Name() string                       { return "Sheet Metal Refold" }
-func (t *SheetMetalRefoldTool) Start(*Session)                     {}
-func (t *SheetMetalRefoldTool) Pick(*Session, Selectable)          {}
 func (t *SheetMetalRefoldTool) CanCommit() bool                    { return true }
-func (t *SheetMetalRefoldTool) Cancel(*Session)                    {}
 func (t *SheetMetalRefoldTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalRefoldTool) Commit(s *Session) error {

--- a/app/sheet_metal_style_tool.go
+++ b/app/sheet_metal_style_tool.go
@@ -21,6 +21,7 @@ import (
 // converts them back to model units and re-authors the Thickness/BendRadius parameters so the
 // rule stays parameter-backed.
 type SheetMetalStyleTool struct {
+	dialogTool
 	thickness   float64 // preferred (display) units
 	bendRadius  float64 // preferred (display) units
 	reliefWidth float64 // preferred (display) units
@@ -33,9 +34,7 @@ type SheetMetalStyleTool struct {
 // NewSheetMetalStyleTool returns a style-editor tool.
 func NewSheetMetalStyleTool() *SheetMetalStyleTool { return &SheetMetalStyleTool{} }
 
-func (t *SheetMetalStyleTool) Name() string              { return "Sheet Metal Style" }
-func (t *SheetMetalStyleTool) Pick(*Session, Selectable) {}
-func (t *SheetMetalStyleTool) Cancel(*Session)           {}
+func (t *SheetMetalStyleTool) Name() string { return "Sheet Metal Style" }
 
 // Start seeds the edit buffers from the active part's rule, converting its model-unit lengths
 // to the document's preferred unit. A no-op when the active part is not sheet metal.

--- a/app/sketch3d_bend_tool.go
+++ b/app/sketch3d_bend_tool.go
@@ -15,6 +15,7 @@ import (
 // auto-applies on the second pick, so a pipe-run's corners can be bent click-by-click
 // after adjusting the radius once.
 type Bend3DTool struct {
+	dialogTool
 	lines  []*sketch.Line3D
 	radius float64 // database units (cm)
 }
@@ -29,7 +30,6 @@ func NewBend3DTool() *Bend3DTool { return &Bend3DTool{radius: defaultBendRadius3
 func (t *Bend3DTool) Name() string { return "Bend" }
 
 // Start/Cancel implement [Tool].
-func (t *Bend3DTool) Start(*Session)  {}
 func (t *Bend3DTool) Cancel(*Session) { t.lines = nil }
 
 // Params exposes the bend radius (the head shows it in the tool-params dialog).

--- a/app/sketch3d_geometry_tools.go
+++ b/app/sketch3d_geometry_tools.go
@@ -13,6 +13,7 @@ import (
 // 3D Line). Points arrive via AddPoint (the head feeds model-space picks; e2e tests call
 // it directly). Committing adds the segments to the active 3D sketch.
 type Line3DTool struct {
+	dialogTool
 	points []math.Point3
 }
 
@@ -23,10 +24,8 @@ func NewLine3DTool() *Line3DTool { return &Line3DTool{} }
 func (t *Line3DTool) Name() string { return "3D Line" }
 
 // Start implements [Tool]; the 3D line tool needs no selection filter.
-func (t *Line3DTool) Start(*Session) {}
 
 // Pick implements [Tool]; model-space picks arrive via AddPoint, not selectables.
-func (t *Line3DTool) Pick(*Session, Selectable) {}
 
 // AddPoint records a model-space vertex of the polyline.
 func (t *Line3DTool) AddPoint(p math.Point3) { t.points = append(t.points, p) }
@@ -51,10 +50,10 @@ func (t *Line3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (no state to restore).
-func (t *Line3DTool) Cancel(*Session) {}
 
 // Point3DTool places a single standalone point in the active 3D sketch.
 type Point3DTool struct {
+	dialogTool
 	point *math.Point3
 }
 
@@ -65,8 +64,6 @@ func NewPoint3DTool() *Point3DTool { return &Point3DTool{} }
 func (t *Point3DTool) Name() string { return "3D Point" }
 
 // Start/Pick implement [Tool]; the point arrives via SetPoint.
-func (t *Point3DTool) Start(*Session)            {}
-func (t *Point3DTool) Pick(*Session, Selectable) {}
 
 // SetPoint records the point's model-space position.
 func (t *Point3DTool) SetPoint(p math.Point3) { t.point = &p }
@@ -88,11 +85,11 @@ func (t *Point3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *Point3DTool) Cancel(*Session) {}
 
 // Circle3DTool places a full circle in the active 3D sketch from a center, a plane axis
 // (defaulting to +Z), and a radius.
 type Circle3DTool struct {
+	dialogTool
 	center *math.Point3
 	axis   math.Vector3
 	radius float64
@@ -102,9 +99,7 @@ type Circle3DTool struct {
 func NewCircle3DTool() *Circle3DTool { return &Circle3DTool{axis: math.V3(0, 0, 1)} }
 
 // Name implements [Tool]; Start/Pick are no-ops (inputs arrive via the setters).
-func (t *Circle3DTool) Name() string              { return "3D Circle" }
-func (t *Circle3DTool) Start(*Session)            {}
-func (t *Circle3DTool) Pick(*Session, Selectable) {}
+func (t *Circle3DTool) Name() string { return "3D Circle" }
 
 // SetCenter/SetAxis/SetRadius supply the circle's inputs.
 func (t *Circle3DTool) SetCenter(p math.Point3) { t.center = &p }
@@ -132,10 +127,10 @@ func (t *Circle3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *Circle3DTool) Cancel(*Session) {}
 
 // Arc3DTool places a circular arc from three picked points: center, start, end.
 type Arc3DTool struct {
+	dialogTool
 	points []math.Point3
 	ccw    bool
 }
@@ -144,9 +139,7 @@ type Arc3DTool struct {
 func NewArc3DTool() *Arc3DTool { return &Arc3DTool{ccw: true} }
 
 // Name implements [Tool]; Start/Pick are no-ops.
-func (t *Arc3DTool) Name() string              { return "3D Arc" }
-func (t *Arc3DTool) Start(*Session)            {}
-func (t *Arc3DTool) Pick(*Session, Selectable) {}
+func (t *Arc3DTool) Name() string { return "3D Arc" }
 
 // AddPoint records the next of the arc's center/start/end points; SetCCW orients it.
 func (t *Arc3DTool) AddPoint(p math.Point3) { t.points = append(t.points, p) }
@@ -169,11 +162,11 @@ func (t *Arc3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *Arc3DTool) Cancel(*Session) {}
 
 // Helix3DTool places a cylindrical helix from an axis-base origin, radius, pitch and turn
 // count (axis defaults to +Z). It is the spring/thread-path tool.
 type Helix3DTool struct {
+	dialogTool
 	origin    *math.Point3
 	axis      math.Vector3
 	radius    float64
@@ -186,9 +179,7 @@ type Helix3DTool struct {
 func NewHelix3DTool() *Helix3DTool { return &Helix3DTool{axis: math.V3(0, 0, 1)} }
 
 // Name implements [Tool]; Start/Pick are no-ops.
-func (t *Helix3DTool) Name() string              { return "Helical Curve" }
-func (t *Helix3DTool) Start(*Session)            {}
-func (t *Helix3DTool) Pick(*Session, Selectable) {}
+func (t *Helix3DTool) Name() string { return "Helical Curve" }
 
 // Setters supply the helix's inputs (radius/pitch in cm, turns a revolution count).
 func (t *Helix3DTool) SetOrigin(p math.Point3) { t.origin = &p }
@@ -221,7 +212,6 @@ func (t *Helix3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *Helix3DTool) Cancel(*Session) {}
 
 // --- Params (generic property dialog) -------------------------------------
 // The 3D tools take their points from viewport clicks; the dialog edits the scalar/bool

--- a/app/sketch3d_reference_tools.go
+++ b/app/sketch3d_reference_tools.go
@@ -15,6 +15,7 @@ import (
 // geometry (an edge as a reference polyline, a vertex as a constrainable anchor point).
 // They re-derive through recompute via their reference keys.
 type IncludeGeometry3DTool struct {
+	dialogTool
 	edges    []EdgeHandle
 	vertices []VertexHandle
 }
@@ -68,13 +69,13 @@ func (t *IncludeGeometry3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *IncludeGeometry3DTool) Cancel(*Session) {}
 
 // SurfaceCurve3DTool is the interactive 3D-sketch surface-derived-curve command: while
 // editing a 3D sketch, pick faces and commit an intersection curve (two faces) or a
 // silhouette curve (one face, for the current view direction) onto the sketch. The curve is
 // associative — it re-evaluates against the rebuilt B-rep on recompute via the face keys.
 type SurfaceCurve3DTool struct {
+	dialogTool
 	faces      []FaceHandle
 	silhouette bool
 	viewDir    math.Vector3
@@ -141,7 +142,6 @@ func (t *SurfaceCurve3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *SurfaceCurve3DTool) Cancel(*Session) {}
 
 var (
 	_ Tool = (*IncludeGeometry3DTool)(nil)

--- a/app/sketch3d_spline_tools.go
+++ b/app/sketch3d_spline_tools.go
@@ -18,6 +18,7 @@ import (
 // them (3D Spline), control shapes the curve by its control polygon (3D Control
 // Point Spline). Closed wraps the curve back to its first point.
 type Spline3DTool struct {
+	dialogTool
 	points []math.Point3
 	fit    bool
 	closed bool
@@ -36,8 +37,6 @@ func (t *Spline3DTool) Name() string {
 	}
 	return "3D Control Point Spline"
 }
-func (t *Spline3DTool) Start(*Session)            {}
-func (t *Spline3DTool) Pick(*Session, Selectable) {}
 
 // AddPoint appends the next defining point (a viewport click).
 func (t *Spline3DTool) AddPoint(p math.Point3) { t.points = append(t.points, p) }
@@ -59,7 +58,6 @@ func (t *Spline3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *Spline3DTool) Cancel(*Session) {}
 
 // Params exposes the closed flag (points come from viewport clicks).
 func (t *Spline3DTool) Params() ToolParams {
@@ -71,6 +69,7 @@ func (t *Spline3DTool) Params() ToolParams {
 // EquationCurve3DTool draws a parametric x(t)/y(t)/z(t) curve over [t0,t1]; the
 // expressions go through the document's expression engine (lengths in cm).
 type EquationCurve3DTool struct {
+	dialogTool
 	xExpr, yExpr, zExpr string
 	t0, t1              float64
 }
@@ -80,9 +79,7 @@ type EquationCurve3DTool struct {
 func NewEquationCurve3DTool() *EquationCurve3DTool { return &EquationCurve3DTool{t1: 1} }
 
 // Name implements [Tool]; Start/Pick are no-ops (all input is the dialog's).
-func (t *EquationCurve3DTool) Name() string              { return "Equation Curve" }
-func (t *EquationCurve3DTool) Start(*Session)            {}
-func (t *EquationCurve3DTool) Pick(*Session, Selectable) {}
+func (t *EquationCurve3DTool) Name() string { return "Equation Curve" }
 
 // CanCommit requires all three expressions and a non-empty parameter range.
 func (t *EquationCurve3DTool) CanCommit() bool {
@@ -104,7 +101,6 @@ func (t *EquationCurve3DTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool].
-func (t *EquationCurve3DTool) Cancel(*Session) {}
 
 // Params exposes the three coordinate expressions and the parameter range.
 func (t *EquationCurve3DTool) Params() ToolParams {

--- a/app/sketch_block_tools.go
+++ b/app/sketch_block_tools.go
@@ -52,6 +52,7 @@ func (t *SketchCreateBlockTool) Commit(s *Session) error {
 
 // SketchPlaceBlockTool stamps instances of a definition at clicked points.
 type SketchPlaceBlockTool struct {
+	dialogTool
 	definition string
 	rotation   float64
 	scale      float64
@@ -76,8 +77,6 @@ func (t *SketchPlaceBlockTool) Prompt(*Session) string {
 func (t *SketchPlaceBlockTool) SetDefinition(name string)   { t.definition = name }
 func (t *SketchPlaceBlockTool) SetRotation(radians float64) { t.rotation = radians }
 func (t *SketchPlaceBlockTool) SetScale(factor float64)     { t.scale = factor }
-func (t *SketchPlaceBlockTool) Start(*Session)              {}
-func (t *SketchPlaceBlockTool) Pick(*Session, Selectable)   {}
 func (t *SketchPlaceBlockTool) Cancel(*Session)             { t.at = nil }
 func (t *SketchPlaceBlockTool) CanCommit() bool             { return t.at != nil && t.definition != "" }
 func (t *SketchPlaceBlockTool) AutoCommits() bool           { return true }

--- a/app/sketch_constraint_tools.go
+++ b/app/sketch_constraint_tools.go
@@ -29,6 +29,7 @@ type constraintPick struct {
 // ConstraintTool is the generic interactive constraint/dimension tool: it gathers
 // accepted picks and applies its constraint when ready.
 type ConstraintTool struct {
+	dialogTool
 	name    string
 	prompt  string
 	accepts func(sketch.Entity) bool
@@ -39,7 +40,6 @@ type ConstraintTool struct {
 
 // Name/Start/Cancel implement [Tool].
 func (t *ConstraintTool) Name() string    { return t.name }
-func (t *ConstraintTool) Start(*Session)  {}
 func (t *ConstraintTool) Cancel(*Session) { t.picks = nil }
 
 // Pick records a clicked entity with no snap context (the generic-tool path).

--- a/app/sketch_create_tools.go
+++ b/app/sketch_create_tools.go
@@ -19,6 +19,7 @@ import (
 // SketchChamferTool bevels the corner between two picked lines (like Fillet, but a flat
 // cut). It uses an equal setback on both lines.
 type SketchChamferTool struct {
+	dialogTool
 	pickCollector
 	distance math.Scalar
 }
@@ -29,7 +30,6 @@ func NewSketchChamferTool(distance float64) *SketchChamferTool {
 }
 
 func (t *SketchChamferTool) Name() string                  { return "Chamfer" }
-func (t *SketchChamferTool) Start(*Session)                {}
 func (t *SketchChamferTool) Pick(_ *Session, s Selectable) { t.take(s) }
 func (t *SketchChamferTool) CanCommit() bool               { return t.ready() }
 func (t *SketchChamferTool) AutoCommitOnPick() bool        { return true }
@@ -55,6 +55,7 @@ func (t *SketchChamferTool) Commit(s *Session) error {
 
 // SketchSlotTool draws a straight slot from two centre-axis clicks and a width.
 type SketchSlotTool struct {
+	dialogTool
 	points []math.Point2
 	width  math.Scalar
 }
@@ -64,12 +65,10 @@ func NewSketchSlotTool(width float64) *SketchSlotTool {
 	return &SketchSlotTool{width: math.Scalar(width)}
 }
 
-func (t *SketchSlotTool) Name() string              { return "Slot" }
-func (t *SketchSlotTool) Start(*Session)            {}
-func (t *SketchSlotTool) Pick(*Session, Selectable) {}
-func (t *SketchSlotTool) Cancel(*Session)           { t.points = nil }
-func (t *SketchSlotTool) AutoCommits() bool         { return true }
-func (t *SketchSlotTool) CanCommit() bool           { return len(t.points) == 2 }
+func (t *SketchSlotTool) Name() string      { return "Slot" }
+func (t *SketchSlotTool) Cancel(*Session)   { t.points = nil }
+func (t *SketchSlotTool) AutoCommits() bool { return true }
+func (t *SketchSlotTool) CanCommit() bool   { return len(t.points) == 2 }
 func (t *SketchSlotTool) Prompt(*Session) string {
 	if len(t.points) == 0 {
 		return "Click the slot's first centre point."
@@ -100,6 +99,7 @@ func (t *SketchSlotTool) Commit(s *Session) error {
 // CenterPointArcSlotTool draws an arc-shaped slot whose centre line is an arc given by its
 // center, start and end (Inventor's Center Point Arc Slot); the width is a parameter.
 type CenterPointArcSlotTool struct {
+	dialogTool
 	collectClicks
 	width math.Scalar
 }
@@ -109,12 +109,10 @@ func NewCenterPointArcSlotTool(width float64) *CenterPointArcSlotTool {
 	return &CenterPointArcSlotTool{width: math.Scalar(width)}
 }
 
-func (t *CenterPointArcSlotTool) Name() string              { return "Center Point Arc Slot" }
-func (t *CenterPointArcSlotTool) Start(*Session)            {}
-func (t *CenterPointArcSlotTool) Pick(*Session, Selectable) {}
-func (t *CenterPointArcSlotTool) Cancel(*Session)           { t.reset() }
-func (t *CenterPointArcSlotTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *CenterPointArcSlotTool) AutoCommits() bool         { return true }
+func (t *CenterPointArcSlotTool) Name() string      { return "Center Point Arc Slot" }
+func (t *CenterPointArcSlotTool) Cancel(*Session)   { t.reset() }
+func (t *CenterPointArcSlotTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *CenterPointArcSlotTool) AutoCommits() bool { return true }
 
 // SetWidth sets the slot width.
 func (t *CenterPointArcSlotTool) SetWidth(w float64) { t.width = math.Scalar(w) }
@@ -152,6 +150,7 @@ func (t *CenterPointArcSlotTool) Params() ToolParams {
 // ThreePointArcSlotTool draws an arc-shaped slot whose centre line is the arc through three
 // clicked points — start, a point on the arc, then end (Inventor's Three Point Arc Slot).
 type ThreePointArcSlotTool struct {
+	dialogTool
 	collectClicks
 	width math.Scalar
 }
@@ -161,12 +160,10 @@ func NewThreePointArcSlotTool(width float64) *ThreePointArcSlotTool {
 	return &ThreePointArcSlotTool{width: math.Scalar(width)}
 }
 
-func (t *ThreePointArcSlotTool) Name() string              { return "Three Point Arc Slot" }
-func (t *ThreePointArcSlotTool) Start(*Session)            {}
-func (t *ThreePointArcSlotTool) Pick(*Session, Selectable) {}
-func (t *ThreePointArcSlotTool) Cancel(*Session)           { t.reset() }
-func (t *ThreePointArcSlotTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *ThreePointArcSlotTool) AutoCommits() bool         { return true }
+func (t *ThreePointArcSlotTool) Name() string      { return "Three Point Arc Slot" }
+func (t *ThreePointArcSlotTool) Cancel(*Session)   { t.reset() }
+func (t *ThreePointArcSlotTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *ThreePointArcSlotTool) AutoCommits() bool { return true }
 
 // SetWidth sets the slot width.
 func (t *ThreePointArcSlotTool) SetWidth(w float64) { t.width = math.Scalar(w) }
@@ -211,6 +208,7 @@ func (t *ThreePointArcSlotTool) Params() ToolParams {
 // font and derives its glyph geometry on demand (by reference), so it is embossable without
 // baking outlines.
 type SketchTextTool struct {
+	dialogTool
 	anchor   *math.Point2
 	text     string
 	height   math.Scalar
@@ -227,11 +225,9 @@ func NewSketchTextTool() *SketchTextTool {
 	return &SketchTextTool{height: 1, family: fontCatalog()[0].Family}
 }
 
-func (t *SketchTextTool) Name() string              { return "Text" }
-func (t *SketchTextTool) Start(*Session)            {}
-func (t *SketchTextTool) Pick(*Session, Selectable) {}
-func (t *SketchTextTool) Cancel(*Session)           { t.anchor, t.text = nil, "" }
-func (t *SketchTextTool) CanCommit() bool           { return t.anchor != nil && t.text != "" }
+func (t *SketchTextTool) Name() string    { return "Text" }
+func (t *SketchTextTool) Cancel(*Session) { t.anchor, t.text = nil, "" }
+func (t *SketchTextTool) CanCommit() bool { return t.anchor != nil && t.text != "" }
 func (t *SketchTextTool) Prompt(*Session) string {
 	if t.anchor == nil {
 		return "Click to place the text anchor."

--- a/app/sketch_geometry_tools.go
+++ b/app/sketch_geometry_tools.go
@@ -45,17 +45,18 @@ func (c *collectClicks) SubmitToken(_ *Session, tok CommandToken) error {
 }
 
 // CircleTool draws a circle from a clicked center and a radius point.
-type CircleTool struct{ collectClicks }
+type CircleTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewCircleTool returns a center-radius circle tool.
 func NewCircleTool() *CircleTool { return &CircleTool{} }
 
-func (t *CircleTool) Name() string              { return "Circle" }
-func (t *CircleTool) Start(*Session)            {}
-func (t *CircleTool) Pick(*Session, Selectable) {}
-func (t *CircleTool) Cancel(*Session)           { t.reset() }
-func (t *CircleTool) CanCommit() bool           { return len(t.pts) == 2 }
-func (t *CircleTool) AutoCommits() bool         { return true }
+func (t *CircleTool) Name() string      { return "Circle" }
+func (t *CircleTool) Cancel(*Session)   { t.reset() }
+func (t *CircleTool) CanCommit() bool   { return len(t.pts) == 2 }
+func (t *CircleTool) AutoCommits() bool { return true }
 
 // Commit adds a circle centered at the first click with radius to the second.
 func (t *CircleTool) Commit(s *Session) error {
@@ -79,17 +80,18 @@ func (t *CircleTool) Prompt(*Session) string {
 }
 
 // ArcTool draws a three-point arc (start, end, then a point the arc passes through).
-type ArcTool struct{ collectClicks }
+type ArcTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewArcTool returns a three-point arc tool.
 func NewArcTool() *ArcTool { return &ArcTool{} }
 
-func (t *ArcTool) Name() string              { return "Arc" }
-func (t *ArcTool) Start(*Session)            {}
-func (t *ArcTool) Pick(*Session, Selectable) {}
-func (t *ArcTool) Cancel(*Session)           { t.reset() }
-func (t *ArcTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *ArcTool) AutoCommits() bool         { return true }
+func (t *ArcTool) Name() string      { return "Arc" }
+func (t *ArcTool) Cancel(*Session)   { t.reset() }
+func (t *ArcTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *ArcTool) AutoCommits() bool { return true }
 
 // Commit fits the arc's center as the circumcenter of the three points; the sweep
 // direction is the orientation of start→through→end so the arc passes through it.
@@ -123,17 +125,18 @@ func (t *ArcTool) Prompt(*Session) string {
 
 // PointTool places a sketch point at the click, then deactivates (one point per
 // activation, like the other auto-commit tools).
-type PointTool struct{ collectClicks }
+type PointTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewPointTool returns a point-placement tool.
 func NewPointTool() *PointTool { return &PointTool{} }
 
-func (t *PointTool) Name() string              { return "Point" }
-func (t *PointTool) Start(*Session)            {}
-func (t *PointTool) Pick(*Session, Selectable) {}
-func (t *PointTool) Cancel(*Session)           { t.reset() }
-func (t *PointTool) CanCommit() bool           { return len(t.pts) >= 1 }
-func (t *PointTool) AutoCommits() bool         { return true }
+func (t *PointTool) Name() string      { return "Point" }
+func (t *PointTool) Cancel(*Session)   { t.reset() }
+func (t *PointTool) CanCommit() bool   { return len(t.pts) >= 1 }
+func (t *PointTool) AutoCommits() bool { return true }
 
 // Commit adds every placed point to the sketch.
 func (t *PointTool) Commit(s *Session) error {
@@ -156,6 +159,7 @@ func (t *PointTool) Prompt(*Session) string {
 
 // SplineTool draws an interpolated spline through clicked points (OK finishes).
 type SplineTool struct {
+	dialogTool
 	collectClicks
 	withHandles bool
 }
@@ -163,11 +167,9 @@ type SplineTool struct {
 // NewSplineTool returns a fit-point spline tool.
 func NewSplineTool() *SplineTool { return &SplineTool{} }
 
-func (t *SplineTool) Name() string              { return "Spline" }
-func (t *SplineTool) Start(*Session)            {}
-func (t *SplineTool) Pick(*Session, Selectable) {}
-func (t *SplineTool) Cancel(*Session)           { t.reset() }
-func (t *SplineTool) CanCommit() bool           { return len(t.pts) >= 2 }
+func (t *SplineTool) Name() string    { return "Spline" }
+func (t *SplineTool) Cancel(*Session) { t.reset() }
+func (t *SplineTool) CanCommit() bool { return len(t.pts) >= 2 }
 
 // SetActivateHandles makes Commit also activate the tangency handle on every
 // placed fit point, ready for interactive shaping (M06-F11, #626).
@@ -200,17 +202,18 @@ func (t *SplineTool) Prompt(*Session) string {
 
 // EllipseTool draws an ellipse from a center, a major-axis endpoint, and a point
 // setting the minor radius.
-type EllipseTool struct{ collectClicks }
+type EllipseTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewEllipseTool returns a center-axis ellipse tool.
 func NewEllipseTool() *EllipseTool { return &EllipseTool{} }
 
-func (t *EllipseTool) Name() string              { return "Ellipse" }
-func (t *EllipseTool) Start(*Session)            {}
-func (t *EllipseTool) Pick(*Session, Selectable) {}
-func (t *EllipseTool) Cancel(*Session)           { t.reset() }
-func (t *EllipseTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *EllipseTool) AutoCommits() bool         { return true }
+func (t *EllipseTool) Name() string      { return "Ellipse" }
+func (t *EllipseTool) Cancel(*Session)   { t.reset() }
+func (t *EllipseTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *EllipseTool) AutoCommits() bool { return true }
 
 // Commit builds the ellipse: the second click sets the major direction and radius, the
 // third its perpendicular distance from the major axis sets the minor radius.
@@ -246,6 +249,7 @@ func (t *EllipseTool) Prompt(*Session) string {
 // PolygonTool draws a regular inscribed polygon from a center and a vertex; Sides sets
 // the edge count (default 6).
 type PolygonTool struct {
+	dialogTool
 	collectClicks
 	Sides int
 }
@@ -258,12 +262,10 @@ func NewPolygonTool(sides int) *PolygonTool {
 	return &PolygonTool{Sides: sides}
 }
 
-func (t *PolygonTool) Name() string              { return "Polygon" }
-func (t *PolygonTool) Start(*Session)            {}
-func (t *PolygonTool) Pick(*Session, Selectable) {}
-func (t *PolygonTool) Cancel(*Session)           { t.reset() }
-func (t *PolygonTool) CanCommit() bool           { return len(t.pts) == 2 }
-func (t *PolygonTool) AutoCommits() bool         { return true }
+func (t *PolygonTool) Name() string      { return "Polygon" }
+func (t *PolygonTool) Cancel(*Session)   { t.reset() }
+func (t *PolygonTool) CanCommit() bool   { return len(t.pts) == 2 }
+func (t *PolygonTool) AutoCommits() bool { return true }
 
 // Commit builds the Sides-gon inscribed in the circle through the vertex click,
 // connecting consecutive vertices with lines sharing their corner points.

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -29,6 +29,7 @@ func (c *pickCollector) Picked() []sketch.Entity { return c.picks }
 
 // SketchFilletTool rounds the corner between two picked lines with a tangent arc.
 type SketchFilletTool struct {
+	dialogTool
 	pickCollector
 	radius math.Scalar
 }
@@ -39,7 +40,6 @@ func NewSketchFilletTool(radius float64) *SketchFilletTool {
 }
 
 func (t *SketchFilletTool) Name() string                  { return "Sketch Fillet" }
-func (t *SketchFilletTool) Start(*Session)                {}
 func (t *SketchFilletTool) Pick(_ *Session, s Selectable) { t.take(s) }
 func (t *SketchFilletTool) CanCommit() bool               { return t.ready() }
 func (t *SketchFilletTool) AutoCommitOnPick() bool        { return true }
@@ -70,6 +70,7 @@ func (t *SketchFilletTool) Commit(s *Session) error {
 
 // SketchOffsetTool offsets a single picked curve by a distance.
 type SketchOffsetTool struct {
+	dialogTool
 	pickCollector
 	distance math.Scalar
 }
@@ -80,7 +81,6 @@ func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
 }
 
 func (t *SketchOffsetTool) Name() string                  { return "Offset" }
-func (t *SketchOffsetTool) Start(*Session)                {}
 func (t *SketchOffsetTool) Pick(_ *Session, s Selectable) { t.take(s) }
 func (t *SketchOffsetTool) CanCommit() bool               { return t.ready() }
 func (t *SketchOffsetTool) AutoCommitOnPick() bool        { return true }
@@ -107,6 +107,7 @@ func (t *SketchOffsetTool) Commit(s *Session) error {
 
 // SketchMirrorTool mirrors the first picked entity across the second picked line.
 type SketchMirrorTool struct {
+	dialogTool
 	pickCollector
 }
 
@@ -116,7 +117,6 @@ func NewSketchMirrorTool() *SketchMirrorTool {
 }
 
 func (t *SketchMirrorTool) Name() string                  { return "Mirror" }
-func (t *SketchMirrorTool) Start(*Session)                {}
 func (t *SketchMirrorTool) Pick(_ *Session, s Selectable) { t.take(s) }
 func (t *SketchMirrorTool) CanCommit() bool               { return t.ready() }
 func (t *SketchMirrorTool) AutoCommitOnPick() bool        { return true }

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -14,6 +14,7 @@ import (
 // sketch geometry can be constrained to the projected anchors). Picks arrive as edge/vertex
 // handles; Commit projects each onto the active 2D sketch.
 type ProjectGeometryTool struct {
+	dialogTool
 	edges    []EdgeHandle
 	vertices []VertexHandle
 }
@@ -67,6 +68,5 @@ func (t *ProjectGeometryTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (no model change to roll back before commit).
-func (t *ProjectGeometryTool) Cancel(*Session) {}
 
 var _ Tool = (*ProjectGeometryTool)(nil)

--- a/app/sketch_tools.go
+++ b/app/sketch_tools.go
@@ -33,6 +33,7 @@ func screenToSketch(s *Session, px, py float64) (math.Point2, bool) {
 // RectangleTool draws an axis-aligned rectangle from two clicked corners (two
 // lines per pair of corners), the most common closed sketch profile.
 type RectangleTool struct {
+	dialogTool
 	corners []math.Point2
 }
 
@@ -43,10 +44,8 @@ func NewRectangleTool() *RectangleTool { return &RectangleTool{} }
 func (t *RectangleTool) Name() string { return "Rectangle" }
 
 // Start requires an active sketch (the sketch environment must be open).
-func (t *RectangleTool) Start(*Session) {}
 
 // Pick is unused; rectangle corners come from raw clicks (see ClickAt).
-func (t *RectangleTool) Pick(*Session, Selectable) {}
 
 // ClickAt records a corner from a clicked pixel (snapped to points/grid).
 func (t *RectangleTool) ClickAt(s *Session, px, py float64) {
@@ -101,6 +100,7 @@ func (t *RectangleTool) Prompt(*Session) string {
 // runs continuous (EnableContinuous): point after point becomes a connected chain with
 // [Close/Undo] options, ended by Enter or Close — AutoCAD's LINE (M26 F02 follow-up).
 type LineTool struct {
+	dialogTool
 	points     []math.Point2
 	continuous bool // command-line polyline mode: chain segments until Enter/Close
 	closed     bool // a Close keyword was given: connect the last point back to the first
@@ -109,9 +109,7 @@ type LineTool struct {
 // NewLineTool returns a two-point line tool.
 func NewLineTool() *LineTool { return &LineTool{} }
 
-func (t *LineTool) Name() string              { return "Line" }
-func (t *LineTool) Start(*Session)            {}
-func (t *LineTool) Pick(*Session, Selectable) {}
+func (t *LineTool) Name() string { return "Line" }
 
 // EnableContinuous switches the tool to AutoCAD-style continuous-polyline mode (the command
 // line calls this when it starts a LINE). The viewport path leaves it off.

--- a/app/sketch_transform_tools.go
+++ b/app/sketch_transform_tools.go
@@ -22,12 +22,11 @@ import (
 // and is ready once at least one entity is selected. Concrete tools embed it and add their
 // parameters + Commit.
 type sketchSelectTool struct {
+	dialogTool
 	picks []sketch.Entity
 }
 
 func (t *sketchSelectTool) PickSnap(ent sketch.Entity, _ SnapResult) { t.picks = append(t.picks, ent) }
-func (t *sketchSelectTool) Pick(*Session, Selectable)                {}
-func (t *sketchSelectTool) Start(*Session)                           {}
 func (t *sketchSelectTool) Cancel(*Session)                          { t.picks = nil }
 func (t *sketchSelectTool) CanCommit() bool                          { return len(t.picks) > 0 }
 
@@ -123,16 +122,15 @@ func (t *SketchCopyTool) Commit(s *Session) error {
 // geometry that shares them — Inventor's Stretch, where endpoints inside the window move
 // and the rest stay. It collects point picks (a non-point pick is ignored).
 type SketchStretchTool struct {
+	dialogTool
 	points []*sketch.Point
 	vector math.Vector2
 }
 
-func NewSketchStretchTool() *SketchStretchTool         { return &SketchStretchTool{} }
-func (t *SketchStretchTool) Name() string              { return "Stretch" }
-func (t *SketchStretchTool) Start(*Session)            {}
-func (t *SketchStretchTool) Pick(*Session, Selectable) {}
-func (t *SketchStretchTool) Cancel(*Session)           { t.points = nil }
-func (t *SketchStretchTool) CanCommit() bool           { return len(t.points) > 0 }
+func NewSketchStretchTool() *SketchStretchTool { return &SketchStretchTool{} }
+func (t *SketchStretchTool) Name() string      { return "Stretch" }
+func (t *SketchStretchTool) Cancel(*Session)   { t.points = nil }
+func (t *SketchStretchTool) CanCommit() bool   { return len(t.points) > 0 }
 func (t *SketchStretchTool) Prompt(*Session) string {
 	return "Pick the vertices to stretch, set the vector, then OK."
 }

--- a/app/sketch_trim_tools.go
+++ b/app/sketch_trim_tools.go
@@ -47,16 +47,17 @@ func (c *curveEditPick) pickedLine() (*sketch.Line, error) {
 
 // SketchTrimTool removes the picked segment of a line up to its nearest crossings with
 // other sketch geometry (lines, circles, arcs).
-type SketchTrimTool struct{ curveEditPick }
+type SketchTrimTool struct {
+	dialogTool
+	curveEditPick
+}
 
 // NewSketchTrimTool makes a trim tool.
 func NewSketchTrimTool() *SketchTrimTool { return &SketchTrimTool{} }
 
-func (t *SketchTrimTool) Name() string              { return "Trim" }
-func (t *SketchTrimTool) Start(*Session)            {}
-func (t *SketchTrimTool) Pick(*Session, Selectable) {}
-func (t *SketchTrimTool) Cancel(*Session)           { t.reset() }
-func (t *SketchTrimTool) Prompt(*Session) string    { return "Pick the curve segment to trim." }
+func (t *SketchTrimTool) Name() string           { return "Trim" }
+func (t *SketchTrimTool) Cancel(*Session)        { t.reset() }
+func (t *SketchTrimTool) Prompt(*Session) string { return "Pick the curve segment to trim." }
 
 // Commit trims the picked curve (line, circle or arc) at the pick point.
 func (t *SketchTrimTool) Commit(s *Session) error {
@@ -83,16 +84,17 @@ func (t *SketchTrimTool) Commit(s *Session) error {
 
 // SketchExtendTool lengthens the picked line's nearer end to the next crossing of its
 // support with other sketch geometry.
-type SketchExtendTool struct{ curveEditPick }
+type SketchExtendTool struct {
+	dialogTool
+	curveEditPick
+}
 
 // NewSketchExtendTool makes an extend tool.
 func NewSketchExtendTool() *SketchExtendTool { return &SketchExtendTool{} }
 
-func (t *SketchExtendTool) Name() string              { return "Extend" }
-func (t *SketchExtendTool) Start(*Session)            {}
-func (t *SketchExtendTool) Pick(*Session, Selectable) {}
-func (t *SketchExtendTool) Cancel(*Session)           { t.reset() }
-func (t *SketchExtendTool) Prompt(*Session) string    { return "Pick near the line end to extend." }
+func (t *SketchExtendTool) Name() string           { return "Extend" }
+func (t *SketchExtendTool) Cancel(*Session)        { t.reset() }
+func (t *SketchExtendTool) Prompt(*Session) string { return "Pick near the line end to extend." }
 
 // Commit extends whichever end of the picked line is nearer the pick point.
 func (t *SketchExtendTool) Commit(s *Session) error {
@@ -109,16 +111,17 @@ func (t *SketchExtendTool) Commit(s *Session) error {
 }
 
 // SketchSplitTool splits the picked line into two at the pick point.
-type SketchSplitTool struct{ curveEditPick }
+type SketchSplitTool struct {
+	dialogTool
+	curveEditPick
+}
 
 // NewSketchSplitTool makes a split tool.
 func NewSketchSplitTool() *SketchSplitTool { return &SketchSplitTool{} }
 
-func (t *SketchSplitTool) Name() string              { return "Split" }
-func (t *SketchSplitTool) Start(*Session)            {}
-func (t *SketchSplitTool) Pick(*Session, Selectable) {}
-func (t *SketchSplitTool) Cancel(*Session)           { t.reset() }
-func (t *SketchSplitTool) Prompt(*Session) string    { return "Pick the point to split the curve." }
+func (t *SketchSplitTool) Name() string           { return "Split" }
+func (t *SketchSplitTool) Cancel(*Session)        { t.reset() }
+func (t *SketchSplitTool) Prompt(*Session) string { return "Pick the point to split the curve." }
 
 // Commit splits the picked line at the pick point.
 func (t *SketchSplitTool) Commit(s *Session) error {

--- a/app/sketch_variant_tools.go
+++ b/app/sketch_variant_tools.go
@@ -16,17 +16,18 @@ import (
 
 // ThreePointRectangleTool draws a rectangle from three corners: a base edge (first two
 // clicks) then the perpendicular extent (third click), so it is not axis-aligned.
-type ThreePointRectangleTool struct{ collectClicks }
+type ThreePointRectangleTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewThreePointRectangleTool returns a three-point rectangle tool.
 func NewThreePointRectangleTool() *ThreePointRectangleTool { return &ThreePointRectangleTool{} }
 
-func (t *ThreePointRectangleTool) Name() string              { return "Three Point Rectangle" }
-func (t *ThreePointRectangleTool) Start(*Session)            {}
-func (t *ThreePointRectangleTool) Pick(*Session, Selectable) {}
-func (t *ThreePointRectangleTool) Cancel(*Session)           { t.reset() }
-func (t *ThreePointRectangleTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *ThreePointRectangleTool) AutoCommits() bool         { return true }
+func (t *ThreePointRectangleTool) Name() string      { return "Three Point Rectangle" }
+func (t *ThreePointRectangleTool) Cancel(*Session)   { t.reset() }
+func (t *ThreePointRectangleTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *ThreePointRectangleTool) AutoCommits() bool { return true }
 
 // Commit adds the rectangle's four lines from the three clicked corners.
 func (t *ThreePointRectangleTool) Commit(s *Session) error {
@@ -54,17 +55,18 @@ func (t *ThreePointRectangleTool) Prompt(*Session) string {
 
 // CenterRectangleTool draws an axis-aligned rectangle from its center and a corner, so the
 // center stays put as the rectangle grows (Inventor's Two Point Center Rectangle).
-type CenterRectangleTool struct{ collectClicks }
+type CenterRectangleTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewCenterRectangleTool returns a center rectangle tool.
 func NewCenterRectangleTool() *CenterRectangleTool { return &CenterRectangleTool{} }
 
-func (t *CenterRectangleTool) Name() string              { return "Two Point Center Rectangle" }
-func (t *CenterRectangleTool) Start(*Session)            {}
-func (t *CenterRectangleTool) Pick(*Session, Selectable) {}
-func (t *CenterRectangleTool) Cancel(*Session)           { t.reset() }
-func (t *CenterRectangleTool) CanCommit() bool           { return len(t.pts) == 2 }
-func (t *CenterRectangleTool) AutoCommits() bool         { return true }
+func (t *CenterRectangleTool) Name() string      { return "Two Point Center Rectangle" }
+func (t *CenterRectangleTool) Cancel(*Session)   { t.reset() }
+func (t *CenterRectangleTool) CanCommit() bool   { return len(t.pts) == 2 }
+func (t *CenterRectangleTool) AutoCommits() bool { return true }
 
 // Commit adds the rectangle's four lines centered on the first click.
 func (t *CenterRectangleTool) Commit(s *Session) error {
@@ -86,17 +88,18 @@ func (t *CenterRectangleTool) Prompt(*Session) string {
 
 // ThreePointCircleTool draws the circle passing through three clicked points (Inventor's
 // Three Point Circle), the dual of the center-radius head tool.
-type ThreePointCircleTool struct{ collectClicks }
+type ThreePointCircleTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewThreePointCircleTool returns a three-point circle tool.
 func NewThreePointCircleTool() *ThreePointCircleTool { return &ThreePointCircleTool{} }
 
-func (t *ThreePointCircleTool) Name() string              { return "Three Point Circle" }
-func (t *ThreePointCircleTool) Start(*Session)            {}
-func (t *ThreePointCircleTool) Pick(*Session, Selectable) {}
-func (t *ThreePointCircleTool) Cancel(*Session)           { t.reset() }
-func (t *ThreePointCircleTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *ThreePointCircleTool) AutoCommits() bool         { return true }
+func (t *ThreePointCircleTool) Name() string      { return "Three Point Circle" }
+func (t *ThreePointCircleTool) Cancel(*Session)   { t.reset() }
+func (t *ThreePointCircleTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *ThreePointCircleTool) AutoCommits() bool { return true }
 
 // Commit fits and adds the circle through the three clicked points.
 func (t *ThreePointCircleTool) Commit(s *Session) error {
@@ -124,17 +127,18 @@ func (t *ThreePointCircleTool) Prompt(*Session) string {
 
 // CenterPointArcTool draws an arc from its center, a start point (sets the radius) and an
 // end point (sets the sweep), the dual of the three-point head arc tool.
-type CenterPointArcTool struct{ collectClicks }
+type CenterPointArcTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewCenterPointArcTool returns a center-point arc tool.
 func NewCenterPointArcTool() *CenterPointArcTool { return &CenterPointArcTool{} }
 
-func (t *CenterPointArcTool) Name() string              { return "Center Point Arc" }
-func (t *CenterPointArcTool) Start(*Session)            {}
-func (t *CenterPointArcTool) Pick(*Session, Selectable) {}
-func (t *CenterPointArcTool) Cancel(*Session)           { t.reset() }
-func (t *CenterPointArcTool) CanCommit() bool           { return len(t.pts) == 3 }
-func (t *CenterPointArcTool) AutoCommits() bool         { return true }
+func (t *CenterPointArcTool) Name() string      { return "Center Point Arc" }
+func (t *CenterPointArcTool) Cancel(*Session)   { t.reset() }
+func (t *CenterPointArcTool) CanCommit() bool   { return len(t.pts) == 3 }
+func (t *CenterPointArcTool) AutoCommits() bool { return true }
 
 // Commit adds the arc; it sweeps counter-clockwise when the end lies CCW of the start
 // about the center (the cross product of the two radii is positive).
@@ -165,16 +169,17 @@ func (t *CenterPointArcTool) Prompt(*Session) string {
 // ControlVertexSplineTool draws a B-spline from its control polygon (the clicked points are
 // control vertices, not points the curve passes through), the dual of the interpolation
 // head spline tool. OK finishes the curve.
-type ControlVertexSplineTool struct{ collectClicks }
+type ControlVertexSplineTool struct {
+	dialogTool
+	collectClicks
+}
 
 // NewControlVertexSplineTool returns a control-vertex spline tool.
 func NewControlVertexSplineTool() *ControlVertexSplineTool { return &ControlVertexSplineTool{} }
 
-func (t *ControlVertexSplineTool) Name() string              { return "Control Vertex Spline" }
-func (t *ControlVertexSplineTool) Start(*Session)            {}
-func (t *ControlVertexSplineTool) Pick(*Session, Selectable) {}
-func (t *ControlVertexSplineTool) Cancel(*Session)           { t.reset() }
-func (t *ControlVertexSplineTool) CanCommit() bool           { return len(t.pts) >= 2 }
+func (t *ControlVertexSplineTool) Name() string    { return "Control Vertex Spline" }
+func (t *ControlVertexSplineTool) Cancel(*Session) { t.reset() }
+func (t *ControlVertexSplineTool) CanCommit() bool { return len(t.pts) >= 2 }
 
 // Commit adds the spline from the clicked control polygon.
 func (t *ControlVertexSplineTool) Commit(s *Session) error {

--- a/app/stitch_tool.go
+++ b/app/stitch_tool.go
@@ -12,6 +12,7 @@ import (
 // into one quilt, promoting a closed quilt to a solid unless "keep as surface" is set. It takes
 // no pick (it operates on all surfaces); the property dialog drives the tolerance and that flag.
 type StitchTool struct {
+	dialogTool
 	tolerance   float64
 	keepSurface bool
 	added       *feature.PartFeature
@@ -24,10 +25,8 @@ func NewStitchTool() *StitchTool { return &StitchTool{} }
 func (t *StitchTool) Name() string { return "Stitch" }
 
 // Start has nothing to select — stitch welds every running surface body.
-func (t *StitchTool) Start(*Session) {}
 
 // Pick is unused.
-func (t *StitchTool) Pick(*Session, Selectable) {}
 
 // The options the dialog drives: weld tolerance and whether to keep a closed quilt as a surface.
 func (t *StitchTool) SetTolerance(v float64) { t.tolerance = v }
@@ -67,7 +66,6 @@ func (t *StitchTool) addStitch(fs *feature.PartFeatures) *feature.PartFeature {
 }
 
 // Cancel abandons the tool with no change.
-func (t *StitchTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *StitchTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/surface_edit_tools.go
+++ b/app/surface_edit_tools.go
@@ -117,6 +117,7 @@ func (t *RuledSurfaceTool) AddedFeature() *feature.PartFeature { return t.added 
 // SurfaceOffsetTool offsets the running surface body along its normal by a distance —
 // parameter-only (the running surface is the input, nothing is picked).
 type SurfaceOffsetTool struct {
+	dialogTool
 	distance float64
 	added    *feature.PartFeature
 }
@@ -133,10 +134,8 @@ func (t *SurfaceOffsetTool) Prompt(*Session) string {
 }
 
 // Start implements [Tool] (no pick — the running surface is the input).
-func (t *SurfaceOffsetTool) Start(*Session) {}
 
 // Pick implements [Tool] (no pick).
-func (t *SurfaceOffsetTool) Pick(*Session, Selectable) {}
 
 // SetDistance/Distance drive how far the surface offsets (sign picks the side).
 func (t *SurfaceOffsetTool) SetDistance(d float64) { t.distance = d }
@@ -167,7 +166,6 @@ func (t *SurfaceOffsetTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (nothing to restore — no selection filter was set).
-func (t *SurfaceOffsetTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SurfaceOffsetTool) AddedFeature() *feature.PartFeature { return t.added }
@@ -175,6 +173,7 @@ func (t *SurfaceOffsetTool) AddedFeature() *feature.PartFeature { return t.added
 // MidSurfaceTool extracts mid-plane patches from the running solid's thin walls —
 // parameter-only (face pairs within the threshold are found automatically).
 type MidSurfaceTool struct {
+	dialogTool
 	maxThickness float64
 	added        *feature.PartFeature
 }
@@ -191,10 +190,8 @@ func (t *MidSurfaceTool) Prompt(*Session) string {
 }
 
 // Start implements [Tool] (no pick — the running solid is the input).
-func (t *MidSurfaceTool) Start(*Session) {}
 
 // Pick implements [Tool] (no pick).
-func (t *MidSurfaceTool) Pick(*Session, Selectable) {}
 
 // SetMaxThickness/MaxThickness drive the wall-pairing threshold.
 func (t *MidSurfaceTool) SetMaxThickness(d float64) { t.maxThickness = d }
@@ -226,7 +223,6 @@ func (t *MidSurfaceTool) Commit(s *Session) error {
 }
 
 // Cancel implements [Tool] (nothing to restore).
-func (t *MidSurfaceTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *MidSurfaceTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/thicken_tool.go
+++ b/app/thicken_tool.go
@@ -12,6 +12,7 @@ import (
 // the wall thickness in the property window and OK to turn it into a solid slab. It takes no
 // face picks — it thickens the running surface body.
 type ThickenTool struct {
+	dialogTool
 	thickness float64
 	approxIdx int // index into ApproximationOptions (#331; 0 = exact)
 	added     *feature.PartFeature
@@ -27,7 +28,6 @@ func (t *ThickenTool) Name() string { return "Thicken" }
 func (t *ThickenTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
 
 // Pick is a no-op — thicken acts on the running surface body, not a selection.
-func (t *ThickenTool) Pick(*Session, Selectable) {}
 
 // SetThickness/Thickness set the wall thickness (database units).
 func (t *ThickenTool) SetThickness(d float64) { t.thickness = d }

--- a/head/internal/addinhost/testdata/echoaddin/main.go
+++ b/head/internal/addinhost/testdata/echoaddin/main.go
@@ -90,4 +90,4 @@ func ObkAddInAutomation(method *C.char, req *C.uint8_t, n C.int, resp **C.uint8_
 	return C.OBK_OK
 }
 
-func main() {}
+func main() { /* fixture add-in: built as a shared library, never run directly */ }

--- a/head/internal/addinhost/testdata/incompataddin/main.go
+++ b/head/internal/addinhost/testdata/incompataddin/main.go
@@ -47,6 +47,6 @@ func ObkAddInDeactivate() C.int { return C.OBK_OK }
 func ObkAddInNotify(ev *C.uint8_t, n C.int) C.int { return C.OBK_OK }
 
 //export ObkFree
-func ObkFree(p *C.uint8_t) {}
+func ObkFree(p *C.uint8_t) { /* fixture: nothing was allocated to free */ }
 
-func main() {}
+func main() { /* fixture add-in: built as a shared library, never run directly */ }

--- a/head/internal/addinhost/testdata/uiaddin/main.go
+++ b/head/internal/addinhost/testdata/uiaddin/main.go
@@ -164,4 +164,4 @@ func callHost(method string, req []byte) ([]byte, bool) {
 //export ObkFree
 func ObkFree(p *C.uint8_t) { C.free(unsafe.Pointer(p)) }
 
-func main() {}
+func main() { /* fixture add-in: built as a shared library, never run directly */ }

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -312,7 +312,7 @@ func InputTextCommand(label string, buf []byte, history []string, histCursor *in
 // that releases every string and the array. Returns (nil, no-op) for an empty slice.
 func cStringArray(ss []string) (**C.char, func()) {
 	if len(ss) == 0 {
-		return nil, func() {}
+		return nil, func() { /* no cleanup needed */ }
 	}
 	arr := C.malloc(C.size_t(len(ss)) * C.size_t(unsafe.Sizeof(uintptr(0))))
 	slice := unsafe.Slice((**C.char)(arr), len(ss))

--- a/model/assembly/constraint.go
+++ b/model/assembly/constraint.go
@@ -136,7 +136,8 @@ func (c *constraintBase) Value() float64 { return 0 }
 
 // SetValue is a no-op by default — a constraint with no driven value (e.g. a custom
 // residual) ignores a positional override. Value-bearing kinds override it.
-func (c *constraintBase) SetValue(float64) {}
+func (c *constraintBase) SetValue(float64) { /* no driven value to set; value-bearing kinds override */
+}
 
 // Limits returns the driven-value bounds, or a nil interface when unbounded.
 func (c *constraintBase) Limits() contract.ConstraintLimits {

--- a/model/assembly/drive_residual.go
+++ b/model/assembly/drive_residual.go
@@ -30,7 +30,7 @@ func (p *drivenPin) Suppressed() bool { return false }
 func (p *drivenPin) anchors() []anchor { return p.joint.anchors() }
 
 // setHealth is a no-op: the pin is transient and carries no reportable health.
-func (p *drivenPin) setHealth(health.Status) {}
+func (p *drivenPin) setHealth(health.Status) { /* transient pin: no reportable health */ }
 
 // bind emits the single pin residual over the joint's two origin placements.
 func (p *drivenPin) bind(b binder) []solve.Residual {

--- a/model/occurrence/listener.go
+++ b/model/occurrence/listener.go
@@ -32,8 +32,13 @@ type OccurrenceListener interface {
 // listener. SetListener(nil) restores it.
 type silentListener struct{}
 
-func (silentListener) OccurrenceAdded(*Occurrence)                     {}
-func (silentListener) OccurrenceRemoved(*Occurrence)                   {}
-func (silentListener) OccurrenceReplaced(*Occurrence, Definition)      {}
-func (silentListener) OccurrenceTransformed(*Occurrence, math.Matrix4) {}
-func (silentListener) OccurrenceSuppressionChanged(*Occurrence)        {}
+func (silentListener) OccurrenceAdded(*Occurrence) { /* silent null object: this event is intentionally ignored */
+}
+func (silentListener) OccurrenceRemoved(*Occurrence) { /* silent null object: this event is intentionally ignored */
+}
+func (silentListener) OccurrenceReplaced(*Occurrence, Definition) { /* silent null object: this event is intentionally ignored */
+}
+func (silentListener) OccurrenceTransformed(*Occurrence, math.Matrix4) { /* silent null object: this event is intentionally ignored */
+}
+func (silentListener) OccurrenceSuppressionChanged(*Occurrence) { /* silent null object: this event is intentionally ignored */
+}

--- a/model/param/expr_ast.go
+++ b/model/param/expr_ast.go
@@ -49,7 +49,7 @@ type callNode struct {
 	args []node
 }
 
-func (n numberNode) walkRefs(func(*refNode))  {}
+func (n numberNode) walkRefs(func(*refNode))  { /* a literal has no references to walk */ }
 func (n *refNode) walkRefs(fn func(*refNode)) { fn(n) }
 func (n binaryNode) walkRefs(fn func(*refNode)) {
 	n.lhs.walkRefs(fn)

--- a/model/sketch/auto_dimension.go
+++ b/model/sketch/auto_dimension.go
@@ -81,7 +81,7 @@ func dimCandidate(add func() (*DimensionConstraint, error), dc *DimensionConstra
 	return func() func() {
 		d, err := add()
 		if err != nil {
-			return func() {}
+			return func() { /* nothing was added, so nothing to undo */ }
 		}
 		return func() { dc.Delete(d) }
 	}


### PR DESCRIPTION
Second maintainability batch: resolve the **209** `go:S1186` findings (empty method bodies needing an explanation).

## Approach
Most are no-op `Start`/`Pick`/`Cancel` hooks duplicated across the **dialog-driven tools** — tools that gather all input from their `Params` dialog and pick nothing in the 3D view. Rather than commenting ~190 identical empty bodies, hoist them into a single embeddable **`dialogTool`** base (mirroring the no-op hooks `derivedViewTool` already provided) and embed it; each tool overrides only the hooks it actually needs (commonly `Start`, to capture the base-view list).

This **removes** the duplication instead of documenting it 190 times — net **−76 lines** across 48 files. Any tool that failed to satisfy `Tool` after the change would be a compile error, so the refactor is verified by the build.

The handful of genuinely-empty bodies that aren't dialog tools — the `silentListener` null object, constraint/pin no-op setters, default no-op closures in the feature-edit router, a literal node's `walkRefs`, and the test-fixture add-in entry points — get a short nested comment explaining why.

## Tests
- `go build ./...`, full root test suite, `golangci-lint`, `gofmt` — all clean; head module builds under cgo.
- No behaviour change: the embedded no-ops are identical to the deleted ones; tools with real `Start`/`Pick` logic keep (shadow) it.

Remaining maintainability work (separate PR): ~50 cognitive-complexity refactors (S3776).

🤖 Generated with [Claude Code](https://claude.com/claude-code)