### PR TITLE
Route the part end-of-part rollback marker (#141)

### DIFF
--- a/addin/router/document_end_of_part.go
+++ b/addin/router/document_end_of_part.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+)
+
+// registerEndOfPartHandlers wires the part end-of-part rollback-marker methods (#141).
+func (r *Router) registerEndOfPartHandlers() {
+	r.handlers[wire.MethodDocumentGetEndOfPart] = getEndOfPart
+	r.handlers[wire.MethodDocumentSetEndOfPart] = setEndOfPart
+}
+
+// getEndOfPart returns the active part's end-of-part marker state
+// (wire.MethodDocumentGetEndOfPart).
+func getEndOfPart(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(endOfPartResult(part))
+}
+
+// setEndOfPart moves the active part's end-of-part marker, re-evaluates the program up to it, and
+// returns the marker's new state (wire.MethodDocumentSetEndOfPart).
+func setEndOfPart(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in wire.SetEndOfPartArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part.SetEndOfPart(in.Position)
+	part.Recompute() // re-evaluate the feature program up to the moved marker
+	return json.Marshal(endOfPartResult(part))
+}
+
+// endOfPartResult reads the part's marker into its wire reply.
+func endOfPartResult(part *compdef.PartComponentDefinition) wire.EndOfPartResult {
+	return wire.EndOfPartResult{Position: part.EndOfPartPosition(), RolledBack: part.IsRolledBack()}
+}

--- a/addin/router/document_end_of_part_test.go
+++ b/addin/router/document_end_of_part_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestEndOfPartRoundTrip reads the active part's marker (at the end by default), rolls it back to an
+// earlier feature index, and restores it — checking each reply reflects the marker state (#141).
+func TestEndOfPartRoundTrip(t *testing.T) {
+	r, s := seededSession(t)
+
+	var got wire.EndOfPartResult
+	call(t, r, s, wire.MethodDocumentGetEndOfPart, `{}`, &got)
+	if got.Position != -1 || got.RolledBack {
+		t.Fatalf("default marker = %+v, want position -1 / not rolled back", got)
+	}
+
+	var back wire.EndOfPartResult
+	call(t, r, s, wire.MethodDocumentSetEndOfPart, mustJSON(t, wire.SetEndOfPartArgs{Position: 0}), &back)
+	if back.Position != 0 || !back.RolledBack {
+		t.Errorf("after roll-back to 0 = %+v, want position 0 / rolled back", back)
+	}
+
+	var end wire.EndOfPartResult
+	call(t, r, s, wire.MethodDocumentSetEndOfPart, mustJSON(t, wire.SetEndOfPartArgs{Position: -1}), &end)
+	if end.Position != -1 || end.RolledBack {
+		t.Errorf("after restore-to-end = %+v, want position -1 / not rolled back", end)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -72,6 +72,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerAssemblyBOMHandlers()
 	r.registerDocumentPropertyHandlers()
 	r.registerDocumentSettingsHandlers()
+	r.registerEndOfPartHandlers()
 	r.registerAttributeHandlers()
 	r.registerSelectionMutationHandlers()
 	r.registerSketchReferenceKeyHandlers()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.74.0
+	oblikovati.org/api v0.76.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.74.0
+	oblikovati.org/api v0.76.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/contract_assert.go
+++ b/model/compdef/contract_assert.go
@@ -15,3 +15,7 @@ var (
 // The assembly definition satisfies the public contract's scalar assembly read surface
 // (#728); the occurrence tree and mutators travel over api/wire (assembly.*).
 var _ contract.AssemblyComponentDefinition = (*AssemblyComponentDefinition)(nil)
+
+// The part definition satisfies the public end-of-part rollback-marker contract (#141): the wire
+// surface (document.get/setEndOfPart) drives EndOfPartPosition / SetEndOfPart / RollToEnd.
+var _ contract.EndOfPart = (*PartComponentDefinition)(nil)


### PR DESCRIPTION
## What

The `/source` half of **#141** — closes the issue. Exposes the part's **end-of-part rollback marker** over the wire (the part analogue of the assembly's end-of-features marker).

The marker and the rollback-replay engine **already existed** (`compdef.PartComponentDefinition.SetEndOfPart`/`EndOfPartPosition`/`RollToEnd`, M08) — this just adds the wire surface the API contract (`oblikovati.org/api` **v0.76.0**) defined.

## Changes

- assert the part definition satisfies the new `contract.EndOfPart`.
- **addin/router**: `document.getEndOfPart` / `document.setEndOfPart` — read the marker, or move it and `Recompute` the program up to it, returning `{position, rolledBack}`.
- pin `oblikovati.org/api v0.76.0` (`go.mod` + `head/go.mod`).

## Tests

Router round-trip: read (at end by default) → roll back to a feature index → restore to end, each reply reflecting the marker state. Full `go test ./...` green, `golangci-lint` clean, head builds, api-parity satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)