### PR TITLE
Add the Rule Fillet ribbon command + interactive tool (#1076)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -271,6 +271,12 @@ func surfaceFeatureCommands() []*CommandDefinition {
 		}).WithTab(tab3DModel).WithEnable(hasActivePart).
 			WithIcon("surface-extend").WithButtonStyle(LargeIconButton).
 			WithTooltip("Extend — grow a surface outward along a boundary edge."),
+		NewCommand("Surface.RuleFillet", "Rule Fillet", "Surface", func(s *Session) error {
+			s.StartTool(NewRuleFilletTool())
+			return nil
+		}).WithTab(tab3DModel).WithEnable(hasActivePart).
+			WithIcon("fillet").WithButtonStyle(LargeIconButton).
+			WithTooltip("Rule Fillet — round a whole class of edges (all rounds, all fillets, or all edges) at one radius."),
 		NewCommand("Surface.Ruled", "Ruled Surface", "Surface", func(s *Session) error {
 			s.StartTool(NewRuledSurfaceTool())
 			return nil

--- a/app/rule_fillet_tool.go
+++ b/app/rule_fillet_tool.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// RuleFilletTool is the interactive Rule Fillet command (#1076): round a whole CLASS of the active
+// part's edges in one feature — every convex edge (All Rounds), every concave edge (All Fillets), or
+// every manifold edge (All Edges) — at one radius. It needs no viewport picking, so it is a dialog
+// tool: the user chooses the rule and radius in the property window, then OK. (The geometry — the
+// edge-class classifier + the dress-up kernel — already shipped via #1020.)
+type RuleFilletTool struct {
+	dialogTool
+	rule     feature.RuleFilletRule
+	radiusMM float64
+	added    *feature.PartFeature
+}
+
+// ruleFilletRuleOptions are the dropdown labels, indexed by [feature.RuleFilletRule].
+var ruleFilletRuleOptions = []string{"All Rounds", "All Fillets", "All Edges"}
+
+// NewRuleFilletTool returns a rule-fillet tool defaulting to All Rounds at a 2 mm radius.
+func NewRuleFilletTool() *RuleFilletTool {
+	return &RuleFilletTool{rule: feature.RuleFilletAllRounds, radiusMM: 2}
+}
+
+// Name implements [Tool].
+func (t *RuleFilletTool) Name() string { return "Rule Fillet" }
+
+// Rule / SetRule and RadiusMM / SetRadiusMM are the property-window accessors.
+func (t *RuleFilletTool) Rule() int         { return int(t.rule) }
+func (t *RuleFilletTool) SetRule(i int)     { t.rule = feature.RuleFilletRule(i) }
+func (t *RuleFilletTool) RadiusMM() float64 { return t.radiusMM }
+func (t *RuleFilletTool) SetRadiusMM(mm float64) {
+	if mm > 0 {
+		t.radiusMM = mm
+	}
+}
+
+// Params exposes the rule selector and radius for the generic property dialog.
+func (t *RuleFilletTool) Params() ToolParams {
+	return ToolParams{
+		Choices: []ChoiceParam{{Label: "Rule", Options: ruleFilletRuleOptions, Get: t.Rule, Set: t.SetRule}},
+		Floats:  []FloatParam{{Label: "Radius (mm)", Get: t.RadiusMM, Set: t.SetRadiusMM}},
+	}
+}
+
+// CanCommit is true once a positive radius is set (always, given the default).
+func (t *RuleFilletTool) CanCommit() bool { return t.radiusMM > 0 }
+
+// Commit rounds the chosen edge class on the active part and recomputes; a sick feature (no matching
+// edges, or a self-colliding radius) keeps the tool open with the reason.
+func (t *RuleFilletTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	radiusCm := t.radiusMM / 10 // model/database length unit is the centimetre (1 unit = 10 mm)
+	t.added = feature.NewDressUpFeatures(part.Features()).AddRuleFillet(t.rule, func() float64 { return radiusCm })
+	part.Recompute()
+	s.recordEdit(part, "Rule Fillet")
+	if !t.added.Health().OK() {
+		return errors.New("rule fillet: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *RuleFilletTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/rule_fillet_tool_test.go
+++ b/app/rule_fillet_tool_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// TestRuleFilletToolEndToEnd drives the Rule Fillet UI: a block, choose All Rounds + a radius, OK —
+// and asserts a valid solid feature was added and the convex edges were rounded (volume dropped from
+// the block's). The tool needs no picking, so it commits straight from its parameters (#1076).
+func TestRuleFilletToolEndToEnd(t *testing.T) {
+	s, _ := newPartWithBlock(t, 6) // 6×6×2 block, vol 72
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	before := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+
+	rf := NewRuleFilletTool()
+	rf.SetRule(int(feature.RuleFilletAllRounds))
+	rf.SetRadiusMM(2)
+	s.StartTool(rf)
+	if !rf.CanCommit() {
+		t.Fatal("rule fillet tool not ready with a positive radius")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	if rf.AddedFeature() == nil || !rf.AddedFeature().Health().OK() {
+		t.Fatalf("rule fillet feature not healthy: %+v", rf.AddedFeature())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("rule-filleted body not a valid solid: %+v", r)
+	}
+	if after := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; after >= before {
+		t.Errorf("volume %g did not drop from %g — All Rounds should round the convex edges", after, before)
+	}
+}
+
+// TestRuleFilletViaRibbonCommand confirms the Surface-panel ribbon command starts the tool.
+func TestRuleFilletViaRibbonCommand(t *testing.T) {
+	s, _ := newPartWithBlock(t, 6)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.RuleFillet"); err != nil {
+		t.Fatalf("execute Surface.RuleFillet: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*RuleFilletTool); !ok {
+		t.Fatal("Rule Fillet command did not start the rule fillet tool")
+	}
+}

--- a/app/rule_fillet_tool_test.go
+++ b/app/rule_fillet_tool_test.go
@@ -41,6 +41,41 @@ func TestRuleFilletToolEndToEnd(t *testing.T) {
 	}
 }
 
+// TestRuleFilletToolParams exercises the property-dialog surface: the name, the rule/radius
+// accessors (radius rejects a non-positive value), and the Params model the head renders.
+func TestRuleFilletToolParams(t *testing.T) {
+	tl := NewRuleFilletTool()
+	if tl.Name() != "Rule Fillet" {
+		t.Errorf("name = %q, want Rule Fillet", tl.Name())
+	}
+	tl.SetRule(int(feature.RuleFilletAllEdges))
+	tl.SetRadiusMM(5)
+	if tl.Rule() != int(feature.RuleFilletAllEdges) || tl.RadiusMM() != 5 {
+		t.Errorf("rule/radius = %d/%g, want allEdges/5", tl.Rule(), tl.RadiusMM())
+	}
+	tl.SetRadiusMM(-1) // a non-positive radius is rejected, keeping the prior value
+	if tl.RadiusMM() != 5 {
+		t.Errorf("radius after -1 = %g, want it kept at 5", tl.RadiusMM())
+	}
+
+	p := tl.Params()
+	if len(p.Choices) != 1 || len(p.Choices[0].Options) != 3 || len(p.Floats) != 1 {
+		t.Fatalf("params = %d choices (%d options) / %d floats, want 1 (3) / 1", len(p.Choices), len(p.Choices[0].Options), len(p.Floats))
+	}
+	p.Choices[0].Set(int(feature.RuleFilletAllFillets))
+	p.Floats[0].Set(8)
+	if p.Choices[0].Get() != int(feature.RuleFilletAllFillets) || p.Floats[0].Get() != 8 {
+		t.Errorf("param round-trip: rule %d radius %g, want allFillets/8", p.Choices[0].Get(), p.Floats[0].Get())
+	}
+}
+
+// TestRuleFilletToolCommitNoPart covers the no-active-part error path.
+func TestRuleFilletToolCommitNoPart(t *testing.T) {
+	if err := NewRuleFilletTool().Commit(NewSession()); err == nil {
+		t.Error("commit with no active part should error")
+	}
+}
+
 // TestRuleFilletViaRibbonCommand confirms the Surface-panel ribbon command starts the tool.
 func TestRuleFilletViaRibbonCommand(t *testing.T) {
 	s, _ := newPartWithBlock(t, 6)


### PR DESCRIPTION
## What

First slice of **#1076** (plastic-features UI DoD): the **Rule Fillet** ribbon button + interactive tool. The geometry (edge-class classifier + dress-up kernel) already shipped via #1020; this is the missing UI so it meets the repo's "done = UI + e2e" bar.

Rule Fillet is the simplest of the four (Rest/RuleFillet/SnapFit/Lip) — it needs **no viewport picking**.

## Changes

- **`RuleFilletTool`** — a dialog-only tool: a rule selector (All Rounds / All Fillets / All Edges) + radius, committing via the existing `AddRuleFillet` dress-up.
- **ribbon**: `Surface.RuleFillet` on the part **Surface** panel — per the canonical ribbon tree (`architecture/mapping/inventor-ribbon-structure.md` lists Rule Fillet as a Surface-panel button; the issue's "Plastic panel" predates that mapping).
- **e2e tests**: the tool rounds a block's convex edges (volume drops, valid solid); the ribbon command starts the tool.

## Live confirmation

`previewshot -op rulefillet` — the block renders with **every convex edge cleanly rounded** (All Rounds), committed through the UI tool.

![rule fillet result](attached in the session)

## Scope

This ships **Rule Fillet** (1 of 4). **Rest**, **Snap Fit**, and **Lip** — the sketch-profile / edge-picking plastic tools — remain on #1076 as follow-ups.

`go test ./app/...` green, `golangci-lint` clean, head builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)