### PR TITLE
fix(#645): point-cloud Crop tool clicks were swallowed by box-select

### DIFF
--- a/app/cloud_move_tool_test.go
+++ b/app/cloud_move_tool_test.go
@@ -108,3 +108,20 @@ func TestCloudMoveToolTrivialsAndNoCloudBranch(t *testing.T) {
 		t.Error("BeginCloudDrag should not start when no cloud is selected")
 	}
 }
+
+// TestActiveToolConsumesClicks: the predicate that makes box-select stand down — true for a
+// PlaneClickTool (the Crop Box tool), false otherwise (#645).
+func TestActiveToolConsumesClicks(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if s.ActiveToolConsumesClicks() {
+		t.Error("no active tool should not consume clicks")
+	}
+	s.StartTool(NewCropBoxTool(nil)) // a PlaneClickTool (ClickAt)
+	if !s.ActiveToolConsumesClicks() {
+		t.Error("the Crop Box tool should consume clicks")
+	}
+	s.StartTool(NewCloudMoveTool()) // drag-driven, not a PlaneClickTool
+	if s.ActiveToolConsumesClicks() {
+		t.Error("the Move tool is drag-driven and should not consume clicks (updateCloudDrag handles it)")
+	}
+}

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -32,6 +32,17 @@ func (s *Session) StartTool(t Tool) {
 // ActiveTool returns the running tool instance, or nil.
 func (s *Session) ActiveTool() *ToolInstance { return s.tool }
 
+// ActiveToolConsumesClicks reports whether the active tool takes raw viewport clicks as input (a
+// [PlaneClickTool] — the sketch geometry tools and the point-cloud Crop Box tool). When it does, the
+// viewport must route a press to the tool, not start a box-select that would swallow it (#645).
+func (s *Session) ActiveToolConsumesClicks() bool {
+	if s.tool == nil {
+		return false
+	}
+	_, ok := s.tool.tool.(PlaneClickTool)
+	return ok
+}
+
 // PickAt hit-tests the pixel through the installed picker without changing selection —
 // the viewport uses it for hover feedback (which plane/face is under the cursor).
 func (s *Session) PickAt(x, y float64, filter *SelectionFilter) (Selectable, bool) {

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -129,6 +129,9 @@ func updateBoxSelect(s *app.Session) bool {
 	if !native.IsItemClicked(native.MouseLeft) {
 		return false
 	}
+	if s.ActiveToolConsumesClicks() {
+		return false // a click tool (sketch geometry, point-cloud Crop Box) owns the press, not box-select
+	}
 	lx, ly := viewportCursor()
 	if _, hit := s.PickAt(lx, ly, app.NewSelectionFilter()); hit {
 		return false // pressed on geometry → normal click select (drag-to-move is future work)

--- a/head/ui/point_cloud_tool_input_test.go
+++ b/head/ui/point_cloud_tool_input_test.go
@@ -1,0 +1,123 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/compdef"
+)
+
+// armCloudSession attaches a small scan to a framed model session with box-select enabled (a region
+// picker + an always-empty point picker), selects the cloud, and returns it.
+func armCloudSession(t *testing.T) (*app.Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s := framedSession()
+	s.SetPicker(fakeEmptyPicker{})                          // every press is on empty space
+	s.SetRegionPicker(fakeRegionHit{sel: app.BodyHandle{}}) // box-select is available (model env)
+	path := filepath.Join(t.TempDir(), "scan.xyz")
+	if err := os.WriteFile(path, []byte("0 0 0\n1 0 0\n0 1 0\n1 1 0\n"), 0o644); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	pc, err := s.AttachPointCloud("Scan", path)
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	s.Select(app.PointCloudHandle{Clouds: def.PointClouds(), Cloud: pc})
+	return s, def
+}
+
+// TestInWindowCropToolOwnsClicks: while the Crop Box tool is active, a viewport press must feed the
+// tool (a crop corner) and NOT start a box-select (which would swallow the click and clear the
+// selection) (#645).
+func TestInWindowCropToolOwnsClicks(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s, def := armCloudSession(t)
+	if err := s.StartCropSelectedCloud(); err != nil {
+		t.Fatalf("StartCropSelectedCloud: %v", err)
+	}
+
+	cx, cy := float32(inWinW/2), float32(inWinH/2)
+	native.InjectMousePos(cx, cy)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, true) // first crop corner
+	viewportFrame(win, s)
+	if s.BoxSelectActive() {
+		t.Fatal("box-select armed while the Crop tool is active — the tool's clicks are intercepted")
+	}
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+
+	// Second corner elsewhere → the crop commits.
+	before := def.PointClouds().Item(0).Crops().Count()
+	native.InjectMousePos(cx+60, cy+40)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, true)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+	if got := def.PointClouds().Item(0).Crops().Count(); got != before+1 {
+		t.Errorf("two viewport clicks added %d crops, want 1 (the tool should own the clicks)", got-before)
+	}
+}
+
+// TestInWindowMoveToolOwnsDrag: while the Move tool is active, a viewport press starts the cloud
+// drag, not a box-select (#645).
+func TestInWindowMoveToolOwnsDrag(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s, _ := armCloudSession(t)
+	if err := s.StartMoveSelectedCloud(); err != nil {
+		t.Fatalf("StartMoveSelectedCloud: %v", err)
+	}
+	cx, cy := float32(inWinW/2), float32(inWinH/2)
+	native.InjectMousePos(cx, cy)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, true)
+	viewportFrame(win, s)
+	if s.BoxSelectActive() {
+		t.Error("box-select armed while the Move tool is active")
+	}
+	if !s.CloudDragActive() {
+		t.Error("the Move tool did not begin a cloud drag on press")
+	}
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+}
+
+// TestInWindowBoxSelectRestoredAfterTool: once a click tool deactivates, an empty-space press
+// begins box-select again (the guard only stands box-select down while a click tool is active).
+func TestInWindowBoxSelectRestoredAfterTool(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s, _ := armCloudSession(t)
+	if err := s.StartCropSelectedCloud(); err != nil {
+		t.Fatalf("StartCropSelectedCloud: %v", err)
+	}
+	s.CancelTool() // leave the Crop tool
+
+	cx, cy := float32(inWinW/2), float32(inWinH/2)
+	native.InjectMousePos(cx, cy)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, true)
+	viewportFrame(win, s)
+	if !s.BoxSelectActive() {
+		t.Error("box-select should arm again once the click tool is gone")
+	}
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+}


