### PR TITLE
Serve body.rename with .obk-persistent names (#1078)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -59,9 +59,8 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
 var notYetHandled = map[string]bool{
-	// #1078 body mutations: the contract (API v0.76.1) lands ahead of the /source handlers,
-	// which follow in the body-rename/delete impl PR. DELETE these the moment those land.
-	"MethodBodyRename": true,
+	// #1078 body delete: the contract (API v0.76.1) lands ahead of the /source handler, which
+	// follows in the body-delete impl PR. DELETE this the moment that handler lands.
 	"MethodBodyDelete": true,
 }
 

--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -51,16 +51,43 @@ func bodyInfo(s *app.Session, index int, b *topo.Body) wire.BodyInfo {
 	key := string(b.ReferenceKey())
 	style, _ := s.BodyColorStyle(key)
 	return wire.BodyInfo{
-		Index: index, Name: bodyDisplayName(index), Solid: b.IsSolid(), Visible: s.BodyVisible(b),
+		Index: index, Name: bodyDisplayName(s, index, key), Solid: b.IsSolid(), Visible: s.BodyVisible(b),
 		Faces: len(b.Faces()), Edges: len(b.Edges()), Vertices: len(b.Vertices()),
 		Shells: len(b.Shells()), Wires: len(b.Wires()),
 		Key: key, Style: style,
 	}
 }
 
-// bodyDisplayName is the body's browser name ("Solid1", …), index-derived until bodies carry
-// stored, renamable names (the #1078 rename follow-up). Matches the model browser.
-func bodyDisplayName(index int) string { return fmt.Sprintf("Solid%d", index+1) }
+// bodyDisplayName is the body's browser name: the user's stored name for that body (#1078), or the
+// index-derived "Solid{N}" default when it was never renamed. Matches the model browser.
+func bodyDisplayName(s *app.Session, index int, key string) string {
+	if d := s.ActiveDocument(); d != nil {
+		if name, ok := d.BodyName(key); ok {
+			return name
+		}
+	}
+	return fmt.Sprintf("Solid%d", index+1)
+}
+
+// bodyRename serves wire.MethodBodyRename: store (or, with an empty name, clear) the display name
+// of one body of the active part, keyed by its reference key so it survives recompute and
+// round-trips in the .obk (#1078).
+func bodyRename(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodyRenameArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	d := s.ActiveDocument()
+	if d == nil {
+		return nil, fmt.Errorf("body.rename: no active document")
+	}
+	d.SetBodyName(string(b.ReferenceKey()), in.Name)
+	return json.Marshal(wire.BodyInfoResult{Body: bodyInfo(s, in.BodyIndex, b)})
+}
 
 // bodyPhysicalProperties serves wire.MethodBodyPhysicalProperties: the geometry and mass
 // properties of one body — the per-body counterpart of analysis.massProperties, which sums all

--- a/addin/router/body_rename_test.go
+++ b/addin/router/body_rename_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+)
+
+// TestBodyRenameSetsAndReverts drives the #1078 rename acceptance: rename a body, see it
+// reflected in body.list, then clear it (empty name) to revert to the "Solid{N}" default.
+func TestBodyRenameSetsAndReverts(t *testing.T) {
+	r, s := boxBodySession(t)
+
+	var res wire.BodyInfoResult
+	call(t, r, s, "body.rename", `{"bodyIndex":0,"name":"Housing"}`, &res)
+	if res.Body.Name != "Housing" {
+		t.Errorf("after rename, body.name = %q, want Housing", res.Body.Name)
+	}
+
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if list.Bodies[0].Name != "Housing" {
+		t.Errorf("body.list after rename = %q, want Housing", list.Bodies[0].Name)
+	}
+
+	call(t, r, s, "body.rename", `{"bodyIndex":0,"name":""}`, &res)
+	if res.Body.Name != "Solid1" {
+		t.Errorf("after clearing the name, body.name = %q, want the Solid1 default", res.Body.Name)
+	}
+}
+
+// TestBodyRenameSurvivesRecompute: a stored body name is keyed by the persistent reference key,
+// so it survives a part recompute (the key is stable across rebuilds).
+func TestBodyRenameSurvivesRecompute(t *testing.T) {
+	r, s := boxBodySession(t)
+	call(t, r, s, "body.rename", `{"bodyIndex":0,"name":"Bracket"}`, &wire.BodyInfoResult{})
+
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	part.Recompute()
+
+	var list wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &list)
+	if list.Bodies[0].Name != "Bracket" {
+		t.Errorf("body name after recompute = %q, want Bracket (the name is refkey-anchored)", list.Bodies[0].Name)
+	}
+}
+
+// TestBodyRenameBadIndexFails: an out-of-range body index is a rejection.
+func TestBodyRenameBadIndexFails(t *testing.T) {
+	r, s := boxBodySession(t)
+	if _, err := r.Handle(s, "body.rename", []byte(`{"bodyIndex":9,"name":"X"}`)); err == nil {
+		t.Error("body.rename with an out-of-range index should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -374,6 +374,7 @@ func (r *Router) registerMaterialHandlers() {
 	// Body topology, queries and facet sets (M07 #293/#629/#630).
 	r.handlers[wire.MethodBodyList] = bodyList
 	r.handlers[wire.MethodBodySetVisible] = bodySetVisible
+	r.handlers[wire.MethodBodyRename] = bodyRename
 	r.handlers[wire.MethodBodyPhysicalProps] = bodyPhysicalProperties
 	r.handlers[wire.MethodBodyShells] = bodyShells
 	r.handlers[wire.MethodBodyWires] = bodyWires

--- a/model/doc/body_names_test.go
+++ b/model/doc/body_names_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import "testing"
+
+// TestBodyNameStoreAndClear pins the per-body name accessors (#1078): set marks dirty and reads
+// back; an empty name clears the entry; a renamed body reverts to "no stored name".
+func TestBodyNameStoreAndClear(t *testing.T) {
+	d := NewPartDocument("/proj/case.obk")
+	if _, ok := d.BodyName("k1"); ok {
+		t.Error("a fresh document should report no stored name for any body")
+	}
+
+	d.ClearDirty()
+	d.SetBodyName("k1", "Housing")
+	if !d.Dirty() {
+		t.Error("SetBodyName should mark the document dirty (names round-trip in the .obk)")
+	}
+	if name, ok := d.BodyName("k1"); !ok || name != "Housing" {
+		t.Errorf("BodyName(k1) = (%q, %v), want (Housing, true)", name, ok)
+	}
+
+	d.SetBodyName("k1", "") // empty reverts to the default
+	if _, ok := d.BodyName("k1"); ok {
+		t.Error("an empty name should clear the stored entry")
+	}
+}
+
+// TestBodyNamesCopyAndRestore: BodyNames returns a defensive copy, and RestoreBodyNames installs a
+// map without dirtying the document (the load path, where memory already matches disk).
+func TestBodyNamesCopyAndRestore(t *testing.T) {
+	d := NewPartDocument("/proj/case.obk")
+	if d.BodyNames() != nil {
+		t.Error("BodyNames on a document with no renamed body should be nil")
+	}
+
+	d.SetBodyName("k1", "Lid")
+	snap := d.BodyNames()
+	snap["k1"] = "tampered" // mutating the snapshot must not affect the document
+	if name, _ := d.BodyName("k1"); name != "Lid" {
+		t.Errorf("BodyNames returned a live map: document name became %q", name)
+	}
+
+	d2 := NewPartDocument("/proj/other.obk")
+	d2.ClearDirty()
+	d2.RestoreBodyNames(map[string]string{"a": "Boss", "b": "Rib"})
+	if d2.Dirty() {
+		t.Error("RestoreBodyNames must not dirty the document (it is the load path)")
+	}
+	if name, ok := d2.BodyName("a"); !ok || name != "Boss" {
+		t.Errorf("after restore, BodyName(a) = (%q, %v), want (Boss, true)", name, ok)
+	}
+	d2.RestoreBodyNames(nil) // restoring empty clears the store
+	if d2.BodyNames() != nil {
+		t.Error("RestoreBodyNames(nil) should leave no stored names")
+	}
+}

--- a/model/doc/document.go
+++ b/model/doc/document.go
@@ -54,6 +54,7 @@ type Document struct {
 	interests        *DocumentInterests     // add-in data registry (M03-F10); lazily seeded
 	attributes       *attr.AttributeManager // add-in attribute sets (#155); lazily seeded
 	sketchSettings   *types.SketchSettings  // per-document sketch-authoring defaults (#147), nil ⇒ defaults
+	bodyNames        map[string]string      // per-body display names, keyed by body reference key (#1078); nil/absent ⇒ the "Solid{N}" default
 }
 
 // newDocument builds a base document. open reflects whether content is paged in;
@@ -252,6 +253,54 @@ func (d *Document) SetSketchSettings(set types.SketchSettings) {
 func (d *Document) RestoreSketchSettings(set types.SketchSettings) {
 	cp := set
 	d.sketchSettings = &cp
+}
+
+// BodyName returns the stored display name for the body with the given reference key, and whether
+// one is set. Bodies without a stored name fall back to the index-derived "Solid{N}" default at
+// the call site (#1078).
+func (d *Document) BodyName(key string) (string, bool) {
+	name, ok := d.bodyNames[key]
+	return name, ok
+}
+
+// SetBodyName stores (or, with an empty name, clears) the display name for one body, keyed by its
+// reference key, and marks the document dirty since body names round-trip in the .obk (#1078).
+func (d *Document) SetBodyName(key, name string) {
+	if name == "" {
+		delete(d.bodyNames, key)
+	} else {
+		if d.bodyNames == nil {
+			d.bodyNames = map[string]string{}
+		}
+		d.bodyNames[key] = name
+	}
+	d.MarkDirty()
+}
+
+// BodyNames returns a copy of the per-body name map (reference key → name), for the persistence
+// save path; nil when no body has been renamed.
+func (d *Document) BodyNames() map[string]string {
+	if len(d.bodyNames) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(d.bodyNames))
+	for k, v := range d.bodyNames {
+		out[k] = v
+	}
+	return out
+}
+
+// RestoreBodyNames installs the per-body name map WITHOUT marking the document dirty — the load
+// path, where the in-memory state already matches disk (like [Document.RestoreSketchSettings]).
+func (d *Document) RestoreBodyNames(names map[string]string) {
+	if len(names) == 0 {
+		d.bodyNames = nil
+		return
+	}
+	d.bodyNames = make(map[string]string, len(names))
+	for k, v := range names {
+		d.bodyNames[k] = v
+	}
 }
 
 // Referenced reports whether any open document references this one. An

--- a/persistence/body_names_test.go
+++ b/persistence/body_names_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPackageBodyNamesSurvivesMarshal checks the per-body display names round-trip through the
+// .obk YAML (marshal → decode), written as a readable block (#1078).
+func TestPackageBodyNamesSurvivesMarshal(t *testing.T) {
+	p := NewPackage()
+	if err := p.SetManifest(Manifest{SchemaVersion: CurrentSchemaVersion, DocumentType: 1, DisplayName: "P"}); err != nil {
+		t.Fatalf("SetManifest: %v", err)
+	}
+	names := map[string]string{"body-key-1": "Housing", "body-key-2": "Lid"}
+	p.SetBodyNames(names)
+
+	data, err := p.marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "bodyNames:") || !strings.Contains(string(data), "Housing") {
+		t.Errorf("body names should be written as a readable YAML block, got:\n%s", data)
+	}
+
+	p2, err := decode(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := p2.BodyNames()
+	if len(got) != 2 || got["body-key-1"] != "Housing" || got["body-key-2"] != "Lid" {
+		t.Errorf("decoded body names = %+v, want {body-key-1:Housing, body-key-2:Lid}", got)
+	}
+}
+
+// TestPackageBodyNamesAbsentWhenEmpty: a document with no renamed body writes no bodyNames block.
+func TestPackageBodyNamesAbsentWhenEmpty(t *testing.T) {
+	p := NewPackage()
+	if err := p.SetManifest(Manifest{SchemaVersion: CurrentSchemaVersion, DocumentType: 1, DisplayName: "P"}); err != nil {
+		t.Fatalf("SetManifest: %v", err)
+	}
+	data, err := p.marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "bodyNames:") {
+		t.Errorf("a document with no renamed body must not write a bodyNames block, got:\n%s", data)
+	}
+}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -57,6 +57,7 @@ func (p *Package) marshal() ([]byte, error) {
 		Attributes:      p.attributes,
 		DisplaySettings: p.display,
 		SketchSettings:  p.sketch,
+		BodyNames:       p.bodyNames,
 		Model:           p.model,
 		Data:            p.streams,
 		Resources:       p.resources,
@@ -87,6 +88,7 @@ func decode(raw []byte) (*Package, error) {
 	p.attributes = doc.Attributes
 	p.display = doc.DisplaySettings
 	p.sketch = doc.SketchSettings
+	p.bodyNames = doc.BodyNames
 	for name, data := range doc.Data {
 		p.WriteStream(name, data)
 	}

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -37,6 +37,7 @@ type Package struct {
 	attributes  []byte                           // add-in attribute sets, encoded (#155)
 	display     *yamlcodec.DisplaySettingsRecord // per-document display settings (M16-F07 #643)
 	sketch      *yamlcodec.SketchSettingsRecord  // per-document sketch settings (#147)
+	bodyNames   map[string]string                // per-body display names by reference key (#1078)
 }
 
 // NewPackage returns an empty package.
@@ -73,6 +74,12 @@ func (p *Package) SetSketchSettings(s *yamlcodec.SketchSettingsRecord) { p.sketc
 
 // SketchSettings returns the per-document sketch settings record (nil when unset).
 func (p *Package) SketchSettings() *yamlcodec.SketchSettingsRecord { return p.sketch }
+
+// SetBodyNames stores the per-body display-name map, keyed by body reference key (#1078).
+func (p *Package) SetBodyNames(names map[string]string) { p.bodyNames = names }
+
+// BodyNames returns the per-body display-name map (nil when no body was renamed).
+func (p *Package) BodyNames() map[string]string { return p.bodyNames }
 
 // SetInterests stores the add-in data-registry records (M03-F10).
 func (p *Package) SetInterests(i []yamlcodec.InterestRecord) { p.interests = i }

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -142,14 +142,17 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 }
 
 // storeDocumentSettings copies a document's per-document settings into the package for the save path:
-// display settings (#643) and sketch settings (#147), each written only when the document customised
-// them.
+// display settings (#643), sketch settings (#147) and per-body names (#1078), each written only when
+// the document customised them.
 func storeDocumentSettings(pkg *Package, d *doc.Document) {
 	if set, ok := d.DisplaySettings(); ok {
 		pkg.SetDisplaySettings(toCodecDisplaySettings(set))
 	}
 	if d.SketchSettingsSet() {
 		pkg.SetSketchSettings(toCodecSketchSettings(d.SketchSettings()))
+	}
+	if names := d.BodyNames(); names != nil {
+		pkg.SetBodyNames(names)
 	}
 }
 
@@ -161,6 +164,9 @@ func restoreDocumentSettings(d *doc.Document, pkg *Package) {
 	}
 	if rec := pkg.SketchSettings(); rec != nil {
 		d.RestoreSketchSettings(fromCodecSketchSettings(rec))
+	}
+	if names := pkg.BodyNames(); names != nil {
+		d.RestoreBodyNames(names)
 	}
 }
 

--- a/persistence/store_test.go
+++ b/persistence/store_test.go
@@ -43,6 +43,35 @@ func TestWorkspaceRoundTripsThroughPackageStore(t *testing.T) {
 	}
 }
 
+// TestBodyNameSurvivesStoreRoundTrip exercises the store/restore hooks (#1078): a renamed body
+// reopens with its stored name, and the reopened document is clean (restore does not dirty it).
+func TestBodyNameSurvivesStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "case.obk")
+	store := NewPackageStore()
+
+	ws := doc.NewWorkspace(store)
+	d, err := ws.Add(doc.Part, path, true)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	d.SetBodyName("body-ref-key", "Housing")
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if name, ok := reopened.BodyName("body-ref-key"); !ok || name != "Housing" {
+		t.Errorf("reopened body name = (%q, %v), want (Housing, true)", name, ok)
+	}
+	if reopened.Dirty() {
+		t.Error("reopened document should be clean (RestoreBodyNames must not dirty it)")
+	}
+}
+
 func TestPackageStoreExists(t *testing.T) {
 	dir := t.TempDir()
 	store := NewPackageStore()

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -57,6 +57,9 @@ type Document struct {
 	// SketchSettings are the per-document sketch-authoring defaults (constraint inference),
 	// nil for a document that never customized them (#147).
 	SketchSettings *SketchSettingsRecord `yaml:"sketchSettings,omitempty"`
+	// BodyNames are the per-body display names keyed by body reference key (#1078), absent for a
+	// document where no body was renamed.
+	BodyNames map[string]string `yaml:"bodyNames,omitempty"`
 }
 
 // SketchSettingsRecord is the on-disk per-document sketch settings (#147): the constraint-inference
@@ -170,6 +173,7 @@ type onDisk struct {
 	Attributes      []byte                 `yaml:"attributes,omitempty"`
 	DisplaySettings *DisplaySettingsRecord `yaml:"displaySettings,omitempty"`
 	SketchSettings  *SketchSettingsRecord  `yaml:"sketchSettings,omitempty"`
+	BodyNames       map[string]string      `yaml:"bodyNames,omitempty"`
 	Resources       yaml.Node              `yaml:"resources,omitempty"`
 	Model           yaml.Node              `yaml:"model,omitempty"`
 	Data            map[string]string      `yaml:"data,omitempty"`
@@ -190,6 +194,7 @@ func MarshalDocument(d Document) ([]byte, error) {
 		Attributes:      d.Attributes,
 		DisplaySettings: d.DisplaySettings,
 		SketchSettings:  d.SketchSettings,
+		BodyNames:       d.BodyNames,
 	}
 	if err := embedNativeNodes(&od, d); err != nil {
 		return nil, err
@@ -268,6 +273,7 @@ func documentHeader(od onDisk) Document {
 		Attributes:      od.Attributes,
 		DisplaySettings: od.DisplaySettings,
 		SketchSettings:  od.SketchSettings,
+		BodyNames:       od.BodyNames,
 	}
 }
 


### PR DESCRIPTION
## What

Implements **body.rename** (the second piece of #1078). Bodies can now carry a user-chosen display name that persists.

- **doc.Document** gains `BodyName / SetBodyName / BodyNames / RestoreBodyNames`, mirroring the per-document sketch/display settings (set dirties the document, restore does not).
- The name is keyed by the body's **persistent reference key**, so it survives a recompute (the key is stable across rebuilds) and round-trips in the `.obk` as a readable `bodyNames:` block — threaded through the yamlcodec `Document` record, the `Package`, `io` marshal/decode, and the `store/restoreDocumentSettings` hooks.
- **body.rename** sets (or, with an empty name, clears) the name; `body.list` and `bodyDisplayName` now read the stored name, falling back to `Solid{N}`.

## Why

Continues #1078 after the read half (#1117). Per the issue, rename "requires a persistent per-body name on the model that survives recompute and round-trips in the .obk" — done here. `body.delete` (the last piece) follows in its own PR; its wire method stays in the router parity allowlist (`notYetHandled`) until then.

## Tests

- `doc.Document` accessors: store/clear, dirty-marking, defensive-copy `BodyNames`, non-dirtying `RestoreBodyNames`.
- Persistence: `bodyNames:` YAML round-trip through marshal/decode, absent when no body renamed, and a full **store round-trip** (rename → save → reopen → name intact, document clean).
- Router: rename sets + reverts on empty, **survives a recompute** (refkey-anchored), out-of-range index rejected.
- Full `model/doc` + `persistence` + `addin/router` suites green; gofmt/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)