### PR TITLE
feat(#645): persist work-point datum-cloud provenance

### DIFF
--- a/app/point_cloud_provenance.go
+++ b/app/point_cloud_provenance.go
@@ -31,13 +31,44 @@ func (s cloudPlaneFitSource) FitFrame() (math.Point3, math.UnitVector3, math.Uni
 	return plane.Origin, plane.UAxis, plane.VAxis, true
 }
 
-// relinkPointCloudFits re-attaches live cloud sources to a freshly opened part's point-cloud-fit
-// work planes (matching by cloud id), then recomputes so they re-fit to the restored clouds. It is
-// a no-op for a non-part document.
-func (s *Session) relinkPointCloudFits(part *compdef.PartComponentDefinition) {
+// cloudPointSource adapts a point cloud to feature.PointFromCloudSource: it anchors a scan point in
+// cloud space (local) and re-derives its model-space position as the cloud moves, identified by
+// cloud name.
+type cloudPointSource struct {
+	cloud *pointcloud.PointCloud
+	local math.Point3 // cloud-space anchor; the model position re-derives from the cloud's placement
+}
+
+func (s cloudPointSource) SourceID() string { return s.cloud.Name() }
+
+// Position re-derives the anchor's current model-space location through the cloud's placement.
+func (s cloudPointSource) Position() (math.Point3, bool) { return s.cloud.ToModelSpace(s.local), true }
+
+// newCloudPointSource anchors a model-space scan point in cloud space so the work point follows the
+// cloud's placement. A non-invertible placement (degenerate, scale 0) leaves the anchor at the raw
+// point — it stays valid, it just will not track.
+func newCloudPointSource(cloud *pointcloud.PointCloud, modelPoint math.Point3) cloudPointSource {
+	local, ok := cloud.FromModelSpace(modelPoint)
+	if !ok {
+		local = modelPoint
+	}
+	return cloudPointSource{cloud: cloud, local: local}
+}
+
+// relinkPointCloudProvenance re-attaches live cloud sources to a freshly opened part's
+// point-cloud-derived datums — the fit planes and the anchored work points — matching by cloud id,
+// then recomputes so they re-derive against the restored clouds. It is a no-op for a non-part
+// document or a part with no such datums.
+func (s *Session) relinkPointCloudProvenance(part *compdef.PartComponentDefinition) {
 	relinked := part.WorkPlanes().RelinkCloudFits(func(id string) (feature.PlaneFitSource, bool) {
 		if pc, ok := part.PointClouds().ByName(id); ok {
 			return cloudPlaneFitSource{pc}, true
+		}
+		return nil, false
+	})
+	relinked += part.WorkPoints().RelinkCloudPoints(func(id string, frozen math.Point3) (feature.PointFromCloudSource, bool) {
+		if pc, ok := part.PointClouds().ByName(id); ok {
+			return newCloudPointSource(pc, frozen), true // reconstruct the cloud-local anchor from the frozen point
 		}
 		return nil, false
 	})

--- a/app/point_cloud_provenance_test.go
+++ b/app/point_cloud_provenance_test.go
@@ -73,7 +73,7 @@ func TestPointCloudPlaneProvenanceRoundTrip(t *testing.T) {
 	}
 
 	// Relink the way OpenDocument does, then recompute: the plane re-fits to the restored cloud.
-	s.relinkPointCloudFits(restored)
+	s.relinkPointCloudProvenance(restored)
 	restored.Recompute()
 	wp := cloudFitPlaneOf(t, restored)
 	if got := float64(wp.Plane().Origin().Z); !approxEq(got, 5) {
@@ -119,5 +119,100 @@ func TestCloudPlaneFitSourceEdges(t *testing.T) {
 	def.WorkPlanes().AddByPointCloudFit(cloudPlaneFitSource{pc})
 	def.PointClouds().Remove("Tiny")
 	s2, _ := emptyPartSession(t)
-	s2.relinkPointCloudFits(def) // no cloud named "Tiny" now → nothing relinked, no recompute
+	s2.relinkPointCloudProvenance(def) // no cloud named "Tiny" now → nothing relinked, no recompute
+}
+
+// TestWorkPointFollowsCloud: a work point anchored on a scan point follows the cloud when it moves,
+// because it keeps a live link (provenance) rather than a frozen position (#645).
+func TestWorkPointFollowsCloud(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(3, 4, 5)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 5)})
+	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("CreateWorkPointAtSelectedCloudPoint: %v", err)
+	}
+	if wp.Point() != math.P3(3, 4, 5) {
+		t.Fatalf("initial work point = %v, want (3,4,5)", wp.Point())
+	}
+
+	pc.SetTransform(liftZ(10)) // the cloud moves up
+	def.Recompute()
+	if wp.Point() != math.P3(3, 4, 15) {
+		t.Errorf("after the cloud moved, work point = %v, want (3,4,15) (it should follow)", wp.Point())
+	}
+}
+
+// TestWorkPointProvenanceRoundTrip: the work point's cloud link survives marshal/restore + relink,
+// so a reopened document re-anchors it and it follows the restored cloud (#645).
+func TestWorkPointProvenanceRoundTrip(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, _ := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(1, 2, 3)})
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(1, 2, 3)})
+	if _, err := s.CreateWorkPointAtSelectedCloudPoint(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	data, err := feature.MarshalWork(def.WorkGeometry())
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := compdef.NewPartComponentDefinition()
+	rid2 := restored.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	rpc, _ := restored.PointClouds().Add("Scan", "s.xyz", rid2, []math.Point3{math.P3(1, 2, 3)})
+	if err := feature.ApplyWork(restored.WorkGeometry(), data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	s.relinkPointCloudProvenance(restored)
+	restored.Recompute()
+
+	wp := restoredCloudPoint(t, restored)
+	if wp.Point() != math.P3(1, 2, 3) {
+		t.Errorf("restored+relinked work point = %v, want (1,2,3)", wp.Point())
+	}
+	rpc.SetTransform(liftZ(8)) // moving the restored cloud drives the relinked point
+	restored.Recompute()
+	if wp.Point() != math.P3(1, 2, 11) {
+		t.Errorf("after moving the restored cloud, work point = %v, want (1,2,11)", wp.Point())
+	}
+}
+
+func restoredCloudPoint(t *testing.T, def *compdef.PartComponentDefinition) *feature.WorkPoint {
+	t.Helper()
+	pts := def.WorkPoints()
+	for i := 0; i < pts.Count(); i++ {
+		// the position kind is "position"; the anchored one round-trips as a distinct frozen point
+		if pts.Item(i).Point() == math.P3(1, 2, 3) {
+			return pts.Item(i)
+		}
+	}
+	t.Fatal("no restored cloud work point")
+	return nil
+}
+
+// TestWorkPointProvenanceEdges covers the degenerate-placement anchor fallback and a work-point
+// relink that finds no matching cloud (#645).
+func TestWorkPointProvenanceEdges(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(1, 1, 1)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	// A singular placement makes FromModelSpace fail → newCloudPointSource anchors at the raw point.
+	pc.SetTransform(math.Matrix4FromCells([16]math.Scalar{}))
+	src := newCloudPointSource(pc, math.P3(2, 2, 2))
+	if src.local != math.P3(2, 2, 2) {
+		t.Errorf("degenerate anchor local = %v, want the raw point (2,2,2)", src.local)
+	}
+
+	// A point-cloud work point whose cloud is gone: relink finds no match (the attach false branch).
+	def.WorkPoints().AddByCloudPoint(newCloudPointSource(pc, math.P3(1, 1, 1)))
+	def.PointClouds().Remove("Scan")
+	s.relinkPointCloudProvenance(def) // no cloud "Scan" now → nothing relinked
 }

--- a/app/point_cloud_snap.go
+++ b/app/point_cloud_snap.go
@@ -17,27 +17,37 @@ import (
 // SelectedCloudPoint returns the model-space location of the snapped scan point selected in the
 // viewport, if one is selected.
 func (s *Session) SelectedCloudPoint() (math.Point3, bool) {
-	for _, it := range s.selection.Items() {
-		if h, ok := it.(PointCloudPointHandle); ok {
-			return h.Position(), true
-		}
+	if h, ok := s.SelectedCloudPointHandle(); ok {
+		return h.Position(), true
 	}
 	return math.Point3{}, false
 }
 
-// CreateWorkPointAtSelectedCloudPoint adds a fixed datum point at the snapped scan point selected in
-// the viewport, then recomputes — the Point Cloud panel's Work Point command. It errors when there
-// is no active part or no scan point is selected.
+// SelectedCloudPointHandle returns the full snapped scan-point selection (the cloud and the picked
+// point), so a consumer that needs the source cloud — like an associative work point — can reach it.
+func (s *Session) SelectedCloudPointHandle() (PointCloudPointHandle, bool) {
+	for _, it := range s.selection.Items() {
+		if h, ok := it.(PointCloudPointHandle); ok {
+			return h, true
+		}
+	}
+	return PointCloudPointHandle{}, false
+}
+
+// CreateWorkPointAtSelectedCloudPoint adds a datum point at the snapped scan point selected in the
+// viewport, then recomputes — the Point Cloud panel's Work Point command. The point keeps a live
+// link to its cloud (provenance): it follows the cloud's placement and the link round-trips in the
+// document. It errors when there is no active part or no scan point is selected.
 func (s *Session) CreateWorkPointAtSelectedCloudPoint() (*feature.WorkPoint, error) {
 	part, err := activePart(s)
 	if err != nil {
 		return nil, err
 	}
-	at, ok := s.SelectedCloudPoint()
+	h, ok := s.SelectedCloudPointHandle()
 	if !ok {
 		return nil, errors.New("app: select a point on a scan (snap to a cloud point) to place a work point")
 	}
-	wp := part.WorkPoints().AddByPosition(func() math.Point3 { return at })
+	wp := part.WorkPoints().AddByCloudPoint(newCloudPointSource(h.Cloud, h.Point))
 	part.Recompute()
 	s.recordEdit(part, labelWorkPoint)
 	return wp, nil

--- a/app/session.go
+++ b/app/session.go
@@ -423,7 +423,7 @@ func (s *Session) OpenDocument(path string) (*doc.Document, error) {
 		return nil, err
 	}
 	if part, ok := d.Content().(*compdef.PartComponentDefinition); ok {
-		s.relinkPointCloudFits(part) // restore datum-cloud provenance links (#645)
+		s.relinkPointCloudProvenance(part) // restore datum-cloud provenance links (#645)
 	}
 	s.documentHistory(d) // open the event stream now so the first edit's before-snapshot is the open state
 	s.loadViewState(d)   // restore this user's saved camera/view layout (kept outside the .obk)

--- a/head/ui/point_cloud_workpoint_provenance_shot_test.go
+++ b/head/ui/point_cloud_workpoint_provenance_shot_test.go
@@ -1,0 +1,78 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// flatScanWithPeak writes a flat grid with one raised peak point, so the work point placed on the
+// peak is easy to spot as it follows the cloud.
+func flatScanWithPeak(t *testing.T) (string, math.Point3) {
+	t.Helper()
+	var body string
+	for ix := -6; ix <= 6; ix++ {
+		for iy := -6; iy <= 6; iy++ {
+			body += fmt.Sprintf("%d %d 0\n", ix, iy)
+		}
+	}
+	peak := math.P3(0, 0, 6)
+	body += fmt.Sprintf("%g %g %g\n", float64(peak.X), float64(peak.Y), float64(peak.Z))
+	path := filepath.Join(t.TempDir(), "peak.xyz")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	return path, peak
+}
+
+// TestInWindowWorkPointProvenanceFollowsCloud places a work point on a snapped scan peak, moves the
+// cloud, and captures the recomputed scene — the visual confirmation that the anchored work point
+// keeps a live link to the cloud and follows it (provenance) (#645). Skips without a display.
+func TestInWindowWorkPointProvenanceFollowsCloud(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	path, peak := flatScanWithPeak(t)
+	pc, err := s.AttachPointCloud("Peak", path)
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	s.Select(app.PointCloudPointHandle{Cloud: pc, Point: peak})
+	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("create work point: %v", err)
+	}
+	z0 := float64(wp.Point().Z)
+
+	pc.SetTransform(liftZ(8)) // move the cloud up; the anchored point must follow on recompute
+	if part, ok := s.ActiveDocument().Content().(*compdef.PartComponentDefinition); ok {
+		part.Recompute()
+	}
+	z1 := float64(wp.Point().Z)
+	t.Logf("work point Z: %.3f before move, %.3f after (cloud lifted +8)", z0, z1)
+	if z1-z0 < 7 {
+		t.Fatalf("work point did not follow the cloud: Z %.3f → %.3f", z0, z1)
+	}
+
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-workpoint-provenance.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -117,6 +117,10 @@ func serializePointDef(def pointDefinition) (WorkFeatureData, error) {
 	case positionPointDef:
 		p := v.at()
 		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+	case *pointCloudPointDef:
+		p := v.FrozenPosition() // last good model position; the source re-derives it after relink (#645)
+		d.CloudID = v.cloudID
+		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
 	case planeAxisPointDef:
 		// references only
 	default:
@@ -279,6 +283,15 @@ func restorePointFeature(c *WorkPoints, d WorkFeatureData) error {
 			return err
 		}
 		c.AddByPosition(func() math.Point3 { return pos })
+		return nil
+	case "point-cloud-point":
+		pos, err := point3From(d.Position, "point-cloud point")
+		if err != nil {
+			return err
+		}
+		// The live cloud source is re-attached after load (RelinkCloudPoints); until then the point
+		// holds its frozen position (#645).
+		c.addUser(&pointCloudPointDef{cloudID: d.CloudID, frozen: pos, hasPos: true})
 		return nil
 	case "plane-axis-intersection":
 		r, err := workRefs(d.Refs, 2)

--- a/model/feature/work_point_cloud.go
+++ b/model/feature/work_point_cloud.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+
+	"oblikovati.org/math"
+)
+
+// Datum-cloud provenance for work points (M17-F06, #645): a work point placed on a scanned point
+// keeps a live link to its cloud so it follows the cloud's placement, and persists the cloud id so
+// the link is re-attached after a reopen — the point counterpart of the point-cloud-fit plane.
+
+// PointFromCloudSource yields a model-space point tracked from a point cloud — a snapped scan point
+// that moves with the cloud. SourceID is the cloud's id (persisted to re-attach the link after a
+// load); Position re-derives the current model-space location, ok=false when the cloud is gone.
+type PointFromCloudSource interface {
+	SourceID() string
+	Position() (math.Point3, bool)
+}
+
+// pointCloudPointDef is a work point anchored on a scanned point. It re-derives its position from
+// the cloud on each recompute (so it follows the cloud), freezing the last good position when the
+// source is unavailable (a lost reference, or a freshly loaded document before re-attachment).
+type pointCloudPointDef struct {
+	source  PointFromCloudSource
+	cloudID string // persisted provenance link (equals source.SourceID() while linked)
+	frozen  math.Point3
+	hasPos  bool
+}
+
+func (d *pointCloudPointDef) kindName() string { return "point-cloud-point" }
+func (d *pointCloudPointDef) refs() []WorkRef  { return nil }
+
+func (d *pointCloudPointDef) eval(workResolver) (math.Point3, error) {
+	if d.source != nil {
+		if p, ok := d.source.Position(); ok {
+			d.frozen, d.hasPos = p, true
+		}
+	}
+	if !d.hasPos {
+		return math.Point3{}, errors.New("point-cloud point: no source cloud and no prior position")
+	}
+	return d.frozen, nil
+}
+
+// CloudID returns the provenance link — the id of the cloud this point is anchored to.
+func (d *pointCloudPointDef) CloudID() string { return d.cloudID }
+
+// FrozenPosition returns the last good model-space position (the serialized fallback). The host
+// uses it to reconstruct the cloud-local anchor when re-attaching the live source after a load.
+func (d *pointCloudPointDef) FrozenPosition() math.Point3 { return d.frozen }
+
+func (d *pointCloudPointDef) relink(src PointFromCloudSource) bool {
+	if src.SourceID() != d.cloudID {
+		return false
+	}
+	d.source = src
+	return true
+}
+
+// AddByCloudPoint creates a work point anchored on the scan point yielded by src, recording its
+// cloud as provenance and seeding the frozen position from the initial location.
+func (c *WorkPoints) AddByCloudPoint(src PointFromCloudSource) *WorkPoint {
+	d := &pointCloudPointDef{source: src, cloudID: src.SourceID()}
+	if p, ok := src.Position(); ok {
+		d.frozen, d.hasPos = p, true
+	}
+	return c.addUser(d)
+}
+
+// RelinkCloudPoints re-attaches live cloud sources to this part's point-cloud work points after a
+// load. attach receives the cloud id and the frozen model position (so the host can reconstruct
+// the cloud-local anchor) and returns a source. Returns how many were relinked.
+func (c *WorkPoints) RelinkCloudPoints(attach func(cloudID string, frozen math.Point3) (PointFromCloudSource, bool)) int {
+	n := 0
+	for _, w := range c.items {
+		d, ok := w.def.(*pointCloudPointDef)
+		if !ok {
+			continue
+		}
+		if src, found := attach(d.cloudID, d.frozen); found && d.relink(src) {
+			n++
+		}
+	}
+	return n
+}

--- a/model/feature/work_point_cloud_test.go
+++ b/model/feature/work_point_cloud_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// fakeCloudPointSource is a named fake: it reports a settable model-space position, and can report
+// "gone" to exercise the freeze path.
+type fakeCloudPointSource struct {
+	id  string
+	pos math.Point3
+	ok  bool
+}
+
+func (f *fakeCloudPointSource) SourceID() string              { return f.id }
+func (f *fakeCloudPointSource) Position() (math.Point3, bool) { return f.pos, f.ok }
+
+// TestCloudPointFollowsAndFreezes: the work point tracks the source as it moves, and freezes the
+// last good position when the source is gone (#645).
+func TestCloudPointFollowsAndFreezes(t *testing.T) {
+	src := &fakeCloudPointSource{id: "Scan", pos: math.P3(1, 2, 3), ok: true}
+	points := NewWorkGeometry().WorkPoints()
+	wp := points.AddByCloudPoint(src)
+
+	wp.recompute(nil)
+	if wp.Point() != math.P3(1, 2, 3) {
+		t.Errorf("initial point = %v, want (1,2,3)", wp.Point())
+	}
+	src.pos = math.P3(4, 5, 6) // the cloud moves
+	wp.recompute(nil)
+	if wp.Point() != math.P3(4, 5, 6) {
+		t.Errorf("re-derived point = %v, want (4,5,6) (should follow the cloud)", wp.Point())
+	}
+	src.ok = false // source gone → freeze at the last good position
+	wp.recompute(nil)
+	if wp.Point() != math.P3(4, 5, 6) {
+		t.Errorf("frozen point = %v, want (4,5,6)", wp.Point())
+	}
+}
+
+// TestCloudPointSerializeRoundTrip: the cloud id and frozen position round-trip, and a relink
+// (carrying the frozen position) restores associativity (#645).
+func TestCloudPointSerializeRoundTrip(t *testing.T) {
+	src := &fakeCloudPointSource{id: "Scan", pos: math.P3(7, 8, 9), ok: true}
+	g := NewWorkGeometry()
+	g.WorkPoints().AddByCloudPoint(src)
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	var pt *WorkFeatureData
+	for i := range data {
+		if data[i].Kind == "point-cloud-point" {
+			pt = &data[i]
+		}
+	}
+	if pt == nil || pt.CloudID != "Scan" || len(pt.Position) != 3 || pt.Position[0] != 7 {
+		t.Fatalf("serialized point-cloud-point = %+v, want cloud Scan at (7,8,9)", pt)
+	}
+
+	g2 := NewWorkGeometry()
+	if err := ApplyWork(g2, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	wp := cloudPointOf(t, g2.WorkPoints())
+	wp.recompute(nil) // no source yet → frozen
+	if wp.Point() != math.P3(7, 8, 9) {
+		t.Errorf("restored frozen point = %v, want (7,8,9)", wp.Point())
+	}
+
+	var gotFrozen math.Point3
+	moved := &fakeCloudPointSource{id: "Scan", pos: math.P3(70, 80, 90), ok: true}
+	n := g2.WorkPoints().RelinkCloudPoints(func(id string, frozen math.Point3) (PointFromCloudSource, bool) {
+		gotFrozen = frozen
+		if id == "Scan" {
+			return moved, true
+		}
+		return nil, false
+	})
+	if n != 1 || gotFrozen != math.P3(7, 8, 9) {
+		t.Fatalf("relinked %d (frozen %v), want 1 carrying (7,8,9)", n, gotFrozen)
+	}
+	wp.recompute(nil)
+	if wp.Point() != math.P3(70, 80, 90) {
+		t.Errorf("after relink point = %v, want (70,80,90)", wp.Point())
+	}
+}
+
+// TestCloudPointEvalAndRelinkEdges covers the no-source/no-position error, CloudID, FrozenPosition,
+// and a relink id-mismatch (#645).
+func TestCloudPointEvalAndRelinkEdges(t *testing.T) {
+	d := &pointCloudPointDef{cloudID: "X"}
+	if _, err := d.eval(nil); err == nil {
+		t.Error("eval with no source and no prior position should error")
+	}
+	if d.CloudID() != "X" || d.FrozenPosition() != (math.Point3{}) {
+		t.Errorf("CloudID/FrozenPosition = %q/%v", d.CloudID(), d.FrozenPosition())
+	}
+	if d.relink(&fakeCloudPointSource{id: "other"}) {
+		t.Error("relink with a mismatched id should report false")
+	}
+}
+
+func cloudPointOf(t *testing.T, points *WorkPoints) *WorkPoint {
+	t.Helper()
+	for i := 0; i < points.Count(); i++ {
+		if _, ok := points.Item(i).def.(*pointCloudPointDef); ok {
+			return points.Item(i)
+		}
+	}
+	t.Fatal("no point-cloud-point in the restored part")
+	return nil
+}


### PR DESCRIPTION
## What

A work point placed on a snapped scan point now keeps a **live link to its cloud (provenance)** — the point counterpart of the associative cloud-fit plane. It follows the cloud's placement on recompute, and the link round-trips in the document so a reopened part re-anchors it. Previously the work point was a frozen datum.

- **`model/feature`** — a `PointFromCloudSource` seam (re-derives a point from a cloud without depending on `pointcloud`). `pointCloudPointDef` re-derives its position each recompute (so the point follows the cloud), freezing the last good position when the source is gone. The cloud id + frozen position serialize; `RelinkCloudPoints` re-attaches live sources after a load (the frozen position lets the host reconstruct the cloud-local anchor).
- **`app`** — `CreateWorkPointAtSelectedCloudPoint` anchors the datum via `AddByCloudPoint(cloudPointSource{…})` (the snapped point in cloud space, keyed by cloud name). The post-open `relinkPointCloudProvenance` now relinks both fit planes and anchored work points.
- **No public API change.**

## Why

Closes the work-point half of datum-cloud provenance (the plane half shipped in the prior PR). If you re-register or nudge the scan, the datum points you built on it follow.

## Testing

- **model/feature**: the point follows the source as it moves; freezes the last good position when the source is gone; serialize round-trip preserves cloud id + frozen position; relink (carrying the frozen position) restores associativity; eval/relink/accessor edges.
- **app**: an anchored work point follows the cloud when it is transformed (z 5 → 15); marshal → restore → relink → recompute re-anchors it and a subsequent cloud move drives it; degenerate-placement anchor fallback and relink-no-match edges.
- **Live visual confirmation**: lifting the cloud +8 moves the anchored work point with it (`TestInWindowWorkPointProvenanceFollowsCloud`, skips in CI). Captured `/tmp/point-cloud-workpoint-provenance.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)