### PR TITLE
feat(#645): auto-recompute cloud-derived datums on a cloud move

### DIFF
--- a/addin/router/point_clouds.go
+++ b/addin/router/point_clouds.go
@@ -115,6 +115,7 @@ func setPointCloudTransform(s *app.Session, raw json.RawMessage) (json.RawMessag
 		return nil, err
 	}
 	pc.SetTransform(math.Matrix4FromCells(in.Transform.Cells))
+	s.RecomputeAfterPointCloudMove() // datums built on the cloud follow it (#645)
 	return json.Marshal(pointCloudInfo(pc))
 }
 
@@ -131,6 +132,7 @@ func setPointCloudScale(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 	if !pc.SetScale(in.Scale) {
 		return nil, fmt.Errorf("pointClouds.setScale: scale must be positive, got %v", in.Scale)
 	}
+	s.RecomputeAfterPointCloudMove() // datums built on the cloud follow it (#645)
 	return json.Marshal(pointCloudInfo(pc))
 }
 

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
+	"oblikovati.org/model/feature"
 )
 
 // writeScan writes a small ASCII scan file and returns its path.
@@ -260,5 +261,37 @@ func TestPointCloudNearestPoint(t *testing.T) {
 	}
 	if _, err := r.Handle(s, "pointClouds.nearestPoint", []byte(`{"cloud":"nope","point":{"x":0,"y":0,"z":0}}`)); err == nil {
 		t.Error("nearestPoint on an unknown cloud should error")
+	}
+}
+
+// TestSetTransformAutoRecomputesDatums: moving a cloud over the wire re-derives a plane fit to it,
+// so the datum follows without any separate recompute call (#645).
+func TestSetTransformAutoRecomputesDatums(t *testing.T) {
+	r, s := emptyPartSession(t)
+	path := writeScan(t, "0 0 5\n2 0 5\n0 2 5\n2 2 5\n")
+	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &wire.PointCloudInfo{})
+
+	var fit wire.FitPointCloudPlaneResult
+	call(t, r, s, "pointClouds.fitPlane", `{"cloud":"Scan"}`, &fit)
+	if stdmath.Abs(fit.Origin.Z-5) > 1e-9 {
+		t.Fatalf("fitted plane Z = %v, want 5", fit.Origin.Z)
+	}
+
+	// Move the cloud up by 10 over the wire; no explicit recompute follows.
+	move := types.TranslationMatrix(types.Vector{X: 0, Y: 0, Z: 10})
+	call(t, r, s, "pointClouds.setTransform", mustJSON(t, wire.SetPointCloudTransformArgs{Name: "Scan", Transform: move}), &wire.PointCloudInfo{})
+
+	// The fitted work plane must have re-derived to z = 15.
+	var plane *feature.WorkPlane
+	for _, p := range s.PickableWorkPlanes() {
+		if p.Kind() == "point-cloud-fit" {
+			plane = p
+		}
+	}
+	if plane == nil {
+		t.Fatal("no point-cloud-fit work plane found")
+	}
+	if got := float64(plane.Plane().Origin().Z); stdmath.Abs(got-15) > 1e-9 {
+		t.Errorf("after the wire move, plane Z = %v, want 15 (auto-recompute should drive it)", got)
 	}
 }

--- a/app/point_cloud_provenance.go
+++ b/app/point_cloud_provenance.go
@@ -101,6 +101,17 @@ func (s *Session) relinkPointCloudProvenance(part *compdef.PartComponentDefiniti
 	}
 }
 