### PR DESCRIPTION
## What

Found and fixed a real interaction bug: the **Crop Box tool didn't work interactively** — its corner clicks were intercepted by box-select.

### Root cause
In the model environment a region picker is installed, so `updateBoxSelect` arms a rubber-band on any empty-space left press. The Crop Box tool is a `PlaneClickTool` whose clicks are routed *last* (`handleViewportClick` → `Session.Pointer` → `sketchClick` → `ClickAt`), so box-select consumed the press first — and the swallowed single-click also committed a degenerate box that **cleared the selection**. Boxing a crop never reached the tool.

### Fix
Stand box-select down while a click-consuming tool is active:
- `Session.ActiveToolConsumesClicks()` — true when the active tool is a `PlaneClickTool`.
- `updateBoxSelect` returns early when it is, so the press falls through to the tool.

The Move tool already owns its drag via `updateCloudDrag` (which runs before box-select). Box-select resumes the moment the tool is gone.

## Testing

A new **real-input** in-window test file (`InjectMousePos`/`InjectMouseButton`, the same harness as the existing box-select tests):
- **Crop tool owns clicks** — a press does not arm box-select; two clicks add a crop (this test *failed* before the fix, confirming the bug).
- **Move tool owns the drag** — a press begins the cloud drag, not box-select.
- **Box-select restored** — after the click tool is cancelled, an empty-space press arms box-select again.
- Plus a non-cgo unit test for `ActiveToolConsumesClicks`.
- Regression: the existing model + sketch box-select and the cloud-move drag tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)