### PR TITLE
M31-F07: Version the reference-key encoding + legacy migration shim

### DIFF
--- a/model/identity/encoding.go
+++ b/model/identity/encoding.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// The reference-key wire format is VERSIONED so the lineage-naming scheme can
+// evolve (F03–F05 and beyond) without orphaning saved documents (M31-F07, #1157).
+// FreeCAD's hard-won lesson: a topological-naming scheme must be versioned and
+// migratable. A key is self-describing — it carries the scheme that minted it — and
+// pre-M31 keys (which have no version tag) are still decoded, so old files reopen.
+//
+// Versioned (v1+) envelope, fixed little-endian layout (architecture core/05):
+//
+//	[magic "OKRK"][scheme u8][ctx u64][kind u32][payloadLen u32][payload]
+//
+// Legacy (pre-M31, "v0") envelope — no magic, the bytes begin with the context id:
+//
+//	[ctx u64][kind u32][payloadLen u32][payload]
+//
+// Only the identity triple (ctx, kind, lineage payload) is encoded. The F06 fallback
+// hints (parent lineage, geometric anchor) are deliberately NOT serialized: the
+// encoding is the attribute-anchor map key (model/attr), and that contract requires
+// equal-lineage keys to encode identically across a recompute. The anchor is a float
+// that can drift on recompute, so folding it into the identity bytes would silently
+// orphan a face's attributes — the very failure topological naming exists to prevent.
+var keyMagic = [4]byte{'O', 'K', 'R', 'K'}
+
+// SchemeLegacy is the implicit version of pre-M31 keys, which carry no version tag.
+// SchemeCurrent is what newly minted keys are stamped with; bump it whenever the
+// payload's meaning changes and add a decode path for the previous value.
+const (
+	SchemeLegacy  uint8 = 0
+	SchemeCurrent uint8 = 1
+)
+
+// Encode serializes the key to its self-describing, versioned envelope. Newly
+// minted keys are always written at SchemeCurrent, so reopening and re-saving an
+// old document upgrades its keys in place.
+//
+// Example: persisted := key.Encode(); ... ; restored, _ := DecodeKey(persisted).
+func (k RefKey) Encode() []byte {
+	buf := make([]byte, 0, len(keyMagic)+17+len(k.payload))
+	buf = append(buf, keyMagic[:]...)
+	buf = append(buf, SchemeCurrent)
+	buf = binary.LittleEndian.AppendUint64(buf, uint64(k.ctx))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(k.kind))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(k.payload)))
+	return append(buf, k.payload...)
+}
+
+// DecodeKey parses bytes produced by [RefKey.Encode], transparently migrating a
+// pre-M31 (legacy, unversioned) key — so old documents rebind rather than orphan.
+// The decoded key's Scheme reports which envelope it came from.
+func DecodeKey(data []byte) (RefKey, error) {
+	if hasMagic(data) {
+		return decodeVersioned(data)
+	}
+	return decodeLegacy(data)
+}
+
+// hasMagic reports whether data begins with the versioned-envelope marker. A legacy
+// key begins with its context id, which cannot collide: it would require a manager
+// to mint over 1.2 billion contexts AND the following byte to be a valid scheme, and
+// decodeVersioned still length-validates, so a false positive cannot bind wrongly.
+func hasMagic(data []byte) bool {
+	return len(data) >= len(keyMagic) && bytes.Equal(data[:len(keyMagic)], keyMagic[:])
+}
+
+// decodeVersioned parses the v1+ envelope: magic, scheme, then the identity triple.
+func decodeVersioned(data []byte) (RefKey, error) {
+	const headerLen = 5 + 16 // magic+scheme, then ctx+kind+payloadLen
+	if len(data) < headerLen {
+		return RefKey{}, fmt.Errorf("identity: versioned key too short: %d bytes, want >= %d", len(data), headerLen)
+	}
+	scheme := data[len(keyMagic)]
+	if scheme == SchemeLegacy || scheme > SchemeCurrent {
+		return RefKey{}, fmt.Errorf("identity: unknown key scheme %d, this build understands 1..%d", scheme, SchemeCurrent)
+	}
+	body := data[len(keyMagic)+1:]
+	k, err := decodeTriple(body)
+	if err != nil {
+		return RefKey{}, err
+	}
+	k.scheme = scheme
+	return k, nil
+}
+
+// decodeLegacy parses a pre-M31 key (no magic, scheme assumed SchemeLegacy).
+func decodeLegacy(data []byte) (RefKey, error) {
+	k, err := decodeTriple(data)
+	if err != nil {
+		return RefKey{}, err
+	}
+	k.scheme = SchemeLegacy
+	return k, nil
+}
+
+// decodeTriple parses the shared identity body [ctx u64][kind u32][len u32][payload],
+// validating that the declared payload length consumes exactly the trailing bytes.
+func decodeTriple(b []byte) (RefKey, error) {
+	if len(b) < 16 {
+		return RefKey{}, fmt.Errorf("identity: key body too short: %d bytes, want >= 16", len(b))
+	}
+	ctx := ContextID(binary.LittleEndian.Uint64(b[0:8]))
+	kind := EntityKind(binary.LittleEndian.Uint32(b[8:12]))
+	n := binary.LittleEndian.Uint32(b[12:16])
+	if int(n) != len(b)-16 {
+		return RefKey{}, fmt.Errorf("identity: key payload length %d does not match %d trailing bytes", n, len(b)-16)
+	}
+	payload := make([]byte, n)
+	copy(payload, b[16:])
+	return RefKey{ctx: ctx, kind: kind, payload: payload}, nil
+}

