### PR TITLE
M31-F04: Name split-face fragments by their cutting faces

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -59,10 +59,11 @@ func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
 // opens a clean clearance), else the zero vector.
 func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.Vector3, error) {
 	impA, impB := imprintAll(fa, fb)
+	prov := provenanceOf(fa, fb)
 	var kept []subFace
-	kept = append(kept, selectFaces(fa, impA, b, fb, op, false)...)
-	kept = append(kept, selectFaces(fb, impB, a, fa, op, true)...)
-	return stitch(kept, provenanceOf(fa, fb))
+	kept = append(kept, selectFaces(fa, impA, b, fb, op, false, prov)...)
+	kept = append(kept, selectFaces(fb, impB, a, fa, op, true, prov)...)
+	return stitch(kept, prov)
 }
 
 // nudgeEps is the magnitude (cm) of the clearance opened at a tangent contact: above the weld
@@ -190,7 +191,7 @@ func minf(a, b float64) float64 {
 // selectFaces splits each face by its imprints and keeps the material sub-faces this
 // operation wants, classifying each via [classifySubFace]. `others` is the other solid's
 // face list (for the coplanar overlap test); `other` is the body itself (for the ray cast).
-func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, others []planarFace, op Op, isB bool) []subFace {
+func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, others []planarFace, op Op, isB bool, prov []imprintSeg) []subFace {
 	var kept []subFace
 	for i, f := range faces {
 		var fromFace []subFace
@@ -200,24 +201,39 @@ func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Bo
 			}
 		}
 		fromFace = mergeFilledHoles(fromFace)
-		// A face that survives as a single piece carries its source lineage unchanged, so
-		// its reference key is identical after the boolean (K1a). A face split into several
-		// kept pieces gives each a distinct child lineage (parent + split#k).
-		for k := range fromFace {
-			fromFace[k].fromB = isB // operand tag, so the stitch can fuse tangent contacts
-			if len(fromFace) == 1 {
-				fromFace[k].lineage = f.lineage
-			} else {
-				fromFace[k].lineage = splitLineage(f.lineage, k)
-			}
-		}
+		nameFragments(fromFace, f.lineage, isB, prov)
 		kept = append(kept, fromFace...)
 	}
 	return kept
 }
 
+// nameFragments assigns each kept piece of one source face its reference-key lineage. A face that
+// survives as a single piece keeps its source lineage unchanged (K1a — its key is identical after
+// the boolean). A face split into several pieces names each piece by the SET of cutting faces
+// bordering it (#1154), so the piece's identity is the geometry that bounds it rather than an
+// ordinal index that an upstream edit can reorder. A piece with no detectable cut border (a
+// degenerate split) and any duplicate cutting set fall back to an ordinal, deferred to F05.
+func nameFragments(fromFace []subFace, parent topo.Lineage, isB bool, prov []imprintSeg) {
+	dups := map[string]int{}
+	for k := range fromFace {
+		fromFace[k].fromB = isB // operand tag, so the stitch can fuse tangent contacts
+		if len(fromFace) == 1 {
+			fromFace[k].lineage = parent // K1a: a single survivor keeps its key
+			continue
+		}
+		cutting := fragmentCuttingFaces(parent, fromFace[k], prov)
+		if len(cutting) == 0 {
+			fromFace[k].lineage = splitLineage(parent, k) // no detectable border: ordinal fallback
+			continue
+		}
+		setKey := string(fragmentLineage(parent, cutting, 0).Key())
+		fromFace[k].lineage = fragmentLineage(parent, cutting, dups[setKey])
+		dups[setKey]++
+	}
+}
+
 // splitLineage derives a distinct child lineage for the k-th piece of a face split into
