### PR TITLE
M31-F05: Geometric disambiguator + intersection-vertex naming

### DIFF
--- a/kernel/brep/boolean_nonmanifold.go
+++ b/kernel/brep/boolean_nonmanifold.go
@@ -59,38 +59,84 @@ func allUsesPaired(uses map[[2]int][]loopEdgeUse) bool {
 // Each edge is named by its GENERATING PARENTS when prov resolves it to an intersection of two
 // faces (#1153) — a name invariant to the stitch's vertex ordering, unlike the ordinal index
 // used as a fallback for edges with no provenance (original face boundaries, and callers that
-// pass nil such as the drilled-hole path).
+// pass nil such as the drilled-hole path). Several edges sharing one parent pair (a face crossed
+// twice) are disambiguated by their order ALONG the parents' intersection line, a
+// transform-invariant characteristic (#1155) rather than a build-order counter.
 func buildResolvedEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, uses map[[2]int][]loopEdgeUse, faces []builtFace, prov []imprintSeg) map[[3]int]*topo.Edge {
-	keys := sortedPairKeys(uses)
+	builds := planEdgeBuilds(verts, uses, faces, prov)
+	rankSamePairEdges(builds, prov)
 	useEdge := make(map[[3]int]*topo.Edge)
-	dups := map[string]int{} // per parent-pair counter, so two edges of one pair never collide
 	idx := 0
-	for _, k := range keys {
-		for _, group := range resolveEdgeUses(k, uses[k], verts, faces) {
-			lin := edgeLineage(verts[k[0]], verts[k[1]], prov, dups, &idx)
-			e := bld.AddEdge(geom.NewLineSegment(verts[k[0]], verts[k[1]]), tv[k[0]], tv[k[1]], lin)
-			for _, h := range group {
-				useEdge[[3]int{h.face, h.ring, h.pos}] = e
-			}
+	for i := range builds {
+		b := &builds[i]
+		e := bld.AddEdge(geom.NewLineSegment(verts[b.k[0]], verts[b.k[1]]), tv[b.k[0]], tv[b.k[1]], edgeBuildLineage(b, &idx))
+		for _, h := range b.group {
+			useEdge[[3]int{h.face, h.ring, h.pos}] = e
 		}
 	}
 	return useEdge
 }
 
-// edgeLineage returns an edge's lineage: its parent-pair name when prov attributes the edge p→q
-// to a face crossing, else the ordinal fallback (incrementing idx). dups disambiguates the rare
-// case of two edges sharing one parent pair.
-func edgeLineage(p, q math.Point3, prov []imprintSeg, dups map[string]int, idx *int) topo.Lineage {
-	lo, hi, ok := edgeParents(p, q, prov)
-	if !ok {
+// edgeBuild is one planned topo edge: its vertex pair, the half-edge uses it carries, its
+// midpoint, and the parent faces (when it is an intersection edge) plus its rank among edges of
+// the same parent pair.
+type edgeBuild struct {
+	k        [2]int
+	group    []loopEdgeUse
+	mid      math.Point3
+	lo, hi   topo.Lineage
+	parented bool
+	rank     int
+}
+
+// planEdgeBuilds enumerates the edges to create (resolving tangent contacts) with each one's
+// parent pair and midpoint — the input the geometric disambiguator ranks.
+func planEdgeBuilds(verts []math.Point3, uses map[[2]int][]loopEdgeUse, faces []builtFace, prov []imprintSeg) []edgeBuild {
+	var builds []edgeBuild
+	for _, k := range sortedPairKeys(uses) {
+		for _, group := range resolveEdgeUses(k, uses[k], verts, faces) {
+			p, q := verts[k[0]], verts[k[1]]
+			lo, hi, ok := edgeParents(p, q, prov)
+			builds = append(builds, edgeBuild{k: k, group: group, mid: p.TranslateBy(p.VectorTo(q).Scale(0.5)), lo: lo, hi: hi, parented: ok})
+		}
+	}
+	return builds
+}
+
+// rankSamePairEdges assigns each parented edge its rank among edges sharing the same parent pair,
+// ordered by the transform-invariant characteristic along the pair's intersection line. A lone
+// edge of a pair keeps rank 0 (no disambiguator); the common case is therefore untouched.
+func rankSamePairEdges(builds []edgeBuild, prov []imprintSeg) {
+	groups := map[string][]int{}
+	for i := range builds {
+		if builds[i].parented {
+			key := string(builds[i].lo.Key()) + "\x00" + string(builds[i].hi.Key())
+			groups[key] = append(groups[key], i)
+		}
+	}
+	for _, idxs := range groups {
+		if len(idxs) < 2 {
+			continue
+		}
+		d, ok := pairLineDir(builds[idxs[0]].lo, builds[idxs[0]].hi, prov)
+		sort.SliceStable(idxs, func(a, b int) bool {
+			return ok && lineCharacteristic(builds[idxs[a]].mid, d) < lineCharacteristic(builds[idxs[b]].mid, d)
+		})
+		for r, i := range idxs {
+			builds[i].rank = r
+		}
+	}
+}
+
+// edgeBuildLineage is an edge's lineage: its parent-pair name (with the disambiguating rank) when
+// it is an intersection edge, else the ordinal fallback (incrementing idx).
+func edgeBuildLineage(b *edgeBuild, idx *int) topo.Lineage {
+	if !b.parented {
 		lin := topo.NewLineage(topo.Tok("brep", "edge", *idx))
 		*idx++
 		return lin
 	}
-	pairKey := string(lo.Key()) + "\x00" + string(hi.Key())
-	dup := dups[pairKey]
-	dups[pairKey]++
-	return intersectionLineage(lo, hi, dup)
+	return intersectionLineage(b.lo, b.hi, b.rank)
 }
 
 // sortedPairKeys returns the vertex pairs in ascending order for stable edge lineage.

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -22,10 +22,13 @@ import (
 // imprintSeg is an intersection (or coplanar-overlap) segment tagged with the lineages of the
 // two faces whose crossing produced it: owner is the face the segment was recorded on, other is
 // the crossing face. The unordered {owner, other} pair is the generating parentage of any edge
-// built along the segment.
+// built along the segment. ownerN/otherN are those faces' outward normals — the geometry the F05
+// disambiguator (#1155) needs to order several edges that share one parent pair by a
+// transform-invariant characteristic.
 type imprintSeg struct {
-	a, b         math.Point3
-	owner, other topo.Lineage
+	a, b           math.Point3
+	owner, other   topo.Lineage
+	ownerN, otherN math.Vector3
 }
 
 // pairImprints returns the intersection/overlap segments of one crossing face pair, as recorded
@@ -49,17 +52,18 @@ func provenanceOf(fa, fb []planarFace) []imprintSeg {
 	for i := range fa {
 		for j := range fb {
 			onA, onB := pairImprints(fa[i], fb[j])
-			prov = appendTagged(prov, onA, fa[i].lineage, fb[j].lineage)
-			prov = appendTagged(prov, onB, fb[j].lineage, fa[i].lineage)
+			prov = appendTagged(prov, onA, fa[i], fb[j])
+			prov = appendTagged(prov, onB, fb[j], fa[i])
 		}
 	}
 	return prov
 }
 
-// appendTagged appends each segment tagged with the owner/other face lineages that produced it.
-func appendTagged(prov []imprintSeg, segs [][2]math.Point3, owner, other topo.Lineage) []imprintSeg {
+// appendTagged appends each segment tagged with the owner/other faces' lineages and normals.
+func appendTagged(prov []imprintSeg, segs [][2]math.Point3, owner, other planarFace) []imprintSeg {
 	for _, s := range segs {
-		prov = append(prov, imprintSeg{a: s[0], b: s[1], owner: owner, other: other})
+		prov = append(prov, imprintSeg{a: s[0], b: s[1],
+			owner: owner.lineage, other: other.lineage, ownerN: owner.normal, otherN: other.normal})
 	}
 	return prov
 }
@@ -112,6 +116,45 @@ func intersectionLineage(lo, hi topo.Lineage, dup int) topo.Lineage {
 		toks = append(toks, topo.Tok("brep", "seg", dup))
 	}
 	return topo.NewLineage(toks...)
+}
+
+// pairLineDir returns the intersection line's direction for the parent pair (lo, hi), derived
+// equivariantly from the two faces' normals (n_lo × n_hi) so it rotates and translates rigidly
+// with the geometry — the canonical axis along which the F05 disambiguator orders several edges
+// that share this parent pair. ok is false when the pair has no segment in prov or the normals
+// are parallel (no unique line).
+func pairLineDir(lo, hi topo.Lineage, prov []imprintSeg) (math.Vector3, bool) {
+	nLo, nHi, ok := pairNormals(lo, hi, prov)
+	if !ok {
+		return math.Vector3{}, false
+	}
+	d := nLo.Cross(nHi)
+	if d.LengthSquared() < 1e-18 {
+		return math.Vector3{}, false
+	}
+	return d.AsUnit().AsVector(), true
+}
+
+// pairNormals finds, in prov, the outward normals of the two faces named by the canonical pair
+// (lo, hi), mapping each seg's owner/other normal to the matching member of the pair.
+func pairNormals(lo, hi topo.Lineage, prov []imprintSeg) (nLo, nHi math.Vector3, ok bool) {
+	loK, hiK := lo.Key(), hi.Key()
+	for _, s := range prov {
+		switch {
+		case bytes.Equal(s.owner.Key(), loK) && bytes.Equal(s.other.Key(), hiK):
+			return s.ownerN, s.otherN, true
+		case bytes.Equal(s.owner.Key(), hiK) && bytes.Equal(s.other.Key(), loK):
+			return s.otherN, s.ownerN, true
+		}
+	}
+	return math.Vector3{}, math.Vector3{}, false
+}
+
+// lineCharacteristic projects p onto direction d — the transform-invariant scalar (a dot product
+// is preserved by rotation; differences of it are preserved by translation) that orders edges
+// sharing one parent pair along their common intersection line.
+func lineCharacteristic(p math.Point3, d math.Vector3) float64 {
+	return float64(d.X)*float64(p.X) + float64(d.Y)*float64(p.Y) + float64(d.Z)*float64(p.Z)
 }
 
 // fragmentMark prefixes a split-face fragment's cutting set; cuttingSep precedes each bordering

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -220,3 +220,77 @@ func fragmentLineage(parent topo.Lineage, cutting []topo.Lineage, dup int) topo.
 	}
 	return topo.NewLineage(toks...)
 }
+
+// vertexMark prefixes an intersection vertex's meeting-face set; meetSep precedes each face so the
+// variable-length set parses unambiguously (brep:meet#0, then one brep:at#0 + that face's tokens).
+var (
+	vertexMark = topo.Tok("brep", "meet", 0)
+	meetSep    = topo.Tok("brep", "at", 0)
+)
+
+// vertexLineages names each welded vertex (M31-F05, #1155). An INTERSECTION vertex — one lying on
+// an imprint segment, i.e. created by the boolean — is named by the order-independent SET of faces
+// meeting at it, each now carrying a parent-derived name, so the vertex name is stable across
+// edits and rigid placements. A vertex on no imprint (an original corner) keeps its ordinal index
+// (its welder position v), so the change is confined to the topology the boolean creates.
+func vertexLineages(verts []math.Point3, faces []builtFace, prov []imprintSeg) []topo.Lineage {
+	sets := vertexFaceSets(verts, faces)
+	out := make([]topo.Lineage, len(verts))
+	dups := map[string]int{}
+	for v := range verts {
+		if len(sets[v]) == 0 || !pointOnAnyImprint(verts[v], prov) {
+			out[v] = topo.NewLineage(topo.Tok("brep", "vertex", v))
+			continue
+		}
+		setKey := string(vertexLineage(sets[v], 0).Key())
+		out[v] = vertexLineage(sets[v], dups[setKey])
+		dups[setKey]++
+	}
+	return out
+}
+
+// vertexFaceSets returns, per welded vertex, the sorted unique lineages of the faces whose loops
+// use it — the set that identifies an intersection vertex.
+func vertexFaceSets(verts []math.Point3, faces []builtFace) [][]topo.Lineage {
+	seen := make([]map[string]topo.Lineage, len(verts))
+	for v := range verts {
+		seen[v] = map[string]topo.Lineage{}
+	}
+	for _, f := range faces {
+		for _, ring := range f.rings {
+			for _, v := range ring {
+				seen[v][string(f.lineage.Key())] = f.lineage
+			}
+		}
+	}
+	out := make([][]topo.Lineage, len(verts))
+	for v := range verts {
+		out[v] = sortedLineages(seen[v])
+	}
+	return out
+}
+
+// pointOnAnyImprint reports whether p lies on some imprint segment — the test for "this vertex was
+// created where the operands cross" (endpoints included, since a vertex is a segment endpoint).
+func pointOnAnyImprint(p math.Point3, prov []imprintSeg) bool {
+	for _, s := range prov {
+		if pointOnSegment3(p, s.a, s.b, edgeParentTol) {
+			return true
+		}
+	}
+	return false
+}
+
+// vertexLineage names an intersection vertex by the canonical set of faces meeting at it:
+// brep:meet#0 / (brep:at#0 / face)*. `dup` disambiguates two vertices with the same meeting set.
+func vertexLineage(faces []topo.Lineage, dup int) topo.Lineage {
+	toks := []topo.LineageToken{vertexMark}
+	for _, f := range faces {
+		toks = append(toks, meetSep)
+		toks = append(toks, f.Tokens()...)
+	}
+	if dup > 0 {
+		toks = append(toks, topo.Tok("brep", "vtx", dup))
+	}
+	return topo.NewLineage(toks...)
+}

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -79,7 +79,7 @@ const edgeParentTol = 1e-7
 func edgeParents(p, q math.Point3, prov []imprintSeg) (topo.Lineage, topo.Lineage, bool) {
 	mid := p.TranslateBy(p.VectorTo(q).Scale(0.5))
 	for _, s := range prov {
-		if pointOnSegment3(mid, s.a, s.b, edgeParentTol) {
+		if pointOnSegment3(mid, s.a, s.b) {
 			lo, hi := canonicalPair(s.owner, s.other)
 			return lo, hi, true
 		}
@@ -176,7 +176,7 @@ func fragmentCuttingFaces(parent topo.Lineage, sf subFace, prov []imprintSeg) []
 		for i := range ring {
 			mid := ring[i].TranslateBy(ring[i].VectorTo(ring[(i+1)%len(ring)]).Scale(0.5))
 			for _, s := range prov {
-				if bytes.Equal(s.owner.Key(), parent.Key()) && pointOnSegment3(mid, s.a, s.b, edgeParentTol) {
+				if bytes.Equal(s.owner.Key(), parent.Key()) && pointOnSegment3(mid, s.a, s.b) {
 					found[string(s.other.Key())] = s.other
 				}
 			}
@@ -274,7 +274,7 @@ func vertexFaceSets(verts []math.Point3, faces []builtFace) [][]topo.Lineage {
 // created where the operands cross" (endpoints included, since a vertex is a segment endpoint).
 func pointOnAnyImprint(p math.Point3, prov []imprintSeg) bool {
 	for _, s := range prov {
-		if pointOnSegment3(p, s.a, s.b, edgeParentTol) {
+		if pointOnSegment3(p, s.a, s.b) {
 			return true
 		}
 	}

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -157,8 +157,9 @@ func assemble(verts []math.Point3, faces []builtFace, prov []imprintSeg) (*topo.
 	uses := collectEdgeUses(faces)
 	bld := topo.NewBuilder(allUsesPaired(uses), topo.NewLineage(topo.Tok("brep", "body", 0)))
 	tv := make([]*topo.Vertex, len(verts))
+	vlin := vertexLineages(verts, faces, prov)
 	for i, p := range verts {
-		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
+		tv[i] = bld.AddVertex(p, vlin[i])
 	}
 	useEdge := buildResolvedEdges(bld, verts, tv, uses, faces, prov)
 	for fi, f := range faces {

--- a/kernel/brep/imprint_public.go
+++ b/kernel/brep/imprint_public.go
@@ -116,23 +116,25 @@ func edgeOnSegments(e *topo.Edge, segs [][2]math.Point3) bool {
 	lo, hi := c.Domain()
 	mid := c.PointAt((lo + hi) / 2)
 	for _, s := range segs {
-		if pointOnSegment3(mid, s[0], s[1], 1e-7) {
+		if pointOnSegment3(mid, s[0], s[1]) {
 			return true
 		}
 	}
 	return false
 }
 
-func pointOnSegment3(p, a, b math.Point3, tol float64) bool {
+// pointOnSegment3 reports whether p lies on the segment a→b within edgeParentTol
+// (the boolean weld tolerance shared by every imprint-segment proximity test).
+func pointOnSegment3(p, a, b math.Point3) bool {
 	ab := a.VectorTo(b)
 	denom := float64(ab.LengthSquared())
 	if denom == 0 {
-		return float64(p.DistanceTo(a)) <= tol
+		return float64(p.DistanceTo(a)) <= edgeParentTol
 	}
 	t := float64(a.VectorTo(p).Dot(ab)) / denom
 	if t < 0 || t > 1 {
 		return false
 	}
 	on := a.TranslateBy(ab.Scale(math.Scalar(t)))
-	return float64(p.DistanceTo(on)) <= tol
+	return float64(p.DistanceTo(on)) <= edgeParentTol
 }

--- a/kernel/brep/tnp_naming_test.go
+++ b/kernel/brep/tnp_naming_test.go
@@ -232,3 +232,38 @@ func TestSamePairEdgesGetDistinctTransformInvariantKeys(t *testing.T) {
 			lo0, loT, hi0, hiT)
 	}
 }
+
+// vertexKeyAt returns the reference key of the body vertex at p, if any.
+func vertexKeyAt(b *topo.Body, p math.Point3) ([]byte, bool) {
+	for _, v := range b.Vertices() {
+		if float64(v.Point().DistanceTo(p)) < 1e-9 {
+			return v.ReferenceKey(), true
+		}
+	}
+	return nil, false
+}
+
+// TestIntersectionVertexNamedByMeetingFaces (F05, #1155): a vertex the boolean creates is named by
+// the SET of faces meeting at it, so its key is meaningful and invariant under a rigid placement —
+// unlike the raw ordinal it carried before. A plain original corner keeps its ordinal.
+func TestIntersectionVertexNamedByMeetingFaces(t *testing.T) {
+	// (8,0,4): the slot's −X wall, the top, and the front face meet — an intersection vertex.
+	k0, ok0 := vertexKeyAt(holedSlotWall(t, 0, 0), math.P3(8, 0, 4))
+	if !ok0 {
+		t.Fatal("expected an intersection vertex at the slot rim corner (harness invalid)")
+	}
+	if !bytes.Contains(k0, []byte("brep:meet")) {
+		t.Errorf("intersection vertex is not named by its meeting faces: %q", k0)
+	}
+
+	kT, okT := vertexKeyAt(holedSlotWall(t, 1000, 2000), math.P3(1008, 2000, 4))
+	if !okT || !bytes.Equal(k0, kT) {
+		t.Errorf("intersection vertex key is not transform-invariant:\n at origin   %q\n translated  %q", k0, kT)
+	}
+
+	// An original plate corner lies on no imprint, so it keeps an ordinal vertex key.
+	corner, ok := vertexKeyAt(holedSlotWall(t, 0, 0), math.P3(0, 0, 0))
+	if !ok || !bytes.Contains(corner, []byte("brep:vertex#")) {
+		t.Errorf("an original corner should keep an ordinal vertex key, got %q (found=%v)", corner, ok)
+	}
+}

--- a/kernel/brep/tnp_naming_test.go
+++ b/kernel/brep/tnp_naming_test.go
@@ -182,3 +182,53 @@ func TestSurvivingFaceKeyIsTheWorkingBaseline(t *testing.T) {
 		t.Fatal("an untouched side face's key did not survive the edit — the K1a baseline is broken")
 	}
 }
+
+// holedSlotWall builds the one geometry where two edges share a parent pair: a plate with a
+// through-hole (x∈[5,15], y∈[3,7]) whose top face is non-convex, then a slot (x∈[8,12]) whose −X
+// wall at x=8 crosses that top in TWO disjoint intervals (y∈[0,3] and y∈[7,10]). Both edges are
+// (plate top × slot wall), so they need the F05 disambiguator. The scene is offset by (ox,oy) to
+// probe transform-invariance.
+func holedSlotWall(t *testing.T, ox, oy float64) *topo.Body {
+	t.Helper()
+	plate := cutDifference(t, boxNamed("plate", ox, oy, 0, 20, 10, 4), boxNamed("hole", ox+5, oy+3, -1, 10, 4, 6))
+	return cutDifference(t, plate, boxNamed("slot", ox+8, oy-1, 2, 4, 12, 4))
+}
+
+// wallEdgeKeysAtX8 returns the reference keys of the two top-face (z=4) edges on the slot's −X
+// wall (x=ox+8), split by whether they lie below or above the hole, so the SAME geometric edge is
+// identified across two builds.
+func wallEdgeKeysAtX8(b *topo.Body, ox, oy float64) (lower, upper []byte) {
+	for _, e := range b.Edges() {
+		m := edgeMidpoint(e)
+		if stdmath.Abs(float64(m.Z-4)) > 1e-6 || stdmath.Abs(float64(m.X-(ox+8))) > 1e-6 {
+			continue
+		}
+		if float64(m.Y) < oy+5 {
+			lower = e.ReferenceKey()
+		} else {
+			upper = e.ReferenceKey()
+		}
+	}
+	return lower, upper
+}
+
+// TestSamePairEdgesGetDistinctTransformInvariantKeys (F05, #1155): two intersection edges sharing
+// one parent pair must get DISTINCT keys, and the disambiguation — their order along the parents'
+// intersection line — must be invariant under a rigid translation of the whole part (the property
+// occurrence placement needs, #735), unlike a build-order counter.
+func TestSamePairEdgesGetDistinctTransformInvariantKeys(t *testing.T) {
+	lo0, hi0 := wallEdgeKeysAtX8(holedSlotWall(t, 0, 0), 0, 0)
+	if lo0 == nil || hi0 == nil {
+		t.Fatal("expected two same-pair wall edges below and above the hole (harness invalid)")
+	}
+	if bytes.Equal(lo0, hi0) {
+		t.Errorf("the two same-parent-pair edges share one key (collision):\n %q", lo0)
+	}
+
+	// Same part translated far from the origin: each edge must keep its key.
+	loT, hiT := wallEdgeKeysAtX8(holedSlotWall(t, 1000, 2000), 1000, 2000)
+	if !bytes.Equal(lo0, loT) || !bytes.Equal(hi0, hiT) {
+		t.Errorf("same-pair edge keys are not transform-invariant:\n lower %q -> %q\n upper %q -> %q",
+			lo0, loT, hi0, hiT)
+	}
+}


### PR DESCRIPTION
## What
Two commits that remove the **last coordinate-ordinals** from boolean-generated topology.

### 1. Geometric edge disambiguator
When two intersection edges share one parent pair (a face crossed twice — e.g. a slot wall meeting a *holed* top face in two intervals), F03 disambiguated them with a build-order counter. Replace it with **Kripac's characteristic point**: order the edges by their position **along the parents' intersection line**, whose direction is derived equivariantly from the two parent-face normals (`n_lo × n_hi`, now carried on the imprint provenance). A dot product is preserved by rotation and its differences by translation, so the ordering is invariant under any rigid placement (#735) — a build-order counter is not. A lone edge of a pair is untouched (rank 0).

### 2. Intersection-vertex naming (absorbed from F03)
A vertex the boolean creates carried the raw ordinal `Tok("brep","vertex",i)`. Name an intersection vertex (one lying on an imprint) by the order-independent **set of faces meeting at it**: `brep:meet#0 / (brep:at#0 / face)*`. Example:
```
\x01brep:vertex#7                                          (before)
\x01brep:meet#0/brep:at#0/base:face#1/.../brep:at#0/p1:face#4   (after)
```
An original corner (on no imprint) keeps its ordinal welder index, so no original-corner key moves.

## Why
These were the residual coordinate ordinals in generated naming — correct today but, in principle, reorderable by the same lower-coordinate insertion that motivated the milestone. With this, **edges, split fragments, and vertices are all named by their generators**.

## Verification
- New test builds the one geometry that yields two same-pair edges and asserts they get **distinct keys** that survive translating the whole part far from the origin.
- New test asserts an intersection vertex is **named by its meeting faces** and is transform-invariant, while an original corner stays ordinal.
- All prior M31 tests (edge/fragment survival, K1a) still pass; full `kernel/...`, `model/...`, `app/...` suites green.

**Honesty note:** I could not construct a case where the *interim* dup-counter actually misbehaves (it was collision-free and empirically transform-invariant), so these tests pin the new behaviour's properties (distinctness, transform-invariance, determinism) rather than reproducing a failure — per the agreed scope of doing the principled fix anyway.

Internal to `kernel/brep`; no API/wire change.

Closes #1155. Part of milestone M31 (#33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)