### PR TITLE
Implement per-document sketch settings (#147)

### DIFF
--- a/addin/router/document_sketch_settings.go
+++ b/addin/router/document_sketch_settings.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// registerDocumentSettingsHandlers wires the per-document settings methods (#147). Starts with the
+// Sketch tab — the constraint-inference defaults the sketch tools read.
+func (r *Router) registerDocumentSettingsHandlers() {
+	r.handlers[wire.MethodDocumentGetSketchSettings] = getDocumentSketchSettings
+	r.handlers[wire.MethodDocumentSetSketchSettings] = setDocumentSketchSettings
+}
+
+// getDocumentSketchSettings returns a document's persisted sketch settings
+// (wire.MethodDocumentGetSketchSettings).
+func getDocumentSketchSettings(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.GetSketchSettingsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	set, err := s.DocumentSketchSettings(a.Document)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SketchSettingsResult{Settings: set})
+}
+
+// setDocumentSketchSettings stores a document's sketch settings and returns the stored value
+// (wire.MethodDocumentSetSketchSettings).
+func setDocumentSketchSettings(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var a wire.SetSketchSettingsArgs
+	if err := decode(args, &a); err != nil {
+		return nil, err
+	}
+	set, err := s.SetDocumentSketchSettings(a.Document, a.Settings)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.SketchSettingsResult{Settings: set})
+}

