### PR TITLE
Point clouds: PLY scan reader (PR 5 of #645)

### DIFF
--- a/head/ui/point_cloud_real_shot_test.go
+++ b/head/ui/point_cloud_real_shot_test.go
@@ -1,0 +1,66 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+// realScanPath is a sample Artec PLY scan; the test skips when it is not present (e.g. CI).
+const realScanPath = "/home/vmiguel/git/oblikovati-workspace/vini-scan-examples/vini scan examples/capstan vertraging.ply"
+
+// TestInWindowRealScanRenders attaches a real binary-PLY laser scan to the active part, budgets and
+// frames it, and captures the live viewport — the visual confirmation that the PLY reader + render
+// path handle real-world scan data (M17-F06, #645). Skips without the sample file or a display.
+func TestInWindowRealScanRenders(t *testing.T) {
+	if _, err := os.Stat(realScanPath); err != nil {
+		t.Skipf("sample scan not present: %v", err)
+	}
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	pc, err := s.AttachPointCloud("Capstan", realScanPath)
+	if err != nil {
+		t.Fatalf("attach real scan: %v", err)
+	}
+	t.Logf("loaded %d scan points", pc.TotalPointCount())
+	pc.SetMaximumPointCount(50000) // budget the 266k-point scan for display
+
+	frameCameraOn(s, pc.RangeBox())
+
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-real-scan.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}
+
+// frameCameraOn points the session camera at a box's centre from a 3/4 view at a distance scaled
+// to its diagonal, so the whole cloud sits in frame.
+func frameCameraOn(s *app.Session, box math.Box) {
+	center := box.Center()
+	d := float64(box.Diagonal().Length())
+	if d <= 0 {
+		d = 1
+	}
+	cam := scene.NewCamera(inWinW, inWinH)
+	off := math.V3(0.6, -0.8, 0.6).Scale(math.Scalar(d * 1.3))
+	cam.Eye = center.TranslateBy(off)
+	cam.Target = center
+	cam.Up = math.V3(0, 0, 1)
+	s.SetCamera(cam)
+}

--- a/model/pointcloud/ply.go
+++ b/model/pointcloud/ply.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	omath "oblikovati.org/math"
+)
+
+// PLY point reader (M17-F06, #645): decodes the vertex positions of a Stanford PLY file —
+// the common export of structured-light / photogrammetry scanners (Artec, etc.). A PLY may carry
+// a full mesh (vertices + faces); a point cloud needs only the vertex x/y/z, so the reader parses
+// the header, reads the vertex element's positions (skipping any extra per-vertex properties such
+// as normals or colour), and ignores the faces. Both ASCII and binary (little/big-endian)
+// encodings are handled. Clean-room from the published PLY format.
+type plyReader struct{}
+
+// NewPLYReader returns the reader for Stanford .ply scan files.
+func NewPLYReader() PointReader { return plyReader{} }
+
+func (plyReader) Extensions() []string { return []string{".ply"} }
+
+// plyProperty is one declared property of an element: its scalar type (empty for a list property,
+// which the reader skips) and, for a list, the size of its count and element scalars.
+type plyProperty struct {
+	name      string
+	scalar    string // "" for a list property
+	listCount string // list count type (e.g. "uchar"), "" for scalar
+	listElem  string // list element type
+}
+
+// plyElement is one declared element block: its name, instance count, and properties in order.
+type plyElement struct {
+	name  string
+	count int
+	props []plyProperty
+}
+
+// Read decodes the PLY's vertex positions into cloud-local points.
+func (plyReader) Read(data []byte) ([]omath.Point3, error) {
+	format, elements, body, err := parsePLYHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	vtx, ok := findElement(elements, "vertex")
+	if !ok || vtx.count == 0 {
+		return nil, fmt.Errorf("pointcloud: PLY has no vertex element")
+	}
+	xi, yi, zi, err := xyzIndices(vtx)
+	if err != nil {
+		return nil, err
+	}
+	if format == "ascii" {
+		return readASCIIVertices(body, vtx, xi, yi, zi)
+	}
+	return readBinaryVertices(body, vtx, xi, yi, zi, format == "binary_big_endian")
+}
+
+// parsePLYHeader reads the ASCII header and returns the format, the element declarations, and the
+// body bytes that follow "end_header".
+func parsePLYHeader(data []byte) (string, []plyElement, []byte, error) {
+	end := bytes.Index(data, []byte("end_header"))
+	if !bytes.HasPrefix(data, []byte("ply")) || end < 0 {
+		return "", nil, nil, fmt.Errorf("pointcloud: not a PLY file (missing magic / end_header)")
+	}
+	body := data[end:]
+	if nl := bytes.IndexByte(body, '\n'); nl >= 0 {
+		body = body[nl+1:]
+	}
+	format := ""
+	var elements []plyElement
+	sc := bufio.NewScanner(bytes.NewReader(data[:end]))
+	for sc.Scan() {
+		f := strings.Fields(sc.Text())
+		switch {
+		case len(f) >= 2 && f[0] == "format":
+			format = f[1]
+		case len(f) >= 3 && f[0] == "element":
+			n, _ := strconv.Atoi(f[2])
+			elements = append(elements, plyElement{name: f[1], count: n})
+		case len(f) >= 2 && f[0] == "property" && len(elements) > 0:
+			appendProperty(&elements[len(elements)-1], f)
+		}
+	}
+	return format, elements, body, nil
+}
+
+// appendProperty adds a property declaration to the element under construction.
+func appendProperty(e *plyElement, f []string) {
+	if f[1] == "list" && len(f) >= 5 {
+		e.props = append(e.props, plyProperty{name: f[4], listCount: f[2], listElem: f[3]})
+		return
+	}
+	e.props = append(e.props, plyProperty{name: f[len(f)-1], scalar: f[1]})
+}
+
+// findElement returns the named element.
+func findElement(elements []plyElement, name string) (plyElement, bool) {
+	for _, e := range elements {
+		if e.name == name {
+			return e, true
+		}
+	}
+	return plyElement{}, false
+}
+
+// xyzIndices returns the property indices of x, y, z in the vertex element, erroring if absent or
+// if any precedes a variable-size list property (which the position decode cannot stride past).
+func xyzIndices(vtx plyElement) (int, int, int, error) {
+	idx := map[string]int{}
+	for i, p := range vtx.props {
+		if p.scalar == "" {
+			return 0, 0, 0, fmt.Errorf("pointcloud: PLY vertex has a list property %q before its positions", p.name)
+		}
+		idx[p.name] = i
+	}
+	xi, okx := idx["x"]
+	yi, oky := idx["y"]
+	zi, okz := idx["z"]
+	if !okx || !oky || !okz {
+		return 0, 0, 0, fmt.Errorf("pointcloud: PLY vertex has no x/y/z properties")
+	}
+	return xi, yi, zi, nil
+}
+
+// readASCIIVertices reads count whitespace-separated vertex lines, taking x/y/z by column.
+func readASCIIVertices(body []byte, vtx plyElement, xi, yi, zi int) ([]omath.Point3, error) {
+	out := make([]omath.Point3, 0, vtx.count)
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() && len(out) < vtx.count {
+		f := strings.Fields(sc.Text())
+		if len(f) <= zi {
+			continue
+		}
+		x, ex := strconv.ParseFloat(f[xi], 64)
+		y, ey := strconv.ParseFloat(f[yi], 64)
+		z, ez := strconv.ParseFloat(f[zi], 64)
+		if ex != nil || ey != nil || ez != nil {
+			return nil, fmt.Errorf("pointcloud: PLY ascii vertex %d is not numeric: %q", len(out), sc.Text())
+		}
+		out = append(out, omath.P3(omath.Scalar(x), omath.Scalar(y), omath.Scalar(z)))
+	}
+	return out, nil
+}
+
+// readBinaryVertices strides over the fixed-size vertex records, decoding x/y/z by their byte
+// offset and scalar type. bigEndian selects the byte order.
+func readBinaryVertices(body []byte, vtx plyElement, xi, yi, zi int, bigEndian bool) ([]omath.Point3, error) {
+	offsets, sizes, stride := vertexLayout(vtx)
+	order := binary.ByteOrder(binary.LittleEndian)
+	if bigEndian {
+		order = binary.BigEndian
+	}
+	out := make([]omath.Point3, 0, vtx.count)
+	for i := 0; i < vtx.count; i++ {
+		base := i * stride
+		if base+stride > len(body) {
+			return nil, fmt.Errorf("pointcloud: PLY truncated at vertex %d of %d", i, vtx.count)
+		}
+		rec := body[base : base+stride]
+		out = append(out, omath.P3(
+			omath.Scalar(scalarValue(rec[offsets[xi]:], vtx.props[xi].scalar, sizes[xi], order)),
+			omath.Scalar(scalarValue(rec[offsets[yi]:], vtx.props[yi].scalar, sizes[yi], order)),
+			omath.Scalar(scalarValue(rec[offsets[zi]:], vtx.props[zi].scalar, sizes[zi], order)),
+		))
+	}
+	return out, nil
+}
+
+// vertexLayout returns each property's byte offset and size within a vertex record, plus the
+// record stride.
+func vertexLayout(vtx plyElement) (offsets, sizes []int, stride int) {
+	offsets = make([]int, len(vtx.props))
+	sizes = make([]int, len(vtx.props))
+	for i, p := range vtx.props {
+		offsets[i] = stride
+		sizes[i] = plyTypeSize(p.scalar)
+		stride += sizes[i]
+	}
+	return offsets, sizes, stride
+}
+
+// scalarValue decodes one numeric value of the given PLY scalar type to a float64.
+func scalarValue(b []byte, typ string, size int, order binary.ByteOrder) float64 {
+	switch typ {
+	case "float", "float32":
+		return float64(math.Float32frombits(order.Uint32(b)))
+	case "double", "float64":
+		return math.Float64frombits(order.Uint64(b))
+	case "char", "int8":
+		return float64(int8(b[0]))
+	case "uchar", "uint8":
+		return float64(b[0])
+	case "short", "int16":
+		return float64(int16(order.Uint16(b)))
+	case "ushort", "uint16":
+		return float64(order.Uint16(b))
+	case "int", "int32":
+		return float64(int32(order.Uint32(b)))
+	case "uint", "uint32":
+		return float64(order.Uint32(b))
+	default:
+		_ = size
+		return 0
+	}
+}
+
+// plyTypeSize returns the byte size of a PLY scalar type (0 for unknown).
+func plyTypeSize(typ string) int {
+	switch typ {
+	case "char", "uchar", "int8", "uint8":
+		return 1
+	case "short", "ushort", "int16", "uint16":
+		return 2
+	case "int", "uint", "int32", "uint32", "float", "float32":
+		return 4
+	case "double", "float64":
+		return 8
+	default:
+		return 0
+	}
+}

