### PR TITLE
Point cloud crop volumes (PR 3 of #645)

### DIFF
--- a/addin/router/point_clouds.go
+++ b/addin/router/point_clouds.go
@@ -31,6 +31,10 @@ func (r *Router) registerPointCloudHandlers() {
 	r.handlers[wire.MethodPointCloudsSetDensity] = setPointCloudDensity
 	r.handlers[wire.MethodPointCloudsToModelSpace] = pointCloudToModelSpace
 	r.handlers[wire.MethodPointCloudsFromModelSpace] = pointCloudFromModelSpace
+	r.handlers[wire.MethodPointCloudsAddCrop] = addPointCloudCrop
+	r.handlers[wire.MethodPointCloudsListCrops] = listPointCloudCrops
+	r.handlers[wire.MethodPointCloudsDeleteCrop] = deletePointCloudCrop
+	r.handlers[wire.MethodPointCloudsSetCropActive] = setPointCloudCropActive
 }
 
 // attachPointCloud reads the scan file, embeds its bytes as a resource, decodes its points, and
@@ -213,6 +217,77 @@ func pointCloudInfo(pc *pointcloud.PointCloud) wire.PointCloudInfo {
 		TotalPointCount:     pc.TotalPointCount(),
 		DisplayedPointCount: pc.DisplayedPointCount(),
 		MaximumPointCount:   pc.MaximumPointCount(),
+	}
+}
+
+// addPointCloudCrop adds an active crop over the requested box on a named cloud.
+func addPointCloudCrop(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.AddPointCloudCropArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Cloud, wire.MethodPointCloudsAddCrop)
+	if err != nil {
+		return nil, err
+	}
+	crop := pc.AddCrop(math.NewBox(point3Of(in.Min), point3Of(in.Max)))
+	return json.Marshal(cropInfo(in.Cloud, crop))
+}
+
+// listPointCloudCrops enumerates a named cloud's crops.
+func listPointCloudCrops(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ListPointCloudCropsArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Cloud, wire.MethodPointCloudsListCrops)
+	if err != nil {
+		return nil, err
+	}
+	crops := pc.Crops()
+	out := make([]wire.PointCloudCropInfo, 0, crops.Count())
+	for i := 0; i < crops.Count(); i++ {
+		out = append(out, cropInfo(in.Cloud, crops.Item(i)))
+	}
+	return json.Marshal(wire.ListPointCloudCropsResult{Crops: out})
+}
+
+// deletePointCloudCrop removes a named crop from a cloud.
+func deletePointCloudCrop(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.PointCloudCropArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Cloud, wire.MethodPointCloudsDeleteCrop)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire.DeletePointCloudCropResult{Crop: in.Crop, Deleted: pc.Crops().Remove(in.Crop)})
+}
+
+// setPointCloudCropActive toggles whether a named crop limits display.
+func setPointCloudCropActive(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.SetPointCloudCropActiveArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Cloud, wire.MethodPointCloudsSetCropActive)
+	if err != nil {
+		return nil, err
+	}
+	crop, ok := pc.Crops().ByName(in.Crop)
+	if !ok {
+		return nil, fmt.Errorf("pointClouds.setCropActive: cloud %q has no crop %q", in.Cloud, in.Crop)
+	}
+	crop.SetActive(in.Active)
+	return json.Marshal(cropInfo(in.Cloud, crop))
+}
+
+// cropInfo maps a crop to its wire shape under the owning cloud's name.
+func cropInfo(cloud string, c *pointcloud.PointCloudCrop) wire.PointCloudCropInfo {
+	return wire.PointCloudCropInfo{
+		Cloud: cloud, Crop: c.Name(), Active: c.Active(),
+		Min: pointOf(c.Box().Min), Max: pointOf(c.Box().Max),
 	}
 }
 

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -147,6 +147,11 @@ func TestPointCloudCropErrors(t *testing.T) {
 	if _, err := r.Handle(s, "pointClouds.setCropActive", []byte(`{"cloud":"S","crop":"nope","active":true}`)); err == nil {
 		t.Error("setCropActive on a missing crop should fail")
 	}
+	for _, m := range []string{"pointClouds.listCrops", "pointClouds.deleteCrop"} {
+		if _, err := r.Handle(s, m, []byte(`{"cloud":"nope","crop":"x"}`)); err == nil {
+			t.Errorf("%s on a missing cloud should fail", m)
+		}
+	}
 }
 
 // TestPointCloudMissingNameErrors: every name-keyed operation errors when no cloud has the name,

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -92,6 +92,63 @@ func TestPointCloudPlacementAndBudget(t *testing.T) {
 	}
 }
 
