### PR TITLE
feat(#645): persist sketch-point datum-cloud provenance

### DIFF
--- a/app/point_cloud_provenance.go
+++ b/app/point_cloud_provenance.go
@@ -8,6 +8,7 @@ import (
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/pointcloud"
+	"oblikovati.org/model/sketch"
 )
 
 // Datum-cloud provenance (M17-F06, #645): a work plane fit to a point cloud keeps a live link to
@@ -55,10 +56,32 @@ func newCloudPointSource(cloud *pointcloud.PointCloud, modelPoint math.Point3) c
 	return cloudPointSource{cloud: cloud, local: local}
 }
 
+// cloudSketchPointSource adapts a point cloud to sketch.CloudPointAnchor: it anchors a scan point in
+// cloud space and re-derives its model-space position as the cloud moves, for the sketch to project.
+type cloudSketchPointSource struct {
+	cloud *pointcloud.PointCloud
+	local math.Point3
+}
+
+func (s cloudSketchPointSource) SourceID() string         { return s.cloud.Name() }
+func (s cloudSketchPointSource) LocalAnchor() math.Point3 { return s.local }
+func (s cloudSketchPointSource) ModelPosition() (math.Point3, bool) {
+	return s.cloud.ToModelSpace(s.local), true
+}
+
+// newCloudSketchPointSource anchors a model-space scan point in cloud space for a sketch point.
+func newCloudSketchPointSource(cloud *pointcloud.PointCloud, modelPoint math.Point3) cloudSketchPointSource {
+	local, ok := cloud.FromModelSpace(modelPoint)
+	if !ok {
+		local = modelPoint
+	}
+	return cloudSketchPointSource{cloud: cloud, local: local}
+}
+
 // relinkPointCloudProvenance re-attaches live cloud sources to a freshly opened part's
-// point-cloud-derived datums — the fit planes and the anchored work points — matching by cloud id,
-// then recomputes so they re-derive against the restored clouds. It is a no-op for a non-part
-// document or a part with no such datums.
+// point-cloud-derived datums — the fit planes, the anchored work points, and the scan-anchored
+// sketch points — matching by cloud id, then recomputes so they re-derive against the restored
+// clouds. It is a no-op for a non-part document or a part with no such datums.
 func (s *Session) relinkPointCloudProvenance(part *compdef.PartComponentDefinition) {
 	relinked := part.WorkPlanes().RelinkCloudFits(func(id string) (feature.PlaneFitSource, bool) {
 		if pc, ok := part.PointClouds().ByName(id); ok {
@@ -72,7 +95,23 @@ func (s *Session) relinkPointCloudProvenance(part *compdef.PartComponentDefiniti
 		}
 		return nil, false
 	})
+	relinked += s.relinkSketchCloudAnchors(part)
 	if relinked > 0 {
 		part.Recompute()
 	}
+}
+
+// relinkSketchCloudAnchors re-attaches cloud sources to every sketch's scan-anchored points.
+func (s *Session) relinkSketchCloudAnchors(part *compdef.PartComponentDefinition) int {
+	n := 0
+	sketches := part.Sketches()
+	for i := 0; i < sketches.Count(); i++ {
+		n += sketches.Item(i).RelinkCloudAnchors(func(id string, local math.Point3) (sketch.CloudPointAnchor, bool) {
+			if pc, ok := part.PointClouds().ByName(id); ok {
+				return cloudSketchPointSource{cloud: pc, local: local}, true
+			}
+			return nil, false
+		})
+	}
+	return n
 }

--- a/app/point_cloud_sketch_point_test.go
+++ b/app/point_cloud_sketch_point_test.go
@@ -98,3 +98,65 @@ func TestProjectScanPointCommandRuns(t *testing.T) {
 		t.Errorf("after command, sketch point count = %d, want %d", sk.Points().Count(), before+1)
 	}
 }
