### PR TITLE
M31-F03: Name boolean intersection edges by their parent faces

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -62,7 +62,7 @@ func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.
 	var kept []subFace
 	kept = append(kept, selectFaces(fa, impA, b, fb, op, false)...)
 	kept = append(kept, selectFaces(fb, impB, a, fa, op, true)...)
-	return stitch(kept)
+	return stitch(kept, provenanceOf(fa, fb))
 }
 
 // nudgeEps is the magnitude (cm) of the clearance opened at a tangent contact: above the weld
@@ -77,7 +77,7 @@ const nudgeEps = 1e-5
 // to the original (topologically resolved) result.
 func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.Vector3) (*topo.Body, error) {
 	fbp := translateFaces(fb, away.Scale(nudgeEps))
-	bp, _, err := stitch(planarToSubFaces(fbp))
+	bp, _, err := stitch(planarToSubFaces(fbp), nil) // materialising nudged B: no intersections to name
 	if err != nil || bp == nil {
 		return original, nil
 	}

--- a/kernel/brep/boolean_nonmanifold.go
+++ b/kernel/brep/boolean_nonmanifold.go
@@ -55,20 +55,42 @@ func allUsesPaired(uses map[[2]int][]loopEdgeUse) bool {
 // tangent/grazing contact between the operands — is split by resolveEdgeUses into manifold
 // pairs, each its own coincident edge between the same endpoints, so no edge ends up shared by
 // more than two faces.
-func buildResolvedEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, uses map[[2]int][]loopEdgeUse, faces []builtFace) map[[3]int]*topo.Edge {
+//
+// Each edge is named by its GENERATING PARENTS when prov resolves it to an intersection of two
+// faces (#1153) — a name invariant to the stitch's vertex ordering, unlike the ordinal index
+// used as a fallback for edges with no provenance (original face boundaries, and callers that
+// pass nil such as the drilled-hole path).
+func buildResolvedEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, uses map[[2]int][]loopEdgeUse, faces []builtFace, prov []imprintSeg) map[[3]int]*topo.Edge {
 	keys := sortedPairKeys(uses)
 	useEdge := make(map[[3]int]*topo.Edge)
+	dups := map[string]int{} // per parent-pair counter, so two edges of one pair never collide
 	idx := 0
 	for _, k := range keys {
 		for _, group := range resolveEdgeUses(k, uses[k], verts, faces) {
-			e := bld.AddEdge(geom.NewLineSegment(verts[k[0]], verts[k[1]]), tv[k[0]], tv[k[1]], topo.NewLineage(topo.Tok("brep", "edge", idx)))
-			idx++
+			lin := edgeLineage(verts[k[0]], verts[k[1]], prov, dups, &idx)
+			e := bld.AddEdge(geom.NewLineSegment(verts[k[0]], verts[k[1]]), tv[k[0]], tv[k[1]], lin)
 			for _, h := range group {
 				useEdge[[3]int{h.face, h.ring, h.pos}] = e
 			}
 		}
 	}
 	return useEdge
+}
+
+// edgeLineage returns an edge's lineage: its parent-pair name when prov attributes the edge p→q
+// to a face crossing, else the ordinal fallback (incrementing idx). dups disambiguates the rare
+// case of two edges sharing one parent pair.
+func edgeLineage(p, q math.Point3, prov []imprintSeg, dups map[string]int, idx *int) topo.Lineage {
+	lo, hi, ok := edgeParents(p, q, prov)
+	if !ok {
+		lin := topo.NewLineage(topo.Tok("brep", "edge", *idx))
+		*idx++
+		return lin
+	}
+	pairKey := string(lo.Key()) + "\x00" + string(hi.Key())
+	dup := dups[pairKey]
+	dups[pairKey]++
+	return intersectionLineage(lo, hi, dup)
 }
 
 // sortedPairKeys returns the vertex pairs in ascending order for stable edge lineage.

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -91,3 +91,24 @@ func canonicalPair(x, y topo.Lineage) (lo, hi topo.Lineage) {
 	}
 	return y, x
 }