--- a/model/identity/encoding_test.go
+++ b/model/identity/encoding_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// legacyEncode builds a pre-M31 (unversioned) key blob in the original layout —
+// [ctx u64][kind u32][len u32][payload], no magic — so the migration path can be
+// exercised against the exact bytes old documents persisted.
+func legacyEncode(ctx ContextID, kind EntityKind, payload []byte) []byte {
+	buf := make([]byte, 0, 16+len(payload))
+	buf = binary.LittleEndian.AppendUint64(buf, uint64(ctx))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(kind))
+	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(payload)))
+	return append(buf, payload...)
+}
+
+func TestEncodeStampsCurrentScheme(t *testing.T) {
+	m := NewKeyManager()
+	ctx := m.CreateKeyContext(&fakeSource{})
+	key, _ := m.GetReferenceKey(ctx, fakeEntity{kind: KindEdge, lin: "ext#1/edge#3"})
+
+	if key.Scheme() != SchemeCurrent {
+		t.Fatalf("minted key scheme = %d, want current %d", key.Scheme(), SchemeCurrent)
+	}
+	back, err := DecodeKey(key.Encode())
+	if err != nil {
+		t.Fatalf("DecodeKey: %v", err)
+	}
+	if back.Scheme() != SchemeCurrent {
+		t.Errorf("round-tripped scheme = %d, want current %d", back.Scheme(), SchemeCurrent)
+	}
+	if !back.Equal(key) {
+		t.Errorf("round trip changed identity: %+v vs %+v", back, key)
+	}
+}
+
+func TestVersionedEnvelopeCarriesMagic(t *testing.T) {
+	m := NewKeyManager()
+	ctx := m.CreateKeyContext(&fakeSource{})
+	key, _ := m.GetReferenceKey(ctx, face("cap"))
+
+	if !hasMagic(key.Encode()) {
+		t.Error("a freshly minted key is not written in the versioned envelope")
+	}
+}
+
+// TestLegacyKeyDecodesAndMigrates is the core migration guarantee: a key persisted
+// by a pre-M31 build still loads (scheme reported as legacy) and re-binds to the
+// unchanged entity, rather than orphaning the reference.
+func TestLegacyKeyDecodesAndMigrates(t *testing.T) {
+	m := NewKeyManager()
+	src := &fakeSource{entities: []Entity{face("base"), fakeEntity{kind: KindEdge, lin: "brep:edge#4"}}}
+	ctx := m.CreateKeyContext(src)
+
+	blob := legacyEncode(ctx, KindEdge, []byte("brep:edge#4"))
+	if hasMagic(blob) {
+		t.Fatal("legacy blob unexpectedly carries the versioned magic")
+	}
+
+	key, err := DecodeKey(blob)
+	if err != nil {
+		t.Fatalf("DecodeKey(legacy): %v", err)
+	}
+	if key.Scheme() != SchemeLegacy {
+		t.Errorf("legacy key scheme = %d, want legacy %d", key.Scheme(), SchemeLegacy)
+	}
+
+	got, match := m.BindKeyToObject(key)
+	if match != MatchExact {
+		t.Fatalf("legacy key match = %v, want exact (unchanged topology)", match)
+	}
+	if string(got.Lineage().LineageKey()) != "brep:edge#4" {
+		t.Errorf("legacy key bound to %q, want brep:edge#4", got.Lineage().LineageKey())
+	}
+}
+
+// TestReEncodeUpgradesLegacyKey shows save-time migration: a legacy key, once
+// decoded, re-encodes into the current versioned envelope.
+func TestReEncodeUpgradesLegacyKey(t *testing.T) {
+	blob := legacyEncode(7, KindFace, []byte("L"))
+	key, err := DecodeKey(blob)
+	if err != nil {
+		t.Fatalf("DecodeKey: %v", err)
+	}
+
+	upgraded := key.Encode()
+	if !hasMagic(upgraded) {
+		t.Fatal("re-encoded legacy key is still unversioned")
+	}
+	back, err := DecodeKey(upgraded)
+	if err != nil {
+		t.Fatalf("DecodeKey(upgraded): %v", err)
+	}
+	if back.Scheme() != SchemeCurrent || !back.Equal(key) {
+		t.Errorf("upgrade lost provenance/identity: scheme %d, equal %v", back.Scheme(), back.Equal(key))
+	}
+}
+
+func TestDecodeRejectsUnknownScheme(t *testing.T) {
+	m := NewKeyManager()
+	ctx := m.CreateKeyContext(&fakeSource{})
+	key, _ := m.GetReferenceKey(ctx, face("x"))
+
+	blob := key.Encode()
+	blob[len(keyMagic)] = SchemeCurrent + 1 // bump the scheme byte past what we know
+	if _, err := DecodeKey(blob); err == nil {
+		t.Error("DecodeKey accepted a key from an unknown future scheme")
+	}
+}
+
+func TestDecodeRejectsTruncatedVersionedKey(t *testing.T) {
+	m := NewKeyManager()
+	ctx := m.CreateKeyContext(&fakeSource{})
+	key, _ := m.GetReferenceKey(ctx, fakeEntity{kind: KindEdge, lin: "ext#1/edge#3"})
+
+	blob := key.Encode()
+	if _, err := DecodeKey(blob[:len(blob)-2]); err == nil {
+		t.Error("DecodeKey accepted a versioned key truncated mid-payload")
+	}
+	if _, err := DecodeKey(keyMagic[:]); err == nil {
+		t.Error("DecodeKey accepted bare magic with no body")
+	}
+}
+
+func TestSchemeIsNotPartOfIdentity(t *testing.T) {
+	// Same triple via the legacy and current envelopes must compare Equal — scheme
+	// is provenance, not identity — so an attribute anchored under an old key is
+	// still found after the key is re-minted.
+	legacy, err := DecodeKey(legacyEncode(3, KindFace, []byte("face#1")))
+	if err != nil {
+		t.Fatalf("DecodeKey: %v", err)
+	}
+	current := RefKey{ctx: 3, kind: KindFace, payload: []byte("face#1"), scheme: SchemeCurrent}
+	if !legacy.Equal(current) {
+		t.Error("legacy and current keys for the same reference are not Equal")
+	}
+	if string(legacy.Encode()) != string(current.Encode()) {
+		t.Error("Equal keys must encode identically regardless of decoded scheme")
+	}
+}

