### PR TITLE
Point clouds: model + persistence + router (PR 1 of M17-F06, #645)

### DIFF
--- a/addin/router/point_clouds.go
+++ b/addin/router/point_clouds.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/pointcloud"
+)
+
+// Attached point clouds over the wire (M17-F06, #645): attach a scan file to the active part,
+// query and place the resulting cloud, and budget its display. The scan bytes are embedded in
+// the document resource table (ADR-0031) on attach, so the cloud round-trips in the .obk.
+
+// registerPointCloudHandlers wires the pointClouds.* methods.
+func (r *Router) registerPointCloudHandlers() {
+	r.handlers[wire.MethodPointCloudsAttach] = attachPointCloud
+	r.handlers[wire.MethodPointCloudsList] = listPointClouds
+	r.handlers[wire.MethodPointCloudsGet] = getPointCloud
+	r.handlers[wire.MethodPointCloudsDelete] = deletePointCloud
+	r.handlers[wire.MethodPointCloudsSetVisible] = setPointCloudVisible
+	r.handlers[wire.MethodPointCloudsSetTransform] = setPointCloudTransform
+	r.handlers[wire.MethodPointCloudsSetScale] = setPointCloudScale
+	r.handlers[wire.MethodPointCloudsSetDensity] = setPointCloudDensity
+	r.handlers[wire.MethodPointCloudsToModelSpace] = pointCloudToModelSpace
+	r.handlers[wire.MethodPointCloudsFromModelSpace] = pointCloudFromModelSpace
+}
+
+// attachPointCloud reads the scan file, embeds its bytes as a resource, decodes its points, and
+// attaches the cloud to the active part under a unique name.
+func attachPointCloud(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.AttachPointCloudArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	data, points, err := loadScan(in.FullFileName)
+	if err != nil {
+		return nil, err
+	}
+	name := in.Name
+	if name == "" {
+		name = part.PointClouds().UniqueName("Cloud")
+	}
+	rid := part.AddResource(doc.Resource{Type: "PointCloudScan", Encoding: doc.EncodingUTF8, Value: data, Origin: in.FullFileName})
+	pc, err := part.PointClouds().Add(name, in.FullFileName, rid, points)
+	if err != nil {
+		return nil, fmt.Errorf("pointClouds.attach: %w", err)
+	}
+	return json.Marshal(pointCloudInfo(pc))
+}
+
+// loadScan reads a scan file and decodes its cloud-local points, returning the raw bytes (for
+// embedding as a resource) alongside the points.
+func loadScan(fullFileName string) ([]byte, []math.Point3, error) {
+	if fullFileName == "" {
+		return nil, nil, fmt.Errorf("pointClouds.attach: fullFileName is required")
+	}
+	data, err := os.ReadFile(fullFileName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pointClouds.attach: read %q: %w", fullFileName, err)
+	}
+	points, err := pointcloud.ReadScan(fullFileName, data)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, points, nil
+}
+
+// listPointClouds enumerates the active part's clouds.
+func listPointClouds(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	clouds := part.PointClouds()
+	out := make([]wire.PointCloudInfo, 0, clouds.Count())
+	for i := 0; i < clouds.Count(); i++ {
+		out = append(out, pointCloudInfo(clouds.Item(i)))
+	}
+	return json.Marshal(wire.ListPointCloudsResult{PointClouds: out})
+}
+
+// getPointCloud returns one named cloud's state.
+func getPointCloud(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	pc, _, err := resolvePointCloud(s, raw, wire.MethodPointCloudsGet)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(pointCloudInfo(pc))
+}
+
+// deletePointCloud removes a named cloud from the active part.
+func deletePointCloud(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.PointCloudNameArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	deleted := part.PointClouds().Remove(in.Name)
+	return json.Marshal(wire.DeletePointCloudResult{Name: in.Name, Deleted: deleted})
+}
+
+// setPointCloudVisible shows or hides a named cloud.
+func setPointCloudVisible(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetPointCloudVisibleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Name, wire.MethodPointCloudsSetVisible)
+	if err != nil {
+		return nil, err
+	}
+	pc.SetVisible(in.Visible)
+	return json.Marshal(pointCloudInfo(pc))
+}
+
+// setPointCloudTransform sets a named cloud's placement.
+func setPointCloudTransform(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetPointCloudTransformArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Name, wire.MethodPointCloudsSetTransform)
+	if err != nil {
+		return nil, err
+	}
+	pc.SetTransform(math.Matrix4FromCells(in.Transform.Cells))
+	return json.Marshal(pointCloudInfo(pc))
+}
+
+// setPointCloudScale sets a named cloud's uniform scale, rejecting a non-positive factor.
+func setPointCloudScale(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetPointCloudScaleArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Name, wire.MethodPointCloudsSetScale)
+	if err != nil {
+		return nil, err
+	}
+	if !pc.SetScale(in.Scale) {
+		return nil, fmt.Errorf("pointClouds.setScale: scale must be positive, got %v", in.Scale)
+	}
+	return json.Marshal(pointCloudInfo(pc))
+}
+
+// setPointCloudDensity sets a named cloud's display budget.
+func setPointCloudDensity(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetPointCloudDensityArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Name, wire.MethodPointCloudsSetDensity)
+	if err != nil {
+		return nil, err
+	}
+	pc.SetMaximumPointCount(in.MaximumPointCount)
+	return json.Marshal(pointCloudInfo(pc))
+}
+
+// pointCloudToModelSpace maps a cloud-local point into model space.
+func pointCloudToModelSpace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	in, pc, err := pointCloudSpaceRequest(s, raw, wire.MethodPointCloudsToModelSpace)
+	if err != nil {
+		return nil, err
+	}
+	m := pc.ToModelSpace(point3Of(in.Point))
+	return json.Marshal(wire.PointCloudSpaceResult{Point: pointOf(m), OK: true})
+}
+
+// pointCloudFromModelSpace maps a model-space point into a cloud's local space.
+func pointCloudFromModelSpace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	in, pc, err := pointCloudSpaceRequest(s, raw, wire.MethodPointCloudsFromModelSpace)
+	if err != nil {
+		return nil, err
+	}
+	p, ok := pc.FromModelSpace(point3Of(in.Point))
+	return json.Marshal(wire.PointCloudSpaceResult{Point: pointOf(p), OK: ok})
+}
+
+// pointCloudSpaceRequest decodes a space-conversion request and resolves its cloud.
+func pointCloudSpaceRequest(s *app.Session, raw json.RawMessage, method string) (wire.PointCloudSpaceArgs, *pointcloud.PointCloud, error) {
+	var in wire.PointCloudSpaceArgs
+	if err := decode(raw, &in); err != nil {
+		return in, nil, err
+	}
+	pc, err := namedCloud(s, in.Name, method)
+	return in, pc, err
+}
+
+// resolvePointCloud decodes a name-only request and resolves its cloud on the active part.
+func resolvePointCloud(s *app.Session, raw json.RawMessage, method string) (*pointcloud.PointCloud, *compdef.PartComponentDefinition, error) {
+	var in wire.PointCloudNameArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, nil, err
+	}
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, nil, err
+	}
+	pc, ok := part.PointClouds().ByName(in.Name)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s: no point cloud named %q", method, in.Name)
+	}
+	return pc, part, nil
+}
+
+// namedCloud resolves a cloud by name on the active part.
+func namedCloud(s *app.Session, name, method string) (*pointcloud.PointCloud, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	pc, ok := part.PointClouds().ByName(name)
+	if !ok {
+		return nil, fmt.Errorf("%s: no point cloud named %q", method, name)
+	}
+	return pc, nil
+}
+
+// pointCloudInfo maps a cloud to its wire shape.
+func pointCloudInfo(pc *pointcloud.PointCloud) wire.PointCloudInfo {
+	return wire.PointCloudInfo{
+		Name:                pc.Name(),
+		Source:              pc.SourceFullFileName(),
+		Visible:             pc.Visible(),
+		Scale:               pc.Scale(),
+		Transform:           types.Matrix{Cells: pc.Transform().Cells()},
+		TotalPointCount:     pc.TotalPointCount(),
+		DisplayedPointCount: pc.DisplayedPointCount(),
+		MaximumPointCount:   pc.MaximumPointCount(),
+	}
+}
+
+// point3Of / pointOf bridge the wire point type and math.Point3.
+func point3Of(p types.Point) math.Point3 {
+	return math.P3(math.Scalar(p.X), math.Scalar(p.Y), math.Scalar(p.Z))
+}
+
+func pointOf(p math.Point3) types.Point {
+	return types.Point{X: float64(p.X), Y: float64(p.Y), Z: float64(p.Z)}
+}

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -92,6 +92,57 @@ func TestPointCloudPlacementAndBudget(t *testing.T) {
 	}
 }
 
