### PR TITLE
feat(#645): persist datum-cloud provenance (associative cloud-fit work plane)

### DIFF
--- a/app/point_cloud_fit.go
+++ b/app/point_cloud_fit.go
@@ -8,7 +8,6 @@ import (
 
 	"oblikovati.org/kernel/fit"
 	"oblikovati.org/kernel/geom"
-	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/pointcloud"
 )
@@ -28,12 +27,13 @@ func (s *Session) CreatePointCloudPlane(cloud string) (*feature.WorkPlane, geom.
 	if !ok {
 		return nil, geom.Plane{}, fmt.Errorf("app: no point cloud named %q to fit a plane to", cloud)
 	}
-	plane, err := fit.Plane(pc.CroppedModelPoints())
+	plane, err := fit.Plane(pc.CroppedModelPoints()) // validate the fit and report origin/normal
 	if err != nil {
 		return nil, geom.Plane{}, fmt.Errorf("app: fit plane to point cloud %q: %w", cloud, err)
 	}
-	origin := plane.Origin
-	wp := finishWorkPlane(part, part.WorkPlanes().AddFixed(func() math.Point3 { return origin }, plane.UAxis, plane.VAxis))
+	// The plane keeps a live link to the cloud (provenance): it re-fits when the cloud moves and
+	// the link round-trips in the document (#645).
+	wp := finishWorkPlane(part, part.WorkPlanes().AddByPointCloudFit(cloudPlaneFitSource{pc}))
 	s.recordEdit(part, labelWorkPlane)
 	return wp, plane, nil
 }

--- a/app/point_cloud_provenance.go
+++ b/app/point_cloud_provenance.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/kernel/fit"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/pointcloud"
+)
+
+// Datum-cloud provenance (M17-F06, #645): a work plane fit to a point cloud keeps a live link to
+// that cloud (a PlaneFitSource) so it re-fits when the cloud moves, and persists the cloud's id so
+// the link is re-attached after a document is reopened (the live source object is not serialized,
+// only its id).
+
+// cloudPlaneFitSource adapts a point cloud to feature.PlaneFitSource: it best-fits the cloud's
+// currently displayed points (those passing its active crops) on demand, identified by cloud name.
+type cloudPlaneFitSource struct{ cloud *pointcloud.PointCloud }
+
+func (s cloudPlaneFitSource) SourceID() string { return s.cloud.Name() }
+
+// FitFrame best-fits a plane to the cloud's cropped points, returning its origin and in-plane axes;
+// ok is false when the points do not determine a plane (too few, or collinear).
+func (s cloudPlaneFitSource) FitFrame() (math.Point3, math.UnitVector3, math.UnitVector3, bool) {
+	plane, err := fit.Plane(s.cloud.CroppedModelPoints())
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, math.UnitVector3{}, false
+	}
+	return plane.Origin, plane.UAxis, plane.VAxis, true
+}
+
+// relinkPointCloudFits re-attaches live cloud sources to a freshly opened part's point-cloud-fit
+// work planes (matching by cloud id), then recomputes so they re-fit to the restored clouds. It is
+// a no-op for a non-part document.
+func (s *Session) relinkPointCloudFits(part *compdef.PartComponentDefinition) {
+	relinked := part.WorkPlanes().RelinkCloudFits(func(id string) (feature.PlaneFitSource, bool) {
+		if pc, ok := part.PointClouds().ByName(id); ok {
+			return cloudPlaneFitSource{pc}, true
+		}
+		return nil, false
+	})
+	if relinked > 0 {
+		part.Recompute()
+	}
+}

