### PR TITLE
M31-F02: Capture imprint provenance for parent-based edge naming

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -134,14 +134,9 @@ func imprintAll(fa, fb []planarFace) (impA, impB [][][2]math.Point3) {
 	impB = make([][][2]math.Point3, len(fb))
 	for i := range fa {
 		for j := range fb {
-			if coplanar(fa[i], fb[j]) {
-				impA[i] = append(impA[i], coplanarOverlapSegments(fa[i], faceEdges3D(fb[j]))...)
-				impB[j] = append(impB[j], coplanarOverlapSegments(fb[j], faceEdges3D(fa[i]))...)
-				continue
-			}
-			segs := imprint(fa[i], fb[j])
-			impA[i] = append(impA[i], interiorSegments(fa[i], segs)...)
-			impB[j] = append(impB[j], interiorSegments(fb[j], segs)...)
+			onA, onB := pairImprints(fa[i], fb[j])
+			impA[i] = append(impA[i], onA...)
+			impB[j] = append(impB[j], onB...)
 		}
 	}
 	return impA, impB

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"bytes"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Imprint provenance (M31-F02, Oblikovati/Oblikovati#1152). An intersection edge a boolean
+// creates is named today by an ordinal index (boolean_nonmanifold.go buildResolvedEdges), which
+// renumbers when an unrelated upstream edit reorders the stitched vertices — the topological
+// naming problem. The robust name is the pair of faces whose crossing produced the edge (Kripac
+// 1997). That pair is known where the imprint is computed (imprintAll), then discarded. This
+// file captures it: provenanceOf tags every intersection/overlap segment with the lineages of
+// the two faces that produced it, and edgeParents resolves a built edge back to that pair by
+// midpoint containment. F03 (#1153) consumes edgeParents to name the edges.
+
+// imprintSeg is an intersection (or coplanar-overlap) segment tagged with the lineages of the
+// two faces whose crossing produced it: owner is the face the segment was recorded on, other is
+// the crossing face. The unordered {owner, other} pair is the generating parentage of any edge
+// built along the segment.
+type imprintSeg struct {
+	a, b         math.Point3
+	owner, other topo.Lineage
+}
+
+// pairImprints returns the intersection/overlap segments of one crossing face pair, as recorded
+// on each face: onA lies interior to a, onB interior to b. Shared by imprintAll (which needs the
+// geometry to split faces) and provenanceOf (which needs the same segments to tag), so the two
+// can never drift — see the boundary-segment caveat on imprintAll.
+func pairImprints(a, b planarFace) (onA, onB [][2]math.Point3) {
+	if coplanar(a, b) {
+		return coplanarOverlapSegments(a, faceEdges3D(b)), coplanarOverlapSegments(b, faceEdges3D(a))
+	}
+	segs := imprint(a, b)
+	return interiorSegments(a, segs), interiorSegments(b, segs)
+}
+
+// provenanceOf tags every imprint segment of every crossing face pair with its generating face
+// lineages. Each segment is recorded twice (once per owning face, with owner/other swapped), so
+// an edge that survives on either side resolves to the same unordered pair; edgeParents
+// canonicalizes it. The list is the input F03 names boolean edges from.
+func provenanceOf(fa, fb []planarFace) []imprintSeg {
+	var prov []imprintSeg
+	for i := range fa {
+		for j := range fb {
+			onA, onB := pairImprints(fa[i], fb[j])
+			prov = appendTagged(prov, onA, fa[i].lineage, fb[j].lineage)
+			prov = appendTagged(prov, onB, fb[j].lineage, fa[i].lineage)
+		}
+	}
+	return prov
+}
+
+// appendTagged appends each segment tagged with the owner/other face lineages that produced it.
+func appendTagged(prov []imprintSeg, segs [][2]math.Point3, owner, other topo.Lineage) []imprintSeg {
+	for _, s := range segs {
+		prov = append(prov, imprintSeg{a: s[0], b: s[1], owner: owner, other: other})
+	}
+	return prov
+}
+
+// edgeParentTol is how far an edge midpoint may sit off an imprint segment and still count as
+// lying on it (model units, cm) — matches the imprint weld tolerance used elsewhere.
+const edgeParentTol = 1e-7
+
+// edgeParents returns the canonical {owner, other} face-lineage pair of the imprint segment the
+// edge p→q lies on, or ok=false when the edge is not an intersection edge (e.g. an original face
+// boundary, which lies on no imprint segment). The edge midpoint is used as the witness: a built
+// intersection edge is a sub-span of its imprint segment, so its midpoint lies on that segment.
+func edgeParents(p, q math.Point3, prov []imprintSeg) (topo.Lineage, topo.Lineage, bool) {
+	mid := p.TranslateBy(p.VectorTo(q).Scale(0.5))
+	for _, s := range prov {
+		if pointOnSegment3(mid, s.a, s.b, edgeParentTol) {
+			lo, hi := canonicalPair(s.owner, s.other)
+			return lo, hi, true
+		}
+	}
+	return topo.Lineage{}, topo.Lineage{}, false
+}
+
+// canonicalPair orders two lineages by their serialized key so the unordered pair {x, y} always
+// yields the same (lo, hi) regardless of which face the segment was recorded on — the property
+// that makes an intersection edge's name independent of operand order.
+func canonicalPair(x, y topo.Lineage) (lo, hi topo.Lineage) {
+	if bytes.Compare(x.Key(), y.Key()) <= 0 {
+		return x, y
+	}
+	return y, x
+}

--- a/kernel/brep/boolean_provenance_test.go
+++ b/kernel/brep/boolean_provenance_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/math"
+)
+
+// provFaces builds a named box and returns its planar faces — the operand form provenanceOf
+// consumes. Box face indices follow subd.Box: 1 = top (+Z), 4 = left (−X).
+func provFaces(name string, px, py, pz, sx, sy, sz float64) []planarFace {
+	m := subd.Box(sx, sy, sz)
+	for i := range m.Verts {
+		m.Verts[i] = m.Verts[i].TranslateBy(math.V3(px, py, pz))
+	}
+	fs, ok := facesOf(subd.ToBody(m, name))
+	if !ok {
+		panic("provFaces: box has a non-planar face")
+	}
+	return fs
+}
+
+// TestProvenanceTagsIntersectionEdgeWithBothParents: the slot rim where the tool's −X wall (x=3)
+// crosses the base's top (z=4) is an intersection edge; edgeParents must return BOTH generating
+// faces — the base top (base:face#1) and the tool left wall (tool:face#4) — canonically ordered.
+func TestProvenanceTagsIntersectionEdgeWithBothParents(t *testing.T) {
+	base := provFaces("base", 0, 0, 0, 16, 10, 4)
+	tool := provFaces("tool", 3, -1, 2, 4, 12, 4) // x∈[3,7], pokes through the top
+	prov := provenanceOf(base, tool)
+
+	// The rim edge runs along x=3, z=4 from y=0 to y=10.
+	lo, hi, ok := edgeParents(math.P3(3, 0, 4), math.P3(3, 10, 4), prov)
+	if !ok {
+		t.Fatal("the slot-rim intersection edge resolved to no parent faces")
+	}
+	got := []string{lo.String(), hi.String()}
+	want := []string{"base:face#1", "tool:face#4"} // canonical (sorted) order
+	if got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("edge parents = %v, want %v (base top × tool −X wall)", got, want)
+	}
+}
+
+// TestProvenanceParentPairIsOperandOrderIndependent: tagging the same crossing from either face
+// yields the same canonical pair, so an edge surviving on the A side or the B side gets one name.
+func TestProvenanceParentPairIsOperandOrderIndependent(t *testing.T) {
+	base := provFaces("base", 0, 0, 0, 16, 10, 4)
+	tool := provFaces("tool", 3, -1, 2, 4, 12, 4)
+
+	loAB, hiAB, okAB := edgeParents(math.P3(3, 0, 4), math.P3(3, 10, 4), provenanceOf(base, tool))
+	loBA, hiBA, okBA := edgeParents(math.P3(3, 0, 4), math.P3(3, 10, 4), provenanceOf(tool, base))
+	if !okAB || !okBA {
+		t.Fatal("rim edge unresolved in one operand order")
+	}
+	if loAB.String() != loBA.String() || hiAB.String() != hiBA.String() {
+		t.Errorf("parent pair depends on operand order: (base,tool)=%v,%v vs (tool,base)=%v,%v",
+			loAB.String(), hiAB.String(), loBA.String(), hiBA.String())
+	}
+}
+
+// TestProvenanceLeavesOriginalBoundaryEdgesUnparented: an edge that is not an intersection edge —
+// an original face boundary, lying on no imprint segment — resolves to no parent pair, so F03 can
+// fall back to carrying its source lineage rather than mislabelling it.
+func TestProvenanceLeavesOriginalBoundaryEdgesUnparented(t *testing.T) {
+	base := provFaces("base", 0, 0, 0, 16, 10, 4)
+	tool := provFaces("tool", 3, -1, 2, 4, 12, 4)
+	prov := provenanceOf(base, tool)
+
+	// A bottom-front boundary edge of the base (z=0, y=0) crosses no imprint.
+	if _, _, ok := edgeParents(math.P3(0, 0, 0), math.P3(16, 0, 0), prov); ok {
+		t.Error("an original boundary edge was wrongly attributed to an intersection")
+	}
+}
+
+// TestImprintAllMatchesProvenanceSegments pins that the imprintAll refactor still emits exactly
+// the segments provenanceOf tags (same shared pairImprints), so geometry and provenance cannot
+// drift: every segment imprintAll records on a face appears, tagged, in the provenance.
+func TestImprintAllMatchesProvenanceSegments(t *testing.T) {
+	base := provFaces("base", 0, 0, 0, 16, 10, 4)
+	tool := provFaces("tool", 3, -1, 2, 4, 12, 4)
+
+	impA, _ := imprintAll(base, tool)
+	prov := provenanceOf(base, tool)
+	tagged := map[string]bool{}
+	for _, s := range prov {
+		tagged[segKey(s.a, s.b)] = true
+	}
+	for i := range impA {
+		for _, s := range impA[i] {
+			if !tagged[segKey(s[0], s[1])] {
+				t.Errorf("imprintAll segment %v–%v on face %d is absent from the provenance", s[0], s[1], i)
+			}
+		}
+	}
+}
+
+// segKey is an endpoint-order-independent key for a 3D segment, rounded to the weld grid.
+func segKey(a, b math.Point3) string {
+	ka, kb := roundKey(a), roundKey(b)
+	if ka <= kb {
+		return ka + "|" + kb
+	}
+	return kb + "|" + ka
+}