+
+// translateX is a +dx translation matrix (row-major, translation in the last column).
+func translateX(dx float64) math.Matrix4 {
+	m := math.Identity4()
+	c := m.Cells()
+	c[3] = math.Scalar(dx)
+	return math.Matrix4FromCells(c)
+}
+
+// TestSketchPointFollowsCloudAndRelink: a scan-anchored sketch point re-projects when the cloud
+// moves (provenance), and relinkSketchCloudAnchors reaches it (#645).
+func TestSketchPointFollowsCloudAndRelink(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(2, 3, 1)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(2, 3, 1)})
+	p, err := s.CreateSketchPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("CreateSketchPointAtSelectedCloudPoint: %v", err)
+	}
+	if p.Position() != math.P2(2, 3) { // (2,3,1) onto XY → (2,3)
+		t.Fatalf("initial sketch point = %v, want (2,3)", p.Position())
+	}
+
+	pc.SetTransform(translateX(10)) // the cloud moves +10 in x
+	sk.UpdateProjections()
+	if p.Position() != math.P2(12, 3) {
+		t.Errorf("after the cloud moved, sketch point = %v, want (12,3) (it should follow)", p.Position())
+	}
+	if n := s.relinkSketchCloudAnchors(def); n != 1 {
+		t.Errorf("relinkSketchCloudAnchors reached %d anchors, want 1", n)
+	}
+}
+
+// TestSketchCloudSourceEdges covers the degenerate-placement anchor fallback and a sketch relink
+// that finds no matching cloud (#645).
+func TestSketchCloudSourceEdges(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(1, 1, 1)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	pc.SetTransform(math.Matrix4FromCells([16]math.Scalar{})) // singular → FromModelSpace fails
+	if src := newCloudSketchPointSource(pc, math.P3(2, 2, 2)); src.local != math.P3(2, 2, 2) {
+		t.Errorf("degenerate anchor local = %v, want raw (2,2,2)", src.local)
+	}
+
+	// A sketch with an anchor whose cloud is gone: relink finds no match.
+	sk := def.Sketches().Add(sketch.XYPlane())
+	sk.RestoreCloudAnchor(sk.Points().Add(math.P2(0, 0)), "Gone", math.P3(0, 0, 0))
+	if n := s.relinkSketchCloudAnchors(def); n != 0 {
+		t.Errorf("relinkSketchCloudAnchors = %d, want 0 (no matching cloud)", n)
+	}
+}

