### PR TITLE
Maintainability: interference coverage + gridCuts complexity

### DIFF
--- a/model/compdef/interference_test.go
+++ b/model/compdef/interference_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// twoBoxAssembly places two unit-ish boxes; boxB is offset by dx along X so the caller controls
+// whether they overlap. Returns the assembly and the two occurrence ids.
+func twoBoxAssembly(t *testing.T, dx float64) (*AssemblyComponentDefinition, uint64, uint64) {
+	t.Helper()
+	a := partWithBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	b := partWithBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	asm := NewAssemblyComponentDefinition()
+	oa := asm.Place("a:1", a, math.Identity4())
+	ob := asm.Place("b:1", b, math.Translation4(math.V3(dx, 0, 0)))
+	return asm, oa.ID(), ob.ID()
+}
+
+// TestAnalyzeInterferenceDetectsOverlap covers AnalyzeInterference and its helpers: overlapping
+// occurrences are reported with positive volume; separated ones are not.
+func TestAnalyzeInterferenceDetectsOverlap(t *testing.T) {
+	overlap, _, _ := twoBoxAssembly(t, 1) // B spans x∈[1,3], overlaps A's x∈[0,2]
+	res := overlap.AnalyzeInterference(nil)
+	if res.Count() != 1 {
+		t.Fatalf("interference count = %d, want 1", res.Count())
+	}
+	if res.Total <= 0 {
+		t.Errorf("interference total volume = %g, want > 0", res.Total)
+	}
+
+	apart, _, _ := twoBoxAssembly(t, 10) // B spans x∈[10,12], no overlap
+	if got := apart.AnalyzeInterference(nil).Count(); got != 0 {
+		t.Errorf("separated parts report %d interferences, want 0", got)
+	}
+}
+
+// TestAnalyzeInterferenceSubsetFilter covers pairInSubset/idInSet: an empty-but-non-nil subset
+// (a pair not naming both ids) excludes the pair.
+func TestAnalyzeInterferenceSubsetFilter(t *testing.T) {
+	asm, a, b := twoBoxAssembly(t, 1)
+	if got := asm.AnalyzeInterference([]uint64{a, b}).Count(); got != 1 {
+		t.Errorf("subset naming both ids: count = %d, want 1", got)
+	}
+	if got := asm.AnalyzeInterference([]uint64{a, a}).Count(); got != 0 {
+		t.Errorf("subset not naming b: count = %d, want 0", got)
+	}
+}
+
+// TestWouldContactBlockWithoutContactSet covers the early no-block path: an occurrence in no
+// contact set never blocks a move.
+func TestWouldContactBlockWithoutContactSet(t *testing.T) {
+	asm, a, _ := twoBoxAssembly(t, 1)
+	if asm.WouldContactBlock(a, math.Translation4(math.V3(0.5, 0, 0))) {
+		t.Error("WouldContactBlock should be false when the occurrence shares no contact set")
+	}
+}

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -151,23 +151,42 @@ func cutPair(segs []taggedSeg, i, j int, cuts [][]cut) {
 //
 //nolint:funlen // spatial-grid binning of segment AABBs; length is the binning, not logic.
 func gridCuts(segs []taggedSeg, cuts [][]cut) {
-	minX, minY := stdmath.Inf(1), stdmath.Inf(1)
-	maxX, maxY := stdmath.Inf(-1), stdmath.Inf(-1)
-	for _, s := range segs {
-		minX, minY = stdmath.Min(minX, stdmath.Min(s.a.X, s.b.X)), stdmath.Min(minY, stdmath.Min(s.a.Y, s.b.Y))
-		maxX, maxY = stdmath.Max(maxX, stdmath.Max(s.a.X, s.b.X)), stdmath.Max(maxY, stdmath.Max(s.a.Y, s.b.Y))
-	}
-	dim := int(stdmath.Sqrt(float64(len(segs))))
-	if dim < 1 {
-		dim = 1
-	} else if dim > 2048 {
-		dim = 2048
-	}
+	minX, minY, maxX, maxY := segsBounds(segs)
+	dim := gridDim(len(segs))
 	cell := stdmath.Max(stdmath.Max(maxX-minX, maxY-minY)/float64(dim), 1e-9)
 	cols := int((maxX-minX)/cell) + 1
 	rows := int((maxY-minY)/cell) + 1
 	col := func(x float64) int { return clampInt(int((x-minX)/cell), cols) }
 	row := func(y float64) int { return clampInt(int((y-minY)/cell), rows) }
+	bins := binSegments(segs, col, row, cols, rows)
+	testBinnedPairs(segs, bins, cuts)
+}
+
+// segsBounds returns the axis-aligned extent of the segment endpoints.
+func segsBounds(segs []taggedSeg) (minX, minY, maxX, maxY float64) {
+	minX, minY = stdmath.Inf(1), stdmath.Inf(1)
+	maxX, maxY = stdmath.Inf(-1), stdmath.Inf(-1)
+	for _, s := range segs {
+		minX, minY = stdmath.Min(minX, stdmath.Min(s.a.X, s.b.X)), stdmath.Min(minY, stdmath.Min(s.a.Y, s.b.Y))
+		maxX, maxY = stdmath.Max(maxX, stdmath.Max(s.a.X, s.b.X)), stdmath.Max(maxY, stdmath.Max(s.a.Y, s.b.Y))
+	}
+	return minX, minY, maxX, maxY
+}
+
+// gridDim picks the uniform-grid resolution from the segment count, clamped to [1, 2048].
+func gridDim(n int) int {
+	dim := int(stdmath.Sqrt(float64(n)))
+	if dim < 1 {
+		return 1
+	}
+	if dim > 2048 {
+		return 2048
+	}
+	return dim
+}
+
+// binSegments buckets each segment into every grid cell its bounding box touches.
+func binSegments(segs []taggedSeg, col, row func(float64) int, cols, rows int) [][]int32 {
 	bins := make([][]int32, cols*rows)
 	for i, s := range segs {
 		for cj := row(stdmath.Min(s.a.Y, s.b.Y)); cj <= row(stdmath.Max(s.a.Y, s.b.Y)); cj++ {
@@ -176,6 +195,12 @@ func gridCuts(segs []taggedSeg, cuts [][]cut) {
 			}
 		}
 	}
+	return bins
+}
+
+// testBinnedPairs cuts every distinct co-binned segment pair exactly once (a pair can share
+// several cells, so a tested-set deduplicates).
+func testBinnedPairs(segs []taggedSeg, bins [][]int32, cuts [][]cut) {
 	tested := map[[2]int32]struct{}{}
 	for _, bin := range bins {
 		for x := 0; x < len(bin); x++ {


### PR DESCRIPTION
Third S3776 + coverage batch.

## Coverage
- `model/compdef/interference.go` was **entirely untested** — `AnalyzeInterference` + overlap/subset helpers + `WouldContactBlock`. New test: two overlapping boxes detect interference with positive volume, separated boxes do not, the subset filter and no-contact-set paths are covered. Package **76.3% → 80.8%**.

## Complexity (go:S3776)
- `model/sketch` `gridCuts` (the segment-arrangement spatial grid) → `segsBounds` / `gridDim` / `binSegments` / `testBinnedPairs`. Behaviour-preserving, still covered.

## Tests
`go build ./...`, the affected suites, `golangci-lint`, `gofmt` — all clean.

Continues the S3776 (53) + repo-coverage (>82%) effort; #1092/#1093/#1094 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)