### PR TITLE
fix(geom): polyline closest-point parameter always returned 0

### DIFF
--- a/kernel/geom/evaluator_point2.go
+++ b/kernel/geom/evaluator_point2.go
@@ -73,9 +73,13 @@ func polylineParamAtPoint2(g Polyline2d, p math.Point2) (float64, SolutionNature
 		local := segmentParamAtPoint2(seg, p)
 		foot := seg.PointAt(local)
 		d := foot.DistanceTo(p)
-		tol := 1e-12 * stdmath.Max(1, best)
+		// tol is a scale-relative band for the closer/tie decision. It must be computed from a
+		// FINITE reference: seeding best with +Inf made 1e-12*best = +Inf, so best-tol was NaN and
+		// the "strictly closer" guard was always false — every point on a polyline resolved to the
+		// start (param 0). Base it on the candidate distance, and always accept the first segment.
+		tol := 1e-12 * stdmath.Max(1, d)
 		switch {
-		case d < best-tol:
+		case stdmath.IsInf(best, 1) || d < best-tol:
 			best, bestT, ties, bestFoot = d, (float64(i)+local)/float64(segs), 0, foot
 		case d <= best+tol && foot.DistanceTo(bestFoot) > math.DefaultTolerance:
 			ties++

--- a/kernel/geom/evaluator_point2_test.go
+++ b/kernel/geom/evaluator_point2_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestCurveParamAtPoint2RoundTrips covers CurveParamAtPoint2 across each 2D curve kind: a point
+// sampled at a known parameter must resolve back to a parameter that evaluates to (approximately)
+// the same point — exercising the per-kind param solvers (segment/circle/arc/polyline).
+func TestCurveParamAtPoint2RoundTrips(t *testing.T) {
+	poly, err := NewPolyline2d([]gmath.Point2{gmath.P2(0, 0), gmath.P2(3, 0), gmath.P2(3, 4)})
+	if err != nil {
+		t.Fatalf("NewPolyline2d: %v", err)
+	}
+	// Each query point is a clear interior point on the curve (corners are intentionally
+	// avoided — a vertex is an ambiguous projection target).
+	cases := []struct {
+		name  string
+		c     Curve2
+		query gmath.Point2
+	}{
+		{"segment", NewLineSegment2d(gmath.P2(0, 0), gmath.P2(10, 0)), gmath.P2(4, 0)},
+		{"circle", NewCircle2d(gmath.P2(0, 0), 2), gmath.P2(2, 0)},
+		{"arc", NewArc2d(gmath.P2(0, 0), 1, 0, math.Pi/2), gmath.P2(float64(math.Sqrt2)/2, float64(math.Sqrt2)/2)},
+		{"polyline", poly, gmath.P2(1.5, 0)},
+	}
+	for _, tc := range cases {
+		got, _ := CurveParamAtPoint2(tc.c, tc.query)
+		back := tc.c.PointAt(got)
+		if d := math.Hypot(float64(back.X-tc.query.X), float64(back.Y-tc.query.Y)); d > 1e-6 {
+			t.Errorf("%s: param %.4f maps to %v, want ~%v (off by %g)", tc.name, got, back, tc.query, d)
+		}
+	}
+}
+
+// TestCurveRangeBox2BoundsCurve covers CurveRangeBox2: the reported box must contain points
+// sampled along each curve.
+func TestCurveRangeBox2BoundsCurve(t *testing.T) {
+	for name, c := range map[string]Curve2{
+		"segment": NewLineSegment2d(gmath.P2(-1, -2), gmath.P2(3, 4)),
+		"circle":  NewCircle2d(gmath.P2(1, 1), 2),
+		"arc":     NewArc2d(gmath.P2(0, 0), 5, 0, math.Pi),
+	} {
+		box := CurveRangeBox2(c)
+		for _, tt := range []float64{0, 0.25, 0.5, 0.75, 1} {
+			p := c.PointAt(tt)
+			if p.X < box.Min.X-1e-6 || p.X > box.Max.X+1e-6 || p.Y < box.Min.Y-1e-6 || p.Y > box.Max.Y+1e-6 {
+				t.Errorf("%s: sampled point %v outside range box %v..%v", name, p, box.Min, box.Max)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Bug
`polylineParamAtPoint2` (the `Polyline2d` case of `CurveParamAtPoint2`) always returned parameter **0** for any query point — every point on a polyline resolved to the start vertex.

### Root cause
`best` is seeded with `+Inf`, and the per-iteration tie tolerance is `tol := 1e-12 * max(1, best)`, which is `+Inf` for that seed. So `best - tol` is `NaN`, the "strictly closer" guard `d < best-tol` is **always false**, and no segment is ever accepted — `bestT` stays `0` (and it's misclassified `DistinctlyManySolutions`).

### Fix
Base the tolerance on the candidate distance `d` (always finite) and always accept the first segment (`IsInf(best, 1) || d < best-tol`).

## How it was found
While adding evaluator coverage: a round-trip test (a point sampled on the curve must resolve to a parameter that evaluates back to that point) failed for polylines while the underlying `segmentParamAtPoint2` was correct — isolating the defect to the polyline aggregation.

## Test / impact
- New `evaluator_point2_test.go`: round-trips `CurveParamAtPoint2` for segment/circle/arc/polyline (the regression guard) and bounds-checks `CurveRangeBox2`. Lifts `evaluator_point2.go` coverage (several 0% solvers now exercised).
- `CurveParamAtPoint2` is consumed by `kernel/geomapi/evaluators.go`; full `kernel/geom`, `kernel/geomapi`, `model/sketch`, `kernel/ops` suites pass — no consumer relied on the buggy behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)