+// RecomputeAfterPointCloudMove re-derives the datums built on point clouds — the fit planes, the
+// anchored work points, and the scan-anchored sketch points — after a cloud's placement (transform
+// or scale) changes, so they follow the cloud immediately instead of waiting for an unrelated
+// recompute. part.Recompute already re-derives the work features and re-projects the sketches'
+// cloud anchors, so one recompute of the active part suffices. It is a no-op outside a part (#645).
+func (s *Session) RecomputeAfterPointCloudMove() {
+	if part, err := activePart(s); err == nil {
+		part.Recompute()
+	}
+}
+
 // relinkSketchCloudAnchors re-attaches cloud sources to every sketch's scan-anchored points.
 func (s *Session) relinkSketchCloudAnchors(part *compdef.PartComponentDefinition) int {
 	n := 0

--- a/app/point_cloud_provenance_test.go
+++ b/app/point_cloud_provenance_test.go
@@ -216,3 +216,28 @@ func TestWorkPointProvenanceEdges(t *testing.T) {
 	def.PointClouds().Remove("Scan")
 	s.relinkPointCloudProvenance(def) // no cloud "Scan" now → nothing relinked
 }
+
+// TestRecomputeAfterPointCloudMoveFollowsDatum: the auto-recompute hook makes a cloud-derived datum
+// follow the cloud without a manual part recompute (#645).
+func TestRecomputeAfterPointCloudMoveFollowsDatum(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(3, 4, 5)})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 5)})
+	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("create work point: %v", err)
+	}
+
+	pc.SetTransform(liftZ(10)) // move the cloud; do NOT call Recompute directly
+	s.RecomputeAfterPointCloudMove()
+	if wp.Point() != math.P3(3, 4, 15) {
+		t.Errorf("work point = %v, want (3,4,15) (the move hook should drive it)", wp.Point())
+	}
+
+	// Outside a part the hook is a harmless no-op.
+	NewSession().RecomputeAfterPointCloudMove()
+}

--- a/app/point_cloud_provenance_test.go
+++ b/app/point_cloud_provenance_test.go
@@ -9,7 +9,25 @@ import (
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
+	"oblikovati.org/model/pointcloud"
 )
+
+// anchorWorkPointOnScan attaches a single-point cloud, selects that scan point, and places a work
+// point on it — the shared setup for the work-point provenance tests.
+func anchorWorkPointOnScan(t *testing.T, s *Session, def *compdef.PartComponentDefinition, at math.Point3) (*pointcloud.PointCloud, *feature.WorkPoint) {
+	t.Helper()
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
+	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{at})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	s.Select(PointCloudPointHandle{Cloud: pc, Point: at})
+	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
+	if err != nil {
+		t.Fatalf("create work point: %v", err)
+	}
+	return pc, wp
+}
 
 // planarPoints are scan points on z = 5 (a horizontal plane), shared by the provenance tests.
 func planarPoints() []math.Point3 {
@@ -126,16 +144,7 @@ func TestCloudPlaneFitSourceEdges(t *testing.T) {
 // because it keeps a live link (provenance) rather than a frozen position (#645).
 func TestWorkPointFollowsCloud(t *testing.T) {
 	s, def := emptyPartSession(t)
-	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
-	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(3, 4, 5)})
-	if err != nil {
-		t.Fatalf("attach: %v", err)
-	}
-	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 5)})
-	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
-	if err != nil {
-		t.Fatalf("CreateWorkPointAtSelectedCloudPoint: %v", err)
-	}
+	pc, wp := anchorWorkPointOnScan(t, s, def, math.P3(3, 4, 5))
 	if wp.Point() != math.P3(3, 4, 5) {
 		t.Fatalf("initial work point = %v, want (3,4,5)", wp.Point())
 	}
@@ -221,16 +230,7 @@ func TestWorkPointProvenanceEdges(t *testing.T) {
 // follow the cloud without a manual part recompute (#645).
 func TestRecomputeAfterPointCloudMoveFollowsDatum(t *testing.T) {
 	s, def := emptyPartSession(t)
-	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("x")})
-	pc, err := def.PointClouds().Add("Scan", "s.xyz", rid, []math.Point3{math.P3(3, 4, 5)})
-	if err != nil {
-		t.Fatalf("attach: %v", err)
-	}
-	s.Select(PointCloudPointHandle{Cloud: pc, Point: math.P3(3, 4, 5)})
-	wp, err := s.CreateWorkPointAtSelectedCloudPoint()
-	if err != nil {
-		t.Fatalf("create work point: %v", err)
-	}
+	pc, wp := anchorWorkPointOnScan(t, s, def, math.P3(3, 4, 5))
 
 	pc.SetTransform(liftZ(10)) // move the cloud; do NOT call Recompute directly
 	s.RecomputeAfterPointCloudMove()

