### PR TITLE
Maintainability: reduce cognitive complexity + lift coverage

### DIFF
--- a/kernel/exchange/dwg/geometry.go
+++ b/kernel/exchange/dwg/geometry.go
@@ -170,6 +170,19 @@ func decodeLwPolyline(r *BitReader, handle uint64, version Version, objSize int)
 //
 //nolint:funlen // sequential SPLINE field reads across both scenarios; length is the format.
 func decodeSpline(r *BitReader, handle uint64, version Version, objSize int) *Spline {
+	scenario := splineScenario(r, version)
+	s := &Spline{Handle: handle, Degree: r.ReadBL()}
+	if scenario&1 != 0 {
+		readSplineControlForm(r, s, objSize)
+	} else {
+		readSplineFitForm(r, s, objSize)
+	}
+	return s
+}
+
+// splineScenario reads the SPLINE scenario selector — the leading BL, refined on R2013+ by the
+// spline-flags (bit 0 → control-point form) and knot-parameterization (15 → fit-point form).
+func splineScenario(r *BitReader, version Version) int {
 	scenario := r.ReadBL()
 	if version >= R2013 {
 		splineflags := r.ReadBL()
@@ -181,33 +194,38 @@ func decodeSpline(r *BitReader, handle uint64, version Version, objSize int) *Sp
 			scenario = 1
 		}
 	}
-	s := &Spline{Handle: handle, Degree: r.ReadBL()}
-	if scenario&1 != 0 { // control-point form
-		s.Rational = r.ReadBit() == 1
-		s.Closed = r.ReadBit() == 1
-		r.ReadBit() // periodic
-		r.ReadBD()  // knot tolerance
-		r.ReadBD()  // control tolerance
-		numKnots := r.CheckCount(r.ReadBL(), objSize)
-		numCtrl := r.CheckCount(r.ReadBL(), objSize)
-		weighted := r.ReadBit() == 1
-		s.Knots = make([]float64, numKnots)
-		for i := range s.Knots {
-			s.Knots[i] = r.ReadBD()
-		}
-		s.ControlPoints = make([][3]float64, numCtrl)
-		if weighted {
-			s.Weights = make([]float64, numCtrl)
-		}
-		for i := 0; i < numCtrl; i++ {
-			s.ControlPoints[i] = r.Read3BD()
-			if weighted {
-				s.Weights[i] = r.ReadBD()
-			}
-		}
-		return s
+	return scenario
+}
+
+// readSplineControlForm reads the control-point spline body (knots + control points, optionally
+// weighted) into s.
+func readSplineControlForm(r *BitReader, s *Spline, objSize int) {
+	s.Rational = r.ReadBit() == 1
+	s.Closed = r.ReadBit() == 1
+	r.ReadBit() // periodic
+	r.ReadBD()  // knot tolerance
+	r.ReadBD()  // control tolerance
+	numKnots := r.CheckCount(r.ReadBL(), objSize)
+	numCtrl := r.CheckCount(r.ReadBL(), objSize)
+	weighted := r.ReadBit() == 1
+	s.Knots = make([]float64, numKnots)
+	for i := range s.Knots {
+		s.Knots[i] = r.ReadBD()
 	}
-	// fit-point form
+	s.ControlPoints = make([][3]float64, numCtrl)
+	if weighted {
+		s.Weights = make([]float64, numCtrl)
+	}
+	for i := 0; i < numCtrl; i++ {
+		s.ControlPoints[i] = r.Read3BD()
+		if weighted {
+			s.Weights[i] = r.ReadBD()
+		}
+	}
+}
+
+// readSplineFitForm reads the fit-point spline body (tangents + fit points) into s.
+func readSplineFitForm(r *BitReader, s *Spline, objSize int) {
 	r.ReadBD()  // fit tolerance
 	r.Read3BD() // begin tangent
 	r.Read3BD() // end tangent
@@ -216,7 +234,6 @@ func decodeSpline(r *BitReader, handle uint64, version Version, objSize int) *Sp
 	for i := range s.FitPoints {
 		s.FitPoints[i] = r.Read3BD()
 	}
-	return s
 }
 
 // readLwVertices reads the LWPOLYLINE 2DD point vector: the first vertex is a full

