### PR TITLE
Feature lifecycle events for UI-driven ops (#1085)

### DIFF
--- a/addin/router/feature_events.go
+++ b/addin/router/feature_events.go
@@ -5,30 +5,13 @@ package router
 import (
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/app"
-	"oblikovati.org/event"
-	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 )
 
-// emitFeatureLifecycle publishes a granular feature-lifecycle notification (#148) on the session
-// bus, so the add-in event relay forwards feature.added/edited/deleted. v1 scope is the host method
-// router (features.add/edit/delete), matching edit.committed (ADR-0004) — the batched model.changed
-// remains the coarse signal that also covers UI-driven paths.
-func emitFeatureLifecycle(s *app.Session, op app.FeatureOp, f *feature.PartFeature) {
-	if f == nil {
-		return
-	}
-	var docID doc.ID
-	if active := s.ActiveDocument(); active != nil {
-		docID = active.ID()
-	}
-	event.Emit(s.Events(), event.After, app.FeatureLifecycleChanged{
-		Document: docID, Op: op, Feature: uint64(f.ID()), Name: f.Name(), Kind: f.Kind(),
-	})
-}
-
 // lastPartFeature returns the active part's most recently added feature, or nil — the feature a
 // successful features.add just appended (every part-feature op appends one feature at the end).
+// The features.add handler passes it to Session.EmitFeatureLifecycle so the add-in relay forwards
+// feature.added for the programmatic path, alongside the UI path's tool-commit emit (#1085).
 func lastPartFeature(s *app.Session) *feature.PartFeature {
 	part, err := modelaccess.ActivePart(s)
 	if err != nil || part == nil {

--- a/addin/router/feature_lifecycle.go
+++ b/addin/router/feature_lifecycle.go
@@ -106,10 +106,9 @@ func editFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := planAndApplyFeatureEdits(part, f, in); err != nil {
 		return nil, err
 	}
-	if err := s.CommitFeatureEdit(f); err != nil {
+	if err := s.CommitFeatureEdit(f); err != nil { // emits feature.edited (#1085)
 		return nil, err
 	}
-	emitFeatureLifecycle(s, app.FeatureEdited, f) // feature.edited (#148)
 	return featureDetailReply(part, f, idx)
 }
 
@@ -156,10 +155,9 @@ func deleteFeature(s *app.Session, raw json.RawMessage) (json.RawMessage, error)
 		return nil, err
 	}
 	id := uint64(f.ID())
-	if err := s.DeleteFeature(f); err != nil {
+	if err := s.DeleteFeature(f); err != nil { // emits feature.deleted (#1085)
 		return nil, err
 	}
-	emitFeatureLifecycle(s, app.FeatureDeleted, f) // feature.deleted (#148); f still holds its identity
 	return json.Marshal(wire.DeleteFeatureResult{ID: id, Deleted: true})
 }
 

--- a/addin/router/features.go
+++ b/addin/router/features.go
@@ -39,6 +39,6 @@ func (r *Router) addFeature(s *app.Session, raw json.RawMessage) (json.RawMessag
 	if err != nil {
 		return nil, err
 	}
-	emitFeatureLifecycle(s, app.FeatureAdded, lastPartFeature(s)) // feature.added (#148)
+	s.EmitFeatureLifecycle(app.FeatureAdded, lastPartFeature(s)) // feature.added (#1085)
 	return out, nil
 }

--- a/app/browser_actions.go
+++ b/app/browser_actions.go
@@ -82,6 +82,7 @@ func (s *Session) DeleteFeature(f *feature.PartFeature) error {
 	s.selection.Clear()
 	part.Recompute()
 	s.recordEdit(part, "Delete Feature")
+	s.EmitFeatureLifecycle(FeatureDeleted, f) // featureDeleted (#1085); f still holds its identity
 	return nil
 }
 

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -53,6 +53,7 @@ func commitFeatureEdit(s *Session, f *feature.PartFeature) error {
 	part.Features().MarkDirty(f)
 	part.Recompute()
 	s.recordEdit(part, "Edit "+f.Name())
+	s.EmitFeatureLifecycle(FeatureEdited, f) // featureEdited for UI-driven edits (#1085)
 	s.Selection().SetFilter(NewSelectionFilter())
 	if !f.Health().OK() {
 		return errors.New("feature edit: " + f.Health().Reason)

--- a/app/feature_lifecycle.go
+++ b/app/feature_lifecycle.go
@@ -101,5 +101,6 @@ func (s *Session) CommitFeatureEdit(f *feature.PartFeature) error {
 	part.Features().MarkDirty(f)
 	part.Recompute()
 	s.recordEdit(part, "Edit Feature")
+	s.EmitFeatureLifecycle(FeatureEdited, f) // featureEdited (#1085)
 	return nil
 }

--- a/app/modeling_events.go
+++ b/app/modeling_events.go
@@ -5,6 +5,7 @@ package app
 import (
 	"oblikovati.org/event"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
 )
 
 // Modeling/sketch event type ids (#148): the granular feature-lifecycle and sketch-edit
@@ -57,4 +58,30 @@ func (s *Session) emitSketchEdit(seq uint64, name string, entered bool) {
 		d = active.ID()
 	}
 	event.Emit(s.bus, event.After, SketchEditChanged{Document: d, Entered: entered, Sketch: seq, Name: name})
+}
+
+// EmitFeatureLifecycle publishes a granular feature-lifecycle notification (#1085) on the
+// session bus, keyed to the active document, so the add-in event relay forwards
+// feature.added/edited/deleted for UI- and add-in-driven feature ops alike (lifting #148's
+// router-only v1 scope). It is the single emit seam the session-level feature ops and the host
+// method router both call. A nil feature is a no-op — a producer tool that built nothing.
+func (s *Session) EmitFeatureLifecycle(op FeatureOp, f *feature.PartFeature) {
+	if f == nil {
+		return
+	}
+	var d doc.ID
+	if active := s.ActiveDocument(); active != nil {
+		d = active.ID()
+	}
+	event.Emit(s.bus, event.After, FeatureLifecycleChanged{
+		Document: d, Op: op, Feature: uint64(f.ID()), Name: f.Name(), Kind: f.Kind(),
+	})
+}
+
+// featureProducer is implemented by the tools that create a part feature; AddedFeature returns
+// the feature they just appended (nil before commit). The tool-commit seam (Session.OK) reads it
+// to fire featureAdded for UI-driven creation (#1085), so every add-tool emits without each one
+// wiring the event itself.
+type featureProducer interface {
+	AddedFeature() *feature.PartFeature
 }

--- a/app/modeling_events_test.go
+++ b/app/modeling_events_test.go
@@ -6,8 +6,104 @@ import (
 	"testing"
 
 	"oblikovati.org/event"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
+
+// collectFeatureEvents subscribes to FeatureLifecycleChanged on the session bus and returns a
+// pointer to the growing slice of events seen.
+func collectFeatureEvents(s *Session) *[]FeatureLifecycleChanged {
+	var got []FeatureLifecycleChanged
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e FeatureLifecycleChanged) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+	return &got
+}
+
+// fakeAddTool is a producer tool: its AddedFeature reports the feature it "created", so the
+// tool-commit seam fires featureAdded.
+type fakeAddTool struct {
+	dialogTool
+	added *feature.PartFeature
+}
+
+func (fakeAddTool) Name() string                          { return "Fake Add" }
+func (fakeAddTool) CanCommit() bool                       { return true }
+func (fakeAddTool) Commit(*Session) error                 { return nil }
+func (t *fakeAddTool) AddedFeature() *feature.PartFeature { return t.added }
+
+// fakePlainTool is a non-producer tool (no AddedFeature) — committing it must emit nothing.
+type fakePlainTool struct{ dialogTool }
+
+func (fakePlainTool) Name() string          { return "Fake Plain" }
+func (fakePlainTool) CanCommit() bool       { return true }
+func (fakePlainTool) Commit(*Session) error { return nil }
+
+// TestToolCommitEmitsFeatureAdded: committing a producer tool through Session.OK fires a single
+// FeatureAdded carrying the created feature's identity (#1085, the UI-driven creation path).
+func TestToolCommitEmitsFeatureAdded(t *testing.T) {
+	s, def := emptyPartSession(t)
+	f := feature.NewHullFeatures(def.Features()).Add()
+	got := collectFeatureEvents(s)
+
+	s.StartTool(&fakeAddTool{added: f})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].Op != FeatureAdded || (*got)[0].Feature != uint64(f.ID()) {
+		t.Fatalf("events = %+v, want one FeatureAdded for feature %d", *got, f.ID())
+	}
+}
+
+// TestNonProducerToolCommitEmitsNothing: a tool without AddedFeature emits no feature-lifecycle
+// event when committed, and neither does a producer that built nothing (nil feature) (#1085).
+func TestNonProducerToolCommitEmitsNothing(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	got := collectFeatureEvents(s)
+
+	s.StartTool(fakePlainTool{})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK plain: %v", err)
+	}
+	s.StartTool(&fakeAddTool{added: nil})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK nil-producer: %v", err)
+	}
+	if len(*got) != 0 {
+		t.Errorf("emitted %d feature events for non-producing commits, want 0: %+v", len(*got), *got)
+	}
+}
+
+// TestDeleteFeatureEmitsFeatureDeleted: Session.DeleteFeature (UI browser + router) fires a single
+// FeatureDeleted carrying the removed feature's identity (#1085).
+func TestDeleteFeatureEmitsFeatureDeleted(t *testing.T) {
+	s, def := emptyPartSession(t)
+	f := feature.NewHullFeatures(def.Features()).Add()
+	got := collectFeatureEvents(s)
+
+	if err := s.DeleteFeature(f); err != nil {
+		t.Fatalf("DeleteFeature: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].Op != FeatureDeleted || (*got)[0].Feature != uint64(f.ID()) {
+		t.Fatalf("events = %+v, want one FeatureDeleted for feature %d", *got, f.ID())
+	}
+}
+
+// TestCommitFeatureEditEmitsFeatureEdited: Session.CommitFeatureEdit (router/freeform edit seam)
+// fires a single FeatureEdited carrying the edited feature's identity (#1085).
+func TestCommitFeatureEditEmitsFeatureEdited(t *testing.T) {
+	s, def := emptyPartSession(t)
+	f := feature.NewHullFeatures(def.Features()).Add()
+	got := collectFeatureEvents(s)
+
+	if err := s.CommitFeatureEdit(f); err != nil {
+		t.Fatalf("CommitFeatureEdit: %v", err)
+	}
+	if len(*got) != 1 || (*got)[0].Op != FeatureEdited || (*got)[0].Feature != uint64(f.ID()) {
+		t.Fatalf("events = %+v, want one FeatureEdited for feature %d", *got, f.ID())
+	}
+}
 
 // TestEnterExitSketchEmitsSketchEdit: entering and leaving a 2D sketch each emit a
 // SketchEditChanged carrying the sketch identity, with Entered distinguishing them (#148).

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -54,6 +54,9 @@ func (s *Session) OK() error {
 		s.notice = err.Error() // surface why (the status bar shows it); keep the tool open
 		return err
 	}
+	if fp, ok := s.tool.tool.(featureProducer); ok {
+		s.EmitFeatureLifecycle(FeatureAdded, fp.AddedFeature()) // featureAdded for UI-driven creation (#1085)
+	}
 	s.notice = ""
 	s.tool = nil
 	s.Graphics().ClearInteraction() // a committed command's transient preview vanishes


### PR DESCRIPTION
## What
Granular feature events (`feature.added` / `feature.edited` / `feature.deleted`) now fire for **UI-driven** feature creation, editing, and deletion — not just the `features.add/edit/delete` router path. This lifts #148's router-only v1 scope and completes the `FeatureEvents` half of #1085. (The `SketchEvents` half — `sketchEditEntered/Exited` — already emits at the session level from #148.)

## How
`Session.EmitFeatureLifecycle(op, f)` is the single emit seam (the event bus lives on the session), keyed to the active document. It's called from the genuine **user-action** seams, which are never hit on document load / undo / replay (no event spam):

| Op | Seam | Covers |
|----|------|--------|
| added | `Session.OK` (the one tool-commit seam) when the tool implements `featureProducer` (`AddedFeature()`, on all 57 creation tools) | every UI create tool |
| added | `features.add` handler → `EmitFeatureLifecycle` | programmatic/MCP add |
| edited | `commitFeatureEdit` (UI) + `CommitFeatureEdit` (router/freeform) | all edit paths |
| deleted | `Session.DeleteFeature` | UI browser + router |

The relay (`addin/events`) already forwards `FeatureLifecycleChanged`, so no relay change was needed; the router's own emit helper is removed and its edit/delete handlers no longer double-emit.

### Edit-vs-add safety
A feature whose creation tool round-trips re-opens that **same** tool to edit it (e.g. editing an extrude re-opens `ExtrudeTool`). In edit mode the tool binds `target`, never sets `added`, and commits via `commitFeatureEdit` — so `AddedFeature()` returns nil, the nil-guard skips the add emit, and only `featureEdited` fires. `TestNonProducerToolCommitEmitsNothing` (with a nil-producer) pins this.

## Tests
`app/modeling_events_test.go`: tool-commit emits featureAdded; non-producer & nil-producer emit nothing; DeleteFeature emits featureDeleted; CommitFeatureEdit emits featureEdited. Existing `TestFeaturesAddEmitsFeatureAdded` (router) and the relay tests still pass against the session path.

## API
No DTO/method change. The stale `FeatureLifecycleEvent` v1-scope doc note is corrected in Oblikovati/Oblikovati.API#197 (docs-only, no version bump); this PR builds against the current pin.

## Note
Events have no visual surface, so validation is the in-proc + relay tests (not a live capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)