### PR TITLE
Add Rest, Snap Fit and Lip plastic-feature tools (#1076)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -468,6 +468,12 @@ func cutFeatureCommands() []*CommandDefinition {
 		}).WithTab(tab3DModel).WithEnable(notInSketch).
 			WithIcon("boss").WithButtonStyle(LargeIconButton).
 			WithTooltip("Boss — raise a cylindrical stud on a planar face (the join-side mirror of Hole)."),
+		NewCommand("Modify.Lip", "Lip", "Modify", func(s *Session) error {
+			s.StartTool(NewLipTool())
+			return nil
+		}).WithTab(tab3DModel).WithEnable(notInSketch).
+			WithIcon("lip").WithButtonStyle(LargeIconButton).
+			WithTooltip("Lip — run a raised lip (or recessed groove) bead along picked edges of the part."),
 		NewCommand("Modify.Chamfer", "Chamfer", "Modify", func(s *Session) error {
 			s.StartTool(NewChamferTool())
 			return nil
@@ -622,6 +628,18 @@ func sweptSolidCommands() []*CommandDefinition {
 		}).WithTab(tab3DModel).WithEnable(notInSketch).
 			WithIcon("grill").WithButtonStyle(LargeIconButton).
 			WithTooltip("Grill — cut a ventilation grill: a vent bridged by the boundary profile's rib/spar/island structure."),
+		NewCommand("Create.Rest", "Rest", "Create", func(s *Session) error {
+			s.StartTool(NewRestTool())
+			return nil
+		}).WithTab(tab3DModel).WithEnable(notInSketch).
+			WithIcon("rest").WithButtonStyle(LargeIconButton).
+			WithTooltip("Rest — raise a pad (or recess a pocket) over a closed sketch region on the part."),
+		NewCommand("Create.SnapFit", "Snap Fit", "Create", func(s *Session) error {
+			s.StartTool(NewSnapFitTool())
+			return nil
+		}).WithTab(tab3DModel).WithEnable(hasActivePart).
+			WithIcon("snap-fit").WithButtonStyle(LargeIconButton).
+			WithTooltip("Snap Fit — add a cantilever snap-fit hook sized by its beam and catch dimensions."),
 		NewCommand("Create.Decal", "Decal", "Create", func(s *Session) error {
 			s.StartTool(NewDecalTool())
 			return nil

--- a/app/lip_tool.go
+++ b/app/lip_tool.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// LipTool is the interactive Lip command (#1076, plastic features): click one or more edges,
+// set the bead width and height in the property window, choose lip (raised) or groove (cut),
+// then OK to run the bead along them. Width sizes the bead along the first adjacent face,
+// height along the second.
+type LipTool struct {
+	edges  []EdgeHandle
+	width  float64
+	height float64
+	groove bool
+	added  *feature.PartFeature
+}
+
+// NewLipTool returns a lip tool defaulting to a raised 1×1 bead.
+func NewLipTool() *LipTool { return &LipTool{width: 1, height: 1} }
+
+// Name implements [Tool].
+func (t *LipTool) Name() string { return "Lip" }
+
+// Start sets the selection filter to edges so clicks pick the bead path.
+func (t *LipTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+
+// Pick appends the clicked edge (ignoring one already chosen, so a double-click does not
+// duplicate it).
+func (t *LipTool) Pick(_ *Session, sel Selectable) {
+	e, ok := sel.(EdgeHandle)
+	if !ok || t.hasEdge(e) {
+		return
+	}
+	t.edges = append(t.edges, e)
+}
+
+func (t *LipTool) hasEdge(e EdgeHandle) bool {
+	for _, h := range t.edges {
+		if h == e {
+			return true
+		}
+	}
+	return false
+}
+
+// The options the property window drives: width, height (database units) and groove (cut vs raise).
+func (t *LipTool) SetWidth(v float64)  { t.width = posOrKeep(v, t.width) }
+func (t *LipTool) Width() float64      { return t.width }
+func (t *LipTool) SetHeight(v float64) { t.height = posOrKeep(v, t.height) }
+func (t *LipTool) Height() float64     { return t.height }
+func (t *LipTool) SetGroove(v bool)    { t.groove = v }
+func (t *LipTool) Groove() bool        { return t.groove }
+
+// Params exposes the bead width, height and groove flag for the generic property dialog.
+func (t *LipTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{
+			{Label: "Width", Get: t.Width, Set: t.SetWidth},
+			{Label: "Height", Get: t.Height, Set: t.SetHeight},
+		},
+		Bools: []BoolParam{{Label: "Groove (cut)", Get: t.Groove, Set: t.SetGroove}},
+	}
+}
+
+// Edges returns the picked edges (for the UI to list/highlight).
+func (t *LipTool) Edges() []EdgeHandle { return append([]EdgeHandle(nil), t.edges...) }
+
+// CanCommit reports whether at least one edge is selected and both dimensions are positive.
+func (t *LipTool) CanCommit() bool { return len(t.edges) > 0 && t.width > 0 && t.height > 0 }
+
+// Commit runs the bead along the picked edges on the active part and recomputes; a sick
+// feature keeps the tool open by returning an error.
+func (t *LipTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = t.addLip(feature.NewDressUpFeatures(part.Features()))
+	part.Recompute()
+	s.recordEdit(part, "Lip")
+	if !t.added.Health().OK() {
+		return errors.New("lip: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// addLip builds the lip feature into dress — shared by Commit and the preview.
+func (t *LipTool) addLip(dress *feature.DressUpFeatures) *feature.PartFeature {
+	w, h, gr := t.width, t.height, t.groove
+	return dress.AddLip(t.selectedEdgeKeys(), func() float64 { return w }, func() float64 { return h }, gr)
+}
+
+// selectedEdgeKeys is the reference-key set a commit writes from this session's picks.
+func (t *LipTool) selectedEdgeKeys() [][]byte {
+	keys := make([][]byte, 0, len(t.edges))
+	for _, e := range t.edges {
+		keys = append(keys, e.Edge.ReferenceKey())
+	}
+	return keys
+}
+
+// DraftFeature returns the unattached lip feature the viewport previews before commit.
+func (t *LipTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addLip(feature.NewDressUpFeatures(fs)), nil
+	})
+}
+
+// Cancel restores the default selection filter.
+func (t *LipTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *LipTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/lip_tool_test.go
+++ b/app/lip_tool_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// TestLipToolEndToEnd drives the Lip UI: start the tool, click a vertical edge of a 2×2×2
+// block, set the bead width/height, OK — and asserts the raised lip added material to a
+// still-valid solid.
+func TestLipToolEndToEnd(t *testing.T) {
+	s, block := newPartWithBlock(t, 2) // 2×2×2, vol 8
+	before := ops.BodyGeometryProperties(block, ops.DefaultQuality()).Volume
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+
+	lt := NewLipTool()
+	s.StartTool(lt)
+	s.Click(50, 50)
+	lt.SetWidth(0.3)
+	lt.SetHeight(0.3)
+	if !lt.CanCommit() {
+		t.Fatal("lip tool not ready after edge + dimensions")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if lt.AddedFeature() == nil || !lt.AddedFeature().Health().OK() {
+		t.Fatalf("lip feature not healthy: %+v", lt.AddedFeature())
+	}
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if v := ops.Validate(body); !v.Valid || !body.IsSolid() {
+		t.Fatalf("lip body not a valid solid: %+v", v)
+	}
+	if after := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; after <= before {
+		t.Errorf("lip volume %g did not rise from %g — a raised lip adds material", after, before)
+	}
+}
+
+// TestLipToolGrooves confirms the groove mode cuts material (volume drops).
+func TestLipToolGrooves(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	before := ops.BodyGeometryProperties(block, ops.DefaultQuality()).Volume
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+
+	lt := NewLipTool()
+	s.StartTool(lt)
+	s.Click(50, 50)
+	lt.SetWidth(0.3)
+	lt.SetHeight(0.3)
+	lt.SetGroove(true)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if v := ops.Validate(body); !v.Valid || !body.IsSolid() {
+		t.Fatalf("grooved body not a valid solid: %+v", v)
+	}
+	if after := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; after >= before {
+		t.Errorf("groove volume %g did not drop from %g — a groove cuts material", after, before)
+	}
+}
+
+// TestLipToolParams exercises the property-dialog surface: name, width/height/groove accessors
+// (the dimensions reject a non-positive value), and the Params model the head renders.
+func TestLipToolParams(t *testing.T) {
+	tl := NewLipTool()
+	if tl.Name() != "Lip" {
+		t.Errorf("name = %q, want Lip", tl.Name())
+	}
+	if tl.CanCommit() {
+		t.Error("lip with no picked edge should not be committable")
+	}
+	tl.SetWidth(2)
+	tl.SetHeight(3)
+	tl.SetGroove(true)
+	if tl.Width() != 2 || tl.Height() != 3 || !tl.Groove() {
+		t.Errorf("width/height/groove = %g/%g/%v, want 2/3/true", tl.Width(), tl.Height(), tl.Groove())
+	}
+	tl.SetWidth(0) // a non-positive dimension is rejected, keeping the prior value
+	if tl.Width() != 2 {
+		t.Errorf("width after 0 = %g, want kept at 2", tl.Width())
+	}
+	p := tl.Params()
+	if len(p.Floats) != 2 || len(p.Bools) != 1 {
+		t.Fatalf("params = %d floats / %d bools, want 2 / 1", len(p.Floats), len(p.Bools))
+	}
+	p.Floats[1].Set(4)
+	p.Bools[0].Set(false)
+	if p.Floats[1].Get() != 4 || p.Bools[0].Get() {
+		t.Errorf("param round-trip: height %g groove %v, want 4/false", p.Floats[1].Get(), p.Bools[0].Get())
+	}
+}
+
+// TestLipToolPreviewAndCancel covers the draft preview (before/after a pick) and Cancel.
+func TestLipToolPreviewAndCancel(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	edge := verticalEdgeOf(t, block)
+	tl := NewLipTool()
+	s.StartTool(tl)
+
+	if _, ok := tl.DraftFeature(s); ok {
+		t.Error("no draft should preview before an edge is picked")
+	}
+	tl.Pick(s, edge)
+	tl.Pick(s, edge) // a repeat pick must not duplicate the edge
+	if len(tl.Edges()) != 1 {
+		t.Fatalf("edges = %d, want 1 (no duplicate)", len(tl.Edges()))
+	}
+	if _, ok := tl.DraftFeature(s); !ok {
+		t.Error("a draft should preview once an edge + dimensions are set")
+	}
+	tl.Cancel(s)
+}
+
+// TestLipToolCommitNoPart covers the no-active-part error path.
+func TestLipToolCommitNoPart(t *testing.T) {
+	if err := NewLipTool().Commit(NewSession()); err == nil {
+		t.Error("commit with no active part should error")
+	}
+}
+
+// TestLipViaRibbonCommand confirms the Modify-panel ribbon command starts the tool.
+func TestLipViaRibbonCommand(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	s.SetPicker(stubPicker{sel: verticalEdgeOf(t, block)})
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Modify.Lip"); err != nil {
+		t.Fatalf("execute Modify.Lip: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*LipTool); !ok {
+		t.Fatal("Lip command did not start the lip tool")
+	}
+}

--- a/app/rest_tool.go
+++ b/app/rest_tool.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// RestTool is the interactive Rest command (#1076, plastic features): pick one or more closed
+// sketch regions, set the depth and whether the rest is raised (a pad) or recessed (a pocket),
+// then OK to add it to the active part. It exposes its parameters through ParameterizedTool, so
+// the head renders the generic property dialog.
+type RestTool struct {
+	profiles []ProfileHandle
+	depth    float64
+	recessed bool
+	added    *feature.PartFeature
+}
+
+// NewRestTool returns a rest tool defaulting to a 1-unit raised pad.
+func NewRestTool() *RestTool { return &RestTool{depth: 1} }
+
+// Name implements [Tool].
+func (t *RestTool) Name() string { return "Rest" }
+
+// Start filters selection to closed regions so clicks pick a profile.
+func (t *RestTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+
+// Pick captures a single clicked region (replacing any previous selection).
+func (t *RestTool) Pick(_ *Session, sel Selectable) {
+	if p, ok := sel.(ProfileHandle); ok {
+		t.profiles = []ProfileHandle{p}
+	}
+}
+
+// PickWithMods extends the selection on Ctrl+click (toggling), to rest several regions at once.
+func (t *RestTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
+	p, ok := sel.(ProfileHandle)
+	if !ok {
+		return
+	}
+	if !mods.Has(CtrlMod) {
+		t.Pick(s, sel)
+		return
+	}
+	if i := indexOfProfile(t.profiles, p); i >= 0 {
+		t.profiles = append(t.profiles[:i], t.profiles[i+1:]...)
+		return
+	}
+	t.profiles = append(t.profiles, p)
+}
+
+// The options the property window drives: depth (database units) and recessed (pocket vs pad).
+func (t *RestTool) SetDepth(d float64) { t.depth = d }
+func (t *RestTool) Depth() float64     { return t.depth }
+func (t *RestTool) SetRecessed(v bool) { t.recessed = v }
+func (t *RestTool) Recessed() bool     { return t.recessed }
+
+// Params exposes the rest depth and recessed flag for the generic property dialog.
+func (t *RestTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{{Label: "Depth", Get: t.Depth, Set: t.SetDepth}},
+		Bools:  []BoolParam{{Label: "Recessed (pocket)", Get: t.Recessed, Set: t.SetRecessed}},
+	}
+}
+
+// PickedProfiles returns the picked regions for the unified tool highlight.
+func (t *RestTool) PickedProfiles() []ProfileHandle {
+	return append([]ProfileHandle(nil), t.profiles...)
+}
+
+// CanCommit reports whether a region is picked and the depth is positive.
+func (t *RestTool) CanCommit() bool { return len(t.profiles) > 0 && t.depth > 0 }
+
+// Commit adds the rest to the active part and recomputes; a sick feature keeps the tool open.
+func (t *RestTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = t.addRest(part.Features())
+	part.Recompute()
+	s.recordEdit(part, "Rest")
+	if !t.added.Health().OK() {
+		return errors.New("rest: " + t.added.Health().Reason)
+	}
+	s.Selection().SetFilter(NewSelectionFilter())
+	return nil
+}
+
+// addRest builds the rest feature into engine fs — shared by Commit and the preview.
+func (t *RestTool) addRest(fs *feature.PartFeatures) *feature.PartFeature {
+	skt := t.profiles[0].Sketch
+	d, rec := t.depth, t.recessed
+	return feature.NewPlasticFeatures(fs).AddRest(skt, profileIndicesOn(t.profiles, skt), func() float64 { return d }, rec, 0)
+}
+
+// DraftFeature returns the unattached rest feature the viewport previews before commit.
+func (t *RestTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return t.addRest(fs), nil
+	})
+}
+
+// Cancel restores the default selection filter.
+func (t *RestTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *RestTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/rest_tool_test.go
+++ b/app/rest_tool_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// TestRestToolEndToEnd drives the Rest UI: pick a region, set a depth, OK — and asserts the
+// raised pad added material (block 72 + 2×2×1 = 76).
+func TestRestToolEndToEnd(t *testing.T) {
+	s, def, region := partWithTopRegion(t)
+	s.SetPicker(stubPicker{sel: region})
+
+	r := NewRestTool()
+	s.StartTool(r)
+	s.Click(100, 100)
+	r.SetDepth(1)
+	if !r.CanCommit() {
+		t.Fatal("rest tool not ready after picking a region + depth")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if r.AddedFeature() == nil || !r.AddedFeature().Health().OK() {
+		t.Fatalf("rest feature not healthy: %+v", r.AddedFeature())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if v := ops.Validate(body); !v.Valid || !body.IsSolid() {
+		t.Fatalf("rest body not a valid solid: %+v", v)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErrApp(v, 76) > 0.01 {
+		t.Errorf("rest volume = %g, want ≈76 (72 + 2×2×1)", v)
+	}
+}
+
+// TestRestToolRecesses confirms the recessed mode cuts a pocket (block 72 − 2×2×1 = 68).
+func TestRestToolRecesses(t *testing.T) {
+	s, def, region := partWithTopRegion(t)
+	s.SetPicker(stubPicker{sel: region})
+
+	r := NewRestTool()
+	s.StartTool(r)
+	s.Click(100, 100)
+	r.SetDepth(1)
+	r.SetRecessed(true)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; relErrApp(v, 68) > 0.01 {
+		t.Errorf("recessed volume = %g, want ≈68 (72 − 2×2×1)", v)
+	}
+}
+
+// TestRestToolParams exercises the property-dialog surface: name, depth/recessed accessors,
+// and the Params model the head renders.
+func TestRestToolParams(t *testing.T) {
+	tl := NewRestTool()
+	if tl.Name() != "Rest" {
+		t.Errorf("name = %q, want Rest", tl.Name())
+	}
+	if tl.CanCommit() {
+		t.Error("rest with no picked region should not be committable")
+	}
+	tl.SetDepth(3)
+	tl.SetRecessed(true)
+	if tl.Depth() != 3 || !tl.Recessed() {
+		t.Errorf("depth/recessed = %g/%v, want 3/true", tl.Depth(), tl.Recessed())
+	}
+	p := tl.Params()
+	if len(p.Floats) != 1 || len(p.Bools) != 1 {
+		t.Fatalf("params = %d floats / %d bools, want 1 / 1", len(p.Floats), len(p.Bools))
+	}
+	p.Floats[0].Set(5)
+	p.Bools[0].Set(false)
+	if p.Floats[0].Get() != 5 || p.Bools[0].Get() {
+		t.Errorf("param round-trip: depth %g recessed %v, want 5/false", p.Floats[0].Get(), p.Bools[0].Get())
+	}
+}
+
+// TestRestToolPreviewAndPick covers the draft preview, Ctrl-toggle multi-pick, and Cancel.
+func TestRestToolPreviewAndPick(t *testing.T) {
+	s, _, region := partWithTopRegion(t)
+	tl := NewRestTool()
+	s.StartTool(tl)
+
+	if _, ok := tl.DraftFeature(s); ok {
+		t.Error("no draft should preview before a region is picked")
+	}
+	tl.PickWithMods(s, region, CtrlMod) // first Ctrl-pick adds it
+	if len(tl.PickedProfiles()) != 1 {
+		t.Fatalf("picked = %d, want 1 after Ctrl-pick", len(tl.PickedProfiles()))
+	}
+	tl.SetDepth(1)
+	if _, ok := tl.DraftFeature(s); !ok {
+		t.Error("a draft should preview once a region + depth are set")
+	}
+	tl.PickWithMods(s, region, CtrlMod) // Ctrl-pick again toggles it off
+	if len(tl.PickedProfiles()) != 0 {
+		t.Errorf("picked = %d, want 0 after toggling the region off", len(tl.PickedProfiles()))
+	}
+	tl.Cancel(s)
+}
+
+// TestRestToolCommitNoPart covers the no-active-part error path.
+func TestRestToolCommitNoPart(t *testing.T) {
+	if err := NewRestTool().Commit(NewSession()); err == nil {
+		t.Error("commit with no active part should error")
+	}
+}
+
+// TestRestViaRibbonCommand confirms the Create-panel ribbon command starts the tool.
+func TestRestViaRibbonCommand(t *testing.T) {
+	s, _, _ := partWithTopRegion(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Create.Rest"); err != nil {
+		t.Fatalf("execute Create.Rest: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*RestTool); !ok {
+		t.Fatal("Rest command did not start the rest tool")
+	}
+}

--- a/app/snap_fit_tool.go
+++ b/app/snap_fit_tool.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// SnapFitTool is the interactive Snap Fit command (#1076, plastic features): a cantilever hook
+// sized purely by its beam and catch dimensions, added at the active sketch origin. It needs no
+// picking, so it commits straight from its parameters, and exposes them through the generic
+// property dialog.
+type SnapFitTool struct {
+	dialogTool
+	length      float64
+	width       float64
+	thickness   float64
+	catchLength float64
+	catchHeight float64
+	added       *feature.PartFeature
+}
+
+// NewSnapFitTool returns a snap-fit tool with a default cantilever hook (beam 5×2×1, catch 1×1).
+func NewSnapFitTool() *SnapFitTool {
+	return &SnapFitTool{length: 5, width: 2, thickness: 1, catchLength: 1, catchHeight: 1}
+}
+
+// Name implements [Tool].
+func (t *SnapFitTool) Name() string { return "Snap Fit" }
+
+// The beam and catch dimensions the property window drives (database units, all positive).
+func (t *SnapFitTool) SetLength(v float64) { t.length = posOrKeep(v, t.length) }
+func (t *SnapFitTool) Length() float64     { return t.length }
+func (t *SnapFitTool) SetWidth(v float64)  { t.width = posOrKeep(v, t.width) }
+func (t *SnapFitTool) Width() float64      { return t.width }
+func (t *SnapFitTool) SetThickness(v float64) {
+	t.thickness = posOrKeep(v, t.thickness)
+}
+func (t *SnapFitTool) Thickness() float64       { return t.thickness }
+func (t *SnapFitTool) SetCatchLength(v float64) { t.catchLength = posOrKeep(v, t.catchLength) }
+func (t *SnapFitTool) CatchLength() float64     { return t.catchLength }
+func (t *SnapFitTool) SetCatchHeight(v float64) { t.catchHeight = posOrKeep(v, t.catchHeight) }
+func (t *SnapFitTool) CatchHeight() float64     { return t.catchHeight }
+
+// Params exposes the five snap-fit dimensions for the generic property dialog.
+func (t *SnapFitTool) Params() ToolParams {
+	return ToolParams{Floats: []FloatParam{
+		{Label: "Beam Length", Get: t.Length, Set: t.SetLength},
+		{Label: "Beam Width", Get: t.Width, Set: t.SetWidth},
+		{Label: "Beam Thickness", Get: t.Thickness, Set: t.SetThickness},
+		{Label: "Catch Length", Get: t.CatchLength, Set: t.SetCatchLength},
+		{Label: "Catch Height", Get: t.CatchHeight, Set: t.SetCatchHeight},
+	}}
+}
+
+// CanCommit reports whether every dimension is positive.
+func (t *SnapFitTool) CanCommit() bool {
+	return t.length > 0 && t.width > 0 && t.thickness > 0 && t.catchLength > 0 && t.catchHeight > 0
+}
+
+// Commit adds the snap-fit hook to the active part and recomputes; a sick feature keeps the
+// tool open by returning an error.
+func (t *SnapFitTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	l, w, th, cl, ch := t.length, t.width, t.thickness, t.catchLength, t.catchHeight
+	t.added = feature.NewPlasticFeatures(part.Features()).AddCantileverSnapFit(
+		func() float64 { return l }, func() float64 { return w }, func() float64 { return th },
+		func() float64 { return cl }, func() float64 { return ch })
+	part.Recompute()
+	s.recordEdit(part, "Snap Fit")
+	if !t.added.Health().OK() {
+		return errors.New("snap fit: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// DraftFeature returns the unattached hook the viewport previews before commit.
+func (t *SnapFitTool) DraftFeature(*Session) (feature.Feature, bool) {
+	if !t.CanCommit() {
+		return nil, false
+	}
+	l, w, th, cl, ch := t.length, t.width, t.thickness, t.catchLength, t.catchHeight
+	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
+		return feature.NewPlasticFeatures(fs).AddCantileverSnapFit(
+			func() float64 { return l }, func() float64 { return w }, func() float64 { return th },
+			func() float64 { return cl }, func() float64 { return ch }), nil
+	})
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *SnapFitTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// posOrKeep accepts v only when positive, otherwise keeps the prior value — guarding the
+// dimension setters against a zero/negative entry that would make an invalid hook.
+func posOrKeep(v, prior float64) float64 {
+	if v > 0 {
+		return v
+	}
+	return prior
+}

--- a/app/snap_fit_tool_test.go
+++ b/app/snap_fit_tool_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// TestSnapFitToolEndToEnd drives the Snap Fit UI: keep the default beam/catch dimensions, OK —
+// and asserts a valid solid hook was added to the empty part.
+func TestSnapFitToolEndToEnd(t *testing.T) {
+	s := newPartSession(t)
+	def := activePartDef(t, s)
+
+	sf := NewSnapFitTool()
+	s.StartTool(sf)
+	if !sf.CanCommit() {
+		t.Fatal("snap-fit tool not ready with its default dimensions")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if sf.AddedFeature() == nil || !sf.AddedFeature().Health().OK() {
+		t.Fatalf("snap-fit feature not healthy: %+v", sf.AddedFeature())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if v := ops.Validate(body); !v.Valid || !body.IsSolid() {
+		t.Fatalf("snap-fit body not a valid solid: %+v", v)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; v <= 0 {
+		t.Errorf("snap-fit volume = %g, want a positive solid", v)
+	}
+}
+
+// TestSnapFitToolParams exercises the property-dialog surface: name, the five dimension
+// accessors (each rejects a non-positive value), and the Params model the head renders.
+func TestSnapFitToolParams(t *testing.T) {
+	tl := NewSnapFitTool()
+	if tl.Name() != "Snap Fit" {
+		t.Errorf("name = %q, want Snap Fit", tl.Name())
+	}
+	tl.SetLength(8)
+	tl.SetWidth(3)
+	tl.SetThickness(1.5)
+	tl.SetCatchLength(2)
+	tl.SetCatchHeight(2)
+	if tl.Length() != 8 || tl.Width() != 3 || tl.Thickness() != 1.5 || tl.CatchLength() != 2 || tl.CatchHeight() != 2 {
+		t.Errorf("dims = %g/%g/%g/%g/%g, want 8/3/1.5/2/2",
+			tl.Length(), tl.Width(), tl.Thickness(), tl.CatchLength(), tl.CatchHeight())
+	}
+	tl.SetLength(0) // non-positive entries are rejected, keeping the prior value
+	tl.SetCatchHeight(-1)
+	if tl.Length() != 8 || tl.CatchHeight() != 2 {
+		t.Errorf("after bad entries length/catchHeight = %g/%g, want kept at 8/2", tl.Length(), tl.CatchHeight())
+	}
+
+	p := tl.Params()
+	if len(p.Floats) != 5 {
+		t.Fatalf("params = %d floats, want 5", len(p.Floats))
+	}
+	p.Floats[0].Set(10)
+	if p.Floats[0].Get() != 10 {
+		t.Errorf("param round-trip: beam length %g, want 10", p.Floats[0].Get())
+	}
+}
+
+// TestSnapFitToolPreview covers the draft preview before and after the dimensions are valid.
+func TestSnapFitToolPreview(t *testing.T) {
+	s := newPartSession(t)
+	tl := NewSnapFitTool()
+	s.StartTool(tl)
+	if _, ok := tl.DraftFeature(s); !ok {
+		t.Error("default dimensions are positive, so a draft should preview")
+	}
+	tl.SetThickness(0) // rejected, kept positive — still previewable
+	if _, ok := tl.DraftFeature(s); !ok {
+		t.Error("a non-positive entry is rejected, so the draft should still preview")
+	}
+}
+
+// TestSnapFitToolCommitNoPart covers the no-active-part error path.
+func TestSnapFitToolCommitNoPart(t *testing.T) {
+	if err := NewSnapFitTool().Commit(NewSession()); err == nil {
+		t.Error("commit with no active part should error")
+	}
+}
+
+// TestSnapFitViaRibbonCommand confirms the Create-panel ribbon command starts the tool.
+func TestSnapFitViaRibbonCommand(t *testing.T) {
+	s := newPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Create.SnapFit"); err != nil {
+		t.Fatalf("execute Create.SnapFit: %v", err)
+	}
+	if _, ok := s.ActiveTool().Tool().(*SnapFitTool); !ok {
+		t.Fatal("Snap Fit command did not start the snap-fit tool")
+	}
+}

--- a/architecture/mapping/inventor-ribbon-structure.md
+++ b/architecture/mapping/inventor-ribbon-structure.md
@@ -56,9 +56,9 @@ autodesk_inventor_ribbon:
             - name: "Sketch"
               buttons: [Start 2D Sketch, Start 3D Sketch]
             - name: "Create"
-              buttons: [Extrude, Revolve, Sweep, Loft, Coil, Rib, Emboss, Decal]
+              buttons: [Extrude, Revolve, Sweep, Loft, Coil, Rib, Emboss, Grill, Rest, Snap Fit, Decal]
             - name: "Modify"
-              buttons: [Hole, Fillet, Chamfer, Shell, Draft, Thread, Split, Direct, Combine, Thicken/Offset]
+              buttons: [Hole, Boss, Lip, Fillet, Chamfer, Shell, Draft, Thread, Split, Direct, Combine, Thicken/Offset]
             - name: "Work Features"
               buttons: [Plane, Axis, Point, Coordinate System]
             - name: "Pattern"

--- a/head/cmd/previewshot/main.go
+++ b/head/cmd/previewshot/main.go
@@ -123,6 +123,12 @@ func setupOp(s *app.Session, op string) error {
 		startPendingEmboss(s, mustBlock(s))
 	case "grill":
 		startPendingGrill(s, mustBlock(s))
+	case "rest":
+		startPendingRest(s, mustBlock(s))
+	case "snapfit":
+		startPendingSnapFit(s)
+	case "lip":
+		startPendingLip(s, mustBlock(s))
 	case "replaceface":
 		startPendingReplaceFace(s, mustBlock(s))
 	case "patch":
@@ -441,6 +447,41 @@ func startPendingGrill(s *app.Session, def *compdef.PartComponentDefinition) {
 	t := app.NewGrillTool()
 	s.StartTool(t)
 	t.Pick(s, app.ProfileHandle{Sketch: es, ProfileIndex: 0})
+}
+
+// startPendingRest raises a pad over a closed region on the block's top face (adds material → green).
+func startPendingRest(s *app.Session, def *compdef.PartComponentDefinition) {
+	es := def.Sketches().Add(topPlaneZ(3))
+	rectOn(es, 2, 2, 4, 4)
+	def.Recompute()
+	t := app.NewRestTool()
+	s.StartTool(t)
+	t.Pick(s, app.ProfileHandle{Sketch: es, ProfileIndex: 0})
+	t.SetDepth(1)
+}
+
+// startPendingSnapFit previews a free-standing cantilever snap-fit hook (adds material → green).
+func startPendingSnapFit(s *app.Session) {
+	newPart(s, previewDocName)
+	t := app.NewSnapFitTool()
+	s.StartTool(t)
+	t.SetLength(6)
+	t.SetWidth(3)
+	t.SetThickness(1.2)
+	t.SetCatchLength(1.5)
+	t.SetCatchHeight(1.2)
+}
+
+// startPendingLip runs a raised bead along a vertical edge of the block (adds material → green).
+func startPendingLip(s *app.Session, def *compdef.PartComponentDefinition) {
+	body := def.SurfaceBodies().Item(0)
+	edge := verticalEdge(body.Edges())
+	t := app.NewLipTool()
+	s.StartTool(t)
+	t.Pick(s, app.EdgeHandle{Edge: edge})
+	t.SetWidth(0.8)
+	t.SetHeight(0.8)
+	aimCameraAtEdge(s, body, edge)
 }
 
 // startPendingReplaceFace replaces the block's chamfered face with a flat side plane (the

--- a/head/icon/assets/lip.svg
+++ b/head/icon/assets/lip.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 4 V17 H20"/><rect x="13" y="10" width="7" height="7" rx="0.5" stroke="#ff0000"/></svg>

--- a/head/icon/assets/rest.svg
+++ b/head/icon/assets/rest.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 19 H21 M3 19 V14 H21 V19"/><path d="M8 14 V9 H16 V14" stroke="#ff0000"/></svg>

--- a/head/icon/assets/snap-fit.svg
+++ b/head/icon/assets/snap-fit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 3 V21"/><path d="M4 10 H17 V13 H4" stroke="#ff0000"/><path d="M17 13 L21 13 L18 6 L17 10" stroke="#ff0000"/></svg>


### PR DESCRIPTION
## What

Completes the plastic-features UI (#1076) by adding interactive commands for the three remaining plastic features, joining the already-shipped Rule Fillet:

| Feature | Ribbon panel | Flow |
|---|---|---|
| **Rest** | Create | pick closed sketch region(s), set depth, raised pad or recessed pocket |
| **Snap Fit** | Create | parametric cantilever hook (beam + catch dims), no picking |
| **Lip** | Modify | raised lip / recessed groove bead along picked edges |

## Why

These plastic features already existed in the kernel/model and the add-in op registry, but had no ribbon command or property dialog — so per the project's "definition of done = UI + e2e" rule they weren't actually done. This wires each to an interactive tool with a live ghost preview, the generic property dialog, a ribbon glyph, and end-to-end tests.

## Details

- Rest mirrors Emboss's profile-pick flow; Lip mirrors the edge-pick dress-up flow; Snap Fit is dialog-only (mirrors Rule Fillet) and previews/commits straight from its five dimensions.
- Each tool previews as a translucent green ghost before commit (added material).
- New glyphs `rest`, `snap-fit`, `lip`; ribbon placement recorded in `architecture/mapping/inventor-ribbon-structure.md`.
- `head/cmd/previewshot` gains `rest`/`snapfit`/`lip` ops; all three were visually confirmed against the live offscreen-Vulkan head.
- No public-API change: the wire/contract surface for these ops already exists.

## Tests

- E2E per tool asserting the resulting solid's volume change (Rest +pad / −pocket, Lip +lip / −groove, Snap Fit positive solid), draft-preview, multi/edge pick, param round-trip, and ribbon-command wiring. New tool code ~98% covered.
- Full `app` suite + `head/icon` green; gofmt/vet/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)