### PR DESCRIPTION
## What
Foundation for the topological-naming fix: capture, at the point the boolean computes face–face imprints, **which two faces produced each intersection segment** — the data needed to name a generated edge by its generating parents instead of by an ordinal index.

- `imprintSeg` tags a segment with the `{owner, other}` face lineages that produced it.
- `provenanceOf(fa, fb)` returns every imprint/overlap segment, tagged.
- `edgeParents(p, q, prov)` resolves a built edge back to its canonical (operand-order-independent) parent pair by midpoint-on-segment containment — returning `ok=false` for an original boundary edge that lies on no imprint.

## Why
Intersection edges are currently named `Tok("brep","edge", idx)` in `buildResolvedEdges`; that ordinal renumbers when an unrelated upstream edit reorders the coordinate-canonical stitch (the gap pinned by #1151's harness). The parent pair, by contrast, is invariant. That pair is computed during `imprintAll` and then discarded — this PR keeps it.

## How (no geometry/key change)
`imprintAll` and `provenanceOf` now share one `pairImprints` helper, so the tagged segments can never drift from the ones that actually split the faces. `imprintAll` is refactored onto it with **no behaviour change**; the full `nopscad_*` regression and the whole `kernel/...` suite stay green. **No naming change in this PR** — F03 (#1153) consumes `edgeParents` to rename the edges and un-skip the harness's edge test.

### Note on decomposition
The threading of provenance into the stitch and the edge-rename are inseparable to test meaningfully (the rename is what makes the F01 edge test pass), so both land together in **F03**. F02 is the zero-risk capture + resolver + unit tests:
- intersection edge resolves to both parents (base top × tool −X wall);
- parent pair is operand-order independent;
- original boundary edges stay unparented;
- imprintAll segments all appear in the provenance (drift guard).

Internal to `kernel/brep`; no API/wire change.

Closes #1152. Part of milestone M31 (#33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)