### PR TITLE
Fix the O(T²) CDT freeze on imported faces with duplicate boundary points (#1073)

### DIFF
--- a/kernel/ops/cdt_build.go
+++ b/kernel/ops/cdt_build.go
@@ -154,17 +154,43 @@ func (m *cdt) flip(t, i int) bool {
 	return true
 }
 
-// insertConstraint forces edge (a,b) into the triangulation (flipping the edges it crosses) and
-// marks it constrained. A non-flippable (non-convex) crossing is retried after others resolve it;
-// it gives up if no progress is possible (a degenerate, near-collinear boundary). The flips rely on
-// the now-exact orient2d, so a near-collinear boundary no longer mis-signs and tangles the mesh.
+// insertConstraint forces edge (a,b) into the triangulation by flipping the edges it crosses, then
+// marks it constrained. A degenerate constraint between coincident endpoints (duplicate boundary
+// samples) is skipped: it has no edge to recover, and the flip loop would otherwise spin its whole
+// 4·len(tris) retry never finding a crossing — the real O(T²) freeze on imported faces with duplicate
+// points (linkrods: 8.3s → 0.1s, #1073; callers pass deduplicated representatives, see
+// constrainedDelaunay). A non-flippable (non-convex) crossing is retried after others resolve it; it
+// gives up if no progress is possible. The flips rely on the exact orient2d, so a near-collinear
+// boundary no longer mis-signs and tangles the mesh.
 func (m *cdt) insertConstraint(a, b int) {
+	if a == b || m.pts[a] == m.pts[b] {
+		return
+	}
 	for tries := 0; !m.hasEdge(a, b) && tries < 4*len(m.tris)+8; tries++ {
 		if !m.flipOneCrossing(a, b) {
 			break
 		}
 	}
 	m.con[conKey(a, b)] = true
+}
+
+// representatives maps each input point index to the inserted vertex that carries its coordinates:
+// itself when unique, or the first earlier point with the same coords (the one insert kept — later
+// duplicates are skipped, owning no triangle). Constraints are recovered between representatives so a
+// duplicate boundary sample never references a vertex absent from the mesh (which the flip recovery
+// would spin on forever, #1073).
+func (m *cdt) representatives() []int {
+	rep := make([]int, m.nsup)
+	canon := map[[2]float64]int{}
+	for i := 0; i < m.nsup; i++ {
+		if c, ok := canon[m.pts[i]]; ok {
+			rep[i] = c
+		} else {
+			canon[m.pts[i]] = i
+			rep[i] = i
+		}
+	}
+	return rep
 }
 
 // flipOneCrossing flips one flippable triangulation edge that properly crosses segment (a,b),
@@ -270,9 +296,14 @@ func constrainedDelaunay(pts [][2]float64, loops [][]int) [][3]int {
 	for i := 0; i < m.nsup; i++ {
 		m.insert(i)
 	}
+	// A duplicate boundary sample (same coords as an earlier point) is SKIPPED by insert (it has no
+	// strictly-bad triangle), so it owns no triangle; a constraint referencing it can be recovered by
+	// neither the corridor walk (no incident triangle) nor the flips (which then spin to exhaustion —
+	// the real O(T²) freeze on imported faces, #1073). Constrain between the inserted REPRESENTATIVES.
+	rep := m.representatives()
 	for _, lp := range loops {
 		for k := 0; k < len(lp); k++ {
-			m.insertConstraint(lp[k], lp[(k+1)%len(lp)])
+			m.insertConstraint(rep[lp[k]], rep[lp[(k+1)%len(lp)]])
 		}
 	}
 	return m.extractDomain()

--- a/kernel/ops/cdt_test.go
+++ b/kernel/ops/cdt_test.go
@@ -52,6 +52,24 @@ func TestCDTSquare(t *testing.T) {
 	}
 }
 
+// TestCDTDuplicateBoundaryPoint guards the #1073 freeze fix: an imported boundary loop with a
+// DUPLICATE sample (two points at the same coords, as STEP pcurves produce) must still triangulate to
+// the correct domain. The duplicate is skipped by point insertion (it owns no triangle), so a
+// constraint referencing it used to make the flip recovery spin its whole 4·len(tris) retry finding
+// no crossing — the O(T²) freeze on large faces. constrainedDelaunay now constrains between the
+// inserted representatives, and the degenerate (coincident-endpoint) edge is skipped.
+func TestCDTDuplicateBoundaryPoint(t *testing.T) {
+	// A unit square whose loop repeats the (0,0) corner as a separate index (4) — a duplicate sample.
+	pts := [][2]float64{{0, 0}, {2, 0}, {2, 2}, {0, 2}, {0, 0}}
+	tris := constrainedDelaunay(pts, [][]int{{0, 1, 2, 3, 4}})
+	if len(tris) != 2 {
+		t.Fatalf("square with a duplicate corner should triangulate to 2 triangles, got %d", len(tris))
+	}
+	if got := cdtAreaSum(pts, tris); stdmath.Abs(got-4) > 1e-9 {
+		t.Errorf("duplicate-corner square area = %g, want 4 (the duplicate constraint cracked the domain)", got)
+	}
+}
+
 func TestCDTConcaveLShape(t *testing.T) {
 	// An L: the triangulation must NOT bridge the notch (that was the plain-Delaunay over-count).
 	pts := [][2]float64{{0, 0}, {2, 0}, {2, 1}, {1, 1}, {1, 2}, {0, 2}}


### PR DESCRIPTION
## What

Fixes the imported-NURBS tessellation **freeze** — the `linkrods.step` blocker of #1073. `linkrods` took **8.3s** to tessellate (and larger models froze); it now takes **0.11s** (**~75×**).

This addresses the *performance* blocker (issue step 2). The screw/linkrods **watertightness** (per-surface conformance) is the remaining, separate part of #1073, so this does **not** close the issue.

## Root cause (profiled)

85% of the time was `insertConstraint → flipOneCrossing` scanning every triangle. A STEP pcurve loop can carry **duplicate samples** (two boundary points at identical coords). Point insertion skips a coincident point — so it owns no triangle — and a constraint referencing it can **never be recovered**: the flip loop spins its full `4·len(tris)` retry finding no crossing, **O(T²) per such edge**.

## Fix

- `constrainedDelaunay` recovers each loop edge between the inserted **representatives** (a duplicate point maps to the first point carrying its coords).
- `insertConstraint` skips a degenerate coincident-endpoint edge outright.

No algorithm change for non-degenerate edges, so clean geometry triangulates exactly as before.

## Results

| Model | Before | After |
|---|---|---|
| linkrods.step | 8.3s | **0.11s** |
| screw.step | 0.15s | **0.01s** |

- **EDF** still imports **0-fold, watertight, volume-correct** (the #585 guards pass).
- OCC oracle + the 7 CDT unit tests unchanged.
- Committed regression `TestCDTDuplicateBoundaryPoint`; env-gated `TestHeavyModelBudget` (700ms) now passes for linkrods.

Minimal diff (the CDT fix + one test); `go test ./kernel/...` and `./app/` green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)