### PR TITLE
feat(#645): place a work point on a snapped scan point

### DIFF
--- a/addin/router/point_clouds.go
+++ b/addin/router/point_clouds.go
@@ -36,6 +36,7 @@ func (r *Router) registerPointCloudHandlers() {
 	r.handlers[wire.MethodPointCloudsDeleteCrop] = deletePointCloudCrop
 	r.handlers[wire.MethodPointCloudsSetCropActive] = setPointCloudCropActive
 	r.handlers[wire.MethodPointCloudsFitPlane] = fitPointCloudPlane
+	r.handlers[wire.MethodPointCloudsNearestPoint] = nearestPointCloudPoint
 }
 
 // attachPointCloud reads the scan file, embeds its bytes as a resource, decodes its points, and
@@ -251,6 +252,26 @@ func fitPointCloudPlane(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 		WorkPlane: wp.Name(),
 		Origin:    pointOf(plane.Origin),
 		Normal:    pointOf(math.P3(n.X, n.Y, n.Z)),
+	})
+}
+
+// nearestPointCloudPoint snaps the query point onto the named cloud, returning its nearest scan
+// point in model space and the distance to it.
+func nearestPointCloudPoint(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.NearestPointArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	pc, err := namedCloud(s, in.Cloud, wire.MethodPointCloudsNearestPoint)
+	if err != nil {
+		return nil, err
+	}
+	query := point3Of(in.Point)
+	nearest, found := pc.NearestModelPoint(query)
+	return json.Marshal(wire.NearestPointResult{
+		Point:    pointOf(nearest),
+		Distance: float64(query.DistanceTo(nearest)),
+		Found:    found,
 	})
 }
 

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -242,3 +242,23 @@ func TestPointCloudFitPlane(t *testing.T) {
 		t.Error("fitPlane on an unknown cloud should error")
 	}
 }
+
+// TestPointCloudNearestPoint: nearestPoint snaps a query onto the cloud's closest scan point and
+// reports the distance; an unknown cloud errors (#645).
+func TestPointCloudNearestPoint(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := writeScan(t, "0 0 0\n2 0 0\n0 2 0\n")
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &wire.PointCloudInfo{})
+
+	var res wire.NearestPointResult
+	call(t, r, s, "pointClouds.nearestPoint", mustJSON(t, wire.NearestPointArgs{Cloud: "Scan", Point: types.Point{X: 1.9, Y: 0.1, Z: 0}}), &res)
+	if !res.Found || res.Point != (types.Point{X: 2, Y: 0, Z: 0}) {
+		t.Errorf("nearest = %+v (found=%v), want (2,0,0)", res.Point, res.Found)
+	}
+	if stdmath.Abs(res.Distance-stdmath.Hypot(0.1, 0.1)) > 1e-9 {
+		t.Errorf("distance = %v, want hypot(0.1,0.1)", res.Distance)
+	}
+	if _, err := r.Handle(s, "pointClouds.nearestPoint", []byte(`{"cloud":"nope","point":{"x":0,"y":0,"z":0}}`)); err == nil {
+		t.Error("nearestPoint on an unknown cloud should error")
+	}
+}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -219,6 +219,12 @@ func pointCloudCommands() []*CommandDefinition {
 		}).WithTab(tab3DModel).WithEnable(canFitPointCloudPlane).
 			WithIcon("point-cloud-fit-plane").WithButtonStyle(SmallIconButton).
 			WithTooltip("Fit Work Plane — least-squares plane through the selected cloud's displayed points (crop first to fit a region)."),
+		NewCommand("PointCloud.WorkPoint", "Work Point", "Point Cloud", func(s *Session) error {
+			_, err := s.CreateWorkPointAtSelectedCloudPoint()
+			return err
+		}).WithTab(tab3DModel).WithEnable(canWorkPointAtCloudPoint).
+			WithIcon("point-cloud-work-point").WithButtonStyle(SmallIconButton).
+			WithTooltip("Work Point — place a datum point on the selected scan point (snap to a cloud point first)."),
 	}
 }
 

