### PR TITLE
feat: feature/sketch events (#148) + parametric sketch coords & pattern counts (#189)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -57,6 +57,7 @@ func Subscribe(s *app.Session, sink Sink) []event.Subscription {
 	subs = append(subs, subscribeSessionUI(bus, sink)...)
 	subs = append(subs, subscribeRepresentations(bus, sink)...)
 	subs = append(subs, subscribeParameters(bus, sink)...)
+	subs = append(subs, subscribeModeling(bus, sink)...)
 	subs = append(subs, subscribeTransactions(bus, sink)...)
 	subs = append(subs, subscribeFileAccess(s.Workspace().Events(), sink)...)
 	subs = append(subs, subscribeAssemblies(s.Workspace().Events(), sink)...)
@@ -113,6 +114,46 @@ func subscribeParameters(bus *event.Bus, sink Sink) []event.Subscription {
 			})
 		}),
 	}
+}
+
+// featureEventType maps a feature-lifecycle op to its wire event constant (references all three so
+// the API↔router parity guard sees each one relayed).
+func featureEventType(op app.FeatureOp) string {
+	switch op {
+	case app.FeatureAdded:
+		return wire.EventFeatureAdded
+	case app.FeatureDeleted:
+		return wire.EventFeatureDeleted
+	default:
+		return wire.EventFeatureEdited
+	}
+}
+
+// subscribeModeling relays the granular feature-lifecycle and sketch-edit notifications (#148): a
+// feature was added/edited/deleted, or a sketch's edit mode was entered/exited — beyond the batched
+// model.changed, so an add-in reacts per feature/sketch without diffing the tree.
+func subscribeModeling(bus *event.Bus, sink Sink) []event.Subscription {
+	return []event.Subscription{
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.FeatureLifecycleChanged) event.Outcome {
+			return relayJSON(sink, wire.FeatureLifecycleEvent{
+				Type: featureEventType(e.Op), Document: uint64(e.Document), Feature: e.Feature, Name: e.Name, Kind: e.Kind,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.SketchEditChanged) event.Outcome {
+			return relayJSON(sink, wire.SketchEditEvent{
+				Type: sketchEditEventType(e.Entered), Document: uint64(e.Document), Sketch: e.Sketch, Name: e.Name,
+			})
+		}),
+	}
+}
+
+// sketchEditEventType maps the entered/exited flag to its wire event constant (references both so
+// the parity guard sees each relayed).
+func sketchEditEventType(entered bool) string {
+	if entered {
+		return wire.EventSketchEditEntered
+	}
+	return wire.EventSketchEditExited
 }
 
 // subscribeRepresentations relays the representation / model-state change notifications (#901): the
@@ -269,7 +310,8 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.FileDialogHookPayload | wire.OccurrenceEventPayload |
 	wire.AssemblyFeaturesChangedEvent | wire.ConstraintEventPayload |
 	wire.JointEventPayload | wire.ParameterChangedEvent |
-	wire.ModelChangedEvent | wire.PanelValueChangedEvent](sink Sink, ev E) event.Outcome {
+	wire.ModelChangedEvent | wire.PanelValueChangedEvent |
+	wire.FeatureLifecycleEvent | wire.SketchEditEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)
 	}

