### PR TITLE
Point clouds: snap to scan points (PR 4 of #645)

### DIFF
--- a/app/point_cloud_browser.go
+++ b/app/point_cloud_browser.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/pointcloud"
 )
@@ -20,6 +21,20 @@ type PointCloudHandle struct {
 
 // SelectionKind implements Selectable.
 func (PointCloudHandle) SelectionKind() SelectionKind { return SelectPointCloud }
+
+// PointCloudPointHandle is a snapped scan point: the owning cloud and the picked point's
+// model-space location. A point-collecting tool reads Position to model against as-built scan
+// data (M17-F06, #645). It is what the ray picker returns when the cursor snaps to a cloud point.
+type PointCloudPointHandle struct {
+	Cloud *pointcloud.PointCloud
+	Point math.Point3
+}
+
+// SelectionKind implements Selectable.
+func (PointCloudPointHandle) SelectionKind() SelectionKind { return SelectPointCloudPoint }
+
+// Position returns the snapped point's model-space location.
+func (h PointCloudPointHandle) Position() math.Point3 { return h.Point }
 
 // PointCloudCropHandle is the selectable browser handle for one crop: the owning cloud (for the
 // crop collection) and the crop itself.

--- a/app/point_cloud_render.go
+++ b/app/point_cloud_render.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"oblikovati.org/math"
 	"oblikovati.org/model/pointcloud"
 	"oblikovati.org/renderer"
 )
@@ -28,6 +29,43 @@ func (s *Session) PointCloudItems(markerSize float64) []renderer.DrawItem {
 		}
 	}
 	return items
+}
+
+// PickablePointClouds returns the active part's visible attached clouds — the snap targets the ray
+// picker tests for cloud-point snapping (M17-F06, #645). Empty when the active document is not a
+// part. The picker itself skips hidden clouds, but filtering here keeps the provider lean.
+func (s *Session) PickablePointClouds() []*pointcloud.PointCloud {
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	clouds := part.PointClouds()
+	out := make([]*pointcloud.PointCloud, 0, clouds.Count())
+	for i := 0; i < clouds.Count(); i++ {
+		if pc := clouds.Item(i); pc.Visible() {
+			out = append(out, pc)
+		}
+	}
+	return out
+}
+
+// CloudPointHighlightColor is the marker color for a selected (snapped) scan point.
+var cloudPointHighlightColor = [4]float32{1.0, 0.62, 0.1, 1}
+
+// SelectedCloudPointHighlight returns an on-top highlight marker for the currently selected scan
+// point (a larger orange cross at its location), or ok=false when the selection is not a cloud
+// point — the visible feedback that a click snapped to a scan point (M17-F06, #645).
+func (s *Session) SelectedCloudPointHighlight(markerSize float64) (renderer.DrawItem, bool) {
+	h, ok := s.Selection().First().(PointCloudPointHandle)
+	if !ok {
+		return renderer.DrawItem{}, false
+	}
+	item := renderer.PointMarkers([]math.Point3{h.Point}, markerSize*2.5, cloudPointHighlightColor, 0)
+	if item == nil {
+		return renderer.DrawItem{}, false
+	}
+	item.OnTop = true // draw over the model so the snap reads clearly
+	return *item, true
 }
 
 // cloudDrawItem builds one visible cloud's marker batch; nil for a hidden or empty cloud.

