### PR TITLE
feat(#645): place a sketch point on a snapped scan point

### DIFF
--- a/app/commands_sketch.go
+++ b/app/commands_sketch.go
@@ -45,6 +45,12 @@ func sketchTabCommands() []*CommandDefinition {
 	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).
 		WithIcon("project-geometry").WithButtonStyle(LargeIconButton).
 		WithTooltip("Project Geometry — pick part edges/vertices to reference onto the sketch plane."))
+	cmds = append(cmds, NewCommand("Sketch.ProjectScanPoint", "Project Scan Point", "Create", func(s *Session) error {
+		_, err := s.CreateSketchPointAtSelectedCloudPoint()
+		return err
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(canSketchPointAtCloudPoint).
+		WithIcon("sketch-point-scan").WithButtonStyle(SmallIconButton).
+		WithTooltip("Project Scan Point — place a sketch point on the selected scan point, projected onto the sketch plane."))
 	cmds = append(cmds, NewCommand("Sketch.Finish", "Finish Sketch", "Exit", func(s *Session) error {
 		return s.FinishSketch()
 	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithEnable(inSketch).

--- a/app/commands_standard_test.go
+++ b/app/commands_standard_test.go
@@ -27,10 +27,10 @@ func TestStandardRibbonHasSketchCreatePanel(t *testing.T) {
 		t.Fatal("Sketch tab has no Create panel")
 	}
 	// Line, Rectangle, Circle, Arc, Slot, Spline, Ellipse, Polygon, Fillet, Chamfer, Text,
-	// Point, Project Geometry (merged from the non-canonical Draw panel 2026-06-11), plus
-	// Create Block (M06-F07, #622).
-	if len(panel.Buttons) != 14 {
-		t.Errorf("Sketch Create panel has %d tools, want 14", len(panel.Buttons))
+	// Point, Project Geometry (merged from the non-canonical Draw panel 2026-06-11), Create
+	// Block (M06-F07, #622), plus Project Scan Point (a sketch point on a snapped scan, #645).
+	if len(panel.Buttons) != 15 {
+		t.Errorf("Sketch Create panel has %d tools, want 15", len(panel.Buttons))
 	}
 }
 

--- a/app/point_cloud_sketch_point_test.go
+++ b/app/point_cloud_sketch_point_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// TestCreateSketchPointAtSelectedCloudPoint: inside a sketch, with a snapped scan point selected,
+// the command adds a sketch point at the scan point projected onto the sketch plane; outside a
+// sketch or with nothing selected it is disabled and errors (#645).
+func TestCreateSketchPointAtSelectedCloudPoint(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(3, 4, 7)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// Not in a sketch yet → disabled and errors even with a scan point selected.
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 7)})
+	if canSketchPointAtCloudPoint(s) {
+		t.Error("Sketch Point should be disabled outside a sketch")
+	}
+	if _, err := s.CreateSketchPointAtSelectedCloudPoint(); err == nil {
+		t.Error("expected an error outside a sketch")
+	}
+
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	// Entering the sketch clears the selection; re-select the snapped scan point.
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 7)})
+	if !canSketchPointAtCloudPoint(s) {
+		t.Error("Sketch Point should be enabled in a sketch with a scan point selected")
+	}
+
+	before := sk.Points().Count()
+	p, err := s.CreateSketchPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("CreateSketchPointAtSelectedCloudPoint: %v", err)
+	}
+	if sk.Points().Count() != before+1 {
+		t.Errorf("sketch point count = %d, want %d", sk.Points().Count(), before+1)
+	}
+	// On the XY plane the scan point (3,4,7) projects to sketch (3,4).
+	if got := p.Position(); got != (math.P2(3, 4)) {
+		t.Errorf("sketch point at %v, want (3,4) — (3,4,7) projected onto XY", got)
+	}
+}

--- a/app/point_cloud_sketch_point_test.go
+++ b/app/point_cloud_sketch_point_test.go
@@ -53,3 +53,36 @@ func TestCreateSketchPointAtSelectedCloudPoint(t *testing.T) {
 		t.Errorf("sketch point at %v, want (3,4) — (3,4,7) projected onto XY", got)
 	}
 }
+
+// TestProjectScanPointCommandRuns: the registered Project Scan Point command executes the consumer
+// end to end, and the in-sketch-without-a-selection path errors (the command's enable would block
+// it, but the action must fail safe) (#645).
+func TestProjectScanPointCommandRuns(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(2, 5, 9)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+
+	// In a sketch but nothing selected → the action errors.
+	if err := s.Execute("Sketch.ProjectScanPoint"); err == nil {
+		t.Error("Project Scan Point should error with no scan point selected")
+	}
+
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(2, 5, 9)})
+	before := sk.Points().Count()
+	if err := s.Execute("Sketch.ProjectScanPoint"); err != nil {
+		t.Fatalf("Execute(Sketch.ProjectScanPoint): %v", err)
+	}
+	if sk.Points().Count() != before+1 {
+		t.Errorf("after command, sketch point count = %d, want %d", sk.Points().Count(), before+1)
+	}
+}

--- a/app/point_cloud_sketch_point_test.go
+++ b/app/point_cloud_sketch_point_test.go
@@ -54,6 +54,18 @@ func TestCreateSketchPointAtSelectedCloudPoint(t *testing.T) {
 	}
 }
 
+// TestSketchPointFromScanNoSelectionInSketch directly covers the in-sketch-without-a-selection
+// branch (a scan point must be picked first) (#645).
+func TestSketchPointFromScanNoSelectionInSketch(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	if _, err := s.CreateSketchPointAtSelectedCloudPoint(); err == nil {
+		t.Error("expected an error in a sketch with no scan point selected")
+	}
+}
+
 // TestProjectScanPointCommandRuns: the registered Project Scan Point command executes the consumer
 // end to end, and the in-sketch-without-a-selection path errors (the command's enable would block
 // it, but the action must fail safe) (#645).

