### PR TITLE
Coverage: generic closest-point solver + feature EditableRefs

### DIFF
--- a/kernel/geom/evaluator_point2_test.go
+++ b/kernel/geom/evaluator_point2_test.go
@@ -55,3 +55,19 @@ func TestCurveRangeBox2BoundsCurve(t *testing.T) {
 		}
 	}
 }
+
+// TestCurveParamAtPoint2GenericPath covers the sampled multistart solver for curves with no
+// closed-form inverse: an ellipse query exercises genericParamAtPoint2 → sampleDistances2 →
+// clusterMinima2 → refineClosest2. The recovered parameter must evaluate back to the query point.
+func TestCurveParamAtPoint2GenericPath(t *testing.T) {
+	el, err := NewEllipseFull2d(gmath.P2(0, 0), gmath.V2(1, 0), 3, 1)
+	if err != nil {
+		t.Fatalf("NewEllipseFull2d: %v", err)
+	}
+	want := el.PointAt(0.3) // a point genuinely on the ellipse, away from the axis vertices
+	got, _ := CurveParamAtPoint2(el, want)
+	back := el.PointAt(got)
+	if d := math.Hypot(float64(back.X-want.X), float64(back.Y-want.Y)); d > 1e-4 {
+		t.Errorf("ellipse param %.4f maps to %v, want ~%v (off by %g)", got, back, want, d)
+	}
+}

--- a/model/feature/editable_refs_test.go
+++ b/model/feature/editable_refs_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "testing"
+
+// TestFeatureEditableRefs covers the EditableRefs slot exposure across the re-pickable feature
+// kinds (the #163 feature-edit re-pick surface) and the slot-builder helpers behind them: each
+// feature lists at least one labelled slot, and exercising the slot's accessors (Count/Keys/
+// Snapshot) covers the keyRef/profileRef/planeRef closures.
+func TestFeatureEditableRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		feat ReferenceEditable
+	}{
+		{"fillet", &FilletFeature{def: &FilletDefinition{}}},
+		{"chamfer", &ChamferFeature{def: &ChamferDefinition{}}},
+		{"shell", &ShellFeature{def: &ShellDefinition{}}},
+		{"draft", &FaceDraftFeature{def: &FaceDraftDefinition{}}},
+		{"hole", &HoleFeature{def: &HoleDefinition{}}},
+		{"extrude", &ExtrudeFeature{def: &ExtrudeDefinition{}}},
+		{"revolve", &RevolveFeature{def: &RevolveDefinition{}}},
+		{"coil", &CoilFeature{def: &CoilDefinition{}}},
+		{"rib", &RibFeature{def: &RibDefinition{}}},
+		{"emboss", &EmbossFeature{def: &EmbossDefinition{}}},
+		{"mirror", &MirrorFeature{def: &MirrorDefinition{}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			slots := c.feat.EditableRefs()
+			if len(slots) == 0 {
+				t.Fatalf("%s exposed no editable ref slots", c.name)
+			}
+			for i, sl := range slots {
+				if sl.Label == "" {
+					t.Errorf("%s slot %d has an empty label", c.name, i)
+				}
+				if sl.Count != nil {
+					_ = sl.Count() // exercises the slot's count closure
+				}
+				if sl.Keys != nil {
+					_ = sl.Keys() // exercises the key-snapshot closure
+				}
+				if sl.Snapshot != nil {
+					restore := sl.Snapshot()
+					if restore != nil {
+						restore() // exercises the undo-snapshot closure
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Coverage batch.

- `kernel/geom/evaluator_point2.go`: an ellipse query covers the sampled multistart closest-point solver (`genericParamAtPoint2` → `sampleDistances2` → `clusterMinima2` → `refineClosest2`), the path for curves with no closed-form inverse.
- `model/feature/editable.go`: cover `EditableRefs` across the re-pickable feature kinds (fillet/chamfer/shell/draft/hole/extrude/revolve/coil/rib/emboss/mirror, the #163 re-pick surface), exercising the keyRef/profileRef/planeRef slot closures. `model/feature` to **81.4%**.

Part of the >82% repo-coverage effort. Branched off develop in parallel with #1098 (different packages).

`go build ./...`, suites, `golangci-lint`, `gofmt` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)