--- a/model/pointcloud/ply_test.go
+++ b/model/pointcloud/ply_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// TestPLYASCII: an ASCII PLY's vertex positions decode, ignoring extra per-vertex columns and the
+// face element.
+func TestPLYASCII(t *testing.T) {
+	src := "ply\nformat ascii 1.0\n" +
+		"element vertex 2\nproperty float x\nproperty float y\nproperty float z\nproperty uchar red\n" +
+		"element face 1\nproperty list uchar int vertex_indices\n" +
+		"end_header\n" +
+		"1 2 3 255\n4 5 6 128\n3 0 1 2\n"
+	pts, err := ReadScan("m.ply", []byte(src))
+	if err != nil {
+		t.Fatalf("Read ascii PLY: %v", err)
+	}
+	if len(pts) != 2 {
+		t.Fatalf("decoded %d points, want 2 (the faces are skipped)", len(pts))
+	}
+	if pts[0].X != 1 || pts[0].Y != 2 || pts[0].Z != 3 || pts[1].X != 4 {
+		t.Errorf("points = %+v, want (1,2,3),(4,5,6)", pts)
+	}
+}
+
+// TestPLYBinaryLittleEndian: a binary little-endian PLY decodes, striding past a non-position
+// property (a uchar) between the floats.
+func TestPLYBinaryLittleEndian(t *testing.T) {
+	var body bytes.Buffer
+	// vertex record layout: float x, float y, float z, uchar flag.
+	for _, v := range [][3]float32{{1, 2, 3}, {-4, 5, -6}} {
+		for _, c := range v {
+			_ = binary.Write(&body, binary.LittleEndian, c)
+		}
+		body.WriteByte(7) // the trailing uchar property
+	}
+	src := append([]byte("ply\nformat binary_little_endian 1.0\n"+
+		"element vertex 2\nproperty float x\nproperty float y\nproperty float z\nproperty uchar flag\n"+
+		"end_header\n"), body.Bytes()...)
+
+	pts, err := ReadScan("m.ply", src)
+	if err != nil {
+		t.Fatalf("Read binary PLY: %v", err)
+	}
+	if len(pts) != 2 || pts[0].X != 1 || pts[0].Z != 3 || pts[1].X != -4 || pts[1].Z != -6 {
+		t.Fatalf("decoded %+v, want (1,2,3),(-4,5,-6)", pts)
+	}
+}
+
+// TestPLYBinaryDoublePrecision: double-precision positions decode.
+func TestPLYBinaryDoublePrecision(t *testing.T) {
+	var body bytes.Buffer
+	for _, c := range []float64{1.5, 2.5, 3.5} {
+		_ = binary.Write(&body, binary.LittleEndian, math.Float64bits(c))
+	}
+	src := append([]byte("ply\nformat binary_little_endian 1.0\n"+
+		"element vertex 1\nproperty double x\nproperty double y\nproperty double z\n"+
+		"end_header\n"), body.Bytes()...)
+	pts, err := ReadScan("m.ply", src)
+	if err != nil || len(pts) != 1 || pts[0].Y != 2.5 {
+		t.Fatalf("double PLY = %+v, err %v; want (1.5,2.5,3.5)", pts, err)
+	}
+}
+
+// TestPLYErrors: a non-PLY blob, a missing vertex element, and missing x/y/z are rejected.
+func TestPLYErrors(t *testing.T) {
+	if _, err := (plyReader{}).Read([]byte("not a ply")); err == nil {
+		t.Error("a non-PLY blob should fail")
+	}
+	noVtx := "ply\nformat ascii 1.0\nelement face 0\nend_header\n"
+	if _, err := (plyReader{}).Read([]byte(noVtx)); err == nil {
+		t.Error("a PLY with no vertex element should fail")
+	}
+	noXYZ := "ply\nformat ascii 1.0\nelement vertex 1\nproperty float u\nproperty float v\nend_header\n0 0\n"
+	if _, err := (plyReader{}).Read([]byte(noXYZ)); err == nil {
+		t.Error("a vertex without x/y/z should fail")
+	}
+}