--- a/app/point_cloud_snap.go
+++ b/app/point_cloud_snap.go
@@ -62,18 +62,19 @@ func canWorkPointAtCloudPoint(s *Session) bool {
 
 // CreateSketchPointAtSelectedCloudPoint adds a sketch point at the snapped scan point selected in
 // the viewport, projected onto the active sketch plane — the in-sketch counterpart of the Work
-// Point command, so a 2D profile can be drawn against scanned features. It errors when there is no
-// active 2D sketch or no scan point is selected.
+// Point command, so a 2D profile can be drawn against scanned features. The point keeps a live link
+// to its cloud (provenance): it re-projects when the cloud moves and the link round-trips in the
+// document. It errors when there is no active 2D sketch or no scan point is selected.
 func (s *Session) CreateSketchPointAtSelectedCloudPoint() (*sketch.Point, error) {
 	sk := s.ActiveSketch()
 	if sk == nil {
 		return nil, errors.New("app: enter a 2D sketch to place a sketch point on a scan point")
 	}
-	at, ok := s.SelectedCloudPoint()
+	h, ok := s.SelectedCloudPointHandle()
 	if !ok {
 		return nil, errors.New("app: select a point on a scan (snap to a cloud point) for a sketch point")
 	}
-	return sk.Points().Add(sk.ToSketch(at)), nil
+	return sk.AddCloudAnchoredPoint(newCloudSketchPointSource(h.Cloud, h.Point)), nil
 }
 
 // canSketchPointAtCloudPoint enables Sketch Point from a scan: in a 2D sketch with a snapped scan

--- a/head/ui/point_cloud_sketchpoint_provenance_shot_test.go
+++ b/head/ui/point_cloud_sketchpoint_provenance_shot_test.go
@@ -1,0 +1,67 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// shiftX is a +dx translation matrix (row-major, translation in the last column).
+func shiftX(dx float64) math.Matrix4 {
+	m := math.Identity4()
+	c := m.Cells()
+	c[3] = math.Scalar(dx)
+	return math.Matrix4FromCells(c)
+}
+
+// TestInWindowSketchPointProvenanceFollowsCloud anchors a sketch point on a scan point, moves the
+// cloud, re-projects, and captures — the visual confirmation that the scan-anchored sketch point
+// keeps a live link to the cloud and follows it (provenance) (#645). Skips without a display.
+func TestInWindowSketchPointProvenanceFollowsCloud(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	path, peak := flatScanNearXY(t) // reuses the grid+peak scan from the sketch-point shot test
+	pc, err := s.AttachPointCloud("Flat", path)
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("enter sketch: %v", err)
+	}
+	s.Select(app.PointCloudPointHandle{Cloud: pc, Point: peak})
+	p, err := s.CreateSketchPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("project scan point: %v", err)
+	}
+	x0 := float64(p.Position().X)
+
+	pc.SetTransform(shiftX(20)) // move the cloud; the anchored sketch point must re-project with it
+	sk.UpdateProjections()
+	x1 := float64(p.Position().X)
+	t.Logf("sketch point X: %.3f before move, %.3f after (cloud shifted +20)", x0, x1)
+	if x1-x0 < 19 {
+		t.Fatalf("sketch point did not follow the cloud: X %.3f → %.3f", x0, x1)
+	}
+
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-sketchpoint-provenance.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/model/sketch/cloud_point.go
+++ b/model/sketch/cloud_point.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// Datum-cloud provenance for sketch points (M17-F06, #645): a sketch point placed on a scanned
+// point keeps a link to its cloud so it re-projects onto the sketch plane when the cloud moves, and
+// persists the link so a reopened document re-anchors it — the sketch counterpart of the
+// point-cloud-fit plane and the anchored work point.
+
+// CloudPointAnchor is a scan point a sketch point is anchored to. SourceID is the cloud's id and
+// LocalAnchor the cloud-local 3D position — both persisted so the link is re-attached after a load;
+// ModelPosition re-derives the current model-space location (ok=false when the cloud is gone), which
+// the sketch projects onto its plane.
+type CloudPointAnchor interface {
+	SourceID() string
+	LocalAnchor() math.Point3
+	ModelPosition() (math.Point3, bool)
+}
+
+// cloudAnchoredPoint links a sketch point to a scan point. The cloud id and local anchor are stored
+// independently of the live source so they survive a load (when source is nil until relinked).
+type cloudAnchoredPoint struct {
+	point   *Point
+	cloudID string
+	local   math.Point3
+	source  CloudPointAnchor
+}
+
+// AddCloudAnchoredPoint adds a standalone sketch point anchored on the scan point described by
+// anchor, projected onto the sketch plane, and records the cloud link (provenance). The point
+// follows the cloud on UpdateProjections.
+func (s *Sketch) AddCloudAnchoredPoint(anchor CloudPointAnchor) *Point {
+	pos := s.plane.ToSketch(modelOrZero(anchor))
+	p := s.points.Add(pos)
+	s.cloudPts = append(s.cloudPts, &cloudAnchoredPoint{
+		point: p, cloudID: anchor.SourceID(), local: anchor.LocalAnchor(), source: anchor,
+	})
+	return p
+}
+
+// updateCloudAnchors re-projects every cloud-anchored point from its (live) source onto the sketch
+// plane; a point whose source is detached (loaded but not yet relinked, or lost) keeps its position.
+func (s *Sketch) updateCloudAnchors() {
+	for _, a := range s.cloudPts {
+		if a.source == nil {
+			continue
+		}
+		if pos, ok := a.source.ModelPosition(); ok {
+			a.point.SetPosition(s.plane.ToSketch(pos))
+		}
+	}
+}
+
+// CloudAnchors returns the persisted provenance of each cloud-anchored point — the point's id, the
+// source cloud's id, and the cloud-local anchor — for serialization.
+func (s *Sketch) CloudAnchors() []CloudAnchorInfo {
+	out := make([]CloudAnchorInfo, 0, len(s.cloudPts))
+	for _, a := range s.cloudPts {
+		out = append(out, CloudAnchorInfo{PointID: a.point.id, CloudID: a.cloudID, Local: a.local})
+	}
+	return out
+}
+
+// CloudAnchorInfo is the persisted form of one cloud-anchored point.
+type CloudAnchorInfo struct {
+	PointID ID
+	CloudID string
+	Local   math.Point3
+}
+
+// RestoreCloudAnchor re-creates a cloud-anchored link over an already-restored point (its source is
+// re-attached later by RelinkCloudAnchors). It is the restore-side counterpart of
+// AddCloudAnchoredPoint.
+func (s *Sketch) RestoreCloudAnchor(point *Point, cloudID string, local math.Point3) {
+	s.cloudPts = append(s.cloudPts, &cloudAnchoredPoint{point: point, cloudID: cloudID, local: local})
+}
+
+// RelinkCloudAnchors re-attaches live cloud sources to this sketch's cloud-anchored points after a
+// load (matching by cloud id), then re-projects them. attach receives the cloud id and the local
+// anchor so the host can rebuild the source. Returns how many were relinked.
+func (s *Sketch) RelinkCloudAnchors(attach func(cloudID string, local math.Point3) (CloudPointAnchor, bool)) int {
+	n := 0
+	for _, a := range s.cloudPts {
+		if src, ok := attach(a.cloudID, a.local); ok {
+			a.source = src
+			n++
+		}
+	}
+	if n > 0 {
+		s.updateCloudAnchors()
+	}
+	return n
+}
+
+// modelOrZero returns the anchor's current model position, or the origin when it cannot fit (the
+// initial seed; the point re-projects once a live source is present).
+func modelOrZero(a CloudPointAnchor) math.Point3 {
+	if p, ok := a.ModelPosition(); ok {
+		return p
+	}
+	return math.Point3{}
+}