--- a/addin/router/document_sketch_settings_test.go
+++ b/addin/router/document_sketch_settings_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestSketchSettingsRoundTrip reads the active document's sketch settings (defaults), writes a
+// changed value back, and checks the reply reflects it (#147).
+func TestSketchSettingsRoundTrip(t *testing.T) {
+	r, s := seededSession(t)
+
+	var got wire.SketchSettingsResult
+	call(t, r, s, wire.MethodDocumentGetSketchSettings, `{"document":0}`, &got)
+	if !got.Settings.InferConstraints || !got.Settings.AutoApplyConstraints {
+		t.Fatalf("default settings = %+v, want inference + auto-apply on", got.Settings)
+	}
+
+	want := types.SketchSettings{InferConstraints: true, AutoApplyConstraints: false, ConstraintPriority: types.PriorityParallelPerpendicular}
+	var back wire.SketchSettingsResult
+	call(t, r, s, wire.MethodDocumentSetSketchSettings, mustJSON(t, wire.SetSketchSettingsArgs{Document: 0, Settings: want}), &back)
+	if back.Settings != want {
+		t.Errorf("set settings = %+v, want %+v", back.Settings, want)
+	}
+
+	// A fresh read returns the stored value — it persisted on the document.
+	var reread wire.SketchSettingsResult
+	call(t, r, s, wire.MethodDocumentGetSketchSettings, `{"document":0}`, &reread)
+	if reread.Settings != want {
+		t.Errorf("re-read settings = %+v, want %+v (not stored on the document)", reread.Settings, want)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -71,6 +71,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyReplicationHandlers()
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()
+	r.registerDocumentSettingsHandlers()
 	r.registerAttributeHandlers()
 	r.registerSelectionMutationHandlers()
 	r.registerSketchReferenceKeyHandlers()

--- a/app/document_sketch_settings.go
+++ b/app/document_sketch_settings.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/sketch"
+)
+
+// errNoActiveDocument is returned when a document-addressed request targets the active document but
+// none is open.
+var errNoActiveDocument = errors.New("app: no active document")
+
+// Per-document sketch settings (#147): the constraint-inference defaults persist with the document
+// (model/doc stores them, persistence round-trips them in the .obk). These session methods are the
+// in-proc seam the head and the addin/router both drive, addressing a document by its session id
+// (0 ⇒ the active document). The sketch tools read the ACTIVE document's settings through
+// SketchInferenceOptions, so each open part keeps its own inference behaviour.
+
+// DocumentSketchSettings returns the sketch settings of the document with the given session id
+// (0 ⇒ the active document), or an error when no such document is open.
+func (s *Session) DocumentSketchSettings(id uint64) (types.SketchSettings, error) {
+	d, err := s.documentForSettings(id)
+	if err != nil {
+		return types.SketchSettings{}, err
+	}
+	return d.SketchSettings(), nil
+}
+
+// SetDocumentSketchSettings stores the sketch settings on the document with the given session id
+// (0 ⇒ the active document) and returns the stored value, or an error when no such document is open.
+func (s *Session) SetDocumentSketchSettings(id uint64, settings types.SketchSettings) (types.SketchSettings, error) {
+	d, err := s.documentForSettings(id)
+	if err != nil {
+		return types.SketchSettings{}, err
+	}
+	d.SetSketchSettings(settings)
+	return d.SketchSettings(), nil
+}
+
+// documentForSettings resolves a settings request's target document: the addressed one by session id,
+// or the active document when id is 0.
+func (s *Session) documentForSettings(id uint64) (sketchSettingsHolder, error) {
+	if id != 0 {
+		return s.DocumentByID(id)
+	}
+	if d := s.ActiveDocument(); d != nil {
+		return d, nil
+	}
+	return nil, errNoActiveDocument
+}
+
+// sketchSettingsHolder is the document capability the per-document sketch settings need — the
+// model.doc.Document accessors. Stated as an interface so the session methods stay testable.
+type sketchSettingsHolder interface {
+	SketchSettings() types.SketchSettings
+	SetSketchSettings(types.SketchSettings)
+}
+
+// sketchInferenceFrom maps the persisted document settings onto the kernel's inference options that
+// the sketch tools consume (the fields are 1:1; the priority enum is shared).
+func sketchInferenceFrom(s types.SketchSettings) sketch.InferenceOptions {
+	return sketch.InferenceOptions{
+		InferEnabled:     s.InferConstraints,
+		ConstrainEnabled: s.AutoApplyConstraints,
+		Priority:         s.ConstraintPriority,
+	}
+}
+
+// sketchSettingsFrom maps the kernel inference options back onto the persisted document settings.
+func sketchSettingsFrom(o sketch.InferenceOptions) types.SketchSettings {
+	return types.SketchSettings{
+		InferConstraints:     o.InferEnabled,
+		AutoApplyConstraints: o.ConstrainEnabled,
+		ConstraintPriority:   o.Priority,
+	}
+}

--- a/app/document_sketch_settings_test.go
+++ b/app/document_sketch_settings_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSketchInferenceOptionsReadActiveDocument checks the per-document wiring (#147): the sketch
+// tools' inference options come from the active document's settings, and editing them persists on
+// that document (so SetDocumentSketchSettings sees the same value).
+func TestSketchInferenceOptionsReadActiveDocument(t *testing.T) {
+	s, _ := emptyPartSession(t)
+
+	// A fresh document yields the defaults (inference + auto-apply on).
+	if o := s.SketchInferenceOptions(); !o.InferEnabled || !o.ConstrainEnabled {
+		t.Fatalf("default inference options = %+v, want inference + constrain on", o)
+	}
+
+	// Editing through the sketch-tools setter writes to the active document.
+	s.SetSketchInferenceOptions(sketch.InferenceOptions{InferEnabled: true, ConstrainEnabled: false, Priority: types.PriorityParallelPerpendicular})
+	if o := s.SketchInferenceOptions(); o.ConstrainEnabled || o.Priority != types.PriorityParallelPerpendicular {
+		t.Errorf("after edit, options = %+v, want constrain off / parallelPerpendicular", o)
+	}
+
+	// The document-addressed API reflects the same state (0 ⇒ active document).
+	got, err := s.DocumentSketchSettings(0)
+	if err != nil {
+		t.Fatalf("DocumentSketchSettings: %v", err)
+	}
+	if got.AutoApplyConstraints || got.ConstraintPriority != types.PriorityParallelPerpendicular {
+		t.Errorf("document settings = %+v, want auto-apply off / parallelPerpendicular", got)
+	}
+}
+
+// TestSetDocumentSketchSettingsNoActiveDocument checks the addressed-document error path.
+func TestSetDocumentSketchSettingsNoActiveDocument(t *testing.T) {
+	s := NewSession() // no document open
+	if _, err := s.DocumentSketchSettings(0); err == nil {
+		t.Error("DocumentSketchSettings with no active document should error")
+	}
+}

--- a/app/sketch_inference_options.go
+++ b/app/sketch_inference_options.go
@@ -4,14 +4,18 @@ package app
 
 import "oblikovati.org/model/sketch"
 
-// Session-level sketch inference preferences (M06-F10, #625): whether point
-// snapping and constraint auto-application run while sketching, and which
-// constraint family wins. Stored per session (the settings surface of #147
-// will lift them into persisted preferences when it lands).
+// Sketch inference preferences (M06-F10, #625): whether point snapping and constraint
+// auto-application run while sketching, and which constraint family wins. As of #147 these are
+// PER-DOCUMENT (persisted in the .obk via doc.SketchSettings); the sketch tools read the active
+// document's settings here. With no active document (headless paths, tests) the session keeps a
+// fallback so the behaviour is still well-defined.
 
-// SketchInferenceOptions returns the session's inference configuration,
-// defaulting on first read.
+// SketchInferenceOptions returns the inference configuration the sketch tools should apply: the
+// active document's persisted sketch settings, or the session fallback when none is active.
 func (s *Session) SketchInferenceOptions() sketch.InferenceOptions {
+	if d := s.ActiveDocument(); d != nil {
+		return sketchInferenceFrom(d.SketchSettings())
+	}
 	if s.sketchInference == nil {
 		opts := sketch.DefaultInferenceOptions()
 		s.sketchInference = &opts
@@ -19,7 +23,12 @@ func (s *Session) SketchInferenceOptions() sketch.InferenceOptions {
 	return *s.sketchInference
 }
 
-// SetSketchInferenceOptions replaces the session's inference configuration.
+// SetSketchInferenceOptions stores the inference configuration on the active document (persisted,
+// per-document, #147), or on the session fallback when none is active.
 func (s *Session) SetSketchInferenceOptions(opts sketch.InferenceOptions) {
+	if d := s.ActiveDocument(); d != nil {
+		d.SetSketchSettings(sketchSettingsFrom(opts))
+		return
+	}
 	s.sketchInference = &opts
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.72.0
+	oblikovati.org/api v0.74.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.72.0
+	oblikovati.org/api v0.74.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/event"
 	"oblikovati.org/model/attr"
 	"oblikovati.org/model/display"
@@ -52,6 +53,7 @@ type Document struct {
 	attachments      *FileAttachments       // external-file attachment records (M03-F08); lazily seeded
 	interests        *DocumentInterests     // add-in data registry (M03-F10); lazily seeded
 	attributes       *attr.AttributeManager // add-in attribute sets (#155); lazily seeded
+	sketchSettings   *types.SketchSettings  // per-document sketch-authoring defaults (#147), nil ⇒ defaults
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;
@@ -221,6 +223,35 @@ func (d *Document) SetDisplaySettings(set display.Settings) {
 func (d *Document) RestoreDisplaySettings(set display.Settings) {
 	cp := set
 	d.displaySettings = &cp
+}
+
+// SketchSettings returns the document's per-document sketch-authoring defaults — the constraint-
+// inference toggles the sketch tools read (#147) — falling back to [types.DefaultSketchSettings]
+// when none have been set on this document.
+func (d *Document) SketchSettings() types.SketchSettings {
+	if d.sketchSettings == nil {
+		return types.DefaultSketchSettings()
+	}
+	return *d.sketchSettings
+}
+
+// SketchSettingsSet reports whether explicit sketch settings have been stored (so the persistence
+// layer writes a record only for documents that customised them).
+func (d *Document) SketchSettingsSet() bool { return d.sketchSettings != nil }
+
+// SetSketchSettings stores the document's sketch settings (and marks it dirty, since they
+// round-trip in the .obk).
+func (d *Document) SetSketchSettings(set types.SketchSettings) {
+	cp := set
+	d.sketchSettings = &cp
+	d.MarkDirty()
+}
+
+// RestoreSketchSettings stores the sketch settings WITHOUT marking the document dirty — the load
+// path, where the in-memory state already matches disk (like [Document.RestoreDisplaySettings]).
+func (d *Document) RestoreSketchSettings(set types.SketchSettings) {
+	cp := set
+	d.sketchSettings = &cp
 }
 
 // Referenced reports whether any open document references this one. An

--- a/model/doc/sketch_settings_test.go
+++ b/model/doc/sketch_settings_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// TestDocumentSketchSettings pins the per-document sketch settings accessors (#147): defaults when
+// unset, SetSketchSettings marks dirty + stores, RestoreSketchSettings stores without dirtying.
+func TestDocumentSketchSettings(t *testing.T) {
+	d := newDocument(Part, "t.obk", nil, true)
+	if got := d.SketchSettings(); got != types.DefaultSketchSettings() {
+		t.Errorf("unset settings = %+v, want defaults", got)
+	}
+	if d.SketchSettingsSet() {
+		t.Error("a fresh document should report no explicit sketch settings")
+	}
+
+	set := types.SketchSettings{InferConstraints: false, AutoApplyConstraints: true, ConstraintPriority: types.PriorityNone}
+	d.ClearDirty()
+	d.SetSketchSettings(set)
+	if !d.Dirty() {
+		t.Error("SetSketchSettings should mark the document dirty")
+	}
+	if !d.SketchSettingsSet() || d.SketchSettings() != set {
+		t.Errorf("SetSketchSettings did not store %+v (got %+v)", set, d.SketchSettings())
+	}
+
+	d.ClearDirty()
+	d.RestoreSketchSettings(types.DefaultSketchSettings())
+	if d.Dirty() {
+		t.Error("RestoreSketchSettings should NOT mark the document dirty (load path)")
+	}
+	if d.SketchSettings() != types.DefaultSketchSettings() {
+		t.Errorf("RestoreSketchSettings did not store the value: %+v", d.SketchSettings())
+	}
+}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -56,6 +56,7 @@ func (p *Package) marshal() ([]byte, error) {
 		Interests:       p.interests,
 		Attributes:      p.attributes,
 		DisplaySettings: p.display,
+		SketchSettings:  p.sketch,
 		Model:           p.model,
 		Data:            p.streams,
 		Resources:       p.resources,
@@ -85,6 +86,7 @@ func decode(raw []byte) (*Package, error) {
 	p.interests = doc.Interests
 	p.attributes = doc.Attributes
 	p.display = doc.DisplaySettings
+	p.sketch = doc.SketchSettings
 	for name, data := range doc.Data {
 		p.WriteStream(name, data)
 	}

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -36,6 +36,7 @@ type Package struct {
 	interests   []yamlcodec.InterestRecord       // add-in data registry (M03-F10)
 	attributes  []byte                           // add-in attribute sets, encoded (#155)
 	display     *yamlcodec.DisplaySettingsRecord // per-document display settings (M16-F07 #643)
+	sketch      *yamlcodec.SketchSettingsRecord  // per-document sketch settings (#147)
 }
 
 // NewPackage returns an empty package.
@@ -66,6 +67,12 @@ func (p *Package) SetDisplaySettings(d *yamlcodec.DisplaySettingsRecord) { p.dis
 
 // DisplaySettings returns the per-document display settings record (nil when unset).
 func (p *Package) DisplaySettings() *yamlcodec.DisplaySettingsRecord { return p.display }
+
+// SetSketchSettings stores the per-document sketch settings record (#147).
+func (p *Package) SetSketchSettings(s *yamlcodec.SketchSettingsRecord) { p.sketch = s }
+
+// SketchSettings returns the per-document sketch settings record (nil when unset).
+func (p *Package) SketchSettings() *yamlcodec.SketchSettingsRecord { return p.sketch }
 
 // SetInterests stores the add-in data-registry records (M03-F10).
 func (p *Package) SetInterests(i []yamlcodec.InterestRecord) { p.interests = i }

--- a/persistence/sketch_settings.go
+++ b/persistence/sketch_settings.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/persistence/yamlcodec"
+)
+
+// toCodecSketchSettings converts the per-document sketch settings into their on-disk record (#147)
+// so they round-trip in the .obk; the constraint-priority enum becomes its frozen integer id.
+func toCodecSketchSettings(s types.SketchSettings) *yamlcodec.SketchSettingsRecord {
+	return &yamlcodec.SketchSettingsRecord{
+		InferConstraints:     s.InferConstraints,
+		AutoApplyConstraints: s.AutoApplyConstraints,
+		ConstraintPriority:   int32(s.ConstraintPriority),
+	}
+}
+
+// fromCodecSketchSettings rebuilds the sketch settings from the on-disk record.
+func fromCodecSketchSettings(r *yamlcodec.SketchSettingsRecord) types.SketchSettings {
+	return types.SketchSettings{
+		InferConstraints:     r.InferConstraints,
+		AutoApplyConstraints: r.AutoApplyConstraints,
+		ConstraintPriority:   types.ConstraintInferencePriority(r.ConstraintPriority),
+	}
+}

--- a/persistence/sketch_settings_test.go
+++ b/persistence/sketch_settings_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// customSketchSettings is a non-default sketch settings value for the round-trip tests (#147).
+func customSketchSettings() types.SketchSettings {
+	return types.SketchSettings{
+		InferConstraints:     true,
+		AutoApplyConstraints: false,
+		ConstraintPriority:   types.PriorityParallelPerpendicular,
+	}
+}
+
+// TestSketchSettingsConverterRoundTrip pins the on-disk record conversion (#147).
+func TestSketchSettingsConverterRoundTrip(t *testing.T) {
+	set := customSketchSettings()
+	if got := fromCodecSketchSettings(toCodecSketchSettings(set)); got != set {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, set)
+	}
+}
+
+// TestPackageSketchSettingsSurvivesMarshal checks the per-document sketch settings round-trip through
+// the .obk YAML (marshal → decode), written as a readable YAML block (#147).
+func TestPackageSketchSettingsSurvivesMarshal(t *testing.T) {
+	p := NewPackage()
+	if err := p.SetManifest(Manifest{SchemaVersion: CurrentSchemaVersion, DocumentType: 1, DisplayName: "P"}); err != nil {
+		t.Fatalf("SetManifest: %v", err)
+	}
+	p.SetSketchSettings(toCodecSketchSettings(customSketchSettings()))
+
+	data, err := p.marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "sketchSettings:") {
+		t.Error("sketch settings should be written as a readable YAML block")
+	}
+
+	p2, err := decode(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p2.SketchSettings() == nil {
+		t.Fatal("sketch settings lost in the marshal/decode round-trip")
+	}
+	if got := fromCodecSketchSettings(p2.SketchSettings()); got != customSketchSettings() {
+		t.Errorf("decoded settings = %+v, want %+v", got, customSketchSettings())
+	}
+}

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -95,10 +95,8 @@ func (s *PackageStore) buildPackage(d *doc.Document, displayName, subType string
 	pkg.SetFileReferences(toCodecFileReferences(d.FileReferenceRecords()))
 	pkg.SetAttachments(toCodecAttachments(d.AttachmentRecords()))
 	pkg.SetInterests(toCodecInterests(d.InterestRecords()))
-	pkg.SetAttributes(d.AttributeBytes())   // #155 add-in attribute sets
-	if set, ok := d.DisplaySettings(); ok { // M16-F07 #643: per-document display settings
-		pkg.SetDisplaySettings(toCodecDisplaySettings(set))
-	}
+	pkg.SetAttributes(d.AttributeBytes()) // #155 add-in attribute sets
+	storeDocumentSettings(pkg, d)         // per-document display (#643) + sketch (#147) settings
 	if rc, ok := d.Content().(doc.RecipeContent); ok {
 		model, err := rc.MarshalRecipe()
 		if err != nil {
@@ -139,10 +137,31 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	if err := applyModelRecipe(d, pkg, fullDocumentName); err != nil {
 		return nil, err
 	}
-	if rec := pkg.DisplaySettings(); rec != nil { // M16-F07 #643: per-document display settings
+	restoreDocumentSettings(d, pkg) // per-document display (#643) + sketch (#147) settings
+	return d, nil
+}
+
+// storeDocumentSettings copies a document's per-document settings into the package for the save path:
+// display settings (#643) and sketch settings (#147), each written only when the document customised
+// them.
+func storeDocumentSettings(pkg *Package, d *doc.Document) {
+	if set, ok := d.DisplaySettings(); ok {
+		pkg.SetDisplaySettings(toCodecDisplaySettings(set))
+	}
+	if d.SketchSettingsSet() {
+		pkg.SetSketchSettings(toCodecSketchSettings(d.SketchSettings()))
+	}
+}
+
+// restoreDocumentSettings applies a package's per-document settings onto the document for the load
+// path (without dirtying it).
+func restoreDocumentSettings(d *doc.Document, pkg *Package) {
+	if rec := pkg.DisplaySettings(); rec != nil {
 		d.RestoreDisplaySettings(fromCodecDisplaySettings(rec))
 	}
-	return d, nil
+	if rec := pkg.SketchSettings(); rec != nil {
+		d.RestoreSketchSettings(fromCodecSketchSettings(rec))
+	}
 }
 
 // applyModelRecipe replays the persisted recipe into the document's content,

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -54,6 +54,17 @@ type Document struct {
 	// DisplaySettings are the per-document display settings (background/edges/ground/shadows),
 	// nil for a document that never customized them (M16-F07 #643).
 	DisplaySettings *DisplaySettingsRecord `yaml:"displaySettings,omitempty"`
+	// SketchSettings are the per-document sketch-authoring defaults (constraint inference),
+	// nil for a document that never customized them (#147).
+	SketchSettings *SketchSettingsRecord `yaml:"sketchSettings,omitempty"`
+}
+
+// SketchSettingsRecord is the on-disk per-document sketch settings (#147): the constraint-inference
+// toggles and family priority. The priority enum is stored as its frozen integer id.
+type SketchSettingsRecord struct {
+	InferConstraints     bool  `yaml:"inferConstraints"`
+	AutoApplyConstraints bool  `yaml:"autoApplyConstraints"`
+	ConstraintPriority   int32 `yaml:"constraintPriority"`
 }
 
 // ColorRecord is a color value object on disk: 8-bit rgb, opacity, and the color-source enum.
@@ -158,6 +169,7 @@ type onDisk struct {
 	Interests       []InterestRecord       `yaml:"interests,omitempty"`
 	Attributes      []byte                 `yaml:"attributes,omitempty"`
 	DisplaySettings *DisplaySettingsRecord `yaml:"displaySettings,omitempty"`
+	SketchSettings  *SketchSettingsRecord  `yaml:"sketchSettings,omitempty"`
 	Resources       yaml.Node              `yaml:"resources,omitempty"`
 	Model           yaml.Node              `yaml:"model,omitempty"`
 	Data            map[string]string      `yaml:"data,omitempty"`
@@ -177,6 +189,7 @@ func MarshalDocument(d Document) ([]byte, error) {
 		Interests:       d.Interests,
 		Attributes:      d.Attributes,
 		DisplaySettings: d.DisplaySettings,
+		SketchSettings:  d.SketchSettings,
 	}
 	if err := embedNativeNodes(&od, d); err != nil {
 		return nil, err
@@ -254,6 +267,7 @@ func documentHeader(od onDisk) Document {
 		Interests:       od.Interests,
 		Attributes:      od.Attributes,
 		DisplaySettings: od.DisplaySettings,
+		SketchSettings:  od.SketchSettings,
 	}
 }
 


### PR DESCRIPTION
## What

The `/source` half of **#147** — implements the per-document sketch settings the API contract (`oblikovati.org/api` **v0.74.0**) defined. Closes #147.

Per-document sketch-authoring defaults (constraint-inference toggles + family priority) now **persist with the document** and are routed over `document.getSketchSettings` / `document.setSketchSettings`. The sketch tools read the **active document's** settings, so each open part keeps its own inference behaviour (lifting them out of the previous session-only state).

## Changes

- **model/doc**: `Document.SketchSettings` / `SetSketchSettings` / `RestoreSketchSettings` + `SketchSettingsSet` (nil ⇒ `types.DefaultSketchSettings`), mirroring the per-document display settings.
- **persistence**: a `SketchSettingsRecord` round-trips in the `.obk` (yamlcodec record + package field + io threading + store save/load), written only when customised.
- **app**: `Session.DocumentSketchSettings` / `SetDocumentSketchSettings` (addressed by session id, 0 ⇒ active) as the in-proc seam; `SketchInferenceOptions` now reads the active document's settings (with a session fallback for headless paths).
- **addin/router**: `getDocumentSketchSettings` / `setDocumentSketchSettings` keyed on the `api/wire` constants.
- pin `oblikovati.org/api v0.74.0` (`go.mod` + `head/go.mod`).

## Tests

- doc accessors + dirty semantics
- `.obk` marshal/decode round-trip (readable YAML block)
- router round-trip persists on the document
- the sketch tools read the active document's settings

Full `go test ./...` green, `golangci-lint` clean, head builds + ui tests pass, `addin/router` api-parity satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)