### PR TITLE
feat(addin): implement body.faceEvaluate (surface evaluation for add-ins)

### DIFF
--- a/addin/router/body_evaluate.go
+++ b/addin/router/body_evaluate.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// bodyFaceEvaluate serves wire.MethodBodyFaceEvaluate: a batched surface evaluation of one
+// face addressed by reference key. It is the out-of-process projection of the kernel surface
+// evaluator (kernel/topo) — a caller sampling a face densely (surface-following toolpaths,
+// point projection) gets all points back in one reply instead of one call per point.
+func bodyFaceEvaluate(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.FaceEvaluateArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	f, ok := b.FindFaceByKey([]byte(in.FaceKey))
+	if !ok {
+		return nil, fmt.Errorf("no face with key %q on body %d", in.FaceKey, in.BodyIndex)
+	}
+	eval := topo.NewFaceEvaluator(f).SurfaceEvaluator
+	out, err := evaluateFaceSurface(eval, in.Mode, in.Inputs)
+	if err != nil {
+		return nil, err
+	}
+	uLo, uHi, vLo, vHi := eval.ParamRange()
+	out.ParamRange = []float64{uLo, vLo, uHi, vHi}
+	return json.Marshal(out)
+}
+
+// evaluateFaceSurface runs the requested batched query over the inputs, filling only the
+// result arrays the mode produces. Parametric modes read (u, v) pairs; closestPoint reads
+// (x, y, z) point triples and projects each onto the surface.
+func evaluateFaceSurface(e topo.SurfaceEvaluator, mode string, inputs []float64) (wire.FaceEvaluateResult, error) {
+	var out wire.FaceEvaluateResult
+	switch mode {
+	case wire.FaceEvalPointAtParam:
+		forEachParam(inputs, func(u, v float64) { out.Points = appendPoint(out.Points, e.PointAt(u, v)) })
+	case wire.FaceEvalNormalAtParam:
+		forEachParam(inputs, func(u, v float64) {
+			out.Points = appendPoint(out.Points, e.PointAt(u, v))
+			out.Normals = appendVector(out.Normals, e.NormalAt(u, v))
+		})
+	case wire.FaceEvalTangents:
+		forEachParam(inputs, func(u, v float64) {
+			du, dv := e.TangentsAt(u, v)
+			out.Points = appendPoint(out.Points, e.PointAt(u, v))
+			out.UTangents = appendVector(out.UTangents, du)
+			out.VTangents = appendVector(out.VTangents, dv)
+		})
+	case wire.FaceEvalClosestPoint:
+		forEachPoint(inputs, func(p math.Point3) {
+			u, v := e.ClosestParam(p)
+			out.Points = appendPoint(out.Points, e.PointAt(u, v))
+			out.UVs = append(out.UVs, u, v)
+		})
+	default:
+		return out, fmt.Errorf("unknown face-evaluate mode %q (want %q, %q, %q or %q)",
+			mode, wire.FaceEvalPointAtParam, wire.FaceEvalNormalAtParam, wire.FaceEvalTangents, wire.FaceEvalClosestPoint)
+	}
+	return out, nil
+}
+
+// forEachParam invokes fn for each (u, v) pair in a flat parameter array (a trailing
+// unpaired value is ignored).
+func forEachParam(flat []float64, fn func(u, v float64)) {
+	for i := 0; i+1 < len(flat); i += 2 {
+		fn(flat[i], flat[i+1])
+	}
+}
+
+// forEachPoint invokes fn for each (x, y, z) triple in a flat point array.
+func forEachPoint(flat []float64, fn func(p math.Point3)) {
+	for i := 0; i+2 < len(flat); i += 3 {
+		fn(math.P3(flat[i], flat[i+1], flat[i+2]))
+	}
+}
+
+// appendPoint flattens a point's (x, y, z) onto a result array.
+func appendPoint(dst []float64, p math.Point3) []float64 { return append(dst, p.X, p.Y, p.Z) }
+
+// appendVector flattens a vector's (x, y, z) onto a result array.
+func appendVector(dst []float64, v math.Vector3) []float64 { return append(dst, v.X, v.Y, v.Z) }