--- a/model/sketch/cloud_point_test.go
+++ b/model/sketch/cloud_point_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// fakeCloudAnchor is a named fake scan-point source: a settable model position (and "gone" flag),
+// plus the persisted id and cloud-local anchor.
+type fakeCloudAnchor struct {
+	id    string
+	local math.Point3
+	pos   math.Point3
+	ok    bool
+}
+
+func (f *fakeCloudAnchor) SourceID() string                   { return f.id }
+func (f *fakeCloudAnchor) LocalAnchor() math.Point3           { return f.local }
+func (f *fakeCloudAnchor) ModelPosition() (math.Point3, bool) { return f.pos, f.ok }
+
+// TestCloudAnchoredPointFollows: a cloud-anchored sketch point projects onto the sketch plane and
+// re-projects when the source moves, on UpdateProjections (#645).
+func TestCloudAnchoredPointFollows(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	src := &fakeCloudAnchor{id: "Scan", local: math.P3(1, 1, 5), pos: math.P3(3, 4, 7), ok: true}
+	p := s.AddCloudAnchoredPoint(src)
+	if p.Position() != math.P2(3, 4) { // (3,4,7) onto XY → (3,4)
+		t.Errorf("initial sketch point = %v, want (3,4)", p.Position())
+	}
+	src.pos = math.P3(8, 9, 2) // the cloud moves
+	s.UpdateProjections()
+	if p.Position() != math.P2(8, 9) {
+		t.Errorf("re-projected point = %v, want (8,9) (should follow the cloud)", p.Position())
+	}
+}
+
+// TestCloudAnchorSerializeRoundTrip: the provenance round-trips, and a relink re-projects the
+// restored point to the re-attached cloud (#645).
+func TestCloudAnchorSerializeRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	src := &fakeCloudAnchor{id: "CapstanScan", local: math.P3(2, 3, 4), pos: math.P3(5, 6, 7), ok: true}
+	s.AddCloudAnchoredPoint(src)
+
+	out := roundTrip(t, sc)
+	anchors := out.CloudAnchors()
+	if len(anchors) != 1 || anchors[0].CloudID != "CapstanScan" || anchors[0].Local != math.P3(2, 3, 4) {
+		t.Fatalf("restored anchors = %+v, want one CapstanScan at local (2,3,4)", anchors)
+	}
+	restored := pointByID(out, anchors[0].PointID)
+	if restored == nil || restored.Position() != math.P2(5, 6) {
+		t.Fatalf("restored point = %v, want (5,6)", restored)
+	}
+
+	moved := &fakeCloudAnchor{id: "CapstanScan", local: math.P3(2, 3, 4), pos: math.P3(50, 60, 7), ok: true}
+	n := out.RelinkCloudAnchors(func(id string, local math.Point3) (CloudPointAnchor, bool) {
+		if id == "CapstanScan" && local == math.P3(2, 3, 4) {
+			return moved, true
+		}
+		return nil, false
+	})
+	if n != 1 {
+		t.Fatalf("relinked %d, want 1", n)
+	}
+	if restored.Position() != math.P2(50, 60) {
+		t.Errorf("after relink point = %v, want (50,60) (follows the re-attached cloud)", restored.Position())
+	}
+}
+
+// TestRelinkCloudAnchorsNoMatch: a relink that finds no matching cloud leaves the point detached.
+func TestRelinkCloudAnchorsNoMatch(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	s.AddCloudAnchoredPoint(&fakeCloudAnchor{id: "Scan", local: math.P3(0, 0, 0), pos: math.P3(1, 1, 0), ok: true})
+	if n := s.RelinkCloudAnchors(func(string, math.Point3) (CloudPointAnchor, bool) { return nil, false }); n != 0 {
+		t.Errorf("relinked %d, want 0 (no match)", n)
+	}
+}
+
+func pointByID(s *Sketch, id ID) *Point {
+	for _, p := range s.AllPoints() {
+		if p.id == id {
+			return p
+		}
+	}
+	return nil
+}
+
+// TestCloudAnchorDetachedAndUnfit covers the unfit seed (source can't fit → origin) and the
+// detached-anchor skip during re-projection (a restored anchor before relink) (#645).
+func TestCloudAnchorDetachedAndUnfit(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	p := s.AddCloudAnchoredPoint(&fakeCloudAnchor{id: "S", ok: false}) // ModelPosition !ok → seeded at origin
+	if p.Position() != math.P2(0, 0) {
+		t.Errorf("unfit seed = %v, want (0,0)", p.Position())
+	}
+	q := s.Points().Add(math.P2(5, 5))
+	s.RestoreCloudAnchor(q, "S2", math.P3(0, 0, 0)) // a restored anchor: source is nil until relinked
+	s.UpdateProjections()                           // must skip the detached anchor, leaving q put
+	if q.Position() != math.P2(5, 5) {
+		t.Errorf("detached anchor moved to %v, want (5,5)", q.Position())
+	}
+}