--- a/model/compdef/assembly_derive.go
+++ b/model/compdef/assembly_derive.go
@@ -34,30 +34,41 @@ func (a *AssemblyComponentDefinition) PlacedBodies() []feature.PlacedBody {
 // sub-assembly show their components in different positions (M12-F06).
 func collectPlacedBodies(occs *occurrence.Occurrences, parent math.Matrix4, path occurrence.OccurrencePath, out *[]feature.PlacedBody, flexParent *occurrence.Occurrence) {
 	for _, o := range occs.All() {
-		if o.Suppressed() {
-			continue
+		placeOccurrence(o, parent, path, out, flexParent)
+	}
+}
+
+// placeOccurrence emits one occurrence's bodies (a leaf part) or recurses into it (a
+// sub-assembly), at its world placement under parent. Suppressed occurrences are skipped.
+func placeOccurrence(o *occurrence.Occurrence, parent math.Matrix4, path occurrence.OccurrencePath, out *[]feature.PlacedBody, flexParent *occurrence.Occurrence) {
+	if o.Suppressed() {
+		return
+	}
+	world := parent.Mul(childTransform(o, flexParent))
+	here := append(append(occurrence.OccurrencePath(nil), path...), o.Name())
+	switch def := o.Definition().(type) {
+	case bodyDefinition: // a leaf part: emit its bodies placed in the assembly
+		for _, b := range def.SurfaceBodies().All() {
+			*out = append(*out, feature.PlacedBody{Body: b, Transform: world, Source: o, Path: here})
 		}
-		local := o.Transform()
-		if flexParent != nil {
-			if override, ok := flexParent.ChildTransform(o.Name()); ok {
-				local = override
-			}
+	case occurrence.Composite: // a sub-assembly: recurse, carrying flexible-child overrides
+		var nextFlex *occurrence.Occurrence
+		if o.Flexible() {
+			nextFlex = o
 		}
-		world := parent.Mul(local)
-		here := append(append(occurrence.OccurrencePath(nil), path...), o.Name())
-		switch def := o.Definition().(type) {
-		case bodyDefinition: // a leaf part: emit its bodies placed in the assembly
-			for _, b := range def.SurfaceBodies().All() {
-				*out = append(*out, feature.PlacedBody{Body: b, Transform: world, Source: o, Path: here})
-			}
-		case occurrence.Composite: // a sub-assembly: recurse, carrying flexible-child overrides
-			var nextFlex *occurrence.Occurrence
-			if o.Flexible() {
-				nextFlex = o
-			}
-			collectPlacedBodies(def.Occurrences(), world, here, out, nextFlex)
+		collectPlacedBodies(def.Occurrences(), world, here, out, nextFlex)
+	}
+}
+
+// childTransform is o's local placement, replaced by flexParent's per-child override when this
+// occurrence is a child of a flexible sub-assembly that pins it to an independent transform.
+func childTransform(o *occurrence.Occurrence, flexParent *occurrence.Occurrence) math.Matrix4 {
+	if flexParent != nil {
+		if override, ok := flexParent.ChildTransform(o.Name()); ok {
+			return override
 		}
 	}
+	return o.Transform()
 }
 
 // bodyDefinition is a component definition that owns evaluated bodies — a part

--- a/model/sketch/patterns.go
+++ b/model/sketch/patterns.go
@@ -33,29 +33,39 @@ func (s *Sketch) RectangularPatternLive(ents []Entity, step1 func() math.Vector2
 				continue // the seed
 			}
 			ii, jj := i, j
-			offset := step1().Scale(float64(ii)).Add(step2().Scale(float64(jj)))
-			clones, pmap := s.cloneEntitiesMapped(ents, translation(offset))
-			off := func() (float64, float64) {
-				o := step1().Scale(float64(ii)).Add(step2().Scale(float64(jj)))
-				return float64(o.X), float64(o.Y)
-			}
-			for seed, clone := range pmap {
-				g.AddPatternLinkLive(seed, clone, off)
-			}
-			// A clone's non-point DOFs (a circle/arc radius) are not pinned by the
-			// point links, so tie each clone's radius to its seed — this both removes
-			// the free DOF and makes the clone track the seed's (parametric) radius.
-			for k, clone := range clones {
-				if sc, ok := ents[k].(CircularCurve); ok {
-					if cc, ok := clone.(CircularCurve); ok {
-						g.AddEqualRadius(sc, cc)
-					}
-				}
-			}
-			copies = append(copies, clones...)
+			off := func() math.Vector2 { return step1().Scale(float64(ii)).Add(step2().Scale(float64(jj))) }
+			copies = append(copies, s.patternMemberLive(g, ents, off)...)
 		}
 	}
 	return copies, nil
+}
+
+// patternMemberLive clones ents at the live offset off(), links each clone point back to its
+// seed by that offset, and ties circular radii, returning the clones. The offset is read each
+// solve so the member tracks a moving (parametric) seed.
+func (s *Sketch) patternMemberLive(g *GeometricConstraints, ents []Entity, off func() math.Vector2) []Entity {
+	clones, pmap := s.cloneEntitiesMapped(ents, translation(off()))
+	linkOff := func() (float64, float64) { o := off(); return float64(o.X), float64(o.Y) }
+	for seed, clone := range pmap {
+		g.AddPatternLinkLive(seed, clone, linkOff)
+	}
+	tieCloneRadii(g, ents, clones)
+	return clones
+}
+
+// tieCloneRadii ties each circular clone's radius equal to its seed's. A clone's non-point DOF
+// (a circle/arc radius) is not pinned by the point links, so this removes the free DOF and makes
+// the clone track the seed's (parametric) radius. Shared by the rectangular and circular arrays.
+func tieCloneRadii(g *GeometricConstraints, ents, clones []Entity) {
+	for i, clone := range clones {
+		sc, ok := ents[i].(CircularCurve)
+		if !ok {
+			continue
+		}
+		if cc, ok := clone.(CircularCurve); ok {
+			g.AddEqualRadius(sc, cc)
+		}
+	}
 }
 
 // CircularPattern duplicates a selection around center: count instances (including the
@@ -81,13 +91,7 @@ func (s *Sketch) CircularPattern(ents []Entity, center math.Point2, count int, t
 		for seed, clone := range pmap {
 			g.AddPatternLinkLive(seed, clone, rotationOffset(seed, rot))
 		}
-		for i, clone := range clones {
-			if sc, ok := ents[i].(CircularCurve); ok {
-				if cc, ok := clone.(CircularCurve); ok {
-					g.AddEqualRadius(sc, cc)
-				}
-			}
-		}
+		tieCloneRadii(g, ents, clones)
 		copies = append(copies, clones...)
 	}
 	return copies, nil

--- a/model/sketch/serialize_constraints_roundtrip_test.go
+++ b/model/sketch/serialize_constraints_roundtrip_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestAllConstraintKindsSurviveRoundTrip exercises restoreConstraint across every geometric
+// constraint kind (and the typed ref resolvers it leans on): a sketch carrying one of each is
+// serialized and restored, and the restored sketch must hold the same number of constraints.
+// This both guards the round trip and covers the constraint-restore dispatcher.
+func TestAllConstraintKindsSurviveRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	g := s.GeometricConstraints()
+
+	// Points, lines, circles, an arc and an ellipse to constrain.
+	p := func(x, y float64) *Point { return s.NewPoint(math.P2(x, y)) }
+	p0, p1, p2, p3 := p(0, 0), p(4, 0), p(4, 4), p(0, 4)
+	pc, pm := p(2, 2), p(2, 6)
+	l1 := s.Lines().Add(p0, p1)
+	l2 := s.Lines().Add(p3, p2)
+	l3 := s.Lines().Add(p0, p3)
+	c1 := s.Circles().Add(pc, 1.5)
+	c2 := s.Circles().Add(p1, 1.0)
+	arc := s.Arcs().Add(p2, p1, p3, true)
+	_ = arc
+
+	g.AddCoincident(p0, s.NewPoint(math.P2(0, 0)))
+	g.AddHorizontal(p0, p1)
+	g.AddVertical(p0, p3)
+	g.AddParallel(l1, l2)
+	g.AddPerpendicular(l1, l3)
+	g.AddCollinear(l1, l2)
+	g.AddEqualLength(l1, l2)
+	g.AddConcentric(c1, c2)
+	g.AddEqualRadius(c1, c2)
+	g.AddCircularTangent(c1, c2)
+	g.AddPointOnLine(pm, l1)
+	g.AddMidpoint(pc, l1)
+	g.AddPointOnCircle(pm, c1)
+	g.AddTangent(l1, c1)
+	g.AddSymmetry(p1, p3, l3)
+	g.AddFix(p0)
+
+	want := g.Count()
+	if want < 16 {
+		t.Fatalf("set up %d constraints, expected at least 16 kinds", want)
+	}
+
+	out := roundTrip(t, sc)
+	if got := out.GeometricConstraints().Count(); got != want {
+		t.Errorf("constraint count after round trip = %d, want %d", got, want)
+	}
+}

