### PR TITLE
M31-F06: Tiered reference binding — ancestral/geometric fallback to Warning health

### DIFF
--- a/model/health/health.go
+++ b/model/health/health.go
@@ -58,3 +58,9 @@ func (h Health) OK() bool { return h.Status == OK }
 func Sicken(reason string) Health {
 	return Health{Status: Sick, Reason: reason}
 }
+
+// Warn returns a Warning health carrying reason — usable but flagged for review
+// (e.g. a reference auto-healed to a surviving sibling rather than its exact entity).
+func Warn(reason string) Health {
+	return Health{Status: Warning, Reason: reason}
+}

--- a/model/health/health_test.go
+++ b/model/health/health_test.go
@@ -24,6 +24,16 @@ func TestSicken(t *testing.T) {
 	}
 }
 
+func TestWarn(t *testing.T) {
+	h := Warn("reference auto-healed via ancestral match")
+	if h.OK() || h.Status != Warning {
+		t.Errorf("Warn status = %v, want warning", h.Status)
+	}
+	if h.Reason != "reference auto-healed via ancestral match" {
+		t.Errorf("Warn reason = %q", h.Reason)
+	}
+}
+
 func TestStatusStrings(t *testing.T) {
 	cases := map[Status]string{OK: "ok", Warning: "warning", Sick: "sick", Suppressed: "suppressed", Status(9): "unknown"}
 	for s, want := range cases {

--- a/model/identity/binding.go
+++ b/model/identity/binding.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import (
+	"bytes"
+
+	"oblikovati.org/math"
+)
+
+// fallbackMatch recovers a reference whose exact entity is gone by degrading
+// through the literature's tiers (Kripac 1997; FreeCAD 1.0 element maps): a lone
+// surviving sibling that shares the key's parent lineage binds ancestrally; when
+// several siblings survive, geometric nearness to the key's mint-time anchor picks
+// one. Both are auto-healed (caller maps them to Warning, not Sick). A key with no
+// recorded parent — a root lineage, or a key reloaded from disk before F07 versions
+// the encoding — has nothing to fall back to and stays MatchNone (M31-F06, #1156).
+func fallbackMatch(k RefKey, ents []Entity) (Entity, MatchType) {
+	if !k.parent.ok {
+		return nil, MatchNone
+	}
+	siblings := survivingSiblings(k, ents)
+	switch len(siblings) {
+	case 0:
+		return nil, MatchNone
+	case 1:
+		return siblings[0], MatchAncestral
+	default:
+		return nearestSibling(k, siblings)
+	}
+}
+
+// survivingSiblings returns the entities of the key's kind whose lineage declares
+// the same parent as the key — the candidates for ancestral recovery. Entities
+// whose lineage cannot name a parent are not siblings and are skipped.
+func survivingSiblings(k RefKey, ents []Entity) []Entity {
+	var out []Entity
+	for _, e := range ents {
+		if e.EntityKind() != k.kind {
+			continue
+		}
+		al, ok := e.Lineage().(AncestralLineage)
+		if ok && bytes.Equal(al.ParentKey(), k.parent.key) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// nearestSibling disambiguates several same-parent siblings by distance to the
+// key's mint-time anchor, returning MatchGeometric for a clear winner. Without an
+// anchor, with no anchored siblings, or when the two closest tie, the choice is not
+// defensible and the reference stays lost (MatchNone) rather than binding wrongly.
+func nearestSibling(k RefKey, siblings []Entity) (Entity, MatchType) {
+	if !k.anchor.ok {
+		return nil, MatchNone
+	}
+	best, second := closestTwo(k.anchor.point, siblings)
+	if best.entity == nil {
+		return nil, MatchNone
+	}
+	if second.entity != nil && best.dist == second.dist {
+		return nil, MatchNone
+	}
+	return best.entity, MatchGeometric
+}
+
+// rankedSibling pairs a sibling with its squared distance to the anchor.
+type rankedSibling struct {
+	entity Entity
+	dist   math.Scalar
+}
+
+// closestTwo returns the nearest and second-nearest anchored siblings to p. A
+// returned entry has a nil entity when fewer than that many siblings expose an
+// anchor; an equal best/second distance signals an unbreakable geometric tie.
+func closestTwo(p math.Point3, siblings []Entity) (best, second rankedSibling) {
+	for _, e := range siblings {
+		d, ok := anchorDistanceSq(p, e)
+		if !ok {
+			continue
+		}
+		cand := rankedSibling{entity: e, dist: d}
+		switch {
+		case best.entity == nil || d < best.dist:
+			second = best
+			best = cand
+		case second.entity == nil || d < second.dist:
+			second = cand
+		}
+	}
+	return best, second
+}
+
+// anchorDistanceSq returns the squared distance from p to e's anchor, or false when
+// e exposes no anchor (such a sibling cannot be ranked geometrically).
+func anchorDistanceSq(p math.Point3, e Entity) (math.Scalar, bool) {
+	ae, ok := e.(AnchoredEntity)
+	if !ok {
+		return 0, false
+	}
+	q, ok := ae.Anchor()
+	if !ok {
+		return 0, false
+	}
+	v := p.VectorTo(q)
+	return v.LengthSquared(), true
+}

--- a/model/identity/binding_test.go
+++ b/model/identity/binding_test.go
@@ -50,6 +50,15 @@ func sibling(parent, child string, p math.Point3, located bool) kinNode {
 	}
 }
 
+// equidistantSiblings is two anchored ext#1 siblings, symmetric about the origin —
+// the ambiguous case both the tie and no-anchor tests model.
+func equidistantSiblings() []Entity {
+	return []Entity{
+		sibling("ext#1", "edge#7", math.P3(5, 0, 0), true),
+		sibling("ext#1", "edge#8", math.P3(-5, 0, 0), true),
+	}
+}
+
 func mintKey(t *testing.T, m *KeyManager, ctx ContextID, e Entity) RefKey {
 	t.Helper()
 	k, err := m.GetReferenceKey(ctx, e)
@@ -59,14 +68,23 @@ func mintKey(t *testing.T, m *KeyManager, ctx ContextID, e Entity) RefKey {
 	return k
 }
 
+// mintFor stands up a manager holding entities, keys keyed (which must be one of
+// them), and returns the manager, its mutable source, and the key — the common
+// arrange step for every rebind test. Mutate src.entities to model the edit, then
+// BindKeyToObject(key).
+func mintFor(t *testing.T, keyed Entity, entities ...Entity) (*KeyManager, *fakeSource, RefKey) {
+	t.Helper()
+	m := NewKeyManager()
+	src := &fakeSource{entities: entities}
+	ctx := m.CreateKeyContext(src)
+	return m, src, mintKey(t, m, ctx, keyed)
+}
+
 // --- ancestral tier ---
 
 func TestAncestralBindsLoneSurvivingSibling(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
-	src := &fakeSource{entities: []Entity{keyed, sibling("ext#1", "edge#4", math.P3(0, 0, 0), false)}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed, sibling("ext#1", "edge#4", math.P3(0, 0, 0), false))
 
 	// The exact edge#3 is gone; one sibling under ext#1 survives (renamed edge#9).
 	src.entities = []Entity{sibling("ext#1", "edge#9", math.P3(0, 0, 0), false)}
@@ -81,11 +99,8 @@ func TestAncestralBindsLoneSurvivingSibling(t *testing.T) {
 }
 
 func TestAncestralMissWhenNoSiblingSharesParent(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
 	// Survivor belongs to a different parent — not a sibling, so the reference is lost.
 	src.entities = []Entity{sibling("ext#2", "edge#3", math.P3(0, 0, 0), false)}
@@ -96,11 +111,8 @@ func TestAncestralMissWhenNoSiblingSharesParent(t *testing.T) {
 }
 
 func TestRootLineageHasNoAncestralFallback(t *testing.T) {
-	m := NewKeyManager()
 	keyed := kinNode{kind: KindFace, lin: tokenLineage{key: "base", parent: ""}}
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
 	src.entities = []Entity{kinNode{kind: KindFace, lin: tokenLineage{key: "base2", parent: ""}}}
 
@@ -110,11 +122,8 @@ func TestRootLineageHasNoAncestralFallback(t *testing.T) {
 }
 
 func TestAncestralSiblingMustMatchKind(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
 	// Same parent, but a vertex — not a candidate for an edge key.
 	src.entities = []Entity{kinNode{kind: KindVertex, lin: tokenLineage{key: "ext#1/vert#0", parent: "ext#1"}}}
@@ -127,11 +136,8 @@ func TestAncestralSiblingMustMatchKind(t *testing.T) {
 // --- geometric tier ---
 
 func TestGeometricPicksNearestAmbiguousSibling(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(10, 0, 0), true)
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
 	// Exact gone; two siblings survive — disambiguate by nearness to the mint anchor.
 	far := sibling("ext#1", "edge#7", math.P3(-10, 0, 0), true)
@@ -148,17 +154,11 @@ func TestGeometricPicksNearestAmbiguousSibling(t *testing.T) {
 }
 
 func TestGeometricMissOnEquidistantTie(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), true)
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
 	// Two equidistant siblings — no defensible winner.
-	src.entities = []Entity{
-		sibling("ext#1", "edge#7", math.P3(5, 0, 0), true),
-		sibling("ext#1", "edge#8", math.P3(-5, 0, 0), true),
-	}
+	src.entities = equidistantSiblings()
 
 	if _, match := m.BindKeyToObject(key); match != MatchNone {
 		t.Fatalf("match = %v, want none (geometric tie is not defensible)", match)
@@ -166,16 +166,10 @@ func TestGeometricMissOnEquidistantTie(t *testing.T) {
 }
 
 func TestGeometricMissWithoutAnchor(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false) // no anchor captured
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
-	src.entities = []Entity{
-		sibling("ext#1", "edge#7", math.P3(5, 0, 0), true),
-		sibling("ext#1", "edge#8", math.P3(-5, 0, 0), true),
-	}
+	src.entities = equidistantSiblings()
 
 	if _, match := m.BindKeyToObject(key); match != MatchNone {
 		t.Fatalf("match = %v, want none (no anchor to disambiguate)", match)
@@ -185,11 +179,8 @@ func TestGeometricMissWithoutAnchor(t *testing.T) {
 // --- exact path is unchanged by the new tiers ---
 
 func TestExactStillWinsOverSiblings(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), true)
-	src := &fakeSource{entities: []Entity{keyed, sibling("ext#1", "edge#4", math.P3(1, 0, 0), true)}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed, sibling("ext#1", "edge#4", math.P3(1, 0, 0), true))
 
 	// edge#3 still present alongside its sibling — exact must win.
 	src.entities = []Entity{sibling("ext#1", "edge#4", math.P3(1, 0, 0), true), keyed}
@@ -205,11 +196,8 @@ func TestExactStillWinsOverSiblings(t *testing.T) {
 // --- health policy: fallback is Warning, true loss is Sick ---
 
 func TestResolveWarnsOnFallbackAndSickensOnLoss(t *testing.T) {
-	m := NewKeyManager()
 	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
-	src := &fakeSource{entities: []Entity{keyed}}
-	ctx := m.CreateKeyContext(src)
-	key := mintKey(t, m, ctx, keyed)
+	m, src, key := mintFor(t, keyed, keyed)
 
 	// Lone sibling survives → ancestral → Warning, entity returned.
 	src.entities = []Entity{sibling("ext#1", "edge#9", math.P3(0, 0, 0), false)}

--- a/model/identity/binding_test.go
+++ b/model/identity/binding_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+)
+
+// --- fakes exercising the optional fallback capabilities (M31-F06) ---
+
+// tokenLineage is a "/"-delimited lineage (parent = all but the last token) that
+// exposes its parent for ancestral matching, modelling kernel/topo lineage keys.
+type tokenLineage struct {
+	key    string
+	parent string // "" means a root with no parent
+}
+
+func (l tokenLineage) LineageKey() []byte { return []byte(l.key) }
+func (l tokenLineage) ParentKey() []byte {
+	if l.parent == "" {
+		return nil
+	}
+	return []byte(l.parent)
+}
+
+// kinNode is an entity with a token lineage and an optional geometric anchor.
+type kinNode struct {
+	kind    EntityKind
+	lin     tokenLineage
+	at      math.Point3
+	located bool
+}
+
+func (e kinNode) EntityKind() EntityKind { return e.kind }
+func (e kinNode) Lineage() Lineage       { return e.lin }
+func (e kinNode) Anchor() (math.Point3, bool) {
+	return e.at, e.located
+}
+
+// sibling builds a face whose lineage is parent/child, optionally anchored at p.
+func sibling(parent, child string, p math.Point3, located bool) kinNode {
+	return kinNode{
+		kind:    KindFace,
+		lin:     tokenLineage{key: parent + "/" + child, parent: parent},
+		at:      p,
+		located: located,
+	}
+}
+
+func mintKey(t *testing.T, m *KeyManager, ctx ContextID, e Entity) RefKey {
+	t.Helper()
+	k, err := m.GetReferenceKey(ctx, e)
+	if err != nil {
+		t.Fatalf("GetReferenceKey: %v", err)
+	}
+	return k
+}
+
+// --- ancestral tier ---
+
+func TestAncestralBindsLoneSurvivingSibling(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
+	src := &fakeSource{entities: []Entity{keyed, sibling("ext#1", "edge#4", math.P3(0, 0, 0), false)}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// The exact edge#3 is gone; one sibling under ext#1 survives (renamed edge#9).
+	src.entities = []Entity{sibling("ext#1", "edge#9", math.P3(0, 0, 0), false)}
+
+	got, match := m.BindKeyToObject(key)
+	if match != MatchAncestral {
+		t.Fatalf("match = %v, want ancestral", match)
+	}
+	if string(got.Lineage().LineageKey()) != "ext#1/edge#9" {
+		t.Errorf("bound to %q, want ext#1/edge#9", got.Lineage().LineageKey())
+	}
+}
+
+func TestAncestralMissWhenNoSiblingSharesParent(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// Survivor belongs to a different parent — not a sibling, so the reference is lost.
+	src.entities = []Entity{sibling("ext#2", "edge#3", math.P3(0, 0, 0), false)}
+
+	if _, match := m.BindKeyToObject(key); match != MatchNone {
+		t.Fatalf("match = %v, want none", match)
+	}
+}
+
+func TestRootLineageHasNoAncestralFallback(t *testing.T) {
+	m := NewKeyManager()
+	keyed := kinNode{kind: KindFace, lin: tokenLineage{key: "base", parent: ""}}
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	src.entities = []Entity{kinNode{kind: KindFace, lin: tokenLineage{key: "base2", parent: ""}}}
+
+	if _, match := m.BindKeyToObject(key); match != MatchNone {
+		t.Fatalf("match = %v, want none (root has no parent to recover via)", match)
+	}
+}
+
+func TestAncestralSiblingMustMatchKind(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// Same parent, but a vertex — not a candidate for an edge key.
+	src.entities = []Entity{kinNode{kind: KindVertex, lin: tokenLineage{key: "ext#1/vert#0", parent: "ext#1"}}}
+
+	if _, match := m.BindKeyToObject(key); match != MatchNone {
+		t.Fatalf("match = %v, want none (kind must match)", match)
+	}
+}
+
+// --- geometric tier ---
+
+func TestGeometricPicksNearestAmbiguousSibling(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(10, 0, 0), true)
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// Exact gone; two siblings survive — disambiguate by nearness to the mint anchor.
+	far := sibling("ext#1", "edge#7", math.P3(-10, 0, 0), true)
+	near := sibling("ext#1", "edge#8", math.P3(9, 0, 0), true)
+	src.entities = []Entity{far, near}
+
+	got, match := m.BindKeyToObject(key)
+	if match != MatchGeometric {
+		t.Fatalf("match = %v, want geometric", match)
+	}
+	if string(got.Lineage().LineageKey()) != "ext#1/edge#8" {
+		t.Errorf("bound to %q, want the nearer ext#1/edge#8", got.Lineage().LineageKey())
+	}
+}
+
+func TestGeometricMissOnEquidistantTie(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), true)
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// Two equidistant siblings — no defensible winner.
+	src.entities = []Entity{
+		sibling("ext#1", "edge#7", math.P3(5, 0, 0), true),
+		sibling("ext#1", "edge#8", math.P3(-5, 0, 0), true),
+	}
+
+	if _, match := m.BindKeyToObject(key); match != MatchNone {
+		t.Fatalf("match = %v, want none (geometric tie is not defensible)", match)
+	}
+}
+
+func TestGeometricMissWithoutAnchor(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false) // no anchor captured
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	src.entities = []Entity{
+		sibling("ext#1", "edge#7", math.P3(5, 0, 0), true),
+		sibling("ext#1", "edge#8", math.P3(-5, 0, 0), true),
+	}
+
+	if _, match := m.BindKeyToObject(key); match != MatchNone {
+		t.Fatalf("match = %v, want none (no anchor to disambiguate)", match)
+	}
+}
+
+// --- exact path is unchanged by the new tiers ---
+
+func TestExactStillWinsOverSiblings(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), true)
+	src := &fakeSource{entities: []Entity{keyed, sibling("ext#1", "edge#4", math.P3(1, 0, 0), true)}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// edge#3 still present alongside its sibling — exact must win.
+	src.entities = []Entity{sibling("ext#1", "edge#4", math.P3(1, 0, 0), true), keyed}
+	got, match := m.BindKeyToObject(key)
+	if match != MatchExact {
+		t.Fatalf("match = %v, want exact", match)
+	}
+	if string(got.Lineage().LineageKey()) != "ext#1/edge#3" {
+		t.Errorf("bound to %q, want ext#1/edge#3", got.Lineage().LineageKey())
+	}
+}
+
+// --- health policy: fallback is Warning, true loss is Sick ---
+
+func TestResolveWarnsOnFallbackAndSickensOnLoss(t *testing.T) {
+	m := NewKeyManager()
+	keyed := sibling("ext#1", "edge#3", math.P3(0, 0, 0), false)
+	src := &fakeSource{entities: []Entity{keyed}}
+	ctx := m.CreateKeyContext(src)
+	key := mintKey(t, m, ctx, keyed)
+
+	// Lone sibling survives → ancestral → Warning, entity returned.
+	src.entities = []Entity{sibling("ext#1", "edge#9", math.P3(0, 0, 0), false)}
+	got, h := m.Resolve(key)
+	if got == nil || h.Status != health.Warning {
+		t.Fatalf("Resolve fallback = (%v, %v), want a healed entity with Warning", got, h.Status)
+	}
+
+	// Nothing under the parent survives → Sick, nil entity.
+	src.entities = []Entity{sibling("ext#2", "edge#9", math.P3(0, 0, 0), false)}
+	got, h = m.Resolve(key)
+	if got != nil || h.Status != health.Sick {
+		t.Fatalf("Resolve loss = (%v, %v), want nil with Sick", got, h.Status)
+	}
+}
+
+func TestMatchTypeStringAndOrdering(t *testing.T) {
+	if MatchExact <= MatchAncestral || MatchAncestral <= MatchGeometric || MatchGeometric <= MatchNone {
+		t.Fatalf("match quality must ascend none<geometric<ancestral<exact")
+	}
+	for m, want := range map[MatchType]string{
+		MatchExact: "exact", MatchAncestral: "ancestral", MatchGeometric: "geometric", MatchNone: "none",
+	} {
+		if got := m.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", m, got, want)
+		}
+	}
+}

--- a/model/identity/entity.go
+++ b/model/identity/entity.go
@@ -17,6 +17,8 @@
 // — that the real topology types implement later. Today it is exercised by fakes.
 package identity
 
+import "oblikovati.org/math"
+
 // EntityKind discriminates the topological/model entities a key can name. Values
 // are STABLE: they are encoded into persisted keys, so never renumber them.
 type EntityKind uint32
@@ -83,6 +85,30 @@ type Lineage interface {
 type Entity interface {
 	EntityKind() EntityKind
 	Lineage() Lineage
+}
+
+// AncestralLineage is an OPTIONAL capability of a [Lineage]: the key of its parent
+// derivation (this lineage with its most-specific step removed). The tiered binder
+// uses it to recover a reference to a surviving sibling when the exact entity is
+// gone — siblings are the entities that share a parent (M31-F06, #1156). A lineage
+// with no meaningful parent (a root) need not implement it; such entities then have
+// no ancestral fallback and a lost key resolves to Sick as before.
+type AncestralLineage interface {
+	Lineage
+	// ParentKey returns the stable bytes of the parent lineage, or nil when this
+	// lineage is a root with no parent to fall back to.
+	ParentKey() []byte
+}
+
+// AnchoredEntity is an OPTIONAL capability of an [Entity]: a representative point in
+// the body's local frame. The binder uses it only as a geometric tie-breaker when
+// several surviving siblings share the key's parent lineage (M31-F06). It is never
+// used for exact binding; entities that cannot supply a stable point omit it.
+type AnchoredEntity interface {
+	Entity
+	// Anchor returns a representative point and true, or the zero point and false
+	// when no stable anchor exists for this entity.
+	Anchor() (math.Point3, bool)
 }
 
 // EntitySource enumerates the entities currently present in a context's topology —

--- a/model/identity/loss.go
+++ b/model/identity/loss.go
@@ -18,14 +18,20 @@ var ErrReferenceLost = errors.New("reference lost")
 
 // Resolve binds a key and translates the outcome into modeling health — the single
 // place the reference-loss policy lives, applied identically by every consumer
-// (features, dimensions, mates). A found entity yields healthy state; a lost
-// reference yields [health.Sick] with a reason naming the entity kind, so the UI
-// can offer re-selection. The repair is simply binding a fresh key (see
+// (features, dimensions, mates). An exact match yields healthy state; a degraded
+// match (ancestral/geometric, M31-F06) yields [health.Warning] so the reference is
+// kept usable but flagged for the user to confirm; only a true loss yields
+// [health.Sick] with a reason naming the entity kind, so the UI can offer
+// re-selection. The repair is simply binding a fresh key (see
 // [KeyManager.GetReferenceKey]) and resolving again.
 func (m *KeyManager) Resolve(k RefKey) (Entity, health.Health) {
 	entity, match := m.BindKeyToObject(k)
-	if match == MatchNone {
+	switch {
+	case match == MatchNone:
 		return nil, health.Sicken(fmt.Sprintf("%s: %s reference no longer binds", ErrReferenceLost, k.kind))
+	case match.IsFallback():
+		return entity, health.Warn(fmt.Sprintf("%s reference auto-healed via %s match; confirm selection", k.kind, match))
+	default:
+		return entity, health.Healthy
 	}
-	return entity, health.Healthy
 }

--- a/model/identity/manager.go
+++ b/model/identity/manager.go
@@ -58,22 +58,69 @@ func (m *KeyManager) GetReferenceKey(id ContextID, e Entity) (RefKey, error) {
 		return RefKey{}, fmt.Errorf("identity: cannot key a nil entity or entity without lineage")
 	}
 	payload := append([]byte(nil), e.Lineage().LineageKey()...)
-	return RefKey{ctx: id, kind: e.EntityKind(), payload: payload}, nil
+	return RefKey{
+		ctx:     id,
+		kind:    e.EntityKind(),
+		payload: payload,
+		parent:  parentHint(e.Lineage()),
+		anchor:  anchorOf(e),
+	}, nil
+}
+
+// parentHint captures the lineage's parent key for ancestral re-binding, when the
+// lineage exposes one (M31-F06). A root lineage yields an absent hint.
+func parentHint(l Lineage) ancestryHint {
+	al, ok := l.(AncestralLineage)
+	if !ok {
+		return ancestryHint{}
+	}
+	pk := al.ParentKey()
+	if len(pk) == 0 {
+		return ancestryHint{}
+	}
+	return ancestryHint{key: append([]byte(nil), pk...), ok: true}
+}
+
+// anchorOf captures the entity's representative point for geometric tie-breaking,
+// when the entity exposes one (M31-F06).
+func anchorOf(e Entity) anchorHint {
+	ae, ok := e.(AnchoredEntity)
+	if !ok {
+		return anchorHint{}
+	}
+	p, ok := ae.Anchor()
+	if !ok {
+		return anchorHint{}
+	}
+	return anchorHint{point: p, ok: true}
 }
 
 // BindKeyToObject resolves a key to a live entity in its context, returning the
-// match type. MatchNone (with a nil entity) means the referenced topology is gone.
+// match type. It tries tiers in descending quality (M31-F06, #1156): an exact
+// lineage match, then — only on an exact miss — an ancestral sibling, then a
+// geometric tie-break among ambiguous siblings. MatchNone (with a nil entity)
+// means the referenced topology is truly gone.
 func (m *KeyManager) BindKeyToObject(k RefKey) (Entity, MatchType) {
 	ctx, ok := m.contexts[k.ctx]
 	if !ok || ctx.source == nil {
 		return nil, MatchNone
 	}
-	for _, e := range ctx.source.Entities() {
+	ents := ctx.source.Entities()
+	if e := exactMatch(k, ents); e != nil {
+		return e, MatchExact
+	}
+	return fallbackMatch(k, ents)
+}
+
+// exactMatch returns the lone entity whose kind and full lineage equal the key, or
+// nil. This is the only tier that yields healthy state.
+func exactMatch(k RefKey, ents []Entity) Entity {
+	for _, e := range ents {
 		if e.EntityKind() == k.kind && bytes.Equal(e.Lineage().LineageKey(), k.payload) {
-			return e, MatchExact
+			return e
 		}
 	}
-	return nil, MatchNone
+	return nil
 }
 
 // CanBindKeyToObject reports whether the key would bind, without returning the

--- a/model/identity/refkey.go
+++ b/model/identity/refkey.go
@@ -7,6 +7,8 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
+
+	"oblikovati.org/math"
 )
 
 // ContextID identifies a key context (a versioned topology snapshot) within a
@@ -21,6 +23,28 @@ type RefKey struct {
 	ctx     ContextID
 	kind    EntityKind
 	payload []byte // the entity's LineageKey at mint time
+
+	// Fallback hints captured at mint time to drive degraded re-binding when the
+	// exact entity is gone (M31-F06). They are an in-memory optimisation only: the
+	// wire format ([RefKey.Encode]) is unchanged, so a key reloaded from disk has
+	// no hints and degrades to exact-only until the encoding is versioned (F07,
+	// #1157). Both are absent unless the keyed entity exposed the capability.
+	parent ancestryHint // the parent lineage, for ancestral sibling recovery
+	anchor anchorHint   // a representative point, for geometric tie-breaking
+}
+
+// ancestryHint records the keyed entity's parent lineage key, present only when
+// the entity's lineage implemented [AncestralLineage] at mint time.
+type ancestryHint struct {
+	key []byte
+	ok  bool
+}
+
+// anchorHint records the keyed entity's representative point, present only when
+// the entity implemented [AnchoredEntity] at mint time.
+type anchorHint struct {
+	point math.Point3
+	ok    bool
 }
 
 // Context returns the key's owning context id.
@@ -40,22 +64,43 @@ func (k RefKey) Equal(other RefKey) bool {
 }
 
 // MatchType classifies a bind attempt. It modernizes COM ReferenceKeyMatchType,
-// trimmed to what the lineage-based design needs.
+// trimmed to what the lineage-based design needs. Values ascend by quality
+// (none < geometric < ancestral < exact), so a larger value is a stronger bind;
+// MatchNone stays the zero value (the natural "no match"). The fallback tiers
+// (M31-F06, #1156) let an edit that destroys the exact entity recover to a
+// surviving sibling instead of fully losing the reference.
 type MatchType uint8
 
 const (
 	// MatchNone: nothing in the current topology matches the key — the reference
 	// is lost (a legitimate, non-fatal outcome).
 	MatchNone MatchType = iota
+	// MatchGeometric: no lineage match, but a lone ancestral sibling was selected
+	// by geometric nearness to the key's mint-time anchor — auto-healed, flagged.
+	MatchGeometric
+	// MatchAncestral: no exact lineage, but a single surviving sibling shares the
+	// key's parent lineage — auto-healed, flagged for review.
+	MatchAncestral
 	// MatchExact: a single entity with the same kind and lineage was found.
 	MatchExact
 )
+
+// IsFallback reports whether the match was recovered by a degraded tier
+// (ancestral/geometric) rather than exact lineage — the binder's signal to
+// resolve the reference to Warning health rather than fully healthy.
+func (m MatchType) IsFallback() bool {
+	return m == MatchAncestral || m == MatchGeometric
+}
 
 // String returns a stable name for diagnostics.
 func (m MatchType) String() string {
 	switch m {
 	case MatchExact:
 		return "exact"
+	case MatchAncestral:
+		return "ancestral"
+	case MatchGeometric:
+		return "geometric"
 	default:
 		return "none"
 	}


### PR DESCRIPTION
## What

Makes `KeyManager.BindKeyToObject` degrade gracefully instead of losing a reference outright. It was exact-equality only and two-valued (`MatchNone | MatchExact`): any miss → `health.Sick`. This adds two fallback tiers between exact and none, drawn from the literature (Kripac 1997; FreeCAD 1.0 element maps):

- **`MatchAncestral`** — on an exact miss, a lone surviving entity of the same kind that shares the key's **parent lineage** binds as the recovered sibling.
- **`MatchGeometric`** — when several siblings survive, the one **nearest the key's mint-time anchor** wins. An equidistant tie or a missing anchor stays lost (no arbitrary bind).

`Resolve` maps both fallbacks to `health.Warning` (auto-healed, flagged for the user to confirm), reserving `Sick` for true loss. The exact path is unchanged.

## Why

Gap **G5** in the M31 TNP assessment: a lost reference should reserve `Sick` for genuine loss; recoverable references should auto-heal and surface as a warning. This markedly improves user-felt robustness even before generation naming is perfect.

## How (design notes)

- Parent lineage and anchor are captured at mint time via two **optional** entity capabilities — `AncestralLineage` and `AnchoredEntity`. Entities that expose neither behave exactly as before, so there is **zero regression** for existing call sites/fakes.
- The hints are **in-memory only**: the wire encoding (`RefKey.Encode`) is untouched, so a key reloaded from disk degrades to exact-only until the encoding is versioned (**F07, #1157**). This keeps F06 free of any persistence/format change.
- `MatchType` values now ascend by quality (`none < geometric < ancestral < exact`); `MatchNone` stays the zero value. Values are runtime-only (never persisted).

## Tests

New `binding_test.go` covers each tier: lone-sibling ancestral bind, non-sibling/different-parent miss, root-lineage no-fallback, kind mismatch, geometric nearest pick, equidistant-tie miss, no-anchor miss, exact-wins-over-siblings, and the Warning/Sick health policy. `health.Warn` gets a unit test.

- `model/identity` coverage 95.6%, `model/health` 100%.
- Full module builds; all dependents (`addin/router`, `app`, `kernel/topo`, `model/...`) pass.

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)