+// TestPointCloudMissingNameErrors: every name-keyed operation errors when no cloud has the name,
+// exercising the not-found branches of each handler (#645).
+func TestPointCloudMissingNameErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	ops := []struct {
+		method string
+		args   string
+	}{
+		{"pointClouds.get", `{"name":"nope"}`},
+		{"pointClouds.setVisible", `{"name":"nope","visible":true}`},
+		{"pointClouds.setScale", `{"name":"nope","scale":2}`},
+		{"pointClouds.setDensity", `{"name":"nope","maximumPointCount":1}`},
+		{"pointClouds.setTransform", `{"name":"nope","transform":{"cells":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}}`},
+		{"pointClouds.toModelSpace", `{"name":"nope","point":{"x":0,"y":0,"z":0}}`},
+		{"pointClouds.fromModelSpace", `{"name":"nope","point":{"x":0,"y":0,"z":0}}`},
+	}
+	for _, op := range ops {
+		if _, err := r.Handle(s, op.method, []byte(op.args)); err == nil {
+			t.Errorf("%s on a missing cloud should fail", op.method)
+		}
+	}
+	// delete of a missing cloud is not an error — it reports Deleted=false.
+	var del wire.DeletePointCloudResult
+	call(t, r, s, "pointClouds.delete", `{"name":"nope"}`, &del)
+	if del.Deleted {
+		t.Error("delete of a missing cloud should report Deleted=false")
+	}
+}
+
+// TestPointCloudBadJSON: a malformed request body is rejected by the decode guard (#645).
+func TestPointCloudBadJSON(t *testing.T) {
+	r, s := emptyPartSession(t)
+	for _, m := range []string{"pointClouds.attach", "pointClouds.get", "pointClouds.setScale", "pointClouds.toModelSpace"} {
+		if _, err := r.Handle(s, m, []byte(`{`)); err == nil {
+			t.Errorf("%s with malformed JSON should fail", m)
+		}
+	}
+}
+
+// TestPointCloudUnreadableScan: attaching a file whose extension has no reader fails (#645).
+func TestPointCloudUnreadableScan(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := filepath.Join(t.TempDir(), "scan.las")
+	if err := os.WriteFile(path, []byte("binary"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := r.Handle(s, "pointClouds.attach", []byte(mustJSON(t, wire.AttachPointCloudArgs{FullFileName: path}))); err == nil {
+		t.Error("attach of an unsupported scan format should fail")
+	}
+}
+
 // TestPointCloudAttachErrors: a missing file and a non-positive scale are rejected (#645).
 func TestPointCloudAttachErrors(t *testing.T) {
 	r, s := emptyPartSession(t)

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// writeScan writes a small ASCII scan file and returns its path.
+func writeScan(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scan.xyz")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	return path
+}
+
+// TestPointCloudAttachListGetDelete: the full attach → list → get → delete flow over the wire,
+// with the cloud's point count and default state surfaced (M17-F06, #645).
+func TestPointCloudAttachListGetDelete(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := writeScan(t, "0 0 0\n1 0 0\n2 0 0\n3 0 0\n")
+
+	var attached wire.PointCloudInfo
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{FullFileName: path}), &attached)
+	if attached.Name != "Cloud1" || attached.TotalPointCount != 4 || !attached.Visible || attached.Scale != 1 {
+		t.Fatalf("attached = %+v, want Cloud1/4 pts/visible/scale 1", attached)
+	}
+
+	var list wire.ListPointCloudsResult
+	call(t, r, s, "pointClouds.list", `{}`, &list)
+	if len(list.PointClouds) != 1 || list.PointClouds[0].Name != "Cloud1" {
+		t.Errorf("list = %+v, want one Cloud1", list.PointClouds)
+	}
+
+	var got wire.PointCloudInfo
+	call(t, r, s, "pointClouds.get", `{"name":"Cloud1"}`, &got)
+	if got.TotalPointCount != 4 {
+		t.Errorf("get TotalPointCount = %d, want 4", got.TotalPointCount)
+	}
+
+	var del wire.DeletePointCloudResult
+	call(t, r, s, "pointClouds.delete", `{"name":"Cloud1"}`, &del)
+	if !del.Deleted {
+		t.Error("delete should report Deleted=true")
+	}
+	call(t, r, s, "pointClouds.list", `{}`, &list)
+	if len(list.PointClouds) != 0 {
+		t.Errorf("after delete, list = %+v, want empty", list.PointClouds)
+	}
+}
+
+// TestPointCloudPlacementAndBudget: setScale/setDensity/setVisible/setTransform mutate the cloud,
+// and the space-conversion methods round-trip a point through the placement (#645).
+func TestPointCloudPlacementAndBudget(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := writeScan(t, "0 0 0\n1 1 1\n2 2 2\n3 3 3\n4 4 4\n")
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &wire.PointCloudInfo{})
+
+	var info wire.PointCloudInfo
+	call(t, r, s, "pointClouds.setScale", `{"name":"Scan","scale":2}`, &info)
+	if info.Scale != 2 {
+		t.Errorf("scale = %v, want 2", info.Scale)
+	}
+	call(t, r, s, "pointClouds.setDensity", `{"name":"Scan","maximumPointCount":2}`, &info)
+	if info.MaximumPointCount != 2 || info.DisplayedPointCount != 2 {
+		t.Errorf("budget = max %d displayed %d, want 2/2", info.MaximumPointCount, info.DisplayedPointCount)
+	}
+	call(t, r, s, "pointClouds.setVisible", `{"name":"Scan","visible":false}`, &info)
+	if info.Visible {
+		t.Error("setVisible(false) should hide the cloud")
+	}
+
+	move := types.TranslationMatrix(types.Vector{X: 10, Y: 0, Z: 0})
+	call(t, r, s, "pointClouds.setTransform", mustJSON(t, wire.SetPointCloudTransformArgs{Name: "Scan", Transform: move}), &info)
+
+	// A cloud point (1,1,1) maps to model space scaled (×2) then translated (+10x) → (12,2,2).
+	var sp wire.PointCloudSpaceResult
+	call(t, r, s, "pointClouds.toModelSpace", mustJSON(t, wire.PointCloudSpaceArgs{Name: "Scan", Point: types.Point{X: 1, Y: 1, Z: 1}}), &sp)
+	if !sp.OK || sp.Point != (types.Point{X: 12, Y: 2, Z: 2}) {
+		t.Errorf("toModelSpace = %+v (ok=%v), want (12,2,2)", sp.Point, sp.OK)
+	}
+	call(t, r, s, "pointClouds.fromModelSpace", mustJSON(t, wire.PointCloudSpaceArgs{Name: "Scan", Point: sp.Point}), &sp)
+	if !sp.OK || sp.Point != (types.Point{X: 1, Y: 1, Z: 1}) {
+		t.Errorf("fromModelSpace round-trip = %+v (ok=%v), want (1,1,1)", sp.Point, sp.OK)
+	}
+}
+
+// TestPointCloudAttachErrors: a missing file and a non-positive scale are rejected (#645).
+func TestPointCloudAttachErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "pointClouds.attach", []byte(`{"fullFileName":"/no/such/scan.xyz"}`)); err == nil {
+		t.Error("attach of a missing file should fail")
+	}
+	path := writeScan(t, "0 0 0\n")
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "S", FullFileName: path}), &wire.PointCloudInfo{})
+	if _, err := r.Handle(s, "pointClouds.setScale", []byte(`{"name":"S","scale":0}`)); err == nil {
+		t.Error("setScale(0) should fail")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -43,6 +43,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerLightingHandlers()
 	r.registerGraphicsHandlers()
 	r.registerExchangeHandlers()
+	r.registerPointCloudHandlers()
 	r.registerFontHandlers()
 	r.registerAddInHandlers()
 	r.registerApplicationHandlers()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.77.0
+	oblikovati.org/api v0.78.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.77.0
+	oblikovati.org/api v0.78.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -13,6 +13,7 @@ import (
 	"oblikovati.org/model/identity"
 	"oblikovati.org/model/material"
 	"oblikovati.org/model/param"
+	"oblikovati.org/model/pointcloud"
 	"oblikovati.org/model/sheetmetal"
 	"oblikovati.org/model/sketch"
 )
@@ -33,9 +34,14 @@ type PartComponentDefinition struct {
 	keys       *identity.KeyManager
 	work       *feature.WorkGeometry // origin coordinate frame + user work planes/axes/points
 	surfaces   *feature.WorkSurfaces // construction surfaces wrapping the result's sheet bodies (M20-F16)
-	units      param.UnitsOfMeasure  // document display units (length/angle/…)
-	version    uint64
-	eop        int // end-of-part feature index; endOfPartAtEnd ⇒ full program
+	// pointClouds are the part's attached laser-scan / photogrammetry references (M17-F06,
+	// #645): transformable display objects a design is modeled against, not B-rep geometry. Their
+	// scan bytes live in resources (ADR-0031); the cloud cites the resource UUID. Document-level
+	// input, NOT part of the recipe — they survive a recipe reset (undo/reopen).
+	pointClouds *pointcloud.PointClouds
+	units       param.UnitsOfMeasure // document display units (length/angle/…)
+	version     uint64
+	eop         int // end-of-part feature index; endOfPartAtEnd ⇒ full program
 	// assignments survive Recompute (keyed by persistent reference key, not body id), so a
 	// material/appearance stays put when the body it is on is regenerated.
 	assignments *material.AssignmentStore
@@ -90,6 +96,7 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		assets:      material.NewAssetSet(),
 		resources:   map[string]doc.Resource{},
 		props:       attr.NewPropertySets(),
+		pointClouds: pointcloud.NewPointClouds(),
 	}
 	d.features.SetResourceStore(d) // re-derive imported bodies from the resource table on open
 	d.features.SetFontResolver(d)  // resolve text/emboss fonts from embedded/app-provided resources
@@ -211,6 +218,9 @@ func (d *PartComponentDefinition) SetUnits(u param.UnitsOfMeasure) { d.units = u
 
 // Sketches returns the part's planar (2D) sketches.
 func (d *PartComponentDefinition) Sketches() *sketch.Sketches { return d.sketches }
+
+// PointClouds returns the part's attached scan collection (M17-F06, #645).
+func (d *PartComponentDefinition) PointClouds() *pointcloud.PointClouds { return d.pointClouds }
 
 // SketchBlocks returns the part's block-definition registry — the reference
 // API's SketchBlocks on the component definition (M06-F07, #622).

--- a/model/compdef/pointcloud_persist.go
+++ b/model/compdef/pointcloud_persist.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/pointcloud"
+)
+
+// Point-cloud persistence (M17-F06, #645): the part implements doc.PointCloudBearer so the store
+// round-trips attached scans. Records carry only metadata + the resource id of the scan bytes;
+// the points are re-decoded from the already-restored resource table on open (the .obk embeds the
+// scan once, in resources). See model/doc/pointcloud_records.go.
+
+// var assertion: the part is a point-cloud bearer.
+var _ doc.PointCloudBearer = (*PartComponentDefinition)(nil)
+
+// PointCloudRecords serialises the part's attached clouds (save path).
+func (d *PartComponentDefinition) PointCloudRecords() []doc.PointCloudRecord {
+	clouds := d.pointClouds
+	out := make([]doc.PointCloudRecord, 0, clouds.Count())
+	for i := 0; i < clouds.Count(); i++ {
+		out = append(out, recordOfCloud(clouds.Item(i)))
+	}
+	return out
+}
+
+// SetPointCloudRecords rebuilds the clouds from their records (load path), re-decoding each
+// cloud's points from the resource table (already restored before this runs). A record whose
+// resource or scan is unreadable still rebuilds the cloud — with no points — so its metadata and
+// placement are not lost.
+func (d *PartComponentDefinition) SetPointCloudRecords(records []doc.PointCloudRecord) {
+	d.pointClouds = pointcloud.NewPointClouds()
+	for _, rec := range records {
+		_ = d.pointClouds.Append(cloudFromRecord(rec, d.scanPoints(rec)))
+	}
+}
+
+// scanPoints re-decodes a record's points from the embedded resource bytes, or nil when the
+// resource is missing or undecodable.
+func (d *PartComponentDefinition) scanPoints(rec doc.PointCloudRecord) []math.Point3 {
+	res, ok := d.resources[rec.ResourceID]
+	if !ok {
+		return nil
+	}
+	points, err := pointcloud.ReadScan(rec.Source, res.Value)
+	if err != nil {
+		return nil
+	}
+	return points
+}
+
+// recordOfCloud captures a cloud's metadata + placement (its points stay in the resource table).
+func recordOfCloud(pc *pointcloud.PointCloud) doc.PointCloudRecord {
+	return doc.PointCloudRecord{
+		Name:       pc.Name(),
+		Source:     pc.SourceFullFileName(),
+		ResourceID: pc.ResourceID(),
+		Visible:    pc.Visible(),
+		Scale:      pc.Scale(),
+		Transform:  cellsToFloats(pc.Transform().Cells()),
+		MaxPoints:  pc.MaximumPointCount(),
+	}
+}
+
+// cloudFromRecord rebuilds a cloud from its record and freshly decoded points.
+func cloudFromRecord(rec doc.PointCloudRecord, points []math.Point3) *pointcloud.PointCloud {
+	pc := pointcloud.New(rec.Name, rec.Source, rec.ResourceID, points)
+	pc.SetVisible(rec.Visible)
+	pc.SetScale(rec.Scale) // rejected for a corrupt non-positive value, leaving the default 1
+	pc.SetTransform(math.Matrix4FromCells(floatsToCells(rec.Transform)))
+	pc.SetMaximumPointCount(rec.MaxPoints)
+	return pc
+}
+
+// cellsToFloats / floatsToCells bridge the matrix cell array between math.Scalar and the record's
+// plain float64s.
+func cellsToFloats(c [16]math.Scalar) [16]float64 {
+	var out [16]float64
+	for i, v := range c {
+		out[i] = float64(v)
+	}
+	return out
+}
+
+func floatsToCells(f [16]float64) [16]math.Scalar {
+	var out [16]math.Scalar
+	for i, v := range f {
+		out[i] = math.Scalar(v)
+	}
+	return out
+}

--- a/model/compdef/pointcloud_persist_test.go
+++ b/model/compdef/pointcloud_persist_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+)
+
+// TestPointCloudRecordRoundTrip: a cloud's metadata + placement survive PointCloudRecords →
+// SetPointCloudRecords, with its points re-decoded from the embedded resource (#645).
+func TestPointCloudRecordRoundTrip(t *testing.T) {
+	def := NewPartComponentDefinition()
+	rid := def.AddResource(doc.Resource{Type: "PointCloudScan", Encoding: doc.EncodingUTF8, Value: []byte("0 0 0\n1 1 1\n"), Origin: "s.xyz"})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, nil)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	pc.SetVisible(false)
+	pc.SetScale(3)
+	pc.SetMaximumPointCount(1)
+
+	records := def.PointCloudRecords()
+	if len(records) != 1 || records[0].Name != "Scan" || records[0].Scale != 3 {
+		t.Fatalf("records = %+v, want one Scan at scale 3", records)
+	}
+
+	target := NewPartComponentDefinition()
+	target.SetResources(map[string]doc.Resource{rid: {Encoding: doc.EncodingUTF8, Value: []byte("0 0 0\n1 1 1\n")}})
+	target.SetPointCloudRecords(records)
+
+	got, ok := target.PointClouds().ByName("Scan")
+	if !ok {
+		t.Fatal("restored definition has no Scan cloud")
+	}
+	if got.Visible() || got.Scale() != 3 || got.MaximumPointCount() != 1 {
+		t.Errorf("restored = visible %v scale %v max %d, want false/3/1", got.Visible(), got.Scale(), got.MaximumPointCount())
+	}
+	if got.TotalPointCount() != 2 { // re-decoded from the resource
+		t.Errorf("restored points = %d, want 2 (re-decoded)", got.TotalPointCount())
+	}
+}
+
+// TestPointCloudRecordMissingResource: a record whose resource is absent still rebuilds the cloud,
+// with no points, so its metadata is not lost (#645).
+func TestPointCloudRecordMissingResource(t *testing.T) {
+	def := NewPartComponentDefinition()
+	def.SetPointCloudRecords([]doc.PointCloudRecord{{
+		Name: "Gone", Source: "s.xyz", ResourceID: "absent", Visible: true, Scale: 1,
+		Transform: math.Identity4().Cells(),
+	}})
+	got, ok := def.PointClouds().ByName("Gone")
+	if !ok {
+		t.Fatal("cloud with a missing resource should still rebuild")
+	}
+	if got.TotalPointCount() != 0 {
+		t.Errorf("missing-resource cloud points = %d, want 0", got.TotalPointCount())
+	}
+}