--- a/app/consts.go
+++ b/app/consts.go
@@ -14,6 +14,7 @@ const (
 
 	labelBaseView  = "Base View"
 	labelWorkPlane = "Work Plane"
+	labelWorkPoint = "Work Point"
 	tabGetStarted  = "Get Started"
 
 	promptSelectTwoLines        = "Select two lines"

--- a/app/point_cloud_snap.go
+++ b/app/point_cloud_snap.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// Snapped scan-point consumer (M17-F06, #645): a picked point on an attached cloud
+// (PointCloudPointHandle) carries its model-space position, so a datum point can be anchored
+// directly on the as-built scan data — the bridge from a reference cloud to model geometry.
+
+// SelectedCloudPoint returns the model-space location of the snapped scan point selected in the
+// viewport, if one is selected.
+func (s *Session) SelectedCloudPoint() (math.Point3, bool) {
+	for _, it := range s.selection.Items() {
+		if h, ok := it.(PointCloudPointHandle); ok {
+			return h.Position(), true
+		}
+	}
+	return math.Point3{}, false
+}
+
+// CreateWorkPointAtSelectedCloudPoint adds a fixed datum point at the snapped scan point selected in
+// the viewport, then recomputes — the Point Cloud panel's Work Point command. It errors when there
+// is no active part or no scan point is selected.
+func (s *Session) CreateWorkPointAtSelectedCloudPoint() (*feature.WorkPoint, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return nil, err
+	}
+	at, ok := s.SelectedCloudPoint()
+	if !ok {
+		return nil, errors.New("app: select a point on a scan (snap to a cloud point) to place a work point")
+	}
+	wp := part.WorkPoints().AddByPosition(func() math.Point3 { return at })
+	part.Recompute()
+	s.recordEdit(part, labelWorkPoint)
+	return wp, nil
+}
+
+// canWorkPointAtCloudPoint enables Work Point from a scan: a snapped scan point is selected and we
+// are not in a sketch.
+func canWorkPointAtCloudPoint(s *Session) bool {
+	_, ok := s.SelectedCloudPoint()
+	return ok && !s.InSketch()
+}

