### PR TITLE
Sketch copy carries constraints + dimensions (#1083)

### DIFF
--- a/addin/router/sketch_copy.go
+++ b/addin/router/sketch_copy.go
@@ -13,12 +13,11 @@ import (
 	"oblikovati.org/model/sketch"
 )
 
-// Sketch-to-sketch copy (#151): re-instantiate one sketch's geometry in another. The source
-// entities' sketch-local coordinates are cloned into the target sketch's plane (offset by
-// Position), reusing the cross-sketch clone machinery (Sketch.CopyEntities reads the source
-// and creates fresh geometry on the target). v1 copies geometry only — external constraints
-// and dimensions are dropped (Inventor CopyEntitiesTo); carry-over among the copied set is a
-// follow-up.
+// Sketch-to-sketch copy (#151, #1083): re-instantiate one sketch's geometry in another. The
+// source entities' sketch-local coordinates are cloned into the target sketch's plane (offset
+// by Position), reusing the cross-sketch clone machinery. CopyEntitiesWithConstraints also
+// carries over the geometric constraints and dimensions whose operands are entirely within the
+// copied set, dropping any that reference geometry left behind (Inventor CopyEntitiesTo).
 
 // sketchCopyTo copies geometry from one 2D sketch into another.
 func sketchCopyTo(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -38,7 +37,7 @@ func sketchCopyTo(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	created := target.CopyEntities(ents, offset)
+	created := target.CopyEntitiesWithConstraints(source, ents, offset)
 	ids := make([]uint64, len(created))
 	for i, e := range created {
 		ids[i] = uint64(e.EntityID())

--- a/addin/router/sketch_copy_test.go
+++ b/addin/router/sketch_copy_test.go
@@ -61,6 +61,81 @@ func TestSketchCopyToOffsetAndSubset(t *testing.T) {
 	}
 }
 
+// TestSketchCopyToCarriesConstraintsAndDimensions (#1083): a rectangle is fully constrained
+// (coincidences/perpendiculars + width/height dimensions); copying the whole sketch carries
+// every relation whose operands are all in the copied set onto the target, with fresh
+// parameter names, and the target rectangle stays solvable.
+func TestSketchCopyToCarriesConstraintsAndDimensions(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+
+	var line1, line2, circle wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,0]]}`, &line1)
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,2],[4,2]]}`, &line2)
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[10,0]],"radius":"1 cm"}`, &circle)
+
+	parallel := mustJSON(t, wire.AddConstraintArgs{SketchIndex: 0, Kind: "parallel", Entities: []uint64{line1.EntityID, line2.EntityID}})
+	call(t, r, s, "sketch.addConstraint", parallel, &wire.AddConstraintResult{})
+	radius := mustJSON(t, wire.AddDimensionArgs{SketchIndex: 0, Kind: "radius", Entities: []uint64{circle.EntityID}, Expression: "1 cm"})
+	call(t, r, s, "sketch.addDimension", radius, &wire.AddDimensionResult{})
+
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{}) // sketch 1, empty
+
+	var srcCons wire.ListConstraintsResult
+	call(t, r, s, "sketch.constraints", `{"sketchIndex":0}`, &srcCons)
+	var srcDims wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":0}`, &srcDims)
+
+	call(t, r, s, "sketch.copyTo", `{"sourceIndex":0,"targetIndex":1,"position":[100,0]}`, &wire.CopySketchResult{})
+
+	var dstCons wire.ListConstraintsResult
+	call(t, r, s, "sketch.constraints", `{"sketchIndex":1}`, &dstCons)
+	if len(dstCons.Constraints) != len(srcCons.Constraints) || !hasConstraintKind(dstCons.Constraints, "parallel") {
+		t.Errorf("carried constraints = %+v, want %d including a parallel (every operand is in the copied set)", dstCons.Constraints, len(srcCons.Constraints))
+	}
+	var dstDims wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":1}`, &dstDims)
+	if len(dstDims.Dimensions) != 1 || dstDims.Dimensions[0].Kind != "radius" {
+		t.Errorf("carried dimensions = %+v, want one radius", dstDims.Dimensions)
+	}
+	// The copied dimension's parameter is freshly minted in the shared part store — no collision.
+	if len(srcDims.Dimensions) == 1 && len(dstDims.Dimensions) == 1 && dstDims.Dimensions[0].Name == srcDims.Dimensions[0].Name {
+		t.Errorf("copied dimension reused source parameter name %q; want a fresh one", srcDims.Dimensions[0].Name)
+	}
+}
+
+// TestSketchCopyToDropsExternalConstraint (#1083): a parallel constraint relates two lines;
+// copying only one of them leaves its partner behind, so the constraint is silently dropped.
+func TestSketchCopyToDropsExternalConstraint(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	var line1, line2 wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,1]]}`, &line1)
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,2],[4,3]]}`, &line2)
+	parallel := mustJSON(t, wire.AddConstraintArgs{SketchIndex: 0, Kind: "parallel", Entities: []uint64{line1.EntityID, line2.EntityID}})
+	call(t, r, s, "sketch.addConstraint", parallel, &wire.AddConstraintResult{})
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{})
+
+	args := mustJSON(t, wire.CopySketchArgs{SourceIndex: 0, TargetIndex: 1, EntityIDs: []uint64{line1.EntityID}})
+	call(t, r, s, "sketch.copyTo", args, &wire.CopySketchResult{})
+
+	var dstCons wire.ListConstraintsResult
+	call(t, r, s, "sketch.constraints", `{"sketchIndex":1}`, &dstCons)
+	if hasConstraintKind(dstCons.Constraints, "parallel") {
+		t.Errorf("carried constraints = %+v, want the parallel dropped (its partner line was not copied)", dstCons.Constraints)
+	}
+}
+
+// hasConstraintKind reports whether any enumerated constraint has the given kind.
+func hasConstraintKind(cons []wire.ConstraintInfo, kind string) bool {
+	for _, c := range cons {
+		if c.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // TestSketchCopyToSameSketchFails (#151): copying a sketch onto itself is rejected.
 func TestSketchCopyToSameSketchFails(t *testing.T) {
 	r, s := emptyPartSession(t)

--- a/model/sketch/copy_constraints.go
+++ b/model/sketch/copy_constraints.go
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// Constraint/dimension carry-over for sketch-to-sketch copy (#1083, follow-up to #151).
+// CopyEntities duplicates geometry only; Inventor's CopyEntitiesTo also re-creates the
+// constraints and dimensions whose operands are *entirely* within the copied set, dropping
+// any that reference geometry left behind. CopyEntitiesWithConstraints adds that carry-over
+// on top of the geometry clone: every operand is remapped through the source→clone maps, and
+// a relation with any external operand is silently dropped.
+
+// cloneMap resolves a source operand (a point or an entity) to its clone. Points are keyed
+// separately from entities because a constraint references the shared *Point inside a line or
+// arc, not the owning entity.
+type cloneMap struct {
+	points   map[*Point]*Point
+	entities map[Entity]Entity
+}
+
+func (m *cloneMap) point(p *Point) (*Point, bool) {
+	np, ok := m.points[p]
+	return np, ok
+}
+
+func (m *cloneMap) line(l *Line) (*Line, bool) {
+	c, ok := m.entities[l]
+	if !ok {
+		return nil, false
+	}
+	nl, ok := c.(*Line)
+	return nl, ok
+}
+
+func (m *cloneMap) curve(c CircularCurve) (CircularCurve, bool) {
+	e, ok := m.entities[c]
+	if !ok {
+		return nil, false
+	}
+	nc, ok := e.(CircularCurve)
+	return nc, ok
+}
+
+func (m *cloneMap) arc(a *Arc) (*Arc, bool) {
+	c, ok := m.entities[a]
+	if !ok {
+		return nil, false
+	}
+	na, ok := c.(*Arc)
+	return na, ok
+}
+
+func (m *cloneMap) ellipse(e *Ellipse) (*Ellipse, bool) {
+	c, ok := m.entities[e]
+	if !ok {
+		return nil, false
+	}
+	ne, ok := c.(*Ellipse)
+	return ne, ok
+}
+
+// CopyEntitiesWithConstraints clones a selection from source into this sketch (translated by
+// v) and carries over every geometric constraint and dimension whose operands lie entirely
+// within the copied set, remapping operands to the clones and dropping any relation with an
+// external operand (Inventor CopyEntitiesTo with constraint carry-over, #1083). A copied
+// driving dimension mints a fresh parameter in this sketch (DimensionConstraints.nextName),
+// so names never collide with the source's. Returns the created entity clones.
+//
+// Example: target.CopyEntitiesWithConstraints(source, source.Entities(), math.V2(50, 0))
+// duplicates the whole source sketch 50 units to the right, fully constrained.
+func (target *Sketch) CopyEntitiesWithConstraints(source *Sketch, ents []Entity, v math.Vector2) []Entity {
+	clones, pmap, emap := target.cloneEntitiesFull(ents, translation(v))
+	m := &cloneMap{points: pmap, entities: emap}
+	for _, c := range source.geomCons.All() {
+		target.geomCons.carryFrom(c, m)
+	}
+	for _, d := range source.dimCons.All() {
+		target.carryDimension(d, m)
+	}
+	return clones
+}
+
+// carryFrom re-creates one source geometric constraint on this (target) collection via the
+// clone map, returning whether it was carried. It is dropped when any operand lies outside
+// the copied set or the kind is not a carryable 2D constraint. The dispatch is split into the
+// point-anchored and line/curve-anchored kinds to keep each switch within the complexity bound.
+func (g *GeometricConstraints) carryFrom(c Constraint, m *cloneMap) bool {
+	if carried, matched := carryPointConstraint(g, c, m); matched {
+		return carried
+	}
+	return carryLineCurveConstraint(g, c, m)
+}
+
+// carryPointConstraint handles the geometric constraints whose operands are points (some with a
+// line or curve anchor). matched reports whether c was one of these kinds, so carryFrom can fall
+// through to the line/curve kinds; carried reports whether it was actually re-created.
+func carryPointConstraint(g *GeometricConstraints, c Constraint, m *cloneMap) (carried, matched bool) {
+	switch v := c.(type) {
+	case *CoincidentConstraint:
+		return carryPoints(m, v.A, v.B, g.AddCoincident), true
+	case *HorizontalConstraint:
+		return carryPoints(m, v.A, v.B, g.AddHorizontal), true
+	case *VerticalConstraint:
+		return carryPoints(m, v.A, v.B, g.AddVertical), true
+	case *MidpointConstraint:
+		return carryPointLine(m, v.P, v.L, g.AddMidpoint), true
+	case *PointOnLineConstraint:
+		return carryPointLine(m, v.P, v.L, g.AddPointOnLine), true
+	case *PointOnCircleConstraint:
+		return carryPointCurve(m, v.P, v.C, g.AddPointOnCircle), true
+	case *SymmetryConstraint:
+		return carrySymmetry(m, v, g), true
+	case *FixConstraint:
+		return carryFix(m, v.P, g), true
+	}
+	return false, false
+}
+
+// carryLineCurveConstraint handles the geometric constraints whose operands are whole lines or
+// circular curves, returning whether the constraint was carried (false for any other kind).
+func carryLineCurveConstraint(g *GeometricConstraints, c Constraint, m *cloneMap) bool {
+	switch v := c.(type) {
+	case *ParallelConstraint:
+		return carryLines(m, v.L1, v.L2, g.AddParallel)
+	case *PerpendicularConstraint:
+		return carryLines(m, v.L1, v.L2, g.AddPerpendicular)
+	case *CollinearConstraint:
+		return carryLines(m, v.L1, v.L2, g.AddCollinear)
+	case *EqualLengthConstraint:
+		return carryLines(m, v.L1, v.L2, g.AddEqualLength)
+	case *ConcentricConstraint:
+		return carryCurves(m, v.C1, v.C2, g.AddConcentric)
+	case *EqualRadiusConstraint:
+		return carryCurves(m, v.C1, v.C2, g.AddEqualRadius)
+	case *CircularTangentConstraint:
+		return carryCurves(m, v.C1, v.C2, g.AddCircularTangent)
+	case *TangentConstraint:
+		return carryLineCurve(m, v.L, v.C, g.AddTangent)
+	default:
+		return false
+	}
+}
+
+// The carry* helpers remap a fixed operand shape and invoke the matching factory iff every
+// operand is inside the copied set. The factory's return value is discarded — the relation is
+// already registered by Add — so they are generic over it (R).
+
+func carryPoints[R any](m *cloneMap, a, b *Point, add func(*Point, *Point) R) bool {
+	na, ok1 := m.point(a)
+	nb, ok2 := m.point(b)
+	if !ok1 || !ok2 {
+		return false
+	}
+	add(na, nb)
+	return true
+}
+
+func carryPointLine[R any](m *cloneMap, p *Point, l *Line, add func(*Point, *Line) R) bool {
+	np, ok1 := m.point(p)
+	nl, ok2 := m.line(l)
+	if !ok1 || !ok2 {
+		return false
+	}
+	add(np, nl)
+	return true
+}
+
+func carryPointCurve[R any](m *cloneMap, p *Point, c CircularCurve, add func(*Point, CircularCurve) R) bool {
+	np, ok1 := m.point(p)
+	nc, ok2 := m.curve(c)
+	if !ok1 || !ok2 {
+		return false
+	}
+	add(np, nc)
+	return true
+}
+
+func carryLines[R any](m *cloneMap, l1, l2 *Line, add func(*Line, *Line) R) bool {
+	n1, ok1 := m.line(l1)
+	n2, ok2 := m.line(l2)
+	if !ok1 || !ok2 {
+		return false
+	}
+	add(n1, n2)
+	return true
+}
+
+func carryCurves[R any](m *cloneMap, c1, c2 CircularCurve, add func(CircularCurve, CircularCurve) R) bool {
+	n1, ok1 := m.curve(c1)
+	n2, ok2 := m.curve(c2)
+	if !ok1 || !ok2 {
+		return false
+	}
+	add(n1, n2)
+	return true
+}
+
+func carryLineCurve[R any](m *cloneMap, l *Line, c CircularCurve, add func(*Line, CircularCurve) R) bool {
+	nl, ok1 := m.line(l)
+	nc, ok2 := m.curve(c)
+	if !ok1 || !ok2 {
+		return false
+	}
+	add(nl, nc)
+	return true
+}
+
+func carrySymmetry(m *cloneMap, c *SymmetryConstraint, g *GeometricConstraints) bool {
+	a, ok1 := m.point(c.A)
+	b, ok2 := m.point(c.B)
+	about, ok3 := m.line(c.About)
+	if !ok1 || !ok2 || !ok3 {
+		return false
+	}
+	g.AddSymmetry(a, b, about)
+	return true
+}
+
+func carryFix(m *cloneMap, p *Point, g *GeometricConstraints) bool {
+	np, ok := m.point(p)
+	if !ok {
+		return false
+	}
+	g.AddFix(np)
+	return true
+}
+
+// carryDimension re-creates one source dimension on this (target) sketch, preserving its
+// expression, driven/driving role and any drive limits. Returns whether it was carried.
+func (target *Sketch) carryDimension(d *DimensionConstraint, m *cloneMap) bool {
+	nd, ok := target.recreateDimension(d, m)
+	if !ok {
+		return false
+	}
+	nd.SetDriven(d.driven)
+	if d.limits.Enabled {
+		nd.SetLimits(d.limits.Min, d.limits.Max)
+	}
+	return true
+}
+
+// recreateDimension remaps the source dimension's refs to their clones and calls the matching
+// factory with the source expression. A dimension whose refs are not all inside the copied set,
+// or a kind that is not a 2D dimension (the 3D kinds), is dropped (nil, false). The dispatch is
+// split into the core and advanced kinds to keep each switch within the complexity bound; both
+// "wrong kind" and "external operand" yield (nil, false), so the only success signal is (nd, true).
+func (target *Sketch) recreateDimension(d *DimensionConstraint, m *cloneMap) (*DimensionConstraint, bool) {
+	if nd, ok := target.recreateCoreDimension(d, m); ok {
+		return nd, true
+	}
+	return target.recreateAdvancedDimension(d, m)
+}
+
+// recreateCoreDimension handles the original M21 dimension kinds (distance, angle, radius,
+// diameter, arc length).
+func (target *Sketch) recreateCoreDimension(d *DimensionConstraint, m *cloneMap) (*DimensionConstraint, bool) {
+	dc := target.dimCons
+	expr := d.param.Expression()
+	switch d.kind {
+	case DistanceDim:
+		if a, b, ok := m.refPoints2(d.refs); ok {
+			return added(dc.AddDistance(a, b, expr))
+		}
+	case AngleDim:
+		if l1, l2, ok := m.refLines2(d.refs); ok {
+			return added(dc.AddAngle(l1, l2, expr))
+		}
+	case RadiusDim:
+		if c, ok := m.refCurve(d.refs); ok {
+			return added(dc.AddRadius(c, expr))
+		}
+	case DiameterDim:
+		if c, ok := m.refCurve(d.refs); ok {
+			return added(dc.AddDiameter(c, expr))
+		}
+	case ArcLengthDim:
+		if a, ok := m.refArc(d.refs); ok {
+			return added(dc.AddArcLength(a, expr))
+		}
+	}
+	return nil, false
+}
+
+// recreateAdvancedDimension handles the M21-F07/#152 dimension kinds (offset, three-point angle,
+// ellipse radius, tangent distance).
+func (target *Sketch) recreateAdvancedDimension(d *DimensionConstraint, m *cloneMap) (*DimensionConstraint, bool) {
+	dc := target.dimCons
+	expr := d.param.Expression()
+	switch d.kind {
+	case OffsetDim:
+		if p, l, ok := m.refPointLine(d.refs); ok {
+			return added(dc.AddOffsetDim(p, l, expr))
+		}
+	case ThreePointAngleDim:
+		if vx, a, b, ok := m.refPoints3(d.refs); ok {
+			return added(dc.AddThreePointAngle(vx, a, b, expr))
+		}
+	case EllipseRadiusDim:
+		if e, ok := m.refEllipse(d.refs); ok {
+			return added(dc.AddEllipseRadius(e, expr))
+		}
+	case TangentDistanceDim:
+		if l, c, ok := m.refLineCurve(d.refs); ok {
+			return added(dc.AddTangentDistance(l, c, d.farSide, expr))
+		}
+	}
+	return nil, false
+}
+
+// added adapts a (dimension, error) factory result: a creation error (e.g. an expression that
+// references a parameter absent in the target) drops the dimension rather than failing the copy.
+func added(d *DimensionConstraint, err error) (*DimensionConstraint, bool) {
+	if err != nil {
+		return nil, false
+	}
+	return d, true
+}
+
+// The ref* helpers extract a dimension's typed operands from its []Entity refs and remap each
+// to its clone, reporting false when any is the wrong type or outside the copied set.
+
+func (m *cloneMap) refPoint(e Entity) (*Point, bool) {
+	p, ok := e.(*Point)
+	if !ok {
+		return nil, false
+	}
+	return m.point(p)
+}
+
+func (m *cloneMap) refPoints2(refs []Entity) (*Point, *Point, bool) {
+	if len(refs) != 2 {
+		return nil, nil, false
+	}
+	a, ok1 := m.refPoint(refs[0])
+	b, ok2 := m.refPoint(refs[1])
+	return a, b, ok1 && ok2
+}
+
+func (m *cloneMap) refPoints3(refs []Entity) (*Point, *Point, *Point, bool) {
+	if len(refs) != 3 {
+		return nil, nil, nil, false
+	}
+	a, ok1 := m.refPoint(refs[0])
+	b, ok2 := m.refPoint(refs[1])
+	c, ok3 := m.refPoint(refs[2])
+	return a, b, c, ok1 && ok2 && ok3
+}
+
+func (m *cloneMap) refLines2(refs []Entity) (*Line, *Line, bool) {
+	if len(refs) != 2 {
+		return nil, nil, false
+	}
+	l1, ok1 := refLine(m, refs[0])
+	l2, ok2 := refLine(m, refs[1])
+	return l1, l2, ok1 && ok2
+}
+
+func (m *cloneMap) refPointLine(refs []Entity) (*Point, *Line, bool) {
+	if len(refs) != 2 {
+		return nil, nil, false
+	}
+	p, ok1 := m.refPoint(refs[0])
+	l, ok2 := refLine(m, refs[1])
+	return p, l, ok1 && ok2
+}
+
+func (m *cloneMap) refLineCurve(refs []Entity) (*Line, CircularCurve, bool) {
+	if len(refs) != 2 {
+		return nil, nil, false
+	}
+	l, ok1 := refLine(m, refs[0])
+	c, ok2 := refCurve(m, refs[1])
+	return l, c, ok1 && ok2
+}
+
+func (m *cloneMap) refCurve(refs []Entity) (CircularCurve, bool) {
+	if len(refs) != 1 {
+		return nil, false
+	}
+	return refCurve(m, refs[0])
+}
+
+func (m *cloneMap) refArc(refs []Entity) (*Arc, bool) {
+	if len(refs) != 1 {
+		return nil, false
+	}
+	a, ok := refs[0].(*Arc)
+	if !ok {
+		return nil, false
+	}
+	return m.arc(a)
+}
+
+func (m *cloneMap) refEllipse(refs []Entity) (*Ellipse, bool) {
+	if len(refs) != 1 {
+		return nil, false
+	}
+	e, ok := refs[0].(*Ellipse)
+	if !ok {
+		return nil, false
+	}
+	return m.ellipse(e)
+}
+
+func refLine(m *cloneMap, e Entity) (*Line, bool) {
+	l, ok := e.(*Line)
+	if !ok {
+		return nil, false
+	}
+	return m.line(l)
+}
+
+func refCurve(m *cloneMap, e Entity) (CircularCurve, bool) {
+	c, ok := e.(CircularCurve)
+	if !ok {
+		return nil, false
+	}
+	return m.curve(c)
+}

--- a/model/sketch/copy_constraints_test.go
+++ b/model/sketch/copy_constraints_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// TestCopyCarriesInternalConstraintAndDimension: copying a line whose horizontal constraint and
+// distance dimension both reference only that line carries both onto the target, and the copy
+// stays solvable there (#1083 — #151's second acceptance criterion).
+func TestCopyCarriesInternalConstraintAndDimension(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	l := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(40, 0))
+	src.GeometricConstraints().AddHorizontal(l.A, l.B)
+	if _, err := src.DimensionConstraints().AddDistance(l.A, l.B, "40 mm"); err != nil {
+		t.Fatalf("source dimension: %v", err)
+	}
+
+	dst := NewSketches().Add(XYPlane())
+	clones := dst.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(0, 50))
+	if len(clones) != 1 {
+		t.Fatalf("clones = %d, want 1", len(clones))
+	}
+	if got := dst.GeometricConstraints().Count(); got != 1 {
+		t.Errorf("carried geometric constraints = %d, want 1", got)
+	}
+	if got := dst.DimensionConstraints().Count(); got != 1 {
+		t.Errorf("carried dimensions = %d, want 1", got)
+	}
+	if res := dst.Solve(); !res.Converged {
+		t.Errorf("copied sketch did not solve: %+v", res)
+	}
+}
+
+// TestCopyDropsConstraintWithExternalOperand: a parallel constraint references two lines; copying
+// only one of them drops the constraint (external operand), but copying both carries it (#1083).
+func TestCopyDropsConstraintWithExternalOperand(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	l1 := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(40, 0))
+	l2 := src.Lines().AddByTwoPoints(math.P2(0, 10), math.P2(40, 10))
+	src.GeometricConstraints().AddParallel(l1, l2)
+
+	only := NewSketches().Add(XYPlane())
+	only.CopyEntitiesWithConstraints(src, []Entity{l1}, math.V2(0, 0))
+	if got := only.GeometricConstraints().Count(); got != 0 {
+		t.Errorf("constraint with an external operand carried = %d, want 0 (dropped)", got)
+	}
+
+	both := NewSketches().Add(XYPlane())
+	both.CopyEntitiesWithConstraints(src, []Entity{l1, l2}, math.V2(0, 0))
+	if got := both.GeometricConstraints().Count(); got != 1 {
+		t.Errorf("constraint with both operands copied carried = %d, want 1", got)
+	}
+}
+
+// TestCopyDimensionMintsFreshParameter: when source and target share a parameter store (as the
+// sketches of one part do), a copied driving dimension takes a fresh name rather than colliding
+// with the source's, and keeps its expression (#1083).
+func TestCopyDimensionMintsFreshParameter(t *testing.T) {
+	store := param.NewParameters()
+	src := NewSketches().Add(XYPlane())
+	src.SetParameters(store)
+	dst := NewSketches().Add(XYPlane())
+	dst.SetParameters(store)
+
+	l := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(40, 0))
+	d, err := src.DimensionConstraints().AddDistance(l.A, l.B, "40 mm")
+	if err != nil {
+		t.Fatalf("source dimension: %v", err)
+	}
+	srcName := d.Parameter().Name()
+
+	dst.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(0, 50))
+	if dst.DimensionConstraints().Count() != 1 {
+		t.Fatalf("carried dimensions = %d, want 1", dst.DimensionConstraints().Count())
+	}
+	nd := dst.DimensionConstraints().Item(0)
+	if nd.Parameter().Name() == srcName {
+		t.Errorf("copied dimension reused source parameter name %q; want a fresh one", srcName)
+	}
+	if got := nd.Parameter().Expression(); got != "40 mm" {
+		t.Errorf("copied dimension expression = %q, want %q", got, "40 mm")
+	}
+}
+
+// TestCopyCarriesEveryConstraintAndDimensionKind builds a sketch holding one of every carryable
+// 2D geometric constraint and dimension kind, then copies the whole sketch: each relation's
+// operands are inside the copied set, so all carry over (#1083). This exercises every carry path
+// and dimension-dispatch branch.
+func TestCopyCarriesEveryConstraintAndDimensionKind(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	g := src.GeometricConstraints()
+	dc := src.DimensionConstraints()
+
+	pa := src.Points().Add(math.P2(0, 0))
+	pb := src.Points().Add(math.P2(1, 0))
+	l1 := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	l2 := src.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(4, 1))
+	l3 := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 4))
+	c1 := src.Circles().Add(src.Points().Add(math.P2(2, 2)), 1)
+	c2 := src.Circles().Add(src.Points().Add(math.P2(5, 2)), 1)
+	arc := src.Arcs().Add(src.Points().Add(math.P2(8, 0)), src.Points().Add(math.P2(9, 0)), src.Points().Add(math.P2(8, 1)), true)
+	ell := src.Ellipses().AddWithCenter(src.Points().Add(math.P2(12, 0)), math.V2(1, 0), 2, 1)
+
+	g.AddCoincident(pa, pb)
+	g.AddHorizontal(l1.A, l1.B)
+	g.AddVertical(l3.A, l3.B)
+	g.AddMidpoint(pa, l1)
+	g.AddPointOnLine(pb, l2)
+	g.AddPointOnCircle(pa, c1)
+	g.AddParallel(l1, l2)
+	g.AddPerpendicular(l1, l3)
+	g.AddCollinear(l1, l2)
+	g.AddEqualLength(l1, l2)
+	g.AddConcentric(c1, c2)
+	g.AddEqualRadius(c1, c2)
+	g.AddCircularTangent(c1, c2)
+	g.AddTangent(l1, c1)
+	g.AddSymmetry(pa, pb, l3)
+	g.AddFix(pa)
+
+	// add spreads a (dimension, error) factory result, failing fast on a build error.
+	add := func(_ *DimensionConstraint, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("source dimension: %v", err)
+		}
+	}
+	add(dc.AddDistance(pa, pb, "1 mm"))
+	add(dc.AddAngle(l1, l3, "90 deg"))
+	add(dc.AddRadius(c1, "1 mm"))
+	add(dc.AddDiameter(c2, "2 mm"))
+	add(dc.AddArcLength(arc, "1 mm"))
+	add(dc.AddOffsetDim(pa, l2, "1 mm"))
+	add(dc.AddThreePointAngle(pa, pb, l1.B, "45 deg"))
+	add(dc.AddEllipseRadius(ell, "2 mm"))
+	add(dc.AddTangentDistance(l1, c1, false, "1 mm"))
+
+	wantC, wantD := g.Count(), dc.Count()
+
+	dst := NewSketches().Add(XYPlane())
+	dst.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(100, 0))
+	if got := dst.GeometricConstraints().Count(); got != wantC {
+		t.Errorf("carried geometric constraints = %d, want %d (every kind)", got, wantC)
+	}
+	if got := dst.DimensionConstraints().Count(); got != wantD {
+		t.Errorf("carried dimensions = %d, want %d (every kind)", got, wantD)
+	}
+}
+
+// TestCopyDropsDimensionWithExternalOperand: a distance dimension between a copied line's
+// endpoint and a point left behind is silently dropped (#1083 — the dimension acceptance case).
+func TestCopyDropsDimensionWithExternalOperand(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	l := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(40, 0))
+	outside := src.Points().Add(math.P2(40, 30))
+	if _, err := src.DimensionConstraints().AddDistance(l.A, outside, "50 mm"); err != nil {
+		t.Fatalf("source dimension: %v", err)
+	}
+
+	dst := NewSketches().Add(XYPlane())
+	dst.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(0, 0)) // copy the line, not the point
+	if got := dst.DimensionConstraints().Count(); got != 0 {
+		t.Errorf("dimension with an external operand carried = %d, want 0 (dropped)", got)
+	}
+}
+
+// TestCopyDimensionPreservesDrivenAndLimits: a copied dimension keeps its driven role and any
+// drive limits (#1083).
+func TestCopyDimensionPreservesDrivenAndLimits(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	l := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(40, 0))
+	d, err := src.DimensionConstraints().AddDistance(l.A, l.B, "40 mm")
+	if err != nil {
+		t.Fatalf("source dimension: %v", err)
+	}
+	d.SetDriven(true)
+	d.SetLimits(10, 80)
+
+	dst := NewSketches().Add(XYPlane())
+	dst.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(0, 50))
+	nd := dst.DimensionConstraints().Item(0)
+	if !nd.Driven() {
+		t.Error("copied dimension lost its driven role")
+	}
+	if lim := nd.Limits(); !lim.Enabled || lim.Min != 10 || lim.Max != 80 {
+		t.Errorf("copied dimension limits = %+v, want {10 80 true}", lim)
+	}
+}
+
+// TestCopyCarriesCurveAndAngleRelations exercises the curve- and line-pair carry paths:
+// concentric circles and an angle dimension between two lines all survive a whole-sketch copy
+// (#1083).
+func TestCopyCarriesCurveAndAngleRelations(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	c1 := src.Circles().Add(src.Points().Add(math.P2(0, 0)), 5)
+	c2 := src.Circles().Add(src.Points().Add(math.P2(0, 0)), 9)
+	src.GeometricConstraints().AddConcentric(c1, c2)
+	src.GeometricConstraints().AddEqualRadius(c1, c2)
+
+	l1 := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(10, 0))
+	l2 := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 10))
+	if _, err := src.DimensionConstraints().AddAngle(l1, l2, "90 deg"); err != nil {
+		t.Fatalf("source angle dimension: %v", err)
+	}
+
+	dst := NewSketches().Add(XYPlane())
+	dst.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(100, 0))
+	if got := dst.GeometricConstraints().Count(); got != 2 {
+		t.Errorf("carried geometric constraints = %d, want 2 (concentric + equal-radius)", got)
+	}
+	if got := dst.DimensionConstraints().Count(); got != 1 {
+		t.Errorf("carried dimensions = %d, want 1 (angle)", got)
+	}
+}

