### PR TITLE
perf(dwg): 2–4× faster decode + fix large-drawing zoom-out clipping

### DIFF
--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -5,6 +5,7 @@
 package ui
 
 import (
+	"math"
 	"strconv"
 	"time"
 
@@ -326,7 +327,7 @@ func viewportDrawList(s *app.Session, cam scene.Camera, hovered *feature.WorkPla
 // baseDrawList is the model geometry (styled) with the current selection highlighted, with
 // no environment overlays — what a passive (non-focused) tile shows for its view's camera.
 func baseDrawList(s *app.Session, cam scene.Camera) renderer.DrawList {
-	list := cachedBodyDrawList(s, cam) // a per-frame copy of the cached tessellation (see viewport_cache.go)
+	list := cachedBodyDrawList(s, cam)                            // a per-frame copy of the cached tessellation (see viewport_cache.go)
 	list.Items = append(list.Items, pointCloudOverlay(s, cam)...) // attached scans (M17-F06, #645)
 	return highlightSelection(list, s.Selection().First(), activeBodies(s))
 }
@@ -458,7 +459,8 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	tb := frameClock()
 	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups)
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
-	mvp := renderer.ViewProjection(cam, viewportNear, viewportFar)
+	flo, fhi, fok := farBounds(mn, mx, hasGeom)
+	mvp := renderer.ViewProjection(cam, viewportNear, viewportClipFar(cam, flo, fhi, fok))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
 	win.SetViewportLighting(viewport.PackLighting(s.SceneLighting()))
 	applyEnvironment(win, s.Environment())
@@ -671,6 +673,50 @@ const (
 	viewportNear = 0.1
 	viewportFar  = 5000.0
 )
+
+// viewportClipFar returns the far clip distance for this frame. It is the fixed viewportFar
+// for ordinary scenes, but extends to enclose the model once the camera pulls back far enough
+// that the geometry would fall beyond it. Large imported drawings (DWG/DXF) span tens of
+// thousands of units, so a fixed 5000 far plane clipped the whole sketch to nothing on
+// zoom-out — the geometry was simply behind the far plane (the near plane stays fixed, so
+// nothing closer is ever clipped and small scenes are unchanged). The bound comes from the
+// camera's distance to the scene's bounding sphere, with a margin so the far face isn't
+// exactly on the plane.
+// farBounds unions the framed (instanced/triangle) bounds with the finished-sketch overlay
+// extent so the adaptive far plane encloses sketch-only drawings. frameBounds/DrawListBounds
+// see only non-OnTop triangles, so a DWG/DXF import — all OnTop line work — would otherwise
+// report no bounds and fall back to the fixed far plane, clipping the sketch on zoom-out.
+func farBounds(mn, mx [3]float32, hasGeom bool) (lo, hi [3]float32, ok bool) {
+	lo, hi, ok = mn, mx, hasGeom
+	smn, smx, sok := cachedSketchOverlayBounds()
+	if !sok {
+		return lo, hi, ok
+	}
+	if !ok {
+		return smn, smx, true
+	}
+	for i := 0; i < 3; i++ {
+		lo[i], hi[i] = minF32(lo[i], smn[i]), maxF32(hi[i], smx[i])
+	}
+	return lo, hi, true
+}
+
+func viewportClipFar(cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64 {
+	if !hasGeom {
+		return viewportFar
+	}
+	cx := (float64(mn[0]) + float64(mx[0])) / 2
+	cy := (float64(mn[1]) + float64(mx[1])) / 2
+	cz := (float64(mn[2]) + float64(mx[2])) / 2
+	rx, ry, rz := float64(mx[0])-cx, float64(mx[1])-cy, float64(mx[2])-cz
+	radius := math.Sqrt(rx*rx + ry*ry + rz*rz)
+	dx, dy, dz := cam.Eye.X-cx, cam.Eye.Y-cy, cam.Eye.Z-cz
+	dist := math.Sqrt(dx*dx + dy*dy + dz*dz)
+	if far := (dist + radius) * 1.1; far > viewportFar {
+		return far
+	}
+	return viewportFar
+}
 
 // readNavInput snapshots this frame's viewport pointer state from the native layer for
 // the pure ApplyNavigation mapping (see navigate.go). It must be called right after the

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -459,8 +459,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	tb := frameClock()
 	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups)
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
-	flo, fhi, fok := farBounds(mn, mx, hasGeom)
-	mvp := renderer.ViewProjection(cam, viewportNear, viewportClipFar(cam, flo, fhi, fok))
+	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(cam, mn, mx, hasGeom))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
 	win.SetViewportLighting(viewport.PackLighting(s.SceneLighting()))
 	applyEnvironment(win, s.Environment())