--- a/app/point_cloud_provenance_test.go
+++ b/app/point_cloud_provenance_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// planarPoints are scan points on z = 5 (a horizontal plane), shared by the provenance tests.
+func planarPoints() []math.Point3 {
+	return []math.Point3{
+		math.P3(0, 0, 5), math.P3(2, 0, 5), math.P3(0, 2, 5),
+		math.P3(2, 2, 5), math.P3(1, 3, 5), math.P3(-1, 1, 5),
+	}
+}
+
+// liftZ is a pure +dz translation matrix (row-major, translation in the last column).
+func liftZ(dz float64) math.Matrix4 {
+	m := math.Identity4()
+	c := m.Cells()
+	c[11] = math.Scalar(dz)
+	return math.Matrix4FromCells(c)
+}
+
+// TestPointCloudPlaneFollowsCloud: a plane fit to a cloud re-fits when the cloud moves, because it
+// keeps a live link to the cloud (provenance), not a frozen frame (#645).
+func TestPointCloudPlaneFollowsCloud(t *testing.T) {
+	s, def := emptyPartSession(t)
+	attachPlanarCloud(t, def) // points on z = 5
+	wp, _, err := s.CreatePointCloudPlane("Scan")
+	if err != nil {
+		t.Fatalf("CreatePointCloudPlane: %v", err)
+	}
+	def.Recompute()
+	if got := float64(wp.Plane().Origin().Z); !approxEq(got, 5) {
+		t.Fatalf("initial plane Z = %v, want 5", got)
+	}
+
+	pc, _ := def.PointClouds().ByName("Scan")
+	pc.SetTransform(liftZ(10)) // the cloud moves up by 10
+	def.Recompute()
+	if got := float64(wp.Plane().Origin().Z); !approxEq(got, 15) {
+		t.Errorf("after the cloud moved, plane Z = %v, want 15 (it should follow)", got)
+	}
+}
+
+// TestPointCloudPlaneProvenanceRoundTrip: the plane's cloud link survives a marshal/restore +
+// relink, so a reopened document re-fits the plane to its cloud (#645).
+func TestPointCloudPlaneProvenanceRoundTrip(t *testing.T) {
+	s, def := emptyPartSession(t)
+	attachPlanarCloud(t, def)
+	if _, _, err := s.CreatePointCloudPlane("Scan"); err != nil {
+		t.Fatalf("CreatePointCloudPlane: %v", err)
+	}
+
+	// Round-trip the work features into a fresh part that also carries the same-named cloud.
+	data, err := feature.MarshalWork(def.WorkGeometry())
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := compdef.NewPartComponentDefinition()
+	rid := restored.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	if _, err := restored.PointClouds().Add("Scan", "s.xyz", rid, planarPoints()); err != nil {
+		t.Fatalf("attach to restored part: %v", err)
+	}
+	if err := feature.ApplyWork(restored.WorkGeometry(), data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+
+	// Relink the way OpenDocument does, then recompute: the plane re-fits to the restored cloud.
+	s.relinkPointCloudFits(restored)
+	restored.Recompute()
+	wp := cloudFitPlaneOf(t, restored)
+	if got := float64(wp.Plane().Origin().Z); !approxEq(got, 5) {
+		t.Errorf("restored+relinked plane Z = %v, want 5", got)
+	}
+
+	// Moving the restored cloud now drives the relinked plane — associativity is live again.
+	pc, _ := restored.PointClouds().ByName("Scan")
+	pc.SetTransform(liftZ(7))
+	restored.Recompute()
+	if got := float64(wp.Plane().Origin().Z); !approxEq(got, 12) {
+		t.Errorf("after moving the restored cloud, plane Z = %v, want 12", got)
+	}
+}
+
+func cloudFitPlaneOf(t *testing.T, def *compdef.PartComponentDefinition) *feature.WorkPlane {
+	t.Helper()
+	planes := def.WorkPlanes()
+	for i := 0; i < planes.Count(); i++ {
+		if planes.Item(i).Kind() == "point-cloud-fit" {
+			return planes.Item(i)
+		}
+	}
+	t.Fatal("no point-cloud-fit plane in the restored part")
+	return nil
+}
+
+func approxEq(a, b float64) bool { d := a - b; return d < 1e-9 && d > -1e-9 }

--- a/app/point_cloud_provenance_test.go
+++ b/app/point_cloud_provenance_test.go
@@ -102,3 +102,22 @@ func cloudFitPlaneOf(t *testing.T, def *compdef.PartComponentDefinition) *featur
 }
 
 func approxEq(a, b float64) bool { d := a - b; return d < 1e-9 && d > -1e-9 }