--- a/model/sketch/projection.go
+++ b/model/sketch/projection.go
@@ -176,4 +176,5 @@ func (s *Sketch) UpdateProjections() {
 			v.Update()
 		}
 	}
+	s.updateCloudAnchors() // re-project scan-anchored points so they follow their clouds (#645)
 }

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -34,14 +34,23 @@ type SketchData struct {
 	DeferUpdates bool    `yaml:"deferUpdates,omitempty"`
 	// Custom line type (issue #161): the pattern is stored so reopening never
 	// needs the original .lin file.
-	CustomLineName    string           `yaml:"customLineName,omitempty"`
-	CustomLineFile    string           `yaml:"customLineFile,omitempty"`
-	CustomLinePattern []float64        `yaml:"customLinePattern,omitempty,flow"`
-	Plane             PlaneData        `yaml:"plane"`
-	Points            []PointData      `yaml:"points,omitempty"`
-	Entities          []EntityData     `yaml:"entities,omitempty"`
-	Constraints       []ConstraintData `yaml:"constraints,omitempty"`
-	Dimensions        []DimensionData  `yaml:"dimensions,omitempty"`
+	CustomLineName    string            `yaml:"customLineName,omitempty"`
+	CustomLineFile    string            `yaml:"customLineFile,omitempty"`
+	CustomLinePattern []float64         `yaml:"customLinePattern,omitempty,flow"`
+	Plane             PlaneData         `yaml:"plane"`
+	Points            []PointData       `yaml:"points,omitempty"`
+	Entities          []EntityData      `yaml:"entities,omitempty"`
+	Constraints       []ConstraintData  `yaml:"constraints,omitempty"`
+	Dimensions        []DimensionData   `yaml:"dimensions,omitempty"`
+	CloudAnchors      []CloudAnchorData `yaml:"cloudAnchors,omitempty"` // scan-anchored points (provenance, #645)
+}
+
+// CloudAnchorData is the persisted provenance of one cloud-anchored sketch point: which standalone
+// point it drives, the source cloud's id, and the cloud-local 3D anchor the point re-projects from.
+type CloudAnchorData struct {
+	PointID int        `yaml:"point"`
+	CloudID string     `yaml:"cloud"`
+	Local   [3]float64 `yaml:"local"`
 }
 
 // PlaneData is a sketch plane as an origin and two in-plane axes (model space).
@@ -213,6 +222,12 @@ func serializeSketch(s *Sketch) (SketchData, error) {
 			return SketchData{}, err
 		}
 		sd.Dimensions = append(sd.Dimensions, dd)
