### PR TITLE
Box-select curved edges by their full sampled span (#936)

### DIFF
--- a/app/region_pick.go
+++ b/app/region_pick.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/renderer"
@@ -70,19 +71,35 @@ func (p *RayPicker) regionFaces(sel screenRect, crossing bool) []Selectable {
 	return hits
 }
 
-// regionEdges selects edges whose projected endpoints satisfy the rectangle (window: both
-// inside; crossing: an endpoint inside or the segment crosses an edge of the box).
+// regionEdges selects edges whose projected outline satisfies the rectangle. The outline is the
+// edge's full adaptive sampling (ops.TessellateEdge — the same discretization the renderer draws),
+// not just the two endpoints, so a curved edge whose mid-span enters the box but whose endpoints
+// sit outside is caught by a crossing select and correctly excluded by a window select (#936).
+// A straight edge samples to its two endpoints, preserving the prior behaviour.
 func (p *RayPicker) regionEdges(sel screenRect, crossing bool) []Selectable {
+	q := ops.DefaultQuality()
 	var hits []Selectable
 	for _, b := range p.bodies() {
 		for _, e := range b.Edges() {
-			pts := p.projectVertices(e.Vertices())
-			if len(pts) == len(e.Vertices()) && regionCoversOutline(pts, sel, crossing) {
+			pts := p.projectModelPoints(ops.TessellateEdge(e, q))
+			if len(pts) >= 2 && regionCoversOutline(pts, sel, crossing) {
 				hits = append(hits, EdgeHandle{Edge: e})
 			}
 		}
 	}
 	return hits
+}
+
+// projectModelPoints maps world points to viewport pixels, dropping any at/behind the camera —
+// the projected outline a region edge test consumes.
+func (p *RayPicker) projectModelPoints(model []math.Point3) []screenPt {
+	out := make([]screenPt, 0, len(model))
+	for _, m := range model {
+		if sx, sy, ok := renderer.Project(p.camera, regionNear, regionFar, m); ok {
+			out = append(out, screenPt{sx, sy})
+		}
+	}
+	return out
 }
 
 // rectCovers reports whether sel covers box per the select mode: crossing = overlap, window =
@@ -132,18 +149,6 @@ func (p *RayPicker) projectVertexRect(vs []*topo.Vertex) (screenRect, bool) {
 		pts[i] = v.Point()
 	}
 	return p.projectPointsRect(pts)
-}
-
-// projectVertices projects topology vertices to viewport pixels, dropping any at/behind the
-// camera — the outline a region edge test consumes.
-func (p *RayPicker) projectVertices(vs []*topo.Vertex) []screenPt {
-	out := make([]screenPt, 0, len(vs))
-	for _, v := range vs {
-		if sx, sy, ok := renderer.Project(p.camera, regionNear, regionFar, v.Point()); ok {
-			out = append(out, screenPt{sx, sy})
-		}
-	}
-	return out
 }
 
 // projectPointsRect projects world points to their screen bounding rectangle. ok is false when

--- a/app/region_pick_curved_test.go
+++ b/app/region_pick_curved_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+	"oblikovati.org/scene"
+)
+
+// cylinderPart returns a session whose active part holds a radius×height cylinder (an extruded
+// circle), so the box-select tests run against genuine curved B-rep rim edges.
+func cylinderPart(t *testing.T, radius, height float64) *Session {
+	t.Helper()
+	s := newPartSession(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), radius)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return height })
+	def.Recompute()
+	return s
+}
+
+// curvedEdgeOf returns the first edge of the body whose adaptive sampling has more than two
+// points — a genuinely curved edge (the cylinder's circular rim).
+func curvedEdgeOf(t *testing.T, b *topo.Body) *topo.Edge {
+	t.Helper()
+	for _, e := range b.Edges() {
+		if len(ops.TessellateEdge(e, ops.DefaultQuality())) > 2 {
+			return e
+		}
+	}
+	t.Fatal("no curved edge found on the cylinder")
+	return nil
+}
+
+// TestPickRegionCurvedEdgeSampledNotEndpoints is the #936 regression: a small rect placed over a
+// MID-SPAN point of a curved rim edge — with the edge's vertices outside it — selects the edge on
+// a crossing drag. The old endpoint-only outline classified the whole rim by its seam vertex and
+// would have missed this; the sampled outline catches it.
+func TestPickRegionCurvedEdgeSampledNotEndpoints(t *testing.T) {
+	s := cylinderPart(t, 2, 4)
+	body := partBodies(s)()[0]
+	edge := curvedEdgeOf(t, body)
+
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target = math.P3(18, 6, 9), math.P3(0, 0, 2) // oblique, so the rim projects to an ellipse
+	p := NewRayPicker(cam, partBodies(s))
+	edges := NewSelectionFilter(SelectEdge)
+
+	proj := func(pt math.Point3) (screenPt, bool) {
+		sx, sy, ok := renderer.Project(cam, regionNear, regionFar, pt)
+		return screenPt{sx, sy}, ok
+	}
+
+	// A mid-span sample of the rim (far from the seam vertex), and a tiny rect around it.
+	samples := ops.TessellateEdge(edge, ops.DefaultQuality())
+	mid, ok := proj(samples[len(samples)/2])
+	if !ok {
+		t.Fatal("mid-span rim sample did not project")
+	}
+	rect := screenRect{minX: mid.x - 5, minY: mid.y - 5, maxX: mid.x + 5, maxY: mid.y + 5}
+
+	// Fixture guard: the rim edge's own vertices must be OUTSIDE this rect, so a hit can only come
+	// from a sampled mid-span point — exactly what the endpoint-only outline missed.
+	for _, v := range edge.Vertices() {
+		if vp, ok := proj(v.Point()); ok && rect.containsPoint(vp.x, vp.y) {
+			t.Fatalf("fixture: a rim vertex %v projected inside the mid-span rect %+v", vp, rect)
+		}
+	}
+
+	hits := p.PickRegion(rect.minX, rect.minY, rect.maxX, rect.maxY, true, edges)
+	if !containsEdge(hits, edge) {
+		t.Fatalf("crossing over a curved rim's mid-span did not select it (got %d hits) — sampling regressed", len(hits))
+	}
+}
+
+// TestPickRegionCurvedEdgeWindowNeedsWholeSpan: a crossing rect over part of the rim selects it,
+// but a window rect over that same part does NOT (the rest of the rim is outside) — window-select
+// requires every sampled point inside, proving the classification uses the full span.
+func TestPickRegionCurvedEdgeWindowNeedsWholeSpan(t *testing.T) {
+	s := cylinderPart(t, 2, 4)
+	body := partBodies(s)()[0]
+	edge := curvedEdgeOf(t, body)
+
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target = math.P3(18, 6, 9), math.P3(0, 0, 2)
+	p := NewRayPicker(cam, partBodies(s))
+	edges := NewSelectionFilter(SelectEdge)
+
+	samples := ops.TessellateEdge(edge, ops.DefaultQuality())
+	midX, _, _ := renderer.Project(cam, regionNear, regionFar, samples[len(samples)/2])
+	// A vertical band over part of the rim: tall enough in Y to cover that side, narrow in X so
+	// the far side of the rim falls outside it.
+	minX, maxX := midX-12, midX+12
+
+	if got := p.PickRegion(minX, -1e6, maxX, 1e6, true, edges); !containsEdge(got, edge) {
+		t.Fatalf("crossing over part of the rim should select it, got %d hits", len(got))
+	}
+	if got := p.PickRegion(minX, -1e6, maxX, 1e6, false, edges); containsEdge(got, edge) {
+		t.Error("window over only part of the rim must NOT select it (the rim extends outside the band)")
+	}
+}
+
+// containsEdge reports whether hits include the given edge.
+func containsEdge(hits []Selectable, e *topo.Edge) bool {
+	for _, h := range hits {
+		if eh, ok := h.(EdgeHandle); ok && eh.Edge == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

`RayPicker.regionEdges` classified each B-rep edge by its **two endpoints only** (`regionCoversOutline` over the end vertices). A curved edge whose mid-span entered the rubber-band rectangle but whose endpoints sat outside was **missed** by both window and crossing selection — and a closed rim edge was judged by its single seam vertex.

Now each edge's outline is its **full adaptive sampling** (`ops.TessellateEdge` — the same discretization the renderer draws), projected to screen and classified with the existing `regionCoversOutline`. A straight edge still samples to its two endpoints, so its behaviour is unchanged.

## Why

Last remaining tail of the viewport-interaction audit (#909 family); box-select itself shipped in #916/#918/#920/#922. Brings 3D B-rep edge box-select to Inventor parity (crossing = any sampled point/segment inside; window = every sampled point inside), matching what sketch-entity box-select already did via `EntityOutline`. No API change.

## Tests (against a real extruded cylinder's curved rim)

- **Regression**: a small rect over a rim's **mid-span sample**, with the edge's vertices guarded outside it, is selected on a crossing drag — the case the endpoint-only outline missed.
- A vertical band over **part** of the rim: crossing selects it, window does **not** (the rest of the rim is outside) — proving the full span drives the classification.
- Existing straight-edge / face / body region-pick tests stay green; the now-orphaned `projectVertices` helper is removed.
- Full `app` suite green; gofmt/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)