+
+// TestCloudPlaneFitSourceEdges covers the source's no-fit branch (too few points) and a relink
+// that finds no matching cloud in the part (#645).
+func TestCloudPlaneFitSourceEdges(t *testing.T) {
+	_, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Tiny", "t.xyz", rid, []math.Point3{math.P3(0, 0, 0), math.P3(1, 1, 1)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	if _, _, _, ok := (cloudPlaneFitSource{pc}).FitFrame(); ok {
+		t.Error("FitFrame on two points should report ok=false (no plane)")
+	}
+	// A point-cloud-fit plane whose cloud is absent: relink finds no match (the attach false branch).
+	def.WorkPlanes().AddByPointCloudFit(cloudPlaneFitSource{pc})
+	def.PointClouds().Remove("Tiny")
+	s2, _ := emptyPartSession(t)
+	s2.relinkPointCloudFits(def) // no cloud named "Tiny" now → nothing relinked, no recompute
+}

--- a/app/session.go
+++ b/app/session.go
@@ -422,6 +422,9 @@ func (s *Session) OpenDocument(path string) (*doc.Document, error) {
 	if err != nil {
 		return nil, err
 	}
+	if part, ok := d.Content().(*compdef.PartComponentDefinition); ok {
+		s.relinkPointCloudFits(part) // restore datum-cloud provenance links (#645)
+	}
 	s.documentHistory(d) // open the event stream now so the first edit's before-snapshot is the open state
 	s.loadViewState(d)   // restore this user's saved camera/view layout (kept outside the .obk)
 	s.rememberRecentDocument(path)

--- a/head/ui/point_cloud_provenance_shot_test.go
+++ b/head/ui/point_cloud_provenance_shot_test.go
@@ -1,0 +1,83 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// tiltedSheetScan writes a flat sheet of scan points on the tilted plane z = 0.3·x + 0.15·y.
+func tiltedSheetScan(t *testing.T) string {
+	t.Helper()
+	var body string
+	for ix := -10; ix <= 10; ix++ {
+		for iy := -10; iy <= 10; iy++ {
+			x, y := float64(ix), float64(iy)
+			body += fmt.Sprintf("%g %g %g\n", x, y, 0.3*x+0.15*y)
+		}
+	}
+	path := filepath.Join(t.TempDir(), "sheet.xyz")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	return path
+}
+
+// liftZ is a +dz translation matrix (row-major, translation in the last column).
+func liftZ(dz float64) math.Matrix4 {
+	m := math.Identity4()
+	c := m.Cells()
+	c[11] = math.Scalar(dz)
+	return math.Matrix4FromCells(c)
+}
+
+// TestInWindowProvenancePlaneFollowsCloud fits a work plane to a scan, moves the cloud up, and
+// captures the recomputed scene — the visual confirmation that the fitted plane keeps a live link
+// to the cloud and follows it (provenance), rather than staying behind as a frozen datum (#645).
+func TestInWindowProvenancePlaneFollowsCloud(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	pc, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t))
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	wp, _, err := s.CreatePointCloudPlane("Sheet")
+	if err != nil {
+		t.Fatalf("fit plane: %v", err)
+	}
+	wp.SetVisible(true)
+	z0 := float64(wp.Plane().Origin().Z)
+
+	// Move the cloud up; a recompute must re-fit the plane to the cloud's new position.
+	pc.SetTransform(liftZ(10))
+	if part, ok := s.ActiveDocument().Content().(*compdef.PartComponentDefinition); ok {
+		part.Recompute()
+	}
+	z1 := float64(wp.Plane().Origin().Z)
+	t.Logf("plane origin Z: %.3f before move, %.3f after (cloud lifted +10)", z0, z1)
+	if z1-z0 < 9 {
+		t.Fatalf("plane did not follow the cloud: Z %0.3f → %0.3f", z0, z1)
+	}
+
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-provenance.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -29,6 +29,7 @@ type WorkFeatureData struct {
 	Position   []float64 `yaml:"position,omitempty"` // point position / fixed-frame origin [x,y,z]
 	XAxis      []float64 `yaml:"xaxis,omitempty"`    // fixed-frame X axis [x,y,z]
 	YAxis      []float64 `yaml:"yaxis,omitempty"`    // fixed-frame Y axis [x,y,z]
+	CloudID    string    `yaml:"cloud,omitempty"`    // point-cloud-fit: the source cloud's id (provenance, #645)
 }
 
 // MarshalWork projects the user work features into the recipe, in creation order.