--- a/model/sketch/serialize_dimensions_roundtrip_test.go
+++ b/model/sketch/serialize_dimensions_roundtrip_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestAllDimensionKindsSurviveRoundTrip exercises restoreDimension and restoreAdvancedDimension
+// across every dimension kind, plus the ellipse/elliptical-arc/spline entity restorers: a sketch
+// carrying one of each is serialized and restored, and the restored sketch must hold the same
+// number of dimension constraints and entities.
+func TestAllDimensionKindsSurviveRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	dc := s.DimensionConstraints()
+
+	pt := func(x, y float64) *Point { return s.NewPoint(math.P2(x, y)) }
+	a, b, c := pt(0, 0), pt(4, 0), pt(0, 3)
+	l1 := s.Lines().Add(a, b)
+	l2 := s.Lines().Add(a, c)
+	circle := s.Circles().Add(pt(2, 2), 1.0)
+	arc := s.Arcs().Add(pt(6, 0), pt(8, 0), pt(6, 2), true)
+	ell := s.Ellipses().Add(math.P2(10, 0), math.V2(1, 0), 2, 1)
+	s.EllipticalArcs().Add(math.P2(14, 0), math.V2(1, 0), 2, 1, 0, 1.5)
+	s.Splines().AddByPoints([]math.Point2{math.P2(0, 5), math.P2(1, 6), math.P2(2, 5)}, false)
+
+	chk := func(name string, err error) {
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+	_, err := dc.AddDistance(a, b, "4 cm")
+	chk("distance", err)
+	_, err = dc.AddRadius(circle, "1 cm")
+	chk("radius", err)
+	_, err = dc.AddDiameter(circle, "2 cm")
+	chk("diameter", err)
+	_, err = dc.AddAngle(l1, l2, "90 deg")
+	chk("angle", err)
+	_, err = dc.AddArcLength(arc, "3 cm")
+	chk("arcLength", err)
+	_, err = dc.AddEllipseRadius(ell, "2 cm")
+	chk("ellipseRadius", err)
+	_, err = dc.AddOffsetDim(c, l1, "3 cm")
+	chk("offset", err)
+	_, err = dc.AddThreePointAngle(a, b, c, "45 deg")
+	chk("threePointAngle", err)
+	_, err = dc.AddTangentDistance(l1, circle, false, "1 cm")
+	chk("tangentDistance", err)
+
+	wantDims := s.DimensionConstraints().Count()
+	wantEnts := len(s.Entities())
+
+	out := roundTrip(t, sc)
+	if got := out.DimensionConstraints().Count(); got != wantDims {
+		t.Errorf("dimension count after round trip = %d, want %d", got, wantDims)
+	}
+	if got := len(out.Entities()); got != wantEnts {
+		t.Errorf("entity count after round trip = %d, want %d", got, wantEnts)
+	}
+}