+// TestPointCloudCropLifecycle: add a crop, see it limit the displayed count, toggle it off and on,
+// list it, and delete it — all over the wire (#645).
+func TestPointCloudCropLifecycle(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := writeScan(t, "0 0 0\n1 0 0\n2 0 0\n3 0 0\n4 0 0\n5 0 0\n")
+	var info wire.PointCloudInfo
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &info)
+	if info.DisplayedPointCount != 6 {
+		t.Fatalf("attached displayed count = %d, want 6", info.DisplayedPointCount)
+	}
+
+	// Crop to x in [0,2] → 3 points displayed.
+	crop := wire.AddPointCloudCropArgs{Cloud: "Scan", Min: types.Point{X: -0.5, Y: -1, Z: -1}, Max: types.Point{X: 2.5, Y: 1, Z: 1}}
+	var ci wire.PointCloudCropInfo
+	call(t, r, s, "pointClouds.addCrop", mustJSON(t, crop), &ci)
+	if ci.Crop != "Crop1" || !ci.Active {
+		t.Fatalf("addCrop = %+v, want active Crop1", ci)
+	}
+	call(t, r, s, "pointClouds.get", `{"name":"Scan"}`, &info)
+	if info.DisplayedPointCount != 3 {
+		t.Errorf("cropped displayed count = %d, want 3 (x 0..2)", info.DisplayedPointCount)
+	}
+
+	// Deactivating restores the full set.
+	call(t, r, s, "pointClouds.setCropActive", `{"cloud":"Scan","crop":"Crop1","active":false}`, &ci)
+	call(t, r, s, "pointClouds.get", `{"name":"Scan"}`, &info)
+	if info.DisplayedPointCount != 6 {
+		t.Errorf("after deactivating crop, displayed = %d, want 6", info.DisplayedPointCount)
+	}
+
+	var list wire.ListPointCloudCropsResult
+	call(t, r, s, "pointClouds.listCrops", `{"cloud":"Scan"}`, &list)
+	if len(list.Crops) != 1 || list.Crops[0].Active {
+		t.Errorf("listCrops = %+v, want one inactive crop", list.Crops)
+	}
+
+	var del wire.DeletePointCloudCropResult
+	call(t, r, s, "pointClouds.deleteCrop", `{"cloud":"Scan","crop":"Crop1"}`, &del)
+	call(t, r, s, "pointClouds.listCrops", `{"cloud":"Scan"}`, &list)
+	if !del.Deleted || len(list.Crops) != 0 {
+		t.Errorf("after delete: deleted=%v crops=%+v, want deleted/empty", del.Deleted, list.Crops)
+	}
+}
+
+// TestPointCloudCropErrors: crop ops on a missing cloud or crop error (#645).
+func TestPointCloudCropErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "pointClouds.addCrop", []byte(`{"cloud":"nope","min":{"x":0,"y":0,"z":0},"max":{"x":1,"y":1,"z":1}}`)); err == nil {
+		t.Error("addCrop on a missing cloud should fail")
+	}
+	path := writeScan(t, "0 0 0\n")
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "S", FullFileName: path}), &wire.PointCloudInfo{})
+	if _, err := r.Handle(s, "pointClouds.setCropActive", []byte(`{"cloud":"S","crop":"nope","active":true}`)); err == nil {
+		t.Error("setCropActive on a missing crop should fail")
+	}
+}
+
 // TestPointCloudMissingNameErrors: every name-keyed operation errors when no cloud has the name,
 // exercising the not-found branches of each handler (#645).
 func TestPointCloudMissingNameErrors(t *testing.T) {

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -64,8 +64,32 @@ func partNodeMenu(n BrowserNode) []BrowserMenuItem {
 		return bodyMenu(n.Select)
 	case "pointCloud":
 		return pointCloudMenu(n.Select)
+	case "pointCloudCrop":
+		return pointCloudCropMenu(n.Select)
 	default:
 		return nil
+	}
+}
+
+// pointCloudCropMenu offers an active toggle and Delete for a crop volume (#645).
+func pointCloudCropMenu(sel Selectable) []BrowserMenuItem {
+	h, ok := sel.(PointCloudCropHandle)
+	if !ok {
+		return nil
+	}
+	toggle := "Deactivate"
+	if !h.Crop.Active() {
+		toggle = "Activate"
+	}
+	return []BrowserMenuItem{
+		{Label: toggle, Enabled: true, Invoke: func(*Session) error {
+			h.Crop.SetActive(!h.Crop.Active())
+			return nil
+		}},
+		{Label: "Delete", Enabled: true, Invoke: func(*Session) error {
+			h.Cloud.Crops().Remove(h.Crop.Name())
+			return nil
+		}},
 	}
 }
 