@@ -82,6 +83,12 @@ func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
 	case *fixedFramePlaneDef:
 		p := v.origin()
 		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+		d.XAxis, d.YAxis = unitSlice(v.x), unitSlice(v.y)
+	case *pointCloudFitPlaneDef:
+		// Persist the provenance link and the last good fit (the frozen frame), so the plane has
+		// geometry on load even before the cloud source is re-attached (#645).
+		d.CloudID = v.cloudID
+		d.Position = []float64{float64(v.origin.X), float64(v.origin.Y), float64(v.origin.Z)}
 		d.XAxis, d.YAxis = unitSlice(v.x), unitSlice(v.y)
 	case *linePlaneAnglePlaneDef:
 		d.Angle = v.angle()
@@ -171,6 +178,8 @@ func restorePlaneFeature(c *WorkPlanes, d WorkFeatureData) error {
 		return restoreRefPlane(d, 3, func(r []WorkRef) { c.AddByThreePoints(r[0], r[1], r[2]) })
 	case "fixed-frame":
 		return restoreFixedFrame(c, d)
+	case "point-cloud-fit":
+		return restorePointCloudFit(c, d)
 	case "plane-point":
 		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPlaneAndPoint(r[0], r[1]) })
 	case "two-planes":
@@ -223,6 +232,26 @@ func restoreFixedFrame(c *WorkPlanes, d WorkFeatureData) error {
 		return err
 	}
 	c.AddFixed(func() math.Point3 { return origin }, x, y)
+	return nil
+}
+
+// restorePointCloudFit rebuilds an associative point-cloud-fit plane from its provenance id and
+// last good fit (the frozen frame). The live cloud source is re-attached after load by the host
+// (RelinkCloudFits), so until then the plane holds its frozen geometry (#645).
+func restorePointCloudFit(c *WorkPlanes, d WorkFeatureData) error {
+	origin, err := point3From(d.Position, "point-cloud-fit origin")
+	if err != nil {
+		return err
+	}
+	x, err := unit3From(d.XAxis, "point-cloud-fit X axis")
+	if err != nil {
+		return err
+	}
+	y, err := unit3From(d.YAxis, "point-cloud-fit Y axis")
+	if err != nil {
+		return err
+	}
+	c.addUser(&pointCloudFitPlaneDef{cloudID: d.CloudID, origin: origin, x: x, y: y, hasFit: true})
 	return nil
 }
 