--- a/addin/events/modeling_relay_test.go
+++ b/addin/events/modeling_relay_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// TestForwardsFeatureLifecycle: the granular feature-lifecycle events are relayed to the add-in
+// sink with the affected feature's identity and the right type tag per op (#148).
+func TestForwardsFeatureLifecycle(t *testing.T) {
+	cases := []struct {
+		op   app.FeatureOp
+		want string
+	}{
+		{app.FeatureAdded, wire.EventFeatureAdded},
+		{app.FeatureEdited, wire.EventFeatureEdited},
+		{app.FeatureDeleted, wire.EventFeatureDeleted},
+	}
+	for _, tc := range cases {
+		s := app.NewSession()
+		var rec rawRecorder
+		if subs := Subscribe(s, rec.sink); len(subs) == 0 {
+			t.Fatal("Subscribe returned no subscriptions")
+		}
+		event.Emit(s.Events(), event.After, app.FeatureLifecycleChanged{
+			Document: 5, Op: tc.op, Feature: 9, Name: "Extrusion1", Kind: "extrude",
+		})
+		if !findFeatureEvent(rec.got, tc.want) {
+			t.Errorf("op %v: no %s event relayed with feature 9; got %d payloads", tc.op, tc.want, len(rec.got))
+		}
+	}
+}
+
+// findFeatureEvent reports whether the recorded payloads contain a feature-lifecycle event of the
+// wanted type carrying feature 9 / Extrusion1 / extrude.
+func findFeatureEvent(got []string, want string) bool {
+	for _, raw := range got {
+		var e wire.FeatureLifecycleEvent
+		if json.Unmarshal([]byte(raw), &e) == nil && e.Type == want {
+			if e.Document == 5 && e.Feature == 9 && e.Name == "Extrusion1" && e.Kind == "extrude" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestForwardsSketchEdit: entering and leaving a sketch relay the editEntered/editExited events
+// with the sketch identity (#148).
+func TestForwardsSketchEdit(t *testing.T) {
+	for _, tc := range []struct {
+		entered bool
+		want    string
+	}{
+		{true, wire.EventSketchEditEntered},
+		{false, wire.EventSketchEditExited},
+	} {
+		s := app.NewSession()
+		var rec rawRecorder
+		Subscribe(s, rec.sink)
+		event.Emit(s.Events(), event.After, app.SketchEditChanged{
+			Document: 5, Entered: tc.entered, Sketch: 3, Name: "Sketch1",
+		})
+		found := false
+		for _, raw := range rec.got {
+			var e wire.SketchEditEvent
+			if json.Unmarshal([]byte(raw), &e) == nil && e.Type == tc.want {
+				if e.Sketch != 3 || e.Name != "Sketch1" {
+					t.Errorf("relayed sketch event = %+v, want Sketch1 (id 3)", e)
+				}
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("entered=%v: no %s event relayed; got %d payloads", tc.entered, tc.want, len(rec.got))
+		}
+	}
+}

--- a/addin/opregistry/count_closure_test.go
+++ b/addin/opregistry/count_closure_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// partWithParams returns a part definition carrying the given user parameters (name→expr).
+func partWithParams(t *testing.T, params map[string]string) *compdef.PartComponentDefinition {
+	t.Helper()
+	def := compdef.NewPartComponentDefinition()
+	for name, expr := range params {
+		if _, err := def.Parameters().AddUserParameter(name, expr); err != nil {
+			t.Fatalf("add parameter %s=%q: %v", name, expr, err)
+		}
+	}
+	return def
+}
+
+// TestCountClosureEvaluatesExpression: a pattern count expression is evaluated through the part's
+// parameter engine (so the occurrence count tracks the parameter), a blank expression yields the
+// numeric fallback, and a non-positive result clamps to 1 (Oblikovati.API#189).
+func TestCountClosureEvaluatesExpression(t *testing.T) {
+	part := partWithParams(t, map[string]string{"slots": "6", "poles": "10"})
+
+	cases := []struct {
+		expr     string
+		fallback int
+		want     int
+	}{
+		{"slots", 4, 6},
+		{"poles / 2", 4, 5},
+		{"slots + 1", 4, 7},
+		{"", 8, 8},          // blank ⇒ fallback
+		{"slots - 9", 4, 1}, // non-positive ⇒ clamps to 1
+	}
+	for _, c := range cases {
+		fn, err := countClosure(part, c.expr, "test: count", c.fallback)
+		if err != nil {
+			t.Errorf("countClosure(%q): %v", c.expr, err)
+			continue
+		}
+		if got := fn(); got != c.want {
+			t.Errorf("countClosure(%q)() = %d, want %d", c.expr, got, c.want)
+		}
+	}
+}
+
+// TestCountClosureTracksParameterChange: the closure re-reads the parameter on each call, so a
+// later parameter edit changes the occurrence count without rebuilding the pattern (#189).
+func TestCountClosureTracksParameterChange(t *testing.T) {
+	part := partWithParams(t, map[string]string{"slots": "6"})
+	fn, err := countClosure(part, "slots", "test: count", 4)
+	if err != nil {
+		t.Fatalf("countClosure: %v", err)
+	}
+	if got := fn(); got != 6 {
+		t.Fatalf("initial count = %d, want 6", got)
+	}
+	p, ok := part.Parameters().ByName("slots")
+	if !ok {
+		t.Fatal("parameter slots not found")
+	}
+	if err := part.Parameters().SetExpression(p.ID(), "9"); err != nil {
+		t.Fatalf("set slots=9: %v", err)
+	}
+	if got := fn(); got != 9 {
+		t.Errorf("after slots=9 count = %d, want 9 (closure must re-read the parameter)", got)
+	}
+}

--- a/addin/opregistry/feature_pattern.go
+++ b/addin/opregistry/feature_pattern.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/types"
@@ -23,9 +24,12 @@ type patternArgs struct {
 	SourceFeatures    []string     `json:"sourceFeatures"`
 	CountX            int          `json:"countX,omitempty"`
 	CountY            int          `json:"countY,omitempty"`
+	CountXExpr        string       `json:"countXExpr,omitempty"`
+	CountYExpr        string       `json:"countYExpr,omitempty"`
 	StepX             []float64    `json:"stepX,omitempty"`
 	StepY             []float64    `json:"stepY,omitempty"`
 	Count             int          `json:"count,omitempty"`
+	CountExpr         string       `json:"countExpr,omitempty"`
 	Angle             string       `json:"angle,omitempty"`
 	AxisPoint         []float64    `json:"axisPoint,omitempty"`
 	AxisDir           []float64    `json:"axisDir,omitempty"`
@@ -54,6 +58,8 @@ const rectPatternSchema = `{
     "sourceFeatures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Names of the features to replicate (see model.tree), e.g. [\"Extrusion1\"]."},
     "countX": {"type": "integer", "minimum": 1, "default": 2},
     "countY": {"type": "integer", "minimum": 1, "default": 1},
+    "countXExpr": {"type": "string", "description": "Parameter-expression form of countX; when set it supersedes countX."},
+    "countYExpr": {"type": "string", "description": "Parameter-expression form of countY; when set it supersedes countY."},
     "stepX": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the first direction [x,y,z] in cm."},
     "stepY": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Spacing vector for the second direction [x,y,z] in cm."},
     "spacingType": {"type": "string", "enum": ["spacing", "fitted", "fitToPathLength"], "description": "How a step is read: 'spacing' = gap between occurrences (default); 'fitted' = total span divided across the count."},
@@ -75,6 +81,7 @@ const circPatternSchema = `{
   "properties": {
     "sourceFeatures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Names of the features to replicate (see model.tree)."},
     "count": {"type": "integer", "minimum": 1, "default": 4},
+    "countExpr": {"type": "string", "description": "Parameter-expression form of count (e.g. \"slots\", \"poles/2\"); when set it supersedes count so the occurrence count tracks the parameter."},
     "angle": {"type": "string", "description": "Total sweep angle, e.g. \"360 deg\"."},
     "axisPoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "A point on the rotation axis [x,y,z] (default origin)."},
     "axisDir": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Rotation axis direction [x,y,z] (default +Z)."},
@@ -147,14 +154,31 @@ func applyRectPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 			return nil, err
 		}
 	}
-	cx, cy := defaultInt(in.CountX, 2), defaultInt(in.CountY, 1)
+	countX, countY, err := rectCounts(part, in)
+	if err != nil {
+		return nil, err
+	}
 	opts, err := patternOptions(in)
 	if err != nil {
 		return nil, err
 	}
-	f := feature.NewPatternFeatures(part.Features()).AddRectangular(ids, constIntFn(cx), constIntFn(cy), stepX, stepY)
+	f := feature.NewPatternFeatures(part.Features()).AddRectangular(ids, countX, countY, stepX, stepY)
 	f.Definition().Options = opts
 	return lastFeatureResult(part)
+}
+
+// rectCounts resolves the two grid counts as live closures, preferring the parameter-expression
+// forms (countXExpr/countYExpr) over the numeric counts (#189).
+func rectCounts(part *compdef.PartComponentDefinition, in patternArgs) (countX, countY func() int, err error) {
+	countX, err = countClosure(part, in.CountXExpr, "patternRectangular: countXExpr", defaultInt(in.CountX, 2))
+	if err != nil {
+		return nil, nil, err
+	}
+	countY, err = countClosure(part, in.CountYExpr, "patternRectangular: countYExpr", defaultInt(in.CountY, 1))
+	if err != nil {
+		return nil, nil, err
+	}
+	return countX, countY, nil
 }
 
 func applyCircPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -166,11 +190,15 @@ func applyCircPattern(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	if err != nil {
 		return nil, err
 	}
+	count, err := countClosure(part, in.CountExpr, "patternCircular: countExpr", defaultInt(in.Count, 4))
+	if err != nil {
+		return nil, err
+	}
 	opts, err := patternOptions(in)
 	if err != nil {
 		return nil, err
 	}
-	f := feature.NewPatternFeatures(part.Features()).AddCircular(ids, constIntFn(defaultInt(in.Count, 4)), angle, originOr(in.AxisPoint), zAxisOr(in.AxisDir))
+	f := feature.NewPatternFeatures(part.Features()).AddCircular(ids, count, angle, originOr(in.AxisPoint), zAxisOr(in.AxisDir))
 	f.Definition().Options = opts
 	return lastFeatureResult(part)
 }
@@ -258,6 +286,28 @@ func defaultInt(v, def int) int {
 		return def
 	}
 	return v
+}
+
+// countClosure turns a pattern count into a live func() int (Oblikovati.API#189): when expr is a
+// parameter expression ("slots", "poles/2") it is evaluated through the part's parameter engine on
+// every recompute, so the occurrence count tracks the parameter; otherwise the numeric fallback (a
+// literal count, defaulted) is used as a constant. Non-positive results clamp to 1 (a pattern has
+// at least the seed).
+func countClosure(part *compdef.PartComponentDefinition, expr, field string, fallback int) (func() int, error) {
+	if strings.TrimSpace(expr) == "" {
+		return constIntFn(fallback), nil
+	}
+	f, err := numberClosure(part, expr, field)
+	if err != nil {
+		return nil, err
+	}
+	return func() int {
+		n := int(f() + 0.5) // counts are positive — round to nearest
+		if n < 1 {
+			return 1
+		}
+		return n
+	}, nil
 }
 
 func originOr(a []float64) math.Point3 {

--- a/addin/router/feature_events.go
+++ b/addin/router/feature_events.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// emitFeatureLifecycle publishes a granular feature-lifecycle notification (#148) on the session
+// bus, so the add-in event relay forwards feature.added/edited/deleted. v1 scope is the host method
+// router (features.add/edit/delete), matching edit.committed (ADR-0004) — the batched model.changed
+// remains the coarse signal that also covers UI-driven paths.
+func emitFeatureLifecycle(s *app.Session, op app.FeatureOp, f *feature.PartFeature) {
+	if f == nil {
+		return
+	}
+	var docID doc.ID
+	if active := s.ActiveDocument(); active != nil {
+		docID = active.ID()
+	}
+	event.Emit(s.Events(), event.After, app.FeatureLifecycleChanged{
+		Document: docID, Op: op, Feature: uint64(f.ID()), Name: f.Name(), Kind: f.Kind(),
+	})
+}
+
+// lastPartFeature returns the active part's most recently added feature, or nil — the feature a
+// successful features.add just appended (every part-feature op appends one feature at the end).
+func lastPartFeature(s *app.Session) *feature.PartFeature {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil || part == nil {
+		return nil
+	}
+	feats := part.Features()
+	if feats.Count() == 0 {
+		return nil
+	}
+	return feats.Item(feats.Count() - 1)
+}

--- a/addin/router/feature_events_test.go
+++ b/addin/router/feature_events_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// TestFeaturesAddEmitsFeatureAdded: a features.add over the router emits a FeatureLifecycleChanged
+// (FeatureAdded) carrying the new feature's identity, so the add-in relay forwards feature.added
+// (#148).
+func TestFeaturesAddEmitsFeatureAdded(t *testing.T) {
+	r, s := seededSession(t) // active part with one rectangle profile on sketch 0
+
+	var got []app.FeatureLifecycleChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.FeatureLifecycleChanged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+
+	var ext extrudeBodies
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"distance":"5 mm"}}`, &ext)
+
+	var added *app.FeatureLifecycleChanged
+	for i := range got {
+		if got[i].Op == app.FeatureAdded {
+			added = &got[i]
+		}
+	}
+	if added == nil {
+		t.Fatalf("features.add emitted no FeatureAdded event; got %d events", len(got))
+	}
+	if added.Kind != "extrude" || added.Feature == 0 {
+		t.Errorf("FeatureAdded = %+v, want kind extrude with a non-zero feature id", *added)
+	}
+}

--- a/addin/router/feature_lifecycle.go
+++ b/addin/router/feature_lifecycle.go
@@ -109,6 +109,7 @@ func editFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := s.CommitFeatureEdit(f); err != nil {
 		return nil, err
 	}
+	emitFeatureLifecycle(s, app.FeatureEdited, f) // feature.edited (#148)
 	return featureDetailReply(part, f, idx)
 }
 
@@ -158,6 +159,7 @@ func deleteFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error)
 	if err := s.DeleteFeature(f); err != nil {
 		return nil, err
 	}
+	emitFeatureLifecycle(s, app.FeatureDeleted, f) // feature.deleted (#148); f still holds its identity
 	return json.Marshal(wire.DeleteFeatureResult{ID: id, Deleted: true})
 }
 

--- a/addin/router/features.go
+++ b/addin/router/features.go
@@ -35,5 +35,10 @@ func (r *Router) addFeature(s *app.Session, raw json.RawMessage) (json.RawMessag
 	if len(args) == 0 {
 		args = json.RawMessage("{}")
 	}
-	return d.Apply(s, args)
+	out, err := d.Apply(s, args)
+	if err != nil {
+		return nil, err
+	}
+	emitFeatureLifecycle(s, app.FeatureAdded, lastPartFeature(s)) // feature.added (#148)
+	return out, nil
 }

--- a/addin/router/sketch_add_entity.go
+++ b/addin/router/sketch_add_entity.go
@@ -114,7 +114,7 @@ func compositePointIDs(ents []sketch.Entity) []uint64 {
 
 // buildComposite dispatches a composite create request to its model builder.
 func buildComposite(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in wire.AddSketchEntityArgs) ([]sketch.Entity, *sketch.Point, error) {
-	pts, err := toPoint2s(in.Points)
+	pts, err := resolvePoints(part, in)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -242,7 +242,7 @@ func buildStraightSlotVariant(sk *sketch.Sketch, in wire.AddSketchEntityArgs, pt
 // buildSketchEntity dispatches a create request to the matching model constructor,
 // returning the entity and the ids of its defining points.
 func buildSketchEntity(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in wire.AddSketchEntityArgs) (sketch.Entity, []uint64, error) {
-	pts, err := toPoint2s(in.Points)
+	pts, err := resolvePoints(part, in)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -537,6 +537,33 @@ func toPoint2s(in [][]float64) ([]math.Point2, error) {
 			return nil, fmt.Errorf("sketch.addEntity: point %d has %d coords, want [x,y]", i, len(p))
 		}
 		out[i] = math.P2(math.Scalar(p[0]), math.Scalar(p[1]))
+	}
+	return out, nil
+}
+
+// resolvePoints returns the entity's defining points, preferring the parameter-expression form
+// PointExprs over the literal Points (Oblikovati.API#189). Each expression coordinate is evaluated
+// through the part's parameter engine (resolveQuantity, the #187 helper) as a length, yielding cm —
+// so generated line/arc/point geometry is parametric at construction. PointExprs supersedes Points
+// when set; otherwise the literal path is unchanged.
+func resolvePoints(part *compdef.PartComponentDefinition, in wire.AddSketchEntityArgs) ([]math.Point2, error) {
+	if len(in.PointExprs) == 0 {
+		return toPoint2s(in.Points)
+	}
+	out := make([]math.Point2, len(in.PointExprs))
+	for i, p := range in.PointExprs {
+		if len(p) != 2 {
+			return nil, fmt.Errorf("sketch.addEntity: pointExprs %d has %d coords, want [x-expr,y-expr]", i, len(p))
+		}
+		x, err := resolveQuantity(part, p[0], param.Length)
+		if err != nil {
+			return nil, fmt.Errorf("sketch.addEntity: point %d x %q: %w", i, p[0], err)
+		}
+		y, err := resolveQuantity(part, p[1], param.Length)
+		if err != nil {
+			return nil, fmt.Errorf("sketch.addEntity: point %d y %q: %w", i, p[1], err)
+		}
+		out[i] = math.P2(math.Scalar(x.Value), math.Scalar(y.Value))
 	}
 	return out, nil
 }

--- a/addin/router/sketch_point_expr_test.go
+++ b/addin/router/sketch_point_expr_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestResolvePointsEvaluatesExpressions: PointExprs coordinates are evaluated through the part's
+// parameter engine (so generated line/arc/point geometry is parametric at construction), while the
+// literal Points path is unchanged when no expressions are given (Oblikovati.API#189).
+func TestResolvePointsEvaluatesExpressions(t *testing.T) {
+	part := partWith(t, map[string]string{"bore_r": "10 mm", "slot_depth": "5 mm"})
+
+	pts, err := resolvePoints(part, wire.AddSketchEntityArgs{
+		PointExprs: [][]string{{"0", "0"}, {"bore_r", "0"}, {"bore_r * 2", "slot_depth"}},
+	})
+	if err != nil {
+		t.Fatalf("resolvePoints(exprs): %v", err)
+	}
+	if len(pts) != 3 {
+		t.Fatalf("got %d points, want 3", len(pts))
+	}
+	// bore_r = 10 mm = 1.0 cm (database unit); bore_r*2 = 2.0 cm; slot_depth = 0.5 cm.
+	if math.Abs(float64(pts[1].X)-1.0) > 1e-9 || math.Abs(float64(pts[2].X)-2.0) > 1e-9 || math.Abs(float64(pts[2].Y)-0.5) > 1e-9 {
+		t.Errorf("resolved points = %v, want second X=1.0, third [2.0,0.5] cm", pts)
+	}
+
+	// No PointExprs ⇒ the literal path (coordinates already in cm).
+	lit, err := resolvePoints(part, wire.AddSketchEntityArgs{Points: [][]float64{{1.5, 2.5}}})
+	if err != nil {
+		t.Fatalf("resolvePoints(literal): %v", err)
+	}
+	if math.Abs(float64(lit[0].X)-1.5) > 1e-9 || math.Abs(float64(lit[0].Y)-2.5) > 1e-9 {
+		t.Errorf("literal point = %v, want [1.5,2.5]", lit[0])
+	}
+}
+
+// TestResolvePointsRejectsMalformedExpr: a point expression without exactly two coordinates errors
+// with the offending index, per the house exception-message rule.
+func TestResolvePointsRejectsMalformedExpr(t *testing.T) {
+	part := partWith(t, nil)
+	if _, err := resolvePoints(part, wire.AddSketchEntityArgs{PointExprs: [][]string{{"1"}}}); err == nil {
+		t.Error("a one-coordinate pointExprs entry should error")
+	}
+}

--- a/app/modeling_events.go
+++ b/app/modeling_events.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+)
+
+// Modeling/sketch event type ids (#148): the granular feature-lifecycle and sketch-edit
+// notifications beyond the batched model.changed (0x08xx = modeling).
+const (
+	tidFeatureLifecycle event.TypeID = 0x0801
+	tidSketchEdit       event.TypeID = 0x0802
+)
+
+// FeatureOp is which feature-lifecycle transition occurred — added, edited, or deleted.
+type FeatureOp uint8
+
+const (
+	FeatureAdded FeatureOp = iota
+	FeatureEdited
+	FeatureDeleted
+)
+
+// FeatureLifecycleChanged announces that a feature was created, edited, or deleted on a document
+// (#148). Op says which transition; Feature/Name/Kind carry the affected feature's identity so a
+// relay forwards it without diffing the model tree.
+type FeatureLifecycleChanged struct {
+	Document doc.ID
+	Op       FeatureOp
+	Feature  uint64
+	Name     string
+	Kind     string
+}
+
+// EventID implements event.Event.
+func (FeatureLifecycleChanged) EventID() event.TypeID { return tidFeatureLifecycle }
+
+// SketchEditChanged announces that the host entered or left a sketch's edit mode (#148). Entered
+// distinguishes the two; Sketch/Name identify the sketch. Fires for UI- and add-in-driven edits.
+type SketchEditChanged struct {
+	Document doc.ID
+	Entered  bool
+	Sketch   uint64
+	Name     string
+}
+
+// EventID implements event.Event.
+func (SketchEditChanged) EventID() event.TypeID { return tidSketchEdit }
+
+// emitSketchEdit publishes a sketch-edit transition (#148) keyed to the active document, so the
+// 2D and 3D enter/exit paths share one emit. A missing active document yields a zero id.
+func (s *Session) emitSketchEdit(seq uint64, name string, entered bool) {
+	var d doc.ID
+	if active := s.ActiveDocument(); active != nil {
+		d = active.ID()
+	}
+	event.Emit(s.bus, event.After, SketchEditChanged{Document: d, Entered: entered, Sketch: seq, Name: name})
+}

--- a/app/modeling_events_test.go
+++ b/app/modeling_events_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/event"
+	"oblikovati.org/model/sketch"
+)
+
+// TestEnterExitSketchEmitsSketchEdit: entering and leaving a 2D sketch each emit a
+// SketchEditChanged carrying the sketch identity, with Entered distinguishing them (#148).
+func TestEnterExitSketchEmitsSketchEdit(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+
+	var got []SketchEditChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e SketchEditChanged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+
+	s.EnterSketch(sk)
+	s.ExitSketch()
+
+	if len(got) != 2 {
+		t.Fatalf("emitted %d sketch-edit events, want 2 (enter, exit)", len(got))
+	}
+	if !got[0].Entered || got[1].Entered {
+		t.Errorf("entered flags = %v/%v, want true then false", got[0].Entered, got[1].Entered)
+	}
+	if got[0].Sketch != sk.Seq() || got[0].Sketch == 0 {
+		t.Errorf("sketch id = %d, want the sketch's seq %d", got[0].Sketch, sk.Seq())
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -308,6 +308,7 @@ func (s *Session) EnterSketch(sk *sketch.Sketch) {
 	s.activeSketch = sk
 	// The contextual environment switched: add-ins re-aim their UI (M05-F12).
 	event.Emit(s.bus, event.After, EnvironmentChanged{Environment: SketchEnvironment})
+	s.emitSketchEdit(sk.Seq(), sk.Name(), true) // SketchEvents surface (#148)
 	sk.Edit()
 	s.beginEditScope(sk.Seq()) // hide features/datums created after this sketch while editing it
 	s.sketchReturnCam = s.camera
@@ -319,6 +320,7 @@ func (s *Session) EnterSketch(sk *sketch.Sketch) {
 
 func (s *Session) ExitSketch() {
 	if s.activeSketch != nil {
+		s.emitSketchEdit(s.activeSketch.Seq(), s.activeSketch.Name(), false) // SketchEvents surface (#148)
 		s.activeSketch.ExitEdit()
 		s.activeSketch = nil
 		event.Emit(s.bus, event.After, EnvironmentChanged{Environment: BaseEnvironment})

--- a/app/sketch3d_env.go
+++ b/app/sketch3d_env.go
@@ -35,12 +35,14 @@ func (s *Session) CreateSketch3D() (*sketch.Sketch3D, error) {
 // sketch there is no plane to face, so the camera is left as the user had it.
 func (s *Session) EnterSketch3D(sk *sketch.Sketch3D) {
 	s.activeSketch3D = sk
+	s.emitSketchEdit(sk.Seq(), sk.Name(), true) // SketchEvents surface (#148)
 	sk.Edit()
 }
 
 // ExitSketch3D leaves the 3D-sketch environment.
 func (s *Session) ExitSketch3D() {
 	if s.activeSketch3D != nil {
+		s.emitSketchEdit(s.activeSketch3D.Seq(), s.activeSketch3D.Name(), false) // SketchEvents surface (#148)
 		s.activeSketch3D.ExitEdit()
 		s.activeSketch3D = nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.71.0
+	oblikovati.org/api v0.72.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.71.0
+	oblikovati.org/api v0.72.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
Implements the two v1 API gaps now that the contract shipped in **oblikovati.org/api v0.72.0** (Oblikovati.API#191).

## #148 — feature & sketch events
The host now relays the **ModelingEvents/SketchEvents** wave to add-ins:
- `EnterSketch`/`ExitSketch` (2D + 3D) emit `app.SketchEditChanged` → `sketch.editEntered`/`editExited`.
- The `features.add`/`edit`/`delete` router handlers emit `app.FeatureLifecycleChanged` → `feature.added`/`edited`/`deleted`, carrying the feature's id/name/kind.
- Relayed in `addin/events`; the API↔router parity guard sees every new wire event relayed.

v1 delivery scope is the host method router, matching `edit.committed` (ADR-0004).

## Oblikovati.API#189 — parametric construction
- `sketch.addEntity` routes the new `pointExprs` through `resolveQuantity` (the #187 evaluator helper), so line/arc/point **coordinates can be parameter expressions** evaluated at construction.
- `patternCircular`/`patternRectangular` gain `countExpr`/`countXExpr`/`countYExpr`, resolved to a **live count closure** that re-reads the parameter each recompute — enabling *model one slot → cut → pattern N = slots*.

## Tests
- Relay tests (feature lifecycle + sketch edit), app emit test, router `features.add` emit test.
- `resolvePoints` expression-evaluation + malformed-input tests; `countClosure` evaluation + parameter-tracking tests.
- Existing #187 `TestRouterUnitStringsGoThroughResolver` + the event parity guard both pass.

`go build ./...`, `vet`, and lint all clean; touched packages' tests green.

Closes #148. Implements the /source half of **Oblikovati.API#189** (the API contract closed it on the API side; I'll close the tracking issue on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)