### PR TITLE
test(#645): verify point-cloud ribbon buttons are wired and working

### DIFF
--- a/app/point_cloud_ribbon_test.go
+++ b/app/point_cloud_ribbon_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// pointCloudButton returns the named button from the 3D Model ▸ Point Cloud panel and whether it
+// is currently enabled.
+func pointCloudButton(t *testing.T, s *Session, name string) (RibbonButton, bool) {
+	t.Helper()
+	tab, ok := BuildRibbon(s).Tab(tab3DModel)
+	if !ok {
+		t.Fatal("ribbon has no 3D Model tab")
+	}
+	panel, ok := tab.Panel("Point Cloud")
+	if !ok {
+		t.Fatal("3D Model tab has no Point Cloud panel")
+	}
+	for _, b := range panel.Buttons {
+		if b.Command.DisplayName() == name {
+			return b, true
+		}
+	}
+	return RibbonButton{}, false
+}
+
+// TestPointCloudRibbonButtonsWiredAndEnable verifies the Point Cloud panel's buttons exist with
+// icons, run their commands, and enable only in the right context — so clicking them in the ribbon
+// actually drives the feature (#645).
+func TestPointCloudRibbonButtonsWiredAndEnable(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+
+	for _, name := range []string{"Import Point Cloud", "Fit Work Plane", "Work Point", "Crop Box"} {
+		b, ok := pointCloudButton(t, s, name)
+		if !ok {
+			t.Fatalf("Point Cloud panel is missing the %q button", name)
+		}
+		if b.Command.Icon() == "" {
+			t.Errorf("%q has no icon (renders as a blank/text button)", name)
+		}
+	}
+
+	// Context-sensitive buttons start disabled (nothing selected) except Import (just needs a part).
+	mustEnabled(t, s, "Import Point Cloud", true)
+	mustEnabled(t, s, "Fit Work Plane", false)
+	mustEnabled(t, s, "Crop Box", false)
+	mustEnabled(t, s, "Work Point", false)
+
+	// Attaching and selecting a cloud enables the cloud-level commands.
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(0, 0, 5), math.P3(2, 0, 5), math.P3(0, 2, 5)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	s.Select(PointCloudHandle{Clouds: def.PointClouds(), Cloud: pc})
+	mustEnabled(t, s, "Fit Work Plane", true)
+	mustEnabled(t, s, "Crop Box", true)
+	mustEnabled(t, s, "Work Point", false) // needs a snapped scan point, not the cloud
+
+	// Selecting a snapped scan point enables Work Point.
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(0, 0, 5)})
+	mustEnabled(t, s, "Work Point", true)
+
+	// Executing through the command registry (the ribbon's click path) runs the feature.
+	if err := s.Execute("PointCloud.WorkPoint"); err != nil {
+		t.Errorf("Execute(PointCloud.WorkPoint): %v", err)
+	}
+	s.Select(PointCloudHandle{Clouds: def.PointClouds(), Cloud: pc})
+	if err := s.Execute("PointCloud.FitPlane"); err != nil {
+		t.Errorf("Execute(PointCloud.FitPlane): %v", err)
+	}
+	if err := s.Execute("PointCloud.CropBox"); err != nil { // starts the crop tool
+		t.Errorf("Execute(PointCloud.CropBox): %v", err)
+	}
+}
+
+// TestSketchProjectScanPointButtonWired verifies the Sketch ▸ Create ▸ Project Scan Point button is
+// wired and enables only in a sketch with a scan point selected (#645).
+func TestSketchProjectScanPointButtonWired(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, _ := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(1, 2, 3)})
+
+	cmd, ok := s.Commands().ByID("Sketch.ProjectScanPoint")
+	if !ok {
+		t.Fatal("Sketch.ProjectScanPoint command is not registered")
+	}
+	if cmd.Icon() == "" {
+		t.Error("Project Scan Point has no icon")
+	}
+	if cmd.IsEnabled(s) {
+		t.Error("Project Scan Point should be disabled outside a sketch")
+	}
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(1, 2, 3)})
+	if !cmd.IsEnabled(s) {
+		t.Error("Project Scan Point should be enabled in a sketch with a scan point selected")
+	}
+	if err := s.Execute("Sketch.ProjectScanPoint"); err != nil {
+		t.Errorf("Execute(Sketch.ProjectScanPoint): %v", err)
+	}
+}
+
+func mustEnabled(t *testing.T, s *Session, name string, want bool) {
+	t.Helper()
+	b, ok := pointCloudButton(t, s, name)
+	if !ok {
+		t.Fatalf("no %q button", name)
+	}
+	if b.Enabled != want {
+		t.Errorf("%q enabled = %v, want %v", name, b.Enabled, want)
+	}
+}

--- a/head/ui/point_cloud_ribbon_shot_test.go
+++ b/head/ui/point_cloud_ribbon_shot_test.go
@@ -1,0 +1,69 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+// pointCloudRibbonPanel extracts the 3D Model ▸ Point Cloud panel from the built ribbon.
+func pointCloudRibbonPanel(t *testing.T, s *app.Session) app.RibbonPanel {
+	t.Helper()
+	tab, ok := app.BuildRibbon(s).Tab("3D Model")
+	if !ok {
+		t.Fatal("no 3D Model tab")
+	}
+	panel, ok := tab.Panel("Point Cloud")
+	if !ok {
+		t.Fatal("no Point Cloud panel")
+	}
+	return panel
+}
+
+// TestInWindowPointCloudPanelButtons renders the Point Cloud ribbon panel on its own (the full 3D
+// Model tab is far wider than the captured window) with a cloud selected, and captures it — the
+// visual confirmation that its buttons (Import / Fit Work Plane / Work Point / Crop Box) render
+// with icons and are enabled, hence clickable (#645).
+func TestInWindowPointCloudPanelButtons(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "ribbon.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, _ := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(0, 0, 5), math.P3(2, 0, 5), math.P3(0, 2, 5)})
+	s.Select(app.PointCloudHandle{Clouds: def.PointClouds(), Cloud: pc}) // enable Fit Work Plane / Crop Box
+
+	for i := 0; i < 4; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s) // binds the icon cache and draws the chrome
+		native.SetNextWindowPos(40, 80)
+		native.SetNextWindowSize(380, 150)
+		if native.Begin("3D Model > Point Cloud") {
+			drawPanel(pointCloudRibbonPanel(t, s), 200)
+		}
+		native.End()
+		win.EndFrame(0.12, 0.12, 0.14)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-panel.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Regression guards confirming the point-cloud UI buttons added this milestone actually work when clicked — not just that the underlying session methods do.

- **`app/point_cloud_ribbon_test.go`** — builds the ribbon and asserts the 3D Model ▸ Point Cloud panel has **Import Point Cloud / Fit Work Plane / Work Point / Crop Box** (and Sketch ▸ Create ▸ **Project Scan Point**), each carrying an icon, enabling only in the right context (a cloud selected → Fit Work Plane / Crop Box; a snapped scan point → Work Point; in a sketch → Project Scan Point), and **executing through the command registry** — the exact path `DrawChrome` → `drawRibbon` → click uses.
- **`head/ui/point_cloud_ribbon_shot_test.go`** — renders the Point Cloud panel in-window and captures it (the full 3D Model tab is wider than the offscreen window), visually confirming the buttons render with icons and the correct enabled/disabled state.

## Result

All buttons verified working: registered on the correct panels, iconned (no blank buttons), context-sensitive enable, and click → execute. The captured panel shows Import / Fit Work Plane / Crop Box enabled with a cloud selected, and Work Point correctly greyed (it needs a snapped scan point). No production changes — verification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)