### PR TITLE
fix(dwg): 3D imports show in browser + viewport; Fit frames sketch-only parts

### DIFF
--- a/app/browser.go
+++ b/app/browser.go
@@ -26,7 +26,7 @@ import (
 // clicking "XY Plane" selects the plane to sketch on).
 type BrowserNode struct {
 	Label    string
-	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "feature" | "occurrence" | "features" | "assemblyFeature"
+	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "sketch3d" | "feature" | "occurrence" | "features" | "assemblyFeature"
 	Select   Selectable
 	Children []BrowserNode
 }
@@ -290,6 +290,7 @@ func addModelTimeline(root *BrowserNode, part *compdef.PartComponentDefinition) 
 	entries = appendWorkPlaneEntries(entries, part)
 	entries = appendWorkAxisPointEntries(entries, part)
 	entries = appendTopLevelSketchEntries(entries, part, absorber)
+	entries = appendSketch3DEntries(entries, part)
 	entries = appendFeatureEntries(entries, part, absorber)
 
 	sort.SliceStable(entries, func(i, j int) bool { return entries[i].seq < entries[j].seq })
@@ -372,6 +373,20 @@ func appendTopLevelSketchEntries(entries []timelineEntry, part *compdef.PartComp
 		}
 		entries = append(entries, timelineEntry{sk.Seq(), func(root *BrowserNode) {
 			root.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
+		}})
+	}
+	return entries
+}
+
+// appendSketch3DEntries adds the part's 3D sketches at their creation position, so an imported
+// or hand-built Sketch3D shows in the browser like a 2D sketch (it was previously omitted, so a
+// non-planar DWG import produced an invisible sketch). 3D sketches are never feature-absorbed.
+func appendSketch3DEntries(entries []timelineEntry, part *compdef.PartComponentDefinition) []timelineEntry {
+	sketches := part.Sketches3D()
+	for i := 0; i < sketches.Count(); i++ {
+		sk := sketches.Item(i)
+		entries = append(entries, timelineEntry{sk.Seq(), func(root *BrowserNode) {
+			root.selectableChild(sk.Name(), "sketch3d", Sketch3DHandle{Sketch3D: sk})
 		}})
 	}
 	return entries

--- a/app/browser_sketch3d_test.go
+++ b/app/browser_sketch3d_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// TestBrowserShowsSketch3D is the regression for the invisible-import bug: a non-planar DWG
+// lands as a Sketch3D, which the model browser used to omit entirely (it only listed 2D
+// sketches), so the import had no browser node. A 3D sketch must now appear as a "sketch3d"
+// node carrying its name and a Sketch3DHandle.
+func TestBrowserShowsSketch3D(t *testing.T) {
+	s := NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "sketch3d-browser.opd", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches3D().Add()
+	sk.AddLine3D(math.P3(0, 0, 0), math.P3(1, 1, 1))
+	def.Recompute()
+
+	root := BuildBrowser(s)
+	var node *BrowserNode
+	for i := range root.Children {
+		if root.Children[i].Kind == "sketch3d" {
+			node = &root.Children[i]
+			break
+		}
+	}
+	if node == nil {
+		t.Fatal("browser has no sketch3d node for the imported 3D sketch")
+	}
+	if node.Label != sk.Name() {
+		t.Errorf("sketch3d node label = %q, want %q", node.Label, sk.Name())
+	}
+	if _, ok := node.Select.(Sketch3DHandle); !ok {
+		t.Errorf("sketch3d node selectable = %T, want Sketch3DHandle", node.Select)
+	}
+}

--- a/app/selection.go
+++ b/app/selection.go
@@ -143,6 +143,12 @@ type SketchHandle struct{ Sketch *sketch.Sketch }
 
 func (SketchHandle) SelectionKind() SelectionKind { return SelectSketch }
 
+// Sketch3DHandle wraps a 3D sketch (selected from its browser node). A 3D sketch is a sketch
+// for selection purposes, so it shares SelectSketch — the concrete handle distinguishes it.
+type Sketch3DHandle struct{ Sketch3D *sketch.Sketch3D }
+
+func (Sketch3DHandle) SelectionKind() SelectionKind { return SelectSketch }
+
 // WorkPlaneHandle wraps a picked origin/work plane (selected to host a new sketch).
 type WorkPlaneHandle struct{ Plane *feature.WorkPlane }
 

--- a/app/view.go
+++ b/app/view.go
@@ -5,6 +5,7 @@ package app
 import (
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
 )
 
 // View navigation commands operate on the session camera. FitView frames the active
@@ -100,11 +101,61 @@ func (s *Session) lookAtPlane(target math.Point3, normal, up math.Vector3) {
 	s.animateCameraTo(s.Camera().Facing(target, normal, up), sketchViewTweenSeconds)
 }
 
-// modelBounds is the union of the active part's body bounding boxes (empty if none).
+// modelBounds is the union of the active part's body bounding boxes AND its visible sketch
+// geometry, so Fit/Home frame a sketch-only part — e.g. a DWG/DXF import that produces a 2D
+// sketch or a Sketch3D with no solid body (issue #1146). Empty when there is nothing visible.
 func (s *Session) modelBounds() math.Box {
 	box := math.EmptyBox()
 	for _, b := range s.sceneBodies() {
 		box = box.Union(b.RangeBox())
 	}
+	return s.unionSketchBounds(box)
+}
+
+// unionSketchBounds widens box by the model-space extent of the active part's visible 2D and 3D
+// sketches. Curves are sampled the same way the viewport overlay and ray picker sample them
+// (EntityPolyline / SamplePolyline3D), so the framed box matches what is drawn.
+func (s *Session) unionSketchBounds(box math.Box) math.Box {
+	part, err := activePart(s)
+	if err != nil {
+		return box
+	}
+	for i := 0; i < part.Sketches().Count(); i++ {
+		if sk := part.Sketches().Item(i); sk.Visible() {
+			box = unionSketch2DBounds(box, sk)
+		}
+	}
+	for i := 0; i < part.Sketches3D().Count(); i++ {
+		if sk := part.Sketches3D().Item(i); sk.Visible() {
+			box = unionSketch3DBounds(box, sk)
+		}
+	}
 	return box
 }
+
+// unionSketch2DBounds widens box by a 2D sketch's entities, mapped from sketch space to model
+// space through the sketch plane.
+func unionSketch2DBounds(box math.Box, sk *sketch.Sketch) math.Box {
+	for _, e := range sk.Entities() {
+		pts, _ := sketch.EntityPolyline(e)
+		for _, p := range pts {
+			m := sk.ToModel(p)
+			box = box.Union(math.NewBox(m, m))
+		}
+	}
+	return box
+}
+
+// unionSketch3DBounds widens box by a 3D sketch's entities, already in model space.
+func unionSketch3DBounds(box math.Box, sk *sketch.Sketch3D) math.Box {
+	for _, e := range sk.Entities() {
+		for _, p := range sketch.SamplePolyline3D(e, sketch3DBoundsSegments) {
+			box = box.Union(math.NewBox(p, p))
+		}
+	}
+	return box
+}
+
+// sketch3DBoundsSegments is the per-curve sample count for the 3D-sketch framing bounds — coarse
+// is fine (Fit adds margin), and a low count keeps a dense import's Fit responsive.
+const sketch3DBoundsSegments = 4

--- a/app/view_sketch_bounds_test.go
+++ b/app/view_sketch_bounds_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestModelBoundsIncludesSketches is the regression for issue #1146: Fit/Home framed only solid
+// bodies, so a sketch-only part (a DWG/DXF import) had empty model bounds and Fit did nothing.
+// modelBounds must now enclose visible 2D and 3D sketch geometry.
+func TestModelBoundsIncludesSketches(t *testing.T) {
+	s := NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "bounds.opd", true); err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+
+	// A 3D sketch line far from the origin (where a body-only bounds would stay empty).
+	def.Sketches3D().Add().AddLine3D(math.P3(100, 200, 300), math.P3(140, 260, 360))
+	// A 2D sketch on XY with a line.
+	sk2d := def.Sketches().Add(sketch.XYPlane())
+	sk2d.Lines().AddByTwoPoints(math.P2(-50, -50), math.P2(-10, -20))
+	def.Recompute()
+
+	box := s.modelBounds()
+	if box.IsEmpty() {
+		t.Fatal("modelBounds is empty for a sketch-only part (Fit would not frame the import)")
+	}
+	for _, p := range []math.Point3{{X: 100, Y: 200, Z: 300}, {X: 140, Y: 260, Z: 360}, {X: -50, Y: -50, Z: 0}} {
+		if !box.Contains(p) {
+			t.Errorf("modelBounds %v does not contain sketch point %v", box, p)
+		}
+	}
+}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -459,7 +459,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	tb := frameClock()
 	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups)
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
-	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(cam, mn, mx, hasGeom))
+	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
 	win.SetViewportLighting(viewport.PackLighting(s.SceneLighting()))
 	applyEnvironment(win, s.Environment())