--- a/app/point_cloud_snap_test.go
+++ b/app/point_cloud_snap_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/pointcloud"
+)
+
+// cloudPicker builds a ray picker over a session's attached clouds (no bodies), framed by the
+// session camera.
+func cloudPicker(s *Session) *RayPicker {
+	p := NewRayPicker(s.Camera(), func() []*topo.Body { return nil }).
+		WithPointClouds(func() []*pointcloud.PointCloud { return s.PickablePointClouds() })
+	p.SetCamera(s.Camera())
+	return p
+}
+
+// TestPickSnapsToCloudPoint: a click at the screen position of a scan point snaps to it, returning
+// a PointCloudPointHandle at the point's model-space location (M17-F06, #645).
+func TestPickSnapsToCloudPoint(t *testing.T) {
+	s, def := emptyPartSession(t) // camera at (0,0,10) → origin projects to screen centre (100,100)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	if _, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(0, 0, 0)}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	sel, ok := cloudPicker(s).Pick(100, 100, NewSelectionFilter())
+	if !ok {
+		t.Fatal("a click at the scan point's screen position should snap to it")
+	}
+	h, isCloud := sel.(PointCloudPointHandle)
+	if !isCloud {
+		t.Fatalf("picked %T, want PointCloudPointHandle", sel)
+	}
+	if h.Position() != math.P3(0, 0, 0) {
+		t.Errorf("snapped location = %v, want the origin point", h.Position())
+	}
+}
+
+// TestPickMissesHiddenCloud: a hidden cloud's points do not snap, and a click away from any point
+// returns no hit (#645).
+func TestPickMissesHiddenCloud(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, _ := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(0, 0, 0)})
+	pc.SetVisible(false)
+
+	if _, ok := cloudPicker(s).Pick(100, 100, NewSelectionFilter()); ok {
+		t.Error("a hidden cloud should not snap")
+	}
+	pc.SetVisible(true)
+	if _, ok := cloudPicker(s).Pick(10, 10, NewSelectionFilter()); ok {
+		t.Error("a click far from any scan point should not snap")
+	}
+}
+
+// TestPointCloudPointHandleKind: the snap handle reports its selection kind (#645).
+func TestPointCloudPointHandleKind(t *testing.T) {
+	if k := (PointCloudPointHandle{}).SelectionKind(); k != SelectPointCloudPoint {
+		t.Errorf("SelectionKind = %v, want SelectPointCloudPoint", k)
+	}
+}
+
+// TestSelectedCloudPointHighlight: selecting a snapped scan point yields an on-top highlight marker
+// at its location; a non-cloud selection yields none (#645).
+func TestSelectedCloudPointHighlight(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if _, ok := s.SelectedCloudPointHighlight(0.5); ok {
+		t.Error("no selection should yield no highlight")
+	}
+	s.Select(PointCloudPointHandle{Point: math.P3(2, 0, 0)})
+	hi, ok := s.SelectedCloudPointHighlight(0.5)
+	if !ok || !hi.OnTop || len(hi.Positions) != 6 {
+		t.Errorf("highlight = %+v (ok=%v), want an on-top 6-vertex cross", hi, ok)
+	}
+}

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -10,6 +10,7 @@ import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
+	"oblikovati.org/model/pointcloud"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/scene"
 )
@@ -27,6 +28,7 @@ type RayPicker struct {
 	axes         func() []*feature.WorkAxis
 	sketches     func() []*sketch.Sketch
 	sketches3D   func() []*sketch.Sketch3D
+	pointClouds  func() []*pointcloud.PointCloud                 // attached scans whose points snap (#645)
 	occurrenceOf func(*topo.Body) (*occurrence.Occurrence, bool) // maps an assembly body hit to its component (#769)
 }
 
@@ -60,6 +62,13 @@ func (p *RayPicker) WithSketches(sketches func() []*sketch.Sketch) *RayPicker {
 // (issue #142).
 func (p *RayPicker) WithSketches3D(sketches3D func() []*sketch.Sketch3D) *RayPicker {
 	p.sketches3D = sketches3D
+	return p
+}
+
+// WithPointClouds adds a provider of the part's visible attached scans, so the cursor snaps to a
+// scan point and a point-collecting tool can model against it (M17-F06, #645).
+func (p *RayPicker) WithPointClouds(clouds func() []*pointcloud.PointCloud) *RayPicker {
+	p.pointClouds = clouds
 	return p
 }
 
@@ -210,6 +219,9 @@ func (p *RayPicker) snapPick(origin math.Point3, dir math.Vector3, filter *Selec
 	}
 	if ax, _ := p.nearestAxis(origin, dir); ax != nil && filter.Accepts(SelectWorkAxis) {
 		return WorkAxisHandle{Axis: ax}, true
+	}
+	if pt, cloud, ok := p.nearestCloudPoint(origin, dir); ok && filter.Accepts(SelectPointCloudPoint) {
+		return PointCloudPointHandle{Cloud: cloud, Point: pt}, true
 	}
 	if v := p.nearestVertex(origin, dir); v != nil && filter.Accepts(SelectVertex) {
 		return VertexHandle{Vertex: v}, true
@@ -445,6 +457,34 @@ func (p *RayPicker) nearestPoint(origin math.Point3, dir math.Vector3) (*feature
 		}
 	}
 	return hit, best
+}
+
+// nearestCloudPoint returns the displayed scan point closest to the ray within the pixel-snap
+// radius, across every visible attached cloud, and its owning cloud (or ok=false if none). Only
+// the budgeted, cropped DisplayedPoints are tested — what the user actually sees and can snap to.
+func (p *RayPicker) nearestCloudPoint(origin math.Point3, dir math.Vector3) (math.Point3, *pointcloud.PointCloud, bool) {
+	if p.pointClouds == nil {
+		return math.Point3{}, nil, false
+	}
+	tol := pickPixelRadius * p.camera.WorldPerPixel()
+	var hit math.Point3
+	var owner *pointcloud.PointCloud
+	best := stdmath.Inf(1)
+	for _, cloud := range p.pointClouds() {
+		if !cloud.Visible() {
+			continue
+		}
+		for _, pt := range cloud.DisplayedPoints() {
+			t := origin.VectorTo(pt).Dot(dir)
+			if t <= 0 || t >= best {
+				continue
+			}
+			if origin.TranslateBy(dir.Scale(t)).DistanceTo(pt) <= tol {
+				best, hit, owner = t, pt, cloud
+			}
+		}
+	}
+	return hit, owner, owner != nil
 }
 
 // nearestAxis returns the closest datum axis within the pixel-snap radius of the ray, and