--- a/model/feature/work_plane_cloud_fit.go
+++ b/model/feature/work_plane_cloud_fit.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Associative point-cloud-fit work plane (M17-F06, #645): a work plane derived by best-fitting a
+// scanned point cloud, which carries its provenance — the source cloud's id — so it re-fits when
+// the cloud moves and the link round-trips in the document. The model/feature package reaches the
+// cloud only through PlaneFitSource, never the pointcloud package (the seam discipline used by the
+// projection PointSource).
+
+// PlaneFitSource yields a best-fit plane frame from external data (a point cloud's current points).
+// SourceID is the cloud's stable id, persisted so the link can be re-attached after a load.
+// FitFrame returns ok=false when the source cannot fit a plane right now (too few points, lost
+// reference), so the def freezes its last good fit instead of jumping.
+type PlaneFitSource interface {
+	SourceID() string
+	FitFrame() (origin math.Point3, xAxis, yAxis math.UnitVector3, ok bool)
+}
+
+// pointCloudFitPlaneDef is a work plane associatively fit to a point cloud. On each recompute it
+// re-fits to the cloud's current points (so the plane follows the cloud); when the source is
+// unavailable — a lost reference, or a freshly loaded document before the source is re-attached —
+// it falls back to the last good fit (the frozen frame, which is what persists).
+type pointCloudFitPlaneDef struct {
+	source  PlaneFitSource
+	cloudID string // persisted provenance link (equals source.SourceID() while linked)
+	// frozen frame: the last successful fit, the fallback and the serialized form.
+	origin math.Point3
+	x, y   math.UnitVector3
+	hasFit bool
+}
+
+func (d *pointCloudFitPlaneDef) kindName() string { return "point-cloud-fit" }
+func (d *pointCloudFitPlaneDef) refs() []WorkRef  { return nil }
+
+// eval re-fits from the live source when attached, updating the frozen frame; otherwise it returns
+// the frozen frame, erroring only when there is neither a source nor a prior fit.
+func (d *pointCloudFitPlaneDef) eval(workResolver) (sketch.Plane, error) {
+	if d.source != nil {
+		if o, x, y, ok := d.source.FitFrame(); ok {
+			d.origin, d.x, d.y, d.hasFit = o, x, y, true
+		}
+	}
+	if !d.hasFit {
+		return sketch.Plane{}, errors.New("point-cloud-fit plane: no source cloud to fit and no prior fit")
+	}
+	return sketch.NewPlane(d.origin, d.x, d.y)
+}
+
+// CloudID returns the provenance link — the id of the cloud this plane is fit to.
+func (d *pointCloudFitPlaneDef) CloudID() string { return d.cloudID }
+
+// relink attaches a live source whose id matches this def's cloud, restoring associativity after a
+// load. It is a no-op when the source's id does not match.
+func (d *pointCloudFitPlaneDef) relink(src PlaneFitSource) bool {
+	if src.SourceID() != d.cloudID {
+		return false
+	}
+	d.source = src
+	return true
+}
+
+// AddByPointCloudFit creates a work plane fit to the cloud identified by src.SourceID(), recording
+// that cloud as its provenance. The initial fit (if the source can provide one) seeds the frozen
+// frame so the plane has geometry even before the first recompute.
+func (c *WorkPlanes) AddByPointCloudFit(src PlaneFitSource) *WorkPlane {
+	d := &pointCloudFitPlaneDef{source: src, cloudID: src.SourceID()}
+	if o, x, y, ok := src.FitFrame(); ok {
+		d.origin, d.x, d.y, d.hasFit = o, x, y, true
+	}
+	return c.addUser(d)
+}
+
+// RelinkCloudFits re-attaches live sources to this part's point-cloud-fit planes after a load,
+// asking attach for a source by cloud id. It is the post-load wiring that restores associativity
+// (the link itself round-trips; the live source object does not). Returns how many were relinked.
+func (c *WorkPlanes) RelinkCloudFits(attach func(cloudID string) (PlaneFitSource, bool)) int {
+	n := 0
+	for _, w := range c.items {
+		d, ok := w.def.(*pointCloudFitPlaneDef)
+		if !ok {
+			continue
+		}
+		if src, found := attach(d.cloudID); found && d.relink(src) {
+			n++
+		}
+	}
+	return n
+}

--- a/model/feature/work_plane_cloud_fit_test.go
+++ b/model/feature/work_plane_cloud_fit_test.go
@@ -112,3 +112,18 @@ func TestCloudFitPlaneSerializeRoundTrip(t *testing.T) {
 		t.Errorf("after relink Z = %v, want 12 (follows the re-attached cloud)", got)
 	}
 }
