### PR TITLE
Serve body.physicalProperties + body Key/Style (#1078)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,7 +58,12 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{}
+var notYetHandled = map[string]bool{
+	// #1078 body mutations: the contract (API v0.76.1) lands ahead of the /source handlers,
+	// which follow in the body-rename/delete impl PR. DELETE these the moment those land.
+	"MethodBodyRename": true,
+	"MethodBodyDelete": true,
+}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They

--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -13,6 +13,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/analysis"
 )
 
 // Body, shell and wire enumeration over the wire (M07-F06, #629), plus the
@@ -44,18 +45,52 @@ func bodyList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	return json.Marshal(out)
 }
 
-// bodyInfo builds a body's wire summary, including its display name and current visibility (#158).
+// bodyInfo builds a body's wire summary: its display name, visibility (#158), persistent
+// reference key and assigned color-style name (#1078).
 func bodyInfo(s *app.Session, index int, b *topo.Body) wire.BodyInfo {
+	key := string(b.ReferenceKey())
+	style, _ := s.BodyColorStyle(key)
 	return wire.BodyInfo{
 		Index: index, Name: bodyDisplayName(index), Solid: b.IsSolid(), Visible: s.BodyVisible(b),
 		Faces: len(b.Faces()), Edges: len(b.Edges()), Vertices: len(b.Vertices()),
 		Shells: len(b.Shells()), Wires: len(b.Wires()),
+		Key: key, Style: style,
 	}
 }
 
 // bodyDisplayName is the body's browser name ("Solid1", …), index-derived until bodies carry
-// stored, renamable names (the #158 rename follow-up). Matches the model browser.
+// stored, renamable names (the #1078 rename follow-up). Matches the model browser.
 func bodyDisplayName(index int) string { return fmt.Sprintf("Solid%d", index+1) }