+	}
+	for _, a := range s.CloudAnchors() {
+		sd.CloudAnchors = append(sd.CloudAnchors, CloudAnchorData{
+			PointID: int(a.PointID), CloudID: a.CloudID,
+			Local: [3]float64{float64(a.Local.X), float64(a.Local.Y), float64(a.Local.Z)},
+		})
 	}
 	return sd, nil
 }

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -46,7 +46,23 @@ func restoreSketch(sc *Sketches, sd SketchData) error {
 	if err := r.restoreConstraints(sd.Constraints); err != nil {
 		return err
 	}
-	return r.restoreDimensions(sd.Dimensions)
+	if err := r.restoreDimensions(sd.Dimensions); err != nil {
+		return err
+	}
+	return r.restoreCloudAnchors(sd.CloudAnchors)
+}
+
+// restoreCloudAnchors re-creates the scan-anchored point links over the already-restored points;
+// the live cloud source is re-attached later by the host (RelinkCloudAnchors) (#645).
+func (r *sketchRestorer) restoreCloudAnchors(anchors []CloudAnchorData) error {
+	for _, a := range anchors {
+		p, ok := r.pointMap[a.PointID]
+		if !ok {
+			return fmt.Errorf("cloud anchor references unknown point id %d", a.PointID)
+		}
+		r.s.RestoreCloudAnchor(p, a.CloudID, math.P3(math.Scalar(a.Local[0]), math.Scalar(a.Local[1]), math.Scalar(a.Local[2])))
+	}
+	return nil
 }
 
 // restoreDerivedCurve rebuilds the M21 derived curves (equation/fixed/offset spline);

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -156,8 +156,9 @@ type Sketch struct {
 	plane     Plane
 	planeHost func() Plane // when set, RefreshPlane re-reads the host (e.g. a work plane)
 	ents      []Entity
-	pts       []*Point // every constrainable point (endpoints, centers, standalone) — the solver's variables
-	refPts    []*Point // fixed reference points (projected anchors): constrainable but not solved
+	pts       []*Point              // every constrainable point (endpoints, centers, standalone) — the solver's variables
+	refPts    []*Point              // fixed reference points (projected anchors): constrainable but not solved
+	cloudPts  []*cloudAnchoredPoint // sketch points anchored on scan points (datum-cloud provenance, #645)
 
 	lines         *Lines
 	arcs          *Arcs


### PR DESCRIPTION
## What

A sketch point placed on a snapped scan point now keeps a **live link to its cloud (provenance)** — the sketch counterpart of the associative cloud-fit plane and anchored work point, and the last of the cloud→model datums to gain provenance. It re-projects onto the sketch plane when the cloud moves, and the link round-trips in the document.

- **`model/sketch`** — a `CloudPointAnchor` seam (cloud id + cloud-local 3D anchor + current model position). A cloud-anchored standalone point re-projects on `UpdateProjections` (so it follows the cloud), persists in a new `cloudAnchors` recipe section, and `RestoreCloudAnchor` + `RelinkCloudAnchors` rebuild and re-attach the link after a load. (Projected geometry isn't otherwise persisted; this is self-contained to scan anchors and doesn't touch the general projection system.)
- **`app`** — `CreateSketchPointAtSelectedCloudPoint` anchors via `AddCloudAnchoredPoint(cloudSketchPointSource{…})`; the post-open `relinkPointCloudProvenance` now also walks each sketch and re-attaches its scan-anchored points.
- **No public API change.**

## Why

Completes datum-cloud provenance across all three cloud-derived datums (plane, work point, sketch point). If you re-register or nudge the scan, the 2D profile geometry you anchored on it follows.

## Testing

- **model/sketch**: the anchored point follows the source on `UpdateProjections`; serialize round-trip preserves cloud id + local anchor; relink re-projects to the re-attached cloud; no-match relink, unfit seed, and detached-anchor skip edges.
- **app**: an anchored sketch point follows the cloud when it is transformed (x 2 → 12); the relink reaches sketch anchors; degenerate-placement and no-match edges; existing sketch-point tests still pass.
- **Live visual confirmation**: shifting the cloud +20 moves the anchored sketch point with it (`TestInWindowSketchPointProvenanceFollowsCloud`, skips in CI). Captured `/tmp/point-cloud-sketchpoint-provenance.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)