--- a/model/doc/pointcloud_records.go
+++ b/model/doc/pointcloud_records.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+// Point-cloud persistence bridge (M17-F06, #645). A point cloud is document-level input (like
+// resources, not part of the recipe), so it round-trips through a neutral record the content
+// exposes — mirroring [ResourceBearer]. The scan's points are NOT in the record: they live once
+// in the resource table (addressed by ResourceID) and the cloud re-decodes them on restore, so
+// the .obk stays small.
+
+// PointCloudRecord is the serialisable form of one attached scan: its metadata and the id of the
+// resource holding its bytes. Transform is the 16 cells of the cloud→model placement matrix in
+// row-major order.
+type PointCloudRecord struct {
+	Name       string
+	Source     string
+	ResourceID string
+	Visible    bool
+	Scale      float64
+	Transform  [16]float64
+	MaxPoints  int
+}
+
+// PointCloudBearer is the optional interface content implements when it owns attached point
+// clouds (#645). The store reads it on save and restores it on open AFTER the resource table is
+// in place (so the cloud can re-decode its points). Like [ResourceBearer], it is optional.
+type PointCloudBearer interface {
+	Content
+	// PointCloudRecords returns the document's attached-cloud records (save path).
+	PointCloudRecords() []PointCloudRecord
+	// SetPointCloudRecords reconstructs the clouds from their records, reading each cloud's
+	// points from the already-restored resource table (load path).
+	SetPointCloudRecords([]PointCloudRecord)
+}