--- a/head/ui/point_cloud_autorecompute_shot_test.go
+++ b/head/ui/point_cloud_autorecompute_shot_test.go
@@ -19,21 +19,10 @@ import (
 // scene without any explicit recompute. The fitted plane must have already followed the cloud,
 // confirming the auto-recompute on a cloud move (#645). Skips without a display.
 func TestInWindowAutoRecomputeOnCloudMove(t *testing.T) {
-	win := newViewportWindow(t)
+	win := newShotWindow(t)
 	defer win.Destroy()
-	dockLaidOut = false
-	icons = nil
-
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t)) // the tilted sheet from the provenance shot
-	if err != nil {
-		t.Fatalf("attach scan: %v", err)
-	}
-	wp, _, err := s.CreatePointCloudPlane("Sheet")
-	if err != nil {
-		t.Fatalf("fit plane: %v", err)
-	}
-	wp.SetVisible(true)
+	pc, wp := attachSheetWithFitPlane(t, s)
 	z0 := float64(wp.Plane().Origin().Z)
 
 	// Move the cloud +12 in z via the router — and do NOT recompute by hand.

--- a/head/ui/point_cloud_autorecompute_shot_test.go
+++ b/head/ui/point_cloud_autorecompute_shot_test.go
@@ -6,7 +6,6 @@ package ui
 
 import (
 	"encoding/json"
-	"path/filepath"
 	"testing"
 
 	"oblikovati.org/addin/opregistry"
@@ -51,13 +50,5 @@ func TestInWindowAutoRecomputeOnCloudMove(t *testing.T) {
 		t.Fatalf("plane did not auto-follow the cloud move: Z %.3f → %.3f", z0, z1)
 	}
 
-	frameCameraOn(s, pc.RangeBox())
-	for i := 0; i < 10; i++ {
-		win.BeginFrame()
-		DrawChrome(win, s)
-		win.EndFrame(0.1, 0.1, 0.12)
-	}
-	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-autorecompute.png")); err != nil {
-		t.Logf("SaveWindowPNG: %v", err)
-	}
+	captureFramed(t, win, s, pc.RangeBox(), "point-cloud-autorecompute")
 }

--- a/head/ui/point_cloud_autorecompute_shot_test.go
+++ b/head/ui/point_cloud_autorecompute_shot_test.go
@@ -1,0 +1,63 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/addin/router"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestInWindowAutoRecomputeOnCloudMove fits a plane to a scan, then moves the cloud through the real
+// pointClouds.setTransform router method — the path an add-in or the UI uses — and captures the
+// scene without any explicit recompute. The fitted plane must have already followed the cloud,
+// confirming the auto-recompute on a cloud move (#645). Skips without a display.
+func TestInWindowAutoRecomputeOnCloudMove(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	pc, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t)) // the tilted sheet from the provenance shot
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	wp, _, err := s.CreatePointCloudPlane("Sheet")
+	if err != nil {
+		t.Fatalf("fit plane: %v", err)
+	}
+	wp.SetVisible(true)
+	z0 := float64(wp.Plane().Origin().Z)
+
+	// Move the cloud +12 in z via the router — and do NOT recompute by hand.
+	r := router.New(opregistry.Default())
+	args, _ := json.Marshal(wire.SetPointCloudTransformArgs{
+		Name: "Sheet", Transform: types.TranslationMatrix(types.Vector{Z: 12}),
+	})
+	if _, err := r.Handle(s, "pointClouds.setTransform", args); err != nil {
+		t.Fatalf("setTransform: %v", err)
+	}
+	z1 := float64(wp.Plane().Origin().Z)
+	t.Logf("plane origin Z: %.3f before move, %.3f after the router move (no manual recompute)", z0, z1)
+	if z1-z0 < 11 {
+		t.Fatalf("plane did not auto-follow the cloud move: Z %.3f → %.3f", z0, z1)
+	}
+
+	frameCameraOn(s, pc.RangeBox())
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "point-cloud-autorecompute.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/head/ui/point_cloud_capture_helpers_test.go
+++ b/head/ui/point_cloud_capture_helpers_test.go
@@ -11,7 +11,34 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/pointcloud"
 )