-// several by the boolean.
+// several by the boolean — the fallback when a piece's cutting border cannot be resolved.
 func splitLineage(parent topo.Lineage, k int) topo.Lineage {
 	return topo.NewLineage(append(parent.Tokens(), topo.Tok("brep", "split", k))...)
 }

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -4,6 +4,7 @@ package brep
 
 import (
 	"bytes"
+	"sort"
 
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -109,6 +110,70 @@ func intersectionLineage(lo, hi topo.Lineage, dup int) topo.Lineage {
 	toks = append(toks, hi.Tokens()...)
 	if dup > 0 {
 		toks = append(toks, topo.Tok("brep", "seg", dup))
+	}
+	return topo.NewLineage(toks...)
+}
+
+// fragmentMark prefixes a split-face fragment's cutting set; cuttingSep precedes each bordering
+// cutting face so the variable-length set parses unambiguously (the parent tokens, then
+// brep:cut#0, then one brep:by#0 + that face's tokens per cutting face).
+var (
+	fragmentMark = topo.Tok("brep", "cut", 0)
+	cuttingSep   = topo.Tok("brep", "by", 0)
+)
+
+// fragmentCuttingFaces returns the sorted, unique set of OTHER-operand face lineages whose imprint
+// borders the fragment sf of `parent` — the faces that cut this piece out (M31-F04, #1154). Only
+// segments recorded ON the parent (owner == parent) count, so each "other" is a genuine cutting
+// face. The set, not an ordinal index, identifies the piece, so it survives an upstream edit that
+// merely reorders the pieces.
+func fragmentCuttingFaces(parent topo.Lineage, sf subFace, prov []imprintSeg) []topo.Lineage {
+	found := map[string]topo.Lineage{}
+	collect := func(ring []math.Point3) {
+		for i := range ring {
+			mid := ring[i].TranslateBy(ring[i].VectorTo(ring[(i+1)%len(ring)]).Scale(0.5))
+			for _, s := range prov {
+				if bytes.Equal(s.owner.Key(), parent.Key()) && pointOnSegment3(mid, s.a, s.b, edgeParentTol) {
+					found[string(s.other.Key())] = s.other
+				}
+			}
+		}
+	}
+	collect(sf.outer)
+	for _, h := range sf.holes {
+		collect(h)
+	}
+	return sortedLineages(found)
+}
+
+// sortedLineages returns a lineage map's values ordered by key, so a cutting-face SET yields one
+// canonical sequence regardless of discovery order.
+func sortedLineages(m map[string]topo.Lineage) []topo.Lineage {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]topo.Lineage, len(keys))
+	for i, k := range keys {
+		out[i] = m[k]
+	}
+	return out
+}
+
+// fragmentLineage names a split-face fragment by its parent plus the canonical set of cutting
+// faces bordering it: parent / brep:cut#0 / (brep:by#0 / cuttingFace)*. `dup` disambiguates two
+// fragments of one face that share the same cutting set (a single straight cut halving a face) —
+// 0 in the common distinct-border case, an interim index F05 (#1155) replaces geometrically.
+func fragmentLineage(parent topo.Lineage, cutting []topo.Lineage, dup int) topo.Lineage {
+	toks := append([]topo.LineageToken{}, parent.Tokens()...)
+	toks = append(toks, fragmentMark)
+	for _, c := range cutting {
+		toks = append(toks, cuttingSep)
+		toks = append(toks, c.Tokens()...)
+	}
+	if dup > 0 {
+		toks = append(toks, topo.Tok("brep", "frag", dup))
 	}
 	return topo.NewLineage(toks...)
 }

--- a/kernel/brep/tnp_naming_test.go
+++ b/kernel/brep/tnp_naming_test.go
@@ -155,10 +155,11 @@ func TestSplitFaceFragmentKeySurvivesUpstreamEdit(t *testing.T) {
 		t.Fatalf("middle top fragment not found over %v after the edit (harness invalid)", middleFragmentPoint)
 	}
 
+	// Fixed in F04 (#1154): the middle fragment is named by the cutting faces bordering it
+	// (the two inner prong walls), a set the lower prong does not change, so its key is stable.
 	if !bytes.Equal(key, f2.ReferenceKey()) {
-		t.Skip("pending #1154 (M31-F04): split-face fragments are named by ordinal piece index " +
-			"(split#k), so an upstream edit that reorders pieces changes the key. Un-skip when " +
-			"bounding-set fragment naming lands.")
+		t.Errorf("split-face fragment key changed across an unrelated edit:\n before = %q\n after  = %q",
+			key, f2.ReferenceKey())
 	}
 }
 


### PR DESCRIPTION
## What
The second half of the generated-topology fix. A face split by a boolean no longer names its pieces by an ordinal index but by their **bounding cutting faces**.

Example — the comb's middle top fragment (between the two prongs):
```
before:  \x03base:face#1/brep:split#1                                     (ordinal piece index)
after:   \x03base:face#1/brep:cut#0/brep:by#0/p1:face#5/brep:by#0/p2:face#4   (base top, cut by the two prong walls)
```

## Why
`split#k` renumbers when an upstream edit reorders the pieces (verified by #1151's harness: adding a lower-X prong moved the middle fragment `split#1 → split#2`). A reference — a fillet/draft on that fragment — then jumps to the wrong piece. The cutting-face set is the geometry that bounds the piece, so it is invariant to piece ordering.

## How
- Threaded F02's `prov` into `selectFaces`; `nameFragments` assigns each piece its lineage.
- A piece's name = parent face / `brep:cut#0` / one `brep:by#0` + cutting-face tokens per **canonically sorted** bordering cutting face (read off the now parent-named intersection edges on its boundary, F03).
- A single survivor keeps its source lineage (**K1a** unchanged); a piece with no resolvable border or a duplicate cutting set (a straight cut halving a face) falls back to the ordinal, deferred to F05's geometric disambiguator (#1155).

## Verification
- **Un-skips** the harness's split-fragment test, now a hard assertion: the middle fragment keeps its key across the lower-prong edit. ✅
- Edge-survival (F03) and K1a controls still pass; the whole harness is now green with **no remaining skips**.
- Full `kernel/...`, `model/...`, `app/...` suites green (entire `nopscad_*` corpus included) — no other reference key or geometry changed.

Internal to `kernel/brep`; no API/wire change.

Closes #1154. Part of milestone M31 (#33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)