### PR TITLE
Coverage: mesh-diagnostic draw list

### DIFF
--- a/renderer/mesh_colors_debug_test.go
+++ b/renderer/mesh_colors_debug_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package renderer
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestBuildDrawListMeshColors covers the mesh-diagnostic draw list (normal/per-face and
+// per-triangle debug colouring): a box produces triangles, each item carrying per-vertex colours.
+func TestBuildDrawListMeshColors(t *testing.T) {
+	b := box(2, math.V3(0, 0, 0))
+	for _, perTri := range []bool{false, true} {
+		list := BuildDrawListMeshColors([]*topo.Body{b}, frontCamera(), ops.DefaultQuality(), perTri)
+		if list.Triangles() == 0 {
+			t.Fatalf("perTriangle=%v: mesh-colors draw list has no triangles", perTri)
+		}
+		colored := false
+		for _, it := range list.Items {
+			if len(it.Colors) == len(it.Positions) && len(it.Colors) > 0 {
+				colored = true
+			}
+		}
+		if !colored {
+			t.Errorf("perTriangle=%v: no item carried per-vertex debug colours", perTri)
+		}
+	}
+}
+
+// TestMeshDebugColorAndHSV covers the debug-colour generators: hsvToRGB stays in range across the
+// hue wheel and successive debug colours differ.
+func TestMeshDebugColorAndHSV(t *testing.T) {
+	for _, h := range []float64{0, 60, 120, 180, 240, 300, 359} {
+		r, g, bl := hsvToRGB(h, 1, 1)
+		for _, c := range []float64{r, g, bl} {
+			if c < 0 || c > 1 {
+				t.Errorf("hsvToRGB(%g,1,1) component %g out of [0,1]", h, c)
+			}
+		}
+	}
+	if meshDebugColor(0) == meshDebugColor(3) {
+		t.Error("meshDebugColor(0) == meshDebugColor(3), expected distinct hues")
+	}
+}


### PR DESCRIPTION
Coverage batch — `renderer/mesh_colors_debug.go` (the normal-debug / per-face / per-triangle colouring used by the live-capture drivers) was entirely untested. New test exercises `BuildDrawListMeshColors` in both per-face and per-triangle modes (a box → coloured triangles) plus `hsvToRGB`/`meshDebugColor`. 6 of 7 functions covered; renderer package to **85.5%**.

The remaining S3776 functions are mostly partially-covered or numerically delicate, so this batch focuses on coverage (raising those functions toward refactor-safe levels) rather than a risky refactor. Continues the >82% repo-coverage effort.

`go build ./...`, suite, `golangci-lint`, `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)