@@ -682,11 +682,15 @@ const (
 // camera's distance to the scene's bounding sphere, with a margin so the far face isn't
 // exactly on the plane.
 // viewportFarPlane is the per-frame far clip distance: it unions the framed geometry with the
-// finished-sketch overlay extent (farBounds) and computes the adaptive far from that
-// (viewportClipFar). Split so the bounding-sphere math is unit-tested in isolation from the
-// package-level overlay cache.
-func viewportFarPlane(cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64 {
+// finished 2D- and 3D-sketch overlay extents (farBounds + cachedSketch3DBounds) and computes
+// the adaptive far from that (viewportClipFar). Split so the bounding-sphere math is unit-tested
+// in isolation from the package-level overlay caches.
+func viewportFarPlane(s *app.Session, cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64 {
 	lo, hi, ok := farBounds(mn, mx, hasGeom)
+	if smn, smx, sok := cachedSketch3DBounds(s); sok {
+		lo, hi = unionBounds(lo, hi, ok, smn, smx)
+		ok = true
+	}
 	return viewportClipFar(cam, lo, hi, ok)
 }
 
@@ -696,17 +700,24 @@ func viewportFarPlane(cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64
 // report no bounds and fall back to the fixed far plane, clipping the sketch on zoom-out.
 func farBounds(mn, mx [3]float32, hasGeom bool) (lo, hi [3]float32, ok bool) {
 	lo, hi, ok = mn, mx, hasGeom
-	smn, smx, sok := cachedSketchOverlayBounds()
-	if !sok {
-		return lo, hi, ok
+	if smn, smx, sok := cachedSketchOverlayBounds(); sok {
+		lo, hi = unionBounds(lo, hi, ok, smn, smx)
+		ok = true
 	}
-	if !ok {
-		return smn, smx, true
+	return lo, hi, ok
+}
+
+// unionBounds widens an (optional) box by another box. When the first box is absent (!has) the
+// second becomes the result; otherwise the two are merged component-wise. The result always has
+// bounds, so the caller sets ok = true.
+func unionBounds(lo, hi [3]float32, has bool, omn, omx [3]float32) ([3]float32, [3]float32) {
+	if !has {
+		return omn, omx
 	}
 	for i := 0; i < 3; i++ {
-		lo[i], hi[i] = minF32(lo[i], smn[i]), maxF32(hi[i], smx[i])
+		lo[i], hi[i] = minF32(lo[i], omn[i]), maxF32(hi[i], omx[i])
 	}
-	return lo, hi, true
+	return lo, hi
 }
 
 func viewportClipFar(cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64 {

--- a/head/ui/sketch3d_overlay.go
+++ b/head/ui/sketch3d_overlay.go
@@ -5,11 +5,60 @@
 package ui
 
 import (
+	"fmt"
+	"strings"
+
 	"oblikovati.org/app"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/renderer"
 )
+
+// sketch3DBoundsCache memoises the model-space extent of the finished 3D-sketch line work, so
+// the viewport's adaptive far plane can enclose a non-planar DWG import (large coordinates,
+// all line primitives) without rescanning every segment each frame. Keyed on the 3D-sketch
+// geometry so it survives camera moves and rebuilds only on import/edit.
+var sketch3DBoundsCache struct {
+	key                  string
+	boundsMin, boundsMax [3]float32
+	hasBounds            bool
+}
+
+// cachedSketch3DBounds returns the extent of the active part's visible 3D sketches, computed at
+// the last geometry change. ok is false when there is no 3D-sketch line work. The far plane
+// unions this with the body/2D-sketch bounds so a 3D import is not clipped on zoom-out.
+func cachedSketch3DBounds(s *app.Session) (min, max [3]float32, ok bool) {
+	key, keyed := sketch3DBoundsKey(s)
+	if !keyed {
+		return drawItemsBounds(sketch3DOverlays(s, 1))
+	}
+	if key != sketch3DBoundsCache.key {
+		sketch3DBoundsCache.key = key
+		sketch3DBoundsCache.boundsMin, sketch3DBoundsCache.boundsMax, sketch3DBoundsCache.hasBounds =
+			drawItemsBounds(sketch3DOverlays(s, 1))
+	}
+	return sketch3DBoundsCache.boundsMin, sketch3DBoundsCache.boundsMax, sketch3DBoundsCache.hasBounds
+}
+
+// sketch3DBoundsKey fingerprints the 3D-sketch geometry (model version + each sketch's seq /
+// visibility / entity count), which changes on import and on add/remove/edit.
+func sketch3DBoundsKey(s *app.Session) (string, bool) {
+	version, ok := activeModelGeometryVersion(s)
+	if !ok {
+		return "", false
+	}
+	part := activePart(s)
+	if part == nil {
+		return "", false
+	}
+	var b strings.Builder
+	b.WriteString(version)
+	for i := 0; i < part.Sketches3D().Count(); i++ {
+		sk := part.Sketches3D().Item(i)
+		fmt.Fprintf(&b, "|%d:%t:%d", sk.Seq(), sk.Visible(), sk.EntityCount())
+	}
+	return b.String(), true
+}
 
 // sketch3DOverlays renders the active part's 3D sketches in the viewport — curves as
 // sampled polylines (the same sampling the ray picker tests against), standalone

--- a/model/exchange/sketch_from_drawing3d.go
+++ b/model/exchange/sketch_from_drawing3d.go
@@ -16,8 +16,8 @@ import (
 // adders live in sketch_from_drawing.go.
 
 // add3DEntities maps decoded entities onto a 3D sketch (used when the drawing is
-// non-planar). Line/Circle/Arc/Spline/Point map directly; ellipses and bulged polylines
-// have no 3D adder yet and are reported as warnings.
+// non-planar). Line/Circle/Arc/Spline/Point/Ellipse/LwPolyline all map directly; an entity
+// with no 3D adder is reported as a warning rather than silently dropped.
 func add3DEntities(sk *sketch.Sketch3D, entities []drawing.Entity) (int, []string) {
 	var warns []string
 	added := 0
@@ -46,10 +46,66 @@ func add3DEntity(sk *sketch.Sketch3D, e drawing.Entity) bool {
 		sk.AddPoint3D(p3(g.Position))
 	case *drawing.Spline:
 		return add3DSpline(sk, g)
+	case *drawing.Ellipse:
+		add3DEllipse(sk, g)
+	case *drawing.LwPolyline:
+		return add3DPolyline(sk, g)
 	default:
 		return false
 	}
 	return true
+}
+
+// add3DEllipse places a DWG ellipse on a 3D sketch in its own plane (center + extrusion
+// normal + major axis). A partial parametric span becomes an elliptical arc, a full span a
+// closed ellipse — mirroring the 2D mapping (which split arcs out to stop giant ovals).
+func add3DEllipse(sk *sketch.Sketch3D, g *drawing.Ellipse) {
+	majorR := math.Hypot(math.Hypot(g.MajorAxis[0], g.MajorAxis[1]), g.MajorAxis[2])
+	center, normal, axis := p3(g.Center), normal3(g.Normal), axisUnit(g.MajorAxis)
+	if isFullEllipse(g.StartAngle, g.EndAngle) {
+		sk.AddEllipse3D(center, normal, axis, majorR, majorR*g.AxisRatio)
+		return
+	}
+	sweep := g.EndAngle - g.StartAngle
+	if sweep <= 0 {
+		sweep += 2 * math.Pi
+	}
+	sk.AddEllipticalArc3D(center, normal, axis, majorR, majorR*g.AxisRatio, g.StartAngle, sweep)
+}
+
+// add3DPolyline places each LWPOLYLINE segment on a 3D sketch at the polyline's elevation: a
+// straight run as a 3D line, a bulged run as a 3D arc in the elevation plane. Mirrors
+// add2DPolyline; returns false only for a degenerate (<2 vertex) polyline.
+func add3DPolyline(sk *sketch.Sketch3D, g *drawing.LwPolyline) bool {
+	n := len(g.Points)
+	if n < 2 {
+		return false
+	}
+	z := g.Elevation
+	last := n - 1
+	if g.Closed {
+		last = n
+	}
+	for i := 0; i < last; i++ {
+		a, b := g.Points[i], g.Points[(i+1)%n]
+		if bulge := bulgeAt(g.Bulges, i); bulge != 0 {
+			c, ccw := bulgeArc(a, b, bulge)
+			sk.AddArc3D(gmath.P3(c[0], c[1], z), gmath.P3(a[0], a[1], z), gmath.P3(b[0], b[1], z), ccw)
+		} else {
+			sk.AddLine3D(gmath.P3(a[0], a[1], z), gmath.P3(b[0], b[1], z))
+		}
+	}
+	return true
+}
+
+// axisUnit makes a unit vector from a decoded ellipse major-axis vector, defaulting to +X for
+// a degenerate (zero) vector.
+func axisUnit(v [3]float64) gmath.UnitVector3 {
+	u, err := gmath.UnitVector3FromVector(gmath.V3(v[0], v[1], v[2]))
+	if err != nil {
+		return gmath.V3(1, 0, 0).AsUnit()
+	}
+	return u
 }
 
 // add3DSpline adds a 3D spline from control points, or fit points when present.

--- a/model/exchange/sketch_from_drawing3d_test.go
+++ b/model/exchange/sketch_from_drawing3d_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/exchange/drawing"
+	"oblikovati.org/model/compdef"
+)
+
+// TestAdd3DEntitiesMapsPolylineAndEllipse is the regression for the dropped-geometry bug: a
+// non-planar DWG used to skip every LWPOLYLINE and ELLIPSE ("no 3D mapping"), so a mostly-
+// polyline drawing imported as a near-empty 3D sketch. Every entity must now be placed, with
+// no warnings.
+func TestAdd3DEntitiesMapsPolylineAndEllipse(t *testing.T) {
+	sk := compdef.NewPartComponentDefinition().Sketches3D().Add()
+	entities := []drawing.Entity{
+		&drawing.Line{Start: [3]float64{0, 0, 0}, End: [3]float64{1, 0, 5}},
+		// closed bulged polyline at a non-zero elevation: 2 straight + 1 arc segment.
+		&drawing.LwPolyline{Closed: true, Elevation: 3, Points: [][2]float64{{0, 0}, {2, 0}, {2, 2}}, Bulges: []float64{0, 0.5, 0}},
+		// full ellipse and a partial one (-> elliptical arc).
+		&drawing.Ellipse{Center: [3]float64{0, 0, 1}, MajorAxis: [3]float64{4, 0, 0}, AxisRatio: 0.5, StartAngle: 0, EndAngle: 2 * 3.14159265358979},
+		&drawing.Ellipse{Center: [3]float64{5, 0, 1}, MajorAxis: [3]float64{4, 0, 0}, AxisRatio: 0.5, StartAngle: 1, EndAngle: 2.5},
+	}
+	added, warns := add3DEntities(sk, entities)
+	if len(warns) != 0 {
+		t.Fatalf("unexpected skip warnings: %v", warns)
+	}
+	if added != len(entities) {
+		t.Errorf("added %d of %d entities", added, len(entities))
+	}
+	// 1 line + (closed polyline: 3 segments) + 2 ellipses = 6 sketch entities.
+	if got := sk.EntityCount(); got != 6 {
+		t.Errorf("sketch has %d entities, want 6 (line + 3 polyline segs + 2 ellipses)", got)
+	}
+}


### PR DESCRIPTION
## What & why

Live-tested DWG import → sketch → viewport for all 7 corpus files over the MCP bridge (each into its own new part doc) and fixed the bugs that made non-planar imports invisible — the reported symptom was "testfile-2 imports but shows no sketch in the browser and nothing in the viewport".

Root cause was a cluster of gaps on the **3D-sketch** path (a DWG with any off-plane geometry imports as a Sketch3D):

1. **3D converter dropped geometry** — `add3DEntity` had no case for LWPOLYLINE or ELLIPSE, so they were silently skipped ("no 3D mapping"). testfile-1 alone dropped 67k polylines + 2.5k ellipses. Now mapped to 3D line/arc segments (bulge → arc) and 3D ellipse / elliptical arc, mirroring the 2D path.
2. **Browser omitted 3D sketches** — the model tree listed only `part.Sketches()` (2D), so an imported Sketch3D had no node. Added a `sketch3d` node + `Sketch3DHandle`.
3. **Far plane ignored 3D sketches** — the adaptive far plane (#1145) unioned only 2D overlay bounds, so a 3D import (large coords, no triangles) fell back to the fixed 5000 plane and clipped to blank. Now caches and unions the 3D-sketch extent.
4. **Fit/Home didn't frame sketch-only parts (#1146)** — `modelBounds` used only solid bodies, so Fit did nothing for a sketch-only import. Now unions visible 2D + 3D sketch geometry. Fixes #1146.

## Live validation (screenshots, MCP bridge, one new part doc per file)

| file | type | browser node | viewport |
|------|------|------|------|
| testfile-2 (the reported case) | 3D | ✅ "3D Sketch1" | ✅ renders, framed |
| testfile-3 | 3D | ✅ | ✅ |
| testfile-5/6/7 | 2D | ✅ | ✅ (e.g. tf-7 oval plaza, framed) |
| testfile-1 | 3D | — | ⛔ separate issue ↓ |

Before: testfile-2 had no browser node and a blank viewport. After: the 3D sketch appears in the tree and the geometry renders, framed by Fit.

## Known follow-up (not in this PR)

testfile-1 (26 MB → ~109k entities) times out on import because the **undo snapshot** `MarshalRecipe` (YAML) takes 7.3 s / 149 MB — decode+convert is only 205 ms. That's the pre-existing undo-serialization perf issue; filed as **#1147** (high blast radius — the undo path runs on every edit — so it gets its own tested PR).

## Tests
- `TestAdd3DEntitiesMapsPolylineAndEllipse` (no skips, all types placed)
- `TestBrowserShowsSketch3D` (sketch3d node + handle)
- `TestModelBoundsIncludesSketches` (Fit frames 2D+3D sketches)
- existing adaptive-far-plane + full `app`/`model/exchange`/`head/ui` suites green; no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)