### PR TITLE
Marking menu: Repeat-last-command + classic-menu toggle (#915)

### DIFF
--- a/app/marking_menu_repeat_test.go
+++ b/app/marking_menu_repeat_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// countingCommand registers a test command that tallies its runs, returning the session and a
+// pointer to the run counter.
+func countingCommand(t *testing.T, s *Session, id string) *int {
+	t.Helper()
+	runs := 0
+	if err := s.Commands().Add(NewCommand(id, "My "+id, "Test", func(*Session) error {
+		runs++
+		return nil
+	})); err != nil {
+		t.Fatalf("register %q: %v", id, err)
+	}
+	return &runs
+}
+
+// TestLastCommandTrackedAndRepeated: executing a command records it as the last, and
+// RepeatLastCommand re-runs it (#915 C5).
+func TestLastCommandTrackedAndRepeated(t *testing.T) {
+	s := NewSession()
+	runs := countingCommand(t, s, "Test.Ping")
+
+	if _, ok := s.LastCommandID(); ok {
+		t.Error("a fresh session should have no last command")
+	}
+	if err := s.Execute("Test.Ping"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if id, ok := s.LastCommandID(); !ok || id != "Test.Ping" {
+		t.Errorf("LastCommandID = (%q, %v), want (Test.Ping, true)", id, ok)
+	}
+
+	if err := s.RepeatLastCommand(); err != nil {
+		t.Fatalf("repeat: %v", err)
+	}
+	if *runs != 2 {
+		t.Errorf("command ran %d times, want 2 (once executed, once repeated)", *runs)
+	}
+}
+
+// TestRepeatLastNoPriorCommandIsNoOp: with no prior command, repeat does nothing.
+func TestRepeatLastNoPriorCommandIsNoOp(t *testing.T) {
+	if err := NewSession().RepeatLastCommand(); err != nil {
+		t.Errorf("repeat with no prior command should be a no-op, got %v", err)
+	}
+}
+
+// TestRepeatMenuEntryIdleAndActive: the Repeat entry shows the last command's name when idle, and
+// is withheld while a tool is active or before any command has run (#915 C5).
+func TestRepeatMenuEntryIdleAndActive(t *testing.T) {
+	s := NewSession()
+	countingCommand(t, s, "Test.Extrude")
+
+	if _, _, ok := s.RepeatMenuEntry(); ok {
+		t.Error("no Repeat entry before any command has run")
+	}
+
+	if err := s.Execute("Test.Extrude"); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	label, id, ok := s.RepeatMenuEntry()
+	if !ok || id != "Test.Extrude" || label != "Repeat My Test.Extrude" {
+		t.Errorf("RepeatMenuEntry = (%q, %q, %v), want (Repeat My Test.Extrude, Test.Extrude, true)", label, id, ok)
+	}
+
+	// While a tool is active the menu offers in-command actions, not Repeat.
+	s.StartTool(NewLineTool())
+	if _, _, ok := s.RepeatMenuEntry(); ok {
+		t.Error("the Repeat entry must be withheld while a tool is active")
+	}
+}
+
+// TestContextMenuStyleToggle: the right-click style defaults to the radial marking menu and flips
+// to the classic linear menu (#915 C8).
+func TestContextMenuStyleToggle(t *testing.T) {
+	s := NewSession()
+	if s.ClassicContextMenu() {
+		t.Error("the right-click menu should default to the radial marking menu")
+	}
+	s.ToggleContextMenuStyle()
+	if !s.ClassicContextMenu() {
+		t.Error("after toggling, the classic linear menu should be selected")
+	}
+	s.SetClassicContextMenu(false)
+	if s.ClassicContextMenu() {
+		t.Error("SetClassicContextMenu(false) should restore the radial marking menu")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -108,6 +108,8 @@ type Session struct {
 	activeAddInEnv       Environment                                      // the entered add-in environment (base when none)
 	markingMenus         map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
 	contextMenus         map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
+	lastCommandID        string                                           // the most recently invoked command, for right-click Repeat (#915 C5)
+	classicContextMenu   bool                                             // right-click shows the classic linear menu instead of the radial marking menu (#915 C8)
 	objectVisibility     wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
 	cmdInput             commandInput                                     // command-alias input box state (M05-F17)
 	cmdLine              *CommandLine                                     // Command Window REPL engine (M26)
@@ -356,11 +358,39 @@ func (s *Session) Execute(id string) error {
 	if !c.IsEnabled(s) {
 		return fmt.Errorf("app: command %q is disabled", id)
 	}
+	s.lastCommandID = id // the right-click Repeat target (#915 C5)
 	event.Emit(s.bus, event.Before, CommandStarted{ID: id})
 	err := c.run(s)
 	event.Emit(s.bus, event.After, CommandEnded{ID: id, Failed: err != nil})
 	return err
 }
+
+// LastCommandID returns the most recently invoked command's id and whether one exists — the
+// target of the right-click "Repeat <command>" entry (#915 C5).
+func (s *Session) LastCommandID() (string, bool) {
+	return s.lastCommandID, s.lastCommandID != ""
+}
+
+// RepeatLastCommand re-invokes the most recently run command, if any and still enabled; with no
+// prior command it is a no-op. This backs the marking menu's idle "Repeat" entry (#915 C5).
+func (s *Session) RepeatLastCommand() error {
+	id, ok := s.LastCommandID()
+	if !ok {
+		return nil
+	}
+	return s.Execute(id)
+}
+
+// ClassicContextMenu reports whether the viewport right-click shows the classic linear menu
+// instead of the radial marking menu (#915 C8).
+func (s *Session) ClassicContextMenu() bool { return s.classicContextMenu }
+
+// SetClassicContextMenu chooses the right-click menu style (true = classic linear, false =
+// radial marking menu).
+func (s *Session) SetClassicContextMenu(classic bool) { s.classicContextMenu = classic }
+
+// ToggleContextMenuStyle flips between the radial marking menu and the classic linear menu.
+func (s *Session) ToggleContextMenuStyle() { s.classicContextMenu = !s.classicContextMenu }
 
 // Invoke is the alias-driven entry (Inventor command alias): typing a command alias
 // runs the matching command.

--- a/app/ui_shell.go
+++ b/app/ui_shell.go
@@ -78,6 +78,24 @@ func (s *Session) SetMarkingMenu(menu wire.MarkingMenuView) error {
 	return nil
 }
 
+// RepeatMenuEntry returns the right-click "Repeat <command>" entry shown when idle: its display
+// label and the command id to re-invoke. ok is false when a tool/command is active (the menu then
+// offers in-command actions, not Repeat) or there is no prior command (#915 C5).
+func (s *Session) RepeatMenuEntry() (label, commandID string, ok bool) {
+	if s.ActiveTool() != nil {
+		return "", "", false
+	}
+	id, has := s.LastCommandID()
+	if !has {
+		return "", "", false
+	}
+	name := id
+	if c, found := s.commands.ByID(id); found {
+		name = c.DisplayName()
+	}
+	return "Repeat " + name, id, true
+}
+
 // SetContextMenuItems replaces one add-in's injected entries for a browser node
 // kind ("" injects into every node's menu).
 func (s *Session) SetContextMenuItems(addin, kind string, items []wire.ContextMenuItemSpec) error {

--- a/head/ui/marking_menu_inwindow_test.go
+++ b/head/ui/marking_menu_inwindow_test.go
@@ -1,0 +1,70 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestInWindowMarkingMenuRepeatAndStyles renders the right-click menu in both styles with an idle
+// Repeat entry present, capturing each to a PNG. It is a smoke guard that the #915 entries draw
+// through the real cgo path without crashing, and the captures back the live visual confirmation.
+func TestInWindowMarkingMenuRepeatAndStyles(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register standard commands: %v", err)
+	}
+	// Run a no-op command so the idle "Repeat <command>" entry has a target, leaving no tool active.
+	if err := s.Commands().Add(app.NewCommand("Test.Demo", "Demo Command", "Test", func(*app.Session) error { return nil })); err != nil {
+		t.Fatalf("add demo command: %v", err)
+	}
+	if err := s.Execute("Test.Demo"); err != nil {
+		t.Fatalf("execute demo: %v", err)
+	}
+	if _, _, ok := s.RepeatMenuEntry(); !ok {
+		t.Fatal("expected an idle Repeat entry after running a command")
+	}
+
+	render := func() {
+		for i := 0; i < 8; i++ {
+			win.BeginFrame()
+			DrawChrome(win, s)
+			win.EndFrame(0.1, 0.1, 0.1)
+		}
+	}
+	save := func(name string) {
+		if err := win.SaveWindowPNG(filepath.Join(outDir(), name)); err != nil {
+			t.Logf("SaveWindowPNG(%s): %v", name, err)
+		}
+	}
+
+	// Radial marking menu (default) with the Repeat entry on top.
+	openMarkingMenuOnFirstFrame = true
+	render()
+	save("mm-radial-repeat.png")
+
+	// Switch to the classic linear menu — the same popup re-renders in the other style.
+	s.SetClassicContextMenu(true)
+	openMarkingMenuOnFirstFrame = true
+	render()
+	save("mm-classic.png")
+}
+
+// outDir returns a writable directory for the capture PNGs (OBK_SHOT_DIR or /tmp).
+func outDir() string {
+	if d := os.Getenv("OBK_SHOT_DIR"); d != "" {
+		return d
+	}
+	return "/tmp"
+}

--- a/head/ui/marking_menu_view.go
+++ b/head/ui/marking_menu_view.go
@@ -38,9 +38,10 @@ var quadrantDirections = map[types.ScreenQuadrant][2]float32{
 	types.QuadrantWest: {-1, 0}, types.QuadrantNorthWest: {-0.7, -0.7},
 }
 
-// drawMarkingMenu renders the popup when open: the ring for the active
-// environment, then the overflow rows. Unknown command ids are skipped, so a
-// customized menu can name commands before they register.
+// drawMarkingMenu renders the right-click popup when open, in the user's chosen style: the radial
+// ring (default) or the classic linear menu (#915 C8). Both lead with the idle "Repeat <command>"
+// entry (#915 C5) and end with the style toggle. Unknown command ids are skipped, so a customized
+// menu can name commands before they register.
 func drawMarkingMenu(s *app.Session) {
 	if openMarkingMenuOnFirstFrame {
 		openMarkingMenuOnFirstFrame = false
@@ -49,6 +50,17 @@ func drawMarkingMenu(s *app.Session) {
 	if !native.BeginPopup(markingMenuPopupID) {
 		return
 	}
+	if s.ClassicContextMenu() {
+		drawClassicContextMenu(s)
+	} else {
+		drawRadialMarkingMenu(s)
+	}
+	native.EndPopup()
+}
+
+// drawRadialMarkingMenu draws the eight-quadrant ring plus its overflow rows.
+func drawRadialMarkingMenu(s *app.Session) {
+	drawRepeatEntry(s)
 	menu := s.MarkingMenu(app.CurrentEnvironment(s))
 	const size = 2*markingMenuRadius + 96 // ring + button width margin
 	centerX, centerY := float32(size)/2, float32(size)/2
@@ -57,7 +69,64 @@ func drawMarkingMenu(s *app.Session) {
 		drawMarkingSlot(s, centerX, centerY, item)
 	}
 	drawMarkingOverflow(s, menu.Overflow)
-	native.EndPopup()
+	drawContextMenuStyleToggle(s)
+}
+
+// drawClassicContextMenu draws the same commands as a plain vertical list — the classic
+// (non-radial) right-click menu (#915 C8).
+func drawClassicContextMenu(s *app.Session) {
+	drawRepeatEntry(s)
+	menu := s.MarkingMenu(app.CurrentEnvironment(s))
+	for _, item := range menu.Quadrants {
+		drawLinearCommandEntry(s, item.CommandID)
+	}
+	for _, id := range menu.Overflow {
+		drawLinearCommandEntry(s, id)
+	}
+	drawContextMenuStyleToggle(s)
+}
+
+// drawRepeatEntry renders the idle "Repeat <command>" entry at the top of the menu when a prior
+// command exists and no tool is active (#915 C5).
+func drawRepeatEntry(s *app.Session) {
+	label, _, ok := s.RepeatMenuEntry()
+	if !ok {
+		return
+	}
+	if native.Selectable(label+"##mm-repeat", false) {
+		_ = s.RepeatLastCommand()
+		native.CloseCurrentPopup()
+	}
+	native.Separator()
+}
+
+// drawContextMenuStyleToggle renders the entry that switches between the radial and classic
+// styles (#915 C8).
+func drawContextMenuStyleToggle(s *app.Session) {
+	native.Separator()
+	label := "Use Classic Menu"
+	if s.ClassicContextMenu() {
+		label = "Use Marking Menu"
+	}
+	if native.Selectable(label+"##mm-style", false) {
+		s.ToggleContextMenuStyle()
+		native.CloseCurrentPopup()
+	}
+}
+
+// drawLinearCommandEntry renders one command as a vertical menu row (greyed when disabled,
+// skipped when unknown), running it and closing the popup on click.
+func drawLinearCommandEntry(s *app.Session, id string) {
+	cmd, ok := s.Commands().ByID(id)
+	if !ok {
+		return
+	}
+	native.BeginDisabled(!cmd.IsEnabled(s))
+	if native.Selectable(cmd.DisplayName()+"##mmc-"+id, false) {
+		_ = s.Execute(id)
+		native.CloseCurrentPopup()
+	}
+	native.EndDisabled()
 }
 
 // drawMarkingSlot places one quadrant's command button on the ring.


### PR DESCRIPTION
## What

The two remaining right-click context behaviours from the viewport-interaction audit (§7 Context **C5** and **C8**):

- **C5 — Repeat last command**: `Session.Execute` now records the last invoked command. The idle marking menu leads with a **"Repeat &lt;command&gt;"** entry (withheld while a tool is active — that state offers in-command actions instead). `RepeatMenuEntry` resolves the label; `RepeatLastCommand` re-runs it.
- **C8 — Classic-menu toggle**: a per-session preference switches the right-click menu between the **radial marking menu** and a **classic linear list**. An entry at the bottom of either style flips it (`ClassicContextMenu` / `SetClassicContextMenu` / `ToggleContextMenuStyle`).

The head renders both styles (`drawRadialMarkingMenu` / `drawClassicContextMenu`), each leading with the Repeat entry and ending with the style toggle.

## Why

Last two open items of the viewport-interaction audit's §7 Context (the #909 family); brings the right-click menu to Inventor parity. No API change — pure app + head/UI.

## Tests

- **App unit tests**: last-command tracked + repeated; repeat is a no-op with no prior command; `RepeatMenuEntry` shows the name when idle and is withheld while a tool is active; the style toggle defaults to radial and flips.
- **Head in-window test** renders both styles through the real cgo path (smoke guard) and captures each to a PNG.
- **Live-confirmed**: captures show the Repeat entry and the style toggle in both the radial and classic menus (the toggle label correctly flips per current style).
- Full `app` suite green; head builds + vets clean; gofmt clean.

Closes #915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)