### PR TITLE
Conform plane absorbers to curved neighbours (#1073 watertightness)

### DIFF
--- a/kernel/ops/conformance_repair.go
+++ b/kernel/ops/conformance_repair.go
@@ -24,44 +24,60 @@ func conformCylConeFaces(faces []*topo.Face, idx map[*topo.Face]int, fm []*Mesh,
 	if len(free) == 0 {
 		return // watertight body: nothing to repair (and the hot path skips the weld below)
 	}
-	for j := range cylConeFacesToFix(faces, idx, fm, free) {
-		if m := conformingCylConeMesh(faces[j], q); m != nil {
+	for j := range facesToFix(faces, idx, fm, free) {
+		if m := conformingMesh(faces[j], q); m != nil {
 			fm[j] = m
 		}
 	}
 }
 
-// cylConeFacesToFix is the set of face indices to re-mesh: every cyl/cone face whose mesh touches
-// a free (unwelded) segment, plus its cyl/cone topo neighbours across the shared edge (the face
-// MISSING the segment).
-func cylConeFacesToFix(faces []*topo.Face, idx map[*topo.Face]int, fm []*Mesh, free map[segKey]bool) map[int]bool {
+// conformingMesh re-meshes an absorber face with the appropriate boundary-faithful mesher: a
+// cyl/cone via the metric-(u,v) CDT, a plane via the projected-plane CDT. Both keep every boundary
+// segment, so the face conforms to its neighbour; nil for anything else (left as meshed).
+func conformingMesh(f *topo.Face, q Quality) *Mesh {
+	switch f.Geometry().(type) {
+	case geom.Cylinder, geom.Cone:
+		return conformingCylConeMesh(f, q)
+	case geom.Plane:
+		return conformingPlaneMesh(f, q)
+	}
+	return nil
+}
+
+// facesToFix is the set of face indices to re-mesh: every cyl/cone/plane face whose mesh touches a
+// free (unwelded) segment, plus its cyl/cone/plane topo neighbours across the shared edge — the face
+// that ABSORBED the segment (dropped a near-collinear shared-edge point its neighbour kept).
+func facesToFix(faces []*topo.Face, idx map[*topo.Face]int, fm []*Mesh, free map[segKey]bool) map[int]bool {
 	toFix := map[int]bool{}
 	for i, f := range faces {
 		if !meshTouchesFree(fm[i], free) {
 			continue
 		}
-		if isCylOrCone(f.Geometry()) {
+		if conformable(f.Geometry()) {
 			toFix[i] = true
 		}
-		addCylConeNeighbours(f, i, idx, toFix)
+		addConformableNeighbours(f, i, idx, toFix)
 	}
 	return toFix
 }
 
-// addCylConeNeighbours marks face i's cyl/cone neighbours (across a shared edge) for re-meshing.
-func addCylConeNeighbours(f *topo.Face, i int, idx map[*topo.Face]int, toFix map[int]bool) {
+// addConformableNeighbours marks face i's cyl/cone/plane neighbours (across a shared edge) for
+// re-meshing — the plane neighbour is the absorber when a planar cap drops a curved rim point.
+func addConformableNeighbours(f *topo.Face, i int, idx map[*topo.Face]int, toFix map[int]bool) {
 	for _, e := range f.Edges() {
 		for _, nf := range e.Faces() {
-			if j, ok := idx[nf]; ok && j != i && isCylOrCone(nf.Geometry()) {
+			if j, ok := idx[nf]; ok && j != i && conformable(nf.Geometry()) {
 				toFix[j] = true
 			}
 		}
 	}
 }
 
-func isCylOrCone(s geom.Surface) bool {
+// conformable reports whether a face's surface has a boundary-faithful conforming re-mesher
+// (conformingMesh): cylinders, cones, and planes.
+func conformable(s geom.Surface) bool {
 	switch s.(type) {
-	case geom.Cylinder, geom.Cone:
+	case geom.Cylinder, geom.Cone, geom.Plane:
 		return true
 	}
 	return false
@@ -96,6 +112,54 @@ func conformingCylConeMesh(f *topo.Face, q Quality) *Mesh {
 		return nil
 	}
 	return patchMeshFrom(b.pos, b.nrm, tris)
+}
+
+// conformingPlaneMesh re-meshes a planar absorber with the projected-plane constrained Delaunay,
+// which keeps EVERY boundary segment (so the face reproduces a near-collinear shared-edge point a
+// curved neighbour kept, instead of the area-gated planarTris dropping it — the plane-absorber crack
+// on screw caps, #1073). It feeds constrainedDelaunay the SAME projected coordinates the plane's
+// neighbours discretize from, so it conforms rather than cascading; and because every one of the
+// plane's OWN boundary segments stays a constraint, re-meshing it cannot crack its other neighbours.
+// nil when the trim has overlapping holes (its own union mesher conforms) or exceeds the CDT budget.
+func conformingPlaneMesh(f *topo.Face, q Quality) *Mesh {
+	normal := f.Geometry().NormalAt(0, 0)
+	flat := planeProjector(normal)
+	outer3D := faceOuterBoundary(f, q)
+	if len(outer3D) < 3 {
+		return nil
+	}
+	holes3D := faceHoleBoundaries(f, q)
+	outer2D := project2D(outer3D, flat)
+	holes2D := make([][]math.Point2, len(holes3D))
+	for i, h := range holes3D {
+		holes2D[i] = project2D(h, flat)
+	}
+	if holesOverlap(holes2D) || boundaryVertCount(outer2D, holes2D) > maxCDTFallbackVerts {
+		return nil
+	}
+	tris := planarCDT(outer2D, holes2D)
+	if len(tris) == 0 {
+		return nil
+	}
+	return planarMeshFromTris(outer3D, holes3D, tris, normal)
+}
+
+// planarMeshFromTris builds a planar face mesh: the outer-then-holes 3D vertex buffer (the order
+// planarTris/planarCDT index into) carrying the face normal, triangulated by tris.
+func planarMeshFromTris(outer3D []math.Point3, holes3D [][]math.Point3, tris [][3]int, normal math.Vector3) *Mesh {
+	m := &Mesh{}
+	for _, p := range outer3D {
+		m.addVertex(p, normal)
+	}
+	for _, h := range holes3D {
+		for _, p := range h {
+			m.addVertex(p, normal)
+		}
+	}
+	for _, t := range tris {
+		m.addTriangle(t[0], t[1], t[2])
+	}
+	return m
 }
 
 // segKey is the collision-free, order-independent key of a welded segment: the quantized (1 µm grid,

--- a/kernel/ops/conformance_repair_test.go
+++ b/kernel/ops/conformance_repair_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestConformableSurfaces pins which surfaces have a boundary-faithful conforming re-mesher: planes,
+// cylinders and cones, but not torus/sphere/B-spline (no conformingMesh for those yet, #1073).
+func TestConformableSurfaces(t *testing.T) {
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	sph, _ := geom.NewSphere(math.P3(0, 0, 0), 1)
+	cases := []struct {
+		name string
+		s    geom.Surface
+		want bool
+	}{
+		{"plane", pl, true},
+		{"cylinder", geom.Cylinder{Radius: 1}, true},
+		{"cone", geom.Cone{}, true},
+		{"sphere", sph, false},
+		{"torus", geom.Torus{}, false},
+	}
+	for _, c := range cases {
+		if got := conformable(c.s); got != c.want {
+			t.Errorf("conformable(%s) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestConformingPlaneMeshKeepsNearCollinearPoint guards the plane-absorber fix (#1073): a planar
+// face whose boundary carries a near-collinear point (as a near-straight shared arc edge produces)
+// must reproduce BOTH segments through that point, so it conforms to a curved neighbour that keeps
+// it — instead of the area-gated planarTris dropping it and cracking the shared edge.
+func TestConformingPlaneMeshKeepsNearCollinearPoint(t *testing.T) {
+	// A pentagon on z=0 whose top edge carries a near-collinear apex (1, 2.0001) between (2,2) and (0,2).
+	mid := math.P3(1, 2.0001, 0)
+	loop := []math.Point3{
+		math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(2, 2, 0), mid, math.P3(0, 2, 0),
+	}
+	f := planarFaceFromLoop(t, loop)
+
+	m := conformingPlaneMesh(f, DefaultQuality())
+	if m == nil {
+		t.Fatal("conformingPlaneMesh returned nil for a simple planar face")
+	}
+	if !meshHasSegment(m, math.P3(2, 2, 0), mid) || !meshHasSegment(m, mid, math.P3(0, 2, 0)) {
+		t.Error("conforming plane mesh dropped the near-collinear boundary point — it would crack a curved neighbour")
+	}
+}
+
+// planarFaceFromLoop builds a single planar (z=0) face from a CCW 3D point loop, each side a line
+// edge — the fixture for the plane-conformance tests.
+func planarFaceFromLoop(t *testing.T, loop []math.Point3) *topo.Face {
+	t.Helper()
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("c", "body", 0)))
+	lin := topo.NewLineage(topo.Tok("c", "x", 0))
+	pl, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	verts := make([]*topo.Vertex, len(loop))
+	for i, p := range loop {
+		verts[i] = bld.AddVertex(p, lin)
+	}
+	uses := make([]topo.Use, len(loop))
+	for i := range loop {
+		j := (i + 1) % len(loop)
+		uses[i] = topo.Fwd(bld.AddEdge(geom.NewLineSegment(loop[i], loop[j]), verts[i], verts[j], lin))
+	}
+	bld.AddFace(pl, lin, topo.OuterLoop(uses...))
+	return bld.Build().Faces()[0]
+}
+
+// meshHasSegment reports whether some triangle of m has an edge between a and b (within weld tol).
+func meshHasSegment(m *Mesh, a, b math.Point3) bool {
+	near := func(p, qp math.Point3) bool { return p.DistanceTo(qp) < 1e-6 }
+	for tr := 0; 3*tr+2 < len(m.Indices); tr++ {
+		v := [3]math.Point3{m.Positions[m.Indices[3*tr]], m.Positions[m.Indices[3*tr+1]], m.Positions[m.Indices[3*tr+2]]}
+		for k := 0; k < 3; k++ {
+			p, qp := v[k], v[(k+1)%3]
+			if (near(p, a) && near(qp, b)) || (near(p, b) && near(qp, a)) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Incremental progress on #1073 **watertightness**: closes the **plane-absorber** cracks (the issue's named `screw.step` blocker). `screw.step` free edges **19 → 13**.

## Background

The cross-face conformance repair (`conformCylConeFaces`) re-meshes a cyl/cone wall that *absorbed* a near-collinear shared-edge point, but it deliberately **skipped planes**: a planar cap's area-gated triangulation (`planarTris`) drops a near-collinear rim point its curved neighbour keeps — too small an area change to trip the CDT fallback — so the shared edge cracks.

## Fix

Extend the repair to also re-mesh a **planar absorber** with `conformingPlaneMesh`: the projected-plane constrained Delaunay keeps **every** boundary segment as a hard constraint, so the cap reproduces the dropped point and conforms. It feeds the same projected coordinates the neighbours discretize from, and keeps all of the plane's *own* boundary segments, so it conforms **without cascading** to the plane's other neighbours. `facesToFix`/`conformable`/`conformingMesh` generalise the cyl/cone face selection to planes.

## Safety

- `screw.step` 19 → **13** free edges.
- **EDF** still 0-fold, watertight, volume-correct.
- OCC oracle + all kernel/app suites unchanged — the repair runs **only** on bodies that already have free edges (watertight bodies skip it entirely).
- Committed regression tests: the `conformable` set, and that the conforming plane mesh keeps a near-collinear boundary point (which the area-gated mesher drops).

## Scope (does not close #1073)

The dominant **residual** cracks are **cone↔cylinder** band/grid conformance and **torus** faces (linkrods is torus-dominant). Those need *volume-preserving interior-node* conformance — the harder, remaining part of #1073, kept for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)