--- a/app/selection.go
+++ b/app/selection.go
@@ -36,6 +36,7 @@ const (
 	SelectModelState
 	SelectDrawingView
 	SelectPointCloud
+	SelectPointCloudPoint
 )
 
 // Selectable is anything the selection set can hold. Concrete handles wrap the

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -28,6 +28,7 @@ import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/pointcloud"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/persistence"
 	"oblikovati.org/persistence/userprefs"
@@ -220,6 +221,7 @@ func installPicker(s *app.Session) {
 			return activeSketches(s)
 		}).
 		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }).
+		WithPointClouds(func() []*pointcloud.PointCloud { return s.PickablePointClouds() }).
 		WithOccurrenceLookup(s.OccurrenceOfBody)
 	s.SetPicker(picker)
 	s.SetRegionPicker(picker) // the same picker answers box-select (window/crossing)

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -554,10 +554,15 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	return list
 }
 
-// pointCloudOverlay builds the active part's visible point-cloud marker batches, sized in screen
-// space so each cross stays a fixed pixel size at any zoom (like sketch point markers, #645).
+// pointCloudOverlay builds the active part's visible point-cloud marker batches, plus a highlight
+// for a snapped/selected scan point, sized in screen space so each cross stays a fixed pixel size
+// at any zoom (like sketch point markers, #645).
 func pointCloudOverlay(s *app.Session, cam scene.Camera) []renderer.DrawItem {
-	return s.PointCloudItems(pointCloudMarkerPixels * cam.WorldPerPixel())
+	items := s.PointCloudItems(pointCloudMarkerPixels * cam.WorldPerPixel())
+	if hi, ok := s.SelectedCloudPointHighlight(pointCloudMarkerPixels * cam.WorldPerPixel()); ok {
+		items = append(items, hi)
+	}
+	return items
 }
 
 // pointCloudMarkerPixels is the on-screen half-extent of a point-cloud cross marker.

--- a/head/ui/point_cloud_shot_test.go
+++ b/head/ui/point_cloud_shot_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"oblikovati.org/app"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
@@ -34,6 +35,8 @@ func TestInWindowPointCloudRenders(t *testing.T) {
 	if len(s.PointCloudItems(0.5)) != 1 {
 		t.Fatalf("expected one point-cloud draw item, got %d", len(s.PointCloudItems(0.5)))
 	}
+	// Select a scan point so its orange snap-highlight reads among the cyan grid.
+	s.Select(app.PointCloudPointHandle{Point: math.P3(0, 0, 0)})
 
 	for i := 0; i < 8; i++ {
 		win.BeginFrame()


### PR DESCRIPTION
## What
Interactive **snapping to point-cloud scan points** — the core 'model against as-built reality' capability. The viewport cursor snaps to the nearest visible scan point, selecting it with a clear highlight, and the picked handle carries the snapped model-space location for point-collecting tools to consume.

## Pieces
- **Picker** — `RayPicker.WithPointClouds` + `nearestCloudPoint`: across every visible cloud, the nearest *displayed* (budgeted + cropped) point within the pixel-snap radius wins, returning a `PointCloudPointHandle` whose `Position()` is the snapped location. Slots into `snapPick` alongside vertices/work-points.
- **Highlight** — `SelectedCloudPointHighlight` draws an on-top orange cross at a selected scan point, so a snap reads clearly.
- **Wiring** — the head picker chain gains `WithPointClouds(PickablePointClouds)` (the active part's visible clouds).

## Visual confirmation
Live in-window capture: the cyan scan grid with **one orange highlighted point** where a scan point is selected (confirmed by viewing the PNG).

## Tests
- `app`: a click at a scan point's screen position snaps to it (`PointCloudPointHandle` at the right location); hidden clouds and empty space don't snap; the selection highlight item.
- `head/ui`: in-window capture of the selected-point highlight.

## Scope
This is the snapping foundation: snap-select + highlight + a location-bearing handle. **Next (PR 5):** consumers (a work point / sketch point *at* a snapped scan point), `PointCloudPlane` (fit a plane to a region), a `pointClouds.nearestPoint` query API, and scans/regions + LAS/E57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)