+
+// TestCloudFitPlaneEvalAndRelinkEdges covers the error/edge branches: eval with neither a source
+// nor a prior fit, the CloudID accessor, and a relink whose id does not match (#645).
+func TestCloudFitPlaneEvalAndRelinkEdges(t *testing.T) {
+	d := &pointCloudFitPlaneDef{cloudID: "X"} // no source, no frozen fit
+	if _, err := d.eval(nil); err == nil {
+		t.Error("eval with no source and no prior fit should error")
+	}
+	if d.CloudID() != "X" {
+		t.Errorf("CloudID = %q, want X", d.CloudID())
+	}
+	if d.relink(&fakePlaneFitSource{id: "other"}) {
+		t.Error("relink with a mismatched id should report false")
+	}
+}

--- a/model/feature/work_plane_cloud_fit_test.go
+++ b/model/feature/work_plane_cloud_fit_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// fakePlaneFitSource is a named fake cloud source: it fits a horizontal plane at a settable height,
+// and can report "cannot fit" to exercise the freeze path.
+type fakePlaneFitSource struct {
+	id     string
+	height float64
+	ok     bool
+}
+
+func (f *fakePlaneFitSource) SourceID() string { return f.id }
+func (f *fakePlaneFitSource) FitFrame() (math.Point3, math.UnitVector3, math.UnitVector3, bool) {
+	x, _ := math.NewUnitVector3(1, 0, 0)
+	y, _ := math.NewUnitVector3(0, 1, 0)
+	return math.P3(0, 0, math.Scalar(f.height)), x, y, f.ok
+}
+
+func newCloudFitPlanes(t *testing.T) *WorkPlanes {
+	t.Helper()
+	return NewWorkGeometry().WorkPlanes()
+}
+
+// TestCloudFitPlaneRefitsOnRecompute: the plane follows the source as it moves, and freezes the
+// last good fit when the source can no longer fit (#645).
+func TestCloudFitPlaneRefitsOnRecompute(t *testing.T) {
+	src := &fakePlaneFitSource{id: "Scan", height: 5, ok: true}
+	planes := newCloudFitPlanes(t)
+	wp := planes.AddByPointCloudFit(src)
+
+	wp.recompute(nil)
+	if got := float64(wp.Plane().Origin().Z); got != 5 {
+		t.Errorf("initial fit Z = %v, want 5", got)
+	}
+	src.height = 9 // the cloud moves up
+	wp.recompute(nil)
+	if got := float64(wp.Plane().Origin().Z); got != 9 {
+		t.Errorf("re-fit Z = %v, want 9 (plane should follow the cloud)", got)
+	}
+	src.ok = false // source can no longer fit → freeze at the last good fit (9)
+	wp.recompute(nil)
+	if got := float64(wp.Plane().Origin().Z); got != 9 {
+		t.Errorf("frozen Z = %v, want 9 (last good fit)", got)
+	}
+}
+
+// TestCloudFitPlaneSerializeRoundTrip: the provenance id and frozen frame round-trip, and the
+// restored plane is unlinked until relinked (#645).
+func TestCloudFitPlaneSerializeRoundTrip(t *testing.T) {
+	src := &fakePlaneFitSource{id: "CapstanScan", height: 3, ok: true}
+	g := NewWorkGeometry()
+	g.WorkPlanes().AddByPointCloudFit(src)
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	var fit *WorkFeatureData
+	for i := range data {
+		if data[i].Kind == "point-cloud-fit" {
+			fit = &data[i]
+		}
+	}
+	if fit == nil {
+		t.Fatal("no point-cloud-fit feature serialized")
+	}
+	if fit.CloudID != "CapstanScan" {
+		t.Errorf("serialized cloud id = %q, want CapstanScan", fit.CloudID)
+	}
+	if len(fit.Position) != 3 || fit.Position[2] != 3 {
+		t.Errorf("serialized frozen origin = %v, want z=3", fit.Position)
+	}
+
+	g2 := NewWorkGeometry()
+	if err := ApplyWork(g2, data); err != nil {
+		t.Fatalf("UnmarshalWork: %v", err)
+	}
+	planes := g2.WorkPlanes()
+	var wp *WorkPlane
+	for i := 0; i < planes.Count(); i++ { // the origin planes are restored too; find the user one
+		if _, ok := planes.Item(i).def.(*pointCloudFitPlaneDef); ok {
+			wp = planes.Item(i)
+		}
+	}
+	if wp == nil {
+		t.Fatal("no restored point-cloud-fit plane")
+	}
+	wp.recompute(nil) // no live source yet → frozen frame
+	if got := float64(wp.Plane().Origin().Z); got != 3 {
+		t.Errorf("restored frozen Z = %v, want 3", got)
+	}
+
+	// Relink a live source whose id matches → associativity restored.
+	moved := &fakePlaneFitSource{id: "CapstanScan", height: 12, ok: true}
+	if n := planes.RelinkCloudFits(func(id string) (PlaneFitSource, bool) {
+		if id == "CapstanScan" {
+			return moved, true
+		}
+		return nil, false
+	}); n != 1 {
+		t.Fatalf("RelinkCloudFits relinked %d, want 1", n)
+	}
+	wp.recompute(nil)
+	if got := float64(wp.Plane().Origin().Z); got != 12 {
+		t.Errorf("after relink Z = %v, want 12 (follows the re-attached cloud)", got)
+	}
+}