--- a/model/identity/manager.go
+++ b/model/identity/manager.go
@@ -64,6 +64,7 @@ func (m *KeyManager) GetReferenceKey(id ContextID, e Entity) (RefKey, error) {
 		payload: payload,
 		parent:  parentHint(e.Lineage()),
 		anchor:  anchorOf(e),
+		scheme:  SchemeCurrent,
 	}, nil
 }
 

--- a/model/identity/refkey.go
+++ b/model/identity/refkey.go
@@ -5,7 +5,6 @@ package identity
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 
 	"oblikovati.org/math"
@@ -25,12 +24,19 @@ type RefKey struct {
 	payload []byte // the entity's LineageKey at mint time
 
 	// Fallback hints captured at mint time to drive degraded re-binding when the
-	// exact entity is gone (M31-F06). They are an in-memory optimisation only: the
-	// wire format ([RefKey.Encode]) is unchanged, so a key reloaded from disk has
-	// no hints and degrades to exact-only until the encoding is versioned (F07,
-	// #1157). Both are absent unless the keyed entity exposed the capability.
+	// exact entity is gone (M31-F06). They are an in-memory SESSION optimisation: a
+	// key reloaded from disk has no hints (they are not serialized — see encoding.go
+	// for why the drift-prone anchor must stay out of the identity bytes) and so
+	// degrades to exact-only. Both are absent unless the keyed entity exposed the
+	// capability.
 	parent ancestryHint // the parent lineage, for ancestral sibling recovery
 	anchor anchorHint   // a representative point, for geometric tie-breaking
+
+	// scheme is the lineage-encoding version this key was decoded from
+	// (SchemeLegacy for a pre-M31 key), or SchemeCurrent for a freshly minted one.
+	// It is provenance only: it is NOT part of the key's identity (see Equal) and
+	// re-encoding always writes SchemeCurrent (M31-F07, #1157).
+	scheme uint8
 }
 
 // ancestryHint records the keyed entity's parent lineage key, present only when