@@ -682,6 +681,15 @@ const (
 // nothing closer is ever clipped and small scenes are unchanged). The bound comes from the
 // camera's distance to the scene's bounding sphere, with a margin so the far face isn't
 // exactly on the plane.
+// viewportFarPlane is the per-frame far clip distance: it unions the framed geometry with the
+// finished-sketch overlay extent (farBounds) and computes the adaptive far from that
+// (viewportClipFar). Split so the bounding-sphere math is unit-tested in isolation from the
+// package-level overlay cache.
+func viewportFarPlane(cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64 {
+	lo, hi, ok := farBounds(mn, mx, hasGeom)
+	return viewportClipFar(cam, lo, hi, ok)
+}
+
 // farBounds unions the framed (instanced/triangle) bounds with the finished-sketch overlay
 // extent so the adaptive far plane encloses sketch-only drawings. frameBounds/DrawListBounds
 // see only non-OnTop triangles, so a DWG/DXF import — all OnTop line work — would otherwise

--- a/head/ui/dwg_zoomout_shot_test.go
+++ b/head/ui/dwg_zoomout_shot_test.go
@@ -1,0 +1,75 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// dwgCorpus loads a real .dwg from the git-ignored experiments tree, skipping when absent.
+func dwgCorpus(t *testing.T, name string) string {
+	t.Helper()
+	dir := os.Getenv("DWG_TESTFILES_DIR")
+	if dir == "" {
+		dir = filepath.Join("..", "..", "..", "experiments", "dwg-reverse-engineering")
+	}
+	path := filepath.Join(dir, name)
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("corpus unavailable: %v", err)
+	}
+	return path
+}
+
+// TestInWindowLargeDWGZoomedOutRenders is the live regression for "zooming out a large-dimension
+// DWG stopped rendering the sketch": testfile-7 is an ~100k-unit oval-plaza plan, so framing the
+// whole drawing puts the camera tens of thousands of units back — well beyond the old fixed 5000
+// far plane, which clipped the entire sketch to a blank viewport. With the adaptive far plane the
+// drawing must produce a non-trivial draw list that frames within the frustum. Saves a PNG for a
+// human/Claude to eyeball the rendered linework.
+func TestInWindowLargeDWGZoomedOutRenders(t *testing.T) {
+	win := newShotWindow(t)
+	defer win.Destroy()
+	s := framedSession()
+
+	plane, err := sketch.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	if err != nil {
+		t.Fatalf("plane: %v", err)
+	}
+	res, err := s.ImportDWGFile(dwgCorpus(t, "testfile-7.dwg"), plane)
+	if err != nil {
+		t.Fatalf("ImportDWGFile: %v", err)
+	}
+	if res.EntityCount == 0 {
+		t.Fatal("imported zero entities")
+	}
+
+	// Frame on the imported drawing's real extent (the line work), which is the whole ~100k-unit
+	// plan, so the camera sits far past the legacy 5000 far plane. The sketch overlay is all OnTop
+	// lines, which DrawListBounds excludes, so the far plane uses the cached overlay bounds.
+	cachedPartSketchOverlays(s) // populate the overlay + bounds cache
+	mn, mx, ok := cachedSketchOverlayBounds()
+	if !ok {
+		t.Fatal("imported sketch produced no overlay bounds (nothing to render)")
+	}
+	box := math.NewBox(math.P3(float64(mn[0]), float64(mn[1]), float64(mn[2])),
+		math.P3(float64(mx[0]), float64(mx[1]), float64(mx[2])))
+	span := box.Diagonal().Length()
+	if span < 5000 {
+		t.Skipf("drawing span %v is within the legacy far plane; not the zoom-out case", span)
+	}
+
+	// The adaptive far plane must enclose the framed camera's view of this box.
+	frameCameraOn(s, box)
+	far := viewportClipFar(s.Camera(), mn, mx, true)
+	if far <= viewportFar {
+		t.Errorf("far plane %v did not extend for a %v-unit drawing (sketch would clip on zoom-out)", far, span)
+	}
+	captureFramed(t, win, s, box, "dwg_zoomout_testfile7")
+}

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -25,6 +25,12 @@ import (
 var sketchOverlayCache struct {
 	key   string
 	items []renderer.DrawItem
+	// bounds is the model-space extent of the cached line work, computed once per rebuild so
+	// the viewport's adaptive far plane can enclose a sketch-only drawing (DWG/DXF imports are
+	// all OnTop line primitives, which DrawListBounds excludes). hasBounds is false for an
+	// empty overlay.
+	boundsMin, boundsMax [3]float32
+	hasBounds            bool
 }
 
 // cachedPartSketchOverlays returns the finished-sketch overlay, rebuilding it only
@@ -39,8 +45,33 @@ func cachedPartSketchOverlays(s *app.Session) []renderer.DrawItem {
 	if key != sketchOverlayCache.key {
 		sketchOverlayCache.key = key
 		sketchOverlayCache.items = partSketchOverlays(s)
+		sketchOverlayCache.boundsMin, sketchOverlayCache.boundsMax, sketchOverlayCache.hasBounds =
+			drawItemsBounds(sketchOverlayCache.items)
 	}
 	return append([]renderer.DrawItem(nil), sketchOverlayCache.items...)
+}
+
+// cachedSketchOverlayBounds returns the model-space extent of the finished-sketch overlay
+// computed at the last cache rebuild, so the viewport far plane encloses it without rescanning
+// hundreds of thousands of line vertices every frame. ok is false when there is no line work.
+func cachedSketchOverlayBounds() (min, max [3]float32, ok bool) {
+	return sketchOverlayCache.boundsMin, sketchOverlayCache.boundsMax, sketchOverlayCache.hasBounds
+}
+
+// drawItemsBounds is the axis-aligned model-space box over every vertex of items (all
+// primitives, including the OnTop lines a sketch overlay is made of). ok is false when items
+// carry no positions.
+func drawItemsBounds(items []renderer.DrawItem) (min, max [3]float32, ok bool) {
+	min = [3]float32{stdmath.MaxFloat32, stdmath.MaxFloat32, stdmath.MaxFloat32}
+	max = [3]float32{-stdmath.MaxFloat32, -stdmath.MaxFloat32, -stdmath.MaxFloat32}
+	for _, it := range items {
+		for _, p := range it.Positions {
+			min[0], max[0] = minF32(min[0], float32(p.X)), maxF32(max[0], float32(p.X))
+			min[1], max[1] = minF32(min[1], float32(p.Y)), maxF32(max[1], float32(p.Y))
+			min[2], max[2] = minF32(min[2], float32(p.Z)), maxF32(max[2], float32(p.Z))
+		}
+	}
+	return min, max, min[0] <= max[0]
 }
 
 // sketchOverlayKey identifies the finished-sketch overlay geometry. Sketch edits do

--- a/head/ui/viewport_clip_test.go
+++ b/head/ui/viewport_clip_test.go
@@ -1,0 +1,45 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+// TestViewportClipFarKeepsDefaultForSmallScenes: an ordinary model close to the camera keeps
+// the fixed far plane, so nothing about normal scenes changes.
+func TestViewportClipFarKeepsDefaultForSmallScenes(t *testing.T) {
+	cam := scene.Camera{Eye: math.P3(40, 40, 40), Target: math.P3(0, 0, 0), Up: math.V3(0, 0, 1), FOV: 0.8}
+	if got := viewportClipFar(cam, [3]float32{-10, -10, -10}, [3]float32{10, 10, 10}, true); got != viewportFar {
+		t.Errorf("small scene far = %v, want fixed %v", got, viewportFar)
+	}
+	if got := viewportClipFar(cam, [3]float32{}, [3]float32{}, false); got != viewportFar {
+		t.Errorf("no-geometry far = %v, want fixed %v", got, viewportFar)
+	}
+}
+
+// TestViewportClipFarEnclosesLargeDrawing: a DWG-scale drawing (~100k units) viewed from far
+// enough that the fixed 5000 far plane would clip it must get a far plane beyond the farthest
+// geometry — the zoom-out-hides-the-sketch bug. The far plane must exceed the camera's
+// distance to the farthest corner.
+func TestViewportClipFarEnclosesLargeDrawing(t *testing.T) {
+	// A 100k-unit-wide drawing centred at the origin, camera pulled back 150k units on Z.
+	mn, mx := [3]float32{-50000, -50000, 0}, [3]float32{50000, 50000, 0}
+	cam := scene.Camera{Eye: math.P3(0, 0, 150000), Target: math.P3(0, 0, 0), Up: math.V3(0, 1, 0), FOV: 0.8}
+
+	far := viewportClipFar(cam, mn, mx, true)
+	if far <= viewportFar {
+		t.Fatalf("large drawing far = %v, expected it to extend past the fixed %v", far, viewportFar)
+	}
+	// The farthest geometry corner is at distance sqrt(50000^2+50000^2+150000^2) from the eye;
+	// the far plane must enclose it or the sketch clips on zoom-out (regression guard).
+	farthest := cam.Eye.DistanceTo(math.P3(50000, 50000, 0))
+	if far < farthest {
+		t.Errorf("far plane %v does not enclose farthest corner at %v", far, farthest)
+	}
+}

--- a/kernel/exchange/dwg/bench_test.go
+++ b/kernel/exchange/dwg/bench_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package dwg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// benchCorpus lists the real DWG files (largest first) used to profile decode. They live in
+// the git-ignored experiments tree, so the benchmark skips when the corpus is absent.
+var benchCorpus = []string{
+	"testfile-1.dwg", "testfile-2.dwg", "testfile-3.dwg", "testfile-4.dwg",
+	"testfile-5.dwg", "testfile-6.dwg", "testfile-7.dwg",
+}
+
+// BenchmarkDecodeCorpus times a full Decode of each corpus file (container + object map +
+// geometry + insert expansion), reporting entities/op so a regression shows up as ns/entity.
+func BenchmarkDecodeCorpus(b *testing.B) {
+	for _, name := range benchCorpus {
+		path := filepath.Join(testFilesDir(), name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			b.Skipf("corpus %s unavailable; set %s to run", name, testFilesEnv)
+			return
+		}
+		b.Run(name, func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			var ents int
+			for i := 0; i < b.N; i++ {
+				dr, _, err := Decode(data)
+				if err != nil {
+					b.Fatalf("decode %s: %v", name, err)
+				}
+				ents = len(dr.Entities)
+			}
+			b.ReportMetric(float64(ents), "entities")
+		})
+	}
+}
+
+// TestReportDecodeTimings prints a one-shot decode time + entity count for every corpus file,
+// a quick human-readable baseline (run with -run TestReportDecodeTimings -v).
+func TestReportDecodeTimings(t *testing.T) {
+	if os.Getenv("DWG_BENCH_REPORT") == "" {
+		t.Skip("set DWG_BENCH_REPORT=1 to print decode timings")
+	}
+	for _, name := range benchCorpus {
+		data := loadTestFile(t, name)
+		dr, warns, err := Decode(data)
+		if err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		fmt.Printf("%-16s %8d bytes -> %7d entities, %3d warnings\n", name, len(data), len(dr.Entities), len(warns))
+	}
+}

--- a/kernel/exchange/dwg/bitreader.go
+++ b/kernel/exchange/dwg/bitreader.go
@@ -56,6 +56,18 @@ func (r *BitReader) SetPosition(bitPos int) {
 	r.bitPos = uint8(bitPos % 8)
 }
 
+// Reset re-points the reader at buf positioned at bit offset bitPos and clears the
+// sticky error, so a single reader can be reused across the many per-object decodes
+// in a drawing without allocating a fresh [BitReader] each time (the object pass runs
+// once per object — 100k+ on large files — and a stack/collector-held reader avoids
+// that many heap allocations).
+func (r *BitReader) Reset(buf []byte, bitPos int) {
+	r.buf = buf
+	r.bytePos = bitPos / 8
+	r.bitPos = uint8(bitPos % 8)
+	r.err = nil
+}
+
 // BitLen returns the total size of the underlying buffer in bits.
 func (r *BitReader) BitLen() int { return len(r.buf) * 8 }
 
@@ -100,19 +112,59 @@ func (r *BitReader) ReadBit() uint {
 
 // ReadBits reads n bits (0..64) MSB-first into the low bits of the result. Used
 // for the 2-bit and 3-bit selector fields and for handle nibbles.
+//
+// It consumes the stream in chunks of up to 8 bits (each spanning at most two
+// bytes) rather than one bit per call: ReadBit-per-bit made the bit reader ~53%
+// of total DWG decode CPU (every RC/RS/RL/RD on a mid-byte cursor fell to an
+// 8-iteration loop). Behaviour is identical; only the throughput changes.
 func (r *BitReader) ReadBits(n int) uint64 {
 	if n < 0 || n > 64 {
 		r.fail("ReadBits invalid count %d (want 0..64)", n)
 		return 0
 	}
 	var v uint64
-	for i := 0; i < n; i++ {
-		v = (v << 1) | uint64(r.ReadBit())
+	for n > 0 {
+		take := n
+		if take > 8 {
+			take = 8
+		}
+		v = v<<uint(take) | uint64(r.readUpTo8(take))
+		n -= take
 	}
 	return v
 }
 
-// ReadRC reads a raw 8-bit char (RC). Valid even when the cursor is mid-byte.
+// readUpTo8 reads take bits (1..8) MSB-first from the current cursor, which may
+// straddle one byte boundary, and advances by take. On overrun it records the
+// sticky error and returns 0. Factored out of [BitReader.ReadBits] so the common
+// 1–8 bit reads avoid a per-bit loop.
+func (r *BitReader) readUpTo8(take int) uint8 {
+	if r.err != nil {
+		return 0
+	}
+	avail := 8 - int(r.bitPos) // bits left in the current byte
+	if take <= avail {
+		if r.bytePos >= len(r.buf) {
+			r.fail("ReadBits past end (len=%d bytes)", len(r.buf))
+			return 0
+		}
+		v := r.buf[r.bytePos] >> uint(avail-take) & (1<<uint(take) - 1)
+		r.advance(take)
+		return v
+	}
+	if r.bytePos+1 >= len(r.buf) {
+		r.fail("ReadBits past end (len=%d bytes)", len(r.buf))
+		return 0
+	}
+	need := take - avail // bits taken from the next byte
+	hi := r.buf[r.bytePos] & (1<<uint(avail) - 1)
+	lo := r.buf[r.bytePos+1] >> uint(8-need)
+	r.advance(take)
+	return hi<<uint(need) | lo
+}
+
+// ReadRC reads a raw 8-bit char (RC). Valid even when the cursor is mid-byte — a
+// mid-byte read is a single two-byte combine, not eight ReadBit calls.
 func (r *BitReader) ReadRC() byte {
 	if r.err != nil {
 		return 0
@@ -126,7 +178,16 @@ func (r *BitReader) ReadRC() byte {
 		r.bytePos++
 		return b
 	}
-	return byte(r.ReadBits(8))
+	if r.bytePos+1 >= len(r.buf) {
+		r.fail("ReadRC past end (len=%d bytes)", len(r.buf))
+		return 0
+	}
+	// The byte spans the low (8-bitPos) bits of the current byte and the high
+	// bitPos bits of the next; advancing 8 bits leaves bitPos unchanged (bytePos++).
+	k := r.bitPos
+	b := r.buf[r.bytePos]<<k | r.buf[r.bytePos+1]>>(8-k)
+	r.bytePos++
+	return b
 }
 
 // ReadRS reads a raw little-endian unsigned 16-bit short (RS).

--- a/kernel/exchange/dwg/decode.go
+++ b/kernel/exchange/dwg/decode.go
@@ -127,7 +127,7 @@ func (c *collector) addObject(cur *entityCursor, hdr ObjectHeader) string {
 		return ""
 	}
 	if cur.common.entmode == entmodeBlock {
-		owner, _ := commonEntityHandles(&c.handleReader, c.data, cur, c.version)
+		owner := commonEntityHandles(&c.handleReader, c.data, cur, c.version)
 		c.blockEntities[owner] = append(c.blockEntities[owner], e)
 	} else {
 		c.modelEntities = append(c.modelEntities, e)

--- a/kernel/exchange/dwg/decode.go
+++ b/kernel/exchange/dwg/decode.go
@@ -65,6 +65,11 @@ type collector struct {
 	blockEntities map[uint64][]Entity // by owning BLOCK_HEADER handle
 	blockInserts  map[uint64][]*Insert
 	paperCurves   int // paper-space curve entities skipped (for classification accounting)
+	// Readers reused across the per-object loop so each object does not allocate a fresh
+	// *BitReader: geomReader walks the data stream (held by the cursor), handleReader the
+	// handle stream. The loop fully decodes one object before the next, so reuse is safe.
+	geomReader   BitReader
+	handleReader BitReader
 }
 
 // collect walks every referenced object, decoding the geometry and INSERT records and
@@ -81,7 +86,7 @@ func (c *collector) collect(refs []ObjectRef) []string {
 		if !isInsert && !hdr.Type.IsSketchGeometry() {
 			continue
 		}
-		cur, err := seekEntity(c.data, ref, c.version)
+		cur, err := seekEntity(&c.geomReader, c.data, ref, c.version)
 		if err != nil {
 			warns = append(warns, err.Error())
 			continue
@@ -92,7 +97,7 @@ func (c *collector) collect(refs []ObjectRef) []string {
 			}
 			continue // paper-space layout geometry is not imported into the model sketch
 		}
-		if w := c.addObject(cur, hdr); w != "" {
+		if w := c.addObject(&cur, hdr); w != "" {
 			warns = append(warns, w)
 		}
 	}
@@ -103,7 +108,7 @@ func (c *collector) collect(refs []ObjectRef) []string {
 // space or its owning block. It returns a warning string on a decode failure.
 func (c *collector) addObject(cur *entityCursor, hdr ObjectHeader) string {
 	if hdr.Type == TypeInsert {
-		in, owner, err := decodeInsert(c.data, cur, hdr.Handle, c.version)
+		in, owner, err := decodeInsert(&c.handleReader, c.data, cur, hdr.Handle, c.version)
 		if err != nil {
 			return err.Error()
 		}
@@ -122,7 +127,7 @@ func (c *collector) addObject(cur *entityCursor, hdr ObjectHeader) string {
 		return ""
 	}
 	if cur.common.entmode == entmodeBlock {
-		owner, _ := commonEntityHandles(c.data, cur, c.version)
+		owner, _ := commonEntityHandles(&c.handleReader, c.data, cur, c.version)
 		c.blockEntities[owner] = append(c.blockEntities[owner], e)
 	} else {
 		c.modelEntities = append(c.modelEntities, e)

--- a/kernel/exchange/dwg/entitydata.go
+++ b/kernel/exchange/dwg/entitydata.go
@@ -39,8 +39,11 @@ type entityCursor struct {
 // flags and the start of its handle stream. It supersedes the previous
 // seekEntityGeometry, which discarded both (ADR: blocks/INSERT need the handle stream
 // and entmode-based space filtering). Supports R2000 (flat) and R2010+ (paged).
-func seekEntity(data []byte, ref ObjectRef, version Version) (*entityCursor, error) {
-	r := NewBitReaderAt(data, int(ref.Offset)*8)
+// The cursor is returned by value so the caller can keep it on its stack: seekEntity runs
+// once per type-matching object (hundreds of thousands on large drawings) and a per-call
+// &entityCursor was the single largest allocation by object count.
+func seekEntity(r *BitReader, data []byte, ref ObjectRef, version Version) (entityCursor, error) {
+	r.Reset(data, int(ref.Offset)*8)
 	size := r.ReadMS() // object size, in bytes, measured from the address below
 	var hssize uint64
 	if version >= R2010 {
@@ -64,9 +67,9 @@ func seekEntity(data []byte, ref ObjectRef, version Version) (*entityCursor, err
 	skipEED(r)
 	ce := readCommonEntityData(r, version)
 	if err := r.Err(); err != nil {
-		return nil, fmt.Errorf("dwg: entity handle %d common data: %w", ref.Handle, err)
+		return entityCursor{}, fmt.Errorf("dwg: entity handle %d common data: %w", ref.Handle, err)
 	}
-	return &entityCursor{geom: r, common: ce, ownHandle: own.Value, handleStart: addrBit + bitsize}, nil
+	return entityCursor{geom: r, common: ce, ownHandle: own.Value, handleStart: addrBit + bitsize}, nil
 }
 
 // skipEED consumes the extended entity data block: BS-sized records each carrying an

--- a/kernel/exchange/dwg/geometry_test.go
+++ b/kernel/exchange/dwg/geometry_test.go
@@ -40,7 +40,7 @@ func decodeGeometry(t *testing.T, name string) (map[uint64]Entity, map[string]in
 		default:
 			continue
 		}
-		cur, err := seekEntity(od, ref, h.Version)
+		cur, err := seekEntity(&BitReader{}, od, ref, h.Version)
 		if err != nil {
 			t.Fatalf("%s: seek handle %d (%s): %v", name, ref.Handle, hdr.Type.Name(), err)
 		}

--- a/kernel/exchange/dwg/handlestream.go
+++ b/kernel/exchange/dwg/handlestream.go
@@ -40,8 +40,8 @@ func readResolvedHandle(r *BitReader, own uint64) uint64 {
 // can be read next. The reader is independent of the geometry/data-stream cursor.
 //
 //nolint:funlen,gocyclo // sequential flag-gated handle reads in spec order; length/branches are the format.
-func commonEntityHandles(data []byte, cur *entityCursor, version Version) (owner uint64, r *BitReader) {
-	r = NewBitReaderAt(data, cur.handleStart)
+func commonEntityHandles(r *BitReader, data []byte, cur *entityCursor, version Version) (owner uint64, _ *BitReader) {
+	r.Reset(data, cur.handleStart)
 	ce := cur.common
 	own := cur.ownHandle
 	if ce.colorByHandle {

--- a/kernel/exchange/dwg/handlestream.go
+++ b/kernel/exchange/dwg/handlestream.go
@@ -34,13 +34,14 @@ func readResolvedHandle(r *BitReader, own uint64) uint64 {
 	return resolveHandle(h.Code, h.Value, own)
 }
 
-// commonEntityHandles walks the common-entity handle references in spec order and
-// returns the owner handle (the owning block for entmode 0; 0 otherwise) plus a reader
-// positioned right after them, so an entity-specific handle (e.g. INSERT.block_header)
-// can be read next. The reader is independent of the geometry/data-stream cursor.
+// commonEntityHandles walks the common-entity handle references in spec order and returns
+// the owner handle (the owning block for entmode 0; 0 otherwise). It reads through the
+// caller's reader r (independent of the geometry/data-stream cursor), leaving it positioned
+// right after the common handles so an entity-specific handle (e.g. INSERT.block_header) can
+// be read next from the same reader.
 //
 //nolint:funlen,gocyclo // sequential flag-gated handle reads in spec order; length/branches are the format.
-func commonEntityHandles(r *BitReader, data []byte, cur *entityCursor, version Version) (owner uint64, _ *BitReader) {
+func commonEntityHandles(r *BitReader, data []byte, cur *entityCursor, version Version) (owner uint64) {
 	r.Reset(data, cur.handleStart)
 	ce := cur.common
 	own := cur.ownHandle
@@ -90,5 +91,5 @@ func commonEntityHandles(r *BitReader, data []byte, cur *entityCursor, version V
 			readResolvedHandle(r, own)
 		}
 	}
-	return owner, r
+	return owner
 }

--- a/kernel/exchange/dwg/insert.go
+++ b/kernel/exchange/dwg/insert.go
@@ -20,7 +20,7 @@ func decodeInsert(hr *BitReader, data []byte, cur *entityCursor, handle uint64, 
 	if e := r.Err(); e != nil {
 		return nil, 0, fmt.Errorf("dwg: INSERT handle %d data: %w", handle, e)
 	}
-	owner, _ = commonEntityHandles(hr, data, cur, version)
+	owner = commonEntityHandles(hr, data, cur, version)
 	block := readResolvedHandle(hr, cur.ownHandle) // block_header is the first entity-specific handle
 	if e := hr.Err(); e != nil {
 		return nil, 0, fmt.Errorf("dwg: INSERT handle %d block ref: %w", handle, e)

--- a/kernel/exchange/dwg/insert.go
+++ b/kernel/exchange/dwg/insert.go
@@ -7,7 +7,7 @@ import "fmt"
 // decodeInsert reads an INSERT entity: its placement (insertion point, scale, rotation)
 // from the data stream and the referenced block's handle from the handle stream
 // (ODA INSERT spec, R2000+). Pre-2004 attribute handles are not needed and left unread.
-func decodeInsert(data []byte, cur *entityCursor, handle uint64, version Version) (in *Insert, owner uint64, err error) {
+func decodeInsert(hr *BitReader, data []byte, cur *entityCursor, handle uint64, version Version) (in *Insert, owner uint64, err error) {
 	r := cur.geom
 	ins := r.Read3BD()
 	scale := readInsertScale(r)
@@ -20,7 +20,7 @@ func decodeInsert(data []byte, cur *entityCursor, handle uint64, version Version
 	if e := r.Err(); e != nil {
 		return nil, 0, fmt.Errorf("dwg: INSERT handle %d data: %w", handle, e)
 	}
-	owner, hr := commonEntityHandles(data, cur, version)
+	owner, _ = commonEntityHandles(hr, data, cur, version)
 	block := readResolvedHandle(hr, cur.ownHandle) // block_header is the first entity-specific handle
 	if e := hr.Err(); e != nil {
 		return nil, 0, fmt.Errorf("dwg: INSERT handle %d block ref: %w", handle, e)

--- a/kernel/exchange/dwg/object.go
+++ b/kernel/exchange/dwg/object.go
@@ -22,7 +22,10 @@ func decodeObjectHeader(data []byte, ref ObjectRef, version Version) (ObjectHead
 	if ref.Offset < 0 || ref.Offset >= int64(len(data)) {
 		return ObjectHeader{}, fmt.Errorf("dwg: object handle %d offset %d out of bounds (len %d)", ref.Handle, ref.Offset, len(data))
 	}
-	r := NewBitReaderAt(data, int(ref.Offset)*8)
+	// A stack-local reader (vs NewBitReaderAt's heap *BitReader): this runs once per
+	// object in the map — 100k+ on large drawings — and the reader does not escape.
+	var r BitReader
+	r.Reset(data, int(ref.Offset)*8)
 	size := r.ReadMS()
 	if version >= R2010 {
 		r.ReadUMC() // handle-stream size, not part of the object size

--- a/kernel/exchange/dwg/objectmap.go
+++ b/kernel/exchange/dwg/objectmap.go
@@ -30,7 +30,10 @@ const objectMapMaxSection = 2040
 //nolint:funlen // section + (handle,location) delta-decode loop; length is the wire format.
 func parseObjectMap(data []byte) ([]ObjectRef, error) {
 	r := NewBitReader(data)
-	var refs []ObjectRef
+	// Pre-size from the map length: each (handle,location) pair is a UMC+MC delta of at
+	// least ~3 bytes, so len/4 is a close lower bound on the final count and spares the
+	// slice the repeated doubling-and-copy that dominated decode allocation (157 MB → ~4 MB).
+	refs := make([]ObjectRef, 0, len(data)/4)
 	for r.Err() == nil {
 		size := int(r.ReadRC())<<8 | int(r.ReadRC()) // section size, big-endian
 		if size == 2 {

--- a/kernel/exchange/dwg/synth_test.go
+++ b/kernel/exchange/dwg/synth_test.go
@@ -56,11 +56,11 @@ func buildInsertObject(ownHandle, blockHandle uint64, ins [3]float64, rot float6
 // walk in CI (no corpus needed).
 func TestDecodeInsertSynthetic(t *testing.T) {
 	data := buildInsertObject(0x10, 0x42, [3]float64{5, 6, 0}, 0.75)
-	cur, err := seekEntity(data, ObjectRef{Handle: 0x10, Offset: 0}, R2000)
+	cur, err := seekEntity(&BitReader{}, data, ObjectRef{Handle: 0x10, Offset: 0}, R2000)
 	if err != nil {
 		t.Fatalf("seekEntity: %v", err)
 	}
-	in, _, err := decodeInsert(data, cur, 0x10, R2000)
+	in, _, err := decodeInsert(&BitReader{}, data, &cur, 0x10, R2000)
 	if err != nil {
 		t.Fatalf("decodeInsert: %v", err)
 	}

--- a/model/exchange/dwgimport_bench_test.go
+++ b/model/exchange/dwgimport_bench_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// benchCorpus loads a real .dwg corpus file for a benchmark, skipping when the git-ignored
+// experiments tree is absent (mirrors corpusFile, which takes *testing.T).
+func benchCorpus(b *testing.B, name string) []byte {
+	b.Helper()
+	dir := os.Getenv("DWG_TESTFILES_DIR")
+	if dir == "" {
+		dir = filepath.Join("..", "..", "..", "experiments", "dwg-reverse-engineering")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		b.Skipf("corpus unavailable: %v", err)
+	}
+	return data
+}
+
+// benchXYPlane is the world XY plane for benchmark imports (mirrors xyPlane).
+func benchXYPlane(b *testing.B) sketch.Plane {
+	b.Helper()
+	p, err := sketch.NewPlane(gmath.P3(0, 0, 0), gmath.V3(1, 0, 0).AsUnit(), gmath.V3(0, 1, 0).AsUnit())
+	if err != nil {
+		b.Fatalf("NewPlane: %v", err)
+	}
+	return p
+}
+
+// BenchmarkImportDWGFull times the whole import pipeline — dwg.Decode plus the sketch
+// conversion (add2DEntities / add3DEntities) into a fresh part — so a regression in either
+// the decoder or the converter shows up. tf-7 is planar (2D sketch), tf-2 is 3D.
+func BenchmarkImportDWGFull(b *testing.B) {
+	cases := []struct{ file string }{{"testfile-7.dwg"}, {"testfile-2.dwg"}, {"testfile-1.dwg"}}
+	for _, tc := range cases {
+		data := benchCorpus(b, tc.file)
+		plane := benchXYPlane(b)
+		b.Run(tc.file, func(b *testing.B) {
+			b.ReportAllocs()
+			var ents int
+			for i := 0; i < b.N; i++ {
+				part := compdef.NewPartComponentDefinition()
+				res, err := ImportDWG(part, data, plane)
+				if err != nil {
+					b.Fatalf("ImportDWG %s: %v", tc.file, err)
+				}
+				ents = res.EntityCount
+			}
+			b.ReportMetric(float64(ents), "sketch_ents")
+		})
+	}
+}


### PR DESCRIPTION
## What & why

Benchmarked the DWG import/manipulation/viewport subsystem against the real
7–26 MB corpus (testfile-1..7) and applied the lessons from the point-cloud perf
pass. Two outcomes: a much faster decoder, and a fix for a real viewport bug
where large drawings vanished on zoom-out.

### Decode: 2–4.4× faster, up to 63% fewer allocations

A CPU profile put `BitReader.ReadBit` at **53%** of all decode CPU — `ReadBits`
looped one `ReadBit` per bit, and a mid-byte `ReadRC` fell back to `ReadBits(8)`,
so every RC/RS/RL/RD on a non-byte-aligned cursor cost ~8 calls. Fixes:

- **Bulk bit reads** — `ReadBits` consumes up to 8 bits per step and a mid-byte
  `ReadRC` is a single two-byte combine (no per-bit loop).
- **Reuse readers across the object pass** — a stack-local reader for the
  per-object header, two collector-held readers (geom + handle) threaded through
  `seekEntity`/`commonEntityHandles`/`decodeInsert`, and `entityCursor` returned
  by value. Eliminates a heap `*BitReader`/cursor per object (100k+ on large files).
- **Pre-size the object-map directory** — `parseObjectMap` grew from nil via
  `append`, ~157 MB of doubling churn per decode; pre-sized from the map length.

| file | before | after | speedup | allocs before→after |
|------|--------|-------|---------|---------------------|
| testfile-1 (26 MB) | 178 ms | 85 ms | 2.1× | 504k → 253k |
| testfile-2 (25 MB) | 275 ms | 66 ms | 3.9× | 973k → 363k |
| testfile-5 (8 MB)  | 337 ms | 77 ms | 4.4× | 352k → 132k |
| testfile-7 (7 MB)  | 114 ms | 28 ms | 4.0× | 53k → 25k |

Output is unchanged — the byte-exact-vs-oracle geometry tests
(`TestDecodeGeometryCorpus`, exact per-type counts + sampled coords) still pass.
New `BenchmarkDecodeCorpus` and `BenchmarkImportDWGFull` lock in the numbers.

### Viewport: large drawings render when zoomed out

Zooming out a large-dimension import stopped rendering the sketch: the far clip
plane was a fixed **5000 units**, but a drawing can span tens of thousands of
units, so framing the whole plan put the camera behind the far plane → blank.

- Adaptive far plane from the camera's distance to the scene's bounding sphere,
  with 5000 as a floor (near plane unchanged → no near-clip regression, small
  scenes untouched).
- `frameBounds`/`DrawListBounds` only see non-OnTop triangles, but a sketch
  import is all OnTop line work, so the finished-sketch overlay's extent is now
  cached at each overlay rebuild (not per frame) and unioned into the far-plane
  bounds — without that, sketch-only drawings never extended the plane.

**On culling / LOD:** the finished-sketch overlay is already cached and
camera-independent (rebuilt only on geometry change), so per-frame render stays
~1 ms even on dense imports; the bounds are now computed once per rebuild, not
per frame. The zoom-out blank was a clip-plane bug, not a throughput problem, so
no per-frame LOD/cull pass was added (it would trade the cache's camera
independence for per-frame work with no clear win at current GPU cost).

## Testing
- `go test ./kernel/exchange/dwg/ ./model/exchange/` green (incl. oracle byte-exact).
- Full `head/ui` suite green.
- Unit tests for the adaptive far plane (small-scene floor + large-drawing enclosure).
- **Live-confirmed**: testfile-7 (~100k-unit oval plaza) renders fully zoomed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)