### PR TITLE
Serve body.delete as a history feature (#1078)

### DIFF
--- a/addin/router/api_parity_test.go
+++ b/addin/router/api_parity_test.go
@@ -58,11 +58,7 @@ func TestEveryWireMethodHasAHandler(t *testing.T) {
 // them. Tracked debt: add an entry only when the contract genuinely lands before its handler, and
 // DELETE it the moment the handler lands (the guard above fails on a stale entry, so this list may
 // only shrink).
-var notYetHandled = map[string]bool{
-	// #1078 body delete: the contract (API v0.76.1) lands ahead of the /source handler, which
-	// follows in the body-delete impl PR. DELETE this the moment that handler lands.
-	"MethodBodyDelete": true,
-}
+var notYetHandled = map[string]bool{}
 
 // notYetRelayed are wire events the API declares ahead of the host behavior that would
 // emit them (the representations / model-state surface has no app-level event yet). They

--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -14,6 +14,7 @@ import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/analysis"
+	"oblikovati.org/model/compdef"
 )
 
 // Body, shell and wire enumeration over the wire (M07-F06, #629), plus the
@@ -38,6 +39,12 @@ func bodyList(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	return bodyListResult(s, part)
+}
+
+// bodyListResult marshals the active part's current body list (shared by body.list and the
+// mutating body.delete, which returns the refreshed list).
+func bodyListResult(s *app.Session, part *compdef.PartComponentDefinition) (json.RawMessage, error) {
 	var out wire.BodyListResult
 	for i, b := range part.SurfaceBodies().All() {
 		out.Bodies = append(out.Bodies, bodyInfo(s, i, b))
@@ -131,6 +138,30 @@ func bodySetVisible(s *app.Session, raw json.RawMessage) (json.RawMessage, error
 	}
 	s.SetBodyVisible(b, in.Visible)
 	return json.Marshal(wire.BodyInfoResult{Body: bodyInfo(s, in.BodyIndex, b)})
+}
+
+// bodyDelete serves wire.MethodBodyDelete: append a delete-body feature that removes the body at
+// BodyIndex (anchored to its reference key so it survives recompute), then return the refreshed
+// body list (#1078).
+func bodyDelete(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BodyIndexArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	all := part.SurfaceBodies().All()
+	if in.BodyIndex < 0 || in.BodyIndex >= len(all) {
+		return nil, fmt.Errorf("body index %d out of range (part has %d bodies)", in.BodyIndex, len(all))
+	}
+	pf := part.Features().AddDeleteBody(all[in.BodyIndex].ReferenceKey())
+	part.Recompute()
+	if !pf.Health().OK() {
+		return nil, fmt.Errorf("body.delete: %s", pf.Health().Reason)
+	}
+	return bodyListResult(s, part)
 }
 
 // bodyShells serves wire.MethodBodyShells.

--- a/addin/router/body_delete_test.go
+++ b/addin/router/body_delete_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// twoBodyPartSession builds a part with two separate box bodies (a 4×4 square at the origin and
+// another offset in +X), each extruded as a new body.
+func twoBodyPartSession(t *testing.T) (*Router, *app.Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	for _, ox := range []float64{0, 10} {
+		sk := def.Sketches().Add(sketch.XYPlane())
+		c0 := sk.Points().Add(math.P2(ox, 0))
+		c1 := sk.Points().Add(math.P2(ox+4, 0))
+		c2 := sk.Points().Add(math.P2(ox+4, 4))
+		c3 := sk.Points().Add(math.P2(ox, 4))
+		sk.Lines().Add(c0, c1)
+		sk.Lines().Add(c1, c2)
+		sk.Lines().Add(c2, c3)
+		sk.Lines().Add(c3, c0)
+		feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	}
+	def.Recompute()
+	return r, s, def
+}
+
+// TestBodyDeleteRemovesOneBody drives the #1078 delete acceptance: two bodies, delete the first,
+// one remains and the call returns the refreshed list.
+func TestBodyDeleteRemovesOneBody(t *testing.T) {
+	r, s, def := twoBodyPartSession(t)
+	if n := len(def.SurfaceBodies().All()); n != 2 {
+		t.Fatalf("setup: %d bodies, want 2", n)
+	}
+
+	var list wire.BodyListResult
+	call(t, r, s, "body.delete", `{"bodyIndex":0}`, &list)
+	if len(list.Bodies) != 1 {
+		t.Fatalf("body.delete returned %d bodies, want 1", len(list.Bodies))
+	}
+	if n := len(def.SurfaceBodies().All()); n != 1 {
+		t.Errorf("after delete the part has %d bodies, want 1", n)
+	}
+}
+
+// TestBodyDeleteIsRecordedInHistory: delete is a history feature, so it appends a recipe step
+// (making it undoable / re-computable).
+func TestBodyDeleteIsRecordedInHistory(t *testing.T) {
+	r, s, def := twoBodyPartSession(t)
+	before := def.Features().Count()
+	call(t, r, s, "body.delete", `{"bodyIndex":1}`, &wire.BodyListResult{})
+	if after := def.Features().Count(); after != before+1 {
+		t.Errorf("feature count = %d, want %d (delete appends one history step)", after, before+1)
+	}
+}
+
+// TestBodyDeleteBadIndexFails: an out-of-range body index is a rejection.
+func TestBodyDeleteBadIndexFails(t *testing.T) {
+	r, s, _ := twoBodyPartSession(t)
+	if _, err := r.Handle(s, "body.delete", []byte(`{"bodyIndex":5}`)); err == nil {
+		t.Error("body.delete with an out-of-range index should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -375,6 +375,7 @@ func (r *Router) registerMaterialHandlers() {
 	r.handlers[wire.MethodBodyList] = bodyList
 	r.handlers[wire.MethodBodySetVisible] = bodySetVisible
 	r.handlers[wire.MethodBodyRename] = bodyRename
+	r.handlers[wire.MethodBodyDelete] = bodyDelete
 	r.handlers[wire.MethodBodyPhysicalProps] = bodyPhysicalProperties
 	r.handlers[wire.MethodBodyShells] = bodyShells
 	r.handlers[wire.MethodBodyWires] = bodyWires

--- a/model/feature/delete_body.go
+++ b/model/feature/delete_body.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"bytes"
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// DeleteBodyDefinition removes one running body — identified by its persistent reference key — from
+// the part (#1078). Keying by reference key (not index) anchors the deletion to the same body
+// across a recompute, even when earlier edits reorder the body list; it is the body-set counterpart
+// of the index-based Combine/Split features.
+type DeleteBodyDefinition struct {
+	BodyKey []byte
+}
+
+// DeleteBodyFeature drops the referenced body from the running state.
+type DeleteBodyFeature struct {
+	def *DeleteBodyDefinition
+}
+
+// Definition returns the delete-body recipe.
+func (f *DeleteBodyFeature) Definition() *DeleteBodyDefinition { return f.def }
+
+// Kind implements [Feature].
+func (f *DeleteBodyFeature) Kind() string { return "delete-body" }
+
+// Recompute returns the running bodies minus the one whose reference key matches; a missing target
+// (its body was already consumed, or never existed) makes the feature go Sick rather than silently
+// deleting nothing.
+func (f *DeleteBodyFeature) Recompute(in Input) (Output, error) {
+	kept := make([]*topo.Body, 0, len(in.Bodies))
+	found := false
+	for _, b := range in.Bodies {
+		if bytes.Equal(b.ReferenceKey(), f.def.BodyKey) {
+			found = true
+			continue
+		}
+		kept = append(kept, b)
+	}
+	if !found {
+		return Output{}, fmt.Errorf("delete-body: the body to delete is no longer in the part (key %x)", f.def.BodyKey)
+	}
+	return Output{Bodies: kept}, nil
+}
+
+// AddDeleteBody appends a delete-body feature removing the body with the given reference key.
+func (fs *PartFeatures) AddDeleteBody(bodyKey []byte) *PartFeature {
+	return fs.Add(&DeleteBodyFeature{def: &DeleteBodyDefinition{BodyKey: append([]byte(nil), bodyKey...)}})
+}

--- a/model/feature/delete_body_test.go
+++ b/model/feature/delete_body_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// TestDeleteBodyDropsTheReferencedBody: with two separate bodies, a delete-body feature keyed by
+// one body's reference key leaves exactly the other (#1078).
+func TestDeleteBodyDropsTheReferencedBody(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketch(4), 0, ops.NewBody, func() float64 { return 5 })
+	NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketchAt(4, 10), 0, ops.NewBody, func() float64 { return 5 })
+	fs.Recompute()
+	if len(fs.Result()) != 2 {
+		t.Fatalf("setup: got %d bodies, want 2", len(fs.Result()))
+	}
+	doomedKey := fs.Result()[0].ReferenceKey()
+	keptKey := fs.Result()[1].ReferenceKey()
+
+	pf := fs.AddDeleteBody(doomedKey)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("delete-body went sick: %s", pf.Health().Reason)
+	}
+
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("after delete = %d bodies, want 1", len(res))
+	}
+	if string(res[0].ReferenceKey()) != string(keptKey) {
+		t.Error("delete-body removed the wrong body")
+	}
+}
+
+// TestDeleteBodyMissingTargetGoesSick: a delete-body feature whose target key matches no running
+// body goes Sick rather than silently deleting nothing.
+func TestDeleteBodyMissingTargetGoesSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketch(4), 0, ops.NewBody, func() float64 { return 5 })
+	fs.AddDeleteBody([]byte("no-such-body-key"))
+	fs.Recompute()
+
+	last := fs.Item(fs.Count() - 1)
+	if last.Health().OK() {
+		t.Error("delete-body with an unknown target key should go Sick")
+	}
+	if len(fs.Result()) != 1 {
+		t.Errorf("a sick delete left %d bodies, want the 1 original untouched", len(fs.Result()))
+	}
+}
+
+// TestDeleteBodySerializeRoundTrip pins the recipe round-trip: a delete-body feature survives
+// MarshalRecipe → ApplyRecipe with its body key intact.
+func TestDeleteBodySerializeRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	key := []byte{0x01, 0x02, 0x03, 0x04}
+	fs.AddDeleteBody(key)
+
+	data, err := fs.MarshalRecipe(emptySketches{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if len(data) != 1 || data[0].Kind != "delete-body" || data[0].DeleteBody == nil {
+		t.Fatalf("marshaled = %+v, want one delete-body with payload", data)
+	}
+
+	restored := NewPartFeatures(nil, nil)
+	if err := restored.ApplyRecipe(data, emptySketches{}, NewWorkGeometry()); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	dbf, ok := restored.Item(0).Definition().(*DeleteBodyFeature)
+	if !ok {
+		t.Fatalf("restored feature is %T, want *DeleteBodyFeature", restored.Item(0).Definition())
+	}
+	if string(dbf.Definition().BodyKey) != string(key) {
+		t.Errorf("restored body key = %x, want %x", dbf.Definition().BodyKey, key)
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -47,6 +47,7 @@ type FeatureData struct {
 	Rib            *RibData            `yaml:"rib,omitempty"`
 	Emboss         *EmbossData         `yaml:"emboss,omitempty"`
 	Combine        *CombineData        `yaml:"combine,omitempty"`
+	DeleteBody     *DeleteBodyData     `yaml:"deleteBody,omitempty"`
 	SplitSolid     *SplitSolidData     `yaml:"splitSolid,omitempty"`
 	DirectEdit     *DirectEditData     `yaml:"directEdit,omitempty"`
 
@@ -222,6 +223,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			return FeatureData{}, err
 		}
 		fd.Combine = &CombineData{Target: f.def.TargetIndex, Tool: f.def.ToolIndex, Operation: op}
+	case *DeleteBodyFeature:
+		fd.DeleteBody = serializeDeleteBody(f.def)
 	case *RectangularPatternFeature:
 		src, err := sourceIndices(f.def.SourceFeatures, idx)
 		if err != nil {
@@ -564,6 +567,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreBoss(fs, fd.Boss)
 	case "combine":
 		return restoreCombine(fs, fd.Combine)
+	case "delete-body":
+		return restoreDeleteBody(fs, fd.DeleteBody)
 	case "directEdit":
 		return restoreDirectEdit(fs, fd.DirectEdit)
 	case "rectangular-pattern":

--- a/model/feature/serialize_delete_body.go
+++ b/model/feature/serialize_delete_body.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// DeleteBodyData persists a delete-body feature (#1078): the reference key of the body it removes,
+// base64-encoded like the other key references.
+type DeleteBodyData struct {
+	Body string `yaml:"body"`
+}
+
+func serializeDeleteBody(def *DeleteBodyDefinition) *DeleteBodyData {
+	return &DeleteBodyData{Body: encodeKey(def.BodyKey)}
+}
+
+func restoreDeleteBody(fs *PartFeatures, d *DeleteBodyData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("delete-body feature is missing its payload")
+	}
+	key, err := decodeKey(d.Body)
+	if err != nil {
+		return nil, fmt.Errorf("delete-body: bad body key: %w", err)
+	}
+	return fs.AddDeleteBody(key), nil
+}


### PR DESCRIPTION
## What

Implements **body.delete** — the last piece of #1078. Deletion is a recorded **history feature** (undoable, re-computable), the body-set counterpart of the index-based Combine/Split.

- **DeleteBodyFeature** drops the running body whose persistent reference key matches; a missing target goes **Sick** rather than silently deleting nothing. Keying by reference key (not index) anchors the deletion to the same body across a recompute.
- Round-trips in the recipe as a `deleteBody:` payload (base64 body key) — wired into the feature serialize envelope, encode, and decode switches.
- **body.delete** appends the feature, recomputes, and returns the refreshed body list.

## Why

Completes #1078 (after the reads #1117 and rename #1118). Per the issue, delete is "model-mutating (a delete-body feature in history); design alongside Combine/Split" — done here. The router parity allowlist (`notYetHandled`) is now **empty again**: every wire body method has a handler.

## Tests

- Feature: two-body part → delete by key leaves exactly the other; unknown-key target goes Sick (1 body untouched); recipe `MarshalRecipe`→`ApplyRecipe` round-trip keeps the body key.
- Router: two bodies → delete one, list shrinks to 1 and the part has 1 body; delete appends one history step (undoable); out-of-range index rejected.
- Full `model/feature` + `addin/router` suites green; gofmt/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)