### PR TITLE
fix(ui): document-scope hidden-body visibility + clear selection on doc switch (#1105)

### DIFF
--- a/app/doc_scoped_state_test.go
+++ b/app/doc_scoped_state_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// addBoxPart adds an extruded-box part document (activated) to the session and returns its
+// document and first body — the geometry the doc-scoped view-state tests switch between.
+func addBoxPart(t *testing.T, s *Session, name string) (*doc.Document, *topo.Body) {
+	t.Helper()
+	d, err := s.Workspace().Add(doc.Part, name, true)
+	if err != nil {
+		t.Fatalf("add part %s: %v", name, err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c := []*sketch.Point{
+		sk.Points().Add(math.P2(-2, -2)), sk.Points().Add(math.P2(2, -2)),
+		sk.Points().Add(math.P2(2, 2)), sk.Points().Add(math.P2(-2, 2)),
+	}
+	for i := range c {
+		sk.Lines().Add(c[i], c[(i+1)%len(c)])
+	}
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+	bodies := s.VisibleBodies()
+	if len(bodies) == 0 {
+		t.Fatalf("part %s produced no body", name)
+	}
+	return d, bodies[0]
+}
+
+// TestHiddenBodiesAreDocumentScoped: hiding a body in one document must not hide (or leak into)
+// another document's bodies, and switching back restores the first document's hidden state (#1105).
+func TestHiddenBodiesAreDocumentScoped(t *testing.T) {
+	s := NewSession()
+	docA, bodyA := addBoxPart(t, s, "A.obk")
+	docB, bodyB := addBoxPart(t, s, "B.obk") // B is now active
+
+	// Hide A's body while A is active.
+	if err := s.Workspace().SetActiveDocument(docA); err != nil {
+		t.Fatalf("activate A: %v", err)
+	}
+	s.SetBodyVisible(bodyA, false)
+	if s.BodyVisible(bodyA) {
+		t.Fatal("body A should be hidden after SetBodyVisible(false)")
+	}
+
+	// Switching to B must NOT carry A's hidden state — B's body stays visible.
+	if err := s.Workspace().SetActiveDocument(docB); err != nil {
+		t.Fatalf("activate B: %v", err)
+	}
+	if !s.BodyVisible(bodyB) {
+		t.Error("body B is hidden after switching from A — hidden state leaked across documents")
+	}
+
+	// Switching back to A must restore A's hidden state (per-document, not cleared).
+	if err := s.Workspace().SetActiveDocument(docA); err != nil {
+		t.Fatalf("re-activate A: %v", err)
+	}
+	if s.BodyVisible(bodyA) {
+		t.Error("body A became visible after a round-trip — its per-document hidden state was lost")
+	}
+}
+
+// TestClosingDocumentReleasesHiddenBodies: a closed document's hidden-body set is dropped, so it
+// cannot leak into a later document and does not accumulate (#1105).
+func TestClosingDocumentReleasesHiddenBodies(t *testing.T) {
+	s := NewSession()
+	docA, bodyA := addBoxPart(t, s, "A.obk")
+	if err := s.Workspace().SetActiveDocument(docA); err != nil {
+		t.Fatalf("activate A: %v", err)
+	}
+	s.SetBodyVisible(bodyA, false)
+
+	if err := s.Workspace().Close(docA, true); err != nil {
+		t.Fatalf("close A: %v", err)
+	}
+	if _, ok := s.hiddenBodyKeysByDoc[docA.ID()]; ok {
+		t.Error("closing document A left its hidden-body set behind (leak)")
+	}
+}
+
+// TestSelectionClearsOnDocumentSwitch: the selection holds refs into the active document, so
+// activating a different document must clear it rather than leak stale picks into the new view
+// (#1105). Re-activating the same document leaves the selection intact.
+func TestSelectionClearsOnDocumentSwitch(t *testing.T) {
+	s := NewSession()
+	docA, bodyA := addBoxPart(t, s, "A.obk")
+	docB, _ := addBoxPart(t, s, "B.obk")
+
+	if err := s.Workspace().SetActiveDocument(docA); err != nil {
+		t.Fatalf("activate A: %v", err)
+	}
+	s.Selection().Add(BodyHandle{Body: bodyA})
+	if s.Selection().Count() == 0 {
+		t.Fatal("selection should hold body A")
+	}
+
+	// Re-activating the SAME document keeps the selection.
+	if err := s.Workspace().SetActiveDocument(docA); err != nil {
+		t.Fatalf("re-activate A: %v", err)
+	}
+	if s.Selection().Count() == 0 {
+		t.Error("re-activating the same document cleared the selection")
+	}
+
+	// Switching to a DIFFERENT document clears the stale selection.
+	if err := s.Workspace().SetActiveDocument(docB); err != nil {
+		t.Fatalf("activate B: %v", err)
+	}
+	if s.Selection().Count() != 0 {
+		t.Error("switching documents left document A's selection in place (stale picks leak)")
+	}
+}

--- a/app/render.go
+++ b/app/render.go
@@ -122,7 +122,7 @@ func (s *Session) BodyVisible(body *topo.Body) bool {
 	if body == nil {
 		return false
 	}
-	return !s.hiddenBodyKeys[string(body.ReferenceKey())]
+	return !s.activeHiddenBodyKeys()[string(body.ReferenceKey())]
 }
 
 // SetBodyVisible updates the browser-driven display state for one body.
@@ -130,12 +130,30 @@ func (s *Session) SetBodyVisible(body *topo.Body, visible bool) {
 	if body == nil {
 		return
 	}
+	keys := s.activeHiddenBodyKeys()
 	key := string(body.ReferenceKey())
 	if visible {
-		delete(s.hiddenBodyKeys, key)
+		delete(keys, key)
 		return
 	}
-	s.hiddenBodyKeys[key] = true
+	keys[key] = true
+}
+
+// activeHiddenBodyKeys returns the hidden-body set for the active document, creating it on first
+// use; with no active document it returns the scratch set. Body visibility is per-document view
+// state (#1105): a single session-wide map leaked one document's hidden bodies into another's
+// viewport and never released them on close — the same class of bug as the client-graphics store.
+func (s *Session) activeHiddenBodyKeys() map[string]bool {
+	d := s.ActiveDocument()
+	if d == nil {
+		return s.hiddenBodyKeys
+	}
+	keys, ok := s.hiddenBodyKeysByDoc[d.ID()]
+	if !ok {
+		keys = map[string]bool{}
+		s.hiddenBodyKeysByDoc[d.ID()] = keys
+	}
+	return keys
 }
 
 // ToggleBodyVisibility flips the browser-driven display state for one body.

--- a/app/session.go
+++ b/app/session.go
@@ -72,7 +72,8 @@ type Session struct {
 	activeSketch3D       *sketch.Sketch3D
 	pendingDim           *sketch.DimensionConstraint
 	overlays             []renderer.DrawItem
-	hiddenBodyKeys       map[string]bool
+	hiddenBodyKeys       map[string]bool                  // scratch hidden-body set used only when no document is active
+	hiddenBodyKeysByDoc  map[doc.ID]map[string]bool       // browser-driven body visibility, scoped per document (#1105)
 	graphics             *clientgraphics.Store            // scratch store used only when no document is active
 	graphicsByDoc        map[doc.ID]*clientgraphics.Store // add-in client/interaction graphics, scoped per document (M05-F05)
 	addins               *AddInManager
@@ -194,8 +195,8 @@ func newSession(store doc.Store) *Session {
 		bus:            event.NewBus(),
 		selection:      NewSelection(),
 		camera:         scene.NewCamera(800, 600),
-		hiddenBodyKeys: map[string]bool{},
-		graphics:       clientgraphics.NewStore(), graphicsByDoc: map[doc.ID]*clientgraphics.Store{},
+		hiddenBodyKeys: map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
+		graphics: clientgraphics.NewStore(), graphicsByDoc: map[doc.ID]*clientgraphics.Store{},
 		addins:          NewAddInManager(),
 		clientApps:      NewClientApplicationRegistry(),
 		browserPanes:    NewAddInBrowserPanes(),
@@ -221,6 +222,7 @@ func newSession(store doc.Store) *Session {
 	s.messageCenter.sink = s.routeMessage            // M26 F03: mirror message-center entries to the command line
 	s.initShellSurfaces()
 	s.watchDocumentCloses()
+	s.watchDocumentSwitches() // #1105: drop the prior document's selection when a different one is activated
 	s.watchDocumentInterests()
 	s.watchDocumentIdentityCollisions() // open-time identity-GUID clash → reassign + notify
 	s.watchTransactions()               // append-only transaction log for bug reports

--- a/app/undo.go
+++ b/app/undo.go
@@ -277,6 +277,24 @@ func (s *Session) watchDocumentCloses() {
 		// The document's add-in client graphics die with it, so its overlays cannot resurface
 		// on a later document that happens to reuse no id (M05-F05 doc-scoped graphics).
 		delete(s.graphicsByDoc, e.Document.ID())
+		// Its hidden-body view state dies with it too (#1105 doc-scoped visibility).
+		delete(s.hiddenBodyKeysByDoc, e.Document.ID())
+		return event.Continue()
+	})
+}
+
+// watchDocumentSwitches clears the selection when a DIFFERENT document is activated (#1105). The
+// selection set holds Selectable refs into the previously active document; without this they leaked
+// into the newly activated document's viewport (stale highlights, wrong-document operations). It
+// fires only on an actual switch, so re-activating the same document leaves its selection intact.
+func (s *Session) watchDocumentSwitches() {
+	var prev doc.ID
+	event.Subscribe(s.workspace.Events(), event.After, func(_ event.Context, e doc.DocumentActivate) event.Outcome {
+		id := e.Document.ID()
+		if id != prev {
+			prev = id
+			s.selection.Clear()
+		}
 		return event.Continue()
 	})
 }


### PR DESCRIPTION
Audit of package-level/global state that should be document-scoped, with the clearly-wrong leaks fixed + doc-switch regression tests.

## Fixed (genuine cross-document leaks)
1. **Hidden-body visibility** — `Session.hiddenBodyKeys` was a single session-wide `map[string]bool`, so one document's hidden bodies leaked into every other document's viewport and were never released on close. Now scoped per `doc.ID` (`hiddenBodyKeysByDoc`, lazy, dropped on `DocumentClose`) — the same shape as the per-document client-graphics store.
2. **Selection on document switch** — the selection holds `Selectable` refs into the active document; switching to another document left those stale picks in place (highlights/operations on the wrong document). A `DocumentActivate` watcher clears the selection on an actual switch (re-activating the same document keeps it).

Regression tests: `TestHiddenBodiesAreDocumentScoped`, `TestClosingDocumentReleasesHiddenBodies`, `TestSelectionClearsOnDocumentSwitch` (doc-switch style of the two prior fixes).

## Audit dispositions (full classification in the issue comment)
- **Already correct / previously fixed:** `graphicsByDoc`, `histories`, `historyBrowserSelection` (per-`doc.ID` maps); material/appearance selectors (resync on activate); `sketchOverlayCache`/`bodyGeometryCache`/`sourceMeshCache`/`viewportEnv` (geometry/version-keyed); `browserSync`/`browserNodeSeq` (reset each frame).
- **Genuinely app-global (leave):** theme/color vars, modal dialog `*UI` structs, ViewCube/normal-debug/screenshot toggles, command-window state, icon cache, stroke font.
- **Lower-priority transient edit state (documented, not fixed):** `activeSketch`/`activeSketch3D`/`pendingDim`, `dimEdit`, in-progress gestures — only stale if the active document is switched *mid-edit*, which the sketch/edit environments guard. Revisit if a concrete leak surfaces.

`go build ./...`, `vet`, lint all clean; full `app` suite green (no regression from the selection-clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)