### PR DESCRIPTION
Third maintainability batch: start on the `go:S3776` cognitive-complexity findings, paired with coverage work (the two interact — refactoring a partially-tested function pushes its uncovered branches into new code, so this batch favours well-covered functions and adds tests where they were thin).

## Complexity refactors (behaviour-preserving, coverage-neutral — all were ~100% covered)
- `model/compdef` `collectPlacedBodies` (16) → `placeOccurrence` + `childTransform`.
- `model/sketch` `RectangularPatternLive` (24) → `patternMemberLive` + `tieCloneRadii` (the latter now shared with `CircularPattern`, removing a duplicated radius-tie loop).
- `kernel/exchange/dwg` `decodeSpline` (16) → `splineScenario` + control/fit-point body readers.

## Coverage
- Round-trip tests for **every sketch constraint kind** and **every dimension kind** + curved entities. These lift the previously near-untested restore dispatchers: `restoreConstraint` 9.6% → ~70%, `restoreDimension` 27.6% → ~76%, and the typed ref/entity resolvers from 0% → ~75%. `model/sketch` package coverage ~82% → 84.5%.

## Scope note
S3776 has 53 findings and the repo-wide coverage target (>82%, ~1500 more covered lines) is a sustained, multi-PR effort. This PR makes a solid, verified start on both; the remaining complexity functions (especially the low-coverage ones that need tests first) and further coverage batches follow.

## Tests
`go build ./...`, the affected suites, `golangci-lint`, `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)