+
+// intersectionSep separates the two parent lineages in an intersection edge's name. Its feature
+// id "brep" and role "x" (for "crossing") carry no separators, so the composed key parses
+// unambiguously (lo tokens / brep:x#0 / hi tokens).
+var intersectionSep = topo.Tok("brep", "x", 0)
+
+// intersectionLineage names an edge born where two faces cross by the canonical concatenation of
+// its two PARENT faces' lineages: lo / brep:x#0 / hi. Because the parents are the ORIGINAL faces
+// (captured before any split), this name is invariant to how those faces are later subdivided and
+// to the stitch's vertex ordering — the property the ordinal index lacked (#1153). `dup` is 0 for
+// the common one-edge-per-pair case; a second edge sharing the same parent pair (a face crossed
+// twice) gets dup>0, an interim disambiguator the geometric one in F05 (#1155) replaces.
+func intersectionLineage(lo, hi topo.Lineage, dup int) topo.Lineage {
+	toks := append([]topo.LineageToken{}, lo.Tokens()...)
+	toks = append(toks, intersectionSep)
+	toks = append(toks, hi.Tokens()...)
+	if dup > 0 {
+		toks = append(toks, topo.Tok("brep", "seg", dup))
+	}
+	return topo.NewLineage(toks...)
+}

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -21,7 +21,7 @@ import (
 // resolved (an edge used by more than two faces): operand B nudged along it separates from the
 // contact, so a re-run yields a non-degenerate, re-weld-safe result. It is the zero vector when
 // the result is already clean.
-func stitch(faces []subFace) (*topo.Body, math.Vector3, error) {
+func stitch(faces []subFace, prov []imprintSeg) (*topo.Body, math.Vector3, error) {
 	if len(faces) == 0 {
 		return nil, math.Vector3{}, nil
 	}
@@ -45,7 +45,7 @@ func stitch(faces []subFace) (*topo.Body, math.Vector3, error) {
 		}
 	}
 	reorientFaces(out, w.points)
-	body, away := assemble(w.points, out)
+	body, away := assemble(w.points, out, prov)
 	return body, away, nil
 }
 
@@ -153,14 +153,14 @@ type builtFace struct {
 // non-manifold edge if collapsed onto one edge — the uses are split into manifold pairs by
 // radial order around the edge (resolveEdgeUses), so each resulting edge is used exactly
 // twice. This keeps a tangent union a valid manifold solid (M20-F01).
-func assemble(verts []math.Point3, faces []builtFace) (*topo.Body, math.Vector3) {
+func assemble(verts []math.Point3, faces []builtFace, prov []imprintSeg) (*topo.Body, math.Vector3) {
 	uses := collectEdgeUses(faces)
 	bld := topo.NewBuilder(allUsesPaired(uses), topo.NewLineage(topo.Tok("brep", "body", 0)))
 	tv := make([]*topo.Vertex, len(verts))
 	for i, p := range verts {
 		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
 	}
-	useEdge := buildResolvedEdges(bld, verts, tv, uses, faces)
+	useEdge := buildResolvedEdges(bld, verts, tv, uses, faces, prov)
 	for fi, f := range faces {
 		specs := make([]topo.LoopSpec, len(f.rings))
 		for ri, r := range f.rings {

--- a/kernel/brep/imprint_public.go
+++ b/kernel/brep/imprint_public.go
@@ -64,7 +64,7 @@ func rebuildImprinted(faces []planarFace, imprints [][][2]math.Point3) (ImprintR
 		}
 		kept = append(kept, pieces...)
 	}
-	body, _, err := stitch(kept)
+	body, _, err := stitch(kept, nil) // imprint edges are tracked geometrically (collectImprintTouches)
 	if err != nil || body == nil {
 		return ImprintResult{}, err
 	}

--- a/kernel/brep/tnp_naming_test.go
+++ b/kernel/brep/tnp_naming_test.go
@@ -130,10 +130,11 @@ func TestGeneratedEdgeKeySurvivesUpstreamEdit(t *testing.T) {
 		t.Fatalf("rim edge not found at %v after the edit (harness invalid)", rimMidpoint)
 	}
 
+	// Fixed in F03 (#1153): the rim edge is named by its parent faces (base top × tool wall),
+	// so the lower-X prong no longer renumbers it.
 	if !bytes.Equal(key, e2.ReferenceKey()) {
-		t.Skip("pending #1153 (M31-F03): boolean-generated edges are named by their rank in the " +
-			"stitch's coordinate ordering, so adding a feature at a lower coordinate renumbers the " +
-			"key. Un-skip when parent-derived edge naming lands.")
+		t.Errorf("generated edge key changed across an unrelated edit:\n before = %q\n after  = %q",
+			key, e2.ReferenceKey())
 	}
 }
 


### PR DESCRIPTION
## What
The core topological-naming fix. A boolean's intersection edges are no longer named by an ordinal index but by their **generating parents** — the canonical pair of original faces whose crossing produced the edge.

Example — the slot rim where the base top meets a tool prong wall:
```
before:  \x02brep:edge#10        (rank in the stitch's coordinate ordering)
after:   \x02base:face#1/brep:x#0/p1:face#4   (base top × tool prong wall)
```

## Why
The ordinal renumbers when an unrelated upstream edit reorders the coordinate-canonical stitch (verified by #1151's harness: a lower-X prong moved the rim edge `edge#10 → edge#17`). A downstream reference — a fillet on that edge — then silently jumps or is lost. The parent pair is invariant: the parents are the *original, pre-split* faces, so the name survives however those faces are later subdivided and however the vertices are ordered.

## How
- Threaded F02's `prov` through `stitch → assemble → buildResolvedEdges`.
- Each edge resolves via `edgeParents`; an attributed edge gets `intersectionLineage(lo, hi)` (canonical `lo / brep:x#0 / hi`), an unattributed one (original boundary; nil-prov drill/nudge paths) keeps the ordinal fallback.
- A per-pair counter disambiguates the rare two-edges-one-pair case (a face crossed twice) until F05's geometric disambiguator (#1155) replaces it.

## Verification
- **Un-skips** the harness's edge-survival test, now a hard assertion: the tracked rim edge keeps its key across the lower-prong edit. ✅
- K1a face-survival control still passes; split-fragment test still skips (its fix is F04 #1154).
- Full `kernel/...`, `model/...`, `app/...` suites green — no other reference key or geometry changed (the whole `nopscad_*` corpus included).

Internal to `kernel/brep`; no API/wire change.

**Scope note:** intersection-*vertex* naming is deferred to **#1155** — a vertex also meets original boundary faces the imprint provenance doesn't track, so it needs that issue's geometric treatment. Commented there.

Closes #1153. Part of milestone M31 (#33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)