--- a/app/point_cloud_snap.go
+++ b/app/point_cloud_snap.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
 )
 
 // Snapped scan-point consumer (M17-F06, #645): a picked point on an attached cloud
@@ -47,4 +48,27 @@ func (s *Session) CreateWorkPointAtSelectedCloudPoint() (*feature.WorkPoint, err
 func canWorkPointAtCloudPoint(s *Session) bool {
 	_, ok := s.SelectedCloudPoint()
 	return ok && !s.InSketch()
+}
+
+// CreateSketchPointAtSelectedCloudPoint adds a sketch point at the snapped scan point selected in
+// the viewport, projected onto the active sketch plane — the in-sketch counterpart of the Work
+// Point command, so a 2D profile can be drawn against scanned features. It errors when there is no
+// active 2D sketch or no scan point is selected.
+func (s *Session) CreateSketchPointAtSelectedCloudPoint() (*sketch.Point, error) {
+	sk := s.ActiveSketch()
+	if sk == nil {
+		return nil, errors.New("app: enter a 2D sketch to place a sketch point on a scan point")
+	}
+	at, ok := s.SelectedCloudPoint()
+	if !ok {
+		return nil, errors.New("app: select a point on a scan (snap to a cloud point) for a sketch point")
+	}
+	return sk.Points().Add(sk.ToSketch(at)), nil
+}
+
+// canSketchPointAtCloudPoint enables Sketch Point from a scan: in a 2D sketch with a snapped scan
+// point selected.
+func canSketchPointAtCloudPoint(s *Session) bool {
+	_, ok := s.SelectedCloudPoint()
+	return ok && s.InSketch()
 }

--- a/head/icon/assets/sketch-point-scan.svg
+++ b/head/icon/assets/sketch-point-scan.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#000" stroke="none"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00"/><polygon points="3,16 12,11 21,14 12,19" fill="#0000ff"/><circle cx="9" cy="6" r="1.1"/><circle cx="15" cy="7" r="1.1"/><circle cx="13" cy="4" r="1.1"/><circle cx="12" cy="15" r="2.2" fill="#ff0000"/></svg>

--- a/head/ui/point_cloud_sketch_point_shot_test.go
+++ b/head/ui/point_cloud_sketch_point_shot_test.go
@@ -1,0 +1,75 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// flatScanNearXY writes a flat grid of scan points just above z = 0, so projecting them onto the XY
+// sketch plane lands sketch points right under the scanned features.
+func flatScanNearXY(t *testing.T) (string, math.Point3) {
+	t.Helper()
+	var body string
+	for ix := -6; ix <= 6; ix++ {
+		for iy := -6; iy <= 6; iy++ {
+			body += fmt.Sprintf("%d %d 1\n", ix, iy)
+		}
+	}
+	peak := math.P3(4, 3, 1)
+	body += fmt.Sprintf("%g %g %g\n", float64(peak.X), float64(peak.Y), float64(peak.Z))
+	path := filepath.Join(t.TempDir(), "flat.xyz")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	return path, peak
+}
+
+// TestInWindowSketchPointFromScanRenders attaches a scan, enters a sketch, selects a scan point,
+// projects it onto the sketch plane as a sketch point, and captures the live viewport — the visual
+// confirmation that Project Scan Point anchors sketch geometry on the as-built data (#645). Skips
+// without a display.
+func TestInWindowSketchPointFromScanRenders(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	path, peak := flatScanNearXY(t)
+	pc, err := s.AttachPointCloud("Flat", path)
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("enter sketch: %v", err)
+	}
+	s.Select(app.PointCloudPointHandle{Cloud: pc, Point: peak})
+	sp, err := s.CreateSketchPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("project scan point: %v", err)
+	}
+	t.Logf("placed sketch point at %v from scan peak %v", sp.Position(), peak)
+
+	// The sketch environment drives its own plan view; this exercises the full attach → sketch →
+	// select → project → render path without error (the placed position is asserted in the app
+	// unit test, which is the authoritative geometric check).
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-sketch-point.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}


### PR DESCRIPTION
## What

The in-sketch counterpart of **Work Point**: **Sketch ▸ Create ▸ Project Scan Point** projects the snapped scan point selected in the viewport onto the active 2D sketch plane and adds a sketch point there — so a profile can be drawn directly against scanned features (#645).

- `Session.CreateSketchPointAtSelectedCloudPoint` reads the selected `PointCloudPointHandle`, projects its 3D position with `Sketch.ToSketch`, and adds the point via `Sketch.Points().Add`.
- `canSketchPointAtCloudPoint` gates the command on being in a sketch with a scan point selected.
- No public API change — it composes existing model methods (the programmatic snap primitive, `pointClouds.nearestPoint`, already shipped).

## Why

After fitting a plane and placing datum points from a scan, drawing a 2D profile against scanned features is the natural next step. This closes the basic cloud→sketch bridge.

## Testing

- **app**: in a sketch with a scan point selected, the command adds a sketch point at the scan point projected onto the plane — `(3,4,7)` on XY → sketch `(3,4)`; disabled/errors outside a sketch or with nothing selected.
- Ribbon Create-panel tool count updated (14 → 15).
- **Live**: a full attach → enter sketch → select scan point → project → render pass runs without error (`TestInWindowSketchPointFromScanRenders`, skips in CI); the placed position is asserted by the app unit test (the authoritative geometric check), since the sketch plan view renders the point as a small marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)