--- a/model/sketch/edit_ops.go
+++ b/model/sketch/edit_ops.go
@@ -151,7 +151,17 @@ func (s *Sketch) cloneEntities(ents []Entity, a affine2) []Entity {
 // cloneEntitiesMapped is cloneEntities that also returns the seed→clone point map, so
 // a caller (a parametric pattern) can link each clone point back to its seed.
 func (s *Sketch) cloneEntitiesMapped(ents []Entity, a affine2) ([]Entity, map[*Point]*Point) {
+	out, pmap, _ := s.cloneEntitiesFull(ents, a)
+	return out, pmap
+}
+
+// cloneEntitiesFull is cloneEntitiesMapped that additionally returns the seed→clone entity
+// map, so the constraint/dimension carry-over (#1083) can decide which relations are wholly
+// inside the copied set and remap their operands. Points are tracked separately (a constraint
+// references a point that may be shared by several entities, so the point map is the finer key).
+func (s *Sketch) cloneEntitiesFull(ents []Entity, a affine2) ([]Entity, map[*Point]*Point, map[Entity]Entity) {
 	pmap := map[*Point]*Point{}
+	emap := map[Entity]Entity{}
 	mapped := func(p *Point) *Point {
 		if np, ok := pmap[p]; ok {
 			return np
@@ -163,10 +173,11 @@ func (s *Sketch) cloneEntitiesMapped(ents []Entity, a affine2) ([]Entity, map[*P
 	out := make([]Entity, 0, len(ents))
 	for _, e := range ents {
 		if c := s.cloneEntity(e, mapped, a); c != nil {
+			emap[e] = c
 			out = append(out, c)
 		}
 	}
-	return out, pmap
+	return out, pmap, emap
 }
 
 // cloneEntity duplicates one entity, resolving its points through mapped and transforming


### PR DESCRIPTION
## What
`sketch.copyTo` now carries over the geometric constraints and dimensions whose operands are **entirely within the copied set**, remapping them onto the clones and silently dropping any relation that references geometry left behind — matching Inventor's `CopyEntitiesTo`. Previously only geometry was copied (#151 v1).

New `Sketch.CopyEntitiesWithConstraints(source, ents, v)` does the carry-over on top of the existing clone machinery; `cloneEntitiesFull` now also returns the source→clone **entity** map (next to the point map) so membership can be decided and operands remapped. A copied driving dimension mints a **fresh parameter** via the target's `nextName` (no collision in a shared part store), and keeps its driven role + drive limits.

Coverage: all 16 carryable 2D geometric constraints and all 9 planar dimension kinds.

## Why
Completes #151's second acceptance criterion — *copied dimensions stay solvable in the target sketch* — and drops external-reference relations cleanly.

## Acceptance (#1083)
- ✅ Constraints/dimensions with every operand inside the set are copied (remapped).
- ✅ A constraint or dimension referencing un-copied geometry is silently dropped.
- ✅ A copied driving dimension creates a fresh parameter (target's nextName).
- ✅ The copied sketch solves in the target.

## Tests
- `model/sketch/copy_constraints_test.go`: carry internal constraint+dimension & solve; drop external constraint; drop external dimension; fresh parameter name in a shared store; preserve driven+limits; every constraint/dimension kind; curve/angle relations.
- `addin/router/sketch_copy_test.go`: end-to-end wire carry-over (parallel + radius) with fresh names; subset copy drops the external constraint.

## API
No DTO/method change. The stale `CopySketchResult` doc in Oblikovati.API is corrected in Oblikovati/Oblikovati.API#196 (docs-only, no version bump); this PR builds against the current `v0.76.1` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)