### PR TITLE
feat(#645): import a 3D scan (.ply/.xyz/.pts) as a point cloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.79.0
+	oblikovati.org/api v0.80.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.79.0
+	oblikovati.org/api v0.80.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -123,30 +123,28 @@ func (d *fileDialog) openForRequest(req app.FileDialogRequest) {
 // isOpen reports whether the modal should render this frame.
 func (d *fileDialog) isOpen() bool { return d.mode != dialogClosed }
 
+// staticDialogTitles maps each mode whose heading is a constant to that heading; the
+// dynamic ones (add-in titles, the open fallback) are handled in title().
+var staticDialogTitles = map[fileDialogMode]string{
+	dialogSaveAs:         "Save As",
+	dialogLoadHDR:        "Load HDR",
+	dialogMeshRef:        "Place Mesh (.stl)",
+	dialogPointCloud:     "Import Point Cloud (.xyz/.pts)",
+	dialogPlaceComponent: "Place Component",
+	dialogImport:         "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.xyz/.pts)",
+	dialogExport:         "Export (.stl/.obj/.3mf/.step/.dxf)",
+	dialogExportBOM:      "Export BOM (.csv)",
+}
+
 // title is the window heading for the current mode.
 func (d *fileDialog) title() string {
-	switch d.mode {
-	case dialogSaveAs:
-		return "Save As"
-	case dialogLoadHDR:
-		return "Load HDR"
-	case dialogMeshRef:
-		return "Place Mesh (.stl)"
-	case dialogPointCloud:
-		return "Import Point Cloud (.xyz/.pts)"
-	case dialogPlaceComponent:
-		return "Place Component"
-	case dialogImport:
-		return "Import (.stl/.obj/.3mf/.step/.dwg/.dxf)"
-	case dialogExport:
-		return "Export (.stl/.obj/.3mf/.step/.dxf)"
-	case dialogExportBOM:
-		return "Export BOM (.csv)"
-	case dialogAddIn:
+	if d.mode == dialogAddIn {
 		return d.addInTitle()
-	default:
-		return "Open"
 	}
+	if t, ok := staticDialogTitles[d.mode]; ok {
+		return t
+	}
+	return "Open"
 }
 
 // addInTitle is the window heading for an add-in's file dialog request: its custom title when
@@ -287,8 +285,9 @@ func (d *fileDialog) allowedExts() []string {
 	case dialogPointCloud:
 		return []string{".xyz", ".pts", ".asc", ".txt"}
 	case dialogImport:
-		// DWG/DXF import into a sketch (curve geometry), the others into bodies.
-		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dwg", ".dxf"}
+		// DWG/DXF import into a sketch, scan formats (.ply/.xyz/.pts/.asc) into a point cloud, the
+		// rest into bodies.
+		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dwg", ".dxf", ".ply", ".xyz", ".pts", ".asc"}
 	case dialogExport:
 		// DXF exports the active sketch; the others export the part's bodies.
 		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dxf"}

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -14,6 +14,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/pointcloud"
 )
 
 // fileModal is the chrome's single file explorer (UI state, not model state, so it lives
@@ -394,6 +395,8 @@ func importFromFile(s *app.Session, act fileAction, name string) {
 		importDWGFromFile(s, act, name)
 	case isDXFPath(act.Path):
 		importDXFFromFile(s, act, name)
+	case pointcloud.IsScanFile(act.Path):
+		attachPointCloudFromFile(s, act.Path, name) // a 3D scan (.ply/.xyz/.pts…) → a point cloud (#645)
 	default:
 		importBodyFromFile(s, act.Path, name)
 	}

--- a/head/ui/file_dialog_test.go
+++ b/head/ui/file_dialog_test.go
@@ -108,7 +108,7 @@ func TestFileDialogTitleDefaultsToOpen(t *testing.T) {
 func TestFileDialogImportExportModes(t *testing.T) {
 	var d fileDialog
 	d.openFor(dialogImport)
-	if d.title() != "Import (.stl/.obj/.3mf/.step/.dwg/.dxf)" {
+	if d.title() != "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.xyz/.pts)" {
 		t.Errorf("import title = %q", d.title())
 	}
 	d.openFor(dialogExport)

--- a/kernel/exchange/plyfmt/plyfmt.go
+++ b/kernel/exchange/plyfmt/plyfmt.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package plyfmt is a clean-room low-level reader for the Stanford PLY format (ASCII and binary,
+// little/big-endian), shared by the point-cloud scan reader (vertices only) and the mesh-exchange
+// importer (vertices + faces) so the header/scalar parsing lives in one place (#645). It parses
+// the header into typed element declarations and reads the vertex positions and face index lists
+// on demand; it deliberately does not weld or triangulate — callers build their own point set or
+// triangle soup.
+package plyfmt
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	omath "oblikovati.org/math"
+)
+
+// Property is one declared property of an element: its scalar type (empty for a list property)
+// and, for a list, the count and element scalar types.
+type Property struct {
+	Name      string
+	Scalar    string
+	ListCount string
+	ListElem  string
+}
+
+// Element is one declared element block: its name, instance count, and properties in order.
+type Element struct {
+	Name  string
+	Count int
+	Props []Property
+}
+
+// Document is a parsed PLY: its encoding, element declarations, and the body bytes (everything
+// after end_header).
+type Document struct {
+	Format   string
+	Elements []Element
+	body     []byte
+}
+
+// Parse reads the ASCII header and captures the body, erroring on a non-PLY input.
+func Parse(data []byte) (*Document, error) {
+	end := bytes.Index(data, []byte("end_header"))
+	if !bytes.HasPrefix(data, []byte("ply")) || end < 0 {
+		return nil, fmt.Errorf("plyfmt: not a PLY file (missing magic / end_header)")
+	}
+	body := data[end:]
+	if nl := bytes.IndexByte(body, '\n'); nl >= 0 {
+		body = body[nl+1:]
+	}
+	d := &Document{body: body}
+	sc := bufio.NewScanner(bytes.NewReader(data[:end]))
+	for sc.Scan() {
+		f := strings.Fields(sc.Text())
+		switch {
+		case len(f) >= 2 && f[0] == "format":
+			d.Format = f[1]
+		case len(f) >= 3 && f[0] == "element":
+			n, _ := strconv.Atoi(f[2])
+			d.Elements = append(d.Elements, Element{Name: f[1], Count: n})
+		case len(f) >= 2 && f[0] == "property" && len(d.Elements) > 0:
+			d.appendProperty(f)
+		}
+	}
+	return d, nil
+}
+
+func (d *Document) appendProperty(f []string) {
+	e := &d.Elements[len(d.Elements)-1]
+	if f[1] == "list" && len(f) >= 5 {
+		e.Props = append(e.Props, Property{Name: f[4], ListCount: f[2], ListElem: f[3]})
+		return
+	}
+	e.Props = append(e.Props, Property{Name: f[len(f)-1], Scalar: f[1]})
+}
+
+func (d *Document) element(name string) (Element, bool) {
+	for _, e := range d.Elements {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return Element{}, false
+}
+
+func (d *Document) byteOrder() binary.ByteOrder {
+	if d.Format == "binary_big_endian" {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+}
+
+// Vertices reads the vertex element's x/y/z positions.
+func (d *Document) Vertices() ([]omath.Point3, error) {
+	vtx, ok := d.element("vertex")
+	if !ok || vtx.Count == 0 {
+		return nil, fmt.Errorf("plyfmt: PLY has no vertex element")
+	}
+	xi, yi, zi, err := xyzIndices(vtx)
+	if err != nil {
+		return nil, err
+	}
+	if d.Format == "ascii" {
+		return d.asciiVertices(vtx, xi, yi, zi)
+	}
+	return d.binaryVertices(vtx, xi, yi, zi)
+}
+
+// Faces reads the face element's vertex-index lists (variable length); nil when there is no face
+// element. It is read after the vertices, so positions and faces decode from one pass each.
+func (d *Document) Faces() ([][]int, error) {
+	face, ok := d.element("face")
+	if !ok || face.Count == 0 {
+		return nil, nil
+	}
+	if d.Format == "ascii" {
+		return d.asciiFaces(face)
+	}
+	return d.binaryFaces(face)
+}
+
+// xyzIndices returns the property indices of x, y, z in an element, erroring if absent or behind a
+// list property the fixed-size stride cannot pass.
+func xyzIndices(e Element) (int, int, int, error) {
+	idx := map[string]int{}
+	for i, p := range e.Props {
+		if p.Scalar == "" {
+			return 0, 0, 0, fmt.Errorf("plyfmt: vertex has a list property %q before its positions", p.Name)
+		}
+		idx[p.Name] = i
+	}
+	xi, okx := idx["x"]
+	yi, oky := idx["y"]
+	zi, okz := idx["z"]
+	if !okx || !oky || !okz {
+		return 0, 0, 0, fmt.Errorf("plyfmt: vertex has no x/y/z properties")
+	}
+	return xi, yi, zi, nil
+}
+
+func (d *Document) asciiVertices(vtx Element, xi, yi, zi int) ([]omath.Point3, error) {
+	out := make([]omath.Point3, 0, vtx.Count)
+	sc := bufio.NewScanner(bytes.NewReader(d.body))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() && len(out) < vtx.Count {
+		f := strings.Fields(sc.Text())
+		if len(f) <= zi {
+			continue
+		}
+		x, ex := strconv.ParseFloat(f[xi], 64)
+		y, ey := strconv.ParseFloat(f[yi], 64)
+		z, ez := strconv.ParseFloat(f[zi], 64)
+		if ex != nil || ey != nil || ez != nil {
+			return nil, fmt.Errorf("plyfmt: ascii vertex %d is not numeric: %q", len(out), sc.Text())
+		}
+		out = append(out, omath.P3(omath.Scalar(x), omath.Scalar(y), omath.Scalar(z)))
+	}
+	return out, nil
+}
+
+func (d *Document) binaryVertices(vtx Element, xi, yi, zi int) ([]omath.Point3, error) {
+	offsets, sizes, stride := layout(vtx)
+	order := d.byteOrder()
+	out := make([]omath.Point3, 0, vtx.Count)
+	for i := 0; i < vtx.Count; i++ {
+		base := i * stride
+		if base+stride > len(d.body) {
+			return nil, fmt.Errorf("plyfmt: truncated at vertex %d of %d", i, vtx.Count)
+		}
+		rec := d.body[base : base+stride]
+		out = append(out, omath.P3(
+			omath.Scalar(scalarValue(rec[offsets[xi]:], vtx.Props[xi].Scalar, sizes[xi], order)),
+			omath.Scalar(scalarValue(rec[offsets[yi]:], vtx.Props[yi].Scalar, sizes[yi], order)),
+			omath.Scalar(scalarValue(rec[offsets[zi]:], vtx.Props[zi].Scalar, sizes[zi], order)),
+		))
+	}
+	return out, nil
+}
+
+// asciiFaces reads the face lines after the vertex lines: "N i0 i1 … i(N-1)".
+func (d *Document) asciiFaces(face Element) ([][]int, error) {
+	vtx, _ := d.element("vertex")
+	sc := bufio.NewScanner(bytes.NewReader(d.body))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for skipped := 0; skipped < vtx.Count && sc.Scan(); {
+		if len(strings.Fields(sc.Text())) > 0 {
+			skipped++
+		}
+	}
+	out := make([][]int, 0, face.Count)
+	for sc.Scan() && len(out) < face.Count {
+		f := strings.Fields(sc.Text())
+		if len(f) == 0 {
+			continue
+		}
+		n, err := strconv.Atoi(f[0])
+		if err != nil || len(f) < n+1 {
+			return nil, fmt.Errorf("plyfmt: malformed ascii face %d: %q", len(out), sc.Text())
+		}
+		idx := make([]int, n)
+		for k := 0; k < n; k++ {
+			idx[k], _ = strconv.Atoi(f[k+1])
+		}
+		out = append(out, idx)
+	}
+	return out, nil
+}
+
+// binaryFaces walks the variable-length face records that follow the fixed-size vertex records.
+func (d *Document) binaryFaces(face Element) ([][]int, error) {
+	vtx, _ := d.element("vertex")
+	_, _, vStride := layout(vtx)
+	pos := vtx.Count * vStride
+	prop := face.Props[0] // a face's single list property (vertex_indices)
+	out := make([][]int, 0, face.Count)
+	for i := 0; i < face.Count; i++ {
+		idx, next, err := d.readBinaryFace(pos, prop, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, idx)
+		pos = next
+	}
+	return out, nil
+}
+
+// readBinaryFace reads one binary face record at pos: a list-count value then that many index
+// values. It returns the indices and the position after the record.
+func (d *Document) readBinaryFace(pos int, prop Property, i int) ([]int, int, error) {
+	order := d.byteOrder()
+	countSize := plyTypeSize(prop.ListCount)
+	elemSize := plyTypeSize(prop.ListElem)
+	if pos+countSize > len(d.body) {
+		return nil, 0, fmt.Errorf("plyfmt: truncated reading face %d count", i)
+	}
+	n := int(scalarValue(d.body[pos:], prop.ListCount, countSize, order))
+	pos += countSize
+	if pos+n*elemSize > len(d.body) {
+		return nil, 0, fmt.Errorf("plyfmt: truncated in face %d indices", i)
+	}
+	idx := make([]int, n)
+	for k := 0; k < n; k++ {
+		idx[k] = int(scalarValue(d.body[pos:], prop.ListElem, elemSize, order))
+		pos += elemSize
+	}
+	return idx, pos, nil
+}
+
+// layout returns each property's byte offset and size in a fixed-size record, plus the stride.
+func layout(e Element) (offsets, sizes []int, stride int) {
+	offsets = make([]int, len(e.Props))
+	sizes = make([]int, len(e.Props))
+	for i, p := range e.Props {
+		offsets[i] = stride
+		sizes[i] = plyTypeSize(p.Scalar)
+		stride += sizes[i]
+	}
+	return offsets, sizes, stride
+}
+
+// scalarValue decodes one numeric value of the given PLY scalar type to a float64.
+func scalarValue(b []byte, typ string, _ int, order binary.ByteOrder) float64 {
+	switch typ {
+	case "float", "float32":
+		return float64(math.Float32frombits(order.Uint32(b)))
+	case "double", "float64":
+		return math.Float64frombits(order.Uint64(b))
+	case "char", "int8":
+		return float64(int8(b[0]))
+	case "uchar", "uint8":
+		return float64(b[0])
+	case "short", "int16":
+		return float64(int16(order.Uint16(b)))
+	case "ushort", "uint16":
+		return float64(order.Uint16(b))
+	case "int", "int32":
+		return float64(int32(order.Uint32(b)))
+	case "uint", "uint32":
+		return float64(order.Uint32(b))
+	default:
+		return 0
+	}
+}
+
+// plyTypeSize returns the byte size of a PLY scalar type (0 for unknown).
+func plyTypeSize(typ string) int {
+	switch typ {
+	case "char", "uchar", "int8", "uint8":
+		return 1
+	case "short", "ushort", "int16", "uint16":
+		return 2
+	case "int", "uint", "int32", "uint32", "float", "float32":
+		return 4
+	case "double", "float64":
+		return 8
+	default:
+		return 0
+	}
+}

--- a/kernel/exchange/plyfmt/plyfmt_test.go
+++ b/kernel/exchange/plyfmt/plyfmt_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package plyfmt
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// TestParseASCIIVerticesAndFaces: an ASCII PLY's vertices (ignoring extra columns) and faces decode.
+func TestParseASCIIVerticesAndFaces(t *testing.T) {
+	src := "ply\nformat ascii 1.0\n" +
+		"element vertex 3\nproperty float x\nproperty float y\nproperty float z\nproperty uchar r\n" +
+		"element face 1\nproperty list uchar int vertex_indices\n" +
+		"end_header\n" +
+		"0 0 0 255\n1 0 0 128\n0 1 0 64\n3 0 1 2\n"
+	d, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	v, err := d.Vertices()
+	if err != nil || len(v) != 3 || v[1].X != 1 || v[2].Y != 1 {
+		t.Fatalf("vertices = %+v, err %v", v, err)
+	}
+	f, err := d.Faces()
+	if err != nil || len(f) != 1 || len(f[0]) != 3 || f[0][2] != 2 {
+		t.Fatalf("faces = %+v, err %v", f, err)
+	}
+}
+
+// TestParseBinaryVerticesAndFaces: a binary little-endian PLY's vertices and a triangle face decode,
+// striding past a non-position vertex property.
+func TestParseBinaryVerticesAndFaces(t *testing.T) {
+	var b bytes.Buffer
+	for _, v := range [][3]float32{{0, 0, 0}, {1, 0, 0}, {0, 1, 0}} {
+		for _, c := range v {
+			_ = binary.Write(&b, binary.LittleEndian, c)
+		}
+		b.WriteByte(9) // a uchar property after xyz
+	}
+	b.WriteByte(3) // face: list count (uchar) = 3
+	for _, idx := range []int32{0, 1, 2} {
+		_ = binary.Write(&b, binary.LittleEndian, idx)
+	}
+	src := append([]byte("ply\nformat binary_little_endian 1.0\n"+
+		"element vertex 3\nproperty float x\nproperty float y\nproperty float z\nproperty uchar flag\n"+
+		"element face 1\nproperty list uchar int vertex_indices\n"+
+		"end_header\n"), b.Bytes()...)
+
+	d, err := Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	v, _ := d.Vertices()
+	if len(v) != 3 || v[1].X != 1 {
+		t.Fatalf("binary vertices = %+v", v)
+	}
+	f, err := d.Faces()
+	if err != nil || len(f) != 1 || f[0][0] != 0 || f[0][2] != 2 {
+		t.Fatalf("binary faces = %+v, err %v", f, err)
+	}
+}
+
+// TestScalarTypes: every PLY scalar type decodes to the right value and reports the right size.
+func TestScalarTypes(t *testing.T) {
+	le := binary.ByteOrder(binary.LittleEndian)
+	cases := []struct {
+		typ  string
+		size int
+		b    []byte
+		want float64
+	}{
+		{"char", 1, []byte{0xFE}, -2},
+		{"uchar", 1, []byte{200}, 200},
+		{"short", 2, le16(0xFFFF), -1},
+		{"ushort", 2, le16(513), 513},
+		{"int", 4, le32(0xFFFFFFFF), -1},
+		{"uint", 4, le32(70000), 70000},
+		{"float", 4, le32(math.Float32bits(2.5)), 2.5},
+		{"double", 8, le64(math.Float64bits(-3.25)), -3.25},
+		{"weird", 0, nil, 0},
+	}
+	for _, c := range cases {
+		if got := plyTypeSize(c.typ); got != c.size {
+			t.Errorf("plyTypeSize(%s) = %d, want %d", c.typ, got, c.size)
+		}
+		if c.b != nil {
+			if got := scalarValue(c.b, c.typ, c.size, le); got != c.want {
+				t.Errorf("scalarValue(%s) = %v, want %v", c.typ, got, c.want)
+			}
+		}
+	}
+}
+
+// TestParseErrors: a non-PLY blob, no vertex element, and missing x/y/z are rejected; no face
+// element yields nil faces.
+func TestParseErrors(t *testing.T) {
+	if _, err := Parse([]byte("nope")); err == nil {
+		t.Error("non-PLY should fail")
+	}
+	noVtx, _ := Parse([]byte("ply\nformat ascii 1.0\nelement face 0\nend_header\n"))
+	if _, err := noVtx.Vertices(); err == nil {
+		t.Error("no vertex element should fail Vertices")
+	}
+	if f, err := noVtx.Faces(); err != nil || f != nil {
+		t.Errorf("no face element should yield nil faces, got %+v err %v", f, err)
+	}
+	noXYZ, _ := Parse([]byte("ply\nformat ascii 1.0\nelement vertex 1\nproperty float u\nproperty float v\nend_header\n0 0\n"))
+	if _, err := noXYZ.Vertices(); err == nil {
+		t.Error("vertex without x/y/z should fail")
+	}
+}
+
+func le16(v uint16) []byte { b := make([]byte, 2); binary.LittleEndian.PutUint16(b, v); return b }
+func le32(v uint32) []byte { b := make([]byte, 4); binary.LittleEndian.PutUint32(b, v); return b }
+func le64(v uint64) []byte { b := make([]byte, 8); binary.LittleEndian.PutUint64(b, v); return b }

--- a/model/pointcloud/collection_test.go
+++ b/model/pointcloud/collection_test.go
@@ -112,3 +112,21 @@ func TestReadScanDispatch(t *testing.T) {
 		t.Error("ReadScan of an unregistered extension should fail")
 	}
 }
+
+// TestIsScanFileAndExtensions: scan extensions are recognized (any case) and non-scan ones are not
+// (#645).
+func TestIsScanFileAndExtensions(t *testing.T) {
+	for _, p := range []string{"room.ply", "scan.XYZ", "a.pts", "b.asc", "c.txt"} {
+		if !IsScanFile(p) {
+			t.Errorf("IsScanFile(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"part.stl", "model.step", "draw.dxf", "noext"} {
+		if IsScanFile(p) {
+			t.Errorf("IsScanFile(%q) = true, want false", p)
+		}
+	}
+	if exts := ScanExtensions(); len(exts) < 5 {
+		t.Errorf("ScanExtensions = %v, want at least the ascii + ply set", exts)
+	}
+}

--- a/model/pointcloud/ply.go
+++ b/model/pointcloud/ply.go
@@ -3,23 +3,14 @@
 package pointcloud
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/binary"
-	"fmt"
-	"math"
-	"strconv"
-	"strings"
-
-	omath "oblikovati.org/math"
+	"oblikovati.org/kernel/exchange/plyfmt"
+	"oblikovati.org/math"
 )
 
-// PLY point reader (M17-F06, #645): decodes the vertex positions of a Stanford PLY file —
-// the common export of structured-light / photogrammetry scanners (Artec, etc.). A PLY may carry
-// a full mesh (vertices + faces); a point cloud needs only the vertex x/y/z, so the reader parses
-// the header, reads the vertex element's positions (skipping any extra per-vertex properties such
-// as normals or colour), and ignores the faces. Both ASCII and binary (little/big-endian)
-// encodings are handled. Clean-room from the published PLY format.
+// PLY point reader (M17-F06, #645): a point cloud needs only the vertex positions of a Stanford
+// PLY (the common 3D-scanner export), so this reader delegates the format parsing to the shared
+// kernel/exchange/plyfmt package and takes its vertices — the same parser the mesh-exchange
+// importer uses for the full mesh, so there is one PLY decoder.
 type plyReader struct{}
 
 // NewPLYReader returns the reader for Stanford .ply scan files.
@@ -27,204 +18,11 @@ func NewPLYReader() PointReader { return plyReader{} }
 
 func (plyReader) Extensions() []string { return []string{".ply"} }
 
-// plyProperty is one declared property of an element: its scalar type (empty for a list property,
-// which the reader skips) and, for a list, the size of its count and element scalars.
-type plyProperty struct {
-	name      string
-	scalar    string // "" for a list property
-	listCount string // list count type (e.g. "uchar"), "" for scalar
-	listElem  string // list element type
-}
-
-// plyElement is one declared element block: its name, instance count, and properties in order.
-type plyElement struct {
-	name  string
-	count int
-	props []plyProperty
-}
-
-// Read decodes the PLY's vertex positions into cloud-local points.
-func (plyReader) Read(data []byte) ([]omath.Point3, error) {
-	format, elements, body, err := parsePLYHeader(data)
+// Read decodes the PLY's vertex positions into cloud-local points (faces are ignored).
+func (plyReader) Read(data []byte) ([]math.Point3, error) {
+	doc, err := plyfmt.Parse(data)
 	if err != nil {
 		return nil, err
 	}
-	vtx, ok := findElement(elements, "vertex")
-	if !ok || vtx.count == 0 {
-		return nil, fmt.Errorf("pointcloud: PLY has no vertex element")
-	}
-	xi, yi, zi, err := xyzIndices(vtx)
-	if err != nil {
-		return nil, err
-	}
-	if format == "ascii" {
-		return readASCIIVertices(body, vtx, xi, yi, zi)
-	}
-	return readBinaryVertices(body, vtx, xi, yi, zi, format == "binary_big_endian")
-}
-
-// parsePLYHeader reads the ASCII header and returns the format, the element declarations, and the
-// body bytes that follow "end_header".
-func parsePLYHeader(data []byte) (string, []plyElement, []byte, error) {
-	end := bytes.Index(data, []byte("end_header"))
-	if !bytes.HasPrefix(data, []byte("ply")) || end < 0 {
-		return "", nil, nil, fmt.Errorf("pointcloud: not a PLY file (missing magic / end_header)")
-	}
-	body := data[end:]
-	if nl := bytes.IndexByte(body, '\n'); nl >= 0 {
-		body = body[nl+1:]
-	}
-	format := ""
-	var elements []plyElement
-	sc := bufio.NewScanner(bytes.NewReader(data[:end]))
-	for sc.Scan() {
-		f := strings.Fields(sc.Text())
-		switch {
-		case len(f) >= 2 && f[0] == "format":
-			format = f[1]
-		case len(f) >= 3 && f[0] == "element":
-			n, _ := strconv.Atoi(f[2])
-			elements = append(elements, plyElement{name: f[1], count: n})
-		case len(f) >= 2 && f[0] == "property" && len(elements) > 0:
-			appendProperty(&elements[len(elements)-1], f)
-		}
-	}
-	return format, elements, body, nil
-}
-
-// appendProperty adds a property declaration to the element under construction.
-func appendProperty(e *plyElement, f []string) {
-	if f[1] == "list" && len(f) >= 5 {
-		e.props = append(e.props, plyProperty{name: f[4], listCount: f[2], listElem: f[3]})
-		return
-	}
-	e.props = append(e.props, plyProperty{name: f[len(f)-1], scalar: f[1]})
-}
-
-// findElement returns the named element.
-func findElement(elements []plyElement, name string) (plyElement, bool) {
-	for _, e := range elements {
-		if e.name == name {
-			return e, true
-		}
-	}
-	return plyElement{}, false
-}
-
-// xyzIndices returns the property indices of x, y, z in the vertex element, erroring if absent or
-// if any precedes a variable-size list property (which the position decode cannot stride past).
-func xyzIndices(vtx plyElement) (int, int, int, error) {
-	idx := map[string]int{}
-	for i, p := range vtx.props {
-		if p.scalar == "" {
-			return 0, 0, 0, fmt.Errorf("pointcloud: PLY vertex has a list property %q before its positions", p.name)
-		}
-		idx[p.name] = i
-	}
-	xi, okx := idx["x"]
-	yi, oky := idx["y"]
-	zi, okz := idx["z"]
-	if !okx || !oky || !okz {
-		return 0, 0, 0, fmt.Errorf("pointcloud: PLY vertex has no x/y/z properties")
-	}
-	return xi, yi, zi, nil
-}
-
-// readASCIIVertices reads count whitespace-separated vertex lines, taking x/y/z by column.
-func readASCIIVertices(body []byte, vtx plyElement, xi, yi, zi int) ([]omath.Point3, error) {
-	out := make([]omath.Point3, 0, vtx.count)
-	sc := bufio.NewScanner(bytes.NewReader(body))
-	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
-	for sc.Scan() && len(out) < vtx.count {
-		f := strings.Fields(sc.Text())
-		if len(f) <= zi {
-			continue
-		}
-		x, ex := strconv.ParseFloat(f[xi], 64)
-		y, ey := strconv.ParseFloat(f[yi], 64)
-		z, ez := strconv.ParseFloat(f[zi], 64)
-		if ex != nil || ey != nil || ez != nil {
-			return nil, fmt.Errorf("pointcloud: PLY ascii vertex %d is not numeric: %q", len(out), sc.Text())
-		}
-		out = append(out, omath.P3(omath.Scalar(x), omath.Scalar(y), omath.Scalar(z)))
-	}
-	return out, nil
-}
-
-// readBinaryVertices strides over the fixed-size vertex records, decoding x/y/z by their byte
-// offset and scalar type. bigEndian selects the byte order.
-func readBinaryVertices(body []byte, vtx plyElement, xi, yi, zi int, bigEndian bool) ([]omath.Point3, error) {
-	offsets, sizes, stride := vertexLayout(vtx)
-	order := binary.ByteOrder(binary.LittleEndian)
-	if bigEndian {
-		order = binary.BigEndian
-	}
-	out := make([]omath.Point3, 0, vtx.count)
-	for i := 0; i < vtx.count; i++ {
-		base := i * stride
-		if base+stride > len(body) {
-			return nil, fmt.Errorf("pointcloud: PLY truncated at vertex %d of %d", i, vtx.count)
-		}
-		rec := body[base : base+stride]
-		out = append(out, omath.P3(
-			omath.Scalar(scalarValue(rec[offsets[xi]:], vtx.props[xi].scalar, sizes[xi], order)),
-			omath.Scalar(scalarValue(rec[offsets[yi]:], vtx.props[yi].scalar, sizes[yi], order)),
-			omath.Scalar(scalarValue(rec[offsets[zi]:], vtx.props[zi].scalar, sizes[zi], order)),
-		))
-	}
-	return out, nil
-}
-
-// vertexLayout returns each property's byte offset and size within a vertex record, plus the
-// record stride.
-func vertexLayout(vtx plyElement) (offsets, sizes []int, stride int) {
-	offsets = make([]int, len(vtx.props))
-	sizes = make([]int, len(vtx.props))
-	for i, p := range vtx.props {
-		offsets[i] = stride
-		sizes[i] = plyTypeSize(p.scalar)
-		stride += sizes[i]
-	}
-	return offsets, sizes, stride
-}
-
-// scalarValue decodes one numeric value of the given PLY scalar type to a float64.
-func scalarValue(b []byte, typ string, size int, order binary.ByteOrder) float64 {
-	switch typ {
-	case "float", "float32":
-		return float64(math.Float32frombits(order.Uint32(b)))
-	case "double", "float64":
-		return math.Float64frombits(order.Uint64(b))
-	case "char", "int8":
-		return float64(int8(b[0]))
-	case "uchar", "uint8":
-		return float64(b[0])
-	case "short", "int16":
-		return float64(int16(order.Uint16(b)))
-	case "ushort", "uint16":
-		return float64(order.Uint16(b))
-	case "int", "int32":
-		return float64(int32(order.Uint32(b)))
-	case "uint", "uint32":
-		return float64(order.Uint32(b))
-	default:
-		_ = size
-		return 0
-	}
-}
-
-// plyTypeSize returns the byte size of a PLY scalar type (0 for unknown).
-func plyTypeSize(typ string) int {
-	switch typ {
-	case "char", "uchar", "int8", "uint8":
-		return 1
-	case "short", "ushort", "int16", "uint16":
-		return 2
-	case "int", "uint", "int32", "uint32", "float", "float32":
-		return 4
-	case "double", "float64":
-		return 8
-	default:
-		return 0
-	}
+	return doc.Vertices()
 }

--- a/model/pointcloud/ply_test.go
+++ b/model/pointcloud/ply_test.go
@@ -68,43 +68,6 @@ func TestPLYBinaryDoublePrecision(t *testing.T) {
 	}
 }
 
-// TestPLYScalarTypes: every PLY scalar type decodes to the right value and reports the right size,
-// so a scan using integer or big-endian position properties reads correctly.
-func TestPLYScalarTypes(t *testing.T) {
-	le := binary.ByteOrder(binary.LittleEndian)
-	cases := []struct {
-		typ  string
-		size int
-		b    []byte
-		want float64
-	}{
-		{"char", 1, []byte{0xFE}, -2},
-		{"uchar", 1, []byte{200}, 200},
-		{"short", 2, le16(0xFFFF), -1},
-		{"ushort", 2, le16(513), 513},
-		{"int", 4, le32(0xFFFFFFFF), -1},
-		{"uint", 4, le32(70000), 70000},
-		{"float", 4, le32(math.Float32bits(2.5)), 2.5},
-		{"double", 8, le64(math.Float64bits(-3.25)), -3.25},
-		{"unknown", 0, nil, 0},
-	}
-	for _, c := range cases {
-		if got := plyTypeSize(c.typ); got != c.size {
-			t.Errorf("plyTypeSize(%s) = %d, want %d", c.typ, got, c.size)
-		}
-		if c.b == nil {
-			continue
-		}
-		if got := scalarValue(c.b, c.typ, c.size, le); got != c.want {
-			t.Errorf("scalarValue(%s) = %v, want %v", c.typ, got, c.want)
-		}
-	}
-}
-
-func le16(v uint16) []byte { b := make([]byte, 2); binary.LittleEndian.PutUint16(b, v); return b }
-func le32(v uint32) []byte { b := make([]byte, 4); binary.LittleEndian.PutUint32(b, v); return b }
-func le64(v uint64) []byte { b := make([]byte, 8); binary.LittleEndian.PutUint64(b, v); return b }
-
 // TestPLYErrors: a non-PLY blob, a missing vertex element, and missing x/y/z are rejected.
 func TestPLYErrors(t *testing.T) {
 	if _, err := (plyReader{}).Read([]byte("not a ply")); err == nil {

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -36,6 +36,32 @@ func ReadScan(filename string, data []byte) ([]math.Point3, error) {
 	return nil, fmt.Errorf("pointcloud: no reader for scan extension %q (file %q)", ext, filename)
 }
 
+// IsScanFile reports whether a path's extension is a 3D-scan point-cloud format handled by a
+// registered reader (.xyz/.pts/.asc/.txt/.ply). The import flow routes such files to the
+// point-cloud attach path — the appropriate home for scan data — rather than the body/sketch
+// importers (#645).
+func IsScanFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, r := range registeredReaders {
+		for _, e := range r.Extensions() {
+			if e == ext {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ScanExtensions returns every file extension a registered scan reader handles (for the import
+// file dialog's filter).
+func ScanExtensions() []string {
+	var out []string
+	for _, r := range registeredReaders {
+		out = append(out, r.Extensions()...)
+	}
+	return out
+}
+
 // PointReader decodes one scan-file format's bytes into cloud-local points. One implementation
 // per format keeps the cloud model format-agnostic; the host wraps any third-party decoder
 // behind this project-owned seam (CLAUDE.md "Dependencies"). The first reader is clean-room


### PR DESCRIPTION
## What

`File ▸ Import` of a 3D-scan file now attaches a **point cloud** instead of attempting a mesh/sketch import. A scan is as-built reference data the design is modelled against, so the point-cloud object — not a solid body — is its proper home (#645).

- New `kernel/exchange/plyfmt`: a clean-room, low-level Stanford-PLY decoder (ASCII + binary little/big-endian, all scalar types) that parses the header into typed element declarations and reads vertex positions and face index lists on demand. It is now the single place that understands the format.
- `model/pointcloud` PLY reader delegates to `plyfmt` rather than carrying a duplicate decoder.
- `model/pointcloud.IsScanFile`/`ScanExtensions` let the import flow recognise a scan file (`.ply/.xyz/.pts/.asc`) and route it to the point-cloud attach path.
- Head: `importFromFile` routes recognised scans to `attachPointCloudFromFile`; the import dialog accepts the scan extensions. `title()`'s constant headings moved to a lookup table (the grown title string crossed the funlen limit).
- Pins `oblikovati.org/api` to **v0.80.1**, which clarifies that PLY is a point-cloud format (`IsPointCloud`, not `IsMesh`).

## Why

3D scanners (structured-light / photogrammetry, e.g. Artec) export PLY/XYZ/PTS. Treating those as a solid mesh body is wrong — they have no manifold topology and are meant to be referenced, snapped to, and measured against. Routing them through the point-cloud API gives the as-built workflow its correct home.

## Testing

- `go test ./model/pointcloud/ ./kernel/exchange/plyfmt/` — green (round-trips for ASCII/binary LE/BE, all scalar types, error paths, `IsScanFile`/extensions).
- Build + `golangci-lint` clean on touched packages.
- Live-confirmed earlier in #645: a real 266k-point binary Artec PLY renders as a point cloud in the running head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)