+
+// bodyPhysicalProperties serves wire.MethodBodyPhysicalProperties: the geometry and mass
+// properties of one body — the per-body counterpart of analysis.massProperties, which sums all
+// bodies (#1078).
+func bodyPhysicalProperties(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodyPhysicalPropertiesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	accuracy := types.MassPropertiesMedium
+	if in.Accuracy != "" {
+		a, ok := types.ParseMassPropertiesAccuracy(in.Accuracy)
+		if !ok {
+			return nil, fmt.Errorf("body.physicalProperties: unknown accuracy %q (want low|medium|high)", in.Accuracy)
+		}
+		accuracy = a
+	}
+	density := in.DensityGCm3
+	if density == 0 { // default to the part's assigned material density
+		if props, ok := s.PhysicalProperties(); ok && props.Density > 0 {
+			density = props.Density
+		}
+	}
+	mp := analysis.MassPropertiesOf([]*topo.Body{b}, density, accuracy)
+	return json.Marshal(massPropertiesResult(mp))
+}
 
 // bodySetVisible shows or hides one body of the active part (#158); the renderer reads the flag.
 func bodySetVisible(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/body_physical_properties_test.go
+++ b/addin/router/body_physical_properties_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestBodyPhysicalPropertiesMatchesBox: body.physicalProperties returns one body's geometry
+// properties — for the 40×30×20 mm box that is a 24 000 mm³ volume (#1078).
+func TestBodyPhysicalPropertiesMatchesBox(t *testing.T) {
+	r, s := boxBodySession(t)
+	var mp wire.MassPropertiesResult
+	call(t, r, s, "body.physicalProperties", `{"bodyIndex":0}`, &mp)
+
+	const wantVol = 40.0 * 30.0 * 20.0 // mm³
+	if math.Abs(mp.VolumeMm3-wantVol) > wantVol*0.01 {
+		t.Errorf("body volume = %g mm³, want ≈%g", mp.VolumeMm3, wantVol)
+	}
+	// Centroid of a box from the origin corner sits at its half-extents.
+	if math.Abs(mp.CentroidXMm-20) > 0.5 || math.Abs(mp.CentroidYMm-15) > 0.5 || math.Abs(mp.CentroidZMm-10) > 0.5 {
+		t.Errorf("centroid = (%g, %g, %g), want ≈(20, 15, 10)", mp.CentroidXMm, mp.CentroidYMm, mp.CentroidZMm)
+	}
+	if mp.MassG <= 0 {
+		t.Errorf("mass = %g g, want a positive mass at the default density", mp.MassG)
+	}
+}
+
+// TestBodyPhysicalPropertiesHonorsDensity: a supplied density scales the mass linearly.
+func TestBodyPhysicalPropertiesHonorsDensity(t *testing.T) {
+	r, s := boxBodySession(t)
+	var mp wire.MassPropertiesResult
+	call(t, r, s, "body.physicalProperties", `{"bodyIndex":0,"densityGCm3":2.5}`, &mp)
+	// volume 24 000 mm³ = 24 cm³; mass = 24 cm³ × 2.5 g/cm³ = 60 g.
+	if math.Abs(mp.MassG-60) > 0.6 {
+		t.Errorf("mass at 2.5 g/cm³ = %g g, want ≈60", mp.MassG)
+	}
+}
+
+// TestBodyPhysicalPropertiesBadIndexFails: an out-of-range body index is a rejection.
+func TestBodyPhysicalPropertiesBadIndexFails(t *testing.T) {
+	r, s := boxBodySession(t)
+	if _, err := r.Handle(s, "body.physicalProperties", []byte(`{"bodyIndex":7}`)); err == nil {
+		t.Error("body.physicalProperties with an out-of-range index should fail")
+	}
+}
+
+// TestBodyPhysicalPropertiesBadAccuracyFails: an unknown accuracy spelling is a rejection.
+func TestBodyPhysicalPropertiesBadAccuracyFails(t *testing.T) {
+	r, s := boxBodySession(t)
+	if _, err := r.Handle(s, "body.physicalProperties", []byte(`{"bodyIndex":0,"accuracy":"ultra"}`)); err == nil {
+		t.Error("body.physicalProperties with an unknown accuracy should fail")
+	}
+}
+
+// TestBodyListReportsKeyAndStyle: body.list now surfaces each body's persistent reference key
+// and assigned color-style name (empty until one is assigned) (#1078).
+func TestBodyListReportsKeyAndStyle(t *testing.T) {
+	r, s := boxBodySession(t)
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	b := list.Bodies[0]
+	if b.Key == "" {
+		t.Error("body.list body has an empty Key, want its persistent reference key")
+	}
+	if b.Style != "" {
+		t.Errorf("body Style = %q, want empty before any style is assigned", b.Style)
+	}
+
+	if err := s.AssignColorStyleToBody(b.Key, "Steel"); err != nil {
+		t.Fatalf("assign color style: %v", err)
+	}
+	call(t, r, s, "body.list", `{}`, &list)
+	if list.Bodies[0].Style != "Steel" {
+		t.Errorf("after assigning Steel, body Style = %q, want Steel", list.Bodies[0].Style)
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -374,6 +374,7 @@ func (r *Router) registerMaterialHandlers() {
 	// Body topology, queries and facet sets (M07 #293/#629/#630).
 	r.handlers[wire.MethodBodyList] = bodyList
 	r.handlers[wire.MethodBodySetVisible] = bodySetVisible
+	r.handlers[wire.MethodBodyPhysicalProps] = bodyPhysicalProperties
 	r.handlers[wire.MethodBodyShells] = bodyShells
 	r.handlers[wire.MethodBodyWires] = bodyWires
 	r.handlers[wire.MethodWireOffsetPlanar] = wireOffsetPlanar

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.76.0
+	oblikovati.org/api v0.76.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.76.0
+	oblikovati.org/api v0.76.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)
@@ -21,6 +21,7 @@ require (
 	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	oblikovati.org/motor-designer v0.0.0
 )
 
 // The core stays a relative replace: head is a submodule of this same repo, so


### PR DESCRIPTION
## What

Implements the **read half** of #1078 (body-API follow-up to #158), against API **v0.76.1**:

- **body.physicalProperties** — per-body geometry + mass properties (volume, surface area, mass, centroid, inertia). The single-body counterpart of `analysis.massProperties` (which sums all bodies); reuses `analysis.MassPropertiesOf` on a one-body slice and honors the same density/accuracy defaults.
- **body.list → Key + Style** — each body now carries its persistent reference key (the handle used to assign a color style) and its assigned color-style name (empty for the plain appearance).

## Why

Contract-first impl per ADR-0018. The mutating half (rename + delete) follows in its own PR; their wire methods are parked in the router parity allowlist (`notYetHandled`) until then, so the API↔router parity guard stays green.

## Tests

- `body.physicalProperties` validated against the analytic 40×30×20 mm box (24 000 mm³, centroid at the half-extents, density scales mass linearly), plus out-of-range index and bad-accuracy rejections.
- `body.list` Key non-empty + Style empty-then-"Steel" after assignment.
- Full `addin/router` suite green; gofmt/golangci-lint clean. API pin bumped to v0.76.1 in `go.mod` + `head/go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)