+
+// newShotWindow opens a viewport window and resets the per-window dock/icon state, the common
+// preamble of the point-cloud in-window shot tests. The caller defers win.Destroy().
+func newShotWindow(t *testing.T) *native.Window {
+	win := newViewportWindow(t)
+	dockLaidOut = false
+	icons = nil
+	return win
+}
+
+// attachSheetWithFitPlane attaches the tilted sheet scan and fits a visible work plane to it — the
+// shared setup for the provenance / move / auto-recompute shot tests.
+func attachSheetWithFitPlane(t *testing.T, s *app.Session) (*pointcloud.PointCloud, *feature.WorkPlane) {
+	t.Helper()
+	pc, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t))
+	if err != nil {
+		t.Fatalf("attach scan: %v", err)
+	}
+	wp, _, err := s.CreatePointCloudPlane("Sheet")
+	if err != nil {
+		t.Fatalf("fit plane: %v", err)
+	}
+	wp.SetVisible(true)
+	return pc, wp
+}
 
 // captureFramed frames the camera on box, renders a few chrome frames, and saves the viewport to
 // name.png — the shared tail of the point-cloud in-window shot tests.

--- a/head/ui/point_cloud_capture_helpers_test.go
+++ b/head/ui/point_cloud_capture_helpers_test.go
@@ -1,0 +1,29 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/math"
+)
+
+// captureFramed frames the camera on box, renders a few chrome frames, and saves the viewport to
+// name.png — the shared tail of the point-cloud in-window shot tests.
+func captureFramed(t *testing.T, win *native.Window, s *app.Session, box math.Box, name string) {
+	t.Helper()
+	frameCameraOn(s, box)
+	for i := 0; i < 10; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.12)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), name+".png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Moving a point cloud now makes the datums built on it follow immediately. `pointClouds.setTransform` / `pointClouds.setScale` recompute the active part after changing the cloud's placement, so the **fit planes, anchored work points, and scan-anchored sketch points** re-derive at once instead of waiting for an unrelated recompute (a feature edit or reopen) — closing the caveat the provenance PRs left open.

- `part.Recompute()` already re-derives the work-feature datums and re-projects the sketches' cloud anchors (via `refreshSketchReferences` → `UpdateProjections` → `updateCloudAnchors`), so the new `Session.RecomputeAfterPointCloudMove` is a single recompute the two router handlers call after the placement changes.
- **No public API change** — `setTransform`/`setScale` are unchanged; they just keep dependents in sync now.

## Why

A scan is reference data you model against; nudging or re-registering it should carry the geometry you built on it. Provenance made the datums *able* to follow; this makes them follow *when the cloud actually moves*.

## Testing

- **app**: the hook drives a cloud-anchored work point to follow a cloud transform without a manual recompute; no-op outside a part.
- **router**: moving a cloud via `pointClouds.setTransform` re-derives a plane fit to it (z 5 → 15) with no separate recompute call.
- **Live visual confirmation**: a +12 move through the real `pointClouds.setTransform` router path carries the fitted work plane with the cloud — captured `/tmp/point-cloud-autorecompute.png`, the plane stays embedded in the moved sheet (`TestInWindowAutoRecomputeOnCloudMove`, skips in CI).

Note: there is no interactive cloud-drag manipulator yet; clouds move through the `setTransform`/`setScale` API (an add-in / MCP / a future drag tool), all of which now trigger the recompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)