--- a/app/point_cloud_snap_consumer_test.go
+++ b/app/point_cloud_snap_consumer_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+)
+
+// TestCreateWorkPointAtSelectedCloudPoint: with a snapped scan point selected, the command adds a
+// datum point at that location; with nothing selected it is disabled and errors (#645).
+func TestCreateWorkPointAtSelectedCloudPoint(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(3, 4, 5)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	if canWorkPointAtCloudPoint(s) {
+		t.Error("Work Point should be disabled with nothing selected")
+	}
+	if _, err := s.CreateWorkPointAtSelectedCloudPoint(); err == nil {
+		t.Error("expected an error with no scan point selected")
+	}
+
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 5)})
+	if !canWorkPointAtCloudPoint(s) {
+		t.Error("Work Point should be enabled with a scan point selected")
+	}
+	if got, ok := s.SelectedCloudPoint(); !ok || got != math.P3(3, 4, 5) {
+		t.Errorf("SelectedCloudPoint = %v,%v want (3,4,5)", got, ok)
+	}
+
+	before := def.WorkPoints().Count()
+	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("CreateWorkPointAtSelectedCloudPoint: %v", err)
+	}
+	if def.WorkPoints().Count() != before+1 {
+		t.Errorf("work point count = %d, want %d", def.WorkPoints().Count(), before+1)
+	}
+	if wp.Point() != math.P3(3, 4, 5) {
+		t.Errorf("work point at %v, want the snapped scan point (3,4,5)", wp.Point())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.83.0
+	oblikovati.org/api v0.84.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.83.0
+	oblikovati.org/api v0.84.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/icon/assets/point-cloud-work-point.svg
+++ b/head/icon/assets/point-cloud-work-point.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000" stroke="none"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00"/><circle cx="7" cy="8" r="1.1"/><circle cx="16" cy="7" r="1.1"/><circle cx="6" cy="16" r="1.1"/><circle cx="17" cy="16" r="1.1"/><circle cx="10" cy="11" r="1.1"/><circle cx="12" cy="13" r="2.2" fill="#ff0000"/></svg>

--- a/head/ui/point_cloud_snap_shot_test.go
+++ b/head/ui/point_cloud_snap_shot_test.go
@@ -1,0 +1,66 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+)
+
+// gridScan writes a small ASCII scan: a flat grid of points with one raised peak, so the placed
+// work point on the peak is easy to spot.
+func gridScan(t *testing.T) string {
+	t.Helper()
+	var body string
+	for ix := -6; ix <= 6; ix++ {
+		for iy := -6; iy <= 6; iy++ {
+			body += fmt.Sprintf("%d %d 0\n", ix, iy)
+		}
+	}
+	body += "0 0 6\n" // a single raised point (the peak) to snap the work point onto
+	path := filepath.Join(t.TempDir(), "grid.xyz")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	return path
+}
+
+// TestInWindowSnapWorkPointRenders attaches a scan, selects its raised peak point, places a work
+// point there, and captures the live viewport — the visual confirmation that Work Point anchors a
+// datum on the as-built scan data (#645). Skips without a display.
+func TestInWindowSnapWorkPointRenders(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	pc, err := s.AttachPointCloud("Grid", gridScan(t))
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	peak := math.P3(0, 0, 6)
+	s.Select(app.PointCloudPointHandle{Cloud: pc, Point: peak})
+	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("create work point: %v", err)
+	}
+	t.Logf("placed work point at %v on the snapped peak", wp.Point())
+
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-snap-workpoint.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/model/pointcloud/pointcloud.go
+++ b/model/pointcloud/pointcloud.go
@@ -138,6 +138,25 @@ func (pc *PointCloud) DisplayedPoints() []math.Point3 {
 // best-fit consumer reads — fitting a work plane to the cloud's current working region (#645).
 func (pc *PointCloud) CroppedModelPoints() []math.Point3 { return pc.croppedModelPoints() }
 
+// NearestModelPoint returns the cloud's scan point in MODEL space closest to query (snapping a
+// model coordinate onto the as-built data), searching the full cloud — placement-transformed but
+// not crop-limited — so a snap finds a point even where the display is cropped away. Found is false
+// only for an empty cloud.
+func (pc *PointCloud) NearestModelPoint(query math.Point3) (math.Point3, bool) {
+	if len(pc.points) == 0 {
+		return math.Point3{}, false
+	}
+	best := pc.ToModelSpace(pc.points[0])
+	bestD := query.DistanceSquaredTo(best)
+	for _, p := range pc.points[1:] {
+		m := pc.ToModelSpace(p)
+		if d := query.DistanceSquaredTo(m); d < bestD {
+			best, bestD = m, d
+		}
+	}
+	return best, true
+}
+
 // croppedModelPoints returns every point in MODEL space that passes the active crops.
 func (pc *PointCloud) croppedModelPoints() []math.Point3 {
 	out := make([]math.Point3, 0, len(pc.points))

--- a/model/pointcloud/pointcloud_test.go
+++ b/model/pointcloud/pointcloud_test.go
@@ -120,3 +120,20 @@ func translation(x, y, z omath.Scalar) omath.Matrix4 {
 func near(a, b omath.Point3) bool {
 	return math.Abs(float64(a.X-b.X)) < 1e-9 && math.Abs(float64(a.Y-b.Y)) < 1e-9 && math.Abs(float64(a.Z-b.Z)) < 1e-9
 }
+
+// TestNearestModelPoint: the closest scan point to a query is returned in model space, honouring
+// the placement scale; an empty cloud reports not-found (#645).
+func TestNearestModelPoint(t *testing.T) {
+	pc := New("s", "", "", []omath.Point3{omath.P3(0, 0, 0), omath.P3(2, 0, 0), omath.P3(0, 2, 0)})
+	got, ok := pc.NearestModelPoint(omath.P3(1.9, 0.1, 0))
+	if !ok || !near(got, omath.P3(2, 0, 0)) {
+		t.Errorf("nearest = %v (ok=%v), want (2,0,0)", got, ok)
+	}
+	pc.SetScale(3) // (0,2,0) → (0,6,0); a query near it snaps there
+	if got, ok := pc.NearestModelPoint(omath.P3(0, 5.5, 0)); !ok || !near(got, omath.P3(0, 6, 0)) {
+		t.Errorf("scaled nearest = %v (ok=%v), want (0,6,0)", got, ok)
+	}
+	if _, ok := New("e", "", "", nil).NearestModelPoint(omath.P3(0, 0, 0)); ok {
+		t.Error("empty cloud should report not-found")
+	}
+}


### PR DESCRIPTION
## What

Adds the **snapped scan-point consumer** — anchoring model geometry directly on the as-built scan data (#645). Two cohesive halves:

- **Interactive (UI)**: 3D Model ▸ Point Cloud ▸ **Work Point** (enabled when a snapped scan point is selected) places a fixed datum point at the picked cloud point. `Session.CreateWorkPointAtSelectedCloudPoint` reads the selected `PointCloudPointHandle` (which already carries its model-space position from the snapping work) and adds a `WorkPoints.AddByPosition` datum.
- **Programmatic (wire)**: `pointClouds.nearestPoint` snaps a model-space query onto a cloud — `PointCloud.NearestModelPoint` searches the whole placement-transformed cloud (not crop-limited) and returns the nearest scan point + distance. Composed with `workPoints.create`, a script can anchor a datum on scan data too.

Pins `oblikovati.org/api` to **v0.84.0** (`pointClouds.nearestPoint`).

## Why

A scan is reference data you build against; placing a datum point exactly on a scanned feature is the most basic bridge from cloud to model. The `PointCloudPointHandle.Position()` snap hook has existed since the snapping PR — this is the first consumer that *builds* geometry from it.

## Testing

- **model** (`pointcloud`): `NearestModelPoint` returns the closest point, honours placement scale, reports not-found for an empty cloud.
- **app**: selecting a scan point enables the command and places a datum at exactly that point; disabled/errors with nothing selected.
- **router**: `nearestPoint` over the wire snaps a query and reports point + distance; unknown-cloud error.
- **Live visual confirmation**: a work point placed on a raised scan peak renders as a datum marker at the snapped location (`TestInWindowSnapWorkPointRenders`, skips in CI). Captured `/tmp/point-cloud-snap-workpoint.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)