### PR DESCRIPTION
## What

A work plane fit to a point cloud now keeps a **live link to that cloud (provenance)**: it re-fits when the cloud moves, and the link round-trips in the document so a reopened part re-fits the plane to its cloud. Previously the fitted plane was a frozen datum with no memory of where it came from.

- **`model/feature`** — a `PlaneFitSource` seam (so the package re-fits from a cloud without depending on `pointcloud`, the same discipline as the projection `PointSource`). `pointCloudFitPlaneDef` re-fits on every recompute (the plane follows the cloud), freezing the last good fit when the source is unavailable. The cloud id + frozen frame serialize; `RelinkCloudFits` re-attaches live sources after a load.
- **`app`** — `CreatePointCloudPlane` now builds the associative plane via `AddByPointCloudFit(cloudPlaneFitSource{…})` (best-fits the cloud's cropped points, keyed by cloud name). `OpenDocument` calls `relinkPointCloudFits` to restore the link and recompute.
- **No public API change** — the wire `pointClouds.fitPlane` is unchanged; the plane it creates is simply associative now.

## Why

A scan is reference data you model against; if you nudge or re-register the scan, the geometry you built from it should follow. This closes the loop the earlier fit/work-point/sketch-point PRs left open (those datums were frozen).

## Testing

- **model/feature**: the plane follows the source as it moves; freezes the last good fit when the source can't fit; serialize round-trip preserves the cloud id + frozen frame; relink restores associativity; eval/relink/CloudID edge branches.
- **app**: a fitted plane follows the cloud when it is transformed (z 5 → 15); marshal → restore → relink → recompute re-fits to the restored cloud and a subsequent cloud move drives the relinked plane; source no-fit and relink-no-match edges.
- **Live visual confirmation**: lifting the cloud +10 moves the fitted work plane with it — it stays embedded in the tilted sheet rather than left behind (`TestInWindowProvenancePlaneFollowsCloud`, skips in CI). Captured `/tmp/point-cloud-provenance.png`.

Note: re-fit triggers on part recompute (a feature edit, or the post-open relink). Auto-recomputing dependents on a cloud *move* is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)