--- a/app/point_cloud_browser.go
+++ b/app/point_cloud_browser.go
@@ -21,8 +21,19 @@ type PointCloudHandle struct {
 // SelectionKind implements Selectable.
 func (PointCloudHandle) SelectionKind() SelectionKind { return SelectPointCloud }
 
+// PointCloudCropHandle is the selectable browser handle for one crop: the owning cloud (for the
+// crop collection) and the crop itself.
+type PointCloudCropHandle struct {
+	Cloud *pointcloud.PointCloud
+	Crop  *pointcloud.PointCloudCrop
+}
+
+// SelectionKind implements Selectable.
+func (PointCloudCropHandle) SelectionKind() SelectionKind { return SelectPointCloud }
+
 // addPointCloudBranch lists the part's attached scans under a Point Clouds folder, a hidden cloud
-// tagged so its state reads in the tree. Omitted when the part has no clouds.
+// tagged so its state reads in the tree, each cloud nesting its crop volumes. Omitted when the
+// part has no clouds.
 func addPointCloudBranch(root *BrowserNode, part *compdef.PartComponentDefinition) {
 	clouds := part.PointClouds()
 	if clouds.Count() == 0 {
@@ -35,6 +46,20 @@ func addPointCloudBranch(root *BrowserNode, part *compdef.PartComponentDefinitio
 		if !pc.Visible() {
 			label += "  (hidden)"
 		}
-		folder.selectableChild(label, "pointCloud", PointCloudHandle{Clouds: clouds, Cloud: pc})
+		node := folder.selectableBranch(label, "pointCloud", PointCloudHandle{Clouds: clouds, Cloud: pc})
+		addCropNodes(node, pc)
+	}
+}
+
+// addCropNodes nests a cloud's crop volumes under its browser node, each tagged active/inactive.
+func addCropNodes(cloudNode *BrowserNode, pc *pointcloud.PointCloud) {
+	crops := pc.Crops()
+	for i := 0; i < crops.Count(); i++ {
+		c := crops.Item(i)
+		label := c.Name()
+		if !c.Active() {
+			label += "  (inactive)"
+		}
+		cloudNode.selectableChild(label, "pointCloudCrop", PointCloudCropHandle{Cloud: pc, Crop: c})
 	}
 }

--- a/app/point_cloud_ui_test.go
+++ b/app/point_cloud_ui_test.go
@@ -96,6 +96,51 @@ func TestAttachPointCloudAndRequest(t *testing.T) {
 	}
 }
 
+// TestBrowserNestsCropsWithMenu: a cloud's crops appear as child nodes (inactive ones tagged),
+// and the crop right-click menu toggles active and deletes (#645).
+func TestBrowserNestsCropsWithMenu(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, _ := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(0, 0, 0)})
+	crop := pc.AddCrop(math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)))
+
+	cloudNode := findChild(*findChild(BuildBrowser(s), "Point Clouds"), "Scan")
+	if cloudNode == nil || len(cloudNode.Children) != 1 || cloudNode.Children[0].Label != "Crop1" {
+		t.Fatalf("cloud node children = %+v, want one Crop1", cloudNode)
+	}
+
+	menu := BrowserMenu(cloudNode.Children[0])
+	if len(menu) != 2 || menu[0].Label != "Deactivate" {
+		t.Fatalf("crop menu = %+v, want Deactivate + Delete", menu)
+	}
+	_ = menu[0].Invoke(s)
+	if crop.Active() {
+		t.Error("Deactivate should have turned the crop off")
+	}
+	// Now the menu's toggle reads Activate, and the node is tagged inactive.
+	cloudNode = findChild(*findChild(BuildBrowser(s), "Point Clouds"), "Scan")
+	if cloudNode.Children[0].Label != "Crop1  (inactive)" {
+		t.Errorf("inactive crop label = %q, want the (inactive) tag", cloudNode.Children[0].Label)
+	}
+	if BrowserMenu(cloudNode.Children[0])[0].Label != "Activate" {
+		t.Error("an inactive crop's menu should offer Activate")
+	}
+	_ = menu[1].Invoke(s)
+	if pc.Crops().Count() != 0 {
+		t.Errorf("Delete left %d crops, want 0", pc.Crops().Count())
+	}
+}
+
+// TestPointCloudCropMenuWrongHandle: the crop menu rejects a non-crop handle (#645).
+func TestPointCloudCropMenuWrongHandle(t *testing.T) {
+	if pointCloudCropMenu(BodyHandle{}) != nil {
+		t.Error("pointCloudCropMenu with a non-crop handle should be nil")
+	}
+	if k := (PointCloudCropHandle{}).SelectionKind(); k != SelectPointCloud {
+		t.Errorf("crop handle SelectionKind = %v, want SelectPointCloud", k)
+	}
+}
+
 // TestPointCloudHandleKind: the browser handle reports the point-cloud selection kind (#645).
 func TestPointCloudHandleKind(t *testing.T) {
 	if k := (PointCloudHandle{}).SelectionKind(); k != SelectPointCloud {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.78.0
+	oblikovati.org/api v0.79.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.78.0
+	oblikovati.org/api v0.79.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/pointcloud_persist.go
+++ b/model/compdef/pointcloud_persist.go
@@ -51,7 +51,8 @@ func (d *PartComponentDefinition) scanPoints(rec doc.PointCloudRecord) []math.Po
 	return points
 }
 
-// recordOfCloud captures a cloud's metadata + placement (its points stay in the resource table).
+// recordOfCloud captures a cloud's metadata + placement + crops (its points stay in the resource
+// table).
 func recordOfCloud(pc *pointcloud.PointCloud) doc.PointCloudRecord {
 	return doc.PointCloudRecord{
 		Name:       pc.Name(),
@@ -61,17 +62,52 @@ func recordOfCloud(pc *pointcloud.PointCloud) doc.PointCloudRecord {
 		Scale:      pc.Scale(),
 		Transform:  cellsToFloats(pc.Transform().Cells()),
 		MaxPoints:  pc.MaximumPointCount(),
+		Crops:      cropRecords(pc.Crops()),
 	}
 }
 
-// cloudFromRecord rebuilds a cloud from its record and freshly decoded points.
+// cloudFromRecord rebuilds a cloud from its record and freshly decoded points, restoring its crops.
 func cloudFromRecord(rec doc.PointCloudRecord, points []math.Point3) *pointcloud.PointCloud {
 	pc := pointcloud.New(rec.Name, rec.Source, rec.ResourceID, points)
 	pc.SetVisible(rec.Visible)
 	pc.SetScale(rec.Scale) // rejected for a corrupt non-positive value, leaving the default 1
 	pc.SetTransform(math.Matrix4FromCells(floatsToCells(rec.Transform)))
 	pc.SetMaximumPointCount(rec.MaxPoints)
+	restoreCrops(pc, rec.Crops)
 	return pc
+}
+
+// cropRecords serialises a cloud's crop volumes.
+func cropRecords(crops *pointcloud.PointCloudCrops) []doc.PointCloudCropRecord {
+	out := make([]doc.PointCloudCropRecord, 0, crops.Count())
+	for i := 0; i < crops.Count(); i++ {
+		c := crops.Item(i)
+		out = append(out, doc.PointCloudCropRecord{
+			Name: c.Name(), Active: c.Active(),
+			Min: pointToFloats(c.Box().Min), Max: pointToFloats(c.Box().Max),
+		})
+	}
+	return out
+}
+
+// restoreCrops rebuilds a cloud's crops from their records (each named crop with its box + active
+// state).
+func restoreCrops(pc *pointcloud.PointCloud, records []doc.PointCloudCropRecord) {
+	for _, r := range records {
+		box := math.NewBox(floatsToPoint(r.Min), floatsToPoint(r.Max))
+		if c, ok := pc.Crops().Add(r.Name, box); ok {
+			c.SetActive(r.Active)
+		}
+	}
+}
+
+// pointToFloats / floatsToPoint bridge a Point3 and the record's plain float64 triple.
+func pointToFloats(p math.Point3) [3]float64 {
+	return [3]float64{float64(p.X), float64(p.Y), float64(p.Z)}
+}
+
+func floatsToPoint(f [3]float64) math.Point3 {
+	return math.P3(math.Scalar(f[0]), math.Scalar(f[1]), math.Scalar(f[2]))
 }
 
 // cellsToFloats / floatsToCells bridge the matrix cell array between math.Scalar and the record's

--- a/model/doc/pointcloud_records.go
+++ b/model/doc/pointcloud_records.go
@@ -19,6 +19,16 @@ type PointCloudRecord struct {
 	Scale      float64
 	Transform  [16]float64
 	MaxPoints  int
+	Crops      []PointCloudCropRecord
+}
+
+// PointCloudCropRecord is the serialisable form of one crop volume (#645): its name, whether it
+// is active, and its model-space box as min/max corners.
+type PointCloudCropRecord struct {
+	Name   string
+	Active bool
+	Min    [3]float64
+	Max    [3]float64
 }
 
 // PointCloudBearer is the optional interface content implements when it owns attached point

--- a/model/pointcloud/crop.go
+++ b/model/pointcloud/crop.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Crops limit which of a cloud's points display: a model-space box volume the user draws to focus
+// on a region of the scan (M17-F06, #645). When a cloud has one or more ACTIVE crops, only points
+// inside at least one active crop render (the crops union); with no active crop, every point shows.
+// Inactive crops are remembered but do not filter, so a crop can be toggled without redefining it.
+
+// PointCloudCrop is one named crop volume — a model-space axis-aligned box plus an active flag.
+type PointCloudCrop struct {
+	name   string
+	box    math.Box
+	active bool
+}
+
+// Name/Box/Active report the crop's identity, model-space bounds, and whether it filters display.
+func (c *PointCloudCrop) Name() string  { return c.name }
+func (c *PointCloudCrop) Box() math.Box { return c.box }
+func (c *PointCloudCrop) Active() bool  { return c.active }
+
+// SetActive toggles whether the crop limits display; SetBox redefines its volume.
+func (c *PointCloudCrop) SetActive(a bool)  { c.active = a }
+func (c *PointCloudCrop) SetBox(b math.Box) { c.box = b }
+
+// PointCloudCrops is a cloud's crop-volume collection.
+type PointCloudCrops struct {
+	items []*PointCloudCrop
+}
+
+// Count returns the number of crops; Item returns the i-th in creation order.
+func (cs *PointCloudCrops) Count() int                 { return len(cs.items) }
+func (cs *PointCloudCrops) Item(i int) *PointCloudCrop { return cs.items[i] }
+
+// Names returns the crop names in creation order.
+func (cs *PointCloudCrops) Names() []string {
+	out := make([]string, len(cs.items))
+	for i, c := range cs.items {
+		out[i] = c.name
+	}
+	return out
+}
+
+// ByName returns the named crop, ok=false when absent.
+func (cs *PointCloudCrops) ByName(name string) (*PointCloudCrop, bool) {
+	for _, c := range cs.items {
+		if c.name == name {
+			return c, true
+		}
+	}
+	return nil, false
+}
+
+// Add appends an active crop over box under name; an empty name is rejected, a duplicate errors
+// via the returned ok=false. The crop starts active so a freshly drawn crop immediately focuses.
+func (cs *PointCloudCrops) Add(name string, box math.Box) (*PointCloudCrop, bool) {
+	if name == "" {
+		return nil, false
+	}
+	if _, exists := cs.ByName(name); exists {
+		return nil, false
+	}
+	c := &PointCloudCrop{name: name, box: box, active: true}
+	cs.items = append(cs.items, c)
+	return c, true
+}
+
+// Remove deletes the named crop, reporting whether it existed.
+func (cs *PointCloudCrops) Remove(name string) bool {
+	for i, c := range cs.items {
+		if c.name == name {
+			cs.items = append(cs.items[:i], cs.items[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// anyActive reports whether at least one crop is currently filtering display.
+func (cs *PointCloudCrops) anyActive() bool {
+	for _, c := range cs.items {
+		if c.active {
+			return true
+		}
+	}
+	return false
+}
+
+// Admits reports whether a model-space point passes the active crops: true when no crop is active
+// (unfiltered), else true only inside at least one active crop.
+func (cs *PointCloudCrops) Admits(p math.Point3) bool {
+	anyActive := false
+	for _, c := range cs.items {
+		if !c.active {
+			continue
+		}
+		anyActive = true
+		if c.box.Contains(p) {
+			return true
+		}
+	}
+	return !anyActive
+}
+
+// uniqueName returns base suffixed with the smallest positive integer free in the collection.
+func (cs *PointCloudCrops) uniqueName(base string) string {
+	for i := 1; ; i++ {
+		name := fmt.Sprintf("%s%d", base, i)
+		if _, exists := cs.ByName(name); !exists {
+			return name
+		}
+	}
+}

--- a/model/pointcloud/crop_test.go
+++ b/model/pointcloud/crop_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// gridCloud returns a cloud of points at integer x in [0,9], y=z=0.
+func gridCloud() *PointCloud {
+	var pts []math.Point3
+	for i := 0; i < 10; i++ {
+		pts = append(pts, math.P3(math.Scalar(i), 0, 0))
+	}
+	return New("scan", "", "", pts)
+}
+
+// TestCropLimitsDisplayedPoints: an active crop limits the displayed (model-space) points to those
+// inside its box; toggling it off restores the full set.
+func TestCropLimitsDisplayedPoints(t *testing.T) {
+	pc := gridCloud()
+	if pc.DisplayedPointCount() != 10 {
+		t.Fatalf("uncropped displayed count = %d, want 10", pc.DisplayedPointCount())
+	}
+
+	crop := pc.AddCrop(math.NewBox(math.P3(-0.5, -1, -1), math.P3(3.5, 1, 1))) // x in [0,3]
+	if pc.DisplayedPointCount() != 4 {
+		t.Errorf("cropped displayed count = %d, want 4 (x 0..3)", pc.DisplayedPointCount())
+	}
+	for _, p := range pc.DisplayedPoints() {
+		if p.X < 0 || p.X > 3 {
+			t.Errorf("displayed point %v outside the crop", p)
+		}
+	}
+
+	crop.SetActive(false)
+	if pc.DisplayedPointCount() != 10 {
+		t.Errorf("after deactivating the crop, displayed = %d, want 10", pc.DisplayedPointCount())
+	}
+}
+
+// TestCropsUnion: two active crops admit the union of their boxes.
+func TestCropsUnion(t *testing.T) {
+	pc := gridCloud()
+	pc.AddCrop(math.NewBox(math.P3(-0.5, -1, -1), math.P3(1.5, 1, 1))) // x 0,1
+	pc.AddCrop(math.NewBox(math.P3(7.5, -1, -1), math.P3(9.5, 1, 1)))  // x 8,9
+	if pc.DisplayedPointCount() != 4 {
+		t.Errorf("two-crop union displayed = %d, want 4 (x 0,1,8,9)", pc.DisplayedPointCount())
+	}
+}
+
+// TestCropBudgetOrder: the display budget applies after cropping, so the cap counts cropped points.
+func TestCropBudgetOrder(t *testing.T) {
+	pc := gridCloud()
+	pc.AddCrop(math.NewBox(math.P3(-0.5, -1, -1), math.P3(5.5, 1, 1))) // x 0..5 → 6 points
+	pc.SetMaximumPointCount(3)
+	if pc.DisplayedPointCount() != 3 || len(pc.DisplayedPoints()) != 3 {
+		t.Errorf("budgeted cropped count = %d / %d, want 3", pc.DisplayedPointCount(), len(pc.DisplayedPoints()))
+	}
+}
+
+// TestCropCollection: add/byName/remove/names + unique-name minting and bad-name rejection.
+func TestCropCollection(t *testing.T) {
+	pc := gridCloud()
+	c1 := pc.AddCrop(math.EmptyBox())
+	c2 := pc.AddCrop(math.EmptyBox())
+	if c1.Name() != "Crop1" || c2.Name() != "Crop2" {
+		t.Errorf("crop names = %q/%q, want Crop1/Crop2", c1.Name(), c2.Name())
+	}
+	crops := pc.Crops()
+	if crops.Count() != 2 || len(crops.Names()) != 2 {
+		t.Errorf("crops Count/Names mismatch: %d", crops.Count())
+	}
+	if got, ok := crops.ByName("Crop2"); !ok || got != c2 {
+		t.Error("ByName(Crop2) failed")
+	}
+	if _, ok := crops.Add("", math.EmptyBox()); ok {
+		t.Error("Add with empty name should fail")
+	}
+	if _, ok := crops.Add("Crop1", math.EmptyBox()); ok {
+		t.Error("Add with duplicate name should fail")
+	}
+	if !crops.Remove("Crop1") || crops.Remove("Crop1") {
+		t.Error("Remove(Crop1) should be true once then false")
+	}
+}

--- a/model/pointcloud/crop_test.go
+++ b/model/pointcloud/crop_test.go
@@ -61,6 +61,24 @@ func TestCropBudgetOrder(t *testing.T) {
 	}
 }
 
+// TestCropAccessors: the crop's box/active accessors and setters round-trip, and Item resolves it.
+func TestCropAccessors(t *testing.T) {
+	pc := gridCloud()
+	box := math.NewBox(math.P3(1, 2, 3), math.P3(4, 5, 6))
+	c := pc.AddCrop(box)
+	if c.Box() != box || !c.Active() {
+		t.Fatalf("new crop = box %+v active %v, want %+v / true", c.Box(), c.Active(), box)
+	}
+	c.SetBox(math.EmptyBox())
+	c.SetActive(false)
+	if c.Active() || !c.Box().IsEmpty() {
+		t.Error("SetBox/SetActive did not take")
+	}
+	if pc.Crops().Item(0) != c {
+		t.Error("Item(0) should return the added crop")
+	}
+}
+
 // TestCropCollection: add/byName/remove/names + unique-name minting and bad-name rejection.
 func TestCropCollection(t *testing.T) {
 	pc := gridCloud()

--- a/model/pointcloud/pointcloud.go
+++ b/model/pointcloud/pointcloud.go
@@ -18,6 +18,17 @@ type PointCloud struct {
 	source     string        // SourceFullFileName (display / re-link metadata)
 	resourceID string        // ADR-0031 resource UUID addressing the scan bytes
 	maxPoints  int           // display budget; 0 = show every point
+	crops      PointCloudCrops
+}
+
+// Crops returns the cloud's crop-volume collection — the model-space boxes that limit display
+// (#645). AddCrop is the factory: it mints a unique name and starts the crop active.
+func (pc *PointCloud) Crops() *PointCloudCrops { return &pc.crops }
+
+// AddCrop adds an active crop over the given model-space box under a freshly minted name.
+func (pc *PointCloud) AddCrop(box math.Box) *PointCloudCrop {
+	c, _ := pc.crops.Add(pc.crops.uniqueName("Crop"), box)
+	return c
 }
 
 // New creates a cloud from decoded cloud-local points. It starts visible, unscaled (factor 1),
@@ -64,13 +75,28 @@ func (pc *PointCloud) SourceFullFileName() string { return pc.source }
 func (pc *PointCloud) ResourceID() string         { return pc.resourceID }
 
 // TotalPointCount returns how many points the scan holds; DisplayedPointCount returns how many
-// render after the display budget (MaximumPointCount) is applied.
+// render after the active crops and the display budget (MaximumPointCount) are applied.
 func (pc *PointCloud) TotalPointCount() int { return len(pc.points) }
 func (pc *PointCloud) DisplayedPointCount() int {
-	if pc.maxPoints <= 0 || pc.maxPoints >= len(pc.points) {
+	n := pc.croppedCount()
+	if pc.maxPoints > 0 && pc.maxPoints < n {
+		return pc.maxPoints
+	}
+	return n
+}
+
+// croppedCount returns how many points pass the active crops (all of them when none is active).
+func (pc *PointCloud) croppedCount() int {
+	if !pc.crops.anyActive() {
 		return len(pc.points)
 	}
-	return pc.maxPoints
+	n := 0
+	for _, p := range pc.points {
+		if pc.crops.Admits(pc.ToModelSpace(p)) {
+			n++
+		}
+	}
+	return n
 }
 
 // MaximumPointCount/SetMaximumPointCount get and set the display budget (0 = unbounded). A
@@ -100,26 +126,35 @@ func (pc *PointCloud) FromModelSpace(p math.Point3) (math.Point3, bool) {
 // CloudPoints returns the scan points in cloud-local space (the decoded coordinates).
 func (pc *PointCloud) CloudPoints() []math.Point3 { return pc.points }
 
-// DisplayedPoints returns the budgeted point set in MODEL space — what the renderer draws. When
-// a display budget is set it strides evenly across the scan so the sample stays spatially
-// representative rather than a truncated prefix.
+// DisplayedPoints returns the rendered point set in MODEL space — the points passing the active
+// crops, then strided evenly to the display budget so the sample stays spatially representative
+// rather than a truncated prefix.
 func (pc *PointCloud) DisplayedPoints() []math.Point3 {
-	out := make([]math.Point3, 0, pc.DisplayedPointCount())
-	for _, p := range pc.sampledCloudPoints() {
-		out = append(out, pc.ToModelSpace(p))
+	return strideSample(pc.croppedModelPoints(), pc.maxPoints)
+}
+
+// croppedModelPoints returns every point in MODEL space that passes the active crops.
+func (pc *PointCloud) croppedModelPoints() []math.Point3 {
+	out := make([]math.Point3, 0, len(pc.points))
+	for _, p := range pc.points {
+		m := pc.ToModelSpace(p)
+		if pc.crops.Admits(m) {
+			out = append(out, m)
+		}
 	}
 	return out
 }
 
-// sampledCloudPoints returns the cloud-local points after the display budget, strided evenly.
-func (pc *PointCloud) sampledCloudPoints() []math.Point3 {
-	if pc.maxPoints <= 0 || pc.maxPoints >= len(pc.points) {
-		return pc.points
+// strideSample returns pts capped to max entries, taken at an even stride (the whole slice when
+// max is 0 or already within budget).
+func strideSample(pts []math.Point3, max int) []math.Point3 {
+	if max <= 0 || max >= len(pts) {
+		return pts
 	}
-	stride := len(pc.points) / pc.maxPoints
-	out := make([]math.Point3, 0, pc.maxPoints)
-	for i := 0; i < len(pc.points) && len(out) < pc.maxPoints; i += stride {
-		out = append(out, pc.points[i])
+	stride := len(pts) / max
+	out := make([]math.Point3, 0, max)
+	for i := 0; i < len(pts) && len(out) < max; i += stride {
+		out = append(out, pts[i])
 	}
 	return out
 }

--- a/persistence/pointcloud_roundtrip_test.go
+++ b/persistence/pointcloud_roundtrip_test.go
@@ -40,6 +40,8 @@ func TestPointCloudSurvivesStoreRoundTrip(t *testing.T) {
 	pc.SetScale(2.5)
 	pc.SetMaximumPointCount(2)
 	pc.SetTransform(translation4(10, 0, 0))
+	crop := pc.AddCrop(math.NewBox(math.P3(0, 0, 0), math.P3(5, 5, 5)))
+	crop.SetActive(false)
 
 	if err := ws.Save(d); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -65,6 +67,10 @@ func TestPointCloudSurvivesStoreRoundTrip(t *testing.T) {
 	}
 	if got.SourceFullFileName() != "room.xyz" || got.ResourceID() != rid {
 		t.Errorf("reopened source/resource = %q/%q, want room.xyz/%q", got.SourceFullFileName(), got.ResourceID(), rid)
+	}
+	rc, ok := got.Crops().ByName("Crop1")
+	if !ok || rc.Active() || rc.Box().Max != math.P3(5, 5, 5) {
+		t.Errorf("reopened crop = %+v (ok=%v), want an inactive Crop1 to (5,5,5)", rc, ok)
 	}
 }
 

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -352,6 +352,7 @@ func toCodecPointClouds(in []doc.PointCloudRecord) []yamlcodec.PointCloudRecord 
 		out[i] = yamlcodec.PointCloudRecord{
 			Name: r.Name, Source: r.Source, ResourceID: r.ResourceID,
 			Visible: r.Visible, Scale: r.Scale, Transform: r.Transform, MaxPoints: r.MaxPoints,
+			Crops: toCodecCrops(r.Crops),
 		}
 	}
 	return out
@@ -366,7 +367,31 @@ func fromCodecPointClouds(in []yamlcodec.PointCloudRecord) []doc.PointCloudRecor
 		out[i] = doc.PointCloudRecord{
 			Name: r.Name, Source: r.Source, ResourceID: r.ResourceID,
 			Visible: r.Visible, Scale: r.Scale, Transform: r.Transform, MaxPoints: r.MaxPoints,
+			Crops: fromCodecCrops(r.Crops),
 		}
+	}
+	return out
+}
+
+// toCodecCrops / fromCodecCrops bridge the document and on-disk crop-volume records (#645).
+func toCodecCrops(in []doc.PointCloudCropRecord) []yamlcodec.PointCloudCropRecord {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]yamlcodec.PointCloudCropRecord, len(in))
+	for i, c := range in {
+		out[i] = yamlcodec.PointCloudCropRecord{Name: c.Name, Active: c.Active, Min: c.Min, Max: c.Max}
+	}
+	return out
+}
+
+func fromCodecCrops(in []yamlcodec.PointCloudCropRecord) []doc.PointCloudCropRecord {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]doc.PointCloudCropRecord, len(in))
+	for i, c := range in {
+		out[i] = doc.PointCloudCropRecord{Name: c.Name, Active: c.Active, Min: c.Min, Max: c.Max}
 	}
 	return out
 }

--- a/persistence/yamlcodec/yamlcodec.go
+++ b/persistence/yamlcodec/yamlcodec.go
@@ -155,13 +155,23 @@ type AttachmentRecord struct {
 // id of the resource holding its bytes, visibility, scale, the 16 cloud→model transform cells,
 // and the display point budget. The points themselves live once in the resource table.
 type PointCloudRecord struct {
-	Name       string      `yaml:"name"`
-	Source     string      `yaml:"source,omitempty"`
-	ResourceID string      `yaml:"resourceId,omitempty"`
-	Visible    bool        `yaml:"visible"`
-	Scale      float64     `yaml:"scale"`
-	Transform  [16]float64 `yaml:"transform,flow"`
-	MaxPoints  int         `yaml:"maxPoints,omitempty"`
+	Name       string                 `yaml:"name"`
+	Source     string                 `yaml:"source,omitempty"`
+	ResourceID string                 `yaml:"resourceId,omitempty"`
+	Visible    bool                   `yaml:"visible"`
+	Scale      float64                `yaml:"scale"`
+	Transform  [16]float64            `yaml:"transform,flow"`
+	MaxPoints  int                    `yaml:"maxPoints,omitempty"`
+	Crops      []PointCloudCropRecord `yaml:"crops,omitempty"`
+}
+
+// PointCloudCropRecord is one crop volume (#645): a name, the active flag, and the model-space box
+// min/max corners.
+type PointCloudCropRecord struct {
+	Name   string     `yaml:"name"`
+	Active bool       `yaml:"active"`
+	Min    [3]float64 `yaml:"min,flow"`
+	Max    [3]float64 `yaml:"max,flow"`
 }
 
 // InterestRecord is one add-in data-registry entry (M03-F10): client X has


### PR DESCRIPTION
## What
**Crop volumes** for attached point clouds (M17-F06): a model-space box on a cloud that, while active, limits its display to points inside (a cloud's active crops union; none active = every point shows). A crop focuses the viewport on a working region of a large scan.

## Layers
- **Model** — `PointCloud.Crops()` collection; `DisplayedPoints`/`DisplayedPointCount` filter through the active crops before the display budget.
- **Persistence** — crops round-trip in the `.obk` (name + active + box) on the cloud record.
- **API** (pinned to api **v0.79.0**, Oblikovati/Oblikovati.API#199) — `pointClouds.addCrop`/`listCrops`/`deleteCrop`/`setCropActive`, served on the active part.
- **Browser** — each cloud node nests its crop volumes (inactive ones tagged) with an Activate/Deactivate + Delete right-click menu.

## Tests
- `model/pointcloud`: crop admit/union, displayed-count filtering, budget-after-crop order, collection.
- `persistence`: crop survives a save/open round-trip.
- `addin/router`: crop lifecycle over the wire (limit → toggle → list → delete) + errors.
- `app`: browser nesting + crop menu (activate/delete).

## Next
PR 4 snappable `PointCloudPoint`/`PointCloudPlane` (modeling input) · PR 5 scans/regions + proxies + LAS/E57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)