--- a/model/pointcloud/ply_test.go
+++ b/model/pointcloud/ply_test.go
@@ -68,6 +68,43 @@ func TestPLYBinaryDoublePrecision(t *testing.T) {
 	}
 }
 
+// TestPLYScalarTypes: every PLY scalar type decodes to the right value and reports the right size,
+// so a scan using integer or big-endian position properties reads correctly.
+func TestPLYScalarTypes(t *testing.T) {
+	le := binary.ByteOrder(binary.LittleEndian)
+	cases := []struct {
+		typ  string
+		size int
+		b    []byte
+		want float64
+	}{
+		{"char", 1, []byte{0xFE}, -2},
+		{"uchar", 1, []byte{200}, 200},
+		{"short", 2, le16(0xFFFF), -1},
+		{"ushort", 2, le16(513), 513},
+		{"int", 4, le32(0xFFFFFFFF), -1},
+		{"uint", 4, le32(70000), 70000},
+		{"float", 4, le32(math.Float32bits(2.5)), 2.5},
+		{"double", 8, le64(math.Float64bits(-3.25)), -3.25},
+		{"unknown", 0, nil, 0},
+	}
+	for _, c := range cases {
+		if got := plyTypeSize(c.typ); got != c.size {
+			t.Errorf("plyTypeSize(%s) = %d, want %d", c.typ, got, c.size)
+		}
+		if c.b == nil {
+			continue
+		}
+		if got := scalarValue(c.b, c.typ, c.size, le); got != c.want {
+			t.Errorf("scalarValue(%s) = %v, want %v", c.typ, got, c.want)
+		}
+	}
+}
+
+func le16(v uint16) []byte { b := make([]byte, 2); binary.LittleEndian.PutUint16(b, v); return b }
+func le32(v uint32) []byte { b := make([]byte, 4); binary.LittleEndian.PutUint32(b, v); return b }
+func le64(v uint64) []byte { b := make([]byte, 8); binary.LittleEndian.PutUint64(b, v); return b }
+
 // TestPLYErrors: a non-PLY blob, a missing vertex element, and missing x/y/z are rejected.
 func TestPLYErrors(t *testing.T) {
 	if _, err := (plyReader{}).Read([]byte("not a ply")); err == nil {

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -18,9 +18,9 @@ import (
 	"oblikovati.org/math"
 )
 
-// registeredReaders is the decoder set keyed by lowercase extension. ASCII formats ship now;
+// registeredReaders is the decoder set keyed by lowercase extension. ASCII and PLY ship now;
 // LAS/E57 readers register here later without touching call sites.
-var registeredReaders = []PointReader{NewASCIIReader()}
+var registeredReaders = []PointReader{NewASCIIReader(), NewPLYReader()}
 
 // ReadScan decodes a scan file's bytes into cloud-local points, choosing the reader by the
 // filename's extension. It errors when no registered reader handles the extension, naming it.


### PR DESCRIPTION
## What
A clean-room **Stanford PLY reader** so real structured-light / photogrammetry scans (Artec et al.) load as point clouds — `pointClouds.attach` and the Import Point Cloud command now accept `.ply`.

## How
Behind the existing `PointReader` seam: parse the ASCII header, read the `vertex` element's x/y/z (striding past extra per-vertex properties like normals/colour), and ignore any `face` element. Handles **ASCII** and **binary little/big-endian** encodings, float/double/int scalar types.

## Validated on real data
Loaded a real **266,673-point binary-PLY Artec scan** (`capstan vertraging.ply`): it decodes fully and renders as a recognizable scanned part in the live viewport.

![real scan](renders as a dense cyan point cloud)

## Tests
- `model/pointcloud`: ASCII PLY (skipping faces + extra columns), binary little-endian with a non-position property between floats, double precision, and the not-a-PLY / no-vertex / missing-xyz errors.
- `head/ui`: in-window capture of the real scan (skips in CI without the sample file).

## Next
PR 6: datum consumers (work point / sketch plane *fit* to scan data), `PointCloudPlane`, the `pointClouds.nearestPoint` API, and E57/LAS readers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)