@@ -52,6 +58,11 @@ func (k RefKey) Context() ContextID { return k.ctx }
 
 // Kind returns the kind of entity the key names.
 func (k RefKey) Kind() EntityKind { return k.kind }
+
+// Scheme returns the lineage-encoding version this key was decoded from
+// ([SchemeLegacy] for a pre-M31 key), or [SchemeCurrent] for a freshly minted key
+// (M31-F07). It is provenance for migration diagnostics, not part of identity.
+func (k RefKey) Scheme() uint8 { return k.scheme }
 
 // IsZero reports whether the key is the zero value (names nothing).
 func (k RefKey) IsZero() bool {
@@ -104,32 +115,6 @@ func (m MatchType) String() string {
 	default:
 		return "none"
 	}
-}
-
-// Encode serializes the key to bytes: [ctx u64][kind u32][len u32][payload]. The
-// layout is fixed and little-endian so keys persist portably (architecture core/05).
-func (k RefKey) Encode() []byte {
-	buf := make([]byte, 0, 16+len(k.payload))
-	buf = binary.LittleEndian.AppendUint64(buf, uint64(k.ctx))
-	buf = binary.LittleEndian.AppendUint32(buf, uint32(k.kind))
-	buf = binary.LittleEndian.AppendUint32(buf, uint32(len(k.payload)))
-	return append(buf, k.payload...)
-}
-
-// DecodeKey parses bytes produced by [RefKey.Encode].
-func DecodeKey(data []byte) (RefKey, error) {
-	if len(data) < 16 {
-		return RefKey{}, fmt.Errorf("identity: key too short: %d bytes, want >= 16", len(data))
-	}
-	ctx := ContextID(binary.LittleEndian.Uint64(data[0:8]))
-	kind := EntityKind(binary.LittleEndian.Uint32(data[8:12]))
-	n := binary.LittleEndian.Uint32(data[12:16])
-	if int(n) != len(data)-16 {
-		return RefKey{}, fmt.Errorf("identity: key payload length %d does not match %d trailing bytes", n, len(data)-16)
-	}
-	payload := make([]byte, n)
-	copy(payload, data[16:])
-	return RefKey{ctx: ctx, kind: kind, payload: payload}, nil
 }
 
 // KeyToString renders a key as a URL-safe base64 string for transport and UI.


### PR DESCRIPTION
## What

Makes the reference-key wire format **self-describing and versioned**, so the lineage-naming scheme can keep evolving (F03–F05 and beyond) without orphaning saved documents.

- Every newly minted key is written in a versioned envelope: `["OKRK" magic][scheme u8][ctx u64][kind u32][payloadLen u32][payload]`.
- `DecodeKey` detects the magic and parses the versioned envelope. A **pre-M31 key** (no magic — the bytes begin with the context id) is transparently decoded as `SchemeLegacy`, so old documents reopen and rebind instead of orphaning.
- Once decoded, a legacy key **re-encodes at `SchemeCurrent`** — an upgrade on save.
- `RefKey.Scheme()` exposes the provenance for migration diagnostics. It is **not** part of identity (`Equal`), so an attribute anchored under an old key is still found after the key is re-minted.

## Why

Gap **G6** in the M31 TNP assessment: the lineage payload had no scheme-version tag, so an evolving naming algorithm would orphan existing keys. FreeCAD's hard-won lesson is that the scheme must be versioned and migratable. Acceptance: the algorithm can evolve without orphaning documents; the key encoding is self-describing.

## Design note — what is NOT encoded, and why

Only the identity triple (ctx, kind, lineage payload) is serialized. The F06 fallback hints (parent lineage, geometric anchor) are **deliberately excluded**: the encoding doubles as the attribute-anchor map key (`model/attr`), whose core contract is that equal-lineage keys encode identically across a recompute (that is how a face keeps its attributes when the B-rep is rebuilt). The anchor is a float that can drift on recompute, so folding it into the identity bytes would silently orphan a face's attributes — exactly the failure topological naming exists to prevent. The hints therefore remain an in-memory session optimisation (F06's comment is updated to say so).

## Migration (best-effort, per the issue)

A legacy key **exact-binds** when its lineage is unchanged. Where exact fails, a legacy key has no hints to drive the F06 ancestral/geometric fallback, so it resolves to `Sick` (graceful loss) rather than crashing — the best-effort behaviour the issue calls for.

## Tests

New `encoding_test.go`: current-scheme stamping + round-trip, magic presence, **legacy-key decode + exact rebind (migration)**, **re-encode upgrades a legacy key**, unknown-future-scheme rejection, truncated-versioned-key rejection, and scheme-is-not-identity (legacy and current keys for the same reference are `Equal` and encode identically). Existing round-trip/reject/string tests still pass unchanged.

- `model/identity` coverage 96.0%.

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)