### PR TITLE
feat(#645): import LAS (ASPRS LiDAR) scans as point clouds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.81.0
+	oblikovati.org/api v0.82.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.81.0
+	oblikovati.org/api v0.82.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -131,7 +131,7 @@ var staticDialogTitles = map[fileDialogMode]string{
 	dialogMeshRef:        "Place Mesh (.stl)",
 	dialogPointCloud:     "Import Point Cloud (.xyz/.pts)",
 	dialogPlaceComponent: "Place Component",
-	dialogImport:         "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.e57/.xyz/.pts)",
+	dialogImport:         "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.e57/.las/.xyz/.pts)",
 	dialogExport:         "Export (.stl/.obj/.3mf/.step/.dxf)",
 	dialogExportBOM:      "Export BOM (.csv)",
 }
@@ -285,9 +285,9 @@ func (d *fileDialog) allowedExts() []string {
 	case dialogPointCloud:
 		return []string{".xyz", ".pts", ".asc", ".txt"}
 	case dialogImport:
-		// DWG/DXF import into a sketch, scan formats (.ply/.e57/.xyz/.pts/.asc) into a point cloud,
-		// the rest into bodies.
-		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dwg", ".dxf", ".ply", ".e57", ".xyz", ".pts", ".asc"}
+		// DWG/DXF import into a sketch, scan formats (.ply/.e57/.las/.xyz/.pts/.asc) into a point
+		// cloud, the rest into bodies.
+		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dwg", ".dxf", ".ply", ".e57", ".las", ".xyz", ".pts", ".asc"}
 	case dialogExport:
 		// DXF exports the active sketch; the others export the part's bodies.
 		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dxf"}

--- a/head/ui/file_dialog_test.go
+++ b/head/ui/file_dialog_test.go
@@ -108,7 +108,7 @@ func TestFileDialogTitleDefaultsToOpen(t *testing.T) {
 func TestFileDialogImportExportModes(t *testing.T) {
 	var d fileDialog
 	d.openFor(dialogImport)
-	if d.title() != "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.e57/.xyz/.pts)" {
+	if d.title() != "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.e57/.las/.xyz/.pts)" {
 		t.Errorf("import title = %q", d.title())
 	}
 	d.openFor(dialogExport)

--- a/head/ui/point_cloud_las_shot_test.go
+++ b/head/ui/point_cloud_las_shot_test.go
@@ -1,0 +1,80 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// synthLASCube builds a minimal valid uncompressed LAS file whose points form the shell of a cube
+// (scale 1, offset 0, point data record format 0), so the live capture has a recognisable shape.
+// There is no public-domain LAS in the sample set, so this stands in for real LiDAR data.
+func synthLASCube() []byte {
+	const headerSize, recordLen = 227, 20
+	var pts [][3]int32
+	for x := 0; x <= 100; x += 10 {
+		for y := 0; y <= 100; y += 10 {
+			for z := 0; z <= 100; z += 10 {
+				if x == 0 || x == 100 || y == 0 || y == 100 || z == 0 || z == 100 {
+					pts = append(pts, [3]int32{int32(x), int32(y), int32(z)})
+				}
+			}
+		}
+	}
+	h := make([]byte, headerSize)
+	copy(h, "LASF")
+	h[24], h[25] = 1, 2
+	binary.LittleEndian.PutUint16(h[94:], headerSize)
+	binary.LittleEndian.PutUint32(h[96:], headerSize)
+	binary.LittleEndian.PutUint16(h[105:], recordLen)
+	binary.LittleEndian.PutUint32(h[107:], uint32(len(pts)))
+	for i := 0; i < 3; i++ {
+		binary.LittleEndian.PutUint64(h[131+i*8:], math.Float64bits(1.0)) // scale = 1
+	}
+	out := h
+	for _, p := range pts {
+		r := make([]byte, recordLen)
+		binary.LittleEndian.PutUint32(r[0:], uint32(p[0]))
+		binary.LittleEndian.PutUint32(r[4:], uint32(p[1]))
+		binary.LittleEndian.PutUint32(r[8:], uint32(p[2]))
+		out = append(out, r...)
+	}
+	return out
+}
+
+// TestInWindowSyntheticLASRenders writes a synthetic .las cube to a temp file, imports it through
+// the real AttachPointCloud path, and captures the live viewport — the visual confirmation that a
+// .las file decodes and renders as a point cloud (#645). Skips without a display.
+func TestInWindowSyntheticLASRenders(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cube.las")
+	if err := os.WriteFile(path, synthLASCube(), 0o644); err != nil {
+		t.Fatalf("write synthetic LAS: %v", err)
+	}
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	pc, err := s.AttachPointCloud("Cube LAS", path)
+	if err != nil {
+		t.Fatalf("attach synthetic LAS: %v", err)
+	}
+	t.Logf("loaded %d LAS points", pc.TotalPointCount())
+
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-las.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/kernel/exchange/lasfmt/header.go
+++ b/kernel/exchange/lasfmt/header.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package lasfmt
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// minHeaderSize is the smallest public header block (LAS 1.0–1.2 is 227 bytes); we only read up to
+// the scale/offset doubles (which end at byte 227), so any conformant header is large enough.
+const minHeaderSize = 227
+
+// las14PointCountOffset is where LAS 1.4 keeps the authoritative 64-bit point count (the legacy
+// 32-bit count at legacyPointCountOffset stays 0 for the big or extended-format files).
+const las14PointCountOffset = 247
+
+// legacyPointCountOffset is the LAS 1.0–1.3 (and 1.4 legacy) 32-bit point count.
+const legacyPointCountOffset = 107
+
+// signature is the 4-byte magic every LAS file starts with.
+var signature = []byte("LASF")
+
+// lasHeader is the subset of the public header block a point-cloud import needs: where the point
+// records start, how many there are and how long each is, and the scale/offset that turn the
+// stored integer XYZ into real coordinates (ASPRS LAS R15, §2.2).
+type lasHeader struct {
+	versionMajor    uint8
+	versionMinor    uint8
+	pointDataOffset uint32
+	pointFormat     uint8
+	recordLength    uint16
+	pointCount      uint64
+	scale           [3]float64
+	offset          [3]float64
+}
+
+// parseHeader reads and validates the public header block, erroring on a non-LAS input, a too-short
+// header, or an out-of-range point data record format (0–10 are defined).
+func parseHeader(data []byte) (lasHeader, error) {
+	if len(data) < minHeaderSize {
+		return lasHeader{}, fmt.Errorf("lasfmt: file is %d bytes, shorter than the %d-byte header", len(data), minHeaderSize)
+	}
+	if string(data[:4]) != string(signature) {
+		return lasHeader{}, fmt.Errorf("lasfmt: not a LAS file (signature %q, want %q)", data[:4], signature)
+	}
+	h := lasHeader{
+		versionMajor:    data[24],
+		versionMinor:    data[25],
+		pointDataOffset: binary.LittleEndian.Uint32(data[96:]),
+		pointFormat:     data[104] & 0x3f, // mask the compression bits a LAZ writer may set
+		recordLength:    binary.LittleEndian.Uint16(data[105:]),
+	}
+	if h.pointFormat > 10 {
+		return lasHeader{}, fmt.Errorf("lasfmt: point data record format %d is out of range (0–10)", h.pointFormat)
+	}
+	h.pointCount = pointCount(data)
+	h.scale = readVec3(data, 131)
+	h.offset = readVec3(data, 155)
+	return h, nil
+}
+
+// pointCount returns the authoritative record count: LAS 1.4's 64-bit field when it is present and
+// the legacy 32-bit field is zero, otherwise the legacy field.
+func pointCount(data []byte) uint64 {
+	legacy := uint64(binary.LittleEndian.Uint32(data[legacyPointCountOffset:]))
+	is14 := data[24] > 1 || (data[24] == 1 && data[25] >= 4)
+	if is14 && legacy == 0 && len(data) >= las14PointCountOffset+8 {
+		return binary.LittleEndian.Uint64(data[las14PointCountOffset:])
+	}
+	return legacy
+}
+
+// readVec3 reads three consecutive little-endian float64 starting at off.
+func readVec3(data []byte, off int) [3]float64 {
+	var v [3]float64
+	for i := 0; i < 3; i++ {
+		v[i] = math.Float64frombits(binary.LittleEndian.Uint64(data[off+i*8:]))
+	}
+	return v
+}

--- a/kernel/exchange/lasfmt/lasfmt.go
+++ b/kernel/exchange/lasfmt/lasfmt.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package lasfmt is a clean-room reader for the ASPRS LAS LiDAR format (uncompressed .las), scoped
+// to what a point-cloud import needs: the XYZ positions. Every LAS point data record format (0–10)
+// begins with the same three little-endian int32 — X, Y, Z — and the public header carries the
+// scale and offset that turn those stored integers into real coordinates
+// (real = stored*scale + offset). This package reads the header and walks the fixed-length records;
+// it does not decode intensity, returns, classification, colour, or waveforms, and it does not
+// handle LAZ (the arithmetic-coded variant) — those are out of scope (#645).
+package lasfmt
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	omath "oblikovati.org/math"
+)
+
+// Document is a parsed LAS file ready to yield its points.
+type Document struct {
+	header lasHeader
+	data   []byte
+}
+
+// Parse reads and validates the LAS public header. It does not decode the points — call Vertices.
+func Parse(data []byte) (*Document, error) {
+	header, err := parseHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Document{header: header, data: data}, nil
+}
+
+// Vertices decodes every point record's XYZ into real coordinates. It errors if the record stride
+// cannot hold an XYZ triple or the records run past the end of the file.
+func (d *Document) Vertices() ([]omath.Point3, error) {
+	h := d.header
+	if h.recordLength < 12 {
+		return nil, fmt.Errorf("lasfmt: point record length %d is too small to hold an XYZ triple", h.recordLength)
+	}
+	start := uint64(h.pointDataOffset)
+	end := start + h.pointCount*uint64(h.recordLength)
+	if end > uint64(len(d.data)) {
+		return nil, fmt.Errorf("lasfmt: %d records of %d bytes from offset %d exceed the %d-byte file", h.pointCount, h.recordLength, start, len(d.data))
+	}
+	out := make([]omath.Point3, 0, h.pointCount)
+	for i := uint64(0); i < h.pointCount; i++ {
+		rec := d.data[start+i*uint64(h.recordLength):]
+		out = append(out, d.point(rec))
+	}
+	return out, nil
+}
+
+// point reads the leading X/Y/Z int32 of one record and applies the header scale and offset.
+func (d *Document) point(rec []byte) omath.Point3 {
+	x := float64(int32(binary.LittleEndian.Uint32(rec[0:])))*d.header.scale[0] + d.header.offset[0]
+	y := float64(int32(binary.LittleEndian.Uint32(rec[4:])))*d.header.scale[1] + d.header.offset[1]
+	z := float64(int32(binary.LittleEndian.Uint32(rec[8:])))*d.header.scale[2] + d.header.offset[2]
+	return omath.P3(omath.Scalar(x), omath.Scalar(y), omath.Scalar(z))
+}

--- a/kernel/exchange/lasfmt/lasfmt_test.go
+++ b/kernel/exchange/lasfmt/lasfmt_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package lasfmt
+
+import (
+	"encoding/binary"
+	"math"
+	"strings"
+	"testing"
+)
+
+// --- synthetic LAS builder (a named fake for the on-disk format) ---
+
+// lasBuilder assembles a minimal valid uncompressed LAS file: a public header followed by
+// fixed-length point records whose leading int32 X/Y/Z are filled (other fields left zero).
+type lasBuilder struct {
+	points       [][3]int32
+	scale        [3]float64
+	offset       [3]float64
+	v14          bool   // LAS 1.4 header (375 bytes, 64-bit count) vs 1.2 (227 bytes, 32-bit)
+	recordLength uint16 // 0 → format-0 default of 20
+}
+
+func (b lasBuilder) bytes() []byte {
+	headerSize := 227
+	if b.v14 {
+		headerSize = 375
+	}
+	recLen := b.recordLength
+	if recLen == 0 {
+		recLen = 20 // point data record format 0
+	}
+	hdr := make([]byte, headerSize)
+	copy(hdr, signature)
+	hdr[24], hdr[25] = 1, 2
+	if b.v14 {
+		hdr[25] = 4
+	}
+	binary.LittleEndian.PutUint16(hdr[94:], uint16(headerSize))
+	binary.LittleEndian.PutUint32(hdr[96:], uint32(headerSize)) // point data starts right after header
+	hdr[104] = 0                                                // point format 0
+	binary.LittleEndian.PutUint16(hdr[105:], recLen)
+	b.writeCount(hdr)
+	putVec3(hdr, 131, b.scale)
+	putVec3(hdr, 155, b.offset)
+
+	out := hdr
+	for _, p := range b.points {
+		rec := make([]byte, recLen)
+		for c, off := 0, 0; c < 3 && off+4 <= int(recLen); c, off = c+1, off+4 {
+			binary.LittleEndian.PutUint32(rec[off:], uint32(p[c])) // only write coords the stride holds
+		}
+		out = append(out, rec...)
+	}
+	return out
+}
+
+// writeCount populates the legacy 32-bit count, and for a 1.4 header the authoritative 64-bit one
+// (with the legacy field left zero, the path a big/extended LAS uses).
+func (b lasBuilder) writeCount(hdr []byte) {
+	if b.v14 {
+		binary.LittleEndian.PutUint64(hdr[las14PointCountOffset:], uint64(len(b.points)))
+		return
+	}
+	binary.LittleEndian.PutUint32(hdr[legacyPointCountOffset:], uint32(len(b.points)))
+}
+
+func putVec3(b []byte, off int, v [3]float64) {
+	for i := 0; i < 3; i++ {
+		binary.LittleEndian.PutUint64(b[off+i*8:], math.Float64bits(v[i]))
+	}
+}
+
+// --- tests ---
+
+func TestParseAndDecodeLAS12(t *testing.T) {
+	scale := [3]float64{0.001, 0.001, 0.01}
+	offset := [3]float64{100, -50, 0}
+	pts := [][3]int32{{1000, 2000, 300}, {-5000, 0, 12345}, {2147483647, -2147483648, 1}}
+	doc, err := Parse(lasBuilder{points: pts, scale: scale, offset: offset}.bytes())
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	got, err := doc.Vertices()
+	if err != nil {
+		t.Fatalf("Vertices: %v", err)
+	}
+	if len(got) != len(pts) {
+		t.Fatalf("got %d points, want %d", len(got), len(pts))
+	}
+	for i, p := range pts {
+		wantX := float64(p[0])*scale[0] + offset[0]
+		wantY := float64(p[1])*scale[1] + offset[1]
+		wantZ := float64(p[2])*scale[2] + offset[2]
+		if float64(got[i].X) != wantX || float64(got[i].Y) != wantY || float64(got[i].Z) != wantZ {
+			t.Errorf("point %d = (%v,%v,%v), want (%v,%v,%v)", i, got[i].X, got[i].Y, got[i].Z, wantX, wantY, wantZ)
+		}
+	}
+}
+
+func TestDecodeLAS14Count64(t *testing.T) {
+	scale := [3]float64{1, 1, 1}
+	pts := [][3]int32{{1, 2, 3}, {4, 5, 6}}
+	doc, err := Parse(lasBuilder{points: pts, scale: scale, v14: true}.bytes())
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if doc.header.pointCount != 2 {
+		t.Fatalf("1.4 count = %d, want 2 (from the 64-bit field)", doc.header.pointCount)
+	}
+	got, err := doc.Vertices()
+	if err != nil || len(got) != 2 || float64(got[1].X) != 4 {
+		t.Fatalf("decoded = %v, err=%v", got, err)
+	}
+}
+
+func TestParseHeaderErrors(t *testing.T) {
+	if _, err := Parse([]byte("LASF tiny")); err == nil {
+		t.Error("want error for short input")
+	}
+	bad := make([]byte, minHeaderSize)
+	copy(bad, "NOPE")
+	if _, err := Parse(bad); err == nil || !strings.Contains(err.Error(), "not a LAS") {
+		t.Errorf("want signature error, got %v", err)
+	}
+	badFmt := lasBuilder{scale: [3]float64{1, 1, 1}}.bytes()
+	badFmt[104] = 11 // out-of-range point data record format
+	if _, err := Parse(badFmt); err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("want format-range error, got %v", err)
+	}
+}
+
+func TestVerticesTruncated(t *testing.T) {
+	raw := lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{1, 1, 1}}.bytes()
+	binary.LittleEndian.PutUint32(raw[legacyPointCountOffset:], 1000) // claim far more points than bytes
+	doc, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if _, err := doc.Vertices(); err == nil || !strings.Contains(err.Error(), "exceed") {
+		t.Errorf("want truncation error, got %v", err)
+	}
+}
+
+func TestVerticesRecordTooSmall(t *testing.T) {
+	doc, err := Parse(lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{1, 1, 1}, recordLength: 8}.bytes())
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if _, err := doc.Vertices(); err == nil || !strings.Contains(err.Error(), "too small") {
+		t.Errorf("want record-length error, got %v", err)
+	}
+}

--- a/model/pointcloud/collection_test.go
+++ b/model/pointcloud/collection_test.go
@@ -108,7 +108,7 @@ func TestReadScanDispatch(t *testing.T) {
 	if err != nil || len(pts) != 1 {
 		t.Fatalf("ReadScan(.PTS) = %v points, err %v", len(pts), err)
 	}
-	if _, err := ReadScan("room.las", []byte("binary")); err == nil {
+	if _, err := ReadScan("room.bin", []byte("binary")); err == nil {
 		t.Error("ReadScan of an unregistered extension should fail")
 	}
 }
@@ -116,7 +116,7 @@ func TestReadScanDispatch(t *testing.T) {
 // TestIsScanFileAndExtensions: scan extensions are recognized (any case) and non-scan ones are not
 // (#645).
 func TestIsScanFileAndExtensions(t *testing.T) {
-	for _, p := range []string{"room.ply", "scan.XYZ", "a.pts", "b.asc", "c.txt", "part.E57"} {
+	for _, p := range []string{"room.ply", "scan.XYZ", "a.pts", "b.asc", "c.txt", "part.E57", "survey.las"} {
 		if !IsScanFile(p) {
 			t.Errorf("IsScanFile(%q) = false, want true", p)
 		}

--- a/model/pointcloud/las.go
+++ b/model/pointcloud/las.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"oblikovati.org/kernel/exchange/lasfmt"
+	"oblikovati.org/math"
+)
+
+// LAS point reader (M17-F06, #645): the ASPRS LAS format is the standard interchange for LiDAR
+// point data (airborne and terrestrial surveys). A point cloud needs only the XYZ positions, so
+// this reader delegates the header/record parsing to the shared kernel/exchange/lasfmt package and
+// takes its vertices. The compressed LAZ variant is not handled here.
+type lasReader struct{}
+
+// NewLASReader returns the reader for ASPRS .las scan files.
+func NewLASReader() PointReader { return lasReader{} }
+
+func (lasReader) Extensions() []string { return []string{".las"} }
+
+// Read decodes the LAS point records into cloud-local points (intensity/returns are ignored).
+func (lasReader) Read(data []byte) ([]math.Point3, error) {
+	doc, err := lasfmt.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	return doc.Vertices()
+}

--- a/model/pointcloud/las_test.go
+++ b/model/pointcloud/las_test.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import "testing"
+
+// The LAS decode itself is covered in kernel/exchange/lasfmt; here we cover the model-layer
+// reader's wiring: its extension, that ReadScan dispatches .las to it, and that malformed bytes
+// surface an error rather than panicking (#645).
+
+func TestLASReaderExtensions(t *testing.T) {
+	exts := NewLASReader().Extensions()
+	if len(exts) != 1 || exts[0] != ".las" {
+		t.Fatalf("LAS extensions = %v, want [.las]", exts)
+	}
+}
+
+func TestReadScanDispatchesLASError(t *testing.T) {
+	_, err := ReadScan("survey.las", []byte("this is not a LAS file"))
+	if err == nil {
+		t.Fatal("want a decode error for non-LAS bytes routed to the las reader")
+	}
+}

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -18,9 +18,9 @@ import (
 	"oblikovati.org/math"
 )
 
-// registeredReaders is the decoder set keyed by lowercase extension. ASCII, PLY, and E57 ship now;
-// a LAS reader registers here later without touching call sites.
-var registeredReaders = []PointReader{NewASCIIReader(), NewPLYReader(), NewE57Reader()}
+// registeredReaders is the decoder set keyed by lowercase extension: ASCII, PLY, E57, and LAS.
+// A new format's reader registers here without touching call sites.
+var registeredReaders = []PointReader{NewASCIIReader(), NewPLYReader(), NewE57Reader(), NewLASReader()}
 
 // ReadScan decodes a scan file's bytes into cloud-local points, choosing the reader by the
 // filename's extension. It errors when no registered reader handles the extension, naming it.
@@ -37,7 +37,7 @@ func ReadScan(filename string, data []byte) ([]math.Point3, error) {
 }
 
 // IsScanFile reports whether a path's extension is a 3D-scan point-cloud format handled by a
-// registered reader (.xyz/.pts/.asc/.txt/.ply/.e57). The import flow routes such files to the
+// registered reader (.xyz/.pts/.asc/.txt/.ply/.e57/.las). The import flow routes such files to the
 // point-cloud attach path — the appropriate home for scan data — rather than the body/sketch
 // importers (#645).
 func IsScanFile(path string) bool {


### PR DESCRIPTION
## What

Adds a LAS reader so `File ▸ Import` of an uncompressed `.las` LiDAR file attaches a **point cloud** (#645) — the fourth scan format after ASCII, PLY, and E57. Same shape as before: a clean-room decoder in `kernel/exchange/lasfmt`, a thin `model/pointcloud` delegate registered in `registeredReaders`, and the host import path/dialog picking it up.

### `kernel/exchange/lasfmt` (clean-room)
LAS is simple and uncompressed: every point data record format (0–10) begins with the same three little-endian `int32` X/Y/Z, and the public header carries the scale and offset that turn those into real coordinates (`real = stored·scale + offset`). The package parses the header — including LAS 1.4's 64-bit point count — and walks the fixed-length records. Intensity, returns, classification, colour, waveforms, and the arithmetic-coded **LAZ** variant are out of scope.

## Why

LAS is the standard interchange for LiDAR (airborne/terrestrial survey) point data — a natural companion to the structured-scanner formats already supported, and it belongs in the point-cloud object a design is modelled against.

## Testing

- **Unit** (`kernel/exchange/lasfmt`, **100%** stmt cov): a synthetic LAS builder covers LAS 1.2 (legacy 32-bit count) and LAS 1.4 (64-bit count), scale/offset decode, and the error paths (short header, bad signature, out-of-range record format, truncated records, undersized stride).
- **Model**: `.las` dispatch + extension + error path; the dispatch test's "unregistered extension" case moved from `.las` (now handled) to `.bin`.
- **Live visual confirmation**: a synthetic `.las` cube imports through the real `AttachPointCloud` path and renders as a point cloud in the running head (`TestInWindowSyntheticLASRenders`, skips in CI). Captured `/tmp/point-cloud-las.png` — a clean cube-shell cloud.
- Pins `oblikovati.org/api` to v0.82.0 (adds `FormatLAS` / `IsPointCloud`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)