--- a/model/pointcloud/collection.go
+++ b/model/pointcloud/collection.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// PointClouds is a component definition's collection of attached scans (M17-F06, #645). Names are
+// unique within a definition so other objects (and the browser) bind to a stable handle.
+type PointClouds struct {
+	items []*PointCloud
+}
+
+// NewPointClouds creates an empty collection.
+func NewPointClouds() *PointClouds { return &PointClouds{} }
+
+// Count returns the number of attached clouds; Item returns the i-th in attach order.
+func (c *PointClouds) Count() int             { return len(c.items) }
+func (c *PointClouds) Item(i int) *PointCloud { return c.items[i] }
+
+// Names returns the cloud names in attach order.
+func (c *PointClouds) Names() []string {
+	out := make([]string, len(c.items))
+	for i, pc := range c.items {
+		out[i] = pc.name
+	}
+	return out
+}
+
+// ByName returns the named cloud, ok=false when absent.
+func (c *PointClouds) ByName(name string) (*PointCloud, bool) {
+	for _, pc := range c.items {
+		if pc.name == name {
+			return pc, true
+		}
+	}
+	return nil, false
+}
+
+// Add attaches a cloud built from decoded cloud-local points under a unique name, erroring on a
+// duplicate name. source/resourceID record the scan's origin path and its embedded-bytes id.
+func (c *PointClouds) Add(name, source, resourceID string, points []math.Point3) (*PointCloud, error) {
+	if name == "" {
+		return nil, fmt.Errorf("pointcloud: a cloud needs a non-empty name")
+	}
+	if _, exists := c.ByName(name); exists {
+		return nil, fmt.Errorf("pointcloud: a cloud named %q already exists", name)
+	}
+	pc := New(name, source, resourceID, points)
+	c.items = append(c.items, pc)
+	return pc, nil
+}
+
+// Append re-attaches an already-built cloud (used by persistence restore, which reconstructs the
+// cloud from the recipe). It enforces the same unique-name rule as Add.
+func (c *PointClouds) Append(pc *PointCloud) error {
+	if pc == nil {
+		return fmt.Errorf("pointcloud: Append(nil)")
+	}
+	if _, exists := c.ByName(pc.name); exists {
+		return fmt.Errorf("pointcloud: a cloud named %q already exists", pc.name)
+	}
+	c.items = append(c.items, pc)
+	return nil
+}
+
+// Remove deletes the named cloud, reporting whether it existed.
+func (c *PointClouds) Remove(name string) bool {
+	for i, pc := range c.items {
+		if pc.name == name {
+			c.items = append(c.items[:i], c.items[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// UniqueName returns base suffixed with the smallest positive integer that is not already a cloud
+// name (Cloud1, Cloud2, …), so an attach with a colliding base still gets a distinct name.
+func (c *PointClouds) UniqueName(base string) string {
+	for i := 1; ; i++ {
+		name := fmt.Sprintf("%s%d", base, i)
+		if _, exists := c.ByName(name); !exists {
+			return name
+		}
+	}
+}

--- a/model/pointcloud/collection_test.go
+++ b/model/pointcloud/collection_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestCollectionAddListByNameRemove: the collection adds uniquely-named clouds, enumerates them,
+// resolves by name, and removes them.
+func TestCollectionAddListByNameRemove(t *testing.T) {
+	c := NewPointClouds()
+	if c.Count() != 0 {
+		t.Fatalf("fresh collection Count = %d, want 0", c.Count())
+	}
+
+	a, err := c.Add("A", "a.xyz", "r1", []math.Point3{math.P3(0, 0, 0)})
+	if err != nil {
+		t.Fatalf("Add A: %v", err)
+	}
+	if _, err := c.Add("B", "b.xyz", "r2", nil); err != nil {
+		t.Fatalf("Add B: %v", err)
+	}
+	if c.Count() != 2 || c.Item(0) != a {
+		t.Errorf("Count = %d, Item(0) mismatch", c.Count())
+	}
+	if names := c.Names(); len(names) != 2 || names[0] != "A" || names[1] != "B" {
+		t.Errorf("Names = %v, want [A B]", names)
+	}
+	if got, ok := c.ByName("B"); !ok || got.Name() != "B" {
+		t.Errorf("ByName(B) = (%v, %v)", got, ok)
+	}
+	if _, ok := c.ByName("missing"); ok {
+		t.Error("ByName(missing) should be false")
+	}
+	if !c.Remove("A") || c.Remove("A") {
+		t.Error("Remove(A) should be true once, then false")
+	}
+	if c.Count() != 1 {
+		t.Errorf("after remove Count = %d, want 1", c.Count())
+	}
+}
+
+// TestCollectionRejectsBadNames: an empty name and a duplicate name are rejected.
+func TestCollectionRejectsBadNames(t *testing.T) {
+	c := NewPointClouds()
+	if _, err := c.Add("", "", "", nil); err == nil {
+		t.Error("Add with an empty name should fail")
+	}
+	if _, err := c.Add("Dup", "", "", nil); err != nil {
+		t.Fatalf("Add Dup: %v", err)
+	}
+	if _, err := c.Add("Dup", "", "", nil); err == nil {
+		t.Error("Add with a duplicate name should fail")
+	}
+}
+
+// TestCollectionAppendAndUniqueName: Append re-attaches a built cloud (rejecting nil/duplicates),
+// and UniqueName avoids existing names.
+func TestCollectionAppendAndUniqueName(t *testing.T) {
+	c := NewPointClouds()
+	if err := c.Append(nil); err == nil {
+		t.Error("Append(nil) should fail")
+	}
+	if err := c.Append(New("Cloud1", "", "", nil)); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := c.Append(New("Cloud1", "", "", nil)); err == nil {
+		t.Error("Append of a duplicate name should fail")
+	}
+	if got := c.UniqueName("Cloud"); got != "Cloud2" {
+		t.Errorf("UniqueName(Cloud) = %q, want Cloud2 (Cloud1 taken)", got)
+	}
+}
+
+// TestCloudScalarAccessors: the simple metadata accessors round-trip, and the degenerate-placement
+// and budget edge cases behave.
+func TestCloudScalarAccessors(t *testing.T) {
+	pc := New("Scan", "s.xyz", "rid", []math.Point3{math.P3(1, 2, 3), math.P3(4, 5, 6)})
+	pc.SetName("Renamed")
+	pc.SetVisible(false)
+	if pc.Name() != "Renamed" || pc.Visible() {
+		t.Errorf("name/visible = %q/%v, want Renamed/false", pc.Name(), pc.Visible())
+	}
+	if len(pc.CloudPoints()) != 2 || pc.CloudRangeBox().IsEmpty() {
+		t.Error("CloudPoints / CloudRangeBox not reported")
+	}
+	pc.SetMaximumPointCount(-5) // clamps to 0 (unbounded)
+	if pc.MaximumPointCount() != 0 || pc.DisplayedPointCount() != 2 {
+		t.Errorf("negative budget: max %d displayed %d, want 0/2", pc.MaximumPointCount(), pc.DisplayedPointCount())
+	}
+}
+
+// TestFromModelSpaceDegenerate: a non-invertible placement (zero scale) reports ok=false.
+func TestFromModelSpaceDegenerate(t *testing.T) {
+	pc := New("s", "", "", nil)
+	pc.scale = 0 // force a degenerate placement (SetScale would reject this)
+	if _, ok := pc.FromModelSpace(math.P3(1, 1, 1)); ok {
+		t.Error("FromModelSpace with zero scale should report ok=false")
+	}
+}
+
+// TestReadScanDispatch: ReadScan routes by extension and errors on an unknown one.
+func TestReadScanDispatch(t *testing.T) {
+	pts, err := ReadScan("room.PTS", []byte("1 2 3\n"))
+	if err != nil || len(pts) != 1 {
+		t.Fatalf("ReadScan(.PTS) = %v points, err %v", len(pts), err)
+	}
+	if _, err := ReadScan("room.las", []byte("binary")); err == nil {
+		t.Error("ReadScan of an unregistered extension should fail")
+	}
+}

--- a/model/pointcloud/pointcloud.go
+++ b/model/pointcloud/pointcloud.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import "oblikovati.org/math"
+
+// PointCloud is one attached scan: its points in cloud-local coordinates, a placement transform
+// and uniform scale into model space, a display point budget, and visibility (M17-F06, #645). It
+// is a referenced object, not B-rep geometry — a design is modeled against it. The scan bytes
+// live in the document resource table (ADR-0031); resourceID addresses them so the cloud
+// re-derives its points on open without the original file.
+type PointCloud struct {
+	name       string
+	visible    bool
+	transform  math.Matrix4  // cloud-space → model-space placement
+	scale      float64       // uniform cloud→model scale (UnitsFactor folded in)
+	points     []math.Point3 // cloud-local coordinates, as decoded
+	source     string        // SourceFullFileName (display / re-link metadata)
+	resourceID string        // ADR-0031 resource UUID addressing the scan bytes
+	maxPoints  int           // display budget; 0 = show every point
+}
+
+// New creates a cloud from decoded cloud-local points. It starts visible, unscaled (factor 1),
+// identity-placed, with no display cap. source/resourceID record where the scan came from and
+// where its bytes are embedded.
+//
+// Example: pc := pointcloud.New("scan", "/scans/room.xyz", "uuid", pts)
+func New(name, source, resourceID string, points []math.Point3) *PointCloud {
+	return &PointCloud{
+		name:       name,
+		visible:    true,
+		transform:  math.Identity4(),
+		scale:      1,
+		points:     points,
+		source:     source,
+		resourceID: resourceID,
+	}
+}
+
+// Name/SetName get and set the cloud's unique browser name.
+func (pc *PointCloud) Name() string     { return pc.name }
+func (pc *PointCloud) SetName(n string) { pc.name = n }
+
+// Visible/SetVisible get and set whether the cloud renders in the viewport.
+func (pc *PointCloud) Visible() bool     { return pc.visible }
+func (pc *PointCloud) SetVisible(v bool) { pc.visible = v }
+
+// Transform/SetTransform get and set the cloud→model placement matrix.
+func (pc *PointCloud) Transform() math.Matrix4     { return pc.transform }
+func (pc *PointCloud) SetTransform(m math.Matrix4) { pc.transform = m }
+
+// Scale/SetScale get and set the uniform cloud→model scale; a non-positive value is rejected.
+func (pc *PointCloud) Scale() float64 { return pc.scale }
+func (pc *PointCloud) SetScale(s float64) bool {
+	if s <= 0 {
+		return false
+	}
+	pc.scale = s
+	return true
+}
+
+// SourceFullFileName returns the scan's original path; ResourceID returns its embedded-bytes id.
+func (pc *PointCloud) SourceFullFileName() string { return pc.source }
+func (pc *PointCloud) ResourceID() string         { return pc.resourceID }
+
+// TotalPointCount returns how many points the scan holds; DisplayedPointCount returns how many
+// render after the display budget (MaximumPointCount) is applied.
+func (pc *PointCloud) TotalPointCount() int { return len(pc.points) }
+func (pc *PointCloud) DisplayedPointCount() int {
+	if pc.maxPoints <= 0 || pc.maxPoints >= len(pc.points) {
+		return len(pc.points)
+	}
+	return pc.maxPoints
+}
+
+// MaximumPointCount/SetMaximumPointCount get and set the display budget (0 = unbounded). A
+// negative budget clamps to 0.
+func (pc *PointCloud) MaximumPointCount() int { return pc.maxPoints }
+func (pc *PointCloud) SetMaximumPointCount(n int) {
+	if n < 0 {
+		n = 0
+	}
+	pc.maxPoints = n
+}
+
+// ToModelSpace maps a cloud-local point to model space (scale then place); FromModelSpace is its
+// inverse, returning false when the placement is non-invertible (a degenerate transform).
+func (pc *PointCloud) ToModelSpace(p math.Point3) math.Point3 {
+	return pc.transform.TransformPoint(scalePoint(p, pc.scale))
+}
+
+func (pc *PointCloud) FromModelSpace(p math.Point3) (math.Point3, bool) {
+	inv, ok := pc.transform.Inverse()
+	if !ok || pc.scale == 0 {
+		return math.Point3{}, false
+	}
+	return scalePoint(inv.TransformPoint(p), 1/pc.scale), true
+}
+
+// CloudPoints returns the scan points in cloud-local space (the decoded coordinates).
+func (pc *PointCloud) CloudPoints() []math.Point3 { return pc.points }
+
+// DisplayedPoints returns the budgeted point set in MODEL space — what the renderer draws. When
+// a display budget is set it strides evenly across the scan so the sample stays spatially
+// representative rather than a truncated prefix.
+func (pc *PointCloud) DisplayedPoints() []math.Point3 {
+	out := make([]math.Point3, 0, pc.DisplayedPointCount())
+	for _, p := range pc.sampledCloudPoints() {
+		out = append(out, pc.ToModelSpace(p))
+	}
+	return out
+}
+
+// sampledCloudPoints returns the cloud-local points after the display budget, strided evenly.
+func (pc *PointCloud) sampledCloudPoints() []math.Point3 {
+	if pc.maxPoints <= 0 || pc.maxPoints >= len(pc.points) {
+		return pc.points
+	}
+	stride := len(pc.points) / pc.maxPoints
+	out := make([]math.Point3, 0, pc.maxPoints)
+	for i := 0; i < len(pc.points) && len(out) < pc.maxPoints; i += stride {
+		out = append(out, pc.points[i])
+	}
+	return out
+}
+
+// RangeBox returns the cloud's axis-aligned bounds in MODEL space; CloudRangeBox returns them in
+// cloud-local space. Both are empty for a cloud with no points.
+func (pc *PointCloud) RangeBox() math.Box {
+	box := math.EmptyBox()
+	for _, p := range pc.points {
+		box = box.ExtendPoint(pc.ToModelSpace(p))
+	}
+	return box
+}
+
+func (pc *PointCloud) CloudRangeBox() math.Box {
+	box := math.EmptyBox()
+	for _, p := range pc.points {
+		box = box.ExtendPoint(p)
+	}
+	return box
+}
+
+// scalePoint scales a point's coordinates about the origin.
+func scalePoint(p math.Point3, s float64) math.Point3 {
+	f := math.Scalar(s)
+	return math.P3(p.X*f, p.Y*f, p.Z*f)
+}

--- a/model/pointcloud/pointcloud_test.go
+++ b/model/pointcloud/pointcloud_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"math"
+	"testing"
+
+	omath "oblikovati.org/math"
+)
+
+// TestASCIIReaderParsesXYZAndSkipsNoise: the ASCII reader reads x y z lines, ignores blank,
+// comment, and extra-column lines, and skips a leading PTS count header.
+func TestASCIIReaderParsesXYZAndSkipsNoise(t *testing.T) {
+	src := "3\n# a comment\n\n1 2 3\n4.5 6 7 128 255 0 0\n// trailing comment\n-1 -2 -3\n"
+	pts, err := NewASCIIReader().Read([]byte(src))
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(pts) != 3 {
+		t.Fatalf("parsed %d points, want 3: %+v", len(pts), pts)
+	}
+	if pts[0] != omath.P3(1, 2, 3) || pts[1] != omath.P3(4.5, 6, 7) || pts[2] != omath.P3(-1, -2, -3) {
+		t.Errorf("points = %+v, want (1,2,3),(4.5,6,7),(-1,-2,-3)", pts)
+	}
+}
+
+// TestASCIIReaderRejectsMalformedLine: a non-coordinate line that is not a leading count header
+// errors, citing the line.
+func TestASCIIReaderRejectsMalformedLine(t *testing.T) {
+	if _, err := NewASCIIReader().Read([]byte("1 2 3\nx y z\n")); err == nil {
+		t.Error("expected an error on a non-numeric coordinate line")
+	}
+}
+
+// TestNewCloudDefaults: a fresh cloud is visible, unit-scaled, identity-placed, uncapped.
+func TestNewCloudDefaults(t *testing.T) {
+	pc := New("scan", "/s/room.xyz", "uuid-1", []omath.Point3{omath.P3(0, 0, 0)})
+	if !pc.Visible() || pc.Scale() != 1 || pc.MaximumPointCount() != 0 {
+		t.Errorf("defaults = visible %v scale %v max %d, want true/1/0", pc.Visible(), pc.Scale(), pc.MaximumPointCount())
+	}
+	if pc.SourceFullFileName() != "/s/room.xyz" || pc.ResourceID() != "uuid-1" {
+		t.Errorf("source/resource = %q/%q", pc.SourceFullFileName(), pc.ResourceID())
+	}
+	if pc.Transform() != omath.Identity4() {
+		t.Error("a fresh cloud should be identity-placed")
+	}
+}
+
+// TestToFromModelSpaceRoundTrip: a scaled, translated placement maps cloud→model and back.
+func TestToFromModelSpaceRoundTrip(t *testing.T) {
+	pc := New("s", "", "", nil)
+	pc.SetScale(2)
+	pc.SetTransform(translation(10, 20, 30))
+
+	p := omath.P3(1, 1, 1)
+	m := pc.ToModelSpace(p)
+	if m != omath.P3(12, 22, 32) { // 1*2 + 10, etc.
+		t.Fatalf("ToModelSpace = %+v, want (12,22,32)", m)
+	}
+	back, ok := pc.FromModelSpace(m)
+	if !ok || !near(back, p) {
+		t.Errorf("FromModelSpace = %+v (ok=%v), want %+v", back, ok, p)
+	}
+}
+
+// TestSetScaleRejectsNonPositive: scale must stay positive (it divides in FromModelSpace).
+func TestSetScaleRejectsNonPositive(t *testing.T) {
+	pc := New("s", "", "", nil)
+	if pc.SetScale(0) || pc.SetScale(-3) {
+		t.Error("SetScale accepted a non-positive factor")
+	}
+	if pc.Scale() != 1 {
+		t.Errorf("scale = %v after rejected sets, want 1", pc.Scale())
+	}
+}
+
+// TestDisplayBudgetStridesEvenly: a display cap strides across the scan rather than truncating,
+// and the displayed count honours the cap.
+func TestDisplayBudgetStridesEvenly(t *testing.T) {
+	var pts []omath.Point3
+	for i := 0; i < 100; i++ {
+		pts = append(pts, omath.P3(omath.Scalar(i), 0, 0))
+	}
+	pc := New("s", "", "", pts)
+	pc.SetMaximumPointCount(10)
+
+	if pc.TotalPointCount() != 100 || pc.DisplayedPointCount() != 10 {
+		t.Fatalf("counts = total %d displayed %d, want 100/10", pc.TotalPointCount(), pc.DisplayedPointCount())
+	}
+	shown := pc.DisplayedPoints()
+	if len(shown) != 10 {
+		t.Fatalf("DisplayedPoints len = %d, want 10", len(shown))
+	}
+	// Strided (every 10th), so the last shown x is 90, not 9 (which truncation would give).
+	if shown[len(shown)-1].X != 90 {
+		t.Errorf("last displayed x = %v, want 90 (even stride, not a prefix)", shown[len(shown)-1].X)
+	}
+}
+
+// TestRangeBoxInModelSpace: the model-space range box reflects scale + placement.
+func TestRangeBoxInModelSpace(t *testing.T) {
+	pc := New("s", "", "", []omath.Point3{omath.P3(0, 0, 0), omath.P3(1, 1, 1)})
+	pc.SetScale(3)
+	box := pc.RangeBox()
+	if box.IsEmpty() || box.Diagonal() != omath.V3(3, 3, 3) {
+		t.Errorf("model range box diagonal = %+v, want (3,3,3)", box.Diagonal())
+	}
+}
+
+// translation builds a pure-translation Matrix4 via the cloud transform setter's expectations.
+func translation(x, y, z omath.Scalar) omath.Matrix4 {
+	m := omath.Identity4()
+	cells := m.Cells()
+	cells[3], cells[7], cells[11] = x, y, z // column-major translation column (row-major last col)
+	return omath.Matrix4FromCells(cells)
+}
+
+// near reports whether two points are within a small tolerance (float round-trip).
+func near(a, b omath.Point3) bool {
+	return math.Abs(float64(a.X-b.X)) < 1e-9 && math.Abs(float64(a.Y-b.Y)) < 1e-9 && math.Abs(float64(a.Z-b.Z)) < 1e-9
+}

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package pointcloud models attached laser-scan / photogrammetry point clouds (M17-F06, #645):
+// a linked, transformable reference object a design can be modeled against, not B-rep geometry.
+// A cloud carries its scan points in cloud-local coordinates plus a placement transform and
+// scale into model space, a display budget, and visibility. Scan decoding is pluggable behind
+// PointReader so new formats (LAS/E57) drop in without touching the cloud model.
+package pointcloud
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"oblikovati.org/math"
+)
+
+// registeredReaders is the decoder set keyed by lowercase extension. ASCII formats ship now;
+// LAS/E57 readers register here later without touching call sites.
+var registeredReaders = []PointReader{NewASCIIReader()}
+
+// ReadScan decodes a scan file's bytes into cloud-local points, choosing the reader by the
+// filename's extension. It errors when no registered reader handles the extension, naming it.
+func ReadScan(filename string, data []byte) ([]math.Point3, error) {
+	ext := strings.ToLower(filepath.Ext(filename))
+	for _, r := range registeredReaders {
+		for _, e := range r.Extensions() {
+			if e == ext {
+				return r.Read(data)
+			}
+		}
+	}
+	return nil, fmt.Errorf("pointcloud: no reader for scan extension %q (file %q)", ext, filename)
+}
+
+// PointReader decodes one scan-file format's bytes into cloud-local points. One implementation
+// per format keeps the cloud model format-agnostic; the host wraps any third-party decoder
+// behind this project-owned seam (CLAUDE.md "Dependencies"). The first reader is clean-room
+// ASCII XYZ/PTS; LAS/E57 are future readers registered the same way.
+type PointReader interface {
+	// Extensions returns the lowercase file extensions (with leading dot) this reader handles.
+	Extensions() []string
+	// Read parses scan bytes into cloud-local points, erroring with the offending input.
+	Read(data []byte) ([]math.Point3, error)
+}
+
+// asciiReader parses the open ASCII point formats — XYZ and PTS — where each non-empty,
+// non-comment line is "x y z" optionally followed by intensity / r g b columns (ignored for
+// now). A lone leading integer (a PTS point-count header) is skipped. Coordinates are read in
+// the file's own units; the owning PointCloud's UnitsFactor/scale maps them to model space.
+type asciiReader struct{}
+
+// NewASCIIReader returns the clean-room reader for .xyz/.pts/.asc/.txt scan files.
+func NewASCIIReader() PointReader { return asciiReader{} }
+
+func (asciiReader) Extensions() []string { return []string{".xyz", ".pts", ".asc", ".txt"} }
+
+// Read parses each coordinate line into a point. A line with fewer than three numeric fields
+// that is the FIRST data line is treated as a PTS count header and skipped; any other malformed
+// line is an error citing the line number and content.
+func (asciiReader) Read(data []byte) ([]math.Point3, error) {
+	var points []math.Point3
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // tolerate long lines
+	line := 0
+	for sc.Scan() {
+		line++
+		text := strings.TrimSpace(sc.Text())
+		if skippableLine(text) {
+			continue
+		}
+		p, ok := parseXYZ(text)
+		if ok {
+			points = append(points, p)
+			continue
+		}
+		if len(points) == 0 && isCountHeader(text) {
+			continue // a PTS file's leading point-count line
+		}
+		return nil, fmt.Errorf("pointcloud: line %d is not \"x y z\": %q", line, text)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("pointcloud: reading scan: %w", err)
+	}
+	return points, nil
+}
+
+// skippableLine reports whether a line carries no coordinate (blank or a comment).
+func skippableLine(text string) bool {
+	return text == "" || strings.HasPrefix(text, "#") || strings.HasPrefix(text, "//")
+}
+
+// parseXYZ reads the first three whitespace-separated fields as x, y, z, ignoring any trailing
+// columns (intensity/colour). ok is false when the line lacks three parseable floats.
+func parseXYZ(text string) (math.Point3, bool) {
+	f := strings.Fields(text)
+	if len(f) < 3 {
+		return math.Point3{}, false
+	}
+	x, ex := strconv.ParseFloat(f[0], 64)
+	y, ey := strconv.ParseFloat(f[1], 64)
+	z, ez := strconv.ParseFloat(f[2], 64)
+	if ex != nil || ey != nil || ez != nil {
+		return math.Point3{}, false
+	}
+	return math.P3(math.Scalar(x), math.Scalar(y), math.Scalar(z)), true
+}
+
+// isCountHeader reports whether a line is a single non-negative integer (a PTS count header).
+func isCountHeader(text string) bool {
+	f := strings.Fields(text)
+	if len(f) != 1 {
+		return false
+	}
+	n, err := strconv.Atoi(f[0])
+	return err == nil && n >= 0
+}

--- a/persistence/io.go
+++ b/persistence/io.go
@@ -54,6 +54,7 @@ func (p *Package) marshal() ([]byte, error) {
 		References:      p.references,
 		Attachments:     p.attachments,
 		Interests:       p.interests,
+		PointClouds:     p.pointClouds,
 		Attributes:      p.attributes,
 		DisplaySettings: p.display,
 		SketchSettings:  p.sketch,
@@ -85,6 +86,7 @@ func decode(raw []byte) (*Package, error) {
 	p.references = doc.References
 	p.attachments = doc.Attachments
 	p.interests = doc.Interests
+	p.pointClouds = doc.PointClouds
 	p.attributes = doc.Attributes
 	p.display = doc.DisplaySettings
 	p.sketch = doc.SketchSettings

--- a/persistence/package.go
+++ b/persistence/package.go
@@ -38,6 +38,7 @@ type Package struct {
 	display     *yamlcodec.DisplaySettingsRecord // per-document display settings (M16-F07 #643)
 	sketch      *yamlcodec.SketchSettingsRecord  // per-document sketch settings (#147)
 	bodyNames   map[string]string                // per-body display names by reference key (#1078)
+	pointClouds []yamlcodec.PointCloudRecord     // attached scan records (M17-F06, #645)
 }
 
 // NewPackage returns an empty package.
@@ -80,6 +81,12 @@ func (p *Package) SetBodyNames(names map[string]string) { p.bodyNames = names }
 
 // BodyNames returns the per-body display-name map (nil when no body was renamed).
 func (p *Package) BodyNames() map[string]string { return p.bodyNames }
+
+// SetPointClouds stores the attached-scan records (M17-F06, #645).
+func (p *Package) SetPointClouds(records []yamlcodec.PointCloudRecord) { p.pointClouds = records }
+
+// PointClouds returns the attached-scan records (nil when none attached).
+func (p *Package) PointClouds() []yamlcodec.PointCloudRecord { return p.pointClouds }
 
 // SetInterests stores the add-in data-registry records (M03-F10).
 func (p *Package) SetInterests(i []yamlcodec.InterestRecord) { p.interests = i }

--- a/persistence/pointcloud_roundtrip_test.go
+++ b/persistence/pointcloud_roundtrip_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package persistence
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/pointcloud"
+)
+
+// TestPointCloudSurvivesStoreRoundTrip: an attached scan's metadata, placement, and points
+// round-trip through a save/open cycle — the points re-decoded from the embedded resource bytes,
+// not re-read from the original file (M17-F06, #645).
+func TestPointCloudSurvivesStoreRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.obk")
+	store := NewPackageStore()
+
+	ws := doc.NewWorkspace(store)
+	d, err := compdef.AddPart(ws, path, true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := d.Content().(*compdef.PartComponentDefinition)
+
+	scan := []byte("0 0 0\n1 2 3\n4 5 6\n")
+	rid := def.AddResource(doc.Resource{Type: "PointCloudScan", Encoding: doc.EncodingUTF8, Value: scan, Origin: "room.xyz"})
+	points, err := pointcloud.ReadScan("room.xyz", scan)
+	if err != nil {
+		t.Fatalf("decode scan: %v", err)
+	}
+	pc, err := def.PointClouds().Add("Cloud1", "room.xyz", rid, points)
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	pc.SetVisible(false)
+	pc.SetScale(2.5)
+	pc.SetMaximumPointCount(2)
+	pc.SetTransform(translation4(10, 0, 0))
+
+	if err := ws.Save(d); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	rdef := reopened.Content().(*compdef.PartComponentDefinition)
+	got, ok := rdef.PointClouds().ByName("Cloud1")
+	if !ok {
+		t.Fatalf("reopened part has no Cloud1; names=%v", rdef.PointClouds().Names())
+	}
+	if got.Visible() || got.Scale() != 2.5 || got.MaximumPointCount() != 2 {
+		t.Errorf("reopened cloud = visible %v scale %v max %d, want false/2.5/2", got.Visible(), got.Scale(), got.MaximumPointCount())
+	}
+	if got.TotalPointCount() != 3 {
+		t.Errorf("reopened total points = %d, want 3 (re-decoded from the embedded resource)", got.TotalPointCount())
+	}
+	if got.Transform() != translation4(10, 0, 0) {
+		t.Errorf("reopened transform = %+v, want a +10x translation", got.Transform())
+	}
+	if got.SourceFullFileName() != "room.xyz" || got.ResourceID() != rid {
+		t.Errorf("reopened source/resource = %q/%q, want room.xyz/%q", got.SourceFullFileName(), got.ResourceID(), rid)
+	}
+}
+
+// translation4 builds a pure-translation 4×4 matrix (cells[3,7,11] hold the translation column).
+func translation4(x, y, z math.Scalar) math.Matrix4 {
+	cells := math.Identity4().Cells()
+	cells[3], cells[7], cells[11] = x, y, z
+	return math.Matrix4FromCells(cells)
+}

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -107,6 +107,9 @@ func (s *PackageStore) buildPackage(d *doc.Document, displayName, subType string
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {
 		pkg.SetResources(toCodecResources(rb.Resources()))
 	}
+	if pb, ok := d.Content().(doc.PointCloudBearer); ok {
+		pkg.SetPointClouds(toCodecPointClouds(pb.PointCloudRecords()))
+	}
 	return pkg, nil
 }
 
@@ -133,6 +136,11 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	// geometry from an embedded resource (e.g. an imported body) can read its bytes (ADR-0031).
 	if rb, ok := d.Content().(doc.ResourceBearer); ok {
 		rb.SetResources(fromCodecResources(pkg.Resources()))
+	}
+	// Point clouds restore AFTER resources (they re-decode their points from the resource table)
+	// but they are not recipe-dependent, so order relative to the recipe does not matter (#645).
+	if pb, ok := d.Content().(doc.PointCloudBearer); ok {
+		pb.SetPointCloudRecords(fromCodecPointClouds(pkg.PointClouds()))
 	}
 	if err := applyModelRecipe(d, pkg, fullDocumentName); err != nil {
 		return nil, err
@@ -328,6 +336,37 @@ func fromCodecResources(in map[string]yamlcodec.Resource) map[string]doc.Resourc
 	out := make(map[string]doc.Resource, len(in))
 	for id, r := range in {
 		out[id] = doc.Resource{Type: r.Type, Encoding: r.Encoding, Value: r.Value, Origin: r.Origin}
+	}
+	return out
+}
+
+// toCodecPointClouds / fromCodecPointClouds bridge the document-layer point-cloud record
+// (doc.PointCloudRecord) and the on-disk serialization type (yamlcodec.PointCloudRecord); the
+// fields are identical, this keeps the layers decoupled (M17-F06, #645).
+func toCodecPointClouds(in []doc.PointCloudRecord) []yamlcodec.PointCloudRecord {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]yamlcodec.PointCloudRecord, len(in))
+	for i, r := range in {
+		out[i] = yamlcodec.PointCloudRecord{
+			Name: r.Name, Source: r.Source, ResourceID: r.ResourceID,
+			Visible: r.Visible, Scale: r.Scale, Transform: r.Transform, MaxPoints: r.MaxPoints,
+		}
+	}
+	return out
+}
+
+func fromCodecPointClouds(in []yamlcodec.PointCloudRecord) []doc.PointCloudRecord {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]doc.PointCloudRecord, len(in))
+	for i, r := range in {
+		out[i] = doc.PointCloudRecord{
+			Name: r.Name, Source: r.Source, ResourceID: r.ResourceID,
+			Visible: r.Visible, Scale: r.Scale, Transform: r.Transform, MaxPoints: r.MaxPoints,
+		}
 	}
 	return out
 }

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -48,6 +48,8 @@ type Document struct {
 	Attachments []AttachmentRecord
 	// Interests are the add-in data registry records (M03-F10).
 	Interests []InterestRecord
+	// PointClouds are the attached scan records (M17-F06, #645); their bytes are in Resources.
+	PointClouds []PointCloudRecord
 	// Attributes is the add-in attribute-set block (#155): the encoded AttributeManager
 	// (model/attr), nil for a document that carries no attributes.
 	Attributes []byte
@@ -149,6 +151,19 @@ type AttachmentRecord struct {
 	BrowserVisible    bool   `yaml:"browserVisible,omitempty"`
 }
 
+// PointCloudRecord is one attached scan's metadata (M17-F06, #645): its name, source path, the
+// id of the resource holding its bytes, visibility, scale, the 16 cloud→model transform cells,
+// and the display point budget. The points themselves live once in the resource table.
+type PointCloudRecord struct {
+	Name       string      `yaml:"name"`
+	Source     string      `yaml:"source,omitempty"`
+	ResourceID string      `yaml:"resourceId,omitempty"`
+	Visible    bool        `yaml:"visible"`
+	Scale      float64     `yaml:"scale"`
+	Transform  [16]float64 `yaml:"transform,flow"`
+	MaxPoints  int         `yaml:"maxPoints,omitempty"`
+}
+
 // InterestRecord is one add-in data-registry entry (M03-F10): client X has
 // data in / depends on this document, readable without loading the add-in.
 type InterestRecord struct {
@@ -170,6 +185,7 @@ type onDisk struct {
 	References      []FileReferenceRecord  `yaml:"references,omitempty"`
 	Attachments     []AttachmentRecord     `yaml:"attachments,omitempty"`
 	Interests       []InterestRecord       `yaml:"interests,omitempty"`
+	PointClouds     []PointCloudRecord     `yaml:"pointClouds,omitempty"`
 	Attributes      []byte                 `yaml:"attributes,omitempty"`
 	DisplaySettings *DisplaySettingsRecord `yaml:"displaySettings,omitempty"`
 	SketchSettings  *SketchSettingsRecord  `yaml:"sketchSettings,omitempty"`
@@ -191,6 +207,7 @@ func MarshalDocument(d Document) ([]byte, error) {
 		References:      d.References,
 		Attachments:     d.Attachments,
 		Interests:       d.Interests,
+		PointClouds:     d.PointClouds,
 		Attributes:      d.Attributes,
 		DisplaySettings: d.DisplaySettings,
 		SketchSettings:  d.SketchSettings,
@@ -270,6 +287,7 @@ func documentHeader(od onDisk) Document {
 		References:      od.References,
 		Attachments:     od.Attachments,
 		Interests:       od.Interests,
+		PointClouds:     od.PointClouds,
 		Attributes:      od.Attributes,
 		DisplaySettings: od.DisplaySettings,
 		SketchSettings:  od.SketchSettings,


### PR DESCRIPTION
## What
First slice of **M17-F06 point clouds** (#645): attach a laser-scan / photogrammetry file to the active part as a transformable, persisted display object, reachable over the wire/MCP.

## Layers (headless, fully tested)
- **`model/pointcloud`** — `PointCloud` (cloud-local points + cloud→model transform/scale, display budget, visibility) + `PointClouds` collection + a **clean-room ASCII XYZ/PTS reader** behind a pluggable `PointReader` seam (LAS/E57 register later). Cloud↔model conversion, even-stride display budgeting, range boxes.
- **Persistence** — full `.obk` round-trip: scan bytes embed once in the resource table (ADR-0031); the cloud re-decodes them on open; metadata/placement persist via a neutral `doc.PointCloudBearer` (mirrors `ResourceBearer`).
- **Router** — `pointClouds.*` handlers on the active part (attach/list/get/delete/setVisible/setTransform/setScale/setDensity/to+fromModelSpace), pinned to api **v0.78.0** (Oblikovati/Oblikovati.API#198).

## Tests
- `model/pointcloud` unit tests (reader, transform, budgeting, range box).
- `persistence` save/open round-trip (metadata + placement + re-decoded points).
- `addin/router` e2e: full lifecycle, placement + budget, space round-trip, missing-file / bad-scale errors.

## Scope / next slices
This is the base attach/query/place surface. **Deferred to follow-up PRs:** viewport rendering + Insert UI (PR 2, hits DoD), scans/regions/crops (PR 3), snappable `PointCloudPoint`/`PointCloudPlane` (PR 4), assembly proxies + LAS/E57 decoders (PR 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)