--- a/addin/router/body_evaluate_test.go
+++ b/addin/router/body_evaluate_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// faceEvalArgs marshals face-evaluate args to a JSON string (reference keys carry raw bytes,
+// so they must be JSON-escaped via Marshal, not concatenated).
+func faceEvalArgs(t *testing.T, args wire.FaceEvaluateArgs) string {
+	t.Helper()
+	b, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return string(b)
+}
+
+// TestBodyFaceEvaluate covers the batched face-evaluation modes on the box's top face: a
+// point projected onto it lands on the plane (z≈5 cm), and re-evaluating the returned (u,v)
+// yields the plane's up normal. Exercises closestPoint → normalAtParam.
+func TestBodyFaceEvaluate(t *testing.T) {
+	r, s := boxPartSession(t)
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	if len(keys.Bodies) == 0 {
+		t.Fatal("no bodies in reference keys")
+	}
+	topKey := ""
+	topZ := stdmath.Inf(-1)
+	for _, face := range keys.Bodies[0].Faces {
+		if face.Kind == "plane" && len(face.Point) == 3 && face.Point[2] > topZ {
+			topZ, topKey = face.Point[2], face.Key
+		}
+	}
+	if topKey == "" {
+		t.Fatal("no top plane face found")
+	}
+
+	// closestPoint: project a point 5 cm above the top-face centre — it must land on z≈5.
+	var closest wire.FaceEvaluateResult
+	call(t, r, s, "body.faceEvaluate", faceEvalArgs(t, wire.FaceEvaluateArgs{
+		BodyIndex: 0, FaceKey: topKey, Mode: wire.FaceEvalClosestPoint, Inputs: []float64{2, 1.5, 10},
+	}), &closest)
+	if len(closest.Points) != 3 || stdmath.Abs(closest.Points[2]-5) > 1e-6 {
+		t.Fatalf("closestPoint = %v, want a point on z=5", closest.Points)
+	}
+	if len(closest.UVs) != 2 {
+		t.Fatalf("closestPoint UVs = %v, want one (u,v) pair", closest.UVs)
+	}
+	if len(closest.ParamRange) != 4 {
+		t.Errorf("paramRange = %v, want [uMin,vMin,uMax,vMax]", closest.ParamRange)
+	}
+
+	// normalAtParam at the projected (u,v): the top face's outward normal is ±Z.
+	var normal wire.FaceEvaluateResult
+	call(t, r, s, "body.faceEvaluate", faceEvalArgs(t, wire.FaceEvaluateArgs{
+		BodyIndex: 0, FaceKey: topKey, Mode: wire.FaceEvalNormalAtParam, Inputs: closest.UVs,
+	}), &normal)
+	if len(normal.Normals) != 3 || stdmath.Abs(stdmath.Abs(normal.Normals[2])-1) > 1e-6 {
+		t.Fatalf("normalAtParam = %v, want ±Z", normal.Normals)
+	}
+	if stdmath.Abs(normal.Points[2]-5) > 1e-6 {
+		t.Errorf("normalAtParam point z = %g, want 5", normal.Points[2])
+	}
+}
+
+// TestBodyFaceEvaluateErrors covers the unknown-mode and unknown-face-key guards.
+func TestBodyFaceEvaluateErrors(t *testing.T) {
+	r, s := boxPartSession(t)
+	badKey := faceEvalArgs(t, wire.FaceEvaluateArgs{BodyIndex: 0, FaceKey: "nope", Mode: wire.FaceEvalClosestPoint, Inputs: []float64{0, 0, 0}})
+	if err := tryCall(t, r, s, "body.faceEvaluate", badKey); err == nil {
+		t.Error("an unknown face key must error")
+	}
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	badMode := faceEvalArgs(t, wire.FaceEvaluateArgs{BodyIndex: 0, FaceKey: keys.Bodies[0].Faces[0].Key, Mode: "bogus", Inputs: []float64{0, 0}})
+	if err := tryCall(t, r, s, "body.faceEvaluate", badMode); err == nil {
+		t.Error("an unknown mode must error")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -395,6 +395,7 @@ func (r *Router) registerMaterialHandlers() {
 	r.handlers[wire.MethodBodyStrokeTolerances] = bodyStrokeTolerances
 	r.handlers[wire.MethodFaceCalculateFacets] = faceCalculateFacets
 	r.handlers[wire.MethodFaceCalculateStrokes] = faceCalculateStrokes
+	r.handlers[wire.MethodBodyFaceEvaluate] = bodyFaceEvaluate
 
 	// The transient B-rep factory (M07 #628) — session-scoped, no document
 	// mutation, so none of these are mutating methods.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.76.1
+	oblikovati.org/api v0.77.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.76.1
+	oblikovati.org/api v0.77.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/topo/param_range_test.go
+++ b/kernel/topo/param_range_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestSurfaceEvaluatorParamRange: a bounded surface reports a finite domain, and an
+// unbounded one (a plane) is clamped to a finite search window rather than returning ±Inf.
+func TestSurfaceEvaluatorParamRange(t *testing.T) {
+	sphere, _ := geom.NewSphere(math.P3(0, 0, 0), 3)
+	uLo, uHi, vLo, vHi := NewSurfaceEvaluator(sphere).ParamRange()
+	if uHi <= uLo || vHi <= vLo {
+		t.Errorf("sphere param range invalid: u[%g,%g] v[%g,%g]", uLo, uHi, vLo, vHi)
+	}
+
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	puLo, puHi, pvLo, pvHi := NewSurfaceEvaluator(plane).ParamRange()
+	for _, b := range []float64{puLo, puHi, pvLo, pvHi} {
+		if stdmath.IsInf(b, 0) {
+			t.Errorf("plane param range must be clamped finite, got u[%g,%g] v[%g,%g]", puLo, puHi, pvLo, pvHi)
+		}
+	}
+}

--- a/kernel/topo/surface_evaluator.go
+++ b/kernel/topo/surface_evaluator.go
@@ -48,6 +48,15 @@ func (e SurfaceEvaluator) ClosestPoint(p math.Point3) math.Point3 {
 	return e.surface.PointAt(u, v)
 }
 
+// ParamRange returns the surface's (u, v) parameter domain as [uLo, uHi, vLo, vHi], with
+// infinite bounds clamped to the same finite window ClosestParam searches — so a caller can
+// pick sample parameters without tripping over an unbounded analytic domain.
+func (e SurfaceEvaluator) ParamRange() (uLo, uHi, vLo, vHi float64) {
+	uLo, uHi = clampDomain(e.surface.UDomain())
+	vLo, vHi = clampDomain(e.surface.VDomain())
+	return uLo, uHi, vLo, vHi
+}
+
 // gridSeed returns the sampled (u, v) nearest p over a coarse grid.
 func gridSeed(s geom.Surface, p math.Point3, uLo, uHi, vLo, vHi float64) (float64, float64) {
 	const n = 16


### PR DESCRIPTION
## What

Implements the new `body.faceEvaluate` wire method (api v0.77.0): resolve a face by its
persistent reference key and batch **point / normal / tangents / point-projection** queries
over the supplied inputs, returning flat parallel arrays in one reply. Adds
`SurfaceEvaluator.ParamRange` (the clamped `(u,v)` domain) and routes the method in
`addin/router`.

## Why

Lets an out-of-process add-in (everything over the C ABI) evaluate a document face's
surface — the query 3D surface-following toolpaths and drop-cutter projection need. It is a
thin projection of the existing kernel evaluator (`kernel/topo`); no new kernel math.

## Notes

- Pins `oblikovati.org/api` to **v0.77.0** (the release adding the contract).
- Tests: router handler (closestPoint → normalAtParam round-trip on a box face) + kernel
  `ParamRange`; API↔router parity guard passes; `go build ./...` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)